### PR TITLE
Update API versioning documentation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,13 +1,44 @@
 # Antrea API
 
-This document lists all the API group versions currently or previously supported
-by Antrea, along with information related to their deprecation and removal when
-appropriate. it is kept up-to-date as we evolve the Antrea API.
+This document lists all the API resource versions currently or previously
+supported by Antrea, along with information related to their deprecation and
+removal when appropriate. It is kept up-to-date as we evolve the Antrea API.
+
+Starting with the v1.0 release, we decided to group all the Custom Resource
+Definitions (CRDs) defined by Antrea in a single API group, `crd.antrea.io`,
+instead of grouping CRDs logically in different API groups based on their
+purposes. The rationale for this change was to avoid profileration of API
+groups. As a result, all resources in the `crd.antrea.io` are versioned
+individually, while before the v1.0 release, we used to have a single version
+number for all the CRDs in a given group: when introducing a new version of the
+API group, we would "move" all CRDs from the earlier version to the new version
+together. This explains why the tables below are presented differently for
+`crd.antrea.io` and for other API groups.
 
 For information about the Antrea API versioning policy, please refer to this
 [document](versioning.md).
 
 ## Currently-supported
+
+### CRDs in `crd.antrea.io`
+
+These are the CRDs currently available in `crd.antrea.io`.
+
+| CRD | CRD version | Introduced in | Deprecated in / Planned Deprecation | Planned Removal |
+|---|---|---|---|---|
+| `AntreaAgentInfo` | v1beta1 | v1.0.0 | N/A | N/A |
+| `AntreaControllerInfo` | v1beta1 | v1.0.0 | N/A | N/A |
+| `ClusterGroup` | v1alpha2 | v1.0.0 | v1.1.0 | Feb 2022 |
+| `ClusterGroup` | v1alpha3 | v1.1.0 | N/A | N/A |
+| `ClusterNetworkPolicy` | v1alpha1 | v1.0.0 | N/A | N/A |
+| `Egress` | v1alpha2 | v1.0.0 | N/A | N/A |
+| `ExternalEntity` | v1alpha2 | v1.0.0 | N/A | N/A |
+| `ExternalIPPool` | v1alpha2 | v1.2.0 | N/A | N/A |
+| `NetworkPolicy` | v1alpha1 | v1.0.0 | N/A | N/A |
+| `Tier` | v1alpha1 | v1.0.0 | N/A | N/A |
+| `Traceflow` | v1alpha1 | v1.0.0 | N/A | N/A |
+
+### Other API groups
 
 These are the API group versions which are curently available when using Antrea.
 
@@ -21,9 +52,6 @@ These are the API group versions which are curently available when using Antrea.
 | `security.antrea.tanzu.vmware.com` | `v1alpha1` | No | v0.8.0 | v1.0.0 | Dec 2021 |
 | `stats.antrea.tanzu.vmware.com` | `v1alpha1` | Yes | v0.10.0 | v1.0.0 | Dec 2021 |
 | `system.antrea.tanzu.vmware.com` | `v1beta1` | Yes | v0.5.0 | v1.0.0 | Dec 2021 |
-| `crd.antrea.io` | `v1alpha1` | No | v1.0.0 | N/A | N/A |
-| `crd.antrea.io` | `v1alpha2` | No | v1.0.0 | N/A | N/A |
-| `crd.antrea.io` | `v1beta1` | No | v1.0.0 | N/A | N/A |
 | `controlplane.antrea.io` | `v1beta2` | Yes | v1.0.0 | N/A | N/A |
 | `stats.antrea.io` | `v1alpha1` | Yes | v1.0.0 | N/A | N/A |
 | `system.antrea.io` | `v1beta1` | Yes | v1.0.0 | N/A | N/A |
@@ -44,9 +72,7 @@ information about the motivations behind this undertaking, please refer to
 
 As part of this renaming, and to avoid profileration of API groups, we have
 decided to group all the Custom Resource Definitions (CRDs) defined by Antrea in
-a single API group: `crd.antrea.io`. In the future, resources within that group
-will be versioned individually as needed, and this will be reflected in the
-table above.
+a single API group: `crd.antrea.io`.
 
 To avoid disruptions to existing Antrea users, our requirements for this
 renaming process were as follows:

