### PR TITLE
[Windows] Enable RSC in the vSwitch to optimize network performance

### DIFF
--- a/pkg/agent/agent_windows.go
+++ b/pkg/agent/agent_windows.go
@@ -36,6 +36,10 @@ func (i *Initializer) prepareHostNetwork() error {
 	// If the HNS Network already exists, return immediately.
 	hnsNetwork, err := hcsshim.GetHNSNetworkByName(util.LocalHNSNetwork)
 	if err == nil {
+		// Enable RSC for existing vSwitch.
+		if err = util.EnableRSCOnVSwitch(util.LocalHNSNetwork); err != nil {
+			return err
+		}
 		// Save the uplink adapter name to check if the OVS uplink port has been created in prepareOVSBridge stage.
 		i.nodeConfig.UplinkNetConfig.Name = hnsNetwork.NetworkAdapterName
 		return nil


### PR DESCRIPTION
Receive Segment Coalescing (RSC) helps reduce host CPU utilization and increases throughput for virtual workloads by coalescing multiple TCP segments into fewer, but larger segments.

In a test environment, the throughput improvement is about 4x.  

Signed-off-by: Quan Tian <qtian@vmware.com>