### PR TITLE
Add validating webhook for IPPool

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -4848,6 +4848,28 @@ webhooks:
     scope: Cluster
   sideEffects: None
   timeoutSeconds: 5
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: antrea
+      namespace: kube-system
+      path: /validate/ippool
+  name: ippoolvalidator.antrea.io
+  rules:
+  - apiGroups:
+    - crd.antrea.io
+    apiVersions:
+    - v1alpha2
+    operations:
+    - UPDATE
+    - DELETE
+    resources:
+    - ippools
+    scope: Cluster
+  sideEffects: None
+  timeoutSeconds: 5
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -4850,6 +4850,28 @@ webhooks:
     scope: Cluster
   sideEffects: None
   timeoutSeconds: 5
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: antrea
+      namespace: kube-system
+      path: /validate/ippool
+  name: ippoolvalidator.antrea.io
+  rules:
+  - apiGroups:
+    - crd.antrea.io
+    apiVersions:
+    - v1alpha2
+    operations:
+    - UPDATE
+    - DELETE
+    resources:
+    - ippools
+    scope: Cluster
+  sideEffects: None
+  timeoutSeconds: 5
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -4848,6 +4848,28 @@ webhooks:
     scope: Cluster
   sideEffects: None
   timeoutSeconds: 5
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: antrea
+      namespace: kube-system
+      path: /validate/ippool
+  name: ippoolvalidator.antrea.io
+  rules:
+  - apiGroups:
+    - crd.antrea.io
+    apiVersions:
+    - v1alpha2
+    operations:
+    - UPDATE
+    - DELETE
+    resources:
+    - ippools
+    scope: Cluster
+  sideEffects: None
+  timeoutSeconds: 5
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -4897,6 +4897,28 @@ webhooks:
     scope: Cluster
   sideEffects: None
   timeoutSeconds: 5
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: antrea
+      namespace: kube-system
+      path: /validate/ippool
+  name: ippoolvalidator.antrea.io
+  rules:
+  - apiGroups:
+    - crd.antrea.io
+    apiVersions:
+    - v1alpha2
+    operations:
+    - UPDATE
+    - DELETE
+    resources:
+    - ippools
+    scope: Cluster
+  sideEffects: None
+  timeoutSeconds: 5
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -4853,6 +4853,28 @@ webhooks:
     scope: Cluster
   sideEffects: None
   timeoutSeconds: 5
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: antrea
+      namespace: kube-system
+      path: /validate/ippool
+  name: ippoolvalidator.antrea.io
+  rules:
+  - apiGroups:
+    - crd.antrea.io
+    apiVersions:
+    - v1alpha2
+    operations:
+    - UPDATE
+    - DELETE
+    resources:
+    - ippools
+    scope: Cluster
+  sideEffects: None
+  timeoutSeconds: 5
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/build/yamls/base/controller.yml
+++ b/build/yamls/base/controller.yml
@@ -168,6 +168,21 @@ webhooks:
     admissionReviewVersions: ["v1", "v1beta1"]
     sideEffects: None
     timeoutSeconds: 5
+  - name: "ippoolvalidator.antrea.io"
+    clientConfig:
+      service:
+        name: "antrea"
+        namespace: "kube-system"
+        path: "/validate/ippool"
+    rules:
+      - operations: ["UPDATE", "DELETE"]
+        apiGroups: ["crd.antrea.io"]
+        apiVersions: ["v1alpha2"]
+        resources: ["ippools"]
+        scope: "Cluster"
+    admissionReviewVersions: ["v1", "v1beta1"]
+    sideEffects: None
+    timeoutSeconds: 5
 ---
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService

--- a/cmd/antrea-controller/controller.go
+++ b/cmd/antrea-controller/controller.go
@@ -94,6 +94,7 @@ var allowedPaths = []string{
 	"/validate/clustergroup",
 	"/validate/externalippool",
 	"/validate/egress",
+	"/validate/ippool",
 	"/convert/clustergroup",
 }
 

--- a/docs/feature-gates.md
+++ b/docs/feature-gates.md
@@ -211,11 +211,12 @@ there is a risk of conflicts in CIDR allocation between the two.
 `AntreaIPAM` is a feature that allows flexible control over Pod IP Addressing. This can
 be achieved by configuring custom resource `IPPool` with desired set of IP ranges.
 The pool can be annotated to Namespace, and Antrea will manage IP address assignment for
