### PR TITLE
Add Go version to full version string for Antrea binaries

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -65,8 +65,9 @@ func GetFullVersion() string {
 }
 
 // GetFullVersionWithRuntimeInfo returns the same version string as GetFullVersion but appends
-// "<GOOS>/<GOARCH>", where GOOS is the running program's operating system target (e.g. darwin,
-// linux) and GOARCH is the the running program's architecture target (e.g. amd64).
+// "<GOOS>/<GOARCH> <GOVERSION>", where GOOS is the running program's operating system target
+// (e.g. darwin, linux), GOARCH is the the running program's architecture target (e.g. amd64), and
+// GOVERSION is the Go version used to build the current binary.
 func GetFullVersionWithRuntimeInfo() string {
-	return fmt.Sprintf("%s %s/%s", GetFullVersion(), runtime.GOOS, runtime.GOARCH)
+	return fmt.Sprintf("%s %s/%s %s", GetFullVersion(), runtime.GOOS, runtime.GOARCH, runtime.Version())
 }


### PR DESCRIPTION
While this can currently be obtained at runtime, it requires installing
a new package (e.g. gdb) in the antrea-ubuntu Docker image. See
https://dave.cheney.net/2017/06/20/how-to-find-out-which-go-version-built-your-binary

This will make it easier to figure out which version of Go was used to
build a given version of Antrea.

Signed-off-by: Antonin Bas <abas@vmware.com>