### PR TITLE
Support external IP management of Services

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -3468,6 +3468,13 @@ rules:
   - watch
   - list
 - apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
   - discovery.k8s.io
   resources:
   - endpointslices
@@ -3631,7 +3638,6 @@ rules:
   resources:
   - pods
   - namespaces
-  - services
   - configmaps
   verbs:
   - get
@@ -3645,6 +3651,17 @@ rules:
   - get
   - watch
   - list
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - services/status
+  verbs:
+  - get
+  - watch
+  - list
+  - update
   - patch
 - apiGroups:
   - networking.k8s.io
@@ -4020,6 +4037,9 @@ data:
     # Enable multicast traffic. This feature is supported only with noEncap mode.
     #  Multicast: false
 
+    # Enable managing external IPs of Services of LoadBalancer type.
+    #  ServiceExternalIP: false
+
     # Name of the OpenVSwitch bridge antrea-agent will create and use.
     # Make sure it doesn't conflict with your existing OpenVSwitch bridges.
     #ovsBridge: br-int
@@ -4243,7 +4263,9 @@ data:
     # Enable flexible IPAM mode for Antrea. This mode allows to assign IP Ranges to Namespaces,
     # Deployments and StatefulSets via IP Pool annotation.
     #  AntreaIPAM: false
-    #
+
+    # Enable managing external IPs of Services of LoadBalancer type.
+    #  ServiceExternalIP: false
 
     # The port for the antrea-controller APIServer to serve on.
     # Note that if it's set to another value, the `containerPort` of the `api` port of the
@@ -4311,7 +4333,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-hc65bkbcgm
+  name: antrea-config-t4d76tttk7
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4382,7 +4404,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-hc65bkbcgm
+          value: antrea-config-t4d76tttk7
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4433,7 +4455,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-hc65bkbcgm
+          name: antrea-config-t4d76tttk7
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4714,7 +4736,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-hc65bkbcgm
+          name: antrea-config-t4d76tttk7
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -3468,6 +3468,13 @@ rules:
   - watch
   - list
 - apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
   - discovery.k8s.io
   resources:
   - endpointslices
@@ -3631,7 +3638,6 @@ rules:
   resources:
   - pods
   - namespaces
-  - services
   - configmaps
   verbs:
   - get
@@ -3645,6 +3651,17 @@ rules:
   - get
   - watch
   - list
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - services/status
+  verbs:
+  - get
+  - watch
+  - list
+  - update
   - patch
 - apiGroups:
   - networking.k8s.io
@@ -4020,6 +4037,9 @@ data:
     # Enable multicast traffic. This feature is supported only with noEncap mode.
     #  Multicast: false
 
+    # Enable managing external IPs of Services of LoadBalancer type.
+    #  ServiceExternalIP: false
+
     # Name of the OpenVSwitch bridge antrea-agent will create and use.
     # Make sure it doesn't conflict with your existing OpenVSwitch bridges.
     #ovsBridge: br-int
@@ -4243,7 +4263,9 @@ data:
     # Enable flexible IPAM mode for Antrea. This mode allows to assign IP Ranges to Namespaces,
     # Deployments and StatefulSets via IP Pool annotation.
     #  AntreaIPAM: false
-    #
+
+    # Enable managing external IPs of Services of LoadBalancer type.
+    #  ServiceExternalIP: false
 
     # The port for the antrea-controller APIServer to serve on.
     # Note that if it's set to another value, the `containerPort` of the `api` port of the
@@ -4311,7 +4333,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-hc65bkbcgm
+  name: antrea-config-t4d76tttk7
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4382,7 +4404,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-hc65bkbcgm
+          value: antrea-config-t4d76tttk7
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4433,7 +4455,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-hc65bkbcgm
+          name: antrea-config-t4d76tttk7
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4716,7 +4738,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-hc65bkbcgm
+          name: antrea-config-t4d76tttk7
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -3468,6 +3468,13 @@ rules:
   - watch
   - list
 - apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
   - discovery.k8s.io
   resources:
   - endpointslices
@@ -3631,7 +3638,6 @@ rules:
   resources:
   - pods
   - namespaces
-  - services
   - configmaps
   verbs:
   - get
@@ -3645,6 +3651,17 @@ rules:
   - get
   - watch
   - list
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - services/status
+  verbs:
+  - get
+  - watch
+  - list
+  - update
   - patch
 - apiGroups:
   - networking.k8s.io
@@ -4020,6 +4037,9 @@ data:
     # Enable multicast traffic. This feature is supported only with noEncap mode.
     #  Multicast: false
 
+    # Enable managing external IPs of Services of LoadBalancer type.
+    #  ServiceExternalIP: false
+
     # Name of the OpenVSwitch bridge antrea-agent will create and use.
     # Make sure it doesn't conflict with your existing OpenVSwitch bridges.
     #ovsBridge: br-int
@@ -4243,7 +4263,9 @@ data:
     # Enable flexible IPAM mode for Antrea. This mode allows to assign IP Ranges to Namespaces,
     # Deployments and StatefulSets via IP Pool annotation.
     #  AntreaIPAM: false
-    #
+
+    # Enable managing external IPs of Services of LoadBalancer type.
+    #  ServiceExternalIP: false
 
     # The port for the antrea-controller APIServer to serve on.
     # Note that if it's set to another value, the `containerPort` of the `api` port of the
@@ -4311,7 +4333,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-9mch246h2k
+  name: antrea-config-b696bmff84
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4382,7 +4404,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-9mch246h2k
+          value: antrea-config-b696bmff84
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4433,7 +4455,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-9mch246h2k
+          name: antrea-config-b696bmff84
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4717,7 +4739,7 @@ spec:
           path: /home/kubernetes/bin
         name: host-cni-bin
       - configMap:
-          name: antrea-config-9mch246h2k
+          name: antrea-config-b696bmff84
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -3468,6 +3468,13 @@ rules:
   - watch
   - list
 - apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
   - discovery.k8s.io
   resources:
   - endpointslices
@@ -3631,7 +3638,6 @@ rules:
   resources:
   - pods
   - namespaces
-  - services
   - configmaps
   verbs:
   - get
@@ -3645,6 +3651,17 @@ rules:
   - get
   - watch
   - list
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - services/status
+  verbs:
+  - get
+  - watch
+  - list
+  - update
   - patch
 - apiGroups:
   - networking.k8s.io
@@ -4020,6 +4037,9 @@ data:
     # Enable multicast traffic. This feature is supported only with noEncap mode.
     #  Multicast: false
 
+    # Enable managing external IPs of Services of LoadBalancer type.
+    #  ServiceExternalIP: false
+
     # Name of the OpenVSwitch bridge antrea-agent will create and use.
     # Make sure it doesn't conflict with your existing OpenVSwitch bridges.
     #ovsBridge: br-int
@@ -4248,7 +4268,9 @@ data:
     # Enable flexible IPAM mode for Antrea. This mode allows to assign IP Ranges to Namespaces,
     # Deployments and StatefulSets via IP Pool annotation.
     #  AntreaIPAM: false
-    #
+
+    # Enable managing external IPs of Services of LoadBalancer type.
+    #  ServiceExternalIP: false
 
     # The port for the antrea-controller APIServer to serve on.
     # Note that if it's set to another value, the `containerPort` of the `api` port of the
@@ -4316,7 +4338,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-2thm85m7gt
+  name: antrea-config-5fm86722mm
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4396,7 +4418,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-2thm85m7gt
+          value: antrea-config-5fm86722mm
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4447,7 +4469,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-2thm85m7gt
+          name: antrea-config-5fm86722mm
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4763,7 +4785,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-2thm85m7gt
+          name: antrea-config-5fm86722mm
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-kind.yml
+++ b/build/yamls/antrea-kind.yml
@@ -3468,6 +3468,13 @@ rules:
   - watch
   - list
 - apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
   - discovery.k8s.io
   resources:
   - endpointslices
@@ -3631,7 +3638,6 @@ rules:
   resources:
   - pods
   - namespaces
-  - services
   - configmaps
   verbs:
   - get
@@ -3645,6 +3651,17 @@ rules:
   - get
   - watch
   - list
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - services/status
+  verbs:
+  - get
+  - watch
+  - list
+  - update
   - patch
 - apiGroups:
   - networking.k8s.io
@@ -4020,6 +4037,9 @@ data:
     # Enable multicast traffic. This feature is supported only with noEncap mode.
     #  Multicast: false
 
+    # Enable managing external IPs of Services of LoadBalancer type.
+    #  ServiceExternalIP: false
+
     # Name of the OpenVSwitch bridge antrea-agent will create and use.
     # Make sure it doesn't conflict with your existing OpenVSwitch bridges.
     #ovsBridge: br-int
@@ -4248,7 +4268,9 @@ data:
     # Enable flexible IPAM mode for Antrea. This mode allows to assign IP Ranges to Namespaces,
     # Deployments and StatefulSets via IP Pool annotation.
     #  AntreaIPAM: false
-    #
+
+    # Enable managing external IPs of Services of LoadBalancer type.
+    #  ServiceExternalIP: false
 
     # The port for the antrea-controller APIServer to serve on.
     # Note that if it's set to another value, the `containerPort` of the `api` port of the
@@ -4316,7 +4338,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-44dgfghbf4
+  name: antrea-config-65d688467c
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4387,7 +4409,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-44dgfghbf4
+          value: antrea-config-65d688467c
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4438,7 +4460,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-44dgfghbf4
+          name: antrea-config-65d688467c
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4715,7 +4737,7 @@ spec:
           type: CharDevice
         name: dev-tun
       - configMap:
-          name: antrea-config-44dgfghbf4
+          name: antrea-config-65d688467c
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -3468,6 +3468,13 @@ rules:
   - watch
   - list
 - apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
   - discovery.k8s.io
   resources:
   - endpointslices
@@ -3631,7 +3638,6 @@ rules:
   resources:
   - pods
   - namespaces
-  - services
   - configmaps
   verbs:
   - get
@@ -3645,6 +3651,17 @@ rules:
   - get
   - watch
   - list
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - services/status
+  verbs:
+  - get
+  - watch
+  - list
+  - update
   - patch
 - apiGroups:
   - networking.k8s.io
@@ -4020,6 +4037,9 @@ data:
     # Enable multicast traffic. This feature is supported only with noEncap mode.
     #  Multicast: false
 
+    # Enable managing external IPs of Services of LoadBalancer type.
+    #  ServiceExternalIP: false
+
     # Name of the OpenVSwitch bridge antrea-agent will create and use.
     # Make sure it doesn't conflict with your existing OpenVSwitch bridges.
     #ovsBridge: br-int
@@ -4248,7 +4268,9 @@ data:
     # Enable flexible IPAM mode for Antrea. This mode allows to assign IP Ranges to Namespaces,
     # Deployments and StatefulSets via IP Pool annotation.
     #  AntreaIPAM: false
-    #
+
+    # Enable managing external IPs of Services of LoadBalancer type.
+    #  ServiceExternalIP: false
 
     # The port for the antrea-controller APIServer to serve on.
     # Note that if it's set to another value, the `containerPort` of the `api` port of the
@@ -4316,7 +4338,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-c4m4ghgm7d
+  name: antrea-config-2k82d6f6t4
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4387,7 +4409,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-c4m4ghgm7d
+          value: antrea-config-2k82d6f6t4
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4438,7 +4460,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-c4m4ghgm7d
+          name: antrea-config-2k82d6f6t4
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4719,7 +4741,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-c4m4ghgm7d
+          name: antrea-config-2k82d6f6t4
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/base/agent-rbac.yml
+++ b/build/yamls/base/agent-rbac.yml
@@ -37,7 +37,14 @@ rules:
     verbs:
       - get
       - watch
-      - list
+      - list  
+  - apiGroups:
+      - ""
+    resources:
+      - services/status
+    verbs:
+      - update
+      - patch
   - apiGroups:
       - discovery.k8s.io
     resources:

--- a/build/yamls/base/conf/antrea-agent.conf
+++ b/build/yamls/base/conf/antrea-agent.conf
@@ -38,6 +38,9 @@ featureGates:
 # Enable multicast traffic. This feature is supported only with noEncap mode.
 #  Multicast: false
 
+# Enable managing external IPs of Services of LoadBalancer type.
+#  ServiceExternalIP: false
+
 # Name of the OpenVSwitch bridge antrea-agent will create and use.
 # Make sure it doesn't conflict with your existing OpenVSwitch bridges.
 #ovsBridge: br-int

--- a/build/yamls/base/conf/antrea-controller.conf
+++ b/build/yamls/base/conf/antrea-controller.conf
@@ -20,7 +20,9 @@ featureGates:
 # Enable flexible IPAM mode for Antrea. This mode allows to assign IP Ranges to Namespaces,
 # Deployments and StatefulSets via IP Pool annotation.
 #  AntreaIPAM: false
-#
+
+# Enable managing external IPs of Services of LoadBalancer type.
+#  ServiceExternalIP: false
 
 # The port for the antrea-controller APIServer to serve on.
 # Note that if it's set to another value, the `containerPort` of the `api` port of the

--- a/build/yamls/base/controller-rbac.yml
+++ b/build/yamls/base/controller-rbac.yml
@@ -15,7 +15,6 @@ rules:
     resources:
       - pods
       - namespaces
-      - services
       - configmaps
     verbs:
       - get
@@ -29,6 +28,17 @@ rules:
       - get
       - watch
       - list
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - services/status
+    verbs:
+      - get
+      - watch
+      - list
+      - update
       - patch
   - apiGroups:
       - networking.k8s.io

