### PR TITLE
[CI] Work-around action/checkout bug

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,11 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        # Check out pull request's HEAD commit instead of the merge commit to
+        # work-around an issue where wrong a commit is being checked out.
+        # For more details, see:
+        # https://github.com/actions/checkout/issues/299.
+        ref: ${{ github.event.pull_request.head.sha }}
     - uses: vmware-tanzu/antrea/ci/gh-actions/has-changes@master
       id: check_diff
       with:
@@ -31,6 +36,12 @@ jobs:
     runs-on: [ubuntu-18.04]
     steps:
     - uses: actions/checkout@v2
+      with:
+        # Check out pull request's HEAD commit instead of the merge commit to
+        # work-around an issue where wrong a commit is being checked out.
+        # For more details, see:
+        # https://github.com/actions/checkout/issues/299.
+        ref: ${{ github.event.pull_request.head.sha }}
     - name: Build Antrea Docker image
       run: make
     - name: Push Antrea Docker image to registry
@@ -48,6 +59,12 @@ jobs:
     runs-on: [windows-2019]
     steps:
     - uses: actions/checkout@v2
+      with:
+        # Check out pull request's HEAD commit instead of the merge commit to
+        # work-around an issue where wrong a commit is being checked out.
+        # For more details, see:
+        # https://github.com/actions/checkout/issues/299.
+        ref: ${{ github.event.pull_request.head.sha }}
     - name: Build Antrea Windows Docker image
       run: make build-windows
     - name: Push Antrea Windows Docker image to registry
@@ -66,6 +83,12 @@ jobs:
     runs-on: [ubuntu-18.04]
     steps:
     - uses: actions/checkout@v2
+      with:
+        # Check out pull request's HEAD commit instead of the merge commit to
+        # work-around an issue where wrong a commit is being checked out.
+        # For more details, see:
+        # https://github.com/actions/checkout/issues/299.
+        ref: ${{ github.event.pull_request.head.sha }}
     - name: Build octant-antrea-ubuntu Docker image
       run: make octant-antrea-ubuntu
     - name: Push octant-antrea-ubuntu Docker image to registry
@@ -83,6 +106,12 @@ jobs:
     runs-on: [ubuntu-18.04]
     steps:
     - uses: actions/checkout@v2
+      with:
+        # Check out pull request's HEAD commit instead of the merge commit to
+        # work-around an issue where wrong a commit is being checked out.
+        # For more details, see:
+        # https://github.com/actions/checkout/issues/299.
+        ref: ${{ github.event.pull_request.head.sha }}
     - name: Build netpol Docker image
       working-directory: hack/netpol
       run: make build

--- a/.github/workflows/build_tag.yml
+++ b/.github/workflows/build_tag.yml
@@ -10,6 +10,12 @@ jobs:
     runs-on: [ubuntu-18.04]
     steps:
     - uses: actions/checkout@v2
+      with:
+        # Check out pull request's HEAD commit instead of the merge commit to
+        # work-around an issue where wrong a commit is being checked out.
+        # For more details, see:
+        # https://github.com/actions/checkout/issues/299.
+        ref: ${{ github.event.pull_request.head.sha }}
     - name: Build Antrea Docker image and push to registry
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
@@ -24,6 +30,12 @@ jobs:
     runs-on: [windows-2019]
     steps:
     - uses: actions/checkout@v2
+      with:
+        # Check out pull request's HEAD commit instead of the merge commit to
+        # work-around an issue where wrong a commit is being checked out.
+        # For more details, see:
+        # https://github.com/actions/checkout/issues/299.
+        ref: ${{ github.event.pull_request.head.sha }}
     - name: Build Antrea Windows Docker image and push to registry
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
@@ -40,6 +52,12 @@ jobs:
     runs-on: [ubuntu-18.04]
     steps:
       - uses: actions/checkout@v2
+        with:
+          # Check out pull request's HEAD commit instead of the merge commit to
+          # work-around an issue where wrong a commit is being checked out.
+          # For more details, see:
+          # https://github.com/actions/checkout/issues/299.
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Build octant-antrea-ubuntu Docker image and push to registry
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/clair.yml
+++ b/.github/workflows/clair.yml
@@ -11,6 +11,12 @@ jobs:
     runs-on: [ubuntu-18.04]
     steps:
     - uses: actions/checkout@v2
+      with:
+        # Check out pull request's HEAD commit instead of the merge commit to
+        # work-around an issue where wrong a commit is being checked out.
+        # For more details, see:
+        # https://github.com/actions/checkout/issues/299.
+        ref: ${{ github.event.pull_request.head.sha }}
     - uses: actions/setup-go@v1
       with:
         go-version: 1.13

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -25,6 +25,12 @@ jobs:
 
     - name: Check-out code
       uses: actions/checkout@v2
