### PR TITLE
Add in-cluster svc fqdn e2e test

### DIFF
--- a/test/e2e/k8s_util.go
+++ b/test/e2e/k8s_util.go
@@ -181,7 +181,10 @@ func (k *KubernetesUtils) ProbeEgress(ns, pod, dstAddr string, port int32, proto
 		return Error, fmt.Errorf("no Pod of label pod=%s in Namespace %s found", pod, ns)
 	}
 	fromPod := fromPods[0]
-
+	// If it's an IPv6 address, add "[]" around it.
+	if strings.Contains(dstAddr, ":") {
+		dstAddr = fmt.Sprintf("[%s]", dstAddr)
+	}
 	connectivity := k.probe(&fromPod, fmt.Sprintf("%s/%s", ns, pod), dstAddr, dstAddr, port, protocol)
 	return connectivity, nil
 }


### PR DESCRIPTION
Add a new test case using in-cluster headless Services to test FQDN
policies, to avoid having a dependency on external connectivity. The reason we
use headless Service is that FQDN will use the IP from DNS A/AAAA records to
implement flows in the egress policy table. For a non-headless Service, the DNS
name resolves to the ClusterIP for the Service. But when traffic arrives to the
egress table, the dstIP has already been DNATed to the Endpoints IP by
AntreaProxy Service Load-Balancing, and the policies are not enforced correctly.
For a headless Service, the Endpoints IP will be directly returned by the DNS
server. In this case, FQDN based policies can be enforced successfully.

Signed-off-by: wgrayson <wgrayson@vmware.com>