### PR TITLE
support ipv6 kind clusters

### DIFF
--- a/build/images/scripts/start_ovs_netdev
+++ b/build/images/scripts/start_ovs_netdev
@@ -20,12 +20,24 @@ function fix_ovs_ctl {
     sed -i 's/\(\w*\)\(insert_mod_if_required || return 1\)/\1# \2/' /usr/share/openvswitch/scripts/ovs-ctl
 }
 
+# grep exits 1 if no matches are found. This function catches exit status 1 to
+# avoid failing if no matches are found. This still allows grep to return with
+# other exit status codes in the case of other failures.
+function grep_allow_no_match {
+  grep "$@" || test $? = 1;
+}
+
 # See http://docs.openvswitch.org/en/latest/howto/userspace-tunneling/
 function add_br_phy {
     log_info $CONTAINER_NAME "Creating OVS br-phy bridge for netdev datapath type"
     hwaddr=$(ip link show eth0 | grep link/ether | awk '{print $2}')
     inet=$(ip addr show eth0 | grep "inet " | awk '{ print $2 }')
+    inet6=$(ip -6 addr show eth0 | grep_allow_no_match global | awk '{ print $2 }')
     gw=$(ip route | grep default | awk '{ print $3 }')
+    gw6=$(ip -6 route | grep_allow_no_match default | awk '{ print $3 }')
+    # eth0 may be assigned an IPv6 address even if IPv6 is disabled in the kernel
+    # we must ensure IPv6 is enabled before we can add IPv6 addresses
+    ipv6enabled=$(sysctl net.ipv6.conf.all.disable_ipv6 --values)
     ovs-vsctl add-br br-phy \
               -- set Bridge br-phy datapath_type=netdev \
               -- br-set-external-id br-phy bridge-id br-phy \
@@ -34,23 +46,43 @@ function add_br_phy {
 
     ovs-vsctl --timeout 10 add-port br-phy eth0
     ip addr add "$inet" dev br-phy
+    if [[ "$ipv6enabled" -eq 0 ]] && [[ -n "$inet6" ]]; then
+      ip addr add "$inet6" dev br-phy
+    fi
     ip link set br-phy up
     ip addr flush dev eth0 2>/dev/null
     ip link set eth0 up
     ip route add default via "$gw" dev br-phy
     iptables -t raw -A PREROUTING -i eth0 -j DROP
+    # While the below ip6tables rule should prevent duplicate packets, we
+    # observed that it caused connectivity to the API server to fail from
+    # outside the cluster. More investigation is required.
+    # ip6tables -t raw -A PREROUTING -i eth0 -j DROP
+    if [[ "$ipv6enabled" -eq 0 ]] && [[ -n "$gw6" ]]; then
+      ip -6 route replace default via "$gw6" dev br-phy
+    fi
 }
 
 function del_br_phy {
     inet=$(ip addr show br-phy | grep "inet " | awk '{ print $2 }')
+    inet6=$(ip -6 addr show br-phy | grep_allow_no_match global | awk '{ print $2 }')
     gw=$(ip route | grep default | awk '{ print $3 }')
+    gw6=$(ip -6 route | grep_allow_no_match default | awk '{ print $3 }')
+    # we must ensure IPv6 is enabled before we can add IPv6 addresses
+    ipv6enabled=$(sysctl net.ipv6.conf.all.disable_ipv6 --values)
     log_info $CONTAINER_NAME "Deleting OVS br-phy bridge"
     ovs-vsctl del-port br-phy eth0
     ovs-vsctl del-br br-phy
     ip addr add "$inet" dev eth0
+    if [[ "$ipv6enabled" -eq 0 ]] && [[ -n "$inet6" ]]; then
+      ip addr add "$inet6" dev eth0
+    fi
     ip link set eth0 up
     ip route add default via "$gw" dev eth0
     iptables -t raw -D PREROUTING -i eth0 -j DROP
+    if [[ "$ipv6enabled" -eq 0 ]] && [[ -n "$gw6" ]]; then
+      ip -6 route replace default via "$gw6" dev eth0
+    fi
 }
 
 # While working on https://github.com/antrea-io/antrea/pull/2215, we sometimes


### PR DESCRIPTION
## Issue
When deploying Antrea on a IPv6 KinD cluster the cluster become unreachable due to missing IPv6 address on the br-phy device.

## Minimal Reproduction
1. Create a cluster config for IPv6
	  ```
	  kind: Cluster
	  apiVersion: kind.x-k8s.io/v1alpha4
	  networking:
	    disableDefaultCNI: true
	    ipFamily: ipv6
	  nodes:
	  - role: control-plane
	  - role: worker
	  - role: worker
	  ```
1. Create the KinD cluster: `kind create cluster --config ./cluster-config.yaml`
1. Fix kind networking: `kind get nodes | xargs ./hack/kind-fix-networking.sh`
1. Deploy Antrea: `kubectl apply -f https://github.com/antrea-io/antrea/releases/download/v1.1.1/antrea-kind.yml`
1. Eventually, during antrea pod init, `kubectl get pods -A` responds with: `Error from server (InternalError): an error on the server ("") has prevented the request from succeeding (get pods)`

## Fix
Add the global inet6 address from eth0 to the br-phy device when running on an ipv6 kind cluster.

Signed-off-by: Aidan Obley <aobley@vmware.com>
Co-authored-by: Christian Ang <angc@vmware.com>