### PR TITLE
allow job to skip when workflow is cancelled

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -470,7 +470,7 @@ jobs:
   artifact-cleanup:
     name: Delete uploaded images
     needs: [build-antrea-coverage-image, build-flow-aggregator-coverage-image, build-antrea-image, test-e2e-encap, test-e2e-encap-no-proxy, test-e2e-noencap, test-e2e-hybrid, test-e2e-encap-no-np, test-netpol-tmp, validate-prometheus-metrics-doc]
-    if: ${{ always() }}
+    if: ${{ always() &&  (needs.build-antrea-coverage-image.result == 'success' || needs.build-flow-aggregator-coverage-image.result == 'success' || needs.build-antrea-image.result == 'success') }}
     runs-on: [ubuntu-latest]
     steps:
     - name: Delete antrea-ubuntu-cov

--- a/.github/workflows/kind_upgrade.yml
+++ b/.github/workflows/kind_upgrade.yml
@@ -215,7 +215,7 @@ jobs:
   artifact-cleanup:
     name: Delete uploaded images
     needs: [build-antrea-image, from-N-1, from-N-2, compatible-N-1, compatible-N-2]
-    if: ${{ always() }}
+    if: ${{ always() && needs.build-antrea-image.result == 'success' }}
     runs-on: [ubuntu-latest]
     steps:
     - name: Delete antrea-ubuntu


### PR DESCRIPTION
we have an issue in github aciton today and I was trying to
cancel workflow so I can rerun it, but it turns out it's impossible
to cancel it when we set `if: ${{ always() }}` in the job level.
so refine the job condition.
here is a workflow I was trying to cancel: https://github.com/antrea-io/antrea/runs/3190321922?check_suite_focus=true

Signed-off-by: Lan Luo <luola@vmware.com>