### PR TITLE
Improve e2e tests on kind clusters

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -10,7 +10,7 @@ on:
     - release-*
 
 env:
-  KIND_VERSION: v0.11.0
+  KIND_VERSION: v0.11.1
 
 jobs:
   check-changes:

--- a/.github/workflows/kind_upgrade.yml
+++ b/.github/workflows/kind_upgrade.yml
@@ -10,7 +10,7 @@ on:
     - release-*
 
 env:
-  KIND_VERSION: v0.11.0
+  KIND_VERSION: v0.11.1
 
 jobs:
   check-changes:

--- a/.github/workflows/netpol_cyclonus.yml
+++ b/.github/workflows/netpol_cyclonus.yml
@@ -5,7 +5,7 @@ on:
     - cron: '0 0 * * *'
 
 env:
-  KIND_VERSION: v0.11.0
+  KIND_VERSION: v0.11.1
 
 jobs:
 

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -61,6 +61,7 @@ const (
 
 	// antreaNamespace is the K8s Namespace in which all Antrea resources are running.
 	antreaNamespace            string = "kube-system"
+	kubeNamespace              string = "kube-system"
 	flowAggregatorNamespace    string = "flow-aggregator"
 	antreaConfigVolume         string = "antrea-config"
 	flowAggregatorConfigVolume string = "flow-aggregator-config"
@@ -534,14 +535,14 @@ func (data *TestData) deployAntreaCommon(yamlFile string, extraOptions string, w
 	if err != nil || rc != 0 {
 		return fmt.Errorf("error when deploying Antrea; is %s available on the control-plane Node?", yamlFile)
 	}
-	rc, _, _, err = provider.RunCommandOnNode(controlPlaneNodeName(), fmt.Sprintf("kubectl -n %s rollout status deploy/%s --timeout=%v", antreaNamespace, antreaDeployment, defaultTimeout))
+	rc, stdout, stderr, err := provider.RunCommandOnNode(controlPlaneNodeName(), fmt.Sprintf("kubectl -n %s rollout status deploy/%s --timeout=%v", antreaNamespace, antreaDeployment, defaultTimeout))
 	if err != nil || rc != 0 {
-		return fmt.Errorf("error when waiting for antrea-controller rollout to complete")
+		return fmt.Errorf("error when waiting for antrea-controller rollout to complete - rc: %v - stdout: %v - stderr: %v - err: %v", rc, stdout, stderr, err)
 	}
 	if waitForAgentRollout {
 		rc, _, _, err = provider.RunCommandOnNode(controlPlaneNodeName(), fmt.Sprintf("kubectl -n %s rollout status ds/%s --timeout=%v", antreaNamespace, antreaDaemonSet, defaultTimeout))
 		if err != nil || rc != 0 {
-			return fmt.Errorf("error when waiting for antrea-agent rollout to complete")
+			return fmt.Errorf("error when waiting for antrea-agent rollout to complete - rc: %v - stdout: %v - stderr: %v - err: %v", rc, stdout, stderr, err)
 		}
 	}
 


### PR DESCRIPTION
1. Update kind to v0.11.1
2. Export logs if setupTest fails
3. Include kube-proxy logs in the exported logs

For #2407

Signed-off-by: Quan Tian <qtian@vmware.com>

I plan to backport this patch to release 0.13~1.1 to bump their kind version and improve log collection. There was no way to figure out what caused #2407 without fetching the kube-proxy logs after setUp failed.