### PR TITLE
Add skipServices to support NodeLocal DNSCache with AntreaProxy

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -3948,6 +3948,10 @@ data:
       # (e.g. 1.2.3.0/24, 1.2.3.4/32). An empty string slice is meant to select all host IPv4/IPv6 addresses.
       # Note that the option is only valid when proxyAll is true.
       #nodePortAddresses: []
+      # An array of string values to specify a list of Services which should be ignored by AntreaProxy (traffic to these
+      # Services will not be load-balanced). Values can be a valid ClusterIP (e.g. 10.11.1.2) or a Service name
+      # with Namespace (e.g. kube-system/kube-dns)
+      #skipServices: []
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -4054,7 +4058,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-b72h88gb7b
+  name: antrea-config-4d7ch86gch
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4125,7 +4129,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-b72h88gb7b
+          value: antrea-config-4d7ch86gch
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4176,7 +4180,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-b72h88gb7b
+          name: antrea-config-4d7ch86gch
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4457,7 +4461,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-b72h88gb7b
+          name: antrea-config-4d7ch86gch
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -3948,6 +3948,10 @@ data:
       # (e.g. 1.2.3.0/24, 1.2.3.4/32). An empty string slice is meant to select all host IPv4/IPv6 addresses.
       # Note that the option is only valid when proxyAll is true.
       #nodePortAddresses: []
+      # An array of string values to specify a list of Services which should be ignored by AntreaProxy (traffic to these
+      # Services will not be load-balanced). Values can be a valid ClusterIP (e.g. 10.11.1.2) or a Service name
+      # with Namespace (e.g. kube-system/kube-dns)
+      #skipServices: []
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -4054,7 +4058,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-b72h88gb7b
+  name: antrea-config-4d7ch86gch
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4125,7 +4129,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-b72h88gb7b
+          value: antrea-config-4d7ch86gch
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4176,7 +4180,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-b72h88gb7b
+          name: antrea-config-4d7ch86gch
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4459,7 +4463,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-b72h88gb7b
+          name: antrea-config-4d7ch86gch
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -3948,6 +3948,10 @@ data:
       # (e.g. 1.2.3.0/24, 1.2.3.4/32). An empty string slice is meant to select all host IPv4/IPv6 addresses.
       # Note that the option is only valid when proxyAll is true.
       #nodePortAddresses: []
+      # An array of string values to specify a list of Services which should be ignored by AntreaProxy (traffic to these
+      # Services will not be load-balanced). Values can be a valid ClusterIP (e.g. 10.11.1.2) or a Service name
+      # with Namespace (e.g. kube-system/kube-dns)
+      #skipServices: []
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -4054,7 +4058,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-hfkckg6t57
+  name: antrea-config-ct7fm8k579
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4125,7 +4129,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-hfkckg6t57
+          value: antrea-config-ct7fm8k579
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4176,7 +4180,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-hfkckg6t57
+          name: antrea-config-ct7fm8k579
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4460,7 +4464,7 @@ spec:
           path: /home/kubernetes/bin
         name: host-cni-bin
       - configMap:
-          name: antrea-config-hfkckg6t57
+          name: antrea-config-ct7fm8k579
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -3953,6 +3953,10 @@ data:
       # (e.g. 1.2.3.0/24, 1.2.3.4/32). An empty string slice is meant to select all host IPv4/IPv6 addresses.
       # Note that the option is only valid when proxyAll is true.
       #nodePortAddresses: []
+      # An array of string values to specify a list of Services which should be ignored by AntreaProxy (traffic to these
+      # Services will not be load-balanced). Values can be a valid ClusterIP (e.g. 10.11.1.2) or a Service name
+      # with Namespace (e.g. kube-system/kube-dns)
+      #skipServices: []
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -4059,7 +4063,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-4f28b82tdt
+  name: antrea-config-7tm5f22tt7
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4139,7 +4143,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-4f28b82tdt
+          value: antrea-config-7tm5f22tt7
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4190,7 +4194,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-4f28b82tdt
+          name: antrea-config-7tm5f22tt7
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4506,7 +4510,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-4f28b82tdt
+          name: antrea-config-7tm5f22tt7
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -3953,6 +3953,10 @@ data:
       # (e.g. 1.2.3.0/24, 1.2.3.4/32). An empty string slice is meant to select all host IPv4/IPv6 addresses.
       # Note that the option is only valid when proxyAll is true.
       #nodePortAddresses: []
