### PR TITLE
Automated cherry pick of #2306: [Windows]Check HostNamespace value when removing HcnEndpoint

### DIFF
--- a/pkg/agent/cniserver/interface_configuration_windows.go
+++ b/pkg/agent/cniserver/interface_configuration_windows.go
@@ -317,7 +317,7 @@ func (ic *ifConfigurator) removeHNSEndpoint(endpoint *hcsshim.HNSEndpoint, conta
 	// Remove HNSEndpoint.
 	go func() {
 		hcnEndpoint, _ := hcn.GetEndpointByID(endpoint.Id)
-		if hcnEndpoint != nil && hcnEndpoint.HostComputeNamespace != "" {
+		if hcnEndpoint != nil && isValidHostNamespace(hcnEndpoint.HostComputeNamespace) {
 			err := hcn.RemoveNamespaceEndpoint(hcnEndpoint.HostComputeNamespace, hcnEndpoint.Id)
 			if err != nil {
 				klog.Errorf("Failed to remove HostComputeEndpoint %s from HostComputeNameSpace %s: %v", hcnEndpoint.Name, hcnEndpoint.HostComputeNamespace, err)
@@ -352,6 +352,13 @@ func (ic *ifConfigurator) removeHNSEndpoint(endpoint *hcsshim.HNSEndpoint, conta
 	// Delete HNSEndpoint from local cache.
 	ic.delEndpoint(epName)
 	return nil
+}
+
+// isValidHostNamespace checks if the hostNamespace is valid or not. When the runtime is docker, the hostNamespace
+// is not set, and Windows HCN should use a default value "00000000-0000-0000-0000-000000000000". An error returns
+// when removing HostComputeEndpoint in this namespace. This field is set with a valid value when containerd is used.
+func isValidHostNamespace(hostNamespace string) bool {
+	return hostNamespace != "" && hostNamespace != "00000000-0000-0000-0000-000000000000"
 }
 
 func parseContainerIfaceFromResults(cfgArgs *cnipb.CniCmdArgs, prevResult *current.Result) *current.Interface {


### PR DESCRIPTION
Cherry pick of #2306 on release-1.0.

#2306: [Windows]Check HostNamespace value when removing HcnEndpoint

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.