### PR TITLE
Use default dnsPolicy for AKS

### DIFF
--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -3475,7 +3475,7 @@ spec:
         component: antrea-agent
     spec:
       hostNetwork: true
-      dnsPolicy: ClusterFirstWithHostNet
+      dnsPolicy: ClusterFirst
       priorityClassName: system-node-critical
       nodeSelector:
         kubernetes.io/os: linux

--- a/build/yamls/chart-values/antrea-aks.yml
+++ b/build/yamls/chart-values/antrea-aks.yml
@@ -1,1 +1,3 @@
 trafficEncapMode: "networkPolicyOnly"
+agent:
+  dnsPolicy: "ClusterFirst"


### PR DESCRIPTION
AKS overrides KUBERNETES_SERVICE_HOST with a FQDN value. Using
ClusterFirstWithHostNet would lead to antrea-agent start failure.

Signed-off-by: Quan Tian <qtian@vmware.com>

For #3699