### PR TITLE
use html comments for issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,27 +8,31 @@ assignees: ''
 ---
 
 **Describe the bug**
+<!--
 A clear and concise description of what the bug is.
 If you believe this bug is a security issue, please don't use this template and follow our [security guidelines](/SECURITY.md)
+-->
 
 **To Reproduce**
-Steps to reproduce the behavior.
+<!-- Steps to reproduce the behavior. -->
 
 **Expected**
-A clear and concise description of what you expected to happen.
+<!-- A clear and concise description of what you expected to happen. -->
 
 **Actual behavior**
-A clear and concise description of what's the actual behavior. If applicable, add screenshots, log messages, etc. to help explain the problem.
+<!-- A clear and concise description of what's the actual behavior. If applicable, add screenshots, log messages, etc. to help explain the problem. -->
 
 **Versions:**
+<!--
 Please provide the following information:
  - Antrea version (Docker image tag).
  - Kubernetes version (use `kubectl version`). If your Kubernetes components have [different versions](https://kubernetes.io/docs/setup/release/version-skew-policy/), please provide the version for all of them.
  - Container runtime: which runtime are you using (e.g. containerd, cri-o, docker) and which version are you using?
  - Linux kernel version on the Kubernetes Nodes (`uname -r`).
  - If you chose to compile the Open vSwitch kernel module manually instead of using the kernel module built into the Linux kernel, which version of the OVS kernel module are you using? Include the output of `modinfo openvswitch` for the Kubernetes Nodes.
+-->
 
 **Additional context**
-Add any other context about the problem here, such as Antrea logs, kubelet logs, etc.
+<!-- Add any other context about the problem here, such as Antrea logs, kubelet logs, etc. -->
 
-(Please consider pasting long output into a [GitHub gist](https://gist.github.com) or any other pastebin.)
+<!-- (Please consider pasting long output into a [GitHub gist](https://gist.github.com) or any other pastebin.) -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,10 +8,10 @@ assignees: ''
 ---
 
 **Describe the problem/challenge you have**
-A description of the current limitation/problem/challenge that you are experiencing.
+<!-- A description of the current limitation/problem/challenge that you are experiencing.-->
 
 **Describe the solution you'd like**
-A description of what you want to happen.
+<!-- A description of what you want to happen. -->
 
 **Anything else you would like to add?**
-Anything else which is relevant and may help us understand the issue.
+<!-- Anything else which is relevant and may help us understand the issue. -->

--- a/.github/ISSUE_TEMPLATE/proposal.md
+++ b/.github/ISSUE_TEMPLATE/proposal.md
@@ -8,22 +8,22 @@ assignees: ''
 ---
 
 **Describe what you are trying to solve**
-A description of the current limitation/problem/challenge that you are experiencing.
+<!-- A description of the current limitation/problem/challenge that you are experiencing. -->
 
 **Describe the solution you have in mind**
-A clear and concise description of what you want to happen.
+<!-- A clear and concise description of what you want to happen. -->
 
 **Describe how your solution impacts user flows**
-Does your solution impact how users interact with Antrea? If your proposal introduces a new user-facing feature, describe how it can be consumed.
+<!-- Does your solution impact how users interact with Antrea? If your proposal introduces a new user-facing feature, describe how it can be consumed. -->
 
 **Describe the main design/architecture of your solution**
-A clear and concise description of what does your solution look like. Rich text and diagrams are preferred.
+<!-- A clear and concise description of what does your solution look like. Rich text and diagrams are preferred. -->
 
 **Alternative solutions that you considered**
-A list of the alternative solutions that you considered, and why they fell short. You can list the pros and cons of each solution.
+<!-- A list of the alternative solutions that you considered, and why they fell short. You can list the pros and cons of each solution. -->
 
 **Test plan**
-Describe what kind of tests you plan on adding to exercise your changes.
+<!-- Describe what kind of tests you plan on adding to exercise your changes. -->
 
 **Additional context**
-Any other relevant information.
+<!-- Any other relevant information.-->

--- a/.github/ISSUE_TEMPLATE/support_request.md
+++ b/.github/ISSUE_TEMPLATE/support_request.md
@@ -8,4 +8,4 @@ assignees: ''
 ---
 
 **Describe what you are trying to do**
-A description of what you are trying to achieve, what you have tried so far and the issues you are facing.
+<!-- A description of what you are trying to achieve, what you have tried so far and the issues you are facing. -->


### PR DESCRIPTION
update issue template descriptions as html comments so it won't show up in preview
which means user can leave it as default without removing them manually

Signed-off-by: Lan Luo <luola@vmware.com>