### PR TITLE
Automated cherry pick of #2486: fix tunnel interface name issue

### DIFF
--- a/pkg/agent/controller/noderoute/node_route_controller.go
+++ b/pkg/agent/controller/noderoute/node_route_controller.go
@@ -222,10 +222,8 @@ func (c *Controller) removeStaleTunnelPorts() error {
 			}
 
 			ifaceID := util.GenerateNodeTunnelInterfaceKey(node.Name)
-			validConfiguration := interfaceConfig.PSK == c.networkConfig.IPSecPSK &&
-				interfaceConfig.RemoteIP.Equal(peerNodeIP) &&
-				interfaceConfig.TunnelInterfaceConfig.Type == c.networkConfig.TunnelType
-			if validConfiguration {
+			ifaceName := util.GenerateNodeTunnelInterfaceName(node.Name)
+			if c.compareInterfaceConfig(interfaceConfig, peerNodeIP, ifaceName) {
 				desiredInterfaces[ifaceID] = true
 			}
 		}
@@ -256,6 +254,14 @@ func (c *Controller) removeStaleTunnelPorts() error {
 	}
 
 	return nil
+}
+
+func (c *Controller) compareInterfaceConfig(interfaceConfig *interfacestore.InterfaceConfig,
+	peerNodeIP net.IP, interfaceName string) bool {
+	return interfaceConfig.InterfaceName == interfaceName &&
+		interfaceConfig.PSK == c.networkConfig.IPSecPSK &&
+		interfaceConfig.RemoteIP.Equal(peerNodeIP) &&
+		interfaceConfig.TunnelInterfaceConfig.Type == c.networkConfig.TunnelType
 }
 
 func (c *Controller) reconcile() error {
@@ -529,16 +535,20 @@ func getPodCIDRsOnNode(node *corev1.Node) []string {
 // createIPSecTunnelPort creates an IPSec tunnel port for the remote Node if the
 // tunnel does not exist, and returns the ofport number.
 func (c *Controller) createIPSecTunnelPort(nodeName string, nodeIP net.IP) (int32, error) {
+	portName := util.GenerateNodeTunnelInterfaceName(nodeName)
 	interfaceConfig, ok := c.interfaceStore.GetNodeTunnelInterface(nodeName)
+	// check if Node IP, PSK, or tunnel type changes. This can
+	// happen if removeStaleTunnelPorts fails to remove a "stale"
+	// tunnel port for which the configuration has changed, return error to requeue the Node.
 	if ok {
-		// TODO: check if Node IP, PSK, or tunnel type changes. This can
-		// happen if removeStaleTunnelPorts fails to remove a "stale"
-		// tunnel port for which the configuration has changed.
+		if !c.compareInterfaceConfig(interfaceConfig, nodeIP, portName) {
+			return 0, fmt.Errorf("IPSec tunnel interface config doesn't match cached one, stale IPSec tunnel port %s", interfaceConfig.InterfaceName)
+		}
+		klog.V(2).InfoS("Found cached IPSec tunnel interface", "interfaceName", interfaceConfig.InterfaceName, "port", interfaceConfig.OFPort, "nodeName", nodeName)
 		if interfaceConfig.OFPort != 0 {
 			return interfaceConfig.OFPort, nil
 		}
 	} else {
-		portName := util.GenerateNodeTunnelInterfaceName(nodeName)
 		ovsExternalIDs := map[string]interface{}{ovsExternalIDNodeName: nodeName}
 		portUUID, err := c.ovsBridgeClient.CreateTunnelPortExt(
 			portName,

--- a/pkg/agent/util/net.go
+++ b/pkg/agent/util/net.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"strings"
 )
 
 const (
@@ -38,10 +39,15 @@ func generateInterfaceName(key string, name string, useHead bool) string {
 	interfaceKey := hex.EncodeToString(hash.Sum(nil))
 	prefix := name
 	if len(name) > interfacePrefixLength {
+		// We use Node/Pod name to generate the interface name,
+		// valid chars for Node/Pod name are ASCII letters from a to z,
+		// the digits from 0 to 9, and the hyphen (-).
+		// Hyphen (-) is the only char which will impact command-line interpretation
+		// if the interface name starts with one, so we remove it here.
 		if useHead {
-			prefix = name[:interfacePrefixLength]
+			prefix = strings.TrimLeft(name[:interfacePrefixLength], "-")
 		} else {
-			prefix = name[len(name)-interfacePrefixLength:]
+			prefix = strings.TrimLeft(name[len(name)-interfacePrefixLength:], "-")
 		}
 	}
 	return fmt.Sprintf("%s-%s", prefix, interfaceKey[:interfaceKeyLength])


### PR DESCRIPTION
Cherry pick of #2486 on release-1.2.

#2486: fix tunnel interface name issue

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.