### PR TITLE
Support configurable interfaces for Pod traffic across Node

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -3805,6 +3805,11 @@ data:
 
     # TLS min version from: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.
     #tlsMinVersion:
+
+    # The name of the interface on Node which is used for tunneling or routing the traffic across Nodes.
+    # If there are multiple IP addresses configured on the interface, the first one is used.
+    # The interface configured with Node IP is used if this parameter is not set.
+    #transportInterface:
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -3887,7 +3892,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-tgm22b6g5t
+  name: antrea-config-gdgb98gmfd
   namespace: kube-system
 ---
 apiVersion: v1
@@ -3958,7 +3963,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-tgm22b6g5t
+          value: antrea-config-gdgb98gmfd
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4009,7 +4014,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-tgm22b6g5t
+          name: antrea-config-gdgb98gmfd
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4305,7 +4310,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-tgm22b6g5t
+          name: antrea-config-gdgb98gmfd
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -3805,6 +3805,11 @@ data:
 
     # TLS min version from: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.
     #tlsMinVersion:
+
+    # The name of the interface on Node which is used for tunneling or routing the traffic across Nodes.
+    # If there are multiple IP addresses configured on the interface, the first one is used.
+    # The interface configured with Node IP is used if this parameter is not set.
+    #transportInterface:
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -3887,7 +3892,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-tgm22b6g5t
+  name: antrea-config-gdgb98gmfd
   namespace: kube-system
 ---
 apiVersion: v1
@@ -3958,7 +3963,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-tgm22b6g5t
+          value: antrea-config-gdgb98gmfd
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4009,7 +4014,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-tgm22b6g5t
+          name: antrea-config-gdgb98gmfd
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4307,7 +4312,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-tgm22b6g5t
+          name: antrea-config-gdgb98gmfd
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -3805,6 +3805,11 @@ data:
 
     # TLS min version from: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.
     #tlsMinVersion:
+
+    # The name of the interface on Node which is used for tunneling or routing the traffic across Nodes.
+    # If there are multiple IP addresses configured on the interface, the first one is used.
+    # The interface configured with Node IP is used if this parameter is not set.
+    #transportInterface:
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -3887,7 +3892,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-246k7dkb5c
+  name: antrea-config-dc9bfdb7f6
   namespace: kube-system
 ---
 apiVersion: v1
@@ -3958,7 +3963,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-246k7dkb5c
+          value: antrea-config-dc9bfdb7f6
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4009,7 +4014,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-246k7dkb5c
+          name: antrea-config-dc9bfdb7f6
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4308,7 +4313,7 @@ spec:
           path: /home/kubernetes/bin
         name: host-cni-bin
       - configMap:
-          name: antrea-config-246k7dkb5c
+          name: antrea-config-dc9bfdb7f6
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -3810,6 +3810,11 @@ data:
 
     # TLS min version from: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.
     #tlsMinVersion:
+
+    # The name of the interface on Node which is used for tunneling or routing the traffic across Nodes.
+    # If there are multiple IP addresses configured on the interface, the first one is used.
+    # The interface configured with Node IP is used if this parameter is not set.
+    #transportInterface:
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -3892,7 +3897,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-5mt4h4g8tk
+  name: antrea-config-cccf8b2ggf
   namespace: kube-system
 ---
 apiVersion: v1
@@ -3972,7 +3977,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-5mt4h4g8tk
+          value: antrea-config-cccf8b2ggf
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4023,7 +4028,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-5mt4h4g8tk
+          name: antrea-config-cccf8b2ggf
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4354,7 +4359,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-5mt4h4g8tk
+          name: antrea-config-cccf8b2ggf
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-windows.yml
+++ b/build/yamls/antrea-windows.yml
@@ -96,6 +96,11 @@ data:
     # hybrid:            noEncap if source and destination Nodes are on the same subnet, otherwise encap.
     #
     #trafficEncapMode: encap
+
+    # The name of the interface on Node which is used for tunneling or routing the traffic across Nodes.
+    # If there are multiple IP addresses configured on the interface, the first one is used.
+    # The interface configured with Node IP is used if this parameter is not set.
+    #transportInterface:
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -114,7 +119,7 @@ kind: ConfigMap
 metadata:
   labels:
     app: antrea
-  name: antrea-windows-config-g5hmmkbh55
+  name: antrea-windows-config-74ctmgh7mf
   namespace: kube-system
 ---
 apiVersion: apps/v1
@@ -202,7 +207,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-windows-config-g5hmmkbh55
+          name: antrea-windows-config-74ctmgh7mf
         name: antrea-windows-config
       - configMap:
           defaultMode: 420

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -3810,6 +3810,11 @@ data:
 
     # TLS min version from: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.
     #tlsMinVersion:
+
+    # The name of the interface on Node which is used for tunneling or routing the traffic across Nodes.
+    # If there are multiple IP addresses configured on the interface, the first one is used.
+    # The interface configured with Node IP is used if this parameter is not set.
+    #transportInterface:
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -3892,7 +3897,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-2567tcm8ck
+  name: antrea-config-mdd77fmc97
   namespace: kube-system
 ---
 apiVersion: v1
@@ -3963,7 +3968,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-2567tcm8ck
+          value: antrea-config-mdd77fmc97
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4014,7 +4019,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-2567tcm8ck
+          name: antrea-config-mdd77fmc97
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4310,7 +4315,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-2567tcm8ck
+          name: antrea-config-mdd77fmc97
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/base/conf/antrea-agent.conf
+++ b/build/yamls/base/conf/antrea-agent.conf
@@ -147,3 +147,8 @@ featureGates:
 
 # TLS min version from: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.
 #tlsMinVersion:
+
+# The name of the interface on Node which is used for tunneling or routing the traffic across Nodes.
+# If there are multiple IP addresses configured on the interface, the first one is used.
+# The interface configured with Node IP is used if this parameter is not set.
+#transportInterface:

--- a/build/yamls/windows/base/conf/antrea-agent.conf
+++ b/build/yamls/windows/base/conf/antrea-agent.conf
@@ -78,3 +78,8 @@ featureGates:
 # hybrid:            noEncap if source and destination Nodes are on the same subnet, otherwise encap.
 #
 #trafficEncapMode: encap
+
+# The name of the interface on Node which is used for tunneling or routing the traffic across Nodes.
+# If there are multiple IP addresses configured on the interface, the first one is used.
+# The interface configured with Node IP is used if this parameter is not set.
+#transportInterface:

