### PR TITLE
Create different namespaces for different e2e tests

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -138,7 +138,6 @@ func run(o *Options) error {
 
 	_, serviceCIDRNet, _ := net.ParseCIDR(o.config.ServiceCIDR)
 	var serviceCIDRNetv6 *net.IPNet
-	// Todo: use FeatureGate to check if IPv6 is enabled and then read configuration item "ServiceCIDRv6".
 	if o.config.ServiceCIDRv6 != "" {
 		_, serviceCIDRNetv6, _ = net.ParseCIDR(o.config.ServiceCIDRv6)
 	}

--- a/multicluster/test/e2e/antreapolicy_test.go
+++ b/multicluster/test/e2e/antreapolicy_test.go
@@ -33,10 +33,11 @@ const (
 )
 
 var (
-	allPodsPerCluster                      []antreae2e.Pod
-	perNamespacePods, perClusterNamespaces []string
-	podsByNamespace                        map[string][]antreae2e.Pod
-	clusterK8sUtilsMap                     map[string]*antreae2e.KubernetesUtils
+	allPodsPerCluster    []antreae2e.Pod
+	perNamespacePods     []string
+	perClusterNamespaces map[string]string
+	podsByNamespace      map[string][]antreae2e.Pod
+	clusterK8sUtilsMap   map[string]*antreae2e.KubernetesUtils
 )
 
 func failOnError(err error, t *testing.T) {
@@ -52,7 +53,10 @@ func failOnError(err error, t *testing.T) {
 // initializeForPolicyTest creates three Pods in three test Namespaces for each test cluster.
 func initializeForPolicyTest(t *testing.T, data *MCTestData) {
 	perNamespacePods = []string{"a", "b", "c"}
-	perClusterNamespaces = []string{"x", "y", "z"}
+	perClusterNamespaces = make(map[string]string)
+	perClusterNamespaces["x"] = "x"
+	perClusterNamespaces["y"] = "y"
+	perClusterNamespaces["z"] = "z"
 
 	allPodsPerCluster = []antreae2e.Pod{}
 	podsByNamespace = make(map[string][]antreae2e.Pod)

--- a/test/e2e/antreaipam_service_test.go
+++ b/test/e2e/antreaipam_service_test.go
@@ -54,12 +54,12 @@ func TestAntreaIPAMService(t *testing.T) {
 	})
 	t.Run("testAntreaIPAMClusterIPv4", func(t *testing.T) {
 		skipIfNotIPv4Cluster(t)
-		data.testClusterIP(t, false, testNamespace, testAntreaIPAMNamespace)
+		data.testClusterIP(t, false, data.testNamespace, testAntreaIPAMNamespace)
 		checkIPPoolsEmpty(t, data, ipPools)
 	})
 	t.Run("testAntreaIPAMPodToClusterIPv4", func(t *testing.T) {
 		skipIfNotIPv4Cluster(t)
-		data.testClusterIP(t, false, testAntreaIPAMNamespace, testNamespace)
+		data.testClusterIP(t, false, testAntreaIPAMNamespace, data.testNamespace)
 		checkIPPoolsEmpty(t, data, ipPools)
 	})
 	t.Run("testAntreaIPAMVLAN11PodToAntreaIPAMVLAN11ClusterIPv4", func(t *testing.T) {
@@ -84,12 +84,12 @@ func TestAntreaIPAMService(t *testing.T) {
 	})
 	t.Run("testAntreaIPAMVLAN11ClusterIPv4", func(t *testing.T) {
 		skipIfNotIPv4Cluster(t)
-		data.testClusterIP(t, false, testNamespace, testAntreaIPAMNamespace11)
+		data.testClusterIP(t, false, data.testNamespace, testAntreaIPAMNamespace11)
 		checkIPPoolsEmpty(t, data, ipPools)
 	})
 	t.Run("testAntreaIPAMVLAN11PodToClusterIPv4", func(t *testing.T) {
 		skipIfNotIPv4Cluster(t)
-		data.testClusterIP(t, false, testAntreaIPAMNamespace11, testNamespace)
+		data.testClusterIP(t, false, testAntreaIPAMNamespace11, data.testNamespace)
 		checkIPPoolsEmpty(t, data, ipPools)
 	})
 
@@ -100,12 +100,12 @@ func TestAntreaIPAMService(t *testing.T) {
 	})
 	t.Run("testAntreaIPAMNodePort", func(t *testing.T) {
 		skipIfHasWindowsNodes(t)
-		data.testNodePort(t, false, testNamespace, testAntreaIPAMNamespace)
+		data.testNodePort(t, false, data.testNamespace, testAntreaIPAMNamespace)
 		checkIPPoolsEmpty(t, data, ipPools)
 	})
 	t.Run("testAntreaIPAMPodToNodePort", func(t *testing.T) {
 		skipIfHasWindowsNodes(t)
-		data.testNodePort(t, false, testAntreaIPAMNamespace, testNamespace)
+		data.testNodePort(t, false, testAntreaIPAMNamespace, data.testNamespace)
 		checkIPPoolsEmpty(t, data, ipPools)
 	})
 	t.Run("testAntreaIPAMVLAN11PodToAntreaIPAMVLAN11NodePort", func(t *testing.T) {
@@ -130,12 +130,12 @@ func TestAntreaIPAMService(t *testing.T) {
 	})
 	t.Run("testAntreaIPAMVLAN11NodePort", func(t *testing.T) {
 		skipIfHasWindowsNodes(t)
-		data.testNodePort(t, false, testNamespace, testAntreaIPAMNamespace11)
+		data.testNodePort(t, false, data.testNamespace, testAntreaIPAMNamespace11)
 		checkIPPoolsEmpty(t, data, ipPools)
 	})
 	t.Run("testAntreaIPAMVLAN11PodToNodePort", func(t *testing.T) {
 		skipIfHasWindowsNodes(t)
-		data.testNodePort(t, false, testAntreaIPAMNamespace11, testNamespace)
+		data.testNodePort(t, false, testAntreaIPAMNamespace11, data.testNamespace)
 		checkIPPoolsEmpty(t, data, ipPools)
 	})
 }

--- a/test/e2e/antreaipam_test.go
+++ b/test/e2e/antreaipam_test.go
@@ -186,12 +186,12 @@ func TestAntreaIPAM(t *testing.T) {
 	})
 	t.Run("testAntreaIPAMHostPortPodConnectivity", func(t *testing.T) {
 		skipIfHasWindowsNodes(t)
-		data.testHostPortPodConnectivity(t, testNamespace, testAntreaIPAMNamespace)
+		data.testHostPortPodConnectivity(t, data.testNamespace, testAntreaIPAMNamespace)
 		checkIPPoolsEmpty(t, data, ipPools)
 	})
 	t.Run("testAntreaIPAMPodToHostPortPodConnectivity", func(t *testing.T) {
 		skipIfHasWindowsNodes(t)
-		data.testHostPortPodConnectivity(t, testAntreaIPAMNamespace, testNamespace)
+		data.testHostPortPodConnectivity(t, testAntreaIPAMNamespace, data.testNamespace)
 		checkIPPoolsEmpty(t, data, ipPools)
 	})
 	t.Run("testAntreaIPAMVLAN11PodToAntreaIPAMVLAN11HostPortPodConnectivity", func(t *testing.T) {
@@ -216,12 +216,12 @@ func TestAntreaIPAM(t *testing.T) {
 	})
 	t.Run("testAntreaIPAMVLAN11HostPortPodConnectivity", func(t *testing.T) {
 		skipIfHasWindowsNodes(t)
-		data.testHostPortPodConnectivity(t, testNamespace, testAntreaIPAMNamespace11)
+		data.testHostPortPodConnectivity(t, data.testNamespace, testAntreaIPAMNamespace11)
 		checkIPPoolsEmpty(t, data, ipPools)
 	})
 	t.Run("testAntreaIPAMVLAN11PodToHostPortPodConnectivity", func(t *testing.T) {
 		skipIfHasWindowsNodes(t)
-		data.testHostPortPodConnectivity(t, testAntreaIPAMNamespace11, testNamespace)
+		data.testHostPortPodConnectivity(t, testAntreaIPAMNamespace11, data.testNamespace)
 		checkIPPoolsEmpty(t, data, ipPools)
 	})
 	t.Run("testAntreaIPAMOVSRestartSameNode", func(t *testing.T) {
@@ -260,7 +260,7 @@ func testAntreaIPAMPodConnectivitySameNode(t *testing.T, data *TestData) {
 	// One Per-Node IPAM Pod
 	podInfos = append(podInfos, podInfo{
 		name:      randName("test-pod-0-"),
-		namespace: testNamespace,
+		namespace: data.testNamespace,
 	})
 	workerNode := workerNodeName(1)
 
@@ -279,7 +279,7 @@ func testAntreaIPAMPodConnectivitySameNode(t *testing.T, data *TestData) {
 func testAntreaIPAMPodConnectivityDifferentNodes(t *testing.T, data *TestData) {
 	maxNodes := 3
 	var podInfos []podInfo
-	for _, namespace := range []string{testNamespace, testAntreaIPAMNamespace, testAntreaIPAMNamespace11, testAntreaIPAMNamespace12} {
+	for _, namespace := range []string{data.testNamespace, testAntreaIPAMNamespace, testAntreaIPAMNamespace11, testAntreaIPAMNamespace12} {
 		createdPodInfos, deletePods := createPodsOnDifferentNodes(t, data, namespace, "differentnodes")
 		defer deletePods()
 		if len(createdPodInfos) > maxNodes {

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -49,12 +49,12 @@ func TestBasic(t *testing.T) {
 	}
 	defer teardownTest(t, data)
 
-	t.Run("testPodAssignIP", func(t *testing.T) { testPodAssignIP(t, data, testNamespace, "", "") })
-	t.Run("testDeletePod", func(t *testing.T) { testDeletePod(t, data, testNamespace) })
+	t.Run("testPodAssignIP", func(t *testing.T) { testPodAssignIP(t, data, data.testNamespace, "", "") })
+	t.Run("testDeletePod", func(t *testing.T) { testDeletePod(t, data, data.testNamespace) })
 	t.Run("testAntreaGracefulExit", func(t *testing.T) { testAntreaGracefulExit(t, data) })
-	t.Run("testIPAMRestart", func(t *testing.T) { testIPAMRestart(t, data, testNamespace) })
+	t.Run("testIPAMRestart", func(t *testing.T) { testIPAMRestart(t, data, data.testNamespace) })
 	t.Run("testDeletePreviousRoundFlowsOnStartup", func(t *testing.T) { testDeletePreviousRoundFlowsOnStartup(t, data) })
-	t.Run("testGratuitousARP", func(t *testing.T) { testGratuitousARP(t, data, testNamespace) })
+	t.Run("testGratuitousARP", func(t *testing.T) { testGratuitousARP(t, data, data.testNamespace) })
 	t.Run("testClusterIdentity", func(t *testing.T) { testClusterIdentity(t, data) })
 }
 
@@ -522,7 +522,7 @@ func TestCleanStaleClusterIPRoutes(t *testing.T) {
 	skipIfProxyAllDisabled(t, data)
 
 	// Create a backend Pod for test Service: if a Service has no backend Pod, no ClusterIP route will be installed.
-	createAndWaitForPod(t, data, data.createNginxPodOnNode, "test-clean-stale-route-pod", nodeName(0), testNamespace, false)
+	createAndWaitForPod(t, data, data.createNginxPodOnNode, "test-clean-stale-route-pod", nodeName(0), data.testNamespace, false)
 
 	if len(clusterInfo.podV4NetworkCIDR) != 0 {
 		t.Logf("Running IPv4 test")
@@ -540,10 +540,10 @@ func testCleanStaleClusterIPRoutes(t *testing.T, data *TestData, isIPv6 bool) {
 		ipProtocol = corev1.IPv6Protocol
 	}
 	// Create two test ClusterIPs.
-	svc, err := data.createNginxClusterIPService(fmt.Sprintf("test-clean-stale-route-svc1-%v", isIPv6), testNamespace, false, &ipProtocol)
+	svc, err := data.createNginxClusterIPService(fmt.Sprintf("test-clean-stale-route-svc1-%v", isIPv6), data.testNamespace, false, &ipProtocol)
 	require.NoError(t, err)
 	require.NotEqual(t, "", svc.Spec.ClusterIP, "ClusterIP should not be empty")
-	svc, err = data.createNginxClusterIPService(fmt.Sprintf("test-clean-stale-route-svc2-%v", isIPv6), testNamespace, false, &ipProtocol)
+	svc, err = data.createNginxClusterIPService(fmt.Sprintf("test-clean-stale-route-svc2-%v", isIPv6), data.testNamespace, false, &ipProtocol)
 	require.NoError(t, err)
 	require.NotEqual(t, "", svc.Spec.ClusterIP, "ClusterIP should not be empty")
 	time.Sleep(time.Second)

--- a/test/e2e/batch_test.go
+++ b/test/e2e/batch_test.go
@@ -54,7 +54,7 @@ func TestBatchCreatePods(t *testing.T) {
 
 	oldFDs := getFDs()
 
-	_, _, cleanupFn := createTestBusyboxPods(t, data, batchNum, testNamespace, node1)
+	_, _, cleanupFn := createTestBusyboxPods(t, data, batchNum, data.testNamespace, node1)
 	defer cleanupFn()
 
 	newFDs := getFDs()

--- a/test/e2e/clustergroup_test.go
+++ b/test/e2e/clustergroup_test.go
@@ -52,7 +52,7 @@ func testInvalidCGIPBlockWithPodSelector(t *testing.T) {
 func testInvalidCGIPBlockWithNSSelector(t *testing.T) {
 	invalidErr := fmt.Errorf("clustergroup created with ipblock and namespaceSelector")
 	cgName := "ipb-ns"
-	nSel := &metav1.LabelSelector{MatchLabels: map[string]string{"ns": "y"}}
+	nSel := &metav1.LabelSelector{MatchLabels: map[string]string{"ns": namespaces["y"]}}
 	cidr := "10.0.0.10/32"
 	ipb := []crdv1alpha1.IPBlock{{CIDR: cidr}}
 	cg := &crdv1alpha3.ClusterGroup{
@@ -97,7 +97,7 @@ func testInvalidCGServiceRefWithPodSelector(t *testing.T) {
 	cgName := "svcref-pod-selector"
 	pSel := &metav1.LabelSelector{MatchLabels: map[string]string{"pod": "x"}}
 	svcRef := &crdv1alpha1.NamespacedName{
-		Namespace: "y",
+		Namespace: namespaces["y"],
 		Name:      "test-svc",
 	}
 	cg := &crdv1alpha3.ClusterGroup{
@@ -118,9 +118,9 @@ func testInvalidCGServiceRefWithPodSelector(t *testing.T) {
 func testInvalidCGServiceRefWithNSSelector(t *testing.T) {
 	invalidErr := fmt.Errorf("clustergroup created with serviceReference and namespaceSelector")
 	cgName := "svcref-ns-selector"
-	nSel := &metav1.LabelSelector{MatchLabels: map[string]string{"ns": "y"}}
+	nSel := &metav1.LabelSelector{MatchLabels: map[string]string{"ns": namespaces["y"]}}
 	svcRef := &crdv1alpha1.NamespacedName{
-		Namespace: "y",
+		Namespace: namespaces["y"],
 		Name:      "test-svc",
 	}
 	cg := &crdv1alpha3.ClusterGroup{
@@ -144,7 +144,7 @@ func testInvalidCGServiceRefWithIPBlock(t *testing.T) {
 	cidr := "10.0.0.10/32"
 	ipb := []crdv1alpha1.IPBlock{{CIDR: cidr}}
 	svcRef := &crdv1alpha1.NamespacedName{
-		Namespace: "y",
+		Namespace: namespaces["y"],
 		Name:      "test-svc",
 	}
 	cg := &crdv1alpha3.ClusterGroup{
@@ -207,7 +207,7 @@ func testInvalidCGChildGroupWithServiceReference(t *testing.T) {
 	invalidErr := fmt.Errorf("clustergroup created with childGroups and ServiceReference")
 	cgName := "child-group-svcref"
 	svcRef := &crdv1alpha1.NamespacedName{
-		Namespace: "y",
+		Namespace: namespaces["y"],
 		Name:      "test-svc",
 	}
 	cg := &crdv1alpha3.ClusterGroup{
@@ -389,6 +389,7 @@ func TestClusterGroup(t *testing.T) {
 		t.Fatalf("Error when setting up test: %v", err)
 	}
 	defer teardownTest(t, data)
+
 	initialize(t, data)
 
 	t.Run("TestGroupClusterGroupValidate", func(t *testing.T) {

--- a/test/e2e/connectivity_test.go
+++ b/test/e2e/connectivity_test.go
@@ -54,16 +54,16 @@ func TestConnectivity(t *testing.T) {
 	})
 	t.Run("testPodConnectivityAfterAntreaRestart", func(t *testing.T) {
 		skipIfHasWindowsNodes(t)
-		testPodConnectivityAfterAntreaRestart(t, data, testNamespace)
+		testPodConnectivityAfterAntreaRestart(t, data, data.testNamespace)
 	})
 	t.Run("testOVSRestartSameNode", func(t *testing.T) {
 		skipIfNotIPv4Cluster(t)
 		skipIfHasWindowsNodes(t)
-		testOVSRestartSameNode(t, data, testNamespace)
+		testOVSRestartSameNode(t, data, data.testNamespace)
 	})
 	t.Run("testOVSFlowReplay", func(t *testing.T) {
 		skipIfHasWindowsNodes(t)
-		testOVSFlowReplay(t, data, testNamespace)
+		testOVSFlowReplay(t, data, data.testNamespace)
 	})
 	t.Run("testPingLargeMTU", func(t *testing.T) {
 		skipIfNumNodesLessThan(t, 2)
@@ -76,7 +76,7 @@ func waitForPodIPs(t *testing.T, data *TestData, podInfos []podInfo) map[string]
 	podIPs := make(map[string]*PodIPs)
 	for _, pi := range podInfos {
 		podName := pi.name
-		podNamespace := testNamespace
+		podNamespace := data.testNamespace
 		if pi.namespace != "" {
 			podNamespace = pi.namespace
 		}
@@ -101,11 +101,11 @@ func (data *TestData) runPingMesh(t *testing.T, podInfos []podInfo, ctrname stri
 			if pi1.name == pi2.name {
 				continue
 			}
-			podNamespace := testNamespace
+			podNamespace := data.testNamespace
 			if pi1.namespace != "" {
 				podNamespace = pi1.namespace
 			}
-			pod2Namespace := testNamespace
+			pod2Namespace := data.testNamespace
 			if pi2.namespace != "" {
 				pod2Namespace = pi2.namespace
 			}
@@ -133,10 +133,10 @@ func (data *TestData) testPodConnectivitySameNode(t *testing.T) {
 	t.Logf("Creating %d agnhost Pods on '%s'", numPods, workerNode)
 	for i := range podInfos {
 		podInfos[i].os = clusterInfo.nodesOS[workerNode]
-		if err := data.createAgnhostPodOnNode(podInfos[i].name, testNamespace, workerNode, false); err != nil {
+		if err := data.createAgnhostPodOnNode(podInfos[i].name, data.testNamespace, workerNode, false); err != nil {
 			t.Fatalf("Error when creating agnhost test Pod '%s': %v", podInfos[i], err)
 		}
-		defer deletePodWrapper(t, data, testNamespace, podInfos[i].name)
+		defer deletePodWrapper(t, data, data.testNamespace, podInfos[i].name)
 	}
 
 	data.runPingMesh(t, podInfos, agnhostContainerName)
@@ -181,7 +181,7 @@ func (data *TestData) testHostPortPodConnectivity(t *testing.T, clientNamespace,
 
 // testHostPortPodConnectivity checks that a Pod with hostPort set is reachable.
 func testHostPortPodConnectivity(t *testing.T, data *TestData) {
-	data.testHostPortPodConnectivity(t, testNamespace, testNamespace)
+	data.testHostPortPodConnectivity(t, data.testNamespace, data.testNamespace)
 }
 
 // createPodsOnDifferentNodes creates agnhost Pods through a DaemonSet. This function returns information of the created
@@ -238,7 +238,7 @@ func (data *TestData) testPodConnectivityDifferentNodes(t *testing.T) {
 		// subnet, all Nodes should have a Pod.
 		numPods = maxPods
 	}
-	podInfos, deletePods := createPodsOnDifferentNodes(t, data, testNamespace, "differentnodes")
+	podInfos, deletePods := createPodsOnDifferentNodes(t, data, data.testNamespace, "differentnodes")
 	defer deletePods()
 
 	if len(podInfos) > maxPods {
@@ -489,13 +489,13 @@ func testOVSFlowReplay(t *testing.T, data *TestData, namespace string) {
 func testPingLargeMTU(t *testing.T, data *TestData) {
 	skipIfNumNodesLessThan(t, 2)
 
-	podInfos, deletePods := createPodsOnDifferentNodes(t, data, testNamespace, "largemtu")
+	podInfos, deletePods := createPodsOnDifferentNodes(t, data, data.testNamespace, "largemtu")
 	defer deletePods()
 	podIPs := waitForPodIPs(t, data, podInfos)
 
 	pingSize := 2000
 	t.Logf("Running ping with size %d between Pods %s and %s", pingSize, podInfos[0].name, podInfos[1].name)
-	if err := data.runPingCommandFromTestPod(podInfos[0], testNamespace, podIPs[podInfos[1].name], agnhostContainerName, pingCount, pingSize); err != nil {
+	if err := data.runPingCommandFromTestPod(podInfos[0], data.testNamespace, podIPs[podInfos[1].name], agnhostContainerName, pingCount, pingSize); err != nil {
 		t.Error(err)
 	}
 }

--- a/test/e2e/k8s_util.go
+++ b/test/e2e/k8s_util.go
@@ -484,7 +484,7 @@ func (data *TestData) DeleteService(ns, name string) error {
 }
 
 // CleanServices is a convenience function for deleting Services in the cluster.
-func (data *TestData) CleanServices(namespaces []string) error {
+func (data *TestData) CleanServices(namespaces map[string]string) error {
 	for _, ns := range namespaces {
 		l, err := data.clientset.CoreV1().Services(ns).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
@@ -577,7 +577,7 @@ func (data *TestData) DeleteNetworkPolicy(ns, name string) error {
 }
 
 // CleanNetworkPolicies is a convenience function for deleting NetworkPolicies in the provided namespaces.
-func (data *TestData) CleanNetworkPolicies(namespaces []string) error {
+func (data *TestData) CleanNetworkPolicies(namespaces map[string]string) error {
 	for _, ns := range namespaces {
 		l, err := data.clientset.NetworkingV1().NetworkPolicies(ns).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
@@ -977,7 +977,7 @@ func (k *KubernetesUtils) Validate(allPods []Pod, reachability *Reachability, po
 	}
 }
 
-func (k *KubernetesUtils) Bootstrap(namespaces, pods []string) (*map[string][]string, error) {
+func (k *KubernetesUtils) Bootstrap(namespaces map[string]string, pods []string) (*map[string][]string, error) {
 	for _, ns := range namespaces {
 		_, err := k.CreateOrUpdateNamespace(ns, map[string]string{"ns": ns})
 		if err != nil {
@@ -1016,7 +1016,7 @@ func (k *KubernetesUtils) Bootstrap(namespaces, pods []string) (*map[string][]st
 	return &podIPs, nil
 }
 
-func (k *KubernetesUtils) Cleanup(namespaces []string) {
+func (k *KubernetesUtils) Cleanup(namespaces map[string]string) {
 	// Cleanup any cluster-scoped resources.
 	if err := k.CleanACNPs(); err != nil {
 		log.Errorf("Error when cleaning up ACNPs: %v", err)

--- a/test/e2e/networkpolicy_test.go
+++ b/test/e2e/networkpolicy_test.go
@@ -84,10 +84,10 @@ func TestNetworkPolicy(t *testing.T) {
 }
 
 func testNetworkPolicyStats(t *testing.T, data *TestData) {
-	serverName, serverIPs, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "test-server-", "", testNamespace, false)
+	serverName, serverIPs, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "test-server-", "", data.testNamespace, false)
 	defer cleanupFunc()
 
-	clientName, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", "", testNamespace, false)
+	clientName, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", "", data.testNamespace, false)
 	defer cleanupFunc()
 
 	// When using the userspace OVS datapath and tunneling,
@@ -95,11 +95,11 @@ func testNetworkPolicyStats(t *testing.T, data *TestData) {
 	// So we need to  "warm-up" the tunnel.
 	if clusterInfo.podV4NetworkCIDR != "" {
 		cmd := []string{"/bin/sh", "-c", fmt.Sprintf("nc -vz -w 4 %s 80", serverIPs.ipv4.String())}
-		data.RunCommandFromPod(testNamespace, clientName, busyboxContainerName, cmd)
+		data.RunCommandFromPod(data.testNamespace, clientName, busyboxContainerName, cmd)
 	}
 	if clusterInfo.podV6NetworkCIDR != "" {
 		cmd := []string{"/bin/sh", "-c", fmt.Sprintf("nc -vz -w 4 %s 80", serverIPs.ipv6.String())}
-		data.RunCommandFromPod(testNamespace, clientName, busyboxContainerName, cmd)
+		data.RunCommandFromPod(data.testNamespace, clientName, busyboxContainerName, cmd)
 	}
 
 	np1, err := data.createNetworkPolicy("test-networkpolicy-ingress", &networkingv1.NetworkPolicySpec{
@@ -155,11 +155,11 @@ func testNetworkPolicyStats(t *testing.T, data *TestData) {
 		go func() {
 			if clusterInfo.podV4NetworkCIDR != "" {
 				cmd := []string{"/bin/sh", "-c", fmt.Sprintf("nc -vz -w 4 %s 80", serverIPs.ipv4.String())}
-				data.RunCommandFromPod(testNamespace, clientName, busyboxContainerName, cmd)
+				data.RunCommandFromPod(data.testNamespace, clientName, busyboxContainerName, cmd)
 			}
 			if clusterInfo.podV6NetworkCIDR != "" {
 				cmd := []string{"/bin/sh", "-c", fmt.Sprintf("nc -vz -w 4 %s 80", serverIPs.ipv6.String())}
-				data.RunCommandFromPod(testNamespace, clientName, busyboxContainerName, cmd)
+				data.RunCommandFromPod(data.testNamespace, clientName, busyboxContainerName, cmd)
 			}
 			wg.Done()
 		}()
@@ -177,7 +177,7 @@ func testNetworkPolicyStats(t *testing.T, data *TestData) {
 	if err := wait.Poll(5*time.Second, defaultTimeout, func() (bool, error) {
 		var ingressStats *v1alpha1.NetworkPolicyStats
 		for _, np := range []string{"test-networkpolicy-ingress", "test-networkpolicy-egress"} {
-			stats, err := data.crdClient.StatsV1alpha1().NetworkPolicyStats(testNamespace).Get(context.TODO(), np, metav1.GetOptions{})
+			stats, err := data.crdClient.StatsV1alpha1().NetworkPolicyStats(data.testNamespace).Get(context.TODO(), np, metav1.GetOptions{})
 			if err != nil {
 				return false, err
 			}
@@ -228,29 +228,29 @@ func (data *TestData) setupDifferentNamedPorts(t *testing.T) (checkFn func(), cl
 
 	server0Port := int32(80)
 	server0Name, server0IPs, cleanupFunc := createAndWaitForPod(t, data, func(name string, ns string, nodeName string, hostNetwork bool) error {
-		return data.createServerPod(name, testNamespace, "http", server0Port, false, false)
-	}, "test-server-", "", testNamespace, false)
+		return data.createServerPod(name, data.testNamespace, "http", server0Port, false, false)
+	}, "test-server-", "", data.testNamespace, false)
 	cleanupFuncs = append(cleanupFuncs, cleanupFunc)
 
 	server1Port := int32(8080)
 	server1Name, server1IPs, cleanupFunc := createAndWaitForPod(t, data, func(name string, ns string, nodeName string, hostNetwork bool) error {
-		return data.createServerPod(name, testNamespace, "http", server1Port, false, false)
-	}, "test-server-", "", testNamespace, false)
+		return data.createServerPod(name, data.testNamespace, "http", server1Port, false, false)
+	}, "test-server-", "", data.testNamespace, false)
 	cleanupFuncs = append(cleanupFuncs, cleanupFunc)
 
-	client0Name, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", "", testNamespace, false)
+	client0Name, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", "", data.testNamespace, false)
 	cleanupFuncs = append(cleanupFuncs, cleanupFunc)
 
-	client1Name, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", "", testNamespace, false)
+	client1Name, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", "", data.testNamespace, false)
 	cleanupFuncs = append(cleanupFuncs, cleanupFunc)
 
 	preCheckFunc := func(server0IP, server1IP string) {
 		// Both clients can connect to both servers.
 		for _, clientName := range []string{client0Name, client1Name} {
-			if err := data.runNetcatCommandFromTestPod(clientName, testNamespace, server0IP, server0Port); err != nil {
+			if err := data.runNetcatCommandFromTestPod(clientName, data.testNamespace, server0IP, server0Port); err != nil {
 				t.Fatalf("Pod %s should be able to connect %s, but was not able to connect", clientName, net.JoinHostPort(server0IP, fmt.Sprint(server0Port)))
 			}
-			if err := data.runNetcatCommandFromTestPod(clientName, testNamespace, server1IP, server1Port); err != nil {
+			if err := data.runNetcatCommandFromTestPod(clientName, data.testNamespace, server1IP, server1Port); err != nil {
 				t.Fatalf("Pod %s should be able to connect %s, but was not able to connect", clientName, net.JoinHostPort(server1IP, fmt.Sprint(server1Port)))
 			}
 		}
@@ -302,17 +302,17 @@ func (data *TestData) setupDifferentNamedPorts(t *testing.T) (checkFn func(), cl
 		server0Address := net.JoinHostPort(server0IP, fmt.Sprint(server0Port))
 		server1Address := net.JoinHostPort(server1IP, fmt.Sprint(server1Port))
 		// client0 can connect to both servers.
-		if err = data.runNetcatCommandFromTestPod(client0Name, testNamespace, server0IP, server0Port); err != nil {
+		if err = data.runNetcatCommandFromTestPod(client0Name, data.testNamespace, server0IP, server0Port); err != nil {
 			t.Fatalf("Pod %s should be able to connect %s, but was not able to connect", client0Name, server0Address)
 		}
-		if err = data.runNetcatCommandFromTestPod(client0Name, testNamespace, server1IP, server1Port); err != nil {
+		if err = data.runNetcatCommandFromTestPod(client0Name, data.testNamespace, server1IP, server1Port); err != nil {
 			t.Fatalf("Pod %s should be able to connect %s, but was not able to connect", client0Name, server1Address)
 		}
 		// client1 cannot connect to both servers.
-		if err = data.runNetcatCommandFromTestPod(client1Name, testNamespace, server0IP, server0Port); err == nil {
+		if err = data.runNetcatCommandFromTestPod(client1Name, data.testNamespace, server0IP, server0Port); err == nil {
 			t.Fatalf("Pod %s should not be able to connect %s, but was able to connect", client1Name, server0Address)
 		}
-		if err = data.runNetcatCommandFromTestPod(client1Name, testNamespace, server1IP, server1Port); err == nil {
+		if err = data.runNetcatCommandFromTestPod(client1Name, data.testNamespace, server1IP, server1Port); err == nil {
 			t.Fatalf("Pod %s should not be able to connect %s, but was able to connect", client1Name, server1Address)
 		}
 	}
@@ -338,21 +338,21 @@ func testDefaultDenyIngressPolicy(t *testing.T, data *TestData) {
 	serverNode := workerNodeName(1)
 	serverNodeIP := workerNodeIP(1)
 	serverPort := int32(80)
-	_, serverIPs, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "test-server-", serverNode, testNamespace, false)
+	_, serverIPs, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "test-server-", serverNode, data.testNamespace, false)
 	defer cleanupFunc()
 
-	service, err := data.CreateService("nginx", testNamespace, serverPort, serverPort, map[string]string{"app": "nginx"}, false, false, corev1.ServiceTypeNodePort, nil)
+	service, err := data.CreateService("nginx", data.testNamespace, serverPort, serverPort, map[string]string{"app": "nginx"}, false, false, corev1.ServiceTypeNodePort, nil)
 	if err != nil {
 		t.Fatalf("Error when creating nginx NodePort service: %v", err)
 	}
 	defer data.deleteService(service.Namespace, service.Name)
 
 	// client1 is a host network Pod and is on the same node as the server Pod, simulating kubelet probe traffic.
-	client1Name, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-hostnetwork-client-can-connect-", serverNode, testNamespace, true)
+	client1Name, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-hostnetwork-client-can-connect-", serverNode, data.testNamespace, true)
 	defer cleanupFunc()
 
 	// client2 is a host network Pod and is on a different node from the server Pod, accessing the server Pod via the NodePort service.
-	client2Name, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-hostnetwork-client-cannot-connect-", controlPlaneNodeName(), testNamespace, true)
+	client2Name, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-hostnetwork-client-cannot-connect-", controlPlaneNodeName(), data.testNamespace, true)
 	defer cleanupFunc()
 
 	spec := &networkingv1.NetworkPolicySpec{
@@ -371,7 +371,7 @@ func testDefaultDenyIngressPolicy(t *testing.T, data *TestData) {
 	}()
 
 	npCheck := func(clientName, serverIP string, serverPort int32, wantErr bool) {
-		if err = data.runNetcatCommandFromTestPod(clientName, testNamespace, serverIP, serverPort); wantErr && err == nil {
+		if err = data.runNetcatCommandFromTestPod(clientName, data.testNamespace, serverIP, serverPort); wantErr && err == nil {
 			t.Fatalf("Pod %s should not be able to connect %s, but was able to connect", clientName, net.JoinHostPort(serverIP, fmt.Sprint(serverPort)))
 		} else if !wantErr && err != nil {
 			t.Fatalf("Pod %s should be able to connect %s, but was not able to connect", clientName, net.JoinHostPort(serverIP, fmt.Sprint(serverPort)))
@@ -397,14 +397,14 @@ func testDefaultDenyIngressPolicy(t *testing.T, data *TestData) {
 
 func testDefaultDenyEgressPolicy(t *testing.T, data *TestData) {
 	serverPort := int32(80)
-	_, serverIPs, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "test-server-", "", testNamespace, false)
+	_, serverIPs, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "test-server-", "", data.testNamespace, false)
 	defer cleanupFunc()
 
-	clientName, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", "", testNamespace, false)
+	clientName, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", "", data.testNamespace, false)
 	defer cleanupFunc()
 
 	preCheckFunc := func(serverIP string) {
-		if err := data.runNetcatCommandFromTestPod(clientName, testNamespace, serverIP, serverPort); err != nil {
+		if err := data.runNetcatCommandFromTestPod(clientName, data.testNamespace, serverIP, serverPort); err != nil {
 			t.Fatalf("Pod %s should be able to connect %s, but was not able to connect", clientName, net.JoinHostPort(serverIP, fmt.Sprint(serverPort)))
 		}
 	}
@@ -431,7 +431,7 @@ func testDefaultDenyEgressPolicy(t *testing.T, data *TestData) {
 	}()
 
 	npCheck := func(serverIP string) {
-		if err = data.runNetcatCommandFromTestPod(clientName, testNamespace, serverIP, serverPort); err == nil {
+		if err = data.runNetcatCommandFromTestPod(clientName, data.testNamespace, serverIP, serverPort); err == nil {
 			t.Fatalf("Pod %s should not be able to connect %s, but was able to connect", clientName, net.JoinHostPort(serverIP, fmt.Sprint(serverPort)))
 		}
 	}
@@ -451,12 +451,12 @@ func testDefaultDenyEgressPolicy(t *testing.T, data *TestData) {
 // https://github.com/kubernetes/kubernetes/pull/93583
 func testEgressToServerInCIDRBlock(t *testing.T, data *TestData) {
 	workerNode := workerNodeName(1)
-	serverAName, serverAIPs, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "test-server-", workerNode, testNamespace, false)
+	serverAName, serverAIPs, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "test-server-", workerNode, data.testNamespace, false)
 	defer cleanupFunc()
-	serverBName, serverBIPs, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "test-server-", workerNode, testNamespace, false)
+	serverBName, serverBIPs, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "test-server-", workerNode, data.testNamespace, false)
 	defer cleanupFunc()
 
-	clientA, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", workerNode, testNamespace, false)
+	clientA, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", workerNode, data.testNamespace, false)
 	defer cleanupFunc()
 	var serverCIDR string
 	var serverAIP, serverBIP string
@@ -467,10 +467,10 @@ func testEgressToServerInCIDRBlock(t *testing.T, data *TestData) {
 	serverAIP = serverAIPs.ipv6.String()
 	serverBIP = serverBIPs.ipv6.String()
 
-	if err := data.runNetcatCommandFromTestPod(clientA, testNamespace, serverAIP, 80); err != nil {
+	if err := data.runNetcatCommandFromTestPod(clientA, data.testNamespace, serverAIP, 80); err != nil {
 		t.Fatalf("%s should be able to netcat %s", clientA, serverAName)
 	}
-	if err := data.runNetcatCommandFromTestPod(clientA, testNamespace, serverBIP, 80); err != nil {
+	if err := data.runNetcatCommandFromTestPod(clientA, data.testNamespace, serverBIP, 80); err != nil {
 		t.Fatalf("%s should be able to netcat %s", clientA, serverBName)
 	}
 
@@ -503,10 +503,10 @@ func testEgressToServerInCIDRBlock(t *testing.T, data *TestData) {
 	}
 	defer cleanupNP()
 
-	if err := data.runNetcatCommandFromTestPod(clientA, testNamespace, serverAIP, 80); err != nil {
+	if err := data.runNetcatCommandFromTestPod(clientA, data.testNamespace, serverAIP, 80); err != nil {
 		t.Fatalf("%s should be able to netcat %s", clientA, serverAName)
 	}
-	if err := data.runNetcatCommandFromTestPod(clientA, testNamespace, serverBIP, 80); err == nil {
+	if err := data.runNetcatCommandFromTestPod(clientA, data.testNamespace, serverBIP, 80); err == nil {
 		t.Fatalf("%s should not be able to netcat %s", clientA, serverBName)
 	}
 }
@@ -518,10 +518,10 @@ func testEgressToServerInCIDRBlock(t *testing.T, data *TestData) {
 // https://github.com/kubernetes/kubernetes/pull/93583
 func testEgressToServerInCIDRBlockWithException(t *testing.T, data *TestData) {
 	workerNode := workerNodeName(1)
-	serverAName, serverAIPs, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "test-server-", workerNode, testNamespace, false)
+	serverAName, serverAIPs, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "test-server-", workerNode, data.testNamespace, false)
 	defer cleanupFunc()
 
-	clientA, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", workerNode, testNamespace, false)
+	clientA, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", workerNode, data.testNamespace, false)
 	defer cleanupFunc()
 	var serverAAllowCIDR string
 	var serverAExceptList []string
@@ -537,7 +537,7 @@ func testEgressToServerInCIDRBlockWithException(t *testing.T, data *TestData) {
 	serverAExceptList = []string{fmt.Sprintf("%s/%d", serverAIPs.ipv6.String(), 128)}
 	serverAIP = serverAIPs.ipv6.String()
 
-	if err := data.runNetcatCommandFromTestPod(clientA, testNamespace, serverAIP, 80); err != nil {
+	if err := data.runNetcatCommandFromTestPod(clientA, data.testNamespace, serverAIP, 80); err != nil {
 		t.Fatalf("%s should be able to netcat %s", clientA, serverAName)
 	}
 
@@ -571,7 +571,7 @@ func testEgressToServerInCIDRBlockWithException(t *testing.T, data *TestData) {
 	}
 	defer cleanupNP()
 
-	if err := data.runNetcatCommandFromTestPod(clientA, testNamespace, serverAIP, 80); err == nil {
+	if err := data.runNetcatCommandFromTestPod(clientA, data.testNamespace, serverAIP, 80); err == nil {
 		t.Fatalf("%s should not be able to netcat %s", clientA, serverAName)
 	}
 }
@@ -583,16 +583,16 @@ func testNetworkPolicyResyncAfterRestart(t *testing.T, data *TestData) {
 		t.Fatalf("Error when getting antrea-agent pod name: %v", err)
 	}
 
-	server0Name, server0IPs, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "test-server-", workerNode, testNamespace, false)
+	server0Name, server0IPs, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "test-server-", workerNode, data.testNamespace, false)
 	defer cleanupFunc()
 
-	server1Name, server1IPs, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "test-server-", workerNode, testNamespace, false)
+	server1Name, server1IPs, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "test-server-", workerNode, data.testNamespace, false)
 	defer cleanupFunc()
 
-	client0Name, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", workerNode, testNamespace, false)
+	client0Name, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", workerNode, data.testNamespace, false)
 	defer cleanupFunc()
 
-	client1Name, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", workerNode, testNamespace, false)
+	client1Name, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", workerNode, data.testNamespace, false)
 	defer cleanupFunc()
 
 	netpol0, err := data.createNetworkPolicy("test-isolate-server0", &networkingv1.NetworkPolicySpec{
@@ -617,10 +617,10 @@ func testNetworkPolicyResyncAfterRestart(t *testing.T, data *TestData) {
 	defer cleanupNetpol0()
 
 	preCheckFunc := func(server0IP, server1IP string) {
-		if err = data.runNetcatCommandFromTestPod(client0Name, testNamespace, server0IP, 80); err == nil {
+		if err = data.runNetcatCommandFromTestPod(client0Name, data.testNamespace, server0IP, 80); err == nil {
 			t.Fatalf("Pod %s should not be able to connect %s, but was able to connect", client0Name, server0Name)
 		}
-		if err = data.runNetcatCommandFromTestPod(client1Name, testNamespace, server1IP, 80); err != nil {
+		if err = data.runNetcatCommandFromTestPod(client1Name, data.testNamespace, server1IP, 80); err != nil {
 			t.Fatalf("Pod %s should be able to connect %s, but was not able to connect", client1Name, server1Name)
 		}
 	}
@@ -673,10 +673,10 @@ func testNetworkPolicyResyncAfterRestart(t *testing.T, data *TestData) {
 	waitForAgentCondition(t, data, antreaPod, v1beta1.ControllerConnectionUp, corev1.ConditionTrue)
 
 	npCheck := func(server0IP, server1IP string) {
-		if err = data.runNetcatCommandFromTestPod(client0Name, testNamespace, server0IP, 80); err != nil {
+		if err = data.runNetcatCommandFromTestPod(client0Name, data.testNamespace, server0IP, 80); err != nil {
 			t.Fatalf("Pod %s should be able to connect %s, but was not able to connect", client0Name, server0Name)
 		}
-		if err = data.runNetcatCommandFromTestPod(client1Name, testNamespace, server1IP, 80); err == nil {
+		if err = data.runNetcatCommandFromTestPod(client1Name, data.testNamespace, server1IP, 80); err == nil {
 			t.Fatalf("Pod %s should not be able to connect %s, but was able to connect", client1Name, server1Name)
 		}
 	}
@@ -691,19 +691,19 @@ func testNetworkPolicyResyncAfterRestart(t *testing.T, data *TestData) {
 
 func testIngressPolicyWithoutPortNumber(t *testing.T, data *TestData) {
 	serverPort := int32(80)
-	_, serverIPs, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "test-server-", "", testNamespace, false)
+	_, serverIPs, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "test-server-", "", data.testNamespace, false)
 	defer cleanupFunc()
 
-	client0Name, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", "", testNamespace, false)
+	client0Name, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", "", data.testNamespace, false)
 	defer cleanupFunc()
 
-	client1Name, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", "", testNamespace, false)
+	client1Name, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", "", data.testNamespace, false)
 	defer cleanupFunc()
 
 	preCheckFunc := func(serverIP string) {
 		// Both clients can connect to server.
 		for _, clientName := range []string{client0Name, client1Name} {
-			if err := data.runNetcatCommandFromTestPod(clientName, testNamespace, serverIP, serverPort); err != nil {
+			if err := data.runNetcatCommandFromTestPod(clientName, data.testNamespace, serverIP, serverPort); err != nil {
 				t.Fatalf("Pod %s should be able to connect %s, but was not able to connect", clientName, net.JoinHostPort(serverIP, fmt.Sprint(serverPort)))
 			}
 		}
@@ -750,11 +750,11 @@ func testIngressPolicyWithoutPortNumber(t *testing.T, data *TestData) {
 	npCheck := func(serverIP string) {
 		serverAddress := net.JoinHostPort(serverIP, fmt.Sprint(serverPort))
 		// Client0 can access server.
-		if err = data.runNetcatCommandFromTestPod(client0Name, testNamespace, serverIP, serverPort); err != nil {
+		if err = data.runNetcatCommandFromTestPod(client0Name, data.testNamespace, serverIP, serverPort); err != nil {
 			t.Fatalf("Pod %s should be able to connect %s, but was not able to connect", client0Name, serverAddress)
 		}
 		// Client1 can't access server.
-		if err = data.runNetcatCommandFromTestPod(client1Name, testNamespace, serverIP, serverPort); err == nil {
+		if err = data.runNetcatCommandFromTestPod(client1Name, data.testNamespace, serverIP, serverPort); err == nil {
 			t.Fatalf("Pod %s should not be able to connect %s, but was able to connect", client1Name, serverAddress)
 		}
 	}
@@ -834,16 +834,16 @@ func testIngressPolicyWithEndPort(t *testing.T, data *TestData) {
 		return nil
 	}
 
-	serverName, serverIPs, cleanupFunc := createAndWaitForPod(t, data, createAgnhostPodOnNodeWithMultiPort, "test-server-", "", testNamespace, false)
+	serverName, serverIPs, cleanupFunc := createAndWaitForPod(t, data, createAgnhostPodOnNodeWithMultiPort, "test-server-", "", data.testNamespace, false)
 	defer cleanupFunc()
 
-	clientName, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", "", testNamespace, false)
+	clientName, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", "", data.testNamespace, false)
 	defer cleanupFunc()
 
 	preCheck := func(serverIP string) {
 		// The client can connect to server on all ports.
 		for _, port := range serverPorts {
-			if err := data.runNetcatCommandFromTestPod(clientName, testNamespace, serverIP, port); err != nil {
+			if err := data.runNetcatCommandFromTestPod(clientName, data.testNamespace, serverIP, port); err != nil {
 				t.Fatalf("Pod %s should be able to connect %s, but was not able to connect", clientName, net.JoinHostPort(serverIP, fmt.Sprint(port)))
 			}
 		}
@@ -900,7 +900,7 @@ func testIngressPolicyWithEndPort(t *testing.T, data *TestData) {
 
 	npCheck := func(serverIP string) {
 		for _, port := range serverPorts {
-			err = data.runNetcatCommandFromTestPod(clientName, testNamespace, serverIP, port)
+			err = data.runNetcatCommandFromTestPod(clientName, data.testNamespace, serverIP, port)
 			if port >= policyPort && port <= policyEndPort {
 				if err != nil {
 					t.Errorf("Pod %s should be able to connect %s, but was not able to connect", clientName, net.JoinHostPort(serverIP, fmt.Sprint(port)))
@@ -941,7 +941,7 @@ func createAndWaitForPodWithServiceAccount(t *testing.T, data *TestData, createF
 		t.Fatalf("Error when creating busybox test Pod: %v", err)
 	}
 	cleanupFunc := func() {
-		deletePodWrapper(t, data, testNamespace, name)
+		deletePodWrapper(t, data, data.testNamespace, name)
 	}
 	podIP, err := data.podWaitForIPs(defaultTimeout, name, ns)
 	if err != nil {

--- a/test/e2e/service_test.go
+++ b/test/e2e/service_test.go
@@ -38,13 +38,14 @@ func TestClusterIPv6(t *testing.T) {
 
 func testClusterIP(t *testing.T, isIPv6 bool) {
 	skipIfNumNodesLessThan(t, 2)
+
 	data, err := setupTest(t)
 	if err != nil {
 		t.Fatalf("Error when setting up test: %v", err)
 	}
 	defer teardownTest(t, data)
 
-	data.testClusterIP(t, isIPv6, testNamespace, testNamespace)
+	data.testClusterIP(t, isIPv6, data.testNamespace, data.testNamespace)
 }
 
 func (data *TestData) testClusterIP(t *testing.T, isIPv6 bool, clientNamespace, serverNamespace string) {
@@ -84,7 +85,7 @@ func (data *TestData) testClusterIP(t *testing.T, isIPv6 bool, clientNamespace, 
 	_, _, cleanupFunc = createAndWaitForPod(t, data, data.createNginxPodOnNode, hostNginx, nodeName(0), serverNamespace, true)
 	defer cleanupFunc()
 	t.Run("HostNetwork Endpoints", func(t *testing.T) {
-		skipIfNamespaceIsNotEqual(t, serverNamespace, testNamespace)
+		skipIfNamespaceIsNotEqual(t, serverNamespace, data.testNamespace)
 		testClusterIPCases(t, data, url, clients, hostNetworkClients, clientNamespace)
 	})
 }
@@ -93,7 +94,7 @@ func testClusterIPCases(t *testing.T, data *TestData, url string, clients, hostN
 	t.Run("All Nodes can access Service ClusterIP", func(t *testing.T) {
 		skipIfProxyAllDisabled(t, data)
 		skipIfKubeProxyEnabled(t, data)
-		skipIfNamespaceIsNotEqual(t, namespace, testNamespace)
+		skipIfNamespaceIsNotEqual(t, namespace, data.testNamespace)
 		for node, pod := range hostNetworkClients {
 			testClusterIPFromPod(t, data, url, node, pod, true, namespace)
 		}
@@ -136,7 +137,7 @@ func TestNodePortWindows(t *testing.T) {
 	}
 	defer teardownTest(t, data)
 
-	data.testNodePort(t, true, testNamespace, testNamespace)
+	data.testNodePort(t, true, data.testNamespace, data.testNamespace)
 }
 
 func (data *TestData) testNodePort(t *testing.T, isWindows bool, clientNamespace, serverNamespace string) {

--- a/test/e2e/traceflow_test.go
+++ b/test/e2e/traceflow_test.go
@@ -102,7 +102,7 @@ func testTraceflowIntraNodeANP(t *testing.T, data *TestData) {
 		nodeIdx = clusterInfo.windowsNodes[0]
 	}
 	node1 := nodeName(nodeIdx)
-	node1Pods, _, node1CleanupFn := createTestAgnhostPods(t, data, 3, testNamespace, node1)
+	node1Pods, _, node1CleanupFn := createTestAgnhostPods(t, data, 3, data.testNamespace, node1)
 	defer node1CleanupFn()
 
 	var denyIngress *v1alpha1.NetworkPolicy
@@ -115,7 +115,7 @@ func testTraceflowIntraNodeANP(t *testing.T, data *TestData) {
 			t.Errorf("Error when deleting Antrea NetworkPolicy: %v", err)
 		}
 	}()
-	if err = data.waitForANPRealized(t, testNamespace, denyIngressName); err != nil {
+	if err = data.waitForANPRealized(t, data.testNamespace, denyIngressName); err != nil {
 		t.Fatal(err)
 	}
 	var rejectIngress *v1alpha1.NetworkPolicy
@@ -128,7 +128,7 @@ func testTraceflowIntraNodeANP(t *testing.T, data *TestData) {
 			t.Errorf("Error when deleting Antrea NetworkPolicy: %v", err)
 		}
 	}()
-	if err = data.waitForANPRealized(t, testNamespace, rejectIngressName); err != nil {
+	if err = data.waitForANPRealized(t, data.testNamespace, rejectIngressName); err != nil {
 		t.Fatal(err)
 	}
 
@@ -138,15 +138,15 @@ func testTraceflowIntraNodeANP(t *testing.T, data *TestData) {
 			ipVersion: 4,
 			tf: &v1alpha1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: randName(fmt.Sprintf("%s-%s-to-%s-%s-", testNamespace, node1Pods[0], testNamespace, node1Pods[1])),
+					Name: randName(fmt.Sprintf("%s-%s-to-%s-%s-", data.testNamespace, node1Pods[0], data.testNamespace, node1Pods[1])),
 				},
 				Spec: v1alpha1.TraceflowSpec{
 					Source: v1alpha1.Source{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
 					Destination: v1alpha1.Destination{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Pod:       node1Pods[1],
 					},
 					Packet: v1alpha1.Packet{
@@ -186,15 +186,15 @@ func testTraceflowIntraNodeANP(t *testing.T, data *TestData) {
 			ipVersion: 4,
 			tf: &v1alpha1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: randName(fmt.Sprintf("%s-%s-to-%s-%s-", testNamespace, node1Pods[0], testNamespace, node1Pods[2])),
+					Name: randName(fmt.Sprintf("%s-%s-to-%s-%s-", data.testNamespace, node1Pods[0], data.testNamespace, node1Pods[2])),
 				},
 				Spec: v1alpha1.TraceflowSpec{
 					Source: v1alpha1.Source{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
 					Destination: v1alpha1.Destination{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Pod:       node1Pods[2],
 					},
 					Packet: v1alpha1.Packet{
@@ -234,15 +234,15 @@ func testTraceflowIntraNodeANP(t *testing.T, data *TestData) {
 			ipVersion: 6,
 			tf: &v1alpha1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: randName(fmt.Sprintf("%s-%s-to-%s-%s-", testNamespace, node1Pods[0], testNamespace, node1Pods[1])),
+					Name: randName(fmt.Sprintf("%s-%s-to-%s-%s-", data.testNamespace, node1Pods[0], data.testNamespace, node1Pods[1])),
 				},
 				Spec: v1alpha1.TraceflowSpec{
 					Source: v1alpha1.Source{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
 					Destination: v1alpha1.Destination{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Pod:       node1Pods[1],
 					},
 					Packet: v1alpha1.Packet{
@@ -299,7 +299,7 @@ func testTraceflowIntraNode(t *testing.T, data *TestData) {
 	node1 := nodeName(nodeIdx)
 
 	agentPod, _ := data.getAntreaPodOnNode(node1)
-	node1Pods, node1IPs, node1CleanupFn := createTestAgnhostPods(t, data, 3, testNamespace, node1)
+	node1Pods, node1IPs, node1CleanupFn := createTestAgnhostPods(t, data, 3, data.testNamespace, node1)
 	defer node1CleanupFn()
 	var pod0IPv4Str, pod1IPv4Str, dstPodIPv4Str, dstPodIPv6Str string
 	if node1IPs[0].ipv4 != nil {
@@ -366,15 +366,15 @@ func testTraceflowIntraNode(t *testing.T, data *TestData) {
 			ipVersion: 4,
 			tf: &v1alpha1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: randName(fmt.Sprintf("%s-%s-to-%s-%s-", testNamespace, node1Pods[0], testNamespace, node1Pods[1])),
+					Name: randName(fmt.Sprintf("%s-%s-to-%s-%s-", data.testNamespace, node1Pods[0], data.testNamespace, node1Pods[1])),
 				},
 				Spec: v1alpha1.TraceflowSpec{
 					Source: v1alpha1.Source{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
 					Destination: v1alpha1.Destination{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Pod:       node1Pods[1],
 					},
 					Packet: v1alpha1.Packet{
@@ -419,15 +419,15 @@ func testTraceflowIntraNode(t *testing.T, data *TestData) {
 			ipVersion: 4,
 			tf: &v1alpha1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: randName(fmt.Sprintf("%s-%s-to-%s-", testNamespace, node1Pods[0], node1Pods[2])),
+					Name: randName(fmt.Sprintf("%s-%s-to-%s-", data.testNamespace, node1Pods[0], node1Pods[2])),
 				},
 				Spec: v1alpha1.TraceflowSpec{
 					Source: v1alpha1.Source{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
 					Destination: v1alpha1.Destination{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Pod:       node1Pods[2],
 					},
 					Packet: v1alpha1.Packet{
@@ -471,11 +471,11 @@ func testTraceflowIntraNode(t *testing.T, data *TestData) {
 			ipVersion: 4,
 			tf: &v1alpha1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: randName(fmt.Sprintf("%s-%s-to-%s-", testNamespace, node1Pods[0], dstPodIPv4Str)),
+					Name: randName(fmt.Sprintf("%s-%s-to-%s-", data.testNamespace, node1Pods[0], dstPodIPv4Str)),
 				},
 				Spec: v1alpha1.TraceflowSpec{
 					Source: v1alpha1.Source{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
 					Destination: v1alpha1.Destination{
@@ -522,11 +522,11 @@ func testTraceflowIntraNode(t *testing.T, data *TestData) {
 			ipVersion: 4,
 			tf: &v1alpha1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: randName(fmt.Sprintf("%s-%s-to-%s-", testNamespace, node1Pods[0], dstPodIPv4Str)),
+					Name: randName(fmt.Sprintf("%s-%s-to-%s-", data.testNamespace, node1Pods[0], dstPodIPv4Str)),
 				},
 				Spec: v1alpha1.TraceflowSpec{
 					Source: v1alpha1.Source{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
 					Destination: v1alpha1.Destination{
@@ -567,15 +567,15 @@ func testTraceflowIntraNode(t *testing.T, data *TestData) {
 			ipVersion: 4,
 			tf: &v1alpha1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: randName(fmt.Sprintf("%s-%s-to-%s-%s-", testNamespace, node1Pods[0], testNamespace, "non-existing-pod")),
+					Name: randName(fmt.Sprintf("%s-%s-to-%s-%s-", data.testNamespace, node1Pods[0], data.testNamespace, "non-existing-pod")),
 				},
 				Spec: v1alpha1.TraceflowSpec{
 					Source: v1alpha1.Source{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
 					Destination: v1alpha1.Destination{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Pod:       "non-existing-pod",
 					},
 				},
@@ -588,28 +588,28 @@ func testTraceflowIntraNode(t *testing.T, data *TestData) {
 			ipVersion: 4,
 			tf: &v1alpha1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: randName(fmt.Sprintf("%s-%s-to-%s-%s-", testNamespace, "non-existing-pod", testNamespace, node1Pods[1])),
+					Name: randName(fmt.Sprintf("%s-%s-to-%s-%s-", data.testNamespace, "non-existing-pod", data.testNamespace, node1Pods[1])),
 				},
 				Spec: v1alpha1.TraceflowSpec{
 					Source: v1alpha1.Source{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Pod:       "non-existing-pod",
 					},
 					Destination: v1alpha1.Destination{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Pod:       node1Pods[1],
 					},
 				},
 			},
 			expectedPhase:   v1alpha1.Failed,
-			expectedReasons: []string{fmt.Sprintf("Invalid Traceflow request, err: %+v", fmt.Errorf("requested source Pod %s not found", k8s.NamespacedName(testNamespace, "non-existing-pod")))},
+			expectedReasons: []string{fmt.Sprintf("Invalid Traceflow request, err: %+v", fmt.Errorf("requested source Pod %s not found", k8s.NamespacedName(data.testNamespace, "non-existing-pod")))},
 		},
 		{
 			name:      "hostNetworkSrcPodIPv4",
 			ipVersion: 4,
 			tf: &v1alpha1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: randName(fmt.Sprintf("%s-%s-to-%s-%s-", antreaNamespace, agentPod, testNamespace, node1Pods[1])),
+					Name: randName(fmt.Sprintf("%s-%s-to-%s-%s-", antreaNamespace, agentPod, data.testNamespace, node1Pods[1])),
 				},
 				Spec: v1alpha1.TraceflowSpec{
 					Source: v1alpha1.Source{
@@ -617,7 +617,7 @@ func testTraceflowIntraNode(t *testing.T, data *TestData) {
 						Pod:       agentPod,
 					},
 					Destination: v1alpha1.Destination{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Pod:       node1Pods[1],
 					},
 				},
@@ -630,11 +630,11 @@ func testTraceflowIntraNode(t *testing.T, data *TestData) {
 			ipVersion: 4,
 			tf: &v1alpha1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: randName(fmt.Sprintf("%s-%s-to-%s-", testNamespace, node1Pods[0], dstPodIPv4Str)),
+					Name: randName(fmt.Sprintf("%s-%s-to-%s-", data.testNamespace, node1Pods[0], dstPodIPv4Str)),
 				},
 				Spec: v1alpha1.TraceflowSpec{
 					Source: v1alpha1.Source{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
 					Destination: v1alpha1.Destination{
@@ -681,14 +681,14 @@ func testTraceflowIntraNode(t *testing.T, data *TestData) {
 			ipVersion: 4,
 			tf: &v1alpha1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: randName(fmt.Sprintf("%s-%s-to-%s-", testNamespace, pod0IPv4Str, node1Pods[1])),
+					Name: randName(fmt.Sprintf("%s-%s-to-%s-", data.testNamespace, pod0IPv4Str, node1Pods[1])),
 				},
 				Spec: v1alpha1.TraceflowSpec{
 					Source: v1alpha1.Source{
 						IP: pod0IPv4Str,
 					},
 					Destination: v1alpha1.Destination{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Pod:       node1Pods[1],
 					},
 					Packet: v1alpha1.Packet{
@@ -733,15 +733,15 @@ func testTraceflowIntraNode(t *testing.T, data *TestData) {
 			ipVersion: 6,
 			tf: &v1alpha1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: randName(fmt.Sprintf("%s-%s-to-%s-%s-", testNamespace, node1Pods[0], testNamespace, node1Pods[1])),
+					Name: randName(fmt.Sprintf("%s-%s-to-%s-%s-", data.testNamespace, node1Pods[0], data.testNamespace, node1Pods[1])),
 				},
 				Spec: v1alpha1.TraceflowSpec{
 					Source: v1alpha1.Source{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
 					Destination: v1alpha1.Destination{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Pod:       node1Pods[1],
 					},
 					Packet: v1alpha1.Packet{
@@ -786,15 +786,15 @@ func testTraceflowIntraNode(t *testing.T, data *TestData) {
 			ipVersion: 6,
 			tf: &v1alpha1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: randName(fmt.Sprintf("%s-%s-to-%s-", testNamespace, node1Pods[0], node1Pods[2])),
+					Name: randName(fmt.Sprintf("%s-%s-to-%s-", data.testNamespace, node1Pods[0], node1Pods[2])),
 				},
 				Spec: v1alpha1.TraceflowSpec{
 					Source: v1alpha1.Source{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
 					Destination: v1alpha1.Destination{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Pod:       node1Pods[2],
 					},
 					Packet: v1alpha1.Packet{
@@ -838,11 +838,11 @@ func testTraceflowIntraNode(t *testing.T, data *TestData) {
 			ipVersion: 6,
 			tf: &v1alpha1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: randName(fmt.Sprintf("%s-%s-to-%s-", testNamespace, node1Pods[0], strings.ReplaceAll(dstPodIPv6Str, ":", "--"))),
+					Name: randName(fmt.Sprintf("%s-%s-to-%s-", data.testNamespace, node1Pods[0], strings.ReplaceAll(dstPodIPv6Str, ":", "--"))),
 				},
 				Spec: v1alpha1.TraceflowSpec{
 					Source: v1alpha1.Source{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
 					Destination: v1alpha1.Destination{
@@ -889,11 +889,11 @@ func testTraceflowIntraNode(t *testing.T, data *TestData) {
 			ipVersion: 6,
 			tf: &v1alpha1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: randName(fmt.Sprintf("%s-%s-to-%s-", testNamespace, node1Pods[0], strings.ReplaceAll(dstPodIPv6Str, ":", "--"))),
+					Name: randName(fmt.Sprintf("%s-%s-to-%s-", data.testNamespace, node1Pods[0], strings.ReplaceAll(dstPodIPv6Str, ":", "--"))),
 				},
 				Spec: v1alpha1.TraceflowSpec{
 					Source: v1alpha1.Source{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
 					Destination: v1alpha1.Destination{
@@ -934,15 +934,15 @@ func testTraceflowIntraNode(t *testing.T, data *TestData) {
 			ipVersion: 6,
 			tf: &v1alpha1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: randName(fmt.Sprintf("%s-%s-to-%s-%s-", testNamespace, node1Pods[0], testNamespace, "non-existing-pod")),
+					Name: randName(fmt.Sprintf("%s-%s-to-%s-%s-", data.testNamespace, node1Pods[0], data.testNamespace, "non-existing-pod")),
 				},
 				Spec: v1alpha1.TraceflowSpec{
 					Source: v1alpha1.Source{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
 					Destination: v1alpha1.Destination{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Pod:       "non-existing-pod",
 					},
 					Packet: v1alpha1.Packet{
@@ -960,11 +960,11 @@ func testTraceflowIntraNode(t *testing.T, data *TestData) {
 			ipVersion: 6,
 			tf: &v1alpha1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: randName(fmt.Sprintf("%s-%s-to-%s-", testNamespace, node1Pods[0], strings.ReplaceAll(dstPodIPv6Str, ":", "--"))),
+					Name: randName(fmt.Sprintf("%s-%s-to-%s-", data.testNamespace, node1Pods[0], strings.ReplaceAll(dstPodIPv6Str, ":", "--"))),
 				},
 				Spec: v1alpha1.TraceflowSpec{
 					Source: v1alpha1.Source{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
 					Destination: v1alpha1.Destination{
@@ -1010,11 +1010,11 @@ func testTraceflowIntraNode(t *testing.T, data *TestData) {
 			ipVersion: 4,
 			tf: &v1alpha1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: randName(fmt.Sprintf("%s-%s-to-%s-", testNamespace, node1Pods[0], gwIPv4Str)),
+					Name: randName(fmt.Sprintf("%s-%s-to-%s-", data.testNamespace, node1Pods[0], gwIPv4Str)),
 				},
 				Spec: v1alpha1.TraceflowSpec{
 					Source: v1alpha1.Source{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
 					Destination: v1alpha1.Destination{
@@ -1058,11 +1058,11 @@ func testTraceflowIntraNode(t *testing.T, data *TestData) {
 			ipVersion: 6,
 			tf: &v1alpha1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: randName(fmt.Sprintf("%s-%s-to-%s-", testNamespace, node1Pods[0], strings.ReplaceAll(gwIPv6Str, ":", "--"))),
+					Name: randName(fmt.Sprintf("%s-%s-to-%s-", data.testNamespace, node1Pods[0], strings.ReplaceAll(gwIPv6Str, ":", "--"))),
 				},
 				Spec: v1alpha1.TraceflowSpec{
 					Source: v1alpha1.Source{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
 					Destination: v1alpha1.Destination{
@@ -1124,8 +1124,8 @@ func testTraceflowInterNode(t *testing.T, data *TestData) {
 	node1 := nodeName(nodeIdx0)
 	node2 := nodeName(nodeIdx1)
 
-	node1Pods, _, node1CleanupFn := createTestAgnhostPods(t, data, 1, testNamespace, node1)
-	node2Pods, node2IPs, node2CleanupFn := createTestAgnhostPods(t, data, 3, testNamespace, node2)
+	node1Pods, _, node1CleanupFn := createTestAgnhostPods(t, data, 1, data.testNamespace, node1)
+	node2Pods, node2IPs, node2CleanupFn := createTestAgnhostPods(t, data, 3, data.testNamespace, node2)
 	gatewayIPv4, gatewayIPv6 := nodeGatewayIPs(1)
 	defer node1CleanupFn()
 	defer node2CleanupFn()
@@ -1143,22 +1143,22 @@ func testTraceflowInterNode(t *testing.T, data *TestData) {
 	mutateFunc := func(pod *corev1.Pod) {
 		pod.Labels["app"] = "agnhost-server"
 	}
-	require.NoError(t, data.createPodOnNode(agnhostPodName, testNamespace, node2, agnhostImage, []string{"sleep", strconv.Itoa(3600)}, nil, nil, nil, false, mutateFunc))
-	agnhostIP, err := data.podWaitForIPs(defaultTimeout, agnhostPodName, testNamespace)
+	require.NoError(t, data.createPodOnNode(agnhostPodName, data.testNamespace, node2, agnhostImage, []string{"sleep", strconv.Itoa(3600)}, nil, nil, nil, false, mutateFunc))
+	agnhostIP, err := data.podWaitForIPs(defaultTimeout, agnhostPodName, data.testNamespace)
 	require.NoError(t, err)
 
 	var agnhostIPv4Str, agnhostIPv6Str, svcIPv4Name, svcIPv6Name string
 	if agnhostIP.ipv4 != nil {
 		agnhostIPv4Str = agnhostIP.ipv4.String()
 		ipv4Protocol := corev1.IPv4Protocol
-		svcIPv4, err := data.CreateService("agnhost-ipv4", testNamespace, 80, 8080, map[string]string{"app": "agnhost-server"}, false, false, corev1.ServiceTypeClusterIP, &ipv4Protocol)
+		svcIPv4, err := data.CreateService("agnhost-ipv4", data.testNamespace, 80, 8080, map[string]string{"app": "agnhost-server"}, false, false, corev1.ServiceTypeClusterIP, &ipv4Protocol)
 		require.NoError(t, err)
 		svcIPv4Name = svcIPv4.Name
 	}
 	if agnhostIP.ipv6 != nil {
 		agnhostIPv6Str = agnhostIP.ipv6.String()
 		ipv6Protocol := corev1.IPv6Protocol
-		svcIPv6, err := data.CreateService("agnhost-ipv6", testNamespace, 80, 8080, map[string]string{"app": "agnhost-server"}, false, false, corev1.ServiceTypeClusterIP, &ipv6Protocol)
+		svcIPv6, err := data.CreateService("agnhost-ipv6", data.testNamespace, 80, 8080, map[string]string{"app": "agnhost-server"}, false, false, corev1.ServiceTypeClusterIP, &ipv6Protocol)
 		require.NoError(t, err)
 		svcIPv6Name = svcIPv6.Name
 	}
@@ -1170,10 +1170,10 @@ func testTraceflowInterNode(t *testing.T, data *TestData) {
 	if isWindows {
 		podInfos := make([]podInfo, 2)
 		podInfos[0].name = node1Pods[0]
-		podInfos[0].namespace = testNamespace
+		podInfos[0].namespace = data.testNamespace
 		podInfos[0].os = "windows"
 		podInfos[1].name = node2Pods[2]
-		podInfos[1].namespace = testNamespace
+		podInfos[1].namespace = data.testNamespace
 		podInfos[1].os = "windows"
 		data.runPingMesh(t, podInfos, agnhostContainerName)
 	}
@@ -1217,15 +1217,15 @@ func testTraceflowInterNode(t *testing.T, data *TestData) {
 			ipVersion: 4,
 			tf: &v1alpha1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: randName(fmt.Sprintf("%s-%s-to-%s-%s-", testNamespace, node1Pods[0], testNamespace, node2Pods[0])),
+					Name: randName(fmt.Sprintf("%s-%s-to-%s-%s-", data.testNamespace, node1Pods[0], data.testNamespace, node2Pods[0])),
 				},
 				Spec: v1alpha1.TraceflowSpec{
 					Source: v1alpha1.Source{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
 					Destination: v1alpha1.Destination{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Pod:       node2Pods[0],
 					},
 					Packet: v1alpha1.Packet{
@@ -1284,11 +1284,11 @@ func testTraceflowInterNode(t *testing.T, data *TestData) {
 			ipVersion: 4,
 			tf: &v1alpha1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: randName(fmt.Sprintf("%s-%s-to-%s-", testNamespace, node1Pods[0], dstPodIPv4Str)),
+					Name: randName(fmt.Sprintf("%s-%s-to-%s-", data.testNamespace, node1Pods[0], dstPodIPv4Str)),
 				},
 				Spec: v1alpha1.TraceflowSpec{
 					Source: v1alpha1.Source{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
 					Destination: v1alpha1.Destination{
@@ -1349,15 +1349,15 @@ func testTraceflowInterNode(t *testing.T, data *TestData) {
 			ipVersion: 4,
 			tf: &v1alpha1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: randName(fmt.Sprintf("%s-%s-to-%s-", testNamespace, node1Pods[0], node2Pods[1])),
+					Name: randName(fmt.Sprintf("%s-%s-to-%s-", data.testNamespace, node1Pods[0], node2Pods[1])),
 				},
 				Spec: v1alpha1.TraceflowSpec{
 					Source: v1alpha1.Source{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
 					Destination: v1alpha1.Destination{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Pod:       node2Pods[1],
 					},
 					Packet: v1alpha1.Packet{
@@ -1412,15 +1412,15 @@ func testTraceflowInterNode(t *testing.T, data *TestData) {
 			ipVersion: 4,
 			tf: &v1alpha1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: randName(fmt.Sprintf("%s-%s-to-svc-%s-", testNamespace, node1Pods[0], svcIPv4Name)),
+					Name: randName(fmt.Sprintf("%s-%s-to-svc-%s-", data.testNamespace, node1Pods[0], svcIPv4Name)),
 				},
 				Spec: v1alpha1.TraceflowSpec{
 					Source: v1alpha1.Source{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
 					Destination: v1alpha1.Destination{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Service:   svcIPv4Name,
 					},
 					Packet: v1alpha1.Packet{
@@ -1448,7 +1448,7 @@ func testTraceflowInterNode(t *testing.T, data *TestData) {
 						},
 						{
 							Component:       v1alpha1.ComponentLB,
-							Pod:             fmt.Sprintf("%s/%s", testNamespace, agnhostPodName),
+							Pod:             fmt.Sprintf("%s/%s", data.testNamespace, agnhostPodName),
 							TranslatedDstIP: agnhostIPv4Str,
 							Action:          v1alpha1.ActionForwarded,
 						},
@@ -1488,15 +1488,15 @@ func testTraceflowInterNode(t *testing.T, data *TestData) {
 			ipVersion: 4,
 			tf: &v1alpha1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: randName(fmt.Sprintf("%s-%s-to-svc-%s-", testNamespace, agnhostPodName, svcIPv4Name)),
+					Name: randName(fmt.Sprintf("%s-%s-to-svc-%s-", data.testNamespace, agnhostPodName, svcIPv4Name)),
 				},
 				Spec: v1alpha1.TraceflowSpec{
 					Source: v1alpha1.Source{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Pod:       agnhostPodName,
 					},
 					Destination: v1alpha1.Destination{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Service:   svcIPv4Name,
 					},
 					Packet: v1alpha1.Packet{
@@ -1524,7 +1524,7 @@ func testTraceflowInterNode(t *testing.T, data *TestData) {
 						},
 						{
 							Component:       v1alpha1.ComponentLB,
-							Pod:             fmt.Sprintf("%s/%s", testNamespace, agnhostPodName),
+							Pod:             fmt.Sprintf("%s/%s", data.testNamespace, agnhostPodName),
 							TranslatedSrcIP: gatewayIPv4,
 							TranslatedDstIP: agnhostIPv4Str,
 							Action:          v1alpha1.ActionForwarded,
@@ -1548,15 +1548,15 @@ func testTraceflowInterNode(t *testing.T, data *TestData) {
 			ipVersion: 4,
 			tf: &v1alpha1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: randName(fmt.Sprintf("%s-%s-to-%s-", testNamespace, node1Pods[0], node2Pods[0])),
+					Name: randName(fmt.Sprintf("%s-%s-to-%s-", data.testNamespace, node1Pods[0], node2Pods[0])),
 				},
 				Spec: v1alpha1.TraceflowSpec{
 					Source: v1alpha1.Source{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
 					Destination: v1alpha1.Destination{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Pod:       node2Pods[0],
 					},
 					LiveTraffic: true,
@@ -1605,15 +1605,15 @@ func testTraceflowInterNode(t *testing.T, data *TestData) {
 			ipVersion: 6,
 			tf: &v1alpha1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: randName(fmt.Sprintf("%s-%s-to-%s-%s-", testNamespace, node1Pods[0], testNamespace, node2Pods[0])),
+					Name: randName(fmt.Sprintf("%s-%s-to-%s-%s-", data.testNamespace, node1Pods[0], data.testNamespace, node2Pods[0])),
 				},
 				Spec: v1alpha1.TraceflowSpec{
 					Source: v1alpha1.Source{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
 					Destination: v1alpha1.Destination{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Pod:       node2Pods[0],
 					},
 					Packet: v1alpha1.Packet{
@@ -1675,11 +1675,11 @@ func testTraceflowInterNode(t *testing.T, data *TestData) {
 			ipVersion: 6,
 			tf: &v1alpha1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: randName(fmt.Sprintf("%s-%s-to-%s-", testNamespace, node1Pods[0], strings.ReplaceAll(dstPodIPv6Str, ":", "--"))),
+					Name: randName(fmt.Sprintf("%s-%s-to-%s-", data.testNamespace, node1Pods[0], strings.ReplaceAll(dstPodIPv6Str, ":", "--"))),
 				},
 				Spec: v1alpha1.TraceflowSpec{
 					Source: v1alpha1.Source{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
 					Destination: v1alpha1.Destination{
@@ -1740,11 +1740,11 @@ func testTraceflowInterNode(t *testing.T, data *TestData) {
 			ipVersion: 6,
 			tf: &v1alpha1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: randName(fmt.Sprintf("%s-%s-to-%s-", testNamespace, node1Pods[0], strings.ReplaceAll(dstPodIPv6Str, ":", "--"))),
+					Name: randName(fmt.Sprintf("%s-%s-to-%s-", data.testNamespace, node1Pods[0], strings.ReplaceAll(dstPodIPv6Str, ":", "--"))),
 				},
 				Spec: v1alpha1.TraceflowSpec{
 					Source: v1alpha1.Source{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
 					Destination: v1alpha1.Destination{
@@ -1799,15 +1799,15 @@ func testTraceflowInterNode(t *testing.T, data *TestData) {
 			ipVersion: 6,
 			tf: &v1alpha1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: randName(fmt.Sprintf("%s-%s-to-svc-%s-", testNamespace, node1Pods[0], svcIPv6Name)),
+					Name: randName(fmt.Sprintf("%s-%s-to-svc-%s-", data.testNamespace, node1Pods[0], svcIPv6Name)),
 				},
 				Spec: v1alpha1.TraceflowSpec{
 					Source: v1alpha1.Source{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
 					Destination: v1alpha1.Destination{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Service:   svcIPv6Name,
 					},
 					Packet: v1alpha1.Packet{
@@ -1835,7 +1835,7 @@ func testTraceflowInterNode(t *testing.T, data *TestData) {
 						},
 						{
 							Component:       v1alpha1.ComponentLB,
-							Pod:             fmt.Sprintf("%s/%s", testNamespace, agnhostPodName),
+							Pod:             fmt.Sprintf("%s/%s", data.testNamespace, agnhostPodName),
 							TranslatedDstIP: agnhostIPv6Str,
 							Action:          v1alpha1.ActionForwarded,
 						},
@@ -1872,15 +1872,15 @@ func testTraceflowInterNode(t *testing.T, data *TestData) {
 			ipVersion: 6,
 			tf: &v1alpha1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: randName(fmt.Sprintf("%s-%s-to-svc-%s-", testNamespace, agnhostPodName, svcIPv6Name)),
+					Name: randName(fmt.Sprintf("%s-%s-to-svc-%s-", data.testNamespace, agnhostPodName, svcIPv6Name)),
 				},
 				Spec: v1alpha1.TraceflowSpec{
 					Source: v1alpha1.Source{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Pod:       agnhostPodName,
 					},
 					Destination: v1alpha1.Destination{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Service:   svcIPv6Name,
 					},
 					Packet: v1alpha1.Packet{
@@ -1908,7 +1908,7 @@ func testTraceflowInterNode(t *testing.T, data *TestData) {
 						},
 						{
 							Component:       v1alpha1.ComponentLB,
-							Pod:             fmt.Sprintf("%s/%s", testNamespace, agnhostPodName),
+							Pod:             fmt.Sprintf("%s/%s", data.testNamespace, agnhostPodName),
 							TranslatedSrcIP: gatewayIPv6,
 							TranslatedDstIP: agnhostIPv6Str,
 							Action:          v1alpha1.ActionForwarded,
@@ -1932,15 +1932,15 @@ func testTraceflowInterNode(t *testing.T, data *TestData) {
 			ipVersion: 6,
 			tf: &v1alpha1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: randName(fmt.Sprintf("%s-%s-to-%s-", testNamespace, node1Pods[0], node2Pods[0])),
+					Name: randName(fmt.Sprintf("%s-%s-to-%s-", data.testNamespace, node1Pods[0], node2Pods[0])),
 				},
 				Spec: v1alpha1.TraceflowSpec{
 					Source: v1alpha1.Source{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
 					Destination: v1alpha1.Destination{
-						Namespace: testNamespace,
+						Namespace: data.testNamespace,
 						Pod:       node2Pods[0],
 					},
 					Packet: v1alpha1.Packet{
@@ -2014,7 +2014,7 @@ func testTraceflowExternalIP(t *testing.T, data *TestData) {
 	}
 	node := nodeName(nodeIdx)
 	nodeIP := nodeIP(nodeIdx)
-	podNames, _, cleanupFn := createTestAgnhostPods(t, data, 1, testNamespace, node)
+	podNames, _, cleanupFn := createTestAgnhostPods(t, data, 1, data.testNamespace, node)
 	defer cleanupFn()
 
 	testcase := testcase{
@@ -2022,11 +2022,11 @@ func testTraceflowExternalIP(t *testing.T, data *TestData) {
 		ipVersion: 4,
 		tf: &v1alpha1.Traceflow{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: randName(fmt.Sprintf("%s-%s-to-%s-%s-", testNamespace, podNames[0], testNamespace, strings.ReplaceAll(nodeIP, ":", "--"))),
+				Name: randName(fmt.Sprintf("%s-%s-to-%s-%s-", data.testNamespace, podNames[0], data.testNamespace, strings.ReplaceAll(nodeIP, ":", "--"))),
 			},
 			Spec: v1alpha1.TraceflowSpec{
 				Source: v1alpha1.Source{
-					Namespace: testNamespace,
+					Namespace: data.testNamespace,
 					Pod:       podNames[0],
 				},
 				Destination: v1alpha1.Destination{
@@ -2138,7 +2138,7 @@ func (data *TestData) createANPDenyIngress(key string, value string, name string
 			Egress: []v1alpha1.Rule{},
 		},
 	}
-	anpCreated, err := k8sUtils.crdClient.CrdV1alpha1().NetworkPolicies(testNamespace).Create(context.TODO(), &anp, metav1.CreateOptions{})
+	anpCreated, err := k8sUtils.crdClient.CrdV1alpha1().NetworkPolicies(data.testNamespace).Create(context.TODO(), &anp, metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -2147,7 +2147,7 @@ func (data *TestData) createANPDenyIngress(key string, value string, name string
 
 // deleteAntreaNetworkpolicy deletes an Antrea NetworkPolicy.
 func (data *TestData) deleteAntreaNetworkpolicy(policy *v1alpha1.NetworkPolicy) error {
-	if err := k8sUtils.crdClient.CrdV1alpha1().NetworkPolicies(testNamespace).Delete(context.TODO(), policy.Name, metav1.DeleteOptions{}); err != nil {
+	if err := k8sUtils.crdClient.CrdV1alpha1().NetworkPolicies(data.testNamespace).Delete(context.TODO(), policy.Name, metav1.DeleteOptions{}); err != nil {
 		return fmt.Errorf("unable to cleanup policy %v: %v", policy.Name, err)
 	}
 	return nil
@@ -2188,18 +2188,18 @@ func (data *TestData) waitForNetworkpolicyRealized(pod string, node string, isWi
 		var stdout, stderr string
 		var err error
 		if isWindows {
-			antctlCmd := fmt.Sprintf("C:/k/antrea/bin/antctl.exe get networkpolicy -S %s -n %s -T %s", networkpolicy, testNamespace, npOption)
+			antctlCmd := fmt.Sprintf("C:/k/antrea/bin/antctl.exe get networkpolicy -S %s -n %s -T %s", networkpolicy, data.testNamespace, npOption)
 			envCmd := fmt.Sprintf("export POD_NAME=antrea-agent;export KUBERNETES_SERVICE_HOST=%s;export KUBERNETES_SERVICE_PORT=%d", clusterInfo.k8sServiceHost, clusterInfo.k8sServicePort)
 			cmd := fmt.Sprintf("%s && %s", envCmd, antctlCmd)
 			_, stdout, stderr, err = data.RunCommandOnNode(node, cmd)
 		} else {
-			cmds := []string{"antctl", "get", "networkpolicy", "-S", networkpolicy, "-n", testNamespace, "-T", npOption}
+			cmds := []string{"antctl", "get", "networkpolicy", "-S", networkpolicy, "-n", data.testNamespace, "-T", npOption}
 			stdout, stderr, err = runAntctl(pod, cmds, data)
 		}
 		if err != nil {
 			return false, fmt.Errorf("Error when executing antctl get NetworkPolicy, stdout: %s, stderr: %s, err: %v", stdout, stderr, err)
 		}
-		return strings.Contains(stdout, fmt.Sprintf("%s:%s/%s", npType, testNamespace, networkpolicy)), nil
+		return strings.Contains(stdout, fmt.Sprintf("%s:%s/%s", npType, data.testNamespace, networkpolicy)), nil
 	}); err == wait.ErrWaitTimeout {
 		return fmt.Errorf("NetworkPolicy %s isn't realized in time", networkpolicy)
 	} else if err != nil {
@@ -2251,7 +2251,7 @@ func runTestTraceflow(t *testing.T, data *TestData, tc testcase) {
 		// Give a little time for Nodes to install OVS flows.
 		time.Sleep(time.Second * 2)
 		// Send an ICMP echo packet from the source Pod to the destination.
-		if err := data.runPingCommandFromTestPod(podInfo{srcPod, osString, "", ""}, testNamespace, dstPodIPs, agnhostContainerName, 2, 0); err != nil {
+		if err := data.runPingCommandFromTestPod(podInfo{srcPod, osString, "", ""}, data.testNamespace, dstPodIPs, agnhostContainerName, 2, 0); err != nil {
 			t.Logf("Ping '%s' -> '%v' failed: ERROR (%v)", srcPod, *dstPodIPs, err)
 		}
 	}

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -54,10 +54,10 @@ func TestUpgrade(t *testing.T) {
 	podName := randName("test-pod-")
 
 	t.Logf("Creating a busybox test Pod on '%s'", nodeName)
-	if err := data.createBusyboxPodOnNode(podName, testNamespace, nodeName, false); err != nil {
+	if err := data.createBusyboxPodOnNode(podName, data.testNamespace, nodeName, false); err != nil {
 		t.Fatalf("Error when creating busybox test Pod: %v", err)
 	}
-	if err := data.podWaitForRunning(defaultTimeout, podName, testNamespace); err != nil {
+	if err := data.podWaitForRunning(defaultTimeout, podName, data.testNamespace); err != nil {
 		t.Fatalf("Error when waiting for Pod '%s' to be in the Running state", podName)
 	}
 
@@ -113,5 +113,5 @@ func TestUpgrade(t *testing.T) {
 		t.Errorf("Namespace deletion failed: %v", err)
 	}
 
-	data.testDeletePod(t, podName, nodeName, testNamespace, false)
+	data.testDeletePod(t, podName, nodeName, data.testNamespace, false)
 }


### PR DESCRIPTION
Fixes #3480
Fixes #3574

Created different namespaces for different e2e tests, so that the test
should not be delayed because of waiting for namespace deletion from
prior tests.

Time Statistics:
```txt
Name                               old time    new time
antrea-e2e test                    2692.584s   2316.626s
antrea-e2e test                    2640.578s   2309.422s
```

Removed stale TODO comment from agent.go file.

Signed-off-by: Pulkit Jain <jainpu@vmware.com>
Co-authored-by: Zhengsheng Zhou <zhengshengz@vmware.com>