### PR TITLE
Do not use the iptables NOTRACK target if not available

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -4309,6 +4309,9 @@ spec:
           readOnly: true
         - mountPath: /run/xtables.lock
           name: xtables-lock
+        - mountPath: /lib/modules
+          name: host-lib-modules
+          readOnly: true
       - args:
         - --log_file_max_size=100
         - --log_file_max_num=4

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -4311,6 +4311,9 @@ spec:
           readOnly: true
         - mountPath: /run/xtables.lock
           name: xtables-lock
+        - mountPath: /lib/modules
+          name: host-lib-modules
+          readOnly: true
       - args:
         - --log_file_max_size=100
         - --log_file_max_num=4

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -4309,6 +4309,9 @@ spec:
           readOnly: true
         - mountPath: /run/xtables.lock
           name: xtables-lock
+        - mountPath: /lib/modules
+          name: host-lib-modules
+          readOnly: true
       - args:
         - --log_file_max_size=100
         - --log_file_max_num=4

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -4358,6 +4358,9 @@ spec:
           readOnly: true
         - mountPath: /run/xtables.lock
           name: xtables-lock
+        - mountPath: /lib/modules
+          name: host-lib-modules
+          readOnly: true
       - args:
         - --log_file_max_size=100
         - --log_file_max_num=4

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -4314,6 +4314,9 @@ spec:
           readOnly: true
         - mountPath: /run/xtables.lock
           name: xtables-lock
+        - mountPath: /lib/modules
+          name: host-lib-modules
+          readOnly: true
       - args:
         - --log_file_max_size=100
         - --log_file_max_num=4

--- a/build/yamls/base/agent.yml
+++ b/build/yamls/base/agent.yml
@@ -150,6 +150,10 @@ spec:
             mountPropagation: HostToContainer
           - name: xtables-lock
             mountPath: /run/xtables.lock
+          # For checking availability of some kernel modules.
+          - name: host-lib-modules
+            mountPath: /lib/modules
+            readOnly: true
         - name: antrea-ovs
           image: antrea
           resources:

--- a/pkg/agent/util/kmod/doc.go
+++ b/pkg/agent/util/kmod/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package kmod provides Go wrappers to inspect and manipulate Linux kernel modules.
+package kmod

--- a/pkg/agent/util/kmod/kmod.go
+++ b/pkg/agent/util/kmod/kmod.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 // Copyright 2021 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/agent/util/kmod/kmod_linux.go
+++ b/pkg/agent/util/kmod/kmod_linux.go
@@ -1,0 +1,101 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kmod
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+func modulesDir() (string, error) {
+	var unameBuf unix.Utsname
+	if err := unix.Uname(&unameBuf); err != nil {
+		return "", err
+	}
+	// unameBuf.Release is a fixed-size 65-byte array, we need to remove the trailing null
+	// characters from it first.
+	kernelVersionStr := string(bytes.TrimRight(unameBuf.Release[:], "\x00"))
+	return path.Join("/lib/modules", kernelVersionStr), nil
+}
+
+func searchBuiltinModules(modulesDir string, suffix string) (bool, error) {
+	builtinFile := path.Join(modulesDir, "modules.builtin")
+	f, err := os.Open(builtinFile)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+
+	// Splits on newlines by default.
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		if strings.Contains(scanner.Text(), suffix) {
+			return true, nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return false, err
+	}
+	return false, nil
+}
+
+// CheckIfKernelModuleExists checks if a kernel module exists. It searches for the corresponding .ko
+// file in /lib/modules and, if includeBuiltinModules is true, it also searches through the list of
+// built-in modules. name is the name of the module. subPath limits the search to a specific
+// sub-directory; use an empty string if you are unsure about which value to provide.
+func CheckIfKernelModuleExists(name string, subPath string, includeBuiltinModules bool) (bool, error) {
+	dir, err := modulesDir()
+	if err != nil {
+		return false, fmt.Errorf("cannot determine modules directory: %w", err)
+	}
+	dir = path.Join(dir, subPath)
+	expectedSuffix := fmt.Sprintf("/%s.ko", name)
+
+	if includeBuiltinModules {
+		moduleFound, err := searchBuiltinModules(dir, expectedSuffix)
+		if err != nil {
+			return false, fmt.Errorf("error when searching in modules.builtin: %w", err)
+		}
+		if moduleFound {
+			return true, nil
+		}
+		// continue on to loadable modules
+	}
+
+	// sentinel error value used to end the walk early when the module file is found.
+	moduleFoundError := errors.New("ending walk early")
+	err = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if strings.HasSuffix(path, expectedSuffix) {
+			return moduleFoundError
+		}
+		return nil
+	})
+	if err != nil && err != moduleFoundError {
+		return false, fmt.Errorf("error when searching for module in %s: %w", dir, err)
+	}
+	return (err == moduleFoundError), nil
+}


### PR DESCRIPTION
We currently use this target to install rules which skip tracking of
encapsulated traffic (VXLAN / Geneve). In some rare instances the kernel
may not have been built with CONFIG_NETFILTER_XT_TARGET_CT, and
trying to install these rules can cause iptables-restore to fail during
Agent intialization on Linux.

See #2635

This patch checks for NOTRACK support by looking for the xt_CT module
(can be built-in or loadable). This requires /lib/modules to be mounted
to the antrea-agent container (read-only).

I considered the following alternatives to this solution:

* call modprobe with --dry-run: it essentially the same thing, with
  modprobe looking at modules.dep (instead of listing files) and
  modules.builtin
* use https://github.com/u-root/u-root/tree/master/pkg/kmodule: again
  essentially the same thing, but we add another dependency
* copy modules.dep and modules.builtin to /var/run/antrea in the
  initContainer, and read them from the antrea-agent. This avoids having
  to mount /lib/modules to the antrea-agent container, but does add an
  extra pre-requisite to run the Agent.
* look at the error of iptables-restore and re-attempt without the
  NOTRACK target rules: very clunky in my opinion.

I'm open to switching to one of these alternatives or to yet another
solution I haven't considered.

If the target is not available, we simply skip installing the rules as
they are for performance only and the Agent can still work without them.

Signed-off-by: Antonin Bas <abas@vmware.com>