### PR TITLE
Reduce permission of antrea-agent service account

### DIFF
--- a/build/charts/antrea/templates/agent/clusterrole.yaml
+++ b/build/charts/antrea/templates/agent/clusterrole.yaml
@@ -42,13 +42,7 @@ rules:
     verbs:
       - get
       - watch
-      - list  
-  - apiGroups:
-      - ""
-    resources:
-      - services/status
-    verbs:
-      - update
+      - list
   - apiGroups:
       - discovery.k8s.io
     resources:

--- a/build/charts/antrea/templates/antctl/clusterrole.yaml
+++ b/build/charts/antrea/templates/antctl/clusterrole.yaml
@@ -53,5 +53,6 @@ rules:
       - /ovstracing
       - /podinterfaces
       - /featuregates
+      - /serviceexternalip
     verbs:
       - get

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -2826,13 +2826,7 @@ rules:
     verbs:
       - get
       - watch
-      - list  
-  - apiGroups:
-      - ""
-    resources:
-      - services/status
-    verbs:
-      - update
+      - list
   - apiGroups:
       - discovery.k8s.io
     resources:
@@ -3027,6 +3021,7 @@ rules:
       - /ovstracing
       - /podinterfaces
       - /featuregates
+      - /serviceexternalip
     verbs:
       - get
 ---

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -2826,13 +2826,7 @@ rules:
     verbs:
       - get
       - watch
-      - list  
-  - apiGroups:
-      - ""
-    resources:
-      - services/status
-    verbs:
-      - update
+      - list
   - apiGroups:
       - discovery.k8s.io
     resources:
@@ -3027,6 +3021,7 @@ rules:
       - /ovstracing
       - /podinterfaces
       - /featuregates
+      - /serviceexternalip
     verbs:
       - get
 ---

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -2826,13 +2826,7 @@ rules:
     verbs:
       - get
       - watch
-      - list  
-  - apiGroups:
-      - ""
-    resources:
-      - services/status
-    verbs:
-      - update
+      - list
   - apiGroups:
       - discovery.k8s.io
     resources:
@@ -3027,6 +3021,7 @@ rules:
       - /ovstracing
       - /podinterfaces
       - /featuregates
+      - /serviceexternalip
     verbs:
       - get
 ---

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -2839,13 +2839,7 @@ rules:
     verbs:
       - get
       - watch
-      - list  
-  - apiGroups:
-      - ""
-    resources:
-      - services/status
-    verbs:
-      - update
+      - list
   - apiGroups:
       - discovery.k8s.io
     resources:
@@ -3040,6 +3034,7 @@ rules:
       - /ovstracing
       - /podinterfaces
       - /featuregates
+      - /serviceexternalip
     verbs:
       - get
 ---

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -2826,13 +2826,7 @@ rules:
     verbs:
       - get
       - watch
-      - list  
-  - apiGroups:
-      - ""
-    resources:
-      - services/status
-    verbs:
-      - update
+      - list
   - apiGroups:
       - discovery.k8s.io
     resources:
@@ -3027,6 +3021,7 @@ rules:
       - /ovstracing
       - /podinterfaces
       - /featuregates
+      - /serviceexternalip
     verbs:
       - get
 ---

--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -612,6 +612,7 @@ func run(o *Options) error {
 	apiServer, err := apiserver.New(
 		agentQuerier,
 		networkPolicyController,
+		externalIPController,
 		o.config.APIPort,
 		*o.config.EnablePrometheusMetrics,
 		o.config.ClientConnection.Kubeconfig,

--- a/pkg/agent/apiserver/handlers/serviceexternalip/handler.go
+++ b/pkg/agent/apiserver/handlers/serviceexternalip/handler.go
@@ -1,0 +1,70 @@
+// Copyright 2022 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package serviceexternalip
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"antrea.io/antrea/pkg/antctl/transform/common"
+	"antrea.io/antrea/pkg/features"
+	"antrea.io/antrea/pkg/querier"
+)
+
+// HandleFunc creates a http.HandlerFunc which uses an ServiceExternalIPStatusQuerier
+// to query Service external IP status.
+func HandleFunc(sq querier.ServiceExternalIPStatusQuerier) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		name := r.URL.Query().Get("name")
+		ns := r.URL.Query().Get("namespace")
+		if !features.DefaultFeatureGate.Enabled(features.ServiceExternalIP) {
+			http.Error(w, "ServiceExternalIP is not enabled", http.StatusServiceUnavailable)
+			return
+		}
+		result := sq.GetServiceExternalIPStatus()
+		var response []Response
+		for _, r := range result {
+			if (len(name) == 0 || name == r.ServiceName) && (len(ns) == 0 || ns == r.Namespace) {
+				response = append(response, Response{r})
+			}
+		}
+		if len(name) > 0 && len(response) == 0 {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			http.Error(w, "Failed to encode response: "+err.Error(), http.StatusInternalServerError)
+		}
+	}
+}
+
+// Response describes the response struct of serviceexternalip command.
+type Response struct {
+	querier.ServiceExternalIPInfo
+}
+
+var _ common.TableOutput = (*Response)(nil)
+
+func (r Response) GetTableHeader() []string {
+	return []string{"NAMESPACE", "NAME", "EXTERNAL-IP-POOL", "EXTERNAL-IP", "ASSIGNED-NODE"}
+}
+
+func (r Response) GetTableRow(_ int) []string {
+	return []string{r.Namespace, r.ServiceName, r.ExternalIPPool, r.ExternalIP, r.AssignedNode}
+}
+
+func (r Response) SortRows() bool {
+	return true
+}

