### PR TITLE
Support timestamp filter in antctl supportbundle command

### DIFF
--- a/pkg/antctl/raw/supportbundle/command.go
+++ b/pkg/antctl/raw/supportbundle/command.go
@@ -62,6 +62,7 @@ var option = &struct {
 	labelSelector  string
 	controllerOnly bool
 	nodeListFile   string
+	since          string
 }{}
 
 var remoteControllerLongDescription = strings.TrimSpace(`
@@ -73,6 +74,8 @@ var remoteControllerExample = strings.Trim(`
   $ antctl supportbundle
   Generate support bundle of the controller
   $ antctl supportbundle --controller-only
+  Generate support bundle of the controller and agents on all Nodes with only the logs generated during the last 1 hour
+  $ antctl supportbundle --since 1h
   Generate support bundles of agents on specific Nodes filtered by name list, no wildcard support
   $ antctl supportbundle node_a node_b node_c
   Generate support bundles of agents on specific Nodes filtered by names in a file (one Node name per line)
@@ -104,7 +107,8 @@ func init() {
 		Command.Flags().StringVarP(&option.dir, "dir", "d", "", "support bundles output dir, the path will be created if it doesn't exist")
 		Command.Flags().StringVarP(&option.labelSelector, "label-selector", "l", "", "selector (label query) to filter Nodes for agent bundles, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
 		Command.Flags().BoolVar(&option.controllerOnly, "controller-only", false, "only collect the support bundle of Antrea controller")
-		Command.Flags().StringVarP(&option.nodeListFile, "node-list-file", "f", "", "only collect the support bundle of Antrea controller")
+		Command.Flags().StringVarP(&option.nodeListFile, "node-list-file", "f", "", "only collect the support bundle of specific nodes filtered by names in a file (one node name per line)")
+		Command.Flags().StringVarP(&option.since, "since", "", "", "only return logs newer than a relative duration like 5s, 2m or 3h. Defaults to all logs")
 		Command.RunE = controllerRemoteRunE
 	}
 }
@@ -160,7 +164,7 @@ func request(component string, client *rest.RESTClient) error {
 	var err error
 	_, err = client.Post().
 		Resource("supportbundles").
-		Body(&systemv1beta1.SupportBundle{ObjectMeta: metav1.ObjectMeta{Name: component}}).
+		Body(&systemv1beta1.SupportBundle{ObjectMeta: metav1.ObjectMeta{Name: component}, Since: option.since}).
 		DoRaw(context.TODO())
 	if err == nil {
 		return nil

--- a/pkg/apis/system/v1beta1/types.go
+++ b/pkg/apis/system/v1beta1/types.go
@@ -35,6 +35,7 @@ type SupportBundle struct {
 
 	Status   BundleStatus `json:"status,omitempty"`
 	Sum      string       `json:"sum,omitempty"`
+	Since    string       `json:"since,omitempty"`
 	Size     uint32       `json:"size,omitempty"`
 	Filepath string       `json:"-"`
 }

--- a/pkg/apiserver/openapi/zz_generated.openapi.go
+++ b/pkg/apiserver/openapi/zz_generated.openapi.go
@@ -3742,6 +3742,12 @@ func schema_pkg_apis_system_v1beta1_SupportBundle(ref common.ReferenceCallback) 
 							Format: "",
 						},
 					},
+					"since": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 					"size": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"integer"},

--- a/pkg/apiserver/registry/system/supportbundle/rest.go
+++ b/pkg/apiserver/registry/system/supportbundle/rest.go
@@ -133,17 +133,17 @@ func (r *supportBundleREST) Create(ctx context.Context, obj runtime.Object, _ re
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	r.cache = &systemv1beta1.SupportBundle{
 		ObjectMeta: metav1.ObjectMeta{Name: r.mode},
+		Since:      requestBundle.Since,
 		Status:     systemv1beta1.SupportBundleStatusCollecting,
 	}
 	r.cancelFunc = cancelFunc
-
-	go func() {
+	go func(since string) {
 		var err error
 		var b *systemv1beta1.SupportBundle
 		if r.mode == modeAgent {
-			b, err = r.collectAgent(ctx)
+			b, err = r.collectAgent(ctx, since)
 		} else if r.mode == modeController {
-			b, err = r.collectController(ctx)
+			b, err = r.collectController(ctx, since)
 		}
 		func() {
 			r.statusLocker.Lock()
@@ -159,10 +159,11 @@ func (r *supportBundleREST) Create(ctx context.Context, obj runtime.Object, _ re
 				r.cache = b
 			}
 		}()
+
 		if err != nil {
 			r.clean(ctx, b.Filepath, bundleExpireDuration)
 		}
-	}()
+	}(r.cache.Since)
 
 	return r.cache, nil
 }
