### PR TITLE
Support TopologyAwareHints in AntreaProxy

### DIFF
--- a/build/charts/antrea/conf/antrea-agent.conf
+++ b/build/charts/antrea/conf/antrea-agent.conf
@@ -12,9 +12,13 @@ featureGates:
 {{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "AntreaProxy" "default" true) }}
 
 # Enable EndpointSlice support in AntreaProxy. Don't enable this feature unless that EndpointSlice
-# API version v1beta1 is supported and set as enabled in Kubernetes. If AntreaProxy is not enabled,
+# API version v1 is supported and set as enabled in Kubernetes. If AntreaProxy is not enabled,
 # this flag will not take effect.
 {{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "EndpointSlice" "default" false) }}
+
+# Enable TopologyAwareHints in AntreaProxy. This requires AntreaProxy and EndpointSlice to be
+# enabled, otherwise this flag will not take effect.
+{{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "TopologyAwareHints" "default" false) }}
 
 # Enable traceflow which provides packet tracing feature to diagnose network issue.
 {{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "Traceflow" "default" true) }}

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -2549,9 +2549,13 @@ data:
     #  AntreaProxy: true
 
     # Enable EndpointSlice support in AntreaProxy. Don't enable this feature unless that EndpointSlice
-    # API version v1beta1 is supported and set as enabled in Kubernetes. If AntreaProxy is not enabled,
+    # API version v1 is supported and set as enabled in Kubernetes. If AntreaProxy is not enabled,
     # this flag will not take effect.
     #  EndpointSlice: false
+
+    # Enable TopologyAwareHints in AntreaProxy. This requires AntreaProxy and EndpointSlice to be
+    # enabled, otherwise this flag will not take effect.
+    #  TopologyAwareHints: false
 
     # Enable traceflow which provides packet tracing feature to diagnose network issue.
     #  Traceflow: true
@@ -3688,7 +3692,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 890f1364c9b89811375830c94fab2fa9f1957518351cc52c623e22b6964e5e75
+        checksum/config: b82a5504883f65d32538dd4c2de4e01f4ac99203ff69191463715f67878e0745
       labels:
         app: antrea
         component: antrea-agent
@@ -3928,7 +3932,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 890f1364c9b89811375830c94fab2fa9f1957518351cc52c623e22b6964e5e75
+        checksum/config: b82a5504883f65d32538dd4c2de4e01f4ac99203ff69191463715f67878e0745
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -2549,9 +2549,13 @@ data:
     #  AntreaProxy: true
 
     # Enable EndpointSlice support in AntreaProxy. Don't enable this feature unless that EndpointSlice
-    # API version v1beta1 is supported and set as enabled in Kubernetes. If AntreaProxy is not enabled,
+    # API version v1 is supported and set as enabled in Kubernetes. If AntreaProxy is not enabled,
     # this flag will not take effect.
     #  EndpointSlice: false
+
+    # Enable TopologyAwareHints in AntreaProxy. This requires AntreaProxy and EndpointSlice to be
+    # enabled, otherwise this flag will not take effect.
+    #  TopologyAwareHints: false
 
     # Enable traceflow which provides packet tracing feature to diagnose network issue.
     #  Traceflow: true
@@ -3688,7 +3692,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 890f1364c9b89811375830c94fab2fa9f1957518351cc52c623e22b6964e5e75
+        checksum/config: b82a5504883f65d32538dd4c2de4e01f4ac99203ff69191463715f67878e0745
       labels:
         app: antrea
         component: antrea-agent
@@ -3930,7 +3934,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 890f1364c9b89811375830c94fab2fa9f1957518351cc52c623e22b6964e5e75
+        checksum/config: b82a5504883f65d32538dd4c2de4e01f4ac99203ff69191463715f67878e0745
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -2549,9 +2549,13 @@ data:
     #  AntreaProxy: true
 
     # Enable EndpointSlice support in AntreaProxy. Don't enable this feature unless that EndpointSlice
