### PR TITLE
Pin markdownlint version for consistent verification result

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -185,7 +185,7 @@ jobs:
         config-file: 'hack/.md_links_config.json'
     - name: Markdownlint
       run: |
-        sudo npm install -g markdownlint-cli
+        sudo npm install -g markdownlint-cli@0.31.1
         make markdownlint
 
   benchmark:


### PR DESCRIPTION
To avoid issues such as #3283, pin markdownlint version.

markdownlint version should be upgraded manually when necessary.

Signed-off-by: Quan Tian <qtian@vmware.com>