### PR TITLE
[Antctl] Add an output formatter to better display multi-line string responses.

### DIFF
--- a/pkg/antctl/command_definition.go
+++ b/pkg/antctl/command_definition.go
@@ -41,6 +41,7 @@ const (
 	jsonFormatter  formatterType = "json"
 	yamlFormatter  formatterType = "yaml"
 	tableFormatter formatterType = "table"
+	rawFormatter   formatterType = "raw"
 )
 
 const (
@@ -541,6 +542,8 @@ func (cd *commandDefinition) output(resp io.Reader, writer io.Writer, ft formatt
 		} else {
 			return output.TableOutput(obj, writer)
 		}
+	case rawFormatter:
+		return output.RawOutput(obj, writer)
 	default:
 		return fmt.Errorf("unsupported format type: %v", ft)
 	}
@@ -648,11 +651,11 @@ func (cd *commandDefinition) applyFlagsToCommand(cmd *cobra.Command) {
 		cmd.Args = cobra.NoArgs
 	}
 	if cd.commandGroup == get {
-		cmd.Flags().StringP("output", "o", "table", "output format: json|table|yaml")
+		cmd.Flags().StringP("output", "o", "table", "output format: json|table|yaml|raw")
 	} else if cd.commandGroup == query {
-		cmd.Flags().StringP("output", "o", "table", "output format: json|table|yaml")
+		cmd.Flags().StringP("output", "o", "table", "output format: json|table|yaml|raw")
 	} else {
-		cmd.Flags().StringP("output", "o", "yaml", "output format: json|table|yaml")
+		cmd.Flags().StringP("output", "o", "yaml", "output format: json|table|yaml|raw")
 	}
 }
 

--- a/pkg/antctl/output/output.go
+++ b/pkg/antctl/output/output.go
@@ -148,6 +148,16 @@ func YamlOutput(obj interface{}, writer io.Writer) error {
 	return nil
 }
 
+// RawOutput is an output formatter whose output is similar to fmt.Print(responseString)
+// to better display multiple-line string responses.
+func RawOutput(obj interface{}, writer io.Writer) error {
+	_, err := fmt.Fprintf(writer, "%v", obj)
+	if err != nil {
+		return fmt.Errorf("error when outputing in raw format: %w", err)
+	}
+	return nil
+}
+
 // tableOutputForGetCommands formats the table output for "get" commands.
 func TableOutputForGetCommands(obj interface{}, writer io.Writer) error {
 	var list []common.TableOutput


### PR DESCRIPTION
Current output formatters (table, json, and yaml) of Antctl are
not good at displaying multi-line string responses.

Add a new output formatter `raw` whose output is similar to
fmt.Print(responseString) to better display multi-line string responses.

Fixes https://github.com/antrea-io/antrea/issues/3426

Signed-off-by: Kumar Atish <atish.iaf@gmail.com>