### PR TITLE
[CI] Fix all-feature-conformance test issue by shortening the job name 

### DIFF
--- a/ci/jenkins/jobs/job-templates.yaml
+++ b/ci/jenkins/jobs/job-templates.yaml
@@ -48,6 +48,55 @@
     wrappers: '{wrappers}'
 
 - job-template:
+    name: '{name}-{test_name}-for-pr'
+    node: '{node}'
+    block-downstream: false
+    block-upstream: false
+    builders: '{builders}'
+    concurrent: false
+    description: '{description}'
+    project-type: freestyle
+    properties:
+    - build-discarder:
+        artifact-days-to-keep: -1
+        artifact-num-to-keep: -1
+        days-to-keep: 7
+        num-to-keep: 30
+    - github:
+        url: 'https://github.com/{org_repo}'
+    publishers: '{publishers}'
+    scm:
+    - git:
+        branches: '{branches}'
+        credentials-id: '{git_credentials_id}'
+        name: origin
+        refspec: +refs/heads/*:refs/remotes/origin/* +refs/pull/${{ghprbPullId}}/*:refs/remotes/origin/pr/${{ghprbPullId}}/*
+        url: 'https://github.com/{org_repo}'
+        wipe-workspace: true
+    triggers:
+    - github-pull-request:
+        admin-list: '{admin_list}'
+        allow-whitelist-orgs-as-admins: '{allow_whitelist_orgs_as_admins}'
+        auth-id: '{ghpr_auth}'
+        auto-close-on-fail: false
+        build-desc-template: null
+        github-hooks: true
+        only-trigger-phrase: '{only_trigger_phrase}'
+        org-list: '{org_list}'
+        permit-all: '{trigger_permit_all}'
+        trigger-phrase: '{trigger_phrase}'
+        white-list-target-branches: '{white_list_target_branches}'
+        white-list: '{white_list}'
+        status-context: '{status_context}'
+        status-url: '{status_url}'
+        success-status: '{success_status}'
+        failure-status: '{failure_status}'
+        error-status: '{error_status}'
+        triggered-status: '{triggered_status}'
+        started-status: '{started_status}'
+    wrappers: '{wrappers}'
+
+- job-template:
     name: '{name}-{test_name}-integration-for-pull-request'
     node: '{node}'
     block-downstream: false

--- a/ci/jenkins/jobs/projects.yaml
+++ b/ci/jenkins/jobs/projects.yaml
@@ -547,7 +547,9 @@
           started_status: null
           wrappers: []
           publishers: []
-      - '{name}-{test_name}-for-pull-request':
+      - '{name}-{test_name}-for-pr':
+          # The cluster name of this job could be too long since job name is encoded in CAPI cluster name.
+          # Use the shorter name as a workaround.
           test_name: all-features-conformance
           node: 'antrea-test-node'
           description: 'This is the {test_name} test for {name}.'


### PR DESCRIPTION
The previous job name of antrea-all-feature-conformance-for-pull-request
was too long to be accepted by CAPV worker nodes.

We renamed it to antrea-all-conformance-for-pull-request, which worked
well in the current testbed.

Signed-off-by: Shuyang Xin <gavinx@vmware.com>
Co-authored-by: Zhengsheng Zhou <zhengshengz@vmware.com>