### PR TITLE
Fix reject action on Service traffic

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -237,6 +237,7 @@ func run(o *Options) error {
 	// after rule deletion.
 	asyncRuleDeleteInterval := o.pollInterval
 	antreaPolicyEnabled := features.DefaultFeatureGate.Enabled(features.AntreaPolicy)
+	antreaProxyEnabled := features.DefaultFeatureGate.Enabled(features.AntreaProxy)
 	// In Antrea agent, status manager and audit logging will automatically be enabled
 	// if AntreaPolicy feature is enabled.
 	statusManagerEnabled := antreaPolicyEnabled
@@ -259,6 +260,7 @@ func run(o *Options) error {
 		groupCounters,
 		groupIDUpdates,
 		antreaPolicyEnabled,
+		antreaProxyEnabled,
 		statusManagerEnabled,
 		loggingEnabled,
 		denyConnStore,

--- a/pkg/agent/controller/networkpolicy/fqdn.go
+++ b/pkg/agent/controller/networkpolicy/fqdn.go
@@ -816,7 +816,7 @@ func (f *fqdnController) sendDNSPacketout(pktIn *ofctrl.PacketIn) error {
 			srcIP,
 			dstIP,
 			uint32(config.HostGatewayOFPort),
-			-1,
+			0,
 			isIPv6,
 			udpSrcPort,
 			udpDstPort,

--- a/pkg/agent/controller/networkpolicy/fqdn.go
+++ b/pkg/agent/controller/networkpolicy/fqdn.go
@@ -810,6 +810,9 @@ func (f *fqdnController) sendDNSPacketout(pktIn *ofctrl.PacketIn) error {
 			klog.ErrorS(err, "Failed to get UDP header data")
 			return err
 		}
+		mutatePacketOut := func(packetOutBuilder binding.PacketOutBuilder) binding.PacketOutBuilder {
+			return packetOutBuilder.AddLoadRegMark(openflow.CustomReasonDNSRegMark)
+		}
 		return f.ofClient.SendUDPPacketOut(
 			pktIn.Data.HWSrc.String(),
 			pktIn.Data.HWDst.String(),
@@ -821,7 +824,7 @@ func (f *fqdnController) sendDNSPacketout(pktIn *ofctrl.PacketIn) error {
 			udpSrcPort,
 			udpDstPort,
 			packetData,
-			true)
+			mutatePacketOut)
 	}
 	return nil
 }

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
@@ -70,6 +70,8 @@ type Controller struct {
 	// antreaPolicyEnabled indicates whether Antrea NetworkPolicy and
 	// ClusterNetworkPolicy are enabled.
 	antreaPolicyEnabled bool
+	// antreaProxyEnabled indicates whether Antrea proxy is enabled.
+	antreaProxyEnabled bool
 	// statusManagerEnabled indicates whether a statusManager is configured.
 	statusManagerEnabled bool
 	// loggingEnabled indicates where Antrea policy audit logging is enabled.
@@ -114,6 +116,7 @@ func NewNetworkPolicyController(antreaClientGetter agent.AntreaClientProvider,
 	groupCounters []proxytypes.GroupCounter,
 	groupIDUpdates <-chan string,
 	antreaPolicyEnabled bool,
+	antreaProxyEnabled bool,
 	statusManagerEnabled bool,
 	loggingEnabled bool,
 	denyConnStore *connections.DenyConnectionStore,
@@ -125,6 +128,7 @@ func NewNetworkPolicyController(antreaClientGetter agent.AntreaClientProvider,
 		queue:                workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(minRetryDelay, maxRetryDelay), "networkpolicyrule"),
 		ofClient:             ofClient,
 		antreaPolicyEnabled:  antreaPolicyEnabled,
+		antreaProxyEnabled:   antreaProxyEnabled,
 		statusManagerEnabled: statusManagerEnabled,
 		loggingEnabled:       loggingEnabled,
 		denyConnStore:        denyConnStore,

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
@@ -56,7 +56,7 @@ func newTestController() (*Controller, *fake.Clientset, *mockReconciler) {
 	ch2 := make(chan string, 100)
 	groupCounters := []proxytypes.GroupCounter{proxytypes.NewGroupCounter(false, ch2)}
 	controller, _ := NewNetworkPolicyController(&antreaClientGetter{clientset}, nil, nil, "node1", ch, groupCounters, ch2,
-		true, true, true, nil, testAsyncDeleteInterval, "8.8.8.8:53")
+		true, true, true, true, nil, testAsyncDeleteInterval, "8.8.8.8:53")
 	reconciler := newMockReconciler()
 	controller.reconciler = reconciler
 	controller.antreaPolicyLogger = nil

--- a/pkg/agent/controller/networkpolicy/reject.go
+++ b/pkg/agent/controller/networkpolicy/reject.go
@@ -1,0 +1,256 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package networkpolicy
+
+import (
+	"encoding/binary"
+
+	"antrea.io/libOpenflow/protocol"
+	"antrea.io/ofnet/ofctrl"
+
+	"antrea.io/antrea/pkg/agent/config"
+	"antrea.io/antrea/pkg/agent/interfacestore"
+	"antrea.io/antrea/pkg/agent/openflow"
+	binding "antrea.io/antrea/pkg/ovs/openflow"
+)
+
+const (
+	IPv4HdrLen uint16 = 20
+	IPv6HdrLen uint16 = 40
+
+	ICMPUnusedHdrLen uint16 = 4
+
+	TCPAck uint8 = 0b010000
+	TCPRst uint8 = 0b000100
+
+	ICMPDstUnreachableType         uint8 = 3
+	ICMPDstHostAdminProhibitedCode uint8 = 10
+
+	ICMPv6DstUnreachableType     uint8 = 1
+	ICMPv6DstAdminProhibitedCode uint8 = 1
+)
+
+type RejectType int
+
+const (
+	// RejectPodLocal represents this packetOut is used to reject Pod-to-Pod traffic
+	// and for this response, the srcPod and the dstPod are on the same Node.
+	RejectPodLocal RejectType = iota
+	// RejectPodRemoteToLocal represents this packetOut is used to reject Pod-to-Pod
+	// traffic and for this response, the srcPod is on a remote Node and the dstPod is
+	// on the local Node.
+	RejectPodRemoteToLocal
+	// RejectLocalToRemote represents this packetOut is used to reject traffic and for
+	// this response, the srcPod is on the local Node and the dstPod is on a remote Node.
+	// While generating rejection from local to remote, there is no difference between
+	// Service traffic and Pod traffic.
+	RejectLocalToRemote
+	// RejectServiceLocal represents this packetOut is used to reject Service traffic,
+	// when AntreaProxy is enabled. The EndpointPod and the dstPod of the reject
+	// response are on the same Node.
+	RejectServiceLocal
+	// RejectServiceRemoteToLocal represents this packetOut is used to reject Service
+	// traffic, when AntreaProxy is enabled. The EndpointPod is on a remote Node and
+	// the dstPod of the reject response is on the local Node.
+	RejectServiceRemoteToLocal
+	// RejectNoAPServiceLocal represents this packetOut is used to reject Service
+	// traffic, when AntreaProxy is disabled. The EndpointPod and the dstPod of the
+	// reject response are on the same Node.
+	RejectNoAPServiceLocal
+	// RejectNoAPServiceRemoteToLocal represents this packetOut is used to reject
+	// Service traffic, when AntreaProxy is disabled. The EndpointPod is on a remote
+	// Node and the dstPod of the reject response is on the local Node.
+	RejectNoAPServiceRemoteToLocal
+)
+
+// rejectRequest sends reject response to the requesting client, based on the
+// packet-in message.
+func (c *Controller) rejectRequest(pktIn *ofctrl.PacketIn) error {
+	// Get ethernet data.
+	srcMAC := pktIn.Data.HWDst.String()
+	dstMAC := pktIn.Data.HWSrc.String()
+
+	var (
+		srcIP  string
+		dstIP  string
+		proto  uint8
+		isIPv6 bool
+	)
+	switch ipPkt := pktIn.Data.Data.(type) {
+	case *protocol.IPv4:
+		// Get IP data.
+		srcIP = ipPkt.NWDst.String()
+		dstIP = ipPkt.NWSrc.String()
+		proto = ipPkt.Protocol
+		isIPv6 = false
+	case *protocol.IPv6:
+		// Get IP data.
+		srcIP = ipPkt.NWDst.String()
+		dstIP = ipPkt.NWSrc.String()
+		proto = ipPkt.NextHeader
+		isIPv6 = true
+	}
+
+	sIface, srcFound := c.ifaceStore.GetInterfaceByIP(srcIP)
+	dIface, dstFound := c.ifaceStore.GetInterfaceByIP(dstIP)
+	// isServiceTraffic checks if it's a Service traffic when the destination of the
+	// reject response is on local Node. When the destination of the reject response is
+	// remote, isServiceTraffic will always return false. Because there is no
+	// difference between Service traffic and Pod-to-Pod traffic in this case. They all
+	// belong to RejectLocalToRemote type and use the same logic to handle.
+	// There are two situations in which it can be determined that this is a service
+	// traffic:
+	// 1. When AntreaProxy is enabled, EpSelectedRegMark is set in ServiceEPStateField.
+	// 2. When AntreaProxy is disabled, dstIP of reject response is on the local Node
+	//    and dstMAC of reject response is antrea-gw's MAC. In this case, the reject
+	//    response is being generated for locally-originated traffic that went through
+	//    kube-proxy and was re-injected into the bridge through antrea-gw.
+	isServiceTraffic := func() bool {
+		if c.antreaProxyEnabled {
+			matches := pktIn.GetMatches()
+			if match := getMatchRegField(matches, openflow.ServiceEPStateField); match != nil {
+				if svcEpstate, err := getInfoInReg(match, openflow.ServiceEPStateField.GetRange().ToNXRange()); err != nil {
+					return svcEpstate&openflow.EpSelectedRegMark.GetValue() == openflow.EpSelectedRegMark.GetValue()
+				}
+			}
+			return false
+		}
+		gwIfaces := c.ifaceStore.GetInterfacesByType(interfacestore.GatewayInterface)
+		return dstFound && dstMAC == gwIfaces[0].MAC.String()
+	}
+	packetOutType := getRejectType(isServiceTraffic(), c.antreaProxyEnabled, srcFound, dstFound)
+	inPort, outPort := getRejectOFPorts(packetOutType, sIface, dIface)
+	mutateFunc := getRejectPacketOutMutateFunc(packetOutType)
+
+	if proto == protocol.Type_TCP {
+		// Get TCP data.
+		oriTCPSrcPort, oriTCPDstPort, oriTCPSeqNum, _, _, err := binding.GetTCPHeaderData(pktIn.Data.Data)
+		if err != nil {
+			return err
+		}
+		// While sending TCP reject packet-out, switch original src/dst port,
+		// set the ackNum as original seqNum+1 and set the flag as ack+rst.
+		return c.ofClient.SendTCPPacketOut(
+			srcMAC,
+			dstMAC,
+			srcIP,
+			dstIP,
+			inPort,
+			outPort,
+			isIPv6,
+			oriTCPDstPort,
+			oriTCPSrcPort,
+			oriTCPSeqNum+1,
+			TCPAck|TCPRst,
+			mutateFunc)
+	}
+	// Use ICMP host administratively prohibited for ICMP, UDP, SCTP reject.
+	icmpType := ICMPDstUnreachableType
+	icmpCode := ICMPDstHostAdminProhibitedCode
+	ipHdrLen := IPv4HdrLen
+	if isIPv6 {
+		icmpType = ICMPv6DstUnreachableType
+		icmpCode = ICMPv6DstAdminProhibitedCode
+		ipHdrLen = IPv6HdrLen
+	}
+	ipHdr, _ := pktIn.Data.Data.MarshalBinary()
+	icmpData := make([]byte, int(ICMPUnusedHdrLen+ipHdrLen+8))
+	// Put ICMP unused header in Data prop and set it to zero.
+	binary.BigEndian.PutUint32(icmpData[:ICMPUnusedHdrLen], 0)
+	copy(icmpData[ICMPUnusedHdrLen:], ipHdr[:ipHdrLen+8])
+	return c.ofClient.SendICMPPacketOut(
+		srcMAC,
+		dstMAC,
+		srcIP,
+		dstIP,
+		inPort,
+		outPort,
+		isIPv6,
+		icmpType,
+		icmpCode,
+		icmpData,
+		mutateFunc)
+}
+
+// getRejectType returns RejectType of a rejection.
+func getRejectType(isServiceTraffic, antreaProxyEnabled, srcIsLocal, dstIsLocal bool) RejectType {
+	if !isServiceTraffic {
+		if srcIsLocal {
+			if dstIsLocal {
+				return RejectPodLocal
+			}
+			return RejectLocalToRemote
+		}
+		return RejectPodRemoteToLocal
+	}
+	if !antreaProxyEnabled {
+		if srcIsLocal {
+			return RejectNoAPServiceLocal
+		}
+		return RejectNoAPServiceRemoteToLocal
+	}
+	if srcIsLocal {
+		if dstIsLocal {
+			return RejectServiceLocal
+		}
+		return RejectLocalToRemote
+	}
+	return RejectServiceRemoteToLocal
+}
+
+// getRejectOFPorts returns the inPort and outPort of a packetOut based on the RejectType.
+func getRejectOFPorts(rejectType RejectType, sIface, dIface *interfacestore.InterfaceConfig) (uint32, uint32) {
+	inPort := uint32(config.HostGatewayOFPort)
+	outPort := uint32(0)
+	switch rejectType {
+	case RejectPodLocal:
+		inPort = uint32(sIface.OFPort)
+		outPort = uint32(dIface.OFPort)
+	case RejectServiceLocal:
+		inPort = uint32(sIface.OFPort)
+	case RejectPodRemoteToLocal:
+		inPort = config.HostGatewayOFPort
+		outPort = uint32(dIface.OFPort)
+	case RejectServiceRemoteToLocal:
+		inPort = config.HostGatewayOFPort
+	case RejectLocalToRemote:
+		inPort = uint32(sIface.OFPort)
+	case RejectNoAPServiceLocal:
+		inPort = uint32(sIface.OFPort)
+		outPort = config.HostGatewayOFPort
+	case RejectNoAPServiceRemoteToLocal:
+		inPort = config.DefaultTunOFPort
+		outPort = config.HostGatewayOFPort
+	}
+	return inPort, outPort
+}
+
+// getRejectPacketOutMutateFunc returns the mutate func of a packetOut based on the RejectType.
+func getRejectPacketOutMutateFunc(rejectType RejectType) func(binding.PacketOutBuilder) binding.PacketOutBuilder {
+	var mutatePacketOut func(binding.PacketOutBuilder) binding.PacketOutBuilder
+	switch rejectType {
+	case RejectServiceLocal:
+		tableID := openflow.ConntrackTable.GetID()
+		mutatePacketOut = func(packetOutBuilder binding.PacketOutBuilder) binding.PacketOutBuilder {
+			return packetOutBuilder.AddResubmitAction(nil, &tableID)
+		}
+	case RejectLocalToRemote:
+		tableID := openflow.L3ForwardingTable.GetID()
+		mutatePacketOut = func(packetOutBuilder binding.PacketOutBuilder) binding.PacketOutBuilder {
+			return packetOutBuilder.AddResubmitAction(nil, &tableID)
+		}
+	}
+	return mutatePacketOut
+}

--- a/pkg/agent/openflow/client_test.go
+++ b/pkg/agent/openflow/client_test.go
@@ -438,7 +438,7 @@ func Test_client_setBasePacketOutBuilder(t *testing.T) {
 		srcIP   string
 		dstIP   string
 		inPort  uint32
-		outPort int32
+		outPort uint32
 	}
 	tests := []struct {
 		name    string

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -653,21 +653,9 @@ func (c *client) connectionTrackFlows(category cookie.Category) []binding.Flow {
 				Cookie(c.cookieAllocator.Request(category).Raw()).
 				Done(),
 			// Add reject response packet bypass flow.
-			c.conntrackBypassRejectFlow(proto),
 		)
 	}
 	return flows
-}
-
-// conntrackBypassRejectFlow generates a flow which is used to bypass the reject
-// response packet sent by the controller to avoid unexpected packet drop.
-func (c *client) conntrackBypassRejectFlow(proto binding.Protocol) binding.Flow {
-	return ConntrackStateTable.BuildFlow(priorityHigh).
-		MatchProtocol(proto).
-		MatchRegMark(CustomReasonRejectRegMark).
-		Cookie(c.cookieAllocator.Request(cookie.Default).Raw()).
-		Action().ResubmitToTable(ConntrackStateTable.GetNext()).
-		Done()
 }
 
 // dnsResponseBypassConntrackFlow generates a flow which is used to bypass the

--- a/pkg/agent/openflow/testing/mock_openflow.go
+++ b/pkg/agent/openflow/testing/mock_openflow.go
@@ -599,7 +599,7 @@ func (mr *MockClientMockRecorder) ReplayFlows() *gomock.Call {
 }
 
 // SendICMPPacketOut mocks base method
-func (m *MockClient) SendICMPPacketOut(arg0, arg1, arg2, arg3 string, arg4, arg5 uint32, arg6 bool, arg7, arg8 byte, arg9 []byte, arg10 openflow.PacketOutType) error {
+func (m *MockClient) SendICMPPacketOut(arg0, arg1, arg2, arg3 string, arg4, arg5 uint32, arg6 bool, arg7, arg8 byte, arg9 []byte, arg10 func(openflow.PacketOutBuilder) openflow.PacketOutBuilder) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SendICMPPacketOut", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)
 	ret0, _ := ret[0].(error)
@@ -613,7 +613,7 @@ func (mr *MockClientMockRecorder) SendICMPPacketOut(arg0, arg1, arg2, arg3, arg4
 }
 
 // SendTCPPacketOut mocks base method
-func (m *MockClient) SendTCPPacketOut(arg0, arg1, arg2, arg3 string, arg4, arg5 uint32, arg6 bool, arg7, arg8 uint16, arg9 uint32, arg10 byte, arg11 openflow.PacketOutType) error {
+func (m *MockClient) SendTCPPacketOut(arg0, arg1, arg2, arg3 string, arg4, arg5 uint32, arg6 bool, arg7, arg8 uint16, arg9 uint32, arg10 byte, arg11 func(openflow.PacketOutBuilder) openflow.PacketOutBuilder) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SendTCPPacketOut", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11)
 	ret0, _ := ret[0].(error)
@@ -641,7 +641,7 @@ func (mr *MockClientMockRecorder) SendTraceflowPacket(arg0, arg1, arg2, arg3 int
 }
 
 // SendUDPPacketOut mocks base method
-func (m *MockClient) SendUDPPacketOut(arg0, arg1, arg2, arg3 string, arg4, arg5 uint32, arg6 bool, arg7, arg8 uint16, arg9 []byte, arg10 bool) error {
+func (m *MockClient) SendUDPPacketOut(arg0, arg1, arg2, arg3 string, arg4, arg5 uint32, arg6 bool, arg7, arg8 uint16, arg9 []byte, arg10 func(openflow.PacketOutBuilder) openflow.PacketOutBuilder) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SendUDPPacketOut", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)
 	ret0, _ := ret[0].(error)

--- a/pkg/agent/openflow/testing/mock_openflow.go
+++ b/pkg/agent/openflow/testing/mock_openflow.go
@@ -599,7 +599,7 @@ func (mr *MockClientMockRecorder) ReplayFlows() *gomock.Call {
 }
 
 // SendICMPPacketOut mocks base method
-func (m *MockClient) SendICMPPacketOut(arg0, arg1, arg2, arg3 string, arg4 uint32, arg5 int32, arg6 bool, arg7, arg8 byte, arg9 []byte, arg10 bool) error {
+func (m *MockClient) SendICMPPacketOut(arg0, arg1, arg2, arg3 string, arg4, arg5 uint32, arg6 bool, arg7, arg8 byte, arg9 []byte, arg10 openflow.PacketOutType) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SendICMPPacketOut", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)
 	ret0, _ := ret[0].(error)
@@ -613,7 +613,7 @@ func (mr *MockClientMockRecorder) SendICMPPacketOut(arg0, arg1, arg2, arg3, arg4
 }
 
 // SendTCPPacketOut mocks base method
-func (m *MockClient) SendTCPPacketOut(arg0, arg1, arg2, arg3 string, arg4 uint32, arg5 int32, arg6 bool, arg7, arg8 uint16, arg9 uint32, arg10 byte, arg11 bool) error {
+func (m *MockClient) SendTCPPacketOut(arg0, arg1, arg2, arg3 string, arg4, arg5 uint32, arg6 bool, arg7, arg8 uint16, arg9 uint32, arg10 byte, arg11 openflow.PacketOutType) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SendTCPPacketOut", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11)
 	ret0, _ := ret[0].(error)
@@ -641,7 +641,7 @@ func (mr *MockClientMockRecorder) SendTraceflowPacket(arg0, arg1, arg2, arg3 int
 }
 
 // SendUDPPacketOut mocks base method
-func (m *MockClient) SendUDPPacketOut(arg0, arg1, arg2, arg3 string, arg4 uint32, arg5 int32, arg6 bool, arg7, arg8 uint16, arg9 []byte, arg10 bool) error {
+func (m *MockClient) SendUDPPacketOut(arg0, arg1, arg2, arg3 string, arg4, arg5 uint32, arg6 bool, arg7, arg8 uint16, arg9 []byte, arg10 bool) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SendUDPPacketOut", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)
 	ret0, _ := ret[0].(error)

--- a/pkg/ovs/openflow/interfaces.go
+++ b/pkg/ovs/openflow/interfaces.go
@@ -381,6 +381,7 @@ type PacketOutBuilder interface {
 	SetOutport(outport uint32) PacketOutBuilder
 	AddLoadAction(name string, data uint64, rng *Range) PacketOutBuilder
 	AddLoadRegMark(mark *RegMark) PacketOutBuilder
+	AddResubmitAction(inPort *uint16, table *uint8) PacketOutBuilder
 	Done() *ofctrl.PacketOut
 }
 

--- a/pkg/ovs/openflow/ofctrl_packetout.go
+++ b/pkg/ovs/openflow/ofctrl_packetout.go
@@ -304,64 +304,6 @@ func (b *ofPacketOutBuilder) AddResubmitAction(inPort *uint16, table *uint8) Pac
 	return b
 }
 
-type PacketOutType int
-
-const (
-	// RejectPodLocal represents this packetOut is used to reject Pod-to-Pod traffic
-	// and for this response, the srcPod and the dstPod are on the same Node.
-	RejectPodLocal PacketOutType = iota
-	// RejectPodRemoteToLocal represents this packetOut is used to reject Pod-to-Pod
-	// traffic and for this response, the srcPod is on a remote Node and the dstPod is
-	// on the local Node.
-	RejectPodRemoteToLocal
-	// RejectLocalToRemote represents this packetOut is used to reject traffic and for
-	// this response, the srcPod is on the local Node and the dstPod is on a remote Node.
-	// While generating rejection from local to remote, there is no difference between
-	// Service traffic and Pod traffic.
-	RejectLocalToRemote
-	// RejectServiceLocal represents this packetOut is used to reject Service traffic,
-	// when AntreaProxy is enabled. The EndpointPod and the dstPod of the reject
-	// response are on the same Node.
-	RejectServiceLocal
-	// RejectServiceRemoteToLocal represents this packetOut is used to reject Service
-	// traffic, when AntreaProxy is enabled. The EndpointPod is on a remote Node and
-	// the dstPod of the reject response is on the local Node.
-	RejectServiceRemoteToLocal
-	// RejectNoAPServiceLocal represents this packetOut is used to reject Service
-	// traffic, when AntreaProxy is disabled. The EndpointPod and the dstPod of the
-	// reject response are on the same Node.
-	RejectNoAPServiceLocal
-	// RejectNoAPServiceRemoteToLocal represents this packetOut is used to reject
-	// Service traffic, when AntreaProxy is disabled. The EndpointPod is on a remote
-	// Node and the dstPod of the reject response is on the local Node.
-	RejectNoAPServiceRemoteToLocal
-)
-
-func GetPacketOutType(isServiceTraffic, antreaProxyEnabled, srcIsLocal, dstIsLocal bool) PacketOutType {
-	if !isServiceTraffic {
-		if srcIsLocal {
-			if dstIsLocal {
-				return RejectPodLocal
-			}
-			return RejectLocalToRemote
-		}
-		return RejectPodRemoteToLocal
-	}
-	if !antreaProxyEnabled {
-		if srcIsLocal {
-			return RejectNoAPServiceLocal
-		}
-		return RejectNoAPServiceRemoteToLocal
-	}
-	if srcIsLocal {
-		if dstIsLocal {
-			return RejectServiceLocal
-		}
-		return RejectLocalToRemote
-	}
-	return RejectServiceRemoteToLocal
-}
-
 func (b *ofPacketOutBuilder) Done() *ofctrl.PacketOut {
 	if b.pktOut.IPHeader != nil && b.pktOut.IPv6Header != nil {
 		klog.Errorf("Invalid PacketOutBuilder: IP header and IPv6 header are not allowed to exist at the same time")

--- a/pkg/ovs/openflow/ofctrl_packetout.go
+++ b/pkg/ovs/openflow/ofctrl_packetout.go
@@ -298,6 +298,70 @@ func (b *ofPacketOutBuilder) AddLoadRegMark(mark *RegMark) PacketOutBuilder {
 	return b.AddLoadAction(name, uint64(mark.value), mark.field.rng)
 }
 
+func (b *ofPacketOutBuilder) AddResubmitAction(inPort *uint16, table *uint8) PacketOutBuilder {
+	act := ofctrl.NewResubmit(inPort, table)
+	b.pktOut.Actions = append(b.pktOut.Actions, act)
+	return b
+}
+
+type PacketOutType int
+
+const (
+	// RejectPodLocal represents this packetOut is used to reject Pod-to-Pod traffic
+	// and for this response, the srcPod and the dstPod are on the same Node.
+	RejectPodLocal PacketOutType = iota
+	// RejectPodRemoteToLocal represents this packetOut is used to reject Pod-to-Pod
+	// traffic and for this response, the srcPod is on a remote Node and the dstPod is
+	// on the local Node.
+	RejectPodRemoteToLocal
+	// RejectLocalToRemote represents this packetOut is used to reject traffic and for
+	// this response, the srcPod is on the local Node and the dstPod is on a remote Node.
+	// While generating rejection from local to remote, there is no difference between
+	// Service traffic and Pod traffic.
+	RejectLocalToRemote
+	// RejectServiceLocal represents this packetOut is used to reject Service traffic,
+	// when AntreaProxy is enabled. The EndpointPod and the dstPod of the reject
+	// response are on the same Node.
+	RejectServiceLocal
+	// RejectServiceRemoteToLocal represents this packetOut is used to reject Service
+	// traffic, when AntreaProxy is enabled. The EndpointPod is on a remote Node and
+	// the dstPod of the reject response is on the local Node.
+	RejectServiceRemoteToLocal
+	// RejectNoAPServiceLocal represents this packetOut is used to reject Service
+	// traffic, when AntreaProxy is disabled. The EndpointPod and the dstPod of the
+	// reject response are on the same Node.
+	RejectNoAPServiceLocal
+	// RejectNoAPServiceRemoteToLocal represents this packetOut is used to reject
+	// Service traffic, when AntreaProxy is disabled. The EndpointPod is on a remote
+	// Node and the dstPod of the reject response is on the local Node.
+	RejectNoAPServiceRemoteToLocal
+)
+
+func GetPacketOutType(isServiceTraffic, antreaProxyEnabled, srcIsLocal, dstIsLocal bool) PacketOutType {
+	if !isServiceTraffic {
+		if srcIsLocal {
+			if dstIsLocal {
+				return RejectPodLocal
+			}
+			return RejectLocalToRemote
+		}
+		return RejectPodRemoteToLocal
+	}
+	if !antreaProxyEnabled {
+		if srcIsLocal {
+			return RejectNoAPServiceLocal
+		}
+		return RejectNoAPServiceRemoteToLocal
+	}
+	if srcIsLocal {
+		if dstIsLocal {
+			return RejectServiceLocal
+		}
+		return RejectLocalToRemote
+	}
+	return RejectServiceRemoteToLocal
+}
+
 func (b *ofPacketOutBuilder) Done() *ofctrl.PacketOut {
 	if b.pktOut.IPHeader != nil && b.pktOut.IPv6Header != nil {
 		klog.Errorf("Invalid PacketOutBuilder: IP header and IPv6 header are not allowed to exist at the same time")

--- a/test/e2e/antreapolicy_test.go
+++ b/test/e2e/antreapolicy_test.go
@@ -1832,7 +1832,6 @@ func testACNPRejectIngress(t *testing.T, protocol v1.Protocol) {
 }
 
 func testRejectServiceTraffic(t *testing.T, data *TestData) {
-
 	clientName := "agnhost-client"
 	require.NoError(t, data.createAgnhostPodOnNode(clientName, testNamespace, nodeName(0), false))
 	defer data.deletePodAndWait(defaultTimeout, clientName, testNamespace)

--- a/test/e2e/k8s_util.go
+++ b/test/e2e/k8s_util.go
@@ -172,20 +172,20 @@ func (k *KubernetesUtils) Probe(ns1, pod1, ns2, pod2 string, port int32, protoco
 
 // ProbeAddr execs into a Pod and checks its connectivity to an arbitrary destination
 // address.
-func (k *KubernetesUtils) ProbeAddr(ns, podLabel, pod, dstAddr string, port int32, protocol v1.Protocol) (PodConnectivityMark, error) {
-	fromPods, err := k.GetPodsByLabel(ns, podLabel, pod)
+func (k *KubernetesUtils) ProbeAddr(ns, podLabelKey, podLabelValue, dstAddr string, port int32, protocol v1.Protocol) (PodConnectivityMark, error) {
+	fromPods, err := k.GetPodsByLabel(ns, podLabelKey, podLabelValue)
 	if err != nil {
 		return Error, fmt.Errorf("unable to get Pods from Namespace %s: %v", ns, err)
 	}
 	if len(fromPods) == 0 {
-		return Error, fmt.Errorf("no Pod of label pod=%s in Namespace %s found", pod, ns)
+		return Error, fmt.Errorf("no Pod of label podLabelKey=%s podLabelValue=%s in Namespace %s found", podLabelKey, podLabelValue, ns)
 	}
 	fromPod := fromPods[0]
 	// If it's an IPv6 address, add "[]" around it.
 	if strings.Contains(dstAddr, ":") {
 		dstAddr = fmt.Sprintf("[%s]", dstAddr)
 	}
-	connectivity := k.probe(&fromPod, fmt.Sprintf("%s/%s", ns, pod), dstAddr, dstAddr, port, protocol)
+	connectivity := k.probe(&fromPod, fmt.Sprintf("%s/%s", ns, podLabelValue), dstAddr, dstAddr, port, protocol)
 	return connectivity, nil
 }
 

--- a/test/e2e/k8s_util.go
+++ b/test/e2e/k8s_util.go
@@ -170,10 +170,10 @@ func (k *KubernetesUtils) Probe(ns1, pod1, ns2, pod2 string, port int32, protoco
 	return connectivity, nil
 }
 
-// Probe execs into a Pod and checks its connectivity to an arbirary destination
+// ProbeAddr execs into a Pod and checks its connectivity to an arbitrary destination
 // address.
-func (k *KubernetesUtils) ProbeEgress(ns, pod, dstAddr string, port int32, protocol v1.Protocol) (PodConnectivityMark, error) {
-	fromPods, err := k.GetPodsByLabel(ns, "pod", pod)
+func (k *KubernetesUtils) ProbeAddr(ns, podLabel, pod, dstAddr string, port int32, protocol v1.Protocol) (PodConnectivityMark, error) {
+	fromPods, err := k.GetPodsByLabel(ns, podLabel, pod)
 	if err != nil {
 		return Error, fmt.Errorf("unable to get Pods from Namespace %s: %v", ns, err)
 	}


### PR DESCRIPTION
Fixes issue #2699 

**1. Change reject response packetOut logic to below:**
* Pod-to-Pod traffic
    * Locally: Directly output the packet to the destination OF port. Use src/dstPod's OF port as in/outPort.
    * Remote to local: Directly output the packet to the destination OF port. Use gateway's OF port as inPort and dstPod's OF port as outPort.
    * Local to remote: Resubmit packet to l3ForwardingTable(70). Use Pod's OF port as inPort.
* Service traffic
    * AntreaProxy enabled
        * Locally: Resubmit packet to conntrackTable(30). Use srcPod's OF port as inPort.
        * Remote to local: Use gateway's OF port as inPort.
        * Local to remote: Same as Pod-to-Pod traffic local to remote case.
    * AntreaProxy disabled
        * Locally: Directly output the packet to gateway's OF port. Use srcPod's OF port as inPort and gateway's OF port as outPort.
        * Remote to local: Directly output the packet to gateway's OF port. Use tunnel's OF port as inPort and gateway's OF port as outPort.
        * Local to remote: Same as Pod-to-Pod traffic local to remote case.
        
**2. To decided if it is Service traffic:**
* AntreaProxy enabled:
   If `EpSelectedRegMark` is set in `ServiceEPStateField`, then it's Service traffic
* AntreaProxy disabled:
   For the destination of the reject response, if dstIP is on local Node, but the dstMAC is the gateway's MAC. We could say this response is heading to kube-proxy, which means it's Service traffic.

**3. Removed reject bypass CT logic.**

**4. Added e2e to test reject action on Service traffic.**


---
_Reference Table of all cases when **Antrea Proxy is disabled**_
| Node       | Policy  | Traffic    | Reject Packet                                                      | Type                           |
| ---------- | ------- | ---------- | ------------------------------------------------------------ | ------------------------------ |
| Inter-Node | Ingress | Pod-to-Pod | srcMAC: srcPod MAC<br />dstMAC: antrea-gw MAC<br />srcIP: srcPodIP<br />dstIP: dstPodIP(remote) | RejectLocalToRemote            |
| Inter-Node | Ingress | Service    | srcMAC: srcPod MAC<br />dstMAC: antrea-gw MAC<br />srcIP: srcPodIP<br />dstIP: dstPodIP(remote) | RejectLocalToRemote            |
| Inter-Node | Egress  | Pod-to-Pod | srcMAC: antrea-gw MAC<br />dstMAC: dstPod MAC<br />srcIP: srcPodIP<br />dstIP: dstPodIP(local) | RejectPodRemoteToLocal         |
| Inter-Node | Egress  | Service    | srcMAC: virtule MAC<br />dstMAC: antrea-gw MAC<br />srcIP: srcPodIP<br />dstIP: dstPodIP(local) | RejectNoAPServiceRemoteToLocal |
| Intra-Node | Ingress | Pod-to-Pod | srcMAC: srcPod MAC<br />dstMAC: dstPod MAC<br />srcIP: srcPodIP<br />dstIP: dstPodIP(local) | RejectPodLocal                 |
| Intra-Node | Ingress | Service    | srcMAC: srcPod MAC<br />dstMAC: antrea-gw MAC<br />srcIP: srcPodIP<br />dstIP: dstPodIP(local) | RejectNoAPServiceLocal         |
| Intra-Node | Egress  | Pod-to-Pod | srcMAC: srcPod MAC<br />dstMAC: dstPod MAC<br />srcIP: srcPodIP<br />dstIP: dstPodIP(local) | RejectPodLocal                 |
| Intra-Node | Egress  | Service    | srcMAC: srcPod MAC<br />dstMAC: antrea-gw MAC<br />srcIP: srcPodIP<br />dstIP: dstPodIP(local) | RejectNoAPServiceLocal         |

Signed-off-by: wgrayson <wgrayson@vmware.com>