### PR TITLE
Allow multiple drivers per IPAM type

### DIFF
--- a/pkg/agent/cniserver/ipam/antrea_ipam.go
+++ b/pkg/agent/cniserver/ipam/antrea_ipam.go
@@ -1,0 +1,67 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipam
+
+import (
+	"github.com/containernetworking/cni/pkg/invoke"
+	"github.com/containernetworking/cni/pkg/types/current"
+	"k8s.io/klog/v2"
+
+	argtypes "antrea.io/antrea/pkg/agent/cniserver/types"
+)
+
+const (
+	ipamAntrea = "antrea-ipam"
+)
+
+// Antrea IPAM driver would allocate IP addresses according to object IPAM annotation,
+// if present. If annotation is not present, the driver will delegate functionality
+// to traditional IPAM driver specified in pluginType
+type AntreaIPAM struct {
+	ipPoolName string
+}
+
+func (d *AntreaIPAM) Add(args *invoke.Args, networkConfig []byte) (*current.Result, error) {
+	// TODO - read the pool and allocate IP address
+	return nil, nil
+}
+
+func (d *AntreaIPAM) Del(args *invoke.Args, networkConfig []byte) error {
+	// TODO - read the pool and release IP address
+	return nil
+}
+
+func (d *AntreaIPAM) Check(args *invoke.Args, networkConfig []byte) error {
+	// TODO - read the pool and verify IP address
+	return nil
+}
+
+func (d *AntreaIPAM) Owns(args *invoke.Args, k8sArgs *argtypes.K8sArgs, networkConfig []byte) bool {
+	// TODO - read namespace based on k8sArgs and check ipam annotation
+	// If present, set ipPoolName and return true
+	return false
+}
+
+func init() {
+	// Antrea driver must come first
+	if err := RegisterIPAMDriver(ipamAntrea, &AntreaIPAM{}); err != nil {
+		klog.Errorf("Failed to register IPAM plugin on type %s", ipamAntrea)
+	}
+
+	// Host local plugin is fallback driver
+	if err := RegisterIPAMDriver(ipamAntrea, &IPAMDelegator{pluginType: ipamHostLocal}); err != nil {
+		klog.Errorf("Failed to register IPAM plugin on type %s", ipamHostLocal)
+	}
+}

