### PR TITLE
Add NodePort support for Antrea Proxy on Linux

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -1312,6 +1312,9 @@ data:
     # this flag will not take effect.
     #  EndpointSlice: false
 
+    # Enable NodePort Service support in AntreaProxy in antrea-agent.
+      AntreaProxyNodePort: true
+
     # Enable traceflow which provides packet tracing feature to diagnose network issue.
     #  Traceflow: true
 
@@ -1434,6 +1437,10 @@ data:
 
     # TLS min version from: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.
     #tlsMinVersion:
+
+    # A string slice of values which specify the addresses to use for NodePorts. Values may be valid IP blocks
+    # (e.g. 1.2.3.0/24, 1.2.3.4/32). The default empty string slice ([]) means to use all local addresses.
+    #nodePortAddresses: []
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -1499,7 +1506,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-mc9bkf47f4
+  name: antrea-config-hdm8fm2tkk
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1619,7 +1626,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-mc9bkf47f4
+          name: antrea-config-hdm8fm2tkk
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1883,7 +1890,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-mc9bkf47f4
+          name: antrea-config-hdm8fm2tkk
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -1312,6 +1312,9 @@ data:
     # this flag will not take effect.
     #  EndpointSlice: false
 
+    # Enable NodePort Service support in AntreaProxy in antrea-agent.
+      AntreaProxyNodePort: true
+
     # Enable traceflow which provides packet tracing feature to diagnose network issue.
     #  Traceflow: true
 
@@ -1434,6 +1437,10 @@ data:
 
     # TLS min version from: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.
     #tlsMinVersion:
+
+    # A string slice of values which specify the addresses to use for NodePorts. Values may be valid IP blocks
+    # (e.g. 1.2.3.0/24, 1.2.3.4/32). The default empty string slice ([]) means to use all local addresses.
+    #nodePortAddresses: []
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -1499,7 +1506,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-mc9bkf47f4
+  name: antrea-config-hdm8fm2tkk
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1619,7 +1626,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-mc9bkf47f4
+          name: antrea-config-hdm8fm2tkk
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1885,7 +1892,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-mc9bkf47f4
+          name: antrea-config-hdm8fm2tkk
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -1312,6 +1312,9 @@ data:
     # this flag will not take effect.
     #  EndpointSlice: false
 
+    # Enable NodePort Service support in AntreaProxy in antrea-agent.
+      AntreaProxyNodePort: true
+
     # Enable traceflow which provides packet tracing feature to diagnose network issue.
     #  Traceflow: true
 
@@ -1434,6 +1437,10 @@ data:
 
     # TLS min version from: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.
     #tlsMinVersion:
+
+    # A string slice of values which specify the addresses to use for NodePorts. Values may be valid IP blocks
+    # (e.g. 1.2.3.0/24, 1.2.3.4/32). The default empty string slice ([]) means to use all local addresses.
+    #nodePortAddresses: []
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -1499,7 +1506,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-bkc6dfdhgt
+  name: antrea-config-f7b6g9b8k2
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1619,7 +1626,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-bkc6dfdhgt
+          name: antrea-config-f7b6g9b8k2
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1886,7 +1893,7 @@ spec:
           path: /home/kubernetes/bin
         name: host-cni-bin
       - configMap:
-          name: antrea-config-bkc6dfdhgt
+          name: antrea-config-f7b6g9b8k2
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -1312,6 +1312,9 @@ data:
     # this flag will not take effect.
     #  EndpointSlice: false
 
+    # Enable NodePort Service support in AntreaProxy in antrea-agent.
+      AntreaProxyNodePort: true
+
     # Enable traceflow which provides packet tracing feature to diagnose network issue.
     #  Traceflow: true
 
@@ -1439,6 +1442,10 @@ data:
 
     # TLS min version from: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.
     #tlsMinVersion:
+
+    # A string slice of values which specify the addresses to use for NodePorts. Values may be valid IP blocks
+    # (e.g. 1.2.3.0/24, 1.2.3.4/32). The default empty string slice ([]) means to use all local addresses.
+    #nodePortAddresses: []
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -1504,7 +1511,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-ftckkg2dc8
+  name: antrea-config-4g9mg9ckm8
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1633,7 +1640,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-ftckkg2dc8
+          name: antrea-config-4g9mg9ckm8
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1932,7 +1939,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-ftckkg2dc8
+          name: antrea-config-4g9mg9ckm8
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -1312,6 +1312,9 @@ data:
     # this flag will not take effect.
     #  EndpointSlice: false
 
+    # Enable NodePort Service support in AntreaProxy in antrea-agent.
+      AntreaProxyNodePort: true
+
     # Enable traceflow which provides packet tracing feature to diagnose network issue.
     #  Traceflow: true
 
@@ -1439,6 +1442,10 @@ data:
 
     # TLS min version from: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.
     #tlsMinVersion:
+
+    # A string slice of values which specify the addresses to use for NodePorts. Values may be valid IP blocks
+    # (e.g. 1.2.3.0/24, 1.2.3.4/32). The default empty string slice ([]) means to use all local addresses.
+    #nodePortAddresses: []
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -1504,7 +1511,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-md64tc85t9
+  name: antrea-config-dgbk4m9gfb
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1624,7 +1631,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-md64tc85t9
+          name: antrea-config-dgbk4m9gfb
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -1888,7 +1895,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-md64tc85t9
+          name: antrea-config-dgbk4m9gfb
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/base/conf/antrea-agent.conf
+++ b/build/yamls/base/conf/antrea-agent.conf
@@ -10,6 +10,9 @@ featureGates:
 # this flag will not take effect.
 #  EndpointSlice: false
 
+# Enable NodePort Service support in AntreaProxy in antrea-agent.
+  AntreaProxyNodePort: true
+
 # Enable traceflow which provides packet tracing feature to diagnose network issue.
 #  Traceflow: true
 
@@ -137,3 +140,7 @@ featureGates:
 
 # TLS min version from: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.
 #tlsMinVersion:
+
+# A string slice of values which specify the addresses to use for NodePorts. Values may be valid IP blocks
+# (e.g. 1.2.3.0/24, 1.2.3.4/32). The default empty string slice ([]) means to use all local addresses.
+#nodePortAddresses: []

--- a/cmd/antrea-agent/config.go
+++ b/cmd/antrea-agent/config.go
@@ -134,4 +134,7 @@ type AgentConfig struct {
 	TLSCipherSuites string `yaml:"tlsCipherSuites,omitempty"`
 	// TLS min version.
 	TLSMinVersion string `yaml:"tlsMinVersion,omitempty"`
+	// A string slice of values which specify the addresses to use for NodePorts. Values may be valid IP blocks
+	// (e.g. 1.2.3.0/24, 1.2.3.4/32). The default empty string slice ([]) means to use all local addresses.
+	NodePortAddresses []string `yaml:"nodePortAddresses,omitempty"`
 }

