### PR TITLE
Upgrade go-ipfix to v0.5.8

### DIFF
--- a/ci/kind/test-e2e-kind.sh
+++ b/ci/kind/test-e2e-kind.sh
@@ -129,7 +129,7 @@ COMMON_IMAGES_LIST=("gcr.io/kubernetes-e2e-test-images/agnhost:2.8" \
                     "projects.registry.vmware.com/library/busybox"  \
                     "projects.registry.vmware.com/antrea/nginx" \
                     "projects.registry.vmware.com/antrea/perftool" \
-                    "projects.registry.vmware.com/antrea/ipfix-collector:v0.5.7" \
+                    "projects.registry.vmware.com/antrea/ipfix-collector:v0.5.8" \
                     "projects.registry.vmware.com/antrea/wireguard-go:0.0.20210424")
 for image in "${COMMON_IMAGES_LIST[@]}"; do
     for i in `seq 3`; do

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/ti-mo/conntrack v0.4.0
 	github.com/vishvananda/netlink v1.1.1-0.20210510164352-d17758a128bf
-	github.com/vmware/go-ipfix v0.5.7
+	github.com/vmware/go-ipfix v0.5.8
 	golang.org/x/crypto v0.0.0-20210503195802-e9a32991a82e
 	golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6
 	golang.org/x/mod v0.4.2

--- a/go.sum
+++ b/go.sum
@@ -641,8 +641,8 @@ github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc/go.mod h1:ZjcWmF
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae h1:4hwBBUfQCFe3Cym0ZtKyq7L16eZUtYKs+BaHDN6mAns=
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
-github.com/vmware/go-ipfix v0.5.7 h1:twv8mrXwlXhlWdixogGmyKwLia/G7hsZM46xd8aO+rc=
-github.com/vmware/go-ipfix v0.5.7/go.mod h1:yzbG1rv+yJ8GeMrRm+MDhOV3akygNZUHLhC1pDoD2AY=
+github.com/vmware/go-ipfix v0.5.8 h1:/npDq+uGp9AoESNJvjsT6f3vT2rQc1Oq1RhHNN+N06k=
+github.com/vmware/go-ipfix v0.5.8/go.mod h1:yzbG1rv+yJ8GeMrRm+MDhOV3akygNZUHLhC1pDoD2AY=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=

--- a/pkg/agent/flowexporter/exporter/exporter_perf_test.go
+++ b/pkg/agent/flowexporter/exporter/exporter_perf_test.go
@@ -53,27 +53,27 @@ go test -test.v -run=BenchmarkExport -test.benchmem -bench=BenchmarkExportConntr
 goos: linux
 goarch: amd64
 pkg: antrea.io/antrea/pkg/agent/flowexporter/exporter
-BenchmarkExportConntrackConns-2   	     100	   3484688 ns/op	  527820 B/op	    8214 allocs/op
---- BENCH: BenchmarkExportConntrackConns-2
-    exporter_perf_test.go:92:
+cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+BenchmarkExportConntrackConns
+    exporter_perf_test.go:95:
         Summary:
         Number of conntrack connections: 20000
         Number of dying conntrack connections: 2000
-        Total connections received: 19698
-    exporter_perf_test.go:92:
+        Total connections received: 19564
+    exporter_perf_test.go:95:
         Summary:
         Number of conntrack connections: 20000
         Number of dying conntrack connections: 2000
-        Total connections received: 18509
-	... [output truncated]
+        Total connections received: 18259
+BenchmarkExportConntrackConns-2   	     100	   3174982 ns/op	  328104 B/op	    3262 allocs/op
 PASS
-ok  	antrea.io/antrea/pkg/agent/flowexporter/exporter	1.134s
+ok  	antrea.io/antrea/pkg/agent/flowexporter/exporter	1.249s
 Reference value:
 	#conns
