### PR TITLE
Resolve flow aggregator close issue

### DIFF
--- a/ci/kind/test-e2e-kind.sh
+++ b/ci/kind/test-e2e-kind.sh
@@ -115,7 +115,7 @@ else
     manifest_args="$manifest_args --no-np"
 fi
 
-COMMON_IMAGES_LIST=("gcr.io/kubernetes-e2e-test-images/agnhost:2.8" "projects.registry.vmware.com/library/busybox" "projects.registry.vmware.com/antrea/nginx" "projects.registry.vmware.com/antrea/perftool" "projects.registry.vmware.com/antrea/ipfix-collector:v0.5.4")
+COMMON_IMAGES_LIST=("gcr.io/kubernetes-e2e-test-images/agnhost:2.8" "projects.registry.vmware.com/library/busybox" "projects.registry.vmware.com/antrea/nginx" "projects.registry.vmware.com/antrea/perftool" "projects.registry.vmware.com/antrea/ipfix-collector:v0.5.7")
 for image in "${COMMON_IMAGES_LIST[@]}"; do
     for i in `seq 3`; do
         docker pull $image && break

--- a/cmd/flow-aggregator/flow-aggregator.go
+++ b/cmd/flow-aggregator/flow-aggregator.go
@@ -17,6 +17,7 @@ package main
 import (
 	"fmt"
 	"hash/fnv"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -115,12 +116,15 @@ func run(o *Options) error {
 	if err != nil {
 		return fmt.Errorf("error when creating aggregation process: %v", err)
 	}
-	go flowAggregator.Run(stopCh)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go flowAggregator.Run(stopCh, &wg)
 
 	informerFactory.Start(stopCh)
 
 	<-stopCh
 	klog.Infof("Stopping flow aggregator")
+	wg.Wait()
 	return nil
 }
 

--- a/pkg/flowaggregator/flowaggregator.go
+++ b/pkg/flowaggregator/flowaggregator.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/vmware/go-ipfix/pkg/collector"
@@ -361,7 +362,8 @@ func (fa *flowAggregator) initExportingProcess() error {
 	return nil
 }
 
-func (fa *flowAggregator) Run(stopCh <-chan struct{}) {
+func (fa *flowAggregator) Run(stopCh <-chan struct{}, wg *sync.WaitGroup) {
+	defer wg.Done()
 	go fa.collectingProcess.Start()
 	defer fa.collectingProcess.Stop()
 	go fa.aggregationProcess.Start()

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -104,7 +104,7 @@ const (
 	busyboxImage        = "projects.registry.vmware.com/library/busybox"
 	nginxImage          = "projects.registry.vmware.com/antrea/nginx"
 	perftoolImage       = "projects.registry.vmware.com/antrea/perftool"
-	ipfixCollectorImage = "projects.registry.vmware.com/antrea/ipfix-collector:v0.5.4"
+	ipfixCollectorImage = "projects.registry.vmware.com/antrea/ipfix-collector:v0.5.7"
 	ipfixCollectorPort  = "4739"
 
 	nginxLBService = "nginx-loadbalancer"
@@ -593,7 +593,7 @@ func (data *TestData) deployAntreaFlowExporter(ipfixCollector string) error {
 	return data.mutateAntreaConfigMap(nil, ac, false, true)
 }
 
-// deployFlowAggregator deploys flow aggregator with ipfix collector address.
+// deployFlowAggregator deploys the Flow Aggregator with ipfix collector address.
 func (data *TestData) deployFlowAggregator(ipfixCollector string) (string, error) {
 	flowAggYaml := flowAggregatorYML
 	if testOptions.enableCoverage {
@@ -601,7 +601,7 @@ func (data *TestData) deployFlowAggregator(ipfixCollector string) (string, error
 	}
 	rc, _, _, err := provider.RunCommandOnNode(controlPlaneNodeName(), fmt.Sprintf("kubectl apply -f %s", flowAggYaml))
 	if err != nil || rc != 0 {
-		return "", fmt.Errorf("error when deploying flow aggregator; %s not available on the control-plane Node", flowAggYaml)
+		return "", fmt.Errorf("error when deploying the Flow Aggregator; %s not available on the control-plane Node", flowAggYaml)
 	}
 	svc, err := data.clientset.CoreV1().Services(flowAggregatorNamespace).Get(context.TODO(), flowAggregatorDeployment, metav1.GetOptions{})
 	if err != nil {
@@ -613,7 +613,7 @@ func (data *TestData) deployFlowAggregator(ipfixCollector string) (string, error
 	if rc, _, _, err = provider.RunCommandOnNode(controlPlaneNodeName(), fmt.Sprintf("kubectl -n %s rollout status deployment/%s --timeout=%v", flowAggregatorNamespace, flowAggregatorDeployment, 2*defaultTimeout)); err != nil || rc != 0 {
 		_, stdout, _, _ := provider.RunCommandOnNode(controlPlaneNodeName(), fmt.Sprintf("kubectl -n %s describe pod", flowAggregatorNamespace))
 		_, logStdout, _, _ := provider.RunCommandOnNode(controlPlaneNodeName(), fmt.Sprintf("kubectl -n %s logs -l app=flow-aggregator", flowAggregatorNamespace))
-		return stdout, fmt.Errorf("error when waiting for flow aggregator rollout to complete. kubectl describe output: %s, logs: %s", stdout, logStdout)
+		return stdout, fmt.Errorf("error when waiting for the Flow Aggregator rollout to complete. kubectl describe output: %s, logs: %s", stdout, logStdout)
 	}
 	return svc.Spec.ClusterIP, nil
 }


### PR DESCRIPTION
When we delete flow aggregator manifests, closing signal does not get passed to flow aggregator to close collecting process and aggregation process before main function exits. Last log (verbose=4) shown in flow aggregator when closing is like:
```
I0719 21:16:56.474762       1 reflector.go:225] Stopping reflector *v1.Pod (12h0m0s) from pkg/mod/k8s.io/client-go@v0.21.0/tools/cache/reflector.go:167
I0719 21:16:56.474949       1 flow-aggregator.go:121] Stopping flow aggregator
rpc error: code = Unknown desc = Error: No such container: dafd2b659ffba89e5170d75072f24fb3f2dcfe33a4c61981cf153ffd6653fb98%
```
There should be logs for closing collecting process https://github.com/vmware/go-ipfix/blob/main/pkg/collector/process.go#L111 but not, which means that collecting process is not closed correctly in flow aggregator. And after we delete the manifests, flow exporter can still send records to previously established connections until garbage collection works on cleaning the connections (about 10-15 mins) even if a new flow aggregator has already been started.  This is not expected behavior because we don't want flow exporter to restart every time flow aggregator gets re-deployed. 
To make sure Flow Exporter will not write to closed connections, we had a fix in go-ipfix https://github.com/vmware/go-ipfix/pull/229. But we still need to wait for collecting process to be completely closed before exiting where waitGroup is added.