### PR TITLE
Support --sort-by flag for "antctl get networkpolicy" for Agent

### DIFF
--- a/pkg/antctl/antctl.go
+++ b/pkg/antctl/antctl.go
@@ -135,7 +135,7 @@ var CommandList = &commandList{
 			agentEndpoint: &endpoint{
 				nonResourceEndpoint: &nonResourceEndpoint{
 					path: "/networkpolicies",
-					params: []flagInfo{
+					params: append([]flagInfo{
 						{
 							name:  "name",
 							usage: "Get NetworkPolicy by name.",
@@ -161,7 +161,7 @@ var CommandList = &commandList{
 							usage:     "Get NetworkPolicies with specific type. Type means the type of its source network policy: K8sNP, ACNP, ANP",
 							shorthand: "T",
 						},
-					},
+					}, getSortByFlag()),
 					outputType: multiple,
 				},
 				addonTransform: networkpolicy.Transform,

--- a/pkg/antctl/command_definition.go
+++ b/pkg/antctl/command_definition.go
@@ -128,14 +128,18 @@ func (e *resourceEndpoint) flags() []flagInfo {
 		})
 	}
 	if e.groupVersionResource == &v1beta2.NetworkPolicyVersionResource {
-		flags = append(flags, flagInfo{
-			name:            "sort-by",
-			defaultValue:    "",
-			supportedValues: []string{sortByEffectivePriority},
-			usage:           "Get NetworkPolicies in specific order. Current supported value is effectivePriority.",
-		})
+		flags = append(flags, getSortByFlag())
 	}
 	return flags
+}
+
+func getSortByFlag() flagInfo {
+	return flagInfo{
+		name:            "sort-by",
+		defaultValue:    "",
+		supportedValues: []string{sortByEffectivePriority},
+		usage:           "Get NetworkPolicies in specific order. Current supported value is effectivePriority.",
+	}
 }
 
 type nonResourceEndpoint struct {


### PR DESCRIPTION
Previous to this change, the flag was only supported in "Controller
mode". This was a bit confusing when running "antctl get networkpolicy"
from the Agent Pod, because 1) the option shows in the examples from the
help message, and 2) the documentation doesn't make it clear that this
flag only works in "Controller mode".

Rather than update the documentation and add complexity in the help
message, I am adding support for that flag in "Agent mode". There
doesn't seem to be any reason not to.

Signed-off-by: Antonin Bas <abas@vmware.com>