--- a/pkg/agent/controller/serviceexternalip/controller.go
+++ b/pkg/agent/controller/serviceexternalip/controller.go
@@ -15,14 +15,12 @@
 package serviceexternalip
 
 import (
-	"context"
 	"fmt"
 	"sync"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apimachinerytypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -36,6 +34,7 @@ import (
 	"antrea.io/antrea/pkg/agent/ipassigner"
 	"antrea.io/antrea/pkg/agent/memberlist"
 	"antrea.io/antrea/pkg/agent/types"
+	"antrea.io/antrea/pkg/querier"
 )
 
 const (
@@ -54,6 +53,7 @@ const (
 
 type externalIPState struct {
 	ip           string
+	ipPool       string
 	assignedNode string
 }
 
@@ -80,6 +80,8 @@ type ServiceExternalIPController struct {
 	assignedIPs      map[string]sets.String
 	assignedIPsMutex sync.Mutex
 }
+
+var _ querier.ServiceExternalIPStatusQuerier = (*ServiceExternalIPController)(nil)
 
 func NewServiceExternalIPController(
 	nodeName string,
@@ -302,21 +304,21 @@ func (c *ServiceExternalIPController) getServiceState(service *corev1.Service) (
 	return state, exist
 }
 
-func (c *ServiceExternalIPController) saveServiceState(service *corev1.Service, state externalIPState) {
+func (c *ServiceExternalIPController) saveServiceState(service *corev1.Service, state *externalIPState) {
 	c.externalIPStatesMutex.Lock()
 	defer c.externalIPStatesMutex.Unlock()
 	name := apimachinerytypes.NamespacedName{
 		Namespace: service.Namespace,
 		Name:      service.Name,
 	}
-	c.externalIPStates[name] = state
+	c.externalIPStates[name] = *state
 }
 
-func (c *ServiceExternalIPController) getServiceExternalIPAndHostname(service *corev1.Service) (string, string) {
+func (c *ServiceExternalIPController) getServiceExternalIP(service *corev1.Service) string {
 	if len(service.Status.LoadBalancer.Ingress) == 0 {
-		return "", ""
+		return ""
 	}
-	return service.Status.LoadBalancer.Ingress[0].IP, service.Status.LoadBalancer.Ingress[0].Hostname
+	return service.Status.LoadBalancer.Ingress[0].IP
 }
 
 func (c *ServiceExternalIPController) syncService(key apimachinerytypes.NamespacedName) error {
@@ -337,9 +339,9 @@ func (c *ServiceExternalIPController) syncService(key apimachinerytypes.Namespac
 		return c.deleteService(key)
 	}
 
-	state, exist := c.getServiceState(service)
-	currentExternalIP, currentHostname := c.getServiceExternalIPAndHostname(service)
-	if exist && state.ip != currentExternalIP {
+	prevState, exist := c.getServiceState(service)
+	currentExternalIP := c.getServiceExternalIP(service)
+	if exist && prevState.ip != currentExternalIP {
 		// External IP of the Service has changed. Delete the previous assigned IP if exists.
 		if err := c.deleteService(key); err != nil {
 			return err
@@ -347,58 +349,41 @@ func (c *ServiceExternalIPController) syncService(key apimachinerytypes.Namespac
 	}
 
 	ipPool := service.ObjectMeta.Annotations[types.ServiceExternalIPPoolAnnotationKey]
+	state := &externalIPState{
+		ip:     currentExternalIP,
+		ipPool: ipPool,
+	}
+	defer c.saveServiceState(service, state)
+
 	if currentExternalIP == "" || ipPool == "" {
 		return nil
 	}
 
-	selectNode := true
 	var filters []func(string) bool
 	if service.Spec.ExternalTrafficPolicy == corev1.ServiceExternalTrafficPolicyTypeLocal {
 		nodes, err := c.nodesHasHealthyServiceEndpoint(service)
 		if err != nil {
 			return err
 		}
-		// Avoid unnecessary migration caused by Endpoints changes.
-		if currentHostname != "" && c.cluster.AliveNodes().Has(currentHostname) && nodes.Has(currentHostname) {
-			selectNode = false
-			state = externalIPState{
-				ip:           currentExternalIP,
-				assignedNode: currentHostname,
-			}
-			c.saveServiceState(service, state)
-		} else {
-			filters = append(filters, func(s string) bool {
-				return nodes.Has(s)
-			})
-		}
+		filters = append(filters, func(s string) bool {
+			return nodes.Has(s)
+		})
 	}
 
-	if selectNode {
-		nodeName, err := c.cluster.SelectNodeForIP(currentExternalIP, ipPool, filters...)
-		if err != nil {
-			if err == memberlist.ErrNoNodeAvailable {
-				// No Node is available for the moment. The Service will be requeued by Endpoints, Node, or Memberlist update events.
-				klog.InfoS("No Node available", "ip", currentExternalIP, "ipPool", ipPool)
-				return nil
-			}
-			return err
+	nodeName, err := c.cluster.SelectNodeForIP(currentExternalIP, ipPool, filters...)
+	if err != nil {
+		if err == memberlist.ErrNoNodeAvailable {
+			// No Node is available at the moment. The Service will be requeued by Endpoints, Node, or Memberlist update events.
+			klog.InfoS("No Node available", "ip", currentExternalIP, "ipPool", ipPool)
+			return nil
 		}
-		klog.InfoS("Select Node for IP", "service", key, "nodeName", nodeName, "currentExternalIP", currentExternalIP, "ipPool", ipPool)
-		state = externalIPState{
-			ip:           currentExternalIP,
-			assignedNode: nodeName,
-		}
-		c.saveServiceState(service, state)
+		return err
 	}
-	// Update the hostname field of Service status and assign the external IP if this Node is selected.
+	klog.InfoS("Select Node for IP", "service", key, "nodeName", nodeName, "currentExternalIP", currentExternalIP, "ipPool", ipPool)
+
+	state.assignedNode = nodeName
+
 	if state.assignedNode == c.nodeName {
-		if service.Status.LoadBalancer.Ingress[0].Hostname != state.assignedNode {
-			serviceToUpdate := service.DeepCopy()
-			serviceToUpdate.Status.LoadBalancer.Ingress[0].Hostname = state.assignedNode
-			if _, err = c.client.CoreV1().Services(serviceToUpdate.Namespace).UpdateStatus(context.TODO(), serviceToUpdate, v1.UpdateOptions{}); err != nil {
-				return err
-			}
-		}
 		return c.assignIP(currentExternalIP, key)
 	}
 	return c.unassignIP(currentExternalIP, key)
@@ -452,4 +437,20 @@ func (c *ServiceExternalIPController) nodesHasHealthyServiceEndpoint(service *co
 		}
 	}
 	return nodes, nil
+}
+
+func (c *ServiceExternalIPController) GetServiceExternalIPStatus() []querier.ServiceExternalIPInfo {
+	c.externalIPStatesMutex.RLock()
+	defer c.externalIPStatesMutex.RUnlock()
+	info := make([]querier.ServiceExternalIPInfo, 0, len(c.externalIPStates))
+	for k, v := range c.externalIPStates {
+		info = append(info, querier.ServiceExternalIPInfo{
+			ServiceName:    k.Name,
+			Namespace:      k.Namespace,
+			ExternalIP:     v.ip,
+			ExternalIPPool: v.ipPool,
+			AssignedNode:   v.assignedNode,
+		})
+	}
+	return info
 }

--- a/pkg/agent/controller/serviceexternalip/controller_test.go
+++ b/pkg/agent/controller/serviceexternalip/controller_test.go
@@ -33,6 +33,7 @@ import (
 	ipassignertest "antrea.io/antrea/pkg/agent/ipassigner/testing"
 	"antrea.io/antrea/pkg/agent/memberlist"
 	"antrea.io/antrea/pkg/agent/types"
+	"antrea.io/antrea/pkg/querier"
 )
 
 const (
@@ -228,6 +229,7 @@ func TestCreateService(t *testing.T) {
 			expectedExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
 				keyFor(servicePolicyCluster): {
 					ip:           fakeServiceExternalIP1,
+					ipPool:       fakeExternalIPPoolName,
 					assignedNode: fakeNode1,
 				},
 			},
@@ -244,6 +246,7 @@ func TestCreateService(t *testing.T) {
 			expectedExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
 				keyFor(servicePolicyCluster): {
 					ip:           fakeServiceExternalIP1,
+					ipPool:       fakeExternalIPPoolName,
 					assignedNode: fakeNode2,
 				},
 			},
@@ -267,6 +270,7 @@ func TestCreateService(t *testing.T) {
 			expectedExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
 				keyFor(servicePolicyLocal): {
 					ip:           fakeServiceExternalIP1,
+					ipPool:       fakeExternalIPPoolName,
 					assignedNode: fakeNode1,
 				},
 			},
@@ -294,6 +298,7 @@ func TestCreateService(t *testing.T) {
 			expectedExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
 				keyFor(servicePolicyLocal): {
 					ip:           fakeServiceExternalIP1,
+					ipPool:       fakeExternalIPPoolName,
 					assignedNode: fakeNode2,
 				},
 			},
@@ -317,6 +322,7 @@ func TestCreateService(t *testing.T) {
 			expectedExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
 				keyFor(servicePolicyLocal): {
 					ip:           fakeServiceExternalIP1,
+					ipPool:       fakeExternalIPPoolName,
 					assignedNode: fakeNode2,
 				},
 			},
@@ -333,17 +339,22 @@ func TestCreateService(t *testing.T) {
 						"2.3.4.6": fakeNode2,
 					}),
 			},
-			serviceToCreate:          servicePolicyLocal,
-			healthyNodes:             []string{fakeNode1, fakeNode2},
-			expectedCalls:            func(mockIPAssigner *ipassignertest.MockIPAssigner) {},
-			expectedExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{},
-			expectError:              true,
+			serviceToCreate: servicePolicyLocal,
+			healthyNodes:    []string{fakeNode1, fakeNode2},
+			expectedCalls:   func(mockIPAssigner *ipassignertest.MockIPAssigner) {},
+			expectedExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
+				keyFor(servicePolicyLocal): {
+					ip:     fakeServiceExternalIP1,
+					ipPool: fakeExternalIPPoolName,
+				},
+			},
+			expectError: true,
 		},
 		{
 			name:              "new Service created and local Node selected and IP already assigned by other Service",
 			existingEndpoints: nil,
 			previousExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
-				keyFor(servicePolicyLocal): {fakeServiceExternalIP1, fakeNode1},
+				keyFor(servicePolicyLocal): {fakeServiceExternalIP1, fakeExternalIPPoolName, fakeNode1},
 			},
 			serviceToCreate: servicePolicyCluster,
 			healthyNodes:    []string{fakeNode1, fakeNode2},
@@ -351,10 +362,12 @@ func TestCreateService(t *testing.T) {
 			expectedExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
 				keyFor(servicePolicyLocal): {
 					ip:           fakeServiceExternalIP1,
+					ipPool:       fakeExternalIPPoolName,
 					assignedNode: fakeNode1,
 				},
 				keyFor(servicePolicyCluster): {
 					ip:           fakeServiceExternalIP1,
+					ipPool:       fakeExternalIPPoolName,
 					assignedNode: fakeNode1,
 				},
 			},
@@ -405,12 +418,6 @@ func TestUpdateService(t *testing.T) {
 	serviceExternalTrafficPolicyClusterWithSameExternalIP.Name = "svc-same-eip"
 	serviceExternalTrafficPolicyClusterWithSameExternalIP.Status.LoadBalancer.Ingress[0].IP = fakeServiceExternalIP2
 
-	serviceExternalTrafficLocalWithNodeSelected := servicePolicyLocal.DeepCopy()
-	serviceExternalTrafficLocalWithNodeSelected.Status.LoadBalancer.Ingress[0].Hostname = fakeNode1
-
-	serviceExternalTrafficLocalUpdatedHostname := servicePolicyLocal.DeepCopy()
-	serviceExternalTrafficLocalUpdatedHostname.Status.LoadBalancer.Ingress[0].Hostname = fakeNode2
-
 	serviceChangedType := servicePolicyCluster.DeepCopy()
 	serviceChangedType.Spec.Type = corev1.ServiceTypeClusterIP
 
@@ -436,10 +443,10 @@ func TestUpdateService(t *testing.T) {
 			endpoints:       nil,
 			serviceToUpdate: serviceExternalTrafficPolicyClusterUpdatedExternalIP,
 			previousExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
-				keyFor(serviceExternalTrafficPolicyClusterUpdatedExternalIP): {fakeServiceExternalIP1, fakeNode1},
+				keyFor(serviceExternalTrafficPolicyClusterUpdatedExternalIP): {fakeServiceExternalIP1, fakeExternalIPPoolName, fakeNode1},
 			},
 			expectedExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
-				keyFor(serviceExternalTrafficPolicyClusterUpdatedExternalIP): {fakeServiceExternalIP2, fakeNode1},
+				keyFor(serviceExternalTrafficPolicyClusterUpdatedExternalIP): {fakeServiceExternalIP2, fakeExternalIPPoolName, fakeNode1},
 			},
 			healthyNodes: []string{fakeNode1, fakeNode2},
 			expectedCalls: func(mockIPAssigner *ipassignertest.MockIPAssigner) {
@@ -453,12 +460,12 @@ func TestUpdateService(t *testing.T) {
 			endpoints:       nil,
 			serviceToUpdate: serviceExternalTrafficPolicyClusterUpdatedExternalIP,
 			previousExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
-				keyFor(serviceExternalTrafficPolicyClusterWithSameExternalIP): {fakeServiceExternalIP1, fakeNode1},
-				keyFor(serviceExternalTrafficPolicyClusterUpdatedExternalIP):  {fakeServiceExternalIP1, fakeNode1},
+				keyFor(serviceExternalTrafficPolicyClusterWithSameExternalIP): {fakeServiceExternalIP1, fakeExternalIPPoolName, fakeNode1},
+				keyFor(serviceExternalTrafficPolicyClusterUpdatedExternalIP):  {fakeServiceExternalIP1, fakeExternalIPPoolName, fakeNode1},
 			},
 			expectedExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
-				keyFor(serviceExternalTrafficPolicyClusterWithSameExternalIP): {fakeServiceExternalIP1, fakeNode1},
-				keyFor(serviceExternalTrafficPolicyClusterUpdatedExternalIP):  {fakeServiceExternalIP2, fakeNode1},
+				keyFor(serviceExternalTrafficPolicyClusterWithSameExternalIP): {fakeServiceExternalIP1, fakeExternalIPPoolName, fakeNode1},
+				keyFor(serviceExternalTrafficPolicyClusterUpdatedExternalIP):  {fakeServiceExternalIP2, fakeExternalIPPoolName, fakeNode1},
 			},
 			healthyNodes: []string{fakeNode1, fakeNode2},
 			expectedCalls: func(mockIPAssigner *ipassignertest.MockIPAssigner) {
@@ -471,10 +478,10 @@ func TestUpdateService(t *testing.T) {
 			endpoints:       nil,
 			serviceToUpdate: serviceExternalTrafficPolicyClusterUpdatedExternalIP,
 			previousExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
-				keyFor(serviceExternalTrafficPolicyClusterUpdatedExternalIP): {fakeServiceExternalIP1, fakeNode1},
+				keyFor(serviceExternalTrafficPolicyClusterUpdatedExternalIP): {fakeServiceExternalIP1, fakeExternalIPPoolName, fakeNode1},
 			},
 			expectedExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
-				keyFor(serviceExternalTrafficPolicyClusterUpdatedExternalIP): {fakeServiceExternalIP2, fakeNode2},
+				keyFor(serviceExternalTrafficPolicyClusterUpdatedExternalIP): {fakeServiceExternalIP2, fakeExternalIPPoolName, fakeNode2},
 			},
 			healthyNodes:   []string{fakeNode1, fakeNode2},
 			overrideHashFn: fakeHashFn(true),
@@ -488,7 +495,7 @@ func TestUpdateService(t *testing.T) {
 			endpoints:       nil,
 			serviceToUpdate: serviceChangedType,
 			previousExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
-				keyFor(serviceExternalTrafficPolicyClusterUpdatedExternalIP): {fakeServiceExternalIP1, fakeNode1},
+				keyFor(serviceExternalTrafficPolicyClusterUpdatedExternalIP): {fakeServiceExternalIP1, fakeExternalIPPoolName, fakeNode1},
 			},
 			expectedExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{},
 			healthyNodes:             []string{fakeNode1, fakeNode2},
@@ -502,7 +509,7 @@ func TestUpdateService(t *testing.T) {
 			endpoints:       nil,
 			serviceToUpdate: serviceChangedType,
 			previousExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
-				keyFor(serviceExternalTrafficPolicyClusterUpdatedExternalIP): {fakeServiceExternalIP1, fakeNode1},
+				keyFor(serviceExternalTrafficPolicyClusterUpdatedExternalIP): {fakeServiceExternalIP1, fakeExternalIPPoolName, fakeNode1},
 			},
 			expectedExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{},
 			healthyNodes:             []string{fakeNode1, fakeNode2},
@@ -523,10 +530,10 @@ func TestUpdateService(t *testing.T) {
 			},
 			serviceToUpdate: serviceChangedExternalTrafficPolicy,
 			previousExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
-				keyFor(serviceChangedExternalTrafficPolicy): {fakeServiceExternalIP1, fakeNode1},
+				keyFor(serviceChangedExternalTrafficPolicy): {fakeServiceExternalIP1, fakeExternalIPPoolName, fakeNode1},
 			},
 			expectedExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
-				keyFor(serviceChangedExternalTrafficPolicy): {fakeServiceExternalIP1, fakeNode2},
+				keyFor(serviceChangedExternalTrafficPolicy): {fakeServiceExternalIP1, fakeExternalIPPoolName, fakeNode2},
 			},
 			healthyNodes: []string{fakeNode1, fakeNode2},
 			expectedCalls: func(mockIPAssigner *ipassignertest.MockIPAssigner) {
@@ -539,10 +546,10 @@ func TestUpdateService(t *testing.T) {
 			endpoints:       nil,
 			serviceToUpdate: servicePolicyCluster,
 			previousExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
-				keyFor(servicePolicyCluster): {fakeServiceExternalIP1, fakeNode1},
+				keyFor(servicePolicyCluster): {fakeServiceExternalIP1, fakeExternalIPPoolName, fakeNode1},
 			},
 			expectedExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
-				keyFor(servicePolicyCluster): {fakeServiceExternalIP1, fakeNode2},
+				keyFor(servicePolicyCluster): {fakeServiceExternalIP1, fakeExternalIPPoolName, fakeNode2},
 			},
 			healthyNodes:   []string{fakeNode1, fakeNode2},
 			overrideHashFn: fakeHashFn(true),
@@ -561,86 +568,16 @@ func TestUpdateService(t *testing.T) {
 						"2.3.4.5": fakeNode1,
 					}),
 			},
-			serviceToUpdate: serviceExternalTrafficLocalWithNodeSelected,
+			serviceToUpdate: servicePolicyLocal,
 			previousExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
-				keyFor(servicePolicyLocal): {fakeServiceExternalIP1, fakeNode1},
+				keyFor(servicePolicyLocal): {fakeServiceExternalIP1, fakeExternalIPPoolName, fakeNode1},
 			},
 			expectedExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
-				keyFor(servicePolicyLocal): {fakeServiceExternalIP1, fakeNode2},
+				keyFor(servicePolicyLocal): {fakeServiceExternalIP1, fakeExternalIPPoolName, fakeNode2},
 			},
 			healthyNodes: []string{fakeNode1, fakeNode2},
 			expectedCalls: func(mockIPAssigner *ipassignertest.MockIPAssigner) {
 				mockIPAssigner.EXPECT().UnassignIP(fakeServiceExternalIP1)
-			},
-			expectError: false,
-		},
-		{
-			name: "should not migrate to other Nodes if selected Node still have healthy endpoints",
-			endpoints: []*corev1.Endpoints{
-				makeEndpoints(servicePolicyLocal.Name, servicePolicyLocal.Namespace,
-					map[string]string{
-						"2.3.4.5": fakeNode1,
-						"2.3.4.6": fakeNode2,
-					},
-					nil,
-				),
-			},
-			overrideHashFn:  fakeHashFn(true),
-			serviceToUpdate: serviceExternalTrafficLocalWithNodeSelected,
-			previousExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
-				keyFor(servicePolicyLocal): {fakeServiceExternalIP1, fakeNode1},
-			},
-			expectedExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
-				keyFor(servicePolicyLocal): {fakeServiceExternalIP1, fakeNode1},
-			},
-			healthyNodes:  []string{fakeNode1, fakeNode2},
-			expectedCalls: func(mockIPAssigner *ipassignertest.MockIPAssigner) {},
-			expectError:   false,
-		},
-		{
-			name: "other Node could promote itself as the new owner",
-			endpoints: []*corev1.Endpoints{
-				makeEndpoints(servicePolicyLocal.Name, servicePolicyLocal.Namespace,
-					map[string]string{
-						"2.3.4.5": fakeNode1,
-						"2.3.4.6": fakeNode2,
-					},
-					nil,
-				),
-			},
-			serviceToUpdate: serviceExternalTrafficLocalUpdatedHostname,
-			previousExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
-				keyFor(servicePolicyLocal): {fakeServiceExternalIP1, fakeNode1},
-			},
-			expectedExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
-				keyFor(servicePolicyLocal): {fakeServiceExternalIP1, fakeNode2},
-			},
-			healthyNodes: []string{fakeNode1, fakeNode2},
-			expectedCalls: func(mockIPAssigner *ipassignertest.MockIPAssigner) {
-				mockIPAssigner.EXPECT().UnassignIP(fakeServiceExternalIP1)
-			},
-			expectError: false,
-		},
-		{
-			name: "agent restarts and should not select new Node if current selected Node still healthy and have healthy endpoints",
-			endpoints: []*corev1.Endpoints{
-				makeEndpoints(servicePolicyLocal.Name, servicePolicyLocal.Namespace,
-					map[string]string{
-						"2.3.4.5": fakeNode1,
-						"2.3.4.6": fakeNode2,
-					},
-					nil,
-				),
-			},
-			overrideHashFn:           fakeHashFn(true),
-			serviceToUpdate:          serviceExternalTrafficLocalWithNodeSelected,
-			previousExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{},
-			expectedExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
-				keyFor(servicePolicyLocal): {fakeServiceExternalIP1, fakeNode1},
-			},
-			healthyNodes: []string{fakeNode1, fakeNode2},
-			expectedCalls: func(mockIPAssigner *ipassignertest.MockIPAssigner) {
-				mockIPAssigner.EXPECT().AssignIP(fakeServiceExternalIP1)
 			},
 			expectError: false,
 		},
