### PR TITLE
Build antrea-cni binary and release binaries without cgo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,10 +55,12 @@ antrea-controller-instr-binary:
 	@mkdir -p $(BINDIR)
 	GOOS=linux $(GO) test -tags testbincover -covermode count -coverpkg=antrea.io/antrea/pkg/... -c -o $(BINDIR)/antrea-controller-coverage $(GOFLAGS) -ldflags '$(LDFLAGS)' antrea.io/antrea/cmd/antrea-controller
 
+# diable cgo for antrea-cni since it can be installed on some systems with
+# incompatible or missing system libraries.
 .PHONY: antrea-cni
 antrea-cni:
 	@mkdir -p $(BINDIR)
-	GOOS=linux $(GO) build -o $(BINDIR) $(GOFLAGS) -ldflags '$(LDFLAGS)' antrea.io/antrea/cmd/antrea-cni
+	GOOS=linux CGO_ENABLED=0 $(GO) build -o $(BINDIR) $(GOFLAGS) -ldflags '$(LDFLAGS)' antrea.io/antrea/cmd/antrea-cni
 
 .PHONY: antctl-ubuntu
 antctl-ubuntu:
@@ -70,10 +72,13 @@ antctl-instr-binary:
 	@mkdir -p $(BINDIR)
 	GOOS=linux $(GO) test -tags testbincover -covermode count -coverpkg=antrea.io/antrea/pkg/... -c -o $(BINDIR)/antctl-coverage $(GOFLAGS) -ldflags '$(LDFLAGS)' antrea.io/antrea/cmd/antctl
 
+# diable cgo for antrea-cni and antrea-agent: antrea-cni is meant to be
+# installed on the host and the antrea-agent is run as a process on Windows
+# hosts (we also distribute it as a release binary).
 .PHONY: windows-bin
 windows-bin:
 	@mkdir -p $(BINDIR)
-	GOOS=windows $(GO) build -o $(BINDIR) $(GOFLAGS) -ldflags '$(LDFLAGS)' antrea.io/antrea/cmd/antrea-cni antrea.io/antrea/cmd/antrea-agent
+	GOOS=windows CGO_ENABLED=0 $(GO) build -o $(BINDIR) $(GOFLAGS) -ldflags '$(LDFLAGS)' antrea.io/antrea/cmd/antrea-cni antrea.io/antrea/cmd/antrea-agent
 
 .PHONY: flow-aggregator
 flow-aggregator:

--- a/hack/release/prepare-assets.sh
+++ b/hack/release/prepare-assets.sh
@@ -54,11 +54,16 @@ for build in "${ANTREA_BUILDS[@]}"; do
     arch="${args[1]}"
     suffix="${args[2]}"
 
-    GOOS=$os GOARCH=$arch ANTCTL_BINARY_NAME="antctl-$suffix" BINDIR="$OUTPUT_DIR"/ make antctl-release
-    cd ./plugins/octant && GOOS=$os GOARCH=$arch ANTREA_OCTANT_PLUGIN_BINARY_NAME="antrea-octant-plugin-$suffix" \
+    # cgo is disabled by default when cross-compiling, but enabled by default
+    # for native builds. We ensure it is always disabled for portability since
+    # these binaries will be distributed as release assets.
+    GOOS=$os GOARCH=$arch CGO_ENABLED=0 ANTCTL_BINARY_NAME="antctl-$suffix" BINDIR="$OUTPUT_DIR"/ make antctl-release
+    cd ./plugins/octant && GOOS=$os GOARCH=$arch CGO_ENABLED=0 ANTREA_OCTANT_PLUGIN_BINARY_NAME="antrea-octant-plugin-$suffix" \
     BINDIR="$OUTPUT_DIR" make antrea-octant-plugin-release && cd ../..
 done
 
+# the windows-bin Makefile target builds antrea-cni and antrea-agent with cgo
+# explicitly disabled.
 BINDIR="$OUTPUT_DIR" make windows-bin
 sed "s/AntreaVersion=\"latest\"/AntreaVersion=\"$VERSION\"/" ./hack/windows/Start.ps1 > "$OUTPUT_DIR"/Start.ps1
 


### PR DESCRIPTION
antrea-cni can be installed (by the initContainer) on systems with
incompatible system libraries. To increase portability, we build
antrea-cni without cgo by setting CG_ENABLED to 0.

Same goes for release binaries (e.g. antctl). Note that when
cross-compiling, cgo is disabled by default, so there is no change there
(e.g. antctl binary for macOS). It's only for native Linux amd64 builds
that there is an actual change.

Fixes #2095