### PR TITLE
Remove Service Port Name

### DIFF
--- a/multicluster/controllers/multicluster/resourceexport_controller.go
+++ b/multicluster/controllers/multicluster/resourceexport_controller.go
@@ -19,7 +19,6 @@ package multicluster
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -454,7 +453,6 @@ func svcPortsConverter(svcPort []corev1.ServicePort) []mcs.ServicePort {
 	var mcsSP []mcs.ServicePort
 	for _, v := range svcPort {
 		mcsSP = append(mcsSP, mcs.ServicePort{
-			Name:     strconv.Itoa(int(v.Port)) + strings.ToLower(string(v.Protocol)),
 			Port:     v.Port,
 			Protocol: v.Protocol,
 		})


### PR DESCRIPTION
Our imported Service has name but endpoint is without name
which causes the Antrea agent fail to install openflow rule.
so simply remove the name since it's defined by ourself.

Signed-off-by: Lan Luo <luola@vmware.com>