### PR TITLE
[Flow Visibility] Fix Clickhouse credentials missing in FA manifest

### DIFF
--- a/build/yamls/flow-aggregator.yml
+++ b/build/yamls/flow-aggregator.yml
@@ -238,6 +238,18 @@ metadata:
   namespace: flow-aggregator
 ---
 apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: flow-aggregator
+  name: clickhouse-secret
+  namespace: flow-aggregator
+stringData:
+  password: clickhouse_operator_password
+  username: clickhouse_operator
+type: Opaque
+---
+apiVersion: v1
 kind: Service
 metadata:
   labels:
@@ -289,6 +301,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: CH_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: clickhouse-secret
+        - name: CH_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: clickhouse-secret
         image: projects.registry.vmware.com/antrea/flow-aggregator:latest
         imagePullPolicy: IfNotPresent
         name: flow-aggregator

--- a/build/yamls/flow-aggregator/base/flow-aggregator.yml
+++ b/build/yamls/flow-aggregator/base/flow-aggregator.yml
@@ -145,6 +145,16 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
+          - name: CH_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: clickhouse-secret
+                key: username
+          - name: CH_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: clickhouse-secret
+                key: password
         ports:
           - containerPort: 4739
         volumeMounts:
@@ -166,3 +176,13 @@ spec:
         hostPath:
           path: /var/log/antrea/flow-aggregator
           type: DirectoryOrCreate
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: clickhouse-secret
+  namespace: flow-aggregator
+type: Opaque
+stringData:
+  username: clickhouse_operator
+  password: clickhouse_operator_password


### PR DESCRIPTION
This change fixes Secret containing Clickhouse credential and
corresponding ENV in flow-aggregator missing due to an overlooked
rebase error. Now the username and password for clickhouse is
correctly created and mounted as part of the manifest.

Signed-off-by: Shawn Wang <wshaoquan@vmware.com>