### PR TITLE
Make externalIP proxying configurable for AntreaProxy

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -4171,6 +4171,13 @@ data:
       # Services will not be load-balanced). Values can be a valid ClusterIP (e.g. 10.11.1.2) or a Service name
       # with Namespace (e.g. kube-system/kube-dns)
       #skipServices: []
+      # When ProxyLoadBalancerIPs is set to false, AntreaProxy no longer load-balances traffic destined to the
+      # External IPs of LoadBalancer Services. This is useful when the external LoadBalancer provides additional
+      # capabilities (e.g. TLS termination) and it is desirable for Pod-to-ExternalIP traffic to be sent to the
+      # external LoadBalancer instead of being load-balanced to an Endpoint directly by AntreaProxy.
+      # Note that setting ProxyLoadBalancerIPs to false usually only makes sense when ProxyAll is set to true and
+      # kube-proxy is removed from the cluser, otherwise kube-proxy will still load-balance this traffic.
+      #proxyLoadBalancerIPs: true
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -4283,7 +4290,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-7f6684k7bk
+  name: antrea-config-mtdf878cgd
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4354,7 +4361,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-7f6684k7bk
+          value: antrea-config-mtdf878cgd
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4405,7 +4412,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-7f6684k7bk
+          name: antrea-config-mtdf878cgd
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4686,7 +4693,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-7f6684k7bk
+          name: antrea-config-mtdf878cgd
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -4171,6 +4171,13 @@ data:
       # Services will not be load-balanced). Values can be a valid ClusterIP (e.g. 10.11.1.2) or a Service name
       # with Namespace (e.g. kube-system/kube-dns)
       #skipServices: []
+      # When ProxyLoadBalancerIPs is set to false, AntreaProxy no longer load-balances traffic destined to the
+      # External IPs of LoadBalancer Services. This is useful when the external LoadBalancer provides additional
+      # capabilities (e.g. TLS termination) and it is desirable for Pod-to-ExternalIP traffic to be sent to the
+      # external LoadBalancer instead of being load-balanced to an Endpoint directly by AntreaProxy.
+      # Note that setting ProxyLoadBalancerIPs to false usually only makes sense when ProxyAll is set to true and
+      # kube-proxy is removed from the cluser, otherwise kube-proxy will still load-balance this traffic.
+      #proxyLoadBalancerIPs: true
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -4283,7 +4290,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-7f6684k7bk
+  name: antrea-config-mtdf878cgd
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4354,7 +4361,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-7f6684k7bk
+          value: antrea-config-mtdf878cgd
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4405,7 +4412,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-7f6684k7bk
+          name: antrea-config-mtdf878cgd
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4688,7 +4695,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-7f6684k7bk
+          name: antrea-config-mtdf878cgd
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -4171,6 +4171,13 @@ data:
       # Services will not be load-balanced). Values can be a valid ClusterIP (e.g. 10.11.1.2) or a Service name
       # with Namespace (e.g. kube-system/kube-dns)
       #skipServices: []
+      # When ProxyLoadBalancerIPs is set to false, AntreaProxy no longer load-balances traffic destined to the
+      # External IPs of LoadBalancer Services. This is useful when the external LoadBalancer provides additional
+      # capabilities (e.g. TLS termination) and it is desirable for Pod-to-ExternalIP traffic to be sent to the
+      # external LoadBalancer instead of being load-balanced to an Endpoint directly by AntreaProxy.
+      # Note that setting ProxyLoadBalancerIPs to false usually only makes sense when ProxyAll is set to true and
+      # kube-proxy is removed from the cluser, otherwise kube-proxy will still load-balance this traffic.
+      #proxyLoadBalancerIPs: true
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -4283,7 +4290,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-25dm52hdd6
+  name: antrea-config-f42d6k25t4
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4354,7 +4361,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-25dm52hdd6
+          value: antrea-config-f42d6k25t4
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4405,7 +4412,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-25dm52hdd6
+          name: antrea-config-f42d6k25t4
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4689,7 +4696,7 @@ spec:
           path: /home/kubernetes/bin
         name: host-cni-bin
       - configMap:
-          name: antrea-config-25dm52hdd6
+          name: antrea-config-f42d6k25t4
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -4176,6 +4176,13 @@ data:
       # Services will not be load-balanced). Values can be a valid ClusterIP (e.g. 10.11.1.2) or a Service name
       # with Namespace (e.g. kube-system/kube-dns)
       #skipServices: []
