### PR TITLE
[Multicast] Multicast group auto-discovery

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -3989,6 +3989,9 @@ data:
     # Deployments and StatefulSets via IP Pool annotation.
     #  AntreaIPAM: false
 
+    # Enable multicast traffic. This feature is supported only with noEncap mode.
+    #  Multicast: false
+
     # Name of the OpenVSwitch bridge antrea-agent will create and use.
     # Make sure it doesn't conflict with your existing OpenVSwitch bridges.
     #ovsBridge: br-int
@@ -4269,7 +4272,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-6dtt4hkmmm
+  name: antrea-config-c5h558tg5g
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4340,7 +4343,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-6dtt4hkmmm
+          value: antrea-config-c5h558tg5g
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4391,7 +4394,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-6dtt4hkmmm
+          name: antrea-config-c5h558tg5g
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4672,7 +4675,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-6dtt4hkmmm
+          name: antrea-config-c5h558tg5g
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -3989,6 +3989,9 @@ data:
     # Deployments and StatefulSets via IP Pool annotation.
     #  AntreaIPAM: false
 
+    # Enable multicast traffic. This feature is supported only with noEncap mode.
+    #  Multicast: false
+
     # Name of the OpenVSwitch bridge antrea-agent will create and use.
     # Make sure it doesn't conflict with your existing OpenVSwitch bridges.
     #ovsBridge: br-int
@@ -4269,7 +4272,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-6dtt4hkmmm
+  name: antrea-config-c5h558tg5g
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4340,7 +4343,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-6dtt4hkmmm
+          value: antrea-config-c5h558tg5g
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4391,7 +4394,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-6dtt4hkmmm
+          name: antrea-config-c5h558tg5g
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4674,7 +4677,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-6dtt4hkmmm
+          name: antrea-config-c5h558tg5g
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -3989,6 +3989,9 @@ data:
     # Deployments and StatefulSets via IP Pool annotation.
     #  AntreaIPAM: false
 
+    # Enable multicast traffic. This feature is supported only with noEncap mode.
+    #  Multicast: false
+
     # Name of the OpenVSwitch bridge antrea-agent will create and use.
     # Make sure it doesn't conflict with your existing OpenVSwitch bridges.
     #ovsBridge: br-int
@@ -4269,7 +4272,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-25kc566684
+  name: antrea-config-h72246h8f2
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4340,7 +4343,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-25kc566684
+          value: antrea-config-h72246h8f2
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4391,7 +4394,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-25kc566684
+          name: antrea-config-h72246h8f2
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4675,7 +4678,7 @@ spec:
           path: /home/kubernetes/bin
         name: host-cni-bin
       - configMap:
-          name: antrea-config-25kc566684
+          name: antrea-config-h72246h8f2
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -3989,6 +3989,9 @@ data:
     # Deployments and StatefulSets via IP Pool annotation.
     #  AntreaIPAM: false
 
+    # Enable multicast traffic. This feature is supported only with noEncap mode.
+    #  Multicast: false
+
     # Name of the OpenVSwitch bridge antrea-agent will create and use.
     # Make sure it doesn't conflict with your existing OpenVSwitch bridges.
     #ovsBridge: br-int
@@ -4274,7 +4277,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-tc6kb6tbkh
+  name: antrea-config-557h844gdh
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4354,7 +4357,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-tc6kb6tbkh
+          value: antrea-config-557h844gdh
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4405,7 +4408,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-tc6kb6tbkh
+          name: antrea-config-557h844gdh
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4721,7 +4724,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-tc6kb6tbkh
+          name: antrea-config-557h844gdh
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-kind.yml
+++ b/build/yamls/antrea-kind.yml
@@ -3989,6 +3989,9 @@ data:
     # Deployments and StatefulSets via IP Pool annotation.
     #  AntreaIPAM: false
 
+    # Enable multicast traffic. This feature is supported only with noEncap mode.
+    #  Multicast: false
+
     # Name of the OpenVSwitch bridge antrea-agent will create and use.
     # Make sure it doesn't conflict with your existing OpenVSwitch bridges.
     #ovsBridge: br-int
@@ -4274,7 +4277,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-d4hfbm5d8h
+  name: antrea-config-f7dbh45mc5
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4345,7 +4348,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-d4hfbm5d8h
+          value: antrea-config-f7dbh45mc5
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4396,7 +4399,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-d4hfbm5d8h
+          name: antrea-config-f7dbh45mc5
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4673,7 +4676,7 @@ spec:
           type: CharDevice
         name: dev-tun
       - configMap:
-          name: antrea-config-d4hfbm5d8h
+          name: antrea-config-f7dbh45mc5
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -3989,6 +3989,9 @@ data:
     # Deployments and StatefulSets via IP Pool annotation.
     #  AntreaIPAM: false
 
+    # Enable multicast traffic. This feature is supported only with noEncap mode.
+    #  Multicast: false
+
     # Name of the OpenVSwitch bridge antrea-agent will create and use.
     # Make sure it doesn't conflict with your existing OpenVSwitch bridges.
     #ovsBridge: br-int
@@ -4274,7 +4277,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-786ttm24c7
+  name: antrea-config-gg2666bbdt
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4345,7 +4348,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-786ttm24c7
+          value: antrea-config-gg2666bbdt
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4396,7 +4399,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-786ttm24c7
+          name: antrea-config-gg2666bbdt
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4677,7 +4680,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-786ttm24c7
+          name: antrea-config-gg2666bbdt
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/base/conf/antrea-agent.conf
+++ b/build/yamls/base/conf/antrea-agent.conf
@@ -35,6 +35,9 @@ featureGates:
 # Deployments and StatefulSets via IP Pool annotation.
 #  AntreaIPAM: false
 
+# Enable multicast traffic. This feature is supported only with noEncap mode.
+#  Multicast: false
+
 # Name of the OpenVSwitch bridge antrea-agent will create and use.
 # Make sure it doesn't conflict with your existing OpenVSwitch bridges.
 #ovsBridge: br-int

--- a/pkg/agent/interfacestore/testing/mock_interfacestore.go
+++ b/pkg/agent/interfacestore/testing/mock_interfacestore.go
@@ -160,6 +160,21 @@ func (mr *MockInterfaceStoreMockRecorder) GetInterfaceByName(arg0 interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInterfaceByName", reflect.TypeOf((*MockInterfaceStore)(nil).GetInterfaceByName), arg0)
 }
 
