### PR TITLE
Use NodeIPAMController code from K8S

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Antrea has been tested with Kubernetes clusters running version 1.16 or later.
 * `NodeIPAMController` must be enabled in the Kubernetes cluster.\
   When deploying a cluster with kubeadm the `--pod-network-cidr <cidr>`
   option must be specified.
+  Alternately, NodeIPAM feature of Antrea Controller should be enabled and
+  configured.
 * Open vSwitch kernel module must be present on every Kubernetes node.
 
 ## Getting Started

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -3420,7 +3420,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - nodes
   - pods
   - namespaces
   - services
@@ -3429,6 +3428,15 @@ rules:
   - get
   - watch
   - list
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - watch
+  - list
+  - patch
 - apiGroups:
   - networking.k8s.io
   resources:
@@ -3952,6 +3960,9 @@ data:
     # Enable controlling SNAT IPs of Pod egress traffic.
     #  Egress: false
 
+    # Run Kubernetes NodeIPAMController with Antrea.
+    #  NodeIPAM: false
+
     # The port for the antrea-controller APIServer to serve on.
     # Note that if it's set to another value, the `containerPort` of the `api` port of the
     # `antrea-controller` container must be set to the same value.
@@ -3991,12 +4002,33 @@ data:
     # API groups. After adding the annotation, legacy CRDs can be deleted safely without impacting
     # new CRDs.
     #legacyCRDMirroring: true
+
+    nodeIPAM:
+    # Enable the integrated Node IPAM controller within the Antrea controller.
+    #  enableNodeIPAM: false
+
+    # CIDR Ranges for Pods in cluster. Value can contain a single CIDR range, or multiple ranges, separated by commas.
+    # The CIDRs could be either IPv4 or IPv6. Value ignored when enableNodeIPAM is false.
+    #  clusterCIDRs:
+
+    # CIDR Ranges for Services in cluster. It is not necessary to specify it when there is no overlap with clusterCIDRs.
+    # Value ignored when enableNodeIPAM is false.
+    #  serviceCIDR:
+    #  secondaryServiceCIDR:
+
+    # Mask size for IPv4 Node CIDR in IPv4 or dual-stack cluster. Value ignored when enableNodeIPAM is false
+    # or when IPv4 Pod CIDR is not configured. Valid range is 16 to 30.
+    #  nodeCIDRMaskSizeIPv4: 24
+
+    # Mask size for IPv6 Node CIDR in IPv6 or dual-stack cluster. Value ignored when enableNodeIPAM is false
+    # or when IPv6 Pod CIDR is not configured. Valid range is 64 to 126.
+    #  nodeCIDRMaskSizeIPv6: 64
 kind: ConfigMap
 metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-99c875tk88
+  name: antrea-config-886tmkcf7h
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4067,7 +4099,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-99c875tk88
+          value: antrea-config-886tmkcf7h
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4118,7 +4150,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-99c875tk88
+          name: antrea-config-886tmkcf7h
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4399,7 +4431,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-99c875tk88
+          name: antrea-config-886tmkcf7h
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -3420,7 +3420,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - nodes
   - pods
   - namespaces
   - services
@@ -3429,6 +3428,15 @@ rules:
   - get
   - watch
   - list
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - watch
+  - list
+  - patch
 - apiGroups:
   - networking.k8s.io
   resources:
@@ -3952,6 +3960,9 @@ data:
     # Enable controlling SNAT IPs of Pod egress traffic.
     #  Egress: false
 
+    # Run Kubernetes NodeIPAMController with Antrea.
+    #  NodeIPAM: false
+
     # The port for the antrea-controller APIServer to serve on.
     # Note that if it's set to another value, the `containerPort` of the `api` port of the
     # `antrea-controller` container must be set to the same value.
@@ -3991,12 +4002,33 @@ data:
     # API groups. After adding the annotation, legacy CRDs can be deleted safely without impacting
     # new CRDs.
     #legacyCRDMirroring: true
+
+    nodeIPAM:
+    # Enable the integrated Node IPAM controller within the Antrea controller.
+    #  enableNodeIPAM: false
+
+    # CIDR Ranges for Pods in cluster. Value can contain a single CIDR range, or multiple ranges, separated by commas.
+    # The CIDRs could be either IPv4 or IPv6. Value ignored when enableNodeIPAM is false.
+    #  clusterCIDRs:
+
+    # CIDR Ranges for Services in cluster. It is not necessary to specify it when there is no overlap with clusterCIDRs.
+    # Value ignored when enableNodeIPAM is false.
+    #  serviceCIDR:
+    #  secondaryServiceCIDR:
+
+    # Mask size for IPv4 Node CIDR in IPv4 or dual-stack cluster. Value ignored when enableNodeIPAM is false
+    # or when IPv4 Pod CIDR is not configured. Valid range is 16 to 30.
+    #  nodeCIDRMaskSizeIPv4: 24
+
+    # Mask size for IPv6 Node CIDR in IPv6 or dual-stack cluster. Value ignored when enableNodeIPAM is false
+    # or when IPv6 Pod CIDR is not configured. Valid range is 64 to 126.
+    #  nodeCIDRMaskSizeIPv6: 64
 kind: ConfigMap
 metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-99c875tk88
+  name: antrea-config-886tmkcf7h
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4067,7 +4099,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-99c875tk88
+          value: antrea-config-886tmkcf7h
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4118,7 +4150,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-99c875tk88
+          name: antrea-config-886tmkcf7h
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4401,7 +4433,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-99c875tk88
+          name: antrea-config-886tmkcf7h
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -3420,7 +3420,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - nodes
   - pods
   - namespaces
   - services
@@ -3429,6 +3428,15 @@ rules:
   - get
   - watch
   - list
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - watch
+  - list
+  - patch
 - apiGroups:
   - networking.k8s.io
   resources:
@@ -3952,6 +3960,9 @@ data:
     # Enable controlling SNAT IPs of Pod egress traffic.
     #  Egress: false
 
+    # Run Kubernetes NodeIPAMController with Antrea.
+    #  NodeIPAM: false
+
     # The port for the antrea-controller APIServer to serve on.
     # Note that if it's set to another value, the `containerPort` of the `api` port of the
     # `antrea-controller` container must be set to the same value.
@@ -3991,12 +4002,33 @@ data:
     # API groups. After adding the annotation, legacy CRDs can be deleted safely without impacting
     # new CRDs.
     #legacyCRDMirroring: true
+
+    nodeIPAM:
+    # Enable the integrated Node IPAM controller within the Antrea controller.
+    #  enableNodeIPAM: false
+
+    # CIDR Ranges for Pods in cluster. Value can contain a single CIDR range, or multiple ranges, separated by commas.
+    # The CIDRs could be either IPv4 or IPv6. Value ignored when enableNodeIPAM is false.
+    #  clusterCIDRs:
+
+    # CIDR Ranges for Services in cluster. It is not necessary to specify it when there is no overlap with clusterCIDRs.
+    # Value ignored when enableNodeIPAM is false.
+    #  serviceCIDR:
+    #  secondaryServiceCIDR:
+
+    # Mask size for IPv4 Node CIDR in IPv4 or dual-stack cluster. Value ignored when enableNodeIPAM is false
+    # or when IPv4 Pod CIDR is not configured. Valid range is 16 to 30.
+    #  nodeCIDRMaskSizeIPv4: 24
+
+    # Mask size for IPv6 Node CIDR in IPv6 or dual-stack cluster. Value ignored when enableNodeIPAM is false
+    # or when IPv6 Pod CIDR is not configured. Valid range is 64 to 126.
+    #  nodeCIDRMaskSizeIPv6: 64
 kind: ConfigMap
 metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-dbmkcb65c8
+  name: antrea-config-7b5cffbt26
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4067,7 +4099,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-dbmkcb65c8
+          value: antrea-config-7b5cffbt26
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4118,7 +4150,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-dbmkcb65c8
+          name: antrea-config-7b5cffbt26
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4402,7 +4434,7 @@ spec:
           path: /home/kubernetes/bin
         name: host-cni-bin
       - configMap:
-          name: antrea-config-dbmkcb65c8
+          name: antrea-config-7b5cffbt26
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -3420,7 +3420,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - nodes
   - pods
   - namespaces
   - services
@@ -3429,6 +3428,15 @@ rules:
   - get
   - watch
   - list
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - watch
+  - list
+  - patch
 - apiGroups:
   - networking.k8s.io
   resources:
@@ -3957,6 +3965,9 @@ data:
     # Enable controlling SNAT IPs of Pod egress traffic.
     #  Egress: false
 
+    # Run Kubernetes NodeIPAMController with Antrea.
+    #  NodeIPAM: false
+
     # The port for the antrea-controller APIServer to serve on.
     # Note that if it's set to another value, the `containerPort` of the `api` port of the
     # `antrea-controller` container must be set to the same value.
@@ -3996,12 +4007,33 @@ data:
     # API groups. After adding the annotation, legacy CRDs can be deleted safely without impacting
     # new CRDs.
     #legacyCRDMirroring: true
+
+    nodeIPAM:
+    # Enable the integrated Node IPAM controller within the Antrea controller.
+    #  enableNodeIPAM: false
+
+    # CIDR Ranges for Pods in cluster. Value can contain a single CIDR range, or multiple ranges, separated by commas.
+    # The CIDRs could be either IPv4 or IPv6. Value ignored when enableNodeIPAM is false.
+    #  clusterCIDRs:
+
+    # CIDR Ranges for Services in cluster. It is not necessary to specify it when there is no overlap with clusterCIDRs.
+    # Value ignored when enableNodeIPAM is false.
+    #  serviceCIDR:
+    #  secondaryServiceCIDR:
+
+    # Mask size for IPv4 Node CIDR in IPv4 or dual-stack cluster. Value ignored when enableNodeIPAM is false
+    # or when IPv4 Pod CIDR is not configured. Valid range is 16 to 30.
+    #  nodeCIDRMaskSizeIPv4: 24
+
+    # Mask size for IPv6 Node CIDR in IPv6 or dual-stack cluster. Value ignored when enableNodeIPAM is false
+    # or when IPv6 Pod CIDR is not configured. Valid range is 64 to 126.
+    #  nodeCIDRMaskSizeIPv6: 64
 kind: ConfigMap
 metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-tthkbhb7k5
