### PR TITLE
[Multicast] Support IGMP query v1/v2/v3 message

### DIFF
--- a/pkg/agent/multicast/mcast_controller_test.go
+++ b/pkg/agent/multicast/mcast_controller_test.go
@@ -80,7 +80,7 @@ func TestUpdateGroupMemberStatus(t *testing.T) {
 	}
 	mctrl.addGroupMemberStatus(event)
 	obj, _, _ := mctrl.groupCache.GetByKey(event.group.String())
-	mockOFClient.EXPECT().SendIGMPQueryPacketOut(igmpQueryDstMac, mcastAllHosts, uint32(openflow13.P_NORMAL), gomock.Any()).Times(1)
+	mockOFClient.EXPECT().SendIGMPQueryPacketOut(igmpQueryDstMac, mcastAllHosts, uint32(openflow13.P_NORMAL), gomock.Any()).Times(len(queryVersions))
 	for _, e := range []*mcastGroupEvent{
 		{group: mgroup, eType: groupJoin, time: event.time.Add(time.Second * 20), iface: if1},
 		{group: mgroup, eType: groupJoin, time: event.time.Add(time.Second * 40), iface: if1},

--- a/pkg/agent/multicast/mcast_discovery.go
+++ b/pkg/agent/multicast/mcast_discovery.go
@@ -97,15 +97,17 @@ func (s *IGMPSnooper) parseSrcInterface(pktIn *ofctrl.PacketIn) (*interfacestore
 	return ifaceConfig, nil
 }
 
-func (s *IGMPSnooper) queryIGMP(group net.IP, version uint8) error {
-	igmp, err := generateIGMPQueryPacket(group, version)
-	if err != nil {
-		return err
+func (s *IGMPSnooper) queryIGMP(group net.IP, versions []uint8) error {
+	for _, version := range versions {
+		igmp, err := generateIGMPQueryPacket(group, version)
+		if err != nil {
+			return err
+		}
+		if err := s.ofClient.SendIGMPQueryPacketOut(igmpQueryDstMac, mcastAllHosts, openflow13.P_NORMAL, igmp); err != nil {
+			return err
+		}
+		klog.V(2).InfoS("Sent packetOut for IGMP query", "group", group.String(), "version", version)
 	}
-	if err := s.ofClient.SendIGMPQueryPacketOut(igmpQueryDstMac, mcastAllHosts, openflow13.P_NORMAL, igmp); err != nil {
-		return err
-	}
-	klog.V(2).InfoS("Sent packetOut form IGMP query", "group", group.String(), "version", version)
 	return nil
 }
 


### PR DESCRIPTION
Antrea Agent sends IGMPv1/v2/v3 query messages to snoop the multicast groups in which local Pods have joined.

Signed-off-by: wenyingd <wenyingd@vmware.com>