### PR TITLE
Add manifest check to Github CI workflows

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,5 @@
 name: Go
-on: 
+on:
   pull_request:
     branches:
     - master
@@ -15,8 +15,7 @@ jobs:
       uses: actions/setup-go@v1
       with:
         go-version: 1.12
-      id: go
-      
+
     - name: Check-out code
       uses: actions/checkout@v1
 
@@ -33,8 +32,7 @@ jobs:
       uses: actions/setup-go@v1
       with:
         go-version: 1.12
-      id: go
-      
+
     - name: Check-out code
       uses: actions/checkout@v1
 
@@ -51,8 +49,7 @@ jobs:
       uses: actions/setup-go@v1
       with:
         go-version: 1.12
-      id: go
-      
+
     - name: Check-out code
       uses: actions/checkout@v1
 
@@ -69,11 +66,26 @@ jobs:
       uses: actions/setup-go@v1
       with:
         go-version: 1.12
-      id: go
-      
+
     - name: Check-out code
       uses: actions/checkout@v1
 
     - name: Check mock generation
-      run: find . -name '*_mock.go' -delete && make mocks && test -z "$(git status --porcelain pkg)"
+      run: ./ci/check-mocks.sh
 
+
+  manifest:
+    name: Check manifest
+    runs-on: [ubuntu-18.04]
+    steps:
+
+    - name: Set up Go 1.12
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.12
+
+    - name: Check-out code
+      uses: actions/checkout@v1
+
+    - name: Check manifest
+      run: ./ci/check-manifest.sh

--- a/ci/check-manifest.sh
+++ b/ci/check-manifest.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 Antrea Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script makes sure that the checked-in manifest YAML is up-to-date.
+
+set -eo pipefail
+
+function echoerr {
+    >&2 echo "$@"
+}
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+pushd $THIS_DIR/.. > /dev/null
+
+rm build/yamls/antrea.yml
+make manifest
+diff="$(git status --porcelain build/yamls/antrea.yml)"
+
+if [ ! -z "$diff" ]; then
+    echoerr "The generated manifest YAML is not up-to-date"
+    echoerr "You can regenerate them with 'make manifest' and commit the changes"
+    exit 1
+fi

--- a/ci/check-mocks.sh
+++ b/ci/check-mocks.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 Antrea Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script makes sure that the checked-in mock files are up-to-date.
+
+set -eo pipefail
+
+function echoerr {
+    >&2 echo "$@"
+}
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+pushd $THIS_DIR/.. > /dev/null
+
+find . -name '*_mock.go' -delete
+make mocks
+diff="$(git status --porcelain pkg)"
+
+if [ ! -z "$diff" ]; then
+    echoerr "The generated mock files are not up-to-date"
+    echoerr "You can regenerate them with 'make mocks' and commit the changes"
+    exit 1
+fi

--- a/hack/verify-kustomize.sh
+++ b/hack/verify-kustomize.sh
@@ -34,6 +34,7 @@ verify_kustomize() {
         >&2 echo "Installing kustomize"
         local kustomize_url="https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/${_MIN_KUSTOMIZE_VERSION}/kustomize_${_MIN_KUSTOMIZE_VERSION}_${ostype}_amd64.tar.gz"
         curl -sLo kustomize.tar.gz "${kustomize_url}" || return 1
+        mkdir -p "$_GOPATH_BIN" || return 1
         tar -xzf kustomize.tar.gz -C "$_GOPATH_BIN" || return 1
         rm -f kustomize.tar.gz
         kustomize="$_GOPATH_BIN/kustomize"


### PR DESCRIPTION
We add scripts to check mocks & the YAML manifest to a ci/ directory to
avoid having too much logic in the CI YAML file.

Step ids in go.yml are removed as they are not used for anything.