+      # An array of string values to specify a list of Services which should be ignored by AntreaProxy (traffic to these
+      # Services will not be load-balanced). Values can be a valid ClusterIP (e.g. 10.11.1.2) or a Service name
+      # with Namespace (e.g. kube-system/kube-dns)
+      #skipServices: []
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -4059,7 +4063,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-bmthb2m52d
+  name: antrea-config-4g55dbc872
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4130,7 +4134,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-bmthb2m52d
+          value: antrea-config-4g55dbc872
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4181,7 +4185,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-bmthb2m52d
+          name: antrea-config-4g55dbc872
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4462,7 +4466,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-bmthb2m52d
+          name: antrea-config-4g55dbc872
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/base/conf/antrea-agent.conf
+++ b/build/yamls/base/conf/antrea-agent.conf
@@ -190,3 +190,7 @@ antreaProxy:
   # (e.g. 1.2.3.0/24, 1.2.3.4/32). An empty string slice is meant to select all host IPv4/IPv6 addresses.
   # Note that the option is only valid when proxyAll is true.
   #nodePortAddresses: []
+  # An array of string values to specify a list of Services which should be ignored by AntreaProxy (traffic to these
+  # Services will not be load-balanced). Values can be a valid ClusterIP (e.g. 10.11.1.2) or a Service name
+  # with Namespace (e.g. kube-system/kube-dns)
+  #skipServices: []

