### PR TITLE
Update label of antrea-mc-controller

### DIFF
--- a/multicluster/build/yamls/antrea-multicluster-leader-namespaced.yml
+++ b/multicluster/build/yamls/antrea-multicluster-leader-namespaced.yml
@@ -527,7 +527,7 @@ kind: Service
 metadata:
   labels:
     app: antrea
-    control-plane: antrea-mc-controller
+    component: antrea-mc-controller
   name: antrea-mc-controller-metrics-service
   namespace: changeme
 spec:
@@ -537,7 +537,7 @@ spec:
     targetPort: https
   selector:
     app: antrea
-    control-plane: antrea-mc-controller
+    component: antrea-mc-controller
 ---
 apiVersion: v1
 kind: Service
@@ -552,14 +552,14 @@ spec:
     targetPort: 9443
   selector:
     app: antrea
-    control-plane: antrea-mc-controller
+    component: antrea-mc-controller
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
     app: antrea
-    control-plane: antrea-mc-controller
+    component: antrea-mc-controller
   name: antrea-mc-controller
   namespace: changeme
 spec:
@@ -567,12 +567,12 @@ spec:
   selector:
     matchLabels:
       app: antrea
-      control-plane: antrea-mc-controller
+      component: antrea-mc-controller
   template:
     metadata:
       labels:
         app: antrea
-        control-plane: antrea-mc-controller
+        component: antrea-mc-controller
     spec:
       containers:
       - args:

--- a/multicluster/build/yamls/antrea-multicluster-member.yml
+++ b/multicluster/build/yamls/antrea-multicluster-member.yml
@@ -1718,7 +1718,7 @@ kind: Service
 metadata:
   labels:
     app: antrea
-    control-plane: antrea-mc-controller
+    component: antrea-mc-controller
   name: antrea-mc-controller-metrics-service
   namespace: kube-system
 spec:
@@ -1728,7 +1728,7 @@ spec:
     targetPort: https
   selector:
     app: antrea
-    control-plane: antrea-mc-controller
+    component: antrea-mc-controller
 ---
 apiVersion: v1
 kind: Service
@@ -1743,14 +1743,14 @@ spec:
     targetPort: 9443
   selector:
     app: antrea
-    control-plane: antrea-mc-controller
+    component: antrea-mc-controller
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
     app: antrea
-    control-plane: antrea-mc-controller
+    component: antrea-mc-controller
   name: antrea-mc-controller
   namespace: kube-system
 spec:
@@ -1758,12 +1758,12 @@ spec:
   selector:
     matchLabels:
       app: antrea
-      control-plane: antrea-mc-controller
+      component: antrea-mc-controller
   template:
     metadata:
       labels:
         app: antrea
-        control-plane: antrea-mc-controller
+        component: antrea-mc-controller
     spec:
       containers:
       - args:

--- a/multicluster/config/manager/manager.yaml
+++ b/multicluster/config/manager/manager.yaml
@@ -4,16 +4,16 @@ metadata:
   name: controller
   namespace: system
   labels:
-    control-plane: antrea-mc-controller
+    component: antrea-mc-controller
 spec:
   selector:
     matchLabels:
-      control-plane: antrea-mc-controller
+      component: antrea-mc-controller
   replicas: 1
   template:
     metadata:
       labels:
-        control-plane: antrea-mc-controller
+        component: antrea-mc-controller
     spec:
       containers:
       - command:

--- a/multicluster/config/prometheus/monitor.yaml
+++ b/multicluster/config/prometheus/monitor.yaml
@@ -4,7 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    control-plane: antrea-mc-controller
+    component: antrea-mc-controller
   name: controller-metrics-monitor
   namespace: system
 spec:
@@ -17,4 +17,4 @@ spec:
         insecureSkipVerify: true
   selector:
     matchLabels:
-      control-plane: antrea-mc-controller
+      component: antrea-mc-controller

--- a/multicluster/config/rbac/auth_proxy_service.yaml
+++ b/multicluster/config/rbac/auth_proxy_service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    control-plane: antrea-mc-controller
+    component: antrea-mc-controller
   name: controller-metrics-service
   namespace: system
 spec:
@@ -11,4 +11,4 @@ spec:
     port: 8443
     targetPort: https
   selector:
-    control-plane: antrea-mc-controller
+    component: antrea-mc-controller

--- a/multicluster/config/webhook/service.yaml
+++ b/multicluster/config/webhook/service.yaml
@@ -9,4 +9,4 @@ spec:
     - port: 443
       targetPort: 9443
   selector:
-    control-plane: antrea-mc-controller
+    component: antrea-mc-controller


### PR DESCRIPTION
Update the label of antrea-mc-controller in manifests to make them
consistent as antrea controller and agent.

Signed-off-by: Lan Luo <luola@vmware.com>