### PR TITLE
Update AllowToCoreDNS rule to permit udp on port 53

### DIFF
--- a/docs/antrea-network-policy.md
+++ b/docs/antrea-network-policy.md
@@ -869,6 +869,8 @@ spec:
         ports:
           - protocol: TCP
             port: 53
+          - protocol: UDP
+            port: 53
         name: AllowToCoreDNS
 ```
 

--- a/docs/antrea-network-policy.md
+++ b/docs/antrea-network-policy.md
@@ -940,6 +940,8 @@ spec:
         ports:
           - protocol: TCP
             port: 53
+          - protocol: UDP
+            port: 53
         name: AllowToCoreDNS
 ```
 


### PR DESCRIPTION
DNS requests are of both UDP and TCP. When testing the AllowToCoreDNS Rule I was running into issues with wget and nslookup not resolving from within a pod by adding in a second port and protocol combo this was resolved. This update should make for it clearer how to expose dns to end users while the old example technically still worked it would not permit all dns traffic.
Signed-off-by: Brian Rieger <brieger@vmware.com>