### PR TITLE
Fix template inconsistency of Flow Aggregator

### DIFF
--- a/pkg/flowaggregator/flowaggregator.go
+++ b/pkg/flowaggregator/flowaggregator.go
@@ -487,20 +487,22 @@ func (fa *flowAggregator) sendTemplateSet(isIPv6 bool) (int, error) {
 		ie := ipfixentities.NewInfoElementWithValue(element, nil)
 		elements = append(elements, ie)
 	}
-	for _, ie := range antreaSourceStatsElementList {
-		element, err := fa.registry.GetInfoElement(ie, ipfixregistry.AntreaEnterpriseID)
+	for i := range antreaSourceStatsElementList {
+		// Add Antrea source stats fields
+		ieName := antreaSourceStatsElementList[i]
+		element, err := fa.registry.GetInfoElement(ieName, ipfixregistry.AntreaEnterpriseID)
 		if err != nil {
-			return 0, fmt.Errorf("%s not present. returned error: %v", ie, err)
+			return 0, fmt.Errorf("%s not present. returned error: %v", ieName, err)
 		}
 		ie := ipfixentities.NewInfoElementWithValue(element, nil)
 		elements = append(elements, ie)
-	}
-	for _, ie := range antreaDestinationStatsElementList {
-		element, err := fa.registry.GetInfoElement(ie, ipfixregistry.AntreaEnterpriseID)
+		// Add Antrea destination stats fields
+		ieName = antreaDestinationStatsElementList[i]
+		element, err = fa.registry.GetInfoElement(ieName, ipfixregistry.AntreaEnterpriseID)
 		if err != nil {
-			return 0, fmt.Errorf("%s not present. returned error: %v", ie, err)
+			return 0, fmt.Errorf("%s not present. returned error: %v", ieName, err)
 		}
-		ie := ipfixentities.NewInfoElementWithValue(element, nil)
+		ie = ipfixentities.NewInfoElementWithValue(element, nil)
 		elements = append(elements, ie)
 	}
 	for _, ie := range antreaLabelsElementList {

--- a/pkg/flowaggregator/flowaggregator_test.go
+++ b/pkg/flowaggregator/flowaggregator_test.go
@@ -194,13 +194,13 @@ func TestFlowAggregator_sendTemplateSet(t *testing.T) {
 			elemList = append(elemList, ipfixentities.NewInfoElementWithValue(ipfixentities.NewInfoElement(ie, 0, 0, ipfixregistry.AntreaEnterpriseID, 0), nil))
 			mockIPFIXRegistry.EXPECT().GetInfoElement(ie, ipfixregistry.AntreaEnterpriseID).Return(elemList[i+len(ianaInfoElements)+len(ianaReverseInfoElements)].Element, nil)
 		}
-		for i, ie := range antreaSourceStatsElementList {
-			elemList = append(elemList, ipfixentities.NewInfoElementWithValue(ipfixentities.NewInfoElement(ie, 0, 0, ipfixregistry.AntreaEnterpriseID, 0), nil))
-			mockIPFIXRegistry.EXPECT().GetInfoElement(ie, ipfixregistry.AntreaEnterpriseID).Return(elemList[i+len(ianaInfoElements)+len(ianaReverseInfoElements)+len(antreaInfoElements)].Element, nil)
-		}
-		for i, ie := range antreaDestinationStatsElementList {
-			elemList = append(elemList, ipfixentities.NewInfoElementWithValue(ipfixentities.NewInfoElement(ie, 0, 0, ipfixregistry.AntreaEnterpriseID, 0), nil))
-			mockIPFIXRegistry.EXPECT().GetInfoElement(ie, ipfixregistry.AntreaEnterpriseID).Return(elemList[i+len(ianaInfoElements)+len(ianaReverseInfoElements)+len(antreaInfoElements)+len(antreaSourceStatsElementList)].Element, nil)
+		for i := range antreaSourceStatsElementList {
+			ieName := antreaSourceStatsElementList[i]
+			elemList = append(elemList, ipfixentities.NewInfoElementWithValue(ipfixentities.NewInfoElement(ieName, 0, 0, ipfixregistry.AntreaEnterpriseID, 0), nil))
+			mockIPFIXRegistry.EXPECT().GetInfoElement(ieName, ipfixregistry.AntreaEnterpriseID).Return(elemList[i*2+len(ianaInfoElements)+len(ianaReverseInfoElements)+len(antreaInfoElements)].Element, nil)
+			ieName = antreaDestinationStatsElementList[i]
+			elemList = append(elemList, ipfixentities.NewInfoElementWithValue(ipfixentities.NewInfoElement(ieName, 0, 0, ipfixregistry.AntreaEnterpriseID, 0), nil))
+			mockIPFIXRegistry.EXPECT().GetInfoElement(ieName, ipfixregistry.AntreaEnterpriseID).Return(elemList[i*2+1+len(ianaInfoElements)+len(ianaReverseInfoElements)+len(antreaInfoElements)].Element, nil)
 		}
 		for i, ie := range antreaLabelsElementList {
 			elemList = append(elemList, ipfixentities.NewInfoElementWithValue(ipfixentities.NewInfoElement(ie, 0, 0, ipfixregistry.AntreaEnterpriseID, 0), nil))


### PR DESCRIPTION
For aggregated stats field in Flow Aggregator, we are sending template with following order of information elements:
```
"octetDeltaCountFromSourceNode",
"octetTotalCountFromSourceNode",
"packetDeltaCountFromSourceNode",
"packetTotalCountFromSourceNode",
... (reverse stats from source)
"octetDeltaCountFromDestinationNode",
"octetTotalCountFromDestinationNode",
"packetDeltaCountFromDestinationNode",
"packetTotalCountFromDestinationNode",
... (reverse stats from destination)
```
While at aggregation process in go-ipfix, we add these fields in following order: https://github.com/vmware/go-ipfix/blob/main/pkg/intermediate/aggregate.go#L588-L614
```
octetDeltaCountFromSourceNode,
octetDeltaCountFromDestinationNode,
octetTotalCountFromSourceNode,    
octetTotalCountFromDestinationNode,
packetDeltaCountFromSourceNode,
packetDeltaCountFromDestinationNode,
packetTotalCountFromSourceNode,
packetTotalCountFromDestinationNode,
... (reverse stats from source)
... (reverse stats from destination)
```
This PR fixes the inconsistency of template between aggregation process and flow aggregator by changing the adding order of src and dst information elements.