### PR TITLE
[CI] Upgrade VMC Jenkins testbed to K8s v1.20.1

### DIFF
--- a/ci/cluster-api/vsphere/templates/cluster.yaml
+++ b/ci/cluster-api/vsphere/templates/cluster.yaml
@@ -44,7 +44,7 @@ spec:
       devices:
       - dhcp4: true
         networkName: NETWORKNAME
-    numCPUs: 2
+    numCPUs: 3
     resourcePool: RESOURCEPOOLPATH
     server: VCENTERNAME
     template: capv-haproxy-v0.6.3
@@ -106,7 +106,7 @@ spec:
         devices:
         - dhcp4: true
           networkName: NETWORKNAME
-      numCPUs: 2
+      numCPUs: 3
       resourcePool: RESOURCEPOOLPATH
       server: VCENTERNAME
       template: OVATEMPLATENAME

--- a/ci/jenkins/jobs/projects.yaml
+++ b/ci/jenkins/jobs/projects.yaml
@@ -894,6 +894,7 @@
                values:
                 - v1.17.5
                 - v1.18.2
+                - v1.19.1
             - axis:
                type: user-defined
                name: IS_MATRIX_TEST
@@ -972,6 +973,7 @@
                values:
                 - v1.17.5
                 - v1.18.2
+                - v1.19.1
             - axis:
                type: user-defined
                name: IS_MATRIX_TEST

