### PR TITLE
Automated cherry pick of #2451: Update OVS version from 2.14.0 to 2.14.2

### DIFF
--- a/.github/workflows/update_ovs_image.yml
+++ b/.github/workflows/update_ovs_image.yml
@@ -15,7 +15,7 @@ jobs:
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        OVS_VERSION: 2.14.0
+        OVS_VERSION: 2.14.2
       run: |
         cd build/images/ovs/
         docker pull antrea/openvswitch-debs:$OVS_VERSION || true

--- a/build/images/Dockerfile.build.coverage
+++ b/build/images/Dockerfile.build.coverage
@@ -11,7 +11,7 @@ COPY . /antrea
 RUN make antrea-agent antrea-controller antrea-cni antctl-ubuntu antrea-controller-instr-binary antrea-agent-instr-binary antctl-instr-binary
 
 
-FROM antrea/base-ubuntu:2.14.0
+FROM antrea/base-ubuntu:2.14.2
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="The Docker image to deploy the Antrea CNI with code coverage measurement enabled (used for testing)."

--- a/build/images/Dockerfile.build.ubuntu
+++ b/build/images/Dockerfile.build.ubuntu
@@ -11,7 +11,7 @@ COPY . /antrea
 RUN make antrea-agent antrea-controller antrea-cni antctl-ubuntu
 
 
-FROM antrea/base-ubuntu:2.14.0
+FROM antrea/base-ubuntu:2.14.2
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="The Docker image to deploy the Antrea CNI. "

--- a/build/images/Dockerfile.ubuntu
+++ b/build/images/Dockerfile.ubuntu
@@ -1,4 +1,4 @@
-FROM antrea/base-ubuntu:2.14.0
+FROM antrea/base-ubuntu:2.14.2
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="The Docker image to deploy the Antrea CNI. "

--- a/build/images/base/Dockerfile
+++ b/build/images/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG OVS_VERSION=2.14.0
+ARG OVS_VERSION=2.14.2
 FROM ubuntu:20.04 as cni-binaries
 
 RUN apt-get update && \

--- a/build/images/flow-aggregator/Dockerfile
+++ b/build/images/flow-aggregator/Dockerfile
@@ -6,7 +6,7 @@ COPY . /antrea
 
 RUN make flow-aggregator
 
-FROM antrea/base-ubuntu:2.14.0
+FROM antrea/base-ubuntu:2.14.2
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="The docker image for the flow aggregator"

--- a/build/images/ovs/Dockerfile
+++ b/build/images/ovs/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04 as ovs-debs
 
 # Some patches may not apply cleanly if another version is provided.
-ARG OVS_VERSION=2.14.0
+ARG OVS_VERSION=2.14.2
 
 # Install dependencies for building OVS deb packages
 # We only install python3 packages and we only support building OVS >= 2.13.0.

--- a/build/images/ovs/README.md
+++ b/build/images/ovs/README.md
@@ -19,7 +19,7 @@ directory. For example:
 
 ```bash
 cd build/images/ovs
-OVS_VERSION=2.14.0 ./build.sh --pull --push
+OVS_VERSION=2.14.2 ./build.sh --pull --push
 ```
 
 The image will be pushed to Dockerhub as `antrea/openvswitch:$OVS_VERSION`.

--- a/build/images/ovs/apply-patches.sh
+++ b/build/images/ovs/apply-patches.sh
@@ -35,8 +35,8 @@ function version_let() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" == "
 # greater than or equal to
 function version_get() { test "$(printf '%s\n' "$@" | sort -rV | head -n 1)" == "$1"; }
 
-if version_lt "$OVS_VERSION" "2.13.0" || version_gt "$OVS_VERSION" "2.14.0"; then
-    echoerr "OVS_VERSION $OVS_VERSION is not supported (must be >= 2.13.0 and <= 2.14.0)"
+if version_lt "$OVS_VERSION" "2.13.0" || version_get "$OVS_VERSION" "2.15.0"; then
+    echoerr "OVS_VERSION $OVS_VERSION is not supported (must be >= 2.13.0 and < 2.15.0)"
     exit 1
 fi
 
@@ -83,10 +83,10 @@ fi
 # Starting from version 5.7.0, strongSwan no longer supports specifying a configuration parameter
 # with the path delimited by dots in a configuration file. This patch fixes the strongSwan
 # configuration parameters that ovs-monitor-ipsec writes, to comply with the new strongSwan format.
