### PR TITLE
[Bug Fix]Fix infinite rejection loop by adding ingress/egress bypass flows

### DIFF
--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -681,6 +681,12 @@ func (c *client) initialize() error {
 	if err := c.ofEntryOperations.AddAll(c.establishedConnectionFlows(cookie.Default)); err != nil {
 		return fmt.Errorf("failed to install flows to skip established connections: %v", err)
 	}
+	if err := c.ofEntryOperations.AddAll(c.relatedConnectionFlows(cookie.Default)); err != nil {
+		return fmt.Errorf("failed to install flows to skip related connections: %v", err)
+	}
+	if err := c.ofEntryOperations.AddAll(c.rejectBypassNetworkpolicyFlows(cookie.Default)); err != nil {
+		return fmt.Errorf("failed to install flows to skip generated reject responses: %v", err)
+	}
 	if c.encapMode.IsNetworkPolicyOnly() {
 		if err := c.setupPolicyOnlyFlows(); err != nil {
 			return fmt.Errorf("failed to setup policy only flows: %w", err)

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -1657,6 +1657,115 @@ func (c *client) establishedConnectionFlows(category cookie.Category) (flows []b
 	return allEstFlows
 }
 
+// relatedConnectionFlows generates flows to ensure related connections skip the NetworkPolicy rules.
+func (c *client) relatedConnectionFlows(category cookie.Category) (flows []binding.Flow) {
+	// egressDropTable checks the source address of packets, and drops packets sent from the AppliedToGroup but not
+	// matching the NetworkPolicy rules. Packets in the related connections need not to be checked with the
+	// egressRuleTable or the egressDropTable.
+	egressDropTable := c.pipeline[EgressDefaultTable]
+	// ingressDropTable checks the destination address of packets, and drops packets sent to the AppliedToGroup but not
+	// matching the NetworkPolicy rules. Packets in the related connections need not to be checked with the
+	// ingressRuleTable or ingressDropTable.
+	ingressDropTable := c.pipeline[IngressDefaultTable]
+	var allRelFlows []binding.Flow
+	for _, ipProto := range c.ipProtocols {
+		egressRelFlow := c.pipeline[EgressRuleTable].BuildFlow(priorityHigh).MatchProtocol(ipProto).
+			MatchCTStateNew(false).MatchCTStateRel(true).
+			Action().GotoTable(egressDropTable.GetNext()).
+			Cookie(c.cookieAllocator.Request(category).Raw()).
+			Done()
+		ingressRelFlow := c.pipeline[IngressRuleTable].BuildFlow(priorityHigh).MatchProtocol(ipProto).
+			MatchCTStateNew(false).MatchCTStateRel(true).
+			Action().GotoTable(ingressDropTable.GetNext()).
+			Cookie(c.cookieAllocator.Request(category).Raw()).
+			Done()
+		allRelFlows = append(allRelFlows, egressRelFlow, ingressRelFlow)
+	}
+	if !c.enableAntreaPolicy {
+		return allRelFlows
+	}
+	apFlows := make([]binding.Flow, 0)
+	for _, tableID := range GetAntreaPolicyEgressTables() {
+		for _, ipProto := range c.ipProtocols {
+			apEgressRelFlow := c.pipeline[tableID].BuildFlow(priorityTopAntreaPolicy).MatchProtocol(ipProto).
+				MatchCTStateNew(false).MatchCTStateRel(true).
+				Action().GotoTable(egressDropTable.GetNext()).
+				Cookie(c.cookieAllocator.Request(category).Raw()).
+				Done()
+			apFlows = append(apFlows, apEgressRelFlow)
+		}
+
+	}
+	for _, tableID := range GetAntreaPolicyIngressTables() {
+		for _, ipProto := range c.ipProtocols {
+			apIngressRelFlow := c.pipeline[tableID].BuildFlow(priorityTopAntreaPolicy).MatchProtocol(ipProto).
+				MatchCTStateNew(false).MatchCTStateRel(true).
+				Action().GotoTable(ingressDropTable.GetNext()).
+				Cookie(c.cookieAllocator.Request(category).Raw()).
+				Done()
+			apFlows = append(apFlows, apIngressRelFlow)
+		}
+
+	}
+	allRelFlows = append(allRelFlows, apFlows...)
+	return allRelFlows
+}
+
+// rejectBypassNetworkpolicyFlows generates flows to ensure reject responses generated
+// by the controller skip the NetworkPolicy rules.
+func (c *client) rejectBypassNetworkpolicyFlows(category cookie.Category) (flows []binding.Flow) {
+	// egressDropTable checks the source address of packets, and drops packets sent from the AppliedToGroup but not
+	// matching the NetworkPolicy rules. Generated reject responses need not to be checked with the
+	// egressRuleTable or the egressDropTable.
+	egressDropTable := c.pipeline[EgressDefaultTable]
+	// ingressDropTable checks the destination address of packets, and drops packets sent to the AppliedToGroup but not
+	// matching the NetworkPolicy rules. Generated reject responses need not to be checked with the
+	// ingressRuleTable or ingressDropTable.
+	ingressDropTable := c.pipeline[IngressDefaultTable]
+	var allRejFlows []binding.Flow
+	for _, ipProto := range c.ipProtocols {
+		egressRejFlow := c.pipeline[EgressRuleTable].BuildFlow(priorityHigh).MatchProtocol(ipProto).
+			MatchRegRange(int(marksReg), CustomReasonReject, CustomReasonMarkRange).
+			Action().GotoTable(egressDropTable.GetNext()).
+			Cookie(c.cookieAllocator.Request(category).Raw()).
+			Done()
+		ingressRejFlow := c.pipeline[IngressRuleTable].BuildFlow(priorityHigh).MatchProtocol(ipProto).
+			MatchRegRange(int(marksReg), CustomReasonReject, CustomReasonMarkRange).
+			Action().GotoTable(ingressDropTable.GetNext()).
+			Cookie(c.cookieAllocator.Request(category).Raw()).
+			Done()
+		allRejFlows = append(allRejFlows, egressRejFlow, ingressRejFlow)
+	}
+	if !c.enableAntreaPolicy {
+		return allRejFlows
+	}
+	apFlows := make([]binding.Flow, 0)
+	for _, tableID := range GetAntreaPolicyEgressTables() {
+		for _, ipProto := range c.ipProtocols {
+			apEgressRejFlow := c.pipeline[tableID].BuildFlow(priorityTopAntreaPolicy).MatchProtocol(ipProto).
+				MatchRegRange(int(marksReg), CustomReasonReject, CustomReasonMarkRange).
+				Action().GotoTable(egressDropTable.GetNext()).
+				Cookie(c.cookieAllocator.Request(category).Raw()).
+				Done()
+			apFlows = append(apFlows, apEgressRejFlow)
+		}
+
+	}
+	for _, tableID := range GetAntreaPolicyIngressTables() {
+		for _, ipProto := range c.ipProtocols {
+			apIngressRejFlow := c.pipeline[tableID].BuildFlow(priorityTopAntreaPolicy).MatchProtocol(ipProto).
+				MatchRegRange(int(marksReg), CustomReasonReject, CustomReasonMarkRange).
+				Action().GotoTable(ingressDropTable.GetNext()).
+				Cookie(c.cookieAllocator.Request(category).Raw()).
+				Done()
+			apFlows = append(apFlows, apIngressRejFlow)
+		}
+
+	}
+	allRejFlows = append(allRejFlows, apFlows...)
+	return allRejFlows
+}
+
 func (c *client) addFlowMatch(fb binding.FlowBuilder, matchKey *types.MatchKey, matchValue interface{}) binding.FlowBuilder {
 	switch matchKey {
 	case MatchDstOFPort:


### PR DESCRIPTION
This PR fixes issue #2548 
This PR added some bypass flows in the ingress and egress table to make sure reject responses won't be enforced by network policies.

**Why we need it**
Previously, reject responses are controlled by network policies, which means that reject responses could also be rejected. It may cause an infinite loop of rejecting reject responses in the OVS pipeline. 
Instead of `Reject` reject response, now we choose to `Allow` the reject responses.


**Added Flows**
```
table=45/50/60/85/90/100, priority=64990,ct_state=-new+rel,ip actions=resubmit(,61/101)
table=45/50/60/85/90/100, priority=64990,ip,reg0=0x2000000/0x7000000 actions=resubmit(,61/101)
```

**Example**
Suppose we have:
* PodA on NodeA
* PodB on NodeB
* PolicyA: appliedTo: PodA,  ingress: Reject from PodB
* PolicyB: appliedTo: PodB,  ingress: Reject from PodA,  egress: Reject to PodA

When PodA tries to talk to PodB using UDP, the process will be:
1. The packet will commit a conntrack on NodeA, then leave NodeA.
2. NodeB receives this packet. Due to the ingress rule of PolicyB, a reject response is generated by the controller with reg loaded.
3. Thanks to the second bypass flow above this reject response can bypass the egress rule of PolicyB, then leave NodeB
4. NodeA receives this reject response, an ICMP Destination Host Prohibited, whose ct_state is `-new+rel`.
5. Thanks to the first bypass flow above this reject response can bypass the ingress rule of PolicyA, then PodA will receive it.

If in the beginning, PodA uses TCP to talk to PodB, then in step 4 above a TCP RST whose ct_state is `-new+est` will be received. And the bypass flow for `ct_state=-new+est` has already existed, so we don't need to handle it in this PR.