### PR TITLE
Revert policy conjunction cache when batch rule reconciliation fails

### DIFF
--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
@@ -135,7 +135,11 @@ func newAppliedToGroup(name string, pods []v1beta2.GroupMember) *v1beta2.Applied
 }
 
 func newNetworkPolicy(name string, uid types.UID, from, to, appliedTo []string, services []v1beta2.Service) *v1beta2.NetworkPolicy {
-	networkPolicyRule1 := newPolicyRule(v1beta2.DirectionIn, from, to, services)
+	dir := v1beta2.DirectionIn
+	if len(from) == 0 && len(to) > 0 {
+		dir = v1beta2.DirectionOut
+	}
+	networkPolicyRule1 := newPolicyRule(dir, from, to, services)
 	return &v1beta2.NetworkPolicy{
 		ObjectMeta:      v1.ObjectMeta{UID: uid, Name: string(uid)},
 		Rules:           []v1beta2.NetworkPolicyRule{networkPolicyRule1},
@@ -432,33 +436,32 @@ func TestAddNetworkPolicyWithMultipleRules(t *testing.T) {
 			actualRule, _ := reconciler.getLastRealized(ruleID)
 			if actualRule.Direction == v1beta2.DirectionIn {
 				if !assert.ElementsMatch(t, actualRule.Services, desiredRule1.Services) {
-					t.Errorf("Expected Services %v, got %v", actualRule.Services, desiredRule1.Services)
+					t.Errorf("Expected Services %v, got %v", desiredRule1.Services, actualRule.Services)
 				}
 				if !actualRule.FromAddresses.Equal(desiredRule1.FromAddresses) {
-					t.Errorf("Expected FromAddresses %v, got %v", actualRule.FromAddresses, desiredRule1.FromAddresses)
+					t.Errorf("Expected FromAddresses %v, got %v", desiredRule1.FromAddresses, actualRule.FromAddresses)
 				}
 				if !actualRule.ToAddresses.Equal(desiredRule1.ToAddresses) {
-					t.Errorf("Expected ToAddresses %v, got %v", actualRule.ToAddresses, desiredRule1.ToAddresses)
+					t.Errorf("Expected ToAddresses %v, got %v", desiredRule1.ToAddresses, actualRule.ToAddresses)
 				}
 				if !actualRule.TargetMembers.Equal(desiredRule1.TargetMembers) {
-					t.Errorf("Expected Pods %v, got %v", actualRule.TargetMembers, desiredRule1.TargetMembers)
+					t.Errorf("Expected Pods %v, got %v", desiredRule1.TargetMembers, actualRule.TargetMembers)
 				}
 			}
 			if actualRule.Direction == v1beta2.DirectionOut {
 				if !assert.ElementsMatch(t, actualRule.Services, desiredRule2.Services) {
-					t.Errorf("Expected Services %v, got %v", actualRule.Services, desiredRule2.Services)
+					t.Errorf("Expected Services %v, got %v", desiredRule2.Services, actualRule.Services)
 				}
 				if !actualRule.FromAddresses.Equal(desiredRule2.FromAddresses) {
-					t.Errorf("Expected FromAddresses %v, got %v", actualRule.FromAddresses, desiredRule2.FromAddresses)
+					t.Errorf("Expected FromAddresses %v, got %v", desiredRule2.FromAddresses, actualRule.FromAddresses)
 				}
 				if !actualRule.ToAddresses.Equal(desiredRule2.ToAddresses) {
-					t.Errorf("Expected ToAddresses %v, got %v", actualRule.ToAddresses, desiredRule2.ToAddresses)
+					t.Errorf("Expected ToAddresses %v, got %v", desiredRule2.ToAddresses, actualRule.ToAddresses)
 				}
 				if !actualRule.TargetMembers.Equal(desiredRule2.TargetMembers) {
-					t.Errorf("Expected Pods %v, got %v", actualRule.TargetMembers, desiredRule2.TargetMembers)
+					t.Errorf("Expected Pods %v, got %v", desiredRule2.TargetMembers, actualRule.TargetMembers)
 				}
 			}
-
 		case <-time.After(time.Millisecond * 100):
 			t.Fatal("Expected two rule updates, got timeout")
 		}


### PR DESCRIPTION
In events where the batch NetworkPolicy rule installation fails after Antrea agent restart (which could be caused by agent Node slowness leading to OVS bundle commit timeout), the global conjunction cache of the Antrea agent should be reverted to empty, so as to keep in sync with the actual state of the OVS tables.

The cache needs to be updated during the flow change calculation step of batch-rule install: since the flow add/mod/del calculation logic is incremental, calculation of flows changes resulted from adding a later rule depends on the state of existing flows created by previous rules, even though they have not been sent to the datapath for realization.

Test done:
Manually set `sendConjunctiveFlows` fails for the batch rule install case. Observed that after the batch rule reconciliation failure, all rules were successfully and correctly realized asynchronously
```
E0723 22:54:37.923424       1 networkpolicy_controller.go:471] Error occurred when reconciling all rules for init events: mock OVS timeout occurred
I0723 22:54:37.923788       1 networkpolicy_controller.go:416] Starting NetworkPolicy workers now
I0723 22:54:37.923803       1 networkpolicy_controller.go:422] Starting IDAllocator worker to maintain the async rule cache
I0723 22:54:37.923816       1 status_controller.go:209] Starting NetworkPolicy StatusController
I0723 22:54:42.924556       1 reconciler.go:234] Reconciling rule 5a3d7e7a1d78778b of NetworkPolicy AntreaClusterNetworkPolicy:acnp-1
I0723 22:54:42.924866       1 reconciler.go:234] Reconciling rule 6832b95a1a09d7bb of NetworkPolicy AntreaClusterNetworkPolicy:acnp-4
I0723 22:54:42.924965       1 reconciler.go:234] Reconciling rule 20520a100d6f9a8c of NetworkPolicy AntreaClusterNetworkPolicy:acnp-2
I0723 22:54:42.924985       1 reconciler.go:234] Reconciling rule 9f049aeb3949480a of NetworkPolicy AntreaClusterNetworkPolicy:acnp-3
I0723 22:54:42.930946       1 reconciler.go:234] Reconciling rule dead74e9013a6be0 of NetworkPolicy AntreaNetworkPolicy:anp-example
I0723 22:54:42.940535       1 reconciler.go:234] Reconciling rule 1da7f954520fde41 of NetworkPolicy AntreaNetworkPolicy:anp-example
I0723 22:54:42.954865       1 reconciler.go:234] Reconciling rule 774a526a5ff2f83e of NetworkPolicy AntreaNetworkPolicy:anp-example
```