### PR TITLE
Automated cherry pick of #2768: Fix triggerCNPUpdates panic

### DIFF
--- a/pkg/controller/networkpolicy/clustergroup.go
+++ b/pkg/controller/networkpolicy/clustergroup.go
@@ -265,42 +265,8 @@ func (c *NetworkPolicyController) triggerCNPUpdates(cg string) {
 		return
 	}
 	for _, obj := range cnps {
-		cnp := obj.(*crdv1alpha1.ClusterNetworkPolicy)
-		// Re-process ClusterNetworkPolicies which may be affected due to updates to CG.
-		curInternalNP := c.processClusterNetworkPolicy(cnp)
-		klog.V(2).Infof("Updating existing internal NetworkPolicy %s for %s", curInternalNP.Name, curInternalNP.SourceRef.ToString())
-		key := internalNetworkPolicyKeyFunc(cnp)
-		// Lock access to internal NetworkPolicy store such that concurrent access
-		// to an internal NetworkPolicy is not allowed. This will avoid the
-		// case in which an Update to an internal NetworkPolicy object may
-		// cause the SpanMeta member to be overridden with stale SpanMeta members
-		// from an older internal NetworkPolicy.
-		c.internalNetworkPolicyMutex.Lock()
-		oldInternalNPObj, _, _ := c.internalNetworkPolicyStore.Get(key)
-		oldInternalNP := oldInternalNPObj.(*antreatypes.NetworkPolicy)
-		// Must preserve old internal NetworkPolicy Spac.
-		curInternalNP.SpanMeta = oldInternalNP.SpanMeta
-		c.internalNetworkPolicyStore.Update(curInternalNP)
-		// Unlock the internal NetworkPolicy store.
-		c.internalNetworkPolicyMutex.Unlock()
-		// Enqueue addressGroup keys to update their group members.
-		// TODO: optimize this to avoid enqueueing address groups when not updated.
-		for _, atg := range curInternalNP.AppliedToGroups {
-			c.enqueueAppliedToGroup(atg)
-		}
-		for _, rule := range curInternalNP.Rules {
-			for _, addrGroupName := range rule.From.AddressGroups {
-				c.enqueueAddressGroup(addrGroupName)
-			}
-			for _, addrGroupName := range rule.To.AddressGroups {
-				c.enqueueAddressGroup(addrGroupName)
-			}
-		}
-		c.enqueueInternalNetworkPolicy(key)
-		c.deleteDereferencedAddressGroups(oldInternalNP)
-		for _, atg := range oldInternalNP.AppliedToGroups {
-			c.deleteDereferencedAppliedToGroup(atg)
-		}
+		// ClusterGroup may be used by AppliedToGroup, enqueuing them after reprocessing CNP.
+		c.reprocessCNP(obj.(*crdv1alpha1.ClusterNetworkPolicy), true)
 	}
 }
 

--- a/pkg/controller/networkpolicy/clusternetworkpolicy.go
+++ b/pkg/controller/networkpolicy/clusternetworkpolicy.go
@@ -126,12 +126,14 @@ func (n *NetworkPolicyController) deleteCNP(old interface{}) {
 	n.deleteDereferencedAddressGroups(oldInternalNP)
 }
 
