### PR TITLE
Install flows to skip SNAT for k8s nodes (#2708)

### DIFF
--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -442,6 +442,9 @@ func (c *client) InstallNodeFlows(hostname string,
 		} else {
 			flows = append(flows, c.l3FwdFlowToRemoteViaRouting(localGatewayMAC, remoteGatewayMAC, cookie.Node, tunnelPeerIP, peerPodCIDR)...)
 		}
+		if c.enableEgress {
+			flows = append(flows, c.snatSkipNodeFlow(tunnelPeerIP, cookie.Node))
+		}
 	}
 	if ipsecTunOFPort != 0 {
 		// When IPSec tunnel is enabled, packets received from the remote Node are

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -1853,6 +1853,21 @@ func (c *client) localProbeFlow(localGatewayIPs []net.IP, category cookie.Catego
 	return flows
 }
 
+// snatSkipNodeFlow installs a flow to skip SNAT for traffic to the transport IP of the a remote Node.
+func (c *client) snatSkipNodeFlow(nodeIP net.IP, category cookie.Category) binding.Flow {
+	l3FwdTable := c.pipeline[l3ForwardingTable]
+	nextTable := l3FwdTable.GetNext()
+	ipProto := getIPProtocol(nodeIP)
+	// This flow is for the traffic to the remote Node IP.
+	return l3FwdTable.BuildFlow(priorityNormal).
+		MatchProtocol(ipProto).
+		MatchRegMark(FromLocalRegMark).
+		MatchDstIP(nodeIP).
+		Action().GotoTable(nextTable).
+		Cookie(c.cookieAllocator.Request(category).Raw()).
+		Done()
+}
+
 // snatCommonFlows installs the default flows for performing SNAT for traffic to
 // the external network. The flows identify the packets to external, and send
 // them to snatTable, where SNAT IPs are looked up for the packets.


### PR DESCRIPTION
If destination IP is nodeIPs, we must skip SNAT if egress is enabled,
no need to forward such packets to the egressIP node

Signed-off-by: Yang Li <yang.li@transwarp.io>