### PR TITLE
Add Go script to process CHANGELOG files before releases

### DIFF
--- a/docs/maintainers/release.md
+++ b/docs/maintainers/release.md
@@ -11,7 +11,10 @@ release. We use `<TAG>` as a placeholder for the release tag (e.g. `v0.1.0`).
      changes and all bug fixes since the first version of the previous minor
      release should be mentioned. The commit message must be *exactly* `"Update
      CHANGELOG for <TAG> release"`, as a bot will look for this commit and
-     cherry-pick it to update the main branch (starting with Antrea v1.0).
+     cherry-pick it to update the main branch (starting with Antrea v1.0). The
+     [process-changelog.go](../../hack/release/process-changelog.go) script
+     should be used to easily generate links to PRs and the Github profiles of
+     PR authors.
   2. a commit to update [VERSION](../../VERSION) as needed.
 
 * Make the release on Github with the release branch as the target: copy the

--- a/hack/release/process-changelog.go
+++ b/hack/release/process-changelog.go
@@ -1,0 +1,106 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Run this script with "go run process-changelog.go <PATH to CHANGELOG> > <PATH to new CHANGELOG>".
+// The script will:
+//  * Add links to PRs, by replacing all instances of [#<NUM>] with [#<NUM>](<link to PR NUM>)
+//  * Add links to the Github profiles of PR authors. It will look for instances of [@<AUTHOR>] in
+//    the CHANGELOG and generate the appropriate Markdown links at the end of the file.
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"regexp"
+	"sort"
+	"time"
+)
+
+const (
+	repo          = "https://github.com/antrea-io/antrea"
+	authorBaseURL = "https://github.com"
+)
+
+var (
+	pullBaseURL = fmt.Sprintf("%s/pull", repo)
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		log.Fatalf("This script expects exactly one argument, the path to the CHANGELOG file")
+	}
+	filePath := os.Args[1]
+	file, err := os.Open(filePath)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer file.Close()
+
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+
+	// Add links to all PRs: [#XXXX] -> [#XXXX](<link>)
+	// Gather all author names: [@<author>]
+	scanner := bufio.NewScanner(file)
+	prRef := regexp.MustCompile(`(\[#[0-9]+\])[^(]`)
+	authorRef := regexp.MustCompile(`\[@([a-zA-Z0-9-]+)\][^(]`)
+	allAuthors := make(map[string]bool)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if len(line) == 0 || line[0] != '-' {
+			out.WriteString(line)
+			out.WriteString("\n")
+			continue
+		}
+		line = prRef.ReplaceAllString(line, fmt.Sprintf("$1(%s/$1)", pullBaseURL))
+		matches := authorRef.FindAllStringSubmatch(line, -1)
+		for _, match := range matches {
+			allAuthors[match[1]] = true
+		}
+		out.WriteString(line)
+		out.WriteString("\n")
+	}
+
+	if err := scanner.Err(); err != nil {
+		log.Fatal(err)
+	}
+
+	out.Flush()
+	log.Printf("Checking Github accounts, this could take a while...")
+
+	numAuthors := len(allAuthors)
+	sortedAuthors := make([]string, 0, numAuthors)
+	for author := range allAuthors {
+		sortedAuthors = append(sortedAuthors, author)
+	}
+	sort.Strings(sortedAuthors)
+	timeout := time.Duration(3 * time.Second)
+	client := http.Client{
+		Timeout: timeout,
+	}
+	for _, author := range sortedAuthors {
+		log.Printf("Checking %s", author)
+		url := fmt.Sprintf("%s/%s", authorBaseURL, author)
+		if _, err := client.Head(url); err != nil {
+			log.Printf("FAILURE: %v", err)
+		} else {
+			log.Printf("SUCCESS")
+		}
+		out.WriteString(fmt.Sprintf("[@%s]: %s\n", author, url))
+	}
+}


### PR DESCRIPTION
This is a new script I wrote to simplify writing the CHANGELOG ahead of
a release. It takes care of automatically generating links for PRs and
PR authors.

Signed-off-by: Antonin Bas <abas@vmware.com>