### PR TITLE
detect antrea-config change automatically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,11 @@ antrea-controller:
 	@mkdir -p $(BINDIR)
 	GOOS=linux $(GO) build -o $(BINDIR) $(GOFLAGS) -ldflags '$(LDFLAGS)' antrea.io/antrea/cmd/antrea-controller
 
+.PHONY: antrea-watcher
+antrea-watcher:
+	@mkdir -p $(BINDIR)
+	GOOS=linux $(GO) build -o $(BINDIR) $(GOFLAGS) -ldflags '$(LDFLAGS)' antrea.io/antrea/cmd/antrea-watcher
+
 .PHONY: .coverage
 .coverage:
 	mkdir -p $(CURDIR)/.coverage

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -2995,6 +2995,14 @@ metadata:
   name: antrea-controller
   namespace: kube-system
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: antrea
+  name: antrea-watcher
+  namespace: kube-system
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -3705,6 +3713,40 @@ rules:
   - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: antrea
+  name: antrea-watcher
+rules:
+- apiGroups:
+  - apps
+  resourceNames:
+  - antrea-controller
+  resources:
+  - deployments
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - apps
+  resourceNames:
+  - antrea-agent
+  resources:
+  - daemonsets
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - watch
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
@@ -3748,6 +3790,21 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: antrea-controller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: antrea
+  name: antrea-watcher
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: antrea-watcher
+subjects:
+- kind: ServiceAccount
+  name: antrea-watcher
   namespace: kube-system
 ---
 apiVersion: v1
@@ -3996,7 +4053,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-99c875tk88
+  name: antrea-config
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4067,7 +4124,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-99c875tk88
+          value: antrea-config
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4118,7 +4175,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-99c875tk88
+          name: antrea-config
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4129,6 +4186,44 @@ spec:
           path: /var/log/antrea
           type: DirectoryOrCreate
         name: host-var-log-antrea
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: antrea
+    component: antrea-watcher
+  name: antrea-watcher
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: antrea
+      component: antrea-watcher
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: antrea
+        component: antrea-watcher
+    spec:
+      containers:
+      - command:
+        - antrea-watcher
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
+        name: antrea-watcher
+        resources:
+          requests:
+            cpu: 50m
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: antrea-watcher
 ---
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService
@@ -4399,7 +4494,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-99c875tk88
+          name: antrea-config
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -2995,6 +2995,14 @@ metadata:
   name: antrea-controller
   namespace: kube-system
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: antrea
+  name: antrea-watcher
+  namespace: kube-system
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -3705,6 +3713,40 @@ rules:
   - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: antrea
+  name: antrea-watcher
+rules:
+- apiGroups:
+  - apps
+  resourceNames:
+  - antrea-controller
+  resources:
+  - deployments
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - apps
+  resourceNames:
+  - antrea-agent
+  resources:
+  - daemonsets
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - watch
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
@@ -3748,6 +3790,21 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: antrea-controller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: antrea
+  name: antrea-watcher
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: antrea-watcher
+subjects:
+- kind: ServiceAccount
+  name: antrea-watcher
   namespace: kube-system
 ---
 apiVersion: v1
@@ -3996,7 +4053,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-99c875tk88
+  name: antrea-config
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4067,7 +4124,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-99c875tk88
+          value: antrea-config
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4118,7 +4175,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-99c875tk88
+          name: antrea-config
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4129,6 +4186,44 @@ spec:
           path: /var/log/antrea
           type: DirectoryOrCreate
         name: host-var-log-antrea
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: antrea
+    component: antrea-watcher
+  name: antrea-watcher
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: antrea
+      component: antrea-watcher
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: antrea
+        component: antrea-watcher
+    spec:
+      containers:
+      - command:
+        - antrea-watcher
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
+        name: antrea-watcher
+        resources:
+          requests:
+            cpu: 50m
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: antrea-watcher
 ---
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService
@@ -4401,7 +4496,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-99c875tk88
+          name: antrea-config
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -2995,6 +2995,14 @@ metadata:
   name: antrea-controller
   namespace: kube-system
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: antrea
+  name: antrea-watcher
+  namespace: kube-system
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -3705,6 +3713,40 @@ rules:
   - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: antrea
