### PR TITLE
Automated cherry pick of #3467: Fix duplicate IP case for NetworkPolicy

### DIFF
--- a/pkg/agent/controller/networkpolicy/cache_test.go
+++ b/pkg/agent/controller/networkpolicy/cache_test.go
@@ -193,6 +193,18 @@ func newAddressGroupMember(ips ...string) *v1beta2.GroupMember {
 	return &v1beta2.GroupMember{IPs: ipAddrs}
 }
 
+func newAddressGroupPodMember(name, namespace string, ips ...string) *v1beta2.GroupMember {
+	ipAddrs := make([]v1beta2.IPAddress, len(ips))
+	for idx, ip := range ips {
+		ipAddrs[idx] = v1beta2.IPAddress(net.ParseIP(ip))
+	}
+	pod := &v1beta2.PodReference{
+		Name:      name,
+		Namespace: namespace,
+	}
+	return &v1beta2.GroupMember{Pod: pod, IPs: ipAddrs}
+}
+
 func TestRuleCacheAddAddressGroup(t *testing.T) {
 	rule1 := &rule{
 		ID:   "rule1",

--- a/pkg/agent/controller/networkpolicy/reconciler.go
+++ b/pkg/agent/controller/networkpolicy/reconciler.go
@@ -674,8 +674,8 @@ func (r *reconciler) update(lastRealized *lastRealized, newRule *CompletedRule, 
 				}
 				lastRealized.ofIDs[svcKey] = ofRule.FlowID
 			} else {
-				addedTo := groupMembersToOFAddresses(members.Difference(prevMembersByServicesMap[svcKey]))
-				deletedTo := groupMembersToOFAddresses(prevMembersByServicesMap[svcKey].Difference(members))
+				addedTo := ipsToOFAddresses(members.IPDifference(prevMembersByServicesMap[svcKey]))
+				deletedTo := ipsToOFAddresses(prevMembersByServicesMap[svcKey].IPDifference(members))
 				originalFQDNAddressSet, newFQDNAddressSet := sets.NewString(), sets.NewString()
 				if r.fqdnController != nil {
 					if lastRealized.fqdnIPAddresses != nil {


### PR DESCRIPTION
Cherry pick of #3467 on release-1.3.

#3467: Fix duplicate IP case for NetworkPolicy

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.