### PR TITLE
Support dynamic ofport on OVS gateway/tunnel port

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -348,7 +348,9 @@ func run(o *Options) error {
 		asyncRuleDeleteInterval,
 		o.dnsServerOverride,
 		v4Enabled,
-		v6Enabled)
+		v6Enabled,
+		nodeConfig.GatewayConfig.OFPort,
+		nodeConfig.TunnelOFPort)
 	if err != nil {
 		return fmt.Errorf("error creating new NetworkPolicy controller: %v", err)
 	}

--- a/pkg/agent/config/node_config.go
+++ b/pkg/agent/config/node_config.go
@@ -73,6 +73,9 @@ type GatewayConfig struct {
 	MAC  net.HardwareAddr
 	// LinkIndex is the link index of host gateway.
 	LinkIndex int
+
+	// OFPort is the OpenFlow port number of host gateway allocated by OVS.
+	OFPort uint32
 }
 
 func (g *GatewayConfig) String() string {
@@ -87,6 +90,8 @@ type AdapterNetConfig struct {
 	Gateway    string
 	DNSServers string
 	Routes     []interface{}
+	// OFPort is the OpenFlow port number of the uplink interface allocated by OVS.
+	OFPort uint32
 }
 
 type WireGuardConfig struct {
@@ -136,6 +141,12 @@ type NodeConfig struct {
 	// Auto discovery will use MTU value of the Node's primary interface.
 	// For Encap and Hybrid mode, Node MTU will be adjusted to account for encap header.
 	NodeMTU int
+	// TunnelOFPort is the OpenFlow port number of tunnel interface allocated by OVS. With noEncap mode, the value is 0.
+	TunnelOFPort uint32
+	// HostInterfaceOFPort is the OpenFlow port number of the host interface allocated by OVS. The host interface is the
+	// one which the IP/MAC of the uplink is moved to. If the host interface is the OVS bridge interface (br-int), the
+	// value is config.BridgeOFPort.
+	HostInterfaceOFPort uint32
 	// The config of the gateway interface on the OVS bridge.
 	GatewayConfig *GatewayConfig
 	// The config of the OVS bridge uplink interface. Only for Windows Node.

--- a/pkg/agent/controller/networkpolicy/fqdn_test.go
+++ b/pkg/agent/controller/networkpolicy/fqdn_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	"antrea.io/antrea/pkg/agent/config"
 	openflowtest "antrea.io/antrea/pkg/agent/openflow/testing"
 )
 
@@ -42,6 +43,7 @@ func newMockFQDNController(t *testing.T, controller *gomock.Controller, dnsServe
 		dirtyRuleHandler,
 		true,
 		false,
+		config.HostGatewayOFPort,
 	)
 	require.NoError(t, err)
 	return f, mockOFClient

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
@@ -109,6 +109,8 @@ type Controller struct {
 	ifaceStore            interfacestore.InterfaceStore
 	// denyConnStore is for storing deny connections for flow exporter.
 	denyConnStore *connections.DenyConnectionStore
+	gwPort        uint32
+	tunPort       uint32
 }
 
 // NewNetworkPolicyController returns a new *Controller.
@@ -127,7 +129,8 @@ func NewNetworkPolicyController(antreaClientGetter agent.AntreaClientProvider,
 	asyncRuleDeleteInterval time.Duration,
 	dnsServerOverride string,
 	v4Enabled bool,
-	v6Enabled bool) (*Controller, error) {
+	v6Enabled bool,
+	gwPort, tunPort uint32) (*Controller, error) {
 	idAllocator := newIDAllocator(asyncRuleDeleteInterval, dnsInterceptRuleID)
 	c := &Controller{
 		antreaClientProvider: antreaClientGetter,
@@ -138,11 +141,13 @@ func NewNetworkPolicyController(antreaClientGetter agent.AntreaClientProvider,
 		statusManagerEnabled: statusManagerEnabled,
 		multicastEnabled:     multicastEnabled,
 		loggingEnabled:       loggingEnabled,
+		gwPort:               gwPort,
+		tunPort:              tunPort,
 	}
 
 	if antreaPolicyEnabled {
 		var err error
-		if c.fqdnController, err = newFQDNController(ofClient, idAllocator, dnsServerOverride, c.enqueueRule, v4Enabled, v6Enabled); err != nil {
+		if c.fqdnController, err = newFQDNController(ofClient, idAllocator, dnsServerOverride, c.enqueueRule, v4Enabled, v6Enabled, gwPort); err != nil {
 			return nil, err
 		}
 

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
@@ -32,6 +32,7 @@ import (
 	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/component-base/metrics/legacyregistry"
 
+	"antrea.io/antrea/pkg/agent/config"
 	"antrea.io/antrea/pkg/agent/metrics"
 	"antrea.io/antrea/pkg/agent/openflow"
 	proxytypes "antrea.io/antrea/pkg/agent/proxy/types"
@@ -60,7 +61,7 @@ func newTestController() (*Controller, *fake.Clientset, *mockReconciler) {
 	ch2 := make(chan string, 100)
 	groupIDAllocator := openflow.NewGroupAllocator(false)
 	groupCounters := []proxytypes.GroupCounter{proxytypes.NewGroupCounter(groupIDAllocator, ch2)}
-	controller, _ := NewNetworkPolicyController(&antreaClientGetter{clientset}, nil, nil, "node1", podUpdateChannel, groupCounters, ch2, true, true, true, false, true, testAsyncDeleteInterval, "8.8.8.8:53", true, false)
+	controller, _ := NewNetworkPolicyController(&antreaClientGetter{clientset}, nil, nil, "node1", podUpdateChannel, groupCounters, ch2, true, true, true, false, true, testAsyncDeleteInterval, "8.8.8.8:53", true, false, config.HostGatewayOFPort, config.DefaultTunOFPort)
 	reconciler := newMockReconciler()
 	controller.reconciler = reconciler
 	controller.antreaPolicyLogger = nil

--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -800,7 +800,7 @@ func (c *client) generatePipelines() {
 
 	if c.enableMulticast {
 		// TODO: add support for IPv6 protocol
-		c.featureMulticast = newFeatureMulticast(c.cookieAllocator, []binding.Protocol{binding.ProtocolIP}, c.bridge, c.enableAntreaPolicy)
+		c.featureMulticast = newFeatureMulticast(c.cookieAllocator, []binding.Protocol{binding.ProtocolIP}, c.bridge, c.enableAntreaPolicy, c.nodeConfig.GatewayConfig.OFPort)
 		c.activatedFeatures = append(c.activatedFeatures, c.featureMulticast)
 	}
 
@@ -1200,7 +1200,7 @@ func (c *client) SendIGMPQueryPacketOut(
 	srcIP := c.nodeConfig.GatewayConfig.IPv4.String()
 	dstMACStr := dstMAC.String()
 	dstIPStr := dstIP.String()
-	packetOutBuilder, err := setBasePacketOutBuilder(c.bridge.BuildPacketOut(), srcMAC, dstMACStr, srcIP, dstIPStr, config.HostGatewayOFPort, outPort)
+	packetOutBuilder, err := setBasePacketOutBuilder(c.bridge.BuildPacketOut(), srcMAC, dstMACStr, srcIP, dstIPStr, c.nodeConfig.GatewayConfig.OFPort, outPort)
 	if err != nil {
 		return err
 	}

--- a/pkg/agent/openflow/fields.go
+++ b/pkg/agent/openflow/fields.go
@@ -15,7 +15,6 @@
 package openflow
 
 import (
-	"antrea.io/antrea/pkg/agent/config"
 	binding "antrea.io/antrea/pkg/ovs/openflow"
 )
 
@@ -85,10 +84,6 @@ var (
 	// reg1(NXM_NX_REG1)
 	// Field to cache the ofPort of the OVS interface where to output packet.
 	TargetOFPortField = binding.NewRegField(1, 0, 31, "TargetOFPort")
-	// OutputToBridgeRegMark marks that the output interface is OVS bridge.
-	OutputToBridgeRegMark = binding.NewRegMark(TargetOFPortField, config.BridgeOFPort)
-	// OutputToUplinkRegMark marks that the output interface is uplink.
-	OutputToUplinkRegMark = binding.NewRegMark(TargetOFPortField, config.UplinkOFPort)
 
 	// reg2(NXM_NX_REG2)
 	// Field to help swap values in two different flow fields in the OpenFlow actions. This field is only used in func

--- a/pkg/agent/openflow/multicast.go
+++ b/pkg/agent/openflow/multicast.go
@@ -30,6 +30,7 @@ type featureMulticast struct {
 	cookieAllocator cookie.Allocator
 	ipProtocols     []binding.Protocol
 	bridge          binding.Bridge
+	gatewayPort     uint32
 
 	cachedFlows        *flowCategoryCache
 	groupCache         sync.Map
@@ -42,7 +43,7 @@ func (f *featureMulticast) getFeatureName() string {
 	return "Multicast"
 }
 
-func newFeatureMulticast(cookieAllocator cookie.Allocator, ipProtocols []binding.Protocol, bridge binding.Bridge, anpEnabled bool) *featureMulticast {
+func newFeatureMulticast(cookieAllocator cookie.Allocator, ipProtocols []binding.Protocol, bridge binding.Bridge, anpEnabled bool, gwPort uint32) *featureMulticast {
 	return &featureMulticast{
 		cookieAllocator:    cookieAllocator,
 		ipProtocols:        ipProtocols,
@@ -51,6 +52,7 @@ func newFeatureMulticast(cookieAllocator cookie.Allocator, ipProtocols []binding
 		category:           cookie.Multicast,
 		groupCache:         sync.Map{},
 		enableAntreaPolicy: anpEnabled,
+		gatewayPort:        gwPort,
 	}
 }
 

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -602,7 +602,7 @@ func (f *featurePodConnectivity) tunnelClassifierFlow(tunnelOFPort uint32) bindi
 func (f *featurePodConnectivity) gatewayClassifierFlow() binding.Flow {
 	return ClassifierTable.ofTable.BuildFlow(priorityNormal).
 		Cookie(f.cookieAllocator.Request(f.category).Raw()).
-		MatchInPort(config.HostGatewayOFPort).
+		MatchInPort(f.gatewayPort).
 		Action().LoadRegMark(FromGatewayRegMark).
 		Action().GotoStage(stageValidation).
 		Done()
@@ -636,7 +636,7 @@ func (f *featurePodConnectivity) podUplinkClassifierFlows(dstMAC net.HardwareAdd
 			// This generates the flow to mark the packets from uplink port.
 			ClassifierTable.ofTable.BuildFlow(priorityHigh).
 				Cookie(cookieID).
-				MatchInPort(config.UplinkOFPort).
+				MatchInPort(f.uplinkPort).
 				MatchDstMAC(dstMAC).
 				MatchVLAN(nonVLAN, vlanID, nil).
 				MatchProtocol(ipProtocol).
@@ -650,7 +650,7 @@ func (f *featurePodConnectivity) podUplinkClassifierFlows(dstMAC net.HardwareAdd
 				// This generates the flow to mark the packets from bridge local port.
 				ClassifierTable.ofTable.BuildFlow(priorityHigh).
 					Cookie(cookieID).
-					MatchInPort(config.BridgeOFPort).
+					MatchInPort(f.hostIfacePort).
 					MatchDstMAC(dstMAC).
 					MatchVLAN(true, 0, nil).
 					MatchProtocol(ipProtocol).
@@ -1026,7 +1026,7 @@ func (f *featurePodConnectivity) flowsToTrace(dataplaneTag uint8,
 			// SendToController and Output if output port is tunnel port.
 			fb := L2ForwardingOutTable.ofTable.BuildFlow(priorityNormal+3).
 				Cookie(cookieID).
-				MatchRegFieldWithValue(TargetOFPortField, config.DefaultTunOFPort).
+				MatchRegFieldWithValue(TargetOFPortField, f.tunnelPort).
 				MatchProtocol(ipProtocol).
 				MatchRegMark(OFPortFoundRegMark).
 				MatchIPDSCP(dataplaneTag).
@@ -1039,7 +1039,7 @@ func (f *featurePodConnectivity) flowsToTrace(dataplaneTag uint8,
 			// request is complete.
 			fb = L2ForwardingOutTable.ofTable.BuildFlow(priorityNormal+2).
 				Cookie(cookieID).
-				MatchRegFieldWithValue(TargetOFPortField, config.HostGatewayOFPort).
+				MatchRegFieldWithValue(TargetOFPortField, f.gatewayPort).
 				MatchProtocol(ipProtocol).
 				MatchRegMark(OFPortFoundRegMark).
 				MatchIPDSCP(dataplaneTag).
@@ -1052,7 +1052,7 @@ func (f *featurePodConnectivity) flowsToTrace(dataplaneTag uint8,
 			// traffic is expected to go out of the gateway port on the way to its destination.
 			fb := L2ForwardingOutTable.ofTable.BuildFlow(priorityNormal+2).
 				Cookie(cookieID).
-				MatchRegFieldWithValue(TargetOFPortField, config.HostGatewayOFPort).
+				MatchRegFieldWithValue(TargetOFPortField, f.gatewayPort).
 				MatchProtocol(ipProtocol).
 				MatchRegMark(OFPortFoundRegMark).
 				MatchIPDSCP(dataplaneTag).
@@ -1066,7 +1066,7 @@ func (f *featurePodConnectivity) flowsToTrace(dataplaneTag uint8,
 		if gatewayIP != nil {
 			fb := L2ForwardingOutTable.ofTable.BuildFlow(priorityNormal+3).
 				Cookie(cookieID).
-				MatchRegFieldWithValue(TargetOFPortField, config.HostGatewayOFPort).
+				MatchRegFieldWithValue(TargetOFPortField, f.gatewayPort).
 				MatchProtocol(ipProtocol).
 				MatchDstIP(gatewayIP).
 				MatchRegMark(OFPortFoundRegMark).
@@ -1565,7 +1565,7 @@ func (f *featurePodConnectivity) gatewayIPSpoofGuardFlows() []binding.Flow {
 		flows = append(flows, SpoofGuardTable.ofTable.BuildFlow(priorityNormal).
 			Cookie(cookieID).
 			MatchProtocol(ipProtocol).
-			MatchInPort(config.HostGatewayOFPort).
+			MatchInPort(f.gatewayPort).
 			Action().LoadRegMark(regMarksToLoad...).
 			Action().GotoTable(targetTables[ipProtocol]).
 			Done(),
@@ -1583,7 +1583,7 @@ func (f *featureService) serviceCIDRDNATFlows() []binding.Flow {
 			Cookie(cookieID).
 			MatchProtocol(ipProtocol).
 			MatchDstIPNet(serviceCIDR).
-			Action().LoadToRegField(TargetOFPortField, config.HostGatewayOFPort).
+			Action().LoadToRegField(TargetOFPortField, f.gatewayPort).
 			Action().LoadRegMark(OFPortFoundRegMark).
 			Action().GotoStage(stageConntrack).
 			Done())
@@ -2711,7 +2711,7 @@ func (f *featureMulticast) externalMulticastReceiverFlow() binding.Flow {
 		Cookie(f.cookieAllocator.Request(f.category).Raw()).
 		MatchProtocol(binding.ProtocolIP).
 		Action().LoadRegMark(OFPortFoundRegMark).
-		Action().LoadToRegField(TargetOFPortField, config.HostGatewayOFPort).
+		Action().LoadToRegField(TargetOFPortField, f.gatewayPort).
 		Action().GotoStage(stageOutput).
 		Done()
 }
@@ -2851,14 +2851,14 @@ func (f *featurePodConnectivity) hostBridgeLocalFlows() []binding.Flow {
 		// This generates the flow to forward the packets from uplink port to bridge local port.
 		ClassifierTable.ofTable.BuildFlow(priorityNormal).
 			Cookie(cookieID).
-			MatchInPort(config.UplinkOFPort).
-			Action().Output(config.BridgeOFPort).
+			MatchInPort(f.uplinkPort).
+			Action().Output(f.hostIfacePort).
 			Done(),
 		// This generates the flow to forward the packets from bridge local port to uplink port.
 		ClassifierTable.ofTable.BuildFlow(priorityNormal).
 			Cookie(cookieID).
-			MatchInPort(config.BridgeOFPort).
-			Action().Output(config.UplinkOFPort).
+			MatchInPort(f.hostIfacePort).
+			Action().Output(f.uplinkPort).
 			Done(),
 	}
 }
@@ -2869,7 +2869,7 @@ func (f *featurePodConnectivity) hostBridgeUplinkVLANFlows() []binding.Flow {
 	return []binding.Flow{
 		VLANTable.ofTable.BuildFlow(priorityLow).
 			Cookie(f.cookieAllocator.Request(f.category).Raw()).
-			MatchInPort(config.UplinkOFPort).
+			MatchInPort(f.uplinkPort).
 			MatchVLAN(false, 0, &vlanMask).
 			Action().PopVLAN().
 			Action().NextTable().
@@ -2882,7 +2882,7 @@ func (f *featurePodConnectivity) podVLANFlow(podOFPort uint32, vlanID uint16) bi
 	return VLANTable.ofTable.BuildFlow(priorityLow).
 		Cookie(f.cookieAllocator.Request(f.category).Raw()).
 		MatchInPort(podOFPort).
-		MatchRegMark(OutputToUplinkRegMark).
+		MatchRegFieldWithValue(TargetOFPortField, f.uplinkPort).
 		Action().PushVLAN(EtherTypeDot1q).
 		Action().SetVLAN(vlanID).
 		Action().NextTable().

--- a/pkg/agent/openflow/service.go
+++ b/pkg/agent/openflow/service.go
@@ -42,6 +42,7 @@ type featureService struct {
 	nodePortAddresses      map[binding.Protocol][]net.IP
 	serviceCIDRs           map[binding.Protocol]net.IPNet
 	networkConfig          *config.NetworkConfig
+	gatewayPort            uint32
 
 	enableProxy           bool
 	proxyAll              bool
@@ -110,6 +111,7 @@ func newFeatureService(
 		nodePortAddresses:      nodePortAddresses,
 		serviceCIDRs:           serviceCIDRs,
 		gatewayMAC:             nodeConfig.GatewayConfig.MAC,
+		gatewayPort:            nodeConfig.GatewayConfig.OFPort,
 		networkConfig:          networkConfig,
 		enableProxy:            enableProxy,
 		proxyAll:               proxyAll,


### PR DESCRIPTION
Originally the OpenFlow entries are using static port numbers for
gateway/tunnel/uplink which are used in the ofport_request fields in OVS
port creation. This is possible to introduce traffic issues if the
actual numbers assigned by OVS are different from the requests.

With this change, the predefined port numbers are still used in the OVS
port creation request, and save the actual port numbers in NodeConfig
after the OVS ports are created. And for the OpenFlow entries, the
actual port numbers are used.

Fixes #3409 

Signed-off-by: wenyingd <wenyingd@vmware.com>