### PR TITLE
Unify config name and format

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -4033,14 +4033,14 @@ data:
     # Enable the integrated Node IPAM controller within the Antrea controller.
     #  enableNodeIPAM: false
 
-    # CIDR Ranges for Pods in cluster. Value can contain a single CIDR range, or multiple ranges, separated by commas.
+    # CIDR Ranges for Pods in cluster. String array containing single CIDR range, or multiple ranges.
     # The CIDRs could be either IPv4 or IPv6. Value ignored when enableNodeIPAM is false.
-    #  clusterCIDRs:
+    #  clusterCIDRs: []
 
     # CIDR Ranges for Services in cluster. It is not necessary to specify it when there is no overlap with clusterCIDRs.
     # Value ignored when enableNodeIPAM is false.
     #  serviceCIDR:
-    #  secondaryServiceCIDR:
+    #  serviceCIDRv6:
 
     # Mask size for IPv4 Node CIDR in IPv4 or dual-stack cluster. Value ignored when enableNodeIPAM is false
     # or when IPv4 Pod CIDR is not configured. Valid range is 16 to 30.
@@ -4054,7 +4054,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-dtc759g79k
+  name: antrea-config-b72h88gb7b
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4125,7 +4125,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-dtc759g79k
+          value: antrea-config-b72h88gb7b
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4176,7 +4176,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-dtc759g79k
+          name: antrea-config-b72h88gb7b
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4457,7 +4457,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-dtc759g79k
+          name: antrea-config-b72h88gb7b
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -4033,14 +4033,14 @@ data:
     # Enable the integrated Node IPAM controller within the Antrea controller.
     #  enableNodeIPAM: false
 
-    # CIDR Ranges for Pods in cluster. Value can contain a single CIDR range, or multiple ranges, separated by commas.
+    # CIDR Ranges for Pods in cluster. String array containing single CIDR range, or multiple ranges.
     # The CIDRs could be either IPv4 or IPv6. Value ignored when enableNodeIPAM is false.
-    #  clusterCIDRs:
+    #  clusterCIDRs: []
 
     # CIDR Ranges for Services in cluster. It is not necessary to specify it when there is no overlap with clusterCIDRs.
     # Value ignored when enableNodeIPAM is false.
     #  serviceCIDR:
-    #  secondaryServiceCIDR:
+    #  serviceCIDRv6:
 
     # Mask size for IPv4 Node CIDR in IPv4 or dual-stack cluster. Value ignored when enableNodeIPAM is false
     # or when IPv4 Pod CIDR is not configured. Valid range is 16 to 30.
@@ -4054,7 +4054,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-dtc759g79k
+  name: antrea-config-b72h88gb7b
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4125,7 +4125,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-dtc759g79k
+          value: antrea-config-b72h88gb7b
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4176,7 +4176,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-dtc759g79k
+          name: antrea-config-b72h88gb7b
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4459,7 +4459,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-dtc759g79k
+          name: antrea-config-b72h88gb7b
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -4033,14 +4033,14 @@ data:
     # Enable the integrated Node IPAM controller within the Antrea controller.
     #  enableNodeIPAM: false
 
-    # CIDR Ranges for Pods in cluster. Value can contain a single CIDR range, or multiple ranges, separated by commas.
+    # CIDR Ranges for Pods in cluster. String array containing single CIDR range, or multiple ranges.
     # The CIDRs could be either IPv4 or IPv6. Value ignored when enableNodeIPAM is false.
-    #  clusterCIDRs:
+    #  clusterCIDRs: []
 
     # CIDR Ranges for Services in cluster. It is not necessary to specify it when there is no overlap with clusterCIDRs.
     # Value ignored when enableNodeIPAM is false.
     #  serviceCIDR:
-    #  secondaryServiceCIDR:
+    #  serviceCIDRv6:
 
     # Mask size for IPv4 Node CIDR in IPv4 or dual-stack cluster. Value ignored when enableNodeIPAM is false
     # or when IPv4 Pod CIDR is not configured. Valid range is 16 to 30.
@@ -4054,7 +4054,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-65f7gf8456
+  name: antrea-config-hfkckg6t57
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4125,7 +4125,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-65f7gf8456
+          value: antrea-config-hfkckg6t57
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4176,7 +4176,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-65f7gf8456
+          name: antrea-config-hfkckg6t57
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4460,7 +4460,7 @@ spec:
           path: /home/kubernetes/bin
         name: host-cni-bin
       - configMap:
