### PR TITLE
Automated cherry pick of #2408: Improve e2e tests on kind clusters

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -10,7 +10,7 @@ on:
     - release-*
 
 env:
-  KIND_VERSION: v0.9.0
+  KIND_VERSION: v0.11.1
 
 jobs:
   check-changes:

--- a/.github/workflows/kind_upgrade.yml
+++ b/.github/workflows/kind_upgrade.yml
@@ -10,7 +10,7 @@ on:
     - release-*
 
 env:
-  KIND_VERSION: v0.9.0
+  KIND_VERSION: v0.11.1
 
 jobs:
   check-changes:

--- a/.github/workflows/netpol_cyclonus.yml
+++ b/.github/workflows/netpol_cyclonus.yml
@@ -5,7 +5,7 @@ on:
     - cron: '0 0 * * *'
 
 env:
-  KIND_VERSION: v0.9.0
+  KIND_VERSION: v0.11.1
 
 jobs:
 

--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -118,6 +118,13 @@ func setupTest(tb testing.TB) (*TestData, error) {
 		tb.Errorf("Error creating logs directory '%s': %v", testData.logsDirForTestCase, err)
 		return nil, err
 	}
+	success := false
+	defer func() {
+		if !success {
+			tb.Fail()
+			exportLogs(tb, testData, "afterSetupTest", true)
+		}
+	}()
 	tb.Logf("Creating '%s' K8s Namespace", testNamespace)
 	if err := ensureAntreaRunning(tb, testData); err != nil {
 		return nil, err
@@ -125,6 +132,7 @@ func setupTest(tb testing.TB) (*TestData, error) {
 	if err := testData.createTestNamespace(); err != nil {
 		return nil, err
 	}
+	success = true
 	return testData, nil
 }
 
@@ -230,6 +238,8 @@ func exportLogs(tb testing.TB, data *TestData, logsSubDir string, writeNodeLogs 
 		w.WriteString(stdout)
 		return nil
 	}
+	data.forAllMatchingPodsInNamespace("k8s-app=kube-proxy", kubeNamespace, writePodLogs)
+
 	data.forAllMatchingPodsInNamespace("app=antrea", antreaNamespace, writePodLogs)
 
 	// dump the logs for monitoring Pods to disk.

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -59,6 +59,7 @@ const (
 
 	// antreaNamespace is the K8s Namespace in which all Antrea resources are running.
 	antreaNamespace            string = "kube-system"
+	kubeNamespace              string = "kube-system"
 	flowAggregatorNamespace    string = "flow-aggregator"
 	antreaConfigVolume         string = "antrea-config"
 	flowAggregatorConfigVolume string = "flow-aggregator-config"
@@ -441,13 +442,13 @@ func (data *TestData) deployAntreaCommon(yamlFile string, extraOptions string) e
 	if err != nil || rc != 0 {
 		return fmt.Errorf("error when deploying Antrea; is %s available on the control-plane Node?", yamlFile)
 	}
-	rc, _, _, err = provider.RunCommandOnNode(controlPlaneNodeName(), fmt.Sprintf("kubectl -n %s rollout status deploy/%s --timeout=%v", antreaNamespace, antreaDeployment, defaultTimeout))
+	rc, stdout, stderr, err := provider.RunCommandOnNode(controlPlaneNodeName(), fmt.Sprintf("kubectl -n %s rollout status deploy/%s --timeout=%v", antreaNamespace, antreaDeployment, defaultTimeout))
 	if err != nil || rc != 0 {
-		return fmt.Errorf("error when waiting for antrea-controller rollout to complete")
+		return fmt.Errorf("error when waiting for antrea-controller rollout to complete - rc: %v - stdout: %v - stderr: %v - err: %v", rc, stdout, stderr, err)
 	}
 	rc, _, _, err = provider.RunCommandOnNode(controlPlaneNodeName(), fmt.Sprintf("kubectl -n %s rollout status ds/%s --timeout=%v", antreaNamespace, antreaDaemonSet, defaultTimeout))
 	if err != nil || rc != 0 {
-		return fmt.Errorf("error when waiting for antrea-agent rollout to complete")
+		return fmt.Errorf("error when waiting for antrea-agent rollout to complete - rc: %v - stdout: %v - stderr: %v - err: %v", rc, stdout, stderr, err)
 	}
 
 	return nil


### PR DESCRIPTION
Cherry pick of #2408 on release-0.13.

#2408: Improve e2e tests on kind clusters

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.