@@ -760,6 +697,69 @@ func TestServiceExternalIPController_nodesHasHealthyServiceEndpoint(t *testing.T
 			got, err := c.nodesHasHealthyServiceEndpoint(tt.serviceToTest)
 			assert.NoError(t, err)
 			assert.True(t, tt.expectedHealthyNodes.Equal(got), "Expected healthy Nodes %v, got %v", tt.expectedHealthyNodes, got)
+		})
+	}
+}
+
+func TestServiceExternalIPController_GetServiceExternalIPStatus(t *testing.T) {
+	tests := []struct {
+		name                          string
+		externalIPStates              map[apimachinerytypes.NamespacedName]externalIPState
+		expectedServiceExternalIPInfo []querier.ServiceExternalIPInfo
+	}{
+		{
+			name:                          "no Service available should return empty slice",
+			externalIPStates:              map[apimachinerytypes.NamespacedName]externalIPState{},
+			expectedServiceExternalIPInfo: []querier.ServiceExternalIPInfo{},
+		},
+		{
+			name: "one Service processed",
+			externalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
+				keyFor(servicePolicyCluster): {fakeServiceExternalIP1, fakeExternalIPPoolName, fakeNode1},
+			},
+			expectedServiceExternalIPInfo: []querier.ServiceExternalIPInfo{
+				{
+
+					ServiceName:    servicePolicyCluster.Name,
+					Namespace:      servicePolicyCluster.Namespace,
+					ExternalIP:     fakeServiceExternalIP1,
+					ExternalIPPool: fakeExternalIPPoolName,
+					AssignedNode:   fakeNode1,
+				},
+			},
+		},
+		{
+			name: "two Services processed",
+			externalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
+				keyFor(servicePolicyCluster): {fakeServiceExternalIP1, fakeExternalIPPoolName, fakeNode1},
+				keyFor(servicePolicyLocal):   {fakeServiceExternalIP2, fakeExternalIPPoolName, fakeNode2},
+			},
+			expectedServiceExternalIPInfo: []querier.ServiceExternalIPInfo{
+				{
+
+					ServiceName:    servicePolicyCluster.Name,
+					Namespace:      servicePolicyCluster.Namespace,
+					ExternalIP:     fakeServiceExternalIP1,
+					ExternalIPPool: fakeExternalIPPoolName,
+					AssignedNode:   fakeNode1,
+				},
+				{
+
+					ServiceName:    servicePolicyLocal.Name,
+					Namespace:      servicePolicyLocal.Namespace,
+					ExternalIP:     fakeServiceExternalIP2,
+					ExternalIPPool: fakeExternalIPPoolName,
+					AssignedNode:   fakeNode2,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newFakeController(t)
+			c.externalIPStates = tt.externalIPStates
+			got := c.ServiceExternalIPController.GetServiceExternalIPStatus()
+			assert.ElementsMatch(t, tt.expectedServiceExternalIPInfo, got)
 		})
 	}
 }