--- a/ci/jenkins/test-vmc.sh
+++ b/ci/jenkins/test-vmc.sh
@@ -171,7 +171,7 @@ function saveLogs() {
 function setup_cluster() {
     export KUBECONFIG=$KUBECONFIG_PATH
     if [ -z $K8S_VERSION ]; then
-      export K8S_VERSION=v1.19.1
+      export K8S_VERSION=v1.20.1
     fi
     if [ -z $TEST_OS ]; then
       export TEST_OS=ubuntu-1804
@@ -375,7 +375,7 @@ function deliver_antrea {
         docker save -o flow-aggregator.tar projects.registry.vmware.com/antrea/flow-aggregator:${DOCKER_IMG_VERSION}
     fi
 
-    control_plane_ip="$(kubectl get nodes -o wide --no-headers=true | awk -v role="$CONTROL_PLANE_NODE_ROLE" '$3 == role {print $6}')"
+    control_plane_ip="$(kubectl get nodes -o wide --no-headers=true | awk -v role="$CONTROL_PLANE_NODE_ROLE" '$3 ~ role {print $6}')"
     ${SCP_WITH_ANTREA_CI_KEY} $GIT_CHECKOUT_DIR/build/yamls/*.yml capv@${control_plane_ip}:~
 
     IPs=($(kubectl get nodes -o wide --no-headers=true | awk '{print $6}' | xargs))
@@ -461,7 +461,7 @@ function run_e2e {
     done
 
     echo "=== Move kubeconfig to control-plane Node ==="
-    control_plane_ip="$(kubectl get nodes -o wide --no-headers=true | awk -v role="$CONTROL_PLANE_NODE_ROLE" '$3 == role {print $6}')"
+    control_plane_ip="$(kubectl get nodes -o wide --no-headers=true | awk -v role="$CONTROL_PLANE_NODE_ROLE" '$3 ~ role {print $6}')"
     ${SSH_WITH_ANTREA_CI_KEY} -n capv@${control_plane_ip} "if [ ! -d ".kube" ]; then mkdir .kube; fi"
     ${SCP_WITH_ANTREA_CI_KEY} $GIT_CHECKOUT_DIR/jenkins/out/kubeconfig capv@${control_plane_ip}:~/.kube/config
 
@@ -527,7 +527,7 @@ function run_conformance {
     kubectl rollout status --timeout=5m deployment.apps/antrea-controller -n kube-system
     kubectl rollout status --timeout=5m daemonset/antrea-agent -n kube-system
 
-    control_plane_ip="$(kubectl get nodes -o wide --no-headers=true | awk -v role="$CONTROL_PLANE_NODE_ROLE" '$3 == role {print $6}')"
+    control_plane_ip="$(kubectl get nodes -o wide --no-headers=true | awk -v role="$CONTROL_PLANE_NODE_ROLE" '$3 ~ role {print $6}')"
     echo "=== Move kubeconfig to control-plane Node ==="
     ${SSH_WITH_ANTREA_CI_KEY} -n capv@${control_plane_ip} "if [ ! -d ".kube" ]; then mkdir .kube; fi"
     ${SCP_WITH_ANTREA_CI_KEY} $GIT_CHECKOUT_DIR/jenkins/out/kubeconfig capv@${control_plane_ip}:~/.kube/config

--- a/ci/jenkins/test.sh
+++ b/ci/jenkins/test.sh
@@ -258,7 +258,10 @@ function deliver_antrea_windows {
     rm -f antrea-windows.tar.gz
     sed -i 's/if (!(Test-Path $AntreaAgentConfigPath))/if ($true)/' hack/windows/Helper.psm1
     kubectl get nodes -o wide --no-headers=true | awk -v role="$CONTROL_PLANE_NODE_ROLE" '$3 != role && $1 ~ /win/ {print $6}' | while read IP; do
+        WORKER_NAME=$(govc vm.info -vm.ip ${IP} -json | jq -r '.VirtualMachines[0].Name')
+        echo "==== Reverting Windows VM ${WORKER_NAME} ====="
         govc snapshot.revert -vm.ip ${IP} win-initial
+        govc vm.power -on ${WORKER_NAME} || true
         # Some tests need us.gcr.io/k8s-artifacts-prod/e2e-test-images/agnhost:2.13 image but it is not for windows/amd64 10.0.17763
         # Use e2eteam/agnhost:2.13 instead
         harbor_images=("sigwindowstools-kube-proxy:v1.18.0" "agnhost:2.13" "agnhost:2.13" "e2eteam-jessie-dnsutils:1.0" "e2eteam-pause:3.2")
@@ -298,7 +301,7 @@ function deliver_antrea_windows {
                 done
                 echo "=== Build Windows on Windows Node==="
                 ssh -o StrictHostKeyChecking=no -n Administrator@${IP} "docker pull ${DOCKER_REGISTRY}/antrea/golang:1.15 && docker tag ${DOCKER_REGISTRY}/antrea/golang:1.15 golang:1.15"
-                ssh -o StrictHostKeyChecking=no -n Administrator@${IP} "rm -rf antrea && mkdir antrea && cd antrea && tar -xzf ../antrea_repo.tar.gz && sed -i \"s|build/images/Dockerfile.build.windows .|build/images/Dockerfile.build.windows . --network host|g\" Makefile && NO_PULL=${NO_PULL} make build-windows && docker save -o antrea-windows.tar ${DOCKER_REGISTRY}/antrea/antrea-windows:latest && gzip -f antrea-windows.tar" || true
+                ssh -o StrictHostKeyChecking=no -n Administrator@${IP} "rm -rf antrea && mkdir antrea && cd antrea && tar -xzf ../antrea_repo.tar.gz > /dev/null && sed -i \"s|build/images/Dockerfile.build.windows .|build/images/Dockerfile.build.windows . --network host|g\" Makefile && NO_PULL=${NO_PULL} make build-windows && docker save -o antrea-windows.tar ${DOCKER_REGISTRY}/antrea/antrea-windows:latest && gzip -f antrea-windows.tar" || true
                 for i in `seq 2`; do
                     timeout 2m scp -o StrictHostKeyChecking=no -T Administrator@${IP}:antrea/antrea-windows.tar.gz . && break
                 done
@@ -513,8 +516,10 @@ function run_install_windows_ovs {
     export_govc_env_var
     OVS_VM_NAME="antrea-microsoft-ovs"
 
-    IP=$(govc vm.ip $OVS_VM_NAME)
     govc snapshot.revert -vm $OVS_VM_NAME initial
+    govc vm.power -on $OVS_VM_NAME || true
+    echo "===== Testing VM has been reverted and powered on ====="
+    IP=$(govc vm.ip $OVS_VM_NAME)
     scp -o StrictHostKeyChecking=no -i ${WORKDIR}/.ssh/id_rsa -T hack/windows/Install-OVS.ps1 Administrator@${IP}:
     ssh -o StrictHostKeyChecking=no -i ${WORKDIR}/.ssh/id_rsa -n Administrator@${IP} '/bin/bash -lc "cp Install-OVS.ps1 C:/k && powershell.exe -File C:/k/Install-OVS.ps1"'
 

--- a/ci/run-k8s-e2e-tests.sh
+++ b/ci/run-k8s-e2e-tests.sh
@@ -41,7 +41,7 @@ KUBE_CONFORMANCE_IMAGE=""
 KUBE_CONFORMANCE_IMAGE_VERSION="$(head -n1 $THIS_DIR/k8s-conformance-image-version)"
 IMAGE_PULL_POLICY="Always"
 CONFORMANCE_IMAGE_CONFIG_PATH="${THIS_DIR}/conformance-image-config.yaml"
-SONOBUOY_IMAGE="projects.registry.vmware.com/sonobuoy/sonobuoy:v0.19.0"
+SONOBUOY_IMAGE="projects.registry.vmware.com/sonobuoy/sonobuoy:v0.20.0"
 
 _usage="Usage: $0 [--e2e-conformance] [--e2e-network-policy] [--e2e-focus <TestRegex>] [--e2e-skip <SkipRegex>]
                   [--kubeconfig <Kubeconfig>] [--kube-conformance-image-version <ConformanceImageVersion>]

--- a/ci/verify-sonobuoy.sh
+++ b/ci/verify-sonobuoy.sh
@@ -16,7 +16,7 @@
 
 _SONOBUOY_BINDIR="/tmp/antrea"
 _SONOBUOY_TARBALL="/tmp/sonobuoy.tar.gz"
-_MIN_SONOBUOY_VERSION="v0.19.0"
+_MIN_SONOBUOY_VERSION="v0.20.0"
 
 install_sonobuoy() {
     local ostype=""

--- a/test/e2e/connectivity_test.go
+++ b/test/e2e/connectivity_test.go
@@ -353,7 +353,7 @@ func TestOVSRestartSameNode(t *testing.T) {
 	time.Sleep(3 * time.Second)
 
 	t.Logf("Restarting antrea-agent on Node '%s'", workerNode)
-	if _, err := data.deleteAntreaAgentOnNode(workerNode, 30 /* grace period in seconds */, defaultTimeout); err != nil {
+	if _, err := data.deleteAntreaAgentOnNode(workerNode, 15 /* grace period in seconds */, defaultTimeout); err != nil {
 		t.Fatalf("Error when restarting antrea-agent on Node '%s': %v", workerNode, err)
 	}
 

--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -143,13 +143,13 @@ func setupTest(tb testing.TB) (*TestData, error) {
 		tb.Errorf("Error creating logs directory '%s': %v", testData.logsDirForTestCase, err)
 		return nil, err
 	}
-	tb.Logf("Creating '%s' K8s Namespace", testNamespace)
 	if err := ensureAntreaRunning(tb, testData); err != nil {
 		return nil, err
 	}
 	if err := testData.createTestNamespace(); err != nil {
 		return nil, err
 	}
+	tb.Logf("K8s Namespace '%s' is created", testNamespace)
 	return testData, nil
 }
 
@@ -350,7 +350,7 @@ func teardownTest(tb testing.TB, data *TestData) {
 
 func deletePodWrapper(tb testing.TB, data *TestData, name string) {
 	tb.Logf("Deleting Pod '%s'", name)
-	if err := data.deletePod(testNamespace, name); err != nil {
+	if err := data.deletePodAndWait(defaultTimeout, name); err != nil {
 		tb.Logf("Error when deleting Pod: %v", err)
 	}
 }

--- a/test/e2e/networkpolicy_test.go
+++ b/test/e2e/networkpolicy_test.go
@@ -988,7 +988,7 @@ func createAndWaitForPodWithLabels(t *testing.T, data *TestData, createFunc func
 		t.Fatalf("Error when creating busybox test Pod: %v", err)
 	}
 	cleanupFunc := func() error {
-		if err := data.deletePod(ns, name); err != nil {
+		if err := data.deletePodAndWaitInNS(defaultTimeout, ns, name); err != nil {
 			return fmt.Errorf("error when deleting Pod: %v", err)
 		}
 		return nil


### PR DESCRIPTION
* Upgrade VMC Jenkins testbed to K8s v1.20.1
* More CPU for VMC testbeds
* Smaller gracePeriodSeconds
* Power on VM after reverting to a snapshot
* Flow aggregator test should delete Pods after the test
* Parallel NPLAddPod test
* Improve logs

Signed-off-by: Zhecheng Li <lzhecheng@vmware.com>