+  name: antrea-watcher
+rules:
+- apiGroups:
+  - apps
+  resourceNames:
+  - antrea-controller
+  resources:
+  - deployments
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - apps
+  resourceNames:
+  - antrea-agent
+  resources:
+  - daemonsets
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - watch
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
@@ -3748,6 +3790,21 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: antrea-controller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: antrea
+  name: antrea-watcher
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: antrea-watcher
+subjects:
+- kind: ServiceAccount
+  name: antrea-watcher
   namespace: kube-system
 ---
 apiVersion: v1
@@ -3996,7 +4053,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-dbmkcb65c8
+  name: antrea-config
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4067,7 +4124,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-dbmkcb65c8
+          value: antrea-config
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4118,7 +4175,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-dbmkcb65c8
+          name: antrea-config
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4129,6 +4186,44 @@ spec:
           path: /var/log/antrea
           type: DirectoryOrCreate
         name: host-var-log-antrea
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: antrea
+    component: antrea-watcher
+  name: antrea-watcher
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: antrea
+      component: antrea-watcher
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: antrea
+        component: antrea-watcher
+    spec:
+      containers:
+      - command:
+        - antrea-watcher
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
+        name: antrea-watcher
+        resources:
+          requests:
+            cpu: 50m
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: antrea-watcher
 ---
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService
@@ -4402,7 +4497,7 @@ spec:
           path: /home/kubernetes/bin
         name: host-cni-bin
       - configMap:
-          name: antrea-config-dbmkcb65c8
+          name: antrea-config
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -2995,6 +2995,14 @@ metadata:
   name: antrea-controller
   namespace: kube-system
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: antrea
+  name: antrea-watcher
+  namespace: kube-system
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -3705,6 +3713,40 @@ rules:
   - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: antrea
+  name: antrea-watcher
+rules:
+- apiGroups:
+  - apps
+  resourceNames:
+  - antrea-controller
+  resources:
+  - deployments
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - apps
+  resourceNames:
+  - antrea-agent
+  resources:
+  - daemonsets
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - watch
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
@@ -3748,6 +3790,21 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: antrea-controller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: antrea
+  name: antrea-watcher
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: antrea-watcher
+subjects:
+- kind: ServiceAccount
+  name: antrea-watcher
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4001,7 +4058,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-tthkbhb7k5
+  name: antrea-config
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4081,7 +4138,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-tthkbhb7k5
+          value: antrea-config
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4132,7 +4189,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-tthkbhb7k5
+          name: antrea-config
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4143,6 +4200,44 @@ spec:
           path: /var/log/antrea
           type: DirectoryOrCreate
         name: host-var-log-antrea
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: antrea
+    component: antrea-watcher
+  name: antrea-watcher
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: antrea
+      component: antrea-watcher
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: antrea
+        component: antrea-watcher
+    spec:
+      containers:
+      - command:
+        - antrea-watcher
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
+        name: antrea-watcher
+        resources:
+          requests:
+            cpu: 50m
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: antrea-watcher
 ---
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService
@@ -4448,7 +4543,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-tthkbhb7k5
+          name: antrea-config
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -2995,6 +2995,14 @@ metadata:
   name: antrea-controller
   namespace: kube-system
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: antrea
+  name: antrea-watcher
+  namespace: kube-system
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -3705,6 +3713,40 @@ rules:
   - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: antrea
+  name: antrea-watcher
+rules:
+- apiGroups:
+  - apps
+  resourceNames:
+  - antrea-controller
+  resources:
+  - deployments
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - apps
+  resourceNames:
+  - antrea-agent
+  resources:
+  - daemonsets
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - watch
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
@@ -3748,6 +3790,21 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: antrea-controller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: antrea
+  name: antrea-watcher
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: antrea-watcher
+subjects:
+- kind: ServiceAccount
+  name: antrea-watcher
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4001,7 +4058,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-mc8h75hbgg
+  name: antrea-config
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4072,7 +4129,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-mc8h75hbgg
+          value: antrea-config
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4123,7 +4180,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-mc8h75hbgg
+          name: antrea-config
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4134,6 +4191,44 @@ spec:
           path: /var/log/antrea
           type: DirectoryOrCreate
         name: host-var-log-antrea
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: antrea
+    component: antrea-watcher
+  name: antrea-watcher
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: antrea
+      component: antrea-watcher
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: antrea
+        component: antrea-watcher
+    spec:
+      containers:
+      - command:
+        - antrea-watcher
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
+        name: antrea-watcher
+        resources:
+          requests:
+            cpu: 50m
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: antrea-watcher
 ---
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService
@@ -4404,7 +4499,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-mc8h75hbgg
+          name: antrea-config
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/base/kustomization.yml
+++ b/build/yamls/base/kustomization.yml
@@ -6,7 +6,11 @@ resources:
 - controller.yml
 - agent-rbac.yml
 - agent.yml
