### PR TITLE
Do not calculate broadcast address for IPv6 CIDR

### DIFF
--- a/pkg/controller/egress/controller_test.go
+++ b/pkg/controller/egress/controller_test.go
@@ -547,6 +547,19 @@ func TestSyncEgressIP(t *testing.T) {
 			expectErr:                  true,
 		},
 		{
+			name:                   "[IPv6]Egress with empty EgressIP and proper ExternalIPPool",
+			existingExternalIPPool: newExternalIPPool("ipPoolA", "2021:2::aaa0/124", "", ""),
+			inputEgress: &v1alpha2.Egress{
+				ObjectMeta: metav1.ObjectMeta{Name: "egressA", UID: "uidA"},
+				Spec: v1alpha2.EgressSpec{
+					ExternalIPPool: "ipPoolA",
+				},
+			},
+			expectedEgressIP:           "2021:2::aaa1",
+			expectedExternalIPPoolUsed: 1,
+			expectErr:                  false,
+		},
+		{
 			name:                   "Egress with non-empty EgressIP and proper ExternalIPPool",
 			existingExternalIPPool: newExternalIPPool("ipPoolA", "1.1.1.0/24", "", ""),
 			inputEgress: &v1alpha2.Egress{


### PR DESCRIPTION
IPv6 does not support broadcast address so it doesn't make sense to
exclude it from IP ranges. And the util function GetLocalBroadcastIP
will panic if an IPv6 CIDR is provided.

Signed-off-by: Quan Tian <qtian@vmware.com>