### PR TITLE
Fix error handling in Reject implementation

### DIFF
--- a/pkg/agent/controller/networkpolicy/reject.go
+++ b/pkg/agent/controller/networkpolicy/reject.go
@@ -121,9 +121,11 @@ func (c *Controller) rejectRequest(pktIn *ofctrl.PacketIn) error {
 		if c.antreaProxyEnabled {
 			matches := pktIn.GetMatches()
 			if match := getMatchRegField(matches, openflow.ServiceEPStateField); match != nil {
-				if svcEpstate, err := getInfoInReg(match, openflow.ServiceEPStateField.GetRange().ToNXRange()); err != nil {
-					return svcEpstate&openflow.EpSelectedRegMark.GetValue() == openflow.EpSelectedRegMark.GetValue()
+				svcEpstate, err := getInfoInReg(match, openflow.ServiceEPStateField.GetRange().ToNXRange())
+				if err != nil {
+					return false
 				}
+				return svcEpstate&openflow.EpSelectedRegMark.GetValue() == openflow.EpSelectedRegMark.GetValue()
 			}
 			return false
 		}


### PR DESCRIPTION
Fix error handling in Reject implementation, when determining if the
packet belongs to Service traffic.
Because of the situation described in PR #3006, I didn't notice this
bug before. Fix it in this PR.

Signed-off-by: wgrayson <wgrayson@vmware.com>