+- watcher-rbac.yml
+- watcher.yml
 - cluster-identity-reader.yml
+generatorOptions:
+  disableNameSuffixHash: true
 configMapGenerator:
 - files:
   - conf/antrea-controller.conf

--- a/build/yamls/base/watcher-rbac.yml
+++ b/build/yamls/base/watcher-rbac.yml
@@ -1,0 +1,51 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: antrea-watcher
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: antrea-watcher
+rules:
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    resourceNames:
+      - antrea-controller
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+    resourceNames:
+      - antrea-agent
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - watch
+      - list
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: antrea-watcher
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: antrea-watcher
+subjects:
+  - kind: ServiceAccount
+    name: antrea-watcher
+    namespace: kube-system

--- a/build/yamls/base/watcher.yml
+++ b/build/yamls/base/watcher.yml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: antrea-watcher
+  labels:
+    component: antrea-watcher
+spec:
+  strategy:
+    # Ensure the existing Pod is killed before the new one is created.
+    type: Recreate
+  selector:
+    matchLabels:
+      component: antrea-watcher
+  template:
+    metadata:
+      labels:
+        component: antrea-watcher
+    spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: antrea-watcher
+      containers:
+        - name: antrea-watcher
+          image: antrea
+          resources:
+            requests:
+              cpu: "50m"
+          command: ["antrea-watcher"]
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+

