### PR TITLE
Automated cherry pick of #3516: Use uplink MAC as source if packet is output to

### DIFF
--- a/pkg/agent/agent_windows.go
+++ b/pkg/agent/agent_windows.go
@@ -42,6 +42,10 @@ func (i *Initializer) prepareHostNetwork() error {
 		}
 		// Save the uplink adapter name to check if the OVS uplink port has been created in prepareOVSBridge stage.
 		i.nodeConfig.UplinkNetConfig.Name = hnsNetwork.NetworkAdapterName
+
+		// Save the uplink adapter MAC to modify Pod traffic source MAC if the packet is directly output to the uplink
+		// interface in OVS pipeline.
+		i.nodeConfig.UplinkNetConfig.MAC, _ = net.ParseMAC(hnsNetwork.SourceMac)
 		return nil
 	}
 	if _, ok := err.(hcsshim.NetworkNotFoundError); !ok {

--- a/pkg/agent/openflow/pipeline_windows.go
+++ b/pkg/agent/openflow/pipeline_windows.go
@@ -310,7 +310,7 @@ func (c *client) l3FwdFlowToRemoteViaRouting(localGatewayMAC net.HardwareAddr, r
 			Action().GotoTable(conntrackCommitTable).
 			Cookie(c.cookieAllocator.Request(category).Raw()).
 			Done()}
-		flows = append(flows, c.l3FwdFlowToRemoteViaGW(remoteGatewayMAC, *peerPodCIDR, category))
+		flows = append(flows, c.l3FwdFlowToRemoteViaUplink(remoteGatewayMAC, *peerPodCIDR, category))
 		return flows
 	}
 	return []binding.Flow{c.l3FwdFlowToRemoteViaGW(localGatewayMAC, *peerPodCIDR, category)}


### PR DESCRIPTION
Cherry pick of #3516 on release-1.2.

#3516: Use uplink MAC as source if packet is output to

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.