-          name: antrea-config-65f7gf8456
+          name: antrea-config-hfkckg6t57
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -4038,14 +4038,14 @@ data:
     # Enable the integrated Node IPAM controller within the Antrea controller.
     #  enableNodeIPAM: false
 
-    # CIDR Ranges for Pods in cluster. Value can contain a single CIDR range, or multiple ranges, separated by commas.
+    # CIDR Ranges for Pods in cluster. String array containing single CIDR range, or multiple ranges.
     # The CIDRs could be either IPv4 or IPv6. Value ignored when enableNodeIPAM is false.
-    #  clusterCIDRs:
+    #  clusterCIDRs: []
 
     # CIDR Ranges for Services in cluster. It is not necessary to specify it when there is no overlap with clusterCIDRs.
     # Value ignored when enableNodeIPAM is false.
     #  serviceCIDR:
-    #  secondaryServiceCIDR:
+    #  serviceCIDRv6:
 
     # Mask size for IPv4 Node CIDR in IPv4 or dual-stack cluster. Value ignored when enableNodeIPAM is false
     # or when IPv4 Pod CIDR is not configured. Valid range is 16 to 30.
@@ -4059,7 +4059,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-fcd8c2h5b5
+  name: antrea-config-4f28b82tdt
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4139,7 +4139,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-fcd8c2h5b5
+          value: antrea-config-4f28b82tdt
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4190,7 +4190,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-fcd8c2h5b5
+          name: antrea-config-4f28b82tdt
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4506,7 +4506,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-fcd8c2h5b5
+          name: antrea-config-4f28b82tdt
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -4038,14 +4038,14 @@ data:
     # Enable the integrated Node IPAM controller within the Antrea controller.
     #  enableNodeIPAM: false
 
-    # CIDR Ranges for Pods in cluster. Value can contain a single CIDR range, or multiple ranges, separated by commas.
+    # CIDR Ranges for Pods in cluster. String array containing single CIDR range, or multiple ranges.
     # The CIDRs could be either IPv4 or IPv6. Value ignored when enableNodeIPAM is false.
-    #  clusterCIDRs:
+    #  clusterCIDRs: []
 
     # CIDR Ranges for Services in cluster. It is not necessary to specify it when there is no overlap with clusterCIDRs.
     # Value ignored when enableNodeIPAM is false.
     #  serviceCIDR:
-    #  secondaryServiceCIDR:
+    #  serviceCIDRv6:
 
     # Mask size for IPv4 Node CIDR in IPv4 or dual-stack cluster. Value ignored when enableNodeIPAM is false
     # or when IPv4 Pod CIDR is not configured. Valid range is 16 to 30.
@@ -4059,7 +4059,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-dhb74b822t
+  name: antrea-config-bmthb2m52d
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4130,7 +4130,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-dhb74b822t
+          value: antrea-config-bmthb2m52d
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4181,7 +4181,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-dhb74b822t
+          name: antrea-config-bmthb2m52d
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4462,7 +4462,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-dhb74b822t
+          name: antrea-config-bmthb2m52d
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/base/conf/antrea-controller.conf
+++ b/build/yamls/base/conf/antrea-controller.conf
@@ -61,14 +61,14 @@ nodeIPAM:
 # Enable the integrated Node IPAM controller within the Antrea controller.
 #  enableNodeIPAM: false
 
-# CIDR Ranges for Pods in cluster. Value can contain a single CIDR range, or multiple ranges, separated by commas.
+# CIDR Ranges for Pods in cluster. String array containing single CIDR range, or multiple ranges.
 # The CIDRs could be either IPv4 or IPv6. Value ignored when enableNodeIPAM is false.
-#  clusterCIDRs:
+#  clusterCIDRs: []
 
 # CIDR Ranges for Services in cluster. It is not necessary to specify it when there is no overlap with clusterCIDRs.
 # Value ignored when enableNodeIPAM is false.
 #  serviceCIDR:
-#  secondaryServiceCIDR:
+#  serviceCIDRv6:
 
 # Mask size for IPv4 Node CIDR in IPv4 or dual-stack cluster. Value ignored when enableNodeIPAM is false
 # or when IPv4 Pod CIDR is not configured. Valid range is 16 to 30.