--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -117,7 +117,9 @@ func run(o *Options) error {
 	networkConfig := &config.NetworkConfig{
 		TunnelType:        ovsconfig.TunnelType(o.config.TunnelType),
 		TrafficEncapMode:  encapMode,
-		EnableIPSecTunnel: o.config.EnableIPSecTunnel}
+		EnableIPSecTunnel: o.config.EnableIPSecTunnel,
+		TransportIface:    o.config.TransportInterface,
+	}
 
 	routeClient, err := route.NewClient(serviceCIDRNet, networkConfig, o.config.NoSNAT)
 	if err != nil {

--- a/cmd/antrea-agent/config.go
+++ b/cmd/antrea-agent/config.go
@@ -148,4 +148,8 @@ type AgentConfig struct {
 	TLSCipherSuites string `yaml:"tlsCipherSuites,omitempty"`
 	// TLS min version.
 	TLSMinVersion string `yaml:"tlsMinVersion,omitempty"`
+	// The name of the interface on Node which is used for tunneling or routing the traffic across Nodes.
+	// If there are multiple IP addresses configured on the interface, the first one is used.
+	// The interface configured with Node IP is used if this parameter is not set.
+	TransportInterface string `yaml:"transportInterface,omitempty"`
 }

--- a/docs/assets/windows_external_traffic.svg
+++ b/docs/assets/windows_external_traffic.svg
@@ -7,92 +7,49 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   sodipodi:docname="windows_external_traffic.svg"
-   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
-   id="svg2121"
-   version="1.1"
-   viewBox="0 0 166.26509 112.72071"
+   width="166.26509mm"
    height="112.72071mm"
-   width="166.26509mm">
+   viewBox="0 0 166.26509 112.72071"
+   version="1.1"
+   id="svg2121"
+   inkscape:version="1.0 (4035a4fb49, 2020-05-01)"
+   sodipodi:docname="windows_external_traffic.svg">
   <defs
      id="defs2115">
     <marker
-       inkscape:isstock="true"
-       style="overflow:visible"
-       id="marker3157"
-       refX="0"
-       refY="0"
-       orient="auto"
-       inkscape:stockid="Arrow1Lend">
-      <path
-         transform="matrix(-0.8,0,0,-0.8,-10,0)"
-         style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:1pt;stroke-opacity:1"
-         d="M 0,0 5,-5 -12.5,0 5,5 Z"
-         id="path3155" />
-    </marker>
-    <inkscape:path-effect
-       lpeversion="1"
-       is_visible="true"
-       id="path-effect3135"
-       effect="spiro" />
-    <inkscape:path-effect
-       lpeversion="1"
-       is_visible="true"
-       id="path-effect3131"
-       effect="spiro" />
-    <rect
-       id="rect3043"
-       height="4.8108516"
-       width="0"
-       y="221.56644"
-       x="29.399649" />
-    <marker
-       inkscape:stockid="Arrow1Mstart"
-       orient="auto"
-       refY="0"
-       refX="0"
-       id="Arrow1Mstart"
-       style="overflow:visible"
-       inkscape:isstock="true">
-      <path
-         id="path971"
-         d="M 0,0 5,-5 -12.5,0 5,5 Z"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         transform="matrix(0.4,0,0,0.4,4,0)" />
-    </marker>
-    <marker
-       inkscape:collect="always"
        inkscape:stockid="Arrow1Lend"
        orient="auto"
        refY="0"
        refX="0"
-       id="Arrow1Lend"
+       id="marker3157"
        style="overflow:visible"
        inkscape:isstock="true">
       <path
-         id="path968"
+         id="path3155"
          d="M 0,0 5,-5 -12.5,0 5,5 Z"
-         style="fill:#00ff00;fill-opacity:1;fill-rule:evenodd;stroke:#00ff00;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#0000ff;fill-opacity:1;fill-rule:evenodd;stroke:#0000ff;stroke-width:1pt;stroke-opacity:1"
          transform="matrix(-0.8,0,0,-0.8,-10,0)" />
     </marker>
-    <marker
-       inkscape:stockid="Arrow1Mend"
-       orient="auto"
-       refY="0"
-       refX="0"
-       id="Arrow1Mend"
-       style="overflow:visible"
-       inkscape:isstock="true">
-      <path
-         id="path974"
-         d="M 0,0 5,-5 -12.5,0 5,5 Z"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
-         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
-    </marker>
+    <inkscape:path-effect
+       effect="spiro"
+       id="path-effect3135"
+       is_visible="true"
+       lpeversion="1" />
+    <inkscape:path-effect
+       effect="spiro"
+       id="path-effect3131"
+       is_visible="true"
+       lpeversion="1" />
+    <rect
+       x="29.399649"
+       y="221.56644"
+       width="0"
+       height="4.8108516"
+       id="rect3043" />
     <marker
        inkscape:isstock="true"
        style="overflow:visible"
-       id="Arrow1Mstart-6"
+       id="Arrow1Mstart"
        refX="0"
        refY="0"
        orient="auto"
@@ -101,26 +58,27 @@
          transform="matrix(0.4,0,0,0.4,4,0)"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
          d="M 0,0 5,-5 -12.5,0 5,5 Z"
-         id="path971-7" />
+         id="path971" />
     </marker>
     <marker
        inkscape:isstock="true"
        style="overflow:visible"
-       id="Arrow1Lend-2"
+       id="Arrow1Lend"
        refX="0"
        refY="0"
        orient="auto"
-       inkscape:stockid="Arrow1Lend">
+       inkscape:stockid="Arrow1Lend"
+       inkscape:collect="always">
       <path
          transform="matrix(-0.8,0,0,-0.8,-10,0)"
-         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         style="fill:#00ff00;fill-opacity:1;fill-rule:evenodd;stroke:#00ff00;stroke-width:1pt;stroke-opacity:1"
          d="M 0,0 5,-5 -12.5,0 5,5 Z"
-         id="path968-2" />
+         id="path968" />
     </marker>
     <marker
        inkscape:isstock="true"
        style="overflow:visible"
-       id="Arrow1Mend-0"
+       id="Arrow1Mend"
        refX="0"
        refY="0"
        orient="auto"
@@ -129,33 +87,75 @@
          transform="matrix(-0.4,0,0,-0.4,-4,0)"
          style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
          d="M 0,0 5,-5 -12.5,0 5,5 Z"
-         id="path974-5" />
+         id="path974" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Mstart-6"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path971-7"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(0.4,0,0,0.4,4,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Lend-2"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path968-2"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.8,0,0,-0.8,-10,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow1Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow1Mend-0"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         id="path974-5"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1pt;stroke-opacity:1"
+         transform="matrix(-0.4,0,0,-0.4,-4,0)" />
     </marker>
   </defs>
   <sodipodi:namedview
-     fit-margin-bottom="0"
-     fit-margin-right="0"
-     fit-margin-left="0"
-     fit-margin-top="0"
-     inkscape:window-maximized="1"
-     inkscape:window-y="-8"
-     inkscape:window-x="-8"
-     inkscape:window-height="1002"
-     inkscape:window-width="1920"
-     inkscape:snap-midpoints="true"
-     showgrid="false"
-     inkscape:document-rotation="0"
-     inkscape:current-layer="layer1"
-     inkscape:document-units="mm"
-     inkscape:cy="197.78859"
-     inkscape:cx="392.05417"
-     inkscape:zoom="0.98994949"
-     inkscape:pageshadow="2"
-     inkscape:pageopacity="0.0"
-     borderopacity="1.0"
-     bordercolor="#666666"
+     id="base"
      pagecolor="#ffffff"
-     id="base" />
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.4"
+     inkscape:cx="499.11354"
+     inkscape:cy="120.21624"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     inkscape:snap-midpoints="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1002"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0" />
   <metadata
      id="metadata2118">
     <rdf:RDF>
@@ -164,224 +164,222 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     transform="translate(-19.766225,-133.87746)"
-     id="layer1"
+     inkscape:label="图层 1"
      inkscape:groupmode="layer"
-     inkscape:label="图层 1">
+     id="layer1"
+     transform="translate(-19.766225,-133.87746)">
     <rect
-       style="fill:#000000;fill-opacity:0;fill-rule:evenodd;stroke:#000000;stroke-width:0.362;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="rect103"
-       width="30.735996"
-       height="25.657875"
-       x="110.24601"
+       inkscape:export-ydpi="25.219645"
+       inkscape:export-xdpi="25.219645"
+       inkscape:export-filename="C:\Users\wenyingd\hns_integration.png"
        y="158.04518"
-       inkscape:export-filename="C:\Users\wenyingd\hns_integration.png"
-       inkscape:export-xdpi="25.219645"
-       inkscape:export-ydpi="25.219645" />
+       x="110.24601"
+       height="25.657875"
+       width="30.735996"
+       id="rect103"
+       style="fill:#000000;fill-opacity:0;fill-rule:evenodd;stroke:#000000;stroke-width:0.362;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <text
-       xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:4.9389px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264999;stroke-miterlimit:4;stroke-dasharray:none"
-       x="117.19498"
-       y="167.13234"
+       inkscape:export-ydpi="25.219645"
+       inkscape:export-xdpi="25.219645"
+       inkscape:export-filename="C:\Users\wenyingd\hns_integration.png"
        id="text107"
-       inkscape:export-filename="C:\Users\wenyingd\hns_integration.png"
-       inkscape:export-xdpi="25.219645"
-       inkscape:export-ydpi="25.219645"><tspan
-         sodipodi:role="line"
-         id="tspan105"
-         x="117.19498"
+       y="167.13234"
+       x="117.19498"
+       style="font-style:normal;font-weight:normal;font-size:4.9389px;line-height:1.25;font-family:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.264999;stroke-miterlimit:4;stroke-dasharray:none"
+       xml:space="preserve"><tspan
+         style="font-size:4.9389px;fill:#000000;fill-opacity:1;stroke-width:0.264999;stroke-miterlimit:4;stroke-dasharray:none"
          y="167.13234"
-         style="font-size:4.9389px;fill:#000000;fill-opacity:1;stroke-width:0.264999;stroke-miterlimit:4;stroke-dasharray:none">Pod1</tspan></text>
+         x="117.19498"
+         id="tspan105"
+         sodipodi:role="line">Pod1</tspan></text>
     <rect
-       style="fill:#000000;fill-opacity:0;stroke:#000000;stroke-width:0.505678;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="rect1281"
-       width="7.4742641"
-       height="11.693162"
-       x="122.11729"
+       inkscape:export-ydpi="25.219645"
+       inkscape:export-xdpi="25.219645"
+       inkscape:export-filename="C:\Users\wenyingd\hns_integration.png"
        y="182.08705"
-       inkscape:export-filename="C:\Users\wenyingd\hns_integration.png"
-       inkscape:export-xdpi="25.219645"
-       inkscape:export-ydpi="25.219645" />
+       x="122.11729"
+       height="11.693162"
+       width="7.4742641"
+       id="rect1281"
+       style="fill:#000000;fill-opacity:0;stroke:#000000;stroke-width:0.505678;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <rect
-       style="fill:#000000;fill-opacity:0;stroke:#000000;stroke-width:0.30554;stroke-miterlimit:4;stroke-dasharray:1.22216, 0.30554;stroke-dashoffset:0;stroke-opacity:1"
-       id="rect1346"
-       width="123.08015"
-       height="12.027128"
-       x="50.778679"
+       inkscape:export-ydpi="25.219645"
+       inkscape:export-xdpi="25.219645"
+       inkscape:export-filename="C:\Users\wenyingd\hns_integration.png"
        y="189.0932"
-       inkscape:export-filename="C:\Users\wenyingd\hns_integration.png"
-       inkscape:export-xdpi="25.219645"
-       inkscape:export-ydpi="25.219645" />
+       x="50.778679"
+       height="12.027128"
+       width="123.08015"
+       id="rect1346"
+       style="fill:#000000;fill-opacity:0;stroke:#000000;stroke-width:0.30554;stroke-miterlimit:4;stroke-dasharray:1.22216, 0.30554;stroke-dashoffset:0;stroke-opacity:1" />
     <text
-       xml:space="preserve"
-       style="font-size:4.23333px;line-height:1.25;font-family:sans-serif;stroke-width:0.264583"
-       x="88.065315"
-       y="197.37854"
+       inkscape:export-ydpi="25.219645"
+       inkscape:export-xdpi="25.219645"
+       inkscape:export-filename="C:\Users\wenyingd\hns_integration.png"
        id="text1350"
-       inkscape:export-filename="C:\Users\wenyingd\hns_integration.png"
-       inkscape:export-xdpi="25.219645"
-       inkscape:export-ydpi="25.219645"><tspan
-         sodipodi:role="line"
-         id="tspan1348"
-         x="88.065315"
+       y="197.37854"
+       x="88.065315"
+       style="font-size:4.23333px;line-height:1.25;font-family:sans-serif;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
          y="197.37854"
-         style="stroke-width:0.264583">br-int</tspan></text>
+         x="88.065315"
+         id="tspan1348"
+         sodipodi:role="line">br-int</tspan></text>
     <rect
-       y="180.60585"
-       x="78.837807"
-       height="12.640779"
-       width="4.543582"
-       id="rect1352-3"
+       inkscape:export-ydpi="25.219645"
+       inkscape:export-xdpi="25.219645"
+       inkscape:export-filename="C:\Users\wenyingd\hns_integration.png"
        style="fill:#000000;fill-opacity:0;stroke:#000000;stroke-width:0.440731;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       inkscape:export-filename="C:\Users\wenyingd\hns_integration.png"
-       inkscape:export-xdpi="25.219645"
-       inkscape:export-ydpi="25.219645" />
-    <rect
-       y="198.04672"
-       x="159.55991"
-       height="7.2162771"
+       id="rect1352-3"
        width="4.543582"
-       id="rect1352-6"
+       height="12.640779"
+       x="78.837807"
+       y="180.60585" />
+    <rect
+       inkscape:export-ydpi="25.219645"
+       inkscape:export-xdpi="25.219645"
+       inkscape:export-filename="C:\Users\wenyingd\hns_integration.png"
        style="fill:#000000;fill-opacity:0;stroke:#000000;stroke-width:0.332999;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       inkscape:export-filename="C:\Users\wenyingd\hns_integration.png"
-       inkscape:export-xdpi="25.219645"
-       inkscape:export-ydpi="25.219645" />
+       id="rect1352-6"
+       width="4.543582"
+       height="7.2162771"
+       x="159.55991"
+       y="198.04672" />
     <rect
-       y="201.00549"
-       x="65.391762"
-       height="18.938536"
-       width="9.4302721"
-       id="rect1352-1"
+       inkscape:export-ydpi="25.219645"
+       inkscape:export-xdpi="25.219645"
+       inkscape:export-filename="C:\Users\wenyingd\hns_integration.png"
        style="fill:#000000;fill-opacity:0;stroke:#000000;stroke-width:0.273007;stroke-miterlimit:2.5;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       inkscape:export-filename="C:\Users\wenyingd\hns_integration.png"
-       inkscape:export-xdpi="25.219645"
-       inkscape:export-ydpi="25.219645" />
+       id="rect1352-1"
+       width="9.4302721"
+       height="18.938536"
+       x="65.391762"
+       y="201.00549" />
     <text
-       xml:space="preserve"
-       style="font-size:4.23333px;line-height:1.25;font-family:sans-serif;stroke-width:0.264583"
-       x="59.73473"
-       y="222.23462"
+       inkscape:export-ydpi="25.219645"
+       inkscape:export-xdpi="25.219645"
+       inkscape:export-filename="C:\Users\wenyingd\hns_integration.png"
        id="text1389"
-       inkscape:export-filename="C:\Users\wenyingd\hns_integration.png"
-       inkscape:export-xdpi="25.219645"
-       inkscape:export-ydpi="25.219645"><tspan
-         sodipodi:role="line"
-         id="tspan1387"
-         x="59.73473"
+       y="222.23462"
+       x="59.73473"
+       style="font-size:4.23333px;line-height:1.25;font-family:sans-serif;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
          y="222.23462"
-         style="stroke-width:0.264583">Ethernet0</tspan></text>
+         x="59.73473"
+         id="tspan1387"
+         sodipodi:role="line">Ethernet0</tspan></text>
     <text
-       xml:space="preserve"
-       style="font-size:4.23333px;line-height:1.25;font-family:sans-serif;stroke-width:0.264583"
-       x="157.44324"
-       y="208.96716"
+       inkscape:export-ydpi="25.219645"
+       inkscape:export-xdpi="25.219645"
+       inkscape:export-filename="C:\Users\wenyingd\hns_integration.png"
        id="text1393"
-       inkscape:export-filename="C:\Users\wenyingd\hns_integration.png"
-       inkscape:export-xdpi="25.219645"
-       inkscape:export-ydpi="25.219645"><tspan
-         sodipodi:role="line"
-         id="tspan1391"
-         x="157.44324"
+       y="208.96716"
+       x="157.44324"
+       style="font-size:4.23333px;line-height:1.25;font-family:sans-serif;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
          y="208.96716"
-         style="stroke-width:0.264583">tun0</tspan><tspan
-         sodipodi:role="line"
          x="157.44324"
+         id="tspan1391"
+         sodipodi:role="line">tun0</tspan><tspan
+         id="tspan1395"
+         style="stroke-width:0.264583"
          y="214.25882"
-         style="stroke-width:0.264583"
-         id="tspan1395" /><tspan
-         sodipodi:role="line"
          x="157.44324"
+         sodipodi:role="line" /><tspan
+         id="tspan1397"
+         style="stroke-width:0.264583"
          y="219.55049"
-         style="stroke-width:0.264583"
-         id="tspan1397" /></text>
+         x="157.44324"
+         sodipodi:role="line" /></text>
     <text
-       transform="scale(1.0350506,0.96613634)"
-       xml:space="preserve"
-       style="font-size:4.08997px;line-height:1.25;font-family:sans-serif;stroke-width:0.255623"
-       x="77.996323"
-       y="185.28487"
+       inkscape:export-ydpi="25.219645"
+       inkscape:export-xdpi="25.219645"
+       inkscape:export-filename="C:\Users\wenyingd\hns_integration.png"
        id="text1401"
-       inkscape:export-filename="C:\Users\wenyingd\hns_integration.png"
-       inkscape:export-xdpi="25.219645"
-       inkscape:export-ydpi="25.219645"><tspan
-         sodipodi:role="line"
+       y="192.95287"
+       x="69.816391"
+       style="font-size:4.08997px;line-height:1.25;font-family:sans-serif;stroke-width:0.255623"
+       xml:space="preserve"
+       transform="scale(1.0350506,0.96613634)"><tspan
+         style="stroke-width:0.255623"
+         y="192.95287"
+         x="69.816391"
          id="tspan1399"
-         x="77.996323"
-         y="185.28487"
-         style="stroke-width:0.255623">gw0</tspan></text>
+         sodipodi:role="line">antrea-gw0</tspan></text>
     <rect
-       ry="0"
-       style="fill:#000000;fill-opacity:0;stroke:#000000;stroke-width:0.283433;stroke-miterlimit:2.5;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="rect1833"
-       width="165.98166"
-       height="79.933693"
-       x="19.907942"
-       y="134.01918"
-       inkscape:export-filename="C:\Users\wenyingd\hns_integration.png"
+       inkscape:export-ydpi="25.219645"
        inkscape:export-xdpi="25.219645"
-       inkscape:export-ydpi="25.219645" />
+       inkscape:export-filename="C:\Users\wenyingd\hns_integration.png"
+       y="134.01918"
+       x="19.907942"
+       height="79.933693"
+       width="165.98166"
+       id="rect1833"
+       style="fill:#000000;fill-opacity:0;stroke:#000000;stroke-width:0.283433;stroke-miterlimit:2.5;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       ry="0" />
+    <text
+       inkscape:export-ydpi="25.219645"
+       inkscape:export-xdpi="25.219645"
+       inkscape:export-filename="C:\Users\wenyingd\hns_integration.png"
+       id="text1837"
+       y="139.89949"
+       x="65.742256"
+       style="font-size:4.23333px;line-height:1.25;font-family:sans-serif;stroke-width:0.264583"
+       xml:space="preserve"><tspan
+         style="stroke-width:0.264583"
+         y="139.89949"
+         x="65.742256"
+         id="tspan1835"
+         sodipodi:role="line">Windows Node</tspan></text>
+    <path
+       style="fill:none;stroke:#00ff00;stroke-width:0.265;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend)"
+       d="m 125.92315,176.6683 c 0,0 -6.36635,15.77278 -12.99094,15.94064 -23.088656,0.58503 -10.75957,1.08283 -25.725206,1.10737 -9.448735,0.0155 -0.553329,-19.28115 -9.431574,-19.45658 -11.92804,-4.96603 -30.062244,16.09031 -16.456744,21.06844 9.993498,2.07329 9.500319,27.25148 1.489652,34.7909 l -7.750816,6.41446 c -2.471789,2.04562 -18.174328,4.00904 -18.174328,4.00904"
+       id="path2342"
+       sodipodi:nodetypes="csscccsc" />
     <text
        xml:space="preserve"
        style="font-size:4.23333px;line-height:1.25;font-family:sans-serif;stroke-width:0.264583"
-       x="65.742256"
-       y="139.89949"
-       id="text1837"
-       inkscape:export-filename="C:\Users\wenyingd\hns_integration.png"
-       inkscape:export-xdpi="25.219645"
-       inkscape:export-ydpi="25.219645"><tspan
-         sodipodi:role="line"
-         id="tspan1835"
-         x="65.742256"
-         y="139.89949"
-         style="stroke-width:0.264583">Windows Node</tspan></text>
-    <path
-       sodipodi:nodetypes="cssssssssc"
-       id="path2342"
-       d="m 125.92315,176.6683 c 0,0 -1.26367,17.28468 -7.88826,17.45254 -23.088657,0.58503 -18.886055,0.70486 -33.851696,0.7294 -9.448735,0.0155 2.470481,-20.41508 -6.407764,-20.59051 -9.37405,-0.18522 -20.136817,-0.0375 -27.528759,3.4745 -6.807143,3.2342 -7.149117,14.66478 -0.267271,16.83799 10.156243,3.20723 12.538603,1.30569 14.699825,2.93996 5.326588,4.02785 5.61152,26.41456 -1.870887,32.60689 l -7.750816,6.41446 c -2.471789,2.04562 -18.174328,4.00904 -18.174328,4.00904"
-       style="fill:none;stroke:#00ff00;stroke-width:0.265;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow1Lend)" />
-    <text
-       id="text3039"
-       y="243.76962"
        x="24.054256"
-       style="font-size:4.23333px;line-height:1.25;font-family:sans-serif;stroke-width:0.264583"
-       xml:space="preserve"><tspan
-         style="stroke-width:0.264583"
-         y="243.76962"
-         x="24.054256"
+       y="243.76962"
+       id="text3039"><tspan
+         sodipodi:role="line"
          id="tspan3037"
-         sodipodi:role="line">8.8.8.8</tspan></text>
+         x="24.054256"
+         y="243.76962"
+         style="stroke-width:0.264583">8.8.8.8</tspan></text>
     <text
-       style="font-size:4.23333px;line-height:1.25;font-family:sans-serif;white-space:pre;shape-inside:url(#rect3043);"
+       xml:space="preserve"
        id="text3041"
-       xml:space="preserve" />
+       style="font-size:4.23333px;line-height:1.25;font-family:sans-serif;white-space:pre;shape-inside:url(#rect3043);" />
     <text
-       id="text3121"
-       y="173.7467"
-       x="34.852478"
+       xml:space="preserve"
        style="font-size:4.23333px;line-height:1.25;font-family:sans-serif;stroke-width:0.264583"
-       xml:space="preserve"><tspan
-         style="stroke-width:0.264583"
-         y="173.7467"
-         x="34.852478"
+       x="42.487602"
+       y="179.71872"
+       id="text3121"><tspan
+         sodipodi:role="line"
          id="tspan3119"
-         sodipodi:role="line">Host IP Forwarding</tspan></text>
+         x="42.487602"
+         y="179.71872"
+         style="stroke-width:0.264583">Windows NAT</tspan></text>
     <path
-       sodipodi:nodetypes="csssc"
-       inkscape:original-d="m 37.142705,242.44055 c 11.851099,-0.42347 27.176988,-19.40571 34.483252,-26.43957 8.334262,-8.02353 -2.29147,-27.28959 2.138577,-15.37253 13.123151,35.30195 7.575107,-3.99636 25.127248,-2.16909 13.431168,1.39826 31.543078,-15.50757 35.285188,-22.88039"
-       inkscape:path-effect="#path-effect3131"
+       style="fill:none;stroke:#0000ff;stroke-width:0.255041px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker3157)"
+       d="m 37.14392,242.44242 c 8.008215,2.61202 17.272585,0.97247 23.89797,-4.2293 6.625384,-5.20177 12.495388,-21.37198 11.858316,-29.77128 -0.612873,-8.08026 -9.335115,-11.93384 -9.877937,-20.01911 -0.271412,-4.04263 2.023109,-6.03658 2.023109,-6.03658 4.553813,-3.07632 9.956241,-2.80721 13.792429,-1.7803 4.543579,6.32039 -0.598736,7.86559 2.271789,12.64078 2.836089,4.12956 10.945713,2.46995 15.721551,3.98259 12.579803,-0.92928 21.506373,-1.9371 28.980643,-7.78368 2.26786,-4.33468 3.49256,-11.38823 2.94618,-16.36801"
        id="path3129"
-       d="m 37.142705,242.44055 c 8.05983,1.86641 16.913489,-0.0511 23.478861,-5.085 6.565372,-5.03391 10.715025,-13.08652 11.004391,-21.35457 0.09216,-2.63328 -0.185546,-5.27005 -0.07195,-7.90249 0.113596,-2.63244 0.659972,-5.33968 2.210526,-7.47004 1.310206,-1.80014 3.269265,-3.07028 5.382465,-3.77136 2.1132,-0.70108 4.377439,-0.85991 6.599222,-0.71566 4.443565,0.2885 8.728388,1.75482 13.145561,2.31793 7.558598,0.96358 15.438768,-0.8337 21.832058,-4.97938 6.39329,-4.14568 11.24913,-10.60696 13.45313,-17.90101"
-       style="fill:none;stroke:#0000ff;stroke-width:0.258067px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker-end:url(#marker3157)" />
+       sodipodi:nodetypes="csszcccccc" />
     <path
-       inkscape:original-d="m 134.1693,175.59608 c 2.6e-4,2.6e-4 2.6e-4,2.6e-4 0,0 z"
-       inkscape:path-effect="#path-effect3135"
-       id="path3133"
+       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        d="M 134.1693,175.59608 Z"
-       style="fill:none;stroke:#000000;stroke-width:0.264583px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+       id="path3133"
+       inkscape:path-effect="#path-effect3135"
+       inkscape:original-d="m 134.1693,175.59608 c 2.6e-4,2.6e-4 2.6e-4,2.6e-4 0,0 z" />
   </g>
 </svg>

--- a/docs/design/windows-design.md
+++ b/docs/design/windows-design.md
@@ -108,93 +108,73 @@ The packets that are sent to/from the Windows host should be forwarded on this i
 is also a valid entry point into the OVS pipeline. A special ofport number 65534 (named as LOCAL) for the
 OVS bridge is used in OpenFlow spec.
 
-In the OVS `Classifier` table, new OpenFlow entries are needed to match the packets from this interface.
-There are two kinds of packets entering OVS pipeline from this interface:
-
- 1) the packet is sent from the Windows host to an external address
- 2) the packet is forwarded from the Windows host to the local Pod (e.g., this happens if the traffic is initiated
-  from a Pod to a NodePort Service, and the chosen Node is where the Pod is located)
-
-For 1, the packet is always output to the uplink interface directly. For 2, the packet is injected into
-the OVS pipeline and output to the backend Pod finally.
+In the OVS `Classifier` table, new OpenFlow entries are needed to match the packets from this interface. The
+packet entering OVS from this interface is output to the uplink interface directly.
 
 ### OVS uplink interface configuration
 
 After the OVS bridge is created, the original physical adapter is added to the OVS bridge as the uplink interface.
