### PR TITLE
[Multicast] Bugfix in multicast in IGMP member snooping

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module antrea.io/antrea
 go 1.17
 
 require (
-	antrea.io/libOpenflow v0.5.2
+	antrea.io/libOpenflow v0.6.1
 	antrea.io/ofnet v0.2.3
 	github.com/Mellanox/sriovnet v1.0.2
 	github.com/Microsoft/go-winio v0.4.16-0.20201130162521-d1ffc52c7331

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
-antrea.io/libOpenflow v0.5.2 h1:EFTyAHlG6UH8ZHpiPi6QPVPETqoIk0eB2B6i88VqacM=
 antrea.io/libOpenflow v0.5.2/go.mod h1:CzEJZxDNAupiGxeL5VOw92PsxfyvehEAvE3PiC6gr8o=
+antrea.io/libOpenflow v0.6.1 h1:RjYKz8WJTjerqu/J9ASygv+oF7Bu0jhIiqLnIIyZPhs=
+antrea.io/libOpenflow v0.6.1/go.mod h1:CzEJZxDNAupiGxeL5VOw92PsxfyvehEAvE3PiC6gr8o=
 antrea.io/ofnet v0.2.3 h1:wxXOqWaT5swtn9Ly6hV7pqvIgfmrr3aQfCGVQqHykr4=
 antrea.io/ofnet v0.2.3/go.mod h1:jW4ICTvGjLO+Qr6GG/Glmjy34k6k/TfVlQhOm76UH84=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=

--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -937,6 +937,10 @@ func (c *client) ReplayFlows() {
 	c.serviceFlowCache.Range(installCachedFlows)
 
 	c.replayPolicyFlows()
+
+	if c.enableMulticast {
+		c.mcastFlowCache.Range(installCachedFlows)
+	}
 }
 
 func (c *client) deleteFlowsByRoundNum(roundNum uint64) error {

--- a/plugins/octant/go.sum
+++ b/plugins/octant/go.sum
@@ -1,4 +1,5 @@
 antrea.io/libOpenflow v0.5.2/go.mod h1:CzEJZxDNAupiGxeL5VOw92PsxfyvehEAvE3PiC6gr8o=
+antrea.io/libOpenflow v0.6.1/go.mod h1:CzEJZxDNAupiGxeL5VOw92PsxfyvehEAvE3PiC6gr8o=
 antrea.io/ofnet v0.2.3/go.mod h1:jW4ICTvGjLO+Qr6GG/Glmjy34k6k/TfVlQhOm76UH84=
 bazil.org/fuse v0.0.0-20160811212531-371fbbdaa898/go.mod h1:Xbm+BRKSBEpa4q4hTSxohYNQpsxXPbPry4JJWOB3LB8=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=


### PR DESCRIPTION
1. Replay multicast cached flows when Agent reconnects to OVS
2. PacketIn all IGMP messages to antrea agent. Since IGMPv1 report uses
    the target multicast group as the IP destination, we can't use static
    destination IP as a filtier for IGMP messages, otherwise IGMPv1 report
    packets would be missing.

Fixes #3184 

Signed-off-by: wenyingd <wenyingd@vmware.com>