### PR TITLE
[Windows] Bugfix: Agent crashed when removing the existing NetNat

### DIFF
--- a/pkg/agent/util/net_windows.go
+++ b/pkg/agent/util/net_windows.go
@@ -596,7 +596,7 @@ func CreateNetNatOnHost(subnetCIDR *net.IPNet) error {
 			return nil
 		}
 		klog.InfoS("Removing the existing netnat", "name", netNatName, "internalIPInterfaceAddressPrefix", internalNet)
-		cmd = fmt.Sprintf("Remove-NetNat -Name %s", netNatName)
+		cmd = fmt.Sprintf("Remove-NetNat -Name %s -Confirm:$false", netNatName)
 		if _, err := ps.RunCommand(cmd); err != nil {
 			klog.ErrorS(err, "Failed to remove the existing netnat", "name", netNatName, "internalIPInterfaceAddressPrefix", internalNet)
 			return err


### PR DESCRIPTION
Append "-Confirm:$false" in the powershell command "Remove-NetNat" for NonInteractive mode

Fixes #2750 

Signed-off-by: wenyingd <wenyingd@vmware.com>