-The uplink interface is used to support traffic from Pods accessing external addresses. The packet is always
-output to the uplink interface if it is sent to an external address and is entering OVS from the bridge
-interface.
+The uplink interface is used to support traffic from Pods accessing the world outside current host.
 
 We should differentiate the traffic if it is entering OVS from the uplink interface in OVS `Classifier`
-table. There are two kinds of packets entering the OVS bridge from the uplink interface:
+table. In encap mode, the packets entering OVS from the uplink interface is output to the bridge interface directly.
+In noEncap mode, there are three kinds of packets entering OVS from the uplink interface:
 
- 1) reply traffic for the traffic that is sent from local Pods to external addresses,
- 2) traffic on the host network
+ 1) traffic that is sent to local Pods from Pod on a different Node,
+ 2) traffic that is sent to local Pods from a different Node according to the routing configuration,
+ 3) traffic on the host network
 
-For 1, the packets should enter the OVS pipeline and be re-written using SNAT information in connection tracking
-context first, and then processed by the OVS pipeline.
-For 2, the packets are output to the OVS bridge interface directly.
+For 1 and 2, the packet enters the OVS pipeline, and the `macRewriteMark` is set to ensure the destination MAC can be
+modified.
+For 3, the packet is output to the OVS bridge interface directly.
+
+The packet is always output to the uplink interface if it is entering OVS from the bridge interface. We
+also output the Pod traffic to the uplink interface in noEncap mode, if the destination is a Pod on a different Node,
+or if it is a reply packet to the request which is sent from a different Node. Then we can reduce the cost that the
+packet enters OVS twice (OVS -> Windows host -> OVS).
+
+Following are the OpenFlow entries for uplink interface in encap mode.
+
+```text
+Classifier Table: 0
+table=0, priority=200, in_port=$uplink actions=LOCAL
+table=0, priority=200, in_port=LOCAL actions=output:$uplink
+```
+
+Following is an example for the OpenFlow entries related with uplink interface in noEncap mode.
+
+```text
+Classifier Table: 0
+table=0, priority=210, ip, in_port=$uplink, nw_dst=$localPodSubnet, actions=load:0x4->NXM_NX_REG0[0..15],load:0x
+1->NXM_NX_REG0[19],resubmit(,29)
+table=0, priority=200, in_port=$uplink actions=LOCAL
+table=0, priority=200, in_port=LOCAL actions=output:$uplink
+
+L3Forwarding Table: 70
+// Rewrite the destination MAC with the Node's MAC on which target Pod is located.
+table=70, priority=200,ip,nw_dst=$peerPodSubnet actions=mod_dl_dst:$peerNodeMAC,resubmit(,80)
+// Rewrite the destination MAC with the Node's MAC if it is a reply for the access from the Node.
+table=70, priority=200,ct_state=+rpl+trk,ip,nw_dst=$peerNodeIP actions=mod_dl_dst:$peerNodeMAC,resubmit(,80)
+
+L2ForwardingCalcTable: 80
+table=80, priority=200,dl_dst=$peerNodeMAC actions=load:$uplink->NXM_NX_REG1[],load:0x1->NXM_NX_REG0[16],resubmit(,105)
+```
 
 ### SNAT configuration
 
 SNAT is an important feature of the Antrea Agent on Windows Nodes, required to support Pods accessing external
