### PR TITLE
[Follow Up][WIP]Antrea Network Policy Audit Logging Deduplication and Unit Tests

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -197,6 +197,7 @@ func run(o *Options) error {
 	// In Antrea agent, status manager and audit logging will automatically be enabled
 	// if AntreaPolicy feature is enabled.
 	statusManagerEnabled := antreaPolicyEnabled
+	loggingEnabled := antreaPolicyEnabled
 
 	var denyConnStore *connections.DenyConnectionStore
 	if features.DefaultFeatureGate.Enabled(features.FlowExporter) {
@@ -211,6 +212,7 @@ func run(o *Options) error {
 		entityUpdates,
 		antreaPolicyEnabled,
 		statusManagerEnabled,
+		loggingEnabled,
 		denyConnStore,
 		asyncRuleDeleteInterval)
 	if err != nil {

--- a/pkg/agent/controller/networkpolicy/audit_logging.go
+++ b/pkg/agent/controller/networkpolicy/audit_logging.go
@@ -150,6 +150,6 @@ func newAntreaPolicyLogger() (*AntreaPolicyLogger, error) {
 		anpLogger:        log.New(logOutput, "", log.Ldate|log.Lmicroseconds),
 		logDeduplication: logRecordDedupMap{logMap: make(map[string]*logDedupRecord)},
 	}
-	klog.InfoS("Initialized Antrea-native Policy Logger for audit logging with log file '%s'", logFile)
+	klog.InfoS("Initialized Antrea-native Policy Logger for audit logging", "logFile", logFile)
 	return antreaPolicyLogger, nil
 }

--- a/pkg/agent/controller/networkpolicy/audit_logging_test.go
+++ b/pkg/agent/controller/networkpolicy/audit_logging_test.go
@@ -128,26 +128,25 @@ func TestDropPacketMultiDedupLog(t *testing.T) {
 	ob, expected := newLogInfo("Drop")
 
 	numPackets := 4
-	go sendMultiplePackets(antreaLogger, ob, numPackets, 50*time.Millisecond)
+	go sendMultiplePackets(antreaLogger, ob, numPackets, 40*time.Millisecond)
 	// Close the channel listening for logged msg after 1s.
 	go closePacketTransmit(mockAnpLogger, 500*time.Millisecond)
 
-	receivedMsg, countMsg := 0, 0
+	receivedPacket, countLog := 0, 0
 	for actual := range mockAnpLogger.logged {
-		t.Log(actual)
 		assert.Contains(t, actual, expected)
-		countMsg++
+		countLog++
 		begin := strings.Index(actual, "[")
 		end := strings.Index(actual, " packets")
 		if begin == -1 {
-			receivedMsg += 1
+			receivedPacket += 1
 		} else {
 			countLoggedMsg, _ := strconv.Atoi(actual[(begin + 1):end])
-			receivedMsg += countLoggedMsg
+			receivedPacket += countLoggedMsg
 		}
 	}
-	// Test at least two messages are logged for all packets.
-	assert.GreaterOrEqual(t, countMsg, 2)
+	// Test two messages are logged for all packets.
+	assert.Equal(t, 2, countLog)
 	// Test all packets are logged correspondingly.
-	assert.Equal(t, numPackets, receivedMsg)
+	assert.Equal(t, numPackets, receivedPacket)
 }

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
@@ -65,6 +65,8 @@ type Controller struct {
 	antreaPolicyEnabled bool
 	// statusManagerEnabled indicates whether a statusManager is configured.
 	statusManagerEnabled bool
+	// loggingEnabled indicates where Antrea policy audit logging is enabled.
+	loggingEnabled bool
 	// antreaClientProvider provides interfaces to get antreaClient, which can be
 	// used to watch Antrea AddressGroups, AppliedToGroups, and NetworkPolicies.
 	// We need to get antreaClient dynamically because the apiserver cert can be
@@ -103,6 +105,7 @@ func NewNetworkPolicyController(antreaClientGetter agent.AntreaClientProvider,
 	entityUpdates <-chan types.EntityReference,
 	antreaPolicyEnabled bool,
 	statusManagerEnabled bool,
+	loggingEnabled bool,
 	denyConnStore *connections.DenyConnectionStore,
 	asyncRuleDeleteInterval time.Duration) (*Controller, error) {
 	c := &Controller{
@@ -112,6 +115,7 @@ func NewNetworkPolicyController(antreaClientGetter agent.AntreaClientProvider,
 		ofClient:             ofClient,
 		antreaPolicyEnabled:  antreaPolicyEnabled,
 		statusManagerEnabled: statusManagerEnabled,
+		loggingEnabled:       loggingEnabled,
 		denyConnStore:        denyConnStore,
 	}
 	c.ruleCache = newRuleCache(c.enqueueRule, entityUpdates)
@@ -128,6 +132,9 @@ func NewNetworkPolicyController(antreaClientGetter agent.AntreaClientProvider,
 	if c.ofClient != nil && antreaPolicyEnabled {
 		// Register packetInHandler
 		c.ofClient.RegisterPacketInHandler(uint8(openflow.PacketInReasonNP), "networkpolicy", c)
+	}
+
+	if loggingEnabled {
 		// Initiate logger for Antrea Policy audit logging
 		antreaPolicyLogger, err := newAntreaPolicyLogger()
 		if err != nil {

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
@@ -132,15 +132,14 @@ func NewNetworkPolicyController(antreaClientGetter agent.AntreaClientProvider,
 	if c.ofClient != nil && antreaPolicyEnabled {
 		// Register packetInHandler
 		c.ofClient.RegisterPacketInHandler(uint8(openflow.PacketInReasonNP), "networkpolicy", c)
-	}
-
-	if loggingEnabled {
-		// Initiate logger for Antrea Policy audit logging
-		antreaPolicyLogger, err := newAntreaPolicyLogger()
-		if err != nil {
-			return nil, err
+		if loggingEnabled {
+			// Initiate logger for Antrea Policy audit logging
+			antreaPolicyLogger, err := newAntreaPolicyLogger()
+			if err != nil {
+				return nil, err
+			}
+			c.antreaPolicyLogger = antreaPolicyLogger
 		}
-		c.antreaPolicyLogger = antreaPolicyLogger
 	}
 
 	// Use nodeName to filter resources when watching resources.

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
@@ -53,7 +53,7 @@ func newTestController() (*Controller, *fake.Clientset, *mockReconciler) {
 	clientset := &fake.Clientset{}
 	ch := make(chan agenttypes.EntityReference, 100)
 	controller, _ := NewNetworkPolicyController(&antreaClientGetter{clientset}, nil, nil, "node1", ch,
-		true, true, nil, testAsyncDeleteInterval)
+		true, true, true, nil, testAsyncDeleteInterval)
 	reconciler := newMockReconciler()
 	controller.reconciler = reconciler
 	controller.antreaPolicyLogger = nil

--- a/pkg/agent/controller/networkpolicy/packetin.go
+++ b/pkg/agent/controller/networkpolicy/packetin.go
@@ -195,7 +195,7 @@ func (c *Controller) logPacket(pktIn *ofctrl.PacketIn) error {
 	}
 
 	// Log the ob info to corresponding file w/ deduplication
-	c.antreaPolicyLogger.logDedupPacket(ob, time.Second)
+	c.antreaPolicyLogger.LogDedupPacket(ob)
 	return nil
 }
 


### PR DESCRIPTION
This is a follow up PR for [Antrea Network Policy Audit Logging Deduplication and Unit Tests](https://github.com/antrea-io/antrea/pull/2294) to address comments.

- Converted back to include both `antreaPolicyEnabled` and `loggingEnabled` for extensible usage.
- Changed `AntreaPolicyLogger` method naming.
- Moved `bufferLength` to a member of `AntreaPolicyLogger` to avoid confusion.