--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -203,14 +203,15 @@ func run(o *Options) error {
 		v4Enabled := config.IsIPv4Enabled(nodeConfig, networkConfig.TrafficEncapMode)
 		v6Enabled := config.IsIPv6Enabled(nodeConfig, networkConfig.TrafficEncapMode)
 		proxyAll := o.config.AntreaProxy.ProxyAll
+		skipServices := o.config.AntreaProxy.SkipServices
 
 		switch {
 		case v4Enabled && v6Enabled:
-			proxier = proxy.NewDualStackProxier(nodeConfig.Name, informerFactory, ofClient, routeClient, nodePortAddressesIPv4, nodePortAddressesIPv6, proxyAll)
+			proxier = proxy.NewDualStackProxier(nodeConfig.Name, informerFactory, ofClient, routeClient, nodePortAddressesIPv4, nodePortAddressesIPv6, proxyAll, skipServices)
 		case v4Enabled:
-			proxier = proxy.NewProxier(nodeConfig.Name, informerFactory, ofClient, false, routeClient, nodePortAddressesIPv4, proxyAll)
+			proxier = proxy.NewProxier(nodeConfig.Name, informerFactory, ofClient, false, routeClient, nodePortAddressesIPv4, proxyAll, skipServices)
 		case v6Enabled:
-			proxier = proxy.NewProxier(nodeConfig.Name, informerFactory, ofClient, true, routeClient, nodePortAddressesIPv6, proxyAll)
+			proxier = proxy.NewProxier(nodeConfig.Name, informerFactory, ofClient, true, routeClient, nodePortAddressesIPv6, proxyAll, skipServices)
 		default:
 			return fmt.Errorf("at least one of IPv4 or IPv6 should be enabled")
 		}

--- a/cmd/antrea-agent/config.go
+++ b/cmd/antrea-agent/config.go
@@ -186,6 +186,10 @@ type AntreaProxyConfig struct {
 	// A string array of values which specifies the host IPv4/IPv6 addresses for NodePorts. Values may be valid IP blocks.
 	// (e.g. 1.2.3.0/24, 1.2.3.4/32). An empty string slice is meant to select all host IPv4/IPv6 addresses.
 	NodePortAddresses []string `yaml:"nodePortAddresses,omitempty"`
+	// An array of string values to specify a list of Services which should be ignored by AntreaProxy (traffic to these
+	// Services will not be load-balanced). Values can be a valid ClusterIP (e.g. 10.11.1.2) or a Service name
+	// with Namespace (e.g. kube-system/kube-dns)
+	SkipServices []string `yaml:"skipServices,omitempty"`
 }
 
 type WireGuardConfig struct {

--- a/cmd/antrea-agent/options.go
+++ b/cmd/antrea-agent/options.go
@@ -232,6 +232,10 @@ func (o *Options) setDefaults() {
 }
 
 func (o *Options) validateAntreaProxyConfig() error {
+	if !features.DefaultFeatureGate.Enabled(features.AntreaProxy) && len(o.config.AntreaProxy.SkipServices) > 0 {
+		klog.InfoS("skipServices will be ignored because AntreaProxy is disabled", "skipServices", o.config.AntreaProxy.SkipServices)
+	}
+
 	if o.config.AntreaProxy.ProxyAll {
 		for _, nodePortAddress := range o.config.AntreaProxy.NodePortAddresses {
 			if _, _, err := net.ParseCIDR(nodePortAddress); err != nil {

--- a/pkg/agent/proxy/proxier.go
+++ b/pkg/agent/proxy/proxier.go
@@ -782,7 +782,8 @@ func NewProxier(
 	isIPv6 bool,
 	routeClient route.Interface,
 	nodePortAddresses []net.IP,
-	proxyAllEnabled bool) *proxier {
+	proxyAllEnabled bool,
+	skipServices []string) *proxier {
 	recorder := record.NewBroadcaster().NewRecorder(
 		runtime.NewScheme(),
 		corev1.EventSource{Component: componentName, Host: hostname},
@@ -800,7 +801,7 @@ func NewProxier(
 		endpointsConfig:          config.NewEndpointsConfig(informerFactory.Core().V1().Endpoints(), resyncPeriod),
 		serviceConfig:            config.NewServiceConfig(informerFactory.Core().V1().Services(), resyncPeriod),
 		endpointsChanges:         newEndpointsChangesTracker(hostname, endpointSliceEnabled, isIPv6),
-		serviceChanges:           newServiceChangesTracker(recorder, ipFamily),
+		serviceChanges:           newServiceChangesTracker(recorder, ipFamily, skipServices),
 		serviceMap:               k8sproxy.ServiceMap{},
 		serviceInstalledMap:      k8sproxy.ServiceMap{},
 		endpointsInstalledMap:    types.EndpointsMap{},
@@ -866,13 +867,14 @@ func NewDualStackProxier(
 	routeClient route.Interface,
 	nodePortAddressesIPv4 []net.IP,
 	nodePortAddressesIPv6 []net.IP,
-	proxyAllEnabled bool) *metaProxierWrapper {
+	proxyAllEnabled bool,
+	skipServices []string) *metaProxierWrapper {
 
 	// Create an IPv4 instance of the single-stack proxier.
-	ipv4Proxier := NewProxier(hostname, informerFactory, ofClient, false, routeClient, nodePortAddressesIPv4, proxyAllEnabled)
+	ipv4Proxier := NewProxier(hostname, informerFactory, ofClient, false, routeClient, nodePortAddressesIPv4, proxyAllEnabled, skipServices)
 
 	// Create an IPv6 instance of the single-stack proxier.
-	ipv6Proxier := NewProxier(hostname, informerFactory, ofClient, true, routeClient, nodePortAddressesIPv6, proxyAllEnabled)
+	ipv6Proxier := NewProxier(hostname, informerFactory, ofClient, true, routeClient, nodePortAddressesIPv6, proxyAllEnabled, skipServices)
 
 	// Create a meta-proxier that dispatch calls between the two
 	// single-stack proxier instances.

--- a/pkg/agent/proxy/service.go
+++ b/pkg/agent/proxy/service.go
@@ -31,8 +31,8 @@ type serviceChangesTracker struct {
 	initialized bool
 }
 
-func newServiceChangesTracker(recorder record.EventRecorder, ipFamily v1.IPFamily) *serviceChangesTracker {
-	return &serviceChangesTracker{tracker: k8sproxy.NewServiceChangeTracker(types.NewServiceInfo, ipFamily, recorder, nil)}
+func newServiceChangesTracker(recorder record.EventRecorder, ipFamily v1.IPFamily, skipServices []string) *serviceChangesTracker {
+	return &serviceChangesTracker{tracker: k8sproxy.NewServiceChangeTracker(types.NewServiceInfo, ipFamily, recorder, nil, skipServices)}
 }
 
 func (sh *serviceChangesTracker) OnServiceSynced() {


### PR DESCRIPTION
Add a `skipServices` in `antrea-agent.conf` so AntreaProxy can be configured to skip proxying kube-dns service which allow user to use `NodeLocal DNSCache`

Resolves #2137

Signed-off-by: Lan Luo <luola@vmware.com>