### PR TITLE
Revert "Resolve flow aggregator close issue"

### DIFF
--- a/ci/kind/test-e2e-kind.sh
+++ b/ci/kind/test-e2e-kind.sh
@@ -115,7 +115,7 @@ else
     manifest_args="$manifest_args --no-np"
 fi
 
-COMMON_IMAGES_LIST=("gcr.io/kubernetes-e2e-test-images/agnhost:2.8" "projects.registry.vmware.com/library/busybox" "projects.registry.vmware.com/antrea/nginx" "projects.registry.vmware.com/antrea/perftool" "projects.registry.vmware.com/antrea/ipfix-collector:v0.5.7")
+COMMON_IMAGES_LIST=("gcr.io/kubernetes-e2e-test-images/agnhost:2.8" "projects.registry.vmware.com/library/busybox" "projects.registry.vmware.com/antrea/nginx" "projects.registry.vmware.com/antrea/perftool" "projects.registry.vmware.com/antrea/ipfix-collector:v0.5.4")
 for image in "${COMMON_IMAGES_LIST[@]}"; do
     for i in `seq 3`; do
         docker pull $image && break

--- a/cmd/flow-aggregator/flow-aggregator.go
+++ b/cmd/flow-aggregator/flow-aggregator.go
@@ -17,7 +17,6 @@ package main
 import (
 	"fmt"
 	"hash/fnv"
-	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -116,15 +115,12 @@ func run(o *Options) error {
 	if err != nil {
 		return fmt.Errorf("error when creating aggregation process: %v", err)
 	}
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go flowAggregator.Run(stopCh, &wg)
+	go flowAggregator.Run(stopCh)
 
 	informerFactory.Start(stopCh)
 
 	<-stopCh
 	klog.Infof("Stopping flow aggregator")
-	wg.Wait()
 	return nil
 }
 

--- a/pkg/flowaggregator/flowaggregator.go
+++ b/pkg/flowaggregator/flowaggregator.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/vmware/go-ipfix/pkg/collector"
@@ -362,8 +361,7 @@ func (fa *flowAggregator) initExportingProcess() error {
 	return nil
 }
 
-func (fa *flowAggregator) Run(stopCh <-chan struct{}, wg *sync.WaitGroup) {
-	defer wg.Done()
+func (fa *flowAggregator) Run(stopCh <-chan struct{}) {
 	go fa.collectingProcess.Start()
 	defer fa.collectingProcess.Stop()
 	go fa.aggregationProcess.Start()

--- a/test/e2e/flowaggregator_test.go
+++ b/test/e2e/flowaggregator_test.go
@@ -15,7 +15,6 @@
 package e2e
 
 import (
-	"context"
 	"fmt"
 	"net"
 	"regexp"
@@ -120,7 +119,6 @@ const (
 	testIngressRuleName            = "test-ingress-rule-name"
 	testEgressRuleName             = "test-egress-rule-name"
 	iperfTimeSec                   = 12
-	connCheckInterval              = 10 * time.Second
 )
 
 var (
@@ -175,15 +173,11 @@ func TestFlowAggregator(t *testing.T) {
 	}
 
 	if v4Enabled {
-		t.Run("IPv4", func(t *testing.T) {
-			testHelper(t, data, podAIPs, podBIPs, podCIPs, podDIPs, podEIPs, false)
-		})
+		t.Run("IPv4", func(t *testing.T) { testHelper(t, data, podAIPs, podBIPs, podCIPs, podDIPs, podEIPs, false) })
 	}
 
 	if v6Enabled {
-		t.Run("IPv6", func(t *testing.T) {
-			testHelper(t, data, podAIPs, podBIPs, podCIPs, podDIPs, podEIPs, true)
-		})
+		t.Run("IPv6", func(t *testing.T) { testHelper(t, data, podAIPs, podBIPs, podCIPs, podDIPs, podEIPs, true) })
 	}
 }
 
@@ -456,7 +450,25 @@ func testHelper(t *testing.T, data *TestData, podAIPs, podBIPs, podCIPs, podDIPs
 	// ToExternalFlows tests the export of IPFIX flow records when a source Pod
 	// sends traffic to an external IP
 	t.Run("ToExternalFlows", func(t *testing.T) {
-		runToExternalFlowsTest(t, data, isIPv6)
+		// Creating an agnhost server as a host network Pod
+		serverPodPort := int32(80)
+		_, serverIPs, cleanupFunc := createAndWaitForPod(t, data, func(name string, ns string, nodeName string) error {
+			return data.createServerPod(name, testNamespace, "", serverPodPort, false, true)
+		}, "test-server-", "", testNamespace)
+		defer cleanupFunc()
+
+		clientName, clientIPs, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", nodeName(0), testNamespace)
+		defer cleanupFunc()
+
+		if !isIPv6 {
+			if clientIPs.ipv4 != nil && serverIPs.ipv4 != nil {
+				checkRecordsForToExternalFlows(t, data, nodeName(0), clientName, clientIPs.ipv4.String(), serverIPs.ipv4.String(), serverPodPort, isIPv6)
+			}
+		} else {
+			if clientIPs.ipv6 != nil && serverIPs.ipv6 != nil {
+				checkRecordsForToExternalFlows(t, data, nodeName(0), clientName, clientIPs.ipv6.String(), serverIPs.ipv6.String(), serverPodPort, isIPv6)
+			}
+		}
 	})
 
 	// LocalServiceAccess tests the case, where Pod and Service are deployed on the same Node and their flow information is exported as IPFIX flow records.
@@ -486,54 +498,6 @@ func testHelper(t *testing.T, data *TestData, podAIPs, podBIPs, podCIPs, podDIPs
 			checkRecordsForFlows(t, data, podAIPs.ipv4.String(), svcC.Spec.ClusterIP, isServiceIPv6, false, true, false, false, checkBandwidth)
 		}
 	})
-
-	// RestartFlowAggregator tests the case where the Flow Aggregator stops: the Flow Exporter should
-	// be able to detect and stop sending records until the Flow Aggregator restarts.
-	t.Run("RestartFlowAggregator", func(t *testing.T) {
-		deleteFlowAggregatorPod(t, testData)
-		antreaPodName, err := data.getAntreaPodOnNode(nodeName(0))
-		if err != nil {
-			t.Errorf("Error when getting Antrea Pod name %v", err)
-		}
-		// Connection error should be detected either during periodical read check or when
-		// sending message to the collector.
-		errMsg1 := "Error when connecting to collector because connection is closed."
-		errMsg2 := "error when sending message on the connection"
-		err = wait.PollImmediate(500*time.Millisecond, connCheckInterval, func() (bool, error) {
-			command := fmt.Sprintf("kubectl logs --pod-running-timeout=%v %s -n kube-system -c antrea-agent --since=%s", connCheckInterval.String(), antreaPodName, connCheckInterval)
-			rc, agentOutput, _, err := provider.RunCommandOnNode(controlPlaneNodeName(), command)
-			if err != nil || rc != 0 {
-				return false, nil
-			}
-			return strings.Contains(agentOutput, errMsg1) || strings.Contains(agentOutput, errMsg2), nil
-		})
-		assert.NoError(t, err)
-		// Run a ToExternalFlowsTest to check whether data is collected correctly after
-		// restarting the Flow Aggregator
-		runToExternalFlowsTest(t, data, isIPv6)
-	})
-}
-
-func runToExternalFlowsTest(t *testing.T, data *TestData, isIPv6 bool) {
-	// Creating an agnhost server as a host network Pod
-	serverPodPort := int32(80)
-	_, serverIPs, cleanupFunc := createAndWaitForPod(t, data, func(name string, ns string, nodeName string) error {
-		return data.createServerPod(name, testNamespace, "", serverPodPort, false, true)
-	}, "test-server-", "", testNamespace)
-	defer cleanupFunc()
-
-	clientName, clientIPs, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", nodeName(0), testNamespace)
-	defer cleanupFunc()
-
-	if !isIPv6 {
-		if clientIPs.ipv4 != nil && serverIPs.ipv4 != nil {
-			checkRecordsForToExternalFlows(t, data, nodeName(0), clientName, clientIPs.ipv4.String(), serverIPs.ipv4.String(), serverPodPort, isIPv6)
-		}
-	} else {
-		if clientIPs.ipv6 != nil && serverIPs.ipv6 != nil {
-			checkRecordsForToExternalFlows(t, data, nodeName(0), clientName, clientIPs.ipv6.String(), serverIPs.ipv6.String(), serverPodPort, isIPv6)
-		}
-	}
 }
 
 func checkRecordsForFlows(t *testing.T, data *TestData, srcIP string, dstIP string, isIPv6 bool, isIntraNode bool, checkService bool, checkK8sNetworkPolicy bool, checkAntreaNetworkPolicy bool, checkBandwidth bool) {
@@ -824,17 +788,6 @@ func getRecordsFromOutput(output string) []string {
 	output = strings.TrimSpace(output)
 	recordSlices := strings.Split(output, "IPFIX-HDR:")
 	return recordSlices
-}
-
-func deleteFlowAggregatorPod(t *testing.T, data *TestData) {
-	pods, err := data.clientset.CoreV1().Pods(flowAggregatorNamespace).List(context.TODO(), metav1.ListOptions{})
-	if err != nil || len(pods.Items) != 1 {
-		t.Error("Error when getting the Flow Aggregator Pod.")
-	}
-	err = testData.deletePod(flowAggregatorNamespace, pods.Items[0].Name)
-	if err != nil {
-		t.Errorf("Error when deleting the Flow Aggregator Pod: %v", err)
-	}
 }
 
 func deployK8sNetworkPolicies(t *testing.T, data *TestData, srcPod, dstPod string) (np1 *networkingv1.NetworkPolicy, np2 *networkingv1.NetworkPolicy) {

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -104,7 +104,7 @@ const (
 	busyboxImage        = "projects.registry.vmware.com/library/busybox"
 	nginxImage          = "projects.registry.vmware.com/antrea/nginx"
 	perftoolImage       = "projects.registry.vmware.com/antrea/perftool"
-	ipfixCollectorImage = "projects.registry.vmware.com/antrea/ipfix-collector:v0.5.7"
+	ipfixCollectorImage = "projects.registry.vmware.com/antrea/ipfix-collector:v0.5.4"
 	ipfixCollectorPort  = "4739"
 
 	nginxLBService = "nginx-loadbalancer"
@@ -593,7 +593,7 @@ func (data *TestData) deployAntreaFlowExporter(ipfixCollector string) error {
 	return data.mutateAntreaConfigMap(nil, ac, false, true)
 }
 
-// deployFlowAggregator deploys the Flow Aggregator with ipfix collector address.
+// deployFlowAggregator deploys flow aggregator with ipfix collector address.
 func (data *TestData) deployFlowAggregator(ipfixCollector string) (string, error) {
 	flowAggYaml := flowAggregatorYML
 	if testOptions.enableCoverage {
@@ -601,7 +601,7 @@ func (data *TestData) deployFlowAggregator(ipfixCollector string) (string, error
 	}
 	rc, _, _, err := provider.RunCommandOnNode(controlPlaneNodeName(), fmt.Sprintf("kubectl apply -f %s", flowAggYaml))
 	if err != nil || rc != 0 {
-		return "", fmt.Errorf("error when deploying the Flow Aggregator; %s not available on the control-plane Node", flowAggYaml)
+		return "", fmt.Errorf("error when deploying flow aggregator; %s not available on the control-plane Node", flowAggYaml)
 	}
 	svc, err := data.clientset.CoreV1().Services(flowAggregatorNamespace).Get(context.TODO(), flowAggregatorDeployment, metav1.GetOptions{})
 	if err != nil {
@@ -613,7 +613,7 @@ func (data *TestData) deployFlowAggregator(ipfixCollector string) (string, error
 	if rc, _, _, err = provider.RunCommandOnNode(controlPlaneNodeName(), fmt.Sprintf("kubectl -n %s rollout status deployment/%s --timeout=%v", flowAggregatorNamespace, flowAggregatorDeployment, 2*defaultTimeout)); err != nil || rc != 0 {
 		_, stdout, _, _ := provider.RunCommandOnNode(controlPlaneNodeName(), fmt.Sprintf("kubectl -n %s describe pod", flowAggregatorNamespace))
 		_, logStdout, _, _ := provider.RunCommandOnNode(controlPlaneNodeName(), fmt.Sprintf("kubectl -n %s logs -l app=flow-aggregator", flowAggregatorNamespace))
-		return stdout, fmt.Errorf("error when waiting for the Flow Aggregator rollout to complete. kubectl describe output: %s, logs: %s", stdout, logStdout)
+		return stdout, fmt.Errorf("error when waiting for flow aggregator rollout to complete. kubectl describe output: %s, logs: %s", stdout, logStdout)
 	}
 	return svc.Spec.ClusterIP, nil
 }


### PR DESCRIPTION
Reverts antrea-io/antrea#2431

@zyiou I'm reverting this PR because I see a large number of failures for the new test, on both Kind and Jenkins testbeds

```
=== RUN   TestFlowAggregator/IPv4/RestartFlowAggregator
    flowaggregator_test.go:510: 
        	Error Trace:	flowaggregator_test.go:510
        	Error:      	Received unexpected error:
        	            	timed out waiting for the condition
        	Test:       	TestFlowAggregator/IPv4/RestartFlowAggregator
    fixtures.go:391: Deleting Pod 'test-client-h5dc1mpy'
    fixtures.go:391: Deleting Pod 'test-server-nsrch7ua'
```