### PR TITLE
Automated cherry pick of #3276: Use iptables-wrapper in Antrea container

### DIFF
--- a/build/images/base/Dockerfile
+++ b/build/images/base/Dockerfile
@@ -30,9 +30,15 @@ LABEL description="Takes care of building the Antrea binaries as part of buildin
 
 USER root
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ipset \
-    jq \
- && rm -rf /var/lib/apt/lists/*
+# See https://github.com/kubernetes-sigs/iptables-wrappers
+# /iptables-wrapper-installer.sh will have permissions of 600.
+# --chmod=700 doesn't work with older versions of Docker and requires DOCKER_BUILDKIT=1, so we use
+# chmod in the RUN command below instead.
+ADD https://raw.githubusercontent.com/kubernetes-sigs/iptables-wrappers/9e6ce59c864623ea71a6f7d59c35fcb13a919b87/iptables-wrapper-installer.sh /iptables-wrapper-installer.sh
+
+RUN apt-get update && apt-get install -y --no-install-recommends ipset jq && \
+    rm -rf /var/lib/apt/lists/* && \
+    chmod +x /iptables-wrapper-installer.sh && \
+    /iptables-wrapper-installer.sh
 
 COPY --from=cni-binaries /opt/cni/bin /opt/cni/bin


### PR DESCRIPTION
Cherry pick of #3276 on release-1.5.

#3276: Use iptables-wrapper in Antrea container

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.