### PR TITLE
Fix AntreaNetworkPolicy e2e test random failures

### DIFF
--- a/multicluster/test/e2e/framework.go
+++ b/multicluster/test/e2e/framework.go
@@ -363,7 +363,10 @@ func (data *TestData) probe(
 	}
 	log.Tracef("Running: kubectl exec %s -c %s -n %s -- %s", podName, containerName, podNamespace, strings.Join(cmd, " "))
 	stdout, stderr, err := data.runCommandFromPod(cluster, podNamespace, podName, containerName, cmd)
-	if err != nil {
+	// It needs to check both err and stderr because:
+	// 1. The probe tried 3 times. If it checks err only, failure+failure+success would be considered connected.
+	// 2. There might be an issue in Pod exec API that it sometimes doesn't return error when the probe fails. See #2394.
+	if err != nil || stderr != "" {
 		// log this error as trace since may be an expected failure
 		log.Tracef("%s -> %s: error when running command: err - %v /// stdout - %s /// stderr - %s", podName, dstName, err, stdout, stderr)
 		// If err != nil and stderr == "", then it means this probe failed because of

--- a/test/e2e/k8s_util.go
+++ b/test/e2e/k8s_util.go
@@ -109,7 +109,10 @@ func (k *KubernetesUtils) probe(
 	}
 	log.Tracef("Running: kubectl exec %s -c %s -n %s -- %s", pod.Name, containerName, pod.Namespace, strings.Join(cmd, " "))
 	stdout, stderr, err := k.runCommandFromPod(pod.Namespace, pod.Name, containerName, cmd)
-	if err != nil {
+	// It needs to check both err and stderr because:
+	// 1. The probe tried 3 times. If it checks err only, failure+failure+success would be considered connected.
+	// 2. There might be an issue in Pod exec API that it sometimes doesn't return error when the probe fails. See #2394.
+	if err != nil || stderr != "" {
 		// log this error as trace since may be an expected failure
 		log.Tracef("%s -> %s: error when running command: err - %v /// stdout - %s /// stderr - %s", podName, dstName, err, stdout, stderr)
 		// If err != nil and stderr == "", then it means this probe failed because of


### PR DESCRIPTION
There might be some issues in Pod exec API that it sometimes doesn't
return error when the probe fails. However, regardless of the issue,
the code should check both err and stderr because the probe tried 3
times. If it checks err only, failure+failure+success would be
considered connected.

Signed-off-by: Quan Tian <qtian@vmware.com>

Fix #2394