### PR TITLE
Stop checking https://nssm.cc/ in markdown link checker

### DIFF
--- a/hack/.md_links_config.json
+++ b/hack/.md_links_config.json
@@ -20,6 +20,9 @@
         },
         {
             "pattern": "^https://app.fossa.com/api/*"
+        },
+        {
+            "pattern": "https://nssm.cc/"
         }
     ],
     "retryOn429": false,


### PR DESCRIPTION
We get a 503 (Service Unavailable) pretty often and it does seem the
website is down from time to time. To avoid CI failures, we explicitly
exclude this link.

Signed-off-by: Antonin Bas <abas@vmware.com>