--- a/go.mod
+++ b/go.mod
@@ -19,9 +19,9 @@ require (
 	github.com/go-logr/logr v0.4.0
 	github.com/go-openapi/spec v0.19.5
 	github.com/gogo/protobuf v1.3.2
-	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e
 	github.com/golang/mock v1.6.0
 	github.com/golang/protobuf v1.5.2
+	github.com/google/btree v1.0.1
 	github.com/google/uuid v1.1.2
 	github.com/hashicorp/memberlist v0.2.4
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.1.0
@@ -106,7 +106,7 @@ require (
 	github.com/go-openapi/jsonpointer v0.19.3 // indirect
 	github.com/go-openapi/jsonreference v0.19.3 // indirect
 	github.com/go-openapi/swag v0.19.5 // indirect
-	github.com/google/btree v1.0.0 // indirect
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/google/go-cmp v0.5.5 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -349,8 +349,9 @@ github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiu
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e/go.mod h1:0AA//k/eakGydO4jKRoRL2j92ZKSzTgj9tclaCrvXHk=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
-github.com/google/btree v1.0.0 h1:0udJVsspx3VBr5FwtLhQQtuAsVc79tTq0ocGIPAU6qo=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
+github.com/google/btree v1.0.1 h1:gK4Kx5IaGY9CD5sPJ36FHiBJ6ZXl0kilRiiCj+jdYp4=
+github.com/google/btree v1.0.1/go.mod h1:xXMiIv4Fb/0kKde4SpL7qlzvu5cMJDRkFDxJfI9uaxA=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=

--- a/pkg/agent/consistenthash/consistenthash.go
+++ b/pkg/agent/consistenthash/consistenthash.go
@@ -1,0 +1,151 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The idea is borrowed from https://github.com/golang/groupcache/blob/master/consistenthash/consistenthash.go with the following modifications:
+// - Store the replicas in a 2-3-4 btree so that we can add/remove keys in O(log N) without rebuilding the whole cache.
+// - Add a function GetWithFilters() to allow filtering keys with desired filters.
+
+// Package consistenthash provides an implementation of a ring hash.
+package consistenthash
+
+import (
+	"hash/crc32"
+	"strconv"
+
+	"github.com/google/btree"
+)
+
+type Hash func(data []byte) uint32
+
+type Map struct {
+	hash     Hash
+	replicas int
+	keys     map[string]struct{}
+	tree     *btree.BTree
+}
+
+type replica struct {
+	key  string
+	hash uint32
+}
+
+func (v *replica) Less(than btree.Item) bool {
+	return v.hash < than.(*replica).hash
+}
+
+var _ btree.Item = (*replica)(nil)
+
+func New(replicas int, fn Hash) *Map {
+	m := &Map{
+		replicas: replicas,
+		hash:     fn,
+		keys:     make(map[string]struct{}),
+		tree:     btree.New(2),
+	}
+	if m.hash == nil {
+		m.hash = crc32.ChecksumIEEE
+	}
+	return m
+}
+
+// IsEmpty returns true if there are no items available.
+func (m *Map) IsEmpty() bool {
+	return len(m.keys) == 0
+}
+
+// Add adds some keys to the hash.
+func (m *Map) Add(keys ...string) {
+	for _, key := range keys {
+		if _, exist := m.keys[key]; exist {
+			continue
+		}
+		for i := 0; i < m.replicas; i++ {
+			hash := m.hash([]byte(strconv.Itoa(i) + key))
+			r := &replica{
+				key:  key,
+				hash: hash,
+			}
+			m.tree.ReplaceOrInsert(r)
+		}
+		m.keys[key] = struct{}{}
+	}
+}
+
+// Remove removes keys from existing hash ring.
+func (m *Map) Remove(keys ...string) {
+	for _, key := range keys {
+		_, exist := m.keys[key]
+		if !exist {
+			continue
+		}
+		for i := 0; i < m.replicas; i++ {
+			hash := m.hash([]byte(strconv.Itoa(i) + key))
+			replica := &replica{
+				key:  key,
+				hash: hash,
+			}
+			m.tree.Delete(replica)
+		}
+		delete(m.keys, key)
+	}
+}
+
+// Get gets the closest item in the hash to the provided key.
+func (m *Map) Get(key string) string {
+	return m.GetWithFilters(key)
+}
+
+// GetWithFilters gets the closest item in the hash to which passes all filters.
+func (m *Map) GetWithFilters(key string, filters ...func(string) bool) string {
+	if m.IsEmpty() {
+		return ""
+	}
+	hash := m.hash([]byte(key))
+	pivot := &replica{
+		key:  key,
+		hash: hash,
+	}
+	var result *replica
+	visited := make(map[string]struct{})
+	iterator := func(item btree.Item) bool {
+		// all keys visited
+		if len(visited) == len(m.keys) {
+			return false
+		}
+		r := item.(*replica)
+		if _, exists := visited[r.key]; exists {
+			return true
+		}
+		for _, f := range filters {
+			if !f(r.key) {
+				visited[r.key] = struct{}{}
+				return true
+			}
+		}
+		// stop iterating
+		result = r
+		return false
+	}
+	// search in [pivot, last]
+	m.tree.AscendGreaterOrEqual(pivot, iterator)
+	if result == nil {
+		// search in [first, pivot)
+		m.tree.AscendLessThan(pivot, iterator)
+	}
+	// no key passes all filters
+	if result == nil {
+		return ""
+	}
+	return result.key
+}

--- a/pkg/agent/consistenthash/consistenthash_test.go
+++ b/pkg/agent/consistenthash/consistenthash_test.go
@@ -1,0 +1,258 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package consistenthash
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/google/btree"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// simpleHashFn is a simple hash function for testing. It will return the integer value of the
+// input key. The key must be the chars of decimal representation of an integer.
+func simpleHashFn(key []byte) uint32 {
+	i, err := strconv.Atoi(string(key))
+	if err != nil {
+		panic(err)
+	}
+	return uint32(i)
+}
+
+func TestMapGet(t *testing.T) {
+	hash := New(3, simpleHashFn)
+
+	// Given the above hash function, this will give replicas with "hashes":
+	// 2, 4, 6, 12, 14, 16, 22, 24, 26
+	hash.Add("6", "4", "2")
+	testCases := map[string]string{
+		"2":  "2",
+		"11": "2",
+		"23": "4",
+		"27": "2",
+	}
+	for k, v := range testCases {
+		assert.Equal(t, v, hash.Get(k))
+	}
+
+	// Adds 8, 18, 28
+	hash.Add("8")
+	// 27 should now map to 8.
+	testCases["27"] = "8"
+	for k, v := range testCases {
+		assert.Equal(t, v, hash.Get(k))
+	}
+
+}
+
+func TestConsistency(t *testing.T) {
+	hash1 := New(1, nil)
+	hash2 := New(1, nil)
+
+	hash1.Add("Bill", "Bob", "Bonny")
+	hash2.Add("Bob", "Bonny", "Bill")
+
+	if hash1.Get("Ben") != hash2.Get("Ben") {
+		t.Errorf("Fetching 'Ben' from both hashes should be the same")
+	}
+}
+
+func TestGetWithFilter(t *testing.T) {
+	testCases := []struct {
+		name         string
+		keys         []string
+		testKey      string
+		expectedHash string
+		filter       []func(string) bool
+	}{
+		{
+			"without filters",
+			[]string{"1", "2", "3"},
+			"2",
+			"2",
+			nil,
+		},
+		{
+			"with one filter to exclude one key",
+			[]string{"1", "2", "3"},
+			"2",
+			"3",
+			[]func(s string) bool{
+				func(s string) bool {
+					return s != "2"
+				},
+			},
+		},
+		{
+			"with one filter to match only one key",
+			[]string{"1", "2", "3"},
+			"2",
+			"1",
+			[]func(s string) bool{
+				func(s string) bool {
+					return s == "1"
+				},
+			},
+		},
+		{
+			"with two filters",
+			[]string{"1", "2", "3"},
+			"2",
+			"1",
+			[]func(s string) bool{
+				func(s string) bool {
+					return s != "2"
+				},
+				func(s string) bool {
+					return s != "3"
+				},
+			},
+		},
+		{
+			"no valid value",
+			[]string{"1", "2", "3"},
+			"2",
+			"",
+			[]func(s string) bool{
+				func(s string) bool {
+					return s == "0"
+				},
+			},
+		},
+		{
+			"filters should check exactly once for each key",
+			[]string{"1", "2", "3"},
+			"2",
+			"",
+			[]func(s string) bool{
+				func(m map[string]struct{}) func(s string) bool {
+					return func(s string) bool {
+						if _, ok := m[s]; ok {
+							t.Errorf("duplicate key passed to filters")
+						}
+						m[s] = struct{}{}
+						return false
+					}
+				}(make(map[string]struct{})),
+			},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			hash := New(3, simpleHashFn)
+			hash.Add(tt.keys...)
+			v := hash.GetWithFilters(tt.testKey, tt.filter...)
+			assert.Equal(t, tt.expectedHash, v)
+		})
+	}
+}
+
+func TestRemove(t *testing.T) {
+	testCases := []struct {
+		name             string
+		keys             []string
+		toRemove         []string
+		expectedHashRing []replica
+	}{
+		{
+			"delete one key",
+			[]string{"1", "2", "3"},
+			[]string{"2"},
+			[]replica{
+				{"1", 1},
+				{"3", 3},
+				{"1", 11},
+				{"3", 13},
+			},
+		},
+		{
+			"delete two keys",
+			[]string{"1", "2", "3"},
+			[]string{"2", "3"},
+			[]replica{
+				{"1", 1},
+				{"1", 11},
+			},
+		}, {
+			"delete all keys",
+			[]string{"1", "2", "3"},
+			[]string{"1", "2", "3"},
+			nil,
+		},
+		{
+			"delete non-existing key",
+			[]string{"1", "2", "3"},
+			[]string{"4"},
+			[]replica{
+				{"1", 1},
+				{"2", 2},
+				{"3", 3},
+				{"1", 11},
+				{"2", 12},
+				{"3", 13},
+			},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			hash := New(2, simpleHashFn)
+			hash.Add(tt.keys...)
+			hash.Remove(tt.toRemove...)
+			var actualHashRing []replica
+			iterator := func(item btree.Item) bool {
+				replica, ok := item.(*replica)
+				require.True(t, ok)
+				actualHashRing = append(actualHashRing, *replica)
+				return true
+			}
+			hash.tree.Ascend(iterator)
+			assert.Equal(t, tt.expectedHashRing, actualHashRing)
+			for _, r := range tt.toRemove {
+				if _, ok := hash.keys[r]; ok {
+					t.Errorf("key %s not deleted", r)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkGet8(b *testing.B)    { benchmarkGet(b, 8) }
+func BenchmarkGet32(b *testing.B)   { benchmarkGet(b, 32) }
+func BenchmarkGet128(b *testing.B)  { benchmarkGet(b, 128) }
+func BenchmarkGet512(b *testing.B)  { benchmarkGet(b, 512) }
+func BenchmarkGet1024(b *testing.B) { benchmarkGet(b, 1024) }
+
+func benchmarkGet(b *testing.B, shards int) {
+	b.SetBytes(1)
+	hash := New(50, nil)
+
+	var buckets []string
+	for i := 0; i < shards; i++ {
+		buckets = append(buckets, fmt.Sprintf("shard-%d", i))
+	}
+
+	hash.Add(buckets...)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		hash.Get(buckets[i&(shards-1)])
+	}
+}

--- a/pkg/agent/controller/serviceexternalip/controller.go
+++ b/pkg/agent/controller/serviceexternalip/controller.go
@@ -1,0 +1,461 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package serviceexternalip
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	apimachinerytypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/kubernetes"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+
+	"antrea.io/antrea/pkg/agent/ipassigner"
+	"antrea.io/antrea/pkg/agent/memberlist"
+	"antrea.io/antrea/pkg/agent/types"
+)
+
+const (
+	controllerName = "ServiceExternalIPController"
+	// How long to wait before retrying the processing of an Service change.
+	minRetryDelay = 5 * time.Second
+	maxRetryDelay = 300 * time.Second
+	// Default number of workers processing an Service change.
+	defaultWorkers = 1
+	// Disable resyncing.
+	resyncPeriod time.Duration = 0
+
+	externalIPIndex     = "externalIP"
+	externalIPPoolIndex = "externalIPPool"
+
+	// ingressDummyDevice is the dummy device that holds the Service external IPs configured to the system by antrea-agent.
+	ingressDummyDevice = "antrea-ingress0"
+)
+
+type externalIPState struct {
+	ip           string
+	assignedNode string
+}
+
+type ServiceExternalIPController struct {
+	nodeName            string
+	serviceInformer     cache.SharedIndexInformer
+	serviceLister       corelisters.ServiceLister
+	serviceListerSynced cache.InformerSynced
+
+	client kubernetes.Interface
+
+	endpointsInformer     cache.SharedIndexInformer
+	endpointsLister       corelisters.EndpointsLister
+	endpointsListerSynced cache.InformerSynced
+
+	queue workqueue.RateLimitingInterface
+
+	externalIPStates      map[apimachinerytypes.NamespacedName]externalIPState
+	externalIPStatesMutex sync.RWMutex
+
+	cluster         memberlist.Interface
+	ipAssigner      ipassigner.IPAssigner
+	localIPDetector ipassigner.LocalIPDetector
+}
+
+func NewServiceExternalIPController(
+	nodeName string,
+	nodeTransportIP net.IP,
+	client kubernetes.Interface,
+	cluster memberlist.Interface,
+	serviceInformer coreinformers.ServiceInformer,
+	endpointsInformer coreinformers.EndpointsInformer,
+	localIPDetector ipassigner.LocalIPDetector,
+) (*ServiceExternalIPController, error) {
+	c := &ServiceExternalIPController{
+		nodeName:              nodeName,
+		client:                client,
+		cluster:               cluster,
+		queue:                 workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(minRetryDelay, maxRetryDelay), "AgentServiceExternalIP"),
+		serviceInformer:       serviceInformer.Informer(),
+		serviceLister:         serviceInformer.Lister(),
+		serviceListerSynced:   serviceInformer.Informer().HasSynced,
+		endpointsInformer:     endpointsInformer.Informer(),
+		endpointsLister:       endpointsInformer.Lister(),
+		endpointsListerSynced: endpointsInformer.Informer().HasSynced,
+		externalIPStates:      make(map[apimachinerytypes.NamespacedName]externalIPState),
+		localIPDetector:       localIPDetector,
+	}
+	ipAssigner, err := ipassigner.NewIPAssigner(nodeTransportIP, ingressDummyDevice)
+	if err != nil {
+		return nil, fmt.Errorf("initializing service external IP assigner failed: %v", err)
+	}
+	c.ipAssigner = ipAssigner
+
+	c.serviceInformer.AddIndexers(cache.Indexers{
+		externalIPIndex: func(obj interface{}) ([]string, error) {
+			service, ok := obj.(*corev1.Service)
+			if !ok {
+				return nil, fmt.Errorf("obj is not Service: %+v", obj)
+			}
+			if len(service.Status.LoadBalancer.Ingress) == 0 {
+				return nil, nil
+			}
+			return []string{service.Status.LoadBalancer.Ingress[0].IP}, nil
+		},
+		externalIPPoolIndex: func(obj interface{}) ([]string, error) {
+			service, ok := obj.(*corev1.Service)
+			if !ok {
+				return nil, fmt.Errorf("obj is not Service: %+v", obj)
+			}
+			eipName, ok := service.Annotations[types.ServiceExternalIPPoolAnnotationKey]
+			if !ok {
+				return nil, nil
+			}
+			return []string{eipName}, nil
+		}},
+	)
+
+	c.serviceInformer.AddEventHandlerWithResyncPeriod(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: c.enqueueService,
+			UpdateFunc: func(old, cur interface{}) {
+				c.enqueueService(cur)
+			},
+			DeleteFunc: c.enqueueService,
+		},
+		resyncPeriod,
+	)
+
+	c.endpointsInformer.AddEventHandlerWithResyncPeriod(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: c.enqueueServiceForEndpoints,
+			UpdateFunc: func(old, cur interface{}) {
+				c.enqueueServiceForEndpoints(cur)
+			},
+			DeleteFunc: c.enqueueServiceForEndpoints,
+		},
+		resyncPeriod,
+	)
+
+	c.localIPDetector.AddEventHandler(c.onLocalIPUpdate)
+	c.cluster.AddClusterEventHandler(c.enqueueServicesByExternalIPPool)
+	return c, nil
+}
+
+func (c *ServiceExternalIPController) enqueueService(obj interface{}) {
+	service, ok := obj.(*corev1.Service)
+	if !ok {
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			klog.Errorf("Received unexpected object: %v", obj)
+			return
+		}
+		service, ok = deletedState.Obj.(*corev1.Service)
+		if !ok {
+			klog.Errorf("DeletedFinalStateUnknown contains non-Service object: %v", deletedState.Obj)
+			return
+		}
+	}
+	key := apimachinerytypes.NamespacedName{
+		Namespace: service.Namespace,
+		Name:      service.Name,
+	}
+	c.queue.Add(key)
+}
+
+func (c *ServiceExternalIPController) enqueueServiceForEndpoints(obj interface{}) {
+	endpoints, ok := obj.(*corev1.Endpoints)
+	if !ok {
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			klog.Errorf("Received unexpected object: %v", obj)
+			return
+		}
+		endpoints, ok = deletedState.Obj.(*corev1.Endpoints)
+		if !ok {
+			klog.Errorf("DeletedFinalStateUnknown contains non-Endpoint object: %v", deletedState.Obj)
+			return
+		}
+	}
+	service, err := c.serviceLister.Services(endpoints.Namespace).Get(endpoints.Name)
+	if err != nil {
+		klog.ErrorS(err, "failed to get Service for Endpoint", "namespace", endpoints.Namespace, "name", endpoints.Name)
+		return
+	}
+	// we only care services with ServiceExternalTrafficPolicy setting to local.
+	if service.Spec.ExternalTrafficPolicy != corev1.ServiceExternalTrafficPolicyTypeLocal || service.Spec.Type != corev1.ServiceTypeLoadBalancer {
+		return
+	}
+	c.queue.Add(apimachinerytypes.NamespacedName{
+		Namespace: service.Namespace,
+		Name:      service.Name,
+	})
+}
+
+// enqueueServicesByExternalIPPool enqueues all services that refer to the provided ExternalIPPool,
+// the ExternalIPPool is affected by a Node update/create/delete event or Node leaves/join cluster
+// event or ExternalIPPool changed event.
+func (c *ServiceExternalIPController) enqueueServicesByExternalIPPool(eipName string) {
+	objects, _ := c.serviceInformer.GetIndexer().ByIndex(externalIPPoolIndex, eipName)
+	for _, object := range objects {
+		service := object.(*corev1.Service)
+		c.queue.Add(apimachinerytypes.NamespacedName{
+			Namespace: service.Namespace,
+			Name:      service.Name,
+		})
+	}
+	klog.InfoS("Detected ExternalIPPool event", "ExternalIPPool", eipName, "enqueueServiceNum", len(objects))
+}
+
+// Run will create defaultWorkers workers (go routines) which will process the Service events from the
+// workqueue.
+func (c *ServiceExternalIPController) Run(stopCh <-chan struct{}) {
+	defer c.queue.ShutDown()
+
+	klog.Infof("Starting %s", controllerName)
+	defer klog.Infof("Shutting down %s", controllerName)
+
+	if !cache.WaitForNamedCacheSync(controllerName, stopCh, c.serviceListerSynced, c.endpointsListerSynced) {
+		return
+	}
+
+	c.removeStaleExternalIPs()
+
+	for i := 0; i < defaultWorkers; i++ {
+		go wait.Until(c.worker, time.Second, stopCh)
+	}
+	<-stopCh
+}
+
+// removeStaleExternalIPs unassigns stale external IPs that shouldn't be present on this Node.
+// This function will only delete IPs which are caused by Service changes when the agent on this Node was
+// not running. Those IPs should be deleted caused by migration will be deleted by processNextWorkItem.
+func (c *ServiceExternalIPController) removeStaleExternalIPs() {
+	desiredExternalIPs := sets.NewString()
+	services, _ := c.serviceLister.List(labels.Everything())
+	for _, service := range services {
+		if service.Spec.Type == corev1.ServiceTypeLoadBalancer &&
+			service.ObjectMeta.Annotations[types.ServiceExternalIPPoolAnnotationKey] != "" &&
+			len(service.Status.LoadBalancer.Ingress) != 0 {
+			desiredExternalIPs.Insert(service.Status.LoadBalancer.Ingress[0].IP)
+		}
+	}
+	actualExternalIPs := c.ipAssigner.AssignedIPs()
+	for ip := range actualExternalIPs.Difference(desiredExternalIPs) {
+		if err := c.ipAssigner.UnassignIP(ip); err != nil {
+			klog.ErrorS(err, "Failed to clean up stale service external IP", "ip", ip)
+		}
+	}
+}
+
+func (c *ServiceExternalIPController) onLocalIPUpdate(ip string, added bool) {
+	services, _ := c.serviceInformer.GetIndexer().ByIndex(externalIPIndex, ip)
+	if len(services) == 0 {
+		return
+	}
+	if added {
+		klog.Infof("Detected service external IP address %s added to this Node", ip)
+	} else {
+		klog.Infof("Detected service external IP address %s deleted from this Node", ip)
+	}
+	for _, s := range services {
+		c.enqueueService(s)
+	}
+}
+
+// worker is a long-running function that will continually call the processNextWorkItem function in
+// order to read and process a message on the workqueue.
+func (c *ServiceExternalIPController) worker() {
+	for c.processNextWorkItem() {
+	}
+}
+
+func (c *ServiceExternalIPController) processNextWorkItem() bool {
+	obj, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(obj)
+	if key, ok := obj.(apimachinerytypes.NamespacedName); !ok {
+		c.queue.Forget(obj)
+		klog.Errorf("Expected NamespacedName in work queue but got %#v", obj)
+		return true
+	} else if err := c.syncService(key); err == nil {
+		// If no error occurs we Forget this item so it does not get queued again until
+		// another change happens.
+		c.queue.Forget(key)
+	} else {
+		// Put the item back on the workqueue to handle any transient errors.
+		c.queue.AddRateLimited(key)
+		klog.ErrorS(err, "Error syncing Service", "Service", key)
+	}
+	return true
+}
+
+func (c *ServiceExternalIPController) deleteService(service apimachinerytypes.NamespacedName) error {
+	c.externalIPStatesMutex.Lock()
+	defer c.externalIPStatesMutex.Unlock()
+	var state externalIPState
+	var exist bool
+	if state, exist = c.externalIPStates[service]; !exist {
+		return nil
+	}
+	if err := c.ipAssigner.UnassignIP(state.ip); err != nil {
+		return err
+	}
+	delete(c.externalIPStates, service)
+	return nil
+}
+
+func (c *ServiceExternalIPController) getServiceState(service *corev1.Service) (externalIPState, bool) {
+	c.externalIPStatesMutex.RLock()
+	defer c.externalIPStatesMutex.RUnlock()
+	name := apimachinerytypes.NamespacedName{
+		Namespace: service.Namespace,
+		Name:      service.Name,
+	}
+	state, exist := c.externalIPStates[name]
+	return state, exist
+}
+
+func (c *ServiceExternalIPController) saveServiceState(service *corev1.Service, state externalIPState) {
+	c.externalIPStatesMutex.Lock()
+	defer c.externalIPStatesMutex.Unlock()
+	name := apimachinerytypes.NamespacedName{
+		Namespace: service.Namespace,
+		Name:      service.Name,
+	}
+	c.externalIPStates[name] = state
+}
+
+func (c *ServiceExternalIPController) getServiceExternalIPAndHostname(service *corev1.Service) (string, string) {
+	if len(service.Status.LoadBalancer.Ingress) == 0 {
+		return "", ""
+	}
+	return service.Status.LoadBalancer.Ingress[0].IP, service.Status.LoadBalancer.Ingress[0].Hostname
+}
+
+func (c *ServiceExternalIPController) syncService(key apimachinerytypes.NamespacedName) error {
+	startTime := time.Now()
+	defer func() {
+		klog.V(4).Infof("Finished syncing Service for %s. (%v)", key, time.Since(startTime))
+	}()
+
+	service, err := c.serviceLister.Services(key.Namespace).Get(key.Name)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return c.deleteService(key)
+		}
+		return err
+	}
+
+	if service.Spec.Type != corev1.ServiceTypeLoadBalancer {
+		return c.deleteService(key)
+	}
+
+	state, exist := c.getServiceState(service)
+	currentExternalIP, currentHostname := c.getServiceExternalIPAndHostname(service)
+	if exist && state.ip != currentExternalIP {
+		// External IP of the Service has changed. Delete the previous assigned IP if exists.
+		if err := c.deleteService(key); err != nil {
+			return err
+		}
+	}
+
+	ipPool := service.ObjectMeta.Annotations[types.ServiceExternalIPPoolAnnotationKey]
+	if currentExternalIP == "" || ipPool == "" {
+		return nil
+	}
+
+	selectNode := true
+	var filters []func(string) bool
+	if service.Spec.ExternalTrafficPolicy == corev1.ServiceExternalTrafficPolicyTypeLocal {
+		nodes, err := c.nodesHasHealthyServiceEndpoint(service)
+		if err != nil {
+			return err
+		}
+		// Avoid unnecessary migration caused by Endpoints changes.
+		if currentHostname != "" && c.cluster.AliveNodes().Has(currentHostname) && nodes.Has(currentHostname) {
+			selectNode = false
+			state = externalIPState{
+				ip:           currentExternalIP,
+				assignedNode: currentHostname,
+			}
+			c.saveServiceState(service, state)
+		} else {
+			filters = append(filters, func(s string) bool {
+				return nodes.Has(s)
+			})
+		}
+	}
+
+	if selectNode {
+		nodeName, err := c.cluster.SelectNodeForIP(currentExternalIP, ipPool, filters...)
+		if err != nil {
+			if err == memberlist.ErrNoNodeAvailable {
+				// No Node is available for the moment. The Service will be requeued by Endpoints, Node, or Memberlist update events.
+				klog.InfoS("No Node available", "ip", currentExternalIP, "ipPool", ipPool)
+				return nil
+			}
+			return err
+		}
+		klog.InfoS("Select Node for IP", "service", key, "nodeName", nodeName, "currentExternalIP", currentExternalIP, "ipPool", ipPool)
+		state = externalIPState{
+			ip:           currentExternalIP,
+			assignedNode: nodeName,
+		}
+		c.saveServiceState(service, state)
+	}
+	// Update the hostname field of Service status and assign the external IP if this Node is selected.
+	if state.assignedNode == c.nodeName {
+		if service.Status.LoadBalancer.Ingress[0].Hostname != state.assignedNode {
+			serviceToUpdate := service.DeepCopy()
+			serviceToUpdate.Status.LoadBalancer.Ingress[0].Hostname = state.assignedNode
+			if _, err = c.client.CoreV1().Services(serviceToUpdate.Namespace).UpdateStatus(context.TODO(), serviceToUpdate, v1.UpdateOptions{}); err != nil {
+				return err
+			}
+		}
+		return c.ipAssigner.AssignIP(currentExternalIP)
+	}
+	return c.ipAssigner.UnassignIP(currentExternalIP)
+}
+
+// nodesHasHealthyServiceEndpoint returns the set of Nodes which has at least one healthy endpoint.
+func (c *ServiceExternalIPController) nodesHasHealthyServiceEndpoint(service *corev1.Service) (sets.String, error) {
+	nodes := sets.NewString()
+	endpoints, err := c.endpointsLister.Endpoints(service.Namespace).Get(service.Name)
+	if err != nil {
+		return nodes, err
+	}
+	for _, subset := range endpoints.Subsets {
+		for _, ep := range subset.Addresses {
+			if ep.NodeName == nil {
+				continue
+			}
+			nodes.Insert(*ep.NodeName)
+		}
+	}
+	return nodes, nil
+}

