### PR TITLE
Add SR-IOV secondary interface support

### DIFF
--- a/build/yamls/patches/sriov/sriov.yml
+++ b/build/yamls/patches/sriov/sriov.yml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: antrea-agent
+spec:
+  template:
+    spec:
+      containers:
+      - name: antrea-agent
+        volumeMounts:
+        - mountPath: /var/lib/kubelet
+          name: host-kubelet
+          readOnly: true
+      volumes:
+      - hostPath:
+          path: /var/lib/kubelet
+        name: host-kubelet

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/golang/mock v1.5.0
 	github.com/golang/protobuf v1.5.0
 	github.com/google/uuid v1.1.2
+	github.com/k8snetworkplumbingwg/sriov-cni v2.1.0+incompatible
 	github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
 	github.com/pkg/errors v0.9.1
@@ -62,6 +63,7 @@ require (
 	k8s.io/kube-aggregator v0.21.0
 	k8s.io/kube-openapi v0.0.0-20210305164622-f622666832c1
 	k8s.io/kubectl v0.21.0
+	k8s.io/kubelet v0.21.0
 	k8s.io/utils v0.0.0-20210305010621-2afb4311ab10
 )
 

--- a/go.sum
+++ b/go.sum
@@ -380,6 +380,8 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
+github.com/k8snetworkplumbingwg/sriov-cni v2.1.0+incompatible h1:5comk9qUB9j99Oc+rvnm92RWWe9urdJ1TP3cXM3fmmc=
+github.com/k8snetworkplumbingwg/sriov-cni v2.1.0+incompatible/go.mod h1:sVTfViXOlaxc7X9fnixa5L1FQqEAybehD20yXyagYLE=
 github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd h1:Coekwdh0v2wtGp9Gmz1Ze3eVRAWJMLokvN3QjdzCHLY=
 github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
@@ -985,6 +987,8 @@ k8s.io/kube-openapi v0.0.0-20210305164622-f622666832c1 h1:bKbnE878105Y2291CtM1YO
 k8s.io/kube-openapi v0.0.0-20210305164622-f622666832c1/go.mod h1:wXW5VT87nVfh/iLV8FpR2uDvrFyomxbtb1KivDbvPTE=
 k8s.io/kubectl v0.21.0 h1:WZXlnG/yjcE4LWO2g6ULjFxtzK6H1TKzsfaBFuVIhNg=
 k8s.io/kubectl v0.21.0/go.mod h1:EU37NukZRXn1TpAkMUoy8Z/B2u6wjHDS4aInsDzVvks=
+k8s.io/kubelet v0.21.0 h1:1VUfM5vKqLPlWFI0zee6fm9kwIZ/UEOGCodVFN+OZrg=
+k8s.io/kubelet v0.21.0/go.mod h1:G5ZxMTVev9t4bhmsSxDAWhH6wXDYEVHVVFyYsw4laR4=
 k8s.io/metrics v0.21.0/go.mod h1:L3Ji9EGPP1YBbfm9sPfEXSpnj8i24bfQbAFAsW0NueQ=
 k8s.io/utils v0.0.0-20200410111917-5770800c2500/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20201110183641-67b214c5f920/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=

--- a/hack/generate-manifest.sh
+++ b/hack/generate-manifest.sh
@@ -43,6 +43,7 @@ Generate a YAML manifest for Antrea using Kustomize and print it to stdout.
         --simulator                   Generates a manifest with antrea-agent simulator included
         --custom-adm-controller       Generates a manifest with custom Antrea admission controller to validate/mutate resources.
         --hw-offload                  Generates a manifest with hw-offload enabled in the antrea-ovs container.
+        --sriov                       Generates a manifest which enables use of Kubelet API for SR-IOV device info.
         --help, -h                    Print this message and exit
 
 In 'release' mode, environment variables IMG_NAME and IMG_TAG must be set.
@@ -82,6 +83,7 @@ K8S_115=false
 SIMULATOR=false
 CUSTOM_ADM_CONTROLLER=false
 HW_OFFLOAD=false
+SRIOV=false
 
 while [[ $# -gt 0 ]]
 do
@@ -163,6 +165,10 @@ case $key in
     ;;
     --hw-offload)
     HW_OFFLOAD=true
+    shift
+    ;;
+    --sriov)
+    SRIOV=true
     shift
     ;;
     -h|--help)
@@ -429,6 +435,16 @@ if $HW_OFFLOAD; then
     $KUSTOMIZE edit add base $BASE
     $KUSTOMIZE edit add patch --path hwOffload.yml
     BASE=../hwoffload
