### PR TITLE
Add example values of the clusterCIDRs parameter of NodeIPAM

### DIFF
--- a/docs/antrea-ipam.md
+++ b/docs/antrea-ipam.md
@@ -31,7 +31,8 @@ NodeIPAM dictionary contains the following items:
 controller. Default is false.
 
 - `clusterCIDRs`: CIDR Ranges for Pods in cluster. String array containing single
-CIDR range, or multiple ranges. The CIDRs could be either IPv4 or IPv6.
+CIDR range, or multiple ranges. The CIDRs could be either IPv4 or IPv6. Example
+values: `[172.100.0.0/16]`, `[172.100.0.0/20, 172.100.32.0/20, fd00:172:100::/64]`.
 
 - `serviceCIDR`: CIDR Range for IPv4 Services in cluster. It is not necessary to
 specify it when there is no overlap with clusterCIDRs.

--- a/docs/eks-installation.md
+++ b/docs/eks-installation.md
@@ -98,8 +98,8 @@ kubectl -n kube-system delete daemonset aws-node
 ### 3. Install Antrea
 
 First, download the Antrea deployment yaml. Note that `encap` mode support for
-EKS was added in release 1.3.0, which means you cannot pick a release older
-than 1.3.0. For any given release `<TAG>` (e.g. `v1.3.0`), get the Antrea
+EKS was added in release 1.4.0, which means you cannot pick a release older
+than 1.4.0. For any given release `<TAG>` (e.g. `v1.4.0`), get the Antrea
 deployment yaml at:
 
 ```text


### PR DESCRIPTION
Also fixed a mistake in eks-installation.md that encap mode for EKS
requires Antrea version >= 1.4, which is the first version with the
Antrea NodeIPAM feature.