### PR TITLE
Fix SetInterfaceMTU not working on Windows bug

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -573,8 +573,10 @@ func (i *Initializer) setupGatewayInterface() error {
 	// restarts.
 	klog.V(4).Infof("Setting gateway interface %s MTU to %d", i.hostGateway, i.nodeConfig.NodeMTU)
 
-	i.ovsBridgeClient.SetInterfaceMTU(i.hostGateway, i.nodeConfig.NodeMTU)
 	if err := i.configureGatewayInterface(gatewayIface); err != nil {
+		return err
+	}
+	if err := i.ovsBridgeClient.SetInterfaceMTU(i.hostGateway, i.nodeConfig.NodeMTU); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
For Windows, antrea-gw0 interface must be enabled before
MTU is set, so MTU is not configured with current code.
Currently the result of SetInterfaceMTU is not checked, so
the error is not found.

Signed-off-by: Zhecheng Li <lzhecheng@vmware.com>