### PR TITLE
Revert "Revert "Support antrea-agent UBI8 based image""

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Build Antrea amd64 Docker image without pushing to registry
       if: ${{ github.repository != 'antrea-io/antrea' || github.event_name != 'push' || github.ref != 'refs/heads/main' }}
       run: |
-        ./hack/build-antrea-ubuntu-all.sh --pull
+        ./hack/build-antrea-linux-all.sh --pull
     - name: Build and push Antrea amd64 Docker image to registry
       if: ${{ github.repository == 'antrea-io/antrea' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       env:
@@ -42,7 +42,7 @@ jobs:
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
       run: |
         echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-        ./hack/build-antrea-ubuntu-all.sh --pull --push-base-images
+        ./hack/build-antrea-linux-all.sh --pull --push-base-images
         docker tag antrea/antrea-ubuntu:latest antrea/antrea-ubuntu-amd64:latest
         docker push antrea/antrea-ubuntu-amd64:latest
     - name: Trigger Antrea arm builds and multi-arch manifest update
@@ -54,6 +54,22 @@ jobs:
         workflow: Build Antrea ARM images and push manifest
         token: ${{ secrets.ANTREA_BUILD_INFRA_WORKFLOW_DISPATCH_PAT }}
         inputs: ${{ format('{{ "antrea-repository":"antrea-io/antrea", "antrea-ref":"{0}", "docker-tag":"{1}" }}', github.ref, 'latest') }}
+
+  build-ubi:
+    needs: check-changes
+    if: ${{ needs.check-changes.outputs.has_changes == 'yes' || github.event_name == 'push' }}
+    runs-on: [ubuntu-latest]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build and push Antrea UBI8 Docker image to registry
+      if: ${{ github.repository == 'antrea-io/antrea' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      env:
+        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      run: |
+        echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+        ./hack/build-antrea-linux-all.sh --pull --push-base-images --distro ubi
+        docker push antrea/antrea-ubi:latest
 
   build-scale:
     needs: check-changes

--- a/.github/workflows/build_tag.yml
+++ b/.github/workflows/build_tag.yml
@@ -24,13 +24,13 @@ jobs:
     needs: get-version
     steps:
     - uses: actions/checkout@v2
-    - name: Build and push Antrea amd64 Docker image to registry
+    - name: Build and push Antrea Ubuntu amd64 Docker image to registry
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         VERSION: ${{ needs.get-version.outputs.version }}
       run: |
-        ./hack/build-antrea-ubuntu-all.sh --pull
+        ./hack/build-antrea-linux-all.sh --pull
         echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         docker tag antrea/antrea-ubuntu:"${VERSION}" antrea/antrea-ubuntu-amd64:"${VERSION}"
         docker push antrea/antrea-ubuntu-amd64:"${VERSION}"
@@ -42,6 +42,21 @@ jobs:
         workflow: Build Antrea ARM images and push manifest
         token: ${{ secrets.ANTREA_BUILD_INFRA_WORKFLOW_DISPATCH_PAT }}
         inputs: ${{ format('{{ "antrea-repository":"antrea-io/antrea", "antrea-ref":"{0}", "docker-tag":"{1}" }}', github.ref, needs.get-version.outputs.version) }}
+
+  build-ubi:
+    runs-on: [ubuntu-latest]
+    needs: get-version
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build and push Antrea UBI8 amd64 Docker image to registry
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          VERSION: ${{ needs.get-version.outputs.version }}
+        run: |
+          ./hack/build-antrea-linux-all.sh --pull --distro ubi
+          echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+          docker push antrea/antrea-ubi:"${VERSION}"
 
   build-windows:
     runs-on: [windows-2019]

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -36,7 +36,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build Antrea Docker image with code coverage support
       run: |
-        ./hack/build-antrea-ubuntu-all.sh --pull --coverage
+        ./hack/build-antrea-linux-all.sh --pull --coverage
     - name: Save Antrea image to tarball
       run:  docker save -o antrea-ubuntu.tar antrea/antrea-ubuntu-coverage:latest
     - name: Upload Antrea image for subsequent jobs

--- a/.github/workflows/kind_upgrade.yml
+++ b/.github/workflows/kind_upgrade.yml
@@ -36,7 +36,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build Antrea Docker image
       run: |
-        ./hack/build-antrea-ubuntu-all.sh --pull
+        ./hack/build-antrea-linux-all.sh --pull
     - name: Save Antrea image to tarball
       run:  docker save -o antrea-ubuntu.tar projects.registry.vmware.com/antrea/antrea-ubuntu:latest
     - name: Upload Antrea image for subsequent jobs

--- a/Makefile
+++ b/Makefile
@@ -66,11 +66,6 @@ antrea-cni:
 	@mkdir -p $(BINDIR)
 	GOOS=linux CGO_ENABLED=0 $(GO) build -o $(BINDIR) $(GOFLAGS) -ldflags '$(LDFLAGS)' antrea.io/antrea/cmd/antrea-cni
 
-.PHONY: antctl-ubuntu
-antctl-ubuntu:
-	@mkdir -p $(BINDIR)
-	GOOS=linux $(GO) build -o $(BINDIR) $(GOFLAGS) -ldflags '$(LDFLAGS)' antrea.io/antrea/cmd/antctl
-
 .PHONY: antctl-instr-binary
 antctl-instr-binary:
 	@mkdir -p $(BINDIR)
@@ -306,6 +301,19 @@ endif
 	docker tag antrea/antrea-ubuntu:$(DOCKER_IMG_VERSION) antrea/antrea-ubuntu
 	docker tag antrea/antrea-ubuntu:$(DOCKER_IMG_VERSION) projects.registry.vmware.com/antrea/antrea-ubuntu
 	docker tag antrea/antrea-ubuntu:$(DOCKER_IMG_VERSION) projects.registry.vmware.com/antrea/antrea-ubuntu:$(DOCKER_IMG_VERSION)
+
+# Build bins in a golang container, and build the antrea-ubi Docker image.
+.PHONY: build-ubi
+build-ubi:
+	@echo "===> Building Antrea bins and antrea/antrea-ubi Docker image <==="
+ifneq ($(NO_PULL),"")
+	docker build -t antrea/antrea-ubi:$(DOCKER_IMG_VERSION) -f build/images/Dockerfile.build.ubi $(DOCKER_BUILD_ARGS) .
+else
+	docker build --pull -t antrea/antrea-ubi:$(DOCKER_IMG_VERSION) -f build/images/Dockerfile.build.ubi $(DOCKER_BUILD_ARGS) .
+endif
+	docker tag antrea/antrea-ubi:$(DOCKER_IMG_VERSION) antrea/antrea-ubi
+	docker tag antrea/antrea-ubi:$(DOCKER_IMG_VERSION) projects.registry.vmware.com/antrea/antrea-ubi
+	docker tag antrea/antrea-ubi:$(DOCKER_IMG_VERSION) projects.registry.vmware.com/antrea/antrea-ubi:$(DOCKER_IMG_VERSION)
 
 .PHONY: build-windows
 build-windows:

--- a/build/images/Dockerfile.build.coverage
+++ b/build/images/Dockerfile.build.coverage
@@ -10,7 +10,8 @@ RUN go mod download
 
 COPY . /antrea
 
-RUN make antrea-agent antrea-controller antrea-cni antctl-ubuntu antrea-controller-instr-binary antrea-agent-instr-binary antctl-instr-binary
+RUN make antrea-agent antrea-controller antrea-cni antctl-linux antrea-controller-instr-binary antrea-agent-instr-binary antctl-instr-binary
+RUN mv bin/antctl-linux bin/antctl
 
 FROM antrea/base-ubuntu:${OVS_VERSION}
 

--- a/build/images/Dockerfile.build.ubi
+++ b/build/images/Dockerfile.build.ubi
@@ -13,10 +13,10 @@ COPY . /antrea
 RUN make antrea-agent antrea-controller antrea-cni antctl-linux
 RUN mv bin/antctl-linux bin/antctl
 
-FROM antrea/base-ubuntu:${OVS_VERSION}
+FROM antrea/base-ubi:${OVS_VERSION}
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
-LABEL description="The Docker image to deploy the Antrea CNI."
+LABEL description="The Docker image to deploy the Antrea CNI. "
 
 USER root
 

--- a/build/images/base/Dockerfile.ubi
+++ b/build/images/base/Dockerfile.ubi
@@ -23,22 +23,13 @@ RUN set -eux; \
     wget -q -O - https://github.com/containernetworking/plugins/releases/download/$CNI_BINARIES_VERSION/cni-plugins-linux-${pluginsArch}-$CNI_BINARIES_VERSION.tgz | tar xz -C /opt/cni/bin $CNI_PLUGINS; \
     wget -q -O - https://downloads.antrea.io/whereabouts/$WHEREABOUTS_VERSION/whereabouts-linux-${pluginsArch}.tgz | tar xz -C /opt/cni/bin/ whereabouts-linux-${pluginsArch}/whereabouts --strip-components=1 --no-same-owner
 
-FROM antrea/openvswitch:${OVS_VERSION}
+FROM antrea/openvswitch-ubi:${OVS_VERSION}
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
-LABEL description="An Ubuntu based Docker base image for Antrea."
+LABEL description="An UBI8 based Docker base image for Antrea."
 
 USER root
 
-# See https://github.com/kubernetes-sigs/iptables-wrappers
-# /iptables-wrapper-installer.sh will have permissions of 600.
-# --chmod=700 doesn't work with older versions of Docker and requires DOCKER_BUILDKIT=1, so we use
-# chmod in the RUN command below instead.
-ADD https://raw.githubusercontent.com/kubernetes-sigs/iptables-wrappers/9e6ce59c864623ea71a6f7d59c35fcb13a919b87/iptables-wrapper-installer.sh /iptables-wrapper-installer.sh
-
-RUN apt-get update && apt-get install -y --no-install-recommends ipset jq && \
-    rm -rf /var/lib/apt/lists/* && \
-    chmod +x /iptables-wrapper-installer.sh && \
-    /iptables-wrapper-installer.sh
+RUN yum install ipset jq -y && yum clean all 
 
 COPY --from=cni-binaries /opt/cni/bin /opt/cni/bin

--- a/build/images/base/build.sh
+++ b/build/images/base/build.sh
@@ -23,11 +23,12 @@ function echoerr {
     >&2 echo "$@"
 }
 
-_usage="Usage: $0 [--pull] [--push] [--platform <PLATFORM>]
+_usage="Usage: $0 [--pull] [--push] [--platform <PLATFORM>] [--distro [ubuntu|ubi]]
 Build the antrea/base-ubuntu:<OVS_VERSION> image.
         --pull                  Always attempt to pull a newer version of the base images
         --push                  Push the built image to the registry
-        --platform <PLATFORM>   Target platform for the image if server is multi-platform capable"
+        --platform <PLATFORM>   Target platform for the image if server is multi-platform capable
+        --distro <distro>       Target Linux distribution"
 
 function print_usage {
     echoerr "$_usage"
@@ -36,6 +37,7 @@ function print_usage {
 PULL=false
 PUSH=false
 PLATFORM=""
+DISTRO="ubuntu"
 
 while [[ $# -gt 0 ]]
 do
@@ -52,6 +54,10 @@ case $key in
     ;;
     --platform)
     PLATFORM="$2"
+    shift 2
+    ;;
+    --distro)
+    DISTRO="$2"
     shift 2
     ;;
     -h|--help)
@@ -75,6 +81,11 @@ if [ "$PLATFORM" != "" ]; then
     PLATFORM_ARG="--platform $PLATFORM"
 fi
 
+if [ "$DISTRO" != "ubuntu" ] && [ "$DISTRO" != "ubi" ]; then
+    echoerr "Invalid distribution $DISTRO"
+    exit 1
+fi
+
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 pushd $THIS_DIR > /dev/null
@@ -89,11 +100,20 @@ if $PULL; then
         docker pull ${DOCKER_REGISTRY}/antrea/ubuntu:20.04
         docker tag ${DOCKER_REGISTRY}/antrea/ubuntu:20.04 ubuntu:20.04
     fi
-    IMAGES_LIST=(
-        "antrea/openvswitch:$OVS_VERSION"
-        "antrea/cni-binaries:$CNI_BINARIES_VERSION"
-        "antrea/base-ubuntu:$OVS_VERSION"
-    )
+
+    if [ "$DISTRO" == "ubuntu" ]; then
+        IMAGES_LIST=(
+            "antrea/openvswitch:$OVS_VERSION"
+            "antrea/cni-binaries:$CNI_BINARIES_VERSION"
+            "antrea/base-ubuntu:$OVS_VERSION"
+        )
+    elif [ "$DISTRO" == "ubi" ]; then
+        IMAGES_LIST=(
+            "antrea/openvswitch-ubi:$OVS_VERSION"
+            "antrea/cni-binaries:$CNI_BINARIES_VERSION"
+            "antrea/base-ubi:$OVS_VERSION"
+        )
+    fi
     for image in "${IMAGES_LIST[@]}"; do
         if [[ ${DOCKER_REGISTRY} == "" ]]; then
             docker pull $PLATFORM_ARG "${image}" || true
@@ -113,16 +133,26 @@ docker build $PLATFORM_ARG --target cni-binaries \
        --build-arg CNI_BINARIES_VERSION=$CNI_BINARIES_VERSION \
        --build-arg OVS_VERSION=$OVS_VERSION .
 
-docker build $PLATFORM_ARG \
-       --cache-from antrea/cni-binaries:$CNI_BINARIES_VERSION \
-       --cache-from antrea/base-ubuntu:$OVS_VERSION \
-       -t antrea/base-ubuntu:$OVS_VERSION \
-       --build-arg CNI_BINARIES_VERSION=$CNI_BINARIES_VERSION \
-       --build-arg OVS_VERSION=$OVS_VERSION .
+if [ "$DISTRO" == "ubuntu" ]; then
+    docker build $PLATFORM_ARG \
+           --cache-from antrea/cni-binaries:$CNI_BINARIES_VERSION \
+           --cache-from antrea/base-ubuntu:$OVS_VERSION \
+           -t antrea/base-ubuntu:$OVS_VERSION \
+           --build-arg CNI_BINARIES_VERSION=$CNI_BINARIES_VERSION \
+           --build-arg OVS_VERSION=$OVS_VERSION .
+elif [ "$DISTRO" == "ubi" ]; then
+    docker build $PLATFORM_ARG \
+           --cache-from antrea/cni-binaries:$CNI_BINARIES_VERSION \
+           --cache-from antrea/base-ubuntu:$OVS_VERSION \
+           -t antrea/base-ubi:$OVS_VERSION \
+           -f Dockerfile.ubi \
+           --build-arg CNI_BINARIES_VERSION=$CNI_BINARIES_VERSION \
+           --build-arg OVS_VERSION=$OVS_VERSION .
+fi
 
 if $PUSH; then
     docker push antrea/cni-binaries:$CNI_BINARIES_VERSION
-    docker push antrea/base-ubuntu:$OVS_VERSION
+    docker push antrea/base-$DISTRO:$OVS_VERSION
 fi
 
 popd > /dev/null

--- a/build/images/flow-aggregator/Dockerfile
+++ b/build/images/flow-aggregator/Dockerfile
@@ -5,7 +5,8 @@ WORKDIR /antrea
 
 COPY . /antrea
 
-RUN make flow-aggregator antctl-ubuntu
+RUN make flow-aggregator antctl-linux
+RUN mv bin/antctl-linux bin/antctl
 
 # Chose this base image so that a shell is available for users to exec into the container, run antctl and run tools like pprof easily
 FROM ubuntu:20.04

--- a/build/images/flow-aggregator/Dockerfile.coverage
+++ b/build/images/flow-aggregator/Dockerfile.coverage
@@ -5,7 +5,8 @@ WORKDIR /antrea
 
 COPY . /antrea
 
-RUN make flow-aggregator antctl-ubuntu flow-aggregator-instr-binary antctl-instr-binary
+RUN make flow-aggregator antctl-linux flow-aggregator-instr-binary antctl-instr-binary
+RUN mv bin/antctl-linux bin/antctl
 
 FROM ubuntu:20.04
 

--- a/build/images/ovs/CentOS.repo
+++ b/build/images/ovs/CentOS.repo
@@ -1,0 +1,23 @@
+[AppStream]
+name=CentOS-8-stream - AppStream
+mirrorlist=http://mirrorlist.centos.org/?release=8-stream&arch=$basearch&repo=AppStream&infra=$infra
+#baseurl=http://mirror.centos.org/$contentdir/8-stream/AppStream/$basearch/os/
+gpgcheck=1
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
+
+[BaseOS]
+name=CentOS-8-stream - Base
+mirrorlist=http://mirrorlist.centos.org/?release=8-stream&arch=$basearch&repo=BaseOS&infra=$infra
+#baseurl=http://mirror.centos.org/$contentdir/8-stream/BaseOS/$basearch/os/
+gpgcheck=1
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
+
+[extras]
+name=CentOS-8-stream - Extras
+mirrorlist=http://mirrorlist.centos.org/?release=8-stream&arch=$basearch&repo=extras&infra=$infra
+#baseurl=http://mirror.centos.org/$contentdir/8-stream/extras/$basearch/os/
+gpgcheck=1
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial

--- a/build/images/ovs/Dockerfile.ubi
+++ b/build/images/ovs/Dockerfile.ubi
@@ -1,0 +1,46 @@
+# OVS build scripts are only applicable for RHEL 7.x:
+# https://docs.openvswitch.org/en/latest/intro/install/fedora
+FROM centos:centos7 as ovs-rpms
+
+# Some patches may not apply cleanly if a non-default version is provided.
+# See build/images/deps/ovs-version for the default version.
+ARG OVS_VERSION
+
+# Install RPM tools and generic build dependencies.
+RUN yum update -y && yum install wget git yum-utils python38 rpm-build epel-release -y
+
+COPY apply-patches.sh /
+
+# Download OVS source code
+RUN wget -q -O - https://www.openvswitch.org/releases/openvswitch-$OVS_VERSION.tar.gz  | tar xz -C /tmp
+RUN cd /tmp/openvswitch* && \
+    /apply-patches.sh && \
+    sed -e "s/@VERSION@/$OVS_VERSION/" rhel/openvswitch-fedora.spec.in > /tmp/ovs.spec && \
+    yum-builddep -y /tmp/ovs.spec && ./boot.sh && \
+    ./configure --prefix=/usr --localstatedir=/var --sysconfdir=/etc && \
+    make rpm-fedora && mkdir -p /tmp/ovs-rpms && \
+    mv /tmp/openvswitch-$OVS_VERSION/rpm/rpmbuild/RPMS/*/*.rpm  /tmp/ovs-rpms && \
+    rm -rf /tmp/openvswitch*
+
+
+FROM registry.access.redhat.com/ubi8
+
+LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
+LABEL description="A Docker image based on UBI8 which includes Open vSwitch built from source."
+
+# Change Repository from UBI8’s to CentOS because UBI8's repository does not contain
+# enough packages required by OVS installation.
+# Using the official RHEL repository would be the best choice but it's not publicly accessible.
+# TODO: update the strongSwan logging config.
+COPY CentOS.repo /tmp/CentOS.repo
+COPY charon-logging.conf /tmp
+COPY --from=ovs-rpms /tmp/ovs-rpms/* /tmp/ovs-rpms/
+RUN rm -f /etc/yum.repos.d/* && mv /tmp/CentOS.repo /etc/yum.repos.d/CentOS.repo && \
+    curl https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official -o /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial && \
+    subscription-manager config --rhsm.manage_repos=0 && \
+    yum clean all -y && yum reinstall yum -y && \
+    yum install /tmp/ovs-rpms/* -y && yum install epel-release -y && \
+    yum install iptables logrotate strongswan -y && \
+    mv /etc/logrotate.d/openvswitch /etc/logrotate.d/openvswitch-switch && \
+    sed -i "/rotate /a\    #size 100M" /etc/logrotate.d/openvswitch-switch && \
+    rm -rf /tmp/* && yum clean all

--- a/build/images/ovs/build.sh
+++ b/build/images/ovs/build.sh
@@ -23,11 +23,12 @@ function echoerr {
     >&2 echo "$@"
 }
 
-_usage="Usage: $0 [--pull] [--push] [--platform <PLATFORM>]
-Build the antrea/ovs:<VERSION> image.
+_usage="Usage: $0 [--pull] [--push] [--platform <PLATFORM>] [--distro [ubuntu|ubi]]
+Build the antrea/base-ubuntu:<OVS_VERSION> image.
         --pull                  Always attempt to pull a newer version of the base images
         --push                  Push the built image to the registry
-        --platform <PLATFORM>   Target platform for the image if server is multi-platform capable"
+        --platform <PLATFORM>   Target platform for the image if server is multi-platform capable
+        --distro <distro>       Target Linux distribution"
 
 function print_usage {
     echoerr "$_usage"
@@ -36,6 +37,7 @@ function print_usage {
 PULL=false
 PUSH=false
 PLATFORM=""
+DISTRO="ubuntu"
 
 while [[ $# -gt 0 ]]
 do
@@ -52,6 +54,10 @@ case $key in
     ;;
     --platform)
     PLATFORM="$2"
+    shift 2
+    ;;
+    --distro)
+    DISTRO="$2"
     shift 2
     ;;
     -h|--help)
@@ -75,6 +81,11 @@ if [ "$PLATFORM" != "" ]; then
     PLATFORM_ARG="--platform $PLATFORM"
 fi
 
+if [ "$DISTRO" != "ubuntu" ] && [ "$DISTRO" != "ubi" ]; then
+    echoerr "Invalid distribution $DISTRO"
+    exit 1
+fi
+
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 pushd $THIS_DIR > /dev/null
@@ -95,10 +106,17 @@ if $PULL; then
         docker pull ${DOCKER_REGISTRY}/antrea/ubuntu:20.04
         docker tag ${DOCKER_REGISTRY}/antrea/ubuntu:20.04 ubuntu:20.04
     fi
-    IMAGES_LIST=(
-        "antrea/openvswitch-debs:$OVS_VERSION"
-        "antrea/openvswitch:$OVS_VERSION"
-    )
+    if [ "$DISTRO" == "ubuntu" ]; then
+        IMAGES_LIST=(
+            "antrea/openvswitch-debs:$OVS_VERSION"
+            "antrea/openvswitch:$OVS_VERSION"
+        )
+    elif [ "$DISTRO" == "ubi" ]; then
+        IMAGES_LIST=(
+            "antrea/openvswitch-rpms:$OVS_VERSION"
+            "antrea/openvswitch-ubi:$OVS_VERSION"
+        )
+    fi
     for image in "${IMAGES_LIST[@]}"; do
         if [[ ${DOCKER_REGISTRY} == "" ]]; then
             docker pull $PLATFORM_ARG "${image}" || true
@@ -112,20 +130,40 @@ if $PULL; then
     done
 fi
 
-docker build $PLATFORM_ARG --target ovs-debs \
-       --cache-from antrea/openvswitch-debs:$OVS_VERSION \
-       -t antrea/openvswitch-debs:$OVS_VERSION \
-       --build-arg OVS_VERSION=$OVS_VERSION .
+if [ "$DISTRO" == "ubuntu" ]; then
+    docker build $PLATFORM_ARG --target ovs-debs \
+           --cache-from antrea/openvswitch-debs:$OVS_VERSION \
+           -t antrea/openvswitch-debs:$OVS_VERSION \
+           --build-arg OVS_VERSION=$OVS_VERSION .
 
-docker build $PLATFORM_ARG \
-       --cache-from antrea/openvswitch-debs:$OVS_VERSION \
-       --cache-from antrea/openvswitch:$OVS_VERSION \
-       -t antrea/openvswitch:$OVS_VERSION \
-       --build-arg OVS_VERSION=$OVS_VERSION .
+    docker build $PLATFORM_ARG \
+           --cache-from antrea/openvswitch-debs:$OVS_VERSION \
+           --cache-from antrea/openvswitch:$OVS_VERSION \
+           -t antrea/openvswitch:$OVS_VERSION \
+           --build-arg OVS_VERSION=$OVS_VERSION .
+elif [ "$DISTRO" == "ubi" ]; then
+    docker build $PLATFORM_ARG --target ovs-rpms \
+           --cache-from antrea/openvswitch-rpms:$OVS_VERSION \
+           -t antrea/openvswitch-rpms:$OVS_VERSION \
+           --build-arg OVS_VERSION=$OVS_VERSION \
+           -f Dockerfile.ubi .
+
+    docker build \
+           --cache-from antrea/openvswitch-rpms:$OVS_VERSION \
+           --cache-from antrea/openvswitch-ubi:$OVS_VERSION \
+           -t antrea/openvswitch-ubi:$OVS_VERSION \
+           --build-arg OVS_VERSION=$OVS_VERSION \
+           -f Dockerfile.ubi .
+fi
 
 if $PUSH; then
-    docker push antrea/openvswitch-debs:$OVS_VERSION
-    docker push antrea/openvswitch:$OVS_VERSION
+    if [ "$DISTRO" == "ubuntu" ]; then
+        docker push antrea/openvswitch-debs:$OVS_VERSION
+        docker push antrea/openvswitch:$OVS_VERSION
+    elif [ "$DISTRO" == "ubi" ]; then
+        docker push antrea/openvswitch-rpms:$OVS_VERSION
+        docker push antrea/openvswitch-ubi:$OVS_VERSION
+    fi
 fi
 
 popd > /dev/null

--- a/ci/jenkins/test-mc.sh
+++ b/ci/jenkins/test-mc.sh
@@ -198,7 +198,7 @@ function deliver_antrea_multicluster {
     ${CLEAN_STALE_IMAGES}
 
     cp -f build/yamls/*.yml $WORKDIR
-    DOCKER_REGISTRY="${DOCKER_REGISTRY}" ./hack/build-antrea-ubuntu-all.sh --pull
+    DOCKER_REGISTRY="${DOCKER_REGISTRY}" ./hack/build-antrea-linux-all.sh --pull
     echo "====== Delivering Antrea to all the Nodes ======"
     docker save -o ${WORKDIR}/antrea-ubuntu.tar $DOCKER_REGISTRY/antrea/antrea-ubuntu:latest
 

--- a/ci/jenkins/test-vmc.sh
+++ b/ci/jenkins/test-vmc.sh
@@ -359,18 +359,18 @@ function deliver_antrea {
     # Pull images from Dockerhub first then try Harbor.
     for i in `seq 3`; do
         if [[ "$COVERAGE" == true ]]; then
-            VERSION="$CLUSTER" ./hack/build-antrea-ubuntu-all.sh --pull --coverage && break
+            VERSION="$CLUSTER" ./hack/build-antrea-linux-all.sh --pull --coverage && break
         else
-            VERSION="$CLUSTER" ./hack/build-antrea-ubuntu-all.sh --pull && break
+            VERSION="$CLUSTER" ./hack/build-antrea-linux-all.sh --pull && break
         fi
     done
     if [ $? -ne 0 ]; then
         echoerr "Failed to build antrea images with Dockerhub"
         for i in `seq 3`; do
             if [[ "$COVERAGE" == true ]]; then
-                VERSION="$CLUSTER" DOCKER_REGISTRY="${DOCKER_REGISTRY}" ./hack/build-antrea-ubuntu-all.sh --pull --coverage && break
+                VERSION="$CLUSTER" DOCKER_REGISTRY="${DOCKER_REGISTRY}" ./hack/build-antrea-linux-all.sh --pull --coverage && break
             else
-                VERSION="$CLUSTER" DOCKER_REGISTRY="${DOCKER_REGISTRY}" ./hack/build-antrea-ubuntu-all.sh --pull && break
+                VERSION="$CLUSTER" DOCKER_REGISTRY="${DOCKER_REGISTRY}" ./hack/build-antrea-linux-all.sh --pull && break
             fi
         done
         if [ $? -ne 0 ]; then

--- a/ci/jenkins/test.sh
+++ b/ci/jenkins/test.sh
@@ -276,7 +276,7 @@ function deliver_antrea_windows {
     ${CLEAN_STALE_IMAGES}
     chmod -R g-w build/images/ovs
     chmod -R g-w build/images/base
-    DOCKER_REGISTRY="${DOCKER_REGISTRY}" ./hack/build-antrea-ubuntu-all.sh --pull
+    DOCKER_REGISTRY="${DOCKER_REGISTRY}" ./hack/build-antrea-linux-all.sh --pull
     if [[ "$TESTCASE" == "windows-networkpolicy-process" ]]; then
         make windows-bin
         make antctl-windows
@@ -431,7 +431,7 @@ function deliver_antrea {
     fi
     chmod -R g-w build/images/ovs
     chmod -R g-w build/images/base
-    DOCKER_REGISTRY="${DOCKER_REGISTRY}" ./hack/build-antrea-ubuntu-all.sh --pull
+    DOCKER_REGISTRY="${DOCKER_REGISTRY}" ./hack/build-antrea-linux-all.sh --pull
     make flow-aggregator-image
 
     # Enable verbose log for troubleshooting.

--- a/hack/build-antrea-linux-all.sh
+++ b/hack/build-antrea-linux-all.sh
@@ -20,14 +20,15 @@ function echoerr {
     >&2 echo "$@"
 }
 
-_usage="Usage: $0 [--pull] [--push-base-images] [--coverage] [--platform <PLATFORM>]
+_usage="Usage: $0 [--pull] [--push-base-images] [--coverage] [--platform <PLATFORM>] [--distro [ubuntu|ubi]]
 Build the antrea/antrea-ubuntu image, as well as all the base images in the build chain. This is
 typically used in CI to build the image with the latest version of all dependencies, taking into
 account changes to all Dockerfiles.
         --pull                  Always attempt to pull a newer version of the base images.
         --push-base-images      Push built images to the registry. Only base images will be pushed.
         --coverage              Build the image with support for code coverage.
-        --platform <PLATFORM>   Target platform for the images if server is multi-platform capable."
+        --platform <PLATFORM>   Target platform for the images if server is multi-platform capable.
+        --distro <distro>       Target Linux distribution."
 
 function print_usage {
     echoerr "$_usage"
@@ -37,6 +38,7 @@ PULL=false
 PUSH=false
 COVERAGE=false
 PLATFORM=""
+DISTRO="ubuntu"
 
 while [[ $# -gt 0 ]]
 do
@@ -57,6 +59,10 @@ case $key in
     ;;
     --platform)
     PLATFORM="$2"
+    shift 2
+    ;;
+    --distro)
+    DISTRO="$2"
     shift 2
     ;;
     -h|--help)
@@ -83,6 +89,17 @@ if [ "$PLATFORM" != "" ]; then
     ARGS="$ARGS --platform $PLATFORM"
     PLATFORM_ARG="--platform $PLATFORM"
 fi
+if [ "$DISTRO" != "ubuntu" ] && [ "$DISTRO" != "ubi" ]; then
+    echoerr "Invalid distribution $DISTRO"
+    exit 1
+fi
+if [ "$DISTRO" == "ubi" ]; then
+    if $COVERAGE ; then
+        echoerr "No coverage build for UBI8"
+        exit 1
+    fi
+    ARGS="$ARGS --distro ubi"
+fi
 
 OVS_VERSION=$(head -n 1 build/images/deps/ovs-version)
 CNI_BINARIES_VERSION=$(head -n 1 build/images/deps/cni-binaries-version)
@@ -103,12 +120,21 @@ if $PULL; then
         docker pull ${DOCKER_REGISTRY}/antrea/golang:$GO_VERSION
         docker tag ${DOCKER_REGISTRY}/antrea/golang:$GO_VERSION golang:$GO_VERSION
     fi
-    IMAGES_LIST=(
-        "antrea/openvswitch-debs:$OVS_VERSION"
-        "antrea/openvswitch:$OVS_VERSION"
-        "antrea/cni-binaries:$CNI_BINARIES_VERSION"
-        "antrea/base-ubuntu:$OVS_VERSION"
-    )
+    if [ "$DISTRO" == "ubuntu" ]; then
+        IMAGES_LIST=(
+            "antrea/openvswitch-debs:$OVS_VERSION"
+            "antrea/openvswitch:$OVS_VERSION"
+            "antrea/cni-binaries:$CNI_BINARIES_VERSION"
+            "antrea/base-ubuntu:$OVS_VERSION"
+        )
+    elif [ "$DISTRO" == "ubi" ]; then
+        IMAGES_LIST=(
+            "antrea/openvswitch-rpms:$OVS_VERSION"
+            "antrea/openvswitch-ubi:$OVS_VERSION"
+            "antrea/cni-binaries:$CNI_BINARIES_VERSION"
+            "antrea/base-ubi:$OVS_VERSION"
+        )
+    fi
     for image in "${IMAGES_LIST[@]}"; do
         if [[ ${DOCKER_REGISTRY} == "" ]]; then
             docker pull $PLATFORM_ARG "${image}" || true
@@ -131,10 +157,14 @@ cd build/images/base
 cd -
 
 export NO_PULL=1
-if $COVERAGE; then
-    make build-ubuntu-coverage
-else
-    make
+if [ "$DISTRO" == "ubuntu" ]; then
+    if $COVERAGE; then
+        make build-ubuntu-coverage
+    else
+        make
+    fi
+elif [ "$DISTRO" == "ubi" ]; then
+    make build-ubi
 fi
 
 popd > /dev/null


### PR DESCRIPTION
Add the required code to build an Antrea image based on Red Hat UBI
(Universal Base Image), which is in used by Red Hat platforms.

Signed-off-by: Kobi Samoray [ksamoray@vmware.com](mailto:ksamoray@vmware.com)

Reverts antrea-io/antrea#3364