### PR TITLE
Fix antrea client connection failure

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -50,6 +50,9 @@ func run(o *Options) error {
 
 	// Create Antrea Clientset for the given config.
 	antreaClient, err := agent.CreateAntreaClient(o.config.AntreaClientConnection)
+	if err != nil {
+		return fmt.Errorf("error creating Antrea client: %v", err)
+	}
 
 	// Create ovsdb and openflow clients.
 	ovsdbConnection, err := ovsconfig.NewOVSDBConnectionUDS("")


### PR DESCRIPTION
* CreateAntreaClient should use its own inClusterConfig
* Antrea Controller generates self-signed certificate with loopback
  address, Agent can not verify server cert for now
* Error of CreateAntreaClient should be checked

Related to: #52 