### PR TITLE
For Windows, the hostname in kube-apiserver is in lowercase.

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -63,6 +63,10 @@ const informerDefaultResync = 12 * time.Hour
 // run starts Antrea agent with the given options and waits for termination signal.
 func run(o *Options) error {
 	klog.Infof("Starting Antrea agent (version %s)", version.GetFullVersion())
+	err := initForOS(o)
+	if err != nil {
+		return fmt.Errorf("error with OS specific initializations: %v", err)
+	}
 	// Create K8s Clientset, CRD Clientset and SharedInformerFactory for the given config.
 	k8sClient, _, crdClient, _, err := k8s.CreateClients(o.config.ClientConnection, o.config.KubeAPIServerOverride)
 	if err != nil {

--- a/cmd/antrea-agent/agent_linux.go
+++ b/cmd/antrea-agent/agent_linux.go
@@ -1,0 +1,19 @@
+// Copyright 2019 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+func initForOS(o *Options) error {
+	return nil
+}

--- a/cmd/antrea-agent/agent_windows.go
+++ b/cmd/antrea-agent/agent_windows.go
@@ -1,0 +1,119 @@
+// +build windows
+
+// Copyright 2019 Antrea Authors
+// Copyright 2018 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"time"
+
+	"k8s.io/apiserver/pkg/server"
+	"k8s.io/klog/v2"
+
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/svc"
+)
+
+const (
+	serviceName = "antrea-agent"
+)
+
+var (
+	service *handler
+)
+
+type handler struct {
+	tosvc   chan bool
+	fromsvc chan error
+}
+
+func initForOS(o *Options) error {
+	if !(o.windowsService) {
+		return nil
+	}
+
+	h := &handler{
+		tosvc:   make(chan bool),
+		fromsvc: make(chan error),
+	}
+
+	service = h
+	var err error
+	go func() {
+		err = svc.Run(serviceName, h)
+		h.fromsvc <- err
+	}()
+
+	// Wait for the first signal from the service handler.
+	err = <-h.fromsvc
+	if err != nil {
+		return err
+	}
+	klog.Infof("Running %s as a Windows service!", serviceName)
+	return nil
+}
+
+func (h *handler) Execute(_ []string, r <-chan svc.ChangeRequest, s chan<- svc.Status) (bool, uint32) {
+	s <- svc.Status{State: svc.StartPending, Accepts: 0}
+	// Unblock initService()
+	h.fromsvc <- nil
+
+	s <- svc.Status{State: svc.Running, Accepts: svc.AcceptStop | svc.AcceptShutdown | svc.Accepted(windows.SERVICE_ACCEPT_PARAMCHANGE)}
+	klog.Infof("Service running")
+Loop:
+	for {
+		select {
+		case <-h.tosvc:
+			break Loop
+		case c := <-r:
+			switch c.Cmd {
+			case svc.Cmd(windows.SERVICE_CONTROL_PARAMCHANGE):
+				s <- c.CurrentStatus
+			case svc.Interrogate:
+				s <- c.CurrentStatus
+			case svc.Stop, svc.Shutdown:
+				klog.Infof("Service stopping")
+				// We need to translate this request into a signal that can be handled by the signal handler
+				// handling shutdowns normally (currently apiserver/pkg/server/signal.go).
+				// If we do not do this, our main threads won't be notified of the upcoming shutdown.
+				// Since Windows services do not use any console, we cannot simply generate a CTRL_BREAK_EVENT
+				// but need a dedicated notification mechanism.
+				graceful := server.RequestShutdown()
+
+				// Free up the control handler and let us terminate as gracefully as possible.
+				// If that takes too long, the service controller will kill the remaining threads.
+				// As per https://docs.microsoft.com/en-us/windows/desktop/services/service-control-handler-function
+				s <- svc.Status{State: svc.StopPending}
+
+				// If we cannot exit gracefully, we really only can exit our process, so atleast the
+				// service manager will think that we gracefully exited. At the time of writing this comment this is
+				// needed for applications that do not use signals (e.g. kube-proxy)
+				if !graceful {
+					go func() {
+						// Ensure the SCM was notified (The operation above (send to s) was received and communicated to the
+						// service control manager - so it doesn't look like the service crashes)
+						time.Sleep(1 * time.Second)
+						os.Exit(0)
+					}()
+				}
+				break Loop
+			}
+		}
+	}
+
+	return false, 0
+}

--- a/cmd/antrea-agent/options.go
+++ b/cmd/antrea-agent/options.go
@@ -62,6 +62,8 @@ type Options struct {
 	activeFlowTimeout time.Duration
 	// Idle flow timeout to export records of inactive flows
 	idleFlowTimeout time.Duration
+	// Run the daemon as a Windows service (noop for Linux)
+	windowsService bool
 }
 
 func newOptions() *Options {
@@ -75,6 +77,7 @@ func newOptions() *Options {
 // addFlags adds flags to fs and binds them to options.
 func (o *Options) addFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.configFile, "config", o.configFile, "The path to the configuration file")
+	fs.BoolVar(&o.windowsService, "service", false, "Run the daemon as a windows service")
 }
 
 // complete completes all the required options.

--- a/pkg/util/env/env.go
+++ b/pkg/util/env/env.go
@@ -16,7 +16,9 @@ package env
 
 import (
 	"os"
+	"runtime"
 	"strconv"
+	"strings"
 
 	"k8s.io/klog/v2"
 )
@@ -47,6 +49,10 @@ func GetNodeName() (string, error) {
 	if err != nil {
 		klog.Errorf("Failed to get local hostname: %v", err)
 		return "", err
+	}
+	// For Windows, the node name registered with kube-apiserver is lowercase.
+	if runtime.GOOS == "windows" {
+		return strings.ToLower(nodeName), nil
 	}
 	return nodeName, nil
 }


### PR DESCRIPTION
Currently, the startup scripts force an environment variable
to have lowercase node name. This gets complex once we add
support to native windows services as they don't get
env variables from local shell.

Signed-off-by: Gurucharan Shetty <gurushetty@google.com>