### PR TITLE
[Windows] Update Windows instructions

### DIFF
--- a/ci/jenkins/test.sh
+++ b/ci/jenkins/test.sh
@@ -33,7 +33,7 @@ IMAGE_PULL_POLICY="Always"
 WINDOWS_CONFORMANCE_FOCUS="\[sig-network\].+\[Conformance\]|\[sig-windows\]"
 WINDOWS_CONFORMANCE_SKIP="\[LinuxOnly\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[sig-cli\]|\[sig-storage\]|\[sig-auth\]|\[sig-api-machinery\]|\[sig-apps\]|\[sig-node\]|\[Privileged\]|should be able to change the type from|\[sig-network\] Services should be able to create a functioning NodePort service \[Conformance\]|Service endpoints latency should not be very high|should be able to create a functioning NodePort service for Windows"
 WINDOWS_NETWORKPOLICY_FOCUS="\[Feature:NetworkPolicy\]"
-WINDOWS_NETWORKPOLICY_SKIP="SKIP_NO_TESTCASE"
+WINDOWS_NETWORKPOLICY_SKIP="SCTP"
 CONFORMANCE_SKIP="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[sig-cli\]|\[sig-storage\]|\[sig-auth\]|\[sig-api-machinery\]|\[sig-apps\]|\[sig-node\]"
 NETWORKPOLICY_SKIP="should allow egress access to server in CIDR block|should enforce except clause while egress access to server in CIDR block"
 
