### PR TITLE
Reduce e2e overall time

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -163,7 +163,7 @@ jobs:
       run: |
         mkdir log
         mkdir test-e2e-encap-no-proxy-coverage
-        ANTREA_LOG_DIR=$PWD/log ANTREA_COV_DIR=$PWD/test-e2e-encap-no-proxy-coverage ./ci/kind/test-e2e-kind.sh --encap-mode encap --no-proxy --coverage
+        ANTREA_LOG_DIR=$PWD/log ANTREA_COV_DIR=$PWD/test-e2e-encap-no-proxy-coverage ./ci/kind/test-e2e-kind.sh --encap-mode encap --no-proxy --coverage --skip mode-irrelevant
     - name: Tar coverage files
       run: tar -czf test-e2e-encap-no-proxy-coverage.tar.gz test-e2e-encap-no-proxy-coverage
     - name: Upload coverage for test-e2e-encap-no-proxy-coverage
@@ -226,7 +226,7 @@ jobs:
       run: |
         mkdir log
         mkdir test-e2e-noencap-coverage
-        ANTREA_LOG_DIR=$PWD/log ANTREA_COV_DIR=$PWD/test-e2e-noencap-coverage ./ci/kind/test-e2e-kind.sh --encap-mode noEncap --coverage
+        ANTREA_LOG_DIR=$PWD/log ANTREA_COV_DIR=$PWD/test-e2e-noencap-coverage ./ci/kind/test-e2e-kind.sh --encap-mode noEncap --coverage --skip mode-irrelevant
     - name: Tar coverage files
       run: tar -czf test-e2e-noencap-coverage.tar.gz test-e2e-noencap-coverage
     - name: Upload coverage for test-e2e-noencap-coverage
@@ -289,7 +289,7 @@ jobs:
       run: |
         mkdir log
         mkdir test-e2e-hybrid-coverage
-        ANTREA_LOG_DIR=$PWD/log ANTREA_COV_DIR=$PWD/test-e2e-hybrid-coverage ./ci/kind/test-e2e-kind.sh --encap-mode hybrid --coverage
+        ANTREA_LOG_DIR=$PWD/log ANTREA_COV_DIR=$PWD/test-e2e-hybrid-coverage ./ci/kind/test-e2e-kind.sh --encap-mode hybrid --coverage --skip mode-irrelevant
     - name: Tar coverage files
       run: tar -czf test-e2e-hybrid-coverage.tar.gz test-e2e-hybrid-coverage
     - name: Upload coverage for test-e2e-hybrid-coverage
@@ -355,7 +355,7 @@ jobs:
       run: |
         mkdir log
         mkdir test-e2e-encap-no-np-coverage
-        ANTREA_LOG_DIR=$PWD/log ANTREA_COV_DIR=$PWD/test-e2e-encap-no-np-coverage ./ci/kind/test-e2e-kind.sh --encap-mode encap --no-np --coverage
+        ANTREA_LOG_DIR=$PWD/log ANTREA_COV_DIR=$PWD/test-e2e-encap-no-np-coverage ./ci/kind/test-e2e-kind.sh --encap-mode encap --no-np --coverage --skip mode-irrelevant
     - name: Tar coverage files
       run: tar -czf test-e2e-encap-no-np-coverage.tar.gz test-e2e-encap-no-np-coverage
     - name: Upload coverage for test-e2e-encap-no-np-coverage
@@ -383,28 +383,9 @@ jobs:
         path: log.tar.gz
         retention-days: 30
 
-  build-antrea-image:
-    name: Build Antrea image to be used for Kind netpol tests
-    needs: check-changes
-    if: ${{ needs.check-changes.outputs.has_changes == 'yes' }}
-    runs-on: [ubuntu-latest]
-    steps:
-    - uses: actions/checkout@v2
-    - name: Build Antrea Docker image
-      run: |
-        ./hack/build-antrea-ubuntu-all.sh --pull
-    - name: Save Antrea image to tarball
-      run:  docker save -o antrea-ubuntu.tar projects.registry.vmware.com/antrea/antrea-ubuntu:latest
-    - name: Upload Antrea image for subsequent jobs
-      uses: actions/upload-artifact@v2
-      with:
-        name: antrea-ubuntu
-        path: antrea-ubuntu.tar
-        retention-days: 1 # minimum value, in case artifact deletion by 'artifact-cleanup' job fails
-
   test-netpol-tmp:
     name: Run experimental network policy tests (netpol) on Kind cluster
