### PR TITLE
Add Go benchmark check

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,9 +1,6 @@
 name: Go Benchmark Test
 
 on:
-  pull_request:
-    branches:
-      - main
   push:
     branches:
       - main

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,46 @@
+name: Go Benchmark Test
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  check-changes:
+    name: Check whether tests need to be run based on diff
+    runs-on: [ ubuntu-latest ]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: antrea-io/antrea/ci/gh-actions/has-changes@main
+        id: check_diff
+        with:
+          args: pkg/*
+    outputs:
+      has_changes: ${{ steps.check_diff.outputs.has_changes }}
+
+  go-benchmark-checks:
+    needs: check-changes
+    if: ${{ needs.check-changes.outputs.has_changes == 'yes' || github.event_name == 'push' }}
+    name: GoBenchmark
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.17
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Install benchci
+        run: curl -sfL https://raw.githubusercontent.com/antrea-io/benchci/main/install.sh | sudo sh -s -- -b /usr/local/bin
+
+      - name: Run benchmark
+        run: benchci -config test/performance/benchmark.yml

--- a/test/performance/benchmark.yml
+++ b/test/performance/benchmark.yml
@@ -9,28 +9,29 @@ benchmarks:
   - name: "BenchmarkInitXLargeScaleWithSmallNamespaces"
     package: "./pkg/controller/networkpolicy"
     threshold: 0.3
-    version_requirement: ">1.3.0"
+    versionRequirement: ">1.3.0"
   - name: "BenchmarkInitXLargeScaleWithLargeNamespaces"
     package: "./pkg/controller/networkpolicy"
     threshold: 0.2
-    version_requirement: ">1.3.0"
+    versionRequirement: ">1.3.0"
   - name: "BenchmarkInitXLargeScaleWithOneNamespace"
     package: "./pkg/controller/networkpolicy"
     threshold: 0.3
-    version_requirement: ">1.3.0"
+    versionRequirement: ">1.3.0"
   - name: "BenchmarkInitXLargeScaleWithNetpolPerPod"
     package: "./pkg/controller/networkpolicy"
     threshold: 0.15
-    version_requirement: ">1.3.0"
+    versionRequirement: ">1.3.0"
   - name: "BenchmarkInitXLargeScaleWithClusterScopedNetpol"
     package: "./pkg/controller/networkpolicy"
-    version_requirement: ">1.3.0"
+    versionRequirement: ">1.3.0"
   - name: "BenchmarkSyncAddressGroup"
     package: "./pkg/controller/networkpolicy"
-    version_requirement: ">1.3.0"
+    versionRequirement: ">1.3.0"
   - name: "BenchmarkCluster_ShouldSelect/Select_Node_from_1000_alive_Nodes-nodeSelectedForEgress"
     package: "./pkg/agent/memberlist"
-    version_requirement: ">1.2.0"
+    versionRequirement: ">1.2.0"
+    threshold: 0.2
   - name: "BenchmarkRuleCacheUnionAddressGroups"
     package: "./pkg/agent/controller/networkpolicy"
     threshold: 0.15
@@ -46,7 +47,7 @@ benchmarks:
     package: "./pkg/agent/controller/networkpolicy"
   - name: "BenchmarkPoll"
     package: "./pkg/agent/flowexporter/connections"
-    version_requirement: ">1.3.0"
+    versionRequirement: ">1.3.0"
   - name: "BenchmarkExportConntrackConns"
     package: "./pkg/agent/flowexporter/exporter"
     threshold: 0.2

--- a/test/performance/benchmark.yml
+++ b/test/performance/benchmark.yml
@@ -1,0 +1,62 @@
+command: go
+benchtime: 10s
+threshold: 0.1
+compare: "ns/op,B/op"
+cpu: 2
+benchmem: true
+timeout: 15m
+benchmarks:
+  - name: "BenchmarkInitXLargeScaleWithSmallNamespaces"
+    package: "./pkg/controller/networkpolicy"
+    threshold: 0.3
+  - name: "BenchmarkInitXLargeScaleWithLargeNamespaces"
+    package: "./pkg/controller/networkpolicy"
+    threshold: 0.2
+  - name: "BenchmarkInitXLargeScaleWithOneNamespace"
+    package: "./pkg/controller/networkpolicy"
+    threshold: 0.3
+  - name: "BenchmarkInitXLargeScaleWithNetpolPerPod"
+    package: "./pkg/controller/networkpolicy"
+    threshold: 0.15
+  - name: "BenchmarkInitXLargeScaleWithClusterScopedNetpol"
+    package: "./pkg/controller/networkpolicy"
+  - name: "BenchmarkSyncAddressGroup"
+    package: "./pkg/controller/networkpolicy"
+  - name: "BenchmarkCluster_ShouldSelect/Select_Node_from_1000_alive_Nodes-nodeSelectedForEgress"
+    package: "./pkg/agent/memberlist"
+  - name: "BenchmarkRuleCacheUnionAddressGroups"
+    package: "./pkg/agent/controller/networkpolicy"
+    threshold: 0.15
+  - name: "BenchmarkNormalizeServices"
+    package: "./pkg/agent/controller/networkpolicy"
+  - name: "BenchmarkGroupPodsByServicesWithNamedPort"
+    package: "./pkg/agent/controller/networkpolicy"
+    threshold: 0.2
+  - name: "BenchmarkGroupPodsByServicesWithoutNamedPort"
+    package: "./pkg/agent/controller/networkpolicy"
+  - name: "BenchmarkSyncHandler"
+    package: "./pkg/agent/controller/networkpolicy"
+  - name: "BenchmarkPoll"
+    package: "./pkg/agent/flowexporter/connections"
+  - name: "BenchmarkExportConntrackConns"
+    package: "./pkg/agent/flowexporter/exporter"
+    threshold: 0.2
+    benchtime: 10x
+  - name: "BenchmarkCompareNPLAnnotationLists/EqualSameOrder"
+    package: "./pkg/agent/nodeportlocal/k8s"
+  - name: "BenchmarkCompareNPLAnnotationLists/EqualDifferentOrder"
+    package: "./pkg/agent/nodeportlocal/k8s"
+  - name: "BenchmarkCompareNPLAnnotationLists/NotEqualSameLength"
+    package: "./pkg/agent/nodeportlocal/k8s"
+  - name: "BenchmarkCompareNPLAnnotationLists/NotEqualDifferentLength"
+    package: "./pkg/agent/nodeportlocal/k8s"
+  - name: "BenchmarkBatchInstallPolicyRuleFlows"
+    package: "./pkg/agent/openflow"
+  - name: "BenchmarkIDAllocate"
+    package: "./pkg/agent/openflow/cookie"
+    benchtime: 100x
+    threshold: 0.15
+  - name: "BenchmarkNormalizeGroupMemberPod"
+    package: "./pkg/apis/controlplane"
+  - name: "BenchmarkSymmetricDifferenceString"
+    package: "./pkg/util/sets"

--- a/test/performance/benchmark.yml
+++ b/test/performance/benchmark.yml
@@ -4,26 +4,33 @@ threshold: 0.1
 compare: "ns/op,B/op"
 cpu: 2
 benchmem: true
-timeout: 15m
+timeout: 10m
 benchmarks:
   - name: "BenchmarkInitXLargeScaleWithSmallNamespaces"
     package: "./pkg/controller/networkpolicy"
     threshold: 0.3
+    version_requirement: ">1.3.0"
   - name: "BenchmarkInitXLargeScaleWithLargeNamespaces"
     package: "./pkg/controller/networkpolicy"
     threshold: 0.2
+    version_requirement: ">1.3.0"
   - name: "BenchmarkInitXLargeScaleWithOneNamespace"
     package: "./pkg/controller/networkpolicy"
     threshold: 0.3
+    version_requirement: ">1.3.0"
   - name: "BenchmarkInitXLargeScaleWithNetpolPerPod"
     package: "./pkg/controller/networkpolicy"
     threshold: 0.15
+    version_requirement: ">1.3.0"
   - name: "BenchmarkInitXLargeScaleWithClusterScopedNetpol"
     package: "./pkg/controller/networkpolicy"
+    version_requirement: ">1.3.0"
   - name: "BenchmarkSyncAddressGroup"
     package: "./pkg/controller/networkpolicy"
+    version_requirement: ">1.3.0"
   - name: "BenchmarkCluster_ShouldSelect/Select_Node_from_1000_alive_Nodes-nodeSelectedForEgress"
     package: "./pkg/agent/memberlist"
+    version_requirement: ">1.2.0"
   - name: "BenchmarkRuleCacheUnionAddressGroups"
     package: "./pkg/agent/controller/networkpolicy"
     threshold: 0.15
@@ -31,31 +38,35 @@ benchmarks:
     package: "./pkg/agent/controller/networkpolicy"
   - name: "BenchmarkGroupPodsByServicesWithNamedPort"
     package: "./pkg/agent/controller/networkpolicy"
-    threshold: 0.2
+    threshold: 0.3
   - name: "BenchmarkGroupPodsByServicesWithoutNamedPort"
     package: "./pkg/agent/controller/networkpolicy"
+    threshold: 0.3
   - name: "BenchmarkSyncHandler"
     package: "./pkg/agent/controller/networkpolicy"
   - name: "BenchmarkPoll"
     package: "./pkg/agent/flowexporter/connections"
+    version_requirement: ">1.3.0"
   - name: "BenchmarkExportConntrackConns"
     package: "./pkg/agent/flowexporter/exporter"
     threshold: 0.2
     benchtime: 10x
   - name: "BenchmarkCompareNPLAnnotationLists/EqualSameOrder"
     package: "./pkg/agent/nodeportlocal/k8s"
+    threshold: 0.2
   - name: "BenchmarkCompareNPLAnnotationLists/EqualDifferentOrder"
     package: "./pkg/agent/nodeportlocal/k8s"
+    threshold: 0.2
   - name: "BenchmarkCompareNPLAnnotationLists/NotEqualSameLength"
     package: "./pkg/agent/nodeportlocal/k8s"
+    threshold: 0.3
   - name: "BenchmarkCompareNPLAnnotationLists/NotEqualDifferentLength"
     package: "./pkg/agent/nodeportlocal/k8s"
   - name: "BenchmarkBatchInstallPolicyRuleFlows"
     package: "./pkg/agent/openflow"
   - name: "BenchmarkIDAllocate"
     package: "./pkg/agent/openflow/cookie"
-    benchtime: 100x
-    threshold: 0.15
+    threshold: 0.2
   - name: "BenchmarkNormalizeGroupMemberPod"
     package: "./pkg/apis/controlplane"
   - name: "BenchmarkSymmetricDifferenceString"


### PR DESCRIPTION
Add Go Benchmark check

Run Go benchmarks as part of CI and automatically monitor for performance
regressions.

Fixes #2488

Signed-off-by: Wenqi Qiu <wenqiq@vmware.com>