### PR TITLE
Ignore non-TCP Service ports in the NodePortLocal implementation

### DIFF
--- a/docs/feature-gates.md
+++ b/docs/feature-gates.md
@@ -187,12 +187,13 @@ metadata:
 
 ```
 
-This annotation denotes that the port 8080 of the Pod can be reached through port 61002 of the
-Node with IP Address 10.10.10.10.
+This annotation denotes that the port 8080 of the Pod can be reached through
+port 61002 of the Node with IP Address 10.10.10.10.
 
 #### Requirements for this Feature
 
-This feature is currently only supported for Nodes running Linux with IPv4 addresses.
+This feature is currently only supported for Nodes running Linux with IPv4
+addresses. Only TCP Service ports are supported.
 
 ### Egress
 

--- a/pkg/agent/nodeportlocal/k8s/npl_controller.go
+++ b/pkg/agent/nodeportlocal/k8s/npl_controller.go
@@ -196,11 +196,11 @@ func (c *NPLController) checkDeletedSvc(obj interface{}) (*corev1.Service, error
 
 func validateNPLService(svc *corev1.Service) {
 	if svc.Spec.Type == corev1.ServiceTypeNodePort {
-		klog.InfoS("Service is of type NodePort and cannot be used for NodePortLocal, the NodePortLocal annotation will have no effect", "Service name", svc.Name)
+		klog.InfoS("Service is of type NodePort and cannot be used for NodePortLocal, the NodePortLocal annotation will have no effect", "service", klog.KObj(svc))
 	}
 	for _, port := range svc.Spec.Ports {
 		if port.Protocol != corev1.ProtocolTCP {
-			klog.InfoS("Service has NodePortLocal enabled but it includes a non-TCP Service port, which will be ignored", "Service name", svc.Name)
+			klog.InfoS("Service has NodePortLocal enabled but it includes a non-TCP Service port, which will be ignored", "service", klog.KObj(svc))
 		}
 	}
 }


### PR DESCRIPTION
And document the restriction that only TCP is supported.

See #2395

Signed-off-by: Antonin Bas <abas@vmware.com>