### PR TITLE
Automated cherry pick of #2672: Convert NodeName obtained from env var to lowercase on

### DIFF
--- a/pkg/util/env/env.go
+++ b/pkg/util/env/env.go
@@ -16,7 +16,9 @@ package env
 
 import (
 	"os"
+	"runtime"
 	"strconv"
+	"strings"
 
 	"k8s.io/klog/v2"
 )
@@ -47,6 +49,9 @@ func GetNodeName() (string, error) {
 	if err != nil {
 		klog.Errorf("Failed to get local hostname: %v", err)
 		return "", err
+	}
+	if runtime.GOOS == "windows" {
+		return strings.ToLower(nodeName), nil
 	}
 	return nodeName, nil
 }


### PR DESCRIPTION
Cherry pick of #2672 on release-1.3.

#2672: Convert NodeName obtained from env var to lowercase on

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.