### PR TITLE
Use cache to reduce overall image build time

### DIFF
--- a/ci/jenkins/test-mc.sh
+++ b/ci/jenkins/test-mc.sh
@@ -195,8 +195,14 @@ function deliver_antrea_multicluster {
 
     git show --numstat
     make clean
-    ${CLEAN_STALE_IMAGES}
+    # Clean up dangling images generated in previous builds.
+    docker image prune -f --filter "until=24h" || true > /dev/null
 
+    # Ensure that files in the Docker context have the correct permissions, or Docker caching cannot
+    # be leveraged successfully
+    chmod -R g-w build/images/ovs
+    chmod -R g-w build/images/base
+    
     cp -f build/yamls/*.yml $WORKDIR
     DOCKER_REGISTRY="${DOCKER_REGISTRY}" ./hack/build-antrea-linux-all.sh --pull
     echo "====== Delivering Antrea to all the Nodes ======"


### PR DESCRIPTION
1. Keep non dangling images which will be used in following
steps to build new images
2. Change the file permission to use cache during antrea image build

Signed-off-by: Lan Luo <luola@vmware.com>