### PR TITLE
Use customized Equal to reduce memory footprint

### DIFF
--- a/pkg/agent/proxy/endpoints.go
+++ b/pkg/agent/proxy/endpoints.go
@@ -17,7 +17,6 @@ package proxy
 import (
 	"fmt"
 	"net"
-	"reflect"
 	"sync"
 
 	corev1 "k8s.io/api/core/v1"
@@ -100,7 +99,7 @@ func (t *endpointsChangesTracker) OnEndpointUpdate(previous, current *corev1.End
 
 	change.current = t.endpointsToEndpointsMap(current)
 	// If change.previous equals to change.current, it means no change.
-	if reflect.DeepEqual(change.previous, change.current) {
+	if change.previous.Equal(change.current) {
 		delete(t.changes, namespacedName)
 	}
 

--- a/pkg/agent/proxy/endpoints_test.go
+++ b/pkg/agent/proxy/endpoints_test.go
@@ -1,0 +1,92 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
+)
+
+func BenchmarkEndpointsChangesTrackerOnEndpointUpdate(b *testing.B) {
+	var oldAddresses []corev1.EndpointAddress
+	nodeName := rand.String(20)
+	resourceVersion := fmt.Sprintf("%d", rand.Int())
+	for i := 0; i < 10; i++ {
+		oldAddresses = append(oldAddresses, corev1.EndpointAddress{
+			IP:       fmt.Sprintf("1.1.1.%d", i),
+			NodeName: &nodeName,
+			TargetRef: &corev1.ObjectReference{
+				Kind:            "Pod",
+				Namespace:       "default",
+				Name:            rand.String(10),
+				UID:             types.UID(uuid.New().String()),
+				ResourceVersion: resourceVersion,
+			},
+		})
+	}
+	oldEndpoints := makeTestEndpoints("foo", "bar", func(ept *corev1.Endpoints) {
+		ept.Subsets = []corev1.EndpointSubset{{
+			Addresses: oldAddresses,
+			Ports: []corev1.EndpointPort{{
+				Name:     "http",
+				Port:     int32(80),
+				Protocol: corev1.ProtocolTCP,
+			}},
+		}}
+	})
+
+	for _, tc := range []struct {
+		name       string
+		mutateFunc func(endpoints *corev1.Endpoints)
+	}{
+		{
+			name:       "equal",
+			mutateFunc: nil,
+		},
+		{
+			name: "not equal, same length",
+			mutateFunc: func(endpoints *corev1.Endpoints) {
+				endpoints.Subsets[0].Addresses[5].IP = "2.2.2.2"
+			},
+		},
+		{
+			name: "not equal, different length",
+			mutateFunc: func(endpoints *corev1.Endpoints) {
+				numAddresses := len(endpoints.Subsets[0].Addresses)
+				endpoints.Subsets[0].Addresses = endpoints.Subsets[0].Addresses[0 : numAddresses-1]
+			},
+		},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			newEndpoints := oldEndpoints.DeepCopy()
+			if tc.mutateFunc != nil {
+				tc.mutateFunc(newEndpoints)
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				t := newEndpointsChangesTracker("node1", false, false)
+				t.OnEndpointUpdate(oldEndpoints, newEndpoints)
+			}
+		})
+	}
+
+}

--- a/pkg/agent/proxy/types/types.go
+++ b/pkg/agent/proxy/types/types.go
@@ -56,3 +56,34 @@ func NewEndpointInfo(baseInfo *k8sproxy.BaseEndpointInfo) k8sproxy.Endpoint {
 }
 
 type EndpointsMap map[k8sproxy.ServicePortName]map[string]k8sproxy.Endpoint
+
+func (m EndpointsMap) Equal(o EndpointsMap) bool {
+	if m == nil && o == nil {
+		return true
+	}
+	if m == nil || o == nil {
+		return false
+	}
+	if len(m) != len(o) {
+		return false
+	}
+	for svcPortName, endpoints := range m {
+		otherEndpoints, exists := o[svcPortName]
+		if !exists {
+			return false
+		}
+		if len(endpoints) != len(otherEndpoints) {
+			return false
+		}
+		for endpointKey, endpoint := range endpoints {
+			otherEndpoint, exists := otherEndpoints[endpointKey]
+			if !exists {
+				return false
+			}
+			if !endpoint.Equal(otherEndpoint) {
+				return false
+			}
+		}
+	}
+	return true
+}


### PR DESCRIPTION
reflect.DeepEqual is generic but has some extra overhead like detecting
cycle and constructing intermediate slices for map keys.
endpointsChangesTracker.OnEndpointUpdate is called quite often and it
uses reflect.DeepEqual to check if an Endpoints object is changed.
pprof heap shows reflect.DeepEqual called by it contributed 10% of
alloc_space. 

This patches adds a customized Equal method to EndpointsMap which avoids
the above overhead.

benchmark comparison with an Endpoints having 10 EndpointAddresses:

```
EndpointsChangesTrackerOnEndpointUpdate/equal-48                          49.2µs ± 2%    25.4µs ± 2%  -48.34%  (p=0.008 n=5+5)
EndpointsChangesTrackerOnEndpointUpdate/not_equal,_same_length-48         38.1µs ± 3%    24.1µs ± 1%  -36.68%  (p=0.008 n=5+5)
EndpointsChangesTrackerOnEndpointUpdate/not_equal,_different_length-48    24.6µs ± 2%    22.2µs ± 2%   -9.77%  (p=0.008 n=5+5)

name                                                                    old alloc/op   new alloc/op   delta
EndpointsChangesTrackerOnEndpointUpdate/equal-48                          7.91kB ± 0%    4.67kB ± 0%  -40.96%  (p=0.016 n=5+4)
EndpointsChangesTrackerOnEndpointUpdate/not_equal,_same_length-48         6.53kB ± 0%    4.67kB ± 0%  -28.53%  (p=0.008 n=5+5)
EndpointsChangesTrackerOnEndpointUpdate/not_equal,_different_length-48    4.80kB ± 0%    4.62kB ± 0%     ~     (p=0.079 n=4+5)

name                                                                    old allocs/op  new allocs/op  delta
EndpointsChangesTrackerOnEndpointUpdate/equal-48                             151 ± 0%        74 ± 0%  -50.99%  (p=0.008 n=5+5)
EndpointsChangesTrackerOnEndpointUpdate/not_equal,_same_length-48            118 ± 0%        74 ± 0%  -37.29%  (p=0.008 n=5+5)
EndpointsChangesTrackerOnEndpointUpdate/not_equal,_different_length-48      74.0 ± 0%      71.0 ± 0%   -4.05%  (p=0.008 n=5+5)
```
Signed-off-by: Quan Tian <qtian@vmware.com>

For #2457