### PR TITLE
Mount /sbin/depmod to initContainer for fixing modprobe error

### DIFF
--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -353,6 +353,11 @@ spec:
           # For loading the OVS kernel module.
           - name: host-lib-modules
             mountPath: /lib/modules
+          # depmod is required by modprobe when the Node OS is different from
+          # that of the Antrea Docker image.
+          - name: host-depmod
+            mountPath: /sbin/depmod
+            readOnly: true
       containers:
         - name: antrea-agent
           image: antrea-ubuntu
@@ -471,3 +476,6 @@ spec:
         - name: host-lib-modules
           hostPath:
             path: /lib/modules
+        - name: host-depmod
+          hostPath:
+            path: /sbin/depmod


### PR DESCRIPTION
When the Node OS is different from that of the Antrea Docker image -
e.g. Node is RHEL or CentOS while the Antrea image is Ubuntu - depmod
from the host filesystem should be used, otherwise modprobe will fail.

Fixes #51 