### PR TITLE
Automated cherry pick of #3661: Replace busybox source to fix image errors

### DIFF
--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -116,7 +116,7 @@ const (
 	nameSuffixLength int = 8
 
 	agnhostImage        = "k8s.gcr.io/e2e-test-images/agnhost:2.29"
-	busyboxImage        = "projects.registry.vmware.com/library/busybox"
+	busyboxImage        = "projects.registry.vmware.com/antrea/busybox"
 	mcjoinImage         = "projects.registry.vmware.com/antrea/mcjoin:v2.9"
 	netshootImage       = "projects.registry.vmware.com/antrea/netshoot:v0.1"
 	nginxImage          = "projects.registry.vmware.com/antrea/nginx:1.21.6-alpine"


### PR DESCRIPTION
Cherry pick of #3661 on release-1.6.

#3661: Replace busybox source to fix image errors

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.