### PR TITLE
Temporary workaround for e2e test memory leak

### DIFF
--- a/ci/jenkins/test-vmc.sh
+++ b/ci/jenkins/test-vmc.sh
@@ -470,8 +470,12 @@ function run_e2e {
     if [[ "$COVERAGE" == true ]]; then
         rm -rf ${GIT_CHECKOUT_DIR}/e2e-coverage
         mkdir -p ${GIT_CHECKOUT_DIR}/e2e-coverage
+        # HACK: see https://github.com/antrea-io/antrea/issues/2292
+        go mod edit -replace github.com/moby/spdystream=github.com/antoninbas/spdystream@v0.2.1 && go mod tidy
         go test -v -timeout=100m antrea.io/antrea/test/e2e --logs-export-dir ${GIT_CHECKOUT_DIR}/antrea-test-logs --prometheus --coverage --coverage-dir ${GIT_CHECKOUT_DIR}/e2e-coverage --provider remote --remote.sshconfig "${CLUSTER_SSHCONFIG}" --remote.kubeconfig "${CLUSTER_KUBECONFIG}"
     else
+        # HACK: see https://github.com/antrea-io/antrea/issues/2292
+        go mod edit -replace github.com/moby/spdystream=github.com/antoninbas/spdystream@v0.2.1 && go mod tidy
         go test -v -timeout=100m antrea.io/antrea/test/e2e --logs-export-dir ${GIT_CHECKOUT_DIR}/antrea-test-logs --prometheus --provider remote --remote.sshconfig "${CLUSTER_SSHCONFIG}" --remote.kubeconfig "${CLUSTER_KUBECONFIG}"
     fi
 

--- a/ci/jenkins/test.sh
+++ b/ci/jenkins/test.sh
@@ -374,6 +374,8 @@ function run_e2e {
 
     set +e
     mkdir -p `pwd`/antrea-test-logs
+    # HACK: see https://github.com/antrea-io/antrea/issues/2292
+    go mod edit -replace github.com/moby/spdystream=github.com/antoninbas/spdystream@v0.2.1 && go mod tidy
     go test -v antrea.io/antrea/test/e2e --logs-export-dir `pwd`/antrea-test-logs --provider remote -timeout=100m --prometheus
     if [[ "$?" != "0" ]]; then
         TEST_FAILURE=true


### PR DESCRIPTION
See #2292

We apply the workaround for all jobs run in Jenkins, as in addition to
dual-stack failures, I have also observed failures for jobs run in VMC,
which may have the same root cause.