### PR TITLE
[Windows] Update helper.psm1 to set env var for Windows FQDN

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -136,8 +136,8 @@ the legacy Antrea CRDs:
    two lists.
 
    ```bash
-   kubectl get lanp.security.antrea.tanzu.vmware.com -o=jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'
-   kubectl get anp.crd.antrea.io -o=jsonpath='{range .items[?(@.metadata.annotations.crd\.antrea\.io/managed-by=="crdmirroring-controller")]}{.metadata.name}{"\n"}{end}'
+   kubectl get lanp.security.antrea.tanzu.vmware.com -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'
+   kubectl get anp.crd.antrea.io -o jsonpath='{range .items[?(@.metadata.annotations.crd\.antrea\.io/managed-by=="crdmirroring-controller")]}{.metadata.name}{"\n"}{end}'
    ```
 
 3. Stop the old version of the application, which uses the legacy CRDs.
@@ -159,13 +159,13 @@ the legacy Antrea CRDs:
    the same command as before should return an empty list:
 
    ```bash
-   kubectl get anp.crd.antrea.io -o=jsonpath='{range .items[?(@.metadata.annotations.crd\.antrea\.io/managed-by=="crdmirroring-controller")]}{.metadata.name}{"\n"}{end}'
+   kubectl get anp.crd.antrea.io -o jsonpath='{range .items[?(@.metadata.annotations.crd\.antrea\.io/managed-by=="crdmirroring-controller")]}{.metadata.name}{"\n"}{end}'
    ```
 
    If you remove the filter, all your ANPs should still exist:
 
    ```bash
-   kubectl get anp.crd.antrea.io -o=jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'
+   kubectl get anp.crd.antrea.io -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'
    ```
 
 6. Safely delete all legacy CRDs previously managed by the application. As an
@@ -179,7 +179,7 @@ the legacy Antrea CRDs:
    Once again, all new ANPs should still exist, which can be confirmed with:
 
    ```bash
-   kubectl get anp.crd.antrea.io -o=jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'
+   kubectl get anp.crd.antrea.io -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'
    ```
 
 7. Start the new version of the application, which uses the new CRDs. All

--- a/hack/windows/Helper.psm1
+++ b/hack/windows/Helper.psm1
@@ -142,6 +142,12 @@ function Install-AntreaAgent {
     kubectl config --kubeconfig=$AntreaEtc\antrea-agent.antrea.kubeconfig set-credentials antrea-agent --token=$TOKEN
     kubectl config --kubeconfig=$AntreaEtc\antrea-agent.antrea.kubeconfig set-context antrea-agent@antrea --cluster=antrea --user=antrea-agent
     kubectl config --kubeconfig=$AntreaEtc\antrea-agent.antrea.kubeconfig use-context antrea-agent@antrea
+
+    $KUBE_DNS_SERVICE_HOST=$(kubectl --kubeconfig=$KubeConfig get service -n kube-system kube-dns -o jsonpath="{.spec.clusterIP}")
+    $KUBE_DNS_SERVICE_PORT=$(kubectl --kubeconfig=$KubeConfig get service -n kube-system kube-dns -o jsonpath="{.spec.ports[0].port}")
+    [System.Environment]::SetEnvironmentVariable('KUBE_DNS_SERVICE_HOST',$KUBE_DNS_SERVICE_HOST)
+    [System.Environment]::SetEnvironmentVariable('KUBE_DNS_SERVICE_PORT',$KUBE_DNS_SERVICE_PORT)
+
     return $true
 }
 

--- a/test/e2e/infra/vagrant/push_antrea.sh
+++ b/test/e2e/infra/vagrant/push_antrea.sh
@@ -165,7 +165,7 @@ if [ "$FLOW_AGGREGATOR" == "true" ]; then
             ssh -F ssh-config k8s-node-control-plane kubectl create namespace elk-flow-collector
             ssh -F ssh-config k8s-node-control-plane kubectl create configmap logstash-configmap -n elk-flow-collector --from-file=./elk-flow-collector/logstash/
             ssh -F ssh-config k8s-node-control-plane kubectl apply -f elk-flow-collector/elk-flow-collector.yml -n elk-flow-collector
-            LOGSTASH_CLUSTER_IP=$(ssh -F ssh-config k8s-node-control-plane kubectl get -n elk-flow-collector svc logstash -o=jsonpath='{.spec.clusterIP}')
+            LOGSTASH_CLUSTER_IP=$(ssh -F ssh-config k8s-node-control-plane kubectl get -n elk-flow-collector svc logstash -o jsonpath='{.spec.clusterIP}')
             ELK_ADDR="${LOGSTASH_CLUSTER_IP}:4739:udp"
 
             $THIS_DIR/../../../../hack/generate-manifest-flow-aggregator.sh --mode dev -fc $ELK_ADDR > "${FLOW_AGG_YML}"


### PR DESCRIPTION
* When Windows agents are started with script, not in a pod,
env var KUBE_DNS_SERVICE_HOST and KUBE_DNS_SERVICE_PORT
need to be set.
* Harmonize all '-o jsonpath' usage

Signed-off-by: Zhecheng Li <lzhecheng@vmware.com>