### PR TITLE
Out-of-the-box "Agent mode" support for antctl on Windows

### DIFF
--- a/pkg/antctl/runtime/runtime.go
+++ b/pkg/antctl/runtime/runtime.go
@@ -20,6 +20,9 @@ import (
 
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+
+	agentapiserver "antrea.io/antrea/pkg/agent/apiserver"
+	"antrea.io/antrea/pkg/util/runtime"
 )
 
 const (
@@ -53,6 +56,15 @@ func init() {
 	podName, found := os.LookupEnv("POD_NAME")
 	InPod = found && (strings.HasPrefix(podName, "antrea-agent") || strings.HasPrefix(podName, "antrea-controller") ||
 		strings.HasPrefix(podName, "flow-aggregator"))
+
+	if runtime.IsWindowsPlatform() && !InPod {
+		if _, err := os.Stat(agentapiserver.TokenPath); err == nil {
+			InPod = true
+			Mode = ModeAgent
+			return
+		}
+	}
+
 	if strings.HasPrefix(podName, "antrea-agent") {
 		Mode = ModeAgent
 	} else if strings.HasPrefix(podName, "flow-aggregator") {

--- a/test/e2e/antctl_test.go
+++ b/test/e2e/antctl_test.go
@@ -36,7 +36,6 @@ type cmdAndReturnCode struct {
 // TestAntctl is the top-level test which contains all subtests for
 // Antctl related test cases as they can share setup, teardown.
 func TestAntctl(t *testing.T) {
-	skipIfHasWindowsNodes(t)
 	skipIfNotRequired(t, "mode-irrelevant")
 
 	data, err := setupTest(t)


### PR DESCRIPTION
At the moment is is possible to run antctl in Agent mode from a Windows
Node on which Antrea is runing, but it requires setting the following
environment variables manually:
```
> $Env:POD_NAME="antrea-agent"
> $Env:KUBERNETES_SERVICE_HOST="<ClusterIP>"
> $Env:KUBERNETES_SERVICE_PORT="443"
```

This is not very convenient and it is not documented
either. Additionally, there is no reason to require
KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT in Agent mode. This
requirement is caused by a bug in the antctl code: when antctl is
running inside a Pod, there is no need to resolve the "in-cluster"
Kubeconfig, as we generate this config manually to connect to the Antrea
API server.

In order to make antctl work out-of-the-box for that case, we change the
logic which decides what the antctl "runtime mode" is: if the antctl
binary is running on Windows and if a loopback client token exists, we
assume that this is a Windows Node which is running the Antrea Agent.

Fixes #2104

Signed-off-by: Antonin Bas <abas@vmware.com>