### PR TITLE
print featuregates via antctl

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -3054,6 +3054,7 @@ rules:
   - /ovsflows
   - /ovstracing
   - /podinterfaces
+  - /featuregates
   verbs:
   - get
 ---
@@ -3229,6 +3230,7 @@ rules:
   - pods
   - namespaces
   - services
+  - configmaps
   verbs:
   - get
   - watch
@@ -3830,6 +3832,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
+        - name: ANTREA_CONFIG_MAP_NAME
+          value: antrea-config-t9hc8tf75d
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -3054,6 +3054,7 @@ rules:
   - /ovsflows
   - /ovstracing
   - /podinterfaces
+  - /featuregates
   verbs:
   - get
 ---
@@ -3229,6 +3230,7 @@ rules:
   - pods
   - namespaces
   - services
+  - configmaps
   verbs:
   - get
   - watch
@@ -3830,6 +3832,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
+        - name: ANTREA_CONFIG_MAP_NAME
+          value: antrea-config-t9hc8tf75d
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -3054,6 +3054,7 @@ rules:
   - /ovsflows
   - /ovstracing
   - /podinterfaces
+  - /featuregates
   verbs:
   - get
 ---
@@ -3229,6 +3230,7 @@ rules:
   - pods
   - namespaces
   - services
+  - configmaps
   verbs:
   - get
   - watch
@@ -3830,6 +3832,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
+        - name: ANTREA_CONFIG_MAP_NAME
+          value: antrea-config-9g829tktd6
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -3054,6 +3054,7 @@ rules:
   - /ovsflows
   - /ovstracing
   - /podinterfaces
+  - /featuregates
   verbs:
   - get
 ---
@@ -3229,6 +3230,7 @@ rules:
   - pods
   - namespaces
   - services
+  - configmaps
   verbs:
   - get
   - watch
@@ -3844,6 +3846,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
+        - name: ANTREA_CONFIG_MAP_NAME
+          value: antrea-config-h5kbhh859d
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -3054,6 +3054,7 @@ rules:
   - /ovsflows
   - /ovstracing
   - /podinterfaces
+  - /featuregates
   verbs:
   - get
 ---
@@ -3229,6 +3230,7 @@ rules:
   - pods
   - namespaces
   - services
+  - configmaps
   verbs:
   - get
   - watch
@@ -3835,6 +3837,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.serviceAccountName
+        - name: ANTREA_CONFIG_MAP_NAME
+          value: antrea-config-cbfh568k9m
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/build/yamls/base/antctl.yml
+++ b/build/yamls/base/antctl.yml
@@ -63,6 +63,7 @@ rules:
       - /ovsflows
       - /ovstracing
       - /podinterfaces
+      - /featuregates
     verbs:
       - get
 ---

--- a/build/yamls/base/controller-rbac.yml
+++ b/build/yamls/base/controller-rbac.yml
@@ -17,6 +17,7 @@ rules:
       - pods
       - namespaces
       - services
+      - configmaps
     verbs:
       - get
       - watch

--- a/build/yamls/base/controller.yml
+++ b/build/yamls/base/controller.yml
@@ -210,6 +210,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.serviceAccountName
+            - name: ANTREA_CONFIG_MAP_NAME
+              value: "$(ANTREA_CONFIG_MAP_NAME)"
           ports:
             - containerPort: 10349
               name: api

--- a/build/yamls/base/kustomization.yml
+++ b/build/yamls/base/kustomization.yml
@@ -20,5 +20,12 @@ namespace: kube-system
 replicas:
 - count: 1
   name: antrea-controller
