### PR TITLE
Upgrade Kustomize from v3.8.8 to v4.4.1 to fix Cronjob patching bugs

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -2967,7 +2967,6 @@ data:
     #  nodeCIDRMaskSizeIPv6: 64
 kind: ConfigMap
 metadata:
-  annotations: {}
   labels:
     app: antrea
   name: antrea-config-tb4cm2bddc

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -2967,7 +2967,6 @@ data:
     #  nodeCIDRMaskSizeIPv6: 64
 kind: ConfigMap
 metadata:
-  annotations: {}
   labels:
     app: antrea
   name: antrea-config-tb4cm2bddc

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -2967,7 +2967,6 @@ data:
     #  nodeCIDRMaskSizeIPv6: 64
 kind: ConfigMap
 metadata:
-  annotations: {}
   labels:
     app: antrea
   name: antrea-config-557b79kcm4

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -2972,7 +2972,6 @@ data:
     #  nodeCIDRMaskSizeIPv6: 64
 kind: ConfigMap
 metadata:
-  annotations: {}
   labels:
     app: antrea
   name: antrea-config-49chg5d6md

--- a/build/yamls/antrea-kind.yml
+++ b/build/yamls/antrea-kind.yml
@@ -2972,7 +2972,6 @@ data:
     #  nodeCIDRMaskSizeIPv6: 64
 kind: ConfigMap
 metadata:
-  annotations: {}
   labels:
     app: antrea
   name: antrea-config-c2kfgd59tm

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -2972,7 +2972,6 @@ data:
     #  nodeCIDRMaskSizeIPv6: 64
 kind: ConfigMap
 metadata:
-  annotations: {}
   labels:
     app: antrea
   name: antrea-config-82b78c27h8

--- a/build/yamls/flow-aggregator.yml
+++ b/build/yamls/flow-aggregator.yml
@@ -205,7 +205,6 @@ data:
       #tlsMinVersion:
 kind: ConfigMap
 metadata:
-  annotations: {}
   labels:
     app: flow-aggregator
   name: flow-aggregator-configmap-g28c52f9kg

--- a/build/yamls/flow-visibility.yml
+++ b/build/yamls/flow-visibility.yml
@@ -53,7 +53,90 @@ subjects:
 ---
 apiVersion: v1
 data:
