### PR TITLE
Fix ovs group id conflict when dual stack is enabled

### DIFF
--- a/pkg/agent/proxy/proxier.go
+++ b/pkg/agent/proxy/proxier.go
@@ -644,7 +644,7 @@ func NewProxier(
 		endpointReferenceCounter: map[string]int{},
 		serviceStringMap:         map[string]k8sproxy.ServicePortName{},
 		oversizeServiceSet:       sets.NewString(),
-		groupCounter:             types.NewGroupCounter(),
+		groupCounter:             types.NewGroupCounter(isIPv6),
 		ofClient:                 ofClient,
 		isIPv6:                   isIPv6,
 	}

--- a/pkg/agent/proxy/proxier_test.go
+++ b/pkg/agent/proxy/proxier_test.go
@@ -102,7 +102,7 @@ func NewFakeProxier(ofClient openflow.Client, isIPv6 bool) *proxier {
 		endpointsInstalledMap:    types.EndpointsMap{},
 		endpointReferenceCounter: map[string]int{},
 		endpointsMap:             types.EndpointsMap{},
-		groupCounter:             types.NewGroupCounter(),
+		groupCounter:             types.NewGroupCounter(isIPv6),
 		ofClient:                 ofClient,
 		serviceStringMap:         map[string]k8sproxy.ServicePortName{},
 		isIPv6:                   isIPv6,

--- a/pkg/agent/proxy/types/groupcounter.go
+++ b/pkg/agent/proxy/types/groupcounter.go
@@ -41,8 +41,12 @@ type groupCounter struct {
 	groupMap map[k8sproxy.ServicePortName]binding.GroupIDType
 }
 
-func NewGroupCounter() *groupCounter {
-	return &groupCounter{groupMap: map[k8sproxy.ServicePortName]binding.GroupIDType{}}
+func NewGroupCounter(isIPv6 bool) *groupCounter {
+	var groupIDCounter binding.GroupIDType
+	if isIPv6 {
+		groupIDCounter = 0x10000000
+	}
+	return &groupCounter{groupMap: map[k8sproxy.ServicePortName]binding.GroupIDType{}, groupIDCounter: groupIDCounter}
 }
 
 func (c *groupCounter) Get(svcPortName k8sproxy.ServicePortName) (binding.GroupIDType, bool) {


### PR DESCRIPTION
When dual stack is enabled, there will be IPv4 and IPv6 AntreaProxy. The IPv4
AntreaProxy and IPv6 AntreaProxy don't share the same GroupCounter. When a
IPv6 Service is created by IPv6 AntreaProxy, the GroupID generated may be
duplicated with a GroupID used by IPv4 Service. GroupCounter of IPv6 AntreaProxy
can start with 0x10000000 to avoid above issue.

Signed-off-by: Hongliang Liu <lhongliang@vmware.com>