### PR TITLE
Add validating webhooks for Egress and ExternalIPPool

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -4539,6 +4539,49 @@ webhooks:
     scope: Cluster
   sideEffects: None
   timeoutSeconds: 5
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: antrea
+      namespace: kube-system
+      path: /validate/externalippool
+  name: externalippoolvalidator.antrea.io
+  rules:
+  - apiGroups:
+    - crd.antrea.io
+    apiVersions:
+    - v1alpha2
+    operations:
+    - UPDATE
+    resources:
+    - externalippools
+    scope: Cluster
+  sideEffects: None
+  timeoutSeconds: 5
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: antrea
+      namespace: kube-system
+      path: /validate/egress
+  name: egressvalidator.antrea.io
+  rules:
+  - apiGroups:
+    - crd.antrea.io
+    apiVersions:
+    - v1alpha2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - egresses
+    scope: Cluster
+  sideEffects: None
+  timeoutSeconds: 5
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -4541,6 +4541,49 @@ webhooks:
     scope: Cluster
   sideEffects: None
   timeoutSeconds: 5
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: antrea
+      namespace: kube-system
+      path: /validate/externalippool
+  name: externalippoolvalidator.antrea.io
+  rules:
+  - apiGroups:
+    - crd.antrea.io
+    apiVersions:
+    - v1alpha2
+    operations:
+    - UPDATE
+    resources:
+    - externalippools
+    scope: Cluster
+  sideEffects: None
+  timeoutSeconds: 5
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: antrea
+      namespace: kube-system
+      path: /validate/egress
+  name: egressvalidator.antrea.io
+  rules:
+  - apiGroups:
+    - crd.antrea.io
+    apiVersions:
+    - v1alpha2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - egresses
+    scope: Cluster
+  sideEffects: None
+  timeoutSeconds: 5
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -4539,6 +4539,49 @@ webhooks:
     scope: Cluster
   sideEffects: None
   timeoutSeconds: 5
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: antrea
+      namespace: kube-system
+      path: /validate/externalippool
+  name: externalippoolvalidator.antrea.io
+  rules:
+  - apiGroups:
+    - crd.antrea.io
+    apiVersions:
+    - v1alpha2
+    operations:
+    - UPDATE
+    resources:
+    - externalippools
+    scope: Cluster
+  sideEffects: None
+  timeoutSeconds: 5
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: antrea
+      namespace: kube-system
+      path: /validate/egress
+  name: egressvalidator.antrea.io
+  rules:
+  - apiGroups:
+    - crd.antrea.io
+    apiVersions:
+    - v1alpha2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - egresses
+    scope: Cluster
+  sideEffects: None
+  timeoutSeconds: 5
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -4588,6 +4588,49 @@ webhooks:
     scope: Cluster
   sideEffects: None
   timeoutSeconds: 5
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: antrea
+      namespace: kube-system
+      path: /validate/externalippool
+  name: externalippoolvalidator.antrea.io
+  rules:
+  - apiGroups:
+    - crd.antrea.io
+    apiVersions:
+    - v1alpha2
+    operations:
+    - UPDATE
+    resources:
+    - externalippools
+    scope: Cluster
+  sideEffects: None
+  timeoutSeconds: 5
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: antrea
+      namespace: kube-system
+      path: /validate/egress
+  name: egressvalidator.antrea.io
+  rules:
+  - apiGroups:
+    - crd.antrea.io
+    apiVersions:
+    - v1alpha2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - egresses
+    scope: Cluster
+  sideEffects: None
+  timeoutSeconds: 5
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -4544,6 +4544,49 @@ webhooks:
     scope: Cluster
   sideEffects: None
   timeoutSeconds: 5
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: antrea
+      namespace: kube-system
+      path: /validate/externalippool
+  name: externalippoolvalidator.antrea.io
+  rules:
+  - apiGroups:
+    - crd.antrea.io
+    apiVersions:
+    - v1alpha2
+    operations:
+    - UPDATE
+    resources:
+    - externalippools
+    scope: Cluster
+  sideEffects: None
+  timeoutSeconds: 5
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: antrea
+      namespace: kube-system
+      path: /validate/egress
+  name: egressvalidator.antrea.io
+  rules:
+  - apiGroups:
+    - crd.antrea.io
+    apiVersions:
+    - v1alpha2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - egresses
+    scope: Cluster
+  sideEffects: None
+  timeoutSeconds: 5
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/build/yamls/base/controller.yml
+++ b/build/yamls/base/controller.yml
@@ -138,6 +138,36 @@ webhooks:
     admissionReviewVersions: ["v1", "v1beta1"]
     sideEffects: None
     timeoutSeconds: 5
