### PR TITLE
Remove CHANGELOG update step from contribution instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,9 +97,7 @@ project's repository.
     git commit -s
     ```
 
-5. Update the "Unreleased" section of the [CHANGELOG](CHANGELOG.md) for any
-   significant change that impacts users.
-6. Keeping branch in sync with upstream.
+5. Keeping branch in sync with upstream.
 
     ```bash
     git checkout branchName
@@ -107,13 +105,13 @@ project's repository.
     git rebase upstream/main
     ```
 
-7. Push local branch to your forked repository.
+6. Push local branch to your forked repository.
 
     ```bash
     git push -f $remoteBranchName branchName
     ```
 
-8. Create a Pull request on GitHub.
+7. Create a Pull request on GitHub.
    Visit your fork at `https://github.com/antrea-io/antrea` and click
    `Compare & Pull Request` button next to your `remoteBranchName` branch.
 


### PR DESCRIPTION
The initial idea was that contributors would add an entry to the
"Unreleased" section of the CHANGELOG for every significant change
contributed to the project. This would have simplified release
management. However, this is an error-prone process and we never
actually implemented it. Instead we should look into auto-generating the
CHANGELOG for each release based on PR descriptions (see #2411).

Signed-off-by: Antonin Bas <abas@vmware.com>