--- a/pkg/agent/cniserver/ipam/ipam_delegator.go
+++ b/pkg/agent/cniserver/ipam/ipam_delegator.go
@@ -23,6 +23,8 @@ import (
 	"github.com/containernetworking/cni/pkg/types"
 	"github.com/containernetworking/cni/pkg/types/current"
 	"k8s.io/klog/v2"
+
+	argtypes "antrea.io/antrea/pkg/agent/cniserver/types"
 )
 
 const (
@@ -74,6 +76,10 @@ func (d *IPAMDelegator) Check(args *invoke.Args, networkConfig []byte) error {
 		return err
 	}
 	return nil
+}
+
+func (d *IPAMDelegator) Owns(args *invoke.Args, k8sArgs *argtypes.K8sArgs, networkConfig []byte) bool {
+	return true
 }
 
 var defaultExec = &invoke.DefaultExec{

--- a/pkg/agent/cniserver/ipam/testing/mock_ipam.go
+++ b/pkg/agent/cniserver/ipam/testing/mock_ipam.go
@@ -20,6 +20,7 @@
 package testing
 
 import (
+	types "antrea.io/antrea/pkg/agent/cniserver/types"
 	invoke "github.com/containernetworking/cni/pkg/invoke"
 	current "github.com/containernetworking/cni/pkg/types/current"
 	gomock "github.com/golang/mock/gomock"
@@ -90,4 +91,18 @@ func (m *MockIPAMDriver) Del(arg0 *invoke.Args, arg1 []byte) error {
 func (mr *MockIPAMDriverMockRecorder) Del(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Del", reflect.TypeOf((*MockIPAMDriver)(nil).Del), arg0, arg1)
+}
+
+// Owns mocks base method
+func (m *MockIPAMDriver) Owns(arg0 *invoke.Args, arg1 *types.K8sArgs, arg2 []byte) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Owns", arg0, arg1, arg2)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// Owns indicates an expected call of Owns
+func (mr *MockIPAMDriverMockRecorder) Owns(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Owns", reflect.TypeOf((*MockIPAMDriver)(nil).Owns), arg0, arg1, arg2)
 }

--- a/pkg/agent/cniserver/ipam/testing/mock_multi_driver.go
+++ b/pkg/agent/cniserver/ipam/testing/mock_multi_driver.go
@@ -1,0 +1,104 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package testing
+
+import (
+	argtypes "antrea.io/antrea/pkg/agent/cniserver/types"
+
+	invoke "github.com/containernetworking/cni/pkg/invoke"
+	current "github.com/containernetworking/cni/pkg/types/current"
+	gomock "github.com/golang/mock/gomock"
+
+	reflect "reflect"
+)
+
+// MockIPAMMultiDriver is a mock of IPAMDriver interface
+type MockIPAMMultiDriver struct {
+	ctrl     *gomock.Controller
+	recorder *MockIPAMMultiDriverMockRecorder
+	ownsFunc func(*argtypes.K8sArgs) bool
+}
+
+// MockIPAMMultiDriverMockRecorder is the mock recorder for MockIPAMMultiDriver
+type MockIPAMMultiDriverMockRecorder struct {
+	mock *MockIPAMMultiDriver
+}
+
+// NewMockIPAMMultiDriver creates a new mock instance
+func NewMockIPAMMultiDriver(ctrl *gomock.Controller, ownsFunc func(*argtypes.K8sArgs) bool) *MockIPAMMultiDriver {
+	mock := &MockIPAMMultiDriver{ctrl: ctrl}
+	mock.recorder = &MockIPAMMultiDriverMockRecorder{mock}
+	mock.ownsFunc = ownsFunc
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockIPAMMultiDriver) EXPECT() *MockIPAMMultiDriverMockRecorder {
+	return m.recorder
+}
+
+// Add mocks base method
+func (m *MockIPAMMultiDriver) Add(arg0 *invoke.Args, arg1 []byte) (*current.Result, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Add", arg0, arg1)
+	ret0, _ := ret[0].(*current.Result)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Add indicates an expected call of Add
+func (mr *MockIPAMMultiDriverMockRecorder) Add(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Add", reflect.TypeOf((*MockIPAMMultiDriver)(nil).Add), arg0, arg1)
+}
+
+// Check mocks base method
+func (m *MockIPAMMultiDriver) Check(arg0 *invoke.Args, arg1 []byte) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Check", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Check indicates an expected call of Check
+func (mr *MockIPAMMultiDriverMockRecorder) Check(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Check", reflect.TypeOf((*MockIPAMMultiDriver)(nil).Check), arg0, arg1)
+}
+
+// Del mocks base method
+func (m *MockIPAMMultiDriver) Del(arg0 *invoke.Args, arg1 []byte) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Del", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Del indicates an expected call of Del
+func (mr *MockIPAMMultiDriverMockRecorder) Del(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Del", reflect.TypeOf((*MockIPAMMultiDriver)(nil).Del), arg0, arg1)
+}
+
+// We don't record a call to Owns, since its a helper method, and rely on functional calls
+// such as Add, Del in testing
+func (m *MockIPAMMultiDriver) Owns(arg0 *invoke.Args, k8sArgs *argtypes.K8sArgs, arg2 []byte) bool {
+	if m.ownsFunc == nil {
+		return true
+	}
+
+	return m.ownsFunc(k8sArgs)
+}

--- a/pkg/agent/cniserver/pod_configuration.go
+++ b/pkg/agent/cniserver/pod_configuration.go
@@ -20,7 +20,6 @@ import (
 	"net"
 	"strings"
 
-	cnitypes "github.com/containernetworking/cni/pkg/types"
 	"github.com/containernetworking/cni/pkg/types/current"
 	"github.com/containernetworking/cni/pkg/version"
 	corev1 "k8s.io/api/core/v1"
@@ -41,13 +40,6 @@ type vethPair struct {
 	name      string
 	ifIndex   int
 	peerIndex int
-}
-
-type k8sArgs struct {
-	cnitypes.CommonArgs
-	K8S_POD_NAME               cnitypes.UnmarshallableString
-	K8S_POD_NAMESPACE          cnitypes.UnmarshallableString
-	K8S_POD_INFRA_CONTAINER_ID cnitypes.UnmarshallableString
 }
 
 const (

--- a/pkg/agent/cniserver/types/arg_types.go
+++ b/pkg/agent/cniserver/types/arg_types.go
@@ -1,0 +1,26 @@
+// Copyright 2019 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	cnitypes "github.com/containernetworking/cni/pkg/types"
+)
+
+type K8sArgs struct {
+	cnitypes.CommonArgs
+	K8S_POD_NAME               cnitypes.UnmarshallableString
+	K8S_POD_NAMESPACE          cnitypes.UnmarshallableString
+	K8S_POD_INFRA_CONTAINER_ID cnitypes.UnmarshallableString
+}

--- a/test/integration/agent/cniserver_test.go
+++ b/test/integration/agent/cniserver_test.go
@@ -600,6 +600,7 @@ func cmdAddDelCheckTest(testNS ns.NetNS, tc testCase, dataDir string) {
 	tester.setNS(testNS, targetNS)
 
 	ipamResult := ipamtest.GenerateIPAMResult("0.4.0", tc.addresses, tc.Routes, tc.DNS)
+	ipamMock.EXPECT().Owns(mock.Any(), mock.Any(), mock.Any()).Return(true).AnyTimes()
 	ipamMock.EXPECT().Add(mock.Any(), mock.Any()).Return(ipamResult, nil).AnyTimes()
 
 	// Mock ovs output while get ovs port external configuration
@@ -666,7 +667,9 @@ func TestAntreaServerFunc(t *testing.T) {
 		dataDir, err = ioutil.TempDir("", "antrea_server_test")
 		require.Nil(t, err)
 
+		ipamMock.EXPECT().Owns(mock.Any(), mock.Any(), mock.Any()).Return(true).AnyTimes()
 		ipamMock.EXPECT().Del(mock.Any(), mock.Any()).Return(nil).AnyTimes()
+		ipamMock.EXPECT().Owns(mock.Any(), mock.Any(), mock.Any()).Return(true).AnyTimes()
 		ipamMock.EXPECT().Check(mock.Any(), mock.Any()).Return(nil).AnyTimes()
 
 		ovsServiceMock.EXPECT().GetPortList().Return([]ovsconfig.OVSPortData{}, nil).AnyTimes()


### PR DESCRIPTION
In preparation for antrea IPAM support, allow a list of drivers to
be registered. This is useful for antrea IPAM: antrea ipam driver
will claim ownership of request if corersponding object has ipam
annotation. Otherwise, fallback driver (host-local) will handle
ipam for this request.

Signed-off-by: Anna Khmelnitsky <akhmelnitsky@vmware.com>