### PR TITLE
Change default port range for NodePortLocal

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -3791,7 +3791,7 @@ data:
     # Provide the port range used by NodePortLocal. When the NodePortLocal feature is enabled, a port from that range will be assigned
     # whenever a Pod's container defines a specific port to be exposed (each container can define a list of ports as pod.spec.containers[].ports),
     # and all Node traffic directed to that port will be forwarded to the Pod.
-    #nplPortRange: 40000-41000
+    #nplPortRange: 61000-62000
 
     # Provide the address of Kubernetes apiserver, to override any value provided in kubeconfig or InClusterConfig.
     # Defaults to "". It must be a host string, a host:port pair, or a URL to the base of the apiserver.
@@ -3887,7 +3887,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-gb8bgg4d2m
+  name: antrea-config-tgm22b6g5t
   namespace: kube-system
 ---
 apiVersion: v1
@@ -3958,7 +3958,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-gb8bgg4d2m
+          value: antrea-config-tgm22b6g5t
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4009,7 +4009,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-gb8bgg4d2m
+          name: antrea-config-tgm22b6g5t
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4305,7 +4305,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-gb8bgg4d2m
+          name: antrea-config-tgm22b6g5t
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -3791,7 +3791,7 @@ data:
     # Provide the port range used by NodePortLocal. When the NodePortLocal feature is enabled, a port from that range will be assigned
     # whenever a Pod's container defines a specific port to be exposed (each container can define a list of ports as pod.spec.containers[].ports),
     # and all Node traffic directed to that port will be forwarded to the Pod.
-    #nplPortRange: 40000-41000
+    #nplPortRange: 61000-62000
 
     # Provide the address of Kubernetes apiserver, to override any value provided in kubeconfig or InClusterConfig.
     # Defaults to "". It must be a host string, a host:port pair, or a URL to the base of the apiserver.
@@ -3887,7 +3887,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-gb8bgg4d2m
+  name: antrea-config-tgm22b6g5t
   namespace: kube-system
 ---
 apiVersion: v1
@@ -3958,7 +3958,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-gb8bgg4d2m
+          value: antrea-config-tgm22b6g5t
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4009,7 +4009,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-gb8bgg4d2m
+          name: antrea-config-tgm22b6g5t
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4307,7 +4307,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-gb8bgg4d2m
+          name: antrea-config-tgm22b6g5t
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -3791,7 +3791,7 @@ data:
     # Provide the port range used by NodePortLocal. When the NodePortLocal feature is enabled, a port from that range will be assigned
     # whenever a Pod's container defines a specific port to be exposed (each container can define a list of ports as pod.spec.containers[].ports),
     # and all Node traffic directed to that port will be forwarded to the Pod.
-    #nplPortRange: 40000-41000
+    #nplPortRange: 61000-62000
 
     # Provide the address of Kubernetes apiserver, to override any value provided in kubeconfig or InClusterConfig.
     # Defaults to "". It must be a host string, a host:port pair, or a URL to the base of the apiserver.
@@ -3887,7 +3887,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-4gm249hc95
+  name: antrea-config-246k7dkb5c
   namespace: kube-system
 ---
 apiVersion: v1
@@ -3958,7 +3958,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-4gm249hc95
+          value: antrea-config-246k7dkb5c
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4009,7 +4009,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-4gm249hc95
+          name: antrea-config-246k7dkb5c
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4308,7 +4308,7 @@ spec:
           path: /home/kubernetes/bin
         name: host-cni-bin
       - configMap:
-          name: antrea-config-4gm249hc95
+          name: antrea-config-246k7dkb5c
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -3796,7 +3796,7 @@ data:
     # Provide the port range used by NodePortLocal. When the NodePortLocal feature is enabled, a port from that range will be assigned
     # whenever a Pod's container defines a specific port to be exposed (each container can define a list of ports as pod.spec.containers[].ports),
     # and all Node traffic directed to that port will be forwarded to the Pod.
-    #nplPortRange: 40000-41000
+    #nplPortRange: 61000-62000
 
     # Provide the address of Kubernetes apiserver, to override any value provided in kubeconfig or InClusterConfig.
     # Defaults to "". It must be a host string, a host:port pair, or a URL to the base of the apiserver.
@@ -3892,7 +3892,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-4949869kb7
+  name: antrea-config-5mt4h4g8tk
   namespace: kube-system
 ---
 apiVersion: v1
@@ -3972,7 +3972,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-4949869kb7
+          value: antrea-config-5mt4h4g8tk
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4023,7 +4023,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-4949869kb7
+          name: antrea-config-5mt4h4g8tk
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4354,7 +4354,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-4949869kb7
+          name: antrea-config-5mt4h4g8tk
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -3796,7 +3796,7 @@ data:
     # Provide the port range used by NodePortLocal. When the NodePortLocal feature is enabled, a port from that range will be assigned
     # whenever a Pod's container defines a specific port to be exposed (each container can define a list of ports as pod.spec.containers[].ports),
     # and all Node traffic directed to that port will be forwarded to the Pod.
-    #nplPortRange: 40000-41000
+    #nplPortRange: 61000-62000
 
     # Provide the address of Kubernetes apiserver, to override any value provided in kubeconfig or InClusterConfig.
     # Defaults to "". It must be a host string, a host:port pair, or a URL to the base of the apiserver.
@@ -3892,7 +3892,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-dcfb6k2hkm
+  name: antrea-config-2567tcm8ck
   namespace: kube-system
 ---
 apiVersion: v1
