### PR TITLE
[Vagrant testbed] Fix kubeconfig permissions

### DIFF
--- a/test/e2e/infra/vagrant/playbook/roles/control-plane/tasks/main.yml
+++ b/test/e2e/infra/vagrant/playbook/roles/control-plane/tasks/main.yml
@@ -46,6 +46,7 @@
         dest: /home/{{ test_user }}/.kube/config
         owner: "{{ test_user }}"
         group: "{{ test_user }}"
+        mode: '0600'
 
 # We currently copy the kube config and join command to the host so that it can
 # be copied to all the worker nodes when provisioning them. An alternative is to

--- a/test/e2e/infra/vagrant/provision.sh
+++ b/test/e2e/infra/vagrant/provision.sh
@@ -86,6 +86,7 @@ time vagrant up --provision
 echo "Writing Vagrant ssh config to file"
 vagrant ssh-config > ssh-config
 
+chmod 0600 "$THIS_DIR/playbook/kube/config"
 # TODO: use Kubeconfig contexts to add new cluster to existing Kubeconfig file
 echo "******************************"
 echo "Kubeconfig file written to $THIS_DIR/playbook/kube/config"


### PR DESCRIPTION
Remove read permissions from 'group' and 'world'. These restricted
permissions are typically recommended by compliance tools, and Helm
complains in case of extra permissions.

Signed-off-by: Antonin Bas <abas@vmware.com>