### PR TITLE
Fix deadlock in initializing GroupEntityIndex with many groups

### DIFF
--- a/cmd/antrea-controller/controller.go
+++ b/cmd/antrea-controller/controller.go
@@ -309,6 +309,10 @@ func run(o *Options) error {
 
 	go controllerMonitor.Run(stopCh)
 
+	// It starts dispatching group updates to consumers, should start individually.
+	// If it's not running, adding Pods/Entities to groupEntityIndex may be blocked because of full channel.
+	go groupEntityIndex.Run(stopCh)
+
 	go groupEntityController.Run(stopCh)
 
 	go networkPolicyController.Run(stopCh)

--- a/pkg/controller/egress/controller_test.go
+++ b/pkg/controller/egress/controller_test.go
@@ -302,6 +302,7 @@ func TestAddEgress(t *testing.T) {
 			controller.crdInformerFactory.Start(stopCh)
 			controller.informerFactory.WaitForCacheSync(stopCh)
 			controller.crdInformerFactory.WaitForCacheSync(stopCh)
+			go controller.groupingInterface.Run(stopCh)
 			go controller.groupingController.Run(stopCh)
 			go controller.Run(stopCh)
 
@@ -349,6 +350,7 @@ func TestUpdateEgress(t *testing.T) {
 	controller.crdInformerFactory.Start(stopCh)
 	controller.informerFactory.WaitForCacheSync(stopCh)
 	controller.crdInformerFactory.WaitForCacheSync(stopCh)
+	go controller.groupingInterface.Run(stopCh)
 	go controller.groupingController.Run(stopCh)
 	go controller.Run(stopCh)
 

--- a/pkg/controller/networkpolicy/networkpolicy_controller_perf_test.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller_perf_test.go
@@ -251,6 +251,7 @@ func testComputeNetworkPolicy(t *testing.T, maxExecutionTime time.Duration, name
 	start := time.Now()
 	c.informerFactory.Start(stopCh)
 	c.informerFactory.WaitForCacheSync(stopCh)
+	go c.groupingInterface.Run(stopCh)
 	go c.groupingController.Run(stopCh)
 	go c.Run(stopCh)
 


### PR DESCRIPTION
When initializing GroupEntityIndex, if there were more than 1000 events
need to send, adding more Pods or ExternalEntity would be pending with
the lock acquired because the channel was full and the Run method that
consumed the channel didn't start. The Run method ran after the
setInitialCounts method, which also needed to acquire the lock, hence
deadlock.

This patch fixes it by starting GroupEntityIndex's Run method
individually. To avoid similar issues in the future, it also removes
the need of acquiring the lock in setInitialCounts and HasSync methods.

Fixes #2378

Signed-off-by: Quan Tian <qtian@vmware.com>