### PR TITLE
Fix pkt mark conflict between HostLocalSourceMark and SNATIPMark

### DIFF
--- a/pkg/agent/types/marks.go
+++ b/pkg/agent/types/marks.go
@@ -16,8 +16,8 @@ package types
 
 const (
 	// HostLocalSourceBit is the bit of the iptables fwmark space to mark locally generated packets.
-	// Value must be within the range [0, 31].
-	HostLocalSourceBit = 0
+	// Value must be within the range [0, 31], and should not conflict with bits for other purposes.
+	HostLocalSourceBit = 31
 )
 
 var (

--- a/test/integration/agent/route_test.go
+++ b/test/integration/agent/route_test.go
@@ -210,7 +210,7 @@ func TestInitialize(t *testing.T) {
 :ANTREA-OUTPUT - [0:0]
 -A PREROUTING -m comment --comment "Antrea: jump to Antrea mangle rules" -j ANTREA-MANGLE
 -A OUTPUT -m comment --comment "Antrea: jump to Antrea output rules" -j ANTREA-OUTPUT
--A ANTREA-OUTPUT -o antrea-gw0 -m comment --comment "Antrea: mark LOCAL output packets" -m addrtype --src-type LOCAL -j MARK --set-xmark 0x1/0x1
+-A ANTREA-OUTPUT -o antrea-gw0 -m comment --comment "Antrea: mark LOCAL output packets" -m addrtype --src-type LOCAL -j MARK --set-xmark 0x80000000/0x80000000
 `,
 			"nat": `:ANTREA-POSTROUTING - [0:0]
 -A POSTROUTING -m comment --comment "Antrea: jump to Antrea postrouting rules" -j ANTREA-POSTROUTING


### PR DESCRIPTION
HostLocalSourceMark is used to mark locally generated packets from Node
net namespace, but it conflicted with bits used by SNATIPMark, leading
to these packets being SNATed mistakenly when there happens to be an
Egress using same mark.

Fixes #3431

Signed-off-by: Quan Tian <qtian@vmware.com>