+    cd ..
+fi
+
+if $SRIOV; then
+    mkdir sriov && cd sriov
+    cp ../../patches/sriov/sriov.yml .
+    touch kustomization.yml
+    $KUSTOMIZE edit add base $BASE
+    $KUSTOMIZE edit add patch --path sriov.yml
+    BASE=../sriov
     cd ..
 fi
 

--- a/pkg/agent/cniserver/interface_configuration_windows.go
+++ b/pkg/agent/cniserver/interface_configuration_windows.go
@@ -113,11 +113,15 @@ func (ic *ifConfigurator) configureContainerLink(
 	containerNetNS string,
 	containerIFDev string,
 	mtu int,
-	sriovVFDeviceID string,
+	brSriovVFDeviceID string,
+	podSriovVFDeviceID string,
 	result *current.Result,
 ) error {
-	if sriovVFDeviceID != "" {
+	if brSriovVFDeviceID != "" {
 		return fmt.Errorf("OVS hardware offload is not supported on windows")
+	}
+	if podSriovVFDeviceID != "" {
+		return fmt.Errorf("Pod SR-IOV interface is not supported on windows")
 	}
 	// We must use the infra container to generate the endpoint name to ensure infra and workload containers use the
 	// same HNSEndpoint.

--- a/pkg/agent/cniserver/pod_configuration.go
+++ b/pkg/agent/cniserver/pod_configuration.go
@@ -205,7 +205,7 @@ func (pc *podConfigurator) configureInterfaces(
 	createOVSPort bool,
 	containerAccess *containerAccessArbitrator,
 ) error {
-	err := pc.ifConfigurator.configureContainerLink(podName, podNameSpace, containerID, containerNetNS, containerIFDev, mtu, sriovVFDeviceID, result)
+	err := pc.ifConfigurator.configureContainerLink(podName, podNameSpace, containerID, containerNetNS, containerIFDev, mtu, sriovVFDeviceID, "", result)
 	if err != nil {
 		return err
 	}

--- a/pkg/agent/cniserver/sriov.go
+++ b/pkg/agent/cniserver/sriov.go
@@ -1,0 +1,140 @@
+// +build linux
+
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cniserver
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"path"
+	"time"
+
+	"github.com/containernetworking/cni/pkg/types/current"
+	sriovcniutils "github.com/k8snetworkplumbingwg/sriov-cni/pkg/utils"
+	"google.golang.org/grpc"
+	"k8s.io/klog/v2"
+
+	// Version v1 of the Kubelet API was introduced in K8s v1.20.
+	// Using version v1alpha1 instead to support older K8s versions.
+	podresourcesv1alpha1 "k8s.io/kubelet/pkg/apis/podresources/v1alpha1"
+
+	"antrea.io/antrea/pkg/agent/util"
+)
+
+const (
+	kubeletPodResourcesPath = "/var/lib/kubelet/pod-resources"
+	kubeletSocket           = "kubelet.sock"
+	connectionTimeout       = 10 * time.Second
+)
+
+type KubeletPodResources struct {
+	resources []*podresourcesv1alpha1.PodResources
+}
+
+// GetPodContainerDeviceIDs returns the device IDs assigned to a Pod's containers.
+func GetPodContainerDeviceIDs(podName string, podNamespace string) ([]string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), connectionTimeout)
+	defer cancel()
+
+	conn, err := grpc.DialContext(ctx, path.Join(kubeletPodResourcesPath, kubeletSocket),
+		grpc.WithInsecure(), grpc.WithContextDialer(func(ctx context.Context, addr string) (conn net.Conn, e error) {
+			return util.DialLocalSocket(addr)
+		}))
+	if err != nil {
+		return []string{}, fmt.Errorf("error getting the gRPC client for Pod resources: %v", err)
+	}
+
+	defer conn.Close()
+
+	client := podresourcesv1alpha1.NewPodResourcesListerClient(conn)
+	if client == nil {
+		return []string{}, fmt.Errorf("error getting the lister client for Pod resources.")
+	}
+
+	podResources, err := client.List(ctx, &podresourcesv1alpha1.ListPodResourcesRequest{})
+	if err != nil {
+		return []string{}, fmt.Errorf("error getting the Pod resources: %v %v", podResources, err)
+	}
+
+	var podDeviceIDs []string
+	var kpr KubeletPodResources
+	kpr.resources = podResources.GetPodResources()
+	for _, pr := range kpr.resources {
+		if pr.Name == podName && pr.Namespace == podNamespace {
+			for _, ctr := range pr.Containers {
+				for _, dev := range ctr.Devices {
+					podDeviceIDs = append(podDeviceIDs, dev.DeviceIds...)
+				}
+			}
+		}
+	}
+	klog.V(2).Infof("Pod container device IDs of %s/%s are: %v", podNamespace, podName, podDeviceIDs)
+	return []string{}, nil
+}
+
+// getVFInfo takes in a VF's PCI device ID and returns its PF and VF ID.
+func getVFInfo(vfPCI string) (string, int, error) {
+	var vfID int
+
+	pf, err := sriovcniutils.GetPfName(vfPCI)
+	if err != nil {
+		return "", vfID, err
+	}
+
+	vfID, err = sriovcniutils.GetVfid(vfPCI, pf)
+	if err != nil {
+		return "", vfID, err
+	}
+
+	return pf, vfID, nil
+}
+
+// getVFLinkName returns a VF's network interface name given its PCI address.
+func getVFLinkName(pciAddress string) (string, error) {
+	return sriovcniutils.GetVFLinkNames(pciAddress)
+}
+
+// configureSecondaryInterface adds Secondary Interface support.
+// Limitation: only SR-IOV interface is supported as of now.
+func (pc *podConfigurator) configureSecondaryInterface(
+	podName string,
+	podNameSpace string,
+	containerID string,
+	containerNetNS string,
+	containerIFDev string,
+	mtu int,
+	podSriovVFDeviceID string,
+	result *current.Result,
+) error {
+	if podSriovVFDeviceID == "" {
+		return fmt.Errorf("error getting the Pod SR-IOV VF device ID")
+	}
+
+	err := pc.ifConfigurator.configureContainerLink(podName, podNameSpace, containerID, containerNetNS, containerIFDev, mtu, "", podSriovVFDeviceID, result)
+	if err != nil {
+		return err
+	}
+	hostIface := result.Interfaces[0]
+	containerIface := result.Interfaces[1]
+
+	if err = pc.ifConfigurator.advertiseContainerAddr(containerNetNS, containerIface.Name, result); err != nil {
+		return fmt.Errorf("failed to advertise IP address for container %s: %v", containerID, err)
+	}
+
+	klog.Infof("Configured interfaces for container %s; hostIface: %+v, containerIface: %+v", containerID, hostIface, containerIface)
+	return nil
+}

