### PR TITLE
[Flow Aggregator] Fix throughput calculation in Logstash

### DIFF
--- a/build/yamls/elk-flow-collector/logstash/filter.rb
+++ b/build/yamls/elk-flow-collector/logstash/filter.rb
@@ -146,6 +146,10 @@ def filter(event)
        startTime = DateTime.strptime(event.get("[ipfix][flowStartSeconds]").to_s, '%Y-%m-%dT%H:%M:%S').to_time.to_i
        endTime = DateTime.strptime(event.get("[ipfix][flowEndSeconds]").to_s, '%Y-%m-%dT%H:%M:%S').to_time.to_i
        duration = endTime-startTime
+       # if startTime equals endTime, just set throughput to current octetDeltaCount
+       if duration == 0
+         duration = 1
+       end
        event.set("[ipfix][throughput]", event.get("[ipfix][octetDeltaCountFromSourceNode]").to_i / duration.to_i)
        event.set("[ipfix][reverseThroughput]", event.get("[ipfix][reverseOctetDeltaCountFromSourceNode]").to_i / duration.to_i)
        @@time_map[key] = endTime

--- a/pkg/agent/flowexporter/connections/conntrack_connections.go
+++ b/pkg/agent/flowexporter/connections/conntrack_connections.go
@@ -228,6 +228,7 @@ func (cs *ConntrackConnectionStore) AddOrUpdateConn(conn *flowexporter.Connectio
 		cs.addNetworkPolicyMetadata(conn)
 		if conn.StartTime.IsZero() {
 			conn.StartTime = time.Now()
+			conn.StopTime = time.Now()
 		}
 		metrics.TotalAntreaConnectionsInConnTrackTable.Inc()
 		klog.V(4).Infof("New Antrea flow added: %v", conn)


### PR DESCRIPTION
This PR fixes throughput divided by 0 issue happened in Logstash. 
Since we introduce `conn.StartTime.IsZero()` check and update StartTime to `time.Now()` in previous fix https://github.com/antrea-io/antrea/pull/2308, there are chances that `StartTime` will be equal or later than `StopTime`, which may cause incorrect throughput calculation or exception (divided by 0) in Logstash. And we will miss some flow records on Kibana due to this exception when the flow duration is quite short (less than 1 second)