+      # When ProxyLoadBalancerIPs is set to false, AntreaProxy no longer load-balances traffic destined to the
+      # External IPs of LoadBalancer Services. This is useful when the external LoadBalancer provides additional
+      # capabilities (e.g. TLS termination) and it is desirable for Pod-to-ExternalIP traffic to be sent to the
+      # external LoadBalancer instead of being load-balanced to an Endpoint directly by AntreaProxy.
+      # Note that setting ProxyLoadBalancerIPs to false usually only makes sense when ProxyAll is set to true and
+      # kube-proxy is removed from the cluser, otherwise kube-proxy will still load-balance this traffic.
+      #proxyLoadBalancerIPs: true
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -4288,7 +4295,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-f6c667c75f
+  name: antrea-config-24g5gkf4m9
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4368,7 +4375,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-f6c667c75f
+          value: antrea-config-24g5gkf4m9
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4419,7 +4426,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-f6c667c75f
+          name: antrea-config-24g5gkf4m9
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4735,7 +4742,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-f6c667c75f
+          name: antrea-config-24g5gkf4m9
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-kind.yml
+++ b/build/yamls/antrea-kind.yml
@@ -4176,6 +4176,13 @@ data:
       # Services will not be load-balanced). Values can be a valid ClusterIP (e.g. 10.11.1.2) or a Service name
       # with Namespace (e.g. kube-system/kube-dns)
       #skipServices: []
+      # When ProxyLoadBalancerIPs is set to false, AntreaProxy no longer load-balances traffic destined to the
+      # External IPs of LoadBalancer Services. This is useful when the external LoadBalancer provides additional
+      # capabilities (e.g. TLS termination) and it is desirable for Pod-to-ExternalIP traffic to be sent to the
+      # external LoadBalancer instead of being load-balanced to an Endpoint directly by AntreaProxy.
+      # Note that setting ProxyLoadBalancerIPs to false usually only makes sense when ProxyAll is set to true and
+      # kube-proxy is removed from the cluser, otherwise kube-proxy will still load-balance this traffic.
+      #proxyLoadBalancerIPs: true
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -4288,7 +4295,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-mcf8bf8b2m
+  name: antrea-config-h5hctb5f9b
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4359,7 +4366,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-mcf8bf8b2m
+          value: antrea-config-h5hctb5f9b
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4410,7 +4417,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-mcf8bf8b2m
+          name: antrea-config-h5hctb5f9b
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4687,7 +4694,7 @@ spec:
           type: CharDevice
         name: dev-tun
       - configMap:
-          name: antrea-config-mcf8bf8b2m
+          name: antrea-config-h5hctb5f9b
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -4176,6 +4176,13 @@ data:
       # Services will not be load-balanced). Values can be a valid ClusterIP (e.g. 10.11.1.2) or a Service name
       # with Namespace (e.g. kube-system/kube-dns)
       #skipServices: []
+      # When ProxyLoadBalancerIPs is set to false, AntreaProxy no longer load-balances traffic destined to the
+      # External IPs of LoadBalancer Services. This is useful when the external LoadBalancer provides additional
+      # capabilities (e.g. TLS termination) and it is desirable for Pod-to-ExternalIP traffic to be sent to the
+      # external LoadBalancer instead of being load-balanced to an Endpoint directly by AntreaProxy.
+      # Note that setting ProxyLoadBalancerIPs to false usually only makes sense when ProxyAll is set to true and
+      # kube-proxy is removed from the cluser, otherwise kube-proxy will still load-balance this traffic.
+      #proxyLoadBalancerIPs: true
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -4288,7 +4295,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-m8g64b5282
+  name: antrea-config-h9276948gc
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4359,7 +4366,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-m8g64b5282
+          value: antrea-config-h9276948gc
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4410,7 +4417,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-m8g64b5282
+          name: antrea-config-h9276948gc
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4691,7 +4698,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-m8g64b5282
+          name: antrea-config-h9276948gc
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/base/conf/antrea-agent.conf
+++ b/build/yamls/base/conf/antrea-agent.conf
@@ -211,3 +211,10 @@ antreaProxy:
   # Services will not be load-balanced). Values can be a valid ClusterIP (e.g. 10.11.1.2) or a Service name
   # with Namespace (e.g. kube-system/kube-dns)
   #skipServices: []
+  # When ProxyLoadBalancerIPs is set to false, AntreaProxy no longer load-balances traffic destined to the
+  # External IPs of LoadBalancer Services. This is useful when the external LoadBalancer provides additional
+  # capabilities (e.g. TLS termination) and it is desirable for Pod-to-ExternalIP traffic to be sent to the
+  # external LoadBalancer instead of being load-balanced to an Endpoint directly by AntreaProxy.
+  # Note that setting ProxyLoadBalancerIPs to false usually only makes sense when ProxyAll is set to true and
+  # kube-proxy is removed from the cluser, otherwise kube-proxy will still load-balance this traffic.
+  #proxyLoadBalancerIPs: true

