### PR TITLE
Remove Endpoint's name during exporting

### DIFF
--- a/multicluster/controllers/multicluster/common/helper.go
+++ b/multicluster/controllers/multicluster/common/helper.go
@@ -73,9 +73,23 @@ func FilterEndpointSubsets(subsets []corev1.EndpointSubset) []corev1.EndpointSub
 		}
 		if len(newAddresses) > 0 {
 			subset.Addresses = newAddresses
-			subset.Ports = s.Ports
+			subset.Ports = RemovePortName(s.Ports)
 			newSubsets = append(newSubsets, subset)
 		}
 	}
 	return newSubsets
+}
+
+// RemovePortName will remove each port's name since Antrea agent will skip reconciling
+// the Service/Endpoint if Service has no name but Endpoint has a name, vice versa.
+func RemovePortName(originalPorts []corev1.EndpointPort) []corev1.EndpointPort {
+	var newPorts []corev1.EndpointPort
+	for _, port := range originalPorts {
+		newPorts = append(newPorts, corev1.EndpointPort{
+			Port:        port.Port,
+			Protocol:    port.Protocol,
+			AppProtocol: port.AppProtocol,
+		})
+	}
+	return newPorts
 }

--- a/multicluster/controllers/multicluster/commonarea/resourceimport_controller_test.go
+++ b/multicluster/controllers/multicluster/commonarea/resourceimport_controller_test.go
@@ -70,7 +70,6 @@ var (
 				Spec: k8smcsapi.ServiceImportSpec{
 					Ports: []k8smcsapi.ServicePort{
 						{
-							Name:     "http",
 							Protocol: corev1.ProtocolTCP,
 							Port:     80,
 						},
@@ -88,7 +87,6 @@ var (
 			},
 			Ports: []corev1.EndpointPort{
 				{
-					Name:     "http",
 					Port:     80,
 					Protocol: corev1.ProtocolTCP,
 				},
@@ -286,7 +284,6 @@ func TestResourceImportReconciler_handleUpdateEvent(t *testing.T) {
 		Spec: k8smcsapi.ServiceImportSpec{
 			Ports: []k8smcsapi.ServicePort{
 				{
-					Name:     "http",
 					Protocol: corev1.ProtocolTCP,
 					Port:     8080,
 				},
@@ -317,7 +314,6 @@ func TestResourceImportReconciler_handleUpdateEvent(t *testing.T) {
 		},
 		Ports: []corev1.EndpointPort{
 			{
-				Name:     "http",
 				Port:     8080,
 				Protocol: corev1.ProtocolTCP,
 			},
@@ -331,7 +327,6 @@ func TestResourceImportReconciler_handleUpdateEvent(t *testing.T) {
 		},
 		Ports: []corev1.EndpointPort{
 			{
-				Name:     "http",
 				Port:     8080,
 				Protocol: corev1.ProtocolTCP,
 			},
@@ -366,7 +361,6 @@ func TestResourceImportReconciler_handleUpdateEvent(t *testing.T) {
 	}
 	newPorts := []k8smcsapi.ServicePort{
 		{
-			Name:     "http",
 			Protocol: corev1.ProtocolTCP,
 			Port:     8080,
 		},
@@ -410,7 +404,6 @@ func TestResourceImportReconciler_handleUpdateEvent(t *testing.T) {
 			resNamespaceName: types.NamespacedName{Namespace: "default", Name: "antrea-mc-nginx"},
 			expectedSvcPorts: []corev1.ServicePort{
 				{
-					Name:     "http",
 					Protocol: corev1.ProtocolTCP,
 					Port:     8080,
 				},

--- a/multicluster/controllers/multicluster/serviceexport_controller_test.go
+++ b/multicluster/controllers/multicluster/serviceexport_controller_test.go
@@ -307,7 +307,7 @@ func TestServiceExportReconciler_handleServiceUpdateEvent(t *testing.T) {
 							IP: "192.168.17.11",
 						},
 					},
-					Ports: epPorts8080,
+					Ports: common.RemovePortName(epPorts8080),
 				},
 			}
 			if !reflect.DeepEqual(subsets, expectedSubsets) {


### PR DESCRIPTION
Antrea agent will skip reconciling the Service/Endpoint if Service has
no name but Endpoint has a name, vice versa. so need to remove
Endpoint's name during exporting since the imported antrea Multi-cluster
Service's port has no name.

Signed-off-by: Lan Luo <luola@vmware.com>