### PR TITLE
Add SKIP_CNI_BINARIES env var to support skipping installing specified cni bins

### DIFF
--- a/build/images/scripts/install_cni
+++ b/build/images/scripts/install_cni
@@ -2,25 +2,38 @@
 
 set -euo pipefail
 
+# Fetching the list of the binaries that user wants to skip installing.
+IFS=',' read -r -a binaries <<< "$SKIP_CNI_BINARIES"
 # Todo: check version and continue installation only for a newer version
 
 # Install Antrea binary file
 install -m 755 /usr/local/bin/antrea-cni /host/opt/cni/bin/antrea
 
+# Checking the condition before installing the binaries, to ensure that user
+# does not want to skip the corressponding CNI binary file
+
 # Install the loopback plugin.
 # It is required by kubelet on Linux when using docker as the container runtime.
 # We replace the binary files even they are already present on the Node to make
 # sure expected versions are used.
-install -m 755 /opt/cni/bin/loopback /host/opt/cni/bin/loopback
+if [[ ! " ${binaries[*]} " =~ " loopback " ]]; then
+  install -m 755 /opt/cni/bin/loopback /host/opt/cni/bin/loopback
+fi
 
 # Install PortMap CNI binary file. It is required to support hostPort.
-install -m 755 /opt/cni/bin/portmap /host/opt/cni/bin/portmap
+if [[ ! " ${binaries[*]} " =~ " portmap " ]]; then
+  install -m 755 /opt/cni/bin/portmap /host/opt/cni/bin/portmap
+fi
 
 # Install bandwidth CNI binary file. It is required to support traffic shaping.
-install -m 755 /opt/cni/bin/bandwidth /host/opt/cni/bin/bandwidth
+if [[ ! " ${binaries[*]} " =~ " bandwidth " ]]; then
+  install -m 755 /opt/cni/bin/bandwidth /host/opt/cni/bin/bandwidth
+fi
 
 # Install whereabouts IPAM binary file. Required for global IPAM support specific to CNF use cases.
-install -m 755 /opt/cni/bin/whereabouts /host/opt/cni/bin/whereabouts
+if [[ ! " ${binaries[*]} " =~ " whereabouts " ]]; then
+  install -m 755 /opt/cni/bin/whereabouts /host/opt/cni/bin/whereabouts
+fi
 
 # Install Antrea configuration file.
 # Note that it needs to be executed after installing the above binaries because container runtimes such as cri-o may

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -3297,6 +3297,9 @@ spec:
       initContainers:
       - command:
         - install_cni_chaining
+        env:
+        - name: SKIP_CNI_BINARIES
+          value: ""
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         name: install-cni

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -3299,6 +3299,9 @@ spec:
       initContainers:
       - command:
         - install_cni_chaining
+        env:
+        - name: SKIP_CNI_BINARIES
+          value: ""
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         name: install-cni

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -3297,6 +3297,9 @@ spec:
       initContainers:
       - command:
         - install_cni
+        env:
+        - name: SKIP_CNI_BINARIES
+          value: ""
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         name: install-cni

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -3346,6 +3346,9 @@ spec:
       initContainers:
       - command:
         - install_cni
+        env:
+        - name: SKIP_CNI_BINARIES
+          value: ""
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         name: install-cni

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -3302,6 +3302,9 @@ spec:
       initContainers:
       - command:
         - install_cni
+        env:
+        - name: SKIP_CNI_BINARIES
+          value: ""
         image: projects.registry.vmware.com/antrea/antrea-ubuntu:latest
         imagePullPolicy: IfNotPresent
         name: install-cni

--- a/build/yamls/base/agent.yml
+++ b/build/yamls/base/agent.yml
@@ -48,6 +48,11 @@ spec:
               add:
                 # SYS_MODULE is required to load the OVS kernel module.
                 - SYS_MODULE
+          env:
+            # SKIP_CNI_BINARIES takes in values as a comma separated list of
+            # binaries that need to be skipped for installation, e.g. "portmap, bandwidth".
+            - name: SKIP_CNI_BINARIES
+              value: ""
           volumeMounts:
           - name: antrea-config
             mountPath: /etc/antrea/antrea-cni.conflist


### PR DESCRIPTION
Fixes #3422.

This PR adds a new feature by introducing skip_cni_binaries variable, to allow users to skip
installing some of the CNI plugin binaries which they think are not
required for certain reasons.

Signed-off-by: Pulkit Jain <jainpu@vmware.com>