--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -230,16 +230,17 @@ func run(o *Options) error {
 	if features.DefaultFeatureGate.Enabled(features.AntreaProxy) {
 		proxyAll := o.config.AntreaProxy.ProxyAll
 		skipServices := o.config.AntreaProxy.SkipServices
+		proxyLoadBalancerIPs := *o.config.AntreaProxy.ProxyLoadBalancerIPs
 
 		switch {
 		case v4Enabled && v6Enabled:
-			proxier = proxy.NewDualStackProxier(nodeConfig.Name, informerFactory, ofClient, routeClient, nodePortAddressesIPv4, nodePortAddressesIPv6, proxyAll, skipServices, v4GroupCounter, v6GroupCounter)
+			proxier = proxy.NewDualStackProxier(nodeConfig.Name, informerFactory, ofClient, routeClient, nodePortAddressesIPv4, nodePortAddressesIPv6, proxyAll, skipServices, proxyLoadBalancerIPs, v4GroupCounter, v6GroupCounter)
 			groupCounters = append(groupCounters, v4GroupCounter, v6GroupCounter)
 		case v4Enabled:
-			proxier = proxy.NewProxier(nodeConfig.Name, informerFactory, ofClient, false, routeClient, nodePortAddressesIPv4, proxyAll, skipServices, v4GroupCounter)
+			proxier = proxy.NewProxier(nodeConfig.Name, informerFactory, ofClient, false, routeClient, nodePortAddressesIPv4, proxyAll, skipServices, proxyLoadBalancerIPs, v4GroupCounter)
 			groupCounters = append(groupCounters, v4GroupCounter)
 		case v6Enabled:
-			proxier = proxy.NewProxier(nodeConfig.Name, informerFactory, ofClient, true, routeClient, nodePortAddressesIPv6, proxyAll, skipServices, v6GroupCounter)
+			proxier = proxy.NewProxier(nodeConfig.Name, informerFactory, ofClient, true, routeClient, nodePortAddressesIPv6, proxyAll, skipServices, proxyLoadBalancerIPs, v6GroupCounter)
 			groupCounters = append(groupCounters, v6GroupCounter)
 		default:
 			return fmt.Errorf("at least one of IPv4 or IPv6 should be enabled")

--- a/cmd/antrea-agent/options.go
+++ b/cmd/antrea-agent/options.go
@@ -219,7 +219,12 @@ func (o *Options) setDefaults() {
 	if o.config.HostProcPathPrefix == "" {
 		o.config.HostProcPathPrefix = defaultHostProcPathPrefix
 	}
-	if !features.DefaultFeatureGate.Enabled(features.AntreaProxy) {
+	if features.DefaultFeatureGate.Enabled(features.AntreaProxy) {
+		if o.config.AntreaProxy.ProxyLoadBalancerIPs == nil {
+			o.config.AntreaProxy.ProxyLoadBalancerIPs = new(bool)
+			*o.config.AntreaProxy.ProxyLoadBalancerIPs = true
+		}
+	} else {
 		if o.config.ServiceCIDR == "" {
 			o.config.ServiceCIDR = defaultServiceCIDR
 		}

--- a/pkg/config/agent/config.go
+++ b/pkg/config/agent/config.go
@@ -192,6 +192,14 @@ type AntreaProxyConfig struct {
 	// Services will not be load-balanced). Values can be a valid ClusterIP (e.g. 10.11.1.2) or a Service name
 	// with Namespace (e.g. kube-system/kube-dns)
 	SkipServices []string `yaml:"skipServices,omitempty"`
+	// When ProxyLoadBalancerIPs is set to false, AntreaProxy no longer load-balances traffic destined to the
+	// External IPs of LoadBalancer Services. This is useful when the external LoadBalancer provides additional
+	// capabilities (e.g. TLS termination) and it is desirable for Pod-to-ExternalIP traffic to be sent to the
+	// external LoadBalancer instead of being load-balanced to an Endpoint directly by AntreaProxy.
+	// Note that setting ProxyLoadBalancerIPs to false usually only makes sense when ProxyAll is set to true and
+	// kube-proxy is removed from the cluser, otherwise kube-proxy will still load-balance this traffic.
+	// Defaults to true.
+	ProxyLoadBalancerIPs *bool `yaml:"proxyLoadBalancerIPs,omitempty"`
 }
 
 type WireGuardConfig struct {


### PR DESCRIPTION
A new proxyExternalIPs configuration parameter is added for
AntreaProxy. When set to false, ntreaProxy no longer load-balances
traffic destined to the ExternalIPs of LoadBalancer Services. This is
useful when the external LoadBalancer provides additional capabilities
(e.g. TLS termination) and it is desirable for Pod-to-ExternalIP traffic
to be sent to the external LoadBalancer instead of being load-balanced
to an Endpoint directly by AntreaProxy.

The default behavior is unchanged, i.e. proxyExternalIPs is true by
default.

Note that setting ProxyExternalIPs to false usually only makes sense
when ProxyAll is set to true and kube-proxy is removed from the cluser,
otherwise kube-proxy will still load-balance this traffic.

This feature cannot be leveraged by an external Load Balancer that
depends on the local proxy (AntreaProxy) being able to load balance
traffic destined to the ExternalIP. This is the case for example with
MetalLB. However Load Balancers that rely on NodePort / NodePortLocal
can leverage this feature.

Fixes #3121

Signed-off-by: Antonin Bas <abas@vmware.com>