### PR TITLE
Support skip deploying kube-proxy in Vagrant testbed

### DIFF
--- a/test/e2e/infra/vagrant/Vagrantfile
+++ b/test/e2e/infra/vagrant/Vagrantfile
@@ -42,13 +42,13 @@ else
 end
 
 KUBE_PROXY_MODE = ENV['KUBE_PROXY_MODE'] || "iptables"
-if KUBE_PROXY_MODE == "iptables"
+if KUBE_PROXY_MODE == "iptables" || KUBE_PROXY_MODE == "none"
   KUBE_PROXY_IPVS_STRICT_ARP = false
 elsif KUBE_PROXY_MODE == "ipvs"
   # For now, we always enable strict ARP, which is required to use MetalLB
   KUBE_PROXY_IPVS_STRICT_ARP = true
 else
-  raise "KUBE_PROXY_MODE env variable should be one of 'iptables' or 'ipvs'"
+  raise "KUBE_PROXY_MODE env variable should be one of 'iptables', 'ipvs' or 'none'"
 end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|

--- a/test/e2e/infra/vagrant/playbook/roles/control-plane/templates/kubeadm.conf.j2
+++ b/test/e2e/infra/vagrant/playbook/roles/control-plane/templates/kubeadm.conf.j2
@@ -1,9 +1,13 @@
-apiVersion: kubeadm.k8s.io/v1beta2
+apiVersion: kubeadm.k8s.io/v1beta3
 kind: InitConfiguration
 nodeRegistration:
   name: "{{ node_name }}"
 localAPIEndpoint:
   advertiseAddress: "{{ k8s_api_server_ip }}"
+{% if kube_proxy_mode == 'none' %}
+skipPhases:
+- addon/kube-proxy
+{% endif %}
 ---
 apiVersion: kubeadm.k8s.io/v1beta2
 kind: ClusterConfiguration
@@ -16,10 +20,12 @@ apiServer:
   extraArgs:
     feature-gates: "NetworkPolicyEndPort=true"
 ---
+{% if kube_proxy_mode != 'none' %}
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 mode: "{{ kube_proxy_mode }}"
 {% if kube_proxy_ipvs_strict_arp %}
 ipvs:
   strictARP: true
+{% endif %}
 {% endif %}

--- a/test/e2e/infra/vagrant/provision.sh
+++ b/test/e2e/infra/vagrant/provision.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-
 function usage() {
     echo "Usage: provision.sh [--ip-family <v4|v6>] [-l|--large] [-h|--help]
     Provisions the Vagrant VMs.
-    --ip-family <v4|v6|dual>           Deploy IPv4, IPv6 or dual-stack Kubernetes cluster.
-    --large                            Deploy large vagrant VMs with 2 vCPUs and 4096MB memory.
-                                       By default, we deploy VMs with 2 vCPUs and 2048MB memory.
-    --kube-proxy-mode <iptables|ipvs>  Which mode to use for kube-proxy (default is iptables)."
+    --ip-family <v4|v6|dual>                Deploy IPv4, IPv6 or dual-stack Kubernetes cluster.
+    --large                                 Deploy large vagrant VMs with 2 vCPUs and 4096MB memory.
+                                            By default, we deploy VMs with 2 vCPUs and 2048MB memory.
+    --kube-proxy-mode <iptables|ipvs|none>  Which mode to use for kube-proxy (default is iptables).
+                                            Setting to 'none' will skip deploying kube-proxy."
 }
 
 K8S_IP_FAMILY="v4"


### PR DESCRIPTION
This can be helpful for running e2e test locally with antrea-proxy `proxyAll` feature enabled.

Signed-off-by: Xu Liu <xliu2@vmware.com>