### PR TITLE
Remove chmod for OVSDB file from start_ovs

### DIFF
--- a/build/images/scripts/start_ovs
+++ b/build/images/scripts/start_ovs
@@ -128,10 +128,6 @@ cleanup_ovs_run_files
 
 start_ovs $hw_offload
 
-# Restrict read permissions for "others"
-# See discussion in https://github.com/antrea-io/antrea/issues/1292
-chmod 0640 $OVS_DB_FILE
-
 # Check OVS status every 30 seconds
 CHECK_OVS_INTERVAL=30
 # Run logrotate every hour

--- a/build/images/scripts/start_ovs_netdev
+++ b/build/images/scripts/start_ovs_netdev
@@ -132,10 +132,6 @@ trap "quit" INT TERM
 fix_ovs_ctl
 start_ovs
 
-# Restrict read permissions for "others"
-# See discussion in https://github.com/antrea-io/antrea/issues/1292
-chmod 0640 $OVS_DB_FILE
-
 if [[ "$#" -ge 1 ]] && [[ "$1" == "--start-ovs-only" ]]; then
   exit 0
 fi


### PR DESCRIPTION
Starting with OVS 2.15.0, the permissions are set correctly (i.e. more
securely) for the OVSDB .db file (with no read permissions for
"others"). Because we use OVS 2.15.1 in Antrea, we no longer need to
manually fix the permissions in start_ovs / start_ovs_netdev.

Fixes #1292

Signed-off-by: Antonin Bas <abas@vmware.com>