### PR TITLE
Fix e2e test for multicluster service

### DIFF
--- a/ci/jenkins/test-mc.sh
+++ b/ci/jenkins/test-mc.sh
@@ -246,8 +246,11 @@ function deliver_multicluster_controller {
 
     for kubeconfig in "${membercluter_kubeconfigs[@]}"
     do
-       ip=$(kubectl get nodes -o wide --no-headers=true ${EAST_CLUSTER_CONFIG} | awk -v role="$CONTROL_PLANE_NODE_ROLE" '$3 == role {print $6}')
-       rsync -avr --progress --inplace -e "ssh -o StrictHostKeyChecking=no" ./multicluster/test/yamls/test-east-serviceexport.yml jenkins@["${ip}"]:"${WORKDIR}"/serviceexport.yml
+       # Remove the longest matched substring '*/' from a string like '--kubeconfig=/var/lib/jenkins/.kube/east'
+       # to get the last element which is the cluster name.
+       cluster=${kubeconfig##*/}
+       ip=$(kubectl get nodes -o wide --no-headers=true ${kubeconfig} | awk -v role="$CONTROL_PLANE_NODE_ROLE" '$3 == role {print $6}')
+       rsync -avr --progress --inplace -e "ssh -o StrictHostKeyChecking=no" ./multicluster/test/yamls/test-${cluster}-serviceexport.yml jenkins@["${ip}"]:"${WORKDIR}"/serviceexport.yml
     done
 }
 

--- a/multicluster/test/e2e/framework.go
+++ b/multicluster/test/e2e/framework.go
@@ -220,6 +220,26 @@ func randName(prefix string) string {
 	return prefix + randSeq(nameSuffixLength)
 }
 
+func (data *MCTestData) probeServiceFromPodInCluster(
+	cluster string,
+	podName string,
+	containerName string,
+	podNamespace string,
+	serviceIP string,
+) error {
+	cmd := []string{
+		"/bin/sh",
+		"-c",
+		fmt.Sprintf("curl --connect-timeout 5 -s %s", serviceIP),
+	}
+	log.Tracef("Running: kubectl exec %s -c %s -n %s -- %s", podName, containerName, podNamespace, strings.Join(cmd, " "))
+	stdout, stderr, err := data.runCommandFromPod(cluster, podNamespace, podName, containerName, cmd)
+	if err != nil || stderr != "" {
+		return fmt.Errorf("%s -> %s: error when running command: err - %v /// stdout - %s /// stderr - %s", podName, serviceIP, err, stdout, stderr)
+	}
+	return nil
+}
+
 func (data *MCTestData) probeFromPodInCluster(
 	cluster string,
 	podNamespace string,


### PR DESCRIPTION
1. verify the MC Service from a Pod instead of a Node.
2. fix the ServiceExport manifests file sync bug.

Signed-off-by: Lan Luo <luola@vmware.com>