--- a/cmd/antrea-watcher/main.go
+++ b/cmd/antrea-watcher/main.go
@@ -1,0 +1,77 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package main under directory cmd parses and validates user input,
+// instantiates and initializes objects imported from pkg, and runs
+// the process.
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
+	"k8s.io/component-base/config"
+	"k8s.io/klog/v2"
+
+	"antrea.io/antrea/pkg/signals"
+	"antrea.io/antrea/pkg/util/k8s"
+)
+
+type Options struct {
+	// The path to the K8s configuration file
+	kubeConfig string
+}
+
+func main() {
+	stopCh := signals.RegisterSignalHandlers()
+	opts := &Options{}
+
+	cmd := &cobra.Command{
+		Use:  "antrea-watcher",
+		Long: "The Antrea Watcher.",
+		Run: func(cmd *cobra.Command, args []string) {
+			wait.Until(func() {
+				if err := run(opts, stopCh); err != nil {
+					klog.ErrorS(err, "Failed to watch config files, will retry later")
+				}
+			}, time.Minute, stopCh)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVar(&opts.kubeConfig, "kube-config", opts.kubeConfig, "The path to the K8s configuration file")
+
+	if err := cmd.Execute(); err != nil {
+		klog.Errorf("fail to run watcher %v", err)
+		os.Exit(1)
+	}
+}
+
+func run(opts *Options, stopCh <-chan struct{}) error {
+	k8sClient, _, _, _, err := k8s.CreateClients(config.ClientConnectionConfiguration{Kubeconfig: opts.kubeConfig}, "")
+	if err != nil {
+		return fmt.Errorf("fail to create K8s client: %v", err)
+	}
+	informerFactory := informers.NewSharedInformerFactory(k8sClient, 60*time.Minute)
+	watcher := NewWatcher(k8sClient, informerFactory)
+	informerFactory.Start(stopCh)
+	go watcher.Run(stopCh)
+	<-stopCh
+	klog.Info("Stopping Antrea Watcher")
+	return nil
+}

--- a/cmd/antrea-watcher/watcher.go
+++ b/cmd/antrea-watcher/watcher.go
@@ -1,0 +1,158 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package main under directory cmd parses and validates user input,
+// instantiates and initializes objects imported from pkg, and runs
+// the process.
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"antrea.io/antrea/pkg/util/env"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+)
+
+const (
+	antreAgentConfigKey      = "antrea-agent.conf"
+	antreControllerConfigKey = "antrea-controller.conf"
+	fileChangeAnnotation     = "config-update-time"
+)
+
+type Watcher struct {
+	K8sClient       kubernetes.Interface
+	cmInformer      coreinformers.ConfigMapInformer
+	configMapSynced cache.InformerSynced
+	queue           workqueue.RateLimitingInterface
+}
+
+func NewWatcher(client kubernetes.Interface, informerFactory informers.SharedInformerFactory) *Watcher {
+	cmInformer := informerFactory.Core().V1().ConfigMaps()
+	w := &Watcher{
+		K8sClient:       client,
+		cmInformer:      cmInformer,
+		configMapSynced: cmInformer.Informer().HasSynced,
+		queue:           workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(2*time.Second, 2*time.Minute), "configmap"),
+	}
+	cmInformer.Informer().AddEventHandlerWithResyncPeriod(
+		cache.ResourceEventHandlerFuncs{
+			UpdateFunc: func(old, cur interface{}) {
+				w.handleConfigMapUpdateEvent(old, cur)
+			},
+		},
+		5*time.Second,
+	)
+	return w
+}
+
+func (w *Watcher) handleConfigMapUpdateEvent(old, cur interface{}) {
+	oldCm := old.(*corev1.ConfigMap)
+	newCm := cur.(*corev1.ConfigMap)
+	if oldCm.GetName() == "antrea-config" {
+		if oldCm.Data[antreControllerConfigKey] != newCm.Data[antreControllerConfigKey] {
+			w.queue.Add(antreControllerConfigKey)
+		}
+		if oldCm.Data[antreAgentConfigKey] != newCm.Data[antreAgentConfigKey] {
+			w.queue.Add(antreAgentConfigKey)
+		}
+	}
+}
+
+func (w *Watcher) Run(stopCh <-chan struct{}) {
+	defer w.queue.ShutDown()
+	klog.Info("Starting Antrea Watcher")
+	defer klog.Infof("Shutting down Antrea Watcher")
+	if !cache.WaitForNamedCacheSync("antrea-watcher", stopCh, w.configMapSynced) {
+		return
+	}
+	go wait.Until(w.worker, time.Second, stopCh)
+	<-stopCh
+}
+
+// worker is a long-running function that will continually call the processNextWorkItem function in
+// order to read and process a message on the workqueue.
+func (w *Watcher) worker() {
+	for w.processNextWorkItem() {
+	}
+}
+
+func (w *Watcher) processNextWorkItem() bool {
+	obj, quit := w.queue.Get()
+	if quit {
+		return false
+	}
+	defer w.queue.Done(obj)
+	if key, ok := obj.(string); !ok {
+		w.queue.Forget(obj)
+		klog.Errorf("Expected string in work queue but got %#v", obj)
+		return true
+	} else if err := w.updateAnnotation(key); err == nil {
+		w.queue.Forget(key)
+	} else {
+		w.queue.AddRateLimited(key)
+		klog.Errorf("Error syncing ConfigMap %s, requeuing. Error: %v", key, err)
+	}
+	return true
+}
+
+func (w *Watcher) updateAnnotation(key string) error {
+	ctx := context.TODO()
+	annotations := map[string]string{}
+	now := fmt.Sprint(time.Now().Unix())
+	if key == antreAgentConfigKey {
+		klog.Infof("antrea-agent.conf is updated, update antrea-agent DaemonSet annotation")
+		agentds, err := w.K8sClient.AppsV1().DaemonSets(env.GetAntreaNamespace()).Get(ctx, "antrea-agent", metav1.GetOptions{})
+		if err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("unable to get antrea-agent DaemonSet %v", err)
+		}
+		if agentds.Spec.Template.GetAnnotations() != nil {
+			annotations = agentds.Spec.Template.GetAnnotations()
+		}
+		annotations[fileChangeAnnotation] = now
+		agentds.Spec.Template.Annotations = annotations
+		_, err = w.K8sClient.AppsV1().DaemonSets(env.GetAntreaNamespace()).Update(ctx, agentds, metav1.UpdateOptions{})
+		if err != nil {
+			return fmt.Errorf("fail to update antrea-agent DaemonSet annotation %v", err)
+		}
+	}
+
+	if key == antreControllerConfigKey {
+		klog.Infof("antrea-controller.conf is updated, update antrea-controller Deployment annotation")
+		controller, err := w.K8sClient.AppsV1().Deployments(env.GetAntreaNamespace()).Get(ctx, "antrea-controller", metav1.GetOptions{})
+		if err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("unable to get antrea-controller deployment %v", err)
+		}
+		if controller.Spec.Template.GetAnnotations() != nil {
+			annotations = controller.Spec.Template.GetAnnotations()
+		}
+		annotations[fileChangeAnnotation] = now
+		controller.Spec.Template.Annotations = annotations
+		_, err = w.K8sClient.AppsV1().Deployments(env.GetAntreaNamespace()).Update(ctx, controller, metav1.UpdateOptions{})
+		if err != nil {
+			return fmt.Errorf("fail to update antrea-controller Deployment annotation %v", err)
+		}
+	}
+	return nil
+}

