### PR TITLE
Bug fix deprecated apiservice

### DIFF
--- a/ci/jenkins/test-mc.sh
+++ b/ci/jenkins/test-mc.sh
@@ -196,7 +196,7 @@ function deliver_antrea_multicluster {
     ${CLEAN_STALE_IMAGES}
 
     cp -f build/yamls/*.yml $WORKDIR
-    docker pull $DOCKER_REGISTRY/antrea/antrea-ubuntu:latest
+    DOCKER_REGISTRY="${DOCKER_REGISTRY}" ./hack/build-antrea-ubuntu-all.sh --pull
     echo "====== Delivering Antrea to all the Nodes ======"
     docker save -o ${WORKDIR}/antrea-ubuntu.tar $DOCKER_REGISTRY/antrea/antrea-ubuntu:latest
 

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -325,7 +325,6 @@ func DefaultCAConfig() *certificate.CAConfig {
 		CAConfigMapName: certificate.AntreaCAConfigMapName,
 		APIServiceNames: []string{
 			"v1alpha1.stats.antrea.tanzu.vmware.com",
-			"v1beta1.controlplane.antrea.tanzu.vmware.com",
 			"v1beta2.controlplane.antrea.tanzu.vmware.com",
 			"v1beta1.system.antrea.tanzu.vmware.com",
 			"v1alpha1.stats.antrea.io",


### PR DESCRIPTION
1. Delete deprecated apiservice v1beta1.controlplane.antrea.tanzu.vmware.com to fix the antrea-controller error
2. Build antrea-controller image from the feature branch rather than pull the latest image.