### PR TITLE
Prepare for Antrea IPAM StatefulSet support

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -3831,8 +3831,17 @@ rules:
   - crd.antrea.io
   resources:
   - externalippools/status
+  - ippools/status
   verbs:
   - update
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - clusterinformation.antrea.tanzu.vmware.com
   resources:

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -3831,8 +3831,17 @@ rules:
   - crd.antrea.io
   resources:
   - externalippools/status
+  - ippools/status
   verbs:
   - update
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - clusterinformation.antrea.tanzu.vmware.com
   resources:

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -3831,8 +3831,17 @@ rules:
   - crd.antrea.io
   resources:
   - externalippools/status
+  - ippools/status
   verbs:
   - update
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - clusterinformation.antrea.tanzu.vmware.com
   resources:

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -3831,8 +3831,17 @@ rules:
   - crd.antrea.io
   resources:
   - externalippools/status
+  - ippools/status
   verbs:
   - update
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - clusterinformation.antrea.tanzu.vmware.com
   resources:

--- a/build/yamls/antrea-kind.yml
+++ b/build/yamls/antrea-kind.yml
@@ -3831,8 +3831,17 @@ rules:
   - crd.antrea.io
   resources:
   - externalippools/status
+  - ippools/status
   verbs:
   - update
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - clusterinformation.antrea.tanzu.vmware.com
   resources:

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -3831,8 +3831,17 @@ rules:
   - crd.antrea.io
   resources:
   - externalippools/status
+  - ippools/status
   verbs:
   - update
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - clusterinformation.antrea.tanzu.vmware.com
   resources:

--- a/build/yamls/base/controller-rbac.yml
+++ b/build/yamls/base/controller-rbac.yml
@@ -229,8 +229,17 @@ rules:
       - crd.antrea.io
     resources:
       - externalippools/status
+      - ippools/status
     verbs:
       - update
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - get
+      - list
+      - watch
   # Deprecated in v1.0.0.
   - apiGroups:
     - clusterinformation.antrea.tanzu.vmware.com

