### PR TITLE
[ExternalNode] Support applying ANP to ExternalEntity

### DIFF
--- a/build/charts/antrea/templates/crds/networkpolicy.yaml
+++ b/build/charts/antrea/templates/crds/networkpolicy.yaml
@@ -57,6 +57,30 @@ spec:
                     type: object
                     # Ensure that Spec.AppliedTo does not allow NamespaceSelector/IPBlock field
                     properties:
+                      externalEntitySelector:
+                        type: object
+                        properties:
+                          matchExpressions:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                key:
+                                  type: string
+                                operator:
+                                  enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                  type: string
+                                values:
+                                  type: array
+                                  items:
+                                    type: string
+                                    pattern: "^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$"
+                          matchLabels:
+                            x-kubernetes-preserve-unknown-fields: true
                       podSelector:
                         type: object
                         properties:

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -1819,6 +1819,30 @@ spec:
                     type: object
                     # Ensure that Spec.AppliedTo does not allow NamespaceSelector/IPBlock field
                     properties:
+                      externalEntitySelector:
+                        type: object
+                        properties:
+                          matchExpressions:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                key:
+                                  type: string
+                                operator:
+                                  enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                  type: string
+                                values:
+                                  type: array
+                                  items:
+                                    type: string
+                                    pattern: "^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$"
+                          matchLabels:
+                            x-kubernetes-preserve-unknown-fields: true
                       podSelector:
                         type: object
                         properties:

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -1819,6 +1819,30 @@ spec:
                     type: object
                     # Ensure that Spec.AppliedTo does not allow NamespaceSelector/IPBlock field
                     properties:
+                      externalEntitySelector:
+                        type: object
+                        properties:
+                          matchExpressions:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                key:
+                                  type: string
+                                operator:
+                                  enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                  type: string
+                                values:
+                                  type: array
+                                  items:
+                                    type: string
+                                    pattern: "^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$"
+                          matchLabels:
+                            x-kubernetes-preserve-unknown-fields: true
                       podSelector:
                         type: object
                         properties:

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -1819,6 +1819,30 @@ spec:
                     type: object
                     # Ensure that Spec.AppliedTo does not allow NamespaceSelector/IPBlock field
                     properties:
+                      externalEntitySelector:
+                        type: object
+                        properties:
+                          matchExpressions:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                key:
+                                  type: string
+                                operator:
+                                  enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                  type: string
+                                values:
+                                  type: array
+                                  items:
+                                    type: string
+                                    pattern: "^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$"
+                          matchLabels:
+                            x-kubernetes-preserve-unknown-fields: true
                       podSelector:
                         type: object
                         properties:

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -1832,6 +1832,30 @@ spec:
                     type: object
                     # Ensure that Spec.AppliedTo does not allow NamespaceSelector/IPBlock field
                     properties:
+                      externalEntitySelector:
+                        type: object
+                        properties:
+                          matchExpressions:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                key:
+                                  type: string
+                                operator:
+                                  enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                  type: string
+                                values:
+                                  type: array
+                                  items:
+                                    type: string
+                                    pattern: "^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$"
+                          matchLabels:
+                            x-kubernetes-preserve-unknown-fields: true
                       podSelector:
                         type: object
                         properties:

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -1819,6 +1819,30 @@ spec:
                     type: object
                     # Ensure that Spec.AppliedTo does not allow NamespaceSelector/IPBlock field
                     properties:
+                      externalEntitySelector:
+                        type: object
+                        properties:
+                          matchExpressions:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                key:
+                                  type: string
+                                operator:
+                                  enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                  type: string
+                                values:
+                                  type: array
+                                  items:
+                                    type: string
+                                    pattern: "^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$"
+                          matchLabels:
+                            x-kubernetes-preserve-unknown-fields: true
                       podSelector:
                         type: object
                         properties:


### PR DESCRIPTION
Add externalEntitySelector in ANP appliedTo field. ACNP is not
supported for EntitySelector yet.

Signed-off-by: wenyingd <wenyingd@vmware.com>