### PR TITLE
Add powershell command replacement in windows doc

### DIFF
--- a/docs/windows.md
+++ b/docs/windows.md
@@ -184,6 +184,13 @@ spec:
       hostNetwork: true
 ```
 
+If the powershell version on your Window Node is earlier than v6.0,
+change the command from `pwsh` to `powershell` in kube-proxy.yml.
+
+```bash
+sed -i 's/pwsh/powershell/g' kube-proxy.yml
+```
+
 Then apply the `kube-proxy.yml`.
 
 ```bash


### PR DESCRIPTION
Fixes #3245 .

kube-proxy.yml uses the command `pwsh` which is not a valid command
when the Powershell version is earlier than 6.0.
This commit added this reminder and the command replacement in
windows doc.

Signed-off-by: wgrayson <wgrayson@vmware.com>