### PR TITLE
Automated cherry pick of #3043: Fix SetInterfaceMTU not working on Windows bug For Windows,

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -552,8 +552,10 @@ func (i *Initializer) setupGatewayInterface() error {
 	// restarts.
 	klog.V(4).Infof("Setting gateway interface %s MTU to %d", i.hostGateway, i.nodeConfig.NodeMTU)
 
-	i.ovsBridgeClient.SetInterfaceMTU(i.hostGateway, i.nodeConfig.NodeMTU)
 	if err := i.configureGatewayInterface(gatewayIface); err != nil {
+		return err
+	}
+	if err := i.ovsBridgeClient.SetInterfaceMTU(i.hostGateway, i.nodeConfig.NodeMTU); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Cherry pick of #3043 on release-1.3.

#3043: Fix SetInterfaceMTU not working on Windows bug For Windows,

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.