### PR TITLE
[CI]add a workflow to cancel previous running workflow

### DIFF
--- a/.github/workflows/cancel_workflows.yml
+++ b/.github/workflows/cancel_workflows.yml
@@ -1,0 +1,15 @@
+name: Cancel Workflows
+on:
+  workflow_run:
+    workflows: ["Go", "Golicense", "Kind", "Build and push latest image if needed", "Antrea upgrade"]
+    types:
+      - requested
+jobs:
+  cancel:
+    name: Cancel workflows
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.event == 'pull_request' }}
+    steps:
+    - uses: styfle/cancel-workflow-action@0.9.0
+      with:
+        workflow_id: ${{ github.event.workflow.id }}


### PR DESCRIPTION
add a cancel workflow so when there is a new push
previous workflow will be cancelled which will help to reduce
concurrent github runner usage and reduce unnecessary waiting time.

refer to https://github.com/styfle/cancel-workflow-action#advanced-pull-requests-from-forks

according to github page [here](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_run)
this file has to be in default branch first to take affect.

this is a part of issue #2014 

Signed-off-by: Lan Luo <luola@vmware.com>