### PR TITLE
Stop checking virtualbox.com in markdown link checker

### DIFF
--- a/hack/.md_links_config.json
+++ b/hack/.md_links_config.json
@@ -23,6 +23,9 @@
         },
         {
             "pattern": "https://nssm.cc/"
+        },
+        {
+            "pattern": "https://www.virtualbox.org/*"
         }
     ],
     "retryOn429": false,


### PR DESCRIPTION
For some reason, the site is down pretty often, causing CI failures. I
have confirmed it manually, so it is not an issue with the link checker
itself.

Signed-off-by: Antonin Bas <abas@vmware.com>