--- a/pkg/agent/controller/serviceexternalip/controller_test.go
+++ b/pkg/agent/controller/serviceexternalip/controller_test.go
@@ -1,0 +1,768 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package serviceexternalip
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	apimachinerytypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/util/workqueue"
+
+	ipassignertest "antrea.io/antrea/pkg/agent/ipassigner/testing"
+	"antrea.io/antrea/pkg/agent/memberlist"
+	"antrea.io/antrea/pkg/agent/types"
+)
+
+const (
+	fakeNode1              = "node1"
+	fakeNode2              = "node2"
+	fakeExternalIPPoolName = "pool1"
+	fakeServiceExternalIP1 = "1.2.3.4"
+	fakeServiceExternalIP2 = "1.2.3.5"
+)
+
+var (
+	servicePolicyCluster = makeService("svc1", "ns1", corev1.ServiceTypeLoadBalancer, corev1.ServiceExternalTrafficPolicyTypeCluster, fakeExternalIPPoolName, fakeServiceExternalIP1)
+	servicePolicyLocal   = makeService("svc2", "ns1", corev1.ServiceTypeLoadBalancer, corev1.ServiceExternalTrafficPolicyTypeLocal, fakeExternalIPPoolName, fakeServiceExternalIP1)
+)
+
+type fakeMemberlistCluster struct {
+	nodes  []string
+	hashFn func([]string) []string
+}
+
+func fakeHashFn(invert bool) func([]string) []string {
+	return func(s []string) []string {
+		hashed := make([]string, len(s))
+		copy(hashed, s)
+		sort.Strings(hashed)
+		if invert {
+			i, j := 0, len(hashed)-1
+			for i < j {
+				hashed[i], hashed[j] = hashed[j], hashed[i]
+				i++
+				j--
+			}
+		}
+		return hashed
+	}
+}
+
+var _ memberlist.Interface = (*fakeMemberlistCluster)(nil)
+
+func (f *fakeMemberlistCluster) AddClusterEventHandler(h memberlist.ClusterNodeEventHandler) {
+
+}
+
+func (f *fakeMemberlistCluster) AliveNodes() sets.String {
+	return sets.NewString(f.nodes...)
+}
+
+func (f *fakeMemberlistCluster) SelectNodeForIP(ip, externalIPPool string, filters ...func(string) bool) (string, error) {
+	var selectNode string
+	for _, n := range f.hashFn(f.nodes) {
+		passed := true
+		for _, f := range filters {
+			if !f(n) {
+				passed = false
+				break
+			}
+		}
+		if passed {
+			selectNode = n
+			break
+		}
+	}
+	if selectNode == "" {
+		return selectNode, fmt.Errorf("no Node available for IP %s and externalIPPool %s", ip, externalIPPool)
+	}
+	return selectNode, nil
+}
+
+type fakeController struct {
+	*ServiceExternalIPController
+	mockController        *gomock.Controller
+	clientset             *fake.Clientset
+	informerFactory       informers.SharedInformerFactory
+	mockIPAssigner        *ipassignertest.MockIPAssigner
+	fakeMemberlistCluster *fakeMemberlistCluster
+}
+
+func newFakeController(t *testing.T, objs ...runtime.Object) *fakeController {
+	controller := gomock.NewController(t)
+	clientset := fake.NewSimpleClientset(objs...)
+	mockIPAssigner := ipassignertest.NewMockIPAssigner(controller)
+	informerFactory := informers.NewSharedInformerFactory(clientset, 0)
+
+	serviceInformer := informerFactory.Core().V1().Services()
+	endpointInformer := informerFactory.Core().V1().Endpoints()
+
+	memberlistCluster := &fakeMemberlistCluster{
+		// default fake hash function which will return the sorted string slice in ascending order.
+		hashFn: fakeHashFn(false),
+	}
+	eipController := &ServiceExternalIPController{
+		nodeName:              fakeNode1,
+		serviceInformer:       serviceInformer.Informer(),
+		serviceListerSynced:   serviceInformer.Informer().HasSynced,
+		serviceLister:         serviceInformer.Lister(),
+		endpointsInformer:     endpointInformer.Informer(),
+		endpointsListerSynced: endpointInformer.Informer().HasSynced,
+		endpointsLister:       endpointInformer.Lister(),
+		queue:                 workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(minRetryDelay, maxRetryDelay), "serviceExternalIP"),
+		client:                clientset,
+		externalIPStates:      make(map[apimachinerytypes.NamespacedName]externalIPState),
+		cluster:               memberlistCluster,
+		ipAssigner:            mockIPAssigner,
+	}
+	return &fakeController{
+		ServiceExternalIPController: eipController,
+		mockController:              controller,
+		clientset:                   clientset,
+		informerFactory:             informerFactory,
+		mockIPAssigner:              mockIPAssigner,
+		fakeMemberlistCluster:       memberlistCluster,
+	}
+}
+
+func makeService(name, namespace string, serviceType corev1.ServiceType,
+	trafficPolicy corev1.ServiceExternalTrafficPolicyType, ipPool, externalIP string) *corev1.Service {
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Type:                  serviceType,
+			ExternalTrafficPolicy: trafficPolicy,
+		},
+	}
+	if externalIP != "" {
+		service.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{
+			{IP: externalIP},
+		}
+	}
+	if ipPool != "" {
+		service.Annotations = map[string]string{
+			types.ServiceExternalIPPoolAnnotationKey: ipPool,
+		}
+	}
+	return service
+}
+
+func makeEndpoints(name, namespace string, addresses, notReadyAddresses map[string]string) *corev1.Endpoints {
+	var addr, notReadyAddr []corev1.EndpointAddress
+	for k, v := range addresses {
+		ip := k
+		addr = append(addr, corev1.EndpointAddress{
+			IP:       ip,
+			NodeName: stringPtr(v),
+		})
+	}
+	for k, v := range notReadyAddresses {
+		ip := k
+		notReadyAddr = append(notReadyAddr, corev1.EndpointAddress{
+			IP:       ip,
+			NodeName: stringPtr(v),
+		})
+	}
+	service := &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+
+		Subsets: []corev1.EndpointSubset{
+			{
+				Addresses:         addr,
+				NotReadyAddresses: notReadyAddr,
+			},
+		},
+	}
+	return service
+}
+
+func TestCreateService(t *testing.T) {
+	tests := []struct {
+		name                     string
+		existingEndpoints        []*corev1.Endpoints
+		serviceToCreate          *corev1.Service
+		healthyNodes             []string
+		overrideHashFn           func([]string) []string
+		expectedCalls            func(mockIPAssigner *ipassignertest.MockIPAssigner)
+		expectedExternalIPStates map[apimachinerytypes.NamespacedName]externalIPState
+		expectError              bool
+	}{
+		{
+			name:              "new Service created and local Node selected",
+			existingEndpoints: nil,
+			serviceToCreate:   servicePolicyCluster,
+			healthyNodes:      []string{fakeNode1, fakeNode2},
+			expectedCalls: func(mockIPAssigner *ipassignertest.MockIPAssigner) {
+				mockIPAssigner.EXPECT().AssignIP(fakeServiceExternalIP1)
+			},
+			expectedExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
+				keyFor(servicePolicyCluster): {
+					ip:           fakeServiceExternalIP1,
+					assignedNode: fakeNode1,
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:              "new Service created and local Node not selected",
+			existingEndpoints: nil,
+			serviceToCreate:   servicePolicyCluster,
+			healthyNodes:      []string{fakeNode1, fakeNode2},
+			overrideHashFn:    fakeHashFn(true),
+			expectedCalls: func(mockIPAssigner *ipassignertest.MockIPAssigner) {
+				mockIPAssigner.EXPECT().UnassignIP(fakeServiceExternalIP1)
+			},
+			expectedExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
+				keyFor(servicePolicyCluster): {
+					ip:           fakeServiceExternalIP1,
+					assignedNode: fakeNode2,
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "new Service created with ExternalTrafficPolicy=Local and local Node selected",
+			existingEndpoints: []*corev1.Endpoints{
+				makeEndpoints(servicePolicyLocal.Name, servicePolicyLocal.Namespace,
+					map[string]string{
+						"2.3.4.5": fakeNode1,
+					},
+					nil),
+			},
+			serviceToCreate: servicePolicyLocal,
+			healthyNodes:    []string{fakeNode1, fakeNode2},
+			expectedCalls: func(mockIPAssigner *ipassignertest.MockIPAssigner) {
+				mockIPAssigner.EXPECT().AssignIP(fakeServiceExternalIP1)
+			},
+			expectedExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
+				keyFor(servicePolicyLocal): {
+					ip:           fakeServiceExternalIP1,
+					assignedNode: fakeNode1,
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "new Service created with ExternalTrafficPolicy=Local and local Node not Selected",
+			existingEndpoints: []*corev1.Endpoints{
+				makeEndpoints(servicePolicyLocal.Name, servicePolicyLocal.Namespace,
+					map[string]string{
+						"2.3.4.5": fakeNode1,
+						"2.3.4.6": fakeNode2,
+					},
+					map[string]string{
+						"2.3.4.7": fakeNode2,
+					},
+				),
+			},
+			serviceToCreate: servicePolicyLocal,
+			healthyNodes:    []string{fakeNode1, fakeNode2},
+			// invert the sorted string to select other Nodes.
+			overrideHashFn: fakeHashFn(true),
+			expectedCalls: func(mockIPAssigner *ipassignertest.MockIPAssigner) {
+				mockIPAssigner.EXPECT().UnassignIP(fakeServiceExternalIP1)
+			},
+			expectedExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
+				keyFor(servicePolicyLocal): {
+					ip:           fakeServiceExternalIP1,
+					assignedNode: fakeNode2,
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "new Service created with ExternalTrafficPolicy=Local and local Node has no healthy endpoints",
+			existingEndpoints: []*corev1.Endpoints{
+				makeEndpoints(servicePolicyLocal.Name, servicePolicyLocal.Namespace,
+					map[string]string{
+						"2.3.4.6": fakeNode2,
+					},
+					map[string]string{
+						"2.3.4.5": fakeNode1,
+					}),
+			},
+			serviceToCreate: servicePolicyLocal,
+			healthyNodes:    []string{fakeNode1, fakeNode2},
+			expectedCalls: func(mockIPAssigner *ipassignertest.MockIPAssigner) {
+				mockIPAssigner.EXPECT().UnassignIP(fakeServiceExternalIP1)
+			},
+			expectedExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
+				keyFor(servicePolicyLocal): {
+					ip:           fakeServiceExternalIP1,
+					assignedNode: fakeNode2,
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "new Service created with ExternalTrafficPolicy=Local and no Nodes has healthy endpoints",
+			existingEndpoints: []*corev1.Endpoints{
+				makeEndpoints(servicePolicyLocal.Name, servicePolicyLocal.Namespace,
+					nil,
+					map[string]string{
+						"2.3.4.5": fakeNode1,
+						"2.3.4.6": fakeNode2,
+					}),
+			},
+			serviceToCreate: servicePolicyLocal,
+			healthyNodes:    []string{fakeNode1, fakeNode2},
+			expectedCalls: func(mockIPAssigner *ipassignertest.MockIPAssigner) {
+			},
+			expectedExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{},
+			expectError:              true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objs := []runtime.Object{}
+			for _, s := range tt.existingEndpoints {
+				objs = append(objs, s)
+			}
+			objs = append(objs, tt.serviceToCreate)
+			c := newFakeController(t, objs...)
+			defer c.mockController.Finish()
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+			c.informerFactory.Start(stopCh)
+			c.informerFactory.WaitForCacheSync(stopCh)
+			c.fakeMemberlistCluster.nodes = tt.healthyNodes
+			if tt.overrideHashFn != nil {
+				c.fakeMemberlistCluster.hashFn = tt.overrideHashFn
+			}
+			tt.expectedCalls(c.mockIPAssigner)
+			err := c.syncService(keyFor(tt.serviceToCreate))
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.expectedExternalIPStates, c.externalIPStates)
+		})
+	}
+}
+
+func TestUpdateService(t *testing.T) {
+	serviceExternlTrafficPolicyClusterUpdatedExternalIP := servicePolicyCluster.DeepCopy()
+	serviceExternlTrafficPolicyClusterUpdatedExternalIP.Status.LoadBalancer.Ingress[0].IP = fakeServiceExternalIP2
+
+	serviceExternalTrafficLocalWithNodeSelectd := servicePolicyLocal.DeepCopy()
+	serviceExternalTrafficLocalWithNodeSelectd.Status.LoadBalancer.Ingress[0].Hostname = fakeNode1
+
+	serviceExternalTrafficLocalUpdatedHostname := servicePolicyLocal.DeepCopy()
+	serviceExternalTrafficLocalUpdatedHostname.Status.LoadBalancer.Ingress[0].Hostname = fakeNode2
+
+	serviceChangedType := servicePolicyCluster.DeepCopy()
+	serviceChangedType.Spec.Type = corev1.ServiceTypeClusterIP
+
+	serviceExternalIPRecalimed := servicePolicyCluster.DeepCopy()
+	serviceExternalIPRecalimed.Status.LoadBalancer.Ingress = nil
+
+	serviceChangedExternalTrafficPolicy := servicePolicyCluster.DeepCopy()
+	serviceChangedExternalTrafficPolicy.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeLocal
+
+	tests := []struct {
+		name                     string
+		endpoints                []*corev1.Endpoints
+		serviceToUpdate          *corev1.Service
+		previousExternalIPStates map[apimachinerytypes.NamespacedName]externalIPState
+		expectedExternalIPStates map[apimachinerytypes.NamespacedName]externalIPState
+		healthyNodes             []string
+		overrideHashFn           func([]string) []string
+		expectedCalls            func(mockIPAssigner *ipassignertest.MockIPAssigner)
+		expectError              bool
+	}{
+		{
+			name:            "Service updated external IP and local Node selected",
+			endpoints:       nil,
+			serviceToUpdate: serviceExternlTrafficPolicyClusterUpdatedExternalIP,
+			previousExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
+				keyFor(serviceExternlTrafficPolicyClusterUpdatedExternalIP): {fakeServiceExternalIP1, fakeNode1},
+			},
+			expectedExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
+				keyFor(serviceExternlTrafficPolicyClusterUpdatedExternalIP): {fakeServiceExternalIP2, fakeNode1},
+			},
+			healthyNodes: []string{fakeNode1, fakeNode2},
+			expectedCalls: func(mockIPAssigner *ipassignertest.MockIPAssigner) {
+				mockIPAssigner.EXPECT().UnassignIP(fakeServiceExternalIP1)
+				mockIPAssigner.EXPECT().AssignIP(fakeServiceExternalIP2)
+			},
+			expectError: false,
+		},
+		{
+			name:            "Service updated external IP and local Node not selected",
+			endpoints:       nil,
+			serviceToUpdate: serviceExternlTrafficPolicyClusterUpdatedExternalIP,
+			previousExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
+				keyFor(serviceExternlTrafficPolicyClusterUpdatedExternalIP): {fakeServiceExternalIP1, fakeNode1},
+			},
+			expectedExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
+				keyFor(serviceExternlTrafficPolicyClusterUpdatedExternalIP): {fakeServiceExternalIP2, fakeNode2},
+			},
+			healthyNodes:   []string{fakeNode1, fakeNode2},
+			overrideHashFn: fakeHashFn(true),
+			expectedCalls: func(mockIPAssigner *ipassignertest.MockIPAssigner) {
+				mockIPAssigner.EXPECT().UnassignIP(fakeServiceExternalIP1)
+				mockIPAssigner.EXPECT().UnassignIP(fakeServiceExternalIP2)
+			},
+			expectError: false,
+		},
+		{
+			name:            "Service changed type to ClusterIP",
+			endpoints:       nil,
+			serviceToUpdate: serviceChangedType,
+			previousExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
+				keyFor(serviceExternlTrafficPolicyClusterUpdatedExternalIP): {fakeServiceExternalIP1, fakeNode1},
+			},
+			expectedExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{},
+			healthyNodes:             []string{fakeNode1, fakeNode2},
+			expectedCalls: func(mockIPAssigner *ipassignertest.MockIPAssigner) {
+				mockIPAssigner.EXPECT().UnassignIP(fakeServiceExternalIP1)
+			},
+			expectError: false,
+		},
+		{
+			name:            "Service external IP reclaimed",
+			endpoints:       nil,
+			serviceToUpdate: serviceChangedType,
+			previousExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
+				keyFor(serviceExternlTrafficPolicyClusterUpdatedExternalIP): {fakeServiceExternalIP1, fakeNode1},
+			},
+			expectedExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{},
+			healthyNodes:             []string{fakeNode1, fakeNode2},
+			expectedCalls: func(mockIPAssigner *ipassignertest.MockIPAssigner) {
+				mockIPAssigner.EXPECT().UnassignIP(fakeServiceExternalIP1)
+			},
+			expectError: false,
+		},
+		{
+			name: "Service changed ExternalTrafficPolicy to local and local Node have to healthy Endpoints",
+			endpoints: []*corev1.Endpoints{
+				makeEndpoints(serviceChangedExternalTrafficPolicy.Name, serviceChangedExternalTrafficPolicy.Namespace,
+					map[string]string{
+						"2.3.4.6": fakeNode2,
+					}, map[string]string{
+						"2.3.4.5": fakeNode1,
+					}),
+			},
+			serviceToUpdate: serviceChangedExternalTrafficPolicy,
+			previousExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
+				keyFor(serviceChangedExternalTrafficPolicy): {fakeServiceExternalIP1, fakeNode1},
+			},
+			expectedExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
+				keyFor(serviceChangedExternalTrafficPolicy): {fakeServiceExternalIP1, fakeNode2},
+			},
+			healthyNodes: []string{fakeNode1, fakeNode2},
+			expectedCalls: func(mockIPAssigner *ipassignertest.MockIPAssigner) {
+				mockIPAssigner.EXPECT().UnassignIP(fakeServiceExternalIP1)
+			},
+			expectError: false,
+		},
+		{
+			name:            "local Node no longer selected",
+			endpoints:       nil,
+			serviceToUpdate: servicePolicyCluster,
+			previousExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
+				keyFor(servicePolicyCluster): {fakeServiceExternalIP1, fakeNode1},
+			},
+			expectedExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
+				keyFor(servicePolicyCluster): {fakeServiceExternalIP1, fakeNode2},
+			},
+			healthyNodes:   []string{fakeNode1, fakeNode2},
+			overrideHashFn: fakeHashFn(true),
+			expectedCalls: func(mockIPAssigner *ipassignertest.MockIPAssigner) {
+				mockIPAssigner.EXPECT().UnassignIP(fakeServiceExternalIP1)
+			},
+			expectError: false,
+		},
+		{
+			name: "local Node no longer have healy endpoints",
+			endpoints: []*corev1.Endpoints{
+				makeEndpoints(servicePolicyLocal.Name, servicePolicyLocal.Namespace,
+					map[string]string{
+						"2.3.4.6": fakeNode2,
+					}, map[string]string{
+						"2.3.4.5": fakeNode1,
+					}),
+			},
+			serviceToUpdate: serviceExternalTrafficLocalWithNodeSelectd,
+			previousExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
+				keyFor(servicePolicyLocal): {fakeServiceExternalIP1, fakeNode1},
+			},
+			expectedExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
+				keyFor(servicePolicyLocal): {fakeServiceExternalIP1, fakeNode2},
+			},
+			healthyNodes: []string{fakeNode1, fakeNode2},
+			expectedCalls: func(mockIPAssigner *ipassignertest.MockIPAssigner) {
+				mockIPAssigner.EXPECT().UnassignIP(fakeServiceExternalIP1)
+			},
+			expectError: false,
+		},
+		{
+			name: "should not migrate to other Nodes if selected Node still have healthy endpoints",
+			endpoints: []*corev1.Endpoints{
+				makeEndpoints(servicePolicyLocal.Name, servicePolicyLocal.Namespace,
+					map[string]string{
+						"2.3.4.5": fakeNode1,
+						"2.3.4.6": fakeNode2,
+					},
+					nil,
+				),
+			},
+			overrideHashFn:  fakeHashFn(true),
+			serviceToUpdate: serviceExternalTrafficLocalWithNodeSelectd,
+			previousExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
+				keyFor(servicePolicyLocal): {fakeServiceExternalIP1, fakeNode1},
+			},
+			expectedExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
+				keyFor(servicePolicyLocal): {fakeServiceExternalIP1, fakeNode1},
+			},
+			healthyNodes: []string{fakeNode1, fakeNode2},
+			expectedCalls: func(mockIPAssigner *ipassignertest.MockIPAssigner) {
+				mockIPAssigner.EXPECT().AssignIP(fakeServiceExternalIP1)
+			},
+			expectError: false,
+		},
+		{
+			name: "other Node could promote itself as the new owner",
+			endpoints: []*corev1.Endpoints{
+				makeEndpoints(servicePolicyLocal.Name, servicePolicyLocal.Namespace,
+					map[string]string{
+						"2.3.4.5": fakeNode1,
+						"2.3.4.6": fakeNode2,
+					},
+					nil,
+				),
+			},
+			serviceToUpdate: serviceExternalTrafficLocalUpdatedHostname,
+			previousExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
+				keyFor(servicePolicyLocal): {fakeServiceExternalIP1, fakeNode1},
+			},
+			expectedExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
+				keyFor(servicePolicyLocal): {fakeServiceExternalIP1, fakeNode2},
+			},
+			healthyNodes: []string{fakeNode1, fakeNode2},
+			expectedCalls: func(mockIPAssigner *ipassignertest.MockIPAssigner) {
+				mockIPAssigner.EXPECT().UnassignIP(fakeServiceExternalIP1)
+			},
+			expectError: false,
+		},
+		{
+			name: "agent restarts and should not select new Node if current selected Node still healthy and have healthy endpoints",
+			endpoints: []*corev1.Endpoints{
+				makeEndpoints(servicePolicyLocal.Name, servicePolicyLocal.Namespace,
+					map[string]string{
+						"2.3.4.5": fakeNode1,
+						"2.3.4.6": fakeNode2,
+					},
+					nil,
+				),
+			},
+			overrideHashFn:           fakeHashFn(true),
+			serviceToUpdate:          serviceExternalTrafficLocalWithNodeSelectd,
+			previousExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{},
+			expectedExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
+				keyFor(servicePolicyLocal): {fakeServiceExternalIP1, fakeNode1},
+			},
+			healthyNodes: []string{fakeNode1, fakeNode2},
+			expectedCalls: func(mockIPAssigner *ipassignertest.MockIPAssigner) {
+				mockIPAssigner.EXPECT().AssignIP(fakeServiceExternalIP1)
+			},
+			expectError: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objs := []runtime.Object{}
+			for _, s := range tt.endpoints {
+				objs = append(objs, s)
+			}
+			objs = append(objs, tt.serviceToUpdate)
+			c := newFakeController(t, objs...)
+			c.externalIPStates = tt.previousExternalIPStates
+			defer c.mockController.Finish()
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+			c.informerFactory.Start(stopCh)
+			c.informerFactory.WaitForCacheSync(stopCh)
+			c.fakeMemberlistCluster.nodes = tt.healthyNodes
+			if tt.overrideHashFn != nil {
+				c.fakeMemberlistCluster.hashFn = tt.overrideHashFn
+			}
+			tt.expectedCalls(c.mockIPAssigner)
+			err := c.syncService(keyFor(tt.serviceToUpdate))
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.expectedExternalIPStates, c.externalIPStates)
+		})
+	}
+}
+
+func TestStaleServiceExternalIPRemoval(t *testing.T) {
+	service3 := servicePolicyCluster.DeepCopy()
+	service3.Name = "svc3"
+	service3.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{
+		{IP: fakeServiceExternalIP2},
+	}
+	tests := []struct {
+		name             string
+		existingServices []*corev1.Service
+		assignedIPs      []string
+		expectedCalls    func(mockIPAssigner *ipassignertest.MockIPAssigner)
+	}{
+		{
+			name:             "should keep assigned IPs if corresponding Services are present",
+			existingServices: []*corev1.Service{servicePolicyCluster, service3},
+			assignedIPs:      []string{fakeNode1, fakeNode2},
+			expectedCalls: func(mockIPAssigner *ipassignertest.MockIPAssigner) {
+				mockIPAssigner.EXPECT().AssignedIPs().DoAndReturn(
+					func() interface{} {
+						return sets.NewString(fakeServiceExternalIP1, fakeServiceExternalIP2)
+					},
+				)
+			},
+		},
+		{
+			name:             "should cleanup stale assigned IPs",
+			existingServices: []*corev1.Service{servicePolicyCluster},
+			assignedIPs:      []string{fakeNode1, fakeNode2},
+			expectedCalls: func(mockIPAssigner *ipassignertest.MockIPAssigner) {
+				mockIPAssigner.EXPECT().AssignedIPs().DoAndReturn(
+					func() interface{} {
+						return sets.NewString(fakeServiceExternalIP1, fakeServiceExternalIP2)
+					},
+				)
+				mockIPAssigner.EXPECT().UnassignIP(fakeServiceExternalIP2)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objs := []runtime.Object{}
+			for _, s := range tt.existingServices {
+				objs = append(objs, s)
+			}
+			c := newFakeController(t, objs...)
+			defer c.mockController.Finish()
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+			c.informerFactory.Start(stopCh)
+			c.informerFactory.WaitForCacheSync(stopCh)
+			tt.expectedCalls(c.mockIPAssigner)
+			c.removeStaleExternalIPs()
+		})
+	}
+}
+
+func keyFor(svc *corev1.Service) apimachinerytypes.NamespacedName {
+	return apimachinerytypes.NamespacedName{
+		Namespace: svc.Namespace,
+		Name:      svc.Name,
+	}
+}
+
+func stringPtr(s string) *string {
+	return &s
+}
+
+func TestServiceExternalIPController_nodesHasHealthyServiceEndpoint(t *testing.T) {
+	tests := []struct {
+		name                 string
+		endpoints            []*corev1.Endpoints
+		serviceToTest        *corev1.Service
+		expectedHealthyNodes sets.String
+	}{
+		{
+			name: "all Endpoints are healthy",
+			endpoints: []*corev1.Endpoints{
+				makeEndpoints(servicePolicyLocal.Name, servicePolicyLocal.Namespace,
+					map[string]string{
+						"2.3.4.5": fakeNode1,
+						"2.3.4.6": fakeNode2,
+					},
+					nil,
+				),
+			},
+			serviceToTest:        servicePolicyLocal.DeepCopy(),
+			expectedHealthyNodes: sets.NewString(fakeNode1, fakeNode2),
+		},
+		{
+			name: "one Node does not have any healthy Endpoints",
+			endpoints: []*corev1.Endpoints{
+				makeEndpoints(servicePolicyLocal.Name, servicePolicyLocal.Namespace,
+					map[string]string{
+						"2.3.4.5": fakeNode1,
+					},
+					map[string]string{
+						"2.3.4.6": fakeNode2,
+					},
+				),
+			},
+			serviceToTest:        servicePolicyLocal.DeepCopy(),
+			expectedHealthyNodes: sets.NewString(fakeNode1),
+		},
+		{
+			name: "Node have both healthy Endpoints and unhealthy Endpoints",
+			endpoints: []*corev1.Endpoints{
+				makeEndpoints(servicePolicyLocal.Name, servicePolicyLocal.Namespace,
+					map[string]string{
+						"2.3.4.6": fakeNode1,
+						"2.3.4.8": fakeNode2,
+					},
+					map[string]string{
+						"2.3.4.5": fakeNode1,
+						"2.3.4.7": fakeNode2,
+					},
+				),
+			},
+			serviceToTest:        servicePolicyLocal.DeepCopy(),
+			expectedHealthyNodes: sets.NewString(fakeNode1, fakeNode2),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objs := []runtime.Object{}
+			for _, s := range tt.endpoints {
+				objs = append(objs, s)
+			}
+			c := newFakeController(t, objs...)
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+			c.informerFactory.Start(stopCh)
+			c.informerFactory.WaitForCacheSync(stopCh)
+			got, err := c.nodesHasHealthyServiceEndpoint(tt.serviceToTest)
+			assert.NoError(t, err)
+			assert.True(t, tt.expectedHealthyNodes.Equal(got), "Expected healthy Nodes %v, got %v", tt.expectedHealthyNodes, got)
+		})
+	}
+}

