### PR TITLE
Fix e2e vagrant doc and script.

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -115,9 +115,8 @@ provide under `infra/vagrant` to provision your Kubernetes cluster, you will
 therefore need the following steps:
 
 1. `./infra/vagrant/provision.sh`
-2. `make`
-3. `./infra/vagrant/push_antrea.sh`
-4. `go test -v -timeout=30m antrea.io/antrea/test/e2e`
+2. `./infra/vagrant/push_antrea.sh`
+3. `go test -v -timeout=30m antrea.io/antrea/test/e2e`
 
 If you need to test an updated version of Antrea, just run
 `./infra/vagrant/push_antrea.sh` and then run the tests again.

--- a/test/e2e/infra/vagrant/push_antrea.sh
+++ b/test/e2e/infra/vagrant/push_antrea.sh
@@ -99,6 +99,7 @@ function pushImgToNodes() {
     IMG_NAME=$1
     SAVED_IMG=$2
 
+    docker pull --quiet $IMG_NAME
     docker inspect $IMG_NAME > /dev/null
     if [ $? -ne 0 ]; then
         echo "Docker image $IMG_NAME was not found"


### PR DESCRIPTION
While playing with the e2e using vagrant, found two issues.
1) There is no Makefile under test/e2e, so remove the `make` step.
2) First time testing doesn't have the ubuntu image pull, so add
   docker pull command.

Signed-off-by: William Tu <u9012063@gmail.com>