### PR TITLE
[CI][e2e] Larger timeout for e2e

### DIFF
--- a/ci/jenkins/jobs/projects.yaml
+++ b/ci/jenkins/jobs/projects.yaml
@@ -279,7 +279,7 @@
                 variable: CODECOV_TOKEN
           - timeout:
               fail: true
-              timeout: 120
+              timeout: 150
               type: absolute
           - credentials-binding:
             - text:


### PR DESCRIPTION
This e2e test is successful but the whole build reached the time limit of 120m.
https://jenkins.antrea-ci.rocks/view/antrea-core/job/antrea-e2e-for-pull-request/2806/consoleFull

Signed-off-by: Zhecheng Li <lzhecheng@vmware.com>