### PR TITLE
Do not panic when processing a PacketIn message for a denied connection

### DIFF
--- a/pkg/agent/controller/networkpolicy/packetin.go
+++ b/pkg/agent/controller/networkpolicy/packetin.go
@@ -160,6 +160,9 @@ func (c *Controller) storeDenyConnection(pktIn *ofctrl.PacketIn) error {
 		rule := c.GetRuleByFlowID(ruleID)
 		if policy == nil || rule == nil {
 			klog.V(4).Infof("Cannot find NetworkPolicy or rule that has ruleID %v", ruleID)
+			// Ignore the connection if there is no matching NetworkPolicy or rule: the
+			// NetworkPolicy must have been deleted or updated.
+			return nil
 		}
 		// Get name and namespace for Antrea Network Policy or Antrea Cluster Network Policy
 		if isAntreaPolicyIngressTable(tableID) {


### PR DESCRIPTION
If the NetworkPolicy or rule cannot be found in the cache.
I assume that this is ok, since the existing log message used for this
scenario has such a high level (4).

Signed-off-by: Antonin Bas <abas@vmware.com>