@@ -3963,7 +3963,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-dcfb6k2hkm
+          value: antrea-config-2567tcm8ck
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4014,7 +4014,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-dcfb6k2hkm
+          name: antrea-config-2567tcm8ck
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4310,7 +4310,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-dcfb6k2hkm
+          name: antrea-config-2567tcm8ck
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/base/conf/antrea-agent.conf
+++ b/build/yamls/base/conf/antrea-agent.conf
@@ -133,7 +133,7 @@ featureGates:
 # Provide the port range used by NodePortLocal. When the NodePortLocal feature is enabled, a port from that range will be assigned
 # whenever a Pod's container defines a specific port to be exposed (each container can define a list of ports as pod.spec.containers[].ports),
 # and all Node traffic directed to that port will be forwarded to the Pod.
-#nplPortRange: 40000-41000
+#nplPortRange: 61000-62000
 
 # Provide the address of Kubernetes apiserver, to override any value provided in kubeconfig or InClusterConfig.
 # Defaults to "". It must be a host string, a host:port pair, or a URL to the base of the apiserver.

--- a/cmd/antrea-agent/options.go
+++ b/cmd/antrea-agent/options.go
@@ -44,7 +44,7 @@ const (
 	defaultFlowPollInterval        = 5 * time.Second
 	defaultActiveFlowExportTimeout = 30 * time.Second
 	defaultIdleFlowExportTimeout   = 15 * time.Second
-	defaultNPLPortRange            = "40000-41000"
+	defaultNPLPortRange            = "61000-62000"
 )
 
 type Options struct {

--- a/docs/feature-gates.md
+++ b/docs/feature-gates.md
@@ -167,7 +167,7 @@ each port of a Pod can be reached from external network using a port in the Node
 on which the Pod is running. In addition to enabling NodePortLocal feature gate,
 the value of `nplPortRange` can be set in Antrea Agent configuration through ConfigMap.
 Ports from a Node will be allocated from the range of ports specified in `nplPortRange`.
-If the value of `nplPortRange` is not specified, the range `40000-41000` will be used as
+If the value of `nplPortRange` is not specified, the range `61000-62000` will be used as
 default.
 
 Pods can be selected for `NodePortLocal` by tagging a Service with Annotation:
@@ -183,11 +183,11 @@ apiVersion: v1
 kind: Pod
 metadata:
   annotations:
-    nodeportlocal.antrea.io: '[{"podPort":8080,"nodeIP":"10.10.10.10","nodePort":40002}]'
+    nodeportlocal.antrea.io: '[{"podPort":8080,"nodeIP":"10.10.10.10","nodePort":61002}]'
 
 ```
 
-This annotation denotes that the port 8080 of the Pod can be reached through port 40002 of the
+This annotation denotes that the port 8080 of the Pod can be reached through port 61002 of the
 Node with IP Address 10.10.10.10.
 
 #### Requirements for this Feature

--- a/pkg/agent/nodeportlocal/k8s/annotations_test.go
+++ b/pkg/agent/nodeportlocal/k8s/annotations_test.go
@@ -27,22 +27,22 @@ func BenchmarkCompareNPLAnnotationLists(b *testing.B) {
 	a1 := NPLAnnotation{
 		PodPort:  80,
 		NodeIP:   nodeIP,
-		NodePort: 40000,
+		NodePort: 61000,
 	}
 	a2 := NPLAnnotation{
 		PodPort:  8080,
 		NodeIP:   nodeIP,
-		NodePort: 40001,
+		NodePort: 61001,
 	}
 	a3 := NPLAnnotation{
 		PodPort:  81,
 		NodeIP:   nodeIP,
-		NodePort: 40002,
+		NodePort: 61002,
 	}
 	a4 := NPLAnnotation{
 		PodPort:  8081,
 		NodeIP:   nodeIP,
-		NodePort: 40003,
+		NodePort: 61003,
 	}
 	benchmarkCases := []struct {
 		name         string

--- a/pkg/agent/nodeportlocal/npl_agent_test.go
+++ b/pkg/agent/nodeportlocal/npl_agent_test.go
@@ -41,7 +41,7 @@ import (
 )
 
 func newPortTable(c *gomock.Controller) *portcache.PortTable {
-	ptable := portcache.PortTable{StartPort: 40000, EndPort: 45000}
+	ptable := portcache.PortTable{StartPort: 61000, EndPort: 65000}
 	ptable.Table = make(map[int]portcache.NodePortData)
 
 	mockTable := npltest.NewMockPodPortRules(c)

--- a/test/e2e/nodeportlocal_test.go
+++ b/test/e2e/nodeportlocal_test.go
@@ -32,10 +32,10 @@ import (
 )
 
 const (
-	defaultStartPort  = 40000
-	defaultEndPort    = 41000
-	updatedStartPort  = 42000
-	updatedEndPort    = 43000
+	defaultStartPort  = 61000
+	defaultEndPort    = 62000
+	updatedStartPort  = 63000
+	updatedEndPort    = 64000
 	defaultTargetPort = 80
 )
 


### PR DESCRIPTION
From 40000-41000 to 61000-62000, to avoid conflict with the default
ip_local_port_range on Linux. This may be a slighlty disruptive change
to users who rely on the NPL feature: NPL port mappings for all existing
Pods will be updated to use the new range. However, I consider this
acceptable and it's better to make this change while NPL is still an
Alpha feature. Note that this behavior is verified by an e2e test:
TestNPLChangePortRangeAgentRestart.

See #2381

Signed-off-by: Antonin Bas <abas@vmware.com>