### PR TITLE
Automated cherry pick of #2598: supportbundle: fix nil pointer error

### DIFF
--- a/pkg/apiserver/registry/system/supportbundle/rest.go
+++ b/pkg/apiserver/registry/system/supportbundle/rest.go
@@ -159,7 +159,9 @@ func (r *supportBundleREST) Create(ctx context.Context, obj runtime.Object, _ re
 				r.cache = b
 			}
 		}()
-		r.clean(ctx, b.Filepath, bundleExpireDuration)
+		if err != nil {
+			r.clean(ctx, b.Filepath, bundleExpireDuration)
+		}
 	}()
 
 	return r.cache, nil


### PR DESCRIPTION
Cherry pick of #2598 on release-1.2.

#2598: supportbundle: fix nil pointer error

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.