### PR TITLE
remove vet

### DIFF
--- a/multicluster/Makefile
+++ b/multicluster/Makefile
@@ -47,21 +47,18 @@ generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and
 fmt: ## Run go fmt against code.
 	go fmt ./...
 
-vet: ## Run go vet against code.
-	go vet ./...
-
 ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
-test: manifests generate fmt vet ## Run tests.
+test: manifests generate fmt ## Run tests.
 	mkdir -p ${ENVTEST_ASSETS_DIR}
 	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh
 	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./... -coverprofile cover.out
 
 ##@ Build
 
-build: generate fmt vet ## Build manager binary.
+build: generate fmt ## Build manager binary.
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/manager main.go
 
-run: manifests generate fmt vet ## Run a controller from your host.
+run: manifests generate fmt ## Run a controller from your host.
 	go run ./main.go
 
 #docker-build: test ## Build docker image with the manager.


### PR DESCRIPTION
`go vet ./...` will fail and report below error:
```
../../../../../pkg/mod/sigs.k8s.io/controller-runtime@v0.9.1/pkg/internal/testing/controlplane/plane.go:195:14: undefined: os.CreateTemp
note: module requires Go 1.16
```

we can use the same lint tools as antrea and enable in the future
so remove it for now, so we can run `make build` correctly.

Signed-off-by: Lan Luo <luola@vmware.com>