### PR TITLE
[WIP][Windows] Process OVS conntrack unsupported packets

### DIFF
--- a/pkg/agent/agent_windows.go
+++ b/pkg/agent/agent_windows.go
@@ -192,6 +192,10 @@ func (i *Initializer) initHostNetworkFlows() error {
 	if err := i.ofClient.InstallBridgeUplinkFlows(config.UplinkOFPort, config.BridgeOFPort); err != nil {
 		return err
 	}
+
+	if err := i.ofClient.HandleUnsupportedPacketFlows(config.UplinkOFPort, config.BridgeOFPort); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/agent/cniserver/server.go
+++ b/pkg/agent/cniserver/server.go
@@ -358,12 +358,12 @@ func (s *CNIServer) CmdAdd(ctx context.Context, request *cnipb.CniCmdRequest) (*
 		// Rollback to delete configurations once ADD is failure.
 		if !success {
 			if isInfraContainer {
-				klog.Warningf("CmdAdd has failed, and try to rollback")
+				klog.Warningf("CmdAdd has failed with containerID %s, and try to rollback", cniConfig.ContainerId)
 				if _, err := s.CmdDel(ctx, request); err != nil {
 					klog.Warningf("Failed to rollback after CNI add failure: %v", err)
 				}
 			} else {
-				klog.Warningf("CmdAdd has failed")
+				klog.Warningf("CmdAdd has failed with containerID: %s", cniConfig.ContainerId)
 			}
 		}
 	}()
@@ -425,7 +425,7 @@ func (s *CNIServer) CmdAdd(ctx context.Context, request *cnipb.CniCmdRequest) (*
 
 	var resultBytes bytes.Buffer
 	_ = result.PrintTo(&resultBytes)
-	klog.Infof("CmdAdd succeeded")
+	klog.Infof("CmdAdd succeeded with containerID %s", cniConfig.ContainerId)
 	// mark success as true to avoid rollback
 	success = true
 	return &cnipb.CniCmdResponse{CniResult: resultBytes.Bytes()}, nil

--- a/pkg/agent/openflow/testing/mock_openflow.go
+++ b/pkg/agent/openflow/testing/mock_openflow.go
@@ -194,6 +194,20 @@ func (mr *MockClientMockRecorder) GetTunnelVirtualMAC() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTunnelVirtualMAC", reflect.TypeOf((*MockClient)(nil).GetTunnelVirtualMAC))
 }
 
+// HandleUnsupportedPacketFlows mocks base method
+func (m *MockClient) HandleUnsupportedPacketFlows(arg0, arg1 uint32) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HandleUnsupportedPacketFlows", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// HandleUnsupportedPacketFlows indicates an expected call of HandleUnsupportedPacketFlows
+func (mr *MockClientMockRecorder) HandleUnsupportedPacketFlows(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleUnsupportedPacketFlows", reflect.TypeOf((*MockClient)(nil).HandleUnsupportedPacketFlows), arg0, arg1)
+}
+
 // InitialTLVMap mocks base method
 func (m *MockClient) InitialTLVMap() error {
 	m.ctrl.T.Helper()

--- a/pkg/agent/proxy/proxier.go
+++ b/pkg/agent/proxy/proxier.go
@@ -173,16 +173,19 @@ func (p *proxier) installServices() {
 			klog.Errorf("Error when installing Endpoints flows: %v", err)
 			continue
 		}
+		klog.Infof("Installed flows for Endpoints %v in Service %s", endpointUpdateList, svcPortName)
 		err := p.ofClient.InstallServiceGroup(groupID, svcInfo.StickyMaxAgeSeconds() != 0, endpointUpdateList)
 		if err != nil {
 			klog.Errorf("Error when installing Endpoints groups: %v", err)
 			p.endpointInstalledMap[svcPortName] = nil
 			continue
 		}
+		klog.Infof("Installed groups with ID %d for Service %s", groupID, svcPortName)
 		if err := p.ofClient.InstallServiceFlows(groupID, svcInfo.ClusterIP(), uint16(svcInfo.Port()), svcInfo.OFProtocol, uint16(svcInfo.StickyMaxAgeSeconds())); err != nil {
 			klog.Errorf("Error when installing Service flows: %v", err)
 			continue
 		}
+		klog.Infof("Installed flows for Service %s", svcPortName)
 		// Install OpenFlow entries for the ingress IPs of LoadBalancer Service.
 		// The LoadBalancer Service should can be accessed from Pod, Node and
 		// external host.

--- a/pkg/ovs/openflow/interfaces.go
+++ b/pkg/ovs/openflow/interfaces.go
@@ -41,6 +41,7 @@ const (
 	ProtocolUDP  Protocol = "udp"
 	ProtocolSCTP Protocol = "sctp"
 	ProtocolICMP Protocol = "icmp"
+	ProtocolIGMP Protocol = "igmp"
 )
 
 const (

--- a/pkg/ovs/openflow/ofctrl_builder.go
+++ b/pkg/ovs/openflow/ofctrl_builder.go
@@ -315,6 +315,9 @@ func (b *ofFlowBuilder) MatchProtocol(protocol Protocol) FlowBuilder {
 	case ProtocolICMP:
 		b.Match.Ethertype = 0x0800
 		b.Match.IpProto = 1
+	case ProtocolIGMP:
+		b.Match.Ethertype = 0x0800
+		b.Match.IpProto = 2
 	}
 	b.protocol = protocol
 	return b

--- a/plugins/octant/cmd/antrea-octant-plugin/traceflow.go
+++ b/plugins/octant/cmd/antrea-octant-plugin/traceflow.go
@@ -324,7 +324,7 @@ func (p *antreaOctantPlugin) traceflowHandler(request service.Request) (componen
 	// Construct the available values of protocols.
 	protocolSelect := make([]component.InputChoice, len(opsv1alpha1.SupportedProtocols))
 	i := 0
-	for p, _ := range opsv1alpha1.SupportedProtocols {
+	for p := range opsv1alpha1.SupportedProtocols {
 		protocolSelect[i] = component.InputChoice{
 			Label:   p,
 			Value:   p,


### PR DESCRIPTION
IGMP is unsupported in OVS ct on Windows, so forward these packets directly
before entering conntrack.

If such packet enters OVS ct, some warning logs should be printed:
```
dpif(handler7)|WARN|system@ovs-system: execute ct(zone=65520,nat),recirc(0x2) failed (not supported) on packet igmp,vlan_tci=0
x0000,dl_src=00:15:5d:1a:d4:02,dl_dst=01:00:5e:00:00:16,nw_src=192.168.227.1,nw_dst=224.0.0.22,nw_tos=0,nw_ecn=0,nw_ttl=1,igmp_type=34,igmp_code=0
 with metadata skb_priority(0),skb_mark(0),in_port(4) mtu 0
```
Fixes #1157 