### PR TITLE
Improve readability of NeedsRoutingToPeer method

### DIFF
--- a/pkg/agent/config/traffic_encap_mode.go
+++ b/pkg/agent/config/traffic_encap_mode.go
@@ -83,7 +83,7 @@ func (m TrafficEncapModeType) NeedsEncapToPeer(peerIP net.IP, localIP *net.IPNet
 	return (m == TrafficEncapModeEncap) || (m == TrafficEncapModeHybrid && !localIP.Contains(peerIP))
 }
 
-// NeedsRoutingToPeer returns true if Pod traffic to peer Node needs underlying routing support.
-func (m TrafficEncapModeType) NeedsRoutingToPeer(peerIP net.IP, localIP *net.IPNet) bool {
-	return m == TrafficEncapModeNoEncap && !localIP.Contains(peerIP)
+// NeedsDirectRoutingToPeer returns true if Pod traffic to peer Node needs a direct route installed to the routing table.
+func (m TrafficEncapModeType) NeedsDirectRoutingToPeer(peerIP net.IP, localIP *net.IPNet) bool {
+	return (m == TrafficEncapModeNoEncap || m == TrafficEncapModeHybrid) && localIP.Contains(peerIP)
 }

--- a/pkg/agent/config/traffic_encap_mode_test.go
+++ b/pkg/agent/config/traffic_encap_mode_test.go
@@ -134,7 +134,7 @@ func TestTrafficEncapModeTypeNeedsEncapToPeer(t *testing.T) {
 	}
 }
 
