### PR TITLE
Automated cherry pick of #3561: Export Service's name to support multi-ports

### DIFF
--- a/ci/jenkins/test-mc.sh
+++ b/ci/jenkins/test-mc.sh
@@ -195,7 +195,13 @@ function deliver_antrea_multicluster {
 
     git show --numstat
     make clean
-    ${CLEAN_STALE_IMAGES}
+    # Clean up dangling images generated in previous builds.
+    docker image prune -f --filter "until=24h" || true > /dev/null
+
+    # Ensure that files in the Docker context have the correct permissions, or Docker caching cannot
+    # be leveraged successfully
+    chmod -R g-w build/images/ovs
+    chmod -R g-w build/images/base
 
     cp -f build/yamls/*.yml $WORKDIR
     DOCKER_REGISTRY="${DOCKER_REGISTRY}" ./hack/build-antrea-linux-all.sh --pull

--- a/docs/multicluster/user-guide.md
+++ b/docs/multicluster/user-guide.md
@@ -412,8 +412,8 @@ converging the update until users correct it to match the Service definition in 
 ResourceImport.
 2. When a member cluster has already exported a Service, e.g.: `default/nginx` with TCP
 Port `80`, then other member clusters can only export the same Service with the same Ports
-definition. Otherwise, Antrea Multi-cluster Controller will skip converging the mismatched
-ResourceExport into the corresponding ResourceImport until users correct it.
+definition including port names. Otherwise, Antrea Multi-cluster Controller will skip converting
+the mismatched ResourceExport into the corresponding ResourceImport until users correct it.
 3. When a member cluster's Service ResourceExport has not been converged successfully
 due to forementioned mismatch issue, Antrea Multi-cluster Controller will also skip converging
 the corresponding Endpoints ResourceExport until users correct it.

--- a/multicluster/controllers/multicluster/resourceexport_controller.go
+++ b/multicluster/controllers/multicluster/resourceexport_controller.go
@@ -494,6 +494,7 @@ func SvcPortsConverter(svcPort []corev1.ServicePort) []mcs.ServicePort {
 	var mcsSP []mcs.ServicePort
 	for _, v := range svcPort {
 		mcsSP = append(mcsSP, mcs.ServicePort{
+			Name:     v.Name,
 			Port:     v.Port,
 			Protocol: v.Protocol,
 		})

--- a/multicluster/controllers/multicluster/resourceexport_controller_test.go
+++ b/multicluster/controllers/multicluster/resourceexport_controller_test.go
@@ -372,7 +372,7 @@ func TestResourceExportReconciler_handleSingleServiceUpdateEvent(t *testing.T) {
 		ServiceImport: &mcs.ServiceImport{
 			Spec: mcs.ServiceImportSpec{
 				Ports: SvcPortsConverter([]corev1.ServicePort{{
-					Name:     "8080tcp",
+					Name:     "http",
 					Port:     8080,
 					Protocol: corev1.ProtocolTCP,
 				}}),

--- a/multicluster/controllers/multicluster/serviceexport_controller.go
+++ b/multicluster/controllers/multicluster/serviceexport_controller.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"reflect"
 	"sort"
-	"strconv"
-	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -544,15 +542,8 @@ func (r *ServiceExportReconciler) refreshResourceExport(resName, kind string,
 	switch kind {
 	case common.ServiceKind:
 		re.ObjectMeta.Name = resName
-		newSvcSpec := svc.Spec.DeepCopy()
-		var renamedPorts []corev1.ServicePort
-		for _, p := range svc.Spec.Ports {
-			p.Name = strings.ToLower(string(p.Protocol)) + strconv.Itoa(int(p.Port))
-			renamedPorts = append(renamedPorts, p)
-		}
-		newSvcSpec.Ports = renamedPorts
 		re.Spec.Service = &mcsv1alpha1.ServiceExport{
-			ServiceSpec: *newSvcSpec,
+			ServiceSpec: svc.Spec,
 		}
 		re.Labels[common.SourceKind] = common.ServiceKind
 	case common.EndpointsKind:

--- a/multicluster/controllers/multicluster/serviceexport_controller_test.go
+++ b/multicluster/controllers/multicluster/serviceexport_controller_test.go
@@ -285,7 +285,7 @@ func TestServiceExportReconciler_handleServiceUpdateEvent(t *testing.T) {
 			ports := svcResExport.Spec.Service.ServiceSpec.Ports
 			expectedPorts := []corev1.ServicePort{
 				{
-					Name:     "tcp8080",
+					Name:     "http",
 					Protocol: corev1.ProtocolTCP,
 					Port:     8080,
 				},


### PR DESCRIPTION
Cherry pick of #3561 on release-1.6.

#3561: Export Service's name to support multi-ports

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.