### PR TITLE
Use pre-built OVS Docker image

### DIFF
--- a/build/images/Dockerfile.build.ubuntu
+++ b/build/images/Dockerfile.build.ubuntu
@@ -7,22 +7,6 @@ RUN mkdir -p /opt/cni/bin && \
     wget -q -O - https://dl.k8s.io/network-plugins/cni-plugins-amd64-v0.7.5.tgz | tar xz -C /opt/cni/bin ./host-local
 
 
-FROM ubuntu:18.04 as ovs-debs
-
-# Install dependencies for building OVS deb packages
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends wget ca-certificates build-essential fakeroot graphviz \
-            bzip2 autoconf automake debhelper dh-autoreconf libssl-dev libtool openssl procps \
-            python-all python-twisted-conch python-zopeinterface python-six libunbound-dev
-
-# Download OVS source code and build debs
-RUN wget -q -O - https://www.openvswitch.org/releases/openvswitch-2.11.1.tar.gz  | tar xz -C /tmp && \
-    cd /tmp/openvswitch* && DEB_BUILD_OPTIONS='parallel=8 nocheck' fakeroot debian/rules binary && \
-    cd /tmp && mkdir ovs-debs && \
-    mv libopenvswitch_*.deb openvswitch-common_*.deb openvswitch-switch_*.deb python-openvswitch_*.deb \
-       openvswitch-ipsec_*.deb ovs-debs/
-
-
 FROM golang:1.12 as antrea-build
 
 COPY . /antrea
@@ -32,24 +16,12 @@ WORKDIR /antrea
 RUN make bin
 
 
-FROM ubuntu:18.04
+FROM antrea/openvswitch:2.11.1
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
-LABEL description="A docker image to deploy the Antrea CNI. Takes care of building the Antrea binaries as part of building the image."
+LABEL description="A Docker image to deploy the Antrea CNI. Takes care of building the Antrea binaries as part of building the image."
 
 USER root
