### PR TITLE
Add Pod labels infomation in flow records

### DIFF
--- a/build/yamls/elk-flow-collector/logstash/ipfix.yml
+++ b/build/yamls/elk-flow-collector/logstash/ipfix.yml
@@ -4142,4 +4142,9 @@
   142:
     - :string
     - :egressNetworkPolicyRuleName
-
+  143:
+    - :string
+    - :sourcePodLabels
+  144:
+    - :string
+    - :destinationPodLabels

--- a/pkg/ipfix/ipfix_intermediate.go
+++ b/pkg/ipfix/ipfix_intermediate.go
@@ -35,6 +35,8 @@ type IPFIXAggregationProcess interface {
 	AreCorrelatedFieldsFilled(record ipfixintermediate.AggregationFlowRecord) bool
 	IsAggregatedRecordIPv4(record ipfixintermediate.AggregationFlowRecord) bool
 	IsExporterOfAggregatedRecordIPv4(record ipfixintermediate.AggregationFlowRecord) bool
+	SetExternalFieldsFilled(record *ipfixintermediate.AggregationFlowRecord)
+	AreExternalFieldsFilled(record ipfixintermediate.AggregationFlowRecord) bool
 }
 
 type ipfixAggregationProcess struct {
@@ -87,4 +89,12 @@ func (ap *ipfixAggregationProcess) IsAggregatedRecordIPv4(record ipfixintermedia
 
 func (ap *ipfixAggregationProcess) IsExporterOfAggregatedRecordIPv4(record ipfixintermediate.AggregationFlowRecord) bool {
 	return ap.AggregationProcess.IsExporterOfAggregatedRecordIPv4(record)
+}
+
+func (ap *ipfixAggregationProcess) SetExternalFieldsFilled(record *ipfixintermediate.AggregationFlowRecord) {
+	ap.AggregationProcess.SetExternalFieldsFilled(record, true)
+}
+
+func (ap *ipfixAggregationProcess) AreExternalFieldsFilled(record ipfixintermediate.AggregationFlowRecord) bool {
+	return ap.AggregationProcess.AreExternalFieldsFilled(record)
 }

--- a/pkg/ipfix/testing/mock_ipfix.go
+++ b/pkg/ipfix/testing/mock_ipfix.go
@@ -239,6 +239,20 @@ func (mr *MockIPFIXAggregationProcessMockRecorder) AreCorrelatedFieldsFilled(arg
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AreCorrelatedFieldsFilled", reflect.TypeOf((*MockIPFIXAggregationProcess)(nil).AreCorrelatedFieldsFilled), arg0)
 }
 
+// AreExternalFieldsFilled mocks base method
+func (m *MockIPFIXAggregationProcess) AreExternalFieldsFilled(arg0 intermediate.AggregationFlowRecord) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AreExternalFieldsFilled", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// AreExternalFieldsFilled indicates an expected call of AreExternalFieldsFilled
+func (mr *MockIPFIXAggregationProcessMockRecorder) AreExternalFieldsFilled(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AreExternalFieldsFilled", reflect.TypeOf((*MockIPFIXAggregationProcess)(nil).AreExternalFieldsFilled), arg0)
+}
+
 // ForAllExpiredFlowRecordsDo mocks base method
 func (m *MockIPFIXAggregationProcess) ForAllExpiredFlowRecordsDo(arg0 intermediate.FlowKeyRecordMapCallBack) error {
 	m.ctrl.T.Helper()
@@ -319,6 +333,18 @@ func (m *MockIPFIXAggregationProcess) SetCorrelatedFieldsFilled(arg0 *intermedia
 func (mr *MockIPFIXAggregationProcessMockRecorder) SetCorrelatedFieldsFilled(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCorrelatedFieldsFilled", reflect.TypeOf((*MockIPFIXAggregationProcess)(nil).SetCorrelatedFieldsFilled), arg0)
+}
+
+// SetExternalFieldsFilled mocks base method
+func (m *MockIPFIXAggregationProcess) SetExternalFieldsFilled(arg0 *intermediate.AggregationFlowRecord) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetExternalFieldsFilled", arg0)
+}
+
+// SetExternalFieldsFilled indicates an expected call of SetExternalFieldsFilled
+func (mr *MockIPFIXAggregationProcessMockRecorder) SetExternalFieldsFilled(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetExternalFieldsFilled", reflect.TypeOf((*MockIPFIXAggregationProcess)(nil).SetExternalFieldsFilled), arg0)
 }
 
 // Start mocks base method

--- a/test/e2e/flowaggregator_test.go
+++ b/test/e2e/flowaggregator_test.go
@@ -96,6 +96,8 @@ DATA SET:
     reverseOctetTotalCountFromDestinationNode: 23108308
     reversePacketDeltaCountFromDestinationNode: 0
     reversePacketTotalCountFromDestinationNode: 444320
+	sourcePodLabels: {"antrea-e2e":"perftest-a","app":"perftool"}
+	destinationPodLabels: {"antrea-e2e":"perftest-b","app":"perftool"}
 
 Intra-Node: Flow record information is complete for source and destination e.g. sourcePodName, destinationPodName
 Inter-Node: Flow record from destination Node is ignored, so only flow record from the source Node has its K8s info e.g., sourcePodName, sourcePodNamespace, sourceNodeName etc.
@@ -696,10 +698,15 @@ func checkPodAndNodeData(t *testing.T, record, srcPod, srcNode, dstPod, dstNode 
 	assert.Contains(record, fmt.Sprintf("sourceNodeName: %s", srcNode), "Record does not have correct sourceNodeName")
 	// For Pod-To-External flow type, we send traffic to an external address,
 	// so we skip the verification of destination Pod info.
+	// Also, source Pod labels are different for Pod-To-External flow test.
 	if dstPod != "" {
 		assert.Contains(record, dstPod, "Record with dstIP does not have Pod name")
 		assert.Contains(record, fmt.Sprintf("destinationPodNamespace: %s", testNamespace), "Record does not have correct destinationPodNamespace")
 		assert.Contains(record, fmt.Sprintf("destinationNodeName: %s", dstNode), "Record does not have correct destinationNodeName")
+		assert.Contains(record, fmt.Sprintf("{\"antrea-e2e\":\"%s\",\"app\":\"perftool\"}", srcPod), "Record does not have correct label for source Pod")
+		assert.Contains(record, fmt.Sprintf("{\"antrea-e2e\":\"%s\",\"app\":\"perftool\"}", dstPod), "Record does not have correct label for destination Pod")
+	} else {
+		assert.Contains(record, fmt.Sprintf("{\"antrea-e2e\":\"%s\",\"app\":\"busybox\"}", srcPod), "Record does not have correct label for source Pod")
 	}
 }
 


### PR DESCRIPTION
In this commit, we fill the Pod labels information in flow records on the Flow Aggregator side.
Label information is necessary for network policy recommendation application and could also enhance usability on Kibana dashboard.