### PR TITLE
Fix status report of Antrea-native policies

### DIFF
--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
@@ -202,7 +202,13 @@ func NewNetworkPolicyController(antreaClientGetter agent.AntreaClientProvider,
 					policy.SourceRef.ToString())
 				return nil
 			}
-			c.ruleCache.UpdateNetworkPolicy(policy)
+			anyRuleUpdate := c.ruleCache.UpdateNetworkPolicy(policy)
+			// If there is any rule update, we ensure statusManager will resync the policy's status once, in case that
+			// the added/deleted/updated rule is not effective, in which case the rule's realization status is not
+			// changed but the whole policy's generation is changed.
+			if c.statusManagerEnabled && anyRuleUpdate && policy.SourceRef.Type != v1beta2.K8sNetworkPolicy {
+				c.statusManager.Resync(policy.UID)
+			}
 			return nil
 		},
 		DeleteFunc: func(obj runtime.Object) error {
@@ -696,25 +702,23 @@ loop:
 			if !ok {
 				return
 			}
+			klog.V(2).InfoS("Received event", "eventType", event.Type, "objectType", w.objectType, "object", event.Object)
 			switch event.Type {
 			case watch.Added:
 				if err := w.AddFunc(event.Object); err != nil {
 					klog.Errorf("Failed to handle added event: %v", err)
 					return
 				}
-				klog.V(2).Infof("Added %s (%#v)", w.objectType, event.Object)
 			case watch.Modified:
 				if err := w.UpdateFunc(event.Object); err != nil {
 					klog.Errorf("Failed to handle modified event: %v", err)
 					return
 				}
-				klog.V(2).Infof("Updated %s (%#v)", w.objectType, event.Object)
 			case watch.Deleted:
 				if err := w.DeleteFunc(event.Object); err != nil {
 					klog.Errorf("Failed to handle deleted event: %v", err)
 					return
 				}
-				klog.V(2).Infof("Removed %s (%#v)", w.objectType, event.Object)
 			default:
 				klog.Errorf("Unknown event: %v", event)
 				return

--- a/test/e2e/antreapolicy_test.go
+++ b/test/e2e/antreapolicy_test.go
@@ -3073,22 +3073,81 @@ func TestAntreaPolicyStatus(t *testing.T) {
 		CurrentNodesRealized: 2,
 		DesiredNodesRealized: 2,
 	}
-	err = wait.Poll(100*time.Millisecond, policyRealizedTimeout, func() (bool, error) {
-		anp, err := data.crdClient.CrdV1alpha1().NetworkPolicies(anp.Namespace).Get(context.TODO(), anp.Name, metav1.GetOptions{})
+	checkANPStatus(t, data, anp, expectedStatus)
+	checkACNPStatus(t, data, acnp, expectedStatus)
+}
+
+func TestAntreaPolicyStatusWithAppliedToPerRule(t *testing.T) {
+	skipIfHasWindowsNodes(t)
+	skipIfAntreaPolicyDisabled(t)
+
+	data, err := setupTest(t)
+	if err != nil {
+		t.Fatalf("Error when setting up test: %v", err)
+	}
+	defer teardownTest(t, data)
+
+	server0Name, _, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "server-0", controlPlaneNodeName(), testNamespace, false)
+	defer cleanupFunc()
+	server1Name, _, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "server-1", workerNodeName(1), testNamespace, false)
+	defer cleanupFunc()
+
+	anpBuilder := &AntreaNetworkPolicySpecBuilder{}
+	anpBuilder = anpBuilder.SetName(testNamespace, "anp-applied-to-per-rule").
+		SetPriority(1.0)
+	anpBuilder.AddIngress(v1.ProtocolTCP, &p80, nil, nil, nil, map[string]string{"pod": "b"}, map[string]string{"ns": "x"},
+		nil, nil, []ANPAppliedToSpec{{PodSelector: map[string]string{"antrea-e2e": server0Name}}}, crdv1alpha1.RuleActionAllow, "")
+	anpBuilder.AddIngress(v1.ProtocolTCP, &p80, nil, nil, nil, map[string]string{"pod": "b"}, map[string]string{"ns": "x"},
+		nil, nil, []ANPAppliedToSpec{{PodSelector: map[string]string{"antrea-e2e": server1Name}}}, crdv1alpha1.RuleActionAllow, "")
+	anp := anpBuilder.Get()
+	log.Debugf("creating ANP %v", anp.Name)
+	anp, err = data.crdClient.CrdV1alpha1().NetworkPolicies(anp.Namespace).Create(context.TODO(), anp, metav1.CreateOptions{})
+	assert.NoError(t, err)
+	defer data.crdClient.CrdV1alpha1().NetworkPolicies(anp.Namespace).Delete(context.TODO(), anp.Name, metav1.DeleteOptions{})
+
+	anp = checkANPStatus(t, data, anp, crdv1alpha1.NetworkPolicyStatus{
+		Phase:                crdv1alpha1.NetworkPolicyRealized,
+		ObservedGeneration:   1,
+		CurrentNodesRealized: 2,
+		DesiredNodesRealized: 2,
+	})
+
+	// Remove the second ingress rule.
+	anp.Spec.Ingress = anp.Spec.Ingress[0:1]
+	_, err = data.crdClient.CrdV1alpha1().NetworkPolicies(anp.Namespace).Update(context.TODO(), anp, metav1.UpdateOptions{})
+	assert.NoError(t, err)
+	checkANPStatus(t, data, anp, crdv1alpha1.NetworkPolicyStatus{
+		Phase:                crdv1alpha1.NetworkPolicyRealized,
+		ObservedGeneration:   2,
+		CurrentNodesRealized: 1,
+		DesiredNodesRealized: 1,
+	})
+}
+
+func checkANPStatus(t *testing.T, data *TestData, anp *crdv1alpha1.NetworkPolicy, expectedStatus crdv1alpha1.NetworkPolicyStatus) *crdv1alpha1.NetworkPolicy {
+	err := wait.Poll(100*time.Millisecond, policyRealizedTimeout, func() (bool, error) {
+		var err error
+		anp, err = data.crdClient.CrdV1alpha1().NetworkPolicies(anp.Namespace).Get(context.TODO(), anp.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
 		return anp.Status == expectedStatus, nil
 	})
 	assert.NoError(t, err, "Antrea NetworkPolicy failed to reach expected status")
-	err = wait.Poll(100*time.Millisecond, policyRealizedTimeout, func() (bool, error) {
-		anp, err := data.crdClient.CrdV1alpha1().ClusterNetworkPolicies().Get(context.TODO(), acnp.Name, metav1.GetOptions{})
+	return anp
+}
+
+func checkACNPStatus(t *testing.T, data *TestData, acnp *crdv1alpha1.ClusterNetworkPolicy, expectedStatus crdv1alpha1.NetworkPolicyStatus) *crdv1alpha1.ClusterNetworkPolicy {
+	err := wait.Poll(100*time.Millisecond, policyRealizedTimeout, func() (bool, error) {
+		var err error
+		acnp, err = data.crdClient.CrdV1alpha1().ClusterNetworkPolicies().Get(context.TODO(), acnp.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
-		return anp.Status == expectedStatus, nil
+		return acnp.Status == expectedStatus, nil
 	})
 	assert.NoError(t, err, "Antrea ClusterNetworkPolicy failed to reach expected status")
+	return acnp
 }
 
 // waitForANPRealized waits untils an ANP is realized and returns, or times out. A policy is


### PR DESCRIPTION
For an Antrea-native policy with multiple rules that have different AppliedTo, some rules may not be effective on a Node when the policy applies to the Node. In this case, antrea-agent didn't make any actual dataplane change and didn't report new status to antrea-controller if the only changed part of a policy event is about the ineffective rules, even though the generation of the policy may have changed. This leads to a policy staying in realizing state because of the missing status report.

This patch fixes it by triggering status report at least once as long as a policy is actually updated. In addition, it removes some useless return value and changes the order of event logs to better reflect the cause of policy reconciliation.

Signed-off-by: Quan Tian <qtian@vmware.com>

Fixes #3075