### PR TITLE
[WIP] Egress IP featrue support multi network interfaces

### DIFF
--- a/pkg/agent/controller/egress/egress_controller_test.go
+++ b/pkg/agent/controller/egress/egress_controller_test.go
@@ -50,6 +50,8 @@ const (
 	fakeLocalEgressIP1  = "1.1.1.1"
 	fakeLocalEgressIP2  = "1.1.1.2"
 	fakeRemoteEgressIP1 = "1.1.1.3"
+	fakeEgressNodeIP1    = "1.1.1.4"
+	fakeEgressNodeIP2    = "1.1.1.5"
 	fakeNode            = "node1"
 )
 
@@ -186,9 +188,9 @@ func TestSyncEgress(t *testing.T) {
 				},
 			},
 			expectedCalls: func(mockOFClient *openflowtest.MockClient, mockRouteClient *routetest.MockInterface, mockIPAssigner *ipassignertest.MockIPAssigner) {
-				mockOFClient.EXPECT().InstallSNATMarkFlows(net.ParseIP(fakeLocalEgressIP1), uint32(1))
-				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(1), net.ParseIP(fakeLocalEgressIP1), uint32(1))
-				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(2), net.ParseIP(fakeLocalEgressIP1), uint32(1))
+				mockOFClient.EXPECT().InstallSNATMarkFlows(util.GenerateMacAddr(fakeLocalEgressIP1), net.ParseIP(fakeLocalEgressIP1), uint32(1))
+				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(1), util.GenerateMacAddr(fakeLocalEgressIP1), net.ParseIP(fakeEgressNodeIP1), uint32(1))
+				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(2), util.GenerateMacAddr(fakeLocalEgressIP1), net.ParseIP(fakeEgressNodeIP1), uint32(1))
 				mockRouteClient.EXPECT().AddSNATRule(net.ParseIP(fakeLocalEgressIP1), uint32(1))
 				mockIPAssigner.EXPECT().UnassignIP(fakeLocalEgressIP1)
 
@@ -198,8 +200,8 @@ func TestSyncEgress(t *testing.T) {
 				mockOFClient.EXPECT().UninstallPodSNATFlows(uint32(2))
 				mockIPAssigner.EXPECT().UnassignIP(fakeLocalEgressIP1)
 
-				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(1), net.ParseIP(fakeLocalEgressIP1), uint32(0))
-				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(3), net.ParseIP(fakeLocalEgressIP1), uint32(0))
+				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(1), util.GenerateMacAddr(fakeLocalEgressIP1), net.ParseIP(fakeEgressNodeIP1), uint32(0))
+				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(3), util.GenerateMacAddr(fakeLocalEgressIP1), net.ParseIP(fakeEgressNodeIP1), uint32(0))
 				mockIPAssigner.EXPECT().UnassignIP(fakeLocalEgressIP1)
 			},
 		},
@@ -236,17 +238,17 @@ func TestSyncEgress(t *testing.T) {
 				},
 			},
 			expectedCalls: func(mockOFClient *openflowtest.MockClient, mockRouteClient *routetest.MockInterface, mockIPAssigner *ipassignertest.MockIPAssigner) {
-				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(1), net.ParseIP(fakeRemoteEgressIP1), uint32(0))
-				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(2), net.ParseIP(fakeRemoteEgressIP1), uint32(0))
+				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(1), util.GenerateMacAddr(fakeLocalEgressIP1), net.ParseIP(fakeEgressNodeIP1), uint32(0))
+				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(2), util.GenerateMacAddr(fakeLocalEgressIP1), net.ParseIP(fakeEgressNodeIP1), uint32(0))
 				mockIPAssigner.EXPECT().UnassignIP(fakeRemoteEgressIP1)
 
 				mockOFClient.EXPECT().UninstallPodSNATFlows(uint32(1))
 				mockOFClient.EXPECT().UninstallPodSNATFlows(uint32(2))
 				mockIPAssigner.EXPECT().UnassignIP(fakeRemoteEgressIP1)
 
