### PR TITLE
Disable K8s dependency upgrades with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,6 @@ updates:
     open-pull-requests-limit: 5
     ignore:
     - dependency-name: "k8s.io/*"
-      update-types: ["version-update:semver-major", "version-update:semver-minor"] # ignore all except for patch updates
     - dependency-name: "github.com/vmware/go-ipfix"
     - dependency-name: "github.com/TomCodeLV/OVSDB-golang-lib"
     - dependency-name: "github.com/vmware-tanzu/octant"


### PR DESCRIPTION
Until Dependabot support grouped updates
(https://github.com/dependabot/dependabot-core/issues/1190), it's not
convenient to rely on Dependabot to upgrade K8s dependencies. So we will
continue doing it manually for now.

Signed-off-by: Antonin Bas <abas@vmware.com>