### PR TITLE
Fix identification of control-plane Node in e2e test framework

### DIFF
--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -417,6 +417,15 @@ func (data *TestData) RunCommandOnNodeExt(nodeName, cmd string, envs map[string]
 }
 
 func (data *TestData) collectClusterInfo() error {
+	// retrieve K8s server version
+	// this needs to be done first, as there may be dependencies on the
+	// version later in this function (e.g., for labelNodeRoleControlPlane()).
+	serverVersion, err := testData.clientset.Discovery().ServerVersion()
+	if err != nil {
+		return err
+	}
+	clusterInfo.k8sServerVersion = serverVersion.String()
+
 	// retrieve Node information
 	nodes, err := testData.clientset.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
@@ -559,14 +568,6 @@ func (data *TestData) collectClusterInfo() error {
 	}
 	clusterInfo.svcV4NetworkCIDR = svcCIDRs[0]
 	clusterInfo.svcV6NetworkCIDR = svcCIDRs[1]
-
-	// retrieve K8s server version
-
-	serverVersion, err := testData.clientset.Discovery().ServerVersion()
-	if err != nil {
-		return err
-	}
-	clusterInfo.k8sServerVersion = serverVersion.String()
 
 	// Retrieve kubernetes Service host and Port
 	svc, err := testData.clientset.CoreV1().Services("default").Get(context.TODO(), "kubernetes", metav1.GetOptions{})


### PR DESCRIPTION
We use the `node-role.kubernetes.io/<ROLE>` label to identify the
control-plane Node. The `<ROLE>` we use needs to depend on the K8s
version because:
- before K8s v1.20, the label is `node-role.kubernetes.io/master`
- starting with K8s v1.24, the label is `node-role.kubernetes.io/control-plane`.
- in between, both labels are used by K8s

However, the function used to determine the correct label to use based
on the K8s version was called *before* the K8s server version was
actually determined, so it was always returning
`node-role.kubernetes.io/master`. This was causing tests to fail for K8s
v1.24 (which has just been released), since the label no longer exists
in that version.

Signed-off-by: Antonin Bas <abas@vmware.com>