+  name: antrea-config-ct4b8f8t4h
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4081,7 +4113,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-tthkbhb7k5
+          value: antrea-config-ct4b8f8t4h
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4132,7 +4164,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-tthkbhb7k5
+          name: antrea-config-ct4b8f8t4h
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4448,7 +4480,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-tthkbhb7k5
+          name: antrea-config-ct4b8f8t4h
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -3420,7 +3420,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - nodes
   - pods
   - namespaces
   - services
@@ -3429,6 +3428,15 @@ rules:
   - get
   - watch
   - list
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - watch
+  - list
+  - patch
 - apiGroups:
   - networking.k8s.io
   resources:
@@ -3957,6 +3965,9 @@ data:
     # Enable controlling SNAT IPs of Pod egress traffic.
     #  Egress: false
 
+    # Run Kubernetes NodeIPAMController with Antrea.
+    #  NodeIPAM: false
+
     # The port for the antrea-controller APIServer to serve on.
     # Note that if it's set to another value, the `containerPort` of the `api` port of the
     # `antrea-controller` container must be set to the same value.
@@ -3996,12 +4007,33 @@ data:
     # API groups. After adding the annotation, legacy CRDs can be deleted safely without impacting
     # new CRDs.
     #legacyCRDMirroring: true
+
+    nodeIPAM:
+    # Enable the integrated Node IPAM controller within the Antrea controller.
+    #  enableNodeIPAM: false
+
+    # CIDR Ranges for Pods in cluster. Value can contain a single CIDR range, or multiple ranges, separated by commas.
+    # The CIDRs could be either IPv4 or IPv6. Value ignored when enableNodeIPAM is false.
+    #  clusterCIDRs:
+
+    # CIDR Ranges for Services in cluster. It is not necessary to specify it when there is no overlap with clusterCIDRs.
+    # Value ignored when enableNodeIPAM is false.
+    #  serviceCIDR:
+    #  secondaryServiceCIDR:
+
+    # Mask size for IPv4 Node CIDR in IPv4 or dual-stack cluster. Value ignored when enableNodeIPAM is false
+    # or when IPv4 Pod CIDR is not configured. Valid range is 16 to 30.
+    #  nodeCIDRMaskSizeIPv4: 24
+
+    # Mask size for IPv6 Node CIDR in IPv6 or dual-stack cluster. Value ignored when enableNodeIPAM is false
+    # or when IPv6 Pod CIDR is not configured. Valid range is 64 to 126.
+    #  nodeCIDRMaskSizeIPv6: 64
 kind: ConfigMap
 metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-mc8h75hbgg
+  name: antrea-config-fhh5d26dg8
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4072,7 +4104,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-mc8h75hbgg
+          value: antrea-config-fhh5d26dg8
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4123,7 +4155,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-mc8h75hbgg
+          name: antrea-config-fhh5d26dg8
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4404,7 +4436,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-mc8h75hbgg
+          name: antrea-config-fhh5d26dg8
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/base/conf/antrea-controller.conf
+++ b/build/yamls/base/conf/antrea-controller.conf
@@ -14,6 +14,9 @@ featureGates:
 # Enable controlling SNAT IPs of Pod egress traffic.
 #  Egress: false
 
+# Run Kubernetes NodeIPAMController with Antrea.
+#  NodeIPAM: false
+
 # The port for the antrea-controller APIServer to serve on.
 # Note that if it's set to another value, the `containerPort` of the `api` port of the
 # `antrea-controller` container must be set to the same value.
@@ -53,3 +56,24 @@ featureGates:
 # API groups. After adding the annotation, legacy CRDs can be deleted safely without impacting
 # new CRDs.
 #legacyCRDMirroring: true
+
+nodeIPAM:
+# Enable the integrated Node IPAM controller within the Antrea controller.
+#  enableNodeIPAM: false
+
+# CIDR Ranges for Pods in cluster. Value can contain a single CIDR range, or multiple ranges, separated by commas.
+# The CIDRs could be either IPv4 or IPv6. Value ignored when enableNodeIPAM is false.
+#  clusterCIDRs:
+
+# CIDR Ranges for Services in cluster. It is not necessary to specify it when there is no overlap with clusterCIDRs.
+# Value ignored when enableNodeIPAM is false.
+#  serviceCIDR:
+#  secondaryServiceCIDR:
+
+# Mask size for IPv4 Node CIDR in IPv4 or dual-stack cluster. Value ignored when enableNodeIPAM is false
+# or when IPv4 Pod CIDR is not configured. Valid range is 16 to 30.
+#  nodeCIDRMaskSizeIPv4: 24
+
+# Mask size for IPv6 Node CIDR in IPv6 or dual-stack cluster. Value ignored when enableNodeIPAM is false
+# or when IPv6 Pod CIDR is not configured. Valid range is 64 to 126.
+#  nodeCIDRMaskSizeIPv6: 64

--- a/build/yamls/base/controller-rbac.yml
+++ b/build/yamls/base/controller-rbac.yml
@@ -13,7 +13,6 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - nodes
       - pods
       - namespaces
       - services
@@ -22,6 +21,15 @@ rules:
       - get
       - watch
       - list
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - watch
+      - list
+      - patch
   - apiGroups:
       - networking.k8s.io
     resources:

--- a/cmd/antrea-controller/config.go
+++ b/cmd/antrea-controller/config.go
@@ -18,6 +18,25 @@ import (
 	componentbaseconfig "k8s.io/component-base/config"
 )
 
