### PR TITLE
Use "go install" to install the tools required by "make verify"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -382,9 +382,9 @@ endif
 .PHONY: verify
 verify:
 	@echo "===> Verifying spellings <==="
-	$(CURDIR)/hack/verify-spelling.sh
+	GO=$(GO) $(CURDIR)/hack/verify-spelling.sh
 	@echo "===> Verifying Table of Contents <==="
-	$(CURDIR)/hack/verify-toc.sh
+	GO=$(GO) $(CURDIR)/hack/verify-toc.sh
 	@echo "===> Verifying documentation formatting for website <==="
 	$(CURDIR)/hack/verify-docs-for-website.sh
 


### PR DESCRIPTION
To avoid the following warning when using Go 1.17 (default version for
Antrea):
go get: installing executables with 'go get' in module mode is deprecated.

See https://golang.org/doc/go-get-install-deprecation

Signed-off-by: Antonin Bas <abas@vmware.com>