### PR TITLE
[windows] Fix bug in configureContainerLink

### DIFF
--- a/pkg/agent/cniserver/interface_configuration_windows.go
+++ b/pkg/agent/cniserver/interface_configuration_windows.go
@@ -140,7 +140,7 @@ func (ic *ifConfigurator) configureContainerLink(
 	containerIface, err := attachContainerLink(endpoint, containerID, containerNetNS, containerIFDev)
 	if err != nil {
 		klog.V(2).Infof("Failed to attach HNS Endpoint to the container, remove it.")
-		if isInfraContainer(containerID) {
+		if isInfraContainer(containerNetNS) {
 			ic.removeHNSEndpoint(endpoint, containerID)
 		}
 		return fmt.Errorf("failed to configure container IP: %v", err)


### PR DESCRIPTION
We should use containerNetNS when deciding if a container is an infra one.

Signed-off-by: Shuyang Xin <gavinx@vmware.com>

Fixes #3077