### PR TITLE
No need to enable Egress FeatureGate in E2E tests

### DIFF
--- a/test/e2e/egress_test.go
+++ b/test/e2e/egress_test.go
@@ -34,14 +34,20 @@ import (
 
 	"antrea.io/antrea/pkg/agent/config"
 	"antrea.io/antrea/pkg/apis/crd/v1alpha2"
+	"antrea.io/antrea/pkg/features"
 )
 
 const waitEgressRealizedTimeout = 3 * time.Second
+
+func skipIfEgressDisabled(tb testing.TB) {
+	skipIfFeatureDisabled(tb, features.Egress, true, true)
+}
 
 func TestEgress(t *testing.T) {
 	skipIfHasWindowsNodes(t)
 	skipIfNumNodesLessThan(t, 2)
 	skipIfAntreaIPAMTest(t)
+	skipIfEgressDisabled(t)
 
 	data, err := setupTest(t)
 	if err != nil {

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -28,8 +28,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"antrea.io/antrea/pkg/agent/config"
-	agentconfig "antrea.io/antrea/pkg/config/agent"
-	controllerconfig "antrea.io/antrea/pkg/config/controller"
 )
 
 type expectTableFlows struct {
@@ -396,7 +394,9 @@ func TestNodePortAndEgressWithTheSameBackendPod(t *testing.T) {
 	skipIfHasWindowsNodes(t)
 	skipIfNotIPv4Cluster(t)
 	skipIfNumNodesLessThan(t, 2)
+	skipIfAntreaIPAMTest(t)
 	skipIfProxyDisabled(t)
+	skipIfEgressDisabled(t)
 
 	data, err := setupTest(t)
 	if err != nil {
@@ -405,17 +405,6 @@ func TestNodePortAndEgressWithTheSameBackendPod(t *testing.T) {
 	defer teardownTest(t, data)
 	skipIfProxyAllDisabled(t, data)
 	skipIfEncapModeIsNot(t, data, config.TrafficEncapModeEncap) // Egress works for encap mode only.
-
-	cc := func(config *controllerconfig.ControllerConfig) {
-		config.FeatureGates["Egress"] = true
-	}
-	ac := func(config *agentconfig.AgentConfig) {
-		config.FeatureGates["Egress"] = true
-	}
-
-	if err := data.mutateAntreaConfigMap(cc, ac, true, true); err != nil {
-		t.Fatalf("Failed to enable Egress feature: %v", err)
-	}
 
 	// Create a NodePort Service.
 	nodePortIP := controlPlaneNodeIPv4()


### PR DESCRIPTION
Egress feature is enabled by default now.

Signed-off-by: Jianjun Shen <shenj@vmware.com>