-corresponding Pods according to pool spec. In future, support will be extended to
+corresponding Pods according to pool spec. In the future, support will be extended to
 Deployments and StatefulSets, as well as requesting specific IP via Pod annotation.
 
 Note that IP pool annotation can not be updated, but rather re-created. IP Pool can be
-extended, but cannot be shrunk if already assigned to a resource.
+extended, but cannot be shrunk if already assigned to a resource. The IP ranges of IP
+Pools must not overlap, otherwise it would lead to undefined behavior.
 
 Traditional `Subnet per Node` IPAM will continue to be used for resources without IP pool
 annotation, or when `AntreaIPAM` feature is disabled.

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -54,6 +54,7 @@ import (
 	"antrea.io/antrea/pkg/apiserver/registry/system/supportbundle"
 	"antrea.io/antrea/pkg/apiserver/storage"
 	"antrea.io/antrea/pkg/controller/egress"
+	"antrea.io/antrea/pkg/controller/ipam"
 	controllernetworkpolicy "antrea.io/antrea/pkg/controller/networkpolicy"
 	"antrea.io/antrea/pkg/controller/querier"
 	"antrea.io/antrea/pkg/controller/stats"
@@ -309,5 +310,9 @@ func installHandlers(c *ExtraConfig, s *genericapiserver.GenericAPIServer) {
 	if features.DefaultFeatureGate.Enabled(features.Egress) {
 		s.Handler.NonGoRestfulMux.HandleFunc("/validate/externalippool", webhook.HandlerForValidateFunc(c.egressController.ValidateExternalIPPool))
 		s.Handler.NonGoRestfulMux.HandleFunc("/validate/egress", webhook.HandlerForValidateFunc(c.egressController.ValidateEgress))
+	}
+
+	if features.DefaultFeatureGate.Enabled(features.AntreaIPAM) {
+		s.Handler.NonGoRestfulMux.HandleFunc("/validate/ippool", webhook.HandlerForValidateFunc(ipam.ValidateIPPool))
 	}
 }

--- a/pkg/controller/ipam/validate.go
+++ b/pkg/controller/ipam/validate.go
@@ -1,0 +1,116 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipam
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	admv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+
+	crdv1alpha2 "antrea.io/antrea/pkg/apis/crd/v1alpha2"
+)
+
+func ValidateIPPool(review *admv1.AdmissionReview) *admv1.AdmissionResponse {
+	var result *metav1.Status
+	var msg string
+	allowed := true
+
+	klog.V(2).Info("Validating IPPool", "request", review.Request)
+	var newObj, oldObj crdv1alpha2.IPPool
+	if review.Request.Object.Raw != nil {
+		if err := json.Unmarshal(review.Request.Object.Raw, &newObj); err != nil {
+			klog.ErrorS(err, "Error de-serializing current IPPool")
+			return newAdmissionResponseForErr(err)
+		}
+	}
+	if review.Request.OldObject.Raw != nil {
+		if err := json.Unmarshal(review.Request.OldObject.Raw, &oldObj); err != nil {
+			klog.ErrorS(err, "Error de-serializing old IPPool")
+			return newAdmissionResponseForErr(err)
+		}
+	}
+
+	switch review.Request.Operation {
+	case admv1.Create:
+		// This shouldn't happen with the webhook configuration we include in the Antrea YAML manifests.
+		klog.V(2).Info("Validating CREATE request for IPPool")
+		// Always allow CREATE request.
+	case admv1.Update:
+		klog.V(2).Info("Validating UPDATE request for IPPool")
+		deletedIPRanges := getIPRangeDifference(oldObj.Spec.IPRanges, newObj.Spec.IPRanges)
+		if len(deletedIPRanges) > 0 {
+			allowed = false
+
+			msg = fmt.Sprintf("existing IPRanges %s cannot be updated or deleted", humanReadableIPRanges(deletedIPRanges))
+		}
+	case admv1.Delete:
+		klog.V(2).Info("Validating DELETE request for IPPool")
+		if len(oldObj.Status.IPAddresses) > 0 {
+			allowed = false
+			msg = fmt.Sprintf("IPPool in use cannot be deleted")
+		}
+	}
+
+	if msg != "" {
+		result = &metav1.Status{
+			Message: msg,
+		}
+	}
+	return &admv1.AdmissionResponse{
+		Allowed: allowed,
+		Result:  result,
+	}
+}
+
+// getIPRangeDifference returns SubnetIPRanges that are in s1 but not in s2.
+func getIPRangeDifference(s1, s2 []crdv1alpha2.SubnetIPRange) []crdv1alpha2.SubnetIPRange {
+	newSet := map[crdv1alpha2.SubnetIPRange]struct{}{}
+	for _, ipRange := range s2 {
+		newSet[ipRange] = struct{}{}
+	}
+
+	var difference []crdv1alpha2.SubnetIPRange
+	for _, ipRange := range s1 {
+		if _, exists := newSet[ipRange]; exists {
+			continue
+		}
+		difference = append(difference, ipRange)
+	}
+	return difference
+}
+
+func humanReadableIPRanges(ipRanges []crdv1alpha2.SubnetIPRange) string {
+	strs := make([]string, len(ipRanges))
+	for i, ipRange := range ipRanges {
+		if ipRange.CIDR != "" {
+			strs[i] = ipRange.CIDR
+		} else {
+			strs[i] = fmt.Sprintf("%s-%s", ipRange.Start, ipRange.End)
+		}
+	}
+	return fmt.Sprintf("[%s]", strings.Join(strs, ","))
+}
+
+func newAdmissionResponseForErr(err error) *admv1.AdmissionResponse {
+	return &admv1.AdmissionResponse{
+		Result: &metav1.Status{
+			Message: err.Error(),
+		},
+	}
+}