-addresses. It is implemented using OpenFlow.
+addresses. It is implemented using the NAT capability of the Windows host.
 
-To support this feature, two additional marks are introduced:
-
-* The 17th bit of NXM Register0 is set for Pod-to-external traffic. This bit is set in the `L3Forwarding` table,
- and is consumed in the `ConntrackCommit` table.
-* The SNATed traffic is marked with **0x40** in the ct context. This mark is set in the `ConntrackCommit`
- table when committing the new connection into the ct zone, and is consumed in the `ConntrackState` table
- to identify SNAT relevant packets.
-
-The following changes in the OVS pipeline are needed:
-
-* Identify the packet that is sent from local Pod-to-external address and set the SNAT bit in the register
- in the `L3Forwarding` table. The packet should have these characteristics:
-  1) it enters the OVS pipeline from a local Pod;
-  2) the destination IP address is not in the cluster Pod CIDRs (Pod subnets of the local or any remote
-  Node), and is not the local Node's management IP;
-  3) the traffic is not for Services;
-  4) it is not the return traffic for a connection from an external IP to a local Pod.
-* Implement SNAT rules and commit the new connection to the ct context in the `ConntrackCommit` table. The SNAT
- rule should change the source address to the Node's internal IP.
-* Forward the IP packet to the `Conntrack` table if it is from the uplink interface in the `Uplink` table.
- This is to ensure the reply packets from the external address to the Pod will be "unSNAT'd".
-* Ensure that the packet is translated based on the NAT information provided when committing the connection by
- using the `nat` argument with the `ct` action.
-* Set the macRewrite bit in the register (reg0[19]) in the `ConntrackState` table if the packet is from the uplink
- interface and has the SNAT ct_mark.
-
-Following is an example for SNAT relevant OpenFlow entries.
+To support this feature, we configure NetNat on the Windows host for the Pod subnet:
 
 ```text
-Classifier Table: 0
-table=0, priority=200, in_port=$uplink,ip actions=load:0x4->NXM_NX_REG0[0..15],goto_table:5
-
-Uplink Table: 5
-table=5, priority=200, ip,reg0=0x4/0xffff actions=goto_table:30
-
-Conntrack Table: 30
-table=30, priority=200, ip actions=ct(table=31,zone=65520,nat)
-
-ConntrackState Table: 31
-table=31, priority=210, ct_state=-new+trk,ct_mark=0x40,ip,reg0=0x4/0xffff actions=load:0x1->NXM_NX_REG0[19],goto_table:40
-table=31, priority=200, ip,reg0=0x4/0xffff actions=output:br-int
-
-L3Forwarding Table: 70
-// Forward the packet to L2ForwardingCalculation table if it is traffic to the local Pods and doesn't require MAC rewriting.
-table=70, priority=200, ip,reg0=0/0x80000,nw_dst=10.10.0.0/24 actions=goto_table:80
-// Forward the packet to L2ForwardingCalculation table if it is Pod-to-Node traffic.
-table=70, priority=200, ip,reg0=0x2/0xffff,nw_dst=$local_nodeIP actions=goto_table:80
-// Forward the packet to L2ForwardingCalculation table if it is return traffic of an external-to-Pod connection.
-table=70, priority=210, ct_state=+rpl+trk,ct_mark=0x20,ip actions=mod_dl_dst:0e:6d:42:66:92:46,resubmit(,80)
-// Add SNAT mark if it is Pod-to-external traffic.
-table=70, priority=190, ct_state=+new+trk,ip,reg0=0x2/0xffff actions=load:0x1->NXM_NX_REG0[17], goto_table:80
-
-ConntrackCommit Table: 105
-table=105, priority=200, ct_state=+new+trk,ip,reg0=0x20000/0x20000, actions=ct(commit,table=110,zone=65520,nat(src=${nodeIP}:10000-20000),exec(load:0x40->NXM_NX_CT_MARK[])))
+New-NetNat -Name antrea-nat -InternalIPInterfaceAddressPrefix $localPodSubnet
 ```
