### PR TITLE
Remove child group existence validation for ClusterGroup

### DIFF
--- a/test/e2e/clustergroup_test.go
+++ b/test/e2e/clustergroup_test.go
@@ -160,23 +160,6 @@ func testInvalidCGServiceRefWithIPBlock(t *testing.T) {
 	}
 }
 
-func testInvalidCGChildGroupDoesNotExist(t *testing.T) {
-	invalidErr := fmt.Errorf("clustergroup childGroup does not exist")
-	cgName := "child-group-not-exist"
-	cg := &crdv1alpha3.ClusterGroup{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: cgName,
-		},
-		Spec: crdv1alpha3.GroupSpec{
-			ChildGroups: []crdv1alpha3.ClusterGroupReference{crdv1alpha3.ClusterGroupReference("some-non-existing-cg")},
-		},
-	}
-	if _, err := k8sUtils.CreateOrUpdateV1Alpha3CG(cg); err == nil {
-		// Above creation of CG must fail as it is an invalid spec.
-		failOnError(invalidErr, t)
-	}
-}
-
 var testChildCGName = "test-child-cg"
 
 func createChildCGForTest(t *testing.T) {
@@ -249,22 +232,38 @@ func testInvalidCGMaxNestedLevel(t *testing.T) {
 			ChildGroups: []crdv1alpha3.ClusterGroupReference{crdv1alpha3.ClusterGroupReference(testChildCGName)},
 		},
 	}
-	if _, err := k8sUtils.CreateOrUpdateV1Alpha3CG(cg1); err != nil {
-		// Above creation of CG must succeed as it is a valid spec.
-		failOnError(err, t)
-	}
 	cg2 := &crdv1alpha3.ClusterGroup{
 		ObjectMeta: metav1.ObjectMeta{Name: cgName2},
 		Spec: crdv1alpha3.GroupSpec{
 			ChildGroups: []crdv1alpha3.ClusterGroupReference{crdv1alpha3.ClusterGroupReference(cgName1)},
 		},
 	}
+	// Try to create cg-nested-1 first and then cg-nested-2.
+	// The creation of cg-nested-2 should fail as it breaks the max nested level
+	if _, err := k8sUtils.CreateOrUpdateV1Alpha3CG(cg1); err != nil {
+		// Above creation of CG must succeed as it is a valid spec.
+		failOnError(err, t)
+	}
 	if _, err := k8sUtils.CreateOrUpdateV1Alpha3CG(cg2); err == nil {
-		// Above creation of CG must fail as it is an invalid spec.
+		// Above creation of CG must fail as cg-nested-2 cannot have cg-nested-1 as childGroup.
 		failOnError(invalidErr, t)
 	}
 	// cleanup cg-nested-1
 	if err := k8sUtils.DeleteV1Alpha3CG(cgName1); err != nil {
+		failOnError(err, t)
+	}
+	// Try to create cg-nested-2 first and then cg-nested-1.
+	// The creation of cg-nested-1 should fail as it breaks the max nested level
+	if _, err := k8sUtils.CreateOrUpdateV1Alpha3CG(cg2); err != nil {
+		// Above creation of CG must succeed as it is a valid spec.
+		failOnError(err, t)
+	}
+	if _, err := k8sUtils.CreateOrUpdateV1Alpha3CG(cg1); err == nil {
+		// Above creation of CG must fail as cg-nested-2 cannot have cg-nested-1 as childGroup.
+		failOnError(invalidErr, t)
+	}
+	// cleanup cg-nested-2
+	if err := k8sUtils.DeleteV1Alpha3CG(cgName2); err != nil {
 		failOnError(err, t)
 	}
 }