@@ -232,7 +232,7 @@ function deliver_antrea_windows {
     chmod -R g-w build/images/ovs
     chmod -R g-w build/images/base
     DOCKER_REGISTRY="${DOCKER_REGISTRY}" ./hack/build-antrea-ubuntu-all.sh --pull
-    if [[ "$TESTCASE" =~ "networkpolicy" ]]; then
+    if [[ "$TESTCASE" == "windows-networkpolicy-process" ]]; then
         make windows-bin
         make antctl-windows
     fi
@@ -271,6 +271,8 @@ function deliver_antrea_windows {
         echo "==== Reverting Windows VM ${WORKER_NAME} ====="
         govc snapshot.revert -vm.ip ${IP} win-initial
         govc vm.power -on ${WORKER_NAME} || true
+        # Windows VM is reverted to an old snapshot so computer date needs updating.
+        ssh -o StrictHostKeyChecking=no -n Administrator@${IP} "powershell W32tm /resync /force"
         # Some tests need us.gcr.io/k8s-artifacts-prod/e2e-test-images/agnhost:2.13 image but it is not for windows/amd64 10.0.17763
         # Use e2eteam/agnhost:2.13 instead
         harbor_images=("sigwindowstools-kube-proxy:v1.18.0" "agnhost:2.13" "agnhost:2.13" "e2eteam-jessie-dnsutils:1.0" "e2eteam-pause:3.2")
@@ -280,13 +282,15 @@ function deliver_antrea_windows {
         done
 
         # Use a script to run antrea agent in windows Network Policy cases
-        if [ "$TESTCASE" == "windows-networkpolicy" ]; then
+        if [ "$TESTCASE" == "windows-networkpolicy-process" ]; then
             for i in `seq 24`; do
                 sleep 5
                 ssh -o StrictHostKeyChecking=no -n Administrator@${IP} "W32tm /resync /force" | grep successfully && break
             done
             ssh -o StrictHostKeyChecking=no -n Administrator@${IP} "powershell stop-service kubelet"
-            ssh -o StrictHostKeyChecking=no -n Administrator@${IP} "powershell restart-service docker"
+            ssh -o StrictHostKeyChecking=no -n Administrator@${IP} "powershell stop-service docker"
+            ssh -o StrictHostKeyChecking=no -n Administrator@${IP} "powershell rm C:\ProgramData\docker\docker.pid" || true
+            ssh -o StrictHostKeyChecking=no -n Administrator@${IP} "powershell start-service docker"
             ssh -o StrictHostKeyChecking=no -n Administrator@${IP} "powershell start-service kubelet"
             ssh -o StrictHostKeyChecking=no -n Administrator@${IP} "powershell start-service ovsdb-server"
             ssh -o StrictHostKeyChecking=no -n Administrator@${IP} "powershell start-service ovs-vswitchd"
@@ -311,7 +315,7 @@ function deliver_antrea_windows {
                 done
                 echo "=== Build Windows on Windows Node==="
                 ssh -o StrictHostKeyChecking=no -n Administrator@${IP} "docker pull ${DOCKER_REGISTRY}/antrea/golang:1.15 && docker tag ${DOCKER_REGISTRY}/antrea/golang:1.15 golang:1.15"
-                ssh -o StrictHostKeyChecking=no -n Administrator@${IP} "rm -rf antrea && mkdir antrea && cd antrea && tar -xzf ../antrea_repo.tar.gz && sed -i \"s|build/images/Dockerfile.build.windows .|build/images/Dockerfile.build.windows . --network host|g\" Makefile && NO_PULL=${NO_PULL} make build-windows && docker save -o antrea-windows.tar ${DOCKER_REGISTRY}/antrea/antrea-windows:latest && gzip -f antrea-windows.tar" || true
+                ssh -o StrictHostKeyChecking=no -n Administrator@${IP} "rm -rf antrea && mkdir antrea && cd antrea && tar -xzf ../antrea_repo.tar.gz > /dev/null && sed -i \"s|build/images/Dockerfile.build.windows .|build/images/Dockerfile.build.windows . --network host|g\" Makefile && NO_PULL=${NO_PULL} make build-windows && docker save -o antrea-windows.tar ${DOCKER_REGISTRY}/antrea/antrea-windows:latest && gzip -f antrea-windows.tar" || true
                 for i in `seq 2`; do
                     timeout 2m scp -o StrictHostKeyChecking=no -T Administrator@${IP}:antrea/antrea-windows.tar.gz . && break
                 done
@@ -495,13 +499,13 @@ function run_conformance_windows {
     export PATH=$GOROOT/bin:$PATH
     export KUBECONFIG=$KUBECONFIG_PATH
 
-    if [[ "$TESTCASE" == "windows-conformance" ]]; then
+    if [[ "$TESTCASE" == "windows-networkpolicy-process" ]]; then
+        # Antrea Windows agents are deployed with scripts as processes on host for Windows NetworkPolicy test
+        wait_for_antrea_windows_processes_ready
+    else
         # Antrea Windows agent Pods are deployed for Windows Conformance test
         clean_for_windows_install_cni
         wait_for_antrea_windows_pods_ready
-    else
-        # Antrea Windows agents are deployed with scripts as processes on host for Windows NetworkPolicy test
-        wait_for_antrea_windows_processes_ready
     fi
 
     echo "====== Run test with e2e.test ======"

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -58,6 +58,8 @@ and daemons are pre-installed on the Windows Nodes in the demo.
     Antrea on Windows, Antrea provides a test-signed OVS package for you.
     See details in [Join Windows worker Nodes](#Join-Windows-worker-nodes)
     section.
+* Some manifests are from [sig-windows-tool](https://github.com/kubernetes-sigs/sig-windows-tools)
+  repo. Release version v0.1.5 has been verified.
 
 ### Installation as a Service (Containerd based runtimes)
 
@@ -87,16 +89,18 @@ $KubeletKubeconfigPath="<KubeletKubeconfigPath>"
 $KubeProxyKubeconfigPath="<KubeProxyKubeconfigPath>"
 $KubernetesHome="c:/k"
 $AntreaHome="c:/k/antrea"
+$KubeProxyLogPath="c:/var/log/kube-proxy"
 
 curl.exe -LO "https://raw.githubusercontent.com/antrea-io/antrea/${TAG}/hack/windows/Helper.psm1"
-
 Import-Module ./Helper.psm1
+
 Install-AntreaAgent -KubernetesVersion "$KubernetesVersion" -KubernetesHome "$KubernetesHome" -KubeConfig "$KubeConfig" -AntreaVersion "$TAG" -AntreaHome "$AntreaHome"
 New-KubeProxyServiceInterface
 
-mkdir "${AntreaHome}/logs"
-nssm install kube-proxy "${KubernetesHome}/kube-proxy.exe" "--proxy-mode=userspace --kubeconfig=$KubeProxyKubeconfigPath --log-dir=c:/var/log/kube-proxy --logtostderr=false --alsologtostderr"
-nssm install antrea-agent "${KubernetesHome}/antrea/bin/antrea-agent.exe" "--config=${KubernetesHome}/antrea/etc/antrea-agent.conf --logtostderr=false --log_dir=${KubernetesHome}/antrea/logs --alsologtostderr --log_file_max_size=100 --log_file_max_num=4"
+New-DirectoryIfNotExist "${AntreaHome}/logs"
+New-DirectoryIfNotExist "${KubeProxyLogPath}"
+nssm install kube-proxy "${KubernetesHome}/kube-proxy.exe" "--proxy-mode=userspace --kubeconfig=${KubeProxyKubeconfigPath} --log-dir=${KubeProxyLogPath} --logtostderr=false --alsologtostderr"
+nssm install antrea-agent "${AntreaHome}/bin/antrea-agent.exe" "--config=${AntreaHome}/etc/antrea-agent.conf --logtostderr=false --log_dir=${AntreaHome}/logs --alsologtostderr --log_file_max_size=100 --log_file_max_num=4"
 
 nssm set antrea-agent DependOnService kube-proxy ovs-vswitchd
 nssm set antrea-agent Start SERVICE_DELAYED_AUTO_START
@@ -130,7 +134,7 @@ kube-proxy version.
 
 ```bash
 # Example:
-curl -L https://github.com/kubernetes-sigs/sig-windows-tools/releases/latest/download/kube-proxy.yml | sed 's/VERSION/v1.18.0/g'  > kube-proxy.yml
+curl -L "https://github.com/kubernetes-sigs/sig-windows-tools/releases/download/v0.1.5/kube-proxy.yml" | sed 's/VERSION/v1.18.0/g' > kube-proxy.yml
 ```
 
 Replace the content of `run-script.ps1` in configmap named `kube-proxy-windows`
@@ -250,7 +254,7 @@ container.
 
 ```powershell
 # Example:
-curl.exe -LO https://github.com/kubernetes-sigs/sig-windows-tools/releases/latest/download/PrepareNode.ps1
+curl.exe -LO "https://github.com/kubernetes-sigs/sig-windows-tools/releases/download/v0.1.5/PrepareNode.ps1"
 .\PrepareNode.ps1 -KubernetesVersion v1.18.0
 ```
 

--- a/hack/windows/Helper.psm1
+++ b/hack/windows/Helper.psm1
@@ -1,9 +1,10 @@
 function Get-WebFileIfNotExist($Path, $URL) {
-    if (Test-Path $Path) {
-        return
+    $count=0
+    while (!(Test-Path $Path) -and ($count -ne 3)) {
+        $count++
+        Write-Host "Downloading $URL to $PATH"
+        curl.exe -skLo $Path $URL
     }
-    Write-Host "Downloading $URL to $PATH"
-    curl.exe -sLo $Path $URL
 }
 
 function New-DirectoryIfNotExist($Path)
@@ -93,7 +94,7 @@ function Install-AntreaAgent {
 
     New-DirectoryIfNotExist $KubernetesHome
     # Download kubectl
-    Get-WebFileIfNotExist $kubectl  "https://$KubernetesURL/$KubernetesVersion/bin/windows/amd64/kubectl.exe"
+    Get-WebFileIfNotExist $kubectl "https://$KubernetesURL/$KubernetesVersion/bin/windows/amd64/kubectl.exe"
     # Download kube-proxy
     Get-WebFileIfNotExist $KubeProxy "https://$KubernetesURL/$KubernetesVersion/bin/windows/amd64/kube-proxy.exe"
     # Download yq

--- a/hack/windows/Prepare-Node.ps1
+++ b/hack/windows/Prepare-Node.ps1
@@ -4,7 +4,8 @@
 
 .DESCRIPTION
 This script is only used for test to assist with joining a Windows node to a cluster.
-For production environment please follow the antrea windows installation guide and use kubernetes official script: https://github.com/kubernetes-sigs/sig-windows-tools/blob/master/kubeadm/scripts/PrepareNode.ps1
+For production environment please follow the antrea windows installation guide and use Kubernetes official PrepareNode.ps1
+script from the sig-windows-tools repo release page: https://github.com/kubernetes-sigs/sig-windows-tools/releases
 - Downloads Kubernetes binaries (kubelet, kubeadm) at the version specified
 - Registers wins as a service in order to run kube-proxy and antrea-agent as DaemonSets.
 - Registers kubelet as an nssm service. More info on nssm: https://nssm.cc/

--- a/hack/windows/Prepare-ServiceInterface.ps1
+++ b/hack/windows/Prepare-ServiceInterface.ps1
@@ -3,7 +3,7 @@
 Create virtual netadapter for kube-proxy. The default full name of the virtual adapter is "vEthernet (HNS Internal NIC)"
 
 .DESCRIPTION
-This script creates virtual netadapter for kube-proxy. The created virtual adapter is used by kube-proxy to configure kubernetes Services IPs on it.
+This script creates virtual netadapter for kube-proxy. The created virtual adapter is used by kube-proxy to configure Kubernetes Services IPs on it.
 
 .PARAMETER KubernetesVersion
 Kubernetes version to download and use


### PR DESCRIPTION
    * Mkdir kube-proxy log path before installation as a Service
      Otherwise kube-proxy Service may not work well.
    * Updated asset links from kubernetes-sigs/sig-windows-tools repo
    * Retry for Get-WebFileIfNotExist
    * Have cleaner environment for docker (stop, remove docker.pid, start)
    * Start Antrea Windows agent in Daemonset way for Windows NetworkPolicy test
      Currently the script way leads to many flaky failures
    * Skip SCTP test for Windows NetworkPolicy tests since it requires privilege mode
      which is not available on Windows Node
    * Force date sync after Windows VM is reverted to a snapshot


Signed-off-by: Zhecheng Li <lzhecheng@vmware.com>