### PR TITLE
Add native windows service support.

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -63,6 +63,10 @@ const informerDefaultResync = 12 * time.Hour
 // run starts Antrea agent with the given options and waits for termination signal.
 func run(o *Options) error {
 	klog.Infof("Starting Antrea agent (version %s)", version.GetFullVersion())
+	err := initForOS(o)
+	if err != nil {
+		return fmt.Errorf("error with OS specific initializations: %v", err)
+	}
 	// Create K8s Clientset, CRD Clientset and SharedInformerFactory for the given config.
 	k8sClient, _, crdClient, _, err := k8s.CreateClients(o.config.ClientConnection, o.config.KubeAPIServerOverride)
 	if err != nil {

--- a/cmd/antrea-agent/agent_linux.go
+++ b/cmd/antrea-agent/agent_linux.go
@@ -1,0 +1,20 @@
+//go:build linux
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+func initForOS(o *Options) error {
+	return nil
+}

--- a/cmd/antrea-agent/agent_windows.go
+++ b/cmd/antrea-agent/agent_windows.go
@@ -1,0 +1,119 @@
+// +build windows
+
+// Copyright 2021 Antrea Authors
+// Copyright 2018 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+	"time"
+
+	"k8s.io/apiserver/pkg/server"
+	"k8s.io/klog/v2"
+
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/svc"
+)
+
+const (
+	serviceName = "antrea-agent"
+)
+
+var (
+	service *handler
+)
+
+type handler struct {
+	tosvc   chan bool
+	fromsvc chan error
+}
+
+func initForOS(o *Options) error {
+	if !(o.windowsService) {
+		return nil
+	}
+
+	h := &handler{
+		tosvc:   make(chan bool),
+		fromsvc: make(chan error),
+	}
+
+	service = h
+	var err error
+	go func() {
+		err = svc.Run(serviceName, h)
+		h.fromsvc <- err
+	}()
+
+	// Wait for the first signal from the service handler.
+	err = <-h.fromsvc
+	if err != nil {
+		return err
+	}
+	klog.Infof("Running %s as a Windows service!", serviceName)
+	return nil
+}
+
+func (h *handler) Execute(_ []string, r <-chan svc.ChangeRequest, s chan<- svc.Status) (bool, uint32) {
+	s <- svc.Status{State: svc.StartPending, Accepts: 0}
+	// Unblock initService()
+	h.fromsvc <- nil
+
+	s <- svc.Status{State: svc.Running, Accepts: svc.AcceptStop | svc.AcceptShutdown | svc.Accepted(windows.SERVICE_ACCEPT_PARAMCHANGE)}
+	klog.Infof("Service running")
+Loop:
+	for {
+		select {
+		case <-h.tosvc:
+			break Loop
+		case c := <-r:
+			switch c.Cmd {
+			case svc.Cmd(windows.SERVICE_CONTROL_PARAMCHANGE):
+				s <- c.CurrentStatus
+			case svc.Interrogate:
+				s <- c.CurrentStatus
+			case svc.Stop, svc.Shutdown:
+				klog.Infof("Service stopping")
+				// We need to translate this request into a signal that can be handled by the signal handler
+				// handling shutdowns normally (currently apiserver/pkg/server/signal.go).
+				// If we do not do this, our main threads won't be notified of the upcoming shutdown.
+				// Since Windows services do not use any console, we cannot simply generate a CTRL_BREAK_EVENT
+				// but need a dedicated notification mechanism.
+				graceful := server.RequestShutdown()
+
+				// Free up the control handler and let us terminate as gracefully as possible.
+				// If that takes too long, the service controller will kill the remaining threads.
+				// As per https://docs.microsoft.com/en-us/windows/desktop/services/service-control-handler-function
+				s <- svc.Status{State: svc.StopPending}
+
+				// If we cannot exit gracefully, we really only can exit our process, so atleast the
+				// service manager will think that we gracefully exited. At the time of writing this comment this is
+				// needed for applications that do not use signals (e.g. kube-proxy)
+				if !graceful {
+					go func() {
+						// Ensure the SCM was notified (The operation above (send to s) was received and communicated to the
+						// service control manager - so it doesn't look like the service crashes)
+						time.Sleep(1 * time.Second)
+						os.Exit(0)
+					}()
+				}
+				break Loop
+			}
+		}
+	}
+
+	return false, 0
+}

--- a/cmd/antrea-agent/options.go
+++ b/cmd/antrea-agent/options.go
@@ -65,6 +65,8 @@ type Options struct {
 	idleFlowTimeout time.Duration
 	// Stale connection timeout to delete connections if they are not exported.
 	staleConnectionTimeout time.Duration
+	// Run the daemon as a Windows service (noop for Linux)
+	windowsService bool
 }
 
 func newOptions() *Options {
@@ -78,6 +80,7 @@ func newOptions() *Options {
 // addFlags adds flags to fs and binds them to options.
 func (o *Options) addFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.configFile, "config", o.configFile, "The path to the configuration file")
+	fs.BoolVar(&o.windowsService, "service", false, "Run the daemon as a windows service")
 }
 
 // complete completes all the required options.


### PR DESCRIPTION
We can now pass '--service' to antrea-agent to make it
run as a native windows service. e.g:

& sc.exe create antrea-agent binPath= "$AntreaAgent \
  --config=$AntreaAgentConfigPath --service --logtostderr=false \
  --log_dir=$LogDir --alsologtostderr --log_file_max_size=100 \
  --log_file_max_num=4" start= demand
& sc.exe failure antrea-agent reset= 0 actions= restart/10000
& sc.exe start antrea-agent

You can then kill antrea-agent to simulate a segfault:
taskkill.exe /f /im antrea-agent.exe

Now, running:
sc.exe query antrea-agent
will show 'RUNNING' after 10 seconds as the restart is being asked
after 10,000 ms.

The core service code is copy paste from:
https://github.com/kubernetes/kubernetes/blob/master/pkg/windows/service/service.go

Signed-off-by: Gurucharan Shetty <gurushetty@google.com>