### PR TITLE
Add user documentation for WireGuard encryption

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -166,10 +166,10 @@ CRDs, which provide advanced features including: policy priority, tiering, deny
 action, external entity, and policy statistics. For more information on usage of
 Antrea Network Policies, refer to the [Antrea Network Policy document](antrea-network-policy.md).
 
-### IPsec Encryption
+### Traffic Encryption
 
-Antrea supports encrypting GRE tunnel traffic with IPsec. To deploy Antrea with
-IPsec encryption enabled, please refer to [this guide](ipsec-tunnel.md).
+Antrea supports encrypting traffic between Linux Nodes using IPsec or WireGuard.
+To deploy Antrea with traffic encryption enabled, please refer to [this guide](traffic-encryption.md).
 
 ### Network Flow Visibility
 

--- a/docs/noencap-hybrid-modes.md
+++ b/docs/noencap-hybrid-modes.md
@@ -30,9 +30,9 @@ described in the [Google Cloud documentation](https://cloud.google.com/vpc/docs/
 
 If the Node network does allow Pod IPs sent out from the Nodes, you can
 configure Antrea to run in the `Hybrid` mode by setting the `trafficEncapMode`
-config option of `antrea-agent` to `hybrid`. The `trafficEncapMode` config
-option is defined in `antrea-agent.conf` of the `antrea` ConfigMap in the
-[Antrea deployment YAML](https://github.com/antrea-io/antrea/blob/main/build/yamls/antrea.yml).
+config parameter of `antrea-agent` to `hybrid`. The `trafficEncapMode` config
+parameter is defined in `antrea-agent.conf` of the `antrea` ConfigMap in the
+[Antrea deployment yaml](https://github.com/antrea-io/antrea/blob/main/build/yamls/antrea.yml).
 
 ```yaml
   antrea-agent.conf: |
@@ -41,7 +41,7 @@ option is defined in `antrea-agent.conf` of the `antrea` ConfigMap in the
     ... ...
 ```
 
-After changing the config option, you can deploy Antrea in `Hybrid` mode with
+After changing the config parameter, you can deploy Antrea in `Hybrid` mode with
 the usual command:
 
 ```bash
@@ -75,14 +75,14 @@ configure Antrea and kube-router to work together.
 
 When the Node network can support forwarding and routing of Pod traffic, Antrea
 can be configured to run in the `NoEncap` mode, by setting the `trafficEncapMode`
-config option of `antrea-agent` to `noEncap`. By default, Antrea performs SNAT
+config parameter of `antrea-agent` to `noEncap`. By default, Antrea performs SNAT
 (source network address translation) for the outbound connections from a Pod to
 outside of the Pod network, using the Node's IP address as the SNAT IP. In the
 `NoEncap` mode, as the Node network knows about Pod IP addresses, the SNAT by
 Antrea might be unnecessary. In this case, you can disable it by setting the
-`noSNAT` config option to `true`. The `trafficEncapMode` and `noSNAT` config
-options are defined in `antrea-agent.conf` of the `antrea` ConfigMap in the
-[Antrea deployment YAML](https://github.com/antrea-io/antrea/blob/main/build/yamls/antrea.yml).
+`noSNAT` config parameter to `true`. The `trafficEncapMode` and `noSNAT` config
+parameters are defined in `antrea-agent.conf` of the `antrea` ConfigMap in the
+[Antrea deployment yaml](https://github.com/antrea-io/antrea/blob/main/build/yamls/antrea.yml).
 
 ```yaml
   antrea-agent.conf: |
@@ -93,8 +93,8 @@ options are defined in `antrea-agent.conf` of the `antrea` ConfigMap in the
     ... ...
 ```
 
-After changing the options, you can deploy Antrea in `noEncap` mode by applying
-the deployment YAML.
+After changing the parameters, you can deploy Antrea in `noEncap` mode by applying
+the deployment yaml.
 
 ### Using kube-router for BGP
 
@@ -107,7 +107,7 @@ To deploy kube-router in advertisement-only mode, first download the
 curl -LO https://raw.githubusercontent.com/cloudnativelabs/kube-router/v0.4.0/daemonset/generic-kuberouter-only-advertise-routes.yaml
 ```
 
-Then edit the YAML file and set the following kube-router arguments:
+Then edit the yaml file and set the following kube-router arguments:
 
 ```yaml
 - "--run-router=true"

--- a/docs/security.md
+++ b/docs/security.md
@@ -26,8 +26,8 @@ remove access to the `/var/run/antrea/` directory for non-root users
 If a malicious Pod can gain read access to this file, or, prior to Antrea v0.10,
 if an attacker can gain access to the host, they can potentially access
 sensitive information stored in the database, most notably the Pre-Shared Key
-(PSK) used to configure [IPsec tunnels](ipsec-tunnel.md), which is stored in
-plaintext in the database. If a PSK is leaked, an attacker can mount a
+(PSK) used to configure [IPsec tunnels](traffic-encryption.md), which is stored
+in plaintext in the database. If a PSK is leaked, an attacker can mount a
 man-in-the-middle attack and intercept tunnel traffic.
 
 If a malicious Pod can gain write access to this file, it can modify the

--- a/docs/traffic-encryption.md
+++ b/docs/traffic-encryption.md
@@ -1,10 +1,14 @@
-# IPsec Encryption of Tunnel Traffic with Antrea
+# Traffic Encryption with Antrea
 
-Antrea supports encrypting tunnel traffic across Nodes with IPsec ESP.
+Antrea supports encrypting traffic across Linux Nodes with IPsec ESP or
+WireGuard. Traffic encryption is not supported on Windows Nodes yet.
+
+## IPsec
+
 IPsec encyption works for all tunnel types supported by OVS including Geneve,
 GRE, VXLAN, and STT tunnel.
 
-## Prerequisites
+### Prerequisites
 
 IPsec requires a set of Linux kernel modules. Check the required kernel modules
 listed in the [strongSwan documentation](https://wiki.strongswan.org/projects/strongswan/wiki/KernelModules).
@@ -15,7 +19,7 @@ If you want to enable IPsec with Geneve, please make sure [this commit](https://
 is included in the kernel. For Ubuntu 18.04, kernel version should be at least
 `4.15.0-128`. For Ubuntu 20.04, kernel version should be at least `5.4.70`.
 
-## Installation
+### Antrea installation
 
 You can simply apply the [Antrea IPsec deployment yaml](/build/yamls/antrea-ipsec.yml)
 to deploy Antrea with IPsec encyption enabled. To deploy a released version of
@@ -58,4 +62,56 @@ After updating the PSK value, deploy Antrea with:
 
 ```bash
 kubectl apply -f antrea-ipsec.yml
+```
+
+## WireGuard
+
+Antrea can leverage [WireGuard](https://www.wireguard.com) to encrypt Pod traffic
+between Nodes. WireGuard encryption works like another tunnel type, and when it
+is enabled the `tunnelType` parameter in the `antrea-agent` configuration file
+will be ignored.
+
+### Prerequisites
+
+WireGuard encryption requires `wireguard` kernel module be present on the
+Kubernetes Nodes. `wireguard` module is part of mainline kernel since Linux 5.6.
+Or, you can compile the module from source code with a kernel version >= 3.10.
+[This WireGuard web page](https://www.wireguard.com/install) documents how to
+install WireGuard together with the kernel module on various operating systems.
+
+### Antrea installation
+
+First, download the [Antrea deployment yaml](/build/yamls/antrea.yml). To deploy
+a released version of Antrea, pick a version from the [list of releases](https://github.com/antrea-io/antrea/releases).
+Note that WireGuard support was added in release 1.3.0, which means you can not
+pick a release older than 1.3.0. For any given release `<TAG>` (e.g. `v1.3.0`),
+get the Antrea deployment yaml at:
+
+```text
+https://github.com/antrea-io/antrea/releases/download/<TAG>/antrea.yml
+```
+
+To deploy the latest version of Antrea (built from the main branch), get the
+deployment yaml at:
+
+```text
+https://raw.githubusercontent.com/antrea-io/antrea/main/build/yamls/antrea.yml
+```
+
+To enable WireGuard encryption, the `trafficEncryptionMode` config parameter of
+`antrea-agent` to `wireGuard`. The `trafficEncryptionMode` config parameter is
+defined in `antrea-agent.conf` of `antrea` ConfigMap in the Antrea deployment
+yaml:
+
+```yaml
+  antrea-agent.conf: |
+    ... ...
+    trafficEncryptionMode: wireGuard
+    ... ...
+```
+
+After saving the yaml file change, deploy Antrea with:
+
+```bash
+kubectl apply -f antrea.yml
 ```

--- a/hack/.notableofcontents
+++ b/hack/.notableofcontents
@@ -19,7 +19,6 @@ docs/eks-installation.md
 docs/feature-gates.md
 docs/getting-started.md
 docs/gke-installation.md
-docs/ipsec-tunnel.md
 docs/kind.md
 docs/kubernetes-installers.md
 docs/maintainers/antrea-docker-image.md
@@ -34,4 +33,5 @@ docs/os-issues.md
 docs/ovs-offload.md
 docs/prometheus-integration.md
 docs/security.md
+docs/traffic-encryption.md
 docs/windows.md


### PR DESCRIPTION
Rename docs/ipsec-tunnel.md to docs/traffic-encryption.md, and include
descriptions about WireGuard.

Signed-off-by: Jianjun Shen <shenj@vmware.com>