### PR TITLE
For Windows, the hostname in kube-apiserver is in lowercase.

### DIFF
--- a/pkg/util/env/env.go
+++ b/pkg/util/env/env.go
@@ -16,7 +16,9 @@ package env
 
 import (
 	"os"
+	"runtime"
 	"strconv"
+	"strings"
 
 	"k8s.io/klog/v2"
 )
@@ -47,6 +49,9 @@ func GetNodeName() (string, error) {
 	if err != nil {
 		klog.Errorf("Failed to get local hostname: %v", err)
 		return "", err
+	}
+	if runtime.GOOS == "windows" {
+		return strings.ToLower(nodeName), nil
 	}
 	return nodeName, nil
 }


### PR DESCRIPTION
Currently, the startup scripts force an environment variable
to have lowercase node name. This gets complex once we add
support to native windows services as they don't get
env variables from local shell.

An example of startup script is function: Start-AntreaAgent in
https://raw.githubusercontent.com/antrea-io/antrea/v1.2.0/hack/windows/Helper.psm1

Signed-off-by: Gurucharan Shetty <gurushetty@google.com>