### PR TITLE
Update ClusterGroup singular name

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -255,7 +255,7 @@ spec:
     plural: clustergroups
     shortNames:
     - cg
-    singular: group
+    singular: clustergroup
   scope: Cluster
   versions:
   - name: v1alpha2

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -255,7 +255,7 @@ spec:
     plural: clustergroups
     shortNames:
     - cg
-    singular: group
+    singular: clustergroup
   scope: Cluster
   versions:
   - name: v1alpha2

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -255,7 +255,7 @@ spec:
     plural: clustergroups
     shortNames:
     - cg
-    singular: group
+    singular: clustergroup
   scope: Cluster
   versions:
   - name: v1alpha2

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -255,7 +255,7 @@ spec:
     plural: clustergroups
     shortNames:
     - cg
-    singular: group
+    singular: clustergroup
   scope: Cluster
   versions:
   - name: v1alpha2

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -255,7 +255,7 @@ spec:
     plural: clustergroups
     shortNames:
     - cg
-    singular: group
+    singular: clustergroup
   scope: Cluster
   versions:
   - name: v1alpha2

--- a/build/yamls/base/crds.yml
+++ b/build/yamls/base/crds.yml
@@ -1610,7 +1610,7 @@ spec:
   scope: Cluster
   names:
     plural: clustergroups
-    singular: group
+    singular: clustergroup
     kind: ClusterGroup
     shortNames:
       - cg


### PR DESCRIPTION
This PR updates the singular name of the ClusterGroup CRD from "group" to "clustergroup". After this update, the "kubectl
get group" command will not return any ClusterGroups. However, the most common way and the documented way to return
ClusterGroups using kubectl have been to use "kubectl get cg" or "kubectl get clustergroups".

Signed-off-by: abhiraut <rauta@vmware.com>