### PR TITLE
Correct Prepare-antreaagent.ps1 Script Path in Docs

### DIFF
--- a/docs/windows.md
+++ b/docs/windows.md
@@ -297,7 +297,7 @@ Insert following line in kubelet service script `c:\k\StartKubelet.ps1` to invok
 `Prepare-AntreaAgent.ps1` when starting kubelet service:
 
 ```powershell
-& C:\k\Prepare-AntreaAgent.ps1
+& C:\k\antrea\Prepare-AntreaAgent.ps1
 ```
 
 * Example2: Create a ScheduledJob that runs at startup.


### PR DESCRIPTION
This corrects an incorrect path in the windows docs that points the prepare script to the wrong folder

Fixes: #2827