-  create_table.sh: "#!/usr/bin/env bash\n\n# Copyright 2022 Antrea Authors.\n#\n# Licensed under the Apache License, Version 2.0 (the \"License\");\n# you may not use this file except in compliance with the License.\n# You may obtain a copy of the License at\n#\n#      http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n\nset -e\nclickhouse client -n -h 127.0.0.1 <<-EOSQL\n\n    CREATE TABLE IF NOT EXISTS flows (\n        timeInserted DateTime DEFAULT now(),\n        flowStartSeconds DateTime,\n        flowEndSeconds DateTime,\n        flowEndSecondsFromSourceNode DateTime,\n        flowEndSecondsFromDestinationNode DateTime,\n        flowEndReason UInt8,\n        sourceIP String,\n        destinationIP String,\n        sourceTransportPort UInt16,\n        destinationTransportPort UInt16,\n        protocolIdentifier UInt8,\n        packetTotalCount UInt64,\n        octetTotalCount UInt64,\n        packetDeltaCount UInt64,\n        octetDeltaCount UInt64,\n        reversePacketTotalCount UInt64,\n        reverseOctetTotalCount UInt64,\n        reversePacketDeltaCount UInt64,\n        reverseOctetDeltaCount UInt64,\n        sourcePodName String,\n        sourcePodNamespace String,\n        sourceNodeName String,\n        destinationPodName String,\n        destinationPodNamespace String,\n        destinationNodeName String,\n        destinationClusterIP String,\n        destinationServicePort UInt16,\n        destinationServicePortName String,\n        ingressNetworkPolicyName String,\n        ingressNetworkPolicyNamespace String,\n        ingressNetworkPolicyRuleName String,\n        ingressNetworkPolicyRuleAction UInt8,\n        ingressNetworkPolicyType UInt8,\n        egressNetworkPolicyName String,\n        egressNetworkPolicyNamespace String,\n        egressNetworkPolicyRuleName String,\n        egressNetworkPolicyRuleAction UInt8,\n        egressNetworkPolicyType UInt8,\n        tcpState String,\n        flowType UInt8,\n        sourcePodLabels String,\n        destinationPodLabels String,\n        throughput UInt64,\n        reverseThroughput UInt64,\n        throughputFromSourceNode UInt64,\n        throughputFromDestinationNode UInt64,\n        reverseThroughputFromSourceNode UInt64,\n        reverseThroughputFromDestinationNode UInt64,\n        trusted UInt8 DEFAULT 0\n    ) engine=MergeTree\n    ORDER BY (timeInserted, flowEndSeconds);\n\n    CREATE MATERIALIZED VIEW flows_pod_view\n    ENGINE = SummingMergeTree\n    ORDER BY (\n        flowEndSeconds,\n        flowEndSecondsFromSourceNode,\n        flowEndSecondsFromDestinationNode,\n        sourcePodName,\n        destinationPodName,\n        destinationIP,\n        destinationServicePortName,\n        flowType,\n        sourcePodNamespace,\n        destinationPodNamespace)\n    POPULATE\n    AS SELECT\n        flowEndSeconds,\n        flowEndSecondsFromSourceNode,\n        flowEndSecondsFromDestinationNode,\n        sourcePodName,\n        destinationPodName,\n        destinationIP,\n        destinationServicePortName,\n        flowType,\n        sourcePodNamespace,\n        destinationPodNamespace,\n        sum(octetDeltaCount) AS octetDeltaCount,\n        sum(reverseOctetDeltaCount) AS reverseOctetDeltaCount,\n        sum(throughput) AS throughput,\n        sum(reverseThroughput) AS reverseThroughput,\n        sum(throughputFromSourceNode) AS throughputFromSourceNode,\n        sum(throughputFromDestinationNode) AS throughputFromDestinationNode\n    FROM flows\n    GROUP BY\n        flowEndSeconds,\n        flowEndSecondsFromSourceNode,\n        flowEndSecondsFromDestinationNode,\n        sourcePodName,\n        destinationPodName,\n        destinationIP,\n        destinationServicePortName,\n        flowType,\n        sourcePodNamespace,\n        destinationPodNamespace;\n\n    CREATE MATERIALIZED VIEW flows_node_view\n    ENGINE = SummingMergeTree\n    ORDER BY (\n        flowEndSeconds,\n        flowEndSecondsFromSourceNode,\n        flowEndSecondsFromDestinationNode,\n        sourceNodeName,\n        destinationNodeName,\n        sourcePodNamespace,\n        destinationPodNamespace)\n    POPULATE\n    AS SELECT\n        flowEndSeconds,\n        flowEndSecondsFromSourceNode,\n        flowEndSecondsFromDestinationNode,\n        sourceNodeName,\n        destinationNodeName,\n        sourcePodNamespace,\n        destinationPodNamespace,\n        sum(octetDeltaCount) AS octetDeltaCount,\n        sum(reverseOctetDeltaCount) AS reverseOctetDeltaCount,\n        sum(throughput) AS throughput,\n        sum(reverseThroughput) AS reverseThroughput,\n        sum(throughputFromSourceNode) AS throughputFromSourceNode,\n        sum(reverseThroughputFromSourceNode) AS reverseThroughputFromSourceNode,\n        sum(throughputFromDestinationNode) AS throughputFromDestinationNode,\n        sum(reverseThroughputFromDestinationNode) AS reverseThroughputFromDestinationNode\n    FROM flows\n    GROUP BY\n        flowEndSeconds,\n        flowEndSecondsFromSourceNode,\n        flowEndSecondsFromDestinationNode,\n        sourceNodeName,\n        destinationNodeName,\n        sourcePodNamespace,\n        destinationPodNamespace;\n\n    CREATE MATERIALIZED VIEW flows_policy_view\n    ENGINE = SummingMergeTree\n    ORDER BY (\n        flowEndSeconds,\n        flowEndSecondsFromSourceNode,\n        flowEndSecondsFromDestinationNode,\n        egressNetworkPolicyName,\n        egressNetworkPolicyRuleAction,\n        ingressNetworkPolicyName,\n        ingressNetworkPolicyRuleAction,\n        sourcePodNamespace,\n        destinationPodNamespace)\n    POPULATE\n    AS SELECT\n        flowEndSeconds,\n        flowEndSecondsFromSourceNode,\n        flowEndSecondsFromDestinationNode,\n        egressNetworkPolicyName,\n        egressNetworkPolicyRuleAction,\n        ingressNetworkPolicyName,\n        ingressNetworkPolicyRuleAction,\n        sourcePodNamespace,\n        destinationPodNamespace,\n        sum(octetDeltaCount) AS octetDeltaCount,\n        sum(reverseOctetDeltaCount) AS reverseOctetDeltaCount,\n        sum(throughput) AS throughput,\n        sum(reverseThroughput) AS reverseThroughput,\n        sum(throughputFromSourceNode) AS throughputFromSourceNode,\n        sum(reverseThroughputFromSourceNode) AS reverseThroughputFromSourceNode,\n        sum(throughputFromDestinationNode) AS throughputFromDestinationNode,\n        sum(reverseThroughputFromDestinationNode) AS reverseThroughputFromDestinationNode\n    FROM flows\n    GROUP BY\n        flowEndSeconds,\n        flowEndSecondsFromSourceNode,\n        flowEndSecondsFromDestinationNode,\n        egressNetworkPolicyName,\n        egressNetworkPolicyRuleAction,\n        ingressNetworkPolicyName,\n        ingressNetworkPolicyRuleAction,\n        sourcePodNamespace,\n        destinationPodNamespace;\n\n    CREATE TABLE IF NOT EXISTS recommendations (\n        id String,\n        type String,\n        timeCreated DateTime,\n        yamls String\n    ) engine=MergeTree\n    ORDER BY (timeCreated);\n    \nEOSQL\n"
+  create_table.sh: "#!/usr/bin/env bash\n\n# Copyright 2022 Antrea Authors.\n#\n#
+    Licensed under the Apache License, Version 2.0 (the \"License\");\n# you may not
+    use this file except in compliance with the License.\n# You may obtain a copy
+    of the License at\n#\n#      http://www.apache.org/licenses/LICENSE-2.0\n#\n#
+    Unless required by applicable law or agreed to in writing, software\n# distributed
+    under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES
+    OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the
+    specific language governing permissions and\n# limitations under the License.\n\nset
+    -e\nclickhouse client -n -h 127.0.0.1 <<-EOSQL\n\n    CREATE TABLE IF NOT EXISTS
+    flows (\n        timeInserted DateTime DEFAULT now(),\n        flowStartSeconds
+    DateTime,\n        flowEndSeconds DateTime,\n        flowEndSecondsFromSourceNode
+    DateTime,\n        flowEndSecondsFromDestinationNode DateTime,\n        flowEndReason
+    UInt8,\n        sourceIP String,\n        destinationIP String,\n        sourceTransportPort
+    UInt16,\n        destinationTransportPort UInt16,\n        protocolIdentifier
+    UInt8,\n        packetTotalCount UInt64,\n        octetTotalCount UInt64,\n        packetDeltaCount
+    UInt64,\n        octetDeltaCount UInt64,\n        reversePacketTotalCount UInt64,\n
+    \       reverseOctetTotalCount UInt64,\n        reversePacketDeltaCount UInt64,\n
+    \       reverseOctetDeltaCount UInt64,\n        sourcePodName String,\n        sourcePodNamespace
+    String,\n        sourceNodeName String,\n        destinationPodName String,\n
+    \       destinationPodNamespace String,\n        destinationNodeName String,\n
+    \       destinationClusterIP String,\n        destinationServicePort UInt16,\n
+    \       destinationServicePortName String,\n        ingressNetworkPolicyName String,\n
+    \       ingressNetworkPolicyNamespace String,\n        ingressNetworkPolicyRuleName
+    String,\n        ingressNetworkPolicyRuleAction UInt8,\n        ingressNetworkPolicyType
+    UInt8,\n        egressNetworkPolicyName String,\n        egressNetworkPolicyNamespace
+    String,\n        egressNetworkPolicyRuleName String,\n        egressNetworkPolicyRuleAction
+    UInt8,\n        egressNetworkPolicyType UInt8,\n        tcpState String,\n        flowType
+    UInt8,\n        sourcePodLabels String,\n        destinationPodLabels String,\n
+    \       throughput UInt64,\n        reverseThroughput UInt64,\n        throughputFromSourceNode
+    UInt64,\n        throughputFromDestinationNode UInt64,\n        reverseThroughputFromSourceNode
+    UInt64,\n        reverseThroughputFromDestinationNode UInt64,\n        trusted
+    UInt8 DEFAULT 0\n    ) engine=MergeTree\n    ORDER BY (timeInserted, flowEndSeconds);\n\n
+    \   CREATE MATERIALIZED VIEW flows_pod_view\n    ENGINE = SummingMergeTree\n    ORDER
+    BY (\n        flowEndSeconds,\n        flowEndSecondsFromSourceNode,\n        flowEndSecondsFromDestinationNode,\n
+    \       sourcePodName,\n        destinationPodName,\n        destinationIP,\n
+    \       destinationServicePortName,\n        flowType,\n        sourcePodNamespace,\n
+    \       destinationPodNamespace)\n    POPULATE\n    AS SELECT\n        flowEndSeconds,\n
+    \       flowEndSecondsFromSourceNode,\n        flowEndSecondsFromDestinationNode,\n
+    \       sourcePodName,\n        destinationPodName,\n        destinationIP,\n
+    \       destinationServicePortName,\n        flowType,\n        sourcePodNamespace,\n
+    \       destinationPodNamespace,\n        sum(octetDeltaCount) AS octetDeltaCount,\n
+    \       sum(reverseOctetDeltaCount) AS reverseOctetDeltaCount,\n        sum(throughput)
+    AS throughput,\n        sum(reverseThroughput) AS reverseThroughput,\n        sum(throughputFromSourceNode)
+    AS throughputFromSourceNode,\n        sum(throughputFromDestinationNode) AS throughputFromDestinationNode\n
+    \   FROM flows\n    GROUP BY\n        flowEndSeconds,\n        flowEndSecondsFromSourceNode,\n
+    \       flowEndSecondsFromDestinationNode,\n        sourcePodName,\n        destinationPodName,\n
+    \       destinationIP,\n        destinationServicePortName,\n        flowType,\n
+    \       sourcePodNamespace,\n        destinationPodNamespace;\n\n    CREATE MATERIALIZED
+    VIEW flows_node_view\n    ENGINE = SummingMergeTree\n    ORDER BY (\n        flowEndSeconds,\n
+    \       flowEndSecondsFromSourceNode,\n        flowEndSecondsFromDestinationNode,\n
+    \       sourceNodeName,\n        destinationNodeName,\n        sourcePodNamespace,\n
+    \       destinationPodNamespace)\n    POPULATE\n    AS SELECT\n        flowEndSeconds,\n
+    \       flowEndSecondsFromSourceNode,\n        flowEndSecondsFromDestinationNode,\n
+    \       sourceNodeName,\n        destinationNodeName,\n        sourcePodNamespace,\n
+    \       destinationPodNamespace,\n        sum(octetDeltaCount) AS octetDeltaCount,\n
+    \       sum(reverseOctetDeltaCount) AS reverseOctetDeltaCount,\n        sum(throughput)
+    AS throughput,\n        sum(reverseThroughput) AS reverseThroughput,\n        sum(throughputFromSourceNode)
+    AS throughputFromSourceNode,\n        sum(reverseThroughputFromSourceNode) AS
+    reverseThroughputFromSourceNode,\n        sum(throughputFromDestinationNode) AS
+    throughputFromDestinationNode,\n        sum(reverseThroughputFromDestinationNode)
+    AS reverseThroughputFromDestinationNode\n    FROM flows\n    GROUP BY\n        flowEndSeconds,\n
+    \       flowEndSecondsFromSourceNode,\n        flowEndSecondsFromDestinationNode,\n
+    \       sourceNodeName,\n        destinationNodeName,\n        sourcePodNamespace,\n
+    \       destinationPodNamespace;\n\n    CREATE MATERIALIZED VIEW flows_policy_view\n
+    \   ENGINE = SummingMergeTree\n    ORDER BY (\n        flowEndSeconds,\n        flowEndSecondsFromSourceNode,\n
+    \       flowEndSecondsFromDestinationNode,\n        egressNetworkPolicyName,\n
+    \       egressNetworkPolicyRuleAction,\n        ingressNetworkPolicyName,\n        ingressNetworkPolicyRuleAction,\n
+    \       sourcePodNamespace,\n        destinationPodNamespace)\n    POPULATE\n
+    \   AS SELECT\n        flowEndSeconds,\n        flowEndSecondsFromSourceNode,\n
+    \       flowEndSecondsFromDestinationNode,\n        egressNetworkPolicyName,\n
+    \       egressNetworkPolicyRuleAction,\n        ingressNetworkPolicyName,\n        ingressNetworkPolicyRuleAction,\n
+    \       sourcePodNamespace,\n        destinationPodNamespace,\n        sum(octetDeltaCount)
+    AS octetDeltaCount,\n        sum(reverseOctetDeltaCount) AS reverseOctetDeltaCount,\n
+    \       sum(throughput) AS throughput,\n        sum(reverseThroughput) AS reverseThroughput,\n
+    \       sum(throughputFromSourceNode) AS throughputFromSourceNode,\n        sum(reverseThroughputFromSourceNode)
+    AS reverseThroughputFromSourceNode,\n        sum(throughputFromDestinationNode)
+    AS throughputFromDestinationNode,\n        sum(reverseThroughputFromDestinationNode)
+    AS reverseThroughputFromDestinationNode\n    FROM flows\n    GROUP BY\n        flowEndSeconds,\n
+    \       flowEndSecondsFromSourceNode,\n        flowEndSecondsFromDestinationNode,\n
+    \       egressNetworkPolicyName,\n        egressNetworkPolicyRuleAction,\n        ingressNetworkPolicyName,\n
+    \       ingressNetworkPolicyRuleAction,\n        sourcePodNamespace,\n        destinationPodNamespace;\n\n
+    \   CREATE TABLE IF NOT EXISTS recommendations (\n        id String,\n        type
+    String,\n        timeCreated DateTime,\n        yamls String\n    ) engine=MergeTree\n
+    \   ORDER BY (timeCreated);\n    \nEOSQL\n"
 kind: ConfigMap
 metadata:
   name: clickhouse-mounted-configmap-44mdg7d2b2
@@ -4712,7 +4795,8 @@ spec:
       containers:
       - env:
         - name: GF_INSTALL_PLUGINS
-          value: https://downloads.antrea.io/artifacts/grafana-custom-plugins/grafana-sankey-plugin-1.0.0.zip;antreaflowvisibility-grafana-sankey-plugin,grafana-clickhouse-datasource 1.0.1
+          value: https://downloads.antrea.io/artifacts/grafana-custom-plugins/grafana-sankey-plugin-1.0.0.zip;antreaflowvisibility-grafana-sankey-plugin,grafana-clickhouse-datasource
+            1.0.1
         - name: CLICKHOUSE_USERNAME
           valueFrom:
             secretKeyRef:

--- a/hack/verify-kustomize.sh
+++ b/hack/verify-kustomize.sh
@@ -18,7 +18,7 @@ THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 _BINDIR="$THIS_DIR/.bin"
 # Must be an exact match, as the generated YAMLs may not be consistent across
 # versions
-_KUSTOMIZE_VERSION="v3.8.8"
+_KUSTOMIZE_VERSION="v4.4.1"
 
 # Ensure the kustomize tool exists and is the correct version, or installs it
 verify_kustomize() {

--- a/multicluster/build/yamls/antrea-multicluster-leader-global.yml
+++ b/multicluster/build/yamls/antrea-multicluster-leader-global.yml
@@ -22,10 +22,14 @@ spec:
         description: ClusterClaim is the Schema for the clusterclaims API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -69,10 +73,14 @@ spec:
         description: ClusterSet is the Schema for the clustersets API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -88,18 +96,21 @@ spec:
                       description: Identify member cluster in ClusterSet.
                       type: string
                     secret:
-                      description: Secret name to access API server of the member from the leader cluster.
+                      description: Secret name to access API server of the member
+                        from the leader cluster.
                       type: string
                     server:
                       description: API server of the destination cluster.
                       type: string
                     serviceAccount:
-                      description: ServiceAccount used by the member cluster to access into leader cluster.
+                      description: ServiceAccount used by the member cluster to access
+                        into leader cluster.
                       type: string
                   type: object
                 type: array
               members:
-                description: Members include member clusters known to the leader clusters. Used in leader cluster.
+                description: Members include member clusters known to the leader clusters.
+                  Used in leader cluster.
                 items:
                   description: MemberCluster defines member cluster information.
                   properties:
@@ -107,18 +118,21 @@ spec:
                       description: Identify member cluster in ClusterSet.
                       type: string
                     secret:
-                      description: Secret name to access API server of the member from the leader cluster.
+                      description: Secret name to access API server of the member
+                        from the leader cluster.
                       type: string
                     server:
                       description: API server of the destination cluster.
                       type: string
                     serviceAccount:
-                      description: ServiceAccount used by the member cluster to access into leader cluster.
+                      description: ServiceAccount used by the member cluster to access
+                        into leader cluster.
                       type: string
                   type: object
                 type: array
               namespace:
-                description: Namespace to connect to in leader clusters. Used in member cluster.
+                description: Namespace to connect to in leader clusters. Used in member
+                  cluster.
                 type: string
             type: object
           status:
@@ -133,20 +147,25 @@ spec:
                       type: string
                     conditions:
                       items:
-                        description: ClusterCondition indicates the readiness condition of a cluster.
+                        description: ClusterCondition indicates the readiness condition
+                          of a cluster.
                         properties:
                           lastTransitionTime:
-                            description: Last time the condition transited from one status to another.
+                            description: Last time the condition transited from one
+                              status to another.
                             format: date-time
                             type: string
                           message:
-                            description: A human readable message indicating details about the transition.
+                            description: A human readable message indicating details
+                              about the transition.
                             type: string
                           reason:
-                            description: Unique, one-word, CamelCase reason for the condition's last transition.
+                            description: Unique, one-word, CamelCase reason for the
+                              condition's last transition.
                             type: string
                           status:
-                            description: Status of the condition, one of True, False, Unknown.
+                            description: Status of the condition, one of True, False,
+                              Unknown.
                             type: string
                           type:
                             type: string
@@ -157,17 +176,21 @@ spec:
               conditions:
                 description: The overall condition of the cluster set.
                 items:
-                  description: ClusterSetCondition indicates the readiness condition of the clusterSet.
+                  description: ClusterSetCondition indicates the readiness condition
+                    of the clusterSet.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transited from one status to another.
+                      description: Last time the condition transited from one status
+                        to another.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about the transition.
+                      description: A human readable message indicating details about
+                        the transition.
                       type: string
                     reason:
-                      description: Unique, one-word, CamelCase reason for the condition's last transition.
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition.
                       type: string
                     status:
                       description: Status of the condition, one of True, False, Unknown.
@@ -222,10 +245,13 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: MemberClusterAnnounce is the Schema for the memberclusterannounces API
+        description: MemberClusterAnnounce is the Schema for the memberclusterannounces
+          API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           clusterID:
             description: ClusterID of the member cluster.
@@ -234,7 +260,9 @@ spec:
             description: ClusterSet this member belongs to.
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           leaderClusterID:
             description: Leader cluster this member has selected.
@@ -272,13 +300,18 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ResourceExportFilter is the Schema for the ResourceExportFilters API
+        description: ResourceExportFilter is the Schema for the ResourceExportFilters
+          API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -286,7 +319,8 @@ spec:
             description: ResourceExportFilterSpec defines the desired state of ResourceExportFilter
             type: object
           status:
-            description: ResourceExportFilterStatus defines the observed state of ResourceExportFilter
+            description: ResourceExportFilterStatus defines the observed state of
+              ResourceExportFilter
             type: object
         type: object
     served: true
@@ -324,10 +358,14 @@ spec:
         description: ResourceExport is the Schema for the resourceexports API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -335,28 +373,46 @@ spec:
             description: ResourceExportSpec defines the desired state of ResourceExport.
             properties:
               clusterID:
-                description: ClusterID specifies the member cluster this resource exported from.
+                description: ClusterID specifies the member cluster this resource
+                  exported from.
                 type: string
               endpoints:
                 description: If exported resource is EndPoints.
                 properties:
                   subsets:
                     items:
-                      description: 'EndpointSubset is a group of addresses with a common set of ports. The expanded set of endpoints is the Cartesian product of Addresses x Ports. For example, given:   {     Addresses: [{"ip": "10.10.1.1"}, {"ip": "10.10.2.2"}],     Ports:     [{"name": "a", "port": 8675}, {"name": "b", "port": 309}]   } The resulting set of endpoints can be viewed as:     a: [ 10.10.1.1:8675, 10.10.2.2:8675 ],     b: [ 10.10.1.1:309, 10.10.2.2:309 ]'
+                      description: 'EndpointSubset is a group of addresses with a
+                        common set of ports. The expanded set of endpoints is the
+                        Cartesian product of Addresses x Ports. For example, given:   {     Addresses:
+                        [{"ip": "10.10.1.1"}, {"ip": "10.10.2.2"}],     Ports:     [{"name":
+                        "a", "port": 8675}, {"name": "b", "port": 309}]   } The resulting
+                        set of endpoints can be viewed as:     a: [ 10.10.1.1:8675,
+                        10.10.2.2:8675 ],     b: [ 10.10.1.1:309, 10.10.2.2:309 ]'
                       properties:
                         addresses:
-                          description: IP addresses which offer the related ports that are marked as ready. These endpoints should be considered safe for load balancers and clients to utilize.
+                          description: IP addresses which offer the related ports
+                            that are marked as ready. These endpoints should be considered
+                            safe for load balancers and clients to utilize.
                           items:
-                            description: EndpointAddress is a tuple that describes single IP address.
+                            description: EndpointAddress is a tuple that describes
+                              single IP address.
                             properties:
                               hostname:
                                 description: The Hostname of this endpoint
                                 type: string
                               ip:
-                                description: 'The IP of this endpoint. May not be loopback (127.0.0.0/8), link-local (169.254.0.0/16), or link-local multicast ((224.0.0.0/24). IPv6 is also accepted but not fully supported on all platforms. Also, certain kubernetes components, like kube-proxy, are not IPv6 ready. TODO: This should allow hostname or IP, See #4447.'
+                                description: 'The IP of this endpoint. May not be
+                                  loopback (127.0.0.0/8), link-local (169.254.0.0/16),
+                                  or link-local multicast ((224.0.0.0/24). IPv6 is
+                                  also accepted but not fully supported on all platforms.
+                                  Also, certain kubernetes components, like kube-proxy,
+                                  are not IPv6 ready. TODO: This should allow hostname
+                                  or IP, See #4447.'
                                 type: string
                               nodeName:
-                                description: 'Optional: Node hosting this endpoint. This can be used to determine endpoints local to a node.'
+                                description: 'Optional: Node hosting this endpoint.
+                                  This can be used to determine endpoints local to
+                                  a node.'
                                 type: string
                               targetRef:
                                 description: Reference to object providing the endpoint.
@@ -365,22 +421,41 @@ spec:
                                     description: API version of the referent.
                                     type: string
                                   fieldPath:
-                                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                                    description: 'If referring to a piece of an object
+                                      instead of an entire object, this string should
+                                      contain a valid JSON/Go field access statement,
+                                      such as desiredState.manifest.containers[2].
+                                      For example, if the object reference is to a
+                                      container within a pod, this would take on a
+                                      value like: "spec.containers{name}" (where "name"
+                                      refers to the name of the container that triggered
+                                      the event) or if no container name is specified
+                                      "spec.containers[2]" (container with index 2
+                                      in this pod). This syntax is chosen only to
+                                      have some well-defined way of referencing a
+                                      part of an object. TODO: this design is not
+                                      final and this field is subject to change in
+                                      the future.'
                                     type: string
                                   kind:
-                                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                    description: 'Kind of the referent. More info:
+                                      https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                   namespace:
-                                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                    description: 'Namespace of the referent. More
+                                      info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                                     type: string
                                   resourceVersion:
-                                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                    description: 'Specific resourceVersion to which
+                                      this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                                     type: string
                                   uid:
-                                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                    description: 'UID of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                                     type: string
                                 type: object
                             required:
@@ -388,18 +463,30 @@ spec:
                             type: object
                           type: array
                         notReadyAddresses:
-                          description: IP addresses which offer the related ports but are not currently marked as ready because they have not yet finished starting, have recently failed a readiness check, or have recently failed a liveness check.
+                          description: IP addresses which offer the related ports
+                            but are not currently marked as ready because they have
+                            not yet finished starting, have recently failed a readiness
+                            check, or have recently failed a liveness check.
                           items:
-                            description: EndpointAddress is a tuple that describes single IP address.
+                            description: EndpointAddress is a tuple that describes
+                              single IP address.
                             properties:
                               hostname:
                                 description: The Hostname of this endpoint
                                 type: string
                               ip:
-                                description: 'The IP of this endpoint. May not be loopback (127.0.0.0/8), link-local (169.254.0.0/16), or link-local multicast ((224.0.0.0/24). IPv6 is also accepted but not fully supported on all platforms. Also, certain kubernetes components, like kube-proxy, are not IPv6 ready. TODO: This should allow hostname or IP, See #4447.'
+                                description: 'The IP of this endpoint. May not be
+                                  loopback (127.0.0.0/8), link-local (169.254.0.0/16),
+                                  or link-local multicast ((224.0.0.0/24). IPv6 is
+                                  also accepted but not fully supported on all platforms.
+                                  Also, certain kubernetes components, like kube-proxy,
+                                  are not IPv6 ready. TODO: This should allow hostname
+                                  or IP, See #4447.'
                                 type: string
                               nodeName:
-                                description: 'Optional: Node hosting this endpoint. This can be used to determine endpoints local to a node.'
+                                description: 'Optional: Node hosting this endpoint.
+                                  This can be used to determine endpoints local to
+                                  a node.'
                                 type: string
                               targetRef:
                                 description: Reference to object providing the endpoint.
@@ -408,22 +495,41 @@ spec:
                                     description: API version of the referent.
                                     type: string
                                   fieldPath:
-                                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                                    description: 'If referring to a piece of an object
+                                      instead of an entire object, this string should
+                                      contain a valid JSON/Go field access statement,
+                                      such as desiredState.manifest.containers[2].
+                                      For example, if the object reference is to a
+                                      container within a pod, this would take on a
+                                      value like: "spec.containers{name}" (where "name"
+                                      refers to the name of the container that triggered
+                                      the event) or if no container name is specified
+                                      "spec.containers[2]" (container with index 2
+                                      in this pod). This syntax is chosen only to
+                                      have some well-defined way of referencing a
+                                      part of an object. TODO: this design is not
+                                      final and this field is subject to change in
+                                      the future.'
                                     type: string
                                   kind:
-                                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                    description: 'Kind of the referent. More info:
+                                      https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                   namespace:
-                                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                    description: 'Namespace of the referent. More
+                                      info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                                     type: string
                                   resourceVersion:
-                                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                    description: 'Specific resourceVersion to which
+                                      this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                                     type: string
                                   uid:
-                                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                    description: 'UID of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                                     type: string
                                 type: object
                             required:
@@ -433,13 +539,24 @@ spec:
                         ports:
                           description: Port numbers available on the related IP addresses.
                           items:
-                            description: EndpointPort is a tuple that describes a single port.
+                            description: EndpointPort is a tuple that describes a
+                              single port.
                             properties:
                               appProtocol:
-                                description: The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol. This is a beta field that is guarded by the ServiceAppProtocol feature gate and enabled by default.
+                                description: The application protocol for this port.
+                                  This field follows standard Kubernetes label syntax.
+                                  Un-prefixed names are reserved for IANA standard
+                                  service names (as per RFC-6335 and http://www.iana.org/assignments/service-names).
+                                  Non-standard protocols should use prefixed names
+                                  such as mycompany.com/my-custom-protocol. This is
+                                  a beta field that is guarded by the ServiceAppProtocol
+                                  feature gate and enabled by default.
                                 type: string
                               name:
-                                description: The name of this port.  This must match the 'name' field in the corresponding ServicePort. Must be a DNS_LABEL. Optional only if one port is defined.
+                                description: The name of this port.  This must match
+                                  the 'name' field in the corresponding ServicePort.
+                                  Must be a DNS_LABEL. Optional only if one port is
+                                  defined.
                                 type: string
                               port:
                                 description: The port number of the endpoint.
@@ -447,7 +564,8 @@ spec:
                                 type: integer
                               protocol:
                                 default: TCP
-                                description: The IP protocol for this port. Must be UDP, TCP, or SCTP. Default is TCP.
+                                description: The IP protocol for this port. Must be
+                                  UDP, TCP, or SCTP. Default is TCP.
                                 type: string
                             required:
                             - port
@@ -460,28 +578,35 @@ spec:
                 description: If exported resource is ExternalEntity.
                 properties:
                   externalentityspec:
-                    description: ExternalEntitySpec defines the desired state for ExternalEntity.
+                    description: ExternalEntitySpec defines the desired state for
+                      ExternalEntity.
                     properties:
                       endpoints:
-                        description: Endpoints is a list of external endpoints associated with this entity.
+                        description: Endpoints is a list of external endpoints associated
+                          with this entity.
                         items:
-                          description: Endpoint refers to an endpoint associated with the ExternalEntity.
+                          description: Endpoint refers to an endpoint associated with
+                            the ExternalEntity.
                           properties:
                             ip:
                               description: IP associated with this endpoint.
                               type: string
                             name:
-                              description: Name identifies this endpoint. Could be the network interface name in case of VMs.
+                              description: Name identifies this endpoint. Could be
+                                the network interface name in case of VMs.
                               type: string
                           type: object
                         type: array
                       externalNode:
-                        description: ExternalNode is the opaque identifier of the agent/controller responsible for additional processing or handling of this external entity.
+                        description: ExternalNode is the opaque identifier of the
+                          agent/controller responsible for additional processing or
+                          handling of this external entity.
                         type: string
                       ports:
                         description: Ports maintain the list of named ports.
                         items:
-                          description: NamedPort describes the port and protocol to match in a rule.
+                          description: NamedPort describes the port and protocol to
+                            match in a rule.
                           properties:
                             name:
                               description: Name associated with the Port.
@@ -492,7 +617,9 @@ spec:
                               type: integer
                             protocol:
                               default: TCP
-                              description: The protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this field defaults to TCP.
+                              description: The protocol (TCP, UDP, or SCTP) which
+                                traffic must match. If not specified, this field defaults
+                                to TCP.
                               type: string
                           type: object
                         type: array
@@ -518,72 +645,231 @@ spec:
                 description: If exported resource is Service.
                 properties:
                   serviceSpec:
-                    description: ServiceSpec describes the attributes that a user creates on a service.
+                    description: ServiceSpec describes the attributes that a user
+                      creates on a service.
                     properties:
                       allocateLoadBalancerNodePorts:
-                        description: allocateLoadBalancerNodePorts defines if NodePorts will be automatically allocated for services with type LoadBalancer.  Default is "true". It may be set to "false" if the cluster load-balancer does not rely on NodePorts. allocateLoadBalancerNodePorts may only be set for services with type LoadBalancer and will be cleared if the type is changed to any other type. This field is alpha-level and is only honored by servers that enable the ServiceLBNodePortControl feature.
+                        description: allocateLoadBalancerNodePorts defines if NodePorts
+                          will be automatically allocated for services with type LoadBalancer.  Default
+                          is "true". It may be set to "false" if the cluster load-balancer
+                          does not rely on NodePorts. allocateLoadBalancerNodePorts
+                          may only be set for services with type LoadBalancer and
+                          will be cleared if the type is changed to any other type.
+                          This field is alpha-level and is only honored by servers
+                          that enable the ServiceLBNodePortControl feature.
                         type: boolean
                       clusterIP:
-                        description: 'clusterIP is the IP address of the service and is usually assigned randomly. If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be blank) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are "None", empty string (""), or a valid IP address. Setting this to "None" makes a "headless service" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                        description: 'clusterIP is the IP address of the service and
+                          is usually assigned randomly. If an address is specified
+                          manually, is in-range (as per system configuration), and
+                          is not in use, it will be allocated to the service; otherwise
+                          creation of the service will fail. This field may not be
+                          changed through updates unless the type field is also being
+                          changed to ExternalName (which requires this field to be
+                          blank) or the type field is being changed from ExternalName
+                          (in which case this field may optionally be specified, as
+                          describe above).  Valid values are "None", empty string
+                          (""), or a valid IP address. Setting this to "None" makes
+                          a "headless service" (no virtual IP), which is useful when
+                          direct endpoint connections are preferred and proxying is
+                          not required.  Only applies to types ClusterIP, NodePort,
+                          and LoadBalancer. If this field is specified when creating
+                          a Service of type ExternalName, creation will fail. This
+                          field will be wiped when updating a Service to type ExternalName.
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
                         type: string
                       clusterIPs:
-                        description: "ClusterIPs is a list of IP addresses assigned to this service, and are usually assigned randomly.  If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be empty) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are \"None\", empty string (\"\"), or a valid IP address.  Setting this to \"None\" makes a \"headless service\" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName.  If this field is not specified, it will be initialized from the clusterIP field.  If this field is specified, clients must ensure that clusterIPs[0] and clusterIP have the same value. \n Unless the \"IPv6DualStack\" feature gate is enabled, this field is limited to one value, which must be the same as the clusterIP field.  If the feature gate is enabled, this field may hold a maximum of two entries (dual-stack IPs, in either order).  These IPs must correspond to the values of the ipFamilies field. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies"
+                        description: "ClusterIPs is a list of IP addresses assigned
+                          to this service, and are usually assigned randomly.  If
+                          an address is specified manually, is in-range (as per system
+                          configuration), and is not in use, it will be allocated
+                          to the service; otherwise creation of the service will fail.
+                          This field may not be changed through updates unless the
+                          type field is also being changed to ExternalName (which
+                          requires this field to be empty) or the type field is being
+                          changed from ExternalName (in which case this field may
+                          optionally be specified, as describe above).  Valid values
+                          are \"None\", empty string (\"\"), or a valid IP address.
+                          \ Setting this to \"None\" makes a \"headless service\"
+                          (no virtual IP), which is useful when direct endpoint connections
+                          are preferred and proxying is not required.  Only applies
+                          to types ClusterIP, NodePort, and LoadBalancer. If this
+                          field is specified when creating a Service of type ExternalName,
+                          creation will fail. This field will be wiped when updating
+                          a Service to type ExternalName.  If this field is not specified,
+                          it will be initialized from the clusterIP field.  If this
+                          field is specified, clients must ensure that clusterIPs[0]
+                          and clusterIP have the same value. \n Unless the \"IPv6DualStack\"
+                          feature gate is enabled, this field is limited to one value,
+                          which must be the same as the clusterIP field.  If the feature
+                          gate is enabled, this field may hold a maximum of two entries
+                          (dual-stack IPs, in either order).  These IPs must correspond
+                          to the values of the ipFamilies field. Both clusterIPs and
+                          ipFamilies are governed by the ipFamilyPolicy field. More
+                          info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies"
                         items:
                           type: string
                         type: array
                         x-kubernetes-list-type: atomic
                       externalIPs:
-                        description: externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service.  These IPs are not managed by Kubernetes.  The user is responsible for ensuring that traffic arrives at a node with this IP.  A common example is external load-balancers that are not part of the Kubernetes system.
+                        description: externalIPs is a list of IP addresses for which
+                          nodes in the cluster will also accept traffic for this service.  These
+                          IPs are not managed by Kubernetes.  The user is responsible
+                          for ensuring that traffic arrives at a node with this IP.  A
+                          common example is external load-balancers that are not part
+                          of the Kubernetes system.
                         items:
                           type: string
                         type: array
                       externalName:
-                        description: externalName is the external reference that discovery mechanisms will return as an alias for this service (e.g. a DNS CNAME record). No proxying will be involved.  Must be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123) and requires `type` to be "ExternalName".
+                        description: externalName is the external reference that discovery
+                          mechanisms will return as an alias for this service (e.g.
+                          a DNS CNAME record). No proxying will be involved.  Must
+                          be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123)
+                          and requires `type` to be "ExternalName".
                         type: string
                       externalTrafficPolicy:
-                        description: externalTrafficPolicy denotes if this Service desires to route external traffic to node-local or cluster-wide endpoints. "Local" preserves the client source IP and avoids a second hop for LoadBalancer and Nodeport type services, but risks potentially imbalanced traffic spreading. "Cluster" obscures the client source IP and may cause a second hop to another node, but should have good overall load-spreading.
+                        description: externalTrafficPolicy denotes if this Service
+                          desires to route external traffic to node-local or cluster-wide
+                          endpoints. "Local" preserves the client source IP and avoids
+                          a second hop for LoadBalancer and Nodeport type services,
+                          but risks potentially imbalanced traffic spreading. "Cluster"
+                          obscures the client source IP and may cause a second hop
+                          to another node, but should have good overall load-spreading.
                         type: string
                       healthCheckNodePort:
-                        description: healthCheckNodePort specifies the healthcheck nodePort for the service. This only applies when type is set to LoadBalancer and externalTrafficPolicy is set to Local. If a value is specified, is in-range, and is not in use, it will be used.  If not specified, a value will be automatically allocated.  External systems (e.g. load-balancers) can use this port to determine if a given node holds endpoints for this service or not.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type).
+                        description: healthCheckNodePort specifies the healthcheck
+                          nodePort for the service. This only applies when type is
+                          set to LoadBalancer and externalTrafficPolicy is set to
+                          Local. If a value is specified, is in-range, and is not
+                          in use, it will be used.  If not specified, a value will
+                          be automatically allocated.  External systems (e.g. load-balancers)
+                          can use this port to determine if a given node holds endpoints
+                          for this service or not.  If this field is specified when
+                          creating a Service which does not need it, creation will
+                          fail. This field will be wiped when updating a Service to
+                          no longer need it (e.g. changing type).
                         format: int32
                         type: integer
                       internalTrafficPolicy:
-                        description: InternalTrafficPolicy specifies if the cluster internal traffic should be routed to all endpoints or node-local endpoints only. "Cluster" routes internal traffic to a Service to all endpoints. "Local" routes traffic to node-local endpoints only, traffic is dropped if no node-local endpoints are ready. The default value is "Cluster".
+                        description: InternalTrafficPolicy specifies if the cluster
+                          internal traffic should be routed to all endpoints or node-local
+                          endpoints only. "Cluster" routes internal traffic to a Service
+                          to all endpoints. "Local" routes traffic to node-local endpoints
+                          only, traffic is dropped if no node-local endpoints are
+                          ready. The default value is "Cluster".
                         type: string
                       ipFamilies:
-                        description: "IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this service, and is gated by the \"IPv6DualStack\" feature gate.  This field is usually assigned automatically based on cluster configuration and the ipFamilyPolicy field. If this field is specified manually, the requested family is available in the cluster, and ipFamilyPolicy allows it, it will be used; otherwise creation of the service will fail.  This field is conditionally mutable: it allows for adding or removing a secondary IP family, but it does not allow changing the primary IP family of the Service.  Valid values are \"IPv4\" and \"IPv6\".  This field only applies to Services of types ClusterIP, NodePort, and LoadBalancer, and does apply to \"headless\" services.  This field will be wiped when updating a Service to type ExternalName. \n This field may hold a maximum of two entries (dual-stack families, in either order).  These families must correspond to the values of the clusterIPs field, if specified. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field."
+                        description: "IPFamilies is a list of IP families (e.g. IPv4,
+                          IPv6) assigned to this service, and is gated by the \"IPv6DualStack\"
+                          feature gate.  This field is usually assigned automatically
+                          based on cluster configuration and the ipFamilyPolicy field.
+                          If this field is specified manually, the requested family
+                          is available in the cluster, and ipFamilyPolicy allows it,
+                          it will be used; otherwise creation of the service will
+                          fail.  This field is conditionally mutable: it allows for
+                          adding or removing a secondary IP family, but it does not
+                          allow changing the primary IP family of the Service.  Valid
+                          values are \"IPv4\" and \"IPv6\".  This field only applies
+                          to Services of types ClusterIP, NodePort, and LoadBalancer,
+                          and does apply to \"headless\" services.  This field will
+                          be wiped when updating a Service to type ExternalName. \n
+                          This field may hold a maximum of two entries (dual-stack
+                          families, in either order).  These families must correspond
+                          to the values of the clusterIPs field, if specified. Both
+                          clusterIPs and ipFamilies are governed by the ipFamilyPolicy
+                          field."
                         items:
-                          description: IPFamily represents the IP Family (IPv4 or IPv6). This type is used to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
+                          description: IPFamily represents the IP Family (IPv4 or
+                            IPv6). This type is used to express the family of an IP
+                            expressed by a type (e.g. service.spec.ipFamilies).
                           type: string
                         type: array
                         x-kubernetes-list-type: atomic
                       ipFamilyPolicy:
-                        description: IPFamilyPolicy represents the dual-stack-ness requested or required by this Service, and is gated by the "IPv6DualStack" feature gate.  If there is no value provided, then this field will be set to SingleStack. Services can be "SingleStack" (a single IP family), "PreferDualStack" (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), or "RequireDualStack" (two IP families on dual-stack configured clusters, otherwise fail). The ipFamilies and clusterIPs fields depend on the value of this field.  This field will be wiped when updating a service to type ExternalName.
+                        description: IPFamilyPolicy represents the dual-stack-ness
+                          requested or required by this Service, and is gated by the
+                          "IPv6DualStack" feature gate.  If there is no value provided,
+                          then this field will be set to SingleStack. Services can
+                          be "SingleStack" (a single IP family), "PreferDualStack"
+                          (two IP families on dual-stack configured clusters or a
+                          single IP family on single-stack clusters), or "RequireDualStack"
+                          (two IP families on dual-stack configured clusters, otherwise
+                          fail). The ipFamilies and clusterIPs fields depend on the
+                          value of this field.  This field will be wiped when updating
+                          a service to type ExternalName.
                         type: string
                       loadBalancerClass:
-                        description: loadBalancerClass is the class of the load balancer implementation this Service belongs to. If specified, the value of this field must be a label-style identifier, with an optional prefix, e.g. "internal-vip" or "example.com/internal-vip". Unprefixed names are reserved for end-users. This field can only be set when the Service type is 'LoadBalancer'. If not set, the default load balancer implementation is used, today this is typically done through the cloud provider integration, but should apply for any default implementation. If set, it is assumed that a load balancer implementation is watching for Services with a matching class. Any default load balancer implementation (e.g. cloud providers) should ignore Services that set this field. This field can only be set when creating or updating a Service to type 'LoadBalancer'. Once set, it can not be changed. This field will be wiped when a service is updated to a non 'LoadBalancer' type.
+                        description: loadBalancerClass is the class of the load balancer
+                          implementation this Service belongs to. If specified, the
+                          value of this field must be a label-style identifier, with
+                          an optional prefix, e.g. "internal-vip" or "example.com/internal-vip".
+                          Unprefixed names are reserved for end-users. This field
+                          can only be set when the Service type is 'LoadBalancer'.
+                          If not set, the default load balancer implementation is
+                          used, today this is typically done through the cloud provider
+                          integration, but should apply for any default implementation.
+                          If set, it is assumed that a load balancer implementation
+                          is watching for Services with a matching class. Any default
+                          load balancer implementation (e.g. cloud providers) should
+                          ignore Services that set this field. This field can only
+                          be set when creating or updating a Service to type 'LoadBalancer'.
+                          Once set, it can not be changed. This field will be wiped
+                          when a service is updated to a non 'LoadBalancer' type.
                         type: string
                       loadBalancerIP:
-                        description: 'Only applies to Service Type: LoadBalancer LoadBalancer will get created with the IP specified in this field. This feature depends on whether the underlying cloud-provider supports specifying the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature.'
+                        description: 'Only applies to Service Type: LoadBalancer LoadBalancer
+                          will get created with the IP specified in this field. This
+                          feature depends on whether the underlying cloud-provider
+                          supports specifying the loadBalancerIP when a load balancer
+                          is created. This field will be ignored if the cloud-provider
+                          does not support the feature.'
                         type: string
                       loadBalancerSourceRanges:
-                        description: 'If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+                        description: 'If specified and supported by the platform,
+                          this will restrict traffic through the cloud-provider load-balancer
+                          will be restricted to the specified client IPs. This field
+                          will be ignored if the cloud-provider does not support the
+                          feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
                         items:
                           type: string
                         type: array
                       ports:
-                        description: 'The list of ports that are exposed by this service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                        description: 'The list of ports that are exposed by this service.
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
                         items:
-                          description: ServicePort contains information on service's port.
+                          description: ServicePort contains information on service's
+                            port.
                           properties:
                             appProtocol:
-                              description: The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol. This is a beta field that is guarded by the ServiceAppProtocol feature gate and enabled by default.
+                              description: The application protocol for this port.
+                                This field follows standard Kubernetes label syntax.
+                                Un-prefixed names are reserved for IANA standard service
+                                names (as per RFC-6335 and http://www.iana.org/assignments/service-names).
+                                Non-standard protocols should use prefixed names such
+                                as mycompany.com/my-custom-protocol. This is a beta
+                                field that is guarded by the ServiceAppProtocol feature
+                                gate and enabled by default.
                               type: string
                             name:
-                              description: The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.
+                              description: The name of this port within the service.
+                                This must be a DNS_LABEL. All ports within a ServiceSpec
+                                must have unique names. When considering the endpoints
+                                for a Service, this must match the 'name' field in
+                                the EndpointPort. Optional if only one ServicePort
+                                is defined on this service.
                               type: string
                             nodePort:
-                              description: 'The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                              description: 'The port on each node on which this service
+                                is exposed when type is NodePort or LoadBalancer.  Usually
+                                assigned by the system. If a value is specified, in-range,
+                                and not in use it will be used, otherwise the operation
+                                will fail.  If not specified, a port will be allocated
+                                if this Service requires one.  If this field is specified
+                                when creating a Service which does not need it, creation
+                                will fail. This field will be wiped when updating
+                                a Service to no longer need it (e.g. changing type
+                                from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
                               format: int32
                               type: integer
                             port:
@@ -592,13 +878,22 @@ spec:
                               type: integer
                             protocol:
                               default: TCP
-                              description: The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
+                              description: The IP protocol for this port. Supports
+                                "TCP", "UDP", and "SCTP". Default is TCP.
                               type: string
                             targetPort:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: 'Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod''s container ports. If this is not specified, the value of the ''port'' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                              description: 'Number or name of the port to access on
+                                the pods targeted by the service. Number must be in
+                                the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                If this is a string, it will be looked up as a named
+                                port in the target Pod''s container ports. If this
+                                is not specified, the value of the ''port'' field
+                                is used (an identity map). This field is ignored for
+                                services with clusterIP=None, and should be omitted
+                                or set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
                               x-kubernetes-int-or-string: true
                           required:
                           - port
@@ -609,35 +904,87 @@ spec:
                         - protocol
                         x-kubernetes-list-type: map
                       publishNotReadyAddresses:
-                        description: publishNotReadyAddresses indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready. The primary use case for setting this field is for a StatefulSet's Headless Service to propagate SRV DNS records for its Pods for the purpose of peer discovery. The Kubernetes controllers that generate Endpoints and EndpointSlice resources for Services interpret this to mean that all endpoints are considered "ready" even if the Pods themselves are not. Agents which consume only Kubernetes generated endpoints through the Endpoints or EndpointSlice resources can safely assume this behavior.
+                        description: publishNotReadyAddresses indicates that any agent
+                          which deals with endpoints for this Service should disregard
+                          any indications of ready/not-ready. The primary use case
+                          for setting this field is for a StatefulSet's Headless Service
+                          to propagate SRV DNS records for its Pods for the purpose
+                          of peer discovery. The Kubernetes controllers that generate
+                          Endpoints and EndpointSlice resources for Services interpret
+                          this to mean that all endpoints are considered "ready" even
+                          if the Pods themselves are not. Agents which consume only
+                          Kubernetes generated endpoints through the Endpoints or
+                          EndpointSlice resources can safely assume this behavior.
                         type: boolean
                       selector:
                         additionalProperties:
                           type: string
-                        description: 'Route service traffic to pods with label keys and values matching this selector. If empty or not present, the service is assumed to have an external process managing its endpoints, which Kubernetes will not modify. Only applies to types ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                        description: 'Route service traffic to pods with label keys
+                          and values matching this selector. If empty or not present,
+                          the service is assumed to have an external process managing
+                          its endpoints, which Kubernetes will not modify. Only applies
+                          to types ClusterIP, NodePort, and LoadBalancer. Ignored
+                          if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
                         type: object
                       sessionAffinity:
-                        description: 'Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                        description: 'Supports "ClientIP" and "None". Used to maintain
+                          session affinity. Enable client IP based session affinity.
+                          Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
                         type: string
                       sessionAffinityConfig:
-                        description: sessionAffinityConfig contains the configurations of session affinity.
+                        description: sessionAffinityConfig contains the configurations
+                          of session affinity.
                         properties:
                           clientIP:
-                            description: clientIP contains the configurations of Client IP based session affinity.
+                            description: clientIP contains the configurations of Client
+                              IP based session affinity.
                             properties:
                               timeoutSeconds:
-                                description: timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP". Default value is 10800(for 3 hours).
+                                description: timeoutSeconds specifies the seconds
+                                  of ClientIP type session sticky time. The value
+                                  must be >0 && <=86400(for 1 day) if ServiceAffinity
+                                  == "ClientIP". Default value is 10800(for 3 hours).
                                 format: int32
                                 type: integer
                             type: object
                         type: object
                       topologyKeys:
-                        description: topologyKeys is a preference-order list of topology keys which implementations of services should use to preferentially sort endpoints when accessing this Service, it can not be used at the same time as externalTrafficPolicy=Local. Topology keys must be valid label keys and at most 16 keys may be specified. Endpoints are chosen based on the first topology key with available backends. If this field is specified and all entries have no backends that match the topology of the client, the service has no backends for that client and connections should fail. The special value "*" may be used to mean "any topology". This catch-all value, if used, only makes sense as the last value in the list. If this is not specified or empty, no topology constraints will be applied. This field is alpha-level and is only honored by servers that enable the ServiceTopology feature. This field is deprecated and will be removed in a future version.
+                        description: topologyKeys is a preference-order list of topology
+                          keys which implementations of services should use to preferentially
+                          sort endpoints when accessing this Service, it can not be
+                          used at the same time as externalTrafficPolicy=Local. Topology
+                          keys must be valid label keys and at most 16 keys may be
+                          specified. Endpoints are chosen based on the first topology
+                          key with available backends. If this field is specified
+                          and all entries have no backends that match the topology
+                          of the client, the service has no backends for that client
+                          and connections should fail. The special value "*" may be
+                          used to mean "any topology". This catch-all value, if used,
+                          only makes sense as the last value in the list. If this
+                          is not specified or empty, no topology constraints will
+                          be applied. This field is alpha-level and is only honored
+                          by servers that enable the ServiceTopology feature. This
+                          field is deprecated and will be removed in a future version.
                         items:
                           type: string
                         type: array
                       type:
-                        description: 'type determines how the Service is exposed. Defaults to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. "ClusterIP" allocates a cluster-internal IP address for load-balancing to endpoints. Endpoints are determined by the selector or if that is not specified, by manual construction of an Endpoints object or EndpointSlice objects. If clusterIP is "None", no virtual IP is allocated and the endpoints are published as a set of endpoints rather than a virtual IP. "NodePort" builds on ClusterIP and allocates a port on every node which routes to the same endpoints as the clusterIP. "LoadBalancer" builds on NodePort and creates an external load-balancer (if supported in the current cloud) which routes to the same endpoints as the clusterIP. "ExternalName" aliases this service to the specified externalName. Several other fields do not apply to ExternalName services. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                        description: 'type determines how the Service is exposed.
+                          Defaults to ClusterIP. Valid options are ExternalName, ClusterIP,
+                          NodePort, and LoadBalancer. "ClusterIP" allocates a cluster-internal
+                          IP address for load-balancing to endpoints. Endpoints are
+                          determined by the selector or if that is not specified,
+                          by manual construction of an Endpoints object or EndpointSlice
+                          objects. If clusterIP is "None", no virtual IP is allocated
+                          and the endpoints are published as a set of endpoints rather
+                          than a virtual IP. "NodePort" builds on ClusterIP and allocates
+                          a port on every node which routes to the same endpoints
+                          as the clusterIP. "LoadBalancer" builds on NodePort and
+                          creates an external load-balancer (if supported in the current
+                          cloud) which routes to the same endpoints as the clusterIP.
+                          "ExternalName" aliases this service to the specified externalName.
+                          Several other fields do not apply to ExternalName services.
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
                         type: string
                     type: object
                 type: object
@@ -647,17 +994,21 @@ spec:
             properties:
               conditions:
                 items:
-                  description: ResourceExportCondition indicates the readiness condition of the ResourceExport.
+                  description: ResourceExportCondition indicates the readiness condition
+                    of the ResourceExport.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transited from one status to another.
+                      description: Last time the condition transited from one status
+                        to another.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about the transition.
+                      description: A human readable message indicating details about
+                        the transition.
                       type: string
                     reason:
-                      description: Unique, one-word, CamelCase reason for the condition's last transition.
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition.
                       type: string
                     status:
                       description: Status of the condition, one of True, False, Unknown.
@@ -700,13 +1051,18 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ResourceImportFilter is the Schema for the ResourceImportFilters API
+        description: ResourceImportFilter is the Schema for the ResourceImportFilters
+          API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -714,7 +1070,8 @@ spec:
             description: ResourceImportFilterSpec defines the desired state of ResourceImportFilter
             type: object
           status:
-            description: ResourceImportFilterStatus defines the observed state of ResourceImportFilter
+            description: ResourceImportFilterStatus defines the observed state of
+              ResourceImportFilter
             type: object
         type: object
     served: true
@@ -752,10 +1109,14 @@ spec:
         description: ResourceImport is the Schema for the resourceimports API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -763,7 +1124,8 @@ spec:
             description: ResourceImportSpec defines the desired state of ResourceImport.
             properties:
               clusterID:
-                description: ClusterIDs specifies the member clusters this resource to import to. When not specified, import to all member clusters.
+                description: ClusterIDs specifies the member clusters this resource
+                  to import to. When not specified, import to all member clusters.
                 items:
                   type: string
                 type: array
@@ -772,21 +1134,38 @@ spec:
                 properties:
                   subsets:
                     items:
-                      description: 'EndpointSubset is a group of addresses with a common set of ports. The expanded set of endpoints is the Cartesian product of Addresses x Ports. For example, given:   {     Addresses: [{"ip": "10.10.1.1"}, {"ip": "10.10.2.2"}],     Ports:     [{"name": "a", "port": 8675}, {"name": "b", "port": 309}]   } The resulting set of endpoints can be viewed as:     a: [ 10.10.1.1:8675, 10.10.2.2:8675 ],     b: [ 10.10.1.1:309, 10.10.2.2:309 ]'
+                      description: 'EndpointSubset is a group of addresses with a
+                        common set of ports. The expanded set of endpoints is the
+                        Cartesian product of Addresses x Ports. For example, given:   {     Addresses:
+                        [{"ip": "10.10.1.1"}, {"ip": "10.10.2.2"}],     Ports:     [{"name":
+                        "a", "port": 8675}, {"name": "b", "port": 309}]   } The resulting
+                        set of endpoints can be viewed as:     a: [ 10.10.1.1:8675,
+                        10.10.2.2:8675 ],     b: [ 10.10.1.1:309, 10.10.2.2:309 ]'
                       properties:
                         addresses:
-                          description: IP addresses which offer the related ports that are marked as ready. These endpoints should be considered safe for load balancers and clients to utilize.
+                          description: IP addresses which offer the related ports
+                            that are marked as ready. These endpoints should be considered
+                            safe for load balancers and clients to utilize.
                           items:
-                            description: EndpointAddress is a tuple that describes single IP address.
+                            description: EndpointAddress is a tuple that describes
+                              single IP address.
                             properties:
                               hostname:
                                 description: The Hostname of this endpoint
                                 type: string
                               ip:
-                                description: 'The IP of this endpoint. May not be loopback (127.0.0.0/8), link-local (169.254.0.0/16), or link-local multicast ((224.0.0.0/24). IPv6 is also accepted but not fully supported on all platforms. Also, certain kubernetes components, like kube-proxy, are not IPv6 ready. TODO: This should allow hostname or IP, See #4447.'
+                                description: 'The IP of this endpoint. May not be
+                                  loopback (127.0.0.0/8), link-local (169.254.0.0/16),
+                                  or link-local multicast ((224.0.0.0/24). IPv6 is
+                                  also accepted but not fully supported on all platforms.
+                                  Also, certain kubernetes components, like kube-proxy,
+                                  are not IPv6 ready. TODO: This should allow hostname
+                                  or IP, See #4447.'
                                 type: string
                               nodeName:
-                                description: 'Optional: Node hosting this endpoint. This can be used to determine endpoints local to a node.'
+                                description: 'Optional: Node hosting this endpoint.
+                                  This can be used to determine endpoints local to
+                                  a node.'
                                 type: string
                               targetRef:
                                 description: Reference to object providing the endpoint.
@@ -795,22 +1174,41 @@ spec:
                                     description: API version of the referent.
                                     type: string
                                   fieldPath:
-                                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                                    description: 'If referring to a piece of an object
+                                      instead of an entire object, this string should
+                                      contain a valid JSON/Go field access statement,
+                                      such as desiredState.manifest.containers[2].
+                                      For example, if the object reference is to a
+                                      container within a pod, this would take on a
+                                      value like: "spec.containers{name}" (where "name"
+                                      refers to the name of the container that triggered
+                                      the event) or if no container name is specified
+                                      "spec.containers[2]" (container with index 2
+                                      in this pod). This syntax is chosen only to
+                                      have some well-defined way of referencing a
+                                      part of an object. TODO: this design is not
+                                      final and this field is subject to change in
+                                      the future.'
                                     type: string
                                   kind:
-                                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                    description: 'Kind of the referent. More info:
+                                      https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                   namespace:
-                                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                    description: 'Namespace of the referent. More
+                                      info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                                     type: string
                                   resourceVersion:
-                                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                    description: 'Specific resourceVersion to which
+                                      this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                                     type: string
                                   uid:
-                                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                    description: 'UID of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                                     type: string
                                 type: object
                             required:
@@ -818,18 +1216,30 @@ spec:
                             type: object
                           type: array
                         notReadyAddresses:
-                          description: IP addresses which offer the related ports but are not currently marked as ready because they have not yet finished starting, have recently failed a readiness check, or have recently failed a liveness check.
+                          description: IP addresses which offer the related ports
+                            but are not currently marked as ready because they have
+                            not yet finished starting, have recently failed a readiness
+                            check, or have recently failed a liveness check.
                           items:
-                            description: EndpointAddress is a tuple that describes single IP address.
+                            description: EndpointAddress is a tuple that describes
+                              single IP address.
                             properties:
                               hostname:
                                 description: The Hostname of this endpoint
                                 type: string
                               ip:
-                                description: 'The IP of this endpoint. May not be loopback (127.0.0.0/8), link-local (169.254.0.0/16), or link-local multicast ((224.0.0.0/24). IPv6 is also accepted but not fully supported on all platforms. Also, certain kubernetes components, like kube-proxy, are not IPv6 ready. TODO: This should allow hostname or IP, See #4447.'
+                                description: 'The IP of this endpoint. May not be
+                                  loopback (127.0.0.0/8), link-local (169.254.0.0/16),
+                                  or link-local multicast ((224.0.0.0/24). IPv6 is
+                                  also accepted but not fully supported on all platforms.
+                                  Also, certain kubernetes components, like kube-proxy,
+                                  are not IPv6 ready. TODO: This should allow hostname
+                                  or IP, See #4447.'
                                 type: string
                               nodeName:
-                                description: 'Optional: Node hosting this endpoint. This can be used to determine endpoints local to a node.'
+                                description: 'Optional: Node hosting this endpoint.
+                                  This can be used to determine endpoints local to
+                                  a node.'
                                 type: string
                               targetRef:
                                 description: Reference to object providing the endpoint.
@@ -838,22 +1248,41 @@ spec:
                                     description: API version of the referent.
                                     type: string
                                   fieldPath:
-                                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                                    description: 'If referring to a piece of an object
+                                      instead of an entire object, this string should
+                                      contain a valid JSON/Go field access statement,
+                                      such as desiredState.manifest.containers[2].
+                                      For example, if the object reference is to a
+                                      container within a pod, this would take on a
+                                      value like: "spec.containers{name}" (where "name"
+                                      refers to the name of the container that triggered
+                                      the event) or if no container name is specified
+                                      "spec.containers[2]" (container with index 2
+                                      in this pod). This syntax is chosen only to
+                                      have some well-defined way of referencing a
+                                      part of an object. TODO: this design is not
+                                      final and this field is subject to change in
+                                      the future.'
                                     type: string
                                   kind:
-                                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                    description: 'Kind of the referent. More info:
+                                      https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                   namespace:
-                                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                    description: 'Namespace of the referent. More
+                                      info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                                     type: string
                                   resourceVersion:
-                                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                    description: 'Specific resourceVersion to which
+                                      this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                                     type: string
                                   uid:
-                                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                    description: 'UID of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                                     type: string
                                 type: object
                             required:
@@ -863,13 +1292,24 @@ spec:
                         ports:
                           description: Port numbers available on the related IP addresses.
                           items:
-                            description: EndpointPort is a tuple that describes a single port.
+                            description: EndpointPort is a tuple that describes a
+                              single port.
                             properties:
                               appProtocol:
-                                description: The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol. This is a beta field that is guarded by the ServiceAppProtocol feature gate and enabled by default.
+                                description: The application protocol for this port.
+                                  This field follows standard Kubernetes label syntax.
+                                  Un-prefixed names are reserved for IANA standard
+                                  service names (as per RFC-6335 and http://www.iana.org/assignments/service-names).
+                                  Non-standard protocols should use prefixed names
+                                  such as mycompany.com/my-custom-protocol. This is
+                                  a beta field that is guarded by the ServiceAppProtocol
+                                  feature gate and enabled by default.
                                 type: string
                               name:
-                                description: The name of this port.  This must match the 'name' field in the corresponding ServicePort. Must be a DNS_LABEL. Optional only if one port is defined.
+                                description: The name of this port.  This must match
+                                  the 'name' field in the corresponding ServicePort.
+                                  Must be a DNS_LABEL. Optional only if one port is
+                                  defined.
                                 type: string
                               port:
                                 description: The port number of the endpoint.
@@ -877,7 +1317,8 @@ spec:
                                 type: integer
                               protocol:
                                 default: TCP
-                                description: The IP protocol for this port. Must be UDP, TCP, or SCTP. Default is TCP.
+                                description: The IP protocol for this port. Must be
+                                  UDP, TCP, or SCTP. Default is TCP.
                                 type: string
                             required:
                             - port
@@ -890,28 +1331,35 @@ spec:
                 description: If imported resource is ExternalEntity.
                 properties:
                   externalentityspec:
-                    description: ExternalEntitySpec defines the desired state for ExternalEntity.
+                    description: ExternalEntitySpec defines the desired state for
+                      ExternalEntity.
                     properties:
                       endpoints:
-                        description: Endpoints is a list of external endpoints associated with this entity.
+                        description: Endpoints is a list of external endpoints associated
+                          with this entity.
                         items:
-                          description: Endpoint refers to an endpoint associated with the ExternalEntity.
+                          description: Endpoint refers to an endpoint associated with
+                            the ExternalEntity.
                           properties:
                             ip:
                               description: IP associated with this endpoint.
                               type: string
                             name:
-                              description: Name identifies this endpoint. Could be the network interface name in case of VMs.
+                              description: Name identifies this endpoint. Could be
+                                the network interface name in case of VMs.
                               type: string
                           type: object
                         type: array
                       externalNode:
-                        description: ExternalNode is the opaque identifier of the agent/controller responsible for additional processing or handling of this external entity.
+                        description: ExternalNode is the opaque identifier of the
+                          agent/controller responsible for additional processing or
+                          handling of this external entity.
                         type: string
                       ports:
                         description: Ports maintain the list of named ports.
                         items:
-                          description: NamedPort describes the port and protocol to match in a rule.
+                          description: NamedPort describes the port and protocol to
+                            match in a rule.
                           properties:
                             name:
                               description: Name associated with the Port.
@@ -922,7 +1370,9 @@ spec:
                               type: integer
                             protocol:
                               default: TCP
-                              description: The protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this field defaults to TCP.
+                              description: The protocol (TCP, UDP, or SCTP) which
+                                traffic must match. If not specified, this field defaults
+                                to TCP.
                               type: string
                           type: object
                         type: array
@@ -938,7 +1388,10 @@ spec:
                 description: Namespace of imported resource.
                 type: string
               raw:
-                description: 'If imported resource is ANP. TODO: ANP uses float64 as priority.  Type float64 is discouraged by k8s, and is not supported by controller-gen tools. NetworkPolicy *v1alpha1.NetworkPolicySpec `json:"networkpolicy,omitempty"` If imported resource Kind is unknown.'
+                description: 'If imported resource is ANP. TODO: ANP uses float64
+                  as priority.  Type float64 is discouraged by k8s, and is not supported
+                  by controller-gen tools. NetworkPolicy *v1alpha1.NetworkPolicySpec
+                  `json:"networkpolicy,omitempty"` If imported resource Kind is unknown.'
                 properties:
                   data:
                     format: byte
@@ -948,10 +1401,16 @@ spec:
                 description: If imported resource is ServiceImport.
                 properties:
                   apiVersion:
-                    description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    description: 'APIVersion defines the versioned schema of this
+                      representation of an object. Servers should convert recognized
+                      schemas to the latest internal value, and may reject unrecognized
+                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
                     type: string
                   kind:
-                    description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    description: 'Kind is a string value representing the REST resource
+                      this object represents. Servers may infer this from the endpoint
+                      the client submits requests to. Cannot be updated. In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                     type: string
                   metadata:
                     type: object
@@ -959,20 +1418,33 @@ spec:
                     description: spec defines the behavior of a ServiceImport.
                     properties:
                       ips:
-                        description: ip will be used as the VIP for this service when type is ClusterSetIP.
+                        description: ip will be used as the VIP for this service when
+                          type is ClusterSetIP.
                         items:
                           type: string
                         maxItems: 1
                         type: array
                       ports:
                         items:
-                          description: ServicePort represents the port on which the service is exposed
+                          description: ServicePort represents the port on which the
+                            service is exposed
                           properties:
                             appProtocol:
-                              description: The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol. Field can be enabled with ServiceAppProtocol feature gate.
+                              description: The application protocol for this port.
+                                This field follows standard Kubernetes label syntax.
+                                Un-prefixed names are reserved for IANA standard service
+                                names (as per RFC-6335 and http://www.iana.org/assignments/service-names).
+                                Non-standard protocols should use prefixed names such
+                                as mycompany.com/my-custom-protocol. Field can be
+                                enabled with ServiceAppProtocol feature gate.
                               type: string
                             name:
-                              description: The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.
+                              description: The name of this port within the service.
+                                This must be a DNS_LABEL. All ports within a ServiceSpec
+                                must have unique names. When considering the endpoints
+                                for a Service, this must match the 'name' field in
+                                the EndpointPort. Optional if only one ServicePort
+                                is defined on this service.
                               type: string
                             port:
                               description: The port that will be exposed by this service.
@@ -980,7 +1452,8 @@ spec:
                               type: integer
                             protocol:
                               default: TCP
-                              description: The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
+                              description: The IP protocol for this port. Supports
+                                "TCP", "UDP", and "SCTP". Default is TCP.
                               type: string
                           required:
                           - port
@@ -988,22 +1461,31 @@ spec:
                         type: array
                         x-kubernetes-list-type: atomic
                       sessionAffinity:
-                        description: 'Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. Ignored when type is Headless More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                        description: 'Supports "ClientIP" and "None". Used to maintain
+                          session affinity. Enable client IP based session affinity.
+                          Must be ClientIP or None. Defaults to None. Ignored when
+                          type is Headless More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
                         type: string
                       sessionAffinityConfig:
-                        description: sessionAffinityConfig contains session affinity configuration.
+                        description: sessionAffinityConfig contains session affinity
+                          configuration.
                         properties:
                           clientIP:
-                            description: clientIP contains the configurations of Client IP based session affinity.
+                            description: clientIP contains the configurations of Client
+                              IP based session affinity.
                             properties:
                               timeoutSeconds:
-                                description: timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP". Default value is 10800(for 3 hours).
+                                description: timeoutSeconds specifies the seconds
+                                  of ClientIP type session sticky time. The value
+                                  must be >0 && <=86400(for 1 day) if ServiceAffinity
+                                  == "ClientIP". Default value is 10800(for 3 hours).
                                 format: int32
                                 type: integer
                             type: object
                         type: object
                       type:
-                        description: type defines the type of this service. Must be ClusterSetIP or Headless.
+                        description: type defines the type of this service. Must be
+                          ClusterSetIP or Headless.
                         enum:
                         - ClusterSetIP
                         - Headless
@@ -1013,15 +1495,19 @@ spec:
                     - type
                     type: object
                   status:
-                    description: status contains information about the exported services that form the multi-cluster service referenced by this ServiceImport.
+                    description: status contains information about the exported services
+                      that form the multi-cluster service referenced by this ServiceImport.
                     properties:
                       clusters:
-                        description: clusters is the list of exporting clusters from which this service was derived.
+                        description: clusters is the list of exporting clusters from
+                          which this service was derived.
                         items:
-                          description: ClusterStatus contains service configuration mapped to a specific source cluster
+                          description: ClusterStatus contains service configuration
+                            mapped to a specific source cluster
                           properties:
                             cluster:
-                              description: cluster is the name of the exporting cluster. Must be a valid RFC-1123 DNS label.
+                              description: cluster is the name of the exporting cluster.
+                                Must be a valid RFC-1123 DNS label.
                               type: string
                           required:
                           - cluster
@@ -1038,27 +1524,33 @@ spec:
             properties:
               clusterStatuses:
                 items:
-                  description: ResourceImportClusterStatus indicates the readiness status of the ResourceImport in clusters.
+                  description: ResourceImportClusterStatus indicates the readiness
+                    status of the ResourceImport in clusters.
                   properties:
                     clusterID:
                       description: ClusterID is the unique identifier of this cluster.
                       type: string
                     conditions:
                       items:
-                        description: ResourceImportCondition indicates the condition of the ResourceImport in a cluster.
+                        description: ResourceImportCondition indicates the condition
+                          of the ResourceImport in a cluster.
                         properties:
                           lastTransitionTime:
-                            description: Last time the condition transited from one status to another.
+                            description: Last time the condition transited from one
+                              status to another.
                             format: date-time
                             type: string
                           message:
-                            description: A human readable message indicating details about the transition.
+                            description: A human readable message indicating details
+                              about the transition.
                             type: string
                           reason:
-                            description: Unique, one-word, CamelCase reason for the condition's last transition.
+                            description: Unique, one-word, CamelCase reason for the
+                              condition's last transition.
                             type: string
                           status:
-                            description: Status of the condition, one of True, False, Unknown.
+                            description: Status of the condition, one of True, False,
+                              Unknown.
                             type: string
                           type:
                             type: string
@@ -1102,38 +1594,68 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ServiceExport declares that the Service with the same name and namespace as this export should be consumable from other clusters.
+        description: ServiceExport declares that the Service with the same name and
+          namespace as this export should be consumable from other clusters.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           status:
-            description: status describes the current state of an exported service. Service configuration comes from the Service that had the same name and namespace as this ServiceExport. Populated by the multi-cluster service implementation's controller.
+            description: status describes the current state of an exported service.
+              Service configuration comes from the Service that had the same name
+              and namespace as this ServiceExport. Populated by the multi-cluster
+              service implementation's controller.
             properties:
               conditions:
                 items:
-                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    type FooStatus struct{     // Represents the observations of a
+                    foo's current state.     // Known .status.conditions.type are:
+                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
+                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                    \n     // other fields }"
                   properties:
                     lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: message is a human readable message indicating details about the transition. This may be an empty string.
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
@@ -1146,7 +1668,11 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -1199,13 +1725,18 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ServiceImport describes a service imported from clusters in a ClusterSet.
+        description: ServiceImport describes a service imported from clusters in a
+          ClusterSet.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -1213,27 +1744,39 @@ spec:
             description: spec defines the behavior of a ServiceImport.
             properties:
               ips:
-                description: ip will be used as the VIP for this service when type is ClusterSetIP.
+                description: ip will be used as the VIP for this service when type
+                  is ClusterSetIP.
                 items:
                   type: string
                 maxItems: 1
                 type: array
               ports:
                 items:
-                  description: ServicePort represents the port on which the service is exposed
+                  description: ServicePort represents the port on which the service
+                    is exposed
                   properties:
                     appProtocol:
-                      description: The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol. Field can be enabled with ServiceAppProtocol feature gate.
+                      description: The application protocol for this port. This field
+                        follows standard Kubernetes label syntax. Un-prefixed names
+                        are reserved for IANA standard service names (as per RFC-6335
+                        and http://www.iana.org/assignments/service-names). Non-standard
+                        protocols should use prefixed names such as mycompany.com/my-custom-protocol.
+                        Field can be enabled with ServiceAppProtocol feature gate.
                       type: string
                     name:
-                      description: The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.
+                      description: The name of this port within the service. This
+                        must be a DNS_LABEL. All ports within a ServiceSpec must have
+                        unique names. When considering the endpoints for a Service,
+                        this must match the 'name' field in the EndpointPort. Optional
+                        if only one ServicePort is defined on this service.
                       type: string
                     port:
                       description: The port that will be exposed by this service.
                       format: int32
                       type: integer
                     protocol:
-                      description: The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
+                      description: The IP protocol for this port. Supports "TCP",
+                        "UDP", and "SCTP". Default is TCP.
                       type: string
                   required:
                   - port
@@ -1241,22 +1784,30 @@ spec:
                 type: array
                 x-kubernetes-list-type: atomic
               sessionAffinity:
-                description: 'Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. Ignored when type is Headless More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                description: 'Supports "ClientIP" and "None". Used to maintain session
+                  affinity. Enable client IP based session affinity. Must be ClientIP
+                  or None. Defaults to None. Ignored when type is Headless More info:
+                  https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
                 type: string
               sessionAffinityConfig:
                 description: sessionAffinityConfig contains session affinity configuration.
                 properties:
                   clientIP:
-                    description: clientIP contains the configurations of Client IP based session affinity.
+                    description: clientIP contains the configurations of Client IP
+                      based session affinity.
                     properties:
                       timeoutSeconds:
-                        description: timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP". Default value is 10800(for 3 hours).
+                        description: timeoutSeconds specifies the seconds of ClientIP
+                          type session sticky time. The value must be >0 && <=86400(for
+                          1 day) if ServiceAffinity == "ClientIP". Default value is
+                          10800(for 3 hours).
                         format: int32
                         type: integer
                     type: object
                 type: object
               type:
-                description: type defines the type of this service. Must be ClusterSetIP or Headless.
+                description: type defines the type of this service. Must be ClusterSetIP
+                  or Headless.
                 enum:
                 - ClusterSetIP
                 - Headless
@@ -1266,15 +1817,19 @@ spec:
             - type
             type: object
           status:
-            description: status contains information about the exported services that form the multi-cluster service referenced by this ServiceImport.
+            description: status contains information about the exported services that
+              form the multi-cluster service referenced by this ServiceImport.
             properties:
               clusters:
-                description: clusters is the list of exporting clusters from which this service was derived.
+                description: clusters is the list of exporting clusters from which
+                  this service was derived.
                 items:
-                  description: ClusterStatus contains service configuration mapped to a specific source cluster
+                  description: ClusterStatus contains service configuration mapped
+                    to a specific source cluster
                   properties:
                     cluster:
-                      description: cluster is the name of the exporting cluster. Must be a valid RFC-1123 DNS label.
+                      description: cluster is the name of the exporting cluster. Must
+                        be a valid RFC-1123 DNS label.
                       type: string
                   required:
                   - cluster

--- a/multicluster/build/yamls/antrea-multicluster-member.yml
+++ b/multicluster/build/yamls/antrea-multicluster-member.yml
@@ -22,10 +22,14 @@ spec:
         description: ClusterClaim is the Schema for the clusterclaims API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -69,10 +73,14 @@ spec:
         description: ClusterSet is the Schema for the clustersets API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -88,18 +96,21 @@ spec:
                       description: Identify member cluster in ClusterSet.
                       type: string
                     secret:
-                      description: Secret name to access API server of the member from the leader cluster.
+                      description: Secret name to access API server of the member
+                        from the leader cluster.
                       type: string
                     server:
                       description: API server of the destination cluster.
                       type: string
                     serviceAccount:
-                      description: ServiceAccount used by the member cluster to access into leader cluster.
+                      description: ServiceAccount used by the member cluster to access
+                        into leader cluster.
                       type: string
                   type: object
                 type: array
               members:
-                description: Members include member clusters known to the leader clusters. Used in leader cluster.
+                description: Members include member clusters known to the leader clusters.
+                  Used in leader cluster.
                 items:
                   description: MemberCluster defines member cluster information.
                   properties:
@@ -107,18 +118,21 @@ spec:
                       description: Identify member cluster in ClusterSet.
                       type: string
                     secret:
-                      description: Secret name to access API server of the member from the leader cluster.
+                      description: Secret name to access API server of the member
+                        from the leader cluster.
                       type: string
                     server:
                       description: API server of the destination cluster.
                       type: string
                     serviceAccount:
-                      description: ServiceAccount used by the member cluster to access into leader cluster.
+                      description: ServiceAccount used by the member cluster to access
+                        into leader cluster.
                       type: string
                   type: object
                 type: array
               namespace:
-                description: Namespace to connect to in leader clusters. Used in member cluster.
+                description: Namespace to connect to in leader clusters. Used in member
+                  cluster.
                 type: string
             type: object
           status:
@@ -133,20 +147,25 @@ spec:
                       type: string
                     conditions:
                       items:
-                        description: ClusterCondition indicates the readiness condition of a cluster.
+                        description: ClusterCondition indicates the readiness condition
+                          of a cluster.
                         properties:
                           lastTransitionTime:
-                            description: Last time the condition transited from one status to another.
+                            description: Last time the condition transited from one
+                              status to another.
                             format: date-time
                             type: string
                           message:
-                            description: A human readable message indicating details about the transition.
+                            description: A human readable message indicating details
+                              about the transition.
                             type: string
                           reason:
-                            description: Unique, one-word, CamelCase reason for the condition's last transition.
+                            description: Unique, one-word, CamelCase reason for the
+                              condition's last transition.
                             type: string
                           status:
-                            description: Status of the condition, one of True, False, Unknown.
+                            description: Status of the condition, one of True, False,
+                              Unknown.
                             type: string
                           type:
                             type: string
@@ -157,17 +176,21 @@ spec:
               conditions:
                 description: The overall condition of the cluster set.
                 items:
-                  description: ClusterSetCondition indicates the readiness condition of the clusterSet.
+                  description: ClusterSetCondition indicates the readiness condition
+                    of the clusterSet.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transited from one status to another.
+                      description: Last time the condition transited from one status
+                        to another.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about the transition.
+                      description: A human readable message indicating details about
+                        the transition.
                       type: string
                     reason:
-                      description: Unique, one-word, CamelCase reason for the condition's last transition.
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition.
                       type: string
                     status:
                       description: Status of the condition, one of True, False, Unknown.
@@ -222,10 +245,13 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: MemberClusterAnnounce is the Schema for the memberclusterannounces API
+        description: MemberClusterAnnounce is the Schema for the memberclusterannounces
+          API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           clusterID:
             description: ClusterID of the member cluster.
@@ -234,7 +260,9 @@ spec:
             description: ClusterSet this member belongs to.
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           leaderClusterID:
             description: Leader cluster this member has selected.
@@ -272,13 +300,18 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ResourceExportFilter is the Schema for the ResourceExportFilters API
+        description: ResourceExportFilter is the Schema for the ResourceExportFilters
+          API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -286,7 +319,8 @@ spec:
             description: ResourceExportFilterSpec defines the desired state of ResourceExportFilter
             type: object
           status:
-            description: ResourceExportFilterStatus defines the observed state of ResourceExportFilter
+            description: ResourceExportFilterStatus defines the observed state of
+              ResourceExportFilter
             type: object
         type: object
     served: true
@@ -324,10 +358,14 @@ spec:
         description: ResourceExport is the Schema for the resourceexports API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -335,28 +373,46 @@ spec:
             description: ResourceExportSpec defines the desired state of ResourceExport.
             properties:
               clusterID:
-                description: ClusterID specifies the member cluster this resource exported from.
+                description: ClusterID specifies the member cluster this resource
+                  exported from.
                 type: string
               endpoints:
                 description: If exported resource is EndPoints.
                 properties:
                   subsets:
                     items:
-                      description: 'EndpointSubset is a group of addresses with a common set of ports. The expanded set of endpoints is the Cartesian product of Addresses x Ports. For example, given:   {     Addresses: [{"ip": "10.10.1.1"}, {"ip": "10.10.2.2"}],     Ports:     [{"name": "a", "port": 8675}, {"name": "b", "port": 309}]   } The resulting set of endpoints can be viewed as:     a: [ 10.10.1.1:8675, 10.10.2.2:8675 ],     b: [ 10.10.1.1:309, 10.10.2.2:309 ]'
+                      description: 'EndpointSubset is a group of addresses with a
+                        common set of ports. The expanded set of endpoints is the
+                        Cartesian product of Addresses x Ports. For example, given:   {     Addresses:
+                        [{"ip": "10.10.1.1"}, {"ip": "10.10.2.2"}],     Ports:     [{"name":
+                        "a", "port": 8675}, {"name": "b", "port": 309}]   } The resulting
+                        set of endpoints can be viewed as:     a: [ 10.10.1.1:8675,
+                        10.10.2.2:8675 ],     b: [ 10.10.1.1:309, 10.10.2.2:309 ]'
                       properties:
                         addresses:
-                          description: IP addresses which offer the related ports that are marked as ready. These endpoints should be considered safe for load balancers and clients to utilize.
+                          description: IP addresses which offer the related ports
+                            that are marked as ready. These endpoints should be considered
+                            safe for load balancers and clients to utilize.
                           items:
-                            description: EndpointAddress is a tuple that describes single IP address.
+                            description: EndpointAddress is a tuple that describes
+                              single IP address.
                             properties:
                               hostname:
                                 description: The Hostname of this endpoint
                                 type: string
                               ip:
-                                description: 'The IP of this endpoint. May not be loopback (127.0.0.0/8), link-local (169.254.0.0/16), or link-local multicast ((224.0.0.0/24). IPv6 is also accepted but not fully supported on all platforms. Also, certain kubernetes components, like kube-proxy, are not IPv6 ready. TODO: This should allow hostname or IP, See #4447.'
+                                description: 'The IP of this endpoint. May not be
+                                  loopback (127.0.0.0/8), link-local (169.254.0.0/16),
+                                  or link-local multicast ((224.0.0.0/24). IPv6 is
+                                  also accepted but not fully supported on all platforms.
+                                  Also, certain kubernetes components, like kube-proxy,
+                                  are not IPv6 ready. TODO: This should allow hostname
+                                  or IP, See #4447.'
                                 type: string
                               nodeName:
-                                description: 'Optional: Node hosting this endpoint. This can be used to determine endpoints local to a node.'
+                                description: 'Optional: Node hosting this endpoint.
+                                  This can be used to determine endpoints local to
+                                  a node.'
                                 type: string
                               targetRef:
                                 description: Reference to object providing the endpoint.
@@ -365,22 +421,41 @@ spec:
                                     description: API version of the referent.
                                     type: string
                                   fieldPath:
-                                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                                    description: 'If referring to a piece of an object
+                                      instead of an entire object, this string should
+                                      contain a valid JSON/Go field access statement,
+                                      such as desiredState.manifest.containers[2].
+                                      For example, if the object reference is to a
+                                      container within a pod, this would take on a
+                                      value like: "spec.containers{name}" (where "name"
+                                      refers to the name of the container that triggered
+                                      the event) or if no container name is specified
+                                      "spec.containers[2]" (container with index 2
+                                      in this pod). This syntax is chosen only to
+                                      have some well-defined way of referencing a
+                                      part of an object. TODO: this design is not
+                                      final and this field is subject to change in
+                                      the future.'
                                     type: string
                                   kind:
-                                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                    description: 'Kind of the referent. More info:
+                                      https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                   namespace:
-                                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                    description: 'Namespace of the referent. More
+                                      info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                                     type: string
                                   resourceVersion:
-                                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                    description: 'Specific resourceVersion to which
+                                      this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                                     type: string
                                   uid:
-                                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                    description: 'UID of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                                     type: string
                                 type: object
                             required:
@@ -388,18 +463,30 @@ spec:
                             type: object
                           type: array
                         notReadyAddresses:
-                          description: IP addresses which offer the related ports but are not currently marked as ready because they have not yet finished starting, have recently failed a readiness check, or have recently failed a liveness check.
+                          description: IP addresses which offer the related ports
+                            but are not currently marked as ready because they have
+                            not yet finished starting, have recently failed a readiness
+                            check, or have recently failed a liveness check.
                           items:
-                            description: EndpointAddress is a tuple that describes single IP address.
+                            description: EndpointAddress is a tuple that describes
+                              single IP address.
                             properties:
                               hostname:
                                 description: The Hostname of this endpoint
                                 type: string
                               ip:
-                                description: 'The IP of this endpoint. May not be loopback (127.0.0.0/8), link-local (169.254.0.0/16), or link-local multicast ((224.0.0.0/24). IPv6 is also accepted but not fully supported on all platforms. Also, certain kubernetes components, like kube-proxy, are not IPv6 ready. TODO: This should allow hostname or IP, See #4447.'
+                                description: 'The IP of this endpoint. May not be
+                                  loopback (127.0.0.0/8), link-local (169.254.0.0/16),
+                                  or link-local multicast ((224.0.0.0/24). IPv6 is
+                                  also accepted but not fully supported on all platforms.
+                                  Also, certain kubernetes components, like kube-proxy,
+                                  are not IPv6 ready. TODO: This should allow hostname
+                                  or IP, See #4447.'
                                 type: string
                               nodeName:
-                                description: 'Optional: Node hosting this endpoint. This can be used to determine endpoints local to a node.'
+                                description: 'Optional: Node hosting this endpoint.
+                                  This can be used to determine endpoints local to
+                                  a node.'
                                 type: string
                               targetRef:
                                 description: Reference to object providing the endpoint.
@@ -408,22 +495,41 @@ spec:
                                     description: API version of the referent.
                                     type: string
                                   fieldPath:
-                                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                                    description: 'If referring to a piece of an object
+                                      instead of an entire object, this string should
+                                      contain a valid JSON/Go field access statement,
+                                      such as desiredState.manifest.containers[2].
+                                      For example, if the object reference is to a
+                                      container within a pod, this would take on a
+                                      value like: "spec.containers{name}" (where "name"
+                                      refers to the name of the container that triggered
+                                      the event) or if no container name is specified
+                                      "spec.containers[2]" (container with index 2
+                                      in this pod). This syntax is chosen only to
+                                      have some well-defined way of referencing a
+                                      part of an object. TODO: this design is not
+                                      final and this field is subject to change in
+                                      the future.'
                                     type: string
                                   kind:
-                                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                    description: 'Kind of the referent. More info:
+                                      https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                   namespace:
-                                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                    description: 'Namespace of the referent. More
+                                      info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                                     type: string
                                   resourceVersion:
-                                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                    description: 'Specific resourceVersion to which
+                                      this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                                     type: string
                                   uid:
-                                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                    description: 'UID of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                                     type: string
                                 type: object
                             required:
@@ -433,13 +539,24 @@ spec:
                         ports:
                           description: Port numbers available on the related IP addresses.
                           items:
-                            description: EndpointPort is a tuple that describes a single port.
+                            description: EndpointPort is a tuple that describes a
+                              single port.
                             properties:
                               appProtocol:
-                                description: The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol. This is a beta field that is guarded by the ServiceAppProtocol feature gate and enabled by default.
+                                description: The application protocol for this port.
+                                  This field follows standard Kubernetes label syntax.
+                                  Un-prefixed names are reserved for IANA standard
+                                  service names (as per RFC-6335 and http://www.iana.org/assignments/service-names).
+                                  Non-standard protocols should use prefixed names
+                                  such as mycompany.com/my-custom-protocol. This is
+                                  a beta field that is guarded by the ServiceAppProtocol
+                                  feature gate and enabled by default.
                                 type: string
                               name:
-                                description: The name of this port.  This must match the 'name' field in the corresponding ServicePort. Must be a DNS_LABEL. Optional only if one port is defined.
+                                description: The name of this port.  This must match
+                                  the 'name' field in the corresponding ServicePort.
+                                  Must be a DNS_LABEL. Optional only if one port is
+                                  defined.
                                 type: string
                               port:
                                 description: The port number of the endpoint.
@@ -447,7 +564,8 @@ spec:
                                 type: integer
                               protocol:
                                 default: TCP
-                                description: The IP protocol for this port. Must be UDP, TCP, or SCTP. Default is TCP.
+                                description: The IP protocol for this port. Must be
+                                  UDP, TCP, or SCTP. Default is TCP.
                                 type: string
                             required:
                             - port
@@ -460,28 +578,35 @@ spec:
                 description: If exported resource is ExternalEntity.
                 properties:
                   externalentityspec:
-                    description: ExternalEntitySpec defines the desired state for ExternalEntity.
+                    description: ExternalEntitySpec defines the desired state for
+                      ExternalEntity.
                     properties:
                       endpoints:
-                        description: Endpoints is a list of external endpoints associated with this entity.
+                        description: Endpoints is a list of external endpoints associated
+                          with this entity.
                         items:
-                          description: Endpoint refers to an endpoint associated with the ExternalEntity.
+                          description: Endpoint refers to an endpoint associated with
+                            the ExternalEntity.
                           properties:
                             ip:
                               description: IP associated with this endpoint.
                               type: string
                             name:
-                              description: Name identifies this endpoint. Could be the network interface name in case of VMs.
+                              description: Name identifies this endpoint. Could be
+                                the network interface name in case of VMs.
                               type: string
                           type: object
                         type: array
                       externalNode:
-                        description: ExternalNode is the opaque identifier of the agent/controller responsible for additional processing or handling of this external entity.
+                        description: ExternalNode is the opaque identifier of the
+                          agent/controller responsible for additional processing or
+                          handling of this external entity.
                         type: string
                       ports:
                         description: Ports maintain the list of named ports.
                         items:
-                          description: NamedPort describes the port and protocol to match in a rule.
+                          description: NamedPort describes the port and protocol to
+                            match in a rule.
                           properties:
                             name:
                               description: Name associated with the Port.
@@ -492,7 +617,9 @@ spec:
                               type: integer
                             protocol:
                               default: TCP
-                              description: The protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this field defaults to TCP.
+                              description: The protocol (TCP, UDP, or SCTP) which
+                                traffic must match. If not specified, this field defaults
+                                to TCP.
                               type: string
                           type: object
                         type: array
@@ -518,72 +645,231 @@ spec:
                 description: If exported resource is Service.
                 properties:
                   serviceSpec:
-                    description: ServiceSpec describes the attributes that a user creates on a service.
+                    description: ServiceSpec describes the attributes that a user
+                      creates on a service.
                     properties:
                       allocateLoadBalancerNodePorts:
-                        description: allocateLoadBalancerNodePorts defines if NodePorts will be automatically allocated for services with type LoadBalancer.  Default is "true". It may be set to "false" if the cluster load-balancer does not rely on NodePorts. allocateLoadBalancerNodePorts may only be set for services with type LoadBalancer and will be cleared if the type is changed to any other type. This field is alpha-level and is only honored by servers that enable the ServiceLBNodePortControl feature.
+                        description: allocateLoadBalancerNodePorts defines if NodePorts
+                          will be automatically allocated for services with type LoadBalancer.  Default
+                          is "true". It may be set to "false" if the cluster load-balancer
+                          does not rely on NodePorts. allocateLoadBalancerNodePorts
+                          may only be set for services with type LoadBalancer and
+                          will be cleared if the type is changed to any other type.
+                          This field is alpha-level and is only honored by servers
+                          that enable the ServiceLBNodePortControl feature.
                         type: boolean
                       clusterIP:
-                        description: 'clusterIP is the IP address of the service and is usually assigned randomly. If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be blank) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are "None", empty string (""), or a valid IP address. Setting this to "None" makes a "headless service" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                        description: 'clusterIP is the IP address of the service and
+                          is usually assigned randomly. If an address is specified
+                          manually, is in-range (as per system configuration), and
+                          is not in use, it will be allocated to the service; otherwise
+                          creation of the service will fail. This field may not be
+                          changed through updates unless the type field is also being
+                          changed to ExternalName (which requires this field to be
+                          blank) or the type field is being changed from ExternalName
+                          (in which case this field may optionally be specified, as
+                          describe above).  Valid values are "None", empty string
+                          (""), or a valid IP address. Setting this to "None" makes
+                          a "headless service" (no virtual IP), which is useful when
+                          direct endpoint connections are preferred and proxying is
+                          not required.  Only applies to types ClusterIP, NodePort,
+                          and LoadBalancer. If this field is specified when creating
+                          a Service of type ExternalName, creation will fail. This
+                          field will be wiped when updating a Service to type ExternalName.
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
                         type: string
                       clusterIPs:
-                        description: "ClusterIPs is a list of IP addresses assigned to this service, and are usually assigned randomly.  If an address is specified manually, is in-range (as per system configuration), and is not in use, it will be allocated to the service; otherwise creation of the service will fail. This field may not be changed through updates unless the type field is also being changed to ExternalName (which requires this field to be empty) or the type field is being changed from ExternalName (in which case this field may optionally be specified, as describe above).  Valid values are \"None\", empty string (\"\"), or a valid IP address.  Setting this to \"None\" makes a \"headless service\" (no virtual IP), which is useful when direct endpoint connections are preferred and proxying is not required.  Only applies to types ClusterIP, NodePort, and LoadBalancer. If this field is specified when creating a Service of type ExternalName, creation will fail. This field will be wiped when updating a Service to type ExternalName.  If this field is not specified, it will be initialized from the clusterIP field.  If this field is specified, clients must ensure that clusterIPs[0] and clusterIP have the same value. \n Unless the \"IPv6DualStack\" feature gate is enabled, this field is limited to one value, which must be the same as the clusterIP field.  If the feature gate is enabled, this field may hold a maximum of two entries (dual-stack IPs, in either order).  These IPs must correspond to the values of the ipFamilies field. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies"
+                        description: "ClusterIPs is a list of IP addresses assigned
+                          to this service, and are usually assigned randomly.  If
+                          an address is specified manually, is in-range (as per system
+                          configuration), and is not in use, it will be allocated
+                          to the service; otherwise creation of the service will fail.
+                          This field may not be changed through updates unless the
+                          type field is also being changed to ExternalName (which
+                          requires this field to be empty) or the type field is being
+                          changed from ExternalName (in which case this field may
+                          optionally be specified, as describe above).  Valid values
+                          are \"None\", empty string (\"\"), or a valid IP address.
+                          \ Setting this to \"None\" makes a \"headless service\"
+                          (no virtual IP), which is useful when direct endpoint connections
+                          are preferred and proxying is not required.  Only applies
+                          to types ClusterIP, NodePort, and LoadBalancer. If this
+                          field is specified when creating a Service of type ExternalName,
+                          creation will fail. This field will be wiped when updating
+                          a Service to type ExternalName.  If this field is not specified,
+                          it will be initialized from the clusterIP field.  If this
+                          field is specified, clients must ensure that clusterIPs[0]
+                          and clusterIP have the same value. \n Unless the \"IPv6DualStack\"
+                          feature gate is enabled, this field is limited to one value,
+                          which must be the same as the clusterIP field.  If the feature
+                          gate is enabled, this field may hold a maximum of two entries
+                          (dual-stack IPs, in either order).  These IPs must correspond
+                          to the values of the ipFamilies field. Both clusterIPs and
+                          ipFamilies are governed by the ipFamilyPolicy field. More
+                          info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies"
                         items:
                           type: string
                         type: array
                         x-kubernetes-list-type: atomic
                       externalIPs:
-                        description: externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service.  These IPs are not managed by Kubernetes.  The user is responsible for ensuring that traffic arrives at a node with this IP.  A common example is external load-balancers that are not part of the Kubernetes system.
+                        description: externalIPs is a list of IP addresses for which
+                          nodes in the cluster will also accept traffic for this service.  These
+                          IPs are not managed by Kubernetes.  The user is responsible
+                          for ensuring that traffic arrives at a node with this IP.  A
+                          common example is external load-balancers that are not part
+                          of the Kubernetes system.
                         items:
                           type: string
                         type: array
                       externalName:
-                        description: externalName is the external reference that discovery mechanisms will return as an alias for this service (e.g. a DNS CNAME record). No proxying will be involved.  Must be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123) and requires `type` to be "ExternalName".
+                        description: externalName is the external reference that discovery
+                          mechanisms will return as an alias for this service (e.g.
+                          a DNS CNAME record). No proxying will be involved.  Must
+                          be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123)
+                          and requires `type` to be "ExternalName".
                         type: string
                       externalTrafficPolicy:
-                        description: externalTrafficPolicy denotes if this Service desires to route external traffic to node-local or cluster-wide endpoints. "Local" preserves the client source IP and avoids a second hop for LoadBalancer and Nodeport type services, but risks potentially imbalanced traffic spreading. "Cluster" obscures the client source IP and may cause a second hop to another node, but should have good overall load-spreading.
+                        description: externalTrafficPolicy denotes if this Service
+                          desires to route external traffic to node-local or cluster-wide
+                          endpoints. "Local" preserves the client source IP and avoids
+                          a second hop for LoadBalancer and Nodeport type services,
+                          but risks potentially imbalanced traffic spreading. "Cluster"
+                          obscures the client source IP and may cause a second hop
+                          to another node, but should have good overall load-spreading.
                         type: string
                       healthCheckNodePort:
-                        description: healthCheckNodePort specifies the healthcheck nodePort for the service. This only applies when type is set to LoadBalancer and externalTrafficPolicy is set to Local. If a value is specified, is in-range, and is not in use, it will be used.  If not specified, a value will be automatically allocated.  External systems (e.g. load-balancers) can use this port to determine if a given node holds endpoints for this service or not.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type).
+                        description: healthCheckNodePort specifies the healthcheck
+                          nodePort for the service. This only applies when type is
+                          set to LoadBalancer and externalTrafficPolicy is set to
+                          Local. If a value is specified, is in-range, and is not
+                          in use, it will be used.  If not specified, a value will
+                          be automatically allocated.  External systems (e.g. load-balancers)
+                          can use this port to determine if a given node holds endpoints
+                          for this service or not.  If this field is specified when
+                          creating a Service which does not need it, creation will
+                          fail. This field will be wiped when updating a Service to
+                          no longer need it (e.g. changing type).
                         format: int32
                         type: integer
                       internalTrafficPolicy:
-                        description: InternalTrafficPolicy specifies if the cluster internal traffic should be routed to all endpoints or node-local endpoints only. "Cluster" routes internal traffic to a Service to all endpoints. "Local" routes traffic to node-local endpoints only, traffic is dropped if no node-local endpoints are ready. The default value is "Cluster".
+                        description: InternalTrafficPolicy specifies if the cluster
+                          internal traffic should be routed to all endpoints or node-local
+                          endpoints only. "Cluster" routes internal traffic to a Service
+                          to all endpoints. "Local" routes traffic to node-local endpoints
+                          only, traffic is dropped if no node-local endpoints are
+                          ready. The default value is "Cluster".
                         type: string
                       ipFamilies:
-                        description: "IPFamilies is a list of IP families (e.g. IPv4, IPv6) assigned to this service, and is gated by the \"IPv6DualStack\" feature gate.  This field is usually assigned automatically based on cluster configuration and the ipFamilyPolicy field. If this field is specified manually, the requested family is available in the cluster, and ipFamilyPolicy allows it, it will be used; otherwise creation of the service will fail.  This field is conditionally mutable: it allows for adding or removing a secondary IP family, but it does not allow changing the primary IP family of the Service.  Valid values are \"IPv4\" and \"IPv6\".  This field only applies to Services of types ClusterIP, NodePort, and LoadBalancer, and does apply to \"headless\" services.  This field will be wiped when updating a Service to type ExternalName. \n This field may hold a maximum of two entries (dual-stack families, in either order).  These families must correspond to the values of the clusterIPs field, if specified. Both clusterIPs and ipFamilies are governed by the ipFamilyPolicy field."
+                        description: "IPFamilies is a list of IP families (e.g. IPv4,
+                          IPv6) assigned to this service, and is gated by the \"IPv6DualStack\"
+                          feature gate.  This field is usually assigned automatically
+                          based on cluster configuration and the ipFamilyPolicy field.
+                          If this field is specified manually, the requested family
+                          is available in the cluster, and ipFamilyPolicy allows it,
+                          it will be used; otherwise creation of the service will
+                          fail.  This field is conditionally mutable: it allows for
+                          adding or removing a secondary IP family, but it does not
+                          allow changing the primary IP family of the Service.  Valid
+                          values are \"IPv4\" and \"IPv6\".  This field only applies
+                          to Services of types ClusterIP, NodePort, and LoadBalancer,
+                          and does apply to \"headless\" services.  This field will
+                          be wiped when updating a Service to type ExternalName. \n
+                          This field may hold a maximum of two entries (dual-stack
+                          families, in either order).  These families must correspond
+                          to the values of the clusterIPs field, if specified. Both
+                          clusterIPs and ipFamilies are governed by the ipFamilyPolicy
+                          field."
                         items:
-                          description: IPFamily represents the IP Family (IPv4 or IPv6). This type is used to express the family of an IP expressed by a type (e.g. service.spec.ipFamilies).
+                          description: IPFamily represents the IP Family (IPv4 or
+                            IPv6). This type is used to express the family of an IP
+                            expressed by a type (e.g. service.spec.ipFamilies).
                           type: string
                         type: array
                         x-kubernetes-list-type: atomic
                       ipFamilyPolicy:
-                        description: IPFamilyPolicy represents the dual-stack-ness requested or required by this Service, and is gated by the "IPv6DualStack" feature gate.  If there is no value provided, then this field will be set to SingleStack. Services can be "SingleStack" (a single IP family), "PreferDualStack" (two IP families on dual-stack configured clusters or a single IP family on single-stack clusters), or "RequireDualStack" (two IP families on dual-stack configured clusters, otherwise fail). The ipFamilies and clusterIPs fields depend on the value of this field.  This field will be wiped when updating a service to type ExternalName.
+                        description: IPFamilyPolicy represents the dual-stack-ness
+                          requested or required by this Service, and is gated by the
+                          "IPv6DualStack" feature gate.  If there is no value provided,
+                          then this field will be set to SingleStack. Services can
+                          be "SingleStack" (a single IP family), "PreferDualStack"
+                          (two IP families on dual-stack configured clusters or a
+                          single IP family on single-stack clusters), or "RequireDualStack"
+                          (two IP families on dual-stack configured clusters, otherwise
+                          fail). The ipFamilies and clusterIPs fields depend on the
+                          value of this field.  This field will be wiped when updating
+                          a service to type ExternalName.
                         type: string
                       loadBalancerClass:
-                        description: loadBalancerClass is the class of the load balancer implementation this Service belongs to. If specified, the value of this field must be a label-style identifier, with an optional prefix, e.g. "internal-vip" or "example.com/internal-vip". Unprefixed names are reserved for end-users. This field can only be set when the Service type is 'LoadBalancer'. If not set, the default load balancer implementation is used, today this is typically done through the cloud provider integration, but should apply for any default implementation. If set, it is assumed that a load balancer implementation is watching for Services with a matching class. Any default load balancer implementation (e.g. cloud providers) should ignore Services that set this field. This field can only be set when creating or updating a Service to type 'LoadBalancer'. Once set, it can not be changed. This field will be wiped when a service is updated to a non 'LoadBalancer' type.
+                        description: loadBalancerClass is the class of the load balancer
+                          implementation this Service belongs to. If specified, the
+                          value of this field must be a label-style identifier, with
+                          an optional prefix, e.g. "internal-vip" or "example.com/internal-vip".
+                          Unprefixed names are reserved for end-users. This field
+                          can only be set when the Service type is 'LoadBalancer'.
+                          If not set, the default load balancer implementation is
+                          used, today this is typically done through the cloud provider
+                          integration, but should apply for any default implementation.
+                          If set, it is assumed that a load balancer implementation
+                          is watching for Services with a matching class. Any default
+                          load balancer implementation (e.g. cloud providers) should
+                          ignore Services that set this field. This field can only
+                          be set when creating or updating a Service to type 'LoadBalancer'.
+                          Once set, it can not be changed. This field will be wiped
+                          when a service is updated to a non 'LoadBalancer' type.
                         type: string
                       loadBalancerIP:
-                        description: 'Only applies to Service Type: LoadBalancer LoadBalancer will get created with the IP specified in this field. This feature depends on whether the underlying cloud-provider supports specifying the loadBalancerIP when a load balancer is created. This field will be ignored if the cloud-provider does not support the feature.'
+                        description: 'Only applies to Service Type: LoadBalancer LoadBalancer
+                          will get created with the IP specified in this field. This
+                          feature depends on whether the underlying cloud-provider
+                          supports specifying the loadBalancerIP when a load balancer
+                          is created. This field will be ignored if the cloud-provider
+                          does not support the feature.'
                         type: string
                       loadBalancerSourceRanges:
-                        description: 'If specified and supported by the platform, this will restrict traffic through the cloud-provider load-balancer will be restricted to the specified client IPs. This field will be ignored if the cloud-provider does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+                        description: 'If specified and supported by the platform,
+                          this will restrict traffic through the cloud-provider load-balancer
+                          will be restricted to the specified client IPs. This field
+                          will be ignored if the cloud-provider does not support the
+                          feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
                         items:
                           type: string
                         type: array
                       ports:
-                        description: 'The list of ports that are exposed by this service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                        description: 'The list of ports that are exposed by this service.
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
                         items:
-                          description: ServicePort contains information on service's port.
+                          description: ServicePort contains information on service's
+                            port.
                           properties:
                             appProtocol:
-                              description: The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol. This is a beta field that is guarded by the ServiceAppProtocol feature gate and enabled by default.
+                              description: The application protocol for this port.
+                                This field follows standard Kubernetes label syntax.
+                                Un-prefixed names are reserved for IANA standard service
+                                names (as per RFC-6335 and http://www.iana.org/assignments/service-names).
+                                Non-standard protocols should use prefixed names such
+                                as mycompany.com/my-custom-protocol. This is a beta
+                                field that is guarded by the ServiceAppProtocol feature
+                                gate and enabled by default.
                               type: string
                             name:
-                              description: The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.
+                              description: The name of this port within the service.
+                                This must be a DNS_LABEL. All ports within a ServiceSpec
+                                must have unique names. When considering the endpoints
+                                for a Service, this must match the 'name' field in
+                                the EndpointPort. Optional if only one ServicePort
+                                is defined on this service.
                               type: string
                             nodePort:
-                              description: 'The port on each node on which this service is exposed when type is NodePort or LoadBalancer.  Usually assigned by the system. If a value is specified, in-range, and not in use it will be used, otherwise the operation will fail.  If not specified, a port will be allocated if this Service requires one.  If this field is specified when creating a Service which does not need it, creation will fail. This field will be wiped when updating a Service to no longer need it (e.g. changing type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                              description: 'The port on each node on which this service
+                                is exposed when type is NodePort or LoadBalancer.  Usually
+                                assigned by the system. If a value is specified, in-range,
+                                and not in use it will be used, otherwise the operation
+                                will fail.  If not specified, a port will be allocated
+                                if this Service requires one.  If this field is specified
+                                when creating a Service which does not need it, creation
+                                will fail. This field will be wiped when updating
+                                a Service to no longer need it (e.g. changing type
+                                from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
                               format: int32
                               type: integer
                             port:
@@ -592,13 +878,22 @@ spec:
                               type: integer
                             protocol:
                               default: TCP
-                              description: The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
+                              description: The IP protocol for this port. Supports
+                                "TCP", "UDP", and "SCTP". Default is TCP.
                               type: string
                             targetPort:
                               anyOf:
                               - type: integer
                               - type: string
-                              description: 'Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod''s container ports. If this is not specified, the value of the ''port'' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                              description: 'Number or name of the port to access on
+                                the pods targeted by the service. Number must be in
+                                the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                If this is a string, it will be looked up as a named
+                                port in the target Pod''s container ports. If this
+                                is not specified, the value of the ''port'' field
+                                is used (an identity map). This field is ignored for
+                                services with clusterIP=None, and should be omitted
+                                or set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
                               x-kubernetes-int-or-string: true
                           required:
                           - port
@@ -609,35 +904,87 @@ spec:
                         - protocol
                         x-kubernetes-list-type: map
                       publishNotReadyAddresses:
-                        description: publishNotReadyAddresses indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready. The primary use case for setting this field is for a StatefulSet's Headless Service to propagate SRV DNS records for its Pods for the purpose of peer discovery. The Kubernetes controllers that generate Endpoints and EndpointSlice resources for Services interpret this to mean that all endpoints are considered "ready" even if the Pods themselves are not. Agents which consume only Kubernetes generated endpoints through the Endpoints or EndpointSlice resources can safely assume this behavior.
+                        description: publishNotReadyAddresses indicates that any agent
+                          which deals with endpoints for this Service should disregard
+                          any indications of ready/not-ready. The primary use case
+                          for setting this field is for a StatefulSet's Headless Service
+                          to propagate SRV DNS records for its Pods for the purpose
+                          of peer discovery. The Kubernetes controllers that generate
+                          Endpoints and EndpointSlice resources for Services interpret
+                          this to mean that all endpoints are considered "ready" even
+                          if the Pods themselves are not. Agents which consume only
+                          Kubernetes generated endpoints through the Endpoints or
+                          EndpointSlice resources can safely assume this behavior.
                         type: boolean
                       selector:
                         additionalProperties:
                           type: string
-                        description: 'Route service traffic to pods with label keys and values matching this selector. If empty or not present, the service is assumed to have an external process managing its endpoints, which Kubernetes will not modify. Only applies to types ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                        description: 'Route service traffic to pods with label keys
+                          and values matching this selector. If empty or not present,
+                          the service is assumed to have an external process managing
+                          its endpoints, which Kubernetes will not modify. Only applies
+                          to types ClusterIP, NodePort, and LoadBalancer. Ignored
+                          if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
                         type: object
                       sessionAffinity:
-                        description: 'Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                        description: 'Supports "ClientIP" and "None". Used to maintain
+                          session affinity. Enable client IP based session affinity.
+                          Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
                         type: string
                       sessionAffinityConfig:
-                        description: sessionAffinityConfig contains the configurations of session affinity.
+                        description: sessionAffinityConfig contains the configurations
+                          of session affinity.
                         properties:
                           clientIP:
-                            description: clientIP contains the configurations of Client IP based session affinity.
+                            description: clientIP contains the configurations of Client
+                              IP based session affinity.
                             properties:
                               timeoutSeconds:
-                                description: timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP". Default value is 10800(for 3 hours).
+                                description: timeoutSeconds specifies the seconds
+                                  of ClientIP type session sticky time. The value
+                                  must be >0 && <=86400(for 1 day) if ServiceAffinity
+                                  == "ClientIP". Default value is 10800(for 3 hours).
                                 format: int32
                                 type: integer
                             type: object
                         type: object
                       topologyKeys:
-                        description: topologyKeys is a preference-order list of topology keys which implementations of services should use to preferentially sort endpoints when accessing this Service, it can not be used at the same time as externalTrafficPolicy=Local. Topology keys must be valid label keys and at most 16 keys may be specified. Endpoints are chosen based on the first topology key with available backends. If this field is specified and all entries have no backends that match the topology of the client, the service has no backends for that client and connections should fail. The special value "*" may be used to mean "any topology". This catch-all value, if used, only makes sense as the last value in the list. If this is not specified or empty, no topology constraints will be applied. This field is alpha-level and is only honored by servers that enable the ServiceTopology feature. This field is deprecated and will be removed in a future version.
+                        description: topologyKeys is a preference-order list of topology
+                          keys which implementations of services should use to preferentially
+                          sort endpoints when accessing this Service, it can not be
+                          used at the same time as externalTrafficPolicy=Local. Topology
+                          keys must be valid label keys and at most 16 keys may be
+                          specified. Endpoints are chosen based on the first topology
+                          key with available backends. If this field is specified
+                          and all entries have no backends that match the topology
+                          of the client, the service has no backends for that client
+                          and connections should fail. The special value "*" may be
+                          used to mean "any topology". This catch-all value, if used,
+                          only makes sense as the last value in the list. If this
+                          is not specified or empty, no topology constraints will
+                          be applied. This field is alpha-level and is only honored
+                          by servers that enable the ServiceTopology feature. This
+                          field is deprecated and will be removed in a future version.
                         items:
                           type: string
                         type: array
                       type:
-                        description: 'type determines how the Service is exposed. Defaults to ClusterIP. Valid options are ExternalName, ClusterIP, NodePort, and LoadBalancer. "ClusterIP" allocates a cluster-internal IP address for load-balancing to endpoints. Endpoints are determined by the selector or if that is not specified, by manual construction of an Endpoints object or EndpointSlice objects. If clusterIP is "None", no virtual IP is allocated and the endpoints are published as a set of endpoints rather than a virtual IP. "NodePort" builds on ClusterIP and allocates a port on every node which routes to the same endpoints as the clusterIP. "LoadBalancer" builds on NodePort and creates an external load-balancer (if supported in the current cloud) which routes to the same endpoints as the clusterIP. "ExternalName" aliases this service to the specified externalName. Several other fields do not apply to ExternalName services. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                        description: 'type determines how the Service is exposed.
+                          Defaults to ClusterIP. Valid options are ExternalName, ClusterIP,
+                          NodePort, and LoadBalancer. "ClusterIP" allocates a cluster-internal
+                          IP address for load-balancing to endpoints. Endpoints are
+                          determined by the selector or if that is not specified,
+                          by manual construction of an Endpoints object or EndpointSlice
+                          objects. If clusterIP is "None", no virtual IP is allocated
+                          and the endpoints are published as a set of endpoints rather
+                          than a virtual IP. "NodePort" builds on ClusterIP and allocates
+                          a port on every node which routes to the same endpoints
+                          as the clusterIP. "LoadBalancer" builds on NodePort and
+                          creates an external load-balancer (if supported in the current
+                          cloud) which routes to the same endpoints as the clusterIP.
+                          "ExternalName" aliases this service to the specified externalName.
+                          Several other fields do not apply to ExternalName services.
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
                         type: string
                     type: object
                 type: object
@@ -647,17 +994,21 @@ spec:
             properties:
               conditions:
                 items:
-                  description: ResourceExportCondition indicates the readiness condition of the ResourceExport.
+                  description: ResourceExportCondition indicates the readiness condition
+                    of the ResourceExport.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transited from one status to another.
+                      description: Last time the condition transited from one status
+                        to another.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about the transition.
+                      description: A human readable message indicating details about
+                        the transition.
                       type: string
                     reason:
-                      description: Unique, one-word, CamelCase reason for the condition's last transition.
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition.
                       type: string
                     status:
                       description: Status of the condition, one of True, False, Unknown.
@@ -700,13 +1051,18 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ResourceImportFilter is the Schema for the ResourceImportFilters API
+        description: ResourceImportFilter is the Schema for the ResourceImportFilters
+          API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -714,7 +1070,8 @@ spec:
             description: ResourceImportFilterSpec defines the desired state of ResourceImportFilter
             type: object
           status:
-            description: ResourceImportFilterStatus defines the observed state of ResourceImportFilter
+            description: ResourceImportFilterStatus defines the observed state of
+              ResourceImportFilter
             type: object
         type: object
     served: true
@@ -752,10 +1109,14 @@ spec:
         description: ResourceImport is the Schema for the resourceimports API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -763,7 +1124,8 @@ spec:
             description: ResourceImportSpec defines the desired state of ResourceImport.
             properties:
               clusterID:
-                description: ClusterIDs specifies the member clusters this resource to import to. When not specified, import to all member clusters.
+                description: ClusterIDs specifies the member clusters this resource
+                  to import to. When not specified, import to all member clusters.
                 items:
                   type: string
                 type: array
@@ -772,21 +1134,38 @@ spec:
                 properties:
                   subsets:
                     items:
-                      description: 'EndpointSubset is a group of addresses with a common set of ports. The expanded set of endpoints is the Cartesian product of Addresses x Ports. For example, given:   {     Addresses: [{"ip": "10.10.1.1"}, {"ip": "10.10.2.2"}],     Ports:     [{"name": "a", "port": 8675}, {"name": "b", "port": 309}]   } The resulting set of endpoints can be viewed as:     a: [ 10.10.1.1:8675, 10.10.2.2:8675 ],     b: [ 10.10.1.1:309, 10.10.2.2:309 ]'
+                      description: 'EndpointSubset is a group of addresses with a
+                        common set of ports. The expanded set of endpoints is the
+                        Cartesian product of Addresses x Ports. For example, given:   {     Addresses:
+                        [{"ip": "10.10.1.1"}, {"ip": "10.10.2.2"}],     Ports:     [{"name":
+                        "a", "port": 8675}, {"name": "b", "port": 309}]   } The resulting
+                        set of endpoints can be viewed as:     a: [ 10.10.1.1:8675,
+                        10.10.2.2:8675 ],     b: [ 10.10.1.1:309, 10.10.2.2:309 ]'
                       properties:
                         addresses:
-                          description: IP addresses which offer the related ports that are marked as ready. These endpoints should be considered safe for load balancers and clients to utilize.
+                          description: IP addresses which offer the related ports
+                            that are marked as ready. These endpoints should be considered
+                            safe for load balancers and clients to utilize.
                           items:
-                            description: EndpointAddress is a tuple that describes single IP address.
+                            description: EndpointAddress is a tuple that describes
+                              single IP address.
                             properties:
                               hostname:
                                 description: The Hostname of this endpoint
                                 type: string
                               ip:
-                                description: 'The IP of this endpoint. May not be loopback (127.0.0.0/8), link-local (169.254.0.0/16), or link-local multicast ((224.0.0.0/24). IPv6 is also accepted but not fully supported on all platforms. Also, certain kubernetes components, like kube-proxy, are not IPv6 ready. TODO: This should allow hostname or IP, See #4447.'
+                                description: 'The IP of this endpoint. May not be
+                                  loopback (127.0.0.0/8), link-local (169.254.0.0/16),
+                                  or link-local multicast ((224.0.0.0/24). IPv6 is
+                                  also accepted but not fully supported on all platforms.
+                                  Also, certain kubernetes components, like kube-proxy,
+                                  are not IPv6 ready. TODO: This should allow hostname
+                                  or IP, See #4447.'
                                 type: string
                               nodeName:
-                                description: 'Optional: Node hosting this endpoint. This can be used to determine endpoints local to a node.'
+                                description: 'Optional: Node hosting this endpoint.
+                                  This can be used to determine endpoints local to
+                                  a node.'
                                 type: string
                               targetRef:
                                 description: Reference to object providing the endpoint.
@@ -795,22 +1174,41 @@ spec:
                                     description: API version of the referent.
                                     type: string
                                   fieldPath:
-                                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                                    description: 'If referring to a piece of an object
+                                      instead of an entire object, this string should
+                                      contain a valid JSON/Go field access statement,
+                                      such as desiredState.manifest.containers[2].
+                                      For example, if the object reference is to a
+                                      container within a pod, this would take on a
+                                      value like: "spec.containers{name}" (where "name"
+                                      refers to the name of the container that triggered
+                                      the event) or if no container name is specified
+                                      "spec.containers[2]" (container with index 2
+                                      in this pod). This syntax is chosen only to
+                                      have some well-defined way of referencing a
+                                      part of an object. TODO: this design is not
+                                      final and this field is subject to change in
+                                      the future.'
                                     type: string
                                   kind:
-                                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                    description: 'Kind of the referent. More info:
+                                      https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                   namespace:
-                                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                    description: 'Namespace of the referent. More
+                                      info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                                     type: string
                                   resourceVersion:
-                                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                    description: 'Specific resourceVersion to which
+                                      this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                                     type: string
                                   uid:
-                                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                    description: 'UID of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                                     type: string
                                 type: object
                             required:
@@ -818,18 +1216,30 @@ spec:
                             type: object
                           type: array
                         notReadyAddresses:
-                          description: IP addresses which offer the related ports but are not currently marked as ready because they have not yet finished starting, have recently failed a readiness check, or have recently failed a liveness check.
+                          description: IP addresses which offer the related ports
+                            but are not currently marked as ready because they have
+                            not yet finished starting, have recently failed a readiness
+                            check, or have recently failed a liveness check.
                           items:
-                            description: EndpointAddress is a tuple that describes single IP address.
+                            description: EndpointAddress is a tuple that describes
+                              single IP address.
                             properties:
                               hostname:
                                 description: The Hostname of this endpoint
                                 type: string
                               ip:
-                                description: 'The IP of this endpoint. May not be loopback (127.0.0.0/8), link-local (169.254.0.0/16), or link-local multicast ((224.0.0.0/24). IPv6 is also accepted but not fully supported on all platforms. Also, certain kubernetes components, like kube-proxy, are not IPv6 ready. TODO: This should allow hostname or IP, See #4447.'
+                                description: 'The IP of this endpoint. May not be
+                                  loopback (127.0.0.0/8), link-local (169.254.0.0/16),
+                                  or link-local multicast ((224.0.0.0/24). IPv6 is
+                                  also accepted but not fully supported on all platforms.
+                                  Also, certain kubernetes components, like kube-proxy,
+                                  are not IPv6 ready. TODO: This should allow hostname
+                                  or IP, See #4447.'
                                 type: string
                               nodeName:
-                                description: 'Optional: Node hosting this endpoint. This can be used to determine endpoints local to a node.'
+                                description: 'Optional: Node hosting this endpoint.
+                                  This can be used to determine endpoints local to
+                                  a node.'
                                 type: string
                               targetRef:
                                 description: Reference to object providing the endpoint.
@@ -838,22 +1248,41 @@ spec:
                                     description: API version of the referent.
                                     type: string
                                   fieldPath:
-                                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                                    description: 'If referring to a piece of an object
+                                      instead of an entire object, this string should
+                                      contain a valid JSON/Go field access statement,
+                                      such as desiredState.manifest.containers[2].
+                                      For example, if the object reference is to a
+                                      container within a pod, this would take on a
+                                      value like: "spec.containers{name}" (where "name"
+                                      refers to the name of the container that triggered
+                                      the event) or if no container name is specified
+                                      "spec.containers[2]" (container with index 2
+                                      in this pod). This syntax is chosen only to
+                                      have some well-defined way of referencing a
+                                      part of an object. TODO: this design is not
+                                      final and this field is subject to change in
+                                      the future.'
                                     type: string
                                   kind:
-                                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                    description: 'Kind of the referent. More info:
+                                      https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                   namespace:
-                                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                    description: 'Namespace of the referent. More
+                                      info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                                     type: string
                                   resourceVersion:
-                                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                    description: 'Specific resourceVersion to which
+                                      this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                                     type: string
                                   uid:
-                                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                    description: 'UID of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                                     type: string
                                 type: object
                             required:
@@ -863,13 +1292,24 @@ spec:
                         ports:
                           description: Port numbers available on the related IP addresses.
                           items:
-                            description: EndpointPort is a tuple that describes a single port.
+                            description: EndpointPort is a tuple that describes a
+                              single port.
                             properties:
                               appProtocol:
-                                description: The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol. This is a beta field that is guarded by the ServiceAppProtocol feature gate and enabled by default.
+                                description: The application protocol for this port.
+                                  This field follows standard Kubernetes label syntax.
+                                  Un-prefixed names are reserved for IANA standard
+                                  service names (as per RFC-6335 and http://www.iana.org/assignments/service-names).
+                                  Non-standard protocols should use prefixed names
+                                  such as mycompany.com/my-custom-protocol. This is
+                                  a beta field that is guarded by the ServiceAppProtocol
+                                  feature gate and enabled by default.
                                 type: string
                               name:
-                                description: The name of this port.  This must match the 'name' field in the corresponding ServicePort. Must be a DNS_LABEL. Optional only if one port is defined.
+                                description: The name of this port.  This must match
+                                  the 'name' field in the corresponding ServicePort.
+                                  Must be a DNS_LABEL. Optional only if one port is
+                                  defined.
                                 type: string
                               port:
                                 description: The port number of the endpoint.
@@ -877,7 +1317,8 @@ spec:
                                 type: integer
                               protocol:
                                 default: TCP
-                                description: The IP protocol for this port. Must be UDP, TCP, or SCTP. Default is TCP.
+                                description: The IP protocol for this port. Must be
+                                  UDP, TCP, or SCTP. Default is TCP.
                                 type: string
                             required:
                             - port
@@ -890,28 +1331,35 @@ spec:
                 description: If imported resource is ExternalEntity.
                 properties:
                   externalentityspec:
-                    description: ExternalEntitySpec defines the desired state for ExternalEntity.
+                    description: ExternalEntitySpec defines the desired state for
+                      ExternalEntity.
                     properties:
                       endpoints:
-                        description: Endpoints is a list of external endpoints associated with this entity.
+                        description: Endpoints is a list of external endpoints associated
+                          with this entity.
                         items:
-                          description: Endpoint refers to an endpoint associated with the ExternalEntity.
+                          description: Endpoint refers to an endpoint associated with
+                            the ExternalEntity.
                           properties:
                             ip:
                               description: IP associated with this endpoint.
                               type: string
                             name:
-                              description: Name identifies this endpoint. Could be the network interface name in case of VMs.
+                              description: Name identifies this endpoint. Could be
+                                the network interface name in case of VMs.
                               type: string
                           type: object
                         type: array
                       externalNode:
-                        description: ExternalNode is the opaque identifier of the agent/controller responsible for additional processing or handling of this external entity.
+                        description: ExternalNode is the opaque identifier of the
+                          agent/controller responsible for additional processing or
+                          handling of this external entity.
                         type: string
                       ports:
                         description: Ports maintain the list of named ports.
                         items:
-                          description: NamedPort describes the port and protocol to match in a rule.
+                          description: NamedPort describes the port and protocol to
+                            match in a rule.
                           properties:
                             name:
                               description: Name associated with the Port.
@@ -922,7 +1370,9 @@ spec:
                               type: integer
                             protocol:
                               default: TCP
-                              description: The protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this field defaults to TCP.
+                              description: The protocol (TCP, UDP, or SCTP) which
+                                traffic must match. If not specified, this field defaults
+                                to TCP.
                               type: string
                           type: object
                         type: array
@@ -938,7 +1388,10 @@ spec:
                 description: Namespace of imported resource.
                 type: string
               raw:
-                description: 'If imported resource is ANP. TODO: ANP uses float64 as priority.  Type float64 is discouraged by k8s, and is not supported by controller-gen tools. NetworkPolicy *v1alpha1.NetworkPolicySpec `json:"networkpolicy,omitempty"` If imported resource Kind is unknown.'
+                description: 'If imported resource is ANP. TODO: ANP uses float64
+                  as priority.  Type float64 is discouraged by k8s, and is not supported
+                  by controller-gen tools. NetworkPolicy *v1alpha1.NetworkPolicySpec
+                  `json:"networkpolicy,omitempty"` If imported resource Kind is unknown.'
                 properties:
                   data:
                     format: byte
@@ -948,10 +1401,16 @@ spec:
                 description: If imported resource is ServiceImport.
                 properties:
                   apiVersion:
-                    description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    description: 'APIVersion defines the versioned schema of this
+                      representation of an object. Servers should convert recognized
+                      schemas to the latest internal value, and may reject unrecognized
+                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
                     type: string
                   kind:
-                    description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    description: 'Kind is a string value representing the REST resource
+                      this object represents. Servers may infer this from the endpoint
+                      the client submits requests to. Cannot be updated. In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                     type: string
                   metadata:
                     type: object
@@ -959,20 +1418,33 @@ spec:
                     description: spec defines the behavior of a ServiceImport.
                     properties:
                       ips:
-                        description: ip will be used as the VIP for this service when type is ClusterSetIP.
+                        description: ip will be used as the VIP for this service when
+                          type is ClusterSetIP.
                         items:
                           type: string
                         maxItems: 1
                         type: array
                       ports:
                         items:
-                          description: ServicePort represents the port on which the service is exposed
+                          description: ServicePort represents the port on which the
+                            service is exposed
                           properties:
                             appProtocol:
-                              description: The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol. Field can be enabled with ServiceAppProtocol feature gate.
+                              description: The application protocol for this port.
+                                This field follows standard Kubernetes label syntax.
+                                Un-prefixed names are reserved for IANA standard service
+                                names (as per RFC-6335 and http://www.iana.org/assignments/service-names).
+                                Non-standard protocols should use prefixed names such
+                                as mycompany.com/my-custom-protocol. Field can be
+                                enabled with ServiceAppProtocol feature gate.
                               type: string
                             name:
-                              description: The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.
+                              description: The name of this port within the service.
+                                This must be a DNS_LABEL. All ports within a ServiceSpec
+                                must have unique names. When considering the endpoints
+                                for a Service, this must match the 'name' field in
+                                the EndpointPort. Optional if only one ServicePort
+                                is defined on this service.
                               type: string
                             port:
                               description: The port that will be exposed by this service.
@@ -980,7 +1452,8 @@ spec:
                               type: integer
                             protocol:
                               default: TCP
-                              description: The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
+                              description: The IP protocol for this port. Supports
+                                "TCP", "UDP", and "SCTP". Default is TCP.
                               type: string
                           required:
                           - port
@@ -988,22 +1461,31 @@ spec:
                         type: array
                         x-kubernetes-list-type: atomic
                       sessionAffinity:
-                        description: 'Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. Ignored when type is Headless More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                        description: 'Supports "ClientIP" and "None". Used to maintain
+                          session affinity. Enable client IP based session affinity.
+                          Must be ClientIP or None. Defaults to None. Ignored when
+                          type is Headless More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
                         type: string
                       sessionAffinityConfig:
-                        description: sessionAffinityConfig contains session affinity configuration.
+                        description: sessionAffinityConfig contains session affinity
+                          configuration.
                         properties:
                           clientIP:
-                            description: clientIP contains the configurations of Client IP based session affinity.
+                            description: clientIP contains the configurations of Client
+                              IP based session affinity.
                             properties:
                               timeoutSeconds:
-                                description: timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP". Default value is 10800(for 3 hours).
+                                description: timeoutSeconds specifies the seconds
+                                  of ClientIP type session sticky time. The value
+                                  must be >0 && <=86400(for 1 day) if ServiceAffinity
+                                  == "ClientIP". Default value is 10800(for 3 hours).
                                 format: int32
                                 type: integer
                             type: object
                         type: object
                       type:
-                        description: type defines the type of this service. Must be ClusterSetIP or Headless.
+                        description: type defines the type of this service. Must be
+                          ClusterSetIP or Headless.
                         enum:
                         - ClusterSetIP
                         - Headless
@@ -1013,15 +1495,19 @@ spec:
                     - type
                     type: object
                   status:
-                    description: status contains information about the exported services that form the multi-cluster service referenced by this ServiceImport.
+                    description: status contains information about the exported services
+                      that form the multi-cluster service referenced by this ServiceImport.
                     properties:
                       clusters:
-                        description: clusters is the list of exporting clusters from which this service was derived.
+                        description: clusters is the list of exporting clusters from
+                          which this service was derived.
                         items:
-                          description: ClusterStatus contains service configuration mapped to a specific source cluster
+                          description: ClusterStatus contains service configuration
+                            mapped to a specific source cluster
                           properties:
                             cluster:
-                              description: cluster is the name of the exporting cluster. Must be a valid RFC-1123 DNS label.
+                              description: cluster is the name of the exporting cluster.
+                                Must be a valid RFC-1123 DNS label.
                               type: string
                           required:
                           - cluster
@@ -1038,27 +1524,33 @@ spec:
             properties:
               clusterStatuses:
                 items:
-                  description: ResourceImportClusterStatus indicates the readiness status of the ResourceImport in clusters.
+                  description: ResourceImportClusterStatus indicates the readiness
+                    status of the ResourceImport in clusters.
                   properties:
                     clusterID:
                       description: ClusterID is the unique identifier of this cluster.
                       type: string
                     conditions:
                       items:
-                        description: ResourceImportCondition indicates the condition of the ResourceImport in a cluster.
+                        description: ResourceImportCondition indicates the condition
+                          of the ResourceImport in a cluster.
                         properties:
                           lastTransitionTime:
-                            description: Last time the condition transited from one status to another.
+                            description: Last time the condition transited from one
+                              status to another.
                             format: date-time
                             type: string
                           message:
-                            description: A human readable message indicating details about the transition.
+                            description: A human readable message indicating details
+                              about the transition.
                             type: string
                           reason:
-                            description: Unique, one-word, CamelCase reason for the condition's last transition.
+                            description: Unique, one-word, CamelCase reason for the
+                              condition's last transition.
                             type: string
                           status:
-                            description: Status of the condition, one of True, False, Unknown.
+                            description: Status of the condition, one of True, False,
+                              Unknown.
                             type: string
                           type:
                             type: string
@@ -1102,38 +1594,68 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ServiceExport declares that the Service with the same name and namespace as this export should be consumable from other clusters.
+        description: ServiceExport declares that the Service with the same name and
+          namespace as this export should be consumable from other clusters.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           status:
-            description: status describes the current state of an exported service. Service configuration comes from the Service that had the same name and namespace as this ServiceExport. Populated by the multi-cluster service implementation's controller.
+            description: status describes the current state of an exported service.
+              Service configuration comes from the Service that had the same name
+              and namespace as this ServiceExport. Populated by the multi-cluster
+              service implementation's controller.
             properties:
               conditions:
                 items:
-                  description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    type FooStatus struct{     // Represents the observations of a
+                    foo's current state.     // Known .status.conditions.type are:
+                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
+                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
+                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                    \n     // other fields }"
                   properties:
                     lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
-                      description: message is a human readable message indicating details about the transition. This may be an empty string.
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
                       maxLength: 32768
                       type: string
                     observedGeneration:
-                      description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
-                      description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
                       maxLength: 1024
                       minLength: 1
                       pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
@@ -1146,7 +1668,11 @@ spec:
                       - Unknown
                       type: string
                     type:
-                      description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
                       maxLength: 316
                       pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
@@ -1199,13 +1725,18 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ServiceImport describes a service imported from clusters in a ClusterSet.
+        description: ServiceImport describes a service imported from clusters in a
+          ClusterSet.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -1213,27 +1744,39 @@ spec:
             description: spec defines the behavior of a ServiceImport.
             properties:
               ips:
-                description: ip will be used as the VIP for this service when type is ClusterSetIP.
+                description: ip will be used as the VIP for this service when type
+                  is ClusterSetIP.
                 items:
                   type: string
                 maxItems: 1
                 type: array
               ports:
                 items:
-                  description: ServicePort represents the port on which the service is exposed
+                  description: ServicePort represents the port on which the service
+                    is exposed
                   properties:
                     appProtocol:
-                      description: The application protocol for this port. This field follows standard Kubernetes label syntax. Un-prefixed names are reserved for IANA standard service names (as per RFC-6335 and http://www.iana.org/assignments/service-names). Non-standard protocols should use prefixed names such as mycompany.com/my-custom-protocol. Field can be enabled with ServiceAppProtocol feature gate.
+                      description: The application protocol for this port. This field
+                        follows standard Kubernetes label syntax. Un-prefixed names
+                        are reserved for IANA standard service names (as per RFC-6335
+                        and http://www.iana.org/assignments/service-names). Non-standard
+                        protocols should use prefixed names such as mycompany.com/my-custom-protocol.
+                        Field can be enabled with ServiceAppProtocol feature gate.
                       type: string
                     name:
-                      description: The name of this port within the service. This must be a DNS_LABEL. All ports within a ServiceSpec must have unique names. When considering the endpoints for a Service, this must match the 'name' field in the EndpointPort. Optional if only one ServicePort is defined on this service.
+                      description: The name of this port within the service. This
+                        must be a DNS_LABEL. All ports within a ServiceSpec must have
+                        unique names. When considering the endpoints for a Service,
+                        this must match the 'name' field in the EndpointPort. Optional
+                        if only one ServicePort is defined on this service.
                       type: string
                     port:
                       description: The port that will be exposed by this service.
                       format: int32
                       type: integer
                     protocol:
-                      description: The IP protocol for this port. Supports "TCP", "UDP", and "SCTP". Default is TCP.
+                      description: The IP protocol for this port. Supports "TCP",
+                        "UDP", and "SCTP". Default is TCP.
                       type: string
                   required:
                   - port
@@ -1241,22 +1784,30 @@ spec:
                 type: array
                 x-kubernetes-list-type: atomic
               sessionAffinity:
-                description: 'Supports "ClientIP" and "None". Used to maintain session affinity. Enable client IP based session affinity. Must be ClientIP or None. Defaults to None. Ignored when type is Headless More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                description: 'Supports "ClientIP" and "None". Used to maintain session
+                  affinity. Enable client IP based session affinity. Must be ClientIP
+                  or None. Defaults to None. Ignored when type is Headless More info:
+                  https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
                 type: string
               sessionAffinityConfig:
                 description: sessionAffinityConfig contains session affinity configuration.
                 properties:
                   clientIP:
-                    description: clientIP contains the configurations of Client IP based session affinity.
+                    description: clientIP contains the configurations of Client IP
+                      based session affinity.
                     properties:
                       timeoutSeconds:
-                        description: timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP". Default value is 10800(for 3 hours).
+                        description: timeoutSeconds specifies the seconds of ClientIP
+                          type session sticky time. The value must be >0 && <=86400(for
+                          1 day) if ServiceAffinity == "ClientIP". Default value is
+                          10800(for 3 hours).
                         format: int32
                         type: integer
                     type: object
                 type: object
               type:
-                description: type defines the type of this service. Must be ClusterSetIP or Headless.
+                description: type defines the type of this service. Must be ClusterSetIP
+                  or Headless.
                 enum:
                 - ClusterSetIP
                 - Headless
@@ -1266,15 +1817,19 @@ spec:
             - type
             type: object
           status:
-            description: status contains information about the exported services that form the multi-cluster service referenced by this ServiceImport.
+            description: status contains information about the exported services that
+              form the multi-cluster service referenced by this ServiceImport.
             properties:
               clusters:
-                description: clusters is the list of exporting clusters from which this service was derived.
+                description: clusters is the list of exporting clusters from which
+                  this service was derived.
                 items:
-                  description: ClusterStatus contains service configuration mapped to a specific source cluster
+                  description: ClusterStatus contains service configuration mapped
+                    to a specific source cluster
                   properties:
                     cluster:
-                      description: cluster is the name of the exporting cluster. Must be a valid RFC-1123 DNS label.
+                      description: cluster is the name of the exporting cluster. Must
+                        be a valid RFC-1123 DNS label.
                       type: string
                   required:
                   - cluster


### PR DESCRIPTION
This PR upgrades Kustomize from v3.8.8 to v4.4.1 to fix the fields-missing problem in Cronjob patching.

Signed-off-by: Yanjun Zhou <zhouya@vmware.com>