--- a/pkg/controller/ipam/antrea_ipam_controller.go
+++ b/pkg/controller/ipam/antrea_ipam_controller.go
@@ -1,0 +1,234 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package networkpolicy provides AntreaIPAMController implementation to manage
+// and synchronize the GroupMembers and Namespaces affected by Network Policies and enforce
+// their rules.
+package ipam
+
+import (
+	"fmt"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
+	appsinformers "k8s.io/client-go/informers/apps/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+
+	crdv1a2 "antrea.io/antrea/pkg/apis/crd/v1alpha2"
+	"antrea.io/antrea/pkg/client/clientset/versioned"
+	"antrea.io/antrea/pkg/client/informers/externalversions"
+	crdinformers "antrea.io/antrea/pkg/client/informers/externalversions/crd/v1alpha2"
+	crdlisters "antrea.io/antrea/pkg/client/listers/crd/v1alpha2"
+	"antrea.io/antrea/pkg/ipam/poolallocator"
+	"antrea.io/antrea/pkg/util/k8s"
+)
+
+const (
+	controllerName = "AntreaIPAMController"
+
+	// TODO: currently these constants are duplicated, move to a shared place
+	AntreaIPAMAnnotationKey       = "ipam.antrea.io/ippools"
+	AntreaIPAMAnnotationDelimiter = ","
+
+	// StatefulSet index name for IPPool cache.
+	statefulSetIndex = "statefulSet"
+
+	minRetryDelay = 5 * time.Second
+	maxRetryDelay = 300 * time.Second
+)
+
+// AntreaIPAMController is responsible for IP address cleanup
+// for StatefulSet objects.
+// In future, it will also be responsible for pre-allocation of
+// continuous IP range for StatefulSets that do not have dedicated
+// IP Pool annotation.
+type AntreaIPAMController struct {
+	// crdClient is the clientset for CRD API group.
+	crdClient versioned.Interface
+
+	// Pool cleanup events triggered by StatefulSet delete
+	statefulSetCleanupQueue workqueue.RateLimitingInterface
+
+	// follow changes for StatefulSet objects
+	statefulSetInformer     appsinformers.StatefulSetInformer
+	statefulSetListerSynced cache.InformerSynced
+
+	// follow changes for IP Pool objects
+	ipPoolInformer     crdinformers.IPPoolInformer
+	ipPoolLister       crdlisters.IPPoolLister
+	ipPoolListerSynced cache.InformerSynced
+}
+
+func statefulSetIndexFunc(obj interface{}) ([]string, error) {
+	ipPool, ok := obj.(*crdv1a2.IPPool)
+	if !ok {
+		return nil, fmt.Errorf("obj is not IPPool: %+v", obj)
+	}
+	statefulSetNames := sets.NewString()
+	for _, address := range ipPool.Status.IPAddresses {
+		if address.Owner.StatefulSet != nil {
+			statefulSetNames.Insert(k8s.NamespacedName(address.Owner.StatefulSet.Namespace, address.Owner.StatefulSet.Name))
+		}
+	}
+	return statefulSetNames.UnsortedList(), nil
+}
+
+func NewAntreaIPAMController(crdClient versioned.Interface,
+	informerFactory informers.SharedInformerFactory,
+	crdInformerFactory externalversions.SharedInformerFactory) *AntreaIPAMController {
+
+	ipPoolInformer := crdInformerFactory.Crd().V1alpha2().IPPools()
+	ipPoolInformer.Informer().AddIndexers(cache.Indexers{statefulSetIndex: statefulSetIndexFunc})
+
+	statefulSetInformer := informerFactory.Apps().V1().StatefulSets()
+
+	c := &AntreaIPAMController{
+		crdClient:               crdClient,
+		statefulSetCleanupQueue: workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(minRetryDelay, maxRetryDelay), "statefulSetCleanup"),
+		statefulSetInformer:     statefulSetInformer,
+		statefulSetListerSynced: statefulSetInformer.Informer().HasSynced,
+		ipPoolInformer:          ipPoolInformer,
+		ipPoolLister:            ipPoolInformer.Lister(),
+		ipPoolListerSynced:      ipPoolInformer.Informer().HasSynced,
+	}
+
+	// Add handlers for Stateful Set events.
+	klog.V(2).InfoS("Subscribing for StatefulSet notifications", "controller", controllerName)
+	statefulSetInformer.Informer().AddEventHandler(
+		cache.ResourceEventHandlerFuncs{
+			DeleteFunc: c.enqueueStatefulSetDeleteEvent,
+		},
+	)
+
+	return c
+}
+
+// Enqueue the StatefulSet delete notification to be processed by the worker
+func (c *AntreaIPAMController) enqueueStatefulSetDeleteEvent(obj interface{}) {
+	ss := obj.(*appsv1.StatefulSet)
+	klog.V(2).InfoS("Delete notification", "StatefulSet", ss.Name)
+
+	key := k8s.NamespacedName(ss.Namespace, ss.Name)
+	c.statefulSetCleanupQueue.Add(key)
+}
+
+// Inspect all IPPools for stale IP Address entries.
+// This may happen if controller was down during StatefulSet delete event.
+// If such entry is found, enqueue cleanup event for this StatefulSet.
+func (c *AntreaIPAMController) cleanupStaleStatefulSets() {
+	pools, _ := c.ipPoolLister.List(labels.Everything())
+	lister := c.statefulSetInformer.Lister()
+	statefulSets, _ := lister.List(labels.Everything())
+	statefulSetMap := make(map[string]bool)
+
+	for _, ss := range statefulSets {
+		// Prepare map of existing StatefulSets for quick reference below
+		statefulSetMap[k8s.NamespacedName(ss.Namespace, ss.Name)] = true
+	}
+
+	for _, ipPool := range pools {
+		for _, address := range ipPool.Status.IPAddresses {
+			if address.Owner.StatefulSet != nil {
+				key := k8s.NamespacedName(address.Owner.StatefulSet.Namespace, address.Owner.StatefulSet.Name)
+				if _, ok := statefulSetMap[key]; !ok {
+					// This entry refers to StatefulSet that no longer exists
+					klog.InfoS("IPPool contains stale IPAddress for StatefulSet that no longer exists", "IPPool", ipPool.Name, "StatefulSet", key)
+					c.statefulSetCleanupQueue.Add(key)
+					// Mark this entry in map to ensure cleanup is enqueued only once
+					statefulSetMap[key] = true
+				}
+			}
+		}
+	}
+}
+
+// Look for an IP Pool associated with this StatefulSet, either a dedicated one or
+// annotated to the namespace. If IPPool is found, this routine will clear all IP
+// addresses that might be reserved for the pool.
+func (c *AntreaIPAMController) cleanIPPoolForStatefulSet(namespacedName string) error {
+	klog.InfoS("Processing delete notification", "StatefulSet", namespacedName)
+	ipPools, _ := c.ipPoolInformer.Informer().GetIndexer().ByIndex(statefulSetIndex, namespacedName)
+
+	for _, item := range ipPools {
+		ipPool := item.(*crdv1a2.IPPool)
+		allocator, err := poolallocator.NewIPPoolAllocator(ipPool.Name, c.crdClient, c.ipPoolLister)
+		if err != nil {
+			// This is not a transient error - log and forget
+			klog.ErrorS(err, "Failed to find IP Pool", "IPPool", ipPool.Name)
+			continue
+		}
+
+		namespace, name := k8s.SplitNamespacedName(namespacedName)
+		err = allocator.ReleaseStatefulSet(namespace, name)
+		if err != nil {
+			// This can be a transient error - worker will retry
+			klog.ErrorS(err, "Failed to clean IP allocations", "StatefulSet", namespacedName, "IPPool", ipPool.Name)
+			continue
+		}
+	}
+
+	return nil
+}
+
+func (c *AntreaIPAMController) statefulSetWorker() {
+	for c.processNextStatefulSetWorkItem() {
+	}
+}
+
+func (c *AntreaIPAMController) processNextStatefulSetWorkItem() bool {
+	key, quit := c.statefulSetCleanupQueue.Get()
+	if quit {
+		return false
+	}
+
+	defer c.statefulSetCleanupQueue.Done(key)
+	err := c.cleanIPPoolForStatefulSet(key.(string))
+
+	if err != nil {
+		// Put the item back on the workqueue to handle any transient errors.
+		c.statefulSetCleanupQueue.AddRateLimited(key)
+		klog.ErrorS(err, "Failed to clean IP Pool for StatefulSet", "StatefulSet", key)
+		return true
+	}
+
+	c.statefulSetCleanupQueue.Forget(key)
+	return true
+}
+
+// Run begins watching and syncing of a AntreaIPAMController.
+func (c *AntreaIPAMController) Run(stopCh <-chan struct{}) {
+
+	defer c.statefulSetCleanupQueue.ShutDown()
+
+	klog.InfoS("Starting", "controller", controllerName)
+	defer klog.InfoS("Shutting down", "controller", controllerName)
+
+	cacheSyncs := []cache.InformerSynced{c.statefulSetListerSynced, c.ipPoolListerSynced}
+	if !cache.WaitForNamedCacheSync(controllerName, stopCh, cacheSyncs...) {
+		return
+	}
+
+	// Make sure any stale StatefulSets that might be present in pools are cleaned up
+	c.cleanupStaleStatefulSets()
+
+	go wait.Until(c.statefulSetWorker, time.Second, stopCh)
+
+	<-stopCh
+}

