### PR TITLE
Fix IPAM doc and enhance validation 

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -4239,11 +4239,12 @@ data:
     # Enable the integrated Node IPAM controller within the Antrea controller.
     #  enableNodeIPAM: false
 
-    # CIDR Ranges for Pods in cluster. String array containing single CIDR range, or multiple ranges.
-    # The CIDRs could be either IPv4 or IPv6. Value ignored when enableNodeIPAM is false.
+    # CIDR ranges for Pods in cluster. String array containing single CIDR range, or multiple ranges.
+    # The CIDRs could be either IPv4 or IPv6. At most one CIDR may be specified for each IP family.
+    # Value ignored when enableNodeIPAM is false.
     #  clusterCIDRs: []
 
-    # CIDR Ranges for Services in cluster. It is not necessary to specify it when there is no overlap with clusterCIDRs.
+    # CIDR ranges for Services in cluster. It is not necessary to specify it when there is no overlap with clusterCIDRs.
     # Value ignored when enableNodeIPAM is false.
     #  serviceCIDR:
     #  serviceCIDRv6:
@@ -4260,7 +4261,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-527f7cfhcm
+  name: antrea-config-6dtt4hkmmm
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4331,7 +4332,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-527f7cfhcm
+          value: antrea-config-6dtt4hkmmm
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4382,7 +4383,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-527f7cfhcm
+          name: antrea-config-6dtt4hkmmm
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4663,7 +4664,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-527f7cfhcm
+          name: antrea-config-6dtt4hkmmm
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -4239,11 +4239,12 @@ data:
     # Enable the integrated Node IPAM controller within the Antrea controller.
     #  enableNodeIPAM: false
 
-    # CIDR Ranges for Pods in cluster. String array containing single CIDR range, or multiple ranges.
-    # The CIDRs could be either IPv4 or IPv6. Value ignored when enableNodeIPAM is false.
+    # CIDR ranges for Pods in cluster. String array containing single CIDR range, or multiple ranges.
+    # The CIDRs could be either IPv4 or IPv6. At most one CIDR may be specified for each IP family.
+    # Value ignored when enableNodeIPAM is false.
     #  clusterCIDRs: []
 
-    # CIDR Ranges for Services in cluster. It is not necessary to specify it when there is no overlap with clusterCIDRs.
+    # CIDR ranges for Services in cluster. It is not necessary to specify it when there is no overlap with clusterCIDRs.
     # Value ignored when enableNodeIPAM is false.
     #  serviceCIDR:
     #  serviceCIDRv6:
@@ -4260,7 +4261,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-527f7cfhcm
+  name: antrea-config-6dtt4hkmmm
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4331,7 +4332,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-527f7cfhcm
+          value: antrea-config-6dtt4hkmmm
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4382,7 +4383,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-527f7cfhcm
+          name: antrea-config-6dtt4hkmmm
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4665,7 +4666,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-527f7cfhcm
+          name: antrea-config-6dtt4hkmmm
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -4239,11 +4239,12 @@ data:
     # Enable the integrated Node IPAM controller within the Antrea controller.
     #  enableNodeIPAM: false
 
-    # CIDR Ranges for Pods in cluster. String array containing single CIDR range, or multiple ranges.
-    # The CIDRs could be either IPv4 or IPv6. Value ignored when enableNodeIPAM is false.
+    # CIDR ranges for Pods in cluster. String array containing single CIDR range, or multiple ranges.
+    # The CIDRs could be either IPv4 or IPv6. At most one CIDR may be specified for each IP family.
+    # Value ignored when enableNodeIPAM is false.
     #  clusterCIDRs: []
 
-    # CIDR Ranges for Services in cluster. It is not necessary to specify it when there is no overlap with clusterCIDRs.
+    # CIDR ranges for Services in cluster. It is not necessary to specify it when there is no overlap with clusterCIDRs.
     # Value ignored when enableNodeIPAM is false.
     #  serviceCIDR:
     #  serviceCIDRv6:
@@ -4260,7 +4261,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-mk687f488f
+  name: antrea-config-25kc566684
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4331,7 +4332,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-mk687f488f
+          value: antrea-config-25kc566684
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4382,7 +4383,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-mk687f488f
+          name: antrea-config-25kc566684
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4666,7 +4667,7 @@ spec:
           path: /home/kubernetes/bin
         name: host-cni-bin
       - configMap:
-          name: antrea-config-mk687f488f
+          name: antrea-config-25kc566684
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -4244,11 +4244,12 @@ data:
     # Enable the integrated Node IPAM controller within the Antrea controller.
     #  enableNodeIPAM: false
 
-    # CIDR Ranges for Pods in cluster. String array containing single CIDR range, or multiple ranges.
-    # The CIDRs could be either IPv4 or IPv6. Value ignored when enableNodeIPAM is false.
+    # CIDR ranges for Pods in cluster. String array containing single CIDR range, or multiple ranges.
+    # The CIDRs could be either IPv4 or IPv6. At most one CIDR may be specified for each IP family.
+    # Value ignored when enableNodeIPAM is false.
     #  clusterCIDRs: []
 
