### PR TITLE
Log maintenance bug fix in the Flow Aggregator

### DIFF
--- a/cmd/flow-aggregator/flow-aggregator.go
+++ b/cmd/flow-aggregator/flow-aggregator.go
@@ -28,6 +28,7 @@ import (
 
 	"antrea.io/antrea/pkg/clusteridentity"
 	aggregator "antrea.io/antrea/pkg/flowaggregator"
+	"antrea.io/antrea/pkg/log"
 	"antrea.io/antrea/pkg/signals"
 )
 
@@ -76,6 +77,8 @@ func run(o *Options) error {
 	// cause the stopCh channel to be closed; if another signal is received before the program
 	// exits, we will force exit.
 	stopCh := signals.RegisterSignalHandlers()
+
+	log.StartLogFileNumberMonitor(stopCh)
 
 	k8sClient, err := createK8sClient()
 	if err != nil {


### PR DESCRIPTION
Periodic deletion of log files is missing in the Flow Aggreegator.
This logic periodically deletes extra files by making sure that max
number of files to be 4. This will ensure that no disk space is wasted
on the Kubernetes node running the Flow Aggregator.

This logic was missed initially when the logging in the Flow Aggregator is
added in the beginning adopting the same framework as the Antrea Agent and the
Antrea Controller.

Signed-off-by: Srikar Tati <stati@vmware.com>