### PR TITLE
Bypass SNAT table for packets to Node's transport address

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -610,11 +610,11 @@ func (i *Initializer) configureGatewayInterface(gatewayIface *interfacestore.Int
 	gatewayIface.IPs = []net.IP{}
 	if i.networkConfig.TrafficEncapMode.IsNetworkPolicyOnly() {
 		// Assign IP to gw as required by SpoofGuard.
-		if i.nodeConfig.NodeIPv4Addr != nil {
+		if i.nodeConfig.NodeTransportIPv4Addr != nil {
 			i.nodeConfig.GatewayConfig.IPv4 = i.nodeConfig.NodeTransportIPv4Addr.IP
 			gatewayIface.IPs = append(gatewayIface.IPs, i.nodeConfig.NodeTransportIPv4Addr.IP)
 		}
-		if i.nodeConfig.NodeIPv6Addr != nil {
+		if i.nodeConfig.NodeTransportIPv6Addr != nil {
 			i.nodeConfig.GatewayConfig.IPv6 = i.nodeConfig.NodeTransportIPv6Addr.IP
 			gatewayIface.IPs = append(gatewayIface.IPs, i.nodeConfig.NodeTransportIPv6Addr.IP)
 		}

--- a/pkg/agent/agent_linux.go
+++ b/pkg/agent/agent_linux.go
@@ -47,14 +47,16 @@ func (i *Initializer) prepareOVSBridge() error {
 	klog.Infof("Preparing OVS bridge for AntreaFlexibleIPAM")
 	// Get uplink network configuration.
 	// TODO(gran): support IPv6
-	_, _, adapter, err := util.GetIPNetDeviceFromIP(&utilip.DualStackIPs{IPv4: i.nodeConfig.NodeIPv4Addr.IP})
+	// Use the transport IP to configure the uplink interface. The transport IP is the Node's IP if there is only one
+	// interface on the Node or the transport interface is not configured.
+	_, _, adapter, err := util.GetIPNetDeviceFromIP(&utilip.DualStackIPs{IPv4: i.nodeConfig.NodeTransportIPv4Addr.IP})
 	if err != nil {
 		return err
 	}
 	uplinkNetConfig := i.nodeConfig.UplinkNetConfig
 	uplinkNetConfig.Name = adapter.Name
 	uplinkNetConfig.MAC = adapter.HardwareAddr
-	uplinkNetConfig.IP = i.nodeConfig.NodeIPv4Addr
+	uplinkNetConfig.IP = i.nodeConfig.NodeTransportIPv4Addr
 	uplinkNetConfig.Index = adapter.Index
 	// Gateway and DNSServers are not configured at adapter in Linux
 	// Limitation: dynamic DNS servers will be lost after DHCP lease expired

--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -815,22 +815,7 @@ func (c *client) Initialize(roundInfo types.RoundInfo, nodeConfig *config.NodeCo
 func (c *client) InstallExternalFlows(exceptCIDRs []net.IPNet) error {
 	localGatewayMAC := c.nodeConfig.GatewayConfig.MAC
 
-	var flows []binding.Flow
-	var ipv4CIDRs []net.IPNet
-	var ipv6CIDRs []net.IPNet
-	for _, cidr := range exceptCIDRs {
-		if cidr.IP.To4() == nil {
-			ipv6CIDRs = append(ipv6CIDRs, cidr)
-		} else {
-			ipv4CIDRs = append(ipv4CIDRs, cidr)
-		}
-	}
-	if c.nodeConfig.NodeIPv4Addr != nil && c.nodeConfig.PodIPv4CIDR != nil {
-		flows = c.externalFlows(c.nodeConfig.NodeIPv4Addr.IP, *c.nodeConfig.PodIPv4CIDR, localGatewayMAC, ipv4CIDRs)
-	}
-	if c.nodeConfig.NodeIPv6Addr != nil && c.nodeConfig.PodIPv6CIDR != nil {
-		flows = append(flows, c.externalFlows(c.nodeConfig.NodeIPv6Addr.IP, *c.nodeConfig.PodIPv6CIDR, localGatewayMAC, ipv6CIDRs)...)
-	}
+	flows := c.externalFlows(localGatewayMAC, exceptCIDRs)
 	if err := c.ofEntryOperations.AddAll(flows); err != nil {
 		return fmt.Errorf("failed to install flows for external communication: %v", err)
 	}


### PR DESCRIPTION
1. Bypass SNAT table if the destination of Pod's traffic is either the
    Node's management IP or transport IP in Egress feature.
2. Remove matching IP/IPv6 protocol in L3RoutingTable flows if no L3/L4
    match conditions are specified.

Fixes #2997 

Signed-off-by: wenyingd <wenyingd@vmware.com>