### PR TITLE
Fix invalid client-go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -75,5 +75,5 @@ replace (
 	// There is an optimization https://github.com/kubernetes/kubernetes/pull/89575 but will only be
 	// available from 1.19.0 and later releases. Use this commit before Antrea bumps up its K8s
 	// dependency version.
-	k8s.io/client-go => github.com/antrea-io/client-go v0.18.19
+	k8s.io/client-go => github.com/antrea-io/client-go v0.18.19-1
 )

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,8 @@ github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmx
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alexflint/go-filemutex v0.0.0-20171022225611-72bdc8eae2ae/go.mod h1:CgnQgUtFrFz9mxFNtED3jI5tLDjKlOM+oUF/sTk6ps0=
-github.com/antrea-io/client-go v0.18.19 h1:HPNE+cNAbGkbTarVVXfBaqYIcZLlem4LngN+YuHkKts=
-github.com/antrea-io/client-go v0.18.19/go.mod h1:lB+d4UqdzSjaU41VODLYm/oon3o05LAzsVpm6Me5XkY=
+github.com/antrea-io/client-go v0.18.19-1 h1:kZ99AfSw3dqn0n+scI8ektQwWgMo2iYpW9MKSGBYKa4=
+github.com/antrea-io/client-go v0.18.19-1/go.mod h1:lB+d4UqdzSjaU41VODLYm/oon3o05LAzsVpm6Me5XkY=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/awalterschulze/gographviz v2.0.1+incompatible h1:XIECBRq9VPEQqkQL5pw2OtjCAdrtIgFKoJU8eT98AS8=
 github.com/awalterschulze/gographviz v2.0.1+incompatible/go.mod h1:GEV5wmg4YquNw7v1kkyoX9etIk8yVmXj+AkDHuuETHs=


### PR DESCRIPTION
In https://github.com/antrea-io/antrea/pull/2452, I made a typo and used
v0.18.19 (which is the upstream release) instead of v0.18.19-1 (which is
the Antrea-specific release with Quan's patch).

Signed-off-by: Antonin Bas <abas@vmware.com>