### PR TITLE
Increase QPS limits for e2e tests

### DIFF
--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -800,6 +800,10 @@ func (data *TestData) createClient() error {
 	if err != nil {
 		return fmt.Errorf("error when building kube config: %v", err)
 	}
+
+	kubeConfig.QPS = 20
+	kubeConfig.Burst = 50
+
 	clientset, err := kubernetes.NewForConfig(kubeConfig)
 	if err != nil {
 		return fmt.Errorf("error when creating kubernetes client: %v", err)


### PR DESCRIPTION
Override default QPS and Burst for the client in e2e tests to align with K8s e2e tests and reduce client-side throttling (#2217)

Signed-off-by: Kaushik Devireddy <kdev@ucla.edu>