-# After a new OVS release with the fix is available, we should switch to use that OVS release, and
-# remove the workaround to apply the patch here.
-curl https://github.com/openvswitch/ovs/commit/b424becaac58d8cb08fb19ea839be6807d3ed57f.patch | \
-    git apply
+if version_lt "$OVS_VERSION" "2.14.1" ; then
+    curl https://github.com/openvswitch/ovs/commit/b424becaac58d8cb08fb19ea839be6807d3ed57f.patch | \
+        git apply
+fi
 
 # OVS hardcodes the installation path to /usr/lib/python3.7/dist-packages/ but this location
 # does not seem to be in the Python path in Ubuntu 20.04. There may be a better way to do this,

--- a/build/images/test/Dockerfile
+++ b/build/images/test/Dockerfile
@@ -1,4 +1,4 @@
-FROM antrea/openvswitch:2.14.0
+FROM antrea/openvswitch:2.14.2
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="A Docker image for antrea integration tests."

--- a/ci/jenkins/test-vmc.sh
+++ b/ci/jenkins/test-vmc.sh
@@ -285,8 +285,8 @@ function deliver_antrea {
     docker image prune -f --filter "until=1h" || true > /dev/null
     cd $GIT_CHECKOUT_DIR
     if [[ ${DOCKER_REGISTRY} != "" ]]; then
-        docker pull ${DOCKER_REGISTRY}/antrea/base-ubuntu:2.14.0
-        docker tag ${DOCKER_REGISTRY}/antrea/base-ubuntu:2.14.0 antrea/base-ubuntu:2.14.0
+        docker pull ${DOCKER_REGISTRY}/antrea/base-ubuntu:2.14.2
+        docker tag ${DOCKER_REGISTRY}/antrea/base-ubuntu:2.14.2 antrea/base-ubuntu:2.14.2
         docker pull ${DOCKER_REGISTRY}/antrea/golang:1.15
         docker tag ${DOCKER_REGISTRY}/antrea/golang:1.15 golang:1.15
     fi
@@ -391,8 +391,8 @@ function run_integration {
     set -x
     echo "===== Run Integration test ====="
     if [[ ${DOCKER_REGISTRY} != "" ]]; then
-        docker pull ${DOCKER_REGISTRY}/antrea/openvswitch:2.14.0
-        docker tag ${DOCKER_REGISTRY}/antrea/openvswitch:2.14.0 antrea/openvswitch:2.14.0
+        docker pull ${DOCKER_REGISTRY}/antrea/openvswitch:2.14.2
+        docker tag ${DOCKER_REGISTRY}/antrea/openvswitch:2.14.2 antrea/openvswitch:2.14.2
     fi
     ssh -q -o StrictHostKeyChecking=no -i "${WORKDIR}/utils/key" -n jenkins@${VM_IP} "git clone ${ghprbAuthorRepoGitUrl} antrea && cd antrea && git checkout ${GIT_BRANCH} && DOCKER_REGISTRY=${DOCKER_REGISTRY} make docker-test-integration"
     if [[ "$COVERAGE" == true ]]; then

--- a/ci/jenkins/test.sh
+++ b/ci/jenkins/test.sh
@@ -102,8 +102,8 @@ fi
 E2ETEST_PATH=${WORKDIR}/kubernetes/_output/dockerized/bin/linux/amd64/e2e.test
 
 function pull_antrea_ubuntu_image {
-    harbor_images=("base-ubuntu:2.14.0" "golang:1.15")
-    antrea_images=("antrea/base-ubuntu:2.14.0" "golang:1.15")
+    harbor_images=("base-ubuntu:2.14.2" "golang:1.15")
+    antrea_images=("antrea/base-ubuntu:2.14.2" "golang:1.15")
     for i in {0..4}; do
         docker pull ${DOCKER_REGISTRY}/antrea/${harbor_images[i]} && docker tag ${DOCKER_REGISTRY}/antrea/${harbor_images[i]} ${antrea_images[i]} || true
     done

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -221,7 +221,7 @@ f06768ee-17ec-4abb-a971-b3b76abc8cda
         Port antrea-gw0
             Interface antrea-gw0
             type: internal
-    ovs_version: "2.14.0"
+    ovs_version: "2.14.2"
 ```
 
 - `ovs-ofctl show br-int`: show OpenFlow information of the OVS bridge.


### PR DESCRIPTION
Cherry pick of #2451 on release-0.13.

#2451: Update OVS version from 2.14.0 to 2.14.2

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.