### PR TITLE
Automated cherry pick of #3728: Fix identification of control-plane Node in e2e test

### DIFF
--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -410,6 +410,15 @@ func RunCommandOnNode(nodeName string, cmd string) (code int, stdout string, std
 }
 
 func collectClusterInfo() error {
+	// retrieve K8s server version
+	// this needs to be done first, as there may be dependencies on the
+	// version later in this function (e.g., for labelNodeRoleControlPlane()).
+	serverVersion, err := testData.clientset.Discovery().ServerVersion()
+	if err != nil {
+		return err
+	}
+	clusterInfo.k8sServerVersion = serverVersion.String()
+
 	// retrieve Node information
 	nodes, err := testData.clientset.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
@@ -552,14 +561,6 @@ func collectClusterInfo() error {
 	}
 	clusterInfo.svcV4NetworkCIDR = svcCIDRs[0]
 	clusterInfo.svcV6NetworkCIDR = svcCIDRs[1]
-
-	// retrieve K8s server version
-
-	serverVersion, err := testData.clientset.Discovery().ServerVersion()
-	if err != nil {
-		return err
-	}
-	clusterInfo.k8sServerVersion = serverVersion.String()
 
 	// Retrieve kubernetes Service host and Port
 	svc, err := testData.clientset.CoreV1().Services("default").Get(context.TODO(), "kubernetes", metav1.GetOptions{})


### PR DESCRIPTION
Cherry pick of #3728 on release-1.5.

#3728: Fix identification of control-plane Node in e2e test

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.