+// GetInterfaceByOFPort mocks base method
+func (m *MockInterfaceStore) GetInterfaceByOFPort(arg0 uint32) (*interfacestore.InterfaceConfig, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetInterfaceByOFPort", arg0)
+	ret0, _ := ret[0].(*interfacestore.InterfaceConfig)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// GetInterfaceByOFPort indicates an expected call of GetInterfaceByOFPort
+func (mr *MockInterfaceStoreMockRecorder) GetInterfaceByOFPort(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInterfaceByOFPort", reflect.TypeOf((*MockInterfaceStore)(nil).GetInterfaceByOFPort), arg0)
+}
+
 // GetInterfaceKeysByType mocks base method
 func (m *MockInterfaceStore) GetInterfaceKeysByType(arg0 interfacestore.InterfaceType) []string {
 	m.ctrl.T.Helper()

--- a/pkg/agent/interfacestore/types.go
+++ b/pkg/agent/interfacestore/types.go
@@ -96,6 +96,7 @@ type InterfaceStore interface {
 	GetContainerInterfacesByPod(podName string, podNamespace string) []*InterfaceConfig
 	GetInterfaceByIP(interfaceIP string) (*InterfaceConfig, bool)
 	GetNodeTunnelInterface(nodeName string) (*InterfaceConfig, bool)
+	GetInterfaceByOFPort(ofPort uint32) (*InterfaceConfig, bool)
 	GetContainerInterfaceNum() int
 	GetInterfacesByType(interfaceType InterfaceType) []*InterfaceConfig
 	Len() int

--- a/pkg/agent/multicast/mcast_controller.go
+++ b/pkg/agent/multicast/mcast_controller.go
@@ -1,0 +1,365 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multicast
+
+import (
+	"net"
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+
+	"antrea.io/antrea/pkg/agent/config"
+	"antrea.io/antrea/pkg/agent/interfacestore"
+	"antrea.io/antrea/pkg/agent/openflow"
+)
+
+type eventType uint8
+
+const (
+	groupJoin eventType = iota
+	groupLeave
+
+	// Use IGMPv3 for IGMP query message because it is the main version for IGMP.
+	// TODO: support sending IGMP query with both v2 and v3 messages
+	queryVersion      = 3
+	podInterfaceIndex = "podInterface"
+
+	// How long to wait before retrying the processing of a multicast group change.
+	minRetryDelay = 5 * time.Second
+	maxRetryDelay = 300 * time.Second
+)
+
+var (
+	workerCount uint8 = 2
+)
+
+type mcastGroupEvent struct {
+	group net.IP
+	eType eventType
+	time  time.Time
+	iface *interfacestore.InterfaceConfig
+}
+
+type GroupMemberStatus struct {
+	group net.IP
+	// localMembers is a set for the local Pod's interface name which has joined in the multicast group.
+	localMembers   sets.String
+	lastIGMPReport time.Time
+	mutex          sync.RWMutex
+}
+
+// eventHandler process the multicast Group membership report or leave messages.
+func (c *Controller) eventHandler(stopCh <-chan struct{}) {
+	for {
+		select {
+		case e := <-c.groupEventCh:
+			c.addOrUpdateGroupEvent(e)
+		case <-stopCh:
+			return
+		}
+	}
+}
+
+// addGroupMemberStatus adds the new group into groupCache.
+func (c *Controller) addGroupMemberStatus(e *mcastGroupEvent) {
+	status := &GroupMemberStatus{
+		group:          e.group,
+		lastIGMPReport: e.time,
+		localMembers:   sets.NewString(e.iface.InterfaceName),
+	}
+	c.groupCache.Add(status)
+	c.queue.Add(e.group.String())
+	klog.InfoS("Added new multicast group to cache", "group", e.group, "interface", e.iface.InterfaceName)
+	return
+}
+
+// updateGroupMemberStatus updates the group status in groupCache. If a "join" message is sent from an existing member,
+// only updates the lastIGMPReport time. If a "join" message is sent from an "unknown" member, updates the lastIGMPReport time and
+// adds the new member into the group's local member set. If a "leave" message is sent from an existing member, removes
+// it from the group's local member set, and if the member is the last one in local cache, a query message on the group
+// is sent out to check if there are still local members in the group.
+func (c *Controller) updateGroupMemberStatus(obj interface{}, e *mcastGroupEvent) {
+	status := obj.(*GroupMemberStatus)
+	status.mutex.Lock()
+	defer status.mutex.Unlock()
+	newStatus := &GroupMemberStatus{
+		group:          status.group,
+		localMembers:   status.localMembers.Union(nil),
+		lastIGMPReport: status.lastIGMPReport,
+	}
+	exist := status.localMembers.Has(e.iface.InterfaceName)
+	switch e.eType {
+	case groupJoin:
+		newStatus.lastIGMPReport = e.time
+		if !exist {
+			newStatus.localMembers.Insert(e.iface.InterfaceName)
+			klog.InfoS("Added member to multicast group", "group", e.group.String(), "member", e.iface.InterfaceName)
+		}
+		c.groupCache.Update(newStatus)
+		c.queue.Add(newStatus.group.String())
+	case groupLeave:
+		if exist {
+			newStatus.localMembers.Delete(e.iface.InterfaceName)
+			c.groupCache.Update(newStatus)
+			klog.InfoS("Deleted member from multicast group", "group", e.group.String(), "member", e.iface.InterfaceName)
+			if len(newStatus.localMembers) == 0 {
+				klog.InfoS("Check last member in multicast group", "group", e.group.String(), "member", e.iface.InterfaceName)
+				c.checkLastMember(e.group)
+			}
+		}
+	}
+	return
+}
+
+// checkLastMember sends out a query message on the group to check if there are still members in the group. If no new
+// membership report is received in the max response time, the group is removed from groupCache.
+func (c *Controller) checkLastMember(group net.IP) {
+	err := c.igmpSnooper.queryIGMP(group, queryVersion)
+	if err != nil {
+		klog.ErrorS(err, "Failed to send IGMP query message", "group", group.String())
+		return
+	}
+	c.queue.AddAfter(group.String(), igmpMaxResponseTime)
+}
+
+// clearStaleGroups checks the stale groups which have not been updated for mcastGroupTimeout, and then notifies worker
+// to remove them from groupCache.
+func (c *Controller) clearStaleGroups() {
+	now := time.Now()
+	for _, obj := range c.groupCache.List() {
+		status := obj.(*GroupMemberStatus)
+		status.mutex.RLock()
+		diff := now.Sub(status.lastIGMPReport)
+		status.mutex.RUnlock()
+		if diff > mcastGroupTimeout {
+			c.queue.Add(status.group.String())
+		}
+	}
+}
+
+type Controller struct {
+	ofClient     openflow.Client
+	nodeConfig   *config.NodeConfig
+	igmpSnooper  *IGMPSnooper
+	groupEventCh chan *mcastGroupEvent
+	groupCache   cache.Indexer
+	queue        workqueue.RateLimitingInterface
+	// installedGroups saves the groups which are configured on both OVS and the host.
+	installedGroups      sets.String
+	installedGroupsMutex sync.RWMutex
+}
+
+func NewMulticastController(ofClient openflow.Client, nodeConfig *config.NodeConfig, ifaceStore interfacestore.InterfaceStore) *Controller {
+	eventCh := make(chan *mcastGroupEvent, workerCount)
+	groupSnooper := newSnooper(ofClient, ifaceStore, eventCh)
+	groupCache := cache.NewIndexer(getGroupEventKey, cache.Indexers{
+		podInterfaceIndex: podInterfaceIndexFunc,
+	})
+	return &Controller{
+		ofClient:        ofClient,
+		nodeConfig:      nodeConfig,
+		igmpSnooper:     groupSnooper,
+		groupEventCh:    eventCh,
+		groupCache:      groupCache,
+		installedGroups: sets.NewString(),
+		queue:           workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(minRetryDelay, maxRetryDelay), "multicastgroup"),
+	}
+}
+
+func (c *Controller) Initialize() error {
+	// Install flows on OVS for IGMP packets and multicast traffic forwarding:
+	// 1) send the IGMP report messages to Antrea Agent,
+	// 2) forward the IMGP query messages to all local Pods,
+	// 3) forward the multicast traffic to antrea-gw0 if no local Pods have joined in the group, and this is to ensure
+	//    local Pods can access the external multicast receivers.
+	err := c.ofClient.InstallMulticastInitialFlows(uint8(openflow.PacketInReasonMC))
+	if err != nil {
+		klog.ErrorS(err, "Failed to install multicast initial flows")
+		return err
+	}
+	return nil
+}
+
+func (c *Controller) Run(stopCh <-chan struct{}) {
+	// Periodically query Multicast Groups on OVS.
+	go wait.NonSlidingUntil(func() {
+		if err := c.igmpSnooper.queryIGMP(net.IPv4zero, queryVersion); err != nil {
+			klog.ErrorS(err, "Failed to send IGMP query")
+		}
+	}, queryInterval, stopCh)
+
+	// Periodically check the group member status, and remove the groups in which no members exist
+	go wait.NonSlidingUntil(c.clearStaleGroups, queryInterval, stopCh)
+
+	go c.eventHandler(stopCh)
+
+	for i := 0; i < int(workerCount); i++ {
+		// Process multicast Group membership report or leave messages.
+		go wait.Until(c.worker, time.Second, stopCh)
+	}
+}
+
+func (c *Controller) worker() {
+	for c.processNextWorkItem() {
+	}
+}
+
+// getGroupMemberStatusByGroup returns the GroupMemberStatus according to the given group.
+func (c *Controller) getGroupMemberStatusByGroup(group net.IP) *GroupMemberStatus {
+	status, ok, _ := c.groupCache.GetByKey(group.String())
+	if ok {
+		return status.(*GroupMemberStatus)
+	}
+	return nil
+}
+
+// getGroupMemberStatusesByPod returns all GroupMemberStatus that the given podInterface is included in its localMembers.
+func (c *Controller) getGroupMemberStatusesByPod(podInterface string) []*GroupMemberStatus {
+	groupMembers := make([]*GroupMemberStatus, 0)
+	statuses, _ := c.groupCache.ByIndex(podInterfaceIndex, podInterface)
+	for _, s := range statuses {
+		groupMembers = append(groupMembers, s.(*GroupMemberStatus))
+	}
+	return groupMembers
+}
+
+func (c *Controller) processNextWorkItem() bool {
+	obj, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(obj)
+
+	// We expect string (multicast group) to come off the workqueue.
+	if key, ok := obj.(string); !ok {
+		// As the item in the workqueue is actually invalid, we call Forget here else we'd
+		// go into a loop of attempting to process a work item that is invalid.
+		// This should not happen.
+		c.queue.Forget(obj)
+		klog.Errorf("Expected string in work queue but got %#v", obj)
+		return true
+	} else if err := c.syncGroup(key); err == nil {
+		// If no error occurs we Forget this item so it does not get queued again until
+		// another change happens.
+		c.queue.Forget(key)
+	} else {
+		// Put the item back on the workqueue to handle any transient errors.
+		c.queue.AddRateLimited(key)
+		klog.Errorf("Error syncing multicast group %s, requeuing. Error: %v", key, err)
+	}
+	return true
+
+}
+
+func (c *Controller) syncGroup(groupKey string) error {
+	startTime := time.Now()
+	defer func() {
+		klog.V(4).Infof("Finished syncing GroupMemberStatus for %s. (%v)", groupKey, time.Since(startTime))
+	}()
+	obj, exists, err := c.groupCache.GetByKey(groupKey)
+	if err != nil {
+		klog.ErrorS(err, "Failed to get GroupMemberStatus", "group", groupKey)
+		return err
+	}
+	if !exists {
+		klog.InfoS("multicast group not found in the cache", "group", groupKey)
+		return nil
+	}
+	status := obj.(*GroupMemberStatus)
+	if c.groupHasInstalled(groupKey) {
+		status.mutex.Lock()
+		defer status.mutex.Unlock()
+		if c.groupIsStale(status) {
+			// Remove the multicast flow entry if no local Pod is in the group.
+			if err := c.ofClient.UninstallMulticastFlow(status.group); err != nil {
+				klog.ErrorS(err, "Failed to uninstall multicast flows", "group", groupKey)
+				return err
+			}
+			c.delInstalledGroup(groupKey)
+			c.groupCache.Delete(status)
+			klog.InfoS("Removed multicast group from cache after all members left", "group", groupKey)
+		}
+		return nil
+	}
+	if err := c.ofClient.InstallMulticastFlow(status.group); err != nil {
+		klog.ErrorS(err, "Failed to install multicast flows", "group", status.group)
+		return err
+	}
+	c.addInstalledGroup(groupKey)
+	return nil
+}
+
+// groupIsStale returns true if no local members in the group, or there is no IGMP report received after mcastGroupTimeout.
+func (c *Controller) groupIsStale(status *GroupMemberStatus) bool {
+	membersCount := len(status.localMembers)
+	diff := time.Now().Sub(status.lastIGMPReport)
+	if membersCount == 0 || diff > mcastGroupTimeout {
+		return true
+	}
+	return false
+}
+
+func (c *Controller) groupHasInstalled(groupKey string) bool {
+	c.installedGroupsMutex.RLock()
+	defer c.installedGroupsMutex.RUnlock()
+	return c.installedGroups.Has(groupKey)
+}
+
+func (c *Controller) addInstalledGroup(groupKey string) {
+	c.installedGroupsMutex.Lock()
+	c.installedGroups.Insert(groupKey)
+	c.installedGroupsMutex.Unlock()
+}
+
+func (c *Controller) delInstalledGroup(groupKey string) {
+	c.installedGroupsMutex.Lock()
+	c.installedGroups.Delete(groupKey)
+	c.installedGroupsMutex.Unlock()
+}
+
+func (c *Controller) addOrUpdateGroupEvent(e *mcastGroupEvent) {
+	obj, ok, _ := c.groupCache.GetByKey(e.group.String())
+	switch e.eType {
+	case groupJoin:
+		if !ok {
+			c.addGroupMemberStatus(e)
+		} else {
+			c.updateGroupMemberStatus(obj, e)
+		}
+	case groupLeave:
+		if ok {
+			c.updateGroupMemberStatus(obj, e)
+		}
+	}
+}
+
+func podInterfaceIndexFunc(obj interface{}) ([]string, error) {
+	groupState := obj.(*GroupMemberStatus)
+	podInterfaces := make([]string, 0, len(groupState.localMembers))
+	for podInterface := range groupState.localMembers {
+		podInterfaces = append(podInterfaces, podInterface)
+	}
+	return podInterfaces, nil
+}
+
+func getGroupEventKey(obj interface{}) (string, error) {
+	groupState := obj.(*GroupMemberStatus)
+	return groupState.group.String(), nil
+}

--- a/pkg/agent/multicast/mcast_controller_test.go
+++ b/pkg/agent/multicast/mcast_controller_test.go
@@ -1,0 +1,251 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multicast
+
+import (
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"antrea.io/libOpenflow/openflow13"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/cache"
+
+	"antrea.io/antrea/pkg/agent/config"
+	"antrea.io/antrea/pkg/agent/interfacestore"
+	ifaceStoretest "antrea.io/antrea/pkg/agent/interfacestore/testing"
+	openflowtest "antrea.io/antrea/pkg/agent/openflow/testing"
+)
+
+var (
+	mockOFClient   *openflowtest.MockClient
+	mockIfaceStore *ifaceStoretest.MockInterfaceStore
+	mgroup         = net.ParseIP("224.96.1.3")
+	if1            = &interfacestore.InterfaceConfig{
+		Type:          interfacestore.ContainerInterface,
+		InterfaceName: "if1",
+		IPs:           []net.IP{net.ParseIP("192.168.1.1")},
+	}
+	if2 = &interfacestore.InterfaceConfig{
+		Type:          interfacestore.ContainerInterface,
+		InterfaceName: "if2",
+		IPs:           []net.IP{net.ParseIP("192.168.1.2")},
+	}
+)
+
+func TestAddGroupMemberStatus(t *testing.T) {
+	event := &mcastGroupEvent{
+		group: mgroup,
+		eType: groupJoin,
+		time:  time.Now(),
+		iface: if1,
+	}
+	mctrl := newMockMulticastController(t)
+	mctrl.addGroupMemberStatus(event)
+	groupCache := mctrl.groupCache
+	compareGroupStatus(t, groupCache, event)
+	obj, _ := mctrl.queue.Get()
+	key, ok := obj.(string)
+	assert.True(t, ok)
+	assert.Equal(t, mgroup.String(), key)
+	mockOFClient.EXPECT().InstallMulticastFlow(mgroup).Times(1)
+	err := mctrl.syncGroup(key)
+	assert.Nil(t, err)
+	mctrl.queue.Forget(obj)
+}
+
+func TestUpdateGroupMemberStatus(t *testing.T) {
+	mctrl := newMockMulticastController(t)
+	igmpMaxResponseTime = time.Second * 1
+	event := &mcastGroupEvent{
+		group: mgroup,
+		eType: groupJoin,
+		time:  time.Now(),
+		iface: if1,
+	}
+	mctrl.addGroupMemberStatus(event)
+	obj, _, _ := mctrl.groupCache.GetByKey(event.group.String())
+	mockOFClient.EXPECT().SendIGMPQueryPacketOut(igmpQueryDstMac, mcastAllHosts, uint32(openflow13.P_NORMAL), gomock.Any()).Times(1)
+	for _, e := range []*mcastGroupEvent{
+		{group: mgroup, eType: groupJoin, time: event.time.Add(time.Second * 20), iface: if1},
+		{group: mgroup, eType: groupJoin, time: event.time.Add(time.Second * 40), iface: if1},
+		{group: mgroup, eType: groupJoin, time: event.time.Add(time.Second * 60), iface: if2},
+		{group: mgroup, eType: groupLeave, time: event.time.Add(time.Second * 61), iface: if1},
+		{group: mgroup, eType: groupLeave, time: event.time.Add(time.Second * 62), iface: if2},
+	} {
+		mctrl.updateGroupMemberStatus(obj, e)
+		groupCache := mctrl.groupCache
+		compareGroupStatus(t, groupCache, e)
+		groups := mctrl.getGroupMemberStatusesByPod(e.iface.InterfaceName)
+		if e.eType == groupJoin {
+			assert.True(t, len(groups) > 0)
+		} else {
+			assert.True(t, len(groups) == 0)
+		}
+	}
+}
+
+func TestCheckLastMember(t *testing.T) {
+	mctrl := newMockMulticastController(t)
+	workerCount = 1
+	igmpMaxResponseTime = time.Second * 1
+	lastProbe := time.Now()
+	testCheckLastMember := func(ev *mcastGroupEvent, expExist bool) {
+		status := &GroupMemberStatus{
+			localMembers:   sets.NewString(),
+			lastIGMPReport: lastProbe,
+		}
+		if ev != nil {
+			status.group = ev.group
+		} else {
+			status.group = mgroup
+		}
+		_ = mctrl.groupCache.Add(status)
+		mctrl.addInstalledGroup(status.group.String())
+		mockOFClient.EXPECT().SendIGMPQueryPacketOut(igmpQueryDstMac, mcastAllHosts, uint32(openflow13.P_NORMAL), gomock.Any()).AnyTimes()
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			mctrl.checkLastMember(status.group)
+			// Wait igmpMaxResponseTime to ensure the group is added into mctrl.queue.
+			time.Sleep(igmpMaxResponseTime)
+			wg.Done()
+		}()
+		if ev != nil {
+			mctrl.addOrUpdateGroupEvent(ev)
+		}
+		wg.Wait()
+		obj, _ := mctrl.queue.Get()
+		key, ok := obj.(string)
+		assert.True(t, ok)
+		assert.Equal(t, status.group.String(), key)
+		err := mctrl.syncGroup(key)
+		assert.Nil(t, err)
+		_, exists, err := mctrl.groupCache.GetByKey(key)
+		assert.Nil(t, err)
+		assert.Equal(t, expExist, exists)
+		// Clear cache to avoid affecting the next test.
+		if _, ok, _ := mctrl.groupCache.GetByKey(key); ok {
+			_ = mctrl.groupCache.Delete(status)
+		}
+		mctrl.queue.Forget(obj)
+	}
+	mockOFClient.EXPECT().UninstallMulticastFlow(gomock.Any()).Times(2)
+	for _, tc := range []struct {
+		ev     *mcastGroupEvent
+		exists bool
+	}{
+		{ev: &mcastGroupEvent{group: net.ParseIP("224.96.1.5"), eType: groupJoin, time: lastProbe.Add(time.Second * 1), iface: if1}, exists: true},
+		{ev: &mcastGroupEvent{group: net.ParseIP("224.96.1.6"), eType: groupLeave, time: lastProbe.Add(time.Second * 1), iface: if1}, exists: false},
+		{ev: nil, exists: false},
+	} {
+		testCheckLastMember(tc.ev, tc.exists)
+	}
+}
+
+func TestClearStaleGroups(t *testing.T) {
+	mctrl := newMockMulticastController(t)
+	workerCount = 1
+
+	mockOFClient.EXPECT().InstallMulticastInitialFlows(gomock.Any()).Times(1)
+	err := mctrl.Initialize()
+	assert.Nil(t, err)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		mctrl.worker()
+		wg.Done()
+	}()
+
+	now := time.Now()
+	validGroups := []*GroupMemberStatus{
+		{
+			group:          net.ParseIP("224.96.1.2"),
+			localMembers:   sets.NewString("p1", "p2"),
+			lastIGMPReport: now.Add(-queryInterval),
+		},
+		{
+			group:          net.ParseIP("224.96.1.3"),
+			localMembers:   sets.NewString(),
+			lastIGMPReport: now.Add(-queryInterval),
+		},
+	}
+	staleGroups := []*GroupMemberStatus{
+		{
+			group:          net.ParseIP("224.96.1.4"),
+			localMembers:   sets.NewString("p1", "p3"),
+			lastIGMPReport: now.Add(-mcastGroupTimeout - time.Second),
+		},
+		{
+			group:          net.ParseIP("224.96.1.5"),
+			localMembers:   sets.NewString(),
+			lastIGMPReport: now.Add(-mcastGroupTimeout - time.Second),
+		},
+	}
+	for _, g := range validGroups {
+		err := mctrl.groupCache.Add(g)
+		assert.Nil(t, err)
+		mctrl.addInstalledGroup(g.group.String())
+	}
+	for _, g := range staleGroups {
+		err := mctrl.groupCache.Add(g)
+		assert.Nil(t, err)
+		mctrl.addInstalledGroup(g.group.String())
+	}
+	mockOFClient.EXPECT().UninstallMulticastFlow(gomock.Any()).Times(len(staleGroups))
+	mctrl.clearStaleGroups()
+	mctrl.queue.ShutDown()
+	wg.Wait()
+	assert.Equal(t, len(validGroups), len(mctrl.groupCache.List()))
+	for _, g := range validGroups {
+		_, exists, _ := mctrl.groupCache.GetByKey(g.group.String())
+		assert.True(t, exists)
+	}
+	for _, g := range staleGroups {
+		_, exists, _ := mctrl.groupCache.GetByKey(g.group.String())
+		assert.False(t, exists)
+	}
+}
+
+func compareGroupStatus(t *testing.T, cache cache.Indexer, event *mcastGroupEvent) {
+	obj, exits, err := cache.GetByKey(event.group.String())
+	assert.Nil(t, err)
+	assert.Truef(t, exits, "failed to add group to cache")
+	status, ok := obj.(*GroupMemberStatus)
+	assert.Equal(t, true, ok)
+	assert.Equal(t, event.group, status.group)
+	if event.eType == groupJoin {
+		assert.True(t, status.lastIGMPReport.Equal(event.time) || status.lastIGMPReport.After(event.time))
+		exists := status.localMembers.Has(event.iface.InterfaceName)
+		assert.Truef(t, exists, "member is not added into cache")
+	} else {
+		assert.True(t, status.lastIGMPReport.Before(event.time))
+		exists := status.localMembers.Has(event.iface.InterfaceName)
+		assert.Falsef(t, exists, "member is not removed from cache")
+	}
+}
+
+func newMockMulticastController(t *testing.T) *Controller {
+	controller := gomock.NewController(t)
+	mockOFClient = openflowtest.NewMockClient(controller)
+	mockIfaceStore = ifaceStoretest.NewMockInterfaceStore(controller)
+	nodeConfig := &config.NodeConfig{}
+	mockOFClient.EXPECT().RegisterPacketInHandler(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+	return NewMulticastController(mockOFClient, nodeConfig, mockIfaceStore)
+}

--- a/pkg/agent/multicast/mcast_discovery.go
+++ b/pkg/agent/multicast/mcast_discovery.go
@@ -1,0 +1,239 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multicast
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"time"
+
+	"antrea.io/libOpenflow/openflow13"
+	"antrea.io/libOpenflow/protocol"
+	"antrea.io/libOpenflow/util"
+	"antrea.io/ofnet/ofctrl"
+	"k8s.io/klog/v2"
+
+	"antrea.io/antrea/pkg/agent/interfacestore"
+	"antrea.io/antrea/pkg/agent/openflow"
+)
+
+const (
+	IGMPProtocolNumber = 2
+)
+
+const (
+	// queryInterval is the interval to send IGMP query messages.
+	queryInterval = time.Second * 125
+	// mcastGroupTimeout is the timeout to detect a group as stale if no IGMP report is received within the time.
+	mcastGroupTimeout = queryInterval * 3
+)
+
+var (
+	// igmpMaxResponseTime is the maximum time allowed before sending a responding report which is used for the
+	// "Max Resp Code" field in the IGMP query message. It is also the maximum time to wait for the IGMP report message
+	// when checking the last group member.
+	igmpMaxResponseTime = time.Second * 10
+	// igmpQueryDstMac is the MAC address used in the dst MAC field in the IGMP query message
+	igmpQueryDstMac, _ = net.ParseMAC("01:00:5e:00:00:01")
+	mcastAllHosts      = net.ParseIP("224.0.0.1").To4()
+)
+
+type IGMPSnooper struct {
+	ofClient   openflow.Client
+	ifaceStore interfacestore.InterfaceStore
+	eventCh    chan *mcastGroupEvent
+}
+
+func (s *IGMPSnooper) HandlePacketIn(pktIn *ofctrl.PacketIn) error {
+	matches := pktIn.GetMatches()
+	// Get custom reasons in this packet-in.
+	match := matches.GetMatchByName(openflow.CustomReasonField.GetNXFieldName())
+	customReasons, err := getInfoInReg(match, openflow.CustomReasonField.GetRange().ToNXRange())
+	if err != nil {
+		klog.ErrorS(err, "Received error while unloading customReason from OVS reg", "regField", openflow.CustomReasonField.GetName())
+		return err
+	}
+	if customReasons&openflow.CustomReasonIGMP == openflow.CustomReasonIGMP {
+		return s.processPacketIn(pktIn)
+	}
+	return nil
+}
+
+func getInfoInReg(regMatch *ofctrl.MatchField, rng *openflow13.NXRange) (uint32, error) {
+	regValue, ok := regMatch.GetValue().(*ofctrl.NXRegister)
+	if !ok {
+		return 0, errors.New("register value cannot be retrieved")
+	}
+	if rng != nil {
+		return ofctrl.GetUint32ValueWithRange(regValue.Data, rng), nil
+	}
+	return regValue.Data, nil
+}
+
+func (s *IGMPSnooper) parseSrcInterface(pktIn *ofctrl.PacketIn) (*interfacestore.InterfaceConfig, error) {
+	matches := pktIn.GetMatches()
+	ofPortField := matches.GetMatchByName("OXM_OF_IN_PORT")
+	if ofPortField == nil {
+		return nil, errors.New("in_port field not found")
+	}
+	ofPort := ofPortField.GetValue().(uint32)
+	ifaceConfig, found := s.ifaceStore.GetInterfaceByOFPort(ofPort)
+	if !found {
+		return nil, errors.New("target Pod not found")
+	}
+	return ifaceConfig, nil
+}
+
+func (s *IGMPSnooper) queryIGMP(group net.IP, version uint8) error {
+	igmp, err := generateIGMPQueryPacket(group, version)
+	if err != nil {
+		return err
+	}
+	if err := s.ofClient.SendIGMPQueryPacketOut(igmpQueryDstMac, mcastAllHosts, openflow13.P_NORMAL, igmp); err != nil {
+		return err
+	}
+	klog.V(2).InfoS("Sent packetOut form IGMP query", "group", group.String(), "version", version)
+	return nil
+}
+
+func (s *IGMPSnooper) processPacketIn(pktIn *ofctrl.PacketIn) error {
+	now := time.Now()
+	iface, err := s.parseSrcInterface(pktIn)
+	if err != nil {
+		return err
+	}
+	klog.V(2).InfoS("Received PacketIn for IGMP packet", "in_port", iface.OFPort)
+	igmp, err := parseIGMPPacket(pktIn.Data)
+	if err != nil {
+		return err
+	}
+	switch igmp.GetMessageType() {
+	case protocol.IGMPv1Report:
+		fallthrough
+	case protocol.IGMPv2Report:
+		mgroup := igmp.(*protocol.IGMPv1or2).GroupAddress
+		klog.InfoS("Received IGMPv1or2 Report message", "group", mgroup.String(), "interface", iface.PodName)
+		event := &mcastGroupEvent{
+			group: mgroup,
+			eType: groupJoin,
+			time:  now,
+			iface: iface,
+		}
+		s.eventCh <- event
+	case protocol.IGMPv3Report:
+		msg := igmp.(*protocol.IGMPv3MembershipReport)
+		for _, gr := range msg.GroupRecords {
+			mgroup := gr.MulticastAddress
+			klog.InfoS("Received IGMPv3 Report message", "group", mgroup.String(), "interface", iface.PodName)
+			event := &mcastGroupEvent{
+				group: mgroup,
+				eType: groupJoin,
+				time:  now,
+				iface: iface,
+			}
+			s.eventCh <- event
+		}
+
+	case protocol.IGMPv2LeaveGroup:
+		mgroup := igmp.(*protocol.IGMPv1or2).GroupAddress
+		klog.InfoS("Received IGMPv2 Leave message", "group", mgroup.String(), "interface", iface.PodName)
+		event := &mcastGroupEvent{
+			group: mgroup,
+			eType: groupLeave,
+			time:  now,
+			iface: iface,
+		}
+		s.eventCh <- event
+	}
+	return nil
+}
+
+func generateIGMPQueryPacket(group net.IP, version uint8) (util.Message, error) {
+	// The max response time field in IGMP protocol uses a value in units of 1/10 second.
+	// See https://datatracker.ietf.org/doc/html/rfc2236 and https://datatracker.ietf.org/doc/html/rfc3376
+	respTime := uint8(igmpMaxResponseTime.Seconds() * 10)
+	switch version {
+	case 1:
+		return &protocol.IGMPv1or2{
+			Type:            protocol.IGMPQuery,
+			MaxResponseTime: 0,
+			Checksum:        0,
+			GroupAddress:    group,
+		}, nil
+	case 2:
+		return &protocol.IGMPv1or2{
+			Type:            protocol.IGMPQuery,
+			MaxResponseTime: respTime,
+			Checksum:        0,
+			GroupAddress:    group,
+		}, nil
+	case 3:
+		return &protocol.IGMPv3Query{
+			Type:                     protocol.IGMPQuery,
+			MaxResponseTime:          respTime,
+			GroupAddress:             group,
+			SuppressRouterProcessing: false,
+			RobustnessValue:          0,
+			IntervalTime:             uint8(queryInterval.Seconds()),
+			NumberOfSources:          0,
+		}, nil
+	}
+	return nil, fmt.Errorf("unsupported IGMP version %d", version)
+}
+
+func parseIGMPPacket(pkt protocol.Ethernet) (protocol.IGMPMessage, error) {
+	if pkt.Ethertype != protocol.IPv4_MSG {
+		return nil, errors.New("not IPv4 packet")
+	}
+	ipPacket, ok := pkt.Data.(*protocol.IPv4)
+	if !ok {
+		return nil, errors.New("failed to parse IPv4 packet")
+	}
+	if ipPacket.Protocol != IGMPProtocolNumber {
+		return nil, errors.New("not IGMP packet")
+	}
+	data, _ := ipPacket.Data.MarshalBinary()
+	igmpLength := ipPacket.Length - uint16(4*ipPacket.IHL)
+	if igmpLength == 8 {
+		igmp := new(protocol.IGMPv1or2)
+		if err := igmp.UnmarshalBinary(data); err != nil {
+			return nil, err
+		}
+		return igmp, nil
+	}
+	switch data[0] {
+	case protocol.IGMPQuery:
+		igmp := new(protocol.IGMPv3Query)
+		if err := igmp.UnmarshalBinary(data); err != nil {
+			return nil, err
+		}
+		return igmp, nil
+	case protocol.IGMPv3Report:
+		igmp := new(protocol.IGMPv3MembershipReport)
+		if err := igmp.UnmarshalBinary(data); err != nil {
+			return nil, err
+		}
+		return igmp, nil
+	default:
+		return nil, errors.New("unknown igmp packet")
+	}
+}
+
+func newSnooper(ofClient openflow.Client, ifaceStore interfacestore.InterfaceStore, eventCh chan *mcastGroupEvent) *IGMPSnooper {
+	d := &IGMPSnooper{ofClient: ofClient, ifaceStore: ifaceStore, eventCh: eventCh}
+	ofClient.RegisterPacketInHandler(uint8(openflow.PacketInReasonMC), "MulticastGroupDiscovery", d)
+	return d
+}