-    # API version v1beta1 is supported and set as enabled in Kubernetes. If AntreaProxy is not enabled,
+    # API version v1 is supported and set as enabled in Kubernetes. If AntreaProxy is not enabled,
     # this flag will not take effect.
     #  EndpointSlice: false
+
+    # Enable TopologyAwareHints in AntreaProxy. This requires AntreaProxy and EndpointSlice to be
+    # enabled, otherwise this flag will not take effect.
+    #  TopologyAwareHints: false
 
     # Enable traceflow which provides packet tracing feature to diagnose network issue.
     #  Traceflow: true
@@ -3688,7 +3692,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: cc8af4219d403a137ab87500ae0ab15b681fc635e41057b5623df6154443fddf
+        checksum/config: c74fa3f40177249ad901af12a4127b31b3291f9b8bf3ce6a9be1e666e29c5447
       labels:
         app: antrea
         component: antrea-agent
@@ -3928,7 +3932,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: cc8af4219d403a137ab87500ae0ab15b681fc635e41057b5623df6154443fddf
+        checksum/config: c74fa3f40177249ad901af12a4127b31b3291f9b8bf3ce6a9be1e666e29c5447
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -2562,9 +2562,13 @@ data:
     #  AntreaProxy: true
 
     # Enable EndpointSlice support in AntreaProxy. Don't enable this feature unless that EndpointSlice
-    # API version v1beta1 is supported and set as enabled in Kubernetes. If AntreaProxy is not enabled,
+    # API version v1 is supported and set as enabled in Kubernetes. If AntreaProxy is not enabled,
     # this flag will not take effect.
     #  EndpointSlice: false
+
+    # Enable TopologyAwareHints in AntreaProxy. This requires AntreaProxy and EndpointSlice to be
+    # enabled, otherwise this flag will not take effect.
+    #  TopologyAwareHints: false
 
     # Enable traceflow which provides packet tracing feature to diagnose network issue.
     #  Traceflow: true
@@ -3701,7 +3705,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: df5271a5c42a550d3f8e73fbe8e5fad8d178884fb74d81c7322128187546db86
+        checksum/config: 1609abc57e2865390df7a7d99e4c3b342c7e097fa879fefe8e4315130eaa9019
         checksum/ipsec-secret: d0eb9c52d0cd4311b6d252a951126bf9bea27ec05590bed8a394f0f792dcb2a4
       labels:
         app: antrea
@@ -3987,7 +3991,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: df5271a5c42a550d3f8e73fbe8e5fad8d178884fb74d81c7322128187546db86
+        checksum/config: 1609abc57e2865390df7a7d99e4c3b342c7e097fa879fefe8e4315130eaa9019
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -2549,9 +2549,13 @@ data:
     #  AntreaProxy: true
 
     # Enable EndpointSlice support in AntreaProxy. Don't enable this feature unless that EndpointSlice
-    # API version v1beta1 is supported and set as enabled in Kubernetes. If AntreaProxy is not enabled,
+    # API version v1 is supported and set as enabled in Kubernetes. If AntreaProxy is not enabled,
     # this flag will not take effect.
     #  EndpointSlice: false
+
+    # Enable TopologyAwareHints in AntreaProxy. This requires AntreaProxy and EndpointSlice to be
+    # enabled, otherwise this flag will not take effect.
+    #  TopologyAwareHints: false
 
     # Enable traceflow which provides packet tracing feature to diagnose network issue.
     #  Traceflow: true
@@ -3688,7 +3692,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 033b7f8c7b77a918ad1a90c3db034bbfc1df67de264a77f8aee6a035836b6812
+        checksum/config: 0814cc9f3baa94e76e83a108b04d05200485610c7f5950c584503af7151a9e86
       labels:
         app: antrea
         component: antrea-agent
@@ -3928,7 +3932,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 033b7f8c7b77a918ad1a90c3db034bbfc1df67de264a77f8aee6a035836b6812
+        checksum/config: 0814cc9f3baa94e76e83a108b04d05200485610c7f5950c584503af7151a9e86
       labels:
         app: antrea
         component: antrea-controller

