### PR TITLE
E2E test for alpha features on Antrea Agent

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -54,8 +54,8 @@ jobs:
       run: |
         ./ci/kind/test-e2e-kind.sh --encap-mode encap
 
-  test-e2e-encap-proxy:
-    name: E2e tests on a Kind cluster on Linux with proxy enabled
+  test-e2e-encap-all-alpha-agent:
+    name: E2e tests on a Kind cluster on Linux with all alpha features enabled on agent
     needs: build-antrea-image
     runs-on: [ubuntu-18.04]
     steps:
@@ -83,7 +83,7 @@ jobs:
         sudo mv kind /usr/local/bin
     - name: Run e2e tests
       run: |
-        ./ci/kind/test-e2e-kind.sh --encap-mode encap --proxy
+        ./ci/kind/test-e2e-kind.sh --encap-mode encap --all-alpha-agent
 
   test-e2e-noencap:
     name: E2e tests on a Kind cluster on Linux (noEncap)
@@ -116,8 +116,8 @@ jobs:
       run: |
         ./ci/kind/test-e2e-kind.sh --encap-mode noEncap
 
-  test-e2e-noencap-proxy:
-    name: E2e tests on a Kind cluster on Linux (noEncap) with proxy enabled
+  test-e2e-noencap-all-alpha-agent:
+    name: E2e tests on a Kind cluster on Linux (noEncap) with all alpha features enabled on agent
     needs: build-antrea-image
     runs-on: [ubuntu-18.04]
     steps:
@@ -145,7 +145,7 @@ jobs:
         sudo mv kind /usr/local/bin
     - name: Run e2e tests
       run: |
-        ./ci/kind/test-e2e-kind.sh --encap-mode noEncap --proxy
+        ./ci/kind/test-e2e-kind.sh --encap-mode noEncap --all-alpha-agent
 
   test-e2e-hybrid:
     name: E2e tests on a Kind cluster on Linux (hybrid)
@@ -178,8 +178,8 @@ jobs:
       run: |
         ./ci/kind/test-e2e-kind.sh --encap-mode hybrid
 
-  test-e2e-hybrid-proxy:
-    name: E2e tests on a Kind cluster on Linux (hybrid) with proxy enabled
+  test-e2e-hybrid-all-alpha-agent:
+    name: E2e tests on a Kind cluster on Linux (hybrid) with all alpha features enabled on agent
     needs: build-antrea-image
     runs-on: [ubuntu-18.04]
     steps:
@@ -207,7 +207,7 @@ jobs:
         sudo mv kind /usr/local/bin
     - name: Run e2e tests
       run: |
-        ./ci/kind/test-e2e-kind.sh --encap-mode hybrid --proxy
+        ./ci/kind/test-e2e-kind.sh --encap-mode hybrid --all-alpha-agent
 
   test-e2e-encap-np:
     name: E2e tests on a Kind cluster on Linux with Antrea NetworkPolicies enabled

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -519,6 +519,9 @@ data:
   antrea-agent.conf: |
     # FeatureGates is a map of feature names to bools that enable or disable experimental features.
     featureGates:
+    # Enable all alpha features in feature gate map.
+    # See https://github.com/vmware-tanzu/antrea/blob/master/docs/feature-gates.md for list of alpha features.
+    #  AllAlpha: false
     # Enable antrea proxy which provides ServiceLB for in-cluster services in antrea agent.
     # It should be enabled on Windows, otherwise NetworkPolicy will not take effect on
     # Service traffic.
@@ -627,7 +630,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-hhthk4g2f4
+  name: antrea-config-fb8727m2hc
   namespace: kube-system
 ---
 apiVersion: v1
@@ -733,7 +736,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-hhthk4g2f4
+          name: antrea-config-fb8727m2hc
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -950,7 +953,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-hhthk4g2f4
+          name: antrea-config-fb8727m2hc
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -519,6 +519,9 @@ data:
   antrea-agent.conf: |
     # FeatureGates is a map of feature names to bools that enable or disable experimental features.
     featureGates:
+    # Enable all alpha features in feature gate map.
+    # See https://github.com/vmware-tanzu/antrea/blob/master/docs/feature-gates.md for list of alpha features.
+    #  AllAlpha: false
     # Enable antrea proxy which provides ServiceLB for in-cluster services in antrea agent.
     # It should be enabled on Windows, otherwise NetworkPolicy will not take effect on
     # Service traffic.
