### PR TITLE
Support antctl in the flow aggregator

### DIFF
--- a/build/images/flow-aggregator/Dockerfile
+++ b/build/images/flow-aggregator/Dockerfile
@@ -5,16 +5,15 @@ WORKDIR /antrea
 
 COPY . /antrea
 
-# Make sure the flow-aggregator binary is statically linked.
-RUN CGO_ENABLED=0 make flow-aggregator
+RUN make flow-aggregator antctl-ubuntu
 
-FROM scratch
+# Chose this base image so that a shell is available for users to exec into the container, run antctl and run tools like pprof easily
+FROM ubuntu:20.04
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="The docker image for the flow aggregator"
 
-ENV USER root
-
 COPY --from=flow-aggregator-build /antrea/bin/flow-aggregator /
+COPY --from=flow-aggregator-build /antrea/bin/antctl /usr/local/bin/
 
 ENTRYPOINT ["/flow-aggregator"]

--- a/build/images/flow-aggregator/Dockerfile.coverage
+++ b/build/images/flow-aggregator/Dockerfile.coverage
@@ -5,7 +5,7 @@ WORKDIR /antrea
 
 COPY . /antrea
 
-RUN make flow-aggregator flow-aggregator-instr-binary
+RUN make flow-aggregator antctl-ubuntu flow-aggregator-instr-binary antctl-instr-binary
 
 FROM ubuntu:20.04
 
@@ -16,3 +16,4 @@ USER root
 
 COPY --from=flow-aggregator-build /antrea/bin/flow-aggregator* /usr/local/bin/
 COPY --from=flow-aggregator-build /antrea/test/e2e/coverage/flow-aggregator-arg-file /
+COPY --from=flow-aggregator-build /antrea/bin/antctl* /usr/local/bin/

--- a/build/yamls/flow-aggregator.yml
+++ b/build/yamls/flow-aggregator.yml
@@ -68,6 +68,19 @@ rules:
   - configmaps
   verbs:
   - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resourceNames:
+  - extension-apiserver-authentication
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - ""
   resourceNames:
@@ -176,6 +189,20 @@ data:
     recordContents:
       # Determine whether source and destination Pod labels will be included in the flow records.
       #podLabels: false
+
+    # apiServer contains APIServer related configuration options.
+    apiServer:
+      # The port for the flow-aggregator APIServer to serve on.
+      #apiPort: 10348
+
+      # Comma-separated list of Cipher Suites. If omitted, the default Go Cipher Suites will be used.
+      # https://golang.org/pkg/crypto/tls/#pkg-constants
+      # Note that TLS1.3 Cipher Suites cannot be added to the list. But the apiserver will always
+      # prefer TLS1.3 Cipher Suites whenever possible.
+      #tlsCipherSuites:
+
+      # TLS min version from: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.
+      #tlsMinVersion:
 kind: ConfigMap
 metadata:
   annotations: {}
@@ -231,6 +258,11 @@ spec:
         - --log_file_max_size=100
         - --log_file_max_num=4
         - --v=0
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         image: projects.registry.vmware.com/antrea/flow-aggregator:latest
         imagePullPolicy: IfNotPresent
         name: flow-aggregator

--- a/build/yamls/flow-aggregator/base/conf/flow-aggregator.conf
+++ b/build/yamls/flow-aggregator/base/conf/flow-aggregator.conf
@@ -41,3 +41,17 @@
 recordContents:
   # Determine whether source and destination Pod labels will be included in the flow records.
   #podLabels: false
+
+# apiServer contains APIServer related configuration options.
+apiServer:
+  # The port for the flow-aggregator APIServer to serve on.
+  #apiPort: 10348
+
+  # Comma-separated list of Cipher Suites. If omitted, the default Go Cipher Suites will be used.
+  # https://golang.org/pkg/crypto/tls/#pkg-constants
+  # Note that TLS1.3 Cipher Suites cannot be added to the list. But the apiserver will always
+  # prefer TLS1.3 Cipher Suites whenever possible.
+  #tlsCipherSuites:
+
+  # TLS min version from: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.
+  #tlsMinVersion:

--- a/build/yamls/flow-aggregator/base/flow-aggregator.yml
+++ b/build/yamls/flow-aggregator/base/flow-aggregator.yml
@@ -24,7 +24,17 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["configmaps"]
-    verbs: ["create"]
+    verbs: ["create", "get", "list", "watch"]
+  # This is the content of built-in role kube-system/extension-apiserver-authentication-reader.
+  # But it doesn't have list/watch permission before K8s v1.17.0 so the extension apiserver (antrea-agent) will
+  # have permission issue after bumping up apiserver library to a version that supports dynamic authentication.
+  # See https://github.com/kubernetes/kubernetes/pull/85375
+  # To support K8s clusters older than v1.17.0, we grant the required permissions directly instead of relying on
+  # the extension-apiserver-authentication role.
+  - apiGroups: [""]
+    resourceNames: ["extension-apiserver-authentication"]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["secrets"]
     resourceNames: ["flow-aggregator-client-tls"]
@@ -130,6 +140,11 @@ spec:
         - --v=0
         name: flow-aggregator
         image: flow-aggregator
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
         ports:
           - containerPort: 4739
         volumeMounts:

--- a/ci/kind/test-e2e-kind.sh
+++ b/ci/kind/test-e2e-kind.sh
@@ -129,7 +129,7 @@ COMMON_IMAGES_LIST=("gcr.io/kubernetes-e2e-test-images/agnhost:2.8" \
                     "projects.registry.vmware.com/library/busybox"  \
                     "projects.registry.vmware.com/antrea/nginx" \
                     "projects.registry.vmware.com/antrea/perftool" \
-                    "projects.registry.vmware.com/antrea/ipfix-collector:v0.5.9" \
+                    "projects.registry.vmware.com/antrea/ipfix-collector:v0.5.10" \
                     "projects.registry.vmware.com/antrea/wireguard-go:0.0.20210424")
 for image in "${COMMON_IMAGES_LIST[@]}"; do
     for i in `seq 3`; do

--- a/cmd/flow-aggregator/options.go
+++ b/cmd/flow-aggregator/options.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/pflag"
 	"gopkg.in/yaml.v2"
 
+	"antrea.io/antrea/pkg/apis"
 	flowaggregatorconfig "antrea.io/antrea/pkg/config/flowaggregator"
 	"antrea.io/antrea/pkg/flowaggregator"
 	"antrea.io/antrea/pkg/util/flowexport"
@@ -137,6 +138,9 @@ func (o *Options) validate(args []string) error {
 		o.format = o.config.RecordFormat
 	}
 	o.includePodLabels = o.config.RecordContents.PodLabels
+	if o.config.APIServer.APIPort == 0 {
+		o.config.APIServer.APIPort = apis.FlowAggregatorAPIPort
+	}
 	return nil
 }
 