+type NodeIPAMConfig struct {
+	// Enable the integrated node IPAM controller within the Antrea controller.
+	// Defaults to false.
+	EnableNodeIPAM bool `yaml:"enableNodeIPAM,omitempty"`
+	// CIDR Ranges for Pods in cluster. Value can contain a single CIDR range, or multiple ranges, separated by commas.
+	// The CIDRs could be either IPv4 or IPv6. Value ignored when EnableNodeIPAM is false.
+	ClusterCIDRs string `yaml:"clusterCIDRs,omitempty"`
+	// CIDR Ranges for Services in cluster. It is not necessary to specify it when there is no overlap with clusterCIDRs.
+	// Value ignored when EnableNodeIPAM is false.
+	ServiceCIDR          string `yaml:"serviceCIDR,omitempty"`
+	SecondaryServiceCIDR string `yaml:"secondaryServiceCIDR,omitempty"`
+	// Mask size for IPv4 Node CIDR in IPv4 or dual-stack cluster. Value ignored when EnableNodeIPAM is false
+	// or when IPv4 Pod CIDR is not configured.
+	NodeCIDRMaskSizeIPv4 int `yaml:"nodeCIDRMaskSizeIPv4,omitempty"`
+	// Mask size for IPv6 Node CIDR in IPv6 or dual-stack cluster. Value ignored when EnableNodeIPAM is false
+	// or when IPv6 Pod CIDR is not configured.
+	NodeCIDRMaskSizeIPv6 int `yaml:"nodeCIDRMaskSizeIPv6,omitempty"`
+}
+
 type ControllerConfig struct {
 	// FeatureGates is a map of feature names to bools that enable or disable experimental features.
 	FeatureGates map[string]bool `yaml:"featureGates,omitempty"`
@@ -45,4 +64,6 @@ type ControllerConfig struct {
 	TLSMinVersion string `yaml:"tlsMinVersion,omitempty"`
 	// Legacy CRD mirroring.
 	LegacyCRDMirroring bool `yaml:"legacyCRDMirroring,omitempty"`
+	// NodeIPAM Configuration
+	NodeIPAM NodeIPAMConfig `yaml:"nodeIPAM"`
 }

--- a/docs/feature-gates.md
+++ b/docs/feature-gates.md
@@ -43,6 +43,7 @@ example, to enable `AntreaProxy` on Linux, edit the Agent configuration in the
 | `NetworkPolicyStats`    | Agent + Controller | `true`  | Beta  | v0.10         | v1.2         | N/A        | No                 |       |
 | `NodePortLocal`         | Agent              | `false` | Alpha | v0.13         | N/A          | N/A        | Yes                |       |
 | `Egress`                | Agent + Controller | `false` | Alpha | v1.0          | N/A          | N/A        | Yes                |       |
+| `NodeIPAM`              | Controller         | `false` | Alpha | v1.4          | N/A          | N/A        | Yes                |       |
 
 ## Description and Requirements of Features
 
@@ -209,3 +210,16 @@ Refer to this [document](egress.md) for more information.
 This feature is currently only supported for Nodes running Linux and "encap"
 mode. The support for Windows and other traffic modes will be added in the
 future.
+
+### NodeIPAM
+
+`NodeIPAM` runs a Node IPAM Controller similar to the one in Kubernetes that
+allocates Pod CIDRs for Nodes.  Running Node IPAM Controller with Antrea is
+useful in environments where Kubernetes Controller Manager does not run the
+Node IPAM Controller, and Antrea has to handle the CIDR allocation.
+
+#### Requirements for this Feature
+
+This feature requires the Node IPAM Controller to be disabled in Kubernetes
+Controller Manager. When Antrea and Kubernetes both run Node IPAM Controller
+there is a risk of conflicts in CIDR allocation between the two.

--- a/pkg/apiserver/handlers/featuregates/handler.go
+++ b/pkg/apiserver/handlers/featuregates/handler.go
@@ -29,7 +29,8 @@ import (
 	"antrea.io/antrea/pkg/util/env"
 )
 
-var controllerOnlyGates = sets.NewString("Traceflow", "AntreaPolicy", "Egress", "NetworkPolicyStats")
+var controllerGates = sets.NewString("Traceflow", "AntreaPolicy", "Egress", "NetworkPolicyStats", "NodeIPAM")
+var agentGates = sets.NewString("AntreaPolicy", "AntreaProxy", "Egress", "EndpointSlice", "Traceflow", "FlowExporter", "NetworkPolicyStats", "NodePortLocal")
 
 type (
 	Config struct {
@@ -88,6 +89,9 @@ func getAgentGatesResponse(cfg *Config) []Response {
 	gatesResp := []Response{}
 	for df := range features.DefaultAntreaFeatureGates {
 		dfs := string(df)
+		if !agentGates.Has(dfs) {
+			continue
+		}
 		status, ok := cfg.FeatureGates[dfs]
 		if !ok {
 			status = features.DefaultMutableFeatureGate.Enabled(df)
@@ -107,7 +111,7 @@ func getControllerGatesResponse() []Response {
 	gatesResp := []Response{}
 	for df := range features.DefaultAntreaFeatureGates {
 		dfs := string(df)
-		if !controllerOnlyGates.Has(dfs) {
+		if !controllerGates.Has(dfs) {
 			continue
 		}
 		gatesResp = append(gatesResp, Response{

--- a/pkg/apiserver/handlers/featuregates/handler_test.go
+++ b/pkg/apiserver/handlers/featuregates/handler_test.go
@@ -137,6 +137,7 @@ func TestHandleFunc(t *testing.T) {
 				{Component: "controller", Name: "Egress", Status: "Disabled", Version: "ALPHA"},
 				{Component: "controller", Name: "Traceflow", Status: "Enabled", Version: "BETA"},
 				{Component: "controller", Name: "NetworkPolicyStats", Status: "Enabled", Version: "BETA"},
+				{Component: "controller", Name: "NodeIPAM", Status: "Disabled", Version: "ALPHA"},
 				{Component: "agent", Name: "AntreaPolicy", Status: "Enabled", Version: "BETA"},
 				{Component: "agent", Name: "AntreaProxy", Status: "Enabled", Version: "BETA"},
 				{Component: "agent", Name: "Egress", Status: "Disabled", Version: "ALPHA"},
@@ -188,6 +189,7 @@ func Test_getControllerGatesResponse(t *testing.T) {
 				{Component: "controller", Name: "Egress", Status: "Disabled", Version: "ALPHA"},
 				{Component: "controller", Name: "Traceflow", Status: "Enabled", Version: "BETA"},
 				{Component: "controller", Name: "NetworkPolicyStats", Status: "Enabled", Version: "BETA"},
+				{Component: "controller", Name: "NodeIPAM", Status: "Disabled", Version: "ALPHA"},
 			},
 		},
 	}

--- a/pkg/features/antrea_features.go
+++ b/pkg/features/antrea_features.go
@@ -67,6 +67,10 @@ const (
 	// alpha: v1.0
 	// Enable controlling SNAT IPs of Pod egress traffic.
 	Egress featuregate.Feature = "Egress"
+
+	// alpha: v1.4
+	// Run Kubernetes NodeIPAM with Antrea.
+	NodeIPAM featuregate.Feature = "NodeIPAM"
 )
 
 var (
@@ -89,6 +93,7 @@ var (
 		FlowExporter:       {Default: false, PreRelease: featuregate.Alpha},
 		NetworkPolicyStats: {Default: true, PreRelease: featuregate.Beta},
 		NodePortLocal:      {Default: false, PreRelease: featuregate.Alpha},
+		NodeIPAM:           {Default: false, PreRelease: featuregate.Alpha},
 	}
 
 	// UnsupportedFeaturesOnWindows records the features not supported on

--- a/third_party/ipam/LICENSE
+++ b/third_party/ipam/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/third_party/ipam/README
+++ b/third_party/ipam/README
@@ -1,0 +1,9 @@
+Packages below have been copied from [k8s.io/kubernetes@/v1.21.1](https://github.com/kubernetes/kubernetes/tree/v1.21.1) to avoid importing the whole kubernetes repo:
+
+k8s.io/kubernetes/pkg/controller/util/node/controller_utils.go -> antrea.io/antrea/third_party/ipam/controller_util_node.go
+k8s.io/kubernetes/pkg/controller/nodeipam/ipam/cidrset/cidr_set.go -> antrea.io/antrea/third_party/ipam/nodeipam/ipam/cidrset/cidr_set.go
+k8s.io/kubernetes/pkg/controller/nodeipam/ipam/cidrset/metrics.go -> antrea.io/antrea/third_party/ipam/nodeipam/ipam/cidrset/metrics.go
+k8s.io/kubernetes/pkg/controller/nodeipam/ipam/cidr_allocator.go -> antrea.io/antrea/third_party/nodeipam/ipam/cidr_allocator.go
+k8s.io/kubernetes/pkg/controller/nodeipam/ipam/range_allocator.go -> antrea.io/antrea/third_party/ipam/nodeipam/ipam/range_allocator.go
+k8s.io/kubernetes/pkg/controller/nodeipam/node_ipam_controller.go -> antrea.io/antrea/third_party/ipam/nodeipam/node_ipam_controller.go
+k8s.io/kubernetes/pkg/util/node/node.go -> antrea.io/antrea/third_party/ipam/util_node/node.go

--- a/third_party/ipam/controller_util_node/controller_utils.go
+++ b/third_party/ipam/controller_util_node/controller_utils.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+/*
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+Modifies:
+- Relocate imports to antrea.io/third_party
+- Cleanup unused imports due to code removal and relocation
+- Remove the following unused funcs to avoid additional code imports:
+	RecordNodeEvent()
+	DeletePods()
+	SetPodTerminationReason()
+	MarkPodsNotReady()
+	SwapNodeControllerTaint()
+	AddOrUpdateLabelsOnNode()
+    GetNodeCondition()
+ - In RecordNodeStatusChange(): Remove recorder parameter, remove ref initialization and comment out recorder.Eventf
+   call
+*/
+
+package node
+
+import (
+	"fmt"
+
+	"k8s.io/api/core/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/tools/cache"
+
+	"k8s.io/klog/v2"
+)
+
+// RecordNodeStatusChange records a event related to a node status change. (Common to lifecycle and ipam)
+func RecordNodeStatusChange(/*recorder record.EventRecorder,*/ node *v1.Node, newStatus string) {
+	//ref := &v1.ObjectReference{
+	//	APIVersion: "v1",
+	//	Kind:       "Node",
+	//	Name:       node.Name,
+	//	UID:        node.UID,
+	//	Namespace:  "",
+	//}
+	klog.V(2).Infof("Recording status change %s event message for node %s", newStatus, node.Name)
+	// TODO: This requires a transaction, either both node status is updated
+	// and event is recorded or neither should happen, see issue #6055.
+	//recorder.Eventf(ref, v1.EventTypeNormal, newStatus, "Node %s status is now: %s", node.Name, newStatus)
+}
+
+// CreateAddNodeHandler creates an add node handler.
+func CreateAddNodeHandler(f func(node *v1.Node) error) func(obj interface{}) {
+	return func(originalObj interface{}) {
+		node := originalObj.(*v1.Node).DeepCopy()
+		if err := f(node); err != nil {
+			utilruntime.HandleError(fmt.Errorf("Error while processing Node Add: %v", err))
+		}
+	}
+}
+
+// CreateUpdateNodeHandler creates a node update handler. (Common to lifecycle and ipam)
+func CreateUpdateNodeHandler(f func(oldNode, newNode *v1.Node) error) func(oldObj, newObj interface{}) {
+	return func(origOldObj, origNewObj interface{}) {
+		node := origNewObj.(*v1.Node).DeepCopy()
+		prevNode := origOldObj.(*v1.Node).DeepCopy()
+
+		if err := f(prevNode, node); err != nil {
+			utilruntime.HandleError(fmt.Errorf("Error while processing Node Add/Delete: %v", err))
+		}
+	}
+}
+
+// CreateDeleteNodeHandler creates a delete node handler. (Common to lifecycle and ipam)
+func CreateDeleteNodeHandler(f func(node *v1.Node) error) func(obj interface{}) {
+	return func(originalObj interface{}) {
+		originalNode, isNode := originalObj.(*v1.Node)
+		// We can get DeletedFinalStateUnknown instead of *v1.Node here and
+		// we need to handle that correctly. #34692
+		if !isNode {
+			deletedState, ok := originalObj.(cache.DeletedFinalStateUnknown)
+			if !ok {
+				klog.Errorf("Received unexpected object: %v", originalObj)
+				return
+			}
+			originalNode, ok = deletedState.Obj.(*v1.Node)
+			if !ok {
+				klog.Errorf("DeletedFinalStateUnknown contained non-Node object: %v", deletedState.Obj)
+				return
+			}
+		}
+		node := originalNode.DeepCopy()
+		if err := f(node); err != nil {
+			utilruntime.HandleError(fmt.Errorf("Error while processing Node Add/Delete: %v", err))
+		}
+	}
+}

--- a/third_party/ipam/nodeipam/ipam/cidr_allocator.go
+++ b/third_party/ipam/nodeipam/ipam/cidr_allocator.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+/*
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+Modifies:
+- Disable CloudAllocatorType support
+- Remove cloud argument from New()
+*/
+
+package ipam
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/wait"
+	informers "k8s.io/client-go/informers/core/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+)
+
+// CIDRAllocatorType is the type of the allocator to use.
+type CIDRAllocatorType string
+
+const (
+	// RangeAllocatorType is the allocator that uses an internal CIDR
+	// range allocator to do node CIDR range allocations.
+	RangeAllocatorType CIDRAllocatorType = "RangeAllocator"
+	// CloudAllocatorType is the allocator that uses cloud platform
+	// support to do node CIDR range allocations.
+	CloudAllocatorType CIDRAllocatorType = "CloudAllocator"
+	// IPAMFromClusterAllocatorType uses the ipam controller sync'ing the node
+	// CIDR range allocations from the cluster to the cloud.
+	IPAMFromClusterAllocatorType = "IPAMFromCluster"
+	// IPAMFromCloudAllocatorType uses the ipam controller sync'ing the node
+	// CIDR range allocations from the cloud to the cluster.
+	IPAMFromCloudAllocatorType = "IPAMFromCloud"
+)
+
+// TODO: figure out the good setting for those constants.
+const (
+	// The amount of time the nodecontroller polls on the list nodes endpoint.
+	apiserverStartupGracePeriod = 10 * time.Minute
+
+	// The no. of NodeSpec updates NC can process concurrently.
+	cidrUpdateWorkers = 30
+
+	// The max no. of NodeSpec updates that can be enqueued.
+	cidrUpdateQueueSize = 5000
+
+	// cidrUpdateRetries is the no. of times a NodeSpec update will be retried before dropping it.
+	cidrUpdateRetries = 3
+
+	// updateRetryTimeout is the time to wait before requeing a failed node for retry
+	updateRetryTimeout = 250 * time.Millisecond
+
+	// maxUpdateRetryTimeout is the maximum amount of time between timeouts.
+	maxUpdateRetryTimeout = 5 * time.Second
+
+	// updateMaxRetries is the max retries for a failed node
+	updateMaxRetries = 10
+)
+
+// nodePollInterval is used in listing node
+// This is a variable instead of a const to enable testing.
+var nodePollInterval = 10 * time.Second
+
+// CIDRAllocator is an interface implemented by things that know how
+// to allocate/occupy/recycle CIDR for nodes.
+type CIDRAllocator interface {
+	// AllocateOrOccupyCIDR looks at the given node, assigns it a valid
+	// CIDR if it doesn't currently have one or mark the CIDR as used if
+	// the node already have one.
+	AllocateOrOccupyCIDR(node *v1.Node) error
+	// ReleaseCIDR releases the CIDR of the removed node
+	ReleaseCIDR(node *v1.Node) error
+	// Run starts all the working logic of the allocator.
+	Run(stopCh <-chan struct{})
+}
+
+// CIDRAllocatorParams is parameters that's required for creating new
+// cidr range allocator.
+type CIDRAllocatorParams struct {
+	// ClusterCIDRs is list of cluster cidrs
+	ClusterCIDRs []*net.IPNet
+	// ServiceCIDR is primary service cidr for cluster
+	ServiceCIDR *net.IPNet
+	// SecondaryServiceCIDR is secondary service cidr for cluster
+	SecondaryServiceCIDR *net.IPNet
+	// NodeCIDRMaskSizes is list of node cidr mask sizes
+	NodeCIDRMaskSizes []int
+}
+
+// New creates a new CIDR range allocator.
+func New(kubeClient clientset.Interface /*, cloud cloudprovider.Interface*/, nodeInformer informers.NodeInformer, allocatorType CIDRAllocatorType, allocatorParams CIDRAllocatorParams) (CIDRAllocator, error) {
+	nodeList, err := listNodes(kubeClient)
+	if err != nil {
+		return nil, err
+	}
+
+	switch allocatorType {
+	case RangeAllocatorType:
+		return NewCIDRRangeAllocator(kubeClient, nodeInformer, allocatorParams, nodeList)
+	//case CloudAllocatorType:
+	//	return NewCloudCIDRAllocator(kubeClient, cloud, nodeInformer)
+	default:
+		return nil, fmt.Errorf("invalid CIDR allocator type: %v", allocatorType)
+	}
+}
+
+func listNodes(kubeClient clientset.Interface) (*v1.NodeList, error) {
+	var nodeList *v1.NodeList
+	// We must poll because apiserver might not be up. This error causes
+	// controller manager to restart.
+	if pollErr := wait.Poll(nodePollInterval, apiserverStartupGracePeriod, func() (bool, error) {
+		var err error
+		nodeList, err = kubeClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{
+			FieldSelector: fields.Everything().String(),
+			LabelSelector: labels.Everything().String(),
+		})
+		if err != nil {
+			klog.Errorf("Failed to list all nodes: %v", err)
+			return false, nil
+		}
+		return true, nil
+	}); pollErr != nil {
+		return nil, fmt.Errorf("failed to list all nodes in %v, cannot proceed without updating CIDR map",
+			apiserverStartupGracePeriod)
+	}
+	return nodeList, nil
+}

--- a/third_party/ipam/nodeipam/ipam/cidrset/cidr_set.go
+++ b/third_party/ipam/nodeipam/ipam/cidrset/cidr_set.go
@@ -1,0 +1,295 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cidrset
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math/big"
+	"math/bits"
+	"net"
+	"sync"
+)
+
+// CidrSet manages a set of CIDR ranges from which blocks of IPs can
+// be allocated from.
+type CidrSet struct {
+	sync.Mutex
+	// clusterCIDR is the CIDR assigned to the cluster
+	clusterCIDR *net.IPNet
+	// clusterMaskSize is the mask size, in bits, assigned to the cluster
+	// caches the mask size to avoid the penalty of calling clusterCIDR.Mask.Size()
+	clusterMaskSize int
+	// nodeMask is the network mask assigned to the nodes
+	nodeMask net.IPMask
+	// nodeMaskSize is the mask size, in bits,assigned to the nodes
+	// caches the mask size to avoid the penalty of calling nodeMask.Size()
+	nodeMaskSize int
+	// maxCIDRs is the maximum number of CIDRs that can be allocated
+	maxCIDRs int
+	// allocatedCIDRs counts the number of CIDRs allocated
+	allocatedCIDRs int
+	// nextCandidate points to the next CIDR that should be free
+	nextCandidate int
+	// used is a bitmap used to track the CIDRs allocated
+	used big.Int
+	// label is used to identify the metrics
+	label string
+}
+
+const (
+	// The subnet mask size cannot be greater than 16 more than the cluster mask size
+	// TODO: https://github.com/kubernetes/kubernetes/issues/44918
+	// clusterSubnetMaxDiff limited to 16 due to the uncompressed bitmap
+	// Due to this limitation the subnet mask for IPv6 cluster cidr needs to be >= 48
+	// as default mask size for IPv6 is 64.
+	clusterSubnetMaxDiff = 16
+	// halfIPv6Len is the half of the IPv6 length
+	halfIPv6Len = net.IPv6len / 2
+)
+
+var (
+	// ErrCIDRRangeNoCIDRsRemaining occurs when there is no more space
+	// to allocate CIDR ranges.
+	ErrCIDRRangeNoCIDRsRemaining = errors.New(
+		"CIDR allocation failed; there are no remaining CIDRs left to allocate in the accepted range")
+	// ErrCIDRSetSubNetTooBig occurs when the subnet mask size is too
+	// big compared to the CIDR mask size.
+	ErrCIDRSetSubNetTooBig = errors.New(
+		"New CIDR set failed; the node CIDR size is too big")
+)
+
+// NewCIDRSet creates a new CidrSet.
+func NewCIDRSet(clusterCIDR *net.IPNet, subNetMaskSize int) (*CidrSet, error) {
+	clusterMask := clusterCIDR.Mask
+	clusterMaskSize, bits := clusterMask.Size()
+
+	var maxCIDRs int
+	if (clusterCIDR.IP.To4() == nil) && (subNetMaskSize-clusterMaskSize > clusterSubnetMaxDiff) {
+		return nil, ErrCIDRSetSubNetTooBig
+	}
+
+	// register CidrSet metrics
+	registerCidrsetMetrics()
+
+	maxCIDRs = 1 << uint32(subNetMaskSize-clusterMaskSize)
+	return &CidrSet{
+		clusterCIDR:     clusterCIDR,
+		nodeMask:        net.CIDRMask(subNetMaskSize, bits),
+		clusterMaskSize: clusterMaskSize,
+		maxCIDRs:        maxCIDRs,
+		nodeMaskSize:    subNetMaskSize,
+		label:           clusterCIDR.String(),
+	}, nil
+}
+
+func (s *CidrSet) indexToCIDRBlock(index int) *net.IPNet {
+	var ip []byte
+	switch /*v4 or v6*/ {
+	case s.clusterCIDR.IP.To4() != nil:
+		{
+			j := uint32(index) << uint32(32-s.nodeMaskSize)
+			ipInt := (binary.BigEndian.Uint32(s.clusterCIDR.IP)) | j
+			ip = make([]byte, net.IPv4len)
+			binary.BigEndian.PutUint32(ip, ipInt)
+		}
+	case s.clusterCIDR.IP.To16() != nil:
+		{
+			// leftClusterIP      |     rightClusterIP
+			// 2001:0DB8:1234:0000:0000:0000:0000:0000
+			const v6NBits = 128
+			const halfV6NBits = v6NBits / 2
+			leftClusterIP := binary.BigEndian.Uint64(s.clusterCIDR.IP[:halfIPv6Len])
+			rightClusterIP := binary.BigEndian.Uint64(s.clusterCIDR.IP[halfIPv6Len:])
+
+			ip = make([]byte, net.IPv6len)
+
+			if s.nodeMaskSize <= halfV6NBits {
+				// We only care about left side IP
+				leftClusterIP |= uint64(index) << uint(halfV6NBits-s.nodeMaskSize)
+			} else {
+				if s.clusterMaskSize < halfV6NBits {
+					// see how many bits are needed to reach the left side
+					btl := uint(s.nodeMaskSize - halfV6NBits)
+					indexMaxBit := uint(64 - bits.LeadingZeros64(uint64(index)))
+					if indexMaxBit > btl {
+						leftClusterIP |= uint64(index) >> btl
+					}
+				}
+				// the right side will be calculated the same way either the
+				// subNetMaskSize affects both left and right sides
+				rightClusterIP |= uint64(index) << uint(v6NBits-s.nodeMaskSize)
+			}
+			binary.BigEndian.PutUint64(ip[:halfIPv6Len], leftClusterIP)
+			binary.BigEndian.PutUint64(ip[halfIPv6Len:], rightClusterIP)
+		}
+	}
+	return &net.IPNet{
+		IP:   ip,
+		Mask: s.nodeMask,
+	}
+}
+
+// AllocateNext allocates the next free CIDR range. This will set the range
+// as occupied and return the allocated range.
+func (s *CidrSet) AllocateNext() (*net.IPNet, error) {
+	s.Lock()
+	defer s.Unlock()
+
+	if s.allocatedCIDRs == s.maxCIDRs {
+		return nil, ErrCIDRRangeNoCIDRsRemaining
+	}
+	candidate := s.nextCandidate
+	var i int
+	for i = 0; i < s.maxCIDRs; i++ {
+		if s.used.Bit(candidate) == 0 {
+			break
+		}
+		candidate = (candidate + 1) % s.maxCIDRs
+	}
+
+	s.nextCandidate = (candidate + 1) % s.maxCIDRs
+	s.used.SetBit(&s.used, candidate, 1)
+	s.allocatedCIDRs++
+	// Update metrics
+	cidrSetAllocations.WithLabelValues(s.label).Inc()
+	cidrSetAllocationTriesPerRequest.WithLabelValues(s.label).Observe(float64(i))
+	cidrSetUsage.WithLabelValues(s.label).Set(float64(s.allocatedCIDRs) / float64(s.maxCIDRs))
+
+	return s.indexToCIDRBlock(candidate), nil
+}
+
+func (s *CidrSet) getBeginingAndEndIndices(cidr *net.IPNet) (begin, end int, err error) {
+	if cidr == nil {
+		return -1, -1, fmt.Errorf("error getting indices for cluster cidr %v, cidr is nil", s.clusterCIDR)
+	}
+	begin, end = 0, s.maxCIDRs-1
+	cidrMask := cidr.Mask
+	maskSize, _ := cidrMask.Size()
+	var ipSize int
+
+	if !s.clusterCIDR.Contains(cidr.IP.Mask(s.clusterCIDR.Mask)) && !cidr.Contains(s.clusterCIDR.IP.Mask(cidr.Mask)) {
+		return -1, -1, fmt.Errorf("cidr %v is out the range of cluster cidr %v", cidr, s.clusterCIDR)
+	}
+
+	if s.clusterMaskSize < maskSize {
+
+		ipSize = net.IPv4len
+		if cidr.IP.To4() == nil {
+			ipSize = net.IPv6len
+		}
+		begin, err = s.getIndexForCIDR(&net.IPNet{
+			IP:   cidr.IP.Mask(s.nodeMask),
+			Mask: s.nodeMask,
+		})
+		if err != nil {
+			return -1, -1, err
+		}
+		ip := make([]byte, ipSize)
+		if cidr.IP.To4() != nil {
+			ipInt := binary.BigEndian.Uint32(cidr.IP) | (^binary.BigEndian.Uint32(cidr.Mask))
+			binary.BigEndian.PutUint32(ip, ipInt)
+		} else {
+			// ipIntLeft          |         ipIntRight
+			// 2001:0DB8:1234:0000:0000:0000:0000:0000
+			ipIntLeft := binary.BigEndian.Uint64(cidr.IP[:net.IPv6len/2]) | (^binary.BigEndian.Uint64(cidr.Mask[:net.IPv6len/2]))
+			ipIntRight := binary.BigEndian.Uint64(cidr.IP[net.IPv6len/2:]) | (^binary.BigEndian.Uint64(cidr.Mask[net.IPv6len/2:]))
+			binary.BigEndian.PutUint64(ip[:net.IPv6len/2], ipIntLeft)
+			binary.BigEndian.PutUint64(ip[net.IPv6len/2:], ipIntRight)
+		}
+		end, err = s.getIndexForCIDR(&net.IPNet{
+			IP:   net.IP(ip).Mask(s.nodeMask),
+			Mask: s.nodeMask,
+		})
+		if err != nil {
+			return -1, -1, err
+		}
+	}
+	return begin, end, nil
+}
+
+// Release releases the given CIDR range.
+func (s *CidrSet) Release(cidr *net.IPNet) error {
+	begin, end, err := s.getBeginingAndEndIndices(cidr)
+	if err != nil {
+		return err
+	}
+	s.Lock()
+	defer s.Unlock()
+	for i := begin; i <= end; i++ {
+		// Only change the counters if we change the bit to prevent
+		// double counting.
+		if s.used.Bit(i) != 0 {
+			s.used.SetBit(&s.used, i, 0)
+			s.allocatedCIDRs--
+			cidrSetReleases.WithLabelValues(s.label).Inc()
+		}
+	}
+
+	cidrSetUsage.WithLabelValues(s.label).Set(float64(s.allocatedCIDRs) / float64(s.maxCIDRs))
+	return nil
+}
+
+// Occupy marks the given CIDR range as used. Occupy succeeds even if the CIDR
+// range was previously used.
+func (s *CidrSet) Occupy(cidr *net.IPNet) (err error) {
+	begin, end, err := s.getBeginingAndEndIndices(cidr)
+	if err != nil {
+		return err
+	}
+	s.Lock()
+	defer s.Unlock()
+	for i := begin; i <= end; i++ {
+		// Only change the counters if we change the bit to prevent
+		// double counting.
+		if s.used.Bit(i) == 0 {
+			s.used.SetBit(&s.used, i, 1)
+			s.allocatedCIDRs++
+			cidrSetAllocations.WithLabelValues(s.label).Inc()
+		}
+	}
+
+	cidrSetUsage.WithLabelValues(s.label).Set(float64(s.allocatedCIDRs) / float64(s.maxCIDRs))
+	return nil
+}
+
+func (s *CidrSet) getIndexForCIDR(cidr *net.IPNet) (int, error) {
+	return s.getIndexForIP(cidr.IP)
+}
+
+func (s *CidrSet) getIndexForIP(ip net.IP) (int, error) {
+	if ip.To4() != nil {
+		cidrIndex := (binary.BigEndian.Uint32(s.clusterCIDR.IP) ^ binary.BigEndian.Uint32(ip.To4())) >> uint32(32-s.nodeMaskSize)
+		if cidrIndex >= uint32(s.maxCIDRs) {
+			return 0, fmt.Errorf("CIDR: %v/%v is out of the range of CIDR allocator", ip, s.nodeMaskSize)
+		}
+		return int(cidrIndex), nil
+	}
+	if ip.To16() != nil {
+		bigIP := big.NewInt(0).SetBytes(s.clusterCIDR.IP)
+		bigIP = bigIP.Xor(bigIP, big.NewInt(0).SetBytes(ip))
+		cidrIndexBig := bigIP.Rsh(bigIP, uint(net.IPv6len*8-s.nodeMaskSize))
+		cidrIndex := cidrIndexBig.Uint64()
+		if cidrIndex >= uint64(s.maxCIDRs) {
+			return 0, fmt.Errorf("CIDR: %v/%v is out of the range of CIDR allocator", ip, s.nodeMaskSize)
+		}
+		return int(cidrIndex), nil
+	}
+
+	return 0, fmt.Errorf("invalid IP: %v", ip)
+}

--- a/third_party/ipam/nodeipam/ipam/cidrset/metrics.go
+++ b/third_party/ipam/nodeipam/ipam/cidrset/metrics.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+/*
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+Modifies:
+- Place metrics in Antrea's namespace
+*/
+
+package cidrset
+
+import (
+	"sync"
+
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+const (
+	metricNamespaceAntrea = "antrea"
+	nodeIpamSubsystem = "node_ipam_controller"
+)
+
+var (
+	cidrSetAllocations = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Namespace:      metricNamespaceAntrea,
+			Subsystem:      nodeIpamSubsystem,
+			Name:           "cidrset_cidrs_allocations_total",
+			Help:           "Counter measuring total number of CIDR allocations.",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"clusterCIDR"},
+	)
+	cidrSetReleases = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Namespace:      metricNamespaceAntrea,
+			Subsystem:      nodeIpamSubsystem,
+			Name:           "cidrset_cidrs_releases_total",
+			Help:           "Counter measuring total number of CIDR releases.",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"clusterCIDR"},
+	)
+	cidrSetUsage = metrics.NewGaugeVec(
+		&metrics.GaugeOpts{
+			Namespace:      metricNamespaceAntrea,
+			Subsystem:      nodeIpamSubsystem,
+			Name:           "cidrset_usage_cidrs",
+			Help:           "Gauge measuring percentage of allocated CIDRs.",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"clusterCIDR"},
+	)
+	cidrSetAllocationTriesPerRequest = metrics.NewHistogramVec(
+		&metrics.HistogramOpts{
+			Namespace:      metricNamespaceAntrea,
+			Subsystem:      nodeIpamSubsystem,
+			Name:           "cidrset_allocation_tries_per_request",
+			Help:           "Number of endpoints added on each Service sync",
+			StabilityLevel: metrics.ALPHA,
+			Buckets:        metrics.ExponentialBuckets(1, 5, 5),
+		},
+		[]string{"clusterCIDR"},
+	)
+)
+
+var registerMetrics sync.Once
+
+// registerCidrsetMetrics the metrics that are to be monitored.
+func registerCidrsetMetrics() {
+	registerMetrics.Do(func() {
+		legacyregistry.MustRegister(cidrSetAllocations)
+		legacyregistry.MustRegister(cidrSetReleases)
+		legacyregistry.MustRegister(cidrSetUsage)
+		legacyregistry.MustRegister(cidrSetAllocationTriesPerRequest)
+	})
+}

--- a/third_party/ipam/nodeipam/ipam/range_allocator.go
+++ b/third_party/ipam/nodeipam/ipam/range_allocator.go
@@ -1,0 +1,412 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+/*
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+Modifies:
+- Replace k8s.io/kubernetes/pkg/controller/nodeipam/ipam import with
+ antrea.io/antrea/third_party/nodeipam/ipam
+- Remove recorder from rangeAllocator type, NewCIDRRangeAllocator(), RecordNodeStatusChange() calls
+*/
+
+package ipam
+
+import (
+	"fmt"
+	"net"
+	"sync"
+
+	"k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	informers "k8s.io/client-go/informers/core/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
+	nodeutil "antrea.io/antrea/third_party/ipam/controller_util_node"
+	"antrea.io/antrea/third_party/ipam/nodeipam/ipam/cidrset"
+	utilnode "antrea.io/antrea/third_party/ipam/util_node"
+)
+
+// cidrs are reserved, then node resource is patched with them
+// this type holds the reservation info for a node
+type nodeReservedCIDRs struct {
+	allocatedCIDRs []*net.IPNet
+	nodeName       string
+}
+
+type rangeAllocator struct {
+	client clientset.Interface
+	// cluster cidrs as passed in during controller creation
+	clusterCIDRs []*net.IPNet
+	// for each entry in clusterCIDRs we maintain a list of what is used and what is not
+	cidrSets []*cidrset.CidrSet
+	// nodeLister is able to list/get nodes and is populated by the shared informer passed to controller
+	nodeLister corelisters.NodeLister
+	// nodesSynced returns true if the node shared informer has been synced at least once.
+	nodesSynced cache.InformerSynced
+	// Channel that is used to pass updating Nodes and their reserved CIDRs to the background
+	// This increases a throughput of CIDR assignment by not blocking on long operations.
+	nodeCIDRUpdateChannel chan nodeReservedCIDRs
+	// Keep a set of nodes that are currently being processed to avoid races in CIDR allocation
+	lock              sync.Mutex
+	nodesInProcessing sets.String
+}
+
+// NewCIDRRangeAllocator returns a CIDRAllocator to allocate CIDRs for node (one from each of clusterCIDRs)
+// Caller must ensure subNetMaskSize is not less than cluster CIDR mask size.
+// Caller must always pass in a list of existing nodes so the new allocator.
+// Caller must ensure that ClusterCIDRs are semantically correct e.g (1 for non DualStack, 2 for DualStack etc..)
+// can initialize its CIDR map. NodeList is only nil in testing.
+func NewCIDRRangeAllocator(client clientset.Interface, nodeInformer informers.NodeInformer, allocatorParams CIDRAllocatorParams, nodeList *v1.NodeList) (CIDRAllocator, error) {
+	if client == nil {
+		klog.Fatalf("kubeClient is nil when starting NodeController")
+	}
+
+	klog.V(0).Infof("Sending events to api server.")
+
+	// create a cidrSet for each cidr we operate on
+	// cidrSet are mapped to clusterCIDR by index
+	cidrSets := make([]*cidrset.CidrSet, len(allocatorParams.ClusterCIDRs))
+	for idx, cidr := range allocatorParams.ClusterCIDRs {
+		cidrSet, err := cidrset.NewCIDRSet(cidr, allocatorParams.NodeCIDRMaskSizes[idx])
+		if err != nil {
+			return nil, err
+		}
+		cidrSets[idx] = cidrSet
+	}
+
+	ra := &rangeAllocator{
+		client:                client,
+		clusterCIDRs:          allocatorParams.ClusterCIDRs,
+		cidrSets:              cidrSets,
+		nodeLister:            nodeInformer.Lister(),
+		nodesSynced:           nodeInformer.Informer().HasSynced,
+		nodeCIDRUpdateChannel: make(chan nodeReservedCIDRs, cidrUpdateQueueSize),
+		nodesInProcessing:     sets.NewString(),
+	}
+
+	if allocatorParams.ServiceCIDR != nil {
+		ra.filterOutServiceRange(allocatorParams.ServiceCIDR)
+	} else {
+		klog.V(0).Info("No Service CIDR provided. Skipping filtering out service addresses.")
+	}
+
+	if allocatorParams.SecondaryServiceCIDR != nil {
+		ra.filterOutServiceRange(allocatorParams.SecondaryServiceCIDR)
+	} else {
+		klog.V(0).Info("No Secondary Service CIDR provided. Skipping filtering out secondary service addresses.")
+	}
+
+	if nodeList != nil {
+		for _, node := range nodeList.Items {
+			if len(node.Spec.PodCIDRs) == 0 {
+				klog.V(4).Infof("Node %v has no CIDR, ignoring", node.Name)
+				continue
+			}
+			klog.V(4).Infof("Node %v has CIDR %s, occupying it in CIDR map", node.Name, node.Spec.PodCIDR)
+			if err := ra.occupyCIDRs(&node); err != nil {
+				// This will happen if:
+				// 1. We find garbage in the podCIDRs field. Retrying is useless.
+				// 2. CIDR out of range: This means a node CIDR has changed.
+				// This error will keep crashing controller-manager.
+				return nil, err
+			}
+		}
+	}
+
+	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: nodeutil.CreateAddNodeHandler(ra.AllocateOrOccupyCIDR),
+		UpdateFunc: nodeutil.CreateUpdateNodeHandler(func(_, newNode *v1.Node) error {
+			// If the PodCIDRs list is not empty we either:
+			// - already processed a Node that already had CIDRs after NC restarted
+			//   (cidr is marked as used),
+			// - already processed a Node successfully and allocated CIDRs for it
+			//   (cidr is marked as used),
+			// - already processed a Node but we did saw a "timeout" response and
+			//   request eventually got through in this case we haven't released
+			//   the allocated CIDRs (cidr is still marked as used).
+			// There's a possible error here:
+			// - NC sees a new Node and assigns CIDRs X,Y.. to it,
+			// - Update Node call fails with a timeout,
+			// - Node is updated by some other component, NC sees an update and
+			//   assigns CIDRs A,B.. to the Node,
+			// - Both CIDR X,Y.. and CIDR A,B.. are marked as used in the local cache,
+			//   even though Node sees only CIDR A,B..
+			// The problem here is that in in-memory cache we see CIDR X,Y.. as marked,
+			// which prevents it from being assigned to any new node. The cluster
+			// state is correct.
+			// Restart of NC fixes the issue.
+			if len(newNode.Spec.PodCIDRs) == 0 {
+				return ra.AllocateOrOccupyCIDR(newNode)
+			}
+			return nil
+		}),
+		DeleteFunc: nodeutil.CreateDeleteNodeHandler(ra.ReleaseCIDR),
+	})
+
+	return ra, nil
+}
+
+func (r *rangeAllocator) Run(stopCh <-chan struct{}) {
+	defer utilruntime.HandleCrash()
+
+	klog.Infof("Starting range CIDR allocator")
+	defer klog.Infof("Shutting down range CIDR allocator")
+
+	if !cache.WaitForNamedCacheSync("cidrallocator", stopCh, r.nodesSynced) {
+		return
+	}
+
+	for i := 0; i < cidrUpdateWorkers; i++ {
+		go r.worker(stopCh)
+	}
+
+	<-stopCh
+}
+
+func (r *rangeAllocator) worker(stopChan <-chan struct{}) {
+	for {
+		select {
+		case workItem, ok := <-r.nodeCIDRUpdateChannel:
+			if !ok {
+				klog.Warning("Channel nodeCIDRUpdateChannel was unexpectedly closed")
+				return
+			}
+			if err := r.updateCIDRsAllocation(workItem); err != nil {
+				// Requeue the failed node for update again.
+				r.nodeCIDRUpdateChannel <- workItem
+			}
+		case <-stopChan:
+			return
+		}
+	}
+}
+
+func (r *rangeAllocator) insertNodeToProcessing(nodeName string) bool {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	if r.nodesInProcessing.Has(nodeName) {
+		return false
+	}
+	r.nodesInProcessing.Insert(nodeName)
+	return true
+}
+
+func (r *rangeAllocator) removeNodeFromProcessing(nodeName string) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	r.nodesInProcessing.Delete(nodeName)
+}
+
+// marks node.PodCIDRs[...] as used in allocator's tracked cidrSet
+func (r *rangeAllocator) occupyCIDRs(node *v1.Node) error {
+	defer r.removeNodeFromProcessing(node.Name)
+	if len(node.Spec.PodCIDRs) == 0 {
+		return nil
+	}
+	for idx, cidr := range node.Spec.PodCIDRs {
+		_, podCIDR, err := net.ParseCIDR(cidr)
+		if err != nil {
+			return fmt.Errorf("failed to parse node %s, CIDR %s", node.Name, node.Spec.PodCIDR)
+		}
+		// If node has a pre allocate cidr that does not exist in our cidrs.
+		// This will happen if cluster went from dualstack(multi cidrs) to non-dualstack
+		// then we have now way of locking it
+		if idx >= len(r.cidrSets) {
+			return fmt.Errorf("node:%s has an allocated cidr: %v at index:%v that does not exist in cluster cidrs configuration", node.Name, cidr, idx)
+		}
+
+		if err := r.cidrSets[idx].Occupy(podCIDR); err != nil {
+			return fmt.Errorf("failed to mark cidr[%v] at idx [%v] as occupied for node: %v: %v", podCIDR, idx, node.Name, err)
+		}
+	}
+	return nil
+}
+
+// WARNING: If you're adding any return calls or defer any more work from this
+// function you have to make sure to update nodesInProcessing properly with the
+// disposition of the node when the work is done.
+func (r *rangeAllocator) AllocateOrOccupyCIDR(node *v1.Node) error {
+	if node == nil {
+		return nil
+	}
+	if !r.insertNodeToProcessing(node.Name) {
+		klog.V(2).Infof("Node %v is already in a process of CIDR assignment.", node.Name)
+		return nil
+	}
+
+	if len(node.Spec.PodCIDRs) > 0 {
+		return r.occupyCIDRs(node)
+	}
+	// allocate and queue the assignment
+	allocated := nodeReservedCIDRs{
+		nodeName:       node.Name,
+		allocatedCIDRs: make([]*net.IPNet, len(r.cidrSets)),
+	}
+
+	for idx := range r.cidrSets {
+		podCIDR, err := r.cidrSets[idx].AllocateNext()
+		if err != nil {
+			r.removeNodeFromProcessing(node.Name)
+			nodeutil.RecordNodeStatusChange(node, "CIDRNotAvailable")
+			return fmt.Errorf("failed to allocate cidr from cluster cidr at idx:%v: %v", idx, err)
+		}
+		allocated.allocatedCIDRs[idx] = podCIDR
+	}
+
+	//queue the assignment
+	klog.V(4).Infof("Putting node %s with CIDR %v into the work queue", node.Name, allocated.allocatedCIDRs)
+	r.nodeCIDRUpdateChannel <- allocated
+	return nil
+}
+
+// ReleaseCIDR marks node.podCIDRs[...] as unused in our tracked cidrSets
+func (r *rangeAllocator) ReleaseCIDR(node *v1.Node) error {
+	if node == nil || len(node.Spec.PodCIDRs) == 0 {
+		return nil
+	}
+
+	for idx, cidr := range node.Spec.PodCIDRs {
+		_, podCIDR, err := net.ParseCIDR(cidr)
+		if err != nil {
+			return fmt.Errorf("failed to parse CIDR %s on Node %v: %v", cidr, node.Name, err)
+		}
+
+		// If node has a pre allocate cidr that does not exist in our cidrs.
+		// This will happen if cluster went from dualstack(multi cidrs) to non-dualstack
+		// then we have now way of locking it
+		if idx >= len(r.cidrSets) {
+			return fmt.Errorf("node:%s has an allocated cidr: %v at index:%v that does not exist in cluster cidrs configuration", node.Name, cidr, idx)
+		}
+
+		klog.V(4).Infof("release CIDR %s for node:%v", cidr, node.Name)
+		if err = r.cidrSets[idx].Release(podCIDR); err != nil {
+			return fmt.Errorf("error when releasing CIDR %v: %v", cidr, err)
+		}
+	}
+	return nil
+}
+
+// Marks all CIDRs with subNetMaskSize that belongs to serviceCIDR as used across all cidrs
+// so that they won't be assignable.
+func (r *rangeAllocator) filterOutServiceRange(serviceCIDR *net.IPNet) {
+	// Checks if service CIDR has a nonempty intersection with cluster
+	// CIDR. It is the case if either clusterCIDR contains serviceCIDR with
+	// clusterCIDR's Mask applied (this means that clusterCIDR contains
+	// serviceCIDR) or vice versa (which means that serviceCIDR contains
+	// clusterCIDR).
+	for idx, cidr := range r.clusterCIDRs {
+		// if they don't overlap then ignore the filtering
+		if !cidr.Contains(serviceCIDR.IP.Mask(cidr.Mask)) && !serviceCIDR.Contains(cidr.IP.Mask(serviceCIDR.Mask)) {
+			continue
+		}
+
+		// at this point, len(cidrSet) == len(clusterCidr)
+		if err := r.cidrSets[idx].Occupy(serviceCIDR); err != nil {
+			klog.Errorf("Error filtering out service cidr out cluster cidr:%v (index:%v) %v: %v", cidr, idx, serviceCIDR, err)
+		}
+	}
+}
+
+// updateCIDRsAllocation assigns CIDR to Node and sends an update to the API server.
+func (r *rangeAllocator) updateCIDRsAllocation(data nodeReservedCIDRs) error {
+	var err error
+	var node *v1.Node
+	defer r.removeNodeFromProcessing(data.nodeName)
+	cidrsString := cidrsAsString(data.allocatedCIDRs)
+	node, err = r.nodeLister.Get(data.nodeName)
+	if err != nil {
+		klog.Errorf("Failed while getting node %v for updating Node.Spec.PodCIDRs: %v", data.nodeName, err)
+		return err
+	}
+
+	// if cidr list matches the proposed.
+	// then we possibly updated this node
+	// and just failed to ack the success.
+	if len(node.Spec.PodCIDRs) == len(data.allocatedCIDRs) {
+		match := true
+		for idx, cidr := range cidrsString {
+			if node.Spec.PodCIDRs[idx] != cidr {
+				match = false
+				break
+			}
+		}
+		if match {
+			klog.V(4).Infof("Node %v already has allocated CIDR %v. It matches the proposed one.", node.Name, data.allocatedCIDRs)
+			return nil
+		}
+	}
+
+	// node has cidrs, release the reserved
+	if len(node.Spec.PodCIDRs) != 0 {
+		klog.Errorf("Node %v already has a CIDR allocated %v. Releasing the new one.", node.Name, node.Spec.PodCIDRs)
+		for idx, cidr := range data.allocatedCIDRs {
+			if releaseErr := r.cidrSets[idx].Release(cidr); releaseErr != nil {
+				klog.Errorf("Error when releasing CIDR idx:%v value: %v err:%v", idx, cidr, releaseErr)
+			}
+		}
+		return nil
+	}
+
+	// If we reached here, it means that the node has no CIDR currently assigned. So we set it.
+	for i := 0; i < cidrUpdateRetries; i++ {
+		if err = utilnode.PatchNodeCIDRs(r.client, types.NodeName(node.Name), cidrsString); err == nil {
+			klog.Infof("Set node %v PodCIDR to %v", node.Name, cidrsString)
+			return nil
+		}
+	}
+	// failed release back to the pool
+	klog.Errorf("Failed to update node %v PodCIDR to %v after multiple attempts: %v", node.Name, cidrsString, err)
+	nodeutil.RecordNodeStatusChange(node, "CIDRAssignmentFailed")
+	// We accept the fact that we may leak CIDRs here. This is safer than releasing
+	// them in case when we don't know if request went through.
+	// NodeController restart will return all falsely allocated CIDRs to the pool.
+	if !apierrors.IsServerTimeout(err) {
+		klog.Errorf("CIDR assignment for node %v failed: %v. Releasing allocated CIDR", node.Name, err)
+		for idx, cidr := range data.allocatedCIDRs {
+			if releaseErr := r.cidrSets[idx].Release(cidr); releaseErr != nil {
+				klog.Errorf("Error releasing allocated CIDR for node %v: %v", node.Name, releaseErr)
+			}
+		}
+	}
+	return err
+}
+
+// converts a slice of cidrs into <c-1>,<c-2>,<c-n>
+func cidrsAsString(inCIDRs []*net.IPNet) []string {
+	outCIDRs := make([]string, len(inCIDRs))
+	for idx, inCIDR := range inCIDRs {
+		outCIDRs[idx] = inCIDR.String()
+	}
+	return outCIDRs
+}

--- a/third_party/ipam/nodeipam/node_ipam_controller.go
+++ b/third_party/ipam/nodeipam/node_ipam_controller.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+/*
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+Modifies:
+- Replace k8s.io/kubernetes/pkg/controller/nodeipam/ipam import with
+ antrea.io/antrea/third_party/nodeipam/ipam
+- Comment out startLegacyIPAM() call as legacy IPAM support is redundant
+- Remove cloud argument from NewNodeIpamController()
+- Remove cloud member from Controler struct
+- Remove unused constants
+*/
+
+package nodeipam
+
+import (
+	"net"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/component-base/metrics/prometheus/ratelimiter"
+	"k8s.io/klog/v2"
+
+	"antrea.io/antrea/third_party/ipam/nodeipam/ipam"
+)
+
+// Controller is the controller that manages node ipam state.
+type Controller struct {
+	allocatorType ipam.CIDRAllocatorType
+
+	clusterCIDRs         []*net.IPNet
+	serviceCIDR          *net.IPNet
+	secondaryServiceCIDR *net.IPNet
+	kubeClient           clientset.Interface
+	// Method for easy mocking in unittest.
+	lookupIP func(host string) ([]net.IP, error)
+
+	nodeLister         corelisters.NodeLister
+	nodeInformerSynced cache.InformerSynced
+
+	cidrAllocator ipam.CIDRAllocator
+}
+
+// NewNodeIpamController returns a new node IP Address Management controller to
+// sync instances from cloudprovider.
+// This method returns an error if it is unable to initialize the CIDR bitmap with
+// podCIDRs it has already allocated to nodes. Since we don't allow podCIDR changes
+// currently, this should be handled as a fatal error.
+func NewNodeIpamController(
+	nodeInformer coreinformers.NodeInformer,
+	kubeClient clientset.Interface,
+	clusterCIDRs []*net.IPNet,
+	serviceCIDR *net.IPNet,
+	secondaryServiceCIDR *net.IPNet,
+	nodeCIDRMaskSizes []int,
+	allocatorType ipam.CIDRAllocatorType) (*Controller, error) {
+
+	if kubeClient == nil {
+		klog.Fatalf("kubeClient is nil when starting Controller")
+	}
+
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartStructuredLogging(0)
+
+	klog.Infof("Sending events to api server.")
+	eventBroadcaster.StartRecordingToSink(
+		&v1core.EventSinkImpl{
+			Interface: kubeClient.CoreV1().Events(""),
+		})
+
+	if kubeClient.CoreV1().RESTClient().GetRateLimiter() != nil {
+		ratelimiter.RegisterMetricAndTrackRateLimiterUsage("node_ipam_controller", kubeClient.CoreV1().RESTClient().GetRateLimiter())
+	}
+
+	// Cloud CIDR allocator does not rely on clusterCIDR or nodeCIDRMaskSize for allocation.
+	if allocatorType != ipam.CloudAllocatorType {
+		if len(clusterCIDRs) == 0 {
+			klog.Fatal("Controller: Must specify --cluster-cidr if --allocate-node-cidrs is set")
+		}
+
+		for idx, cidr := range clusterCIDRs {
+			mask := cidr.Mask
+			if maskSize, _ := mask.Size(); maskSize > nodeCIDRMaskSizes[idx] {
+				klog.Fatal("Controller: Invalid --cluster-cidr, mask size of cluster CIDR must be less than or equal to --node-cidr-mask-size configured for CIDR family")
+			}
+		}
+	}
+
+	ic := &Controller{
+		kubeClient:           kubeClient,
+		lookupIP:             net.LookupIP,
+		clusterCIDRs:         clusterCIDRs,
+		serviceCIDR:          serviceCIDR,
+		secondaryServiceCIDR: secondaryServiceCIDR,
+		allocatorType:        allocatorType,
+	}
+
+	// TODO: Abstract this check into a generic controller manager should run method.
+	if ic.allocatorType == ipam.IPAMFromClusterAllocatorType || ic.allocatorType == ipam.IPAMFromCloudAllocatorType {
+		//startLegacyIPAM(ic, nodeInformer, cloud, kubeClient, clusterCIDRs, serviceCIDR, nodeCIDRMaskSizes)
+	} else {
+		var err error
+
+		allocatorParams := ipam.CIDRAllocatorParams{
+			ClusterCIDRs:         clusterCIDRs,
+			ServiceCIDR:          ic.serviceCIDR,
+			SecondaryServiceCIDR: ic.secondaryServiceCIDR,
+			NodeCIDRMaskSizes:    nodeCIDRMaskSizes,
+		}
+
+		ic.cidrAllocator, err = ipam.New(kubeClient, nodeInformer, ic.allocatorType, allocatorParams)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	ic.nodeLister = nodeInformer.Lister()
+	ic.nodeInformerSynced = nodeInformer.Informer().HasSynced
+
+	return ic, nil
+}
+
+// Run starts an asynchronous loop that monitors the status of cluster nodes.
+func (nc *Controller) Run(stopCh <-chan struct{}) {
+	defer utilruntime.HandleCrash()
+
+	klog.Infof("Starting ipam controller")
+	defer klog.Infof("Shutting down ipam controller")
+
+	if !cache.WaitForNamedCacheSync("node", stopCh, nc.nodeInformerSynced) {
+		return
+	}
+
+	if nc.allocatorType != ipam.IPAMFromClusterAllocatorType && nc.allocatorType != ipam.IPAMFromCloudAllocatorType {
+		go nc.cidrAllocator.Run(stopCh)
+	}
+
+	<-stopCh
+}

--- a/third_party/ipam/util_node/node.go
+++ b/third_party/ipam/util_node/node.go
@@ -1,0 +1,295 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+/*
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+Modifies:
+- Cleanup unused imports due to code removal and relocation
+- Remove the following unused funcs to avoid additional code imports:
+	GetNodeHostIPs()
+	GetNodeHostIP()
+	GetNodeIP()
+*/
+
+package node
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	clientset "k8s.io/client-go/kubernetes"
+	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/klog/v2"
+)
+
+const (
+	// NodeUnreachablePodReason is the reason on a pod when its state cannot be confirmed as kubelet is unresponsive
+	// on the node it is (was) running.
+	NodeUnreachablePodReason = "NodeLost"
+	// NodeUnreachablePodMessage is the message on a pod when its state cannot be confirmed as kubelet is unresponsive
+	// on the node it is (was) running.
+	NodeUnreachablePodMessage = "Node %v which was running pod %v is unresponsive"
+)
+
+// GetHostname returns OS's hostname if 'hostnameOverride' is empty; otherwise, return 'hostnameOverride'.
+func GetHostname(hostnameOverride string) (string, error) {
+	hostName := hostnameOverride
+	if len(hostName) == 0 {
+		nodeName, err := os.Hostname()
+		if err != nil {
+			return "", fmt.Errorf("couldn't determine hostname: %v", err)
+		}
+		hostName = nodeName
+	}
+
+	// Trim whitespaces first to avoid getting an empty hostname
+	// For linux, the hostname is read from file /proc/sys/kernel/hostname directly
+	hostName = strings.TrimSpace(hostName)
+	if len(hostName) == 0 {
+		return "", fmt.Errorf("empty hostname is invalid")
+	}
+	return strings.ToLower(hostName), nil
+}
+
+// NoMatchError is a typed implementation of the error interface. It indicates a failure to get a matching Node.
+type NoMatchError struct {
+	addresses []v1.NodeAddress
+}
+
+// Error is the implementation of the conventional interface for
+// representing an error condition, with the nil value representing no error.
+func (e *NoMatchError) Error() string {
+	return fmt.Sprintf("no preferred addresses found; known addresses: %v", e.addresses)
+}
+
+// GetPreferredNodeAddress returns the address of the provided node, using the provided preference order.
+// If none of the preferred address types are found, an error is returned.
+func GetPreferredNodeAddress(node *v1.Node, preferredAddressTypes []v1.NodeAddressType) (string, error) {
+	for _, addressType := range preferredAddressTypes {
+		for _, address := range node.Status.Addresses {
+			if address.Type == addressType {
+				return address.Address, nil
+			}
+		}
+	}
+	return "", &NoMatchError{addresses: node.Status.Addresses}
+}
+
+type nodeForConditionPatch struct {
+	Status nodeStatusForPatch `json:"status"`
+}
+
+type nodeStatusForPatch struct {
+	Conditions []v1.NodeCondition `json:"conditions"`
+}
+
+// SetNodeCondition updates specific node condition with patch operation.
+func SetNodeCondition(c clientset.Interface, node types.NodeName, condition v1.NodeCondition) error {
+	generatePatch := func(condition v1.NodeCondition) ([]byte, error) {
+		patch := nodeForConditionPatch{
+			Status: nodeStatusForPatch{
+				Conditions: []v1.NodeCondition{
+					condition,
+				},
+			},
+		}
+		patchBytes, err := json.Marshal(&patch)
+		if err != nil {
+			return nil, err
+		}
+		return patchBytes, nil
+	}
+	condition.LastHeartbeatTime = metav1.NewTime(time.Now())
+	patch, err := generatePatch(condition)
+	if err != nil {
+		return nil
+	}
+	_, err = c.CoreV1().Nodes().PatchStatus(context.TODO(), string(node), patch)
+	return err
+}
+
+type nodeForCIDRMergePatch struct {
+	Spec nodeSpecForMergePatch `json:"spec"`
+}
+
+type nodeSpecForMergePatch struct {
+	PodCIDR  string   `json:"podCIDR"`
+	PodCIDRs []string `json:"podCIDRs,omitempty"`
+}
+
+// PatchNodeCIDR patches the specified node's CIDR to the given value.
+func PatchNodeCIDR(c clientset.Interface, node types.NodeName, cidr string) error {
+	patch := nodeForCIDRMergePatch{
+		Spec: nodeSpecForMergePatch{
+			PodCIDR: cidr,
+		},
+	}
+	patchBytes, err := json.Marshal(&patch)
+	if err != nil {
+		return fmt.Errorf("failed to json.Marshal CIDR: %v", err)
+	}
+
+	if _, err := c.CoreV1().Nodes().Patch(context.TODO(), string(node), types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{}); err != nil {
+		return fmt.Errorf("failed to patch node CIDR: %v", err)
+	}
+	return nil
+}
+
+// PatchNodeCIDRs patches the specified node.CIDR=cidrs[0] and node.CIDRs to the given value.
+func PatchNodeCIDRs(c clientset.Interface, node types.NodeName, cidrs []string) error {
+	// set the pod cidrs list and set the old pod cidr field
+	patch := nodeForCIDRMergePatch{
+		Spec: nodeSpecForMergePatch{
+			PodCIDR:  cidrs[0],
+			PodCIDRs: cidrs,
+		},
+	}
+
+	patchBytes, err := json.Marshal(&patch)
+	if err != nil {
+		return fmt.Errorf("failed to json.Marshal CIDR: %v", err)
+	}
+	klog.V(4).Infof("cidrs patch bytes are:%s", string(patchBytes))
+	if _, err := c.CoreV1().Nodes().Patch(context.TODO(), string(node), types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{}); err != nil {
+		return fmt.Errorf("failed to patch node CIDR: %v", err)
+	}
+	return nil
+}
+
+// PatchNodeStatus patches node status.
+func PatchNodeStatus(c v1core.CoreV1Interface, nodeName types.NodeName, oldNode *v1.Node, newNode *v1.Node) (*v1.Node, []byte, error) {
+	patchBytes, err := preparePatchBytesforNodeStatus(nodeName, oldNode, newNode)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	updatedNode, err := c.Nodes().Patch(context.TODO(), string(nodeName), types.StrategicMergePatchType, patchBytes, metav1.PatchOptions{}, "status")
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to patch status %q for node %q: %v", patchBytes, nodeName, err)
+	}
+	return updatedNode, patchBytes, nil
+}
+
+func preparePatchBytesforNodeStatus(nodeName types.NodeName, oldNode *v1.Node, newNode *v1.Node) ([]byte, error) {
+	oldData, err := json.Marshal(oldNode)
+	if err != nil {
+		return nil, fmt.Errorf("failed to Marshal oldData for node %q: %v", nodeName, err)
+	}
+
+	// NodeStatus.Addresses is incorrectly annotated as patchStrategy=merge, which
+	// will cause strategicpatch.CreateTwoWayMergePatch to create an incorrect patch
+	// if it changed.
+	manuallyPatchAddresses := (len(oldNode.Status.Addresses) > 0) && !equality.Semantic.DeepEqual(oldNode.Status.Addresses, newNode.Status.Addresses)
+
+	// Reset spec to make sure only patch for Status or ObjectMeta is generated.
+	// Note that we don't reset ObjectMeta here, because:
+	// 1. This aligns with Nodes().UpdateStatus().
+	// 2. Some component does use this to update node annotations.
+	diffNode := newNode.DeepCopy()
+	diffNode.Spec = oldNode.Spec
+	if manuallyPatchAddresses {
+		diffNode.Status.Addresses = oldNode.Status.Addresses
+	}
+	newData, err := json.Marshal(diffNode)
+	if err != nil {
+		return nil, fmt.Errorf("failed to Marshal newData for node %q: %v", nodeName, err)
+	}
+
+	patchBytes, err := strategicpatch.CreateTwoWayMergePatch(oldData, newData, v1.Node{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to CreateTwoWayMergePatch for node %q: %v", nodeName, err)
+	}
+	if manuallyPatchAddresses {
+		patchBytes, err = fixupPatchForNodeStatusAddresses(patchBytes, newNode.Status.Addresses)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fix up NodeAddresses in patch for node %q: %v", nodeName, err)
+		}
+	}
+
+	return patchBytes, nil
+}
+
+// fixupPatchForNodeStatusAddresses adds a replace-strategy patch for Status.Addresses to
+// the existing patch
+func fixupPatchForNodeStatusAddresses(patchBytes []byte, addresses []v1.NodeAddress) ([]byte, error) {
+	// Given patchBytes='{"status": {"conditions": [ ... ], "phase": ...}}' and
+	// addresses=[{"type": "InternalIP", "address": "10.0.0.1"}], we need to generate:
+	//
+	//   {
+	//     "status": {
+	//       "conditions": [ ... ],
+	//       "phase": ...,
+	//       "addresses": [
+	//         {
+	//           "type": "InternalIP",
+	//           "address": "10.0.0.1"
+	//         },
+	//         {
+	//           "$patch": "replace"
+	//         }
+	//       ]
+	//     }
+	//   }
+
+	var patchMap map[string]interface{}
+	if err := json.Unmarshal(patchBytes, &patchMap); err != nil {
+		return nil, err
+	}
+
+	addrBytes, err := json.Marshal(addresses)
+	if err != nil {
+		return nil, err
+	}
+	var addrArray []interface{}
+	if err := json.Unmarshal(addrBytes, &addrArray); err != nil {
+		return nil, err
+	}
+	addrArray = append(addrArray, map[string]interface{}{"$patch": "replace"})
+
+	status := patchMap["status"]
+	if status == nil {
+		status = map[string]interface{}{}
+		patchMap["status"] = status
+	}
+	statusMap, ok := status.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("unexpected data in patch")
+	}
+	statusMap["addresses"] = addrArray
+
+	return json.Marshal(patchMap)
+}


### PR DESCRIPTION
Import K8S NodeIPAMController code into third_party, use it within Antrea Controller. Then run it within Antrea Controller.
Usable when kube-controller-manager doesn't run nodeipam such as in EKS.
Uses RangeAllocatorType only.