### PR TITLE
Fix deprecated kubectl exec commands

### DIFF
--- a/ci/jenkins/test-mc.sh
+++ b/ci/jenkins/test-mc.sh
@@ -128,7 +128,7 @@ function cleanup_multicluster_antrea {
     echo "====== Cleanup Antrea controller and agent ======"
     kubeconfig=$1
     kubectl get pod -n kube-system -l component=antrea-agent --no-headers=true $kubeconfig | awk '{print $1}' | while read AGENTNAME; do
-       kubectl exec $AGENTNAME -c antrea-agent -n kube-system ${kubeconfig}  ovs-vsctl del-port br-int gw0 || true
+       kubectl exec $AGENTNAME -c antrea-agent -n kube-system ${kubeconfig} -- ovs-vsctl del-port br-int gw0 || true
     done
 
    for antrea_yml in ${WORKDIR}/*.yml; do

--- a/docs/antctl.md
+++ b/docs/antctl.md
@@ -43,7 +43,7 @@ to connect to the Antrea Agent. Simply exec into the antrea-agent container for
 the appropriate antrea-agent Pod and run `antctl`:
 
 ```bash
-kubectl exec -it ANTREA-AGENT_POD_NAME -n kube-system -c antrea-agent bash
+kubectl exec -it ANTREA-AGENT_POD_NAME -n kube-system -c antrea-agent -- bash
 > antctl help
 ```
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -42,7 +42,7 @@ To check the OVS daemon logs (e.g. if the `antrea-ovs` container logs indicate
 that one of the OVS daemons generated an error), you can use `kubectl exec`:
 
 ```bash
-kubectl exec -n kube-system <antrea-agent Pod name> -c antrea-ovs tail /var/log/openvswitch/<DAEMON>.log
+kubectl exec -n kube-system <antrea-agent Pod name> -c antrea-ovs -- tail /var/log/openvswitch/<DAEMON>.log
 ```
 
 The `antrea-controller` Pod and the list of `antrea-agent` Pods, along with the
@@ -147,7 +147,7 @@ agent with this command:
 
 ```bash
 # Get into the antrea-agent container
-kubectl exec -it <antrea-agent Pod name> -n kube-system -c antrea-agent bash
+kubectl exec -it <antrea-agent Pod name> -n kube-system -c antrea-agent -- bash
 # View the agent's NetworkPolicy
 antctl get networkpolicy
 ```
@@ -223,7 +223,7 @@ command line tools (e.g. `ovs-vsctl`, `ovs-ofctl`, `ovs-appctl`) in the
 container, for example:
 
 ```bash
-kubectl exec -n kube-system <antrea-agent Pod name> -c antrea-ovs ovs-vsctl show
+kubectl exec -n kube-system <antrea-agent Pod name> -c antrea-ovs -- ovs-vsctl show
 ```
 
 By default the host directory `/var/run/antrea/openvswitch/` is mounted to


### PR DESCRIPTION
Fix below deprecated warning in case it's removed in the future.
```log
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
```

Signed-off-by: Lan Luo <luola@vmware.com>