### PR TITLE
Fix typo in antrea-network-policy doc

### DIFF
--- a/docs/antrea-network-policy.md
+++ b/docs/antrea-network-policy.md
@@ -281,7 +281,7 @@ metadata:
   name: isolate-all-pods-in-namespace
 spec:
   priority: 1
-  tier: securityOps
+  tier: securityops
   appliedTo:
     - namespaceSelector:
         matchLabels:


### PR DESCRIPTION
This is a one-line change: there was a typo in the Tier name for one
policy example.
s/securityOps/securityops

Signed-off-by: Antonin Bas <abas@vmware.com>