--- a/pkg/controller/ipam/antrea_ipam_controller_test.go
+++ b/pkg/controller/ipam/antrea_ipam_controller_test.go
@@ -1,0 +1,271 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package networkpolicy provides AntreaIPAMController implementation to manage
+// and synchronize the GroupMembers and Namespaces affected by Network Policies and enforce
+// their rules.
+package ipam
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+
+	crdv1a2 "antrea.io/antrea/pkg/apis/crd/v1alpha2"
+	fakecrd "antrea.io/antrea/pkg/client/clientset/versioned/fake"
+	crdinformers "antrea.io/antrea/pkg/client/informers/externalversions"
+	listers "antrea.io/antrea/pkg/client/listers/crd/v1alpha2"
+	"antrea.io/antrea/pkg/ipam/poolallocator"
+)
+
+var (
+	testPool     = "test-pool"
+	testWithPool = "test-pool"
+	testNoPool   = "test-no-pool"
+	testStale    = "test-stale"
+)
+
+// StatefulSet objects are not defined here, since IPAM annotations
+// are configured on Pods which belong to the StatefulSet via "app" label.
+func initTestClients(pool *crdv1a2.IPPool) (*fake.Clientset, *fakecrd.Clientset) {
+	crdClient := fakecrd.NewSimpleClientset(pool)
+
+	k8sClient := fake.NewSimpleClientset(
+		&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        testWithPool,
+				Annotations: map[string]string{AntreaIPAMAnnotationKey: testPool},
+			},
+		},
+		&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: testNoPool,
+			},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testNoPool,
+				Namespace: testWithPool,
+				Labels:    map[string]string{"app": testNoPool},
+			},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{AntreaIPAMAnnotationKey: testPool},
+				Labels:      map[string]string{"app": testWithPool},
+				Namespace:   testNoPool,
+			},
+		},
+		&appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testWithPool,
+				Namespace: testNoPool,
+			},
+		},
+	)
+
+	return k8sClient, crdClient
+}
+
+func verifyPoolAllocatedSize(t *testing.T, poolLister listers.IPPoolLister, size int) {
+
+	err := wait.PollImmediate(100*time.Millisecond, 1*time.Second, func() (bool, error) {
+		pool, err := poolLister.Get(testPool)
+		if err != nil {
+			return false, nil
+		}
+		if len(pool.Status.IPAddresses) == size {
+			return true, nil
+		}
+
+		return false, nil
+	})
+
+	require.NoError(t, err)
+}
+
+// This test verifies release of reserved IPs for dedicated IP pool annotation,
+// as well as namespace-based IP Pool annotation.
+func TestReleaseStatefulSet(t *testing.T) {
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	ipRange := crdv1a2.IPRange{
+		Start: "10.2.2.100",
+		End:   "10.2.2.200",
+	}
+
+	subnetInfo := crdv1a2.SubnetInfo{
+		Gateway:      "10.2.2.1",
+		PrefixLength: 24,
+	}
+
+	subnetRange := crdv1a2.SubnetIPRange{IPRange: ipRange,
+		SubnetInfo: subnetInfo}
+
+	pool := crdv1a2.IPPool{
+		ObjectMeta: metav1.ObjectMeta{Name: testPool},
+		Spec: crdv1a2.IPPoolSpec{
+			IPRanges: []crdv1a2.SubnetIPRange{subnetRange},
+		},
+	}
+
+	k8sClient, crdClient := initTestClients(&pool)
+
+	informerFactory := informers.NewSharedInformerFactory(k8sClient, 0)
+
+	crdInformerFactory := crdinformers.NewSharedInformerFactory(crdClient, 0)
+	poolInformer := crdInformerFactory.Crd().V1alpha2().IPPools()
+	poolLister := poolInformer.Lister()
+
+	controller := NewAntreaIPAMController(crdClient, informerFactory, crdInformerFactory)
+	require.NotNil(t, controller)
+	informerFactory.Start(stopCh)
+	crdInformerFactory.Start(stopCh)
+
+	go controller.Run(stopCh)
+
+	var allocator *poolallocator.IPPoolAllocator
+	var err error
+	// Wait until pool propagates to the informer
+	pollErr := wait.PollImmediate(100*time.Millisecond, 1*time.Second, func() (bool, error) {
+		allocator, err = poolallocator.NewIPPoolAllocator(testPool, crdClient, poolLister)
+		if err != nil {
+			return false, nil
+		}
+		return true, nil
+	})
+	require.NoError(t, pollErr)
+
+	verifyPoolAllocatedSize(t, poolLister, 0)
+
+	// Allocate StatefulSet with dedicated IP Pool
+	err = allocator.AllocateStatefulSet(testNoPool, testWithPool, 5)
+	require.NoError(t, err, "Failed to reserve IPs for StatefulSet")
+	verifyPoolAllocatedSize(t, poolLister, 5)
+
+	// Allocate StatefulSet with namespace-based IP Pool annotation
+	err = allocator.AllocateStatefulSet(testWithPool, testNoPool, 3)
+	require.NoError(t, err, "Failed to reserve IPs for StatefulSet")
+	verifyPoolAllocatedSize(t, poolLister, 8)
+
+	// Delete StatefulSet with namespace-based IP Pool annotation
+	controller.enqueueStatefulSetDeleteEvent(&appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testNoPool,
+			Namespace: testWithPool,
+		}})
+
+	// Verify delete event was handled by the controller
+	verifyPoolAllocatedSize(t, poolLister, 5)
+
+	// Delete StatefulSet with dedicated IP Pool
+	controller.enqueueStatefulSetDeleteEvent(&appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testWithPool,
+			Namespace: testNoPool,
+		}})
+
+	// Verify delete event was handled by the controller
+	verifyPoolAllocatedSize(t, poolLister, 0)
+}
+
+// Test for cleanup on controller startup: stale addresses that belong no StatefulSet objects
+// that no longer exist should be cleaned up.
+func TestReleaseStaleAddresses(t *testing.T) {
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	ipRange := crdv1a2.IPRange{
+		CIDR: "10.2.2.0/24",
+	}
+
+	subnetInfo := crdv1a2.SubnetInfo{
+		Gateway:      "10.2.2.1",
+		PrefixLength: 24,
+	}
+
+	subnetRange := crdv1a2.SubnetIPRange{IPRange: ipRange,
+		SubnetInfo: subnetInfo}
+
+	// pool includes two entries for non-existent StatefulSet at startup
+	// as well as one legit entry
+	activeSetOwner := crdv1a2.StatefulSetOwner{
+		Name:      testWithPool,
+		Namespace: testNoPool,
+		Index:     0,
+	}
+
+	staleSetOwner := crdv1a2.StatefulSetOwner{
+		Name:      testStale,
+		Namespace: testNoPool,
+		Index:     0,
+	}
+
+	addresses := []crdv1a2.IPAddressState{
+		{IPAddress: "10.2.2.12",
+			Phase: crdv1a2.IPAddressPhasePreallocated,
+			Owner: crdv1a2.IPAddressOwner{StatefulSet: &activeSetOwner}},
+		{IPAddress: "20.1.1.100",
+			Phase: crdv1a2.IPAddressPhasePreallocated,
+			Owner: crdv1a2.IPAddressOwner{StatefulSet: &staleSetOwner}},
+		{IPAddress: "20.1.1.200",
+			Phase: crdv1a2.IPAddressPhasePreallocated,
+			Owner: crdv1a2.IPAddressOwner{StatefulSet: &staleSetOwner}},
+	}
+	pool := crdv1a2.IPPool{
+		ObjectMeta: metav1.ObjectMeta{Name: testPool},
+		Spec: crdv1a2.IPPoolSpec{
+			IPRanges: []crdv1a2.SubnetIPRange{subnetRange},
+		},
+		Status: crdv1a2.IPPoolStatus{
+			IPAddresses: addresses,
+		},
+	}
+
+	k8sClient, crdClient := initTestClients(&pool)
+
+	informerFactory := informers.NewSharedInformerFactory(k8sClient, 0)
+
+	crdInformerFactory := crdinformers.NewSharedInformerFactory(crdClient, 0)
+	poolInformer := crdInformerFactory.Crd().V1alpha2().IPPools()
+	poolLister := poolInformer.Lister()
+
+	controller := NewAntreaIPAMController(crdClient, informerFactory, crdInformerFactory)
+	require.NotNil(t, controller)
+	informerFactory.Start(stopCh)
+	crdInformerFactory.Start(stopCh)
+
+	go controller.Run(stopCh)
+
+	// Wait until pool propagates to the informer
+	pollErr := wait.PollImmediate(100*time.Millisecond, 1*time.Second, func() (bool, error) {
+		_, err := poolallocator.NewIPPoolAllocator(testPool, crdClient, poolLister)
+		if err != nil {
+			return false, nil
+		}
+		return true, nil
+	})
+	require.NoError(t, pollErr)
+
+	// after cleanup pool should have single entry
+	verifyPoolAllocatedSize(t, poolLister, 1)
+}

