### PR TITLE
Do not fail clair-scan if docker containers cannot be killed

### DIFF
--- a/ci/clair-scan/run.sh
+++ b/ci/clair-scan/run.sh
@@ -42,9 +42,9 @@ docker run --rm -d --name clair-db arminc/clair-db:latest
 docker run --rm -p 6060:6060 --link clair-db:postgres -d --name clair arminc/clair-local-scan:v2.0.8_fe9b059d930314b54c78f75afe265955faf4fdc1
 
 function cleanup {
-  echo "Stoping docker containers"
-  docker kill clair
-  docker kill clair-db
+  echo "Stopping docker containers"
+  docker kill clair || true
+  docker kill clair-db || true
 }
 
 trap cleanup EXIT


### PR DESCRIPTION
Recently some the clair-scan CI job has been failing because of an error
during cleanup. It seems that by the time we call "docker kill", at
least one of the containers (clair) may not exist any more. Maybe the
process is crashing, but the scan does complete successfully every time
regardless... To avoid job failures, we tolerate errors when calling
"docker kill" during the cleanup phase.