### PR TITLE
[flexible-ipam] Support Pod IPPool/IP annotation and StatefulSet

### DIFF
--- a/pkg/agent/cniserver/ipam/annotations.go
+++ b/pkg/agent/cniserver/ipam/annotations.go
@@ -15,6 +15,9 @@
 package ipam
 
 const (
-	AntreaIPAMAnnotationKey       = "ipam.antrea.io/ippools"
+	// AntreaIPAMAnnotationKey annotation can be added to Namespace and PodTemplate of StatefulSet/Deployment
+	AntreaIPAMAnnotationKey = "ipam.antrea.io/ippools"
+	// AntreaIPAMPodIPAnnotationKey annotation can be added to Pod
+	AntreaIPAMPodIPAnnotationKey  = "ipam.antrea.io/pod-ips"
 	AntreaIPAMAnnotationDelimiter = ","
 )

--- a/pkg/agent/cniserver/ipam/antrea_ipam_controller.go
+++ b/pkg/agent/cniserver/ipam/antrea_ipam_controller.go
@@ -16,6 +16,7 @@ package ipam
 
 import (
 	"fmt"
+	"net"
 	"strings"
 
 	"k8s.io/client-go/informers"
@@ -25,15 +26,19 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
+	crdv1a2 "antrea.io/antrea/pkg/apis/crd/v1alpha2"
 	clientsetversioned "antrea.io/antrea/pkg/client/clientset/versioned"
 	"antrea.io/antrea/pkg/client/informers/externalversions"
 	crdinformers "antrea.io/antrea/pkg/client/informers/externalversions/crd/v1alpha2"
 	crdlisters "antrea.io/antrea/pkg/client/listers/crd/v1alpha2"
 	"antrea.io/antrea/pkg/ipam/poolallocator"
+	"antrea.io/antrea/pkg/util/k8s"
 )
 
 const (
 	controllerName = "AntreaIPAMController"
+	// Pod index name for IPPool cache.
+	podIndex = "pod"
 )
 
 // Antrea IPAM Controller maintains map of Namespace annotations using
