### PR TITLE
Move group ID allocator under path pkg/agent/openflow

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -231,8 +231,10 @@ func run(o *Options) error {
 
 	var groupCounters []proxytypes.GroupCounter
 	groupIDUpdates := make(chan string, 100)
-	v4GroupCounter := proxytypes.NewGroupCounter(false, groupIDUpdates)
-	v6GroupCounter := proxytypes.NewGroupCounter(true, groupIDUpdates)
+	v4GroupIDAllocator := openflow.NewGroupAllocator(false)
+	v4GroupCounter := proxytypes.NewGroupCounter(v4GroupIDAllocator, groupIDUpdates)
+	v6GroupIDAllocator := openflow.NewGroupAllocator(true)
+	v6GroupCounter := proxytypes.NewGroupCounter(v6GroupIDAllocator, groupIDUpdates)
 
 	v4Enabled := networkConfig.IPv4Enabled
 	v6Enabled := networkConfig.IPv6Enabled

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/component-base/metrics/legacyregistry"
 
 	"antrea.io/antrea/pkg/agent/metrics"
+	"antrea.io/antrea/pkg/agent/openflow"
 	proxytypes "antrea.io/antrea/pkg/agent/proxy/types"
 	agenttypes "antrea.io/antrea/pkg/agent/types"
 	"antrea.io/antrea/pkg/apis/controlplane/v1beta2"
@@ -54,7 +55,8 @@ func newTestController() (*Controller, *fake.Clientset, *mockReconciler) {
 	clientset := &fake.Clientset{}
 	ch := make(chan agenttypes.EntityReference, 100)
 	ch2 := make(chan string, 100)
-	groupCounters := []proxytypes.GroupCounter{proxytypes.NewGroupCounter(false, ch2)}
+	groupIDAllocator := openflow.NewGroupAllocator(false)
+	groupCounters := []proxytypes.GroupCounter{proxytypes.NewGroupCounter(groupIDAllocator, ch2)}
 	controller, _ := NewNetworkPolicyController(&antreaClientGetter{clientset}, nil, nil, "node1", ch, groupCounters, ch2,
 		true, true, true, true, testAsyncDeleteInterval, "8.8.8.8:53", true, false)
 	reconciler := newMockReconciler()

--- a/pkg/agent/controller/networkpolicy/reconciler_test.go
+++ b/pkg/agent/controller/networkpolicy/reconciler_test.go
@@ -101,7 +101,8 @@ func newCIDR(cidrStr string) *net.IPNet {
 func newTestReconciler(t *testing.T, controller *gomock.Controller, ifaceStore interfacestore.InterfaceStore, ofClient *openflowtest.MockClient, v4Enabled, v6Enabled bool) *reconciler {
 	f, _ := newMockFQDNController(t, controller, nil)
 	ch := make(chan string, 100)
-	groupCounters := []proxytypes.GroupCounter{proxytypes.NewGroupCounter(false, ch)}
+	groupIDAllocator := openflow.NewGroupAllocator(v6Enabled)
+	groupCounters := []proxytypes.GroupCounter{proxytypes.NewGroupCounter(groupIDAllocator, ch)}
 	r := newReconciler(ofClient, ifaceStore, newIDAllocator(testAsyncDeleteInterval), f, groupCounters, v4Enabled, v6Enabled)
 	return r
 }

--- a/pkg/agent/openflow/groups.go
+++ b/pkg/agent/openflow/groups.go
@@ -1,0 +1,65 @@
+// Copyright 2022 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openflow
+
+import (
+	"sync"
+
+	binding "antrea.io/antrea/pkg/ovs/openflow"
+)
+
+type GroupAllocator interface {
+	Allocate() binding.GroupIDType
+	Release(id binding.GroupIDType)
+}
+
+type groupAllocator struct {
+	// mu is a lock for the groupAllocator.
+	mu sync.Mutex
+
+	groupIDCounter binding.GroupIDType
+	recycled       []binding.GroupIDType
+}
+
+// Allocate allocates a new group ID. It allocates id from the "recycled" slices first, then increases the groupIDCounter if no
+// recycled ids exist.
+func (a *groupAllocator) Allocate() binding.GroupIDType {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	var id binding.GroupIDType
+	if len(a.recycled) != 0 {
+		id = a.recycled[len(a.recycled)-1]
+		a.recycled = a.recycled[:len(a.recycled)-1]
+	} else {
+		a.groupIDCounter += 1
+		id = a.groupIDCounter
+	}
+	return id
+}
+
+func (a *groupAllocator) Release(id binding.GroupIDType) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	a.recycled = append(a.recycled, id)
+}
+
+func NewGroupAllocator(isIPv6 bool) GroupAllocator {
+	var groupIDCounter binding.GroupIDType
+	if isIPv6 {
+		groupIDCounter = 0x10000000
+	}
+	return &groupAllocator{groupIDCounter: groupIDCounter}
+}


### PR DESCRIPTION
The existing code maintains OpenFlow group ID allocator under path
pkg/agent/proxy, and it introduces difficulty for other features to
leverage OpenFlow groups

The change moves OpenFlow group ID new/recycle function to a seperate
struct under path pkg/agent/openflow, and leaves the caches inside the
caller package, then we could have a unique group ID allocator.

Signed-off-by: wenyingd <wenyingd@vmware.com>