### PR TITLE
Disable CGO to make binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,12 +28,12 @@ GRPID   := $(shell id -g)
 .PHONY: bin
 bin:
 	@mkdir -p $(BINDIR)
-	GOOS=linux $(GO) build -o $(BINDIR) $(GOFLAGS) -ldflags '$(LDFLAGS)' antrea.io/antrea/cmd/...
+	GOOS=linux CGO_ENABLED=0 $(GO) build -o $(BINDIR) $(GOFLAGS) -ldflags '$(LDFLAGS)' antrea.io/antrea/cmd/...
 
 .PHONY: antrea-agent
 antrea-agent:
 	@mkdir -p $(BINDIR)
-	GOOS=linux $(GO) build -o $(BINDIR) $(GOFLAGS) -ldflags '$(LDFLAGS)' antrea.io/antrea/cmd/antrea-agent
+	GOOS=linux CGO_ENABLED=0 $(GO) build -o $(BINDIR) $(GOFLAGS) -ldflags '$(LDFLAGS)' antrea.io/antrea/cmd/antrea-agent
 
 .PHONY: antrea-agent-simulator
 antrea-agent-simulator:
@@ -48,7 +48,7 @@ antrea-agent-instr-binary:
 .PHONY: antrea-controller
 antrea-controller:
 	@mkdir -p $(BINDIR)
-	GOOS=linux $(GO) build -o $(BINDIR) $(GOFLAGS) -ldflags '$(LDFLAGS)' antrea.io/antrea/cmd/antrea-controller
+	GOOS=linux CGO_ENABLED=0 $(GO) build -o $(BINDIR) $(GOFLAGS) -ldflags '$(LDFLAGS)' antrea.io/antrea/cmd/antrea-controller
 
 .PHONY: .coverage
 .coverage:
@@ -180,7 +180,7 @@ docker-tidy: $(DOCKER_CACHE)
 
 ANTCTL_BINARIES := antctl-darwin antctl-linux antctl-windows
 $(ANTCTL_BINARIES): antctl-%:
-	@GOOS=$* $(GO) build -o $(BINDIR)/$@ $(GOFLAGS) -ldflags '$(LDFLAGS)' antrea.io/antrea/cmd/antctl
+	@GOOS=$* CGO_ENABLED=0 $(GO) build -o $(BINDIR)/$@ $(GOFLAGS) -ldflags '$(LDFLAGS)' antrea.io/antrea/cmd/antctl
 	@if [[ $@ != *windows ]]; then \
 	  chmod 0755 $(BINDIR)/$@; \
 	else \

--- a/hack/release/prepare-assets.sh
+++ b/hack/release/prepare-assets.sh
@@ -54,10 +54,11 @@ for build in "${ANTREA_BUILDS[@]}"; do
     arch="${args[1]}"
     suffix="${args[2]}"
 
+    # cgo for antctl is explicitly disabled in the Makefile to ensure it is disabled for native builds.
+    GOOS=$os GOARCH=$arch ANTCTL_BINARY_NAME="antctl-$suffix" BINDIR="$OUTPUT_DIR"/ make antctl-release
     # cgo is disabled by default when cross-compiling, but enabled by default
     # for native builds. We ensure it is always disabled for portability since
     # these binaries will be distributed as release assets.
-    GOOS=$os GOARCH=$arch CGO_ENABLED=0 ANTCTL_BINARY_NAME="antctl-$suffix" BINDIR="$OUTPUT_DIR"/ make antctl-release
     cd ./plugins/octant && GOOS=$os GOARCH=$arch CGO_ENABLED=0 ANTREA_OCTANT_PLUGIN_BINARY_NAME="antrea-octant-plugin-$suffix" \
     BINDIR="$OUTPUT_DIR" make antrea-octant-plugin-release && cd ../..
 done


### PR DESCRIPTION
Fixes #3346.

This PR disable CGO while building the binaries to prevent antrea controller from crashing while deploying on the arm64 architecture. 

It solves the issue of crashing antrea when deploying antrea using the image build from the Makefile in the arm64 architecture.


Signed-off-by: Pulkit Jain <jainpu@vmware.com>