### PR TITLE
Add network policy related metadata to flow records

### DIFF
--- a/build/yamls/elk-flow-collector/logstash/filter.rb
+++ b/build/yamls/elk-flow-collector/logstash/filter.rb
@@ -119,6 +119,22 @@ def filter(event)
         event.remove("[ipfix][egressNetworkPolicyNamespace]")
         event.set("[ipfix][egressNetworkPolicyNamespace]", "N/A")
     end
+    ingressNetworkPolicyType = event.get("[ipfix][ingressNetworkPolicyType]")
+    if ingressNetworkPolicyType == 1
+        event.set("[ipfix][ingressNetworkPolicyTypeStr]", "K8s NetworkPolicy")
+    elsif ingressNetworkPolicyType == 2
+        event.set("[ipfix][ingressNetworkPolicyTypeStr]", "Antrea NetworkPolicy")
+    elsif ingressNetworkPolicyType == 3
+        event.set("[ipfix][ingressNetworkPolicyTypeStr]", "Antrea ClusterNetworkPolicy")
+    end
+    egressNetworkPolicyType = event.get("[ipfix][egressNetworkPolicyType]")
+    if egressNetworkPolicyType == 1
+        event.set("[ipfix][egressNetworkPolicyTypeStr]", "K8s NetworkPolicy")
+    elsif egressNetworkPolicyType == 2
+        event.set("[ipfix][egressNetworkPolicyTypeStr]", "Antrea NetworkPolicy")
+    elsif egressNetworkPolicyType == 3
+        event.set("[ipfix][egressNetworkPolicyTypeStr]", "Antrea ClusterNetworkPolicy")
+    end
     key = event.get("[ipfix][flowKey]")
     if @@time_map.has_key?(key)
        t = DateTime.strptime(event.get("[ipfix][flowEndSeconds]").to_s, '%Y-%m-%dT%H:%M:%S').to_time.to_i

--- a/build/yamls/elk-flow-collector/logstash/ipfix.yml
+++ b/build/yamls/elk-flow-collector/logstash/ipfix.yml
@@ -4070,6 +4070,12 @@
   113:
     - :string
     - :egressNetworkPolicyNamespace
+  115:
+    - :uint8
+    - :ingressNetworkPolicyType
+  118:
+    - :uint8
+    - :egressNetworkPolicyType
   120:
     - :uint64
     - :packetTotalCountFromSourceNode
@@ -4130,3 +4136,10 @@
   140:
     - :uint8
     - :egressNetworkPolicyRuleAction
+  141:
+    - :string
+    - :ingressNetworkPolicyRuleName
+  142:
+    - :string
+    - :egressNetworkPolicyRuleName
+

--- a/docs/network-flow-visibility.md
+++ b/docs/network-flow-visibility.md
@@ -163,26 +163,30 @@ the flow. All the IEs used by the Antrea Flow Exporter are listed below:
 
 #### IEs from Antrea IE Registry
 
