### PR TITLE
Add a manual Github workflow to build and push antrea/ethtool

### DIFF
--- a/.github/workflows/docker_update_ethtool.yml
+++ b/.github/workflows/docker_update_ethtool.yml
@@ -1,0 +1,43 @@
+# Anyone with write permissions to the antrea-io/antrea Github repository can
+# trigger this workflow manually, but please check with a maintainer first. The
+# workflow will build and push the antrea/ethtool image, with multi-platform
+# support.
+name: Manually update antrea/ethtool Docker image
+
+on:
+  workflow_dispatch:
+    # It is unlikely that anyone will need to use non-default values for these inputs.
+    inputs:
+      antrea-ref:
+        description: 'The Git ref to use when checking-out the Antrea repository'
+        required: false
+        default: 'main'
+      docker-tag:
+        description: 'Tag for built Docker image'
+        required: false
+        default: 'latest'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check-out code
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.inputs.antrea-ref }}
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v2
+      with:
+        context: build/images/ethtool
+        platforms: linux/amd64,linux/arm64,linux/arm/v7
+        push: true
+        tags: antrea/ethtool:${{ github.event.inputs.docker-tag }}

--- a/build/images/ethtool/README.md
+++ b/build/images/ethtool/README.md
@@ -3,14 +3,14 @@
 This Docker image is a very lightweight image based on Ubuntu 20.04 which
 includes ethtool, the ip tools and iptables.
 
-If you need to build a new version of the image and push it to Dockerhub, you
-can run the following:
+If you need to build a new version of the image locally, you can run the following:
 
 ```bash
 cd build/images/ethtool
 docker build -t antrea/ethtool:latest .
-docker push antrea/ethtool:latest
 ```
 
-The `docker push` command will fail if you do not have permission to push to the
-`antrea` Dockerhub repository.
+To update the version of the image on Dockerhub, you can run the `Manually
+update antrea/ethtool Docker image` Github workflow. Only contributors with
+`write` access to the antrea-io/antrea Github repository can trigger the
+workflow. If you need to update the image, please check with a maintainer first.


### PR DESCRIPTION
Anyone with write permissions to antrea-io/antrea can run the workflow,
but they should check with a maintainer first. If someone runs the
workflow by mistake, it is very unliekly that anything will break.

The Docker image now supports ARM (arm64 and arm/v7) in addition to
amd64. This is useful for example if someone wants to run a Kind cluster
with Antrea on a MAC laptop with an M1 chip. See #2895.

Signed-off-by: Antonin Bas <abas@vmware.com>