### PR TITLE
Implement agent side Network Policy controller

### DIFF
--- a/cmd/antrea-agent/config.go
+++ b/cmd/antrea-agent/config.go
@@ -23,6 +23,9 @@ type AgentConfig struct {
 	// clientConnection specifies the kubeconfig file and client connection settings for the agent
 	// to communicate with the apiserver.
 	ClientConnection componentbaseconfig.ClientConnectionConfiguration `yaml:"clientConnection"`
+	// AntreaClientConnection specifies the kubeconfig file and client connection settings for the
+	// agent to communicate with the Antrea Controller apiserver.
+	AntreaClientConnection componentbaseconfig.ClientConnectionConfiguration `yaml:"antreaClientConnection"`
 	// Name of the OpenVSwitch bridge antrea-agent will create and use.
 	// Make sure it doesn't conflict with your existing OpenVSwitch bridges.
 	// Defaults to br-int.

--- a/pkg/agent/client.go
+++ b/pkg/agent/client.go
@@ -1,0 +1,81 @@
+package agent
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/cert"
+	"k8s.io/component-base/config"
+	"k8s.io/klog"
+
+	"github.com/vmware-tanzu/antrea/pkg/client/clientset/versioned"
+)
+
+// CreateAntreaClient creates an Antrea client from the given config.
+func CreateAntreaClient(config config.ClientConnectionConfiguration) (versioned.Interface, error) {
+	var kubeConfig *rest.Config
+	var err error
+
+	if len(config.Kubeconfig) == 0 {
+		klog.Info("No kubeconfig file was specified. Falling back to in-cluster config")
+		kubeConfig, err = rest.InClusterConfig()
+	} else {
+		kubeConfig, err = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+			&clientcmd.ClientConfigLoadingRules{ExplicitPath: config.Kubeconfig},
+			&clientcmd.ConfigOverrides{}).ClientConfig()
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	kubeConfig.AcceptContentTypes = config.AcceptContentTypes
+	kubeConfig.ContentType = config.ContentType
+	kubeConfig.QPS = config.QPS
+	kubeConfig.Burst = int(config.Burst)
+
+	client, err := versioned.NewForConfig(kubeConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return client, nil
+}
+
+// inClusterConfig returns a config object which uses the service account
+// kubernetes gives to pods. It's intended for clients that expect to be
+// running inside a pod running on kubernetes. It will return error
+// if called from a process not running in a kubernetes environment.
+func inClusterConfig() (*rest.Config, error) {
+	const (
+		tokenFile  = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+		rootCAFile = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+	)
+	host, port := os.Getenv("ANTREA_SERVICE_HOST"), os.Getenv("ANTREA_SERVICE_PORT")
+	if len(host) == 0 || len(port) == 0 {
+		return nil, fmt.Errorf("unable to load in-cluster configuration, ANTREA_SERVICE_HOST and ANTREA_SERVICE_PORT must be defined")
+	}
+
+	token, err := ioutil.ReadFile(tokenFile)
+	if err != nil {
+		return nil, err
+	}
+
+	tlsClientConfig := rest.TLSClientConfig{}
+
+	if _, err := cert.NewPool(rootCAFile); err != nil {
+		klog.Errorf("Expected to load root CA config from %s, but got err: %v", rootCAFile, err)
+	} else {
+		tlsClientConfig.CAFile = rootCAFile
+	}
+
+	return &rest.Config{
+		Host:            "https://" + net.JoinHostPort(host, port),
+		TLSClientConfig: tlsClientConfig,
+		BearerToken:     string(token),
+		BearerTokenFile: tokenFile,
+	}, nil
+}

--- a/pkg/agent/controller/networkpolicy/cache_test.go
+++ b/pkg/agent/controller/networkpolicy/cache_test.go
@@ -1,0 +1,717 @@
+// Copyright 2019 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package networkpolicy
+
+import (
+	"net"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/vmware-tanzu/antrea/pkg/apis/networkpolicy/v1beta1"
+)
+
+func TestAddressGroupIndexFunc(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    interface{}
+		want    []string
+		wantErr error
+	}{
+		{
+			"zero-group",
+			&rule{
+				ID: "foo",
+			},
+			[]string{},
+			nil,
+		},
+		{
+			"two-groups",
+			&rule{
+				ID:   "foo",
+				From: v1beta1.NetworkPolicyPeer{AddressGroups: []string{"group1", "group2"}},
+			},
+			[]string{"group1", "group2"},
+			nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := addressGroupIndexFunc(tt.args)
+			if err != tt.wantErr {
+				t.Errorf("addressGroupIndexFunc() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("addressGroupIndexFunc() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAppliedToGroupIndexFunc(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    interface{}
+		want    []string
+		wantErr error
+	}{
+		{
+			"zero-group",
+			&rule{
+				ID: "foo",
+			},
+			nil,
+			nil,
+		},
+		{
+			"two-groups",
+			&rule{
+				ID:              "foo",
+				AppliedToGroups: []string{"group1", "group2"},
+			},
+			[]string{"group1", "group2"},
+			nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := appliedToGroupIndexFunc(tt.args)
+			if err != tt.wantErr {
+				t.Errorf("appliedToGroupIndexFunc() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("appliedToGroupIndexFunc() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+type dirtyRuleRecorder struct {
+	rules sets.String
+}
+
+func newDirtyRuleRecorder() *dirtyRuleRecorder {
+	return &dirtyRuleRecorder{sets.NewString()}
+}
+
+func (r *dirtyRuleRecorder) Record(ruleID string) {
+	r.rules.Insert(ruleID)
+}
+
+func ipStrToIPAddress(ip string) v1beta1.IPAddress {
+	return v1beta1.IPAddress(net.ParseIP(ip))
+}
+
+func TestRuleCacheAddAddressGroup(t *testing.T) {
+	rule1 := &rule{
+		ID:   "rule1",
+		From: v1beta1.NetworkPolicyPeer{AddressGroups: []string{"group1"}},
+	}
+	rule2 := &rule{
+		ID:   "rule2",
+		From: v1beta1.NetworkPolicyPeer{AddressGroups: []string{"group1", "group2"}},
+	}
+	tests := []struct {
+		name               string
+		rules              []*rule
+		args               *v1beta1.AddressGroup
+		expectedAddresses  sets.String
+		expectedDirtyRules sets.String
+	}{
+		{
+			"zero-rule",
+			[]*rule{rule1, rule2},
+			&v1beta1.AddressGroup{
+				ObjectMeta:  metav1.ObjectMeta{Name: "group0"},
+				IPAddresses: []v1beta1.IPAddress{},
+			},
+			sets.NewString(),
+			sets.NewString(),
+		},
+		{
+			"one-rule",
+			[]*rule{rule1, rule2},
+			&v1beta1.AddressGroup{
+				ObjectMeta:  metav1.ObjectMeta{Name: "group2"},
+				IPAddresses: []v1beta1.IPAddress{ipStrToIPAddress("1.1.1.1")},
+			},
+			sets.NewString("1.1.1.1"),
+			sets.NewString("rule2"),
+		},
+		{
+			"two-rule",
+			[]*rule{rule1, rule2},
+			&v1beta1.AddressGroup{
+				ObjectMeta:  metav1.ObjectMeta{Name: "group1"},
+				IPAddresses: []v1beta1.IPAddress{ipStrToIPAddress("1.1.1.1"), ipStrToIPAddress("2.2.2.2")},
+			},
+			sets.NewString("1.1.1.1", "2.2.2.2"),
+			sets.NewString("rule1", "rule2"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := newDirtyRuleRecorder()
+			c := newRuleCache(recorder.Record)
+			for _, rule := range tt.rules {
+				c.rules.Add(rule)
+			}
+			c.AddAddressGroup(tt.args)
+
+			if !recorder.rules.Equal(tt.expectedDirtyRules) {
+				t.Errorf("Got dirty rules %v, expected %v", recorder.rules, tt.expectedDirtyRules)
+			}
+			actualAddresses, exists := c.addressSetByGroup[tt.args.Name]
+			if !exists {
+				t.Fatalf("AddressGroup %s not found", tt.args.Name)
+			}
+			if !actualAddresses.Equal(tt.expectedAddresses) {
+				t.Errorf("Got addresses %v, expected %v", actualAddresses, tt.expectedAddresses)
+			}
+		})
+	}
+}
+
+func TestRuleCacheAddAppliedToGroup(t *testing.T) {
+	rule1 := &rule{
+		ID:              "rule1",
+		AppliedToGroups: []string{"group1"},
+	}
+	rule2 := &rule{
+		ID:              "rule2",
+		AppliedToGroups: []string{"group1", "group2"},
+	}
+	tests := []struct {
+		name               string
+		rules              []*rule
+		args               *v1beta1.AppliedToGroup
+		expectedPods       podSet
+		expectedDirtyRules sets.String
+	}{
+		{
+			"zero-rule",
+			[]*rule{rule1, rule2},
+			&v1beta1.AppliedToGroup{
+				ObjectMeta: metav1.ObjectMeta{Name: "group0"},
+				Pods:       []v1beta1.PodReference{},
+			},
+			newPodSet(),
+			sets.NewString(),
+		},
+		{
+			"one-rule",
+			[]*rule{rule1, rule2},
+			&v1beta1.AppliedToGroup{
+				ObjectMeta: metav1.ObjectMeta{Name: "group2"},
+				Pods:       []v1beta1.PodReference{{"pod1", "ns1"}},
+			},
+			newPodSet(v1beta1.PodReference{"pod1", "ns1"}),
+			sets.NewString("rule2"),
+		},
+		{
+			"one-rule",
+			[]*rule{rule1, rule2},
+			&v1beta1.AppliedToGroup{
+				ObjectMeta: metav1.ObjectMeta{Name: "group1"},
+				Pods:       []v1beta1.PodReference{{"pod1", "ns1"}, {"pod2", "ns1"}},
+			},
+			newPodSet(v1beta1.PodReference{"pod1", "ns1"}, v1beta1.PodReference{"pod2", "ns1"}),
+			sets.NewString("rule1", "rule2"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := newDirtyRuleRecorder()
+			c := newRuleCache(recorder.Record)
+			for _, rule := range tt.rules {
+				c.rules.Add(rule)
+			}
+			c.AddAppliedToGroup(tt.args)
+
+			if !recorder.rules.Equal(tt.expectedDirtyRules) {
+				t.Errorf("Got dirty rules %v, expected %v", recorder.rules, tt.expectedDirtyRules)
+			}
+			actualPods, exists := c.podSetByGroup[tt.args.Name]
+			if !exists {
+				t.Fatalf("AppliedToGroup %s not found", tt.args.Name)
+			}
+			if !actualPods.Equal(tt.expectedPods) {
+				t.Errorf("Got addresses %v, expected %v", actualPods, tt.expectedPods)
+			}
+		})
+	}
+}
+
+func TestRuleCacheAddNetworkPolicy(t *testing.T) {
+	networkPolicyRule1 := &v1beta1.NetworkPolicyRule{
+		Direction: v1beta1.DirectionIn,
+		From:      v1beta1.NetworkPolicyPeer{AddressGroups: []string{"addressGroup1"}},
+		To:        v1beta1.NetworkPolicyPeer{},
+		Services:  nil,
+	}
+	networkPolicyRule2 := &v1beta1.NetworkPolicyRule{
+		Direction: v1beta1.DirectionIn,
+		From:      v1beta1.NetworkPolicyPeer{AddressGroups: []string{"addressGroup2"}},
+		To:        v1beta1.NetworkPolicyPeer{},
+		Services:  nil,
+	}
+	networkPolicy1 := &v1beta1.NetworkPolicy{
+		ObjectMeta:      metav1.ObjectMeta{UID: "policy1"},
+		Rules:           nil,
+		AppliedToGroups: []string{"appliedToGroup1"},
+	}
+	networkPolicy2 := &v1beta1.NetworkPolicy{
+		ObjectMeta:      metav1.ObjectMeta{UID: "policy2"},
+		Rules:           []v1beta1.NetworkPolicyRule{*networkPolicyRule1, *networkPolicyRule2},
+		AppliedToGroups: []string{"appliedToGroup1"},
+	}
+	rule1 := toRule(networkPolicyRule1, networkPolicy2)
+	rule2 := toRule(networkPolicyRule2, networkPolicy2)
+	tests := []struct {
+		name               string
+		args               *v1beta1.NetworkPolicy
+		expectedRules      []*rule
+		expectedDirtyRules sets.String
+	}{
+		{
+			"zero-rule",
+			networkPolicy1,
+			[]*rule{},
+			sets.NewString(),
+		},
+		{
+			"two-rule",
+			networkPolicy2,
+			[]*rule{rule1, rule2},
+			sets.NewString(rule1.ID, rule2.ID),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := newDirtyRuleRecorder()
+			c := newRuleCache(recorder.Record)
+			c.AddNetworkPolicy(tt.args)
+			actualRules := c.rules.List()
+			if !assert.ElementsMatch(t, tt.expectedRules, actualRules) {
+				t.Errorf("Got rules %v, expected %v", actualRules, tt.expectedRules)
+			}
+			if !recorder.rules.Equal(tt.expectedDirtyRules) {
+				t.Errorf("Got dirty rules %v, expected %v", recorder.rules, tt.expectedDirtyRules)
+			}
+		})
+	}
+}
+
+func TestRuleCacheDeleteNetworkPolicy(t *testing.T) {
+	rule1 := &rule{
+		ID:        "rule1",
+		PolicyUID: "policy1",
+	}
+	rule2 := &rule{
+		ID:        "rule2",
+		PolicyUID: "policy2",
+	}
+	rule3 := &rule{
+		ID:        "rule3",
+		PolicyUID: "policy2",
+	}
+	tests := []struct {
+		name               string
+		rules              []*rule
+		args               *v1beta1.NetworkPolicy
+		expectedRules      []*rule
+		expectedDirtyRules sets.String
+	}{
+		{
+			"delete-zero-rule",
+			[]*rule{rule1, rule2, rule3},
+			&v1beta1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{UID: "policy0"},
+			},
+			[]*rule{rule1, rule2, rule3},
+			sets.NewString(),
+		},
+		{
+			"delete-one-rule",
+			[]*rule{rule1, rule2, rule3},
+			&v1beta1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{UID: "policy1"},
+			},
+			[]*rule{rule2, rule3},
+			sets.NewString("rule1"),
+		},
+		{
+			"delete-two-rule",
+			[]*rule{rule1, rule2, rule3},
+			&v1beta1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{UID: "policy2"},
+			},
+			[]*rule{rule1},
+			sets.NewString("rule2", "rule3"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := newDirtyRuleRecorder()
+			c := newRuleCache(recorder.Record)
+			for _, rule := range tt.rules {
+				c.rules.Add(rule)
+			}
+			c.DeleteNetworkPolicy(tt.args)
+
+			actualRules := c.rules.List()
+			if !assert.ElementsMatch(t, tt.expectedRules, actualRules) {
+				t.Errorf("Got rules %v, expected %v", actualRules, tt.expectedRules)
+			}
+			if !recorder.rules.Equal(tt.expectedDirtyRules) {
+				t.Errorf("Got dirty rules %v, expected %v", recorder.rules, tt.expectedDirtyRules)
+			}
+		})
+	}
+}
+
+func TestRuleCacheGetCompletedRule(t *testing.T) {
+	addressGroup1 := sets.NewString("1.1.1.1", "1.1.1.2")
+	addressGroup2 := sets.NewString("1.1.1.2", "1.1.1.3")
+	appliedToGroup1 := newPodSet(v1beta1.PodReference{"pod1", "ns1"}, v1beta1.PodReference{"pod2", "ns1"})
+	appliedToGroup2 := newPodSet(v1beta1.PodReference{"pod2", "ns1"}, v1beta1.PodReference{"pod3", "ns1"})
+	rule1 := &rule{
+		ID:              "rule1",
+		Direction:       v1beta1.DirectionIn,
+		From:            v1beta1.NetworkPolicyPeer{AddressGroups: []string{"addressGroup1"}},
+		AppliedToGroups: []string{"appliedToGroup1"},
+	}
+	rule2 := &rule{
+		ID:              "rule2",
+		Direction:       v1beta1.DirectionOut,
+		To:              v1beta1.NetworkPolicyPeer{AddressGroups: []string{"addressGroup1", "addressGroup2"}},
+		AppliedToGroups: []string{"appliedToGroup1", "appliedToGroup2"},
+	}
+	rule3 := &rule{
+		ID:              "rule3",
+		Direction:       v1beta1.DirectionIn,
+		From:            v1beta1.NetworkPolicyPeer{AddressGroups: []string{"addressGroup1", "addressGroup2", "addressGroup3"}},
+		AppliedToGroups: []string{"appliedToGroup1", "appliedToGroup2"},
+	}
+	tests := []struct {
+		name              string
+		args              string
+		wantCompletedRule *CompletedRule
+		wantExists        bool
+		wantCompleted     bool
+	}{
+		{
+			"one-group-rule",
+			rule1.ID,
+			&CompletedRule{
+				rule:          rule1,
+				FromAddresses: addressGroup1,
+				ToAddresses:   nil,
+				Pods:          appliedToGroup1,
+			},
+			true,
+			true,
+		},
+		{
+			"two-groups-rule",
+			rule2.ID,
+			&CompletedRule{
+				rule:          rule2,
+				FromAddresses: nil,
+				ToAddresses:   addressGroup1.Union(addressGroup2),
+				Pods:          appliedToGroup1.Union(appliedToGroup2),
+			},
+			true,
+			true,
+		},
+		{
+			"incompleted-rule",
+			rule3.ID,
+			nil,
+			true,
+			false,
+		},
+		{
+			"non-existing-rule",
+			"rule4",
+			nil,
+			false,
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := newDirtyRuleRecorder()
+			c := newRuleCache(recorder.Record)
+			c.addressSetByGroup["addressGroup1"] = addressGroup1
+			c.addressSetByGroup["addressGroup2"] = addressGroup2
+			c.podSetByGroup["appliedToGroup1"] = appliedToGroup1
+			c.podSetByGroup["appliedToGroup2"] = appliedToGroup2
+			c.rules.Add(rule1)
+			c.rules.Add(rule2)
+			c.rules.Add(rule3)
+
+			gotCompletedRule, gotExists, gotCompleted := c.GetCompletedRule(tt.args)
+			if !reflect.DeepEqual(gotCompletedRule, tt.wantCompletedRule) {
+				t.Errorf("GetCompletedRule() gotCompletedRule = %v, want %v", gotCompletedRule, tt.wantCompletedRule)
+			}
+			if gotExists != tt.wantExists {
+				t.Errorf("GetCompletedRule() gotExists = %v, want %v", gotExists, tt.wantExists)
+			}
+			if gotCompleted != tt.wantCompleted {
+				t.Errorf("GetCompletedRule() gotCompleted = %v, want %v", gotCompleted, tt.wantCompleted)
+			}
+		})
+	}
+}
+
+func TestRuleCachePatchAppliedToGroup(t *testing.T) {
+	rule1 := &rule{
+		ID:              "rule1",
+		AppliedToGroups: []string{"group1"},
+	}
+	rule2 := &rule{
+		ID:              "rule2",
+		AppliedToGroups: []string{"group1", "group2"},
+	}
+	tests := []struct {
+		name               string
+		rules              []*rule
+		podSetByGroup      map[string]podSet
+		args               *v1beta1.AppliedToGroupPatch
+		expectedPods       podSet
+		expectedDirtyRules sets.String
+		expectedErr        bool
+	}{
+		{
+			"non-existing-group",
+			nil,
+			nil,
+			&v1beta1.AppliedToGroupPatch{
+				ObjectMeta: metav1.ObjectMeta{Name: "group0"},
+				AddedPods:  []v1beta1.PodReference{{"pod1", "ns1"}},
+			},
+			nil,
+			sets.NewString(),
+			true,
+		},
+		{
+			"add-and-remove-pods-affecting-one-rule",
+			[]*rule{rule1, rule2},
+			map[string]podSet{"group2": newPodSet(v1beta1.PodReference{"pod1", "ns1"})},
+			&v1beta1.AppliedToGroupPatch{
+				ObjectMeta:  metav1.ObjectMeta{Name: "group2"},
+				AddedPods:   []v1beta1.PodReference{{"pod2", "ns1"}},
+				RemovedPods: []v1beta1.PodReference{{"pod1", "ns1"}},
+			},
+			newPodSet(v1beta1.PodReference{"pod2", "ns1"}),
+			sets.NewString("rule2"),
+			false,
+		},
+		{
+			"add-and-remove-pods-affecting-two-rule",
+			[]*rule{rule1, rule2},
+			map[string]podSet{"group1": newPodSet(v1beta1.PodReference{"pod1", "ns1"})},
+			&v1beta1.AppliedToGroupPatch{
+				ObjectMeta:  metav1.ObjectMeta{Name: "group1"},
+				AddedPods:   []v1beta1.PodReference{{"pod2", "ns1"}},
+				RemovedPods: []v1beta1.PodReference{{"pod1", "ns1"}},
+			},
+			newPodSet(v1beta1.PodReference{"pod2", "ns1"}),
+			sets.NewString("rule1", "rule2"),
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := newDirtyRuleRecorder()
+			c := newRuleCache(recorder.Record)
+			c.podSetByGroup = tt.podSetByGroup
+			for _, rule := range tt.rules {
+				c.rules.Add(rule)
+			}
+			err := c.PatchAppliedToGroup(tt.args)
+			if (err == nil) == tt.expectedErr {
+				t.Fatalf("Got error %v, expected %t", err, tt.expectedErr)
+			}
+			if !recorder.rules.Equal(tt.expectedDirtyRules) {
+				t.Errorf("Got dirty rules %v, expected %v", recorder.rules, tt.expectedDirtyRules)
+			}
+			actualPods, _ := c.podSetByGroup[tt.args.Name]
+			if !actualPods.Equal(tt.expectedPods) {
+				t.Errorf("Got pods %v, expected %v", actualPods, tt.expectedPods)
+			}
+		})
+	}
+}
+
+func TestRuleCachePatchAddressGroup(t *testing.T) {
+	rule1 := &rule{
+		ID:   "rule1",
+		From: v1beta1.NetworkPolicyPeer{AddressGroups: []string{"group1"}},
+	}
+	rule2 := &rule{
+		ID: "rule2",
+		To: v1beta1.NetworkPolicyPeer{AddressGroups: []string{"group1", "group2"}},
+	}
+	tests := []struct {
+		name               string
+		rules              []*rule
+		addressSetByGroup  map[string]sets.String
+		args               *v1beta1.AddressGroupPatch
+		expectedAddresses  sets.String
+		expectedDirtyRules sets.String
+		expectedErr        bool
+	}{
+		{
+			"non-existing-group",
+			nil,
+			nil,
+			&v1beta1.AddressGroupPatch{
+				ObjectMeta:       metav1.ObjectMeta{Name: "group0"},
+				AddedIPAddresses: []v1beta1.IPAddress{ipStrToIPAddress("1.1.1.1"), ipStrToIPAddress("2.2.2.2")},
+			},
+			nil,
+			sets.NewString(),
+			true,
+		},
+		{
+			"add-and-remove-addresses-affecting-one-rule",
+			[]*rule{rule1, rule2},
+			map[string]sets.String{"group2": sets.NewString("1.1.1.1")},
+			&v1beta1.AddressGroupPatch{
+				ObjectMeta:         metav1.ObjectMeta{Name: "group2"},
+				AddedIPAddresses:   []v1beta1.IPAddress{ipStrToIPAddress("2.2.2.2")},
+				RemovedIPAddresses: []v1beta1.IPAddress{ipStrToIPAddress("1.1.1.1")},
+			},
+			sets.NewString("2.2.2.2"),
+			sets.NewString("rule2"),
+			false,
+		},
+		{
+			"add-and-remove-addresses-affecting-two-rule",
+			[]*rule{rule1, rule2},
+			map[string]sets.String{"group1": sets.NewString("1.1.1.1")},
+			&v1beta1.AddressGroupPatch{
+				ObjectMeta:         metav1.ObjectMeta{Name: "group1"},
+				AddedIPAddresses:   []v1beta1.IPAddress{ipStrToIPAddress("2.2.2.2")},
+				RemovedIPAddresses: []v1beta1.IPAddress{ipStrToIPAddress("1.1.1.1")},
+			},
+			sets.NewString("2.2.2.2"),
+			sets.NewString("rule1", "rule2"),
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := newDirtyRuleRecorder()
+			c := newRuleCache(recorder.Record)
+			c.addressSetByGroup = tt.addressSetByGroup
+			for _, rule := range tt.rules {
+				c.rules.Add(rule)
+			}
+			err := c.PatchAddressGroup(tt.args)
+			if (err == nil) == tt.expectedErr {
+				t.Fatalf("Got error %v, expected %t", err, tt.expectedErr)
+			}
+			if !recorder.rules.Equal(tt.expectedDirtyRules) {
+				t.Errorf("Got dirty rules %v, expected %v", recorder.rules, tt.expectedDirtyRules)
+			}
+			actualAddresses, _ := c.addressSetByGroup[tt.args.Name]
+			if !actualAddresses.Equal(tt.expectedAddresses) {
+				t.Errorf("Got addresses %v, expected %v", actualAddresses, tt.expectedAddresses)
+			}
+		})
+	}
+}
+
+func TestRuleCacheUpdateNetworkPolicy(t *testing.T) {
+	networkPolicyRule1 := &v1beta1.NetworkPolicyRule{
+		Direction: v1beta1.DirectionIn,
+		From:      v1beta1.NetworkPolicyPeer{AddressGroups: []string{"addressGroup1"}},
+		To:        v1beta1.NetworkPolicyPeer{},
+		Services:  nil,
+	}
+	networkPolicyRule2 := &v1beta1.NetworkPolicyRule{
+		Direction: v1beta1.DirectionIn,
+		From:      v1beta1.NetworkPolicyPeer{AddressGroups: []string{"addressGroup2"}},
+		To:        v1beta1.NetworkPolicyPeer{},
+		Services:  nil,
+	}
+	networkPolicy1 := &v1beta1.NetworkPolicy{
+		ObjectMeta:      metav1.ObjectMeta{UID: "policy1"},
+		Rules:           []v1beta1.NetworkPolicyRule{*networkPolicyRule1},
+		AppliedToGroups: []string{"addressGroup1"},
+	}
+	networkPolicy2 := &v1beta1.NetworkPolicy{
+		ObjectMeta:      metav1.ObjectMeta{UID: "policy1"},
+		Rules:           []v1beta1.NetworkPolicyRule{*networkPolicyRule1},
+		AppliedToGroups: []string{"addressGroup2"},
+	}
+	networkPolicy3 := &v1beta1.NetworkPolicy{
+		ObjectMeta:      metav1.ObjectMeta{UID: "policy1"},
+		Rules:           []v1beta1.NetworkPolicyRule{*networkPolicyRule1, *networkPolicyRule2},
+		AppliedToGroups: []string{"addressGroup1"},
+	}
+	rule1 := toRule(networkPolicyRule1, networkPolicy1)
+	rule2 := toRule(networkPolicyRule1, networkPolicy2)
+	rule3 := toRule(networkPolicyRule2, networkPolicy3)
+	tests := []struct {
+		name               string
+		rules              []*rule
+		args               *v1beta1.NetworkPolicy
+		expectedRules      []*rule
+		expectedDirtyRules sets.String
+	}{
+		{
+			"updating-addressgroup",
+			[]*rule{rule1},
+			networkPolicy2,
+			[]*rule{rule2},
+			sets.NewString(rule1.ID, rule2.ID),
+		},
+		{
+			"adding-rule",
+			[]*rule{rule1},
+			networkPolicy3,
+			[]*rule{rule1, rule3},
+			sets.NewString(rule3.ID),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := newDirtyRuleRecorder()
+			c := newRuleCache(recorder.Record)
+			for _, rule := range tt.rules {
+				c.rules.Add(rule)
+			}
+			c.UpdateNetworkPolicy(tt.args)
+
+			actualRules := c.rules.List()
+			if !assert.ElementsMatch(t, tt.expectedRules, actualRules) {
+				t.Errorf("Got rules %v, expected %v", actualRules, tt.expectedRules)
+			}
+			if !recorder.rules.Equal(tt.expectedDirtyRules) {
+				t.Errorf("Got dirty rules %v, expected %v", recorder.rules, tt.expectedDirtyRules)
+			}
+		})
+	}
+}

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
@@ -1,0 +1,315 @@
+// Copyright 2019 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package networkpolicy
+
+import (
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog"
+
+	"github.com/vmware-tanzu/antrea/pkg/agent"
+	"github.com/vmware-tanzu/antrea/pkg/agent/openflow"
+	"github.com/vmware-tanzu/antrea/pkg/apis/networkpolicy/v1beta1"
+	"github.com/vmware-tanzu/antrea/pkg/client/clientset/versioned"
+)
+
+const (
+	// How long to wait before retrying the processing of a network policy change.
+	minRetryDelay = 5 * time.Second
+	maxRetryDelay = 300 * time.Second
+	// Default number of workers processing a rule change.
+	defaultWorkers = 4
+)
+
+// Controller is responsible for watching Antrea AddressGroups, AppliedToGroups,
+// and NetworkPolicies, feeding them to ruleCache, getting dirty rules from
+// ruleCache, invoking reconciler to reconcile them.
+//
+//          a.Feed AddressGroups,AppliedToGroups
+//               and NetworkPolicies
+//  |-----------|    <--------    |----------- |  c. Reconcile dirty rules |----------- |
+//  | ruleCache |                 | Controller |     ------------>         | reconciler |
+//  | ----------|    -------->    |----------- |                           |----------- |
+//              b. Notify dirty rules
+//
+type Controller struct {
+	// nodeName is the name of this node, which is used to filter resources
+	// when watching resources.
+	nodeName string
+	// antreaClient provides interfaces to watch Antrea AddressGroups,
+	// AppliedToGroups, and NetworkPolicies.
+	antreaClient versioned.Interface
+	// queue maintains the NetworkPolicy ruleIDs that need to be synced.
+	queue workqueue.RateLimitingInterface
+	// ruleCache maintains the desired state of NetworkPolicy rules.
+	ruleCache *ruleCache
+	// reconciler provides interfaces to reconcile the desired state of
+	// NetworkPolicy rules with the actual state of Openflow entries.
+	reconciler Reconciler
+}
+
+// NewNetworkPolicyController returns a new *Controller.
+func NewNetworkPolicyController(antreaClient versioned.Interface, ofClient openflow.Client, ifaceStore agent.InterfaceStore, nodeName string) *Controller {
+	c := &Controller{
+		antreaClient: antreaClient,
+		nodeName:     nodeName,
+		queue:        workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(minRetryDelay, maxRetryDelay), "networkpolicyrule"),
+		reconciler:   &NoopReconciler{},
+	}
+	c.ruleCache = newRuleCache(c.enqueueRule)
+	return c
+}
+
+// Run begins watching and processing Antrea AddressGroups, AppliedToGroups
+// and NetworkPolicies, and spawns workers that reconciles NetworkPolicy rules.
+// Run will not return until stopCh is closed.
+func (c *Controller) Run(stopCh <-chan struct{}) error {
+	go wait.Until(c.watchAppliedToGroups, 5*time.Second, stopCh)
+	go wait.Until(c.watchAddressGroups, 5*time.Second, stopCh)
+	go wait.Until(c.watchNetworkPolicies, 5*time.Second, stopCh)
+
+	for i := 0; i < defaultWorkers; i++ {
+		go wait.Until(c.worker, time.Second, stopCh)
+	}
+
+	<-stopCh
+	return nil
+}
+
+func (c *Controller) enqueueRule(ruleID string) {
+	c.queue.Add(ruleID)
+}
+
+// worker runs a worker thread that just dequeues items, processes them, and
+// marks them done. You may run as many of these in parallel as you wish; the
+// workqueue guarantees that they will not end up processing the same rule at
+// the same time.
+func (c *Controller) worker() {
+	for c.processNextWorkItem() {
+	}
+}
+
+func (c *Controller) processNextWorkItem() bool {
+	key, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(key)
+
+	err := c.syncRule(key.(string))
+	c.handleErr(err, key)
+
+	return true
+}
+
+func (c *Controller) syncRule(key string) error {
+	startTime := time.Now()
+	defer func() {
+		klog.V(4).Infof("Finished syncing rule %q. (%v)", key, time.Since(startTime))
+	}()
+
+	rule, exists, completed := c.ruleCache.GetCompletedRule(key)
+	if !exists {
+		klog.V(2).Infof("Rule %v had been deleted, removing its flows", key)
+		if err := c.reconciler.Forget(key); err != nil {
+			return err
+		}
+		return nil
+	}
+	// If the rule is not complete, we can simply skip it as it will be marked as dirty
+	// and queued again when we receive the missing group it missed.
+	if !completed {
+		klog.V(2).Infof("Rule %v was not complete, skipping", key)
+		return nil
+	}
+	if err := c.reconciler.Reconcile(rule); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *Controller) handleErr(err error, key interface{}) {
+	if err == nil {
+		c.queue.Forget(key)
+		return
+	}
+
+	klog.Errorf("Error syncing rule %q, retrying. Error: %v", key, err)
+	c.queue.AddRateLimited(key)
+}
+
+func (c *Controller) nodeScopedListOptions() metav1.ListOptions {
+	options := metav1.ListOptions{}
+	options.FieldSelector = fields.OneTermEqualSelector("nodeName", c.nodeName).String()
+	return options
+}
+
+func (c *Controller) watchAppliedToGroups() {
+	// TODO: Cleanup AppliedToGroups that are removed during reconnection.
+	klog.Info("Start watching AppliedToGroups")
+	options := c.nodeScopedListOptions()
+	w, err := c.antreaClient.NetworkpolicyV1beta1().AppliedToGroups().Watch(options)
+	if err != nil {
+		klog.Errorf("Failed to watch AppliedToGroups: %v", err)
+		return
+	}
+
+	eventCount := 0
+	defer func() {
+		klog.Infof("Stop watching AppliedToGroups, total %v items received", eventCount)
+		w.Stop()
+	}()
+
+	for {
+		select {
+		case event, ok := <-w.ResultChan():
+			if !ok {
+				return
+			}
+			switch event.Type {
+			case watch.Added:
+				group, ok := event.Object.(*v1beta1.AppliedToGroup)
+				if !ok {
+					klog.Errorf("Cannot convert to *v1beta1.AppliedToGroup: %v", event.Object)
+					return
+				}
+				klog.V(2).Infof("Added AppliedToGroup (%#v)", event.Object)
+				c.ruleCache.AddAppliedToGroup(group)
+			case watch.Modified:
+				patch, ok := event.Object.(*v1beta1.AppliedToGroupPatch)
+				if !ok {
+					klog.Errorf("Cannot convert to *v1beta1.AppliedToGroupPatch: %v", event.Object)
+					return
+				}
+				klog.V(2).Infof("Patched AppliedToGroup (%#v)", event.Object)
+				c.ruleCache.PatchAppliedToGroup(patch)
+			case watch.Deleted:
+				group, ok := event.Object.(*v1beta1.AppliedToGroup)
+				if !ok {
+					klog.Errorf("Cannot convert to *v1beta1.AppliedToGroup: %v", event.Object)
+					return
+				}
+				klog.V(2).Infof("Removed AppliedToGroup (%#v)", event.Object)
+				c.ruleCache.DeleteAppliedToGroup(group)
+			}
+			eventCount++
+		}
+	}
+}
+
+func (c *Controller) watchAddressGroups() {
+	// TODO: Cleanup AddressGroups that are removed during reconnection.
+	klog.Info("Start watching AddressGroups")
+	options := c.nodeScopedListOptions()
+	w, err := c.antreaClient.NetworkpolicyV1beta1().AddressGroups().Watch(options)
+	if err != nil {
+		klog.Errorf("Failed to watch AddressGroups: %v", err)
+		return
+	}
+
+	eventCount := 0
+	defer func() {
+		klog.Infof("Stop watching AddressGroups, total %v items received", eventCount)
+		w.Stop()
+	}()
+
+	for {
+		select {
+		case event, ok := <-w.ResultChan():
+			if !ok {
+				return
+			}
+			switch event.Type {
+			case watch.Added:
+				group, ok := event.Object.(*v1beta1.AddressGroup)
+				if !ok {
+					klog.Errorf("Cannot convert to *v1beta1.AddressGroup: %v", event.Object)
+					return
+				}
+				c.ruleCache.AddAddressGroup(group)
+			case watch.Modified:
+				patch, ok := event.Object.(*v1beta1.AddressGroupPatch)
+				if !ok {
+					klog.Errorf("Cannot convert to *v1beta1.AddressGroupPatch: %v", event.Object)
+					return
+				}
+				c.ruleCache.PatchAddressGroup(patch)
+			case watch.Deleted:
+				group, ok := event.Object.(*v1beta1.AddressGroup)
+				if !ok {
+					klog.Errorf("Cannot convert to *v1beta1.AddressGroup: %v", event.Object)
+					return
+				}
+				c.ruleCache.DeleteAddressGroup(group)
+			}
+			eventCount++
+		}
+	}
+}
+
+func (c *Controller) watchNetworkPolicies() {
+	// TODO: Cleanup NetworkPolicies that are removed during reconnection.
+	klog.Info("Start watching NetworkPolicies")
+	options := c.nodeScopedListOptions()
+	w, err := c.antreaClient.NetworkpolicyV1beta1().NetworkPolicies("").Watch(options)
+	if err != nil {
+		klog.Errorf("Failed to watch NetworkPolicies: %v", err)
+		return
+	}
+
+	eventCount := 0
+	defer func() {
+		klog.Infof("Stop watching NetworkPolicies, total %v items received", eventCount)
+		w.Stop()
+	}()
+
+	for {
+		select {
+		case event, ok := <-w.ResultChan():
+			if !ok {
+				return
+			}
+			switch event.Type {
+			case watch.Added:
+				policy, ok := event.Object.(*v1beta1.NetworkPolicy)
+				if !ok {
+					klog.Errorf("Cannot convert to *v1beta1.NetworkPolicy: %v", event.Object)
+					return
+				}
+				c.ruleCache.AddNetworkPolicy(policy)
+			case watch.Modified:
+				policy, ok := event.Object.(*v1beta1.NetworkPolicy)
+				if !ok {
+					klog.Errorf("Cannot convert to *v1beta1.NetworkPolicy: %v", event.Object)
+					return
+				}
+				c.ruleCache.UpdateNetworkPolicy(policy)
+			case watch.Deleted:
+				policy, ok := event.Object.(*v1beta1.NetworkPolicy)
+				if !ok {
+					klog.Errorf("cannot convert to *v1beta1.NetworkPolicy: %v", event.Object)
+					return
+				}
+				c.ruleCache.DeleteNetworkPolicy(policy)
+			}
+			eventCount++
+		}
+	}
+}

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
@@ -1,0 +1,261 @@
+// Copyright 2019 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package networkpolicy
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/watch"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/vmware-tanzu/antrea/pkg/apis/networkpolicy/v1beta1"
+	"github.com/vmware-tanzu/antrea/pkg/client/clientset/versioned/fake"
+)
+
+func newTestController() (*Controller, *fake.Clientset, *mockReconciler) {
+	clientset := &fake.Clientset{}
+
+	controller := NewNetworkPolicyController(clientset, nil, nil, "node1")
+	reconciler := newMockReconciler()
+	controller.reconciler = reconciler
+	return controller, clientset, reconciler
+}
+
+type mockReconciler struct {
+	lastRealized map[string]*CompletedRule
+	updated      chan string
+}
+
+func newMockReconciler() *mockReconciler {
+	return &mockReconciler{map[string]*CompletedRule{}, make(chan string, 3)}
+}
+
+func (r *mockReconciler) Reconcile(rule *CompletedRule) error {
+	r.lastRealized[rule.ID] = rule
+	r.updated <- rule.ID
+	return nil
+}
+
+func (r *mockReconciler) Forget(ruleID string) error {
+	delete(r.lastRealized, ruleID)
+	r.updated <- ruleID
+	return nil
+}
+
+var _ Reconciler = &mockReconciler{}
+
+func getAddressGroup(name string, addresses []v1beta1.IPAddress) *v1beta1.AddressGroup {
+	return &v1beta1.AddressGroup{
+		ObjectMeta:  v1.ObjectMeta{Name: name},
+		IPAddresses: addresses,
+	}
+}
+
+func getAppliedToGroup(name string, pods []v1beta1.PodReference) *v1beta1.AppliedToGroup {
+	return &v1beta1.AppliedToGroup{
+		ObjectMeta: v1.ObjectMeta{Name: name},
+		Pods:       pods,
+	}
+}
+
+func getNetworkPolicy(uid string, from, to, appliedTo []string, services []v1beta1.Service) *v1beta1.NetworkPolicy {
+	networkPolicyRule1 := v1beta1.NetworkPolicyRule{
+		Direction: v1beta1.DirectionIn,
+		From:      v1beta1.NetworkPolicyPeer{AddressGroups: from},
+		To:        v1beta1.NetworkPolicyPeer{AddressGroups: to},
+		Services:  services,
+	}
+	return &v1beta1.NetworkPolicy{
+		ObjectMeta:      v1.ObjectMeta{UID: types.UID(uid)},
+		Rules:           []v1beta1.NetworkPolicyRule{networkPolicyRule1},
+		AppliedToGroups: appliedTo,
+	}
+}
+
+func TestAddSingleGroupRule(t *testing.T) {
+	controller, clientset, reconciler := newTestController()
+	addressGroupWatcher := watch.NewFake()
+	appliedToGroupWatcher := watch.NewFake()
+	networkPolicyWatcher := watch.NewFake()
+	clientset.AddWatchReactor("addressgroups", k8stesting.DefaultWatchReactor(addressGroupWatcher, nil))
+	clientset.AddWatchReactor("appliedtogroups", k8stesting.DefaultWatchReactor(appliedToGroupWatcher, nil))
+	clientset.AddWatchReactor("networkpolicies", k8stesting.DefaultWatchReactor(networkPolicyWatcher, nil))
+
+	protocolTCP := v1beta1.ProtocolTCP
+	port := int32(80)
+	services := []v1beta1.Service{{Protocol: &protocolTCP, Port: &port}}
+	desiredRule := &CompletedRule{
+		rule:          &rule{Direction: v1beta1.DirectionIn, Services: services},
+		FromAddresses: sets.NewString("1.1.1.1", "2.2.2.2"),
+		ToAddresses:   sets.NewString(),
+		Pods:          newPodSet(v1beta1.PodReference{"pod1", "ns1"}),
+	}
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	go controller.Run(stopCh)
+
+	// policy1 comes first, no rule will be synced due to missing addressGroup1 and appliedToGroup1.
+	networkPolicyWatcher.Add(getNetworkPolicy("policy1", []string{"addressGroup1"}, []string{}, []string{"appliedToGroup1"}, services))
+	select {
+	case ruleID := <-reconciler.updated:
+		t.Fatalf("Expected no update, got %v", ruleID)
+	case <-time.After(time.Millisecond * 100):
+	}
+
+	// addressGroup1 comes, no rule will be synced due to missing appliedToGroup1 data.
+	addressGroupWatcher.Add(getAddressGroup("addressGroup1", []v1beta1.IPAddress{ipStrToIPAddress("1.1.1.1"), ipStrToIPAddress("2.2.2.2")}))
+	select {
+	case ruleID := <-reconciler.updated:
+		t.Fatalf("Expected no update, got %v", ruleID)
+	case <-time.After(time.Millisecond * 100):
+	}
+
+	// appliedToGroup1 comes, policy1 will be synced.
+	appliedToGroupWatcher.Add(getAppliedToGroup("appliedToGroup1", []v1beta1.PodReference{{"pod1", "ns1"}}))
+	select {
+	case ruleID := <-reconciler.updated:
+		actualRule := reconciler.lastRealized[ruleID]
+		if actualRule.Direction != desiredRule.Direction {
+			t.Errorf("Expected Direction %v, got %v", actualRule.Direction, desiredRule.Direction)
+		}
+		if !assert.ElementsMatch(t, actualRule.Services, desiredRule.Services) {
+			t.Errorf("Expected Services %v, got %v", actualRule.Services, desiredRule.Services)
+		}
+		if !actualRule.FromAddresses.Equal(desiredRule.FromAddresses) {
+			t.Errorf("Expected FromAddresses %v, got %v", actualRule.FromAddresses, desiredRule.FromAddresses)
+		}
+		if !actualRule.ToAddresses.Equal(desiredRule.ToAddresses) {
+			t.Errorf("Expected ToAddresses %v, got %v", actualRule.ToAddresses, desiredRule.ToAddresses)
+		}
+		if !actualRule.Pods.Equal(desiredRule.Pods) {
+			t.Errorf("Expected Pods %v, got %v", actualRule.Pods, desiredRule.Pods)
+		}
+	case <-time.After(time.Millisecond * 100):
+		t.Fatal("Expected one update, got none")
+	}
+}
+
+func TestAddMultipleGroupsRule(t *testing.T) {
+	controller, clientset, reconciler := newTestController()
+	addressGroupWatcher := watch.NewFake()
+	appliedToGroupWatcher := watch.NewFake()
+	networkPolicyWatcher := watch.NewFake()
+	clientset.AddWatchReactor("addressgroups", k8stesting.DefaultWatchReactor(addressGroupWatcher, nil))
+	clientset.AddWatchReactor("appliedtogroups", k8stesting.DefaultWatchReactor(appliedToGroupWatcher, nil))
+	clientset.AddWatchReactor("networkpolicies", k8stesting.DefaultWatchReactor(networkPolicyWatcher, nil))
+
+	protocolTCP := v1beta1.ProtocolTCP
+	port := int32(80)
+	services := []v1beta1.Service{{Protocol: &protocolTCP, Port: &port}}
+	desiredRule := &CompletedRule{
+		rule:          &rule{Direction: v1beta1.DirectionIn, Services: services},
+		FromAddresses: sets.NewString("1.1.1.1", "2.2.2.2", "3.3.3.3"),
+		ToAddresses:   sets.NewString(),
+		Pods:          newPodSet(v1beta1.PodReference{"pod1", "ns1"}, v1beta1.PodReference{"pod2", "ns2"}),
+	}
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	go controller.Run(stopCh)
+
+	// addressGroup1 comes, no rule will be synced.
+	addressGroupWatcher.Add(getAddressGroup("addressGroup1", []v1beta1.IPAddress{ipStrToIPAddress("1.1.1.1"), ipStrToIPAddress("2.2.2.2")}))
+	// appliedToGroup1 comes, no rule will be synced.
+	appliedToGroupWatcher.Add(getAppliedToGroup("appliedToGroup1", []v1beta1.PodReference{{"pod1", "ns1"}}))
+	// policy1 comes first, no rule will be synced due to missing addressGroup2 and appliedToGroup2.
+	networkPolicyWatcher.Add(getNetworkPolicy("policy1", []string{"addressGroup1", "addressGroup2"}, []string{}, []string{"appliedToGroup1", "appliedToGroup2"}, services))
+	select {
+	case ruleID := <-reconciler.updated:
+		t.Fatalf("Expected no update, got %v", ruleID)
+	case <-time.After(time.Millisecond * 100):
+	}
+
+	// addressGroup2 comes, no rule will be synced due to missing appliedToGroup2 data.
+	addressGroupWatcher.Add(getAddressGroup("addressGroup2", []v1beta1.IPAddress{ipStrToIPAddress("1.1.1.1"), ipStrToIPAddress("3.3.3.3")}))
+	select {
+	case ruleID := <-reconciler.updated:
+		t.Fatalf("Expected no update, got %v", ruleID)
+	case <-time.After(time.Millisecond * 100):
+	}
+
+	// appliedToGroup2 comes, policy1 will be synced.
+	appliedToGroupWatcher.Add(getAppliedToGroup("appliedToGroup2", []v1beta1.PodReference{{"pod2", "ns2"}}))
+	select {
+	case ruleID := <-reconciler.updated:
+		actualRule := reconciler.lastRealized[ruleID]
+		if actualRule.Direction != desiredRule.Direction {
+			t.Errorf("Expected Direction %v, got %v", actualRule.Direction, desiredRule.Direction)
+		}
+		if !assert.ElementsMatch(t, actualRule.Services, desiredRule.Services) {
+			t.Errorf("Expected Services %v, got %v", actualRule.Services, desiredRule.Services)
+		}
+		if !actualRule.FromAddresses.Equal(desiredRule.FromAddresses) {
+			t.Errorf("Expected FromAddresses %v, got %v", actualRule.FromAddresses, desiredRule.FromAddresses)
+		}
+		if !actualRule.ToAddresses.Equal(desiredRule.ToAddresses) {
+			t.Errorf("Expected ToAddresses %v, got %v", actualRule.ToAddresses, desiredRule.ToAddresses)
+		}
+		if !actualRule.Pods.Equal(desiredRule.Pods) {
+			t.Errorf("Expected Pods %v, got %v", actualRule.Pods, desiredRule.Pods)
+		}
+	case <-time.After(time.Millisecond * 100):
+		t.Fatal("Expected one update, got none")
+	}
+}
+
+func TestDeleteRule(t *testing.T) {
+	controller, clientset, reconciler := newTestController()
+	addressGroupWatcher := watch.NewFake()
+	appliedToGroupWatcher := watch.NewFake()
+	networkPolicyWatcher := watch.NewFake()
+	clientset.AddWatchReactor("addressgroups", k8stesting.DefaultWatchReactor(addressGroupWatcher, nil))
+	clientset.AddWatchReactor("appliedtogroups", k8stesting.DefaultWatchReactor(appliedToGroupWatcher, nil))
+	clientset.AddWatchReactor("networkpolicies", k8stesting.DefaultWatchReactor(networkPolicyWatcher, nil))
+
+	protocolTCP := v1beta1.ProtocolTCP
+	port := int32(80)
+	services := []v1beta1.Service{{Protocol: &protocolTCP, Port: &port}}
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	go controller.Run(stopCh)
+
+	addressGroupWatcher.Add(getAddressGroup("addressGroup1", []v1beta1.IPAddress{ipStrToIPAddress("1.1.1.1"), ipStrToIPAddress("2.2.2.2")}))
+	appliedToGroupWatcher.Add(getAppliedToGroup("appliedToGroup1", []v1beta1.PodReference{{"pod1", "ns1"}}))
+	networkPolicyWatcher.Add(getNetworkPolicy("policy1", []string{"addressGroup1"}, []string{}, []string{"appliedToGroup1"}, services))
+	select {
+	case ruleID := <-reconciler.updated:
+		_, exists := reconciler.lastRealized[ruleID]
+		if !exists {
+			t.Fatalf("Expected rule %s, got none", ruleID)
+		}
+	case <-time.After(time.Millisecond * 100):
+		t.Fatal("Expected one update, got none")
+	}
+
+	networkPolicyWatcher.Delete(getNetworkPolicy("policy1", []string{}, []string{}, []string{}, nil))
+	select {
+	case ruleID := <-reconciler.updated:
+		actualRule, exists := reconciler.lastRealized[ruleID]
+		if exists {
+			t.Errorf("Expected no rule, got %v", actualRule)
+		}
+	case <-time.After(time.Millisecond * 100):
+		t.Fatal("Expected one update, got none")
+	}
+}

