### PR TITLE
correct the docs for getInfraContainer wrt the kubelet vs containerd/…

### DIFF
--- a/pkg/agent/cniserver/server_windows.go
+++ b/pkg/agent/cniserver/server_windows.go
@@ -76,14 +76,17 @@ func getInfraContainer(containerID, netNS string) string {
 }
 
 // getInfraContainer returns the infra (sandbox) container ID of a Pod.
-// On Windows, kubelet sends two kinds of CNI ADD requests for each Pod:
+// On Windows, dockershim/containerd sends two sequentiral CNI ADD requests when a new pod is created...
+//
 // 1. <container_id:"067e66fa59ade9c36552aeedac4f1420fe8efe0d2a4061ecdac45f67c5ef035c" netns:"none" ifname:"eth0"
 // args:"IgnoreUnknown=1;K8S_POD_NAMESPACE=default;K8S_POD_NAME=win-webserver-6c7bdbf9fc-lswt2;K8S_POD_INFRA_CONTAINER_ID=067e66fa59ade9c36552aeedac4f1420fe8efe0d2a4061ecdac45f67c5ef035c" >
+//
 // 2. <container_id:"0cd7ab3df88aa15f6a9b7f5fc2008ef4cb5740e9ded8ede3633dca7344fd58ca" netns:"container:067e66fa59ade9c36552aeedac4f1420fe8efe0d2a4061ecdac45f67c5ef035c" ifname:"eth0"
 // args:"IgnoreUnknown=1;K8S_POD_NAMESPACE=default;K8S_POD_NAME=win-webserver-6c7bdbf9fc-lswt2;K8S_POD_INFRA_CONTAINER_ID=0cd7ab3df88aa15f6a9b7f5fc2008ef4cb5740e9ded8ede3633dca7344fd58ca" >
 //
-// The first request uses infra container ID as "container_id", while subsequent requests use workload container ID as
-// "container_id" and have infra container ID in "netns" in the form of "container:<INFRA CONTAINER ID>".
+// The first request uses infra container ID as "container_id".
+// The subsequent request uses workload container ID "container_id"
+// and infra container ID "netns",  "container:<INFRA CONTAINER ID>".
 func (c *CNIConfig) getInfraContainer() string {
 	return getInfraContainer(c.ContainerId, c.Netns)
 }


### PR DESCRIPTION
just a quick update to clarify the weird double CNI ADD that we do, confirmed we also do this in dockershim thanks to help from @squeed 