### PR TITLE
Fix the issue that Antrea Agent gets crashed with specified misconfiguration

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -183,7 +183,7 @@ func run(o *Options) error {
 
 	// Get all available NodePort addresses.
 	var nodePortAddressesIPv4, nodePortAddressesIPv6 []net.IP
-	if o.config.AntreaProxy.ProxyAll {
+	if features.DefaultFeatureGate.Enabled(features.AntreaProxy) && o.config.AntreaProxy.ProxyAll {
 		nodePortAddressesIPv4, nodePortAddressesIPv6, err = getAvailableNodePortAddresses(o.config.AntreaProxy.NodePortAddresses, append(excludeNodePortDevices, o.config.HostGateway))
 		if err != nil {
 			return fmt.Errorf("getting available NodePort IP addresses failed: %v", err)

--- a/cmd/antrea-agent/util.go
+++ b/cmd/antrea-agent/util.go
@@ -20,6 +20,8 @@ import (
 	"strconv"
 	"strings"
 
+	"k8s.io/klog/v2"
+
 	"antrea.io/antrea/pkg/agent/util"
 )
 
@@ -37,6 +39,10 @@ func getAvailableNodePortAddresses(nodePortAddressesFromConfig []string, exclude
 	var nodePortIPNets []*net.IPNet
 	for _, nodePortIP := range nodePortAddressesFromConfig {
 		_, ipNet, _ := net.ParseCIDR(nodePortIP)
+		// Skip invalid ipNet.
+		if ipNet == nil {
+			continue
+		}
 		nodePortIPNets = append(nodePortIPNets, ipNet)
 	}
 
@@ -52,6 +58,12 @@ func getAvailableNodePortAddresses(nodePortAddressesFromConfig []string, exclude
 				nodePortAddressesIPv6 = append(nodePortAddressesIPv6, nodeAddressesIPv6[i])
 			}
 		}
+	}
+	if len(nodePortAddressesIPv4) == 0 {
+		klog.Warning("No valid IPv4 address found for NodePort, thus IPv4 NodePort Service is unavailable on this Node")
+	}
+	if len(nodePortAddressesIPv6) == 0 {
+		klog.Warning("No valid IPv6 address found for NodePort, thus IPv6 NodePort Service is unavailable on this Node")
 	}
 
 	return nodePortAddressesIPv4, nodePortAddressesIPv6, nil


### PR DESCRIPTION
- If feature gate of AntreaProxy is disabled, but proxyAll is set
  to true deliberately, NodePort addresses are also initialized.
- If a string of NodePort address from config is not a valid ipNet,
  the returned value is nil after calling function `ParseCIDR`, and
  the nil value is still appended to a slice. In subsequent code,
  every member of the slice calls a method `Contain`, and a nil
  value call this method leads to the crashing of Antrea Agent
- If there is no valid IPv4 / IPv6 NodePort address, thus IPv4 /
  IPv6 NodePort Service is unavailable, and there is no log about
  this.

This PR fixes the issue described as above.

Signed-off-by: Hongliang Liu <lhongliang@vmware.com>