### PR TITLE
Use Node transport IP as advertise address in memberlist clusters

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -305,7 +305,7 @@ func run(o *Options) error {
 		)
 		localIPDetector = ipassigner.NewLocalIPDetector()
 		memberlistCluster, err = memberlist.NewCluster(o.config.ClusterMembershipPort,
-			nodeConfig.Name, nodeInformer, externalIPPoolInformer,
+			nodeConfig.Name, nodeTransportIP, nodeInformer, externalIPPoolInformer,
 		)
 		if err != nil {
 			return fmt.Errorf("error creating new MemberList cluster: %v", err)

--- a/pkg/agent/memberlist/cluster.go
+++ b/pkg/agent/memberlist/cluster.go
@@ -17,6 +17,7 @@ package memberlist
 import (
 	"fmt"
 	"io/ioutil"
+	"net"
 	"reflect"
 	"sync"
 	"time"
@@ -115,6 +116,7 @@ type Cluster struct {
 func NewCluster(
 	clusterBindPort int,
 	nodeName string,
+	nodeIP net.IP,
 	nodeInformer coreinformers.NodeInformer,
 	externalIPPoolInformer crdinformers.ExternalIPPoolInformer,
 ) (*Cluster, error) {
@@ -138,6 +140,7 @@ func NewCluster(
 	conf.Name = c.nodeName
 	conf.BindPort = c.bindPort
 	conf.AdvertisePort = c.bindPort
+	conf.AdvertiseAddr = nodeIP.String()
 	conf.Events = &memberlist.ChannelEventDelegate{Ch: nodeEventCh}
 	conf.LogOutput = ioutil.Discard
 	klog.V(1).InfoS("New memberlist cluster", "config", conf)

--- a/pkg/agent/memberlist/cluster_test.go
+++ b/pkg/agent/memberlist/cluster_test.go
@@ -56,8 +56,8 @@ func newFakeCluster(nodeConfig *config.NodeConfig, stopCh <-chan struct{}, i int
 	crdClient := fakeversioned.NewSimpleClientset([]runtime.Object{}...)
 	crdInformerFactory := crdinformers.NewSharedInformerFactory(crdClient, 0)
 	ipPoolInformer := crdInformerFactory.Crd().V1alpha2().ExternalIPPools()
-
-	cluster, err := NewCluster(port, nodeConfig.Name, nodeInformer, ipPoolInformer)
+	ip := net.ParseIP("127.0.0.1")
+	cluster, err := NewCluster(port, nodeConfig.Name, ip, nodeInformer, ipPoolInformer)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Set the transport IP of memberlist Nodes to avoid possible conflict in multiple NIC environments. If the advertise address is not set, memberlist might choose an IP other than the Node IP or the transport IP on other NICs. If the chosen IP conflict with other Nodes, the ping message sent to other nodes will be dropped which results in the Node being considered as not healthy.

Signed-off-by: Xu Liu <xliu2@vmware.com>