### PR TITLE
[Multicast] removal of stale multicast routes

### DIFF
--- a/pkg/agent/multicast/mcast_controller.go
+++ b/pkg/agent/multicast/mcast_controller.go
@@ -113,7 +113,6 @@ func (c *Controller) addGroupMemberStatus(e *mcastGroupEvent) {
 	c.groupCache.Add(status)
 	c.queue.Add(e.group.String())
 	klog.InfoS("Added new multicast group to cache", "group", e.group, "interface", e.iface.InterfaceName)
-	return
 }
 
 // updateGroupMemberStatus updates the group status in groupCache. If a "join" message is sent from an existing member,
@@ -162,7 +161,6 @@ func (c *Controller) updateGroupMemberStatus(obj interface{}, e *mcastGroupEvent
 			}
 		}
 	}
-	return
 }
 
 // checkLastMember sends out a query message on the group to check if there are still members in the group. If no new
@@ -295,7 +293,7 @@ func NewMulticastController(ofClient openflow.Client,
 	groupCache := cache.NewIndexer(getGroupEventKey, cache.Indexers{
 		podInterfaceIndex: podInterfaceIndexFunc,
 	})
-	multicastRouteClient := newRouteClient(nodeConfig, groupCache, multicastSocket, multicastInterfaces, isEncap, enableFlexibleIPAM)
+	multicastRouteClient := newRouteClient(nodeConfig, groupCache, multicastSocket, multicastInterfaces, enableFlexibleIPAM)
 	c := &Controller{
 		ofClient:             ofClient,
 		ifaceStore:           ifaceStore,
@@ -497,7 +495,7 @@ func (c *Controller) syncGroup(groupKey string) error {
 	deleteLocalMulticastGroup := func() error {
 		err := c.mRouteClient.deleteInboundMrouteEntryByGroup(status.group)
 		if err != nil {
-			klog.ErrorS(err, "Cannot delete multicast group", "group", groupKey)
+			klog.ErrorS(err, "Failed to delete multicast group", "group", groupKey)
 			return err
 		}
 		klog.InfoS("Removed multicast route entry", "group", status.group)

--- a/pkg/agent/multicast/mcast_socket_others.go
+++ b/pkg/agent/multicast/mcast_socket_others.go
@@ -27,11 +27,15 @@ const (
 	SizeofIgmpmsg  = 0
 )
 
-func (s *Socket) AddMrouteEntry(src net.IP, group net.IP, iif uint16, oifVIFs []uint16) (err error) {
+func (s *Socket) AddMrouteEntry(src net.IP, group net.IP, iif uint16, oifVIFs []uint16) error {
 	return nil
 }
 
-func (s *Socket) DelMrouteEntry(src net.IP, group net.IP, iif uint16) (err error) {
+func (s *Socket) GetMroutePacketCount(src net.IP, group net.IP) (uint32, error) {
+	return 0, nil
+}
+
+func (s *Socket) DelMrouteEntry(src net.IP, group net.IP, iif uint16) error {
 	return nil
 }
 

--- a/pkg/agent/multicast/testing/mock_multicast.go
+++ b/pkg/agent/multicast/testing/mock_multicast.go
@@ -122,6 +122,21 @@ func (mr *MockRouteInterfaceMockRecorder) GetFD() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFD", reflect.TypeOf((*MockRouteInterface)(nil).GetFD))
 }
 
+// GetMroutePacketCount mocks base method.
+func (m *MockRouteInterface) GetMroutePacketCount(arg0, arg1 net.IP) (uint32, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMroutePacketCount", arg0, arg1)
+	ret0, _ := ret[0].(uint32)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMroutePacketCount indicates an expected call of GetMroutePacketCount.
+func (mr *MockRouteInterfaceMockRecorder) GetMroutePacketCount(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMroutePacketCount", reflect.TypeOf((*MockRouteInterface)(nil).GetMroutePacketCount), arg0, arg1)
+}
+
 // MulticastInterfaceJoinMgroup mocks base method.
 func (m *MockRouteInterface) MulticastInterfaceJoinMgroup(arg0, arg1 net.IP, arg2 string) error {
 	m.ctrl.T.Helper()

--- a/pkg/agent/util/syscall/linux/types.go
+++ b/pkg/agent/util/syscall/linux/types.go
@@ -47,6 +47,7 @@ const (
 
 type Mfcctl C.struct_mfcctl
 type Vifctl C.struct_vifctl_with_ifindex
+type SiocSgReq C.struct_siocsgreq
 
 const SizeofMfcctl = C.sizeof_struct_mfcctl
 const SizeofVifctl = C.sizeof_struct_vifctl_with_ifindex

--- a/pkg/agent/util/syscall/syscall_unix.go
+++ b/pkg/agent/util/syscall/syscall_unix.go
@@ -34,7 +34,13 @@ func setsockopt(s int, level int, name int, val unsafe.Pointer, vallen uintptr) 
 	return
 }
 
-// Please add your wrapped syscall functions below
+func ioctlPtr(fd int, req uint, arg unsafe.Pointer) (err error) {
+	_, _, e1 := syscall.Syscall(syscall.SYS_IOCTL, uintptr(fd), uintptr(req), uintptr(arg))
+	if e1 != 0 {
+		return e1
+	}
+	return
+}
 
 func SetsockoptMfcctl(fd, level, opt int, mfcctl *Mfcctl) error {
 	return setsockopt(fd, level, opt, unsafe.Pointer(mfcctl), SizeofMfcctl)
@@ -42,4 +48,8 @@ func SetsockoptMfcctl(fd, level, opt int, mfcctl *Mfcctl) error {
 
 func SetsockoptVifctl(fd, level, opt int, vifctl *Vifctl) error {
 	return setsockopt(fd, level, opt, unsafe.Pointer(vifctl), SizeofVifctl)
+}
+
+func IoctlGetSiocSgReq(fd int, siocsgreq *SiocSgReq) error {
+	return ioctlPtr(fd, SIOCGETSGCNT, unsafe.Pointer(siocsgreq))
 }

--- a/pkg/agent/util/syscall/ztypes_linux.go
+++ b/pkg/agent/util/syscall/ztypes_linux.go
@@ -26,6 +26,7 @@ const (
 	MRT_INIT         = 0xc8
 	MRT_FLUSH        = 0xd4
 	MAXVIFS          = 0x20
+	SIOCGETSGCNT     = 0x89e1
 )
 
 type Mfcctl struct {
@@ -35,7 +36,7 @@ type Mfcctl struct {
 	Ttls     [32]uint8
 	Pkt_cnt  uint32
 	Byte_cnt uint32
-	Wrong_if uint32
+	Wrong_if uint32 /* number wrong of iif hits */
 	Expire   int32
 }
 
@@ -46,6 +47,18 @@ type Vifctl struct {
 	Rate_limit  uint32
 	Lcl_ifindex int32
 	Rmt_addr    [4]byte /* in_addr */
+}
+
+// SiocSgReq is the Golang version of Linux kernel struct sioc_sg_req.
+// Please check https://github.com/torvalds/linux/blob/master/include/uapi/linux/mroute.h#L92.
+// The struct encodes the packet count and byte count of a multicast route
+// identified by Src(source) and Grp(group).
+type SiocSgReq = struct {
+	Src      [4]byte /* in_addr */
+	Grp      [4]byte /* in_addr */
+	Pktcnt   uint32
+	Bytecnt  uint32
+	Wrong_if uint32 /* number wrong of iif hits */
 }
 
 const SizeofMfcctl = 0x3c


### PR DESCRIPTION
This commit removes the relevant stale multicast routes. When multicast sender Pods are deleted or stop sending multicast traffic in 10 minutes, the related multicast routes should be considered as stale and are removed with this commit. MRouted implements a similar stale routes cleanup mechanism in [OpenBSD](https://github.com/openbsd/src/blob/1eb3d403c0b906b74d72964ea1ac54f688ca1692/usr.sbin/mrouted/prune.c#L1470-L1497) and [NetBSD](https://github.com/NetBSD/src/blob/5970d5082c482e82e9d8ca572f57c4acdb86c996/usr.sbin/mrouted/prune.c#L1686-L1714).

Periodically cleaning stale multicast routes would improve the readability of multicast routes, such as the readability of "ip mroute" output. Also, the memory consumption of Nodes could be slightly reduced(
 running 28 multicast senders, each sending multicast traffic to 2000 multicast groups, around 16M Slab Unclaimable memory was consumed by 56000 multicast route entries, observed from Netdata).

![Xnip2024-03-22_19-01-16](https://github.com/antrea-io/antrea/assets/2628211/5b17c210-d2f4-4b12-b2ec-7200d1af3c31)