+vars:
+  - name: ANTREA_CONFIG_MAP_NAME
+    objref:
+      kind: ConfigMap
+      name: antrea-config
+      apiVersion: v1
+
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/cmd/antrea-controller/controller.go
+++ b/cmd/antrea-controller/controller.go
@@ -412,6 +412,7 @@ func createAPIServerConfig(kubeconfig string,
 
 	return apiserver.NewConfig(
 		serverConfig,
+		client,
 		addressGroupStore,
 		appliedToGroupStore,
 		networkPolicyStore,

--- a/docs/antctl.md
+++ b/docs/antctl.md
@@ -17,6 +17,7 @@ running in two different modes:
 - [Installation](#installation)
 - [Usage](#usage)
   - [Showing or changing log verbosity level](#showing-or-changing-log-verbosity-level)
+  - [Showing feature gates status](#showing-feature-gates-status)
   - [Collecting support information](#collecting-support-information)
   - [controllerinfo and agentinfo commands](#controllerinfo-and-agentinfo-commands)
   - [NetworkPolicy commands](#networkpolicy-commands)
@@ -96,6 +97,18 @@ integer):
 
 ```bash
 antctl log-level LEVEL
+```
+
+### Showing feature gates status
+
+The feature gates of Antrea Controller and Agent can be shown using the `antctl get featuregates` command.
+The command can run locally inside the `antrea-controller` or `antrea-agent` container or out-of-cluster,
+when it is running out-of-cluster or in Controller Pod, it will print both Controller and Agent's feature gates list.
+
+The following command prints the current feature gates:
+
+```bash
+antctl get featuregates
 ```
 
 ### Collecting support information

--- a/pkg/agent/apiserver/apiserver.go
+++ b/pkg/agent/apiserver/apiserver.go
@@ -35,6 +35,7 @@ import (
 	"antrea.io/antrea/pkg/agent/apiserver/handlers/addressgroup"
 	"antrea.io/antrea/pkg/agent/apiserver/handlers/agentinfo"
 	"antrea.io/antrea/pkg/agent/apiserver/handlers/appliedtogroup"
+	"antrea.io/antrea/pkg/agent/apiserver/handlers/featuregates"
 	"antrea.io/antrea/pkg/agent/apiserver/handlers/networkpolicy"
 	"antrea.io/antrea/pkg/agent/apiserver/handlers/ovsflows"
 	"antrea.io/antrea/pkg/agent/apiserver/handlers/ovstracing"
@@ -73,6 +74,7 @@ func (s *agentAPIServer) Run(stopCh <-chan struct{}) error {
 
 func installHandlers(aq agentquerier.AgentQuerier, npq querier.AgentNetworkPolicyInfoQuerier, s *genericapiserver.GenericAPIServer) {
 	s.Handler.NonGoRestfulMux.HandleFunc("/loglevel", loglevel.HandleFunc())
+	s.Handler.NonGoRestfulMux.HandleFunc("/featuregates", featuregates.HandleFunc())
 	s.Handler.NonGoRestfulMux.HandleFunc("/agentinfo", agentinfo.HandleFunc(aq))
 	s.Handler.NonGoRestfulMux.HandleFunc("/podinterfaces", podinterface.HandleFunc(aq))
 	s.Handler.NonGoRestfulMux.HandleFunc("/networkpolicies", networkpolicy.HandleFunc(aq))

--- a/pkg/agent/apiserver/handlers/featuregates/handler.go
+++ b/pkg/agent/apiserver/handlers/featuregates/handler.go
@@ -1,0 +1,62 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package featuregates
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"k8s.io/klog/v2"
+
+	"antrea.io/antrea/pkg/features"
+)
+
+type Response struct {
+	Component string `json:"component,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Status    string `json:"status,omitempty"`
+	Version   string `json:"version,omitempty"`
+}
+
+// HandleFunc returns the function which can handle queries issued by 'antctl get featuregates' command.
+// The handler function populates Antrea Agent feature gates information to the response.
+// For now, it will return all feature gates included in features.DefaultAntreaFeatureGates for agent
+// We need to exclude any new feature gates which is not consumed by agent in the future.
+func HandleFunc() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var featureGates []Response
+		status, version := "", ""
+		for df := range features.DefaultAntreaFeatureGates {
+			if features.DefaultMutableFeatureGate.Enabled(df) {
+				status = "Enabled"
+			} else {
+				status = "Disabled"
+			}
+			version = string(features.DefaultAntreaFeatureGates[df].PreRelease)
+			featureGates = append(featureGates, Response{
+				Component: "agent",
+				Name:      string(df),
+				Status:    status,
+				Version:   version,
+			})
+		}
+
+		err := json.NewEncoder(w).Encode(featureGates)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			klog.Errorf("Error when encoding FeatureGates to json: %v", err)
+		}
+	}
+}

--- a/pkg/antctl/antctl.go
+++ b/pkg/antctl/antctl.go
@@ -23,6 +23,7 @@ import (
 	"antrea.io/antrea/pkg/agent/apiserver/handlers/podinterface"
 	"antrea.io/antrea/pkg/agent/openflow"
 	fallbackversion "antrea.io/antrea/pkg/antctl/fallback/version"
+	"antrea.io/antrea/pkg/antctl/raw/featuregates"
 	"antrea.io/antrea/pkg/antctl/raw/proxy"
 	"antrea.io/antrea/pkg/antctl/raw/supportbundle"
 	"antrea.io/antrea/pkg/antctl/raw/traceflow"
@@ -446,6 +447,12 @@ var CommandList = &commandList{
 			cobraCommand:      proxy.Command,
 			supportAgent:      false,
 			supportController: true,
+		},
+		{
+			cobraCommand:      featuregates.Command,
+			supportAgent:      true,
+			supportController: true,
+			commandGroup:      get,
 		},
 	},
 	codec: scheme.Codecs,

--- a/pkg/antctl/command_definition.go
+++ b/pkg/antctl/command_definition.go
@@ -184,6 +184,7 @@ type rawCommand struct {
 	cobraCommand      *cobra.Command
 	supportAgent      bool
 	supportController bool
+	commandGroup      commandGroup
 }
 
 // commandDefinition defines options to create a cobra.Command for an antctl client.

--- a/pkg/antctl/raw/featuregates/command.go
+++ b/pkg/antctl/raw/featuregates/command.go
@@ -1,0 +1,158 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package featuregates
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"antrea.io/antrea/pkg/antctl/raw"
+	"antrea.io/antrea/pkg/antctl/runtime"
+	"antrea.io/antrea/pkg/apiserver/handlers/featuregates"
+	antrea "antrea.io/antrea/pkg/client/clientset/versioned"
+)
+
+var Command *cobra.Command
+
+func init() {
+	Command = &cobra.Command{
+		Use:   "featuregates",
+		Short: "Get feature gates list",
+	}
+	if runtime.Mode == runtime.ModeAgent {
+		Command.RunE = agentRunE
+		Command.Long = "Get current Antrea agent feature gates info"
+	} else if runtime.Mode == runtime.ModeController && runtime.InPod {
+		Command.RunE = controllerLocalRunE
+		Command.Long = "Get Antrea feature gates info including Controller and Agent"
+	} else if runtime.Mode == runtime.ModeController && !runtime.InPod {
+		Command.Long = "Get Antrea feature gates info including Controller and Agent"
+		Command.RunE = controllerRemoteRunE
+	}
+}
+
+func agentRunE(cmd *cobra.Command, _ []string) error {
+	return featureGateRequest(cmd, runtime.ModeAgent)
+}
+
+func controllerLocalRunE(cmd *cobra.Command, _ []string) error {
+	return featureGateRequest(cmd, runtime.ModeController)
+}
+
+func controllerRemoteRunE(cmd *cobra.Command, _ []string) error {
+	return featureGateRequest(cmd, "remote")
+}
+
+func featureGateRequest(cmd *cobra.Command, mode string) error {
+	kubeconfig, err := raw.ResolveKubeconfig(cmd)
+	if err != nil {
+		return err
+	}
+	kubeconfig.GroupVersion = &schema.GroupVersion{Group: "", Version: ""}
+	restconfigTmpl := rest.CopyConfig(kubeconfig)
+	raw.SetupKubeconfig(restconfigTmpl)
+	if server, err := Command.Flags().GetString("server"); err != nil {
+		kubeconfig.Host = server
+	}
+
+	k8sClientset, antreaClientset, err := raw.SetupClients(kubeconfig)
+	if err != nil {
+		return fmt.Errorf("failed to create clientset: %w", err)
+	}
+
+	var resp []featuregates.Response
+	var client *rest.RESTClient
+
+	switch mode {
+	case runtime.ModeAgent, runtime.ModeController:
+		client, err = rest.RESTClientFor(restconfigTmpl)
+	case "remote":
+		client, err = getControllerClient(k8sClientset, antreaClientset, restconfigTmpl)
+	}
+	if err != nil {
+		return fmt.Errorf("fail to create rest client: %w", err)
+	}
+
+	if resp, err = getFeatureGatesRequest(client); err != nil {
+		return err
+	}
+	var agentGates []featuregates.Response
+	var controllerGates []featuregates.Response
+	for _, v := range resp {
+		if v.Component == "agent" {
+			agentGates = append(agentGates, v)
+		} else {
+			controllerGates = append(controllerGates, v)
+		}
+	}
+	if len(agentGates) > 0 {
+		fmt.Println(output(agentGates, runtime.ModeAgent))
+	}
+	if len(controllerGates) > 0 {
+		fmt.Println(output(controllerGates, runtime.ModeController))
+	}
+	return nil
+}
+
+func getControllerClient(k8sClientset kubernetes.Interface, antreaClientset antrea.Interface, cfgTmpl *rest.Config) (*rest.RESTClient, error) {
+	controllerClientCfg, err := raw.CreateControllerClientCfg(k8sClientset, antreaClientset, cfgTmpl)
+	if err != nil {
+		return nil, fmt.Errorf("error when creating controller client config: %w", err)
+	}
+	controllerClient, err := rest.RESTClientFor(controllerClientCfg)
+	if err != nil {
+		return nil, fmt.Errorf("error when creating controller client: %w", err)
+	}
+	return controllerClient, nil
+}
+
+func getFeatureGatesRequest(client *rest.RESTClient) ([]featuregates.Response, error) {
+	var resp []featuregates.Response
+	u := url.URL{Path: "/featuregates"}
+	getter := client.Get().RequestURI(u.RequestURI())
+	rawResp, err := getter.DoRaw(context.TODO())
+	if err != nil {
+		return nil, fmt.Errorf("error when requesting feature gates list: %w", err)
+	}
+	err = json.Unmarshal(rawResp, &resp)
+	if err != nil {
+		return nil, fmt.Errorf("fail to unmarshal feature gates list: %w", err)
+	}
+	return resp, nil
+}
+
+func output(resps []featuregates.Response, runtimeMode string) string {
+	var output strings.Builder
+	switch runtimeMode {
+	case runtime.ModeAgent:
+		output.Write([]byte("Antrea Agent Feature Gates\n"))
+	case runtime.ModeController:
+		output.Write([]byte("Antrea Controller Feature Gates\n"))
+	}
+	formatter := "%-25s%-15s%-10s\n"
+	output.Write([]byte(fmt.Sprintf(formatter, "FEATUREGATE", "STATUS", "VERSION")))
+	for _, r := range resps {
+		fmt.Fprintf(&output, formatter, r.Name, r.Status, r.Version)
+	}
+	return output.String()
+}

--- a/pkg/antctl/raw/helper.go
+++ b/pkg/antctl/raw/helper.go
@@ -1,0 +1,128 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package raw
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	agentapiserver "antrea.io/antrea/pkg/agent/apiserver"
+	"antrea.io/antrea/pkg/antctl/runtime"
+	"antrea.io/antrea/pkg/apis"
+	clusterinformationv1beta1 "antrea.io/antrea/pkg/apis/crd/v1beta1"
+	controllerapiserver "antrea.io/antrea/pkg/apiserver"
+	antrea "antrea.io/antrea/pkg/client/clientset/versioned"
+	"antrea.io/antrea/pkg/client/clientset/versioned/scheme"
+	"antrea.io/antrea/pkg/util/k8s"
+)
+
+func SetupClients(kubeconfig *rest.Config) (*kubernetes.Clientset, *antrea.Clientset, error) {
+	k8sClientset, err := kubernetes.NewForConfig(kubeconfig)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create K8s clientset: %w", err)
+	}
+	antreaClientset, err := antrea.NewForConfig(kubeconfig)
+	if err != nil {
+		return k8sClientset, nil, fmt.Errorf("error when creating Antrea clientset: %w", err)
+	}
+	return k8sClientset, antreaClientset, nil
+}
+
+func ResolveKubeconfig(cmd *cobra.Command) (*rest.Config, error) {
+	kubeconfigPath, err := cmd.Flags().GetString("kubeconfig")
+	if err != nil {
+		return nil, err
+	}
+	kubeconfig, err := runtime.ResolveKubeconfig(kubeconfigPath)
+	if err != nil {
+		return nil, err
+	}
+	return kubeconfig, nil
+}
+
+// TODO: generate kubeconfig in Antrea agent for antctl in-Pod access.
+func SetupKubeconfig(kubeconfig *rest.Config) {
+	kubeconfig.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	kubeconfig.Insecure = true
+	kubeconfig.CAFile = ""
+	kubeconfig.CAData = nil
+	if runtime.InPod {
+		if runtime.Mode == runtime.ModeAgent {
+			kubeconfig.Host = net.JoinHostPort("127.0.0.1", strconv.Itoa(apis.AntreaAgentAPIPort))
+			kubeconfig.BearerTokenFile = agentapiserver.TokenPath
+		} else {
+			kubeconfig.Host = net.JoinHostPort("127.0.0.1", strconv.Itoa(apis.AntreaControllerAPIPort))
+			kubeconfig.BearerTokenFile = controllerapiserver.TokenPath
+		}
+	}
+}
+
+func CreateAgentClientCfg(k8sClientset kubernetes.Interface, antreaClientset antrea.Interface, cfgTmpl *rest.Config, nodeName string) (*rest.Config, error) {
+	node, err := k8sClientset.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("error when looking up Node %s: %w", nodeName, err)
+	}
+	// TODO: filter by Node name, but that would require API support
+	agentInfoList, err := antreaClientset.CrdV1beta1().AntreaAgentInfos().List(context.TODO(), metav1.ListOptions{ResourceVersion: "0"})
+	if err != nil {
+		return nil, err
+	}
+	var agentInfo *clusterinformationv1beta1.AntreaAgentInfo
+	for i := range agentInfoList.Items {
+		ai := agentInfoList.Items[i]
+		if ai.NodeRef.Name == nodeName {
+			agentInfo = &ai
+			break
+		}
+	}
+	if agentInfo == nil {
+		return nil, fmt.Errorf("no Antrea Agent found for Node name %s", nodeName)
+	}
+	nodeIP, err := k8s.GetNodeAddr(node)
+	if err != nil {
+		return nil, fmt.Errorf("error when parsing IP of Node %s", nodeName)
+	}
+	cfg := rest.CopyConfig(cfgTmpl)
+	cfg.Host = fmt.Sprintf("https://%s", net.JoinHostPort(nodeIP.String(), fmt.Sprint(agentInfo.APIPort)))
+	return cfg, nil
+}
+
+func CreateControllerClientCfg(k8sClientset kubernetes.Interface, antreaClientset antrea.Interface, cfgTmpl *rest.Config) (*rest.Config, error) {
+	controllerInfo, err := antreaClientset.CrdV1beta1().AntreaControllerInfos().Get(context.TODO(), "antrea-controller", metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	controllerNode, err := k8sClientset.CoreV1().Nodes().Get(context.TODO(), controllerInfo.NodeRef.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("error when searching the Node of the controller: %w", err)
+	}
+	var controllerNodeIP net.IP
+	controllerNodeIP, err = k8s.GetNodeAddr(controllerNode)
+	if err != nil {
+		return nil, fmt.Errorf("error when parsing controller IP: %w", err)
+	}
+
+	cfg := rest.CopyConfig(cfgTmpl)
+	cfg.Host = fmt.Sprintf("https://%s", net.JoinHostPort(controllerNodeIP.String(), fmt.Sprint(controllerInfo.APIPort)))
+	return cfg, nil
+}

--- a/pkg/antctl/raw/traceflow/command.go
+++ b/pkg/antctl/raw/traceflow/command.go
@@ -34,9 +34,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 
-	"antrea.io/antrea/pkg/antctl/runtime"
+	"antrea.io/antrea/pkg/antctl/raw"
 	"antrea.io/antrea/pkg/apis/crd/v1alpha1"
-	clientset "antrea.io/antrea/pkg/client/clientset/versioned"
 )
 
 const defaultTimeout time.Duration = time.Second * 10
@@ -142,22 +141,14 @@ func runE(cmd *cobra.Command, _ []string) error {
 		return nil
 	}
 
-	kubeconfigPath, err := cmd.Flags().GetString("kubeconfig")
-	if err != nil {
-		return err
-	}
-	kubeconfig, err := runtime.ResolveKubeconfig(kubeconfigPath)
+	kubeconfig, err := raw.ResolveKubeconfig(cmd)
 	if err != nil {
 		return err
 	}
 
-	k8sclient, err := kubernetes.NewForConfig(kubeconfig)
+	k8sclient, client, err := raw.SetupClients(kubeconfig)
 	if err != nil {
-		return fmt.Errorf("error when creating kubernetes clientset: %w", err)
-	}
-	client, err := clientset.NewForConfig(kubeconfig)
-	if err != nil {
-		return fmt.Errorf("error when creating clientset: %w", err)
+		return fmt.Errorf("failed to create clientset: %w", err)
 	}
 
 	tf, err := newTraceflow(k8sclient)

--- a/pkg/apiserver/handlers/featuregates/handler.go
+++ b/pkg/apiserver/handlers/featuregates/handler.go
@@ -1,0 +1,129 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package featuregates
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"gopkg.in/yaml.v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+
+	"antrea.io/antrea/pkg/features"
+	"antrea.io/antrea/pkg/util/env"
+)
+
+var controllerOnlyGates = sets.NewString("Traceflow", "AntreaPolicy", "Egress", "NetworkPolicyStats")
+
+type (
+	Config struct {
+		// FeatureGates is a map of feature names to bools that enable or disable experimental features.
+		FeatureGates map[string]bool `yaml:"featureGates,omitempty"`
+	}
+
+	Response struct {
+		Component string `json:"component,omitempty"`
+		Name      string `json:"name,omitempty"`
+		Status    string `json:"status,omitempty"`
+		Version   string `json:"version,omitempty"`
+	}
+)
+
+const (
+	controllerMode = "controller"
+	agentMode      = "agent"
+)
+
+// HandleFunc returns the function which can handle queries issued by 'antctl get featuregates' command.
+// The handler function populates Antrea featuregates information to the response.
+// For now, it will return all feature gates included in features.DefaultAntreaFeatureGates for agent
+// We need to exclude any new feature gates which is not consumed by agent in the future.
+func HandleFunc(k8sclient clientset.Interface) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		antreaConfigName := env.GetAntreaConfigMapName()
+		antreaConfig, err := k8sclient.CoreV1().ConfigMaps(env.GetAntreaNamespace()).Get(context.TODO(), antreaConfigName, metav1.GetOptions{})
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			klog.Errorf("Error when getting config map %s: %v", antreaConfigName, err)
+			return
+		}
+
+		agentConfig := &Config{}
+		err = yaml.Unmarshal([]byte(antreaConfig.Data["antrea-agent.conf"]), agentConfig)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			klog.Errorf("Failed to unmarshal Antrea antrea-agent.conf: %v", err)
+			return
+		}
+
+		agentfeatureGates := getAgentGatesResponse(agentConfig)
+		controllerfeatureGates := getControllerGatesResponse()
+		result := append(agentfeatureGates, controllerfeatureGates...)
+		err = json.NewEncoder(w).Encode(result)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			klog.Errorf("Error when encoding FeatureGates to json: %v", err)
+			return
+		}
+	}
+}
+
+func getAgentGatesResponse(cfg *Config) []Response {
+	gatesResp := []Response{}
+	for df := range features.DefaultAntreaFeatureGates {
+		dfs := string(df)
+		status, ok := cfg.FeatureGates[dfs]
+		if !ok {
+			status = features.DefaultMutableFeatureGate.Enabled(df)
+		}
+		featureStatus := getStatus(status)
+		gatesResp = append(gatesResp, Response{
+			Component: agentMode,
+			Name:      dfs,
+			Status:    featureStatus,
+			Version:   string(features.DefaultAntreaFeatureGates[df].PreRelease),
+		})
+	}
+	return gatesResp
+}
+
+func getControllerGatesResponse() []Response {
+	gatesResp := []Response{}
+	for df := range features.DefaultAntreaFeatureGates {
+		dfs := string(df)
+		if !controllerOnlyGates.Has(dfs) {
+			continue
+		}
+		gatesResp = append(gatesResp, Response{
+			Component: controllerMode,
+			Name:      dfs,
+			Status:    getStatus(features.DefaultMutableFeatureGate.Enabled(df)),
+			Version:   string(features.DefaultAntreaFeatureGates[df].PreRelease),
+		})
+	}
+	return gatesResp
+}
+
+func getStatus(status bool) string {
+	if status {
+		return "Enabled"
+	} else {
+		return "Disabled"
+	}
+}

--- a/pkg/apiserver/handlers/featuregates/handler_test.go
+++ b/pkg/apiserver/handlers/featuregates/handler_test.go
@@ -1,0 +1,208 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package featuregates
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"antrea.io/antrea/pkg/features"
+)
+
+func Test_getGatesResponse(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *Config
+		want []Response
+	}{
+		{
+			name: "mutated AntreaPolicy feature gate, agent mode",
+			cfg: &Config{
+				FeatureGates: map[string]bool{
+					"AntreaPolicy": false,
+				},
+			},
+			want: []Response{
+				{Component: "agent", Name: "AntreaPolicy", Status: "Disabled", Version: "BETA"},
+				{Component: "agent", Name: "AntreaProxy", Status: "Enabled", Version: "BETA"},
+				{Component: "agent", Name: "Egress", Status: "Disabled", Version: "ALPHA"},
+				{Component: "agent", Name: "EndpointSlice", Status: "Disabled", Version: "ALPHA"},
+				{Component: "agent", Name: "Traceflow", Status: "Enabled", Version: "BETA"},
+				{Component: "agent", Name: "FlowExporter", Status: "Disabled", Version: "ALPHA"},
+				{Component: "agent", Name: "NetworkPolicyStats", Status: "Disabled", Version: "ALPHA"},
+				{Component: "agent", Name: "NodePortLocal", Status: "Disabled", Version: "ALPHA"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getAgentGatesResponse(tt.cfg)
+			sort.SliceStable(got, func(i, j int) bool {
+				return got[i].Name < got[j].Name
+			})
+			sort.SliceStable(tt.want, func(i, j int) bool {
+				return tt.want[i].Name < tt.want[j].Name
+			})
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getAgentGatesResponse() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_getStatus(t *testing.T) {
+	tests := []struct {
+		name   string
+		status bool
+		want   string
+	}{
+		{
+			name:   "Enabled case",
+			status: true,
+			want:   "Enabled",
+		},
+		{
+			name:   "Disabled case",
+			status: false,
+			want:   "Disabled",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getStatus(tt.status); got != tt.want {
+				t.Errorf("getStatus() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHandleFunc(t *testing.T) {
+	fakeClient := fake.NewSimpleClientset(
+		&v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "antrea-controller-wotqiwth",
+				Namespace: "kube-system",
+			},
+			Spec: v1.PodSpec{
+				Volumes: []v1.Volume{{
+					Name: "antrea-config",
+					VolumeSource: v1.VolumeSource{ConfigMap: &v1.ConfigMapVolumeSource{
+						LocalObjectReference: v1.LocalObjectReference{
+							Name: "antrea-config-aswieut",
+						},
+					}},
+				}}},
+		},
+		&v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "kube-system", Name: "antrea-config-aswieut"},
+			Data: map[string]string{
+				"antrea-agent.conf":      "#configmap-value",
+				"antrea-controller.conf": "#configmap-value",
+			},
+		},
+	)
+
+	tests := []struct {
+		name             string
+		expectedStatus   int
+		expectedResponse []Response
+	}{
+		{
+			name:           "good path",
+			expectedStatus: http.StatusOK,
+			expectedResponse: []Response{
+				{Component: "controller", Name: "AntreaPolicy", Status: "Enabled", Version: "BETA"},
+				{Component: "controller", Name: "Egress", Status: "Disabled", Version: "ALPHA"},
+				{Component: "controller", Name: "Traceflow", Status: "Enabled", Version: "BETA"},
+				{Component: "controller", Name: "NetworkPolicyStats", Status: "Disabled", Version: "ALPHA"},
+				{Component: "agent", Name: "AntreaPolicy", Status: "Enabled", Version: "BETA"},
+				{Component: "agent", Name: "AntreaProxy", Status: "Enabled", Version: "BETA"},
+				{Component: "agent", Name: "Egress", Status: "Disabled", Version: "ALPHA"},
+				{Component: "agent", Name: "EndpointSlice", Status: "Disabled", Version: "ALPHA"},
+				{Component: "agent", Name: "Traceflow", Status: "Enabled", Version: "BETA"},
+				{Component: "agent", Name: "FlowExporter", Status: "Disabled", Version: "ALPHA"},
+				{Component: "agent", Name: "NetworkPolicyStats", Status: "Disabled", Version: "ALPHA"},
+				{Component: "agent", Name: "NodePortLocal", Status: "Disabled", Version: "ALPHA"},
+			},
+		},
+	}
+	os.Setenv("POD_NAME", "antrea-controller-wotqiwth")
+	os.Setenv("ANTREA_CONFIG_MAP_NAME", "antrea-config-aswieut")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := HandleFunc(fakeClient)
+			req, err := http.NewRequest(http.MethodGet, "", nil)
+			assert.Nil(t, err)
+			recorder := httptest.NewRecorder()
+			handler.ServeHTTP(recorder, req)
+			assert.Equal(t, tt.expectedStatus, recorder.Code)
+			if tt.expectedStatus != http.StatusOK {
+				return
+			}
+			var resp []Response
+			err = json.Unmarshal(recorder.Body.Bytes(), &resp)
+			assert.Nil(t, err)
+			for _, v := range resp {
+				for n, f := range features.DefaultAntreaFeatureGates {
+					if v.Name == string(n) {
+						assert.Equal(t, v.Status, getStatus(f.Default))
+						assert.Equal(t, v.Version, string(f.PreRelease))
+					}
+				}
+			}
+		})
+	}
+}
+
+func Test_getControllerGatesResponse(t *testing.T) {
+	tests := []struct {
+		name string
+		want []Response
+	}{
+		{
+			name: "good path",
+			want: []Response{
+				{Component: "controller", Name: "AntreaPolicy", Status: "Enabled", Version: "BETA"},
+				{Component: "controller", Name: "Egress", Status: "Disabled", Version: "ALPHA"},
+				{Component: "controller", Name: "Traceflow", Status: "Enabled", Version: "BETA"},
+				{Component: "controller", Name: "NetworkPolicyStats", Status: "Disabled", Version: "ALPHA"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getControllerGatesResponse()
+			sort.SliceStable(got, func(i, j int) bool {
+				return got[i].Name < got[j].Name
+			})
+			sort.SliceStable(tt.want, func(i, j int) bool {
+				return tt.want[i].Name < tt.want[j].Name
+			})
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getControllerGatesResponse() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/apiserver/registry/system/controllerinfo/rest_test.go
+++ b/pkg/apiserver/registry/system/controllerinfo/rest_test.go
@@ -23,6 +23,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	clientset "k8s.io/client-go/kubernetes"
 
 	"antrea.io/antrea/pkg/apis/crd/v1beta1"
 )
@@ -30,6 +31,8 @@ import (
 type fakeControllerQuerier struct{}
 
 func (q *fakeControllerQuerier) GetControllerInfo(info *v1beta1.AntreaControllerInfo, partial bool) {}
+
+func (q *fakeControllerQuerier) GetK8sClient() clientset.Interface { return nil }
 
 func TestRESTList(t *testing.T) {
 	tests := []struct {

--- a/pkg/controller/querier/querier.go
+++ b/pkg/controller/querier/querier.go
@@ -37,8 +37,12 @@ type controllerQuerier struct {
 	apiPort                  int
 }
 
-func NewControllerQuerier(networkPolicyInfoQuerier querier.ControllerNetworkPolicyInfoQuerier, apiPort int) *controllerQuerier {
-	return &controllerQuerier{networkPolicyInfoQuerier: networkPolicyInfoQuerier, apiPort: apiPort}
+func NewControllerQuerier(networkPolicyInfoQuerier querier.ControllerNetworkPolicyInfoQuerier,
+	apiPort int) *controllerQuerier {
+	return &controllerQuerier{
+		networkPolicyInfoQuerier: networkPolicyInfoQuerier,
+		apiPort:                  apiPort,
+	}
 }
 
 // getNetworkPolicyInfoQuerier gets current network policy info querier.

--- a/pkg/features/antrea_features.go
+++ b/pkg/features/antrea_features.go
@@ -79,7 +79,7 @@ var (
 	// defaultAntreaFeatureGates consists of all known Antrea-specific feature keys.
 	// To add a new feature, define a key for it above and add it here. The features will be
 	// available throughout Antrea binaries.
-	defaultAntreaFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
+	DefaultAntreaFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 		AntreaPolicy:       {Default: true, PreRelease: featuregate.Beta},
 		AntreaProxy:        {Default: true, PreRelease: featuregate.Beta},
 		Egress:             {Default: false, PreRelease: featuregate.Alpha},
@@ -107,12 +107,12 @@ var (
 )
 
 func init() {
-	runtime.Must(DefaultMutableFeatureGate.Add(defaultAntreaFeatureGates))
+	runtime.Must(DefaultMutableFeatureGate.Add(DefaultAntreaFeatureGates))
 }
 
 // SupportedOnWindows checks whether a feature is supported on a Windows Node.
 func SupportedOnWindows(feature featuregate.Feature) bool {
-	_, exists := defaultAntreaFeatureGates[feature]
+	_, exists := DefaultAntreaFeatureGates[feature]
 	if !exists {
 		return false
 	}

--- a/pkg/util/env/env.go
+++ b/pkg/util/env/env.go
@@ -21,12 +21,12 @@ import (
 	"k8s.io/klog/v2"
 )
 
-// NodeNameEnvKey is environment variable.
 const (
-	NodeNameEnvKey     = "NODE_NAME"
-	podNameEnvKey      = "POD_NAME"
-	podNamespaceEnvKey = "POD_NAMESPACE"
-	svcAcctNameEnvKey  = "SERVICEACCOUNT_NAME"
+	NodeNameEnvKey        = "NODE_NAME"
+	podNameEnvKey         = "POD_NAME"
+	podNamespaceEnvKey    = "POD_NAMESPACE"
+	svcAcctNameEnvKey     = "SERVICEACCOUNT_NAME"
+	antreaConfigMapEnvKey = "ANTREA_CONFIG_MAP_NAME"
 
 	antreaCloudEKSEnvKey = "ANTREA_CLOUD_EKS"
 
@@ -58,6 +58,15 @@ func GetPodName() string {
 		klog.Warningf("Environment variable %s not found", podNameEnvKey)
 	}
 	return podName
+}
+
+// GetAntreaConfigMapName returns the configMap name of Antrea config.
+func GetAntreaConfigMapName() string {
+	configMapName := os.Getenv(antreaConfigMapEnvKey)
+	if configMapName == "" {
+		klog.Warningf("Environment variable %s not found", antreaConfigMapEnvKey)
+	}
+	return configMapName
 }
 
 // GetPodNamespace returns Namespace of the Pod where the code executes.

--- a/pkg/util/env/env_test.go
+++ b/pkg/util/env/env_test.go
@@ -74,3 +74,21 @@ func comparePodName(k, v string, t *testing.T) {
 		t.Errorf("Failed to retrieve pod name, want: %s, get: %s", v, podName)
 	}
 }
+
+func TestGetAntreaConfigMapName(t *testing.T) {
+	testTable := map[string]string{
+		"antrea-config-asjqowieut": "antrea-config-asjqowieut",
+		"antrea-config-x":          "antrea-config-x",
+	}
+
+	for k, v := range testTable {
+		if k != "" {
+			_ = os.Setenv(antreaConfigMapEnvKey, k)
+			defer os.Unsetenv(antreaConfigMapEnvKey)
+		}
+		configMapName := GetAntreaConfigMapName()
+		if configMapName != v {
+			t.Errorf("Failed to retrieve antrea configmap name, want: %s, get: %s", v, configMapName)
+		}
+	}
+}

--- a/test/e2e/antctl_test.go
+++ b/test/e2e/antctl_test.go
@@ -63,7 +63,7 @@ func antctlCoverageArgs(antctlPath string) []string {
 	return []string{antctlPath, "-test.run=TestBincoverRunMain", fmt.Sprintf("-test.coverprofile=antctl-%s.out", timeStamp)}
 }
 
-// TestAntctlAgentLocalAccess ensures antctl is accessible in a agent Pod.
+// TestAntctlAgentLocalAccess ensures antctl is accessible in an agent Pod.
 func TestAntctlAgentLocalAccess(t *testing.T) {
 	skipIfHasWindowsNodes(t)
 


### PR DESCRIPTION
allow user to run `antctl get featuregates` inside of agent or controller container or out of cluster to get feature gates information.
Resolves https://github.com/vmware-tanzu/antrea/issues/2010
sample cli:
```
#antctl get featuregates
Antrea Agent Feature Gates
FEATUREGATE              STATUS         VERSION
AntreaProxy              Enabled        BETA
Egress                   Disabled       ALPHA
EndpointSlice            Disabled       ALPHA
Traceflow                Enabled        BETA
FlowExporter             Disabled       ALPHA
NetworkPolicyStats       Disabled       ALPHA
NodePortLocal            Disabled       ALPHA
AntreaPolicy             Enabled        BETA

Antrea Controller Feature Gates
FEATUREGATE              STATUS         VERSION
NetworkPolicyStats       Disabled       ALPHA
AntreaPolicy             Enabled        BETA
Egress                   Disabled       ALPHA
Traceflow                Enabled        BETA

```

 Signed-off-by: Lan Luo <luola@vmware.com>
