### PR TITLE
Fix NetworkPolicy resources dump for Agent's supportbundle

### DIFF
--- a/pkg/apis/controlplane/v1beta2/marshal.go
+++ b/pkg/apis/controlplane/v1beta2/marshal.go
@@ -1,0 +1,23 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1beta2
+
+import (
+	"net"
+)
+
+func (a IPAddress) MarshalYAML() (interface{}, error) {
+	return net.IP(a).String(), nil
+}

--- a/pkg/support/dump.go
+++ b/pkg/support/dump.go
@@ -16,7 +16,6 @@ package support
 
 import (
 	"bufio"
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -28,6 +27,7 @@ import (
 	"time"
 
 	"github.com/spf13/afero"
+	"gopkg.in/yaml.v2"
 	"k8s.io/utils/exec"
 
 	agentquerier "antrea.io/antrea/pkg/agent/querier"
@@ -216,12 +216,28 @@ func directoryCopy(fs afero.Fs, targetDir string, srcDir string, prefixFilter st
 	})
 }
 
-// writeFile writes the given data to the specified filePath. Param "resource" is used to identify the type of the given
-// data in the error message.
+// writeFile writes the given data to the specified filePath. Param "resource" is used to identify
+// the type of the given data in the error message.
 func writeFile(fs afero.Fs, filePath string, resource string, data []byte) error {
 	err := afero.WriteFile(fs, filePath, data, 0644)
 	if err != nil {
 		return fmt.Errorf("error when writing %s to file: %w", resource, err)
+	}
+	return nil
+}
+
+// writeYAMLFile writes the given data to the specified filePath in YAML format. Param "resource" is
+// used to identify the type of the given data in the error message.
+func writeYAMLFile(fs afero.Fs, filePath string, resource string, data interface{}) error {
+	f, err := fs.Create(filePath)
+	if err != nil {
+		return fmt.Errorf("error when creating file %s to write %s: %w", filePath, resource, err)
+	}
+	defer f.Close()
+	encoder := yaml.NewEncoder(f)
+	defer encoder.Close()
+	if err := encoder.Encode(data); err != nil {
+		return fmt.Errorf("error when writing %s to %s in YAML format: %w", resource, filePath, err)
 	}
 	return nil
 }
@@ -268,28 +284,14 @@ type agentDumper struct {
 }
 
 func (d *agentDumper) DumpAgentInfo(basedir string) error {
-	ci := new(clusterinformationv1beta1.AntreaAgentInfo)
-	d.aq.GetAgentInfo(ci, false)
-	f, err := d.fs.Create(filepath.Join(basedir, "agentinfo"))
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-	encoder := json.NewEncoder(f)
-	encoder.SetIndent("", "  ")
-	return encoder.Encode(ci)
+	ai := new(clusterinformationv1beta1.AntreaAgentInfo)
+	d.aq.GetAgentInfo(ai, false)
+	return writeYAMLFile(d.fs, filepath.Join(basedir, "agentinfo"), "agentinfo", ai)
 }
 
 func (d *agentDumper) DumpNetworkPolicyResources(basedir string) error {
 	dump := func(o interface{}, name string) error {
-		f, err := d.fs.Create(filepath.Join(basedir, "agentinfo"))
-		if err != nil {
-			return err
-		}
-		defer f.Close()
-		encoder := json.NewEncoder(f)
-		encoder.SetIndent("", "  ")
-		return encoder.Encode(o)
+		return writeYAMLFile(d.fs, filepath.Join(basedir, name), name, o)
 	}
 	if err := dump(d.npq.GetAddressGroups(), "addressgroups"); err != nil {
 		return err


### PR DESCRIPTION
There was an obvious bug where all NetworkPolicy resources
(NetworkPolicies, AddressGroups, AppliedToGroups) were dumped to the
same file, and the file itself ("agentinfo") was subsequently
overwritten with a dump of the appropriate AgentInfo CRD as expected.

This is fixed by dumping these resources to their respective appropriate
files: networkpolicies, addressgroups, appliedtogroups.

In addition, we:
* switch from JSON to YAML for these resources (along with the AgentInfo
  CRD) for consistency with the files included in the Controller's
  supportbundle.
* define a custom MarshalYAML function for the IPAddress type. IPAddress
  is typedef'ed to a byte slice, which means that by default it is
  marshalled as an array of individual byte values, making the files
  difficult to read.

Fixes #3082

Signed-off-by: Antonin Bas <abas@vmware.com>