### PR TITLE
Remove IPSec tunnel limitation

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -3740,8 +3740,7 @@ data:
     # also adjust MTU to accommodate for tunnel encapsulation overhead (if applicable).
     #defaultMTU: 0
 
-    # Whether or not to enable IPsec encryption of tunnel traffic. IPsec encryption is only supported
-    # for the GRE tunnel type.
+    # Whether or not to enable IPsec encryption of tunnel traffic.
     #enableIPSecTunnel: false
 
     # ClusterIP CIDR range for IPv6 Services. It's required when using kube-proxy to provide IPv6 Service in a Dual-Stack
@@ -3892,7 +3891,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-gdgb98gmfd
+  name: antrea-config-66dt98cgtb
   namespace: kube-system
 ---
 apiVersion: v1
@@ -3963,7 +3962,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-gdgb98gmfd
+          value: antrea-config-66dt98cgtb
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4014,7 +4013,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-gdgb98gmfd
+          name: antrea-config-66dt98cgtb
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4295,7 +4294,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-gdgb98gmfd
+          name: antrea-config-66dt98cgtb
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -3740,8 +3740,7 @@ data:
     # also adjust MTU to accommodate for tunnel encapsulation overhead (if applicable).
     #defaultMTU: 0
 
-    # Whether or not to enable IPsec encryption of tunnel traffic. IPsec encryption is only supported
-    # for the GRE tunnel type.
+    # Whether or not to enable IPsec encryption of tunnel traffic.
     #enableIPSecTunnel: false
 
     # ClusterIP CIDR range for IPv6 Services. It's required when using kube-proxy to provide IPv6 Service in a Dual-Stack
@@ -3892,7 +3891,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-gdgb98gmfd
+  name: antrea-config-66dt98cgtb
   namespace: kube-system
 ---
 apiVersion: v1
@@ -3963,7 +3962,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-gdgb98gmfd
+          value: antrea-config-66dt98cgtb
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4014,7 +4013,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-gdgb98gmfd
+          name: antrea-config-66dt98cgtb
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4297,7 +4296,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-gdgb98gmfd
+          name: antrea-config-66dt98cgtb
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -3740,8 +3740,7 @@ data:
     # also adjust MTU to accommodate for tunnel encapsulation overhead (if applicable).
     #defaultMTU: 0
 
-    # Whether or not to enable IPsec encryption of tunnel traffic. IPsec encryption is only supported
-    # for the GRE tunnel type.
+    # Whether or not to enable IPsec encryption of tunnel traffic.
     #enableIPSecTunnel: false
 
     # ClusterIP CIDR range for IPv6 Services. It's required when using kube-proxy to provide IPv6 Service in a Dual-Stack
@@ -3892,7 +3891,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-dc9bfdb7f6
+  name: antrea-config-d2f597tg62
   namespace: kube-system
 ---
 apiVersion: v1
@@ -3963,7 +3962,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-dc9bfdb7f6
+          value: antrea-config-d2f597tg62
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4014,7 +4013,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-dc9bfdb7f6
+          name: antrea-config-d2f597tg62
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4298,7 +4297,7 @@ spec:
           path: /home/kubernetes/bin
         name: host-cni-bin
       - configMap:
-          name: antrea-config-dc9bfdb7f6
+          name: antrea-config-d2f597tg62
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -3740,8 +3740,7 @@ data:
     # also adjust MTU to accommodate for tunnel encapsulation overhead (if applicable).
     #defaultMTU: 0
 
-    # Whether or not to enable IPsec encryption of tunnel traffic. IPsec encryption is only supported
-    # for the GRE tunnel type.
+    # Whether or not to enable IPsec encryption of tunnel traffic.
     enableIPSecTunnel: true
 
     # ClusterIP CIDR range for Services. It's required when AntreaProxy is not enabled, and should be
@@ -3897,7 +3896,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-cccf8b2ggf
+  name: antrea-config-bgd79km9c8
   namespace: kube-system
 ---
 apiVersion: v1
@@ -3977,7 +3976,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-cccf8b2ggf
+          value: antrea-config-bgd79km9c8
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4028,7 +4027,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-cccf8b2ggf
+          name: antrea-config-bgd79km9c8
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4344,7 +4343,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-cccf8b2ggf
+          name: antrea-config-bgd79km9c8
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -3740,8 +3740,7 @@ data:
     # also adjust MTU to accommodate for tunnel encapsulation overhead (if applicable).
     #defaultMTU: 0
 
-    # Whether or not to enable IPsec encryption of tunnel traffic. IPsec encryption is only supported
-    # for the GRE tunnel type.
+    # Whether or not to enable IPsec encryption of tunnel traffic.
     #enableIPSecTunnel: false
 
     # ClusterIP CIDR range for Services. It's required when AntreaProxy is not enabled, and should be
@@ -3897,7 +3896,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-mdd77fmc97
+  name: antrea-config-dd8ffc8tk9
   namespace: kube-system
 ---
 apiVersion: v1
