### PR TITLE
Fix importer issue after leader controller restart

### DIFF
--- a/multicluster/controllers/multicluster/commonarea/leader_elector.go
+++ b/multicluster/controllers/multicluster/commonarea/leader_elector.go
@@ -122,6 +122,8 @@ func (r *remoteCommonAreaManager) setElectedLeader(cluster RemoteCommonArea) {
 	}
 	r.electedLeaderCluster = cluster
 	if cluster != nil {
-		cluster.StartWatching()
+		if err := cluster.StartWatching(); err != nil {
+			klog.ErrorS(err, "Failed to start watching events")
+		}
 	}
 }

--- a/multicluster/controllers/multicluster/commonarea/remote_common_area.go
+++ b/multicluster/controllers/multicluster/commonarea/remote_common_area.go
@@ -147,7 +147,6 @@ func NewRemoteCommonArea(clusterID common.ClusterID, clusterSetID common.Cluster
 	if e != nil {
 		return nil, e
 	}
-
 	remote := &remoteCommonArea{
 		Client:                  remoteClient,
 		ClusterManager:          mgr,
@@ -409,6 +408,17 @@ func (r *remoteCommonArea) StopWatching() {
 	}
 	r.managerStopFunc()
 	r.managerStopFunc = nil
+
+	// Reset ClusterManager so this common area can be started again when it's reconnected.
+	mgr, err := ctrl.NewManager(r.config, ctrl.Options{
+		Scheme:             r.scheme,
+		MetricsBindAddress: "0",
+		Namespace:          r.Namespace,
+	})
+	if err != nil {
+		klog.ErrorS(err, "Error to reset manager for RemoteCommonArea", "Cluster", r.ClusterID)
+	}
+	r.ClusterManager = mgr
 }
 
 func (r *remoteCommonArea) GetStatus() []multiclusterv1alpha1.ClusterCondition {

--- a/multicluster/controllers/multicluster/commonarea/resourceimport_controller.go
+++ b/multicluster/controllers/multicluster/commonarea/resourceimport_controller.go
@@ -210,7 +210,6 @@ func (r *ResourceImportReconciler) handleResImpUpdateForService(ctx context.Cont
 			klog.ErrorS(err, "Failed to update imported Service", "service", svcName.String())
 			return ctrl.Result{}, err
 		}
-		r.installedResImports.Update(*resImp)
 	}
 
 	if !apiequality.Semantic.DeepEqual(svcImp.Spec, svcImpObj.Spec) {
@@ -221,8 +220,8 @@ func (r *ResourceImportReconciler) handleResImpUpdateForService(ctx context.Cont
 			klog.ErrorS(err, "Failed to update ServiceImport", "serviceimport", svcImpName.String())
 			return ctrl.Result{}, err
 		}
-		r.installedResImports.Update(*resImp)
 	}
+	r.installedResImports.Update(*resImp)
 	return ctrl.Result{}, nil
 }
 
@@ -324,8 +323,8 @@ func (r *ResourceImportReconciler) handleResImpUpdateForEndpoints(ctx context.Co
 			klog.ErrorS(err, "Failed to update MCS Endpoints", "endpoints", epNamespaced.String())
 			return ctrl.Result{}, err
 		}
-		r.installedResImports.Update(*resImp)
 	}
+	r.installedResImports.Update(*resImp)
 	return ctrl.Result{}, nil
 }
 


### PR DESCRIPTION
1. Reset common area's cluster manager so it can be started again
when member cluster disconnects from leader and reconnects. Otherwise,
it will raise an error `can't accept new runnable as stop procedure is already engaged`.

2. Always update the ResourceImport cache for importer so it can handle
deletion event correctly.

Fixes #3593

Signed-off-by: Lan Luo <luola@vmware.com>