### PR TITLE
Ignore additional dependencies in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
     open-pull-requests-limit: 5
     ignore:
     - dependency-name: "k8s.io/*"
+    - dependency-name: "sigs.k8s.io/*"
+    - dependency-name: "github.com/containernetworking/*"
     - dependency-name: "github.com/vmware/go-ipfix"
     - dependency-name: "github.com/TomCodeLV/OVSDB-golang-lib"
     - dependency-name: "github.com/vmware-tanzu/octant"


### PR DESCRIPTION
* sigs.k8s.io/* modules
* github.com/containernetworking/* modules

These are things we want to update manually.

Signed-off-by: Antonin Bas <abas@vmware.com>