### PR TITLE
Set kubelet's cgroup driver to groupfs in playbook

### DIFF
--- a/test/e2e/infra/vagrant/playbook/roles/control-plane/templates/kubeadm.conf.j2
+++ b/test/e2e/infra/vagrant/playbook/roles/control-plane/templates/kubeadm.conf.j2
@@ -15,3 +15,7 @@ apiServer:
   - "{{ k8s_api_server_ip }}"
   extraArgs:
     feature-gates: "NetworkPolicyEndPort=true"
+---
+kind: KubeletConfiguration
+apiVersion: kubelet.config.k8s.io/v1beta1
+cgroupDriver: cgroupfs


### PR DESCRIPTION
 In v1.22, if the user is not setting the cgroupDriver field under
 KubeletConfiguration, kubeadm will default it to systemd.

Signed-off-by: Hang Yan <yhang@vmware.com>