--- a/cmd/antrea-agent/options.go
+++ b/cmd/antrea-agent/options.go
@@ -43,6 +43,8 @@ const (
 	defaultFlowPollInterval       = 5 * time.Second
 	defaultFlowExportFrequency    = 12
 	defaultNPLPortRange           = "40000-41000"
+	defaultNodePortVirtualIP      = "169.254.169.110"
+	defaultNodePortVirtualIPv6    = "fec0::ffee:ddcc:bbaa"
 )
 
 type Options struct {
@@ -56,10 +58,14 @@ type Options struct {
 	flowCollectorProto string
 	// Flow exporter poll interval
 	pollInterval time.Duration
+	// The virtual IP for NodePort Service support.
+	nodePortVirtualIP, nodePortVirtualIPv6 net.IP
 }
 
 func newOptions() *Options {
 	return &Options{
+		nodePortVirtualIP:   net.ParseIP(defaultNodePortVirtualIP),
+		nodePortVirtualIPv6: net.ParseIP(defaultNodePortVirtualIPv6),
 		config: &AgentConfig{
 			EnablePrometheusMetrics:   true,
 			EnableTLSToFlowAggregator: true,
@@ -141,6 +147,9 @@ func (o *Options) validate(args []string) error {
 		// (but SNAT can be done by the primary CNI).
 		o.config.NoSNAT = true
 	}
+	if err := o.validateAntreaProxyConfig(); err != nil {
+		return fmt.Errorf("proxy config is invalid: %w", err)
+	}
 	if err := o.validateFlowExporterConfig(); err != nil {
 		return fmt.Errorf("failed to validate flow exporter config: %v", err)
 	}
@@ -206,6 +215,17 @@ func (o *Options) setDefaults() {
 			o.config.NPLPortRange = defaultNPLPortRange
 		}
 	}
+}
+
+func (o *Options) validateAntreaProxyConfig() error {
+	if features.DefaultFeatureGate.Enabled(features.AntreaProxyNodePort) {
+		for _, nodePortAddress := range o.config.NodePortAddresses {
+			if _, _, err := net.ParseCIDR(nodePortAddress); err != nil {
+				return fmt.Errorf("NodePortAddress is not valid, can not parse `%s`: %w", nodePortAddress, err)
+			}
+		}
+	}
+	return nil
 }
 
 func (o *Options) validateFlowExporterConfig() error {

--- a/hack/generate-manifest.sh
+++ b/hack/generate-manifest.sh
@@ -241,6 +241,7 @@ fi
 
 if $ALLFEATURES; then
     sed -i.bak -E "s/^[[:space:]]*#[[:space:]]*AntreaPolicy[[:space:]]*:[[:space:]]*[a-z]+[[:space:]]*$/  AntreaPolicy: true/" antrea-agent.conf
+    sed -i.bak -E "s/^[[:space:]]*#[[:space:]]*AntreaProxyNodePort[[:space:]]*:[[:space:]]*[a-z]+[[:space:]]*$/  AntreaProxyNodePort: true/" antrea-agent.conf
     sed -i.bak -E "s/^[[:space:]]*#[[:space:]]*FlowExporter[[:space:]]*:[[:space:]]*[a-z]+[[:space:]]*$/  FlowExporter: true/" antrea-agent.conf
     sed -i.bak -E "s/^[[:space:]]*#[[:space:]]*NetworkPolicyStats[[:space:]]*:[[:space:]]*[a-z]+[[:space:]]*$/  NetworkPolicyStats: true/" antrea-agent.conf
     sed -i.bak -E "s/^[[:space:]]*#[[:space:]]*EndpointSlice[[:space:]]*:[[:space:]]*[a-z]+[[:space:]]*$/  EndpointSlice: true/" antrea-agent.conf

--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -532,6 +532,15 @@ func (c *client) InstallGatewayFlows() error {
 	// Add flow to ensure the liveness check packet could be forwarded correctly.
 	flows = append(flows, c.localProbeFlow(gatewayIPs, cookie.Default)...)
 	flows = append(flows, c.ctRewriteDstMACFlows(gatewayConfig.MAC, cookie.Default)...)
+	if c.enableProxy {
+		flows = append(flows, c.arpNodePortVirtualResponderFlow())
+		if gatewayConfig.IPv6 != nil {
+			flows = append(flows, c.serviceGatewayFlow(true))
+		}
+		if gatewayConfig.IPv4 != nil {
+			flows = append(flows, c.serviceGatewayFlow(false))
+		}
+	}
 	// In NoEncap , no traffic from tunnel port
 	if c.encapMode.SupportsEncap() {
 		flows = append(flows, c.l3FwdFlowToGateway(gatewayIPs, gatewayConfig.MAC, cookie.Default)...)

--- a/pkg/agent/openflow/client_test.go
+++ b/pkg/agent/openflow/client_test.go
@@ -38,7 +38,10 @@ import (
 
 const bridgeName = "dummy-br"
 
-var bridgeMgmtAddr = ofconfig.GetMgmtAddress(ovsconfig.DefaultOVSRunDir, bridgeName)
+var (
+	bridgeMgmtAddr    = ofconfig.GetMgmtAddress(ovsconfig.DefaultOVSRunDir, bridgeName)
+	nodePortVirtualIP = net.ParseIP("169.254.169.110")
+)
 
 func installNodeFlows(ofClient Client, cacheKey string) (int, error) {
 	hostName := cacheKey
@@ -91,7 +94,7 @@ func TestIdempotentFlowInstallation(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
-			ofClient := NewClient(bridgeName, bridgeMgmtAddr, ovsconfig.OVSDatapathSystem, true, false)
+			ofClient := NewClient(bridgeName, bridgeMgmtAddr, ovsconfig.OVSDatapathSystem, nodePortVirtualIP, nil, true, false)
 			client := ofClient.(*client)
 			client.cookieAllocator = cookie.NewAllocator(0)
 			client.ofEntryOperations = m
@@ -122,7 +125,7 @@ func TestIdempotentFlowInstallation(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
-			ofClient := NewClient(bridgeName, bridgeMgmtAddr, ovsconfig.OVSDatapathSystem, true, false)
+			ofClient := NewClient(bridgeName, bridgeMgmtAddr, ovsconfig.OVSDatapathSystem, nodePortVirtualIP, nil, true, false)
 			client := ofClient.(*client)
 			client.cookieAllocator = cookie.NewAllocator(0)
 			client.ofEntryOperations = m
@@ -166,7 +169,7 @@ func TestFlowInstallationFailed(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
-			ofClient := NewClient(bridgeName, bridgeMgmtAddr, ovsconfig.OVSDatapathSystem, true, false)
+			ofClient := NewClient(bridgeName, bridgeMgmtAddr, ovsconfig.OVSDatapathSystem, nodePortVirtualIP, nil, true, false)
 			client := ofClient.(*client)
 			client.cookieAllocator = cookie.NewAllocator(0)
 			client.ofEntryOperations = m
@@ -203,7 +206,7 @@ func TestConcurrentFlowInstallation(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
-			ofClient := NewClient(bridgeName, bridgeMgmtAddr, ovsconfig.OVSDatapathSystem, true, false)
+			ofClient := NewClient(bridgeName, bridgeMgmtAddr, ovsconfig.OVSDatapathSystem, nodePortVirtualIP, nil, true, false)
 			client := ofClient.(*client)
 			client.cookieAllocator = cookie.NewAllocator(0)
 			client.ofEntryOperations = m
@@ -469,7 +472,7 @@ func Test_client_SendTraceflowPacket(t *testing.T) {
 }
 
 func prepareTraceflowFlow(ctrl *gomock.Controller) *client {
-	ofClient := NewClient(bridgeName, bridgeMgmtAddr, ovsconfig.OVSDatapathSystem, true, true)
+	ofClient := NewClient(bridgeName, bridgeMgmtAddr, ovsconfig.OVSDatapathSystem, nodePortVirtualIP, nil, true, true)
 	c := ofClient.(*client)
 	c.cookieAllocator = cookie.NewAllocator(0)
 	c.nodeConfig = &config.NodeConfig{}
@@ -487,7 +490,7 @@ func prepareTraceflowFlow(ctrl *gomock.Controller) *client {
 }
 
 func prepareSendTraceflowPacket(ctrl *gomock.Controller, success bool) *client {
-	ofClient := NewClient(bridgeName, bridgeMgmtAddr, ovsconfig.OVSDatapathSystem, true, true)
+	ofClient := NewClient(bridgeName, bridgeMgmtAddr, ovsconfig.OVSDatapathSystem, nil, nil, true, true)
 	c := ofClient.(*client)
 	mac, _ := net.ParseMAC("aa:bb:cc:dd:ee:ff")
 	c.nodeConfig = &config.NodeConfig{GatewayConfig: &config.GatewayConfig{MAC: mac}}

--- a/pkg/agent/openflow/testing/mock_openflow.go
+++ b/pkg/agent/openflow/testing/mock_openflow.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Antrea Authors
+// Copyright 2021 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/agent/proxy/proxier_test.go
+++ b/pkg/agent/proxy/proxier_test.go
@@ -33,9 +33,13 @@ import (
 	ofmock "github.com/vmware-tanzu/antrea/pkg/agent/openflow/testing"
 	"github.com/vmware-tanzu/antrea/pkg/agent/proxy/metrics"
 	"github.com/vmware-tanzu/antrea/pkg/agent/proxy/types"
+	"github.com/vmware-tanzu/antrea/pkg/agent/route"
+	routetesting "github.com/vmware-tanzu/antrea/pkg/agent/route/testing"
 	binding "github.com/vmware-tanzu/antrea/pkg/ovs/openflow"
 	k8sproxy "github.com/vmware-tanzu/antrea/third_party/proxy"
 )
+
+var virtualNodePortIP = net.ParseIP("169.254.169.110")
 
 func makeNamespaceName(namespace, name string) apimachinerytypes.NamespacedName {
 	return apimachinerytypes.NamespacedName{Namespace: namespace, Name: name}
@@ -80,7 +84,7 @@ func makeTestEndpoints(namespace, name string, eptFunc func(*corev1.Endpoints)) 
 	return ept
 }
 
-func NewFakeProxier(ofClient openflow.Client, isIPv6 bool) *proxier {
+func NewFakeProxier(routeClient route.Interface, ofClient openflow.Client, isIPv6, nodeportSupport bool) *proxier {
 	hostname := "localhost"
 	eventBroadcaster := record.NewBroadcaster()
 	recorder := eventBroadcaster.NewRecorder(
@@ -97,8 +101,12 @@ func NewFakeProxier(ofClient openflow.Client, isIPv6 bool) *proxier {
 		endpointsMap:             types.EndpointsMap{},
 		groupCounter:             types.NewGroupCounter(),
 		ofClient:                 ofClient,
+		routeClient:              routeClient,
 		serviceStringMap:         map[string]k8sproxy.ServicePortName{},
 		isIPv6:                   isIPv6,
+		nodeIPs:                  []net.IP{net.ParseIP("192.168.0.1")},
+		virtualNodePortIP:        virtualNodePortIP,
+		nodePortSupport:          nodeportSupport,
 	}
 	return p
 }
@@ -107,7 +115,8 @@ func testClusterIP(t *testing.T, svcIP net.IP, epIP net.IP, isIPv6 bool) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockOFClient := ofmock.NewMockClient(ctrl)
-	fp := NewFakeProxier(mockOFClient, isIPv6)
+	mockRouteClient := routetesting.NewMockInterface(ctrl)
+	fp := NewFakeProxier(mockRouteClient, mockOFClient, isIPv6, false)
 
 	svcPort := 80
 	svcPortName := k8sproxy.ServicePortName{
@@ -141,7 +150,7 @@ func testClusterIP(t *testing.T, svcIP net.IP, epIP net.IP, isIPv6 bool) {
 		}),
 	)
 
-	groupID, _ := fp.groupCounter.Get(svcPortName)
+	groupID, _ := fp.groupCounter.Get(svcPortName, "")
 	mockOFClient.EXPECT().InstallServiceGroup(groupID, false, gomock.Any()).Times(1)
 	bindingProtocol := binding.ProtocolTCP
 	if isIPv6 {
@@ -157,7 +166,8 @@ func TestLoadbalancer(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockOFClient := ofmock.NewMockClient(ctrl)
-	fp := NewFakeProxier(mockOFClient, false)
+	mockRouteClient := routetesting.NewMockInterface(ctrl)
+	fp := NewFakeProxier(mockRouteClient, mockOFClient, false, true)
 
 	svcIPv4 := net.ParseIP("10.20.30.41")
 	svcPort := 80
@@ -198,12 +208,79 @@ func TestLoadbalancer(t *testing.T) {
 		}),
 	)
 
-	groupID, _ := fp.groupCounter.Get(svcPortName)
+	groupID, _ := fp.groupCounter.Get(svcPortName, "")
 	mockOFClient.EXPECT().InstallServiceGroup(groupID, false, gomock.Any()).Times(1)
 	mockOFClient.EXPECT().InstallEndpointFlows(binding.ProtocolTCP, gomock.Any(), false).Times(1)
 	mockOFClient.EXPECT().InstallServiceFlows(groupID, svcIPv4, uint16(svcPort), binding.ProtocolTCP, uint16(0)).Times(1)
 	mockOFClient.EXPECT().InstallServiceFlows(groupID, loadBalancerIPv4, uint16(svcPort), binding.ProtocolTCP, uint16(0)).Times(1)
 	mockOFClient.EXPECT().InstallLoadBalancerServiceFromOutsideFlows(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+	fp.syncProxyRules()
+}
+
+func TestExternalNameToNodePort(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockOFClient := ofmock.NewMockClient(ctrl)
+	mockRouteClient := routetesting.NewMockInterface(ctrl)
+	fp := NewFakeProxier(mockRouteClient, mockOFClient, false, true)
+
+	svcIPv4 := net.ParseIP("10.20.30.41")
+	svcPort := 80
+	svcNodePort := 31000
+	svcPortName := k8sproxy.ServicePortName{
+		NamespacedName: makeNamespaceName("ns1", "svc1"),
+		Port:           "80",
+		Protocol:       corev1.ProtocolTCP,
+	}
+	makeServiceMap(fp,
+		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *corev1.Service) {
+			svc.Spec.ClusterIP = svcIPv4.String() // Should be ignored.
+			svc.Spec.Type = corev1.ServiceTypeExternalName
+			svc.Spec.ExternalName = "a.b.c.com"
+			svc.Spec.Ports = []corev1.ServicePort{{
+				Name:     svcPortName.Port,
+				Port:     int32(svcPort),
+				Protocol: corev1.ProtocolTCP,
+			}}
+		}),
+	)
+	fp.syncProxyRules()
+
+	makeServiceMap(fp,
+		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *corev1.Service) {
+			svc.Spec.ClusterIP = svcIPv4.String()
+			svc.Spec.Type = corev1.ServiceTypeNodePort
+			svc.Spec.Ports = []corev1.ServicePort{{
+				NodePort: int32(svcNodePort),
+				Name:     svcPortName.Port,
+				Port:     int32(svcPort),
+				Protocol: corev1.ProtocolTCP,
+			}}
+		}),
+	)
+	epIP := net.ParseIP("10.180.0.1")
+	epFunc := func(ept *corev1.Endpoints) {
+		ept.Subsets = []corev1.EndpointSubset{{
+			Addresses: []corev1.EndpointAddress{{
+				IP: epIP.String(),
+			}},
+			Ports: []corev1.EndpointPort{{
+				Name:     svcPortName.Port,
+				Port:     int32(svcPort),
+				Protocol: corev1.ProtocolTCP,
+			}},
+		}}
+	}
+	ep := makeTestEndpoints(svcPortName.Namespace, svcPortName.Name, epFunc)
+	makeEndpointsMap(fp, ep)
+	groupID, _ := fp.groupCounter.Get(svcPortName, "")
+	mockOFClient.EXPECT().InstallServiceGroup(groupID, false, gomock.Any()).Times(1)
+	bindingProtocol := binding.ProtocolTCP
+	mockOFClient.EXPECT().InstallEndpointFlows(bindingProtocol, gomock.Any(), false).Times(1)
+	mockOFClient.EXPECT().InstallServiceFlows(groupID, svcIPv4, uint16(svcPort), bindingProtocol, uint16(0)).Times(1)
+	mockOFClient.EXPECT().InstallServiceFlows(groupID, virtualNodePortIP, uint16(svcNodePort), bindingProtocol, uint16(0)).Times(1)
+	mockRouteClient.EXPECT().AddNodePort(gomock.Any(), gomock.Any(), false).Times(1)
 
 	fp.syncProxyRules()
 }
@@ -220,7 +297,8 @@ func testClusterIPRemoval(t *testing.T, svcIP net.IP, epIP net.IP, isIPv6 bool) 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockOFClient := ofmock.NewMockClient(ctrl)
-	fp := NewFakeProxier(mockOFClient, isIPv6)
+	mockRouteClient := routetesting.NewMockInterface(ctrl)
+	fp := NewFakeProxier(mockRouteClient, mockOFClient, isIPv6, true)
 
 	svcPort := 80
 	svcPortName := k8sproxy.ServicePortName{
@@ -257,7 +335,7 @@ func testClusterIPRemoval(t *testing.T, svcIP net.IP, epIP net.IP, isIPv6 bool) 
 	}
 	ep := makeTestEndpoints(svcPortName.Namespace, svcPortName.Name, epFunc)
 	makeEndpointsMap(fp, ep)
-	groupID, _ := fp.groupCounter.Get(svcPortName)
+	groupID, _ := fp.groupCounter.Get(svcPortName, "")
 	mockOFClient.EXPECT().InstallServiceGroup(groupID, false, gomock.Any()).Times(1)
 	mockOFClient.EXPECT().InstallEndpointFlows(bindingProtocol, gomock.Any(), isIPv6).Times(1)
 	mockOFClient.EXPECT().InstallServiceFlows(groupID, svcIP, uint16(svcPort), bindingProtocol, uint16(0)).Times(1)
@@ -284,7 +362,8 @@ func testClusterIPNoEndpoint(t *testing.T, svcIP net.IP, isIPv6 bool) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockOFClient := ofmock.NewMockClient(ctrl)
-	fp := NewFakeProxier(mockOFClient, isIPv6)
+	mockRouteClient := routetesting.NewMockInterface(ctrl)
+	fp := NewFakeProxier(mockRouteClient, mockOFClient, isIPv6, false)
 
 	svcPort := 80
 	svcNodePort := 3001
@@ -321,7 +400,8 @@ func testClusterIPRemoveSamePortEndpoint(t *testing.T, svcIP net.IP, epIP net.IP
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockOFClient := ofmock.NewMockClient(ctrl)
-	fp := NewFakeProxier(mockOFClient, isIPv6)
+	mockRouteClient := routetesting.NewMockInterface(ctrl)
+	fp := NewFakeProxier(mockRouteClient, mockOFClient, isIPv6, false)
 
 	svcPort := 80
 	svcPortName := k8sproxy.ServicePortName{
@@ -385,8 +465,8 @@ func testClusterIPRemoveSamePortEndpoint(t *testing.T, svcIP net.IP, epIP net.IP
 	}
 	makeEndpointsMap(fp, ep, epUDP)
 
-	groupID, _ := fp.groupCounter.Get(svcPortName)
-	groupIDUDP, _ := fp.groupCounter.Get(svcPortNameUDP)
+	groupID, _ := fp.groupCounter.Get(svcPortName, "")
+	groupIDUDP, _ := fp.groupCounter.Get(svcPortNameUDP, "")
 	mockOFClient.EXPECT().InstallServiceGroup(groupID, false, gomock.Any()).Times(1)
 	mockOFClient.EXPECT().InstallServiceGroup(groupIDUDP, false, gomock.Any()).Times(2)
 	mockOFClient.EXPECT().InstallEndpointFlows(protocolTCP, gomock.Any(), isIPv6).Times(1)
@@ -412,7 +492,8 @@ func testClusterIPRemoveEndpoints(t *testing.T, svcIP net.IP, epIP net.IP, isIPv
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockOFClient := ofmock.NewMockClient(ctrl)
-	fp := NewFakeProxier(mockOFClient, isIPv6)
+	mockRouteClient := routetesting.NewMockInterface(ctrl)
+	fp := NewFakeProxier(mockRouteClient, mockOFClient, isIPv6, false)
 
 	svcPort := 80
 	svcPortName := k8sproxy.ServicePortName{
@@ -448,7 +529,7 @@ func testClusterIPRemoveEndpoints(t *testing.T, svcIP net.IP, epIP net.IP, isIPv
 		bindingProtocol = binding.ProtocolTCPv6
 	}
 	makeEndpointsMap(fp, ep)
-	groupID, _ := fp.groupCounter.Get(svcPortName)
+	groupID, _ := fp.groupCounter.Get(svcPortName, "")
 	mockOFClient.EXPECT().InstallServiceGroup(groupID, false, gomock.Any()).Times(2)
 	mockOFClient.EXPECT().InstallEndpointFlows(bindingProtocol, gomock.Any(), isIPv6).Times(2)
 	mockOFClient.EXPECT().InstallServiceFlows(groupID, svcIP, uint16(svcPort), bindingProtocol, uint16(0)).Times(1)
@@ -471,7 +552,8 @@ func testSessionAffinityNoEndpoint(t *testing.T, svcExternalIPs net.IP, svcIP ne
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockOFClient := ofmock.NewMockClient(ctrl)
-	fp := NewFakeProxier(mockOFClient, isIPv6)
+	mockRouteClient := routetesting.NewMockInterface(ctrl)
+	fp := NewFakeProxier(mockRouteClient, mockOFClient, isIPv6, false)
 
 	svcPort := 80
 	svcNodePort := 3001
@@ -484,7 +566,7 @@ func testSessionAffinityNoEndpoint(t *testing.T, svcExternalIPs net.IP, svcIP ne
 
 	makeServiceMap(fp,
 		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *corev1.Service) {
-			svc.Spec.Type = "NodePort"
+			svc.Spec.Type = corev1.ServiceTypeNodePort
 			svc.Spec.ClusterIP = svcIP.String()
 			svc.Spec.ExternalIPs = []string{svcExternalIPs.String()}
 			svc.Spec.SessionAffinity = corev1.ServiceAffinityClientIP
@@ -519,7 +601,7 @@ func testSessionAffinityNoEndpoint(t *testing.T, svcExternalIPs net.IP, svcIP ne
 	if isIPv6 {
 		bindingProtocol = binding.ProtocolTCPv6
 	}
-	groupID, _ := fp.groupCounter.Get(svcPortName)
+	groupID, _ := fp.groupCounter.Get(svcPortName, "")
 	mockOFClient.EXPECT().InstallServiceGroup(groupID, true, gomock.Any()).Times(1)
 	mockOFClient.EXPECT().InstallEndpointFlows(bindingProtocol, gomock.Any(), isIPv6).Times(1)
 	mockOFClient.EXPECT().InstallServiceFlows(groupID, svcIP, uint16(svcPort), bindingProtocol, uint16(corev1.DefaultClientIPServiceAffinitySeconds)).Times(1)
@@ -539,7 +621,7 @@ func testSessionAffinity(t *testing.T, svcExternalIPs net.IP, svcIP net.IP, isIP
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockOFClient := ofmock.NewMockClient(ctrl)
-	fp := NewFakeProxier(mockOFClient, isIPv6)
+	fp := NewFakeProxier(nil, mockOFClient, isIPv6, false)
 
 	svcPort := 80
 	svcNodePort := 3001
@@ -552,7 +634,7 @@ func testSessionAffinity(t *testing.T, svcExternalIPs net.IP, svcIP net.IP, isIP
 
 	makeServiceMap(fp,
 		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *corev1.Service) {
-			svc.Spec.Type = "NodePort"
+			svc.Spec.Type = corev1.ServiceTypeNodePort
 			svc.Spec.ClusterIP = svcIP.String()
 			svc.Spec.ExternalIPs = []string{svcExternalIPs.String()}
 			svc.Spec.SessionAffinity = corev1.ServiceAffinityClientIP
@@ -586,7 +668,8 @@ func testPortChange(t *testing.T, svcIP net.IP, epIP net.IP, isIPv6 bool) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockOFClient := ofmock.NewMockClient(ctrl)
-	fp := NewFakeProxier(mockOFClient, isIPv6)
+	mockRouteClient := routetesting.NewMockInterface(ctrl)
+	fp := NewFakeProxier(mockRouteClient, mockOFClient, isIPv6, false)
 
 	svcPort1 := 80
 	svcPort2 := 8080
@@ -625,7 +708,7 @@ func testPortChange(t *testing.T, svcIP net.IP, epIP net.IP, isIPv6 bool) {
 	}
 	ep := makeTestEndpoints(svcPortName.Namespace, svcPortName.Name, epFunc)
 	makeEndpointsMap(fp, ep)
-	groupID, _ := fp.groupCounter.Get(svcPortName)
+	groupID, _ := fp.groupCounter.Get(svcPortName, "")
 	mockOFClient.EXPECT().InstallServiceGroup(groupID, false, gomock.Any()).Times(1)
 	mockOFClient.EXPECT().InstallEndpointFlows(bindingProtocol, gomock.Any(), isIPv6).Times(1)
 	mockOFClient.EXPECT().InstallServiceFlows(groupID, svcIP, uint16(svcPort1), bindingProtocol, uint16(0))
@@ -659,7 +742,8 @@ func TestServicesWithSameEndpoints(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockOFClient := ofmock.NewMockClient(ctrl)
-	fp := NewFakeProxier(mockOFClient, false)
+	mockRouteClient := routetesting.NewMockInterface(ctrl)
+	fp := NewFakeProxier(mockRouteClient, mockOFClient, false, false)
 	epIP := net.ParseIP("10.50.60.71")
 	svcIP1 := net.ParseIP("10.180.30.41")
 	svcIP2 := net.ParseIP("10.180.30.42")
@@ -710,8 +794,8 @@ func TestServicesWithSameEndpoints(t *testing.T) {
 	ep1 := epMapFactory(svcPortName1, epIP.String())
 	ep2 := epMapFactory(svcPortName2, epIP.String())
 
-	groupID1, _ := fp.groupCounter.Get(svcPortName1)
-	groupID2, _ := fp.groupCounter.Get(svcPortName2)
+	groupID1, _ := fp.groupCounter.Get(svcPortName1, "")
+	groupID2, _ := fp.groupCounter.Get(svcPortName2, "")
 	mockOFClient.EXPECT().InstallServiceGroup(groupID1, false, gomock.Any()).Times(1)
 	mockOFClient.EXPECT().InstallServiceGroup(groupID2, false, gomock.Any()).Times(1)
 	bindingProtocol := binding.ProtocolTCP

--- a/pkg/agent/route/interfaces.go
+++ b/pkg/agent/route/interfaces.go
@@ -18,6 +18,7 @@ import (
 	"net"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/config"
+	"github.com/vmware-tanzu/antrea/pkg/agent/proxy/types"
 )
 
 // Interface is the interface for routing container packets in host network.
@@ -37,6 +38,20 @@ type Interface interface {
 	// DeleteRoutes should delete routes to the provided podCIDR.
 	// It should do nothing if the routes don't exist, without error.
 	DeleteRoutes(podCIDR *net.IPNet) error
+
+	// AddRoutes should add the route to the NodePort virtual IP.
+	AddNodePortRoute(isIPv6 bool) error
+
+	// ReconcileNodePort should remove orphaned NodePort ipset entries.
+	ReconcileNodePort(nodeIPs []net.IP, svcEntries []*types.ServiceInfo) error
+
+	// AddNodePort should add entries of the NodePort Service to the ipset.
+	// It should have no effect if the entry already exist, without error.
+	AddNodePort(nodeIPs []net.IP, svcInfo *types.ServiceInfo, isIPv6 bool) error
+
+	// DeleteNodePort should delete entries of the NodePort Service from ipset.
+	// It should do nothing if entries of the NodePort Service don't exist, without error.
+	DeleteNodePort(nodeIPs []net.IP, svcInfo *types.ServiceInfo, isIPv6 bool) error
 
 	// MigrateRoutesToGw should move routes from device linkname to local gateway.
 	MigrateRoutesToGw(linkName string) error

--- a/pkg/agent/route/route_windows.go
+++ b/pkg/agent/route/route_windows.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/config"
+	"github.com/vmware-tanzu/antrea/pkg/agent/proxy/types"
 	"github.com/vmware-tanzu/antrea/pkg/agent/util"
 	"github.com/vmware-tanzu/antrea/pkg/agent/util/winfirewall"
 )
@@ -35,6 +36,9 @@ const (
 	outboundFirewallRuleName = "Antrea: accept packets to local Pods"
 )
 
+// Client implements Interface.
+var _ Interface = &Client{}
+
 type Client struct {
 	nr          netroute.Interface
 	nodeConfig  *config.NodeConfig
@@ -43,9 +47,32 @@ type Client struct {
 	fwClient    *winfirewall.Client
 }
 
+func (c *Client) AddNodePortRoute(isIPv6 bool) error {
+	return nil
+}
+
+func (c *Client) AddNodePort(nodeIPs []net.IP, svcInfo *types.ServiceInfo, isIPv6 bool) error {
+	return nil
+}
+
+func (c *Client) DeleteNodePort(nodeIPs []net.IP, svcInfo *types.ServiceInfo, isIPv6 bool) error {
+	return nil
+}
+
+func (c *Client) ReconcileNodePort(nodeIPs []net.IP, ports []*types.ServiceInfo) error {
+	return nil
+}
+
 // NewClient returns a route client.
 // Todo: remove param serviceCIDR after kube-proxy is replaced by Antrea Proxy completely.
-func NewClient(serviceCIDR *net.IPNet, networkConfig *config.NetworkConfig, noSNAT bool) (*Client, error) {
+func NewClient(
+	nodePortVirtualIP net.IP,
+	nodePortVirtualIPv6 net.IP,
+	serviceCIDR *net.IPNet,
+	networkConfig *config.NetworkConfig,
+	noSNAT bool,
+	nodeportSupport bool,
+) (*Client, error) {
 	nr := netroute.New()
 	return &Client{
 		nr:          nr,

--- a/pkg/agent/route/route_windows_test.go
+++ b/pkg/agent/route/route_windows_test.go
@@ -53,7 +53,7 @@ func TestRouteOperation(t *testing.T) {
 	nr := netroute.New()
 	defer nr.Exit()
 
-	client, err := NewClient(serviceCIDR, &config.NetworkConfig{}, false)
+	client, err := NewClient(nil, nil, serviceCIDR, &config.NetworkConfig{}, false, false)
 	require.Nil(t, err)
 	nodeConfig := &config.NodeConfig{
 		GatewayConfig: &config.GatewayConfig{

--- a/pkg/agent/route/testing/mock_route.go
+++ b/pkg/agent/route/testing/mock_route.go
@@ -22,6 +22,7 @@ package testing
 import (
 	gomock "github.com/golang/mock/gomock"
 	config "github.com/vmware-tanzu/antrea/pkg/agent/config"
+	types "github.com/vmware-tanzu/antrea/pkg/agent/proxy/types"
 	net "net"
 	reflect "reflect"
 )
@@ -49,6 +50,34 @@ func (m *MockInterface) EXPECT() *MockInterfaceMockRecorder {
 	return m.recorder
 }
 
+// AddNodePort mocks base method
+func (m *MockInterface) AddNodePort(arg0 []net.IP, arg1 *types.ServiceInfo, arg2 bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddNodePort", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddNodePort indicates an expected call of AddNodePort
+func (mr *MockInterfaceMockRecorder) AddNodePort(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddNodePort", reflect.TypeOf((*MockInterface)(nil).AddNodePort), arg0, arg1, arg2)
+}
+
+// AddNodePortRoute mocks base method
+func (m *MockInterface) AddNodePortRoute(arg0 bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddNodePortRoute", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddNodePortRoute indicates an expected call of AddNodePortRoute
+func (mr *MockInterfaceMockRecorder) AddNodePortRoute(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddNodePortRoute", reflect.TypeOf((*MockInterface)(nil).AddNodePortRoute), arg0)
+}
+
 // AddRoutes mocks base method
 func (m *MockInterface) AddRoutes(arg0 *net.IPNet, arg1, arg2 net.IP) error {
 	m.ctrl.T.Helper()
@@ -61,6 +90,20 @@ func (m *MockInterface) AddRoutes(arg0 *net.IPNet, arg1, arg2 net.IP) error {
 func (mr *MockInterfaceMockRecorder) AddRoutes(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddRoutes", reflect.TypeOf((*MockInterface)(nil).AddRoutes), arg0, arg1, arg2)
+}
+
+// DeleteNodePort mocks base method
+func (m *MockInterface) DeleteNodePort(arg0 []net.IP, arg1 *types.ServiceInfo, arg2 bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteNodePort", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteNodePort indicates an expected call of DeleteNodePort
+func (mr *MockInterfaceMockRecorder) DeleteNodePort(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNodePort", reflect.TypeOf((*MockInterface)(nil).DeleteNodePort), arg0, arg1, arg2)
 }
 
 // DeleteRoutes mocks base method
@@ -117,6 +160,20 @@ func (m *MockInterface) Reconcile(arg0 []string) error {
 func (mr *MockInterfaceMockRecorder) Reconcile(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reconcile", reflect.TypeOf((*MockInterface)(nil).Reconcile), arg0)
+}
+
+// ReconcileNodePort mocks base method
+func (m *MockInterface) ReconcileNodePort(arg0 []net.IP, arg1 []*types.ServiceInfo) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReconcileNodePort", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ReconcileNodePort indicates an expected call of ReconcileNodePort
+func (mr *MockInterfaceMockRecorder) ReconcileNodePort(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReconcileNodePort", reflect.TypeOf((*MockInterface)(nil).ReconcileNodePort), arg0, arg1)
 }
 
 // Run mocks base method

--- a/pkg/agent/util/ipset/ipset.go
+++ b/pkg/agent/util/ipset/ipset.go
@@ -28,6 +28,8 @@ const (
 	// The lookup time grows linearly with the number of the different prefix values added to the set.
 	HashNet SetType = "hash:net"
 	HashIP  SetType = "hash:ip"
+	// The hash:ip,port set type uses a hash to store IP address and protocol-port pairs in it.
+	HashIPPort SetType = "hash:ip,port"
 )
 
 // memberPattern is used to match the members part of ipset list result.

--- a/pkg/agent/util/iptables/iptables.go
+++ b/pkg/agent/util/iptables/iptables.go
@@ -38,6 +38,7 @@ const (
 	MasqueradeTarget = "MASQUERADE"
 	MarkTarget       = "MARK"
 	ConnTrackTarget  = "CT"
+	DNATTarget       = "DNAT"
 	NoTrackTarget    = "NOTRACK"
 
 	PreRoutingChain  = "PREROUTING"
@@ -122,8 +123,9 @@ func (c *Client) ChainExists(table string, chain string) (bool, error) {
 	return false, nil
 }
 
-// EnsureRule checks if target rule already exists, appends it if not.
-func (c *Client) EnsureRule(table string, chain string, ruleSpec []string) error {
+// EnsureRule checks if target rule already exists, add it if not. If prepend is true, the rule will be added to the top
+// of the chain. Otherwise, the rule will be appended to the chain.
+func (c *Client) EnsureRule(table string, chain string, ruleSpec []string, prepend bool) error {
 	for idx := range c.ipts {
 		ipt := c.ipts[idx]
 		exist, err := ipt.Exists(table, chain, ruleSpec...)
@@ -133,7 +135,13 @@ func (c *Client) EnsureRule(table string, chain string, ruleSpec []string) error
 		if exist {
 			return nil
 		}
-		if err := ipt.Append(table, chain, ruleSpec...); err != nil {
+		var f func() error
+		if !prepend {
+			f = func() error { return ipt.Append(table, chain, ruleSpec...) }
+		} else {
+			f = func() error { return ipt.Insert(table, chain, 1, ruleSpec...) }
+		}
+		if err := f(); err != nil {
 			return fmt.Errorf("error appending rule %v to table %s chain %s: %v", ruleSpec, table, chain, err)
 		}
 	}

--- a/pkg/features/antrea_features.go
+++ b/pkg/features/antrea_features.go
@@ -45,6 +45,10 @@ const (
 	// Service traffic.
 	AntreaProxy featuregate.Feature = "AntreaProxy"
 
+	// alpha: v0.14
+	// Enable NodePort Service support in AntreaProxy in antrea-agent.
+	AntreaProxyNodePort featuregate.Feature = "AntreaProxyNodePort"
+
 	// alpha: v0.8
 	// beta: v0.11
 	// Allows to trace path from a generated packet.
@@ -75,13 +79,14 @@ var (
 	// To add a new feature, define a key for it above and add it here. The features will be
 	// available throughout Antrea binaries.
 	defaultAntreaFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-		AntreaPolicy:       {Default: false, PreRelease: featuregate.Alpha},
-		AntreaProxy:        {Default: true, PreRelease: featuregate.Beta},
-		EndpointSlice:      {Default: false, PreRelease: featuregate.Alpha},
-		Traceflow:          {Default: true, PreRelease: featuregate.Beta},
-		FlowExporter:       {Default: false, PreRelease: featuregate.Alpha},
-		NetworkPolicyStats: {Default: false, PreRelease: featuregate.Alpha},
-		NodePortLocal:      {Default: false, PreRelease: featuregate.Alpha},
+		AntreaPolicy:        {Default: false, PreRelease: featuregate.Alpha},
+		AntreaProxy:         {Default: true, PreRelease: featuregate.Beta},
+		EndpointSlice:       {Default: false, PreRelease: featuregate.Alpha},
+		AntreaProxyNodePort: {Default: false, PreRelease: featuregate.Alpha},
+		Traceflow:           {Default: true, PreRelease: featuregate.Beta},
+		FlowExporter:        {Default: false, PreRelease: featuregate.Alpha},
+		NetworkPolicyStats:  {Default: false, PreRelease: featuregate.Alpha},
+		NodePortLocal:       {Default: false, PreRelease: featuregate.Alpha},
 	}
 
 	// UnsupportedFeaturesOnWindows records the features not supported on
@@ -95,7 +100,8 @@ var (
 	// can have different FeatureSpecs between Linux and Windows, we should
 	// still define a separate defaultAntreaFeatureGates map for Windows.
 	unsupportedFeaturesOnWindows = map[featuregate.Feature]struct{}{
-		NodePortLocal: {},
+		AntreaProxyNodePort: {},
+		NodePortLocal:       {},
 	}
 )
 

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -24,11 +24,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/apiserver/handlers/podinterface"
 	"github.com/vmware-tanzu/antrea/pkg/agent/config"
 	"github.com/vmware-tanzu/antrea/pkg/agent/openflow/cookie"
+	"github.com/vmware-tanzu/antrea/pkg/features"
 )
 
 // TestDeploy is a "no-op" test that simply performs setup and teardown.
@@ -351,7 +353,11 @@ func testReconcileGatewayRoutesOnStartup(t *testing.T, data *TestData, isIPv6 bo
 				continue
 			}
 			route := Route{}
-			if _, route.peerPodCIDR, err = net.ParseCIDR(matches[1]); err != nil {
+			m1 := matches[1]
+			if !strings.Contains(m1, "/") {
+				m1 = m1 + "/32"
+			}
+			if _, route.peerPodCIDR, err = net.ParseCIDR(m1); err != nil {
 				return nil, fmt.Errorf("%s is not a valid net CIDR", matches[1])
 			}
 			if route.peerPodGW = net.ParseIP(matches[2]); route.peerPodGW == nil {
@@ -368,6 +374,12 @@ func testReconcileGatewayRoutesOnStartup(t *testing.T, data *TestData, isIPv6 bo
 
 	} else if encapMode == config.TrafficEncapModeHybrid {
 		expectedRtNumMin = 1
+	}
+	agentFeatures, err := data.GetAgentFeatures(antreaNamespace)
+	require.NoError(t, err)
+	if agentFeatures.Enabled(features.AntreaProxy) && agentFeatures.Enabled(features.AntreaProxyNodePort) {
+		expectedRtNumMin += 1
+		expectedRtNumMax += 1
 	}
 
 	t.Logf("Retrieving gateway routes on Node '%s'", nodeName)

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -1233,6 +1233,11 @@ func (data *TestData) createNginxClusterIPService(name string, affinity bool, ip
 	return data.createService(name, 80, 80, map[string]string{"app": "nginx"}, affinity, corev1.ServiceTypeClusterIP, ipFamily)
 }
 
+// createNginxNodePortService create a NodePort nginx service with the given name.
+func (data *TestData) createNginxNodePortService(affinity bool, ipFamily *corev1.IPFamily) (*corev1.Service, error) {
+	return data.createService("nginx", 80, 80, map[string]string{"app": "nginx"}, affinity, corev1.ServiceTypeNodePort, ipFamily)
+}
+
 func (data *TestData) createNginxLoadBalancerService(affinity bool, ingressIPs []string, ipFamily *corev1.IPFamily) (*corev1.Service, error) {
 	svc, err := data.createService(nginxLBService, 80, 80, map[string]string{"app": "nginx"}, affinity, corev1.ServiceTypeLoadBalancer, ipFamily)
 	if err != nil {

--- a/test/integration/agent/openflow_test.go
+++ b/test/integration/agent/openflow_test.go
@@ -108,7 +108,7 @@ func TestConnectivityFlows(t *testing.T) {
 		antrearuntime.WindowsOS = runtime.GOOS
 	}
 
-	c = ofClient.NewClient(br, bridgeMgmtAddr, ovsconfig.OVSDatapathNetdev, true, false)
+	c = ofClient.NewClient(br, bridgeMgmtAddr, ovsconfig.OVSDatapathNetdev, net.ParseIP("169.254.169.110"), nil, true, false)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge: %v", err))
 	defer func() {
@@ -135,7 +135,7 @@ func TestConnectivityFlows(t *testing.T) {
 }
 
 func TestReplayFlowsConnectivityFlows(t *testing.T) {
-	c = ofClient.NewClient(br, bridgeMgmtAddr, ovsconfig.OVSDatapathNetdev, true, false)
+	c = ofClient.NewClient(br, bridgeMgmtAddr, ovsconfig.OVSDatapathNetdev, net.ParseIP("169.254.169.110"), nil, true, false)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge: %v", err))
 
@@ -162,7 +162,7 @@ func TestReplayFlowsConnectivityFlows(t *testing.T) {
 }
 
 func TestReplayFlowsNetworkPolicyFlows(t *testing.T) {
-	c = ofClient.NewClient(br, bridgeMgmtAddr, ovsconfig.OVSDatapathNetdev, true, false)
+	c = ofClient.NewClient(br, bridgeMgmtAddr, ovsconfig.OVSDatapathNetdev, net.ParseIP("169.254.169.110"), nil, true, false)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge: %v", err))
 
@@ -335,7 +335,7 @@ func TestNetworkPolicyFlows(t *testing.T) {
 	// Initialize ovs metrics (Prometheus) to test them
 	metrics.InitializeOVSMetrics()
 
-	c = ofClient.NewClient(br, bridgeMgmtAddr, ovsconfig.OVSDatapathNetdev, true, false)
+	c = ofClient.NewClient(br, bridgeMgmtAddr, ovsconfig.OVSDatapathNetdev, net.ParseIP("169.254.169.110"), nil, true, false)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge %s", br))
 
@@ -445,7 +445,7 @@ func TestIPv6ConnectivityFlows(t *testing.T) {
 	// Initialize ovs metrics (Prometheus) to test them
 	metrics.InitializeOVSMetrics()
 
-	c = ofClient.NewClient(br, bridgeMgmtAddr, ovsconfig.OVSDatapathNetdev, true, false)
+	c = ofClient.NewClient(br, bridgeMgmtAddr, ovsconfig.OVSDatapathNetdev, nil, nil, true, false)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge: %v", err))
 
@@ -476,7 +476,7 @@ type svcConfig struct {
 }
 
 func TestProxyServiceFlows(t *testing.T) {
-	c = ofClient.NewClient(br, bridgeMgmtAddr, ovsconfig.OVSDatapathNetdev, true, false)
+	c = ofClient.NewClient(br, bridgeMgmtAddr, ovsconfig.OVSDatapathNetdev, net.ParseIP("169.254.169.110"), nil, true, false)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge %s", br))
 

--- a/test/integration/agent/route_test.go
+++ b/test/integration/agent/route_test.go
@@ -137,7 +137,7 @@ func TestInitialize(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Logf("Running Initialize test with mode %s node config %s", tc.networkConfig.TrafficEncapMode, nodeConfig)
-		routeClient, err := route.NewClient(serviceCIDR, tc.networkConfig, tc.noSNAT)
+		routeClient, err := route.NewClient(net.ParseIP("169.254.169.110"), nil, serviceCIDR, tc.networkConfig, tc.noSNAT, false)
 		assert.NoError(t, err)
 
 		var xtablesReleasedTime, initializedTime time.Time
@@ -241,7 +241,7 @@ func TestIpTablesSync(t *testing.T) {
 	gwLink := createDummyGW(t)
 	defer netlink.LinkDel(gwLink)
 
-	routeClient, err := route.NewClient(serviceCIDR, &config.NetworkConfig{TrafficEncapMode: config.TrafficEncapModeEncap}, false)
+	routeClient, err := route.NewClient(nil, nil, serviceCIDR, &config.NetworkConfig{TrafficEncapMode: config.TrafficEncapModeEncap}, false, false)
 	assert.Nil(t, err)
 
 	inited := make(chan struct{})
@@ -304,7 +304,7 @@ func TestAddAndDeleteRoutes(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Logf("Running test with mode %s peer cidr %s peer ip %s node config %s", tc.mode, tc.peerCIDR, tc.peerIP, nodeConfig)
-		routeClient, err := route.NewClient(serviceCIDR, &config.NetworkConfig{TrafficEncapMode: tc.mode}, false)
+		routeClient, err := route.NewClient(net.ParseIP("169.254.169.110"), nil, serviceCIDR, &config.NetworkConfig{TrafficEncapMode: tc.mode}, false, false)
 		assert.NoError(t, err)
 		err = routeClient.Initialize(nodeConfig, func() {})
 		assert.NoError(t, err)
@@ -400,7 +400,7 @@ func TestReconcile(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Logf("Running test with mode %s added routes %v desired routes %v", tc.mode, tc.addedRoutes, tc.desiredPeerCIDRs)
-		routeClient, err := route.NewClient(serviceCIDR, &config.NetworkConfig{TrafficEncapMode: tc.mode}, false)
+		routeClient, err := route.NewClient(net.ParseIP("169.254.169.110"), nil, serviceCIDR, &config.NetworkConfig{TrafficEncapMode: tc.mode}, false, false)
 		assert.NoError(t, err)
 		err = routeClient.Initialize(nodeConfig, func() {})
 		assert.NoError(t, err)
@@ -438,9 +438,9 @@ func TestRouteTablePolicyOnly(t *testing.T) {
 	gwLink := createDummyGW(t)
 	defer netlink.LinkDel(gwLink)
 
-	routeClient, err := route.NewClient(serviceCIDR, &config.NetworkConfig{TrafficEncapMode: config.TrafficEncapModeNetworkPolicyOnly}, false)
+	routeClient, err := route.NewClient(net.ParseIP("169.254.169.110"), nil, serviceCIDR, &config.NetworkConfig{TrafficEncapMode: config.TrafficEncapModeNetworkPolicyOnly}, false, false)
 	assert.NoError(t, err)
-	err = routeClient.Initialize(nodeConfig, func() {})
+	routeClient.Initialize(nodeConfig, func() {})
 	assert.NoError(t, err)
 	// Verify gw IP
 	gwName := nodeConfig.GatewayConfig.Name
@@ -497,7 +497,7 @@ func TestIPv6RoutesAndNeighbors(t *testing.T) {
 	gwLink := createDummyGW(t)
 	defer netlink.LinkDel(gwLink)
 
-	routeClient, err := route.NewClient(serviceCIDR, &config.NetworkConfig{TrafficEncapMode: config.TrafficEncapModeEncap}, false)
+	routeClient, err := route.NewClient(nil, nil, serviceCIDR, &config.NetworkConfig{TrafficEncapMode: config.TrafficEncapModeEncap}, false, false)
 	assert.Nil(t, err)
 	_, ipv6Subnet, _ := net.ParseCIDR("fd74:ca9b:172:19::/64")
 	gwIPv6 := net.ParseIP("fd74:ca9b:172:19::1")


### PR DESCRIPTION
Note: To verify this PR, the NodePort support is enabled. The feature gate should be disabled before merging this PR.
Resolves #1463.
Signed-off-by: Weiqiang Tang <weiqiangt@vmware.com>