### PR TITLE
Automated cherry pick of #2318: Fix cross-Node service access when AntreaProxy is disabled

### DIFF
--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -575,11 +575,7 @@ func (c *client) InstallGatewayFlows() error {
 
 	// Add flow to ensure the liveness check packet could be forwarded correctly.
 	flows = append(flows, c.localProbeFlow(gatewayIPs, cookie.Default)...)
-	flows = append(flows, c.ctRewriteDstMACFlows(gatewayConfig.MAC, cookie.Default)...)
-	// In NoEncap , no traffic from tunnel port
-	if c.encapMode.SupportsEncap() {
-		flows = append(flows, c.l3FwdFlowToGateway(gatewayIPs, gatewayConfig.MAC, cookie.Default)...)
-	}
+	flows = append(flows, c.l3FwdFlowToGateway(gatewayIPs, gatewayConfig.MAC, cookie.Default)...)
 
 	if err := c.ofEntryOperations.AddAll(flows); err != nil {
 		return err

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -611,18 +611,6 @@ func (c *client) connectionTrackFlows(category cookie.Category) []binding.Flow {
 			ctZone = CtZoneV6
 		}
 		flows = append(flows,
-			// If a connection was initiated through the gateway (i.e. has gatewayCTMark) and
-			// the packet is received on the gateway port, go to the next table directly. This
-			// is to bypass the flow which is installed by ctRewriteDstMACFlow in the same
-			// table, and which will rewrite the destination MAC address for traffic with the
-			// gatewayCTMark, but which is flowing in the opposite direction.
-			connectionTrackStateTable.BuildFlow(priorityHigh).MatchProtocol(proto).
-				MatchRegRange(int(marksReg), markTrafficFromGateway, binding.Range{0, 15}).
-				MatchCTMark(gatewayCTMark, nil).
-				MatchCTStateNew(false).MatchCTStateTrk(true).
-				Action().GotoTable(connectionTrackStateTable.GetNext()).
-				Cookie(c.cookieAllocator.Request(category).Raw()).
-				Done(),
 			// Connections initiated through the gateway are marked with gatewayCTMark.
 			connectionTrackCommitTable.BuildFlow(priorityNormal).MatchProtocol(proto).
 				MatchRegRange(int(marksReg), markTrafficFromGateway, binding.Range{0, 15}).
@@ -835,36 +823,6 @@ func (c *client) traceflowNetworkPolicyFlows(dataplaneTag uint8, timeout uint16,
 					Done())
 			}
 		}
-	}
-	return flows
-}
-
-// ctRewriteDstMACFlow rewrites the destination MAC address with the local host gateway MAC if the
-// packet is marked with gatewayCTMark but was not received on the host gateway. In other words, it
-// rewrites the destination MAC address for reply traffic for connections which were initiated
-// through the gateway, to ensure that this reply traffic gets forwarded correctly (back to the host
-// network namespace, through the gateway). In particular, it is necessary in the following 2 cases:
-//  1) reply traffic for connections from a local Pod to a ClusterIP Service (when AntreaProxy is
-//  disabled and kube-proxy is used). In this case the destination IP address of the reply traffic
-//  is the Pod which initiated the connection to the Service (no SNAT). We need to make sure that
-//  these packets are sent back through the gateway so that the source IP can be rewritten (Service
-//  backend IP -> Service ClusterIP).
-//  2) when hair-pinning is involved, i.e. for connections between 2 local Pods belonging to this
-//  Node and for which NAT is performed. This applies regardless of whether AntreaProxy is enabled
-//  or not, and thus also applies to Windows Nodes (for which AntreaProxy is enabled by default).
-//  One example is a Pod accessing a NodePort Service for which externalTrafficPolicy is set to
-//  Local, using the local Node's IP address.
-func (c *client) ctRewriteDstMACFlows(gatewayMAC net.HardwareAddr, category cookie.Category) []binding.Flow {
-	connectionTrackStateTable := c.pipeline[conntrackStateTable]
-	var flows []binding.Flow
-	for _, proto := range c.ipProtocols {
-		flows = append(flows, connectionTrackStateTable.BuildFlow(priorityNormal).MatchProtocol(proto).
-			MatchCTMark(gatewayCTMark, nil).
-			MatchCTStateNew(false).MatchCTStateTrk(true).
-			Action().SetDstMAC(gatewayMAC).
-			Action().GotoTable(connectionTrackStateTable.GetNext()).
-			Cookie(c.cookieAllocator.Request(category).Raw()).
-			Done())
 	}
 	return flows
 }
