### PR TITLE
Use a smaller nginx image

### DIFF
--- a/ci/kind/test-e2e-kind.sh
+++ b/ci/kind/test-e2e-kind.sh
@@ -127,7 +127,7 @@ fi
 
 COMMON_IMAGES_LIST=("k8s.gcr.io/e2e-test-images/agnhost:2.29" \
                     "projects.registry.vmware.com/library/busybox"  \
-                    "projects.registry.vmware.com/antrea/nginx" \
+                    "projects.registry.vmware.com/antrea/nginx:1.21.6-alpine" \
                     "projects.registry.vmware.com/antrea/perftool" \
                     "projects.registry.vmware.com/antrea/ipfix-collector:v0.5.11" \
                     "projects.registry.vmware.com/antrea/wireguard-go:0.0.20210424")

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -119,7 +119,7 @@ const (
 	busyboxImage        = "projects.registry.vmware.com/library/busybox"
 	mcjoinImage         = "projects.registry.vmware.com/antrea/mcjoin:v2.9"
 	netshootImage       = "projects.registry.vmware.com/antrea/netshoot:v0.1"
-	nginxImage          = "projects.registry.vmware.com/antrea/nginx"
+	nginxImage          = "projects.registry.vmware.com/antrea/nginx:1.21.6-alpine"
 	perftoolImage       = "projects.registry.vmware.com/antrea/perftool"
 	ipfixCollectorImage = "projects.registry.vmware.com/antrea/ipfix-collector:v0.5.11"
 	ipfixCollectorPort  = "4739"


### PR DESCRIPTION
To avoid flaky e2e tests caused by image pulling error, use the alpine based image (23.4MB) which is much smaller than the debian one (141MB).

Signed-off-by: Quan Tian <qtian@vmware.com>