--- a/pkg/ipam/poolallocator/allocator.go
+++ b/pkg/ipam/poolallocator/allocator.go
@@ -181,6 +181,35 @@ func (a *IPPoolAllocator) updateIPAddressState(ipPool *v1alpha2.IPPool, ip net.I
 
 }
 
+func (a *IPPoolAllocator) appendPoolUsageForStatefulSet(ipPool *v1alpha2.IPPool, ips []net.IP, namespace, name string) error {
+	newPool := ipPool.DeepCopy()
+
+	for i, ip := range ips {
+		owner := v1alpha2.IPAddressOwner{
+			StatefulSet: &v1alpha2.StatefulSetOwner{
+				Namespace: namespace,
+				Name:      name,
+				Index:     i,
+			},
+		}
+		usageEntry := v1alpha2.IPAddressState{
+			IPAddress: ip.String(),
+			Phase:     v1alpha2.IPAddressPhasePreallocated,
+			Owner:     owner,
+		}
+
+		newPool.Status.IPAddresses = append(newPool.Status.IPAddresses, usageEntry)
+	}
+	_, err := a.crdClient.CrdV1alpha2().IPPools().UpdateStatus(context.TODO(), newPool, metav1.UpdateOptions{})
+	if err != nil {
+		klog.Warningf("IP Pool %s update with status %+v failed: %+v", newPool.Name, newPool.Status, err)
+		return err
+	}
+	klog.V(2).InfoS("IP Pool update succeeded", "pool", newPool.Name, "allocation", newPool.Status)
+	return nil
+
+}
+
 // removeIPAddressState updates ipPool status to delete released IP allocation, and keeps preallocation information
 func (a *IPPoolAllocator) removeIPAddressState(ipPool *v1alpha2.IPPool, ip net.IP) error {
 
@@ -306,7 +335,7 @@ func (a *IPPoolAllocator) AllocateNext(state v1alpha2.IPAddressPhase, owner v1al
 	})
 
 	if err != nil {
-		klog.Errorf("Failed to allocate from pool %s: %+v", a.ipPoolName, err)
+		klog.ErrorS(err, "Failed to allocate from IPPool", "IPPool", a.ipPoolName)
 	}
 	return ip, subnetSpec, err
 }
