### PR TITLE
Update Audit Logging Documentation and Format

### DIFF
--- a/docs/antrea-network-policy.md
+++ b/docs/antrea-network-policy.md
@@ -426,7 +426,7 @@ to a separate file (`/var/log/antrea/networkpolicy/np.log`) on the Node on
 which the rule is applied. These log files can then be retrieved for further
 analysis. By default, rules are not logged. The example policy logs all
 traffic that matches the "DropToThirdParty" egress rule, while the rule
-"AllowFromFrontend" is not logged. Specifically for drop and reject rules, 
+"AllowFromFrontend" is not logged. Specifically for drop and reject rules,
 deduplication is applied to simplify the logs. By default, the buffer length is 1 second.
 The rules are logged in the following format:
 

--- a/docs/antrea-network-policy.md
+++ b/docs/antrea-network-policy.md
@@ -426,14 +426,18 @@ to a separate file (`/var/log/antrea/networkpolicy/np.log`) on the Node on
 which the rule is applied. These log files can then be retrieved for further
 analysis. By default, rules are not logged. The example policy logs all
 traffic that matches the "DropToThirdParty" egress rule, while the rule
-"AllowFromFrontend" is not logged. The rules are logged in the following
-format:
+"AllowFromFrontend" is not logged. Specifically for drop and reject rules, 
+deduplication is applied to simplify the logs. By default, the buffer length is 1 second.
+The rules are logged in the following format:
 
 ```text
-    <yyyy/mm/dd> <time> <ovs-table-name> <antrea-native-policy-reference> <action> <openflow-priority> SRC: <source-ip> DEST: <destination-ip> <packet-length> <protocol>
+    <yyyy/mm/dd> <time> <ovs-table-name> <antrea-native-policy-reference> <action> <openflow-priority> <source-ip> <destination-ip> <packet-length> <protocol>
+    Deduplication:
+    <yyyy/mm/dd> <time> <ovs-table-name> <antrea-native-policy-reference> <action> <openflow-priority> <source-ip> <destination-ip> <packet-length> <protocol> [<num of packets> packets in <duplicate duration>]
 
     Example:
-    2020/11/02 22:21:21.148395 AntreaPolicyAppTierIngressRule AntreaNetworkPolicy:default/test-anp Allow 61800 SRC: 10.0.0.4 DEST: 10.0.0.5 60 TCP
+    2020/11/02 22:21:21.148395 AntreaPolicyAppTierIngressRule AntreaNetworkPolicy:default/test-anp Allow 61800 10.0.0.4 10.0.0.5 60 TCP
+    2021/06/24 23:56:41.346165 AntreaPolicyEgressRule AntreaNetworkPolicy:default/test-anp Drop 44900 10.0.0.5 10.0.0.4 60 TCP [3 packets in 1.011379442s]
 ```
 
 **`appliedTo` per rule**: A ClusterNetworkPolicy ingress or egress rule may

--- a/docs/antrea-network-policy.md
+++ b/docs/antrea-network-policy.md
@@ -427,7 +427,7 @@ which the rule is applied. These log files can then be retrieved for further
 analysis. By default, rules are not logged. The example policy logs all
 traffic that matches the "DropToThirdParty" egress rule, while the rule
 "AllowFromFrontend" is not logged. Specifically for drop and reject rules,
-deduplication is applied to simplify the logs. By default, the buffer length is 1 second.
+deduplication is applied to simplify multiple logs. Duplication buffer length is set as 1 second.
 The rules are logged in the following format:
 
 ```text

--- a/pkg/agent/controller/networkpolicy/audit_logging.go
+++ b/pkg/agent/controller/networkpolicy/audit_logging.go
@@ -111,7 +111,7 @@ func (l *AntreaPolicyLogger) updateLogKey(logMsg string, bufferLength time.Durat
 // LogDedupPacket logs information in ob based on disposition and duplication conditions.
 func (l *AntreaPolicyLogger) LogDedupPacket(ob *logInfo) {
 	// Deduplicate non-Allow packet log.
-	logMsg := fmt.Sprintf("%s %s %s %s SRC: %s DEST: %s %d %s", ob.tableName, ob.npRef, ob.disposition, ob.ofPriority, ob.srcIP, ob.destIP, ob.pktLength, ob.protocolStr)
+	logMsg := fmt.Sprintf("%s %s %s %s %s %s %d %s", ob.tableName, ob.npRef, ob.disposition, ob.ofPriority, ob.srcIP, ob.destIP, ob.pktLength, ob.protocolStr)
 	if ob.disposition == openflow.DispositionToString[openflow.DispositionAllow] {
 		l.anpLogger.Printf(logMsg)
 	} else {

--- a/pkg/agent/controller/networkpolicy/audit_logging_test.go
+++ b/pkg/agent/controller/networkpolicy/audit_logging_test.go
@@ -59,7 +59,7 @@ func newTestAntreaPolicyLogger(bufferLength time.Duration) (*AntreaPolicyLogger,
 }
 
 func newLogInfo(disposition string) (*logInfo, string) {
-	expected := fmt.Sprintf("AntreaPolicyIngressRule AntreaNetworkPolicy:default/test %s 0 SRC: 0.0.0.0 DEST: 1.1.1.1 60 TCP", disposition)
+	expected := fmt.Sprintf("AntreaPolicyIngressRule AntreaNetworkPolicy:default/test %s 0 0.0.0.0 1.1.1.1 60 TCP", disposition)
 	return &logInfo{
 		tableName:   "AntreaPolicyIngressRule",
 		npRef:       "AntreaNetworkPolicy:default/test",

--- a/test/e2e/antreapolicy_test.go
+++ b/test/e2e/antreapolicy_test.go
@@ -2102,8 +2102,8 @@ func testAuditLoggingBasic(t *testing.T, data *TestData) {
 						continue
 					}
 					expectedNumEntries += 1
-					// The audit log should contain log entry `... Drop <ofPriority> SRC: <x/a IP> DEST: <z/* IP> ...`
-					re := regexp.MustCompile(`Drop [0-9]+ SRC: ` + srcIPs[i] + ` DEST: ` + dstIPs[j])
+					// The audit log should contain log entry `... Drop <ofPriority> <x/a IP> <z/* IP> ...`
+					re := regexp.MustCompile(`Drop [0-9]+ ` + srcIPs[i] + ` ` + dstIPs[j])
 					if re.MatchString(stdout) {
 						actualNumEntries += 1
 					} else {


### PR DESCRIPTION
This PR follows [the previous PR](https://github.com/antrea-io/antrea/pull/1477) to update the documentation for audit logging. Recently deduplication is added for drop and reject packets.

Also, there was a discussion in the PR about removing `SRC: DEST:` in the log to keep consistency.