### PR TITLE
[Windows] Use uplink MAC as source if packet is output to uplink

### DIFF
--- a/pkg/agent/agent_windows.go
+++ b/pkg/agent/agent_windows.go
@@ -43,6 +43,10 @@ func (i *Initializer) prepareHostNetwork() error {
 		}
 		// Save the uplink adapter name to check if the OVS uplink port has been created in prepareOVSBridge stage.
 		i.nodeConfig.UplinkNetConfig.Name = hnsNetwork.NetworkAdapterName
+
+		// Save the uplink adapter MAC to modify Pod traffic source MAC if the packet is directly output to the uplink
+		// interface in OVS pipeline.
+		i.nodeConfig.UplinkNetConfig.MAC, _ = net.ParseMAC(hnsNetwork.SourceMac)
 		return nil
 	}
 	if _, ok := err.(hcsshim.NetworkNotFoundError); !ok {

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -1357,6 +1357,7 @@ func (f *featurePodConnectivity) l3FwdFlowToRemoteViaUplink(remoteGatewayMAC net
 			MatchProtocol(ipProtocol).
 			MatchRegMark(NotAntreaFlexibleIPAMRegMark).
 			MatchDstIPNet(peerSubnet).
+			Action().SetSrcMAC(f.nodeConfig.UplinkNetConfig.MAC).
 			Action().SetDstMAC(remoteGatewayMAC).
 			Action().GotoTable(L3DecTTLTable.GetID()).
 			Done()

--- a/pkg/agent/openflow/pipeline_windows.go
+++ b/pkg/agent/openflow/pipeline_windows.go
@@ -85,6 +85,7 @@ func (f *featurePodConnectivity) l3FwdFlowToRemoteViaRouting(localGatewayMAC net
 				MatchDstIP(peerIP).
 				MatchCTStateRpl(true).
 				MatchCTStateTrk(true).
+				Action().SetSrcMAC(f.nodeConfig.UplinkNetConfig.MAC).
 				Action().SetDstMAC(remoteGatewayMAC).
 				Action().NextTable().
 				Done(),


### PR DESCRIPTION
With noEncap mode the Pod packet to remote Pod/Node is output to the
uplink interface directly. This change modifies the source MAC with the
uplink interface's MAC, so that it doesn't require hybrid configurations
on the host interface.

Fixes #3505 

Signed-off-by: wenyingd <wenyingd@vmware.com>