### PR TITLE
Fail in Agent initialization if GRE tunnel type is used with IPv6

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -2728,6 +2728,7 @@ data:
     # - vxlan
     # - gre
     # - stt
+    # Note that "gre" is not supported for IPv6 clusters (IPv6-only or dual-stack clusters).
     #tunnelType: geneve
 
     # Determines how tunnel traffic is encrypted. Currently encryption only works with encap mode.
@@ -2975,7 +2976,7 @@ kind: ConfigMap
 metadata:
   labels:
     app: antrea
-  name: antrea-config-bkgd5728h8
+  name: antrea-config-665mgk228m
   namespace: kube-system
 ---
 apiVersion: v1
@@ -3046,7 +3047,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-bkgd5728h8
+          value: antrea-config-665mgk228m
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -3097,7 +3098,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-bkgd5728h8
+          name: antrea-config-665mgk228m
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -3333,7 +3334,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-bkgd5728h8
+          name: antrea-config-665mgk228m
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -2728,6 +2728,7 @@ data:
     # - vxlan
     # - gre
     # - stt
+    # Note that "gre" is not supported for IPv6 clusters (IPv6-only or dual-stack clusters).
     #tunnelType: geneve
 
     # Determines how tunnel traffic is encrypted. Currently encryption only works with encap mode.
@@ -2975,7 +2976,7 @@ kind: ConfigMap
 metadata:
   labels:
     app: antrea
-  name: antrea-config-bkgd5728h8
+  name: antrea-config-665mgk228m
   namespace: kube-system
 ---
 apiVersion: v1
@@ -3046,7 +3047,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-bkgd5728h8
+          value: antrea-config-665mgk228m
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -3097,7 +3098,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-bkgd5728h8
+          name: antrea-config-665mgk228m
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -3335,7 +3336,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-bkgd5728h8
+          name: antrea-config-665mgk228m
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -2728,6 +2728,7 @@ data:
     # - vxlan
     # - gre
     # - stt
+    # Note that "gre" is not supported for IPv6 clusters (IPv6-only or dual-stack clusters).
     #tunnelType: geneve
 
     # Determines how tunnel traffic is encrypted. Currently encryption only works with encap mode.
@@ -2975,7 +2976,7 @@ kind: ConfigMap
 metadata:
   labels:
     app: antrea
-  name: antrea-config-c8cgkb72ch
+  name: antrea-config-2cfft84t59
   namespace: kube-system
 ---
 apiVersion: v1
@@ -3046,7 +3047,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-c8cgkb72ch
+          value: antrea-config-2cfft84t59
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -3097,7 +3098,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-c8cgkb72ch
+          name: antrea-config-2cfft84t59
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -3336,7 +3337,7 @@ spec:
           path: /home/kubernetes/bin
         name: host-cni-bin
       - configMap:
-          name: antrea-config-c8cgkb72ch
+          name: antrea-config-2cfft84t59
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -2728,6 +2728,7 @@ data:
     # - vxlan
     # - gre
     # - stt
+    # Note that "gre" is not supported for IPv6 clusters (IPv6-only or dual-stack clusters).
     tunnelType: gre
 
     # Determines how tunnel traffic is encrypted. Currently encryption only works with encap mode.
@@ -2980,7 +2981,7 @@ kind: ConfigMap
 metadata:
   labels:
     app: antrea
-  name: antrea-config-7tbgf2gbc9
+  name: antrea-config-2m674972kf
   namespace: kube-system
 ---
 apiVersion: v1
@@ -3060,7 +3061,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-7tbgf2gbc9
+          value: antrea-config-2m674972kf
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -3111,7 +3112,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-7tbgf2gbc9
+          name: antrea-config-2m674972kf
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -3382,7 +3383,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-7tbgf2gbc9
+          name: antrea-config-2m674972kf
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -2728,6 +2728,7 @@ data:
     # - vxlan
     # - gre
     # - stt
+    # Note that "gre" is not supported for IPv6 clusters (IPv6-only or dual-stack clusters).
     #tunnelType: geneve
 
     # Determines how tunnel traffic is encrypted. Currently encryption only works with encap mode.
@@ -2980,7 +2981,7 @@ kind: ConfigMap
 metadata:
   labels:
     app: antrea
-  name: antrea-config-557m769449
+  name: antrea-config-h6d7mmd9hg
   namespace: kube-system
 ---
 apiVersion: v1
@@ -3051,7 +3052,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-557m769449
+          value: antrea-config-h6d7mmd9hg
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -3102,7 +3103,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-557m769449
+          name: antrea-config-h6d7mmd9hg
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -3338,7 +3339,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-557m769449
+          name: antrea-config-h6d7mmd9hg
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/base/conf/antrea-agent.conf
+++ b/build/yamls/base/conf/antrea-agent.conf
@@ -87,6 +87,7 @@ featureGates:
 # - vxlan
 # - gre
 # - stt
