### PR TITLE
Remove stale service route when proxyAll is disabled

### DIFF
--- a/pkg/agent/route/route_linux.go
+++ b/pkg/agent/route/route_linux.go
@@ -729,8 +729,8 @@ func (c *Client) Reconcile(podCIDRs []string, svcIPs map[string]bool) error {
 		if desiredIPv6GWs.Has(route.Dst.IP.String()) {
 			continue
 		}
-		// Don't delete the routes which are added by AntreaProxy.
-		if c.isServiceRoute(&route) {
+		// Don't delete the routes which are added by AntreaProxy when proxyAll is enabled.
+		if c.proxyAll && c.isServiceRoute(&route) {
 			continue
 		}
 


### PR DESCRIPTION
When proxyAll is enabled, routing entries about Service are added by AntreaProxy,
and then proxyAll is disabled, the routing entries should be removed.

Signed-off-by: Hongliang Liu <lhongliang@vmware.com>