### PR TITLE
Add new target mockgen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -275,6 +275,11 @@ codegen:
 	@echo "===> Updating generated code <==="
 	$(CURDIR)/hack/update-codegen.sh
 
+.PHONY: mockgen
+mockgen:
+	@echo "===> Updating generated mock code <==="
+	$(CURDIR)/hack/update-codegen.sh mockgen
+
 ### Docker images ###
 
 .PHONY: ubuntu

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -29,4 +29,4 @@ function docker_run() {
 		"${IMAGE_NAME}" "$@"
 }
 
-docker_run hack/update-codegen-dockerized.sh
+docker_run hack/update-codegen-dockerized.sh "$@"


### PR DESCRIPTION
Some times, the codes we changed just requires mock code re-generation
but we can only run `make codegen` at this moment to run all auto-gen tools
which is a little time-consuming, so move mockgen related codes out of codegen
with standalone Makefile target, developer can use `make mockgen` to
update mock codes separately.

Signed-off-by: Lan Luo <luola@vmware.com>