### PR TITLE
Automate Go module dependency updates with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,6 @@ updates:
       update-types: ["version-update:semver-major", "version-update:semver-minor"] # ignore all except for patch updates
     - dependency-name: "github.com/vmware/go-ipfix"
     - dependency-name: "github.com/TomCodeLV/OVSDB-golang-lib"
-    - dependency-name: "github.com/contiv/libOpenflow"
-    - dependency-name: "github.com/ofnet/libOpenflow"
     - dependency-name: "github.com/vmware-tanzu/octant"
       update-types: ["version-update:semver-major", "version-update:semver-minor"] # ignore all except for patch updates
     - dependency-name: "github.com/Microsoft/hcsshim" # we use a replace directive for this dependency

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 5
+    ignore:
+    - dependency-name: "k8s.io/*"
+      update-types: ["version-update:semver-major", "version-update:semver-minor"] # ignore all except for patch updates
+    - dependency-name: "github.com/vmware/go-ipfix"
+    - dependency-name: "github.com/TomCodeLV/OVSDB-golang-lib"
+    - dependency-name: "github.com/contiv/libOpenflow"
+    - dependency-name: "github.com/ofnet/libOpenflow"
+    - dependency-name: "github.com/vmware-tanzu/octant"
+      update-types: ["version-update:semver-major", "version-update:semver-minor"] # ignore all except for patch updates
+    - dependency-name: "github.com/Microsoft/hcsshim" # we use a replace directive for this dependency
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the default location of `.github/workflows`
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 5

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,55 @@
+name: Dependabot Workflow
+
+# This workflow commits to Dependabot branches to ensure that the corresponding
+# PRs can satisfy all status checks.
+
+# WARNING: Combining pull_request_target workflow trigger with an explicit
+# checkout of an untrusted PR is a dangerous practice that may lead to
+# repository compromise.
+# See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+# To prevent repository compromise, the workflow jobs must only execute on PRs
+# openened by Dependabot and which are labelled correctly (note that these two
+# checks are somewhat redundant since labelling PRs require write access to the
+# repository).
+# An alternative is to use the "two workflow method" (see
+# https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/automating-dependabot-with-github-actions#handling-push-events),
+# but that is more tedious to configure and should not be required here.
+
+on:
+  pull_request_target:
+    types: [labeled, synchronize]
+
+permissions:
+  contents: write
+
+jobs:
+  # This job ensures that "go mod tidy" is run for all Go modules included in
+  # this repository.
+  tidy:
+    name: Go tidiness for Dependabot PR
+    # 'dependencies' and 'go' are the default labels used by Dependabot when updating Go dependencies
+    if: ${{ github.actor == 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'dependencies') && contains(github.event.pull_request.labels.*.name, 'go') }}
+    runs-on: [ubuntu-latest]
+    steps:
+    - name: Set up Go 1.15
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.15
+    - uses: actions/checkout@v2
+      with:
+        # Check out the pull request HEAD
+        ref: ${{ github.event.pull_request.head.sha }}
+    - name: Run go mod tidy
+      # the checks above (Github actor and PR labels) ensure that a malicious
+      # actor cannot open a PR with a modified "tidy" Makefile target and
+      # execute arbitrary code with write access and access to secrets. In
+      # particular, someone would need write access to the repo to add the
+      # "dependencies" and "go" labels.
+      run: make tidy
+    - name: Commit changes
+      uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        commit_message: Go tidiness for Dependabot PR
+        commit_options: '--no-verify'
+        file_pattern: '**/go.mod **/go.sum'
+        disable_globbing: false

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -8,10 +8,10 @@ name: Dependabot Workflow
 # repository compromise.
 # See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
 # To prevent repository compromise, the workflow jobs must only execute on PRs
-# openened by Dependabot and which are labelled correctly (note that these two
+# opened by Dependabot and which are labelled correctly (note that these two
 # checks are somewhat redundant since labelling PRs require write access to the
 # repository).
-# An alternative is to use the "two workflow method" (see
+# An alternative is to use the "two-workflow method" (see
 # https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/automating-dependabot-with-github-actions#handling-push-events),
 # but that is more tedious to configure and should not be required here.
 


### PR DESCRIPTION
We enable Dependabot, which will automatically open PRs to update
dependencies (mainly go modules, but also Github actions). Some
troublesome dependencies are explicitly ignored and for some
dependencies (k8s.io modules), we only consider patch updates.

To ensure that the PR tidiness check will succeed for Dependabot PRs, we
add a new workflow which will run "make tidy" when Dependabot opens a PR
and which will commit the resulting changes to the source branch. While
Dependabot does run "go mod tidy" automatically (currently using Go
1.16), that would not be sufficient for updating plugins/octant/go.sum.

The workflow uses pull_request_target as a trigger. This can lead to
security vulnerabilities when checking-out arbitrary code. Therefore, we
ensure that the job only runs for Dependabot PRs, by checking the actor
and PR labels.

Fixes #2453

Signed-off-by: Antonin Bas <abas@vmware.com>