### PR TITLE
Fix issue of TestReconcileGatewayRoutesOnStartup in particular case

### DIFF
--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -400,6 +400,13 @@ func testReconcileGatewayRoutesOnStartup(t *testing.T, data *TestData, isIPv6 bo
 				continue
 			}
 			route := Route{}
+			mask := 32
+			if isIPv6 {
+				mask = 128
+			}
+			if net.ParseIP(matches[1]) != nil {
+				matches[1] = fmt.Sprintf("%s/%d", matches[1], mask)
+			}
 			if _, route.peerPodCIDR, err = net.ParseCIDR(matches[1]); err != nil {
 				return nil, fmt.Errorf("%s is not a valid net CIDR", matches[1])
 			}


### PR DESCRIPTION
When a Service NodePort and an Egress CRD has the same backend Pod, accessing
to the NodePort Service may fail in particular cases. Assume that the backend
When proxyAll is enabled and a LoadBalancer Service that has external IPs is
created, routing entries like `192.168.1.1 via 169.254.0.253 dev antrea-gw0`
will be installed on K8s Node. In this situation, running
TestReconcileGatewayRoutesOnStartup will get a failure since the destination
is an IP without network mask and cannot be parsed to a CIDR.

Signed-off-by: Hongliang Liu <lhongliang@vmware.com>