### PR TITLE
Automated cherry pick of #2302: Fix MarshalJSON error caused by incorrect conversion function

### DIFF
--- a/pkg/apis/controlplane/v1beta1/conversion.go
+++ b/pkg/apis/controlplane/v1beta1/conversion.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/vmware-tanzu/antrea/pkg/apis/controlplane"
-	"github.com/vmware-tanzu/antrea/pkg/apis/security/v1alpha1"
 )
 
 func init() {
@@ -402,18 +401,7 @@ func Convert_controlplane_NetworkPolicy_To_v1beta1_NetworkPolicy(in *controlplan
 }
 
 func Convert_controlplane_NetworkPolicyRule_To_v1beta1_NetworkPolicyRule(in *controlplane.NetworkPolicyRule, out *NetworkPolicyRule, s conversion.Scope) error {
-	out.Direction = Direction(in.Direction)
-	if err := Convert_controlplane_NetworkPolicyPeer_To_v1beta1_NetworkPolicyPeer(&in.From, &out.From, s); err != nil {
-		return err
-	}
-	if err := Convert_controlplane_NetworkPolicyPeer_To_v1beta1_NetworkPolicyPeer(&in.To, &out.To, s); err != nil {
-		return err
-	}
-	out.Services = *(*[]Service)(unsafe.Pointer(&in.Services))
-	out.Priority = in.Priority
-	out.Action = (*v1alpha1.RuleAction)(unsafe.Pointer(in.Action))
-	out.EnableLogging = in.EnableLogging
-	return nil
+	return autoConvert_controlplane_NetworkPolicyRule_To_v1beta1_NetworkPolicyRule(in, out, s)
 }
 
 func Convert_v1beta1_Service_To_controlplane_Service(in *Service, out *controlplane.Service, s conversion.Scope) error {

--- a/pkg/apis/controlplane/v1beta1/conversion_test.go
+++ b/pkg/apis/controlplane/v1beta1/conversion_test.go
@@ -128,6 +128,7 @@ var (
 	v1b1TCP     = ProtocolTCP
 	cpTCP       = controlplane.ProtocolTCP
 	int80       = intstr.FromInt(80)
+	int81       = intstr.FromInt(81)
 	v1b1Service = Service{
 		Protocol: &v1b1TCP,
 		Port:     &int80,
@@ -281,4 +282,27 @@ func TestConvertBetweenV1beta1AndControlplaneService(t *testing.T) {
 	require.NoError(t,
 		Convert_v1beta1_Service_To_controlplane_Service(&v1b1Service, &convertedCPService, nil))
 	assert.Equal(t, cpService, convertedCPService, "v1beta1.GroupMember -> controlplane.GroupMember")
+}
+
+func TestConvertBetweenV1beta1NetworkPolicyRuleAndControlplaneNetworkPolicyRule(t *testing.T) {
+	scheme := runtime.NewScheme()
+	assert.NoError(t, RegisterConversions(scheme))
+
+	cpRule := controlplane.NetworkPolicyRule{
+		Direction: controlplane.DirectionIn,
+		Services: []controlplane.Service{
+			{Protocol: &cpTCP, Port: &int80},
+			{Protocol: &cpTCP, Port: &int81},
+		},
+		From: controlplane.NetworkPolicyPeer{
+			AddressGroups: []string{"abc", "bcd"},
+		},
+	}
+	var convertedCPRule controlplane.NetworkPolicyRule
+	var convertedV1beta1Rule NetworkPolicyRule
+	require.NoError(t,
+		Convert_controlplane_NetworkPolicyRule_To_v1beta1_NetworkPolicyRule(&cpRule, &convertedV1beta1Rule, nil))
+	require.NoError(t,
+		Convert_v1beta1_NetworkPolicyRule_To_controlplane_NetworkPolicyRule(&convertedV1beta1Rule, &convertedCPRule, nil))
+	assert.Equal(t, cpRule, convertedCPRule)
 }


### PR DESCRIPTION
Cherry pick of #2302 on release-0.13.

#2302: Fix MarshalJSON error caused by incorrect conversion function

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.