### PR TITLE
Fix test-upgrade-antrea.sh script so it can be used in release branches

### DIFF
--- a/ci/kind/test-upgrade-antrea.sh
+++ b/ci/kind/test-upgrade-antrea.sh
@@ -34,7 +34,7 @@ provided.
                                         test from the latest bug fix release for *minor* version
                                         N-{COUNT}. N-1 designates the latest minor release. If this
                                         script is run from a release branch, it will only consider
-                                        releases which predate that relase branch.
+                                        releases which predate that release branch.
         --controller-only               Update antrea-controller only when upgrading.
         --help, -h                      Print this message and exit
 "


### PR DESCRIPTION
The script should not consider minor releases which predate the
"current" version (which we can retrieve from the top-level VERSION
file).

Signed-off-by: Antonin Bas <abas@vmware.com>