### PR TITLE
[CI] Update Service tests

### DIFF
--- a/ci/jenkins/test.sh
+++ b/ci/jenkins/test.sh
@@ -32,7 +32,7 @@ GO_VERSION=$(head -n1 "${WORKSPACE}/build/images/deps/go-version")
 IMAGE_PULL_POLICY="Always"
 
 WINDOWS_CONFORMANCE_FOCUS="\[sig-network\].+\[Conformance\]|\[sig-windows\]"
-WINDOWS_CONFORMANCE_SKIP="\[LinuxOnly\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[sig-cli\]|\[sig-storage\]|\[sig-auth\]|\[sig-api-machinery\]|\[sig-apps\]|\[sig-node\]|\[Privileged\]|should be able to change the type from|\[sig-network\] Services should be able to create a functioning NodePort service \[Conformance\]|Service endpoints latency should not be very high|should be able to create a functioning NodePort service for Windows"
+WINDOWS_CONFORMANCE_SKIP="\[LinuxOnly\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[sig-cli\]|\[sig-storage\]|\[sig-auth\]|\[sig-api-machinery\]|\[sig-apps\]|\[sig-node\]|\[Privileged\]|should be able to change the type from|Service endpoints latency should not be very high"
 WINDOWS_NETWORKPOLICY_FOCUS="\[Feature:NetworkPolicy\]"
 WINDOWS_NETWORKPOLICY_SKIP="SCTP"
 CONFORMANCE_SKIP="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[sig-cli\]|\[sig-storage\]|\[sig-auth\]|\[sig-api-machinery\]|\[sig-apps\]|\[sig-node\]"

--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -111,12 +111,6 @@ func skipIfHasWindowsNodes(tb testing.TB) {
 	}
 }
 
-func skipIfNoWindowsNodes(tb testing.TB) {
-	if len(clusterInfo.windowsNodes) == 0 {
-		tb.Skipf("Skipping test as the cluster has no Windows Nodes")
-	}
-}
-
 func skipIfFeatureDisabled(tb testing.TB, feature featuregate.Feature, checkAgent bool, checkController bool) {
 	if checkAgent {
 		if featureGate, err := GetAgentFeatures(); err != nil {

--- a/test/e2e/k8s_util.go
+++ b/test/e2e/k8s_util.go
@@ -232,7 +232,7 @@ func (k *KubernetesUtils) CreateOrUpdateDeployment(ns, deploymentName string, re
 		return v1.Container{
 			Name:            fmt.Sprintf("c%d", port),
 			ImagePullPolicy: v1.PullIfNotPresent,
-			Image:           "k8s.gcr.io/e2e-test-images/agnhost:2.29",
+			Image:           agnhostImage,
 			Env:             []v1.EnvVar{{Name: fmt.Sprintf("SERVE_SCTP_PORT_%d", port), Value: "foo"}},
 			Command:         []string{"/bin/bash", "-c"},
 			Args:            args,

--- a/third_party/ipam/controller_util_node/controller_utils.go
+++ b/third_party/ipam/controller_util_node/controller_utils.go
@@ -56,7 +56,7 @@ import (
 )
 
 // RecordNodeStatusChange records a event related to a node status change. (Common to lifecycle and ipam)
-func RecordNodeStatusChange(/*recorder record.EventRecorder,*/ node *v1.Node, newStatus string) {
+func RecordNodeStatusChange( /*recorder record.EventRecorder,*/ node *v1.Node, newStatus string) {
 	//ref := &v1.ObjectReference{
 	//	APIVersion: "v1",
 	//	Kind:       "Node",

--- a/third_party/ipam/nodeipam/ipam/cidrset/metrics.go
+++ b/third_party/ipam/nodeipam/ipam/cidrset/metrics.go
@@ -43,7 +43,7 @@ import (
 
 const (
 	metricNamespaceAntrea = "antrea"
-	nodeIpamSubsystem = "node_ipam_controller"
+	nodeIpamSubsystem     = "node_ipam_controller"
 )
 
 var (


### PR DESCRIPTION
* Enable conformance NodePort Service tests on Windows testbed
* Remove NodePort e2e tests
* Refactor ClusterIP e2e tests to enable parallelism
* Unify agnhostImage
* go fmt

Signed-off-by: Zhecheng Li <lzhecheng@vmware.com>