@@ -332,7 +331,6 @@ func TestClusterGroup(t *testing.T) {
 		t.Run("Case=ServiceRefWithPodSelectorDenied", func(t *testing.T) { testInvalidCGServiceRefWithPodSelector(t) })
 		t.Run("Case=ServiceRefWithNamespaceSelectorDenied", func(t *testing.T) { testInvalidCGServiceRefWithNSSelector(t) })
 		t.Run("Case=ServiceRefWithIPBlockDenied", func(t *testing.T) { testInvalidCGServiceRefWithIPBlock(t) })
-		t.Run("Case=InvalidChildGroupName", func(t *testing.T) { testInvalidCGChildGroupDoesNotExist(t) })
 	})
 	t.Run("TestGroupClusterGroupValidateChildGroup", func(t *testing.T) {
 		createChildCGForTest(t)

--- a/test/e2e/legacyclustergroup_test.go
+++ b/test/e2e/legacyclustergroup_test.go
@@ -137,23 +137,6 @@ func testLegacyInvalidCGServiceRefWithIPBlock(t *testing.T) {
 	}
 }
 
-func testLegacyInvalidCGChildGroupDoesNotExist(t *testing.T) {
-	invalidErr := fmt.Errorf("clustergroup childGroup does not exist")
-	cgName := "child-group-not-exist"
-	cg := &legacycorev1alpha2.ClusterGroup{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: cgName,
-		},
-		Spec: crdv1alpha2.GroupSpec{
-			ChildGroups: []crdv1alpha2.ClusterGroupReference{crdv1alpha2.ClusterGroupReference("some-non-existing-cg")},
-		},
-	}
-	if _, err := k8sUtils.CreateOrUpdateLegacyCG(cg); err == nil {
-		// Above creation of CG must fail as it is an invalid spec.
-		failOnError(invalidErr, t)
-	}
-}
-
 func createLegacyChildCGForTest(t *testing.T) {
 	cg := &legacycorev1alpha2.ClusterGroup{
 		ObjectMeta: metav1.ObjectMeta{
@@ -261,7 +244,6 @@ func TestLegacyClusterGroup(t *testing.T) {
 		t.Run("Case=LegacyServiceRefWithPodSelectorDenied", func(t *testing.T) { testLegacyInvalidCGServiceRefWithPodSelector(t) })
 		t.Run("Case=LegacyServiceRefWithNamespaceSelectorDenied", func(t *testing.T) { testLegacyInvalidCGServiceRefWithNSSelector(t) })
 		t.Run("Case=LegacyServiceRefWithIPBlockDenied", func(t *testing.T) { testLegacyInvalidCGServiceRefWithIPBlock(t) })
-		t.Run("Case=LegacyInvalidChildGroupName", func(t *testing.T) { testLegacyInvalidCGChildGroupDoesNotExist(t) })
 	})
 
 	t.Run("TestLegacyGroupClusterGroupValidateChildGroup", func(t *testing.T) {


### PR DESCRIPTION
This is the first of two PRs that relaxes admission validations for ClusterGroup references. This PR removes the restriction that a child ClusterGroup must exist before it can be referred to as `childGroup` in other ClusterGroups. With this change, the effective member of a nested ClusterGroup will be calculated as the union of its childGroup members, for each childGroup that exist in the cluster.

Note that this PR does not change the max nested level of ClusterGroups, which is 1 at the moment. This means that any ClusterGroup that has a parent cannot be a nested ClusterGroup itself; and reversely, a ClusterGroup cannot select another nested ClusterGroup as its `childGroup`. This is validated upon creation/update of a ClusterGroup. The order of events matter in this case, as any update which would cause a ClusterGroup nesting over the order of 1 will be rejected.

i.e. if we have 3 ClusterGroups: cg1; cg2: child=cg1; cg3: child=cg2
1) Creation of cg1, cg2 in whichever order will be allowed. After that, creation of cg3 will not be allowed.
2) Creation of cg1, cg3 in whichever order will be allowed. After that, creation of cg2 will not be allowed.
3) Creation of cg2, cg3 in whichever order will be allowed. After that, creation of cg1 will not be allowed.

Tests done:
1. Creation of CG validation, as specified above
2. ClusterGroup membership for nested CG whose childGroups all exist, partially exist and none exist.
3. ACNP with ClusterGroup reference, whose childGroup is then created/updated/deleted.