### PR TITLE
[ExternalNode] Add feature gate to run Agent on a non-Kubernetes Node

### DIFF
--- a/build/yamls/externalnode/conf/antrea-agent.conf
+++ b/build/yamls/externalnode/conf/antrea-agent.conf
@@ -1,0 +1,43 @@
+# FeatureGates is a map of feature names to bools that enable or disable experimental features.
+featureGates:
+# Enable running agent on an unmanaged VM/BM.
+  ExternalNode: true
+
+# Enable Antrea ClusterNetworkPolicy feature to complement K8s NetworkPolicy for cluster admins
+# to define security policies which apply to the entire cluster, and Antrea NetworkPolicy
+# feature that supports priorities, rule actions and externalEntities in the future.
+  AntreaPolicy: true
+
+# Enable collecting and exposing NetworkPolicy statistics.
+  NetworkPolicyStats: true
+
+# Name of the OpenVSwitch bridge antrea-agent will create and use.
+# Make sure it doesn't conflict with your existing OpenVSwitch bridges.
+#ovsBridge: br-int
+
+# Datapath type to use for the OpenVSwitch bridge created by Antrea. Supported values are:
+# - system
+# - netdev
+# 'system' is the default value and corresponds to the kernel datapath. Use 'netdev' to run
+# OVS in userspace mode (not fully supported yet). Userspace mode requires the tun device driver to
+# be available.
+#ovsDatapathType: system
+
+# The port for the antrea-agent APIServer to serve on.
+# Note that if it's set to another value, the `containerPort` of the `api` port of the
+# `antrea-agent` container must be set to the same value.
+#apiPort: 10350
+
+# NodeType is type of the Node where Antrea Agent is running.
+# Defaults to "k8sNode". Valid values include "k8sNode", and "externalNode".
+nodeType: externalNode
+
+# The path to access the kubeconfig file used in the connection to K8s APIServer. The file contains the K8s
+# APIServer endpoint and the token of ServiceAccount required in the connection.
+clientConnection:
+  kubeconfig: antrea-agent.kubeconfig
+
+# The path to access the kubeconfig file used in the connection to Antrea Controller. The file contains the
+# antrea-controller APIServer endpoint and the token of ServiceAccount required in the connection.
+antreaClientConnection:
+  kubeconfig: antrea-agent.antrea.kubeconfig

--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -79,6 +79,8 @@ const resyncPeriodDisabled = 0 * time.Minute
 // The devices that should be excluded from NodePort.
 var excludeNodePortDevices = []string{"antrea-egress0", "antrea-ingress0", "kube-ipvs0"}
 
