### PR TITLE
Fix exporter benchmark failures

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -219,10 +219,10 @@ func run(o *Options) error {
 	v4GroupCounter := proxytypes.NewGroupCounter(false, groupIDUpdates)
 	v6GroupCounter := proxytypes.NewGroupCounter(true, groupIDUpdates)
 
+	v4Enabled := config.IsIPv4Enabled(nodeConfig, networkConfig.TrafficEncapMode)
+	v6Enabled := config.IsIPv6Enabled(nodeConfig, networkConfig.TrafficEncapMode)
 	var proxier proxy.Proxier
 	if features.DefaultFeatureGate.Enabled(features.AntreaProxy) {
-		v4Enabled := config.IsIPv4Enabled(nodeConfig, networkConfig.TrafficEncapMode)
-		v6Enabled := config.IsIPv6Enabled(nodeConfig, networkConfig.TrafficEncapMode)
 		proxyAll := o.config.AntreaProxy.ProxyAll
 		skipServices := o.config.AntreaProxy.SkipServices
 
@@ -370,9 +370,11 @@ func run(o *Options) error {
 			nodeRouteController,
 			networkConfig.TrafficEncapMode,
 			nodeConfig,
+			v4Enabled,
+			v6Enabled,
 			serviceCIDRNet,
 			serviceCIDRNetv6,
-			&ovsDatapathType,
+			ovsDatapathType,
 			features.DefaultFeatureGate.Enabled(features.AntreaProxy),
 			networkPolicyController,
 			flowExporterOptions)

--- a/pkg/agent/flowexporter/exporter/exporter.go
+++ b/pkg/agent/flowexporter/exporter/exporter.go
@@ -149,8 +149,8 @@ func prepareExporterInputArgs(collectorAddr, collectorProto, nodeName string) ex
 }
 
 func NewFlowExporter(ifaceStore interfacestore.InterfaceStore, proxier proxy.Proxier, k8sClient kubernetes.Interface, nodeRouteController *noderoute.Controller,
-	trafficEncapMode config.TrafficEncapModeType, nodeConfig *config.NodeConfig, serviceCIDRNet, serviceCIDRNetv6 *net.IPNet, ovsDatapathType *ovsconfig.OVSDatapathType,
-	proxyEnabled bool, npQuerier querier.AgentNetworkPolicyInfoQuerier, o *flowexporter.FlowExporterOptions) (*FlowExporter, error) {
+	trafficEncapMode config.TrafficEncapModeType, nodeConfig *config.NodeConfig, v4Enabled, v6Enabled bool, serviceCIDRNet, serviceCIDRNetv6 *net.IPNet,
+	ovsDatapathType ovsconfig.OVSDatapathType, proxyEnabled bool, npQuerier querier.AgentNetworkPolicyInfoQuerier, o *flowexporter.FlowExporterOptions) (*FlowExporter, error) {
 	// Initialize IPFIX registry
 	registry := ipfix.NewIPFIXRegistry()
 	registry.LoadRegistry()
@@ -162,10 +162,7 @@ func NewFlowExporter(ifaceStore interfacestore.InterfaceStore, proxier proxy.Pro
 	}
 	expInput := prepareExporterInputArgs(o.FlowCollectorAddr, o.FlowCollectorProto, nodeName)
 
-	v4Enabled := config.IsIPv4Enabled(nodeConfig, trafficEncapMode)
-	v6Enabled := config.IsIPv6Enabled(nodeConfig, trafficEncapMode)
-
-	connTrackDumper := connections.InitializeConnTrackDumper(nodeConfig, serviceCIDRNet, serviceCIDRNetv6, *ovsDatapathType, proxyEnabled)
+	connTrackDumper := connections.InitializeConnTrackDumper(nodeConfig, serviceCIDRNet, serviceCIDRNetv6, ovsDatapathType, proxyEnabled)
 	denyConnStore := connections.NewDenyConnectionStore(ifaceStore, proxier, o)
 	conntrackConnStore := connections.NewConntrackConnectionStore(connTrackDumper, v4Enabled, v6Enabled, npQuerier, ifaceStore, proxier, o)
 


### PR DESCRIPTION
Add a dedicated initialization function for testing purpose - `NewFlowExporterForTest`. 

Fixes: #2984 

Signed-off-by: heanlan <hanlan@vmware.com>