-				mockOFClient.EXPECT().InstallSNATMarkFlows(net.ParseIP(fakeRemoteEgressIP1), uint32(1))
-				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(1), net.ParseIP(fakeRemoteEgressIP1), uint32(1))
-				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(3), net.ParseIP(fakeRemoteEgressIP1), uint32(1))
+				mockOFClient.EXPECT().InstallSNATMarkFlows(util.GenerateMacAddr(fakeRemoteEgressIP1), net.ParseIP(fakeRemoteEgressIP1), uint32(1))
+				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(1), util.GenerateMacAddr(fakeRemoteEgressIP1), net.ParseIP(fakeEgressNodeIP2), uint32(1))
+				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(3), util.GenerateMacAddr(fakeRemoteEgressIP1), net.ParseIP(fakeEgressNodeIP2), uint32(1))
 				mockRouteClient.EXPECT().AddSNATRule(net.ParseIP(fakeRemoteEgressIP1), uint32(1))
 				mockIPAssigner.EXPECT().UnassignIP(fakeRemoteEgressIP1)
 			},
@@ -283,9 +285,9 @@ func TestSyncEgress(t *testing.T) {
 				},
 			},
 			expectedCalls: func(mockOFClient *openflowtest.MockClient, mockRouteClient *routetest.MockInterface, mockIPAssigner *ipassignertest.MockIPAssigner) {
-				mockOFClient.EXPECT().InstallSNATMarkFlows(net.ParseIP(fakeLocalEgressIP1), uint32(1))
-				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(1), net.ParseIP(fakeLocalEgressIP1), uint32(1))
-				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(2), net.ParseIP(fakeLocalEgressIP1), uint32(1))
+				mockOFClient.EXPECT().InstallSNATMarkFlows(util.GenerateMacAddr(fakeLocalEgressIP1), net.ParseIP(fakeLocalEgressIP1), uint32(1))
+				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(1), util.GenerateMacAddr(fakeLocalEgressIP1), net.ParseIP(fakeEgressNodeIP1), uint32(1))
+				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(2), util.GenerateMacAddr(fakeLocalEgressIP1), net.ParseIP(fakeEgressNodeIP1), uint32(1))
 				mockRouteClient.EXPECT().AddSNATRule(net.ParseIP(fakeLocalEgressIP1), uint32(1))
 				mockIPAssigner.EXPECT().UnassignIP(fakeLocalEgressIP1)
 
@@ -296,9 +298,9 @@ func TestSyncEgress(t *testing.T) {
 				mockIPAssigner.EXPECT().UnassignIP(fakeLocalEgressIP1)
 				mockIPAssigner.EXPECT().UnassignIP(fakeLocalEgressIP2)
 
-				mockOFClient.EXPECT().InstallSNATMarkFlows(net.ParseIP(fakeLocalEgressIP2), uint32(1))
-				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(1), net.ParseIP(fakeLocalEgressIP2), uint32(1))
-				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(3), net.ParseIP(fakeLocalEgressIP2), uint32(1))
+				mockOFClient.EXPECT().InstallSNATMarkFlows(util.GenerateMacAddr(fakeLocalEgressIP2), net.ParseIP(fakeLocalEgressIP2), uint32(1))
+				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(1), util.GenerateMacAddr(fakeLocalEgressIP2), net.ParseIP(fakeEgressNodeIP1), uint32(1))
+				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(3), util.GenerateMacAddr(fakeLocalEgressIP2), net.ParseIP(fakeEgressNodeIP1), uint32(1))
 				mockRouteClient.EXPECT().AddSNATRule(net.ParseIP(fakeLocalEgressIP2), uint32(1))
 				mockIPAssigner.EXPECT().UnassignIP(fakeLocalEgressIP2)
 			},
