### PR TITLE
Fix ACNP incorrectly process rules with no From/To in rules

### DIFF
--- a/docs/antrea-network-policy.md
+++ b/docs/antrea-network-policy.md
@@ -12,6 +12,7 @@
   - [The Antrea ClusterNetworkPolicy resource](#the-antrea-clusternetworkpolicy-resource)
     - [ACNP with stand alone selectors](#acnp-with-stand-alone-selectors)
     - [ACNP with ClusterGroup reference](#acnp-with-clustergroup-reference)
+    - [ACNP for Pod-level isolation in Namespaces](#acnp-for-pod-level-isolation-in-namespaces)
     - [ACNP for default Namespace isolation](#acnp-for-default-namespace-isolation)
   - [Behavior of <em>to</em> and <em>from</em> selectors](#behavior-of-to-and-from-selectors)
   - [Key differences from K8s NetworkPolicy](#key-differences-from-k8s-networkpolicy)
@@ -265,6 +266,30 @@ spec:
       enableLogging: true
 ```
 
+#### ACNP for Pod-level isolation in Namespaces
+
+```yaml
+apiVersion: crd.antrea.io/v1alpha1
+kind: ClusterNetworkPolicy
+metadata:
+  name: isolate-all-pods-in-namespace
+spec:
+  priority: 1
+  tier: securityOps
+  appliedTo:
+    - namespaceSelector:
+        matchLabels:
+          app: no-network-access-required
+  ingress:
+    - action: Drop              # For all Pods in those Namespaces, drop and log all ingress traffic from anywhere
+      name: drop-all-ingress
+      enableLogging: true
+  egress:
+    - action: Drop              # For all Pods in those Namespaces, drop and log all egress traffic towards anywhere
+      name: drop-all-egress
+      enableLogging: true
+```
+
 #### ACNP for default Namespace isolation
 
 ```yaml
@@ -324,6 +349,8 @@ In the [first example](#acnp-with-stand-alone-selectors), the policy applies to 
 labels "env=prod".
 The [second example](#acnp-with-clustergroup-reference) policy applies to all network endpoints selected by the
 "test-cg-with-db-selector" ClusterGroup.
+The [third example](#acnp-for-pod-level-isolation-in-namespaces) policy applies to all Pods in the Namespaces that
+matches label "app=no-network-access-required".
 
 **priority**: The `priority` field determines the relative priority of the
 policy among all ClusterNetworkPolicies in the given cluster. This field is
@@ -360,7 +387,11 @@ and the second specified by a combination of a `podSelector` and a
 The [second example](#acnp-with-clustergroup-reference) policy contains a single rule, which allows matched traffic on
 multiple TCP ports (8000 through 9000 included, plus 6379) from all network endpoints
 selected by the "test-cg-with-frontend-selector" ClusterGroup.
-**Note**: The order in which the ingress rules are set matter, i.e. rules will
+The [third example](#acnp-for-pod-level-isolation-in-namespaces) policy contains a single rule,
+which drops all ingress traffic towards any Pod in Namespaces that has label `app` set to
+`no-network-access-required`. Note that an empty `From` in the ingress rule means that
+this rule matches all ingress sources.
+**Note**: The order in which the ingress rules are specified matters, i.e., rules will
 be enforced in the order in which they are written.
 
 **egress**: Each ClusterNetworkPolicy may consist of zero or more ordered set
@@ -379,7 +410,11 @@ single port, to the 10.0.10.0/24 subnet specified by the `ipBlock` field.
 The [second example](#acnp-with-clustergroup-reference) policy contains a single rule, which drops matched traffic on
 TCP port 5978 to all network endpoints selected by the "test-cg-with-ip-block"
 ClusterGroup.
-**Note**: The order in which the egress rules are set matter, i.e. rules will
+The [third example](#acnp-for-pod-level-isolation-in-namespaces) policy contains a single rule,
+which drops all egress traffic initiated by any Pod in Namespaces that has label `app` set to
+`no-network-access-required`. Note that an empty `To` in the egress rule means that
+this rule matches all egress destinations.
+**Note**: The order in which the egress rules are specified matters, i.e., rules will
 be enforced in the order in which they are written.
 
 **enableLogging**: A ClusterNetworkPolicy ingress or egress rule can be
@@ -433,7 +468,7 @@ that the corresponding `podSelector` (or all Pods if `podSelector` is not set)
 should only select Pods belonging to the same Namespace as the workload targeted
 (either through a policy-level AppliedTo or a rule-level Applied-To) by the current
 ingress or egress rule. This enables policy writers to create per-Namespace rules within a
-single policy. See the [third example](#acnp-for-default-namespace-isolation) YAML above. This field is
+single policy. See the [example](#acnp-for-default-namespace-isolation) YAML above. This field is
 optional and cannot be set along with a `namespaceSelector` within the same peer.
 
 **group**: A `group` refers to a ClusterGroup to which this ingress/egress peer, or

--- a/docs/antrea-network-policy.md
+++ b/docs/antrea-network-policy.md
@@ -12,7 +12,7 @@
   - [The Antrea ClusterNetworkPolicy resource](#the-antrea-clusternetworkpolicy-resource)
     - [ACNP with stand alone selectors](#acnp-with-stand-alone-selectors)
     - [ACNP with ClusterGroup reference](#acnp-with-clustergroup-reference)
-    - [ACNP for Pod-level isolation in Namespaces](#acnp-for-pod-level-isolation-in-namespaces)
+    - [ACNP for complete Pod isolation in selected Namespaces](#acnp-for-complete-pod-isolation-in-selected-namespaces)
     - [ACNP for default Namespace isolation](#acnp-for-default-namespace-isolation)
   - [Behavior of <em>to</em> and <em>from</em> selectors](#behavior-of-to-and-from-selectors)
   - [Key differences from K8s NetworkPolicy](#key-differences-from-k8s-networkpolicy)
@@ -266,7 +266,7 @@ spec:
       enableLogging: true
 ```
 
-#### ACNP for Pod-level isolation in Namespaces
+#### ACNP for complete Pod isolation in selected Namespaces
 
 ```yaml
 apiVersion: crd.antrea.io/v1alpha1
@@ -349,8 +349,8 @@ In the [first example](#acnp-with-stand-alone-selectors), the policy applies to 
 labels "env=prod".
 The [second example](#acnp-with-clustergroup-reference) policy applies to all network endpoints selected by the
 "test-cg-with-db-selector" ClusterGroup.
-The [third example](#acnp-for-pod-level-isolation-in-namespaces) policy applies to all Pods in the Namespaces that
-matches label "app=no-network-access-required".
+The [third example](#acnp-for-complete-pod-isolation-in-selected-namespaces) policy applies to all Pods in the
+Namespaces that matches label "app=no-network-access-required".
 
 **priority**: The `priority` field determines the relative priority of the
 policy among all ClusterNetworkPolicies in the given cluster. This field is
@@ -387,8 +387,8 @@ and the second specified by a combination of a `podSelector` and a
 The [second example](#acnp-with-clustergroup-reference) policy contains a single rule, which allows matched traffic on
 multiple TCP ports (8000 through 9000 included, plus 6379) from all network endpoints
 selected by the "test-cg-with-frontend-selector" ClusterGroup.
-The [third example](#acnp-for-pod-level-isolation-in-namespaces) policy contains a single rule,
-which drops all ingress traffic towards any Pod in Namespaces that has label `app` set to
+The [third example](#acnp-for-complete-pod-isolation-in-selected-namespaces) policy contains a single rule,
+which drops all ingress traffic towards any Pod in Namespaces that have label `app` set to
 `no-network-access-required`. Note that an empty `From` in the ingress rule means that
 this rule matches all ingress sources.
 **Note**: The order in which the ingress rules are specified matters, i.e., rules will
@@ -410,8 +410,8 @@ single port, to the 10.0.10.0/24 subnet specified by the `ipBlock` field.
 The [second example](#acnp-with-clustergroup-reference) policy contains a single rule, which drops matched traffic on
 TCP port 5978 to all network endpoints selected by the "test-cg-with-ip-block"
 ClusterGroup.
-The [third example](#acnp-for-pod-level-isolation-in-namespaces) policy contains a single rule,
-which drops all egress traffic initiated by any Pod in Namespaces that has label `app` set to
+The [third example](#acnp-for-complete-pod-isolation-in-selected-namespaces) policy contains a single rule,
+which drops all egress traffic initiated by any Pod in Namespaces that have `app` set to
 `no-network-access-required`. Note that an empty `To` in the egress rule means that
 this rule matches all egress destinations.
 **Note**: The order in which the egress rules are specified matters, i.e., rules will

--- a/pkg/controller/networkpolicy/clusternetworkpolicy.go
+++ b/pkg/controller/networkpolicy/clusternetworkpolicy.go
@@ -307,7 +307,9 @@ func (n *NetworkPolicyController) processClusterNetworkPolicy(cnp *crdv1alpha1.C
 				}
 				rules = append(rules, rule)
 			}
-			if len(clusterPeers) > 0 {
+			// When a rule's NetworkPolicyPeer is empty, a cluster level rule should be created
+			// with an Antrea peer matching all addresses.
+			if len(clusterPeers) > 0 || len(perNSPeers) == 0 {
 				ruleAppliedTos := cnpRule.AppliedTo
 				// For ACNPs that have per-namespace rules, cluster-level rules will be created with appliedTo
 				// set as the spec appliedTo for each rule.

--- a/test/e2e/antreapolicy_test.go
+++ b/test/e2e/antreapolicy_test.go
@@ -865,7 +865,7 @@ func testACNPAllowNoDefaultIsolation(t *testing.T, protocol v1.Protocol) {
 	executeTests(t, testCase)
 }
 
-// testACNPDropEgress tests that a ACNP is able to drop egress traffic from pods labelled A to namespace Z.
+// testACNPDropEgress tests that an ACNP is able to drop egress traffic from pods labelled A to namespace Z.
 func testACNPDropEgress(t *testing.T, protocol v1.Protocol) {
 	if protocol == v1.ProtocolSCTP {
 		skipIfProviderIs(t, "kind", "OVS userspace conntrack does not have the SCTP support for now.")
@@ -906,7 +906,41 @@ func testACNPDropEgress(t *testing.T, protocol v1.Protocol) {
 	executeTests(t, testCase)
 }
 
-// testACNPNoEffectOnOtherProtocols tests that a ACNP which drops TCP traffic won't affect other protocols (e.g. UDP).
+// testACNPDropIngressInNamespace tests that an ACNP is able to drop all ingress traffic towards a specific Namespace.
+// The ACNP is created by selecting the Namespace as an appliedTo, and adding an ingress rule with Drop action and
+// no `From` (which translate to drop ingress from everywhere).
+func testACNPDropIngressToNamespace(t *testing.T) {
+	builder := &ClusterNetworkPolicySpecBuilder{}
+	builder = builder.SetName("acnp-deny-ingress-to-x").
+		SetPriority(1.0).
+		SetAppliedToGroup([]ACNPAppliedToSpec{{NSSelector: map[string]string{"ns": "x"}}})
+	builder.AddIngress(v1.ProtocolTCP, &p80, nil, nil, nil, nil, nil, nil, nil, false, nil,
+		crdv1alpha1.RuleActionDrop, "", "drop-all-ingress")
+
+	reachability := NewReachability(allPods, Connected)
+	reachability.ExpectAllIngress("x/a", Dropped)
+	reachability.ExpectAllIngress("x/b", Dropped)
+	reachability.ExpectAllIngress("x/c", Dropped)
+	reachability.ExpectSelf(allPods, Connected)
+	testStep := []*TestStep{
+		{
+			"Port 80",
+			reachability,
+			[]metav1.Object{builder.Get()},
+			nil,
+			[]int32{80},
+			v1.ProtocolTCP,
+			0,
+			nil,
+		},
+	}
+	testCase := []*TestCase{
+		{"ACNP Drop all Ingress to Namespace x", testStep},
+	}
+	executeTests(t, testCase)
+}
+
+// testACNPNoEffectOnOtherProtocols tests that an ACNP which drops TCP traffic won't affect other protocols (e.g. UDP).
 func testACNPNoEffectOnOtherProtocols(t *testing.T) {
 	builder := &ClusterNetworkPolicySpecBuilder{}
 	builder = builder.SetName("acnp-deny-a-to-z-ingress").
@@ -1029,7 +1063,7 @@ func testACNPIngressRuleDenyCGWithXBtoYA(t *testing.T) {
 	executeTests(t, testCase)
 }
 
-// testACNPAppliedToRuleCGWithPodsAToNsZ tests that a ACNP is able to drop egress traffic from CG with pods labelled A namespace Z.
+// testACNPAppliedToRuleCGWithPodsAToNsZ tests that an ACNP is able to drop egress traffic from CG with pods labelled A namespace Z.
 func testACNPAppliedToRuleCGWithPodsAToNsZ(t *testing.T) {
 	cgName := "cg-pods-a"
 	cgBuilder := &ClusterGroupV1Alpha3SpecBuilder{}
@@ -1063,7 +1097,7 @@ func testACNPAppliedToRuleCGWithPodsAToNsZ(t *testing.T) {
 	executeTests(t, testCase)
 }
 
-// testACNPEgressRulePodsAToCGWithNsZ tests that a ACNP is able to drop egress traffic from pods labelled A to a CG with namespace Z.
+// testACNPEgressRulePodsAToCGWithNsZ tests that an ACNP is able to drop egress traffic from pods labelled A to a CG with namespace Z.
 func testACNPEgressRulePodsAToCGWithNsZ(t *testing.T) {
 	cgName := "cg-ns-z"
 	cgBuilder := &ClusterGroupV1Alpha3SpecBuilder{}
@@ -1368,7 +1402,7 @@ func testACNPClusterGroupRefRuleIPBlocks(t *testing.T) {
 	executeTests(t, testCase)
 }
 
-// testBaselineNamespaceIsolation tests that a ACNP in the baseline Tier is able to enforce default namespace isolation,
+// testBaselineNamespaceIsolation tests that an ACNP in the baseline Tier is able to enforce default namespace isolation,
 // which can be later overridden by developer K8s NetworkPolicies.
 func testBaselineNamespaceIsolation(t *testing.T) {
 	builder := &ClusterNetworkPolicySpecBuilder{}
@@ -1728,7 +1762,7 @@ func testACNPRulePriority(t *testing.T) {
 	executeTests(t, testCase)
 }
 
-// testACNPPortRange tests the port range in a ACNP can work.
+// testACNPPortRange tests the port range in an ACNP can work.
 func testACNPPortRange(t *testing.T) {
 	builder := &ClusterNetworkPolicySpecBuilder{}
 	builder = builder.SetName("acnp-deny-a-to-z-egress-port-range").
@@ -1761,7 +1795,7 @@ func testACNPPortRange(t *testing.T) {
 	executeTests(t, testCase)
 }
 
-// testACNPRejectEgress tests that a ACNP is able to reject egress traffic from pods labelled A to namespace Z.
+// testACNPRejectEgress tests that an ACNP is able to reject egress traffic from pods labelled A to namespace Z.
 func testACNPRejectEgress(t *testing.T) {
 	builder := &ClusterNetworkPolicySpecBuilder{}
 	builder = builder.SetName("acnp-reject-a-to-z-egress").
@@ -1793,8 +1827,8 @@ func testACNPRejectEgress(t *testing.T) {
 	executeTests(t, testCase)
 }
 
-// testACNPRejectIngress tests that a ACNP is able to reject egress traffic from pods labelled A to namespace Z.
-func testACNPRejectIngress(t *testing.T, data *TestData, protocol v1.Protocol) {
+// testACNPRejectIngress tests that an ACNP is able to reject egress traffic from pods labelled A to namespace Z.
+func testACNPRejectIngress(t *testing.T, protocol v1.Protocol) {
 	builder := &ClusterNetworkPolicySpecBuilder{}
 	builder = builder.SetName("acnp-reject-a-from-z-ingress").
 		SetPriority(1.0).
@@ -2693,10 +2727,11 @@ func TestAntreaPolicy(t *testing.T) {
 		t.Run("Case=ACNPDropEgress", func(t *testing.T) { testACNPDropEgress(t, v1.ProtocolTCP) })
 		t.Run("Case=ACNPDropEgressUDP", func(t *testing.T) { testACNPDropEgress(t, v1.ProtocolUDP) })
 		t.Run("Case=ACNPDropEgressSCTP", func(t *testing.T) { testACNPDropEgress(t, v1.ProtocolSCTP) })
+		t.Run("Case=ACNPDropIngressToNamespace", func(t *testing.T) { testACNPDropIngressToNamespace(t) })
 		t.Run("Case=ACNPPortRange", func(t *testing.T) { testACNPPortRange(t) })
 		t.Run("Case=ACNPRejectEgress", func(t *testing.T) { testACNPRejectEgress(t) })
-		t.Run("Case=ACNPRejectIngress", func(t *testing.T) { testACNPRejectIngress(t, data, v1.ProtocolTCP) })
-		t.Run("Case=ACNPRejectIngressUDP", func(t *testing.T) { testACNPRejectIngress(t, data, v1.ProtocolUDP) })
+		t.Run("Case=ACNPRejectIngress", func(t *testing.T) { testACNPRejectIngress(t, v1.ProtocolTCP) })
+		t.Run("Case=ACNPRejectIngressUDP", func(t *testing.T) { testACNPRejectIngress(t, v1.ProtocolUDP) })
 		t.Run("Case=ACNPNoEffectOnOtherProtocols", func(t *testing.T) { testACNPNoEffectOnOtherProtocols(t) })
 		t.Run("Case=ACNPBaselinePolicy", func(t *testing.T) { testBaselineNamespaceIsolation(t) })
 		t.Run("Case=ACNPPriorityOverride", func(t *testing.T) { testACNPPriorityOverride(t) })

--- a/test/e2e/antreapolicy_test.go
+++ b/test/e2e/antreapolicy_test.go
@@ -906,10 +906,10 @@ func testACNPDropEgress(t *testing.T, protocol v1.Protocol) {
 	executeTests(t, testCase)
 }
 
-// testACNPDropIngressInNamespace tests that an ACNP is able to drop all ingress traffic towards a specific Namespace.
+// testACNPDropIngressInSelectedNamespace tests that an ACNP is able to drop all ingress traffic towards a specific Namespace.
 // The ACNP is created by selecting the Namespace as an appliedTo, and adding an ingress rule with Drop action and
 // no `From` (which translate to drop ingress from everywhere).
-func testACNPDropIngressToNamespace(t *testing.T) {
+func testACNPDropIngressInSelectedNamespace(t *testing.T) {
 	builder := &ClusterNetworkPolicySpecBuilder{}
 	builder = builder.SetName("acnp-deny-ingress-to-x").
 		SetPriority(1.0).
@@ -2727,7 +2727,7 @@ func TestAntreaPolicy(t *testing.T) {
 		t.Run("Case=ACNPDropEgress", func(t *testing.T) { testACNPDropEgress(t, v1.ProtocolTCP) })
 		t.Run("Case=ACNPDropEgressUDP", func(t *testing.T) { testACNPDropEgress(t, v1.ProtocolUDP) })
 		t.Run("Case=ACNPDropEgressSCTP", func(t *testing.T) { testACNPDropEgress(t, v1.ProtocolSCTP) })
-		t.Run("Case=ACNPDropIngressToNamespace", func(t *testing.T) { testACNPDropIngressToNamespace(t) })
+		t.Run("Case=ACNPDropIngressInNamespace", func(t *testing.T) { testACNPDropIngressInSelectedNamespace(t) })
 		t.Run("Case=ACNPPortRange", func(t *testing.T) { testACNPPortRange(t) })
 		t.Run("Case=ACNPRejectEgress", func(t *testing.T) { testACNPRejectEgress(t) })
 		t.Run("Case=ACNPRejectIngress", func(t *testing.T) { testACNPRejectIngress(t, v1.ProtocolTCP) })

--- a/test/e2e/utils/anpspecbuilder.go
+++ b/test/e2e/utils/anpspecbuilder.go
@@ -137,7 +137,8 @@ func (b *AntreaNetworkPolicySpecBuilder) AddIngress(protoc v1.Protocol,
 	for _, at := range ruleAppliedToSpecs {
 		appliedTos = append(appliedTos, b.GetAppliedToPeer(at.PodSelector, at.PodSelectorMatchExp))
 	}
-	var policyPeer []crdv1alpha1.NetworkPolicyPeer
+	// An empty From/To in ANP rules evaluates to match all addresses.
+	policyPeer := make([]crdv1alpha1.NetworkPolicyPeer, 0)
 	if ps != nil || ns != nil || ipBlock != nil {
 		policyPeer = []crdv1alpha1.NetworkPolicyPeer{{
 			PodSelector:       ps,

--- a/test/e2e/utils/cnpspecbuilder.go
+++ b/test/e2e/utils/cnpspecbuilder.go
@@ -162,7 +162,8 @@ func (b *ClusterNetworkPolicySpecBuilder) AddIngress(protoc v1.Protocol,
 	for _, at := range ruleAppliedToSpecs {
 		appliedTos = append(appliedTos, b.GetAppliedToPeer(at.PodSelector, at.NSSelector, at.PodSelectorMatchExp, at.NSSelectorMatchExp, at.Group))
 	}
-	var policyPeer []crdv1alpha1.NetworkPolicyPeer
+	// An empty From/To in ACNP rules evaluates to match all addresses.
+	policyPeer := make([]crdv1alpha1.NetworkPolicyPeer, 0)
 	if pSel != nil || nSel != nil || ns != nil || ipBlock != nil || ruleClusterGroup != "" {
 		policyPeer = []crdv1alpha1.NetworkPolicyPeer{{
 			PodSelector:       pSel,


### PR DESCRIPTION
This PR fixes #2380. When the From/To in ACNP ingress/egress rule is empty, there will be no clusterPeers or perNSPeers. However, a cluster level rule should still be created with peer being `matchAllPeer`, as defined:
```
NetworkPolicyPeer is supposed to match all addresses when it is empty and no clusterGroup is present.
It's treated as an IPBlock "0.0.0.0/0".
```
This PR also adds E2E testcase for this specific scenario and updates the doc to inform user of this usage.
Thanks to @tnqn for raising this issue.