### PR TITLE
Automated cherry pick of #3030: Fix ClusterGroup realization status logic
#3383: Fix ipBlock referenced in child ClusterGroup not processed

### DIFF
--- a/pkg/apiserver/registry/networkpolicy/clustergroupmember/rest.go
+++ b/pkg/apiserver/registry/networkpolicy/clustergroupmember/rest.go
@@ -53,12 +53,13 @@ func (r *REST) Get(ctx context.Context, name string, options *metav1.GetOptions)
 	if err != nil {
 		return nil, errors.NewInternalError(err)
 	}
-	effectiveMembers := make([]controlplane.GroupMember, 0, len(members))
-	for _, member := range members {
-		effectiveMembers = append(effectiveMembers, *member)
-	}
-	memberList := &controlplane.ClusterGroupMembers{
-		EffectiveMembers: effectiveMembers,
+	memberList := &controlplane.ClusterGroupMembers{}
+	if len(members) > 0 {
+		effectiveMembers := make([]controlplane.GroupMember, 0, len(members))
+		for _, member := range members {
+			effectiveMembers = append(effectiveMembers, *member)
+		}
+		memberList.EffectiveMembers = effectiveMembers
 	}
 	memberList.Name = name
 	return memberList, nil

--- a/pkg/apiserver/registry/networkpolicy/clustergroupmember/rest_test.go
+++ b/pkg/apiserver/registry/networkpolicy/clustergroupmember/rest_test.go
@@ -117,7 +117,7 @@ func TestRESTGet(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cgC",
 				},
-				EffectiveMembers: []controlplane.GroupMember{},
+				EffectiveMembers: nil,
 			},
 			expectedErr: false,
 		},

--- a/pkg/controller/networkpolicy/clustergroup.go
+++ b/pkg/controller/networkpolicy/clustergroup.go
@@ -206,6 +206,7 @@ func (n *NetworkPolicyController) syncInternalGroup(key string) error {
 		return nil
 	}
 	grp := grpObj.(*antreatypes.Group)
