### PR TITLE
Skip FQDN e2e test in ipv6-only test env

### DIFF
--- a/test/e2e/antreapolicy_test.go
+++ b/test/e2e/antreapolicy_test.go
@@ -2358,6 +2358,8 @@ func testACNPNamespaceIsolation(t *testing.T, data *TestData) {
 }
 
 func testFQDNPolicy(t *testing.T) {
+	// The ipv6-only test env doesn't have IPv6 access to the web.
+	skipIfNotIPv4Cluster(t)
 	builder := &ClusterNetworkPolicySpecBuilder{}
 	builder = builder.SetName("test-acnp-drop-all-google").
 		SetTier("application").


### PR DESCRIPTION
Fixes #2653
The IPv6-only CI test env don't have IPv6 access to the web.

Signed-off-by: wgrayson <wgrayson@vmware.com>