### PR TITLE
Remove references to Antrea Slack channels

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,8 +16,7 @@ Before getting started, go through the following:
 
 At minimum, you need the following accounts for effective participation:
 1. **Github** : Committing any change requires you to have a [github account](https://github.com/join).
-2. **Slack**: Please join the [#antrea-dev](https://projectantrea.slack.com/messages/antrea-dev) channel to participate in discussions.
-3. **Google**: Join our [mailing list](https://groups.google.com/forum/#!forum/projectantrea-dev).
+2. **Google Group**: Join our [mailing list](https://groups.google.com/forum/#!forum/projectantrea-dev).
 
 ## Contribute
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -21,7 +21,7 @@ The Antrea community abides by this [code of conduct](CODE_OF_CONDUCT.md).
 ## Community Roles
 
 * **Users:** Members that engage with the Antrea community via any medium
-  (Slack, GitHub, mailing lists, etc.).
+  (GitHub, mailing lists, etc.).
 * **Contributors:** Do regular contributions to the Antrea project
   (documentation, code reviews, responding to issues, participating in proposal
   discussions, contributing code, etc.).

--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ for information.
 ### Contribute
 
 The Antrea community welcomes new contributors. Please join our
-[#antrea-dev](https://projectantrea.slack.com/messages/antrea-dev) Slack channel and
 [projectantrea-dev](https://groups.google.com/forum/#!forum/projectantrea-dev) mailing list to stay
 updated, get help to get started, start conversations and propose new ideas. We are waiting for your
 PRs!
@@ -105,9 +104,7 @@ Also check the [Architecture document](/docs/architecture.md) for the Antrea arc
 * **Twitter**: [@ProjectAntrea](https://twitter.com/ProjectAntrea)
 * **Announcements mailing list**: Join the [projectantrea-announce](https://groups.google.com/forum/#!forum/projectantrea-announce)
   mailing list for important announcements about Antrea (e.g. new releases).
-* **User groups**: Join the [#antrea-users](https://projectantrea.slack.com/messages/antrea-users)
-  Slack channel or the [projectantrea](https://groups.google.com/forum/#!forum/projectantrea)
+* **User groups**: Join the [projectantrea](https://groups.google.com/forum/#!forum/projectantrea)
   mailing list to get updates about Antrea or provide feedback.
-* **Developer groups**: Join the [#antrea-dev](https://projectantrea.slack.com/messages/antrea-dev)
-  Slack channel or the [projectantrea-dev](https://groups.google.com/forum/#!forum/projectantrea-dev)
+* **Developer groups**: Join the [projectantrea-dev](https://groups.google.com/forum/#!forum/projectantrea-dev)
   mailing list to participate in discussions on Antrea development.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,7 +10,7 @@ evolve. This document lists some features as the potential features of future
 Antrea releases, but the list is not finalized. A feature that is not listed now
 does not  mean it will not be considered for Antrea. We definitely welcome
 suggestions and ideas from everyone about the roadmap and Antrea features. Reach
-us through Issues, Slack, and Google Group!
+us through Issues and / or Google Group!
 
 # Features under Development
 The following features are being actively developed and will be available soon:


### PR DESCRIPTION
Until the choice of which Slack workspace to use is final.