@@ -334,9 +336,9 @@ func TestSyncEgress(t *testing.T) {
 				},
 			},
 			expectedCalls: func(mockOFClient *openflowtest.MockClient, mockRouteClient *routetest.MockInterface, mockIPAssigner *ipassignertest.MockIPAssigner) {
-				mockOFClient.EXPECT().InstallSNATMarkFlows(net.ParseIP(fakeLocalEgressIP1), uint32(1))
-				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(1), net.ParseIP(fakeLocalEgressIP1), uint32(1))
-				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(2), net.ParseIP(fakeLocalEgressIP1), uint32(1))
+				mockOFClient.EXPECT().InstallSNATMarkFlows(util.GenerateMacAddr(fakeLocalEgressIP1), net.ParseIP(fakeLocalEgressIP1), uint32(1))
+				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(1), util.GenerateMacAddr(fakeLocalEgressIP1), net.ParseIP(fakeEgressNodeIP1), uint32(1))
+				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(2), util.GenerateMacAddr(fakeLocalEgressIP1), net.ParseIP(fakeEgressNodeIP1), uint32(1))
 				mockRouteClient.EXPECT().AddSNATRule(net.ParseIP(fakeLocalEgressIP1), uint32(1))
 				mockIPAssigner.EXPECT().UnassignIP(fakeLocalEgressIP1)
 
@@ -347,8 +349,8 @@ func TestSyncEgress(t *testing.T) {
 				mockIPAssigner.EXPECT().UnassignIP(fakeLocalEgressIP1)
 				mockIPAssigner.EXPECT().UnassignIP(fakeRemoteEgressIP1)
 
-				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(1), net.ParseIP(fakeRemoteEgressIP1), uint32(0))
-				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(3), net.ParseIP(fakeRemoteEgressIP1), uint32(0))
+				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(1), util.GenerateMacAddr(fakeRemoteEgressIP1), net.ParseIP(fakeEgressNodeIP2), uint32(0))
+				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(3), util.GenerateMacAddr(fakeRemoteEgressIP1), net.ParseIP(fakeEgressNodeIP2), uint32(0))
 				mockIPAssigner.EXPECT().UnassignIP(fakeRemoteEgressIP1)
 			},
 		},
@@ -384,8 +386,8 @@ func TestSyncEgress(t *testing.T) {
 				},
 			},
 			expectedCalls: func(mockOFClient *openflowtest.MockClient, mockRouteClient *routetest.MockInterface, mockIPAssigner *ipassignertest.MockIPAssigner) {
-				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(1), net.ParseIP(fakeRemoteEgressIP1), uint32(0))
-				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(2), net.ParseIP(fakeRemoteEgressIP1), uint32(0))
+				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(1), util.GenerateMacAddr(fakeRemoteEgressIP1), net.ParseIP(fakeEgressNodeIP2), uint32(0))
+				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(2), util.GenerateMacAddr(fakeRemoteEgressIP1), net.ParseIP(fakeEgressNodeIP2), uint32(0))
 				mockIPAssigner.EXPECT().UnassignIP(fakeRemoteEgressIP1)
 
 				mockOFClient.EXPECT().UninstallPodSNATFlows(uint32(1))
@@ -393,9 +395,9 @@ func TestSyncEgress(t *testing.T) {
 				mockIPAssigner.EXPECT().UnassignIP(fakeRemoteEgressIP1)
 				mockIPAssigner.EXPECT().UnassignIP(fakeLocalEgressIP1)
 
-				mockOFClient.EXPECT().InstallSNATMarkFlows(net.ParseIP(fakeLocalEgressIP1), uint32(1))
-				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(1), net.ParseIP(fakeLocalEgressIP1), uint32(1))
-				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(3), net.ParseIP(fakeLocalEgressIP1), uint32(1))
+				mockOFClient.EXPECT().InstallSNATMarkFlows(util.GenerateMacAddr(fakeLocalEgressIP1), net.ParseIP(fakeLocalEgressIP1), uint32(1))
+				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(1), util.GenerateMacAddr(fakeLocalEgressIP1), net.ParseIP(fakeEgressNodeIP1), uint32(1))
+				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(3), util.GenerateMacAddr(fakeLocalEgressIP1), net.ParseIP(fakeEgressNodeIP1), uint32(1))
 				mockRouteClient.EXPECT().AddSNATRule(net.ParseIP(fakeLocalEgressIP1), uint32(1))
 				mockIPAssigner.EXPECT().UnassignIP(fakeLocalEgressIP1)
 			},
