### PR TITLE
Add github labels to indicate actions required to take

### DIFF
--- a/docs/contributors/cherry-picks.md
+++ b/docs/contributors/cherry-picks.md
@@ -17,7 +17,7 @@ policy](../versioning.md#minor-releases-and-patch-releases).
 
 * A PR which was approved and merged into the main branch.
 * The PR was identified as a good candidate for backporting by an Antrea
-  maintainer: they will leave a comment on Github for the PR and provide a list
+  maintainer: they will label the PR with `action/backport` and comment a list
   of release branches to which the patch should be backported (example:
   [`release-1.0`](https://github.com/antrea-io/antrea/tree/release-1.0)).
 * Have the [Github CLI](https://cli.github.com/) installed (version >= 1.3) and

--- a/docs/contributors/github-labels.md
+++ b/docs/contributors/github-labels.md
@@ -111,6 +111,8 @@ The labels in this list originated within Kubernetes at
 | triage/needs-information           | Indicates an issue needs more information in order to work on it. | Humans |
 | triage/not-reproducible            | Indicates an issue can not be reproduced as described. | Humans |
 | triage/unresolved                  | Indicates an issue that can not or will not be resolved. | Humans |
+| action/backport                    | Indicates a PR that requires backports. | Humans |
+| action/release-note                | Indicates a PR that should be included in release notes.  | Humans |
 
 ## Labels that apply only to issues
 

--- a/docs/maintainers/release.md
+++ b/docs/maintainers/release.md
@@ -15,13 +15,14 @@ release. We use `<TAG>` as a placeholder for the release tag (e.g. `v1.4.0`).
 2. Open a PR (labelled with `kind/release`) against the appropriate release
    branch with the following commits:
    - a commit to update the [CHANGELOG](../../CHANGELOG). *For a minor release*,
-     all significant changes and all bug fixes since the first version of the
-     previous minor release should be mentioned, even bug fixes which have
-     already been included in some patch release. *For a patch release*, you
-     will mention all the bug fixes since the previous release with the same
-     minor version. The commit message must be *exactly* `"Update CHANGELOG for
-     <TAG> release"`, as a bot will look for this commit and cherry-pick it to
-     update the main branch (starting with Antrea v1.0). The
+     all significant changes and all bug fixes (labelled with
+     `action/release-note` since the first version of the previous minor release
+     should be mentioned, even bug fixes which have already been included in
+     some patch release. *For a patch release*, you will mention all the bug
+     fixes since the previous release with the same minor version. The commit
+     message must be *exactly* `"Update CHANGELOG for <TAG> release"`, as a bot
+     will look for this commit and cherry-pick it to update the main branch
+     (starting with Antrea v1.0). The
      [process-changelog.go](../../hack/release/process-changelog.go) script may
      be used to easily generate links to PRs and the Github profiles of PR
      authors.


### PR DESCRIPTION
action/backport: Indicates a PR that requires backports.
action/release-note: Indicates a PR that should be included in release notes.

Signed-off-by: Quan Tian <qtian@vmware.com>