### PR TITLE
Use Service ClusterIPs as MC Service's Endpoints

### DIFF
--- a/build/charts/antrea/README.md
+++ b/build/charts/antrea/README.md
@@ -78,6 +78,8 @@ Kubernetes: `>= 1.16.0-0`
 | logVerbosity | int | `0` |  |
 | multicast.igmpQueryInterval | string | `"125s"` | The interval at which the antrea-agent sends IGMP queries to Pods. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". |
 | multicast.multicastInterfaces | list | `[]` | Names of the interfaces on Nodes that are used to forward multicast traffic. |
+| multicluster.enable | bool | `false` | Enable Antrea Multi-cluster Gateway to support cross-cluster traffic. This feature is supported only with encap mode. |
+| multicluster.namespace | string | `""` | The Namespace where Antrea Multi-cluster Controller is running. 'kube-system' will be used by default if it's empty. |
 | noSNAT | bool | `false` | Whether or not to SNAT (using the Node IP) the egress traffic from a Pod to the external network. |
 | nodeIPAM.clusterCIDRs | list | `[]` | CIDR ranges to use when allocating Pod IP addresses. |
 | nodeIPAM.enable | bool | `false` | Enable Node IPAM in Antrea |

--- a/build/charts/antrea/conf/antrea-agent.conf
+++ b/build/charts/antrea/conf/antrea-agent.conf
@@ -39,6 +39,10 @@ featureGates:
 # Enable multicast traffic. This feature is supported only with noEncap mode.
 {{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "Multicast" "default" false) }}
 
+# Enable Antrea Multi-cluster Gateway to support cross-cluster traffic.
+# This feature is supported only with encap mode.
+{{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "Multicluster" "default" false) }}
+
 # Enable support for provisioning secondary network interfaces for Pods (using
 # Pod annotations). At the moment, Antrea can only create secondary network
 # interfaces using SR-IOV VFs on baremetal Nodes.
@@ -278,4 +282,14 @@ antreaProxy:
   # Note that setting ProxyLoadBalancerIPs to false usually only makes sense when ProxyAll is set to true and
   # kube-proxy is removed from the cluser, otherwise kube-proxy will still load-balance this traffic.
   proxyLoadBalancerIPs: {{ .proxyLoadBalancerIPs }}
+{{- end }}
+
+multicluster:
+{{- with .Values.multicluster }}
+# Enable Antrea Multi-cluster Gateway to support cross-cluster traffic.
+# This feature is supported only with encap mode.
+  enable: {{ .enable }}
+# The Namespace where Antrea Multi-cluster Controller is running.
+# 'kube-system' will be used by default if it's empty.
+  namespace: {{ .namespace | quote }}
 {{- end }}

--- a/build/charts/antrea/templates/agent/clusterrole.yaml
+++ b/build/charts/antrea/templates/agent/clusterrole.yaml
@@ -180,3 +180,19 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+    - multicluster.crd.antrea.io
+    resources:
+    - gateways
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - multicluster.crd.antrea.io
+    resources:
+    - clusterinfoimports
+    verbs:
+    - get
+    - list
+    - watch

--- a/build/charts/antrea/values.yaml
+++ b/build/charts/antrea/values.yaml
@@ -273,6 +273,15 @@ logVerbosity: 0
 whereabouts:
   enable: false
 
+## -- Configure Multicluster, for use by the antrea-agent.
+multicluster:
+  # -- Enable Antrea Multi-cluster Gateway to support cross-cluster traffic.
+  # This feature is supported only with encap mode.
+  enable: false
+  # -- The Namespace where Antrea Multi-cluster Controller is running.
+  # 'kube-system' will be used by default if it's empty.
+  namespace: ""
+
 testing:
   ## -- enable code coverage measurement (used when testing Antrea only).
   coverage: false

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -55,7 +55,7 @@ metadata:
   labels:
     app: antrea
 data:
-  antrea-agent.conf: |
+  antrea-agent.conf: |-
     # FeatureGates is a map of feature names to bools that enable or disable experimental features.
     featureGates:
     # Enable AntreaProxy which provides ServiceLB for in-cluster Services in antrea-agent.
@@ -96,6 +96,10 @@ data:
 
     # Enable multicast traffic. This feature is supported only with noEncap mode.
     #  Multicast: false
+
+    # Enable Antrea Multi-cluster Gateway to support cross-cluster traffic.
+    # This feature is supported only with encap mode.
+    #  Multicluster: false
 
     # Enable support for provisioning secondary network interfaces for Pods (using
     # Pod annotations). At the moment, Antrea can only create secondary network
@@ -312,6 +316,14 @@ data:
       # Note that setting ProxyLoadBalancerIPs to false usually only makes sense when ProxyAll is set to true and
       # kube-proxy is removed from the cluser, otherwise kube-proxy will still load-balance this traffic.
       proxyLoadBalancerIPs: true
+
+    multicluster:
+    # Enable Antrea Multi-cluster Gateway to support cross-cluster traffic.
+    # This feature is supported only with encap mode.
+      enable: false
+    # The Namespace where Antrea Multi-cluster Controller is running.
+    # 'kube-system' will be used by default if it's empty.
+      namespace: ""
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -2996,6 +3008,22 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+    - multicluster.crd.antrea.io
+    resources:
+    - gateways
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - multicluster.crd.antrea.io
+    resources:
+    - clusterinfoimports
+    verbs:
+    - get
+    - list
+    - watch
 ---
 # Source: antrea/templates/antctl/clusterrole.yaml
 kind: ClusterRole
@@ -3496,7 +3524,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: fd449f30e949fff2d22ed79bca0a040535429c5b605b7b93dfdbfd3b359115ae
+        checksum/config: ba66e59fdd6eaf473d294b55615319b0bf31c0774eef88b8fbbe2afaa6fb6d0e
       labels:
         app: antrea
         component: antrea-agent
@@ -3736,7 +3764,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: fd449f30e949fff2d22ed79bca0a040535429c5b605b7b93dfdbfd3b359115ae
+        checksum/config: ba66e59fdd6eaf473d294b55615319b0bf31c0774eef88b8fbbe2afaa6fb6d0e
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -55,7 +55,7 @@ metadata:
   labels:
     app: antrea
 data:
-  antrea-agent.conf: |
+  antrea-agent.conf: |-
     # FeatureGates is a map of feature names to bools that enable or disable experimental features.
     featureGates:
     # Enable AntreaProxy which provides ServiceLB for in-cluster Services in antrea-agent.
@@ -96,6 +96,10 @@ data:
 
     # Enable multicast traffic. This feature is supported only with noEncap mode.
     #  Multicast: false
+
+    # Enable Antrea Multi-cluster Gateway to support cross-cluster traffic.
+    # This feature is supported only with encap mode.
+    #  Multicluster: false
 
     # Enable support for provisioning secondary network interfaces for Pods (using
     # Pod annotations). At the moment, Antrea can only create secondary network
@@ -312,6 +316,14 @@ data:
       # Note that setting ProxyLoadBalancerIPs to false usually only makes sense when ProxyAll is set to true and
       # kube-proxy is removed from the cluser, otherwise kube-proxy will still load-balance this traffic.
       proxyLoadBalancerIPs: true
+
+    multicluster:
+    # Enable Antrea Multi-cluster Gateway to support cross-cluster traffic.
+    # This feature is supported only with encap mode.
+      enable: false
+    # The Namespace where Antrea Multi-cluster Controller is running.
+    # 'kube-system' will be used by default if it's empty.
+      namespace: ""
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -2996,6 +3008,22 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+    - multicluster.crd.antrea.io
+    resources:
+    - gateways
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - multicluster.crd.antrea.io
+    resources:
+    - clusterinfoimports
+    verbs:
+    - get
+    - list
+    - watch
 ---
 # Source: antrea/templates/antctl/clusterrole.yaml
 kind: ClusterRole
@@ -3496,7 +3524,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: fd449f30e949fff2d22ed79bca0a040535429c5b605b7b93dfdbfd3b359115ae
+        checksum/config: ba66e59fdd6eaf473d294b55615319b0bf31c0774eef88b8fbbe2afaa6fb6d0e
       labels:
         app: antrea
         component: antrea-agent
@@ -3738,7 +3766,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: fd449f30e949fff2d22ed79bca0a040535429c5b605b7b93dfdbfd3b359115ae
+        checksum/config: ba66e59fdd6eaf473d294b55615319b0bf31c0774eef88b8fbbe2afaa6fb6d0e
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -55,7 +55,7 @@ metadata:
   labels:
     app: antrea
 data:
-  antrea-agent.conf: |
+  antrea-agent.conf: |-
     # FeatureGates is a map of feature names to bools that enable or disable experimental features.
     featureGates:
     # Enable AntreaProxy which provides ServiceLB for in-cluster Services in antrea-agent.
@@ -96,6 +96,10 @@ data:
 
     # Enable multicast traffic. This feature is supported only with noEncap mode.
     #  Multicast: false
+
+    # Enable Antrea Multi-cluster Gateway to support cross-cluster traffic.
+    # This feature is supported only with encap mode.
+    #  Multicluster: false
 
     # Enable support for provisioning secondary network interfaces for Pods (using
     # Pod annotations). At the moment, Antrea can only create secondary network
@@ -312,6 +316,14 @@ data:
       # Note that setting ProxyLoadBalancerIPs to false usually only makes sense when ProxyAll is set to true and
       # kube-proxy is removed from the cluser, otherwise kube-proxy will still load-balance this traffic.
       proxyLoadBalancerIPs: true
+
+    multicluster:
+    # Enable Antrea Multi-cluster Gateway to support cross-cluster traffic.
+    # This feature is supported only with encap mode.
+      enable: false
+    # The Namespace where Antrea Multi-cluster Controller is running.
+    # 'kube-system' will be used by default if it's empty.
+      namespace: ""
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -2996,6 +3008,22 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+    - multicluster.crd.antrea.io
+    resources:
+    - gateways
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - multicluster.crd.antrea.io
+    resources:
+    - clusterinfoimports
+    verbs:
+    - get
+    - list
+    - watch
 ---
 # Source: antrea/templates/antctl/clusterrole.yaml
 kind: ClusterRole
@@ -3496,7 +3524,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 7e0d8c70d728f9f981756d8238d9b19a9c2321206b09a814a1cdb4ac604b190c
+        checksum/config: 3c212cbbcaeaaeafffe65493f0fdcfc2a6c6085b798af6db77464dcb9323dcec
       labels:
         app: antrea
         component: antrea-agent
@@ -3736,7 +3764,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 7e0d8c70d728f9f981756d8238d9b19a9c2321206b09a814a1cdb4ac604b190c
+        checksum/config: 3c212cbbcaeaaeafffe65493f0fdcfc2a6c6085b798af6db77464dcb9323dcec
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -68,7 +68,7 @@ metadata:
   labels:
     app: antrea
 data:
-  antrea-agent.conf: |
+  antrea-agent.conf: |-
     # FeatureGates is a map of feature names to bools that enable or disable experimental features.
     featureGates:
     # Enable AntreaProxy which provides ServiceLB for in-cluster Services in antrea-agent.
@@ -109,6 +109,10 @@ data:
 
     # Enable multicast traffic. This feature is supported only with noEncap mode.
     #  Multicast: false
+
+    # Enable Antrea Multi-cluster Gateway to support cross-cluster traffic.
+    # This feature is supported only with encap mode.
+    #  Multicluster: false
 
     # Enable support for provisioning secondary network interfaces for Pods (using
     # Pod annotations). At the moment, Antrea can only create secondary network
@@ -325,6 +329,14 @@ data:
       # Note that setting ProxyLoadBalancerIPs to false usually only makes sense when ProxyAll is set to true and
       # kube-proxy is removed from the cluser, otherwise kube-proxy will still load-balance this traffic.
       proxyLoadBalancerIPs: true
+
+    multicluster:
+    # Enable Antrea Multi-cluster Gateway to support cross-cluster traffic.
+    # This feature is supported only with encap mode.
+      enable: false
+    # The Namespace where Antrea Multi-cluster Controller is running.
+    # 'kube-system' will be used by default if it's empty.
+      namespace: ""
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -3009,6 +3021,22 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+    - multicluster.crd.antrea.io
+    resources:
+    - gateways
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - multicluster.crd.antrea.io
+    resources:
+    - clusterinfoimports
+    verbs:
+    - get
+    - list
+    - watch
 ---
 # Source: antrea/templates/antctl/clusterrole.yaml
 kind: ClusterRole
@@ -3509,7 +3537,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: d5038309e5a226d5d860b167b95e0d8ed55af1914526f52e5ef8600e527695e5
+        checksum/config: 206ebde029eea5ca9046181558ee7dc2e81cfa9bf62552c2f276aa66b1be32e9
         checksum/ipsec-secret: d0eb9c52d0cd4311b6d252a951126bf9bea27ec05590bed8a394f0f792dcb2a4
       labels:
         app: antrea
