### PR TITLE
Automated cherry pick of #2768: Fix triggerCNPUpdates panic

### DIFF
--- a/pkg/controller/networkpolicy/clustergroup_test.go
+++ b/pkg/controller/networkpolicy/clustergroup_test.go
@@ -18,8 +18,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"antrea.io/antrea/pkg/apis/controlplane"
@@ -827,4 +830,129 @@ func TestGetGroupMembers(t *testing.T) {
 			assert.Equal(t, tt.expectedMembers, members)
 		})
 	}
+}
+
+func TestSyncInternalGroup(t *testing.T) {
+	p10 := float64(10)
+	p20 := float64(20)
+	allowAction := crdv1alpha1.RuleActionAllow
+	cgName := "cgA"
+	cgUID := types.UID("uidA")
+	cg := &crdv1alpha3.ClusterGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: cgName, UID: cgUID},
+		Spec:       crdv1alpha3.GroupSpec{NamespaceSelector: &selectorA},
+	}
+	cnp1 := &crdv1alpha1.ClusterNetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "cnp1", UID: "uid1"},
+		Spec: crdv1alpha1.ClusterNetworkPolicySpec{
+			AppliedTo: []crdv1alpha1.NetworkPolicyPeer{
+				{PodSelector: &selectorB},
+			},
+			Priority: p10,
+			Ingress: []crdv1alpha1.Rule{
+				{
+					From: []crdv1alpha1.NetworkPolicyPeer{
+						{Group: cgName},
+					},
+					Action: &allowAction,
+				},
+			},
+		},
+	}
+	cnp2 := &crdv1alpha1.ClusterNetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "cnp2", UID: "uid2"},
+		Spec: crdv1alpha1.ClusterNetworkPolicySpec{
+			AppliedTo: []crdv1alpha1.NetworkPolicyPeer{
+				{PodSelector: &selectorC},
+			},
+			Priority: p20,
+			Ingress: []crdv1alpha1.Rule{
+				{
+					From: []crdv1alpha1.NetworkPolicyPeer{
+						{Group: cgName},
+					},
+					Action: &allowAction,
+				},
+			},
+		},
+	}
+
+	_, npc := newControllerWithoutEventHandler(nil, []runtime.Object{cnp1, cnp2, cg})
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	npc.crdInformerFactory.Start(stopCh)
+	npc.crdInformerFactory.WaitForCacheSync(stopCh)
+
+	// After creating a ClusterGroup:
+	// - A corresponding internal group should be added for it.
+	// - The internal NetworkPolicies for the ClusterNetworkPolicies that use it should reference to it regardless of
+	//   whether they are added before the ClusterGroup or after it.
+	// - An AddressGroup should be created for it.
+
+	// cnp1 is added before the ClusterGroup.
+	npc.addCNP(cnp1)
+	npc.addClusterGroup(cg)
+	err := npc.syncInternalGroup(internalGroupKeyFunc(cg))
+	require.NoError(t, err)
+	// cnp2 is added after the ClusterGroup.
+	npc.addCNP(cnp2)
+
+	expectedInternalNetworkPolicy1 := &antreatypes.NetworkPolicy{
+		UID:  "uid1",
+		Name: "uid1",
+		SourceRef: &controlplane.NetworkPolicyReference{
+			Type: controlplane.AntreaClusterNetworkPolicy,
+			Name: "cnp1",
+			UID:  "uid1",
+		},
+		Priority:     &p10,
+		TierPriority: &DefaultTierPriority,
+		Rules: []controlplane.NetworkPolicyRule{
+			{
+				Direction: controlplane.DirectionIn,
+				From:      controlplane.NetworkPolicyPeer{AddressGroups: []string{cgName}},
+				Priority:  0,
+				Action:    &allowAction,
+			},
+		},
+		AppliedToGroups: []string{getNormalizedUID(toGroupSelector("", &selectorB, nil, nil).NormalizedName)},
+	}
+	actualInternalNetworkPolicy1, exists, _ := npc.internalNetworkPolicyStore.Get(internalNetworkPolicyKeyFunc(cnp1))
+	require.True(t, exists)
+	assert.Equal(t, expectedInternalNetworkPolicy1, actualInternalNetworkPolicy1)
+
+	expectedInternalNetworkPolicy2 := &antreatypes.NetworkPolicy{
+		UID:  "uid2",
+		Name: "uid2",
+		SourceRef: &controlplane.NetworkPolicyReference{
+			Type: controlplane.AntreaClusterNetworkPolicy,
+			Name: "cnp2",
+			UID:  "uid2",
+		},
+		Priority:     &p20,
+		TierPriority: &DefaultTierPriority,
+		Rules: []controlplane.NetworkPolicyRule{
+			{
+				Direction: controlplane.DirectionIn,
+				From:      controlplane.NetworkPolicyPeer{AddressGroups: []string{cgName}},
+				Priority:  0,
+				Action:    &allowAction,
+			},
+		},
+		AppliedToGroups: []string{getNormalizedUID(toGroupSelector("", &selectorC, nil, nil).NormalizedName)},
+	}
+	actualInternalNetworkPolicy2, exists, _ := npc.internalNetworkPolicyStore.Get(internalNetworkPolicyKeyFunc(cnp2))
+	require.True(t, exists)
+	assert.Equal(t, expectedInternalNetworkPolicy2, actualInternalNetworkPolicy2)
+
+	expectedInternalGroup := &antreatypes.Group{
+		UID:      cgUID,
+		Name:     cgName,
+		Selector: toGroupSelector("", nil, &selectorA, nil),
+	}
+	actualInternalGroup, exists, _ := npc.internalGroupStore.Get(internalGroupKeyFunc(cg))
+	require.True(t, exists)
+	assert.Equal(t, expectedInternalGroup, actualInternalGroup)
+	_, exists, _ = npc.addressGroupStore.Get(cgName)
+	require.True(t, exists, "An AddressGroup should be created for the ClusterGroup when it's referenced by any ClusterNetworkPolicy")
 }

--- a/pkg/controller/networkpolicy/networkpolicy_controller_perf_test.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller_perf_test.go
@@ -470,7 +470,7 @@ func benchmarkInit(b *testing.B, namespaces []*corev1.Namespace, networkPolicies
 	objs := toRunTimeObjects(namespaces, networkPolicies, pods)
 	stopCh := make(chan struct{})
 	defer close(stopCh)
-	_, c := newControllerWithoutEventHandler(objs...)
+	_, c := newControllerWithoutEventHandler(objs, nil)
 	c.informerFactory.Start(stopCh)
 	c.informerFactory.WaitForCacheSync(stopCh)
 


### PR DESCRIPTION
Cherry pick of #2768 on release-1.2.

#2768: Fix triggerCNPUpdates panic

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.