### PR TITLE
Make pre-commit hook script executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ GRPID   := $(shell id -g)
 .PHONY: install-hooks
 install-hooks:
 	@echo "===> Copying Antrea git hooks to local <==="
-	cp hack/git_client_side_hooks/pre-commit .git/hooks/
+	install hack/git_client_side_hooks/pre-commit .git/hooks/
 
 .PHONY: uninstall-hooks
 uninstall-hooks:


### PR DESCRIPTION
The script is currently not executable, which gives an error when
committing:
```
hint: The '.git/hooks/pre-commit' hook was ignored because it's not set as executable.
hint: You can disable this warning with `git config advice.ignoredHook false`.
```

Signed-off-by: Antonin Bas <abas@vmware.com>