-    needs: build-antrea-image
+    needs: build-antrea-coverage-image
     runs-on: [ubuntu-latest]
     steps:
     - name: Free disk space
@@ -419,9 +400,12 @@ jobs:
     - name: Download Antrea image from previous job
       uses: actions/download-artifact@v1
       with:
-        name: antrea-ubuntu
+        name: antrea-ubuntu-cov
     - name: Load Antrea image
-      run:  docker load -i antrea-ubuntu/antrea-ubuntu.tar
+      run: |
+        docker load -i antrea-ubuntu-cov/antrea-ubuntu.tar
+        docker tag antrea/antrea-ubuntu-coverage:latest antrea/antrea-ubuntu:latest
+        docker tag antrea/antrea-ubuntu-coverage:latest projects.registry.vmware.com/antrea/antrea-ubuntu:latest
     - name: Install Kind
       run: |
         curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
@@ -436,7 +420,7 @@ jobs:
 
   validate-prometheus-metrics-doc:
     name: Validate metrics in Prometheus document match running deployment's
-    needs: build-antrea-image
+    needs: build-antrea-coverage-image
     runs-on: [ubuntu-latest]
     steps:
       - name: Free disk space
@@ -451,9 +435,12 @@ jobs:
       - name: Download Antrea image from previous job
         uses: actions/download-artifact@v1
         with:
-          name: antrea-ubuntu
+          name: antrea-ubuntu-cov
       - name: Load Antrea image
-        run:  docker load -i antrea-ubuntu/antrea-ubuntu.tar
+        run: |
+          docker load -i antrea-ubuntu-cov/antrea-ubuntu.tar
+          docker tag antrea/antrea-ubuntu-coverage:latest antrea/antrea-ubuntu:latest
+          docker tag antrea/antrea-ubuntu-coverage:latest projects.registry.vmware.com/antrea/antrea-ubuntu:latest
       - name: Install Kind
         run: |
           curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
@@ -469,8 +456,8 @@ jobs:
   # yet.
   artifact-cleanup:
     name: Delete uploaded images
-    needs: [build-antrea-coverage-image, build-flow-aggregator-coverage-image, build-antrea-image, test-e2e-encap, test-e2e-encap-no-proxy, test-e2e-noencap, test-e2e-hybrid, test-e2e-encap-no-np, test-netpol-tmp, validate-prometheus-metrics-doc]
-    if: ${{ always() &&  (needs.build-antrea-coverage-image.result == 'success' || needs.build-flow-aggregator-coverage-image.result == 'success' || needs.build-antrea-image.result == 'success') }}
+    needs: [build-antrea-coverage-image, build-flow-aggregator-coverage-image, test-e2e-encap, test-e2e-encap-no-proxy, test-e2e-noencap, test-e2e-hybrid, test-e2e-encap-no-np, test-netpol-tmp, validate-prometheus-metrics-doc]
+    if: ${{ always() &&  (needs.build-antrea-coverage-image.result == 'success' || needs.build-flow-aggregator-coverage-image.result == 'success') }}
     runs-on: [ubuntu-latest]
     steps:
     - name: Delete antrea-ubuntu-cov
@@ -483,9 +470,4 @@ jobs:
       uses: geekyeggo/delete-artifact@v1
       with:
         name: flow-aggregator-cov
-    - name: Delete antrea-ubuntu
-      if: ${{ needs.build-antrea-image.result == 'success' }}
-      uses: geekyeggo/delete-artifact@v1
-      with:
-        name: antrea-ubuntu
         failOnError: false

--- a/ci/kind/test-e2e-kind.sh
+++ b/ci/kind/test-e2e-kind.sh
@@ -28,6 +28,7 @@ _usage="Usage: $0 [--encap-mode <mode>] [--ip-family <v4|v6>] [--no-proxy] [--np
         --no-proxy                    Disables Antrea proxy.
         --endpointslice               Enables Antrea proxy and EndpointSlice support.
         --no-np                       Disables Antrea-native policies.
