### PR TITLE
Update Node's MAC address to the Node's annotation for direct routing

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -3052,6 +3052,7 @@ rules:
   - get
   - watch
   - list
+  - patch
 - apiGroups:
   - ""
   resources:

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -3052,6 +3052,7 @@ rules:
   - get
   - watch
   - list
+  - patch
 - apiGroups:
   - ""
   resources:

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -3052,6 +3052,7 @@ rules:
   - get
   - watch
   - list
+  - patch
 - apiGroups:
   - ""
   resources:

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -3052,6 +3052,7 @@ rules:
   - get
   - watch
   - list
+  - patch
 - apiGroups:
   - ""
   resources:

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -3052,6 +3052,7 @@ rules:
   - get
   - watch
   - list
+  - patch
 - apiGroups:
   - ""
   resources:

--- a/build/yamls/base/agent-rbac.yml
+++ b/build/yamls/base/agent-rbac.yml
@@ -18,6 +18,7 @@ rules:
       - get
       - watch
       - list
+      - patch
   - apiGroups:
       - ""
     resources:

--- a/pkg/agent/agent_windows.go
+++ b/pkg/agent/agent_windows.go
@@ -71,7 +71,7 @@ func (i *Initializer) prepareHostNetwork() error {
 	// Create HNS network.
 	subnetCIDR := i.nodeConfig.PodIPv4CIDR
 	if subnetCIDR == nil {
-		return fmt.Errorf("Failed to find valid IPv4 PodCIDR")
+		return fmt.Errorf("failed to find valid IPv4 PodCIDR")
 	}
 	return util.PrepareHNSNetwork(subnetCIDR, i.nodeConfig.NodeIPAddr, adapter)
 }
@@ -82,7 +82,7 @@ func (i *Initializer) prepareOVSBridge() error {
 	hnsNetwork, err := hcsshim.GetHNSNetworkByName(util.LocalHNSNetwork)
 	defer func() {
 		// prepareOVSBridge only works on windows platform. The operation has a chance to fail on the first time agent
-		// starts up when OVS bridge uplink and local inteface have not been configured. If the operation fails, the
+		// starts up when OVS bridge uplink and local interface have not been configured. If the operation fails, the
 		// host can not communicate with external network. To make sure the agent can connect to API server in
 		// next retry, this step deletes OVS bridge and HNS network created previously which will restore the
 		// host network.
@@ -144,7 +144,7 @@ func (i *Initializer) prepareOVSBridge() error {
 
 	// Move network configuration of uplink interface to OVS bridge local interface.
 	// - The net configuration of uplink will be restored by OS if the attached HNS network is deleted.
-	// - When ovs-switchd is down, antrea-agent will disable OVS Extension. The OVS bridge local interface will work
+	// - When ovs-vswitchd is down, antrea-agent will disable OVS Extension. The OVS bridge local interface will work
 	//   like a normal interface on host and is responsible for forwarding host traffic.
 	if err = util.EnableHostInterface(brName); err != nil {
 		return err

--- a/pkg/agent/types/annotations.go
+++ b/pkg/agent/types/annotations.go
@@ -1,0 +1,20 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+const (
+	// NodeMACAddressAnnotationKey represents the key of the Node's MAC address in the Annotations of the Node.
+	NodeMACAddressAnnotationKey string = "node.antrea.io/mac-address"
+)

--- a/pkg/agent/util/net_windows.go
+++ b/pkg/agent/util/net_windows.go
@@ -400,7 +400,7 @@ func GetLocalBroadcastIP(ipNet *net.IPNet) net.IP {
 	return lastAddr
 }
 
-// GetDefaultGatewayByInterfaceIndex returns the default gateway configured on the speicified interface.
+// GetDefaultGatewayByInterfaceIndex returns the default gateway configured on the specified interface.
 func GetDefaultGatewayByInterfaceIndex(ifIndex int) (string, error) {
 	cmd := fmt.Sprintf("$(Get-NetRoute -InterfaceIndex %d -DestinationPrefix 0.0.0.0/0 ).NextHop", ifIndex)
 	defaultGW, err := CallPSCommand(cmd)

--- a/pkg/util/env/env.go
+++ b/pkg/util/env/env.go
@@ -21,9 +21,9 @@ import (
 	"k8s.io/klog/v2"
 )
 
-// nodeNameEnvKey is environment variable.
+// NodeNameEnvKey is environment variable.
 const (
-	nodeNameEnvKey     = "NODE_NAME"
+	NodeNameEnvKey     = "NODE_NAME"
 	podNameEnvKey      = "POD_NAME"
 	podNamespaceEnvKey = "POD_NAMESPACE"
 	svcAcctNameEnvKey  = "SERVICEACCOUNT_NAME"
@@ -37,11 +37,11 @@ const (
 // - Environment variable NODE_NAME, which should be set by Downward API
 // - OS's hostname
 func GetNodeName() (string, error) {
-	nodeName := os.Getenv(nodeNameEnvKey)
+	nodeName := os.Getenv(NodeNameEnvKey)
 	if nodeName != "" {
 		return nodeName, nil
 	}
-	klog.Infof("Environment variable %s not found, using hostname instead", nodeNameEnvKey)
+	klog.Infof("Environment variable %s not found, using hostname instead", NodeNameEnvKey)
 	var err error
 	nodeName, err = os.Hostname()
 	if err != nil {

--- a/pkg/util/env/env_test.go
+++ b/pkg/util/env/env_test.go
@@ -39,8 +39,8 @@ func TestGetNodeName(t *testing.T) {
 
 func compareNodeName(k, v string, t *testing.T) {
 	if k != "" {
-		_ = os.Setenv(nodeNameEnvKey, k)
-		defer os.Unsetenv(nodeNameEnvKey)
+		_ = os.Setenv(NodeNameEnvKey, k)
+		defer os.Unsetenv(NodeNameEnvKey)
 	}
 	nodeName, err := GetNodeName()
 	if err != nil {


### PR DESCRIPTION
To bypass Windows host network when forwarding Pod egress traffic in noencap mode, antrea-agent needs to know peer Nodes' MAC addresses so that it can configure Openflow rules which route the packets to underlay network via uplink interface directly.

To discover the MAC addresses, the PR makes each antrea-agent report its uplink's MAC address to the Node's annotation, then other agents can get it when the NodeRouteController configures route/flows to this Node.

Signed-off-by: Quan Tian <qtian@vmware.com>

For #2157