### PR TITLE
Support external IP management of Services

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -3457,6 +3457,13 @@ rules:
   - watch
   - list
 - apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
   - discovery.k8s.io
   resources:
   - endpointslices
@@ -3612,7 +3619,6 @@ rules:
   resources:
   - pods
   - namespaces
-  - services
   - configmaps
   verbs:
   - get
@@ -3626,6 +3632,17 @@ rules:
   - get
   - watch
   - list
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - services/status
+  verbs:
+  - get
+  - watch
+  - list
+  - update
   - patch
 - apiGroups:
   - networking.k8s.io

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -3457,6 +3457,13 @@ rules:
   - watch
   - list
 - apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
   - discovery.k8s.io
   resources:
   - endpointslices
@@ -3612,7 +3619,6 @@ rules:
   resources:
   - pods
   - namespaces
-  - services
   - configmaps
   verbs:
   - get
@@ -3626,6 +3632,17 @@ rules:
   - get
   - watch
   - list
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - services/status
+  verbs:
+  - get
+  - watch
+  - list
+  - update
   - patch
 - apiGroups:
   - networking.k8s.io

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -3457,6 +3457,13 @@ rules:
   - watch
   - list
 - apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
   - discovery.k8s.io
   resources:
   - endpointslices
@@ -3612,7 +3619,6 @@ rules:
   resources:
   - pods
   - namespaces
-  - services
   - configmaps
   verbs:
   - get
@@ -3626,6 +3632,17 @@ rules:
   - get
   - watch
   - list
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - services/status
+  verbs:
+  - get
+  - watch
+  - list
+  - update
   - patch
 - apiGroups:
   - networking.k8s.io

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -3457,6 +3457,13 @@ rules:
   - watch
   - list
 - apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
   - discovery.k8s.io
   resources:
   - endpointslices
@@ -3612,7 +3619,6 @@ rules:
   resources:
   - pods
   - namespaces
-  - services
   - configmaps
   verbs:
   - get
@@ -3626,6 +3632,17 @@ rules:
   - get
   - watch
   - list
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - services/status
+  verbs:
+  - get
+  - watch
+  - list
+  - update
   - patch
 - apiGroups:
   - networking.k8s.io

--- a/build/yamls/antrea-kind.yml
+++ b/build/yamls/antrea-kind.yml
@@ -3457,6 +3457,13 @@ rules:
   - watch
   - list
 - apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
   - discovery.k8s.io
   resources:
   - endpointslices
@@ -3612,7 +3619,6 @@ rules:
   resources:
   - pods
   - namespaces
-  - services
   - configmaps
   verbs:
   - get
@@ -3626,6 +3632,17 @@ rules:
   - get
   - watch
   - list
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - services/status
+  verbs:
+  - get
+  - watch
+  - list
+  - update
   - patch
 - apiGroups:
   - networking.k8s.io

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -3457,6 +3457,13 @@ rules:
   - watch
   - list
 - apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
   - discovery.k8s.io
   resources:
   - endpointslices
@@ -3612,7 +3619,6 @@ rules:
   resources:
   - pods
   - namespaces
-  - services
   - configmaps
   verbs:
   - get
@@ -3626,6 +3632,17 @@ rules:
   - get
   - watch
   - list
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - services/status
+  verbs:
+  - get
+  - watch
+  - list
+  - update
   - patch
 - apiGroups:
   - networking.k8s.io

--- a/build/yamls/base/agent-rbac.yml
+++ b/build/yamls/base/agent-rbac.yml
@@ -37,7 +37,14 @@ rules:
     verbs:
       - get
       - watch
-      - list
+      - list  
+  - apiGroups:
+      - ""
+    resources:
+      - services/status
+    verbs:
+      - update
+      - patch
   - apiGroups:
       - discovery.k8s.io
     resources:

--- a/build/yamls/base/controller-rbac.yml
+++ b/build/yamls/base/controller-rbac.yml
@@ -15,7 +15,6 @@ rules:
     resources:
       - pods
       - namespaces
-      - services
       - configmaps
     verbs:
       - get
@@ -29,6 +28,17 @@ rules:
       - get
       - watch
       - list
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - services/status
+    verbs:
+      - get
+      - watch
+      - list
+      - update
       - patch
   - apiGroups:
       - networking.k8s.io

