### PR TITLE
Fix e2e issue about wget in busybox

### DIFF
--- a/test/e2e/egress_test.go
+++ b/test/e2e/egress_test.go
@@ -168,8 +168,8 @@ ip netns exec %[1]s /agnhost netexec
 
 			// getClientIP gets the translated client IP by accessing the API that replies the request's client IP.
 			getClientIP := func(pod string) (string, string, error) {
-				cmd := []string{"wget", "-T", "3", "-O", "-", fmt.Sprintf("%s:8080/clientip", serverIPStr)}
-				return data.runCommandFromPod(testNamespace, pod, busyboxContainerName, cmd)
+				url := fmt.Sprintf("%s:8080/clientip", serverIPStr)
+				return data.runWgetCommandOnBusyboxWithRetry(pod, testNamespace, url, 5)
 			}
 
 			// assertClientIP asserts the Pod is translated to the provided client IP.

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -1787,6 +1787,23 @@ func (data *TestData) runNetcatCommandFromTestPodWithProtocol(podName string, ns
 	return fmt.Errorf("nc stdout: <%v>, stderr: <%v>, err: <%v>", stdout, stderr, err)
 }
 
+func (data *TestData) runWgetCommandOnBusyboxWithRetry(podName, ns string, url string, maxAttempts int) (string, string, error) {
+	var stdout, stderr string
+	var err error
+	cmd := []string{"wget", "-O", "-", url, "-T", "1"}
+	for i := 0; i < maxAttempts; i++ {
+		stdout, stderr, err = data.runCommandFromPod(ns, podName, busyboxContainerName, cmd)
+		if err != nil {
+			if i < maxAttempts-1 {
+				time.Sleep(time.Second)
+			}
+		} else {
+			break
+		}
+	}
+	return stdout, stderr, err
+}
+
 func (data *TestData) doesOVSPortExist(antreaPodName string, portName string) (bool, error) {
 	cmd := []string{"ovs-vsctl", "port-to-br", portName}
 	_, stderr, err := data.runCommandFromPod(antreaNamespace, antreaPodName, ovsContainerName, cmd)

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -119,19 +119,19 @@ func probeClientIPFromNode(node string, baseUrl string) (string, error) {
 }
 
 func probeFromPod(data *TestData, pod string, url string) error {
-	_, _, err := data.runCommandFromPod(testNamespace, pod, busyboxContainerName, []string{"wget", "-O", "-", url, "-T", "1", "-t", "5"})
+	_, _, err := data.runWgetCommandOnBusyboxWithRetry(pod, testNamespace, url, 5)
 	return err
 }
 
 func probeHostnameFromPod(data *TestData, pod string, baseUrl string) (string, error) {
 	url := fmt.Sprintf("%s/%s", baseUrl, "hostname")
-	hostname, _, err := data.runCommandFromPod(testNamespace, pod, busyboxContainerName, []string{"wget", "-O", "-", url, "-T", "1", "-t", "5"})
+	hostname, _, err := data.runWgetCommandOnBusyboxWithRetry(pod, testNamespace, url, 5)
 	return hostname, err
 }
 
 func probeClientIPFromPod(data *TestData, pod string, baseUrl string) (string, error) {
 	url := fmt.Sprintf("%s/%s", baseUrl, "clientip")
-	hostPort, _, err := data.runCommandFromPod(testNamespace, pod, busyboxContainerName, []string{"wget", "-O", "-", url, "-T", "1", "-t", "5"})
+	hostPort, _, err := data.runWgetCommandOnBusyboxWithRetry(pod, testNamespace, url, 5)
 	if err != nil {
 		return "", err
 	}
@@ -648,10 +648,10 @@ func testProxyServiceSessionAffinity(ipFamily *corev1.IPFamily, ingressIPs []str
 	require.NoError(t, data.createBusyboxPodOnNode(busyboxPod, testNamespace, nodeName, false))
 	defer data.deletePodAndWait(defaultTimeout, busyboxPod, testNamespace)
 	require.NoError(t, data.podWaitForRunning(defaultTimeout, busyboxPod, testNamespace))
-	stdout, stderr, err := data.runCommandFromPod(testNamespace, busyboxPod, busyboxContainerName, []string{"wget", "-O", "-", svc.Spec.ClusterIP, "-T", "1", "-t", "5"})
+	stdout, stderr, err := data.runWgetCommandOnBusyboxWithRetry(busyboxPod, testNamespace, svc.Spec.ClusterIP, 5)
 	require.NoError(t, err, fmt.Sprintf("ipFamily: %v\nstdout: %s\nstderr: %s\n", *ipFamily, stdout, stderr))
 	for _, ingressIP := range ingressIPs {
-		stdout, stderr, err := data.runCommandFromPod(testNamespace, busyboxPod, busyboxContainerName, []string{"wget", "-O", "-", ingressIP, "-T", "1", "-t", "5"})
+		stdout, stderr, err := data.runWgetCommandOnBusyboxWithRetry(busyboxPod, testNamespace, ingressIP, 5)
 		require.NoError(t, err, fmt.Sprintf("ipFamily: %v\nstdout: %s\nstderr: %s\n", *ipFamily, stdout, stderr))
 	}
 

--- a/test/e2e/service_test.go
+++ b/test/e2e/service_test.go
@@ -158,11 +158,10 @@ func (data *TestData) testNodePort(t *testing.T, isWindows bool, namespace strin
 	nodePort := int(svc.Spec.Ports[0].NodePort)
 	url := fmt.Sprintf("http://%s:%d", nodeIP, nodePort)
 
-	cmd := []string{"wget", "-O", "-", url, "-T", "1", "-t", "5"}
-	stdout, stderr, err := data.runCommandFromPod(namespace, clientName, busyboxContainerName, cmd)
+	stdout, stderr, err := data.runWgetCommandOnBusyboxWithRetry(clientName, namespace, url, 5)
 	if err != nil {
-		t.Errorf("Error when running command '%s' from Pod '%s', stdout: %s, stderr: %s, error: %v",
-			strings.Join(cmd, " "), clientName, stdout, stderr, err)
+		t.Errorf("Error when running 'wget -O - %s' from Pod '%s', stdout: %s, stderr: %s, error: %v",
+			url, clientName, stdout, stderr, err)
 	} else {
 		t.Logf("wget from Pod '%s' to '%s' succeeded", clientName, url)
 	}


### PR DESCRIPTION
Wget in busybox doesn't support retry argument. To avoid
failure of related tests as possible, this PR adds a
function to run wget command in busybox Pod in a loop.

Signed-off-by: Hongliang Liu <lhongliang@vmware.com>