### PR TITLE
Use iptables-wrapper in Antrea container

### DIFF
--- a/build/images/base/Dockerfile
+++ b/build/images/base/Dockerfile
@@ -30,9 +30,15 @@ LABEL description="Takes care of building the Antrea binaries as part of buildin
 
 USER root
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ipset \
-    jq \
- && rm -rf /var/lib/apt/lists/*
+# See https://github.com/kubernetes-sigs/iptables-wrappers
+# /iptables-wrapper-installer.sh will have permissions of 600.
+# --chmod=700 doesn't work with older versions of Docker and requires DOCKER_BUILDKIT=1, so we use
+# chmod in the RUN command below instead.
+ADD https://raw.githubusercontent.com/kubernetes-sigs/iptables-wrappers/9e6ce59c864623ea71a6f7d59c35fcb13a919b87/iptables-wrapper-installer.sh /iptables-wrapper-installer.sh
+
+RUN apt-get update && apt-get install -y --no-install-recommends ipset jq && \
+    rm -rf /var/lib/apt/lists/* && \
+    chmod +x /iptables-wrapper-installer.sh && \
+    /iptables-wrapper-installer.sh
 
 COPY --from=cni-binaries /opt/cni/bin /opt/cni/bin


### PR DESCRIPTION
Instead of iptables directly.
Antrea uses a Ubuntu 20.04 base container image, for which the default iptables
mode is "legacy". This may not match the iptables mode for the Node OS, which in
turn can create issues:
 * Other K8s components (kubelet, kube-proxy) will create rules using the
   default iptables mode for the Node. Assumptions about evaluation order
   between these rules and the Antrea rules may break.
 * The required kernel module for the "legacy" mode (ip_tables) may not be
   available on the Node.

The iptables-wrapper is meant to address these issues:
https://github.com/kubernetes-sigs/iptables-wrappers. We install it in the
Antrea container image. The first time Antrea invokes iptables, the wrapper will
determine the underlying iptables mode (for the Node OS) and adjust the iptables
symlinks in the container.

Fixes #3243
Fixes #3274

Signed-off-by: Antonin Bas <abas@vmware.com>