### PR TITLE
Pin codegen image tag to kubernetes-1.21.0-build.0

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -19,7 +19,7 @@ set -o nounset
 set -o pipefail
 
 ANTREA_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
-IMAGE_NAME="antrea/codegen:kubernetes-1.21.0"
+IMAGE_NAME="antrea/codegen:kubernetes-1.21.0-build.0"
 
 function docker_run() {
   docker pull ${IMAGE_NAME}


### PR DESCRIPTION
codegen:kubernetes-1.21.0 has been reverted to Golang v1.15 as previous
releases still use it. codegen:kubernetes-1.21.0-build.0 is created
with Golang upgraded to v1.17.

Signed-off-by: Quan Tian <qtian@vmware.com>

For #2780