+# Note that "gre" is not supported for IPv6 clusters (IPv6-only or dual-stack clusters).
 #tunnelType: geneve
 
 # Determines how tunnel traffic is encrypted. Currently encryption only works with encap mode.

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -321,9 +321,11 @@ to the local Pods on their Nodes.
 
 ### IPsec encryption
 
-Antrea supports encrypting GRE tunnel traffic with IPsec ESP. The IPsec
-implementation leverages [OVS IPsec](http://docs.openvswitch.org/en/latest/tutorials/ipsec)
-and leverages [strongSwan](https://www.strongswan.org) as the IKE daemon.
+Antrea supports encrypting Pod traffic across Linux Nodes with IPsec ESP. The
+IPsec implementation leverages [OVS
+IPsec](http://docs.openvswitch.org/en/latest/tutorials/ipsec) and leverages
+[strongSwan](https://www.strongswan.org) as the IKE daemon. By default GRE
+tunnels are used but other tunnel types are also supported.
 
 To enable IPsec, an extra container -`antrea-ipsec` - must be added to the
 Antrea Agent DaemonSet, which runs the `ovs-monitor-ipsec` and strongSwan

--- a/docs/network-requirements.md
+++ b/docs/network-requirements.md
@@ -3,15 +3,15 @@
 Antrea has a few network requirements to get started, ensure that your hosts and
 firewalls allow the necessary traffic based on your configuration.
 
-| Configuration                 | Host(s)             | ports/protocols                            |
-| ----------------------------- | ------------------- | ------------------------------------------ |
-| Antrea with VXLAN enabled     | All                 | UDP 4789                                   |
-| Antrea with Geneve enabled    | All                 | UDP 6081                                   |
-| Antrea with STT enabled       | All                 | TCP 7471                                   |
-| Antrea with GRE enabled       | All                 | IP Protocol ID 47                          |
-| Antrea with IPsec ESP enabled | All                 | IP protocol ID 50 and 51, UDP 500 and 4500 |
-| All                           | kube-apiserver host | TCP 443 or 6443\*                          |
-| All                           | All                 | TCP 10349, 10350                           |
+| Configuration                 | Host(s)             | ports/protocols                            | Other |
+| ----------------------------- | ------------------- | ------------------------------------------ | ----- |
+| Antrea with VXLAN enabled     | All                 | UDP 4789                                   |       |
+| Antrea with Geneve enabled    | All                 | UDP 6081                                   |       |
+| Antrea with STT enabled       | All                 | TCP 7471                                   |       |
+| Antrea with GRE enabled       | All                 | IP Protocol ID 47                          | No support for IPv6 clusters |
+| Antrea with IPsec ESP enabled | All                 | IP protocol ID 50 and 51, UDP 500 and 4500 |       |
+| All                           | kube-apiserver host | TCP 443 or 6443\*                          |       |
+| All                           | All                 | TCP 10349, 10350                           |       |
 
 \* _The value passed to kube-apiserver using the --secure-port flag. If you cannot
 locate this, check the targetPort value returned by kubectl get svc kubernetes -o yaml._

--- a/docs/traffic-encryption.md
+++ b/docs/traffic-encryption.md
@@ -8,6 +8,10 @@ WireGuard. Traffic encryption is not supported on Windows Nodes yet.
 IPsec encyption works for all tunnel types supported by OVS including Geneve,
 GRE, VXLAN, and STT tunnel.
 
+Note that GRE is not supported for IPv6 clusters (IPv6-only or dual-stack
+clusters). For such clusters, please choose a different tunnel type such as
+Geneve or VXLAN.
+
 ### Prerequisites
 
 IPsec requires a set of Linux kernel modules. Check the required kernel modules
@@ -63,6 +67,10 @@ After updating the PSK value, deploy Antrea with:
 ```bash
 kubectl apply -f antrea-ipsec.yml
 ```
+
+By default, the deployment yaml uses GRE as the tunnel type, which you can
+change by editing the file. You will need to change the tunnel type to another
+one if your cluster supports IPv6.
 
 ## WireGuard
 


### PR DESCRIPTION
The 'gre' tunnel type does not work for IPv6 overlays. The correct
tunnel type for OVS would be 'ip6gre'. For dual-stack clusters with both
an IPv4 and an IPv6 overlay, we would need 2 default tunnel ports: one
for IPv4 (with type 'gre') and one for IPv6 (with type 'ip6gre'). This
would add complexity (and require testing) as the code currently assumes
a single default tunnel port. Rather than trying to support IPv6 with
the added complexity that it entails, we choose to fail during Agent
initialization for now if the user-provided tunnel type is 'gre' and the
cluster supports IPv6.

Note that this means that the default manifest for IPsec
(antrea-ipsec.yml) cannot be used in an IPv6 cluster as the tunnel type
defaults to GRE in that case. However, this is not new, and it is better
to fail explicitly rather than have a cluster where the Agent appears to
be running fine but there is no connectivity.

See #3150

Signed-off-by: Antonin Bas <abas@vmware.com>