--- a/pkg/agent/controller/networkpolicy/podset.go
+++ b/pkg/agent/controller/networkpolicy/podset.go
@@ -1,0 +1,70 @@
+// Copyright 2019 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package networkpolicy
+
+import (
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/vmware-tanzu/antrea/pkg/apis/networkpolicy/v1beta1"
+)
+
+// TODO: use set-gen to generate it.
+type podSet map[v1beta1.PodReference]sets.Empty
+
+// Union returns a new set which includes items in either s1 or s2.
+func (s podSet) Union(o podSet) podSet {
+	result := podSet{}
+	for key := range s {
+		result.Insert(key)
+	}
+	for key := range o {
+		result.Insert(key)
+	}
+	return result
+}
+
+// Insert adds items to the set.
+func (s podSet) Insert(items ...v1beta1.PodReference) {
+	for _, item := range items {
+		s[item] = sets.Empty{}
+	}
+}
+
+// IsSuperset returns true if and only if s1 is a superset of s2.
+func (s1 podSet) IsSuperset(s2 podSet) bool {
+	for item := range s2 {
+		_, contained := s1[item]
+		if !contained {
+			return false
+		}
+	}
+	return true
+}
+
+// Equal returns true if and only if s1 is equal (as a set) to s2.
+// Two sets are equal if their membership is identical.
+// (In practice, this means same elements, order doesn't matter)
+func (s1 podSet) Equal(s2 podSet) bool {
+	return len(s1) == len(s2) && s1.IsSuperset(s2)
+}
+
+// newPodSet builds an podSet from a list of v1beta1.PodReference.
+func newPodSet(pods ...v1beta1.PodReference) podSet {
+	s := podSet{}
+	for _, a := range pods {
+		s[a] = sets.Empty{}
+	}
+	return s
+}

