### PR TITLE
Explicitly use testNamespace in creating Pods for e2e tests

### DIFF
--- a/test/e2e/antreapolicy_test.go
+++ b/test/e2e/antreapolicy_test.go
@@ -2776,9 +2776,9 @@ func TestAntreaPolicyStatus(t *testing.T) {
 	defer teardownTest(t, data)
 	skipIfAntreaPolicyDisabled(t, data)
 
-	_, _, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "server-0", controlPlaneNodeName())
+	_, _, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "server-0", controlPlaneNodeName(), testNamespace)
 	defer cleanupFunc()
-	_, _, cleanupFunc = createAndWaitForPod(t, data, data.createNginxPodOnNode, "server-1", workerNodeName(1))
+	_, _, cleanupFunc = createAndWaitForPod(t, data, data.createNginxPodOnNode, "server-1", workerNodeName(1), testNamespace)
 	defer cleanupFunc()
 
 	anpBuilder := &AntreaNetworkPolicySpecBuilder{}
@@ -2876,10 +2876,10 @@ func TestANPNetworkPolicyStatsWithDropAction(t *testing.T) {
 	skipIfAntreaPolicyDisabled(t, data)
 	skipIfNetworkPolicyStatsDisabled(t, data)
 
-	serverName, serverIPs, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "test-server-", "")
+	serverName, serverIPs, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "test-server-", "", testNamespace)
 	defer cleanupFunc()
 
-	clientName, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", "")
+	clientName, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", "", testNamespace)
 	defer cleanupFunc()
 	k8sUtils, err = NewKubernetesUtils(data)
 	failOnError(err, t)
@@ -3020,10 +3020,10 @@ func TestAntreaClusterNetworkPolicyStats(t *testing.T) {
 	skipIfAntreaPolicyDisabled(t, data)
 	skipIfNetworkPolicyStatsDisabled(t, data)
 
-	serverName, serverIPs, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "test-server-", "")
+	serverName, serverIPs, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "test-server-", "", testNamespace)
 	defer cleanupFunc()
 
-	clientName, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", "")
+	clientName, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", "", testNamespace)
 	defer cleanupFunc()
 	k8sUtils, err = NewKubernetesUtils(data)
 	failOnError(err, t)

--- a/test/e2e/bandwidth_test.go
+++ b/test/e2e/bandwidth_test.go
@@ -37,13 +37,13 @@ func TestBenchmarkBandwidthIntraNode(t *testing.T) {
 		t.Fatalf("Error when setting up test: %v", err)
 	}
 	defer teardownTest(t, data)
