### PR TITLE
[CI]Wait for Service to be realized in proxy tests

### DIFF
--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/component-base/featuregate"
 
 	"antrea.io/antrea/pkg/agent/config"
@@ -454,4 +455,14 @@ func createTestBusyboxPods(tb testing.TB, data *TestData, num int, ns string, no
 	}
 
 	return podNames, podIPs, cleanupFn
+}
+
+func testServicefromNode(tb testing.TB, svc *corev1.Service, node string) {
+	// Retry is needed for rules to be installed by kube-proxy/antrea-proxy.
+	cmd := fmt.Sprintf("curl --connect-timeout 1 --retry 5 --retry-connrefused %s:80", svc.Spec.ClusterIP)
+	rc, stdout, stderr, err := RunCommandOnNode(node, cmd)
+	if rc != 0 || err != nil {
+		tb.Errorf("Error when running command '%s' on Node '%s', rc: %d, stdout: %s, stderr: %s, error: %v",
+			cmd, node, rc, stdout, stderr, err)
+	}
 }

--- a/test/e2e/flowaggregator_test.go
+++ b/test/e2e/flowaggregator_test.go
@@ -187,8 +187,9 @@ func testHelper(t *testing.T, data *TestData, podAIPs, podBIPs, podCIPs, podDIPs
 		t.Fatalf("Error when creating perftest Services: %v", err)
 	}
 	defer deletePerftestServices(t, data)
-	// Wait for the Service to be realized.
-	time.Sleep(3 * time.Second)
+	// Wait for the Services to be realized.
+	data.waitForServiceRealized(defaultTimeout, svcB.Name)
+	data.waitForServiceRealized(defaultTimeout, svcC.Name)
 
 	// OVS userspace implementation of conntrack doesn't maintain packet or byte counter statistics, so we ignore the bandwidth test in Kind cluster.
 	checkBandwidth := testOptions.providerName != "kind"

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -1041,20 +1041,6 @@ func (data *TestData) deletePodAndWait(timeout time.Duration, name string, ns st
 	}
 }
 
-func (data *TestData) waitForServiceRealized(timeout time.Duration, name string) error {
-	if err := wait.Poll(defaultInterval, timeout, func() (bool, error) {
-		svc, err := data.clientset.CoreV1().Services(testNamespace).Get(context.TODO(), name, metav1.GetOptions{})
-		if svc != nil && err == nil {
-			return true, nil
-		}
-		return false, err
-	}); err == wait.ErrWaitTimeout {
-		return fmt.Errorf("service '%s' is not realized after %v", name, timeout)
-	} else {
-		return err
-	}
-}
-
 type PodCondition func(*corev1.Pod) (bool, error)
 
 // podWaitFor polls the K8s apiserver until the specified Pod is found (in the test Namespace) and


### PR DESCRIPTION
Change the mechanism to wait for service to be realized from `sleep` for a fixed length of time into poll to check the service exists in the namespace.

Fixes: #2275 