### PR TITLE
Periodic Syncing of NPL iptables Rules

### DIFF
--- a/pkg/agent/nodeportlocal/npl_agent_init.go
+++ b/pkg/agent/nodeportlocal/npl_agent_init.go
@@ -19,6 +19,7 @@ package nodeportlocal
 
 import (
 	"fmt"
+	"time"
 
 	nplk8s "antrea.io/antrea/pkg/agent/nodeportlocal/k8s"
 	"antrea.io/antrea/pkg/agent/nodeportlocal/portcache"
@@ -27,6 +28,8 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 )
+
+const iptablesSyncInterval = 1 * time.Minute
 
 // InitializeNPLAgent initializes the NodePortLocal agent.
 // It sets up event handlers to handle Pod add, update and delete events.
@@ -45,5 +48,5 @@ func InitializeNPLAgent(
 	}
 
 	svcInformer := informerFactory.Core().V1().Services().Informer()
-	return nplk8s.NewNPLController(kubeClient, podInformer, svcInformer, portTable, nodeName), nil
+	return nplk8s.NewNPLController(kubeClient, podInformer, svcInformer, portTable, nodeName, iptablesSyncInterval), nil
 }

--- a/pkg/agent/nodeportlocal/npl_agent_test.go
+++ b/pkg/agent/nodeportlocal/npl_agent_test.go
@@ -253,7 +253,7 @@ func setUp(t *testing.T, tc *testConfig, objects ...runtime.Object) *testData {
 	)
 	svcInformer := informerFactory.Core().V1().Services().Informer()
 
-	c := nplk8s.NewNPLController(data.k8sClient, localPodInformer, svcInformer, data.portTable, defaultNodeName)
+	c := nplk8s.NewNPLController(data.k8sClient, localPodInformer, svcInformer, data.portTable, defaultNodeName, iptablesSyncInterval)
 
 	data.runWrapper(c)
 	informerFactory.Start(data.stopCh)

--- a/pkg/agent/nodeportlocal/rules/iptable_rule.go
+++ b/pkg/agent/nodeportlocal/rules/iptable_rule.go
@@ -45,18 +45,10 @@ func NewIPTableRules() *iptablesRules {
 	return &iptRule
 }
 
-// Init initializes IPTABLES rules for NPL. Currently it deletes existing rules to ensure that no stale entries are present.
-func (ipt *iptablesRules) Init() error {
-	if err := ipt.initRules(); err != nil {
-		return fmt.Errorf("initialization of NPL iptables rules failed: %v", err)
-	}
-	return nil
-}
-
-// initRules creates the NPL chain and links it to the PREROUTING (for incoming
+// SyncFixedRules creates the NPL chain and links it to the PREROUTING (for incoming
 // traffic) and OUTPUT chain (for locally-generated traffic). All NPL DNAT rules
 // will be added to this chain.
