### PR TITLE
Wait for AntreaProxy to be ready before accessing Service

### DIFF
--- a/third_party/proxy/meta_proxier.go
+++ b/third_party/proxy/meta_proxier.go
@@ -67,6 +67,11 @@ func (proxier *metaProxier) SyncLoop() {
 	proxier.ipv4Proxier.SyncLoop()    // never returns
 }
 
+// SyncedOnce returns true if the proxier has synced rules at least once.
+func (proxier *metaProxier) SyncedOnce() bool {
+	return proxier.ipv4Proxier.SyncedOnce() && proxier.ipv6Proxier.SyncedOnce()
+}
+
 // OnServiceAdd is called whenever creation of new service object is observed.
 func (proxier *metaProxier) OnServiceAdd(service *v1.Service) {
 	proxier.ipv4Proxier.OnServiceAdd(service)

--- a/third_party/proxy/types.go
+++ b/third_party/proxy/types.go
@@ -56,6 +56,10 @@ type Provider interface {
 	// This is expected to run as a goroutine or as the main loop of the app.
 	// It does not return.
 	SyncLoop()
+
+	// SyncedOnce returns true if the proxier has synced rules at least once.
+	SyncedOnce() bool
+
 	Run(stopCh <-chan struct{})
 }
 


### PR DESCRIPTION
Otherwise components that rely on Service availability (e.g. agent
APIServer) would fail to initialize and crash the whole process.

Signed-off-by: Quan Tian <qtian@vmware.com>

Fixes #2857