### PR TITLE
Fix kustomize path issue

### DIFF
--- a/multicluster/Makefile
+++ b/multicluster/Makefile
@@ -92,28 +92,9 @@ docker-build: build ## Build docker image with the manager.
 
 ##@ Deployment
 
-install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/crd | kubectl apply -f -
-
-uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/crd | kubectl delete -f -
-
-deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default | kubectl apply -f -
-
-undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/default | kubectl delete -f -
-
-
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 controller-gen: ## Download controller-gen locally if necessary.
 	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1)
-
-KUSTOMIZE = $(shell pwd)/bin/kustomize
-
-kustomize: ## Download kustomize locally if necessary.
-	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.8.7)
 
 codegen:
 	./hack/update-codegen.sh

--- a/multicluster/hack/generate-manifest.sh
+++ b/multicluster/hack/generate-manifest.sh
@@ -29,9 +29,6 @@ Generate a YAML manifest for Antrea MultiCluster using Kustomize and print it to
         --member  | -m                      Generate a manifest for a Cluster as member in a ClusterSet
         --help    | -h                      Print this message and exit
 
-This tool uses kustomize (https://github.com/kubernetes-sigs/kustomize) to generate manifests for
-Antrea MultiCluster Controller. please run 'make kustomize' first
-
 Environment variables IMG_NAME and IMG_TAG must be set when release mode is enabled.
 "
 
@@ -91,11 +88,19 @@ if [ "$MODE" == "release" ] && [ -z "$IMG_NAME" ]; then
     exit 1
 fi
 
-THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+WORK_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-KUSTOMIZE=$THIS_DIR/../bin/kustomize
+source $WORK_DIR/../../hack/verify-kustomize.sh
 
-KUSTOMIZATION_DIR=$THIS_DIR/../config
+if [ -z "$KUSTOMIZE" ]; then
+    KUSTOMIZE="$(verify_kustomize)"
+elif ! $KUSTOMIZE version > /dev/null 2>&1; then
+    echoerr "$KUSTOMIZE does not appear to be a valid kustomize binary"
+    print_help
+    exit 1
+fi
+
+KUSTOMIZATION_DIR=$WORK_DIR/../config
 
 cd $KUSTOMIZATION_DIR
 


### PR DESCRIPTION
Golicense job is still failed: https://github.com/antrea-io/antrea/runs/4837536108?check_suite_focus=true
1. reuse verify-kustomize.sh to install and verify kustomize.
2. remove some unused Make targets.

Signed-off-by: Lan Luo <luola@vmware.com>