### PR TITLE
Automated cherry pick of #2305: Fix wrong types and missing field selectors in legacy APIs

### DIFF
--- a/pkg/legacyapis/controlplane/v1beta1/conversion.go
+++ b/pkg/legacyapis/controlplane/v1beta1/conversion.go
@@ -1,0 +1,46 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1beta1
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func init() {
+	localSchemeBuilder.Register(addConversionFuncs)
+}
+
+// addConversionFuncs adds non-generated conversion functions to the given scheme.
+func addConversionFuncs(scheme *runtime.Scheme) error {
+	for _, kind := range []string{"AppliedToGroup", "AddressGroup", "NetworkPolicy"} {
+		err := scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.WithKind(kind),
+			func(label, value string) (string, string, error) {
+				switch label {
+				// Antrea Agents select resources by nodeName.
+				case "metadata.name", "nodeName":
+					return label, value, nil
+				default:
+					return "", "", fmt.Errorf("field label not supported: %s", label)
+				}
+			},
+		)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/legacyapis/controlplane/v1beta1/register.go
+++ b/pkg/legacyapis/controlplane/v1beta1/register.go
@@ -19,7 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	"antrea.io/antrea/pkg/apis/controlplane/v1beta2"
+	"antrea.io/antrea/pkg/apis/controlplane/v1beta1"
 )
 
 // GroupName is the group name used in this package.
@@ -44,15 +44,15 @@ var (
 // Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
-		&v1beta2.AppliedToGroup{},
-		&v1beta2.AppliedToGroupPatch{},
-		&v1beta2.AppliedToGroupList{},
-		&v1beta2.AddressGroup{},
-		&v1beta2.AddressGroupPatch{},
-		&v1beta2.AddressGroupList{},
-		&v1beta2.NetworkPolicy{},
-		&v1beta2.NetworkPolicyList{},
-		&v1beta2.NodeStatsSummary{},
+		&v1beta1.AppliedToGroup{},
+		&v1beta1.AppliedToGroupPatch{},
+		&v1beta1.AppliedToGroupList{},
+		&v1beta1.AddressGroup{},
+		&v1beta1.AddressGroupPatch{},
+		&v1beta1.AddressGroupList{},
+		&v1beta1.NetworkPolicy{},
+		&v1beta1.NetworkPolicyList{},
+		&v1beta1.NodeStatsSummary{},
 	)
 
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/pkg/legacyapis/networking/v1beta1/conversion.go
+++ b/pkg/legacyapis/networking/v1beta1/conversion.go
@@ -1,0 +1,46 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1beta1
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func init() {
+	localSchemeBuilder.Register(addConversionFuncs)
+}
+
+// addConversionFuncs adds non-generated conversion functions to the given scheme.
+func addConversionFuncs(scheme *runtime.Scheme) error {
+	for _, kind := range []string{"AppliedToGroup", "AddressGroup", "NetworkPolicy"} {
+		err := scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.WithKind(kind),
+			func(label, value string) (string, string, error) {
+				switch label {
+				// Antrea Agents select resources by nodeName.
+				case "metadata.name", "nodeName":
+					return label, value, nil
+				default:
+					return "", "", fmt.Errorf("field label not supported: %s", label)
+				}
+			},
+		)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Cherry pick of #2305 on release-1.1.

#2305: Fix wrong types and missing field selectors in legacy APIs

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.