--- a/cmd/antrea-controller/config.go
+++ b/cmd/antrea-controller/config.go
@@ -24,11 +24,11 @@ type NodeIPAMConfig struct {
 	EnableNodeIPAM bool `yaml:"enableNodeIPAM,omitempty"`
 	// CIDR Ranges for Pods in cluster. Value can contain a single CIDR range, or multiple ranges, separated by commas.
 	// The CIDRs could be either IPv4 or IPv6. Value ignored when EnableNodeIPAM is false.
-	ClusterCIDRs string `yaml:"clusterCIDRs,omitempty"`
+	ClusterCIDRs []string `yaml:"clusterCIDRs,omitempty"`
 	// CIDR Ranges for Services in cluster. It is not necessary to specify it when there is no overlap with clusterCIDRs.
 	// Value ignored when EnableNodeIPAM is false.
-	ServiceCIDR          string `yaml:"serviceCIDR,omitempty"`
-	SecondaryServiceCIDR string `yaml:"secondaryServiceCIDR,omitempty"`
+	ServiceCIDR   string `yaml:"serviceCIDR,omitempty"`
+	ServiceCIDRv6 string `yaml:"serviceCIDRv6,omitempty"`
 	// Mask size for IPv4 Node CIDR in IPv4 or dual-stack cluster. Value ignored when EnableNodeIPAM is false
 	// or when IPv4 Pod CIDR is not configured.
 	NodeCIDRMaskSizeIPv4 int `yaml:"nodeCIDRMaskSizeIPv4,omitempty"`

--- a/cmd/antrea-controller/options.go
+++ b/cmd/antrea-controller/options.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
-	"strings"
 
 	"github.com/spf13/pflag"
 	"gopkg.in/yaml.v2"
@@ -88,10 +87,9 @@ func (o *Options) validate(args []string) error {
 
 func (o *Options) validateNodeIPAMControllerOptions() error {
 	// Validate ClusterCIDRs
-	cidrSplit := strings.Split(strings.TrimSpace(o.config.NodeIPAM.ClusterCIDRs), ",")
-	cidrs, err := netutils.ParseCIDRs(cidrSplit)
+	cidrs, err := netutils.ParseCIDRs(o.config.NodeIPAM.ClusterCIDRs)
 	if err != nil {
-		return fmt.Errorf("cluster CIDRs %s is invalid", o.config.NodeIPAM.ClusterCIDRs)
+		return fmt.Errorf("cluster CIDRs %v is invalid", o.config.NodeIPAM.ClusterCIDRs)
 	}
 
 	hasIP4, hasIP6 := false, false
@@ -116,17 +114,17 @@ func (o *Options) validateNodeIPAMControllerOptions() error {
 		}
 	}
 
-	// Validate ServiceCIDR and SecondaryServiceCIDR. Service CIDRs can be empty when there is no overlap with ClusterCIDR
+	// Validate ServiceCIDR and ServiceCIDRv6. Service CIDRs can be empty when there is no overlap with ClusterCIDR
 	if o.config.NodeIPAM.ServiceCIDR != "" {
 		_, _, err = net.ParseCIDR(o.config.NodeIPAM.ServiceCIDR)
 		if err != nil {
 			return fmt.Errorf("service CIDR %s is invalid", o.config.NodeIPAM.ServiceCIDR)
 		}
 	}
-	if o.config.NodeIPAM.SecondaryServiceCIDR != "" {
-		_, _, err = net.ParseCIDR(o.config.NodeIPAM.SecondaryServiceCIDR)
+	if o.config.NodeIPAM.ServiceCIDRv6 != "" {
+		_, _, err = net.ParseCIDR(o.config.NodeIPAM.ServiceCIDRv6)
 		if err != nil {
-			return fmt.Errorf("secondary service CIDR %s is invalid", o.config.NodeIPAM.SecondaryServiceCIDR)
+			return fmt.Errorf("secondary service CIDR %s is invalid", o.config.NodeIPAM.ServiceCIDRv6)
 		}
 	}
 	return nil


### PR DESCRIPTION
Use same naming and format convention for for NodeIPAM as it is for
other Antrea features.

Fixes: #2839