### PR TITLE
Stop forcing tunnel type to VXLAN for Kind NetworkPolicy tests

### DIFF
--- a/ci/kind/test-e2e-kind.sh
+++ b/ci/kind/test-e2e-kind.sh
@@ -108,10 +108,7 @@ fi
 if $endpointslice; then
     manifest_args="$manifest_args --endpointslice"
 fi
-if $np; then
-    # See https://github.com/antrea-io/antrea/issues/897
-    manifest_args="$manifest_args --tun vxlan"
-else
+if ! $np; then
     manifest_args="$manifest_args --no-np"
 fi
 


### PR DESCRIPTION
A patch was merged in upstream OVS and we picked up this patch when we
upgraded to OVS 2.15.1.

Fixes #897

Signed-off-by: Antonin Bas <abas@vmware.com>