### PR TITLE
keep latest workflows only for PR

### DIFF
--- a/.github/workflows/cancel_workflows.yml
+++ b/.github/workflows/cancel_workflows.yml
@@ -12,4 +12,5 @@ jobs:
     steps:
     - uses: styfle/cancel-workflow-action@0.9.0
       with:
+        all_but_latest: true
         workflow_id: ${{ github.event.workflow.id }}


### PR DESCRIPTION
cancel all workflows but latest for any PR.

refer to https://github.com/styfle/cancel-workflow-action#advanced-all-but-latest

Signed-off-by: Lan Luo <luola@vmware.com>

