### PR TITLE
Automated cherry pick of #2363: RunCommand with os/exec * Use "os/exec" to run

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/Microsoft/go-winio v0.4.16-0.20201130162521-d1ffc52c7331
 	github.com/Microsoft/hcsshim v0.8.9
 	github.com/TomCodeLV/OVSDB-golang-lib v0.0.0-20200116135253-9bbdfadcd881
-	github.com/antoninbas/go-powershell v0.1.0
 	github.com/awalterschulze/gographviz v2.0.1+incompatible
 	github.com/blang/semver v3.5.0+incompatible
 	github.com/cenk/hub v1.0.1 // indirect
@@ -32,7 +31,6 @@ require (
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/common v0.4.1
-	github.com/rakelkar/gonetsh v0.0.0-20190930180311-e5c5ffe4bdf0
 	github.com/satori/go.uuid v1.2.0
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/afero v1.4.1
@@ -77,7 +75,6 @@ replace (
 	// were ignored. We need to change antrea/plugins/octant/go.mod if there is any change here.
 	github.com/contiv/ofnet => github.com/wenyingd/ofnet v0.0.0-20210205051801-5a4f247248d4
 	// avoid dependency on juju packages, which are licensed under LGPL v3
-	github.com/rakelkar/gonetsh => github.com/antoninbas/gonetsh v0.1.2
 	// fake.NewSimpleClientset is quite slow when it's initialized with massive objects due to
 	// https://github.com/kubernetes/kubernetes/issues/89574. It takes more than tens of minutes to
 	// init a fake client with 200k objects, which makes it hard to run the NetworkPolicy scale test.

--- a/go.sum
+++ b/go.sum
@@ -35,10 +35,6 @@ github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmx
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae/go.mod h1:CgnQgUtFrFz9mxFNtED3jI5tLDjKlOM+oUF/sTk6ps0=
-github.com/antoninbas/go-powershell v0.1.0 h1:LKwuZJt3loyr++Y2Qc+FZoUt8TwbrTWB3HublPoykxA=
-github.com/antoninbas/go-powershell v0.1.0/go.mod h1:01pgKhz1CJxGnCWqXVDgvmp/QmHgWgEdxdYP+1azopE=
-github.com/antoninbas/gonetsh v0.1.2 h1:twRwmATT+Xnj/0JD0UBY4tWeW0D4vcEWITlj8nItJbI=
-github.com/antoninbas/gonetsh v0.1.2/go.mod h1:CMmmf/2dAGQRmgWUDXf4Om/MBof1Emt1V0UH/sgw85c=
 github.com/antoninbas/libOpenflow v0.0.0-20210218001059-32f2e57d0435 h1:vVl9f3eDJm14Cyu9ye0ENw6j1Q++XYLEshV4KYBc9ac=
 github.com/antoninbas/libOpenflow v0.0.0-20210218001059-32f2e57d0435/go.mod h1:KqprRw1Mp8VGnGj0NzPeZQojUvT5X26DV7suLSM1iqM=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
@@ -387,7 +383,6 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/stretchr/testify v1.6.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/ti-mo/conntrack v0.3.0 h1:572/72R9la2FVvO6CbsLiCmR48U3pgCvIlLKoUrExDU=

--- a/pkg/agent/agent_windows.go
+++ b/pkg/agent/agent_windows.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	"github.com/Microsoft/hcsshim"
-	"github.com/rakelkar/gonetsh/netroute"
 	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/config"
@@ -211,9 +210,7 @@ func (i *Initializer) getTunnelPortLocalIP() net.IP {
 // The routes will be restored on OVS bridge interface after the IP configuration
 // is moved to the OVS bridge.
 func (i *Initializer) saveHostRoutes() error {
-	nr := netroute.New()
-	defer nr.Exit()
-	routes, err := nr.GetNetRoutesAll()
+	routes, err := util.GetNetRoutesAll()
 	if err != nil {
 		return err
 	}
@@ -244,15 +241,19 @@ func (i *Initializer) saveHostRoutes() error {
 // the antrea network initialize stage.
 // The backup routes are restored after the IP configuration change.
 func (i *Initializer) restoreHostRoutes() error {
-	nr := netroute.New()
-	defer nr.Exit()
 	brInterface, err := net.InterfaceByName(i.ovsBridge)
 	if err != nil {
 		return nil
 	}
 	for _, route := range i.nodeConfig.UplinkNetConfig.Routes {
-		rt := route.(netroute.Route)
-		if err := nr.NewNetRoute(brInterface.Index, rt.DestinationSubnet, rt.GatewayAddress); err != nil {
+		rt := route.(util.Route)
+		newRt := util.Route{
+			LinkIndex:         brInterface.Index,
+			DestinationSubnet: rt.DestinationSubnet,
+			GatewayAddress:    rt.GatewayAddress,
+			RouteMetric:       rt.RouteMetric,
+		}
+		if err := util.NewNetRoute(&newRt); err != nil {
 			return err
 		}
 	}

--- a/pkg/agent/route/route_windows_test.go
+++ b/pkg/agent/route/route_windows_test.go
@@ -20,12 +20,12 @@ import (
 	"net"
 	"testing"
 
-	"github.com/rakelkar/gonetsh/netroute"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/klog"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/config"
+	"github.com/vmware-tanzu/antrea/pkg/agent/util"
 )
 
 func getNetLinkIndex(dev string) int {
@@ -50,9 +50,6 @@ func TestRouteOperation(t *testing.T) {
 	gwIP2 := net.ParseIP("192.168.3.1")
 	_, destCIDR2, _ := net.ParseCIDR(dest2)
 
-	nr := netroute.New()
-	defer nr.Exit()
-
 	client, err := NewClient(serviceCIDR, &config.NetworkConfig{}, false)
 	require.Nil(t, err)
 	nodeConfig := &config.NodeConfig{
@@ -69,25 +66,25 @@ func TestRouteOperation(t *testing.T) {
 	// Add initial routes.
 	err = client.AddRoutes(destCIDR1, peerNodeIP1, gwIP1)
 	require.Nil(t, err)
-	routes1, err := nr.GetNetRoutes(gwLink, destCIDR1)
+	routes1, err := util.GetNetRoutes(gwLink, destCIDR1)
 	require.Nil(t, err)
 	assert.Equal(t, 1, len(routes1))
 
 	err = client.AddRoutes(destCIDR2, peerNodeIP2, gwIP2)
 	require.Nil(t, err)
-	routes2, err := nr.GetNetRoutes(gwLink, destCIDR2)
+	routes2, err := util.GetNetRoutes(gwLink, destCIDR2)
 	require.Nil(t, err)
 	assert.Equal(t, 1, len(routes2))
 
 	err = client.Reconcile([]string{dest2})
 	require.Nil(t, err)
-	routes3, err := nr.GetNetRoutes(gwLink, destCIDR1)
+	routes3, err := util.GetNetRoutes(gwLink, destCIDR1)
 	require.Nil(t, err)
 	assert.Equal(t, 0, len(routes3))
 
 	err = client.DeleteRoutes(destCIDR2)
 	require.Nil(t, err)
-	routes4, err := nr.GetNetRoutes(gwLink, destCIDR2)
+	routes4, err := util.GetNetRoutes(gwLink, destCIDR2)
 	require.Nil(t, err)
 	assert.Equal(t, 0, len(routes4))
 }

--- a/pkg/agent/util/net_windows.go
+++ b/pkg/agent/util/net_windows.go
@@ -17,20 +17,22 @@
 package util
 
 import (
+	"bufio"
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"net"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/Microsoft/go-winio"
 	"github.com/Microsoft/hcsshim"
-	ps "github.com/antoninbas/go-powershell"
-	"github.com/antoninbas/go-powershell/backend"
 	"github.com/containernetworking/plugins/pkg/ip"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog"
+
+	ps "github.com/vmware-tanzu/antrea/pkg/agent/util/powershell"
 )
 
 const (
@@ -41,7 +43,16 @@ const (
 	namedPipePrefix      = `\\.\pipe\`
 	commandRetryTimeout  = 5 * time.Second
 	commandRetryInterval = time.Second
+
+	DefaultMetric = 256
 )
+
+type Route struct {
+	LinkIndex         int
+	DestinationSubnet *net.IPNet
+	GatewayAddress    net.IP
+	RouteMetric       int
+}
 
 func GetNSPath(containerNetNS string) (string, error) {
 	return containerNetNS, nil
@@ -49,7 +60,7 @@ func GetNSPath(containerNetNS string) (string, error) {
 
 func GetHostInterfaceStatus(ifaceName string) (string, error) {
 	cmd := fmt.Sprintf(`Get-NetAdapter -InterfaceAlias "%s" | Select-Object -Property Status | Format-Table -HideTableHeaders`, ifaceName)
-	out, err := CallPSCommand(cmd)
+	out, err := ps.RunCommand(cmd)
 	if err != nil {
 		return "", err
 	}
@@ -63,7 +74,7 @@ func EnableHostInterface(ifaceName string) error {
 	// It returns immediately no matter whether the interface has been enabled or not.
 	// So we need to check the interface status to ensure it is up before returning.
 	if err := wait.PollImmediate(commandRetryInterval, commandRetryTimeout, func() (done bool, err error) {
-		if err := InvokePSCommand(cmd); err != nil {
+		if _, err := ps.RunCommand(cmd); err != nil {
 			klog.Errorf("Failed to run command %s: %v", cmd, err)
 			return false, nil
 		}
@@ -87,7 +98,7 @@ func EnableHostInterface(ifaceName string) error {
 func ConfigureInterfaceAddress(ifaceName string, ipConfig *net.IPNet) error {
 	ipStr := strings.Split(ipConfig.String(), "/")
 	cmd := fmt.Sprintf(`New-NetIPAddress -InterfaceAlias "%s" -IPAddress %s -PrefixLength %s`, ifaceName, ipStr[0], ipStr[1])
-	err := InvokePSCommand(cmd)
+	_, err := ps.RunCommand(cmd)
 	// If the address already exists, ignore the error.
 	if err != nil && !strings.Contains(err.Error(), "already exists") {
 		return err
@@ -98,7 +109,7 @@ func ConfigureInterfaceAddress(ifaceName string, ipConfig *net.IPNet) error {
 // RemoveInterfaceAddress removes IPAddress from the specified interface.
 func RemoveInterfaceAddress(ifaceName string, ipAddr net.IP) error {
 	cmd := fmt.Sprintf(`Remove-NetIPAddress -InterfaceAlias "%s" -IPAddress %s -Confirm:$false`, ifaceName, ipAddr.String())
-	err := InvokePSCommand(cmd)
+	_, err := ps.RunCommand(cmd)
 	// If the address does not exist, ignore the error.
 	if err != nil && !strings.Contains(err.Error(), "No matching") {
 		return err
@@ -111,7 +122,7 @@ func RemoveInterfaceAddress(ifaceName string, ipAddr net.IP) error {
 func ConfigureInterfaceAddressWithDefaultGateway(ifaceName string, ipConfig *net.IPNet, gateway string) error {
 	ipStr := strings.Split(ipConfig.String(), "/")
 	cmd := fmt.Sprintf(`New-NetIPAddress -InterfaceAlias "%s" -IPAddress %s -PrefixLength %s -DefaultGateway %s`, ifaceName, ipStr[0], ipStr[1], gateway)
-	err := InvokePSCommand(cmd)
+	_, err := ps.RunCommand(cmd)
 	// If the address already exists, ignore the error.
 	if err != nil && !strings.Contains(err.Error(), "already exists") {
 		return err
@@ -122,35 +133,8 @@ func ConfigureInterfaceAddressWithDefaultGateway(ifaceName string, ipConfig *net
 // EnableIPForwarding enables the IP interface to forward packets that arrive on this interface to other interfaces.
 func EnableIPForwarding(ifaceName string) error {
 	cmd := fmt.Sprintf(`Set-NetIPInterface -InterfaceAlias "%s" -Forwarding Enabled`, ifaceName)
-	return InvokePSCommand(cmd)
-}
-
-func InvokePSCommand(cmd string) error {
-	_, err := CallPSCommand(cmd)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func CallPSCommand(cmd string) (string, error) {
-	// Create a backend shell.
-	back := &backend.Local{}
-
-	// start a local powershell process
-	shell, err := ps.New(back)
-	if err != nil {
-		return "", err
-	}
-	defer shell.Exit()
-	stdout, stderr, err := shell.Execute(cmd)
-	if err != nil {
-		return stdout, err
-	}
-	if stderr != "" {
-		return stdout, fmt.Errorf("%s", stderr)
-	}
-	return stdout, nil
+	_, err := ps.RunCommand(cmd)
+	return err
 }
 
 // RemoveManagementInterface removes the management interface of the HNS Network, and then the physical interface can be
@@ -162,7 +146,7 @@ func RemoveManagementInterface(networkName string) error {
 	cmd := fmt.Sprintf("Get-VMSwitch -Name %s  | Set-VMSwitch -AllowManagementOS $false ", networkName)
 	// Retry the operation here because an error is returned at the first invocation.
 	for i < maxRetry {
-		err = InvokePSCommand(cmd)
+		_, err = ps.RunCommand(cmd)
 		if err == nil {
 			return nil
 		}
@@ -176,7 +160,8 @@ func SetAdapterMACAddress(adapterName string, macConfig *net.HardwareAddr) error
 	macAddr := strings.Replace(macConfig.String(), ":", "", -1)
 	cmd := fmt.Sprintf("Set-NetAdapterAdvancedProperty -Name %s -RegistryKeyword NetworkAddress -RegistryValue %s",
 		adapterName, macAddr)
-	return InvokePSCommand(cmd)
+	_, err := ps.RunCommand(cmd)
+	return err
 }
 
 // WindowsHyperVEnabled checks if the Hyper-V is enabled on the host.
@@ -184,7 +169,7 @@ func SetAdapterMACAddress(adapterName string, macConfig *net.HardwareAddr) error
 // test, OVS requires "Microsoft-Hyper-V" feature to be enabled.
 func WindowsHyperVEnabled() (bool, error) {
 	cmd := "$(Get-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V).State"
-	result, err := CallPSCommand(cmd)
+	result, err := ps.RunCommand(cmd)
 	if err != nil {
 		return true, err
 	}
@@ -403,7 +388,7 @@ func GetLocalBroadcastIP(ipNet *net.IPNet) net.IP {
 // GetDefaultGatewayByInterfaceIndex returns the default gateway configured on the speicified interface.
 func GetDefaultGatewayByInterfaceIndex(ifIndex int) (string, error) {
 	cmd := fmt.Sprintf("$(Get-NetRoute -InterfaceIndex %d -DestinationPrefix 0.0.0.0/0 ).NextHop", ifIndex)
-	defaultGW, err := CallPSCommand(cmd)
+	defaultGW, err := ps.RunCommand(cmd)
 	if err != nil {
 		return "", err
 	}
@@ -414,7 +399,7 @@ func GetDefaultGatewayByInterfaceIndex(ifIndex int) (string, error) {
 // GetDNServersByInterfaceIndex returns the DNS servers configured on the specified interface.
 func GetDNServersByInterfaceIndex(ifIndex int) (string, error) {
 	cmd := fmt.Sprintf("$(Get-DnsClientServerAddress -InterfaceIndex %d -AddressFamily IPv4).ServerAddresses", ifIndex)
-	dnsServers, err := CallPSCommand(cmd)
+	dnsServers, err := ps.RunCommand(cmd)
 	if err != nil {
 		return "", err
 	}
@@ -426,7 +411,7 @@ func GetDNServersByInterfaceIndex(ifIndex int) (string, error) {
 // SetAdapterDNSServers configures DNSServers on network adapter.
 func SetAdapterDNSServers(adapterName, dnsServers string) error {
 	cmd := fmt.Sprintf("Set-DnsClientServerAddress -InterfaceAlias %s -ServerAddresses %s", adapterName, dnsServers)
-	if err := InvokePSCommand(cmd); err != nil {
+	if _, err := ps.RunCommand(cmd); err != nil {
 		return err
 	}
 	return nil
@@ -461,8 +446,76 @@ func HostInterfaceExists(ifaceName string) bool {
 	// So if a interface cannot be found by above function, use powershell command
 	// "Get-NetAdapter" to check if it exists.
 	cmd := fmt.Sprintf(`Get-NetAdapter -InterfaceAlias "%s"`, ifaceName)
-	if err := InvokePSCommand(cmd); err != nil {
+	if _, err := ps.RunCommand(cmd); err != nil {
 		return false
 	}
 	return true
+}
+
+func NewNetRoute(route *Route) error {
+	cmd := fmt.Sprintf("New-NetRoute -InterfaceIndex %v -DestinationPrefix %v -NextHop %v -RouteMetric %d -Verbose",
+		route.LinkIndex, route.DestinationSubnet.String(), route.GatewayAddress.String(), route.RouteMetric)
+	_, err := ps.RunCommand(cmd)
+	return err
+}
+
+func RemoveNetRoute(route *Route) error {
+	cmd := fmt.Sprintf("Remove-NetRoute -InterfaceIndex %v -DestinationPrefix %v -NextHop  %v -Verbose -Confirm:$false",
+		route.LinkIndex, route.DestinationSubnet.String(), route.GatewayAddress.String())
+	_, err := ps.RunCommand(cmd)
+	return err
+}
+
+func GetNetRoutes(linkIndex int, dstSubnet *net.IPNet) ([]Route, error) {
+	cmd := fmt.Sprintf("Get-NetRoute -InterfaceIndex %d -DestinationPrefix %s -erroraction Ignore | Format-Table -HideTableHeaders",
+		linkIndex, dstSubnet.String())
+	return getNetRoutes(cmd)
+}
+
+func GetNetRoutesAll() ([]Route, error) {
+	cmd := "Get-NetRoute -ErrorAction Ignore | Format-Table -HideTableHeaders"
+	return getNetRoutes(cmd)
+}
+
+func getNetRoutes(cmd string) ([]Route, error) {
+	routesStr, _ := ps.RunCommand(cmd)
+	routes, err := parseRoutes(routesStr)
+	if err != nil {
+		return nil, err
+	}
+	return routes, nil
+}
+
+func parseRoutes(routesStr string) ([]Route, error) {
+	scanner := bufio.NewScanner(strings.NewReader(routesStr))
+	var routes []Route
+	for scanner.Scan() {
+		items := strings.Fields(scanner.Text())
+		if len(items) < 6 {
+			// Skip if an empty line or something similar
+			continue
+		}
+
+		idx, err := strconv.Atoi(items[0])
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse the LinkIndex '%s': %v", items[0], err)
+		}
+		_, dstSubnet, err := net.ParseCIDR(items[1])
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse the DestinationSubnet '%s': %v", items[1], err)
+		}
+		gw := net.ParseIP(items[2])
+		metric, err := strconv.Atoi(items[3])
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse the RouteMetric '%s': %v", items[3], err)
+		}
+		route := Route{
+			LinkIndex:         idx,
+			DestinationSubnet: dstSubnet,
+			GatewayAddress:    gw,
+			RouteMetric:       metric,
+		}
+		routes = append(routes, route)
+	}
+	return routes, nil
 }

--- a/pkg/agent/util/powershell/powershell_windows.go
+++ b/pkg/agent/util/powershell/powershell_windows.go
@@ -1,0 +1,35 @@
+// +build windows
+
+//Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package powershell
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+func RunCommand(cmd string) (string, error) {
+	// The try/catch command idea is from the following page:
+	// https://stackoverflow.com/questions/19282870/how-can-i-use-try-catch-and-get-my-script-to-stop-if-theres-an-error/19285405
+	psCmd := exec.Command("powershell.exe", "-NoLogo", "-NoProfile", "-NonInteractive", "-Command",
+		fmt.Sprintf(`$ErrorActionPreference="Stop";try {%s} catch {Write-Host $_;os.Exit(1)}`, cmd)) // #nosec G204
+	stdout, err := psCmd.Output()
+	stdoutStr := string(stdout)
+	if err != nil {
+		return "", fmt.Errorf("failed to run command '%s': output '%s', %v", cmd, stdoutStr, err)
+	}
+	return stdoutStr, nil
+}

--- a/pkg/agent/util/winfirewall/winfirewall.go
+++ b/pkg/agent/util/winfirewall/winfirewall.go
@@ -23,7 +23,7 @@ import (
 
 	"k8s.io/klog"
 
-	"github.com/vmware-tanzu/antrea/pkg/agent/util"
+	ps "github.com/vmware-tanzu/antrea/pkg/agent/util/powershell"
 )
 
 type FWRuleDirection string
@@ -66,7 +66,8 @@ type winFirewallRule struct {
 // add adds Firewall rule on the Windows host. The name and display name of the firewall rule are the same.
 func (r *winFirewallRule) add() error {
 	cmd := fmt.Sprintf("New-NetFirewallRule -Enabled True -Group %s %s", fwRuleGroup, r.getCommandString())
-	return util.InvokePSCommand(cmd)
+	_, err := ps.RunCommand(cmd)
+	return err
 }
 
 func (r *winFirewallRule) getCommandString() string {
@@ -109,7 +110,7 @@ func (c *Client) AddRuleBlockIP(name string, direction FWRuleDirection, ipNet *n
 
 func (c *Client) FirewallRuleExists(name string) (bool, error) {
 	cmd := fmt.Sprintf("Get-NetfirewallRule -DisplayName '%s'", name)
-	result, err := util.CallPSCommand(cmd)
+	result, err := ps.RunCommand(cmd)
 	if err != nil {
 		if strings.Contains(err.Error(), "No MSFT_NetFirewallRule objects found") {
 			return false, nil
@@ -131,13 +132,13 @@ func checkDeletionError(err error) error {
 
 func (c *Client) DelFirewallRuleByName(name string) error {
 	cmd := fmt.Sprintf("Remove-NetFirewallRule -DisplayName '%s'", name)
-	err := util.InvokePSCommand(cmd)
+	_, err := ps.RunCommand(cmd)
 	return checkDeletionError(err)
 }
 
 func (c *Client) DelAllFirewallRules() error {
 	cmd := fmt.Sprintf("Remove-NetFirewallRule -Group '%s'", fwRuleGroup)
-	err := util.InvokePSCommand(cmd)
+	_, err := ps.RunCommand(cmd)
 	return checkDeletionError(err)
 }
 

--- a/plugins/octant/go.sum
+++ b/plugins/octant/go.sum
@@ -70,7 +70,6 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae/go.mod h1:CgnQgUtFrFz9mxFNtED3jI5tLDjKlOM+oUF/sTk6ps0=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
-github.com/antoninbas/go-powershell v0.1.0/go.mod h1:01pgKhz1CJxGnCWqXVDgvmp/QmHgWgEdxdYP+1azopE=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
@@ -513,7 +512,6 @@ github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7z
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.5/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/rakelkar/gonetsh v0.0.0-20190930180311-e5c5ffe4bdf0/go.mod h1:4XHkfaUj+URzGO9sohoAgt2V9Y8nIW7fugpu0E6gShk=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-charset v0.0.0-20180617210344-2471d30d28b4/go.mod h1:qgYeAmZ5ZIpBWTGllZSQnw97Dj+woV0toclVaRGI8pc=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/test/integration/agent/net_test_windows.go
+++ b/test/integration/agent/net_test_windows.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/vmware-tanzu/antrea/pkg/agent/util"
+	ps "github.com/vmware-tanzu/antrea/pkg/agent/util/powershell"
 )
 
 func adapterName(name string) string {
@@ -39,7 +40,8 @@ func createTestInterface(t *testing.T, name string) string {
 	}
 	t.Logf("Creating test vSwitch and adapter '%s'", name)
 	cmd := fmt.Sprintf("New-VMSwitch %s -SwitchType Internal", name)
-	require.NoError(t, util.InvokePSCommand(cmd))
+	_, err = ps.RunCommand(cmd)
+	require.NoError(t, err)
 	return adapterName(name)
 }
 
@@ -52,7 +54,8 @@ func setTestInterfaceUp(t *testing.T, name string) int {
 func deleteTestInterface(t *testing.T, name string) {
 	t.Logf("Deleting test vSwitch '%s'", name)
 	cmd := fmt.Sprintf(`Remove-VMSwitch "%s" -Force`, name)
-	assert.NoError(t, util.InvokePSCommand(cmd))
+	_, err := ps.RunCommand(cmd)
+	assert.NoError(t, err)
 }
 
 func getTestInterfaceAddresses(t *testing.T, name string) []*net.IPNet {
@@ -72,5 +75,6 @@ func getTestInterfaceAddresses(t *testing.T, name string) []*net.IPNet {
 func addTestInterfaceAddress(t *testing.T, name string, addr *net.IPNet) {
 	ipStr := strings.Split(addr.String(), "/")
 	cmd := fmt.Sprintf(`New-NetIPAddress -InterfaceAlias "%s" -IPAddress %s -PrefixLength %s`, adapterName(name), ipStr[0], ipStr[1])
-	require.NoError(t, util.InvokePSCommand(cmd))
+	_, err := ps.RunCommand(cmd)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
Cherry pick of #2363 on release-0.13.

#2363: RunCommand with os/exec * Use "os/exec" to run

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.