### PR TITLE
add offensive terminology word check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,21 @@ jobs:
     outputs:
       has_changes: ${{ steps.check_diff.outputs.has_changes }}
 
+  check-terminology:
+    name: Check if new commit contains any offensive words
+    runs-on: [ubuntu-latest]
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - uses: antrea-io/antrea/ci/gh-actions/check-termimology@main
+      id: check_terminology
+    - name: Get the check_terminology output
+      if: ${{ steps.check_terminology.outputs.has_offensive_words == 'yes' }}
+      run: |
+        echo "The commit contains offensive words, please check https://github.com/antrea-io/antrea/blob/main/docs/inclusive-terminology.md to choose an alternative word."
+        exit 1
+
   build:
     needs: check-changes
     if: ${{ needs.check-changes.outputs.has_changes == 'yes' || github.event_name == 'push' }}

--- a/ci/gh-actions/check-terminology/Dockerfile
+++ b/ci/gh-actions/check-terminology/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:20.04
+
+LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
+LABEL description="A Docker-based Github action to determine if changes contain undesired offensive words."
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends git jq && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY check-files.sh /check-files.sh
+
+ENTRYPOINT ["/check-files.sh"]

--- a/ci/gh-actions/check-terminology/action.yml
+++ b/ci/gh-actions/check-terminology/action.yml
@@ -1,0 +1,9 @@
+# action.yml
+name: 'Offensive Words Check'
+description: 'Checks if diff includes changes have any undesired offensive words'
+outputs:
+  has_offensive_words:
+    description: 'Whether (yes/no) the diff contains any undesired offensive words'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'

--- a/ci/gh-actions/check-terminology/check-files.sh
+++ b/ci/gh-actions/check-terminology/check-files.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# skip-terminology-file-check
+set -eo pipefail
+
+cat "$GITHUB_EVENT_PATH"
+
+PR_BASE_SHA=$(jq -r '.pull_request.base.sha' "$GITHUB_EVENT_PATH")
+BEFORE=$(jq -r '.before' "$GITHUB_EVENT_PATH")
+if [[ $PR_BASE_SHA != "" && $PR_BASE_SHA != "null" ]]; then # PR events
+    SHA=$PR_BASE_SHA
+elif [[ $BEFORE != "" && $BEFORE != "null" ]]; then # push events
+    SHA=$BEFORE
+else
+    echo "This does not appear to be a PR or a push event"
+    echo "Setting 'has_offensive_words' to 'no'"
+    echo "::set-output name=has_offensive_words::no"
+    exit 0
+fi
+echo "BASE SHA: $SHA"
+
+rootpath=$(git rev-parse --show-toplevel)
+files=($(git diff "$SHA" HEAD --name-only))
+
+files_need_check=""
+for f in "${files[@]}";
+do
+  set +e
+  grep 'skip-terminology-file-check' $rootpath"/"$f
+  if [ $? -ne 0 ];then
+    files_need_check="$files_need_check $f"
+  fi
+  set -e
+done
+
+result=false
+files_need_check_arr=($files_need_check)
+for file in "${files_need_check_arr[@]}";
+do
+  set +e
+  git diff "$SHA" HEAD $file > diffcontent
+  # check new added content only
+  cat diffcontent | grep '^+' | grep -w 'kill\|whitelist\|blacklist\|blackout\|brownout\|master\|slave\|segregate\|segregation' --binary-files=without-match
+  if [ $? -eq 0 ];then
+    echo "================"
+    echo "found offensive words in $file"
+    result=true
+  fi
+  set -e
+done
+
+if $result;then
+  echo "::set-output name=has_offensive_words::yes"
+  exit 0
+fi

--- a/docs/inclusive-terminology.md
+++ b/docs/inclusive-terminology.md
@@ -1,0 +1,20 @@
+# Inclusice Terminology
+<!--- skip-terminology-file-check --->
+
+To build inclusiveness in Antrea community, please identifying and eliminating insensitive terms that don't reflect our values. 
+Below table is a word list which need your immediate action to remove them in any new codes or docs, and also provides recommended alternative words.
+
+| Word | Alternative |
+|--|--|
+|blacklist|**Recommended:** <li>denylist(n)</li><li>block(v)</li><br>**Other:**<li>banned list (n)</li>|
+|whitelist|**Recommended:**  <li>allowlist (n) </li><li>approve (v)  </li><br>**Other:** <li>safelist (n)</li><li>acceptlist (n)</li><li>approved list (n)  </li>|
+|blackout<br>brownout|**Recommended:** <li>restrict (v)</li><li>restriction (n)</li><br>**Other:** <li>outage (n)</li><li>failed (adj)</li><li>network degradation (np; alternative term for brownout in the context of networking)</li>|
+|kill|**Recommended:** <li>stop (v)</li><br>**Other:** <li>halt (v)</li>|
+|master|**Recommended:** <li>primary (n, adj)</li><li>main (n, adj)</li><br>**Other:**<li>leader (n, adj)</li><li>controller (n, adj)</li><li>control plane (n, adj; in the context of Kubernetes)</li><li>original (n, adj)</li><li>reference (n, adj)</li>|
+|slave|**Recommended:** <li>secondary (n, adj)</li><li>worker (n, adj)</li><br>**Other:** <li>replica (n, adj)</li>|
+|segregate/segregation|**Recommended:** <li>separate (v, adj)</li><li>separation (n)</li>|
+
+
+You can skip the terminology check for any file if you think the check is not applicable, you can add a comment with the key word `skip-terminology-file-check` like `// skip-terminology-file-check` or `# skip-terminology-file-check` etc.
+
+You can also refer to [Inclusive Naming Initiative](https://inclusivenaming.org/) to learn more about how to make consistent and responsible choices to remove harmful language.


### PR DESCRIPTION
1. add a github action to check offensive words.
2. add a step in build workflow to trigger terminology check.
3. add a doc with undesired offensive word list and alternatives.
4. developer can use comment like `#skip-terminology-file-check` to skip
   offensive word check.

Resolves item 2 of #2783
Signed-off-by: Lan Luo <luola@vmware.com>