### PR TITLE
Support for kube-proxy ipvs mode in Vagrant testbed

### DIFF
--- a/test/e2e/infra/vagrant/Vagrantfile
+++ b/test/e2e/infra/vagrant/Vagrantfile
@@ -35,9 +35,20 @@ end
 NODE_NETWORK_V4_PREFIX = "192.168.77."
 NODE_NETWORK_V6_PREFIX = "fd3b:fcf5:3e92:d732::"
 
-MEMORY = 2048
 if ENV['K8S_NODE_LARGE'] == "true"
   MEMORY = 4096
+else
+  MEMORY = 2048
+end
+
+KUBE_PROXY_MODE = ENV['KUBE_PROXY_MODE'] || "iptables"
+if KUBE_PROXY_MODE == "iptables"
+  KUBE_PROXY_IPVS_STRICT_ARP = false
+elsif KUBE_PROXY_MODE == "ipvs"
+  # For now, we always enable strict ARP, which is required to use MetalLB
+  KUBE_PROXY_IPVS_STRICT_ARP = true
+else
+  raise "KUBE_PROXY_MODE env variable should be one of 'iptables' or 'ipvs'"
 end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
@@ -90,6 +101,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         k8s_api_server_ip: (MODE == "v6") ? node_ipv6 : node_ipv4,
         k8s_ip_family: MODE,
         k8s_antrea_gw_ip: K8S_NODE_CP_GW_IP,
+        kube_proxy_mode: KUBE_PROXY_MODE,
+        kube_proxy_ipvs_strict_arp: KUBE_PROXY_IPVS_STRICT_ARP,
       }
     end
   end

--- a/test/e2e/infra/vagrant/playbook/roles/control-plane/templates/kubeadm.conf.j2
+++ b/test/e2e/infra/vagrant/playbook/roles/control-plane/templates/kubeadm.conf.j2
@@ -15,3 +15,11 @@ apiServer:
   - "{{ k8s_api_server_ip }}"
   extraArgs:
     feature-gates: "NetworkPolicyEndPort=true"
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+mode: "{{ kube_proxy_mode }}"
+{% if kube_proxy_ipvs_strict_arp -%}
+ipvs:
+  strictARP: true
+{% endif %}

--- a/test/e2e/infra/vagrant/provision.sh
+++ b/test/e2e/infra/vagrant/provision.sh
@@ -3,13 +3,15 @@
 function usage() {
     echo "Usage: provision.sh [--ip-family <v4|v6>] [-l|--large] [-h|--help]
     Provisions the Vagrant VMs.
-    --ip-family <v4|v6|dual>  Deploy IPv4, IPv6 or dual-stack Kubernetes cluster.
-    --large                   Deploy large vagrant VMs with 2 vCPUs and 4096MB memory.
-                              By default, we deploy VMs with 2 vCPUs and 2048MB memory."
+    --ip-family <v4|v6|dual>           Deploy IPv4, IPv6 or dual-stack Kubernetes cluster.
+    --large                            Deploy large vagrant VMs with 2 vCPUs and 4096MB memory.
+                                       By default, we deploy VMs with 2 vCPUs and 2048MB memory.
+    --kube-proxy-mode <iptables|ipvs>  Which mode to use for kube-proxy (default is iptables)."
 }
 
 K8S_IP_FAMILY="v4"
 K8S_NODE_LARGE=false
+KUBE_PROXY_MODE="iptables"
 while [[ $# -gt 0 ]]
 do
 key="$1"
@@ -22,6 +24,10 @@ case $key in
     -l|--large)
     K8S_NODE_LARGE=true
     shift 1
+    ;;
+    --kube-proxy-mode)
+    KUBE_PROXY_MODE="$2"
+    shift 2
     ;;
     -h|--help)
     usage
@@ -39,6 +45,7 @@ pushd $THIS_DIR
 
 export K8S_NODE_LARGE
 export K8S_IP_FAMILY
+export KUBE_PROXY_MODE
 
 # A few important considerations for IPv6 clusters:
 # * there is no assumption that the host machine supports IPv6.


### PR DESCRIPTION
Signed-off-by: Antonin Bas <abas@vmware.com>