### PR TITLE
Use actions/setup-go@v2 in all workflows

### DIFF
--- a/.github/workflows/clair.yml
+++ b/.github/workflows/clair.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-go@v1
+    - uses: actions/setup-go@v2
       with:
         go-version: 1.15
     - name: Scan Antrea Docker image for vulnerabilities

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
 
     - name: Set up Go 1.15
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
         go-version: 1.15
 
@@ -47,7 +47,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Set up Go 1.15
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
         go-version: 1.15
     - name: Check-out code
@@ -61,7 +61,7 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
     - name: Set up Go 1.15
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
         go-version: 1.15
     - name: Check-out code
@@ -80,7 +80,7 @@ jobs:
     steps:
 
     - name: Set up Go 1.15
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
         go-version: 1.15
 
@@ -96,7 +96,7 @@ jobs:
     steps:
 
     - name: Set up Go 1.15
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
         go-version: 1.15
 
@@ -112,7 +112,7 @@ jobs:
     steps:
 
       - name: Set up Go 1.15
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
           go-version: 1.15
 
@@ -129,7 +129,7 @@ jobs:
     steps:
 
     - name: Set up Go 1.15
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
         go-version: 1.15
 
@@ -146,7 +146,7 @@ jobs:
     steps:
 
     - name: Set up Go 1.15
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
         go-version: 1.15
 
@@ -163,7 +163,7 @@ jobs:
     steps:
 
     - name: Set up Go 1.15
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
         go-version: 1.15
 
@@ -179,7 +179,7 @@ jobs:
     steps:
 
     - name: Set up Go 1.15
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
         go-version: 1.15
 

--- a/.github/workflows/golicense.yml
+++ b/.github/workflows/golicense.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
     - name: Set up Go 1.15
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v2
       with:
         go-version: 1.15
     - uses: actions/checkout@v2

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -74,7 +74,7 @@ jobs:
         sudo apt-get clean
         df -h
     - uses: actions/checkout@v2
-    - uses: actions/setup-go@v1
+    - uses: actions/setup-go@v2
       with:
         go-version: 1.15
     - name: Download Antrea image from previous job
@@ -139,7 +139,7 @@ jobs:
         sudo apt-get clean
         df -h
     - uses: actions/checkout@v2
-    - uses: actions/setup-go@v1
+    - uses: actions/setup-go@v2
       with:
         go-version: 1.15
     - name: Download Antrea image from previous job
@@ -202,7 +202,7 @@ jobs:
         sudo apt-get clean
         df -h
     - uses: actions/checkout@v2
-    - uses: actions/setup-go@v1
+    - uses: actions/setup-go@v2
       with:
         go-version: 1.15
     - name: Download Antrea image from previous job
@@ -265,7 +265,7 @@ jobs:
         sudo apt-get clean
         df -h
     - uses: actions/checkout@v2
-    - uses: actions/setup-go@v1
+    - uses: actions/setup-go@v2
       with:
         go-version: 1.15
     - name: Download Antrea image from previous job
@@ -331,7 +331,7 @@ jobs:
         sudo apt-get clean
         df -h
     - uses: actions/checkout@v2
-    - uses: actions/setup-go@v1
+    - uses: actions/setup-go@v2
       with:
         go-version: 1.15
     - name: Download Antrea image from previous job
@@ -413,7 +413,7 @@ jobs:
         sudo apt-get clean
         df -h
     - uses: actions/checkout@v2
-    - uses: actions/setup-go@v1
+    - uses: actions/setup-go@v2
       with:
         go-version: 1.15
     - name: Download Antrea image from previous job
@@ -445,7 +445,7 @@ jobs:
           sudo apt-get clean
           df -h
       - uses: actions/checkout@v2
-      - uses: actions/setup-go@v1
+      - uses: actions/setup-go@v2
         with:
           go-version: 1.15
       - name: Download Antrea image from previous job

--- a/.github/workflows/kind_upgrade.yml
+++ b/.github/workflows/kind_upgrade.yml
@@ -59,7 +59,7 @@ jobs:
         sudo apt-get clean
         df -h
     - uses: actions/checkout@v2
-    - uses: actions/setup-go@v1
+    - uses: actions/setup-go@v2
       with:
         go-version: 1.15
     - name: Download Antrea image from previous job
@@ -99,7 +99,7 @@ jobs:
         sudo apt-get clean
         df -h
     - uses: actions/checkout@v2
-    - uses: actions/setup-go@v1
+    - uses: actions/setup-go@v2
       with:
         go-version: 1.15
     - name: Download Antrea image from previous job
@@ -139,7 +139,7 @@ jobs:
           sudo apt-get clean
           df -h
       - uses: actions/checkout@v2
-      - uses: actions/setup-go@v1
+      - uses: actions/setup-go@v2
         with:
           go-version: 1.15
       - name: Download Antrea image from previous job
@@ -179,7 +179,7 @@ jobs:
           sudo apt-get clean
           df -h
       - uses: actions/checkout@v2
-      - uses: actions/setup-go@v1
+      - uses: actions/setup-go@v2
         with:
           go-version: 1.15
       - name: Download Antrea image from previous job


### PR DESCRIPTION
Closes #2514

Changes `actions/setup-go@v1` to `actions/setup-go@v2` in all workflows.