### PR TITLE
Fix log spam in NodeRouteController 

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -518,7 +518,7 @@ func run(o *Options) error {
 			nodeConfig,
 			ifaceStore,
 			multicastSocket,
-			sets.NewString(append(o.config.MulticastInterfaces, networkConfig.TransportIface)...),
+			sets.NewString(append(o.config.MulticastInterfaces, nodeConfig.NodeTransportInterfaceName)...),
 			ovsBridgeClient)
 		if err := mcastController.Initialize(); err != nil {
 			return err

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -373,15 +373,16 @@ func TestInitNodeLocalConfig(t *testing.T) {
 			client := fake.NewSimpleClientset(node)
 			ifaceStore := interfacestore.NewInterfaceStore()
 			expectedNodeConfig := config.NodeConfig{
-				Name:                  nodeName,
-				OVSBridge:             ovsBridge,
-				DefaultTunName:        defaultTunInterfaceName,
-				PodIPv4CIDR:           podCIDR,
-				NodeIPv4Addr:          nodeIPNet,
-				NodeTransportIPv4Addr: nodeIPNet,
-				NodeLocalInterfaceMTU: tt.expectedNodeLocalIfaceMTU,
-				NodeMTU:               tt.expectedMTU,
-				UplinkNetConfig:       new(config.AdapterNetConfig),
+				Name:                       nodeName,
+				OVSBridge:                  ovsBridge,
+				DefaultTunName:             defaultTunInterfaceName,
+				PodIPv4CIDR:                podCIDR,
+				NodeIPv4Addr:               nodeIPNet,
+				NodeTransportInterfaceName: ipDevice.Name,
+				NodeTransportIPv4Addr:      nodeIPNet,
+				NodeTransportInterfaceMTU:  tt.expectedNodeLocalIfaceMTU,
+				NodeMTU:                    tt.expectedMTU,
+				UplinkNetConfig:            new(config.AdapterNetConfig),
 			}
 
 			initializer := &Initializer{
@@ -396,11 +397,13 @@ func TestInitNodeLocalConfig(t *testing.T) {
 			}
 			if tt.transportIfName != "" {
 				initializer.networkConfig.TransportIface = tt.transportInterface.iface.Name
+				expectedNodeConfig.NodeTransportInterfaceName = tt.transportInterface.iface.Name
 				expectedNodeConfig.NodeTransportIPv4Addr = tt.transportInterface.ipV4Net
 				expectedNodeConfig.NodeTransportIPv6Addr = tt.transportInterface.ipV6Net
 				defer mockGetTransportIPNetDeviceByName(tt.transportInterface.ipV4Net, tt.transportInterface.ipV6Net, tt.transportInterface.iface)()
 			} else if len(tt.transportIfCIDRs) > 0 {
 				initializer.networkConfig.TransportIfaceCIDRs = tt.transportIfCIDRs
+				expectedNodeConfig.NodeTransportInterfaceName = tt.transportInterface.iface.Name
 				expectedNodeConfig.NodeTransportIPv4Addr = tt.transportInterface.ipV4Net
 				expectedNodeConfig.NodeTransportIPv6Addr = tt.transportInterface.ipV6Net
 				defer mockGetIPNetDeviceByCIDRs(tt.transportInterface.ipV4Net, tt.transportInterface.ipV6Net, tt.transportInterface.iface)()

--- a/pkg/agent/config/node_config.go
+++ b/pkg/agent/config/node_config.go
@@ -118,12 +118,15 @@ type NodeConfig struct {
 	NodeIPv4Addr *net.IPNet
 	// The Node's IPv6 address used in Kubernetes. It has the network mask information.
 	NodeIPv6Addr *net.IPNet
+	// The name of the Node's transport interface. The transport interface defaults to the interface that has the K8s
+	// Node IP, and can be overridden by the configuration parameters TransportInterface and TransportInterfaceCIDRs.
+	NodeTransportInterfaceName string
 	// The IPv4 address on the Node's transport interface. It is used for tunneling or routing the Pod traffic across Nodes.
 	NodeTransportIPv4Addr *net.IPNet
 	// The IPv6 address on the Node's transport interface. It is used for tunneling or routing the Pod traffic across Nodes.
 	NodeTransportIPv6Addr *net.IPNet
-	// The original MTU of Node's local interface which has the K8s Node IP.
-	NodeLocalInterfaceMTU int
+	// The original MTU of the Node's transport interface.
+	NodeTransportInterfaceMTU int
 	// Set either via defaultMTU config in antrea.yaml or auto discovered.
 	// Auto discovery will use MTU value of the Node's primary interface.
 	// For Encap and Hybrid mode, Node MTU will be adjusted to account for encap header.
@@ -143,7 +146,7 @@ func (n *NodeConfig) String() string {
 		n.Name, n.OVSBridge, n.PodIPv4CIDR, n.PodIPv6CIDR, n.NodeIPv4Addr, n.NodeIPv6Addr, n.NodeTransportIPv4Addr, n.NodeTransportIPv6Addr, n.GatewayConfig)
 }
 
-// User provided network configuration parameters.
+// NetworkConfig includes user provided network configuration parameters.
 type NetworkConfig struct {
 	TrafficEncapMode      TrafficEncapModeType
 	TunnelType            ovsconfig.TunnelType

--- a/pkg/agent/controller/noderoute/node_route_controller.go
+++ b/pkg/agent/controller/noderoute/node_route_controller.go
@@ -782,7 +782,7 @@ func (c *Controller) getNodeTransportAddrs(node *corev1.Node) (*utilip.DualStack
 			}
 			return transportAddrs, nil
 		}
-		klog.InfoS("Transport address is not found, using NodeIP instead")
+		klog.InfoS("Transport address is not found, using NodeIP instead", "node", node.Name)
 	}
 	// Use NodeIP if the transport IP address is not set or not found.
 	peerNodeIPs, err := k8s.GetNodeAddrs(node)


### PR DESCRIPTION
NetworkConfig.TransportIface represents user provided transport interface name. It shouldn't be overridden by the actual transport interface calculated based on default value and user configuration, otherwise code that check its value would think it's set by users and behaves unexpectedly, e.g. getNodeTransportAddrs, leading to log spam.

The patch adds NodeConfig.NodeTransportInterfaceName to represent the actual transport interface. It also corrects some improper variable names and comments.

Signed-off-by: Quan Tian <qtian@vmware.com>

Fixes #3208