--- a/pkg/antctl/antctl.go
+++ b/pkg/antctl/antctl.go
@@ -21,6 +21,7 @@ import (
 	"antrea.io/antrea/pkg/agent/apiserver/handlers/agentinfo"
 	"antrea.io/antrea/pkg/agent/apiserver/handlers/ovsflows"
 	"antrea.io/antrea/pkg/agent/apiserver/handlers/podinterface"
+	"antrea.io/antrea/pkg/agent/apiserver/handlers/serviceexternalip"
 	"antrea.io/antrea/pkg/agent/openflow"
 	fallbackversion "antrea.io/antrea/pkg/antctl/fallback/version"
 	"antrea.io/antrea/pkg/antctl/raw/featuregates"
@@ -508,6 +509,32 @@ var CommandList = &commandList{
 				},
 			},
 			transformedResponse: reflect.TypeOf(recordmetrics.Response{}),
+		},
+		{
+			use:          "serviceexternalip",
+			short:        "Print Service external IP status",
+			long:         "Print Service external IP status. It includes the external IP, external IP pool and the assigned Node for Services with type LoadBalancer managed by Antrea",
+			commandGroup: get,
+			aliases:      []string{"seip", "serviceexternalips"},
+			agentEndpoint: &endpoint{
+				nonResourceEndpoint: &nonResourceEndpoint{
+					path: "/serviceexternalip",
+					params: []flagInfo{
+						{
+							name:  "name",
+							usage: "Name of the Service; if present, Namespace must be provided as well.",
+							arg:   true,
+						},
+						{
+							name:      "namespace",
+							usage:     "Only get the external IP status for Services in the provided Namespace.",
+							shorthand: "n",
+						},
+					},
+					outputType: multiple,
+				},
+			},
+			transformedResponse: reflect.TypeOf(serviceexternalip.Response{}),
 		},
 	},
 	rawCommands: []rawCommand{

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -90,3 +90,19 @@ type NetworkPolicyQueryFilter struct {
 	// The type of the original NetworkPolicy that the internal NetworkPolicy is created for.(K8sNP, CNP, ANP)
 	SourceType cpv1beta.NetworkPolicyType
 }
+
+// ServiceExternalIPStatusQuerier queries the Service external IP status for debugging purposes.
+// Ideally, every Node should have consistent results eventually. This should only be used when
+// ServiceExternalIP feature is enabled.
+type ServiceExternalIPStatusQuerier interface {
+	GetServiceExternalIPStatus() []ServiceExternalIPInfo
+}
+
+// ServiceExternalIPInfo contains the essential information for Services with type of Loadbalancer managed by Antrea.
+type ServiceExternalIPInfo struct {
+	ServiceName    string `json:"serviceName,omitempty" antctl:"name,Name of the Service"`
+	Namespace      string `json:"namespace,omitempty"`
+	ExternalIP     string `json:"externalIP,omitempty"`
+	ExternalIPPool string `json:"externalIPPool,omitempty"`
+	AssignedNode   string `json:"assignedNode,omitempty"`
+}

--- a/test/e2e/antctl_test.go
+++ b/test/e2e/antctl_test.go
@@ -113,7 +113,7 @@ func testAntctlAgentLocalAccess(t *testing.T, data *TestData) {
 		cmd := strings.Join(args, " ")
 		t.Run(cmd, func(t *testing.T) {
 			stdout, stderr, err := runAntctl(podName, args, data)
-			if err != nil {
+			if err != nil && !strings.HasSuffix(stderr, "not enabled\n") {
 				t.Fatalf("Error when running `antctl %s` from %s: %v\n%s", c, podName, err, antctlOutput(stdout, stderr))
 			}
 		})


### PR DESCRIPTION
Remove the update permission for services/status of antrea-agent
service account. Remove the optimization for ExternalTrafficPolicy
setting to Local cases in ServiceExternalIP feature accordingly.

Signed-off-by: Xu Liu <xliu2@vmware.com>