### PR TITLE
Configure crictl correctly in Vagrant testbed

### DIFF
--- a/test/e2e/infra/vagrant/playbook/roles/common/tasks/containerd.yml
+++ b/test/e2e/infra/vagrant/playbook/roles/common/tasks/containerd.yml
@@ -61,3 +61,8 @@
     daemon_reload: yes
     state: restarted
   when: containerd_config.changed
+
+- name: Configure crictl
+  template:
+    src: templates/crictl.yaml.j2
+    dest: /etc/crictl.yaml

--- a/test/e2e/infra/vagrant/playbook/roles/common/templates/crictl.yaml.j2
+++ b/test/e2e/infra/vagrant/playbook/roles/common/templates/crictl.yaml.j2
@@ -1,0 +1,2 @@
+runtime-endpoint: unix:///run/containerd/containerd.sock
+image-endpoint: unix:///run/containerd/containerd.sock


### PR DESCRIPTION
Set endpoints correctly for containerd to avoid error logs.

Signed-off-by: Antonin Bas <abas@vmware.com>