### PR TITLE
 [ExternalNode]Create/Delete AntreaAgentInfo based on ExternalNode

### DIFF
--- a/build/charts/antrea/templates/agent/clusterrole.yaml
+++ b/build/charts/antrea/templates/agent/clusterrole.yaml
@@ -57,9 +57,7 @@ rules:
       - antreaagentinfos
     verbs:
       - get
-      - create
       - update
-      - delete
   - apiGroups:
       - controlplane.antrea.io
     resources:

--- a/build/charts/antrea/templates/controller/clusterrole.yaml
+++ b/build/charts/antrea/templates/controller/clusterrole.yaml
@@ -143,6 +143,7 @@ rules:
       - antreaagentinfos
     verbs:
       - list
+      - create
       - delete
   - apiGroups:
       - crd.antrea.io

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -2940,9 +2940,7 @@ rules:
       - antreaagentinfos
     verbs:
       - get
-      - create
       - update
-      - delete
   - apiGroups:
       - controlplane.antrea.io
     resources:
@@ -3287,6 +3285,7 @@ rules:
       - antreaagentinfos
     verbs:
       - list
+      - create
       - delete
   - apiGroups:
       - crd.antrea.io

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -2940,9 +2940,7 @@ rules:
       - antreaagentinfos
     verbs:
       - get
-      - create
       - update
-      - delete
   - apiGroups:
       - controlplane.antrea.io
     resources:
@@ -3287,6 +3285,7 @@ rules:
       - antreaagentinfos
     verbs:
       - list
+      - create
       - delete
   - apiGroups:
       - crd.antrea.io

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -2940,9 +2940,7 @@ rules:
       - antreaagentinfos
     verbs:
       - get
-      - create
       - update
-      - delete
   - apiGroups:
       - controlplane.antrea.io
     resources:
@@ -3287,6 +3285,7 @@ rules:
       - antreaagentinfos
     verbs:
       - list
+      - create
       - delete
   - apiGroups:
       - crd.antrea.io

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -2953,9 +2953,7 @@ rules:
       - antreaagentinfos
     verbs:
       - get
-      - create
       - update
-      - delete
   - apiGroups:
       - controlplane.antrea.io
     resources:
@@ -3300,6 +3298,7 @@ rules:
       - antreaagentinfos
     verbs:
       - list
+      - create
       - delete
   - apiGroups:
       - crd.antrea.io

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -2940,9 +2940,7 @@ rules:
       - antreaagentinfos
     verbs:
       - get
-      - create
       - update
-      - delete
   - apiGroups:
       - controlplane.antrea.io
     resources:
@@ -3287,6 +3285,7 @@ rules:
       - antreaagentinfos
     verbs:
       - list
+      - create
       - delete
   - apiGroups:
       - crd.antrea.io

--- a/cmd/antrea-controller/controller.go
+++ b/cmd/antrea-controller/controller.go
@@ -172,7 +172,8 @@ func run(o *Options) error {
 
 	controllerQuerier := querier.NewControllerQuerier(networkPolicyController, o.config.APIPort)
 
-	controllerMonitor := monitor.NewControllerMonitor(crdClient, nodeInformer, controllerQuerier)
+	externalNodeEnabled := features.DefaultFeatureGate.Enabled(features.ExternalNode)
+	controllerMonitor := monitor.NewControllerMonitor(crdClient, nodeInformer, externalNodeInformer, controllerQuerier, externalNodeEnabled)
 
 	var egressController *egress.EgressController
 	var externalIPPoolController *externalippool.ExternalIPPoolController


### PR DESCRIPTION
[ExternalNode]Create/Delete AntreaAgentInfo based on ExternalNode
    
Antrea controller watches ExternalNode create and delete event.
It creates AntreaAgentInfo whose name is the same as ExternalNode name
after ExternalNode is created and delete AntreaAgentInfo when
ExternalNode is deleted.
    
The change also refactors monitoring part for Node case and lets controller
create AntreaAgentInfo for Node too. With this change,
for both Node and ExternalNode cases, it is always
Antrea controller to create/delete AntreaAgentInfo and
it is always Antrea agent to update AntreaAgentInfo.
    
Signed-off-by: Mengdie Song <songm@vmware.com>
