### PR TITLE
Add clusterID annotation to ServiceExport/Import

### DIFF
--- a/multicluster/controllers/multicluster/common/helper.go
+++ b/multicluster/controllers/multicluster/common/helper.go
@@ -16,7 +16,8 @@ package common
 import corev1 "k8s.io/api/core/v1"
 
 const (
-	AntreaMCServiceAnnotation = "multicluster.antrea.io/imported-service"
+	AntreaMCServiceAnnotation   = "multicluster.antrea.io/imported-service"
+	AntreaMCClusterIDAnnotation = "multicluster.antrea.io/local-cluster-id"
 
 	AntreaMCSPrefix   = "antrea-mc-"
 	ServiceKind       = "Service"

--- a/multicluster/controllers/multicluster/commonarea/remote_common_area.go
+++ b/multicluster/controllers/multicluster/commonarea/remote_common_area.go
@@ -378,6 +378,7 @@ func (r *remoteCommonArea) StartWatching() error {
 		r.ClusterManager.GetClient(),
 		r.ClusterManager.GetScheme(),
 		r.localClusterClient,
+		string(r.remoteCommonAreaManager.GetLocalClusterID()),
 		r,
 	)
 

--- a/multicluster/controllers/multicluster/serviceexport_controller.go
+++ b/multicluster/controllers/multicluster/serviceexport_controller.go
@@ -330,6 +330,11 @@ func (r *ServiceExportReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			return ctrl.Result{}, err
 		}
 	}
+
+	if err = r.updateSvcExportAnnotation(&svcExport); err != nil {
+		// Ignore the error since it's not critical and we can update in next event.
+		klog.ErrorS(err, "Failed to update ServiceExport annotation", "serviceexport", klog.KObj(&svcExport))
+	}
 	return ctrl.Result{}, nil
 }
 
@@ -378,12 +383,21 @@ func (r *ServiceExportReconciler) handleEndpointDeleteEvent(ctx context.Context,
 	return nil
 }
 
+func (r *ServiceExportReconciler) updateSvcExportAnnotation(svcExport *k8smcsv1alpha1.ServiceExport) error {
+	addAnnotation(svcExport, r.localClusterID)
+	if err := r.Client.Update(ctx, svcExport, &client.UpdateOptions{}); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (r *ServiceExportReconciler) updateSvcExportStatus(ctx context.Context, req ctrl.Request, cause reason) error {
 	svcExport := &k8smcsv1alpha1.ServiceExport{}
 	err := r.Client.Get(ctx, req.NamespacedName, svcExport)
 	if err != nil {
 		return client.IgnoreNotFound(err)
 	}
+	addAnnotation(svcExport, r.localClusterID)
 	now := metav1.Now()
 	var res, message *string
 	switch cause {
@@ -578,6 +592,15 @@ func (r *ServiceExportReconciler) updateOrCreateResourceExport(resName string,
 	}
 
 	return nil
+}
+
+func addAnnotation(svcExport *k8smcsv1alpha1.ServiceExport, localClusterID string) {
+	if svcExport.Annotations == nil {
+		svcExport.Annotations = make(map[string]string)
+	}
+	if _, ok := svcExport.Annotations[common.AntreaMCClusterIDAnnotation]; !ok {
+		svcExport.Annotations[common.AntreaMCClusterIDAnnotation] = localClusterID
+	}
 }
 
 func getEndPointsAddress(ep *corev1.Endpoints) []string {

--- a/multicluster/controllers/multicluster/serviceexport_controller_test.go
+++ b/multicluster/controllers/multicluster/serviceexport_controller_test.go
@@ -124,7 +124,15 @@ func TestServiceExportReconciler_ExportNotFoundService(t *testing.T) {
 			if *reason != "not_found_service" {
 				t.Errorf("latest ServiceExport status should be 'not_found_service' but got %v", reason)
 			}
+			checkAnnotation(t, newSvcExport)
 		}
+	}
+}
+
+func checkAnnotation(t *testing.T, svcExport *k8smcsv1alpha1.ServiceExport) {
+	id, ok := svcExport.Annotations[common.AntreaMCClusterIDAnnotation]
+	if id != localClusterID || !ok {
+		t.Errorf("latest ServiceExport annotation should be %v but got %v", localClusterID, id)
 	}
 }
 
@@ -160,6 +168,7 @@ func TestServiceExportReconciler_ExportMCSService(t *testing.T) {
 			if *reason != "imported_service" {
 				t.Errorf("latest ServiceExport status should be 'imported_service' but got %v", reason)
 			}
+			checkAnnotation(t, newSvcExport)
 		}
 	}
 }
@@ -195,6 +204,9 @@ func TestServiceExportReconciler_handleServiceExportCreateEvent(t *testing.T) {
 		if err != nil {
 			t.Errorf("ServiceExport Reconciler should get new Endpoints kind of ResourceExport successfully but got error = %v", err)
 		}
+		newSvcExport := &k8smcsv1alpha1.ServiceExport{}
+		fakeClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "nginx"}, newSvcExport)
+		checkAnnotation(t, newSvcExport)
 	}
 }
 
@@ -302,6 +314,9 @@ func TestServiceExportReconciler_handleServiceUpdateEvent(t *testing.T) {
 				t.Errorf("expected Endpoints subsets are %v but got %v", expectedSubsets, subsets)
 			}
 		}
+		newSvcExport := &k8smcsv1alpha1.ServiceExport{}
+		fakeClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "nginx"}, newSvcExport)
+		checkAnnotation(t, newSvcExport)
 	}
 }
 


### PR DESCRIPTION
Add local cluster ID as an annotation to ServiceExport/Import
which help to simplify the logic to group ServiceExport/Import in
Antctl.

Signed-off-by: Lan Luo <luola@vmware.com>