--- a/docs/api.md
+++ b/docs/api.md
@@ -7,7 +7,7 @@ removal when appropriate. It is kept up-to-date as we evolve the Antrea API.
 Starting with the v1.0 release, we decided to group all the Custom Resource
 Definitions (CRDs) defined by Antrea in a single API group, `crd.antrea.io`,
 instead of grouping CRDs logically in different API groups based on their
-purposes. The rationale for this change was to avoid profileration of API
+purposes. The rationale for this change was to avoid proliferation of API
 groups. As a result, all resources in the `crd.antrea.io` are versioned
 individually, while before the v1.0 release, we used to have a single version
 number for all the CRDs in a given group: when introducing a new version of the
@@ -70,7 +70,7 @@ For the v1.0 release, we undertook to rename all Antrea API to use the
 information about the motivations behind this undertaking, please refer to
 [Github issue #1715](https://github.com/antrea-io/antrea/issues/1715).
 
-As part of this renaming, and to avoid profileration of API groups, we have
+As part of this renaming, and to avoid proliferation of API groups, we have
 decided to group all the Custom Resource Definitions (CRDs) defined by Antrea in
 a single API group: `crd.antrea.io`.
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -12,6 +12,8 @@
 - [Deprecation policies](#deprecation-policies)
   - [Prometheus metrics deprecation policy](#prometheus-metrics-deprecation-policy)
   - [APIs deprecation policy](#apis-deprecation-policy)
+- [Introducing new API resources](#introducing-new-api-resources)
+  - [Introducing new CRDs](#introducing-new-crds)
 <!-- /toc -->
 
 ## Versioning scheme
@@ -214,6 +216,43 @@ the following rules:
 * For deprecated Beta and GA API versions, a [conversion webhook] must be
   provided along with each Antrea release, until the API version is removed
   altogether.
+
+## Introducing new API resources
+
+### Introducing new CRDs
+
+Starting with Antrea v1.0, all Custom Resource Definitions (CRDs) for Antrea are
+defined in the same API group, `crd.antrea.io`, and all CRDs in this group are
+versioned individually. For example, at the time of writing this (v1.3 release
+timeframe), the Antrea CRDs include:
+
+* `ClusterGroup` in `crd.antrea.io/v1alpha2`
+* `ClusterGroup` in `crd.antrea.io/v1alpha3`
+* `Egress` in `crd.antrea.io/v1alpha2`
+* etc.
+
+Notice how 2 versions of `ClusterGroup` are supported: the one in
+`crd.antrea.io/v1alpha2` was introduced in v1.0, and is being deprecated as it
+was replaced by the one in `crd.antrea.io/v1alpha3`, introduced in v1.1.
+
+When introducing a new version of a CRD, [the API deprecation policy should be
+followed](#apis-deprecation-policy).
+
+When introducing a CRD, the following rule should be followed in order to avoid
+potential dependency cyles (and thus import cycles in Go): if the CRD depends on
+other object types spread across potentially different versions of
+`crd.antrea.io`, the CRD should be defined in a group version greater or equal
+to all of these versions. For example, if we want to introduce a new CRD which
+depends on types `v1alpha1.X` and `v1alpha2.Y`, it needs to go into `v1alpha2`
+or a more recent version of `crd.antrea.io`. As a rule it should probably go
+into `v1alpha2` unless it is closely related to other CRDs in a later version,
+in which case it can be defined alongside these CRDs, in order to avoid user
+confusion.
+
+If a new CRD does not have dependencies and is not closely related to an
+existing CRD, it will typically be defined in `v1alpha1`. In some rare cases, a
+CRD can be defined in `v1beta1` directly if there is enough confidence in the
+stability of the API.
 
 [Semantic Versioning]: https://semver.org/
 [CHANGELOG]: ../CHANGELOG.md


### PR DESCRIPTION
* Update table of supported APIs to reflect the changes in Antrea v1.0
  (all CRDs to defined in the same API group). We can now track
  versioning of indvidual CRDs independently.
* Provide guidelines on which version to use when introducing new CRDs.

Signed-off-by: Antonin Bas <abas@vmware.com>