### PR TITLE
add TranslatedSrcIP for SNAT

### DIFF
--- a/pkg/graphviz/traceflow.go
+++ b/pkg/graphviz/traceflow.go
@@ -193,6 +193,9 @@ func getTraceflowMessage(o *crdv1alpha1.Observation, spec *crdv1alpha1.Traceflow
 			spec.Destination.Pod = o.Pod[strings.Index(o.Pod, `/`)+1:]
 		}
 	}
+	if o.Action != crdv1alpha1.ActionDropped && len(o.TranslatedSrcIP) > 0 {
+		str += "\nTranslated Source IP: " + o.TranslatedSrcIP
+	}
 	if o.Action != crdv1alpha1.ActionDropped && len(o.TranslatedDstIP) > 0 {
 		str += "\nTranslated Destination IP: " + o.TranslatedDstIP
 	}

--- a/test/e2e/traceflow_test.go
+++ b/test/e2e/traceflow_test.go
@@ -1425,6 +1425,7 @@ func TestTraceflowInterNode(t *testing.T) {
 						{
 							Component:       v1alpha1.ComponentLB,
 							Pod:             fmt.Sprintf("%s/%s", testNamespace, nginxPodName),
+							TranslatedSrcIP: "169.254.169.252",
 							TranslatedDstIP: nginxIPv4Str,
 							Action:          v1alpha1.ActionForwarded,
 						},
@@ -1802,6 +1803,7 @@ func TestTraceflowInterNode(t *testing.T) {
 						{
 							Component:       v1alpha1.ComponentLB,
 							Pod:             fmt.Sprintf("%s/%s", testNamespace, nginxPodName),
+							TranslatedSrcIP: "fc00::aabb:ccdd:eeff",
 							TranslatedDstIP: nginxIPv6Str,
 							Action:          v1alpha1.ActionForwarded,
 						},


### PR DESCRIPTION
add TranslatedSrcIP in traceflow observation results for service SNAT:
```
$antctl traceflow -S kube-system/coredns-558bd4d5db-588zw -D kube-system/kube-dns -f udp,udp_dst=53,udp_src=100
name: kube-system-coredns-558bd4d5db-588zw-to-kube-system-kube-dns-gzhpt5xk
phase: Succeeded
source: kube-system/coredns-558bd4d5db-588zw
destination: kube-system/kube-dns
results:
- node: lan-k8s-0-1
  timestamp: 1622446545
  observations:
  - component: SpoofGuard
    action: Forwarded
  - component: LB
    action: Forwarded
    pod: kube-system/coredns-558bd4d5db-588zw
    translatedSrcIP: 169.254.169.252
    translatedDstIP: 192.168.225.4
  - component: Forwarding
    componentInfo: Output
    action: Delivered
```
and add this field to octant UI as well
<img width="519" alt="image" src="https://user-images.githubusercontent.com/80799348/120161873-62fb8d80-c22a-11eb-9164-3497ffbd5ac2.png">


This resolves #2179 
Signed-off-by: Luo Lan <luola@vmware.com>