--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -29,6 +29,7 @@ import (
 	"antrea.io/antrea/pkg/agent/cniserver/ipam"
 	"antrea.io/antrea/pkg/agent/config"
 	"antrea.io/antrea/pkg/agent/controller/egress"
+	"antrea.io/antrea/pkg/agent/controller/externalip"
 	"antrea.io/antrea/pkg/agent/controller/networkpolicy"
 	"antrea.io/antrea/pkg/agent/controller/noderoute"
 	"antrea.io/antrea/pkg/agent/controller/traceflow"
@@ -85,6 +86,8 @@ func run(o *Options) error {
 	traceflowInformer := crdInformerFactory.Crd().V1alpha1().Traceflows()
 	egressInformer := crdInformerFactory.Crd().V1alpha2().Egresses()
 	nodeInformer := informerFactory.Core().V1().Nodes()
+	serviceInformer := informerFactory.Core().V1().Services()
+	endpointsInformer := informerFactory.Core().V1().Endpoints()
 	externalIPPoolInformer := crdInformerFactory.Crd().V1alpha2().ExternalIPPools()
 
 	// Create Antrea Clientset for the given config.
@@ -296,26 +299,42 @@ func run(o *Options) error {
 	}
 
 	var externalIPPoolController *externalippool.ExternalIPPoolController
+	var externalIPController *externalip.ExternalIPController
 	var memberlistCluster *memberlist.Cluster
 	var localIPDetector ipassigner.LocalIPDetector
 
-	if features.DefaultFeatureGate.Enabled(features.Egress) {
+	if features.DefaultFeatureGate.Enabled(features.Egress) || features.DefaultFeatureGate.Enabled(features.ServiceExternalIP) {
 		externalIPPoolController = externalippool.NewExternalIPPoolController(
 			crdClient, externalIPPoolInformer,
 		)
 		localIPDetector = ipassigner.NewLocalIPDetector()
-		memberlistCluster, err = memberlist.NewCluster(o.config.ClusterMembershipPort,
+
+		memberlistCluster, err = memberlist.NewCluster(nodeTransportIP, o.config.ClusterMembershipPort,
 			nodeConfig.Name, nodeInformer, externalIPPoolInformer,
 		)
 		if err != nil {
-			return fmt.Errorf("error creating new MemberList cluster: %v", err)
+			return fmt.Errorf("error creating new memberlist cluster: %v", err)
 		}
+	}
+	if features.DefaultFeatureGate.Enabled(features.Egress) {
 		egressController, err = egress.NewEgressController(
 			ofClient, antreaClientProvider, crdClient, ifaceStore, routeClient, nodeConfig.Name, nodeTransportIP,
 			memberlistCluster, egressInformer, nodeInformer, localIPDetector,
 		)
 		if err != nil {
 			return fmt.Errorf("error creating new Egress controller: %v", err)
+		}
+	}
+	if features.DefaultFeatureGate.Enabled(features.ServiceExternalIP) {
+		externalIPController, err = externalip.NewExternalIPController(
+			nodeConfig.Name,
+			nodeConfig.NodeIPv4Addr.IP,
+			k8sClient,
+			memberlistCluster, serviceInformer,
+			endpointsInformer, localIPDetector,
+		)
+		if err != nil {
+			return fmt.Errorf("error creating new ExternalIP controller: %v", err)
 		}
 	}
 
@@ -443,11 +462,18 @@ func run(o *Options) error {
 
 	go networkPolicyController.Run(stopCh)
 
-	if features.DefaultFeatureGate.Enabled(features.Egress) {
+	if features.DefaultFeatureGate.Enabled(features.Egress) || features.DefaultFeatureGate.Enabled(features.ServiceExternalIP) {
 		go externalIPPoolController.Run(stopCh)
 		go localIPDetector.Run(stopCh)
 		go memberlistCluster.Run(stopCh)
+	}
+
+	if features.DefaultFeatureGate.Enabled(features.Egress) {
 		go egressController.Run(stopCh)
+	}
+
+	if features.DefaultFeatureGate.Enabled(features.ServiceExternalIP) {
+		go externalIPController.Run(stopCh)
 	}
 
 	if features.DefaultFeatureGate.Enabled(features.NetworkPolicyStats) {

--- a/go.mod
+++ b/go.mod
@@ -22,9 +22,9 @@ require (
 	github.com/elazarl/goproxy v0.0.0-20190911111923-ecfe977594f1 // indirect
 	github.com/go-openapi/spec v0.19.5
 	github.com/gogo/protobuf v1.3.2
-	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e
 	github.com/golang/mock v1.6.0
 	github.com/golang/protobuf v1.5.0
+	github.com/google/btree v1.0.1
 	github.com/google/uuid v1.1.2
 	github.com/hashicorp/memberlist v0.2.4
 	github.com/k8snetworkplumbingwg/sriov-cni v2.1.0+incompatible
@@ -91,7 +91,7 @@ require (
 	github.com/go-openapi/jsonpointer v0.19.3 // indirect
 	github.com/go-openapi/jsonreference v0.19.3 // indirect
 	github.com/go-openapi/swag v0.19.5 // indirect
-	github.com/google/btree v1.0.0 // indirect
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/google/go-cmp v0.5.5 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/googleapis/gnostic v0.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -303,8 +303,9 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e/go.mod h1:0AA//k/eakGydO4jKRoRL2j92ZKSzTgj9tclaCrvXHk=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
-github.com/google/btree v1.0.0 h1:0udJVsspx3VBr5FwtLhQQtuAsVc79tTq0ocGIPAU6qo=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
+github.com/google/btree v1.0.1 h1:gK4Kx5IaGY9CD5sPJ36FHiBJ6ZXl0kilRiiCj+jdYp4=
+github.com/google/btree v1.0.1/go.mod h1:xXMiIv4Fb/0kKde4SpL7qlzvu5cMJDRkFDxJfI9uaxA=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=

--- a/pkg/agent/consistenthash/consistenthash.go
+++ b/pkg/agent/consistenthash/consistenthash.go
@@ -1,0 +1,146 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package consistenthash provides an implementation of a ring hash.
+package consistenthash
+
+import (
+	"hash/crc32"
+	"strconv"
+
+	"github.com/google/btree"
+)
+
+type Hash func(data []byte) uint32
+
+type Map struct {
+	hash     Hash
+	replicas int
+	keys     map[string]struct{}
+	tree     *btree.BTree
+}
+
+type replica struct {
+	key  string
+	hash uint32
+}
+
+func (v *replica) Less(than btree.Item) bool {
+	return v.hash < than.(*replica).hash
+}
+
+var _ btree.Item = (*replica)(nil)
+
+func New(replicas int, fn Hash) *Map {
+	m := &Map{
+		replicas: replicas,
+		hash:     fn,
+		keys:     make(map[string]struct{}),
+		tree:     btree.New(2),
+	}
+	if m.hash == nil {
+		m.hash = crc32.ChecksumIEEE
+	}
+	return m
+}
+
+// IsEmpty returns true if there are no items available.
+func (m *Map) IsEmpty() bool {
+	return len(m.keys) == 0
+}
+
+// Add adds some keys to the hash.
+func (m *Map) Add(keys ...string) {
+	for _, key := range keys {
+		if _, exist := m.keys[key]; exist {
+			continue
+		}
+		for i := 0; i < m.replicas; i++ {
+			hash := m.hash([]byte(strconv.Itoa(i) + key))
+			replica := &replica{
+				key:  key,
+				hash: hash,
+			}
+			m.tree.ReplaceOrInsert(replica)
+		}
+		m.keys[key] = struct{}{}
+	}
+}
+
+// Remove removes keys from existing hash ring.
+func (m *Map) Remove(keys ...string) {
+	for _, key := range keys {
+		_, exist := m.keys[key]
+		if !exist {
+			continue
+		}
+		for i := 0; i < m.replicas; i++ {
+			hash := m.hash([]byte(strconv.Itoa(i) + key))
+			replica := &replica{
+				key:  key,
+				hash: hash,
+			}
+			m.tree.Delete(replica)
+		}
+		delete(m.keys, key)
+	}
+}
+
+// Get gets the closest item in the hash to the provided key.
+func (m *Map) Get(key string) string {
+	return m.GetWithFilters(key)
+}
+
+// Get gets the closest item in the hash to the provided key with filters.
+func (m *Map) GetWithFilters(key string, filters ...func(string) bool) string {
+	if m.IsEmpty() {
+		return ""
+	}
+	hash := m.hash([]byte(key))
+	pivot := &replica{
+		hash: hash,
+	}
+	var result *replica
+	visited := make(map[string]struct{})
+	iterator := func(item btree.Item) bool {
+		replica := item.(*replica)
+		if _, exists := visited[replica.key]; exists {
+			return true
+		}
+		// all key visited
+		if len(visited) == len(m.keys) {
+			return false
+		}
+		for _, f := range filters {
+			if !f(replica.key) {
+				visited[replica.key] = struct{}{}
+				return true
+			}
+		}
+		// stop iterating
+		result = replica
+		return false
+	}
+	// search in [pivot, last]
+	m.tree.AscendGreaterOrEqual(pivot, iterator)
+	if result == nil {
+		// search in [first, pivot)
+		m.tree.AscendLessThan(pivot, iterator)
+	}
+	// no key passes all filters
+	if result == nil {
+		return ""
+	}
+	return result.key
+}

--- a/pkg/agent/consistenthash/consistenthash_test.go
+++ b/pkg/agent/consistenthash/consistenthash_test.go
@@ -1,0 +1,267 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package consistenthash
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/google/btree"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// simpleHashFn is a hash function to return easier to reason about values. Assumes
+// the keys can be converted to an integer.
+func simpleHashFn(t *testing.T) func(key []byte) uint32 {
+	return func(key []byte) uint32 {
+		i, err := strconv.Atoi(string(key))
+		if err != nil {
+			t.Fatalf("hash failed: %v", err)
+		}
+		return uint32(i)
+	}
+}
+
+func TestHashing(t *testing.T) {
+
+	hash := New(3, simpleHashFn(t))
+
+	// Given the above hash function, this will give replicas with "hashes":
+	// 2, 4, 6, 12, 14, 16, 22, 24, 26
+	hash.Add("6", "4", "2")
+
+	testCases := map[string]string{
+		"2":  "2",
+		"11": "2",
+		"23": "4",
+		"27": "2",
+	}
+
+	for k, v := range testCases {
+		if hash.Get(k) != v {
+			t.Errorf("Asking for %s, should have yielded %s", k, v)
+		}
+	}
+
+	// Adds 8, 18, 28
+	hash.Add("8")
+
+	// 27 should now map to 8.
+	testCases["27"] = "8"
+
+	for k, v := range testCases {
+		if hash.Get(k) != v {
+			t.Errorf("Asking for %s, should have yielded %s", k, v)
+		}
+	}
+
+}
+
+func TestConsistency(t *testing.T) {
+	hash1 := New(1, nil)
+	hash2 := New(1, nil)
+
+	hash1.Add("Bill", "Bob", "Bonny")
+	hash2.Add("Bob", "Bonny", "Bill")
+
+	if hash1.Get("Ben") != hash2.Get("Ben") {
+		t.Errorf("Fetching 'Ben' from both hashes should be the same")
+	}
+}
+
+func TestGetWithFilter(t *testing.T) {
+	testCases := []struct {
+		name         string
+		keys         []string
+		testKey      string
+		expectedHash string
+		filter       []func(string) bool
+	}{
+		{
+			"with out filter",
+			[]string{"1", "2", "3"},
+			"2",
+			"2",
+			nil,
+		},
+		{
+			"with one filter to exclude one key",
+			[]string{"1", "2", "3"},
+			"2",
+			"3",
+			[]func(s string) bool{
+				func(s string) bool {
+					return s != "2"
+				},
+			},
+		},
+		{
+			"with one filter to match only one key",
+			[]string{"1", "2", "3"},
+			"2",
+			"1",
+			[]func(s string) bool{
+				func(s string) bool {
+					return s == "1"
+				},
+			},
+		},
+		{
+			"with two filters",
+			[]string{"1", "2", "3"},
+			"2",
+			"1",
+			[]func(s string) bool{
+				func(s string) bool {
+					return s != "2"
+				},
+				func(s string) bool {
+					return s != "3"
+				},
+			},
+		},
+		{
+			"no valid value",
+			[]string{"1", "2", "3"},
+			"2",
+			"",
+			[]func(s string) bool{
+				func(s string) bool {
+					return s == "0"
+				},
+			},
+		},
+		{
+			"filters should check exactly once for each key",
+			[]string{"1", "2", "3"},
+			"2",
+			"",
+			[]func(s string) bool{
+				func(m map[string]struct{}) func(s string) bool {
+					return func(s string) bool {
+						if _, ok := m[s]; ok {
+							t.Errorf("duplicate key passed to filters")
+						}
+						return false
+					}
+				}(make(map[string]struct{})),
+			},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			hash := New(3, simpleHashFn(t))
+			hash.Add(tt.keys...)
+			v := hash.GetWithFilters(tt.testKey, tt.filter...)
+			assert.Equal(t, tt.expectedHash, v)
+		})
+	}
+}
+func TestRemove(t *testing.T) {
+	testCases := []struct {
+		name             string
+		keys             []string
+		toRemove         []string
+		expectedHashRing []replica
+	}{
+		{
+			"delete one key",
+			[]string{"1", "2", "3"},
+			[]string{"2"},
+			[]replica{
+				{"1", 1},
+				{"3", 3},
+				{"1", 11},
+				{"3", 13},
+			},
+		},
+		{
+			"delete two keys",
+			[]string{"1", "2", "3"},
+			[]string{"2", "3"},
+			[]replica{
+				{"1", 1},
+				{"1", 11},
+			},
+		}, {
+			"delete all keys",
+			[]string{"1", "2", "3"},
+			[]string{"1", "2", "3"},
+			nil,
+		},
+		{
+			"delete non-existing key",
+			[]string{"1", "2", "3"},
+			[]string{"4"},
+			[]replica{
+				{"1", 1},
+				{"2", 2},
+				{"3", 3},
+				{"1", 11},
+				{"2", 12},
+				{"3", 13},
+			},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			hash := New(2, simpleHashFn(t))
+			hash.Add(tt.keys...)
+			hash.Remove(tt.toRemove...)
+			var actualHashRing []replica
+			iterator := func(item btree.Item) bool {
+				replica, ok := item.(*replica)
+				require.True(t, ok)
+				actualHashRing = append(actualHashRing, *replica)
+				return true
+			}
+			hash.tree.Ascend(iterator)
+			assert.Equal(t, tt.expectedHashRing, actualHashRing)
+			for _, r := range tt.toRemove {
+				if _, ok := hash.keys[r]; ok {
+					t.Errorf("key %s not deleted", r)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkGet8(b *testing.B)    { benchmarkGet(b, 8) }
+func BenchmarkGet32(b *testing.B)   { benchmarkGet(b, 32) }
+func BenchmarkGet128(b *testing.B)  { benchmarkGet(b, 128) }
+func BenchmarkGet512(b *testing.B)  { benchmarkGet(b, 512) }
+func BenchmarkGet1024(b *testing.B) { benchmarkGet(b, 1024) }
+
+func benchmarkGet(b *testing.B, shards int) {
+	b.SetBytes(1)
+	hash := New(50, nil)
+
+	var buckets []string
+	for i := 0; i < shards; i++ {
+		buckets = append(buckets, fmt.Sprintf("shard-%d", i))
+	}
+
+	hash.Add(buckets...)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		hash.Get(buckets[i&(shards-1)])
+	}
+}

--- a/pkg/agent/controller/externalip/controller.go
+++ b/pkg/agent/controller/externalip/controller.go
@@ -1,0 +1,452 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package externalip
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	apimachinerytypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/kubernetes"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+
+	"antrea.io/antrea/pkg/agent/ipassigner"
+	"antrea.io/antrea/pkg/agent/memberlist"
+	"antrea.io/antrea/pkg/agent/types"
+)
+
+const (
+	controllerName = "AntreaAgentLoadBalancerController"
+	// How long to wait before retrying the processing of an Service change.
+	minRetryDelay = 5 * time.Second
+	maxRetryDelay = 300 * time.Second
+	// Default number of workers processing an Service change.
+	defaultWorkers = 4
+	// Disable resyncing.
+	resyncPeriod time.Duration = 0
+
+	ExternalIPIndex     = "externalIP"
+	externalIPPoolIndex = "externalIPPool"
+
+	// externalIPDummyDevice is the dummy device that holds the External IPs configured to the system by antrea-agent.
+	externalIPDummyDevice = "antrea-lb0"
+)
+
+type externalIPState struct {
+	ip           string
+	assignedNode string
+}
+
+type ExternalIPController struct {
+	nodeName            string
+	serviceInformer     cache.SharedIndexInformer
+	serviceLister       corelisters.ServiceLister
+	serviceListerSynced cache.InformerSynced
+
+	client kubernetes.Interface
+
+	endpointsInformer     cache.SharedIndexInformer
+	endpointsLister       corelisters.EndpointsLister
+	endpointsListerSynced cache.InformerSynced
+
+	queue workqueue.RateLimitingInterface
+
+	loadBalancerStates      map[apimachinerytypes.NamespacedName]externalIPState
+	loadBalancerStatesMutex sync.RWMutex
+
+	cluster         memberlist.Interface
+	ipAssigner      ipassigner.IPAssigner
+	localIPDetector ipassigner.LocalIPDetector
+}
+
+func NewExternalIPController(
+	nodeName string,
+	nodeIP net.IP,
+	client kubernetes.Interface,
+	cluster memberlist.Interface,
+	serviceInformer coreinformers.ServiceInformer,
+	endpointsInformer coreinformers.EndpointsInformer,
+	localIPDetector ipassigner.LocalIPDetector,
+) (*ExternalIPController, error) {
+	c := &ExternalIPController{
+		nodeName:              nodeName,
+		client:                client,
+		cluster:               cluster,
+		queue:                 workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(minRetryDelay, maxRetryDelay), "loadbalancer"),
+		serviceInformer:       serviceInformer.Informer(),
+		serviceLister:         serviceInformer.Lister(),
+		serviceListerSynced:   serviceInformer.Informer().HasSynced,
+		endpointsInformer:     endpointsInformer.Informer(),
+		endpointsLister:       endpointsInformer.Lister(),
+		endpointsListerSynced: endpointsInformer.Informer().HasSynced,
+		loadBalancerStates:    make(map[apimachinerytypes.NamespacedName]externalIPState),
+		localIPDetector:       localIPDetector,
+	}
+	ipAssigner, err := ipassigner.NewIPAssigner(nodeIP, externalIPDummyDevice)
+	if err != nil {
+		return nil, fmt.Errorf("initializing LoadBalancer IP assigner failed: %v", err)
+	}
+	c.ipAssigner = ipAssigner
+
+	c.serviceInformer.AddIndexers(cache.Indexers{ExternalIPIndex: func(obj interface{}) ([]string, error) {
+		service, ok := obj.(*corev1.Service)
+		if !ok {
+			return nil, fmt.Errorf("obj is not Service: %+v", obj)
+		}
+		if len(service.Status.LoadBalancer.Ingress) == 0 {
+			return nil, nil
+		}
+		return []string{service.Status.LoadBalancer.Ingress[0].IP}, nil
+	}})
+
+	c.serviceInformer.AddIndexers(cache.Indexers{externalIPPoolIndex: func(obj interface{}) ([]string, error) {
+		service, ok := obj.(*corev1.Service)
+		if !ok {
+			return nil, fmt.Errorf("obj is not Service: %+v", obj)
+		}
+		eipName, ok := service.Annotations[types.ServiceExternalIPPoolAnnotationKey]
+		if !ok {
+			return nil, nil
+		}
+		return []string{eipName}, nil
+	}})
+
+	c.serviceInformer.AddEventHandlerWithResyncPeriod(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: c.enqueueService,
+			UpdateFunc: func(old, cur interface{}) {
+				c.enqueueService(cur)
+			},
+			DeleteFunc: c.enqueueService,
+		},
+		resyncPeriod,
+	)
+
+	c.endpointsInformer.AddEventHandlerWithResyncPeriod(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: c.enqueueServiceForEndpoints,
+			UpdateFunc: func(old, cur interface{}) {
+				c.enqueueServiceForEndpoints(cur)
+			},
+			DeleteFunc: c.enqueueServiceForEndpoints,
+		},
+		resyncPeriod,
+	)
+
+	c.localIPDetector.AddEventHandler(c.onLocalIPUpdate)
+	c.cluster.AddClusterEventHandler(c.enqueueServicesByExternalIPPool)
+	return c, nil
+}
+
+func (c *ExternalIPController) enqueueService(obj interface{}) {
+	service, ok := obj.(*corev1.Service)
+	if !ok {
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			klog.Errorf("Received unexpected object: %v", obj)
+			return
+		}
+		service, ok = deletedState.Obj.(*corev1.Service)
+		if !ok {
+			klog.Errorf("DeletedFinalStateUnknown contains non-Service object: %v", deletedState.Obj)
+			return
+		}
+	}
+	c.queue.Add(apimachinerytypes.NamespacedName{
+		Namespace: service.Namespace,
+		Name:      service.Name,
+	})
+}
+
+func (c *ExternalIPController) enqueueServiceForEndpoints(obj interface{}) {
+	endpoints, ok := obj.(*corev1.Endpoints)
+	if !ok {
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			klog.Errorf("Received unexpected object: %v", obj)
+			return
+		}
+		endpoints, ok = deletedState.Obj.(*corev1.Endpoints)
+		if !ok {
+			klog.Errorf("DeletedFinalStateUnknown contains non-Endpoint object: %v", deletedState.Obj)
+			return
+		}
+	}
+	service, err := c.serviceLister.Services(endpoints.Namespace).Get(endpoints.Name)
+	if err != nil {
+		klog.ErrorS(err, "failed to get Service for Endpoint", "namespace", endpoints.Namespace, "name", endpoints.Name)
+		return
+	}
+	// we only care services with ServiceExternalTrafficPolicy setting to local
+	if service.Spec.ExternalTrafficPolicy != corev1.ServiceExternalTrafficPolicyTypeLocal {
+		return
+	}
+	c.queue.Add(apimachinerytypes.NamespacedName{
+		Namespace: service.Namespace,
+		Name:      service.Name,
+	})
+}
+
+func (c *ExternalIPController) onLocalIPUpdate(ip string, added bool) {
+	services, _ := c.serviceInformer.GetIndexer().ByIndex(ExternalIPIndex, ip)
+	if len(services) == 0 {
+		return
+	}
+	if added {
+		klog.Infof("Detected LoadBalancer IP address %s added to this Node", ip)
+	} else {
+		klog.Infof("Detected LoadBalancer IP address %s deleted from this Node", ip)
+	}
+	for _, s := range services {
+		c.enqueueService(s)
+	}
+}
+
+// enqueueServiceesByExternalIPPool enqueues all LoadBalancer type Services that refer to the provided ExternalIPPool,
+// the ExternalIPPool is affected by a Node update/create/delete event or
+// Node leaves/join cluster event or ExternalIPPool changed.
+func (c *ExternalIPController) enqueueServicesByExternalIPPool(eipName string) {
+	objects, _ := c.serviceInformer.GetIndexer().ByIndex(externalIPPoolIndex, eipName)
+	for _, object := range objects {
+		service := object.(*corev1.Service)
+		c.queue.Add(apimachinerytypes.NamespacedName{
+			Namespace: service.Namespace,
+			Name:      service.Name,
+		})
+	}
+	klog.InfoS("Detected ExternalIPPool event", "ExternalIPPool", eipName, "enqueueServiceNum", len(objects))
+}
+
+// Run will create defaultWorkers workers (go routines) which will process the Service events from the
+// workqueue.
+func (c *ExternalIPController) Run(stopCh <-chan struct{}) {
+	defer c.queue.ShutDown()
+
+	klog.Infof("Starting %s", controllerName)
+	defer klog.Infof("Shutting down %s", controllerName)
+
+	go c.localIPDetector.Run(stopCh)
+
+	if !cache.WaitForNamedCacheSync(controllerName, stopCh, c.serviceListerSynced, c.endpointsListerSynced, c.localIPDetector.HasSynced) {
+		return
+	}
+
+	c.removeStaleExternalIPs()
+
+	for i := 0; i < defaultWorkers; i++ {
+		go wait.Until(c.worker, time.Second, stopCh)
+	}
+	<-stopCh
+}
+
+// removeStaleExternalIPs unassigns stale LoadBalancer IPs that shouldn't be present on this Node.
+// This function will only delete IPs which caused by Service changes when the agent on this Node was
+// not running. Those IPs should be deleted caused by migration will be deleted by processNextWorkItem.
+func (c *ExternalIPController) removeStaleExternalIPs() {
+	desiredLoadBalancerIPs := sets.NewString()
+	services, _ := c.serviceLister.List(labels.Everything())
+	for _, service := range services {
+		if service.Spec.Type == corev1.ServiceTypeLoadBalancer &&
+			service.ObjectMeta.Annotations[types.ServiceExternalIPPoolAnnotationKey] != "" &&
+			len(service.Status.LoadBalancer.Ingress) != 0 {
+			desiredLoadBalancerIPs.Insert(service.Status.LoadBalancer.Ingress[0].IP)
+		}
+	}
+	actualLocalLoadBalancerIPs := c.ipAssigner.AssignedIPs()
+	for ip := range actualLocalLoadBalancerIPs.Difference(desiredLoadBalancerIPs) {
+		if err := c.ipAssigner.UnassignIP(ip); err != nil {
+			klog.ErrorS(err, "Failed to clean up stale LoadBalancer IP", "ip", ip)
+		}
+	}
+}
+
+// worker is a long-running function that will continually call the processNextWorkItem function in
+// order to read and process a message on the workqueue.
+func (c *ExternalIPController) worker() {
+	for c.processNextWorkItem() {
+	}
+}
+
+func (c *ExternalIPController) processNextWorkItem() bool {
+	obj, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(obj)
+	if key, ok := obj.(apimachinerytypes.NamespacedName); !ok {
+		c.queue.Forget(obj)
+		klog.Errorf("Expected NamespacedName in work queue but got %#v", obj)
+		return true
+	} else if err := c.syncService(key); err == nil {
+		// If no error occurs we Forget this item so it does not get queued again until
+		// another change happens.
+		c.queue.Forget(key)
+	} else {
+		// Put the item back on the workqueue to handle any transient errors.
+		c.queue.AddRateLimited(key)
+		klog.Errorf("Error syncing Service %s, requeuing. Error: %v", key, err)
+	}
+	return true
+}
+
+func (c *ExternalIPController) deleteService(service apimachinerytypes.NamespacedName) error {
+	c.loadBalancerStatesMutex.Lock()
+	defer c.loadBalancerStatesMutex.Unlock()
+	if state, exist := c.loadBalancerStates[service]; !exist {
+		return nil
+	} else {
+		delete(c.loadBalancerStates, service)
+		return c.ipAssigner.UnassignIP(state.ip)
+	}
+}
+
+func (c *ExternalIPController) getServiceState(service *corev1.Service) (externalIPState, bool) {
+	c.loadBalancerStatesMutex.RLock()
+	defer c.loadBalancerStatesMutex.RUnlock()
+	name := apimachinerytypes.NamespacedName{
+		Namespace: service.Namespace,
+		Name:      service.Name,
+	}
+	state, exist := c.loadBalancerStates[name]
+	return state, exist
+}
+
+func (c *ExternalIPController) saveServiceState(service *corev1.Service, state externalIPState) {
+	c.loadBalancerStatesMutex.Lock()
+	defer c.loadBalancerStatesMutex.Unlock()
+	name := apimachinerytypes.NamespacedName{
+		Namespace: service.Namespace,
+		Name:      service.Name,
+	}
+	c.loadBalancerStates[name] = state
+}
+
+func (c *ExternalIPController) getServiceExternalIP(service *corev1.Service) string {
+	if len(service.Status.LoadBalancer.Ingress) == 0 {
+		return ""
+	}
+	return service.Status.LoadBalancer.Ingress[0].IP
+}
+
+func (c *ExternalIPController) syncService(key apimachinerytypes.NamespacedName) error {
+	startTime := time.Now()
+	defer func() {
+		klog.V(4).Infof("Finished syncing Service for %s. (%v)", key, time.Since(startTime))
+	}()
+
+	service, err := c.serviceLister.Services(key.Namespace).Get(key.Name)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return c.deleteService(key)
+		}
+		return err
+	}
+
+	if service.Spec.Type != corev1.ServiceTypeLoadBalancer {
+		return c.deleteService(key)
+	}
+
+	state, exist := c.getServiceState(service)
+	currentLoadBalancerIP := c.getServiceExternalIP(service)
+	if exist && state.ip != currentLoadBalancerIP {
+		if err := c.deleteService(key); err != nil {
+			return err
+		}
+	}
+
+	ipPoool := service.ObjectMeta.Annotations[types.ServiceExternalIPPoolAnnotationKey]
+	if currentLoadBalancerIP == "" || ipPoool == "" {
+		return nil
+	}
+
+	selectNode := true
+	var filters []func(string) bool
+	if service.Spec.ExternalTrafficPolicy == corev1.ServiceExternalTrafficPolicyTypeLocal {
+		nodes, err := c.nodesHasHealthyServiceEndpoint(service)
+		if err != nil {
+			return err
+		}
+		// Avoid unnecessary migration caused by Endpoint changes.
+		if exist && c.cluster.AliveNodes().Has(state.assignedNode) && nodes.Has(state.assignedNode) {
+			selectNode = false
+		} else {
+			filters = append(filters, func(s string) bool {
+				return nodes.Has(s)
+			})
+		}
+	}
+
+	if selectNode {
+		nodeName, err := c.cluster.SelectNodeForIP(currentLoadBalancerIP, ipPoool, filters...)
+		if err != nil {
+			return err
+		}
+		klog.InfoS("SelectNodeForIP", "nodeName", nodeName, "currentLoadBalancerIP", currentLoadBalancerIP, "ipPoool", ipPoool)
+		state = externalIPState{
+			ip:           currentLoadBalancerIP,
+			assignedNode: nodeName,
+		}
+		c.saveServiceState(service, state)
+	}
+
+	serviceToUpdate := service.DeepCopy()
+	serviceToUpdate.Status.LoadBalancer.Ingress[0].Hostname = state.assignedNode
+
+	if state.assignedNode == c.nodeName {
+		if _, err = c.client.CoreV1().Services(serviceToUpdate.Namespace).UpdateStatus(context.TODO(), serviceToUpdate, v1.UpdateOptions{}); err != nil {
+			return err
+		}
+		return c.ipAssigner.AssignIP(currentLoadBalancerIP)
+	}
+	return c.ipAssigner.UnassignIP(currentLoadBalancerIP)
+
+}
+
+// nodesHasHealthyServiceEndpoint returns the set of Nodes which has at least one healthy endpoint.
+func (c *ExternalIPController) nodesHasHealthyServiceEndpoint(lbService *corev1.Service) (sets.String, error) {
+	nodes := sets.NewString()
+	endpoints, err := c.endpointsLister.Endpoints(lbService.Namespace).Get(lbService.Name)
+	if err != nil {
+		return nodes, err
+	}
+	for _, subset := range endpoints.Subsets {
+		for _, ep := range subset.Addresses {
+			if ep.NodeName == nil {
+				continue
+			}
+			nodes.Insert(*ep.NodeName)
+		}
+		for _, ep := range subset.NotReadyAddresses {
+			if ep.NodeName == nil {
+				continue
+			}
+			nodes.Delete(*ep.NodeName)
+		}
+	}
+	return nodes, nil
+}

--- a/pkg/agent/controller/externalip/controller_test.go
+++ b/pkg/agent/controller/externalip/controller_test.go
@@ -1,0 +1,638 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package externalip
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	apimachinerytypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/util/workqueue"
+
+	"antrea.io/antrea/pkg/agent/ipassigner"
+	ipassignertest "antrea.io/antrea/pkg/agent/ipassigner/testing"
+	"antrea.io/antrea/pkg/agent/memberlist"
+	"antrea.io/antrea/pkg/agent/types"
+)
+
+const (
+	fakeNode1              = "node1"
+	fakeNode2              = "node2"
+	fakeNodeIP             = "1.1.1.1"
+	fakeExternalIPPoolName = "pool1"
+	fakeLoadBalancerIP1    = "1.2.3.4"
+	fakeLoadBalancerIP2    = "1.2.3.5"
+)
+
+var (
+	servicePolicyCluster = makeService("svc1", "ns1", corev1.ServiceTypeLoadBalancer, corev1.ServiceExternalTrafficPolicyTypeCluster, fakeExternalIPPoolName, fakeLoadBalancerIP1)
+	servicePolicyLocal   = makeService("svc2", "ns1", corev1.ServiceTypeLoadBalancer, corev1.ServiceExternalTrafficPolicyTypeLocal, fakeExternalIPPoolName, fakeLoadBalancerIP1)
+)
+
+type fakeLocalIPDetector struct {
+	localIPs sets.String
+}
+
+func (d *fakeLocalIPDetector) IsLocalIP(ip string) bool {
+	return d.localIPs.Has(ip)
+}
+
+func (d *fakeLocalIPDetector) Run(stopCh <-chan struct{}) {
+	<-stopCh
+}
+
+func (d *fakeLocalIPDetector) AddEventHandler(handler ipassigner.LocalIPEventHandler) {
+}
+
+func (d *fakeLocalIPDetector) HasSynced() bool {
+	return true
+}
+
+var _ ipassigner.LocalIPDetector = (*fakeLocalIPDetector)(nil)
+
+type fakeMemberlistCluster struct {
+	nodes []string
+}
+
+var _ memberlist.Interface = (*fakeMemberlistCluster)(nil)
+
+func (f *fakeMemberlistCluster) AddClusterEventHandler(h memberlist.ClusterNodeEventHandler) {
+
+}
+
+func (f *fakeMemberlistCluster) AliveNodes() sets.String {
+	return sets.NewString(f.nodes...)
+}
+
+func (f *fakeMemberlistCluster) SelectNodeForIP(ip, externalIPPool string, fillters ...func(string) bool) (string, error) {
+	var selectNode string
+	for _, n := range f.nodes {
+		passed := true
+		for _, f := range fillters {
+			if !f(n) {
+				passed = false
+				break
+			}
+		}
+		if passed {
+			selectNode = n
+			break
+		}
+	}
+	if selectNode == "" {
+		return selectNode, fmt.Errorf("no Node available for IP %s and externalIPPool %s", ip, externalIPPool)
+	}
+	return selectNode, nil
+}
+
+type fakeController struct {
+	*ExternalIPController
+	mockController        *gomock.Controller
+	clientset             *fake.Clientset
+	informerFactory       informers.SharedInformerFactory
+	mockIPAssigner        *ipassignertest.MockIPAssigner
+	fakeMemberlistCluster *fakeMemberlistCluster
+}
+
+func newFakeController(t *testing.T, objs ...runtime.Object) *fakeController {
+
+	controller := gomock.NewController(t)
+	clientset := fake.NewSimpleClientset(objs...)
+	mockIPAssigner := ipassignertest.NewMockIPAssigner(controller)
+	informerFactory := informers.NewSharedInformerFactory(clientset, 0)
+
+	localIPDetector := &fakeLocalIPDetector{}
+	serviceInformer := informerFactory.Core().V1().Services()
+	endpointInformer := informerFactory.Core().V1().Endpoints()
+
+	memberlistCluster := &fakeMemberlistCluster{}
+	eipController := &ExternalIPController{
+		nodeName:              fakeNode1,
+		serviceInformer:       serviceInformer.Informer(),
+		serviceListerSynced:   serviceInformer.Informer().HasSynced,
+		serviceLister:         serviceInformer.Lister(),
+		endpointsInformer:     endpointInformer.Informer(),
+		endpointsListerSynced: endpointInformer.Informer().HasSynced,
+		endpointsLister:       endpointInformer.Lister(),
+		queue:                 workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(minRetryDelay, maxRetryDelay), "loadbalancer"),
+
+		loadBalancerStates: make(map[apimachinerytypes.NamespacedName]externalIPState),
+		cluster:            memberlistCluster,
+		ipAssigner:         mockIPAssigner,
+		localIPDetector:    localIPDetector,
+	}
+	return &fakeController{
+		ExternalIPController:  eipController,
+		mockController:        controller,
+		clientset:             clientset,
+		informerFactory:       informerFactory,
+		mockIPAssigner:        mockIPAssigner,
+		fakeMemberlistCluster: memberlistCluster,
+	}
+
+}
+
+func makeService(name, namespace string, serviceType corev1.ServiceType,
+	trafficPolicy corev1.ServiceExternalTrafficPolicyType, ipPool, lbIP string) *corev1.Service {
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Type:                  serviceType,
+			ExternalTrafficPolicy: trafficPolicy,
+		},
+	}
+	if lbIP != "" {
+		service.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{
+			{IP: lbIP},
+		}
+	}
+	if ipPool != "" {
+		service.Annotations = map[string]string{
+			types.ServiceExternalIPPoolAnnotationKey: ipPool,
+		}
+	}
+	return service
+}
+
+func makeEndpoints(name, namespace string, addresses, notReadyAddresses map[string]string) *corev1.Endpoints {
+	var addr, notReadyAddr []corev1.EndpointAddress
+	for k, v := range addresses {
+		ip := k
+		addr = append(addr, corev1.EndpointAddress{
+			IP:       ip,
+			NodeName: stringPtr(v),
+		})
+	}
+	for k, v := range notReadyAddresses {
+		ip := k
+		notReadyAddr = append(notReadyAddr, corev1.EndpointAddress{
+			IP:       ip,
+			NodeName: stringPtr(v),
+		})
+	}
+	service := &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+
+		Subsets: []corev1.EndpointSubset{
+			{
+				Addresses:         addr,
+				NotReadyAddresses: notReadyAddr,
+			},
+		},
+	}
+	return service
+}
+
+func TestCreateService(t *testing.T) {
+	tests := []struct {
+		name              string
+		existingEndpoints []*corev1.Endpoints
+		serviceToCreate   *corev1.Service
+		healthyNodes      []string
+		expectedCalls     func(mockIPAssigner *ipassignertest.MockIPAssigner)
+		expectedLBStates  map[apimachinerytypes.NamespacedName]externalIPState
+		expectedError     bool
+	}{
+		{
+			"new Service created and local Node selected",
+			nil,
+			servicePolicyCluster,
+			[]string{fakeNode1, fakeNode2},
+			func(mockIPAssigner *ipassignertest.MockIPAssigner) {
+				mockIPAssigner.EXPECT().AssignIP(fakeLoadBalancerIP1)
+			},
+			map[apimachinerytypes.NamespacedName]externalIPState{
+				keyFor(servicePolicyCluster): {
+					ip:           fakeLoadBalancerIP1,
+					assignedNode: fakeNode1,
+				},
+			},
+			false,
+		},
+
+		{
+			"new Service created and local Node not selected",
+			nil,
+			servicePolicyCluster,
+			[]string{fakeNode2, fakeNode1},
+			func(mockIPAssigner *ipassignertest.MockIPAssigner) {
+				mockIPAssigner.EXPECT().UnassignIP(fakeLoadBalancerIP1)
+			},
+			map[apimachinerytypes.NamespacedName]externalIPState{
+				keyFor(servicePolicyCluster): {
+					ip:           fakeLoadBalancerIP1,
+					assignedNode: fakeNode2,
+				},
+			},
+			false,
+		},
+		{
+			"new Service created with ExternalTrafficPolicy=Local and local Node selected",
+			[]*corev1.Endpoints{
+				makeEndpoints(servicePolicyLocal.Name, servicePolicyLocal.Namespace,
+					map[string]string{
+						"2.3.4.5": fakeNode1,
+					},
+					nil),
+			},
+			servicePolicyLocal,
+			[]string{fakeNode1, fakeNode2},
+			func(mockIPAssigner *ipassignertest.MockIPAssigner) {
+				mockIPAssigner.EXPECT().AssignIP(fakeLoadBalancerIP1)
+			},
+			map[apimachinerytypes.NamespacedName]externalIPState{
+				keyFor(servicePolicyLocal): {
+					ip:           fakeLoadBalancerIP1,
+					assignedNode: fakeNode1,
+				},
+			},
+			false,
+		},
+		{
+			"new Service created with ExternalTrafficPolicy=Local and local Node not Selected",
+			[]*corev1.Endpoints{
+				makeEndpoints(servicePolicyLocal.Name, servicePolicyLocal.Namespace,
+					map[string]string{
+						"2.3.4.5": fakeNode1,
+						"2.3.4.6": fakeNode2,
+					},
+					nil),
+			},
+			servicePolicyLocal,
+			[]string{fakeNode2, fakeNode1},
+			func(mockIPAssigner *ipassignertest.MockIPAssigner) {
+				mockIPAssigner.EXPECT().UnassignIP(fakeLoadBalancerIP1)
+			},
+			map[apimachinerytypes.NamespacedName]externalIPState{
+				keyFor(servicePolicyLocal): {
+					ip:           fakeLoadBalancerIP1,
+					assignedNode: fakeNode2,
+				},
+			},
+			false,
+		},
+		{
+			"new Service created with ExternalTrafficPolicy=Local and local Node has no healthy endpoints",
+			[]*corev1.Endpoints{
+				makeEndpoints(servicePolicyLocal.Name, servicePolicyLocal.Namespace,
+					map[string]string{
+						"2.3.4.5": fakeNode1,
+						"2.3.4.6": fakeNode2,
+					},
+					map[string]string{
+						"2.3.4.5": fakeNode1,
+					}),
+			},
+			servicePolicyLocal,
+			[]string{fakeNode1, fakeNode2},
+			func(mockIPAssigner *ipassignertest.MockIPAssigner) {
+				mockIPAssigner.EXPECT().UnassignIP(fakeLoadBalancerIP1)
+			},
+			map[apimachinerytypes.NamespacedName]externalIPState{
+				keyFor(servicePolicyLocal): {
+					ip:           fakeLoadBalancerIP1,
+					assignedNode: fakeNode2,
+				},
+			},
+			false,
+		},
+		{
+			"new Service created with ExternalTrafficPolicy=Local and no Nodes has healthy endpoints",
+			[]*corev1.Endpoints{
+				makeEndpoints(servicePolicyLocal.Name, servicePolicyLocal.Namespace,
+					map[string]string{
+						"2.3.4.5": fakeNode1,
+						"2.3.4.6": fakeNode2,
+					},
+					map[string]string{
+						"2.3.4.5": fakeNode1,
+						"2.3.4.6": fakeNode2,
+					}),
+			},
+			servicePolicyLocal,
+			[]string{fakeNode1, fakeNode2},
+			func(mockIPAssigner *ipassignertest.MockIPAssigner) {
+			},
+			map[apimachinerytypes.NamespacedName]externalIPState{},
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objs := []runtime.Object{}
+			for _, s := range tt.existingEndpoints {
+				objs = append(objs, s)
+			}
+			objs = append(objs, tt.serviceToCreate)
+			c := newFakeController(t, objs...)
+			defer c.mockController.Finish()
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+			c.informerFactory.Start(stopCh)
+			c.informerFactory.WaitForCacheSync(stopCh)
+			c.fakeMemberlistCluster.nodes = tt.healthyNodes
+			tt.expectedCalls(c.mockIPAssigner)
+			err := c.syncService(keyFor(tt.serviceToCreate))
+			if tt.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.expectedLBStates, c.loadBalancerStates)
+		})
+	}
+}
+
+func TestUpdateService(t *testing.T) {
+	service1UpdatedLBIP := servicePolicyCluster.DeepCopy()
+	service1UpdatedLBIP.Status.LoadBalancer.Ingress[0].IP = fakeLoadBalancerIP2
+
+	service1ChangedType := servicePolicyCluster.DeepCopy()
+	service1ChangedType.Spec.Type = corev1.ServiceTypeClusterIP
+
+	service1LBIPRecalimed := servicePolicyCluster.DeepCopy()
+	service1LBIPRecalimed.Status.LoadBalancer.Ingress = nil
+
+	serviceChangedExternalTrafficPolicy := servicePolicyCluster.DeepCopy()
+	serviceChangedExternalTrafficPolicy.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeLocal
+
+	tests := []struct {
+		name             string
+		endpoints        []*corev1.Endpoints
+		serviceToUpdate  *corev1.Service
+		previousLBStates map[apimachinerytypes.NamespacedName]externalIPState
+		expectedLBStates map[apimachinerytypes.NamespacedName]externalIPState
+		healthyNodes     []string
+		expectedCalls    func(mockIPAssigner *ipassignertest.MockIPAssigner)
+		expectedError    bool
+	}{
+		{
+			"Service Updated LB IP and local Node selected",
+			nil,
+			service1UpdatedLBIP,
+			map[apimachinerytypes.NamespacedName]externalIPState{
+				keyFor(service1UpdatedLBIP): {fakeLoadBalancerIP1, fakeNode1},
+			},
+			map[apimachinerytypes.NamespacedName]externalIPState{
+				keyFor(service1UpdatedLBIP): {fakeLoadBalancerIP2, fakeNode1},
+			},
+			[]string{fakeNode1, fakeNode2},
+			func(mockIPAssigner *ipassignertest.MockIPAssigner) {
+				mockIPAssigner.EXPECT().UnassignIP(fakeLoadBalancerIP1)
+				mockIPAssigner.EXPECT().AssignIP(fakeLoadBalancerIP2)
+			},
+			false,
+		},
+		{
+			"Service Updated LB IP and local Node not selected",
+			nil,
+			service1UpdatedLBIP,
+			map[apimachinerytypes.NamespacedName]externalIPState{
+				keyFor(service1UpdatedLBIP): {fakeLoadBalancerIP1, fakeNode1},
+			},
+			map[apimachinerytypes.NamespacedName]externalIPState{
+				keyFor(service1UpdatedLBIP): {fakeLoadBalancerIP2, fakeNode2},
+			},
+			[]string{fakeNode2, fakeNode1},
+			func(mockIPAssigner *ipassignertest.MockIPAssigner) {
+				mockIPAssigner.EXPECT().UnassignIP(fakeLoadBalancerIP1)
+				mockIPAssigner.EXPECT().UnassignIP(fakeLoadBalancerIP2)
+			},
+			false,
+		},
+		{
+			"Service changed type to ClusterIP",
+			nil,
+			service1ChangedType,
+			map[apimachinerytypes.NamespacedName]externalIPState{
+				keyFor(service1UpdatedLBIP): {fakeLoadBalancerIP1, fakeNode1},
+			},
+			map[apimachinerytypes.NamespacedName]externalIPState{},
+			[]string{fakeNode1, fakeNode2},
+			func(mockIPAssigner *ipassignertest.MockIPAssigner) {
+				mockIPAssigner.EXPECT().UnassignIP(fakeLoadBalancerIP1)
+			},
+			false,
+		},
+		{
+			"Service LoadBalancer IP reclaimed",
+			nil,
+			service1ChangedType,
+			map[apimachinerytypes.NamespacedName]externalIPState{
+				keyFor(service1UpdatedLBIP): {fakeLoadBalancerIP1, fakeNode1},
+			},
+			map[apimachinerytypes.NamespacedName]externalIPState{},
+			[]string{fakeNode1, fakeNode2},
+			func(mockIPAssigner *ipassignertest.MockIPAssigner) {
+				mockIPAssigner.EXPECT().UnassignIP(fakeLoadBalancerIP1)
+			},
+			false,
+		},
+		{
+			"Service changed ExternalTrafficPolicy to local",
+			[]*corev1.Endpoints{
+				makeEndpoints(serviceChangedExternalTrafficPolicy.Name, serviceChangedExternalTrafficPolicy.Namespace,
+					map[string]string{
+						"2.3.4.5": fakeNode1,
+						"2.3.4.6": fakeNode2,
+					}, map[string]string{
+						"2.3.4.5": fakeNode1,
+					}),
+			},
+			serviceChangedExternalTrafficPolicy,
+			map[apimachinerytypes.NamespacedName]externalIPState{
+				keyFor(serviceChangedExternalTrafficPolicy): {fakeLoadBalancerIP1, fakeNode1},
+			},
+			map[apimachinerytypes.NamespacedName]externalIPState{
+				keyFor(serviceChangedExternalTrafficPolicy): {fakeLoadBalancerIP1, fakeNode2},
+			},
+			[]string{fakeNode1, fakeNode2},
+			func(mockIPAssigner *ipassignertest.MockIPAssigner) {
+				mockIPAssigner.EXPECT().UnassignIP(fakeLoadBalancerIP1)
+			},
+			false,
+		},
+		{
+			"local Node no longer selected",
+			nil,
+			servicePolicyCluster,
+			map[apimachinerytypes.NamespacedName]externalIPState{
+				keyFor(servicePolicyCluster): {fakeLoadBalancerIP1, fakeNode1},
+			},
+			map[apimachinerytypes.NamespacedName]externalIPState{
+				keyFor(servicePolicyCluster): {fakeLoadBalancerIP1, fakeNode2},
+			},
+			[]string{fakeNode2, fakeNode1},
+			func(mockIPAssigner *ipassignertest.MockIPAssigner) {
+				mockIPAssigner.EXPECT().UnassignIP(fakeLoadBalancerIP1)
+			},
+			false,
+		},
+		{
+			"local Node no longer have healy endpoints",
+			[]*corev1.Endpoints{
+				makeEndpoints(servicePolicyLocal.Name, servicePolicyLocal.Namespace,
+					map[string]string{
+						"2.3.4.5": fakeNode1,
+						"2.3.4.6": fakeNode2,
+					}, map[string]string{
+						"2.3.4.5": fakeNode1,
+					}),
+			},
+			servicePolicyLocal,
+			map[apimachinerytypes.NamespacedName]externalIPState{
+				keyFor(servicePolicyLocal): {fakeLoadBalancerIP1, fakeNode1},
+			},
+			map[apimachinerytypes.NamespacedName]externalIPState{
+				keyFor(servicePolicyLocal): {fakeLoadBalancerIP1, fakeNode2},
+			},
+			[]string{fakeNode1, fakeNode2},
+			func(mockIPAssigner *ipassignertest.MockIPAssigner) {
+				mockIPAssigner.EXPECT().UnassignIP(fakeLoadBalancerIP1)
+			},
+			false,
+		},
+		{
+			"should not migrate to other nodes if local Node still have healthy endpoints",
+			[]*corev1.Endpoints{
+				makeEndpoints(servicePolicyLocal.Name, servicePolicyLocal.Namespace,
+					map[string]string{
+						"2.3.4.5": fakeNode1,
+						"2.3.4.6": fakeNode2,
+					},
+					nil,
+				),
+			},
+			servicePolicyLocal,
+			map[apimachinerytypes.NamespacedName]externalIPState{
+				keyFor(servicePolicyLocal): {fakeLoadBalancerIP1, fakeNode1},
+			},
+			map[apimachinerytypes.NamespacedName]externalIPState{
+				keyFor(servicePolicyLocal): {fakeLoadBalancerIP1, fakeNode1},
+			},
+			[]string{fakeNode2, fakeNode1},
+			func(mockIPAssigner *ipassignertest.MockIPAssigner) {
+				mockIPAssigner.EXPECT().AssignIP(fakeLoadBalancerIP1)
+			},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objs := []runtime.Object{}
+			for _, s := range tt.endpoints {
+				objs = append(objs, s)
+			}
+			objs = append(objs, tt.serviceToUpdate)
+			c := newFakeController(t, objs...)
+			c.loadBalancerStates = tt.previousLBStates
+			defer c.mockController.Finish()
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+			c.informerFactory.Start(stopCh)
+			c.informerFactory.WaitForCacheSync(stopCh)
+			c.fakeMemberlistCluster.nodes = tt.healthyNodes
+			tt.expectedCalls(c.mockIPAssigner)
+			err := c.syncService(keyFor(tt.serviceToUpdate))
+			if tt.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.expectedLBStates, c.loadBalancerStates)
+		})
+	}
+}
+
+func TestStaleLoadBalancerIPRemoval(t *testing.T) {
+	service3 := servicePolicyCluster.DeepCopy()
+	service3.Name = "svc3"
+	service3.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{
+		{IP: fakeLoadBalancerIP2},
+	}
+	tests := []struct {
+		name             string
+		existingServices []*corev1.Service
+		assignedIPs      []string
+		expectedCalls    func(mockIPAssigner *ipassignertest.MockIPAssigner)
+	}{
+		{
+			"should keep assigned IPs if coressponding Services are present",
+			[]*corev1.Service{servicePolicyCluster, service3},
+			[]string{fakeNode1, fakeNode2},
+			func(mockIPAssigner *ipassignertest.MockIPAssigner) {
+				mockIPAssigner.EXPECT().AssignedIPs().DoAndReturn(
+					func() interface{} {
+						return sets.NewString(fakeLoadBalancerIP1, fakeLoadBalancerIP2)
+					},
+				)
+			},
+		},
+		{
+			"should cleanup stale assigned IPs",
+			[]*corev1.Service{servicePolicyCluster},
+			[]string{fakeNode1, fakeNode2},
+			func(mockIPAssigner *ipassignertest.MockIPAssigner) {
+				mockIPAssigner.EXPECT().AssignedIPs().DoAndReturn(
+					func() interface{} {
+						return sets.NewString(fakeLoadBalancerIP1, fakeLoadBalancerIP2)
+					},
+				)
+				mockIPAssigner.EXPECT().UnassignIP(fakeLoadBalancerIP2)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objs := []runtime.Object{}
+			for _, s := range tt.existingServices {
+				objs = append(objs, s)
+			}
+			c := newFakeController(t, objs...)
+			defer c.mockController.Finish()
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+			c.informerFactory.Start(stopCh)
+			c.informerFactory.WaitForCacheSync(stopCh)
+			tt.expectedCalls(c.mockIPAssigner)
+			c.removeStaleExternalIPs()
+		})
+	}
+}
+
+func keyFor(svc *corev1.Service) apimachinerytypes.NamespacedName {
+	return apimachinerytypes.NamespacedName{
+		Namespace: svc.Namespace,
+		Name:      svc.Name,
+	}
+}
+
+func stringPtr(s string) *string {
+	return &s
+}

