### PR TITLE
Use upstream action for markdown link check

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -204,7 +204,7 @@ jobs:
     - name: Run verify scripts
       run: make verify
     - name: Checking for broken Markdown links
-      uses: antoninbas/github-action-markdown-link-check@1.0.9-pre
+      uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
         folder-path: './docs'
         file-path: './README.md, ./CHANGELOG.md, ./CONTRIBUTING.md, ./GOVERNANCE.md, ./MAINTAINERS.md, ./ROADMAP.md, ./SECURITY.md'


### PR DESCRIPTION
We were using a fork temporarily because of a bug that had not been
fixed yet. The bug was fixed upstream a while back and we can now
switch back to the upstream action. It may help with the transient
failures we sometimes observe for this Github workflow.

Signed-off-by: Antonin Bas <abas@vmware.com>