@@ -3968,7 +3967,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-mdd77fmc97
+          value: antrea-config-dd8ffc8tk9
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4019,7 +4018,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-mdd77fmc97
+          name: antrea-config-dd8ffc8tk9
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4300,7 +4299,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-mdd77fmc97
+          name: antrea-config-dd8ffc8tk9
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/base/conf/antrea-agent.conf
+++ b/build/yamls/base/conf/antrea-agent.conf
@@ -77,8 +77,7 @@ featureGates:
 # also adjust MTU to accommodate for tunnel encapsulation overhead (if applicable).
 #defaultMTU: 0
 
-# Whether or not to enable IPsec encryption of tunnel traffic. IPsec encryption is only supported
-# for the GRE tunnel type.
+# Whether or not to enable IPsec encryption of tunnel traffic.
 #enableIPSecTunnel: false
 
 # ClusterIP CIDR range for Services. It's required when AntreaProxy is not enabled, and should be

--- a/cmd/antrea-agent/config.go
+++ b/cmd/antrea-agent/config.go
@@ -89,8 +89,7 @@ type AgentConfig struct {
 	// --service-cluster-ip-range. When AntreaProxy is enabled, this parameter is not needed.
 	// No default value for this field.
 	ServiceCIDRv6 string `yaml:"serviceCIDRv6,omitempty"`
-	// Whether or not to enable IPSec (ESP) encryption for Pod traffic across Nodes. IPSec encryption
-	// is supported only for the GRE tunnel type. Antrea uses Preshared Key (PSK) for IKE
+	// Whether or not to enable IPSec (ESP) encryption for Pod traffic across Nodes. Antrea uses Preshared Key (PSK) for IKE
 	// authentication. When IPSec tunnel is enabled, the PSK value must be passed to Antrea Agent
 	// through an environment variable: ANTREA_IPSEC_PSK.
 	// Defaults to false.

--- a/cmd/antrea-agent/options.go
+++ b/cmd/antrea-agent/options.go
@@ -116,9 +116,6 @@ func (o *Options) validate(args []string) error {
 		o.config.TunnelType != ovsconfig.GRETunnel && o.config.TunnelType != ovsconfig.STTTunnel {
 		return fmt.Errorf("tunnel type %s is invalid", o.config.TunnelType)
 	}
-	if o.config.EnableIPSecTunnel && o.config.TunnelType != ovsconfig.GRETunnel {
-		return fmt.Errorf("IPSec encyption is supported only for GRE tunnel")
-	}
 	if o.config.OVSDatapathType != string(ovsconfig.OVSDatapathSystem) && o.config.OVSDatapathType != string(ovsconfig.OVSDatapathNetdev) {
 		return fmt.Errorf("OVS datapath type %s is not supported", o.config.OVSDatapathType)
 	}

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -331,7 +331,7 @@ the [Antrea IPsec deployment yaml](/build/yamls/antrea-ipsec.yml), which creates
 a Kubernetes Secret to save the PSK value and populates it to the
 `ANTREA_IPSEC_PSK` environment variable of the Antrea Agent container.
 
-When IPsec is enabled, Antrea Agent will create a separate GRE tunnel port on
+When IPsec is enabled, Antrea Agent will create a separate tunnel port on
 the OVS bridge for each remote Node, and write the PSK string and the remote
 Node IP address to two OVS interface options of the tunnel interface. Then
 `ovs-monitor-ipsec` can detect the tunnel and create IPsec Security Policies

--- a/docs/ipsec-tunnel.md
+++ b/docs/ipsec-tunnel.md
@@ -1,8 +1,8 @@
 # IPsec Encryption of Tunnel Traffic with Antrea
 
-Antrea supports encrypting tunnel traffic across Nodes with IPsec ESP. At this
-moment, IPsec encyption works only for GRE tunnel (but not Geneve, VXLAN, and
-STT tunnel types).
+Antrea supports encrypting tunnel traffic across Nodes with IPsec ESP.
+IPsec encyption works for all tunnel types supported by OVS including Geneve,
+GRE, VXLAN, and STT tunnel.
 
 ## Prerequisites
 
@@ -10,6 +10,10 @@ IPsec requires a set of Linux kernel modules. Check the required kernel modules
 listed in the [strongSwan documentation](https://wiki.strongswan.org/projects/strongswan/wiki/KernelModules).
 Make sure the required kernel modules are loaded on the Kubernetes Nodes before
 deploying Antrea with IPsec encyption enabled.
+
+If you want to enable IPsec with Geneve, please make sure [this commit](https://github.com/torvalds/linux/commit/34beb21594519ce64a55a498c2fe7d567bc1ca20)
+is included in the kernel. For Ubuntu 18.04, kernel version should be at least
+`4.15.0-128`. For Ubuntu 20.04, kernel version should be at least `5.4.70`.
 
 ## Installation
 


### PR DESCRIPTION
I was trying to enable IPSec with VxLAN tunnel, after verify the traffic in real cluster, it turns out Antrea can actually support all tunnel modes now without much code changes. 
I verified all tunnel modes with IPSec in a local Cluster, it all works fine now, so I remove the limitation on our docs and the check in the code.

resolves #2468 