### PR TITLE
Automated cherry pick of #2489: remove tunnel limitation for IPSec

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -3740,8 +3740,7 @@ data:
     # also adjust MTU to accommodate for tunnel encapsulation overhead (if applicable).
     #defaultMTU: 0
 
-    # Whether or not to enable IPsec encryption of tunnel traffic. IPsec encryption is only supported
-    # for the GRE tunnel type.
+    # Whether or not to enable IPsec encryption of tunnel traffic.
     #enableIPSecTunnel: false
 
     # ClusterIP CIDR range for IPv6 Services. It's required when using kube-proxy to provide IPv6 Service in a Dual-Stack
@@ -3887,7 +3886,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-tgm22b6g5t
+  name: antrea-config-hk22hhtb9f
   namespace: kube-system
 ---
 apiVersion: v1
@@ -3958,7 +3957,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-tgm22b6g5t
+          value: antrea-config-hk22hhtb9f
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4009,7 +4008,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-tgm22b6g5t
+          name: antrea-config-hk22hhtb9f
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4305,7 +4304,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-tgm22b6g5t
+          name: antrea-config-hk22hhtb9f
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -3740,8 +3740,7 @@ data:
     # also adjust MTU to accommodate for tunnel encapsulation overhead (if applicable).
     #defaultMTU: 0
 
-    # Whether or not to enable IPsec encryption of tunnel traffic. IPsec encryption is only supported
-    # for the GRE tunnel type.
+    # Whether or not to enable IPsec encryption of tunnel traffic.
     #enableIPSecTunnel: false
 
     # ClusterIP CIDR range for IPv6 Services. It's required when using kube-proxy to provide IPv6 Service in a Dual-Stack
@@ -3887,7 +3886,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-tgm22b6g5t
+  name: antrea-config-hk22hhtb9f
   namespace: kube-system
 ---
 apiVersion: v1
@@ -3958,7 +3957,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-tgm22b6g5t
+          value: antrea-config-hk22hhtb9f
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4009,7 +4008,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-tgm22b6g5t
+          name: antrea-config-hk22hhtb9f
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4307,7 +4306,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-tgm22b6g5t
+          name: antrea-config-hk22hhtb9f
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -3740,8 +3740,7 @@ data:
     # also adjust MTU to accommodate for tunnel encapsulation overhead (if applicable).
     #defaultMTU: 0
 
-    # Whether or not to enable IPsec encryption of tunnel traffic. IPsec encryption is only supported
-    # for the GRE tunnel type.
+    # Whether or not to enable IPsec encryption of tunnel traffic.
     #enableIPSecTunnel: false
 
     # ClusterIP CIDR range for IPv6 Services. It's required when using kube-proxy to provide IPv6 Service in a Dual-Stack
@@ -3887,7 +3886,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-246k7dkb5c
+  name: antrea-config-2bk69mkcmb
   namespace: kube-system
 ---
 apiVersion: v1
@@ -3958,7 +3957,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-246k7dkb5c
+          value: antrea-config-2bk69mkcmb
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4009,7 +4008,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-246k7dkb5c
+          name: antrea-config-2bk69mkcmb
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4308,7 +4307,7 @@ spec:
           path: /home/kubernetes/bin
         name: host-cni-bin
       - configMap:
-          name: antrea-config-246k7dkb5c
+          name: antrea-config-2bk69mkcmb
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -3740,8 +3740,7 @@ data:
     # also adjust MTU to accommodate for tunnel encapsulation overhead (if applicable).
     #defaultMTU: 0
 
-    # Whether or not to enable IPsec encryption of tunnel traffic. IPsec encryption is only supported
-    # for the GRE tunnel type.
+    # Whether or not to enable IPsec encryption of tunnel traffic.
     enableIPSecTunnel: true
 
     # ClusterIP CIDR range for Services. It's required when AntreaProxy is not enabled, and should be
@@ -3892,7 +3891,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-5mt4h4g8tk
+  name: antrea-config-fk4ff77ct6
   namespace: kube-system
 ---
 apiVersion: v1
@@ -3972,7 +3971,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-5mt4h4g8tk
+          value: antrea-config-fk4ff77ct6
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4023,7 +4022,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-5mt4h4g8tk
+          name: antrea-config-fk4ff77ct6
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4354,7 +4353,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-5mt4h4g8tk
+          name: antrea-config-fk4ff77ct6
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -3740,8 +3740,7 @@ data:
     # also adjust MTU to accommodate for tunnel encapsulation overhead (if applicable).
     #defaultMTU: 0
 
-    # Whether or not to enable IPsec encryption of tunnel traffic. IPsec encryption is only supported
-    # for the GRE tunnel type.
+    # Whether or not to enable IPsec encryption of tunnel traffic.
     #enableIPSecTunnel: false
 
     # ClusterIP CIDR range for Services. It's required when AntreaProxy is not enabled, and should be
@@ -3892,7 +3891,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-2567tcm8ck
+  name: antrea-config-t8cc9bfb6t
   namespace: kube-system
 ---
 apiVersion: v1
