### PR TITLE
Wait for ovs-vswitchd PID before calling ovs-appctl

### DIFF
--- a/build/images/scripts/start_ovs
+++ b/build/images/scripts/start_ovs
@@ -112,6 +112,7 @@ function quit {
     stop_ovs
     # kill background sleep process
     if [ "$SLEEP_PID" != "" ]; then kill $SLEEP_PID > /dev/null 2>&1 || true; fi
+    cleanup_ovs_run_files
     exit 0
 }
 

--- a/pkg/ovs/ovsctl/interface.go
+++ b/pkg/ovs/ovsctl/interface.go
@@ -14,6 +14,7 @@
 package ovsctl
 
 import (
+	"fmt"
 	"net"
 	"os/exec"
 )
@@ -84,4 +85,8 @@ func (e *ExecError) GetErrorOutput() string {
 		return ""
 	}
 	return e.errorOutput
+}
+
+func (e *ExecError) Error() string {
+	return fmt.Sprintf("ExecError: %v, output: %s", e.error, e.errorOutput)
 }


### PR DESCRIPTION
Otherwise the call may fail and crash the process.

Besides, it cleans up the OVS run files on exit to avoid stale PID
from being used.

Signed-off-by: Quan Tian <qtian@vmware.com>

Fixes #2694