### PR TITLE
Added windows task delay up to 30s to improve job resiliency

### DIFF
--- a/docs/windows.md
+++ b/docs/windows.md
@@ -303,7 +303,7 @@ Insert following line in kubelet service script `c:\k\StartKubelet.ps1` to invok
 * Example2: Create a ScheduledJob that runs at startup.
 
 ```powershell
-$trigger = New-JobTrigger -AtStartup
+$trigger = New-JobTrigger -AtStartup -RandomDelay 00:00:30 
 $options = New-ScheduledJobOption -RunElevated
 Register-ScheduledJob -Name PrepareAntreaAgent -Trigger $trigger  -ScriptBlock { Invoke-Expression C:\k\antrea\Prepare-AntreaAgent.ps1 } -ScheduledJobOption $options
 ```


### PR DESCRIPTION
Adds a randomdelay flag to the windows scheduled job to allow the task to run slightly after startup.  Running directly At Startup can include a failure to initialise, where this delay allows a slight leeway to run a little after. 
Fixes: #2826 

Signed-off-by: Peri Thompson <perit@vmware.com>