### PR TITLE
Add an agent config parameter for enabling flexible IPAM (bridging mode)

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -2597,8 +2597,8 @@ data:
     # Enable controlling SNAT IPs of Pod egress traffic.
     #  Egress: false
 
-    # Enable flexible IPAM mode for Antrea. This mode allows to assign IP Ranges to Namespaces,
-    # Deployments and StatefulSets via IP Pool annotation.
+    # Enable AntreaIPAM, which can allocate IP addresses from IPPools. AntreaIPAM is required by the
+    # bridging mode and allocates IPs to Pods in bridging mode.
     #  AntreaIPAM: false
 
     # Enable multicast traffic. This feature is supported only with noEncap mode.
@@ -2663,6 +2663,15 @@ data:
     #                    variable: ANTREA_IPSEC_PSK.
     # - wireGuard:       Enable WireGuard for tunnel traffic encryption.
     #trafficEncryptionMode: none
+
+    # Enable bridging mode of Pod network on Nodes, in which the Node's transport interface is connected
+    # to the OVS bridge, and cross-Node/VLAN traffic from AntreaIPAM Pods (Pods whose IP addresses are
+    # allocated by AntreaIPAM from IPPools) is sent to the underlay network via the uplink, and
+    # forwarded/routed by the underlay network.
+    # This option requires the `AntreaIPAM` feature gate to be enabled. At this moment, it supports only
+    # IPv4 and Linux Nodes, and can be enabled only when `ovsDatapathType` is `system`,
+    # `trafficEncapMode` is `noEncap`, and `noSNAT` is true.
+    #enableBridgingMode: false
 
     # Default MTU to use for the host gateway interface and the network interface of each Pod.
     # If omitted, antrea-agent will discover the MTU of the Node's primary interface and
@@ -2891,7 +2900,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-bg855thh55
+  name: antrea-config-tb4cm2bddc
   namespace: kube-system
 ---
 apiVersion: v1
@@ -2962,7 +2971,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-bg855thh55
+          value: antrea-config-tb4cm2bddc
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -3013,7 +3022,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-bg855thh55
+          name: antrea-config-tb4cm2bddc
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -3249,7 +3258,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-bg855thh55
+          name: antrea-config-tb4cm2bddc
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -2597,8 +2597,8 @@ data:
     # Enable controlling SNAT IPs of Pod egress traffic.
     #  Egress: false
 
-    # Enable flexible IPAM mode for Antrea. This mode allows to assign IP Ranges to Namespaces,
-    # Deployments and StatefulSets via IP Pool annotation.
+    # Enable AntreaIPAM, which can allocate IP addresses from IPPools. AntreaIPAM is required by the
+    # bridging mode and allocates IPs to Pods in bridging mode.
     #  AntreaIPAM: false
 
     # Enable multicast traffic. This feature is supported only with noEncap mode.
@@ -2663,6 +2663,15 @@ data:
     #                    variable: ANTREA_IPSEC_PSK.
     # - wireGuard:       Enable WireGuard for tunnel traffic encryption.
     #trafficEncryptionMode: none
+
+    # Enable bridging mode of Pod network on Nodes, in which the Node's transport interface is connected
+    # to the OVS bridge, and cross-Node/VLAN traffic from AntreaIPAM Pods (Pods whose IP addresses are
+    # allocated by AntreaIPAM from IPPools) is sent to the underlay network via the uplink, and
+    # forwarded/routed by the underlay network.
+    # This option requires the `AntreaIPAM` feature gate to be enabled. At this moment, it supports only
+    # IPv4 and Linux Nodes, and can be enabled only when `ovsDatapathType` is `system`,
+    # `trafficEncapMode` is `noEncap`, and `noSNAT` is true.
+    #enableBridgingMode: false
 
     # Default MTU to use for the host gateway interface and the network interface of each Pod.
     # If omitted, antrea-agent will discover the MTU of the Node's primary interface and
@@ -2891,7 +2900,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-bg855thh55
+  name: antrea-config-tb4cm2bddc
   namespace: kube-system
 ---
 apiVersion: v1
