### PR TITLE
Automated cherry pick of #3007: Use go 1.17 to build release assets

### DIFF
--- a/.github/workflows/upload_release_assets.yml
+++ b/.github/workflows/upload_release_assets.yml
@@ -9,6 +9,10 @@ jobs:
   build:
     runs-on: [ubuntu-latest]
     steps:
+    - name: Set up Go 1.17
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17
     - uses: actions/checkout@v2
     - name: Build assets
       env:


### PR DESCRIPTION
Cherry pick of #3007 on release-1.3.

#3007: Use go 1.17 to build release assets

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.