### PR TITLE
Update generate-manifest-flow-aggregator.sh with new config

### DIFF
--- a/ci/jenkins/README.md
+++ b/ci/jenkins/README.md
@@ -182,6 +182,11 @@ DOCKER_REGISTRY="$(head -n1 ci/docker-registry)"
   daily validation of elk flow collector manifest. If build fails, Jenkins will send an email to
   projectantrea-dev@googlegroups.com for notification.
 
+* [daily-flow-visibility-validate](https://jenkins.antrea-ci.rocks/job/antrea-daily-flow-visibility-validate-for-period/):
+  [![Build Status](http://jenkins.antrea-ci.rocks/buildStatus/icon?job=antrea-daily-flow-visibility-validate-for-period)](http://jenkins.antrea-ci.rocks/view/cloud/job/antrea-daily-flow-visibility-validate-for-period/)
+  daily validation of Flow Visibility manifest. If build fails, Jenkins will send an email to
+  projectantrea-dev@googlegroups.com for notification.
+
 * [matrix-test [weekly]](https://jenkins.antrea-ci.rocks/job/antrea-weekly-matrix-compatibility-test/):
   runs Antrea e2e, K8s Conformance and NetworkPolicy tests, using different combinations of various operating systems and K8s releases.
   |  K8s Version   |  Node OS        |  Status  |

--- a/ci/test-flow-visibility.sh
+++ b/ci/test-flow-visibility.sh
@@ -102,7 +102,7 @@ config_antrea() {
 
 setup_flow_aggregator() {
   echo "=== Config Antrea Flow Aggregator ==="
-  perl -i -p0e 's/      # Enable is the switch to enable exporting flow records to ClickHouse.\n      #enable: false/      # Enable is the switch to enable exporting flow records to ClickHouse.\n      enable: true/' ./build/yamls/flow-aggregator.yml
+  $GIT_CHECKOUT_DIR/hack/generate-manifest-flow-aggregator.sh -ch > ${GIT_CHECKOUT_DIR}/build/yamls/flow-aggregator.yml
   echo "=== Start Antrea Flow Aggregator ==="
   kubectl apply -f ${GIT_CHECKOUT_DIR}/build/yamls/flow-aggregator.yml
   echo "=== Waiting for Antrea Flow Aggregator to be ready ==="


### PR DESCRIPTION
In this commit, we updated the hack/generate-manifest-flow-aggregator.sh
with the new configuration of Flow Aggregator introduced in PR #3196 to 
support both FlowCollector and Clickhouse sink.

Signed-off-by: Yongming Ding <dyongming@vmware.com>