--- a/pkg/agent/ipassigner/ip_assigner_linux.go
+++ b/pkg/agent/ipassigner/ip_assigner_linux.go
@@ -54,7 +54,7 @@ func NewIPAssigner(nodeTransportIPAddr net.IP, dummyDeviceName string) (*ipAssig
 	} else {
 		nodeTransportIPs.IPv4 = nodeTransportIPAddr
 	}
-	_, _, egressInterface, err := util.GetIPNetDeviceFromIP(nodeTransportIPs)
+	_, _, externalInterface, err := util.GetIPNetDeviceFromIP(nodeTransportIPs)
 	if err != nil {
 		return nil, fmt.Errorf("get IPNetDevice from ip %v error: %+v", nodeTransportIPAddr, err)
 	}
@@ -65,7 +65,7 @@ func NewIPAssigner(nodeTransportIPAddr net.IP, dummyDeviceName string) (*ipAssig
 	}
 
 	a := &ipAssigner{
-		externalInterface: egressInterface,
+		externalInterface: externalInterface,
 		dummyDevice:       dummyDevice,
 		assignedIPs:       sets.NewString(),
 	}

--- a/pkg/agent/memberlist/cluster.go
+++ b/pkg/agent/memberlist/cluster.go
@@ -15,16 +15,17 @@
 package memberlist
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"reflect"
 	"sync"
 	"time"
 
-	"github.com/golang/groupcache/consistenthash"
 	"github.com/hashicorp/memberlist"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -35,6 +36,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 
+	"antrea.io/antrea/pkg/agent/consistenthash"
 	"antrea.io/antrea/pkg/apis/crd/v1alpha2"
 	crdinformers "antrea.io/antrea/pkg/client/informers/externalversions/crd/v1alpha2"
 	crdlister "antrea.io/antrea/pkg/client/listers/crd/v1alpha2"
@@ -59,6 +61,9 @@ const (
 	nodeEventTypeUpdate nodeEventType = "Update"
 )
 
+// ErrNoNodeAvailable is the error returned if no Node is chosen in SelectNodeForIP and ShouldSelectIP.
+var ErrNoNodeAvailable = errors.New("no Node available")
+
 type nodeEventType string
 
 // Default Hash Fn is crc32.ChecksumIEEE.
@@ -75,7 +80,13 @@ var mapNodeEventType = map[memberlist.NodeEventType]nodeEventType{
 	memberlist.NodeUpdate: nodeEventTypeUpdate,
 }
 
