### PR TITLE
Fix incorrect results by `antctl get networkpolicy` on Pods

### DIFF
--- a/pkg/agent/apiserver/handlers/networkpolicy/handler.go
+++ b/pkg/agent/apiserver/handlers/networkpolicy/handler.go
@@ -30,7 +30,7 @@ import (
 // to query network policy rules in current agent.
 func HandleFunc(aq agentquerier.AgentQuerier) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		npFilter, err := newFilterFromURLQuery(r.URL.Query())
+		npFilter, pod, err := newFilterFromURLQuery(r.URL.Query())
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
@@ -40,10 +40,11 @@ func HandleFunc(aq agentquerier.AgentQuerier) http.HandlerFunc {
 		npq := aq.GetNetworkPolicyInfoQuerier()
 		var nps []cpv1beta.NetworkPolicy
 
-		if npFilter.Pod != "" {
-			interfaces := aq.GetInterfaceStore().GetContainerInterfacesByPod(npFilter.Pod, npFilter.Namespace)
+		if pod != "" {
+			namespaceAndPodName := strings.Split(pod, "/")
+			interfaces := aq.GetInterfaceStore().GetContainerInterfacesByPod(namespaceAndPodName[1], namespaceAndPodName[0])
 			if len(interfaces) > 0 {
-				nps = npq.GetAppliedNetworkPolicies(npFilter.Pod, npFilter.Namespace, npFilter)
+				nps = npq.GetAppliedNetworkPolicies(namespaceAndPodName[1], namespaceAndPodName[0], npFilter)
 			}
 		} else {
 			nps = npq.GetNetworkPolicies(npFilter)
@@ -65,30 +66,34 @@ var mapToNetworkPolicyType = map[string]cpv1beta.NetworkPolicyType{
 }
 
 // Create a Network Policy Filter from URL Query
-func newFilterFromURLQuery(query url.Values) (*querier.NetworkPolicyQueryFilter, error) {
-	namespace := query.Get("namespace")
-	pod := query.Get("pod")
+func newFilterFromURLQuery(query url.Values) (*querier.NetworkPolicyQueryFilter, string, error) {
+	namespace, pod := query.Get("namespace"), query.Get("pod")
 	if pod != "" && namespace == "" {
-		return nil, fmt.Errorf("with a pod name, namespace must be provided")
+		return nil, "", fmt.Errorf("with a pod name, namespace must be provided")
 	}
-
 	strSourceType := strings.ToUpper(query.Get("type"))
 	npSourceType, ok := mapToNetworkPolicyType[strSourceType]
 	if strSourceType != "" && !ok {
-		return nil, fmt.Errorf("invalid reference type. It should be K8sNP, ACNP or ANP")
+		return nil, "", fmt.Errorf("invalid policy source type. Valid values are K8sNP, ACNP and ANP")
 	}
-
 	source := query.Get("source")
 	name := query.Get("name")
 	if name != "" && (source != "" || namespace != "" || pod != "" || strSourceType != "") {
-		return nil, fmt.Errorf("with a name, none of the other fields can be set")
+		return nil, "", fmt.Errorf("with a name, none of the other fields can be set")
 	}
-
+	// In case of getting policies applied to a specific Pod, the -n option is used to specify the
+	// Namespace of the Pod, not the Namespace of the orginating policy.
+	if pod != "" {
+		return &querier.NetworkPolicyQueryFilter{
+			SourceName: source,
+			Namespace:  "",
+			SourceType: npSourceType,
+		}, namespace + "/" + pod, nil
+	}
 	return &querier.NetworkPolicyQueryFilter{
 		Name:       name,
 		SourceName: source,
 		Namespace:  namespace,
-		Pod:        pod,
 		SourceType: npSourceType,
-	}, nil
+	}, "", nil
 }

--- a/pkg/agent/controller/networkpolicy/cache.go
+++ b/pkg/agent/controller/networkpolicy/cache.go
@@ -220,6 +220,7 @@ func (c *ruleCache) getAppliedNetworkPolicies(pod, namespace string, npFilter *q
 			}
 			if c.networkPolicyMatchFilter(npFilter, np) {
 				policies = append(policies, *np)
+				policyKeys.Insert(string(rule.PolicyUID))
 			}
 		}
 	}

--- a/pkg/antctl/antctl.go
+++ b/pkg/antctl/antctl.go
@@ -148,7 +148,7 @@ var CommandList = &commandList{
   Get the list of control plane NetworkPolicies with a specific source Type (supported by agent only)
   $ antctl get networkpolicy -T acnp
   Get the list of control plane NetworkPolicies applied to a Pod (supported by agent only)
-  $ antctl get networkpolicy -p pod1 -n ns1`,
+  $ antctl get networkpolicy -p ns1/pod1`,
 			commandGroup: get,
 			controllerEndpoint: &endpoint{
 				resourceEndpoint: &resourceEndpoint{
@@ -177,7 +177,7 @@ var CommandList = &commandList{
 						},
 						{
 							name:      "pod",
-							usage:     "Get NetworkPolicies applied to the Pod. If present, Namespace must be provided.",
+							usage:     "Get NetworkPolicies applied to the Pod. Pod format is podNamespace/podName.",
 							shorthand: "p",
 						},
 						{

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -87,8 +87,6 @@ type NetworkPolicyQueryFilter struct {
 	SourceName string
 	// The namespace of the original Namespace that the internal NetworkPolicy is created for.
 	Namespace string
-	// Name of the pod that the network policy is applied on.
-	Pod string
 	// The type of the original NetworkPolicy that the internal NetworkPolicy is created for.(K8sNP, CNP, ANP)
 	SourceType cpv1beta.NetworkPolicyType
 }


### PR DESCRIPTION
When the `-p <PodName> -n <PodNamespace>` options are used in `antctl get networkpolicy` command, the `-n` option should only be used to identify the Pod being queried, but not filter any internal policies based on the Namespace. Otherwise, all ACNPs applied to the Pod will be filtered out.

This PR also fixes an issue where duplicate policy names are displayed.

Signed-off-by: Yang Ding <dingyang@vmware.com>