### PR TITLE
Fluentd for Audit Logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -391,7 +391,7 @@ verify:
 .PHONY: toc
 toc:
 	@echo "===> Generating Table of Contents for Antrea docs <==="
-	$(CURDIR)/hack/update-toc.sh
+	GO=$(GO) $(CURDIR)/hack/update-toc.sh
 
 .PHONE: markdownlint
 markdownlint:

--- a/docs/antrea-network-policy.md
+++ b/docs/antrea-network-policy.md
@@ -29,6 +29,7 @@
 - [ClusterGroup](#clustergroup)
   - [The ClusterGroup resource](#the-clustergroup-resource)
   - [kubectl commands for ClusterGroup](#kubectl-commands-for-clustergroup)
+- [Audit logging for Antrea-native policies](#audit-logging-for-antrea-native-policies)
 - [Select Namespace by Name](#select-namespace-by-name)
   - [K8s clusters with version 1.21 and above](#k8s-clusters-with-version-121-and-above)
   - [K8s clusters with version 1.20 and below](#k8s-clusters-with-version-120-and-below)
@@ -876,6 +877,12 @@ The following kubectl commands can be used to retrieve CG resources:
     # Use short name with API Group
     kubectl get cg.crd.antrea.io
 ```
+
+## Audit logging for Antrea-native policies
+
+Logs are recorded in `/var/log/antrea/networkpolicy` when `enableLogging` is configured.
+Fluentd can be used to assist with analyzing the logs. Refer to the
+[Fluentd cookbook](cookbooks/fluentd) for documentation.
 
 ## Select Namespace by Name
 

--- a/docs/cookbooks/fluentd/README.md
+++ b/docs/cookbooks/fluentd/README.md
@@ -1,0 +1,149 @@
+# Using Antrea with Fluentd
+
+This guide will describe how to use Project Antrea with
+[Fluentd](https://github.com/fluent/fluentd-kubernetes-daemonset),
+in order for efficient audit logging.
+In this scenario, Antrea is used for the default network,
+[Elasticsearch](https://www.elastic.co/) is used for the default storage,
+and [Kibana](https://www.elastic.co/kibana/) dashboard is used for visualization.
+
+<!-- toc -->
+- [Prerequisites](#prerequisites)
+- [Practical steps](#practical-steps)
+  - [Step 1: Deploying Antrea](#step-1-deploying-antrea)
+  - [Step 2: Deploy Elasticsearch and Kibana Dashboard](#step-2-deploy-elasticsearch-and-kibana-dashboard)
+  - [Step 3: Configure Custom Fluentd Plugins](#step-3-configure-custom-fluentd-plugins)
+  - [Step 4: Deploy Fluentd DaemonSet](#step-4-deploy-fluentd-daemonset)
+  - [Step 5: Visualize with Kibana Dashboard](#step-5-visualize-with-kibana-dashboard)
+- [Email Alerting](#email-alerting)
+<!-- /toc -->
+
+## Prerequisites
+
+The only prerequisites are:
+
+* a K8s cluster (Linux Nodes) running a K8s version supported by Antrea.
+* [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+
+All the required software will be deployed using YAML manifests, and the
+corresponding container images will be downloaded from public registries.
+
+## Practical steps
+
+### Step 1: Deploying Antrea
+
+For detailed information on the Antrea requirements and instructions on how to
+deploy Antrea, please refer to
+[getting-started.md](../../getting-started.md). To deploy the latest version of
+Antrea, use:
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/antrea-io/antrea/main/build/yamls/antrea.yml
+```
+
+You may also choose a [released Antrea
+version](https://github.com/antrea-io/antrea/releases).
+
+### Step 2: Deploy Elasticsearch and Kibana Dashboard
+
+Fluentd supports multiple [output plugins](https://www.fluentd.org/plugins).
+Details will be discussed in [Step 4](#step-4-deploy-fluentd-daemonset), but
+by default, log records are collected by Fluentd DaemonSet and sent to Elasticsearch.
+A Kibana Dashboard can then be used to visualize the data. The YAML file for
+deployment is included in the `resources` directory. To deploy Elasticsearch
+and Kibana, run:
+
+```bash
+kubectl apply -f docs/cookbooks/fluentd/resources/kibana-elasticsearch.yml
+```
+
+### Step 3: Configure Custom Fluentd Plugins
+
+The architecture of Fluentd is a pipeline from input-> parser-> buffer->
+output-> formatter, many of these are plugins that could be configured to
+fit users’ different use cases.
+
+To specify custom input plugins and parsers, modify `./resources/kubernetes.conf`
+and create a ConfigMap with the following command. Later, direct Fluentd
+DaemonSet to refer to that ConfigMap. To see more variations of custom
+configuration, refer to
+[Fluentd inputs](https://docs.fluentbit.io/manual/pipeline/inputs).
+This cookbook uses the [tail](https://docs.fluentbit.io/manual/pipeline/inputs/tail)
+input plugin to monitor the audit logging files for Antrea-native policies
+on every K8s Node.
+
+```bash
+kubectl create configmap fluentd-conf --from-file=docs/cookbooks/fluentd/resources/kubernetes.conf --namespace=kube-logging
+```
+
+### Step 4: Deploy Fluentd DaemonSet
+
+Fluentd deployment includes RBAC and DaemonSet. Fluentd will collect logs
+from cluster components, so permissions need to be granted first through
+RBAC. In `fluentd.yml`, we create a ServiceAccount, and use a ClusterRole
+and a ClusterRoleBinding to grant it permissions to read, list and watch
+Pods in cluster scope.
+
+In the DaemonSet configuration, specify Elasticsearch host, port and scheme,
+as they are required by the Elasticsearch output plugin.
+In [Fluentd official documentation](https://github.com/fluent/fluentd-kubernetes-daemonset),
+output plugins are specified in `fluent.conf` depending on the chosen image.
+To change output plugins, choose a different image and specify it in `./resources/fluentd.yml`.
+When choosing image version, note that the current Elasticsearch version
+specified in `resources/kibana-elasticsearch.yml` is 7.8.0 and that the major
+Elasticsearch version must match between the 2 files.
+
+```bash
+kubectl apply -f docs/cookbooks/fluentd/resources/fluentd.yml
+```
+
+### Step 5: Visualize with Kibana Dashboard
+
+Navigate to `http://[NodeIP]: 30007` and create an index pattern with "fluentd-*".
+Go to `http://[NodeIP]: 30007/app/kibana#/discover` to see the results as below.
+
+<img src="https://downloads.antrea.io/static/10182021/audit-logging-fluentd-kibana.png" width="900" alt="Audit Logging Fluentd Kibana">
+
+## Email Alerting
+
+Kibana dashboard supports creating alerts with the logs in this
+[guide](https://www.elastic.co/guide/en/kibana/current/alerting-getting-started.html).
+This
+[documentation](https://docs.fluentd.org/how-to-guides/splunk-like-grep-and-alert-email)
+also provides a detailed guide for email alerting when using td-agent
+(the stable version of Fluentd and preconfigured).
+
+For this cookbook with custom Fluentd configuration, modify and add the following
+code to `./resources/kubernetes.conf`, then update ConfigMap in
+[Step 3: Configure Custom Fluentd Plugins](#step-3-configure-custom-fluentd-plugins).
+
+```editorconfig
+<match antrea-networkpolicy>
+  @type grepcounter
+  count_interval 3  # The time window for counting errors (in secs)
+  input_key code    # The field to apply the regular expression
+  regexp ^5\d\d$    # The regular expression to be applied
+  threshold 1       # The minimum number of erros to trigger an alert
+  add_tag_prefix error_ANPxx  # Generate tags like "error_ANPxx.antrea-networkpolicy"
+</match>
+
+<match error_5xx.antrea-networkpolicy>
+  @type copy  
+  <store>
+    @type stdout  # Print to stdout for debugging
+  </store>
+  <store>
+    @type mail
+    host smtp.gmail.com        # Change this to your SMTP server host
+    port 587                   # Normally 25/587/465 are used for submission
+    user USERNAME              # Use your username to log in
+    password PASSWORD          # Use your login password
+    enable_starttls_auto true  # Use this option to enable STARTTLS
+    from example@antrea.com    # Set the sender address
+    to alert@example.com       # Set the recipient address
+    subject 'Antrea Native Policy Error'
+    message Total ANPxx error count: %s\n\nPlease check Antrea Native Policy feature ASAP
+    message_out_keys count     # Use the "count" field to replace "%s" above
+  </store>
+</match>
+```

--- a/docs/cookbooks/fluentd/resources/fluentd.yml
+++ b/docs/cookbooks/fluentd/resources/fluentd.yml
@@ -1,0 +1,102 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fluentd
+  namespace: kube-logging
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: fluentd
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: fluentd
+roleRef:
+  kind: ClusterRole
+  name: fluentd
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: fluentd
+    namespace: kube-logging
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: fluentd
+  namespace: kube-logging
+  labels:
+    k8s-app: fluentd-logging
+    version: v1
+spec:
+  selector:
+    matchLabels:
+      k8s-app: fluentd-logging
+      version: v1
+  template:
+    metadata:
+      labels:
+        k8s-app: fluentd-logging
+        version: v1
+    spec:
+      serviceAccount: fluentd
+      serviceAccountName: fluentd
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+      containers:
+        - name: fluentd
+          image: fluent/fluentd-kubernetes-daemonset:v1.8.1-debian-elasticsearch7-1.3
+          env:
+            - name:  FLUENT_ELASTICSEARCH_HOST
+              value: "elasticsearch.kube-logging.svc.cluster.local"
+            - name:  FLUENT_ELASTICSEARCH_PORT
+              value: "9200"
+            - name: FLUENT_ELASTICSEARCH_SCHEME
+              value: "http"
+            - name: FLUENT_ELASTICSEARCH_LOGSTASH_INDEX_NAME
+              value: "fluentd"
+            - name: FLUENT_ELASTICSEARCH_LOGSTASH_PREFIX
+              value: "fluentd"
+            - name: FLUENT_ELASTICSEARCH_SSL_VERIFY
+              value: "false"
+            - name: FLUENTD_SYSTEMD_CONF
+              value: disable
+          resources:
+            limits:
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 200Mi
+          volumeMounts:
+            - name: config-volume
+              mountPath: /fluentd/etc/kubernetes.conf
+              subPath: kubernetes.conf
+            - name: varlog
+              mountPath: /var/log
+            - name: dockercontainerlogdirectory
+              mountPath: /var/log/pods
+              readOnly: true
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: config-volume
+          configMap:
+            name: fluentd-conf
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: dockercontainerlogdirectory
+          hostPath:
+            path: /var/log/pods

--- a/docs/cookbooks/fluentd/resources/kibana-elasticsearch.yml
+++ b/docs/cookbooks/fluentd/resources/kibana-elasticsearch.yml
@@ -1,0 +1,193 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kube-logging
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: elastic-storage
+  namespace: kube-logging
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: Immediate
+reclaimPolicy: Delete
+allowVolumeExpansion: True
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: elasticsearch-pvc
+  namespace: kube-logging
+spec:
+  storageClassName: elastic-storage
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: elasticsearch-pv
+  namespace: kube-logging
+spec:
+  storageClassName: elastic-storage
+  capacity:
+    storage: 2Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: "/data/elasticsearch/"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: elasticsearch
+  namespace: kube-logging
+  labels:
+    app: elasticsearch
+spec:
+  selector:
+    app: elasticsearch
+  ports:
+    - port: 9200
+      targetPort: 9200
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: elasticsearch
+  namespace: kube-logging
+  labels:
+    app: elasticsearch
+spec:
+  selector:
+    matchLabels:
+      app: elasticsearch
+  serviceName: elasticsearch
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: elasticsearch
+    spec:
+      initContainers:
+        - name: init-sysctl
+          image: busybox:1.27.2
+          command:
+            - sysctl
+            - -w
+            - vm.max_map_count=262144
+          securityContext:
+            privileged: true
+      containers:
+        - name: es-data
+          image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.8.0
+          env:
+            - name: ES_JAVA_OPTS
+              value: "-Xms512m -Xmx1g"
+            - name: cluster.name
+              value: "kube-logging"
+            - name: bootstrap.memory_lock
+              value: "false"
+            - name: network.host
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: http.port
+              value: "9200"
+            - name: discovery.type
+              value: "single-node"
+            - name: indices.query.bool.max_clause_count
+              value: "8192"
+            - name: search.max_buckets
+              value: "100000"
+            - name: action.destructive_requires_name
+              value: "true"
+          ports:
+            - containerPort: 9200
+              name: http
+            - containerPort: 9300
+              name: transport
+          livenessProbe:
+            tcpSocket:
+              port: transport
+            initialDelaySeconds: 90
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /_cluster/health
+              port: http
+            initialDelaySeconds: 90
+            timeoutSeconds: 20
+          volumeMounts:
+            - name: es-data
+              mountPath: /data
+      nodeSelector:
+        kubernetes.io/os: linux
+        kubernetes.io/arch: amd64
+      volumes:
+        - name: es-data
+          persistentVolumeClaim:
+            claimName: elasticsearch-pvc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kibana
+  namespace: kube-logging
+  labels:
+    app: kibana
+spec:
+  type: NodePort
+  selector:
+    app: kibana
+  ports:
+    - port: 5601
+      targetPort: 5601
+      nodePort: 30007
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kibana
+  namespace: kube-logging
+  labels:
+    app: kibana
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kibana
+  template:
+    metadata:
+      labels:
+        app: kibana
+    spec:
+      containers:
+        - name: kibana
+          image: docker.elastic.co/kibana/kibana-oss:7.8.0
+          env:
+            - name: action.destructive_requires_name
+              value: "true"
+            - name: SERVER_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: SERVER_PORT
+              value: "5601"
+            - name: ELASTICSEARCH_URL
+              value: "http://elasticsearch:9200"
+            - name: KIBANA_DEFAULTAPPID
+              value: "dashboard/3b331b30-b987-11ea-b16e-fb06687c3589"
+            - name: LOGGING_QUIET
+              value: "true"
+            - name: KIBANA_AUTOCOMPLETETERMINATEAFTER
+              value: "100000"
+          ports:
+            - containerPort: 5601
+              name: http
+      nodeSelector:
+        kubernetes.io/os: linux
+        kubernetes.io/arch: amd64

--- a/docs/cookbooks/fluentd/resources/kubernetes.conf
+++ b/docs/cookbooks/fluentd/resources/kubernetes.conf
@@ -1,0 +1,24 @@
+<match fluent.**>
+  @type null
+</match>
+
+<source>
+  @type tail
+  @id in_tail_auditlogging
+  path /var/log/antrea/networkpolicy/*.log
+  pos_file /var/log/fluentd-anp.pos
+  tag antrea-networkpolicy
+  <parse>
+    @type regexp
+    expression /^(?<date>[^ ]*) (?<time>[^ ]*) (?<rule>[^ ]*) (?<anp>[^ ]*) (?<disposition>[^ ]*) (?<priority>[^ ]*) (?<srcIP>[^ ]*) (?<destIP>[^ ]*) (?<length>[^ ]*) (?<protocol>[^ ]*) (?:(?<duplication>\[.*\]))?$/
+    time_format %H:%M:%S.%L
+  </parse>
+</source>
+
+<filter kubernetes.**>
+  @type kubernetes_metadata
+  @id filter_kube_metadata
+  kubernetes_url "#{ENV['FLUENT_FILTER_KUBERNETES_URL'] || 'https://' + ENV.fetch('KUBERNETES_SERVICE_HOST') + ':' + ENV.fetch('KUBERNETES_SERVICE_PORT') + '/api'}"
+  verify_ssl "#{ENV['KUBERNETES_VERIFY_SSL'] || true}"
+  ca_file "#{ENV['KUBERNETES_CA_FILE']}"
+</filter>

--- a/docs/network-flow-visibility.md
+++ b/docs/network-flow-visibility.md
@@ -377,7 +377,7 @@ Antrea, the Flow Aggregator Service and the ELK Flow Collector on the
 
 If you would like to deploy elastic search with high resources, you can change
 the `ES_JAVA_OPTS` in the [ELK Flow Collector configuration](../build/yamls/elk-flow-collector/elk-flow-collector.yml)
-according to the [guide](https://www.elastic.co/guide/en/elasticsearch/reference/current/advanced-configuration.html#set-jvm-heap-size).
+according to the [guide](https://www.elastic.co/guide/en/elasticsearch/reference/7.8/heap-size.html).
 A larger heap size, like `-Xms1g -Xmx2g`, requires the Vagrant Nodes to have
 higher memory than default. In this case, we need to provision the Nodes with
 the `--large` option as with the following command:

--- a/hack/update-spelling.sh
+++ b/hack/update-spelling.sh
@@ -32,7 +32,7 @@ exitHandler() (
 trap exitHandler EXIT
 
 cd "${TMP_DIR}"
-GO111MODULE=on GOBIN="${TMP_DIR}" go get "github.com/client9/misspell/cmd/misspell@${TOOL_VERSION}"
+GO111MODULE=on GOBIN="${TMP_DIR}" go install "github.com/client9/misspell/cmd/misspell@${TOOL_VERSION}"
 export PATH="${TMP_DIR}:${PATH}"
 cd "${ROOT}"
 


### PR DESCRIPTION
This is to complete this issue request [Add documentation support for Fluentd integration with Audit Logging](https://github.com/antrea-io/antrea/issues/2642)

- Added a cookbook for using Fluentd with Antrea
- Changed `go get` to `go install` in file `hack/update-toc.sh` and `hack/update-spelling.sh`
- Changed set jvm guide link to 7.8 version to avoid 404 status

After investigating with `top`, the CPU consumption percentage does not have significant change after deploying Fluentd.