### PR TITLE
Clean NetNat rules before CI testing on windows testbed

### DIFF
--- a/ci/jenkins/test.sh
+++ b/ci/jenkins/test.sh
@@ -353,6 +353,8 @@ function deliver_antrea_windows {
             sleep 5
             ssh -o StrictHostKeyChecking=no -n Administrator@${IP} "W32tm /resync /force" | grep successfully && break
         done
+        # Clean netnat rules
+        ssh -o StrictHostKeyChecking=no -n Administrator@${IP} "powershell Remove-NetNat -Confirm:'$'false"
         # Some tests need us.gcr.io/k8s-artifacts-prod/e2e-test-images/agnhost:2.13 image but it is not for windows/amd64 10.0.17763
         # Use e2eteam/agnhost:2.13 instead
         harbor_images=("sigwindowstools-kube-proxy:v1.18.0" "agnhost:2.13" "agnhost:2.13" "e2eteam-jessie-dnsutils:1.0" "e2eteam-pause:3.2")


### PR DESCRIPTION
NetNat rules need to be deleted to ensure OVS config is not affected.

Signed-off-by: Shuyang Xin <gavinx@vmware.com>