### PR TITLE
Fix broken "go mod" because of missing Octant source code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,9 @@ require (
 	k8s.io/utils v0.0.0-20190607212802-c55fbcfc754a // indirect
 )
 
-// Octant is renamed from vmware/octant to vmware-tanzu/octant since v0.9.0
-// However Octant v0.9.0 K8s API is not compatible with Antrea K8s API version
-// Will remove this and upgrade Octant version after finding another compatible Octant release
-replace github.com/vmware/octant => github.com/vmware-tanzu/octant v0.8.0
+// Octant is renamed from vmware/octant to vmware-tanzu/octant since v0.9.0.
+// However, Octant v0.9.0 K8s API is not compatible with Antrea K8s API version.
+// Furthermore, octant v0.8 and v0.9 do not check-in some generated code required for testing
+// (mocks), which breaks "go mod". This has been fixed in master.
+// Will remove this and upgrade Octant version after finding another compatible Octant release.
+replace github.com/vmware/octant => github.com/antoninbas/octant v0.8.1-0.20191116223915-811df1acc59f

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/akavel/rsrc v0.8.0/go.mod h1:uLoCtb9J+EyAqh+26kdrTgmzRBFPGOolLWKpdxkK
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae/go.mod h1:CgnQgUtFrFz9mxFNtED3jI5tLDjKlOM+oUF/sTk6ps0=
+github.com/antoninbas/octant v0.8.1-0.20191116223915-811df1acc59f h1:9AHwwr1Y0Bvu6raE33gvYM0OZJ+akIuT0sWs2fMkGQo=
+github.com/antoninbas/octant v0.8.1-0.20191116223915-811df1acc59f/go.mod h1:gSpch7YnaA2PGkea7j/dvS6nYoehF9jXfA0ldJJb/5w=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
@@ -324,8 +326,6 @@ github.com/vishvananda/netlink v1.0.0 h1:bqNY2lgheFIu1meHUFSH3d7vG93AFyqg3oGbJCO
 github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
 github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc h1:R83G5ikgLMxrBvLh22JhdfI8K6YXEPHx5P03Uu3DRs4=
 github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
-github.com/vmware-tanzu/octant v0.8.0 h1:bCAO3eZLQ4/MdHPWP+//iCcXkIcB/uWsc0Gq5ZQyO64=
-github.com/vmware-tanzu/octant v0.8.0/go.mod h1:gSpch7YnaA2PGkea7j/dvS6nYoehF9jXfA0ldJJb/5w=
 github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18 h1:MPPkRncZLN9Kh4MEFmbnK4h3BD7AUmskWv2+EeZJCCs=
 github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=


### PR DESCRIPTION
"go mod" was unstable with go 1.12 and broken with go 1.13 because of
some missing test source files in the Octant repository. "go mod tidy"
records test dependencies which means that even generated source files
(e.g. mocks) which are only used for testing have to be checked-in.

This has been patched in the Octant master branch but because we are
using an older version of Octant (v0.8), we are using an Octant fork at
the moment, which includes a back-port of the change to v0.8.

Fixes #81