### PR TITLE
Fix Cyclonus NetworkPolicy Github workflow

### DIFF
--- a/hack/netpol-generator/install-cyclonus.yml
+++ b/hack/netpol-generator/install-cyclonus.yml
@@ -11,11 +11,13 @@ spec:
       - command:
         - ./cyclonus
         - generate
-        - --mode=upstream
+        - --include=upstream-e2e
+        - --exclude=
         - --noisy=true
-        - --perturbation-wait-seconds=15
+        - --perturbation-wait-seconds=5
         - --cleanup-namespaces=true
+        - --server-protocol=tcp,udp
         name: cyclonus
         imagePullPolicy: IfNotPresent
-        image: mfenwick100/cyclonus:v0.1.4
+        image: mfenwick100/cyclonus:v0.4.7
       serviceAccount: cyclonus

--- a/hack/netpol-generator/test-kind.sh
+++ b/hack/netpol-generator/test-kind.sh
@@ -17,8 +17,8 @@ kind get nodes | xargs "$ROOT_DIR"/hack/kind-fix-networking.sh
 kind load docker-image projects.registry.vmware.com/antrea/antrea-ubuntu:latest
 
 # pre-load cyclonus image
-docker pull mfenwick100/cyclonus:v0.1.4
-kind load docker-image mfenwick100/cyclonus:v0.1.4
+docker pull mfenwick100/cyclonus:v0.4.7
+kind load docker-image mfenwick100/cyclonus:v0.4.7
 # pre-load agnhost image
 docker pull k8s.gcr.io/e2e-test-images/agnhost:2.21
 kind load docker-image k8s.gcr.io/e2e-test-images/agnhost:2.21


### PR DESCRIPTION
It has been failing ever since we updated to a more recent version of
Kind (v0.11), which comes with a more recent version of K8s. To fix it,
we need to update to a more recent Cyclonus version.

Signed-off-by: Antonin Bas <abas@vmware.com>