### PR TITLE
Enhance some methods of FlowBuilder and CTAction

### DIFF
--- a/pkg/agent/openflow/pipeline_other.go
+++ b/pkg/agent/openflow/pipeline_other.go
@@ -65,8 +65,7 @@ func (f *featurePodConnectivity) hostBridgeUplinkFlows(localSubnetMap map[bindin
 		L2ForwardingOutTable.ofTable.BuildFlow(priorityHigh).
 			Cookie(cookieID).
 			MatchProtocol(binding.ProtocolIP).
-			MatchRegMark(OutputToBridgeRegMark).
-			MatchRegMark(OFPortFoundRegMark).
+			MatchRegMark(OutputToBridgeRegMark, OFPortFoundRegMark).
 			Action().Output(config.BridgeOFPort).
 			Done(),
 		// Handle outgoing packet from AntreaFlexibleIPAM Pods. Broadcast is not supported.

--- a/pkg/agent/openflow/pipeline_windows.go
+++ b/pkg/agent/openflow/pipeline_windows.go
@@ -54,8 +54,7 @@ func (f *featurePodConnectivity) hostBridgeUplinkFlows(localSubnetMap map[bindin
 				MatchProtocol(ipProtocol).
 				MatchInPort(config.UplinkOFPort).
 				MatchDstIPNet(localSubnet).
-				Action().LoadRegMark(FromUplinkRegMark).
-				Action().LoadRegMark(RewriteMACRegMark).
+				Action().LoadRegMark(FromUplinkRegMark, RewriteMACRegMark).
 				Action().GotoStage(stageConntrackState).
 				Done())
 		}

--- a/pkg/agent/openflow/pod_connectivity.go
+++ b/pkg/agent/openflow/pod_connectivity.go
@@ -42,6 +42,7 @@ type featurePodConnectivity struct {
 
 	connectUplinkToBridge bool
 	ctZoneSrcField        *binding.RegField
+	ipCtZoneTypeRegMarks  map[binding.Protocol]*binding.RegMark
 	enableMulticast       bool
 
 	category cookie.Category
@@ -63,6 +64,7 @@ func newFeaturePodConnectivity(
 	gatewayIPs := make(map[binding.Protocol]net.IP)
 	localCIDRs := make(map[binding.Protocol]net.IPNet)
 	nodeIPs := make(map[binding.Protocol]net.IP)
+	ipCtZoneTypeRegMarks := make(map[binding.Protocol]*binding.RegMark)
 	for _, ipProtocol := range ipProtocols {
 		if ipProtocol == binding.ProtocolIP {
 			ctZones[ipProtocol] = CtZone
@@ -71,6 +73,7 @@ func newFeaturePodConnectivity(
 			if nodeConfig.PodIPv4CIDR != nil {
 				localCIDRs[ipProtocol] = *nodeConfig.PodIPv4CIDR
 			}
+			ipCtZoneTypeRegMarks[ipProtocol] = IPCtZoneTypeRegMark
 		} else if ipProtocol == binding.ProtocolIPv6 {
 			ctZones[ipProtocol] = CtZoneV6
 			gatewayIPs[ipProtocol] = nodeConfig.GatewayConfig.IPv6
@@ -78,6 +81,7 @@ func newFeaturePodConnectivity(
 			if nodeConfig.PodIPv6CIDR != nil {
 				localCIDRs[ipProtocol] = *nodeConfig.PodIPv6CIDR
 			}
+			ipCtZoneTypeRegMarks[ipProtocol] = IPv6CtZoneTypeRegMark
 		}
 	}
 
@@ -94,6 +98,7 @@ func newFeaturePodConnectivity(
 		networkConfig:         networkConfig,
 		ovsDatapathType:       ovsDatapathType,
 		connectUplinkToBridge: connectUplinkToBridge,
+		ipCtZoneTypeRegMarks:  ipCtZoneTypeRegMarks,
 		ctZoneSrcField:        getZoneSrcField(connectUplinkToBridge),
 		enableMulticast:       enableMulticast,
 		category:              cookie.PodConnectivity,

--- a/pkg/ovs/openflow/interfaces.go
+++ b/pkg/ovs/openflow/interfaces.go
@@ -203,7 +203,7 @@ type Flow interface {
 type Action interface {
 	LoadARPOperation(value uint16) FlowBuilder
 	LoadToRegField(field *RegField, value uint32) FlowBuilder
-	LoadRegMark(mark *RegMark) FlowBuilder
+	LoadRegMark(marks ...*RegMark) FlowBuilder
 	LoadPktMarkRange(value uint32, to *Range) FlowBuilder
 	LoadIPDSCP(value uint8) FlowBuilder
 	LoadRange(name string, addr uint64, to *Range) FlowBuilder
@@ -247,7 +247,7 @@ type FlowBuilder interface {
 	MatchProtocol(name Protocol) FlowBuilder
 	MatchIPProtocolValue(isIPv6 bool, protoValue uint8) FlowBuilder
 	MatchXXReg(regID int, data []byte) FlowBuilder
-	MatchRegMark(mark *RegMark) FlowBuilder
+	MatchRegMark(marks ...*RegMark) FlowBuilder
 	MatchRegFieldWithValue(field *RegField, data uint32) FlowBuilder
 	MatchInPort(inPort uint32) FlowBuilder
 	MatchDstIP(ip net.IP) FlowBuilder
@@ -270,7 +270,7 @@ type FlowBuilder interface {
 	MatchCTStateInv(isSet bool) FlowBuilder
 	MatchCTStateDNAT(isSet bool) FlowBuilder
 	MatchCTStateSNAT(isSet bool) FlowBuilder
-	MatchCTMark(mark *CtMark) FlowBuilder
+	MatchCTMark(marks ...*CtMark) FlowBuilder
 	MatchCTLabelField(high, low uint64, field *CtLabel) FlowBuilder
 	MatchPktMark(value uint32, mask *uint32) FlowBuilder
 	MatchConjID(value uint32) FlowBuilder
@@ -359,7 +359,7 @@ type MeterBandBuilder interface {
 
 type CTAction interface {
 	LoadToMark(value uint32) CTAction
-	LoadToCtMark(mark *CtMark) CTAction
+	LoadToCtMark(marks ...*CtMark) CTAction
 	LoadToLabelField(value uint64, labelField *CtLabel) CTAction
 	MoveToLabel(fromName string, fromRng, labelRng *Range) CTAction
 	MoveToCtMarkField(fromRegField *RegField, ctMark *CtMarkField) CTAction

--- a/pkg/ovs/openflow/ofctrl_action.go
+++ b/pkg/ovs/openflow/ofctrl_action.go
@@ -94,9 +94,11 @@ func (a *ofCTAction) LoadToMark(value uint32) CTAction {
 	return a
 }
 
-func (a *ofCTAction) LoadToCtMark(mark *CtMark) CTAction {
+func (a *ofCTAction) LoadToCtMark(marks ...*CtMark) CTAction {
 	field, _, _ := getFieldRange(NxmFieldCtMark)
-	a.load(field, uint64(mark.value), mark.field.rng)
+	for _, mark := range marks {
+		a.load(field, uint64(mark.value), mark.field.rng)
+	}
 	return a
 }
 
@@ -292,8 +294,13 @@ func (a *ofFlowAction) LoadToRegField(field *RegField, value uint32) FlowBuilder
 	return a.builder
 }
 
-func (a *ofFlowAction) LoadRegMark(mark *RegMark) FlowBuilder {
-	return a.LoadToRegField(mark.field, mark.value)
+func (a *ofFlowAction) LoadRegMark(marks ...*RegMark) FlowBuilder {
+	var fb FlowBuilder
+	fb = a.builder
+	for _, mark := range marks {
+		fb = a.LoadToRegField(mark.field, mark.value)
+	}
+	return fb
 }
 
 // LoadToPktMarkRange is an action to load data into pkt_mark at specified range.

--- a/pkg/ovs/openflow/testing/mock_openflow.go
+++ b/pkg/ovs/openflow/testing/mock_openflow.go
@@ -844,17 +844,21 @@ func (mr *MockActionMockRecorder) LoadRange(arg0, arg1, arg2 interface{}) *gomoc
 }
 
 // LoadRegMark mocks base method
-func (m *MockAction) LoadRegMark(arg0 *openflow.RegMark) openflow.FlowBuilder {
+func (m *MockAction) LoadRegMark(arg0 ...*openflow.RegMark) openflow.FlowBuilder {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LoadRegMark", arg0)
+	varargs := []interface{}{}
+	for _, a := range arg0 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "LoadRegMark", varargs...)
 	ret0, _ := ret[0].(openflow.FlowBuilder)
 	return ret0
 }
 
 // LoadRegMark indicates an expected call of LoadRegMark
-func (mr *MockActionMockRecorder) LoadRegMark(arg0 interface{}) *gomock.Call {
+func (mr *MockActionMockRecorder) LoadRegMark(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadRegMark", reflect.TypeOf((*MockAction)(nil).LoadRegMark), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadRegMark", reflect.TypeOf((*MockAction)(nil).LoadRegMark), arg0...)
 }
 
 // LoadToRegField mocks base method
@@ -1277,17 +1281,21 @@ func (mr *MockCTActionMockRecorder) DNAT(arg0, arg1 interface{}) *gomock.Call {
 }
 
 // LoadToCtMark mocks base method
-func (m *MockCTAction) LoadToCtMark(arg0 *openflow.CtMark) openflow.CTAction {
+func (m *MockCTAction) LoadToCtMark(arg0 ...*openflow.CtMark) openflow.CTAction {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LoadToCtMark", arg0)
+	varargs := []interface{}{}
+	for _, a := range arg0 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "LoadToCtMark", varargs...)
 	ret0, _ := ret[0].(openflow.CTAction)
 	return ret0
 }
 
 // LoadToCtMark indicates an expected call of LoadToCtMark
-func (mr *MockCTActionMockRecorder) LoadToCtMark(arg0 interface{}) *gomock.Call {
+func (mr *MockCTActionMockRecorder) LoadToCtMark(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadToCtMark", reflect.TypeOf((*MockCTAction)(nil).LoadToCtMark), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadToCtMark", reflect.TypeOf((*MockCTAction)(nil).LoadToCtMark), arg0...)
 }
 
 // LoadToLabelField mocks base method
@@ -1566,17 +1574,21 @@ func (mr *MockFlowBuilderMockRecorder) MatchCTLabelField(arg0, arg1, arg2 interf
 }
 
 // MatchCTMark mocks base method
-func (m *MockFlowBuilder) MatchCTMark(arg0 *openflow.CtMark) openflow.FlowBuilder {
+func (m *MockFlowBuilder) MatchCTMark(arg0 ...*openflow.CtMark) openflow.FlowBuilder {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MatchCTMark", arg0)
+	varargs := []interface{}{}
+	for _, a := range arg0 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "MatchCTMark", varargs...)
 	ret0, _ := ret[0].(openflow.FlowBuilder)
 	return ret0
 }
 
 // MatchCTMark indicates an expected call of MatchCTMark
-func (mr *MockFlowBuilderMockRecorder) MatchCTMark(arg0 interface{}) *gomock.Call {
+func (mr *MockFlowBuilderMockRecorder) MatchCTMark(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MatchCTMark", reflect.TypeOf((*MockFlowBuilder)(nil).MatchCTMark), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MatchCTMark", reflect.TypeOf((*MockFlowBuilder)(nil).MatchCTMark), arg0...)
 }
 
 // MatchCTProtocol mocks base method
@@ -1944,17 +1956,21 @@ func (mr *MockFlowBuilderMockRecorder) MatchRegFieldWithValue(arg0, arg1 interfa
 }
 
 // MatchRegMark mocks base method
-func (m *MockFlowBuilder) MatchRegMark(arg0 *openflow.RegMark) openflow.FlowBuilder {
+func (m *MockFlowBuilder) MatchRegMark(arg0 ...*openflow.RegMark) openflow.FlowBuilder {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MatchRegMark", arg0)
+	varargs := []interface{}{}
+	for _, a := range arg0 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "MatchRegMark", varargs...)
 	ret0, _ := ret[0].(openflow.FlowBuilder)
 	return ret0
 }
 
 // MatchRegMark indicates an expected call of MatchRegMark
-func (mr *MockFlowBuilderMockRecorder) MatchRegMark(arg0 interface{}) *gomock.Call {
+func (mr *MockFlowBuilderMockRecorder) MatchRegMark(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MatchRegMark", reflect.TypeOf((*MockFlowBuilder)(nil).MatchRegMark), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MatchRegMark", reflect.TypeOf((*MockFlowBuilder)(nil).MatchRegMark), arg0...)
 }
 
 // MatchSrcIP mocks base method

--- a/test/integration/agent/openflow_test.go
+++ b/test/integration/agent/openflow_test.go
@@ -1067,7 +1067,7 @@ func preparePodFlows(podIPs []net.IP, podMAC net.HardwareAddr, podOFPort uint32,
 			[]*ofTestUtils.ExpectFlow{
 				{
 					MatchStr: fmt.Sprintf("priority=210,ip,in_port=%d%s,dl_dst=%s", 3, matchVlanVIDString, podMAC.String()),
-					ActStr:   fmt.Sprintf("load:0x1->NXM_NX_REG8[12..15],load:%s->NXM_NX_REG8[0..11],load:0x4->NXM_NX_REG0[0..3],goto_table:SNATConntrackZone", vlanVIDString),
+					ActStr:   fmt.Sprintf("load:0x1->NXM_NX_REG8[12..15],load:0x4->NXM_NX_REG0[0..3],load:%s->NXM_NX_REG8[0..11],goto_table:SNATConntrackZone", vlanVIDString),
 				},
 			},
 		}}...)


### PR DESCRIPTION
- MatchRegMark supports matching multiple reg marks
- MatchCTMark supports matching multiple CT marks
- LoadRegMark supports loading multiple reg marks
- LoadToCtMark supports loading multiple CT marks

Signed-off-by: Hongliang Liu <lhongliang@vmware.com>