### PR TITLE
fix tunnel interface name issue

### DIFF
--- a/pkg/agent/util/net.go
+++ b/pkg/agent/util/net.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"strings"
 )
 
 const (
@@ -38,10 +39,15 @@ func generateInterfaceName(key string, name string, useHead bool) string {
 	interfaceKey := hex.EncodeToString(hash.Sum(nil))
 	prefix := name
 	if len(name) > interfacePrefixLength {
+		// We use Node/Pod name to generate the interface name,
+		// valid chars for Node/Pod name are ASCII letters from a to z,
+		// the digits from 0 to 9, and the hyphen (-).
+		// Hyphen (-) is the only char which will impact command-line interpretation
+		// if the interface name starts with one, so we remove it here.
 		if useHead {
-			prefix = name[:interfacePrefixLength]
+			prefix = strings.TrimLeft(name[:interfacePrefixLength], "-")
 		} else {
-			prefix = name[len(name)-interfacePrefixLength:]
+			prefix = strings.TrimLeft(name[len(name)-interfacePrefixLength:], "-")
 		}
 	}
 	return fmt.Sprintf("%s-%s", prefix, interfaceKey[:interfaceKeyLength])


### PR DESCRIPTION
the purpose of this commit is to fix a tunnel interface issue founded during some IPSec PoC verification:

1. when the node name is like 'lan-k8s-0-0', the IPsec tunnel interface name will be
like '-k8s-0-2-e8dbe6', then it will failed to run command like
`ipsec up '-k8s-0-2-e8dbe6'` inside a Antrea agent with error `/usr/lib/ipsec/stroke: invalid option -- 'k'`
due to the first char is '-', ipsec command interrupted it as an
option. so changed the `generateInterfaceName` method to use `strings.TrimLeft()` to remove '-' in left.

2. `createIPSecTunnelPort` method can't handle the case when tunnel
interface name changed when there is cache matched for the node. it
will reuse the existing tunnel name without creating a new one with new
name which means any change in `generateInterfaceName` won't take
affect. so refine it with more checks.

and also add some unit test cases.

Signed-off-by: Lan Luo <luola@vmware.com>