### PR TITLE
CI: Keep Cloud Related Job Results for One Month

### DIFF
--- a/ci/jenkins/jobs/job-templates.yaml
+++ b/ci/jenkins/jobs/job-templates.yaml
@@ -223,7 +223,7 @@
      - build-discarder:
          artifact-days-to-keep: -1
          artifact-num-to-keep: -1
-         days-to-keep: 7
+         days-to-keep: 30
          num-to-keep: 30
      - github:
          url: '{repo_url}'
@@ -264,7 +264,7 @@
      - build-discarder:
          artifact-days-to-keep: -1
          artifact-num-to-keep: -1
-         days-to-keep: 7
+         days-to-keep: 30
          num-to-keep: 30
      - github:
          url: '{repo_url}'


### PR DESCRIPTION
Sometimes cleanup job failed to delete GKE. Increase days-to-keep to 30
days to help triaging the problem.