### PR TITLE
Add flow-aggregator e2e test for pod-to-external flow type

### DIFF
--- a/test/e2e/connectivity_test.go
+++ b/test/e2e/connectivity_test.go
@@ -106,7 +106,7 @@ func (data *TestData) testHostPortPodConnectivity(t *testing.T) {
 	// Create a server Pod with hostPort set to 80.
 	hpPodName := randName("test-host-port-pod-")
 	hpPodPort := int32(80)
-	if err := data.createServerPod(hpPodName, "", hpPodPort, true); err != nil {
+	if err := data.createServerPod(hpPodName, "", hpPodPort, true, false); err != nil {
 		t.Fatalf("Error when creating HostPort server Pod: %v", err)
 	}
 	defer deletePodWrapper(t, data, hpPodName)

--- a/test/e2e/flowaggregator_test.go
+++ b/test/e2e/flowaggregator_test.go
@@ -69,12 +69,12 @@ DATA SET:
     ingressNetworkPolicyNamespace: antrea-test
     ingressNetworkPolicyType: 2
     ingressNetworkPolicyRuleName: test-ingress-rule-name
-	ingressNetworkPolicyRuleAction: 1
+    ingressNetworkPolicyRuleAction: 1
     egressNetworkPolicyName: test-flow-aggregator-networkpolicy-egress
     egressNetworkPolicyNamespace: antrea-test
     egressNetworkPolicyType: 2
     egressNetworkPolicyRuleName: test-egress-rule-name
-	egressNetworkPolicyRuleAction: 1
+    egressNetworkPolicyRuleAction: 1
     flowType: 1
     destinationClusterIPv4: 0.0.0.0
     originalExporterIPv4Address: 10.10.0.1
@@ -115,7 +115,6 @@ const (
 	egressAntreaNetworkPolicyName  = "test-flow-aggregator-antrea-networkpolicy-egress"
 	testIngressRuleName            = "test-ingress-rule-name"
 	testEgressRuleName             = "test-egress-rule-name"
-	collectorCheckTimeout          = 12 * time.Second
 	iperfTimeSec                   = 12
 	// Single iperf run results in two connections with separate ports (control connection and actual data connection).
 	// As 2s is the export active timeout of flow exporter and iperf traffic runs for 12s, we expect totally 12 records
@@ -427,6 +426,30 @@ func testHelper(t *testing.T, data *TestData, podAIPs, podBIPs, podCIPs, podDIPs
 		}
 	})
 
+	// ToExternalFlows tests the export of IPFIX flow records when a source Pod
+	// sends traffic to an external IP
+	t.Run("ToExternalFlows", func(t *testing.T) {
+		// Creating an agnhost server as a host network Pod
+		serverPodPort := int32(80)
+		_, serverIPs, cleanupFunc := createAndWaitForPod(t, data, func(name string, nodeName string) error {
+			return data.createServerPod(name, "", serverPodPort, false, true)
+		}, "test-server-", "")
+		defer cleanupFunc()
+
+		clientName, clientIPs, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", nodeName(0))
+		defer cleanupFunc()
+
+		if !isIPv6 {
+			if clientIPs.ipv4 != nil && serverIPs.ipv4 != nil {
+				checkRecordsForToExternalFlows(t, data, nodeName(0), clientName, clientIPs.ipv4.String(), serverIPs.ipv4.String(), serverPodPort, isIPv6)
+			}
+		} else {
+			if clientIPs.ipv6 != nil && serverIPs.ipv6 != nil {
+				checkRecordsForToExternalFlows(t, data, nodeName(0), clientName, clientIPs.ipv6.String(), serverIPs.ipv6.String(), serverPodPort, isIPv6)
+			}
+		}
+	})
+
 	// LocalServiceAccess tests the case, where Pod and Service are deployed on the same Node and their flow information is exported as IPFIX flow records.
 	t.Run("LocalServiceAccess", func(t *testing.T) {
 		skipIfProxyDisabled(t, data)
@@ -475,31 +498,7 @@ func checkRecordsForFlows(t *testing.T, data *TestData, srcIP string, dstIP stri
 		t.Fatalf("Unit of the traffic bandwidth reported by iperf should either be Mbits or Gbits, failing the test.")
 	}
 
-	// Polling to make sure all the data records corresponding to the iperf flow
-	// are received.
-	err = wait.PollImmediate(500*time.Millisecond, aggregatorInactiveFlowRecordTimeout, func() (bool, error) {
-		// `pod-running-timeout` option is added to cover scenarios where ipfix flow-collector has crashed after being deployed.
-		rc, collectorOutput, _, err := provider.RunCommandOnNode(controlPlaneNodeName(), fmt.Sprintf("kubectl logs --since=%v --pod-running-timeout=%v ipfix-collector -n antrea-test", time.Since(timeStart).String(), aggregatorInactiveFlowRecordTimeout.String()))
-		if err != nil || rc != 0 {
-			return false, err
-		}
-		recordSlices := getRecordsFromOutput(collectorOutput)
-		for _, record := range recordSlices {
-			exportTime := int64(getUnit64FieldFromRecord(t, record, "flowEndSeconds"))
-			if strings.Contains(record, srcIP) && strings.Contains(record, dstIP) {
-				if exportTime >= timeStartSec+iperfTimeSec {
-					return true, nil
-				}
-			}
-		}
-		return false, nil
-	})
-	require.NoErrorf(t, err, "IPFIX collector did not receive the expected records and timed out with error: %v", err)
-
-	rc, collectorOutput, _, err := provider.RunCommandOnNode(controlPlaneNodeName(), fmt.Sprintf("kubectl logs --since=%v ipfix-collector -n antrea-test", time.Since(timeStart).String()))
-	if err != nil || rc != 0 {
-		t.Errorf("Error when getting logs %v, rc: %v", err, rc)
-	}
+	collectorOutput := getCollectorOutput(t, srcIP, dstIP, timeStart, true)
 	// Iterate over recordSlices and build some results to test with expected results
 	recordSlices := getRecordsFromOutput(collectorOutput)
 	dataRecordsCount := 0
@@ -574,6 +573,32 @@ func checkRecordsForFlows(t *testing.T, data *TestData, srcIP string, dstIP stri
 	assert.GreaterOrEqualf(t, dataRecordsCount, expectedNumDataRecords, "IPFIX collector should receive expected number of flow records. Considered records: ", len(recordSlices))
 }
 
+func checkRecordsForToExternalFlows(t *testing.T, data *TestData, srcNodeName string, srcPodName string, srcIP string, dstIP string, dstPort int32, isIPv6 bool) {
+	timeStart := time.Now()
+	var cmd string
+	if !isIPv6 {
+		cmd = fmt.Sprintf("wget -O- %s:%d", dstIP, dstPort)
+	} else {
+		cmd = fmt.Sprintf("wget -O- [%s]:%d", dstIP, dstPort)
+	}
+	stdout, stderr, err := data.runCommandFromPod(testNamespace, srcPodName, busyboxContainerName, strings.Fields(cmd))
+	require.NoErrorf(t, err, "Error when running wget command, stdout: %s, stderr: %s", stdout, stderr)
+
+	collectorOutput := getCollectorOutput(t, srcIP, dstIP, timeStart, false)
+	recordSlices := getRecordsFromOutput(collectorOutput)
+	for _, record := range recordSlices {
+		if strings.Contains(record, srcIP) && strings.Contains(record, dstIP) {
+			checkPodAndNodeData(t, record, srcPodName, srcNodeName, "", "")
+			checkFlowType(t, record, ipfixregistry.FlowTypeToExternal)
+			// Since the OVS userspace conntrack implementation doesn't maintain
+			// packet or byte counter statistics, skip the check for Kind clusters
+			if testOptions.providerName != "kind" {
+				assert.NotContains(t, record, "octetDeltaCount: 0", "octetDeltaCount should be non-zero")
+			}
+		}
+	}
+}
+
 func checkRecordsForDenyFlows(t *testing.T, data *TestData, testFlow1, testFlow2 testFlow, isIPv6 bool, isIntraNode bool, isANP bool) {
 	timeStart := time.Now()
 	var cmdStr1, cmdStr2 string
@@ -589,20 +614,7 @@ func checkRecordsForDenyFlows(t *testing.T, data *TestData, testFlow1, testFlow2
 	_, _, err = data.runCommandFromPod(testNamespace, testFlow2.srcPodName, "", []string{"timeout", "2", "bash", "-c", cmdStr2})
 	assert.Error(t, err)
 
-	err = wait.Poll(250*time.Millisecond, collectorCheckTimeout, func() (bool, error) {
-		rc, collectorOutput, _, err := provider.RunCommandOnNode(controlPlaneNodeName(), fmt.Sprintf("kubectl logs --since=%v ipfix-collector -n antrea-test", time.Since(timeStart).String()))
-		if err != nil || rc != 0 {
-			return false, err
-		}
-		return strings.Contains(collectorOutput, testFlow1.srcIP) && strings.Contains(collectorOutput, testFlow2.srcIP), nil
-	})
-	require.NoErrorf(t, err, "IPFIX collector did not receive the expected records and timed out with error: %v", err)
-
-	rc, collectorOutput, _, err := provider.RunCommandOnNode(controlPlaneNodeName(), fmt.Sprintf("kubectl logs --since=%v ipfix-collector -n antrea-test", time.Since(timeStart).String()))
-	if err != nil || rc != 0 {
-		t.Errorf("Error when getting logs %v, rc: %v", err, rc)
-	}
-
+	collectorOutput := getCollectorOutput(t, testFlow1.srcIP, testFlow2.srcIP, timeStart, false)
 	// Iterate over recordSlices and build some results to test with expected results
 	recordSlices := getRecordsFromOutput(collectorOutput)
 	for _, record := range recordSlices {
@@ -673,9 +685,17 @@ func checkPodAndNodeData(t *testing.T, record, srcPod, srcNode, dstPod, dstNode 
 	assert.Contains(record, srcPod, "Record with srcIP does not have Pod name")
 	assert.Contains(record, fmt.Sprintf("sourcePodNamespace: %s", testNamespace), "Record does not have correct sourcePodNamespace")
 	assert.Contains(record, fmt.Sprintf("sourceNodeName: %s", srcNode), "Record does not have correct sourceNodeName")
-	assert.Contains(record, dstPod, "Record with dstIP does not have Pod name")
-	assert.Contains(record, fmt.Sprintf("destinationPodNamespace: %s", testNamespace), "Record does not have correct destinationPodNamespace")
-	assert.Contains(record, fmt.Sprintf("destinationNodeName: %s", dstNode), "Record does not have correct destinationNodeName")
+	// For Pod-To-External flow type, we send traffic to an external address,
+	// so we skip the verification of destination Pod info.
+	if dstPod != "" {
+		assert.Contains(record, dstPod, "Record with dstIP does not have Pod name")
+		assert.Contains(record, fmt.Sprintf("destinationPodNamespace: %s", testNamespace), "Record does not have correct destinationPodNamespace")
+		assert.Contains(record, fmt.Sprintf("destinationNodeName: %s", dstNode), "Record does not have correct destinationNodeName")
+	}
+}
+
+func checkFlowType(t *testing.T, record string, flowType uint8) {
+	assert.Containsf(t, record, fmt.Sprintf("flowType: %d", flowType), "Record does not have correct flowType")
 }
 
 func getUnit64FieldFromRecord(t *testing.T, record string, field string) uint64 {
@@ -691,9 +711,34 @@ func getUnit64FieldFromRecord(t *testing.T, record string, field string) uint64 
 	return 0
 }
 
-// TODO: Add a test that checks the functionality of Pod-To-External flow.
-func checkFlowType(t *testing.T, record string, flowType uint8) {
-	assert.Containsf(t, record, fmt.Sprintf("flowType: %d", flowType), "Record does not have correct flowType")
+func getCollectorOutput(t *testing.T, srcIP string, dstIP string, timeStart time.Time, checkAllRecords bool) string {
+	var collectorOutput string
+	err := wait.PollImmediate(500*time.Millisecond, aggregatorInactiveFlowRecordTimeout, func() (bool, error) {
+		var rc int
+		var err error
+		// `pod-running-timeout` option is added to cover scenarios where ipfix flow-collector has crashed after being deployed
+		rc, collectorOutput, _, err = provider.RunCommandOnNode(controlPlaneNodeName(), fmt.Sprintf("kubectl logs --since=%v --pod-running-timeout=%v ipfix-collector -n antrea-test", time.Since(timeStart).String(), aggregatorInactiveFlowRecordTimeout.String()))
+		if err != nil || rc != 0 {
+			return false, err
+		}
+		// Checking that all the data records which correspond to the iperf flow are received
+		if checkAllRecords {
+			recordSlices := getRecordsFromOutput(collectorOutput)
+			for _, record := range recordSlices {
+				exportTime := int64(getUnit64FieldFromRecord(t, record, "flowEndSeconds"))
+				if strings.Contains(record, srcIP) && strings.Contains(record, dstIP) {
+					if exportTime >= timeStart.Unix()+iperfTimeSec {
+						return true, nil
+					}
+				}
+			}
+			return false, nil
+		} else {
+			return strings.Contains(collectorOutput, srcIP) && strings.Contains(collectorOutput, dstIP), nil
+		}
+	})
+	require.NoErrorf(t, err, "IPFIX collector did not receive the expected records and timed out with error")
+	return collectorOutput
 }
 
 func getRecordsFromOutput(output string) []string {

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -974,7 +974,7 @@ func (data *TestData) createNginxPod(name, nodeName string) error {
 }
 
 // createServerPod creates a Pod that can listen to specified port and have named port set.
-func (data *TestData) createServerPod(name string, portName string, portNum int32, setHostPort bool) error {
+func (data *TestData) createServerPod(name string, portName string, portNum int32, setHostPort bool, hostNetwork bool) error {
 	// See https://github.com/kubernetes/kubernetes/blob/master/test/images/agnhost/porter/porter.go#L17 for the image's detail.
 	cmd := "porter"
 	env := corev1.EnvVar{Name: fmt.Sprintf("SERVE_PORT_%d", portNum), Value: "foo"}
@@ -983,7 +983,7 @@ func (data *TestData) createServerPod(name string, portName string, portNum int3
 		// If hostPort is to be set, it must match the container port number.
 		port.HostPort = int32(portNum)
 	}
-	return data.createPodOnNode(name, "", agnhostImage, nil, []string{cmd}, []corev1.EnvVar{env}, []corev1.ContainerPort{port}, false, nil)
+	return data.createPodOnNode(name, "", agnhostImage, nil, []string{cmd}, []corev1.EnvVar{env}, []corev1.ContainerPort{port}, hostNetwork, nil)
 }
 
 // createCustomPod creates a Pod in given Namespace with custom labels.

--- a/test/e2e/networkpolicy_test.go
+++ b/test/e2e/networkpolicy_test.go
@@ -205,13 +205,13 @@ func (data *TestData) setupDifferentNamedPorts(t *testing.T) (checkFn func(), cl
 
 	server0Port := int32(80)
 	server0Name, server0IPs, cleanupFunc := createAndWaitForPod(t, data, func(name string, nodeName string) error {
-		return data.createServerPod(name, "http", server0Port, false)
+		return data.createServerPod(name, "http", server0Port, false, false)
 	}, "test-server-", "")
 	cleanupFuncs = append(cleanupFuncs, cleanupFunc)
 
 	server1Port := int32(8080)
 	server1Name, server1IPs, cleanupFunc := createAndWaitForPod(t, data, func(name string, nodeName string) error {
-		return data.createServerPod(name, "http", server1Port, false)
+		return data.createServerPod(name, "http", server1Port, false, false)
 	}, "test-server-", "")
 	cleanupFuncs = append(cleanupFuncs, cleanupFunc)
 


### PR DESCRIPTION
In the current flow-aggregator e2e tests, we have tests for flow types: intra-node and inter-node. This PR adds a test case for pod-to-external flow type. It takes a busybox pod as the source pod (client), a host network nginx pod as the destination (server). Server's IP will be the node's IP where it is deployed on. Let the client send requests to the server, then we generate pod-to-external flows. Finally we check the exports of IPFIX flow records.
Thanks @antoninbas 's suggestions on generating pod-to-external traffic.