@@ -627,7 +630,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-mbkmc9bb22
+  name: antrea-config-94mmbf9gtt
   namespace: kube-system
 ---
 apiVersion: v1
@@ -733,7 +736,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-mbkmc9bb22
+          name: antrea-config-94mmbf9gtt
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -948,7 +951,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-mbkmc9bb22
+          name: antrea-config-94mmbf9gtt
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -519,6 +519,9 @@ data:
   antrea-agent.conf: |
     # FeatureGates is a map of feature names to bools that enable or disable experimental features.
     featureGates:
+    # Enable all alpha features in feature gate map.
+    # See https://github.com/vmware-tanzu/antrea/blob/master/docs/feature-gates.md for list of alpha features.
+    #  AllAlpha: false
     # Enable antrea proxy which provides ServiceLB for in-cluster services in antrea agent.
     # It should be enabled on Windows, otherwise NetworkPolicy will not take effect on
     # Service traffic.
@@ -627,7 +630,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-5tkdbb96c6
+  name: antrea-config-tdg6654bt4
   namespace: kube-system
 ---
 apiVersion: v1
@@ -742,7 +745,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-5tkdbb96c6
+          name: antrea-config-tdg6654bt4
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -992,7 +995,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-5tkdbb96c6
+          name: antrea-config-tdg6654bt4
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -519,6 +519,9 @@ data:
   antrea-agent.conf: |
     # FeatureGates is a map of feature names to bools that enable or disable experimental features.
     featureGates:
+    # Enable all alpha features in feature gate map.
+    # See https://github.com/vmware-tanzu/antrea/blob/master/docs/feature-gates.md for list of alpha features.
+    #  AllAlpha: false
     # Enable antrea proxy which provides ServiceLB for in-cluster services in antrea agent.
     # It should be enabled on Windows, otherwise NetworkPolicy will not take effect on
     # Service traffic.
@@ -627,7 +630,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-hc2t9429cd
+  name: antrea-config-2b4m4km84d
   namespace: kube-system
 ---
 apiVersion: v1
@@ -733,7 +736,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-hc2t9429cd
+          name: antrea-config-2b4m4km84d
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -948,7 +951,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-hc2t9429cd
+          name: antrea-config-2b4m4km84d
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/base/conf/antrea-agent.conf
+++ b/build/yamls/base/conf/antrea-agent.conf
@@ -1,5 +1,8 @@
 # FeatureGates is a map of feature names to bools that enable or disable experimental features.
 featureGates:
+# Enable all alpha features in feature gate map.
+# See https://github.com/vmware-tanzu/antrea/blob/master/docs/feature-gates.md for list of alpha features.
+#  AllAlpha: false
 # Enable antrea proxy which provides ServiceLB for in-cluster services in antrea agent.
 # It should be enabled on Windows, otherwise NetworkPolicy will not take effect on
 # Service traffic.

--- a/ci/kind/test-e2e-kind.sh
+++ b/ci/kind/test-e2e-kind.sh
@@ -22,9 +22,9 @@ function echoerr {
     >&2 echo "$@"
 }
 
-_usage="Usage: $0 [--encap-mode <mode>] [--proxy] [--np] [--help|-h]
+_usage="Usage: $0 [--encap-mode <mode>] [--all-alpha-agent] [--np] [--help|-h]
         --encap-mode                  Traffic encapsulation mode. (default is 'encap')
-        --proxy                       Enables Antrea proxy.
+	--all-alpha-agent             Enables all alpha features on Antrea Agent in feature gate map.
         --np                          Enables Namespaced Antrea NetworkPolicy CRDs and ClusterNetworkPolicy related CRDs.
         --help, -h                    Print this message and exit
 "
@@ -47,21 +47,21 @@ function quit {
 trap "quit" INT EXIT
 
 mode=""
-proxy=false
+alpha_agent=false
 np=false
 while [[ $# -gt 0 ]]
 do
 key="$1"
 
 case $key in
-    --proxy)
-    proxy=true
-    shift
-    ;;
     --np)
     np=true
     shift
     ;;
+    --all-alpha-agent)
+    alpha_agent=true
+    shift
+    ;;    
     --encap-mode)
     mode="$2"
     shift 2