@@ -1118,9 +1076,8 @@ func (c *client) l3FwdFlowRouteToGW(gwMAC net.HardwareAddr, category cookie.Cate
 	return flows
 }
 
-// l3FwdFlowToGateway generates the L3 forward flows for traffic from tunnel to
-// the local gateway. It rewrites the destination MAC (should be
-// globalVirtualMAC) of the packets to the gateway interface MAC.
+// l3FwdFlowToGateway generates the L3 forward flows to rewrite the destination MAC of the packets to the gateway interface
+// MAC if the destination IP is the gateway IP or the connection was initiated through the gateway interface.
 func (c *client) l3FwdFlowToGateway(localGatewayIPs []net.IP, localGatewayMAC net.HardwareAddr, category cookie.Category) []binding.Flow {
 	l3FwdTable := c.pipeline[l3ForwardingTable]
 	var flows []binding.Flow
@@ -1129,6 +1086,27 @@ func (c *client) l3FwdFlowToGateway(localGatewayIPs []net.IP, localGatewayMAC ne
 		flows = append(flows, l3FwdTable.BuildFlow(priorityNormal).MatchProtocol(ipProtocol).
 			MatchRegRange(int(marksReg), macRewriteMark, macRewriteMarkRange).
 			MatchDstIP(ip).
+			Action().SetDstMAC(localGatewayMAC).
+			Action().GotoTable(l3FwdTable.GetNext()).
+			Cookie(c.cookieAllocator.Request(category).Raw()).
+			Done())
+	}
+	// Rewrite the destination MAC address with the local host gateway MAC if the packet is in the reply direction and
+	// is marked with gatewayCTMark. This is for connections which were initiated through the gateway, to ensure that
+	// this reply traffic gets forwarded correctly (back to the host network namespace, through the gateway). In
+	// particular, it is necessary in the following 2 cases:
+	//  1) reply traffic for connections from a local Pod to a ClusterIP Service (when AntreaProxy is disabled and
+	//  kube-proxy is used). In this case the destination IP address of the reply traffic is the Pod which initiated the
+	//  connection to the Service (no SNAT). We need to make sure that these packets are sent back through the gateway
+	//  so that the source IP can be rewritten (Service backend IP -> Service ClusterIP).
+	//  2) when hair-pinning is involved, i.e. connections between 2 local Pods, for which NAT is performed. This
+	//  applies regardless of whether AntreaProxy is enabled or not, and thus also applies to Windows Nodes (for which
+	//  AntreaProxy is enabled by default). One example is a Pod accessing a NodePort Service for which
+	//  externalTrafficPolicy is set to Local, using the local Node's IP address.
+	for _, proto := range c.ipProtocols {
+		flows = append(flows, l3FwdTable.BuildFlow(priorityHigh).MatchProtocol(proto).
+			MatchCTMark(gatewayCTMark, nil).
+			MatchCTStateRpl(true).MatchCTStateTrk(true).
 			Action().SetDstMAC(localGatewayMAC).
 			Action().GotoTable(l3FwdTable.GetNext()).
 			Cookie(c.cookieAllocator.Request(category).Raw()).

--- a/test/e2e/service_test.go
+++ b/test/e2e/service_test.go
@@ -1,0 +1,89 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// TestClusterIP tests traffic from Nodes and Pods to ClusterIP Service.
+func TestClusterIP(t *testing.T) {
+	// TODO: Support for dual-stack and IPv6-only clusters
+	skipIfIPv6Cluster(t)
+
+	data, err := setupTest(t)
+	if err != nil {
+		t.Fatalf("Error when setting up test: %v", err)
+	}
+	defer teardownTest(t, data)
+
+	svcName := "nginx"
+	serverPodNode := nodeName(0)
+	svc, cleanup := data.createClusterIPServiceAndBackendPods(t, svcName, serverPodNode)
+	defer cleanup()
+	t.Logf("%s Service is ready", svcName)
+
+	testFromPod := func(podName, nodeName string, hostNetwork bool) {
+		require.NoError(t, data.createPodOnNode(podName, nodeName, busyboxImage, []string{"sleep", strconv.Itoa(3600)}, nil, nil, nil, hostNetwork, nil))
+		defer data.deletePodAndWait(defaultTimeout, podName)
+		require.NoError(t, data.podWaitForRunning(defaultTimeout, podName, testNamespace))
+		err := data.runNetcatCommandFromTestPod(podName, svc.Spec.ClusterIP, 80)
+		require.NoError(t, err, "Pod %s should be able to connect %s, but was not able to connect", podName, net.JoinHostPort(svc.Spec.ClusterIP, fmt.Sprint(80)))
+	}
+
+	t.Run("ClusterIP", func(t *testing.T) {
+		t.Run("Same Linux Node can access the Service", func(t *testing.T) {
+			t.Parallel()
+			testFromPod("hostnetwork-client-on-same-node", serverPodNode, true)
+		})
+		t.Run("Different Linux Node can access the Service", func(t *testing.T) {
+			t.Parallel()
+			skipIfNumNodesLessThan(t, 2)
+			testFromPod("hostnetwork-client-on-different-node", nodeName(1), true)
+		})
+		t.Run("Linux Pod on same Node can access the Service", func(t *testing.T) {
+			t.Parallel()
+			testFromPod("client-on-same-node", serverPodNode, false)
+		})
+		t.Run("Linux Pod on different Node can access the Service", func(t *testing.T) {
+			t.Parallel()
+			skipIfNumNodesLessThan(t, 2)
+			testFromPod("client-on-different-node", nodeName(1), false)
+		})
+	})
+}
+
+func (data *TestData) createClusterIPServiceAndBackendPods(t *testing.T, name string, node string) (*corev1.Service, func()) {
+	ipv4Protocol := corev1.IPv4Protocol
+	require.NoError(t, data.createNginxPod(name, node))
+	_, err := data.podWaitForIPs(defaultTimeout, name, testNamespace)
+	require.NoError(t, err)
+	require.NoError(t, data.podWaitForRunning(defaultTimeout, name, testNamespace))
+	svc, err := data.createNginxClusterIPService(name, false, &ipv4Protocol)
+	require.NoError(t, err)
+
+	cleanup := func() {
+		data.deletePodAndWait(defaultTimeout, name)
+		data.deleteServiceAndWait(defaultTimeout, name)
+	}
+
+	return svc, cleanup
+}

--- a/test/integration/agent/openflow_test.go
+++ b/test/integration/agent/openflow_test.go
@@ -1072,11 +1072,11 @@ func prepareGatewayFlows(gwIPs []net.IP, gwMAC net.HardwareAddr, vMAC net.Hardwa
 				},
 			},
 			expectTableFlows{
-				uint8(31),
+				uint8(70),
 				[]*ofTestUtils.ExpectFlow{
 					{
-						MatchStr: fmt.Sprintf("priority=200,ct_state=-new+trk,ct_mark=0x20,%s", ipProtoStr),
-						ActStr:   fmt.Sprintf("set_field:%s->eth_dst,goto_table:42", gwMAC.String()),
+						MatchStr: fmt.Sprintf("priority=210,ct_state=+rpl+trk,ct_mark=0x20,%s", ipProtoStr),
+						ActStr:   fmt.Sprintf("set_field:%s->eth_dst,goto_table:80", gwMAC.String()),
 					},
 				},
 			},
@@ -1170,7 +1170,6 @@ func prepareDefaultFlows(config *testConfig) []expectTableFlows {
 	}
 	if config.enableIPv4 {
 		table31Flows.flows = append(table31Flows.flows,
-			&ofTestUtils.ExpectFlow{MatchStr: "priority=210,ct_state=-new+trk,ct_mark=0x20,ip,reg0=0x1/0xffff", ActStr: "goto_table:42"},
 			&ofTestUtils.ExpectFlow{MatchStr: "priority=190,ct_state=+inv+trk,ip", ActStr: "drop"},
 		)
 		table105Flows.flows = append(table105Flows.flows,
@@ -1184,7 +1183,6 @@ func prepareDefaultFlows(config *testConfig) []expectTableFlows {
 	}
 	if config.enableIPv6 {
 		table31Flows.flows = append(table31Flows.flows,
-			&ofTestUtils.ExpectFlow{MatchStr: "priority=210,ct_state=-new+trk,ct_mark=0x20,ipv6,reg0=0x1/0xffff", ActStr: "goto_table:42"},
 			&ofTestUtils.ExpectFlow{MatchStr: "priority=190,ct_state=+inv+trk,ipv6", ActStr: "drop"},
 		)
 		table105Flows.flows = append(table105Flows.flows,


### PR DESCRIPTION
Cherry pick of #2318 on release-1.0.

#2318: Fix cross-Node service access when AntreaProxy is disabled

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.