@@ -3785,7 +3813,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: d5038309e5a226d5d860b167b95e0d8ed55af1914526f52e5ef8600e527695e5
+        checksum/config: 206ebde029eea5ca9046181558ee7dc2e81cfa9bf62552c2f276aa66b1be32e9
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -55,7 +55,7 @@ metadata:
   labels:
     app: antrea
 data:
-  antrea-agent.conf: |
+  antrea-agent.conf: |-
     # FeatureGates is a map of feature names to bools that enable or disable experimental features.
     featureGates:
     # Enable AntreaProxy which provides ServiceLB for in-cluster Services in antrea-agent.
@@ -96,6 +96,10 @@ data:
 
     # Enable multicast traffic. This feature is supported only with noEncap mode.
     #  Multicast: false
+
+    # Enable Antrea Multi-cluster Gateway to support cross-cluster traffic.
+    # This feature is supported only with encap mode.
+    #  Multicluster: false
 
     # Enable support for provisioning secondary network interfaces for Pods (using
     # Pod annotations). At the moment, Antrea can only create secondary network
@@ -312,6 +316,14 @@ data:
       # Note that setting ProxyLoadBalancerIPs to false usually only makes sense when ProxyAll is set to true and
       # kube-proxy is removed from the cluser, otherwise kube-proxy will still load-balance this traffic.
       proxyLoadBalancerIPs: true
+
+    multicluster:
+    # Enable Antrea Multi-cluster Gateway to support cross-cluster traffic.
+    # This feature is supported only with encap mode.
+      enable: false
+    # The Namespace where Antrea Multi-cluster Controller is running.
+    # 'kube-system' will be used by default if it's empty.
+      namespace: ""
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -2996,6 +3008,22 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+    - multicluster.crd.antrea.io
+    resources:
+    - gateways
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - multicluster.crd.antrea.io
+    resources:
+    - clusterinfoimports
+    verbs:
+    - get
+    - list
+    - watch
 ---
 # Source: antrea/templates/antctl/clusterrole.yaml
 kind: ClusterRole
@@ -3496,7 +3524,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 03ee0481c65f3ec8ff9e879ff10c3cf65991a347a7aec1c9bc866b019ec470f1
+        checksum/config: fec25e3e166fc9cfb9388a309702ce54d18bd6fa7a3051ef6992a0423b62da95
       labels:
         app: antrea
         component: antrea-agent
@@ -3736,7 +3764,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 03ee0481c65f3ec8ff9e879ff10c3cf65991a347a7aec1c9bc866b019ec470f1
+        checksum/config: fec25e3e166fc9cfb9388a309702ce54d18bd6fa7a3051ef6992a0423b62da95
       labels:
         app: antrea
         component: antrea-controller

--- a/cmd/antrea-agent-simulator/simulator.go
+++ b/cmd/antrea-agent-simulator/simulator.go
@@ -38,7 +38,7 @@ import (
 
 func run() error {
 	klog.Infof("Starting Antrea agent simulator (version %s)", version.GetFullVersion())
-	k8sClient, _, _, _, err := k8s.CreateClients(componentbaseconfig.ClientConnectionConfiguration{}, "")
+	k8sClient, _, _, _, _, err := k8s.CreateClients(componentbaseconfig.ClientConnectionConfiguration{}, "")
 	if err != nil {
 		return fmt.Errorf("error creating K8s clients: %v", err)
 	}

--- a/cmd/antrea-agent/options.go
+++ b/cmd/antrea-agent/options.go
@@ -174,6 +174,11 @@ func (o *Options) validate(args []string) error {
 			}
 		}
 	}
+	if (features.DefaultFeatureGate.Enabled(features.Multicluster) || o.config.Multicluster.Enable) &&
+		encapMode != config.TrafficEncapModeEncap {
+		// Only Encap mode is supported for Multi-cluster feature.
+		return fmt.Errorf("Multicluster is only applicable to the %s mode", config.TrafficEncapModeEncap)
+	}
 	if features.DefaultFeatureGate.Enabled(features.NodePortLocal) {
 		startPort, endPort, err := parsePortRange(o.config.NodePortLocal.PortRange)
 		if err != nil {

--- a/cmd/antrea-controller/controller.go
+++ b/cmd/antrea-controller/controller.go
@@ -105,7 +105,7 @@ func run(o *Options) error {
 	// Create K8s Clientset, Aggregator Clientset, CRD Clientset and SharedInformerFactory for the given config.
 	// Aggregator Clientset is used to update the CABundle of the APIServices backed by antrea-controller so that
 	// the aggregator can verify its serving certificate.
-	client, aggregatorClient, crdClient, apiExtensionClient, err := k8s.CreateClients(o.config.ClientConnection, "")
+	client, aggregatorClient, crdClient, apiExtensionClient, _, err := k8s.CreateClients(o.config.ClientConnection, "")
 	if err != nil {
 		return fmt.Errorf("error creating K8s clients: %v", err)
 	}

--- a/multicluster/controllers/multicluster/common/helper.go
+++ b/multicluster/controllers/multicluster/common/helper.go
@@ -82,3 +82,29 @@ func FilterEndpointSubsets(subsets []corev1.EndpointSubset) []corev1.EndpointSub
 	}
 	return newSubsets
 }
+
+func GetServiceEndpointSubset(svc *corev1.Service) corev1.EndpointSubset {
+	var epSubset corev1.EndpointSubset
+	for _, ip := range svc.Spec.ClusterIPs {
+		epSubset.Addresses = append(epSubset.Addresses, corev1.EndpointAddress{IP: ip})
+	}
+
+	epSubset.Ports = GetServiceEndpointPorts(svc.Spec.Ports)
+	return epSubset
+}
+
+// GetServiceEndpointPorts converts Service's port to EndpointPort
+func GetServiceEndpointPorts(ports []corev1.ServicePort) []corev1.EndpointPort {
+	if len(ports) == 0 {
+		return nil
+	}
+	var epPorts []corev1.EndpointPort
+	for _, p := range ports {
+		epPorts = append(epPorts, corev1.EndpointPort{
+			Name:     p.Name,
+			Port:     p.Port,
+			Protocol: p.Protocol,
+		})
+	}
+	return epPorts
+}

--- a/multicluster/controllers/multicluster/commonarea/resourceimport_controller_test.go
+++ b/multicluster/controllers/multicluster/commonarea/resourceimport_controller_test.go
@@ -342,12 +342,22 @@ func TestResourceImportReconciler_handleUpdateEvent(t *testing.T) {
 	}
 	newSubsets := []corev1.EndpointSubset{subSetA, subSetB}
 
-	existEp := &corev1.Endpoints{
+	existSvc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
 			Name:      "nginx",
 		},
-		Subsets: []corev1.EndpointSubset{subSetB},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Name:     "http",
+					Protocol: corev1.ProtocolTCP,
+					Port:     8080,
+				},
+			},
+			ClusterIP:  "10.10.11.13",
+			ClusterIPs: []string{"10.10.11.13"},
+		},
 	}
 
 	svcWithoutAutoAnnotation := &corev1.Service{
@@ -392,7 +402,7 @@ func TestResourceImportReconciler_handleUpdateEvent(t *testing.T) {
 	epResImportWithConflicts.Spec.Namespace = "kube-system"
 
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existMCSvc, existMCEp, existSvcImp,
-		existEp, existMCSvcConflicts, existMCEpConflicts, svcWithoutAutoAnnotation, epWithoutAutoAnnotation).Build()
+		existSvc, existMCSvcConflicts, existMCEpConflicts, svcWithoutAutoAnnotation, epWithoutAutoAnnotation).Build()
 	fakeRemoteClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(updatedEpResImport, updatedSvcResImport,
 		svcResImportWithConflicts, epResImportWithConflicts).Build()
 	remoteCluster := NewFakeRemoteCommonArea(scheme, remoteMgr, fakeRemoteClient, "leader-cluster", "default")