+
+The packet that is sent from local Pod to an external address leaves OVS from `antrea-gw0` and enters Windows host,
+and SNAT action is performed. The SNATed address is chosen by Windows host according to the routing configuration.
+As for the reply packet of the Pod-to-external traffic, it enters Windows host and performs de-SNAT first, and then
+the packet enters OVS from `antrea-gw0` and is forwarded to the Pod finally.
 
 ### Using Windows named pipe for internal connections
 
@@ -235,25 +215,22 @@ to select the backend endpoint and performs DNAT on the traffic.
 
 ### External Traffic
 
-The Pod-to-external traffic is SNATed in OVS using the Node's internal IP first, and then it leaves
-the OVS pipeline on the gateway interface. As IP-Forwarding on the gateway interface is enabled, the packet
-is forwarded to the OVS bridge interface and enters OVS for the second time.
-When the packet enters OVS at the second time, the dMAC is changed to an appropriate value using the host
-network stack. And OVS outputs the packet to the uplink interface directly.
+The Pod-to-external traffic leaves the OVS pipeline from the gateway interface, and then is SNATed on the Windows
+host. If the packet should leave Windows host from OVS uplink interface according to the routing configuration on
+the Windows host, it is forwarded to OVS bridge first on which the host IP is configured, and then output to the
+uplink interface by OVS pipeline.
 
-The corresponding reply traffic will enter OVS on the uplink interface. It will access the ct zone, and
-the destination IP will be translated back to the original Pod's IP within the ct context. Then it will be
-output to the Pod.
-
+The corresponding reply traffic will enter OVS from the uplink interface first, and then enter the host from the
+OVS bridge interface. It is de-SNATed on the host and then back to OVS from `antre-gw0` and forwarded to the Pod
+finally.
 <img src="../assets/windows_external_traffic.svg" width="600" alt="Traffic to external">
 
 ### Host Traffic
 
-In "Transparent" mode, the Antrea Agent should also process the host traffic when necessary, which includes
+In "Transparent" mode, the Antrea Agent should also support the host traffic when necessary, which includes
 packets sent from the host to external addresses, and the ones sent from external addresses to the host.
 
-The host traffic case is similar to Pod-to-external traffic, as the destination IP is not in the cluster
-CIDR, but we can differentiate based on the source IP. If the packet is sent from the OVS bridge interface,
-and if it is destined to a local Pod, it is output to the uplink interface directly. Reply traffic goes through
-conntrack first, then through the rest of the OVS pipeline if the ct_mark is set. If the packet is not set, it
-is output to the Windows host on the OVS bridge interface.
+The host traffic enters OVS bridge and output to the uplink interface if the destination is reachable from the
+network adapter which is plugged on OVS as uplink. For the reverse path, the packet enters OVS from the uplink
+interface first, and then directly output to the bridge interface and enters Windows host. For the traffic that
+is connected to the Windows network adapters other than the OVS uplink interface, it is managed by Windows host.

