### PR TITLE
Fix "make fmt" on Mac OS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ GO              ?= go
 LDFLAGS         :=
 GOFLAGS         :=
 BINDIR          := $(CURDIR)/bin
-GO_FILES        := $(shell find . -name '*.go')
+GO_FILES        := $(shell find . -type d -name '.cache' -prune -o -type f -name '*.go' -print)
 GOPATH          ?= $$(go env GOPATH)
 DOCKER_CACHE    := $(CURDIR)/.cache
 


### PR DESCRIPTION
When developing on Mac OS, one can use "make docker-test-unit" to build
Antrea and run unit tests inside a Docker container. This creates a
.cache directory which caches all the Go dependencies. Because of the
large number of Go source files under .cache, GO_FILES include too many
files and the gofmt invocation fails because the shell argument list is
too long.

Fixes #64