### PR TITLE
[CI] Exit immediately if building images fails

### DIFF
--- a/ci/jenkins/test-vmc.sh
+++ b/ci/jenkins/test-vmc.sh
@@ -309,7 +309,7 @@ function deliver_antrea {
     # be leveraged successfully
     chmod -R g-w build/images/ovs
     chmod -R g-w build/images/base
-    for i in `seq 2`
+    for i in `seq 3`
     do
         if [[ "$COVERAGE" == true ]]; then
             VERSION="$CLUSTER" DOCKER_REGISTRY="${DOCKER_REGISTRY}" ./hack/build-antrea-ubuntu-all.sh --pull --coverage && break
@@ -317,6 +317,10 @@ function deliver_antrea {
             VERSION="$CLUSTER" DOCKER_REGISTRY="${DOCKER_REGISTRY}" ./hack/build-antrea-ubuntu-all.sh --pull && break
         fi
     done
+    if [ $? -ne 0 ]; then
+        echoerr "Failed to build antrea images"
+        exit 1
+    fi
     if [[ "$COVERAGE" == true ]]; then
       VERSION="$CLUSTER" make flow-aggregator-ubuntu-coverage
     else


### PR DESCRIPTION
Previously it retried once and ignored the failures if it kept failing,
which lead to confusing logs in the following process. This patch also
adds one more retry.

Signed-off-by: Quan Tian <qtian@vmware.com>

For example, the following tests actually failed because of pulling images but the errors were ignored and they continued building and then failed when using the images:
https://jenkins.antrea-ci.rocks/job/antrea-e2e-for-pull-request/2494/console
https://jenkins.antrea-ci.rocks/job/antrea-networkpolicy-for-pull-request/2101/console
https://jenkins.antrea-ci.rocks/job/antrea-all-features-conformance-for-pull-request/695/console

```
20.04: Pulling from antrea/ubuntu
Digest: sha256:86ac87f73641c920fb42cc9612d4fb57b5626b56ea2a19b894d0673fd5b4f2e9
Status: Image is up to date for projects.registry.vmware.com/antrea/ubuntu:20.04
projects.registry.vmware.com/antrea/ubuntu:20.04
1.15: Pulling from antrea/golang
bd8f6a7501cc: Pulling fs layer
44718e6d535d: Pulling fs layer
efe9738af0cb: Pulling fs layer
f37aabde37b8: Pulling fs layer
f37aabde37b8: Waiting
44718e6d535d: Waiting
bd8f6a7501cc: Waiting
efe9738af0cb: Waiting
c4c446e03742: Pulling fs layer
b79d3f7d1d7f: Pulling fs layer
b79d3f7d1d7f: Waiting
f37aabde37b8: Waiting
c4c446e03742: Waiting
44718e6d535d: Verifying Checksum
44718e6d535d: Download complete
ec0591a27469: Pulling fs layer
b79d3f7d1d7f: Waiting
ec0591a27469: Waiting
error pulling image configuration: unknown blob
===> Building antrea/flow-aggregator-coverage Docker image <===
...
...
Successfully built b12f71c915b4
Successfully tagged antrea/flow-aggregator-coverage:antrea-networkpolicy-for-pull-request-2101
docker tag antrea/flow-aggregator-coverage:antrea-networkpolicy-for-pull-request-2101 antrea/flow-aggregator-coverage
make: Entering directory '/var/lib/jenkins/workspace/antrea-networkpolicy-for-pull-request'
/var/lib/jenkins/workspace/antrea-networkpolicy-for-pull-request/hack/generate-manifest.sh --mode dev --coverage > build/yamls/antrea-coverage.yml
Installing kustomize
/var/lib/jenkins/workspace/antrea-networkpolicy-for-pull-request/hack/generate-manifest.sh --mode dev --ipsec --coverage > build/yamls/antrea-ipsec-coverage.yml
/var/lib/jenkins/workspace/antrea-networkpolicy-for-pull-request/hack/generate-manifest-flow-aggregator.sh --mode dev --coverage > build/yamls/flow-aggregator-coverage.yml
make: Leaving directory '/var/lib/jenkins/workspace/antrea-networkpolicy-for-pull-request'
====== Delivering Antrea to all the Nodes ======
Error response from daemon: reference does not exist