### PR TITLE
Fix bug in FlowAggregator when sending template set

### DIFF
--- a/pkg/flowaggregator/flowaggregator_test.go
+++ b/pkg/flowaggregator/flowaggregator_test.go
@@ -185,12 +185,14 @@ func TestFlowAggregator_sendTemplateSet(t *testing.T) {
 			elemList = append(elemList, ipfixentities.NewInfoElementWithValue(ipfixentities.NewInfoElement(ie, 0, 0, ipfixregistry.AntreaEnterpriseID, 0), nil))
 			mockIPFIXRegistry.EXPECT().GetInfoElement(ie, ipfixregistry.AntreaEnterpriseID).Return(elemList[i+len(ianaInfoElements)+len(ianaReverseInfoElements)+len(antreaInfoElements)+len(aggregatorElements)+len(antreaSourceStatsElementList)].Element, nil)
 		}
+		mockTempSet.EXPECT().ResetSet()
+		mockTempSet.EXPECT().PrepareSet(ipfixentities.Template, testTemplateID).Return(nil)
 		mockTempSet.EXPECT().AddRecord(elemList, testTemplateID).Return(nil)
 		// Passing 0 for sentBytes as it is not used anywhere in the test. If this not a call to mock, the actual sentBytes
 		// above elements: ianaInfoElements, ianaReverseInfoElements and antreaInfoElements.
 		mockIPFIXExpProc.EXPECT().SendSet(mockTempSet).Return(0, nil)
 
-		_, err := fa.sendTemplateSet(mockTempSet, isIPv6)
+		_, err := fa.sendTemplateSet(isIPv6)
 		assert.NoErrorf(t, err, "Error in sending template record: %v, isIPv6: %v", err, isIPv6)
 	}
 }

--- a/test/e2e/flowaggregator_test.go
+++ b/test/e2e/flowaggregator_test.go
@@ -463,8 +463,9 @@ func checkRecordsForFlows(t *testing.T, data *TestData, srcIP string, dstIP stri
 
 	// Polling to make sure all the data records corresponding to the iperf flow
 	// are received.
-	err = wait.Poll(250*time.Millisecond, collectorCheckTimeout, func() (bool, error) {
-		rc, collectorOutput, _, err := provider.RunCommandOnNode(controlPlaneNodeName(), fmt.Sprintf("kubectl logs --since=%v ipfix-collector -n antrea-test", time.Since(timeStart).String()))
+	err = wait.PollImmediate(500*time.Millisecond, aggregatorInactiveFlowRecordTimeout, func() (bool, error) {
+		// `pod-running-timeout` option is added to cover scenarios where ipfix flow-collector has crashed after being deployed.
+		rc, collectorOutput, _, err := provider.RunCommandOnNode(controlPlaneNodeName(), fmt.Sprintf("kubectl logs --since=%v --pod-running-timeout=%v ipfix-collector -n antrea-test", time.Since(timeStart).String(), aggregatorInactiveFlowRecordTimeout.String()))
 		if err != nil || rc != 0 {
 			return false, err
 		}


### PR DESCRIPTION
We need to reset set and prepare the set as a template set before sending the template record. Otherwise, the flow aggregator will crash when retrying to establish the connection to the flow collector. The bug was the missing reset set operation.

In addition, during this failure, the test is taking a long time to finish.
Fix the e2e flow aggregator test timeouts. Timeout values are quite high when the tests are failing
intermittently on dual-stack clusters.
Fix that by reducing poll timeout when checking for logs on ipfix-collector pod.

Fixes #2035 