### PR TITLE
[CI][doc] Update Jenkins trigger phrase

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,7 +166,8 @@ Here are the trigger phrases for individual checks:
 
 Here are the trigger phrases for groups of checks:
 
-* `/test-all`: Linux IPv4 and Windows tests
+* `/test-all`: Linux IPv4 tests
+* `/test-windows-all`: Windows IPv4 tests
 * `/test-ipv6-all`: Linux dual stack tests
 * `/test-ipv6-only-all`: Linux IPv6 only tests
 


### PR DESCRIPTION
Use test-windows-all for whole Windows tests, instead of part of
test-all.

Signed-off-by: lzhecheng <lzhecheng@vmware.com>