### PR TITLE
Update ClickHouse Server default image in ClickHouse-Operator manifest

### DIFF
--- a/build/yamls/clickhouse-operator-install-bundle.yml
+++ b/build/yamls/clickhouse-operator-install-bundle.yml
@@ -3487,7 +3487,7 @@ data:
                 "containers" : [
                   {
                     "name": "clickhouse",
-                    "image": "projects.registry.vmware.com/antrea/flow-visibility-clickhouse-server:21.3",
+                    "image": "projects.registry.vmware.com/antrea/flow-visibility-clickhouse-server:21.11",
                     "ports": [
                       {
                         "name": "http",


### PR DESCRIPTION
Make this change to keep the default image in ClickHouse-Operator in consistent with the one in flow-visibility.yml

Signed-off-by: heanlan <hanlan@vmware.com>