### PR TITLE
Update Kind from v0.11.1 to v0.12.0

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -12,7 +12,7 @@ on:
     - feature/*
 
 env:
-  KIND_VERSION: v0.11.1
+  KIND_VERSION: v0.12.0
 
 jobs:
   check-changes:

--- a/.github/workflows/kind_upgrade.yml
+++ b/.github/workflows/kind_upgrade.yml
@@ -12,7 +12,7 @@ on:
     - feature/*
 
 env:
-  KIND_VERSION: v0.11.1
+  KIND_VERSION: v0.12.0
 
 jobs:
   check-changes:

--- a/.github/workflows/netpol_cyclonus.yml
+++ b/.github/workflows/netpol_cyclonus.yml
@@ -5,7 +5,7 @@ on:
     - cron: '0 0 * * *'
 
 env:
-  KIND_VERSION: v0.11.1
+  KIND_VERSION: v0.12.0
 
 jobs:
 

--- a/multicluster/hack/verify-tools.sh
+++ b/multicluster/hack/verify-tools.sh
@@ -22,7 +22,7 @@ WORKDIR=$1
 os=$(echo $(uname) | tr '[:upper:]' '[:lower:]')
 if ! which kind > /dev/null; then
     if [[ ${os} == 'darwin' || ${os} == 'linux' ]]; then
-        curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/v0.11.1/kind-${os}-amd64
+        curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/v0.12.0/kind-${os}-amd64
         chmod +x ./kind
         if [[ "$WORKDIR" != "" ]];then
           mv kind "$WORKDIR"


### PR DESCRIPTION
This is the first Kind release in almost a year.
The default K8s image is now v1.23.4.

Thanks to https://github.com/kubernetes-sigs/kind/pull/2375, we no
longer need to explicitly enable route_localnet when testing ProxyAll
and disabling kube-proxy.

Signed-off-by: Antonin Bas <abas@vmware.com>