### PR TITLE
[Not4Review]Hyper-V disablement support

### DIFF
--- a/pkg/agent/config/node_config.go
+++ b/pkg/agent/config/node_config.go
@@ -25,13 +25,15 @@ const (
 	// Invalid ofport_request number is in range 1 to 65,279. For ofport_request number not in the range, OVS
 	// ignore the it and automatically assign a port number.
 	// Here we use an invalid port number "0" to request for automatically port allocation.
-	AutoAssignedOFPort = 0
-	DefaultTunOFPort   = 1
-	HostGatewayOFPort  = 2
-	UplinkOFPort       = 3
-	// 0xfffffffe is a reserved port number in OpenFlow protocol, which is dedicated for the Bridge interface.
-	BridgeOFPort = 0xfffffffe
+	AutoAssignedOFPort         = 0
+	DefaultTunOFPort           = 1
+	HostGatewayOFPort          = 2
+	UplinkOFPort               = 3
+	HyperVDisabledBridgeOFPort = 4
 )
+
+// 0xfffffffe is a reserved port number in OpenFlow protocol, which is dedicated for the Bridge interface.
+var BridgeOFPort uint32 = 0xfffffffe
 
 const (
 	VXLANOverhead  = 50
@@ -93,6 +95,7 @@ type NodeConfig struct {
 	GatewayConfig *GatewayConfig
 	// The config of the OVS bridge uplink interface. Only for Windows Node.
 	UplinkNetConfig *AdapterNetConfig
+	HyperVInstalled bool
 }
 
 func (n *NodeConfig) String() string {

--- a/pkg/ovs/ovsconfig/default_windows.go
+++ b/pkg/ovs/ovsconfig/default_windows.go
@@ -25,8 +25,8 @@ const (
 
 	defaultConnNetwork = "winpipe"
 	namedPipePrefix    = `\\.\pipe\`
-	// Wait up to 5 seconds when getting port.
-	defaultGetPortTimeout    = 5 * time.Second
+	// Wait up to 15 seconds when getting port. OVS operation is slower on Windows.
+	defaultGetPortTimeout    = 15 * time.Second
 	defaultOvsVersionMessage = "OVS version not found in ovsdb.  You might try running 'ovs-vsctl --no-wait set Open_vSwitch . ovs_version=$OVS_VERSION'"
 )
 

--- a/pkg/ovs/ovsconfig/interfaces.go
+++ b/pkg/ovs/ovsconfig/interfaces.go
@@ -36,6 +36,7 @@ type OVSBridgeClient interface {
 	SetInterfaceOptions(name string, options map[string]interface{}) Error
 	CreatePort(name, ifDev string, externalIDs map[string]interface{}) (string, Error)
 	CreateInternalPort(name string, ofPortRequest int32, externalIDs map[string]interface{}) (string, Error)
+	CreateInternalPortExt(portName, ifName string, ofPortRequest int32, externalIDs map[string]interface{}) (string, Error)
 	CreateTunnelPort(name string, tunnelType TunnelType, ofPortRequest int32) (string, Error)
 	CreateTunnelPortExt(name string, tunnelType TunnelType, ofPortRequest int32, csum bool, localIP string, remoteIP string, psk string, externalIDs map[string]interface{}) (string, Error)
 	CreateUplinkPort(name string, ofPortRequest int32, externalIDs map[string]interface{}) (string, Error)

--- a/pkg/ovs/ovsconfig/ovs_client.go
+++ b/pkg/ovs/ovsconfig/ovs_client.go
@@ -362,10 +362,22 @@ func (br *OVSBridge) DeletePort(portUUID string) Error {
 // port's external_ids.
 // If ofPortRequest is not zero, it will be passed to the OVS port creation.
 func (br *OVSBridge) CreateInternalPort(name string, ofPortRequest int32, externalIDs map[string]interface{}) (string, Error) {
+	return br.CreateInternalPortExt(name, name, ofPortRequest, externalIDs)
+}
+
+// CreateInternalPortExt creates an internal port with the specified port name and
+// interface name on the bridge.
+// If externalIDs is not empty, the map key/value pairs will be set to the
+// port's external_ids.
+// If ofPortRequest is not zero, it will be passed to the OVS port creation.
+func (br *OVSBridge) CreateInternalPortExt(portName, ifName string, ofPortRequest int32, externalIDs map[string]interface{}) (string, Error) {
 	if ofPortRequest < 0 || ofPortRequest > ofPortRequestMax {
 		return "", newInvalidArgumentsError(fmt.Sprint("invalid ofPortRequest value: ", ofPortRequest))
 	}
-	return br.createPort(name, name, "internal", ofPortRequest, externalIDs, nil)
+	if ifName == "" {
+		return "", newInvalidArgumentsError("interface name can not be empty")
+	}
+	return br.createPort(portName, ifName, "internal", ofPortRequest, externalIDs, nil)
 }
 
 // CreateTunnelPort creates a tunnel port with the specified name and type on

--- a/pkg/ovs/ovsconfig/testing/mock_ovsconfig.go
+++ b/pkg/ovs/ovsconfig/testing/mock_ovsconfig.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Antrea Authors
+// Copyright 2021 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -89,6 +89,21 @@ func (m *MockOVSBridgeClient) CreateInternalPort(arg0 string, arg1 int32, arg2 m
 func (mr *MockOVSBridgeClientMockRecorder) CreateInternalPort(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateInternalPort", reflect.TypeOf((*MockOVSBridgeClient)(nil).CreateInternalPort), arg0, arg1, arg2)
+}
+
+// CreateInternalPortExt mocks base method
+func (m *MockOVSBridgeClient) CreateInternalPortExt(arg0, arg1 string, arg2 int32, arg3 map[string]interface{}) (string, ovsconfig.Error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateInternalPortExt", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(ovsconfig.Error)
+	return ret0, ret1
+}
+
+// CreateInternalPortExt indicates an expected call of CreateInternalPortExt
+func (mr *MockOVSBridgeClientMockRecorder) CreateInternalPortExt(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateInternalPortExt", reflect.TypeOf((*MockOVSBridgeClient)(nil).CreateInternalPortExt), arg0, arg1, arg2, arg3)
 }
 
 // CreatePort mocks base method


### PR DESCRIPTION
- Save Hyper-V installation status in node config
- Use interface "vEthernet (Ethernet 0)" for br-int port
- Use new OFPort number for br-int port if Hyper-V in not installed
- Increase timeout to 15s for OVSDB operation.

Signed-off-by: Rui Cao <rcao@vmware.com>