### PR TITLE
Fix IPSec abbr to IPsec

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,7 @@ to effectively get it merged upstream.
   - [Getting reviewers](#getting-reviewers)
   - [Getting your PR verified by CI](#getting-your-pr-verified-by-ci)
   - [Cherry-picks to release branches](#cherry-picks-to-release-branches)
+  - [Conventions for Writing Documentation](#conventions-for-writing-documentation)
   - [Inclusive Naming](#inclusive-naming)
   - [Building and testing your change](#building-and-testing-your-change)
   - [Reverting a commit](#reverting-a-commit)
@@ -130,6 +131,8 @@ To make it easier for reviewers to review your PR, consider the following:
    cannot be fixed automatically, an error message will be displayed so you can address the issue.
 3. Follow [git commit](https://chris.beams.io/posts/git-commit/) guidelines.
 4. Follow [logging](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md) guidelines.
+5. Please refer to [Conventions for Writing Documentation](#conventions-for-writing-documentation) for
+spelling conventions when writing documentation or commenting code.
 
 If your PR fixes a bug or implements a new feature, add the appropriate test
 cases to our [automated test suite](ci/README.md) to guarantee enough
@@ -194,6 +197,11 @@ branches which are still maintained. If this is the case, one of the Antrea
 maintainers will let you know once your PR is approved. Please refer to the
 documentation on [cherry-picks](docs/contributors/cherry-picks.md) for more
 information.
+
+### Conventions for Writing Documentation
+
+* Short name of `IP Security` should be `IPsec` as per [rfc 6071](https://datatracker.ietf.org/doc/html/rfc6071).
+* Any Kubernetes object in log/comment should start with upper case, eg: Namespace, Pod, Service.
 
 ### Inclusive Naming
 

--- a/build/images/ovs/README.md
+++ b/build/images/ovs/README.md
@@ -2,7 +2,7 @@
 
 This directory contains utilities to build a Docker image which includes Open
 vSwitch (OVS) built from source. We build OVS from source because some features
-of Antrea (such as IPSec) require a recent version of OVS, more recent than the
+of Antrea (such as IPsec) require a recent version of OVS, more recent than the
 version included in Ubuntu 20.04. The built image is then used as the base image
 for the Antrea main Docker image.
 

--- a/build/images/scripts/start_ovs_ipsec
+++ b/build/images/scripts/start_ovs_ipsec
@@ -40,7 +40,7 @@ function stop_agents {
 SLEEP_PID=
 
 function quit {
-    log_info $CONTAINER_NAME "Stopping OVS IPSec before quit"
+    log_info $CONTAINER_NAME "Stopping OVS IPsec before quit"
     stop_agents
     # terminate background sleep process
     if [ "$SLEEP_PID" != "" ]; then kill $SLEEP_PID > /dev/null 2>&1 || true; fi
@@ -63,7 +63,7 @@ while true; do
     wait $SLEEP_PID
 
     if ! check_ovs_ipsec_status ; then
-        log_warning $CONTAINER_NAME "OVS IPSec was stopped. Starting it again"
+        log_warning $CONTAINER_NAME "OVS IPsec was stopped. Starting it again"
 
         start_agents
     fi

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -4048,8 +4048,8 @@ data:
     # Determines how tunnel traffic is encrypted. Currently encryption only works with encap mode.
     # It has the following options:
     # - none (default):  Inter-node Pod traffic will not be encrypted.
-    # - ipsec:           Enable IPSec (ESP) encryption for Pod traffic across Nodes. Antrea uses
-    #                    Preshared Key (PSK) for IKE authentication. When IPSec tunnel is enabled,
+    # - ipsec:           Enable IPsec (ESP) encryption for Pod traffic across Nodes. Antrea uses
+    #                    Preshared Key (PSK) for IKE authentication. When IPsec tunnel is enabled,
     #                    the PSK value must be passed to Antrea Agent through an environment
     #                    variable: ANTREA_IPSEC_PSK.
     # - wireGuard:       Enable WireGuard for tunnel traffic encryption.
@@ -4283,7 +4283,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-c5h558tg5g
+  name: antrea-config-7f6684k7bk
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4354,7 +4354,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-c5h558tg5g
+          value: antrea-config-7f6684k7bk
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4405,7 +4405,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-c5h558tg5g
+          name: antrea-config-7f6684k7bk
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4686,7 +4686,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-c5h558tg5g
+          name: antrea-config-7f6684k7bk
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -4048,8 +4048,8 @@ data:
     # Determines how tunnel traffic is encrypted. Currently encryption only works with encap mode.
     # It has the following options:
     # - none (default):  Inter-node Pod traffic will not be encrypted.
-    # - ipsec:           Enable IPSec (ESP) encryption for Pod traffic across Nodes. Antrea uses
-    #                    Preshared Key (PSK) for IKE authentication. When IPSec tunnel is enabled,
+    # - ipsec:           Enable IPsec (ESP) encryption for Pod traffic across Nodes. Antrea uses
+    #                    Preshared Key (PSK) for IKE authentication. When IPsec tunnel is enabled,
     #                    the PSK value must be passed to Antrea Agent through an environment
     #                    variable: ANTREA_IPSEC_PSK.
     # - wireGuard:       Enable WireGuard for tunnel traffic encryption.
@@ -4283,7 +4283,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-c5h558tg5g
+  name: antrea-config-7f6684k7bk
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4354,7 +4354,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-c5h558tg5g
+          value: antrea-config-7f6684k7bk
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4405,7 +4405,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-c5h558tg5g
+          name: antrea-config-7f6684k7bk
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4688,7 +4688,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-c5h558tg5g
+          name: antrea-config-7f6684k7bk
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -4048,8 +4048,8 @@ data:
     # Determines how tunnel traffic is encrypted. Currently encryption only works with encap mode.
     # It has the following options:
     # - none (default):  Inter-node Pod traffic will not be encrypted.
-    # - ipsec:           Enable IPSec (ESP) encryption for Pod traffic across Nodes. Antrea uses
-    #                    Preshared Key (PSK) for IKE authentication. When IPSec tunnel is enabled,
+    # - ipsec:           Enable IPsec (ESP) encryption for Pod traffic across Nodes. Antrea uses
+    #                    Preshared Key (PSK) for IKE authentication. When IPsec tunnel is enabled,
     #                    the PSK value must be passed to Antrea Agent through an environment
     #                    variable: ANTREA_IPSEC_PSK.
     # - wireGuard:       Enable WireGuard for tunnel traffic encryption.
@@ -4283,7 +4283,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-h72246h8f2
+  name: antrea-config-25dm52hdd6
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4354,7 +4354,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-h72246h8f2
+          value: antrea-config-25dm52hdd6
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4405,7 +4405,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-h72246h8f2
+          name: antrea-config-25dm52hdd6
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4689,7 +4689,7 @@ spec:
           path: /home/kubernetes/bin
         name: host-cni-bin
       - configMap:
-          name: antrea-config-h72246h8f2
+          name: antrea-config-25dm52hdd6
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -4048,8 +4048,8 @@ data:
     # Determines how tunnel traffic is encrypted. Currently encryption only works with encap mode.
     # It has the following options:
     # - none (default):  Inter-node Pod traffic will not be encrypted.
-    # - ipsec:           Enable IPSec (ESP) encryption for Pod traffic across Nodes. Antrea uses
-    #                    Preshared Key (PSK) for IKE authentication. When IPSec tunnel is enabled,
+    # - ipsec:           Enable IPsec (ESP) encryption for Pod traffic across Nodes. Antrea uses
+    #                    Preshared Key (PSK) for IKE authentication. When IPsec tunnel is enabled,
     #                    the PSK value must be passed to Antrea Agent through an environment
     #                    variable: ANTREA_IPSEC_PSK.
     # - wireGuard:       Enable WireGuard for tunnel traffic encryption.
@@ -4288,7 +4288,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-557h844gdh
+  name: antrea-config-f6c667c75f
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4368,7 +4368,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-557h844gdh
+          value: antrea-config-f6c667c75f
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4419,7 +4419,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-557h844gdh
+          name: antrea-config-f6c667c75f
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4735,7 +4735,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-557h844gdh
+          name: antrea-config-f6c667c75f
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-kind.yml
+++ b/build/yamls/antrea-kind.yml
@@ -4048,8 +4048,8 @@ data:
     # Determines how tunnel traffic is encrypted. Currently encryption only works with encap mode.
     # It has the following options:
     # - none (default):  Inter-node Pod traffic will not be encrypted.
-    # - ipsec:           Enable IPSec (ESP) encryption for Pod traffic across Nodes. Antrea uses
-    #                    Preshared Key (PSK) for IKE authentication. When IPSec tunnel is enabled,
+    # - ipsec:           Enable IPsec (ESP) encryption for Pod traffic across Nodes. Antrea uses
+    #                    Preshared Key (PSK) for IKE authentication. When IPsec tunnel is enabled,
     #                    the PSK value must be passed to Antrea Agent through an environment
     #                    variable: ANTREA_IPSEC_PSK.
     # - wireGuard:       Enable WireGuard for tunnel traffic encryption.
@@ -4288,7 +4288,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-f7dbh45mc5
+  name: antrea-config-mcf8bf8b2m
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4359,7 +4359,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-f7dbh45mc5
+          value: antrea-config-mcf8bf8b2m
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4410,7 +4410,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-f7dbh45mc5
+          name: antrea-config-mcf8bf8b2m
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4687,7 +4687,7 @@ spec:
           type: CharDevice
         name: dev-tun
       - configMap:
-          name: antrea-config-f7dbh45mc5
+          name: antrea-config-mcf8bf8b2m
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -4048,8 +4048,8 @@ data:
     # Determines how tunnel traffic is encrypted. Currently encryption only works with encap mode.
     # It has the following options:
     # - none (default):  Inter-node Pod traffic will not be encrypted.
-    # - ipsec:           Enable IPSec (ESP) encryption for Pod traffic across Nodes. Antrea uses
-    #                    Preshared Key (PSK) for IKE authentication. When IPSec tunnel is enabled,
+    # - ipsec:           Enable IPsec (ESP) encryption for Pod traffic across Nodes. Antrea uses
+    #                    Preshared Key (PSK) for IKE authentication. When IPsec tunnel is enabled,
     #                    the PSK value must be passed to Antrea Agent through an environment
     #                    variable: ANTREA_IPSEC_PSK.
     # - wireGuard:       Enable WireGuard for tunnel traffic encryption.
@@ -4288,7 +4288,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-gg2666bbdt
+  name: antrea-config-m8g64b5282
   namespace: kube-system
 ---
 apiVersion: v1
@@ -4359,7 +4359,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-gg2666bbdt
+          value: antrea-config-m8g64b5282
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -4410,7 +4410,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-gg2666bbdt
+          name: antrea-config-m8g64b5282
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -4691,7 +4691,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-gg2666bbdt
+          name: antrea-config-m8g64b5282
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/base/conf/antrea-agent.conf
+++ b/build/yamls/base/conf/antrea-agent.conf
@@ -83,8 +83,8 @@ featureGates:
 # Determines how tunnel traffic is encrypted. Currently encryption only works with encap mode.
 # It has the following options:
 # - none (default):  Inter-node Pod traffic will not be encrypted.
-# - ipsec:           Enable IPSec (ESP) encryption for Pod traffic across Nodes. Antrea uses
-#                    Preshared Key (PSK) for IKE authentication. When IPSec tunnel is enabled,
+# - ipsec:           Enable IPsec (ESP) encryption for Pod traffic across Nodes. Antrea uses
+#                    Preshared Key (PSK) for IKE authentication. When IPsec tunnel is enabled,
 #                    the PSK value must be passed to Antrea Agent through an environment
 #                    variable: ANTREA_IPSEC_PSK.
 # - wireGuard:       Enable WireGuard for tunnel traffic encryption.

--- a/build/yamls/patches/ipsec/pskEnv.yml
+++ b/build/yamls/patches/ipsec/pskEnv.yml
@@ -8,7 +8,7 @@ spec:
       containers:
         - name: antrea-agent
           env:
-            # Pre-shared key for IPSec IKE.
+            # Pre-shared key for IPsec IKE.
             - name: ANTREA_IPSEC_PSK
               valueFrom:
                 secretKeyRef:

--- a/docs/contributors/github-labels.md
+++ b/docs/contributors/github-labels.md
@@ -77,7 +77,7 @@ The labels in this list originated within Kubernetes at
 | area/transit/addressing            | Issues or PRs related to IP addressing category (unicast, multicast, broadcast, anycast) | Any |
 | area/transit/egress                | Issues or PRs related to Egress (SNAT for traffic egressing the cluster) | Any |
 | area/transit/encapsulation         | Issues or PRs related to encapsulation | Any |
-| area/transit/encryption            | Issues or PRs related to transit encryption (IPSec, SSL) | Any |
+| area/transit/encryption            | Issues or PRs related to transit encryption (IPsec, SSL) | Any |
 | area/transit/ipv6                  | Issues or PRs related to IPv6 | Any |
 | area/transit/qos                   | Issues or PRs related to transit qos or policing | Any |
 | area/transit/routing               | Issues or PRs related to routing and forwarding | Any |

--- a/docs/network-requirements.md
+++ b/docs/network-requirements.md
@@ -9,7 +9,7 @@ firewalls allow the necessary traffic based on your configuration.
 | Antrea with Geneve enabled    | All                 | UDP 6081                                   |
 | Antrea with STT enabled       | All                 | TCP 7471                                   |
 | Antrea with GRE enabled       | All                 | IP Protocol ID 47                          |
-| Antrea with IPSec ESP enabled | All                 | IP protocol ID 50 and 51, UDP 500 and 4500 |
+| Antrea with IPsec ESP enabled | All                 | IP protocol ID 50 and 51, UDP 500 and 4500 |
 | All                           | kube-apiserver host | TCP 443 or 6443\*                          |
 | All                           | All                 | TCP 10349, 10350                           |
 

--- a/hack/generate-manifest.sh
+++ b/hack/generate-manifest.sh
@@ -26,7 +26,7 @@ Generate a YAML manifest for Antrea using Kustomize and print it to stdout.
         --encap-mode                  Traffic encapsulation mode. (default is 'encap')
         --kind                        Generate a manifest appropriate for running Antrea in a Kind cluster
         --cloud                       Generate a manifest appropriate for running Antrea in Public Cloud
-        --ipsec                       Generate a manifest with IPSec encryption of tunnel traffic enabled
+        --ipsec                       Generate a manifest with IPsec encryption of tunnel traffic enabled
         --all-features                Generate a manifest with all alpha features enabled
         --no-proxy                    Generate a manifest with Antrea proxy disabled
         --proxy-all                   Generate a manifest with Antrea proxy with all Service support enabled
@@ -299,7 +299,7 @@ fi
 
 if $IPSEC; then
     sed -i.bak -E "s/^[[:space:]]*#[[:space:]]*trafficEncryptionMode[[:space:]]*:[[:space:]]*[a-z]+[[:space:]]*$/trafficEncryptionMode: ipsec/" antrea-agent.conf
-    # change the tunnel type to GRE which works better with IPSec encryption than other types.
+    # change the tunnel type to GRE which works better with IPsec encryption than other types.
     sed -i.bak -E "s/^[[:space:]]*#[[:space:]]*tunnelType[[:space:]]*:[[:space:]]*[a-z]+[[:space:]]*$/tunnelType: gre/" antrea-agent.conf
 fi
 
@@ -377,7 +377,7 @@ if $IPSEC; then
     $KUSTOMIZE edit add base $BASE
     # create a K8s Secret to save the PSK (pre-shared key) for IKE authentication.
     $KUSTOMIZE edit add resource ipsecSecret.yml
-    # add a container to the Agent DaemonSet that runs the OVS IPSec and strongSwan daemons.
+    # add a container to the Agent DaemonSet that runs the OVS IPsec and strongSwan daemons.
     $KUSTOMIZE edit add patch --path ipsecContainer.yml
     # add an environment variable to the antrea-agent container for passing the PSK to Agent.
     $KUSTOMIZE edit add patch --path pskEnv.yml

--- a/pkg/agent/controller/noderoute/node_route_controller.go
+++ b/pkg/agent/controller/noderoute/node_route_controller.go
@@ -549,8 +549,8 @@ func (c *Controller) addNodeRoute(nodeName string, node *corev1.Node) error {
 
 	var ipsecTunOFPort uint32
 	if c.networkConfig.TrafficEncryptionMode == config.TrafficEncryptionModeIPSec {
-		// Create a separate tunnel port for the Node, as OVS IPSec monitor needs to
-		// read PSK and remote IP from the Node's tunnel interface to create IPSec
+		// Create a separate tunnel port for the Node, as OVS IPsec monitor needs to
+		// read PSK and remote IP from the Node's tunnel interface to create IPsec
 		// security policies.
 		peerNodeIP := peerNodeIPs.IPv4
 		if peerNodeIP == nil {
@@ -622,7 +622,7 @@ func getPodCIDRsOnNode(node *corev1.Node) []string {
 	return []string{node.Spec.PodCIDR}
 }
 
-// createIPSecTunnelPort creates an IPSec tunnel port for the remote Node if the
+// createIPSecTunnelPort creates an IPsec tunnel port for the remote Node if the
 // tunnel does not exist, and returns the ofport number.
 func (c *Controller) createIPSecTunnelPort(nodeName string, nodeIP net.IP) (int32, error) {
 	portName := util.GenerateNodeTunnelInterfaceName(nodeName)
@@ -632,15 +632,15 @@ func (c *Controller) createIPSecTunnelPort(nodeName string, nodeIP net.IP) (int3
 	// tunnel port for which the configuration has changed, return error to requeue the Node.
 	if exists {
 		if !c.compareInterfaceConfig(interfaceConfig, nodeIP, portName) {
-			klog.InfoS("IPSec tunnel interface config doesn't match the cached one, deleting the stale IPSec tunnel port", "node", nodeName, "interface", interfaceConfig.InterfaceName)
+			klog.InfoS("IPsec tunnel interface config doesn't match the cached one, deleting the stale IPsec tunnel port", "node", nodeName, "interface", interfaceConfig.InterfaceName)
 			if err := c.ovsBridgeClient.DeletePort(interfaceConfig.PortUUID); err != nil {
-				return 0, fmt.Errorf("fail to delete the stale IPSec tunnel port %s: %v", interfaceConfig.InterfaceName, err)
+				return 0, fmt.Errorf("fail to delete the stale IPsec tunnel port %s: %v", interfaceConfig.InterfaceName, err)
 			}
 			c.interfaceStore.DeleteInterface(interfaceConfig)
 			exists = false
 		} else {
 			if interfaceConfig.OFPort != 0 {
-				klog.V(2).InfoS("Found cached IPSec tunnel interface", "node", nodeName, "interface", interfaceConfig.InterfaceName, "port", interfaceConfig.OFPort)
+				klog.V(2).InfoS("Found cached IPsec tunnel interface", "node", nodeName, "interface", interfaceConfig.InterfaceName, "port", interfaceConfig.OFPort)
 				return interfaceConfig.OFPort, nil
 			}
 		}
@@ -657,9 +657,9 @@ func (c *Controller) createIPSecTunnelPort(nodeName string, nodeIP net.IP) (int3
 			c.networkConfig.IPSecPSK,
 			ovsExternalIDs)
 		if err != nil {
-			return 0, fmt.Errorf("failed to create IPSec tunnel port for Node %s", nodeName)
+			return 0, fmt.Errorf("failed to create IPsec tunnel port for Node %s", nodeName)
 		}
-		klog.Infof("Created IPSec tunnel port %s for Node %s", portName, nodeName)
+		klog.Infof("Created IPsec tunnel port %s for Node %s", portName, nodeName)
 
 		ovsPortConfig := &interfacestore.OVSPortConfig{PortUUID: portUUID}
 		interfaceConfig = interfacestore.NewIPSecTunnelInterface(
@@ -676,14 +676,14 @@ func (c *Controller) createIPSecTunnelPort(nodeName string, nodeIP net.IP) (int3
 	if err != nil {
 		// Could be a temporary OVSDB connection failure or timeout.
 		// Let NodeRouteController retry at errors.
-		return 0, fmt.Errorf("failed to get of_port of IPSec tunnel port for Node %s", nodeName)
+		return 0, fmt.Errorf("failed to get of_port of IPsec tunnel port for Node %s", nodeName)
 	}
 	interfaceConfig.OFPort = ofPort
 	return ofPort, nil
 }
 
 // ParseTunnelInterfaceConfig initializes and returns an InterfaceConfig struct
-// for a tunnel interface. It reads tunnel type, remote IP, IPSec PSK from the
+// for a tunnel interface. It reads tunnel type, remote IP, IPsec PSK from the
 // OVS interface options, and NodeName from the OVS port external_ids.
 // nil is returned, if the OVS port and interface configurations are not valid
 // for a tunnel interface.

--- a/pkg/agent/interfacestore/interface_cache.go
+++ b/pkg/agent/interfacestore/interface_cache.go
@@ -51,7 +51,7 @@ const (
 //     IP, MAC, and OVS Port configurations.
 //  2) For host gateway port, the fields should include: name, IP, MAC, and OVS port
 //     configurations.
-//  3) For tunnel port, the fields include: name and tunnel type; and for an IPSec tunnel,
+//  3) For tunnel port, the fields include: name and tunnel type; and for an IPsec tunnel,
 //     additionally: remoteIP, PSK and remote Node name.
 // OVS Port configurations include PortUUID and OFPort.
 // Container interface is added into cache after invocation of cniserver.CmdAdd, and removed
@@ -59,7 +59,7 @@ const (
 // check previousResult with local cache.
 // Host gateway and the default tunnel interfaces are added into cache in node initialization
 // phase or retrieved from existing OVS ports.
-// An IPSec tunnel interface is added into the cache when IPSec encyption is enabled, and
+// An IPsec tunnel interface is added into the cache when IPsec encyption is enabled, and
 // NodeRouteController watches a new remote Node from K8s API, and is removed when the remote
 // Node is deleted.
 // Todo: add periodic task to sync local cache with container veth pair

--- a/pkg/agent/interfacestore/types.go
+++ b/pkg/agent/interfacestore/types.go
@@ -136,7 +136,7 @@ func NewTunnelInterface(tunnelName string, tunnelType ovsconfig.TunnelType, loca
 	return &InterfaceConfig{InterfaceName: tunnelName, Type: TunnelInterface, TunnelInterfaceConfig: tunnelConfig}
 }
 
-// NewIPSecTunnelInterface creates InterfaceConfig for the IPSec tunnel to the
+// NewIPSecTunnelInterface creates InterfaceConfig for the IPsec tunnel to the
 // Node.
 func NewIPSecTunnelInterface(interfaceName string, tunnelType ovsconfig.TunnelType, nodeName string, nodeIP net.IP, psk string) *InterfaceConfig {
 	tunnelConfig := &TunnelInterfaceConfig{Type: tunnelType, NodeName: nodeName, RemoteIP: nodeIP, PSK: psk}

--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -60,8 +60,8 @@ type Client interface {
 	InstallDefaultTunnelFlows() error
 
 	// InstallNodeFlows should be invoked when a connection to a remote Node is going to be set
-	// up. The hostname is used to identify the added flows. When IPSec tunnel is enabled,
-	// ipsecTunOFPort must be set to the OFPort number of the IPSec tunnel port to the remote Node;
+	// up. The hostname is used to identify the added flows. When IPsec tunnel is enabled,
+	// ipsecTunOFPort must be set to the OFPort number of the IPsec tunnel port to the remote Node;
 	// otherwise ipsecTunOFPort must be set to 0.
 	// InstallNodeFlows has all-or-nothing semantics(call succeeds if all the flows are installed
 	// successfully, otherwise no flows will be installed). Calls to InstallNodeFlows are idempotent.
@@ -468,9 +468,9 @@ func (c *client) InstallNodeFlows(hostname string,
 		}
 	}
 	if ipsecTunOFPort != 0 {
-		// When IPSec tunnel is enabled, packets received from the remote Node are
-		// input from the Node's IPSec tunnel port, not the default tunnel port. So,
-		// add a separate tunnelClassifierFlow for the IPSec tunnel port.
+		// When IPsec tunnel is enabled, packets received from the remote Node are
+		// input from the Node's IPsec tunnel port, not the default tunnel port. So,
+		// add a separate tunnelClassifierFlow for the IPsec tunnel port.
 		flows = append(flows, c.tunnelClassifierFlow(ipsecTunOFPort, cookie.Node))
 	}
 

--- a/pkg/config/agent/config.go
+++ b/pkg/config/agent/config.go
@@ -94,8 +94,8 @@ type AgentConfig struct {
 	// Determines how tunnel traffic is encrypted.
 	// It has the following options:
 	// - none (default): Inter-node Pod traffic will not be encrypted.
-	// - ipsec:          Enable IPSec (ESP) encryption for Pod traffic across Nodes. Antrea uses
-	//                   Preshared Key (PSK) for IKE authentication. When IPSec tunnel is enabled,
+	// - ipsec:          Enable IPsec (ESP) encryption for Pod traffic across Nodes. Antrea uses
+	//                   Preshared Key (PSK) for IKE authentication. When IPsec tunnel is enabled,
 	//                   the PSK value must be passed to Antrea Agent through an environment
 	//                   variable: ANTREA_IPSEC_PSK.
 	// - wireguard:      Enable WireGuard for tunnel traffic encryption.

--- a/pkg/ovs/ovsconfig/ovs_client.go
+++ b/pkg/ovs/ovsconfig/ovs_client.go
@@ -380,8 +380,8 @@ func (br *OVSBridge) CreateTunnelPort(name string, tunnelType TunnelType, ofPort
 // If ofPortRequest is not zero, it will be passed to the OVS port creation.
 // If remoteIP is not empty, it will be set to the tunnel port interface
 // options; otherwise flow based tunneling will be configured.
-// psk is for the pre-shared key of IPSec ESP tunnel. If it is not empty, it
-// will be set to the tunnel port interface options. Flow based IPSec tunnel is
+// psk is for the pre-shared key of IPsec ESP tunnel. If it is not empty, it
+// will be set to the tunnel port interface options. Flow based IPsec tunnel is
 // not supported, so remoteIP must be provided too when psk is not empty.
 // If externalIDs is not nill, the IDs in it will be added to the port's
 // external_ids.
@@ -395,7 +395,7 @@ func (br *OVSBridge) CreateTunnelPortExt(
 	psk string,
 	externalIDs map[string]interface{}) (string, Error) {
 	if psk != "" && remoteIP == "" {
-		return "", newInvalidArgumentsError("IPSec tunnel can not be flow based. remoteIP must be set")
+		return "", newInvalidArgumentsError("IPsec tunnel can not be flow based. remoteIP must be set")
 	}
 	return br.createTunnelPort(name, tunnelType, ofPortRequest, csum, localIP, remoteIP, psk, externalIDs)
 }
@@ -478,7 +478,7 @@ func (br *OVSBridge) SetInterfaceOptions(name string, options map[string]interfa
 	return nil
 }
 
-// ParseTunnelInterfaceOptions reads remote IP, local IP, IPSec PSK, and csum
+// ParseTunnelInterfaceOptions reads remote IP, local IP, IPsec PSK, and csum
 // from the tunnel interface options and returns them.
 func ParseTunnelInterfaceOptions(portData *OVSPortData) (net.IP, net.IP, string, bool) {
 	if portData.Options == nil {

--- a/test/e2e/ipsec_test.go
+++ b/test/e2e/ipsec_test.go
@@ -26,9 +26,9 @@ import (
 )
 
 // TestIPSec is the top-level test which contains all subtests for
-// IPSec related test cases so they can share setup, teardown.
+// IPsec related test cases so they can share setup, teardown.
 func TestIPSec(t *testing.T) {
-	skipIfProviderIs(t, "kind", "IPSec tunnel does not work with Kind")
+	skipIfProviderIs(t, "kind", "IPsec tunnel does not work with Kind")
 	skipIfIPv6Cluster(t)
 	skipIfNumNodesLessThan(t, 2)
 	skipIfHasWindowsNodes(t)
@@ -73,10 +73,10 @@ func (data *TestData) readSecurityAssociationsStatus(nodeName string) (up int, c
 }
 
 // testIPSecTunnelConnectivity checks that Pod traffic across two Nodes over
-// the IPSec tunnel, by creating multiple Pods across distinct Nodes and having
+// the IPsec tunnel, by creating multiple Pods across distinct Nodes and having
 // them ping each other.
 func testIPSecTunnelConnectivity(t *testing.T, data *TestData) {
-	t.Logf("Redeploy Antrea with IPSec tunnel enabled")
+	t.Logf("Redeploy Antrea with IPsec tunnel enabled")
 	data.redeployAntrea(t, deployAntreaIPsec)
 
 	data.testPodConnectivityDifferentNodes(t)
@@ -92,7 +92,7 @@ func testIPSecTunnelConnectivity(t *testing.T, data *TestData) {
 		t.Logf("Found %d 'up' SecurityAssociation(s) for Node '%s'", up, nodeName)
 	}
 
-	// Restore normal Antrea deployment with IPSec disabled.
+	// Restore normal Antrea deployment with IPsec disabled.
 	data.redeployAntrea(t, deployAntreaDefault)
 }
 
@@ -100,7 +100,7 @@ func testIPSecTunnelConnectivity(t *testing.T, data *TestData) {
 // non-encrypted mode, the previously created tunnel ports are deleted
 // correctly.
 func testIPSecDeleteStaleTunnelPorts(t *testing.T, data *TestData) {
-	t.Logf("Redeploy Antrea with IPSec tunnel enabled")
+	t.Logf("Redeploy Antrea with IPsec tunnel enabled")
 	data.redeployAntrea(t, deployAntreaIPsec)
 
 	nodeName0 := nodeName(0)
@@ -132,7 +132,7 @@ func testIPSecDeleteStaleTunnelPorts(t *testing.T, data *TestData) {
 		t.Fatalf("Error while waiting for OVS tunnel port to be created")
 	}
 
-	t.Logf("Redeploy Antrea with IPSec tunnel disabled")
+	t.Logf("Redeploy Antrea with IPsec tunnel disabled")
 	data.redeployAntrea(t, deployAntreaDefault)
 
 	t.Logf("Checking that tunnel port has been deleted")


### PR DESCRIPTION
1. according to [rfc6071](https://datatracker.ietf.org/doc/html/rfc6071), correct abbr
   for `IP security` should be `IPsec`, replace all `IPSec` to `IPsec`
2. add a new section to highlight some general words and abbreviations

Signed-off-by: Lan Luo <luola@vmware.com>