### PR TITLE
Automated cherry pick of #2467: Use GroupMemberSet.Merge to reduce CPU usage and memory

### DIFF
--- a/pkg/agent/controller/networkpolicy/cache.go
+++ b/pkg/agent/controller/networkpolicy/cache.go
@@ -787,7 +787,7 @@ func (c *ruleCache) unionAddressGroups(groupNames []string) (v1beta.GroupMemberS
 			klog.V(2).Infof("AddressGroup %v was not found", groupName)
 			return nil, false
 		}
-		set = set.Union(curSet)
+		set.Merge(curSet)
 	}
 	return set, true
 }
@@ -807,7 +807,7 @@ func (c *ruleCache) unionAppliedToGroups(groupNames []string) (v1beta.GroupMembe
 			continue
 		}
 		anyExists = true
-		set = set.Union(curSet)
+		set.Merge(curSet)
 	}
 	return set, anyExists
 }

--- a/pkg/apis/controlplane/sets.go
+++ b/pkg/apis/controlplane/sets.go
@@ -118,6 +118,21 @@ func (s GroupMemberSet) Union(o GroupMemberSet) GroupMemberSet {
 	return result
 }
 
+// Merge merges the other set into the set.
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s1.Merge(s2) = {a1, a2, a3, a4, a5}
+// s1 = {a1, a2, a3, a4, a5}
+//
+// It should be used instead of s1.Union(s2) when constructing a new set is not required.
+func (s GroupMemberSet) Merge(o GroupMemberSet) GroupMemberSet {
+	for key, item := range o {
+		s[key] = item
+	}
+	return s
+}
+
 // IsSuperset returns true if and only if s1 is a superset of s2.
 func (s GroupMemberSet) IsSuperset(o GroupMemberSet) bool {
 	for key := range o {

--- a/pkg/apis/controlplane/v1beta1/sets.go
+++ b/pkg/apis/controlplane/v1beta1/sets.go
@@ -91,6 +91,21 @@ func (s GroupMemberPodSet) Union(o GroupMemberPodSet) GroupMemberPodSet {
 	return result
 }
 
+// Merge merges the other set into the set.
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s1.Merge(s2) = {a1, a2, a3, a4, a5}
+// s1 = {a1, a2, a3, a4, a5}
+//
+// It should be used instead of s1.Union(s2) when constructing a new set is not required.
+func (s GroupMemberSet) Merge(o GroupMemberSet) GroupMemberSet {
+	for key, item := range o {
+		s[key] = item
+	}
+	return s
+}
+
 // IsSuperset returns true if and only if s1 is a superset of s2.
 func (s GroupMemberPodSet) IsSuperset(o GroupMemberPodSet) bool {
 	for key := range o {

--- a/pkg/apis/controlplane/v1beta2/sets.go
+++ b/pkg/apis/controlplane/v1beta2/sets.go
@@ -118,6 +118,21 @@ func (s GroupMemberSet) Union(o GroupMemberSet) GroupMemberSet {
 	return result
 }
 
+// Merge merges the other set into the set.
+// For example:
+// s1 = {a1, a2, a3}
+// s2 = {a1, a2, a4, a5}
+// s1.Merge(s2) = {a1, a2, a3, a4, a5}
+// s1 = {a1, a2, a3, a4, a5}
+//
+// It should be used instead of s1.Union(s2) when constructing a new set is not required.
+func (s GroupMemberSet) Merge(o GroupMemberSet) GroupMemberSet {
+	for key, item := range o {
+		s[key] = item
+	}
+	return s
+}
+
 // IsSuperset returns true if and only if s1 is a superset of s2.
 func (s GroupMemberSet) IsSuperset(o GroupMemberSet) bool {
 	for key := range o {

--- a/pkg/controller/egress/store/egressgroup.go
+++ b/pkg/controller/egress/store/egressgroup.go
@@ -75,11 +75,11 @@ func (event *egressGroupEvent) ToWatchEvent(selectors *storage.Selectors, isInit
 		} else {
 			currMembers = controlplane.GroupMemberSet{}
 			for _, members := range event.CurrGroup.GroupMemberByNode {
-				currMembers = currMembers.Union(members)
+				currMembers.Merge(members)
 			}
 			prevMembers = controlplane.GroupMemberSet{}
 			for _, members := range event.PrevGroup.GroupMemberByNode {
-				prevMembers = prevMembers.Union(members)
+				prevMembers.Merge(members)
 			}
 		}
 		for _, member := range currMembers.Difference(prevMembers) {

--- a/pkg/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller.go
@@ -1129,7 +1129,7 @@ func (n *NetworkPolicyController) getClusterGroupMemberSet(group *antreatypes.Gr
 		childGroup, found, _ := n.internalGroupStore.Get(childName)
 		if found {
 			child := childGroup.(*antreatypes.Group)
-			groupMemberSet = groupMemberSet.Union(n.getMemberSetForGroupType(clusterGroupType, child.Name))
+			groupMemberSet.Merge(n.getMemberSetForGroupType(clusterGroupType, child.Name))
 		}
 	}
 	return groupMemberSet

--- a/pkg/controller/networkpolicy/store/appliedtogroup.go
+++ b/pkg/controller/networkpolicy/store/appliedtogroup.go
@@ -76,11 +76,11 @@ func (event *appliedToGroupEvent) ToWatchEvent(selectors *storage.Selectors, isI
 		} else {
 			currMembers = controlplane.GroupMemberSet{}
 			for _, members := range event.CurrGroup.GroupMemberByNode {
-				currMembers = currMembers.Union(members)
+				currMembers.Merge(members)
 			}
 			prevMembers = controlplane.GroupMemberSet{}
 			for _, members := range event.PrevGroup.GroupMemberByNode {
-				prevMembers = prevMembers.Union(members)
+				prevMembers.Merge(members)
 			}
 		}
 		for _, member := range currMembers.Difference(prevMembers) {


### PR DESCRIPTION
Cherry pick of #2467 on release-1.2.

#2467: Use GroupMemberSet.Merge to reduce CPU usage and memory

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.