### PR TITLE
Remove unused job in Benchmark Github Workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,23 +6,7 @@ on:
       - main
 
 jobs:
-  check-changes:
-    name: Check whether tests need to be run based on diff
-    runs-on: [ ubuntu-latest ]
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - uses: antrea-io/has-changes@v1
-        id: check_diff
-        with:
-          args: pkg/*
-    outputs:
-      has_changes: ${{ steps.check_diff.outputs.has_changes }}
-
   go-benchmark-checks:
-    needs: check-changes
-    if: ${{ needs.check-changes.outputs.has_changes == 'yes' || github.event_name == 'push' }}
     name: GoBenchmark
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The "check-changes" job is both incorrect and unused.
Incorrect because it ignores changes in the pkg/ directory, which is the
opposite of what it should be doing. This is probably because of poor
naming of the "args" action parameter for the has-changes action (it
should really be something like "ignore-paths").
Unused because the "go-benchmark-checks" will anyway run for all "push"
changes, and the Github workflow itself is configured to only run for
"push" events (on the main branch).

Signed-off-by: Antonin Bas <abas@vmware.com>