### PR TITLE
[CI] Recover integration test by skipping certificate check

### DIFF
--- a/ci/jenkins/test-vmc.sh
+++ b/ci/jenkins/test-vmc.sh
@@ -443,6 +443,7 @@ function deliver_antrea {
 
 function run_integration {
     VM_NAME="antrea-integration-0"
+    export GOVC_INSECURE=1
     export GOVC_URL=${GOVC_URL}
     export GOVC_USERNAME=${GOVC_USERNAME}
     export GOVC_PASSWORD=${GOVC_PASSWORD}


### PR DESCRIPTION
After skipping certificate check, CI integration test will be recovered with new private IP.
The reason is this IP is not yet included in the vCenter certificate.

Signed-off-by: Shuyang Xin <gavinx@vmware.com>