### PR TITLE
Added functionality for running the same trace request again with the same parameters.

### DIFF
--- a/plugins/octant/cmd/antrea-octant-plugin/main.go
+++ b/plugins/octant/cmd/antrea-octant-plugin/main.go
@@ -73,7 +73,7 @@ func main() {
 	a := newAntreaOctantPlugin()
 
 	capabilities := &plugin.Capabilities{
-		ActionNames: []string{addTfAction, addLiveTfAction, showGraphAction},
+		ActionNames: []string{addTfAction, addLiveTfAction, showGraphAction, runTraceAgainAction},
 		IsModule:    true,
 	}
 


### PR DESCRIPTION
A "RUN TRACE AGAIN" option has been added to the Octant UI. The new graph's label is changed to reflect the time the trace was run again.

Fixes: #2178

Signed-off-by: Dhruv Jain <2dhruv@gmail.com>