### PR TITLE
Update apt repository link for Kubernetes

### DIFF
--- a/test/e2e/infra/vagrant/playbook/roles/common/tasks/kube.yml
+++ b/test/e2e/infra/vagrant/playbook/roles/common/tasks/kube.yml
@@ -7,7 +7,7 @@
   apt_repository:
     # kubernetes-xenial should work for Ubuntu 16.04+, there is no
     # kubernetes-bionic
-    repo: deb https://apt.kubernetes.io/ kubernetes-xenial main
+    repo: deb https://packages.cloud.google.com/apt/ kubernetes-xenial main
     state: present
     filename: kubernetes.list
 


### PR DESCRIPTION
The original link [https://apt.kubernetes.io/](https://apt.kubernetes.io/) is just a redirect to the link [https://packages.cloud.google.com/apt/](https://packages.cloud.google.com/apt/). Use the later one to avoid some redirection issues.

Signed-off-by: Yanjun Zhou <zhouya@vmware.com>