### PR TITLE
Fix link in kubernetes-installers.md

### DIFF
--- a/docs/kubernetes-installers.md
+++ b/docs/kubernetes-installers.md
@@ -5,9 +5,9 @@
 The table below is not comprehensive. Antrea should work with most K8s
 installers and distributions. The table refers to specific version combinations
 which are known to work and have been tested, but support is not limited to that
-list. Each Antrea version supports [multiple K8s minor
-versions](versioning.md#supported-k8s-versions), and installers / distributions
-based on any one of these K8s versions should work with that Antrea version.
+list. Each Antrea version supports [multiple K8s minor versions](versioning.md#supported-k8s-versions),
+and installers / distributions based on any one of these K8s versions should
+work with that Antrea version.
 
 | Antrea Version | Installer / Distribution | Cloud Infra | Node Info | Node Size | Conformance Results | Comments |
 |-|-|-|-|-|-|-|


### PR DESCRIPTION
Somehow the line wrapping is breaking the HTML rendering by
Redcarpet. This is strange since I don't think I have noticed this issue
with other links. Since we are switching to a different stack for the
antrea.io website, I just want to fix the issue, without doing too much
digging.

Fixes #2518

Signed-off-by: Antonin Bas <abas@vmware.com>