### PR TITLE
Increase timeout for jenkins-networkpolicy CI job

### DIFF
--- a/ci/jenkins/jobs/projects.yaml
+++ b/ci/jenkins/jobs/projects.yaml
@@ -662,7 +662,7 @@
                 variable: CODECOV_TOKEN
           - timeout:
               fail: true
-              timeout: 80
+              timeout: 120
               type: absolute
           - credentials-binding:
             - text:


### PR DESCRIPTION
It is frequently timing out in cleanup.

Signed-off-by: Antonin Bas <abas@vmware.com>