### PR TITLE
Add method AllocateIfNotExist to interface GroupCounter in proxy

### DIFF
--- a/pkg/agent/proxy/types/groupcounter.go
+++ b/pkg/agent/proxy/types/groupcounter.go
@@ -27,15 +27,14 @@ import (
 
 // GroupCounter generates and manages global unique group ID.
 type GroupCounter interface {
-	// Get generates a global unique group ID for a specific service.
-	// If the group ID of the service has been generated, then return the
-	// prior one. The bool return value indicates whether the groupID is newly
-	// generated.
+	// AllocateIfNotExist generates a global unique group ID for a Service if the group ID has not been generated, then
+	// return the group ID (newly allocated or already allocated).
+	AllocateIfNotExist(svcPortName k8sproxy.ServicePortName, isEndpointsLocal bool) binding.GroupIDType
+	// Get gets the group ID for the Service.
 	Get(svcPortName k8sproxy.ServicePortName, isEndpointsLocal bool) (binding.GroupIDType, bool)
-	// Recycle removes a Service Group ID mapping. The recycled groupID can be
-	// reused.
+	// Recycle removes the Service group ID mapping. The recycled group ID can be reused.
 	Recycle(svcPortName k8sproxy.ServicePortName, isEndpointsLocal bool) bool
-	// GetAllGroupIDs gets all groupID related to a Service.
+	// GetAllGroupIDs gets all group IDs related to the Service.
 	GetAllGroupIDs(svcNamespacedName string) []binding.GroupIDType
 }
 
@@ -80,18 +79,26 @@ func (c *groupCounter) deleteServicePortNameMap(svcNamespacedName string, svcKey
 	}
 }
 
-func (c *groupCounter) Get(svcPortName k8sproxy.ServicePortName, isEndpointsLocal bool) (binding.GroupIDType, bool) {
+func (c *groupCounter) AllocateIfNotExist(svcPortName k8sproxy.ServicePortName, isEndpointsLocal bool) binding.GroupIDType {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	key := keyString(svcPortName, isEndpointsLocal)
 	if id, ok := c.groupMap[key]; ok {
-		return id, false
+		return id
 	}
 	id := c.groupAllocator.Allocate()
 	c.groupMap[key] = id
 	c.updateServicePortNameMap(svcPortName.NamespacedName.String(), key)
 	c.groupIDUpdates <- svcPortName.NamespacedName.String()
-	return id, true
+	return id
+}
+
+func (c *groupCounter) Get(svcPortName k8sproxy.ServicePortName, isEndpointsLocal bool) (binding.GroupIDType, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	key := keyString(svcPortName, isEndpointsLocal)
+	id, exist := c.groupMap[key]
+	return id, exist
 }
 
 func (c *groupCounter) Recycle(svcPortName k8sproxy.ServicePortName, isEndpointsLocal bool) bool {


### PR DESCRIPTION
Add method IfAllocateNotExist to generate a unique group ID for a Service
if the group ID has not been generated, then return the group ID (new
allocated or already allocated). Method Get is reserved and can be
only to get the allocated group ID.

Fix #3339

Signed-off-by: Hongliang Liu <lhongliang@vmware.com>