### PR TITLE
Fix init node transport interface bug

### DIFF
--- a/pkg/agent/controller/noderoute/node_route_controller.go
+++ b/pkg/agent/controller/noderoute/node_route_controller.go
@@ -739,7 +739,7 @@ func getNodeMAC(node *corev1.Node) (net.HardwareAddr, error) {
 }
 
 func (c *Controller) getNodeTransportAddrs(node *corev1.Node) (*utilip.DualStackIPs, error) {
-	var transportAddrs *utilip.DualStackIPs
+	var transportAddrs = new(utilip.DualStackIPs)
 	if c.networkConfig.TransportIface != "" {
 		transportAddrsStr := node.Annotations[types.NodeTransportAddressAnnotationKey]
 		if transportAddrsStr != "" {

--- a/pkg/agent/util/net.go
+++ b/pkg/agent/util/net.go
@@ -165,9 +165,11 @@ func GetIPNetDeviceByName(ifaceName string) (v4IPNet *net.IPNet, v6IPNet *net.IP
 		if ipNet, ok := addr.(*net.IPNet); ok {
 			if ipNet.IP.IsGlobalUnicast() {
 				if ipNet.IP.To4() != nil {
+					if v4IPNet == nil {
+						v4IPNet = ipNet
+					}
+				} else if v6IPNet == nil {
 					v6IPNet = ipNet
-				} else {
-					v4IPNet = ipNet
 				}
 			}
 		}


### PR DESCRIPTION
1.Fix adding node routes crash bug, which caused by uninitialized DualStackIPs param.

2.Fix ipv4 address and ipv6 address confused bug and return the first ipv4 and ipv6 ips for transport interface.

Fixes #2665

Signed-off-by: Wu zhengdong <zhengdong.wu@transwarp.io>