-func TestTrafficEncapModeTypeNeedsRoutingToPeer(t *testing.T) {
+func TestTrafficEncapModeTypeNeedsDirectRoutingToPeer(t *testing.T) {
 	tests := []struct {
 		name    string
 		mode    TrafficEncapModeType
@@ -153,19 +153,9 @@ func TestTrafficEncapModeTypeNeedsRoutingToPeer(t *testing.T) {
 			expBool: false,
 		},
 		{
-			name:   "no-encap-mode-no-need-support",
+			name:   "no-encap-mode-need-direct-routing",
 			mode:   1,
 			peerIP: net.ParseIP("192.168.0.5"),
-			localIP: &net.IPNet{
-				IP:   net.IPv4(192, 168, 0, 1),
-				Mask: net.IPv4Mask(255, 255, 255, 0),
-			},
-			expBool: false,
-		},
-		{
-			name:   "no-encap-mode-need-support",
-			mode:   1,
-			peerIP: net.ParseIP("192.168.1.5"),
 			localIP: &net.IPNet{
 				IP:   net.IPv4(192, 168, 0, 1),
 				Mask: net.IPv4Mask(255, 255, 255, 0),
@@ -173,20 +163,30 @@ func TestTrafficEncapModeTypeNeedsRoutingToPeer(t *testing.T) {
 			expBool: true,
 		},
 		{
-			name:   "hybrid-mode",
-			mode:   2,
-			peerIP: net.ParseIP("192.168.0.5"),
+			name:   "no-encap-mode-no-need-direct-routing",
+			mode:   1,
+			peerIP: net.ParseIP("192.168.1.5"),
 			localIP: &net.IPNet{
 				IP:   net.IPv4(192, 168, 0, 1),
 				Mask: net.IPv4Mask(255, 255, 255, 0),
 			},
 			expBool: false,
 		},
+		{
+			name:   "hybrid-mode-need-direct-routing",
+			mode:   2,
+			peerIP: net.ParseIP("192.168.0.5"),
+			localIP: &net.IPNet{
+				IP:   net.IPv4(192, 168, 0, 1),
+				Mask: net.IPv4Mask(255, 255, 255, 0),
+			},
+			expBool: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actualBool := tt.mode.NeedsRoutingToPeer(tt.peerIP, tt.localIP)
-			assert.Equal(t, tt.expBool, actualBool, "NeedsRoutingToPeer did not return correct result")
+			actualBool := tt.mode.NeedsDirectRoutingToPeer(tt.peerIP, tt.localIP)
+			assert.Equal(t, tt.expBool, actualBool, "NeedsDirectRoutingToPeer did not return correct result")
 		})
 	}
 }

--- a/pkg/agent/openflow/pipeline_windows.go
+++ b/pkg/agent/openflow/pipeline_windows.go
@@ -297,7 +297,7 @@ func (c *client) hostBridgeUplinkFlows(localSubnet net.IPNet, category cookie.Ca
 
 func (c *client) l3FwdFlowToRemoteViaRouting(localGatewayMAC net.HardwareAddr, remoteGatewayMAC net.HardwareAddr,
 	category cookie.Category, peerIP net.IP, peerPodCIDR *net.IPNet) []binding.Flow {
-	if !c.encapMode.NeedsRoutingToPeer(peerIP, c.nodeConfig.NodeIPAddr) && remoteGatewayMAC != nil {
+	if c.encapMode.NeedsDirectRoutingToPeer(peerIP, c.nodeConfig.NodeIPAddr) && remoteGatewayMAC != nil {
 		// It enhances Windows Noencap mode performance by bypassing host network.
 		flows := []binding.Flow{c.pipeline[l2ForwardingCalcTable].BuildFlow(priorityNormal).
 			MatchDstMAC(remoteGatewayMAC).

--- a/pkg/agent/route/route_linux.go
+++ b/pkg/agent/route/route_linux.go
@@ -590,8 +590,9 @@ func (c *Client) AddRoutes(podCIDR *net.IPNet, nodeName string, nodeIP, nodeGwIP
 		}
 		route.LinkIndex = c.nodeConfig.GatewayConfig.LinkIndex
 		route.Gw = nodeGwIP
-	} else if !c.networkConfig.TrafficEncapMode.NeedsRoutingToPeer(nodeIP, c.nodeConfig.NodeIPAddr) {
-		// NoEncap traffic need routing help.
+	} else if c.networkConfig.TrafficEncapMode.NeedsDirectRoutingToPeer(nodeIP, c.nodeConfig.NodeIPAddr) {
+		// NoEncap traffic to Node on the same subnet.
+		// Set the peerNodeIP as next hop.
 		route.Gw = nodeIP
 	} else {
 		// NoEncap traffic to Node on the same subnet. It is handled by host default route.

--- a/pkg/agent/route/route_windows.go
+++ b/pkg/agent/route/route_windows.go
@@ -115,7 +115,7 @@ func (c *Client) AddRoutes(podCIDR *net.IPNet, nodeName string, peerNodeIP, peer
 	if c.networkConfig.TrafficEncapMode.NeedsEncapToPeer(peerNodeIP, c.nodeConfig.NodeIPAddr) {
 		route.LinkIndex = c.nodeConfig.GatewayConfig.LinkIndex
 		route.GatewayAddress = peerGwIP
-	} else if !c.networkConfig.TrafficEncapMode.NeedsRoutingToPeer(peerNodeIP, c.nodeConfig.NodeIPAddr) {
+	} else if c.networkConfig.TrafficEncapMode.NeedsDirectRoutingToPeer(peerNodeIP, c.nodeConfig.NodeIPAddr) {
 		// NoEncap traffic to Node on the same subnet.
 		// Set the peerNodeIP as next hop.
 		route.LinkIndex = c.bridgeInfIndex


### PR DESCRIPTION
It was confusing that antrea-agent needed to add a route to the routing
table when NeedsRoutingToPeer returns false. "Need Routing" here meant
the Node cannot reach peer Node directly and it needs routing support
from the network connecting the Nodes. To make it clear, this patch
changes the method name to "NeedsDirectRoutingToPeer" and returns true
if the Node can reach peer Node directly which indicates antrea-agent
needs to add a direct route to the routing table.

Signed-off-by: Quan Tian <qtian@vmware.com>