### PR TITLE
Fix IPsec for IPv6 overlays

### DIFF
--- a/build/images/ovs/apply-patches.sh
+++ b/build/images/ovs/apply-patches.sh
@@ -88,6 +88,11 @@ if version_lt "$OVS_VERSION" "2.14.1" ; then
         git apply
 fi
 
+# This patch is necessary to ensure that ovs-monitor-ipsec generates a correct IPsec configuration
+# for strongSwan when using IPv6.
+curl https://github.com/openvswitch/ovs/commit/e59194b606078d90b73f86092f9b76385afa73f0.patch | \
+    git apply
+
 # OVS hardcodes the installation path to /usr/lib/python3.7/dist-packages/ but this location
 # does not seem to be in the Python path in Ubuntu 20.04. There may be a better way to do this,
 # but this seems like an acceptable workaround.


### PR DESCRIPTION
When using IPv6, the IPsec configuration (ipsec.conf) generated by
ovs-monitor-ipsec for strongSwan is currently not correct. A patch has
been submitted upstream, but until it is accepted and merged, we apply a
temporary version of the patch.

This was tested for a VXLAN overlay in an IPv6-only cluster.

Fixes #3151

Signed-off-by: Antonin Bas <abas@vmware.com>