### PR TITLE
e2e: ssh should return error other than nil

### DIFF
--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -402,9 +402,10 @@ func collectClusterInfo() error {
 
 	retrieveCIDRs := func(cmd string, reg string) ([]string, error) {
 		res := make([]string, 2)
-		rc, stdout, _, err := RunCommandOnNode(controlPlaneNodeName(), cmd)
+		controlPlaneNode := controlPlaneNodeName()
+		rc, stdout, _, err := RunCommandOnNode(controlPlaneNode, cmd)
 		if err != nil || rc != 0 {
-			return res, fmt.Errorf("error when running the following command `%s` on control-plane Node: %v, %s", cmd, err, stdout)
+			return res, fmt.Errorf("error when running the following command `%s` on control-plane Node %s: %d, %v, %s", cmd, controlPlaneNode, rc, err, stdout)
 		}
 		re := regexp.MustCompile(reg)
 		if matches := re.FindStringSubmatch(stdout); len(matches) == 0 {

--- a/test/e2e/providers/exec/ssh.go
+++ b/test/e2e/providers/exec/ssh.go
@@ -44,7 +44,7 @@ func RunSSHCommand(host string, config *ssh.ClientConfig, cmd string) (code int,
 			return 0, "", "", fmt.Errorf("did not get an exit status for SSH command: %v", e)
 		case *ssh.ExitError:
 			// SSH operation successful, but command returned error code
-			return e.ExitStatus(), stdoutB.String(), stderrB.String(), nil
+			return e.ExitStatus(), stdoutB.String(), stderrB.String(), err
 		default:
 			return 0, "", "", fmt.Errorf("unknown error when executing SSH command: %v", err)
 		}


### PR DESCRIPTION
e2e: ssh should return error other than nil even if the error type is ssh.ExitError