### PR TITLE
Use the correct mc controller image for e2e testing

### DIFF
--- a/ci/jenkins/test-mc.sh
+++ b/ci/jenkins/test-mc.sh
@@ -222,7 +222,7 @@ function deliver_multicluster_controller {
     docker images | grep 'mc-controller' | awk '{print $3}' | xargs -r docker rmi || true
     export NO_PULL=1;make antrea-mc-controller
 
-    docker save antrea/antrea-mc-controller:latest -o "${WORKDIR}"/antrea-mcs.tar
+    docker save projects.registry.vmware.com/antrea/antrea-mc-controller:latest -o "${WORKDIR}"/antrea-mcs.tar
     ./multicluster/hack/generate-manifest.sh -l antrea-mcs-ns >./multicluster/test/yamls/manifest.yml
 
     for kubeconfig in ${multicluster_kubeconfigs[@]}


### PR DESCRIPTION
Fix issue in multi-cluster e2e tests introduced by #3466.
The pipeline is not picking up the correct image to test because it's saving the newly built image as `antrea/antrea-mc-controller:latest` instead of `projects.registry.vmware.com/antrea/antrea-mc-controller:latest`.

Signed-off-by: Yang Ding <dingyang@vmware.com>