### PR TITLE
Fix e2e TestClusterGroup on kind flaky

### DIFF
--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/containernetworking/plugins/pkg/ip"
+	log "github.com/sirupsen/logrus"
 	"golang.org/x/mod/semver"
 	"gopkg.in/yaml.v2"
 	appsv1 "k8s.io/api/apps/v1"
@@ -622,6 +623,13 @@ func (data *TestData) deleteNamespace(namespace string, timeout time.Duration) e
 		GracePeriodSeconds: &gracePeriodSeconds,
 		PropagationPolicy:  &propagationPolicy,
 	}
+
+	// To log time statistics
+	startTime := time.Now()
+	defer func() {
+		log.Infof("Deleting Namespace %s took %v", namespace, time.Since(startTime))
+	}()
+
 	if err := data.clientset.CoreV1().Namespaces().Delete(context.TODO(), namespace, deleteOptions); err != nil {
 		if errors.IsNotFound(err) {
 			// namespace does not exist, we return right away

--- a/test/e2e/k8s_util.go
+++ b/test/e2e/k8s_util.go
@@ -941,7 +941,7 @@ func (k *KubernetesUtils) Cleanup(namespaces []string) {
 
 	for _, ns := range namespaces {
 		log.Infof("Deleting test Namespace %s", ns)
-		if err := k.clientset.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{}); err != nil {
+		if err := k.deleteNamespace(ns, defaultTimeout); err != nil {
 			log.Errorf("Error when deleting Namespace '%s': %v", ns, err)
 		}
 	}


### PR DESCRIPTION
Fixes #3387.

This PR adds a Poll to the deletion of namespace, that is done after
completion of a particular test. So, that the namespaces are deleted
completely and no content remains, so as to prevent race condition when
performing further test.