@@ -251,8 +252,8 @@ func (r *supportBundleREST) collect(ctx context.Context, dumpers ...func(string)
 	}, nil
 }
 
-func (r *supportBundleREST) collectAgent(ctx context.Context) (*systemv1beta1.SupportBundle, error) {
-	dumper := support.NewAgentDumper(defaultFS, defaultExecutor, r.ovsCtlClient, r.aq, r.npq)
+func (r *supportBundleREST) collectAgent(ctx context.Context, since string) (*systemv1beta1.SupportBundle, error) {
+	dumper := support.NewAgentDumper(defaultFS, defaultExecutor, r.ovsCtlClient, r.aq, r.npq, since)
 	return r.collect(
 		ctx,
 		dumper.DumpLog,
@@ -265,8 +266,8 @@ func (r *supportBundleREST) collectAgent(ctx context.Context) (*systemv1beta1.Su
 	)
 }
 
-func (r *supportBundleREST) collectController(ctx context.Context) (*systemv1beta1.SupportBundle, error) {
-	dumper := support.NewControllerDumper(defaultFS, defaultExecutor)
+func (r *supportBundleREST) collectController(ctx context.Context, since string) (*systemv1beta1.SupportBundle, error) {
+	dumper := support.NewControllerDumper(defaultFS, defaultExecutor, since)
 	return r.collect(
 		ctx,
 		dumper.DumpLog,

--- a/pkg/log/log_file.go
+++ b/pkg/log/log_file.go
@@ -150,6 +150,8 @@ func checkLogFiles() {
 	infoLogFiles := []os.FileInfo{}
 	warningLogFiles := []os.FileInfo{}
 	errorLogFiles := []os.FileInfo{}
+	fatalLogFIles := []os.FileInfo{}
+
 	for _, file := range allFiles {
 		if !file.Mode().IsRegular() {
 			// Skip dir, symbol link, etc.
@@ -164,6 +166,8 @@ func checkLogFiles() {
 			warningLogFiles = append(warningLogFiles, file)
 		} else if strings.Contains(file.Name(), ".log.ERROR.") {
 			errorLogFiles = append(errorLogFiles, file)
+		} else if strings.Contains(file.Name(), ".log.FATAL.") {
+			fatalLogFIles = append(fatalLogFIles, file)
 		}
 	}
 
@@ -189,4 +193,5 @@ func checkLogFiles() {
 	checkFilesFn(infoLogFiles)
 	checkFilesFn(warningLogFiles)
 	checkFilesFn(errorLogFiles)
+	checkFilesFn(fatalLogFIles)
 }

--- a/pkg/support/dump.go
+++ b/pkg/support/dump.go
@@ -15,6 +15,7 @@
 package support
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -22,7 +23,9 @@ import (
 	"path"
 	"path/filepath"
 	"runtime/pprof"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/spf13/afero"
 	"k8s.io/utils/exec"
@@ -104,10 +107,52 @@ func dumpNetworkPolicyResources(fs afero.Fs, executor exec.Interface, basedir st
 	return dumpAntctlGet(fs, executor, "addressgroups", basedir)
 }
 
-// fileCopy copies files under the srcDir to the targetDir. Only files whose
-// name matches the prefixFilter will be copied. Copied files will be located
-// under the same relative path.
-func fileCopy(fs afero.Fs, targetDir string, srcDir string, prefixFilter string) error {
+func timestampFilter(since string) *time.Time {
+	var timeFilter *time.Time
+	if since != "" {
+		duration, _ := time.ParseDuration(since)
+		start := time.Now().Add(-duration)
+		timeFilter = &start
+	}
+	return timeFilter
+
+}
+
+// parseTimeFromFileName parse time from log file name.
+// example log file format: <component>.<hostname>.<user>.log.<level>.<yyyymmdd>-<hhmmss>.1
+func parseTimeFromFileName(name string) (time.Time, error) {
+	ss := strings.Split(name, ".")
+	ts := ss[len(ss)-2]
+	return time.Parse("20060102-150405", ts)
+
+}
+
+// parseTimeFromLogLine parse timestamp from the log line.
+// example(kubelet/agent/controller): "I0817 06:55:10.804384       1 shared_informer.go:270] caches populated"
+// example(ovs): "2021-06-02T16:18:52.285Z|00004|reconnect|INFO|unix:/var/run/openvswitch/db.sock: connecting..."
+// the first char indicates the log level.
+func parseTimeFromLogLine(log string, year string, prefix string) (time.Time, error) {
+	ss := strings.Split(log, ".")
+	if ss[0] == "" {
+		return time.Time{}, fmt.Errorf("log line is empty")
+	}
+
+	dateStr := year + ss[0][1:]
+	layout := "20060102 15:04:05"
+	if prefix == "ovs" {
+		dateStr = ss[0]
+		layout = "2006-01-02T15:04:05"
+	}
+
+	return time.Parse(layout, dateStr)
+
+}
+
+// directoryCopy copies files under the srcDir to the targetDir. Only files whose name matches
+// the prefixFilter will be copied. If prefixFiler is "", no filter is performed. At the same time, if the timeFilter is set,
+// only files whose modTime is later than the timeFilter will be copied. If a file contains both older logs and matched logs, only
+// the matched logs will be copied. Copied files will be located under the same relative path.
+func directoryCopy(fs afero.Fs, targetDir string, srcDir string, prefixFilter string, timeFilter *time.Time) error {
 	err := fs.MkdirAll(targetDir, os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("error when creating target dir: %w", err)
@@ -119,20 +164,53 @@ func fileCopy(fs afero.Fs, targetDir string, srcDir string, prefixFilter string)
 		if !info.Mode().IsRegular() {
 			return nil
 		}
-		if !strings.HasPrefix(info.Name(), prefixFilter) {
+		if prefixFilter != "" && !strings.HasPrefix(info.Name(), prefixFilter) {
 			return nil
 		}
+
+		if timeFilter != nil && info.ModTime().Before(*timeFilter) {
+			return nil
+		}
+
 		targetPath := path.Join(targetDir, info.Name())
 		targetFile, err := fs.Create(targetPath)
 		if err != nil {
 			return err
 		}
 		defer targetFile.Close()
+
 		srcFile, err := fs.Open(filePath)
 		if err != nil {
 			return err
 		}
 		defer srcFile.Close()
+
+		startTime, err := parseTimeFromFileName(info.Name())
+		if timeFilter != nil {
+			// if name contains timestamp, use it to find the first matched file. If not, such as ovs log file,
+			// just parse the log file (usually there is only one log file for each component)
+			if err == nil && startTime.Before(*timeFilter) || err != nil {
+				data := ""
+				scanner := bufio.NewScanner(srcFile)
+				for scanner.Scan() {
+					// the size limit of single log line is 64k. marked it as known issue and fix it if
+					// error occurs
+					line := scanner.Text()
+					if data != "" {
+						data += line + "\n"
+					} else {
+						ts, err := parseTimeFromLogLine(line, strconv.Itoa(timeFilter.Year()), prefixFilter)
+						if err == nil {
+							if !ts.Before(*timeFilter) {
+								data += line + "\n"
+							}
+						}
+					}
+				}
+				_, err = targetFile.WriteString(data)
+				return err
+			}
+		}
 		_, err = io.Copy(targetFile, srcFile)
 		return err
 	})
@@ -152,6 +230,7 @@ type controllerDumper struct {
 	fs       afero.Fs
 	executor exec.Interface
 	cq       controllerquerier.ControllerQuerier
+	since    string
 }
 
 func (d *controllerDumper) DumpControllerInfo(basedir string) error {
@@ -164,17 +243,18 @@ func (d *controllerDumper) DumpNetworkPolicyResources(basedir string) error {
 
 func (d *controllerDumper) DumpLog(basedir string) error {
 	logDir := logdir.GetLogDir()
-	return fileCopy(d.fs, path.Join(basedir, "logs", "controller"), logDir, "antrea-controller")
+	return directoryCopy(d.fs, path.Join(basedir, "logs", "controller"), logDir, "antrea-controller", timestampFilter(d.since))
 }
 
 func (d *controllerDumper) DumpHeapPprof(basedir string) error {
 	return DumpHeapPprof(d.fs, basedir)
 }
 
-func NewControllerDumper(fs afero.Fs, executor exec.Interface) ControllerDumper {
+func NewControllerDumper(fs afero.Fs, executor exec.Interface, since string) ControllerDumper {
 	return &controllerDumper{
 		fs:       fs,
 		executor: executor,
+		since:    since,
 	}
 }
 
@@ -184,6 +264,7 @@ type agentDumper struct {
 	ovsCtlClient ovsctl.OVSCtlClient
 	aq           agentquerier.AgentQuerier
 	npq          querier.AgentNetworkPolicyInfoQuerier
+	since        string
 }
 
 func (d *agentDumper) DumpAgentInfo(basedir string) error {
@@ -243,12 +324,13 @@ func (d *agentDumper) DumpOVSPorts(basedir string) error {
 	return writeFile(d.fs, filepath.Join(basedir, "ovsports"), "ports", []byte(strings.Join(portData, "\n")))
 }
 
-func NewAgentDumper(fs afero.Fs, executor exec.Interface, ovsCtlClient ovsctl.OVSCtlClient, aq agentquerier.AgentQuerier, npq querier.AgentNetworkPolicyInfoQuerier) AgentDumper {
+func NewAgentDumper(fs afero.Fs, executor exec.Interface, ovsCtlClient ovsctl.OVSCtlClient, aq agentquerier.AgentQuerier, npq querier.AgentNetworkPolicyInfoQuerier, since string) AgentDumper {
 	return &agentDumper{
 		fs:           fs,
 		executor:     executor,
 		ovsCtlClient: ovsCtlClient,
 		aq:           aq,
 		npq:          npq,
+		since:        since,
 	}
 }

--- a/pkg/support/dump_others.go
+++ b/pkg/support/dump_others.go
@@ -28,10 +28,12 @@ import (
 
 func (d *agentDumper) DumpLog(basedir string) error {
 	logDir := logdir.GetLogDir()
-	if err := fileCopy(d.fs, path.Join(basedir, "logs", "agent"), logDir, "antrea-agent"); err != nil {
+	timeFilter := timestampFilter(d.since)
+
+	if err := directoryCopy(d.fs, path.Join(basedir, "logs", "agent"), logDir, "antrea-agent", timeFilter); err != nil {
 		return err
 	}
-	return fileCopy(d.fs, path.Join(basedir, "logs", "ovs"), logDir, "ovs")
+	return directoryCopy(d.fs, path.Join(basedir, "logs", "ovs"), logDir, "ovs", timeFilter)
 }
 
 func (d *agentDumper) DumpHostNetworkInfo(basedir string) error {

--- a/pkg/support/dump_test.go
+++ b/pkg/support/dump_test.go
@@ -1,0 +1,40 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package support
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseLogDate(t *testing.T) {
+	data := "I0817 06:55:10.804384       1 shared_informer.go:270] caches populated"
+	ts, err := parseTimeFromLogLine(data, "2021", "antrea-agent")
+	assert.Nil(t, err)
+	assert.Equal(t, ts.String(), "2021-08-17 06:55:10 +0000 UTC")
+
+	data = "2021-06-01T09:30:43.823Z|00004|memory|INFO|cells:299 monitors:2 sessions:2"
+	ts, err = parseTimeFromLogLine(data, "2021", "ovs")
+	assert.Nil(t, err)
+	assert.Equal(t, ts.String(), "2021-06-01 09:30:43 +0000 UTC")
+}
+
+func TestParseFileName(t *testing.T) {
+	name := "antrea-agent.ubuntu-1.root.log.WARNING.20210817-094758.1"
+	ts, err := parseTimeFromFileName(name)
+	assert.Nil(t, err)
+	assert.Equal(t, ts.String(), "2021-08-17 09:47:58 +0000 UTC")
+}

--- a/pkg/support/dump_windows.go
+++ b/pkg/support/dump_windows.go
@@ -33,15 +33,17 @@ const (
 // collecting them from a configurable path in the future.
 func (d *agentDumper) DumpLog(basedir string) error {
 	logDir := logdir.GetLogDir()
-	if err := fileCopy(d.fs, path.Join(basedir, "logs", "agent"), logDir, "rancher-wins-antrea-agent"); err != nil {
+	timeFilter := timestampFilter(d.since)
+
+	if err := directoryCopy(d.fs, path.Join(basedir, "logs", "agent"), logDir, "rancher-wins-antrea-agent", timeFilter); err != nil {
 		return err
 	}
 	// Dump OVS logs.
-	if err := fileCopy(d.fs, path.Join(basedir, "logs", "ovs"), antreaWindowsOVSLogDir, "ovs"); err != nil {
+	if err := directoryCopy(d.fs, path.Join(basedir, "logs", "ovs"), antreaWindowsOVSLogDir, "ovs", timeFilter); err != nil {
 		return err
 	}
 	// Dump kubelet logs.
-	if err := fileCopy(d.fs, path.Join(basedir, "logs", "kubelet"), antreaWindowsKubeletLogDir, "kubelet"); err != nil {
+	if err := directoryCopy(d.fs, path.Join(basedir, "logs", "kubelet"), antreaWindowsKubeletLogDir, "kubelet", timeFilter); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
This PR is based on #1560, besides conflict fixes, the additional
changes are:
1. fix a command args help string error
2. revert the interface changes and use struct fields
3. create a func to do timefilter cal

Co-authored-by: Weiqiang Tang <weiqiangt@vmware.com>
Signed-off-by: Hang Yan <yhang@vmware.com>