### PR TITLE
Fix invalid prerelease characters when parse kernel version

### DIFF
--- a/pkg/util/runtime/runtime_linux.go
+++ b/pkg/util/runtime/runtime_linux.go
@@ -17,6 +17,7 @@ package runtime
 import (
 	"bytes"
 	"fmt"
+	"strings"
 
 	"github.com/blang/semver"
 	"golang.org/x/sys/unix"
@@ -29,7 +30,14 @@ func parseKernelVersionStr(kernelVersionStr string) (semver.Version, error) {
 	// Patch: 0
 	// Pre: [72-generic]
 	// Build: []
-	return semver.Parse(kernelVersionStr)
+	verStrs := strings.Split(kernelVersionStr, ".")
+	switch {
+	case len(verStrs) < 2:
+		return semver.Version{}, fmt.Errorf("unable to get kernel version from %q", kernelVersionStr)
+	case len(verStrs) < 3:
+		verStrs = append(verStrs, "0")
+	}
+	return semver.Parse(strings.Join(verStrs[:3], "."))
 }
 
 // GetKernelVersion returns the Linux kernel version for the current host.

--- a/pkg/util/runtime/runtime_linux_test.go
+++ b/pkg/util/runtime/runtime_linux_test.go
@@ -1,0 +1,70 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/blang/semver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseKernelVersion(t *testing.T) {
+	testcases := []struct {
+		// input
+		kernelString string
+		// expectations
+		expectedKernelVersion semver.Version
+		expectedError         error
+	}{
+		{
+			kernelString:          "4.10",
+			expectedKernelVersion: semver.MustParse("4.10.0"),
+			expectedError:         nil,
+		},
+		{
+			kernelString:          "4.10.3",
+			expectedKernelVersion: semver.MustParse("4.10.3"),
+			expectedError:         nil,
+		},
+		{
+			kernelString:          "4.12.17-040917-generic",
+			expectedKernelVersion: semver.MustParse("4.12.17-040917-generic"),
+			expectedError:         nil,
+		},
+		{
+			kernelString:          "4.13.18-300.el7.x86_64",
+			expectedKernelVersion: semver.MustParse("4.13.18-300"),
+			expectedError:         nil,
+		},
+		{
+			kernelString:          "5",
+			expectedKernelVersion: semver.Version{},
+			expectedError:         fmt.Errorf("unable to get kernel version from \"5\""),
+		},
+	}
+	for _, tc := range testcases {
+		parsedKernelVersion, err := parseKernelVersionStr(tc.kernelString)
+		if tc.expectedError != nil {
+			assert.Equal(t, tc.expectedError, err)
+		} else {
+			require.Nil(t, err)
+			assert.Equal(t, tc.expectedKernelVersion, parsedKernelVersion)
+		}
+
+	}
+}


### PR DESCRIPTION
Check kernel version splitted array length and intercept the first 3 elements for parsing kernel version.

Fixes #2449 

Signed-off-by: Zhengdong Wu <zhengdong.wu@transwarp.io>