### PR TITLE
Fix the deadlock between the exporter and the conntrack polling go routines

### DIFF
--- a/pkg/agent/flowexporter/connections/conntrack_connections.go
+++ b/pkg/agent/flowexporter/connections/conntrack_connections.go
@@ -103,7 +103,7 @@ func (cs *ConntrackConnectionStore) Poll() ([]int, error) {
 	// Reset IsPresent flag for all connections in connection map before dumping flows in conntrack module.
 	// if the connection does not exist in conntrack table and has been exported, we will delete it from connection map.
 	deleteIfStaleOrResetConn := func(key flowexporter.ConnectionKey, conn *flowexporter.Connection) error {
-		if !conn.IsPresent && conn.DoneExport {
+		if !conn.IsPresent && conn.DyingAndDoneExport {
 			if err := cs.DeleteConnWithoutLock(key); err != nil {
 				return err
 			}
@@ -246,17 +246,4 @@ func (cs *ConntrackConnectionStore) DeleteConnWithoutLock(connKey flowexporter.C
 	delete(cs.connections, connKey)
 	metrics.TotalAntreaConnectionsInConnTrackTable.Dec()
 	return nil
-}
-
-// SetExportDone sets DoneExport field of conntrack connection to true given the connection key.
-func (cs *ConntrackConnectionStore) SetExportDone(connKey flowexporter.ConnectionKey) error {
-	cs.mutex.Lock()
-	defer cs.mutex.Unlock()
-
-	if conn, found := cs.connections[connKey]; !found {
-		return fmt.Errorf("connection with key %v does not exist in connection map", connKey)
-	} else {
-		conn.DoneExport = true
-		return nil
-	}
 }

--- a/pkg/agent/flowexporter/connections/conntrack_connections_perf_test.go
+++ b/pkg/agent/flowexporter/connections/conntrack_connections_perf_test.go
@@ -121,7 +121,7 @@ func generateUpdatedConns(conns []*flowexporter.Connection) []*flowexporter.Conn
 	updatedConns := make([]*flowexporter.Connection, length)
 	for i := 0; i < len(conns); i++ {
 		// replace deleted connection with new connection
-		if conns[i].DoneExport == true {
+		if conns[i].DyingAndDoneExport == true {
 			conns[i] = getNewConn()
 		} else { // update rest of connections
 			conns[i].OriginalPackets += 5
@@ -136,9 +136,9 @@ func generateUpdatedConns(conns []*flowexporter.Connection) []*flowexporter.Conn
 	}
 	randomNum := getRandomNum(int64(length - testNumOfDeletedConns))
 	for i := randomNum; i < testNumOfDeletedConns+randomNum; i++ {
-		// hardcode DoneExport here for testing deletion of connections
+		// hardcode DyingAndDoneExport here for testing deletion of connections
 		// not valid for testing update and export of records
-		updatedConns[i].DoneExport = true
+		updatedConns[i].DyingAndDoneExport = true
 	}
 	return updatedConns
 }
@@ -154,7 +154,7 @@ func getNewConn() *flowexporter.Connection {
 		StartTime:                 time.Now().Add(-time.Duration(randomNum1) * time.Second),
 		StopTime:                  time.Now(),
 		IsPresent:                 true,
-		DoneExport:                false,
+		DyingAndDoneExport:        false,
 		FlowKey:                   flowKey,
 		OriginalPackets:           10,
 		OriginalBytes:             100,

--- a/pkg/agent/flowexporter/exporter/exporter_perf_test.go
+++ b/pkg/agent/flowexporter/exporter/exporter_perf_test.go
@@ -187,7 +187,7 @@ func addConnsAndGetRecords(connStore *connections.ConntrackConnectionStore) *flo
 			StopTime:                   time.Now(),
 			LastExportTime:             time.Now().Add(-time.Duration(randomNum1)*time.Millisecond - testActiveFlowTimeout),
 			IsPresent:                  true,
-			DoneExport:                 false,
+			DyingAndDoneExport:         false,
 			FlowKey:                    flowKey,
 			OriginalPackets:            100,
 			OriginalBytes:              10,

--- a/pkg/agent/flowexporter/types.go
+++ b/pkg/agent/flowexporter/types.go
@@ -43,9 +43,9 @@ type Connection struct {
 	StopTime time.Time
 	// IsPresent flag helps in cleaning up connections when they are not in conntrack table anymore.
 	IsPresent bool
-	// DoneExport marks whether the related flow records are already exported or not so that we can
+	// DyingAndDoneExport marks whether the related flow records are already exported or not so that we can
 	// safely delete the connection from the connection map.
-	DoneExport         bool
+	DyingAndDoneExport bool
 	Zone               uint16
 	Mark               uint32
 	StatusFlag         uint32
@@ -88,5 +88,6 @@ type FlowRecord struct {
 	PrevReverseBytes   uint64
 	IsIPv6             bool
 	LastExportTime     time.Time
+	DyingAndDoneExport bool
 	IsActive           bool
 }


### PR DESCRIPTION
Deadlock is due to the access of connection map from exporter goroutine waiting to acquire connection map lock to update the "DoneExport" flag of the stored connection. At the same time, the connection polling goroutine acquires the connection map lock waiting to acquire flow record map, which is acquired by the exporter goroutine. 
This was caught in scale testing.
Resolved this through a temporary fix by adding the same flag in the flow record data struct. 

The connection and record deletion logic will be re-evaluated through PR #2360 as it refactors the related code quite a bit.