-    # CIDR Ranges for Services in cluster. It is not necessary to specify it when there is no overlap with clusterCIDRs.
+    # CIDR ranges for Services in cluster. It is not necessary to specify it when there is no overlap with clusterCIDRs.
     # Value ignored when enableNodeIPAM is false.
     #  serviceCIDR:
     #  serviceCIDRv6:
@@ -4265,7 +4266,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-2k4k228tc7
+  name: antrea-config-tc6kb6tbkh
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4345,7 +4346,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-2k4k228tc7
+          value: antrea-config-tc6kb6tbkh
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4396,7 +4397,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-2k4k228tc7
+          name: antrea-config-tc6kb6tbkh
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4712,7 +4713,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-2k4k228tc7
+          name: antrea-config-tc6kb6tbkh
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-kind.yml
+++ b/build/yamls/antrea-kind.yml
@@ -4244,11 +4244,12 @@ data:
     # Enable the integrated Node IPAM controller within the Antrea controller.
     #  enableNodeIPAM: false
 
-    # CIDR Ranges for Pods in cluster. String array containing single CIDR range, or multiple ranges.
-    # The CIDRs could be either IPv4 or IPv6. Value ignored when enableNodeIPAM is false.
+    # CIDR ranges for Pods in cluster. String array containing single CIDR range, or multiple ranges.
+    # The CIDRs could be either IPv4 or IPv6. At most one CIDR may be specified for each IP family.
+    # Value ignored when enableNodeIPAM is false.
     #  clusterCIDRs: []
 
-    # CIDR Ranges for Services in cluster. It is not necessary to specify it when there is no overlap with clusterCIDRs.
+    # CIDR ranges for Services in cluster. It is not necessary to specify it when there is no overlap with clusterCIDRs.
     # Value ignored when enableNodeIPAM is false.
     #  serviceCIDR:
     #  serviceCIDRv6:
@@ -4265,7 +4266,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-f7ctgtgb6b
+  name: antrea-config-d4hfbm5d8h
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4336,7 +4337,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-f7ctgtgb6b
+          value: antrea-config-d4hfbm5d8h
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4387,7 +4388,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-f7ctgtgb6b
+          name: antrea-config-d4hfbm5d8h
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4664,7 +4665,7 @@ spec:
           type: CharDevice
         name: dev-tun
       - configMap:
-          name: antrea-config-f7ctgtgb6b
+          name: antrea-config-d4hfbm5d8h
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -4244,11 +4244,12 @@ data:
     # Enable the integrated Node IPAM controller within the Antrea controller.
     #  enableNodeIPAM: false
 
-    # CIDR Ranges for Pods in cluster. String array containing single CIDR range, or multiple ranges.
-    # The CIDRs could be either IPv4 or IPv6. Value ignored when enableNodeIPAM is false.
+    # CIDR ranges for Pods in cluster. String array containing single CIDR range, or multiple ranges.
+    # The CIDRs could be either IPv4 or IPv6. At most one CIDR may be specified for each IP family.
+    # Value ignored when enableNodeIPAM is false.
     #  clusterCIDRs: []
 
-    # CIDR Ranges for Services in cluster. It is not necessary to specify it when there is no overlap with clusterCIDRs.
+    # CIDR ranges for Services in cluster. It is not necessary to specify it when there is no overlap with clusterCIDRs.
     # Value ignored when enableNodeIPAM is false.
     #  serviceCIDR:
     #  serviceCIDRv6:
@@ -4265,7 +4266,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-ckdtm6hc68
+  name: antrea-config-786ttm24c7
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4336,7 +4337,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-ckdtm6hc68
+          value: antrea-config-786ttm24c7
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4387,7 +4388,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-ckdtm6hc68
+          name: antrea-config-786ttm24c7
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4668,7 +4669,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-ckdtm6hc68
+          name: antrea-config-786ttm24c7
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/base/conf/antrea-controller.conf
+++ b/build/yamls/base/conf/antrea-controller.conf
@@ -66,11 +66,12 @@ nodeIPAM:
 # Enable the integrated Node IPAM controller within the Antrea controller.
 #  enableNodeIPAM: false
 
-# CIDR Ranges for Pods in cluster. String array containing single CIDR range, or multiple ranges.
-# The CIDRs could be either IPv4 or IPv6. Value ignored when enableNodeIPAM is false.
+# CIDR ranges for Pods in cluster. String array containing single CIDR range, or multiple ranges.
+# The CIDRs could be either IPv4 or IPv6. At most one CIDR may be specified for each IP family.
+# Value ignored when enableNodeIPAM is false.
 #  clusterCIDRs: []
 
-# CIDR Ranges for Services in cluster. It is not necessary to specify it when there is no overlap with clusterCIDRs.
+# CIDR ranges for Services in cluster. It is not necessary to specify it when there is no overlap with clusterCIDRs.
 # Value ignored when enableNodeIPAM is false.
 #  serviceCIDR:
 #  serviceCIDRv6:

