### PR TITLE
Use go 1.17 to build release assets

### DIFF
--- a/.github/workflows/upload_release_assets.yml
+++ b/.github/workflows/upload_release_assets.yml
@@ -9,6 +9,10 @@ jobs:
   build:
     runs-on: [ubuntu-latest]
     steps:
+    - name: Set up Go 1.17
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17
     - uses: actions/checkout@v2
     - name: Build assets
       env:


### PR DESCRIPTION
For some reason, I forgot to use the setup-go action for that workflow
when I added it, which means that we have been using the default Go
version provided by the Github runners since the beginning. The default
Go version is [currently 1.15](https://github.com/actions/virtual-environments/blob/8fd74ebe0f0706cb6aa2cc01f5863961d01173e9/images/linux/toolsets/toolset-2004.json#L52), which is not maintained.

We now use the setup-go action to use the same Go version as all other
workflows (1.17).

Signed-off-by: Antonin Bas <abas@vmware.com>