### PR TITLE
Add validate egress.to.namespaces.match of AntreaClusterNetworkPolicy rules

### DIFF
--- a/build/charts/antrea/templates/crds/clusternetworkpolicy.yaml
+++ b/build/charts/antrea/templates/crds/clusternetworkpolicy.yaml
@@ -494,6 +494,8 @@ spec:
                               type: object
                               properties:
                                 match:
+                                  enum:
+                                    - Self
                                   type: string
                             ipBlock:
                               type: object

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -1245,6 +1245,8 @@ spec:
                               type: object
                               properties:
                                 match:
+                                  enum:
+                                    - Self
                                   type: string
                             ipBlock:
                               type: object

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -1245,6 +1245,8 @@ spec:
                               type: object
                               properties:
                                 match:
+                                  enum:
+                                    - Self
                                   type: string
                             ipBlock:
                               type: object

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -1245,6 +1245,8 @@ spec:
                               type: object
                               properties:
                                 match:
+                                  enum:
+                                    - Self
                                   type: string
                             ipBlock:
                               type: object

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -1258,6 +1258,8 @@ spec:
                               type: object
                               properties:
                                 match:
+                                  enum:
+                                    - Self
                                   type: string
                             ipBlock:
                               type: object

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -1245,6 +1245,8 @@ spec:
                               type: object
                               properties:
                                 match:
+                                  enum:
+                                    - Self
                                   type: string
                             ipBlock:
                               type: object


### PR DESCRIPTION
This is an addition to Validate namespaces.match of AntreaClusterNetworkPolicy rules [#3109](https://github.com/antrea-io/antrea/pull/3109), the PR validated ingress.from, this PR adds the same validation to egress.to.

Signed-off-by: Qiyue Yao <yaoq@vmware.com>