### PR TITLE
Implement Network Policy rule reconciler

### DIFF
--- a/pkg/agent/controller/networkpolicy/allocator.go
+++ b/pkg/agent/controller/networkpolicy/allocator.go
@@ -1,0 +1,100 @@
+// Copyright 2019 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package networkpolicy
+
+import (
+	"fmt"
+	"math"
+	"sync"
+)
+
+// idAllocator provides interfaces to allocate and release uint32 IDs. It's thread-safe.
+// It caches the last allocated ID and the IDs that have been released.
+// If no IDs that have been released, the next allocated IP will be lastAllocatedID+1.
+// If there are IDs that have been released, they will be reused FIFO.
+type idAllocator struct {
+	sync.Mutex
+	// lastAllocatedID is the last allocated ID.
+	// IDs that are greater than it must be available.
+	// IDs that are less than or equal to it are available if they are in availableSet,
+	// otherwise unavailable.
+	lastAllocatedID uint32
+
+	// availableSet maintains the IDs that can be reused for allocation.
+	availableSet map[uint32]struct{}
+	// availableSlice maintains the order of release.
+	availableSlice []uint32
+}
+
+// newIDAllocator returns a new *idAllocator.
+// It takes a list of allocated IDs, which can be used for the restart case.
+func newIDAllocator(allocatedIDs ...uint32) *idAllocator {
+	allocator := &idAllocator{
+		availableSet: make(map[uint32]struct{}),
+	}
+
+	var maxID uint32
+	allocatedSet := make(map[uint32]struct{}, len(allocatedIDs))
+	for _, id := range allocatedIDs {
+		allocatedSet[id] = struct{}{}
+		if id > maxID {
+			maxID = id
+		}
+	}
+	for id := uint32(1); id < maxID; id++ {
+		if _, exists := allocatedSet[id]; !exists {
+			allocator.availableSet[id] = struct{}{}
+			allocator.availableSlice = append(allocator.availableSlice, id)
+		}
+	}
+	allocator.lastAllocatedID = maxID
+	return allocator
+}
+
+// allocate allocates an uint32 ID if there's available, otherwise error is returned.
+// It will try to reuse IDs that have been released first, then allocate a new ID by
+// incrementing the last allocated one.
+func (a *idAllocator) allocate() (uint32, error) {
+	a.Lock()
+	defer a.Unlock()
+
+	if len(a.availableSlice) > 0 {
+		var id uint32
+		id, a.availableSlice = a.availableSlice[0], a.availableSlice[1:]
+		delete(a.availableSet, id)
+		return id, nil
+	}
+	if a.lastAllocatedID == math.MaxUint32 {
+		return 0, fmt.Errorf("no ID available")
+	}
+	a.lastAllocatedID++
+	return a.lastAllocatedID, nil
+}
+
+// release releases an uint32 ID if it has been allocated before, otherwise error is returned.
+func (a *idAllocator) release(id uint32) error {
+	a.Lock()
+	defer a.Unlock()
+
+	if _, exists := a.availableSet[id]; exists {
+		return fmt.Errorf("ID %d has been released, duplicate release is not allowed", id)
+	}
+	if id > a.lastAllocatedID {
+		return fmt.Errorf("ID %d was not allocated, can't be released", id)
+	}
+	a.availableSet[id] = struct{}{}
+	a.availableSlice = append(a.availableSlice, id)
+	return nil
+}