--- a/pkg/agent/agent_linux.go
+++ b/pkg/agent/agent_linux.go
@@ -18,6 +18,8 @@ package agent
 
 import (
 	"net"
+
+	"antrea.io/antrea/pkg/agent/util"
 )
 
 // prepareHostNetwork returns immediately on Linux.
@@ -39,4 +41,8 @@ func (i *Initializer) initHostNetworkFlows() error {
 // On linux platform, local_ip option is not needed.
 func (i *Initializer) getTunnelPortLocalIP() net.IP {
 	return nil
+}
+
+func GetTransportIPNetDeviceByName(ifaceName string, ovsBridgeName string) (*net.IPNet, *net.Interface, error) {
+	return util.GetIPNetDeviceByName(ifaceName)
 }

--- a/pkg/agent/config/node_config.go
+++ b/pkg/agent/config/node_config.go
@@ -85,6 +85,8 @@ type NodeConfig struct {
 	PodIPv6CIDR *net.IPNet
 	// The Node's IP used in Kubernetes. It has the network mask information.
 	NodeIPAddr *net.IPNet
+	// The IP on the Node's transport interface. It is used for tunneling or routing the Pod traffic across Nodes.
+	NodeTransportIPAddr *net.IPNet
 	// Set either via defaultMTU config in antrea.yaml or auto discovered.
 	// Auto discovery will use MTU value of the Node's primary interface.
 	// For Encap and Hybrid mode, Node MTU will be adjusted to account for encap header.
@@ -96,8 +98,8 @@ type NodeConfig struct {
 }
 
 func (n *NodeConfig) String() string {
-	return fmt.Sprintf("NodeName: %s, OVSBridge: %s, PodIPv4CIDR: %s, PodIPv6CIDR: %s, NodeIP: %s, Gateway: %s",
-		n.Name, n.OVSBridge, n.PodIPv4CIDR, n.PodIPv6CIDR, n.NodeIPAddr, n.GatewayConfig)
+	return fmt.Sprintf("NodeName: %s, OVSBridge: %s, PodIPv4CIDR: %s, PodIPv6CIDR: %s, NodeIP: %s, TransportIP: %s, Gateway: %s",
+		n.Name, n.OVSBridge, n.PodIPv4CIDR, n.PodIPv6CIDR, n.NodeIPAddr, n.NodeTransportIPAddr, n.GatewayConfig)
 }
 
 // User provided network configuration parameters.
@@ -106,6 +108,7 @@ type NetworkConfig struct {
 	TunnelType        ovsconfig.TunnelType
 	EnableIPSecTunnel bool
 	IPSecPSK          string
+	TransportIface    string
 }
 
 // IsIPv4Enabled returns true if the cluster network supports IPv4.

--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -390,7 +390,7 @@ func (c *client) InstallNodeFlows(hostname string,
 			// only work for IPv4 addresses.
 			flows = append(flows, c.arpResponderFlow(peerGatewayIP, cookie.Node))
 		}
-		if c.encapMode.NeedsEncapToPeer(tunnelPeerIP, c.nodeConfig.NodeIPAddr) {
+		if c.encapMode.NeedsEncapToPeer(tunnelPeerIP, c.nodeConfig.NodeTransportIPAddr) {
 			// tunnelPeerIP is the Node Internal Address. In a dual-stack setup, whether this address is an IPv4 address or an
 			// IPv6 one is decided by the address family of Node Internal Address.
 			flows = append(flows, c.l3FwdFlowToRemote(localGatewayMAC, *peerPodCIDR, tunnelPeerIP, cookie.Node))

--- a/pkg/agent/openflow/pipeline_other.go
+++ b/pkg/agent/openflow/pipeline_other.go
@@ -24,14 +24,6 @@ import (
 	binding "antrea.io/antrea/pkg/ovs/openflow"
 )
 
-// externalFlows returns the flows needed to enable SNAT for external traffic.
-func (c *client) externalFlows(nodeIP net.IP, localSubnet net.IPNet, localGatewayMAC net.HardwareAddr) []binding.Flow {
-	if !c.enableEgress {
-		return nil
-	}
-	return c.snatCommonFlows(nodeIP, localSubnet, localGatewayMAC, cookie.SNAT)
-}
-
 func (c *client) snatMarkFlows(snatIP net.IP, mark uint32) []binding.Flow {
 	return []binding.Flow{c.snatIPFromTunnelFlow(snatIP, mark)}
 }

--- a/pkg/agent/openflow/pipeline_windows.go
+++ b/pkg/agent/openflow/pipeline_windows.go
@@ -26,8 +26,6 @@ import (
 )
 
 const (
-	markTrafficFromBridge = 5
-
 	// ctZoneSNAT is only used on Windows and only when AntreaProxy is enabled.
 	// When a Pod access a ClusterIP Service, and the IP of the selected endpoint
 	// is not in "cluster-cidr". The request packets need to be SNAT'd(set src IP to local Node IP)
@@ -42,161 +40,9 @@ const (
 	// Pod <-- unDNAT(CtZone) <-- unSNAT(ctZoneSNAT) <-- Endpoint(API server NodeIP)
 	ctZoneSNAT = 0xffdc
 
-	// snatDefaultMark indicates the packet should be SNAT'd with the default
-	// SNAT IP (the Node IP).
-	snatDefaultMark = 0b1
-
 	// snatCTMark indicates SNAT is performed for packets of the connection.
 	snatCTMark = 0x40
 )
-
-var (
-	// snatMarkRange takes the 17th bit of register marksReg to indicate if
-	// the packet needs to be SNATed with Node's IP or not.
-	snatMarkRange = binding.Range{17, 17}
-)
-
-// uplinkSNATFlows installs flows for traffic from the uplink port that help
-// the SNAT implementation of the external traffic.
-func (c *client) uplinkSNATFlows(localSubnet net.IPNet, category cookie.Category) []binding.Flow {
-	ctStateNext := dnatTable
-	if c.enableProxy {
-		ctStateNext = endpointDNATTable
-	}
-	bridgeOFPort := uint32(config.BridgeOFPort)
-	flows := []binding.Flow{
-		// Mark the packet to indicate its destination MAC should be
-		// rewritten to the real MAC in the L3Forwarding table, if the
-		// packet is a reply to a local Pod from an external address.
-		c.pipeline[conntrackStateTable].BuildFlow(priorityHigh).
-			MatchProtocol(binding.ProtocolIP).
-			MatchCTStateNew(false).MatchCTStateTrk(true).
-			MatchCTMark(snatCTMark, nil).
-			MatchRegRange(int(marksReg), markTrafficFromUplink, binding.Range{0, 15}).
-			Action().LoadRegRange(int(marksReg), macRewriteMark, macRewriteMarkRange).
-			Cookie(c.cookieAllocator.Request(category).Raw()).
-			Action().GotoTable(ctStateNext).
-			Done(),
-		// Output the non-SNAT packet to the bridge interface directly
-		// if it is received from the uplink interface.
-		c.pipeline[conntrackStateTable].BuildFlow(priorityNormal).
-			MatchProtocol(binding.ProtocolIP).
-			MatchRegRange(int(marksReg), markTrafficFromUplink, binding.Range{0, 15}).
-			Action().Output(int(bridgeOFPort)).
-			Cookie(c.cookieAllocator.Request(category).Raw()).
-			Done(),
-	}
-	// Forward the IP packets from the uplink interface to
-	// conntrackTable. This is for unSNAT the traffic from the local
-	// Pod subnet to the external network. Non-SNAT packets will be
-	// output to the bridge port in conntrackStateTable.
-	if c.enableProxy {
-		// For the connection which is both applied DNAT and SNAT, the reply packtets
-		// are received from uplink and need to enter ctZoneSNAT first to do unSNAT.
-		//   Pod --> DNAT(CtZone) --> SNAT(ctZoneSNAT) --> ExternalServer
-		//   Pod <-- unDNAT(CtZone) <-- unSNAT(ctZoneSNAT) <-- ExternalServer
-		flows = append(flows, c.pipeline[uplinkTable].BuildFlow(priorityNormal).
-			MatchProtocol(binding.ProtocolIP).
-			MatchRegRange(int(marksReg), markTrafficFromUplink, binding.Range{0, 15}).
-			Action().CT(false, conntrackTable, ctZoneSNAT).NAT().CTDone().
-			Cookie(c.cookieAllocator.Request(category).Raw()).
-			Done())
-	} else {
-		flows = append(flows, c.pipeline[uplinkTable].BuildFlow(priorityNormal).
-			MatchProtocol(binding.ProtocolIP).
-			MatchRegRange(int(marksReg), markTrafficFromUplink, binding.Range{0, 15}).
-			Action().GotoTable(conntrackTable).
-			Cookie(c.cookieAllocator.Request(category).Raw()).
-			Done())
-	}
-	return flows
-}
-
-// snatImplementationFlows installs flows that implement SNAT with OVS NAT.
-func (c *client) snatImplementationFlows(nodeIP net.IP, category cookie.Category) []binding.Flow {
-	snatIPRange := &binding.IPRange{StartIP: nodeIP, EndIP: nodeIP}
-	l3FwdTable := c.pipeline[l3ForwardingTable]
-	nextTable := l3FwdTable.GetNext()
-	ctCommitTable := c.pipeline[conntrackCommitTable]
-	ccNextTable := ctCommitTable.GetNext()
-	flows := []binding.Flow{
-		// Default to using Node IP as the SNAT IP for local Pods.
-		c.pipeline[snatTable].BuildFlow(priorityLow).
-			MatchProtocol(binding.ProtocolIP).
-			MatchCTStateNew(true).MatchCTStateTrk(true).
-			MatchRegRange(int(marksReg), markTrafficFromLocal, binding.Range{0, 15}).
-			Action().LoadRegRange(int(marksReg), snatDefaultMark, snatMarkRange).
-			Action().GotoTable(nextTable).
-			Cookie(c.cookieAllocator.Request(category).Raw()).
-			Done(),
-		// Force IP packet into the conntrack zone with SNAT. If the connection is SNATed, the reply packet should use
-		// Pod IP as the destination, and then is forwarded to conntrackStateTable.
-		c.pipeline[conntrackTable].BuildFlow(priorityNormal).MatchProtocol(binding.ProtocolIP).
-			Action().CT(false, conntrackStateTable, CtZone).NAT().CTDone().
-			Cookie(c.cookieAllocator.Request(category).Raw()).
-			Done(),
-		// Perform SNAT with the default SNAT IP (the Node IP). A SNAT
-		// packet has these characteristics: 1) the ct_state is
-		// "+new+trk", 2) reg0[17] is set to 1; 3) ct_mark is set to
-		// 0x40.
-		ctCommitTable.BuildFlow(priorityNormal).
-			MatchProtocol(binding.ProtocolIP).
-			MatchCTStateNew(true).MatchCTStateTrk(true).MatchCTStateDNAT(false).
-			MatchRegRange(int(marksReg), snatDefaultMark, snatMarkRange).
-			Action().CT(true, ccNextTable, CtZone).
-			SNAT(snatIPRange, nil).
-			LoadToMark(snatCTMark).CTDone().
-			Cookie(c.cookieAllocator.Request(category).Raw()).
-			Done(),
-	}
-	// The following flows are for both apply DNAT + SNAT for packets.
-	// If AntreaProxy is disabled, no DNAT happens in OVS pipeline.
-	if c.enableProxy {
-		flows = append(flows, []binding.Flow{
-			// If the SNAT is needed after DNAT, mark the
-			// snatDefaultMark even the connection is not new,
-			// because this kind of packets need to enter ctZoneSNAT
-			// to make sure the SNAT can be applied before leaving
-			// the pipeline.
-			l3FwdTable.BuildFlow(priorityLow).
-				MatchProtocol(binding.ProtocolIP).
-				MatchCTStateNew(false).MatchCTStateTrk(true).MatchCTStateDNAT(true).
-				MatchRegRange(int(marksReg), markTrafficFromLocal, binding.Range{0, 15}).
-				Action().LoadRegRange(int(marksReg), snatDefaultMark, snatMarkRange).
-				Action().GotoTable(nextTable).
-				Cookie(c.cookieAllocator.Request(category).Raw()).
-				Done(),
-			// If SNAT is needed after DNAT:
-			//   - For new connection: commit to ctZoneSNAT
-			//   - For existing connection: enter ctZoneSNAT to apply SNAT
-			ctCommitTable.BuildFlow(priorityNormal).
-				MatchProtocol(binding.ProtocolIP).
-				MatchCTStateNew(true).MatchCTStateTrk(true).MatchCTStateDNAT(true).
-				MatchRegRange(int(marksReg), snatDefaultMark, snatMarkRange).
-				Action().CT(true, ccNextTable, ctZoneSNAT).
-				SNAT(snatIPRange, nil).
-				LoadToMark(snatCTMark).CTDone().
-				Cookie(c.cookieAllocator.Request(category).Raw()).
-				Done(),
-			ctCommitTable.BuildFlow(priorityNormal).
-				MatchProtocol(binding.ProtocolIP).
-				MatchCTStateNew(false).MatchCTStateTrk(true).MatchCTStateDNAT(true).
-				MatchRegRange(int(marksReg), snatDefaultMark, snatMarkRange).
-				Action().CT(false, ccNextTable, ctZoneSNAT).NAT().CTDone().
-				Cookie(c.cookieAllocator.Request(category).Raw()).
-				Done(),
-		}...)
-	}
-	return flows
-}
-
-// externalFlows returns the flows needed to enable SNAT for external traffic.
-func (c *client) externalFlows(nodeIP net.IP, localSubnet net.IPNet, localGatewayMAC net.HardwareAddr) []binding.Flow {
-	flows := c.snatCommonFlows(nodeIP, localSubnet, localGatewayMAC, cookie.SNAT)
-	flows = append(flows, c.uplinkSNATFlows(localSubnet, cookie.SNAT)...)
-	flows = append(flows, c.snatImplementationFlows(nodeIP, cookie.SNAT)...)
-	return flows
-}
 
 func (c *client) snatMarkFlows(snatIP net.IP, mark uint32) []binding.Flow {
 	snatIPRange := &binding.IPRange{StartIP: snatIP, EndIP: snatIP}
@@ -233,62 +79,27 @@ func (c *client) snatMarkFlows(snatIP net.IP, mark uint32) []binding.Flow {
 // bridge local port and the uplink port to support the host traffic with
 // outside.
 func (c *client) hostBridgeUplinkFlows(localSubnet net.IPNet, category cookie.Category) (flows []binding.Flow) {
-	bridgeOFPort := uint32(config.BridgeOFPort)
 	flows = []binding.Flow{
 		c.pipeline[ClassifierTable].BuildFlow(priorityNormal).
 			MatchInPort(config.UplinkOFPort).
-			Action().LoadRegRange(int(marksReg), markTrafficFromUplink, binding.Range{0, 15}).
-			Action().GotoTable(uplinkTable).
+			Action().Output(config.BridgeOFPort).
 			Cookie(c.cookieAllocator.Request(category).Raw()).
 			Done(),
 		c.pipeline[ClassifierTable].BuildFlow(priorityNormal).
 			MatchInPort(config.BridgeOFPort).
-			Action().LoadRegRange(int(marksReg), markTrafficFromBridge, binding.Range{0, 15}).
-			Action().GotoTable(uplinkTable).
-			Cookie(c.cookieAllocator.Request(category).Raw()).
-			Done(),
-		// Output non-IP packets to the bridge port directly. IP packets
-		// are redirected to conntrackTable in uplinkSNATFlows() (in
-		// case they need unSNAT).
-		c.pipeline[uplinkTable].BuildFlow(priorityLow).
-			MatchRegRange(int(marksReg), markTrafficFromUplink, binding.Range{0, 15}).
-			Action().Output(int(bridgeOFPort)).
-			Cookie(c.cookieAllocator.Request(category).Raw()).
-			Done(),
-		// Forward the packet to conntrackTable if it enters the OVS
-		// pipeline from the bridge interface and is sent to the local
-		// Pod subnet. Mark the packet to indicate its destination MAC
-		// should be rewritten to the real MAC in the L3Frowarding
-		// table. This is for the case a Pod accesses a NodePort Service
-		// using the local Node's IP, and then the return traffic after
-		// the kube-proxy processing will enter the bridge from the
-		// bridge interface (but not the gateway interface. This is
-		// probably because we do not enable IP forwarding on the bridge
-		// interface).
-		c.pipeline[uplinkTable].BuildFlow(priorityHigh).
-			MatchProtocol(binding.ProtocolIP).
-			MatchRegRange(int(marksReg), markTrafficFromBridge, binding.Range{0, 15}).
-			MatchDstIPNet(localSubnet).
-			Action().LoadRegRange(int(marksReg), macRewriteMark, macRewriteMarkRange).
-			Action().GotoTable(conntrackTable).
-			Cookie(c.cookieAllocator.Request(category).Raw()).
-			Done(),
-		// Output other packets from the bridge port to the uplink port
-		// directly.
-		c.pipeline[uplinkTable].BuildFlow(priorityLow).
-			MatchRegRange(int(marksReg), markTrafficFromBridge, binding.Range{0, 15}).
 			Action().Output(config.UplinkOFPort).
 			Cookie(c.cookieAllocator.Request(category).Raw()).
 			Done(),
 	}
 	if c.encapMode.SupportsNoEncap() {
 		// If NoEncap is enabled, the reply packets from remote Pod can be forwarded to local Pod directly.
-		// by explicitly resubmitting them to endpointDNATTable and marking "macRewriteMark" at same time.
-		flows = append(flows, c.pipeline[conntrackStateTable].BuildFlow(priorityHigh).MatchProtocol(binding.ProtocolIP).
-			MatchRegRange(int(marksReg), markTrafficFromUplink, binding.Range{0, 15}).
+		// by explicitly resubmitting them to serviceHairpinTable and marking "macRewriteMark" at same time.
+		flows = append(flows, c.pipeline[ClassifierTable].BuildFlow(priorityHigh).MatchProtocol(binding.ProtocolIP).
+			MatchInPort(config.UplinkOFPort).
 			MatchDstIPNet(localSubnet).
+			Action().LoadRegRange(int(marksReg), markTrafficFromUplink, binding.Range{0, 15}).
 			Action().LoadRegRange(int(marksReg), macRewriteMark, macRewriteMarkRange).
-			Action().GotoTable(endpointDNATTable).
+			Action().GotoTable(serviceHairpinTable).
 			Cookie(c.cookieAllocator.Request(category).Raw()).
 			Done())
 	}
@@ -297,7 +108,9 @@ func (c *client) hostBridgeUplinkFlows(localSubnet net.IPNet, category cookie.Ca
 
 func (c *client) l3FwdFlowToRemoteViaRouting(localGatewayMAC net.HardwareAddr, remoteGatewayMAC net.HardwareAddr,
 	category cookie.Category, peerIP net.IP, peerPodCIDR *net.IPNet) []binding.Flow {
-	if c.encapMode.NeedsDirectRoutingToPeer(peerIP, c.nodeConfig.NodeIPAddr) && remoteGatewayMAC != nil {
+	if c.encapMode.NeedsDirectRoutingToPeer(peerIP, c.nodeConfig.NodeTransportIPAddr) && remoteGatewayMAC != nil {
+		ipProto := getIPProtocol(peerIP)
+		l3FwdTable := c.pipeline[l3ForwardingTable]
 		// It enhances Windows Noencap mode performance by bypassing host network.
 		flows := []binding.Flow{c.pipeline[l2ForwardingCalcTable].BuildFlow(priorityNormal).
 			MatchDstMAC(remoteGatewayMAC).
@@ -305,7 +118,20 @@ func (c *client) l3FwdFlowToRemoteViaRouting(localGatewayMAC net.HardwareAddr, r
 			Action().LoadRegRange(int(marksReg), macRewriteMark, ofPortMarkRange).
 			Action().GotoTable(conntrackCommitTable).
 			Cookie(c.cookieAllocator.Request(category).Raw()).
-			Done()}
+			Done(),
+			// Output the reply packet to the uplink interface if the destination is another Node's IP.
+			// This is for the scenario that another Node directly accesses Pods on this Node. Since the request
+			// packet enters OVS from the uplink interface, the reply should go back in the same path. Otherwise,
+			// Windows host will perform stateless SNAT on the reply, and the packets are possibly dropped on peer
+			// Node because of the wrong source address.
+			l3FwdTable.BuildFlow(priorityNormal).MatchProtocol(ipProto).
+				MatchDstIP(peerIP).
+				MatchCTStateRpl(true).MatchCTStateTrk(true).
+				Action().SetDstMAC(remoteGatewayMAC).
+				Action().GotoTable(l3FwdTable.GetNext()).
+				Cookie(c.cookieAllocator.Request(category).Raw()).
+				Done(),
+		}
 		flows = append(flows, c.l3FwdFlowToRemoteViaGW(remoteGatewayMAC, *peerPodCIDR, category))
 		return flows
 	}

--- a/pkg/agent/route/route_linux.go
+++ b/pkg/agent/route/route_linux.go
@@ -438,7 +438,7 @@ func (c *Client) restoreIptablesData(podCIDR *net.IPNet, podIPSet string, snatMa
 func (c *Client) initIPRoutes() error {
 	if c.networkConfig.TrafficEncapMode.IsNetworkPolicyOnly() {
 		gwLink := util.GetNetLink(c.nodeConfig.GatewayConfig.Name)
-		_, gwIP, _ := net.ParseCIDR(fmt.Sprintf("%s/32", c.nodeConfig.NodeIPAddr.IP.String()))
+		_, gwIP, _ := net.ParseCIDR(fmt.Sprintf("%s/32", c.nodeConfig.NodeTransportIPAddr.IP.String()))
 		if err := netlink.AddrReplace(gwLink, &netlink.Addr{IPNet: gwIP}); err != nil {
 			return fmt.Errorf("failed to add address %s to gw %s: %v", gwIP, gwLink.Attrs().Name, err)
 		}
@@ -576,7 +576,7 @@ func (c *Client) AddRoutes(podCIDR *net.IPNet, nodeName string, nodeIP, nodeGwIP
 		Dst: podCIDR,
 	}
 	var routes []*netlink.Route
-	if c.networkConfig.TrafficEncapMode.NeedsEncapToPeer(nodeIP, c.nodeConfig.NodeIPAddr) {
+	if c.networkConfig.TrafficEncapMode.NeedsEncapToPeer(nodeIP, c.nodeConfig.NodeTransportIPAddr) {
 		if podCIDR.IP.To4() == nil {
 			// "on-link" is not identified in IPv6 route entries, so split the configuration into 2 entries.
 			routes = []*netlink.Route{
@@ -590,7 +590,7 @@ func (c *Client) AddRoutes(podCIDR *net.IPNet, nodeName string, nodeIP, nodeGwIP
 		}
 		route.LinkIndex = c.nodeConfig.GatewayConfig.LinkIndex
 		route.Gw = nodeGwIP
-	} else if c.networkConfig.TrafficEncapMode.NeedsDirectRoutingToPeer(nodeIP, c.nodeConfig.NodeIPAddr) {
+	} else if c.networkConfig.TrafficEncapMode.NeedsDirectRoutingToPeer(nodeIP, c.nodeConfig.NodeTransportIPAddr) {
 		// NoEncap traffic to Node on the same subnet.
 		// Set the peerNodeIP as next hop.
 		route.Gw = nodeIP

--- a/pkg/agent/route/route_windows_test.go
+++ b/pkg/agent/route/route_windows_test.go
@@ -50,7 +50,7 @@ func TestRouteOperation(t *testing.T) {
 	gwIP2 := net.ParseIP("192.168.3.1")
 	_, destCIDR2, _ := net.ParseCIDR(dest2)
 
-	client, err := NewClient(serviceCIDR, &config.NetworkConfig{}, false)
+	client, err := NewClient(serviceCIDR, &config.NetworkConfig{}, true)
 	require.Nil(t, err)
 	nodeConfig := &config.NodeConfig{
 		OVSBridge: "Loopback Pseudo-Interface 1",

--- a/pkg/agent/types/annotations.go
+++ b/pkg/agent/types/annotations.go
@@ -17,4 +17,7 @@ package types
 const (
 	// NodeMACAddressAnnotationKey represents the key of the Node's MAC address in the Annotations of the Node.
 	NodeMACAddressAnnotationKey string = "node.antrea.io/mac-address"
+
+	// NodeTransportAddressAnnotationKey represents the key of the interface's IP address on which the Node transfers Pod traffic in the Annotations of the Node.
+	NodeTransportAddressAnnotationKey string = "node.antrea.io/transport-address"
 )

--- a/pkg/agent/util/net.go
+++ b/pkg/agent/util/net.go
@@ -123,6 +123,26 @@ func GetIPNetDeviceFromIP(localIP net.IP) (*net.IPNet, *net.Interface, error) {
 	return nil, nil, fmt.Errorf("unable to find local IP and device")
 }
 
+func GetIPNetDeviceByName(ifaceName string) (*net.IPNet, *net.Interface, error) {
+	link, err := net.InterfaceByName(ifaceName)
+	if err != nil {
+		return nil, nil, err
+	}
+	addrList, err := link.Addrs()
+	if err != nil {
+		return nil, nil, err
+	}
+	for _, addr := range addrList {
+		if ipNet, ok := addr.(*net.IPNet); ok {
+			if ipNet.IP.IsGlobalUnicast() {
+				return ipNet, link, nil
+			}
+		}
+		continue
+	}
+	return nil, nil, fmt.Errorf("unable to find local IP and device")
+}
+
 func GetIPv4Addr(ips []net.IP) net.IP {
 	for _, ip := range ips {
 		if ip.To4() != nil {

--- a/test/integration/agent/route_test.go
+++ b/test/integration/agent/route_test.go
@@ -63,10 +63,11 @@ var (
 	gwName            = "antrea-gw0"
 	gwConfig          = &config.GatewayConfig{IPv4: gwIP, MAC: gwMAC, Name: gwName}
 	nodeConfig        = &config.NodeConfig{
-		Name:          "test",
-		PodIPv4CIDR:   podCIDR,
-		NodeIPAddr:    nodeIP,
-		GatewayConfig: gwConfig,
+		Name:                "test",
+		PodIPv4CIDR:         podCIDR,
+		NodeIPAddr:          nodeIP,
+		NodeTransportIPAddr: nodeIP,
+		GatewayConfig:       gwConfig,
 	}
 )
 


### PR DESCRIPTION
1. SNAT is performed by Windows host for Pod-to-external traffic, not by OVS
2. Antrea Agent uses the configurable interface for Pod traffic. The interface
   which is configured with Node IP is chosen, if user doesn't configure the
   in-band traffic interface.

Signed-off-by: wenyingd <wenyingd@vmware.com>

Fixes #2344 