+var ipv4Localhost = net.ParseIP("127.0.0.1")
+
 // run starts Antrea agent with the given options and waits for termination signal.
 func run(o *Options) error {
 	klog.Infof("Starting Antrea agent (version %s)", version.GetFullVersion())
@@ -133,7 +135,10 @@ func run(o *Options) error {
 		connectUplinkToBridge,
 		features.DefaultFeatureGate.Enabled(features.Multicast))
 
-	_, serviceCIDRNet, _ := net.ParseCIDR(o.config.ServiceCIDR)
+	var serviceCIDRNet *net.IPNet
+	if o.nodeType == config.K8sNode {
+		_, serviceCIDRNet, _ = net.ParseCIDR(o.config.ServiceCIDR)
+	}
 	var serviceCIDRNetv6 *net.IPNet
 	// Todo: use FeatureGate to check if IPv6 is enabled and then read configuration item "ServiceCIDRv6".
 	if o.config.ServiceCIDRv6 != "" {
@@ -212,6 +217,7 @@ func run(o *Options) error {
 		serviceConfig,
 		networkReadyCh,
 		stopCh,
+		o.nodeType,
 		features.DefaultFeatureGate.Enabled(features.AntreaProxy),
 		o.config.AntreaProxy.ProxyAll,
 		connectUplinkToBridge)
@@ -221,17 +227,20 @@ func run(o *Options) error {
 	}
 	nodeConfig := agentInitializer.GetNodeConfig()
 
-	nodeRouteController := noderoute.NewNodeRouteController(
-		k8sClient,
-		informerFactory,
-		ofClient,
-		ovsBridgeClient,
-		routeClient,
-		ifaceStore,
-		networkConfig,
-		nodeConfig,
-		agentInitializer.GetWireGuardClient(),
-		o.config.AntreaProxy.ProxyAll)
+	var nodeRouteController *noderoute.Controller
+	if o.nodeType == config.K8sNode {
+		nodeRouteController = noderoute.NewNodeRouteController(
+			k8sClient,
+			informerFactory,
+			ofClient,
+			ovsBridgeClient,
+			routeClient,
+			ifaceStore,
+			networkConfig,
+			nodeConfig,
+			agentInitializer.GetWireGuardClient(),
+			o.config.AntreaProxy.ProxyAll)
+	}
 
 	var groupCounters []proxytypes.GroupCounter
 	groupIDUpdates := make(chan string, 100)
@@ -354,32 +363,35 @@ func run(o *Options) error {
 		}
 	}
 
-	isChaining := false
-	if networkConfig.TrafficEncapMode.IsNetworkPolicyOnly() {
-		isChaining = true
-	}
-	cniServer := cniserver.New(
-		o.config.CNISocket,
-		o.config.HostProcPathPrefix,
-		nodeConfig,
-		k8sClient,
-		routeClient,
-		isChaining,
-		enableBridgingMode,
-		enableAntreaIPAM,
-		networkReadyCh)
-
+	var cniServer *cniserver.CNIServer
 	var cniPodInfoStore cnipodcache.CNIPodInfoStore
-	if features.DefaultFeatureGate.Enabled(features.SecondaryNetwork) {
-		cniPodInfoStore = cnipodcache.NewCNIPodInfoStore()
-		err = cniServer.Initialize(ovsBridgeClient, ofClient, ifaceStore, podUpdateChannel, cniPodInfoStore)
-		if err != nil {
-			return fmt.Errorf("error initializing CNI server with cniPodInfoStore cache: %v", err)
+	if o.nodeType == config.K8sNode {
+		isChaining := false
+		if networkConfig.TrafficEncapMode.IsNetworkPolicyOnly() {
+			isChaining = true
 		}
-	} else {
-		err = cniServer.Initialize(ovsBridgeClient, ofClient, ifaceStore, podUpdateChannel, nil)
-		if err != nil {
-			return fmt.Errorf("error initializing CNI server: %v", err)
+		cniServer = cniserver.New(
+			o.config.CNISocket,
+			o.config.HostProcPathPrefix,
+			nodeConfig,
+			k8sClient,
+			routeClient,
+			isChaining,
+			enableBridgingMode,
+			enableAntreaIPAM,
+			networkReadyCh)
+
+		if features.DefaultFeatureGate.Enabled(features.SecondaryNetwork) {
+			cniPodInfoStore = cnipodcache.NewCNIPodInfoStore()
+			err = cniServer.Initialize(ovsBridgeClient, ofClient, ifaceStore, podUpdateChannel, cniPodInfoStore)
+			if err != nil {
+				return fmt.Errorf("error initializing CNI server with cniPodInfoStore cache: %v", err)
+			}
+		} else {
+			err = cniServer.Initialize(ovsBridgeClient, ofClient, ifaceStore, podUpdateChannel, nil)
+			if err != nil {
+				return fmt.Errorf("error initializing CNI server: %v", err)
+			}
 		}
 	}
 
@@ -468,15 +480,14 @@ func run(o *Options) error {
 
 	log.StartLogFileNumberMonitor(stopCh)
 
-	go podUpdateChannel.Run(stopCh)
-
-	go routeClient.Run(stopCh)
-
-	go cniServer.Run(stopCh)
+	if o.nodeType == config.K8sNode {
+		go routeClient.Run(stopCh)
+		go podUpdateChannel.Run(stopCh)
+		go cniServer.Run(stopCh)
+		go nodeRouteController.Run(stopCh)
+	}
 
 	go antreaClientProvider.Run(stopCh)
-
-	go nodeRouteController.Run(stopCh)
 
 	go networkPolicyController.Run(stopCh)
 
@@ -607,9 +618,14 @@ func run(o *Options) error {
 	if err != nil {
 		return fmt.Errorf("error generating Cipher Suite list: %v", err)
 	}
+	bindAddress := net.IPv4zero
+	if o.nodeType == config.ExternalNode {
+		bindAddress = ipv4Localhost
+	}
 	apiServer, err := apiserver.New(
 		agentQuerier,
 		networkPolicyController,
+		bindAddress,
 		o.config.APIPort,
 		*o.config.EnablePrometheusMetrics,
 		o.config.ClientConnection.Kubeconfig,

--- a/cmd/antrea-agent/options.go
+++ b/cmd/antrea-agent/options.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/spf13/pflag"
 	"gopkg.in/yaml.v2"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/klog/v2"
 
 	"antrea.io/antrea/pkg/agent/config"
@@ -49,6 +50,7 @@ const (
 	defaultIdleFlowExportTimeout   = 15 * time.Second
 	defaultStaleConnectionTimeout  = 5 * time.Minute
 	defaultNPLPortRange            = "61000-62000"
+	defaultNodeType                = config.K8sNode
 )
 
 type Options struct {
@@ -70,6 +72,7 @@ type Options struct {
 	staleConnectionTimeout time.Duration
 	nplStartPort           int
 	nplEndPort             int
+	nodeType               config.NodeType
 }
 
 func newOptions() *Options {
@@ -95,6 +98,11 @@ func (o *Options) complete(args []string) error {
 		return err
 	}
 	o.setDefaults()
+	if o.config.NodeType == config.ExternalNode.String() {
+		if err := o.resetVMDefaultFeatures(); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -104,85 +112,24 @@ func (o *Options) validate(args []string) error {
 		return fmt.Errorf("no positional arguments are supported")
 	}
 
-	if o.config.TunnelType != ovsconfig.VXLANTunnel && o.config.TunnelType != ovsconfig.GeneveTunnel &&
-		o.config.TunnelType != ovsconfig.GRETunnel && o.config.TunnelType != ovsconfig.STTTunnel {
-		return fmt.Errorf("tunnel type %s is invalid", o.config.TunnelType)
-	}
-	ok, encryptionMode := config.GetTrafficEncryptionModeFromStr(o.config.TrafficEncryptionMode)
-	if !ok {
-		return fmt.Errorf("TrafficEncryptionMode %s is unknown", o.config.TrafficEncryptionMode)
-	}
 	if o.config.OVSDatapathType != string(ovsconfig.OVSDatapathSystem) && o.config.OVSDatapathType != string(ovsconfig.OVSDatapathNetdev) {
 		return fmt.Errorf("OVS datapath type %s is not supported", o.config.OVSDatapathType)
 	}
 	if o.config.OVSDatapathType == string(ovsconfig.OVSDatapathNetdev) {
 		klog.Info("OVS 'netdev' datapath is not fully supported at the moment")
 	}
-	ok, encapMode := config.GetTrafficEncapModeFromStr(o.config.TrafficEncapMode)
-	if !ok {
-		return fmt.Errorf("TrafficEncapMode %s is unknown", o.config.TrafficEncapMode)
+	if config.ExternalNode.String() == o.config.NodeType && !features.DefaultFeatureGate.Enabled(features.ExternalNode) {
+		return fmt.Errorf("nodeType %s requires feature gate ExternalNode to be enabled", o.config.NodeType)
 	}
-
-	// Check if the enabled features are supported on the OS.
-	if err := o.checkUnsupportedFeatures(); err != nil {
-		return err
+	if o.config.NodeType == config.ExternalNode.String() {
+		o.nodeType = config.ExternalNode
+		return o.validateExternalNodeOptions()
+	} else if o.config.NodeType == config.K8sNode.String() {
+		o.nodeType = config.K8sNode
+		return o.validateK8sNodeOptions()
+	} else {
+		return fmt.Errorf("unsupported nodeType %s", o.config.NodeType)
 	}
-
-	if encapMode.SupportsNoEncap() {
-		// When using NoEncap traffic mode without AntreaProxy, Pod-to-Service traffic is handled by kube-proxy
-		// (iptables/ipvs) in the root netns. If the Endpoint is not local the DNATed traffic will be output to
-		// the physical network directly without going back to OVS for Egress NetworkPolicy enforcement, which
-		// breaks basic security functionality. Therefore, we usually do not allow the NoEncap traffic mode without
-		// AntreaProxy. But one can bypass this check and force this feature combination to be allowed, by defining
-		// the ALLOW_NO_ENCAP_WITHOUT_ANTREA_PROXY environment variable and setting it to true. This may lead to
-		// better performance when using NoEncap if Egress NetworkPolicy enforcement is not required.
-		if !features.DefaultFeatureGate.Enabled(features.AntreaProxy) {
-			if env.GetAllowNoEncapWithoutAntreaProxy() {
-				klog.InfoS("Disabling AntreaProxy in NoEncap mode will prevent Egress NetworkPolicy rules from being enforced correctly")
-			} else {
-				return fmt.Errorf("TrafficEncapMode %s requires AntreaProxy to be enabled", o.config.TrafficEncapMode)
-			}
-		}
-		if encryptionMode != config.TrafficEncryptionModeNone {
-			return fmt.Errorf("TrafficEncryptionMode %s may only be enabled in %s mode", encryptionMode, config.TrafficEncapModeEncap)
-		}
-	}
-	if o.config.NoSNAT && !(encapMode == config.TrafficEncapModeNoEncap || encapMode == config.TrafficEncapModeNetworkPolicyOnly) {
-		return fmt.Errorf("noSNAT is only applicable to the %s mode", config.TrafficEncapModeNoEncap)
-	}
-	if encapMode == config.TrafficEncapModeNetworkPolicyOnly {
-		// In the NetworkPolicyOnly mode, Antrea will not perform SNAT
-		// (but SNAT can be done by the primary CNI).
-		o.config.NoSNAT = true
-	}
-	if err := o.validateAntreaProxyConfig(); err != nil {
-		return fmt.Errorf("proxy config is invalid: %w", err)
-	}
-	if err := o.validateFlowExporterConfig(); err != nil {
-		return fmt.Errorf("failed to validate flow exporter config: %v", err)
-	}
-	if features.DefaultFeatureGate.Enabled(features.Egress) {
-		for _, cidr := range o.config.Egress.ExceptCIDRs {
-			_, _, err := net.ParseCIDR(cidr)
-			if err != nil {
-				return fmt.Errorf("Egress Except CIDR %s is invalid", cidr)
-			}
-		}
-	}
-	if features.DefaultFeatureGate.Enabled(features.NodePortLocal) {
-		startPort, endPort, err := parsePortRange(o.config.NodePortLocal.PortRange)
-		if err != nil {
-			return fmt.Errorf("NodePortLocal portRange is not valid: %v", err)
-		}
-		o.nplStartPort = startPort
-		o.nplEndPort = endPort
-	} else if o.config.NodePortLocal.Enable {
-		klog.InfoS("The nodePortLocal.enable config option is set to true, but it will be ignored because the NodePortLocal feature gate is disabled")
-	}
-	if err := o.validateAntreaIPAMConfig(); err != nil {
-		return fmt.Errorf("failed to validate AntreaIPAM config: %v", err)
-	}
-	return nil
 }
 
 func (o *Options) loadConfigFromFile() error {
@@ -195,9 +142,6 @@ func (o *Options) loadConfigFromFile() error {
 }
 
 func (o *Options) setDefaults() {
-	if o.config.CNISocket == "" {
-		o.config.CNISocket = cni.AntreaCNISocketAddr
-	}
 	if o.config.OVSBridge == "" {
 		o.config.OVSBridge = defaultOVSBridge
 	}
@@ -207,69 +151,16 @@ func (o *Options) setDefaults() {
 	if o.config.OVSRunDir == "" {
 		o.config.OVSRunDir = ovsconfig.DefaultOVSRunDir
 	}
-	if o.config.HostGateway == "" {
-		o.config.HostGateway = defaultHostGateway
-	}
-	if o.config.TrafficEncapMode == "" {
-		o.config.TrafficEncapMode = config.TrafficEncapModeEncap.String()
-	}
-	if o.config.TrafficEncryptionMode == "" {
-		o.config.TrafficEncryptionMode = config.TrafficEncryptionModeNone.String()
-	}
-	if o.config.TunnelType == "" {
-		o.config.TunnelType = defaultTunnelType
-	}
-	if o.config.HostProcPathPrefix == "" {
-		o.config.HostProcPathPrefix = defaultHostProcPathPrefix
-	}
-	if features.DefaultFeatureGate.Enabled(features.AntreaProxy) {
-		if o.config.AntreaProxy.ProxyLoadBalancerIPs == nil {
-			o.config.AntreaProxy.ProxyLoadBalancerIPs = new(bool)
-			*o.config.AntreaProxy.ProxyLoadBalancerIPs = true
-		}
-	} else {
-		if o.config.ServiceCIDR == "" {
-			o.config.ServiceCIDR = defaultServiceCIDR
-		}
-	}
 	if o.config.APIPort == 0 {
 		o.config.APIPort = apis.AntreaAgentAPIPort
 	}
-	if o.config.ClusterMembershipPort == 0 {
-		o.config.ClusterMembershipPort = apis.AntreaAgentClusterMembershipPort
+	if o.config.NodeType == "" {
+		o.config.NodeType = defaultNodeType.String()
 	}
-	if o.config.EnablePrometheusMetrics == nil {
-		o.config.EnablePrometheusMetrics = new(bool)
-		*o.config.EnablePrometheusMetrics = true
-	}
-	if o.config.WireGuard.Port == 0 {
-		o.config.WireGuard.Port = apis.WireGuardListenPort
-	}
-
-	if features.DefaultFeatureGate.Enabled(features.FlowExporter) {
-		if o.config.FlowCollectorAddr == "" {
-			o.config.FlowCollectorAddr = defaultFlowCollectorAddress
-		}
-		if o.config.FlowPollInterval == "" {
-			o.pollInterval = defaultFlowPollInterval
-		}
-		if o.config.ActiveFlowExportTimeout == "" {
-			o.activeFlowTimeout = defaultActiveFlowExportTimeout
-		}
-		if o.config.IdleFlowExportTimeout == "" {
-			o.idleFlowTimeout = defaultIdleFlowExportTimeout
-		}
-	}
-
-	if features.DefaultFeatureGate.Enabled(features.NodePortLocal) {
-		switch {
-		case o.config.NodePortLocal.PortRange != "":
-		case o.config.NPLPortRange != "":
-			klog.InfoS("The nplPortRange option is deprecated, please use nodePortLocal.portRange instead")
-			o.config.NodePortLocal.PortRange = o.config.NPLPortRange
-		default:
-			o.config.NodePortLocal.PortRange = defaultNPLPortRange
-		}
+	if o.config.NodeType == config.K8sNode.String() {
+		o.setK8sNodeDefaultOptions()
+	} else {
+		o.setExternalNodeDefaultOptions()
 	}
 }
 
@@ -373,4 +264,192 @@ func (o *Options) validateAntreaIPAMConfig() error {
 		return fmt.Errorf("Bridging mode requires noSNAT")
 	}
 	return nil
+}
+
+func (o *Options) setK8sNodeDefaultOptions() {
+	if o.config.CNISocket == "" {
+		o.config.CNISocket = cni.AntreaCNISocketAddr
+	}
+	if o.config.HostGateway == "" {
+		o.config.HostGateway = defaultHostGateway
+	}
+	if o.config.TrafficEncapMode == "" {
+		o.config.TrafficEncapMode = config.TrafficEncapModeEncap.String()
+	}
+	if o.config.TrafficEncryptionMode == "" {
+		o.config.TrafficEncryptionMode = config.TrafficEncryptionModeNone.String()
+	}
+	if o.config.TunnelType == "" {
+		o.config.TunnelType = defaultTunnelType
+	}
+	if o.config.HostProcPathPrefix == "" {
+		o.config.HostProcPathPrefix = defaultHostProcPathPrefix
+	}
+	if features.DefaultFeatureGate.Enabled(features.AntreaProxy) {
+		if o.config.AntreaProxy.ProxyLoadBalancerIPs == nil {
+			o.config.AntreaProxy.ProxyLoadBalancerIPs = new(bool)
+			*o.config.AntreaProxy.ProxyLoadBalancerIPs = true
+		}
+	} else {
+		if o.config.ServiceCIDR == "" {
+			o.config.ServiceCIDR = defaultServiceCIDR
+		}
+	}
+	if o.config.ClusterMembershipPort == 0 {
+		o.config.ClusterMembershipPort = apis.AntreaAgentClusterMembershipPort
+	}
+	if o.config.EnablePrometheusMetrics == nil {
+		o.config.EnablePrometheusMetrics = new(bool)
+		*o.config.EnablePrometheusMetrics = true
+	}
+	if o.config.WireGuard.Port == 0 {
+		o.config.WireGuard.Port = apis.WireGuardListenPort
+	}
+
+	if features.DefaultFeatureGate.Enabled(features.FlowExporter) {
+		if o.config.FlowCollectorAddr == "" {
+			o.config.FlowCollectorAddr = defaultFlowCollectorAddress
+		}
+		if o.config.FlowPollInterval == "" {
+			o.pollInterval = defaultFlowPollInterval
+		}
+		if o.config.ActiveFlowExportTimeout == "" {
+			o.activeFlowTimeout = defaultActiveFlowExportTimeout
+		}
+		if o.config.IdleFlowExportTimeout == "" {
+			o.idleFlowTimeout = defaultIdleFlowExportTimeout
+		}
+	}
+
+	if features.DefaultFeatureGate.Enabled(features.NodePortLocal) {
+		switch {
+		case o.config.NodePortLocal.PortRange != "":
+		case o.config.NPLPortRange != "":
+			klog.InfoS("The nplPortRange option is deprecated, please use nodePortLocal.portRange instead")
+			o.config.NodePortLocal.PortRange = o.config.NPLPortRange
+		default:
+			o.config.NodePortLocal.PortRange = defaultNPLPortRange
+		}
+	}
+}
+
+func (o *Options) validateK8sNodeOptions() error {
+	if o.config.TunnelType != ovsconfig.VXLANTunnel && o.config.TunnelType != ovsconfig.GeneveTunnel &&
+		o.config.TunnelType != ovsconfig.GRETunnel && o.config.TunnelType != ovsconfig.STTTunnel {
+		return fmt.Errorf("tunnel type %s is invalid", o.config.TunnelType)
+	}
+	ok, encryptionMode := config.GetTrafficEncryptionModeFromStr(o.config.TrafficEncryptionMode)
+	if !ok {
+		return fmt.Errorf("TrafficEncryptionMode %s is unknown", o.config.TrafficEncryptionMode)
+	}
+	ok, encapMode := config.GetTrafficEncapModeFromStr(o.config.TrafficEncapMode)
+	if !ok {
+		return fmt.Errorf("TrafficEncapMode %s is unknown", o.config.TrafficEncapMode)
+	}
+
+	// Check if the enabled features are supported on the OS.
+	if err := o.checkUnsupportedFeatures(); err != nil {
+		return err
+	}
+
+	if encapMode.SupportsNoEncap() {
+		// When using NoEncap traffic mode without AntreaProxy, Pod-to-Service traffic is handled by kube-proxy
+		// (iptables/ipvs) in the root netns. If the Endpoint is not local the DNATed traffic will be output to
+		// the physical network directly without going back to OVS for Egress NetworkPolicy enforcement, which
+		// breaks basic security functionality. Therefore, we usually do not allow the NoEncap traffic mode without
+		// AntreaProxy. But one can bypass this check and force this feature combination to be allowed, by defining
+		// the ALLOW_NO_ENCAP_WITHOUT_ANTREA_PROXY environment variable and setting it to true. This may lead to
+		// better performance when using NoEncap if Egress NetworkPolicy enforcement is not required.
+		if !features.DefaultFeatureGate.Enabled(features.AntreaProxy) {
+			if env.GetAllowNoEncapWithoutAntreaProxy() {
+				klog.InfoS("Disabling AntreaProxy in NoEncap mode will prevent Egress NetworkPolicy rules from being enforced correctly")
+			} else {
+				return fmt.Errorf("TrafficEncapMode %s requires AntreaProxy to be enabled", o.config.TrafficEncapMode)
+			}
+		}
+		if encryptionMode != config.TrafficEncryptionModeNone {
+			return fmt.Errorf("TrafficEncryptionMode %s may only be enabled in %s mode", encryptionMode, config.TrafficEncapModeEncap)
+		}
+	}
+	if o.config.NoSNAT && !(encapMode == config.TrafficEncapModeNoEncap || encapMode == config.TrafficEncapModeNetworkPolicyOnly) {
+		return fmt.Errorf("noSNAT is only applicable to the %s mode", config.TrafficEncapModeNoEncap)
+	}
+	if encapMode == config.TrafficEncapModeNetworkPolicyOnly {
+		// In the NetworkPolicyOnly mode, Antrea will not perform SNAT
+		// (but SNAT can be done by the primary CNI).
+		o.config.NoSNAT = true
+	}
+	if err := o.validateAntreaProxyConfig(); err != nil {
+		return fmt.Errorf("proxy config is invalid: %w", err)
+	}
+	if err := o.validateFlowExporterConfig(); err != nil {
+		return fmt.Errorf("failed to validate flow exporter config: %v", err)
+	}
+	if features.DefaultFeatureGate.Enabled(features.Egress) {
+		for _, cidr := range o.config.Egress.ExceptCIDRs {
+			_, _, err := net.ParseCIDR(cidr)
+			if err != nil {
+				return fmt.Errorf("Egress Except CIDR %s is invalid", cidr)
+			}
+		}
+	}
+	if features.DefaultFeatureGate.Enabled(features.NodePortLocal) {
+		startPort, endPort, err := parsePortRange(o.config.NodePortLocal.PortRange)
+		if err != nil {
+			return fmt.Errorf("NodePortLocal portRange is not valid: %v", err)
+		}
+		o.nplStartPort = startPort
+		o.nplEndPort = endPort
+	} else if o.config.NodePortLocal.Enable {
+		klog.InfoS("The nodePortLocal.enable config option is set to true, but it will be ignored because the NodePortLocal feature gate is disabled")
+	}
+	if err := o.validateAntreaIPAMConfig(); err != nil {
+		return fmt.Errorf("failed to validate AntreaIPAM config: %v", err)
+	}
+	return nil
+}
+
+// resetVMDefaultFeatures sets the feature's default enablement status as false if it is not supported on a VM or a BM.
+func (o *Options) resetVMDefaultFeatures() error {
+	disabledFeatureMap := make(map[string]bool)
+	for f, s := range features.DefaultAntreaFeatureGates {
+		if s.Default && !features.SupportedOnExternalNode(f) {
+			disabledFeatureMap[string(f)] = false
+		}
+	}
+	return features.DefaultMutableFeatureGate.SetFromMap(disabledFeatureMap)
+}
+
+func (o *Options) validateExternalNodeOptions() error {
+	var unsupported []string
+	for f, enabled := range o.config.FeatureGates {
+		if enabled && !features.SupportedOnExternalNode(featuregate.Feature(f)) {
+			unsupported = append(unsupported, f)
+		}
+	}
+	if o.config.TrafficEncapMode != config.TrafficEncapModeNoEncap.String() {
+		unsupported = append(unsupported, o.config.TrafficEncapMode)
+	}
+	if o.config.NodePortLocal.Enable {
+		unsupported = append(unsupported, "NodePortLocal")
+	}
+	if o.config.EnableIPSecTunnel {
+		unsupported = append(unsupported, "EnableIPSecTunnel")
+	}
+	if unsupported != nil {
+		return fmt.Errorf("unsupported features on Virtual Machine: {%s}", strings.Join(unsupported, ", "))
+	}
+	return nil
+}
+
+func (o *Options) setExternalNodeDefaultOptions() {
+	// Following options are default values for agent running on a Virtual Machine.
+	// They are set to avoid unexpected agent crash.
+	if o.config.TrafficEncapMode == "" {
+		o.config.TrafficEncapMode = config.TrafficEncapModeNoEncap.String()
+	}
+	if o.config.EnablePrometheusMetrics == nil {
+		o.config.EnablePrometheusMetrics = new(bool)
+		*o.config.EnablePrometheusMetrics = false
+	}
 }

--- a/docs/feature-gates.md
+++ b/docs/feature-gates.md
@@ -48,6 +48,7 @@ example, to enable `AntreaProxy` on Linux, edit the Agent configuration in the
 | `Multicast`             | Agent              | `false` | Alpha | v1.5          | N/A          | N/A        | Yes                |       |
 | `SecondaryNetwork`      | Agent              | `false` | Alpha | v1.5          | N/A          | N/A        | Yes                |       |
 | `ServiceExternalIP`     | Agent + Controller | `false` | Alpha | v1.5          | N/A          | N/A        | Yes                |       |
+| `ExternalNode`          | Agent              | `false` | Alpha | v1.7          | N/A          | N/A        | Yes                |       |
 
 ## Description and Requirements of Features
 
@@ -320,3 +321,19 @@ Refer to this [document](service-loadbalancer.md) for more information.
 #### Requirements for this Feature
 
 This feature is currently only supported for Nodes running Linux.
+
+### ExternalNode
+
+The `ExternalNode` feature enables Antrea Agent runs on a virtual machine or a bare-metal server which is not a
+Kubernetes Node, and enforces Antrea NetworkPolicy for the VM/BM. Antrea Agent supports the `ExternalNode` feature on
+both Linux and Windows.
+
+More documentation will be coming in the future.
+
+#### Requirements for this Feature
+
+Since Antrea Agent is running on an unmanaged VM/BM when this feature is enabled, features designed for K8s Pods are
+disabled. As of now, this feature requires that `AntreaProxy` and `NetworkPolicyStats` are also enabled.
+
+OVS is required to be installed on the virtual machine or the bare-metal server before running Antrea Agent, and the OVS
+version must be >= 2.13.0 and <= 2.15.1.

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -97,6 +97,7 @@ type Initializer struct {
 	proxyAll       bool
 	networkReadyCh chan<- struct{}
 	stopCh         <-chan struct{}
+	nodeType       config.NodeType
 }
 
 func NewInitializer(
@@ -114,6 +115,7 @@ func NewInitializer(
 	serviceConfig *config.ServiceConfig,
 	networkReadyCh chan<- struct{},
 	stopCh <-chan struct{},
+	nodeType config.NodeType,
 	enableProxy bool,
 	proxyAll bool,
 	connectUplinkToBridge bool,
@@ -133,6 +135,7 @@ func NewInitializer(
 		serviceConfig:         serviceConfig,
 		networkReadyCh:        networkReadyCh,
 		stopCh:                stopCh,
+		nodeType:              nodeType,
 		enableProxy:           enableProxy,
 		proxyAll:              proxyAll,
 		connectUplinkToBridge: connectUplinkToBridge,
@@ -169,13 +172,15 @@ func (i *Initializer) setupOVSBridge() error {
 		return err
 	}
 
-	if err := i.setupDefaultTunnelInterface(); err != nil {
-		return err
-	}
-	// Set up host gateway interface
-	err := i.setupGatewayInterface()
-	if err != nil {
-		return err
+	if i.nodeType == config.K8sNode {
+		if err := i.setupDefaultTunnelInterface(); err != nil {
+			return err
+		}
+		// Set up host gateway interface
+		err := i.setupGatewayInterface()
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -336,9 +341,6 @@ func (i *Initializer) Initialize() error {
 		return err
 	}
 
-	i.networkConfig.IPv4Enabled = config.IsIPv4Enabled(i.nodeConfig, i.networkConfig.TrafficEncapMode)
-	i.networkConfig.IPv6Enabled = config.IsIPv6Enabled(i.nodeConfig, i.networkConfig.TrafficEncapMode)
-
 	if err := i.prepareHostNetwork(); err != nil {
 		return err
 	}
@@ -359,23 +361,30 @@ func (i *Initializer) Initialize() error {
 		}
 	}
 
-	wg.Add(1)
-	// routeClient.Initialize() should be after i.setupOVSBridge() which
-	// creates the host gateway interface.
-	if err := i.routeClient.Initialize(i.nodeConfig, wg.Done); err != nil {
-		return err
-	}
+	if i.nodeType == config.K8sNode {
+		wg.Add(1)
+		// routeClient.Initialize() should be after i.setupOVSBridge() which
+		// creates the host gateway interface.
+		if err := i.routeClient.Initialize(i.nodeConfig, wg.Done); err != nil {
+			return err
+		}
 
-	// Install OpenFlow entries on OVS bridge.
-	if err := i.initOpenFlowPipeline(); err != nil {
-		return err
-	}
+		// Install OpenFlow entries on OVS bridge.
+		if err := i.initOpenFlowPipeline(); err != nil {
+			return err
+		}
 
-	// The Node's network is ready only when both synchronous and asynchronous initialization are done.
-	go func() {
-		wg.Wait()
-		close(i.networkReadyCh)
-	}()
+		// The Node's network is ready only when both synchronous and asynchronous initialization are done.
+		go func() {
+			wg.Wait()
+			close(i.networkReadyCh)
+		}()
+	} else {
+		// Install OpenFlow entries on OVS bridge.
+		if err := i.initOpenFlowPipeline(); err != nil {
+			return err
+		}
+	}
 	klog.Infof("Agent initialized NodeConfig=%v, NetworkConfig=%v", i.nodeConfig, i.networkConfig)
 	return nil
 }
@@ -735,11 +744,7 @@ func (i *Initializer) enableTunnelCsum(tunnelPortName string) error {
 
 // initNodeLocalConfig retrieves node's subnet CIDR from node.spec.PodCIDR, which is used for IPAM and setup
 // host gateway interface.
-func (i *Initializer) initNodeLocalConfig() error {
-	nodeName, err := env.GetNodeName()
-	if err != nil {
-		return err
-	}
+func (i *Initializer) initK8sNodeLocalConfig(nodeName string) error {
 	node, err := i.client.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to get Node with name %s from K8s: %w", nodeName, err)
@@ -817,6 +822,7 @@ func (i *Initializer) initNodeLocalConfig() error {
 
 	i.nodeConfig = &config.NodeConfig{
 		Name:                       nodeName,
+		Type:                       config.K8sNode,
 		OVSBridge:                  i.ovsBridge,
 		DefaultTunName:             defaultTunInterfaceName,
 		NodeIPv4Addr:               nodeIPv4Addr,
@@ -1083,4 +1089,35 @@ func (i *Initializer) patchNodeAnnotations(nodeName, key string, value interface
 // with NetworkPolicyOnly mode on public cloud setup, e.g., AKS.
 func (i *Initializer) getNodeInterfaceFromIP(nodeIPs *utilip.DualStackIPs) (v4IPNet *net.IPNet, v6IPNet *net.IPNet, iface *net.Interface, err error) {
 	return getIPNetDeviceFromIP(nodeIPs, sets.NewString(i.hostGateway))
+}
+
+func (i *Initializer) initNodeLocalConfig() error {
+	nodeName, err := env.GetNodeName()
+	if err != nil {
+		return err
+	}
+	if i.nodeType == config.K8sNode {
+		if err := i.initK8sNodeLocalConfig(nodeName); err != nil {
+			return err
+		}
+
+		i.networkConfig.IPv4Enabled = config.IsIPv4Enabled(i.nodeConfig, i.networkConfig.TrafficEncapMode)
+		i.networkConfig.IPv6Enabled = config.IsIPv6Enabled(i.nodeConfig, i.networkConfig.TrafficEncapMode)
+		return nil
+	}
+	if err := i.initVMLocalConfig(nodeName); err != nil {
+		return err
+	}
+	// Only IPv4 is supported on a VM Node.
+	i.networkConfig.IPv4Enabled = true
+	return nil
+}
+
+func (i *Initializer) initVMLocalConfig(nodeName string) error {
+	i.nodeConfig = &config.NodeConfig{
+		Name:      nodeName,
+		Type:      config.ExternalNode,
+		OVSBridge: i.ovsBridge,
+	}
+	return nil
 }

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -375,6 +375,7 @@ func TestInitNodeLocalConfig(t *testing.T) {
 			ifaceStore := interfacestore.NewInterfaceStore()
 			expectedNodeConfig := config.NodeConfig{
 				Name:                       nodeName,
+				Type:                       config.K8sNode,
 				OVSBridge:                  ovsBridge,
 				DefaultTunName:             defaultTunInterfaceName,
 				PodIPv4CIDR:                podCIDR,
@@ -412,7 +413,7 @@ func TestInitNodeLocalConfig(t *testing.T) {
 			defer mockGetIPNetDeviceFromIP(nodeIPNet, ipDevice)()
 			defer mockNodeNameEnv(nodeName)()
 
-			require.NoError(t, initializer.initNodeLocalConfig())
+			require.NoError(t, initializer.initK8sNodeLocalConfig(nodeName))
 			assert.Equal(t, expectedNodeConfig, *initializer.nodeConfig)
 			node, err := client.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
 			require.NoError(t, err)

--- a/pkg/agent/agent_windows.go
+++ b/pkg/agent/agent_windows.go
@@ -32,8 +32,15 @@ import (
 	"antrea.io/antrea/pkg/util/ip"
 )
 
-// prepareHostNetwork creates HNS Network for containers.
 func (i *Initializer) prepareHostNetwork() error {
+	if i.nodeConfig.Type == config.K8sNode {
+		return i.prepareHNSNetworkAndOVSExtension()
+	}
+	return nil
+}
+
+// prepareHNSNetworkAndOVSExtension creates HNS Network for containers, and enables OVS Extension on it.
+func (i *Initializer) prepareHNSNetworkAndOVSExtension() error {
 	// If the HNS Network already exists, return immediately.
 	hnsNetwork, err := hcsshim.GetHNSNetworkByName(util.LocalHNSNetwork)
 	if err == nil {
@@ -104,12 +111,19 @@ func (i *Initializer) prepareHostNetwork() error {
 	return util.PrepareHNSNetwork(subnetCIDR, i.nodeConfig.NodeTransportIPv4Addr, adapter, i.nodeConfig.UplinkNetConfig.Gateway, dnsServers, i.nodeConfig.UplinkNetConfig.Routes, i.ovsBridge)
 }
 
-// prepareOVSBridge adds local port and uplink to ovs bridge.
-// This function will delete OVS bridge and HNS network created by antrea on failure.
 func (i *Initializer) prepareOVSBridge() error {
+	if i.nodeType == config.K8sNode {
+		return i.prepareOVSBridgeOnHNSNetwork()
+	}
+	return nil
+}
+
+// prepareOVSBridgeOnHNSNetwork adds local port and uplink to OVS bridge after the OVS Extension is enabled on HNSNetwork.
+// This function will delete OVS bridge and HNS network created by Antrea at failures.
+func (i *Initializer) prepareOVSBridgeOnHNSNetwork() error {
 	hnsNetwork, err := hcsshim.GetHNSNetworkByName(util.LocalHNSNetwork)
 	defer func() {
-		// prepareOVSBridge only works on windows platform. The operation has a chance to fail on the first time agent
+		// prepareOVSBridge only works on Windows platform. The operation has a chance to fail on the first time agent
 		// starts up when OVS bridge uplink and local interface have not been configured. If the operation fails, the
 		// host can not communicate with external network. To make sure the agent can connect to API server in
 		// next retry, this step deletes OVS bridge and HNS network created previously which will restore the
@@ -136,7 +150,7 @@ func (i *Initializer) prepareOVSBridge() error {
 	datapathID := strings.Replace(hnsNetwork.SourceMac, ":", "", -1)
 	datapathID = "0000" + datapathID
 	if err = i.ovsBridgeClient.SetDatapathID(datapathID); err != nil {
-		klog.Errorf("Failed to set datapath_id %s: %v", datapathID, err)
+		klog.ErrorS(err, "Failed to set OVS bridge datapath_id", "datapathID", datapathID)
 		return err
 	}
 

--- a/pkg/agent/apiserver/apiserver.go
+++ b/pkg/agent/apiserver/apiserver.go
@@ -95,9 +95,9 @@ func installAPIGroup(s *genericapiserver.GenericAPIServer, aq agentquerier.Agent
 }
 
 // New creates an APIServer for running in antrea agent.
-func New(aq agentquerier.AgentQuerier, npq querier.AgentNetworkPolicyInfoQuerier, bindPort int,
+func New(aq agentquerier.AgentQuerier, npq querier.AgentNetworkPolicyInfoQuerier, bindAddress net.IP, bindPort int,
 	enableMetrics bool, kubeconfig string, cipherSuites []uint16, tlsMinVersion uint16, v4Enabled, v6Enabled bool) (*agentAPIServer, error) {
-	cfg, err := newConfig(npq, bindPort, enableMetrics, kubeconfig)
+	cfg, err := newConfig(npq, bindAddress, bindPort, enableMetrics, kubeconfig)
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +114,7 @@ func New(aq agentquerier.AgentQuerier, npq querier.AgentNetworkPolicyInfoQuerier
 	return &agentAPIServer{GenericAPIServer: s}, nil
 }
 
-func newConfig(npq querier.AgentNetworkPolicyInfoQuerier, bindPort int, enableMetrics bool, kubeconfig string) (*genericapiserver.CompletedConfig, error) {
+func newConfig(npq querier.AgentNetworkPolicyInfoQuerier, bindAddress net.IP, bindPort int, enableMetrics bool, kubeconfig string) (*genericapiserver.CompletedConfig, error) {
 	secureServing := genericoptions.NewSecureServingOptions().WithLoopback()
 	authentication := genericoptions.NewDelegatingAuthenticationOptions()
 	authorization := genericoptions.NewDelegatingAuthorizationOptions().WithAlwaysAllowPaths("/healthz", "/livez", "/readyz")
@@ -128,7 +128,7 @@ func newConfig(npq querier.AgentNetworkPolicyInfoQuerier, bindPort int, enableMe
 	// Set the PairName but leave certificate directory blank to generate in-memory by default.
 	secureServing.ServerCert.CertDirectory = ""
 	secureServing.ServerCert.PairName = Name
-	secureServing.BindAddress = net.IPv4zero
+	secureServing.BindAddress = bindAddress
 	secureServing.BindPort = bindPort
 
 	if err := secureServing.MaybeDefaultWithSelfSignedCerts("localhost", nil, []net.IP{net.ParseIP("127.0.0.1"), net.IPv6loopback}); err != nil {

--- a/pkg/agent/config/node_config.go
+++ b/pkg/agent/config/node_config.go
@@ -59,6 +59,23 @@ var (
 	VirtualServiceIPv6 = net.ParseIP("fc01::aabb:ccdd:eeff")
 )
 
+type NodeType uint8
+
+const (
+	K8sNode NodeType = iota
+	ExternalNode
+)
+
+func (t NodeType) String() string {
+	switch t {
+	case K8sNode:
+		return "k8sNode"
+	case ExternalNode:
+		return "externalNode"
+	}
+	return "unknown"
+}
+
 type GatewayConfig struct {
 	// Name is the name of host gateway, e.g. antrea-gw0.
 	Name string
@@ -103,6 +120,8 @@ type EgressConfig struct {
 type NodeConfig struct {
 	// The Node's name used in Kubernetes.
 	Name string
+	// The type to identify it is a Kubernetes Node or an external Node.
+	Type NodeType
 	// The name of the OpenVSwitch bridge antrea-agent uses.
 	OVSBridge string
 	// The name of the default tunnel interface. Defaults to "antrea-tun0", but can

--- a/pkg/agent/openflow/client_test.go
+++ b/pkg/agent/openflow/client_test.go
@@ -54,6 +54,7 @@ var (
 		WireGuardConfig: &config.WireGuardConfig{},
 		PodIPv4CIDR:     ipNet,
 		NodeIPv4Addr:    nodeIP,
+		Type:            config.K8sNode,
 	}
 	networkConfig = &config.NetworkConfig{IPv4Enabled: true}
 	egressConfig  = &config.EgressConfig{}

--- a/pkg/agent/openflow/network_policy_test.go
+++ b/pkg/agent/openflow/network_policy_test.go
@@ -529,7 +529,7 @@ func TestBatchInstallPolicyRuleFlows(t *testing.T) {
 			c = ofClient.(*client)
 			c.cookieAllocator = cookie.NewAllocator(0)
 			c.ofEntryOperations = mockOperations
-			c.nodeConfig = &config.NodeConfig{PodIPv4CIDR: podIPv4CIDR, PodIPv6CIDR: nil}
+			c.nodeConfig = &config.NodeConfig{PodIPv4CIDR: podIPv4CIDR, PodIPv6CIDR: nil, Type: config.K8sNode}
 			c.networkConfig = &config.NetworkConfig{IPv4Enabled: true}
 			c.ipProtocols = []binding.Protocol{binding.ProtocolIP}
 			mockFeaturePodConnectivity.cookieAllocator = c.cookieAllocator

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -391,6 +391,7 @@ type client struct {
 	enableEgress          bool
 	enableMulticast       bool
 	connectUplinkToBridge bool
+	nodeType              config.NodeType
 	roundInfo             types.RoundInfo
 	cookieAllocator       cookie.Allocator
 	bridge                binding.Bridge

--- a/pkg/config/agent/config.go
+++ b/pkg/config/agent/config.go
@@ -189,6 +189,9 @@ type AgentConfig struct {
 	AntreaProxy AntreaProxyConfig `yaml:"antreaProxy,omitempty"`
 	// Egress related configurations.
 	Egress EgressConfig `yaml:"egress"`
+	// NodeType is type of the Node where Antrea Agent is running.
+	// Defaults to "k8sNode". Valid values include "k8sNode", and "externalNode".
+	NodeType string `yaml:"nodeType,omitempty"`
 }
 
 type AntreaProxyConfig struct {

--- a/pkg/features/antrea_features.go
+++ b/pkg/features/antrea_features.go
@@ -91,6 +91,10 @@ const (
 	// alpha: v1.5
 	// Enable controlling Services with ExternalIP.
 	ServiceExternalIP featuregate.Feature = "ServiceExternalIP"
+
+	// alpha: v1.7
+	// Enable running agent on an unmanaged VM/BM.
+	ExternalNode featuregate.Feature = "ExternalNode"
 )
 
 var (
@@ -118,6 +122,7 @@ var (
 		Multicast:          {Default: false, PreRelease: featuregate.Alpha},
 		SecondaryNetwork:   {Default: false, PreRelease: featuregate.Alpha},
 		ServiceExternalIP:  {Default: false, PreRelease: featuregate.Alpha},
+		ExternalNode:       {Default: false, PreRelease: featuregate.Alpha},
 	}
 
 	// UnsupportedFeaturesOnWindows records the features not supported on
@@ -137,6 +142,14 @@ var (
 		Multicast:         {},
 		SecondaryNetwork:  {},
 		ServiceExternalIP: {},
+	}
+	// supportedFeaturesOnExternalNode records the features supported on an external
+	// Node. Antrea Agent checks the enabled features if it is running on an
+	// unmanaged VM/BM, and fails the startup if an unsupported feature is enabled.
+	supportedFeaturesOnExternalNode = map[featuregate.Feature]struct{}{
+		ExternalNode:       {},
+		AntreaPolicy:       {},
+		NetworkPolicyStats: {},
 	}
 )
 
@@ -163,4 +176,14 @@ func SupportedOnWindows(feature featuregate.Feature) bool {
 	}
 	_, exists = unsupportedFeaturesOnWindows[feature]
 	return !exists
+}
+
+// SupportedOnExternalNode checks whether a feature is supported on a external Node.
+func SupportedOnExternalNode(feature featuregate.Feature) bool {
+	_, exists := DefaultAntreaFeatureGates[feature]
+	if !exists {
+		return false
+	}
+	_, exists = supportedFeaturesOnExternalNode[feature]
+	return exists
 }

--- a/pkg/ovs/ovsconfig/interfaces.go
+++ b/pkg/ovs/ovsconfig/interfaces.go
@@ -33,6 +33,7 @@ type OVSBridgeClient interface {
 	Delete() Error
 	GetExternalIDs() (map[string]string, Error)
 	SetExternalIDs(externalIDs map[string]interface{}) Error
+	GetDatapathID() (string, Error)
 	SetDatapathID(datapathID string) Error
 	GetInterfaceOptions(name string) (map[string]string, Error)
 	SetInterfaceOptions(name string, options map[string]interface{}) Error

--- a/pkg/ovs/ovsconfig/testing/mock_ovsconfig.go
+++ b/pkg/ovs/ovsconfig/testing/mock_ovsconfig.go
@@ -250,6 +250,21 @@ func (mr *MockOVSBridgeClientMockRecorder) GetBridgeName() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBridgeName", reflect.TypeOf((*MockOVSBridgeClient)(nil).GetBridgeName))
 }
 
+// GetDatapathID mocks base method
+func (m *MockOVSBridgeClient) GetDatapathID() (string, ovsconfig.Error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDatapathID")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(ovsconfig.Error)
+	return ret0, ret1
+}
+
+// GetDatapathID indicates an expected call of GetDatapathID
+func (mr *MockOVSBridgeClientMockRecorder) GetDatapathID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDatapathID", reflect.TypeOf((*MockOVSBridgeClient)(nil).GetDatapathID))
+}
+
 // GetExternalIDs mocks base method
 func (m *MockOVSBridgeClient) GetExternalIDs() (map[string]string, ovsconfig.Error) {
 	m.ctrl.T.Helper()

--- a/test/integration/agent/openflow_test.go
+++ b/test/integration/agent/openflow_test.go
@@ -975,7 +975,7 @@ func prepareConfiguration(enableIPv4, enableIPv6 bool) *testConfig {
 
 	gatewayConfig := &config1.GatewayConfig{MAC: gwMAC}
 	uplinkConfig := &config1.AdapterNetConfig{MAC: uplinkMAC}
-	nodeConfig := &config1.NodeConfig{GatewayConfig: gatewayConfig, UplinkNetConfig: uplinkConfig}
+	nodeConfig := &config1.NodeConfig{GatewayConfig: gatewayConfig, UplinkNetConfig: uplinkConfig, Type: config1.K8sNode}
 	podCfg := &testLocalPodConfig{
 		name: "container-1",
 		testPortConfig: &testPortConfig{


### PR DESCRIPTION
1. Use feature gate "ExternalNode" to support Antrea Agent running
    on a non-Kubernetes Node.
3. Support Agent running APIServer only on localhost if it is not
   running on cluster worker Node.
4. CNIServer is loaded only when Agent is running on cluster worker
   Node.

Signed-off-by: wenyingd <wenyingd@vmware.com>