### PR TITLE
Add multi-cluster manual integration job

### DIFF
--- a/ci/jenkins/jobs/macros.yaml
+++ b/ci/jenkins/jobs/macros.yaml
@@ -15,6 +15,16 @@
             DOCKER_REGISTRY="$(head -n1 ci/docker-registry)"
             ./ci/jenkins/test-vmc.sh --testcase integration --coverage --codecov-token "${CODECOV_TOKEN}" --registry ${DOCKER_REGISTRY}
 
+
+- builder:
+      name: builder-multicluster-integration
+      builders:
+        - shell: |-
+            #!/bin/bash
+            set -e
+            DOCKER_REGISTRY="$(head -n1 ci/docker-registry)"
+            ./ci/jenkins/test-vmc.sh --testcase multicluster-integration --coverage --codecov-token "${CODECOV_TOKEN}" --registry ${DOCKER_REGISTRY}
+
 - builder:
     name: builder-eks-cluster-cleanup
     builders:

--- a/ci/jenkins/jobs/projects.yaml
+++ b/ci/jenkins/jobs/projects.yaml
@@ -159,7 +159,7 @@
           - nobody123_nobody123_
           only_trigger_phrase: false
           trigger_permit_all: true
-          status_context: Integration tests
+          status_context: jenkins-integration-tests
           status_url: null
           success_status: Build finished.
           failure_status: Failed.
@@ -204,11 +204,56 @@
           white_list: '{antrea_white_list}'
           only_trigger_phrase: true
           trigger_permit_all: true
-          status_context: Integration tests
+          status_context: jenkins-integration-tests
           status_url: null
           success_status: Build finished.
           failure_status: Failed. Add comment /test-integration to re-trigger.
           error_status: Failed. Add comment /test-integration to re-trigger.
+          triggered_status: null
+          started_status: null
+          wrappers:
+          - timeout:
+              fail: true
+              timeout: 20
+              type: absolute
+          - credentials-binding:
+              - text:
+                  credential-id: GOVC_URL
+                  variable: GOVC_URL
+              - text:
+                  credential-id: GOVC_USERNAME
+                  variable: GOVC_USERNAME
+              - text:
+                  credential-id: GOVC_PASSWORD
+                  variable: GOVC_PASSWORD
+              - text:
+                  credential-id: CODECOV_TOKEN # Jenkins secret that stores codecov token
+                  variable: CODECOV_TOKEN
+          publishers: []
+      - '{name}-{test_name}-integration-for-pull-request':
+          test_name: multicluster-manual
+          node: 'antrea-test-node'
+          description: 'This is the {test_name} integration test for {name}.'
+          branches:
+          - ${{sha1}}
+          builders:
+          - builder-multicluster-integration
+          trigger_phrase: ^(?!Thanks for your PR).*/test-mc-integration.*
+          throttle_concurrent_builds_category:
+            - integration
+          throttle_concurrent_builds_enabled: 'true'
+          white_list_target_branches: []
+          allow_whitelist_orgs_as_admins: true
+          admin_list: '{antrea_admin_list}'
+          org_list: '{antrea_org_list}'
+          white_list: '{antrea_white_list}'
+          only_trigger_phrase: true
+          trigger_permit_all: true
+          status_context: jenkins-mc-integration-tests
+          status_url: null
+          success_status: Build finished.
+          failure_status: Failed. Add comment /test-mc-integration to re-trigger.
+          error_status: Failed. Add comment /test-mc-integration to re-trigger.
           triggered_status: null
           started_status: null
           wrappers:


### PR DESCRIPTION
1. add multi-cluster manual integration job
2. update status_context for all integration jobs to be consistent as
   other jobs.

the change to add  multicluster-integration test cases support in `test-vmc.sh` will be submitted in another PR in feature branch.

Signed-off-by: Lan Luo <luola@vmware.com>