@@ -2962,7 +2971,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-bg855thh55
+          value: antrea-config-tb4cm2bddc
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -3013,7 +3022,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-bg855thh55
+          name: antrea-config-tb4cm2bddc
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -3251,7 +3260,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-bg855thh55
+          name: antrea-config-tb4cm2bddc
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -2597,8 +2597,8 @@ data:
     # Enable controlling SNAT IPs of Pod egress traffic.
     #  Egress: false
 
-    # Enable flexible IPAM mode for Antrea. This mode allows to assign IP Ranges to Namespaces,
-    # Deployments and StatefulSets via IP Pool annotation.
+    # Enable AntreaIPAM, which can allocate IP addresses from IPPools. AntreaIPAM is required by the
+    # bridging mode and allocates IPs to Pods in bridging mode.
     #  AntreaIPAM: false
 
     # Enable multicast traffic. This feature is supported only with noEncap mode.
@@ -2663,6 +2663,15 @@ data:
     #                    variable: ANTREA_IPSEC_PSK.
     # - wireGuard:       Enable WireGuard for tunnel traffic encryption.
     #trafficEncryptionMode: none
+
+    # Enable bridging mode of Pod network on Nodes, in which the Node's transport interface is connected
+    # to the OVS bridge, and cross-Node/VLAN traffic from AntreaIPAM Pods (Pods whose IP addresses are
+    # allocated by AntreaIPAM from IPPools) is sent to the underlay network via the uplink, and
+    # forwarded/routed by the underlay network.
+    # This option requires the `AntreaIPAM` feature gate to be enabled. At this moment, it supports only
+    # IPv4 and Linux Nodes, and can be enabled only when `ovsDatapathType` is `system`,
+    # `trafficEncapMode` is `noEncap`, and `noSNAT` is true.
+    #enableBridgingMode: false
 
     # Default MTU to use for the host gateway interface and the network interface of each Pod.
     # If omitted, antrea-agent will discover the MTU of the Node's primary interface and
@@ -2891,7 +2900,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-d44h5956gg
+  name: antrea-config-557b79kcm4
   namespace: kube-system
 ---
 apiVersion: v1
@@ -2962,7 +2971,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-d44h5956gg
+          value: antrea-config-557b79kcm4
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -3013,7 +3022,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-d44h5956gg
+          name: antrea-config-557b79kcm4
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -3252,7 +3261,7 @@ spec:
           path: /home/kubernetes/bin
         name: host-cni-bin
       - configMap:
-          name: antrea-config-d44h5956gg
+          name: antrea-config-557b79kcm4
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -2597,8 +2597,8 @@ data:
     # Enable controlling SNAT IPs of Pod egress traffic.
     #  Egress: false
 
-    # Enable flexible IPAM mode for Antrea. This mode allows to assign IP Ranges to Namespaces,
-    # Deployments and StatefulSets via IP Pool annotation.
+    # Enable AntreaIPAM, which can allocate IP addresses from IPPools. AntreaIPAM is required by the
+    # bridging mode and allocates IPs to Pods in bridging mode.
     #  AntreaIPAM: false
 
     # Enable multicast traffic. This feature is supported only with noEncap mode.
@@ -2663,6 +2663,15 @@ data:
     #                    variable: ANTREA_IPSEC_PSK.
     # - wireGuard:       Enable WireGuard for tunnel traffic encryption.
     trafficEncryptionMode: ipsec
+
+    # Enable bridging mode of Pod network on Nodes, in which the Node's transport interface is connected
+    # to the OVS bridge, and cross-Node/VLAN traffic from AntreaIPAM Pods (Pods whose IP addresses are
+    # allocated by AntreaIPAM from IPPools) is sent to the underlay network via the uplink, and
+    # forwarded/routed by the underlay network.
+    # This option requires the `AntreaIPAM` feature gate to be enabled. At this moment, it supports only
+    # IPv4 and Linux Nodes, and can be enabled only when `ovsDatapathType` is `system`,
+    # `trafficEncapMode` is `noEncap`, and `noSNAT` is true.
+    #enableBridgingMode: false
 
     # Default MTU to use for the host gateway interface and the network interface of each Pod.
     # If omitted, antrea-agent will discover the MTU of the Node's primary interface and
