### PR TITLE
[Windows][AntreaProxy] Fix route reconcile()

### DIFF
--- a/pkg/agent/controller/noderoute/node_route_controller.go
+++ b/pkg/agent/controller/noderoute/node_route_controller.go
@@ -205,10 +205,8 @@ func (c *Controller) removeStaleGatewayRoutes() error {
 
 		svcs, err := c.svcLister.List(labels.Everything())
 		for _, svc := range svcs {
-			if svc.Spec.Type == corev1.ServiceTypeClusterIP {
-				for _, ip := range svc.Spec.ClusterIPs {
-					desiredClusterIPSvcIPs[ip] = true
-				}
+			for _, ip := range svc.Spec.ClusterIPs {
+				desiredClusterIPSvcIPs[ip] = true
 			}
 		}
 		if err != nil {

--- a/pkg/agent/route/route_windows.go
+++ b/pkg/agent/route/route_windows.go
@@ -354,11 +354,6 @@ func (c *Client) listRoutes() (map[string]*util.Route, error) {
 		if !rt.GatewayAddress.Equal(config.VirtualServiceIPv4) && rt.DestinationSubnet.IP.Equal(util.GetLocalBroadcastIP(rt.DestinationSubnet)) {
 			continue
 		}
-		// If the GatewayAddress equals VirtualServiceIPv4, the route is for ClusterIP Service traffic from the host.
-		// Otherwise, the route is added by kube-proxy, which is needed to access the Service.
-		if !rt.GatewayAddress.Equal(config.VirtualServiceIPv4) && c.serviceCIDR.Contains(rt.DestinationSubnet.IP) {
-			continue
-		}
 		rtMap[rt.DestinationSubnet.String()] = &rt
 	}
 	return rtMap, nil


### PR DESCRIPTION
listRoutes() only considers routes with antrea-gw0 as interface
so no need to consider kube-proxy Service routes. Also for AntreaProxy
Service routes, all of them should be returned and be compared with
desiredClusterIPSvcIPs.

NodePort and LoadBalancer Services also have ClusterIPs so the check
if Service is ClusterIP Service is unnecessary.

Signed-off-by: Zhecheng Li <lzhecheng@vmware.com>