### PR TITLE
Only add patchType when there is a patch for mutating webhooks

### DIFF
--- a/pkg/controller/networkpolicy/mutate.go
+++ b/pkg/controller/networkpolicy/mutate.go
@@ -91,12 +91,16 @@ func (m *NetworkPolicyMutator) Mutate(ar *admv1.AdmissionReview) *admv1.Admissio
 			Message: msg,
 		}
 	}
-	return &admv1.AdmissionResponse{
-		Allowed:   allowed,
-		Result:    result,
-		PatchType: &patchType,
-		Patch:     patch,
+	response := &admv1.AdmissionResponse{
+		Allowed: allowed,
+		Result:  result,
 	}
+	// For a mutating webhook, patch and patchType must be provided together only when patch exists
+	if len(patch) > 0 {
+		response.PatchType = &patchType
+		response.Patch = patch
+	}
+	return response
 }
 
 // mutateAntreaPolicy mutates names of rules of an Antrea NetworkPolicy CRD.


### PR DESCRIPTION
Co-existence of `patchType` and `patch` is validated by [admissionreview](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/request/admissionreview.go#L67). In case of resource deletions (ACNP and ANP for now), there is usually no mutation needed, and no `patch` in AdmissionResponse as a result. Hence the `patchType` in such AdmissionResponse should not be set. 
This was not yet an issue in Antrea due to the fact that we do not register DELETE as a mutating webhook operation in Antrea manifest.
