### PR TITLE
Support configurable network V4 CIDR for Pod traffic across Node (#2473)

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -3911,9 +3911,20 @@ data:
     #tlsMinVersion:
 
     # The name of the interface on Node which is used for tunneling or routing the traffic across Nodes.
-    # If there are multiple IP addresses configured on the interface, the first one is used.
-    # The interface configured with Node IP is used if this parameter is not set.
+    # If there are multiple IP addresses configured on the interface, the first one is used. The order for
+    # configuring tunneling or routing the traffic across Nodes is (from highest to lowest):
+    # 1.TransportInterface
+    # 2.TransportV4CIDR
+    # 3.The Node IP.
     #transportInterface:
+
+    # The network V4 CIDR of the interface on Node which is used for tunneling or routing the traffic across
+    # Nodes. If there are multiple interfaces configured the same network V4 CIDR, the first one is used. The
+    # order for configuring tunneling or routing the traffic across Nodes is (from highest to lowest):
+    # 1.TransportInterface
+    # 2.TransportV4CIDR
+    # 3.The Node IP
+    #transportV4CIDR:
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -3911,9 +3911,20 @@ data:
     #tlsMinVersion:
 
     # The name of the interface on Node which is used for tunneling or routing the traffic across Nodes.
-    # If there are multiple IP addresses configured on the interface, the first one is used.
-    # The interface configured with Node IP is used if this parameter is not set.
+    # If there are multiple IP addresses configured on the interface, the first one is used. The order for
+    # configuring tunneling or routing the traffic across Nodes is (from highest to lowest):
+    # 1.TransportInterface
+    # 2.TransportV4CIDR
+    # 3.The Node IP.
     #transportInterface:
+
+    # The network V4 CIDR of the interface on Node which is used for tunneling or routing the traffic across
+    # Nodes. If there are multiple interfaces configured the same network V4 CIDR, the first one is used. The
+    # order for configuring tunneling or routing the traffic across Nodes is (from highest to lowest):
+    # 1.TransportInterface
+    # 2.TransportV4CIDR
+    # 3.The Node IP
+    #transportV4CIDR:
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -3911,9 +3911,20 @@ data:
     #tlsMinVersion:
 
     # The name of the interface on Node which is used for tunneling or routing the traffic across Nodes.
-    # If there are multiple IP addresses configured on the interface, the first one is used.
-    # The interface configured with Node IP is used if this parameter is not set.
+    # If there are multiple IP addresses configured on the interface, the first one is used. The order for
+    # configuring tunneling or routing the traffic across Nodes is (from highest to lowest):
+    # 1.TransportInterface
+    # 2.TransportV4CIDR
+    # 3.The Node IP.
     #transportInterface:
+
+    # The network V4 CIDR of the interface on Node which is used for tunneling or routing the traffic across
+    # Nodes. If there are multiple interfaces configured the same network V4 CIDR, the first one is used. The
+    # order for configuring tunneling or routing the traffic across Nodes is (from highest to lowest):
+    # 1.TransportInterface
+    # 2.TransportV4CIDR
+    # 3.The Node IP
+    #transportV4CIDR:
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -3916,9 +3916,20 @@ data:
     #tlsMinVersion:
 
     # The name of the interface on Node which is used for tunneling or routing the traffic across Nodes.
-    # If there are multiple IP addresses configured on the interface, the first one is used.
-    # The interface configured with Node IP is used if this parameter is not set.
+    # If there are multiple IP addresses configured on the interface, the first one is used. The order for
+    # configuring tunneling or routing the traffic across Nodes is (from highest to lowest):
+    # 1.TransportInterface
+    # 2.TransportV4CIDR
+    # 3.The Node IP.
     #transportInterface:
+
+    # The network V4 CIDR of the interface on Node which is used for tunneling or routing the traffic across
+    # Nodes. If there are multiple interfaces configured the same network V4 CIDR, the first one is used. The
+    # order for configuring tunneling or routing the traffic across Nodes is (from highest to lowest):
+    # 1.TransportInterface
+    # 2.TransportV4CIDR
+    # 3.The Node IP
+    #transportV4CIDR:
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",

--- a/build/yamls/antrea-windows.yml
+++ b/build/yamls/antrea-windows.yml
@@ -98,9 +98,20 @@ data:
     #trafficEncapMode: encap
 
     # The name of the interface on Node which is used for tunneling or routing the traffic across Nodes.
-    # If there are multiple IP addresses configured on the interface, the first one is used.
-    # The interface configured with Node IP is used if this parameter is not set.
+    # If there are multiple IP addresses configured on the interface, the first one is used. The order for
+    # configuring tunneling or routing the traffic across Nodes is (from highest to lowest):
+    # 1.TransportInterface
+    # 2.TransportV4CIDR
+    # 3.The Node IP.
     #transportInterface:
+
+    # The network V4 CIDR of the interface on Node which is used for tunneling or routing the traffic across
+    # Nodes. If there are multiple interfaces configured the same network V4 CIDR, the first one is used. The
+    # order for configuring tunneling or routing the traffic across Nodes is (from highest to lowest):
+    # 1.TransportInterface
+    # 2.TransportV4CIDR
+    # 3.The Node IP
+    #transportV4CIDR:
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -3916,9 +3916,20 @@ data:
     #tlsMinVersion:
 
     # The name of the interface on Node which is used for tunneling or routing the traffic across Nodes.
-    # If there are multiple IP addresses configured on the interface, the first one is used.
-    # The interface configured with Node IP is used if this parameter is not set.
+    # If there are multiple IP addresses configured on the interface, the first one is used. The order for
+    # configuring tunneling or routing the traffic across Nodes is (from highest to lowest):
+    # 1.TransportInterface
+    # 2.TransportV4CIDR
+    # 3.The Node IP.
     #transportInterface:
+
+    # The network V4 CIDR of the interface on Node which is used for tunneling or routing the traffic across
+    # Nodes. If there are multiple interfaces configured the same network V4 CIDR, the first one is used. The
+    # order for configuring tunneling or routing the traffic across Nodes is (from highest to lowest):
+    # 1.TransportInterface
+    # 2.TransportV4CIDR
+    # 3.The Node IP
+    #transportV4CIDR:
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",

--- a/build/yamls/base/conf/antrea-agent.conf
+++ b/build/yamls/base/conf/antrea-agent.conf
@@ -161,6 +161,17 @@ wireGuard:
 #tlsMinVersion:
 
 # The name of the interface on Node which is used for tunneling or routing the traffic across Nodes.
-# If there are multiple IP addresses configured on the interface, the first one is used.
-# The interface configured with Node IP is used if this parameter is not set.
+# If there are multiple IP addresses configured on the interface, the first one is used. The order for
+# configuring tunneling or routing the traffic across Nodes is (from highest to lowest):
+# 1.TransportInterface
+# 2.TransportV4CIDR
+# 3.The Node IP.
 #transportInterface:
+
+# The network V4 CIDR of the interface on Node which is used for tunneling or routing the traffic across
+# Nodes. If there are multiple interfaces configured the same network V4 CIDR, the first one is used. The
+# order for configuring tunneling or routing the traffic across Nodes is (from highest to lowest):
+# 1.TransportInterface
+# 2.TransportV4CIDR
+# 3.The Node IP
+#transportV4CIDR:

--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -124,6 +124,7 @@ func run(o *Options) error {
 		TrafficEncapMode:      encapMode,
 		TrafficEncryptionMode: encryptionMode,
 		TransportIface:        o.config.TransportInterface,
+		TransportV4CIDR:       o.config.TransportV4CIDR,
 	}
 
 	wireguardConfig := &config.WireGuardConfig{

--- a/cmd/antrea-agent/config.go
+++ b/cmd/antrea-agent/config.go
@@ -159,9 +159,19 @@ type AgentConfig struct {
 	// TLS min version.
 	TLSMinVersion string `yaml:"tlsMinVersion,omitempty"`
 	// The name of the interface on Node which is used for tunneling or routing the traffic across Nodes.
-	// If there are multiple IP addresses configured on the interface, the first one is used.
-	// The interface configured with Node IP is used if this parameter is not set.
+	// If there are multiple IP addresses configured on the interface, the first one is used. The order for
+	// configuring tunneling or routing the traffic across Nodes is (from highest to lowest):
+	// 1.TransportInterface
+	// 2.TransportV4CIDR
+	// 3.The Node IP
 	TransportInterface string `yaml:"transportInterface,omitempty"`
+	// The network CIDR of the interface on Node which is used for tunneling or routing the traffic across
+	// Nodes. If there are multiple interfaces configured the same network CIDR, the first one is used. The
+	// order for configuring tunneling or routing the traffic across Nodes is (from highest to lowest):
+	// 1.TransportInterface
+	// 2.TransportV4CIDR
+	// 3.The Node IP
+	TransportV4CIDR string `yaml:"transportV4CIDR,omitempty"`
 }
 
 type WireGuardConfig struct {

--- a/pkg/agent/config/node_config.go
+++ b/pkg/agent/config/node_config.go
@@ -129,6 +129,7 @@ type NetworkConfig struct {
 	TrafficEncryptionMode TrafficEncryptionModeType
 	IPSecPSK              string
 	TransportIface        string
+	TransportV4CIDR     string
 }
 
 // IsIPv4Enabled returns true if the cluster network supports IPv4.

--- a/pkg/agent/controller/noderoute/node_route_controller.go
+++ b/pkg/agent/controller/noderoute/node_route_controller.go
@@ -739,8 +739,8 @@ func getNodeMAC(node *corev1.Node) (net.HardwareAddr, error) {
 }
 
 func (c *Controller) getNodeTransportAddrs(node *corev1.Node) (*utilip.DualStackIPs, error) {
-	var transportAddrs *utilip.DualStackIPs
-	if c.networkConfig.TransportIface != "" {
+	transportAddrs := &utilip.DualStackIPs{}
+	if c.networkConfig.TransportIface != "" || c.networkConfig.TransportV4CIDR != "" {
 		transportAddrsStr := node.Annotations[types.NodeTransportAddressAnnotationKey]
 		if transportAddrsStr != "" {
 			for _, addr := range strings.Split(transportAddrsStr, ",") {


### PR DESCRIPTION
Support configurable network V4 CIDR for Pod traffic across Node (#2473)

Antrea Agent uses the configurable CIDR for Pod traffic. The order for configuring
tunneling or routing the traffic across Nodes is (from highest to lowest):
a.TransportInterface
b.TransportCIDR
c.The Node Internal IP or External IP

Fix add node routes crash bug, which caused by uninitialized DualStackIPs param

Fix ipv4 address and ipv6 address confused bug

Signed-off-by: Wu zhengdong <zhengdong.wu@transwarp.io>