### PR TITLE
Egress traffic bandwidth limit support.

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -1512,6 +1512,8 @@ spec:
                         x-kubernetes-preserve-unknown-fields: true
                     type: object
                 type: object
+              bandwidth:
+                type: string
               egressIP:
                 oneOf:
                 - format: ipv4

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -1512,6 +1512,8 @@ spec:
                         x-kubernetes-preserve-unknown-fields: true
                     type: object
                 type: object
+              bandwidth:
+                type: string
               egressIP:
                 oneOf:
                 - format: ipv4

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -1512,6 +1512,8 @@ spec:
                         x-kubernetes-preserve-unknown-fields: true
                     type: object
                 type: object
+              bandwidth:
+                type: string
               egressIP:
                 oneOf:
                 - format: ipv4

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -1512,6 +1512,8 @@ spec:
                         x-kubernetes-preserve-unknown-fields: true
                     type: object
                 type: object
+              bandwidth:
+                type: string
               egressIP:
                 oneOf:
                 - format: ipv4

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -1512,6 +1512,8 @@ spec:
                         x-kubernetes-preserve-unknown-fields: true
                     type: object
                 type: object
+              bandwidth:
+                type: string
               egressIP:
                 oneOf:
                 - format: ipv4

--- a/build/yamls/base/crds.yml
+++ b/build/yamls/base/crds.yml
@@ -83,6 +83,8 @@ spec:
                 - format: ipv6
               externalIPPool:
                 type: string
+              bandwidth:
+                type: string
           status:
             type: object
             properties:

--- a/pkg/agent/openflow/testing/mock_openflow.go
+++ b/pkg/agent/openflow/testing/mock_openflow.go
@@ -68,6 +68,20 @@ func (mr *MockClientMockRecorder) AddAddressToDNSConjunction(arg0, arg1 interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddAddressToDNSConjunction", reflect.TypeOf((*MockClient)(nil).AddAddressToDNSConjunction), arg0, arg1)
 }
 
