### PR TITLE
Fix Prometheus metrics doc

### DIFF
--- a/ci/kind/kind-setup.sh
+++ b/ci/kind/kind-setup.sh
@@ -257,7 +257,7 @@ networking:
 nodes:
 - role: control-plane
 EOF
-  for i in $(seq 1 $NUM_WORKERS); do
+  for (( i=0; i<$NUM_WORKERS; i++ )); do
     echo -e "- role: worker" >> $config_file
   done
   kind create cluster --name $CLUSTER_NAME --config $config_file

--- a/docs/prometheus-integration.md
+++ b/docs/prometheus-integration.md
@@ -157,9 +157,9 @@ when a flow is rejected/dropped by network policy.
 - **antrea_agent_egress_networkpolicy_rule_count:** Number of egress
 NetworkPolicy rules on local Node which are managed by the Antrea Agent.
 - **antrea_agent_flow_collector_reconnection_count:** Number of re-connections
-between Flow Exporter and flow collector. This metric gets updated whenever the
-connection is re-established between the Flow Exporter and the flow collector
-(e.g.  the Flow Aggregator).
+between Flow Exporter and flow collector. This metric gets updated whenever
+the connection is re-established between the Flow Exporter and the flow
+collector (e.g. the Flow Aggregator).
 - **antrea_agent_ingress_networkpolicy_rule_count:** Number of ingress
 NetworkPolicy rules on local Node which are managed by the Antrea Agent.
 - **antrea_agent_local_pod_count:** Number of Pods on local Node which are


### PR DESCRIPTION
PR #2668 did not update the Prometheus metrics documentation correctly
(the CI job actually failed, but we missed it). As a consequence, the CI
job keeps failing for all new PRs. This commit updates the documentation
and makes a few minor improvements to the ./hack/make-metrics-doc.sh
script.

Signed-off-by: Antonin Bas <abas@vmware.com>