### PR TITLE
Automated cherry pick of #2522: Log maintenance bug fix in the Flow Aggregator

### DIFF
--- a/cmd/flow-aggregator/flow-aggregator.go
+++ b/cmd/flow-aggregator/flow-aggregator.go
@@ -28,6 +28,7 @@ import (
 
 	"antrea.io/antrea/pkg/clusteridentity"
 	aggregator "antrea.io/antrea/pkg/flowaggregator"
+	"antrea.io/antrea/pkg/log"
 	"antrea.io/antrea/pkg/signals"
 )
 
@@ -76,6 +77,8 @@ func run(o *Options) error {
 	// cause the stopCh channel to be closed; if another signal is received before the program
 	// exits, we will force exit.
 	stopCh := signals.RegisterSignalHandlers()
+
+	log.StartLogFileNumberMonitor(stopCh)
 
 	k8sClient, err := createK8sClient()
 	if err != nil {


### PR DESCRIPTION
Cherry pick of #2522 on release-1.2.

#2522: Log maintenance bug fix in the Flow Aggregator

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.