### PR TITLE
Unify the installation of initial flows in AntreaProxy

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -191,6 +191,12 @@ func run(o *Options) error {
 			return fmt.Errorf("getting available NodePort IP addresses failed: %v", err)
 		}
 	}
+	serviceConfig := &config.ServiceConfig{
+		ServiceCIDR:           serviceCIDRNet,
+		ServiceCIDRv6:         serviceCIDRNetv6,
+		NodePortAddressesIPv4: nodePortAddressesIPv4,
+		NodePortAddressesIPv6: nodePortAddressesIPv6,
+	}
 
 	// Initialize agent and node network.
 	agentInitializer := agent.NewInitializer(
@@ -202,17 +208,14 @@ func run(o *Options) error {
 		o.config.OVSBridge,
 		o.config.HostGateway,
 		o.config.DefaultMTU,
-		serviceCIDRNet,
-		serviceCIDRNetv6,
 		networkConfig,
 		wireguardConfig,
 		egressConfig,
+		serviceConfig,
 		networkReadyCh,
 		stopCh,
 		features.DefaultFeatureGate.Enabled(features.AntreaProxy),
 		o.config.AntreaProxy.ProxyAll,
-		nodePortAddressesIPv4,
-		nodePortAddressesIPv6,
 		connectUplinkToBridge)
 	err = agentInitializer.Initialize()
 	if err != nil {

--- a/pkg/agent/agent_linux.go
+++ b/pkg/agent/agent_linux.go
@@ -125,15 +125,6 @@ func (i *Initializer) prepareOVSBridge() error {
 	return nil
 }
 
-// initHostNetworkFlows installs Openflow flows between bridge local port and uplink port to support
-// host networking.
-func (i *Initializer) initHostNetworkFlows() error {
-	if err := i.ofClient.InstallBridgeUplinkFlows(); err != nil {
-		return err
-	}
-	return nil
-}
-
 // getTunnelLocalIP returns local_ip of tunnel port.
 // On linux platform, local_ip option is not needed.
 func (i *Initializer) getTunnelPortLocalIP() net.IP {

--- a/pkg/agent/agent_windows.go
+++ b/pkg/agent/agent_windows.go
@@ -191,15 +191,6 @@ func (i *Initializer) prepareOVSBridge() error {
 	return nil
 }
 
-// initHostNetworkFlows installs Openflow flows between bridge local port and uplink port to support
-// host networking.
-func (i *Initializer) initHostNetworkFlows() error {
-	if err := i.ofClient.InstallBridgeUplinkFlows(); err != nil {
-		return err
-	}
-	return nil
-}
-
 // getTunnelLocalIP returns local_ip of tunnel port
 func (i *Initializer) getTunnelPortLocalIP() net.IP {
 	return i.nodeConfig.NodeTransportIPv4Addr.IP

--- a/pkg/agent/config/node_config.go
+++ b/pkg/agent/config/node_config.go
@@ -182,3 +182,11 @@ func (nc *NetworkConfig) NeedsTunnelToPeer(peerIP net.IP, localIP *net.IPNet) bo
 func (nc *NetworkConfig) NeedsDirectRoutingToPeer(peerIP net.IP, localIP *net.IPNet) bool {
 	return (nc.TrafficEncapMode == TrafficEncapModeNoEncap || nc.TrafficEncapMode == TrafficEncapModeHybrid) && localIP.Contains(peerIP)
 }
+
+// ServiceConfig includes K8s Service CIDR and available IP addresses for NodePort.
+type ServiceConfig struct {
+	ServiceCIDR           *net.IPNet // K8s Service ClusterIP CIDR
+	ServiceCIDRv6         *net.IPNet // K8s Service ClusterIP CIDR in IPv6
+	NodePortAddressesIPv4 []net.IP
+	NodePortAddressesIPv6 []net.IP
+}

--- a/pkg/agent/openflow/client_test.go
+++ b/pkg/agent/openflow/client_test.go
@@ -56,6 +56,8 @@ var (
 		NodeIPv4Addr:    nodeIP,
 	}
 	networkConfig = &config.NetworkConfig{IPv4Enabled: true}
+	egressConfig  = &config.EgressConfig{}
+	serviceConfig = &config.ServiceConfig{}
 )
 
 func installNodeFlows(ofClient Client, cacheKey string) (int, error) {
@@ -111,6 +113,8 @@ func TestIdempotentFlowInstallation(t *testing.T) {
 			client.ofEntryOperations = m
 			client.nodeConfig = nodeConfig
 			client.networkConfig = networkConfig
+			client.egressConfig = egressConfig
+			client.serviceConfig = serviceConfig
 			client.ipProtocols = []binding.Protocol{binding.ProtocolIP}
 			client.generatePipelines()
 
@@ -142,6 +146,8 @@ func TestIdempotentFlowInstallation(t *testing.T) {
 			client.ofEntryOperations = m
 			client.nodeConfig = nodeConfig
 			client.networkConfig = networkConfig
+			client.egressConfig = egressConfig
+			client.serviceConfig = serviceConfig
 			client.ipProtocols = []binding.Protocol{binding.ProtocolIP}
 			client.generatePipelines()
 
@@ -186,6 +192,8 @@ func TestFlowInstallationFailed(t *testing.T) {
 			client.ofEntryOperations = m
 			client.nodeConfig = nodeConfig
 			client.networkConfig = networkConfig
+			client.egressConfig = egressConfig
+			client.serviceConfig = serviceConfig
 			client.ipProtocols = []binding.Protocol{binding.ProtocolIP}
 			client.generatePipelines()
 
@@ -223,6 +231,8 @@ func TestConcurrentFlowInstallation(t *testing.T) {
 			client.ofEntryOperations = m
 			client.nodeConfig = nodeConfig
 			client.networkConfig = networkConfig
+			client.egressConfig = egressConfig
+			client.serviceConfig = serviceConfig
 			client.ipProtocols = []binding.Protocol{binding.ProtocolIP}
 			client.generatePipelines()
 
@@ -415,6 +425,8 @@ func prepareTraceflowFlow(ctrl *gomock.Controller) *client {
 	c.ofEntryOperations = m
 	c.nodeConfig = nodeConfig
 	c.networkConfig = networkConfig
+	c.egressConfig = egressConfig
+	c.serviceConfig = serviceConfig
 	c.ipProtocols = []binding.Protocol{binding.ProtocolIP}
 	c.generatePipelines()
 

--- a/pkg/agent/openflow/multicast.go
+++ b/pkg/agent/openflow/multicast.go
@@ -27,7 +27,7 @@ type featureMulticast struct {
 	cookieAllocator cookie.Allocator
 	ipProtocols     []binding.Protocol
 
-	mcastFlowCache *flowCategoryCache
+	cachedFlows *flowCategoryCache
 
 	category cookie.Category
 }
@@ -40,7 +40,7 @@ func newFeatureMulticast(cookieAllocator cookie.Allocator, ipProtocols []binding
 	return &featureMulticast{
 		cookieAllocator: cookieAllocator,
 		ipProtocols:     ipProtocols,
-		mcastFlowCache:  newFlowCategoryCache(),
+		cachedFlows:     newFlowCategoryCache(),
 		category:        cookie.Multicast,
 	}
 }
@@ -61,5 +61,5 @@ func (f *featureMulticast) initFlows() []binding.Flow {
 
 func (f *featureMulticast) replayFlows() []binding.Flow {
 	// Get cached flows.
-	return getCachedFlows(f.mcastFlowCache)
+	return getCachedFlows(f.cachedFlows)
 }

--- a/pkg/agent/openflow/testing/mock_openflow.go
+++ b/pkg/agent/openflow/testing/mock_openflow.go
@@ -253,74 +253,18 @@ func (mr *MockClientMockRecorder) InitialTLVMap() *gomock.Call {
 }
 
 // Initialize mocks base method
-func (m *MockClient) Initialize(arg0 types.RoundInfo, arg1 *config.NodeConfig, arg2 *config.NetworkConfig) (<-chan struct{}, error) {
+func (m *MockClient) Initialize(arg0 types.RoundInfo, arg1 *config.NodeConfig, arg2 *config.NetworkConfig, arg3 *config.EgressConfig, arg4 *config.ServiceConfig) (<-chan struct{}, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Initialize", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "Initialize", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(<-chan struct{})
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Initialize indicates an expected call of Initialize
-func (mr *MockClientMockRecorder) Initialize(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) Initialize(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Initialize", reflect.TypeOf((*MockClient)(nil).Initialize), arg0, arg1, arg2)
-}
-
-// InstallBridgeUplinkFlows mocks base method
-func (m *MockClient) InstallBridgeUplinkFlows() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstallBridgeUplinkFlows")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// InstallBridgeUplinkFlows indicates an expected call of InstallBridgeUplinkFlows
-func (mr *MockClientMockRecorder) InstallBridgeUplinkFlows() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallBridgeUplinkFlows", reflect.TypeOf((*MockClient)(nil).InstallBridgeUplinkFlows))
-}
-
-// InstallClusterServiceCIDRFlows mocks base method
-func (m *MockClient) InstallClusterServiceCIDRFlows(arg0 []*net.IPNet) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstallClusterServiceCIDRFlows", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// InstallClusterServiceCIDRFlows indicates an expected call of InstallClusterServiceCIDRFlows
-func (mr *MockClientMockRecorder) InstallClusterServiceCIDRFlows(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallClusterServiceCIDRFlows", reflect.TypeOf((*MockClient)(nil).InstallClusterServiceCIDRFlows), arg0)
-}
-
-// InstallDefaultServiceFlows mocks base method
-func (m *MockClient) InstallDefaultServiceFlows(arg0, arg1 []net.IP) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstallDefaultServiceFlows", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// InstallDefaultServiceFlows indicates an expected call of InstallDefaultServiceFlows
-func (mr *MockClientMockRecorder) InstallDefaultServiceFlows(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallDefaultServiceFlows", reflect.TypeOf((*MockClient)(nil).InstallDefaultServiceFlows), arg0, arg1)
-}
-
-// InstallDefaultTunnelFlows mocks base method
-func (m *MockClient) InstallDefaultTunnelFlows() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstallDefaultTunnelFlows")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// InstallDefaultTunnelFlows indicates an expected call of InstallDefaultTunnelFlows
-func (mr *MockClientMockRecorder) InstallDefaultTunnelFlows() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallDefaultTunnelFlows", reflect.TypeOf((*MockClient)(nil).InstallDefaultTunnelFlows))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Initialize", reflect.TypeOf((*MockClient)(nil).Initialize), arg0, arg1, arg2, arg3, arg4)
 }
 
 // InstallEndpointFlows mocks base method
@@ -335,34 +279,6 @@ func (m *MockClient) InstallEndpointFlows(arg0 openflow.Protocol, arg1 []proxy.E
 func (mr *MockClientMockRecorder) InstallEndpointFlows(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallEndpointFlows", reflect.TypeOf((*MockClient)(nil).InstallEndpointFlows), arg0, arg1)
-}
-
-// InstallExternalFlows mocks base method
-func (m *MockClient) InstallExternalFlows(arg0 []net.IPNet) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstallExternalFlows", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// InstallExternalFlows indicates an expected call of InstallExternalFlows
-func (mr *MockClientMockRecorder) InstallExternalFlows(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallExternalFlows", reflect.TypeOf((*MockClient)(nil).InstallExternalFlows), arg0)
-}
-
-// InstallGatewayFlows mocks base method
-func (m *MockClient) InstallGatewayFlows() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstallGatewayFlows")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// InstallGatewayFlows indicates an expected call of InstallGatewayFlows
-func (mr *MockClientMockRecorder) InstallGatewayFlows() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallGatewayFlows", reflect.TypeOf((*MockClient)(nil).InstallGatewayFlows))
 }
 
 // InstallMulticastFlow mocks base method


### PR DESCRIPTION
Functions listed in the following are used to install initial flows. However,
in framework Flexible Pipeline, every feature has a method `initFlows()`
to install initial flows. This PR moves the installation of initial flows in
the following functions to the method `initFlows()` of corresponding
features.

 - InstallGatewayFlows() error -> feature PodConnectivity
 - InstallClusterServiceCIDRFlows(serviceNets []*net.IPNet) error -> feature Service
 - InstallDefaultServiceFlows(nodePortAddressesIPv4, nodePortAddressesIPv6 []net.IP) error -> feature Service
 - InstallDefaultTunnelFlows() error -> feature PodConnectivity
 - InstallBridgeUplinkFlows() error -> feature PodConnectivity
 - InstallExternalFlows(exceptCIDRs []net.IPNet) error  -> feature Egress

 Signed-off-by: Hongliang Liu <lhongliang@vmware.com>