@@ -2896,7 +2905,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-56dhk99g5f
+  name: antrea-config-49chg5d6md
   namespace: kube-system
 ---
 apiVersion: v1
@@ -2976,7 +2985,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-56dhk99g5f
+          value: antrea-config-49chg5d6md
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -3027,7 +3036,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-56dhk99g5f
+          name: antrea-config-49chg5d6md
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -3298,7 +3307,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-56dhk99g5f
+          name: antrea-config-49chg5d6md
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea-kind.yml
+++ b/build/yamls/antrea-kind.yml
@@ -2597,8 +2597,8 @@ data:
     # Enable controlling SNAT IPs of Pod egress traffic.
     #  Egress: false
 
-    # Enable flexible IPAM mode for Antrea. This mode allows to assign IP Ranges to Namespaces,
-    # Deployments and StatefulSets via IP Pool annotation.
+    # Enable AntreaIPAM, which can allocate IP addresses from IPPools. AntreaIPAM is required by the
+    # bridging mode and allocates IPs to Pods in bridging mode.
     #  AntreaIPAM: false
 
     # Enable multicast traffic. This feature is supported only with noEncap mode.
@@ -2663,6 +2663,15 @@ data:
     #                    variable: ANTREA_IPSEC_PSK.
     # - wireGuard:       Enable WireGuard for tunnel traffic encryption.
     #trafficEncryptionMode: none
+
+    # Enable bridging mode of Pod network on Nodes, in which the Node's transport interface is connected
+    # to the OVS bridge, and cross-Node/VLAN traffic from AntreaIPAM Pods (Pods whose IP addresses are
+    # allocated by AntreaIPAM from IPPools) is sent to the underlay network via the uplink, and
+    # forwarded/routed by the underlay network.
+    # This option requires the `AntreaIPAM` feature gate to be enabled. At this moment, it supports only
+    # IPv4 and Linux Nodes, and can be enabled only when `ovsDatapathType` is `system`,
+    # `trafficEncapMode` is `noEncap`, and `noSNAT` is true.
+    #enableBridgingMode: false
 
     # Default MTU to use for the host gateway interface and the network interface of each Pod.
     # If omitted, antrea-agent will discover the MTU of the Node's primary interface and
@@ -2896,7 +2905,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-m4h4624d24
+  name: antrea-config-c2kfgd59tm
   namespace: kube-system
 ---
 apiVersion: v1
@@ -2967,7 +2976,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-m4h4624d24
+          value: antrea-config-c2kfgd59tm
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -3018,7 +3027,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-m4h4624d24
+          name: antrea-config-c2kfgd59tm
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -3250,7 +3259,7 @@ spec:
           type: CharDevice
         name: dev-tun
       - configMap:
-          name: antrea-config-m4h4624d24
+          name: antrea-config-c2kfgd59tm
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -2597,8 +2597,8 @@ data:
     # Enable controlling SNAT IPs of Pod egress traffic.
     #  Egress: false
 
-    # Enable flexible IPAM mode for Antrea. This mode allows to assign IP Ranges to Namespaces,
-    # Deployments and StatefulSets via IP Pool annotation.
+    # Enable AntreaIPAM, which can allocate IP addresses from IPPools. AntreaIPAM is required by the
+    # bridging mode and allocates IPs to Pods in bridging mode.
     #  AntreaIPAM: false
 
     # Enable multicast traffic. This feature is supported only with noEncap mode.
@@ -2663,6 +2663,15 @@ data:
     #                    variable: ANTREA_IPSEC_PSK.
     # - wireGuard:       Enable WireGuard for tunnel traffic encryption.
     #trafficEncryptionMode: none
