### PR TITLE
Automated cherry pick of #3661: Replace busybox source to fix image errors

### DIFF
--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -105,7 +105,7 @@ const (
 	nameSuffixLength int = 8
 
 	agnhostImage        = "projects.registry.vmware.com/antrea/agnhost:2.26"
-	busyboxImage        = "projects.registry.vmware.com/library/busybox"
+	busyboxImage        = "projects.registry.vmware.com/antrea/busybox"
 	nginxImage          = "projects.registry.vmware.com/antrea/nginx"
 	perftoolImage       = "projects.registry.vmware.com/antrea/perftool"
 	ipfixCollectorImage = "projects.registry.vmware.com/antrea/ipfix-collector:v0.5.8"


### PR DESCRIPTION
Cherry pick of #3661 on release-1.4.

#3661: Replace busybox source to fix image errors

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.