### PR TITLE
Remove assumption that there is a single ovs-vswitchd .ctl file

### DIFF
--- a/pkg/ovs/ovsctl/ovsctl_windows.go
+++ b/pkg/ovs/ovsctl/ovsctl_windows.go
@@ -18,8 +18,10 @@ package ovsctl
 
 import "os/exec"
 
-// File path of the ovs-vswitchd control named pipe.
-const ovsVSwitchdUDS = "c:/openvswitch/var/run/openvswitch/ovs-vswitchd.ctl"
+// ovsVSwitchdUDS returns the file path of the ovs-vswitchd control named pipe.
+func ovsVSwitchdUDS() string {
+	return "c:/openvswitch/var/run/openvswitch/ovs-vswitchd.ctl"
+}
 
 func getOVSCommand(cmdStr string) *exec.Cmd {
 	return exec.Command("cmd.exe", "/c", cmdStr)


### PR DESCRIPTION
Make the code more robust by removing the assumption that there is a
single ovs-vswitch control socket file in /var/run/openvswitch when
running ovs-appctl. Instead we read the ovs-vswitchd PID from the
pidfile and use the read value to determine the correct control socket
file.

While we do remove stale .ctl files in the start_ovs script, I recently
noticed that we were not doing the same thing in the start_ovs_netdev
script, leading to issues when running ovs-appctl commands in
antrea-agent. It's probably a good idea to remove stale .ctl files in
start_ovs_netdev when (re)starting OVS, but in the meantime it also
feels like a good idea to remove the assumption of a single .ctl file
from the antrea-agent code.