### PR TITLE
Optimize Egress sync process

### DIFF
--- a/pkg/agent/memberlist/cluster.go
+++ b/pkg/agent/memberlist/cluster.go
@@ -160,7 +160,11 @@ func NewCluster(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: c.enqueueExternalIPPool,
 			UpdateFunc: func(oldObj, newObj interface{}) {
-				c.enqueueExternalIPPool(newObj)
+				oldExternalIPPool := oldObj.(*v1alpha2.ExternalIPPool)
+				curExternalIPPool := newObj.(*v1alpha2.ExternalIPPool)
+				if !reflect.DeepEqual(oldExternalIPPool.Spec.NodeSelector, curExternalIPPool.Spec.NodeSelector) {
+					c.enqueueExternalIPPool(newObj)
+				}
 			},
 			DeleteFunc: c.enqueueExternalIPPool,
 		},

--- a/pkg/controller/egress/controller.go
+++ b/pkg/controller/egress/controller.go
@@ -575,7 +575,9 @@ func (c *EgressController) updateEgress(old, cur interface{}) {
 		groupSelector := antreatypes.NewGroupSelector("", curEgress.Spec.AppliedTo.PodSelector, curEgress.Spec.AppliedTo.NamespaceSelector, nil)
 		c.groupingInterface.AddGroup(egressGroupType, curEgress.Name, groupSelector)
 	}
-	c.queue.Add(curEgress.Name)
+	if oldEgress.GetGeneration() != curEgress.GetGeneration() {
+		c.queue.Add(curEgress.Name)
+	}
 }
 
 // deleteEgress processes Egress DELETE events and deletes corresponding EgressGroup.

--- a/pkg/controller/egress/controller_test.go
+++ b/pkg/controller/egress/controller_test.go
@@ -448,6 +448,7 @@ func TestUpdateEgress(t *testing.T) {
 	}
 	egress.Spec.ExternalIPPool = eipFoo2.Name
 	egress.Spec.EgressIP = ""
+	egress.Generation += 1
 	controller.crdClient.CrdV1alpha2().Egresses().Update(context.TODO(), egress, metav1.UpdateOptions{})
 	assert.Equal(t, &watch.Event{
 		Type: watch.Deleted,


### PR DESCRIPTION
1. Ignore handling the Egress with empty Egress IP in Antrea Agent addEgress event.
2. Compare CR Generation in informer update event to ignore CR Status change.
3. Ignore handling the Egress IP Add event in onLocalIPUpdate process, which the IP already has been assigned by ipAssigner.

Fixes: #2880

Signed-off-by: Wu zhengdong <zhengdong.wu@transwarp.io>