### PR TITLE
[Bug Fix] Change e2e test multi-port probe logic

### DIFF
--- a/test/e2e/antreapolicy_test.go
+++ b/test/e2e/antreapolicy_test.go
@@ -126,7 +126,7 @@ type TestStep struct {
 	Reachability      *Reachability
 	Policies          []metav1.Object
 	ServicesAndGroups []metav1.Object
-	Port              []int32
+	Ports             []int32
 	Protocol          v1.Protocol
 	Duration          time.Duration
 	CustomProbes      []*CustomProbe
@@ -1801,7 +1801,7 @@ func testACNPPortRange(t *testing.T) {
 	reachability.Expect(Pod("z/a"), Pod("z/c"), Dropped)
 	testSteps := []*TestStep{
 		{
-			fmt.Sprintf("ACNP Drop Port 8080:8085"),
+			fmt.Sprintf("ACNP Drop Ports 8080:8085"),
 			reachability,
 			[]metav1.Object{builder.Get()},
 			nil,
@@ -1896,7 +1896,7 @@ func testANPPortRange(t *testing.T) {
 
 	var testSteps []*TestStep
 	testSteps = append(testSteps, &TestStep{
-		fmt.Sprintf("ANP Drop Port 8080:8085"),
+		fmt.Sprintf("ANP Drop Ports 8080:8085"),
 		reachability,
 		[]metav1.Object{builder.Get()},
 		nil,
@@ -2050,7 +2050,7 @@ func testAuditLoggingBasic(t *testing.T, data *TestData) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			k8sUtils.Probe(ns1, pod1, ns2, pod2, []int32{p80}, v1.ProtocolTCP)
+			k8sUtils.Probe(ns1, pod1, ns2, pod2, p80, v1.ProtocolTCP)
 		}()
 	}
 	oneProbe("x", "a", "z", "a")
@@ -2440,7 +2440,7 @@ func executeTestsWithData(t *testing.T, testList []*TestCase, data *TestData) {
 			reachability := step.Reachability
 			if reachability != nil {
 				start := time.Now()
-				k8sUtils.Validate(allPods, reachability, step.Port, step.Protocol)
+				k8sUtils.Validate(allPods, reachability, step.Ports, step.Protocol)
 				step.Duration = time.Now().Sub(start)
 
 				_, wrong, _ := step.Reachability.Summary()
@@ -2472,7 +2472,7 @@ func doProbe(t *testing.T, data *TestData, p *CustomProbe, protocol v1.Protocol)
 	_, _, dstPodCleanupFunc := createAndWaitForPodWithLabels(t, data, data.createServerPodWithLabels, p.DestPod.Pod.PodName(), p.DestPod.Pod.Namespace(), p.Port, p.DestPod.Labels)
 	defer dstPodCleanupFunc()
 	log.Tracef("Probing: %s -> %s", p.SourcePod.Pod.PodName(), p.DestPod.Pod.PodName())
-	connectivity, err := k8sUtils.Probe(p.SourcePod.Pod.Namespace(), p.SourcePod.Pod.PodName(), p.DestPod.Pod.Namespace(), p.DestPod.Pod.PodName(), []int32{p.Port}, protocol)
+	connectivity, err := k8sUtils.Probe(p.SourcePod.Pod.Namespace(), p.SourcePod.Pod.PodName(), p.DestPod.Pod.Namespace(), p.DestPod.Pod.PodName(), p.Port, protocol)
 	if err != nil {
 		t.Errorf("failure -- could not complete probe: %v", err)
 	}
@@ -2622,7 +2622,7 @@ func printResults() {
 				testFailed = true
 			}
 			fmt.Printf("\tStep %s on port %d, duration %d seconds, result: %s\n",
-				step.Name, step.Port, int(step.Duration.Seconds()), result)
+				step.Name, step.Ports, int(step.Duration.Seconds()), result)
 			if wrong != 0 {
 				fmt.Printf("\n%s\n", comparison.PrettyPrint("\t\t"))
 			}

--- a/test/e2e/k8s_util.go
+++ b/test/e2e/k8s_util.go
@@ -84,9 +84,11 @@ func (k *KubernetesUtils) GetPodsByLabel(ns string, key string, val string) ([]v
 	return v1PodList, nil
 }
 
-// Probe execs into a Pod and checks its connectivity to another Pod. Of course it assumes
-// that the target Pod is serving on input ports, and also that agnhost is installed.
-func (k *KubernetesUtils) Probe(ns1, pod1, ns2, pod2 string, ports []int32, protocol v1.Protocol) (PodConnectivityMark, error) {
+// Probe execs into a Pod and checks its connectivity to another Pod. Of course it
+// assumes that the target Pod is serving on the input port, and also that agnhost
+// is installed. The connectivity from source Pod to all IPs of the target Pod
+// should be consistent. Otherwise, Error PodConnectivityMark will be returned.
+func (k *KubernetesUtils) Probe(ns1, pod1, ns2, pod2 string, port int32, protocol v1.Protocol) (PodConnectivityMark, error) {
 	fromPods, err := k.GetPodsByLabel(ns1, "pod", pod1)
 	if err != nil {
 		return Error, fmt.Errorf("unable to get Pods from Namespace %s: %v", ns1, err)
@@ -113,7 +115,6 @@ func (k *KubernetesUtils) Probe(ns1, pod1, ns2, pod2 string, ports []int32, prot
 		if strings.Contains(toIP, ":") {
 			toIP = fmt.Sprintf("[%s]", toIP)
 		}
-
 		// There seems to be an issue when running Antrea in Kind where tunnel traffic is dropped at
 		// first. This leads to the first test being run consistently failing. To avoid this issue
 		// until it is resolved, we try to connect 3 times.
@@ -122,38 +123,36 @@ func (k *KubernetesUtils) Probe(ns1, pod1, ns2, pod2 string, ports []int32, prot
 			"/bin/sh",
 			"-c",
 		}
-		for _, port := range ports {
-			switch protocol {
-			case v1.ProtocolTCP:
-				cmd = append(cmd, fmt.Sprintf("for i in $(seq 1 3); do /agnhost connect %s:%d --timeout=1s --protocol=tcp && exit 0 || true; done; exit 1", toIP, port))
-			case v1.ProtocolUDP:
-				cmd = append(cmd, fmt.Sprintf("for i in $(seq 1 3); do /agnhost connect %s:%d --timeout=1s --protocol=udp && exit 0 || true; done; exit 1", toIP, port))
-			case v1.ProtocolSCTP:
-				cmd = append(cmd, fmt.Sprintf("for i in $(seq 1 3); do /agnhost connect %s:%d --timeout=1s --protocol=sctp && exit 0 || true; done; exit 1", toIP, port))
-			}
-			// HACK: inferring container name as c80, c81, etc, for simplicity.
-			containerName := fmt.Sprintf("c%v", port)
-			log.Tracef("Running: kubectl exec %s -c %s -n %s -- %s", fromPod.Name, containerName, fromPod.Namespace, strings.Join(cmd, " "))
-			stdout, stderr, err := k.runCommandFromPod(fromPod.Namespace, fromPod.Name, containerName, cmd)
-			var curConnectivity PodConnectivityMark
-			if err != nil {
-				// log this error as trace since may be an expected failure
-				log.Tracef("%s/%s -> %s/%s:%d: error when running command: err - %v /// stdout - %s /// stderr - %s", ns1, pod1, ns2, pod2, port, err, stdout, stderr)
-				// do not return an error
-				if strings.Contains(stderr, "TIMEOUT") {
-					curConnectivity = Dropped
-				} else {
-					curConnectivity = Rejected
-				}
+		switch protocol {
+		case v1.ProtocolTCP:
+			cmd = append(cmd, fmt.Sprintf("for i in $(seq 1 3); do /agnhost connect %s:%d --timeout=1s --protocol=tcp && exit 0 || true; done; exit 1", toIP, port))
+		case v1.ProtocolUDP:
+			cmd = append(cmd, fmt.Sprintf("for i in $(seq 1 3); do /agnhost connect %s:%d --timeout=1s --protocol=udp && exit 0 || true; done; exit 1", toIP, port))
+		case v1.ProtocolSCTP:
+			cmd = append(cmd, fmt.Sprintf("for i in $(seq 1 3); do /agnhost connect %s:%d --timeout=1s --protocol=sctp && exit 0 || true; done; exit 1", toIP, port))
+		}
+		// HACK: inferring container name as c80, c81, etc, for simplicity.
+		containerName := fmt.Sprintf("c%v", port)
+		log.Tracef("Running: kubectl exec %s -c %s -n %s -- %s", fromPod.Name, containerName, fromPod.Namespace, strings.Join(cmd, " "))
+		stdout, stderr, err := k.runCommandFromPod(fromPod.Namespace, fromPod.Name, containerName, cmd)
+		var curConnectivity PodConnectivityMark
+		if err != nil {
+			// log this error as trace since may be an expected failure
+			log.Tracef("%s/%s -> %s/%s: error when running command: err - %v /// stdout - %s /// stderr - %s", ns1, pod1, ns2, pod2, err, stdout, stderr)
+			// do not return an error
+			if strings.Contains(stderr, "TIMEOUT") {
+				curConnectivity = Dropped
 			} else {
-				curConnectivity = Connected
+				curConnectivity = Rejected
 			}
+		} else {
+			curConnectivity = Connected
+		}
 
-			if connectivity == Unknown {
-				connectivity = curConnectivity
-			} else if connectivity != curConnectivity {
-				return Error, nil
-			}
+		if connectivity == Unknown {
+			connectivity = curConnectivity
+		} else if connectivity != curConnectivity {
+			return Error, nil
 		}
 	}
 	return connectivity, nil
@@ -702,31 +701,40 @@ func (k *KubernetesUtils) waitForPodInNamespace(ns string, pod string) ([]string
 func (k *KubernetesUtils) waitForHTTPServers(allPods []Pod) error {
 	const maxTries = 10
 	log.Infof("waiting for HTTP servers (ports 80, 81 and 8080:8085) to become ready")
-	var wrong int
-	for i := 0; i < maxTries; i++ {
+
+	serversAreReady := func() bool {
 		reachability := NewReachability(allPods, Connected)
-		curWrong := 0
-
 		k.Validate(allPods, reachability, []int32{80, 81, 8080, 8081, 8082, 8083, 8084, 8085}, v1.ProtocolTCP)
-		_, curWrong, _ = reachability.Summary()
-		wrong += curWrong
-		k.Validate(allPods, reachability, []int32{80, 81}, v1.ProtocolUDP)
-		_, curWrong, _ = reachability.Summary()
-		wrong += curWrong
-		k.Validate(allPods, reachability, []int32{80, 81}, v1.ProtocolSCTP)
-		_, curWrong, _ = reachability.Summary()
-		wrong += curWrong
+		if _, wrong, _ := reachability.Summary(); wrong != 0 {
+			return false
+		}
 
-		if wrong == 0 {
+		k.Validate(allPods, reachability, []int32{80, 81}, v1.ProtocolUDP)
+		if _, wrong, _ := reachability.Summary(); wrong != 0 {
+			return false
+		}
+
+		k.Validate(allPods, reachability, []int32{80, 81}, v1.ProtocolSCTP)
+		if _, wrong, _ := reachability.Summary(); wrong != 0 {
+			return false
+		}
+		return true
+	}
+
+	for i := 0; i < maxTries; i++ {
+		if serversAreReady() {
 			log.Infof("All HTTP servers are ready")
 			return nil
 		}
-		log.Debugf("%d HTTP servers not ready", wrong)
 		time.Sleep(defaultInterval)
 	}
-	return errors.Errorf("after %d tries, %d HTTP servers are not ready", maxTries, wrong)
+	return errors.Errorf("after %d tries, HTTP servers are not ready", maxTries)
 }
 
+// Validate checks the connectivity between all Pods in both directions with a
+// list of ports and a protocol. The connectivity from a Pod to another Pod should
+// be consistent across all provided ports. Otherwise, this connectivity will be
+// treated as Error.
 func (k *KubernetesUtils) Validate(allPods []Pod, reachability *Reachability, ports []int32, protocol v1.Protocol) {
 	type probeResult struct {
 		podFrom      Pod
@@ -734,17 +742,19 @@ func (k *KubernetesUtils) Validate(allPods []Pod, reachability *Reachability, po
 		connectivity PodConnectivityMark
 		err          error
 	}
-	numProbes := len(allPods) * len(allPods)
+	numProbes := len(allPods) * len(allPods) * len(ports)
 	resultsCh := make(chan *probeResult, numProbes)
 	// TODO: find better metrics, this is only for POC.
-	oneProbe := func(podFrom, podTo Pod) {
+	oneProbe := func(podFrom, podTo Pod, port int32) {
 		log.Tracef("Probing: %s -> %s", podFrom, podTo)
-		connectivity, err := k.Probe(podFrom.Namespace(), podFrom.PodName(), podTo.Namespace(), podTo.PodName(), ports, protocol)
+		connectivity, err := k.Probe(podFrom.Namespace(), podFrom.PodName(), podTo.Namespace(), podTo.PodName(), port, protocol)
 		resultsCh <- &probeResult{podFrom, podTo, connectivity, err}
 	}
 	for _, pod1 := range allPods {
 		for _, pod2 := range allPods {
-			go oneProbe(pod1, pod2)
+			for _, port := range ports {
+				go oneProbe(pod1, pod2, port)
+			}
 		}
 	}
 	for i := 0; i < numProbes; i++ {
@@ -752,9 +762,22 @@ func (k *KubernetesUtils) Validate(allPods []Pod, reachability *Reachability, po
 		if r.err != nil {
 			log.Errorf("unable to perform probe %s -> %s: %v", r.podFrom, r.podTo, r.err)
 		}
-		reachability.Observe(r.podFrom, r.podTo, r.connectivity)
+
+		// We will receive the connectivity from podFrom to podTo len(ports) times.
+		// If it's the first time we observe the connectivity from podFrom to podTo, just
+		// store the connectivity we received in reachability matrix.
+		// If the connectivity from podFrom to podTo has been observed and is different
+		// from the connectivity we received, store Error connectivity in reachability
+		// matrix.
+		prevConn := reachability.Observed.Get(r.podFrom.String(), r.podTo.String())
+		if prevConn == Unknown {
+			reachability.Observe(r.podFrom, r.podTo, r.connectivity)
+		} else if prevConn != r.connectivity {
+			reachability.Observe(r.podFrom, r.podTo, Error)
+		}
+
 		if r.connectivity != Connected && reachability.Expected.Get(r.podFrom.String(), r.podTo.String()) == Connected {
-			log.Warnf("FAILED CONNECTION FOR ALLOWED PODS %s -> %s ON %s !!!!", r.podFrom, r.podTo, protocol)
+			log.Warnf("FAILED CONNECTION FOR ALLOWED PODS %s -> %s !!!! ", r.podFrom, r.podTo)
 		}
 	}
 }

--- a/test/e2e/legacyantreapolicy_test.go
+++ b/test/e2e/legacyantreapolicy_test.go
@@ -1741,9 +1741,9 @@ func testLegacyAuditLoggingBasic(t *testing.T, data *TestData) {
 	time.Sleep(networkPolicyDelay)
 
 	// generate some traffic that will be dropped by test-log-acnp-deny
-	k8sUtils.Probe("x", "a", "z", "a", p80, v1.ProtocolTCP)
-	k8sUtils.Probe("x", "a", "z", "b", p80, v1.ProtocolTCP)
-	k8sUtils.Probe("x", "a", "z", "c", p80, v1.ProtocolTCP)
+	k8sUtils.Probe("x", "a", "z", "a", []int32{p80}, v1.ProtocolTCP)
+	k8sUtils.Probe("x", "a", "z", "b", []int32{p80}, v1.ProtocolTCP)
+	k8sUtils.Probe("x", "a", "z", "c", []int32{p80}, v1.ProtocolTCP)
 	time.Sleep(networkPolicyDelay)
 
 	podXA, err := k8sUtils.GetPodByLabel("x", "a")
@@ -2026,9 +2026,7 @@ func executeLegacyTestsWithData(t *testing.T, testList []*TestCase, data *TestDa
 			reachability := step.Reachability
 			if reachability != nil {
 				start := time.Now()
-				for _, port := range step.Port {
-					k8sUtils.Validate(allPods, reachability, port, step.Protocol)
-				}
+				k8sUtils.Validate(allPods, reachability, step.Port, step.Protocol)
 				step.Duration = time.Since(start)
 
 				_, wrong, _ := step.Reachability.Summary()

--- a/test/e2e/legacyantreapolicy_test.go
+++ b/test/e2e/legacyantreapolicy_test.go
@@ -1557,7 +1557,7 @@ func testLegacyACNPPortRange(t *testing.T) {
 
 	var testSteps []*TestStep
 	testSteps = append(testSteps, &TestStep{
-		fmt.Sprint("ACNP Drop Port 8080:8085"),
+		fmt.Sprint("ACNP Drop Ports 8080:8085"),
 		reachability,
 		[]metav1.Object{builder.GetLegacy()},
 		nil,
@@ -1661,7 +1661,7 @@ func testLegacyANPPortRange(t *testing.T) {
 
 	var testSteps []*TestStep
 	testSteps = append(testSteps, &TestStep{
-		fmt.Sprint("ANP Drop Port 8080:8085"),
+		fmt.Sprint("ANP Drop Ports 8080:8085"),
 		reachability,
 		[]metav1.Object{builder.GetLegacy()},
 		nil,
@@ -1741,9 +1741,9 @@ func testLegacyAuditLoggingBasic(t *testing.T, data *TestData) {
 	time.Sleep(networkPolicyDelay)
 
 	// generate some traffic that will be dropped by test-log-acnp-deny
-	k8sUtils.Probe("x", "a", "z", "a", []int32{p80}, v1.ProtocolTCP)
-	k8sUtils.Probe("x", "a", "z", "b", []int32{p80}, v1.ProtocolTCP)
-	k8sUtils.Probe("x", "a", "z", "c", []int32{p80}, v1.ProtocolTCP)
+	k8sUtils.Probe("x", "a", "z", "a", p80, v1.ProtocolTCP)
+	k8sUtils.Probe("x", "a", "z", "b", p80, v1.ProtocolTCP)
+	k8sUtils.Probe("x", "a", "z", "c", p80, v1.ProtocolTCP)
 	time.Sleep(networkPolicyDelay)
 
 	podXA, err := k8sUtils.GetPodByLabel("x", "a")
@@ -2026,7 +2026,7 @@ func executeLegacyTestsWithData(t *testing.T, testList []*TestCase, data *TestDa
 			reachability := step.Reachability
 			if reachability != nil {
 				start := time.Now()
-				k8sUtils.Validate(allPods, reachability, step.Port, step.Protocol)
+				k8sUtils.Validate(allPods, reachability, step.Ports, step.Protocol)
 				step.Duration = time.Since(start)
 
 				_, wrong, _ := step.Reachability.Summary()

--- a/test/e2e/reachability.go
+++ b/test/e2e/reachability.go
@@ -147,11 +147,11 @@ func (ct *ConnectivityTable) SetAllTo(to string, value PodConnectivityMark) {
 func (ct *ConnectivityTable) Get(from string, to string) PodConnectivityMark {
 	dict, ok := ct.Values[from]
 	if !ok {
-		panic(errors.New(fmt.Sprintf("key %s not found in map", from)))
+		return Unknown
 	}
 	val, ok := dict[to]
 	if !ok {
-		panic(errors.New(fmt.Sprintf("key %s not found in map (%+v)", to, dict)))
+		return Unknown
 	}
 	return val
 }


### PR DESCRIPTION
Previously, if there are multiple ports in `testStep`, `executeTestsWithData` will call `k8sUtils.Validate` for each port. In this case, when we call `step.Reachability.Summary()` to get the result, the data in `step.Reachability` is just what we observed from the last port, which is not what we want.
This PR makes `Validate` and `Probe` functions take multi-port instead of a single port as one of its parameters. The connectivity should be:
1. If the connectivities on all ports are the same, the connectivity from `fromPod` to `toPod` is this connectivity.
2. If the connectivities on all ports are not the same, the connectivity from `fromPod` to `toPod` is Error.