--- a/cmd/antrea-watcher/watcher_test.go
+++ b/cmd/antrea-watcher/watcher_test.go
@@ -1,0 +1,156 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package main under directory cmd parses and validates user input,
+// instantiates and initializes objects imported from pkg, and runs
+// the process.
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	apps "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+type fakeWatcher struct {
+	*Watcher
+	clientset       *fake.Clientset
+	informerFactory informers.SharedInformerFactory
+}
+
+func newWatcher(t *testing.T) (*fakeWatcher, func()) {
+	clientset := fake.NewSimpleClientset()
+	ctrl := gomock.NewController(t)
+	informerFactory := informers.NewSharedInformerFactory(clientset, 12*time.Hour)
+	w := NewWatcher(clientset, informerFactory)
+	return &fakeWatcher{
+		Watcher:         w,
+		clientset:       clientset,
+		informerFactory: informerFactory,
+	}, ctrl.Finish
+}
+
+func TestConfigMapUpdateEvent(t *testing.T) {
+	w, closeFn := newWatcher(t)
+	defer closeFn()
+	defer w.queue.ShutDown()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	w.informerFactory.Start(stopCh)
+	w.informerFactory.WaitForCacheSync(stopCh)
+
+	oldCm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "antrea-config",
+		},
+		Data: map[string]string{
+			antreAgentConfigKey:      "agent.config",
+			antreControllerConfigKey: "controller.config",
+		},
+	}
+	newCm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "antrea-config",
+		},
+		Data: map[string]string{
+			antreAgentConfigKey:      "agent.config.update",
+			antreControllerConfigKey: "controller.config.update",
+		},
+	}
+	agentds := &apps.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       uuid.NewUUID(),
+			Name:      "antrea-agent",
+			Namespace: "kube-system",
+		},
+		Spec: apps.DaemonSetSpec{
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Image: "foo/bar",
+						},
+					},
+					DNSPolicy: v1.DNSDefault,
+				},
+			},
+		},
+	}
+
+	controller := &apps.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:         uuid.NewUUID(),
+			Name:        "antrea-controller",
+			Namespace:   "kube-system",
+			Annotations: make(map[string]string),
+		},
+		Spec: apps.DeploymentSpec{
+			Replicas: func() *int32 { i := int32(1); return &i }(),
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Image: "foo/bar",
+						},
+					},
+				},
+			},
+		},
+	}
+	ctx := context.Background()
+	_, err := w.clientset.CoreV1().ConfigMaps("kube-system").Create(ctx, oldCm, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = w.clientset.AppsV1().Deployments("kube-system").Create(ctx, controller, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = w.clientset.AppsV1().DaemonSets("kube-system").Create(ctx, agentds, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	go w.Run(stopCh)
+
+	_, err = w.clientset.CoreV1().ConfigMaps("kube-system").Update(ctx, newCm, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(1 * time.Second)
+	newagent, err := w.clientset.AppsV1().DaemonSets("kube-system").Get(ctx, "antrea-agent", metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	annotations := newagent.Spec.Template.Annotations
+	_, ok := annotations[fileChangeAnnotation]
+	assert.Equal(t, true, ok)
+	newcontroller, err := w.clientset.AppsV1().Deployments("kube-system").Get(ctx, "antrea-controller", metav1.GetOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	annotations = newcontroller.Spec.Template.Annotations
+	_, ok = annotations[fileChangeAnnotation]
+	assert.Equal(t, true, ok)
+}


### PR DESCRIPTION
remove antrea-config suffix add a new deployment antrea-watcher with single replica to
watch configmap `antrea-config` change, then update antrea-agent or
antrea-controller deployment according to the config change.

This PR is a part of #723
Signed-off-by: Lan Luo <luola@vmware.com>