### PR TITLE
Protect Traceflow state from concurrent access in Octant plugin

### DIFF
--- a/plugins/octant/cmd/antrea-octant-plugin/main.go
+++ b/plugins/octant/cmd/antrea-octant-plugin/main.go
@@ -18,6 +18,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/vmware-tanzu/octant/pkg/navigation"
 	"github.com/vmware-tanzu/octant/pkg/plugin"
@@ -39,8 +40,12 @@ const (
 
 type antreaOctantPlugin struct {
 	client *clientset.Clientset
-	graph  string
-	lastTf *crdv1alpha1.Traceflow
+	// tfMutex protects the Traceflow state in case of multiple client
+	// sessions concurrently accessing the Traceflow functionality of the
+	// Antrea plugin.
+	tfMutex sync.Mutex
+	graph   string
+	lastTf  *crdv1alpha1.Traceflow
 }
 
 func newAntreaOctantPlugin() *antreaOctantPlugin {


### PR DESCRIPTION
After checking with the Octant developers, we need to protect the global
plugin state in case multiple client sessions are opened (e.g. multiple
tabs). While this is not a typical use case, it could potentially lead
to some data corruption.

We don't try to get fancy with the locking scheme, i.e. we don't try to
keep the size of the critical section small, as it doesn't seem to
matter much in this case. The goal is to ensure code correctness.

Note that the K8s client itself is thread-safe, and it is never updated
after initialiation.

Signed-off-by: Antonin Bas <abas@vmware.com>