### PR TITLE
Fix code formatting

### DIFF
--- a/third_party/ipam/controller_util_node/controller_utils.go
+++ b/third_party/ipam/controller_util_node/controller_utils.go
@@ -56,7 +56,7 @@ import (
 )
 
 // RecordNodeStatusChange records a event related to a node status change. (Common to lifecycle and ipam)
-func RecordNodeStatusChange(/*recorder record.EventRecorder,*/ node *v1.Node, newStatus string) {
+func RecordNodeStatusChange( /*recorder record.EventRecorder,*/ node *v1.Node, newStatus string) {
 	//ref := &v1.ObjectReference{
 	//	APIVersion: "v1",
 	//	Kind:       "Node",

--- a/third_party/ipam/nodeipam/ipam/cidrset/metrics.go
+++ b/third_party/ipam/nodeipam/ipam/cidrset/metrics.go
@@ -43,7 +43,7 @@ import (
 
 const (
 	metricNamespaceAntrea = "antrea"
-	nodeIpamSubsystem = "node_ipam_controller"
+	nodeIpamSubsystem     = "node_ipam_controller"
 )
 
 var (


### PR DESCRIPTION
gofmt discovers the formatting issues. They were not found by CI because
golangci-lint skips "third_party" dir by default. The original third
party code are formatted correctly.

Signed-off-by: Quan Tian <qtian@vmware.com>