+
+    # Enable bridging mode of Pod network on Nodes, in which the Node's transport interface is connected
+    # to the OVS bridge, and cross-Node/VLAN traffic from AntreaIPAM Pods (Pods whose IP addresses are
+    # allocated by AntreaIPAM from IPPools) is sent to the underlay network via the uplink, and
+    # forwarded/routed by the underlay network.
+    # This option requires the `AntreaIPAM` feature gate to be enabled. At this moment, it supports only
+    # IPv4 and Linux Nodes, and can be enabled only when `ovsDatapathType` is `system`,
+    # `trafficEncapMode` is `noEncap`, and `noSNAT` is true.
+    #enableBridgingMode: false
 
     # Default MTU to use for the host gateway interface and the network interface of each Pod.
     # If omitted, antrea-agent will discover the MTU of the Node's primary interface and
@@ -2896,7 +2905,7 @@ metadata:
   annotations: {}
   labels:
     app: antrea
-  name: antrea-config-895f7f85g9
+  name: antrea-config-82b78c27h8
   namespace: kube-system
 ---
 apiVersion: v1
@@ -2967,7 +2976,7 @@ spec:
             fieldRef:
               fieldPath: spec.serviceAccountName
         - name: ANTREA_CONFIG_MAP_NAME
-          value: antrea-config-895f7f85g9
+          value: antrea-config-82b78c27h8
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -3018,7 +3027,7 @@ spec:
         key: node-role.kubernetes.io/master
       volumes:
       - configMap:
-          name: antrea-config-895f7f85g9
+          name: antrea-config-82b78c27h8
         name: antrea-config
       - name: antrea-controller-tls
         secret:
@@ -3254,7 +3263,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-config-895f7f85g9
+          name: antrea-config-82b78c27h8
         name: antrea-config
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/base/conf/antrea-agent.conf
+++ b/build/yamls/base/conf/antrea-agent.conf
@@ -31,8 +31,8 @@ featureGates:
 # Enable controlling SNAT IPs of Pod egress traffic.
 #  Egress: false
 
-# Enable flexible IPAM mode for Antrea. This mode allows to assign IP Ranges to Namespaces,
-# Deployments and StatefulSets via IP Pool annotation.
+# Enable AntreaIPAM, which can allocate IP addresses from IPPools. AntreaIPAM is required by the
+# bridging mode and allocates IPs to Pods in bridging mode.
 #  AntreaIPAM: false
 
 # Enable multicast traffic. This feature is supported only with noEncap mode.
@@ -97,6 +97,15 @@ featureGates:
 #                    variable: ANTREA_IPSEC_PSK.
 # - wireGuard:       Enable WireGuard for tunnel traffic encryption.
 #trafficEncryptionMode: none
+
+# Enable bridging mode of Pod network on Nodes, in which the Node's transport interface is connected
+# to the OVS bridge, and cross-Node/VLAN traffic from AntreaIPAM Pods (Pods whose IP addresses are
+# allocated by AntreaIPAM from IPPools) is sent to the underlay network via the uplink, and
+# forwarded/routed by the underlay network.
+# This option requires the `AntreaIPAM` feature gate to be enabled. At this moment, it supports only
+# IPv4 and Linux Nodes, and can be enabled only when `ovsDatapathType` is `system`,
+# `trafficEncapMode` is `noEncap`, and `noSNAT` is true.
+#enableBridgingMode: false
 
 # Default MTU to use for the host gateway interface and the network interface of each Pod.
 # If omitted, antrea-agent will discover the MTU of the Node's primary interface and

