### PR TITLE
Improve e2e tests

### DIFF
--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -101,7 +101,7 @@ func skipIfHasWindowsNodes(tb testing.TB) {
 
 func skipIfNoWindowsNodes(tb testing.TB) {
 	if len(clusterInfo.windowsNodes) == 0 {
-		tb.Skipf("Skipping test as the cluster has Windows Nodes")
+		tb.Skipf("Skipping test as the cluster has no Windows Nodes")
 	}
 }
 

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -87,7 +87,10 @@ func TestUpgrade(t *testing.T) {
 	if *pruneAll {
 		extraOptions = "--prune -l app=antrea --prune-whitelist=apiregistration.k8s.io/v1/APIService"
 	}
-	data.deployAntreaCommon(*upgradeToYML, extraOptions)
+	// Do not wait for agent rollout as its updateStrategy is set to OnDelete for upgrade test.
+	if err := data.deployAntreaCommon(*upgradeToYML, extraOptions, false); err != nil {
+		t.Fatalf("Error upgrading Antrea: %v", err)
+	}
 	if *controllerOnly == false {
 		t.Logf("Restarting all Antrea DaemonSet Pods")
 		if err := data.restartAntreaAgentPods(defaultTimeout); err != nil {


### PR DESCRIPTION
1. Use hostNetwork Pod to test Host-to-Service connection to avoid
   relying on Nodes' ssh config.
2. Fail upgrade test if deploying new yaml fails.
3. Correct skip message when there is no Windows Nodes.


Signed-off-by: Quan Tian <qtian@vmware.com>