### PR TITLE
Fix incorrect update to vmware-tanzu/antrea-build-infra repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
       if: ${{ github.repository == 'antrea-io/antrea' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       uses: benc-uk/workflow-dispatch@v1
       with:
-        repo: antrea-io/antrea-build-infra
+        repo: vmware-tanzu/antrea-build-infra
         ref: refs/heads/main
         workflow: Build Antrea ARM images and push manifest
         token: ${{ secrets.ANTREA_BUILD_INFRA_WORKFLOW_DISPATCH_PAT }}

--- a/.github/workflows/build_tag.yml
+++ b/.github/workflows/build_tag.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Trigger Antrea arm builds and multi-arch manifest update
       uses: benc-uk/workflow-dispatch@v1
       with:
-        repo: antrea-io/antrea-build-infra
+        repo: vmware-tanzu/antrea-build-infra
         ref: refs/heads/main
         workflow: Build Antrea ARM images and push manifest
         token: ${{ secrets.ANTREA_BUILD_INFRA_WORKFLOW_DISPATCH_PAT }}


### PR DESCRIPTION
This repo has not moved (yet), so antrea-io/antrea-build-infra is not
correct.