### PR TITLE
Fix intra-Node service access when both Egress and AntreaProxy is enabled

### DIFF
--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -1805,10 +1805,11 @@ func (c *client) snatCommonFlows(nodeIP net.IP, localSubnet net.IPNet, localGate
 	ipProto := getIPProtocol(localSubnet.IP)
 	flows := []binding.Flow{
 		// First install flows for traffic that should bypass SNAT.
-		// This flow is for traffic to the local Pod subnet.
+		// This flow is for traffic to the local Pod subnet that don't need MAC rewriting (L2 forwarding case). Other
+		// traffic to the local Pod subnet will be handled by L3 forwarding rules.
 		l3FwdTable.BuildFlow(priorityNormal).
 			MatchProtocol(ipProto).
-			MatchRegRange(int(marksReg), markTrafficFromLocal, binding.Range{0, 15}).
+			MatchRegRange(int(marksReg), 0, macRewriteMarkRange).
 			MatchDstIPNet(localSubnet).
 			Action().GotoTable(nextTable).
 			Cookie(c.cookieAllocator.Request(category).Raw()).
@@ -1821,22 +1822,9 @@ func (c *client) snatCommonFlows(nodeIP net.IP, localSubnet net.IPNet, localGate
 			Action().GotoTable(nextTable).
 			Cookie(c.cookieAllocator.Request(category).Raw()).
 			Done(),
-		// This flow is for the return traffic of connections to a local
-		// Pod through the gateway interface (so gatewayCTMark is set).
-		// For example, the return traffic of a connection from an IP
-		// address (not the Node's management IP or gateway interface IP
-		// which are covered by other flows already) of the local Node
-		// to a local Pod. It might also catch the Service return
-		// traffic from a local server Pod, but this case is also
-		// covered by other flows (the flows matching the local and
-		// remote Pod subnets) anyway.
-		l3FwdTable.BuildFlow(priorityNormal).
-			MatchProtocol(ipProto).
-			MatchRegRange(int(marksReg), markTrafficFromLocal, binding.Range{0, 15}).
-			MatchCTMark(gatewayCTMark, nil).
-			Action().GotoTable(nextTable).
-			Cookie(c.cookieAllocator.Request(category).Raw()).
-			Done(),
+		// The return traffic of connections to a local Pod through the gateway interface (so gatewayCTMark is set)
+		// should bypass SNAT too. But it has been covered by the gatewayCT related flow generated in l3FwdFlowToGateway
+		// which forwards all reply traffic for such connections back to the gateway interface with the high priority.
 
 		// Send the traffic to external to snatTable.
 		l3FwdTable.BuildFlow(priorityLow).

--- a/test/integration/agent/openflow_test.go
+++ b/test/integration/agent/openflow_test.go
@@ -1295,15 +1295,11 @@ func prepareExternalFlows(nodeIP net.IP, localSubnet *net.IPNet, gwMAC net.Hardw
 			uint8(70),
 			[]*ofTestUtils.ExpectFlow{
 				{
-					MatchStr: fmt.Sprintf("priority=200,%s,reg0=0x2/0xffff,%s=%s", ipProtoStr, nwDstFieldName, localSubnet.String()),
+					MatchStr: fmt.Sprintf("priority=200,%s,reg0=0/0x80000,%s=%s", ipProtoStr, nwDstFieldName, localSubnet.String()),
 					ActStr:   "goto_table:80",
 				},
 				{
 					MatchStr: fmt.Sprintf("priority=200,%s,reg0=0x2/0xffff,%s=%s", ipProtoStr, nwDstFieldName, nodeIP.String()),
-					ActStr:   "goto_table:80",
-				},
-				{
-					MatchStr: fmt.Sprintf("priority=200,ct_mark=0x20,%s,reg0=0x2/0xffff", ipProtoStr),
 					ActStr:   "goto_table:80",
 				},
 				{


### PR DESCRIPTION
When Egress enabled, extra flows will be added to L3Forwarding table,
one of which make the packets to local Pods jump to
L2ForwardingCalculation directly to prevent them from entering SNAT
table. However, it would also prevent the packets' MAC from being
rewritten even when they are marked as requiring it, which leads to
local Pods cannot access local Pods via their Services' ClusterIPs.

This patch fixes it by making the SNAT skipping flow apply to packets
that don't have macRewriteMark set only, with which all traffic to local
Pods will either be forwarded to L2ForwardingCalculation directly or be
MAC rewritten first before going to L2ForwardingCalculation if they are
required to do so. It also removes a flow in L3Forwarding table that
specially handles gatewayCT related traffic, which has been taken care
of by another more generic flow in same table.

Signed-off-by: Quan Tian <qtian@vmware.com>

Fixes #2330