+// AddMeterFlow mocks base method
+func (m *MockClient) AddMeterFlow(arg0, arg1 uint32) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddMeterFlow", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddMeterFlow indicates an expected call of AddMeterFlow
+func (mr *MockClientMockRecorder) AddMeterFlow(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddMeterFlow", reflect.TypeOf((*MockClient)(nil).AddMeterFlow), arg0, arg1)
+}
+
 // AddPolicyRuleAddress mocks base method
 func (m *MockClient) AddPolicyRuleAddress(arg0 uint32, arg1 types.AddressType, arg2 []types.Address, arg3 *uint16) error {
 	m.ctrl.T.Helper()
@@ -108,6 +122,20 @@ func (m *MockClient) DeleteAddressFromDNSConjunction(arg0 uint32, arg1 []types.A
 func (mr *MockClientMockRecorder) DeleteAddressFromDNSConjunction(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAddressFromDNSConjunction", reflect.TypeOf((*MockClient)(nil).DeleteAddressFromDNSConjunction), arg0, arg1)
+}
+
+// DeleteMeterFlow mocks base method
+func (m *MockClient) DeleteMeterFlow(arg0 uint32) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteMeterFlow", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteMeterFlow indicates an expected call of DeleteMeterFlow
+func (mr *MockClientMockRecorder) DeleteMeterFlow(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMeterFlow", reflect.TypeOf((*MockClient)(nil).DeleteMeterFlow), arg0)
 }
 
 // DeletePolicyRuleAddress mocks base method
@@ -407,17 +435,17 @@ func (mr *MockClientMockRecorder) InstallPodFlows(arg0, arg1, arg2, arg3 interfa
 }
 
 // InstallPodSNATFlows mocks base method
-func (m *MockClient) InstallPodSNATFlows(arg0 uint32, arg1 net.IP, arg2 uint32) error {
+func (m *MockClient) InstallPodSNATFlows(arg0 uint32, arg1 net.IP, arg2, arg3 uint32) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstallPodSNATFlows", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "InstallPodSNATFlows", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InstallPodSNATFlows indicates an expected call of InstallPodSNATFlows
-func (mr *MockClientMockRecorder) InstallPodSNATFlows(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) InstallPodSNATFlows(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallPodSNATFlows", reflect.TypeOf((*MockClient)(nil).InstallPodSNATFlows), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallPodSNATFlows", reflect.TypeOf((*MockClient)(nil).InstallPodSNATFlows), arg0, arg1, arg2, arg3)
 }
 
 // InstallPolicyRuleFlows mocks base method

--- a/pkg/apis/crd/v1alpha2/types.go
+++ b/pkg/apis/crd/v1alpha2/types.go
@@ -226,6 +226,8 @@ type EgressSpec struct {
 	// If it is non-empty, the EgressIP will be assigned to a Node specified by the pool automatically and will failover
 	// to a different Node when the Node becomes unreachable.
 	ExternalIPPool string `json:"externalIPPool"`
+	// The Bandwidth limit of the selected workloads traffic.
+	Bandwidth string `json:"bandwidth,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controller/egress/validate.go
+++ b/pkg/controller/egress/validate.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/klog/v2"
 
 	crdv1alpha2 "antrea.io/antrea/pkg/apis/crd/v1alpha2"
+	bandwidthutil "antrea.io/antrea/pkg/util/bandwidth"
 )
 
 func (c *EgressController) ValidateExternalIPPool(review *admv1.AdmissionReview) *admv1.AdmissionResponse {
@@ -100,6 +101,10 @@ func (c *EgressController) ValidateEgress(review *admv1.AdmissionReview) *admv1.
 	}
 
 	shouldAllow := func(oldEgress, newEgress *crdv1alpha2.Egress) (bool, string) {
+		// Allow it if Egress Bandwidth is valid.
+		if _, err := bandwidthutil.ParseBandwidth(newEgress.Spec.Bandwidth, bandwidthutil.Kilo); err != nil {
+			return false, fmt.Sprintf("Bandwidth %s is not valid, %v", newEgress.Spec.Bandwidth, err)
+		}
 		// Allow it if EgressIP and ExternalIPPool don't change.
 		if newEgress.Spec.EgressIP == oldEgress.Spec.EgressIP && newEgress.Spec.ExternalIPPool == oldEgress.Spec.ExternalIPPool {
 			return true, ""

--- a/pkg/util/bandwidth/bandwidth.go
+++ b/pkg/util/bandwidth/bandwidth.go
@@ -1,0 +1,57 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bandwidth
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+const (
+	Kilo resource.Scale = 3
+	Mega resource.Scale = 6
+	Giga resource.Scale = 9
+)
+
+var minRsrc = resource.MustParse("1k")
+var maxRsrc = resource.MustParse("1T")
+
+// validateBandwidthIsReasonable returns the bandwidth is in valid scale.
+func validateBandwidthIsReasonable(rsrc *resource.Quantity) error {
+	if rsrc.Value() < minRsrc.Value() {
+		return fmt.Errorf("resource is unreasonably small (< 1kbit)")
+	}
+	if rsrc.Value() > maxRsrc.Value() {
+		return fmt.Errorf("resoruce is unreasonably large (> 1Tbit)")
+	}
+	return nil
+}
+
+// ParseBandwidth returns the bandwidth from the given string
+func ParseBandwidth(bandwidthStr string, scale resource.Scale) (bandwidth uint32, err error) {
+	if bandwidthStr == "" {
+		return 0, nil
+	}
+	bandwidthValue, err := resource.ParseQuantity(bandwidthStr)
+	if err != nil {
+		return 0, err
+	}
+	if err := validateBandwidthIsReasonable(&bandwidthValue); err != nil {
+		return 0, err
+	}
+	bandwidth = uint32(bandwidthValue.ScaledValue(scale))
+	return bandwidth, nil
+}

--- a/pkg/util/bandwidth/bandwidth_test.go
+++ b/pkg/util/bandwidth/bandwidth_test.go
@@ -1,0 +1,77 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bandwidth
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestParseBandwidth(t *testing.T) {
+	fakeBandwidth1, _ := resource.ParseQuantity("2M")
+	fakeBandwidth2, _ := resource.ParseQuantity("2G")
+
+	testcases := []struct {
+		bandwidthString   string
+		expectedScale     resource.Scale
+		expectedBandwidth uint32
+		expectedError     error
+	}{
+		{
+			bandwidthString:   "",
+			expectedScale:     Mega,
+			expectedBandwidth: uint32(0),
+			expectedError:     nil,
+		},
+		{
+			bandwidthString:   "2M",
+			expectedScale:     Mega,
+			expectedBandwidth: uint32(fakeBandwidth1.ScaledValue(Mega)),
+			expectedError:     nil,
+		},
+		{
+			bandwidthString:   "2G",
+			expectedScale:     Giga,
+			expectedBandwidth: uint32(fakeBandwidth2.ScaledValue(Giga)),
+			expectedError:     nil,
+		},
+		{
+			bandwidthString:   "2T",
+			expectedScale:     resource.Tera,
+			expectedBandwidth: uint32(0),
+			expectedError:     fmt.Errorf("resoruce is unreasonably large (> 1Tbit)"),
+		},
+		{
+			bandwidthString:   "2A",
+			expectedScale:     resource.Peta,
+			expectedBandwidth: uint32(0),
+			expectedError:     fmt.Errorf("quantities must match the regular expression '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'"),
+		},
+	}
+	for _, tc := range testcases {
+		parsedBandwidth, err := ParseBandwidth(tc.bandwidthString, tc.expectedScale)
+		if tc.expectedError != nil {
+			assert.Equal(t, tc.expectedError, err)
+		} else {
+			require.Nil(t, err)
+			assert.Equal(t, tc.expectedBandwidth, parsedBandwidth)
+		}
+
+	}
+}

--- a/test/integration/agent/openflow_test.go
+++ b/test/integration/agent/openflow_test.go
@@ -1434,10 +1434,10 @@ func TestSNATFlows(t *testing.T) {
 
 	c.InstallSNATMarkFlows(snatIP, snatMark)
 	c.InstallSNATMarkFlows(snatIPV6, snatMarkV6)
-	c.InstallPodSNATFlows(podOFPort, snatIP, snatMark)
-	c.InstallPodSNATFlows(podOFPortRemote, snatIP, 0)
-	c.InstallPodSNATFlows(podOFPortV6, snatIPV6, snatMarkV6)
-	c.InstallPodSNATFlows(podOFPortRemoteV6, snatIPV6, 0)
+	c.InstallPodSNATFlows(podOFPort, snatIP, snatMark, 0)
+	c.InstallPodSNATFlows(podOFPortRemote, snatIP, 0, 0)
+	c.InstallPodSNATFlows(podOFPortV6, snatIPV6, snatMarkV6, 0)
+	c.InstallPodSNATFlows(podOFPortRemoteV6, snatIPV6, 0, 0)
 	for _, tableFlow := range expectedFlows {
 		ofTestUtils.CheckFlowExists(t, ovsCtlClient, tableFlow.tableID, true, tableFlow.flows)
 	}


### PR DESCRIPTION
This PR implements support for Egress traffic bandwidth limit. Use OpenFlow Meter to limit the selected workloads Egress traffic.

Fixes: #2766

Signed-off-by: Wu zhengdong <zhengdong.wu@transwarp.io>