@@ -78,12 +78,12 @@ esac
 done
 
 manifest_args=""
-if $proxy; then
-    manifest_args="$manifest_args --proxy"
-fi
 if $np; then
     # See https://github.com/vmware-tanzu/antrea/issues/897
     manifest_args="$manifest_args --np --tun vxlan"
+fi
+if $alpha_agent; then
+    manifest_args="$manifest_args --all-alpha-agent"
 fi
 
 function run_test {

--- a/hack/generate-manifest.sh
+++ b/hack/generate-manifest.sh
@@ -27,7 +27,7 @@ Generate a YAML manifest for Antrea using Kustomize and print it to stdout.
         --kind                        Generate a manifest appropriate for running Antrea in a Kind cluster
         --cloud                       Generate a manifest appropriate for running Antrea in Public Cloud
         --ipsec                       Generate a manifest with IPSec encryption of tunnel traffic enabled
-        --proxy                       Generate a manifest with Antrea proxy enabled
+        --all-alpha-agent             Generate a manifest with all alpha features enabled on Antrea Agent
         --np                          Generate a manifest with Namespaced Antrea NetworkPolicy CRDs and ClusterNetworkPolicy related CRDs enabled
         --keep                        Debug flag which will preserve the generated kustomization.yml
         --tun (geneve|vxlan|gre|stt)  Choose encap tunnel type from geneve, gre, stt and vxlan (default is geneve)
@@ -51,7 +51,7 @@ function print_help {
 MODE="dev"
 KIND=false
 IPSEC=false
-PROXY=false
+ALPHA_AGENT=false
 NP=false
 KEEP=false
 ENCAP_MODE=""
@@ -83,8 +83,8 @@ case $key in
     IPSEC=true
     shift
     ;;
-    --proxy)
-    PROXY=true
+    --all-alpha-agent)
+    ALPHA_AGENT=true
     shift
     ;;
     --np)
@@ -170,8 +170,8 @@ if $IPSEC; then
     sed -i.bak -E "s/^[[:space:]]*#[[:space:]]*tunnelType[[:space:]]*:[[:space:]]*[a-z]+[[:space:]]*$/tunnelType: gre/" antrea-agent.conf
 fi
 
-if $PROXY; then
-    sed -i.bak -E "s/^[[:space:]]*#[[:space:]]*AntreaProxy[[:space:]]*:[[:space:]]*[a-z]+[[:space:]]*$/  AntreaProxy: true/" antrea-agent.conf
+if $ALPHA_AGENT; then
+    sed -i.bak -E "s/^[[:space:]]*#[[:space:]]*AllAlpha[[:space:]]*:[[:space:]]*[a-z]+[[:space:]]*$/  AllAlpha: true/" antrea-agent.conf
 fi
 
 if $NP; then

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -132,7 +132,14 @@ also need to copy the Antrea manifest to the master Docker container:
 ./hack/generate-manifest.sh --kind | docker exec -i kind-control-plane dd of=/root/antrea.yml
 go test -v github.com/vmware-tanzu/antrea/test/e2e -provider=kind
 ```
+### Running e2e tests specific to an alpha feature on Agent
+[Alpha feature list](/docs/feature-gates.md) provides the details of the features supported in Antrea.
+If you would like run a feature specific e2e test, you may use following commands:
 
+```bash
+./hack/generate-manifest.sh --kind --all-alpha-agent | docker exec -i kind-control-plane dd of=/root/antrea.yml
+go test -v github.com/vmware-tanzu/antrea/test/e2e -provider=kind -run <Alpha feature specific test name e.g., TestProxyEndpointLifeCycle>
+```
 ## Running the performance test
 To run all benchmarks, without the standard e2e tests:
 ```bash


### PR DESCRIPTION
Instead of running whole suite for every alpha feature, it was discussed
in Issue #893 to run the suite by enabling all alpha features. This PR handles alpha
features on Antrea Agent.
As there is ongoing geneve tunnel issue, Issue #897 with ClusterNetworkPolicy
alpha feature on the controller, I did not club alpha features on agent and
controller. Similarly, the e2e tests of Traceflow feature could be modified,
when both agent and controller alpha features are clubbed together.

This PR is useful to turn on e2e tests for flow exporter feature PR #825.
Modified e2e documentation to run specific tests corresponding to alpha feature locally.

