### PR TITLE
Fix CT mark matching without range in flow exporter

### DIFF
--- a/pkg/agent/apiserver/handlers/ovsflows/handler.go
+++ b/pkg/agent/apiserver/handlers/ovsflows/handler.go
@@ -156,7 +156,6 @@ func getPodFlows(aq agentquerier.AgentQuerier, podName, namespace string) ([]Res
 
 	flowKeys := aq.GetOpenflowClient().GetPodFlowKeys(interfaces[0].InterfaceName)
 	return dumpMatchedFlows(aq, flowKeys)
-
 }
 
 func getServiceFlows(aq agentquerier.AgentQuerier, serviceName, namespace string) ([]Response, error) {

--- a/pkg/agent/flowexporter/exporter/exporter.go
+++ b/pkg/agent/flowexporter/exporter/exporter.go
@@ -551,7 +551,7 @@ func (exp *FlowExporter) findFlowType(conn flowexporter.Connection) uint8 {
 		return 0
 	}
 	if exp.nodeRouteController.IPInPodSubnets(conn.FlowKey.SourceAddress) {
-		if conn.Mark == openflow.ServiceCTMark.GetValue() || exp.nodeRouteController.IPInPodSubnets(conn.FlowKey.DestinationAddress) {
+		if conn.Mark&openflow.ServiceCTMark.GetRange().ToNXRange().ToUint32Mask() == openflow.ServiceCTMark.GetValue() || exp.nodeRouteController.IPInPodSubnets(conn.FlowKey.DestinationAddress) {
 			if conn.SourcePodName == "" || conn.DestinationPodName == "" {
 				return ipfixregistry.FlowTypeInterNode
 			}

--- a/test/e2e/connectivity_test.go
+++ b/test/e2e/connectivity_test.go
@@ -311,7 +311,7 @@ func testPodConnectivityAfterAntreaRestart(t *testing.T, data *TestData, namespa
 // ndetdev datapath, since in this case the datapath functionality is implemented by the
 // ovs-vswitchd daemon itself. When ovs-vswitchd restarts, datapath flows are flushed and it may
 // take some time for the Agent to replay the flows. This will not impact this test, since we are
-// just testing L2 connectivity betwwen 2 Pods on the same Node, and the default behavior of the
+// just testing L2 connectivity between 2 Pods on the same Node, and the default behavior of the
 // br-int bridge is to implement normal L2 forwarding.
 func testOVSRestartSameNode(t *testing.T, data *TestData, namespace string) {
 	workerNode := workerNodeName(1)


### PR DESCRIPTION
- Fix CT mark matching without range in
  pkg/agent/flowexporter/exporter/exporter.go
- Fix typo in test/e2e/connectivity_test.go
- Remove extra blank line in
  pkg/agent/apiserver/handlers/ovsflows/handler.go

Signed-off-by: Hongliang Liu <lhongliang@vmware.com>