-
-COPY --from=ovs-debs /tmp/ovs-debs/* /tmp/ovs-debs/
-
-# We clean-up apt cache after installing packages to reduce the size of the
-# final image
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends iptables libstrongswan-standard-plugins && \
-    (dpkg -i /tmp/ovs-debs/*.deb || apt-get -f -y --no-install-recommends install) && \
-    rm -rf /var/cache/apt/* /var/lib/apt/lists/* && \
-    rm -rf /tmp/ovs-debs && \
-    CHARON_FILELOG_CONFIG="\ \ \ \ \ \ \ \ /var/log/strongswan/charon.log {\n\ \ \ \ \ \ \ \ }" && \
-    sed -i "/^.*filelog.*{/a $CHARON_FILELOG_CONFIG" /etc/strongswan.d/charon-logging.conf
 
 COPY --from=cni-binaries /opt/cni/bin /opt/cni/bin
 

--- a/build/images/Dockerfile.ubuntu
+++ b/build/images/Dockerfile.ubuntu
@@ -7,40 +7,12 @@ RUN mkdir -p /opt/cni/bin && \
     wget -q -O - https://dl.k8s.io/network-plugins/cni-plugins-amd64-v0.7.5.tgz | tar xz -C /opt/cni/bin ./host-local
 
 
-FROM ubuntu:18.04 as ovs-debs
-
-# Install dependencies for building OVS deb packages
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends wget ca-certificates build-essential fakeroot graphviz \
-            bzip2 autoconf automake debhelper dh-autoreconf libssl-dev libtool openssl procps \
-            python-all python-twisted-conch python-zopeinterface python-six libunbound-dev
-
-# Download OVS source code and build debs
-RUN wget -q -O - https://www.openvswitch.org/releases/openvswitch-2.11.1.tar.gz  | tar xz -C /tmp && \
-    cd /tmp/openvswitch* && DEB_BUILD_OPTIONS='parallel=8 nocheck' fakeroot debian/rules binary && \
-    cd /tmp && mkdir ovs-debs && \
-    mv libopenvswitch_*.deb openvswitch-common_*.deb openvswitch-switch_*.deb python-openvswitch_*.deb \
-       openvswitch-ipsec_*.deb ovs-debs/
-
-
-FROM ubuntu:18.04
+FROM antrea/openvswitch:2.11.1
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
-LABEL description="A docker image to deploy the Antrea CNI. Requires the Antrea binaries to be built prior to building the image."
+LABEL description="A Docker image to deploy the Antrea CNI. Requires the Antrea binaries to be built prior to building the image."
 
 USER root
-
-COPY --from=ovs-debs /tmp/ovs-debs/* /tmp/ovs-debs/
-
-# We clean-up apt cache after installing packages to reduce the size of the
-# final image
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends iptables libstrongswan-standard-plugins && \
-    (dpkg -i /tmp/ovs-debs/*.deb || apt-get -f -y --no-install-recommends install) && \
-    rm -rf /var/cache/apt/* /var/lib/apt/lists/* && \
-    rm -rf /tmp/ovs-debs && \
-    CHARON_FILELOG_CONFIG="\ \ \ \ \ \ \ \ /var/log/strongswan/charon.log {\n\ \ \ \ \ \ \ \ }" && \
-    sed -i "/^.*filelog.*{/a $CHARON_FILELOG_CONFIG" /etc/strongswan.d/charon-logging.conf
 
 COPY --from=cni-binaries /opt/cni/bin /opt/cni/bin
 

--- a/build/images/ovs/Dockerfile
+++ b/build/images/ovs/Dockerfile
@@ -1,0 +1,34 @@
+FROM ubuntu:18.04 as ovs-debs
+
+ARG OVS_VERSION=2.11.1
+
+# Install dependencies for building OVS deb packages
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends wget ca-certificates build-essential fakeroot graphviz \
+            bzip2 autoconf automake debhelper dh-autoreconf libssl-dev libtool openssl procps \
+            python-all python-twisted-conch python-zopeinterface python-six libunbound-dev
+
+# Download OVS source code and build debs
+RUN wget -q -O - https://www.openvswitch.org/releases/openvswitch-$OVS_VERSION.tar.gz  | tar xz -C /tmp && \
+    cd /tmp/openvswitch* && DEB_BUILD_OPTIONS='parallel=8 nocheck' fakeroot debian/rules binary && \
+    cd /tmp && mkdir ovs-debs && \
+    mv libopenvswitch_*.deb openvswitch-common_*.deb openvswitch-switch_*.deb python-openvswitch_*.deb \
+       openvswitch-ipsec_*.deb ovs-debs/
+
+
+FROM ubuntu:18.04
+
+LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
+LABEL description="A Docker image based on Ubuntu 18.04 which includes Open vSwitch built from source."
+
+COPY --from=ovs-debs /tmp/ovs-debs/* /tmp/ovs-debs/
+
+# We clean-up apt cache after installing packages to reduce the size of the
+# final image
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends iptables libstrongswan-standard-plugins && \
+    (dpkg -i /tmp/ovs-debs/*.deb || apt-get -f -y --no-install-recommends install) && \
+    rm -rf /var/cache/apt/* /var/lib/apt/lists/* && \
+    rm -rf /tmp/ovs-debs && \
+    CHARON_FILELOG_CONFIG="\ \ \ \ \ \ \ \ /var/log/strongswan/charon.log {\n\ \ \ \ \ \ \ \ }" && \
+    sed -i "/^.*filelog.*{/a $CHARON_FILELOG_CONFIG" /etc/strongswan.d/charon-logging.conf

--- a/build/images/ovs/README.md
+++ b/build/images/ovs/README.md
@@ -1,0 +1,21 @@
+# images/ovs
+
+This directory contains utilities to build a Docker image which includes Open
+vSwitch (OVS) built from source. We build OVS from source because some features
+of Antrea (such as IPSec) require a recent version of OVS, more recent than the
+version included in Ubuntu 18.04. The built image is then used as the base image
+for the Antrea main Docker image.
+
+## Building the image and pushing it to Dockerhub
+
+Choose the version of OVS you want to build by setting the `OVS_VERSION`
+environment variable. Then run the `build_and_push.sh` script. For example:
+
+```bash
+OVS_VERSION=2.11.1 ./ovs/build_and_push.sh
+```
+
+The image will be pushed to Dockerhub as `antrea/openvswitch:$OVS_VERSION`.
+
+The script will fail if you do not have permission to push to the `antrea`
+Dockerhub repository.

--- a/build/images/ovs/build_and_push.sh
+++ b/build/images/ovs/build_and_push.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 Antrea Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is a very simple script that builds the Open vSwitch base image for Antrea and pushes it to
+# the Antrea Dockerhub (https://hub.docker.com/u/antrea). The image is tagged with the OVS version.
+
+set -eo pipefail
+
+function echoerr {
+    >&2 echo "$@"
+}
+
+if [ -z "$OVS_VERSION" ]; then
+    echoerr "The OVS_VERSION env variable must be set to a valid value (e.g. 2.11.1)"
+    exit 1
+fi
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+pushd $THIS_DIR > /dev/null
+
+docker build -t antrea/openvswitch:$OVS_VERSION --build-arg OVS_VERSION=$OVS_VERSION .
+docker push antrea/openvswitch:$OVS_VERSION
+
+popd > /dev/null


### PR DESCRIPTION
We will now use a pre-built OVS image, hosted in the Antrea Dockerhub repository
as antrea/openvswitch:2.11.1. This image is used as a base image when building
the main Antrea Docker image (antrea-ubuntu), which considerably speeds-up fresh
builds. This commit also documents how to build and push a new image for OVS, in
case we need to use a different OVS version for Antrea.

Fixes #39