@@ -437,14 +439,14 @@ func TestSyncEgress(t *testing.T) {
 				},
 			},
 			expectedCalls: func(mockOFClient *openflowtest.MockClient, mockRouteClient *routetest.MockInterface, mockIPAssigner *ipassignertest.MockIPAssigner) {
-				mockOFClient.EXPECT().InstallSNATMarkFlows(net.ParseIP(fakeLocalEgressIP1), uint32(1))
-				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(1), net.ParseIP(fakeLocalEgressIP1), uint32(1))
-				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(2), net.ParseIP(fakeLocalEgressIP1), uint32(1))
+				mockOFClient.EXPECT().InstallSNATMarkFlows(util.GenerateMacAddr(fakeLocalEgressIP1), net.ParseIP(fakeLocalEgressIP1), uint32(1))
+				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(1), util.GenerateMacAddr(fakeLocalEgressIP1), net.ParseIP(fakeEgressNodeIP1), uint32(1))
+				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(2),util.GenerateMacAddr(fakeLocalEgressIP1),  net.ParseIP(fakeEgressNodeIP1), uint32(1))
 				mockRouteClient.EXPECT().AddSNATRule(net.ParseIP(fakeLocalEgressIP1), uint32(1))
 				mockIPAssigner.EXPECT().UnassignIP(fakeLocalEgressIP1)
 
-				mockOFClient.EXPECT().InstallSNATMarkFlows(net.ParseIP(fakeLocalEgressIP2), uint32(2))
-				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(3), net.ParseIP(fakeLocalEgressIP2), uint32(2))
+				mockOFClient.EXPECT().InstallSNATMarkFlows(util.GenerateMacAddr(fakeLocalEgressIP2), net.ParseIP(fakeLocalEgressIP2), uint32(2))
+				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(3), util.GenerateMacAddr(fakeLocalEgressIP2), net.ParseIP(fakeEgressNodeIP1), uint32(2))
 				mockRouteClient.EXPECT().AddSNATRule(net.ParseIP(fakeLocalEgressIP2), uint32(2))
 				mockIPAssigner.EXPECT().UnassignIP(fakeLocalEgressIP2)
 
@@ -488,11 +490,11 @@ func TestSyncEgress(t *testing.T) {
 				},
 			},
 			expectedCalls: func(mockOFClient *openflowtest.MockClient, mockRouteClient *routetest.MockInterface, mockIPAssigner *ipassignertest.MockIPAssigner) {
-				mockOFClient.EXPECT().InstallSNATMarkFlows(net.ParseIP(fakeLocalEgressIP1), uint32(1))
-				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(1), net.ParseIP(fakeLocalEgressIP1), uint32(1))
-				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(2), net.ParseIP(fakeLocalEgressIP1), uint32(1))
+				mockOFClient.EXPECT().InstallSNATMarkFlows(util.GenerateMacAddr(fakeLocalEgressIP1), net.ParseIP(fakeLocalEgressIP1), uint32(1))
+				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(1), util.GenerateMacAddr(fakeLocalEgressIP1), net.ParseIP(fakeEgressNodeIP1), uint32(1))
+				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(2), util.GenerateMacAddr(fakeLocalEgressIP1), net.ParseIP(fakeEgressNodeIP1), uint32(1))
 				mockRouteClient.EXPECT().AddSNATRule(net.ParseIP(fakeLocalEgressIP1), uint32(1))
