### PR TITLE
Update the Antrea-live office-hours google doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Your feedback is more than welcome!
 every two weeks on Tuesday at 5AM GMT+1 (United Kingdom time). See Antrea team calendar for localized times.
     - [Meeting minutes](https://github.com/antrea-io/antrea/wiki/Community-Meetings)
     - [Meeting recordings](https://www.youtube.com/playlist?list=PLuzde2hYeDBdw0BuQCYbYqxzoJYY1hfwv)
-  + [Antrea-live office hours](https://docs.google.com/document/d/1iy6pVVwf0pMV7I7YLZkOaFoJCNmCL1AXeSt_ErHQiG4/edit),
+  + [Antrea live office hours](https://antrea.io/live),
 every two weeks on Tuesday at 10PM GMT+1 (United Kingdom time). See Antrea team calendar for localized times.
 * Join our mailing lists to always stay up-to-date with Antrea development:
   + [projectantrea-announce](https://groups.google.com/forum/#!forum/projectantrea-announce)


### PR DESCRIPTION
Fixes #2885

This will have a URL that changes every wk, so, I put it in the google doc.

Later on,  can use `rebrandly` to make a snappy url like antrea.io/live if folks want to help on that front.