### PR TITLE
Add E2E test for antrea multiclusters

### DIFF
--- a/ci/jenkins/test-mc.sh
+++ b/ci/jenkins/test-mc.sh
@@ -1,0 +1,293 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 Antrea Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+function echoerr {
+    >&2 echo "$@"
+}
+
+DEFAULT_WORKDIR="/var/lib/jenkins"
+DEFAULT_KUBECONFIG_PATH=$DEFAULT_WORKDIR/kube.conf
+WORKDIR=$DEFAULT_WORKDIR
+TESTCASE=""
+TEST_FAILURE=false
+DOCKER_REGISTRY=$(head -n1 "${WORKSPACE}/ci/docker-registry")
+GO_VERSION=$(head -n1 "${WORKSPACE}/build/images/deps/go-version")
+IMAGE_PULL_POLICY="Always"
+MULTICLUSTER_KUBECONFIG_PATH=$WORKDIR/.kube
+LEADER_CLUSTER_CONFIG="--kubeconfig=$MULTICLUSTER_KUBECONFIG_PATH/leader"
+EAST_CLUSTER_CONFIG="--kubeconfig=$MULTICLUSTER_KUBECONFIG_PATH/east"
+WEST_CLUSTER_CONFIG="--kubeconfig=$MULTICLUSTER_KUBECONFIG_PATH/west"
+
+CONTROL_PLANE_NODE_ROLE="control-plane,master"
+
+multicluster_kubeconfigs=($EAST_CLUSTER_CONFIG $LEADER_CLUSTER_CONFIG $WEST_CLUSTER_CONFIG)
+membercluter_kubeconfigs=($EAST_CLUSTER_CONFIG $WEST_CLUSTER_CONFIG)
+
+
+CLEAN_STALE_IMAGES="docker system prune --force --all --filter until=48h"
+
+_usage="Usage: $0 [--kubeconfigs-path <KubeconfigSavePath>] [--workdir <HomePath>]
+                  [--testcase <e2e>]
+
+Run Antrea multi-cluster e2e tests on a remote (Jenkins) Linux Cluster Set.
+
+        --kubeconfigs-path            Path of cluster set kubeconfigs.
+        --workdir                     Home path for Go, vSphere information and antrea_logs during cluster setup. Default is $WORKDIR.
+        --testcase                    Antrea multi-cluster e2e test cases on a Linux cluster set.
+        --registry                    The docker registry to use instead of dockerhub."
+
+function print_usage {
+    echoerr "$_usage"
+}
+
+
+while [[ $# -gt 0 ]]
+do
+key="$1"
+
+case $key in
+    --kubeconfigs-path)
+    MULTICLUSTER_KUBECONFIG_PATH="$2"
+    shift 2
+    ;;
+    --workdir)
+    WORKDIR="$2"
+    shift 2
+    ;;
+    --testcase)
+    TESTCASE="$2"
+    shift 2
+    ;;
+    --registry)
+    DOCKER_REGISTRY="$2"
+    shift 2
+    ;;
+    -h|--help)
+    print_usage
+    exit 0
+    ;;
+    *)    # unknown option
+    echoerr "Unknown option $1"
+    exit 1
+    ;;
+esac
+done
+
+function clean_tmp() {
+    echo "===== Clean up stale files & folders older than 7 days under /tmp ====="
+    CLEAN_LIST=(
+        "*codecov*"
+        "kustomize-*"
+        "*antrea*"
+        "go-build*"
+    )
+    for item in "${CLEAN_LIST[@]}"; do
+        find /tmp -name "${item}" -mtime +7 -exec rm -rf {} \; 2>&1 | grep -v "Permission denied" || true
+    done
+    find ${WORKDIR} -name "support-bundles*" -mtime +7 -exec rm -rf {} \; 2>&1 | grep -v "Permission denied" || true
+}
+
+
+function cleanup_multicluster_ns {
+    ns=$1
+    kubeconfig=$2
+
+    kubectl delete ns "${ns}" --ignore-not-found=true ${kubeconfig} --timeout=30s || true
+}
+
+function cleanup_multicluster_controller {
+    echo "====== Cleanup Multicluster Controller Installation ======"
+    kubeconfig=$1
+    for multicluster_yml in ${WORKSPACE}/multicluster/test/yamls/*.yml; do
+        kubectl delete -f $multicluster_yml $kubeconfig --ignore-not-found=true  --timeout=30s || true
+    done
+
+    for multicluster_yml in ${WORKSPACE}/multicluster/build/yamls/*.yml; do
+        kubectl delete -f $multicluster_yml $kubeconfig --ignore-not-found=true --timeout=30s || true
+    done
+}
+
+function cleanup_multicluster_antrea {
+    echo "====== Cleanup Antrea controller and agent ======"
+    kubeconfig=$1
+    kubectl get pod -n kube-system -l component=antrea-agent --no-headers=true $kubeconfig | awk '{print $1}' | while read AGENTNAME; do
+       kubectl exec $AGENTNAME -c antrea-agent -n kube-system ${kubeconfig}  ovs-vsctl del-port br-int gw0 || true
+    done
+
+   for antrea_yml in ${WORKDIR}/*.yml; do
+        kubectl delete -f $antrea_yml --ignore-not-found=true ${kubeconfig} --timeout=30s || true
+    done
+}
+
+function clean_multicluster {
+    echo "====== Cleanup Multicluster Antrea Installation in clusters ======"
+    for kubeconfig in ${multicluster_kubeconfigs[@]}
+    do
+        cleanup_multicluster_ns "antrea-multicluster-test" $kubeconfig
+        cleanup_multicluster_ns "antrea-mcs-ns" $kubeconfig
+        cleanup_multicluster_controller $kubeconfig
+        cleanup_multicluster_antrea $kubeconfig
+    done
+}
+
+function wait_for_antrea_multicluster_pods_ready {
+    kubeconfig=$1
+    kubectl apply -f build/yamls/antrea.yml "${kubeconfig}"
+    kubectl rollout restart deployment/coredns -n kube-system "${kubeconfig}"
+    kubectl rollout status deployment/coredns -n kube-system "${kubeconfig}"
+    kubectl rollout status deployment.apps/antrea-controller -n kube-system "${kubeconfig}"
+    kubectl rollout status daemonset/antrea-agent -n kube-system "${kubeconfig}"
+}
+
+function wait_for_multicluster_controller_ready {
+    kubectl create ns antrea-mcs-ns  "${LEADER_CLUSTER_CONFIG}" || true
+    kubectl apply -f ./multicluster/test/yamls/manifest.yml "${LEADER_CLUSTER_CONFIG}"
+    kubectl apply -f ./multicluster/build/yamls/antrea-multicluster-leader-global.yml "${LEADER_CLUSTER_CONFIG}"
+    kubectl rollout status deployment/antrea-mc-controller -n antrea-mcs-ns "${LEADER_CLUSTER_CONFIG}" || true
+    kubectl apply -f ./multicluster/test/yamls/manifest.yml "${LEADER_CLUSTER_CONFIG}"
+    kubectl create -f ./multicluster/test/yamls/leader-access-token-secret.yml "${LEADER_CLUSTER_CONFIG}" || true
+    kubectl get secret -n antrea-mcs-ns leader-access-token "${LEADER_CLUSTER_CONFIG}" -o yaml > ./multicluster/test/yamls/leader-access-token.yml
+
+    sed -i '/uid:/d' ./multicluster/test/yamls/leader-access-token.yml
+    sed -i '/resourceVersion/d' ./multicluster/test/yamls/leader-access-token.yml
+    sed -i '/last-applied-configuration/d' ./multicluster/test/yamls/leader-access-token.yml
+    sed -i '/type/d' ./multicluster/test/yamls/leader-access-token.yml
+    sed -i '/creationTimestamp/d' ./multicluster/test/yamls/leader-access-token.yml
+    sed -i 's/antrea-multicluster-member-access-sa/antrea-multicluster-controller/g' ./multicluster/test/yamls/leader-access-token.yml
+    sed -i 's/antrea-mcs-ns/kube-system/g' ./multicluster/test/yamls/leader-access-token.yml
+    echo "type: Opaque" >>./multicluster/test/yamls/leader-access-token.yml
+
+    for config in ${membercluter_kubeconfigs[@]};
+    do
+        kubectl apply -f ./multicluster/build/yamls/antrea-multicluster-member.yml ${config}
+        kubectl rollout status deployment/antrea-mc-controller -n kube-system ${config}
+        kubectl apply -f ./multicluster/test/yamls/leader-access-token.yml ${config}
+    done
+
+    kubectl apply -f ./multicluster/test/yamls/east-member-cluster.yml "${EAST_CLUSTER_CONFIG}"
+    kubectl apply -f ./multicluster/test/yamls/west-member-cluster.yml "${WEST_CLUSTER_CONFIG}"
+    kubectl apply -f ./multicluster/test/yamls/clusterset.yml "${LEADER_CLUSTER_CONFIG}"
+}
+
+function deliver_antrea_multicluster {
+    echo "====== Building Antrea for the Following Commit ======"
+    export GO111MODULE=on
+    export GOPATH=${WORKDIR}/go
+    export GOROOT=/usr/local/go
+    export PATH=${GOROOT}/bin:$PATH
+
+    git show --numstat
+    make clean
+    ${CLEAN_STALE_IMAGES}
+
+    cp -f build/yamls/*.yml $WORKDIR
+    docker pull $DOCKER_REGISTRY/antrea/antrea-ubuntu:latest
+    echo "====== Delivering Antrea to all the Nodes ======"
+    docker save -o ${WORKDIR}/antrea-ubuntu.tar $DOCKER_REGISTRY/antrea/antrea-ubuntu:latest
+
+
+    for kubeconfig in ${multicluster_kubeconfigs[@]}
+    do
+       kubectl get nodes -o wide --no-headers=true ${kubeconfig}| awk '{print $6}' | while read IP; do
+            rsync -avr --progress --inplace -e "ssh -o StrictHostKeyChecking=no" "${WORKDIR}"/antrea-ubuntu.tar jenkins@[${IP}]:${WORKDIR}/antrea-ubuntu.tar
+            ssh -o StrictHostKeyChecking=no -n jenkins@${IP} "${CLEAN_STALE_IMAGES}; docker load -i ${WORKDIR}/antrea-ubuntu.tar" || true
+       done
+    done
+}
+
+function deliver_multicluster_controller {
+    echo "====== Build Antrea Multiple Cluster Controller and YAMLs ======"
+    export GO111MODULE=on
+    export GOPATH=${WORKDIR}/go
+    export GOROOT=/usr/local/go
+    export PATH=${GOROOT}/bin:$PATH
+
+    docker images | grep 'mc-controller' | awk '{print $3}' | xargs -r docker rmi || true
+    cd multicluster && mkdir -p bin && ln -s /usr/local/bin/kustomize ./bin/kustomize || true
+    make docker-build && cd ..
+
+    docker save antrea/antrea-mc-controller:latest -o "${WORKDIR}"/antrea-mcs.tar
+    ./multicluster/hack/generate-manifest.sh -l antrea-mcs-ns >./multicluster/test/yamls/manifest.yml
+
+    for kubeconfig in ${multicluster_kubeconfigs[@]}
+    do
+        kubectl get nodes -o wide --no-headers=true "${kubeconfig}"| awk '{print $6}' | while read IP; do
+            rsync -avr --progress --inplace -e "ssh -o StrictHostKeyChecking=no" "${WORKDIR}"/antrea-mcs.tar jenkins@[${IP}]:${WORKDIR}/antrea-mcs.tar
+            ssh -o StrictHostKeyChecking=no -n jenkins@"${IP}" "${CLEAN_STALE_IMAGES}; docker load -i ${WORKDIR}/antrea-mcs.tar" || true
+        done
+    done
+
+    leader_ip=$(kubectl get nodes -o wide --no-headers=true ${LEADER_CLUSTER_CONFIG} | awk -v role="$CONTROL_PLANE_NODE_ROLE" '$3 == role {print $6}')
+    sed -i "s|<LEADER_CLUSTER_IP>|${leader_ip}|" ./multicluster/test/yamls/east-member-cluster.yml
+    sed -i "s|<LEADER_CLUSTER_IP>|${leader_ip}|" ./multicluster/test/yamls/west-member-cluster.yml
+
+    for kubeconfig in ${membercluter_kubeconfigs[@]}
+    do
+       ip=$(kubectl get nodes -o wide --no-headers=true ${EAST_CLUSTER_CONFIG} | awk -v role="$CONTROL_PLANE_NODE_ROLE" '$3 == role {print $6}')
+       rsync -avr --progress --inplace -e "ssh -o StrictHostKeyChecking=no" ./multicluster/test/yamls/test-east-serviceexport.yml jenkins@[${ip}]:${WORKDIR}/serviceexport.yml
+    done
+}
+
+function run_multicluster_e2e {
+   echo "====== Running Multicluster e2e Tests ======"
+    export GO111MODULE=on
+    export GOPATH=${WORKDIR}/go
+    export GOROOT=/usr/local/go
+    export GOCACHE=${WORKDIR}/.cache/go-build
+    export PATH=$GOROOT/bin:$PATH
+
+    wait_for_antrea_multicluster_pods_ready "${LEADER_CLUSTER_CONFIG}"
+    wait_for_antrea_multicluster_pods_ready "${EAST_CLUSTER_CONFIG}"
+    wait_for_antrea_multicluster_pods_ready "${WEST_CLUSTER_CONFIG}"
+
+    wait_for_multicluster_controller_ready
+
+    docker pull "${DOCKER_REGISTRY}/antrea/nginx"
+    docker tag "${DOCKER_REGISTRY}/antrea/nginx:latest" "nginx:latest"
+    docker save nginx:latest -o "${WORKDIR}"/nginx.tar
+
+    for kubeconfig in ${membercluter_kubeconfigs[@]}
+    do
+        kubectl get nodes -o wide --no-headers=true "${kubeconfig}"| awk '{print $6}' | while read IP; do
+            rsync -avr --progress --inplace -e "ssh -o StrictHostKeyChecking=no" "${WORKDIR}"/nginx.tar jenkins@["${IP}"]:"${WORKDIR}"/nginx.tar
+            ssh -o StrictHostKeyChecking=no -n jenkins@"${IP}" "${CLEAN_STALE_IMAGES}; docker load -i ${WORKDIR}/nginx.tar" || true
+        done
+
+    done
+
+    set +e
+    mkdir -p `pwd`/antrea-multicluster-test-logs
+    go test -v antrea.io/antrea/multicluster/test/e2e --logs-export-dir  `pwd`/antrea-multicluster-test-logs
+    if [[ "$?" != "0" ]]; then
+        TEST_FAILURE=true
+    fi
+    set -e
+}
+
+trap clean_multicluster EXIT
+clean_tmp
+
+if [[ ${TESTCASE} =~ "e2e" ]]; then
+    deliver_antrea_multicluster
+    deliver_multicluster_controller
+    run_multicluster_e2e
+fi
+
+if [[ ${TEST_FAILURE} == true ]]; then
+    exit 1
+fi

--- a/ci/jenkins/test.sh
+++ b/ci/jenkins/test.sh
@@ -52,7 +52,7 @@ Run K8s e2e community tests (Conformance & Network Policy) or Antrea e2e tests o
 
         --kubeconfig             Path of cluster kubeconfig.
         --workdir                Home path for Go, vSphere information and antrea_logs during cluster setup. Default is $WORKDIR.
-        --testcase               Windows install OVS, Conformance and Network Policy or Antrea e2e testcases on a Windows or Linux cluster. It can also be flexible ipam e2e test.
+        --testcase               Windows install OVS, Conformance and Network Policy or Antrea e2e test cases on a Windows or Linux cluster. It can also be flexible ipam e2e test.
         --registry               The docker registry to use instead of dockerhub.
         --proxyall               Enable proxyAll to test AntreaProxy.
         --flexible-ipam          Run tests in flexible ipam mode"

--- a/multicluster/test/e2e/README.md
+++ b/multicluster/test/e2e/README.md
@@ -1,0 +1,13 @@
+# Running the Antrea Multicluster end-to-end tests
+
+## Creating the test Kubernetes ClusterSet
+
+The tests must be run on an actual Kubernetes cluster set, and there must be at least three clusters. We can create the clusters using [kubeadm](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm) or following [the e2e test instructions](https://github.com/antrea-io/antrea/blob/main/test/e2e/README.md) or through other ways.
+
+The three clusters are called leader cluster, west cluster and east cluster. Pod CIDR of each cluster should not be the same. For example, Pod CIDRs could be `192.168.0.1/22`,`192.168.4.1/22` and `192.168.8.1/22` in three clusters.
+
+## Running the tests
+
+Make sure that your clusters are provisioned and that the Antrea build artifacts are pushed to all the Nodes. If you install the multicluster manually, you can then run the tests from the top-level directory with `go test -v antrea.io/antrea/multicluster/test/e2e` or you can just run `bash ci/jenkins/test-mc.sh --testcase e2e`.
+
+When you use `test-mc.sh`, make sure your kubeconfig files of the clusters in the specific path of the script, or you can change the parameter `MULTICLUSTER_KUBECONFIG_PATH` and other parameters to your own path in the script.

--- a/multicluster/test/e2e/fixtures.go
+++ b/multicluster/test/e2e/fixtures.go
@@ -1,0 +1,94 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func createDirectory(path string) error {
+	return os.Mkdir(path, 0700)
+}
+
+func (data *TestData) setupLogDirectoryForTest(testName string) error {
+	path := filepath.Join(testOptions.logsExportDir, testName)
+	// remove directory if it already exists. This ensures that we start with an empty
+	// directory
+	_ = os.RemoveAll(path)
+	err := createDirectory(path)
+	if err != nil {
+		return err
+	}
+	data.logsDirForTestCase = path
+	return nil
+}
+
+func setupTest(tb testing.TB) (*TestData, error) {
+	if err := testData.setupLogDirectoryForTest(tb.Name()); err != nil {
+		tb.Errorf("Error creating logs directory '%s': %v", testData.logsDirForTestCase, err)
+		return nil, err
+	}
+	success := false
+	defer func() {
+		if !success {
+			tb.Fail()
+		}
+	}()
+	tb.Logf("Creating '%s' K8s Namespace", multiClusterTestNamespace)
+	if err := testData.createTestNamespace(); err != nil {
+		return nil, err
+	}
+
+	success = true
+	return testData, nil
+}
+
+func teardownTest(tb testing.TB, data *TestData) {
+	if empty, _ := IsDirEmpty(data.logsDirForTestCase); empty {
+		_ = os.Remove(data.logsDirForTestCase)
+	}
+}
+
+func createPodWrapper(tb testing.TB, data *TestData, cluster string, namespace string, name string, image string, ctr string, command []string,
+	args []string, env []corev1.EnvVar, ports []corev1.ContainerPort, hostNetwork bool, mutateFunc func(pod *corev1.Pod)) error {
+	tb.Logf("Creating Pod '%s'", name)
+	if err := data.createPod(cluster, name, namespace, ctr, image, command, args, env, ports, hostNetwork, mutateFunc); err != nil {
+		return err
+	}
+
+	_, err := data.podWaitFor(defaultTimeout, westCluster, name, multiClusterTestNamespace, func(pod *corev1.Pod) (bool, error) {
+		return pod.Status.Phase == corev1.PodRunning, nil
+	})
+
+	return err
+}
+
+func deletePodWrapper(tb testing.TB, data *TestData, clusterName string, namespace string, name string) {
+	tb.Logf("Deleting Pod '%s'", name)
+	if err := data.deletePod(clusterName, namespace, name); err != nil {
+		tb.Logf("Error when deleting Pod: %v", err)
+	}
+}
+
+func deleteServiceWrapper(tb testing.TB, data *TestData, clusterName string, namespace string, name string) {
+	tb.Logf("Deleting Service '%s'", name)
+	if err := data.deleteService(clusterName, namespace, name); err != nil {
+		tb.Logf("Error when deleting Service: %v", err)
+	}
+}

--- a/multicluster/test/e2e/framework.go
+++ b/multicluster/test/e2e/framework.go
@@ -1,0 +1,384 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"antrea.io/antrea/test/e2e/providers"
+)
+
+var (
+	homedir, _ = os.UserHomeDir()
+)
+
+const (
+	defaultTimeout     = 90 * time.Second
+	defaultInterval    = 1 * time.Second
+	importServiceDelay = 10 * time.Second
+
+	multiClusterTestNamespace string = "antrea-multicluster-test"
+	eastClusterTestService    string = "east-nginx"
+	westClusterTestService    string = "west-nginx"
+	eastCluster               string = "east-cluster"
+	westCluster               string = "west-cluster"
+	leaderCluster             string = "leader-cluster"
+	serviceExportYML          string = "serviceexport.yml"
+
+	nameSuffixLength int = 8
+
+	nginxImage = "nginx:latest"
+)
+
+var provider providers.ProviderInterface
+
+type TestOptions struct {
+	leaderClusterKubeConfigPath string
+	westClusterKubeConfigPath   string
+	eastClusterKubeConfigPath   string
+	logsExportDir               string
+}
+
+var testOptions TestOptions
+
+type TestData struct {
+	kubeconfigs map[string]*restclient.Config
+	clients     map[string]kubernetes.Interface
+	clusters    []string
+
+	logsDirForTestCase string
+}
+
+var testData *TestData
+
+func (data *TestData) createClients() error {
+	data.clients = make(map[string]kubernetes.Interface)
+	data.kubeconfigs = make(map[string]*restclient.Config)
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	configOverrides := &clientcmd.ConfigOverrides{}
+
+	kubeConfigPaths := []string{
+		testOptions.leaderClusterKubeConfigPath,
+		testOptions.eastClusterKubeConfigPath,
+		testOptions.westClusterKubeConfigPath,
+	}
+	data.clusters = []string{
+		leaderCluster, eastCluster, westCluster,
+	}
+	for i, cluster := range data.clusters {
+		loadingRules.ExplicitPath = kubeConfigPaths[i]
+		kubeConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides).ClientConfig()
+		if err != nil {
+			return fmt.Errorf("error when building kube config of cluster %s: %v", cluster, err)
+		}
+		clusterClient, err := kubernetes.NewForConfig(kubeConfig)
+		if err != nil {
+			return fmt.Errorf("error when creating kubernetes client of cluster %s: %v", cluster, err)
+		}
+		data.kubeconfigs[cluster] = kubeConfig
+		data.clients[cluster] = clusterClient
+	}
+
+	return nil
+}
+
+func (data *TestData) createTestNamespace() error {
+	for _, client := range data.clients {
+		if err := createNamespace(client, multiClusterTestNamespace, nil); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (data *TestData) deletePod(clusterName string, namespace string, name string) error {
+	client := data.getClientOfCluster(clusterName)
+	return deletePod(client, namespace, name)
+}
+
+func (data *TestData) deleteService(clusterName string, namespace string, name string) error {
+	client := data.getClientOfCluster(clusterName)
+	return deleteService(client, namespace, name)
+}
+
+func (data *TestData) deleteTestNamespace(timeout time.Duration) error {
+	return data.deleteNamespaceInAllClusters(multiClusterTestNamespace, timeout)
+}
+
+func (data *TestData) deleteNamespace(clusterName string, namespace string, timeout time.Duration) error {
+	client := data.getClientOfCluster(clusterName)
+	return deleteNamespace(client, namespace, timeout)
+}
+
+func (data *TestData) deleteNamespaceInAllClusters(namespace string, timeout time.Duration) error {
+	for _, client := range data.clients {
+		if err := deleteNamespace(client, namespace, timeout); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (data *TestData) createPod(clusterName string, name string, namespace string, ctrName string, image string, command []string,
+	args []string, env []corev1.EnvVar, ports []corev1.ContainerPort, hostNetwork bool, mutateFunc func(pod *corev1.Pod)) error {
+	client := data.getClientOfCluster(clusterName)
+	return createPod(client, name, namespace, ctrName, image, command, args, env, ports, hostNetwork, mutateFunc)
+}
+
+func (data *TestData) getService(clusterName string, namespace string, serviceName string) (*corev1.Service, error) {
+	client := data.getClientOfCluster(clusterName)
+	return getService(client, namespace, serviceName)
+}
+
+func (data *TestData) createService(cluster string, serviceName string, namespace string, port int32, targetPort int32,
+	protocol corev1.Protocol, selector map[string]string, affinity bool, nodeLocalExternal bool, serviceType corev1.ServiceType,
+	ipFamily *corev1.IPFamily, annotation map[string]string) (*corev1.Service, error) {
+	client := data.getClientOfCluster(cluster)
+	return createService(client, serviceName, namespace, port, targetPort, protocol, selector, affinity, nodeLocalExternal, serviceType, ipFamily, annotation)
+}
+
+func (data *TestData) getClientOfCluster(clusterName string) kubernetes.Interface {
+	return data.clients[clusterName]
+}
+
+type PodCondition func(*corev1.Pod) (bool, error)
+
+// podWaitFor polls the K8s apiserver until the specified Pod is found (in the test Namespace) and
+// the condition predicate is met (or until the provided timeout expires).
+func (data *TestData) podWaitFor(timeout time.Duration, clusterName string, name string, namespace string, condition PodCondition) (*corev1.Pod, error) {
+	client := data.getClientOfCluster(clusterName)
+	return podWaitFor(client, timeout, name, namespace, condition)
+}
+
+func initProvider() error {
+	newProvider, err := providers.NewRemoteProvider("multicluster")
+	if err != nil {
+		return err
+	}
+	provider = newProvider
+	return nil
+}
+
+// A DNS-1123 subdomain must consist of lower case alphanumeric characters
+var lettersAndDigits = []rune("abcdefghijklmnopqrstuvwxyz0123456789")
+
+func randSeq(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		// #nosec G404: random number generator not used for security purposes
+		randIdx := rand.Intn(len(lettersAndDigits))
+		b[i] = lettersAndDigits[randIdx]
+	}
+	return string(b)
+}
+
+func randName(prefix string) string {
+	return prefix + randSeq(nameSuffixLength)
+}
+
+func createNamespace(client kubernetes.Interface, namespace string, mutateFunc func(namespace2 *corev1.Namespace)) error {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: namespace,
+		},
+	}
+	if mutateFunc != nil {
+		mutateFunc(ns)
+	}
+
+	if ns, err := client.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{}); err != nil {
+		// Ignore error if the namespace already exists
+		if !errors.IsAlreadyExists(err) {
+			return fmt.Errorf("error when creating '%s' Namespace: %v", namespace, err)
+		}
+		// When namespace already exists, check phase
+		if ns.Status.Phase == corev1.NamespaceTerminating {
+			return fmt.Errorf("error when creating '%s' Namespace: namespace exists but is in 'Terminating' phase", namespace)
+		}
+	}
+	return nil
+}
+
+func deletePod(client kubernetes.Interface, namespace string, name string) error {
+	var gracePeriodSeconds int64 = 5
+	deleteOptions := metav1.DeleteOptions{
+		GracePeriodSeconds: &gracePeriodSeconds,
+	}
+
+	if err := client.CoreV1().Pods(namespace).Delete(context.TODO(), name, deleteOptions); err != nil {
+		if !errors.IsNotFound(err) {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func deleteService(client kubernetes.Interface, namespace string, name string) error {
+	var gracePeriodSeconds int64 = 5
+	deleteOptions := metav1.DeleteOptions{
+		GracePeriodSeconds: &gracePeriodSeconds,
+	}
+
+	return client.CoreV1().Services(namespace).Delete(context.TODO(), name, deleteOptions)
+}
+
+func deleteNamespace(client kubernetes.Interface, namespace string, timeout time.Duration) error {
+	var gracePeriodSeconds int64
+	var propagationPolicy = metav1.DeletePropagationForeground
+	deleteOptions := metav1.DeleteOptions{
+		GracePeriodSeconds: &gracePeriodSeconds,
+		PropagationPolicy:  &propagationPolicy,
+	}
+
+	if err := client.CoreV1().Namespaces().Delete(context.TODO(), namespace, deleteOptions); err != nil {
+		if errors.IsNotFound(err) {
+			// namespace does not exist, we return right away
+			return nil
+		}
+		return fmt.Errorf("error when deleting '%s' Namespace: %v", namespace, err)
+	}
+	err := wait.Poll(defaultInterval, timeout, func() (bool, error) {
+		if ns, err := client.CoreV1().Namespaces().Get(context.TODO(), namespace, metav1.GetOptions{}); err != nil {
+			if errors.IsNotFound(err) {
+				// Success
+				return true, nil
+			}
+			return false, fmt.Errorf("error when getting Namespace '%s' after delete: %v", namespace, err)
+		} else if ns.Status.Phase != corev1.NamespaceTerminating {
+			return false, fmt.Errorf("deleted Namespace '%s' should be in 'Terminating' phase", namespace)
+		}
+
+		// Keep trying
+		return false, nil
+	})
+
+	return err
+}
+
+func createPod(client kubernetes.Interface, name string, namespace string, ctrName string, image string, command []string,
+	args []string, env []corev1.EnvVar, ports []corev1.ContainerPort, hostNetwork bool, mutateFunc func(pod *corev1.Pod)) error {
+	podSpec := corev1.PodSpec{
+		Containers: []corev1.Container{
+			{
+				Name:            ctrName,
+				Image:           image,
+				ImagePullPolicy: corev1.PullIfNotPresent,
+				Command:         command,
+				Args:            args,
+				Env:             env,
+				Ports:           ports,
+			},
+		},
+		RestartPolicy: corev1.RestartPolicyNever,
+		HostNetwork:   hostNetwork,
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				"antrea-multicluster-e2e": name,
+				"app":                     ctrName,
+			},
+		},
+		Spec: podSpec,
+	}
+
+	if mutateFunc != nil {
+		mutateFunc(pod)
+	}
+
+	_, err := client.CoreV1().Pods(namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+	return err
+}
+
+func createService(client kubernetes.Interface, serviceName string, namespace string, port int32, targetPort int32,
+	protocol corev1.Protocol, selector map[string]string, affinity bool, nodeLocalExternal bool, serviceType corev1.ServiceType,
+	ipFamily *corev1.IPFamily, annotation map[string]string) (*corev1.Service, error) {
+	affinityType := corev1.ServiceAffinityNone
+	var ipFamilies []corev1.IPFamily
+	if ipFamily != nil {
+		ipFamilies = append(ipFamilies, *ipFamily)
+	}
+	if affinity {
+		affinityType = corev1.ServiceAffinityClientIP
+	}
+	service := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serviceName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"antrea-multicluster-e2e": serviceName,
+				"app":                     serviceName,
+			},
+			Annotations: annotation,
+		},
+		Spec: corev1.ServiceSpec{
+			SessionAffinity: affinityType,
+			Ports: []corev1.ServicePort{{
+				Port:       port,
+				TargetPort: intstr.FromInt(int(targetPort)),
+				Protocol:   protocol,
+			}},
+			Type:       serviceType,
+			Selector:   selector,
+			IPFamilies: ipFamilies,
+		},
+	}
+	if (serviceType == corev1.ServiceTypeNodePort || serviceType == corev1.ServiceTypeLoadBalancer) && nodeLocalExternal {
+		service.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeLocal
+	}
+
+	return client.CoreV1().Services(namespace).Create(context.TODO(), &service, metav1.CreateOptions{})
+}
+
+func getService(client kubernetes.Interface, namespace string, serviceName string) (*corev1.Service, error) {
+	svc, err := client.CoreV1().Services(namespace).Get(context.TODO(), serviceName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("Error when Getting service %s/%s", namespace, serviceName)
+	}
+	return svc, err
+}
+
+func podWaitFor(client kubernetes.Interface, timeout time.Duration, name string, namespace string, condition PodCondition) (*corev1.Pod, error) {
+	err := wait.Poll(defaultInterval, timeout, func() (bool, error) {
+		pod, err := client.CoreV1().Pods(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		if err != nil {
+			if errors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, fmt.Errorf("error when getting Pod '%s' in west clsuter: %v", name, err)
+		}
+		return condition(pod)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return client.CoreV1().Pods(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+}

--- a/multicluster/test/e2e/main_test.go
+++ b/multicluster/test/e2e/main_test.go
@@ -1,0 +1,92 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package main under directory cmd parses and validates user input,
+// instantiates and initializes objects imported from pkg, and runs
+// the process
+
+package e2e
+
+import (
+	"flag"
+	"io/ioutil"
+	"log"
+	"math/rand"
+	"os"
+	"path"
+	"testing"
+	"time"
+)
+
+// setupLogging creates a temporary directory to export the test logs if necessary. If a directory
+// was provided by the user, it checks that the directory exists.
+func (tOptions *TestOptions) setupLogging() func() {
+	if tOptions.logsExportDir == "" {
+		name, err := ioutil.TempDir("", "antrea-multicluster-test-")
+		if err != nil {
+			log.Fatalf("Error when creating temporary directory to export logs: %v", err)
+		}
+		log.Printf("Test logs (if any) will be exported under the '%s' directory", name)
+		tOptions.logsExportDir = name
+		// we will delete the temporary directory if no logs are exported
+		return func() {
+			if empty, _ := IsDirEmpty(name); empty {
+				log.Printf("Removing empty logs directory '%s'", name)
+				_ = os.Remove(name)
+			} else {
+				log.Printf("Logs exported under '%s', it is your responsibility to delete the directory when you no longer need it", name)
+			}
+		}
+	}
+	fInfo, err := os.Stat(tOptions.logsExportDir)
+	if err != nil {
+		log.Fatalf("Cannot stat provided directory '%s': %v", tOptions.logsExportDir, err)
+	}
+	if !fInfo.Mode().IsDir() {
+		log.Fatalf("'%s' is not a valid directory", tOptions.logsExportDir)
+	}
+	// no-op cleanup function
+	return func() {}
+}
+
+func testMain(m *testing.M) int {
+	flag.StringVar(&testOptions.logsExportDir, "logs-export-dir", "", "Export directory for test logs")
+	flag.StringVar(&testOptions.leaderClusterKubeConfigPath, "leader-cluster-kubeconfig-path", path.Join(homedir, ".kube", "leader"), "Kubeconfig Path of the leader cluster")
+	flag.StringVar(&testOptions.eastClusterKubeConfigPath, "east-cluster-kubeconfig-path", path.Join(homedir, ".kube", "east"), "Kubeconfig Path of the east cluster")
+	flag.StringVar(&testOptions.westClusterKubeConfigPath, "west-cluster-kubeconfig-path", path.Join(homedir, ".kube", "west"), "Kubeconfig Path of the west cluster")
+
+	flag.Parse()
+
+	if err := initProvider(); err != nil {
+		log.Fatalf("Error when initializing provider: %v", err)
+	}
+
+	cleanupLogging := testOptions.setupLogging()
+	defer cleanupLogging()
+
+	testData = &TestData{}
+	log.Println("Creating k8s clientsets")
+	if err := testData.createClients(); err != nil {
+		log.Fatalf("Error when creating k8s clientset: %v", err)
+		return 1
+	}
+	rand.Seed(time.Now().UnixNano())
+
+	ret := m.Run()
+	return ret
+}
+
+func TestMain(m *testing.M) {
+	os.Exit(testMain(m))
+}

--- a/multicluster/test/e2e/service_test.go
+++ b/multicluster/test/e2e/service_test.go
@@ -1,0 +1,130 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestConnectivity(t *testing.T) {
+	data, err := setupTest(t)
+	if err != nil {
+		t.Fatalf("Error when setting up test: %v", err)
+	}
+	defer teardownTest(t, data)
+
+	t.Run("testServiceExport", func(t *testing.T) {
+		testServiceExport(t, data)
+	})
+}
+
+func testServiceExport(t *testing.T, data *TestData) {
+	data.testServiceExport(t)
+}
+
+// testServiceExport is used to test the service between clusters by following steps
+// we create a nginx in on cluster(east), and try to curl it in another cluster(west).
+// If we got status code 200, it means that the resources is exported by the east cluster
+// and imported by the west cluster.
+func (data *TestData) testServiceExport(t *testing.T) {
+	podName := randName("test-nginx-")
+
+	if err := createPodWrapper(t, data, westCluster, multiClusterTestNamespace, podName, nginxImage, "nginx", nil, nil, nil, nil, false, nil); err != nil {
+		t.Fatalf("Error when creating nginx Pod in west cluster: %v", err)
+	}
+	defer deletePodWrapper(t, data, westCluster, multiClusterTestNamespace, podName)
+
+	if err := createPodWrapper(t, data, eastCluster, multiClusterTestNamespace, podName, nginxImage, "nginx", nil, nil, nil, nil, false, nil); err != nil {
+		t.Fatalf("Error when creating nginx Pod in east cluster: %v", err)
+	}
+	defer deletePodWrapper(t, data, eastCluster, multiClusterTestNamespace, podName)
+
+	if _, err := data.createService(westCluster, westClusterTestService, multiClusterTestNamespace, 80, 80, corev1.ProtocolTCP, map[string]string{"app": "nginx"}, false,
+		false, corev1.ServiceTypeClusterIP, nil, nil); err != nil {
+		t.Fatalf("Error when creating Servie %s in west cluster: %v", westClusterTestService, err)
+	}
+	defer deleteServiceWrapper(t, testData, westCluster, multiClusterTestNamespace, westClusterTestService)
+
+	if _, err := data.createService(eastCluster, eastClusterTestService, multiClusterTestNamespace, 80, 80, corev1.ProtocolTCP, map[string]string{"app": "nginx"}, false,
+		false, corev1.ServiceTypeClusterIP, nil, nil); err != nil {
+		t.Fatalf("Error when creating Servie %s in east cluster: %v", eastClusterTestService, err)
+	}
+	defer deleteServiceWrapper(t, testData, eastCluster, multiClusterTestNamespace, eastClusterTestService)
+
+	if err := data.deployServiceExport(westCluster); err != nil {
+		t.Fatalf("Error when deploy ServiceExport in west cluster: %v", err)
+	}
+	defer data.deleteServiceExport(westCluster)
+	if err := data.deployServiceExport(eastCluster); err != nil {
+		t.Fatalf("Error when deploy ServiceExport in east cluster: %v", err)
+	}
+	defer data.deleteServiceExport(eastCluster)
+	time.Sleep(importServiceDelay)
+
+	svc, err := data.getService(eastCluster, multiClusterTestNamespace, fmt.Sprintf("antrea-mc-%s", westClusterTestService))
+	if err != nil {
+		t.Fatalf("Error when getting the imported service %s: %v", fmt.Sprintf("antrea-mc-%s", westClusterTestService), err)
+	}
+
+	eastIP := svc.Spec.ClusterIP
+	if err := data.probeFromCluster(eastCluster, eastIP); err != nil {
+		t.Fatalf("Error when probe service from %s", eastCluster)
+	}
+	svc, err = data.getService(westCluster, multiClusterTestNamespace, fmt.Sprintf("antrea-mc-%s", eastClusterTestService))
+	if err != nil {
+		t.Fatalf("Error when getting the imported service %s: %v", fmt.Sprintf("antrea-mc-%s", eastClusterTestService), err)
+	}
+	westIP := svc.Spec.ClusterIP
+	if err := data.probeFromCluster(westCluster, westIP); err != nil {
+		t.Fatalf("Error when probe service from %s", westCluster)
+	}
+}
+
+func (data *TestData) deployServiceExport(clusterName string) error {
+	var rc int
+	var err error
+	rc, _, _, err = provider.RunCommandOnNode(clusterName, fmt.Sprintf("kubectl apply -f %s", serviceExportYML))
+	if err != nil || rc != 0 {
+		return fmt.Errorf("error when deploying the ServiceExport: %v", err)
+	}
+
+	return nil
+}
+
+func (data *TestData) deleteServiceExport(clusterName string) error {
+	var rc int
+	var err error
+	rc, _, _, err = provider.RunCommandOnNode(clusterName, fmt.Sprintf("kubectl delete -f %s", serviceExportYML))
+	if err != nil || rc != 0 {
+		return fmt.Errorf("error when deleting the ServiceExport: %v", err)
+	}
+
+	return nil
+}
+
+func (data *TestData) probeFromCluster(clusterName string, url string) error {
+	var rc int
+	var err error
+	rc, _, _, err = provider.RunCommandOnNode(clusterName, fmt.Sprintf("curl --connect-timeout 5 -s %s", url))
+	if err != nil || rc != 0 {
+		return fmt.Errorf("error when curl the url %s: %v", url, err)
+	}
+
+	return nil
+}

--- a/multicluster/test/e2e/util.go
+++ b/multicluster/test/e2e/util.go
@@ -1,0 +1,35 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"io"
+	"os"
+)
+
+// IsDirEmpty checks whether a directory is empty or not.
+func IsDirEmpty(name string) (bool, error) {
+	f, err := os.Open(name)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+
+	_, err = f.Readdirnames(1)
+	if err == io.EOF {
+		return true, nil
+	}
+	return false, err
+}

--- a/multicluster/test/yamls/clusterset.yml
+++ b/multicluster/test/yamls/clusterset.yml
@@ -1,0 +1,31 @@
+apiVersion: multicluster.crd.antrea.io/v1alpha1
+kind: ClusterClaim
+metadata:
+  name: leadercluster-id
+  namespace: antrea-mcs-ns
+name: id.k8s.io
+value: test-cluster-leader
+---
+apiVersion: multicluster.crd.antrea.io/v1alpha1
+kind: ClusterClaim
+metadata:
+  name: clusterset-id
+  namespace: antrea-mcs-ns
+name: clusterSet.k8s.io
+value: test-clusterset
+---
+apiVersion: multicluster.crd.antrea.io/v1alpha1
+kind: ClusterSet
+metadata:
+  name: test-clusterset
+  namespace: antrea-mcs-ns
+spec:
+  leaders:
+    - clusterID: test-cluster-leader
+  members:
+    - clusterID: test-cluster-east
+      serviceAccount: antrea-mc-member-access-sa
+    - clusterID: test-cluster-west
+      serviceAccount: antrea-mc-member-access-sa
+  namespace: antrea-mcs-ns
+

--- a/multicluster/test/yamls/east-member-cluster.yml
+++ b/multicluster/test/yamls/east-member-cluster.yml
@@ -1,0 +1,30 @@
+apiVersion: multicluster.crd.antrea.io/v1alpha1
+kind: ClusterClaim
+metadata:
+  name: east-membercluster-id
+  namespace: kube-system
+name: id.k8s.io
+value: test-cluster-east
+---
+apiVersion: multicluster.crd.antrea.io/v1alpha1
+kind: ClusterClaim
+metadata:
+  name: clusterset-id
+  namespace: kube-system
+name: clusterSet.k8s.io
+value: test-clusterset
+---
+apiVersion: multicluster.crd.antrea.io/v1alpha1
+kind: ClusterSet
+metadata:
+  name: test-clusterset
+  namespace: kube-system
+spec:
+  leaders:
+    - clusterID: test-cluster-leader
+      secret: leader-access-token
+      server: https://<LEADER_CLUSTER_IP>:6443
+  members:
+    - clusterID: test-cluster-east
+  namespace: antrea-mcs-ns
+

--- a/multicluster/test/yamls/leader-access-token-secret.yml
+++ b/multicluster/test/yamls/leader-access-token-secret.yml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: leader-access-token
+  namespace: antrea-mcs-ns
+  annotations:
+    kubernetes.io/service-account.name: antrea-mc-member-access-sa
+type: kubernetes.io/service-account-token
+

--- a/multicluster/test/yamls/test-east-serviceexport.yml
+++ b/multicluster/test/yamls/test-east-serviceexport.yml
@@ -1,0 +1,6 @@
+apiVersion: multicluster.x-k8s.io/v1alpha1
+kind: ServiceExport
+metadata:
+  name: east-nginx
+  namespace: antrea-multicluster-test
+

--- a/multicluster/test/yamls/test-west-serviceexport.yml
+++ b/multicluster/test/yamls/test-west-serviceexport.yml
@@ -1,0 +1,6 @@
+apiVersion: multicluster.x-k8s.io/v1alpha1
+kind: ServiceExport
+metadata:
+  name: west-nginx
+  namespace: antrea-multicluster-test
+

--- a/multicluster/test/yamls/west-member-cluster.yml
+++ b/multicluster/test/yamls/west-member-cluster.yml
@@ -1,0 +1,30 @@
+apiVersion: multicluster.crd.antrea.io/v1alpha1
+kind: ClusterClaim
+metadata:
+  name: west-membercluster-id
+  namespace: kube-system
+name: id.k8s.io
+value: test-cluster-west
+---
+apiVersion: multicluster.crd.antrea.io/v1alpha1
+kind: ClusterClaim
+metadata:
+  name: clusterset-id
+  namespace: kube-system
+name: clusterSet.k8s.io
+value: test-clusterset
+---
+apiVersion: multicluster.crd.antrea.io/v1alpha1
+kind: ClusterSet
+metadata:
+  name: test-clusterset
+  namespace: kube-system
+spec:
+  leaders:
+    - clusterID: test-cluster-leader
+      secret: leader-access-token
+      server: https://<LEADER_CLUSTER_IP>:6443
+  members:
+    - clusterID: test-cluster-west
+  namespace: antrea-mcs-ns
+


### PR DESCRIPTION
1. build clusters base on the Getting-started of multi-cluster
2. run test cases to export service and try to test the imported service.

This PR is based on #3024 , only the top commit need to be reviewed.