### PR TITLE
Configure path MTU as interface MTU in Flow Aggregator

### DIFF
--- a/pkg/flowaggregator/flowaggregator.go
+++ b/pkg/flowaggregator/flowaggregator.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
+	"antrea.io/antrea/pkg/agent/util"
 	"antrea.io/antrea/pkg/ipfix"
 )
 
@@ -336,9 +337,13 @@ func (fa *flowAggregator) initExportingProcess() error {
 			CollectorProtocol:   fa.externalFlowCollectorProto,
 			ObservationDomainID: fa.observationDomainID,
 			TempRefTimeout:      1800,
-			PathMTU:             0,
 			IsEncrypted:         false,
 		}
+		_, podInterface, err := util.GetIPNetDeviceByName("eth0")
+		if err != nil {
+			return err
+		}
+		expInput.PathMTU = podInterface.MTU
 	}
 	ep, err := ipfix.NewIPFIXExportingProcess(expInput)
 	if err != nil {


### PR DESCRIPTION
For UDP transport in the Flow Aggregator, currently max MTU is used as default MTU of 512B.
Changing it to interface MTU.