### PR TITLE
Upgrade artifact upload and download Github Actions

### DIFF
--- a/.github/workflows/clair.yml
+++ b/.github/workflows/clair.yml
@@ -23,7 +23,7 @@ jobs:
         ./ci/clair-scan/run.sh ./clair-reports
     - name: Upload Clair scan reports
       if: ${{ always() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: clair-scan-reports
         path: clair-reports/*.json

--- a/.github/workflows/golicense.yml
+++ b/.github/workflows/golicense.yml
@@ -61,7 +61,7 @@ jobs:
         ./ci/golicense/run.sh ./antrea-bins ./license-reports
     - name: Upload licensing information
       if: ${{ always() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: licenses.deps
         path: license-reports/ALL.deps.txt

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Save Antrea image to tarball
       run:  docker save -o antrea-ubuntu.tar antrea/antrea-ubuntu-coverage:latest
     - name: Upload Antrea image for subsequent jobs
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: antrea-ubuntu-cov
         path: antrea-ubuntu.tar
@@ -59,7 +59,7 @@ jobs:
     - name: Save Flow Aggregator image to tarball
       run: docker save -o flow-aggregator.tar antrea/flow-aggregator-coverage:latest
     - name: Upload Flow Aggregator image for subsequent jobs
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: flow-aggregator-cov
         path: flow-aggregator.tar
@@ -80,7 +80,7 @@ jobs:
       with:
         go-version: 1.17
     - name: Download Antrea images from previous jobs
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
     - name: Load Antrea image
       run:  |
         docker load -i antrea-ubuntu-cov/antrea-ubuntu.tar
@@ -98,7 +98,7 @@ jobs:
     - name: Tar coverage files
       run: tar -czf test-e2e-encap-coverage.tar.gz test-e2e-encap-coverage
     - name: Upload coverage for test-e2e-encap-coverage
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: test-e2e-encap-coverage
         path: test-e2e-encap-coverage.tar.gz
@@ -115,7 +115,7 @@ jobs:
       if: ${{ failure() }}
       run: tar -czf log.tar.gz log
     - name: Upload test log
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: ${{ failure() }}
       with:
         name: e2e-kind-encap.tar.gz
@@ -137,7 +137,7 @@ jobs:
       with:
         go-version: 1.17
     - name: Download Antrea images from previous jobs
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
     - name: Load Antrea image
       run: |
         docker load -i antrea-ubuntu-cov/antrea-ubuntu.tar
@@ -155,7 +155,7 @@ jobs:
     - name: Tar coverage files
       run: tar -czf test-e2e-encap-no-proxy-coverage.tar.gz test-e2e-encap-no-proxy-coverage
     - name: Upload coverage for test-e2e-encap-no-proxy-coverage
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: test-e2e-encap-no-proxy-coverage
         path: test-e2e-encap-no-proxy-coverage.tar.gz
@@ -172,7 +172,7 @@ jobs:
       if: ${{ failure() }}
       run: tar -czf log.tar.gz log
     - name: Upload test log
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: ${{ failure() }}
       with:
         name: e2e-kind-encap-no-proxy.tar.gz
@@ -193,14 +193,8 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: 1.17
-      - name: Download Antrea image from previous job
-        uses: actions/download-artifact@v1
-        with:
-          name: antrea-ubuntu-cov
-      - name: Download Flow Aggregator image from previous job
-        uses: actions/download-artifact@v1
-        with:
-          name: flow-aggregator-cov
+      - name: Download Antrea images from previous jobs
+        uses: actions/download-artifact@v3
       - name: Load Antrea image
         run: |
           docker load -i antrea-ubuntu-cov/antrea-ubuntu.tar
@@ -218,7 +212,7 @@ jobs:
       - name: Tar coverage files
         run: tar -czf test-e2e-encap-proxy-all-coverage.tar.gz test-e2e-encap-proxy-all-coverage
       - name: Upload coverage for test-e2e-encap-proxy-all-coverage
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: test-e2e-encap-proxy-all-coverage
           path: test-e2e-encap-proxy-all-coverage.tar.gz
@@ -235,7 +229,7 @@ jobs:
         if: ${{ failure() }}
         run: tar -czf log.tar.gz log
       - name: Upload test log
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ failure() }}
         with:
           name: e2e-kind-encap-proxy-all.tar.gz
@@ -257,7 +251,7 @@ jobs:
       with:
         go-version: 1.17
     - name: Download Antrea images from previous jobs
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
     - name: Load Antrea image
       run: |
         docker load -i antrea-ubuntu-cov/antrea-ubuntu.tar
@@ -275,7 +269,7 @@ jobs:
     - name: Tar coverage files
       run: tar -czf test-e2e-noencap-coverage.tar.gz test-e2e-noencap-coverage
     - name: Upload coverage for test-e2e-noencap-coverage
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: test-e2e-noencap-coverage
         path: test-e2e-noencap-coverage.tar.gz
@@ -292,7 +286,7 @@ jobs:
       if: ${{ failure() }}
       run: tar -czf log.tar.gz log
     - name: Upload test log
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: ${{ failure() }}
       with:
         name: e2e-kind-noencap.tar.gz
@@ -314,7 +308,7 @@ jobs:
       with:
         go-version: 1.17
     - name: Download Antrea images from previous jobs
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
     - name: Load Antrea image
       run: |
         docker load -i antrea-ubuntu-cov/antrea-ubuntu.tar
@@ -332,7 +326,7 @@ jobs:
     - name: Tar coverage files
       run: tar -czf test-e2e-hybrid-coverage.tar.gz test-e2e-hybrid-coverage
     - name: Upload coverage for test-e2e-hybrid-coverage
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: test-e2e-hybrid-coverage
         path: test-e2e-hybrid-coverage.tar.gz
@@ -349,7 +343,7 @@ jobs:
       if: ${{ failure() }}
       run: tar -czf log.tar.gz log
     - name: Upload test log
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: ${{ failure() }}
       with:
         name: e2e-kind-hybrid.tar.gz
@@ -374,7 +368,7 @@ jobs:
       with:
         go-version: 1.17
     - name: Download Antrea images from previous jobs
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
     - name: Load Antrea image
       run: |
         docker load -i antrea-ubuntu-cov/antrea-ubuntu.tar
@@ -392,7 +386,7 @@ jobs:
     - name: Tar coverage files
       run: tar -czf test-e2e-encap-no-np-coverage.tar.gz test-e2e-encap-no-np-coverage
     - name: Upload coverage for test-e2e-encap-no-np-coverage
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: test-e2e-encap-no-np-coverage
         path: test-e2e-encap-no-np-coverage.tar.gz
@@ -409,7 +403,7 @@ jobs:
       if: ${{ failure() }}
       run: tar -czf log.tar.gz log
     - name: Upload test log
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: ${{ failure() }}
       with:
         name: e2e-kind-encap-no-np.tar.gz
@@ -431,9 +425,10 @@ jobs:
       with:
         go-version: 1.17
     - name: Download Antrea image from previous job
-      uses: actions/download-artifact@v1
+      uses: actions/download-artifact@v3
       with:
         name: antrea-ubuntu-cov
+        path: antrea-ubuntu-cov
     - name: Load Antrea image
       run: |
         docker load -i antrea-ubuntu-cov/antrea-ubuntu.tar
@@ -466,9 +461,10 @@ jobs:
         with:
           go-version: 1.17
       - name: Download Antrea image from previous job
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3
         with:
           name: antrea-ubuntu-cov
+          path: antrea-ubuntu-cov
       - name: Load Antrea image
         run: |
           docker load -i antrea-ubuntu-cov/antrea-ubuntu.tar

--- a/.github/workflows/kind_upgrade.yml
+++ b/.github/workflows/kind_upgrade.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Save Antrea image to tarball
       run:  docker save -o antrea-ubuntu.tar projects.registry.vmware.com/antrea/antrea-ubuntu:latest
     - name: Upload Antrea image for subsequent jobs
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: antrea-ubuntu
         path: antrea-ubuntu.tar
@@ -65,9 +65,10 @@ jobs:
       with:
         go-version: 1.17
     - name: Download Antrea image from previous job
-      uses: actions/download-artifact@v1
+      uses: actions/download-artifact@v3
       with:
         name: antrea-ubuntu
+        path: antrea-ubuntu
     - name: Load Antrea image
       run:  docker load -i antrea-ubuntu/antrea-ubuntu.tar
     - name: Install Kind
@@ -83,7 +84,7 @@ jobs:
       if: ${{ failure() }}
       run: tar -czf log.tar.gz log
     - name: Upload test log
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: ${{ failure() }}
       with:
         name: upgrade-from-antrea-version-n-1.tar.gz
@@ -105,9 +106,10 @@ jobs:
       with:
         go-version: 1.17
     - name: Download Antrea image from previous job
-      uses: actions/download-artifact@v1
+      uses: actions/download-artifact@v3
       with:
         name: antrea-ubuntu
+        path: antrea-ubuntu
     - name: Load Antrea image
       run:  docker load -i antrea-ubuntu/antrea-ubuntu.tar
     - name: Install Kind
@@ -123,7 +125,7 @@ jobs:
       if: ${{ failure() }}
       run: tar -czf log.tar.gz log
     - name: Upload test log
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: ${{ failure() }}
       with:
         name: upgrade-from-antrea-version-n-2.tar.gz
@@ -145,9 +147,10 @@ jobs:
         with:
           go-version: 1.17
       - name: Download Antrea image from previous job
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3
         with:
           name: antrea-ubuntu
+          path: antrea-ubuntu
       - name: Load Antrea image
         run:  docker load -i antrea-ubuntu/antrea-ubuntu.tar
       - name: Install Kind
@@ -163,7 +166,7 @@ jobs:
         if: ${{ failure() }}
         run: tar -czf log.tar.gz log
       - name: Upload test log
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ failure() }}
         with:
           name: api-compatible-with-client-version-n-1.tar.gz
@@ -185,9 +188,10 @@ jobs:
         with:
           go-version: 1.17
       - name: Download Antrea image from previous job
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v3
         with:
           name: antrea-ubuntu
+          path: antrea-ubuntu
       - name: Load Antrea image
         run:  docker load -i antrea-ubuntu/antrea-ubuntu.tar
       - name: Install Kind
@@ -203,7 +207,7 @@ jobs:
         if: ${{ failure() }}
         run: tar -czf log.tar.gz log
       - name: Upload test log
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ failure() }}
         with:
           name: api-compatible-with-client-version-n-2.tar.gz


### PR DESCRIPTION
From v1 & v2 to v3.
Some small manual changes were required because of breaking changes
introduced between download-artifact@v1 and download-artifact@v2.

Signed-off-by: Antonin Bas <abas@vmware.com>