### PR TITLE
[CI] Don't clone repo if pending or skip jobs

### DIFF
--- a/ci/jenkins/jobs/job-templates.yaml
+++ b/ci/jenkins/jobs/job-templates.yaml
@@ -48,6 +48,47 @@
     wrappers: '{wrappers}'
 
 - job-template:
+      name: '{name}-{test_name}-no-scm'
+      node: '{node}'
+      block-downstream: false
+      block-upstream: false
+      builders: '{builders}'
+      concurrent: false
+      description: '{description}'
+      project-type: freestyle
+      properties:
+          - build-discarder:
+                artifact-days-to-keep: -1
+                artifact-num-to-keep: -1
+                days-to-keep: 7
+                num-to-keep: 30
+          - github:
+                url: 'https://github.com/{org_repo}'
+      publishers: '{publishers}'
+      triggers:
+          - github-pull-request:
+                admin-list: '{admin_list}'
+                allow-whitelist-orgs-as-admins: '{allow_whitelist_orgs_as_admins}'
+                auth-id: '{ghpr_auth}'
+                auto-close-on-fail: false
+                build-desc-template: null
+                github-hooks: true
+                only-trigger-phrase: '{only_trigger_phrase}'
+                org-list: '{org_list}'
+                permit-all: '{trigger_permit_all}'
+                trigger-phrase: '{trigger_phrase}'
+                white-list-target-branches: '{white_list_target_branches}'
+                white-list: '{white_list}'
+                status-context: '{status_context}'
+                status-url: '{status_url}'
+                success-status: '{success_status}'
+                failure-status: '{failure_status}'
+                error-status: '{error_status}'
+                triggered-status: '{triggered_status}'
+                started-status: '{started_status}'
+      wrappers: '{wrappers}'
+
+- job-template:
     name: '{name}-{test_name}-job-validator'
     node: '{node}'
     block-downstream: false

--- a/ci/jenkins/jobs/projects.yaml
+++ b/ci/jenkins/jobs/projects.yaml
@@ -224,7 +224,7 @@
                   credential-id: CODECOV_TOKEN # Jenkins secret that stores codecov token
                   variable: CODECOV_TOKEN
           publishers: []
-      - '{name}-{test_name}-for-pull-request':
+      - '{name}-{test_name}-no-scm':
           test_name: e2e-pending-label
           node: null
           description: 'This is for marking PR as pending for e2e test.'
@@ -305,7 +305,7 @@
               default-excludes: true
               fingerprint: false
               only-if-success: false
-      - '{name}-{test_name}-for-pull-request':
+      - '{name}-{test_name}-no-scm':
           test_name: e2e-skip
           node: null
           description: 'This is for marking PR as passed.'
@@ -329,7 +329,7 @@
           started_status: null
           wrappers: []
           publishers: []
-      - '{name}-{test_name}-for-pull-request':
+      - '{name}-{test_name}-no-scm':
           test_name: conformance-pending-label
           node: null
           description: 'This is for marking PR as pending for conformance test.'
@@ -411,7 +411,7 @@
               default-excludes: true
               fingerprint: false
               only-if-success: false
-      - '{name}-{test_name}-for-pull-request':
+      - '{name}-{test_name}-no-scm':
           test_name: conformance-skip
           node: null
           description: 'This is for marking PR as passed.'
@@ -435,7 +435,7 @@
           started_status: null
           wrappers: []
           publishers: []
-      - '{name}-{test_name}-for-pull-request':
+      - '{name}-{test_name}-no-scm':
           test_name: all-features-conformance-pending-label
           node: null
           description: 'This is for marking PR as pending for conformance test with all alpha features enabled.'
@@ -501,7 +501,7 @@
               default-excludes: true
               fingerprint: false
               only-if-success: false
-      - '{name}-{test_name}-for-pull-request':
+      - '{name}-{test_name}-no-scm':
           test_name: all-features-conformance-skip
           node: null
           description: 'This is for marking PR as passed.'
@@ -582,7 +582,7 @@
               default-excludes: true
               fingerprint: false
               only-if-success: false
-      - '{name}-{test_name}-for-pull-request':
+      - '{name}-{test_name}-no-scm':
           test_name: whole-conformance-skip
           node: null
           description: 'This is for marking PR as passed.'
@@ -606,7 +606,7 @@
           started_status: null
           wrappers: []
           publishers: []
-      - '{name}-{test_name}-for-pull-request':
+      - '{name}-{test_name}-no-scm':
           test_name: networkpolicy-pending-label
           node: null
           description: 'This is for marking PR as pending for networkpolicy test.'
@@ -688,7 +688,7 @@
               default-excludes: true
               fingerprint: false
               only-if-success: false
-      - '{name}-{test_name}-for-pull-request':
+      - '{name}-{test_name}-no-scm':
           test_name: networkpolicy-skip
           node: null
           description: 'This is for marking PR as passed.'


### PR DESCRIPTION
There's no need to clone antrea repo if it is a pending or skip job.
This PR should fasten job build speed by deleting scm related fields in
job-template.

Signed-off-by: Zhecheng Li <lzhecheng@vmware.com>