--- a/plugins/octant/go.sum
+++ b/plugins/octant/go.sum
@@ -431,6 +431,7 @@ github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/X
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
+github.com/k8snetworkplumbingwg/sriov-cni v2.1.0+incompatible/go.mod h1:sVTfViXOlaxc7X9fnixa5L1FQqEAybehD20yXyagYLE=
 github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
@@ -1112,6 +1113,7 @@ k8s.io/kube-aggregator v0.21.0/go.mod h1:sIaa9L4QCBo9gjPyoGJns4cBjYVLq3s49FxF7m/
 k8s.io/kube-openapi v0.0.0-20200403204345-e1beb1bd0f35 h1:FDWYFE3itI1G8UFOMjUuLbROZExo+Rrfm/Qaf473rm4=
 k8s.io/kube-openapi v0.0.0-20200403204345-e1beb1bd0f35/go.mod h1:NwPpO8COeh/j9Q9ModsqBxwHcWDo/PmrJOPyquZCC1A=
 k8s.io/kubectl v0.21.0/go.mod h1:EU37NukZRXn1TpAkMUoy8Z/B2u6wjHDS4aInsDzVvks=
+k8s.io/kubelet v0.21.0/go.mod h1:G5ZxMTVev9t4bhmsSxDAWhH6wXDYEVHVVFyYsw4laR4=
 k8s.io/metrics v0.19.3/go.mod h1:Eap/Lk1FiAIjkaArFuv41v+ph6dbDpVGwAg7jMI+4vg=
 k8s.io/metrics v0.21.0 h1:uwS3CgheLKaw3PTpwhjMswnm/PMqeLbdLH88VI7FMQQ=
 k8s.io/metrics v0.21.0/go.mod h1:L3Ji9EGPP1YBbfm9sPfEXSpnj8i24bfQbAFAsW0NueQ=


### PR DESCRIPTION
This is an initial PR to provide SR-IOV support for secondary interface:
• API support added to configure SR-IOV VFs as secondary interface.
• Depends on vendor specific NIC configuration, creation of VFs and
  configuration of the SR-IOV Network Device Plugin.
• Does not configure OVS flows.