-	if err := data.createPodOnNode("perftest-a", controlPlaneNodeName(), perftoolImage, nil, nil, nil, nil, false, nil); err != nil {
+	if err := data.createPodOnNode("perftest-a", testNamespace, controlPlaneNodeName(), perftoolImage, nil, nil, nil, nil, false, nil); err != nil {
 		t.Fatalf("Error when creating the perftest client Pod: %v", err)
 	}
 	if err := data.podWaitForRunning(defaultTimeout, "perftest-a", testNamespace); err != nil {
 		t.Fatalf("Error when waiting for the perftest client Pod: %v", err)
 	}
-	if err := data.createPodOnNode("perftest-b", controlPlaneNodeName(), perftoolImage, nil, nil, nil, []v1.ContainerPort{{Protocol: v1.ProtocolTCP, ContainerPort: iperfPort}}, false, nil); err != nil {
+	if err := data.createPodOnNode("perftest-b", testNamespace, controlPlaneNodeName(), perftoolImage, nil, nil, nil, []v1.ContainerPort{{Protocol: v1.ProtocolTCP, ContainerPort: iperfPort}}, false, nil); err != nil {
 		t.Fatalf("Error when creating the perftest server Pod: %v", err)
 	}
 	podBIPs, err := data.podWaitForIPs(defaultTimeout, "perftest-b", testNamespace)
@@ -72,13 +72,13 @@ func benchmarkBandwidthService(t *testing.T, endpointNode, clientNode string) {
 	if err != nil {
 		t.Fatalf("Error when creating perftest service: %v", err)
 	}
-	if err := data.createPodOnNode("perftest-a", clientNode, perftoolImage, nil, nil, nil, nil, false, nil); err != nil {
+	if err := data.createPodOnNode("perftest-a", testNamespace, clientNode, perftoolImage, nil, nil, nil, nil, false, nil); err != nil {
 		t.Fatalf("Error when creating the perftest client Pod: %v", err)
 	}
 	if err := data.podWaitForRunning(defaultTimeout, "perftest-a", testNamespace); err != nil {
 		t.Fatalf("Error when waiting for the perftest client Pod: %v", err)
 	}
-	if err := data.createPodOnNode("perftest-b", endpointNode, perftoolImage, nil, nil, nil, []v1.ContainerPort{{Protocol: v1.ProtocolTCP, ContainerPort: iperfPort}}, false, nil); err != nil {
+	if err := data.createPodOnNode("perftest-b", testNamespace, endpointNode, perftoolImage, nil, nil, nil, []v1.ContainerPort{{Protocol: v1.ProtocolTCP, ContainerPort: iperfPort}}, false, nil); err != nil {
 		t.Fatalf("Error when creating the perftest server Pod: %v", err)
 	}
 	if err := data.podWaitForRunning(defaultTimeout, "perftest-b", testNamespace); err != nil {
@@ -146,7 +146,7 @@ func TestPodTrafficShaping(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			clientPodName := fmt.Sprintf("client-a-%d", i)
 			serverPodName := fmt.Sprintf("server-a-%d", i)
-			if err := data.createPodOnNode(clientPodName, nodeName, perftoolImage, nil, nil, nil, nil, false, func(pod *v1.Pod) {
+			if err := data.createPodOnNode(clientPodName, testNamespace, nodeName, perftoolImage, nil, nil, nil, nil, false, func(pod *v1.Pod) {
 				pod.Annotations = map[string]string{
 					"kubernetes.io/egress-bandwidth": fmt.Sprintf("%dM", tt.clientEgressBandwidth),
 				}
@@ -157,7 +157,7 @@ func TestPodTrafficShaping(t *testing.T) {
 			if err := data.podWaitForRunning(defaultTimeout, clientPodName, testNamespace); err != nil {
 				t.Fatalf("Error when waiting for the perftest client Pod: %v", err)
 			}
-			if err := data.createPodOnNode(serverPodName, nodeName, perftoolImage, nil, nil, nil, []v1.ContainerPort{{Protocol: v1.ProtocolTCP, ContainerPort: iperfPort}}, false, func(pod *v1.Pod) {
+			if err := data.createPodOnNode(serverPodName, testNamespace, nodeName, perftoolImage, nil, nil, nil, []v1.ContainerPort{{Protocol: v1.ProtocolTCP, ContainerPort: iperfPort}}, false, func(pod *v1.Pod) {
 				pod.Annotations = map[string]string{
 					"kubernetes.io/ingress-bandwidth": fmt.Sprintf("%dM", tt.serverIngressBandwidth),
 				}

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -60,7 +60,7 @@ func TestPodAssignIP(t *testing.T) {
 	podName := randName("test-pod-")
 
 	t.Logf("Creating a busybox test Pod")
-	if err := data.createBusyboxPodOnNode(podName, ""); err != nil {
+	if err := data.createBusyboxPodOnNode(podName, testNamespace, ""); err != nil {
 		t.Fatalf("Error when creating busybox test Pod: %v", err)
 	}
 	defer deletePodWrapper(t, data, podName)
@@ -194,7 +194,7 @@ func (data *TestData) testDeletePod(t *testing.T, podName string, nodeName strin
 	}
 
 	t.Logf("Deleting Pod '%s'", podName)
-	if err := data.deletePodAndWait(defaultTimeout, podName); err != nil {
+	if err := data.deletePodAndWait(defaultTimeout, podName, testNamespace); err != nil {
 		t.Fatalf("Error when deleting Pod: %v", err)
 	}
 
@@ -233,7 +233,7 @@ func TestDeletePod(t *testing.T) {
 	podName := randName("test-pod-")
 
 	t.Logf("Creating a agnhost test Pod on '%s'", nodeName)
-	if err := data.createAgnhostPodOnNode(podName, nodeName); err != nil {
+	if err := data.createAgnhostPodOnNode(podName, testNamespace, nodeName); err != nil {
 		t.Fatalf("Error when creating agnhost test Pod: %v", err)
 	}
 	if err := data.podWaitForRunning(defaultTimeout, podName, testNamespace); err != nil {
@@ -301,7 +301,7 @@ func TestIPAMRestart(t *testing.T) {
 
 	createPodAndGetIP := func(podName string) (*PodIPs, error) {
 		t.Logf("Creating a busybox test Pod '%s' and waiting for IP", podName)
-		if err := data.createBusyboxPodOnNode(podName, nodeName); err != nil {
+		if err := data.createBusyboxPodOnNode(podName, testNamespace, nodeName); err != nil {
 			t.Fatalf("Error when creating busybox test Pod '%s': %v", podName, err)
 			return nil, err
 		}
@@ -757,7 +757,7 @@ func TestGratuitousARP(t *testing.T) {
 	nodeName := workerNodeName(1)
 
 	t.Logf("Creating Pod '%s' on '%s'", podName, nodeName)
-	if err := data.createBusyboxPodOnNode(podName, nodeName); err != nil {
+	if err := data.createBusyboxPodOnNode(podName, testNamespace, nodeName); err != nil {
 		t.Fatalf("Error when creating Pod '%s': %v", podName, err)
 	}
 	defer deletePodWrapper(t, data, podName)

--- a/test/e2e/batch_test.go
+++ b/test/e2e/batch_test.go
@@ -53,7 +53,7 @@ func TestBatchCreatePods(t *testing.T) {
 
 	oldFDs := getFDs()
 
-	_, _, cleanupFn := createTestBusyboxPods(t, data, batchNum, node1)
+	_, _, cleanupFn := createTestBusyboxPods(t, data, batchNum, testNamespace, node1)
 	defer cleanupFn()
 
 	newFDs := getFDs()

--- a/test/e2e/egress_test.go
+++ b/test/e2e/egress_test.go
@@ -82,7 +82,7 @@ ip netns exec %[1]s ip link set dev %[1]s-a up && \
 ip netns exec %[1]s ip route replace default via %[3]s && \
 ip netns exec %[1]s /agnhost netexec
 `, fakeServer, serverIP, localIP0, localIP1)
-	if err := data.createPodOnNode(fakeServer, egressNode, agnhostImage, []string{"sh", "-c", cmd}, nil, nil, nil, true, func(pod *v1.Pod) {
+	if err := data.createPodOnNode(fakeServer, testNamespace, egressNode, agnhostImage, []string{"sh", "-c", cmd}, nil, nil, nil, true, func(pod *v1.Pod) {
 		privileged := true
 		pod.Spec.Containers[0].SecurityContext = &v1.SecurityContext{Privileged: &privileged}
 	}); err != nil {
@@ -95,14 +95,14 @@ ip netns exec %[1]s /agnhost netexec
 
 	localPod := "localpod"
 	remotePod := "remotepod"
-	if err := data.createBusyboxPodOnNode(localPod, egressNode); err != nil {
+	if err := data.createBusyboxPodOnNode(localPod, testNamespace, egressNode); err != nil {
 		t.Fatalf("Failed to create local Pod: %v", err)
 	}
 	defer deletePodWrapper(t, data, localPod)
 	if err := data.podWaitForRunning(defaultTimeout, localPod, testNamespace); err != nil {
 		t.Fatalf("Error when waiting for Pod '%s' to be in the Running state", localPod)
 	}
-	if err := data.createBusyboxPodOnNode(remotePod, workerNodeName(1)); err != nil {
+	if err := data.createBusyboxPodOnNode(remotePod, testNamespace, workerNodeName(1)); err != nil {
 		t.Fatalf("Failed to create remote Pod: %v", err)
 	}
 	defer deletePodWrapper(t, data, remotePod)

--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -188,7 +188,7 @@ func setupTestWithIPFIXCollector(tb testing.TB) (*TestData, bool, bool, error) {
 		return testData, v4Enabled, v6Enabled, err
 	}
 	// Create pod using ipfix collector image
-	if err = testData.createPodOnNode("ipfix-collector", "", ipfixCollectorImage, nil, nil, nil, nil, true, nil); err != nil {
+	if err = testData.createPodOnNode("ipfix-collector", testNamespace, "", ipfixCollectorImage, nil, nil, nil, nil, true, nil); err != nil {
 		tb.Errorf("Error when creating the ipfix collector Pod: %v", err)
 	}
 	ipfixCollectorIP, err := testData.podWaitForIPs(defaultTimeout, "ipfix-collector", testNamespace)
@@ -391,7 +391,7 @@ func deletePodWrapper(tb testing.TB, data *TestData, name string) {
 // nodeName is the empty string, each Pod will be created on an arbitrary
 // Node. createTestBusyboxPods returns the cleanupFn function which can be used to delete the
 // created Pods. Pods are created in parallel to reduce the time required to run the tests.
-func createTestBusyboxPods(tb testing.TB, data *TestData, num int, nodeName string) (
+func createTestBusyboxPods(tb testing.TB, data *TestData, num int, ns string, nodeName string) (
 	podNames []string, podIPs []*PodIPs, cleanupFn func(),
 ) {
 	cleanupFn = func() {
@@ -414,14 +414,13 @@ func createTestBusyboxPods(tb testing.TB, data *TestData, num int, nodeName stri
 
 	createPodAndGetIP := func() (string, *PodIPs, error) {
 		podName := randName("test-pod-")
-
 		tb.Logf("Creating a busybox test Pod '%s' and waiting for IP", podName)
-		if err := data.createBusyboxPodOnNode(podName, nodeName); err != nil {
+		if err := data.createBusyboxPodOnNode(podName, ns, nodeName); err != nil {
 			tb.Errorf("Error when creating busybox test Pod '%s': %v", podName, err)
 			return "", nil, err
 		}
 
-		if podIP, err := data.podWaitForIPs(defaultTimeout, podName, testNamespace); err != nil {
+		if podIP, err := data.podWaitForIPs(defaultTimeout, podName, ns); err != nil {
 			tb.Errorf("Error when waiting for IP for Pod '%s': %v", podName, err)
 			return podName, nil, err
 		} else {

--- a/test/e2e/flowaggregator_test.go
+++ b/test/e2e/flowaggregator_test.go
@@ -452,12 +452,12 @@ func testHelper(t *testing.T, data *TestData, podAIPs, podBIPs, podCIPs, podDIPs
 	t.Run("ToExternalFlows", func(t *testing.T) {
 		// Creating an agnhost server as a host network Pod
 		serverPodPort := int32(80)
-		_, serverIPs, cleanupFunc := createAndWaitForPod(t, data, func(name string, nodeName string) error {
-			return data.createServerPod(name, "", serverPodPort, false, true)
-		}, "test-server-", "")
+		_, serverIPs, cleanupFunc := createAndWaitForPod(t, data, func(name string, ns string, nodeName string) error {
+			return data.createServerPod(name, testNamespace, "", serverPodPort, false, true)
+		}, "test-server-", "", testNamespace)
 		defer cleanupFunc()
 
-		clientName, clientIPs, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", nodeName(0))
+		clientName, clientIPs, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", nodeName(0), testNamespace)
 		defer cleanupFunc()
 
 		if !isIPv6 {
@@ -949,7 +949,7 @@ func deployDenyNetworkPolicies(t *testing.T, data *TestData, pod1, pod2 string) 
 }
 
 func createPerftestPods(data *TestData) (podAIPs *PodIPs, podBIPs *PodIPs, podCIPs *PodIPs, podDIPs *PodIPs, podEIPs *PodIPs, err error) {
-	if err := data.createPodOnNode("perftest-a", controlPlaneNodeName(), perftoolImage, nil, nil, nil, nil, false, nil); err != nil {
+	if err := data.createPodOnNode("perftest-a", testNamespace, controlPlaneNodeName(), perftoolImage, nil, nil, nil, nil, false, nil); err != nil {
 		return nil, nil, nil, nil, nil, fmt.Errorf("Error when creating the perftest client Pod: %v", err)
 	}
 	podAIPs, err = data.podWaitForIPs(defaultTimeout, "perftest-a", testNamespace)
@@ -957,7 +957,7 @@ func createPerftestPods(data *TestData) (podAIPs *PodIPs, podBIPs *PodIPs, podCI
 		return nil, nil, nil, nil, nil, fmt.Errorf("Error when waiting for the perftest client Pod: %v", err)
 	}
 
-	if err := data.createPodOnNode("perftest-b", controlPlaneNodeName(), perftoolImage, nil, nil, nil, []corev1.ContainerPort{{Protocol: corev1.ProtocolTCP, ContainerPort: iperfPort}}, false, nil); err != nil {
+	if err := data.createPodOnNode("perftest-b", testNamespace, controlPlaneNodeName(), perftoolImage, nil, nil, nil, []corev1.ContainerPort{{Protocol: corev1.ProtocolTCP, ContainerPort: iperfPort}}, false, nil); err != nil {
 		return nil, nil, nil, nil, nil, fmt.Errorf("Error when creating the perftest server Pod: %v", err)
 	}
 	podBIPs, err = data.podWaitForIPs(defaultTimeout, "perftest-b", testNamespace)
@@ -965,7 +965,7 @@ func createPerftestPods(data *TestData) (podAIPs *PodIPs, podBIPs *PodIPs, podCI
 		return nil, nil, nil, nil, nil, fmt.Errorf("Error when getting the perftest server Pod's IPs: %v", err)
 	}
 
-	if err := data.createPodOnNode("perftest-c", workerNodeName(1), perftoolImage, nil, nil, nil, []corev1.ContainerPort{{Protocol: corev1.ProtocolTCP, ContainerPort: iperfPort}}, false, nil); err != nil {
+	if err := data.createPodOnNode("perftest-c", testNamespace, workerNodeName(1), perftoolImage, nil, nil, nil, []corev1.ContainerPort{{Protocol: corev1.ProtocolTCP, ContainerPort: iperfPort}}, false, nil); err != nil {
 		return nil, nil, nil, nil, nil, fmt.Errorf("Error when creating the perftest server Pod: %v", err)
 	}
 	podCIPs, err = data.podWaitForIPs(defaultTimeout, "perftest-c", testNamespace)
@@ -973,7 +973,7 @@ func createPerftestPods(data *TestData) (podAIPs *PodIPs, podBIPs *PodIPs, podCI
 		return nil, nil, nil, nil, nil, fmt.Errorf("Error when getting the perftest server Pod's IPs: %v", err)
 	}
 
-	if err := data.createPodOnNode("perftest-d", controlPlaneNodeName(), perftoolImage, nil, nil, nil, []corev1.ContainerPort{{Protocol: corev1.ProtocolTCP, ContainerPort: iperfPort}}, false, nil); err != nil {
+	if err := data.createPodOnNode("perftest-d", testNamespace, controlPlaneNodeName(), perftoolImage, nil, nil, nil, []corev1.ContainerPort{{Protocol: corev1.ProtocolTCP, ContainerPort: iperfPort}}, false, nil); err != nil {
 		return nil, nil, nil, nil, nil, fmt.Errorf("Error when creating the perftest server Pod: %v", err)
 	}
 	podDIPs, err = data.podWaitForIPs(defaultTimeout, "perftest-d", testNamespace)
@@ -981,7 +981,7 @@ func createPerftestPods(data *TestData) (podAIPs *PodIPs, podBIPs *PodIPs, podCI
 		return nil, nil, nil, nil, nil, fmt.Errorf("Error when getting the perftest server Pod's IPs: %v", err)
 	}
 
-	if err := data.createPodOnNode("perftest-e", workerNodeName(1), perftoolImage, nil, nil, nil, []corev1.ContainerPort{{Protocol: corev1.ProtocolTCP, ContainerPort: iperfPort}}, false, nil); err != nil {
+	if err := data.createPodOnNode("perftest-e", testNamespace, workerNodeName(1), perftoolImage, nil, nil, nil, []corev1.ContainerPort{{Protocol: corev1.ProtocolTCP, ContainerPort: iperfPort}}, false, nil); err != nil {
 		return nil, nil, nil, nil, nil, fmt.Errorf("Error when creating the perftest server Pod: %v", err)
 	}
 	podEIPs, err = data.podWaitForIPs(defaultTimeout, "perftest-e", testNamespace)

--- a/test/e2e/legacyantreapolicy_test.go
+++ b/test/e2e/legacyantreapolicy_test.go
@@ -2246,9 +2246,9 @@ func TestLegacyAntreaPolicyStatus(t *testing.T) {
 	defer teardownTest(t, data)
 	skipIfAntreaPolicyDisabled(t, data)
 
-	_, _, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "server-0", controlPlaneNodeName())
+	_, _, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "server-0", controlPlaneNodeName(), testNamespace)
 	defer cleanupFunc()
-	_, _, cleanupFunc = createAndWaitForPod(t, data, data.createNginxPodOnNode, "server-1", workerNodeName(1))
+	_, _, cleanupFunc = createAndWaitForPod(t, data, data.createNginxPodOnNode, "server-1", workerNodeName(1), testNamespace)
 	defer cleanupFunc()
 
 	anpBuilder := &AntreaNetworkPolicySpecBuilder{}
@@ -2312,10 +2312,10 @@ func TestLegacyANPNetworkPolicyStatsWithDropAction(t *testing.T) {
 	skipIfAntreaPolicyDisabled(t, data)
 	skipIfNetworkPolicyStatsDisabled(t, data)
 
-	serverName, serverIPs, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "test-server-", "")
+	serverName, serverIPs, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "test-server-", "", testNamespace)
 	defer cleanupFunc()
 
-	clientName, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", "")
+	clientName, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", "", testNamespace)
 	defer cleanupFunc()
 	k8sUtils, err = NewKubernetesUtils(data)
 	failOnError(err, t)
@@ -2456,10 +2456,10 @@ func TestLegacyAntreaClusterNetworkPolicyStats(t *testing.T) {
 	skipIfAntreaPolicyDisabled(t, data)
 	skipIfNetworkPolicyStatsDisabled(t, data)
 
-	serverName, serverIPs, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "test-server-", "")
+	serverName, serverIPs, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "test-server-", "", testNamespace)
 	defer cleanupFunc()
 
-	clientName, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", "")
+	clientName, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", "", testNamespace)
 	defer cleanupFunc()
 	k8sUtils, err = NewKubernetesUtils(data)
 	failOnError(err, t)

--- a/test/e2e/nodeportlocal_test.go
+++ b/test/e2e/nodeportlocal_test.go
@@ -175,7 +175,7 @@ func deleteNPLRuleFromIPTables(t *testing.T, data *TestData, r *require.Assertio
 
 func checkTrafficForNPL(data *TestData, r *require.Assertions, nplAnnotations []k8s.NPLAnnotation, clientName string) {
 	for i := range nplAnnotations {
-		err := data.runNetcatCommandFromTestPod(clientName, nplAnnotations[i].NodeIP, int32(nplAnnotations[i].NodePort))
+		err := data.runNetcatCommandFromTestPod(clientName, testNamespace, nplAnnotations[i].NodeIP, int32(nplAnnotations[i].NodePort))
 		r.NoError(err, "Traffic test failed for NodeIP: %s, NodePort: %d", nplAnnotations[i].NodeIP, nplAnnotations[i].NodePort)
 	}
 }
@@ -248,12 +248,12 @@ func NPLTestMultiplePods(t *testing.T) {
 	for i := 0; i < 4; i++ {
 		testPodName := randName("test-pod-")
 		testPods = append(testPods, testPodName)
-		err := testData.createNginxPodOnNode(testPodName, node)
+		err := testData.createNginxPodOnNode(testPodName, testNamespace, node)
 		r.NoError(err, "Error creating test Pod: %v", err)
 	}
 
 	clientName := randName("test-client-")
-	err := testData.createBusyboxPodOnNode(clientName, node)
+	err := testData.createBusyboxPodOnNode(clientName, testNamespace, node)
 	r.NoError(err, "Error creating Pod %s: %v", clientName)
 
 	err = testData.podWaitForRunning(defaultTimeout, clientName, testNamespace)
@@ -294,7 +294,7 @@ func NPLTestPodAddMultiPort(t *testing.T) {
 	podcmd := "porter"
 
 	// Creating a Pod using agnhost image to support multiple ports, instead of nginx.
-	err := testData.createPodOnNode(testPodName, node, agnhostImage, nil, []string{podcmd}, []corev1.EnvVar{
+	err := testData.createPodOnNode(testPodName, testNamespace, node, agnhostImage, nil, []string{podcmd}, []corev1.EnvVar{
 		{
 			Name: fmt.Sprintf("SERVE_PORT_%d", 80), Value: "foo",
 		},
@@ -319,7 +319,7 @@ func NPLTestPodAddMultiPort(t *testing.T) {
 	nplAnnotations, testPodIP := getNPLAnnotations(t, testData, r, testPodName)
 
 	clientName := randName("test-client-")
-	err = testData.createBusyboxPodOnNode(clientName, node)
+	err = testData.createBusyboxPodOnNode(clientName, testNamespace, node)
 	r.NoError(err, "Error when creating Pod %s", clientName)
 
 	err = testData.podWaitForRunning(defaultTimeout, clientName, testNamespace)
@@ -350,11 +350,11 @@ func NPLTestLocalAccess(t *testing.T) {
 	node := nodeName(0)
 
 	testPodName := randName("test-pod-")
-	err := testData.createNginxPodOnNode(testPodName, node)
+	err := testData.createNginxPodOnNode(testPodName, testNamespace, node)
 	r.NoError(err, "Error creating test Pod: %v", err)
 
 	clientName := randName("test-client-")
-	err = testData.createHostNetworkBusyboxPodOnNode(clientName, node)
+	err = testData.createHostNetworkBusyboxPodOnNode(clientName, testNamespace, node)
 	r.NoError(err, "Error creating hostNetwork Pod %s: %v", clientName)
 
 	err = testData.podWaitForRunning(defaultTimeout, clientName, testNamespace)
@@ -401,12 +401,12 @@ func TestNPLMultiplePodsAgentRestart(t *testing.T) {
 	for i := 0; i < 4; i++ {
 		testPodName := randName("test-pod-")
 		testPods = append(testPods, testPodName)
-		err = testData.createNginxPodOnNode(testPodName, node)
+		err = testData.createNginxPodOnNode(testPodName, testNamespace, node)
 		r.NoError(err, "Error creating test Pod: %v", err)
 	}
 
 	clientName := randName("test-client-")
-	err = data.createBusyboxPodOnNode(clientName, node)
+	err = data.createBusyboxPodOnNode(clientName, testNamespace, node)
 	r.NoError(err, "Error when creating Pod %s", clientName)
 
 	err = data.podWaitForRunning(defaultTimeout, clientName, testNamespace)
@@ -473,12 +473,12 @@ func TestNPLChangePortRangeAgentRestart(t *testing.T) {
 	for i := 0; i < 4; i++ {
 		testPodName := randName("test-pod-")
 		testPods = append(testPods, testPodName)
-		err = testData.createNginxPodOnNode(testPodName, node)
+		err = testData.createNginxPodOnNode(testPodName, testNamespace, node)
 		r.NoError(err, "Error Creating test Pod: %v", err)
 	}
 
 	clientName := randName("test-client-")
-	err = data.createBusyboxPodOnNode(clientName, node)
+	err = data.createBusyboxPodOnNode(clientName, testNamespace, node)
 	r.NoError(err, "Error when creating Pod %s", clientName)
 
 	err = data.podWaitForRunning(defaultTimeout, clientName, testNamespace)

--- a/test/e2e/service_test.go
+++ b/test/e2e/service_test.go
@@ -53,10 +53,10 @@ func TestClusterIP(t *testing.T) {
 	}
 
 	testFromPod := func(podName, nodeName string, hostNetwork bool) {
-		require.NoError(t, data.createPodOnNode(podName, nodeName, busyboxImage, []string{"sleep", strconv.Itoa(3600)}, nil, nil, nil, hostNetwork, nil))
-		defer data.deletePodAndWait(defaultTimeout, podName)
+		require.NoError(t, data.createPodOnNode(podName, testNamespace, nodeName, busyboxImage, []string{"sleep", strconv.Itoa(3600)}, nil, nil, nil, hostNetwork, nil))
+		defer data.deletePodAndWait(defaultTimeout, podName, testNamespace)
 		require.NoError(t, data.podWaitForRunning(defaultTimeout, podName, testNamespace))
-		err := data.runNetcatCommandFromTestPod(podName, svc.Spec.ClusterIP, 80)
+		err := data.runNetcatCommandFromTestPod(podName, testNamespace, svc.Spec.ClusterIP, 80)
 		require.NoError(t, err, "Pod %s should be able to connect %s, but was not able to connect", podName, net.JoinHostPort(svc.Spec.ClusterIP, fmt.Sprint(80)))
 	}
 
@@ -91,7 +91,7 @@ func TestClusterIP(t *testing.T) {
 
 func (data *TestData) createClusterIPServiceAndBackendPods(t *testing.T, name string, node string) (*corev1.Service, func()) {
 	ipv4Protocol := corev1.IPv4Protocol
-	require.NoError(t, data.createNginxPodOnNode(name, node))
+	require.NoError(t, data.createNginxPodOnNode(name, testNamespace, node))
 	_, err := data.podWaitForIPs(defaultTimeout, name, testNamespace)
 	require.NoError(t, err)
 	require.NoError(t, data.podWaitForRunning(defaultTimeout, name, testNamespace))
@@ -99,7 +99,7 @@ func (data *TestData) createClusterIPServiceAndBackendPods(t *testing.T, name st
 	require.NoError(t, err)
 
 	cleanup := func() {
-		data.deletePodAndWait(defaultTimeout, name)
+		data.deletePodAndWait(defaultTimeout, name, testNamespace)
 		data.deleteServiceAndWait(defaultTimeout, name)
 	}
 
@@ -128,8 +128,8 @@ func TestNodePortWindows(t *testing.T) {
 	// It doesn't need to be the control-plane for e2e test and other Linux workers will work as well. However, in this
 	// e2e framework, nodeName(0)/Control-plane Node is guaranteed to be a Linux one.
 	clientName := "agnhost-client"
-	require.NoError(t, data.createAgnhostPodOnNode(clientName, nodeName(0)))
-	defer data.deletePodAndWait(defaultTimeout, clientName)
+	require.NoError(t, data.createAgnhostPodOnNode(clientName, testNamespace, nodeName(0)))
+	defer data.deletePodAndWait(defaultTimeout, clientName, testNamespace)
 	_, err = data.podWaitForIPs(defaultTimeout, clientName, testNamespace)
 	require.NoError(t, err)
 
@@ -150,7 +150,7 @@ func TestNodePortWindows(t *testing.T) {
 func (data *TestData) createAgnhostServiceAndBackendPods(t *testing.T, name string, node string, svcType corev1.ServiceType) (*corev1.Service, func()) {
 	ipv4Protocol := corev1.IPv4Protocol
 	args := []string{"netexec", "--http-port=80", "--udp-port=80"}
-	require.NoError(t, data.createPodOnNode(name, node, agnhostImage, []string{}, args, nil, []corev1.ContainerPort{
+	require.NoError(t, data.createPodOnNode(name, testNamespace, node, agnhostImage, []string{}, args, nil, []corev1.ContainerPort{
 		{
 			Name:          "http",
 			ContainerPort: 80,
@@ -164,7 +164,7 @@ func (data *TestData) createAgnhostServiceAndBackendPods(t *testing.T, name stri
 	require.NoError(t, err)
 
 	cleanup := func() {
-		data.deletePodAndWait(defaultTimeout, name)
+		data.deletePodAndWait(defaultTimeout, name, testNamespace)
 		data.deleteServiceAndWait(defaultTimeout, name)
 	}
 

--- a/test/e2e/traceflow_test.go
+++ b/test/e2e/traceflow_test.go
@@ -75,7 +75,7 @@ func TestTraceflowIntraNodeANP(t *testing.T) {
 	failOnError(err, t)
 
 	node1 := nodeName(0)
-	node1Pods, _, node1CleanupFn := createTestBusyboxPods(t, data, 3, node1)
+	node1Pods, _, node1CleanupFn := createTestBusyboxPods(t, data, 3, testNamespace, node1)
 	defer node1CleanupFn()
 
 	var denyIngress *secv1alpha1.NetworkPolicy
@@ -270,7 +270,7 @@ func TestTraceflowIntraNode(t *testing.T) {
 
 	node1 := nodeName(0)
 
-	node1Pods, node1IPs, node1CleanupFn := createTestBusyboxPods(t, data, 3, node1)
+	node1Pods, node1IPs, node1CleanupFn := createTestBusyboxPods(t, data, 3, testNamespace, node1)
 	defer node1CleanupFn()
 	var pod0IPv4Str, pod1IPv4Str, dstPodIPv4Str, dstPodIPv6Str string
 	if node1IPs[0].ipv4 != nil {
@@ -1045,8 +1045,8 @@ func TestTraceflowInterNode(t *testing.T) {
 	node1 := nodeName(0)
 	node2 := nodeName(1)
 
-	node1Pods, _, node1CleanupFn := createTestBusyboxPods(t, data, 1, node1)
-	node2Pods, node2IPs, node2CleanupFn := createTestBusyboxPods(t, data, 2, node2)
+	node1Pods, _, node1CleanupFn := createTestBusyboxPods(t, data, 1, testNamespace, node1)
+	node2Pods, node2IPs, node2CleanupFn := createTestBusyboxPods(t, data, 2, testNamespace, node2)
 	defer node1CleanupFn()
 	defer node2CleanupFn()
 	var dstPodIPv4Str, dstPodIPv6Str string
@@ -1060,7 +1060,7 @@ func TestTraceflowInterNode(t *testing.T) {
 	// Create Service backend Pod. The "hairpin" testcases require the Service to have a single backend Pod,
 	// and no more, in order to be deterministic.
 	nginxPodName := "nginx"
-	require.NoError(t, data.createNginxPodOnNode(nginxPodName, node2))
+	require.NoError(t, data.createNginxPodOnNode(nginxPodName, testNamespace, node2))
 	nginxIP, err := data.podWaitForIPs(defaultTimeout, nginxPodName, testNamespace)
 	require.NoError(t, err)
 
@@ -1900,7 +1900,7 @@ func TestTraceflowExternalIP(t *testing.T) {
 
 	node := nodeName(0)
 	nodeIP := nodeIP(0)
-	podNames, _, cleanupFn := createTestBusyboxPods(t, data, 1, node)
+	podNames, _, cleanupFn := createTestBusyboxPods(t, data, 1, testNamespace, node)
 	defer cleanupFn()
 
 	testcase := testcase{
@@ -2124,7 +2124,7 @@ func runTestTraceflow(t *testing.T, data *TestData, tc testcase) {
 		// Give a little time for Nodes to install OVS flows.
 		time.Sleep(time.Second * 2)
 		// Send an ICMP echo packet from the source Pod to the destination.
-		if err := data.runPingCommandFromTestPod(podInfo{srcPod, "linux"}, dstPodIPs, busyboxContainerName, 2, 0); err != nil {
+		if err := data.runPingCommandFromTestPod(podInfo{srcPod, "linux"}, testNamespace, dstPodIPs, busyboxContainerName, 2, 0); err != nil {
 			t.Logf("Ping '%s' -> '%v' failed: ERROR (%v)", srcPod, *dstPodIPs, err)
 		}
 	}

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -54,7 +54,7 @@ func TestUpgrade(t *testing.T) {
 	podName := randName("test-pod-")
 
 	t.Logf("Creating a busybox test Pod on '%s'", nodeName)
-	if err := data.createBusyboxPodOnNode(podName, nodeName); err != nil {
+	if err := data.createBusyboxPodOnNode(podName, testNamespace, nodeName); err != nil {
 		t.Fatalf("Error when creating busybox test Pod: %v", err)
 	}
 	if err := data.podWaitForRunning(defaultTimeout, podName, testNamespace); err != nil {


### PR DESCRIPTION
In the most cases of e2e tests, we implicitly set namespace to `testNamespace` while we create Pods. And we then we make call to `podWaitForRunning(defaultTimeout, podName, testNamespace)` for example, which makes it unintuitive of the occurrence of `testNamespace` here. So we decide to make namespace as a parameter when we create Pods.

Fixes: #2249 