### PR TITLE
Automated cherry pick of #2487: Fix test-upgrade-antrea.sh script so it can be used in

### DIFF
--- a/ci/kind/test-upgrade-antrea.sh
+++ b/ci/kind/test-upgrade-antrea.sh
@@ -34,7 +34,7 @@ provided.
                                         test from the latest bug fix release for *minor* version
                                         N-{COUNT}. N-1 designates the latest minor release. If this
                                         script is run from a release branch, it will only consider
-                                        releases which predate that relase branch.
+                                        releases which predate that release branch.
         --controller-only               Update antrea-controller only when upgrading.
         --help, -h                      Print this message and exit
 "


### PR DESCRIPTION
Cherry pick of #2487 on release-1.1.

#2487: Fix test-upgrade-antrea.sh script so it can be used in

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.