### PR TITLE
Fix the case of protocol in flow-aggregator doc

### DIFF
--- a/docs/network-flow-visibility.md
+++ b/docs/network-flow-visibility.md
@@ -262,10 +262,10 @@ value for this parameter in the following snippet.
 
 * If you have deployed the [go-ipfix collector](#deployment-steps),
 then please use the address:  
-`<Ipfix-Collector Cluster IP>:<port>:<TCP|UDP>`
+`<Ipfix-Collector Cluster IP>:<port>:<tcp|udp>`
 * If you have deployed the [ELK
 flow collector](#deployment-steps-1), then please use the address:  
-`<Logstash Cluster IP>:4739:<TCP|UDP>` for sending IPFIX messages, or `<Logstash Cluster IP>:4736:<TCP|UDP>`
+`<Logstash Cluster IP>:4739:<tcp|udp>` for sending IPFIX messages, or `<Logstash Cluster IP>:4736:<tcp|udp>`
 for sending JSON format records. Record format is specified with `recordFormat` (defaults
 to IPFIX) and must match the format expected by the collector.
 


### PR DESCRIPTION
The protocol must be written in lowercase, otherwise the validation
would fail.

Signed-off-by: Quan Tian <qtian@vmware.com>

I followed the doc to deploy flow-aggregator and found it crashed because of this.