### PR TITLE
[flexible-ipam] Optimization on NodeIPAM code path

### DIFF
--- a/pkg/agent/cniserver/ipam/antrea_ipam_controller.go
+++ b/pkg/agent/cniserver/ipam/antrea_ipam_controller.go
@@ -148,6 +148,20 @@ func (c *AntreaIPAMController) getIPPoolsByPod(namespace, name string) ([]string
 		}
 		return nil, nil, nil, err
 	}
+
+	annotations, exists := pod.Annotations[AntreaIPAMAnnotationKey]
+	if !exists {
+		// Find IPPool by Namespace
+		ns, err := c.namespaceLister.Get(namespace)
+		if err != nil {
+			return nil, nil, nil, nil
+		}
+		annotations, exists = ns.Annotations[AntreaIPAMAnnotationKey]
+		if !exists {
+			return nil, nil, nil, nil
+		}
+	}
+
 	// Collect specified IPs if exist
 	ipStrings, _ := pod.Annotations[AntreaIPAMPodIPAnnotationKey]
 	ipStrings = strings.ReplaceAll(ipStrings, " ", "")
@@ -187,20 +201,6 @@ ownerReferenceLoop:
 		}
 	}
 
-	annotations, exists := pod.Annotations[AntreaIPAMAnnotationKey]
-	if exists {
-		return strings.Split(annotations, AntreaIPAMAnnotationDelimiter), ips, reservedOwner, ipErr
-	}
-
-	// Find IPPool by Namespace
-	ns, err := c.namespaceLister.Get(namespace)
-	if err != nil {
-		return nil, nil, nil, nil
-	}
-	annotations, exists = ns.Annotations[AntreaIPAMAnnotationKey]
-	if !exists {
-		return nil, nil, nil, nil
-	}
 	return strings.Split(annotations, AntreaIPAMAnnotationDelimiter), ips, reservedOwner, ipErr
 }
 


### PR DESCRIPTION
Avoid running unnecessary code in getIPPoolsByPod function when
no IPAM annotation is present.
Signed-off-by: Anna Khmelnitsky <akhmelnitsky@vmware.com>