### PR TITLE
Fix dual-stack support for Vagrant-based test cluster

### DIFF
--- a/test/e2e/infra/vagrant/Vagrantfile
+++ b/test/e2e/infra/vagrant/Vagrantfile
@@ -69,23 +69,17 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     node.vm.hostname = "k8s-node-control-plane"
     node_ipv4 = NODE_NETWORK_V4_PREFIX + "100"
     node_ipv6 = NODE_NETWORK_V6_PREFIX + "100"
-    if MODE != "v6"
-      node.vm.network "private_network", ip: node_ipv4
-    end
-    if MODE != "v4"
-      node.vm.network "private_network", ip: node_ipv6
-    end
+    # The network will be configured using the Ansible playbook
+    # Despite setting auto_config to false, it seems that it is necessary to
+    # provide an IP address, even though it won't be used.
+    # See https://github.com/hashicorp/vagrant/issues/7583
+    node.vm.network "private_network", ip: node_ipv4, auto_config: false
     if MODE == "v4"
       node_ip = node_ipv4
     elsif MODE == "v6"
       node_ip = node_ipv6
     else
       node_ip = node_ipv4 + "," + node_ipv6
-    end
-
-    if MODE != "v4"
-      # add a fake default route for IPv6: required for ClusterIP traffic even though it is DNATed
-      node.vm.provision :shell, privileged: true, inline: "ip -6 route replace default via " + NODE_NETWORK_V6_PREFIX + "200"
     end
 
     node.vm.provision :ansible  do |ansible|
@@ -95,6 +89,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         # Ubuntu bionic does not ship with python2
         ansible_python_interpreter:"/usr/bin/python3",
         node_ip: node_ip,
+        node_ipv4: (MODE != "v6") ? node_ipv4 : "",
+        node_ipv6: (MODE != "v4") ? node_ipv6 : "",
         node_name: "k8s-node-control-plane",
         k8s_pod_network_cidr: K8S_POD_NETWORK_CIDR,
         k8s_service_network_cidr: K8S_SERVICE_NETWORK_CIDR,
@@ -112,12 +108,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       node.vm.hostname = "k8s-node-worker-#{node_id}"
       node_ipv4 = NODE_NETWORK_V4_PREFIX + "#{100 + node_id}"
       node_ipv6 = NODE_NETWORK_V6_PREFIX + "#{100 + node_id}"
-      if MODE != "v6"
-        node.vm.network "private_network", ip: node_ipv4
-      end
-      if MODE != "v4"
-        node.vm.network "private_network", ip: node_ipv6
-      end
+      node.vm.network "private_network", ip: node_ipv4, auto_config: false
       if MODE == "v4"
         node_ip = node_ipv4
       elsif MODE == "v6"
@@ -126,17 +117,14 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         node_ip = node_ipv4 + "," + node_ipv6
       end
 
-      if MODE != "v4"
-        # add a fake default route for IPv6: required for ClusterIP traffic even though it is DNATed
-        node.vm.provision :shell, privileged: true, inline: "ip -6 route replace default via " + NODE_NETWORK_V6_PREFIX + "200"
-      end
-
       node.vm.provision :ansible do |ansible|
         ansible.playbook = "playbook/k8s.yml"
         ansible.groups = groups
         ansible.extra_vars = {
           ansible_python_interpreter:"/usr/bin/python3",
           node_ip: node_ip,
+          node_ipv4: (MODE != "v6") ? node_ipv4 : "",
+          node_ipv6: (MODE != "v4") ? node_ipv6 : "",
           node_name: "k8s-node-worker-#{node_id}",
         }
       end

--- a/test/e2e/infra/vagrant/playbook/roles/common/tasks/containerd.yml
+++ b/test/e2e/infra/vagrant/playbook/roles/common/tasks/containerd.yml
@@ -14,7 +14,7 @@
     state: present
 
 - name: Loading required kernel modules on boot
-  template: 
+  template:
     src: templates/containerd_modules.conf.j2
     dest: /etc/modules-load.d/containerd.conf
 
@@ -35,7 +35,7 @@
     state: present
     sysctl_file: /etc/sysctl.d/99-kubernetes-cri.conf
     reload: yes
-  with_items: 
+  with_items:
     - { name: net.bridge.bridge-nf-call-iptables, value: 1 }
     - { name: net.ipv4.ip_forward, value: 1 }
     - { name: net.bridge.bridge-nf-call-ip6tables, value: 1 }

--- a/test/e2e/infra/vagrant/playbook/roles/common/tasks/main.yml
+++ b/test/e2e/infra/vagrant/playbook/roles/common/tasks/main.yml
@@ -2,6 +2,8 @@
   assert:
     that: ansible_version.full is version_compare('2.4.0', '>=')
 
+- import_tasks: netplan.yml
+
 - import_tasks: base.yml
 
 - import_tasks: containerd.yml

--- a/test/e2e/infra/vagrant/playbook/roles/common/tasks/netplan.yml
+++ b/test/e2e/infra/vagrant/playbook/roles/common/tasks/netplan.yml
@@ -1,0 +1,9 @@
+- name: Install netplan config file
+  template:
+    src: templates/netplan.conf.j2
+    dest: /etc/netplan/10-networks.yaml
+  register: netplan_config
+
+- name: Apply netplan
+  shell: netplan apply
+  when: netplan_config.changed

--- a/test/e2e/infra/vagrant/playbook/roles/common/templates/netplan.conf.j2
+++ b/test/e2e/infra/vagrant/playbook/roles/common/templates/netplan.conf.j2
@@ -1,0 +1,20 @@
+---
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    # this assumes that the private network created by Vagrant uses this inteface name
+    enp0s8:
+      addresses:
+{% if node_ipv4 != "" %}
+      - {{ node_ipv4 }}/24
+{% endif %}
+{% if node_ipv6 != "" %}
+      - {{ node_ipv6 }}/64
+{% endif %}
+{% if node_ipv6 != "" %}
+      routes:
+      # add a fake default route for IPv6: required for ClusterIP traffic even though it is DNATed
+      - to: ::/0
+        via: fd3b:fcf5:3e92:d732::200
+{% endif %}

--- a/test/e2e/infra/vagrant/playbook/roles/control-plane/templates/kubeadm.conf.j2
+++ b/test/e2e/infra/vagrant/playbook/roles/control-plane/templates/kubeadm.conf.j2
@@ -19,7 +19,7 @@ apiServer:
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 mode: "{{ kube_proxy_mode }}"
-{% if kube_proxy_ipvs_strict_arp -%}
+{% if kube_proxy_ipvs_strict_arp %}
 ipvs:
   strictARP: true
 {% endif %}


### PR DESCRIPTION
Use same private network for IPv4 and IPv6 by using a custom netplan
instead of relying on Vagrant to configure K8s networking. This enables
us to meet the condition that both the Node's IPv4 and IPv6 addresses be
assigned to the same interface (required by Antrea).

Fixes #3157

Signed-off-by: Antonin Bas <abas@vmware.com>