### PR TITLE
Fix whereabouts binary permission in antrea/base-ubuntu image

### DIFF
--- a/build/images/base/Dockerfile
+++ b/build/images/base/Dockerfile
@@ -20,7 +20,7 @@ RUN set -eux; \
     esac; \
     mkdir -p /opt/cni/bin; \
     wget -q -O - https://github.com/containernetworking/plugins/releases/download/$CNI_BINARIES_VERSION/cni-plugins-linux-${pluginsArch}-$CNI_BINARIES_VERSION.tgz | tar xz -C /opt/cni/bin $CNI_PLUGINS; \
-    wget -q -O - https://downloads.antrea.io/whereabouts/v0.4/whereabouts-linux-${pluginsArch}.tgz | tar xz -C /opt/cni/bin/ whereabouts-linux-${pluginsArch}/whereabouts --strip-components=1
+    wget -q -O - https://downloads.antrea.io/whereabouts/v0.4/whereabouts-linux-${pluginsArch}.tgz | tar xz -C /opt/cni/bin/ whereabouts-linux-${pluginsArch}/whereabouts --strip-components=1 --no-same-owner
 
 FROM antrea/openvswitch:${OVS_VERSION}
 


### PR DESCRIPTION
We use '--no-same-owner' so that the files are extracted as the current
user (instead of as the user who created the archive).

Signed-off-by: Antonin Bas <abas@vmware.com>

Before:
```
abas-a01:base abas$ docker run -ti antrea/base-ubuntu:2.14.0 bash
root@99cd63fd5466:/# ls -l /opt/cni/bin/
total 50652
-rwxr-xr-x 1 root root   4246019 Aug 26  2020 bandwidth
-rwxr-xr-x 1 root root   3745368 Aug 26  2020 host-local
-rwxr-xr-x 1 root root   3566204 Aug 26  2020 loopback
-rwxr-xr-x 1 root root   3979034 Aug 26  2020 portmap
-rwxr-xr-x 1  502 staff 36322924 May 18 21:58 whereabouts
```

(502 is my UID on my work laptop, and I am the one who created & uploaded the archives)

After:
```
abas-a01:base abas$ docker run -ti antrea/base-ubuntu:2.14.0 bash
root@1078e02c805e:/# ls -l /opt/cni/bin/
total 50652
-rwxr-xr-x 1 root root  4246019 Aug 26  2020 bandwidth
-rwxr-xr-x 1 root root  3745368 Aug 26  2020 host-local
-rwxr-xr-x 1 root root  3566204 Aug 26  2020 loopback
-rwxr-xr-x 1 root root  3979034 Aug 26  2020 portmap
-rwxr-xr-x 1 root root 36322924 May 18 21:58 whereabouts
```