+  - name: "externalippoolvalidator.antrea.io"
+    clientConfig:
+      service:
+        name: "antrea"
+        namespace: "kube-system"
+        path: "/validate/externalippool"
+    rules:
+      - operations: ["UPDATE"]
+        apiGroups: ["crd.antrea.io"]
+        apiVersions: ["v1alpha2"]
+        resources: ["externalippools"]
+        scope: "Cluster"
+    admissionReviewVersions: ["v1", "v1beta1"]
+    sideEffects: None
+    timeoutSeconds: 5
+  - name: "egressvalidator.antrea.io"
+    clientConfig:
+      service:
+        name: "antrea"
+        namespace: "kube-system"
+        path: "/validate/egress"
+    rules:
+      - operations: ["CREATE", "UPDATE"]
+        apiGroups: ["crd.antrea.io"]
+        apiVersions: ["v1alpha2"]
+        resources: ["egresses"]
+        scope: "Cluster"
+    admissionReviewVersions: ["v1", "v1beta1"]
+    sideEffects: None
+    timeoutSeconds: 5
 ---
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService

--- a/cmd/antrea-controller/controller.go
+++ b/cmd/antrea-controller/controller.go
@@ -89,6 +89,8 @@ var allowedPaths = []string{
 	"/validate/acnp",
 	"/validate/anp",
 	"/validate/clustergroup",
+	"/validate/externalippool",
+	"/validate/egress",
 	"/convert/clustergroup",
 }
 
@@ -274,6 +276,7 @@ func run(o *Options) error {
 		endpointQuerier,
 		networkPolicyController,
 		networkPolicyStatusController,
+		egressController,
 		statsAggregator,
 		o.config.EnablePrometheusMetrics,
 		cipherSuites,
@@ -364,6 +367,7 @@ func createAPIServerConfig(kubeconfig string,
 	endpointQuerier networkpolicy.EndpointQuerier,
 	npController *networkpolicy.NetworkPolicyController,
 	networkPolicyStatusController *networkpolicy.StatusController,
+	egressController *egress.EgressController,
 	statsAggregator *stats.Aggregator,
 	enableMetrics bool,
 	cipherSuites []uint16,
@@ -424,5 +428,6 @@ func createAPIServerConfig(kubeconfig string,
 		controllerQuerier,
 		networkPolicyStatusController,
 		endpointQuerier,
-		npController), nil
+		npController,
+		egressController), nil
 }

--- a/pkg/controller/egress/controller_test.go
+++ b/pkg/controller/egress/controller_test.go
@@ -62,6 +62,21 @@ var (
 	eipFoo2 = newExternalIPPool("pool2", "", "2.2.2.10", "2.2.2.20")
 )
 
