### PR TITLE
Rename CreateGroup to CreateGroupTypeSelect

### DIFF
--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -2422,7 +2422,7 @@ func (f *featureService) endpointDNATFlow(endpointIP net.IP, endpointPort uint16
 // will resubmit packets back to ServiceLBTable to trigger the learn flow, the learn flow will then send packets to
 // EndpointDNATTable. Otherwise, buckets will resubmit packets to EndpointDNATTable directly.
 func (f *featureService) serviceEndpointGroup(groupID binding.GroupIDType, withSessionAffinity bool, endpoints ...proxy.Endpoint) binding.Group {
-	group := f.bridge.CreateGroup(groupID).ResetBuckets()
+	group := f.bridge.CreateGroupTypeSelect(groupID).ResetBuckets()
 	var resubmitTableID uint8
 	if withSessionAffinity {
 		resubmitTableID = ServiceLBTable.GetID()

--- a/pkg/ovs/openflow/interfaces.go
+++ b/pkg/ovs/openflow/interfaces.go
@@ -94,7 +94,7 @@ type Bridge interface {
 	CreateTable(table Table, next uint8, missAction MissActionType) Table
 	// AddTable adds table on the Bridge. Return true if the operation succeeds, otherwise return false.
 	DeleteTable(id uint8) bool
-	CreateGroup(id GroupIDType) Group
+	CreateGroupTypeSelect(id GroupIDType) Group
 	DeleteGroup(id GroupIDType) bool
 	CreateMeter(id MeterIDType, flags ofctrl.MeterFlag) Meter
 	DeleteMeter(id MeterIDType) bool

--- a/pkg/ovs/openflow/ofctrl_bridge.go
+++ b/pkg/ovs/openflow/ofctrl_bridge.go
@@ -189,7 +189,7 @@ type OFBridge struct {
 	multipartReplyChs map[uint32]chan *openflow13.MultipartReply
 }
 
-func (b *OFBridge) CreateGroup(id GroupIDType) Group {
+func (b *OFBridge) CreateGroupTypeSelect(id GroupIDType) Group {
 	ofctrlGroup, err := b.ofSwitch.NewGroup(uint32(id), ofctrl.GroupSelect)
 	if err != nil { // group already exists
 		ofctrlGroup = b.ofSwitch.GetGroup(uint32(id))

--- a/pkg/ovs/openflow/testing/mock_openflow.go
+++ b/pkg/ovs/openflow/testing/mock_openflow.go
@@ -120,18 +120,18 @@ func (mr *MockBridgeMockRecorder) Connect(arg0, arg1 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Connect", reflect.TypeOf((*MockBridge)(nil).Connect), arg0, arg1)
 }
 
-// CreateGroup mocks base method
-func (m *MockBridge) CreateGroup(arg0 openflow.GroupIDType) openflow.Group {
+// CreateGroupTypeSelect mocks base method
+func (m *MockBridge) CreateGroupTypeSelect(arg0 openflow.GroupIDType) openflow.Group {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateGroup", arg0)
+	ret := m.ctrl.Call(m, "CreateGroupTypeSelect", arg0)
 	ret0, _ := ret[0].(openflow.Group)
 	return ret0
 }
 
-// CreateGroup indicates an expected call of CreateGroup
-func (mr *MockBridgeMockRecorder) CreateGroup(arg0 interface{}) *gomock.Call {
+// CreateGroupTypeSelect indicates an expected call of CreateGroupTypeSelect
+func (mr *MockBridgeMockRecorder) CreateGroupTypeSelect(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateGroup", reflect.TypeOf((*MockBridge)(nil).CreateGroup), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateGroupTypeSelect", reflect.TypeOf((*MockBridge)(nil).CreateGroupTypeSelect), arg0)
 }
 
 // CreateMeter mocks base method

--- a/test/integration/ovs/ofctrl_test.go
+++ b/test/integration/ovs/ofctrl_test.go
@@ -280,7 +280,7 @@ func TestOFctrlGroup(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			group := br.CreateGroup(1)
+			group := br.CreateGroupTypeSelect(1)
 			for _, bucket := range buckets {
 				require.NotZero(t, bucket.weight, "Weight value of a bucket must be specified")
 				bucketBuilder := group.Bucket().Weight(bucket.weight)
@@ -529,7 +529,7 @@ func TestBundleWithGroupAndFlow(t *testing.T) {
 	field1 := binding.NewRegField(1, 0, 31, "field1")
 	field2 := binding.NewRegField(2, 0, 31, "field2")
 	field3 := binding.NewRegField(3, 0, 31, "field3")
-	group := bridge.CreateGroup(groupID).
+	group := bridge.CreateGroupTypeSelect(groupID).
 		Bucket().Weight(100).
 		LoadToRegField(field1, uint32(0xa0a0002)).
 		LoadToRegField(field2, uint32(0x35)).


### PR DESCRIPTION
In PR #3508, CreateGroupTypeAll is added, and to differentiate from it, CreateGroup
is renamed to CreateGroupTypeSelect.

Signed-off-by: Hongliang Liu <lhongliang@vmware.com>