-| IPFIX Information Element     | Enterprise ID | Field ID | Type        |
-|-------------------------------|---------------|----------|-------------|
-| sourcePodNamespace            | 56506         | 100      | string      |
-| sourcePodName                 | 56506         | 101      | string      |
-| destinationPodNamespace       | 56506         | 102      | string      |
-| destinationPodName            | 56506         | 103      | string      |
-| sourceNodeName                | 56506         | 104      | string      |
-| destinationNodeName           | 56506         | 105      | string      |
-| destinationClusterIPv4        | 56506         | 106      | ipv4Address |
-| destinationClusterIPv6        | 56506         | 107      | ipv6Address |
-| destinationServicePort        | 56506         | 108      | unsigned16  |
-| destinationServicePortName    | 56506         | 109      | string      |
-| ingressNetworkPolicyName      | 56506         | 110      | string      |
-| ingressNetworkPolicyNamespace | 56506         | 111      | string      |
-| egressNetworkPolicyName       | 56506         | 112      | string      |
-| egressNetworkPolicyNamespace  | 56506         | 113      | string      |
-| tcpState                      | 56506         | 136      | string      |
-| flowType                      | 56506         | 137      | unsigned8   |
-| ingressNetworkPolicyRuleAction| 56506         | 139      | unsigned8   |
-| egressNetworkPolicyRuleAction | 56506         | 140      | unsigned8   |
+| IPFIX Information Element        | Enterprise ID | Field ID | Type        |
+|----------------------------------|---------------|----------|-------------|
+| sourcePodNamespace               | 56506         | 100      | string      |
+| sourcePodName                    | 56506         | 101      | string      |
+| destinationPodNamespace          | 56506         | 102      | string      |
+| destinationPodName               | 56506         | 103      | string      |
+| sourceNodeName                   | 56506         | 104      | string      |
+| destinationNodeName              | 56506         | 105      | string      |
+| destinationClusterIPv4           | 56506         | 106      | ipv4Address |
+| destinationClusterIPv6           | 56506         | 107      | ipv6Address |
+| destinationServicePort           | 56506         | 108      | unsigned16  |
+| destinationServicePortName       | 56506         | 109      | string      |
+| ingressNetworkPolicyName         | 56506         | 110      | string      |
+| ingressNetworkPolicyNamespace    | 56506         | 111      | string      |
+| ingressNetworkPolicyType         | 56506         | 115      | unsigned8   |
+| ingressNetworkPolicyRuleName     | 56506         | 141      | string      |
+| egressNetworkPolicyName          | 56506         | 112      | string      |
+| egressNetworkPolicyNamespace     | 56506         | 113      | string      |
+| egressNetworkPolicyType          | 56506         | 118      | unsigned8   |
+| egressNetworkPolicyRuleName      | 56506         | 142      | string      |
+| ingressNetworkPolicyRuleAction   | 56506         | 139      | unsigned8   |
+| egressNetworkPolicyRuleAction    | 56506         | 140      | unsigned8   |
+| tcpState                         | 56506         | 136      | string      |
+| flowType                         | 56506         | 137      | unsigned8   |
 
 ### Supported capabilities
 