-				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(3), net.ParseIP(fakeLocalEgressIP1), uint32(1))
+				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(3), util.GenerateMacAddr(fakeLocalEgressIP1), net.ParseIP(fakeEgressNodeIP1), uint32(1))
 				mockIPAssigner.EXPECT().UnassignIP(fakeLocalEgressIP1).Times(3)
 			},
 		},
@@ -594,22 +596,22 @@ func TestSyncOverlappingEgress(t *testing.T) {
 	item, _ = c.queue.Get()
 	c.queue.Done(item)
 
-	c.mockOFClient.EXPECT().InstallSNATMarkFlows(net.ParseIP(fakeLocalEgressIP1), uint32(1))
-	c.mockOFClient.EXPECT().InstallPodSNATFlows(uint32(1), net.ParseIP(fakeLocalEgressIP1), uint32(1))
-	c.mockOFClient.EXPECT().InstallPodSNATFlows(uint32(2), net.ParseIP(fakeLocalEgressIP1), uint32(1))
+	c.mockOFClient.EXPECT().InstallSNATMarkFlows(util.GenerateMacAddr(fakeLocalEgressIP1), net.ParseIP(fakeLocalEgressIP1), uint32(1))
+	c.mockOFClient.EXPECT().InstallPodSNATFlows(uint32(1), util.GenerateMacAddr(fakeLocalEgressIP1), net.ParseIP(fakeEgressNodeIP1), uint32(1))
+	c.mockOFClient.EXPECT().InstallPodSNATFlows(uint32(2), util.GenerateMacAddr(fakeLocalEgressIP1), net.ParseIP(fakeEgressNodeIP1), uint32(1))
 	c.mockRouteClient.EXPECT().AddSNATRule(net.ParseIP(fakeLocalEgressIP1), uint32(1))
 	c.mockIPAssigner.EXPECT().UnassignIP(fakeLocalEgressIP1)
 	err := c.syncEgress(egress1.Name)
 	assert.NoError(t, err)
 
 	// egress2's IP is not local and pod1 has enforced egress1, so only one Pod SNAT flow is expected.
-	c.mockOFClient.EXPECT().InstallPodSNATFlows(uint32(3), net.ParseIP(fakeRemoteEgressIP1), uint32(0))
+	c.mockOFClient.EXPECT().InstallPodSNATFlows(uint32(3), util.GenerateMacAddr(fakeLocalEgressIP1), net.ParseIP(fakeEgressNodeIP1), uint32(0))
 	c.mockIPAssigner.EXPECT().UnassignIP(fakeRemoteEgressIP1)
 	err = c.syncEgress(egress2.Name)
 	assert.NoError(t, err)
 
 	// egress3 shares the same IP as egress1 and pod2 has enforced egress1, so only one Pod SNAT flow is expected.
-	c.mockOFClient.EXPECT().InstallPodSNATFlows(uint32(4), net.ParseIP(fakeLocalEgressIP1), uint32(1))
+	c.mockOFClient.EXPECT().InstallPodSNATFlows(uint32(4), util.GenerateMacAddr(fakeLocalEgressIP1), net.ParseIP(fakeEgressNodeIP1), uint32(1))
 	c.mockIPAssigner.EXPECT().UnassignIP(fakeLocalEgressIP1)
 	err = c.syncEgress(egress3.Name)
 	assert.NoError(t, err)
@@ -638,13 +640,13 @@ func TestSyncOverlappingEgress(t *testing.T) {
 	assert.ElementsMatch(t, []string{egress2.Name, egress3.Name}, pendingItems)
 
 	// pod1 is expected to enforce egress2.
-	c.mockOFClient.EXPECT().InstallPodSNATFlows(uint32(1), net.ParseIP(fakeRemoteEgressIP1), uint32(0))
+	c.mockOFClient.EXPECT().InstallPodSNATFlows(uint32(1), util.GenerateMacAddr(fakeRemoteEgressIP1), net.ParseIP(fakeEgressNodeIP2), uint32(0))
 	c.mockIPAssigner.EXPECT().UnassignIP(fakeRemoteEgressIP1)
 	err = c.syncEgress(egress2.Name)
 	assert.NoError(t, err)
 
 	// pod2 is expected to enforce egress3.
-	c.mockOFClient.EXPECT().InstallPodSNATFlows(uint32(2), net.ParseIP(fakeLocalEgressIP1), uint32(1))
+	c.mockOFClient.EXPECT().InstallPodSNATFlows(uint32(2), util.GenerateMacAddr(fakeLocalEgressIP1), net.ParseIP(fakeEgressNodeIP1), uint32(1))
 	c.mockIPAssigner.EXPECT().UnassignIP(fakeLocalEgressIP1)
 	err = c.syncEgress(egress3.Name)
 	assert.NoError(t, err)

--- a/pkg/agent/openflow/pipeline_other.go
+++ b/pkg/agent/openflow/pipeline_other.go
@@ -26,8 +26,8 @@ import (
 	binding "antrea.io/antrea/pkg/ovs/openflow"
 )
 
-func (c *client) snatMarkFlows(snatIP net.IP, mark uint32) []binding.Flow {
-	return []binding.Flow{c.snatIPFromTunnelFlow(snatIP, mark)}
+func (c *client) snatMarkFlows(mac net.HardwareAddr, snatIP net.IP, mark uint32) []binding.Flow {
+	return []binding.Flow{c.snatIPFromTunnelFlow(mac, snatIP, mark)}
 }
 
 func (c *client) l3FwdFlowToRemoteViaRouting(localGatewayMAC net.HardwareAddr, remoteGatewayMAC net.HardwareAddr,

--- a/pkg/agent/openflow/pipeline_windows.go
+++ b/pkg/agent/openflow/pipeline_windows.go
@@ -47,12 +47,12 @@ var (
 	snatCTMark = binding.NewCTMark(0x40, 0, 31)
 )
 
-func (c *client) snatMarkFlows(snatIP net.IP, mark uint32) []binding.Flow {
+func (c *client) snatMarkFlows(mac net.HardwareAddr, snatIP net.IP, mark uint32) []binding.Flow {
 	snatIPRange := &binding.IPRange{StartIP: snatIP, EndIP: snatIP}
 	ctCommitTable := c.pipeline[conntrackCommitTable]
 	nextTable := ctCommitTable.GetNext()
 	flows := []binding.Flow{
-		c.snatIPFromTunnelFlow(snatIP, mark),
+		c.snatIPFromTunnelFlow(mac, snatIP, mark),
 		ctCommitTable.BuildFlow(priorityNormal).
 			MatchProtocol(binding.ProtocolIP).
 			MatchCTStateNew(true).MatchCTStateTrk(true).MatchCTStateDNAT(false).

--- a/pkg/agent/openflow/testing/mock_openflow.go
+++ b/pkg/agent/openflow/testing/mock_openflow.go
@@ -406,7 +406,7 @@ func (mr *MockClientMockRecorder) InstallPodFlows(arg0, arg1, arg2, arg3 interfa
 }
 
 // InstallPodSNATFlows mocks base method
-func (m *MockClient) InstallPodSNATFlows(arg0 uint32, arg1 net.IP, arg2 uint32) error {
+func (m *MockClient) InstallPodSNATFlows(arg0 uint32, arg1 net.HardwareAddr, arg2 net.IP, arg3 uint32) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstallPodSNATFlows", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -414,9 +414,9 @@ func (m *MockClient) InstallPodSNATFlows(arg0 uint32, arg1 net.IP, arg2 uint32) 
 }
 
 // InstallPodSNATFlows indicates an expected call of InstallPodSNATFlows
-func (mr *MockClientMockRecorder) InstallPodSNATFlows(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) InstallPodSNATFlows(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallPodSNATFlows", reflect.TypeOf((*MockClient)(nil).InstallPodSNATFlows), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallPodSNATFlows", reflect.TypeOf((*MockClient)(nil).InstallPodSNATFlows), arg0, arg1, arg2, arg3)
 }
 
 // InstallPolicyRuleFlows mocks base method
@@ -434,17 +434,17 @@ func (mr *MockClientMockRecorder) InstallPolicyRuleFlows(arg0 interface{}) *gomo
 }
 
 // InstallSNATMarkFlows mocks base method
-func (m *MockClient) InstallSNATMarkFlows(arg0 net.IP, arg1 uint32) error {
+func (m *MockClient) InstallSNATMarkFlows(arg0 net.HardwareAddr, arg1 net.IP, arg2 uint32) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstallSNATMarkFlows", arg0, arg1)
+	ret := m.ctrl.Call(m, "InstallSNATMarkFlows", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InstallSNATMarkFlows indicates an expected call of InstallSNATMarkFlows
-func (mr *MockClientMockRecorder) InstallSNATMarkFlows(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) InstallSNATMarkFlows(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallSNATMarkFlows", reflect.TypeOf((*MockClient)(nil).InstallSNATMarkFlows), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallSNATMarkFlows", reflect.TypeOf((*MockClient)(nil).InstallSNATMarkFlows), arg0, arg1, arg2)
 }
 
 // InstallServiceFlows mocks base method

--- a/pkg/agent/util/net.go
+++ b/pkg/agent/util/net.go
@@ -90,6 +90,18 @@ func GenerateNodeTunnelInterfaceName(nodeName string) string {
 	return generateInterfaceName(GenerateNodeTunnelInterfaceKey(nodeName), nodeName, false)
 }
 
+// The GenerateMacAddr is guaranteed to be consistent: the same key will always yield the same
+// MAC address.
+func GenerateMacAddr(key string) net.HardwareAddr {
+	hash := sha1.New() // #nosec G401: not used for security purposes
+	io.WriteString(hash, key)
+	macKey := hash.Sum(nil)
+	// In the first byte of the MAC, the 'multicast' bit should be
+	// clear and 'locally administered' bit should be set.
+	macKey[0] = (macKey[0] & 0xFE) | 0x02
+	return net.HardwareAddr(macKey[:6])
+}
+
 type LinkNotFound struct {
 	error
 }

--- a/pkg/agent/util/net_test.go
+++ b/pkg/agent/util/net_test.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"antrea.io/antrea/pkg/util/ip"
 )
 
@@ -46,6 +48,28 @@ func TestGenerateContainerInterfaceName(t *testing.T) {
 	iface2 := GenerateContainerInterfaceName(podName1, podNamespace, containerID1)
 	if iface1 == iface2 {
 		t.Errorf("failed to differentiate interfaces with pods that have the same pod namespace and name")
+	}
+}
+
+func TestGenerateMacAddr(t *testing.T) {
+	testcases := []struct {
+		// input
+		key string
+		// expectations
+		expectedMac net.HardwareAddr
+	}{
+		{
+			key: "192.168.0.1",
+			expectedMac: net.HardwareAddr([]byte{0x26, 0xed, 0x8b, 0xba, 0xbb, 0x59}),
+		},
+		{
+			key: "pod1-abcde-12345",
+			expectedMac: net.HardwareAddr([]byte{0xba, 0x76, 0x6, 0x49, 0xfb, 0xf8}),
+		},
+	}
+	for _, tc := range testcases {
+		parsedMac := GenerateMacAddr(tc.key)
+		assert.Equal(t, tc.expectedMac, parsedMac)
 	}
 }
 


### PR DESCRIPTION
1.Use the egress node transport ip as tunnel destination ip.

2.Generate a virtual mac by SNAT ip, and set the mac to be source mac, then match 
the SNAT packets by the virtual mac on egress node.

Fixes:  #2685

Signed-off-by: Wu zhengdong <zhengdong.wu@transwarp.io>