### PR TITLE
Automated cherry pick of #3030: Fix ClusterGroup realization status logic

### DIFF
--- a/pkg/controller/networkpolicy/clustergroup.go
+++ b/pkg/controller/networkpolicy/clustergroup.go
@@ -206,6 +206,7 @@ func (n *NetworkPolicyController) syncInternalGroup(key string) error {
 		return nil
 	}
 	grp := grpObj.(*antreatypes.Group)
+	originalMembersComputedStatus := grp.MembersComputed
 	// Retrieve the ClusterGroup corresponding to this key.
 	cg, err := n.cgLister.Get(grp.Name)
 	if err != nil {
@@ -218,27 +219,46 @@ func (n *NetworkPolicyController) syncInternalGroup(key string) error {
 	} else {
 		n.groupingInterface.DeleteGroup(clusterGroupType, grp.Name)
 	}
-	if selectorUpdated {
-		// Update the internal Group object in the store with the new selector.
+
+	membersComputed, membersComputedStatus := true, v1.ConditionFalse
+	// Update the ClusterGroup status to Realized as Antrea has recognized the Group and
+	// processed its group members. The ClusterGroup is considered realized if:
+	//   1. It does not have child groups. The group members are immediately considered
+	//      computed during syncInternalGroup, as the group selector is finalized.
+	//   2. All its child groups are created and realized.
+	if len(grp.ChildGroups) > 0 {
+		for _, cgName := range grp.ChildGroups {
+			cg, found, _ := n.internalGroupStore.Get(cgName)
+			if !found || cg.(*antreatypes.Group).MembersComputed != v1.ConditionTrue {
+				membersComputed = false
+				break
+			}
+		}
+	}
+	if membersComputed {
+		klog.V(4).Infof("Updating GroupMembersComputed Status for group %s", cg.Name)
+		err = n.updateGroupStatus(cg, v1.ConditionTrue)
+		if err != nil {
+			klog.Errorf("Failed to update ClusterGroup %s GroupMembersComputed condition to %s: %v", cg.Name, v1.ConditionTrue, err)
+		} else {
+			membersComputedStatus = v1.ConditionTrue
+		}
+	}
+	if selectorUpdated || membersComputedStatus != originalMembersComputedStatus {
+		// Update the internal Group object in the store with the new selector and status.
 		updatedGrp := &antreatypes.Group{
 			UID:              grp.UID,
 			Name:             grp.Name,
+			MembersComputed:  membersComputedStatus,
 			Selector:         grp.Selector,
+			IPBlocks:         grp.IPBlocks,
 			ServiceReference: grp.ServiceReference,
 			ChildGroups:      grp.ChildGroups,
 		}
 		klog.V(2).Infof("Updating existing internal Group %s", key)
 		n.internalGroupStore.Update(updatedGrp)
 	}
-	// Update the ClusterGroup status to Realized as Antrea has recognized the Group and
-	// processed its group members.
-	err = n.updateGroupStatus(cg, v1.ConditionTrue)
-	if err != nil {
-		klog.Errorf("Failed to update ClusterGroup %s GroupMembersComputed condition to %s: %v", cg.Name, v1.ConditionTrue, err)
-		return err
-	}
-	n.triggerParentGroupSync(grp)
-	return n.triggerCNPUpdates(cg)
+	return err
 }
 
 func (n *NetworkPolicyController) triggerParentGroupSync(grp *antreatypes.Group) {

--- a/pkg/controller/networkpolicy/clustergroup_test.go
+++ b/pkg/controller/networkpolicy/clustergroup_test.go
@@ -946,9 +946,10 @@ func TestSyncInternalGroup(t *testing.T) {
 	assert.Equal(t, expectedInternalNetworkPolicy2, actualInternalNetworkPolicy2)
 
 	expectedInternalGroup := &antreatypes.Group{
-		UID:      cgUID,
-		Name:     cgName,
-		Selector: toGroupSelector("", nil, &selectorA, nil),
+		UID:             cgUID,
+		Name:            cgName,
+		Selector:        toGroupSelector("", nil, &selectorA, nil),
+		MembersComputed: corev1.ConditionTrue,
 	}
 	actualInternalGroup, exists, _ := npc.internalGroupStore.Get(internalGroupKeyFunc(cg))
 	require.True(t, exists)

--- a/pkg/controller/types/group.go
+++ b/pkg/controller/types/group.go
@@ -19,6 +19,7 @@ import (
 	"sort"
 	"strings"
 
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -104,6 +105,9 @@ type Group struct {
 	UID types.UID
 	// Name of the ClusterGroup for which this internal Group is created.
 	Name string
+	// MembersComputed knows whether the controller has computed the comprehensive members
+	// of the Group. It is updated during the syncInternalGroup process.
+	MembersComputed v1.ConditionStatus
 	// Selector describes how the internal group selects Pods to get their addresses.
 	// Selector is nil if Group is defined with ipBlock, or if it has ServiceReference
 	// and has not been processed by the controller yet / Service cannot be found.

--- a/test/e2e/clustergroup_test.go
+++ b/test/e2e/clustergroup_test.go
@@ -17,8 +17,10 @@ package e2e
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	crdv1alpha1 "antrea.io/antrea/pkg/apis/crd/v1alpha1"
@@ -269,6 +271,71 @@ func testInvalidCGMaxNestedLevel(t *testing.T) {
 	}
 }
 
+func getRealizationStatus(cg *crdv1alpha3.ClusterGroup) v1.ConditionStatus {
+	conds := cg.Status.Conditions
+	for _, cond := range conds {
+		if cond.Type == crdv1alpha3.GroupMembersComputed && cond.Status == v1.ConditionTrue {
+			return v1.ConditionTrue
+		}
+	}
+	return v1.ConditionFalse
+}
+
+func testClusterGroupRealizationStatus(t *testing.T) {
+	invalidErr1 := fmt.Errorf("clustergroup with child groups should only be considered realized when all its child groups are realized")
+	invalidErr2 := fmt.Errorf("clustergroup with selectors or serviceRef should be realized once processed")
+	childCG1Returned, _ := k8sUtils.GetV1Alpha3CG(testChildCGName)
+	// test-child-cg should be considered realized as soon as its synced.
+	if getRealizationStatus(childCG1Returned) != v1.ConditionTrue {
+		failOnError(invalidErr2, t)
+	}
+	cgParent := &crdv1alpha3.ClusterGroup{
+		ObjectMeta: metav1.ObjectMeta{Name: "parent-cg"},
+		Spec: crdv1alpha3.GroupSpec{
+			ChildGroups: []crdv1alpha3.ClusterGroupReference{
+				crdv1alpha3.ClusterGroupReference(testChildCGName),
+				crdv1alpha3.ClusterGroupReference("child-cg-2"),
+			},
+		},
+	}
+	if _, err := k8sUtils.CreateOrUpdateV1Alpha3CG(cgParent); err != nil {
+		// Above creation of CG must succeed as it is a valid spec.
+		failOnError(err, t)
+	}
+	time.Sleep(networkPolicyDelay / 2)
+	cgParentReturned, _ := k8sUtils.GetV1Alpha3CG("parent-cg")
+	// cgParent should not be considered realized yet since child-cg-2 is not yet created.
+	if getRealizationStatus(cgParentReturned) != v1.ConditionFalse {
+		failOnError(invalidErr1, t)
+	}
+	cgChild2 := &crdv1alpha3.ClusterGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "child-cg-2",
+		},
+		Spec: crdv1alpha3.GroupSpec{
+			IPBlocks: []crdv1alpha1.IPBlock{
+				{CIDR: "192.168.2.0/24"},
+			},
+		},
+	}
+	if _, err := k8sUtils.CreateOrUpdateV1Alpha3CG(cgChild2); err != nil {
+		// Above creation of CG must succeed as it is a valid spec.
+		failOnError(err, t)
+	}
+	time.Sleep(networkPolicyDelay / 2)
+	childCG2Returned, _ := k8sUtils.GetV1Alpha3CG("child-cg-2")
+	// child-cg-2 should be considered realized as soon as its synced.
+	if getRealizationStatus(childCG2Returned) != v1.ConditionTrue {
+		failOnError(invalidErr2, t)
+	}
+	cgParentReturned, _ = k8sUtils.GetV1Alpha3CG("parent-cg")
+	// cgParent should now be considered realized.
+	if getRealizationStatus(cgParentReturned) != v1.ConditionTrue {
+		failOnError(invalidErr1, t)
+	}
+
+}
+
 func testClusterGroupConversionV1A2AndV1A3(t *testing.T) {
 	cgName1, cgName2 := "cg-v1a2", "cg-v1a3"
 	ipb1 := crdv1alpha1.IPBlock{
@@ -339,6 +406,7 @@ func TestClusterGroup(t *testing.T) {
 		t.Run("Case=ChildGroupWithPodSelectorDenied", func(t *testing.T) { testInvalidCGChildGroupWithPodSelector(t) })
 		t.Run("Case=ChildGroupWithPodServiceReferenceDenied", func(t *testing.T) { testInvalidCGChildGroupWithServiceReference(t) })
 		t.Run("Case=ChildGroupExceedMaxNestedLevel", func(t *testing.T) { testInvalidCGMaxNestedLevel(t) })
+		t.Run("Case=ClusterGroupRealizationStatusWithChildGroups", func(t *testing.T) { testClusterGroupRealizationStatus(t) })
 		cleanupChildCGForTest(t)
 	})
 	t.Run("TestGroupClusterGroupConversion", func(t *testing.T) {


### PR DESCRIPTION
Cherry pick of #3030 on release-1.2.

#3030: Fix ClusterGroup realization status logic

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.