### PR TITLE
[Not4Review] [Windows] Delete virtual network adapter before HNSEndpoint

### DIFF
--- a/pkg/agent/cniserver/interface_configuration_windows.go
+++ b/pkg/agent/cniserver/interface_configuration_windows.go
@@ -263,6 +263,9 @@ func (ic *ifConfigurator) removeContainerLink(containerID, epName string) error 
 	if !found {
 		return nil
 	}
+	if err := util.RemoveVMNetworkAdapter(ep.Name); err != nil {
+		return err
+	}
 	return ic.removeHNSEndpoint(ep, containerID)
 }
 

--- a/pkg/agent/cniserver/pod_configuration.go
+++ b/pkg/agent/cniserver/pod_configuration.go
@@ -283,6 +283,9 @@ func (pc *podConfigurator) removeInterfaces(containerID string) error {
 		return nil
 	}
 
+	if err := pc.ifConfigurator.removeContainerLink(containerID, containerConfig.InterfaceName); err != nil {
+		return err
+	}
 	// Deleting veth devices and OVS port must be called after Openflows are uninstalled.
 	// Otherwise there could be a race condition:
 	// 1. Pod A's ofport was released
@@ -294,10 +297,6 @@ func (pc *podConfigurator) removeInterfaces(containerID string) error {
 	// step 4 can remove flows owned by Pod B by mistake.
 	// Note that deleting the interface attached to an OVS port can release the ofport.
 	if err := pc.disconnectInterfaceFromOVS(containerConfig); err != nil {
-		return err
-	}
-
-	if err := pc.ifConfigurator.removeContainerLink(containerID, containerConfig.InterfaceName); err != nil {
 		return err
 	}
 

--- a/pkg/agent/util/net_windows.go
+++ b/pkg/agent/util/net_windows.go
@@ -836,3 +836,12 @@ func ReplaceNetNeighbor(neighbor *Neighbor) error {
 func VirtualAdapterName(name string) string {
 	return fmt.Sprintf("%s (%s)", ContainerVNICPrefix, name)
 }
+
+func RemoveVMNetworkAdapter(ifaceName string) error {
+	cmd := fmt.Sprintf(`Remove-VMNetworkAdapter -ManagementOS -ComputerName "$(hostname)" -Name "%s" -SwitchName "%s"`, ifaceName, LocalHNSNetwork)
+	_, err := ps.RunCommand(cmd)
+	if err != nil && !strings.Contains(err.Error(), "ObjectNotFound") {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
Since it is possible that HNSEndpoint deletion is stuck because of
Windows HNS call issues, the virtual network adapter is disconnected
from the VMSwitch after OVS port is deletion. And then the
disconnected adapter is failed to remove forever.

This patch is to change the order to remove the virtual network adapter
first in CmdDel request to avoid the stale adapters.

Signed-off-by: wenyingd <wenyingd@vmware.com>