### PR TITLE
[CI] Update trigger phrases for Windows tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,8 +168,7 @@ Here are the trigger phrases for individual checks:
 Here are the trigger phrases for groups of checks:
 
 * `/test-all`: Linux IPv4 tests
-* `/test-windows-all`: Windows IPv4 tests
-* `/test-windows-proxyall-all`: Windows IPv4 tests with proxyAll enabled
+* `/test-windows-all`: Windows IPv4 tests, including e2e tests with proxyAll enabled
 * `/test-ipv6-all`: Linux dual stack tests
 * `/test-ipv6-only-all`: Linux IPv6 only tests
 


### PR DESCRIPTION
proxyall-e2e is included in test-windows-all and remove
test-windows-proxyall-all

Signed-off-by: Zhecheng Li <lzhecheng@vmware.com>