### PR TITLE
Add env parameter to support noEncap without AntreaProxy

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -4324,6 +4324,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: ALLOW_NO_ENCAP_WITHOUT_ANTREA_PROXY
+          value: "true"
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -4326,6 +4326,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: ALLOW_NO_ENCAP_WITHOUT_ANTREA_PROXY
+          value: "true"
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -4324,6 +4324,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: ALLOW_NO_ENCAP_WITHOUT_ANTREA_PROXY
+          value: "true"
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -4373,6 +4373,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: ALLOW_NO_ENCAP_WITHOUT_ANTREA_PROXY
+          value: "true"
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -4329,6 +4329,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: ALLOW_NO_ENCAP_WITHOUT_ANTREA_PROXY
+          value: "true"
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/build/yamls/base/agent.yml
+++ b/build/yamls/base/agent.yml
@@ -87,6 +87,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            # For using noEncap or hybrid traffic mode without AntreaProxy
+            - name: ALLOW_NO_ENCAP_WITHOUT_ANTREA_PROXY
+              value: "true"
           ports:
             - containerPort: 10350
               name: api

--- a/pkg/util/env/env.go
+++ b/pkg/util/env/env.go
@@ -33,6 +33,8 @@ const (
 	antreaCloudEKSEnvKey = "ANTREA_CLOUD_EKS"
 
 	defaultAntreaNamespace = "kube-system"
+
+	allowNoEncapWithoutAntreaProxy = "ALLOW_NO_ENCAP_WITHOUT_ANTREA_PROXY"
 )
 
 // GetNodeName returns the node's name used in Kubernetes, based on the priority:
@@ -120,4 +122,9 @@ func GetAntreaNamespace() string {
 		namespace = defaultAntreaNamespace
 	}
 	return namespace
+}
+
+// GetAllowNoEncapWithoutAntreaProxy returns the status if can use noEncap or hybrid traffic mode without AntreaProxy.
+func GetAllowNoEncapWithoutAntreaProxy() bool {
+	return getBoolEnvVar(allowNoEncapWithoutAntreaProxy, false)
 }


### PR DESCRIPTION
NoEncap mode can make the traffic output to physical network directly. When antrea proxy is disable, traffic won't go back to OVS for Egress NetworkPolicy enforcement, it breaks the basic security function, we can force support NoEncap with TrafficDirectRouting environment parameter for performance.

Fixes: #2600

Signed-off-by: Wenze Gao <wenze.gao@transwarp.io>