@@ -407,7 +417,7 @@ func TestResourceImportReconciler_handleUpdateEvent(t *testing.T) {
 		expectedErr      bool
 	}{
 		{
-			name:             "update service",
+			name:             "update Service",
 			objType:          "Service",
 			req:              svcImportReq,
 			resNamespaceName: types.NamespacedName{Namespace: "default", Name: "antrea-mc-nginx"},
@@ -420,14 +430,14 @@ func TestResourceImportReconciler_handleUpdateEvent(t *testing.T) {
 			},
 		},
 		{
-			name:             "update endpoints",
+			name:             "update Endpoints",
 			objType:          "Endpoints",
 			req:              epImportReq,
 			resNamespaceName: types.NamespacedName{Namespace: "default", Name: "antrea-mc-nginx"},
 			expectedSubset:   []corev1.EndpointSubset{subSetA},
 		},
 		{
-			name:    "skip update a service without mcs annotation",
+			name:    "skip update a Service without mcs annotation",
 			objType: "Service",
 			req: ctrl.Request{NamespacedName: types.NamespacedName{
 				Namespace: leaderNamespace,
@@ -437,7 +447,7 @@ func TestResourceImportReconciler_handleUpdateEvent(t *testing.T) {
 			expectedErr:      true,
 		},
 		{
-			name:    "skip update an endpoint without mcs annotation",
+			name:    "skip update an Endpoint without mcs annotation",
 			objType: "Endpoints",
 			req: ctrl.Request{NamespacedName: types.NamespacedName{
 				Namespace: leaderNamespace,

--- a/multicluster/controllers/multicluster/gateway_controller.go
+++ b/multicluster/controllers/multicluster/gateway_controller.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"sort"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -156,13 +155,16 @@ func (r *GatewayReconciler) getLastCreatedGateway() (*mcsv1alpha1.GatewayInfo, e
 		return nil, nil
 	}
 
-	// Sort Gateways by CreationTimestamp, the last created Gateway will be the first element.
-	sort.Slice(gws.Items, func(i, j int) bool {
-		return !gws.Items[i].CreationTimestamp.Before(&gws.Items[j].CreationTimestamp)
-	})
+	// Comparing Gateway's CreationTimestamp to get the last created Gateway.
+	lastCreatedGW := gws.Items[0]
+	for _, gw := range gws.Items {
+		if lastCreatedGW.CreationTimestamp.Before(&gw.CreationTimestamp) {
+			lastCreatedGW = gw
+		}
+	}
 
 	// Make sure we only return the last created Gateway for now.
-	return &mcsv1alpha1.GatewayInfo{GatewayIP: gws.Items[0].GatewayIP}, nil
+	return &mcsv1alpha1.GatewayInfo{GatewayIP: lastCreatedGW.GatewayIP}, nil
 }
 
 func (r *GatewayReconciler) updateResourceExport(ctx context.Context, req ctrl.Request,

--- a/multicluster/controllers/multicluster/gateway_controller_test.go
+++ b/multicluster/controllers/multicluster/gateway_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,18 +38,23 @@ var (
 	serviceCIDR = "10.96.0.0/12"
 	clusterID   = "cluster-a"
 
+	gw1CreationTime = metav1.NewTime(time.Now())
+	gw2CreationTime = metav1.NewTime(time.Now().Add(10 * time.Minute))
+
 	gwNode1 = mcsv1alpha1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "node-1",
-			Namespace: "default",
+			Name:              "node-1",
+			Namespace:         "default",
+			CreationTimestamp: gw1CreationTime,
 		},
 		GatewayIP:  "10.10.10.10",
 		InternalIP: "172.11.10.1",
 	}
 	gwNode2 = mcsv1alpha1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "node-2",
-			Namespace: "default",
+			Name:              "node-2",
+			Namespace:         "default",
+			CreationTimestamp: gw2CreationTime,
 		},
 		GatewayIP:  "10.8.8.8",
 		InternalIP: "172.11.10.1",

--- a/multicluster/hack/mc-integration-test.sh
+++ b/multicluster/hack/mc-integration-test.sh
@@ -17,7 +17,7 @@
 set -e
 
 clean_up() {
-  kind delete cluster --name antrea-integration-kind
+  kind delete cluster --name antrea-integration
 }
 
 trap clean_up EXIT
@@ -29,7 +29,7 @@ if [[ "$WORKDIR" != "" ]];then
 fi
 
 echo "" > /tmp/mc-integration-kubeconfig
-kind create cluster --name=antrea-integration-kind --kubeconfig=/tmp/mc-integration-kubeconfig
+kind create cluster --name=antrea-integration --kubeconfig=/tmp/mc-integration-kubeconfig
 sleep 5
 export KUBECONFIG=/tmp/mc-integration-kubeconfig
 kubectl create namespace leader-ns
@@ -38,7 +38,7 @@ kubectl apply -f test/integration/cluster-admin.yml
 
 if [[ $NO_LOCAL == "true" ]];then
   # Run go test in a Docker container
-  container_ip=$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' antrea-integration-kind-control-plane)
+  container_ip=$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' antrea-integration-control-plane)
   sed -i "s|server: https://.*|server: https://${container_ip}:6443|" /tmp/mc-integration-kubeconfig
   docker run --network kind --privileged --rm \
 	  -w /usr/src/antrea.io/antrea \

--- a/multicluster/test/e2e/fixtures.go
+++ b/multicluster/test/e2e/fixtures.go
@@ -65,10 +65,10 @@ func teardownTest(tb testing.TB, data *MCTestData) {
 	}
 }
 
-func createPodWrapper(tb testing.TB, data *MCTestData, cluster string, namespace string, name string, image string, ctr string, command []string,
+func createPodWrapper(tb testing.TB, data *MCTestData, cluster string, namespace string, name string, nodeName string, image string, ctr string, command []string,
 	args []string, env []corev1.EnvVar, ports []corev1.ContainerPort, hostNetwork bool, mutateFunc func(pod *corev1.Pod)) error {
-	tb.Logf("Creating Pod '%s'", name)
-	if err := data.createPod(cluster, name, namespace, ctr, image, command, args, env, ports, hostNetwork, mutateFunc); err != nil {
+	tb.Logf("Creating Pod '%s' in Namespace %s of cluster %s", name, namespace, cluster)
+	if err := data.createPod(cluster, name, nodeName, namespace, ctr, image, command, args, env, ports, hostNetwork, mutateFunc); err != nil {
 		return err
 	}
 
@@ -80,14 +80,14 @@ func createPodWrapper(tb testing.TB, data *MCTestData, cluster string, namespace
 }
 
 func deletePodWrapper(tb testing.TB, data *MCTestData, clusterName string, namespace string, name string) {
-	tb.Logf("Deleting Pod '%s'", name)
+	tb.Logf("Deleting Pod '%s' in Namespace %s of cluster %s", name, namespace, clusterName)
 	if err := data.deletePod(clusterName, namespace, name); err != nil {
 		tb.Logf("Error when deleting Pod: %v", err)
 	}
 }
 
 func deleteServiceWrapper(tb testing.TB, data *MCTestData, clusterName string, namespace string, name string) {
-	tb.Logf("Deleting Service '%s'", name)
+	tb.Logf("Deleting Service '%s' in Namespace %s of cluster %s", name, namespace, clusterName)
 	if err := data.deleteService(clusterName, namespace, name); err != nil {
 		tb.Logf("Error when deleting Service: %v", err)
 	}

--- a/multicluster/test/e2e/framework.go
+++ b/multicluster/test/e2e/framework.go
@@ -35,7 +35,7 @@ var (
 
 const (
 	defaultTimeout     = 90 * time.Second
-	importServiceDelay = 10 * time.Second
+	importServiceDelay = 2 * time.Second
 
 	multiClusterTestNamespace string = "antrea-multicluster-test"
 	eastClusterTestService    string = "east-nginx"
@@ -57,15 +57,18 @@ type TestOptions struct {
 	leaderClusterKubeConfigPath string
 	westClusterKubeConfigPath   string
 	eastClusterKubeConfigPath   string
+	enableGateway               bool
 	logsExportDir               string
 }
 
 var testOptions TestOptions
 
 type MCTestData struct {
-	clusters           []string
-	clusterTestDataMap map[string]antreae2e.TestData
-	logsDirForTestCase string
+	clusters            []string
+	clusterTestDataMap  map[string]antreae2e.TestData
+	logsDirForTestCase  string
+	clusterGateways     map[string]string
+	clusterRegularNodes map[string]string
 }
 
 var testData *MCTestData
@@ -149,19 +152,10 @@ func (data *MCTestData) deleteTestNamespaces(timeout time.Duration) error {
 	return nil
 }
 
-func (data *MCTestData) deleteNamespace(clusterName, namespace string, timeout time.Duration) error {
-	if d, ok := data.clusterTestDataMap[clusterName]; ok {
-		if err := d.DeleteNamespace(namespace, timeout); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (data *MCTestData) createPod(clusterName, name, namespace, ctrName, image string, command []string,
+func (data *MCTestData) createPod(clusterName, name, nodeName, namespace, ctrName, image string, command []string,
 	args []string, env []corev1.EnvVar, ports []corev1.ContainerPort, hostNetwork bool, mutateFunc func(pod *corev1.Pod)) error {
 	if d, ok := data.clusterTestDataMap[clusterName]; ok {
-		return d.CreatePodOnNodeInNamespace(name, namespace, "", ctrName, image, command, args, env, ports, hostNetwork, mutateFunc)
+		return d.CreatePodOnNodeInNamespace(name, namespace, nodeName, ctrName, image, command, args, env, ports, hostNetwork, mutateFunc)
 	}
 	return fmt.Errorf("clusterName %s not found", clusterName)
 }

--- a/multicluster/test/integration/README.md
+++ b/multicluster/test/integration/README.md
@@ -12,7 +12,7 @@ like Service, Endpoints controllers etc.
 
 The tests must be run on an real Kubernetes cluster. At the moment, you can
 simply run `make test-integration` in `antrea/multicluster` folder. It will
-create a Kind cluster named `antrea-integration-kind` and execute the integration
+create a Kind cluster named `antrea-integration` and execute the integration
 codes.
 
 if you'd like to run the integration test in an existing Kubernetes cluster, you

--- a/multicluster/test/integration/resourceexport_controller_test.go
+++ b/multicluster/test/integration/resourceexport_controller_test.go
@@ -163,8 +163,8 @@ var _ = Describe("ResourceExport controller", func() {
 				Subsets: []corev1.EndpointSubset{
 					{
 						Addresses: []corev1.EndpointAddress{
+							addr2,
 							addr3,
-							addr4,
 						},
 						Ports: epPorts,
 					},

--- a/multicluster/test/integration/serviceexport_controller_test.go
+++ b/multicluster/test/integration/serviceexport_controller_test.go
@@ -53,25 +53,7 @@ var _ = Describe("ServiceExport controller", func() {
 		Namespace: svc.Namespace,
 		Name:      svc.Name,
 	}
-	epNamespacedName := svcNamespacedName
 
-	ep := &corev1.Endpoints{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "nginx-svc",
-			Namespace: testNamespace,
-		},
-		Subsets: []corev1.EndpointSubset{
-			{
-				Addresses: []corev1.EndpointAddress{
-					addr1,
-				},
-				NotReadyAddresses: []corev1.EndpointAddress{
-					addr2,
-				},
-				Ports: epPorts,
-			},
-		},
-	}
 	svcExport := &k8smcsv1alpha1.ServiceExport{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "nginx-svc",
@@ -85,7 +67,7 @@ var _ = Describe("ServiceExport controller", func() {
 		},
 	}
 	svcResExportName := LocalClusterID + "-" + svc.Namespace + "-" + svc.Name + "-service"
-	epResExportName := LocalClusterID + "-" + ep.Namespace + "-" + ep.Name + "-endpoints"
+	epResExportName := LocalClusterID + "-" + svc.Namespace + "-" + svc.Name + "-endpoints"
 
 	expectedEpResExport := &mcsv1alpha1.ResourceExport{
 		ObjectMeta: metav1.ObjectMeta{
@@ -94,8 +76,8 @@ var _ = Describe("ServiceExport controller", func() {
 		},
 		Spec: mcsv1alpha1.ResourceExportSpec{
 			ClusterID: LocalClusterID,
-			Name:      ep.Name,
-			Namespace: ep.Namespace,
+			Name:      svc.Name,
+			Namespace: svc.Namespace,
 			Kind:      common.EndpointsKind,
 		},
 	}
@@ -103,20 +85,7 @@ var _ = Describe("ServiceExport controller", func() {
 	ctx := context.Background()
 	It("Should create ResourceExports when new ServiceExport for ClusterIP Service is created", func() {
 		By("By exposing a ClusterIP type of Service")
-		expectedEpResExport.Spec.Endpoints = &mcsv1alpha1.EndpointsExport{
-			Subsets: []corev1.EndpointSubset{
-				{
-					Addresses: []corev1.EndpointAddress{
-						{
-							IP: "192.168.17.11",
-						},
-					},
-					Ports: epPorts,
-				},
-			},
-		}
 		Expect(k8sClient.Create(ctx, svc)).Should(Succeed())
-		Expect(k8sClient.Create(ctx, ep)).Should(Succeed())
 		Expect(k8sClient.Create(ctx, svcExport)).Should(Succeed())
 		var err error
 		latestSvc := &corev1.Service{}
@@ -131,6 +100,18 @@ var _ = Describe("ServiceExport controller", func() {
 		Expect(svcResExport.ObjectMeta.Labels["sourceKind"]).Should(Equal("Service"))
 		Expect(svcResExport.Spec.Service.ServiceSpec.ClusterIP).Should(Equal(latestSvc.Spec.ClusterIP))
 		Expect(len(svcResExport.Spec.Service.ServiceSpec.Ports)).Should(Equal(len(svcPorts)))
+		expectedEpResExport.Spec.Endpoints = &mcsv1alpha1.EndpointsExport{
+			Subsets: []corev1.EndpointSubset{
+				{
+					Addresses: []corev1.EndpointAddress{
+						{
+							IP: latestSvc.Spec.ClusterIP,
+						},
+					},
+					Ports: epPorts,
+				},
+			},
+		}
 		Eventually(func() bool {
 			err = k8sClient.Get(ctx, types.NamespacedName{Namespace: LeaderNamespace, Name: epResExportName}, epResExport)
 			return err == nil
@@ -178,42 +159,6 @@ var _ = Describe("ServiceExport controller", func() {
 		conditions := latestSvcExportNoService.Status.Conditions
 		Expect(len(conditions)).Should(Equal(1))
 		Expect(*conditions[0].Message).Should(Equal("the Service does not exist"))
-	})
-
-	It("Should update existing ResourceExport when corresponding Endpoints has new Endpoint", func() {
-		By("By update an Endpoint with a new address")
-		latestEp := &corev1.Endpoints{}
-		Expect(k8sClient.Get(ctx, epNamespacedName, latestEp)).Should(Succeed())
-		addresses := latestEp.Subsets[0].Addresses
-		addresses = append(addresses, addr3)
-		latestEp.Subsets[0].Addresses = addresses
-		Expect(k8sClient.Update(ctx, latestEp)).Should(Succeed())
-		time.Sleep(2 * time.Second)
-		epResExport := &mcsv1alpha1.ResourceExport{}
-		expectedEpResExport.Spec.Endpoints = &mcsv1alpha1.EndpointsExport{
-			Subsets: []corev1.EndpointSubset{
-				{
-					Addresses: []corev1.EndpointAddress{
-						{
-							IP: "192.168.17.11",
-						},
-						{
-							IP: "192.168.17.13",
-						},
-					},
-					Ports: epPorts,
-				},
-			},
-		}
-
-		var err error
-		Eventually(func() bool {
-			err = k8sClient.Get(ctx, types.NamespacedName{Namespace: LeaderNamespace, Name: epResExportName}, epResExport)
-			return err == nil
-		}, timeout, interval).Should(BeTrue())
-		Expect(epResExport.ObjectMeta.Labels["sourceKind"]).Should(Equal("Endpoints"))
-		Expect(epResExport.Spec).Should(Equal(expectedEpResExport.Spec))
-
 	})
 
 	It("Should delete existing ResourceExport when existing ServiceExport is deleted", func() {

--- a/multicluster/test/integration/test_data.go
+++ b/multicluster/test/integration/test_data.go
@@ -29,10 +29,6 @@ var (
 		IP:       "192.168.17.13",
 		Hostname: "pod3",
 	}
-	addr4 = corev1.EndpointAddress{
-		IP:       "192.168.17.14",
-		Hostname: "pod4",
-	}
 	epPorts = []corev1.EndpointPort{
 		{
 			Name:     "http",

--- a/pkg/agent/multicluster/mc_route_controller.go
+++ b/pkg/agent/multicluster/mc_route_controller.go
@@ -1,0 +1,460 @@
+// Copyright 2022 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package noderoute
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"reflect"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+
+	mcv1alpha1 "antrea.io/antrea/multicluster/apis/multicluster/v1alpha1"
+	mcclientset "antrea.io/antrea/multicluster/pkg/client/clientset/versioned"
+	mcinformers "antrea.io/antrea/multicluster/pkg/client/informers/externalversions/multicluster/v1alpha1"
+	mclisters "antrea.io/antrea/multicluster/pkg/client/listers/multicluster/v1alpha1"
+	"antrea.io/antrea/pkg/agent/config"
+	"antrea.io/antrea/pkg/agent/interfacestore"
+	"antrea.io/antrea/pkg/agent/openflow"
+	"antrea.io/antrea/pkg/ovs/ovsconfig"
+)
+
+const (
+	controllerName = "AntreaAgentMCRouteController"
+
+	// Set resyncPeriod to 0 to disable resyncing
+	resyncPeriod = 0 * time.Second
+	// How long to wait before retrying the processing of a resource change
+	minRetryDelay = 2 * time.Second
+	maxRetryDelay = 120 * time.Second
+
+	// Default number of workers processing a resource change
+	defaultWorkers = 1
+	workerItemKey  = "key"
+)
+
+// MCRouteController watches Gateway and ClusterInfoImport events.
+// It is responsible for setting up necessary Openflow entries for multi-cluster
+// traffic on a Gateway or a regular Node.
+type MCRouteController struct {
+	mcClient             mcclientset.Interface
+	ovsBridgeClient      ovsconfig.OVSBridgeClient
+	ofClient             openflow.Client
+	interfaceStore       interfacestore.InterfaceStore
+	nodeConfig           *config.NodeConfig
+	gwInformer           mcinformers.GatewayInformer
+	gwLister             mclisters.GatewayLister
+	gwListerSynced       cache.InformerSynced
+	ciImportInformer     mcinformers.ClusterInfoImportInformer
+	ciImportLister       mclisters.ClusterInfoImportLister
+	ciImportListerSynced cache.InformerSynced
+	queue                workqueue.RateLimitingInterface
+	// installedCIImports is for saving ClusterInfos which have been processed
+	// in MCRouteController.
+	installedCIImports cache.Indexer
+	// Need to use mutex to protect 'installedActiveGWName' if we plan to change
+	// the number of 'defaultWorkers' to run multiple go routines to handle
+	// events.
+	installedActiveGWName string
+	// The Namespace where Antrea Multi-cluster Controller is running.
+	namespace string
+}
+
+func NewMCRouteController(
+	mcClient mcclientset.Interface,
+	gwInformer mcinformers.GatewayInformer,
+	ciImportInformer mcinformers.ClusterInfoImportInformer,
+	client openflow.Client,
+	ovsBridgeClient ovsconfig.OVSBridgeClient,
+	interfaceStore interfacestore.InterfaceStore,
+	nodeConfig *config.NodeConfig,
+	namespace string,
+) *MCRouteController {
+	controller := &MCRouteController{
+		mcClient:             mcClient,
+		ovsBridgeClient:      ovsBridgeClient,
+		ofClient:             client,
+		interfaceStore:       interfaceStore,
+		nodeConfig:           nodeConfig,
+		gwInformer:           gwInformer,
+		gwLister:             gwInformer.Lister(),
+		gwListerSynced:       gwInformer.Informer().HasSynced,
+		ciImportInformer:     ciImportInformer,
+		ciImportLister:       ciImportInformer.Lister(),
+		ciImportListerSynced: ciImportInformer.Informer().HasSynced,
+		queue:                workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(minRetryDelay, maxRetryDelay), "gatewayroute"),
+		installedCIImports:   cache.NewIndexer(clusterInfoImportKeyFunc, cache.Indexers{}),
+		namespace:            namespace,
+	}
+	controller.gwInformer.Informer().AddEventHandlerWithResyncPeriod(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: func(cur interface{}) {
+				controller.enqueueGateway(cur, false)
+			},
+			UpdateFunc: func(old, cur interface{}) {
+				controller.enqueueGateway(cur, false)
+			},
+			DeleteFunc: func(old interface{}) {
+				controller.enqueueGateway(old, true)
+			},
+		},
+		resyncPeriod,
+	)
+	controller.ciImportInformer.Informer().AddEventHandlerWithResyncPeriod(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: func(cur interface{}) {
+				controller.enqueueClusterInfoImport(cur, false)
+			},
+			UpdateFunc: func(old, cur interface{}) {
+				controller.enqueueClusterInfoImport(cur, false)
+			},
+			DeleteFunc: func(old interface{}) {
+				controller.enqueueClusterInfoImport(old, true)
+			},
+		},
+		resyncPeriod,
+	)
+	return controller
+}
+
+func clusterInfoImportKeyFunc(obj interface{}) (string, error) {
+	return obj.(*mcv1alpha1.ClusterInfoImport).Name, nil
+}
+
+func (c *MCRouteController) enqueueGateway(obj interface{}, isDelete bool) {
+	gw, isGW := obj.(*mcv1alpha1.Gateway)
+	if !isGW {
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			klog.ErrorS(nil, "Received unexpected object", "object", obj)
+			return
+		}
+		gw, ok = deletedState.Obj.(*mcv1alpha1.Gateway)
+		if !ok {
+			klog.ErrorS(nil, "DeletedFinalStateUnknown contains non-Gateway object", "object", deletedState.Obj)
+			return
+		}
+	}
+	if !isDelete {
+		if net.ParseIP(gw.InternalIP) == nil || net.ParseIP(gw.GatewayIP) == nil {
+			klog.ErrorS(nil, "No valid Internal IP or Gateway IP is found in Gateway", "gateway", gw.Namespace+"/"+gw.Name)
+			return
+		}
+	}
+	c.queue.Add(workerItemKey)
+}
+
+func (c *MCRouteController) enqueueClusterInfoImport(obj interface{}, isDelete bool) {
+	ciImp, isciImp := obj.(*mcv1alpha1.ClusterInfoImport)
+	if !isciImp {
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			klog.ErrorS(nil, "Received unexpected object", "object", obj)
+			return
+		}
+		ciImp, ok = deletedState.Obj.(*mcv1alpha1.ClusterInfoImport)
+		if !ok {
+			klog.ErrorS(nil, "DeletedFinalStateUnknown contains non-ClusterInfoImport object", "object", deletedState.Obj)
+			return
+		}
+	}
+
+	if !isDelete {
+		if len(ciImp.Spec.GatewayInfos) == 0 {
+			klog.ErrorS(nil, "Received invalid ClusterInfoImport", "object", obj)
+			return
+		}
+		if net.ParseIP(ciImp.Spec.GatewayInfos[0].GatewayIP) == nil {
+			klog.ErrorS(nil, "Received ClusterInfoImport with invalid Gateway IP", "object", obj)
+			return
+		}
+	}
+
+	c.queue.Add(workerItemKey)
+}
+
+// Run will create defaultWorkers workers (go routines) which will process
+// the Gateway events from the workqueue.
+func (c *MCRouteController) Run(stopCh <-chan struct{}) {
+	defer c.queue.ShutDown()
+	cacheSyncs := []cache.InformerSynced{c.gwListerSynced, c.ciImportListerSynced}
+	klog.InfoS("Starting controller", "controller", controllerName)
+	defer klog.InfoS("Shutting down controller", "controller", controllerName)
+	if !cache.WaitForNamedCacheSync(controllerName, stopCh, cacheSyncs...) {
+		return
+	}
+
+	for i := 0; i < defaultWorkers; i++ {
+		go wait.Until(c.worker, time.Second, stopCh)
+	}
+	<-stopCh
+}
+
+// worker is a long-running function that will continually call the processNextWorkItem
+// function in order to read and process a message on the workqueue.
+func (c *MCRouteController) worker() {
+	for c.processNextWorkItem() {
+	}
+}
+
+func (c *MCRouteController) processNextWorkItem() bool {
+	obj, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(obj)
+
+	if k, ok := obj.(string); !ok {
+		c.queue.Forget(obj)
+		klog.InfoS("Expected string in work queue but got", "object", obj)
+		return true
+	} else if err := c.syncMCFlows(); err == nil {
+		c.queue.Forget(k)
+	} else {
+		// Put the item back on the workqueue to handle any transient errors.
+		c.queue.AddRateLimited(k)
+		klog.ErrorS(err, "Error syncing key, requeuing", "key", k)
+	}
+	return true
+}
+
+func (c *MCRouteController) syncMCFlows() error {
+	startTime := time.Now()
+	defer func() {
+		klog.V(4).InfoS("Finished syncing flows for Multi-cluster", "time", time.Since(startTime))
+	}()
+	activeGW, err := c.getActiveGateway()
+	if err != nil {
+		return err
+	}
+	if activeGW == nil && c.installedActiveGWName == "" {
+		klog.V(2).InfoS("No active Gateway is found")
+		return nil
+	}
+
+	klog.V(2).InfoS("Installed Gateway", "gateway", c.installedActiveGWName)
+	if activeGW != nil && activeGW.Name == c.installedActiveGWName {
+		// Active Gateway name doesn't change but do a full flows resync
+		// for any Gateway Spec or ClusterInfoImport changes.
+		if err := c.syncMCFlowsForAllCIImps(activeGW); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	if c.installedActiveGWName != "" {
+		if err := c.cleanupFlows(c.installedActiveGWName); err != nil {
+			return err
+		}
+		c.installedActiveGWName = ""
+	}
+
+	if activeGW != nil {
+		if activeGW.Name == c.nodeConfig.Name {
+			if err := c.ofClient.InstallMulticlusterClassifierFlows(activeGW.Name, config.DefaultTunOFPort, true); err != nil {
+				return err
+			}
+			c.installedActiveGWName = activeGW.Name
+			return c.addMCFlowsForAllCIImps(activeGW)
+		} else {
+			if err := c.ofClient.InstallMulticlusterClassifierFlows(activeGW.Name, config.DefaultTunOFPort, false); err != nil {
+				return err
+			}
+			c.installedActiveGWName = activeGW.Name
+			return c.addMCFlowsForAllCIImps(activeGW)
+		}
+	}
+	return nil
+}
+
+func (c *MCRouteController) syncMCFlowsForAllCIImps(activeGW *mcv1alpha1.Gateway) error {
+	installedCIImportsCache := c.installedCIImports.List()
+	desiredCIImports, err := c.ciImportLister.ClusterInfoImports(c.namespace).List(labels.Everything())
+	if err != nil {
+		return err
+	}
+	installedCIImports := map[string]*mcv1alpha1.ClusterInfoImport{}
+	for _, ciImp := range installedCIImportsCache {
+		ciImport := ciImp.(*mcv1alpha1.ClusterInfoImport)
+		installedCIImports[ciImport.Name] = ciImport
+	}
+
+	for ciImpName, ciImp := range installedCIImports {
+		if !c.containsCIImport(desiredCIImports, ciImpName) {
+			if err := c.deleteMCFlowsForCIImport(ciImp); err != nil {
+				return err
+			}
+		}
+	}
+
+	for _, ciImp := range desiredCIImports {
+		if err = c.addMCFlowsForSingleCIImp(activeGW, ciImp, installedCIImports[ciImp.Name]); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *MCRouteController) containsCIImport(ciImports []*mcv1alpha1.ClusterInfoImport, ciImportName string) bool {
+	for _, cii := range ciImports {
+		if cii.Name == ciImportName {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *MCRouteController) cleanupFlows(gatewayName string) error {
+	if err := c.deleteMCFlowsForAllCIImps(); err != nil {
+		return err
+	}
+	if err := c.ofClient.UninstallMulticlusterFlows(gatewayName); err != nil {
+		return err
+	}
+	klog.V(2).InfoS("Deleted flows for Gateway", "gateway", gatewayName)
+	return nil
+}
+
+func (c *MCRouteController) addMCFlowsForAllCIImps(activeGW *mcv1alpha1.Gateway) error {
+	allCIImports, err := c.ciImportLister.ClusterInfoImports(c.namespace).List(labels.Everything())
+	if err != nil {
+		return err
+	}
+	if len(allCIImports) == 0 {
+		klog.V(2).InfoS("No remote ClusterInfo imported, do nothing")
+		return nil
+	}
+
+	for _, ciImport := range allCIImports {
+		if err := c.addMCFlowsForSingleCIImp(activeGW, ciImport, nil); err != nil {
+			if strings.Contains(err.Error(), "invalid Gateway IP") {
+				continue
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *MCRouteController) addMCFlowsForSingleCIImp(activeGW *mcv1alpha1.Gateway, ciImport *mcv1alpha1.ClusterInfoImport, installedCIImp *mcv1alpha1.ClusterInfoImport) error {
+	tunnelPeerIP := getPeerGatewayIP(ciImport.Spec)
+	if tunnelPeerIP == nil {
+		return errors.New("invalid Gateway IP")
+	}
+	if installedCIImp != nil && reflect.DeepEqual(ciImport, installedCIImp) {
+		klog.V(2).InfoS("No difference between new and installed ClusterInfoImports, skip updating", "clusterinfoimport", ciImport.Name)
+		return nil
+	}
+	klog.InfoS("Adding/updating remote Gateway Node flows for Multi-cluster", "gateway", klog.KObj(activeGW),
+		"node", c.nodeConfig.Name, "peer", tunnelPeerIP)
+	allCIDRs := []string{ciImport.Spec.ServiceCIDR}
+	peerConfigs, err := generatePeerConfigs(allCIDRs, tunnelPeerIP)
+	if err != nil {
+		klog.ErrorS(err, "Parse error for serviceCIDR from remote cluster", "clusterinfoimport", ciImport.Name, "gateway", activeGW.Name)
+		return err
+	}
+	if activeGW.Name == c.nodeConfig.Name {
+		klog.V(2).InfoS("Adding/updating flows to remote Gateway Node for Multi-cluster traffic", "clusterinfoimport", ciImport.Name, "cidrs", allCIDRs)
+		localGatewayIP := net.ParseIP(activeGW.GatewayIP)
+		if err := c.ofClient.InstallMulticlusterGatewayFlows(
+			ciImport.Name,
+			peerConfigs,
+			tunnelPeerIP,
+			localGatewayIP); err != nil {
+			return fmt.Errorf("failed to install flows to remote Gateway in ClusterInfoImport %s: %v", ciImport.Name, err)
+		}
+	} else {
+		klog.V(2).InfoS("Adding/updating flows to the local active Gateway for Multi-cluster traffic", "clusterinfoimport", ciImport.Name, "cidrs", allCIDRs)
+		tunnelPeerIP := net.ParseIP(activeGW.InternalIP)
+		if err := c.ofClient.InstallMulticlusterNodeFlows(
+			ciImport.Name,
+			peerConfigs,
+			tunnelPeerIP); err != nil {
+			return fmt.Errorf("failed to install flows to Gateway %s: %v", activeGW.Name, err)
+		}
+	}
+
+	c.installedCIImports.Add(ciImport)
+	return nil
+}
+
+func (c *MCRouteController) deleteMCFlowsForCIImport(ciImp *mcv1alpha1.ClusterInfoImport) error {
+	if err := c.ofClient.UninstallMulticlusterFlows(ciImp.Name); err != nil {
+		return fmt.Errorf("failed to uninstall multi-cluster flows to remote Gateway Node %s: %v", ciImp.Name, err)
+	}
+	c.installedCIImports.Delete(ciImp)
+	return nil
+}
+
+func (c *MCRouteController) deleteMCFlowsForAllCIImps() error {
+	cachedCIImps := c.installedCIImports.List()
+	for _, ciImp := range cachedCIImps {
+		ciImport := ciImp.(*mcv1alpha1.ClusterInfoImport)
+		c.deleteMCFlowsForCIImport(ciImport)
+	}
+	return nil
+}
+
+// getActiveGateway compares Gateway's CreationTimestamp to get the active Gateway,
+// The last created Gateway will be the active Gateway.
+func (c *MCRouteController) getActiveGateway() (*mcv1alpha1.Gateway, error) {
+	gws, err := c.gwLister.Gateways(c.namespace).List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+	if len(gws) == 0 {
+		return nil, nil
+	}
+	// Comparing Gateway's CreationTimestamp to get the last created Gateway.
+	lastCreatedGW := gws[0]
+	for _, gw := range gws {
+		if lastCreatedGW.CreationTimestamp.Before(&gw.CreationTimestamp) {
+			lastCreatedGW = gw
+		}
+	}
+	if net.ParseIP(lastCreatedGW.GatewayIP) == nil {
+		return nil, errors.New("the last created Gateway" + lastCreatedGW.Name + " has no valid GatewayIP")
+	}
+	return lastCreatedGW, nil
+}
+
+func generatePeerConfigs(subnets []string, gatewayIP net.IP) (map[*net.IPNet]net.IP, error) {
+	peerConfigs := make(map[*net.IPNet]net.IP, len(subnets))
+	for _, subnet := range subnets {
+		_, peerCIDR, err := net.ParseCIDR(subnet)
+		if err != nil {
+			return nil, err
+		}
+		peerConfigs[peerCIDR] = gatewayIP
+	}
+	return peerConfigs, nil
+}
+
+// getPeerGatewayIP will always return the first Gateway IP.
+func getPeerGatewayIP(spec mcv1alpha1.ClusterInfo) net.IP {
+	if len(spec.GatewayInfos) == 0 {
+		return nil
+	}
+	return net.ParseIP(spec.GatewayInfos[0].GatewayIP)
+}

--- a/pkg/agent/multicluster/mc_route_controller_test.go
+++ b/pkg/agent/multicluster/mc_route_controller_test.go
@@ -1,0 +1,293 @@
+// Copyright 2022 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package noderoute
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	mcv1alpha1 "antrea.io/antrea/multicluster/apis/multicluster/v1alpha1"
+	mcfake "antrea.io/antrea/multicluster/pkg/client/clientset/versioned/fake"
+	mcinformers "antrea.io/antrea/multicluster/pkg/client/informers/externalversions"
+	"antrea.io/antrea/pkg/agent/config"
+	"antrea.io/antrea/pkg/agent/interfacestore"
+	oftest "antrea.io/antrea/pkg/agent/openflow/testing"
+	ovsconfigtest "antrea.io/antrea/pkg/ovs/ovsconfig/testing"
+)
+
+type fakeRouteController struct {
+	*MCRouteController
+	mcClient        *mcfake.Clientset
+	informerFactory mcinformers.SharedInformerFactory
+	ofClient        *oftest.MockClient
+	ovsClient       *ovsconfigtest.MockOVSBridgeClient
+	interfaceStore  interfacestore.InterfaceStore
+}
+
+func newMCRouteController(t *testing.T, nodeConfig *config.NodeConfig) (*fakeRouteController, func()) {
+	mcClient := mcfake.NewSimpleClientset()
+	mcInformerFactory := mcinformers.NewSharedInformerFactory(mcClient, 60*time.Second)
+	gwInformer := mcInformerFactory.Multicluster().V1alpha1().Gateways()
+	ciImpInformer := mcInformerFactory.Multicluster().V1alpha1().ClusterInfoImports()
+
+	ctrl := gomock.NewController(t)
+	ofClient := oftest.NewMockClient(ctrl)
+	ovsClient := ovsconfigtest.NewMockOVSBridgeClient(ctrl)
+	interfaceStore := interfacestore.NewInterfaceStore()
+	c := NewMCRouteController(
+		mcClient,
+		gwInformer,
+		ciImpInformer,
+		ofClient,
+		ovsClient,
+		interfaceStore,
+		nodeConfig,
+		"default",
+	)
+	return &fakeRouteController{
+		MCRouteController: c,
+		mcClient:          mcClient,
+		informerFactory:   mcInformerFactory,
+		ofClient:          ofClient,
+		ovsClient:         ovsClient,
+		interfaceStore:    interfaceStore,
+	}, ctrl.Finish
+}
+
+var (
+	gw1CreationTime = metav1.NewTime(time.Now())
+	gw2CreationTime = metav1.NewTime(time.Now().Add(10 * time.Minute))
+	gateway1        = mcv1alpha1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "node-1",
+			Namespace:         "default",
+			CreationTimestamp: gw1CreationTime,
+		},
+		GatewayIP:  "172.17.0.11",
+		InternalIP: "192.17.0.11",
+	}
+	gateway2 = mcv1alpha1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "node-2",
+			Namespace:         "default",
+			CreationTimestamp: gw2CreationTime,
+		},
+		GatewayIP:  "172.17.0.12",
+		InternalIP: "192.17.0.12",
+	}
+	gw1GatewayIP  = net.ParseIP(gateway1.GatewayIP)
+	gw2InternalIP = net.ParseIP(gateway2.InternalIP)
+
+	clusterInfoImport1 = mcv1alpha1.ClusterInfoImport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-b-default-clusterinfo",
+			Namespace: "default",
+		},
+		Spec: mcv1alpha1.ClusterInfo{
+			ClusterID:   "cluster-b",
+			ServiceCIDR: "10.12.2.0/12",
+			GatewayInfos: []mcv1alpha1.GatewayInfo{
+				{
+					GatewayIP: "172.18.0.10",
+				},
+			},
+		},
+	}
+
+	clusterInfoImport2 = mcv1alpha1.ClusterInfoImport{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-c-default-clusterinfo",
+			Namespace: "default",
+		},
+		Spec: mcv1alpha1.ClusterInfo{
+			ClusterID:   "cluster-c",
+			ServiceCIDR: "13.13.2.0/12",
+			GatewayInfos: []mcv1alpha1.GatewayInfo{
+				{
+					GatewayIP: "12.11.0.10",
+				},
+			},
+		},
+	}
+)
+
+func TestMCRouteControllerAsGateway(t *testing.T) {
+	c, closeFn := newMCRouteController(t, &config.NodeConfig{Name: "node-1"})
+	defer closeFn()
+	defer c.queue.ShutDown()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	c.informerFactory.Start(stopCh)
+	c.informerFactory.WaitForCacheSync(stopCh)
+
+	finishCh := make(chan struct{})
+	go func() {
+		defer close(finishCh)
+
+		// Create Gateway1
+		c.mcClient.MulticlusterV1alpha1().Gateways(gateway1.GetNamespace()).Create(context.TODO(),
+			&gateway1, metav1.CreateOptions{})
+		c.ofClient.EXPECT().InstallMulticlusterClassifierFlows(gateway1.Name, uint32(1), true).Times(1)
+		c.processNextWorkItem()
+
+		// Create two ClusterInfoImports
+		c.mcClient.MulticlusterV1alpha1().ClusterInfoImports(clusterInfoImport1.GetNamespace()).
+			Create(context.TODO(), &clusterInfoImport1, metav1.CreateOptions{})
+		peerNodeIP1 := getPeerGatewayIP(clusterInfoImport1.Spec)
+		c.ofClient.EXPECT().InstallMulticlusterGatewayFlows(clusterInfoImport1.Name,
+			gomock.Any(), peerNodeIP1, gw1GatewayIP).Times(1)
+		c.processNextWorkItem()
+
+		c.mcClient.MulticlusterV1alpha1().ClusterInfoImports(clusterInfoImport2.GetNamespace()).
+			Create(context.TODO(), &clusterInfoImport2, metav1.CreateOptions{})
+		peerNodeIP2 := getPeerGatewayIP(clusterInfoImport2.Spec)
+		c.ofClient.EXPECT().InstallMulticlusterGatewayFlows(clusterInfoImport2.Name,
+			gomock.Any(), peerNodeIP2, gw1GatewayIP).Times(1)
+		c.processNextWorkItem()
+
+		// Update a ClusterInfoImport
+		clusterInfoImport1.Spec.ServiceCIDR = "192.10.1.0/24"
+		c.mcClient.MulticlusterV1alpha1().ClusterInfoImports(clusterInfoImport1.GetNamespace()).
+			Update(context.TODO(), &clusterInfoImport1, metav1.UpdateOptions{})
+		c.ofClient.EXPECT().InstallMulticlusterGatewayFlows(clusterInfoImport1.Name,
+			gomock.Any(), peerNodeIP1, gw1GatewayIP).Times(1)
+		c.processNextWorkItem()
+
+		// Delete a ClusterInfoImport
+		c.mcClient.MulticlusterV1alpha1().ClusterInfoImports(clusterInfoImport2.GetNamespace()).Delete(context.TODO(),
+			clusterInfoImport2.Name, metav1.DeleteOptions{})
+		c.ofClient.EXPECT().UninstallMulticlusterFlows(clusterInfoImport2.Name).Times(1)
+		c.processNextWorkItem()
+
+		// Create Gateway2 as active Gateway
+		c.mcClient.MulticlusterV1alpha1().Gateways(gateway2.GetNamespace()).Create(context.TODO(),
+			&gateway2, metav1.CreateOptions{})
+		c.ofClient.EXPECT().UninstallMulticlusterFlows(gateway1.Name).Times(1)
+		c.ofClient.EXPECT().UninstallMulticlusterFlows(clusterInfoImport1.Name).Times(1)
+		c.ofClient.EXPECT().InstallMulticlusterClassifierFlows(gateway2.Name, uint32(1), false).Times(1)
+		c.ofClient.EXPECT().InstallMulticlusterNodeFlows(clusterInfoImport1.Name, gomock.Any(), gw2InternalIP).Times(1)
+		c.processNextWorkItem()
+
+		// Delete Gateway2, then Gateway1 become active Gateway
+		c.mcClient.MulticlusterV1alpha1().Gateways(gateway2.GetNamespace()).Delete(context.TODO(),
+			gateway2.Name, metav1.DeleteOptions{})
+		c.ofClient.EXPECT().UninstallMulticlusterFlows(gateway2.Name).Times(1)
+		c.ofClient.EXPECT().UninstallMulticlusterFlows(clusterInfoImport1.Name).Times(1)
+		c.ofClient.EXPECT().InstallMulticlusterClassifierFlows(gateway1.Name, uint32(1), true).Times(1)
+		c.ofClient.EXPECT().InstallMulticlusterGatewayFlows(clusterInfoImport1.Name,
+			gomock.Any(), peerNodeIP1, gw1GatewayIP).Times(1)
+		c.processNextWorkItem()
+
+		// Delete last Gateway
+		c.mcClient.MulticlusterV1alpha1().Gateways(gateway1.GetNamespace()).Delete(context.TODO(),
+			gateway1.Name, metav1.DeleteOptions{})
+		c.ofClient.EXPECT().UninstallMulticlusterFlows(gateway1.Name).Times(1)
+		c.ofClient.EXPECT().UninstallMulticlusterFlows(clusterInfoImport1.Name).Times(1)
+		c.processNextWorkItem()
+	}()
+	select {
+	case <-time.After(5 * time.Second):
+		t.Errorf("Test didn't finish in time")
+	case <-finishCh:
+	}
+}
+
+func TestMCRouteControllerAsRegularNode(t *testing.T) {
+	c, closeFn := newMCRouteController(t, &config.NodeConfig{Name: "node-3"})
+	defer closeFn()
+	defer c.queue.ShutDown()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	c.informerFactory.Start(stopCh)
+	c.informerFactory.WaitForCacheSync(stopCh)
+
+	finishCh := make(chan struct{})
+	go func() {
+		defer close(finishCh)
+		peerNodeIP1 := net.ParseIP(gateway1.InternalIP)
+		peerNodeIP2 := net.ParseIP(gateway2.InternalIP)
+
+		// Create Gateway1
+		c.mcClient.MulticlusterV1alpha1().Gateways(gateway1.GetNamespace()).Create(context.TODO(),
+			&gateway1, metav1.CreateOptions{})
+		c.ofClient.EXPECT().InstallMulticlusterClassifierFlows(gateway1.Name, uint32(1), false).Times(1)
+		c.processNextWorkItem()
+
+		// Create two ClusterInfoImports
+		c.mcClient.MulticlusterV1alpha1().ClusterInfoImports(clusterInfoImport1.GetNamespace()).
+			Create(context.TODO(), &clusterInfoImport1, metav1.CreateOptions{})
+		c.ofClient.EXPECT().InstallMulticlusterNodeFlows(
+			clusterInfoImport1.Name, gomock.Any(), peerNodeIP1).Times(1)
+		c.processNextWorkItem()
+
+		c.mcClient.MulticlusterV1alpha1().ClusterInfoImports(clusterInfoImport2.GetNamespace()).
+			Create(context.TODO(), &clusterInfoImport2, metav1.CreateOptions{})
+		c.ofClient.EXPECT().InstallMulticlusterNodeFlows(
+			clusterInfoImport2.Name, gomock.Any(), peerNodeIP1).Times(1)
+		c.processNextWorkItem()
+
+		// Update a ClusterInfoImport
+		clusterInfoImport1.Spec.ServiceCIDR = "192.12.1.0/24"
+		c.mcClient.MulticlusterV1alpha1().ClusterInfoImports(clusterInfoImport1.GetNamespace()).
+			Update(context.TODO(), &clusterInfoImport1, metav1.UpdateOptions{})
+		c.ofClient.EXPECT().InstallMulticlusterNodeFlows(clusterInfoImport1.Name,
+			gomock.Any(), peerNodeIP1).Times(1)
+		c.processNextWorkItem()
+
+		// Delete a ClusterInfoImport
+		c.mcClient.MulticlusterV1alpha1().ClusterInfoImports(clusterInfoImport2.GetNamespace()).Delete(context.TODO(),
+			clusterInfoImport2.Name, metav1.DeleteOptions{})
+		c.ofClient.EXPECT().UninstallMulticlusterFlows(clusterInfoImport2.Name).Times(1)
+		c.processNextWorkItem()
+
+		// Create Gateway2 as the active Gateway
+		c.mcClient.MulticlusterV1alpha1().Gateways(gateway2.GetNamespace()).Create(context.TODO(),
+			&gateway2, metav1.CreateOptions{})
+		c.ofClient.EXPECT().InstallMulticlusterClassifierFlows(gateway2.Name, uint32(1), false).Times(1)
+		c.ofClient.EXPECT().InstallMulticlusterNodeFlows(clusterInfoImport1.Name, gomock.Any(), peerNodeIP2).Times(1)
+		c.ofClient.EXPECT().UninstallMulticlusterFlows(gateway1.Name).Times(1)
+		c.ofClient.EXPECT().UninstallMulticlusterFlows(clusterInfoImport1.Name).Times(1)
+		c.processNextWorkItem()
+
+		// Delete Gateway2, then Gateway1 become active Gateway
+		c.mcClient.MulticlusterV1alpha1().Gateways(gateway2.GetNamespace()).Delete(context.TODO(),
+			gateway2.Name, metav1.DeleteOptions{})
+		c.ofClient.EXPECT().UninstallMulticlusterFlows(gateway2.Name).Times(1)
+		c.ofClient.EXPECT().UninstallMulticlusterFlows(clusterInfoImport1.Name).Times(1)
+		c.ofClient.EXPECT().InstallMulticlusterClassifierFlows(gateway1.Name, uint32(1), false).Times(1)
+		c.ofClient.EXPECT().InstallMulticlusterNodeFlows(
+			clusterInfoImport1.Name, gomock.Any(), peerNodeIP1).Times(1)
+		c.processNextWorkItem()
+
+		// Delete last Gateway
+		c.mcClient.MulticlusterV1alpha1().Gateways(gateway1.GetNamespace()).Delete(context.TODO(),
+			gateway1.Name, metav1.DeleteOptions{})
+		c.ofClient.EXPECT().UninstallMulticlusterFlows(gateway1.Name).Times(1)
+		c.ofClient.EXPECT().UninstallMulticlusterFlows(clusterInfoImport1.Name).Times(1)
+		c.processNextWorkItem()
+	}()
+	select {
+	case <-time.After(5 * time.Second):
+		t.Errorf("Test didn't finish in time")
+	case <-finishCh:
+	}
+}

--- a/pkg/agent/openflow/client_test.go
+++ b/pkg/agent/openflow/client_test.go
@@ -107,7 +107,7 @@ func TestIdempotentFlowInstallation(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
-			ofClient := NewClient(bridgeName, bridgeMgmtAddr, true, false, false, false, false, false, false, false)
+			ofClient := NewClient(bridgeName, bridgeMgmtAddr, true, false, false, false, false, false, false, false, false)
 			client := ofClient.(*client)
 			client.cookieAllocator = cookie.NewAllocator(0)
 			client.ofEntryOperations = m
@@ -140,7 +140,7 @@ func TestIdempotentFlowInstallation(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
-			ofClient := NewClient(bridgeName, bridgeMgmtAddr, true, false, false, false, false, false, false, false)
+			ofClient := NewClient(bridgeName, bridgeMgmtAddr, true, false, false, false, false, false, false, false, false)
 			client := ofClient.(*client)
 			client.cookieAllocator = cookie.NewAllocator(0)
 			client.ofEntryOperations = m
@@ -186,7 +186,7 @@ func TestFlowInstallationFailed(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
-			ofClient := NewClient(bridgeName, bridgeMgmtAddr, true, false, false, false, false, false, false, false)
+			ofClient := NewClient(bridgeName, bridgeMgmtAddr, true, false, false, false, false, false, false, false, false)
 			client := ofClient.(*client)
 			client.cookieAllocator = cookie.NewAllocator(0)
 			client.ofEntryOperations = m
@@ -225,7 +225,7 @@ func TestConcurrentFlowInstallation(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
-			ofClient := NewClient(bridgeName, bridgeMgmtAddr, true, false, false, false, false, false, false, false)
+			ofClient := NewClient(bridgeName, bridgeMgmtAddr, true, false, false, false, false, false, false, false, false)
 			client := ofClient.(*client)
 			client.cookieAllocator = cookie.NewAllocator(0)
 			client.ofEntryOperations = m
@@ -420,7 +420,7 @@ func Test_client_SendTraceflowPacket(t *testing.T) {
 }
 
 func prepareTraceflowFlow(ctrl *gomock.Controller) *client {
-	ofClient := NewClient(bridgeName, bridgeMgmtAddr, true, true, false, false, false, false, false, false)
+	ofClient := NewClient(bridgeName, bridgeMgmtAddr, true, true, false, false, false, false, false, false, false)
 	c := ofClient.(*client)
 	c.cookieAllocator = cookie.NewAllocator(0)
 	c.nodeConfig = nodeConfig
@@ -446,7 +446,7 @@ func prepareTraceflowFlow(ctrl *gomock.Controller) *client {
 }
 
 func prepareSendTraceflowPacket(ctrl *gomock.Controller, success bool) *client {
-	ofClient := NewClient(bridgeName, bridgeMgmtAddr, true, true, false, false, false, false, false, false)
+	ofClient := NewClient(bridgeName, bridgeMgmtAddr, true, true, false, false, false, false, false, false, false)
 	c := ofClient.(*client)
 	c.nodeConfig = nodeConfig
 	m := ovsoftest.NewMockBridge(ctrl)
@@ -534,7 +534,7 @@ func Test_client_setBasePacketOutBuilder(t *testing.T) {
 }
 
 func prepareSetBasePacketOutBuilder(ctrl *gomock.Controller, success bool) *client {
-	ofClient := NewClient(bridgeName, bridgeMgmtAddr, true, true, false, false, false, false, false, false)
+	ofClient := NewClient(bridgeName, bridgeMgmtAddr, true, true, false, false, false, false, false, false, false)
 	c := ofClient.(*client)
 	m := ovsoftest.NewMockBridge(ctrl)
 	c.bridge = m

--- a/pkg/agent/openflow/cookie/allocator.go
+++ b/pkg/agent/openflow/cookie/allocator.go
@@ -36,6 +36,7 @@ const (
 	Service
 	Egress
 	Multicast
+	Multicluster
 	Traceflow
 )
 
@@ -53,6 +54,8 @@ func (c Category) String() string {
 		return "Egress"
 	case Multicast:
 		return "Multicast"
+	case Multicluster:
+		return "Multicluster"
 	case Traceflow:
 		return "Traceflow"
 	default:

--- a/pkg/agent/openflow/fields.go
+++ b/pkg/agent/openflow/fields.go
@@ -89,6 +89,8 @@ var (
 	OutputToBridgeRegMark = binding.NewRegMark(TargetOFPortField, config.BridgeOFPort)
 	// OutputToUplinkRegMark marks that the output interface is uplink.
 	OutputToUplinkRegMark = binding.NewRegMark(TargetOFPortField, config.UplinkOFPort)
+	// OutputToTunnelRegMark marks that the output interface is tunnel interface.
+	OutputToTunnelRegMark = binding.NewRegMark(TargetOFPortField, config.DefaultTunOFPort)
 
 	// reg2(NXM_NX_REG2)
 	// Field to help swap values in two different flow fields in the OpenFlow actions. This field is only used in func
@@ -179,6 +181,7 @@ var (
 	ConnSourceCTMarkField = binding.NewCTMarkField(0, 3)
 	FromGatewayCTMark     = binding.NewCTMark(ConnSourceCTMarkField, gatewayVal)
 	FromBridgeCTMark      = binding.NewCTMark(ConnSourceCTMarkField, bridgeVal)
+	FromTunnelCTMark      = binding.NewCTMark(ConnSourceCTMarkField, tunnelVal)
 
 	// CTMark[4]: Marks to indicate whether DNAT is performed on the connection for Service.
 	// These CT marks are used in CtZone / CtZoneV6 and SNATCtZone / SNATCtZoneV6.

--- a/pkg/agent/openflow/framework.go
+++ b/pkg/agent/openflow/framework.go
@@ -250,6 +250,16 @@ func (f *featureMulticast) getRequiredTables() []*Table {
 	}
 }
 
+func (f *featureMulticluster) getRequiredTables() []*Table {
+	return []*Table{
+		ClassifierTable,
+		SNATConntrackTable,
+		L3ForwardingTable,
+		SNATConntrackCommitTable,
+		L2ForwardingOutTable,
+	}
+}
+
 func (f *featureTraceflow) getRequiredTables() []*Table {
 	return nil
 }

--- a/pkg/agent/openflow/multicluster.go
+++ b/pkg/agent/openflow/multicluster.go
@@ -1,0 +1,198 @@
+// Copyright 2022 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openflow
+
+import (
+	"net"
+
+	"antrea.io/antrea/pkg/agent/openflow/cookie"
+	binding "antrea.io/antrea/pkg/ovs/openflow"
+)
+
+// GlobalVirtualMACForMulticluster is a vritual MAC which will be used only
+// for cross-cluster traffic to distinguish in-cluster traffic.
+var GlobalVirtualMACForMulticluster, _ = net.ParseMAC("aa:bb:cc:dd:ee:f0")
+
+type featureMulticluster struct {
+	cookieAllocator cookie.Allocator
+	cachedFlows     *flowCategoryCache
+	category        cookie.Category
+	ipProtocols     []binding.Protocol
+	snatCtZones     map[binding.Protocol]int
+}
+
+func (f *featureMulticluster) getFeatureName() string {
+	return "Multicluster"
+}
+
+func newFeatureMulticluster(cookieAllocator cookie.Allocator, ipProtocols []binding.Protocol) *featureMulticluster {
+	snatCtZones := make(map[binding.Protocol]int)
+	snatCtZones[ipProtocols[0]] = MCSNATCtZone
+	return &featureMulticluster{
+		cookieAllocator: cookieAllocator,
+		cachedFlows:     newFlowCategoryCache(),
+		category:        cookie.Multicluster,
+		ipProtocols:     ipProtocols,
+		snatCtZones:     snatCtZones,
+	}
+}
+
+func (f *featureMulticluster) initFlows() []binding.Flow {
+	return []binding.Flow{}
+}
+
+func (f *featureMulticluster) replayFlows() []binding.Flow {
+	return getCachedFlows(f.cachedFlows)
+}
+
+func (f *featureMulticluster) l3FwdFlowToGatewayNodeViaTun(
+	localGatewayMAC net.HardwareAddr,
+	peerServiceCIDR net.IPNet,
+	tunnelPeer net.IP,
+	remoteGatewayIP net.IP) []binding.Flow {
+	ipProtocol := getIPProtocol(peerServiceCIDR.IP)
+	cookieID := f.cookieAllocator.Request(f.category).Raw()
+	var flows []binding.Flow
+	flows = append(flows,
+		// This generates the flow to forward cross-cluster request packets based
+		// on Service ClusterIP range.
+		L3ForwardingTable.ofTable.BuildFlow(priorityNormal).
+			Cookie(cookieID).
+			MatchProtocol(ipProtocol).
+			MatchDstIPNet(peerServiceCIDR).
+			Action().SetSrcMAC(localGatewayMAC).  // Rewrite src MAC to local gateway MAC.
+			Action().SetDstMAC(GlobalVirtualMAC). // Rewrite dst MAC to virtual MAC.
+			Action().SetTunnelDst(tunnelPeer).    // Flow based tunnel. Set tunnel destination.
+			Action().LoadRegMark(ToTunnelRegMark).
+			Action().GotoTable(L3DecTTLTable.GetID()).
+			Done(),
+		// This generates the flow to forward cross-cluster reply traffic based
+		// on Gateway IP.
+		L3ForwardingTable.ofTable.BuildFlow(priorityNormal).
+			Cookie(cookieID).
+			MatchProtocol(ipProtocol).
+			MatchCTStateRpl(true).
+			MatchCTStateTrk(true).
+			MatchDstIP(remoteGatewayIP).
+			Action().SetSrcMAC(localGatewayMAC).
+			Action().SetDstMAC(GlobalVirtualMACForMulticluster).
+			Action().SetTunnelDst(tunnelPeer). // Flow based tunnel. Set tunnel destination.
+			Action().LoadRegMark(ToTunnelRegMark).
+			Action().GotoTable(L3DecTTLTable.GetID()).
+			Done(),
+	)
+	return flows
+}
+
+func (f *featureMulticluster) l3FwdFlowToRemoteGatewayViaTun(
+	localGatewayMAC net.HardwareAddr,
+	peerServiceCIDR net.IPNet,
+	tunnelPeer net.IP,
+	remoteGatewayIP net.IP) []binding.Flow {
+	ipProtocol := getIPProtocol(remoteGatewayIP)
+	cookieID := f.cookieAllocator.Request(f.category).Raw()
+	var flows []binding.Flow
+	flows = append(flows,
+		// This generates the flow to forward cross-cluster request packets based
+		// on Service ClusterIP range.
+		L3ForwardingTable.ofTable.BuildFlow(priorityNormal).
+			Cookie(cookieID).
+			MatchProtocol(ipProtocol).
+			MatchDstIPNet(peerServiceCIDR).
+			Action().SetSrcMAC(localGatewayMAC).                 // Rewrite src MAC to local gateway MAC.
+			Action().SetDstMAC(GlobalVirtualMACForMulticluster). // Rewrite dst MAC to virtual Multi-cluster MAC.
+			Action().SetTunnelDst(tunnelPeer).                   // Flow based tunnel. Set tunnel destination.
+			Action().LoadRegMark(ToTunnelRegMark).
+			Action().GotoTable(L3DecTTLTable.GetID()).
+			Done(),
+		// This generates the flow to forward cross-cluster reply traffic based
+		// on Gateway IP.
+		L3ForwardingTable.ofTable.BuildFlow(priorityNormal).
+			Cookie(cookieID).
+			MatchProtocol(ipProtocol).
+			MatchDstIP(remoteGatewayIP).
+			MatchCTStateRpl(true).
+			MatchCTStateTrk(true).
+			Action().SetSrcMAC(localGatewayMAC).
+			Action().SetDstMAC(GlobalVirtualMACForMulticluster).
+			Action().SetTunnelDst(tunnelPeer). // Flow based tunnel. Set tunnel destination.
+			Action().LoadRegMark(ToTunnelRegMark).
+			Action().GotoTable(L3DecTTLTable.GetID()).
+			Done(),
+	)
+	return flows
+}
+
+func (f *featureMulticluster) tunnelClassifierFlow(category cookie.Category, tunnelOFPort uint32) binding.Flow {
+	return ClassifierTable.ofTable.BuildFlow(priorityHigh).
+		Cookie(f.cookieAllocator.Request(category).Raw()).
+		MatchInPort(tunnelOFPort).
+		MatchDstMAC(GlobalVirtualMACForMulticluster).
+		Action().LoadRegMark(FromTunnelRegMark).
+		Action().LoadRegMark(RewriteMACRegMark).
+		Action().GotoStage(stageConntrackState).
+		Done()
+}
+
+func (f *featureMulticluster) outputFlow(category cookie.Category, tunnelOFPort uint32) binding.Flow {
+	return L2ForwardingOutTable.ofTable.BuildFlow(priorityHigh).
+		Cookie(f.cookieAllocator.Request(f.category).Raw()).
+		MatchRegMark(RewriteMACRegMark).
+		MatchRegMark(OutputToTunnelRegMark).
+		MatchInPort(tunnelOFPort).
+		Action().OutputInPort().
+		Done()
+}
+
+func (f *featureMulticluster) snatConntrackFlows(serviceCIDR net.IPNet, localGatewayIP net.IP) []binding.Flow {
+	cookieID := f.cookieAllocator.Request(f.category).Raw()
+	var flows []binding.Flow
+	ipProtocol := getIPProtocol(localGatewayIP)
+	flows = append(flows,
+		// This generates the flow to restore destination IP of reply packets of cross-cluster Service
+		// connections committed in the SNAT CT zone
+		SNATConntrackTable.ofTable.BuildFlow(priorityHigh).
+			Cookie(cookieID).
+			MatchProtocol(ipProtocol).
+			MatchDstIP(localGatewayIP).
+			Action().CT(false, SNATConntrackTable.GetNext(), f.snatCtZones[ipProtocol], nil).
+			NAT().
+			CTDone().
+			Done(),
+		SNATConntrackCommitTable.ofTable.BuildFlow(priorityNormal).
+			Cookie(cookieID).
+			MatchProtocol(ipProtocol).
+			MatchDstIPNet(serviceCIDR).
+			Action().CT(true, SNATConntrackCommitTable.GetNext(), f.snatCtZones[ipProtocol], nil).
+			MoveToCtMarkField(PktSourceField, ConnSourceCTMarkField).
+			SNAT(&binding.IPRange{StartIP: localGatewayIP, EndIP: localGatewayIP}, nil).
+			CTDone().
+			Done(),
+		ConntrackTable.ofTable.BuildFlow(priorityHigh).
+			Cookie(cookieID).
+			MatchProtocol(ipProtocol).
+			MatchSrcIPNet(serviceCIDR).
+			MatchCTMark(FromTunnelCTMark).
+			Action().GotoTable(PreRoutingClassifierTable.GetID()).
+			Done(),
+		ConntrackCommitTable.ofTable.BuildFlow(priorityHigh).
+			Cookie(cookieID).
+			MatchProtocol(ipProtocol).
+			MatchCTMark(FromTunnelCTMark).
+			Action().GotoTable(L2ForwardingOutTable.GetID()).
+			Done(),
+	)
+	return flows
+}

--- a/pkg/agent/openflow/network_policy_test.go
+++ b/pkg/agent/openflow/network_policy_test.go
@@ -524,7 +524,7 @@ func TestBatchInstallPolicyRuleFlows(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			mockOperations := oftest.NewMockOFEntryOperations(ctrl)
-			ofClient := NewClient(bridgeName, bridgeMgmtAddr, false, true, false, false, false, false, false, false)
+			ofClient := NewClient(bridgeName, bridgeMgmtAddr, false, true, false, false, false, false, false, false, false)
 			c = ofClient.(*client)
 			c.cookieAllocator = cookie.NewAllocator(0)
 			c.ofEntryOperations = mockOperations

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -314,6 +314,7 @@ const (
 	CtZoneV6     = 0xffe6
 	SNATCtZone   = 0xfff1
 	SNATCtZoneV6 = 0xffe7
+	MCSNATCtZone = 0xfffa
 
 	// disposition values used in AP
 	DispositionAllow = 0b00
@@ -394,6 +395,7 @@ type client struct {
 	enableEgress          bool
 	enableMulticast       bool
 	enableTrafficControl  bool
+	enableMulticluster    bool
 	connectUplinkToBridge bool
 	roundInfo             types.RoundInfo
 	cookieAllocator       cookie.Allocator
@@ -404,6 +406,7 @@ type client struct {
 	featureEgress          *featureEgress
 	featureNetworkPolicy   *featureNetworkPolicy
 	featureMulticast       *featureMulticast
+	featureMulticluster    *featureMulticluster
 	activatedFeatures      []feature
 
 	featureTraceflow  *featureTraceflow
@@ -2646,7 +2649,8 @@ func NewClient(bridgeName string,
 	proxyAll bool,
 	connectUplinkToBridge bool,
 	enableMulticast bool,
-	enableTrafficControl bool) Client {
+	enableTrafficControl bool,
+	enableMulticluster bool) Client {
 	bridge := binding.NewOFBridge(bridgeName, mgmtAddr)
 	c := &client{
 		bridge:                bridge,
@@ -2657,6 +2661,7 @@ func NewClient(bridgeName string,
 		enableEgress:          enableEgress,
 		enableMulticast:       enableMulticast,
 		enableTrafficControl:  enableTrafficControl,
+		enableMulticluster:    enableMulticluster,
 		connectUplinkToBridge: connectUplinkToBridge,
 		pipelines:             make(map[binding.PipelineID]binding.Pipeline),
 		packetInHandlers:      map[uint8]map[string]PacketInHandler{},

--- a/pkg/agent/openflow/testing/mock_openflow.go
+++ b/pkg/agent/openflow/testing/mock_openflow.go
@@ -324,6 +324,48 @@ func (mr *MockClientMockRecorder) InstallMulticastInitialFlows(arg0 interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallMulticastInitialFlows", reflect.TypeOf((*MockClient)(nil).InstallMulticastInitialFlows), arg0)
 }
 
+// InstallMulticlusterClassifierFlows mocks base method
+func (m *MockClient) InstallMulticlusterClassifierFlows(arg0 string, arg1 uint32, arg2 bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InstallMulticlusterClassifierFlows", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// InstallMulticlusterClassifierFlows indicates an expected call of InstallMulticlusterClassifierFlows
+func (mr *MockClientMockRecorder) InstallMulticlusterClassifierFlows(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallMulticlusterClassifierFlows", reflect.TypeOf((*MockClient)(nil).InstallMulticlusterClassifierFlows), arg0, arg1, arg2)
+}
+
+// InstallMulticlusterGatewayFlows mocks base method
+func (m *MockClient) InstallMulticlusterGatewayFlows(arg0 string, arg1 map[*net.IPNet]net.IP, arg2, arg3 net.IP) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InstallMulticlusterGatewayFlows", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// InstallMulticlusterGatewayFlows indicates an expected call of InstallMulticlusterGatewayFlows
+func (mr *MockClientMockRecorder) InstallMulticlusterGatewayFlows(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallMulticlusterGatewayFlows", reflect.TypeOf((*MockClient)(nil).InstallMulticlusterGatewayFlows), arg0, arg1, arg2, arg3)
+}
+
+// InstallMulticlusterNodeFlows mocks base method
+func (m *MockClient) InstallMulticlusterNodeFlows(arg0 string, arg1 map[*net.IPNet]net.IP, arg2 net.IP) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InstallMulticlusterNodeFlows", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// InstallMulticlusterNodeFlows indicates an expected call of InstallMulticlusterNodeFlows
+func (mr *MockClientMockRecorder) InstallMulticlusterNodeFlows(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallMulticlusterNodeFlows", reflect.TypeOf((*MockClient)(nil).InstallMulticlusterNodeFlows), arg0, arg1, arg2)
+}
+
 // InstallNodeFlows mocks base method
 func (m *MockClient) InstallNodeFlows(arg0 string, arg1 map[*net.IPNet]net.IP, arg2 *ip.DualStackIPs, arg3 uint32, arg4 net.HardwareAddr) error {
 	m.ctrl.T.Helper()
@@ -680,6 +722,20 @@ func (m *MockClient) UninstallMulticastFlows(arg0 net.IP) error {
 func (mr *MockClientMockRecorder) UninstallMulticastFlows(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UninstallMulticastFlows", reflect.TypeOf((*MockClient)(nil).UninstallMulticastFlows), arg0)
+}
+
+// UninstallMulticlusterFlows mocks base method
+func (m *MockClient) UninstallMulticlusterFlows(arg0 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UninstallMulticlusterFlows", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UninstallMulticlusterFlows indicates an expected call of UninstallMulticlusterFlows
+func (mr *MockClientMockRecorder) UninstallMulticlusterFlows(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UninstallMulticlusterFlows", reflect.TypeOf((*MockClient)(nil).UninstallMulticlusterFlows), arg0)
 }
 
 // UninstallNodeFlows mocks base method

--- a/pkg/apiserver/handlers/featuregates/handler.go
+++ b/pkg/apiserver/handlers/featuregates/handler.go
@@ -30,7 +30,8 @@ import (
 )
 
 var controllerGates = sets.NewString("Traceflow", "AntreaPolicy", "Egress", "NetworkPolicyStats", "NodeIPAM", "ServiceExternalIP")
-var agentGates = sets.NewString("AntreaPolicy", "AntreaProxy", "Egress", "EndpointSlice", "Traceflow", "FlowExporter", "NetworkPolicyStats", "NodePortLocal", "AntreaIPAM", "Multicast", "ServiceExternalIP")
+var agentGates = sets.NewString("AntreaPolicy", "AntreaProxy", "Egress", "EndpointSlice", "Traceflow", "FlowExporter", "NetworkPolicyStats",
+	"NodePortLocal", "AntreaIPAM", "Multicast", "ServiceExternalIP", "Multicluster")
 
 type (
 	Config struct {

--- a/pkg/apiserver/handlers/featuregates/handler_test.go
+++ b/pkg/apiserver/handlers/featuregates/handler_test.go
@@ -62,6 +62,7 @@ func Test_getGatesResponse(t *testing.T) {
 				{Component: "agent", Name: "NodePortLocal", Status: nplStatus, Version: "BETA"},
 				{Component: "agent", Name: "Multicast", Status: "Disabled", Version: "ALPHA"},
 				{Component: "agent", Name: "ServiceExternalIP", Status: "Disabled", Version: "ALPHA"},
+				{Component: "agent", Name: "Multicluster", Status: "Disabled", Version: "ALPHA"},
 			},
 		},
 	}

--- a/pkg/config/agent/config.go
+++ b/pkg/config/agent/config.go
@@ -192,6 +192,8 @@ type AgentConfig struct {
 	AntreaProxy AntreaProxyConfig `yaml:"antreaProxy,omitempty"`
 	// Egress related configurations.
 	Egress EgressConfig `yaml:"egress"`
+	// Multicluster configuration options.
+	Multicluster MulticlusterConfig `yaml:"multicluster,omitempty"`
 }
 
 type AntreaProxyConfig struct {
@@ -245,4 +247,13 @@ type MulticastConfig struct {
 
 type EgressConfig struct {
 	ExceptCIDRs []string `yaml:"exceptCIDRs,omitempty"`
+}
+
+type MulticlusterConfig struct {
+	// Enable Multicluster which allow cross-cluster traffic between member clusters
+	// in a ClusterSet.
+	Enable bool `yaml:"enable,omitempty"`
+	// The Namespace where the Antrea Multi-cluster controller is running.
+	// 'kube-system' will be used by default if it's emtpy.
+	Namespace string `yaml:"namespace,omitempty"`
 }

--- a/pkg/features/antrea_features.go
+++ b/pkg/features/antrea_features.go
@@ -84,6 +84,10 @@ const (
 	// Enable Multicast.
 	Multicast featuregate.Feature = "Multicast"
 
+	// alpha: v1.7
+	// Enable Multicluster.
+	Multicluster featuregate.Feature = "Multicluster"
+
 	// alpha: v1.5
 	// Enable Secondary interface feature for Antrea.
 	SecondaryNetwork featuregate.Feature = "SecondaryNetwork"
@@ -120,6 +124,7 @@ var (
 		NodePortLocal:      {Default: true, PreRelease: featuregate.Beta},
 		NodeIPAM:           {Default: false, PreRelease: featuregate.Alpha},
 		Multicast:          {Default: false, PreRelease: featuregate.Alpha},
+		Multicluster:       {Default: false, PreRelease: featuregate.Alpha},
 		SecondaryNetwork:   {Default: false, PreRelease: featuregate.Alpha},
 		ServiceExternalIP:  {Default: false, PreRelease: featuregate.Alpha},
 		TrafficControl:     {Default: false, PreRelease: featuregate.Alpha},
@@ -142,6 +147,9 @@ var (
 		Multicast:         {},
 		SecondaryNetwork:  {},
 		ServiceExternalIP: {},
+		// Multicluster feature is not validated on Windows yet. This can removed
+		// in the future if it's fully tested on Windows.
+		Multicluster: {},
 	}
 )
 

--- a/pkg/ovs/openflow/interfaces.go
+++ b/pkg/ovs/openflow/interfaces.go
@@ -76,6 +76,7 @@ const (
 	NxmFieldDstIPv4     = "NXM_OF_IP_DST"
 	NxmFieldSrcIPv6     = "NXM_NX_IPV6_SRC"
 	NxmFieldDstIPv6     = "NXM_NX_IPV6_DST"
+	NxmFieldInPort      = "NXM_OF_IN_PORT"
 
 	OxmFieldVLANVID = "OXM_OF_VLAN_VID"
 )

--- a/pkg/ovs/openflow/ofctrl_action.go
+++ b/pkg/ovs/openflow/ofctrl_action.go
@@ -270,14 +270,14 @@ func (a *ofFlowAction) SetVLAN(vlanID uint16) FlowBuilder {
 	return a.builder
 }
 
-// LoadARPOperation is an action to Load data to NXM_OF_ARP_OP field.
+// LoadARPOperation is an action to load data to NXM_OF_ARP_OP field.
 func (a *ofFlowAction) LoadARPOperation(value uint16) FlowBuilder {
 	loadAct, _ := ofctrl.NewNXLoadAction(NxmFieldARPOp, uint64(value), openflow13.NewNXRange(0, 15))
 	a.builder.ApplyAction(loadAct)
 	return a.builder
 }
 
-// LoadRange is an action to Load data to the target field at specified range.
+// LoadRange is an action to load data to the target field at specified range.
 func (a *ofFlowAction) LoadRange(name string, value uint64, rng *Range) FlowBuilder {
 	loadAct, _ := ofctrl.NewNXLoadAction(name, value, rng.ToNXRange())
 	if a.builder.ofFlow.Table != nil && a.builder.ofFlow.Table.Switch != nil {

--- a/pkg/ovs/openflow/ofctrl_group.go
+++ b/pkg/ovs/openflow/ofctrl_group.go
@@ -103,7 +103,7 @@ func (b *bucketBuilder) LoadXXReg(regID int, data []byte) BucketBuilder {
 	return b
 }
 
-// LoadRegRange is an action to Load data to the target register at specified range.
+// LoadRegRange is an action to load data to the target register at specified range.
 func (b *bucketBuilder) LoadRegRange(regID int, data uint32, rng *Range) BucketBuilder {
 	reg := fmt.Sprintf("%s%d", NxmFieldReg, regID)
 	regField, _ := openflow13.FindFieldHeaderByName(reg, true)

--- a/test/integration/agent/openflow_test.go
+++ b/test/integration/agent/openflow_test.go
@@ -117,7 +117,7 @@ func TestConnectivityFlows(t *testing.T) {
 		antrearuntime.WindowsOS = runtime.GOOS
 	}
 
-	c = ofClient.NewClient(br, bridgeMgmtAddr, true, false, true, false, false, false, false, false)
+	c = ofClient.NewClient(br, bridgeMgmtAddr, true, false, true, false, false, false, false, false, false)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge: %v", err))
 	defer func() {
@@ -165,7 +165,7 @@ func TestAntreaFlexibleIPAMConnectivityFlows(t *testing.T) {
 	legacyregistry.Reset()
 	metrics.InitializeOVSMetrics()
 
-	c = ofClient.NewClient(br, bridgeMgmtAddr, true, false, true, false, false, true, false, false)
+	c = ofClient.NewClient(br, bridgeMgmtAddr, true, false, true, false, false, true, false, false, false)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge: %v", err))
 	defer func() {
@@ -224,7 +224,7 @@ func TestReplayFlowsConnectivityFlows(t *testing.T) {
 	legacyregistry.Reset()
 	metrics.InitializeOVSMetrics()
 
-	c = ofClient.NewClient(br, bridgeMgmtAddr, true, false, true, false, false, false, false, false)
+	c = ofClient.NewClient(br, bridgeMgmtAddr, true, false, true, false, false, false, false, false, false)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge: %v", err))
 
@@ -266,7 +266,7 @@ func TestReplayFlowsNetworkPolicyFlows(t *testing.T) {
 	legacyregistry.Reset()
 	metrics.InitializeOVSMetrics()
 
-	c = ofClient.NewClient(br, bridgeMgmtAddr, true, false, false, false, false, false, false, false)
+	c = ofClient.NewClient(br, bridgeMgmtAddr, true, false, false, false, false, false, false, false, false)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge: %v", err))
 
@@ -443,7 +443,7 @@ func TestNetworkPolicyFlows(t *testing.T) {
 	legacyregistry.Reset()
 	metrics.InitializeOVSMetrics()
 
-	c = ofClient.NewClient(br, bridgeMgmtAddr, true, false, false, false, false, false, false, false)
+	c = ofClient.NewClient(br, bridgeMgmtAddr, true, false, false, false, false, false, false, false, false)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge %s", br))
 
@@ -557,7 +557,7 @@ func TestIPv6ConnectivityFlows(t *testing.T) {
 	legacyregistry.Reset()
 	metrics.InitializeOVSMetrics()
 
-	c = ofClient.NewClient(br, bridgeMgmtAddr, true, false, true, false, false, false, false, false)
+	c = ofClient.NewClient(br, bridgeMgmtAddr, true, false, true, false, false, false, false, false, false)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge: %v", err))
 
@@ -605,7 +605,7 @@ func TestProxyServiceFlows(t *testing.T) {
 	legacyregistry.Reset()
 	metrics.InitializeOVSMetrics()
 
-	c = ofClient.NewClient(br, bridgeMgmtAddr, true, false, false, false, false, false, false, false)
+	c = ofClient.NewClient(br, bridgeMgmtAddr, true, false, false, false, false, false, false, false, false)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge %s", br))
 
@@ -1681,7 +1681,7 @@ func TestEgressMarkFlows(t *testing.T) {
 	legacyregistry.Reset()
 	metrics.InitializeOVSMetrics()
 
-	c = ofClient.NewClient(br, bridgeMgmtAddr, false, false, true, false, false, false, false, false)
+	c = ofClient.NewClient(br, bridgeMgmtAddr, false, false, true, false, false, false, false, false, false)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge %s", br))
 
@@ -1738,7 +1738,7 @@ func TestTrafficControlFlows(t *testing.T) {
 	legacyregistry.Reset()
 	metrics.InitializeOVSMetrics()
 
-	c = ofClient.NewClient(br, bridgeMgmtAddr, false, false, false, false, false, false, false, true)
+	c = ofClient.NewClient(br, bridgeMgmtAddr, false, false, false, false, false, false, false, true, false)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge %s", br))
 


### PR DESCRIPTION
This PR is on top of #3603, only top commit is for Endpoint change. 

Use Service ClusterIPs instead of Pod IPs as MC Service's Endpoints.
The ServiceExport controller will only watch ServiceExport and
Service events, and wrap Service's ClusterIPs into a new Endpoint kind of
ResourceExport.

Signed-off-by: Lan Luo <luola@vmware.com>