### PR TITLE
Automated cherry pick of #3162: Recover integration test by skipping certificate check

### DIFF
--- a/ci/jenkins/test-vmc.sh
+++ b/ci/jenkins/test-vmc.sh
@@ -419,6 +419,7 @@ function deliver_antrea {
 
 function run_integration {
     VM_NAME="antrea-integration-0"
+    export GOVC_INSECURE=1
     export GOVC_URL=${GOVC_URL}
     export GOVC_USERNAME=${GOVC_USERNAME}
     export GOVC_PASSWORD=${GOVC_PASSWORD}


### PR DESCRIPTION
Cherry pick of #3162 on release-1.3.

#3162: Recover integration test by skipping certificate check

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.