### PR TITLE
Fix NodePortLocal bug when syncing-up iptables rules on restart

### DIFF
--- a/pkg/agent/nodeportlocal/rules/iptable_rule.go
+++ b/pkg/agent/nodeportlocal/rules/iptable_rule.go
@@ -97,7 +97,7 @@ func (ipt *iptablesRules) AddAllRules(nplList []PodNodePort) error {
 	for _, nplData := range nplList {
 		destination := nplData.PodIP + ":" + fmt.Sprint(nplData.PodPort)
 		rule := buildRuleForPod(nplData.NodePort, destination)
-		writeLine(iptablesData, rule...)
+		writeLine(iptablesData, append([]string{"-A", NodePortLocalChain}, rule...)...)
 	}
 	writeLine(iptablesData, "COMMIT")
 	if err := ipt.table.Restore(iptablesData.Bytes(), false, false); err != nil {


### PR DESCRIPTION
A bug was introduced in https://github.com/antrea-io/antrea/pull/2200: I
unified some code but ended up forgetting to prepend the chain name in
the code that syncs up rules on restart. This causes the
iptables-restore command to fail, and the NPL controller to shut down.

Unfortunately this was not caught by any of the e2e tests, so I updated
one of them to ensure that similar mistakes can be avoided in the
future.

Signed-off-by: Antonin Bas <abas@vmware.com>