@@ -3963,7 +3962,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-2567tcm8ck
+          value: antrea-config-t8cc9bfb6t
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4014,7 +4013,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-2567tcm8ck
+          name: antrea-config-t8cc9bfb6t
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4310,7 +4309,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-2567tcm8ck
+          name: antrea-config-t8cc9bfb6t
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/base/conf/antrea-agent.conf
+++ b/build/yamls/base/conf/antrea-agent.conf
@@ -77,8 +77,7 @@ featureGates:
 # also adjust MTU to accommodate for tunnel encapsulation overhead (if applicable).
 #defaultMTU: 0
 
-# Whether or not to enable IPsec encryption of tunnel traffic. IPsec encryption is only supported
-# for the GRE tunnel type.
+# Whether or not to enable IPsec encryption of tunnel traffic.
 #enableIPSecTunnel: false
 
 # ClusterIP CIDR range for Services. It's required when AntreaProxy is not enabled, and should be

--- a/cmd/antrea-agent/config.go
+++ b/cmd/antrea-agent/config.go
@@ -89,8 +89,7 @@ type AgentConfig struct {
 	// --service-cluster-ip-range. When AntreaProxy is enabled, this parameter is not needed.
 	// No default value for this field.
 	ServiceCIDRv6 string `yaml:"serviceCIDRv6,omitempty"`
-	// Whether or not to enable IPSec (ESP) encryption for Pod traffic across Nodes. IPSec encryption
-	// is supported only for the GRE tunnel type. Antrea uses Preshared Key (PSK) for IKE
+	// Whether or not to enable IPSec (ESP) encryption for Pod traffic across Nodes. Antrea uses Preshared Key (PSK) for IKE
 	// authentication. When IPSec tunnel is enabled, the PSK value must be passed to Antrea Agent
 	// through an environment variable: ANTREA_IPSEC_PSK.
 	// Defaults to false.

--- a/cmd/antrea-agent/options.go
+++ b/cmd/antrea-agent/options.go
@@ -116,9 +116,6 @@ func (o *Options) validate(args []string) error {
 		o.config.TunnelType != ovsconfig.GRETunnel && o.config.TunnelType != ovsconfig.STTTunnel {
 		return fmt.Errorf("tunnel type %s is invalid", o.config.TunnelType)
 	}
-	if o.config.EnableIPSecTunnel && o.config.TunnelType != ovsconfig.GRETunnel {
-		return fmt.Errorf("IPSec encyption is supported only for GRE tunnel")
-	}
 	if o.config.OVSDatapathType != string(ovsconfig.OVSDatapathSystem) && o.config.OVSDatapathType != string(ovsconfig.OVSDatapathNetdev) {
 		return fmt.Errorf("OVS datapath type %s is not supported", o.config.OVSDatapathType)
 	}

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -331,7 +331,7 @@ the [Antrea IPsec deployment yaml](/build/yamls/antrea-ipsec.yml), which creates
 a Kubernetes Secret to save the PSK value and populates it to the
 `ANTREA_IPSEC_PSK` environment variable of the Antrea Agent container.
 
-When IPsec is enabled, Antrea Agent will create a separate GRE tunnel port on
+When IPsec is enabled, Antrea Agent will create a separate tunnel port on
 the OVS bridge for each remote Node, and write the PSK string and the remote
 Node IP address to two OVS interface options of the tunnel interface. Then
 `ovs-monitor-ipsec` can detect the tunnel and create IPsec Security Policies

--- a/docs/ipsec-tunnel.md
+++ b/docs/ipsec-tunnel.md
@@ -1,8 +1,8 @@
 # IPsec Encryption of Tunnel Traffic with Antrea
 
-Antrea supports encrypting tunnel traffic across Nodes with IPsec ESP. At this
-moment, IPsec encyption works only for GRE tunnel (but not Geneve, VXLAN, and
-STT tunnel types).
+Antrea supports encrypting tunnel traffic across Nodes with IPsec ESP.
+IPsec encyption works for all tunnel types supported by OVS including Geneve,
+GRE, VXLAN, and STT tunnel.
 
 ## Prerequisites
 
@@ -10,6 +10,10 @@ IPsec requires a set of Linux kernel modules. Check the required kernel modules
 listed in the [strongSwan documentation](https://wiki.strongswan.org/projects/strongswan/wiki/KernelModules).
 Make sure the required kernel modules are loaded on the Kubernetes Nodes before
 deploying Antrea with IPsec encyption enabled.
+
+If you want to enable IPsec with Geneve, please make sure [this commit](https://github.com/torvalds/linux/commit/34beb21594519ce64a55a498c2fe7d567bc1ca20)
+is included in the kernel. For Ubuntu 18.04, kernel version should be at least
+`4.15.0-128`. For Ubuntu 20.04, kernel version should be at least `5.4.70`.
 
 ## Installation
 


### PR DESCRIPTION
Cherry pick of #2489 on release-1.2.

#2489: remove tunnel limitation for IPSec

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.