### PR TITLE
Automated cherry pick of #2670: Fix init node transport interface bug (#2670)

### DIFF
--- a/pkg/agent/controller/noderoute/node_route_controller.go
+++ b/pkg/agent/controller/noderoute/node_route_controller.go
@@ -739,7 +739,7 @@ func getNodeMAC(node *corev1.Node) (net.HardwareAddr, error) {
 }
 
 func (c *Controller) getNodeTransportAddrs(node *corev1.Node) (*utilip.DualStackIPs, error) {
-	var transportAddrs *utilip.DualStackIPs
+	var transportAddrs = new(utilip.DualStackIPs)
 	if c.networkConfig.TransportIface != "" {
 		transportAddrsStr := node.Annotations[types.NodeTransportAddressAnnotationKey]
 		if transportAddrsStr != "" {

--- a/pkg/agent/util/net.go
+++ b/pkg/agent/util/net.go
@@ -165,9 +165,11 @@ func GetIPNetDeviceByName(ifaceName string) (v4IPNet *net.IPNet, v6IPNet *net.IP
 		if ipNet, ok := addr.(*net.IPNet); ok {
 			if ipNet.IP.IsGlobalUnicast() {
 				if ipNet.IP.To4() != nil {
+					if v4IPNet == nil {
+						v4IPNet = ipNet
+					}
+				} else if v6IPNet == nil {
 					v6IPNet = ipNet
-				} else {
-					v4IPNet = ipNet
 				}
 			}
 		}


### PR DESCRIPTION
Cherry pick of #2670 on release-1.3.

#2670: Fix init node transport interface bug (#2670)

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.