### PR TITLE
Use Github PAT when creating or committing to a PR in a workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -39,6 +39,7 @@ jobs:
       with:
         # Check out the pull request HEAD
         ref: ${{ github.event.pull_request.head.sha }}
+        token: ${{ secrets.ANTREA_BOT_WRITE_PAT }}
     - name: Run go mod tidy
       # the checks above (Github actor and PR labels) ensure that a malicious
       # actor cannot open a PR with a modified "tidy" Makefile target and

--- a/.github/workflows/update_changelog.yml
+++ b/.github/workflows/update_changelog.yml
@@ -49,6 +49,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:
+          token: ${{ secrets.ANTREA_BOT_WRITE_PAT }}
           delete-branch: true
           title: "Update CHANGELOG for ${{ needs.check-version.outputs.version }} release"
           body: |


### PR DESCRIPTION
Events triggered by the default GITHUB_TOKEN will not create new workflow runs,
which means that checks will not be run on the commit. The recommended
workaround is to use a Personal Access Token (PAT) with the right scope. We use
a PAT created for the antrea-bot account.

See
https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token

Signed-off-by: Antonin Bas <abas@vmware.com>