### PR TITLE
Automated cherry pick of #3430: Fix pkt mark conflict between HostLocalSourceMark and

### DIFF
--- a/pkg/agent/types/marks.go
+++ b/pkg/agent/types/marks.go
@@ -16,8 +16,8 @@ package types
 
 const (
 	// HostLocalSourceBit is the bit of the iptables fwmark space to mark locally generated packets.
-	// Value must be within the range [0, 31].
-	HostLocalSourceBit = 0
+	// Value must be within the range [0, 31], and should not conflict with bits for other purposes.
+	HostLocalSourceBit = 31
 )
 
 var (

--- a/test/integration/agent/route_test.go
+++ b/test/integration/agent/route_test.go
@@ -205,7 +205,7 @@ func TestInitialize(t *testing.T) {
 :ANTREA-OUTPUT - [0:0]
 -A PREROUTING -m comment --comment "Antrea: jump to Antrea mangle rules" -j ANTREA-MANGLE
 -A OUTPUT -m comment --comment "Antrea: jump to Antrea output rules" -j ANTREA-OUTPUT
--A ANTREA-OUTPUT -o antrea-gw0 -m comment --comment "Antrea: mark LOCAL output packets" -m addrtype --src-type LOCAL -j MARK --set-xmark 0x1/0x1
+-A ANTREA-OUTPUT -o antrea-gw0 -m comment --comment "Antrea: mark LOCAL output packets" -m addrtype --src-type LOCAL -j MARK --set-xmark 0x80000000/0x80000000
 `,
 			"nat": `:ANTREA-POSTROUTING - [0:0]
 -A POSTROUTING -m comment --comment "Antrea: jump to Antrea postrouting rules" -j ANTREA-POSTROUTING


### PR DESCRIPTION
Cherry pick of #3430 on release-1.4.

#3430: Fix pkt mark conflict between HostLocalSourceMark and

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.