### PR TITLE
Fix NetworkPolicyOnly mode issue

### DIFF
--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -1272,8 +1272,7 @@ func (f *featurePodConnectivity) l3FwdFlowToPod(localGatewayMAC net.HardwareAddr
 }
 
 // l3FwdFlowRouteToPod generates the flows to match the packets destined for a Pod based on the destination IPs. It rewrites
-// destination MAC to the Pod interface's MAC. The flows are used in networkPolicyOnly mode to match the packets from the
-// Antrea gateway.
+// destination MAC to the Pod interface's MAC. The flows are only used in networkPolicyOnly mode.
 func (f *featurePodConnectivity) l3FwdFlowRouteToPod(podInterfaceIPs []net.IP, podInterfaceMAC net.HardwareAddr) []binding.Flow {
 	cookieID := f.cookieAllocator.Request(f.category).Raw()
 	var flows []binding.Flow
@@ -1284,7 +1283,7 @@ func (f *featurePodConnectivity) l3FwdFlowRouteToPod(podInterfaceIPs []net.IP, p
 			MatchProtocol(ipProtocol).
 			MatchDstIP(ip).
 			Action().SetDstMAC(podInterfaceMAC).
-			Action().NextTable().
+			Action().GotoTable(L3DecTTLTable.GetID()).
 			Done())
 	}
 	return flows
@@ -1302,7 +1301,7 @@ func (f *featurePodConnectivity) l3FwdFlowRouteToGW() []binding.Flow {
 			MatchProtocol(ipProtocol).
 			Action().SetDstMAC(f.nodeConfig.GatewayConfig.MAC).
 			Action().LoadRegMark(ToGatewayRegMark).
-			Action().NextTable().
+			Action().GotoTable(L3DecTTLTable.GetID()).
 			Done(),
 		)
 	}

--- a/pkg/agent/openflow/pod_connectivity.go
+++ b/pkg/agent/openflow/pod_connectivity.go
@@ -63,13 +63,17 @@ func newFeaturePodConnectivity(
 		if ipProtocol == binding.ProtocolIP {
 			ctZones[ipProtocol] = CtZone
 			gatewayIPs[ipProtocol] = nodeConfig.GatewayConfig.IPv4
-			localCIDRs[ipProtocol] = *nodeConfig.PodIPv4CIDR
 			nodeIPs[ipProtocol] = nodeConfig.NodeIPv4Addr.IP
+			if nodeConfig.PodIPv4CIDR != nil {
+				localCIDRs[ipProtocol] = *nodeConfig.PodIPv4CIDR
+			}
 		} else if ipProtocol == binding.ProtocolIPv6 {
 			ctZones[ipProtocol] = CtZoneV6
 			gatewayIPs[ipProtocol] = nodeConfig.GatewayConfig.IPv6
-			localCIDRs[ipProtocol] = *nodeConfig.PodIPv6CIDR
 			nodeIPs[ipProtocol] = nodeConfig.NodeIPv6Addr.IP
+			if nodeConfig.PodIPv6CIDR != nil {
+				localCIDRs[ipProtocol] = *nodeConfig.PodIPv6CIDR
+			}
 		}
 	}
 
@@ -104,7 +108,6 @@ func (f *featurePodConnectivity) initFlows() []binding.Flow {
 			}
 		}
 	}
-	flows = append(flows, f.l3FwdFlowToLocalPodCIDR()...)
 	if f.connectUplinkToBridge {
 		flows = append(flows, f.l3FwdFlowToNode()...)
 	}
@@ -117,6 +120,11 @@ func (f *featurePodConnectivity) initFlows() []binding.Flow {
 		// If IPv6 is enabled, this flow will never get hit.
 		// Replies any ARP request with the same global virtual MAC.
 		flows = append(flows, f.arpResponderStaticFlow())
+	} else {
+		// If NetworkPolicyOnly mode is enabled, IPAM is implemented by the primary CNI, which may not use the Pod CIDR
+		// of the Node. Therefore, it doesn't make sense to install flows for the Pod CIDR. Individual flow for each local
+		// Pod IP will take care of routing the traffic to destination Pod.
+		flows = append(flows, f.l3FwdFlowToLocalPodCIDR()...)
 	}
 	return flows
 }


### PR DESCRIPTION
When NetworkPolicyOnly mode is enabled, PodIPv4CIDR of nodeConfig is nil,
then l3FwdFlowToLocalPodCIDR should not be called.

Signed-off-by: Hongliang Liu <lhongliang@vmware.com>