### PR TITLE
Use Node TransportIP interface to send EgressIP gratuitous arp

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -262,17 +262,17 @@ func run(o *Options) error {
 	}
 
 	var egressController *egress.EgressController
-	var nodeIP net.IP
-	if nodeConfig.NodeIPv4Addr != nil {
-		nodeIP = nodeConfig.NodeIPv4Addr.IP
-	} else if nodeConfig.NodeIPv6Addr != nil {
-		nodeIP = nodeConfig.NodeIPv6Addr.IP
+	var nodeTransportIP net.IP
+	if nodeConfig.NodeTransportIPv4Addr != nil {
+		nodeTransportIP = nodeConfig.NodeTransportIPv4Addr.IP
+	} else if nodeConfig.NodeTransportIPv6Addr != nil {
+		nodeTransportIP = nodeConfig.NodeTransportIPv6Addr.IP
 	} else {
-		return fmt.Errorf("invalid NodeIPAddr in Node config: %v", nodeConfig)
+		return fmt.Errorf("invalid Node Transport IPAddr in Node config: %v", nodeConfig)
 	}
 	if features.DefaultFeatureGate.Enabled(features.Egress) {
 		egressController, err = egress.NewEgressController(
-			ofClient, antreaClientProvider, crdClient, ifaceStore, routeClient, nodeConfig.Name, nodeIP,
+			ofClient, antreaClientProvider, crdClient, ifaceStore, routeClient, nodeConfig.Name, nodeTransportIP,
 			o.config.ClusterMembershipPort, egressInformer, nodeInformer, externalIPPoolInformer,
 		)
 		if err != nil {

--- a/pkg/agent/controller/egress/egress_controller.go
+++ b/pkg/agent/controller/egress/egress_controller.go
@@ -151,7 +151,7 @@ func NewEgressController(
 	ifaceStore interfacestore.InterfaceStore,
 	routeClient route.Interface,
 	nodeName string,
-	nodeIP net.IP,
+	nodeTransportIP net.IP,
 	clusterPort int,
 	egressInformer crdinformers.EgressInformer,
 	nodeInformer coreinformers.NodeInformer,
@@ -176,13 +176,13 @@ func NewEgressController(
 		localIPDetector:      localIPDetector,
 		idAllocator:          newIDAllocator(minEgressMark, maxEgressMark),
 	}
-	ipAssigner, err := ipassigner.NewIPAssigner(nodeIP, egressDummyDevice)
+	ipAssigner, err := ipassigner.NewIPAssigner(nodeTransportIP, egressDummyDevice)
 	if err != nil {
 		return nil, fmt.Errorf("initializing egressIP assigner failed: %v", err)
 	}
 	c.ipAssigner = ipAssigner
 
-	cluster, err := memberlist.NewCluster(clusterPort, nodeIP, nodeName, nodeInformer, externalIPPoolInformer)
+	cluster, err := memberlist.NewCluster(clusterPort, nodeName, nodeInformer, externalIPPoolInformer)
 	if err != nil {
 		return nil, fmt.Errorf("initializing memberlist cluster failed: %v", err)
 	}

--- a/pkg/agent/controller/egress/ipassigner/ip_assigner_linux.go
+++ b/pkg/agent/controller/egress/ipassigner/ip_assigner_linux.go
@@ -47,16 +47,16 @@ type ipAssigner struct {
 }
 
 // NewIPAssigner returns an *ipAssigner.
-func NewIPAssigner(nodeIPAddr net.IP, dummyDeviceName string) (*ipAssigner, error) {
-	nodeIPs := new(ip.DualStackIPs)
-	if nodeIPAddr.To4() == nil {
-		nodeIPs.IPv6 = nodeIPAddr
+func NewIPAssigner(nodeTransportIPAddr net.IP, dummyDeviceName string) (*ipAssigner, error) {
+	nodeTransportIPs := new(ip.DualStackIPs)
+	if nodeTransportIPAddr.To4() == nil {
+		nodeTransportIPs.IPv6 = nodeTransportIPAddr
 	} else {
-		nodeIPs.IPv4 = nodeIPAddr
+		nodeTransportIPs.IPv4 = nodeTransportIPAddr
 	}
-	_, _, egressInterface, err := util.GetIPNetDeviceFromIP(nodeIPs)
+	_, _, egressInterface, err := util.GetIPNetDeviceFromIP(nodeTransportIPs)
 	if err != nil {
-		return nil, fmt.Errorf("get IPNetDevice from ip %v error: %+v", nodeIPAddr, err)
+		return nil, fmt.Errorf("get IPNetDevice from ip %v error: %+v", nodeTransportIPAddr, err)
 	}
 
 	dummyDevice, err := ensureDummyDevice(dummyDeviceName)

--- a/pkg/agent/controller/egress/ipassigner/ip_assigner_windows.go
+++ b/pkg/agent/controller/egress/ipassigner/ip_assigner_windows.go
@@ -23,7 +23,7 @@ import (
 type ipAssigner struct {
 }
 
-func NewIPAssigner(nodeIPAddr net.IP, dummyDeviceName string) (*ipAssigner, error) {
+func NewIPAssigner(nodeTransportIPAddr net.IP, dummyDeviceName string) (*ipAssigner, error) {
 	return nil, nil
 }
 

--- a/pkg/agent/memberlist/cluster.go
+++ b/pkg/agent/memberlist/cluster.go
@@ -17,7 +17,6 @@ package memberlist
 import (
 	"fmt"
 	"io/ioutil"
-	"net"
 	"reflect"
 	"sync"
 	"time"
@@ -81,8 +80,6 @@ type clusterNodeEventHandler func(objName string)
 // Cluster implements ClusterInterface.
 type Cluster struct {
 	bindPort int
-	// IP addr of local Node.
-	localNodeIP net.IP
 	// Name of local Node. Node name must be unique in the cluster.
 	nodeName string
 
@@ -117,7 +114,6 @@ type Cluster struct {
 // NewCluster returns a new *Cluster.
 func NewCluster(
 	clusterBindPort int,
-	localNodeIP net.IP,
 	nodeName string,
 	nodeInformer coreinformers.NodeInformer,
 	externalIPPoolInformer crdinformers.ExternalIPPoolInformer,
@@ -126,7 +122,6 @@ func NewCluster(
 	nodeEventCh := make(chan memberlist.NodeEvent, 1024)
 	c := &Cluster{
 		bindPort:                        clusterBindPort,
-		localNodeIP:                     localNodeIP,
 		nodeName:                        nodeName,
 		consistentHashMap:               make(map[string]*consistenthash.Map),
 		nodeEventsCh:                    nodeEventCh,

--- a/pkg/agent/memberlist/cluster_test.go
+++ b/pkg/agent/memberlist/cluster_test.go
@@ -58,7 +58,7 @@ func newFakeCluster(nodeConfig *config.NodeConfig, stopCh <-chan struct{}, i int
 	crdInformerFactory := crdinformers.NewSharedInformerFactory(crdClient, 0)
 	ipPoolInformer := crdInformerFactory.Crd().V1alpha2().ExternalIPPools()
 
-	cluster, err := NewCluster(port, nodeConfig.NodeIPv4Addr.IP, nodeConfig.Name, nodeInformer, ipPoolInformer)
+	cluster, err := NewCluster(port, nodeConfig.Name, nodeInformer, ipPoolInformer)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
1. Use transportInterface as Egress external interface to send EgressIP gratuitous arp.

2. Remove unused field in Cluster struct.

Signed-off-by: Wu zhengdong <zhengdong.wu@transwarp.io>