### PR TITLE
whereabouts IPAM package support for Antrea

### DIFF
--- a/build/images/base/Dockerfile
+++ b/build/images/base/Dockerfile
@@ -19,8 +19,8 @@ RUN set -eux; \
          *) pluginsArch=''; echo >&2; echo >&2 "unsupported architecture '$dpkgArch'"; echo >&2 ; exit 1 ;; \
     esac; \
     mkdir -p /opt/cni/bin; \
-    wget -q -O - https://github.com/containernetworking/plugins/releases/download/$CNI_BINARIES_VERSION/cni-plugins-linux-${pluginsArch}-$CNI_BINARIES_VERSION.tgz | tar xz -C /opt/cni/bin $CNI_PLUGINS
-
+    wget -q -O - https://github.com/containernetworking/plugins/releases/download/$CNI_BINARIES_VERSION/cni-plugins-linux-${pluginsArch}-$CNI_BINARIES_VERSION.tgz | tar xz -C /opt/cni/bin $CNI_PLUGINS; \
+    wget -q -O - https://downloads.antrea.io/whereabouts/v0.4/whereabouts-linux-${pluginsArch}.tgz | tar xz -C /opt/cni/bin/ whereabouts-linux-${pluginsArch}/whereabouts --strip-components=1
 
 FROM antrea/openvswitch:${OVS_VERSION}
 

--- a/build/images/scripts/install_cni
+++ b/build/images/scripts/install_cni
@@ -24,8 +24,11 @@ install -m 755 /opt/cni/bin/loopback /host/opt/cni/bin/loopback
 # Install PortMap CNI binary file. It is required to support hostPort.
 install -m 755 /opt/cni/bin/portmap /host/opt/cni/bin/portmap
 
-# Install bandwidth CNI binary file, It is required to support traffic shaping.
+# Install bandwidth CNI binary file. It is required to support traffic shaping.
 install -m 755 /opt/cni/bin/bandwidth /host/opt/cni/bin/bandwidth
+
+# Install whereabouts IPAM binary file. Required for global IPAM support specific to CNF use cases.
+install -m 755 /opt/cni/bin/whereabouts /host/opt/cni/bin/whereabouts
 
 # Load the OVS kernel module
 modprobe openvswitch || (echo "Failed to load the OVS kernel module from the container, try running 'modprobe openvswitch' on your Nodes"; exit 1)


### PR DESCRIPTION
Whereabouts IPAM package support for Antrea
 - Required for CNF use case support.