+      with:
+        # Check out pull request's HEAD commit instead of the merge commit to
+        # work-around an issue where wrong a commit is being checked out.
+        # For more details, see:
+        # https://github.com/actions/checkout/issues/299.
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Run unit tests
       run: make test-unit
@@ -50,6 +56,12 @@ jobs:
         go-version: 1.13
     - name: Check-out code
       uses: actions/checkout@v2
+      with:
+        # Check out pull request's HEAD commit instead of the merge commit to
+        # work-around an issue where wrong a commit is being checked out.
+        # For more details, see:
+        # https://github.com/actions/checkout/issues/299.
+        ref: ${{ github.event.pull_request.head.sha }}
     - name: Run golangci-lint
       run: make golangci
 
@@ -64,6 +76,12 @@ jobs:
         go-version: 1.13
     - name: Check-out code
       uses: actions/checkout@v2
+      with:
+        # Check out pull request's HEAD commit instead of the merge commit to
+        # work-around an issue where wrong a commit is being checked out.
+        # For more details, see:
+        # https://github.com/actions/checkout/issues/299.
+        ref: ${{ github.event.pull_request.head.sha }}
     - name: Run golangci-lint
       working-directory: hack/netpol
       run: make golangci
@@ -81,6 +99,12 @@ jobs:
 
     - name: Check-out code
       uses: actions/checkout@v2
+      with:
+        # Check out pull request's HEAD commit instead of the merge commit to
+        # work-around an issue where wrong a commit is being checked out.
+        # For more details, see:
+        # https://github.com/actions/checkout/issues/299.
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Build Antrea binaries
       run: make bin
@@ -100,6 +124,12 @@ jobs:
 
       - name: Check-out code
         uses: actions/checkout@v2
+        with:
+          # Check out pull request's HEAD commit instead of the merge commit to
+          # work-around an issue where wrong a commit is being checked out.
+          # For more details, see:
+          # https://github.com/actions/checkout/issues/299.
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Build antctl binaries
         run: make antctl
@@ -117,6 +147,12 @@ jobs:
 
     - name: Check-out code
       uses: actions/checkout@v2
+      with:
+        # Check out pull request's HEAD commit instead of the merge commit to
+        # work-around an issue where wrong a commit is being checked out.
+        # For more details, see:
+        # https://github.com/actions/checkout/issues/299.
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Check code generation
       run: ./ci/check-codegen.sh
@@ -134,6 +170,12 @@ jobs:
 
     - name: Check-out code
       uses: actions/checkout@v2
+      with:
+        # Check out pull request's HEAD commit instead of the merge commit to
+        # work-around an issue where wrong a commit is being checked out.
+        # For more details, see:
+        # https://github.com/actions/checkout/issues/299.
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Check manifest
       run: ./ci/check-manifest.sh
@@ -151,6 +193,12 @@ jobs:
 
     - name: Check-out code
       uses: actions/checkout@v2
+      with:
+        # Check out pull request's HEAD commit instead of the merge commit to
+        # work-around an issue where wrong a commit is being checked out.
+        # For more details, see:
+        # https://github.com/actions/checkout/issues/299.
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Check tidy
       run: make test-tidy
@@ -167,6 +215,12 @@ jobs:
 
     - name: Check-out code
       uses: actions/checkout@v2
+      with:
+        # Check out pull request's HEAD commit instead of the merge commit to
+        # work-around an issue where wrong a commit is being checked out.
+        # For more details, see:
+        # https://github.com/actions/checkout/issues/299.
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Run verify scripts
       run: make verify

--- a/.github/workflows/golicense.yml
+++ b/.github/workflows/golicense.yml
@@ -20,6 +20,11 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        # Check out pull request's HEAD commit instead of the merge commit to
+        # work-around an issue where wrong a commit is being checked out.
+        # For more details, see:
+        # https://github.com/actions/checkout/issues/299.
+        ref: ${{ github.event.pull_request.head.sha }}
     - uses: vmware-tanzu/antrea/ci/gh-actions/has-changes@master
       id: check_diff
       with:
@@ -37,6 +42,12 @@ jobs:
       with:
         go-version: 1.13
     - uses: actions/checkout@v2
+      with:
+        # Check out pull request's HEAD commit instead of the merge commit to
+        # work-around an issue where wrong a commit is being checked out.
+        # For more details, see:
+        # https://github.com/actions/checkout/issues/299.
+        ref: ${{ github.event.pull_request.head.sha }}
     - name: Cache licensing information for dependencies
       uses: actions/cache@v2
       id: cache

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,6 +14,12 @@ jobs:
     runs-on: [ubuntu-18.04]
     steps:
     - uses: actions/checkout@v2
