### PR TITLE
Automated cherry pick of #3083: Fix NetworkPolicy resources dump for Agent's supportbundle

### DIFF
--- a/pkg/apis/controlplane/v1beta2/marshal.go
+++ b/pkg/apis/controlplane/v1beta2/marshal.go
@@ -1,0 +1,23 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1beta2
+
+import (
+	"net"
+)
+
+func (a IPAddress) MarshalYAML() (interface{}, error) {
+	return net.IP(a).String(), nil
+}


### PR DESCRIPTION
Cherry pick of #3083 on release-1.2.

#3083: Fix NetworkPolicy resources dump for Agent's supportbundle

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.