### PR TITLE
[flexible-ipam] Use IP Pool informer in pool allocator

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -403,7 +403,8 @@ func run(o *Options) error {
 		ipamController, err := ipam.InitializeAntreaIPAMController(
 			k8sClient,
 			crdClient,
-			informerFactory)
+			informerFactory,
+			crdInformerFactory)
 		if err != nil {
 			return fmt.Errorf("failed to start Antrea IPAM agent: %v", err)
 		}

--- a/pkg/agent/cniserver/ipam/antrea_ipam.go
+++ b/pkg/agent/cniserver/ipam/antrea_ipam.go
@@ -190,17 +190,14 @@ func (d *AntreaIPAM) owns(k8sArgs *argtypes.K8sArgs) (bool, *poolallocator.IPPoo
 	// supported as well
 	namespace := string(k8sArgs.K8S_POD_NAMESPACE)
 	klog.V(2).InfoS("Inspecting IPAM annotation", "namespace", namespace)
-	poolNames := d.controller.getIPPoolsByNamespace(namespace)
-	if len(poolNames) < 1 {
-		return false, nil, nil
-	}
-	// Only one pool is supported as of today
-	// TODO - support a pool for each IP version
-	ipPool := poolNames[0]
-	allocator, err := poolallocator.NewIPPoolAllocator(ipPool, d.controller.crdClient)
+	allocator, err := d.controller.getPoolAllocatorByNamespace(namespace)
 	if err != nil {
 		// Failed to find pool - error should be returned from this driver
 		return true, nil, err
+	}
+	if allocator == nil {
+		// No pool annotation for this namespace
+		return false, nil, nil
 	}
 	return true, allocator, nil
 }

