### PR TITLE
Fix ClusterGroup realization status logic

### DIFF
--- a/pkg/controller/networkpolicy/clustergroup_test.go
+++ b/pkg/controller/networkpolicy/clustergroup_test.go
@@ -946,9 +946,10 @@ func TestSyncInternalGroup(t *testing.T) {
 	assert.Equal(t, expectedInternalNetworkPolicy2, actualInternalNetworkPolicy2)
 
 	expectedInternalGroup := &antreatypes.Group{
-		UID:      cgUID,
-		Name:     cgName,
-		Selector: toGroupSelector("", nil, &selectorA, nil),
+		UID:             cgUID,
+		Name:            cgName,
+		Selector:        toGroupSelector("", nil, &selectorA, nil),
+		MembersComputed: corev1.ConditionTrue,
 	}
 	actualInternalGroup, exists, _ := npc.internalGroupStore.Get(internalGroupKeyFunc(cg))
 	require.True(t, exists)

--- a/pkg/controller/types/group.go
+++ b/pkg/controller/types/group.go
@@ -19,6 +19,7 @@ import (
 	"sort"
 	"strings"
 
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -104,6 +105,9 @@ type Group struct {
 	UID types.UID
 	// Name of the ClusterGroup for which this internal Group is created.
 	Name string
+	// MembersComputed knows whether the controller has computed the comprehensive members
+	// of the Group. It is updated during the syncInternalGroup process.
+	MembersComputed v1.ConditionStatus
 	// Selector describes how the internal group selects Pods to get their addresses.
 	// Selector is nil if Group is defined with ipBlock, or if it has ServiceReference
 	// and has not been processed by the controller yet / Service cannot be found.


### PR DESCRIPTION
Fixes #3002.

ClusterGroup with child groups should only be considered groupMembersComputed after all its child groups are created and processed.

Signed-off-by: Yang Ding <dingyang@vmware.com>