### PR TITLE
Fix local access (from worker Node) to Node Port Local ports

### DIFF
--- a/test/integration/agent/route_test.go
+++ b/test/integration/agent/route_test.go
@@ -202,16 +202,18 @@ func TestInitialize(t *testing.T) {
 :ANTREA-OUTPUT - [0:0]
 -A PREROUTING -m comment --comment "Antrea: jump to Antrea mangle rules" -j ANTREA-MANGLE
 -A OUTPUT -m comment --comment "Antrea: jump to Antrea output rules" -j ANTREA-OUTPUT
--A ANTREA-OUTPUT -o antrea-gw0 -m comment --comment "Antrea: mark local output packets" -m addrtype --src-type LOCAL -j MARK --set-xmark 0x1/0x1
+-A ANTREA-OUTPUT -o antrea-gw0 -m comment --comment "Antrea: mark LOCAL output packets" -m addrtype --src-type LOCAL -j MARK --set-xmark 0x1/0x1
 `,
 			"nat": `:ANTREA-POSTROUTING - [0:0]
 -A POSTROUTING -m comment --comment "Antrea: jump to Antrea postrouting rules" -j ANTREA-POSTROUTING
 -A ANTREA-POSTROUTING -s 10.10.10.0/24 -m comment --comment "Antrea: masquerade Pod to external packets" -m set ! --match-set ANTREA-POD-IP dst -j MASQUERADE
+-A ANTREA-POSTROUTING -o antrea-gw0 -m comment --comment "Antrea: masquerade LOCAL traffic" -m addrtype ! --src-type LOCAL --limit-iface-out -m addrtype --src-type LOCAL -j MASQUERADE --random-fully
 `}
 
 		if tc.noSNAT {
 			expectedIPTables["nat"] = `:ANTREA-POSTROUTING - [0:0]
 -A POSTROUTING -m comment --comment "Antrea: jump to Antrea postrouting rules" -j ANTREA-POSTROUTING
+-A ANTREA-POSTROUTING -o antrea-gw0 -m comment --comment "Antrea: masquerade LOCAL traffic" -m addrtype ! --src-type LOCAL --limit-iface-out -m addrtype --src-type LOCAL -j MASQUERADE --random-fully
 `
 		}
 


### PR DESCRIPTION
The following changes were required:
* ANTREA-NODE-PORT-LOCAL nat chain needs to be linked to OUTPUT in
  addition to PREROUTING.
* For the OUTPUT case, traffic needs to be masqueraded to ensure that
  the local gateway's IP is used as the source. Otherwise ARP requests may
  advertise a different source IP address, in which case they will be dropped
  by the SpoofGuard table in the OVS pipeline (see arp_announce sysctl
  parameter). We masquerade all local traffic egressing through the gateway
  for which the source IP address does not match any address assigned to
  the gateway.

In addition to the above changes, we also add a new match to the NPL
iptables rules so that DNAT is only performed when the destination IP is
local.

Fixes #1923

Signed-off-by: Antonin Bas <abas@vmware.com>