### PR TITLE
[WIP]Enhance FQDN processing for dual stack

### DIFF
--- a/ci/jenkins/test-vm.sh
+++ b/ci/jenkins/test-vm.sh
@@ -275,7 +275,7 @@ function run_e2e_vms {
     configure_vm_agent
     echo "====== Running Antrea e2e Tests for VM ======"
     mkdir -p `pwd`/antrea-test-logs
-    go test -v -timeout=100m antrea.io/antrea/test/e2e -run=TestVMAgent --logs-export-dir `pwd`/antrea-test-logs -provider=remote -windowsVMs="${WIN_HOSTNAMES[*]}" -linuxVMs="${LIN_HOSTNAMES[*]}"
+    go test -v -timeout=100m antrea.io/antrea/test/e2e -run=TestVMAgent --logs-export-dir `pwd`/antrea-test-logs -provider=remote -windowsVMs="${WIN_HOSTNAMES[*]}" -linuxVMs="${LIN_HOSTNAMES[*]}" -run=TestAntreaPolicy
     if [[ "$?" != "0" ]]; then
         TEST_FAILURE=true
     fi

--- a/ci/jenkins/test-vmc.sh
+++ b/ci/jenkins/test-vmc.sh
@@ -502,11 +502,11 @@ function run_e2e {
         mkdir -p ${GIT_CHECKOUT_DIR}/e2e-coverage
         # HACK: see https://github.com/antrea-io/antrea/issues/2292
         go mod edit -replace github.com/moby/spdystream=github.com/antoninbas/spdystream@v0.2.1 && go mod tidy
-        go test -v -timeout=100m antrea.io/antrea/test/e2e --logs-export-dir ${GIT_CHECKOUT_DIR}/antrea-test-logs --prometheus --coverage --coverage-dir ${GIT_CHECKOUT_DIR}/e2e-coverage --provider remote --remote.sshconfig "${CLUSTER_SSHCONFIG}" --remote.kubeconfig "${CLUSTER_KUBECONFIG}"
+        go test -v -timeout=100m antrea.io/antrea/test/e2e --logs-export-dir ${GIT_CHECKOUT_DIR}/antrea-test-logs --prometheus --coverage --coverage-dir ${GIT_CHECKOUT_DIR}/e2e-coverage --provider remote --remote.sshconfig "${CLUSTER_SSHCONFIG}" --remote.kubeconfig "${CLUSTER_KUBECONFIG}" -run=TestAntreaPolicy
     else
         # HACK: see https://github.com/antrea-io/antrea/issues/2292
         go mod edit -replace github.com/moby/spdystream=github.com/antoninbas/spdystream@v0.2.1 && go mod tidy
-        go test -v -timeout=100m antrea.io/antrea/test/e2e --logs-export-dir ${GIT_CHECKOUT_DIR}/antrea-test-logs --prometheus --provider remote --remote.sshconfig "${CLUSTER_SSHCONFIG}" --remote.kubeconfig "${CLUSTER_KUBECONFIG}"
+        go test -v -timeout=100m antrea.io/antrea/test/e2e --logs-export-dir ${GIT_CHECKOUT_DIR}/antrea-test-logs --prometheus --provider remote --remote.sshconfig "${CLUSTER_SSHCONFIG}" --remote.kubeconfig "${CLUSTER_KUBECONFIG}" -run=TestAntreaPolicy
     fi
 
     test_rc=$?

--- a/ci/jenkins/test.sh
+++ b/ci/jenkins/test.sh
@@ -689,9 +689,9 @@ function run_e2e {
     # HACK: see https://github.com/antrea-io/antrea/issues/2292
     go mod edit -replace github.com/moby/spdystream=github.com/antoninbas/spdystream@v0.2.1 && go mod tidy
     if [[ $TESTBED_TYPE == "flexible-ipam" ]]; then
-        go test -v antrea.io/antrea/test/e2e --logs-export-dir `pwd`/antrea-test-logs --provider remote -timeout=100m --prometheus --antrea-ipam
+        go test -v antrea.io/antrea/test/e2e --logs-export-dir `pwd`/antrea-test-logs --provider remote -timeout=100m --prometheus --antrea-ipam -run=TestAntreaPolicy
     else
-        go test -v antrea.io/antrea/test/e2e --logs-export-dir `pwd`/antrea-test-logs --provider remote -timeout=100m --prometheus
+        go test -v antrea.io/antrea/test/e2e --logs-export-dir `pwd`/antrea-test-logs --provider remote -timeout=100m --prometheus -run=TestAntreaPolicy
     fi
     if [[ "$?" != "0" ]]; then
         TEST_FAILURE=true

--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -427,7 +427,6 @@ func run(o *Options) error {
 		gwPort = nodeConfig.GatewayConfig.OFPort
 		tunPort = nodeConfig.TunnelOFPort
 	}
-
 	nodeKey := nodeConfig.Name
 	if o.nodeType == config.ExternalNode {
 		nodeKey = k8s.NamespacedName(o.config.ExternalNode.ExternalNodeNamespace, nodeKey)

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
@@ -171,9 +171,10 @@ func NewNetworkPolicyController(antreaClientGetter agent.AntreaClientProvider,
 		c.l7RuleReconciler = l7engine.NewReconciler()
 		c.l7VlanIDAllocator = newL7VlanIDAllocator()
 	}
-
+	klog.Infof("======= NewNetworkPolicyController")
 	if antreaPolicyEnabled {
 		var err error
+		klog.Infof("=========== start fqdn controller")
 		if c.fqdnController, err = newFQDNController(ofClient, idAllocator, dnsServerOverride, c.enqueueRule, v4Enabled, v6Enabled, gwPort); err != nil {
 			return nil, err
 		}

--- a/pkg/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller.go
@@ -411,6 +411,7 @@ func NewNetworkPolicyController(kubeClient clientset.Interface,
 		labelIdentityInterface:     labelIdentityInterface,
 		stretchNPEnabled:           stretchedNPEnabled,
 	}
+	klog.Infof("======= in antrea controller new np controller")
 	n.groupingInterface.AddEventHandler(appliedToGroupType, n.enqueueAppliedToGroup)
 	n.groupingInterface.AddEventHandler(addressGroupType, n.enqueueAddressGroup)
 	n.groupingInterface.AddEventHandler(internalGroupType, n.enqueueInternalGroup)


### PR DESCRIPTION
An IP address is kicked out of the DNS cache for a specific FQDN, if it has past the TTL and is not seen in the latest dns response for that FQDN. However, this needs to be fine-tuned for dual-stack cases. An IPv6 address of an FQDN should not be evicted if it has past TTL and a A response for that FQDN does not contain that address (which it never will). The FQDN controller should wait for the AAA response to determine whether that record should stay. The reverse is true for IPv4. This could cause some churn in dataplane, where some addresses got removed in OVS rules, just to be added 0.01s later.

This issue is fixed by having separate DNSMetas for the IPv4 and IPv6 addresses for the same FQDN.

Signed-off-by: wgrayson <wgrayson@vmware.com>