### PR TITLE
Fix NodePort e2e test

### DIFF
--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -126,19 +126,19 @@ func probeClientIPFromNode(node string, baseUrl string) (string, error) {
 }
 
 func probeFromPod(data *TestData, pod string, url string) error {
-	_, _, err := data.runCommandFromPod(testNamespace, pod, busyboxContainerName, []string{"wget", "-O", "-", url, "-T", "1"})
+	_, _, err := data.runCommandFromPod(testNamespace, pod, busyboxContainerName, []string{"wget", "-O", "-", url, "-T", "1", "-t", "5"})
 	return err
 }
 
 func probeHostnameFromPod(data *TestData, pod string, baseUrl string) (string, error) {
 	url := fmt.Sprintf("%s/%s", baseUrl, "hostname")
-	hostname, _, err := data.runCommandFromPod(testNamespace, pod, busyboxContainerName, []string{"wget", "-O", "-", url, "-T", "1"})
+	hostname, _, err := data.runCommandFromPod(testNamespace, pod, busyboxContainerName, []string{"wget", "-O", "-", url, "-T", "1", "-t", "5"})
 	return hostname, err
 }
 
 func probeClientIPFromPod(data *TestData, pod string, baseUrl string) (string, error) {
 	url := fmt.Sprintf("%s/%s", baseUrl, "clientip")
-	hostPort, _, err := data.runCommandFromPod(testNamespace, pod, busyboxContainerName, []string{"wget", "-O", "-", url, "-T", "1"})
+	hostPort, _, err := data.runCommandFromPod(testNamespace, pod, busyboxContainerName, []string{"wget", "-O", "-", url, "-T", "1", "-t", "5"})
 	if err != nil {
 		return "", err
 	}
@@ -574,10 +574,10 @@ func testProxyServiceSessionAffinity(ipFamily *corev1.IPFamily, ingressIPs []str
 	require.NoError(t, data.createBusyboxPodOnNode(busyboxPod, testNamespace, nodeName, false))
 	defer data.deletePodAndWait(defaultTimeout, busyboxPod, testNamespace)
 	require.NoError(t, data.podWaitForRunning(defaultTimeout, busyboxPod, testNamespace))
-	stdout, stderr, err := data.runCommandFromPod(testNamespace, busyboxPod, busyboxContainerName, []string{"wget", "-O", "-", svc.Spec.ClusterIP, "-T", "1"})
+	stdout, stderr, err := data.runCommandFromPod(testNamespace, busyboxPod, busyboxContainerName, []string{"wget", "-O", "-", svc.Spec.ClusterIP, "-T", "1", "-t", "5"})
 	require.NoError(t, err, fmt.Sprintf("ipFamily: %v\nstdout: %s\nstderr: %s\n", *ipFamily, stdout, stderr))
 	for _, ingressIP := range ingressIPs {
-		stdout, stderr, err := data.runCommandFromPod(testNamespace, busyboxPod, busyboxContainerName, []string{"wget", "-O", "-", ingressIP, "-T", "1"})
+		stdout, stderr, err := data.runCommandFromPod(testNamespace, busyboxPod, busyboxContainerName, []string{"wget", "-O", "-", ingressIP, "-T", "1", "-t", "5"})
 		require.NoError(t, err, fmt.Sprintf("ipFamily: %v\nstdout: %s\nstderr: %s\n", *ipFamily, stdout, stderr))
 	}
 

--- a/test/e2e/service_test.go
+++ b/test/e2e/service_test.go
@@ -147,8 +147,8 @@ func (data *TestData) testNodePort(t *testing.T, isWindows bool, namespace strin
 	// Unlike upstream Kubernetes Conformance, here the client is on a Linux Node (nodeName(0)).
 	// It doesn't need to be the control-plane for e2e test and other Linux workers will work as well. However, in this
 	// e2e framework, nodeName(0)/Control-plane Node is guaranteed to be a Linux one.
-	clientName := "agnhost-client"
-	require.NoError(t, data.createAgnhostPodOnNode(clientName, namespace, nodeName(0), false))
+	clientName := "busybox-client"
+	require.NoError(t, data.createBusyboxPodOnNode(clientName, namespace, nodeName(0), false))
 	defer data.deletePodAndWait(defaultTimeout, clientName, namespace)
 	podIPs, err := data.podWaitForIPs(defaultTimeout, clientName, namespace)
 	require.NoError(t, err)
@@ -156,15 +156,15 @@ func (data *TestData) testNodePort(t *testing.T, isWindows bool, namespace strin
 
 	nodeIP := clusterInfo.nodes[0].ip()
 	nodePort := int(svc.Spec.Ports[0].NodePort)
-	addr := fmt.Sprintf("http://%s:%d", nodeIP, nodePort)
+	url := fmt.Sprintf("http://%s:%d", nodeIP, nodePort)
 
-	cmd := append([]string{"curl", "--connect-timeout", "1", "--retry", "5", "--retry-connrefused"}, addr)
-	stdout, stderr, err := data.runCommandFromPod(namespace, clientName, agnhostContainerName, cmd)
+	cmd := []string{"wget", "-O", "-", url, "-T", "1", "-t", "5"}
+	stdout, stderr, err := data.runCommandFromPod(namespace, clientName, busyboxContainerName, cmd)
 	if err != nil {
 		t.Errorf("Error when running command '%s' from Pod '%s', stdout: %s, stderr: %s, error: %v",
 			strings.Join(cmd, " "), clientName, stdout, stderr, err)
 	} else {
-		t.Logf("curl from Pod '%s' to '%s' succeeded", clientName, addr)
+		t.Logf("wget from Pod '%s' to '%s' succeeded", clientName, url)
 	}
 }
 


### PR DESCRIPTION
In NodePort e2e test, a test Service and its backend Pod are
created. The match label is app=agnhost. However, the test
client is also a Pod that has label app=agnhost, but netexec is
not running on the test client. As a result, the test has a 50%
chance of failing. This PR fixes the issue by using a busybox Pod
as test client.

Signed-off-by: Hongliang Liu <lhongliang@vmware.com>