### PR TITLE
Automated cherry pick of #3219: Add ignored interfaces names when getting interface by IP

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -293,17 +293,9 @@ func run(o *Options) error {
 	}
 
 	var egressController *egress.EgressController
-	var nodeTransportIP net.IP
-	if nodeConfig.NodeTransportIPv4Addr != nil {
-		nodeTransportIP = nodeConfig.NodeTransportIPv4Addr.IP
-	} else if nodeConfig.NodeTransportIPv6Addr != nil {
-		nodeTransportIP = nodeConfig.NodeTransportIPv6Addr.IP
-	} else {
-		return fmt.Errorf("invalid Node Transport IPAddr in Node config: %v", nodeConfig)
-	}
 	if features.DefaultFeatureGate.Enabled(features.Egress) {
 		egressController, err = egress.NewEgressController(
-			ofClient, antreaClientProvider, crdClient, ifaceStore, routeClient, nodeConfig.Name, nodeTransportIP,
+			ofClient, antreaClientProvider, crdClient, ifaceStore, routeClient, nodeConfig.Name, nodeConfig.NodeTransportInterfaceName,
 			o.config.ClusterMembershipPort, egressInformer, nodeInformer, externalIPPoolInformer,
 		)
 		if err != nil {

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -28,6 +28,7 @@ import (
 	"github.com/containernetworking/plugins/pkg/ip"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apitypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
@@ -47,6 +48,7 @@ import (
 	"antrea.io/antrea/pkg/ovs/ovsconfig"
 	"antrea.io/antrea/pkg/ovs/ovsctl"
 	"antrea.io/antrea/pkg/util/env"
+	utilip "antrea.io/antrea/pkg/util/ip"
 	"antrea.io/antrea/pkg/util/k8s"
 )
 
@@ -729,7 +731,7 @@ func (i *Initializer) initNodeLocalConfig() error {
 	if err != nil {
 		return fmt.Errorf("failed to obtain local IP addresses from K8s: %w", err)
 	}
-	nodeIPv4Addr, nodeIPv6Addr, localIntf, err = getIPNetDeviceFromIP(ipAddrs)
+	nodeIPv4Addr, nodeIPv6Addr, localIntf, err = i.getNodeInterfaceFromIP(ipAddrs)
 	if err != nil {
 		return fmt.Errorf("failed to get local IPNet device with IP %v: %v", ipAddrs, err)
 	}
@@ -787,16 +789,17 @@ func (i *Initializer) initNodeLocalConfig() error {
 	}
 
 	i.nodeConfig = &config.NodeConfig{
-		Name:                  nodeName,
-		OVSBridge:             i.ovsBridge,
-		DefaultTunName:        defaultTunInterfaceName,
-		NodeIPv4Addr:          nodeIPv4Addr,
-		NodeIPv6Addr:          nodeIPv6Addr,
-		NodeTransportIPv4Addr: transportIPv4Addr,
-		NodeTransportIPv6Addr: transportIPv6Addr,
-		UplinkNetConfig:       new(config.AdapterNetConfig),
-		NodeLocalInterfaceMTU: localIntf.MTU,
-		WireGuardConfig:       i.wireGuardConfig,
+		Name:                       nodeName,
+		OVSBridge:                  i.ovsBridge,
+		DefaultTunName:             defaultTunInterfaceName,
+		NodeIPv4Addr:               nodeIPv4Addr,
+		NodeIPv6Addr:               nodeIPv6Addr,
+		NodeTransportInterfaceName: localIntf.Name,
+		NodeTransportIPv4Addr:      transportIPv4Addr,
+		NodeTransportIPv6Addr:      transportIPv6Addr,
+		UplinkNetConfig:            new(config.AdapterNetConfig),
+		NodeLocalInterfaceMTU:      localIntf.MTU,
+		WireGuardConfig:            i.wireGuardConfig,
 	}
 
 	mtu, err := i.getNodeMTU(localIntf)
@@ -1047,4 +1050,11 @@ func (i *Initializer) patchNodeAnnotations(nodeName, key string, value interface
 		return err
 	}
 	return nil
+}
+
+// getNodeInterfaceFromIP returns the IPv4/IPv6 configuration, and the associated interface according the give nodeIPs.
+// When searching the Node interface, antrea-gw0 is ignored because it is configured with the same address as Node IP
+// with NetworkPolicyOnly mode on public cloud setup, e.g., AKS.
+func (i *Initializer) getNodeInterfaceFromIP(nodeIPs *utilip.DualStackIPs) (v4IPNet *net.IPNet, v6IPNet *net.IPNet, iface *net.Interface, err error) {
+	return getIPNetDeviceFromIP(nodeIPs, sets.NewString(i.hostGateway))
 }

--- a/pkg/agent/agent_linux.go
+++ b/pkg/agent/agent_linux.go
@@ -47,7 +47,7 @@ func (i *Initializer) prepareOVSBridge() error {
 	klog.Infof("Preparing OVS bridge for AntreaFlexibleIPAM")
 	// Get uplink network configuration.
 	// TODO(gran): support IPv6
-	_, _, adapter, err := util.GetIPNetDeviceFromIP(&utilip.DualStackIPs{IPv4: i.nodeConfig.NodeIPv4Addr.IP})
+	_, _, adapter, err := i.getNodeInterfaceFromIP(&utilip.DualStackIPs{IPv4: i.nodeConfig.NodeIPv4Addr.IP})
 	if err != nil {
 		return err
 	}

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes/fake"
 
 	"antrea.io/antrea/pkg/agent/cniserver"
@@ -356,15 +357,16 @@ func TestInitNodeLocalConfig(t *testing.T) {
 			client := fake.NewSimpleClientset(node)
 			ifaceStore := interfacestore.NewInterfaceStore()
 			expectedNodeConfig := config.NodeConfig{
-				Name:                  nodeName,
-				OVSBridge:             ovsBridge,
-				DefaultTunName:        defaultTunInterfaceName,
-				PodIPv4CIDR:           podCIDR,
-				NodeIPv4Addr:          nodeIPNet,
-				NodeTransportIPv4Addr: nodeIPNet,
-				NodeLocalInterfaceMTU: tt.expectedNodeLocalIfaceMTU,
-				NodeMTU:               tt.expectedMTU,
-				UplinkNetConfig:       new(config.AdapterNetConfig),
+				Name:                       nodeName,
+				OVSBridge:                  ovsBridge,
+				DefaultTunName:             defaultTunInterfaceName,
+				PodIPv4CIDR:                podCIDR,
+				NodeIPv4Addr:               nodeIPNet,
+				NodeTransportInterfaceName: ipDevice.Name,
+				NodeTransportIPv4Addr:      nodeIPNet,
+				NodeLocalInterfaceMTU:      tt.expectedNodeLocalIfaceMTU,
+				NodeMTU:                    tt.expectedMTU,
+				UplinkNetConfig:            new(config.AdapterNetConfig),
 			}
 
 			initializer := &Initializer{
@@ -402,7 +404,7 @@ func TestInitNodeLocalConfig(t *testing.T) {
 
 func mockGetIPNetDeviceFromIP(ipNet *net.IPNet, ipDevice *net.Interface) func() {
 	prevGetIPNetDeviceFromIP := getIPNetDeviceFromIP
-	getIPNetDeviceFromIP = func(localIP *ip.DualStackIPs) (*net.IPNet, *net.IPNet, *net.Interface, error) {
+	getIPNetDeviceFromIP = func(localIP *ip.DualStackIPs, ignoredHostInterfaces sets.String) (*net.IPNet, *net.IPNet, *net.Interface, error) {
 		return ipNet, nil, ipDevice, nil
 	}
 	return func() { getIPNetDeviceFromIP = prevGetIPNetDeviceFromIP }

--- a/pkg/agent/agent_windows.go
+++ b/pkg/agent/agent_windows.go
@@ -51,7 +51,7 @@ func (i *Initializer) prepareHostNetwork() error {
 	// Get uplink network configuration. The uplink interface is the one used for transporting Pod traffic across Nodes.
 	// Use the interface specified with "transportInterface" in the configuration if configured, otherwise the interface
 	// configured with NodeIP is used as uplink.
-	_, _, adapter, err := util.GetIPNetDeviceFromIP(&ip.DualStackIPs{IPv4: i.nodeConfig.NodeTransportIPv4Addr.IP})
+	_, _, adapter, err := i.getNodeInterfaceFromIP(&ip.DualStackIPs{IPv4: i.nodeConfig.NodeTransportIPv4Addr.IP})
 	if err != nil {
 		return err
 	}

--- a/pkg/agent/config/node_config.go
+++ b/pkg/agent/config/node_config.go
@@ -118,6 +118,9 @@ type NodeConfig struct {
 	NodeIPv4Addr *net.IPNet
 	// The Node's IPv6 address used in Kubernetes. It has the network mask information.
 	NodeIPv6Addr *net.IPNet
+	// The name of the Node's transport interface. The transport interface defaults to the interface that has the K8s
+	// Node IP, and can be overridden by the configuration parameters TransportInterface and TransportInterfaceCIDRs.
+	NodeTransportInterfaceName string
 	// The IPv4 address on the Node's transport interface. It is used for tunneling or routing the Pod traffic across Nodes.
 	NodeTransportIPv4Addr *net.IPNet
 	// The IPv6 address on the Node's transport interface. It is used for tunneling or routing the Pod traffic across Nodes.

--- a/pkg/agent/controller/egress/egress_controller.go
+++ b/pkg/agent/controller/egress/egress_controller.go
@@ -151,7 +151,7 @@ func NewEgressController(
 	ifaceStore interfacestore.InterfaceStore,
 	routeClient route.Interface,
 	nodeName string,
-	nodeTransportIP net.IP,
+	nodeTransportInterface string,
 	clusterPort int,
 	egressInformer crdinformers.EgressInformer,
 	nodeInformer coreinformers.NodeInformer,
@@ -176,7 +176,7 @@ func NewEgressController(
 		localIPDetector:      localIPDetector,
 		idAllocator:          newIDAllocator(minEgressMark, maxEgressMark),
 	}
-	ipAssigner, err := ipassigner.NewIPAssigner(nodeTransportIP, egressDummyDevice)
+	ipAssigner, err := ipassigner.NewIPAssigner(nodeTransportInterface, egressDummyDevice)
 	if err != nil {
 		return nil, fmt.Errorf("initializing egressIP assigner failed: %v", err)
 	}

--- a/pkg/agent/controller/egress/ipassigner/ip_assigner_linux.go
+++ b/pkg/agent/controller/egress/ipassigner/ip_assigner_linux.go
@@ -26,7 +26,6 @@ import (
 	"antrea.io/antrea/pkg/agent/util"
 	"antrea.io/antrea/pkg/agent/util/arping"
 	"antrea.io/antrea/pkg/agent/util/ndp"
-	"antrea.io/antrea/pkg/util/ip"
 )
 
 // ipAssigner creates a dummy device and assigns IPs to it.
@@ -47,16 +46,10 @@ type ipAssigner struct {
 }
 
 // NewIPAssigner returns an *ipAssigner.
-func NewIPAssigner(nodeTransportIPAddr net.IP, dummyDeviceName string) (*ipAssigner, error) {
-	nodeTransportIPs := new(ip.DualStackIPs)
-	if nodeTransportIPAddr.To4() == nil {
-		nodeTransportIPs.IPv6 = nodeTransportIPAddr
-	} else {
-		nodeTransportIPs.IPv4 = nodeTransportIPAddr
-	}
-	_, _, egressInterface, err := util.GetIPNetDeviceFromIP(nodeTransportIPs)
+func NewIPAssigner(nodeTransportInterface string, dummyDeviceName string) (*ipAssigner, error) {
+	_, _, externalInterface, err := util.GetIPNetDeviceByName(nodeTransportInterface)
 	if err != nil {
-		return nil, fmt.Errorf("get IPNetDevice from ip %v error: %+v", nodeTransportIPAddr, err)
+		return nil, fmt.Errorf("get IPNetDevice from name %s error: %+v", nodeTransportInterface, err)
 	}
 
 	dummyDevice, err := ensureDummyDevice(dummyDeviceName)
@@ -65,7 +58,7 @@ func NewIPAssigner(nodeTransportIPAddr net.IP, dummyDeviceName string) (*ipAssig
 	}
 
 	a := &ipAssigner{
-		externalInterface: egressInterface,
+		externalInterface: externalInterface,
 		dummyDevice:       dummyDevice,
 		assignedIPs:       sets.NewString(),
 	}

--- a/pkg/agent/controller/egress/ipassigner/ip_assigner_windows.go
+++ b/pkg/agent/controller/egress/ipassigner/ip_assigner_windows.go
@@ -15,15 +15,13 @@
 package ipassigner
 
 import (
-	"net"
-
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 type ipAssigner struct {
 }
 
-func NewIPAssigner(nodeTransportIPAddr net.IP, dummyDeviceName string) (*ipAssigner, error) {
+func NewIPAssigner(nodeTransportInterface string, dummyDeviceName string) (*ipAssigner, error) {
 	return nil, nil
 }
 

--- a/pkg/agent/util/net_test.go
+++ b/pkg/agent/util/net_test.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	"antrea.io/antrea/pkg/util/ip"
 )
 
@@ -58,7 +60,7 @@ func TestGetDefaultLocalNodeAddr(t *testing.T) {
 	localAddr := conn.LocalAddr().(*net.UDPAddr).IP
 
 	nodeIPs := &ip.DualStackIPs{IPv4: localAddr}
-	_, _, dev, err := GetIPNetDeviceFromIP(nodeIPs)
+	_, _, dev, err := GetIPNetDeviceFromIP(nodeIPs, sets.NewString())
 	if err != nil {
 		t.Error(err)
 	}

--- a/test/integration/agent/ip_assigner_linux_test.go
+++ b/test/integration/agent/ip_assigner_linux_test.go
@@ -30,10 +30,10 @@ import (
 const dummyDeviceName = "antrea-dummy0"
 
 func TestIPAssigner(t *testing.T) {
-	nodeIPAddr := nodeIPv4.IP
-	require.NotNil(t, nodeIPAddr, "Get Node IP failed")
+	nodeLinkName := nodeIntf.Name
+	require.NotNil(t, nodeLinkName, "Get Node link failed")
 
-	ipAssigner, err := ipassigner.NewIPAssigner(nodeIPAddr, dummyDeviceName)
+	ipAssigner, err := ipassigner.NewIPAssigner(nodeLinkName, dummyDeviceName)
 	require.NoError(t, err, "Initializing IP assigner failed")
 
 	dummyDevice, err := netlink.LinkByName(dummyDeviceName)
@@ -65,7 +65,7 @@ func TestIPAssigner(t *testing.T) {
 	assert.Equal(t, desiredIPs, actualIPs, "Actual IPs don't match")
 
 	// NewIPAssigner should load existing IPs correctly.
-	newIPAssigner, err := ipassigner.NewIPAssigner(nodeIPAddr, dummyDeviceName)
+	newIPAssigner, err := ipassigner.NewIPAssigner(nodeLinkName, dummyDeviceName)
 	require.NoError(t, err, "Initializing new IP assigner failed")
 	assert.Equal(t, desiredIPs, newIPAssigner.AssignedIPs(), "Assigned IPs don't match")
 

--- a/test/integration/agent/route_test.go
+++ b/test/integration/agent/route_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/net/nettest"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"antrea.io/antrea/pkg/agent/config"
 	"antrea.io/antrea/pkg/agent/route"
@@ -55,7 +56,7 @@ var (
 		conn, _ := net.Dial("udp", "8.8.8.8:80")
 		defer conn.Close()
 		return &utilip.DualStackIPs{IPv4: conn.LocalAddr().(*net.UDPAddr).IP}
-	}())
+	}(), sets.NewString())
 	nodeLink, _       = netlink.LinkByName(nodeIntf.Name)
 	localPeerIP       = ip.NextIP(nodeIPv4.IP)
 	remotePeerIP      = net.ParseIP("50.50.50.1")


### PR DESCRIPTION
Cherry pick of #3219 on release-1.4.

#3219: Add ignored interfaces names when getting interface by IP

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.