### PR TITLE
Combine FlowExporter resources initialization in agent.go

### DIFF
--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
@@ -119,7 +119,6 @@ func NewNetworkPolicyController(antreaClientGetter agent.AntreaClientProvider,
 	antreaProxyEnabled bool,
 	statusManagerEnabled bool,
 	loggingEnabled bool,
-	denyConnStore *connections.DenyConnectionStore,
 	asyncRuleDeleteInterval time.Duration,
 	dnsServerOverride string) (*Controller, error) {
 	idAllocator := newIDAllocator(asyncRuleDeleteInterval, dnsInterceptRuleID)
@@ -131,7 +130,6 @@ func NewNetworkPolicyController(antreaClientGetter agent.AntreaClientProvider,
 		antreaProxyEnabled:   antreaProxyEnabled,
 		statusManagerEnabled: statusManagerEnabled,
 		loggingEnabled:       loggingEnabled,
-		denyConnStore:        denyConnStore,
 	}
 	if antreaPolicyEnabled {
 		var err error
@@ -406,6 +404,10 @@ func (c *Controller) GetRuleByFlowID(ruleFlowID uint32) *types.PolicyRule {
 func (c *Controller) GetControllerConnectionStatus() bool {
 	// When the watchers are connected, controller connection status is true. Otherwise, it is false.
 	return c.addressGroupWatcher.isConnected() && c.appliedToGroupWatcher.isConnected() && c.networkPolicyWatcher.isConnected()
+}
+
+func (c *Controller) SetDenyConnStore(denyConnStore *connections.DenyConnectionStore) {
+	c.denyConnStore = denyConnStore
 }
 
 // Run begins watching and processing Antrea AddressGroups, AppliedToGroups

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
@@ -56,7 +56,7 @@ func newTestController() (*Controller, *fake.Clientset, *mockReconciler) {
 	ch2 := make(chan string, 100)
 	groupCounters := []proxytypes.GroupCounter{proxytypes.NewGroupCounter(false, ch2)}
 	controller, _ := NewNetworkPolicyController(&antreaClientGetter{clientset}, nil, nil, "node1", ch, groupCounters, ch2,
-		true, true, true, true, nil, testAsyncDeleteInterval, "8.8.8.8:53")
+		true, true, true, true, testAsyncDeleteInterval, "8.8.8.8:53")
 	reconciler := newMockReconciler()
 	controller.reconciler = reconciler
 	controller.antreaPolicyLogger = nil

--- a/pkg/agent/flowexporter/connections/connections.go
+++ b/pkg/agent/flowexporter/connections/connections.go
@@ -45,15 +45,13 @@ type connectionStore struct {
 func NewConnectionStore(
 	ifaceStore interfacestore.InterfaceStore,
 	proxier proxy.Proxier,
-	expirePriorityQueue *priorityqueue.ExpirePriorityQueue,
-	staleConnectionTimeout time.Duration,
-) connectionStore {
+	o *flowexporter.FlowExporterOptions) connectionStore {
 	return connectionStore{
 		connections:            make(map[flowexporter.ConnectionKey]*flowexporter.Connection),
 		ifaceStore:             ifaceStore,
 		antreaProxier:          proxier,
-		expirePriorityQueue:    expirePriorityQueue,
-		staleConnectionTimeout: staleConnectionTimeout,
+		expirePriorityQueue:    priorityqueue.NewExpirePriorityQueue(o.ActiveFlowTimeout, o.IdleFlowTimeout),
+		staleConnectionTimeout: o.StaleConnectionTimeout,
 	}
 }
 

--- a/pkg/agent/flowexporter/connections/conntrack_connections.go
+++ b/pkg/agent/flowexporter/connections/conntrack_connections.go
@@ -49,22 +49,20 @@ type ConntrackConnectionStore struct {
 
 func NewConntrackConnectionStore(
 	connTrackDumper ConnTrackDumper,
-	ifaceStore interfacestore.InterfaceStore,
 	v4Enabled bool,
 	v6Enabled bool,
-	proxier proxy.Proxier,
 	npQuerier querier.AgentNetworkPolicyInfoQuerier,
-	pollInterval time.Duration,
-	expirePriorityQueue *priorityqueue.ExpirePriorityQueue,
-	staleConnectionTimeout time.Duration,
+	ifaceStore interfacestore.InterfaceStore,
+	proxier proxy.Proxier,
+	o *flowexporter.FlowExporterOptions,
 ) *ConntrackConnectionStore {
 	return &ConntrackConnectionStore{
 		connDumper:           connTrackDumper,
 		v4Enabled:            v4Enabled,
 		v6Enabled:            v6Enabled,
 		networkPolicyQuerier: npQuerier,
-		pollInterval:         pollInterval,
-		connectionStore:      NewConnectionStore(ifaceStore, proxier, expirePriorityQueue, staleConnectionTimeout),
+		pollInterval:         o.PollInterval,
+		connectionStore:      NewConnectionStore(ifaceStore, proxier, o),
 	}
 }
 
@@ -289,4 +287,8 @@ func (cs *ConntrackConnectionStore) deleteConnWithoutLock(connKey flowexporter.C
 	delete(cs.connections, connKey)
 	metrics.TotalAntreaConnectionsInConnTrackTable.Dec()
 	return nil
+}
+
+func (cs *ConntrackConnectionStore) GetPriorityQueue() *priorityqueue.ExpirePriorityQueue {
+	return cs.connectionStore.expirePriorityQueue
 }

--- a/pkg/agent/flowexporter/connections/conntrack_connections_perf_test.go
+++ b/pkg/agent/flowexporter/connections/conntrack_connections_perf_test.go
@@ -33,7 +33,6 @@ import (
 
 	"antrea.io/antrea/pkg/agent/flowexporter"
 	connectionstest "antrea.io/antrea/pkg/agent/flowexporter/connections/testing"
-	"antrea.io/antrea/pkg/agent/flowexporter/priorityqueue"
 	"antrea.io/antrea/pkg/agent/interfacestore"
 	interfacestoretest "antrea.io/antrea/pkg/agent/interfacestore/testing"
 	"antrea.io/antrea/pkg/agent/openflow"
@@ -105,9 +104,7 @@ func setupConntrackConnStore(b *testing.B) (*ConntrackConnectionStore, *connecti
 	mockProxier.EXPECT().GetServiceByIP(serviceStr).Return(servicePortName, true).AnyTimes()
 
 	npQuerier := queriertest.NewMockAgentNetworkPolicyInfoQuerier(ctrl)
-	pq := priorityqueue.NewExpirePriorityQueue(testActiveFlowTimeout, testIdleFlowTimeout)
-	return NewConntrackConnectionStore(mockConnDumper, mockIfaceStore, true, false, mockProxier,
-		npQuerier, testPollInterval, pq, testStaleConnectionTimeout), mockConnDumper
+	return NewConntrackConnectionStore(mockConnDumper, true, false, npQuerier, mockIfaceStore, nil, testFlowExporterOptions), mockConnDumper
 }
 
 func generateConns() []*flowexporter.Connection {

--- a/pkg/agent/flowexporter/connections/conntrack_connections_test.go
+++ b/pkg/agent/flowexporter/connections/conntrack_connections_test.go
@@ -32,7 +32,6 @@ import (
 
 	"antrea.io/antrea/pkg/agent/flowexporter"
 	connectionstest "antrea.io/antrea/pkg/agent/flowexporter/connections/testing"
-	"antrea.io/antrea/pkg/agent/flowexporter/priorityqueue"
 	"antrea.io/antrea/pkg/agent/interfacestore"
 	interfacestoretest "antrea.io/antrea/pkg/agent/interfacestore/testing"
 	"antrea.io/antrea/pkg/agent/metrics"
@@ -211,9 +210,7 @@ func TestConntrackConnectionStore_AddOrUpdateConn(t *testing.T) {
 	mockProxier := proxytest.NewMockProxier(ctrl)
 	mockConnDumper := connectionstest.NewMockConnTrackDumper(ctrl)
 	npQuerier := queriertest.NewMockAgentNetworkPolicyInfoQuerier(ctrl)
-	pq := priorityqueue.NewExpirePriorityQueue(testActiveFlowTimeout, testIdleFlowTimeout)
-	conntrackConnStore := NewConntrackConnectionStore(mockConnDumper, mockIfaceStore, true, false,
-		mockProxier, npQuerier, testPollInterval, pq, testStaleConnectionTimeout)
+	conntrackConnStore := NewConntrackConnectionStore(mockConnDumper, true, false, npQuerier, mockIfaceStore, mockProxier, testFlowExporterOptions)
 
 	for _, c := range tc {
 		t.Run(c.name, func(t *testing.T) {
@@ -296,7 +293,7 @@ func TestConnectionStore_DeleteConnectionByKey(t *testing.T) {
 	metrics.TotalAntreaConnectionsInConnTrackTable.Set(float64(len(testFlows)))
 	// Create connectionStore
 	mockIfaceStore := interfacestoretest.NewMockInterfaceStore(ctrl)
-	connStore := NewConntrackConnectionStore(nil, mockIfaceStore, true, false, nil, nil, testPollInterval, nil, testStaleConnectionTimeout)
+	connStore := NewConntrackConnectionStore(nil, true, false, nil, mockIfaceStore, nil, testFlowExporterOptions)
 	// Add flows to the connection store.
 	for i, flow := range testFlows {
 		connStore.connections[*testFlowKeys[i]] = flow
@@ -320,7 +317,7 @@ func TestConnectionStore_MetricSettingInPoll(t *testing.T) {
 	// Create connectionStore
 	mockIfaceStore := interfacestoretest.NewMockInterfaceStore(ctrl)
 	mockConnDumper := connectionstest.NewMockConnTrackDumper(ctrl)
-	conntrackConnStore := NewConntrackConnectionStore(mockConnDumper, mockIfaceStore, true, false, nil, nil, testPollInterval, nil, testStaleConnectionTimeout)
+	conntrackConnStore := NewConntrackConnectionStore(mockConnDumper, true, false, nil, mockIfaceStore, nil, testFlowExporterOptions)
 	// Hard-coded conntrack occupancy metrics for test
 	TotalConnections := 0
 	MaxConnections := 300000

--- a/pkg/agent/flowexporter/connections/deny_connections.go
+++ b/pkg/agent/flowexporter/connections/deny_connections.go
@@ -32,10 +32,9 @@ type DenyConnectionStore struct {
 	connectionStore
 }
 
-func NewDenyConnectionStore(ifaceStore interfacestore.InterfaceStore,
-	proxier proxy.Proxier, expirePriorityQueue *priorityqueue.ExpirePriorityQueue, staleConnectionTimeout time.Duration) *DenyConnectionStore {
+func NewDenyConnectionStore(ifaceStore interfacestore.InterfaceStore, proxier proxy.Proxier, o *flowexporter.FlowExporterOptions) *DenyConnectionStore {
 	return &DenyConnectionStore{
-		connectionStore: NewConnectionStore(ifaceStore, proxier, expirePriorityQueue, staleConnectionTimeout),
+		connectionStore: NewConnectionStore(ifaceStore, proxier, o),
 	}
 }
 
@@ -136,4 +135,8 @@ func (ds *DenyConnectionStore) deleteConnWithoutLock(connKey flowexporter.Connec
 	delete(ds.connections, connKey)
 	metrics.TotalDenyConnections.Dec()
 	return nil
+}
+
+func (ds *DenyConnectionStore) GetPriorityQueue() *priorityqueue.ExpirePriorityQueue {
+	return ds.connectionStore.expirePriorityQueue
 }

--- a/pkg/agent/flowexporter/types.go
+++ b/pkg/agent/flowexporter/types.go
@@ -87,3 +87,12 @@ type ItemToExpire struct {
 	// Index in the priority queue (heap)
 	Index int
 }
+
+type FlowExporterOptions struct {
+	FlowCollectorAddr      string
+	FlowCollectorProto     string
+	ActiveFlowTimeout      time.Duration
+	IdleFlowTimeout        time.Duration
+	StaleConnectionTimeout time.Duration
+	PollInterval           time.Duration
+}

--- a/test/integration/agent/flowexporter_test.go
+++ b/test/integration/agent/flowexporter_test.go
@@ -30,7 +30,6 @@ import (
 	"antrea.io/antrea/pkg/agent/flowexporter"
 	"antrea.io/antrea/pkg/agent/flowexporter/connections"
 	connectionstest "antrea.io/antrea/pkg/agent/flowexporter/connections/testing"
-	"antrea.io/antrea/pkg/agent/flowexporter/priorityqueue"
 	"antrea.io/antrea/pkg/agent/interfacestore"
 	interfacestoretest "antrea.io/antrea/pkg/agent/interfacestore/testing"
 	"antrea.io/antrea/pkg/agent/openflow"
@@ -114,8 +113,12 @@ func TestConnectionStoreAndFlowRecords(t *testing.T) {
 	ifStoreMock := interfacestoretest.NewMockInterfaceStore(ctrl)
 	npQuerier := queriertest.NewMockAgentNetworkPolicyInfoQuerier(ctrl)
 	// TODO: Enhance the integration test by testing service.
-	pq := priorityqueue.NewExpirePriorityQueue(testActiveFlowTimeout, testIdleFlowTimeout)
-	conntrackConnStore := connections.NewConntrackConnectionStore(connDumperMock, ifStoreMock, true, false, nil, npQuerier, testPollInterval, pq, testStaleConnectionTimeout)
+	o := &flowexporter.FlowExporterOptions{
+		ActiveFlowTimeout:      testActiveFlowTimeout,
+		IdleFlowTimeout:        testIdleFlowTimeout,
+		StaleConnectionTimeout: testStaleConnectionTimeout,
+		PollInterval:           testPollInterval}
+	conntrackConnStore := connections.NewConntrackConnectionStore(connDumperMock, true, false, npQuerier, ifStoreMock, nil, o)
 	// Expect calls for connStore.poll and other callees
 	connDumperMock.EXPECT().DumpFlows(uint16(openflow.CtZone)).Return(testConns, 0, nil)
 	connDumperMock.EXPECT().GetMaxConnections().Return(0, nil)


### PR DESCRIPTION
1. Include the initializations of priority queue and connection store into flowExporter
2. Use setter to to inject the `denyConnStore` into the `networkPolicyController`

Fixed: #2829 

Signed-off-by: heanlan <hanlan@vmware.com>