--- a/docs/network-flow-visibility.md
+++ b/docs/network-flow-visibility.md
@@ -22,6 +22,7 @@
     - [Storage of Flow Records](#storage-of-flow-records)
     - [Correlation of Flow Records](#correlation-of-flow-records)
     - [Aggregation of Flow Records](#aggregation-of-flow-records)
+  - [Antctl support](#antctl-support)
 - [Quick deployment](#quick-deployment)
 - [Flow Collectors](#flow-collectors)
   - [Go-ipfix Collector](#go-ipfix-collector)
@@ -297,6 +298,20 @@ flow-aggregator.conf: |
   recordContents:
     # Determine whether source and destination Pod labels will be included in the flow records.
     #podLabels: false
+
+  # apiServer contains APIServer related configuration options.
+  apiServer:
+    # The port for the flow-aggregator APIServer to serve on.
+    #apiPort: 10348
+
+    # Comma-separated list of Cipher Suites. If omitted, the default Go Cipher Suites will be used.
+    # https://golang.org/pkg/crypto/tls/#pkg-constants
+    # Note that TLS1.3 Cipher Suites cannot be added to the list. But the apiserver will always
+    # prefer TLS1.3 Cipher Suites whenever possible.
+    #tlsCipherSuites:
+
+    # TLS min version from: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.
+    #tlsMinVersion:
 ```
 
 Please note that the default values for `flowExportInterval`, `aggregatorTransportProtocol`,
@@ -309,6 +324,10 @@ both sides or disabled for both sides. Please modify the parameters as per your 
 Please note that the default value for `podLabels` is `false`, which
 indicates source and destination Pod labels will not be included in the flow
 records. If you would like to include them, you can modify the value to true.
+
+Please note that the default value for  `apiPort` is `10348`, which is the port
+used to expose the Flow Aggregator's APIServer. Please modify the parameters as
+per your requirements.
 
 ### IPFIX Information Elements (IEs) in an Aggregated Flow Record
 
@@ -364,6 +383,12 @@ updated. For the purpose of updating flow statistics fields, Flow Aggregator int
 the [new fields](#ies-from-antrea-ie-registry) in Antrea Enterprise IPFIX registry
 corresponding to the Source Node and Destination Node, so that flow statistics from
 different Nodes can be preserved.
+
+### Antctl support
+
+antctl can access the Flow Aggregator API to dump flow records and print metrics
+about flow record processing. Refer to the
+[antctl documentation](antctl.md#flow-aggregator-commands) for more information.
 
 ## Quick deployment
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -13,6 +13,9 @@
   - [Using antctl](#using-antctl-1)
   - [Using antctl proxy](#using-antctl-proxy-1)
   - [Directly accessing the antrea-agent API](#directly-accessing-the-antrea-agent-api)
+- [Accessing the flow-aggregator API](#accessing-the-flow-aggregator-api)
+  - [Using antctl](#using-antctl-2)
+  - [Directly accessing the flow-aggregator API](#directly-accessing-the-flow-aggregator-api)
 - [Troubleshooting Open vSwitch](#troubleshooting-open-vswitch)
 - [Troubleshooting with antctl](#troubleshooting-with-antctl)
 - [Profiling Antrea components](#profiling-antrea-components)
@@ -180,6 +183,37 @@ curl --insecure --header "Authorization: Bearer $TOKEN" https://<Node IP address
 
 However, in this case you will be limited to the endpoints that `antctl` is
 allowed to access, as defined [here](/build/yamls/base/antctl.yml).
+
+## Accessing the flow-aggregator API
+
+flow-aggregator runs as a Deployment and exposes its API via a local endpoint.
+There are two ways you can access it:
+
+### Using antctl
+
+To use `antctl` to access the flow-aggregator API, you need to exec into the
+flow-aggregator container first. `antctl` is embedded in the image so it can be
+used directly.
+
+For example, you can dump the flow records with this command:
+
+```bash
+# Get into the flow-aggregator container
+kubectl exec -it <flow-aggregator Pod name> -n flow-aggregator -- bash
+# View the flow records
+antctl get flowrecords
+```
+
+### Directly accessing the flow-aggregator API
+
+If you want to directly access the flow-aggregator API, you need to exec into
+the flow-aggregator container. Then access the local endpoint directly using the
+Bearer Token stored in the file system:
+
+```bash
+TOKEN=$(cat /var/run/antrea/apiserver/loopback-client-token)
+curl --insecure --header "Authorization: Bearer $TOKEN" https://127.0.0.1:10348/
+```
 
 ## Troubleshooting Open vSwitch
 

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/ti-mo/conntrack v0.4.0
 	github.com/vishvananda/netlink v1.1.1-0.20210510164352-d17758a128bf
-	github.com/vmware/go-ipfix v0.5.9
+	github.com/vmware/go-ipfix v0.5.10
 	golang.org/x/crypto v0.0.0-20210503195802-e9a32991a82e
 	golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6
 	golang.org/x/mod v0.4.2

--- a/go.sum
+++ b/go.sum
@@ -653,8 +653,8 @@ github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc/go.mod h1:ZjcWmF
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae h1:4hwBBUfQCFe3Cym0ZtKyq7L16eZUtYKs+BaHDN6mAns=
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
-github.com/vmware/go-ipfix v0.5.9 h1:SsDzrbdZx0xg6WzpRIKo/+RL4+Cccii9sRTclhzli9A=
-github.com/vmware/go-ipfix v0.5.9/go.mod h1:yzbG1rv+yJ8GeMrRm+MDhOV3akygNZUHLhC1pDoD2AY=
+github.com/vmware/go-ipfix v0.5.10 h1:32ITLwn/IZcagB+bG0g9f8KsSk2atWG9uHHy8InIuUc=
+github.com/vmware/go-ipfix v0.5.10/go.mod h1:yzbG1rv+yJ8GeMrRm+MDhOV3akygNZUHLhC1pDoD2AY=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=

--- a/pkg/antctl/client.go
+++ b/pkg/antctl/client.go
@@ -32,6 +32,7 @@ import (
 	"antrea.io/antrea/pkg/antctl/runtime"
 	"antrea.io/antrea/pkg/apis"
 	controllerapiserver "antrea.io/antrea/pkg/apiserver"
+	flowaggregatorapiserver "antrea.io/antrea/pkg/flowaggregator/apiserver"
 )
 
 // requestOption describes options to issue requests.
@@ -85,6 +86,9 @@ func (c *client) resolveKubeconfig(opt *requestOption) (*rest.Config, error) {
 		} else if runtime.Mode == runtime.ModeController {
 			kubeconfig.Host = net.JoinHostPort("127.0.0.1", fmt.Sprint(apis.AntreaControllerAPIPort))
 			kubeconfig.BearerTokenFile = controllerapiserver.TokenPath
+		} else if runtime.Mode == runtime.ModeFlowAggregator {
+			kubeconfig.Host = net.JoinHostPort("127.0.0.1", fmt.Sprint(apis.FlowAggregatorAPIPort))
+			kubeconfig.BearerTokenFile = flowaggregatorapiserver.TokenPath
 		}
 	}
 	return kubeconfig, nil
@@ -94,6 +98,8 @@ func (c *client) request(opt *requestOption) (io.Reader, error) {
 	var e *endpoint
 	if runtime.Mode == runtime.ModeAgent {
 		e = opt.commandDefinition.agentEndpoint
+	} else if runtime.Mode == runtime.ModeFlowAggregator {
+		e = opt.commandDefinition.flowAggregatorEndpoint
 	} else {
 		e = opt.commandDefinition.controllerEndpoint
 	}

--- a/pkg/antctl/command_definition_test.go
+++ b/pkg/antctl/command_definition_test.go
@@ -355,9 +355,10 @@ func TestFormat(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			opt := &commandDefinition{
-				transformedResponse: tc.responseStruct,
-				controllerEndpoint:  &endpoint{addonTransform: tc.transform},
-				agentEndpoint:       &endpoint{addonTransform: tc.transform},
+				transformedResponse:    tc.responseStruct,
+				controllerEndpoint:     &endpoint{addonTransform: tc.transform},
+				agentEndpoint:          &endpoint{addonTransform: tc.transform},
+				flowAggregatorEndpoint: &endpoint{addonTransform: tc.transform},
 			}
 			var responseData []byte
 			responseData, err := json.Marshal(tc.rawResponseData)

--- a/pkg/antctl/command_list.go
+++ b/pkg/antctl/command_list.go
@@ -52,7 +52,8 @@ func (cl *commandList) applyToRootCommand(root *cobra.Command, client AntctlClie
 	for i := range cl.definitions {
 		def := &cl.definitions[i]
 		if (runtime.Mode == runtime.ModeAgent && def.agentEndpoint == nil) ||
-			(runtime.Mode == runtime.ModeController && def.controllerEndpoint == nil) {
+			(runtime.Mode == runtime.ModeController && def.controllerEndpoint == nil) ||
+			(runtime.Mode == runtime.ModeFlowAggregator && def.flowAggregatorEndpoint == nil) {
 			continue
 		}
 		def.applySubCommandToRoot(root, client, out)
@@ -126,9 +127,9 @@ func (cl *commandList) GetDebugCommands(mode string) [][]string {
 			// log-level command does not support remote execution.
 			continue
 		}
-
 		if mode == runtime.ModeAgent && def.agentEndpoint != nil ||
-			mode == runtime.ModeController && def.controllerEndpoint != nil {
+			mode == runtime.ModeController && def.controllerEndpoint != nil ||
+			mode == runtime.ModeFlowAggregator && def.flowAggregatorEndpoint != nil {
 			var currentCommand []string
 			if group, ok := groupCommands[def.commandGroup]; ok {
 				currentCommand = append(currentCommand, group.Use)

--- a/pkg/antctl/runtime/runtime.go
+++ b/pkg/antctl/runtime/runtime.go
@@ -23,8 +23,9 @@ import (
 )
 
 const (
-	ModeController string = "controller"
-	ModeAgent      string = "agent"
+	ModeController     string = "controller"
+	ModeAgent          string = "agent"
+	ModeFlowAggregator string = "flowaggregator"
 )
 
 var (
@@ -50,9 +51,12 @@ func ResolveKubeconfig(path string) (*rest.Config, error) {
 
 func init() {
 	podName, found := os.LookupEnv("POD_NAME")
-	InPod = found && (strings.HasPrefix(podName, "antrea-agent") || strings.HasPrefix(podName, "antrea-controller"))
+	InPod = found && (strings.HasPrefix(podName, "antrea-agent") || strings.HasPrefix(podName, "antrea-controller") ||
+		strings.HasPrefix(podName, "flow-aggregator"))
 	if strings.HasPrefix(podName, "antrea-agent") {
 		Mode = ModeAgent
+	} else if strings.HasPrefix(podName, "flow-aggregator") {
+		Mode = ModeFlowAggregator
 	} else {
 		Mode = ModeController
 	}

--- a/pkg/antctl/transform/common/transform.go
+++ b/pkg/antctl/transform/common/transform.go
@@ -52,6 +52,10 @@ func Int32ToString(val int32) string {
 	return strconv.Itoa(int(val))
 }
 
+func Int64ToString(val int64) string {
+	return strconv.Itoa(int(val))
+}
+
 func GenerateTableElementWithSummary(list []string, maxColumnLength int) string {
 	element := ""
 	sort.Strings(list)

--- a/pkg/apis/ports.go
+++ b/pkg/apis/ports.go
@@ -15,6 +15,9 @@
 package apis
 
 const (
+	// FlowAggregatorAPIPort is the default port for the flow-aggregator APIServer.
+	// The Flow Aggregator is a K8s service, and its API server is exposed through this port.
+	FlowAggregatorAPIPort = 10348
 	// AntreaControllerAPIPort is the default port for the antrea-controller APIServer.
 	AntreaControllerAPIPort = 10349
 	// AntreaAgentAPIPort is the default port for the antrea-agent APIServer.

--- a/pkg/config/flowaggregator/config.go
+++ b/pkg/config/flowaggregator/config.go
@@ -56,8 +56,20 @@ type FlowAggregatorConfig struct {
 	// recordContents enables configuring some fields in the flow records. Fields can be
 	// excluded to reduce record size.
 	RecordContents RecordContentsConfig `yaml:"recordContents,omitempty"`
+	// apiServer contains APIServer related configuration options.
+	APIServer APIServerConfig `yaml:"apiServer,omitempty"`
 }
 
 type RecordContentsConfig struct {
 	PodLabels bool `yaml:"podLabels,omitempty"`
+}
+
+type APIServerConfig struct {
+	// APIPort is the port for the antrea-agent APIServer to serve on.
+	// Defaults to 10348.
+	APIPort int `yaml:"apiPort,omitempty"`
+	// Cipher suites to use.
+	TLSCipherSuites string `yaml:"tlsCipherSuites,omitempty"`
+	// TLS min version.
+	TLSMinVersion string `yaml:"tlsMinVersion,omitempty"`
 }

--- a/pkg/flowaggregator/apiserver/apiserver.go
+++ b/pkg/flowaggregator/apiserver/apiserver.go
@@ -1,0 +1,137 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiserver
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+	"path"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	k8sversion "k8s.io/apimachinery/pkg/version"
+	genericapiserver "k8s.io/apiserver/pkg/server"
+	genericoptions "k8s.io/apiserver/pkg/server/options"
+
+	systeminstall "antrea.io/antrea/pkg/apis/system/install"
+	"antrea.io/antrea/pkg/apiserver/handlers/loglevel"
+	"antrea.io/antrea/pkg/flowaggregator/apiserver/handlers/flowrecords"
+	"antrea.io/antrea/pkg/flowaggregator/apiserver/handlers/recordmetrics"
+	"antrea.io/antrea/pkg/flowaggregator/querier"
+	antreaversion "antrea.io/antrea/pkg/version"
+)
+
+const (
+	Name = "flow-aggregator-api"
+	// authenticationTimeout specifies a time limit for requests made by the authorization webhook client
+	// The default value (10 seconds) is not long enough as defined in
+	// https://pkg.go.dev/k8s.io/apiserver@v0.21.0/pkg/server/options#NewDelegatingAuthenticationOptions
+	// A value of zero means no timeout.
+	authenticationTimeout = 0
+)
+
+var (
+	// Scheme defines methods for serializing and deserializing API objects.
+	scheme = runtime.NewScheme()
+	// Codecs provides methods for retrieving codecs and serializers for specific
+	// versions and content types.
+	codecs = serializer.NewCodecFactory(scheme)
+	// #nosec G101: false positive triggered by variable name which includes "token"
+	TokenPath = "/var/run/antrea/apiserver/loopback-client-token"
+)
+
+func init() {
+	systeminstall.Install(scheme)
+	metav1.AddToGroupVersion(scheme, schema.GroupVersion{Version: "v1"})
+}
+
+type flowAggregatorAPIServer struct {
+	GenericAPIServer *genericapiserver.GenericAPIServer
+}
+
+func (s *flowAggregatorAPIServer) Run(stopCh <-chan struct{}) error {
+	return s.GenericAPIServer.PrepareRun().Run(stopCh)
+}
+
+func installHandlers(s *genericapiserver.GenericAPIServer, faq querier.FlowAggregatorQuerier) {
+	s.Handler.NonGoRestfulMux.HandleFunc("/flowrecords", flowrecords.HandleFunc(faq))
+	s.Handler.NonGoRestfulMux.HandleFunc("/recordmetrics", recordmetrics.HandleFunc(faq))
+	s.Handler.NonGoRestfulMux.HandleFunc("/loglevel", loglevel.HandleFunc())
+}
+
+// New creates an APIServer for running in flow aggregator.
+func New(faq querier.FlowAggregatorQuerier, bindPort int, cipherSuites []uint16, tlsMinVersion uint16) (*flowAggregatorAPIServer, error) {
+	cfg, err := newConfig(bindPort)
+	if err != nil {
+		return nil, err
+	}
+	s, err := cfg.New(Name, genericapiserver.NewEmptyDelegate())
+	if err != nil {
+		return nil, err
+	}
+	s.SecureServingInfo.CipherSuites = cipherSuites
+	s.SecureServingInfo.MinTLSVersion = tlsMinVersion
+	installHandlers(s, faq)
+	return &flowAggregatorAPIServer{GenericAPIServer: s}, nil
+}
+
+func newConfig(bindPort int) (*genericapiserver.CompletedConfig, error) {
+	secureServing := genericoptions.NewSecureServingOptions().WithLoopback()
+	authentication := genericoptions.NewDelegatingAuthenticationOptions()
+	authorization := genericoptions.NewDelegatingAuthorizationOptions().WithAlwaysAllowPaths("/healthz", "/livez", "/readyz")
+
+	// Set the PairName but leave certificate directory blank to generate in-memory by default.
+	secureServing.ServerCert.CertDirectory = ""
+	secureServing.ServerCert.PairName = Name
+	secureServing.BindAddress = net.IPv4zero
+	secureServing.BindPort = bindPort
+
+	authentication.WithClientTimeout(authenticationTimeout)
+
+	if err := secureServing.MaybeDefaultWithSelfSignedCerts("localhost", nil, []net.IP{net.ParseIP("127.0.0.1"), net.IPv6loopback}); err != nil {
+		return nil, fmt.Errorf("error creating self-signed certificates: %v", err)
+	}
+	serverConfig := genericapiserver.NewConfig(codecs)
+	if err := secureServing.ApplyTo(&serverConfig.SecureServing, &serverConfig.LoopbackClientConfig); err != nil {
+		return nil, err
+	}
+	if err := authentication.ApplyTo(&serverConfig.Authentication, serverConfig.SecureServing, nil); err != nil {
+		return nil, err
+	}
+	if err := authorization.ApplyTo(&serverConfig.Authorization); err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(path.Dir(TokenPath), os.ModeDir); err != nil {
+		return nil, fmt.Errorf("error when creating dirs of token file: %v", err)
+	}
+	if err := ioutil.WriteFile(TokenPath, []byte(serverConfig.LoopbackClientConfig.BearerToken), 0600); err != nil {
+		return nil, fmt.Errorf("error when writing loopback access token to file: %v", err)
+	}
+	v := antreaversion.GetVersion()
+	serverConfig.Version = &k8sversion.Info{
+		Major:        fmt.Sprint(v.Major),
+		Minor:        fmt.Sprint(v.Minor),
+		GitVersion:   v.String(),
+		GitTreeState: antreaversion.GitTreeState,
+		GitCommit:    antreaversion.GetGitSHA(),
+	}
+
+	completedServerCfg := serverConfig.Complete(nil)
+	return &completedServerCfg, nil
+}

--- a/pkg/flowaggregator/apiserver/handlers/flowrecords/handler.go
+++ b/pkg/flowaggregator/apiserver/handlers/flowrecords/handler.go
@@ -1,0 +1,113 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flowrecords
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	ipfixintermediate "github.com/vmware/go-ipfix/pkg/intermediate"
+
+	"antrea.io/antrea/pkg/flowaggregator/querier"
+)
+
+// Response is the response struct of flowrecords command.
+type Response map[string]interface{}
+
+// HandleFunc returns the function which can handle the /flowrecords API request.
+func HandleFunc(faq querier.FlowAggregatorQuerier) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var resps []Response
+		sourceAddress := r.URL.Query().Get("srcip")
+		destinationAddress := r.URL.Query().Get("dstip")
+		protocol := r.URL.Query().Get("proto")
+		sourcePort := r.URL.Query().Get("srcport")
+		destinationPort := r.URL.Query().Get("dstport")
+		var flowKey *ipfixintermediate.FlowKey
+		if sourceAddress == "" && destinationAddress == "" && protocol == "" && sourcePort == "" && destinationPort == "" {
+			flowKey = nil
+		} else {
+			var protocolNum, srcPortNum, dstPortNum uint64
+			var err error
+			if protocol != "" {
+				if protocolNum, err = strconv.ParseUint(protocol, 10, 8); err != nil {
+					http.Error(w, "Error when parsing protocol: "+err.Error(), http.StatusNotFound)
+					return
+				}
+			}
+			if sourcePort != "" {
+				if srcPortNum, err = strconv.ParseUint(sourcePort, 10, 16); err != nil {
+					http.Error(w, "Error when parsing source port: "+err.Error(), http.StatusNotFound)
+					return
+				}
+			}
+			if destinationPort != "" {
+				if dstPortNum, err = strconv.ParseUint(destinationPort, 10, 16); err != nil {
+					http.Error(w, "Error when parsing destination port: "+err.Error(), http.StatusNotFound)
+					return
+				}
+			}
+
+			flowKey = &ipfixintermediate.FlowKey{
+				SourceAddress:      sourceAddress,
+				DestinationAddress: destinationAddress,
+				Protocol:           uint8(protocolNum),
+				SourcePort:         uint16(srcPortNum),
+				DestinationPort:    uint16(dstPortNum),
+			}
+		}
+		records := faq.GetFlowRecords(flowKey)
+		for _, record := range records {
+			resps = append(resps, record)
+		}
+		err := json.NewEncoder(w).Encode(resps)
+		if err != nil {
+			http.Error(w, "Failed to encode response: "+err.Error(), http.StatusInternalServerError)
+		}
+	}
+}
+
+func (r Response) GetTableHeader() []string {
+	return []string{"SRC_IP", "DST_IP", "SPORT", "DPORT", "PROTO", "SRC_POD", "DST_POD", "SRC_NS", "DST_NS", "SERVICE"}
+}
+
+func (r Response) GetTableRow(maxColumnLength int) []string {
+	var sourceAddress, destinationAddress interface{}
+	if r["sourceIPv4Address"] != nil {
+		sourceAddress = r["sourceIPv4Address"]
+		destinationAddress = r["destinationIPv4Address"]
+	} else {
+		sourceAddress = r["sourceIPv6Address"]
+		destinationAddress = r["destinationIPv6Address"]
+	}
+	return []string{
+		fmt.Sprintf("%v", sourceAddress),
+		fmt.Sprintf("%v", destinationAddress),
+		fmt.Sprintf("%v", r["sourceTransportPort"]),
+		fmt.Sprintf("%v", r["destinationTransportPort"]),
+		fmt.Sprintf("%v", r["protocolIdentifier"]),
+		fmt.Sprintf("%v", r["sourcePodName"]),
+		fmt.Sprintf("%v", r["destinationPodName"]),
+		fmt.Sprintf("%v", r["sourcePodNamespace"]),
+		fmt.Sprintf("%v", r["destinationPodNamespace"]),
+		fmt.Sprintf("%v", r["destinationServicePortName"]),
+	}
+}
+
+func (r Response) SortRows() bool {
+	return false
+}

--- a/pkg/flowaggregator/apiserver/handlers/recordmetrics/handler.go
+++ b/pkg/flowaggregator/apiserver/handlers/recordmetrics/handler.go
@@ -1,0 +1,68 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package recordmetrics
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"k8s.io/klog/v2"
+
+	"antrea.io/antrea/pkg/antctl/transform/common"
+	"antrea.io/antrea/pkg/flowaggregator/querier"
+)
+
+// Response is the response struct of recordmetrics command.
+type Response struct {
+	NumRecordsExported int64 `json:"numRecordsExported,omitempty"`
+	NumRecordsReceived int64 `json:"numRecordsReceived,omitempty"`
+	NumFlows           int64 `json:"numFlows,omitempty"`
+	NumConnToCollector int64 `json:"numConnToCollector,omitempty"`
+}
+
+// HandleFunc returns the function which can handle the /recordmetrics API request.
+func HandleFunc(faq querier.FlowAggregatorQuerier) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		metrics := faq.GetRecordMetrics()
+		metricsResponse := Response{
+			NumRecordsExported: metrics.NumRecordsExported,
+			NumRecordsReceived: metrics.NumRecordsReceived,
+			NumFlows:           metrics.NumFlows,
+			NumConnToCollector: metrics.NumConnToCollector,
+		}
+		err := json.NewEncoder(w).Encode(metricsResponse)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			klog.Errorf("Error when encoding AntreaAgentInfo to json: %v", err)
+		}
+	}
+}
+
+func (r Response) GetTableHeader() []string {
+	return []string{"RECORDS-EXPORTED", "RECORDS-RECEIVED", "FLOWS", "EXPORTERS-CONNECTED"}
+}
+
+func (r Response) GetTableRow(maxColumnLength int) []string {
+	return []string{
+		common.Int64ToString(r.NumRecordsExported),
+		common.Int64ToString(r.NumRecordsReceived),
+		common.Int64ToString(r.NumFlows),
+		common.Int64ToString(r.NumConnToCollector),
+	}
+}
+
+func (r Response) SortRows() bool {
+	return true
+}

--- a/pkg/flowaggregator/flowaggregator.go
+++ b/pkg/flowaggregator/flowaggregator.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
+	"antrea.io/antrea/pkg/flowaggregator/querier"
 	"antrea.io/antrea/pkg/ipfix"
 )
 
@@ -652,5 +653,18 @@ func (fa *flowAggregator) fillPodLabels(key ipfixintermediate.FlowKey, record ip
 		}
 	} else {
 		klog.Warningf("Get destinationPodLabels InfoElement failed: %v", err)
+	}
+}
+
+func (fa *flowAggregator) GetFlowRecords(flowKey *ipfixintermediate.FlowKey) []map[string]interface{} {
+	return fa.aggregationProcess.GetRecords(flowKey)
+}
+
+func (fa *flowAggregator) GetRecordMetrics() querier.Metrics {
+	return querier.Metrics{
+		NumRecordsExported: fa.numRecordsExported,
+		NumRecordsReceived: fa.collectingProcess.GetNumRecordsReceived(),
+		NumFlows:           fa.aggregationProcess.GetNumFlows(),
+		NumConnToCollector: fa.collectingProcess.GetNumConnToCollector(),
 	}
 }

--- a/pkg/flowaggregator/querier/querier.go
+++ b/pkg/flowaggregator/querier/querier.go
@@ -1,0 +1,31 @@
+// Copyright 2020 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package querier
+
+import (
+	ipfixintermediate "github.com/vmware/go-ipfix/pkg/intermediate"
+)
+
+type Metrics struct {
+	NumRecordsExported int64
+	NumRecordsReceived int64
+	NumFlows           int64
+	NumConnToCollector int64
+}
+
+type FlowAggregatorQuerier interface {
+	GetFlowRecords(flowKey *ipfixintermediate.FlowKey) []map[string]interface{}
+	GetRecordMetrics() Metrics
+}

--- a/pkg/ipfix/ipfix_intermediate.go
+++ b/pkg/ipfix/ipfix_intermediate.go
@@ -30,6 +30,7 @@ type IPFIXAggregationProcess interface {
 	Stop()
 	ForAllExpiredFlowRecordsDo(callback ipfixintermediate.FlowKeyRecordMapCallBack) error
 	GetExpiryFromExpirePriorityQueue() time.Duration
+	GetRecords(flowKey *ipfixintermediate.FlowKey) []map[string]interface{}
 	ResetStatElementsInRecord(record ipfixentities.Record) error
 	SetCorrelatedFieldsFilled(record *ipfixintermediate.AggregationFlowRecord)
 	AreCorrelatedFieldsFilled(record ipfixintermediate.AggregationFlowRecord) bool
@@ -69,6 +70,10 @@ func (ap *ipfixAggregationProcess) ForAllExpiredFlowRecordsDo(callback ipfixinte
 
 func (ap *ipfixAggregationProcess) GetExpiryFromExpirePriorityQueue() time.Duration {
 	return ap.AggregationProcess.GetExpiryFromExpirePriorityQueue()
+}
+
+func (ap *ipfixAggregationProcess) GetRecords(flowKey *ipfixintermediate.FlowKey) []map[string]interface{} {
+	return ap.AggregationProcess.GetRecords(flowKey)
 }
 
 func (ap *ipfixAggregationProcess) ResetStatElementsInRecord(record ipfixentities.Record) error {

--- a/pkg/ipfix/testing/mock_ipfix.go
+++ b/pkg/ipfix/testing/mock_ipfix.go
@@ -323,6 +323,20 @@ func (mr *MockIPFIXAggregationProcessMockRecorder) GetNumFlows() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNumFlows", reflect.TypeOf((*MockIPFIXAggregationProcess)(nil).GetNumFlows))
 }
 
+// GetRecords mocks base method
+func (m *MockIPFIXAggregationProcess) GetRecords(arg0 *intermediate.FlowKey) []map[string]interface{} {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRecords", arg0)
+	ret0, _ := ret[0].([]map[string]interface{})
+	return ret0
+}
+
+// GetRecords indicates an expected call of GetRecords
+func (mr *MockIPFIXAggregationProcessMockRecorder) GetRecords(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRecords", reflect.TypeOf((*MockIPFIXAggregationProcess)(nil).GetRecords), arg0)
+}
+
 // IsAggregatedRecordIPv4 mocks base method
 func (m *MockIPFIXAggregationProcess) IsAggregatedRecordIPv4(arg0 intermediate.AggregationFlowRecord) bool {
 	m.ctrl.T.Helper()

--- a/plugins/octant/go.sum
+++ b/plugins/octant/go.sum
@@ -697,7 +697,7 @@ github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/vmware-tanzu/octant v0.17.0 h1:2H2AiQU5C1RiHxxYrrOosDHHI9eV51nP+e9PjRP+c48=
 github.com/vmware-tanzu/octant v0.17.0/go.mod h1:lA32xKa6icUclg+DjAX/E/Id1cTqwCXZUem3RGEp/2A=
-github.com/vmware/go-ipfix v0.5.9/go.mod h1:yzbG1rv+yJ8GeMrRm+MDhOV3akygNZUHLhC1pDoD2AY=
+github.com/vmware/go-ipfix v0.5.10/go.mod h1:yzbG1rv+yJ8GeMrRm+MDhOV3akygNZUHLhC1pDoD2AY=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/test/e2e/antctl_test.go
+++ b/test/e2e/antctl_test.go
@@ -67,12 +67,18 @@ func antctlOutput(stdout, stderr string) string {
 // runAntctl runs antctl commands on antrea Pods, the controller, or agents.
 func runAntctl(podName string, cmds []string, data *TestData) (string, string, error) {
 	var containerName string
+	var namespace string
 	if strings.Contains(podName, "agent") {
 		containerName = "antrea-agent"
+		namespace = antreaNamespace
+	} else if strings.Contains(podName, "flow-aggregator") {
+		containerName = "flow-aggregator"
+		namespace = flowAggregatorNamespace
 	} else {
 		containerName = "antrea-controller"
+		namespace = antreaNamespace
 	}
-	stdout, stderr, err := data.runCommandFromPod(antreaNamespace, podName, containerName, cmds)
+	stdout, stderr, err := data.runCommandFromPod(namespace, podName, containerName, cmds)
 	// remove Bincover metadata if needed
 	if err == nil {
 		index := strings.Index(stdout, "START_BINCOVER_METADATA")


### PR DESCRIPTION
This commit supports antctl in the flow aggregator pod. It supports three commands only running locally inside the flow-aggregator container.

1. Showing or changing log verbosity level: The `antctl get log-level` command works the same as the one in antrea-agent or antrea-controller.
2. Dumping flow records: The `antctl get flowrecords [-o json]` command can dump all matched flow records. The command provides a compact display of the flow records in the default table output format. Using the `json` or `yaml` antctl output format can print more information of the flow records. The command supports the 5-tuple flow key or a subset of 5-tuples as a filter. A 5-tuple flow key contains Source IP, Destination IP, Source Port, Destination Port and Transport Protocol. If the filter is empty, all flow records will be dumped.
Example outputs of dumping flow records:
```
$ antctl get flowrecords --srcip 10.10.0.1 --srcport 50497 -o json
[
  {
    "destinationClusterIPv4": "0.0.0.0",
    "destinationIPv4Address": "10.10.1.2",
    "destinationNodeName": "k8s-node-worker-1",
    "destinationPodName": "coredns-78fcd69978-x2twv",
    "destinationPodNamespace": "kube-system",
    "destinationServicePort": 0,
    "destinationServicePortName": "",
    "destinationTransportPort": 53,
    "egressNetworkPolicyName": "",
    "egressNetworkPolicyNamespace": "",
    "egressNetworkPolicyRuleAction": 0,
    "egressNetworkPolicyRuleName": "",
    "egressNetworkPolicyType": 0,
    "flowEndReason": 3,
    "flowEndSeconds": 1635546893,
    "flowStartSeconds": 1635546867,
    "flowType": 2,
    "ingressNetworkPolicyName": "",
    "ingressNetworkPolicyNamespace": "",
    "ingressNetworkPolicyRuleAction": 0,
    "ingressNetworkPolicyRuleName": "",
    "ingressNetworkPolicyType": 0,
    "octetDeltaCount": 99,
    "octetDeltaCountFromDestinationNode": 99,
    "octetDeltaCountFromSourceNode": 0,
    "octetTotalCount": 99,
    "octetTotalCountFromDestinationNode": 99,
    "octetTotalCountFromSourceNode": 0,
    "packetDeltaCount": 1,
    "packetDeltaCountFromDestinationNode": 1,
    "packetDeltaCountFromSourceNode": 0,
    "packetTotalCount": 1,
    "packetTotalCountFromDestinationNode": 1,
    "packetTotalCountFromSourceNode": 0,
    "protocolIdentifier": 17,
    "reverseOctetDeltaCount": 192,
    "reverseOctetDeltaCountFromDestinationNode": 192,
    "reverseOctetDeltaCountFromSourceNode": 0,
    "reverseOctetTotalCount": 192,
    "reverseOctetTotalCountFromDestinationNode": 192,
    "reverseOctetTotalCountFromSourceNode": 0,
    "reversePacketDeltaCount": 1,
    "reversePacketDeltaCountFromDestinationNode": 1,
    "reversePacketDeltaCountFromSourceNode": 0,
    "reversePacketTotalCount": 1,
    "reversePacketTotalCountFromDestinationNode": 1,
    "reversePacketTotalCountFromSourceNode": 0,
    "sourceIPv4Address": "10.10.0.1",
    "sourceNodeName": "",
    "sourcePodName": "",
    "sourcePodNamespace": "",
    "sourceTransportPort": 50497,
    "tcpState": ""
  }
]
```

3. Flow records metrics: The `antctl get recordmetrics` command can print all metrics related to the Flow Aggregator. The metrics include number of records received by the collector process in the Flow Aggregator, number of records exported by the Flow Aggregator, number of active flows that are being tracked, number of exporters connected to the Flow Aggregator
 

Fixes: #1966 
