### PR TITLE
Fix contained configuration for Vagrant testbed

### DIFF
--- a/test/e2e/infra/vagrant/playbook/roles/common/templates/containerd.conf.j2
+++ b/test/e2e/infra/vagrant/playbook/roles/common/templates/containerd.conf.j2
@@ -1,7 +1,6 @@
 root = "/var/lib/containerd"
 state = "/run/containerd"
 oom_score = 0
-imports = ["/etc/containerd/runtime_*.toml", "./debug.toml"]
 
 [grpc]
   address = "/run/containerd/containerd.sock"


### PR DESCRIPTION
Recently provisioning the testbed has been failing with:
containerd: failed to load TOML: /etc/containerd/debug.toml: open /etc/containerd/debug.toml: no such file or directory

I am not sure what changed, so I am just removing the `imports`
directive, which is not present in the sample configuration given at
https://containerd.io/docs/getting-started/.

Signed-off-by: Antonin Bas <abas@vmware.com>