### PR TITLE
Support collect logs for failed agents and controller for supportbundle

### DIFF
--- a/pkg/antctl/raw/supportbundle/command_test.go
+++ b/pkg/antctl/raw/supportbundle/command_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Antrea Authors
+// copyright 2023 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -41,6 +41,7 @@ import (
 	fakeclientset "antrea.io/antrea/pkg/client/clientset/versioned/fake"
 	"antrea.io/antrea/pkg/client/clientset/versioned/scheme"
 	systemclientset "antrea.io/antrea/pkg/client/clientset/versioned/typed/system/v1beta1"
+	"antrea.io/antrea/pkg/util/compress"
 )
 
 var (
@@ -59,6 +60,10 @@ var (
 			Kind: "Node",
 			Name: "node-1",
 		},
+		PodRef: v1.ObjectReference{
+			Name:      "antrea-controller-1",
+			Namespace: "kube-system",
+		},
 	}
 	node1 = v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
@@ -76,7 +81,11 @@ var (
 	}
 	node2 = v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "node-1",
+			Name:            "node-1",
+			ResourceVersion: "0",
+		},
+		Status: v1.NodeStatus{
+			Addresses: []v1.NodeAddress{},
 		},
 	}
 	node3 = v1.Node{
@@ -95,7 +104,7 @@ var (
 	}
 	agentInfo1 = &v1beta1.AntreaAgentInfo{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "antrea-agent-1",
+			Name: "node-1",
 		},
 		APIPort: 0,
 		PodRef: v1.ObjectReference{
@@ -108,7 +117,7 @@ var (
 	}
 	agentInfo2 = &v1beta1.AntreaAgentInfo{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "antrea-agent-2",
+			Name: "node-2",
 		},
 		APIPort: 0,
 		PodRef: v1.ObjectReference{
@@ -117,6 +126,63 @@ var (
 		NodeRef: v1.ObjectReference{
 			Kind: "Node",
 			Name: "node-3",
+		},
+	}
+	controllerPod = &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "antrea-controller-1",
+			Namespace: "kube-system",
+			Labels: map[string]string{
+				"app":       "antrea",
+				"component": "antrea-controller",
+			},
+		},
+		Spec: v1.PodSpec{
+			NodeName: "node-1",
+			Containers: []v1.Container{
+				{
+					Name: "antrea-controller",
+				},
+			},
+		},
+	}
+	pod1 = &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "antrea-agent-1",
+			Namespace: "kube-system",
+			Labels: map[string]string{
+				"app":       "antrea",
+				"component": "antrea-agent",
+			},
+		},
+		Spec: v1.PodSpec{
+			NodeName: "node-1",
+			Containers: []v1.Container{
+				{
+					Name: "antrea-agent",
+				},
+				{
+					Name: "antrea-ovs",
+				},
+			},
+		},
+	}
+	pod2 = &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "antrea-agent-2",
+			Namespace: "kube-system",
+			Labels: map[string]string{
+				"app":       "antrea",
+				"component": "antrea-agent",
+			},
+		},
+		Spec: v1.PodSpec{
+			NodeName: "node-2",
+			Containers: []v1.Container{
+				{
+					Name: "antrea-agent",
+				},
+			},
 		},
 	}
 	nameList = []string{"node-1", "node-3"}