@@ -368,6 +397,32 @@ func (a *IPPoolAllocator) AllocateReservedOrNext(state v1alpha2.IPAddressPhase, 
 	return ip, subnetSpec, err
 }
 
+// AllocateStatefulSet pre-allocates continuous range of IPs for StatefulSet.
+// This functionality is useful when StatefulSet does not have a dedicated IP Pool assigned.
+// It returns error if such range is not available. In this case IPs for the StatefulSet will
+// be allocated on the fly, and there is no guarantee for continuous IPs.
+func (a *IPPoolAllocator) AllocateStatefulSet(namespace, name string, size int) error {
+	// Retry on CRD update conflict which is caused by multiple agents updating a pool at same time.
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		ipPool, allocators, err := a.getPoolAndInitIPAllocators()
+		if err != nil {
+			return err
+		}
+
+		ips, err := allocators.AllocateRange(size)
+		if err != nil {
+			return err
+		}
+
+		return a.appendPoolUsageForStatefulSet(ipPool, ips, namespace, name)
+	})
+
+	if err != nil {
+		klog.ErrorS(err, "Failed to allocate from IPPool", "IPPool", a.ipPoolName)
+	}
+	return err
+}
+
 // Release releases the provided IP. It returns error if the IP is not in the range or not allocated,
 // or in case CRD failed to update its state.
 // In case of success, IP pool CRD status is updated with released IP/state/resource.
