### PR TITLE
Fix race condition in EgressController and unit tests

### DIFF
--- a/pkg/controller/egress/controller.go
+++ b/pkg/controller/egress/controller.go
@@ -329,7 +329,7 @@ func (c *EgressController) syncEgressIP(egress *egressv1alpha2.Egress) (net.IP, 
 		return net.ParseIP(egress.Spec.EgressIP), nil
 	}
 
-	ipAllocator, exists := c.ipAllocatorMap[egress.Spec.ExternalIPPool]
+	ipAllocator, exists := c.getIPAllocator(egress.Spec.ExternalIPPool)
 	if !exists {
 		// The IP pool has been deleted, reclaim the IP from the Egress API.
 		if egress.Spec.EgressIP != "" {

--- a/pkg/controller/egress/controller_test.go
+++ b/pkg/controller/egress/controller_test.go
@@ -285,6 +285,8 @@ func TestAddEgress(t *testing.T) {
 			controller := newController(fakeObjects, fakeCRDObjects)
 			controller.informerFactory.Start(stopCh)
 			controller.crdInformerFactory.Start(stopCh)
+			controller.informerFactory.WaitForCacheSync(stopCh)
+			controller.crdInformerFactory.WaitForCacheSync(stopCh)
 			go controller.groupingController.Run(stopCh)
 			go controller.Run(stopCh)
 
@@ -330,6 +332,8 @@ func TestUpdateEgress(t *testing.T) {
 	controller := newController([]runtime.Object{nsDefault, podFoo1}, []runtime.Object{eipFoo1, eipFoo2})
 	controller.informerFactory.Start(stopCh)
 	controller.crdInformerFactory.Start(stopCh)
+	controller.informerFactory.WaitForCacheSync(stopCh)
+	controller.crdInformerFactory.WaitForCacheSync(stopCh)
 	go controller.groupingController.Run(stopCh)
 	go controller.Run(stopCh)
 
@@ -644,6 +648,8 @@ func TestSyncEgressIP(t *testing.T) {
 			controller := newController(nil, fakeObjects)
 			controller.informerFactory.Start(stopCh)
 			controller.crdInformerFactory.Start(stopCh)
+			controller.informerFactory.WaitForCacheSync(stopCh)
+			controller.crdInformerFactory.WaitForCacheSync(stopCh)
 			controller.createOrUpdateIPAllocator(tt.existingExternalIPPool)
 			for _, egress := range tt.existingEgresses {
 				controller.updateIPAllocation(egress)


### PR DESCRIPTION
ipAllocatorMap was read without holding the mutex in syncEgressIP. This
patch fixes it and stabilizes the unit tests by waiting for cache sync
before starting creating objects. This is because resource creation
events will be missing if the resources are created in-between list and
watch call of an fake informer.

Signed-off-by: Quan Tian <qtian@vmware.com>