### PR TITLE
[Windows] Bugfix for MTU configuration on nonexistent interface

### DIFF
--- a/pkg/agent/cniserver/interface_configuration_linux.go
+++ b/pkg/agent/cniserver/interface_configuration_linux.go
@@ -341,6 +341,7 @@ func (ic *ifConfigurator) configureContainerLink(
 	brSriovVFDeviceID string,
 	podSriovVFDeviceID string,
 	result *current.Result,
+	containerAccess *containerAccessArbitrator,
 ) error {
 	if brSriovVFDeviceID != "" {
 		if !ic.isOvsHardwareOffloadEnabled {

--- a/pkg/agent/cniserver/pod_configuration.go
+++ b/pkg/agent/cniserver/pod_configuration.go
@@ -204,7 +204,7 @@ func (pc *podConfigurator) configureInterfaces(
 	createOVSPort bool,
 	containerAccess *containerAccessArbitrator,
 ) error {
-	err := pc.ifConfigurator.configureContainerLink(podName, podNameSpace, containerID, containerNetNS, containerIFDev, mtu, sriovVFDeviceID, "", result)
+	err := pc.ifConfigurator.configureContainerLink(podName, podNameSpace, containerID, containerNetNS, containerIFDev, mtu, sriovVFDeviceID, "", result, containerAccess)
 	if err != nil {
 		return err
 	}

--- a/pkg/agent/cniserver/sriov.go
+++ b/pkg/agent/cniserver/sriov.go
@@ -125,7 +125,7 @@ func (pc *podConfigurator) configureSecondaryInterface(
 		return fmt.Errorf("error getting the Pod SR-IOV VF device ID")
 	}
 
-	err := pc.ifConfigurator.configureContainerLink(podName, podNameSpace, containerID, containerNetNS, containerIFDev, mtu, "", podSriovVFDeviceID, result)
+	err := pc.ifConfigurator.configureContainerLink(podName, podNameSpace, containerID, containerNetNS, containerIFDev, mtu, "", podSriovVFDeviceID, result, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Use a separate goroutine to process interface configuration async. The
configurations are taken after the host interface is created.

Signed-off-by: wenyingd <wenyingd@vmware.com>

Fixes #2773 