@@ -391,12 +446,13 @@ func (a *IPPoolAllocator) Release(ip net.IP) error {
 	})
 
 	if err != nil {
-		klog.Errorf("Failed to release IP address %s from pool %s: %+v", ip, a.ipPoolName, err)
+		klog.ErrorS(err, "Failed to release IP address", "IPAddress", ip, "IPPool", a.ipPoolName)
 	}
 	return err
 }
 
-// ReleaseResource releases the IP associated with specified Pod. It returns error if the resource is not present in state or in case CRD failed to update its state.
+// ReleasePod releases the IP associated with specified Pod.
+// It returns error if the pod is not present in state or in case CRD failed to update state.
 // In case of success, IP pool CRD status is updated with released entry.
 func (a *IPPoolAllocator) ReleasePod(namespace, podName string) error {
 
@@ -421,7 +477,52 @@ func (a *IPPoolAllocator) ReleasePod(namespace, podName string) error {
 	})
 
 	if err != nil {
-		klog.Errorf("Failed to release IP address for Pod:%s/%s from pool %s: %+v", namespace, podName, a.ipPoolName, err)
+		klog.ErrorS(err, "Failed to release IP address", "Namespace", namespace, "Pod", podName, "IPPool", a.ipPoolName)
+	}
+	return err
+}
+
+// ReleaseStatefulSet releases all IPs associated with specified StatefulSet. It returns error
+// in case CRD failed to update its state.
+// In case of success, IP pool CRD status is updated with released entries.
+func (a *IPPoolAllocator) ReleaseStatefulSet(namespace, name string) error {
+
+	// Retry on CRD update conflict which is caused by multiple agents updating a pool at same time.
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		ipPool, err := a.getPool()
+
+		if err != nil {
+			return err
+		}
+
+		var updatedAdresses []v1alpha2.IPAddressState
+		for _, ip := range ipPool.Status.IPAddresses {
+			if ip.Owner.StatefulSet == nil || ip.Owner.StatefulSet.Namespace != namespace || ip.Owner.StatefulSet.Name != name {
+				updatedAdresses = append(updatedAdresses, ip)
+			}
+		}
+
+		if len(ipPool.Status.IPAddresses) == len(updatedAdresses) {
+			// no change
+			klog.V(4).InfoS("No reserved IPs found", "pool", ipPool.Name, "Namespace", namespace, "StatefulSet", name)
+			return nil
+		}
+
+		newPool := ipPool.DeepCopy()
+		newPool.Status.IPAddresses = updatedAdresses
+
+		_, err = a.crdClient.CrdV1alpha2().IPPools().UpdateStatus(context.TODO(), newPool, metav1.UpdateOptions{})
+		if err != nil {
+			klog.Warningf("IP Pool %s update failed: %+v", newPool.Name, err)
+			return err
+		}
+		klog.V(2).InfoS("IP Pool update successful", "pool", newPool.Name, "allocation", newPool.Status)
+		return nil
+
+	})
+
+	if err != nil {
+		klog.ErrorS(err, "Failed to release IP addresses", "Namespace", namespace, "StatefulSet", name, "IPPool", a.ipPoolName)
 	}
 	return err
 }
