### PR TITLE
Add NamespaceIndex to podInformer of NPLController

### DIFF
--- a/pkg/agent/nodeportlocal/npl_agent_init.go
+++ b/pkg/agent/nodeportlocal/npl_agent_init.go
@@ -70,7 +70,7 @@ func InitController(kubeClient clientset.Interface, informerFactory informers.Sh
 		kubeClient,
 		metav1.NamespaceAll,
 		resyncPeriod,
-		cache.Indexers{},
+		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, // NamespaceIndex is used in NPLController.
 		listOptions,
 	)
 


### PR DESCRIPTION
Otherwise the List method would log the following message when querying
Pods of a namespace in NPLController.getPodsFromService, and falls back
to slow search without index.

"can not retrieve list of objects using index : Index with name
 namespace does not exist"

Signed-off-by: Quan Tian <qtian@vmware.com>