### PR TITLE
Automated cherry pick of #2555: Handle iptables-restore failures correctly in NPL

### DIFF
--- a/pkg/agent/nodeportlocal/npl_agent_init.go
+++ b/pkg/agent/nodeportlocal/npl_agent_init.go
@@ -76,9 +76,5 @@ func InitController(kubeClient clientset.Interface, informerFactory informers.Sh
 		portTable,
 		nodeName)
 
-	if err := c.Initialize(); err != nil {
-		return nil, fmt.Errorf("error when initializing NodePortLocal Controller: %v", err)
-	}
-
 	return c, nil
 }

--- a/pkg/agent/nodeportlocal/npl_agent_init.go
+++ b/pkg/agent/nodeportlocal/npl_agent_init.go
@@ -76,5 +76,9 @@ func InitController(kubeClient clientset.Interface, informerFactory informers.Sh
 		portTable,
 		nodeName)
 
+	if err := c.Initialize(); err != nil {
+		return nil, fmt.Errorf("error when initializing NodePortLocal Controller: %v", err)
+	}
+
 	return c, nil
 }

--- a/pkg/agent/nodeportlocal/npl_agent_test.go
+++ b/pkg/agent/nodeportlocal/npl_agent_test.go
@@ -154,12 +154,11 @@ func getTestSvcWithPortName(portName string) *corev1.Service {
 
 type testData struct {
 	*testing.T
-	stopCh         chan struct{}
-	ctrl           *gomock.Controller
-	k8sClient      *k8sfake.Clientset
-	portTable      *portcache.PortTable
-	mockPortOpener *portcachetesting.MockLocalPortOpener
-	wg             sync.WaitGroup
+	stopCh    chan struct{}
+	ctrl      *gomock.Controller
+	k8sClient *k8sfake.Clientset
+	portTable *portcache.PortTable
+	wg        sync.WaitGroup
 }
 
 func (data *testData) runWrapper(c *nplk8s.NPLController) {
@@ -170,18 +169,25 @@ func (data *testData) runWrapper(c *nplk8s.NPLController) {
 	}()
 }
 
+type customizePortOpenerExpectations func(*portcachetesting.MockLocalPortOpener)
+type customizePodPortRulesExpectations func(*rulestesting.MockPodPortRules)
+
 type testConfig struct {
-	defaultPortOpenerExpectations bool
+	customPortOpenerExpectations   customizePortOpenerExpectations
+	customPodPortRulesExpectations customizePodPortRulesExpectations
 }
 
 func newTestConfig() *testConfig {
-	return &testConfig{
-		defaultPortOpenerExpectations: true,
-	}
+	return &testConfig{}
 }
 
-func (tc *testConfig) withDefaultPortOpenerExpectations(v bool) *testConfig {
-	tc.defaultPortOpenerExpectations = false
+func (tc *testConfig) withCustomPortOpenerExpectations(fn customizePortOpenerExpectations) *testConfig {
+	tc.customPortOpenerExpectations = fn
+	return tc
+}
+
+func (tc *testConfig) withCustomPodPortRulesExpectations(fn customizePodPortRulesExpectations) *testConfig {
+	tc.customPodPortRulesExpectations = fn
 	return tc
 }
 
@@ -191,22 +197,27 @@ func setUp(t *testing.T, tc *testConfig, objects ...runtime.Object) *testData {
 	mockCtrl := gomock.NewController(t)
 
 	mockIPTables := rulestesting.NewMockPodPortRules(mockCtrl)
-	mockIPTables.EXPECT().AddRule(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
-	mockIPTables.EXPECT().DeleteRule(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
-	mockIPTables.EXPECT().AddAllRules(gomock.Any()).AnyTimes()
+	if tc.customPodPortRulesExpectations != nil {
+		tc.customPodPortRulesExpectations(mockIPTables)
+	} else {
+		mockIPTables.EXPECT().AddRule(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+		mockIPTables.EXPECT().DeleteRule(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+		mockIPTables.EXPECT().AddAllRules(gomock.Any()).AnyTimes()
+	}
 
 	mockPortOpener := portcachetesting.NewMockLocalPortOpener(mockCtrl)
-	if tc.defaultPortOpenerExpectations {
+	if tc.customPortOpenerExpectations != nil {
+		tc.customPortOpenerExpectations(mockPortOpener)
+	} else {
 		mockPortOpener.EXPECT().OpenLocalPort(gomock.Any()).AnyTimes().Return(&fakeSocket{}, nil)
 	}
 
 	data := &testData{
-		T:              t,
-		stopCh:         make(chan struct{}),
-		ctrl:           mockCtrl,
-		k8sClient:      k8sfake.NewSimpleClientset(objects...),
-		portTable:      newPortTable(mockIPTables, mockPortOpener),
-		mockPortOpener: mockPortOpener,
+		T:         t,
+		stopCh:    make(chan struct{}),
+		ctrl:      mockCtrl,
+		k8sClient: k8sfake.NewSimpleClientset(objects...),
+		portTable: newPortTable(mockIPTables, mockPortOpener),
 	}
 
 	// informerFactory is initialized and started from cmd/antrea-agent/agent.go
@@ -659,30 +670,35 @@ var (
 // TestNodePortAlreadyBoundTo validates that when a port is already bound to, a different port will
 // be selected for NPL.
 func TestNodePortAlreadyBoundTo(t *testing.T) {
-	testSvc := getTestSvc()
-	testPod := getTestPod()
-	testConfig := newTestConfig().withDefaultPortOpenerExpectations(false)
-	testData := setUp(t, testConfig)
-	defer testData.tearDown()
-
 	var nodePort int
-	gomock.InOrder(
-		testData.mockPortOpener.EXPECT().OpenLocalPort(gomock.Any()).Return(nil, portTakenError),
-		testData.mockPortOpener.EXPECT().OpenLocalPort(gomock.Any()).DoAndReturn(func(port int) (portcache.Closeable, error) {
-			nodePort = port
-			return &fakeSocket{}, nil
-		}),
-	)
-
-	_, err := testData.k8sClient.CoreV1().Services(defaultNS).Create(context.TODO(), testSvc, metav1.CreateOptions{})
-	require.NoError(t, err, "Service creation failed")
-
-	_, err = testData.k8sClient.CoreV1().Pods(defaultNS).Create(context.TODO(), testPod, metav1.CreateOptions{})
-	require.NoError(t, err, "Pod creation failed")
+	testConfig := newTestConfig().withCustomPortOpenerExpectations(func(mockPortOpener *portcachetesting.MockLocalPortOpener) {
+		gomock.InOrder(
+			mockPortOpener.EXPECT().OpenLocalPort(gomock.Any()).Return(nil, portTakenError),
+			mockPortOpener.EXPECT().OpenLocalPort(gomock.Any()).DoAndReturn(func(port int) (portcache.Closeable, error) {
+				nodePort = port
+				return &fakeSocket{}, nil
+			}),
+		)
+	})
+	testData, _, testPod := setUpWithTestServiceAndPod(t, testConfig)
+	defer testData.tearDown()
 
 	value, err := testData.pollForPodAnnotation(testPod.Name, true)
 	require.NoError(t, err, "Poll for annotation check failed")
 	annotation := testData.checkAnnotationValue(value, defaultPort)[0] // length of slice is guaranteed to be correct at this stage
 	assert.Equal(t, nodePort, annotation.NodePort)
-	assert.True(t, testData.portTable.RuleExists(defaultPodIP, defaultPort))
+}
+
+func TestSyncRulesError(t *testing.T) {
+	testConfig := newTestConfig().withCustomPodPortRulesExpectations(func(mockIPTables *rulestesting.MockPodPortRules) {
+		mockIPTables.EXPECT().AddRule(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+		mockIPTables.EXPECT().DeleteRule(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+		gomock.InOrder(
+			mockIPTables.EXPECT().AddAllRules(gomock.Any()).Return(fmt.Errorf("iptables failure")),
+			mockIPTables.EXPECT().AddAllRules(gomock.Any()).Return(nil).AnyTimes(),
+		)
+	})
+
+	testData, _, _ := setUpWithTestServiceAndPod(t, testConfig)
+	defer testData.tearDown()
 }

--- a/pkg/agent/nodeportlocal/portcache/port_table.go
+++ b/pkg/agent/nodeportlocal/portcache/port_table.go
@@ -203,7 +203,7 @@ func (pt *PortTable) RestoreRules(allNPLPorts []rules.PodNodePort, synced chan<-
 		var backoffTime = 2 * time.Second
 		for {
 			if err := pt.syncRules(); err != nil {
-				klog.Errorf("Failed to initialize iptables: %v - will retry in %v", err, backoffTime)
+				klog.ErrorS(err, "Failed to restore iptables rules", "backoff", backoffTime)
 				time.Sleep(backoffTime)
 				continue
 			}

--- a/pkg/agent/nodeportlocal/portcache/port_table.go
+++ b/pkg/agent/nodeportlocal/portcache/port_table.go
@@ -197,7 +197,7 @@ func (pt *PortTable) RestoreRules(allNPLPorts []rules.PodNodePort, synced chan<-
 		pt.Table[nplPort.NodePort] = data
 	}
 	// retry mechanism as iptables-restore can fail if other components (in Antrea or other
-	// software) or accessing iptables.
+	// software) are accessing iptables.
 	go func() {
 		defer close(synced)
 		var backoffTime = 2 * time.Second

--- a/pkg/agent/nodeportlocal/portcache/port_table.go
+++ b/pkg/agent/nodeportlocal/portcache/port_table.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net"
 	"sync"
+	"time"
 
 	"k8s.io/klog/v2"
 
@@ -156,8 +157,26 @@ func (pt *PortTable) RuleExists(podIP string, podPort int) bool {
 	return false
 }
 
-func (pt *PortTable) SyncRules(allNPLPorts []rules.PodNodePort) error {
-	validNPLPorts := make([]rules.PodNodePort, 0, len(allNPLPorts))
+// syncRules ensures that contents of the port table matches the iptables rules present on the Node.
+func (pt *PortTable) syncRules() error {
+	pt.tableLock.Lock()
+	defer pt.tableLock.Unlock()
+	nplPorts := make([]rules.PodNodePort, 0, len(pt.Table))
+	for _, data := range pt.Table {
+		nplPorts = append(nplPorts, rules.PodNodePort{
+			NodePort: data.NodePort,
+			PodPort:  data.PodPort,
+			PodIP:    data.PodIP,
+		})
+	}
+	return pt.PodPortRules.AddAllRules(nplPorts)
+}
+
+// RestoreRules should be called on startup to restore a set of NPL rules. It is non-blocking but
+// takes as a parameter a channel, synced, which will be closed when the necessary rules have been
+// restored successfully. No other operations should be performed on the PortTable until the channel
+// is closed.
+func (pt *PortTable) RestoreRules(allNPLPorts []rules.PodNodePort, synced chan<- struct{}) error {
 	pt.tableLock.Lock()
 	defer pt.tableLock.Unlock()
 	for _, nplPort := range allNPLPorts {
@@ -176,9 +195,22 @@ func (pt *PortTable) SyncRules(allNPLPorts []rules.PodNodePort) error {
 			socket:   socket,
 		}
 		pt.Table[nplPort.NodePort] = data
-		validNPLPorts = append(validNPLPorts, nplPort)
 	}
-	return pt.PodPortRules.AddAllRules(validNPLPorts)
+	// retry mechanism as iptables-restore can fail if other components (in Antrea or other
+	// software) or accessing iptables.
+	go func() {
+		defer close(synced)
+		var backoffTime = 2 * time.Second
+		for {
+			if err := pt.syncRules(); err != nil {
+				klog.Errorf("Failed to initialize iptables: %v - will retry in %v", err, backoffTime)
+				time.Sleep(backoffTime)
+				continue
+			}
+			break
+		}
+	}()
+	return nil
 }
 
 // openLocalPort binds to the provided port.


### PR DESCRIPTION
Cherry pick of #2555 on release-1.2.

#2555: Handle iptables-restore failures correctly in NPL

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.