### PR TITLE
Use unique agnhost Docker image for all e2e tests

### DIFF
--- a/ci/kind/test-e2e-kind.sh
+++ b/ci/kind/test-e2e-kind.sh
@@ -125,7 +125,7 @@ if ! $np; then
     manifest_args="$manifest_args --no-np"
 fi
 
-COMMON_IMAGES_LIST=("gcr.io/kubernetes-e2e-test-images/agnhost:2.8" \
+COMMON_IMAGES_LIST=("k8s.gcr.io/e2e-test-images/agnhost:2.29" \
                     "projects.registry.vmware.com/library/busybox"  \
                     "projects.registry.vmware.com/antrea/nginx" \
                     "projects.registry.vmware.com/antrea/perftool" \

--- a/hack/netpol-generator/test-kind.sh
+++ b/hack/netpol-generator/test-kind.sh
@@ -20,8 +20,8 @@ kind load docker-image projects.registry.vmware.com/antrea/antrea-ubuntu:latest
 docker pull mfenwick100/cyclonus:v0.4.7
 kind load docker-image mfenwick100/cyclonus:v0.4.7
 # pre-load agnhost image
-docker pull k8s.gcr.io/e2e-test-images/agnhost:2.21
-kind load docker-image k8s.gcr.io/e2e-test-images/agnhost:2.21
+docker pull k8s.gcr.io/e2e-test-images/agnhost:2.29
+kind load docker-image k8s.gcr.io/e2e-test-images/agnhost:2.29
 
 "$ROOT_DIR"/hack/generate-manifest.sh --kind --tun "vxlan" | kubectl apply -f -
 

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -108,7 +108,7 @@ const (
 
 	nameSuffixLength int = 8
 
-	agnhostImage        = "projects.registry.vmware.com/antrea/agnhost:2.26"
+	agnhostImage        = "k8s.gcr.io/e2e-test-images/agnhost:2.29"
 	busyboxImage        = "projects.registry.vmware.com/library/busybox"
 	nginxImage          = "projects.registry.vmware.com/antrea/nginx"
 	perftoolImage       = "projects.registry.vmware.com/antrea/perftool"
@@ -1092,7 +1092,6 @@ func (data *TestData) createServerPod(name string, ns string, portName string, p
 // createCustomPod creates a Pod in given Namespace with custom labels.
 func (data *TestData) createServerPodWithLabels(name, ns string, portNum int32, labels map[string]string) error {
 	cmd := []string{"/agnhost", "serve-hostname", "--tcp", "--http=false", "--port", fmt.Sprintf("%d", portNum)}
-	image := "k8s.gcr.io/e2e-test-images/agnhost:2.29"
 	env := corev1.EnvVar{Name: fmt.Sprintf("SERVE_PORT_%d", portNum), Value: "foo"}
 	port := corev1.ContainerPort{ContainerPort: portNum}
 	containerName := fmt.Sprintf("c%v", portNum)
@@ -1101,7 +1100,7 @@ func (data *TestData) createServerPodWithLabels(name, ns string, portNum int32, 
 			pod.Labels[k] = v
 		}
 	}
-	return data.createPodOnNodeInNamespace(name, ns, "", containerName, image, cmd, nil, []corev1.EnvVar{env}, []corev1.ContainerPort{port}, false, mutateLabels)
+	return data.createPodOnNodeInNamespace(name, ns, "", containerName, agnhostImage, cmd, nil, []corev1.EnvVar{env}, []corev1.ContainerPort{port}, false, mutateLabels)
 }
 
 // deletePod deletes a Pod in the test namespace.

--- a/test/e2e/k8s_util.go
+++ b/test/e2e/k8s_util.go
@@ -252,7 +252,7 @@ func (k *KubernetesUtils) CreateOrUpdateDeployment(ns, deploymentName string, re
 		return v1.Container{
 			Name:            fmt.Sprintf("c%d", port),
 			ImagePullPolicy: v1.PullIfNotPresent,
-			Image:           "k8s.gcr.io/e2e-test-images/agnhost:2.29",
+			Image:           agnhostImage,
 			Env:             []v1.EnvVar{{Name: fmt.Sprintf("SERVE_SCTP_PORT_%d", port), Value: "foo"}},
 			Command:         []string{"/bin/bash", "-c"},
 			Args:            args,

--- a/test/e2e/nodeportlocal_test.go
+++ b/test/e2e/nodeportlocal_test.go
@@ -393,7 +393,6 @@ func NPLTestPodAddMultiProtocol(t *testing.T) {
 	args := []string{
 		fmt.Sprintf("/agnhost serve-hostname --udp --http=false --port %d & /agnhost serve-hostname --tcp --http=false --port %d", 8080, 8080),
 	}
-	image := "k8s.gcr.io/e2e-test-images/agnhost:2.29"
 	port := corev1.ContainerPort{ContainerPort: 8080}
 	containerName := fmt.Sprintf("c%v", 8080)
 	mutateLabels := func(pod *corev1.Pod) {
@@ -401,7 +400,7 @@ func NPLTestPodAddMultiProtocol(t *testing.T) {
 			pod.Labels[k] = v
 		}
 	}
-	err := testData.createPodOnNodeInNamespace(testPodName, testNamespace, node, containerName, image, cmd, args, []corev1.EnvVar{}, []corev1.ContainerPort{port}, false, mutateLabels)
+	err := testData.createPodOnNodeInNamespace(testPodName, testNamespace, node, containerName, agnhostImage, cmd, args, []corev1.EnvVar{}, []corev1.ContainerPort{port}, false, mutateLabels)
 
 	r.NoError(err, "Error creating test Pod: %v", err)
 


### PR DESCRIPTION
And pre-load the image into all Kind Nodes when using Kind for CI
testing.

This is an attempt to mitigate #3119

Signed-off-by: Antonin Bas <abas@vmware.com>