### PR TITLE
Adds Certificate rotate duration parameter to Antrea controller

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -986,12 +986,18 @@ data:
     # And the Secret must be mounted to directory "/var/run/antrea/antrea-controller-tls" of the
     # antrea-controller container.
     #selfSignedCert: true
+
+    # Indicates how long an auto-generated certificate is used until its rotated.
+    # Ignored if SelfSignedCert is false. If the certificate expiry period is less than
+    # this value, it is ignored.
+    # Defaults to the number of hours in a year.
+    #certRotateDuration: 8760h
 kind: ConfigMap
 metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-g6mm797kch
+  name: antrea-config-4dcbfd756f
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1097,7 +1103,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-g6mm797kch
+          name: antrea-config-4dcbfd756f
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1312,7 +1318,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-g6mm797kch
+          name: antrea-config-4dcbfd756f
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -986,12 +986,18 @@ data:
     # And the Secret must be mounted to directory "/var/run/antrea/antrea-controller-tls" of the
     # antrea-controller container.
     #selfSignedCert: true
+
+    # Indicates how long an auto-generated certificate is used until its rotated.
+    # Ignored if SelfSignedCert is false. If the certificate expiry period is less than
+    # this value, it is ignored.
+    # Defaults to the number of hours in a year.
+    #certRotateDuration: 8760h
 kind: ConfigMap
 metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-g6mm797kch
+  name: antrea-config-4dcbfd756f
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1097,7 +1103,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-g6mm797kch
+          name: antrea-config-4dcbfd756f
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1314,7 +1320,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-g6mm797kch
+          name: antrea-config-4dcbfd756f
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -986,12 +986,18 @@ data:
     # And the Secret must be mounted to directory "/var/run/antrea/antrea-controller-tls" of the
     # antrea-controller container.
     #selfSignedCert: true
+
+    # Indicates how long an auto-generated certificate is used until its rotated.
+    # Ignored if SelfSignedCert is false. If the certificate expiry period is less than
+    # this value, it is ignored.
+    # Defaults to the number of hours in a year.
+    #certRotateDuration: 8760h
 kind: ConfigMap
 metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-f72hcg8m78
+  name: antrea-config-6fmt4g4284
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1097,7 +1103,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-f72hcg8m78
+          name: antrea-config-6fmt4g4284
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1312,7 +1318,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-f72hcg8m78
+          name: antrea-config-6fmt4g4284
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -991,12 +991,18 @@ data:
     # And the Secret must be mounted to directory "/var/run/antrea/antrea-controller-tls" of the
     # antrea-controller container.
     #selfSignedCert: true
+
+    # Indicates how long an auto-generated certificate is used until its rotated.
+    # Ignored if SelfSignedCert is false. If the certificate expiry period is less than
+    # this value, it is ignored.
+    # Defaults to the number of hours in a year.
+    #certRotateDuration: 8760h
 kind: ConfigMap
 metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-d429bkg4d6
+  name: antrea-config-9622929bk5
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1111,7 +1117,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-d429bkg4d6
+          name: antrea-config-9622929bk5
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1361,7 +1367,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-d429bkg4d6
+          name: antrea-config-9622929bk5
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -991,12 +991,18 @@ data:
     # And the Secret must be mounted to directory "/var/run/antrea/antrea-controller-tls" of the
     # antrea-controller container.
     #selfSignedCert: true
+
+    # Indicates how long an auto-generated certificate is used until its rotated.
+    # Ignored if SelfSignedCert is false. If the certificate expiry period is less than
+    # this value, it is ignored.
+    # Defaults to the number of hours in a year.
+    #certRotateDuration: 8760h
 kind: ConfigMap
 metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-64fmb8kc28
+  name: antrea-config-h49m6d2k97
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1102,7 +1108,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-64fmb8kc28
+          name: antrea-config-h49m6d2k97
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1317,7 +1323,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-64fmb8kc28
+          name: antrea-config-h49m6d2k97
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/base/conf/antrea-controller.conf
+++ b/build/yamls/base/conf/antrea-controller.conf
@@ -24,3 +24,9 @@ featureGates:
 # And the Secret must be mounted to directory "/var/run/antrea/antrea-controller-tls" of the
 # antrea-controller container.
 #selfSignedCert: true
+
+# Indicates how long an auto-generated certificate is used until its rotated.
+# Ignored if SelfSignedCert is false. If the certificate expiry period is less than
+# this value, it is ignored.
+# Defaults to the number of hours in a year.
+#certRotateDuration: 8760h

--- a/cmd/antrea-controller/config.go
+++ b/cmd/antrea-controller/config.go
@@ -15,6 +15,8 @@
 package main
 
 import (
+	"time"
+
 	componentbaseconfig "k8s.io/component-base/config"
 )
 
@@ -39,4 +41,9 @@ type ControllerConfig struct {
 	// antrea-controller container.
 	// Defaults to true.
 	SelfSignedCert bool `yaml:"selfSignedCert,omitempty"`
+	// Indicates how long an auto-generated certificate is used until its rotated.
+	// Ignored if SelfSignedCert is false. If the certificate expiry period is less than
+	// this value, it is ignored.
+	// Defaults to the number of hours in a year.
+	CertRotateDuration time.Duration `yaml:"certRotateDuration,omitempty"`
 }