@@ -47,15 +52,20 @@ type AntreaIPAMController struct {
 	ipPoolLister      crdlisters.IPPoolLister
 	namespaceInformer coreinformers.NamespaceInformer
 	namespaceLister   corelisters.NamespaceLister
+	podInformer       cache.SharedIndexInformer
+	podLister         corelisters.PodLister
 }
 
 func NewAntreaIPAMController(kubeClient clientset.Interface,
 	crdClient clientsetversioned.Interface,
 	informerFactory informers.SharedInformerFactory,
+	podInformer cache.SharedIndexInformer,
 	crdInformerFactory externalversions.SharedInformerFactory) *AntreaIPAMController {
 
 	namespaceInformer := informerFactory.Core().V1().Namespaces()
 	ipPoolInformer := crdInformerFactory.Crd().V1alpha2().IPPools()
+	ipPoolInformer.Informer().AddIndexers(cache.Indexers{podIndex: podIndexFunc})
+
 	c := AntreaIPAMController{
 		kubeClient:        kubeClient,
 		crdClient:         crdClient,
@@ -63,13 +73,29 @@ func NewAntreaIPAMController(kubeClient clientset.Interface,
 		ipPoolLister:      ipPoolInformer.Lister(),
 		namespaceInformer: namespaceInformer,
 		namespaceLister:   namespaceInformer.Lister(),
+		podInformer:       podInformer,
+		podLister:         corelisters.NewPodLister(podInformer.GetIndexer()),
 	}
 
 	return &c
 }
 
-func InitializeAntreaIPAMController(kubeClient clientset.Interface, crdClient clientsetversioned.Interface, informerFactory informers.SharedInformerFactory, crdInformerFactory externalversions.SharedInformerFactory) (*AntreaIPAMController, error) {
-	antreaIPAMController := NewAntreaIPAMController(kubeClient, crdClient, informerFactory, crdInformerFactory)
+func podIndexFunc(obj interface{}) ([]string, error) {
+	ipPool, ok := obj.(*crdv1a2.IPPool)
+	if !ok {
+		return nil, fmt.Errorf("obj is not IPPool: %+v", obj)
+	}
+	indexes := make([]string, len(ipPool.Status.IPAddresses))
+	for _, IPAddress := range ipPool.Status.IPAddresses {
+		if IPAddress.Owner.Pod != nil {
+			indexes = append(indexes, k8s.NamespacedName(IPAddress.Owner.Pod.Namespace, IPAddress.Owner.Pod.Name))
+		}
+	}
+	return indexes, nil
+}
+
+func InitializeAntreaIPAMController(kubeClient clientset.Interface, crdClient clientsetversioned.Interface, informerFactory informers.SharedInformerFactory, podInformer cache.SharedIndexInformer, crdInformerFactory externalversions.SharedInformerFactory) (*AntreaIPAMController, error) {
+	antreaIPAMController := NewAntreaIPAMController(kubeClient, crdClient, informerFactory, podInformer, crdInformerFactory)
 
 	// Order of init causes antreaIPAMDriver to be initialized first
 	// After controller is initialized by agent init, we need to make it
@@ -91,34 +117,100 @@ func (c *AntreaIPAMController) Run(stopCh <-chan struct{}) {
 	}()
 
 	klog.InfoS("Starting", "controller", controllerName)
-	if !cache.WaitForNamedCacheSync(controllerName, stopCh, c.namespaceInformer.Informer().HasSynced, c.ipPoolInformer.Informer().HasSynced) {
+	if !cache.WaitForNamedCacheSync(controllerName, stopCh, c.namespaceInformer.Informer().HasSynced, c.ipPoolInformer.Informer().HasSynced, c.podInformer.HasSynced) {
 		return
 	}
 
 	<-stopCh
 }
 
-func (c *AntreaIPAMController) getIPPoolsByNamespace(namespace string) []string {
+func (c *AntreaIPAMController) getIPPoolsByPod(namespace, name string) ([]string, []net.IP, *crdv1a2.IPAddressOwner, error) {
+	// Find IPPool by Pod
+	var ips []net.IP
+	var reservedOwner *crdv1a2.IPAddressOwner
+	pod, err := c.podLister.Pods(namespace).Get(name)
+	if err != nil {
+		// For CNI DEL case, getting Pod may fail. Try to get information from allocated IPs of all IPPools.
+		klog.ErrorS(err, "Getting pod failed", "namespace", namespace, "name", name)
+		ipPools, _ := c.ipPoolInformer.Informer().GetIndexer().ByIndex(podIndex, k8s.NamespacedName(namespace, name))
+		for _, item := range ipPools {
+			ipPool := item.(*crdv1a2.IPPool)
+			if ipPool.Spec.IPVersion != 4 {
+				continue
+			}
+			for _, IPAddress := range ipPool.Status.IPAddresses {
+				if IPAddress.Owner.Pod != nil && IPAddress.Owner.Pod.Namespace == namespace && IPAddress.Owner.Pod.Name == name {
+					// reservedOwner is nil, since this is not needed for CNI DEL case
+					return []string{ipPool.Name}, []net.IP{net.ParseIP(IPAddress.IPAddress)}, nil, nil
+				}
+			}
+		}
+		return nil, nil, nil, err
+	}
+	// Collect specified IPs if exist
+	ipStrings, _ := pod.Annotations[AntreaIPAMPodIPAnnotationKey]
+	ipStrings = strings.ReplaceAll(ipStrings, " ", "")
+	var ipErr error
+	if ipStrings != "" {
+		splittedIPStrings := strings.Split(ipStrings, AntreaIPAMAnnotationDelimiter)
+		for _, ipString := range splittedIPStrings {
+			ip := net.ParseIP(ipString)
+			if ipString != "" && ip == nil {
+				ipErr = fmt.Errorf("invalid IP annotation %s", ipStrings)
+				ips = nil
+				break
+			}
+			ips = append(ips, ip)
+		}
+	}
+
+ownerReferenceLoop:
+	for _, ownerReference := range pod.OwnerReferences {
+		if ownerReference.Controller != nil && *ownerReference.Controller == true {
+			switch ownerReference.Kind {
+			case "StatefulSet":
+				// Parse StatefulSet name/index from Pod name
+				statefulSetName, index, err := k8s.ParseStatefulSetName(name)
+				if err != nil {
+					// This should not occur unless user creates an invalid Pod manually
+					klog.Warningf("Invalid StatefulSet name: %s", name)
+					break ownerReferenceLoop
+				}
+				reservedOwner = &crdv1a2.IPAddressOwner{StatefulSet: &crdv1a2.StatefulSetOwner{
+					Name:      statefulSetName,
+					Namespace: namespace,
+					Index:     index,
+				}}
+				break ownerReferenceLoop
+			}
+		}
+	}
+
+	annotations, exists := pod.Annotations[AntreaIPAMAnnotationKey]
+	if exists {
+		return strings.Split(annotations, AntreaIPAMAnnotationDelimiter), ips, reservedOwner, ipErr
+	}
+
+	// Find IPPool by Namespace
 	ns, err := c.namespaceLister.Get(namespace)
 	if err != nil {
-		return nil
+		return nil, nil, nil, nil
 	}
-	annotations, exists := ns.Annotations[AntreaIPAMAnnotationKey]
+	annotations, exists = ns.Annotations[AntreaIPAMAnnotationKey]
 	if !exists {
-		return nil
+		return nil, nil, nil, nil
 	}
-	return strings.Split(annotations, AntreaIPAMAnnotationDelimiter)
+	return strings.Split(annotations, AntreaIPAMAnnotationDelimiter), ips, reservedOwner, ipErr
 }
 
-func (c *AntreaIPAMController) getPoolAllocatorByNamespace(namespace string) (*poolallocator.IPPoolAllocator, error) {
-	poolNames := c.getIPPoolsByNamespace(namespace)
-	if len(poolNames) < 1 {
-		// This namespace does not contain IP Pool annotation
-		return nil, nil
+func (c *AntreaIPAMController) getPoolAllocatorByPod(namespace, podName string) (*poolallocator.IPPoolAllocator, []net.IP, *crdv1a2.IPAddressOwner, error) {
+	poolNames, ips, reservedOwner, err := c.getIPPoolsByPod(namespace, podName)
+	if err != nil || len(poolNames) < 1 {
+		return nil, nil, nil, err
 	}
-
 	// Only one pool is supported as of today
 	// TODO - support a pool for each IP version
 	ipPool := poolNames[0]
-	return poolallocator.NewIPPoolAllocator(ipPool, c.crdClient, c.ipPoolLister)
+	allocator, err := poolallocator.NewIPPoolAllocator(ipPool, c.crdClient, c.ipPoolLister)
+	return allocator, ips, reservedOwner, err
 }

--- a/pkg/agent/cniserver/ipam/antrea_ipam_test.go
+++ b/pkg/agent/cniserver/ipam/antrea_ipam_test.go
@@ -15,6 +15,7 @@
 package ipam
 
 import (
+	"fmt"
 	"regexp"
 	"testing"
 	"time"
@@ -26,10 +27,13 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	k8suuid "k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
+	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
 
 	cniservertest "antrea.io/antrea/pkg/agent/cniserver/testing"
 	argtypes "antrea.io/antrea/pkg/agent/cniserver/types"
@@ -41,6 +45,7 @@ import (
 var (
 	testApple          = "apple"
 	testOrange         = "orange"
+	testPear           = "pear"
 	testNoAnnotation   = "empty"
 	testJunkAnnotation = "junk"
 )
@@ -88,11 +93,62 @@ func createIPPools(crdClient *fakepoolclient.IPPoolClientset) {
 			IPRanges: []crdv1a2.SubnetIPRange{subnetRangeOrange},
 		},
 	})
+
+	ipRangePear := crdv1a2.IPRange{
+		Start: "10.2.3.100",
+		End:   "10.2.3.200",
+	}
+	subnetInfoPear := crdv1a2.SubnetInfo{
+		Gateway:      "10.2.3.1",
+		PrefixLength: 24,
+	}
+	subnetRangePear := crdv1a2.SubnetIPRange{IPRange: ipRangePear,
+		SubnetInfo: subnetInfoPear}
+	crdClient.InitPool(&crdv1a2.IPPool{
+		ObjectMeta: metav1.ObjectMeta{Name: testPear},
+		Spec: crdv1a2.IPPoolSpec{
+			IPRanges:  []crdv1a2.SubnetIPRange{subnetRangePear},
+			IPVersion: 4,
+		},
+		Status: crdv1a2.IPPoolStatus{IPAddresses: []crdv1a2.IPAddressState{{
+			IPAddress: "10.2.3.198",
+			Phase:     crdv1a2.IPAddressPhaseReserved,
+			Owner: crdv1a2.IPAddressOwner{StatefulSet: &crdv1a2.StatefulSetOwner{
+				Name:      "pear-sts",
+				Namespace: testPear,
+				Index:     8,
+			}},
+		}, {
+			IPAddress: "10.2.3.197",
+			Phase:     crdv1a2.IPAddressPhaseReserved,
+			Owner: crdv1a2.IPAddressOwner{
+				Pod: &crdv1a2.PodOwner{
+					Name:        "pear-sts-9",
+					Namespace:   testPear,
+					ContainerID: "pear-sts-9-container",
+				},
+				StatefulSet: &crdv1a2.StatefulSetOwner{
+					Name:      "pear-sts",
+					Namespace: testPear,
+					Index:     9,
+				}},
+		}, {
+			IPAddress: "10.2.3.196",
+			Phase:     crdv1a2.IPAddressPhaseReserved,
+			Owner: crdv1a2.IPAddressOwner{
+				Pod: &crdv1a2.PodOwner{
+					Name:        "pear10",
+					Namespace:   testPear,
+					ContainerID: "pear10-container",
+				}},
+		}}},
+	})
 }
 
 func initTestClients() (*fake.Clientset, *fakepoolclient.IPPoolClientset) {
 	crdClient := fakepoolclient.NewIPPoolClient()
 
+	bTrue := true
 	k8sClient := fake.NewSimpleClientset(
 		&corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
@@ -108,6 +164,12 @@ func initTestClients() (*fake.Clientset, *fakepoolclient.IPPoolClientset) {
 		},
 		&corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
+				Name:        testPear,
+				Annotations: map[string]string{"junk": "garbage"},
+			},
+		},
+		&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:        testJunkAnnotation,
 				Annotations: map[string]string{AntreaIPAMAnnotationKey: testJunkAnnotation},
 			},
@@ -116,6 +178,125 @@ func initTestClients() (*fake.Clientset, *fakepoolclient.IPPoolClientset) {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: testNoAnnotation,
 			},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "apple1",
+				Namespace: testApple,
+			},
+			Spec: corev1.PodSpec{NodeName: "fakeNode"},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "apple2",
+				Namespace: testApple,
+			},
+			Spec: corev1.PodSpec{NodeName: "fakeNode"},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "apple-sts-0",
+				Namespace:       testApple,
+				OwnerReferences: []metav1.OwnerReference{{Controller: &bTrue, Kind: "StatefulSet"}},
+			},
+			Spec: corev1.PodSpec{NodeName: "fakeNode"},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "orange1",
+				Namespace: testOrange,
+			},
+			Spec: corev1.PodSpec{NodeName: "fakeNode"},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "orange2",
+				Namespace: testOrange,
+			},
+			Spec: corev1.PodSpec{NodeName: "fakeNode"},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "pear1",
+				Namespace:   testPear,
+				Annotations: map[string]string{"junk": "garbage", AntreaIPAMAnnotationKey: testPear},
+			},
+			Spec: corev1.PodSpec{NodeName: "fakeNode"},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "pear2",
+				Namespace:   testPear,
+				Annotations: map[string]string{"junk": "garbage", AntreaIPAMAnnotationKey: testPear, AntreaIPAMPodIPAnnotationKey: " "},
+			},
+			Spec: corev1.PodSpec{NodeName: "fakeNode"},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "pear3",
+				Namespace:   testPear,
+				Annotations: map[string]string{"junk": "garbage", AntreaIPAMAnnotationKey: testPear, AntreaIPAMPodIPAnnotationKey: "10.2.3.199"},
+			},
+			Spec: corev1.PodSpec{NodeName: "fakeNode"},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				// conflict
+				Name:        "pear4",
+				Namespace:   testPear,
+				Annotations: map[string]string{"junk": "garbage", AntreaIPAMAnnotationKey: testPear, AntreaIPAMPodIPAnnotationKey: "10.2.3.199"},
+			},
+			Spec: corev1.PodSpec{NodeName: "fakeNode"},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				// out of range
+				Name:        "pear5",
+				Namespace:   testPear,
+				Annotations: map[string]string{"junk": "garbage", AntreaIPAMAnnotationKey: testPear, AntreaIPAMPodIPAnnotationKey: "10.2.4.199"},
+			},
+			Spec: corev1.PodSpec{NodeName: "fakeNode"},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				// invalid IP
+				Name:        "pear6",
+				Namespace:   testPear,
+				Annotations: map[string]string{"junk": "garbage", AntreaIPAMAnnotationKey: testPear, AntreaIPAMPodIPAnnotationKey: "junk"},
+			},
+			Spec: corev1.PodSpec{NodeName: "fakeNode"},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				// invalid IPPool
+				Name:        "pear7",
+				Namespace:   testPear,
+				Annotations: map[string]string{"junk": "garbage", AntreaIPAMAnnotationKey: testJunkAnnotation},
+			},
+			Spec: corev1.PodSpec{NodeName: "fakeNode"},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "pear-sts-8",
+				Namespace:       testPear,
+				Annotations:     map[string]string{AntreaIPAMAnnotationKey: testPear},
+				OwnerReferences: []metav1.OwnerReference{{Controller: &bTrue, Kind: "StatefulSet"}},
+			},
+			Spec: corev1.PodSpec{NodeName: "fakeNode"},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testNoAnnotation,
+				Namespace: testNoAnnotation,
+			},
+			Spec: corev1.PodSpec{NodeName: "fakeNode"},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testJunkAnnotation,
+				Namespace: testJunkAnnotation,
+			},
+			Spec: corev1.PodSpec{NodeName: "fakeNode"},
 		})
 
 	return k8sClient, crdClient
