### PR TITLE
Fix Clean-AntreaNetwork.ps1

### DIFF
--- a/hack/windows/Clean-AntreaNetwork.ps1
+++ b/hack/windows/Clean-AntreaNetwork.ps1
@@ -6,7 +6,7 @@
   OVS installation directory. It is the path argument when using Install-OVS.ps1. The default path is "C:\openvswitch".
 #>
 Param(
-    [parameter(Mandatory = $false)] [string] $OVSInstallDir = "C:\openvswitch",
+    [parameter(Mandatory = $false)] [string] $OVSInstallDir = "C:\openvswitch"
 )
 
 # Replace the path using the actual path where ovs-vswitchd.pid locates. It is always under path $OVSInstallDir\var\run\openvswitch.


### PR DESCRIPTION
The script is currently failing with

```
At C:\k\antrea\Clean-AntreaNetwork.ps1:9 char:80
+ ... eter(Mandatory = $false)] [string] $OVSInstallDir = "C:\openvswitch",
+                                                                          ~
Missing expression after ','.
    + CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : MissingExpressionAfterToken
```

I don't know if this is dependent on the PowerShell version, but it
seems that in our other scripts we don't end with a comma for the last
parameter in the list.

Thanks @mmottaghi for reporting this.

Signed-off-by: Antonin Bas <abas@vmware.com>