### PR TITLE
Automated cherry pick of #3219: Add ignored interfaces names when getting interface by IP

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -227,7 +227,7 @@ func run(o *Options) error {
 	var egressController *egress.EgressController
 	if features.DefaultFeatureGate.Enabled(features.Egress) {
 		egressController, err = egress.NewEgressController(
-			ofClient, antreaClientProvider, crdClient, ifaceStore, routeClient, nodeConfig.Name, nodeConfig.NodeIPAddr.IP,
+			ofClient, antreaClientProvider, crdClient, ifaceStore, routeClient, nodeConfig.Name, nodeConfig.NodeTransportInterfaceName, nodeConfig.NodeIPAddr.IP,
 			o.config.ClusterMembershipPort, egressInformer, nodeInformer, externalIPPoolInformer,
 		)
 		if err != nil {

--- a/pkg/agent/agent_windows.go
+++ b/pkg/agent/agent_windows.go
@@ -48,7 +48,7 @@ func (i *Initializer) prepareHostNetwork() error {
 		return err
 	}
 	// Get uplink network configuration.
-	_, adapter, err := util.GetIPNetDeviceFromIP(i.nodeConfig.NodeIPAddr.IP)
+	_, adapter, err := i.getNodeInterfaceFromIP(i.nodeConfig.NodeIPAddr.IP)
 	if err != nil {
 		return err
 	}

--- a/pkg/agent/config/node_config.go
+++ b/pkg/agent/config/node_config.go
@@ -85,6 +85,9 @@ type NodeConfig struct {
 	PodIPv6CIDR *net.IPNet
 	// The Node's IP used in Kubernetes. It has the network mask information.
 	NodeIPAddr *net.IPNet
+	// The name of the Node's transport interface. The transport interface defaults to the
+	// interface that has the K8s Node IP.
+	NodeTransportInterfaceName string
 	// Set either via defaultMTU config in antrea.yaml or auto discovered.
 	// Auto discovery will use MTU value of the Node's primary interface.
 	// For Encap and Hybrid mode, Node MTU will be adjusted to account for encap header.

--- a/pkg/agent/controller/egress/egress_controller.go
+++ b/pkg/agent/controller/egress/egress_controller.go
@@ -150,7 +150,8 @@ func NewEgressController(
 	ifaceStore interfacestore.InterfaceStore,
 	routeClient route.Interface,
 	nodeName string,
-	nodeIP net.IP,
+	nodeTransportInterface string,
+	nodeTransportIP net.IP,
 	clusterPort int,
 	egressInformer crdinformers.EgressInformer,
 	nodeInformer coreinformers.NodeInformer,
@@ -175,13 +176,13 @@ func NewEgressController(
 		localIPDetector:      localIPDetector,
 		idAllocator:          newIDAllocator(minEgressMark, maxEgressMark),
 	}
-	ipAssigner, err := ipassigner.NewIPAssigner(nodeIP, egressDummyDevice)
+	ipAssigner, err := ipassigner.NewIPAssigner(nodeTransportInterface, egressDummyDevice)
 	if err != nil {
 		return nil, fmt.Errorf("initializing egressIP assigner failed: %v", err)
 	}
 	c.ipAssigner = ipAssigner
 
-	cluster, err := memberlist.NewCluster(clusterPort, nodeIP, nodeName, nodeInformer, externalIPPoolInformer)
+	cluster, err := memberlist.NewCluster(clusterPort, nodeTransportIP, nodeName, nodeInformer, externalIPPoolInformer)
 	if err != nil {
 		return nil, fmt.Errorf("initializing memberlist cluster failed: %v", err)
 	}

--- a/pkg/agent/controller/egress/ipassigner/ip_assigner_linux.go
+++ b/pkg/agent/controller/egress/ipassigner/ip_assigner_linux.go
@@ -48,10 +48,10 @@ type ipAssigner struct {
 }
 
 // NewIPAssigner returns an *ipAssigner.
-func NewIPAssigner(nodeIPAddr net.IP, dummyDeviceName string) (*ipAssigner, error) {
-	_, egressInterface, err := util.GetIPNetDeviceFromIP(nodeIPAddr)
+func NewIPAssigner(nodeTransportInterface string, dummyDeviceName string) (*ipAssigner, error) {
+	_, externalInterface, err := util.GetIPNetDeviceByName(nodeTransportInterface)
 	if err != nil {
-		return nil, fmt.Errorf("get IPNetDevice from ip %v error: %+v", nodeIPAddr, err)
+		return nil, fmt.Errorf("get IPNetDevice from name %s error: %+v", nodeTransportInterface, err)
 	}
 
 	dummyDevice, err := ensureDummyDevice(dummyDeviceName)
@@ -60,7 +60,7 @@ func NewIPAssigner(nodeIPAddr net.IP, dummyDeviceName string) (*ipAssigner, erro
 	}
 
 	a := &ipAssigner{
-		externalInterface: egressInterface,
+		externalInterface: externalInterface,
 		dummyDevice:       dummyDevice,
 		assignedIPs:       sets.NewString(),
 	}

--- a/pkg/agent/controller/egress/ipassigner/ip_assigner_windows.go
+++ b/pkg/agent/controller/egress/ipassigner/ip_assigner_windows.go
@@ -15,15 +15,13 @@
 package ipassigner
 
 import (
-	"net"
-
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 type ipAssigner struct {
 }
 
-func NewIPAssigner(nodeIPAddr net.IP, dummyDeviceName string) (*ipAssigner, error) {
+func NewIPAssigner(nodeTransportInterface string, dummyDeviceName string) (*ipAssigner, error) {
 	return nil, nil
 }
 

--- a/pkg/agent/util/net_test.go
+++ b/pkg/agent/util/net_test.go
@@ -19,6 +19,8 @@ import (
 	"net"
 	"strings"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 func TestGenerateContainerInterfaceName(t *testing.T) {
@@ -55,7 +57,7 @@ func TestGetDefaultLocalNodeAddr(t *testing.T) {
 	defer conn.Close()
 	ip := conn.LocalAddr().(*net.UDPAddr).IP
 
-	_, dev, err := GetIPNetDeviceFromIP(ip)
+	_, dev, err := GetIPNetDeviceFromIP(ip, sets.NewString())
 	if err != nil {
 		t.Error(err)
 	}

--- a/test/integration/agent/ip_assigner_linux_test.go
+++ b/test/integration/agent/ip_assigner_linux_test.go
@@ -15,7 +15,6 @@
 package agent
 
 import (
-	"net"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,7 +28,10 @@ import (
 const dummyDeviceName = "antrea-dummy0"
 
 func TestIPAssigner(t *testing.T) {
-	ipAssigner, err := ipassigner.NewIPAssigner(net.ParseIP("127.0.0.1"), dummyDeviceName)
+	nodeLinkName := nodeIntf.Name
+	require.NotNil(t, nodeLinkName, "Get Node link failed")
+
+	ipAssigner, err := ipassigner.NewIPAssigner(nodeLinkName, dummyDeviceName)
 	require.NoError(t, err, "Initializing IP assigner failed")
 
 	dummyDevice, err := netlink.LinkByName(dummyDeviceName)
@@ -55,7 +57,7 @@ func TestIPAssigner(t *testing.T) {
 	assert.Equal(t, desiredIPs, actualIPs, "Actual IPs don't match")
 
 	// NewIPAssigner should load existing IPs correctly.
-	newIPAssigner, err := ipassigner.NewIPAssigner(net.ParseIP("127.0.0.1"), dummyDeviceName)
+	newIPAssigner, err := ipassigner.NewIPAssigner(nodeLinkName, dummyDeviceName)
 	require.NoError(t, err, "Initializing new IP assigner failed")
 	assert.Equal(t, desiredIPs, newIPAssigner.AssignedIPs(), "Assigned IPs don't match")
 

--- a/test/integration/agent/route_test.go
+++ b/test/integration/agent/route_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/net/nettest"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"antrea.io/antrea/pkg/agent/config"
 	"antrea.io/antrea/pkg/agent/route"
@@ -54,7 +55,7 @@ var (
 		conn, _ := net.Dial("udp", "8.8.8.8:80")
 		defer conn.Close()
 		return conn.LocalAddr().(*net.UDPAddr).IP
-	}())
+	}(), sets.NewString())
 	nodeLink, _       = netlink.LinkByName(nodeIntf.Name)
 	localPeerIP       = ip.NextIP(nodeIP.IP)
 	remotePeerIP      = net.ParseIP("50.50.50.1")


### PR DESCRIPTION
Cherry pick of #3219 on release-1.2.

#3219: Add ignored interfaces names when getting interface by IP

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.