--- a/docs/feature-gates.md
+++ b/docs/feature-gates.md
@@ -34,9 +34,10 @@ example, to enable `AntreaProxy` on Linux, edit the Agent configuration in the
 ## List of Available Features
 
 | Feature Name            | Component          | Default | Stage | Alpha Release | Beta Release | GA Release | Extra Requirements | Notes |
-| ----------------------- | ------------------ | ------- | ----- | ------------- | ------------ | ---------- | ------------------ | ----- |
+| ----------------------- | ------------------ | ------- | ----- |---------------| ------------ | ---------- | ------------------ | ----- |
 | `AntreaProxy`           | Agent              | `true`  | Beta  | v0.8          | v0.11        | N/A        | Yes                | Must be enabled for Windows. |
 | `EndpointSlice`         | Agent              | `false` | Alpha | v0.13.0       | N/A          | N/A        | Yes                |       |
+| `TopologyAwareHints`    | Agent              | `false` | Alpha | v1.8          | N/A          | N/A        | Yes                |       |
 | `AntreaPolicy`          | Agent + Controller | `true`  | Beta  | v0.8          | v1.0         | N/A        | No                 | Agent side config required from v0.9.0+. |
 | `Traceflow`             | Agent + Controller | `true`  | Beta  | v0.8          | v0.11        | N/A        | Yes                |       |
 | `FlowExporter`          | Agent              | `false` | Alpha | v0.9          | N/A          | N/A        | Yes                |       |
@@ -89,6 +90,19 @@ and will not implement Cluster IP functionality as expected.
 
 When using the OVS built-in kernel module (which is the most common case), your
 kernel version must be >= 4.6 (as opposed to >= 4.4 without this feature).