--- a/pkg/controller/ipam/validate_test.go
+++ b/pkg/controller/ipam/validate_test.go
@@ -1,0 +1,188 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipam
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	admv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	crdv1alpha2 "antrea.io/antrea/pkg/apis/crd/v1alpha2"
+)
+
+var testIPPool = &crdv1alpha2.IPPool{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "test-ip-pool",
+	},
+	Spec: crdv1alpha2.IPPoolSpec{
+		IPVersion: 4,
+		IPRanges: []crdv1alpha2.SubnetIPRange{
+			{
+				IPRange: crdv1alpha2.IPRange{
+					CIDR: "192.168.0.0/24",
+				},
+				SubnetInfo: crdv1alpha2.SubnetInfo{
+					Gateway:      "192.168.0.1",
+					PrefixLength: 24,
+				},
+			},
+			{
+				IPRange: crdv1alpha2.IPRange{
+					CIDR: "192.168.1.0/24",
+				},
+				SubnetInfo: crdv1alpha2.SubnetInfo{
+					Gateway:      "192.168.1.1",
+					PrefixLength: 24,
+				},
+			},
+			{
+				IPRange: crdv1alpha2.IPRange{
+					Start: "192.168.3.10",
+					End:   "192.168.3.20",
+				},
+				SubnetInfo: crdv1alpha2.SubnetInfo{
+					Gateway:      "192.168.3.1",
+					PrefixLength: 24,
+				},
+			},
+		},
+	},
+	Status: crdv1alpha2.IPPoolStatus{},
+}
+
+func marshal(object runtime.Object) []byte {
+	raw, _ := json.Marshal(object)
+	return raw
+}
+
+func copyAndMutateIPPool(in *crdv1alpha2.IPPool, mutateFunc func(*crdv1alpha2.IPPool)) *crdv1alpha2.IPPool {
+	out := in.DeepCopy()
+	mutateFunc(out)
+	return out
+}
+
+func TestEgressControllerValidateExternalIPPool(t *testing.T) {
+	tests := []struct {
+		name             string
+		request          *admv1.AdmissionRequest
+		expectedResponse *admv1.AdmissionResponse
+	}{
+		{
+			name: "CREATE operation should be allowed",
+			request: &admv1.AdmissionRequest{
+				Name:      "foo",
+				Operation: "CREATE",
+				Object:    runtime.RawExtension{Raw: marshal(testIPPool)},
+			},
+			expectedResponse: &admv1.AdmissionResponse{Allowed: true},
+		},
+		{
+			name: "Deleting IPRange should not be allowed",
+			request: &admv1.AdmissionRequest{
+				Name:      "foo",
+				Operation: "UPDATE",
+				OldObject: runtime.RawExtension{Raw: marshal(testIPPool)},
+				Object: runtime.RawExtension{Raw: marshal(copyAndMutateIPPool(testIPPool, func(pool *crdv1alpha2.IPPool) {
+					pool.Spec.IPRanges = pool.Spec.IPRanges[:1]
+				}))},
+			},
+			expectedResponse: &admv1.AdmissionResponse{
+				Allowed: false,
+				Result: &metav1.Status{
+					Message: "existing IPRanges [192.168.1.0/24,192.168.3.10-192.168.3.20] cannot be updated or deleted",
+				},
+			},
+		},
+		{
+			name: "Updating IPRange should not be allowed",
+			request: &admv1.AdmissionRequest{
+				Name:      "foo",
+				Operation: "UPDATE",
+				OldObject: runtime.RawExtension{Raw: marshal(testIPPool)},
+				Object: runtime.RawExtension{Raw: marshal(copyAndMutateIPPool(testIPPool, func(pool *crdv1alpha2.IPPool) {
+					pool.Spec.IPRanges[0].Gateway = "192.168.0.2"
+				}))},
+			},
+			expectedResponse: &admv1.AdmissionResponse{
+				Allowed: false,
+				Result: &metav1.Status{
+					Message: "existing IPRanges [192.168.0.0/24] cannot be updated or deleted",
+				},
+			},
+		},
+		{
+			name: "Adding IPRange should be allowed",
+			request: &admv1.AdmissionRequest{
+				Name:      "foo",
+				Operation: "UPDATE",
+				OldObject: runtime.RawExtension{Raw: marshal(testIPPool)},
+				Object: runtime.RawExtension{Raw: marshal(copyAndMutateIPPool(testIPPool, func(pool *crdv1alpha2.IPPool) {
+					pool.Spec.IPRanges = append(pool.Spec.IPRanges, crdv1alpha2.SubnetIPRange{
+						IPRange: crdv1alpha2.IPRange{
+							CIDR: "192.168.100.0/24",
+						},
+						SubnetInfo: crdv1alpha2.SubnetInfo{
+							Gateway:      "192.168.100.1",
+							PrefixLength: 24,
+						},
+					})
+				}))},
+			},
+			expectedResponse: &admv1.AdmissionResponse{Allowed: true},
+		},
+		{
+			name: "Deleting IPPool in use should not be allowed",
+			request: &admv1.AdmissionRequest{
+				Name:      "foo",
+				Operation: "DELETE",
+				OldObject: runtime.RawExtension{Raw: marshal(copyAndMutateIPPool(testIPPool, func(pool *crdv1alpha2.IPPool) {
+					pool.Status.IPAddresses = []crdv1alpha2.IPAddressState{
+						{
+							IPAddress: "192.168.0.10",
+						},
+					}
+				}))},
+			},
+			expectedResponse: &admv1.AdmissionResponse{
+				Allowed: false,
+				Result: &metav1.Status{
+					Message: "IPPool in use cannot be deleted",
+				},
+			},
+		},
+		{
+			name: "Deleting IPPool not in use should be allowed",
+			request: &admv1.AdmissionRequest{
+				Name:      "foo",
+				Operation: "DELETE",
+				Object:    runtime.RawExtension{Raw: marshal(testIPPool)},
+			},
+			expectedResponse: &admv1.AdmissionResponse{Allowed: true},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			review := &admv1.AdmissionReview{
+				Request: tt.request,
+			}
+			gotResponse := ValidateIPPool(review)
+			assert.Equal(t, tt.expectedResponse, gotResponse)
+		})
+	}
+}


### PR DESCRIPTION
The patch adds a ValdatingWebhookConfiguration for IPPool:
- For update operation, the IPPool must not shrink
- For delete operation, the IPPool must not be in use

Based on #2871, the only new patch in this PR is https://github.com/antrea-io/antrea/pull/2946/commits/0f81d3a777b842647b25f46324427e166e62c47a