+func newEgress(name, egressIP, externalIPPool string, podSelector, namespaceSelector *metav1.LabelSelector) *v1alpha2.Egress {
+	egress := &v1alpha2.Egress{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: v1alpha2.EgressSpec{
+			AppliedTo: corev1a2.AppliedTo{
+				PodSelector:       podSelector,
+				NamespaceSelector: namespaceSelector,
+			},
+			EgressIP:       egressIP,
+			ExternalIPPool: externalIPPool,
+		},
+	}
+	return egress
+}
+
 func newExternalIPPool(name, cidr, start, end string) *v1alpha2.ExternalIPPool {
 	pool := &v1alpha2.ExternalIPPool{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/egress/ipallocator/allocator_test.go
+++ b/pkg/controller/egress/ipallocator/allocator_test.go
@@ -175,6 +175,33 @@ func TestAllocateRelease(t *testing.T) {
 	}
 }
 
+func TestHas(t *testing.T) {
+	tests := []struct {
+		name        string
+		ipAllocator IPAllocator
+		ip          net.IP
+		expectedHas bool
+	}{
+		{
+			name:        "IPv4-single",
+			ipAllocator: newCIDRAllocator("10.10.10.0/24"),
+			ip:          net.ParseIP("10.10.10.0"),
+			expectedHas: false,
+		},
+		{
+			name:        "IPv4-multiple",
+			ipAllocator: MultiIPAllocator{newIPRangeAllocator("1.1.1.10", "1.1.1.20"), newCIDRAllocator("10.10.10.128/30")},
+			ip:          net.ParseIP("10.10.10.130"),
+			expectedHas: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expectedHas, tt.ipAllocator.Has(tt.ip))
+		})
+	}
+}
+
 func TestName(t *testing.T) {
 	ma := MultiIPAllocator{newIPRangeAllocator("1.1.1.10", "1.1.1.20"), newCIDRAllocator("10.10.10.128/30")}
 	assert.Equal(t, []string{"1.1.1.10-1.1.1.20", "10.10.10.128/30"}, ma.Names())

--- a/pkg/controller/egress/validate.go
+++ b/pkg/controller/egress/validate.go
@@ -1,0 +1,168 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package egress
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+
+	admv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
+
+	crdv1alpha2 "antrea.io/antrea/pkg/apis/crd/v1alpha2"
+)
+
+func (c *EgressController) ValidateExternalIPPool(review *admv1.AdmissionReview) *admv1.AdmissionResponse {
+	var result *metav1.Status
+	var msg string
+	allowed := true
+
+	klog.V(2).Info("Validating ExternalIPPool", "request", review.Request)
+	var newObj, oldObj crdv1alpha2.ExternalIPPool
+	if review.Request.Object.Raw != nil {
+		if err := json.Unmarshal(review.Request.Object.Raw, &newObj); err != nil {
+			klog.ErrorS(err, "Error de-serializing current ExternalIPPool")
+			return newAdmissionResponseForErr(err)
+		}
+	}
+	if review.Request.OldObject.Raw != nil {
+		if err := json.Unmarshal(review.Request.OldObject.Raw, &oldObj); err != nil {
+			klog.ErrorS(err, "Error de-serializing old ExternalIPPool")
+			return newAdmissionResponseForErr(err)
+		}
+	}
+
+	switch review.Request.Operation {
+	case admv1.Create:
+		// This shouldn't happen with the webhook configuration we include in the Antrea YAML manifests.
+		klog.V(2).Info("Validating CREATE request for ExternalIPPool")
+		// Always allow CREATE request.
+	case admv1.Update:
+		klog.V(2).Info("Validating UPDATE request for ExternalIPPool")
+
+		oldIPRangeSet := getIPRangeSet(oldObj.Spec.IPRanges)
+		newIPRangeSet := getIPRangeSet(newObj.Spec.IPRanges)
+		deletedIPRanges := oldIPRangeSet.Difference(newIPRangeSet)
+		if deletedIPRanges.Len() > 0 {
+			allowed = false
+			msg = fmt.Sprintf("existing IPRanges %v cannot be deleted", deletedIPRanges.List())
+		}
+	case admv1.Delete:
+		// This shouldn't happen with the webhook configuration we include in the Antrea YAML manifests.
+		klog.V(2).Info("Validating DELETE request for ExternalIPPool")
+		// Always allow DELETE request.
+	}
+
+	if msg != "" {
+		result = &metav1.Status{
+			Message: msg,
+		}
+	}
+	return &admv1.AdmissionResponse{
+		Allowed: allowed,
+		Result:  result,
+	}
+}
+
+func (c *EgressController) ValidateEgress(review *admv1.AdmissionReview) *admv1.AdmissionResponse {
+	var result *metav1.Status
+	var msg string
+	allowed := true
+
+	klog.V(2).Info("Validating Egress", "request", review.Request)
+	var newObj, oldObj crdv1alpha2.Egress
+	if review.Request.Object.Raw != nil {
+		if err := json.Unmarshal(review.Request.Object.Raw, &newObj); err != nil {
+			klog.ErrorS(err, "Error de-serializing current Egress")
+			return newAdmissionResponseForErr(err)
+		}
+	}
+	if review.Request.OldObject.Raw != nil {
+		if err := json.Unmarshal(review.Request.OldObject.Raw, &oldObj); err != nil {
+			klog.ErrorS(err, "Error de-serializing old Egress")
+			return newAdmissionResponseForErr(err)
+		}
+	}
+
+	shouldAllow := func(oldEgress, newEgress *crdv1alpha2.Egress) (bool, string) {
+		// Allow it if EgressIP and ExternalIPPool don't change.
+		if newEgress.Spec.EgressIP == oldEgress.Spec.EgressIP && newEgress.Spec.ExternalIPPool == oldEgress.Spec.ExternalIPPool {
+			return true, ""
+		}
+		// Only validate whether the specified Egress IP is in the Pool when they are both set.
+		if newEgress.Spec.EgressIP == "" || newEgress.Spec.ExternalIPPool == "" {
+			return true, ""
+		}
+		ip := net.ParseIP(newEgress.Spec.EgressIP)
+		if ip == nil {
+			return false, fmt.Sprintf("IP %s is not valid", newEgress.Spec.EgressIP)
+		}
+		ipAllocator, exists := c.getIPAllocator(newEgress.Spec.ExternalIPPool)
+		// The ExternalIPPool doesn't exist, cannot determine whether the IP is in the pool.
+		if !exists {
+			return false, fmt.Sprintf("ExternalIPPool %s does not exist", newEgress.Spec.ExternalIPPool)
+		}
+		if !ipAllocator.Has(ip) {
+			return false, fmt.Sprintf("IP %s is not within the IP range", newEgress.Spec.EgressIP)
+		}
+		return true, ""
+	}
+
+	switch review.Request.Operation {
+	case admv1.Create:
+		klog.V(2).Info("Validating CREATE request for Egress")
+		allowed, msg = shouldAllow(&oldObj, &newObj)
+	case admv1.Update:
+		klog.V(2).Info("Validating UPDATE request for Egress")
+		allowed, msg = shouldAllow(&oldObj, &newObj)
+	case admv1.Delete:
+		// This shouldn't happen with the webhook configuration we include in the Antrea YAML manifests.
+		klog.V(2).Info("Validating DELETE request for Egress")
+		// Always allow DELETE request.
+	}
+
+	if msg != "" {
+		result = &metav1.Status{
+			Message: msg,
+		}
+	}
+	return &admv1.AdmissionResponse{
+		Allowed: allowed,
+		Result:  result,
+	}
+}
+
+func getIPRangeSet(ipRanges []crdv1alpha2.IPRange) sets.String {
+	set := sets.NewString()
+	for _, ipRange := range ipRanges {
+		ipRangeStr := ipRange.CIDR
+		if ipRangeStr == "" {
+			ipRangeStr = fmt.Sprintf("%s-%s", ipRange.Start, ipRange.End)
+		}
+		set.Insert(ipRangeStr)
+	}
+	return set
+}
+
+func newAdmissionResponseForErr(err error) *admv1.AdmissionResponse {
+	return &admv1.AdmissionResponse{
+		Result: &metav1.Status{
+			Message: err.Error(),
+		},
+	}
+}