+        --skip                        A comma-separated list of keywords, with which tests should be skipped.
         --coverage                    Enables measure Antrea code coverage when run e2e tests on kind.
         --help, -h                    Print this message and exit.
 "
@@ -55,6 +56,7 @@ proxy=true
 endpointslice=false
 np=true
 coverage=false
+skiplist=""
 while [[ $# -gt 0 ]]
 do
 key="$1"
@@ -75,6 +77,10 @@ case $key in
     --no-np)
     np=false
     shift
+    ;;
+    --skip)
+    skiplist="$2"
+    shift 2
     ;;
     --encap-mode)
     mode="$2"
@@ -141,6 +147,7 @@ function run_test {
   echo "creating test bed with args $args"
   eval "timeout 600 $TESTBED_CMD create kind --antrea-cni false $args"
 
+
   if $coverage; then
       $YML_CMD --kind --encap-mode $current_mode $manifest_args | docker exec -i kind-control-plane dd of=/root/antrea-coverage.yml
       $FLOWAGGREGATOR_YML_CMD --coverage | docker exec -i kind-control-plane dd of=/root/flow-aggregator-coverage.yml
@@ -149,10 +156,11 @@ function run_test {
       $FLOWAGGREGATOR_YML_CMD | docker exec -i kind-control-plane dd of=/root/flow-aggregator.yml
   fi
   sleep 1
+
   if $coverage; then
-      go test -v -timeout=70m antrea.io/antrea/test/e2e -provider=kind --logs-export-dir=$ANTREA_LOG_DIR --coverage --coverage-dir $ANTREA_COV_DIR
+      go test -v -timeout=70m antrea.io/antrea/test/e2e -provider=kind --logs-export-dir=$ANTREA_LOG_DIR --coverage --coverage-dir $ANTREA_COV_DIR --skip=$skiplist
   else
-      go test -v -timeout=65m antrea.io/antrea/test/e2e -provider=kind --logs-export-dir=$ANTREA_LOG_DIR
+      go test -v -timeout=65m antrea.io/antrea/test/e2e -provider=kind --logs-export-dir=$ANTREA_LOG_DIR --skip=$skiplist
   fi
   $TESTBED_CMD destroy kind
 }

--- a/hack/tidy-check.sh
+++ b/hack/tidy-check.sh
@@ -96,6 +96,11 @@ function check {
   MOD_DIFF=$(diff "$MOD_FILE" "$TMP_MOD_FILE")
   SUM_DIFF=$(diff "$SUM_FILE" "$TMP_SUM_FILE")
   if [ -n "$MOD_DIFF" ] || [ -n "$SUM_DIFF" ]; then
+    echo "=== go.mod diff ==="
+    echo $MOD_DIFF
+    echo "=== go.sum diff ==="
+    echo $SUM_DIFF
+
     echoerr "dependencies are not tidy"
     general_help
     clean

--- a/test/e2e/batch_test.go
+++ b/test/e2e/batch_test.go
@@ -25,6 +25,7 @@ import (
 // TestBatchCreatePods verifies there is no FD leak after batched Pod creation.
 func TestBatchCreatePods(t *testing.T) {
 	skipIfHasWindowsNodes(t)
+	skipIfNotRequired(t, "mode-irrelevant")
 
 	data, err := setupTest(t)
 	if err != nil {

--- a/test/e2e/clustergroup_test.go
+++ b/test/e2e/clustergroup_test.go
@@ -316,13 +316,13 @@ func testClusterGroupConversionV1A2AndV1A3(t *testing.T) {
 
 func TestClusterGroup(t *testing.T) {
 	skipIfHasWindowsNodes(t)
+	skipIfAntreaPolicyDisabled(t)
 
 	data, err := setupTest(t)
 	if err != nil {
 		t.Fatalf("Error when setting up test: %v", err)
 	}
 	defer teardownTest(t, data)
-	skipIfAntreaPolicyDisabled(t, data)
 	initialize(t, data)
 
 	t.Run("TestGroupClusterGroupValidate", func(t *testing.T) {

--- a/test/e2e/egress_test.go
+++ b/test/e2e/egress_test.go
@@ -37,6 +37,7 @@ func TestEgress(t *testing.T) {
 	skipIfProviderIs(t, "kind", "pkt_mark field is not properly supported for OVS userspace (netdev) datapath.")
 	// TODO: remove this after making the test support IPv6 and dual-stack.
 	skipIfIPv6Cluster(t)
+
 	data, err := setupTest(t)
 	if err != nil {
 		t.Fatalf("Error when setting up test: %v", err)

--- a/test/e2e/flowaggregator_test.go
+++ b/test/e2e/flowaggregator_test.go
@@ -220,7 +220,7 @@ func testHelper(t *testing.T, data *TestData, podAIPs, podBIPs, podCIPs, podDIPs
 	// applied to destination Pod (one reject rule, one drop rule) and their flow information is exported as IPFIX flow records.
 	// perftest-a -> perftest-b (Ingress reject), perftest-a -> perftest-d (Ingress drop)
 	t.Run("IntraNodeDenyConnIngressANP", func(t *testing.T) {
-		skipIfAntreaPolicyDisabled(t, data)
+		skipIfAntreaPolicyDisabled(t)
 		anp1, anp2 := deployDenyAntreaNetworkPolicies(t, data, "perftest-a", "perftest-b", "perftest-d", true)
 		defer func() {
 			if anp1 != nil {
@@ -255,7 +255,7 @@ func testHelper(t *testing.T, data *TestData, podAIPs, podBIPs, podCIPs, podDIPs
 	// applied to source Pods (one reject rule, one drop rule) and their flow information is exported as IPFIX flow records.
 	// perftest-a (Egress reject) -> perftest-b , perftest-a (Egress drop) -> perftest-d
 	t.Run("IntraNodeDenyConnEgressANP", func(t *testing.T) {
-		skipIfAntreaPolicyDisabled(t, data)
+		skipIfAntreaPolicyDisabled(t)
 		anp1, anp2 := deployDenyAntreaNetworkPolicies(t, data, "perftest-a", "perftest-b", "perftest-d", false)
 		defer func() {
 			if anp1 != nil {
@@ -290,7 +290,7 @@ func testHelper(t *testing.T, data *TestData, podAIPs, podBIPs, podCIPs, podDIPs
 	// applied to one destination Pod, one source Pod, respectively and their flow information is exported as IPFIX flow records.
 	// perftest-a -> perftest-b (Ingress deny), perftest-d (Egress deny) -> perftest-a
 	t.Run("IntraNodeDenyConnNP", func(t *testing.T) {
-		skipIfAntreaPolicyDisabled(t, data)
+		skipIfAntreaPolicyDisabled(t)
 		np1, np2 := deployDenyNetworkPolicies(t, data, "perftest-b", "perftest-d")
 		defer func() {
 			if np1 != nil {
@@ -325,7 +325,7 @@ func testHelper(t *testing.T, data *TestData, podAIPs, podBIPs, podCIPs, podDIPs
 	// and their flow information is exported as IPFIX flow records.
 	// Antrea network policies are being tested here.
 	t.Run("InterNodeFlows", func(t *testing.T) {
-		skipIfAntreaPolicyDisabled(t, data)
+		skipIfAntreaPolicyDisabled(t)
 		anp1, anp2 := deployAntreaNetworkPolicies(t, data, "perftest-a", "perftest-c")
 		defer func() {
 			if anp1 != nil {
@@ -346,7 +346,7 @@ func testHelper(t *testing.T, data *TestData, podAIPs, podBIPs, podCIPs, podDIPs
 	// applied to destination Pod (one reject rule, one drop rule) and their flow information is exported as IPFIX flow records.
 	// perftest-a -> perftest-c (Ingress reject), perftest-a -> perftest-e (Ingress drop)
 	t.Run("InterNodeDenyConnIngressANP", func(t *testing.T) {
-		skipIfAntreaPolicyDisabled(t, data)
+		skipIfAntreaPolicyDisabled(t)
 		anp1, anp2 := deployDenyAntreaNetworkPolicies(t, data, "perftest-a", "perftest-c", "perftest-e", true)
 		defer func() {
 			if anp1 != nil {
@@ -381,7 +381,7 @@ func testHelper(t *testing.T, data *TestData, podAIPs, podBIPs, podCIPs, podDIPs
 	// applied to source Pod (one reject rule, one drop rule) and their flow information is exported as IPFIX flow records.
 	// perftest-a (Egress reject) -> perftest-c, perftest-a (Egress drop)-> perftest-e
 	t.Run("InterNodeDenyConnEgressANP", func(t *testing.T) {
-		skipIfAntreaPolicyDisabled(t, data)
+		skipIfAntreaPolicyDisabled(t)
 		anp1, anp2 := deployDenyAntreaNetworkPolicies(t, data, "perftest-a", "perftest-c", "perftest-e", false)
 		defer func() {
 			if anp1 != nil {
@@ -416,7 +416,7 @@ func testHelper(t *testing.T, data *TestData, podAIPs, podBIPs, podCIPs, podDIPs
 	// applied to one destination Pod, one source Pod, respectively and their flow information is exported as IPFIX flow records.
 	// perftest-a -> perftest-c (Ingress deny), perftest-b (Egress deny) -> perftest-e
 	t.Run("InterNodeDenyConnNP", func(t *testing.T) {
-		skipIfAntreaPolicyDisabled(t, data)
+		skipIfAntreaPolicyDisabled(t)
 		np1, np2 := deployDenyNetworkPolicies(t, data, "perftest-c", "perftest-b")
 		defer func() {
 			if np1 != nil {
@@ -473,7 +473,7 @@ func testHelper(t *testing.T, data *TestData, podAIPs, podBIPs, podCIPs, podDIPs
 
 	// LocalServiceAccess tests the case, where Pod and Service are deployed on the same Node and their flow information is exported as IPFIX flow records.
 	t.Run("LocalServiceAccess", func(t *testing.T) {
-		skipIfProxyDisabled(t, data)
+		skipIfProxyDisabled(t)
 		// In dual stack cluster, Service IP can be assigned as different IP family from specified.
 		// In that case, source IP and destination IP will align with IP family of Service IP.
 		// For IPv4-only and IPv6-only cluster, IP family of Service IP will be same as Pod IPs.
@@ -487,7 +487,7 @@ func testHelper(t *testing.T, data *TestData, podAIPs, podBIPs, podCIPs, podDIPs
 
 	// RemoteServiceAccess tests the case, where Pod and Service are deployed on different Nodes and their flow information is exported as IPFIX flow records.
 	t.Run("RemoteServiceAccess", func(t *testing.T) {
-		skipIfProxyDisabled(t, data)
+		skipIfProxyDisabled(t)
 		// In dual stack cluster, Service IP can be assigned as different IP family from specified.
 		// In that case, source IP and destination IP will align with IP family of Service IP.
 		// For IPv4-only and IPv6-only cluster, IP family of Service IP will be same as Pod IPs.

--- a/test/e2e/ipsec_test.go
+++ b/test/e2e/ipsec_test.go
@@ -25,6 +25,24 @@ import (
 	"antrea.io/antrea/pkg/agent/util"
 )
 
+// TestIPSec is the top-level test which contains all subtests for
+// IPSec related test cases so they can share setup, teardown.
+func TestIPSec(t *testing.T) {
+	skipIfProviderIs(t, "kind", "IPSec tunnel does not work with Kind")
+	skipIfIPv6Cluster(t)
+	skipIfNumNodesLessThan(t, 2)
+	skipIfHasWindowsNodes(t)
+
+	data, err := setupTest(t)
+	if err != nil {
+		t.Fatalf("Error when setting up test: %v", err)
+	}
+	defer teardownTest(t, data)
+
+	t.Run("testIPSecTunnelConnectivity", func(t *testing.T) { testIPSecTunnelConnectivity(t, data) })
+	t.Run("testIPSecDeleteStaleTunnelPorts", func(t *testing.T) { testIPSecDeleteStaleTunnelPorts(t, data) })
+}
+
 func (data *TestData) readSecurityAssociationsStatus(nodeName string) (up int, connecting int, err error) {
 	antreaPodName, err := data.getAntreaPodOnNode(nodeName)
 	if err != nil {
@@ -53,21 +71,10 @@ func (data *TestData) readSecurityAssociationsStatus(nodeName string) (up int, c
 	return up, connecting, nil
 }
 
-// TestIPSecTunnelConnectivity checks that Pod traffic across two Nodes over
+// testIPSecTunnelConnectivity checks that Pod traffic across two Nodes over
 // the IPSec tunnel, by creating multiple Pods across distinct Nodes and having
 // them ping each other.
-func TestIPSecTunnelConnectivity(t *testing.T) {
-	skipIfProviderIs(t, "kind", "IPSec tunnel does not work with Kind")
-	skipIfIPv6Cluster(t)
-	skipIfNumNodesLessThan(t, 2)
-	skipIfHasWindowsNodes(t)
-
-	data, err := setupTest(t)
-	if err != nil {
-		t.Fatalf("Error when setting up test: %v", err)
-	}
-	defer teardownTest(t, data)
-
+func testIPSecTunnelConnectivity(t *testing.T, data *TestData) {
 	t.Logf("Redeploy Antrea with IPSec tunnel enabled")
 	data.redeployAntrea(t, true)
 
@@ -88,21 +95,10 @@ func TestIPSecTunnelConnectivity(t *testing.T) {
 	data.redeployAntrea(t, false)
 }
 
-// TestIPSecDeleteStaleTunnelPorts checks that when switching from IPsec mode to
+// testIPSecDeleteStaleTunnelPorts checks that when switching from IPsec mode to
 // non-encrypted mode, the previously created tunnel ports are deleted
 // correctly.
-func TestIPSecDeleteStaleTunnelPorts(t *testing.T) {
-	skipIfProviderIs(t, "kind", "IPSec tunnel does not work with Kind")
-	skipIfIPv6Cluster(t)
-	skipIfNumNodesLessThan(t, 2)
-	skipIfHasWindowsNodes(t)
-
-	data, err := setupTest(t)
-	if err != nil {
-		t.Fatalf("Error when setting up test: %v", err)
-	}
-	defer teardownTest(t, data)
-
+func testIPSecDeleteStaleTunnelPorts(t *testing.T, data *TestData) {
 	t.Logf("Redeploy Antrea with IPSec tunnel enabled")
 	data.redeployAntrea(t, true)
 

--- a/test/e2e/legacyclustergroup_test.go
+++ b/test/e2e/legacyclustergroup_test.go
@@ -244,15 +244,18 @@ func testLegacyInvalidCGMaxNestedLevel(t *testing.T) {
 	}
 }
 
+// TestLegacyClusterGroup is the top-level test which contains all subtests for
+// LegacyClusterGroup related test cases so they can share setup, teardown.
 func TestLegacyClusterGroup(t *testing.T) {
 	skipIfProviderIs(t, "kind", "This test is for legacy API groups and is almost the same as new API groups'.")
 	skipIfHasWindowsNodes(t)
+	skipIfAntreaPolicyDisabled(t)
+
 	data, err := setupTest(t)
 	if err != nil {
 		t.Fatalf("Error when setting up test: %v", err)
 	}
 	defer teardownTest(t, data)
-	skipIfAntreaPolicyDisabled(t, data)
 	initialize(t, data)
 
 	t.Run("TestLegacyGroupClusterGroupValidate", func(t *testing.T) {

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -80,6 +80,23 @@ func init() {
 	flag.BoolVar(&prometheusEnabled, "prometheus", false, "Enables Prometheus tests")
 }
 
+// TestPrometheus is the top-level test which contains all subtests for
+// Prometheus related test cases so they can share setup, teardown.
+func TestPrometheus(t *testing.T) {
+	skipIfPrometheusDisabled(t)
+	skipIfHasWindowsNodes(t)
+
+	data, err := setupTest(t)
+	if err != nil {
+		t.Fatalf("Error when setting up test: %v", err)
+	}
+	defer teardownTest(t, data)
+	t.Run("testPrometheusMetricsOnController", func(t *testing.T) { testPrometheusMetricsOnController(t, data) })
+	t.Run("testPrometheusMetricsOnAgent", func(t *testing.T) { testPrometheusMetricsOnAgent(t, data) })
+	t.Run("testPrometheusServerControllerMetrics", func(t *testing.T) { testPrometheusServerControllerMetrics(t, data) })
+	t.Run("testPrometheusServerAgentMetrics", func(t *testing.T) { testPrometheusServerAgentMetrics(t, data) })
+}
+
 // skipIfPrometheusDisabled checks if Prometheus testing enabled, skip otherwise
 func skipIfPrometheusDisabled(t *testing.T) {
 	if !prometheusEnabled {
@@ -230,33 +247,15 @@ func getPrometheusEndpoint(t *testing.T, data *TestData) (string, int32) {
 	return hostIP, nodePort
 }
 
-// TestPrometheusMetricsOnController validates that metrics are returned from Prometheus client on the Antrea Controller
+// testPrometheusMetricsOnController validates that metrics are returned from Prometheus client on the Antrea Controller
 // and checks that metrics in antreaControllerMetrics exists in the controller output
-func TestPrometheusMetricsOnController(t *testing.T) {
-	skipIfPrometheusDisabled(t)
-	skipIfHasWindowsNodes(t)
-
-	data, err := setupTest(t)
-	if err != nil {
-		t.Fatalf("Error when setting up test: %v", err)
-	}
-	defer teardownTest(t, data)
-
+func testPrometheusMetricsOnController(t *testing.T, data *TestData) {
 	testPrometheusMetricsOnPods(t, data, "antrea-controller", antreaControllerMetrics)
 }
 
-// TestPrometheusMetricsOnAgent validates that metrics are returned from Prometheus client on the Antrea Agent
+// testPrometheusMetricsOnAgent validates that metrics are returned from Prometheus client on the Antrea Agent
 // and checks that metrics in antreaAgentMetrics exists in the agent's output
-func TestPrometheusMetricsOnAgent(t *testing.T) {
-	skipIfPrometheusDisabled(t)
-	skipIfHasWindowsNodes(t)
-
-	data, err := setupTest(t)
-	if err != nil {
-		t.Fatalf("Error when setting up test: %v", err)
-	}
-	defer teardownTest(t, data)
-
+func testPrometheusMetricsOnAgent(t *testing.T, data *TestData) {
 	testPrometheusMetricsOnPods(t, data, "antrea-agent", antreaAgentMetrics)
 }
 
@@ -310,28 +309,10 @@ func testMetricsFromPrometheusServer(t *testing.T, data *TestData, prometheusJob
 	}
 }
 
-func TestPrometheusServerControllerMetrics(t *testing.T) {
-	skipIfPrometheusDisabled(t)
-	skipIfHasWindowsNodes(t)
-
-	data, err := setupTest(t)
-	if err != nil {
-		t.Fatalf("Error when setting up test: %v", err)
-	}
-	defer teardownTest(t, data)
-
+func testPrometheusServerControllerMetrics(t *testing.T, data *TestData) {
 	testMetricsFromPrometheusServer(t, data, "antrea-controllers", antreaControllerMetrics)
 }
 
-func TestPrometheusServerAgentMetrics(t *testing.T) {
-	skipIfPrometheusDisabled(t)
-	skipIfHasWindowsNodes(t)
-
-	data, err := setupTest(t)
-	if err != nil {
-		t.Fatalf("Error when setting up test: %v", err)
-	}
-	defer teardownTest(t, data)
-
+func testPrometheusServerAgentMetrics(t *testing.T, data *TestData) {
 	testMetricsFromPrometheusServer(t, data, "antrea-agents", antreaAgentMetrics)
 }

--- a/test/e2e/security_test.go
+++ b/test/e2e/security_test.go
@@ -43,9 +43,11 @@ const (
 	caConfigMapNamespace = "kube-system"
 )
 
-// TestUserProvidedCert tests the selfSignedCert=false case. It covers dynamic server certificate.
-func TestUserProvidedCert(t *testing.T) {
+// TestSecurity is the top-level test which contains all subtests for
+// Security related test cases so they can share setup, teardown.
+func TestSecurity(t *testing.T) {
 	skipIfHasWindowsNodes(t)
+	skipIfNotRequired(t, "mode-irrelevant")
 
 	data, err := setupTest(t)
 	if err != nil {
@@ -53,6 +55,12 @@ func TestUserProvidedCert(t *testing.T) {
 	}
 	defer teardownTest(t, data)
 
+	t.Run("testUserProvidedCert", func(t *testing.T) { testUserProvidedCert(t, data) })
+	t.Run("testSelfSignedCert", func(t *testing.T) { testSelfSignedCert(t, data) })
+}
+
+// testUserProvidedCert tests the selfSignedCert=false case. It covers dynamic server certificate.
+func testUserProvidedCert(t *testing.T, data *TestData) {
 	// Re-configure antrea-controller to use user-provided cert.
 	// Note antrea-controller must be restarted to take effect.
 	cc := []configChange{
@@ -112,16 +120,8 @@ func TestUserProvidedCert(t *testing.T) {
 	testCert(t, data, string(certPem), false)
 }
 
-// TestSelfSignedCert tests the selfSignedCert=true case.
-func TestSelfSignedCert(t *testing.T) {
-	skipIfHasWindowsNodes(t)
-
-	data, err := setupTest(t)
-	if err != nil {
-		t.Fatalf("Error when setting up test: %v", err)
-	}
-	defer teardownTest(t, data)
-
+// testSelfSignedCert tests the selfSignedCert=true case.
+func testSelfSignedCert(t *testing.T, data *TestData) {
 	testCert(t, data, "", true)
 }
 

--- a/test/e2e/supportbundle_test.go
+++ b/test/e2e/supportbundle_test.go
@@ -48,6 +48,7 @@ func getAccessToken(podName string, containerName string, tokenPath string, data
 // testSupportBundle tests all support bundle related APIs.
 func testSupportBundle(name string, t *testing.T) {
 	skipIfHasWindowsNodes(t)
+	skipIfNotRequired(t, "mode-irrelevant")
 
 	data, err := setupTest(t)
 	if err != nil {

--- a/test/e2e/tls_test.go
+++ b/test/e2e/tls_test.go
@@ -39,6 +39,7 @@ var (
 // TestAntreaApiserverTLSConfig tests Cipher Suite and TLSVersion config on Antrea apiserver, Controller side or Agent side.
 func TestAntreaApiserverTLSConfig(t *testing.T) {
 	skipIfHasWindowsNodes(t)
+	skipIfNotRequired(t, "mode-irrelevant")
 
 	data, err := setupTest(t)
 	if err != nil {
@@ -66,7 +67,9 @@ func TestAntreaApiserverTLSConfig(t *testing.T) {
 		{"AgentApiserver", agentPodName, agentContainerName, apis.AntreaAgentAPIPort, "Agent"},
 	}
 	for _, tc := range tests {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			data.checkTLS(t, tc.podName, tc.containerName, tc.apiserver, tc.apiserverStr)
 		})
 	}


### PR DESCRIPTION
A few areas to reduce e2e overall time:

1. add t.Parallel() for those tests with multiple test data.
2. use subtest to reorganize most e2e test files so they can share the same setup/teardown.
3. add `skipIfNotRequired` method to allow user to skip cases with provided key word.
4. set some cases as default cases which will not be impacted by encap/noencap/hybird mode via method `skipIfNotRequired` with skip keyword "mode-irrelevant-case",  and execute them in " E2e tests on a Kind cluster on Linux" only and remove them from below jobs with option '--skip-mode-irrelevant'
  * E2e tests on a Kind cluster on Linux with AntreaProxy disabled
  * E2e tests on a Kind cluster on Linux (noEncap)
  * E2e tests on a Kind cluster on Linux (hybrid)
  * E2e tests on a Kind cluster on Linux with Antrea-native policies disabled
 
The mode-irrelevant test cases are as blow:
  * antctl_test
  * bandwidth_test
  * basic_test
  * batch_test
  * security_test
  * supportbuddle_test
  * tls_test
 
5. deploy Antrea in main_test.go to get feature gate earlier, so we can do skip e2e check before setupTest(t).
6. merge some jobs and remove redundant steps in workflow files go.yml and kind.yaml so we can have less concurrent jobs for one PR to reduce github runner waiting time.

there are also some minor changes related with duplicate imports and fix for syntax warning.

The e2e result for the new implementation is here https://github.com/antrea-io/antrea/actions/runs/937670984, the total e2e time are around 15m less comparing with other jobs eg: https://github.com/antrea-io/antrea/actions/runs/937012490. 
The total e2e duration highly depends on the total concurrent jobs which I don't think we have a proper way to measure the improvement.

Close #2014 

Signed-off-by: Lan Luo <luola@vmware.com>