-func (ipt *iptablesRules) initRules() error {
+func (ipt *iptablesRules) SyncFixedRules() error {
 	if err := ipt.table.EnsureChain(iptables.ProtocolIPv4, iptables.NATTable, NodePortLocalChain); err != nil {
 		return err
 	}

--- a/pkg/agent/nodeportlocal/rules/rules.go
+++ b/pkg/agent/nodeportlocal/rules/rules.go
@@ -19,11 +19,11 @@ package rules
 
 // PodPortRules is an interface to abstract operations on rules for Pods
 type PodPortRules interface {
-	Init() error
 	AddRule(nodePort int, podIP string, podPort int, protocol string) error
 	DeleteRule(nodePort int, podIP string, podPort int, protocol string) error
 	DeleteAllRules() error
 	AddAllRules(nplList []PodNodePort) error
+	SyncFixedRules() error
 }
 
 // InitRules initializes rules based on the underlying implementation

--- a/pkg/agent/nodeportlocal/rules/testing/mock_rules.go
+++ b/pkg/agent/nodeportlocal/rules/testing/mock_rules.go
@@ -36,6 +36,10 @@ type MockPodPortRulesMockRecorder struct {
 	mock *MockPodPortRules
 }
 
+func (m *MockPodPortRules) SyncFixedRules() error {
+	return nil
+}
+
 // NewMockPodPortRules creates a new mock instance
 func NewMockPodPortRules(ctrl *gomock.Controller) *MockPodPortRules {
 	mock := &MockPodPortRules{ctrl: ctrl}

--- a/pkg/agent/util/iptables/iptables.go
+++ b/pkg/agent/util/iptables/iptables.go
@@ -151,6 +151,25 @@ func (c *Client) ChainExists(protocol Protocol, table string, chain string) (boo
 	return true, nil
 }
 
+//Exists function checks whether rules are present in a particular chain
+func (c *Client) Exists(protocol Protocol, table, chain string, rulespec []string) (bool, error) {
+	for p := range c.ipts {
+		ipt := c.ipts[p]
+		if !matchProtocol(ipt, protocol) {
+			continue
+		}
+		exists, err := ipt.Exists(table, chain, rulespec...)
+		if err != nil {
+			return false, fmt.Errorf("error checking if rule exists: %s", err)
+		}
+		if !exists {
+			return false, nil
+		}
+		klog.V(2).InfoS("Rule exists", "chain", chain, "table", table, "protocol", p)
+	}
+	return true, nil
+}
+
 // AppendRule checks if target rule already exists with the protocol, appends it if not.
 func (c *Client) AppendRule(protocol Protocol, table string, chain string, ruleSpec []string) error {
 	for p := range c.ipts {

--- a/test/integration/agent/npl_test.go
+++ b/test/integration/agent/npl_test.go
@@ -1,0 +1,132 @@
+//go:build linux
+// +build linux
+
+// Copyright 2022 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"testing"
+	"time"
+
+	nplcontroller "antrea.io/antrea/pkg/agent/nodeportlocal/k8s"
+	portcache "antrea.io/antrea/pkg/agent/nodeportlocal/portcache"
+	rules "antrea.io/antrea/pkg/agent/nodeportlocal/rules"
+	iptables "antrea.io/antrea/pkg/agent/util/iptables"
+)
+
+func TestNPLIptablesRestore(t *testing.T) {
+	portTable, err := portcache.NewPortTable(61000, 62000)
+	if err != nil {
+		t.Fatalf("Failed to initialize porttable: %v", err)
+	}
+	// get testing NPLController
+	synced := make(chan struct{})
+	nplCtrl := nplcontroller.NewTestingNPLController(portTable, 1*time.Second)
+	// add the static rules
+	err = portTable.PodPortRules.SyncFixedRules()
+	if err != nil {
+		t.Fatalf("Failed to add static rules: %v", err)
+	}
+	defer func() {
+		err := portTable.PodPortRules.DeleteAllRules()
+		if err != nil {
+			t.Fatalf("Failed to delete iptables rules: %v", err)
+		}
+	}()
+	// add some initial iptables rules from some fake pod data
+	allNPLPorts := []rules.PodNodePort{
+		{
+			NodePort:  61001,
+			PodPort:   80,
+			PodIP:     "20.0.0.1",
+			Protocols: []string{"tcp"},
+		},
+		{
+			NodePort:  61002,
+			PodPort:   80,
+			PodIP:     "21.0.0.2",
+			Protocols: []string{"tcp", "udp"},
+		},
+	}
+	err = portTable.RestoreRules(allNPLPorts, synced)
+	if err != nil {
+		t.Fatalf("Failed to add iptables rules %v", err)
+	}
+	t.Logf("Waiting for portTable to set NPL iptables rules")
+	<-synced
+	t.Logf("Success set NPL iptables rules")
+	// delete iptables rules including the static rules
+	err = portTable.PodPortRules.DeleteAllRules()
+	if err != nil {
+		t.Fatalf("Failed to delete iptables rules: %v", err)
+	}
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	go nplCtrl.SyncRules(stopCh)
+	t.Logf("Waiting for NPLController to recover NPL iptables rules")
+	time.Sleep(nplCtrl.SyncRuleInterval + 1*time.Second)
+	t.Logf("Checking if NPL iptables rules are recovered")
+	// check if NPL chain is present.
+	ipt, err := iptables.New(true, false)
+	exists, err := ipt.ChainExists(iptables.ProtocolIPv4, iptables.NATTable, rules.NodePortLocalChain)
+	if exists {
+		t.Logf("NPL chain exists in nat table.")
+	} else {
+		t.Fatalf("error checking if  NPL chain  exists in nat table ")
+	}
+
+	//Check if static rules are restored.
+	rulespec := []string{
+		"-p", "all", "-m", "addrtype", "--dst-type", "LOCAL", "-j", rules.NodePortLocalChain,
+	}
+	exists, err = ipt.Exists(iptables.ProtocolIPv4, iptables.NATTable, iptables.PreRoutingChain, rulespec)
+	if exists {
+		t.Logf("Static rules successfully restored in PreRouting chain")
+	} else {
+		t.Fatalf("Failed to restore static rules in PreRouting Chain ")
+	}
+
+	exists, err = ipt.Exists(iptables.ProtocolIPv4, iptables.NATTable, iptables.OutputChain, rulespec)
+	if exists {
+		t.Logf("Static rules successfully restored in Output chain")
+	} else {
+		t.Fatalf("Failed to restore static rules in Output Chain ")
+	}
+
+	//Check if dynamic rules are restored.
+	ruleSpecs := [][]string{
+		{
+			"-p", "tcp", "-m", "tcp", "--dport", "61001",
+			"-j", "DNAT", "--to-destination", "20.0.0.1:80",
+		},
+		{
+			"-p", "tcp", "-m", "tcp", "--dport", "61002",
+			"-j", "DNAT", "--to-destination", "21.0.0.2:80",
+		},
+		{
+			"-p", "udp", "-m", "udp", "--dport", "61002",
+			"-j", "DNAT", "--to-destination", "21.0.0.2:80",
+		},
+	}
+	for n, ruleSpec := range ruleSpecs {
+		exists, err = ipt.Exists(iptables.ProtocolIPv4, iptables.NATTable, rules.NodePortLocalChain, ruleSpec)
+		if exists {
+			t.Logf("Dynamic rule %d successfully restored in NPL chain", n)
+		} else {
+			t.Fatalf("Failed to restore dynamic rule %d in NPL Chain ", n)
+		}
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/antrea-io/antrea/issues/2210

Periodically verify that all required NodePortLocal iptables rules are present in the Node.

Changes made to npl_controller.go where a go routine was added to periodically call the SyncRules() function from port_table.go .

Signed off by : Naman Agarwal agarwalna@vmware.com