### PR TITLE
Automated cherry pick of #2695: Wait for ovs-vswitchd PID before calling ovs-appctl

### DIFF
--- a/build/images/scripts/start_ovs
+++ b/build/images/scripts/start_ovs
@@ -112,6 +112,7 @@ function quit {
     stop_ovs
     # kill background sleep process
     if [ "$SLEEP_PID" != "" ]; then kill $SLEEP_PID > /dev/null 2>&1 || true; fi
+    cleanup_ovs_run_files
     exit 0
 }
 

--- a/pkg/ovs/ovsctl/interface.go
+++ b/pkg/ovs/ovsctl/interface.go
@@ -14,6 +14,7 @@
 package ovsctl
 
 import (
+	"fmt"
 	"net"
 	"os/exec"
 )
@@ -84,4 +85,8 @@ func (e *ExecError) GetErrorOutput() string {
 		return ""
 	}
 	return e.errorOutput
+}
+
+func (e *ExecError) Error() string {
+	return fmt.Sprintf("ExecError: %v, output: %s", e.error, e.errorOutput)
 }


### PR DESCRIPTION
Cherry pick of #2695 on release-1.3.

#2695: Wait for ovs-vswitchd PID before calling ovs-appctl

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.