+      with:
+        # Check out pull request's HEAD commit instead of the merge commit to
+        # work-around an issue where wrong a commit is being checked out.
+        # For more details, see:
+        # https://github.com/actions/checkout/issues/299.
+        ref: ${{ github.event.pull_request.head.sha }}
     - uses: actions/setup-go@v1
       with:
         go-version: 1.13

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -22,6 +22,11 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        # Check out pull request's HEAD commit instead of the merge commit to
+        # work-around an issue where wrong a commit is being checked out.
+        # For more details, see:
+        # https://github.com/actions/checkout/issues/299.
+        ref: ${{ github.event.pull_request.head.sha }}
     - uses: vmware-tanzu/antrea/ci/gh-actions/has-changes@master
       id: check_diff
       with:
@@ -36,6 +41,12 @@ jobs:
     runs-on: [ubuntu-18.04]
     steps:
     - uses: actions/checkout@v2
+      with:
+        # Check out pull request's HEAD commit instead of the merge commit to
+        # work-around an issue where wrong a commit is being checked out.
+        # For more details, see:
+        # https://github.com/actions/checkout/issues/299.
+        ref: ${{ github.event.pull_request.head.sha }}
     - run: make build-ubuntu-coverage
     - name: Save Antrea image to tarball
       run:  docker save -o antrea-ubuntu.tar antrea/antrea-ubuntu-coverage:latest
@@ -56,6 +67,12 @@ jobs:
         sudo apt-get clean
         df -h
     - uses: actions/checkout@v2
+      with:
+        # Check out pull request's HEAD commit instead of the merge commit to
+        # work-around an issue where wrong a commit is being checked out.
+        # For more details, see:
+        # https://github.com/actions/checkout/issues/299.
+        ref: ${{ github.event.pull_request.head.sha }}
     - uses: actions/setup-go@v1
       with:
         go-version: 1.13
@@ -110,6 +127,12 @@ jobs:
         sudo apt-get clean
         df -h
     - uses: actions/checkout@v2
+      with:
+        # Check out pull request's HEAD commit instead of the merge commit to
+        # work-around an issue where wrong a commit is being checked out.
+        # For more details, see:
+        # https://github.com/actions/checkout/issues/299.
+        ref: ${{ github.event.pull_request.head.sha }}
     - uses: actions/setup-go@v1
       with:
         go-version: 1.13
@@ -164,6 +187,12 @@ jobs:
         sudo apt-get clean
         df -h
     - uses: actions/checkout@v2
+      with:
+        # Check out pull request's HEAD commit instead of the merge commit to
+        # work-around an issue where wrong a commit is being checked out.
+        # For more details, see:
+        # https://github.com/actions/checkout/issues/299.
+        ref: ${{ github.event.pull_request.head.sha }}
     - uses: actions/setup-go@v1
       with:
         go-version: 1.13
@@ -218,6 +247,12 @@ jobs:
         sudo apt-get clean
         df -h
     - uses: actions/checkout@v2
+      with:
+        # Check out pull request's HEAD commit instead of the merge commit to
+        # work-around an issue where wrong a commit is being checked out.
+        # For more details, see:
+        # https://github.com/actions/checkout/issues/299.
+        ref: ${{ github.event.pull_request.head.sha }}
     - uses: actions/setup-go@v1
       with:
         go-version: 1.13
@@ -272,6 +307,12 @@ jobs:
         sudo apt-get clean
         df -h
     - uses: actions/checkout@v2
+      with:
+        # Check out pull request's HEAD commit instead of the merge commit to
+        # work-around an issue where wrong a commit is being checked out.
+        # For more details, see:
+        # https://github.com/actions/checkout/issues/299.
+        ref: ${{ github.event.pull_request.head.sha }}
     - uses: actions/setup-go@v1
       with:
         go-version: 1.13
@@ -322,6 +363,12 @@ jobs:
     runs-on: [ubuntu-18.04]
     steps:
     - uses: actions/checkout@v2
+      with:
+        # Check out pull request's HEAD commit instead of the merge commit to
+        # work-around an issue where wrong a commit is being checked out.
+        # For more details, see:
+        # https://github.com/actions/checkout/issues/299.
+        ref: ${{ github.event.pull_request.head.sha }}
     - run: make
     - name: Save Antrea image to tarball
       run:  docker save -o antrea-ubuntu-netpol.tar antrea/antrea-ubuntu:latest
@@ -342,6 +389,12 @@ jobs:
         sudo apt-get clean
         df -h
     - uses: actions/checkout@v2
+      with:
+        # Check out pull request's HEAD commit instead of the merge commit to
+        # work-around an issue where wrong a commit is being checked out.
+        # For more details, see:
+        # https://github.com/actions/checkout/issues/299.
+        ref: ${{ github.event.pull_request.head.sha }}
     - uses: actions/setup-go@v1
       with:
         go-version: 1.13
