### PR TITLE
Fix remaining VMSwitch command issue

### DIFF
--- a/hack/windows/Helper.psm1
+++ b/hack/windows/Helper.psm1
@@ -163,7 +163,7 @@ function New-KubeProxyServiceInterface {
         Write-Host "Network adapter $INTERFACE_TO_ADD_SERVICE_IP exists, exit."
         return
     }
-    if (!(Get-VMSwitch -Name $hnsSwitchName -ErrorAction SilentlyContinue)) {
+    if (!(Get-VMSwitch -ComputerName $(hostname) -Name $hnsSwitchName -ErrorAction SilentlyContinue)) {
         Write-Host "Creating internal switch: $hnsSwitchName for kube-proxy"
         New-VMSwitch -name $hnsSwitchName -SwitchType Internal
     }
@@ -216,7 +216,7 @@ function Start-OVSServices {
     }
     # Try to cleanup ovsdb-server configurations if the antrea-hnsnetwork is not existing. Or ovs-vswitchd service
     # will can not get started.
-    if (!(Get-VMswitch -Name "antrea-hnsnetwork" -SwitchType External -ErrorAction SilentlyContinue)) {
+    if (!(Get-VMswitch -ComputerName $(hostname) -Name "antrea-hnsnetwork" -SwitchType External -ErrorAction SilentlyContinue)) {
         & ovs-vsctl.exe --no-wait --if-exists del-br br-int
         if ($LASTEXITCODE) {
             return $false

--- a/hack/windows/Prepare-ServiceInterface.ps1
+++ b/hack/windows/Prepare-ServiceInterface.ps1
@@ -25,7 +25,7 @@ if (Get-NetAdapter -InterfaceAlias $INTERFACE_TO_ADD_SERVICE_IP -ErrorAction Sil
     return
 }
 [Environment]::SetEnvironmentVariable("INTERFACE_TO_ADD_SERVICE_IP", $INTERFACE_TO_ADD_SERVICE_IP, [System.EnvironmentVariableTarget]::Machine)
-$hnsSwitchName = $(Get-VMSwitch -SwitchType Internal).Name
+$hnsSwitchName = $(Get-VMSwitch -ComputerName $(hostname) -SwitchType Internal).Name
 Add-VMNetworkAdapter -ManagementOS -Name $InterfaceAlias -SwitchName $hnsSwitchName
 Set-NetIPInterface -ifAlias $INTERFACE_TO_ADD_SERVICE_IP -Forwarding Enabled
 


### PR DESCRIPTION
CI testbed building still failed randomly with unmodified commands.

This issue can be fixed by adding hostname to configuration.
e.g. Get-VMSwitch -ComputerName $(hostname) -Name %s

Refer to #3169

Signed-off-by: Shuyang Xin <gavinx@vmware.com>