### PR TITLE
Automated cherry pick of #2317: Fix ovs group id conflict when dual stack is enabled

### DIFF
--- a/pkg/agent/proxy/proxier.go
+++ b/pkg/agent/proxy/proxier.go
@@ -644,7 +644,7 @@ func NewProxier(
 		endpointReferenceCounter: map[string]int{},
 		serviceStringMap:         map[string]k8sproxy.ServicePortName{},
 		oversizeServiceSet:       sets.NewString(),
-		groupCounter:             types.NewGroupCounter(),
+		groupCounter:             types.NewGroupCounter(isIPv6),
 		ofClient:                 ofClient,
 		isIPv6:                   isIPv6,
 	}

--- a/pkg/agent/proxy/proxier_test.go
+++ b/pkg/agent/proxy/proxier_test.go
@@ -102,7 +102,7 @@ func NewFakeProxier(ofClient openflow.Client, isIPv6 bool) *proxier {
 		endpointsInstalledMap:    types.EndpointsMap{},
 		endpointReferenceCounter: map[string]int{},
 		endpointsMap:             types.EndpointsMap{},
-		groupCounter:             types.NewGroupCounter(),
+		groupCounter:             types.NewGroupCounter(isIPv6),
 		ofClient:                 ofClient,
 		serviceStringMap:         map[string]k8sproxy.ServicePortName{},
 		isIPv6:                   isIPv6,

--- a/pkg/agent/proxy/types/groupcounter.go
+++ b/pkg/agent/proxy/types/groupcounter.go
@@ -41,8 +41,12 @@ type groupCounter struct {
 	groupMap map[k8sproxy.ServicePortName]binding.GroupIDType
 }
 
-func NewGroupCounter() *groupCounter {
-	return &groupCounter{groupMap: map[k8sproxy.ServicePortName]binding.GroupIDType{}}
+func NewGroupCounter(isIPv6 bool) *groupCounter {
+	var groupIDCounter binding.GroupIDType
+	if isIPv6 {
+		groupIDCounter = 0x10000000
+	}
+	return &groupCounter{groupMap: map[k8sproxy.ServicePortName]binding.GroupIDType{}, groupIDCounter: groupIDCounter}
 }
 
 func (c *groupCounter) Get(svcPortName k8sproxy.ServicePortName) (binding.GroupIDType, bool) {


### PR DESCRIPTION
Cherry pick of #2317 on release-1.1.

#2317: Fix ovs group id conflict when dual stack is enabled

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.