### PR TITLE
Support TCP transport for elk flow collector

### DIFF
--- a/build/yamls/elk-flow-collector/elk-flow-collector.yml
+++ b/build/yamls/elk-flow-collector/elk-flow-collector.yml
@@ -190,7 +190,12 @@ spec:
   ports:
     - port: 4739
       targetPort: 4739
+      protocol: TCP
+      name: logstash-tcp
+    - port: 4739
+      targetPort: 4739
       protocol: UDP
+      name: logstash-udp
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -226,6 +231,10 @@ spec:
           ports:
             - containerPort: 4739
               protocol: UDP
+              name: logstash-udp
+            - containerPort: 4739
+              protocol: TCP
+              name: logstash-tcp
       nodeSelector:
         kubernetes.io/os: linux
         kubernetes.io/arch: amd64

--- a/build/yamls/elk-flow-collector/logstash/logstash.conf
+++ b/build/yamls/elk-flow-collector/logstash/logstash.conf
@@ -18,6 +18,19 @@ input {
     }
     type => "ipfix"
   }
+  tcp {
+    host => "${POD_IP}"
+    port => "4739"
+    codec => netflow {
+      versions => [10]
+      target => "ipfix"
+      include_flowset_id => "true"
+      # Set template expiration time to 365 days
+      cache_ttl => 31536000
+      ipfix_definitions => "/usr/share/logstash/definitions/ipfix.yml"
+    }
+    type => "ipfix"
+  }
 }
 
 filter {

--- a/docs/network-flow-visibility.md
+++ b/docs/network-flow-visibility.md
@@ -263,7 +263,7 @@ then please use the address:
 `<Ipfix-Collector Cluster IP>:<port>:<TCP|UDP>`
 * If you have deployed the [ELK
 flow collector](#deployment-steps-1), then please use the address:  
-`<Logstash Cluster IP>:4739:UDP`
+`<Logstash Cluster IP>:4739:<TCP|UDP>`
 
 ```yaml
 flow-aggregator.conf: |


### PR DESCRIPTION
Previously we do not support tcp transport for elk flow collector because template expiration is set by default for tcp transport, which does not align with IANA standard. 
Now we set expiration for templates from tcp to 365 days as workaround to provide support for tcp transport.