### PR TITLE
supportbundle: fix nil pointer error

### DIFF
--- a/pkg/apiserver/registry/system/supportbundle/rest.go
+++ b/pkg/apiserver/registry/system/supportbundle/rest.go
@@ -159,7 +159,9 @@ func (r *supportBundleREST) Create(ctx context.Context, obj runtime.Object, _ re
 				r.cache = b
 			}
 		}()
-		r.clean(ctx, b.Filepath, bundleExpireDuration)
+		if err != nil {
+			r.clean(ctx, b.Filepath, bundleExpireDuration)
+		}
 	}()
 
 	return r.cache, nil


### PR DESCRIPTION
When iproute2 is not installed in docker image, and one runs `antctl supportbundle` in
antrea-agent, it will panic. This is because collectAgent will return a nil pointer
for systemv1beta1.SupportBundle, and in `func (r *supportBundleREST) Create`,
antrea calls a method on the nil pointer directly which leads to the panic.

Signed-off-by: Bin Liu <biliu@vmware.com>