### PR TITLE
Fix nil pointer dereference in networkPolicy only mode

### DIFF
--- a/pkg/agent/cniserver/server.go
+++ b/pkg/agent/cniserver/server.go
@@ -204,7 +204,10 @@ func (s *CNIServer) isCNIVersionSupported(reqVersion string) bool {
 }
 
 func (s *CNIServer) valiateCNIAndIPAMType(cniConfig *CNIConfig) *cnipb.CniCmdResponse {
-	ipamType := cniConfig.IPAM.Type
+	var ipamType string
+	if cniConfig.IPAM != nil {
+		ipamType = cniConfig.IPAM.Type
+	}
 	if cniConfig.Type == antreaCNIType {
 		if s.isChaining {
 			return nil


### PR DESCRIPTION
In networkPolicy only mode, Antrea is not reponsible for IPAM so ipam
field in cni conf is not set. The code that reads ipam type would panic
if it doesn't check nil first.

Signed-off-by: Quan Tian <qtian@vmware.com>

For #3699