### PR TITLE
Fix leader eletion timeout issue

### DIFF
--- a/multicluster/build/yamls/antrea-multicluster-leader-namespaced.yml
+++ b/multicluster/build/yamls/antrea-multicluster-leader-namespaced.yml
@@ -511,13 +511,15 @@ data:
     webhook:
       port: 9443
     leaderElection:
-      leaderElect: true
+      leaderElect: false
       resourceName: 6536456a.crd.antrea.io
+      leaseDuration: "30s"
+      renewDeadline: "20s"
 kind: ConfigMap
 metadata:
   labels:
     app: antrea
-  name: antrea-mc-controller-config-kk4mdd82g2
+  name: antrea-mc-controller-config-49875k4ht8
   namespace: changeme
 ---
 apiVersion: v1
@@ -619,7 +621,7 @@ spec:
       terminationGracePeriodSeconds: 10
       volumes:
       - configMap:
-          name: antrea-mc-controller-config-kk4mdd82g2
+          name: antrea-mc-controller-config-49875k4ht8
         name: antrea-mc-controller-config
 ---
 apiVersion: admissionregistration.k8s.io/v1

--- a/multicluster/build/yamls/antrea-multicluster-member.yml
+++ b/multicluster/build/yamls/antrea-multicluster-member.yml
@@ -1702,13 +1702,15 @@ data:
     webhook:
       port: 9443
     leaderElection:
-      leaderElect: true
+      leaderElect: false
       resourceName: 6536456a.crd.antrea.io
+      leaseDuration: "30s"
+      renewDeadline: "20s"
 kind: ConfigMap
 metadata:
   labels:
     app: antrea
-  name: antrea-mc-controller-config-kk4mdd82g2
+  name: antrea-mc-controller-config-49875k4ht8
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1810,7 +1812,7 @@ spec:
       terminationGracePeriodSeconds: 10
       volumes:
       - configMap:
-          name: antrea-mc-controller-config-kk4mdd82g2
+          name: antrea-mc-controller-config-49875k4ht8
         name: antrea-mc-controller-config
 ---
 apiVersion: admissionregistration.k8s.io/v1

--- a/multicluster/cmd/multicluster-controller/controller.go
+++ b/multicluster/cmd/multicluster-controller/controller.go
@@ -113,7 +113,7 @@ func getMutationWebhooks(controllerNs string) []string {
 
 func setupManagerAndCertController(o *Options) (manager.Manager, error) {
 	opts := zap.Options{
-		Development: true,
+		Development: false,
 	}
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))

--- a/multicluster/cmd/multicluster-controller/options.go
+++ b/multicluster/cmd/multicluster-controller/options.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/spf13/pflag"
 	"k8s.io/klog/v2"
@@ -63,11 +64,16 @@ func (o *Options) addFlags(fs *pflag.FlagSet) {
 }
 
 func (o *Options) setDefaults() {
+	// see https://github.com/operator-framework/operator-sdk/issues/1813
+	leaseDuration := 30 * time.Second
+	renewDeadline := 20 * time.Second
 	o.options = ctrl.Options{
 		Scheme:                 scheme,
 		MetricsBindAddress:     ":8080",
 		Port:                   9443,
 		HealthProbeBindAddress: ":8081",
 		LeaderElection:         false,
+		LeaseDuration:          &leaseDuration,
+		RenewDeadline:          &renewDeadline,
 	}
 }

--- a/multicluster/config/default/configmap/controller_manager_config.yaml
+++ b/multicluster/config/default/configmap/controller_manager_config.yaml
@@ -7,5 +7,7 @@ metrics:
 webhook:
   port: 9443
 leaderElection:
-  leaderElect: true
+  leaderElect: false
   resourceName: 6536456a.crd.antrea.io
+  leaseDuration: "30s"
+  renewDeadline: "20s"


### PR DESCRIPTION
I found below error in a long running MC controller, so increase the
timeout, and disable leader election by default in config yaml.
```
E0106 07:29:05.501113       1 leaderelection.go:361] Failed to update lock: context deadline exceeded
I0106 07:29:05.895992       1 leaderelection.go:278] failed to renew lease antrea-mcs-ns/6536456a.crd.antrea.io: timed out waiting for the condition
2022-01-06T07:29:05.896Z	DEBUG	controller-runtime.manager.events	Normal	{"object": {"kind":"ConfigMap","namespace":"antrea-mcs-ns","name":"6536456a.crd.antrea.io","uid":"a4de74cd-0441-4140-a78b-acf163055f91","apiVersion":"v1","resourceVersion":"23629919"}, "reason": "LeaderElection", "message": "antrea-mc-controller-6dcb88b9d6-vxqvm_e1b1b0a9-b2b5-471f-b424-b11a34343d64 stopped leading"}
2022-01-06T07:29:05.999Z	DEBUG	controller-runtime.manager.events	Normal	{"object": {"kind":"Lease","namespace":"antrea-mcs-ns","name":"6536456a.crd.antrea.io","uid":"6709c340-ee00-459b-b186-e56c15fbde67","apiVersion":"coordination.k8s.io/v1","resourceVersion":"23629901"}, "reason": "LeaderElection", "message": "antrea-mc-controller-6dcb88b9d6-vxqvm_e1b1b0a9-b2b5-471f-b424-b11a34343d64 stopped leading"}
2022-01-06T07:29:05.598Z	DEBUG	controller-runtime.webhook.webhooks	received request	{"webhook": "/validate-multicluster-crd-antrea-io-v1alpha1-memberclusterannounce", "UID": "da938dc5-cbda-4714-a9f3-f25d7f105353", "kind": "multicluster.crd.antrea.io/v1alpha1, Kind=MemberClusterAnnounce", "resource": {"group":"multicluster.crd.antrea.io","version":"v1alpha1","resource":"memberclusterannounces"}}
F0106 07:29:06.099280       1 leader.go:41] Error running controller: error running Manager: leader election lost
```
refer to https://github.com/operator-framework/operator-sdk/issues/1813

Signed-off-by: Lan Luo <luola@vmware.com>