### PR TITLE
Add [antctl mc] command for antrea multicluster resources

### DIFF
--- a/pkg/antctl/antctl.go
+++ b/pkg/antctl/antctl.go
@@ -24,6 +24,7 @@ import (
 	"antrea.io/antrea/pkg/agent/openflow"
 	fallbackversion "antrea.io/antrea/pkg/antctl/fallback/version"
 	"antrea.io/antrea/pkg/antctl/raw/featuregates"
+	"antrea.io/antrea/pkg/antctl/raw/multicluster"
 	"antrea.io/antrea/pkg/antctl/raw/proxy"
 	"antrea.io/antrea/pkg/antctl/raw/supportbundle"
 	"antrea.io/antrea/pkg/antctl/raw/traceflow"
@@ -530,6 +531,12 @@ var CommandList = &commandList{
 			supportAgent:      true,
 			supportController: true,
 			commandGroup:      get,
+		},
+		{
+			cobraCommand:      multicluster.GetCmd,
+			supportAgent:      false,
+			supportController: false,
+			commandGroup:      mc,
 		},
 	},
 	codec: scheme.Codecs,

--- a/pkg/antctl/command_definition_test.go
+++ b/pkg/antctl/command_definition_test.go
@@ -31,6 +31,7 @@ import (
 
 	"antrea.io/antrea/pkg/agent/apiserver/handlers/agentinfo"
 	"antrea.io/antrea/pkg/agent/apiserver/handlers/podinterface"
+	"antrea.io/antrea/pkg/antctl/output"
 	"antrea.io/antrea/pkg/antctl/runtime"
 	"antrea.io/antrea/pkg/antctl/transform/addressgroup"
 	"antrea.io/antrea/pkg/antctl/transform/appliedtogroup"
@@ -289,9 +290,8 @@ default   nginx-6db489d4b7-vgv7v Interface      127.0.0.1 07-16-76-00-02-86 port
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			opt := &commandDefinition{}
 			var outputBuf bytes.Buffer
-			err := opt.tableOutputForGetCommands(tc.rawResponseData, &outputBuf)
+			err := output.TableOutputForGetCommands(tc.rawResponseData, &outputBuf)
 			fmt.Println(outputBuf.String())
 			assert.Nil(t, err)
 			assert.Equal(t, tc.expected, outputBuf.String())

--- a/pkg/antctl/command_list.go
+++ b/pkg/antctl/command_list.go
@@ -63,7 +63,8 @@ func (cl *commandList) applyToRootCommand(root *cobra.Command, client AntctlClie
 
 	for _, cmd := range cl.rawCommands {
 		if (runtime.Mode == runtime.ModeAgent && cmd.supportAgent) ||
-			(runtime.Mode == runtime.ModeController && cmd.supportController) {
+			(runtime.Mode == runtime.ModeController && cmd.supportController) ||
+			(!runtime.InPod && cmd.commandGroup == mc) {
 			if groupCommand, ok := groupCommands[cmd.commandGroup]; ok {
 				groupCommand.AddCommand(cmd.cobraCommand)
 			} else {

--- a/pkg/antctl/output/output.go
+++ b/pkg/antctl/output/output.go
@@ -1,0 +1,280 @@
+// Copyright 2022 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"reflect"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"gopkg.in/yaml.v2"
+
+	"antrea.io/antrea/pkg/antctl/transform/common"
+)
+
+const (
+	maxTableOutputColumnLength int = 50
+)
+
+func TableOutput(obj interface{}, writer io.Writer) error {
+	target, err := respTransformer(obj)
+	if err != nil {
+		return fmt.Errorf("error when transforming obj: %w", err)
+	}
+
+	list, multiple := target.([]interface{})
+	var args []string
+	if multiple {
+		for _, el := range list {
+			m := el.(map[string]interface{})
+			for k := range m {
+				args = append(args, k)
+			}
+			// break after one iteration intentionally (we are just retrieving attribute
+			// names to use as the table header in the output)
+			break // nolint:staticcheck
+		}
+	} else {
+		m, _ := target.(map[string]interface{})
+		for k := range m {
+			args = append(args, k)
+		}
+	}
+
+	var buffer bytes.Buffer
+	for _, arg := range args {
+		buffer.WriteString(arg)
+		buffer.WriteString("\t")
+	}
+	attrLine := buffer.String()
+
+	var valLines []string
+	if multiple {
+		for _, el := range list {
+			m := el.(map[string]interface{})
+			buffer.Reset()
+			for _, k := range args {
+				var output bytes.Buffer
+				if err = jsonEncode(m[k], &output); err != nil {
+					return fmt.Errorf("error when encoding data in json: %w", err)
+				}
+				buffer.WriteString(strings.Trim(output.String(), "\"\n"))
+				buffer.WriteString("\t")
+			}
+			valLines = append(valLines, buffer.String())
+		}
+	} else {
+		buffer.Reset()
+		m, _ := target.(map[string]interface{})
+		for _, k := range args {
+			var output bytes.Buffer
+			if err = jsonEncode(m[k], &output); err != nil {
+				return fmt.Errorf("error when encoding: %w", err)
+			}
+			buffer.WriteString(strings.Trim(output.String(), "\"\n"))
+			buffer.WriteString("\t")
+		}
+		valLines = append(valLines, buffer.String())
+	}
+
+	var b bytes.Buffer
+	w := tabwriter.NewWriter(&b, 15, 0, 1, ' ', 0)
+	fmt.Fprintln(w, attrLine)
+	for _, line := range valLines {
+		fmt.Fprintln(w, line)
+	}
+	w.Flush()
+
+	if _, err = io.Copy(writer, &b); err != nil {
+		return fmt.Errorf("error when copy output into writer: %w", err)
+	}
+
+	return nil
+}
+
+func JsonOutput(obj interface{}, writer io.Writer) error {
+	var output bytes.Buffer
+	if err := jsonEncode(obj, &output); err != nil {
+		return fmt.Errorf("error when encoding data in json: %w", err)
+	}
+
+	var prettifiedBuf bytes.Buffer
+	err := json.Indent(&prettifiedBuf, output.Bytes(), "", "  ")
+	if err != nil {
+		return fmt.Errorf("error when formatting outputing in json: %w", err)
+	}
+	_, err = io.Copy(writer, &prettifiedBuf)
+	if err != nil {
+		return fmt.Errorf("error when outputing in json format: %w", err)
+	}
+	return nil
+}
+
+func YamlOutput(obj interface{}, writer io.Writer) error {
+	var jsonObj interface{}
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(obj); err != nil {
+		return fmt.Errorf("error when outputing in yaml format: %w", err)
+	}
+	// Comment copied from: sigs.k8s.io/yaml
+	// We are using yaml.Unmarshal here (instead of json.Unmarshal) because the
+	// Go JSON library doesn't try to pick the right number type (int, float,
+	// etc.) when unmarshalling to interface{}, it just picks float64
+	// universally. go-yaml does go through the effort of picking the right
+	// number type, so we can preserve number type throughout this process.
+	if err := yaml.Unmarshal(buf.Bytes(), &jsonObj); err != nil {
+		return fmt.Errorf("error when outputing in yaml format: %w", err)
+	}
+	if err := yaml.NewEncoder(writer).Encode(jsonObj); err != nil {
+		return fmt.Errorf("error when outputing in yaml format: %w", err)
+	}
+	return nil
+}
+
+// tableOutputForGetCommands formats the table output for "get" commands.
+func TableOutputForGetCommands(obj interface{}, writer io.Writer) error {
+	var list []common.TableOutput
+	if reflect.TypeOf(obj).Kind() == reflect.Slice {
+		s := reflect.ValueOf(obj)
+		if s.Len() == 0 || s.Index(0).Interface() == nil {
+			var buffer bytes.Buffer
+			buffer.WriteString("\n")
+			if _, err := io.Copy(writer, &buffer); err != nil {
+				return fmt.Errorf("error when copy output into writer: %w", err)
+			}
+			return nil
+		}
+		if _, ok := s.Index(0).Interface().(common.TableOutput); !ok {
+			return TableOutput(obj, writer)
+		}
+		for i := 0; i < s.Len(); i++ {
+			ele := s.Index(i)
+			list = append(list, ele.Interface().(common.TableOutput))
+		}
+	} else {
+		ele, ok := obj.(common.TableOutput)
+		if !ok {
+			return TableOutput(obj, writer)
+		}
+		list = []common.TableOutput{ele}
+	}
+
+	// Get the elements and headers of table.
+	args := list[0].GetTableHeader()
+	rows := make([][]string, len(list)+1)
+	rows[0] = list[0].GetTableHeader()
+	for i, element := range list {
+		rows[i+1] = element.GetTableRow(maxTableOutputColumnLength)
+	}
+
+	if list[0].SortRows() {
+		// Sort the table rows according to columns in order.
+		body := rows[1:]
+		sort.Slice(body, func(i, j int) bool {
+			for k := range body[i] {
+				if body[i][k] != body[j][k] {
+					return body[i][k] < body[j][k]
+				}
+			}
+			return true
+		})
+	}
+	// Construct the table.
+	numRows, numCols := len(list)+1, len(args)
+	widths := GetColumnWidths(numRows, numCols, rows)
+	return ConstructTable(numRows, numCols, widths, rows, writer)
+}
+
+func GetColumnWidths(numRows int, numCols int, rows [][]string) []int {
+	widths := make([]int, numCols)
+	if numCols == 1 {
+		// Do not limit the column length for a single column table.
+		// This is for the case a single column table can have long rows which cannot
+		// fit into a single line (one example is the ovsflows outputs).
+		widths[0] = 0
+	} else {
+		// Get the width of every column.
+		for j := 0; j < numCols; j++ {
+			width := len(rows[0][j])
+			for i := 1; i < numRows; i++ {
+				if len(rows[i][j]) == 0 {
+					rows[i][j] = "<NONE>"
+				}
+				if width < len(rows[i][j]) {
+					width = len(rows[i][j])
+				}
+			}
+			widths[j] = width
+			if j != 0 {
+				widths[j]++
+			}
+		}
+	}
+	return widths
+}
+
+func ConstructTable(numRows int, numCols int, widths []int, rows [][]string, writer io.Writer) error {
+	var buffer bytes.Buffer
+	for i := 0; i < numRows; i++ {
+		for j := 0; j < numCols; j++ {
+			val := ""
+			if j != 0 {
+				val = " " + val
+			}
+			val += rows[i][j]
+			if widths[j] > 0 {
+				val += strings.Repeat(" ", widths[j]-len(val))
+			}
+			buffer.WriteString(val)
+		}
+		buffer.WriteString("\n")
+	}
+	if _, err := io.Copy(writer, &buffer); err != nil {
+		return fmt.Errorf("error when copy output into writer: %w", err)
+	}
+
+	return nil
+}
+
+func jsonEncode(obj interface{}, output *bytes.Buffer) error {
+	if err := json.NewEncoder(output).Encode(obj); err != nil {
+		return fmt.Errorf("error when encoding data in json: %w", err)
+	}
+	return nil
+}
+
+// respTransformer collects output fields in original transformedResponse
+// and flattens them. respTransformer realizes this by turning obj into
+// JSON and unmarshalling it.
+// E.g. agent's transformedVersionResponse will only have two fields after
+// transforming: agentVersion and antctlVersion.
+func respTransformer(obj interface{}) (interface{}, error) {
+	var jsonObj bytes.Buffer
+	if err := json.NewEncoder(&jsonObj).Encode(obj); err != nil {
+		return nil, fmt.Errorf("error when encoding data in json: %w", err)
+	}
+	jsonStr := jsonObj.String()
+
+	var target interface{}
+	if err := json.Unmarshal([]byte(jsonStr), &target); err != nil {
+		return nil, fmt.Errorf("error when unmarshalling data in json: %w", err)
+	}
+	return target, nil
+}

--- a/pkg/antctl/raw/multicluster/commands.go
+++ b/pkg/antctl/raw/multicluster/commands.go
@@ -1,0 +1,30 @@
+// Copyright 2022 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multicluster
+
+import (
+	"github.com/spf13/cobra"
+
+	"antrea.io/antrea/pkg/antctl/raw/multicluster/get"
+)
+
+var GetCmd = &cobra.Command{
+	Use:   "get",
+	Short: "Display one or many resources in a ClusterSet",
+}
+
+func init() {
+	GetCmd.AddCommand(get.NewResourceImportCommand())
+}

--- a/pkg/antctl/raw/multicluster/get/output.go
+++ b/pkg/antctl/raw/multicluster/get/output.go
@@ -1,0 +1,45 @@
+// Copyright 2022 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package get
+
+import (
+	"os"
+
+	antcltOutput "antrea.io/antrea/pkg/antctl/output"
+)
+
+func output(resources interface{}, single bool, outputFormat string, transform func(r interface{}, single bool) (interface{}, error)) error {
+	switch outputFormat {
+	case "json":
+		if err := antcltOutput.JsonOutput(resources, os.Stdout); err != nil {
+			return err
+		}
+	case "yaml":
+		if err := antcltOutput.YamlOutput(resources, os.Stdout); err != nil {
+			return err
+		}
+	default:
+		obj, err := transform(resources, single)
+		if err != nil {
+			return err
+		}
+		err = antcltOutput.TableOutputForGetCommands(obj, os.Stdout)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/antctl/raw/multicluster/get/resourceimport.go
+++ b/pkg/antctl/raw/multicluster/get/resourceimport.go
@@ -1,0 +1,157 @@
+// Copyright 2022 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package get
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	multiclusterv1alpha1 "antrea.io/antrea/multicluster/apis/multicluster/v1alpha1"
+	"antrea.io/antrea/pkg/antctl/raw"
+	"antrea.io/antrea/pkg/antctl/raw/multicluster/scheme"
+	"antrea.io/antrea/pkg/antctl/transform/resourceimport"
+)
+
+type resourceImportOptions struct {
+	namespace     string
+	outputFormat  string
+	allNamespaces bool
+}
+
+var options *resourceImportOptions
+
+var resourceImportExamples = strings.Trim(`
+Gel all ResourceImports of a ClusterSet in default Namespace
+$ antctl mc get resourceimport
+Get all ResourceImports of a ClusterSet in all Namespaces
+$ antctl mc get resourceimport -A
+Get all ResourceImports in the specified Namespace
+$ antctl mc get resourceimport -n <NAMESPACE>
+Get all ResourceImports and print them in JSON format
+$ antctl mc get resourceimport -o json
+Get the specified ResourceImport
+$ antctl mc get resourceimport <RESOURCEIMPORT> -n <NAMESPACE>
+`, "\n")
+
+func (o *resourceImportOptions) validateAndComplete() {
+	if o.allNamespaces {
+		o.namespace = metav1.NamespaceAll
+		return
+	}
+	if o.namespace == "" {
+		o.namespace = metav1.NamespaceDefault
+		return
+	}
+}
+
+func NewResourceImportCommand() *cobra.Command {
+	command := &cobra.Command{
+		Use: "resourceimport",
+		Aliases: []string{
+			"resourceimports",
+			"ri",
+		},
+		Short:   "Print Multi-Cluster ResourceImports",
+		Args:    cobra.MaximumNArgs(1),
+		Example: resourceImportExamples,
+		RunE:    runE,
+	}
+	o := &resourceImportOptions{}
+	options = o
+	command.Flags().StringVarP(&o.namespace, "namespace", "n", "", "Namespace of ResourceImports")
+	command.Flags().StringVarP(&o.outputFormat, "output", "o", "", "Output format. Supported formats: json|yaml")
+	command.Flags().BoolVarP(&o.allNamespaces, "all-namespaces", "A", false, "If present, list ResourceImports across all Namespaces")
+
+	return command
+}
+
+func runE(cmd *cobra.Command, args []string) error {
+	options.validateAndComplete()
+	argsNum := len(args)
+	if options.allNamespaces && argsNum > 0 {
+		return fmt.Errorf("a resource cannot be retrieved by name across all Namespaces")
+	}
+
+	kubeconfig, err := raw.ResolveKubeconfig(cmd)
+	if err != nil {
+		return err
+	}
+	kubeconfig.GroupVersion = &schema.GroupVersion{Group: "", Version: ""}
+	restconfigTmpl := rest.CopyConfig(kubeconfig)
+	raw.SetupKubeconfig(restconfigTmpl)
+
+	k8sClient, err := client.New(kubeconfig, client.Options{Scheme: scheme.Scheme})
+	if err != nil {
+		return err
+	}
+
+	singleResource := false
+	if argsNum > 0 {
+		singleResource = true
+	}
+	var res interface{}
+
+	if singleResource {
+		resourceImportName := args[0]
+		resourceImport := multiclusterv1alpha1.ResourceImport{}
+		err = k8sClient.Get(context.TODO(), types.NamespacedName{
+			Namespace: options.namespace,
+			Name:      resourceImportName,
+		}, &resourceImport)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return fmt.Errorf("ResourceImport %s not found in Namespace %s", resourceImportName, options.namespace)
+			}
+
+			return err
+		}
+
+		gvks, unversioned, err := k8sClient.Scheme().ObjectKinds(&resourceImport)
+		if err != nil {
+			return err
+		}
+		if !unversioned && len(gvks) == 1 {
+			resourceImport.SetGroupVersionKind(gvks[0])
+		}
+		res = resourceImport
+	} else {
+		resourceImportList := &multiclusterv1alpha1.ResourceImportList{}
+		err = k8sClient.List(context.TODO(), resourceImportList, &client.ListOptions{Namespace: options.namespace})
+		if err != nil {
+			return err
+		}
+
+		if len(resourceImportList.Items) == 0 {
+			if options.namespace != "" {
+				fmt.Fprintf(cmd.ErrOrStderr(), "No resources found in Namespace %s\n", options.namespace)
+			} else {
+				fmt.Fprintln(cmd.ErrOrStderr(), "No resources found in all Namespaces")
+			}
+			return nil
+		}
+		res = resourceImportList.Items
+	}
+
+	return output(res, singleResource, options.outputFormat, resourceimport.Transform)
+}

--- a/pkg/antctl/raw/multicluster/scheme/scheme.go
+++ b/pkg/antctl/raw/multicluster/scheme/scheme.go
@@ -1,0 +1,32 @@
+// Copyright 2022 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scheme
+
+import (
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	k8sscheme "k8s.io/client-go/kubernetes/scheme"
+	mcsscheme "sigs.k8s.io/mcs-api/pkg/client/clientset/versioned/scheme"
+
+	antreamcscheme "antrea.io/antrea/multicluster/pkg/client/clientset/versioned/scheme"
+)
+
+var Scheme = k8sruntime.NewScheme()
+
+func init() {
+	utilruntime.Must(mcsscheme.AddToScheme(Scheme))
+	utilruntime.Must(antreamcscheme.AddToScheme(Scheme))
+	utilruntime.Must(k8sscheme.AddToScheme(Scheme))
+}

--- a/pkg/antctl/transform/resourceimport/transform.go
+++ b/pkg/antctl/transform/resourceimport/transform.go
@@ -1,0 +1,70 @@
+// Copyright 2022 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourceimport
+
+import (
+	multiclusterv1alpha1 "antrea.io/antrea/multicluster/apis/multicluster/v1alpha1"
+	"antrea.io/antrea/pkg/antctl/transform/common"
+)
+
+type Response struct {
+	Namespace string `json:"namespace" yaml:"namespace"`
+	Name      string `json:"name" yaml:"name"`
+	Kind      string `json:"kind" yaml:"kind"`
+}
+
+func Transform(r interface{}, single bool) (interface{}, error) {
+	if single {
+		return objectTransform(r)
+	}
+	return listTransform(r)
+}
+
+func listTransform(l interface{}) (interface{}, error) {
+	resourceImports := l.([]multiclusterv1alpha1.ResourceImport)
+	var result []interface{}
+
+	for i := range resourceImports {
+		item := resourceImports[i]
+		o, _ := objectTransform(item)
+		result = append(result, o.(Response))
+	}
+
+	return result, nil
+}
+
+func objectTransform(o interface{}) (interface{}, error) {
+	resourceImport := o.(multiclusterv1alpha1.ResourceImport)
+
+	return Response{
+		Namespace: resourceImport.Namespace,
+		Name:      resourceImport.Name,
+		Kind:      resourceImport.Spec.Kind,
+	}, nil
+}
+
+var _ common.TableOutput = new(Response)
+
+func (r Response) GetTableHeader() []string {
+	return []string{"NAMESPACE", "NAME", "KIND"}
+}
+
+func (r Response) GetTableRow(maxColumnLength int) []string {
+	return []string{r.Namespace, r.Name, r.Kind}
+}
+
+func (r Response) SortRows() bool {
+	return true
+}


### PR DESCRIPTION
antctl: add multicluster subcommand

Add a new subcommand for antrea multicluster and add get verb for query resources. We could list or get mc resource by antctl mc get <Resource>.

Example:

```bash
# ./antctl mc get ri -A
NAMESPACE                NAME                                                       KIND
antrea-mcs-ns            antrea-multicluster-test-east-nginx-endpoints              ResourceImport
antrea-mcs-ns            antrea-multicluster-test-east-nginx-service                ResourceImport
antrea-mcs-ns            antrea-multicluster-test-west-nginx-endpoints              ResourceImport
antrea-mcs-ns            antrea-multicluster-test-west-nginx-service                ResourceImport
```

In the future, other verb like `create` or `delete` also could be added to the sub-command mc if it is nesscessary.