### PR TITLE
Add e2e test to check flow records from flow aggregator antctl

### DIFF
--- a/pkg/antctl/command_list.go
+++ b/pkg/antctl/command_list.go
@@ -114,8 +114,8 @@ func (cl *commandList) validate() []error {
 	return errs
 }
 
-// GetDebugCommands returns all commands supported by Controller or Agent that
-// are used for debugging purpose.
+// GetDebugCommands returns all commands supported by Controller, Agent or Flow Aggregator
+// that are used for debugging purpose.
 func (cl *commandList) GetDebugCommands(mode string) [][]string {
 	var allCommands [][]string
 	for _, def := range cl.definitions {

--- a/test/e2e/antctl_test.go
+++ b/test/e2e/antctl_test.go
@@ -222,7 +222,7 @@ func testAntctlVerboseMode(t *testing.T, data *TestData) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			t.Logf("Running commnand `%s` on pod %s", tc.commands, podName)
+			t.Logf("Running command `%s` on pod %s", tc.commands, podName)
 			stdout, stderr, err := runAntctl(podName, tc.commands, data)
 			assert.Nil(t, err, antctlOutput(stdout, stderr))
 			if !tc.hasStderr {


### PR DESCRIPTION
This commit adds a more concrete e2e test to check the output of `antctl get flowrecords -o json` on the Flow Aggregator. 

Signed-off-by: Yanjun Zhou <zhouya@vmware.com>