### PR TITLE
Share test functions between e2e and multicluster e2e package

### DIFF
--- a/multicluster/test/e2e/fixtures.go
+++ b/multicluster/test/e2e/fixtures.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Antrea Authors
+// Copyright 2022 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ func createDirectory(path string) error {
 	return os.Mkdir(path, 0700)
 }
 
-func (data *TestData) setupLogDirectoryForTest(testName string) error {
+func (data *MCTestData) setupLogDirectoryForTest(testName string) error {
 	path := filepath.Join(testOptions.logsExportDir, testName)
 	// remove directory if it already exists. This ensures that we start with an empty
 	// directory
@@ -39,7 +39,7 @@ func (data *TestData) setupLogDirectoryForTest(testName string) error {
 	return nil
 }
 
-func setupTest(tb testing.TB) (*TestData, error) {
+func setupTest(tb testing.TB) (*MCTestData, error) {
 	if err := testData.setupLogDirectoryForTest(tb.Name()); err != nil {
 		tb.Errorf("Error creating logs directory '%s': %v", testData.logsDirForTestCase, err)
 		return nil, err
@@ -51,7 +51,7 @@ func setupTest(tb testing.TB) (*TestData, error) {
 		}
 	}()
 	tb.Logf("Creating '%s' K8s Namespace", multiClusterTestNamespace)
-	if err := testData.createTestNamespace(); err != nil {
+	if err := testData.createTestNamespaces(); err != nil {
 		return nil, err
 	}
 
@@ -59,13 +59,13 @@ func setupTest(tb testing.TB) (*TestData, error) {
 	return testData, nil
 }
 
-func teardownTest(tb testing.TB, data *TestData) {
+func teardownTest(tb testing.TB, data *MCTestData) {
 	if empty, _ := IsDirEmpty(data.logsDirForTestCase); empty {
 		_ = os.Remove(data.logsDirForTestCase)
 	}
 }
 
-func createPodWrapper(tb testing.TB, data *TestData, cluster string, namespace string, name string, image string, ctr string, command []string,
+func createPodWrapper(tb testing.TB, data *MCTestData, cluster string, namespace string, name string, image string, ctr string, command []string,
 	args []string, env []corev1.EnvVar, ports []corev1.ContainerPort, hostNetwork bool, mutateFunc func(pod *corev1.Pod)) error {
 	tb.Logf("Creating Pod '%s'", name)
 	if err := data.createPod(cluster, name, namespace, ctr, image, command, args, env, ports, hostNetwork, mutateFunc); err != nil {
@@ -79,14 +79,14 @@ func createPodWrapper(tb testing.TB, data *TestData, cluster string, namespace s
 	return err
 }
 
-func deletePodWrapper(tb testing.TB, data *TestData, clusterName string, namespace string, name string) {
+func deletePodWrapper(tb testing.TB, data *MCTestData, clusterName string, namespace string, name string) {
 	tb.Logf("Deleting Pod '%s'", name)
 	if err := data.deletePod(clusterName, namespace, name); err != nil {
 		tb.Logf("Error when deleting Pod: %v", err)
 	}
 }
 
-func deleteServiceWrapper(tb testing.TB, data *TestData, clusterName string, namespace string, name string) {
+func deleteServiceWrapper(tb testing.TB, data *MCTestData, clusterName string, namespace string, name string) {
 	tb.Logf("Deleting Service '%s'", name)
 	if err := data.deleteService(clusterName, namespace, name); err != nil {
 		tb.Logf("Error when deleting Service: %v", err)

--- a/multicluster/test/e2e/main_test.go
+++ b/multicluster/test/e2e/main_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Antrea Authors
+// Copyright 2022 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -65,21 +65,19 @@ func testMain(m *testing.M) int {
 	flag.StringVar(&testOptions.leaderClusterKubeConfigPath, "leader-cluster-kubeconfig-path", path.Join(homedir, ".kube", "leader"), "Kubeconfig Path of the leader cluster")
 	flag.StringVar(&testOptions.eastClusterKubeConfigPath, "east-cluster-kubeconfig-path", path.Join(homedir, ".kube", "east"), "Kubeconfig Path of the east cluster")
 	flag.StringVar(&testOptions.westClusterKubeConfigPath, "west-cluster-kubeconfig-path", path.Join(homedir, ".kube", "west"), "Kubeconfig Path of the west cluster")
-
 	flag.Parse()
-
-	if err := initProvider(); err != nil {
-		log.Fatalf("Error when initializing provider: %v", err)
-	}
 
 	cleanupLogging := testOptions.setupLogging()
 	defer cleanupLogging()
 
-	testData = &TestData{}
-	log.Println("Creating k8s clientsets")
+	testData = &MCTestData{}
+	log.Println("Creating K8s clientsets for ClusterSet")
 	if err := testData.createClients(); err != nil {
-		log.Fatalf("Error when creating k8s clientset: %v", err)
+		log.Fatalf("Error when creating K8s ClientSet: %v", err)
 		return 1
+	}
+	if err := testData.initProviders(); err != nil {
+		log.Fatalf("Error when initializing providers for ClusterSet: %v", err)
 	}
 	rand.Seed(time.Now().UnixNano())
 

--- a/test/e2e/antreaipam_test.go
+++ b/test/e2e/antreaipam_test.go
@@ -478,7 +478,7 @@ func checkStatefulSetIPPoolAllocation(tb testing.TB, data *TestData, name string
 
 func deleteAntreaIPAMNamespace(tb testing.TB, data *TestData, namespace string) {
 	tb.Logf("Deleting '%s' K8s Namespace", namespace)
-	if err := data.deleteNamespace(namespace, defaultTimeout); err != nil {
+	if err := data.DeleteNamespace(namespace, defaultTimeout); err != nil {
 		tb.Logf("Error when tearing down test: %v", err)
 	}
 }

--- a/test/e2e/antreapolicy_test.go
+++ b/test/e2e/antreapolicy_test.go
@@ -1912,7 +1912,7 @@ func testAuditLoggingBasic(t *testing.T, data *TestData) {
 	cmd := []string{"cat", logDir + logfileName}
 
 	if err := wait.Poll(1*time.Second, 10*time.Second, func() (bool, error) {
-		stdout, stderr, err := data.runCommandFromPod(antreaNamespace, antreaPodName, "antrea-agent", cmd)
+		stdout, stderr, err := data.RunCommandFromPod(antreaNamespace, antreaPodName, "antrea-agent", cmd)
 		if err != nil || stderr != "" {
 			// file may not exist yet
 			t.Logf("Error when printing the audit log file, err: %v, stderr: %v", err, stderr)
@@ -3360,11 +3360,11 @@ func testANPNetworkPolicyStatsWithDropAction(t *testing.T, data *TestData) {
 	// So we need to  "warm-up" the tunnel.
 	if clusterInfo.podV4NetworkCIDR != "" {
 		cmd := []string{"/bin/sh", "-c", fmt.Sprintf("nc -vz -w 4 %s 80", serverIPs.ipv4.String())}
-		data.runCommandFromPod(testNamespace, clientName, busyboxContainerName, cmd)
+		data.RunCommandFromPod(testNamespace, clientName, busyboxContainerName, cmd)
 	}
 	if clusterInfo.podV6NetworkCIDR != "" {
 		cmd := []string{"/bin/sh", "-c", fmt.Sprintf("nc -vz -w 4 %s 80", serverIPs.ipv6.String())}
-		data.runCommandFromPod(testNamespace, clientName, busyboxContainerName, cmd)
+		data.RunCommandFromPod(testNamespace, clientName, busyboxContainerName, cmd)
 	}
 	var anp = &crdv1alpha1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: "np1", Labels: map[string]string{"antrea-e2e": "np1"}},
@@ -3422,14 +3422,14 @@ func testANPNetworkPolicyStatsWithDropAction(t *testing.T, data *TestData) {
 			if clusterInfo.podV4NetworkCIDR != "" {
 				cmd := []string{"/bin/sh", "-c", fmt.Sprintf("echo test | nc -w 4 -u %s 80", serverIPs.ipv4.String())}
 				cmd2 := []string{"/bin/sh", "-c", fmt.Sprintf("echo test | nc -w 4 -u %s 443", serverIPs.ipv4.String())}
-				data.runCommandFromPod(testNamespace, clientName, busyboxContainerName, cmd)
-				data.runCommandFromPod(testNamespace, clientName, busyboxContainerName, cmd2)
+				data.RunCommandFromPod(testNamespace, clientName, busyboxContainerName, cmd)
+				data.RunCommandFromPod(testNamespace, clientName, busyboxContainerName, cmd2)
 			}
 			if clusterInfo.podV6NetworkCIDR != "" {
 				cmd := []string{"/bin/sh", "-c", fmt.Sprintf("echo test | nc -w 4 -u %s 80", serverIPs.ipv6.String())}
 				cmd2 := []string{"/bin/sh", "-c", fmt.Sprintf("echo test | nc -w 4 -u %s 443", serverIPs.ipv6.String())}
-				data.runCommandFromPod(testNamespace, clientName, busyboxContainerName, cmd)
-				data.runCommandFromPod(testNamespace, clientName, busyboxContainerName, cmd2)
+				data.RunCommandFromPod(testNamespace, clientName, busyboxContainerName, cmd)
+				data.RunCommandFromPod(testNamespace, clientName, busyboxContainerName, cmd2)
 			}
 			wg.Done()
 		}()
@@ -3495,11 +3495,11 @@ func testAntreaClusterNetworkPolicyStats(t *testing.T, data *TestData) {
 	// So we need to  "warm-up" the tunnel.
 	if clusterInfo.podV4NetworkCIDR != "" {
 		cmd := []string{"/bin/sh", "-c", fmt.Sprintf("nc -vz -w 4 %s 80", serverIPs.ipv4.String())}
-		data.runCommandFromPod(testNamespace, clientName, busyboxContainerName, cmd)
+		data.RunCommandFromPod(testNamespace, clientName, busyboxContainerName, cmd)
 	}
 	if clusterInfo.podV6NetworkCIDR != "" {
 		cmd := []string{"/bin/sh", "-c", fmt.Sprintf("nc -vz -w 4 %s 80", serverIPs.ipv6.String())}
-		data.runCommandFromPod(testNamespace, clientName, busyboxContainerName, cmd)
+		data.RunCommandFromPod(testNamespace, clientName, busyboxContainerName, cmd)
 	}
 	var acnp = &crdv1alpha1.ClusterNetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: "cnp1", Labels: map[string]string{"antrea-e2e": "cnp1"}},
@@ -3557,14 +3557,14 @@ func testAntreaClusterNetworkPolicyStats(t *testing.T, data *TestData) {
 			if clusterInfo.podV4NetworkCIDR != "" {
 				cmd := []string{"/bin/sh", "-c", fmt.Sprintf("echo test | nc -w 4 -u %s 800", serverIPs.ipv4.String())}
 				cmd2 := []string{"/bin/sh", "-c", fmt.Sprintf("echo test | nc -w 4 -u %s 4430", serverIPs.ipv4.String())}
-				data.runCommandFromPod(testNamespace, clientName, busyboxContainerName, cmd)
-				data.runCommandFromPod(testNamespace, clientName, busyboxContainerName, cmd2)
+				data.RunCommandFromPod(testNamespace, clientName, busyboxContainerName, cmd)
+				data.RunCommandFromPod(testNamespace, clientName, busyboxContainerName, cmd2)
 			}
 			if clusterInfo.podV6NetworkCIDR != "" {
 				cmd := []string{"/bin/sh", "-c", fmt.Sprintf("echo test | nc -w 4 -u %s 800", serverIPs.ipv6.String())}
 				cmd2 := []string{"/bin/sh", "-c", fmt.Sprintf("echo test | nc -w 4 -u %s 4430", serverIPs.ipv6.String())}
-				data.runCommandFromPod(testNamespace, clientName, busyboxContainerName, cmd)
-				data.runCommandFromPod(testNamespace, clientName, busyboxContainerName, cmd2)
+				data.RunCommandFromPod(testNamespace, clientName, busyboxContainerName, cmd)
+				data.RunCommandFromPod(testNamespace, clientName, busyboxContainerName, cmd2)
 			}
 			wg.Done()
 		}()

--- a/test/e2e/bandwidth_test.go
+++ b/test/e2e/bandwidth_test.go
@@ -82,7 +82,7 @@ func testBenchmarkBandwidthIntraNode(t *testing.T, data *TestData) {
 		t.Fatalf("Error when getting the perftest server Pod's IP: %v", err)
 	}
 	podBIP := podBIPs.ipv4.String()
-	stdout, _, err := data.runCommandFromPod(testNamespace, "perftest-a", "perftool", []string{"bash", "-c", fmt.Sprintf("iperf3 -c %s|grep sender|awk '{print $7,$8}'", podBIP)})
+	stdout, _, err := data.RunCommandFromPod(testNamespace, "perftest-a", "perftool", []string{"bash", "-c", fmt.Sprintf("iperf3 -c %s|grep sender|awk '{print $7,$8}'", podBIP)})
 	if err != nil {
 		t.Fatalf("Error when running iperf3 client: %v", err)
 	}
@@ -91,7 +91,7 @@ func testBenchmarkBandwidthIntraNode(t *testing.T, data *TestData) {
 }
 
 func benchmarkBandwidthService(t *testing.T, endpointNode, clientNode string, data *TestData) {
-	svc, err := data.createService("perftest-b", testNamespace, iperfPort, iperfPort, map[string]string{"antrea-e2e": "perftest-b"}, false, false, v1.ServiceTypeClusterIP, nil)
+	svc, err := data.CreateService("perftest-b", testNamespace, iperfPort, iperfPort, map[string]string{"antrea-e2e": "perftest-b"}, false, false, v1.ServiceTypeClusterIP, nil)
 	if err != nil {
 		t.Fatalf("Error when creating perftest service: %v", err)
 	}
@@ -107,7 +107,7 @@ func benchmarkBandwidthService(t *testing.T, endpointNode, clientNode string, da
 	if err := data.podWaitForRunning(defaultTimeout, "perftest-b", testNamespace); err != nil {
 		t.Fatalf("Error when getting the perftest server Pod's IP: %v", err)
 	}
-	stdout, stderr, err := data.runCommandFromPod(testNamespace, "perftest-a", perftoolContainerName, []string{"bash", "-c", fmt.Sprintf("iperf3 -c %s|grep sender|awk '{print $7,$8}'", svc.Spec.ClusterIP)})
+	stdout, stderr, err := data.RunCommandFromPod(testNamespace, "perftest-a", perftoolContainerName, []string{"bash", "-c", fmt.Sprintf("iperf3 -c %s|grep sender|awk '{print $7,$8}'", svc.Spec.ClusterIP)})
 	if err != nil {
 		t.Fatalf("Error when running iperf3 client: %v, stderr: %s", err, stderr)
 	}
@@ -132,7 +132,7 @@ func testPodTrafficShaping(t *testing.T, data *TestData) {
 	// So we disable it except for IPv4 single-stack clusters for now.
 	skipIfIPv6Cluster(t)
 	nodeName := controlPlaneNodeName()
-	skipIfMissingKernelModule(t, nodeName, []string{"ifb", "sch_tbf", "sch_ingress"})
+	skipIfMissingKernelModule(t, data, nodeName, []string{"ifb", "sch_tbf", "sch_ingress"})
 
 	tests := []struct {
 		name string
@@ -183,7 +183,7 @@ func testPodTrafficShaping(t *testing.T, data *TestData) {
 			}
 
 			runIperf := func(cmd []string) {
-				stdout, _, err := data.runCommandFromPod(testNamespace, clientPodName, "perftool", cmd)
+				stdout, _, err := data.RunCommandFromPod(testNamespace, clientPodName, "perftool", cmd)
 				if err != nil {
 					t.Fatalf("Error when running iperf3 client: %v", err)
 				}

--- a/test/e2e/batch_test.go
+++ b/test/e2e/batch_test.go
@@ -42,12 +42,12 @@ func TestBatchCreatePods(t *testing.T) {
 	getFDs := func() string {
 		// In case that antrea-agent is not running as Pid 1 in future.
 		cmds := []string{"pgrep", "-o", "antrea-agent"}
-		pid, _, err := data.runCommandFromPod(antreaNamespace, podName, "antrea-agent", cmds)
+		pid, _, err := data.RunCommandFromPod(antreaNamespace, podName, "antrea-agent", cmds)
 		assert.NoError(t, err)
 
 		// Ignore the difference of modification time by specifying "--time-style +".
 		cmds = []string{"ls", "-l", "--time-style", "+", fmt.Sprintf("/proc/%s/fd/", strings.TrimSpace(pid))}
-		stdout, _, err := data.runCommandFromPod(antreaNamespace, podName, "antrea-agent", cmds)
+		stdout, _, err := data.RunCommandFromPod(antreaNamespace, podName, "antrea-agent", cmds)
 		assert.NoError(t, err)
 		return stdout
 	}

--- a/test/e2e/connectivity_test.go
+++ b/test/e2e/connectivity_test.go
@@ -157,7 +157,7 @@ func (data *TestData) testHostPortPodConnectivity(t *testing.T, clientNamespace,
 	}
 	defer deletePodWrapper(t, data, serverNamespace, hpPodName)
 	// Retrieve the IP Address of the Node on which the Pod is scheduled.
-	hpPod, err := data.podWaitFor(defaultTimeout, hpPodName, serverNamespace, func(pod *corev1.Pod) (bool, error) {
+	hpPod, err := data.PodWaitFor(defaultTimeout, hpPodName, serverNamespace, func(pod *corev1.Pod) (bool, error) {
 		return pod.Status.Phase == corev1.PodRunning, nil
 	})
 	if err != nil {
@@ -324,7 +324,7 @@ func testOVSRestartSameNode(t *testing.T, data *TestData, namespace string) {
 		// utility in busybox does not let us choose a smaller interval than 1 second.
 		count := 25
 		cmd := fmt.Sprintf("arping -c %d %s", count, podIPs[1].ipv4.String())
-		stdout, stderr, err := data.runCommandFromPod(namespace, podNames[0], busyboxContainerName, strings.Fields(cmd))
+		stdout, stderr, err := data.RunCommandFromPod(namespace, podNames[0], busyboxContainerName, strings.Fields(cmd))
 		if err != nil {
 			return fmt.Errorf("error when running arping command: %v - stdout: %s - stderr: %s", err, stdout, stderr)
 		}
@@ -396,7 +396,7 @@ func testOVSFlowReplay(t *testing.T, data *TestData, namespace string) {
 
 	countFlows := func() int {
 		cmd := []string{"ovs-ofctl", "dump-flows", defaultBridgeName}
-		stdout, stderr, err := data.runCommandFromPod(antreaNamespace, antreaPodName, ovsContainerName, cmd)
+		stdout, stderr, err := data.RunCommandFromPod(antreaNamespace, antreaPodName, ovsContainerName, cmd)
 		if err != nil {
 			t.Fatalf("error when dumping flows: <%v>, err: <%v>", stderr, err)
 		}
@@ -406,7 +406,7 @@ func testOVSFlowReplay(t *testing.T, data *TestData, namespace string) {
 	}
 	countGroups := func() int {
 		cmd := []string{"ovs-ofctl", "dump-groups", defaultBridgeName}
-		stdout, stderr, err := data.runCommandFromPod(antreaNamespace, antreaPodName, ovsContainerName, cmd)
+		stdout, stderr, err := data.RunCommandFromPod(antreaNamespace, antreaPodName, ovsContainerName, cmd)
 		if err != nil {
 			t.Fatalf("error when dumping groups: <%v>, err: <%v>", stderr, err)
 		}
@@ -424,12 +424,12 @@ func testOVSFlowReplay(t *testing.T, data *TestData, namespace string) {
 	if !testOptions.enableAntreaIPAM {
 		delFlowsAndGroups := func() {
 			cmd := []string{"ovs-ofctl", "del-flows", defaultBridgeName}
-			_, stderr, err := data.runCommandFromPod(antreaNamespace, antreaPodName, ovsContainerName, cmd)
+			_, stderr, err := data.RunCommandFromPod(antreaNamespace, antreaPodName, ovsContainerName, cmd)
 			if err != nil {
 				t.Fatalf("error when deleting flows: <%v>, err: <%v>", stderr, err)
 			}
 			cmd = []string{"ovs-ofctl", "del-groups", defaultBridgeName}
-			_, stderr, err = data.runCommandFromPod(antreaNamespace, antreaPodName, ovsContainerName, cmd)
+			_, stderr, err = data.RunCommandFromPod(antreaNamespace, antreaPodName, ovsContainerName, cmd)
 			if err != nil {
 				t.Fatalf("error when deleting groups: <%v>, err: <%v>", stderr, err)
 			}
@@ -440,7 +440,7 @@ func testOVSFlowReplay(t *testing.T, data *TestData, namespace string) {
 		// run one command to delete flows and groups and to restart OVS to avoid connectivity issue
 		restartCmd = []string{"bash", "-c", fmt.Sprintf("ovs-ofctl del-flows %s ; ovs-ofctl del-groups %s ; /usr/share/openvswitch/scripts/ovs-ctl --system-id=random restart --db-file=/var/run/openvswitch/conf.db", defaultBridgeName, defaultBridgeName)}
 	}
-	if stdout, stderr, err := data.runCommandFromPod(antreaNamespace, antreaPodName, ovsContainerName, restartCmd); err != nil {
+	if stdout, stderr, err := data.RunCommandFromPod(antreaNamespace, antreaPodName, ovsContainerName, restartCmd); err != nil {
 		t.Fatalf("Error when restarting OVS with ovs-ctl: %v - stdout: %s - stderr: %s", err, stdout, stderr)
 	} else {
 		t.Logf("Restarted OVS with ovs-ctl: stdout: %s - stderr: %s", stdout, stderr)

--- a/test/e2e/egress_test.go
+++ b/test/e2e/egress_test.go
@@ -251,8 +251,8 @@ ip netns exec %[1]s /agnhost netexec
 			}); err != nil {
 				t.Fatalf("Failed to create Pod initial-ip-checker: %v", err)
 			}
-			defer data.deletePod(testNamespace, initialIPChecker)
-			_, err = data.podWaitFor(timeout, initialIPChecker, testNamespace, func(pod *v1.Pod) (bool, error) {
+			defer data.DeletePod(testNamespace, initialIPChecker)
+			_, err = data.PodWaitFor(timeout, initialIPChecker, testNamespace, func(pod *v1.Pod) (bool, error) {
 				if pod.Status.Phase == v1.PodFailed {
 					return false, fmt.Errorf("Pod terminated with failure")
 				}
@@ -607,7 +607,7 @@ func testEgressNodeFailure(t *testing.T, data *TestData) {
 			}
 			signalAgent := func(nodeName, signal string) {
 				cmd := fmt.Sprintf("pkill -%s antrea-agent", signal)
-				rc, stdout, stderr, err := RunCommandOnNode(nodeName, cmd)
+				rc, stdout, stderr, err := data.RunCommandOnNode(nodeName, cmd)
 				if rc != 0 || err != nil {
 					t.Errorf("Error when running command '%s' on Node '%s', rc: %d, stdout: %s, stderr: %s, error: %v",
 						cmd, nodeName, rc, stdout, stderr, err)
@@ -711,7 +711,7 @@ func hasIP(data *TestData, nodeName string, ip string) (bool, error) {
 		return false, err
 	}
 	cmd := []string{"ip", "-br", "addr"}
-	stdout, _, err := data.runCommandFromPod(antreaNamespace, antreaPodName, agentContainerName, cmd)
+	stdout, _, err := data.RunCommandFromPod(antreaNamespace, antreaPodName, agentContainerName, cmd)
 	if err != nil {
 		return false, err
 	}

--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -99,11 +99,11 @@ func skipIfNotIPv6Cluster(tb testing.TB) {
 	}
 }
 
-func skipIfMissingKernelModule(tb testing.TB, nodeName string, requiredModules []string) {
+func skipIfMissingKernelModule(tb testing.TB, data *TestData, nodeName string, requiredModules []string) {
 	for _, module := range requiredModules {
 		// modprobe with "--dry-run" does not require root privileges
 		cmd := fmt.Sprintf("modprobe --dry-run %s", module)
-		rc, stdout, stderr, err := RunCommandOnNode(nodeName, cmd)
+		rc, stdout, stderr, err := data.RunCommandOnNode(nodeName, cmd)
 		if err != nil {
 			tb.Skipf("Skipping test as modprobe could not be run to confirm the presence of module '%s': %v", module, err)
 		}
@@ -290,7 +290,7 @@ func exportLogs(tb testing.TB, data *TestData, logsSubDir string, writeNodeLogs 
 	// runKubectl runs the provided kubectl command on the control-plane Node and returns the
 	// output. It returns an empty string in case of error.
 	runKubectl := func(cmd string) string {
-		rc, stdout, _, err := RunCommandOnNode(controlPlaneNodeName(), cmd)
+		rc, stdout, _, err := data.RunCommandOnNode(controlPlaneNodeName(), cmd)
 		if err != nil || rc != 0 {
 			tb.Errorf("Error when running this kubectl command on control-plane Node: %s", cmd)
 			return ""
@@ -362,7 +362,7 @@ func exportLogs(tb testing.TB, data *TestData, logsSubDir string, writeNodeLogs 
 		if clusterInfo.nodesOS[nodeName] == "windows" {
 			cmd = "Get-EventLog -LogName \"System\" -Source \"Service Control Manager\" | grep kubelet ; Get-EventLog -LogName \"Application\" -Source \"nssm\" | grep kubelet"
 		}
-		rc, stdout, _, err := RunCommandOnNode(nodeName, cmd)
+		rc, stdout, _, err := data.RunCommandOnNode(nodeName, cmd)
 		if err != nil || rc != 0 {
 			// return an error and skip subsequent Nodes
 			return fmt.Errorf("error when running journalctl on Node '%s', is it available? Error: %v", nodeName, err)
@@ -387,7 +387,7 @@ func teardownFlowAggregator(tb testing.TB, data *TestData) {
 		}
 	}
 	tb.Logf("Deleting '%s' K8s Namespace", flowAggregatorNamespace)
-	if err := data.deleteNamespace(flowAggregatorNamespace, defaultTimeout); err != nil {
+	if err := data.DeleteNamespace(flowAggregatorNamespace, defaultTimeout); err != nil {
 		tb.Logf("Error when tearing down flow aggregator: %v", err)
 	}
 }
@@ -405,7 +405,7 @@ func teardownTest(tb testing.TB, data *TestData) {
 
 func deletePodWrapper(tb testing.TB, data *TestData, namespace, name string) {
 	tb.Logf("Deleting Pod '%s'", name)
-	if err := data.deletePod(namespace, name); err != nil {
+	if err := data.DeletePod(namespace, name); err != nil {
 		tb.Logf("Error when deleting Pod: %v", err)
 	}
 }

--- a/test/e2e/ipsec_test.go
+++ b/test/e2e/ipsec_test.go
@@ -50,7 +50,7 @@ func (data *TestData) readSecurityAssociationsStatus(nodeName string) (up int, c
 		return 0, 0, err
 	}
 	cmd := []string{"ipsec", "status"}
-	stdout, stderr, err := data.runCommandFromPod(antreaNamespace, antreaPodName, "antrea-ipsec", cmd)
+	stdout, stderr, err := data.RunCommandFromPod(antreaNamespace, antreaPodName, "antrea-ipsec", cmd)
 	if err != nil {
 		return 0, 0, fmt.Errorf("error when running 'ipsec status' on '%s': %v - stdout: %s - stderr: %s", nodeName, err, stdout, stderr)
 	}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -85,21 +85,23 @@ func testMain(m *testing.M) int {
 	flag.StringVar(&testOptions.skipCases, "skip", "", "Key words to skip cases")
 	flag.Parse()
 
-	if err := initProvider(); err != nil {
-		log.Fatalf("Error when initializing provider: %v", err)
-	}
-
 	cleanupLogging := testOptions.setupLogging()
 	defer cleanupLogging()
 
 	testData = &TestData{}
-	log.Println("Creating K8s clientset")
-	if err := testData.createClient(); err != nil {
-		log.Fatalf("Error when creating K8s clientset: %v", err)
-		return 1
+	if err := testData.InitProvider(testOptions.providerName, testOptions.providerConfigPath); err != nil {
+		log.Fatalf("Error when initializing provider: %v", err)
+	}
+	log.Println("Creating K8s ClientSet")
+	kubeconfigPath, err := testData.provider.GetKubeconfigPath()
+	if err != nil {
+		log.Fatalf("Error when getting Kubeconfig path: %v", err)
+	}
+	if err := testData.CreateClient(kubeconfigPath); err != nil {
+		log.Fatalf("Error when creating K8s ClientSet: %v", err)
 	}
 	log.Println("Collecting information about K8s cluster")
-	if err := collectClusterInfo(); err != nil {
+	if err := testData.collectClusterInfo(); err != nil {
 		log.Fatalf("Error when collecting information about K8s cluster: %v", err)
 	}
 	if clusterInfo.podV4NetworkCIDR != "" {
@@ -115,7 +117,7 @@ func testMain(m *testing.M) int {
 		log.Printf("Service IPv6 network: '%s'", clusterInfo.svcV6NetworkCIDR)
 	}
 	log.Printf("Num nodes: %d", clusterInfo.numNodes)
-	err := ensureAntreaRunning(testData)
+	err = ensureAntreaRunning(testData)
 	if err != nil {
 		log.Fatalf("Error when deploying Antrea: %v", err)
 	}

--- a/test/e2e/networkpolicy_test.go
+++ b/test/e2e/networkpolicy_test.go
@@ -95,11 +95,11 @@ func testNetworkPolicyStats(t *testing.T, data *TestData) {
 	// So we need to  "warm-up" the tunnel.
 	if clusterInfo.podV4NetworkCIDR != "" {
 		cmd := []string{"/bin/sh", "-c", fmt.Sprintf("nc -vz -w 4 %s 80", serverIPs.ipv4.String())}
-		data.runCommandFromPod(testNamespace, clientName, busyboxContainerName, cmd)
+		data.RunCommandFromPod(testNamespace, clientName, busyboxContainerName, cmd)
 	}
 	if clusterInfo.podV6NetworkCIDR != "" {
 		cmd := []string{"/bin/sh", "-c", fmt.Sprintf("nc -vz -w 4 %s 80", serverIPs.ipv6.String())}
-		data.runCommandFromPod(testNamespace, clientName, busyboxContainerName, cmd)
+		data.RunCommandFromPod(testNamespace, clientName, busyboxContainerName, cmd)
 	}
 
 	np1, err := data.createNetworkPolicy("test-networkpolicy-ingress", &networkingv1.NetworkPolicySpec{
@@ -155,11 +155,11 @@ func testNetworkPolicyStats(t *testing.T, data *TestData) {
 		go func() {
 			if clusterInfo.podV4NetworkCIDR != "" {
 				cmd := []string{"/bin/sh", "-c", fmt.Sprintf("nc -vz -w 4 %s 80", serverIPs.ipv4.String())}
-				data.runCommandFromPod(testNamespace, clientName, busyboxContainerName, cmd)
+				data.RunCommandFromPod(testNamespace, clientName, busyboxContainerName, cmd)
 			}
 			if clusterInfo.podV6NetworkCIDR != "" {
 				cmd := []string{"/bin/sh", "-c", fmt.Sprintf("nc -vz -w 4 %s 80", serverIPs.ipv6.String())}
-				data.runCommandFromPod(testNamespace, clientName, busyboxContainerName, cmd)
+				data.RunCommandFromPod(testNamespace, clientName, busyboxContainerName, cmd)
 			}
 			wg.Done()
 		}()
@@ -341,7 +341,7 @@ func testDefaultDenyIngressPolicy(t *testing.T, data *TestData) {
 	_, serverIPs, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "test-server-", serverNode, testNamespace, false)
 	defer cleanupFunc()
 
-	service, err := data.createService("nginx", testNamespace, serverPort, serverPort, map[string]string{"app": "nginx"}, false, false, corev1.ServiceTypeNodePort, nil)
+	service, err := data.CreateService("nginx", testNamespace, serverPort, serverPort, map[string]string{"app": "nginx"}, false, false, corev1.ServiceTypeNodePort, nil)
 	if err != nil {
 		t.Fatalf("Error when creating nginx NodePort service: %v", err)
 	}
@@ -957,7 +957,7 @@ func createAndWaitForPodWithLabels(t *testing.T, data *TestData, createFunc func
 		t.Fatalf("Error when creating busybox test Pod: %v", err)
 	}
 	cleanupFunc := func() error {
-		if err := data.deletePod(ns, name); err != nil {
+		if err := data.DeletePod(ns, name); err != nil {
 			return fmt.Errorf("error when deleting Pod: %v", err)
 		}
 		return nil

--- a/test/e2e/performance_test.go
+++ b/test/e2e/performance_test.go
@@ -237,7 +237,7 @@ func httpRequest(requests, policyRules int, data *TestData, b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		b.Logf("Running http request bench %d/%d", i+1, b.N)
 		cmd := []string{"ab", "-n", fmt.Sprint(requests), "-c", fmt.Sprint(*httpConcurrency), serverURL.String()}
-		stdout, stderr, err := data.runCommandFromPod(testNamespace, perftoolPodName, perftoolContainerName, cmd)
+		stdout, stderr, err := data.RunCommandFromPod(testNamespace, perftoolPodName, perftoolContainerName, cmd)
 		if err != nil {
 			b.Errorf("Error when running http request %dx: %v, stdout: %s, stderr: %s\n", requests, err, stdout, stderr)
 		}
@@ -296,7 +296,7 @@ func checkRealize(policyRules int, data *TestData) (bool, error) {
 	}
 	// table IngressRule is the ingressRuleTable where the rules in workload network policy is being applied to.
 	cmd := []string{"ovs-ofctl", "dump-flows", defaultBridgeName, fmt.Sprintf("table=%s", openflow.IngressRuleTable.GetName())}
-	stdout, _, err := data.runCommandFromPod(antreaNamespace, antreaPodName, "antrea-agent", cmd)
+	stdout, _, err := data.RunCommandFromPod(antreaNamespace, antreaPodName, "antrea-agent", cmd)
 	if err != nil {
 		return false, err
 	}

--- a/test/e2e/service_test.go
+++ b/test/e2e/service_test.go
@@ -80,7 +80,7 @@ func (data *TestData) testClusterIP(t *testing.T, isIPv6 bool, clientNamespace, 
 		testClusterIPCases(t, data, url, clients, hostNetworkClients, clientNamespace)
 	})
 
-	require.NoError(t, data.deletePod(serverNamespace, nginx))
+	require.NoError(t, data.DeletePod(serverNamespace, nginx))
 	_, _, cleanupFunc = createAndWaitForPod(t, data, data.createNginxPodOnNode, hostNginx, nodeName(0), serverNamespace, true)
 	defer cleanupFunc()
 	t.Run("HostNetwork Endpoints", func(t *testing.T) {
@@ -109,7 +109,7 @@ func testClusterIPFromPod(t *testing.T, data *TestData, url, nodeName, podName s
 	cmd := []string{"/agnhost", "connect", url, "--timeout=1s", "--protocol=tcp"}
 	err := wait.PollImmediate(1*time.Second, 5*time.Second, func() (bool, error) {
 		t.Logf(strings.Join(cmd, " "))
-		stdout, stderr, err := data.runCommandFromPod(namespace, podName, agnhostContainerName, cmd)
+		stdout, stderr, err := data.RunCommandFromPod(namespace, podName, agnhostContainerName, cmd)
 		t.Logf("stdout: %s - stderr: %s - err: %v", stdout, stderr, err)
 		if err == nil {
 			return true, nil
@@ -188,7 +188,7 @@ func (data *TestData) createAgnhostServiceAndBackendPods(t *testing.T, name, nam
 	require.NoError(t, err)
 	t.Logf("Created service Pod IPs %v", podIPs.ipStrings)
 	require.NoError(t, data.podWaitForRunning(defaultTimeout, name, namespace))
-	svc, err := data.createService(name, namespace, 80, 80, map[string]string{"app": "agnhost"}, false, false, svcType, &ipv4Protocol)
+	svc, err := data.CreateService(name, namespace, 80, 80, map[string]string{"app": "agnhost"}, false, false, svcType, &ipv4Protocol)
 	require.NoError(t, err)
 
 	cleanup := func() {

--- a/test/e2e/supportbundle_test.go
+++ b/test/e2e/supportbundle_test.go
@@ -38,7 +38,7 @@ import (
 
 // getAccessToken retrieves the local access token of an antrea component API server.
 func getAccessToken(podName string, containerName string, tokenPath string, data *TestData) (string, error) {
-	stdout, _, err := data.runCommandFromPod(metav1.NamespaceSystem, podName, containerName, []string{"cat", tokenPath})
+	stdout, _, err := data.RunCommandFromPod(metav1.NamespaceSystem, podName, containerName, []string{"cat", tokenPath})
 	if err != nil {
 		return "", err
 	}

--- a/test/e2e/tls_test.go
+++ b/test/e2e/tls_test.go
@@ -148,7 +148,7 @@ func (data *TestData) opensslConnect(t *testing.T, pod string, container string,
 		if tls12 {
 			cmd = append(cmd, "-tls1_2")
 		}
-		stdout, stderr, err := data.runCommandFromPod(antreaNamespace, pod, container, cmd)
+		stdout, stderr, err := data.RunCommandFromPod(antreaNamespace, pod, container, cmd)
 		assert.NoError(t, err, "failed to run openssl command on Pod '%s'\nstderr: %s", pod, stderr)
 		t.Logf("Ran '%s' on Pod %s", strings.Join(cmd, " "), pod)
 		stdouts = append(stdouts, stdout)

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -64,10 +64,10 @@ func TestUpgrade(t *testing.T) {
 	namespace := randName("test-namespace-")
 
 	t.Logf("Creating namespace '%s'", namespace)
-	if err := data.createNamespace(namespace, nil); err != nil {
+	if err := data.CreateNamespace(namespace, nil); err != nil {
 		t.Fatalf("Error when creating namespace '%s'", namespace)
 	}
-	defer data.deleteNamespace(namespace, defaultTimeout)
+	defer data.DeleteNamespace(namespace, defaultTimeout)
 
 	data.testPodConnectivitySameNode(t)
 	data.testPodConnectivityDifferentNodes(t)
@@ -109,7 +109,7 @@ func TestUpgrade(t *testing.T) {
 	checkFn()
 
 	t.Logf("Deleting namespace '%s'", namespace)
-	if err := data.deleteNamespace(namespace, defaultTimeout); err != nil {
+	if err := data.DeleteNamespace(namespace, defaultTimeout); err != nil {
 		t.Errorf("Namespace deletion failed: %v", err)
 	}
 

--- a/test/e2e/wireguard_test.go
+++ b/test/e2e/wireguard_test.go
@@ -35,11 +35,12 @@ func TestWireGuard(t *testing.T) {
 	skipIfNumNodesLessThan(t, 2)
 	skipIfHasWindowsNodes(t)
 	skipIfAntreaIPAMTest(t)
-	for _, node := range clusterInfo.nodes {
-		skipIfMissingKernelModule(t, node.name, []string{"wireguard"})
-	}
+
 	data, err := setupTest(t)
 	skipIfEncapModeIsNot(t, data, config.TrafficEncapModeEncap)
+	for _, node := range clusterInfo.nodes {
+		skipIfMissingKernelModule(t, data, node.name, []string{"wireguard"})
+	}
 
 	if err != nil {
 		t.Fatalf("Error when setting up test: %v", err)
@@ -72,7 +73,7 @@ func (data *TestData) getWireGuardPeerEndpointsWithHandshake(nodeName string) ([
 		return peerEndpoints, err
 	}
 	cmd := []string{"wg"}
-	stdout, stderr, err := data.runCommandFromPod(antreaNamespace, antreaPodName, "wireguard", cmd)
+	stdout, stderr, err := data.RunCommandFromPod(antreaNamespace, antreaPodName, "wireguard", cmd)
 	if err != nil {
 		return peerEndpoints, fmt.Errorf("error when running 'wg' on '%s': %v - stdout: %s - stderr: %s", nodeName, err, stdout, stderr)
 	}


### PR DESCRIPTION
Main changes:
- Export some functions from `/test/e2e.TestData` so that they can be reused by multi-cluster e2e pkg.
- Changed some util functions' receiver from `k8sUtils` to `TestData` so that they can be reused by multi-cluster e2e pkg.
- In multi-cluster e2e pkg, instantiate a new `MCTestData` which has copies of `TestData` of each cluster, instead of creating an entirely new TestData struct. 

Signed-off-by: Yang Ding <dingyang@vmware.com>