-// reprocessCNP is triggered by Namespace ADD/UPDATE/DELETE events when they impact the
-// per-namespace rules of a CNP.
-func (n *NetworkPolicyController) reprocessCNP(cnp *crdv1alpha1.ClusterNetworkPolicy) {
+// reprocessCNP is triggered when a CNP may be impacted by non-ClusterNetworkPolicy events, including Namespace events
+// (for per-namespace rules) and ClusterGroup events (for ClusterGroup reference).
+func (n *NetworkPolicyController) reprocessCNP(cnp *crdv1alpha1.ClusterNetworkPolicy, enqueueAppliedToGroup bool) {
 	key := internalNetworkPolicyKeyFunc(cnp)
 	n.internalNetworkPolicyMutex.Lock()
 	oldInternalNPObj, exist, _ := n.internalNetworkPolicyStore.Get(key)
+	// The internal NetworkPolicy may haven't been created yet. It's fine to skip processing this CNP as addCNP will
+	// create it eventually.
 	if !exist {
 		klog.V(2).Infof("Cannot find the original internal NetworkPolicy, skip reprocessCNP")
 		n.internalNetworkPolicyMutex.Unlock()
@@ -145,6 +147,11 @@ func (n *NetworkPolicyController) reprocessCNP(cnp *crdv1alpha1.ClusterNetworkPo
 	curInternalNP.SpanMeta = oldInternalNP.SpanMeta
 	n.internalNetworkPolicyStore.Update(curInternalNP)
 	n.internalNetworkPolicyMutex.Unlock()
+	if enqueueAppliedToGroup {
+		for _, atg := range curInternalNP.AppliedToGroups {
+			n.enqueueAppliedToGroup(atg)
+		}
+	}
 	// Enqueue addressGroup keys to update their Node span.
 	for _, rule := range curInternalNP.Rules {
 		for _, addrGroupName := range rule.From.AddressGroups {
@@ -196,7 +203,7 @@ func (n *NetworkPolicyController) addNamespace(obj interface{}) {
 	affectedACNPs := n.filterPerNamespaceRuleACNPsByNSLabels(namespace.Labels)
 	for cnpName := range affectedACNPs {
 		if cnp, err := n.cnpLister.Get(cnpName); err == nil {
-			n.reprocessCNP(cnp)
+			n.reprocessCNP(cnp, false)
 		}
 	}
 }
@@ -213,7 +220,7 @@ func (n *NetworkPolicyController) updateNamespace(oldObj, curObj interface{}) {
 	affectedACNPs := utilsets.SymmetricDifferenceString(affectedACNPsByOldLabels, affectedACNPsByCurLabels)
 	for cnpName := range affectedACNPs {
 		if cnp, err := n.cnpLister.Get(cnpName); err == nil {
-			n.reprocessCNP(cnp)
+			n.reprocessCNP(cnp, false)
 		}
 	}
 }
@@ -243,7 +250,7 @@ func (n *NetworkPolicyController) deleteNamespace(old interface{}) {
 			klog.Errorf("Error getting Antrea ClusterNetworkPolicy %s", cnpName)
 			continue
 		}
-		n.reprocessCNP(cnp)
+		n.reprocessCNP(cnp, false)
 	}
 }
 

--- a/pkg/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller.go
@@ -215,6 +215,75 @@ type heartbeat struct {
 	timestamp time.Time
 }
 
+var tierIndexers = cache.Indexers{
+	PriorityIndex: func(obj interface{}) ([]string, error) {
+		tr, ok := obj.(*secv1alpha1.Tier)
+		if !ok {
+			return []string{}, nil
+		}
+		return []string{strconv.FormatInt(int64(tr.Spec.Priority), 10)}, nil
+	},
+}
+
+var cnpIndexers = cache.Indexers{
+	TierIndex: func(obj interface{}) ([]string, error) {
+		cnp, ok := obj.(*secv1alpha1.ClusterNetworkPolicy)
+		if !ok {
+			return []string{}, nil
+		}
+		return []string{cnp.Spec.Tier}, nil
+	},
+	ClusterGroupIndex: func(obj interface{}) ([]string, error) {
+		cnp, ok := obj.(*secv1alpha1.ClusterNetworkPolicy)
+		if !ok {
+			return []string{}, nil
+		}
+		groupNames := sets.String{}
+		for _, appTo := range cnp.Spec.AppliedTo {
+			if appTo.Group != "" {
+				groupNames.Insert(appTo.Group)
+			}
+		}
+		if len(cnp.Spec.Ingress) == 0 && len(cnp.Spec.Egress) == 0 {
+			return groupNames.List(), nil
+		}
+		appendGroups := func(rule secv1alpha1.Rule) {
+			for _, peer := range rule.To {
+				if peer.Group != "" {
+					groupNames.Insert(peer.Group)
+				}
+			}
+			for _, peer := range rule.From {
+				if peer.Group != "" {
+					groupNames.Insert(peer.Group)
+				}
+			}
+			for _, appTo := range rule.AppliedTo {
+				if appTo.Group != "" {
+					groupNames.Insert(appTo.Group)
+				}
+			}
+		}
+		for _, rule := range cnp.Spec.Egress {
+			appendGroups(rule)
+		}
+		for _, rule := range cnp.Spec.Ingress {
+			appendGroups(rule)
+		}
+		return groupNames.List(), nil
+	},
+}
+
+var anpIndexers = cache.Indexers{
+	TierIndex: func(obj interface{}) ([]string, error) {
+		anp, ok := obj.(*secv1alpha1.NetworkPolicy)
+		if !ok {
+			return []string{}, nil
+		}
+		return []string{anp.Spec.Tier}, nil
+	},
+}
+
 // NewNetworkPolicyController returns a new *NetworkPolicyController.
 func NewNetworkPolicyController(kubeClient clientset.Interface,
 	crdClient versioned.Interface,
@@ -296,67 +365,8 @@ func NewNetworkPolicyController(kubeClient clientset.Interface,
 			},
 			resyncPeriod,
 		)
-		tierInformer.Informer().AddIndexers(
-			cache.Indexers{
-				PriorityIndex: func(obj interface{}) ([]string, error) {
-					tr, ok := obj.(*secv1alpha1.Tier)
-					if !ok {
-						return []string{}, nil
-					}
-					return []string{strconv.FormatInt(int64(tr.Spec.Priority), 10)}, nil
-				},
-			},
-		)
-		cnpInformer.Informer().AddIndexers(
-			cache.Indexers{
-				TierIndex: func(obj interface{}) ([]string, error) {
-					cnp, ok := obj.(*secv1alpha1.ClusterNetworkPolicy)
-					if !ok {
-						return []string{}, nil
-					}
-					return []string{cnp.Spec.Tier}, nil
-				},
-				ClusterGroupIndex: func(obj interface{}) ([]string, error) {
-					cnp, ok := obj.(*secv1alpha1.ClusterNetworkPolicy)
-					if !ok {
-						return []string{}, nil
-					}
-					groupNames := sets.String{}
-					for _, appTo := range cnp.Spec.AppliedTo {
-						if appTo.Group != "" {
-							groupNames.Insert(appTo.Group)
-						}
-					}
-					if len(cnp.Spec.Ingress) == 0 && len(cnp.Spec.Egress) == 0 {
-						return groupNames.List(), nil
-					}
-					appendGroups := func(rule secv1alpha1.Rule) {
-						for _, peer := range rule.To {
-							if peer.Group != "" {
-								groupNames.Insert(peer.Group)
-							}
-						}
-						for _, peer := range rule.From {
-							if peer.Group != "" {
-								groupNames.Insert(peer.Group)
-							}
-						}
-						for _, appTo := range rule.AppliedTo {
-							if appTo.Group != "" {
-								groupNames.Insert(appTo.Group)
-							}
-						}
-					}
-					for _, rule := range cnp.Spec.Egress {
-						appendGroups(rule)
-					}
-					for _, rule := range cnp.Spec.Ingress {
-						appendGroups(rule)
-					}
-					return groupNames.List(), nil
-				},
-			},
-		)
+		tierInformer.Informer().AddIndexers(tierIndexers)
+		cnpInformer.Informer().AddIndexers(cnpIndexers)
 		cnpInformer.Informer().AddEventHandlerWithResyncPeriod(
 			cache.ResourceEventHandlerFuncs{
 				AddFunc:    n.addCNP,
@@ -365,17 +375,7 @@ func NewNetworkPolicyController(kubeClient clientset.Interface,
 			},
 			resyncPeriod,
 		)
-		anpInformer.Informer().AddIndexers(
-			cache.Indexers{
-				TierIndex: func(obj interface{}) ([]string, error) {
-					anp, ok := obj.(*secv1alpha1.NetworkPolicy)
-					if !ok {
-						return []string{}, nil
-					}
-					return []string{anp.Spec.Tier}, nil
-				},
-			},
-		)
+		anpInformer.Informer().AddIndexers(anpIndexers)
 		anpInformer.Informer().AddEventHandlerWithResyncPeriod(
 			cache.ResourceEventHandlerFuncs{
 				AddFunc:    n.addANP,

--- a/pkg/controller/networkpolicy/networkpolicy_controller_perf_test.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller_perf_test.go
@@ -471,7 +471,7 @@ func benchmarkInit(b *testing.B, namespaces []*corev1.Namespace, networkPolicies
 	objs := toRunTimeObjects(namespaces, networkPolicies, pods)
 	stopCh := make(chan struct{})
 	defer close(stopCh)
-	_, c := newControllerWithoutEventHandler(objs...)
+	_, c := newControllerWithoutEventHandler(objs, nil)
 	c.informerFactory.Start(stopCh)
 	c.informerFactory.WaitForCacheSync(stopCh)
 


### PR DESCRIPTION
Cherry pick of #2768 on release-1.3.

#2768: Fix triggerCNPUpdates panic

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.