### PR TITLE
Upgrade to go-ipfix v0.5.9

### DIFF
--- a/ci/kind/test-e2e-kind.sh
+++ b/ci/kind/test-e2e-kind.sh
@@ -129,7 +129,7 @@ COMMON_IMAGES_LIST=("gcr.io/kubernetes-e2e-test-images/agnhost:2.8" \
                     "projects.registry.vmware.com/library/busybox"  \
                     "projects.registry.vmware.com/antrea/nginx" \
                     "projects.registry.vmware.com/antrea/perftool" \
-                    "projects.registry.vmware.com/antrea/ipfix-collector:v0.5.8" \
+                    "projects.registry.vmware.com/antrea/ipfix-collector:v0.5.9" \
                     "projects.registry.vmware.com/antrea/wireguard-go:0.0.20210424")
 for image in "${COMMON_IMAGES_LIST[@]}"; do
     for i in `seq 3`; do

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/ti-mo/conntrack v0.4.0
 	github.com/vishvananda/netlink v1.1.1-0.20210510164352-d17758a128bf
-	github.com/vmware/go-ipfix v0.5.8
+	github.com/vmware/go-ipfix v0.5.9
 	golang.org/x/crypto v0.0.0-20210503195802-e9a32991a82e
 	golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6
 	golang.org/x/mod v0.4.2

--- a/go.sum
+++ b/go.sum
@@ -653,8 +653,8 @@ github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc/go.mod h1:ZjcWmF
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae h1:4hwBBUfQCFe3Cym0ZtKyq7L16eZUtYKs+BaHDN6mAns=
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
-github.com/vmware/go-ipfix v0.5.8 h1:/npDq+uGp9AoESNJvjsT6f3vT2rQc1Oq1RhHNN+N06k=
-github.com/vmware/go-ipfix v0.5.8/go.mod h1:yzbG1rv+yJ8GeMrRm+MDhOV3akygNZUHLhC1pDoD2AY=
+github.com/vmware/go-ipfix v0.5.9 h1:SsDzrbdZx0xg6WzpRIKo/+RL4+Cccii9sRTclhzli9A=
+github.com/vmware/go-ipfix v0.5.9/go.mod h1:yzbG1rv+yJ8GeMrRm+MDhOV3akygNZUHLhC1pDoD2AY=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=

--- a/pkg/agent/flowexporter/exporter/exporter.go
+++ b/pkg/agent/flowexporter/exporter/exporter.go
@@ -138,7 +138,6 @@ func prepareExporterInputArgs(collectorAddr, collectorProto, nodeName string) ex
 		expInput.IsEncrypted = false
 		expInput.CollectorProtocol = collectorProto
 	}
-	expInput.PathMTU = 0
 
 	return expInput
 }

--- a/pkg/flowaggregator/flowaggregator.go
+++ b/pkg/flowaggregator/flowaggregator.go
@@ -341,7 +341,6 @@ func (fa *flowAggregator) initExportingProcess() error {
 			CollectorProtocol:   fa.externalFlowCollectorProto,
 			ObservationDomainID: fa.observationDomainID,
 			TempRefTimeout:      0,
-			PathMTU:             0,
 			IsEncrypted:         false,
 			SendJSONRecord:      fa.sendJSONRecord,
 		}
@@ -352,7 +351,6 @@ func (fa *flowAggregator) initExportingProcess() error {
 			CollectorProtocol:   fa.externalFlowCollectorProto,
 			ObservationDomainID: fa.observationDomainID,
 			TempRefTimeout:      1800,
-			PathMTU:             0,
 			IsEncrypted:         false,
 			SendJSONRecord:      fa.sendJSONRecord,
 		}

--- a/pkg/ipfix/ipfix_collector.go
+++ b/pkg/ipfix/ipfix_collector.go
@@ -60,9 +60,9 @@ func (cp *ipfixCollectingProcess) GetMsgChan() chan *ipfixentities.Message {
 }
 
 func (cp *ipfixCollectingProcess) GetNumRecordsReceived() int64 {
-	return int64(cp.CollectingProcess.GetNumOfRecordsReceived())
+	return cp.CollectingProcess.GetNumRecordsReceived()
 }
 
 func (cp *ipfixCollectingProcess) GetNumConnToCollector() int64 {
-	return int64(cp.CollectingProcess.GetNumOfConnToCollector())
+	return cp.CollectingProcess.GetNumConnToCollector()
 }

--- a/pkg/ipfix/ipfix_intermediate.go
+++ b/pkg/ipfix/ipfix_intermediate.go
@@ -96,5 +96,5 @@ func (ap *ipfixAggregationProcess) AreExternalFieldsFilled(record ipfixintermedi
 }
 
 func (ap *ipfixAggregationProcess) GetNumFlows() int64 {
-	return int64(ap.AggregationProcess.GetNumberOfFlows())
+	return ap.AggregationProcess.GetNumFlows()
 }

--- a/plugins/octant/go.sum
+++ b/plugins/octant/go.sum
@@ -697,7 +697,7 @@ github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/vmware-tanzu/octant v0.17.0 h1:2H2AiQU5C1RiHxxYrrOosDHHI9eV51nP+e9PjRP+c48=
 github.com/vmware-tanzu/octant v0.17.0/go.mod h1:lA32xKa6icUclg+DjAX/E/Id1cTqwCXZUem3RGEp/2A=
-github.com/vmware/go-ipfix v0.5.8/go.mod h1:yzbG1rv+yJ8GeMrRm+MDhOV3akygNZUHLhC1pDoD2AY=
+github.com/vmware/go-ipfix v0.5.9/go.mod h1:yzbG1rv+yJ8GeMrRm+MDhOV3akygNZUHLhC1pDoD2AY=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -107,7 +107,7 @@ const (
 	busyboxImage        = "projects.registry.vmware.com/library/busybox"
 	nginxImage          = "projects.registry.vmware.com/antrea/nginx"
 	perftoolImage       = "projects.registry.vmware.com/antrea/perftool"
-	ipfixCollectorImage = "projects.registry.vmware.com/antrea/ipfix-collector:v0.5.8"
+	ipfixCollectorImage = "projects.registry.vmware.com/antrea/ipfix-collector:v0.5.9"
 	ipfixCollectorPort  = "4739"
 
 	nginxLBService = "nginx-loadbalancer"


### PR DESCRIPTION
This commit adds changes in [go-ipfix v0.5.9](https://github.com/vmware/go-ipfix/releases/tag/v0.5.9). 

It is expected to be merged with PR #2878.

Signed-off-by: Yanjun Zhou <zhouya@vmware.com>