### PR TITLE
Automated cherry pick of #2582: remove config mismatched port during creation

### DIFF
--- a/pkg/agent/controller/noderoute/node_route_controller.go
+++ b/pkg/agent/controller/noderoute/node_route_controller.go
@@ -536,19 +536,26 @@ func getPodCIDRsOnNode(node *corev1.Node) []string {
 // tunnel does not exist, and returns the ofport number.
 func (c *Controller) createIPSecTunnelPort(nodeName string, nodeIP net.IP) (int32, error) {
 	portName := util.GenerateNodeTunnelInterfaceName(nodeName)
-	interfaceConfig, ok := c.interfaceStore.GetNodeTunnelInterface(nodeName)
+	interfaceConfig, exists := c.interfaceStore.GetNodeTunnelInterface(nodeName)
 	// check if Node IP, PSK, or tunnel type changes. This can
 	// happen if removeStaleTunnelPorts fails to remove a "stale"
 	// tunnel port for which the configuration has changed, return error to requeue the Node.
-	if ok {
+	if exists {
 		if !c.compareInterfaceConfig(interfaceConfig, nodeIP, portName) {
-			return 0, fmt.Errorf("IPSec tunnel interface config doesn't match cached one, stale IPSec tunnel port %s", interfaceConfig.InterfaceName)
+			klog.InfoS("IPSec tunnel interface config doesn't match the cached one, deleting the stale IPSec tunnel port", "node", nodeName, "interface", interfaceConfig.InterfaceName)
+			if err := c.ovsBridgeClient.DeletePort(interfaceConfig.PortUUID); err != nil {
+				return 0, fmt.Errorf("fail to delete the stale IPSec tunnel port %s: %v", interfaceConfig.InterfaceName, err)
+			}
+			c.interfaceStore.DeleteInterface(interfaceConfig)
+			exists = false
+		} else {
+			if interfaceConfig.OFPort != 0 {
+				klog.V(2).InfoS("Found cached IPSec tunnel interface", "node", nodeName, "interface", interfaceConfig.InterfaceName, "port", interfaceConfig.OFPort)
+				return interfaceConfig.OFPort, nil
+			}
 		}
-		klog.V(2).InfoS("Found cached IPSec tunnel interface", "interfaceName", interfaceConfig.InterfaceName, "port", interfaceConfig.OFPort, "nodeName", nodeName)
-		if interfaceConfig.OFPort != 0 {
-			return interfaceConfig.OFPort, nil
-		}
-	} else {
+	}
+	if !exists {
 		ovsExternalIDs := map[string]interface{}{ovsExternalIDNodeName: nodeName}
 		portUUID, err := c.ovsBridgeClient.CreateTunnelPortExt(
 			portName,
@@ -574,7 +581,6 @@ func (c *Controller) createIPSecTunnelPort(nodeName string, nodeIP net.IP) (int3
 		interfaceConfig.OVSPortConfig = ovsPortConfig
 		c.interfaceStore.AddInterface(interfaceConfig)
 	}
-
 	// GetOFPort will wait for up to 1 second for OVSDB to report the OFPort number.
 	ofPort, err := c.ovsBridgeClient.GetOFPort(interfaceConfig.InterfaceName)
 	if err != nil {

--- a/pkg/agent/controller/noderoute/node_route_controller_test.go
+++ b/pkg/agent/controller/noderoute/node_route_controller_test.go
@@ -332,11 +332,18 @@ func TestCreateIPSecTunnelPort(t *testing.T) {
 	c.informerFactory.WaitForCacheSync(stopCh)
 
 	node1PortName := util.GenerateNodeTunnelInterfaceName("xyz-k8s-0-1")
+	node2PortName := util.GenerateNodeTunnelInterfaceName("xyz-k8s-0-2")
 	c.ovsClient.EXPECT().CreateTunnelPortExt(
 		node1PortName, ovsconfig.TunnelType("vxlan"), int32(0),
 		false, "", nodeIP1.String(), "changeme",
 		map[string]interface{}{ovsExternalIDNodeName: "xyz-k8s-0-1"}).Times(1)
+	c.ovsClient.EXPECT().CreateTunnelPortExt(
+		node2PortName, ovsconfig.TunnelType("vxlan"), int32(0),
+		false, "", nodeIP2.String(), "changeme",
+		map[string]interface{}{ovsExternalIDNodeName: "xyz-k8s-0-2"}).Times(1)
 	c.ovsClient.EXPECT().GetOFPort(node1PortName).Return(int32(1), nil)
+	c.ovsClient.EXPECT().GetOFPort(node2PortName).Return(int32(2), nil)
+	c.ovsClient.EXPECT().DeletePort("123").Times(1)
 
 	tests := []struct {
 		name       string
@@ -356,7 +363,8 @@ func TestCreateIPSecTunnelPort(t *testing.T) {
 			name:       "hit cache but interface name changed for the same node",
 			nodeName:   "xyz-k8s-0-2",
 			peerNodeIP: nodeIP2,
-			wantErr:    true,
+			wantErr:    false,
+			want:       2,
 		},
 		{
 			name:       "hit cache and return directly",


### PR DESCRIPTION
Cherry pick of #2582 on release-1.2.

#2582: remove config mismatched port during creation

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.