### PR TITLE
Fix coverage upload issue

### DIFF
--- a/ci/jenkins/jobs/projects.yaml
+++ b/ci/jenkins/jobs/projects.yaml
@@ -147,6 +147,13 @@
           - ${{sha1}}
           builders:
           - builder-integration
+          properties:
+          - throttle:
+              max-per-node: 1
+              max-total: 0
+              categories: integration
+              option: category
+              enabled: true
           trigger_phrase: null
           white_list_target_branches: []
           allow_whitelist_orgs_as_admins: false
@@ -190,6 +197,13 @@
           - ${{sha1}}
           builders:
           - builder-integration
+          properties:
+          - throttle:
+              max-per-node: 1
+              max-total: 0
+              categories: integration
+              option: category
+              enabled: true
           trigger_phrase: ^(?!Thanks for your PR).*/test-integration.*
           white_list_target_branches: []
           allow_whitelist_orgs_as_admins: true

--- a/ci/jenkins/test-vmc.sh
+++ b/ci/jenkins/test-vmc.sh
@@ -303,12 +303,9 @@ function run_codecov { (set -e
 
     if [[ $remote == true ]]; then
         ${SCP_WITH_UTILS_KEY} codecov jenkins@${ip}:~
-    fi
-
-    if [[ $remote == true ]]; then
-        ${SSH_WITH_UTILS_KEY} -n jenkins@${ip} "env -i bash -s -- -c -t ${CODECOV_TOKEN} -F ${flag} -f ${file}"
+        ${SSH_WITH_UTILS_KEY} -n jenkins@${ip} "~/codecov -c -t ${CODECOV_TOKEN} -F ${flag} -f ${file} -C ${GIT_COMMIT} -r antrea-io/antrea"
     else
-        env -i bash -s -- -c -t ${CODECOV_TOKEN} -F ${flag} -f ${file} -s ${dir}
+        ./codecov -c -t ${CODECOV_TOKEN} -F ${flag} -f ${file} -s ${dir} -C ${GIT_COMMIT} -r antrea-io/antrea
     fi
     rm -f trustedkeys.gpg codecov
 )}
@@ -455,7 +452,7 @@ function run_integration {
     # umask ensures that files are cloned with the correct permissions so that Docker caching can be leveraged
     ${SSH_WITH_UTILS_KEY} -n jenkins@${VM_IP} "umask 0022 && git clone ${ghprbAuthorRepoGitUrl} antrea && cd antrea && git checkout ${GIT_BRANCH} && DOCKER_REGISTRY=${DOCKER_REGISTRY} ./build/images/ovs/build.sh --pull && NO_PULL=${NO_PULL} make docker-test-integration"
     if [[ "$COVERAGE" == true ]]; then
-        run_codecov "integration-tests" ".coverage/coverage-integration.txt" "" true ${VM_IP}
+        run_codecov "integration-tests" "antrea/.coverage/coverage-integration.txt" "" true ${VM_IP}
     fi
 }
 

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -27,6 +27,14 @@ coverage:
         target: auto
         flags:
           - e2e-tests
+      antrea-kind-e2e-tests:
+        target: auto
+        flags:
+          - kind-e2e-tests
+      antrea-mc-integration-tests:
+        target: auto
+        flags:
+          - mc-integration-tests
 
 ignore:
   - "**/testing/mock_*.go"


### PR DESCRIPTION
1. fix the bug where codecov is not executed at all
2. add missing codecov flag `kind-e2e-tests` which is used in kind workflow
3. add a new flag for multicluster integration test
4. limit concurrent integration jobs

Resolve #3060

Signed-off-by: Lan Luo <luola@vmware.com>