### PR TITLE
Validate serviceCIDR configuration only if AntreaProxy is disabled

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -149,7 +149,7 @@ func run(o *Options) error {
 	egressConfig := &config.EgressConfig{
 		ExceptCIDRs: exceptCIDRs,
 	}
-	routeClient, err := route.NewClient(serviceCIDRNet, networkConfig, o.config.NoSNAT, o.config.AntreaProxy.ProxyAll, connectUplinkToBridge)
+	routeClient, err := route.NewClient(networkConfig, o.config.NoSNAT, o.config.AntreaProxy.ProxyAll, connectUplinkToBridge)
 	if err != nil {
 		return fmt.Errorf("error creating route client: %v", err)
 	}

--- a/pkg/agent/route/route_linux.go
+++ b/pkg/agent/route/route_linux.go
@@ -90,7 +90,6 @@ type Client struct {
 	nodeConfig    *config.NodeConfig
 	networkConfig *config.NetworkConfig
 	noSNAT        bool
-	serviceCIDR   *net.IPNet
 	ipt           *iptables.Client
 	// nodeRoutes caches ip routes to remote Pods. It's a map of podCIDR to routes.
 	nodeRoutes sync.Map
@@ -117,11 +116,8 @@ type Client struct {
 }
 
 // NewClient returns a route client.
-// TODO: remove param serviceCIDR after kube-proxy is replaced by Antrea Proxy. This param is not used in this file;
-// leaving it here is to be compatible with the implementation on Windows.
-func NewClient(serviceCIDR *net.IPNet, networkConfig *config.NetworkConfig, noSNAT, proxyAll, connectUplinkToBridge bool) (*Client, error) {
+func NewClient(networkConfig *config.NetworkConfig, noSNAT, proxyAll, connectUplinkToBridge bool) (*Client, error) {
 	return &Client{
-		serviceCIDR:           serviceCIDR,
 		networkConfig:         networkConfig,
 		noSNAT:                noSNAT,
 		proxyAll:              proxyAll,

--- a/pkg/agent/route/route_windows.go
+++ b/pkg/agent/route/route_windows.go
@@ -49,7 +49,6 @@ var (
 type Client struct {
 	nodeConfig     *config.NodeConfig
 	networkConfig  *config.NetworkConfig
-	serviceCIDR    *net.IPNet
 	hostRoutes     *sync.Map
 	fwClient       *winfirewall.Client
 	bridgeInfIndex int
@@ -58,11 +57,9 @@ type Client struct {
 }
 
 // NewClient returns a route client.
-// Todo: remove param serviceCIDR after kube-proxy is replaced by Antrea Proxy completely.
-func NewClient(serviceCIDR *net.IPNet, networkConfig *config.NetworkConfig, noSNAT, proxyAll, connectUplinkToBridge bool) (*Client, error) {
+func NewClient(networkConfig *config.NetworkConfig, noSNAT, proxyAll, connectUplinkToBridge bool) (*Client, error) {
 	return &Client{
 		networkConfig: networkConfig,
-		serviceCIDR:   serviceCIDR,
 		hostRoutes:    &sync.Map{},
 		fwClient:      winfirewall.NewClient(),
 		noSNAT:        noSNAT,

--- a/pkg/agent/route/route_windows_test.go
+++ b/pkg/agent/route/route_windows_test.go
@@ -42,7 +42,6 @@ func TestRouteOperation(t *testing.T) {
 	hostGateway := "Loopback Pseudo-Interface 1"
 	gwLink := getNetLinkIndex("Loopback Pseudo-Interface 1")
 
-	_, serviceCIDR, _ := net.ParseCIDR("1.1.0.0/16")
 	peerNodeIP1 := net.ParseIP("10.0.0.2")
 	peerNodeIP2 := net.ParseIP("10.0.0.3")
 	gwIP1 := net.ParseIP("192.168.2.1")
@@ -51,7 +50,7 @@ func TestRouteOperation(t *testing.T) {
 	gwIP2 := net.ParseIP("192.168.3.1")
 	_, destCIDR2, _ := net.ParseCIDR(dest2)
 
-	client, err := NewClient(serviceCIDR, &config.NetworkConfig{}, true, false, false)
+	client, err := NewClient(&config.NetworkConfig{}, true, false, false)
 	svcStr1 := "1.1.0.10"
 	svcIP1 := net.ParseIP(svcStr1)
 	svcIPNet1 := util.NewIPNet(svcIP1)


### PR DESCRIPTION
Move the validation for serviceCIDR under the condition that AntreaProxy
is disabled. So that the user could not ignore the item when using
AntreaProxy instead of kube-proxy.

Fixes #2935 

Signed-off-by: wenyingd <wenyingd@vmware.com>