### PR TITLE
Use @antrea-io/review-manager to manage PR reviews

### DIFF
--- a/.github/AREA-OWNERS
+++ b/.github/AREA-OWNERS
@@ -1,0 +1,111 @@
+maintainers:
+- antoninbas
+- jianjuns
+- tnqn
+- salv-orlando
+
+# Any antrea-io org member can add themselves to this list by opening a PR.
+reviewers:
+  area/api:
+  - antoninbas
+  - jianjuns
+  area/component/octant:
+  - mengdie-song
+  area/flow-visibility*:
+  - dreamtalen
+  - zyiou
+  area/grouping:
+  - Dyanngg
+  area/ipam:
+  - annakhm
+  - gran-vmv
+  - ksamoray
+  area/multi-cluster:
+  - luolanzone
+  area/network-policy*:
+  - Dyanngg
+  - GraysonWu
+  - qiyueyao
+  area/network-policy/api:
+  - antoninbas
+  - Dyanngg
+  - GraysonWu
+  - jianjuns
+  area/octant:
+  - mengdie-song
+  area/ops/traceflow:
+  - gran-vmv
+  area/OS/windows:
+  - lzhecheng
+  area/ovs*:
+  - antoninbas
+  - GraysonWu
+  area/proxy*:
+  - hongliangl
+  area/proxy/nodeport:
+  - chauhanshubham
+  - monotosh-avi
+  area/transit/encryption:
+  - luolanzone
+  - xliuxu
+  area/test/*:
+  - lzhecheng
+  area/transit/ipv6:
+  - wenyingd
+  - lzhecheng
+
+# Any approver is also a reviewer.
+# Maintainers can promote reviewers to approvers.
+# If an area has reviewers but no approvers, approver list will default to maintainers.
+approvers:
+  area/api:
+  - tnqn
+  area/arch/arm:
+  - antoninbas
+  area/build-release:
+  - antoninbas
+  area/component/antctl:
+  - antoninbas
+  - jianjuns
+  - tnqn
+  area/component/cni:
+  - tnqn
+  area/flow-visibility*:
+  - antoninbas
+  - srikartati
+  area/grouping:
+  - abhiraut
+  - tnqn
+  area/ipam:
+  - jianjuns
+  area/multi-cluster:
+  - abhiraut
+  area/network-policy*:
+  - abhiraut
+  - tnqn
+  area/network-policy/api:
+  - abhiraut
+  - tnqn
+  area/ops/traceflow:
+  - antoninbas
+  - jianjuns
+  area/OS/windows:
+  - wenyingd
+  - tnqn
+  area/ovs*:
+  - jianjuns
+  - tnqn
+  - wenyingd
+  area/proxy*:
+  - tnqn
+  area/proxy/nodeport:
+  - antoninbas
+  area/test/*:
+  - antoninbas
+  area/test/infra:
+  - antoninbas
+  - edwardbadboy
+  area/test/jenkins:
+  - antoninbas
+  - edwardbadboy
+  - lzhecheng

--- a/.github/workflows/reviews.yml
+++ b/.github/workflows/reviews.yml
@@ -1,0 +1,37 @@
+name: Test
+on:
+  # The pull_request_target workflow trigger presents a security risk when
+  # combined with an explicit checkout of an untrusted PR. This is not the case
+  # here: actions/checkout will checkout the code in the PR base branch.
+  pull_request_target:
+    branches:
+    - main
+    types: ["opened", "synchronize", "reopened", "labeled", "unlabeled", "ready_for_review", "review_request_removed"]
+  pull_request_review:
+    branches:
+    - main
+
+permissions:
+  pull-requests: write
+
+jobs:
+  test:
+    runs-on: [ubuntu-latest]
+    steps:
+    - name: Check-out code
+      uses: actions/checkout@v2
+    - uses: antrea-io/review-manager@v0.3.0
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        area_ownership_file: '.github/AREA-OWNERS'
+        min_approving_reviews_total: 2
+        min_approving_reviews_per_area: 1
+        fail_if_cannot_be_merged: false # temporary for initial testing
+        label_on_success: 'can-be-merged'
+        require_area_label: false
+        succeed_if_maintainer_approves: false
+        maintainers_are_universal_approvers: true
+        ignore_if_not_labelled_with: 'review-manager-test' # temporary for initial testing
+        require_enough_available_approvers_for_area: false
+        support_label_regex: true
+        request_reviews_from_maintainers_if_needed: true


### PR DESCRIPTION
Reviews will be automatically requested based on the area label(s) added
to the PR. Based on the set of approving reviews, the Github action will
then determine whether the PR can be merged.

For the sake of initial testing, the action will only run on PRs
labelled with 'review-manager-test'.

One potential concern is rate-limiting of Github API operations (1,000
requests per hour per repository). We will see if this becomes an issue
and we can adjust @antrea-io/review-manager accordingly if needed.

See #2752

Signed-off-by: Antonin Bas <abas@vmware.com>