### PR TITLE
[WireGuard] Fix service traffic requiring SNAT

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -269,6 +269,15 @@ func (i *Initializer) Initialize() error {
 		return err
 	}
 
+	if err := i.prepareHostNetwork(); err != nil {
+		return err
+	}
+
+	if err := i.setupOVSBridge(); err != nil {
+		return err
+	}
+
+	// initializeWireGuard must be executed after setupOVSBridge as it requires gateway addresses on the OVS bridge.
 	switch i.networkConfig.TrafficEncryptionMode {
 	case config.TrafficEncryptionModeIPSec:
 		if err := i.initializeIPSec(); err != nil {
@@ -278,14 +287,6 @@ func (i *Initializer) Initialize() error {
 		if err := i.initializeWireGuard(); err != nil {
 			return err
 		}
-	}
-
-	if err := i.prepareHostNetwork(); err != nil {
-		return err
-	}
-
-	if err := i.setupOVSBridge(); err != nil {
-		return err
 	}
 
 	wg.Add(1)

--- a/pkg/agent/wireguard/client_windows.go
+++ b/pkg/agent/wireguard/client_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 // Copyright 2021 Antrea Authors


### PR DESCRIPTION
The service traffic requiring SNAT couldn't be transferred to peer Node
when the endpoint Pod is on another Node. This was because we didn't
set any address on WireGuard device antrea-wg0. Therefore, when
iptables MASQUERADE action took effect, it chose one IP from other
interfaces, which might not be the gateway address on antrea-gw0. This
caused two problems:

1. Peer wireguard didn't accept the packet as its source address was not
in its "allowed ips"

2. Peer Node wouldn't route the response back via the encrypted tunnel
as the destination IP was not in its "allowed ips"

This patch fixes it by assigning the gateway IPs on the WireGuard
device. But it uses "/32" mask for IPv4 address and "/128" mask for
IPv6 address to avoid impacting routes on Antrea gateway.

Signed-off-by: Quan Tian <qtian@vmware.com>

Fixes #2696

Note: we cannot just add a rule to "ANTREA-POSTROUTING" chain which SNATs the traffic to the gateway's IP because currently KUBE-SERVICE chain is above ANTREA-POSTROUTING, it has applied MASQUERADE before it hits Antrea's rule.