### PR TITLE
Antctl for multicluster

### DIFF
--- a/pkg/antctl/raw/multicluster/commands.go
+++ b/pkg/antctl/raw/multicluster/commands.go
@@ -26,5 +26,7 @@ var GetCmd = &cobra.Command{
 }
 
 func init() {
+	GetCmd.AddCommand(get.NewClusterSetCommand())
 	GetCmd.AddCommand(get.NewResourceImportCommand())
+	GetCmd.AddCommand(get.NewResourceExportCommand())
 }

--- a/pkg/antctl/raw/multicluster/get/clusterset.go
+++ b/pkg/antctl/raw/multicluster/get/clusterset.go
@@ -1,0 +1,162 @@
+// Copyright 2022 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package get
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	multiclusterv1alpha1 "antrea.io/antrea/multicluster/apis/multicluster/v1alpha1"
+	"antrea.io/antrea/pkg/antctl/raw"
+	multiclusterscheme "antrea.io/antrea/pkg/antctl/raw/multicluster/scheme"
+	"antrea.io/antrea/pkg/antctl/transform/clusterset"
+)
+
+var cmdClusterSet *cobra.Command
+
+type clusterSetOptions struct {
+	namespace     string
+	outputFormat  string
+	allNamespaces bool
+}
+
+var optionsClusterSet *clusterSetOptions
+
+var clusterSetExamples = strings.Trim(`
+Gel all ClusterSets in default Namesapce
+$ antctl mc get clusterset
+Get all ClusterSets in all Namespaces
+$ antctl mc get clusterset -A
+Get all ClusterSets in the specified Namespace
+$ antctl mc get clusterset -n <NAMESPACE>
+Get all ClusterSets and print them in JSON format
+$ antctl mc get clusterset -o json
+Get the specified ClusterSet
+$ antctl mc get clusterset <CLUSTERSETID>
+`, "\n")
+
+func (o *clusterSetOptions) validateAndComplete() {
+	if o.allNamespaces {
+		o.namespace = metav1.NamespaceAll
+		return
+	}
+	if o.namespace == "" {
+		o.namespace = metav1.NamespaceDefault
+		return
+	}
+}
+
+func NewClusterSetCommand() *cobra.Command {
+	cmdClusterSet = &cobra.Command{
+		Use: "clusterset",
+		Aliases: []string{
+			"clustersets",
+		},
+		Short:   "Print Multi-cluster ClusterSets",
+		Args:    cobra.MaximumNArgs(1),
+		Example: clusterSetExamples,
+		RunE:    runEClusterSet,
+	}
+	o := &clusterSetOptions{}
+	optionsClusterSet = o
+	cmdClusterSet.Flags().StringVarP(&o.namespace, "namespace", "n", "", "Namespace of ClusterSets")
+	cmdClusterSet.Flags().StringVarP(&o.outputFormat, "output", "o", "", "Output format. Supported formats: json|yaml")
+	cmdClusterSet.Flags().BoolVarP(&o.allNamespaces, "all-namespaces", "A", false, "If present, list ClusterSets across all namespaces")
+
+	return cmdClusterSet
+}
+
+func runEClusterSet(cmd *cobra.Command, args []string) error {
+	optionsClusterSet.validateAndComplete()
+
+	kubeconfig, err := raw.ResolveKubeconfig(cmd)
+	if err != nil {
+		return err
+	}
+
+	argsNum := len(args)
+	singleResource := false
+	if argsNum > 0 {
+		singleResource = true
+	}
+
+	k8sClient, err := client.New(kubeconfig, client.Options{Scheme: multiclusterscheme.Scheme})
+	if err != nil {
+		return err
+	}
+
+	var clusterSets []multiclusterv1alpha1.ClusterSet
+	if singleResource {
+		clusterSetName := args[0]
+		clusterSet := multiclusterv1alpha1.ClusterSet{}
+		err = k8sClient.Get(context.TODO(), types.NamespacedName{
+			Namespace: optionsClusterSet.namespace,
+			Name:      clusterSetName,
+		}, &clusterSet)
+		if err != nil {
+			return err
+		}
+		gvks, unversioned, err := k8sClient.Scheme().ObjectKinds(&clusterSet)
+		if err != nil {
+			return err
+		}
+		if !unversioned && len(gvks) == 1 {
+			clusterSet.SetGroupVersionKind(gvks[0])
+		}
+		clusterSets = append(clusterSets, clusterSet)
+	} else {
+		clusterSetList := &multiclusterv1alpha1.ClusterSetList{}
+		err = k8sClient.List(context.TODO(), clusterSetList, &client.ListOptions{Namespace: optionsClusterSet.namespace})
+		if err != nil {
+			return err
+		}
+		clusterSets = clusterSetList.Items
+	}
+
+	if len(clusterSets) == 0 {
+		if optionsClusterSet.namespace != "" {
+			fmt.Fprintf(cmd.ErrOrStderr(), "No resource found in Namespace %s\n", optionsClusterSet.namespace)
+		} else {
+			fmt.Fprintln(cmd.ErrOrStderr(), "No resources found")
+		}
+		return nil
+	}
+
+	switch optionsClusterSet.outputFormat {
+	case "json", "yaml":
+		err := output(clusterSets, true, optionsClusterSet.outputFormat, clusterset.Transform)
+		if err != nil {
+			return err
+		}
+	default:
+		clusterSetsNum := len(clusterSets)
+		for i, singleclusterset := range clusterSets {
+			err := output(singleclusterset, true, optionsClusterSet.outputFormat, clusterset.Transform)
+			if err != nil {
+				return err
+			}
+			if i != clusterSetsNum-1 {
+				fmt.Print("\n")
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/antctl/raw/multicluster/get/resourceexport.go
+++ b/pkg/antctl/raw/multicluster/get/resourceexport.go
@@ -1,0 +1,156 @@
+// Copyright 2022 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package get
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	multiclusterv1alpha1 "antrea.io/antrea/multicluster/apis/multicluster/v1alpha1"
+	"antrea.io/antrea/pkg/antctl/raw"
+	multiclusterscheme "antrea.io/antrea/pkg/antctl/raw/multicluster/scheme"
+	"antrea.io/antrea/pkg/antctl/transform/resourceexport"
+)
+
+var cmdResourceExport *cobra.Command
+
+type resourceExportOptions struct {
+	namespace     string
+	outputFormat  string
+	allNamespaces bool
+	clusterID     string
+}
+
+var optionsResourceExport *resourceExportOptions
+
+var resourceExportExamples = strings.Trim(`
+Get all ResourceExports of ClusterSet in default Namesapce
+$ antctl mc get resourceexport
+Get all ResourceExports of ClusterSet in all Namespaces
+$ antctl mc get resourceexport -A
+Get all ResourceExports in the specified Namespace
+$ antctl mc get resourceexport -n <NAMESPACE>
+Get all ResourceExports and print them in JSON format
+$ antctl mc get resourceexport -o json
+Get the specified ResourceExport
+$ antctl mc get resourceexport <RESOURCEEXPORT> -n <NAMESPACE>
+`, "\n")
+
+func (o *resourceExportOptions) validateAndComplete() {
+	if o.allNamespaces {
+		o.namespace = metav1.NamespaceAll
+		return
+	}
+	if o.namespace == "" {
+		o.namespace = metav1.NamespaceDefault
+		return
+	}
+}
+
+func NewResourceExportCommand() *cobra.Command {
+	cmdResourceExport = &cobra.Command{
+		Use: "resourceexport",
+		Aliases: []string{
+			"resourceexports",
+			"re",
+		},
+		Short:   "Print Multi-cluster ResourceExports",
+		Args:    cobra.MaximumNArgs(1),
+		Example: resourceExportExamples,
+		RunE:    runEResourceExport,
+	}
+	o := &resourceExportOptions{}
+	optionsResourceExport = o
+	cmdResourceExport.Flags().StringVarP(&o.namespace, "namespace", "n", "", "Namespace of ResourceExport")
+	cmdResourceExport.Flags().StringVarP(&o.outputFormat, "output", "o", "", "Output format. Supported formats: json|yaml")
+	cmdResourceExport.Flags().BoolVarP(&o.allNamespaces, "all-namespaces", "A", false, "If present, list ResourceExport across all namespaces")
+	cmdResourceExport.Flags().StringVarP(&o.clusterID, "cluster-id", "", "", "List of the ResourceExport of specific clusterID")
+
+	return cmdResourceExport
+}
+
+func runEResourceExport(cmd *cobra.Command, args []string) error {
+	optionsResourceExport.validateAndComplete()
+
+	kubeconfig, err := raw.ResolveKubeconfig(cmd)
+	if err != nil {
+		return err
+	}
+
+	argsNum := len(args)
+	singleResource := false
+	if argsNum > 0 {
+		singleResource = true
+	}
+	var resExports []multiclusterv1alpha1.ResourceExport
+	k8sClient, err := client.New(kubeconfig, client.Options{Scheme: multiclusterscheme.Scheme})
+	if err != nil {
+		return err
+	}
+
+	if singleResource {
+		resourceExportName := args[0]
+		resourceExport := multiclusterv1alpha1.ResourceExport{}
+		err = k8sClient.Get(context.TODO(), types.NamespacedName{
+			Namespace: optionsResourceExport.namespace,
+			Name:      resourceExportName,
+		}, &resourceExport)
+		if err != nil {
+			return err
+		}
+		gvks, unversioned, err := k8sClient.Scheme().ObjectKinds(&resourceExport)
+		if err != nil {
+			return err
+		}
+		if !unversioned && len(gvks) == 1 {
+			resourceExport.SetGroupVersionKind(gvks[0])
+		}
+		resExports = append(resExports, resourceExport)
+	} else {
+		var labels map[string]string
+		if optionsResourceExport.clusterID != "" {
+			labels = map[string]string{"sourceClusterID": optionsResourceExport.clusterID}
+		}
+		selector := metav1.LabelSelector{MatchLabels: labels}
+		labelSelector, _ := metav1.LabelSelectorAsSelector(&selector)
+		resourceExportList := &multiclusterv1alpha1.ResourceExportList{}
+		err = k8sClient.List(context.TODO(), resourceExportList, &client.ListOptions{
+			Namespace:     optionsResourceExport.namespace,
+			LabelSelector: labelSelector,
+		})
+		if err != nil {
+			return err
+		}
+		resExports = resourceExportList.Items
+	}
+
+	if len(resExports) == 0 {
+		if optionsResourceExport.namespace != "" {
+			fmt.Fprintf(cmd.ErrOrStderr(), "No resources found in Namespace %s\n", optionsResourceExport.namespace)
+		} else {
+			fmt.Fprintln(cmd.ErrOrStderr(), "No resources found")
+		}
+		return nil
+	}
+
+	return output(resExports, false, optionsResourceExport.outputFormat, resourceexport.Transform)
+
+}

--- a/pkg/antctl/transform/clusterset/transform.go
+++ b/pkg/antctl/transform/clusterset/transform.go
@@ -1,0 +1,76 @@
+// Copyright 2022 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusterset
+
+import (
+	multiclusterv1alpha1 "antrea.io/antrea/multicluster/apis/multicluster/v1alpha1"
+	"antrea.io/antrea/pkg/antctl/transform/common"
+)
+
+type Response struct {
+	ClusterID    string `json:"clusterID" yaml:"clusterID"`
+	Namespace    string `json:"namespace" yaml:"namespace"`
+	ClusterSetID string `json:"clusterSetID" yaml:"clusterSetID"`
+	Type         string `json:"type" yaml:"type"`
+	Status       string `json:"status" yaml:"status"`
+	Reason       string `json:"reason" yaml:"reason"`
+}
+
+func Transform(r interface{}, single bool) (interface{}, error) {
+	return listTransform(r)
+}
+
+func listTransform(l interface{}) (interface{}, error) {
+	clusterSet := l.(multiclusterv1alpha1.ClusterSet)
+	var result []interface{}
+
+	for i := range clusterSet.Status.ClusterStatuses {
+		r := clusterSet.Status.ClusterStatuses[i]
+		for j := range r.Conditions {
+			condition := r.Conditions[j]
+			o, _ := objectTransform(clusterSet, r, condition)
+			result = append(result, o.(Response))
+		}
+	}
+
+	return result, nil
+}
+
+func objectTransform(clusterSet multiclusterv1alpha1.ClusterSet, status multiclusterv1alpha1.ClusterStatus,
+	condition multiclusterv1alpha1.ClusterCondition) (interface{}, error) {
+
+	return Response{
+		ClusterID:    status.ClusterID,
+		Namespace:    clusterSet.Namespace,
+		ClusterSetID: clusterSet.Name,
+		Type:         string(condition.Type),
+		Status:       string(condition.Status),
+		Reason:       condition.Reason,
+	}, nil
+}
+
+var _ common.TableOutput = new(Response)
+
+func (r Response) GetTableHeader() []string {
+	return []string{"CLUSTER-ID", "NAMESPACE", "CLUSTER-SET-ID", "TYPE", "STATUS", "REASON"}
+}
+
+func (r Response) GetTableRow(maxColumnLength int) []string {
+	return []string{r.ClusterID, r.Namespace, r.ClusterSetID, r.Type, r.Status, r.Reason}
+}
+
+func (r Response) SortRows() bool {
+	return true
+}

--- a/pkg/antctl/transform/resourceexport/transform.go
+++ b/pkg/antctl/transform/resourceexport/transform.go
@@ -1,0 +1,72 @@
+// Copyright 2022 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourceexport
+
+import (
+	multiclusterv1alpha1 "antrea.io/antrea/multicluster/apis/multicluster/v1alpha1"
+	"antrea.io/antrea/pkg/antctl/transform/common"
+)
+
+type Response struct {
+	ClusterID string `json:"clusterID" yaml:"clusterID"`
+	Namespace string `json:"namespace" yaml:"namespace"`
+	Name      string `json:"name" yaml:"name"`
+	Kind      string `json:"kind" yaml:"kind"`
+}
+
+func Transform(r interface{}, single bool) (interface{}, error) {
+	if single {
+		return objectTransform(r)
+	}
+	return listTransform(r)
+}
+
+func listTransform(l interface{}) (interface{}, error) {
+	resourceExports := l.([]multiclusterv1alpha1.ResourceExport)
+	var result []interface{}
+
+	for i := range resourceExports {
+		item := resourceExports[i]
+		o, _ := objectTransform(&item)
+		result = append(result, o.(Response))
+	}
+
+	return result, nil
+}
+
+func objectTransform(o interface{}) (interface{}, error) {
+	resourceExport := o.(*multiclusterv1alpha1.ResourceExport)
+
+	return Response{
+		ClusterID: resourceExport.Labels["sourceClusterID"],
+		Namespace: resourceExport.Namespace,
+		Name:      resourceExport.Name,
+		Kind:      resourceExport.Spec.Kind,
+	}, nil
+}
+
+var _ common.TableOutput = new(Response)
+
+func (r Response) GetTableHeader() []string {
+	return []string{"CLUSTER-ID", "NAMESPACE", "NAME", "KIND"}
+}
+
+func (r Response) GetTableRow(maxColumnLength int) []string {
+	return []string{r.ClusterID, r.Namespace, r.Name, r.Kind}
+}
+
+func (r Response) SortRows() bool {
+	return true
+}


### PR DESCRIPTION
antctl multicluster command for clusterset & clustersets, resourceexport

For command lines for ClusterSets, we have 
```
Gel all ClusterSets in default Namesapce
$ antctl mc get clusterset
Get all ClusterSets in all Namespaces
$ antctl mc get clusterset -A
Get all ClusterSets in the specified Namespace
$ antctl mc get clusterset -n <NAMESPACE>
Get all ClusterSets and print them in JSON format
$ antctl mc get clusterset -o json
Get the specified ClusterSet
$ antctl mc get clusterset <CLUSTERSETID>
```

For command lines for ResourceExport, we have
```
Gel all ResourceExports of ClusterSet in default Namesapce
$ antctl mc get resourceexport
Get all ResourceExports of ClusterSet in all Namespaces
$ antctl mc get resourceexport -A
Get all ResourceExports in the specified Namespace
$ antctl mc get resourceexport -n <NAMESPACE>
Get all ResourceExports and print them in JSON format
$ antctl mc get resourceexport -o json
Get the specified ResourceExport
$ antctl mc get resourceexport <RESOURCEEXPORT> -n <NAMESPACE>
```

