### PR TITLE
Remove https://avinetworks.com from link checker

### DIFF
--- a/hack/.md_links_config.json
+++ b/hack/.md_links_config.json
@@ -26,6 +26,9 @@
         },
         {
             "pattern": "https://www.virtualbox.org/*"
+        },
+        {
+            "pattern": "https://avinetworks.com/*"
         }
     ],
     "retryOn429": false,


### PR DESCRIPTION
The avinetworks link in the documentation seems to cause link checking
to fail very frequently. The link is not dead, but it is possible that
the website uses DDoS protection, or something else causing the check to
fail.

Signed-off-by: Antonin Bas <abas@vmware.com>