### PR TITLE
Fix broken Markdown links check

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -206,6 +206,7 @@ jobs:
     - name: Run verify scripts
       run: make verify
     - name: Checking for broken Markdown links
+      if: ${{ github.event_name == 'pull_request' }}
       uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
         # Check modified files only for pull requests. Cronjob "Verify docs" takes care of checking all markdown files.


### PR DESCRIPTION
`check-modified-files-only` can only be used for pull_request events (as
per the documentation for the action), and `github.base_ref` is not set
for push events.

At the moment the Github job is failing because it is run for push
events on the main and release branches.

Signed-off-by: Antonin Bas <abas@vmware.com>