### PR TITLE
[Windows] Use IP and MAC to find virtual management adatper

### DIFF
--- a/pkg/agent/agent_windows.go
+++ b/pkg/agent/agent_windows.go
@@ -252,9 +252,9 @@ func (i *Initializer) restoreHostRoutes() error {
 }
 
 func GetTransportIPNetDeviceByName(ifaceName string, ovsBridgeName string) (*net.IPNet, *net.IPNet, *net.Interface, error) {
-	// Find transport Interface in the order: ifaceName -> "vEthernet (ifaceName)" -> br-int. Return immediately if
-	// an interface using the specified name exists. Using "vEthernet (ifaceName)" or br-int is for restart agent case.
-	for _, name := range []string{ifaceName, util.VirtualAdapterName(ifaceName), ovsBridgeName} {
+	// Find transport Interface in the order: ifaceName -> br-int. Return immediately if
+	// an interface using the specified name exists. Using br-int is for restart agent case.
+	for _, name := range []string{ifaceName, ovsBridgeName} {
 		ipNet, _, link, err := util.GetIPNetDeviceByName(name)
 		if err == nil {
 			return ipNet, nil, link, nil


### PR DESCRIPTION
1. After creating HNSNetwork, Windows host creates a virtual management
   network adapter which takes over the uplink's IP and MAC. Originally
   the name with a format "vEthernet ($uplink_name)" is used to get the
   virtual adapter, but it might fail when the name is taken by other
   adapter. In this change, uses the uplink's IP and MAC to find the
   adpter, and uses the prefix "vEthernet" as a filter.
2. Remove the virtual adapter name from the name list to search the
   Windows Node transport interface's IP configuration in agent restart
   case. This is because the IP is finally moved to OVS bridge
   interface, which is renamed from the virtual network adapter. So in a
   restart case, a virtual network adapter with the name format 
   "vEthernet ($uplink_name)" should not exist.

Fixes #3636 

Signed-off-by: wenyingd <wenyingd@vmware.com>