### PR TITLE
Add antctl get oftables command to output table IDs and names

### DIFF
--- a/pkg/agent/apiserver/apiserver.go
+++ b/pkg/agent/apiserver/apiserver.go
@@ -38,6 +38,7 @@ import (
 	"antrea.io/antrea/pkg/agent/apiserver/handlers/featuregates"
 	"antrea.io/antrea/pkg/agent/apiserver/handlers/networkpolicy"
 	"antrea.io/antrea/pkg/agent/apiserver/handlers/ovsflows"
+	"antrea.io/antrea/pkg/agent/apiserver/handlers/ovstables"
 	"antrea.io/antrea/pkg/agent/apiserver/handlers/ovstracing"
 	"antrea.io/antrea/pkg/agent/apiserver/handlers/podinterface"
 	agentquerier "antrea.io/antrea/pkg/agent/querier"
@@ -81,6 +82,7 @@ func installHandlers(aq agentquerier.AgentQuerier, npq querier.AgentNetworkPolic
 	s.Handler.NonGoRestfulMux.HandleFunc("/appliedtogroups", appliedtogroup.HandleFunc(npq))
 	s.Handler.NonGoRestfulMux.HandleFunc("/addressgroups", addressgroup.HandleFunc(npq))
 	s.Handler.NonGoRestfulMux.HandleFunc("/ovsflows", ovsflows.HandleFunc(aq))
+	s.Handler.NonGoRestfulMux.HandleFunc("/ovstables", ovstables.HandleFunc(aq))
 	s.Handler.NonGoRestfulMux.HandleFunc("/ovstracing", ovstracing.HandleFunc(aq))
 }
 

--- a/pkg/agent/apiserver/handlers/ovstables/handler.go
+++ b/pkg/agent/apiserver/handlers/ovstables/handler.go
@@ -1,0 +1,64 @@
+// Copyright 2022 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ovstables
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"k8s.io/klog/v2"
+
+	agentquerier "antrea.io/antrea/pkg/agent/querier"
+)
+
+type Response struct {
+	Id   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
+}
+
+func HandleFunc(aq agentquerier.AgentQuerier) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		tableStrs, err := aq.GetOVSCtlClient().DumpTables()
+		if err != nil {
+			klog.ErrorS(err, "Failed to dump tables")
+			http.Error(w, "OVS table dumping failed", http.StatusInternalServerError)
+			return
+		}
+		tables := make([]Response, 0, len(tableStrs))
+		for _, tableStr := range tableStrs {
+			id := strings.Split(tableStr, " ")[0]
+			name := strings.Split(tableStr, " ")[1]
+			tables = append(tables, Response{id, name})
+		}
+		err = json.NewEncoder(w).Encode(tables)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			klog.ErrorS(err, "Error when encoding tables to json")
+		}
+	}
+}
+
+func (r Response) GetTableHeader() []string {
+	return []string{"TABLE-ID", "TABLE-NAME"}
+}
+
+func (r Response) GetTableRow(maxColumnLength int) []string {
+	return []string{r.Id, r.Name}
+}
+
+func (r Response) SortRows() bool {
+	return false
+}

--- a/pkg/antctl/antctl.go
+++ b/pkg/antctl/antctl.go
@@ -20,6 +20,7 @@ import (
 
 	"antrea.io/antrea/pkg/agent/apiserver/handlers/agentinfo"
 	"antrea.io/antrea/pkg/agent/apiserver/handlers/ovsflows"
+	"antrea.io/antrea/pkg/agent/apiserver/handlers/ovstables"
 	"antrea.io/antrea/pkg/agent/apiserver/handlers/podinterface"
 	"antrea.io/antrea/pkg/agent/openflow"
 	fallbackversion "antrea.io/antrea/pkg/antctl/fallback/version"
@@ -370,6 +371,22 @@ var CommandList = &commandList{
 			},
 			commandGroup:        get,
 			transformedResponse: reflect.TypeOf(ovsflows.Response{}),
+		},
+		{
+			use:     "ovstables",
+			aliases: []string{"ot"},
+			short:   "Dump OVS tables",
+			long:    "Dump all the OVS tables for the specified entity.",
+			example: `  Dump all OVS tables
+  $ antctl get ovstables`,
+			agentEndpoint: &endpoint{
+				nonResourceEndpoint: &nonResourceEndpoint{
+					path:       "/ovstables",
+					outputType: multiple,
+				},
+			},
+			commandGroup:        get,
+			transformedResponse: reflect.TypeOf(ovstables.Response{}),
 		},
 		{
 			use:   "trace-packet",

--- a/pkg/ovs/ovsctl/interface.go
+++ b/pkg/ovs/ovsctl/interface.go
@@ -34,12 +34,14 @@ type TracingRequest struct {
 // OVSCtlClient is an interface for executing OVS "ovs-ofctl" and "ovs-appctl"
 // commands.
 type OVSCtlClient interface {
+	// DumpTables returns tables of the bridge.
+	DumpTables() ([]string, error)
 	// DumpFlows returns flows of the bridge.
 	DumpFlows(args ...string) ([]string, error)
 	// DumpFlowsWithoutTableNames returns flows of the bridge, and the table is shown as uint8 value in the result.
 	// This function is only used in test.
 	DumpFlowsWithoutTableNames(args ...string) ([]string, error)
-	// DumpMatchedFlows returns the flow which exactly matches the matchStr.
+	// DumpMatchedFlow returns the flow which exactly matches the matchStr.
 	DumpMatchedFlow(matchStr string) (string, error)
 	// DumpTableFlows returns all flows in the table.
 	DumpTableFlows(table uint8) ([]string, error)

--- a/pkg/ovs/ovsctl/testing/mock_ovsctl.go
+++ b/pkg/ovs/ovsctl/testing/mock_ovsctl.go
@@ -161,6 +161,21 @@ func (mr *MockOVSCtlClientMockRecorder) DumpTableFlows(arg0 interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DumpTableFlows", reflect.TypeOf((*MockOVSCtlClient)(nil).DumpTableFlows), arg0)
 }
 
+// DumpTables mocks base method
+func (m *MockOVSCtlClient) DumpTables() ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DumpTables")
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DumpTables indicates an expected call of DumpTables
+func (mr *MockOVSCtlClientMockRecorder) DumpTables() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DumpTables", reflect.TypeOf((*MockOVSCtlClient)(nil).DumpTables))
+}
+
 // GetDPFeatures mocks base method
 func (m *MockOVSCtlClient) GetDPFeatures() (map[ovsctl.DPFeature]bool, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Example:

```
$ antctl get ovstables
TABLE-ID TABLE-NAME
0        PipelineRootClassifier
1        ARPSpoofGuard
2        ARPResponder
3        Classifier
4        SpoofGuard
5        IPv6
6        SNATConntrackZone
7        ConntrackZone
8        ConntrackState
9        PreRoutingClassifier
10       NodePortMark
11       SessionAffinity
12       ServiceLB
13       EndpointDNAT
14       AntreaPolicyEgressRule
15       EgressRule
16       EgressDefaultRule
17       EgressMetric
18       L3Forwarding
19       EgressMark
20       L3DecTTL
21       ServiceMark
22       SNATConntrackCommit
23       L2ForwardingCalc
24       IngressSecurityClassifier
25       AntreaPolicyIngressRule
26       IngressRule
27       IngressDefaultRule
28       IngressMetric
29       ConntrackCommit
30       Output
```

Signed-off-by: Hongliang Liu <lhongliang@vmware.com>