-type clusterNodeEventHandler func(objName string)
+type ClusterNodeEventHandler func(objName string)
+
+type Interface interface {
+	SelectNodeForIP(ip, externalIPPool string, filters ...func(string) bool) (string, error)
+	AliveNodes() sets.String
+	AddClusterEventHandler(handler ClusterNodeEventHandler)
+}
 
 // Cluster implements ClusterInterface.
 type Cluster struct {
@@ -97,7 +108,7 @@ type Cluster struct {
 	// For example, when a new Node joins the cluster, each Node should compute whether it should still hold all
 	// its existing Egresses, and when a Node leaves the cluster,
 	// each Node should check whether it is now responsible for some of the Egresses from that Node.
-	clusterNodeEventHandlers []clusterNodeEventHandler
+	clusterNodeEventHandlers []ClusterNodeEventHandler
 
 	nodeInformer     coreinformers.NodeInformer
 	nodeLister       corelisters.NodeLister
@@ -113,6 +124,7 @@ type Cluster struct {
 
 // NewCluster returns a new *Cluster.
 func NewCluster(
+	nodeIP net.IP,
 	clusterBindPort int,
 	nodeName string,
 	nodeInformer coreinformers.NodeInformer,
@@ -138,6 +150,7 @@ func NewCluster(
 	conf.Name = c.nodeName
 	conf.BindPort = c.bindPort
 	conf.AdvertisePort = c.bindPort
+	conf.AdvertiseAddr = nodeIP.String()
 	conf.Events = &memberlist.ChannelEventDelegate{Ch: nodeEventCh}
 	conf.LogOutput = ioutil.Discard
 	klog.V(1).InfoS("New memberlist cluster", "config", conf)
@@ -376,7 +389,7 @@ func (c *Cluster) syncConsistentHash(eipName string) error {
 
 	eip, err := c.externalIPPoolLister.Get(eipName)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			c.consistentHashRWMutex.Lock()
 			defer c.consistentHashRWMutex.Unlock()
 			delete(c.consistentHashMap, eipName)
@@ -395,7 +408,7 @@ func (c *Cluster) syncConsistentHash(eipName string) error {
 		if err != nil {
 			return fmt.Errorf("listing Nodes error: %v", err)
 		}
-		aliveNodes := c.aliveNodes()
+		aliveNodes := c.AliveNodes()
 		// Node alive and Node labels match ExternalIPPool nodeSelector.
 		var aliveAndMatchedNodes []string
 		for _, node := range nodes {
@@ -433,7 +446,7 @@ func (c *Cluster) handleClusterNodeEvents(nodeEvent *memberlist.NodeEvent) {
 		// if the Node has failed, ExternalIPPools consistentHash maybe changed, and affected ExternalIPPool should be enqueued.
 		coreNode, err := c.nodeLister.Get(node.Name)
 		if err != nil {
-			if errors.IsNotFound(err) {
+			if apierrors.IsNotFound(err) {
 				// Node has been deleted, and deleteNode handler has been executed.
 				klog.ErrorS(err, "Processing Node event, not found", "eventType", event)
 				return
@@ -449,8 +462,8 @@ func (c *Cluster) handleClusterNodeEvents(nodeEvent *memberlist.NodeEvent) {
 	}
 }
 
-// aliveNodes returns the list of nodeNames in the cluster.
-func (c *Cluster) aliveNodes() sets.String {
+// AliveNodes returns the list of nodeNames in the cluster.
+func (c *Cluster) AliveNodes() sets.String {
 	nodes := sets.NewString()
 	for _, node := range c.mList.Members() {
 		nodes.Insert(node.Name)
@@ -462,7 +475,7 @@ func (c *Cluster) aliveNodes() sets.String {
 // ExternalIPPool. The local Node in the cluster holds the same consistent hash ring for each ExternalIPPool,
 // consistentHash.Get gets the closest item (Node name) in the hash to the provided key (IP), if the name of
 // the local Node is equal to the name of the selected Node, returns true.
-func (c *Cluster) ShouldSelectIP(ip, externalIPPool string) (bool, error) {
+func (c *Cluster) ShouldSelectIP(ip, externalIPPool string, filters ...func(string) bool) (bool, error) {
 	if externalIPPool == "" || ip == "" {
 		return false, nil
 	}
@@ -472,11 +485,29 @@ func (c *Cluster) ShouldSelectIP(ip, externalIPPool string) (bool, error) {
 	if !ok {
 		return false, fmt.Errorf("local Node consistentHashMap has not synced, ExternalIPPool %s", externalIPPool)
 	}
-	node := consistentHash.Get(ip)
-	if node == "" {
-		klog.Warningf("No valid Node chosen for IP %s in externalIPPool %s", ip, externalIPPool)
+	node := consistentHash.GetWithFilters(ip, filters...)
+	if node == "" && len(filters) > 0 {
+		return false, ErrNoNodeAvailable
 	}
 	return node == c.nodeName, nil
+}
+
+// SelectNodeForIP returns the closest item (Node name) in the hash to the provided key (IP) and ExternalIPPool.
+func (c *Cluster) SelectNodeForIP(ip, externalIPPool string, filters ...func(string) bool) (string, error) {
+	if externalIPPool == "" || ip == "" {
+		return "", fmt.Errorf("IP and externalIPPool cannot be empty")
+	}
+	c.consistentHashRWMutex.RLock()
+	defer c.consistentHashRWMutex.RUnlock()
+	consistentHash, ok := c.consistentHashMap[externalIPPool]
+	if !ok {
+		return "", fmt.Errorf("local Node consistentHashMap has not synced, ExternalIPPool %s", externalIPPool)
+	}
+	node := consistentHash.GetWithFilters(ip, filters...)
+	if node == "" {
+		return "", ErrNoNodeAvailable
+	}
+	return node, nil
 }
 
 func (c *Cluster) notify(objName string) {
@@ -487,6 +518,6 @@ func (c *Cluster) notify(objName string) {
 
 // AddClusterEventHandler adds a clusterNodeEventHandler, which will run when consistentHashMap is updated,
 // due to an ExternalIPPool or Node event.
-func (c *Cluster) AddClusterEventHandler(handler clusterNodeEventHandler) {
+func (c *Cluster) AddClusterEventHandler(handler ClusterNodeEventHandler) {
 	c.clusterNodeEventHandlers = append(c.clusterNodeEventHandlers, handler)
 }

--- a/pkg/agent/memberlist/cluster_test.go
+++ b/pkg/agent/memberlist/cluster_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/groupcache/consistenthash"
 	"github.com/hashicorp/memberlist"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
@@ -34,6 +33,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"antrea.io/antrea/pkg/agent/config"
+	"antrea.io/antrea/pkg/agent/consistenthash"
 	"antrea.io/antrea/pkg/apis"
 	crdv1a2 "antrea.io/antrea/pkg/apis/crd/v1alpha2"
 	fakeversioned "antrea.io/antrea/pkg/client/clientset/versioned/fake"
@@ -56,8 +56,8 @@ func newFakeCluster(nodeConfig *config.NodeConfig, stopCh <-chan struct{}, i int
 	crdClient := fakeversioned.NewSimpleClientset([]runtime.Object{}...)
 	crdInformerFactory := crdinformers.NewSharedInformerFactory(crdClient, 0)
 	ipPoolInformer := crdInformerFactory.Crd().V1alpha2().ExternalIPPools()
-
-	cluster, err := NewCluster(port, nodeConfig.Name, nodeInformer, ipPoolInformer)
+	ip := net.ParseIP("127.0.0.1")
+	cluster, err := NewCluster(ip, port, nodeConfig.Name, nodeInformer, ipPoolInformer)
 	if err != nil {
 		return nil, err
 	}
@@ -537,6 +537,71 @@ func TestCluster_ShouldSelectEgress(t *testing.T) {
 				selected, err := fakeCluster.ShouldSelectIP(fakeEgress.Spec.EgressIP, fakeEgress.Spec.ExternalIPPool)
 				assert.NoError(t, err)
 				assert.Equal(t, node == tCase.expectedNode, selected, "Selected Node for Egress not match")
+			}
+		})
+	}
+}
+
+func TestCluster_SelectNodeForIP(t *testing.T) {
+	testCases := []struct {
+		name         string
+		nodeNum      int
+		ip           string
+		expectedNode string
+		filters      []func(string) bool
+	}{
+		{
+			name:         "Select Node from 0 Nodes",
+			nodeNum:      0,
+			ip:           "1.1.1.1",
+			expectedNode: "",
+			filters:      nil,
+		},
+		{
+			name:         "Select Node from 1 Nodes",
+			nodeNum:      1,
+			ip:           "1.1.1.1",
+			expectedNode: "node-0",
+			filters:      nil,
+		},
+		{
+			name:         "Select Node from 3 Nodes",
+			nodeNum:      3,
+			ip:           "1.1.1.1",
+			expectedNode: "node-1",
+			filters:      nil,
+		},
+		{
+			name:         "Select Node from 10 Nodes",
+			nodeNum:      10,
+			ip:           "1.1.1.1",
+			expectedNode: "node-1",
+			filters:      nil,
+		},
+		{
+			name:         "Select Node from 100 Nodes",
+			nodeNum:      100,
+			ip:           "1.1.1.1",
+			expectedNode: "node-79",
+			filters:      nil,
+		},
+	}
+	for _, tCase := range testCases {
+		t.Run(tCase.name, func(t *testing.T) {
+			fakeEIPName := "fakeExternalIPPool"
+			consistentHashMap := newNodeConsistentHashMap()
+			consistentHashMap.Add(genNodes(tCase.nodeNum)...)
+
+			fakeCluster := &Cluster{
+				consistentHashMap: map[string]*consistenthash.Map{fakeEIPName: consistentHashMap},
+			}
+
+			for i := 0; i < tCase.nodeNum; i++ {
+				node := fmt.Sprintf("node-%d", i)
+				fakeCluster.nodeName = node
+				selected, err := fakeCluster.ShouldSelectIP(tCase.ip, fakeEIPName, tCase.filters...)
+				assert.NoError(t, err)
+				assert.Equal(t, node == tCase.expectedNode, selected, "Selected Node not match")
 			}
 		})
 	}

--- a/pkg/agent/types/annotations.go
+++ b/pkg/agent/types/annotations.go
@@ -23,4 +23,7 @@ const (
 
 	// NodeWireGuardPublicAnnotationKey represents the key of the Node's WireGuard public key in the Annotations of the Node.
 	NodeWireGuardPublicAnnotationKey string = "node.antrea.io/wireguard-public-key"
+
+	// ServiceExternalIPPoolAnnotationKey is the key of the Service annotation that specifies the Service's desired external IP pool.
+	ServiceExternalIPPoolAnnotationKey string = "service.antrea.io/external-ip-pool"
 )

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -310,9 +310,12 @@ func installHandlers(c *ExtraConfig, s *genericapiserver.GenericAPIServer) {
 		})
 	}
 
+	if features.DefaultFeatureGate.Enabled(features.Egress) || features.DefaultFeatureGate.Enabled(features.ServiceExternalIP) {
+		s.Handler.NonGoRestfulMux.HandleFunc("/validate/externalippool", webhook.HandlerForValidateFunc(c.externalIPPoolController.ValidateExternalIPPool))
+	}
+
 	if features.DefaultFeatureGate.Enabled(features.Egress) {
 		s.Handler.NonGoRestfulMux.HandleFunc("/validate/egress", webhook.HandlerForValidateFunc(c.egressController.ValidateEgress))
-		s.Handler.NonGoRestfulMux.HandleFunc("/validate/externalippool", webhook.HandlerForValidateFunc(c.externalIPPoolController.ValidateExternalIPPool))
 	}
 
 	if features.DefaultFeatureGate.Enabled(features.AntreaIPAM) {

--- a/pkg/apiserver/handlers/featuregates/handler.go
+++ b/pkg/apiserver/handlers/featuregates/handler.go
@@ -29,8 +29,8 @@ import (
 	"antrea.io/antrea/pkg/util/env"
 )
 
-var controllerGates = sets.NewString("Traceflow", "AntreaPolicy", "Egress", "NetworkPolicyStats", "NodeIPAM")
-var agentGates = sets.NewString("AntreaPolicy", "AntreaProxy", "Egress", "EndpointSlice", "Traceflow", "FlowExporter", "NetworkPolicyStats", "NodePortLocal", "AntreaIPAM", "Multicast")
+var controllerGates = sets.NewString("Traceflow", "AntreaPolicy", "Egress", "NetworkPolicyStats", "NodeIPAM", "ServiceExternalIP")
+var agentGates = sets.NewString("AntreaPolicy", "AntreaProxy", "Egress", "EndpointSlice", "Traceflow", "FlowExporter", "NetworkPolicyStats", "NodePortLocal", "AntreaIPAM", "Multicast", "ServiceExternalIP")
 
 type (
 	Config struct {

--- a/pkg/apiserver/handlers/featuregates/handler_test.go
+++ b/pkg/apiserver/handlers/featuregates/handler_test.go
@@ -55,6 +55,7 @@ func Test_getGatesResponse(t *testing.T) {
 				{Component: "agent", Name: "NetworkPolicyStats", Status: "Enabled", Version: "BETA"},
 				{Component: "agent", Name: "NodePortLocal", Status: "Enabled", Version: "BETA"},
 				{Component: "agent", Name: "Multicast", Status: "Disabled", Version: "ALPHA"},
+				{Component: "agent", Name: "ServiceExternalIP", Status: "Disabled", Version: "ALPHA"},
 			},
 		},
 	}
@@ -140,6 +141,7 @@ func TestHandleFunc(t *testing.T) {
 				{Component: "controller", Name: "Traceflow", Status: "Enabled", Version: "BETA"},
 				{Component: "controller", Name: "NetworkPolicyStats", Status: "Enabled", Version: "BETA"},
 				{Component: "controller", Name: "NodeIPAM", Status: "Disabled", Version: "ALPHA"},
+				{Component: "controller", Name: "ServiceExternalIP", Status: "Disabled", Version: "ALPHA"},
 				{Component: "agent", Name: "AntreaPolicy", Status: "Enabled", Version: "BETA"},
 				{Component: "agent", Name: "AntreaProxy", Status: "Enabled", Version: "BETA"},
 				{Component: "agent", Name: "Egress", Status: "Disabled", Version: "ALPHA"},
@@ -148,6 +150,7 @@ func TestHandleFunc(t *testing.T) {
 				{Component: "agent", Name: "FlowExporter", Status: "Disabled", Version: "ALPHA"},
 				{Component: "agent", Name: "NetworkPolicyStats", Status: "Enabled", Version: "BETA"},
 				{Component: "agent", Name: "NodePortLocal", Status: "Enabled", Version: "BETA"},
+				{Component: "agent", Name: "ServiceExternalIP", Status: "Disabled", Version: "ALPHA"},
 			},
 		},
 	}
@@ -192,6 +195,7 @@ func Test_getControllerGatesResponse(t *testing.T) {
 				{Component: "controller", Name: "Traceflow", Status: "Enabled", Version: "BETA"},
 				{Component: "controller", Name: "NetworkPolicyStats", Status: "Enabled", Version: "BETA"},
 				{Component: "controller", Name: "NodeIPAM", Status: "Disabled", Version: "ALPHA"},
+				{Component: "controller", Name: "ServiceExternalIP", Status: "Disabled", Version: "ALPHA"},
 			},
 		},
 	}

--- a/pkg/controller/serviceexternalip/controller.go
+++ b/pkg/controller/serviceexternalip/controller.go
@@ -1,0 +1,395 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package serviceexternalip
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"reflect"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	apimachineryerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	apimachinerytypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+
+	antreaagenttypes "antrea.io/antrea/pkg/agent/types"
+	"antrea.io/antrea/pkg/controller/externalippool"
+)
+
+const (
+	controllerName = "ExternalIPController"
+	// Set resyncPeriod to 0 to disable resyncing.
+	resyncPeriod time.Duration = 0
+	// How long to wait before retrying the processing of an Service change.
+	minRetryDelay = 5 * time.Second
+	maxRetryDelay = 300 * time.Second
+	// Default number of workers processing an Service change.
+	defaultWorkers = 4
+
+	externalIPPoolIndex = "externalIPPool"
+)
+
+// ipAllocation contains the IP and the IP Pool which allocates it.
+type ipAllocation struct {
+	ip     net.IP
+	ipPool string
+}
+
+// ServiceExternalIPController is responsible for synchronizing the Services that need external IPs.
+type ServiceExternalIPController struct {
+	externalIPAllocator externalippool.ExternalIPAllocator
+	client              clientset.Interface
+
+	// ipAllocationMap is a map from Service name to IP allocated.
+	ipAllocationMap   map[apimachinerytypes.NamespacedName]*ipAllocation
+	ipAllocationMutex sync.RWMutex
+
+	serviceInformer     cache.SharedIndexInformer
+	serviceLister       corelisters.ServiceLister
+	serviceListerSynced cache.InformerSynced
+	// queue maintains the Service objects that need to be synced.
+	queue workqueue.RateLimitingInterface
+}
+
+func NewServiceExternalIPController(
+	client clientset.Interface,
+	serviceInformer coreinformers.ServiceInformer,
+	externalIPAllocator externalippool.ExternalIPAllocator,
+) *ServiceExternalIPController {
+	c := &ServiceExternalIPController{
+		client:              client,
+		queue:               workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(minRetryDelay, maxRetryDelay), "serviceExternalIP"),
+		serviceInformer:     serviceInformer.Informer(),
+		serviceLister:       serviceInformer.Lister(),
+		serviceListerSynced: serviceInformer.Informer().HasSynced,
+		externalIPAllocator: externalIPAllocator,
+		ipAllocationMap:     make(map[apimachinerytypes.NamespacedName]*ipAllocation),
+	}
+
+	c.serviceInformer.AddIndexers(cache.Indexers{
+		externalIPPoolIndex: func(obj interface{}) ([]string, error) {
+			service, ok := obj.(*corev1.Service)
+			if !ok {
+				return nil, fmt.Errorf("obj is not Service: %+v", obj)
+			}
+			eipName, ok := service.Annotations[antreaagenttypes.ServiceExternalIPPoolAnnotationKey]
+			if !ok {
+				return nil, nil
+			}
+			return []string{eipName}, nil
+		},
+	})
+
+	c.serviceInformer.AddEventHandlerWithResyncPeriod(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: c.enqueueService,
+			UpdateFunc: func(old, cur interface{}) {
+				c.enqueueService(cur)
+			},
+			DeleteFunc: c.enqueueService,
+		},
+		resyncPeriod,
+	)
+
+	c.externalIPAllocator.AddEventHandler(c.enqueueServicesByExternalIPPool)
+	return c
+}
+
+func (c *ServiceExternalIPController) enqueueService(obj interface{}) {
+	service, ok := obj.(*corev1.Service)
+	if !ok {
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			klog.Errorf("Received unexpected object: %v", obj)
+			return
+		}
+		service, ok = deletedState.Obj.(*corev1.Service)
+		if !ok {
+			klog.Errorf("DeletedFinalStateUnknown contains non-Service object: %v", deletedState.Obj)
+			return
+		}
+	}
+	namespacedName := apimachinerytypes.NamespacedName{
+		Namespace: service.Namespace,
+		Name:      service.Name,
+	}
+	c.queue.Add(namespacedName)
+}
+
+// enqueueServicesByExternalIPPool enqueues all Services that refer to the provided ExternalIPPool.
+// The ExternalIPPool is affected by a Node update/create/delete event or ExternalIPPool changes.
+func (c *ServiceExternalIPController) enqueueServicesByExternalIPPool(eipName string) {
+	objects, _ := c.serviceInformer.GetIndexer().ByIndex(externalIPPoolIndex, eipName)
+	for _, object := range objects {
+		c.enqueueService(object)
+	}
+	klog.InfoS("Detected ExternalIPPool event", "ExternalIPPool", eipName)
+}
+
+// Run will create defaultWorkers workers (go routines) which will process the Service events from the
+// workqueue.
+func (c *ServiceExternalIPController) Run(stopCh <-chan struct{}) {
+	defer c.queue.ShutDown()
+
+	klog.Infof("Starting %s", controllerName)
+	defer klog.Infof("Shutting down %s", controllerName)
+
+	if !cache.WaitForNamedCacheSync(controllerName, stopCh, c.serviceListerSynced, c.externalIPAllocator.HasSynced) {
+		return
+	}
+
+	svcs, _ := c.serviceLister.List(labels.Everything())
+	c.restoreIPAllocations(svcs)
+
+	for i := 0; i < defaultWorkers; i++ {
+		go wait.Until(c.worker, time.Second, stopCh)
+	}
+	<-stopCh
+}
+
+// restoreIPAllocations restores the existing external IPs of Services and records the successful ones in ipAllocationMap.
+func (c *ServiceExternalIPController) restoreIPAllocations(services []*corev1.Service) {
+	var previousIPAllocations []externalippool.IPAllocation
+	for _, svc := range services {
+		ipPool := svc.ObjectMeta.Annotations[antreaagenttypes.ServiceExternalIPPoolAnnotationKey]
+		if svc.Spec.Type != corev1.ServiceTypeLoadBalancer || ipPool == "" || len(svc.Status.LoadBalancer.Ingress) == 0 {
+			continue
+		}
+		ip := net.ParseIP(svc.Status.LoadBalancer.Ingress[0].IP)
+		allocation := externalippool.IPAllocation{
+			ObjectReference: v1.ObjectReference{
+				Name:      svc.Name,
+				Namespace: svc.Namespace,
+				Kind:      svc.Kind,
+			},
+			IPPoolName: ipPool,
+			IP:         ip,
+		}
+		previousIPAllocations = append(previousIPAllocations, allocation)
+	}
+	succeededAllocations := c.externalIPAllocator.RestoreIPAllocations(previousIPAllocations)
+	for _, alloc := range succeededAllocations {
+		name := apimachinerytypes.NamespacedName{
+			Namespace: alloc.ObjectReference.Namespace,
+			Name:      alloc.ObjectReference.Name,
+		}
+		c.setIPAllocation(name, alloc.IPPoolName, alloc.IP)
+		klog.InfoS("Restored external IP", "service", name, "ip", alloc.IP, "pool", alloc.IPPoolName)
+	}
+}
+
+func (c *ServiceExternalIPController) setIPAllocation(name apimachinerytypes.NamespacedName, ipPool string, ip net.IP) {
+	c.ipAllocationMutex.Lock()
+	defer c.ipAllocationMutex.Unlock()
+	c.ipAllocationMap[name] = &ipAllocation{
+		ip:     ip,
+		ipPool: ipPool,
+	}
+}
+
+// worker is a long-running function that will continually call the processNextWorkItem function in
+// order to read and process a message on the workqueue.
+func (c *ServiceExternalIPController) worker() {
+	for c.processNextWorkItem() {
+	}
+}
+
+func (c *ServiceExternalIPController) processNextWorkItem() bool {
+	obj, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(obj)
+	if key, ok := obj.(apimachinerytypes.NamespacedName); !ok {
+		c.queue.Forget(obj)
+		klog.Errorf("Expected NamespacedName in work queue but got %#v", obj)
+		return true
+	} else if err := c.syncService(key); err == nil {
+		// If no error occurs we Forget this item so it does not get queued again until
+		// another change happens.
+		c.queue.Forget(key)
+	} else {
+		// Put the item back on the workqueue to handle any transient errors.
+		c.queue.AddRateLimited(key)
+		klog.Errorf("Error syncing Service %s, requeuing. Error: %v", key, err)
+	}
+	return true
+}
+
+func (c *ServiceExternalIPController) releaseExternalIP(service apimachinerytypes.NamespacedName) error {
+	c.ipAllocationMutex.Lock()
+	defer c.ipAllocationMutex.Unlock()
+	allocation, exists := c.ipAllocationMap[service]
+	if exists {
+		if err := c.externalIPAllocator.ReleaseIP(allocation.ipPool, allocation.ip); err != nil {
+			if err == externalippool.ErrExternalIPPoolNotFound {
+				// Ignore the error since the external IP Pool could be deleted.
+				klog.Warningf("Failed to release IP %s for service %s: IP Pool %s does not exist", service, allocation.ip, allocation.ipPool)
+			} else {
+				klog.ErrorS(err, "Failed to release external IP", "service", service, "ip", allocation.ip, "pool", allocation.ipPool)
+				return err
+			}
+		} else {
+			klog.InfoS("Released external IP", "service", service, "ip", allocation.ip, "pool", allocation.ipPool)
+		}
+		delete(c.ipAllocationMap, service)
+	}
+	return nil
+}
+
+func (c *ServiceExternalIPController) getExternalIPAllocation(service apimachinerytypes.NamespacedName) (*ipAllocation, bool) {
+	c.ipAllocationMutex.RLock()
+	defer c.ipAllocationMutex.RUnlock()
+	allocation, exist := c.ipAllocationMap[service]
+	return allocation, exist
+}
+
+func getServiceExternalIP(service *corev1.Service) string {
+	if len(service.Status.LoadBalancer.Ingress) == 0 {
+		return ""
+	}
+	return service.Status.LoadBalancer.Ingress[0].IP
+}
+
+func (c *ServiceExternalIPController) syncService(key apimachinerytypes.NamespacedName) error {
+	startTime := time.Now()
+	defer func() {
+		klog.V(4).Infof("Finished syncing Service for %s. (%v)", key, time.Since(startTime))
+	}()
+
+	service, err := c.serviceLister.Services(key.Namespace).Get(key.Name)
+	if err != nil {
+		// Service already deleted
+		if apimachineryerrors.IsNotFound(err) {
+			if err := c.releaseExternalIP(key); err != nil {
+				return err
+			}
+			return nil
+		}
+		return err
+	}
+
+	// Service does not need external IP or type has changed.
+	if service.Spec.Type != corev1.ServiceTypeLoadBalancer {
+		if err := c.releaseExternalIP(key); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	currentIPPool := service.ObjectMeta.Annotations[antreaagenttypes.ServiceExternalIPPoolAnnotationKey]
+	prevIPAllocation, allocationExists := c.getExternalIPAllocation(key)
+	currentExternalIP := getServiceExternalIP(service)
+
+	// If user specifies external IP in spec, we should check whether it matches the current external IP.
+	specIPMatched := service.Spec.LoadBalancerIP == "" || service.Spec.LoadBalancerIP == currentExternalIP
+
+	if allocationExists && specIPMatched &&
+		c.externalIPAllocator.IPPoolExists(currentIPPool) &&
+		c.externalIPAllocator.IPPoolHasIP(currentIPPool, prevIPAllocation.ip) &&
+		currentIPPool == prevIPAllocation.ipPool &&
+		currentExternalIP == prevIPAllocation.ip.String() {
+		return nil
+	}
+
+	// The ExternalIPPool does not exist or has been deleted. Reclaim the external IP.
+	if currentIPPool != "" && !c.externalIPAllocator.IPPoolExists(currentIPPool) {
+		if err := c.releaseExternalIP(key); err != nil {
+			return err
+		}
+		if currentExternalIP != "" {
+			toUpdate := service.DeepCopy()
+			toUpdate.Status.LoadBalancer.Ingress = nil
+			return c.updateServiceStatus(service, toUpdate)
+		}
+	}
+
+	// the external IP or ExternalIPPool changed somehow. Delete the previous allocation.
+	if err := c.releaseExternalIP(key); err != nil {
+		return err
+	}
+
+	if currentIPPool == "" {
+		klog.V(2).InfoS("Ignored Service as required annotation is not found", "service", key)
+		return nil
+	}
+
+	var newExternalIP net.IP
+	var allocated bool
+	if service.Spec.LoadBalancerIP != "" {
+		// check whether the specified IP is in the desired IP pool or not.
+		newExternalIP = net.ParseIP(service.Spec.LoadBalancerIP)
+		if !c.externalIPAllocator.IPPoolHasIP(currentIPPool, newExternalIP) {
+			klog.ErrorS(nil, "IP pool does not contain required external IP", "ipPool", currentIPPool, "ip", newExternalIP)
+			return nil
+		}
+		err = c.externalIPAllocator.UpdateIPAllocation(currentIPPool, newExternalIP)
+	} else {
+		// Allocate IP from existing ExternalIPPool.
+		newExternalIP, err = c.externalIPAllocator.AllocateIPFromPool(currentIPPool)
+		allocated = true
+	}
+	if err != nil {
+		// If the ExternalIPPool does not exist, we can ignore the error since the Service will get requeued by ExternalIPPool change events.
+		if errors.Is(err, externalippool.ErrExternalIPPoolNotFound) {
+			klog.ErrorS(err, "Error when allocating IP from ExternalIPPool", "service", service, "ip", newExternalIP, "externalIPPool", currentIPPool)
+			return nil
+		}
+		return fmt.Errorf("error when allocating IP %s from ExternalIPPool %s for Service %s: %v", newExternalIP, currentIPPool, key, err)
+	}
+	klog.InfoS("Allocated external IP for service", "service", key, "ip", newExternalIP, "externalIPPool", currentIPPool)
+
+	toUpdate := service.DeepCopy()
+	toUpdate.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{
+		{
+			IP: newExternalIP.String(),
+		},
+	}
+	if err := c.updateServiceStatus(service, toUpdate); err != nil {
+		if allocated {
+			if rerr := c.externalIPAllocator.ReleaseIP(currentIPPool, newExternalIP); rerr != nil &&
+				rerr != externalippool.ErrExternalIPPoolNotFound {
+				klog.ErrorS(rerr, "Failed to release IP", "service", key, "ip", newExternalIP, "externalIPPool", currentIPPool)
+			}
+		}
+		return err
+	}
+	c.setIPAllocation(key, currentIPPool, newExternalIP)
+	return nil
+}
+
+// updateService updates the Service status in Kubernetes API.
+func (c *ServiceExternalIPController) updateServiceStatus(prev, current *corev1.Service) error {
+	if !reflect.DeepEqual(prev.Status, current.Status) {
+		_, err := c.client.CoreV1().Services(current.Namespace).UpdateStatus(context.TODO(), current, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/controller/serviceexternalip/controller_test.go
+++ b/pkg/controller/serviceexternalip/controller_test.go
@@ -1,0 +1,323 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package serviceexternalip
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+
+	antreaagenttypes "antrea.io/antrea/pkg/agent/types"
+	antreacrds "antrea.io/antrea/pkg/apis/crd/v1alpha2"
+	"antrea.io/antrea/pkg/client/clientset/versioned"
+	fakeversioned "antrea.io/antrea/pkg/client/clientset/versioned/fake"
+	crdinformers "antrea.io/antrea/pkg/client/informers/externalversions"
+	"antrea.io/antrea/pkg/controller/externalippool"
+)
+
+type loadBalancerController struct {
+	*ServiceExternalIPController
+	crdClient           versioned.Interface
+	client              kubernetes.Interface
+	informerFactory     informers.SharedInformerFactory
+	crdInformerFactory  crdinformers.SharedInformerFactory
+	externalIPAllocator *externalippool.ExternalIPPoolController
+}
+
+func newExternalIPPool(name, cidr, start, end string) *antreacrds.ExternalIPPool {
+	pool := &antreacrds.ExternalIPPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+	if len(cidr) > 0 {
+		pool.Spec.IPRanges = append(pool.Spec.IPRanges, antreacrds.IPRange{CIDR: cidr})
+	}
+	if len(start) > 0 && len(end) > 0 {
+		pool.Spec.IPRanges = append(pool.Spec.IPRanges, antreacrds.IPRange{Start: start, End: end})
+	}
+	return pool
+}
+
+func newService(name, namespace string, serviceType corev1.ServiceType, externalIP, ipPool string) *corev1.Service {
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Type:           serviceType,
+			LoadBalancerIP: externalIP,
+		},
+	}
+	if ipPool != "" {
+		service.Annotations = map[string]string{
+			antreaagenttypes.ServiceExternalIPPoolAnnotationKey: ipPool,
+		}
+	}
+	return service
+}
+
+func newController(objects, crdObjects []runtime.Object) *loadBalancerController {
+	client := fake.NewSimpleClientset(objects...)
+	crdClient := fakeversioned.NewSimpleClientset(crdObjects...)
+	informerFactory := informers.NewSharedInformerFactory(client, resyncPeriod)
+	crdInformerFactory := crdinformers.NewSharedInformerFactory(crdClient, resyncPeriod)
+	externalIPPoolController := externalippool.NewExternalIPPoolController(crdClient, crdInformerFactory.Crd().V1alpha2().ExternalIPPools())
+	controller := NewServiceExternalIPController(client, informerFactory.Core().V1().Services(), externalIPPoolController)
+	return &loadBalancerController{
+		ServiceExternalIPController: controller,
+		informerFactory:             informerFactory,
+		crdInformerFactory:          crdInformerFactory,
+		crdClient:                   crdClient,
+		client:                      client,
+		externalIPAllocator:         externalIPPoolController,
+	}
+}
+
+func TestAddService(t *testing.T) {
+	tests := []struct {
+		name               string
+		externalIPPool     []*antreacrds.ExternalIPPool
+		service            *corev1.Service
+		expectedExternalIP string
+	}{
+		{
+			name: "Service with valid ExternalIPPool annotation",
+			externalIPPool: []*antreacrds.ExternalIPPool{
+				newExternalIPPool("eip1", "", "1.2.3.4", "1.2.3.5"),
+			},
+			service:            newService("svc1", "ns1", corev1.ServiceTypeLoadBalancer, "", "eip1"),
+			expectedExternalIP: "1.2.3.4",
+		},
+		{
+			name: "Service with valid ExternalIPPool annotation and multiple ExternalIPPool present",
+			externalIPPool: []*antreacrds.ExternalIPPool{
+				newExternalIPPool("eip1", "", "1.2.3.4", "1.2.3.5"),
+				newExternalIPPool("eip2", "", "1.2.4.4", "1.2.4.5"),
+			},
+			service:            newService("svc1", "ns1", corev1.ServiceTypeLoadBalancer, "", "eip2"),
+			expectedExternalIP: "1.2.4.4",
+		},
+		{
+			name: "Service with user specified external IP",
+			externalIPPool: []*antreacrds.ExternalIPPool{
+				newExternalIPPool("eip1", "", "1.2.3.4", "1.2.3.5"),
+			},
+			service:            newService("svc1", "ns1", corev1.ServiceTypeLoadBalancer, "1.2.3.5", "eip1"),
+			expectedExternalIP: "1.2.3.5",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+			var fakeObjects []runtime.Object
+			var fakeCRDObjects []runtime.Object
+			for _, eip := range tt.externalIPPool {
+				fakeCRDObjects = append(fakeCRDObjects, eip)
+			}
+			controller := newController(fakeObjects, fakeCRDObjects)
+			controller.informerFactory.Start(stopCh)
+			controller.crdInformerFactory.Start(stopCh)
+			controller.informerFactory.WaitForCacheSync(stopCh)
+			controller.crdInformerFactory.WaitForCacheSync(stopCh)
+			go controller.externalIPAllocator.Run(stopCh)
+			require.True(t, cache.WaitForCacheSync(stopCh, controller.externalIPAllocator.HasSynced))
+			go controller.Run(stopCh)
+			_, err := controller.client.CoreV1().Services(tt.service.Namespace).Create(context.TODO(), tt.service, metav1.CreateOptions{})
+			require.NoError(t, err)
+			var svcUpdated *corev1.Service
+			var externalIP string
+			assert.Eventually(t, func() bool {
+				var err error
+				svcUpdated, err = controller.client.CoreV1().Services(tt.service.Namespace).Get(context.TODO(), tt.service.Name, metav1.GetOptions{})
+				require.NoError(t, err)
+				externalIP = getServiceExternalIP(svcUpdated)
+				return externalIP == tt.expectedExternalIP
+			}, 500*time.Millisecond, 100*time.Millisecond)
+			ipPool := svcUpdated.Annotations[antreaagenttypes.ServiceExternalIPPoolAnnotationKey]
+			assert.NotEmpty(t, ipPool)
+			assert.True(t, controller.externalIPAllocator.IPPoolExists(ipPool))
+			assert.True(t, controller.externalIPAllocator.IPPoolHasIP(ipPool, net.ParseIP(externalIP)))
+		})
+	}
+}
+
+func TestSyncService(t *testing.T) {
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	var fakeObjects []runtime.Object
+	var fakeCRDObjects []runtime.Object
+	controller := newController(fakeObjects, fakeCRDObjects)
+	controller.informerFactory.Start(stopCh)
+	controller.crdInformerFactory.Start(stopCh)
+	controller.informerFactory.WaitForCacheSync(stopCh)
+	controller.crdInformerFactory.WaitForCacheSync(stopCh)
+	go controller.externalIPAllocator.Run(stopCh)
+	go controller.Run(stopCh)
+
+	require.True(t, cache.WaitForCacheSync(stopCh, controller.externalIPAllocator.HasSynced))
+
+	var service *corev1.Service
+	var err error
+
+	service = newService("svc1", "ns1", corev1.ServiceTypeLoadBalancer, "", "eip1")
+	_, err = controller.client.CoreV1().Services(service.Namespace).Create(context.TODO(), service, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	eip1 := newExternalIPPool("eip1", "", "1.2.3.4", "1.2.3.5")
+
+	t.Run("IP pool eip1 created", func(t *testing.T) {
+		_, err = controller.crdClient.CrdV1alpha2().ExternalIPPools().Create(context.TODO(), eip1, metav1.CreateOptions{})
+		require.NoError(t, err)
+		checkForServiceExternalIP(t, controller, service.Name, service.Namespace, "1.2.3.4")
+		checkExternalIPPoolUsed(t, controller, "eip1", 1)
+	})
+
+	t.Run("IP pool eip1 deleted", func(t *testing.T) {
+		err = controller.crdClient.CrdV1alpha2().ExternalIPPools().Delete(context.TODO(), eip1.Name, metav1.DeleteOptions{})
+		assert.NoError(t, err)
+		checkForServiceExternalIP(t, controller, service.Name, service.Namespace, "")
+	})
+
+	t.Run("IP pool eip1 re-created", func(t *testing.T) {
+		// Re-create ExternalIPPool.
+		_, err = controller.crdClient.CrdV1alpha2().ExternalIPPools().Create(context.TODO(), eip1, metav1.CreateOptions{})
+		require.NoError(t, err)
+		checkForServiceExternalIP(t, controller, service.Name, service.Namespace, "1.2.3.4")
+		checkExternalIPPoolUsed(t, controller, "eip1", 1)
+	})
+
+	t.Run("Service changes ExternalIPPool annotation to eip2", func(t *testing.T) {
+		// Change ExternalIPPool annotation.
+		service.Annotations[antreaagenttypes.ServiceExternalIPPoolAnnotationKey] = "eip2"
+		_, err = controller.client.CoreV1().Services(service.Namespace).Update(context.TODO(), service, metav1.UpdateOptions{})
+		require.NoError(t, err)
+		checkForServiceExternalIP(t, controller, service.Name, service.Namespace, "")
+		checkExternalIPPoolUsed(t, controller, "eip1", 0)
+	})
+
+	eip2 := newExternalIPPool("eip2", "", "1.2.4.4", "1.2.4.5")
+
+	t.Run("IP pool eip2 created", func(t *testing.T) {
+		// Create second ExternalIPPool.
+		_, err = controller.crdClient.CrdV1alpha2().ExternalIPPools().Create(context.TODO(), eip2, metav1.CreateOptions{})
+		require.NoError(t, err)
+		checkForServiceExternalIP(t, controller, service.Name, service.Namespace, "1.2.4.4")
+		checkExternalIPPoolUsed(t, controller, "eip1", 0)
+		checkExternalIPPoolUsed(t, controller, "eip2", 1)
+	})
+
+	t.Run("specify another IP from IP pool eip2", func(t *testing.T) {
+		service.Spec.LoadBalancerIP = "1.2.4.5"
+		_, err = controller.client.CoreV1().Services(service.Namespace).Update(context.TODO(), service, metav1.UpdateOptions{})
+		require.NoError(t, err)
+		checkForServiceExternalIP(t, controller, service.Name, service.Namespace, "1.2.4.5")
+		checkExternalIPPoolUsed(t, controller, "eip1", 0)
+		checkExternalIPPoolUsed(t, controller, "eip2", 1)
+	})
+
+	t.Run("specify an IP from IP pool eip1 without changing annotation", func(t *testing.T) {
+		service.Spec.LoadBalancerIP = "1.2.3.4"
+		_, err = controller.client.CoreV1().Services(service.Namespace).Update(context.TODO(), service, metav1.UpdateOptions{})
+		require.NoError(t, err)
+		checkForServiceExternalIP(t, controller, service.Name, service.Namespace, "")
+		checkExternalIPPoolUsed(t, controller, "eip1", 0)
+		checkExternalIPPoolUsed(t, controller, "eip2", 0)
+	})
+
+	t.Run("change annotation to use IP pool eip1", func(t *testing.T) {
+		service.Annotations[antreaagenttypes.ServiceExternalIPPoolAnnotationKey] = "eip1"
+		_, err = controller.client.CoreV1().Services(service.Namespace).Update(context.TODO(), service, metav1.UpdateOptions{})
+		require.NoError(t, err)
+		checkForServiceExternalIP(t, controller, service.Name, service.Namespace, "1.2.3.4")
+		checkExternalIPPoolUsed(t, controller, "eip1", 1)
+		checkExternalIPPoolUsed(t, controller, "eip2", 0)
+	})
+
+	t.Run("Specify non-existent IP of IP pool eip1", func(t *testing.T) {
+		service.Spec.LoadBalancerIP = "1.2.3.6"
+		service.Annotations[antreaagenttypes.ServiceExternalIPPoolAnnotationKey] = "eip1"
+		_, err = controller.client.CoreV1().Services(service.Namespace).Update(context.TODO(), service, metav1.UpdateOptions{})
+		assert.NoError(t, err)
+		checkForServiceExternalIP(t, controller, service.Name, service.Namespace, "")
+		checkExternalIPPoolUsed(t, controller, "eip1", 0)
+		checkExternalIPPoolUsed(t, controller, "eip2", 0)
+	})
+
+	t.Run("Change Service type", func(t *testing.T) {
+		// Change Service type.
+		service.Spec.LoadBalancerIP = ""
+		_, err = controller.client.CoreV1().Services(service.Namespace).Update(context.TODO(), service, metav1.UpdateOptions{})
+		assert.NoError(t, err)
+		checkForServiceExternalIP(t, controller, service.Name, service.Namespace, "1.2.3.4")
+
+		service.Spec.Type = corev1.ServiceTypeClusterIP
+		_, err = controller.client.CoreV1().Services(service.Namespace).Update(context.TODO(), service, metav1.UpdateOptions{})
+		assert.NoError(t, err)
+		checkForServiceExternalIP(t, controller, service.Name, service.Namespace, "")
+		checkExternalIPPoolUsed(t, controller, "eip1", 0)
+		checkExternalIPPoolUsed(t, controller, "eip2", 0)
+	})
+
+	t.Run("Change Service type back", func(t *testing.T) {
+		service.Spec.Type = corev1.ServiceTypeLoadBalancer
+		_, err = controller.client.CoreV1().Services(service.Namespace).Update(context.TODO(), service, metav1.UpdateOptions{})
+		require.NoError(t, err)
+		checkForServiceExternalIP(t, controller, service.Name, service.Namespace, "1.2.3.4")
+		checkExternalIPPoolUsed(t, controller, "eip1", 1)
+		checkExternalIPPoolUsed(t, controller, "eip2", 0)
+	})
+
+	t.Run("Delete service", func(t *testing.T) {
+		err = controller.client.CoreV1().Services(service.Namespace).Delete(context.TODO(), service.Name, metav1.DeleteOptions{})
+		require.NoError(t, err)
+		checkExternalIPPoolUsed(t, controller, "eip1", 0)
+		checkExternalIPPoolUsed(t, controller, "eip2", 0)
+	})
+}
+
+func checkForServiceExternalIP(t *testing.T, controller *loadBalancerController, name, namespace, expectedExternalIP string) {
+	assert.Eventually(t, func() bool {
+		serviceUpdated, err := controller.client.CoreV1().Services(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		require.NoError(t, err)
+		externalIP := getServiceExternalIP(serviceUpdated)
+		return externalIP == expectedExternalIP
+	}, 500*time.Millisecond, 100*time.Millisecond)
+}
+
+func checkExternalIPPoolUsed(t *testing.T, controller *loadBalancerController, poolName string, used int) {
+	exists := controller.externalIPAllocator.IPPoolExists(poolName)
+	require.True(t, exists)
+	assert.Eventually(t, func() bool {
+		eip, err := controller.crdClient.CrdV1alpha2().ExternalIPPools().Get(context.TODO(), poolName, metav1.GetOptions{})
+		require.NoError(t, err)
+		t.Logf("current status %#v", eip.Status)
+		return eip.Status.Usage.Used == used
+	}, 500*time.Millisecond, 100*time.Millisecond)
+}

--- a/pkg/features/antrea_features.go
+++ b/pkg/features/antrea_features.go
@@ -84,6 +84,10 @@ const (
 	// alpha: v1.5
 	// Enable Secondary interface feature for Antrea.
 	SecondaryNetwork featuregate.Feature = "SecondaryNetwork"
+
+	// alpha: v1.5
+	// Enable controlling Services with ExternalIP.
+	ServiceExternalIP featuregate.Feature = "ServiceExternalIP"
 )
 
 var (
@@ -110,6 +114,7 @@ var (
 		NodeIPAM:           {Default: false, PreRelease: featuregate.Alpha},
 		Multicast:          {Default: false, PreRelease: featuregate.Alpha},
 		SecondaryNetwork:   {Default: false, PreRelease: featuregate.Alpha},
+		ServiceExternalIP:  {Default: false, PreRelease: featuregate.Alpha},
 	}
 
 	// UnsupportedFeaturesOnWindows records the features not supported on
@@ -123,11 +128,12 @@ var (
 	// can have different FeatureSpecs between Linux and Windows, we should
 	// still define a separate defaultAntreaFeatureGates map for Windows.
 	unsupportedFeaturesOnWindows = map[featuregate.Feature]struct{}{
-		NodePortLocal:    {},
-		Egress:           {},
-		AntreaIPAM:       {},
-		Multicast:        {},
-		SecondaryNetwork: {},
+		NodePortLocal:     {},
+		Egress:            {},
+		AntreaIPAM:        {},
+		Multicast:         {},
+		SecondaryNetwork:  {},
+		ServiceExternalIP: {},
 	}
 )
 

--- a/plugins/octant/go.sum
+++ b/plugins/octant/go.sum
@@ -516,6 +516,7 @@ github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEW
 github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e/go.mod h1:0AA//k/eakGydO4jKRoRL2j92ZKSzTgj9tclaCrvXHk=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
+github.com/google/btree v1.0.1/go.mod h1:xXMiIv4Fb/0kKde4SpL7qlzvu5cMJDRkFDxJfI9uaxA=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -87,6 +87,16 @@ func skipIfProxyAllDisabled(t *testing.T, data *TestData) {
 	}
 }
 
+func skipIfProxyAllEnabled(t *testing.T, data *TestData) {
+	isProxyAll, err := data.isProxyAll()
+	if err != nil {
+		t.Fatalf("Error getting option antreaProxy.proxyAll value")
+	}
+	if isProxyAll {
+		t.Skipf("Skipping test because option antreaProxy.proxyAll is enabled")
+	}
+}
+
 func skipIfKubeProxyEnabled(t *testing.T, data *TestData) {
 	_, err := data.clientset.AppsV1().DaemonSets(kubeNamespace).Get(context.TODO(), "kube-proxy", metav1.GetOptions{})
 	if err == nil {

--- a/test/e2e/service_externalip_test.go
+++ b/test/e2e/service_externalip_test.go
@@ -1,0 +1,660 @@
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+	utilnet "k8s.io/utils/net"
+
+	antreaagenttypes "antrea.io/antrea/pkg/agent/types"
+	"antrea.io/antrea/pkg/apis/crd/v1alpha2"
+	agentconfig "antrea.io/antrea/pkg/config/agent"
+	controllerconfig "antrea.io/antrea/pkg/config/controller"
+)
+
+func TestServiceExternalIP(t *testing.T) {
+	skipIfHasWindowsNodes(t)
+	skipIfNumNodesLessThan(t, 2)
+	skipIfAntreaIPAMTest(t)
+
+	data, err := setupTest(t)
+	if err != nil {
+		t.Fatalf("Error when setting up test: %v", err)
+	}
+	defer teardownTest(t, data)
+
+	cc := func(config *controllerconfig.ControllerConfig) {
+		config.FeatureGates["ServiceExternalIP"] = true
+	}
+	ac := func(config *agentconfig.AgentConfig) {
+		config.FeatureGates["ServiceExternalIP"] = true
+	}
+
+	if err := data.mutateAntreaConfigMap(cc, ac, true, true); err != nil {
+		t.Fatalf("Failed to enable ServiceExternalIP feature: %v", err)
+	}
+
+	t.Run("testServiceWithExternalIPCRUD", func(t *testing.T) { testServiceWithExternalIPCRUD(t, data) })
+	t.Run("testServiceUpdateExternalIP", func(t *testing.T) { testServiceUpdateExternalIP(t, data) })
+	t.Run("testServiceExternalTrafficPolicyLocal", func(t *testing.T) { testServiceExternalTrafficPolicyLocal(t, data) })
+	t.Run("testServiceNodeFailure", func(t *testing.T) { testServiceNodeFailure(t, data) })
+	t.Run("testExternalIPAccess", func(t *testing.T) { testExternalIPAccess(t, data) })
+}
+
+func testServiceExternalTrafficPolicyLocal(t *testing.T, data *TestData) {
+	tests := []struct {
+		name                    string
+		ipRange                 v1alpha2.IPRange
+		nodeSelector            metav1.LabelSelector
+		originalEndpointSubsets []v1.EndpointSubset
+		expectedExternalIP      string
+		expectedNodeOrigin      string
+		updatedEndpointSubsets  []v1.EndpointSubset
+		expectedNodeUpdated     string
+	}{
+		{
+			name:    "endpoint created",
+			ipRange: v1alpha2.IPRange{CIDR: "169.254.100.0/30"},
+			nodeSelector: metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      v1.LabelHostname,
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{nodeName(0), nodeName(1)},
+					},
+				},
+			},
+			expectedExternalIP:      "169.254.100.1",
+			originalEndpointSubsets: nil,
+			expectedNodeOrigin:      "",
+			updatedEndpointSubsets: []v1.EndpointSubset{
+				{
+					Addresses: []v1.EndpointAddress{
+						{
+							IP:       "192.168.200.1",
+							NodeName: stringPtr(nodeName(0)),
+						},
+					},
+				},
+			},
+			expectedNodeUpdated: nodeName(0),
+		},
+		{
+			name:    "endpoint changed",
+			ipRange: v1alpha2.IPRange{CIDR: "169.254.100.0/30"},
+			nodeSelector: metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      v1.LabelHostname,
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{nodeName(0), nodeName(1)},
+					},
+				},
+			},
+			expectedExternalIP: "169.254.100.1",
+			originalEndpointSubsets: []v1.EndpointSubset{
+				{
+					Addresses: []v1.EndpointAddress{
+						{
+							IP:       "192.168.100.1",
+							NodeName: stringPtr(nodeName(0)),
+						},
+					},
+				},
+			},
+			expectedNodeOrigin: nodeName(0),
+			updatedEndpointSubsets: []v1.EndpointSubset{
+				{
+					Addresses: []v1.EndpointAddress{
+						{
+							IP:       "192.168.100.1",
+							NodeName: stringPtr(nodeName(1)),
+						},
+					},
+				},
+			},
+			expectedNodeUpdated: nodeName(1),
+		},
+	}
+	for idx, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if utilnet.IsIPv6String(tt.expectedExternalIP) {
+				skipIfNotIPv6Cluster(t)
+			} else {
+				skipIfNotIPv4Cluster(t)
+			}
+			var err error
+			var service *v1.Service
+			var eps *v1.Endpoints
+			ipPool := data.createExternalIPPool(t, "test-service-pool-", tt.ipRange, tt.nodeSelector.MatchExpressions, tt.nodeSelector.MatchLabels)
+			defer data.crdClient.CrdV1alpha2().ExternalIPPools().Delete(context.TODO(), ipPool.Name, metav1.DeleteOptions{})
+
+			annotation := map[string]string{
+				antreaagenttypes.ServiceExternalIPPoolAnnotationKey: ipPool.Name,
+			}
+			service, err = data.createServiceWithAnnotations(fmt.Sprintf("test-svc-local-%d", idx),
+				testNamespace, 80, 80, corev1.ProtocolTCP, nil, false, true, v1.ServiceTypeLoadBalancer, nil, annotation)
+			require.NoError(t, err)
+			defer data.clientset.CoreV1().Services(service.Namespace).Delete(context.TODO(), service.Name, metav1.DeleteOptions{})
+
+			eps = &v1.Endpoints{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      service.Name,
+					Namespace: service.Namespace,
+					Labels: map[string]string{
+						"antrea-e2e": service.Name,
+						"app":        service.Name,
+					},
+				},
+				Subsets: tt.originalEndpointSubsets,
+			}
+			eps, err = data.clientset.CoreV1().Endpoints(eps.Namespace).Create(context.TODO(), eps, metav1.CreateOptions{})
+			require.NoError(t, err)
+			defer data.clientset.CoreV1().Endpoints(eps.Namespace).Delete(context.TODO(), eps.Name, metav1.DeleteOptions{})
+
+			service, err = data.waitForServiceConfigured(service, tt.expectedExternalIP, tt.expectedNodeOrigin != "", tt.expectedNodeOrigin)
+			require.NoError(t, err)
+			_, node := getServiceExternalIPAndHost(service)
+			assert.Equal(t, tt.expectedNodeOrigin, node)
+
+			epsToUpdate := eps.DeepCopy()
+			epsToUpdate.Subsets = tt.updatedEndpointSubsets
+			_, err = data.clientset.CoreV1().Endpoints(eps.Namespace).Update(context.TODO(), epsToUpdate, metav1.UpdateOptions{})
+			require.NoError(t, err)
+			service, err = data.waitForServiceConfigured(service, tt.expectedExternalIP, tt.expectedNodeUpdated != "", tt.expectedNodeUpdated)
+			require.NoError(t, err)
+			_, node = getServiceExternalIPAndHost(service)
+			assert.Equal(t, tt.expectedNodeUpdated, node)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func stringPtr(s string) *string {
+	return &s
+}
+
+func testServiceWithExternalIPCRUD(t *testing.T, data *TestData) {
+	tests := []struct {
+		name               string
+		ipRange            v1alpha2.IPRange
+		nodeSelector       metav1.LabelSelector
+		expectedExternalIP string
+		expectedNodes      sets.String
+		expectedTotal      int
+	}{
+		{
+			name:    "single matching Node",
+			ipRange: v1alpha2.IPRange{CIDR: "169.254.100.0/30"},
+			nodeSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					v1.LabelHostname: nodeName(0),
+				},
+			},
+			expectedExternalIP: "169.254.100.1",
+			expectedNodes:      sets.NewString(nodeName(0)),
+			expectedTotal:      2,
+		},
+		{
+			name:    "two matching Nodes",
+			ipRange: v1alpha2.IPRange{Start: "169.254.101.10", End: "169.254.101.11"},
+			nodeSelector: metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      v1.LabelHostname,
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{nodeName(0), nodeName(1)},
+					},
+				},
+			},
+			expectedExternalIP: "169.254.101.10",
+			expectedNodes:      sets.NewString(nodeName(0), nodeName(1)),
+			expectedTotal:      2,
+		},
+		{
+			name:    "no matching Node",
+			ipRange: v1alpha2.IPRange{CIDR: "169.254.102.0/30"},
+			nodeSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"foo": "bar",
+				},
+			},
+			expectedExternalIP: "169.254.102.1",
+			expectedNodes:      sets.NewString(),
+			expectedTotal:      2,
+		},
+	}
+	for idx, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if utilnet.IsIPv6String(tt.expectedExternalIP) {
+				skipIfNotIPv6Cluster(t)
+			} else {
+				skipIfNotIPv4Cluster(t)
+			}
+			var err error
+			var service *v1.Service
+			ipPool := data.createExternalIPPool(t, "crud-pool-", tt.ipRange, tt.nodeSelector.MatchExpressions, tt.nodeSelector.MatchLabels)
+			defer data.crdClient.CrdV1alpha2().ExternalIPPools().Delete(context.TODO(), ipPool.Name, metav1.DeleteOptions{})
+
+			annotation := map[string]string{
+				antreaagenttypes.ServiceExternalIPPoolAnnotationKey: ipPool.Name,
+			}
+			service, err = data.createServiceWithAnnotations(fmt.Sprintf("test-svc-eip-%d", idx),
+				testNamespace, 80, 80, corev1.ProtocolTCP, nil, false, false, v1.ServiceTypeLoadBalancer, nil, annotation)
+			require.NoError(t, err)
+
+			defer data.clientset.CoreV1().Services(service.Namespace).Delete(context.TODO(), service.Name, metav1.DeleteOptions{})
+			waitForNodeConfigured := len(tt.expectedNodes) != 0
+			service, err = data.waitForServiceConfigured(service, tt.expectedExternalIP, waitForNodeConfigured, "")
+			require.NoError(t, err)
+
+			if len(tt.expectedNodes) > 0 {
+				_, assignedNode := getServiceExternalIPAndHost(service)
+				assert.True(t, tt.expectedNodes.Has(assignedNode), "expected assigned Node in %s, got %s", tt.expectedNodes, assignedNode)
+			}
+
+			checkEIPStatus := func(expectedUsed int) {
+				var gotUsed, gotTotal int
+				err := wait.PollImmediate(200*time.Millisecond, 2*time.Second, func() (done bool, err error) {
+					pool, err := data.crdClient.CrdV1alpha2().ExternalIPPools().Get(context.TODO(), ipPool.Name, metav1.GetOptions{})
+					if err != nil {
+						return false, fmt.Errorf("failed to get ExternalIPPool: %v", err)
+					}
+					gotUsed, gotTotal = pool.Status.Usage.Used, pool.Status.Usage.Total
+					if expectedUsed != pool.Status.Usage.Used {
+						return false, nil
+					}
+					if tt.expectedTotal != pool.Status.Usage.Total {
+						return false, nil
+					}
+					return true, nil
+				})
+				require.NoError(t, err, "ExternalIPPool status not match: expectedTotal=%d, got=%d, expectedUsed=%d, got=%d", tt.expectedTotal, gotTotal, expectedUsed, gotUsed)
+			}
+			checkEIPStatus(1)
+			err = data.clientset.CoreV1().Services(service.Namespace).Delete(context.TODO(), service.Name, metav1.DeleteOptions{})
+			require.NoError(t, err, "Failed to delete Service")
+			checkEIPStatus(0)
+		})
+	}
+}
+
+func testServiceUpdateExternalIP(t *testing.T, data *TestData) {
+	tests := []struct {
+		name               string
+		originalNode       string
+		newNode            string
+		originalIPRange    v1alpha2.IPRange
+		originalExternalIP string
+		newIPRange         v1alpha2.IPRange
+		newExternalIP      string
+	}{
+		{
+			name:               "same Node",
+			originalNode:       nodeName(0),
+			newNode:            nodeName(0),
+			originalIPRange:    v1alpha2.IPRange{CIDR: "169.254.100.0/30"},
+			originalExternalIP: "169.254.100.1",
+			newIPRange:         v1alpha2.IPRange{CIDR: "169.254.101.0/30"},
+			newExternalIP:      "169.254.101.1",
+		},
+		{
+			name:               "different Nodes",
+			originalNode:       nodeName(0),
+			newNode:            nodeName(1),
+			originalIPRange:    v1alpha2.IPRange{CIDR: "169.254.100.0/30"},
+			originalExternalIP: "169.254.100.1",
+			newIPRange:         v1alpha2.IPRange{CIDR: "169.254.101.0/30"},
+			newExternalIP:      "169.254.101.1",
+		},
+	}
+	for idx, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if utilnet.IsIPv6String(tt.originalExternalIP) {
+				skipIfNotIPv6Cluster(t)
+			} else {
+				skipIfNotIPv4Cluster(t)
+			}
+
+			originalPool := data.createExternalIPPool(t, "originalpool-", tt.originalIPRange, nil, map[string]string{v1.LabelHostname: tt.originalNode})
+			defer data.crdClient.CrdV1alpha2().ExternalIPPools().Delete(context.TODO(), originalPool.Name, metav1.DeleteOptions{})
+			newPool := data.createExternalIPPool(t, "newpool-", tt.newIPRange, nil, map[string]string{v1.LabelHostname: tt.newNode})
+			defer data.crdClient.CrdV1alpha2().ExternalIPPools().Delete(context.TODO(), newPool.Name, metav1.DeleteOptions{})
+
+			annotation := map[string]string{
+				antreaagenttypes.ServiceExternalIPPoolAnnotationKey: originalPool.Name,
+			}
+			service, err := data.createServiceWithAnnotations(fmt.Sprintf("test-update-eip-%d", idx),
+				testNamespace, 80, 80, corev1.ProtocolTCP, nil, false, false, v1.ServiceTypeLoadBalancer, nil, annotation)
+			require.NoError(t, err)
+			defer data.clientset.CoreV1().Services(service.Namespace).Delete(context.TODO(), service.Name, metav1.DeleteOptions{})
+
+			service, err = data.waitForServiceConfigured(service, tt.originalExternalIP, true, tt.originalNode)
+			require.NoError(t, err)
+
+			toUpdate := service.DeepCopy()
+			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				toUpdate.Annotations[antreaagenttypes.ServiceExternalIPPoolAnnotationKey] = newPool.Name
+				_, err = data.clientset.CoreV1().Services(toUpdate.Namespace).Update(context.TODO(), toUpdate, metav1.UpdateOptions{})
+				if err != nil && errors.IsConflict(err) {
+					toUpdate, _ = data.clientset.CoreV1().Services(toUpdate.Namespace).Get(context.TODO(), toUpdate.Name, metav1.GetOptions{})
+				}
+				return err
+			})
+			require.NoError(t, err, "Failed to update Service")
+
+			_, err = data.waitForServiceConfigured(service, tt.newExternalIP, true, tt.newNode)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func testServiceNodeFailure(t *testing.T, data *TestData) {
+	if testOptions.providerName != "kind" {
+		t.Skipf("Skipping test because root permission is required")
+	}
+	tests := []struct {
+		name       string
+		ipRange    v1alpha2.IPRange
+		expectedIP string
+	}{
+		{
+			name:       "IPv4 cluster",
+			ipRange:    v1alpha2.IPRange{CIDR: "169.254.100.0/30"},
+			expectedIP: "169.254.100.1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if utilnet.IsIPv6String(tt.expectedIP) {
+				skipIfNotIPv6Cluster(t)
+			} else {
+				skipIfNotIPv4Cluster(t)
+			}
+			signalAgent := func(nodeName, signal string) {
+				cmd := fmt.Sprintf("pkill -%s antrea-agent", signal)
+				rc, stdout, stderr, err := RunCommandOnNode(nodeName, cmd)
+				if rc != 0 || err != nil {
+					t.Errorf("Error when running command '%s' on Node '%s', rc: %d, stdout: %s, stderr: %s, error: %v",
+						cmd, nodeName, rc, stdout, stderr, err)
+				}
+			}
+			pauseAgent := func(evictNode string) {
+				// Send "STOP" signal to antrea-agent.
+				signalAgent(evictNode, "STOP")
+			}
+			restoreAgent := func(evictNode string) {
+				// Send "CONT" signal to antrea-agent.
+				signalAgent(evictNode, "CONT")
+			}
+
+			nodeCandidates := sets.NewString(nodeName(0), nodeName(1))
+			matchExpressions := []metav1.LabelSelectorRequirement{
+				{
+					Key:      v1.LabelHostname,
+					Operator: metav1.LabelSelectorOpIn,
+					Values:   nodeCandidates.List(),
+				},
+			}
+			externalIPPoolTwoNodes := data.createExternalIPPool(t, "pool-with-two-nodes-", tt.ipRange, matchExpressions, nil)
+			defer data.crdClient.CrdV1alpha2().ExternalIPPools().Delete(context.TODO(), externalIPPoolTwoNodes.Name, metav1.DeleteOptions{})
+			annotation := map[string]string{
+				antreaagenttypes.ServiceExternalIPPoolAnnotationKey: externalIPPoolTwoNodes.Name,
+			}
+			service, err := data.createServiceWithAnnotations("test-service-node-failure", testNamespace, 80, 80,
+				corev1.ProtocolTCP, nil, false, false, v1.ServiceTypeLoadBalancer, nil, annotation)
+			require.NoError(t, err)
+			defer data.clientset.CoreV1().Services(service.Namespace).Delete(context.TODO(), service.Name, metav1.DeleteOptions{})
+
+			service, err = data.waitForServiceConfigured(service, tt.expectedIP, true, "")
+			assert.NoError(t, err)
+			_, originalNode := getServiceExternalIPAndHost(service)
+			pauseAgent(originalNode)
+			defer restoreAgent(originalNode)
+
+			var expectedMigratedNode string
+			if originalNode == nodeName(0) {
+				expectedMigratedNode = nodeName(1)
+			} else {
+				expectedMigratedNode = nodeName(0)
+			}
+			service, err = data.waitForServiceConfigured(service, tt.expectedIP, true, expectedMigratedNode)
+			assert.NoError(t, err)
+			restoreAgent(originalNode)
+			_, err = data.waitForServiceConfigured(service, tt.expectedIP, true, originalNode)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func testExternalIPAccess(t *testing.T, data *TestData) {
+	tests := []struct {
+		name            string
+		externalIPCIDR  string
+		clientName      string
+		clientIP        string
+		localIP         string
+		clientIPMaskLen int
+	}{
+		{
+			name:            "IPv4 cluster",
+			externalIPCIDR:  "169.254.170.128/25",
+			clientName:      "eth-ipv4",
+			clientIP:        "169.254.170.1",
+			localIP:         "169.254.170.2",
+			clientIPMaskLen: 24,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			skipIfProxyAllEnabled(t, data)
+			ipFamily := corev1.IPv4Protocol
+			if utilnet.IsIPv6CIDRString(tt.externalIPCIDR) {
+				skipIfNotIPv6Cluster(t)
+				ipFamily = corev1.IPv6Protocol
+			} else {
+				skipIfNotIPv4Cluster(t)
+			}
+			nodes := []string{nodeName(0), nodeName(1)}
+			ipRange := v1alpha2.IPRange{CIDR: tt.externalIPCIDR}
+			ipPool := data.createExternalIPPool(t, "ippool-", ipRange, nil, nil)
+			defer data.crdClient.CrdV1alpha2().ExternalIPPools().Delete(context.TODO(), ipPool.Name, metav1.DeleteOptions{})
+			agnhosts := []string{"agnhost-0", "agnhost-1"}
+			// Create agnhost Pods on each Node.
+			for idx, node := range nodes {
+				createAgnhostPod(t, data, agnhosts[idx], node, false)
+			}
+			var port int32 = 8080
+			externalIPTestCases := []struct {
+				name                       string
+				externalTrafficPolicyLocal bool
+				serviceName                string
+			}{
+				{
+					name:                       "ExternalTrafficPolicy setting to Cluster",
+					externalTrafficPolicyLocal: false,
+					serviceName:                "agnhost-cluster",
+				},
+				{
+					name:                       "ExternalTrafficPolicy setting to Local",
+					externalTrafficPolicyLocal: true,
+					serviceName:                "agnhost-local",
+				},
+			}
+			waitExternalIPConfigured := func(service *v1.Service) (string, string, error) {
+				var ip string
+				var host string
+				err := wait.PollImmediate(200*time.Millisecond, 5*time.Second, func() (done bool, err error) {
+					service, err = data.clientset.CoreV1().Services(service.Namespace).Get(context.TODO(), service.Name, metav1.GetOptions{})
+					if err != nil {
+						return false, err
+					}
+					if len(service.Status.LoadBalancer.Ingress) == 0 || service.Status.LoadBalancer.Ingress[0].IP == "" || service.Status.LoadBalancer.Ingress[0].Hostname == "" {
+						return false, nil
+					}
+					ip = service.Status.LoadBalancer.Ingress[0].IP
+					host = service.Status.LoadBalancer.Ingress[0].Hostname
+					return true, nil
+				})
+				return ip, host, err
+			}
+			for _, et := range externalIPTestCases {
+				t.Run(et.name, func(t *testing.T) {
+					annotations := map[string]string{
+						antreaagenttypes.ServiceExternalIPPoolAnnotationKey: ipPool.Name,
+					}
+					service, err := data.createServiceWithAnnotations(et.serviceName, testNamespace, port, port, corev1.ProtocolTCP, map[string]string{"app": "agnhost"}, false, et.externalTrafficPolicyLocal, corev1.ServiceTypeLoadBalancer, &ipFamily, annotations)
+					require.NoError(t, err)
+					externalIP, host, err := waitExternalIPConfigured(service)
+					require.NoError(t, err)
+
+					// Create a pod in a different netns with the same subnet of the external IP to mock as another Node in the same subnet.
+					cmd := fmt.Sprintf(`ip netns add %[1]s && \
+ip link add dev %[1]s-a type veth peer name %[1]s-b && \
+ip link set dev %[1]s-a netns %[1]s && \
+ip addr add %[3]s/%[4]d dev %[1]s-b && \
+ip link set dev %[1]s-b up && \
+ip netns exec %[1]s ip addr add %[2]s/%[4]d dev %[1]s-a && \
+ip netns exec %[1]s ip link set dev %[1]s-a up && \
+ip netns exec %[1]s \
+sleep 3600`, tt.clientName, tt.clientIP, tt.localIP, tt.clientIPMaskLen)
+
+					baseUrl := net.JoinHostPort(externalIP, strconv.FormatInt(int64(port), 10))
+
+					require.NoError(t, data.createPodOnNode(tt.clientName, testNamespace, host, agnhostImage, []string{"sh", "-c", cmd}, nil, nil, nil, true, func(pod *v1.Pod) {
+						privileged := true
+						pod.Spec.Containers[0].SecurityContext = &v1.SecurityContext{Privileged: &privileged}
+						delete(pod.Labels, "app")
+						// curl will exit immediately if the destination IP is unreachable and will NOT retry despite having retry flags set.
+						// Use an exec readiness probe to ensure the route is configured to the interface.
+						// Refer to https://github.com/curl/curl/issues/1603.
+						probeCmd := strings.Split(fmt.Sprintf("ip netns exec %s curl -s %s", tt.clientName, baseUrl), " ")
+						pod.Spec.Containers[0].ReadinessProbe = &v1.Probe{
+							Handler: v1.Handler{
+								Exec: &v1.ExecAction{
+									Command: probeCmd,
+								},
+							},
+							InitialDelaySeconds: 1,
+							PeriodSeconds:       1,
+						}
+					}))
+
+					_, err = data.podWaitFor(defaultTimeout, tt.clientName, testNamespace, func(p *v1.Pod) (bool, error) {
+						for _, condition := range p.Status.Conditions {
+							if condition.Type == corev1.PodReady {
+								return condition.Status == corev1.ConditionTrue, nil
+							}
+						}
+						return false, nil
+					})
+					require.NoError(t, err)
+					defer data.deletePodAndWait(defaultTimeout, tt.clientName, testNamespace)
+
+					hostNameUrl := fmt.Sprintf("%s/%s", baseUrl, "hostname")
+					probeCmd := fmt.Sprintf("ip netns exec %s curl --connect-timeout 1 --retry 5 --retry-connrefused %s", tt.clientName, hostNameUrl)
+					hostname, stderr, err := data.runCommandFromPod(testNamespace, tt.clientName, "", []string{"sh", "-c", probeCmd})
+					assert.NoError(t, err, "External IP should be able to be connected from remote: %s", stderr)
+
+					if et.externalTrafficPolicyLocal {
+						for idx, node := range nodes {
+							if node == host {
+								assert.Equal(t, agnhosts[idx], hostname, "Hostname should match when ExternalTrafficPolicy setting to Local")
+							}
+						}
+						clientIPUrl := fmt.Sprintf("%s/clientip", baseUrl)
+						probeClientIPCmd := fmt.Sprintf("ip netns exec %s curl --connect-timeout 1 --retry 5 --retry-connrefused %s", tt.clientName, clientIPUrl)
+						clientIPPort, stderr, err := data.runCommandFromPod(testNamespace, tt.clientName, "", []string{"sh", "-c", probeClientIPCmd})
+						assert.NoError(t, err, "External IP should be able to be connected from remote: %s", stderr)
+						clientIP, _, err := net.SplitHostPort(clientIPPort)
+						assert.NoError(t, err)
+						assert.Equal(t, tt.clientIP, clientIP, "Source IP should be preserved when ExternalTrafficPolicy setting to Local")
+					}
+				})
+			}
+		})
+	}
+}
+
+func getServiceExternalIPAndHost(service *v1.Service) (string, string) {
+	if service == nil || len(service.Status.LoadBalancer.Ingress) == 0 {
+		return "", ""
+	}
+	return service.Status.LoadBalancer.Ingress[0].IP, service.Status.LoadBalancer.Ingress[0].Hostname
+}
+
+func (data *TestData) waitForServiceConfigured(service *v1.Service, expectedExternalIP string, waitForNodeConfigured bool, expectedNodeName string, otherNodes ...string) (*corev1.Service, error) {
+	err := wait.PollImmediate(200*time.Millisecond, 15*time.Second, func() (done bool, err error) {
+		service, err = data.clientset.CoreV1().Services(service.Namespace).Get(context.TODO(), service.Name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		if len(service.Status.LoadBalancer.Ingress) == 0 || service.Status.LoadBalancer.Ingress[0].IP != expectedExternalIP {
+			return false, nil
+		}
+		if waitForNodeConfigured || expectedNodeName != "" {
+			if service.Status.LoadBalancer.Ingress[0].Hostname == "" {
+				return false, nil
+			}
+		}
+		if expectedNodeName != "" && service.Status.LoadBalancer.Ingress[0].Hostname != expectedNodeName {
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		return service, fmt.Errorf("wait for Service %q configured failed: %v. Expected external IP %s on Node %s, actual status %#v",
+			service.Name, err, expectedExternalIP, expectedNodeName, service.Status)
+	}
+	err = wait.PollImmediate(200*time.Millisecond, 10*time.Second, func() (done bool, err error) {
+		// Make sure the IP is configured on the expected Node.
+		if expectedNodeName != "" {
+			exists, err := hasIP(data, expectedNodeName, expectedExternalIP)
+			if err != nil || !exists {
+				return false, fmt.Errorf("expected external IP %s to be assigned to Node %s: %v", expectedExternalIP, expectedNodeName, err)
+			}
+		}
+		// Make sure the IP is not configured on the other Nodes.
+		if len(otherNodes) != 0 {
+			for _, node := range otherNodes {
+				exists, err := hasIP(data, node, expectedExternalIP)
+				if err != nil || exists {
+					return false, fmt.Errorf("expected external IP %s not to be assigned to Node %s: %v", expectedExternalIP, expectedNodeName, err)
+				}
+			}
+		}
+		return true, nil
+	})
+	if err != nil {
+		return service, fmt.Errorf("wait for IP assigned to Node failed: %v", err)
+	}
+	return service, nil
+}


### PR DESCRIPTION
Add an externalIP controller which is able to automatically allocate external IPs for LoadBalancer type Services from an IP Pool defined by ExternalIPPool CRD, and configure the external IPs on the Nodes selected by the ExternalIPPool.

Fixes: #3115

Signed-off-by: Shengkai Lin <hi.jefflin@qq.com>