### PR TITLE
Improve concurrency of NetworkPolicy e2e tests

### DIFF
--- a/test/e2e/flowaggregator_test.go
+++ b/test/e2e/flowaggregator_test.go
@@ -793,7 +793,7 @@ func getRecordsFromOutput(output string) []string {
 func deployK8sNetworkPolicies(t *testing.T, data *TestData, srcPod, dstPod string) (np1 *networkingv1.NetworkPolicy, np2 *networkingv1.NetworkPolicy) {
 	// Add K8s NetworkPolicy between two iperf Pods.
 	var err error
-	np1, err = data.createNetworkPolicy(ingressAllowNetworkPolicyName, &networkingv1.NetworkPolicySpec{
+	np1, err = data.createNetworkPolicy(testNamespace, ingressAllowNetworkPolicyName, &networkingv1.NetworkPolicySpec{
 		PodSelector: metav1.LabelSelector{},
 		PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
 		Ingress: []networkingv1.NetworkPolicyIngressRule{{
@@ -809,7 +809,7 @@ func deployK8sNetworkPolicies(t *testing.T, data *TestData, srcPod, dstPod strin
 	if err != nil {
 		t.Errorf("Error when creating Network Policy: %v", err)
 	}
-	np2, err = data.createNetworkPolicy(egressAllowNetworkPolicyName, &networkingv1.NetworkPolicySpec{
+	np2, err = data.createNetworkPolicy(testNamespace, egressAllowNetworkPolicyName, &networkingv1.NetworkPolicySpec{
 		PodSelector: metav1.LabelSelector{},
 		PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
 		Egress: []networkingv1.NetworkPolicyEgressRule{{
@@ -916,7 +916,7 @@ func deployDenyAntreaNetworkPolicies(t *testing.T, data *TestData, srcPod, podRe
 }
 
 func deployDenyNetworkPolicies(t *testing.T, data *TestData, pod1, pod2 string) (np1 *networkingv1.NetworkPolicy, np2 *networkingv1.NetworkPolicy) {
-	np1, err := data.createNetworkPolicy(ingressDenyNPName, &networkingv1.NetworkPolicySpec{
+	np1, err := data.createNetworkPolicy(testNamespace, ingressDenyNPName, &networkingv1.NetworkPolicySpec{
 		PodSelector: metav1.LabelSelector{
 			MatchLabels: map[string]string{
 				"antrea-e2e": pod1,
@@ -928,7 +928,7 @@ func deployDenyNetworkPolicies(t *testing.T, data *TestData, pod1, pod2 string) 
 	if err != nil {
 		t.Errorf("Error when creating Network Policy: %v", err)
 	}
-	np2, err = data.createNetworkPolicy(egressDenyNPName, &networkingv1.NetworkPolicySpec{
+	np2, err = data.createNetworkPolicy(testNamespace, egressDenyNPName, &networkingv1.NetworkPolicySpec{
 		PodSelector: metav1.LabelSelector{
 			MatchLabels: map[string]string{
 				"antrea-e2e": pod2,

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -1427,7 +1427,7 @@ func (data *TestData) deleteServiceAndWait(timeout time.Duration, name string) e
 }
 
 // createNetworkPolicy creates a network policy with spec.
-func (data *TestData) createNetworkPolicy(name string, spec *networkingv1.NetworkPolicySpec) (*networkingv1.NetworkPolicy, error) {
+func (data *TestData) createNetworkPolicy(namespace, name string, spec *networkingv1.NetworkPolicySpec) (*networkingv1.NetworkPolicy, error) {
 	policy := &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
@@ -1437,7 +1437,7 @@ func (data *TestData) createNetworkPolicy(name string, spec *networkingv1.Networ
 		},
 		Spec: *spec,
 	}
-	return data.clientset.NetworkingV1().NetworkPolicies(testNamespace).Create(context.TODO(), policy, metav1.CreateOptions{})
+	return data.clientset.NetworkingV1().NetworkPolicies(namespace).Create(context.TODO(), policy, metav1.CreateOptions{})
 }
 
 // deleteNetworkpolicy deletes the network policy.

--- a/test/e2e/traceflow_test.go
+++ b/test/e2e/traceflow_test.go
@@ -2042,7 +2042,7 @@ func (data *TestData) createNPDenyAllIngress(key string, value string, name stri
 		},
 		PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
 	}
-	return data.createNetworkPolicy(name, spec)
+	return data.createNetworkPolicy(testNamespace, name, spec)
 }
 
 // createNPAllowAllEgress creates a NetworkPolicy that allows all egress traffic.
@@ -2054,7 +2054,7 @@ func (data *TestData) createNPAllowAllEgress(name string) (*networkingv1.Network
 		},
 		PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
 	}
-	return data.createNetworkPolicy(name, spec)
+	return data.createNetworkPolicy(testNamespace, name, spec)
 }
 
 // waitForNetworkpolicyRealized waits for the NetworkPolicy to be realized by the antrea-agent Pod.

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -74,7 +74,7 @@ func TestUpgrade(t *testing.T) {
 	// We test NetworkPolicy with 2 scenarios:
 	// 1. The NetworkPolicy is created before upgrading controller.
 	// 2. The NetworkPolicy is created after upgrading controller.
-	checkFn, cleanupFn := data.setupDifferentNamedPorts(t)
+	checkFn, cleanupFn := data.setupDifferentNamedPorts(t, "test-upgrade-before-upgrade")
 	defer cleanupFn()
 	checkFn()
 
@@ -110,7 +110,7 @@ func TestUpgrade(t *testing.T) {
 	checkFn()
 	// Verify that the NetworkPolicy created after upgrading works.
 	// random resource names are used in the test so it's OK to call setupDifferentNamedPorts the second time.
-	checkFn, cleanupFn = data.setupDifferentNamedPorts(t)
+	checkFn, cleanupFn = data.setupDifferentNamedPorts(t, "test-upgrade-after-upgrade")
 	defer cleanupFn()
 	checkFn()
 


### PR DESCRIPTION
This patches makes NetworkPolicy tests run in their own Namespaces to
avoid interference and makes them run in parallel.