### PR TITLE
remove namespace creation

### DIFF
--- a/multicluster/Makefile
+++ b/multicluster/Makefile
@@ -91,8 +91,7 @@ CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 controller-gen: ## Download controller-gen locally if necessary.
 	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1)
 
-#KUSTOMIZE = $(shell pwd)/bin/kustomize
-KUSTOMIZE = $(shell which kustomize)
+KUSTOMIZE = $(shell pwd)/bin/kustomize
 
 kustomize: ## Download kustomize locally if necessary.
 	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.8.7)

--- a/multicluster/config/crd/bases/multicluster.crd.antrea.io_clustersets.yaml
+++ b/multicluster/config/crd/bases/multicluster.crd.antrea.io_clustersets.yaml
@@ -19,7 +19,7 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ClusterSet is the Schema for the clustersets API
+        description: ClusterSet is the Schema for the clustersets API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/multicluster/config/crd/bases/multicluster.crd.antrea.io_resourceexports.yaml
+++ b/multicluster/config/crd/bases/multicluster.crd.antrea.io_resourceexports.yaml
@@ -19,7 +19,7 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ResourceExport is the Schema for the resourceexports API
+        description: ResourceExport is the Schema for the resourceexports API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -34,7 +34,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: ResourceExportSpec defines the desired state of ResourceExport
+            description: ResourceExportSpec defines the desired state of ResourceExport.
             properties:
               clusterID:
                 description: ClusterID specifies the member cluster this resource
@@ -654,28 +654,28 @@ spec:
                 type: object
             type: object
           status:
-            description: ResourceExportStatus defines the observed state of ResourceExport
+            description: ResourceExportStatus defines the observed state of ResourceExport.
             properties:
               conditions:
                 items:
                   description: ResourceExportCondition indicates the readiness condition
-                    of the ResourceExport
+                    of the ResourceExport.
                   properties:
                     lastTransitionTime:
                       description: Last time the condition transited from one status
-                        to another
+                        to another.
                       format: date-time
                       type: string
                     message:
                       description: A human readable message indicating details about
-                        the transition
+                        the transition.
                       type: string
                     reason:
                       description: Unique, one-word, CamelCase reason for the condition's
                         last transition.
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown
+                      description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
                       type: string

--- a/multicluster/config/crd/bases/multicluster.crd.antrea.io_resourceimports.yaml
+++ b/multicluster/config/crd/bases/multicluster.crd.antrea.io_resourceimports.yaml
@@ -19,7 +19,7 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ResourceImport is the Schema for the resourceimports API
+        description: ResourceImport is the Schema for the resourceimports API.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -34,7 +34,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: ResourceImportSpec defines the desired state of ResourceImport
+            description: ResourceImportSpec defines the desired state of ResourceImport.
             properties:
               clusterID:
                 description: ClusterIDs specifies the member clusters this resource
@@ -433,12 +433,12 @@ spec:
                 type: object
             type: object
           status:
-            description: ResourceImportStatus defines the observed state of ResourceImport
+            description: ResourceImportStatus defines the observed state of ResourceImport.
             properties:
               clusterStatuses:
                 items:
                   description: ResourceImportClusterStatus indicates the readiness
-                    status of the ResourceImport in clusters
+                    status of the ResourceImport in clusters.
                   properties:
                     clusterID:
                       description: ClusterID is the unique identifier of this cluster.
@@ -446,16 +446,16 @@ spec:
                     conditions:
                       items:
                         description: ResourceImportCondition indicates the condition
-                          of the ResourceImport in a cluster
+                          of the ResourceImport in a cluster.
                         properties:
                           lastTransitionTime:
                             description: Last time the condition transited from one
-                              status to another
+                              status to another.
                             format: date-time
                             type: string
                           message:
                             description: A human readable message indicating details
-                              about the transition
+                              about the transition.
                             type: string
                           reason:
                             description: Unique, one-word, CamelCase reason for the
@@ -463,7 +463,7 @@ spec:
                             type: string
                           status:
                             description: Status of the condition, one of True, False,
-                              Unknown
+                              Unknown.
                             type: string
                           type:
                             type: string

--- a/multicluster/config/default/kustomization.yaml
+++ b/multicluster/config/default/kustomization.yaml
@@ -9,8 +9,8 @@ namespace: kube-system
 namePrefix: antrea-multicluster-
 
 # Labels to add to all resources and selectors.
-#commonLabels:
-#  someName: someValue
+commonLabels:
+  app: antrea
 
 bases:
 - ../crd

--- a/multicluster/config/manager/manager.yaml
+++ b/multicluster/config/manager/manager.yaml
@@ -1,10 +1,3 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    control-plane: controller-manager
-  name: system
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/multicluster/config/multi-cluster.yaml
+++ b/multicluster/config/multi-cluster.yaml
@@ -1,10 +1,3 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    control-plane: controller-manager
-  name: kube-system
----
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:


### PR DESCRIPTION
1. remove namespace in config/manager/manager.yaml, so we won't have
a `kube-system` namespace definition in multi-cluster.yaml
2. use `KUSTOMIZE = $(shell pwd)/bin/kustomize` in Makefile,
   otherwise,it will do nothing if KUSTOMIZE is empty by `shell which kustomize`
3. add a common label `app: antrea` for all resources
4. other changes are auto-generated by `make manifests`

Signed-off-by: Lan Luo <luola@vmware.com>