### PR TITLE
Add env parameter to support noEncap without AntreaProxy

### DIFF
--- a/docs/noencap-hybrid-modes.md
+++ b/docs/noencap-hybrid-modes.md
@@ -9,6 +9,30 @@ are in different subnets, but does not encapsulate when the source and the
 destination Nodes are in the same subnet. This document describes how to
 configure Antrea with the `NoEncap` and `Hybrid` modes.
 
+The NoEncap and Hybrid traffic modes require AntreaProxy to support correct
+NetworkPolicy enforcement, which is why trying to disable AntreaProxy in these
+modes will normally cause the Antrea Agent to fail. It is possible to override
+this behavior and force AntreaProxy to be disabled by setting the
+ALLOW_NO_ENCAP_WITHOUT_ANTREA_PROXY environment variable to true for the Antrea
+Agent. For example:
+
+```yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: antrea-agent
+  labels:
+    component: antrea-agent
+spec:
+  containers:
+    - name: antrea-agent
+      ... ...
+      env:
+        - name: ALLOW_NO_ENCAP_WITHOUT_ANTREA_PROXY
+          value: "true"
+      ... ...
+```
+
 ## Hybrid Mode
 
 Let us start from `Hybrid` mode which is simpler to configure. `Hybrid` mode

--- a/pkg/util/env/env.go
+++ b/pkg/util/env/env.go
@@ -33,6 +33,8 @@ const (
 	antreaCloudEKSEnvKey = "ANTREA_CLOUD_EKS"
 
 	defaultAntreaNamespace = "kube-system"
+
+	allowNoEncapWithoutAntreaProxyEnvKey = "ALLOW_NO_ENCAP_WITHOUT_ANTREA_PROXY"
 )
 
 // GetNodeName returns the node's name used in Kubernetes, based on the priority:
@@ -120,4 +122,10 @@ func GetAntreaNamespace() string {
 		namespace = defaultAntreaNamespace
 	}
 	return namespace
+}
+
+// GetAllowNoEncapWithoutAntreaProxy returns whether AntreaProxy can be disabled for traffic
+// modes which support noEncap.
+func GetAllowNoEncapWithoutAntreaProxy() bool {
+	return getBoolEnvVar(allowNoEncapWithoutAntreaProxyEnvKey, false)
 }


### PR DESCRIPTION
When using NoEncap traffic mode without AntreaProxy, Pod-to-Service
traffic is handled by kube-proxy (iptables/ipvs) in the root netns.
If the Endpoint is not local the DNATed traffic will be output to
the physical network directly without going back to OVS for Egress
NetworkPolicy enforcement, which breaks basic security functionality.
Therefore, we usually do not allow the NoEncap traffic mode without
AntreaProxy. But one can bypass this check and force this feature
combination to be allowed, by defining the ALLOW_NO_ENCAP_WITHOUT_ANTREA_PROXY
environment variable and setting it to true. This may lead to better
performance when using NoEncap if Egress NetworkPolicy enforcement is
not required.

Signed-off-by: Wenze Gao <wenze.gao@transwarp.io>
Signed-off-by: Wu zhengdong <zhengdong.wu@transwarp.io>