+	originalMembersComputedStatus := grp.MembersComputed
 	// Retrieve the ClusterGroup corresponding to this key.
 	cg, err := n.cgLister.Get(grp.Name)
 	if err != nil {
@@ -218,27 +219,46 @@ func (n *NetworkPolicyController) syncInternalGroup(key string) error {
 	} else {
 		n.groupingInterface.DeleteGroup(clusterGroupType, grp.Name)
 	}
-	if selectorUpdated {
-		// Update the internal Group object in the store with the new selector.
+
+	membersComputed, membersComputedStatus := true, v1.ConditionFalse
+	// Update the ClusterGroup status to Realized as Antrea has recognized the Group and
+	// processed its group members. The ClusterGroup is considered realized if:
+	//   1. It does not have child groups. The group members are immediately considered
+	//      computed during syncInternalGroup, as the group selector is finalized.
+	//   2. All its child groups are created and realized.
+	if len(grp.ChildGroups) > 0 {
+		for _, cgName := range grp.ChildGroups {
+			cg, found, _ := n.internalGroupStore.Get(cgName)
+			if !found || cg.(*antreatypes.Group).MembersComputed != v1.ConditionTrue {
+				membersComputed = false
+				break
+			}
+		}
+	}
+	if membersComputed {
+		klog.V(4).Infof("Updating GroupMembersComputed Status for group %s", cg.Name)
+		err = n.updateGroupStatus(cg, v1.ConditionTrue)
+		if err != nil {
+			klog.Errorf("Failed to update ClusterGroup %s GroupMembersComputed condition to %s: %v", cg.Name, v1.ConditionTrue, err)
+		} else {
+			membersComputedStatus = v1.ConditionTrue
+		}
+	}
+	if selectorUpdated || membersComputedStatus != originalMembersComputedStatus {
+		// Update the internal Group object in the store with the new selector and status.
 		updatedGrp := &antreatypes.Group{
 			UID:              grp.UID,
 			Name:             grp.Name,
+			MembersComputed:  membersComputedStatus,
 			Selector:         grp.Selector,
+			IPBlocks:         grp.IPBlocks,
 			ServiceReference: grp.ServiceReference,
 			ChildGroups:      grp.ChildGroups,
 		}
 		klog.V(2).Infof("Updating existing internal Group %s", key)
 		n.internalGroupStore.Update(updatedGrp)
 	}
-	// Update the ClusterGroup status to Realized as Antrea has recognized the Group and
-	// processed its group members.
-	err = n.updateGroupStatus(cg, v1.ConditionTrue)
-	if err != nil {
-		klog.Errorf("Failed to update ClusterGroup %s GroupMembersComputed condition to %s: %v", cg.Name, v1.ConditionTrue, err)
-		return err
-	}
-	n.triggerParentGroupSync(grp)
-	return n.triggerCNPUpdates(cg)
+	return err
 }
 
 func (n *NetworkPolicyController) triggerParentGroupSync(grp *antreatypes.Group) {

--- a/pkg/controller/networkpolicy/clustergroup_test.go
+++ b/pkg/controller/networkpolicy/clustergroup_test.go
@@ -946,9 +946,10 @@ func TestSyncInternalGroup(t *testing.T) {
 	assert.Equal(t, expectedInternalNetworkPolicy2, actualInternalNetworkPolicy2)
 
 	expectedInternalGroup := &antreatypes.Group{
-		UID:      cgUID,
-		Name:     cgName,
-		Selector: toGroupSelector("", nil, &selectorA, nil),
+		UID:             cgUID,
+		Name:            cgName,
+		Selector:        toGroupSelector("", nil, &selectorA, nil),
+		MembersComputed: corev1.ConditionTrue,
 	}
 	actualInternalGroup, exists, _ := npc.internalGroupStore.Get(internalGroupKeyFunc(cg))
 	require.True(t, exists)

--- a/pkg/controller/networkpolicy/clusternetworkpolicy.go
+++ b/pkg/controller/networkpolicy/clusternetworkpolicy.go
@@ -278,7 +278,7 @@ func (n *NetworkPolicyController) processClusterNetworkPolicy(cnp *crdv1alpha1.C
 	// If appliedTo is set at spec level and the ACNP has per-namespace rules, then each appliedTo needs
 	// to be split into appliedToGroups for each of its affected Namespace.
 	var clusterAppliedToAffectedNS []string
-	// atgForNamespace is the appliedToGroups splitted by Namespaces.
+	// atgForNamespace is the appliedToGroups split by Namespaces.
 	var atgForNamespace []string
 	if hasPerNamespaceRule && len(cnp.Spec.AppliedTo) > 0 {
 		for _, at := range cnp.Spec.AppliedTo {
@@ -489,6 +489,31 @@ func getUniqueNSSelectors(selectors []labels.Selector) []labels.Selector {
 	return selectors[:i]
 }
 
+// processInternalGroupForRule examines the internal group (and its childGroups if applicable)
+// to determine whether an addressGroup needs to be created, and returns any ipBlocks contained
+// by the internal Group as well.
+func (n *NetworkPolicyController) processInternalGroupForRule(group *antreatypes.Group) (bool, []controlplane.IPBlock) {
+	if len(group.IPBlocks) > 0 {
+		return false, group.IPBlocks
+	} else if len(group.ChildGroups) == 0 {
+		return true, nil
+	}
+	var ipBlocks []controlplane.IPBlock
+	createAddrGroup := false
+	for _, childName := range group.ChildGroups {
+		childGroup, found, _ := n.internalGroupStore.Get(childName)
+		if found {
+			child := childGroup.(*antreatypes.Group)
+			createChildAG, ipb := n.processInternalGroupForRule(child)
+			if createChildAG {
+				createAddrGroup = true
+			}
+			ipBlocks = append(ipBlocks, ipb...)
+		}
+	}
+	return createAddrGroup, ipBlocks
+}
+
 // processRefCG processes the ClusterGroup reference present in the rule and returns the
 // NetworkPolicyPeer with the corresponding AddressGroup or IPBlock.
 func (n *NetworkPolicyController) processRefCG(g string) (string, []controlplane.IPBlock) {
@@ -510,12 +535,17 @@ func (n *NetworkPolicyController) processRefCG(g string) (string, []controlplane
 		return "", nil
 	}
 	intGrp := ig.(*antreatypes.Group)
-	if len(intGrp.IPBlocks) > 0 {
-		return "", intGrp.IPBlocks
+	// The ClusterGroup referred in the rule might have childGroups defined using selectors
+	// or ipBlocks (or both). An addressGroup needs to be created as long as there is at least
+	// one childGroup defined by selectors, or the ClusterGroup itself is defined by selectors.
+	// In case of updates, the original addressGroup created will be de-referenced and cleaned
+	// up if the ClusterGroup becomes ipBlocks-only.
+	createAddrGroup, ipb := n.processInternalGroupForRule(intGrp)
+	if createAddrGroup {
+		agKey := n.createAddressGroupForClusterGroupCRD(intGrp)
+		return agKey, ipb
 	}
-	agKey := n.createAddressGroupForClusterGroupCRD(intGrp)
-	// Return if addressGroup was created or found.
-	return agKey, nil
+	return "", ipb
 }
 
 func (n *NetworkPolicyController) processAppliedToGroupForCG(g string) string {

--- a/pkg/controller/networkpolicy/crd_utils.go
+++ b/pkg/controller/networkpolicy/crd_utils.go
@@ -108,9 +108,8 @@ func (n *NetworkPolicyController) toAntreaPeerForCRD(peers []v1alpha1.NetworkPol
 			normalizedUID, groupIPBlocks := n.processRefCG(peer.Group)
 			if normalizedUID != "" {
 				addressGroups = append(addressGroups, normalizedUID)
-			} else if len(groupIPBlocks) > 0 {
-				ipBlocks = append(ipBlocks, groupIPBlocks...)
 			}
+			ipBlocks = append(ipBlocks, groupIPBlocks...)
 		} else {
 			normalizedUID := n.createAddressGroup(np.GetNamespace(), peer.PodSelector, peer.NamespaceSelector, peer.ExternalEntitySelector)
 			addressGroups = append(addressGroups, normalizedUID)

--- a/pkg/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller.go
@@ -1111,28 +1111,37 @@ func (n *NetworkPolicyController) getAddressGroupMemberSet(g *antreatypes.Addres
 	groupObj, found, _ := n.internalGroupStore.Get(g.Name)
 	if found {
 		// This AddressGroup is derived from a ClusterGroup.
+		// In case the ClusterGroup is defined by a mix of childGroup with selectors and
+		// childGroup with ipBlocks, this function only returns the aggregated GroupMemberSet
+		// computed from childGroup with selectors, as ipBlocks will be processed differently.
 		group := groupObj.(*antreatypes.Group)
-		return n.getClusterGroupMemberSet(group)
+		members, _ := n.getClusterGroupMembers(group)
+		return members
 	}
 	return n.getMemberSetForGroupType(addressGroupType, g.Name)
 }
 
-// getClusterGroupMemberSet knows how to construct a GroupMemberSet that contains
+// getClusterGroupMembers knows how to construct a GroupMemberSet and ipBlocks that contains
 // all the entities selected by a ClusterGroup. For ClusterGroup that has childGroups,
 // the members are computed as the union of all its childGroup's members.
-func (n *NetworkPolicyController) getClusterGroupMemberSet(group *antreatypes.Group) controlplane.GroupMemberSet {
-	if len(group.ChildGroups) == 0 {
-		return n.getMemberSetForGroupType(clusterGroupType, group.Name)
+func (n *NetworkPolicyController) getClusterGroupMembers(group *antreatypes.Group) (controlplane.GroupMemberSet, []controlplane.IPBlock) {
+	if len(group.IPBlocks) > 0 {
+		return nil, group.IPBlocks
+	} else if len(group.ChildGroups) == 0 {
+		return n.getMemberSetForGroupType(clusterGroupType, group.Name), nil
 	}
+	var ipBlocks []controlplane.IPBlock
 	groupMemberSet := controlplane.GroupMemberSet{}
 	for _, childName := range group.ChildGroups {
 		childGroup, found, _ := n.internalGroupStore.Get(childName)
 		if found {
 			child := childGroup.(*antreatypes.Group)
-			groupMemberSet.Merge(n.getMemberSetForGroupType(clusterGroupType, child.Name))
+			members, ipb := n.getClusterGroupMembers(child)
+			ipBlocks = append(ipBlocks, ipb...)
+			groupMemberSet.Merge(members)
 		}
 	}
-	return groupMemberSet
+	return groupMemberSet, ipBlocks
 }
 
 // getMemberSetForGroupType knows how to construct a GroupMemberSet for the given

--- a/pkg/controller/types/group.go
+++ b/pkg/controller/types/group.go
@@ -19,6 +19,7 @@ import (
 	"sort"
 	"strings"
 
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -104,6 +105,9 @@ type Group struct {
 	UID types.UID
 	// Name of the ClusterGroup for which this internal Group is created.
 	Name string
+	// MembersComputed knows whether the controller has computed the comprehensive members
+	// of the Group. It is updated during the syncInternalGroup process.
+	MembersComputed v1.ConditionStatus
 	// Selector describes how the internal group selects Pods to get their addresses.
 	// Selector is nil if Group is defined with ipBlock, or if it has ServiceReference
 	// and has not been processed by the controller yet / Service cannot be found.

--- a/test/e2e/antreapolicy_test.go
+++ b/test/e2e/antreapolicy_test.go
@@ -1366,7 +1366,7 @@ func testACNPClusterGroupRefRuleIPBlocks(t *testing.T) {
 		SetIPBlocks(ipBlock2)
 
 	builder := &ClusterNetworkPolicySpecBuilder{}
-	builder = builder.SetName("acnp-deny-ya-to-x-ips-ingress").
+	builder = builder.SetName("acnp-deny-x-ips-ingress-for-ya").
 		SetPriority(1.0).
 		SetAppliedToGroup([]ACNPAppliedToSpec{
 			{
@@ -1397,7 +1397,7 @@ func testACNPClusterGroupRefRuleIPBlocks(t *testing.T) {
 		},
 	}
 	testCase := []*TestCase{
-		{"ACNP Drop Ingress From Pod: y/a to ClusterGroup with ipBlocks", testStep},
+		{"ACNP Drop Ingress From x to Pod y/a to ClusterGroup with ipBlocks", testStep},
 	}
 	executeTests(t, testCase)
 }
@@ -2323,6 +2323,82 @@ func testACNPNestedClusterGroupCreateAndUpdate(t *testing.T, data *TestData) {
 	executeTestsWithData(t, testCase, data)
 }
 
+func testACNPNestedIPBlockClusterGroupCreateAndUpdate(t *testing.T) {
+	podXAIP, _ := podIPs["x/a"]
+	podXBIP, _ := podIPs["x/b"]
+	genCIDR := func(ip string) string {
+		if strings.Contains(ip, ".") {
+			return ip + "/32"
+		}
+		return ip + "/128"
+	}
+	cg1Name, cg2Name, cg3Name := "cg-x-a-ipb", "cg-x-b-ipb", "cg-select-x-c"
+	cgParentName := "cg-parent"
+	var ipBlockXA, ipBlockXB []crdv1alpha1.IPBlock
+	for i := 0; i < len(podXAIP); i++ {
+		ipBlockXA = append(ipBlockXA, crdv1alpha1.IPBlock{CIDR: genCIDR(podXAIP[i])})
+		ipBlockXB = append(ipBlockXB, crdv1alpha1.IPBlock{CIDR: genCIDR(podXBIP[i])})
+	}
+	cgBuilder1 := &ClusterGroupV1Alpha3SpecBuilder{}
+	cgBuilder1 = cgBuilder1.SetName(cg1Name).SetIPBlocks(ipBlockXA)
+	cgBuilder2 := &ClusterGroupV1Alpha3SpecBuilder{}
+	cgBuilder2 = cgBuilder2.SetName(cg2Name).SetIPBlocks(ipBlockXB)
+	cgParent := &ClusterGroupV1Alpha3SpecBuilder{}
+	cgParent = cgParent.SetName(cgParentName).SetChildGroups([]string{cg1Name, cg2Name})
+
+	builder := &ClusterNetworkPolicySpecBuilder{}
+	builder = builder.SetName("acnp-deny-x-ips-ingress-for-ya").
+		SetPriority(1.0).
+		SetAppliedToGroup([]ACNPAppliedToSpec{
+			{
+				PodSelector: map[string]string{"pod": "a"},
+				NSSelector:  map[string]string{"ns": "y"},
+			},
+		})
+	builder.AddIngress(v1.ProtocolTCP, &p80, nil, nil, nil, nil, nil,
+		nil, nil, false, nil, crdv1alpha1.RuleActionDrop, cgParentName, "")
+
+	reachability := NewReachability(allPods, Connected)
+	reachability.Expect("x/a", "y/a", Dropped)
+	reachability.Expect("x/b", "y/a", Dropped)
+	testStep := &TestStep{
+		"Port 80",
+		reachability,
+		[]metav1.Object{builder.Get()},
+		[]metav1.Object{cgBuilder1.Get(), cgBuilder2.Get(), cgParent.Get()},
+		[]int32{80},
+		v1.ProtocolTCP,
+		0,
+		nil,
+	}
+
+	cgBuilder3 := &ClusterGroupV1Alpha3SpecBuilder{}
+	cgBuilder3 = cgBuilder3.SetName(cg3Name).
+		SetNamespaceSelector(map[string]string{"ns": "x"}, nil).
+		SetPodSelector(map[string]string{"pod": "c"}, nil)
+	updatedCGParent := &ClusterGroupV1Alpha3SpecBuilder{}
+	updatedCGParent = updatedCGParent.SetName(cgParentName).SetChildGroups([]string{cg1Name, cg3Name})
+
+	reachability2 := NewReachability(allPods, Connected)
+	reachability2.Expect("x/a", "y/a", Dropped)
+	reachability2.Expect("x/c", "y/a", Dropped)
+	testStep2 := &TestStep{
+		"Port 80, updated",
+		reachability2,
+		nil,
+		[]metav1.Object{cgBuilder3.Get(), updatedCGParent.Get()},
+		[]int32{80},
+		v1.ProtocolTCP,
+		0,
+		nil,
+	}
+
+	testCase := []*TestCase{
+		{"ACNP Drop Ingress From x to Pod y/a with nested ClusterGroup with ipBlocks", []*TestStep{testStep, testStep2}},
+	}
+	executeTests(t, testCase)
+}
+
 func testACNPNamespaceIsolation(t *testing.T, data *TestData) {
 	builder := &ClusterNetworkPolicySpecBuilder{}
 	builder = builder.SetName("test-acnp-ns-isolation").
@@ -2756,6 +2832,7 @@ func TestAntreaPolicy(t *testing.T) {
 		t.Run("Case=ACNPClusterGroupIngressRuleDenyCGWithXBtoYA", func(t *testing.T) { testACNPIngressRuleDenyCGWithXBtoYA(t) })
 		t.Run("Case=ACNPClusterGroupServiceRef", func(t *testing.T) { testACNPClusterGroupServiceRefCreateAndUpdate(t, data) })
 		t.Run("Case=ACNPNestedClusterGroup", func(t *testing.T) { testACNPNestedClusterGroupCreateAndUpdate(t, data) })
+		t.Run("Case=ACNPNestedIPBlockClusterGroup", func(t *testing.T) { testACNPNestedIPBlockClusterGroupCreateAndUpdate(t) })
 	})
 	// print results for reachability tests
 	printResults()


### PR DESCRIPTION
Cherry pick of #3030 #3383 on release-1.2.

#3030: Fix ClusterGroup realization status logic
#3383: Fix ipBlock referenced in child ClusterGroup not processed

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.