--- a/cmd/antrea-controller/options.go
+++ b/cmd/antrea-controller/options.go
@@ -89,6 +89,13 @@ func (o *Options) validateNodeIPAMControllerOptions() error {
 		return fmt.Errorf("cluster CIDRs %v is invalid", o.config.NodeIPAM.ClusterCIDRs)
 	}
 
+	if len(cidrs) == 0 {
+		return fmt.Errorf("at least one cluster CIDR must be specified")
+	}
+	if len(cidrs) > 2 {
+		return fmt.Errorf("at most two cluster CIDRs may be specified")
+	}
+
 	hasIP4, hasIP6 := false, false
 	for _, cidr := range cidrs {
 		if cidr.IP.To4() == nil {
@@ -97,6 +104,12 @@ func (o *Options) validateNodeIPAMControllerOptions() error {
 			hasIP4 = true
 		}
 	}
+
+	dualStack := hasIP4 && hasIP6
+	if len(cidrs) > 1 && !dualStack {
+		return fmt.Errorf("at most one cluster CIDR may be specified for each IP family")
+	}
+
 	if hasIP4 {
 		if o.config.NodeIPAM.NodeCIDRMaskSizeIPv4 < ipamIPv4MaskLo || o.config.NodeIPAM.NodeCIDRMaskSizeIPv4 > ipamIPv4MaskHi {
 			return fmt.Errorf("node IPv4 CIDR mask size %d is invalid, should be between %d and %d",

--- a/docs/antrea-ipam.md
+++ b/docs/antrea-ipam.md
@@ -30,14 +30,15 @@ NodeIPAM dictionary contains the following items:
 - `enableNodeIPAM`: Enable the integrated NodeIPAM controller within the Antrea
 controller. Default is false.
 
-- `clusterCIDRs`: CIDR Ranges for Pods in cluster. String array containing single
-CIDR range, or multiple ranges. The CIDRs could be either IPv4 or IPv6. Example
-values: `[172.100.0.0/16]`, `[172.100.0.0/20, 172.100.32.0/20, fd00:172:100::/64]`.
+- `clusterCIDRs`: CIDR ranges for Pods in cluster. String array containing single
+CIDR range, or multiple ranges. The CIDRs could be either IPv4 or IPv6. At most
+one CIDR may be specified for each IP family. Example values:
+`[172.100.0.0/16]`, `[172.100.0.0/20, fd00:172:100::/60]`.
 
-- `serviceCIDR`: CIDR Range for IPv4 Services in cluster. It is not necessary to
+- `serviceCIDR`: CIDR range for IPv4 Services in cluster. It is not necessary to
 specify it when there is no overlap with clusterCIDRs.
 
-- `serviceCIDRv6`: CIDR Range for IPv6 Services in cluster. It is not necessary to
+- `serviceCIDRv6`: CIDR range for IPv6 Services in cluster. It is not necessary to
   specify it when there is no overlap with clusterCIDRs.
 
 - `nodeCIDRMaskSizeIPv4`: Mask size for IPv4 Node CIDR in IPv4 or dual-stack

--- a/pkg/config/controller/config.go
+++ b/pkg/config/controller/config.go
@@ -22,10 +22,11 @@ type NodeIPAMConfig struct {
 	// Enable the integrated node IPAM controller within the Antrea controller.
 	// Defaults to false.
 	EnableNodeIPAM bool `yaml:"enableNodeIPAM,omitempty"`
-	// CIDR Ranges for Pods in cluster. Value can contain a single CIDR range, or multiple ranges, separated by commas.
-	// The CIDRs could be either IPv4 or IPv6. Value ignored when EnableNodeIPAM is false.
+	// CIDR ranges for Pods in cluster. String array containing single CIDR range, or multiple ranges. The CIDRs could
+	// be either IPv4 or IPv6. At most one CIDR may be specified for each IP family. Value ignored when EnableNodeIPAM
+	// is false.
 	ClusterCIDRs []string `yaml:"clusterCIDRs,omitempty"`
-	// CIDR Ranges for Services in cluster. It is not necessary to specify it when there is no overlap with clusterCIDRs.
+	// CIDR ranges for Services in cluster. It is not necessary to specify it when there is no overlap with clusterCIDRs.
 	// Value ignored when EnableNodeIPAM is false.
 	ServiceCIDR   string `yaml:"serviceCIDR,omitempty"`
 	ServiceCIDRv6 string `yaml:"serviceCIDRv6,omitempty"`

--- a/pkg/features/antrea_features.go
+++ b/pkg/features/antrea_features.go
@@ -73,7 +73,7 @@ const (
 	// Run Kubernetes NodeIPAM with Antrea.
 	NodeIPAM featuregate.Feature = "NodeIPAM"
 
-	// alpha: v1.3
+	// alpha: v1.4
 	// Enable flexible IPAM for Pods.
 	AntreaIPAM featuregate.Feature = "AntreaIPAM"
 )


### PR DESCRIPTION
* Multiple CIDRs for an IP family is not supported by NodeIPAM
* nodeCIDRMaskSizeIPv6 defaults to 64, use a larger CIDR as example
* AntreaIPAM is introduced in v1.4

Signed-off-by: Quan Tian <qtian@vmware.com>