### PR TITLE
Bump up kind version to v0.12.0

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -10,7 +10,7 @@ on:
     - release-*
 
 env:
-  KIND_VERSION: v0.11.1
+  KIND_VERSION: v0.12.0
 
 jobs:
   check-changes:

--- a/.github/workflows/kind_upgrade.yml
+++ b/.github/workflows/kind_upgrade.yml
@@ -10,7 +10,7 @@ on:
     - release-*
 
 env:
-  KIND_VERSION: v0.11.1
+  KIND_VERSION: v0.12.0
 
 jobs:
   check-changes:

--- a/.github/workflows/netpol_cyclonus.yml
+++ b/.github/workflows/netpol_cyclonus.yml
@@ -5,7 +5,7 @@ on:
     - cron: '0 0 * * *'
 
 env:
-  KIND_VERSION: v0.11.1
+  KIND_VERSION: v0.12.0
 
 jobs:
 


### PR DESCRIPTION
kind v0.12.0 enables sysctl route_localnet on node images to allow
nodes dns to work. Patching the setting in antrea's script is no longer
needed.

Signed-off-by: Quan Tian <qtian@vmware.com>

Check https://github.com/kubernetes-sigs/kind/releases/tag/v0.12.0#fixes for details.