--- a/pkg/agent/controller/networkpolicy/allocator_test.go
+++ b/pkg/agent/controller/networkpolicy/allocator_test.go
@@ -1,0 +1,145 @@
+// Copyright 2019 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package networkpolicy
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewIDAllocator(t *testing.T) {
+	tests := []struct {
+		name                    string
+		args                    []uint32
+		expectedLastAllocatedID uint32
+		expectedAvailableSets   map[uint32]struct{}
+		expectedAvailableSlice  []uint32
+	}{
+		{
+			"zero-allocated-ids",
+			nil,
+			0,
+			map[uint32]struct{}{},
+			nil,
+		},
+		{
+			"consecutive-allocated-ids",
+			[]uint32{1, 2},
+			2,
+			map[uint32]struct{}{},
+			nil,
+		},
+		{
+			"inconsecutive-allocated-ids",
+			[]uint32{2, 7, 5},
+			7,
+			map[uint32]struct{}{1: {}, 3: {}, 4: {}, 6: {}},
+			[]uint32{1, 3, 4, 6},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := newIDAllocator(tt.args...)
+			assert.Equalf(t, tt.expectedLastAllocatedID, got.lastAllocatedID, "Got lastAllocatedID %v, expected %v", got.lastAllocatedID, tt.expectedLastAllocatedID)
+			assert.Equalf(t, tt.expectedAvailableSets, got.availableSet, "Got availableSet %v, expected %v", got.availableSet, tt.expectedAvailableSets)
+			assert.Equalf(t, tt.expectedAvailableSlice, got.availableSlice, "Got availableSlice %v, expected %v", got.availableSlice, tt.expectedAvailableSlice)
+		})
+	}
+}
+
+func TestAllocate(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []uint32
+		expectedID  uint32
+		expectedErr error
+	}{
+		{
+			"zero-allocated-ids",
+			nil,
+			1,
+			nil,
+		},
+		{
+			"consecutive-allocated-ids",
+			[]uint32{1, 2},
+			3,
+			nil,
+		},
+		{
+			"inconsecutive-allocated-ids",
+			[]uint32{1, 7, 5},
+			2,
+			nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := newIDAllocator(tt.args...)
+			actualID, actualErr := a.allocate()
+			if actualErr != tt.expectedErr {
+				t.Fatalf("Got error %v, expected %v", actualErr, tt.expectedErr)
+			}
+			assert.Equalf(t, tt.expectedID, actualID, "Got id %v, expected %v", actualID, tt.expectedID)
+		})
+	}
+}
+
+func TestRelease(t *testing.T) {
+	tests := []struct {
+		name                   string
+		newArgs                []uint32
+		releaseArgs            uint32
+		expectedErr            error
+		expectedAvailableSets  map[uint32]struct{}
+		expectedAvailableSlice []uint32
+	}{
+		{
+			"duplicate-release",
+			[]uint32{2},
+			1,
+			fmt.Errorf("ID %d has been released, duplicate release is not allowed", 1),
+			map[uint32]struct{}{1: {}},
+			[]uint32{1},
+		},
+		{
+			"invalid-release",
+			[]uint32{1, 2},
+			5,
+			fmt.Errorf("ID %d was not allocated, can't be released", 5),
+			map[uint32]struct{}{},
+			nil,
+		},
+		{
+			"valid-release",
+			[]uint32{1, 2, 3},
+			2,
+			nil,
+			map[uint32]struct{}{2: {}},
+			[]uint32{2},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := newIDAllocator(tt.newArgs...)
+			actualErr := a.release(tt.releaseArgs)
+			assert.Equalf(t, tt.expectedErr, actualErr, "Got error %v, expected %v", actualErr, tt.expectedErr)
+			assert.Equalf(t, tt.expectedAvailableSets, a.availableSet, "Got availableSet %v, expected %v", a.availableSet, tt.expectedAvailableSets)
+			assert.Equalf(t, tt.expectedAvailableSlice, a.availableSlice, "Got availableSlice %v, expected %v", a.availableSlice, tt.expectedAvailableSlice)
+		})
+	}
+}

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
@@ -71,7 +71,7 @@ func NewNetworkPolicyController(antreaClient versioned.Interface, ofClient openf
 		antreaClient: antreaClient,
 		nodeName:     nodeName,
 		queue:        workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(minRetryDelay, maxRetryDelay), "networkpolicyrule"),
