### PR TITLE
Automated cherry pick of #2751: Bugfix: Agent crashed when removing the existing

### DIFF
--- a/pkg/agent/util/net_windows.go
+++ b/pkg/agent/util/net_windows.go
@@ -596,7 +596,7 @@ func CreateNetNatOnHost(subnetCIDR *net.IPNet) error {
 			return nil
 		}
 		klog.InfoS("Removing the existing netnat", "name", netNatName, "internalIPInterfaceAddressPrefix", internalNet)
-		cmd = fmt.Sprintf("Remove-NetNat -Name %s", netNatName)
+		cmd = fmt.Sprintf("Remove-NetNat -Name %s -Confirm:$false", netNatName)
 		if _, err := ps.RunCommand(cmd); err != nil {
 			klog.ErrorS(err, "Failed to remove the existing netnat", "name", netNatName, "internalIPInterfaceAddressPrefix", internalNet)
 			return err


### PR DESCRIPTION
Cherry pick of #2751 on release-1.3.

#2751: Bugfix: Agent crashed when removing the existing netnat

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.