### PR TITLE
Automated cherry pick of #3283: Fix markdownlint verification MD050/strong-style

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -187,7 +187,7 @@ jobs:
         config-file: 'hack/.md_links_config.json'
     - name: Markdownlint
       run: |
-        sudo npm install -g markdownlint-cli
+        sudo npm install -g markdownlint-cli@0.31.1
         make markdownlint
 
   benchmark:

--- a/docs/antrea-network-policy.md
+++ b/docs/antrea-network-policy.md
@@ -836,7 +836,7 @@ status:
       lastTransitionTime: "2021-01-29T20:21:48Z"
 ```
 
-There are a few __restrictions__ on how ClusterGroups can be configured:
+There are a few **restrictions** on how ClusterGroups can be configured:
 
 - A ClusterGroup is a cluster-scoped resource and therefore can only be set in an Antrea
   ClusterNetworkPolicy's `appliedTo` and `to`/`from` peers.


### PR DESCRIPTION
Cherry pick of #3283 on release-1.5.

#3283: Fix markdownlint verification MD050/strong-style

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.