-		reconciler:   &NoopReconciler{},
+		reconciler:   newReconciler(ofClient, ifaceStore),
 	}
 	c.ruleCache = newRuleCache(c.enqueueRule)
 	return c
@@ -243,6 +243,7 @@ func (c *Controller) watchAddressGroups() {
 					klog.Errorf("Cannot convert to *v1beta1.AddressGroup: %v", event.Object)
 					return
 				}
+				klog.V(2).Infof("Added AddressGroup (%#v)", event.Object)
 				c.ruleCache.AddAddressGroup(group)
 			case watch.Modified:
 				patch, ok := event.Object.(*v1beta1.AddressGroupPatch)
@@ -250,6 +251,7 @@ func (c *Controller) watchAddressGroups() {
 					klog.Errorf("Cannot convert to *v1beta1.AddressGroupPatch: %v", event.Object)
 					return
 				}
+				klog.V(2).Infof("Patched AddressGroup (%#v)", event.Object)
 				c.ruleCache.PatchAddressGroup(patch)
 			case watch.Deleted:
 				group, ok := event.Object.(*v1beta1.AddressGroup)
@@ -257,6 +259,7 @@ func (c *Controller) watchAddressGroups() {
 					klog.Errorf("Cannot convert to *v1beta1.AddressGroup: %v", event.Object)
 					return
 				}
+				klog.V(2).Infof("Removed AddressGroup (%#v)", event.Object)
 				c.ruleCache.DeleteAddressGroup(group)
 			}
 			eventCount++
@@ -293,6 +296,7 @@ func (c *Controller) watchNetworkPolicies() {
 					klog.Errorf("Cannot convert to *v1beta1.NetworkPolicy: %v", event.Object)
 					return
 				}
+				klog.V(2).Infof("Added NetworkPolicy (%#v)", event.Object)
 				c.ruleCache.AddNetworkPolicy(policy)
 			case watch.Modified:
 				policy, ok := event.Object.(*v1beta1.NetworkPolicy)
@@ -300,6 +304,7 @@ func (c *Controller) watchNetworkPolicies() {
 					klog.Errorf("Cannot convert to *v1beta1.NetworkPolicy: %v", event.Object)
 					return
 				}
+				klog.V(2).Infof("Updated NetworkPolicy (%#v)", event.Object)
 				c.ruleCache.UpdateNetworkPolicy(policy)
 			case watch.Deleted:
 				policy, ok := event.Object.(*v1beta1.NetworkPolicy)
@@ -307,6 +312,7 @@ func (c *Controller) watchNetworkPolicies() {
 					klog.Errorf("cannot convert to *v1beta1.NetworkPolicy: %v", event.Object)
 					return
 				}
+				klog.V(2).Infof("Removed NetworkPolicy (%#v)", event.Object)
 				c.ruleCache.DeleteNetworkPolicy(policy)
 			}
 			eventCount++

--- a/pkg/agent/controller/networkpolicy/podset.go
+++ b/pkg/agent/controller/networkpolicy/podset.go
@@ -35,6 +35,22 @@ func (s podSet) Union(o podSet) podSet {
 	return result
 }
 