@@ -320,9 +386,9 @@ func TestProcessResults(t *testing.T) {
 		option.dir = path
 	}()
 	tests := []struct {
-		name        string
-		resultMap   map[string]error
-		expectedErr string
+		name           string
+		resultMap      map[string]error
+		expectFileList map[string][]string
 	}{
 		{
 			name: "All nodes failed",
@@ -331,7 +397,20 @@ func TestProcessResults(t *testing.T) {
 				"node-1": fmt.Errorf("error-1"),
 				"node-2": fmt.Errorf("error-2"),
 			},
-			expectedErr: "no data was collected:",
+			expectFileList: map[string][]string{
+				"": {
+					filepath.Join("logs", "controller", "antrea-controller.log"),
+				},
+				"node-1": {
+					"agentinfo",
+					filepath.Join("logs", "ovs", "antrea-ovs.log"),
+					filepath.Join("logs", "agent", "antrea-agent.log"),
+				},
+				"node-2": {
+					"agentinfo",
+					filepath.Join("logs", "agent", "antrea-agent.log"),
+				},
+			},
 		},
 		{
 			name: "Not all nodes failed",
@@ -339,6 +418,16 @@ func TestProcessResults(t *testing.T) {
 				"":       fmt.Errorf("error-0"),
 				"node-1": fmt.Errorf("error-1"),
 				"node-2": nil,
+			},
+			expectFileList: map[string][]string{
+				"": {
+					filepath.Join("logs", "controller", "antrea-controller.log"),
+				},
+				"node-1": {
+					"agentinfo",
+					filepath.Join("logs", "ovs", "antrea-ovs.log"),
+					filepath.Join("logs", "agent", "antrea-agent.log"),
+				},
 			},
 		},
 	}
@@ -351,17 +440,34 @@ func TestProcessResults(t *testing.T) {
 				defaultFS = afero.NewOsFs()
 			}()
 
-			err := processResults(tt.resultMap, option.dir)
-			if tt.expectedErr != "" {
-				require.ErrorContains(t, err, tt.expectedErr)
-			} else {
-				require.NoError(t, err)
-			}
-			// Both test cases above have failed Nodes, hence this file should always be created/
+			antreaInterface := fakeclientset.NewSimpleClientset(&controllerInfo, agentInfo1, agentInfo2)
+			k8sClient := fake.NewSimpleClientset(controllerPod, pod1, pod2)
+			require.NoError(t, processResults(context.TODO(), antreaInterface, k8sClient, tt.resultMap, option.dir))
 			b, err := afero.ReadFile(defaultFS, filepath.Join(option.dir, "failed_nodes"))
 			require.NoError(t, err)
 			data := string(b)
 			for node, err := range tt.resultMap {
+				tgzFileName := fmt.Sprintf("agent_%s.tar.gz", node)
+				if node == "" {
+					tgzFileName = "controller_node-1.tar.gz"
+				}
+				if err != nil {
+					// fallback path to retrieve data from kubernetes API instead of Antrea API.
+					ok, checkErr := afero.Exists(defaultFS, filepath.Join(option.dir, tgzFileName))
+					require.NoError(t, checkErr)
+					require.True(t, ok, "expected bundle file %s not found", tgzFileName)
+
+					unpackError := compress.UnpackDir(defaultFS, filepath.Join(option.dir, tgzFileName), option.dir)
+					require.NoError(t, unpackError)
+					files, _ := tt.expectFileList[node]
+					for _, expectFileName := range files {
+						ok, checkErr = afero.Exists(defaultFS, filepath.Join(option.dir, expectFileName))
+						require.NoError(t, checkErr)
+						assert.True(t, ok, "expected bundle file %s for %s not found", expectFileName, node)
+						defaultFS.Remove(filepath.Join(option.dir, expectFileName))
+					}
+
+				}
 				if node == "" {
 					continue
 				}

--- a/pkg/util/k8s/pod.go
+++ b/pkg/util/k8s/pod.go
@@ -20,3 +20,15 @@ import v1 "k8s.io/api/core/v1"
 func IsPodTerminated(pod *v1.Pod) bool {
 	return pod.Status.Phase == v1.PodFailed || pod.Status.Phase == v1.PodSucceeded
 }
+
+// GetPodContainersNames returns all the container names in a Pod, including init containers.
+func GetPodContainerNames(pod *v1.Pod) []string {
+	var names []string
+	for _, c := range pod.Spec.InitContainers {
+		names = append(names, c.Name)
+	}
+	for _, c := range pod.Spec.Containers {
+		names = append(names, c.Name)
+	}
+	return names
+}


### PR DESCRIPTION
When the normal supportbundle api failed for some nodes or controller,
use kubernetes api instead to collect logs. Also, in either case,
clusterinfo will always be gathered first.

Signed-off-by: Hang Yan <yhang@vmware.com>