-	20000     100	   3484688 ns/op	  527820 B/op	    8214 allocs/op
-	30000     100 	   5868374 ns/op	  788098 B/op	   12313 allocs/op
-	40000     100	   7300047 ns/op	 1047562 B/op	   16392 allocs/op
-	50000     100	   9312464 ns/op	 1308313 B/op	   20503 allocs/op
+	20000     100	   3174982 ns/op	  328104 B/op	    3262 allocs/op
+	30000     100	   5074667 ns/op	  489624 B/op	    4874 allocs/op
+	40000     100	   5910591 ns/op	  649683 B/op	    6442 allocs/op
+	50000     100	   8435327 ns/op	  811341 B/op	    8057 allocs/op
 */
 func BenchmarkExportConntrackConns(b *testing.B) {
 	disableLogToStderr()
@@ -101,27 +101,27 @@ go test -test.v -run=BenchmarkExport -test.benchmem -bench=BenchmarkExportDenyCo
 goos: linux
 goarch: amd64
 pkg: antrea.io/antrea/pkg/agent/flowexporter/exporter
-BenchmarkExportDenyConns-2   	     100	   3714699 ns/op	  507942 B/op	    7037 allocs/op
---- BENCH: BenchmarkExportDenyConns-2
-    exporter_perf_test.go:135:
+cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
+BenchmarkExportDenyConns
+    exporter_perf_test.go:143:
         Summary:
         Number of deny connections: 20000
         Number of idle deny connections: 2000
-        Total connections received: 19742
-    exporter_perf_test.go:135:
+        Total connections received: 19218
+    exporter_perf_test.go:143:
         Summary:
         Number of deny connections: 20000
         Number of idle deny connections: 2000
-        Total connections received: 19671
-	... [output truncated]
+        Total connections received: 19237
+BenchmarkExportDenyConns-2   	     100	   3133778 ns/op	  322203 B/op	    3474 allocs/op
 PASS
-ok  	antrea.io/antrea/pkg/agent/flowexporter/exporter	1.331s
+ok  	antrea.io/antrea/pkg/agent/flowexporter/exporter	1.238s
 Reference value:
 	#conns
-	20000   100	   3714699 ns/op	  507942 B/op	    7037 allocs/op
-	30000   100	   5073132 ns/op	  755810 B/op	   10488 allocs/op
-	40000   100	   7874295 ns/op	 1004996 B/op	   13965 allocs/op
-	50000   100	   8681581 ns/op	 1257332 B/op	   17527 allocs/op
+	20000   100	   3133778 ns/op	  322203 B/op	    3474 allocs/op
+	30000   100	   4813561 ns/op	  480075 B/op	    5175 allocs/op
+	40000   100	   6772657 ns/op	  637599 B/op	    6860 allocs/op
+	50000   100	   7078690 ns/op	  795104 B/op	    8549 allocs/op
 */
 func BenchmarkExportDenyConns(b *testing.B) {
 	disableLogToStderr()

--- a/plugins/octant/go.sum
+++ b/plugins/octant/go.sum
@@ -687,7 +687,7 @@ github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/vmware-tanzu/octant v0.17.0 h1:2H2AiQU5C1RiHxxYrrOosDHHI9eV51nP+e9PjRP+c48=
 github.com/vmware-tanzu/octant v0.17.0/go.mod h1:lA32xKa6icUclg+DjAX/E/Id1cTqwCXZUem3RGEp/2A=
-github.com/vmware/go-ipfix v0.5.7/go.mod h1:yzbG1rv+yJ8GeMrRm+MDhOV3akygNZUHLhC1pDoD2AY=
+github.com/vmware/go-ipfix v0.5.8/go.mod h1:yzbG1rv+yJ8GeMrRm+MDhOV3akygNZUHLhC1pDoD2AY=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -107,7 +107,7 @@ const (
 	busyboxImage        = "projects.registry.vmware.com/library/busybox"
 	nginxImage          = "projects.registry.vmware.com/antrea/nginx"
 	perftoolImage       = "projects.registry.vmware.com/antrea/perftool"
-	ipfixCollectorImage = "projects.registry.vmware.com/antrea/ipfix-collector:v0.5.7"
+	ipfixCollectorImage = "projects.registry.vmware.com/antrea/ipfix-collector:v0.5.8"
 	ipfixCollectorPort  = "4739"
 
 	nginxLBService = "nginx-loadbalancer"


### PR DESCRIPTION
see https://github.com/vmware/go-ipfix/releases/tag/v0.5.8 for changes.

With basic structure change of NewInfoElementWithValue, memory usage is expected to be reduced. Here is the Flow Exporter benchmarking improvement for conntrack connections:
Before:
|# conns | iterations | ns/op | B/op | allocs/op|
|-- | -- | -- | -- | --|
|20000   |  100	 |  3484688 ns/op	|  527820 B/op	|    8214 allocs/op|
|30000  |  100  |  5868374 ns/op	|  788098 B/op        |   12313 allocs/op|
|40000  |   100 | 7300047 ns/op     | 1047562 B/op	|   16392 allocs/op|
|50000  |  100	 |  9312464 ns/op	| 1308313 B/op	|   20503 allocs/op|

After change:
|# conns | iterations | ns/op | B/op | allocs/op|
|-- | -- | -- | -- | --|
|20000   |   100	|   3174982 ns/op 	 | 328104 B/op	|    3262 allocs/op|
|30000   |   100	 |  5074667 ns/op	|  489624 B/op  |  4874 allocs/op|
|40000   |  100	|   5910591 ns/op	|  649683 B/op  | 6442 allocs/op|
|50000   |  100	|   8435327 ns/op	|  811341 B/op	  |  8057 allocs/op|

Improvements - reduce by:
|# conns | iterations | ns/op | B/op | allocs/op|
|-- | -- | -- | -- | --|
|20000   |  100	 |  8.89%	|  37.8%	|   60.29%|
|30000  |  100  |  13.53%|  37.87%        |   60.42%|
|40000  |   100 |  19.03%    | 37.98% 	|   60.70%|
|50000  |  100	 |  9.42%	| 37.99%	|   60.70%|

From the result we can see a stable 37% reduction in memory usage and 60% reduction in allocations. Flow Exporter benchmarking of denied connections also achieve around 36% reduction in memory usage and 50% reduction in allocations.