### PR TITLE
Fix race condition in ConntrackConnectionStore and FlowExporter

### DIFF
--- a/pkg/agent/flowexporter/connections/connections.go
+++ b/pkg/agent/flowexporter/connections/connections.go
@@ -70,7 +70,20 @@ func (cs *connectionStore) ForAllConnectionsDo(callback flowexporter.ConnectionM
 	for k, v := range cs.connections {
 		err := callback(k, v)
 		if err != nil {
-			klog.Errorf("Callback execution failed for flow with key: %v, conn: %v, k, v: %v", k, v, err)
+			klog.ErrorS(err, "Callback execution failed for flow", "key", k, "conn", v)
+			return err
+		}
+	}
+	return nil
+}
+
+// ForAllConnectionsDoWithoutLock execute the callback for each connection in connection
+// map, without grabbing the lock. Caller is expected to grab lock.
+func (cs *connectionStore) ForAllConnectionsDoWithoutLock(callback flowexporter.ConnectionMapCallBack) error {
+	for k, v := range cs.connections {
+		err := callback(k, v)
+		if err != nil {
+			klog.ErrorS(err, "Callback execution failed for flow", "key", k, "conn", v)
 			return err
 		}
 	}

--- a/pkg/agent/flowexporter/connections/conntrack_connections_test.go
+++ b/pkg/agent/flowexporter/connections/conntrack_connections_test.go
@@ -118,6 +118,7 @@ func TestConntrackConnectionStore_AddOrUpdateConn(t *testing.T) {
 				FlowKey:                        tuple1,
 				Labels:                         []byte{0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0},
 				Mark:                           openflow.ServiceCTMark.GetValue(),
+				IsPresent:                      true,
 				IsActive:                       true,
 				DestinationPodName:             "pod1",
 				DestinationPodNamespace:        "ns1",

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -126,6 +126,7 @@ const (
 
 	nginxLBService = "nginx-loadbalancer"
 
+	exporterFlowPollInterval            = 1 * time.Second
 	exporterActiveFlowExportTimeout     = 2 * time.Second
 	exporterIdleFlowExportTimeout       = 1 * time.Second
 	aggregatorActiveFlowRecordTimeout   = 3500 * time.Millisecond
@@ -694,7 +695,7 @@ func (data *TestData) enableAntreaFlowExporter(ipfixCollector string) error {
 	// Enable flow exporter feature and add related config params to antrea agent configmap.
 	ac := func(config *agentconfig.AgentConfig) {
 		config.FeatureGates["FlowExporter"] = true
-		config.FlowPollInterval = "1s"
+		config.FlowPollInterval = exporterFlowPollInterval.String()
 		config.ActiveFlowExportTimeout = exporterActiveFlowExportTimeout.String()
 		config.IdleFlowExportTimeout = exporterIdleFlowExportTimeout.String()
 		if ipfixCollector != "" {


### PR DESCRIPTION
Conntrack connection store's polling go routine and flow exporter both access to conntrack connection store, and there's a race condition error. 

In `func (cs *ConntrackConnectionStore) Poll()`, two things happen in sequence:
1. in `deleteIfStaleOrResetConn`, we acquire the lock, reset `conn.IsPresent = false` for all the connections in connection map, and then release the lock (`conn.IsPresent` is used to describe whether the connection exist in conntrack table or not)
2. if a connection is verified to exist in the conntrack table, in `AddOrUpdateConn`, we acquire the lock, set `conn.IsPresent = true`, then release the lock

It is likely to happen, when flow exporter's timer is triggered between 1 and 2, it will grab the lock, and read a connection with `IsPresent` set to false. In the corresponding exported flow record, `flowEndReason` will be set to 3, representing the flow has ended. Here's an antrea-agent log to verify the existence of this error: [log](https://github.com/heanlan/antrea/blob/66fed3037f2ec30457a241493cab7dfc7463e250/output.log)

We fix it by holding the lock until we finish 1&2. 

The observation comes from the error [log](https://gist.githubusercontent.com/antoninbas/f543aa2e9eb2c34cba41edf9825bf39e/raw/9db538ef44b12268b11c075a40687da2ea44487d/logs.txt) of flowaggregator e2e test. In the record, `flowEndReason` was set to 3, so the test treated the record as the last record. [Pointer to test code](https://github.com/antrea-io/antrea/blob/bd82ef668efc43c733566edefbf83ec0461e61ef/test/e2e/flowaggregator_test.go#L680).  It computed the throughput value by totalByteCount/iperfTimeSec, without reading from the throughput field in the record, which has the correct value.

Fixes: #3650 

Signed-off-by: heanlan <hanlan@vmware.com>