### PR TITLE
Automated cherry pick of #3169: Fix agent initialization error by adjusting

### DIFF
--- a/pkg/agent/util/net_windows.go
+++ b/pkg/agent/util/net_windows.go
@@ -157,7 +157,7 @@ func RemoveManagementInterface(networkName string) error {
 	var err error
 	var maxRetry = 3
 	var i = 0
-	cmd := fmt.Sprintf("Get-VMSwitch -Name %s  | Set-VMSwitch -AllowManagementOS $false ", networkName)
+	cmd := fmt.Sprintf("Get-VMSwitch -ComputerName $(hostname) -Name %s  | Set-VMSwitch -ComputerName $(hostname) -AllowManagementOS $false ", networkName)
 	// Retry the operation here because an error is returned at the first invocation.
 	for i < maxRetry {
 		_, err = ps.RunCommand(cmd)
@@ -379,7 +379,7 @@ func PrepareHNSNetwork(subnetCIDR *net.IPNet, nodeIPNet *net.IPNet, uplinkAdapte
 // EnableRSCOnVSwitch enables RSC in the vSwitch to reduce host CPU utilization and increase throughput for virtual
 // workloads by coalescing multiple TCP segments into fewer, but larger segments.
 func EnableRSCOnVSwitch(vSwitch string) error {
-	cmd := fmt.Sprintf("Get-VMSwitch -Name %s | Select-Object -Property SoftwareRscEnabled | Format-Table -HideTableHeaders", vSwitch)
+	cmd := fmt.Sprintf("Get-VMSwitch -ComputerName $(hostname) -Name %s | Select-Object -Property SoftwareRscEnabled | Format-Table -HideTableHeaders", vSwitch)
 	stdout, err := ps.RunCommand(cmd)
 	if err != nil {
 		return err
@@ -397,7 +397,7 @@ func EnableRSCOnVSwitch(vSwitch string) error {
 		klog.Infof("Receive Segment Coalescing (RSC) for vSwitch %s is already enabled", vSwitch)
 		return nil
 	}
-	cmd = fmt.Sprintf("Set-VMSwitch -Name %s -EnableSoftwareRsc $True", vSwitch)
+	cmd = fmt.Sprintf("Set-VMSwitch -ComputerName $(hostname) -Name %s -EnableSoftwareRsc $True", vSwitch)
 	_, err = ps.RunCommand(cmd)
 	if err != nil {
 		return err


### PR DESCRIPTION
Cherry pick of #3169 on release-1.2.

#3169: Fix agent initialization error by adjusting

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.