--- a/pkg/agent/controller/networkpolicy/reconciler.go
+++ b/pkg/agent/controller/networkpolicy/reconciler.go
@@ -1,0 +1,42 @@
+// Copyright 2019 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package networkpolicy
+
+import (
+	"k8s.io/klog"
+)
+
+// Reconciler is an interface that knows how to reconcile the desired state of
+// CompletedRule with the actual state of Openflow entries.
+type Reconciler interface {
+	// Reconcile reconciles the desired state of the provided CompletedRule
+	// with the actual state of Openflow entries.
+	Reconcile(rule *CompletedRule) error
+
+	// Forget cleanups the actual state of Openflow entries of the specified ruleID.
+	Forget(ruleID string) error
+}
+
+type NoopReconciler struct{}
+
+func (r *NoopReconciler) Reconcile(rule *CompletedRule) error {
+	klog.Infof("Reconciling rule %v", rule)
+	return nil
+}
+
+func (r *NoopReconciler) Forget(ruleID string) error {
+	klog.Infof("Forgetting rule %v", ruleID)
+	return nil
+}


### PR DESCRIPTION
This patch adds a Network Policy controller which watching Antrea
AddressGroups, AppliedToGroups, and NetworkPolicies, feeding them to
ruleCache, getting dirty rules from ruleCache, invoking reconciler to
reconcile them with Openflow entries.

This patch implements ruleCache that maintains the desired state of
NetworkPolicy rules and uses a noop reconciler implementation
temporarily.