### PR TITLE
Update default image to vmware registry

### DIFF
--- a/multicluster/build/yamls/antrea-multicluster-leader-namespaced.yml
+++ b/multicluster/build/yamls/antrea-multicluster-leader-namespaced.yml
@@ -585,7 +585,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: antrea/antrea-mc-controller:latest
+        image: projects.registry.vmware.com/antrea/antrea-mc-controller:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/multicluster/build/yamls/antrea-multicluster-member.yml
+++ b/multicluster/build/yamls/antrea-multicluster-member.yml
@@ -2331,7 +2331,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: antrea/antrea-mc-controller:latest
+        image: projects.registry.vmware.com/antrea/antrea-mc-controller:latest
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/multicluster/hack/generate-manifest.sh
+++ b/multicluster/hack/generate-manifest.sh
@@ -131,6 +131,8 @@ fi
 
 if [ "$MODE" == "release" ]; then
     $KUSTOMIZE edit set image antrea/antrea-mc-controller=$IMG_NAME:$IMG_TAG
+else
+    $KUSTOMIZE edit set image antrea/antrea-mc-controller=projects.registry.vmware.com/antrea/antrea-mc-controller:latest
 fi
 $KUSTOMIZE build
 rm -rf $TMP_DIR


### PR DESCRIPTION
Update the default multi-cluster image to
projects.registry.vmware.com/antrea/antrea-mc-controller:latest
which is the same as other antrea manifests.

Signed-off-by: Lan Luo <luola@vmware.com>