### PR TITLE
Packet-in rate limiting with OF Meter

### DIFF
--- a/build/images/scripts/start_ovs_netdev
+++ b/build/images/scripts/start_ovs_netdev
@@ -4,6 +4,7 @@ source logging
 source daemon_status
 
 CONTAINER_NAME="antrea-ovs"
+OVS_RUN_DIR="/var/run/openvswitch"
 OVS_DB_FILE="/var/run/openvswitch/conf.db"
 
 if ! ip addr show eth0 > /dev/null 2>&1; then
@@ -52,7 +53,18 @@ function del_br_phy {
     iptables -t raw -D PREROUTING -i eth0 -j DROP
 }
 
+# While working on https://github.com/antrea-io/antrea/pull/2215, we sometimes
+# observed a few leftover .ctl files across OVS restarts, causing failures in
+# the agent when trying to run ovs-appctl commands. This impacted testing on
+# Kind, so we started deleting these files before starting OVS.
+function cleanup_ovs_run_files {
+    rm -rf ${OVS_RUN_DIR}/ovs*.pid
+    rm -rf ${OVS_RUN_DIR}/ovs*.ctl
+    rm -rf ${OVS_RUN_DIR}/.conf.db.*~lock~
+}
+
 function start_ovs {
+    cleanup_ovs_run_files
     log_info $CONTAINER_NAME "Starting OVS"
     # Unlike the start_ovs script, we don't set flow-restore-wait when starting OVS
     # with the netdev datapath. This is because the Node's network relies on the

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/confluentinc/bincover v0.1.0
 	github.com/containernetworking/cni v0.8.0
 	github.com/containernetworking/plugins v0.8.7
-	github.com/contiv/libOpenflow v0.0.0-20210312221048-1d504242120d
+	github.com/contiv/libOpenflow v0.0.0-20210521033357-6b49eccb12e0
 	github.com/contiv/ofnet v0.0.0-00010101000000-000000000000
 	github.com/coreos/go-iptables v0.4.5
 	github.com/elazarl/goproxy v0.0.0-20190911111923-ecfe977594f1 // indirect
@@ -73,5 +73,5 @@ replace (
 	github.com/Microsoft/hcsshim v0.8.9 => github.com/ruicao93/hcsshim v0.8.10-0.20210114035434-63fe00c1b9aa
 	// antrea/plugins/octant/go.mod also has this replacement since replace statement in dependencies
 	// were ignored. We need to change antrea/plugins/octant/go.mod if there is any change here.
-	github.com/contiv/ofnet => github.com/wenyingd/ofnet v0.0.0-20210318032909-171b6795a2da
+	github.com/contiv/ofnet => github.com/wenyingd/ofnet v0.0.0-20210526054554-3e71e19fd0cf
 )

--- a/go.sum
+++ b/go.sum
@@ -122,9 +122,8 @@ github.com/containernetworking/cni v0.8.0 h1:BT9lpgGoH4jw3lFC7Odz2prU5ruiYKcgAjM
 github.com/containernetworking/cni v0.8.0/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
 github.com/containernetworking/plugins v0.8.7 h1:bU7QieuAp+sACI2vCzESJ3FoT860urYP+lThyZkb/2M=
 github.com/containernetworking/plugins v0.8.7/go.mod h1:R7lXeZaBzpfqapcAbHRW8/CYwm0dHzbz0XEjofx0uB0=
-github.com/contiv/libOpenflow v0.0.0-20201014051314-c1702744526c/go.mod h1:DtsPlJOByJZ+MO9YITEGUlbJ/jfh/ef0qeNyBYaeNR4=
-github.com/contiv/libOpenflow v0.0.0-20210312221048-1d504242120d h1:qHFOB6hTrpBzbYdhOMyQwHdX7XfLGGoqN/NfgDrSEXg=
-github.com/contiv/libOpenflow v0.0.0-20210312221048-1d504242120d/go.mod h1:DtsPlJOByJZ+MO9YITEGUlbJ/jfh/ef0qeNyBYaeNR4=
+github.com/contiv/libOpenflow v0.0.0-20210521033357-6b49eccb12e0 h1:Vf4MMw2EBHj+sQaBgXiS6RR6CDi3ZF8xx59eZkWxmHY=
+github.com/contiv/libOpenflow v0.0.0-20210521033357-6b49eccb12e0/go.mod h1:DtsPlJOByJZ+MO9YITEGUlbJ/jfh/ef0qeNyBYaeNR4=
 github.com/contiv/libovsdb v0.0.0-20170227191248-d0061a53e358 h1:AiA9SKyNXulsU7aAnyka3UFHYOIH00A9HvdIRnDXlg0=
 github.com/contiv/libovsdb v0.0.0-20170227191248-d0061a53e358/go.mod h1:+qKEHaNVPj+wrn5st7TEFH9wcUWCJq5ZBvVKPQwzAeg=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
@@ -616,8 +615,8 @@ github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df h1:OviZH7qLw/7Zo
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 github.com/vmware/go-ipfix v0.5.3 h1:ZJTn5vQd6W0WWt05gm+nNFjjgbgVfUkvywdxKmWj4uM=
 github.com/vmware/go-ipfix v0.5.3/go.mod h1:SF6BrZTPvoVdzgmjJvshoegBVbicn4xWlkoCNADab6E=
-github.com/wenyingd/ofnet v0.0.0-20210318032909-171b6795a2da h1:ragN21nQa4zKuCwR2UEbTXEAh3L2YN/Id5SCVkjjwdY=
-github.com/wenyingd/ofnet v0.0.0-20210318032909-171b6795a2da/go.mod h1:8mMMWAYBNUeTGXYKizOLETfN3WIbu3P5DgvS2jiXKdI=
+github.com/wenyingd/ofnet v0.0.0-20210526054554-3e71e19fd0cf h1:EEGpnM6W07pq2nKdqk+lig1Qit5f8eUe+Vt1ditTLgk=
+github.com/wenyingd/ofnet v0.0.0-20210526054554-3e71e19fd0cf/go.mod h1:tZiqxY3POhek8GrqcmU+5bvVzDwY1zZ7Wh9+zwaoV3s=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=

--- a/pkg/agent/openflow/meters_linux.go
+++ b/pkg/agent/openflow/meters_linux.go
@@ -1,0 +1,48 @@
+// +build linux
+
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openflow
+
+import (
+	"github.com/blang/semver"
+	"k8s.io/klog/v2"
+
+	"antrea.io/antrea/pkg/ovs/ovsconfig"
+	"antrea.io/antrea/pkg/util/runtime"
+)
+
+func ovsMetersAreSupported(ovsDatapathType ovsconfig.OVSDatapathType) bool {
+	if ovsDatapathType == ovsconfig.OVSDatapathNetdev {
+		return true
+	}
+	// According to the OVS documentation, meters are supported in the kernel module since 4.15
+	// (https://docs.openvswitch.org/en/latest/faq/releases/). However, it turns out that
+	// because of a bug meters cannot be used with kernel versions older than 4.18, which is
+	// when this patch was merged: https://github.com/torvalds/linux/commit/25432eba9cd.
+	// To avoid increasing the minimum required kernel version for Antrea, we will avoid using
+	// meters altogether if they are not supported, instead of erroring out.
+	minKernelVersion := semver.MustParse("4.18.0") // patch version is required
+	kernelVersion, err := runtime.GetKernelVersion()
+	if err != nil {
+		klog.Warningf("Cannot retrieve Linux kernel version, cannot use OVS meters: %v", err)
+		return false
+	}
+	if kernelVersion.GTE(minKernelVersion) {
+		return true
+	}
+	klog.Infof("Linux kernel version (%s) is less than %s and therefore the OVS kernel datapath does not support meters", kernelVersion, minKernelVersion)
+	return false
+}

--- a/pkg/agent/openflow/meters_others.go
+++ b/pkg/agent/openflow/meters_others.go
@@ -1,0 +1,26 @@
+// +build !linux
+
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openflow
+
+import (
+	"antrea.io/antrea/pkg/ovs/ovsconfig"
+)
+
+func ovsMetersAreSupported(ovsDatapathType ovsconfig.OVSDatapathType) bool {
+	// TODO: revisit after Windows OVS supports OpenFlow meters.
+	return false
+}

--- a/pkg/agent/openflow/packetin.go
+++ b/pkg/agent/openflow/packetin.go
@@ -31,6 +31,15 @@ type PacketInHandler interface {
 }
 
 const (
+	// We use OpenFlow Meter for packet-in rate limiting on OVS side.
+	// Meter Entry ID.
+	PacketInMeterIDNP = 1
+	PacketInMeterIDTF = 2
+	// Meter Entry Rate. It is represented as number of events per second.
+	// Packets which exceed the rate will be dropped.
+	PacketInMeterRateNP = 100
+	PacketInMeterRateTF = 100
+
 	// PacketIn reasons
 	PacketInReasonTF ofpPacketInReason = 1
 	PacketInReasonNP ofpPacketInReason = 0

--- a/pkg/ovs/openflow/interfaces.go
+++ b/pkg/ovs/openflow/interfaces.go
@@ -24,6 +24,7 @@ import (
 type Protocol string
 type TableIDType uint8
 type GroupIDType uint32
+type MeterIDType uint32
 
 type MissActionType uint32
 type Range [2]uint32
@@ -87,6 +88,9 @@ type Bridge interface {
 	DeleteTable(id TableIDType) bool
 	CreateGroup(id GroupIDType) Group
 	DeleteGroup(id GroupIDType) bool
+	CreateMeter(id MeterIDType, flags ofctrl.MeterFlag) Meter
+	DeleteMeter(id MeterIDType) bool
+	DeleteMeterAll() error
 	DumpTableStatus() []TableStatus
 	// DumpFlows queries the Openflow entries from OFSwitch. The filter of the query is Openflow cookieID; the result is
 	// a map from flow cookieID to FlowStates.
@@ -141,6 +145,7 @@ type EntryType string
 const (
 	FlowEntry  EntryType = "FlowEntry"
 	GroupEntry EntryType = "GroupEntry"
+	MeterEntry EntryType = "MeterEntry"
 )
 
 type OFEntry interface {
@@ -204,6 +209,7 @@ type Action interface {
 	GotoTable(table TableIDType) FlowBuilder
 	SendToController(reason uint8) FlowBuilder
 	Note(notes string) FlowBuilder
+	Meter(meterId uint32) FlowBuilder
 }
 
 type FlowBuilder interface {
@@ -300,6 +306,21 @@ type BucketBuilder interface {
 	LoadRegRange(regID int, data uint32, rng Range) BucketBuilder
 	ResubmitToTable(tableID TableIDType) BucketBuilder
 	Done() Group
+}
+
+type Meter interface {
+	OFEntry
+	ResetMeterBands() Meter
+	MeterBand() MeterBandBuilder
+}
+
+type MeterBandBuilder interface {
+	MeterType(meterType ofctrl.MeterType) MeterBandBuilder
+	Rate(rate uint32) MeterBandBuilder
+	Burst(burst uint32) MeterBandBuilder
+	PrecLevel(precLevel uint8) MeterBandBuilder
+	Experimenter(experimenter uint32) MeterBandBuilder
+	Done() Meter
 }
 
 type CTAction interface {

--- a/pkg/ovs/openflow/ofctrl_action.go
+++ b/pkg/ovs/openflow/ofctrl_action.go
@@ -330,6 +330,11 @@ func (a *ofFlowAction) SendToController(reason uint8) FlowBuilder {
 	return a.builder
 }
 
+func (a *ofFlowAction) Meter(meterId uint32) FlowBuilder {
+	a.builder.ofFlow.Meter(meterId)
+	return a.builder
+}
+
 //  Learn is an action which adds or modifies a flow in an OpenFlow table.
 func (a *ofFlowAction) Learn(id TableIDType, priority uint16, idleTimeout, hardTimeout uint16, cookieID uint64) LearnAction {
 	la := &ofLearnAction{

--- a/pkg/ovs/openflow/ofctrl_meter.go
+++ b/pkg/ovs/openflow/ofctrl_meter.go
@@ -1,0 +1,133 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openflow
+
+import (
+	"fmt"
+
+	"github.com/contiv/libOpenflow/openflow13"
+	"github.com/contiv/libOpenflow/util"
+	"github.com/contiv/ofnet/ofctrl"
+)
+
+type ofMeter struct {
+	ofctrl *ofctrl.Meter
+	bridge *OFBridge
+}
+
+func (m *ofMeter) Reset() {
+	m.ofctrl.Switch = m.bridge.ofSwitch
+}
+
+func (m *ofMeter) Add() error {
+	return m.ofctrl.Install()
+}
+
+func (m *ofMeter) Modify() error {
+	return m.ofctrl.Install()
+}
+
+func (m *ofMeter) Delete() error {
+	return m.ofctrl.Delete()
+}
+
+func (m *ofMeter) Type() EntryType {
+	return MeterEntry
+}
+
+func (m *ofMeter) KeyString() string {
+	return fmt.Sprintf("meter_id:%d", m.ofctrl.ID)
+}
+
+func (m *ofMeter) GetBundleMessage(entryOper OFOperation) (ofctrl.OpenFlowModMessage, error) {
+	var operation int
+	switch entryOper {
+	case AddMessage:
+		operation = openflow13.OFPMC_ADD
+	case ModifyMessage:
+		operation = openflow13.OFPMC_MODIFY
+	case DeleteMessage:
+		operation = openflow13.OFPMC_DELETE
+	}
+	message := m.ofctrl.GetBundleMessage(operation)
+	return message, nil
+}
+
+func (m *ofMeter) ResetMeterBands() Meter {
+	m.ofctrl.MeterBands = nil
+	return m
+}
+
+func (m *ofMeter) MeterBand() MeterBandBuilder {
+	return &meterBandBuilder{
+		meter:           m,
+		meterBandHeader: openflow13.NewMeterBandHeader(),
+		prevLevel:       0,
+		experimenter:    0,
+	}
+}
+
+type meterBandBuilder struct {
+	meter           *ofMeter
+	meterBandHeader *openflow13.MeterBandHeader
+	prevLevel       uint8
+	experimenter    uint32
+}
+
+func (m *meterBandBuilder) MeterType(meterType ofctrl.MeterType) MeterBandBuilder {
+	m.meterBandHeader.Type = uint16(meterType)
+	return m
+}
+
+func (m *meterBandBuilder) Rate(rate uint32) MeterBandBuilder {
+	m.meterBandHeader.Rate = rate
+	return m
+}
+
+func (m *meterBandBuilder) Burst(burst uint32) MeterBandBuilder {
+	m.meterBandHeader.BurstSize = burst
+	return m
+}
+
+func (m *meterBandBuilder) PrecLevel(precLevel uint8) MeterBandBuilder {
+	m.prevLevel = precLevel
+	return m
+}
+
+func (m *meterBandBuilder) Experimenter(experimenter uint32) MeterBandBuilder {
+	m.experimenter = experimenter
+	return m
+}
+
+func (m *meterBandBuilder) Done() Meter {
+	var mb util.Message
+	switch m.meterBandHeader.Type {
+	case uint16(ofctrl.MeterDrop):
+		mbDrop := new(openflow13.MeterBandDrop)
+		mbDrop.MeterBandHeader = *m.meterBandHeader
+		mb = mbDrop
+	case uint16(ofctrl.MeterDSCPRemark):
+		mbDscp := new(openflow13.MeterBandDSCP)
+		mbDscp.MeterBandHeader = *m.meterBandHeader
+		mbDscp.PrecLevel = m.prevLevel
+		mb = mbDscp
+	case uint16(ofctrl.MeterExperimenter):
+		mbExp := new(openflow13.MeterBandExperimenter)
+		mbExp.MeterBandHeader = *m.meterBandHeader
+		mbExp.Experimenter = m.experimenter
+	}
+	m.meter.ofctrl.AddMeterBand(&mb)
+	return m.meter
+}

--- a/pkg/ovs/openflow/testing/mock_openflow.go
+++ b/pkg/ovs/openflow/testing/mock_openflow.go
@@ -134,6 +134,20 @@ func (mr *MockBridgeMockRecorder) CreateGroup(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateGroup", reflect.TypeOf((*MockBridge)(nil).CreateGroup), arg0)
 }
 
+// CreateMeter mocks base method
+func (m *MockBridge) CreateMeter(arg0 openflow.MeterIDType, arg1 ofctrl.MeterFlag) openflow.Meter {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateMeter", arg0, arg1)
+	ret0, _ := ret[0].(openflow.Meter)
+	return ret0
+}
+
+// CreateMeter indicates an expected call of CreateMeter
+func (mr *MockBridgeMockRecorder) CreateMeter(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateMeter", reflect.TypeOf((*MockBridge)(nil).CreateMeter), arg0, arg1)
+}
+
 // CreateTable mocks base method
 func (m *MockBridge) CreateTable(arg0, arg1 openflow.TableIDType, arg2 openflow.MissActionType) openflow.Table {
 	m.ctrl.T.Helper()
@@ -174,6 +188,34 @@ func (m *MockBridge) DeleteGroup(arg0 openflow.GroupIDType) bool {
 func (mr *MockBridgeMockRecorder) DeleteGroup(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteGroup", reflect.TypeOf((*MockBridge)(nil).DeleteGroup), arg0)
+}
+
+// DeleteMeter mocks base method
+func (m *MockBridge) DeleteMeter(arg0 openflow.MeterIDType) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteMeter", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// DeleteMeter indicates an expected call of DeleteMeter
+func (mr *MockBridgeMockRecorder) DeleteMeter(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMeter", reflect.TypeOf((*MockBridge)(nil).DeleteMeter), arg0)
+}
+
+// DeleteMeterAll mocks base method
+func (m *MockBridge) DeleteMeterAll() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteMeterAll")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteMeterAll indicates an expected call of DeleteMeterAll
+func (mr *MockBridgeMockRecorder) DeleteMeterAll() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMeterAll", reflect.TypeOf((*MockBridge)(nil).DeleteMeterAll))
 }
 
 // DeleteTable mocks base method
@@ -747,6 +789,20 @@ func (m *MockAction) LoadRegRange(arg0 int, arg1 uint32, arg2 openflow.Range) op
 func (mr *MockActionMockRecorder) LoadRegRange(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadRegRange", reflect.TypeOf((*MockAction)(nil).LoadRegRange), arg0, arg1, arg2)
+}
+
+// Meter mocks base method
+func (m *MockAction) Meter(arg0 uint32) openflow.FlowBuilder {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Meter", arg0)
+	ret0, _ := ret[0].(openflow.FlowBuilder)
+	return ret0
+}
+
+// Meter indicates an expected call of Meter
+func (mr *MockActionMockRecorder) Meter(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Meter", reflect.TypeOf((*MockAction)(nil).Meter), arg0)
 }
 
 // Move mocks base method

--- a/pkg/util/runtime/runtime_linux.go
+++ b/pkg/util/runtime/runtime_linux.go
@@ -1,0 +1,49 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/blang/semver"
+	"golang.org/x/sys/unix"
+)
+
+func parseKernelVersionStr(kernelVersionStr string) (semver.Version, error) {
+	// "5.4.0-72-generic" is parsed successfully to:
+	// Major: 5
+	// Minor: 4
+	// Patch: 0
+	// Pre: [72-generic]
+	// Build: []
+	return semver.Parse(kernelVersionStr)
+}
+
+// GetKernelVersion returns the Linux kernel version for the current host.
+func GetKernelVersion() (semver.Version, error) {
+	var unameBuf unix.Utsname
+	if err := unix.Uname(&unameBuf); err != nil {
+		return semver.Version{}, err
+	}
+	// unameBuf.Release is a fixed-size 65-byte array, we need to remove the trailing null
+	// characters from it first.
+	kernelVersionStr := string(bytes.TrimRight(unameBuf.Release[:], "\x00"))
+	v, err := parseKernelVersionStr(kernelVersionStr)
+	if err != nil {
+		return semver.Version{}, fmt.Errorf("error when parsing Linux kernel version string: %v", err)
+	}
+	return v, nil
+}

--- a/plugins/octant/go.sum
+++ b/plugins/octant/go.sum
@@ -136,7 +136,7 @@ github.com/containerd/typeurl v0.0.0-20180627222232-a93fcdb778cd/go.mod h1:Cm3kw
 github.com/containernetworking/cni v0.8.0/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
 github.com/containernetworking/plugins v0.8.7/go.mod h1:R7lXeZaBzpfqapcAbHRW8/CYwm0dHzbz0XEjofx0uB0=
 github.com/contiv/libOpenflow v0.0.0-20201014051314-c1702744526c/go.mod h1:DtsPlJOByJZ+MO9YITEGUlbJ/jfh/ef0qeNyBYaeNR4=
-github.com/contiv/libOpenflow v0.0.0-20210312221048-1d504242120d/go.mod h1:DtsPlJOByJZ+MO9YITEGUlbJ/jfh/ef0qeNyBYaeNR4=
+github.com/contiv/libOpenflow v0.0.0-20210521033357-6b49eccb12e0/go.mod h1:DtsPlJOByJZ+MO9YITEGUlbJ/jfh/ef0qeNyBYaeNR4=
 github.com/contiv/libovsdb v0.0.0-20170227191248-d0061a53e358/go.mod h1:+qKEHaNVPj+wrn5st7TEFH9wcUWCJq5ZBvVKPQwzAeg=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=


### PR DESCRIPTION
Add OF meter to implement rate-limiting for packet-in messages.

1. Add meter entries during initialization: one for Traceflow packets
   and one for other (NetworkPolicy-related) packets.
2. While building the flow that will trigger packet-in, use the meter
   action.
3. Update libOpenflow and ofnet version, to get meter programming
   support.

Since Windows OVS doesn't support OF meters, we skip OF meter related
operations for now. On Linux, for the OVS kernel datapath, kernel
version 4.18 is required for meter support (should be 4.15, but is 4.18
in practice because of an implementation bug): we add a check and
disable meters if the Linux kernel is not recent enough. This is to
avoid increasing the minimum kernel version requirement for Antrea, at
least for now.

Fixes #2069

Co-authored-by: Antonin Bas <abas@vmware.com>

Signed-off-by: wgrayson <wgrayson@vmware.com>
Signed-off-by: Antonin Bas <abas@vmware.com>