### PR TITLE
Suppress helm file permission warning

### DIFF
--- a/hack/generate-manifest.sh
+++ b/hack/generate-manifest.sh
@@ -269,10 +269,6 @@ fi
 
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-# Avoid potential Helm warnings about invalid permissions for Kubeconfig file.
-# The Kubeconfig does not matter for "helm template".
-unset KUBECONFIG
-
 source $THIS_DIR/verify-helm.sh
 
 if [ -z "$HELM" ]; then
@@ -409,10 +405,13 @@ for v in "${HELM_VALUES_FILES[@]}"; do
 done
 
 ANTREA_CHART="$THIS_DIR/../build/charts/antrea"
+# Suppress potential Helm warnings about invalid permissions for Kubeconfig file
+# by throwing away related warnings.
 $HELM template \
       --namespace kube-system \
       $HELM_VALUES_OPTION \
       $HELM_VALUES_FILES_OPTION \
-      "$ANTREA_CHART"
+      "$ANTREA_CHART" \
+      2> >(grep -v 'This is insecure' >&2)
 
 rm -rf $TMP_DIR

--- a/hack/verify-helm.sh
+++ b/hack/verify-helm.sh
@@ -27,7 +27,7 @@ verify_helm() {
     local helm="$(PATH=$_BINDIR command -v helm)"
     if [ -x "$helm" ]; then
         # Verify version if helm was already installed.
-        local helm_version="$($helm version --short)"
+        local helm_version="$($helm version --short 2> >(grep -v 'This is insecure' >&2))"
         # Should work with:
         #  - v3.8.1
         #  - v3.8.1+g5cb9af4


### PR DESCRIPTION
The file permission warning is still showing without KUBECONFIG, so
suppress this warning via throwing away it.
 
referring to a workaround from here https://github.com/helm/helm/issues/8776#issuecomment-1017081701

Signed-off-by: Lan Luo <luola@vmware.com>