### PR TITLE
Support multiple IPPools for secondary network IPAM

### DIFF
--- a/pkg/agent/cniserver/ipam/antrea_ipam_controller.go
+++ b/pkg/agent/cniserver/ipam/antrea_ipam_controller.go
@@ -63,9 +63,9 @@ func podIndexFunc(obj interface{}) ([]string, error) {
 		return nil, fmt.Errorf("obj is not IPPool: %+v", obj)
 	}
 	podNames := sets.NewString()
-	for _, IPAddress := range ipPool.Status.IPAddresses {
-		if IPAddress.Owner.Pod != nil {
-			podNames.Insert(k8s.NamespacedName(IPAddress.Owner.Pod.Namespace, IPAddress.Owner.Pod.Name))
+	for _, ipAddress := range ipPool.Status.IPAddresses {
+		if ipAddress.Owner.Pod != nil {
+			podNames.Insert(k8s.NamespacedName(ipAddress.Owner.Pod.Namespace, ipAddress.Owner.Pod.Name))
 		}
 	}
 	return podNames.UnsortedList(), nil
@@ -217,7 +217,7 @@ func (c *AntreaIPAMController) getPoolAllocatorByPod(namespace, podName string) 
 			break
 		}
 	}
-	if allocator == nil {
+	if err == nil && allocator == nil {
 		err = fmt.Errorf("no valid IPPool found")
 	}
 
@@ -231,8 +231,8 @@ func (c *AntreaIPAMController) getPoolAllocatorsByOwner(podOwner *crdv1a2.PodOwn
 		k8s.NamespacedName(podOwner.Namespace, podOwner.Name))
 	for _, item := range ipPools {
 		ipPool := item.(*crdv1a2.IPPool)
-		for _, IPAddress := range ipPool.Status.IPAddresses {
-			savedPod := IPAddress.Owner.Pod
+		for _, ipAddress := range ipPool.Status.IPAddresses {
+			savedPod := ipAddress.Owner.Pod
 			if savedPod != nil && savedPod.ContainerID == podOwner.ContainerID && savedPod.IFName == podOwner.IFName {
 				allocator, err := poolallocator.NewIPPoolAllocator(ipPool.Name, c.crdClient, c.ipPoolLister)
 				if err != nil {

--- a/pkg/agent/cniserver/ipam/antrea_ipam_test.go
+++ b/pkg/agent/cniserver/ipam/antrea_ipam_test.go
@@ -523,8 +523,8 @@ func TestAntreaIPAMDriver(t *testing.T) {
 	testAdd("apple1", "10.2.2.100", "10.2.2.1", "ffffff00", false)
 	testAdd("apple-sts-0", "10.2.2.102", "10.2.2.1", "ffffff00", true)
 
-	// Make sure repeated call for previous container results in error
-	testAddError("apple2")
+	// Make sure repeated call for previous container gets identical result
+	testAdd("apple2", "10.2.2.101", "10.2.2.1", "ffffff00", false)
 
 	// Make sure repeated Add works for pod that was previously released
 	testAdd("pear3", "10.2.3.199", "10.2.3.1", "ffffff00", false)

--- a/pkg/ipam/poolallocator/allocator_test.go
+++ b/pkg/ipam/poolallocator/allocator_test.go
@@ -373,23 +373,24 @@ func TestHas(t *testing.T) {
 	_, _, err := allocator.AllocateNext(crdv1a2.IPAddressPhaseAllocated, owner)
 	require.NoError(t, err)
 	err = wait.PollImmediate(100*time.Millisecond, 1*time.Second, func() (bool, error) {
-		has, _ := allocator.HasPod(testNamespace, "fakePod")
+		has, _ := allocator.hasPod(testNamespace, "fakePod")
 		return has, nil
 	})
 	require.NoError(t, err)
 
-	has, err := allocator.HasPod(testNamespace, "realPod")
+	has, err := allocator.hasPod(testNamespace, "realPod")
 	require.NoError(t, err)
 	assert.False(t, has)
-	has, err = allocator.HasContainer("fakeContainer", "eth1")
+	var ip net.IP
+	ip, err = allocator.GetContainerIP("fakeContainer", "eth1")
 	require.NoError(t, err)
-	assert.True(t, has)
-	has, err = allocator.HasContainer("fakeContainer", "")
+	assert.NotNil(t, ip)
+	ip, err = allocator.GetContainerIP("fakeContainer", "")
 	require.NoError(t, err)
-	assert.False(t, has)
-	has, err = allocator.HasContainer("realContainer", "eth1")
+	assert.Nil(t, ip)
+	ip, err = allocator.GetContainerIP("realContainer", "eth1")
 	require.NoError(t, err)
-	assert.False(t, has)
+	assert.Nil(t, ip)
 }
 
 func TestAllocateReleaseStatefulSet(t *testing.T) {


### PR DESCRIPTION
With this change, multiple IPPools can be specified in the CNI IPAM
config, and then antrea-agent will try allocating one IP in each IPPool
for the secondary network interface.

```
An example CNI config:
  {
      "cniVersion": "0.3.0",
      "type": "macvlan",
      "master": "enp0s9",
      "mode": "bridge",
      "ipam": {
          "type": "antrea-ipam",
          "ippool": ["ippool-v4", "ipppol-v6"]
      }
  }
```

Signed-off-by: Jianjun Shen <shenj@vmware.com>