--- a/pkg/agent/types/annotations.go
+++ b/pkg/agent/types/annotations.go
@@ -23,4 +23,7 @@ const (
 
 	// NodeWireGuardPublicAnnotationKey represents the key of the Node's WireGuard public key in the Annotations of the Node.
 	NodeWireGuardPublicAnnotationKey string = "node.antrea.io/wireguard-public-key"
+
+	// ServiceExternalIPPoolAnnotationKey represents the key of the Service's desired external IP pool.
+	ServiceExternalIPPoolAnnotationKey string = "service.antrea.io/external-ip-pool"
 )

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -309,6 +309,10 @@ func installHandlers(c *ExtraConfig, s *genericapiserver.GenericAPIServer) {
 		})
 	}
 
+	if features.DefaultFeatureGate.Enabled(features.Egress) || features.DefaultFeatureGate.Enabled(features.ServiceExternalIP) {
+		s.Handler.NonGoRestfulMux.HandleFunc("/validate/externalippool", webhook.HandlerForValidateFunc(c.externalIPPoolController.ValidateExternalIPPool))
+	}
+
 	if features.DefaultFeatureGate.Enabled(features.Egress) {
 		s.Handler.NonGoRestfulMux.HandleFunc("/validate/egress", webhook.HandlerForValidateFunc(c.egressController.ValidateEgress))
 		s.Handler.NonGoRestfulMux.HandleFunc("/validate/externalippool", webhook.HandlerForValidateFunc(c.externalIPPoolController.ValidateExternalIPPool))

--- a/pkg/apiserver/handlers/featuregates/handler.go
+++ b/pkg/apiserver/handlers/featuregates/handler.go
@@ -29,8 +29,8 @@ import (
 	"antrea.io/antrea/pkg/util/env"
 )
 
-var controllerGates = sets.NewString("Traceflow", "AntreaPolicy", "Egress", "NetworkPolicyStats", "NodeIPAM")
-var agentGates = sets.NewString("AntreaPolicy", "AntreaProxy", "Egress", "EndpointSlice", "Traceflow", "FlowExporter", "NetworkPolicyStats", "NodePortLocal", "AntreaIPAM")
+var controllerGates = sets.NewString("Traceflow", "AntreaPolicy", "Egress", "NetworkPolicyStats", "NodeIPAM", "LoadBalancer")
+var agentGates = sets.NewString("AntreaPolicy", "AntreaProxy", "Egress", "EndpointSlice", "Traceflow", "FlowExporter", "NetworkPolicyStats", "NodePortLocal", "AntreaIPAM", "LoadBalancer")
 
 type (
 	Config struct {

--- a/pkg/apiserver/handlers/featuregates/handler_test.go
+++ b/pkg/apiserver/handlers/featuregates/handler_test.go
@@ -54,6 +54,7 @@ func Test_getGatesResponse(t *testing.T) {
 				{Component: "agent", Name: "FlowExporter", Status: "Disabled", Version: "ALPHA"},
 				{Component: "agent", Name: "NetworkPolicyStats", Status: "Enabled", Version: "BETA"},
 				{Component: "agent", Name: "NodePortLocal", Status: "Enabled", Version: "BETA"},
+				{Component: "agent", Name: "LoadBalancer", Status: "Disabled", Version: "ALPHA"},
 			},
 		},
 	}
@@ -139,6 +140,7 @@ func TestHandleFunc(t *testing.T) {
 				{Component: "controller", Name: "Traceflow", Status: "Enabled", Version: "BETA"},
 				{Component: "controller", Name: "NetworkPolicyStats", Status: "Enabled", Version: "BETA"},
 				{Component: "controller", Name: "NodeIPAM", Status: "Disabled", Version: "ALPHA"},
+				{Component: "controller", Name: "LoadBalancer", Status: "Disabled", Version: "ALPHA"},
 				{Component: "agent", Name: "AntreaPolicy", Status: "Enabled", Version: "BETA"},
 				{Component: "agent", Name: "AntreaProxy", Status: "Enabled", Version: "BETA"},
 				{Component: "agent", Name: "Egress", Status: "Disabled", Version: "ALPHA"},
@@ -147,6 +149,7 @@ func TestHandleFunc(t *testing.T) {
 				{Component: "agent", Name: "FlowExporter", Status: "Disabled", Version: "ALPHA"},
 				{Component: "agent", Name: "NetworkPolicyStats", Status: "Enabled", Version: "BETA"},
 				{Component: "agent", Name: "NodePortLocal", Status: "Enabled", Version: "BETA"},
+				{Component: "agent", Name: "LoadBalancer", Status: "Disabled", Version: "ALPHA"},
 			},
 		},
 	}