@@ -128,10 +309,21 @@ func TestAntreaIPAMDriver(t *testing.T) {
 
 	informerFactory := informers.NewSharedInformerFactory(k8sClient, 0)
 	crdInformerFactory := crdinformers.NewSharedInformerFactory(crdClient, 0)
+	listOptions := func(options *metav1.ListOptions) {
+		options.FieldSelector = fields.OneTermEqualSelector("spec.nodeName", "fakeNode").String()
+	}
+	localPodInformer := coreinformers.NewFilteredPodInformer(
+		k8sClient,
+		metav1.NamespaceAll,
+		0,
+		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, // NamespaceIndex is used in NPLController.
+		listOptions,
+	)
 
-	antreaIPAMController, err := InitializeAntreaIPAMController(k8sClient, crdClient, informerFactory, crdInformerFactory)
+	antreaIPAMController, err := InitializeAntreaIPAMController(k8sClient, crdClient, informerFactory, localPodInformer, crdInformerFactory)
 	require.NoError(t, err, "Expected no error in initialization for Antrea IPAM Controller")
 	informerFactory.Start(stopCh)
+	go localPodInformer.Run(stopCh)
 
 	createIPPools(crdClient)
 
@@ -148,19 +340,19 @@ func TestAntreaIPAMDriver(t *testing.T) {
 
 	cniArgsMap := make(map[string]*invoke.Args)
 	k8sArgsMap := make(map[string]*argtypes.K8sArgs)
-	for _, test := range []string{"apple1", "apple2", "orange1", "orange2", testNoAnnotation, testJunkAnnotation} {
+	for _, test := range []string{"apple1", "apple2", "apple-sts-0", "orange1", "orange2", testNoAnnotation, testJunkAnnotation, "pear1", "pear2", "pear3", "pear4", "pear5", "pear6", "pear7", "pear-sts-8", "pear-sts-9", "pear10"} {
 		// extract Namespace by removing numerals
-		re := regexp.MustCompile("[0-9]$")
+		re := regexp.MustCompile("(-sts-)*[0-9]*$")
 		namespace := re.ReplaceAllString(test, "")
 		args := argtypes.K8sArgs{}
 		cnitypes.LoadArgs(cniservertest.GenerateCNIArgs(test, namespace, uuid.New().String()), &args)
 		k8sArgsMap[test] = &args
 		cniArgsMap[test] = &invoke.Args{
-			ContainerID: uuid.New().String(),
+			ContainerID: fmt.Sprintf("%s-container", test),
 		}
 	}
 
-	testAdd := func(test string, expectedIP string, expectedGW string, expectedMask string) {
+	testAdd := func(test string, expectedIP string, expectedGW string, expectedMask string, isReserved bool) {
 		owns, result, err := testDriver.Add(cniArgsMap[test], k8sArgsMap[test], networkConfig)
 		require.NoError(t, err, "expected no error in Add call")
 		assert.True(t, owns)
@@ -169,6 +361,28 @@ func TestAntreaIPAMDriver(t *testing.T) {
 		assert.Equal(t, expectedIP, result.IPs[0].Address.IP.String())
 		assert.Equal(t, expectedMask, result.IPs[0].Address.Mask.String())
 		assert.Equal(t, expectedGW, result.IPs[0].Gateway.String())
+
+		podNamespace := string(k8sArgsMap[test].K8S_POD_NAMESPACE)
+		podName := string(k8sArgsMap[test].K8S_POD_NAME)
+		err = wait.Poll(time.Millisecond*200, time.Second, func() (bool, error) {
+			ipPool, _ := antreaIPAMController.ipPoolLister.Get(podNamespace)
+			found := false
+			for _, ipAddress := range ipPool.Status.IPAddresses {
+				if expectedIP == ipAddress.IPAddress {
+					assert.Equal(t, ipAddress.Owner.StatefulSet != nil, isReserved)
+					if ipAddress.Owner.StatefulSet != nil {
+						assert.Equal(t, podName, fmt.Sprintf("%s-%d", ipAddress.Owner.StatefulSet.Name, ipAddress.Owner.StatefulSet.Index))
+						assert.Equal(t, podNamespace, ipAddress.Owner.StatefulSet.Namespace)
+					}
+					assert.Equal(t, podName, ipAddress.Owner.Pod.Name)
+					assert.Equal(t, podNamespace, ipAddress.Owner.Pod.Namespace)
+					found = true
+					break
+				}
+			}
+			return found == true, nil
+		})
+		assert.Nil(t, err)
 	}
 
 	testAddError := func(test string) {
@@ -177,10 +391,29 @@ func TestAntreaIPAMDriver(t *testing.T) {
 		require.Error(t, err, "expected error in Add call")
 	}
 
-	testDel := func(test string) {
+	testDel := func(test string, isReserved bool) {
 		owns, err := testDriver.Del(cniArgsMap[test], k8sArgsMap[test], networkConfig)
 		assert.True(t, owns)
 		require.NoError(t, err, "expected no error in Del call")
+
+		podNamespace := string(k8sArgsMap[test].K8S_POD_NAMESPACE)
+		podName := string(k8sArgsMap[test].K8S_POD_NAME)
+		err = wait.Poll(time.Millisecond*200, time.Second, func() (bool, error) {
+			ipPool, _ := antreaIPAMController.ipPoolLister.Get(podNamespace)
+			found := false
+			for _, ipAddress := range ipPool.Status.IPAddresses {
+				if ipAddress.Owner.Pod != nil && ipAddress.Owner.Pod.Name == podName && ipAddress.Owner.Pod.Namespace == podNamespace {
+					t.Logf("IP allocation is not removed")
+					return false, nil
+				}
+				if ipAddress.Owner.StatefulSet != nil && podName == fmt.Sprintf("%s-%d", ipAddress.Owner.StatefulSet.Name, ipAddress.Owner.StatefulSet.Index) && podNamespace == ipAddress.Owner.StatefulSet.Namespace {
+					found = true
+					break
+				}
+			}
+			return found == isReserved, nil
+		})
+		assert.Nil(t, err)
 	}
 
 	testCheck := func(test string, shouldExist bool) {
@@ -195,12 +428,17 @@ func TestAntreaIPAMDriver(t *testing.T) {
 
 	// Run several adds from two Namespaces that have pool annotations
 	ipv6Mask := "ffffffffffffffff0000000000000000"
-	testAdd("apple1", "10.2.2.100", "10.2.2.1", "ffffff00")
+	testAdd("apple1", "10.2.2.100", "10.2.2.1", "ffffff00", false)
 
 	// introduce new IP Pool in mid-action
-	testAdd("orange1", "20::2", "20::1", ipv6Mask)
-	testAdd("orange2", "20::3", "20::1", ipv6Mask)
-	testAdd("apple2", "10.2.2.101", "10.2.2.1", "ffffff00")
+	testAdd("orange1", "20::2", "20::1", ipv6Mask, false)
+	testAdd("orange2", "20::3", "20::1", ipv6Mask, false)
+	testAdd("apple2", "10.2.2.101", "10.2.2.1", "ffffff00", false)
+	testAdd("apple-sts-0", "10.2.2.102", "10.2.2.1", "ffffff00", true)
+	testAdd("pear1", "10.2.3.100", "10.2.3.1", "ffffff00", false)
+	testAdd("pear2", "10.2.3.101", "10.2.3.1", "ffffff00", false)
+	testAdd("pear3", "10.2.3.199", "10.2.3.1", "ffffff00", false)
+	testAdd("pear-sts-8", "10.2.3.198", "10.2.3.1", "ffffff00", true)
 
 	// Make sure the driver does not own request without pool annotation
 	owns, _, err := testDriver.Add(cniArgsMap[testNoAnnotation], k8sArgsMap[testNoAnnotation], networkConfig)
@@ -212,9 +450,34 @@ func TestAntreaIPAMDriver(t *testing.T) {
 	require.NotNil(t, err, "expected error in Add call due to non-existent pool")
 	assert.True(t, owns)
 
+	// Verify that annotation for conflict ip errors
+	owns, _, err = testDriver.Add(cniArgsMap["pear4"], k8sArgsMap["pear4"], networkConfig)
+	require.NotNil(t, err, "expected error in Add call due to conflict ip")
+	assert.True(t, owns)
+
+	// Verify that annotation for ip out of range errors
+	owns, _, err = testDriver.Add(cniArgsMap["pear5"], k8sArgsMap["pear5"], networkConfig)
+	require.NotNil(t, err, "expected error in Add call due to ip out of range")
+	assert.True(t, owns)
+
+	// Verify that annotation for invalid ip errors
+	owns, _, err = testDriver.Add(cniArgsMap["pear6"], k8sArgsMap["pear6"], networkConfig)
+	require.NotNil(t, err, "expected error in Add call due to invalid ip")
+	assert.True(t, owns)
+
+	// Verify that annotation for non existent pool errors out
+	owns, _, err = testDriver.Add(cniArgsMap["pear7"], k8sArgsMap["pear7"], networkConfig)
+	require.NotNil(t, err, "expected error in Add call due to non-existent pool")
+	assert.True(t, owns)
+
 	// Del two of the Pods
-	testDel("apple1")
-	testDel("orange2")
+	testDel("apple1", false)
+	testDel("orange2", false)
+	testDel("pear3", false)
+	testDel("apple-sts-0", true)
+	testDel("pear-sts-8", true)
+	testDel("pear-sts-9", true)
+	testDel("pear10", false)
 
 	// Verify last update was propagated to informer
 	err = wait.PollImmediate(100*time.Millisecond, 1*time.Second, func() (bool, error) {
@@ -232,6 +495,12 @@ func TestAntreaIPAMDriver(t *testing.T) {
 	testCheck("apple1", false)
 	testCheck("apple2", true)
 	testCheck("orange1", true)
+	testCheck("orange2", false)
+	testCheck("pear1", true)
+	testCheck("pear2", true)
+	testCheck("pear3", false)
+	testCheck("apple-sts-0", false)
+	testCheck("pear-sts-8", false)
 
 	// Make sure Del call with irrelevant container ID is ignored
 	cniArgsBadContainer := &invoke.Args{
@@ -243,8 +512,15 @@ func TestAntreaIPAMDriver(t *testing.T) {
 	require.NoError(t, err, "expected no error in Del call")
 
 	// Make sure repeated Add works for Pod that was previously released
-	testAdd("apple1", "10.2.2.100", "10.2.2.1", "ffffff00")
+	testAdd("apple1", "10.2.2.100", "10.2.2.1", "ffffff00", false)
+	testAdd("apple-sts-0", "10.2.2.102", "10.2.2.1", "ffffff00", true)
 
 	// Make sure repeated call for previous container results in error
 	testAddError("apple2")
+
+	// Make sure repeated Add works for pod that was previously released
+	testAdd("pear3", "10.2.3.199", "10.2.3.1", "ffffff00", false)
+
+	// Make sure repeated call without previous container results in error
+	testAddError("pear3")
 }

--- a/pkg/agent/nodeportlocal/k8s/npl_controller.go
+++ b/pkg/agent/nodeportlocal/k8s/npl_controller.go
@@ -125,7 +125,6 @@ func (c *NPLController) Run(stopCh <-chan struct{}) {
 	}()
 
 	klog.Infof("Starting %s", controllerName)
-	go c.podInformer.Run(stopCh)
 	if !cache.WaitForNamedCacheSync(controllerName, stopCh, c.podInformer.HasSynced, c.svcInformer.HasSynced) {
 		return
 	}

--- a/pkg/agent/nodeportlocal/npl_agent_init_windows.go
+++ b/pkg/agent/nodeportlocal/npl_agent_init_windows.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
 )
 
 // InitializeNPLAgent starts NodePortLocal (NPL) agent.
@@ -32,6 +33,7 @@ func InitializeNPLAgent(
 	startPort int,
 	endPort int,
 	nodeName string,
+	podInformer cache.SharedIndexInformer,
 ) (*windowsCtrl, error) {
 	return nil, errors.New("Windows Platform not supported for NPL")
 }

--- a/pkg/apis/crd/v1alpha2/types.go
+++ b/pkg/apis/crd/v1alpha2/types.go
@@ -346,6 +346,7 @@ type IPAddressPhase string
 const (
 	IPAddressPhaseAllocated    IPAddressPhase = "Allocated"
 	IPAddressPhasePreallocated IPAddressPhase = "Preallocated"
+	IPAddressPhaseReserved     IPAddressPhase = "Reserved"
 )
 
 type IPAddressState struct {

--- a/pkg/util/k8s/name.go
+++ b/pkg/util/k8s/name.go
@@ -14,6 +14,12 @@
 
 package k8s
 
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
 // NamespacedName generates the conventional K8s resource name,
 // which connects namespace and name with "/".
 func NamespacedName(namespace, name string) string {
@@ -22,4 +28,18 @@ func NamespacedName(namespace, name string) string {
 		return name
 	}
 	return namespace + "/" + name
+}
+
+func ParseStatefulSetName(name string) (statefulSetName string, index int, err error) {
+	splittedName := strings.Split(name, "-")
+	if len(splittedName) < 2 {
+		err = fmt.Errorf("invalid StatefulSet name: %s", name)
+		return
+	}
+	index, err = strconv.Atoi(splittedName[len(splittedName)-1])
+	if err != nil {
+		return
+	}
+	statefulSetName = strings.Join(splittedName[:len(splittedName)-1], "-")
+	return
 }


### PR DESCRIPTION
Add support for Pod annotation "ipam.antrea.io/ippools" and
"ipam.antrea.io/pod-ips", which allows user to specify IPPool and IP for a
specified Pod.

Support persistent IP for StatefulSet. A StatefulSet Pod will keep its
allocated IP during restart process.

Signed-off-by: gran <gran@vmware.com>