### PR TITLE
Unconditionally sync CA cert for Controller webhooks

### DIFF
--- a/pkg/apiserver/certificate/cacert_controller.go
+++ b/pkg/apiserver/certificate/cacert_controller.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
 
-	"antrea.io/antrea/pkg/features"
 	"antrea.io/antrea/pkg/util/env"
 )
 
@@ -118,17 +117,16 @@ func (c *CACertController) syncCACert() error {
 		return err
 	}
 
-	if features.DefaultFeatureGate.Enabled(features.AntreaPolicy) {
-		if err := c.syncMutatingWebhooks(caCert); err != nil {
-			return err
-		}
-		if err := c.syncValidatingWebhooks(caCert); err != nil {
-			return err
-		}
-		if err := c.syncConversionWebhooks(caCert); err != nil {
-			return err
-		}
+	if err := c.syncMutatingWebhooks(caCert); err != nil {
+		return err
 	}
+	if err := c.syncValidatingWebhooks(caCert); err != nil {
+		return err
+	}
+	if err := c.syncConversionWebhooks(caCert); err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Webhooks are used by other features besided AntreaPolicy. At the moment,
if someone tries to disable AnteraPolicy and enable Egress for example,
the webhooks would not be using the correct CA cert and the Egress API
would not be usable.

Given that we unconditionally create these webhooks in the Antrea
deployment manifest, it makes sense to unconditionally sync the CA cert
for them.

Signed-off-by: Antonin Bas <abas@vmware.com>