--- a/pkg/agent/controller/networkpolicy/packetin.go
+++ b/pkg/agent/controller/networkpolicy/packetin.go
@@ -26,6 +26,7 @@ import (
 	"github.com/contiv/libOpenflow/openflow13"
 	"github.com/contiv/libOpenflow/protocol"
 	"github.com/contiv/ofnet/ofctrl"
+	"github.com/vmware/go-ipfix/pkg/registry"
 	"gopkg.in/natefinch/lumberjack.v2"
 	"k8s.io/klog/v2"
 
@@ -380,8 +381,10 @@ func (c *Controller) storeDenyConnection(pktIn *ofctrl.PacketIn) error {
 
 	// For K8s NetworkPolicy implicit drop action, we cannot get name/namespace.
 	if tableID == openflow.IngressDefaultTable {
+		denyConn.IngressNetworkPolicyType = registry.PolicyTypeK8sNetworkPolicy
 		denyConn.IngressNetworkPolicyRuleAction = flowexporter.RuleActionToUint8(disposition)
 	} else if tableID == openflow.EgressDefaultTable {
+		denyConn.EgressNetworkPolicyType = registry.PolicyTypeK8sNetworkPolicy
 		denyConn.EgressNetworkPolicyRuleAction = flowexporter.RuleActionToUint8(disposition)
 	} else { // Get name and namespace for Antrea Network Policy or Antrea Cluster Network Policy
 		// Set match to corresponding ingress/egress reg according to disposition
@@ -391,18 +394,23 @@ func (c *Controller) storeDenyConnection(pktIn *ofctrl.PacketIn) error {
 			return fmt.Errorf("error when obtaining rule id from reg: %v", err)
 		}
 		policy := c.GetNetworkPolicyByRuleFlowID(ruleID)
+		rule := c.GetRuleByFlowID(ruleID)
 
-		if policy == nil {
+		if policy == nil || rule == nil {
 			// Default drop by K8s NetworkPolicy
-			klog.V(4).Infof("Cannot find NetworkPolicy that has ruleID %v", ruleID)
+			klog.V(4).Infof("Cannot find NetworkPolicy or rule that has ruleID %v", ruleID)
 		} else {
 			if tableID == openflow.AntreaPolicyIngressRuleTable {
 				denyConn.IngressNetworkPolicyName = policy.Name
 				denyConn.IngressNetworkPolicyNamespace = policy.Namespace
+				denyConn.IngressNetworkPolicyType = flowexporter.PolicyTypeToUint8(policy.Type)
+				denyConn.IngressNetworkPolicyRuleName = rule.Name
 				denyConn.IngressNetworkPolicyRuleAction = flowexporter.RuleActionToUint8(disposition)
 			} else if tableID == openflow.AntreaPolicyEgressRuleTable {
 				denyConn.EgressNetworkPolicyName = policy.Name
 				denyConn.EgressNetworkPolicyNamespace = policy.Namespace
+				denyConn.EgressNetworkPolicyType = flowexporter.PolicyTypeToUint8(policy.Type)
+				denyConn.EgressNetworkPolicyRuleName = rule.Name
 				denyConn.EgressNetworkPolicyRuleAction = flowexporter.RuleActionToUint8(disposition)
 			}
 		}

--- a/pkg/agent/flowexporter/connections/conntrack_connections.go
+++ b/pkg/agent/flowexporter/connections/conntrack_connections.go
@@ -158,25 +158,31 @@ func (cs *ConntrackConnectionStore) addNetworkPolicyMetadata(conn *flowexporter.
 		egressOfID := binary.LittleEndian.Uint32(conn.Labels[4:8])
 		if ingressOfID != 0 {
 			policy := cs.networkPolicyQuerier.GetNetworkPolicyByRuleFlowID(ingressOfID)
-			if policy == nil {
+			rule := cs.networkPolicyQuerier.GetRuleByFlowID(ingressOfID)
+			if policy == nil || rule == nil {
 				// This should not happen because the rule flow ID to rule mapping is
 				// preserved for max(5s, flowPollInterval) even after the rule deletion.
-				klog.Warningf("Cannot find NetworkPolicy that has rule with ingressOfID %v", ingressOfID)
+				klog.Warningf("Cannot find NetworkPolicy or rule with ingressOfID %v", ingressOfID)
 			} else {
 				conn.IngressNetworkPolicyName = policy.Name
 				conn.IngressNetworkPolicyNamespace = policy.Namespace
+				conn.IngressNetworkPolicyType = flowexporter.PolicyTypeToUint8(policy.Type)
+				conn.IngressNetworkPolicyRuleName = rule.Name
 				conn.IngressNetworkPolicyRuleAction = registry.NetworkPolicyRuleActionAllow
 			}
 		}
 		if egressOfID != 0 {
 			policy := cs.networkPolicyQuerier.GetNetworkPolicyByRuleFlowID(egressOfID)
-			if policy == nil {
+			rule := cs.networkPolicyQuerier.GetRuleByFlowID(egressOfID)
+			if policy == nil || rule == nil {
 				// This should not happen because the rule flow ID to rule mapping is
 				// preserved for max(5s, flowPollInterval) even after the rule deletion.
-				klog.Warningf("Cannot find NetworkPolicy that has rule with egressOfID %v", egressOfID)
+				klog.Warningf("Cannot find NetworkPolicy or rule with egressOfID %v", egressOfID)
 			} else {
 				conn.EgressNetworkPolicyName = policy.Name
 				conn.EgressNetworkPolicyNamespace = policy.Namespace
+				conn.EgressNetworkPolicyType = flowexporter.PolicyTypeToUint8(policy.Type)
+				conn.EgressNetworkPolicyRuleName = rule.Name
 				conn.EgressNetworkPolicyRuleAction = registry.NetworkPolicyRuleActionAllow
 			}
 		}

--- a/pkg/agent/flowexporter/exporter/exporter.go
+++ b/pkg/agent/flowexporter/exporter/exporter.go
@@ -69,9 +69,13 @@ var (
 		"destinationServicePortName",
 		"ingressNetworkPolicyName",
 		"ingressNetworkPolicyNamespace",
+		"ingressNetworkPolicyType",
+		"ingressNetworkPolicyRuleName",
 		"ingressNetworkPolicyRuleAction",
 		"egressNetworkPolicyName",
 		"egressNetworkPolicyNamespace",
+		"egressNetworkPolicyType",
+		"egressNetworkPolicyRuleName",
 		"egressNetworkPolicyRuleAction",
 		"tcpState",
 		"flowType",
@@ -537,12 +541,20 @@ func (exp *flowExporter) addRecordToSet(record flowexporter.FlowRecord) error {
 			ie.Value = record.Conn.IngressNetworkPolicyName
 		case "ingressNetworkPolicyNamespace":
 			ie.Value = record.Conn.IngressNetworkPolicyNamespace
+		case "ingressNetworkPolicyType":
+			ie.Value = record.Conn.IngressNetworkPolicyType
+		case "ingressNetworkPolicyRuleName":
+			ie.Value = record.Conn.IngressNetworkPolicyRuleName
 		case "ingressNetworkPolicyRuleAction":
 			ie.Value = record.Conn.IngressNetworkPolicyRuleAction
 		case "egressNetworkPolicyName":
 			ie.Value = record.Conn.EgressNetworkPolicyName
 		case "egressNetworkPolicyNamespace":
 			ie.Value = record.Conn.EgressNetworkPolicyNamespace
+		case "egressNetworkPolicyType":
+			ie.Value = record.Conn.EgressNetworkPolicyType
+		case "egressNetworkPolicyRuleName":
+			ie.Value = record.Conn.EgressNetworkPolicyRuleName
 		case "egressNetworkPolicyRuleAction":
 			ie.Value = record.Conn.EgressNetworkPolicyRuleAction
 		case "tcpState":
@@ -655,12 +667,20 @@ func (exp *flowExporter) addDenyConnToSet(conn *flowexporter.Connection, flowEnd
 			ie.Value = conn.IngressNetworkPolicyName
 		case "ingressNetworkPolicyNamespace":
 			ie.Value = conn.IngressNetworkPolicyNamespace
+		case "ingressNetworkPolicyType":
+			ie.Value = conn.IngressNetworkPolicyType
+		case "ingressNetworkPolicyRuleName":
+			ie.Value = conn.IngressNetworkPolicyRuleName
 		case "ingressNetworkPolicyRuleAction":
 			ie.Value = conn.IngressNetworkPolicyRuleAction
 		case "egressNetworkPolicyName":
 			ie.Value = conn.EgressNetworkPolicyName
 		case "egressNetworkPolicyNamespace":
 			ie.Value = conn.EgressNetworkPolicyNamespace
+		case "egressNetworkPolicyType":
+			ie.Value = conn.EgressNetworkPolicyType
+		case "egressNetworkPolicyRuleName":
+			ie.Value = conn.EgressNetworkPolicyRuleName
 		case "egressNetworkPolicyRuleAction":
 			ie.Value = conn.EgressNetworkPolicyRuleAction
 		case "tcpState":

--- a/pkg/agent/flowexporter/exporter/exporter_test.go
+++ b/pkg/agent/flowexporter/exporter/exporter_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	ipfixentities "github.com/vmware/go-ipfix/pkg/entities"
 	ipfixentitiestesting "github.com/vmware/go-ipfix/pkg/entities/testing"
+	"github.com/vmware/go-ipfix/pkg/registry"
 	ipfixregistry "github.com/vmware/go-ipfix/pkg/registry"
 
 	"antrea.io/antrea/pkg/agent/flowexporter"
@@ -244,6 +245,10 @@ func getElemList(ianaIE []string, antreaIE []string) []*ipfixentities.InfoElemen
 			elemList[i] = ipfixentities.NewInfoElementWithValue(ie.Element, "")
 		case "ingressNetworkPolicyName", "ingressNetworkPolicyNamespace", "egressNetworkPolicyName", "egressNetworkPolicyNamespace":
 			elemList[i] = ipfixentities.NewInfoElementWithValue(ie.Element, "")
+		case "ingressNetworkPolicyRuleName", "egressNetworkPolicyRuleName":
+			elemList[i] = ipfixentities.NewInfoElementWithValue(ie.Element, "")
+		case "ingressNetworkPolicyType", "egressNetworkPolicyType", "ingressNetworkPolicyRuleAction", "egressNetworkPolicyRuleAction":
+			elemList[i] = ipfixentities.NewInfoElementWithValue(ie.Element, uint8(0))
 		}
 	}
 	return elemList
@@ -274,8 +279,12 @@ func getConnection(isIPv6 bool, isPresent bool, statusFlag uint32, protoID uint8
 		DestinationPodName:            "",
 		IngressNetworkPolicyName:      "",
 		IngressNetworkPolicyNamespace: "",
+		IngressNetworkPolicyType:      registry.PolicyTypeK8sNetworkPolicy,
+		IngressNetworkPolicyRuleName:  "",
 		EgressNetworkPolicyName:       "np",
 		EgressNetworkPolicyNamespace:  "np-ns",
+		EgressNetworkPolicyType:       registry.PolicyTypeK8sNetworkPolicy,
+		EgressNetworkPolicyRuleName:   "",
 		DestinationServicePortName:    "service",
 		TCPState:                      tcpState,
 	}

--- a/pkg/agent/flowexporter/types.go
+++ b/pkg/agent/flowexporter/types.go
@@ -64,9 +64,13 @@ type Connection struct {
 	DestinationServicePort         uint16
 	IngressNetworkPolicyName       string
 	IngressNetworkPolicyNamespace  string
+	IngressNetworkPolicyType       uint8
+	IngressNetworkPolicyRuleName   string
 	IngressNetworkPolicyRuleAction uint8
 	EgressNetworkPolicyName        string
 	EgressNetworkPolicyNamespace   string
+	EgressNetworkPolicyType        uint8
+	EgressNetworkPolicyRuleName    string
 	EgressNetworkPolicyRuleAction  uint8
 	TCPState                       string
 	// fields specific to deny connections

--- a/pkg/agent/flowexporter/utils.go
+++ b/pkg/agent/flowexporter/utils.go
@@ -18,6 +18,8 @@ import (
 	"strconv"
 
 	"github.com/vmware/go-ipfix/pkg/registry"
+
+	"antrea.io/antrea/pkg/apis/controlplane/v1beta2"
 )
 
 const (
@@ -62,5 +64,19 @@ func RuleActionToUint8(action string) uint8 {
 		return registry.NetworkPolicyRuleActionReject
 	default:
 		return registry.NetworkPolicyRuleActionNoAction
+	}
+}
+
+// policyTypeToUint8 converts NetworkPolicy type to uint8
+func PolicyTypeToUint8(policyType v1beta2.NetworkPolicyType) uint8 {
+	switch policyType {
+	case v1beta2.K8sNetworkPolicy:
+		return registry.PolicyTypeK8sNetworkPolicy
+	case v1beta2.AntreaNetworkPolicy:
+		return registry.PolicyTypeAntreaNetworkPolicy
+	case v1beta2.AntreaClusterNetworkPolicy:
+		return registry.PolicyTypeAntreaClusterNetworkPolicy
+	default:
+		return registry.PolicyTypeK8sNetworkPolicy
 	}
 }

--- a/pkg/flowaggregator/flowaggregator.go
+++ b/pkg/flowaggregator/flowaggregator.go
@@ -65,9 +65,13 @@ var (
 		"destinationServicePortName",
 		"ingressNetworkPolicyName",
 		"ingressNetworkPolicyNamespace",
+		"ingressNetworkPolicyType",
+		"ingressNetworkPolicyRuleName",
 		"ingressNetworkPolicyRuleAction",
 		"egressNetworkPolicyName",
 		"egressNetworkPolicyNamespace",
+		"egressNetworkPolicyType",
+		"egressNetworkPolicyRuleName",
 		"egressNetworkPolicyRuleAction",
 		"tcpState",
 		"flowType",
@@ -136,8 +140,12 @@ var (
 		"ingressNetworkPolicyName",
 		"ingressNetworkPolicyNamespace",
 		"ingressNetworkPolicyRuleAction",
+		"ingressNetworkPolicyType",
+		"ingressNetworkPolicyRuleName",
 		"egressNetworkPolicyName",
 		"egressNetworkPolicyNamespace",
+		"egressNetworkPolicyType",
+		"egressNetworkPolicyRuleName",
 	}
 )
 


### PR DESCRIPTION
1. Add fields: network policy type, rule name to flow records of flow exporter
2. Update related unit-tests, e2e tests
3. Make necessary changes on elk-flow-collector and flow-visibility doc

Fixes #1545 