### PR TITLE
Change dockerLibraryRegistry for conformance testing

### DIFF
--- a/ci/conformance-image-config.yaml
+++ b/ci/conformance-image-config.yaml
@@ -1,1 +1,1 @@
-dockerLibraryRegistry: mirror.gcr.io/library
+dockerLibraryRegistry: k8s.gcr.io/e2e-test-images


### PR DESCRIPTION
It seems that images are sometimes missing from
mirror.gcr.io/library. After some testing, it seems that
k8s.gcr.io/e2e-test-images includes all images.

Signed-off-by: Antonin Bas <abas@vmware.com>