@@ -374,6 +427,12 @@ jobs:
           sudo apt-get clean
           df -h
       - uses: actions/checkout@v2
+        with:
+          # Check out pull request's HEAD commit instead of the merge commit to
+          # work-around an issue where wrong a commit is being checked out.
+          # For more details, see:
+          # https://github.com/actions/checkout/issues/299.
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-go@v1
         with:
           go-version: 1.13

--- a/.github/workflows/kind_upgrade.yml
+++ b/.github/workflows/kind_upgrade.yml
@@ -20,6 +20,11 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        # Check out pull request's HEAD commit instead of the merge commit to
+        # work-around an issue where wrong a commit is being checked out.
+        # For more details, see:
+        # https://github.com/actions/checkout/issues/299.
+        ref: ${{ github.event.pull_request.head.sha }}
     - uses: vmware-tanzu/antrea/ci/gh-actions/has-changes@master
       id: check_diff
       with:
@@ -34,6 +39,12 @@ jobs:
     runs-on: [ubuntu-18.04]
     steps:
     - uses: actions/checkout@v2
+      with:
+        # Check out pull request's HEAD commit instead of the merge commit to
+        # work-around an issue where wrong a commit is being checked out.
+        # For more details, see:
+        # https://github.com/actions/checkout/issues/299.
+        ref: ${{ github.event.pull_request.head.sha }}
     - run: make
     - name: Save Antrea image to tarball
       run:  docker save -o antrea-ubuntu.tar antrea/antrea-ubuntu:latest
@@ -56,6 +67,12 @@ jobs:
         sudo apt-get clean
         df -h
     - uses: actions/checkout@v2
+      with:
+        # Check out pull request's HEAD commit instead of the merge commit to
+        # work-around an issue where wrong a commit is being checked out.
+        # For more details, see:
+        # https://github.com/actions/checkout/issues/299.
+        ref: ${{ github.event.pull_request.head.sha }}
     - uses: actions/setup-go@v1
       with:
         go-version: 1.13
@@ -85,6 +102,12 @@ jobs:
         sudo apt-get clean
         df -h
     - uses: actions/checkout@v2
+      with:
+        # Check out pull request's HEAD commit instead of the merge commit to
+        # work-around an issue where wrong a commit is being checked out.
+        # For more details, see:
+        # https://github.com/actions/checkout/issues/299.
+        ref: ${{ github.event.pull_request.head.sha }}
     - uses: actions/setup-go@v1
       with:
         go-version: 1.13
@@ -114,6 +137,12 @@ jobs:
           sudo apt-get clean
           df -h
       - uses: actions/checkout@v2
+        with:
+          # Check out pull request's HEAD commit instead of the merge commit to
+          # work-around an issue where wrong a commit is being checked out.
+          # For more details, see:
+          # https://github.com/actions/checkout/issues/299.
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-go@v1
         with:
           go-version: 1.13
@@ -143,6 +172,12 @@ jobs:
           sudo apt-get clean
           df -h
       - uses: actions/checkout@v2
+        with:
+          # Check out pull request's HEAD commit instead of the merge commit to
+          # work-around an issue where wrong a commit is being checked out.
+          # For more details, see:
+          # https://github.com/actions/checkout/issues/299.
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-go@v1
         with:
           go-version: 1.13

--- a/.github/workflows/update_ovs_image.yml
+++ b/.github/workflows/update_ovs_image.yml
@@ -11,6 +11,12 @@ jobs:
     runs-on: [ubuntu-18.04]
     steps:
     - uses: actions/checkout@v2
+      with:
+        # Check out pull request's HEAD commit instead of the merge commit to
+        # work-around an issue where wrong a commit is being checked out.
+        # For more details, see:
+        # https://github.com/actions/checkout/issues/299.
+        ref: ${{ github.event.pull_request.head.sha }}
     - name: Build antrea/openvswitch Docker image and push to registry
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/upload_release_assets.yml
+++ b/.github/workflows/upload_release_assets.yml
@@ -10,6 +10,12 @@ jobs:
     runs-on: [ubuntu-18.04]
     steps:
     - uses: actions/checkout@v2
+      with:
+        # Check out pull request's HEAD commit instead of the merge commit to
+        # work-around an issue where wrong a commit is being checked out.
+        # For more details, see:
+        # https://github.com/actions/checkout/issues/299.
+        ref: ${{ github.event.pull_request.head.sha }}
     - name: Build assets
       env:
         TAG: ${{ github.ref }}


### PR DESCRIPTION
Check out pull request's HEAD commit instead of the merge commit to
work-around an issue where wrong a commit is being checked out.
For more details, see:
https://github.com/actions/checkout/issues/299.