@@ -191,6 +194,7 @@ func Test_getControllerGatesResponse(t *testing.T) {
 				{Component: "controller", Name: "Traceflow", Status: "Enabled", Version: "BETA"},
 				{Component: "controller", Name: "NetworkPolicyStats", Status: "Enabled", Version: "BETA"},
 				{Component: "controller", Name: "NodeIPAM", Status: "Disabled", Version: "ALPHA"},
+				{Component: "controller", Name: "LoadBalancer", Status: "Disabled", Version: "ALPHA"},
 			},
 		},
 	}

--- a/pkg/controller/externalip/controller.go
+++ b/pkg/controller/externalip/controller.go
@@ -1,0 +1,393 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package externalip
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"reflect"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	apimachineryerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	apimachinerytypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+
+	antreaagenttypes "antrea.io/antrea/pkg/agent/types"
+	"antrea.io/antrea/pkg/controller/externalippool"
+)
+
+const (
+	controllerName = "ExternalIPController"
+	// Set resyncPeriod to 0 to disable resyncing.
+	resyncPeriod time.Duration = 0
+	// How long to wait before retrying the processing of an Egress change.
+	minRetryDelay = 5 * time.Second
+	maxRetryDelay = 300 * time.Second
+	// Default number of workers processing an Egress change.
+	defaultWorkers = 4
+
+	loadBalancerIPIndex = "loadBalancerIP"
+	externalIPPoolIndex = "externalIPPool"
+)
+
+// ipAllocation contains the IP and the IP Pool which allocates it.
+type ipAllocation struct {
+	ip     net.IP
+	ipPool string
+}
+
+// ExternalIPController is responsible for synchronizing the Services need external IPs
+type ExternalIPController struct {
+	externalIPAllocator externalippool.ExternalIPAllocator
+	client              clientset.Interface
+
+	// ipAllocationMap is a map from Service name to IP allocated.
+	ipAllocationMap   map[apimachinerytypes.NamespacedName]*ipAllocation
+	ipAllocationMutex sync.RWMutex
+
+	serviceInformer     cache.SharedIndexInformer
+	serviceLister       corelisters.ServiceLister
+	serviceListerSynced cache.InformerSynced
+	// queue maintains the Service objects that need to be synced.
+	queue workqueue.RateLimitingInterface
+}
+
+func NewExternalIPController(
+	client clientset.Interface,
+	serviceInformer coreinformers.ServiceInformer,
+	externalIPAllocator externalippool.ExternalIPAllocator,
+) *ExternalIPController {
+	c := &ExternalIPController{
+		client:              client,
+		queue:               workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(minRetryDelay, maxRetryDelay), "loadbalancer"),
+		serviceInformer:     serviceInformer.Informer(),
+		serviceLister:       serviceInformer.Lister(),
+		serviceListerSynced: serviceInformer.Informer().HasSynced,
+		externalIPAllocator: externalIPAllocator,
+		ipAllocationMap:     make(map[apimachinerytypes.NamespacedName]*ipAllocation),
+	}
+
+	c.serviceInformer.AddIndexers(cache.Indexers{loadBalancerIPIndex: func(obj interface{}) ([]string, error) {
+		service, ok := obj.(*corev1.Service)
+		if !ok {
+			return nil, fmt.Errorf("obj is not Service: %+v", obj)
+		}
+		if len(service.Status.LoadBalancer.Ingress) == 0 {
+			return nil, nil
+		}
+		return []string{service.Status.LoadBalancer.Ingress[0].IP}, nil
+	}})
+
+	c.serviceInformer.AddIndexers(cache.Indexers{externalIPPoolIndex: func(obj interface{}) ([]string, error) {
+		service, ok := obj.(*corev1.Service)
+		if !ok {
+			return nil, fmt.Errorf("obj is not Service: %+v", obj)
+		}
+		eipName, ok := service.Annotations[antreaagenttypes.ServiceExternalIPPoolAnnotationKey]
+		if !ok {
+			return nil, nil
+		}
+		return []string{eipName}, nil
+	}})
+
+	c.serviceInformer.AddEventHandlerWithResyncPeriod(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: c.enqueueService,
+			UpdateFunc: func(old, cur interface{}) {
+				c.enqueueService(cur)
+			},
+			DeleteFunc: c.enqueueService,
+		},
+		resyncPeriod,
+	)
+
+	c.externalIPAllocator.AddEventHandler(func(ipPool string) {
+		c.enqueueServicesByExternalIPPool(ipPool)
+	})
+	return c
+}
+
+func (c *ExternalIPController) enqueueService(obj interface{}) {
+	service, ok := obj.(*corev1.Service)
+	if !ok {
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			klog.Errorf("Received unexpected object: %v", obj)
+			return
+		}
+		service, ok = deletedState.Obj.(*corev1.Service)
+		if !ok {
+			klog.Errorf("DeletedFinalStateUnknown contains non-Service object: %v", deletedState.Obj)
+			return
+		}
+	}
+	namespacedName := apimachinerytypes.NamespacedName{
+		Namespace: service.Namespace,
+		Name:      service.Name,
+	}
+	c.queue.Add(namespacedName)
+}
+
+// enqueueServiceesByExternalIPPool enqueues all LoadBalancer type Services that refer to the provided ExternalIPPool,
+// the ExternalIPPool is affected by a Node update/create/delete event or ExternalIPPool changed.
+func (c *ExternalIPController) enqueueServicesByExternalIPPool(eipName string) {
+	objects, _ := c.serviceInformer.GetIndexer().ByIndex(externalIPPoolIndex, eipName)
+	objectsWithEmptyExternalIPPool, _ := c.serviceInformer.GetIndexer().ByIndex(externalIPPoolIndex, "")
+	objects = append(objects, objectsWithEmptyExternalIPPool...)
+	for _, object := range objects {
+		c.enqueueService(object)
+	}
+	klog.InfoS("Detected ExternalIPPool event", "ExternalIPPool", eipName, "enqueueServiceNum", len(objects))
+}
+
+// Run will create defaultWorkers workers (go routines) which will process the Service events from the
+// workqueue.
+func (c *ExternalIPController) Run(stopCh <-chan struct{}) {
+	defer c.queue.ShutDown()
+
+	klog.Infof("Starting %s", controllerName)
+	defer klog.Infof("Shutting down %s", controllerName)
+
+	if !cache.WaitForNamedCacheSync(controllerName, stopCh, c.serviceListerSynced, c.externalIPAllocator.HasSynced) {
+		return
+	}
+
+	svcs, _ := c.serviceLister.List(labels.Everything())
+	c.restoreIPAllocations(svcs)
+
+	for i := 0; i < defaultWorkers; i++ {
+		go wait.Until(c.worker, time.Second, stopCh)
+	}
+	<-stopCh
+}
+
+// updateIPAllocation sets the LoadBalancer IP of an Service as allocated in the specified ExternalIPPool and records the
+// allocation in ipAllocationMap.
+func (c *ExternalIPController) restoreIPAllocations(services []*corev1.Service) {
+	var previousIPAllocations []externalippool.IPAllocation
+	for _, svc := range services {
+		ipPool := svc.ObjectMeta.Annotations[antreaagenttypes.ServiceExternalIPPoolAnnotationKey]
+		if svc.Spec.Type != corev1.ServiceTypeLoadBalancer || ipPool == "" || len(svc.Status.LoadBalancer.Ingress) == 0 {
+			continue
+		}
+		ip := net.ParseIP(svc.Status.LoadBalancer.Ingress[0].IP)
+		allocation := externalippool.IPAllocation{
+			ObjectReference: v1.ObjectReference{
+				Name:      svc.Name,
+				Namespace: svc.Namespace,
+				Kind:      svc.Kind,
+			},
+			IPPoolName: ipPool,
+			IP:         ip,
+		}
+		previousIPAllocations = append(previousIPAllocations, allocation)
+	}
+	succeededAllocations := c.externalIPAllocator.RestoreIPAllocations(previousIPAllocations)
+	for _, alloc := range succeededAllocations {
+		name := apimachinerytypes.NamespacedName{
+			Namespace: alloc.ObjectReference.Namespace,
+			Name:      alloc.ObjectReference.Name,
+		}
+		c.setIPAllocation(name, alloc.IPPoolName, alloc.IP)
+		klog.InfoS("Restored Loadbalancer IP", "service", name, "ip", alloc.IP, "pool", alloc.IPPoolName)
+	}
+}
+
+func (c *ExternalIPController) setIPAllocation(name apimachinerytypes.NamespacedName, ipPool string, ip net.IP) {
+	c.ipAllocationMutex.Lock()
+	defer c.ipAllocationMutex.Unlock()
+	c.ipAllocationMap[name] = &ipAllocation{
+		ip:     ip,
+		ipPool: ipPool,
+	}
+}
+
+// worker is a long-running function that will continually call the processNextWorkItem function in
+// order to read and process a message on the workqueue.
+func (c *ExternalIPController) worker() {
+	for c.processNextWorkItem() {
+	}
+}
+
+func (c *ExternalIPController) processNextWorkItem() bool {
+	obj, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(obj)
+	if key, ok := obj.(apimachinerytypes.NamespacedName); !ok {
+		c.queue.Forget(obj)
+		klog.Errorf("Expected NamespacedName in work queue but got %#v", obj)
+		return true
+	} else if err := c.syncService(key); err == nil {
+		// If no error occurs we Forget this item so it does not get queued again until
+		// another change happens.
+		c.queue.Forget(key)
+	} else {
+		// Put the item back on the workqueue to handle any transient errors.
+		c.queue.AddRateLimited(key)
+		klog.Errorf("Error syncing Service %s, requeuing. Error: %v", key, err)
+	}
+	return true
+}
+
+func (c *ExternalIPController) deleteLoadBalancer(service apimachinerytypes.NamespacedName) {
+	c.ipAllocationMutex.Lock()
+	defer c.ipAllocationMutex.Unlock()
+	allocation, exists := c.ipAllocationMap[service]
+	if exists {
+		c.externalIPAllocator.ReleaseIP(allocation.ipPool, allocation.ip)
+		delete(c.ipAllocationMap, service)
+	}
+}
+
+func (c *ExternalIPController) getAssignedLoadBalancerIPAllocation(service apimachinerytypes.NamespacedName) (*ipAllocation, bool) {
+	c.ipAllocationMutex.RLock()
+	defer c.ipAllocationMutex.RUnlock()
+	allocation, exist := c.ipAllocationMap[service]
+	return allocation, exist
+}
+
+func getServiceExternalIP(service *corev1.Service) string {
+	if len(service.Status.LoadBalancer.Ingress) == 0 {
+		return ""
+	}
+	return service.Status.LoadBalancer.Ingress[0].IP
+}
+
+func (c *ExternalIPController) syncService(key apimachinerytypes.NamespacedName) error {
+	startTime := time.Now()
+	defer func() {
+		klog.V(4).Infof("Finished syncing Service for %s. (%v)", key, time.Since(startTime))
+	}()
+
+	prev, err := c.serviceLister.Services(key.Namespace).Get(key.Name)
+	if err != nil {
+		// service already deleted
+		if apimachineryerrors.IsNotFound(err) {
+			c.deleteLoadBalancer(key)
+			return nil
+		}
+		return err
+	}
+
+	service := prev.DeepCopy()
+	// service is not LoadBalancer or type changed
+	if service.Spec.Type != corev1.ServiceTypeLoadBalancer {
+		c.deleteLoadBalancer(key)
+		return nil
+	}
+
+	currentIPPool := service.ObjectMeta.Annotations[antreaagenttypes.ServiceExternalIPPoolAnnotationKey]
+	prevIPAllocation, allocationExists := c.getAssignedLoadBalancerIPAllocation(key)
+	currentLoadBalancerIP := getServiceExternalIP(service)
+
+	// if user specifies LoadBalancerIP in spec, we should check whether it matches the current LoadBalancer IP.
+	specIPMatched := service.Spec.LoadBalancerIP == "" || service.Spec.LoadBalancerIP == currentLoadBalancerIP
+
+	if allocationExists && specIPMatched &&
+		c.externalIPAllocator.IPPoolExists(currentIPPool) &&
+		c.externalIPAllocator.IPPoolHasIP(currentIPPool, prevIPAllocation.ip) &&
+		currentIPPool == prevIPAllocation.ipPool &&
+		currentLoadBalancerIP == prevIPAllocation.ip.String() {
+		return nil
+	}
+
+	// The ExternalIPPool does not exist or has been deleted. Reclaim the LoadBalancer IP.
+	if currentIPPool != "" && !c.externalIPAllocator.IPPoolExists(currentIPPool) {
+		c.deleteLoadBalancer(key)
+		if currentLoadBalancerIP != "" {
+			service.Status.LoadBalancer.Ingress = nil
+			return c.updateService(prev, service)
+		}
+	}
+
+	// the LoadBalancer IP or ExternalIPPool changed somehow. Delete the previous allocation.
+	c.deleteLoadBalancer(key)
+	var newIPPool string
+	var newLBIP net.IP
+	if service.Spec.LoadBalancerIP != "" {
+		// find the coressponding ExternalIPPool for user specified IP address.
+		newLBIP = net.ParseIP(service.Spec.LoadBalancerIP)
+		newIPPool, err = c.externalIPAllocator.LocateIP(newLBIP)
+		if err == nil {
+			err = c.externalIPAllocator.UpdateIPAllocation(newIPPool, newLBIP)
+		}
+	} else if currentIPPool == "" {
+		// ExternalIPPool is not specified. Allocate IP and ExternalIPPool.
+		newIPPool, newLBIP, err = c.externalIPAllocator.AllocateIP()
+	} else {
+		// allocate IP from existing ExternalIPPool.
+		newLBIP, err = c.externalIPAllocator.AllocateIPFromPool(currentIPPool)
+		newIPPool = currentIPPool
+	}
+	if err != nil {
+		// If the ExternalIPPool does not exist, we can ignore the error sine the Service will get requeued by ExternalIPPool change events.
+		if errors.Is(err, externalippool.ErrExternalIPPoolNotFound) {
+			klog.Errorf("Error when allocating IP from ExternalIPPool %s for LoadBalancer Service %s: %v", newIPPool, key, err)
+			return nil
+		}
+		return fmt.Errorf("error when allocating IP %s from ExternalIPPool %s for LoadBalancer Service %s: %v", newLBIP, newIPPool, key, err)
+	}
+	klog.InfoS("Allocated Service LoadBalancer IP", "service", key, "ip", newLBIP, "pool", newIPPool)
+	if service.Annotations == nil {
+		service.Annotations = make(map[string]string)
+	}
+	service.Annotations[antreaagenttypes.ServiceExternalIPPoolAnnotationKey] = newIPPool
+	service.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{
+		{
+			IP: newLBIP.String(),
+		},
+	}
+	c.setIPAllocation(key, newIPPool, newLBIP)
+	return c.updateService(prev, service)
+}
+
+// updateService updates the Service in Kubernetes API.
+func (c *ExternalIPController) updateService(prev, current *corev1.Service) error {
+	var svcUpdated *corev1.Service
+	var err error
+	if !(reflect.DeepEqual(prev.Annotations, current.Annotations) && reflect.DeepEqual(prev.Spec, current.Spec)) {
+		svcUpdated, err = c.client.CoreV1().Services(current.Namespace).Update(context.TODO(), current, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+	}
+	if !reflect.DeepEqual(prev.Status, current.Status) {
+		if svcUpdated != nil {
+			current.Status.DeepCopyInto(&svcUpdated.Status)
+		} else {
+			svcUpdated = current
+		}
+		_, err = c.client.CoreV1().Services(current.Namespace).UpdateStatus(context.TODO(), svcUpdated, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/controller/externalip/controller_test.go
+++ b/pkg/controller/externalip/controller_test.go
@@ -1,0 +1,308 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package externalip
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+
+	antreaagenttypes "antrea.io/antrea/pkg/agent/types"
+	antreacrds "antrea.io/antrea/pkg/apis/crd/v1alpha2"
+	"antrea.io/antrea/pkg/client/clientset/versioned"
+	fakeversioned "antrea.io/antrea/pkg/client/clientset/versioned/fake"
+	crdinformers "antrea.io/antrea/pkg/client/informers/externalversions"
+	"antrea.io/antrea/pkg/controller/externalippool"
+)
+
+type loadBalancerController struct {
+	*ExternalIPController
+	crdClient           versioned.Interface
+	client              kubernetes.Interface
+	informerFactory     informers.SharedInformerFactory
+	crdInformerFactory  crdinformers.SharedInformerFactory
+	externalIPAllocator *externalippool.ExternalIPPoolController
+}
+
+func newExternalIPPool(name, cidr, start, end string) *antreacrds.ExternalIPPool {
+	pool := &antreacrds.ExternalIPPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+	if len(cidr) > 0 {
+		pool.Spec.IPRanges = append(pool.Spec.IPRanges, antreacrds.IPRange{CIDR: cidr})
+	}
+	if len(start) > 0 && len(end) > 0 {
+		pool.Spec.IPRanges = append(pool.Spec.IPRanges, antreacrds.IPRange{Start: start, End: end})
+	}
+	return pool
+}
+
+func newService(name, namespace string, serviceType corev1.ServiceType, lbIP, ipPool string) *corev1.Service {
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Type:           serviceType,
+			LoadBalancerIP: lbIP,
+		},
+	}
+	if ipPool != "" {
+		service.Annotations = map[string]string{
+			antreaagenttypes.ServiceExternalIPPoolAnnotationKey: ipPool,
+		}
+	}
+	return service
+}
+
+func newController(objects, crdObjects []runtime.Object) *loadBalancerController {
+	client := fake.NewSimpleClientset(objects...)
+	crdClient := fakeversioned.NewSimpleClientset(crdObjects...)
+	informerFactory := informers.NewSharedInformerFactory(client, resyncPeriod)
+	crdInformerFactory := crdinformers.NewSharedInformerFactory(crdClient, resyncPeriod)
+	externalIPPoolController := externalippool.NewExternalIPPoolController(crdClient, crdInformerFactory.Crd().V1alpha2().ExternalIPPools())
+	controller := NewExternalIPController(client, informerFactory.Core().V1().Services(), externalIPPoolController)
+	return &loadBalancerController{
+		ExternalIPController: controller,
+		informerFactory:      informerFactory,
+		crdInformerFactory:   crdInformerFactory,
+		crdClient:            crdClient,
+		client:               client,
+		externalIPAllocator:  externalIPPoolController,
+	}
+}
+
+func TestAddService(t *testing.T) {
+	tests := []struct {
+		name                   string
+		externalIPPool         []*antreacrds.ExternalIPPool
+		service                *corev1.Service
+		expectedLoadBalancerIP string
+	}{
+		{
+			"Service with valid ExternalIPPool annotation",
+			[]*antreacrds.ExternalIPPool{
+				newExternalIPPool("eip1", "", "1.2.3.4", "1.2.3.5"),
+			},
+			newService("svc1", "ns1", corev1.ServiceTypeLoadBalancer, "", "eip1"),
+			"1.2.3.4",
+		},
+		{
+			"Service with valid ExternalIPPool annotation and multiple ExternalIPPool present",
+			[]*antreacrds.ExternalIPPool{
+				newExternalIPPool("eip1", "", "1.2.3.4", "1.2.3.5"),
+				newExternalIPPool("eip2", "", "1.2.4.4", "1.2.4.5"),
+			},
+			newService("svc1", "ns1", corev1.ServiceTypeLoadBalancer, "", "eip2"),
+			"1.2.4.4",
+		},
+		{
+			"Service with empty ExternalIPPool annotation",
+			[]*antreacrds.ExternalIPPool{
+				newExternalIPPool("eip1", "", "1.2.3.4", "1.2.3.5"),
+			},
+			newService("svc1", "ns1", corev1.ServiceTypeLoadBalancer, "", "eip1"),
+			"1.2.3.4",
+		},
+		{
+			"Service with user specified LoadBalancer IP",
+			[]*antreacrds.ExternalIPPool{
+				newExternalIPPool("eip1", "", "1.2.3.4", "1.2.3.5"),
+			},
+			newService("svc1", "ns1", corev1.ServiceTypeLoadBalancer, "1.2.3.5", "eip1"),
+			"1.2.3.5",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			var fakeObjects []runtime.Object
+			var fakeCRDObjects []runtime.Object
+			for _, eip := range tt.externalIPPool {
+				fakeCRDObjects = append(fakeCRDObjects, eip)
+			}
+			controller := newController(fakeObjects, fakeCRDObjects)
+			controller.informerFactory.Start(stopCh)
+			controller.crdInformerFactory.Start(stopCh)
+			controller.informerFactory.WaitForCacheSync(stopCh)
+			controller.crdInformerFactory.WaitForCacheSync(stopCh)
+			go controller.externalIPAllocator.Run(stopCh)
+			require.True(t, cache.WaitForCacheSync(stopCh, controller.externalIPAllocator.HasSynced))
+			go controller.Run(stopCh)
+			_, err := controller.client.CoreV1().Services(tt.service.Namespace).Create(ctx, tt.service, metav1.CreateOptions{})
+			require.NoError(t, err)
+			var svcUpdated *corev1.Service
+			var lbIP string
+			assert.Eventually(t, func() bool {
+				var err error
+				svcUpdated, err = controller.client.CoreV1().Services(tt.service.Namespace).Get(ctx, tt.service.Name, metav1.GetOptions{})
+				require.NoError(t, err)
+				lbIP = getServiceExternalIP(svcUpdated)
+				return lbIP == tt.expectedLoadBalancerIP
+			}, 500*time.Millisecond, 100*time.Millisecond)
+			ipPool := svcUpdated.Annotations[antreaagenttypes.ServiceExternalIPPoolAnnotationKey]
+			assert.NotEmpty(t, ipPool)
+			assert.True(t, controller.externalIPAllocator.IPPoolExists(ipPool))
+			assert.True(t, controller.externalIPAllocator.IPPoolHasIP(ipPool, net.ParseIP(lbIP)))
+		})
+	}
+}
+
+func TestSyncService(t *testing.T) {
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var fakeObjects []runtime.Object
+	var fakeCRDObjects []runtime.Object
+	controller := newController(fakeObjects, fakeCRDObjects)
+	controller.informerFactory.Start(stopCh)
+	controller.crdInformerFactory.Start(stopCh)
+	controller.informerFactory.WaitForCacheSync(stopCh)
+	controller.crdInformerFactory.WaitForCacheSync(stopCh)
+	go controller.externalIPAllocator.Run(stopCh)
+	go controller.Run(stopCh)
+
+	require.True(t, cache.WaitForCacheSync(stopCh, controller.externalIPAllocator.HasSynced))
+
+	var service *corev1.Service
+	var err error
+
+	service = newService("svc1", "ns1", corev1.ServiceTypeLoadBalancer, "", "eip1")
+	_, err = controller.client.CoreV1().Services(service.Namespace).Create(ctx, service, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	// Create ExternalIPPool
+	eip1 := newExternalIPPool("eip1", "", "1.2.3.4", "1.2.3.5")
+	_, err = controller.crdClient.CrdV1alpha2().ExternalIPPools().Create(ctx, eip1, metav1.CreateOptions{})
+	assert.NoError(t, err)
+	checkForLBIP(t, controller, ctx, service.Name, service.Namespace, "1.2.3.4")
+	checkExternalIPPoolUsed(t, controller, ctx, "eip1", 1)
+
+	// Delete ExternalIPPool
+	err = controller.crdClient.CrdV1alpha2().ExternalIPPools().Delete(ctx, eip1.Name, metav1.DeleteOptions{})
+	assert.NoError(t, err)
+	checkForLBIP(t, controller, ctx, service.Name, service.Namespace, "")
+
+	// Re-create ExternalIPPool
+	_, err = controller.crdClient.CrdV1alpha2().ExternalIPPools().Create(ctx, eip1, metav1.CreateOptions{})
+	assert.NoError(t, err)
+	checkForLBIP(t, controller, ctx, service.Name, service.Namespace, "1.2.3.4")
+	checkExternalIPPoolUsed(t, controller, ctx, "eip1", 1)
+
+	// Change ExternalIPPool annotation
+	service.Annotations[antreaagenttypes.ServiceExternalIPPoolAnnotationKey] = "eip2"
+	_, err = controller.client.CoreV1().Services(service.Namespace).Update(ctx, service, metav1.UpdateOptions{})
+	assert.NoError(t, err)
+	checkForLBIP(t, controller, ctx, service.Name, service.Namespace, "")
+	checkExternalIPPoolUsed(t, controller, ctx, "eip1", 0)
+
+	// Create second ExternalIPPool
+	eip2 := newExternalIPPool("eip2", "", "1.2.4.4", "1.2.4.5")
+	_, err = controller.crdClient.CrdV1alpha2().ExternalIPPools().Create(ctx, eip2, metav1.CreateOptions{})
+	assert.NoError(t, err)
+	checkForLBIP(t, controller, ctx, service.Name, service.Namespace, "1.2.4.4")
+	checkExternalIPPoolUsed(t, controller, ctx, "eip1", 0)
+	checkExternalIPPoolUsed(t, controller, ctx, "eip2", 1)
+
+	// Specify IP from ExternalIPPool
+	service.Spec.LoadBalancerIP = "1.2.4.5"
+	_, err = controller.client.CoreV1().Services(service.Namespace).Update(ctx, service, metav1.UpdateOptions{})
+	assert.NoError(t, err)
+	checkForLBIP(t, controller, ctx, service.Name, service.Namespace, "1.2.4.5")
+	checkExternalIPPoolUsed(t, controller, ctx, "eip1", 0)
+	checkExternalIPPoolUsed(t, controller, ctx, "eip2", 1)
+
+	// Specify IP from ExternalIPPool with mismatched ExternalIPPool annotation
+	service.Spec.LoadBalancerIP = "1.2.4.4"
+	service.Annotations[antreaagenttypes.ServiceExternalIPPoolAnnotationKey] = "eip1"
+	_, err = controller.client.CoreV1().Services(service.Namespace).Update(ctx, service, metav1.UpdateOptions{})
+	assert.NoError(t, err)
+	checkForLBIP(t, controller, ctx, service.Name, service.Namespace, "1.2.4.4")
+	checkExternalIPPoolUsed(t, controller, ctx, "eip1", 0)
+	checkExternalIPPoolUsed(t, controller, ctx, "eip2", 1)
+
+	// Specify non-existent IP of ExternalIPPool
+	service.Spec.LoadBalancerIP = "1.2.4.6"
+	service.Annotations[antreaagenttypes.ServiceExternalIPPoolAnnotationKey] = "eip2"
+	_, err = controller.client.CoreV1().Services(service.Namespace).Update(ctx, service, metav1.UpdateOptions{})
+	assert.NoError(t, err)
+	checkForLBIP(t, controller, ctx, service.Name, service.Namespace, "")
+	checkExternalIPPoolUsed(t, controller, ctx, "eip1", 0)
+	checkExternalIPPoolUsed(t, controller, ctx, "eip2", 0)
+
+	// Change Service type
+	service.Spec.LoadBalancerIP = ""
+	_, err = controller.client.CoreV1().Services(service.Namespace).Update(ctx, service, metav1.UpdateOptions{})
+	assert.NoError(t, err)
+	checkForLBIP(t, controller, ctx, service.Name, service.Namespace, "1.2.4.4")
+
+	service.Spec.Type = corev1.ServiceTypeClusterIP
+	_, err = controller.client.CoreV1().Services(service.Namespace).Update(ctx, service, metav1.UpdateOptions{})
+	assert.NoError(t, err)
+	checkForLBIP(t, controller, ctx, service.Name, service.Namespace, "")
+	checkExternalIPPoolUsed(t, controller, ctx, "eip1", 0)
+	checkExternalIPPoolUsed(t, controller, ctx, "eip2", 0)
+
+	// Change Service type back to LoadBalancer
+	service.Spec.Type = corev1.ServiceTypeLoadBalancer
+	_, err = controller.client.CoreV1().Services(service.Namespace).Update(ctx, service, metav1.UpdateOptions{})
+	assert.NoError(t, err)
+	checkForLBIP(t, controller, ctx, service.Name, service.Namespace, "1.2.4.4")
+	checkExternalIPPoolUsed(t, controller, ctx, "eip2", 1)
+
+	// Delete Service
+	err = controller.client.CoreV1().Services(service.Namespace).Delete(ctx, service.Name, metav1.DeleteOptions{})
+	assert.NoError(t, err)
+	checkExternalIPPoolUsed(t, controller, ctx, "eip2", 0)
+
+}
+
+func checkForLBIP(t *testing.T, controller *loadBalancerController, ctx context.Context, name, namespace, expectedLBIP string) {
+	assert.Eventually(t, func() bool {
+		serviceUpdated, err := controller.client.CoreV1().Services(namespace).Get(ctx, name, metav1.GetOptions{})
+		require.NoError(t, err)
+		lbIP := getServiceExternalIP(serviceUpdated)
+		return lbIP == expectedLBIP
+	}, 500*time.Millisecond, 100*time.Millisecond)
+}
+
+func checkExternalIPPoolUsed(t *testing.T, controller *loadBalancerController, ctx context.Context, poolName string, used int) {
+	exists := controller.externalIPAllocator.IPPoolExists(poolName)
+	require.True(t, exists)
+	assert.Eventually(t, func() bool {
+		eip, err := controller.crdClient.CrdV1alpha2().ExternalIPPools().Get(context.TODO(), poolName, metav1.GetOptions{})
+		require.NoError(t, err)
+		t.Logf("current status %#v", eip.Status)
+		return eip.Status.Usage.Used == used
+	}, 500*time.Millisecond, 100*time.Millisecond)
+}

--- a/pkg/controller/externalippool/controller_test.go
+++ b/pkg/controller/externalippool/controller_test.go
@@ -1,4 +1,6 @@
 // Copyright 2021 Antrea Authors
+
+// Copyright 2021 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/features/antrea_features.go
+++ b/pkg/features/antrea_features.go
@@ -76,6 +76,10 @@ const (
 	// alpha: v1.4
 	// Enable flexible IPAM for Pods.
 	AntreaIPAM featuregate.Feature = "AntreaIPAM"
+
+	// alpha: v1.5
+	// Enable controlling Services with ExternalIP.
+	ServiceExternalIP featuregate.Feature = "ServiceExternalIP"
 )
 
 var (
@@ -100,6 +104,7 @@ var (
 		NetworkPolicyStats: {Default: true, PreRelease: featuregate.Beta},
 		NodePortLocal:      {Default: true, PreRelease: featuregate.Beta},
 		NodeIPAM:           {Default: false, PreRelease: featuregate.Alpha},
+		ServiceExternalIP:  {Default: false, PreRelease: featuregate.Alpha},
 	}
 
 	// UnsupportedFeaturesOnWindows records the features not supported on
@@ -113,9 +118,10 @@ var (
 	// can have different FeatureSpecs between Linux and Windows, we should
 	// still define a separate defaultAntreaFeatureGates map for Windows.
 	unsupportedFeaturesOnWindows = map[featuregate.Feature]struct{}{
-		NodePortLocal: {},
-		Egress:        {},
-		AntreaIPAM:    {},
+		NodePortLocal:     {},
+		Egress:            {},
+		AntreaIPAM:        {},
+		ServiceExternalIP: {},
 	}
 )
 

--- a/test/e2e/service_externalip_test.go
+++ b/test/e2e/service_externalip_test.go
@@ -1,0 +1,584 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+	utilnet "k8s.io/utils/net"
+
+	antreaagenttypes "antrea.io/antrea/pkg/agent/types"
+	"antrea.io/antrea/pkg/apis/crd/v1alpha2"
+	agentconfig "antrea.io/antrea/pkg/config/agent"
+	controllerconfig "antrea.io/antrea/pkg/config/controller"
+)
+
+func TestServiceExternalIP(t *testing.T) {
+	skipIfHasWindowsNodes(t)
+	skipIfNumNodesLessThan(t, 2)
+	skipIfAntreaIPAMTest(t)
+
+	data, err := setupTest(t)
+	if err != nil {
+		t.Fatalf("Error when setting up test: %v", err)
+	}
+	defer teardownTest(t, data)
+
+	cc := func(config *controllerconfig.ControllerConfig) {
+		config.FeatureGates["ServiceExternalIP"] = true
+	}
+	ac := func(config *agentconfig.AgentConfig) {
+		config.FeatureGates["ServiceExternalIP"] = true
+	}
+
+	if err := data.mutateAntreaConfigMap(cc, ac, true, true); err != nil {
+		t.Fatalf("Failed to enable LB feature: %v", err)
+	}
+
+	// t.Run("testServiceWithExternalIPCRUD", func(t *testing.T) { testServiceWithExternalIPCRUD(t, data) })
+	// t.Run("testServiceUpdateExternalIP", func(t *testing.T) { testServiceUpdateExternalIP(t, data) })
+	// t.Run("testServiceExternalTrafficPolicyLocal", func(t *testing.T) { testServiceExternalTrafficPolicyLocal(t, data) })
+	t.Run("testServiceNodeFailure", func(t *testing.T) { testServiceNodeFailure(t, data) })
+}
+
+func testServiceExternalTrafficPolicyLocal(t *testing.T, data *TestData) {
+	tests := []struct {
+		name                    string
+		ipRange                 v1alpha2.IPRange
+		nodeSelector            metav1.LabelSelector
+		originalEndpointSubsets []v1.EndpointSubset
+		expectedExternalIP      string
+		expectedNodeOrigin      string
+		updatedEndpointSubsets  []v1.EndpointSubset
+		expectedNodeUpdated     string
+	}{
+		{
+			name:    "endpoint created",
+			ipRange: v1alpha2.IPRange{CIDR: "169.254.100.0/30"},
+			nodeSelector: metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      v1.LabelHostname,
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{nodeName(0), nodeName(1)},
+					},
+				},
+			},
+			expectedExternalIP:      "169.254.100.1",
+			originalEndpointSubsets: nil,
+			expectedNodeOrigin:      "",
+			updatedEndpointSubsets: []v1.EndpointSubset{
+				{
+					Addresses: []v1.EndpointAddress{
+						{
+							IP:       "192.168.200.1",
+							NodeName: stringPtr(nodeName(0)),
+						},
+					},
+				},
+			},
+			expectedNodeUpdated: nodeName(0),
+		},
+		{
+			name:    "endpoint created IPv6",
+			ipRange: v1alpha2.IPRange{CIDR: "2021:1::aaa0/124"},
+			nodeSelector: metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      v1.LabelHostname,
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{nodeName(0), nodeName(1)},
+					},
+				},
+			},
+			expectedExternalIP:      "2021:1::aaa1",
+			originalEndpointSubsets: nil,
+			expectedNodeOrigin:      "",
+			updatedEndpointSubsets: []v1.EndpointSubset{
+				{
+					Addresses: []v1.EndpointAddress{
+						{
+							IP:       "fe80::01",
+							NodeName: stringPtr(nodeName(0)),
+						},
+					},
+				},
+			},
+			expectedNodeUpdated: nodeName(0),
+		},
+		{
+			name:    "endpoint changed",
+			ipRange: v1alpha2.IPRange{CIDR: "169.254.100.0/30"},
+			nodeSelector: metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      v1.LabelHostname,
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{nodeName(0), nodeName(1)},
+					},
+				},
+			},
+			expectedExternalIP: "169.254.100.1",
+			originalEndpointSubsets: []v1.EndpointSubset{
+				{
+					Addresses: []v1.EndpointAddress{
+						{
+							IP:       "192.168.100.1",
+							NodeName: stringPtr(nodeName(0)),
+						},
+					},
+				},
+			},
+			expectedNodeOrigin: nodeName(0),
+			updatedEndpointSubsets: []v1.EndpointSubset{
+				{
+					Addresses: []v1.EndpointAddress{
+						{
+							IP:       "192.168.100.1",
+							NodeName: stringPtr(nodeName(1)),
+						},
+					},
+				},
+			},
+			expectedNodeUpdated: nodeName(1),
+		},
+		{
+			name:    "endpoint changed IPv6",
+			ipRange: v1alpha2.IPRange{CIDR: "2021:1::aaa0/124"},
+			nodeSelector: metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      v1.LabelHostname,
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{nodeName(0), nodeName(1)},
+					},
+				},
+			},
+			expectedExternalIP: "2021:1::aaa1",
+			originalEndpointSubsets: []v1.EndpointSubset{
+				{
+					Addresses: []v1.EndpointAddress{
+						{
+							IP:       "fe80::01",
+							NodeName: stringPtr(nodeName(0)),
+						},
+					},
+				},
+			},
+			expectedNodeOrigin: nodeName(0),
+			updatedEndpointSubsets: []v1.EndpointSubset{
+				{
+					Addresses: []v1.EndpointAddress{
+						{
+							IP:       "fe80::01",
+							NodeName: stringPtr(nodeName(1)),
+						},
+					},
+				},
+			},
+			expectedNodeUpdated: nodeName(1),
+		},
+	}
+	for idx, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if utilnet.IsIPv6String(tt.expectedExternalIP) {
+				skipIfNotIPv6Cluster(t)
+			} else {
+				skipIfNotIPv4Cluster(t)
+			}
+			var err error
+			var service *v1.Service
+			var eps *v1.Endpoints
+			ipPool := data.createExternalIPPool(t, "test-service-pool-", tt.ipRange, tt.nodeSelector.MatchExpressions, tt.nodeSelector.MatchLabels)
+			defer data.crdClient.CrdV1alpha2().ExternalIPPools().Delete(context.TODO(), ipPool.Name, metav1.DeleteOptions{})
+
+			service, err = data.createService(fmt.Sprintf("test-svc-eip-%d", idx), testNamespace, 80, 80, nil, false, true, v1.ServiceTypeLoadBalancer, nil)
+			require.NoError(t, err)
+			defer data.clientset.CoreV1().Services(service.Namespace).Delete(context.TODO(), service.Name, metav1.DeleteOptions{})
+
+			eps = &v1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      service.Name,
+					Namespace: service.Namespace,
+					Labels: map[string]string{
+						"antrea-e2e": service.Name,
+						"app":        service.Name,
+					},
+				},
+				Subsets: tt.originalEndpointSubsets,
+			}
+			eps, err = data.clientset.CoreV1().Endpoints(eps.Namespace).Create(context.TODO(), eps, metav1.CreateOptions{})
+			require.NoError(t, err)
+			defer data.clientset.CoreV1().Endpoints(eps.Namespace).Delete(context.TODO(), eps.Name, metav1.DeleteOptions{})
+
+			service, err = data.waitForServiceConfigured(service, tt.expectedExternalIP, tt.expectedNodeOrigin)
+			require.NoError(t, err)
+			_, node := getServiceExternalIPAndHost(service)
+			assert.Equal(t, tt.expectedNodeOrigin, node)
+
+			epsToUpdate := eps.DeepCopy()
+			epsToUpdate.Subsets = tt.updatedEndpointSubsets
+			_, err = data.clientset.CoreV1().Endpoints(eps.Namespace).Update(context.TODO(), epsToUpdate, metav1.UpdateOptions{})
+			require.NoError(t, err)
+			service, err = data.waitForServiceConfigured(service, tt.expectedExternalIP, tt.expectedNodeUpdated)
+			require.NoError(t, err)
+			_, node = getServiceExternalIPAndHost(service)
+			assert.Equal(t, tt.expectedNodeUpdated, node)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func stringPtr(s string) *string {
+	return &s
+}
+
+func testServiceWithExternalIPCRUD(t *testing.T, data *TestData) {
+	tests := []struct {
+		name               string
+		ipRange            v1alpha2.IPRange
+		nodeSelector       metav1.LabelSelector
+		expectedExternalIP string
+		expectedNodes      sets.String
+		expectedTotal      int
+	}{
+		{
+			name:    "single matching Node",
+			ipRange: v1alpha2.IPRange{CIDR: "169.254.100.0/30"},
+			nodeSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					v1.LabelHostname: nodeName(0),
+				},
+			},
+			expectedExternalIP: "169.254.100.1",
+			expectedNodes:      sets.NewString(nodeName(0)),
+			expectedTotal:      2,
+		},
+		{
+			name:    "single matching Node with IPv6 range",
+			ipRange: v1alpha2.IPRange{CIDR: "2021:1::aaa0/124"},
+			nodeSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					v1.LabelHostname: nodeName(0),
+				},
+			},
+			expectedExternalIP: "2021:1::aaa1",
+			expectedNodes:      sets.NewString(nodeName(0)),
+			expectedTotal:      15,
+		},
+		{
+			name:    "two matching Nodes",
+			ipRange: v1alpha2.IPRange{Start: "169.254.101.10", End: "169.254.101.11"},
+			nodeSelector: metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      v1.LabelHostname,
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{nodeName(0), nodeName(1)},
+					},
+				},
+			},
+			expectedExternalIP: "169.254.101.10",
+			expectedNodes:      sets.NewString(nodeName(0), nodeName(1)),
+			expectedTotal:      2,
+		},
+		{
+			name:    "no matching Node",
+			ipRange: v1alpha2.IPRange{CIDR: "169.254.102.0/30"},
+			nodeSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"foo": "bar",
+				},
+			},
+			expectedExternalIP: "169.254.102.1",
+			expectedNodes:      sets.NewString(),
+			expectedTotal:      2,
+		},
+	}
+	for idx, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if utilnet.IsIPv6String(tt.expectedExternalIP) {
+				skipIfNotIPv6Cluster(t)
+			} else {
+				skipIfNotIPv4Cluster(t)
+			}
+			var err error
+			var service *v1.Service
+			pool := data.createExternalIPPool(t, "crud-pool-", tt.ipRange, tt.nodeSelector.MatchExpressions, tt.nodeSelector.MatchLabels)
+			defer data.crdClient.CrdV1alpha2().ExternalIPPools().Delete(context.TODO(), pool.Name, metav1.DeleteOptions{})
+			service, err = data.createService(fmt.Sprintf("test-lb-%d", idx), testNamespace, 80, 80, nil, false, false, v1.ServiceTypeLoadBalancer, nil)
+			require.NoError(t, err)
+			defer data.clientset.CoreV1().Services(service.Namespace).Delete(context.TODO(), service.Name, metav1.DeleteOptions{})
+			service, err = data.waitForServiceConfigured(service, tt.expectedExternalIP, "")
+			require.NoError(t, err)
+
+			if len(tt.expectedNodes) > 0 {
+				_, assignedNode := getServiceExternalIPAndHost(service)
+				err = data.checkNodesForAssignedIP(t, assignedNode, tt.expectedExternalIP)
+				assert.NoError(t, err)
+			}
+
+			checkEIPStatus := func(expectedUsed int) {
+				var gotUsed, gotTotal int
+				err := wait.PollImmediate(200*time.Millisecond, 2*time.Second, func() (done bool, err error) {
+					pool, err := data.crdClient.CrdV1alpha2().ExternalIPPools().Get(context.TODO(), pool.Name, metav1.GetOptions{})
+					if err != nil {
+						return false, fmt.Errorf("failed to get ExternalIPPool: %v", err)
+					}
+					gotUsed, gotTotal = pool.Status.Usage.Used, pool.Status.Usage.Total
+					if expectedUsed != pool.Status.Usage.Used {
+						return false, nil
+					}
+					if tt.expectedTotal != pool.Status.Usage.Total {
+						return false, nil
+					}
+					return true, nil
+				})
+				require.NoError(t, err, "ExternalIPPool status not match: expectedTotal=%d, got=%d, expectedUsed=%d, got=%d", tt.expectedTotal, gotTotal, expectedUsed, gotUsed)
+			}
+			checkEIPStatus(1)
+			err = data.clientset.CoreV1().Services(service.Namespace).Delete(context.TODO(), service.Name, metav1.DeleteOptions{})
+			require.NoError(t, err, "Failed to delete Service")
+			checkEIPStatus(0)
+		})
+	}
+}
+
+func (data *TestData) checkNodesForAssignedIP(t *testing.T, node, expectedIP string) error {
+	return wait.PollImmediate(200*time.Millisecond, 3*time.Second, func() (done bool, err error) {
+		var nodeHaveExpectedIP []string
+		for _, n := range clusterInfo.nodes {
+			if expectedIP != "" {
+				exists, err := hasIP(data, n.name, expectedIP)
+				require.NoError(t, err, "Failed to check if IP exists on Node %s", n.name)
+				if exists {
+					nodeHaveExpectedIP = append(nodeHaveExpectedIP, n.name)
+				}
+			}
+		}
+		if len(nodeHaveExpectedIP) != 1 || nodeHaveExpectedIP[0] != node {
+			return false, fmt.Errorf("check for expected IP failed. Expected Node %s have IP %s. Actual Nodes have expected IP: %v", node, expectedIP, nodeHaveExpectedIP)
+		}
+		return true, nil
+	})
+}
+
+func testServiceUpdateExternalIP(t *testing.T, data *TestData) {
+	tests := []struct {
+		name               string
+		originalNode       string
+		newNode            string
+		originalIPRange    v1alpha2.IPRange
+		originalExternalIP string
+		newIPRange         v1alpha2.IPRange
+		newExternalIP      string
+	}{
+		{
+			name:               "same Node",
+			originalNode:       nodeName(0),
+			newNode:            nodeName(0),
+			originalIPRange:    v1alpha2.IPRange{CIDR: "169.254.100.0/30"},
+			originalExternalIP: "169.254.100.1",
+			newIPRange:         v1alpha2.IPRange{CIDR: "169.254.101.0/30"},
+			newExternalIP:      "169.254.101.1",
+		},
+		{
+			name:               "different Nodes",
+			originalNode:       nodeName(0),
+			newNode:            nodeName(1),
+			originalIPRange:    v1alpha2.IPRange{CIDR: "169.254.100.0/30"},
+			originalExternalIP: "169.254.100.1",
+			newIPRange:         v1alpha2.IPRange{CIDR: "169.254.101.0/30"},
+			newExternalIP:      "169.254.101.1",
+		},
+		{
+			name:               "different Nodes in IPv6 cluster",
+			originalNode:       nodeName(0),
+			newNode:            nodeName(1),
+			originalIPRange:    v1alpha2.IPRange{CIDR: "2021:2::aaa0/124"},
+			originalExternalIP: "2021:2::aaa1",
+			newIPRange:         v1alpha2.IPRange{CIDR: "2021:2::bbb0/124"},
+			newExternalIP:      "2021:2::bbb1",
+		},
+	}
+	for idx, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if utilnet.IsIPv6String(tt.originalExternalIP) {
+				skipIfNotIPv6Cluster(t)
+			} else {
+				skipIfNotIPv4Cluster(t)
+			}
+
+			originalPool := data.createExternalIPPool(t, "originalpool-", tt.originalIPRange, nil, map[string]string{v1.LabelHostname: tt.originalNode})
+			defer data.crdClient.CrdV1alpha2().ExternalIPPools().Delete(context.TODO(), originalPool.Name, metav1.DeleteOptions{})
+			newPool := data.createExternalIPPool(t, "newpool-", tt.newIPRange, nil, map[string]string{v1.LabelHostname: tt.newNode})
+			defer data.crdClient.CrdV1alpha2().ExternalIPPools().Delete(context.TODO(), newPool.Name, metav1.DeleteOptions{})
+
+			annotation := map[string]string{
+				antreaagenttypes.ServiceExternalIPPoolAnnotationKey: originalPool.Name,
+			}
+			service, err := data.createServiceWithAnnotations(fmt.Sprintf("test-lb-%d", idx),
+				testNamespace, 80, 80, corev1.ProtocolTCP, nil, false, false, v1.ServiceTypeLoadBalancer, nil, annotation)
+			require.NoError(t, err)
+			defer data.clientset.CoreV1().Services(service.Namespace).Delete(context.TODO(), service.Name, metav1.DeleteOptions{})
+
+			service, err = data.waitForServiceConfigured(service, tt.originalExternalIP, "")
+			require.NoError(t, err)
+
+			_, assignedNode := getServiceExternalIPAndHost(service)
+			err = data.checkNodesForAssignedIP(t, assignedNode, tt.originalExternalIP)
+			assert.NoError(t, err)
+
+			toUpdate := service.DeepCopy()
+			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				toUpdate.Annotations[antreaagenttypes.ServiceExternalIPPoolAnnotationKey] = newPool.Name
+				_, err = data.clientset.CoreV1().Services(toUpdate.Namespace).Update(context.TODO(), toUpdate, metav1.UpdateOptions{})
+				if err != nil && errors.IsConflict(err) {
+					toUpdate, _ = data.clientset.CoreV1().Services(toUpdate.Namespace).Get(context.TODO(), toUpdate.Name, metav1.GetOptions{})
+				}
+				return err
+			})
+			require.NoError(t, err, "Failed to update Service")
+
+			toUpdate, err = data.waitForServiceConfigured(service, tt.newExternalIP, "")
+			require.NoError(t, err)
+
+			_, assignedNode = getServiceExternalIPAndHost(toUpdate)
+			err = data.checkNodesForAssignedIP(t, assignedNode, tt.newExternalIP)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func testServiceNodeFailure(t *testing.T, data *TestData) {
+	tests := []struct {
+		name       string
+		ipRange    v1alpha2.IPRange
+		expectedIP string
+	}{
+		{
+			name:       "IPv4 cluster",
+			ipRange:    v1alpha2.IPRange{CIDR: "169.254.100.0/30"},
+			expectedIP: "169.254.100.1",
+		},
+		{
+			name:       "IPv6 cluster",
+			ipRange:    v1alpha2.IPRange{CIDR: "2021:4::aaa0/124"},
+			expectedIP: "2021:4::aaa1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if utilnet.IsIPv6String(tt.expectedIP) {
+				skipIfNotIPv6Cluster(t)
+			} else {
+				skipIfNotIPv4Cluster(t)
+			}
+			signalAgent := func(nodeName, signal string) {
+				cmd := fmt.Sprintf("pkill -%s antrea-agent", signal)
+				rc, stdout, stderr, err := RunCommandOnNode(nodeName, cmd)
+				if rc != 0 || err != nil {
+					t.Errorf("Error when running command '%s' on Node '%s', rc: %d, stdout: %s, stderr: %s, error: %v",
+						cmd, nodeName, rc, stdout, stderr, err)
+				}
+			}
+			pauseAgent := func(evictNode string) {
+				// Send "STOP" signal to antrea-agent.
+				signalAgent(evictNode, "STOP")
+			}
+			restoreAgent := func(evictNode string) {
+				// Send "CONT" signal to antrea-agent.
+				signalAgent(evictNode, "CONT")
+			}
+
+			nodeCandidates := sets.NewString(nodeName(0), nodeName(1))
+			matchExpressions := []metav1.LabelSelectorRequirement{
+				{
+					Key:      v1.LabelHostname,
+					Operator: metav1.LabelSelectorOpIn,
+					Values:   nodeCandidates.List(),
+				},
+			}
+			externalIPPoolTwoNodes := data.createExternalIPPool(t, "pool-with-two-nodes-", tt.ipRange, matchExpressions, nil)
+			defer data.crdClient.CrdV1alpha2().ExternalIPPools().Delete(context.TODO(), externalIPPoolTwoNodes.Name, metav1.DeleteOptions{})
+			annotation := map[string]string{
+				antreaagenttypes.ServiceExternalIPPoolAnnotationKey: externalIPPoolTwoNodes.Name,
+			}
+			service, err := data.createServiceWithAnnotations("test-service-node-failure", testNamespace, 80, 80,
+				corev1.ProtocolTCP, nil, false, false, v1.ServiceTypeLoadBalancer, nil, annotation)
+			require.NoError(t, err)
+			defer data.clientset.CoreV1().Services(service.Namespace).Delete(context.TODO(), service.Name, metav1.DeleteOptions{})
+
+			service, err = data.waitForServiceConfigured(service, tt.expectedIP, "")
+			assert.NoError(t, err)
+			_, originalNode := getServiceExternalIPAndHost(service)
+			pauseAgent(originalNode)
+			defer restoreAgent(originalNode)
+
+			var expectedMigratedNode string
+			if originalNode == nodeName(0) {
+				expectedMigratedNode = nodeName(1)
+			} else {
+				expectedMigratedNode = nodeName(0)
+			}
+			_, err = data.waitForServiceConfigured(service, tt.expectedIP, expectedMigratedNode)
+			assert.NoError(t, err)
+			restoreAgent(originalNode)
+			_, err = data.waitForServiceConfigured(service, tt.expectedIP, originalNode)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func getServiceExternalIPAndHost(service *v1.Service) (string, string) {
+	if service == nil || len(service.Status.LoadBalancer.Ingress) == 0 {
+		return "", ""
+	}
+	return service.Status.LoadBalancer.Ingress[0].IP, service.Status.LoadBalancer.Ingress[0].Hostname
+}
+
+func (data *TestData) waitForServiceConfigured(service *v1.Service, expectedExternalIP, expectedNodeName string) (*v1.Service, error) {
+	err := wait.PollImmediate(200*time.Millisecond, 5*time.Second, func() (done bool, err error) {
+		service, err = data.clientset.CoreV1().Services(service.Namespace).Get(context.TODO(), service.Name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		if len(service.Status.LoadBalancer.Ingress) == 0 || service.Status.LoadBalancer.Ingress[0].IP != expectedExternalIP {
+			return false, nil
+		}
+		if expectedNodeName != "" && service.Status.LoadBalancer.Ingress[0].Hostname != expectedNodeName {
+			return false, nil
+		}
+		return true, nil
+
+	})
+	if err != nil {
+		return nil, fmt.Errorf("wait for LB Service %q configured failed: %v. Expected external IP %s on Node %s, actual status %+v",
+			service.Name, err, expectedExternalIP, expectedNodeName, service.Status)
+	}
+	return service, nil
+}


### PR DESCRIPTION
Add an externalIP controller which is able to automatically allocate external IPs for LoadBalancer type Services from an IP Pool defined by ExternalIPPool CRD, and configure the external IPs on the Nodes selected by the ExternalIPPool.