--- a/pkg/agent/openflow/client_test.go
+++ b/pkg/agent/openflow/client_test.go
@@ -103,7 +103,7 @@ func TestIdempotentFlowInstallation(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
-			ofClient := NewClient(bridgeName, bridgeMgmtAddr, ovsconfig.OVSDatapathSystem, true, false, false, false, false, false)
+			ofClient := NewClient(bridgeName, bridgeMgmtAddr, ovsconfig.OVSDatapathSystem, true, false, false, false, false, false, false)
 			client := ofClient.(*client)
 			client.cookieAllocator = cookie.NewAllocator(0)
 			client.ofEntryOperations = m
@@ -132,7 +132,7 @@ func TestIdempotentFlowInstallation(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
-			ofClient := NewClient(bridgeName, bridgeMgmtAddr, ovsconfig.OVSDatapathSystem, true, false, false, false, false, false)
+			ofClient := NewClient(bridgeName, bridgeMgmtAddr, ovsconfig.OVSDatapathSystem, true, false, false, false, false, false, false)
 			client := ofClient.(*client)
 			client.cookieAllocator = cookie.NewAllocator(0)
 			client.ofEntryOperations = m
@@ -174,7 +174,7 @@ func TestFlowInstallationFailed(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
-			ofClient := NewClient(bridgeName, bridgeMgmtAddr, ovsconfig.OVSDatapathSystem, true, false, false, false, false, false)
+			ofClient := NewClient(bridgeName, bridgeMgmtAddr, ovsconfig.OVSDatapathSystem, true, false, false, false, false, false, false)
 			client := ofClient.(*client)
 			client.cookieAllocator = cookie.NewAllocator(0)
 			client.ofEntryOperations = m
@@ -209,7 +209,7 @@ func TestConcurrentFlowInstallation(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
-			ofClient := NewClient(bridgeName, bridgeMgmtAddr, ovsconfig.OVSDatapathSystem, true, false, false, false, false, false)
+			ofClient := NewClient(bridgeName, bridgeMgmtAddr, ovsconfig.OVSDatapathSystem, true, false, false, false, false, false, false)
 			client := ofClient.(*client)
 			client.cookieAllocator = cookie.NewAllocator(0)
 			client.ofEntryOperations = m
@@ -400,7 +400,7 @@ func Test_client_SendTraceflowPacket(t *testing.T) {
 }
 
 func prepareTraceflowFlow(ctrl *gomock.Controller) *client {
-	ofClient := NewClient(bridgeName, bridgeMgmtAddr, ovsconfig.OVSDatapathSystem, true, true, false, false, false, false)
+	ofClient := NewClient(bridgeName, bridgeMgmtAddr, ovsconfig.OVSDatapathSystem, true, true, false, false, false, false, false)
 	c := ofClient.(*client)
 	c.cookieAllocator = cookie.NewAllocator(0)
 	c.nodeConfig = nodeConfig
@@ -418,7 +418,7 @@ func prepareTraceflowFlow(ctrl *gomock.Controller) *client {
 }
 
 func prepareSendTraceflowPacket(ctrl *gomock.Controller, success bool) *client {
-	ofClient := NewClient(bridgeName, bridgeMgmtAddr, ovsconfig.OVSDatapathSystem, true, true, false, false, false, false)
+	ofClient := NewClient(bridgeName, bridgeMgmtAddr, ovsconfig.OVSDatapathSystem, true, true, false, false, false, false, false)
 	c := ofClient.(*client)
 	c.nodeConfig = nodeConfig
 	m := ovsoftest.NewMockBridge(ctrl)
@@ -506,7 +506,7 @@ func Test_client_setBasePacketOutBuilder(t *testing.T) {
 }
 
 func prepareSetBasePacketOutBuilder(ctrl *gomock.Controller, success bool) *client {
-	ofClient := NewClient(bridgeName, bridgeMgmtAddr, ovsconfig.OVSDatapathSystem, true, true, false, false, false, false)
+	ofClient := NewClient(bridgeName, bridgeMgmtAddr, ovsconfig.OVSDatapathSystem, true, true, false, false, false, false, false)
 	c := ofClient.(*client)
 	m := ovsoftest.NewMockBridge(ctrl)
 	c.bridge = m

--- a/pkg/agent/openflow/fields.go
+++ b/pkg/agent/openflow/fields.go
@@ -56,15 +56,17 @@ var (
 	DispositionPassRegMark  = binding.NewRegMark(APDispositionField, DispositionPass)
 	// reg0[24..27]: Field to indicate the reasons of sending packet to the controller.
 	// Marks in this field include,
-	//   - 0b0001: logging
-	//   - 0b0010: reject
-	//   - 0b0100: deny (used by Flow Exporter)
-	//   - 0b1000: DNS packet (used by FQDN)
-	CustomReasonField          = binding.NewRegField(0, 24, 27, "PacketInReason")
+	//   - 0b00001: logging
+	//   - 0b00010: reject
+	//   - 0b00100: deny (used by Flow Exporter)
+	//   - 0b01000: DNS packet (used by FQDN)
+	//   - 0b10000: IGMP packet (used by Multicast)
+	CustomReasonField          = binding.NewRegField(0, 24, 28, "PacketInReason")
 	CustomReasonLoggingRegMark = binding.NewRegMark(CustomReasonField, CustomReasonLogging)
 	CustomReasonRejectRegMark  = binding.NewRegMark(CustomReasonField, CustomReasonReject)
 	CustomReasonDenyRegMark    = binding.NewRegMark(CustomReasonField, CustomReasonDeny)
 	CustomReasonDNSRegMark     = binding.NewRegMark(CustomReasonField, CustomReasonDNS)
+	CustomReasonIGMPRegMark    = binding.NewRegMark(CustomReasonField, CustomReasonIGMP)
 
 	// reg1(NXM_NX_REG1)
 	// Field to cache the ofPort of the OVS interface where to output packet.

--- a/pkg/agent/openflow/network_policy_test.go
+++ b/pkg/agent/openflow/network_policy_test.go
@@ -507,7 +507,7 @@ func TestBatchInstallPolicyRuleFlows(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			mockOperations := oftest.NewMockOFEntryOperations(ctrl)
-			ofClient := NewClient(bridgeName, bridgeMgmtAddr, ovsconfig.OVSDatapathSystem, false, true, false, false, false, false)
+			ofClient := NewClient(bridgeName, bridgeMgmtAddr, ovsconfig.OVSDatapathSystem, false, true, false, false, false, false, false)
 			c = ofClient.(*client)
 			c.cookieAllocator = cookie.NewAllocator(0)
 			c.ofEntryOperations = mockOperations
@@ -575,7 +575,7 @@ func BenchmarkBatchInstallPolicyRuleFlows(b *testing.B) {
 	ctrl := gomock.NewController(b)
 	defer ctrl.Finish()
 	mockOperations := oftest.NewMockOFEntryOperations(ctrl)
-	ofClient := NewClient(bridgeName, bridgeMgmtAddr, ovsconfig.OVSDatapathSystem, false, true, false, false, false, false)
+	ofClient := NewClient(bridgeName, bridgeMgmtAddr, ovsconfig.OVSDatapathSystem, false, true, false, false, false, false, false)
 	c = ofClient.(*client)
 	c.cookieAllocator = cookie.NewAllocator(0)
 	c.ofEntryOperations = mockOperations

--- a/pkg/agent/openflow/packetin.go
+++ b/pkg/agent/openflow/packetin.go
@@ -42,7 +42,12 @@ const (
 
 	// PacketIn reasons
 	PacketInReasonTF ofpPacketInReason = 1
+	// PacketInReasonNP is used for the custom packetIn reasons for Network Policy, including: Logging, Reject, Deny.
+	// It is also used to mark the DNS Response packet.
 	PacketInReasonNP ofpPacketInReason = 0
+	// PacketInReasonMC shares PacketInReasonNP for IGMP packet_in message. This is because OVS "controller" action
+	// only correctly supports reason 0 or 1. Change to another value after the OVS action is corrected.
+	PacketInReasonMC = PacketInReasonNP
 	// PacketInQueueSize defines the size of PacketInQueue.
 	// When PacketInQueue reaches PacketInQueueSize, new packet-in will be dropped.
 	PacketInQueueSize = 200
@@ -111,6 +116,7 @@ func (c *client) parsePacketIn(featurePacketIn *featureStartPacketIn) {
 		}
 		// Use corresponding handlers subscribed to the reason to handle PacketIn
 		for name, handler := range c.packetInHandlers[featurePacketIn.reason] {
+			klog.V(2).InfoS("Received packetIn", "reason", featurePacketIn.reason, "handler", name)
 			err := handler.HandlePacketIn(pktIn)
 			if err != nil {
 				klog.Errorf("PacketIn handler %s failed to process packet: %+v", name, err)

--- a/pkg/agent/openflow/testing/mock_openflow.go
+++ b/pkg/agent/openflow/testing/mock_openflow.go
@@ -25,6 +25,7 @@ import (
 	openflow "antrea.io/antrea/pkg/ovs/openflow"
 	ip "antrea.io/antrea/pkg/util/ip"
 	proxy "antrea.io/antrea/third_party/proxy"
+	util "antrea.io/libOpenflow/util"
 	gomock "github.com/golang/mock/gomock"
 	v1 "k8s.io/api/core/v1"
 	net "net"
@@ -378,6 +379,34 @@ func (mr *MockClientMockRecorder) InstallLoadBalancerServiceFromOutsideFlows(arg
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallLoadBalancerServiceFromOutsideFlows", reflect.TypeOf((*MockClient)(nil).InstallLoadBalancerServiceFromOutsideFlows), arg0, arg1, arg2)
 }
 
+// InstallMulticastFlow mocks base method
+func (m *MockClient) InstallMulticastFlow(arg0 net.IP) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InstallMulticastFlow", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// InstallMulticastFlow indicates an expected call of InstallMulticastFlow
+func (mr *MockClientMockRecorder) InstallMulticastFlow(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallMulticastFlow", reflect.TypeOf((*MockClient)(nil).InstallMulticastFlow), arg0)
+}
+
+// InstallMulticastInitialFlows mocks base method
+func (m *MockClient) InstallMulticastInitialFlows(arg0 byte) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InstallMulticastInitialFlows", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// InstallMulticastInitialFlows indicates an expected call of InstallMulticastInitialFlows
+func (mr *MockClientMockRecorder) InstallMulticastInitialFlows(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallMulticastInitialFlows", reflect.TypeOf((*MockClient)(nil).InstallMulticastInitialFlows), arg0)
+}
+
 // InstallNodeFlows mocks base method
 func (m *MockClient) InstallNodeFlows(arg0 string, arg1 map[*net.IPNet]net.IP, arg2 *ip.DualStackIPs, arg3 uint32, arg4 net.HardwareAddr) error {
 	m.ctrl.T.Helper()
@@ -612,6 +641,20 @@ func (mr *MockClientMockRecorder) SendICMPPacketOut(arg0, arg1, arg2, arg3, arg4
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendICMPPacketOut", reflect.TypeOf((*MockClient)(nil).SendICMPPacketOut), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)
 }
 
+// SendIGMPQueryPacketOut mocks base method
+func (m *MockClient) SendIGMPQueryPacketOut(arg0 net.HardwareAddr, arg1 net.IP, arg2 uint32, arg3 util.Message) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SendIGMPQueryPacketOut", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SendIGMPQueryPacketOut indicates an expected call of SendIGMPQueryPacketOut
+func (mr *MockClientMockRecorder) SendIGMPQueryPacketOut(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendIGMPQueryPacketOut", reflect.TypeOf((*MockClient)(nil).SendIGMPQueryPacketOut), arg0, arg1, arg2, arg3)
+}
+
 // SendTCPPacketOut mocks base method
 func (m *MockClient) SendTCPPacketOut(arg0, arg1, arg2, arg3 string, arg4, arg5 uint32, arg6 bool, arg7, arg8 uint16, arg9 uint32, arg10 byte, arg11 func(openflow.PacketOutBuilder) openflow.PacketOutBuilder) error {
 	m.ctrl.T.Helper()
@@ -706,6 +749,20 @@ func (m *MockClient) UninstallLoadBalancerServiceFromOutsideFlows(arg0 net.IP, a
 func (mr *MockClientMockRecorder) UninstallLoadBalancerServiceFromOutsideFlows(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UninstallLoadBalancerServiceFromOutsideFlows", reflect.TypeOf((*MockClient)(nil).UninstallLoadBalancerServiceFromOutsideFlows), arg0, arg1, arg2)
+}
+
+// UninstallMulticastFlow mocks base method
+func (m *MockClient) UninstallMulticastFlow(arg0 net.IP) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UninstallMulticastFlow", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UninstallMulticastFlow indicates an expected call of UninstallMulticastFlow
+func (mr *MockClientMockRecorder) UninstallMulticastFlow(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UninstallMulticastFlow", reflect.TypeOf((*MockClient)(nil).UninstallMulticastFlow), arg0)
 }
 
 // UninstallNodeFlows mocks base method

--- a/pkg/apiserver/handlers/featuregates/handler.go
+++ b/pkg/apiserver/handlers/featuregates/handler.go
@@ -30,7 +30,7 @@ import (
 )
 
 var controllerGates = sets.NewString("Traceflow", "AntreaPolicy", "Egress", "NetworkPolicyStats", "NodeIPAM")
-var agentGates = sets.NewString("AntreaPolicy", "AntreaProxy", "Egress", "EndpointSlice", "Traceflow", "FlowExporter", "NetworkPolicyStats", "NodePortLocal", "AntreaIPAM")
+var agentGates = sets.NewString("AntreaPolicy", "AntreaProxy", "Egress", "EndpointSlice", "Traceflow", "FlowExporter", "NetworkPolicyStats", "NodePortLocal", "AntreaIPAM", "Multicast")
 
 type (
 	Config struct {

--- a/pkg/apiserver/handlers/featuregates/handler_test.go
+++ b/pkg/apiserver/handlers/featuregates/handler_test.go
@@ -54,6 +54,7 @@ func Test_getGatesResponse(t *testing.T) {
 				{Component: "agent", Name: "FlowExporter", Status: "Disabled", Version: "ALPHA"},
 				{Component: "agent", Name: "NetworkPolicyStats", Status: "Enabled", Version: "BETA"},
 				{Component: "agent", Name: "NodePortLocal", Status: "Enabled", Version: "BETA"},
+				{Component: "agent", Name: "Multicast", Status: "Disabled", Version: "ALPHA"},
 			},
 		},
 	}

--- a/pkg/features/antrea_features.go
+++ b/pkg/features/antrea_features.go
@@ -76,6 +76,10 @@ const (
 	// alpha: v1.4
 	// Enable flexible IPAM for Pods.
 	AntreaIPAM featuregate.Feature = "AntreaIPAM"
+
+	// alpha: v1.5
+	// Enable Multicast.
+	Multicast featuregate.Feature = "Multicast"
 )
 
 var (
@@ -100,6 +104,7 @@ var (
 		NetworkPolicyStats: {Default: true, PreRelease: featuregate.Beta},
 		NodePortLocal:      {Default: true, PreRelease: featuregate.Beta},
 		NodeIPAM:           {Default: false, PreRelease: featuregate.Alpha},
+		Multicast:          {Default: false, PreRelease: featuregate.Alpha},
 	}
 
 	// UnsupportedFeaturesOnWindows records the features not supported on
@@ -116,6 +121,7 @@ var (
 		NodePortLocal: {},
 		Egress:        {},
 		AntreaIPAM:    {},
+		Multicast:     {},
 	}
 )
 

--- a/pkg/ovs/openflow/interfaces.go
+++ b/pkg/ovs/openflow/interfaces.go
@@ -18,6 +18,7 @@ import (
 	"net"
 	"time"
 
+	"antrea.io/libOpenflow/util"
 	"antrea.io/ofnet/ofctrl"
 )
 
@@ -46,6 +47,7 @@ const (
 	ProtocolSCTPv6 Protocol = "sctpv6"
 	ProtocolICMP   Protocol = "icmp"
 	ProtocolICMPv6 Protocol = "icmpv6"
+	ProtocolIGMP   Protocol = "igmp"
 )
 
 const (
@@ -382,6 +384,7 @@ type PacketOutBuilder interface {
 	AddLoadAction(name string, data uint64, rng *Range) PacketOutBuilder
 	AddLoadRegMark(mark *RegMark) PacketOutBuilder
 	AddResubmitAction(inPort *uint16, table *uint8) PacketOutBuilder
+	SetL4Packet(packet util.Message) PacketOutBuilder
 	Done() *ofctrl.PacketOut
 }
 

--- a/pkg/ovs/openflow/ofctrl_builder.go
+++ b/pkg/ovs/openflow/ofctrl_builder.go
@@ -487,6 +487,9 @@ func (b *ofFlowBuilder) MatchProtocol(protocol Protocol) FlowBuilder {
 	case ProtocolICMPv6:
 		b.Match.Ethertype = 0x86dd
 		b.Match.IpProto = 58
+	case ProtocolIGMP:
+		b.Match.Ethertype = 0x0800
+		b.Match.IpProto = 2
 	}
 	b.protocol = protocol
 	return b

--- a/test/integration/agent/openflow_test.go
+++ b/test/integration/agent/openflow_test.go
@@ -115,7 +115,7 @@ func TestConnectivityFlows(t *testing.T) {
 		antrearuntime.WindowsOS = runtime.GOOS
 	}
 
-	c = ofClient.NewClient(br, bridgeMgmtAddr, ovsconfig.OVSDatapathNetdev, true, false, true, false, false, false)
+	c = ofClient.NewClient(br, bridgeMgmtAddr, ovsconfig.OVSDatapathNetdev, true, false, true, false, false, false, false)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge: %v", err))
 	defer func() {
@@ -159,7 +159,7 @@ func TestAntreaFlexibleIPAMConnectivityFlows(t *testing.T) {
 	// Initialize ovs metrics (Prometheus) to test them
 	metrics.InitializeOVSMetrics()
 
-	c = ofClient.NewClient(br, bridgeMgmtAddr, ovsconfig.OVSDatapathNetdev, true, false, true, false, false, true)
+	c = ofClient.NewClient(br, bridgeMgmtAddr, ovsconfig.OVSDatapathNetdev, true, false, true, false, false, true, false)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge: %v", err))
 	defer func() {
@@ -201,7 +201,7 @@ func TestAntreaFlexibleIPAMConnectivityFlows(t *testing.T) {
 }
 
 func TestReplayFlowsConnectivityFlows(t *testing.T) {
-	c = ofClient.NewClient(br, bridgeMgmtAddr, ovsconfig.OVSDatapathNetdev, true, false, false, false, false, false)
+	c = ofClient.NewClient(br, bridgeMgmtAddr, ovsconfig.OVSDatapathNetdev, true, false, false, false, false, false, false)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge: %v", err))
 
@@ -237,7 +237,7 @@ func TestReplayFlowsConnectivityFlows(t *testing.T) {
 }
 
 func TestReplayFlowsNetworkPolicyFlows(t *testing.T) {
-	c = ofClient.NewClient(br, bridgeMgmtAddr, ovsconfig.OVSDatapathNetdev, true, false, false, false, false, false)
+	c = ofClient.NewClient(br, bridgeMgmtAddr, ovsconfig.OVSDatapathNetdev, true, false, false, false, false, false, false)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge: %v", err))
 
@@ -423,7 +423,7 @@ func TestNetworkPolicyFlows(t *testing.T) {
 	// Initialize ovs metrics (Prometheus) to test them
 	metrics.InitializeOVSMetrics()
 
-	c = ofClient.NewClient(br, bridgeMgmtAddr, ovsconfig.OVSDatapathNetdev, true, false, false, false, false, false)
+	c = ofClient.NewClient(br, bridgeMgmtAddr, ovsconfig.OVSDatapathNetdev, true, false, false, false, false, false, false)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge %s", br))
 
@@ -533,7 +533,7 @@ func TestIPv6ConnectivityFlows(t *testing.T) {
 	// Initialize ovs metrics (Prometheus) to test them
 	metrics.InitializeOVSMetrics()
 
-	c = ofClient.NewClient(br, bridgeMgmtAddr, ovsconfig.OVSDatapathNetdev, true, false, true, false, false, false)
+	c = ofClient.NewClient(br, bridgeMgmtAddr, ovsconfig.OVSDatapathNetdev, true, false, true, false, false, false, false)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge: %v", err))
 
@@ -575,7 +575,7 @@ type svcConfig struct {
 }
 
 func TestProxyServiceFlows(t *testing.T) {
-	c = ofClient.NewClient(br, bridgeMgmtAddr, ovsconfig.OVSDatapathNetdev, true, false, false, false, false, false)
+	c = ofClient.NewClient(br, bridgeMgmtAddr, ovsconfig.OVSDatapathNetdev, true, false, false, false, false, false, false)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge %s", br))
 
@@ -1514,7 +1514,7 @@ func prepareSNATFlows(snatIP net.IP, mark, podOFPort, podOFPortRemote uint32, vM
 }
 
 func TestSNATFlows(t *testing.T) {
-	c = ofClient.NewClient(br, bridgeMgmtAddr, ovsconfig.OVSDatapathNetdev, false, false, true, false, false, false)
+	c = ofClient.NewClient(br, bridgeMgmtAddr, ovsconfig.OVSDatapathNetdev, false, false, true, false, false, false, false)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge %s", br))
 


### PR DESCRIPTION
1. Use packetIn/packetOut to collect IGMP membership report and detect
    Multicast group.
    
2. Add an OpenFlow entry for each Multicast group in which local Pods
    have joined to forward the packet normally and output it to
    antrea-gw0.
 
3. Output the Multicast traffic to antrea-gw0 if no local Pods have
    joined the target Multicast group.

Signed-off-by: wenyingd <wenyingd@vmware.com>