### PR TITLE
Fix concurrent setting for integration jobs

### DIFF
--- a/ci/jenkins/jobs/job-templates.yaml
+++ b/ci/jenkins/jobs/job-templates.yaml
@@ -48,6 +48,61 @@
     wrappers: '{wrappers}'
 
 - job-template:
+    name: '{name}-{test_name}-integration-for-pull-request'
+    node: '{node}'
+    block-downstream: false
+    block-upstream: false
+    builders: '{builders}'
+    concurrent: false
+    description: '{description}'
+    project-type: freestyle
+    properties:
+    - build-discarder:
+        artifact-days-to-keep: -1
+        artifact-num-to-keep: -1
+        days-to-keep: 7
+        num-to-keep: 30
+    - github:
+        url: 'https://github.com/{org_repo}'
+    - throttle:
+        max-per-node: 1
+        max-total: 0
+        categories: '{throttle_concurrent_builds_category}'
+        option: category
+        enabled: '{throttle_concurrent_builds_enabled}'
+    publishers: '{publishers}'
+    scm:
+    - git:
+        branches: '{branches}'
+        credentials-id: '{git_credentials_id}'
+        name: origin
+        refspec: +refs/heads/*:refs/remotes/origin/* +refs/pull/${{ghprbPullId}}/*:refs/remotes/origin/pr/${{ghprbPullId}}/*
+        url: 'https://github.com/{org_repo}'
+        wipe-workspace: true
+    triggers:
+    - github-pull-request:
+        admin-list: '{admin_list}'
+        allow-whitelist-orgs-as-admins: '{allow_whitelist_orgs_as_admins}'
+        auth-id: '{ghpr_auth}'
+        auto-close-on-fail: false
+        build-desc-template: null
+        github-hooks: true
+        only-trigger-phrase: '{only_trigger_phrase}'
+        org-list: '{org_list}'
+        permit-all: '{trigger_permit_all}'
+        trigger-phrase: '{trigger_phrase}'
+        white-list-target-branches: '{white_list_target_branches}'
+        white-list: '{white_list}'
+        status-context: '{status_context}'
+        status-url: '{status_url}'
+        success-status: '{success_status}'
+        failure-status: '{failure_status}'
+        error-status: '{error_status}'
+        triggered-status: '{triggered_status}'
+        started-status: '{started_status}'
+    wrappers: '{wrappers}'
+
+- job-template:
       name: '{name}-{test_name}-no-scm'
       node: '{node}'
       block-downstream: false

--- a/ci/jenkins/jobs/projects.yaml
+++ b/ci/jenkins/jobs/projects.yaml
@@ -139,22 +139,18 @@
           publishers: []
           included_regions:
           - ci/jenkins/jobs/.*
-      - '{name}-{test_name}-for-pull-request':
-          test_name: integration
+      - '{name}-{test_name}-integration-for-pull-request':
+          test_name: auto
           node: 'antrea-test-node'
-          description: 'This is the {test_name} test for {name}.'
+          description: 'This is the {test_name} integration test for {name}.'
           branches:
           - ${{sha1}}
           builders:
           - builder-integration
-          properties:
-          - throttle:
-              max-per-node: 1
-              max-total: 0
-              categories: integration
-              option: category
-              enabled: true
           trigger_phrase: null
+          throttle_concurrent_builds_category:
+            - integration
+          throttle_concurrent_builds_enabled: 'true'
           white_list_target_branches: []
           allow_whitelist_orgs_as_admins: false
           admin_list: []
@@ -189,22 +185,18 @@
                   credential-id: CODECOV_TOKEN # Jenkins secret that stores codecov token
                   variable: CODECOV_TOKEN
           publishers: []
-      - '{name}-{test_name}-for-pull-request':
-          test_name: integration-manual
+      - '{name}-{test_name}-integration-for-pull-request':
+          test_name: manual
           node: 'antrea-test-node'
-          description: 'This is the {test_name} test for {name}.'
+          description: 'This is the {test_name} integration test for {name}.'
           branches:
           - ${{sha1}}
           builders:
           - builder-integration
-          properties:
-          - throttle:
-              max-per-node: 1
-              max-total: 0
-              categories: integration
-              option: category
-              enabled: true
           trigger_phrase: ^(?!Thanks for your PR).*/test-integration.*
+          throttle_concurrent_builds_category:
+            - integration
+          throttle_concurrent_builds_enabled: 'true'
           white_list_target_branches: []
           allow_whitelist_orgs_as_admins: true
           admin_list: '{antrea_admin_list}'


### PR DESCRIPTION
Add throttle setting property in project definition will be
overwritten by template, so add a new template for integration jobs
so we can define throttle concurrency for them.

Signed-off-by: Lan Luo <luola@vmware.com>