### PR TITLE
Add performance unit test for Flow Exporter

### DIFF
--- a/pkg/agent/flowexporter/connections/connections.go
+++ b/pkg/agent/flowexporter/connections/connections.go
@@ -66,6 +66,14 @@ func (cs *connectionStore) ForAllConnectionsDo(callback flowexporter.ConnectionM
 	return nil
 }
 
+// AddConnToMap adds the connection to connections map given connection key.
+// This is used only for unit tests.
+func (cs *connectionStore) AddConnToMap(connKey *flowexporter.ConnectionKey, conn *flowexporter.Connection) {
+	cs.mutex.Lock()
+	defer cs.mutex.Unlock()
+	cs.connections[*connKey] = conn
+}
+
 func (cs *connectionStore) fillPodInfo(conn *flowexporter.Connection) {
 	if cs.ifaceStore == nil {
 		klog.V(4).Info("Interface store is not available to retrieve local Pods information.")

--- a/pkg/agent/flowexporter/connections/conntrack_connections_perf_test.go
+++ b/pkg/agent/flowexporter/connections/conntrack_connections_perf_test.go
@@ -1,0 +1,178 @@
+// +build !race
+
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connections
+
+import (
+	"crypto/rand"
+	"flag"
+	"fmt"
+	"math/big"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2"
+
+	"antrea.io/antrea/pkg/agent/flowexporter"
+	connectionstest "antrea.io/antrea/pkg/agent/flowexporter/connections/testing"
+	"antrea.io/antrea/pkg/agent/flowexporter/flowrecords"
+	"antrea.io/antrea/pkg/agent/interfacestore"
+	interfacestoretest "antrea.io/antrea/pkg/agent/interfacestore/testing"
+	"antrea.io/antrea/pkg/agent/openflow"
+	proxytest "antrea.io/antrea/pkg/agent/proxy/testing"
+	queriertest "antrea.io/antrea/pkg/querier/testing"
+	k8sproxy "antrea.io/antrea/third_party/proxy"
+)
+
+const (
+	testNumOfConns        = 10000
+	testNumOfNewConns     = 1000
+	testNumOfDeletedConns = 1000
+)
+
+/*
+Sample output (10000 init connections, 1000 new connections, 1000 deleted connections):
+    go test -test.v -run=BenchmarkPoll -test.benchmem -bench=. -memprofile memprofile.out -cpuprofile profile.out
+	goos: linux
+	goarch: amd64
+	pkg: antrea.io/antrea/pkg/agent/flowexporter/connections
+	cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+	BenchmarkPoll
+	BenchmarkPoll-2   	     116	   9068998 ns/op	  889713 B/op	   54458 allocs/op
+	PASS
+	ok  	antrea.io/antrea/pkg/agent/flowexporter/connections	3.618s
+*/
+
+func BenchmarkPoll(b *testing.B) {
+	disableLogToStderr()
+	connStore, mockConnDumper := setupConntrackConnStore(b)
+	conns := generateConns()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		mockConnDumper.EXPECT().DumpFlows(uint16(openflow.CtZone)).Return(conns, testNumOfConns, nil)
+		connStore.Poll()
+		b.StopTimer()
+		conns = generateUpdatedConns(conns)
+		b.StartTimer()
+	}
+	b.Logf("\nSummary:\nNumber of initial connections: %d\nNumber of new connections/poll: %d\nNumber of deleted connections/poll: %d\n", testNumOfConns, testNumOfNewConns, testNumOfDeletedConns)
+}
+
+func setupConntrackConnStore(b *testing.B) (*ConntrackConnectionStore, *connectionstest.MockConnTrackDumper) {
+	ctrl := gomock.NewController(b)
+	defer ctrl.Finish()
+	mockIfaceStore := interfacestoretest.NewMockInterfaceStore(ctrl)
+	testInterface := &interfacestore.InterfaceConfig{
+		Type: interfacestore.ContainerInterface,
+		ContainerInterfaceConfig: &interfacestore.ContainerInterfaceConfig{
+			PodName:      "pod",
+			PodNamespace: "pod-ns",
+		},
+	}
+	mockIfaceStore.EXPECT().GetInterfaceByIP(gomock.Any()).Return(testInterface, true).AnyTimes()
+
+	mockConnDumper := connectionstest.NewMockConnTrackDumper(ctrl)
+	mockConnDumper.EXPECT().GetMaxConnections().Return(100000, nil).AnyTimes()
+
+	serviceStr := "10.0.0.1:30000/TCP"
+	servicePortName := k8sproxy.ServicePortName{
+		NamespacedName: types.NamespacedName{
+			Namespace: "serviceNS1",
+			Name:      "service1",
+		},
+		Port:     "30000",
+		Protocol: v1.ProtocolTCP,
+	}
+	mockProxier := proxytest.NewMockProxier(ctrl)
+	mockProxier.EXPECT().GetServiceByIP(serviceStr).Return(servicePortName, true).AnyTimes()
+
+	npQuerier := queriertest.NewMockAgentNetworkPolicyInfoQuerier(ctrl)
+
+	return NewConntrackConnectionStore(mockConnDumper, flowrecords.NewFlowRecords(), mockIfaceStore, true, false, mockProxier, npQuerier, testPollInterval), mockConnDumper
+}
+
+func generateConns() []*flowexporter.Connection {
+	conns := make([]*flowexporter.Connection, testNumOfConns)
+	for i := 0; i < testNumOfConns; i++ {
+		conns[i] = getNewConn()
+	}
+	return conns
+}
+
+func generateUpdatedConns(conns []*flowexporter.Connection) []*flowexporter.Connection {
+	length := len(conns) - testNumOfDeletedConns + testNumOfNewConns
+	updatedConns := make([]*flowexporter.Connection, length)
+	for i := 0; i < len(conns); i++ {
+		// replace deleted connection with new connection
+		if conns[i].DoneExport == true {
+			conns[i] = getNewConn()
+		} else { // update rest of connections
+			conns[i].OriginalPackets += 5
+			conns[i].OriginalBytes += 20
+			conns[i].ReversePackets += 2
+			conns[i].ReverseBytes += 10
+		}
+		updatedConns[i] = conns[i]
+	}
+	for i := len(conns); i < length; i++ {
+		updatedConns[i] = getNewConn()
+	}
+	randomNum := getRandomNum(int64(length - testNumOfDeletedConns))
+	for i := randomNum; i < testNumOfDeletedConns+randomNum; i++ {
+		// hardcode DoneExport here for testing deletion of connections
+		// not valid for testing update and export of records
+		updatedConns[i].DoneExport = true
+	}
+	return updatedConns
+}
+
+func getNewConn() *flowexporter.Connection {
+	randomNum1 := getRandomNum(255)
+	randomNum2 := getRandomNum(255)
+	randomNum3 := getRandomNum(255)
+	src := net.ParseIP(fmt.Sprintf("192.%d.%d.%d", randomNum1, randomNum2, randomNum3))
+	dst := net.ParseIP(fmt.Sprintf("192.%d.%d.%d", randomNum3, randomNum2, randomNum1))
+	flowKey := flowexporter.Tuple{SourceAddress: src, DestinationAddress: dst, Protocol: 6, SourcePort: uint16(randomNum1), DestinationPort: uint16(randomNum2)}
+	return &flowexporter.Connection{
+		StartTime:                 time.Now().Add(-time.Duration(randomNum1) * time.Second),
+		StopTime:                  time.Now(),
+		IsPresent:                 true,
+		DoneExport:                false,
+		FlowKey:                   flowKey,
+		OriginalPackets:           10,
+		OriginalBytes:             100,
+		ReversePackets:            5,
+		ReverseBytes:              50,
+		DestinationServiceAddress: net.ParseIP("10.0.0.1"),
+		DestinationServicePort:    30000,
+		TCPState:                  "SYN_SENT",
+	}
+}
+
+func getRandomNum(value int64) uint64 {
+	number, _ := rand.Int(rand.Reader, big.NewInt(value))
+	return number.Uint64()
+}
+
+func disableLogToStderr() {
+	klogFlagSet := flag.NewFlagSet("klog", flag.ContinueOnError)
+	klog.InitFlags(klogFlagSet)
+	klogFlagSet.Parse([]string{"-logtostderr=false"})
+}

--- a/pkg/agent/flowexporter/connections/deny_connections.go
+++ b/pkg/agent/flowexporter/connections/deny_connections.go
@@ -71,8 +71,7 @@ func (ds *DenyConnectionStore) AddOrUpdateConn(conn *flowexporter.Connection, ti
 
 // ResetConnStatsWithoutLock resets DeltaBytes and DeltaPackets of connection
 // after exporting without grabbing the lock. Caller is expected to grab lock.
-func (ds *DenyConnectionStore) ResetConnStatsWithoutLock(conn *flowexporter.Connection) {
-	connKey := flowexporter.NewConnectionKey(conn)
+func (ds *DenyConnectionStore) ResetConnStatsWithoutLock(connKey flowexporter.ConnectionKey) {
 	conn, exist := ds.connections[connKey]
 	if !exist {
 		klog.Warningf("Connection with key %s does not exist in deny connection store.", connKey)

--- a/pkg/agent/flowexporter/exporter/exporter.go
+++ b/pkg/agent/flowexporter/exporter/exporter.go
@@ -104,26 +104,20 @@ type flowExporter struct {
 	k8sClient           kubernetes.Interface
 	nodeRouteController *noderoute.Controller
 	isNetworkPolicyOnly bool
+	nodeName            string
 }
 
-func genObservationID() (uint32, error) {
-	name, err := env.GetNodeName()
-	if err != nil {
-		return 0, err
-	}
+func genObservationID(nodeName string) uint32 {
 	h := fnv.New32()
-	h.Write([]byte(name))
-	return h.Sum32(), nil
+	h.Write([]byte(nodeName))
+	return h.Sum32()
 }
 
-func prepareExporterInputArgs(collectorAddr, collectorProto string) (exporter.ExporterInput, error) {
+func prepareExporterInputArgs(collectorAddr, collectorProto, nodeName string) exporter.ExporterInput {
 	expInput := exporter.ExporterInput{}
-	var err error
 	// Exporting process requires domain observation ID.
-	expInput.ObservationDomainID, err = genObservationID()
-	if err != nil {
-		return expInput, err
-	}
+	expInput.ObservationDomainID = genObservationID(nodeName)
+
 	expInput.CollectorAddress = collectorAddr
 	if collectorProto == "tls" {
 		expInput.IsEncrypted = true
@@ -134,7 +128,7 @@ func prepareExporterInputArgs(collectorAddr, collectorProto string) (exporter.Ex
 	}
 	expInput.PathMTU = 0
 
-	return expInput, nil
+	return expInput
 }
 
 func NewFlowExporter(connStore *connections.ConntrackConnectionStore, records *flowrecords.FlowRecords, denyConnStore *connections.DenyConnectionStore,
@@ -146,10 +140,11 @@ func NewFlowExporter(connStore *connections.ConntrackConnectionStore, records *f
 	registry.LoadRegistry()
 
 	// Prepare input args for IPFIX exporting process.
-	expInput, err := prepareExporterInputArgs(collectorAddr, collectorProto)
+	nodeName, err := env.GetNodeName()
 	if err != nil {
 		return nil, err
 	}
+	expInput := prepareExporterInputArgs(collectorAddr, collectorProto, nodeName)
 
 	return &flowExporter{
 		conntrackConnStore:  connStore,
@@ -165,6 +160,7 @@ func NewFlowExporter(connStore *connections.ConntrackConnectionStore, records *f
 		k8sClient:           k8sClient,
 		nodeRouteController: nodeRouteController,
 		isNetworkPolicyOnly: isNetworkPolicyOnly,
+		nodeName:            nodeName,
 	}, nil
 }
 
@@ -334,7 +330,7 @@ func (exp *flowExporter) sendFlowRecords() error {
 				return err
 			}
 			exp.numDataSetsSent = exp.numDataSetsSent + 1
-			exp.denyConnStore.ResetConnStatsWithoutLock(conn)
+			exp.denyConnStore.ResetConnStatsWithoutLock(connKey)
 		}
 		if time.Since(conn.LastExportTime) >= exp.idleFlowTimeout {
 			if err := exp.addDenyConnToSet(conn, ipfixregistry.IdleTimeoutReason); err != nil {
@@ -414,8 +410,6 @@ func (exp *flowExporter) sendTemplateSet(isIPv6 bool) (int, error) {
 }
 
 func (exp *flowExporter) addRecordToSet(record flowexporter.FlowRecord) error {
-	nodeName, _ := env.GetNodeName()
-
 	// Iterate over all infoElements in the list
 	eL := exp.elementsListv4
 	if record.IsIPv6 {
@@ -488,7 +482,7 @@ func (exp *flowExporter) addRecordToSet(record flowexporter.FlowRecord) error {
 		case "sourceNodeName":
 			// Add nodeName for only local pods whose pod names are resolved.
 			if record.Conn.SourcePodName != "" {
-				ie.Value = nodeName
+				ie.Value = exp.nodeName
 			} else {
 				ie.Value = ""
 			}
@@ -499,7 +493,7 @@ func (exp *flowExporter) addRecordToSet(record flowexporter.FlowRecord) error {
 		case "destinationNodeName":
 			// Add nodeName for only local pods whose pod names are resolved.
 			if record.Conn.DestinationPodName != "" {
-				ie.Value = nodeName
+				ie.Value = exp.nodeName
 			} else {
 				ie.Value = ""
 			}
@@ -570,7 +564,6 @@ func (exp *flowExporter) addRecordToSet(record flowexporter.FlowRecord) error {
 }
 
 func (exp *flowExporter) addDenyConnToSet(conn *flowexporter.Connection, flowEndReason uint8) error {
-	nodeName, _ := env.GetNodeName()
 	exp.ipfixSet.ResetSet()
 
 	eL := exp.elementsListv4
@@ -622,7 +615,7 @@ func (exp *flowExporter) addDenyConnToSet(conn *flowexporter.Connection, flowEnd
 		case "sourceNodeName":
 			// Add nodeName for only local pods whose pod names are resolved.
 			if conn.SourcePodName != "" {
-				ie.Value = nodeName
+				ie.Value = exp.nodeName
 			} else {
 				ie.Value = ""
 			}
@@ -633,7 +626,7 @@ func (exp *flowExporter) addDenyConnToSet(conn *flowexporter.Connection, flowEnd
 		case "destinationNodeName":
 			// Add nodeName for only local pods whose pod names are resolved.
 			if conn.DestinationPodName != "" {
-				ie.Value = nodeName
+				ie.Value = exp.nodeName
 			} else {
 				ie.Value = ""
 			}

--- a/pkg/agent/flowexporter/exporter/exporter_perf_test.go
+++ b/pkg/agent/flowexporter/exporter/exporter_perf_test.go
@@ -1,0 +1,272 @@
+// +build !race
+
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exporter
+
+import (
+	"crypto/rand"
+	"flag"
+	"fmt"
+	"math/big"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/vmware/go-ipfix/pkg/registry"
+	"k8s.io/klog/v2"
+
+	"antrea.io/antrea/pkg/agent/flowexporter"
+	"antrea.io/antrea/pkg/agent/flowexporter/connections"
+	"antrea.io/antrea/pkg/agent/flowexporter/flowrecords"
+)
+
+const (
+	testNumOfConns         = 20000
+	testNumOfDenyConns     = 20000
+	testNumOfDyingConns    = 2000
+	testNumOfIdleRecords   = 2000
+	testNumOfIdleDenyConns = 2000
+	testBufferSize         = 1048
+)
+
+var recordsReceived = 0
+
+/*
+Sample output:
+	go test -test.v -run=BenchmarkExport -test.benchmem -bench=BenchmarkExportConntrackConns -memprofile memprofile.out -cpuprofile profile.out
+	goos: linux
+	goarch: amd64
+	pkg: antrea.io/antrea/pkg/agent/flowexporter/exporter
+	cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+	BenchmarkExportConntrackConns (truncated output)
+		exporter_perf_test.go:79:
+			Summary:
+			Number of conntrack connections: 20000
+			Number of dying conntrack connections: 2000
+			Total connections received: 18703
+	BenchmarkExportConntrackConns-2   	      75	  13750074 ns/op	  965550 B/op	   22268 allocs/op
+	PASS
+	ok  	antrea.io/antrea/pkg/agent/flowexporter/exporter	5.494s
+Reference value:
+	#conns
+	20000     156	   8037522 ns/op	  340792 B/op	   13540 allocs/op
+	30000      61	  20510362 ns/op	 1082075 B/op	   43304 allocs/op
+	40000      39	  46557414 ns/op	 3180649 B/op	  127687 allocs/op
+	50000      18	  55581807 ns/op	 4420593 B/op	  177554 allocs/op
+*/
+func BenchmarkExportConntrackConns(b *testing.B) {
+	disableLogToStderr()
+	ctrl := gomock.NewController(b)
+	defer ctrl.Finish()
+
+	recordsReceived = 0
+	exp, err := setupExporter(true)
+	if err != nil {
+		b.Fatalf("error when setting up exporter: %v", err)
+	}
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		exp.initFlowExporter()
+		exp.sendFlowRecords()
+	}
+	b.Logf("\nSummary:\nNumber of conntrack connections: %d\nNumber of dying conntrack connections: %d\nTotal connections received: %d\n", testNumOfConns, testNumOfDyingConns, recordsReceived)
+}
+
+/*
+Sample output:
+	go test -test.v -run=BenchmarkExport -test.benchmem -bench=BenchmarkExportDenyConns -memprofile memprofile.out -cpuprofile profile.out
+	goos: linux
+	goarch: amd64
+	pkg: antrea.io/antrea/pkg/agent/flowexporter/exporter
+	cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+	BenchmarkExportDenyConns (truncated output)
+		exporter_perf_test.go:112:
+			Summary:
+			Number of deny connections: 20000
+			Number of idle deny connections: 2000
+			Total connections received: 19124
+	BenchmarkExportDenyConns-2   	     204	   6922004 ns/op	  357215 B/op	   12106 allocs/op
+	PASS
+	ok  	antrea.io/antrea/pkg/agent/flowexporter/exporter	6.189s
+Reference value:
+	#conns
+	20000   210	   5401396 ns/op	  195415 B/op	    7908 allocs/op
+	30000   102	  11793506 ns/op	  555344 B/op	   22770 allocs/op
+	40000    64	  19141650 ns/op	 1239398 B/op	   51008 allocs/op
+	50000    37	  27369835 ns/op	 2036012 B/op	   83802 allocs/op
+*/
+func BenchmarkExportDenyConns(b *testing.B) {
+	disableLogToStderr()
+	ctrl := gomock.NewController(b)
+	defer ctrl.Finish()
+
+	recordsReceived = 0
+	exp, err := setupExporter(false)
+	if err != nil {
+		b.Fatalf("error when setting up exporter: %v", err)
+	}
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		exp.initFlowExporter()
+		exp.sendFlowRecords()
+	}
+	b.Logf("\nSummary:\nNumber of deny connections: %d\nNumber of idle deny connections: %d\nTotal connections received: %d\n", testNumOfDenyConns, testNumOfIdleDenyConns, recordsReceived)
+
+}
+
+func setupExporter(isConntrackConn bool) (*flowExporter, error) {
+	var err error
+	collectorAddr, err := startLocalServer()
+	if err != nil {
+		return nil, err
+	}
+
+	// create connection store and generate connections
+	records := flowrecords.NewFlowRecords()
+	denyConnStore := connections.NewDenyConnectionStore(nil, nil)
+	conntrackConnStore := connections.NewConntrackConnectionStore(nil, flowrecords.NewFlowRecords(), nil, true, false, nil, nil, 1)
+	if isConntrackConn {
+		records = addConnsAndGetRecords(conntrackConnStore)
+	} else {
+		addDenyConns(denyConnStore)
+	}
+
+	exp, _ := NewFlowExporter(conntrackConnStore, records, denyConnStore, collectorAddr.String(), collectorAddr.Network(), testActiveFlowTimeout, testIdleFlowTimeout, true, false, nil, nil, false)
+	return exp, err
+}
+
+func startLocalServer() (net.Addr, error) {
+	udpAddr, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
+	if err != nil {
+		return nil, fmt.Errorf("error when resolving UDP address: %v", err)
+	}
+	conn, err := net.ListenUDP("udp", udpAddr)
+	if err != nil {
+		return nil, fmt.Errorf("error when creating local server: %v", err)
+	}
+	go func() {
+		defer conn.Close()
+		for {
+			buff := make([]byte, testBufferSize)
+			_, _, err := conn.ReadFromUDP(buff)
+			if err != nil {
+				return
+			}
+			recordsReceived++
+		}
+	}()
+	return conn.LocalAddr(), nil
+}
+
+func addConnsAndGetRecords(connStore *connections.ConntrackConnectionStore) *flowrecords.FlowRecords {
+	randomNum := int(getRandomNum(int64(testNumOfConns - testNumOfDyingConns)))
+	records := flowrecords.NewFlowRecords()
+	for i := 0; i < testNumOfConns; i++ {
+		// create and add connection to connection store
+		randomNum1 := getRandomNum(255)
+		randomNum2 := getRandomNum(255)
+		src := net.ParseIP(fmt.Sprintf("192.168.%d.%d", randomNum1, randomNum2))
+		dst := net.ParseIP(fmt.Sprintf("192.169.%d.%d", randomNum2, randomNum1))
+		flowKey := flowexporter.Tuple{SourceAddress: src, DestinationAddress: dst, Protocol: 6, SourcePort: uint16(i), DestinationPort: uint16(i)}
+		conn := &flowexporter.Connection{
+			StartTime:                  time.Now().Add(-time.Duration(randomNum1) * time.Second),
+			StopTime:                   time.Now(),
+			LastExportTime:             time.Now().Add(-time.Duration(randomNum1)*time.Millisecond - testActiveFlowTimeout),
+			IsPresent:                  true,
+			DoneExport:                 false,
+			FlowKey:                    flowKey,
+			OriginalPackets:            100,
+			OriginalBytes:              10,
+			ReversePackets:             50,
+			ReverseBytes:               5,
+			SourcePodNamespace:         "ns1",
+			SourcePodName:              "pod1",
+			DestinationPodNamespace:    "ns2",
+			DestinationPodName:         "pod2",
+			DestinationServicePortName: "service",
+			DestinationServiceAddress:  net.ParseIP("0.0.0.0"),
+			TCPState:                   "SYN_SENT",
+		}
+		connKey := flowexporter.NewConnectionKey(conn)
+		// set connection to dying state
+		if i >= randomNum && i < testNumOfDyingConns+randomNum {
+			conn.TCPState = "TIME_WAIT"
+		}
+		connStore.AddConnToMap(&connKey, conn)
+
+		// generate record from connection and add the record to record map
+		record := &flowexporter.FlowRecord{
+			Conn:               *conn,
+			PrevPackets:        0,
+			PrevBytes:          0,
+			PrevReversePackets: 0,
+			PrevReverseBytes:   0,
+			IsIPv6:             false,
+			LastExportTime:     time.Now().Add(-testActiveFlowTimeout),
+			IsActive:           true,
+		}
+		if i < testNumOfIdleRecords {
+			record.PrevPackets = conn.OriginalPackets
+			record.PrevReversePackets = conn.ReversePackets
+			record.LastExportTime = time.Now().Add(-testIdleFlowTimeout)
+		}
+		records.AddFlowRecordToMap(&connKey, record)
+	}
+	return records
+}
+
+func addDenyConns(connStore *connections.DenyConnectionStore) {
+	for i := 0; i < testNumOfDenyConns; i++ {
+		randomNum1 := getRandomNum(255)
+		randomNum2 := getRandomNum(255)
+		src := net.ParseIP(fmt.Sprintf("192.166.%d.%d", randomNum1, randomNum2))
+		dst := net.ParseIP(fmt.Sprintf("192.167.%d.%d", randomNum2, randomNum1))
+		flowKey := flowexporter.Tuple{SourceAddress: src, DestinationAddress: dst, Protocol: 6, SourcePort: uint16(i), DestinationPort: uint16(i)}
+		conn := &flowexporter.Connection{
+			StartTime:                     time.Now().Add(-time.Duration(randomNum1) * time.Second),
+			StopTime:                      time.Now(),
+			LastExportTime:                time.Now().Add(-time.Duration(randomNum1)*time.Millisecond - testActiveFlowTimeout),
+			FlowKey:                       flowKey,
+			OriginalPackets:               10,
+			OriginalBytes:                 100,
+			DeltaBytes:                    20,
+			DeltaPackets:                  5,
+			SourcePodNamespace:            "ns1",
+			SourcePodName:                 "pod1",
+			EgressNetworkPolicyName:       "egress-reject",
+			EgressNetworkPolicyType:       registry.PolicyTypeAntreaNetworkPolicy,
+			EgressNetworkPolicyNamespace:  "egress-ns",
+			EgressNetworkPolicyRuleAction: registry.NetworkPolicyRuleActionReject,
+		}
+		if i < testNumOfIdleDenyConns {
+			conn.LastExportTime = time.Now().Add(-testIdleFlowTimeout)
+		}
+		connKey := flowexporter.NewConnectionKey(conn)
+		connStore.AddConnToMap(&connKey, conn)
+	}
+}
+
+func getRandomNum(value int64) uint64 {
+	number, _ := rand.Int(rand.Reader, big.NewInt(value))
+	return number.Uint64()
+}
+
+func disableLogToStderr() {
+	klogFlagSet := flag.NewFlagSet("klog", flag.ContinueOnError)
+	klog.InitFlags(klogFlagSet)
+	klogFlagSet.Parse([]string{"-logtostderr=false"})
+}

--- a/pkg/agent/flowexporter/flowrecords/flow_records.go
+++ b/pkg/agent/flowexporter/flowrecords/flow_records.go
@@ -124,7 +124,7 @@ func (fr *FlowRecords) ForAllFlowRecordsDo(callback flowexporter.FlowRecordCallB
 	for k, v := range fr.recordsMap {
 		err := callback(k, v)
 		if err != nil {
-			klog.Errorf("Error when executing callback for flow record")
+			klog.Errorf("Error when executing callback for flow record: %v", err)
 			return err
 		}
 	}


### PR DESCRIPTION
This commit adds performance benchmarking for Flow Exporter. It evaluates Export() function under different number of conntrack connections, dying connections, idle records, deny connections and idle deny connections. A local server will receive the records and count number. CPU and memory profile is collected and visualized using pprof.

Also from benchmarking, we discovered and removed redundant calls like `GetNodeName()`, which is called every time when exporting a record and `ResetConnStatsWithoutLock`, which unnecessarily calls `NewConnectionKey` each time.

With fixes and changes in go-ipfix [v0.5.3](https://github.com/vmware/go-ipfix/releases/tag/v0.5.3) and redundant calls removal in this PR, we had following improvements:
Before:
```
BenchmarkExportConntrackConns   	  50	  21747542 ns/op	 3708730 B/op	   80838 allocs/op
BenchmarkExportDenyConns      	          126	  14497807 ns/op	 2522699 B/op	   53345 allocs/op
BenchmarkPoll   	                 141	   8372127 ns/op	  813834 B/op	   52738 allocs/op
```
After
```
BenchmarkExportConntrackConns   	 126	  11444126 ns/op	  459816 B/op	   18332 allocs/op
BenchmarkExportDenyConns   	     223	   6391654 ns/op	  261669 B/op	   10637 allocs/op
BenchmarkPoll   	         130	   8280194 ns/op	  818076 B/op	   52814 allocs/op
```
Improvement
| Test   |  ns/op | B/op   | allocs/op |
| ------------------------- | --------- | --- | --- |
| BenchmarkExportConntrackConns  |  reduce by 47.4%	|  reduce by 87.6% | reduce by 77.3% | 
| BenchmarkExportDenyConns  |   reduce by 42.9%	|  reduce by 89.6%	|   reduce by 80.0% | 
| BenchmarkPoll  |  less than 1% diff	|  less than 1% diff	| less than 1% diff  | 
