### PR TITLE
Fix Ansible playbooks (Vagrant test infra) for K8s 1.22

### DIFF
--- a/test/e2e/infra/vagrant/playbook/roles/common/tasks/docker.yml
+++ b/test/e2e/infra/vagrant/playbook/roles/common/tasks/docker.yml
@@ -46,3 +46,16 @@
 # Install docker-py so that docker images can be pulled
 - pip:
     name: docker-py
+
+- name: Create Docker daemon configuration from template
+  template:
+    src: templates/docker.json.j2
+    dest: /etc/docker/daemon.json
+  register: docker_config
+
+- name: Restart Docker
+  service:
+    name: docker
+    daemon_reload: yes
+    state: restarted
+  when: docker_config.changed

--- a/test/e2e/infra/vagrant/playbook/roles/common/templates/docker.json.j2
+++ b/test/e2e/infra/vagrant/playbook/roles/common/templates/docker.json.j2
@@ -1,0 +1,8 @@
+{
+  "exec-opts": ["native.cgroupdriver=systemd"],
+  "log-driver": "json-file",
+  "log-opts": {
+    "max-size": "100m"
+  },
+  "storage-driver": "overlay2"
+}


### PR DESCRIPTION
In the playbooks, we always use the latest available version of K8s. K8s
v1.22 was just released, and one of the included changes was preventing
the Vagrant-based cluster from being provisioned successfully.

See https://github.com/kubernetes/kubernetes/pull/99647

This change requires us to configure the systemd cgroup explicitly for
Docker, or kubelet will refuse to run.

Signed-off-by: Antonin Bas <abas@vmware.com>