+
+### TopologyAwareHints
+
+`TopologyAwareHints` enables TopologyAwareHints support in AntreaProxy. The feature
+TopologyAwareHints is at beta stage in Kubernetes 1.23 (beta), and it is enabled by
+default in Kubernetes 1.24. For AntreaProxy, traffic can be routed to the Endpoint
+which is closer to its origin with this feature. Refer to this
+[link](https://kubernetes.io/docs/concepts/services-networking/topology-aware-hints/)
+for more information.
+
+#### Requirements for this Feature
+
+Feature EndpointSlice is enabled.
 
 ### AntreaPolicy
 

--- a/pkg/agent/proxy/endpoints.go
+++ b/pkg/agent/proxy/endpoints.go
@@ -21,7 +21,7 @@ import (
 	"sync"
 
 	corev1 "k8s.io/api/core/v1"
-	discovery "k8s.io/api/discovery/v1beta1"
+	discovery "k8s.io/api/discovery/v1"
 	apimachinerytypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 

--- a/pkg/agent/proxy/proxier_test.go
+++ b/pkg/agent/proxy/proxier_test.go
@@ -215,10 +215,10 @@ func testClusterIP(t *testing.T, svcIP net.IP, ep1IP, ep2IP net.IP, isIPv6, node
 	allEps := append(extraEps, makeTestEndpoints(svcPortName.Namespace, svcPortName.Name, epFunc))
 	makeEndpointsMap(fp, allEps...)
 
-	expectedLocalEps := []k8sproxy.Endpoint{k8sproxy.NewBaseEndpointInfo(ep2IP.String(), svcPort, true, nil)}
+	expectedLocalEps := []k8sproxy.Endpoint{k8sproxy.NewBaseEndpointInfo(ep2IP.String(), "", "", svcPort, true, false, false, false, nil)}
 	expectedAllEps := expectedLocalEps
 	if !nodeLocalInternal {
-		expectedAllEps = append(expectedAllEps, k8sproxy.NewBaseEndpointInfo(ep1IP.String(), svcPort, false, nil))
+		expectedAllEps = append(expectedAllEps, k8sproxy.NewBaseEndpointInfo(ep1IP.String(), "", "", svcPort, false, false, false, false, nil))
 	}
 
 	bindingProtocol := binding.ProtocolTCP
@@ -307,10 +307,10 @@ func testLoadBalancer(t *testing.T, nodePortAddresses []net.IP, svcIP, ep1IP, ep
 	eps := []*corev1.Endpoints{makeTestEndpoints(svcPortName.Namespace, svcPortName.Name, epFunc)}
 	makeEndpointsMap(fp, eps...)
 
-	expectedLocalEps := []k8sproxy.Endpoint{k8sproxy.NewBaseEndpointInfo(ep2IP.String(), svcPort, true, nil)}
+	expectedLocalEps := []k8sproxy.Endpoint{k8sproxy.NewBaseEndpointInfo(ep2IP.String(), "", "", svcPort, true, false, false, false, nil)}
 	expectedAllEps := expectedLocalEps
 	if !(nodeLocalInternal && nodeLocalExternal) {
-		expectedAllEps = append(expectedAllEps, k8sproxy.NewBaseEndpointInfo(ep1IP.String(), svcPort, false, nil))
+		expectedAllEps = append(expectedAllEps, k8sproxy.NewBaseEndpointInfo(ep1IP.String(), "", "", svcPort, false, false, false, false, nil))
 	}
 
 	bindingProtocol := binding.ProtocolTCP
@@ -430,10 +430,10 @@ func testNodePort(t *testing.T, nodePortAddresses []net.IP, svcIP, ep1IP, ep2IP 
 	eps = append(eps, makeTestEndpoints(svcPortName.Namespace, svcPortName.Name, epFunc))
 	makeEndpointsMap(fp, eps...)
 
-	expectedLocalEps := []k8sproxy.Endpoint{k8sproxy.NewBaseEndpointInfo(ep2IP.String(), svcPort, true, nil)}
+	expectedLocalEps := []k8sproxy.Endpoint{k8sproxy.NewBaseEndpointInfo(ep2IP.String(), "", "", svcPort, true, false, false, false, nil)}
 	expectedAllEps := expectedLocalEps
 	if !(nodeLocalInternal && nodeLocalExternal) {
-		expectedAllEps = append(expectedAllEps, k8sproxy.NewBaseEndpointInfo(ep1IP.String(), svcPort, false, nil))
+		expectedAllEps = append(expectedAllEps, k8sproxy.NewBaseEndpointInfo(ep1IP.String(), "", "", svcPort, false, false, false, false, nil))
 	}
 
 	bindingProtocol := binding.ProtocolTCP

--- a/pkg/agent/proxy/topology.go
+++ b/pkg/agent/proxy/topology.go
@@ -1,0 +1,67 @@
+// Copyright 2022 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+
+	k8sproxy "antrea.io/antrea/third_party/proxy"
+)
+
+func filterEndpoints(endpoints map[string]k8sproxy.Endpoint, svcInfo k8sproxy.ServicePort, nodeLabels map[string]string) map[string]k8sproxy.Endpoint {
+	if svcInfo.NodeLocalExternal() || svcInfo.NodeLocalInternal() {
+		return endpoints
+	}
+
+	return filterEndpointsWithHints(endpoints, svcInfo.HintsAnnotation(), nodeLabels)
+}
+
+func filterEndpointsWithHints(endpoints map[string]k8sproxy.Endpoint, hintsAnnotation string, nodeLabels map[string]string) map[string]k8sproxy.Endpoint {
+	if hintsAnnotation != "Auto" && hintsAnnotation != "auto" {
+		if hintsAnnotation != "" && hintsAnnotation != "Disabled" && hintsAnnotation != "disabled" {
+			klog.InfoS("Skipping topology aware Endpoint filtering since Service has unexpected value", "annotationTopologyAwareHints", v1.AnnotationTopologyAwareHints, "hints", hintsAnnotation)
+		}
+		return endpoints
+	}
+
+	zone, ok := nodeLabels[v1.LabelTopologyZone]
+	if !ok || zone == "" {
+		klog.InfoS("Skipping topology aware Endpoint filtering since Node is missing label", "label", v1.LabelTopologyZone)
+		return endpoints
+	}
+
+	filteredEndpoints := make(map[string]k8sproxy.Endpoint)
+
+	for key, endpoint := range endpoints {
+		if !endpoint.IsReady() {
+			continue
+		}
+		if endpoint.GetZoneHints().Len() == 0 {
+			klog.InfoS("Skipping topology aware Endpoint filtering since one or more Endpoints is missing a zone hint")
+			return endpoints
+		}
+		if endpoint.GetZoneHints().Has(zone) {
+			filteredEndpoints[key] = endpoint
+		}
+	}
+
+	if len(filteredEndpoints) == 0 {
+		klog.InfoS("Skipping topology aware Endpoint filtering since no hints were provided for zone", "zone", zone)
+		return endpoints
+	}
+
+	return filteredEndpoints
+}

--- a/pkg/agent/proxy/topology_test.go
+++ b/pkg/agent/proxy/topology_test.go
@@ -1,0 +1,123 @@
+// Copyright 2022 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package proxy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	k8sproxy "antrea.io/antrea/third_party/proxy"
+)
+
+func TestTopologyAwareHints(t *testing.T) {
+	testCases := []struct {
+		name              string
+		nodeLabels        map[string]string
+		hintsAnnotation   string
+		endpoints         map[string]k8sproxy.Endpoint
+		expectedEndpoints sets.String
+	}{
+		{
+			name:            "hints annotation == auto",
+			nodeLabels:      map[string]string{v1.LabelTopologyZone: "zone-a"},
+			hintsAnnotation: "auto",
+			endpoints: map[string]k8sproxy.Endpoint{
+				"10.1.2.3:80": &k8sproxy.BaseEndpointInfo{Endpoint: "10.1.2.3:80", ZoneHints: sets.NewString("zone-a"), Ready: true},
+				"10.1.2.4:80": &k8sproxy.BaseEndpointInfo{Endpoint: "10.1.2.4:80", ZoneHints: sets.NewString("zone-b"), Ready: true},
+				"10.1.2.5:80": &k8sproxy.BaseEndpointInfo{Endpoint: "10.1.2.5:80", ZoneHints: sets.NewString("zone-c"), Ready: true},
+				"10.1.2.6:80": &k8sproxy.BaseEndpointInfo{Endpoint: "10.1.2.6:80", ZoneHints: sets.NewString("zone-a"), Ready: true},
+			},
+			expectedEndpoints: sets.NewString("10.1.2.3:80", "10.1.2.6:80"),
+		},
+		{
+			name:            "hints annotation == disabled, hints ignored",
+			nodeLabels:      map[string]string{v1.LabelTopologyZone: "zone-a"},
+			hintsAnnotation: "disabled",
+			endpoints: map[string]k8sproxy.Endpoint{
+				"10.1.2.3:80": &k8sproxy.BaseEndpointInfo{Endpoint: "10.1.2.3:80", ZoneHints: sets.NewString("zone-a"), Ready: true},
+				"10.1.2.4:80": &k8sproxy.BaseEndpointInfo{Endpoint: "10.1.2.4:80", ZoneHints: sets.NewString("zone-b"), Ready: true},
+				"10.1.2.5:80": &k8sproxy.BaseEndpointInfo{Endpoint: "10.1.2.5:80", ZoneHints: sets.NewString("zone-c"), Ready: true},
+				"10.1.2.6:80": &k8sproxy.BaseEndpointInfo{Endpoint: "10.1.2.6:80", ZoneHints: sets.NewString("zone-a"), Ready: true},
+			},
+			expectedEndpoints: sets.NewString("10.1.2.3:80", "10.1.2.4:80", "10.1.2.5:80", "10.1.2.6:80"),
+		},
+		{
+			name:            "hints annotation == aUto (wrong capitalization), hints ignored",
+			nodeLabels:      map[string]string{v1.LabelTopologyZone: "zone-a"},
+			hintsAnnotation: "aUto",
+			endpoints: map[string]k8sproxy.Endpoint{
+				"10.1.2.3:80": &k8sproxy.BaseEndpointInfo{Endpoint: "10.1.2.3:80", ZoneHints: sets.NewString("zone-a"), Ready: true},
+				"10.1.2.4:80": &k8sproxy.BaseEndpointInfo{Endpoint: "10.1.2.4:80", ZoneHints: sets.NewString("zone-b"), Ready: true},
+				"10.1.2.5:80": &k8sproxy.BaseEndpointInfo{Endpoint: "10.1.2.5:80", ZoneHints: sets.NewString("zone-c"), Ready: true},
+				"10.1.2.6:80": &k8sproxy.BaseEndpointInfo{Endpoint: "10.1.2.6:80", ZoneHints: sets.NewString("zone-a"), Ready: true},
+			},
+			expectedEndpoints: sets.NewString("10.1.2.3:80", "10.1.2.4:80", "10.1.2.5:80", "10.1.2.6:80"),
+		},
+		{
+			name:            "hints annotation empty, hints ignored",
+			nodeLabels:      map[string]string{v1.LabelTopologyZone: "zone-a"},
+			hintsAnnotation: "",
+			endpoints: map[string]k8sproxy.Endpoint{
+				"10.1.2.3:80": &k8sproxy.BaseEndpointInfo{Endpoint: "10.1.2.3:80", ZoneHints: sets.NewString("zone-a"), Ready: true},
+				"10.1.2.4:80": &k8sproxy.BaseEndpointInfo{Endpoint: "10.1.2.4:80", ZoneHints: sets.NewString("zone-b"), Ready: true},
+				"10.1.2.5:80": &k8sproxy.BaseEndpointInfo{Endpoint: "10.1.2.5:80", ZoneHints: sets.NewString("zone-c"), Ready: true},
+				"10.1.2.6:80": &k8sproxy.BaseEndpointInfo{Endpoint: "10.1.2.6:80", ZoneHints: sets.NewString("zone-a"), Ready: true},
+			},
+			expectedEndpoints: sets.NewString("10.1.2.3:80", "10.1.2.4:80", "10.1.2.5:80", "10.1.2.6:80"),
+		},
+		{
+			name:            "empty node labels",
+			nodeLabels:      nil,
+			hintsAnnotation: "auto",
+			endpoints: map[string]k8sproxy.Endpoint{
+				"10.1.2.3:80": &k8sproxy.BaseEndpointInfo{Endpoint: "10.1.2.3:80", ZoneHints: sets.NewString("zone-a"), Ready: true},
+			},
+			expectedEndpoints: sets.NewString("10.1.2.3:80"),
+		},
+		{
+			name:            "empty zone label",
+			nodeLabels:      map[string]string{v1.LabelTopologyZone: ""},
+			hintsAnnotation: "auto",
+			endpoints: map[string]k8sproxy.Endpoint{
+				"10.1.2.3:80": &k8sproxy.BaseEndpointInfo{Endpoint: "10.1.2.3:80", ZoneHints: sets.NewString("zone-a"), Ready: true},
+			},
+			expectedEndpoints: sets.NewString("10.1.2.3:80"),
+		},
+		{
+			name:            "node in different zone, no endpoint filtering",
+			nodeLabels:      map[string]string{v1.LabelTopologyZone: "zone-b"},
+			hintsAnnotation: "auto",
+			endpoints: map[string]k8sproxy.Endpoint{
+				"10.1.2.3:80": &k8sproxy.BaseEndpointInfo{Endpoint: "10.1.2.3:80", ZoneHints: sets.NewString("zone-a"), Ready: true},
+				"10.1.2.5:80": &k8sproxy.BaseEndpointInfo{Endpoint: "10.1.2.5:80", ZoneHints: sets.NewString("zone-c"), Ready: true},
+			},
+			expectedEndpoints: sets.NewString("10.1.2.3:80", "10.1.2.5:80"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			endpointsMap := filterEndpointsWithHints(tc.endpoints, tc.hintsAnnotation, tc.nodeLabels)
+			endpoints := sets.NewString()
+			for key := range endpointsMap {
+				endpoints.Insert(key)
+			}
+			assert.Equal(t, tc.expectedEndpoints, endpoints)
+		})
+	}
+}

--- a/pkg/features/antrea_features.go
+++ b/pkg/features/antrea_features.go
@@ -41,6 +41,11 @@ const (
 	// flag will not take effect.
 	EndpointSlice featuregate.Feature = "EndpointSlice"
 
+	// alpha: v1.8
+	// Enable TopologyAwareHints in AntreaProxy. If EndpointSlice is not enabled, this
+	// flag will not take effect.
+	TopologyAwareHints featuregate.Feature = "TopologyAwareHints"
+
 	// alpha: v0.8
 	// beta: v0.11
 	// Enable antrea proxy which provides ServiceLB for in-cluster services in antrea agent.
@@ -121,6 +126,7 @@ var (
 		AntreaProxy:        {Default: true, PreRelease: featuregate.Beta},
 		Egress:             {Default: true, PreRelease: featuregate.Beta},
 		EndpointSlice:      {Default: false, PreRelease: featuregate.Alpha},
+		TopologyAwareHints: {Default: false, PreRelease: featuregate.Alpha},
 		Traceflow:          {Default: true, PreRelease: featuregate.Beta},
 		AntreaIPAM:         {Default: false, PreRelease: featuregate.Alpha},
 		FlowExporter:       {Default: false, PreRelease: featuregate.Alpha},

--- a/third_party/proxy/endpoints.go
+++ b/third_party/proxy/endpoints.go
@@ -43,6 +43,8 @@ import (
 	"net"
 	"strconv"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	utilproxy "antrea.io/antrea/third_party/proxy/util"
 )
 
@@ -53,8 +55,32 @@ import (
 type BaseEndpointInfo struct {
 	Endpoint string // TODO: should be an endpointString type
 	// IsLocal indicates whether the endpoint is running in same host as kube-proxy.
-	IsLocal  bool
-	Topology map[string]string
+	IsLocal bool
+
+	// ZoneHints represent the zone hints for the endpoint. This is based on
+	// endpoint.hints.forZones[*].name in the EndpointSlice API.
+	ZoneHints sets.String
+	// Ready indicates whether this endpoint is ready and NOT terminating.
+	// For pods, this is true if a pod has a ready status and a nil deletion timestamp.
+	// This is only set when watching EndpointSlices. If using Endpoints, this is always
+	// true since only ready endpoints are read from Endpoints.
+	// TODO: Ready can be inferred from Serving and Terminating below when enabled by default.
+	Ready bool
+	// Serving indiciates whether this endpoint is ready regardless of its terminating state.
+	// For pods this is true if it has a ready status regardless of its deletion timestamp.
+	// This is only set when watching EndpointSlices. If using Endpoints, this is always
+	// true since only ready endpoints are read from Endpoints.
+	Serving bool
+	// Terminating indicates whether this endpoint is terminating.
+	// For pods this is true if it has a non-nil deletion timestamp.
+	// This is only set when watching EndpointSlices. If using Endpoints, this is always
+	// false since terminating endpoints are always excluded from Endpoints.
+	Terminating bool
+
+	// NodeName is the name of the node this endpoint belongs to
+	NodeName string
+	// Zone is the name of the zone this endpoint belongs to
+	Zone string
 }
 
 var _ Endpoint = &BaseEndpointInfo{}
@@ -69,9 +95,26 @@ func (info *BaseEndpointInfo) GetIsLocal() bool {
 	return info.IsLocal
 }
 
-// GetTopology returns the topology information of the endpoint.
-func (info *BaseEndpointInfo) GetTopology() map[string]string {
-	return info.Topology
+// IsReady returns true if an endpoint is ready and not terminating.
+func (info *BaseEndpointInfo) IsReady() bool {
+	return info.Ready
+}
+
+// IsServing returns true if an endpoint is ready, regardless of if the
+// endpoint is terminating.
+func (info *BaseEndpointInfo) IsServing() bool {
+	return info.Serving
+}
+
+// IsTerminating retruns true if an endpoint is terminating. For pods,
+// that is any pod with a deletion timestamp.
+func (info *BaseEndpointInfo) IsTerminating() bool {
+	return info.Terminating
+}
+
+// GetZoneHints returns the zone hint for the endpoint.
+func (info *BaseEndpointInfo) GetZoneHints() sets.String {
+	return info.ZoneHints
 }
 
 // IP returns just the IP part of the endpoint, it's a part of proxy.Endpoint interface.
@@ -86,13 +129,31 @@ func (info *BaseEndpointInfo) Port() (int, error) {
 
 // Equal is part of proxy.Endpoint interface.
 func (info *BaseEndpointInfo) Equal(other Endpoint) bool {
-	return info.String() == other.String() && info.GetIsLocal() == other.GetIsLocal()
+	return info.String() == other.String() &&
+		info.GetIsLocal() == other.GetIsLocal() &&
+		info.IsReady() == other.IsReady()
 }
 
-func NewBaseEndpointInfo(IP string, port int, isLocal bool, topology map[string]string) *BaseEndpointInfo {
+// GetNodeName returns the NodeName for this endpoint.
+func (info *BaseEndpointInfo) GetNodeName() string {
+	return info.NodeName
+}
+
+// GetZone returns the Zone for this endpoint.
+func (info *BaseEndpointInfo) GetZone() string {
+	return info.Zone
+}
+
+func NewBaseEndpointInfo(IP, nodeName, zone string, port int, isLocal bool,
+	ready, serving, terminating bool, zoneHints sets.String) *BaseEndpointInfo {
 	return &BaseEndpointInfo{
-		Endpoint: net.JoinHostPort(IP, strconv.Itoa(port)),
-		IsLocal:  isLocal,
-		Topology: topology,
+		Endpoint:    net.JoinHostPort(IP, strconv.Itoa(port)),
+		IsLocal:     isLocal,
+		Ready:       ready,
+		Serving:     serving,
+		Terminating: terminating,
+		ZoneHints:   zoneHints,
+		NodeName:    nodeName,
+		Zone:        zone,
 	}
 }

--- a/third_party/proxy/types.go
+++ b/third_party/proxy/types.go
@@ -43,6 +43,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"antrea.io/antrea/third_party/proxy/config"
 )
@@ -117,14 +118,33 @@ type Endpoint interface {
 	String() string
 	// GetIsLocal returns true if the endpoint is running in same host as kube-proxy, otherwise returns false.
 	GetIsLocal() bool
-	// GetTopology returns the topology information of the endpoint.
-	GetTopology() map[string]string
+	// IsReady returns true if an endpoint is ready and not terminating.
+	// This is only set when watching EndpointSlices. If using Endpoints, this is always
+	// true since only ready endpoints are read from Endpoints.
+	IsReady() bool
+	// IsServing returns true if an endpoint is ready. It does not account
+	// for terminating state.
+	// This is only set when watching EndpointSlices. If using Endpoints, this is always
+	// true since only ready endpoints are read from Endpoints.
+	IsServing() bool
+	// IsTerminating retruns true if an endpoint is terminating. For pods,
+	// that is any pod with a deletion timestamp.
+	// This is only set when watching EndpointSlices. If using Endpoints, this is always
+	// false since terminating endpoints are always excluded from Endpoints.
+	IsTerminating() bool
+	// GetZoneHint returns the zone hint for the endpoint. This is based on
+	// endpoint.hints.forZones[0].name in the EndpointSlice API.
+	GetZoneHints() sets.String
 	// IP returns IP part of the endpoint.
 	IP() string
 	// Port returns the Port part of the endpoint.
 	Port() (int, error)
 	// Equal checks if two endpoints are equal.
 	Equal(Endpoint) bool
+	// GetNodeName returns the node name for the endpoint
+	GetNodeName() string
+	// GetZone returns the zone for the endpoint
+	GetZone() string
 }
 
 // ServiceEndpoint is used to identify a service and one of its endpoint pair.


### PR DESCRIPTION
Feature TopologyAwareHints is at Beta stage in Kubernetes v1.23, and it is
enabled by default in Kubernetes v1.24 See more
https://kubernetes.io/docs/concepts/services-networking/topology-aware-hints/.

Signed-off-by: Hongliang Liu <lhongliang@vmware.com>