--- a/pkg/controller/egress/validate_test.go
+++ b/pkg/controller/egress/validate_test.go
@@ -1,0 +1,206 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package egress
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	admv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	crdv1alpha2 "antrea.io/antrea/pkg/apis/crd/v1alpha2"
+)
+
+func marshal(object runtime.Object) []byte {
+	raw, _ := json.Marshal(object)
+	return raw
+}
+
+func TestEgressControllerValidateExternalIPPool(t *testing.T) {
+	tests := []struct {
+		name             string
+		request          *admv1.AdmissionRequest
+		expectedResponse *admv1.AdmissionResponse
+	}{
+		{
+			name: "CREATE operation should be allowed",
+			request: &admv1.AdmissionRequest{
+				Name:      "foo",
+				Operation: "CREATE",
+				Object:    runtime.RawExtension{Raw: marshal(newExternalIPPool("foo", "10.10.10.0/24", "", ""))},
+			},
+			expectedResponse: &admv1.AdmissionResponse{Allowed: true},
+		},
+		{
+			name: "Deleting IPRange should not be allowed",
+			request: &admv1.AdmissionRequest{
+				Name:      "foo",
+				Operation: "UPDATE",
+				OldObject: runtime.RawExtension{Raw: marshal(newExternalIPPool("foo", "10.10.10.0/24", "10.10.20.1", "10.10.20.2"))},
+				Object:    runtime.RawExtension{Raw: marshal(newExternalIPPool("foo", "10.10.10.0/24", "", ""))},
+			},
+			expectedResponse: &admv1.AdmissionResponse{
+				Allowed: false,
+				Result: &metav1.Status{
+					Message: "existing IPRanges [10.10.20.1-10.10.20.2] cannot be deleted",
+				},
+			},
+		},
+		{
+			name: "Adding IPRange should be allowed",
+			request: &admv1.AdmissionRequest{
+				Name:      "foo",
+				Operation: "UPDATE",
+				OldObject: runtime.RawExtension{Raw: marshal(newExternalIPPool("foo", "10.10.10.0/24", "", ""))},
+				Object:    runtime.RawExtension{Raw: marshal(newExternalIPPool("foo", "10.10.10.0/24", "10.10.20.1", "10.10.20.2"))},
+			},
+			expectedResponse: &admv1.AdmissionResponse{Allowed: true},
+		},
+		{
+			name: "DELETE operation should be allowed",
+			request: &admv1.AdmissionRequest{
+				Name:      "foo",
+				Operation: "DELETE",
+				Object:    runtime.RawExtension{Raw: marshal(newExternalIPPool("foo", "10.10.10.0/24", "", ""))},
+			},
+			expectedResponse: &admv1.AdmissionResponse{Allowed: true},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newController(nil, nil)
+			review := &admv1.AdmissionReview{
+				Request: tt.request,
+			}
+			gotResponse := c.ValidateExternalIPPool(review)
+			assert.Equal(t, tt.expectedResponse, gotResponse)
+		})
+	}
+}
+
+func TestEgressControllerValidateEgress(t *testing.T) {
+	tests := []struct {
+		name                   string
+		existingExternalIPPool *crdv1alpha2.ExternalIPPool
+		request                *admv1.AdmissionRequest
+		expectedResponse       *admv1.AdmissionResponse
+	}{
+		{
+			name:                   "Requesting IP from non-existing ExternalIPPool should not be allowed",
+			existingExternalIPPool: nil,
+			request: &admv1.AdmissionRequest{
+				Name:      "foo",
+				Operation: "CREATE",
+				Object:    runtime.RawExtension{Raw: marshal(newEgress("foo", "10.10.10.1", "nonExistingPool", nil, nil))},
+			},
+			expectedResponse: &admv1.AdmissionResponse{
+				Allowed: false,
+				Result: &metav1.Status{
+					Message: "ExternalIPPool nonExistingPool does not exist",
+				},
+			},
+		},
+		{
+			name:                   "Requesting IP out of range should not be allowed",
+			existingExternalIPPool: newExternalIPPool("bar", "10.10.10.0/24", "", ""),
+			request: &admv1.AdmissionRequest{
+				Name:      "foo",
+				Operation: "CREATE",
+				Object:    runtime.RawExtension{Raw: marshal(newEgress("foo", "10.10.11.1", "bar", nil, nil))},
+			},
+			expectedResponse: &admv1.AdmissionResponse{
+				Allowed: false,
+				Result: &metav1.Status{
+					Message: "IP 10.10.11.1 is not within the IP range",
+				},
+			},
+		},
+		{
+			name:                   "Requesting normal IP should be allowed",
+			existingExternalIPPool: newExternalIPPool("bar", "10.10.10.0/24", "", ""),
+			request: &admv1.AdmissionRequest{
+				Name:      "foo",
+				Operation: "CREATE",
+				Object:    runtime.RawExtension{Raw: marshal(newEgress("foo", "10.10.10.1", "bar", nil, nil))},
+			},
+			expectedResponse: &admv1.AdmissionResponse{Allowed: true},
+		},
+		{
+			name:                   "Updating EgressIP to invalid one should not be allowed",
+			existingExternalIPPool: newExternalIPPool("bar", "10.10.10.0/24", "", ""),
+			request: &admv1.AdmissionRequest{
+				Name:      "foo",
+				Operation: "UPDATE",
+				OldObject: runtime.RawExtension{Raw: marshal(newEgress("foo", "10.10.10.1", "bar", nil, nil))},
+				Object:    runtime.RawExtension{Raw: marshal(newEgress("foo", "10.10.11.1", "bar", nil, nil))},
+			},
+			expectedResponse: &admv1.AdmissionResponse{
+				Allowed: false,
+				Result: &metav1.Status{
+					Message: "IP 10.10.11.1 is not within the IP range",
+				},
+			},
+		},
+		{
+			name:                   "Updating EgressIP to valid one should be allowed",
+			existingExternalIPPool: newExternalIPPool("bar", "10.10.10.0/24", "", ""),
+			request: &admv1.AdmissionRequest{
+				Name:      "foo",
+				Operation: "UPDATE",
+				OldObject: runtime.RawExtension{Raw: marshal(newEgress("foo", "10.10.10.1", "bar", nil, nil))},
+				Object:    runtime.RawExtension{Raw: marshal(newEgress("foo", "10.10.10.2", "bar", nil, nil))},
+			},
+			expectedResponse: &admv1.AdmissionResponse{Allowed: true},
+		},
+		{
+			name:                   "Updating podSelector should be allowed",
+			existingExternalIPPool: newExternalIPPool("bar", "10.10.10.0/24", "", ""),
+			request: &admv1.AdmissionRequest{
+				Name:      "foo",
+				Operation: "UPDATE",
+				OldObject: runtime.RawExtension{Raw: marshal(newEgress("foo", "10.10.10.1", "bar", nil, nil))},
+				Object: runtime.RawExtension{Raw: marshal(newEgress("foo", "10.10.10.2", "bar", &metav1.LabelSelector{
+					MatchLabels: map[string]string{"foo": "bar"},
+				}, nil))},
+			},
+			expectedResponse: &admv1.AdmissionResponse{Allowed: true},
+		},
+		{
+			name: "DELETE operation should be allowed",
+			request: &admv1.AdmissionRequest{
+				Name:      "foo",
+				Operation: "DELETE",
+				Object:    runtime.RawExtension{Raw: marshal(newEgress("foo", "10.10.10.2", "bar", nil, nil))},
+			},
+			expectedResponse: &admv1.AdmissionResponse{Allowed: true},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newController(nil, nil)
+			if tt.existingExternalIPPool != nil {
+				c.createOrUpdateIPAllocator(tt.existingExternalIPPool)
+			}
+			review := &admv1.AdmissionReview{
+				Request: tt.request,
+			}
+			gotResponse := c.ValidateEgress(review)
+			assert.Equal(t, tt.expectedResponse, gotResponse)
+		})
+	}
+}


### PR DESCRIPTION
The webhook for Egress validates that the EgressIP must be within the IP
ranges of the ExternalIPPool if both are set.

The webhook for ExternalIPPool validates that the ExternalIPPool must
not shrink.

For #2128

Signed-off-by: Quan Tian <qtian@vmware.com>