+// Difference returns a set of objects that are not in s2
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s1.Difference(s2) = {a3}
+// s2.Difference(s1) = {a4, a5}
+func (s podSet) Difference(s2 podSet) podSet {
+	result := newPodSet()
+	for key := range s {
+		if _, contained := s2[key]; !contained {
+			result.Insert(key)
+		}
+	}
+	return result
+}
+
 // Insert adds items to the set.
 func (s podSet) Insert(items ...v1beta1.PodReference) {
 	for _, item := range items {

--- a/pkg/agent/controller/networkpolicy/reconciler.go
+++ b/pkg/agent/controller/networkpolicy/reconciler.go
@@ -15,7 +15,19 @@
 package networkpolicy
 
 import (
+	"fmt"
+	"net"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/klog"
+
+	"github.com/vmware-tanzu/antrea/pkg/agent"
+	"github.com/vmware-tanzu/antrea/pkg/agent/openflow"
+	"github.com/vmware-tanzu/antrea/pkg/agent/types"
+	"github.com/vmware-tanzu/antrea/pkg/apis/networkpolicy/v1beta1"
 )
 
 // Reconciler is an interface that knows how to reconcile the desired state of
@@ -29,14 +41,275 @@ type Reconciler interface {
 	Forget(ruleID string) error
 }
 
-type NoopReconciler struct{}
+// lastRealized is the struct cached by reconciler.
+type lastRealized struct {
+	// ofID identifies a rule in Openflow implementation.
+	ofID uint32
+	// The desired state of a policy rule.
+	*CompletedRule
+}
 
-func (r *NoopReconciler) Reconcile(rule *CompletedRule) error {
-	klog.Infof("Reconciling rule %v", rule)
+// reconciler implements Reconciler.
+// Note that although its Reconcile and Forget methods are thread-safe, it's
+// assumed each rule can only be processed by a single client at any given
+// time. Different rules can be processed in parallel.
+type reconciler struct {
+	// ofClient is the Openflow interface.
+	ofClient openflow.Client
+
+	// ofClient is the Openflow interface.
+	ifaceStore agent.InterfaceStore
+
+	// lastRealizeds caches the last realized rules.
+	// It's a mapping from ruleID to *lastRealized.
+	lastRealizeds sync.Map
+
+	// idAllocator provides interfaces to allocate and release uint32 id.
+	idAllocator *idAllocator
+}
+
+// newReconciler returns a new *reconciler.
+func newReconciler(ofClient openflow.Client, ifaceStore agent.InterfaceStore) *reconciler {
+	reconciler := &reconciler{
+		ofClient:      ofClient,
+		ifaceStore:    ifaceStore,
+		lastRealizeds: sync.Map{},
+		idAllocator:   newIDAllocator(),
+	}
+	return reconciler
+}
+
+// Reconcile checks whether the provided rule have been enforced or not, and
+// invoke the add or update method accordingly.
+func (r *reconciler) Reconcile(rule *CompletedRule) error {
+	klog.Infof("Reconciling rule %v", rule.ID)
+
+	value, exists := r.lastRealizeds.Load(rule.ID)
+	if !exists {
+		return r.add(rule)
+	}
+	return r.update(value.(*lastRealized), rule)
+}
+
+// add allocates an unique Openflow ID for the provide CompletedRule, converts
+// it to PolicyRule, and invoke InstallPolicyRuleFlows to install the later.
+func (r *reconciler) add(rule *CompletedRule) error {
+	klog.V(2).Infof("Adding new rule %v (%v, %d FromAddresses, %d ToAddresses, %d Pods)",
+		rule.ID, rule.Direction, len(rule.FromAddresses), len(rule.ToAddresses), len(rule.Pods))
+	ofID, err := r.idAllocator.allocate()
+	if err != nil {
+		return fmt.Errorf("error allocating Openflow ID")
+	}
+	// Release the ID if encountering any error.
+	defer func() {
+		if err != nil {
+			r.idAllocator.release(ofID)
+		}
+	}()
+	// TODO: Update types.PolicyRule to use Antrea Direction type.
+	var direction networkingv1.PolicyType
+	// TODO: Differentiate rule that match everything and rule that match nothing.
+	// nil slice should match everything and empty slice should match nothing.
+	var from, to []types.Address
+	if rule.Direction == v1beta1.DirectionIn {
+		direction = networkingv1.PolicyTypeIngress
+
+		if rule.FromAddresses != nil || rule.From.IPBlocks != nil {
+			from = make([]types.Address, 0, len(rule.FromAddresses)+len(rule.From.IPBlocks))
+		}
+		for a := range rule.FromAddresses {
+			from = append(from, openflow.NewIPAddress(net.ParseIP(a)))
+		}
+		// TODO: handle except field.
+		for _, b := range rule.From.IPBlocks {
+			from = append(from, openflow.NewIPNetAddress(antreaIPNetToIPNet(b.CIDR)))
+		}
+
+		to = r.podsToOFPortAddresses(rule.Pods)
+	} else {
+		direction = networkingv1.PolicyTypeEgress
+
+		from = r.podsToIPAddresses(rule.Pods)
+
+		if rule.ToAddresses != nil || rule.To.IPBlocks != nil {
+			to = make([]types.Address, 0, len(rule.ToAddresses)+len(rule.To.IPBlocks))
+		}
+		for a := range rule.ToAddresses {
+			to = append(to, openflow.NewIPAddress(net.ParseIP(a)))
+		}
+		// TODO: handle except field.
+		for _, b := range rule.To.IPBlocks {
+			to = append(to, openflow.NewIPNetAddress(antreaIPNetToIPNet(b.CIDR)))
+		}
+	}
+
+	// TODO: Update types.PolicyRule to use Antrea Service type.
+	services := servicesToNetworkPolicyPort(rule.Services)
+
+	ofRule := &types.PolicyRule{
+		ID:        ofID,
+		Direction: direction,
+		From:      from,
+		To:        to,
+		Service:   services,
+	}
+
+	klog.V(2).Infof("Installing ofRule %d (%v, %d From, %d To, %d Service)",
+		ofRule.ID, ofRule.Direction, len(ofRule.From), len(ofRule.To), len(ofRule.Service))
+	if err := r.ofClient.InstallPolicyRuleFlows(ofRule); err != nil {
+		return fmt.Errorf("error installing ofRule %v: %v", ofRule.ID, err)
+	}
+
+	r.lastRealizeds.Store(rule.ID, &lastRealized{ofID, rule})
 	return nil
 }
 
-func (r *NoopReconciler) Forget(ruleID string) error {
-	klog.Infof("Forgetting rule %v", ruleID)
+func servicesToNetworkPolicyPort(in []v1beta1.Service) []*networkingv1.NetworkPolicyPort {
+	var out []*networkingv1.NetworkPolicyPort
+	for _, s := range in {
+		service := &networkingv1.NetworkPolicyPort{}
+		if s.Protocol != nil {
+			protoStr := string(*s.Protocol)
+			proto := corev1.Protocol(protoStr)
+			service.Protocol = &proto
+		}
+		if s.Port != nil {
+			// We have converted named port to int port in antrea-controller.
+			// Here it's just to adapt the PolicyRule type, and can be removed
+			// once switching to use Antrea Service type.
+			port := intstr.FromInt(int(*s.Port))
+			service.Port = &port
+		}
+		out = append(out, service)
+	}
+	return out
+}
+
+// update calculates the difference of Addresses between oldRule and newRule,
+// and invokes Openflow client's methods to reconcile them.
+func (r *reconciler) update(lastRealized *lastRealized, newRule *CompletedRule) error {
+	klog.V(2).Infof("Updating existing rule %v (%v, %d FromAddresses, %d ToAddresses, %d Pods)",
+		newRule.ID, newRule.Direction, len(newRule.FromAddresses), len(newRule.ToAddresses), len(newRule.Pods))
+	// As rule identifier is calculated from the rule's content, the update can
+	// only happen to Group members.
+	var addedFrom, addedTo, deletedFrom, deletedTo []types.Address
+	if newRule.Direction == v1beta1.DirectionIn {
+		for a := range newRule.FromAddresses.Difference(lastRealized.FromAddresses) {
+			addedFrom = append(addedFrom, openflow.NewIPAddress(net.ParseIP(a)))
+		}
+		for a := range lastRealized.FromAddresses.Difference(newRule.FromAddresses) {
+			deletedFrom = append(deletedFrom, openflow.NewIPAddress(net.ParseIP(a)))
+		}
+		addedTo = r.podsToOFPortAddresses(newRule.Pods.Difference(lastRealized.Pods))
+		deletedTo = r.podsToOFPortAddresses(lastRealized.Pods.Difference(lastRealized.Pods))
+	} else {
+		addedFrom = r.podsToIPAddresses(newRule.Pods.Difference(lastRealized.Pods))
+		deletedFrom = r.podsToIPAddresses(lastRealized.Pods.Difference(newRule.Pods))
+		for a := range newRule.ToAddresses.Difference(lastRealized.ToAddresses) {
+			addedTo = append(addedTo, openflow.NewIPAddress(net.ParseIP(a)))
+		}
+		for a := range lastRealized.ToAddresses.Difference(newRule.ToAddresses) {
+			deletedTo = append(deletedTo, openflow.NewIPAddress(net.ParseIP(a)))
+		}
+	}
+
+	klog.V(2).Infof("Updating ofRule %d (%d addedFrom, %d addedTo, %d deleteFrom, %d deletedTo)",
+		lastRealized.ofID, len(addedFrom), len(addedTo), len(deletedFrom), len(deletedTo))
+
+	// TODO: This might be unnecessarily complex and hard for error handling, consider revising the Openflow interfaces.
+	if len(addedFrom) > 0 {
+		if err := r.ofClient.AddPolicyRuleAddress(lastRealized.ofID, types.SrcAddress, addedFrom); err != nil {
+			return fmt.Errorf("error adding policy rule source addresses for ofRule %v: %v", lastRealized.ofID, err)
+		}
+	}
+	if len(addedTo) > 0 {
+		if err := r.ofClient.AddPolicyRuleAddress(lastRealized.ofID, types.DstAddress, addedTo); err != nil {
+			return fmt.Errorf("error adding policy rule destination addresses for ofRule %v: %v", lastRealized.ofID, err)
+		}
+	}
+	if len(deletedFrom) > 0 {
+		if err := r.ofClient.DeletePolicyRuleAddress(lastRealized.ofID, types.SrcAddress, deletedFrom); err != nil {
+			return fmt.Errorf("error deleting policy rule source addresses for ofRule %v: %v", lastRealized.ofID, err)
+		}
+	}
+	if len(deletedTo) > 0 {
+		if err := r.ofClient.DeletePolicyRuleAddress(lastRealized.ofID, types.DstAddress, deletedTo); err != nil {
+			return fmt.Errorf("error deleting policy rule destination addresses for ofRule %v: %v", lastRealized.ofID, err)
+		}
+	}
+
+	lastRealized.CompletedRule = newRule
 	return nil
+}
+
+// Forget invokes UninstallPolicyRuleFlows to uninstall Openflow entries
+// associated with the provided ruleID if it was enforced before.
+func (r *reconciler) Forget(ruleID string) error {
+	klog.Infof("Forgetting rule %v", ruleID)
+
+	value, exists := r.lastRealizeds.Load(ruleID)
+
+	if !exists {
+		// No-op if the rule was not realized before.
+		return nil
+	}
+
+	lastRealized := value.(*lastRealized)
+	klog.V(3).Infof("Uninstalling ofRule %d", lastRealized.ofID)
+	if err := r.ofClient.UninstallPolicyRuleFlows(lastRealized.ofID); err != nil {
+		return fmt.Errorf("error uninstalling ofRule %v: %v", lastRealized.ofID, err)
+	}
+
+	if err := r.idAllocator.release(lastRealized.ofID); err != nil {
+		// This should never happen. If it does, it is a programming error.
+		klog.Errorf("Error releasing Openflow ID for ofRule %v: %v", lastRealized.ofID, err)
+	}
+
+	r.lastRealizeds.Delete(ruleID)
+	return nil
+}
+
+func (r *reconciler) podsToOFPortAddresses(pods podSet) []types.Address {
+	// If pods is nil, nil must be returned, can't be empty slice.
+	if pods == nil {
+		return nil
+	}
+	addresses := make([]types.Address, 0, len(pods))
+	for pod := range pods {
+		iface, found := r.ifaceStore.GetContainerInterface(pod.Name, pod.Namespace)
+		if !found {
+			// This might be because the container has been deleted during realization.
+			klog.Warningf("Can't find interface for Pod %s/%s, skipping", pod.Namespace, pod.Name)
+			continue
+		}
+		klog.V(2).Infof("Got OFPort %v for Pod %s/%s", iface.OFPort, pod.Namespace, pod.Name)
+		addresses = append(addresses, openflow.NewOFPortAddress(iface.OFPort))
+	}
+	return addresses
+}
+
+func (r *reconciler) podsToIPAddresses(pods podSet) []types.Address {
+	// If pods is nil, nil must be returned, can't be empty slice.
+	if pods == nil {
+		return nil
+	}
+	addresses := make([]types.Address, 0, len(pods))
+	for pod := range pods {
+		iface, found := r.ifaceStore.GetContainerInterface(pod.Name, pod.Namespace)
+		if !found {
+			// This might be because the container has been deleted during realization.
+			klog.Warningf("Can't find interface for Pod %s/%s, skipping", pod.Namespace, pod.Name)
+			continue
+		}
+		klog.V(2).Infof("Got IP %v for Pod %s/%s", iface.IP, pod.Namespace, pod.Name)
+		addresses = append(addresses, openflow.NewIPAddress(iface.IP))
+	}
+	return addresses
+}
+
+func antreaIPNetToIPNet(in v1beta1.IPNet) net.IPNet {
+	return net.IPNet{
+		IP:   net.IP(in.IP),
+		Mask: net.CIDRMask(int(in.PrefixLength), 32),
+	}
 }

--- a/pkg/agent/controller/networkpolicy/reconciler_test.go
+++ b/pkg/agent/controller/networkpolicy/reconciler_test.go
@@ -1,0 +1,166 @@
+// Copyright 2019 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package networkpolicy
+
+import (
+	"net"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/vmware-tanzu/antrea/pkg/agent"
+	"github.com/vmware-tanzu/antrea/pkg/agent/openflow"
+	openflowtest "github.com/vmware-tanzu/antrea/pkg/agent/openflow/testing"
+	"github.com/vmware-tanzu/antrea/pkg/agent/types"
+	"github.com/vmware-tanzu/antrea/pkg/agent/util"
+	"github.com/vmware-tanzu/antrea/pkg/apis/networkpolicy/v1beta1"
+)
+
+func TestReconcilerForget(t *testing.T) {
+	tests := []struct {
+		name             string
+		lastRealizeds    map[string]*lastRealized
+		args             string
+		expectedOFRuleID uint32
+		wantErr          bool
+	}{
+		{
+			"unknown-rule",
+			map[string]*lastRealized{"foo": {ofID: 8}},
+			"unknown-rule-id",
+			0,
+			false,
+		},
+		{
+			"known-rule",
+			map[string]*lastRealized{"foo": {ofID: 8}},
+			"foo",
+			uint32(8),
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			controller := gomock.NewController(t)
+			defer controller.Finish()
+			ifaceStore := agent.NewInterfaceStore()
+			mockOFClient := openflowtest.NewMockClient(controller)
+			if tt.expectedOFRuleID == 0 {
+				mockOFClient.EXPECT().UninstallPolicyRuleFlows(gomock.Any()).Times(0)
+			} else {
+				mockOFClient.EXPECT().UninstallPolicyRuleFlows(tt.expectedOFRuleID)
+			}
+			r := newReconciler(mockOFClient, ifaceStore)
+			for key, value := range tt.lastRealizeds {
+				r.lastRealizeds.Store(key, value)
+			}
+			if err := r.Forget(tt.args); (err != nil) != tt.wantErr {
+				t.Fatalf("Forget() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestReconcilerReconcile(t *testing.T) {
+	addressGroup1 := sets.NewString("1.1.1.1")
+	appliedToGroup1 := newPodSet(v1beta1.PodReference{"pod1", "ns1"})
+	appliedToGroup2 := newPodSet(v1beta1.PodReference{"pod2", "ns1"})
+	ifaceStore := agent.NewInterfaceStore()
+	ifaceStore.AddInterface(util.GenerateContainerInterfaceName("pod1", "ns1"),
+		&agent.InterfaceConfig{IP: net.ParseIP("2.2.2.2"), OVSPortConfig: &agent.OVSPortConfig{OFPort: 1}})
+	protocolTCP := v1beta1.ProtocolTCP
+	port80 := int32(80)
+	service1 := v1beta1.Service{Protocol: &protocolTCP, Port: &port80}
+	service2 := v1beta1.Service{Protocol: &protocolTCP}
+	tests := []struct {
+		name           string
+		args           *CompletedRule
+		expectedOFRule *types.PolicyRule
+		wantErr        bool
+	}{
+		{
+			"ingress-rule",
+			&CompletedRule{
+				rule:          &rule{ID: "ingress-rule", Direction: v1beta1.DirectionIn, Services: []v1beta1.Service{service1, service2}},
+				FromAddresses: addressGroup1,
+				ToAddresses:   nil,
+				Pods:          appliedToGroup1,
+			},
+			&types.PolicyRule{
+				ID:         1,
+				Direction:  networkingv1.PolicyTypeIngress,
+				From:       []types.Address{openflow.NewIPAddress(net.ParseIP("1.1.1.1"))},
+				ExceptFrom: nil,
+				To:         []types.Address{openflow.NewOFPortAddress(1)},
+				ExceptTo:   nil,
+				Service:    servicesToNetworkPolicyPort([]v1beta1.Service{service1, service2}),
+			},
+			false,
+		},
+		{
+			"ingress-rule-with-missing-ofport",
+			&CompletedRule{
+				rule:          &rule{ID: "ingress-rule", Direction: v1beta1.DirectionIn},
+				FromAddresses: addressGroup1,
+				ToAddresses:   nil,
+				Pods:          appliedToGroup2,
+			},
+			&types.PolicyRule{
+				ID:         1,
+				Direction:  networkingv1.PolicyTypeIngress,
+				From:       []types.Address{openflow.NewIPAddress(net.ParseIP("1.1.1.1"))},
+				ExceptFrom: nil,
+				To:         []types.Address{},
+				ExceptTo:   nil,
+				Service:    nil,
+			},
+			false,
+		},
+		{
+			"egress-rule",
+			&CompletedRule{
+				rule:          &rule{ID: "egress-rule", Direction: v1beta1.DirectionOut},
+				FromAddresses: nil,
+				ToAddresses:   addressGroup1,
+				Pods:          appliedToGroup1,
+			},
+			&types.PolicyRule{
+				ID:         1,
+				Direction:  networkingv1.PolicyTypeEgress,
+				From:       []types.Address{openflow.NewIPAddress(net.ParseIP("2.2.2.2"))},
+				ExceptFrom: nil,
+				To:         []types.Address{openflow.NewIPAddress(net.ParseIP("1.1.1.1"))},
+				ExceptTo:   nil,
+				Service:    nil,
+			},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			controller := gomock.NewController(t)
+			defer controller.Finish()
+			ifaceStore := agent.NewInterfaceStore()
+			mockOFClient := openflowtest.NewMockClient(controller)
+			mockOFClient.EXPECT().InstallPolicyRuleFlows(gomock.Eq(tt.expectedOFRule))
+			r := newReconciler(mockOFClient, ifaceStore)
+			if err := r.Reconcile(tt.args); (err != nil) != tt.wantErr {
+				t.Fatalf("Forget() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This patch implements the rule reconciler that caches the last realized state of each rule and invokes corresponding Openflow interfaces to reconcile the desired rule.

Besides, to generate uint32 Openflow ID, it implements an ID allocator.