--- a/pkg/ipam/poolallocator/allocator.go
+++ b/pkg/ipam/poolallocator/allocator.go
@@ -21,6 +21,7 @@ import (
 
 	"antrea.io/antrea/pkg/apis/crd/v1alpha2"
 	crdclientset "antrea.io/antrea/pkg/client/clientset/versioned"
+	informers "antrea.io/antrea/pkg/client/listers/crd/v1alpha2"
 	"antrea.io/antrea/pkg/ipam/ipallocator"
 	iputil "antrea.io/antrea/pkg/util/ip"
 
@@ -37,27 +38,36 @@ type IPPoolAllocator struct {
 	// Name of IP Pool custom resource
 	ipPoolName string
 
-	// crd client to access the pool
+	// crd client to update the pool
 	crdClient crdclientset.Interface
+
+	// pool lister for reading the pool
+	ipPoolLister informers.IPPoolLister
 }
 
 // NewIPPoolAllocator creates an IPPoolAllocator based on the provided IP pool.
-func NewIPPoolAllocator(poolName string, client crdclientset.Interface) (*IPPoolAllocator, error) {
+func NewIPPoolAllocator(poolName string, client crdclientset.Interface, poolLister informers.IPPoolLister) (*IPPoolAllocator, error) {
 
 	// Validate the pool exists
 	// This has an extra roundtrip cost, however this would allow fallback to
 	// default IPAM driver if needed
-	_, err := client.CrdV1alpha2().IPPools().Get(context.TODO(), poolName, metav1.GetOptions{})
+	_, err := poolLister.Get(poolName)
 	if err != nil {
 		return nil, err
 	}
 
 	allocator := &IPPoolAllocator{
-		ipPoolName: poolName,
-		crdClient:  client,
+		ipPoolName:   poolName,
+		crdClient:    client,
+		ipPoolLister: poolLister,
 	}
 
 	return allocator, nil
+}
+
+func (a *IPPoolAllocator) getPool() (*v1alpha2.IPPool, error) {
+	pool, err := a.ipPoolLister.Get(a.ipPoolName)
+	return pool, err
 }
 
 // initAllocatorList reads IP Pool status and initializes a list of allocators based on
@@ -109,8 +119,8 @@ func (a *IPPoolAllocator) initIPAllocators(ipPool *v1alpha2.IPPool) (ipallocator
 	return allocators, nil
 }
 
-func (a *IPPoolAllocator) readPoolAndInitIPAllocators() (*v1alpha2.IPPool, ipallocator.MultiIPAllocator, error) {
-	ipPool, err := a.crdClient.CrdV1alpha2().IPPools().Get(context.TODO(), a.ipPoolName, metav1.GetOptions{})
+func (a *IPPoolAllocator) getPoolAndInitIPAllocators() (*v1alpha2.IPPool, ipallocator.MultiIPAllocator, error) {
+	ipPool, err := a.getPool()
 
 	if err != nil {
 		return nil, ipallocator.MultiIPAllocator{}, err
@@ -178,7 +188,7 @@ func (a *IPPoolAllocator) AllocateIP(ip net.IP, state v1alpha2.IPAddressPhase, o
 	var subnetSpec v1alpha2.SubnetInfo
 	// Retry on CRD update conflict which is caused by multiple agents updating a pool at same time.
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		ipPool, allocators, err := a.readPoolAndInitIPAllocators()
+		ipPool, allocators, err := a.getPoolAndInitIPAllocators()
 		if err != nil {
 			return err
 		}
@@ -232,7 +242,7 @@ func (a *IPPoolAllocator) AllocateNext(state v1alpha2.IPAddressPhase, owner v1al
 
 	// Retry on CRD update conflict which is caused by multiple agents updating a pool at same time.
 	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		ipPool, allocators, err := a.readPoolAndInitIPAllocators()
+		ipPool, allocators, err := a.getPoolAndInitIPAllocators()
 		if err != nil {
 			return err
 		}
@@ -269,7 +279,7 @@ func (a *IPPoolAllocator) Release(ip net.IP) error {
 
 	// Retry on CRD update conflict which is caused by multiple agents updating a pool at same time.
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		ipPool, allocators, err := a.readPoolAndInitIPAllocators()
+		ipPool, allocators, err := a.getPoolAndInitIPAllocators()
 		if err != nil {
 			return err
 		}
@@ -296,7 +306,7 @@ func (a *IPPoolAllocator) ReleasePod(namespace, podName string) error {
 
 	// Retry on CRD update conflict which is caused by multiple agents updating a pool at same time.
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		ipPool, err := a.crdClient.CrdV1alpha2().IPPools().Get(context.TODO(), a.ipPoolName, metav1.GetOptions{})
+		ipPool, err := a.getPool()
 
 		if err != nil {
 			return err
@@ -327,7 +337,7 @@ func (a *IPPoolAllocator) ReleaseContainerIfPresent(containerID string) error {
 
 	// Retry on CRD update conflict which is caused by multiple agents updating a pool at same time.
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		ipPool, err := a.crdClient.CrdV1alpha2().IPPools().Get(context.TODO(), a.ipPoolName, metav1.GetOptions{})
+		ipPool, err := a.getPool()
 
 		if err != nil {
 			return err
@@ -354,7 +364,7 @@ func (a *IPPoolAllocator) ReleaseContainerIfPresent(containerID string) error {
 // HasResource checks whether an IP was associated with specified pod. It returns error if the resource is crd fails to be retrieved.
 func (a *IPPoolAllocator) HasPod(namespace, podName string) (bool, error) {
 
-	ipPool, err := a.crdClient.CrdV1alpha2().IPPools().Get(context.TODO(), a.ipPoolName, metav1.GetOptions{})
+	ipPool, err := a.getPool()
 
 	if err != nil {
 		return false, err
@@ -371,7 +381,7 @@ func (a *IPPoolAllocator) HasPod(namespace, podName string) (bool, error) {
 // HasResource checks whether an IP was associated with specified container. It returns error if the resource is crd fails to be retrieved.
 func (a *IPPoolAllocator) HasContainer(containerID string) (bool, error) {
 
-	ipPool, err := a.crdClient.CrdV1alpha2().IPPools().Get(context.TODO(), a.ipPoolName, metav1.GetOptions{})
+	ipPool, err := a.getPool()
 
 	if err != nil {
 		return false, err

--- a/pkg/ipam/poolallocator/allocator_test.go
+++ b/pkg/ipam/poolallocator/allocator_test.go
@@ -18,18 +18,19 @@ import (
 	"fmt"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	crdv1a2 "antrea.io/antrea/pkg/apis/crd/v1alpha2"
-	fakeversioned "antrea.io/antrea/pkg/client/clientset/versioned/fake"
+	informers "antrea.io/antrea/pkg/client/informers/externalversions"
+	fakepoolclient "antrea.io/antrea/pkg/ipam/poolallocator/testing"
 
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 )
 
@@ -43,9 +44,28 @@ var fakePodOwner = crdv1a2.IPAddressOwner{
 	},
 }
 
-func newIPPoolAllocator(poolName string, initObjects []runtime.Object) *IPPoolAllocator {
-	crdClient := fakeversioned.NewSimpleClientset(initObjects...)
-	allocator, _ := NewIPPoolAllocator(poolName, crdClient)
+func newTestIPPoolAllocator(pool *crdv1a2.IPPool, stopCh <-chan struct{}) *IPPoolAllocator {
+
+	crdClient := fakepoolclient.NewIPPoolClient()
+
+	crdInformerFactory := informers.NewSharedInformerFactory(crdClient, 0)
+	pools := crdInformerFactory.Crd().V1alpha2().IPPools()
+	poolInformer := pools.Informer()
+
+	go crdInformerFactory.Start(stopCh)
+
+	crdClient.InitPool(pool)
+	cache.WaitForCacheSync(stopCh, poolInformer.HasSynced)
+
+	var allocator *IPPoolAllocator
+	var err error
+	wait.PollImmediate(100*time.Millisecond, 1*time.Second, func() (bool, error) {
+		allocator, err = NewIPPoolAllocator(pool.Name, crdClient, pools.Lister())
+		if err != nil {
+			return false, nil
+		}
+		return true, nil
+	})
 	return allocator
 }
 
@@ -69,7 +89,10 @@ func validateAllocationSequence(t *testing.T, allocator *IPPoolAllocator, subnet
 }
 
 func TestAllocateIP(t *testing.T) {
-	poolName := "fakePool"
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	poolName := uuid.New().String()
 	ipRange := crdv1a2.IPRange{
 		Start: "10.2.2.100",
 		End:   "10.2.2.120",
@@ -86,7 +109,8 @@ func TestAllocateIP(t *testing.T) {
 		Spec:       crdv1a2.IPPoolSpec{IPRanges: []crdv1a2.SubnetIPRange{subnetRange}},
 	}
 
-	allocator := newIPPoolAllocator(poolName, []runtime.Object{&pool})
+	allocator := newTestIPPoolAllocator(&pool, stopCh)
+	require.NotNil(t, allocator)
 
 	// Allocate specific IP from the range
 	returnInfo, err := allocator.AllocateIP(net.ParseIP("10.2.2.101"), crdv1a2.IPAddressPhaseAllocated, fakePodOwner)
@@ -107,7 +131,10 @@ func TestAllocateIP(t *testing.T) {
 }
 
 func TestAllocateNext(t *testing.T) {
-	poolName := "fakePool"
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	poolName := uuid.New().String()
 	ipRange := crdv1a2.IPRange{
 		Start: "10.2.2.100",
 		End:   "10.2.2.120",
@@ -124,63 +151,17 @@ func TestAllocateNext(t *testing.T) {
 		Spec:       crdv1a2.IPPoolSpec{IPRanges: []crdv1a2.SubnetIPRange{subnetRange}},
 	}
 
-	allocator := newIPPoolAllocator(poolName, []runtime.Object{&pool})
+	allocator := newTestIPPoolAllocator(&pool, stopCh)
+	require.NotNil(t, allocator)
 
 	validateAllocationSequence(t, allocator, subnetInfo, []string{"10.2.2.100", "10.2.2.101"})
 }
 
-// This test verifies correct behavior in case of update conflict. Allocation should be retiried
-// Taking into account the latest status
-func TestAllocateConflict(t *testing.T) {
-	poolName := "fakePool"
-	ipRange := crdv1a2.IPRange{
-		Start: "10.2.2.100",
-		End:   "10.2.2.120",
-	}
-	subnetInfo := crdv1a2.SubnetInfo{
-		Gateway:      "10.2.2.1",
-		PrefixLength: 24,
-	}
-	subnetRange := crdv1a2.SubnetIPRange{IPRange: ipRange,
-		SubnetInfo: subnetInfo}
-
-	pool := crdv1a2.IPPool{
-		ObjectMeta: metav1.ObjectMeta{Name: poolName},
-		Spec:       crdv1a2.IPPoolSpec{IPRanges: []crdv1a2.SubnetIPRange{subnetRange}},
-	}
-
-	crdClient := &fakeversioned.Clientset{}
-	updateCount := 0
-	// fail for the first two update attempts, and succeed on third
-	crdClient.AddReactor("update", "ippools", func(action k8stesting.Action) (bool, runtime.Object, error) {
-		updateCount += 1
-		if updateCount < 3 {
-			return true, nil, &errors.StatusError{ErrStatus: metav1.Status{Reason: metav1.StatusReasonConflict, Message: "pool status update conflict"}}
-		}
-		return true, &pool, nil
-	})
-
-	// after update conflict, return pool status that simulates simultaneous allocation
-	// by another agent
-	crdClient.AddReactor("get", "ippools", func(action k8stesting.Action) (bool, runtime.Object, error) {
-		if updateCount > 0 && len(pool.Status.IPAddresses) == 0 {
-			pool.Status.IPAddresses = append(pool.Status.IPAddresses, crdv1a2.IPAddressState{
-				IPAddress: "10.2.2.100",
-				Phase:     crdv1a2.IPAddressPhaseAllocated,
-				Owner:     crdv1a2.IPAddressOwner{Pod: &crdv1a2.PodOwner{ContainerID: "another-containerID"}},
-			})
-		}
-		return true, &pool, nil
-	})
-
-	allocator, _ := NewIPPoolAllocator(poolName, crdClient)
-
-	validateAllocationSequence(t, allocator, subnetInfo, []string{"10.2.2.101"})
-	assert.Equal(t, updateCount, 3)
-}
-
 func TestAllocateNextMultiRange(t *testing.T) {
-	poolName := "fakePool"
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	poolName := uuid.New().String()
 	ipRange1 := crdv1a2.IPRange{
 		Start: "10.2.2.100",
 		End:   "10.2.2.101",
@@ -201,14 +182,18 @@ func TestAllocateNextMultiRange(t *testing.T) {
 			IPRanges: []crdv1a2.SubnetIPRange{subnetRange1, subnetRange2}},
 	}
 
-	allocator := newIPPoolAllocator(poolName, []runtime.Object{&pool})
+	allocator := newTestIPPoolAllocator(&pool, stopCh)
+	require.NotNil(t, allocator)
 
 	// Allocate the 2 available IPs from first range then switch to second range
 	validateAllocationSequence(t, allocator, subnetInfo, []string{"10.2.2.100", "10.2.2.101", "10.2.2.2", "10.2.2.3"})
 }
 
 func TestAllocateNextMultiRangeExausted(t *testing.T) {
-	poolName := "fakePool"
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	poolName := uuid.New().String()
 	ipRange1 := crdv1a2.IPRange{
 		Start: "10.2.2.100",
 		End:   "10.2.2.101",
@@ -232,7 +217,8 @@ func TestAllocateNextMultiRangeExausted(t *testing.T) {
 			IPRanges: []crdv1a2.SubnetIPRange{subnetRange1, subnetRange2}},
 	}
 
-	allocator := newIPPoolAllocator(poolName, []runtime.Object{&pool})
+	allocator := newTestIPPoolAllocator(&pool, stopCh)
+	require.NotNil(t, allocator)
 
 	// Allocate all available IPs
 	validateAllocationSequence(t, allocator, subnetInfo, []string{"10.2.2.100", "10.2.2.101", "10.2.2.200"})
@@ -243,7 +229,10 @@ func TestAllocateNextMultiRangeExausted(t *testing.T) {
 }
 
 func TestAllocateReleaseSequence(t *testing.T) {
-	poolName := "fakePool"
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	poolName := uuid.New().String()
 	ipRange1 := crdv1a2.IPRange{
 		Start: "2001::1000",
 		End:   "2001::1000",
@@ -264,7 +253,8 @@ func TestAllocateReleaseSequence(t *testing.T) {
 			IPRanges: []crdv1a2.SubnetIPRange{subnetRange1, subnetRange2}},
 	}
 
-	allocator := newIPPoolAllocator(poolName, []runtime.Object{&pool})
+	allocator := newTestIPPoolAllocator(&pool, stopCh)
+	require.NotNil(t, allocator)
 
 	// Allocate the single available IPs from first range then 3 IPs from second range
 	validateAllocationSequence(t, allocator, subnetInfo, []string{"2001::1000", "2001::2", "2001::3", "2001::4"})
@@ -279,7 +269,10 @@ func TestAllocateReleaseSequence(t *testing.T) {
 }
 
 func TestReleaseResource(t *testing.T) {
-	poolName := "fakePool"
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	poolName := uuid.New().String()
 	ipRange1 := crdv1a2.IPRange{
 		Start: "2001::1000",
 		End:   "2001::1000",
@@ -300,7 +293,8 @@ func TestReleaseResource(t *testing.T) {
 			IPRanges: []crdv1a2.SubnetIPRange{subnetRange1, subnetRange2}},
 	}
 
-	allocator := newIPPoolAllocator(poolName, []runtime.Object{&pool})
+	allocator := newTestIPPoolAllocator(&pool, stopCh)
+	require.NotNil(t, allocator)
 
 	// Allocate the single available IPs from first range then 3 IPs from second range
 	validateAllocationSequence(t, allocator, subnetInfo, []string{"2001::1000", "2001::2", "2001::3", "2001::4", "2001::5"})
@@ -315,6 +309,9 @@ func TestReleaseResource(t *testing.T) {
 }
 
 func TestHas(t *testing.T) {
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
 	owner := crdv1a2.IPAddressOwner{
 		Pod: &crdv1a2.PodOwner{
 			Name:        "fakePod",
@@ -322,7 +319,7 @@ func TestHas(t *testing.T) {
 			ContainerID: "fakeContainer",
 		},
 	}
-	poolName := "fakePool"
+	poolName := uuid.New().String()
 	ipRange1 := crdv1a2.IPRange{
 		Start: "2001::1000",
 		End:   "2001::1000",
@@ -340,14 +337,18 @@ func TestHas(t *testing.T) {
 			IPRanges: []crdv1a2.SubnetIPRange{subnetRange1}},
 	}
 
-	allocator := newIPPoolAllocator(poolName, []runtime.Object{&pool})
+	allocator := newTestIPPoolAllocator(&pool, stopCh)
+	require.NotNil(t, allocator)
 
 	_, _, err := allocator.AllocateNext(crdv1a2.IPAddressPhaseAllocated, owner)
 	require.NoError(t, err)
-	has, err := allocator.HasPod(testNamespace, "fakePod")
+	err = wait.PollImmediate(100*time.Millisecond, 1*time.Second, func() (bool, error) {
+		has, _ := allocator.HasPod(testNamespace, "fakePod")
+		return has, nil
+	})
 	require.NoError(t, err)
-	assert.True(t, has)
-	has, err = allocator.HasPod(testNamespace, "realPod")
+
+	has, err := allocator.HasPod(testNamespace, "realPod")
 	require.NoError(t, err)
 	assert.False(t, has)
 	has, err = allocator.HasContainer("fakeContainer")

--- a/pkg/ipam/poolallocator/testing/fake_client.go
+++ b/pkg/ipam/poolallocator/testing/fake_client.go
@@ -1,0 +1,76 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testing
+
+import (
+	"sync"
+
+	"github.com/google/uuid"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	k8stesting "k8s.io/client-go/testing"
+
+	crdv1a2 "antrea.io/antrea/pkg/apis/crd/v1alpha2"
+	fakeversioned "antrea.io/antrea/pkg/client/clientset/versioned/fake"
+)
+
+// Simple client is not sufficient for pool allocator testing,
+// since pool allocator relies on both crd client and pool informer
+// to work in sync. This client extension mimics the real client in
+// conflict handling functionality - pool update will return conflict
+// error unless ResourceVersion for the updated pool reflect the version
+// stored in the client.
+type IPPoolClientset struct {
+	fakeversioned.Clientset
+	// store latest ResourceVersion for given pool
+	poolVersion sync.Map
+	watcher     *watch.RaceFreeFakeWatcher
+}
+
+func (c *IPPoolClientset) InitPool(pool *crdv1a2.IPPool) {
+	pool.ResourceVersion = uuid.New().String()
+	c.poolVersion.Store(pool.Name, pool.ResourceVersion)
+
+	c.watcher.Add(pool)
+}
+
+func NewIPPoolClient() *IPPoolClientset {
+
+	crdClient := &IPPoolClientset{watcher: watch.NewRaceFreeFake(),
+		poolVersion: sync.Map{}}
+
+	crdClient.AddReactor("update", "ippools", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		updatedPool := action.(k8stesting.UpdateAction).GetObject().(*crdv1a2.IPPool)
+		obj, exists := crdClient.poolVersion.Load(updatedPool.Name)
+		if !exists {
+			return false, nil, nil
+		}
+		storedPoolVersion := obj.(string)
+		if storedPoolVersion != updatedPool.ResourceVersion {
+			return true, nil, &errors.StatusError{ErrStatus: metav1.Status{Reason: metav1.StatusReasonConflict, Message: "pool status update conflict"}}
+		}
+
+		updatedPool.ResourceVersion = uuid.New().String()
+		crdClient.poolVersion.Store(updatedPool.Name, updatedPool.ResourceVersion)
+		crdClient.watcher.Modify(updatedPool)
+		return true, updatedPool, nil
+	})
+
+	crdClient.AddWatchReactor("ippools", k8stesting.DefaultWatchReactor(crdClient.watcher, nil))
+
+	return crdClient
+}


### PR DESCRIPTION
For sake of efficiency, use pool informer rather than client.
This change introduces a ip pool specific testing client, since
simple fake client is not designed to deal with object versioning.


Signed-off-by: Anna Khmelnitsky <akhmelnitsky@vmware.com>