--- a/cmd/antrea-agent/options_windows.go
+++ b/cmd/antrea-agent/options_windows.go
@@ -53,6 +53,9 @@ func (o *Options) checkUnsupportedFeatures() error {
 	if encryptionMode != config.TrafficEncryptionModeNone {
 		unsupported = append(unsupported, "TrafficEncryptionMode: "+encryptionMode.String())
 	}
+	if o.config.EnableBridgingMode {
+		unsupported = append(unsupported, "EnableBridgingMode")
+	}
 	if unsupported != nil {
 		return fmt.Errorf("unsupported features on Windows: {%s}", strings.Join(unsupported, ", "))
 	}

--- a/hack/generate-manifest.sh
+++ b/hack/generate-manifest.sh
@@ -47,7 +47,7 @@ Generate a YAML manifest for Antrea using Kustomize and print it to stdout.
         --sriov                       Generates a manifest which enables use of Kubelet API for SR-IOV device info.
         --wireguard-go                Generate a manifest with WireGuard (golang implementation) encryption enabled.
                                       This option will work only for Kind clusters (when using '--kind').
-        --flexible-ipam               Generates a manifest for flexible ipam mode.
+        --flexible-ipam               Generates a manifest with flexible IPAM enabled.
         --whereabouts                 Generates a manifest which enables whereabouts configuration for secondary network IPAM.
         --help, -h                    Print this message and exit
         --multicast                   Generates a manifest for multicast.
@@ -333,6 +333,7 @@ fi
 if $FLEXIBLE_IPAM; then
     sed -i.bak -E "s/^[[:space:]]*#[[:space:]]*AntreaIPAM[[:space:]]*:[[:space:]]*[a-z]+[[:space:]]*$/  AntreaIPAM: true/" antrea-controller.conf
     sed -i.bak -E "s/^[[:space:]]*#[[:space:]]*AntreaIPAM[[:space:]]*:[[:space:]]*[a-z]+[[:space:]]*$/  AntreaIPAM: true/" antrea-agent.conf
+    sed -i.bak -E "s/^[[:space:]]*#[[:space:]]*enableBridgingMode[[:space:]]*:[[:space:]]*[a-z]+[[:space:]]*$/enableBridgingMode: true/" antrea-agent.conf
     sed -i.bak -E "s/^[[:space:]]*#[[:space:]]*trafficEncapMode[[:space:]]*:[[:space:]]*[a-z]+[[:space:]]*$/trafficEncapMode: noEncap/" antrea-agent.conf
     sed -i.bak -E "s/^[[:space:]]*#[[:space:]]*noSNAT[[:space:]]*:[[:space:]]*[a-z]+[[:space:]]*$/noSNAT: true/" antrea-agent.conf
 fi

--- a/pkg/agent/agent_linux.go
+++ b/pkg/agent/agent_linux.go
@@ -39,8 +39,8 @@ func (i *Initializer) prepareHostNetwork() error {
 	return nil
 }
 
-// prepareOVSBridge returns immediately on Linux if connectUplinkToBridge is false.
 func (i *Initializer) prepareOVSBridge() error {
+	// Return immediately on Linux if connectUplinkToBridge is false.
 	if !i.connectUplinkToBridge {
 		return nil
 	}
@@ -194,8 +194,8 @@ func (i *Initializer) restoreHostRoutesToInterface(ifaceName string) error {
 	return nil
 }
 
-// BridgeUplinkToOVSBridge returns immediately on Linux if connectUplinkToBridge is false.
-func (i *Initializer) BridgeUplinkToOVSBridge() error {
+func (i *Initializer) ConnectUplinkToOVSBridge() error {
+	// Return immediately on Linux if connectUplinkToBridge is false.
 	if !i.connectUplinkToBridge {
 		return nil
 	}
@@ -208,16 +208,16 @@ func (i *Initializer) BridgeUplinkToOVSBridge() error {
 	uplink := uplinkNetConfig.Name
 	if _, err := i.ovsBridgeClient.GetOFPort(uplink, false); err == nil {
 		klog.Infof("Uplink %s already exists, skip the configuration", uplink)
-		return err
+		return nil
 	}
 	// Create uplink port.
-	uplinkPortUUId, err := i.ovsBridgeClient.CreateUplinkPort(uplink, config.UplinkOFPort, map[string]interface{}{interfacestore.AntreaInterfaceTypeKey: interfacestore.AntreaUplink})
+	uplinkPortUUID, err := i.ovsBridgeClient.CreateUplinkPort(uplink, config.UplinkOFPort, map[string]interface{}{interfacestore.AntreaInterfaceTypeKey: interfacestore.AntreaUplink})
 	if err != nil {
 		return fmt.Errorf("failed to add uplink port %s: err=%w", uplink, err)
 	}
 	// Add newly created uplinkInterface to interface cache. This will be overwritten by initInterfaceStore.
 	uplinkInterface := interfacestore.NewUplinkInterface(uplink)
-	uplinkInterface.OVSPortConfig = &interfacestore.OVSPortConfig{uplinkPortUUId, config.UplinkOFPort} //nolint: govet
+	uplinkInterface.OVSPortConfig = &interfacestore.OVSPortConfig{uplinkPortUUID, config.UplinkOFPort} //nolint: govet
 	i.ifaceStore.AddInterface(uplinkInterface)
 
 	// Move network configuration of uplink interface to OVS bridge local interface.

--- a/pkg/agent/agent_windows.go
+++ b/pkg/agent/agent_windows.go
@@ -263,8 +263,9 @@ func GetTransportIPNetDeviceByName(ifaceName string, ovsBridgeName string) (*net
 	return nil, nil, nil, fmt.Errorf("unable to find local IP and device")
 }
 
-// BridgeUplinkToOVSBridge returns immediately on Windows.
-func (i *Initializer) BridgeUplinkToOVSBridge() error { return nil }
+// ConnectUplinkToOVSBridge returns immediately on Windows. The uplink interface
+// will be connected to the bridge in prepareOVSBridge().
+func (i *Initializer) ConnectUplinkToOVSBridge() error { return nil }
 
 // RestoreOVSBridge returns immediately in Windows.
 // OVS is managed by system in Windows, network config can be retained after Antrea shutdown.

--- a/pkg/config/agent/config.go
+++ b/pkg/config/agent/config.go
@@ -102,14 +102,21 @@ type AgentConfig struct {
 	TrafficEncryptionMode string `yaml:"trafficEncryptionMode,omitempty"`
 	// WireGuard related configurations.
 	WireGuard WireGuardConfig `yaml:"wireGuard"`
+	// Enable bridging mode of Pod network on Nodes, in which the Node's transport interface is connected
+	// to the OVS bridge, and cross-Node/VLAN traffic from AntreaIPAM Pods (Pods whose IP addresses are
+	// allocated by AntreaIPAM from IPPools) is sent to the underlay network via the uplink, and
+	// forwarded/routed by the underlay network.
+	// This option requires the `AntreaIPAM` feature gate to be enabled. At this moment, it supports only
+	// IPv4 and Linux Nodes, and can be enabled only when `ovsDatapathType` is `system`,
+	// `trafficEncapMode` is `noEncap`, and `noSNAT` is true.
+	EnableBridgingMode bool `yaml:"enableBridgingMode,omitempty"`
 	// APIPort is the port for the antrea-agent APIServer to serve on.
 	// Defaults to 10350.
 	APIPort int `yaml:"apiPort,omitempty"`
-
-	// ClusterMembershipPort is the server port used by the antrea-agent to run a gossip-based cluster membership protocol. Currently it's used only when the Egress feature is enabled.
+	// ClusterMembershipPort is the server port used by the antrea-agent to run a gossip-based cluster
+	// membership protocol. Currently it's used only when the Egress feature is enabled.
 	// Defaults to 10351.
 	ClusterMembershipPort int `yaml:"clusterPort,omitempty"`
-
 	// Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener
 	// Defaults to true.
 	EnablePrometheusMetrics *bool `yaml:"enablePrometheusMetrics,omitempty"`


### PR DESCRIPTION
In the current implementation, enabling the AntreaIPAM feature gate will
enable both AntreaIPAM which allocates IPs from IPPools, and Node side
datapath configurations to support traffic forwarding of AntreaIPAM Pods
whose IPs are allocated from IPPools by AntreaIPAM.
This commit adds a separate config parameter - enableBridgingMode - to
antrea-agent, to enable/disable support for AntreaIPAM Pods on a Node.
Only when enableBridgingMode is set to true, Antrea Agent connects the
uplink interface to the OVS bridge, requests IP allocation from
AntreaIPAM and implements traffic forwarding for AntreaIPAM (bridging
mode) Pods. This change is also needed to extend AntreaIPAM for other
IPAM use cases, in addition to IPAM for bridging mode Pods.

Signed-off-by: Jianjun Shen <shenj@vmware.com>