### PR TITLE
add lock for podCache in case of concurrent map writes

### DIFF
--- a/test/e2e/k8s_util.go
+++ b/test/e2e/k8s_util.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/pkg/errors"
@@ -38,6 +39,7 @@ import (
 type KubernetesUtils struct {
 	*TestData
 	podCache map[string][]v1.Pod
+	podLock  sync.Mutex
 }
 
 func NewKubernetesUtils(data *TestData) (*KubernetesUtils, error) {
@@ -71,6 +73,8 @@ func (k *KubernetesUtils) getPodsUncached(ns string, key, val string) ([]v1.Pod,
 
 // GetPodsByLabel returns an array of all Pods in the given Namespace having a k/v label pair.
 func (k *KubernetesUtils) GetPodsByLabel(ns string, key string, val string) ([]v1.Pod, error) {
+	k.podLock.Lock()
+	defer k.podLock.Unlock()
 	if p, ok := k.podCache[fmt.Sprintf("%v_%v_%v", ns, key, val)]; ok {
 		return p, nil
 	}


### PR DESCRIPTION
when I ran antrea 0.13.2 with e2e:

=== RUN   TestAntreaPolicy
    fixtures.go:121: Creating 'antrea-test' K8s Namespace
    fixtures.go:84: Applying Antrea YAML
    fixtures.go:88: Waiting for all Antrea DaemonSet Pods
    fixtures.go:92: Checking CoreDNS deployment
...
fatal error: concurrent map writes

goroutine 1053 [running]:
runtime.throw(0x1b31cf4, 0x15)
	/usr/local/go/src/runtime/panic.go:1117 +0x72 fp=0xc0017cb388 sp=0xc0017cb358 pc=0x43a5d2
runtime.mapassign_faststr(0x18f1d40, 0xc000940ed0, 0xc000db84e8, 0x7, 0x3)
	/usr/local/go/src/runtime/map_faststr.go:211 +0x3f1 fp=0xc0017cb3f0 sp=0xc0017cb388 pc=0x4168b1
github.com/vmware-tanzu/antrea/test/e2e.(*KubernetesUtils).GetPods(0xc0006992e0, 0xc0009c6ee3, 0x1, 0x1b17f8d, 0x3, 0xc0009c6ee5, 0x1, 0x0, 0x0, 0x0, ...)
	/var/lib/jenkins/workspace/antrea-private-e2e-for-test/antrea/test/e2e/k8s_util.go:80 +0x3f1 fp=0xc0017cb4b8 sp=0xc0017cb3f0 pc=0x1722811
github.com/vmware-tanzu/antrea/test/e2e.(*KubernetesUtils).Probe(0xc0006992e0, 0xc0009c6ee3, 0x1, 0xc0009c6ee5, 0x1, 0xc0009c6ed6, 0x1, 0xc0009c6ed8, 0x1, 0x50, ...)
	/var/lib/jenkins/workspace/antrea-private-e2e-for-test/antrea/test/e2e/k8s_util.go:87 +0x8c fp=0xc0017cbeb8 sp=0xc0017cb4b8 pc=0x172294c
github.com/vmware-tanzu/antrea/test/e2e.(*KubernetesUtils).Validate.func1(0xc0009c6ee3, 0x3, 0xc0009c6ed6, 0x3)
	/var/lib/jenkins/workspace/antrea-private-e2e-for-test/antrea/test/e2e/k8s_util.go:663 +0x26c fp=0xc0017cbfc0 sp=0xc0017cbeb8 pc=0x17914ac
runtime.goexit()
	/usr/local/go/src/runtime/asm_amd64.s:1371 +0x1 fp=0xc0017cbfc8 sp=0xc0017cbfc0 pc=0x4739c1
created by github.com/vmware-tanzu/antrea/test/e2e.(*KubernetesUtils).Validate
	/var/lib/jenkins/workspace/antrea-private-e2e-for-test/antrea/test/e2e/k8s_util.go:668 +0x13f
...

I 've also checked main branch, podCache does not have lock also, which may also encounter concurrent map writes