### PR TITLE
Validate namespaces.match of AntreaClusterNetworkPolicy rules

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -927,6 +927,8 @@ spec:
                           namespaces:
                             properties:
                               match:
+                                enum:
+                                - Self
                                 type: string
                             type: object
                           podSelector:

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -927,6 +927,8 @@ spec:
                           namespaces:
                             properties:
                               match:
+                                enum:
+                                - Self
                                 type: string
                             type: object
                           podSelector:

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -927,6 +927,8 @@ spec:
                           namespaces:
                             properties:
                               match:
+                                enum:
+                                - Self
                                 type: string
                             type: object
                           podSelector:

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -927,6 +927,8 @@ spec:
                           namespaces:
                             properties:
                               match:
+                                enum:
+                                - Self
                                 type: string
                             type: object
                           podSelector:

--- a/build/yamls/antrea-kind.yml
+++ b/build/yamls/antrea-kind.yml
@@ -927,6 +927,8 @@ spec:
                           namespaces:
                             properties:
                               match:
+                                enum:
+                                - Self
                                 type: string
                             type: object
                           podSelector:

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -927,6 +927,8 @@ spec:
                           namespaces:
                             properties:
                               match:
+                                enum:
+                                - Self
                                 type: string
                             type: object
                           podSelector:

--- a/build/yamls/base/crds.yml
+++ b/build/yamls/base/crds.yml
@@ -942,6 +942,8 @@ spec:
                               type: object
                               properties:
                                 match:
+                                  enum:
+                                    - Self
                                   type: string
                             ipBlock:
                               type: object


### PR DESCRIPTION
Signed-off-by: Quan Tian <qtian@vmware.com>

The issue mentioned in #3091 has been encountered by several people, validating the value can avoid misuse of the field.