--- a/cmd/antrea-controller/controller.go
+++ b/cmd/antrea-controller/controller.go
@@ -118,6 +118,7 @@ func run(o *Options) error {
 		client,
 		aggregatorClient,
 		o.config.SelfSignedCert,
+		o.config.CertRotateDuration,
 		o.config.APIPort,
 		addressGroupStore,
 		appliedToGroupStore,
@@ -171,6 +172,7 @@ func createAPIServerConfig(kubeconfig string,
 	client clientset.Interface,
 	aggregatorClient aggregatorclientset.Interface,
 	selfSignedCert bool,
+	certRotateDuration time.Duration,
 	bindPort int,
 	addressGroupStore storage.Interface,
 	appliedToGroupStore storage.Interface,
@@ -182,7 +184,7 @@ func createAPIServerConfig(kubeconfig string,
 	authentication := genericoptions.NewDelegatingAuthenticationOptions()
 	authorization := genericoptions.NewDelegatingAuthorizationOptions().WithAlwaysAllowPaths("/healthz")
 
-	caCertController, err := certificate.ApplyServerCert(selfSignedCert, client, aggregatorClient, secureServing)
+	caCertController, err := certificate.ApplyServerCert(selfSignedCert, certRotateDuration, client, aggregatorClient, secureServing)
 	if err != nil {
 		return nil, fmt.Errorf("error applying server cert: %v", err)
 	}

--- a/cmd/antrea-controller/options.go
+++ b/cmd/antrea-controller/options.go
@@ -17,6 +17,7 @@ package main
 import (
 	"errors"
 	"io/ioutil"
+	"time"
 
 	"github.com/spf13/pflag"
 	"gopkg.in/yaml.v2"
@@ -71,7 +72,8 @@ func (o *Options) loadConfigFromFile(file string) (*ControllerConfig, error) {
 	}
 
 	c := ControllerConfig{
-		SelfSignedCert: true,
+		SelfSignedCert:     true,
+		CertRotateDuration: 24 * 365 * time.Hour,
 	}
 	err = yaml.UnmarshalStrict(data, &c)
 	if err != nil {

--- a/docs/securing-control-plane.md
+++ b/docs/securing-control-plane.md
@@ -158,4 +158,5 @@ If you are using cert-manager to issue the certificate, it will renew the
 certificate before expiry and update the Secret automatically.
 
 If you are using certificates signed by Antrea, Antrea will rotate the
-certificate automatically before expiration.
+certificate automatically before expiration. A rotation duration can
+be provided to force the certificate to be rotated prior to the expiry.

--- a/pkg/apiserver/certificate/certificate.go
+++ b/pkg/apiserver/certificate/certificate.go
@@ -73,7 +73,7 @@ func GetAntreaServerNames() []string {
 	return []string{antreaServerName}
 }
 
-func ApplyServerCert(selfSignedCert bool, client kubernetes.Interface, aggregatorClient clientset.Interface,
+func ApplyServerCert(selfSignedCert bool, userRotateDuration time.Duration, client kubernetes.Interface, aggregatorClient clientset.Interface,
 	secureServing *options.SecureServingOptionsWithLoopback) (*CACertController, error) {
 	var err error
 	var caContentProvider dynamiccertificates.CAContentProvider
@@ -115,7 +115,12 @@ func ApplyServerCert(selfSignedCert bool, client kubernetes.Interface, aggregato
 	caCertController := newCACertController(caContentProvider, client, aggregatorClient)
 
 	if selfSignedCert {
-		go rotateSelfSignedCertificates(caCertController, secureServing, maxRotateDuration)
+		rotateDuration := userRotateDuration
+		if maxRotateDuration < rotateDuration {
+			rotateDuration = maxRotateDuration
+		}
+
+		go rotateSelfSignedCertificates(caCertController, secureServing, rotateDuration)
 	}
 
 	return caCertController, nil

--- a/pkg/apiserver/certificate/certificate_test.go
+++ b/pkg/apiserver/certificate/certificate_test.go
@@ -184,7 +184,7 @@ func TestApplyServerCert(t *testing.T) {
 
 			clientset := fakeclientset.NewSimpleClientset()
 			aggregatorClientset := fakeaggregatorclientset.NewSimpleClientset()
-			got, err := ApplyServerCert(tt.selfSignedCert, clientset, aggregatorClientset, secureServing)
+			got, err := ApplyServerCert(tt.selfSignedCert, 8760*time.Hour, clientset, aggregatorClientset, secureServing)
 
 			if err != nil || tt.wantErr {
 				if (err != nil) != tt.wantErr {


### PR DESCRIPTION
Adds parameter to controller conf to allow for specification of the rotation duration. Can be used by users for more frequent certificate rotation. Also used in testing to verify rotation. 

Adds unit test using parameter to verify rotation occurs correctly.