### PR TITLE
Fix e2e networkpolicy tests on Kind for slower machines

### DIFF
--- a/test/e2e/k8s_util.go
+++ b/test/e2e/k8s_util.go
@@ -788,7 +788,7 @@ func (k *KubernetesUtils) Validate(allPods []Pod, reachability *Reachability, po
 		// built-in retry (3x) mechanism. Probably because of the large number of probes,
 		// each one being executed in its own goroutine. For example, with 9 Pods and for
 		// ports 80, 81, 8080, 8081, 8082, 8083, 8084 and 8085, we would end up with
-		// potentisally 9*9*8 = 648 simultaneous probes.
+		// potentially 9*9*8 = 648 simultaneous probes.
 		k.validateOnePort(allPods, reachability, port, protocol)
 	}
 }


### PR DESCRIPTION
I tried running the tests locally today and couldn't get the test setup
(initial probe to check connectivity between all Pods) to succeed. I
added some log messages and it seems that a fraction of the probes
(different set of probes for every attempt) was always failing. I wasn't
able to reproduce the connection failures by exec'ing into the Pods
directly. I believe that this is caused by
https://github.com/antrea-io/antrea/pull/2565, which is causing a vey
large number of probes (648) to execute in parallel, each in its own
goroutine. This happens when running Docker on my macOS laptop, but
surprisingly I haven't observed any such failure in Github Actions. My
fix is to limit parallel probes to a single port number.

Signed-off-by: Antonin Bas <abas@vmware.com>