### PR TITLE
Adding documentation for minikube

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -155,6 +155,11 @@ information.
 To deploy Antrea in a [Kind](https://github.com/kubernetes-sigs/kind) cluster,
 please refer to this [guide](kind.md).
 
+### Deploying Antrea in Minikube
+
+To deploy Antrea in a [Minikube](https://github.com/kubernetes/minikube) cluster,
+please refer to this [guide](minikube.md).
+
 ### Deploying Antrea in AKS, EKS, and GKE
 
 Antrea can work with cloud managed Kubernetes services, and can be deployed to

--- a/docs/kubernetes-installers.md
+++ b/docs/kubernetes-installers.md
@@ -23,6 +23,7 @@ work with that Antrea version.
 | - | AKS, K8s v1.18.14 | Azure | Ubuntu 18.04, moby | Standard_DS2_v2 |  | Antrea CI |
 | - | AKS, K8s v1.19.9 | Azure | Ubuntu 18.04, containerd | Standard_DS2_v2 |  | Antrea CI |
 | - | Kind v0.9.0, K8s v1.19.1 | N/A | Ubuntu 20.10, containerd://1.4.0 | N/A |  | [Requirements for using Antrea on Kind](kind.md) |
+| - | Minikube v1.25.0 | N/A | Ubuntu 20.04.2 LTS (5.10.76-linuxkit) arm64, docker://20.10.12 | 8GB RAM | | |
 
 ## Installer-specific instructions
 
@@ -56,6 +57,10 @@ cluster without deploying a specific network plugin.
 ### Kind
 
 To deploy Antrea on Kind, please follow these [steps](kind.md).
+
+### Minikube
+
+To deploy Antrea on minikube, please follow these [steps](minikube.md).
 
 ## Updating the list
 

--- a/docs/minikube.md
+++ b/docs/minikube.md
@@ -1,0 +1,47 @@
+# Deploying Antrea on Minikube
+
+<!-- toc -->
+- [Install Minikube](#install-minikube)
+- [Deploy Antrea](#deploy-antrea)
+  - [Deploy Antrea to Minikube cluster](#deploy-antrea-to-minikube-cluster)
+  - [Deploy a local build of Antrea to Minikube cluster (for developers)](#deploy-a-local-build-of-antrea-to-minikube-cluster-for-developers)
+- [Verification](#verification)
+<!-- /toc -->
+
+## Install Minikube
+
+Follow these [steps](https://minikube.sigs.k8s.io/docs/start) to install minikube and set its development environment.
+
+## Deploy Antrea
+
+### Deploy Antrea to Minikube cluster
+
+```bash
+# curl is required because --cni flag does not accept URL as a parameter
+curl -Lo https://github.com/antrea-io/antrea/releases/download/<TAG>/antrea.yml
+minikube start --cni=antrea.yml --network-plugin=cni
+```
+
+### Deploy a local build of Antrea to Minikube cluster (for developers)
+
+These instructions assume that you have built the Antrea Docker image locally
+(e.g. by running `make` from the root of the repository, or in case of arm64 architecture by running
+`DOCKER_BUILDKIT=1 ./hack/build-antrea-ubuntu-all.sh --platform linux/arm64`).
+
+```bash
+# load the Antrea Docker image in the minikube nodes
+minikube image load projects.registry.vmware.com/antrea/antrea-ubuntu:latest
+# deploy Antrea
+kubectl apply -f antrea/build/yamls/antrea.yml
+```
+
+## Verification
+
+After a few seconds you should be able to observe the following when running
+`kubectl get pods -l app=antrea -n kube-system`:
+
+```txt
+NAME                                 READY   STATUS    RESTARTS   AGE
+antrea-agent-9ftn9                   2/2     Running   0          66m
+antrea-controller-56f97bbcff-zbfmv   1/1     Running   0          66m
+```


### PR DESCRIPTION
This PR updates the kubernetes-installer documentation
and adds a minikube to the list, also supporting documentation
to deploy antrea in minikube is added.

Signed-off-by: Pulkit Jain <jainpu@vmware.com>