@@ -452,7 +553,7 @@ func (a *IPPoolAllocator) ReleaseContainerIfPresent(containerID string) error {
 	})
 
 	if err != nil {
-		klog.Errorf("Failed to release IP address for container %s from pool %s: %+v", containerID, a.ipPoolName, err)
+		klog.ErrorS(err, "Failed to release IP address", "Container", containerID, "IPPool", a.ipPoolName)
 	}
 	return err
 }

--- a/pkg/util/k8s/name.go
+++ b/pkg/util/k8s/name.go
@@ -30,6 +30,18 @@ func NamespacedName(namespace, name string) string {
 	return namespace + "/" + name
 }
 
+// SplitNamespacedName splits conventional K8s resource name
+// to Namespace and Resource Name
+func SplitNamespacedName(name string) (string, string) {
+	tokens := strings.Split(name, "/")
+
+	if len(tokens) == 2 {
+		return tokens[0], tokens[1]
+	}
+
+	return "", tokens[0]
+}
+
 func ParseStatefulSetName(name string) (statefulSetName string, index int, err error) {
 	splittedName := strings.Split(name, "-")
 	if len(splittedName) < 2 {


### PR DESCRIPTION
* Support continuous IP range allocation in ip allocator
* Support pe-allocating continuous range of IPs from an IP
Pool for StatefulSet. This functionality will be used by
StatefulSets that do not have a dedicated IP Pool annotated.

Signed-off-by: Anna Khmelnitsky <akhmelnitsky@vmware.com>