### PR TITLE
[ExternalNode] Add InterfaceConfig type for ExternalEntity

### DIFF
--- a/pkg/agent/controller/networkpolicy/reconciler.go
+++ b/pkg/agent/controller/networkpolicy/reconciler.go
@@ -874,12 +874,14 @@ func (r *reconciler) getOFPorts(members v1beta2.GroupMemberSet) sets.Int32 {
 	ofPorts := sets.NewInt32()
 	for _, m := range members {
 		var entityName, ns string
+		var ifaces []*interfacestore.InterfaceConfig
 		if m.Pod != nil {
 			entityName, ns = m.Pod.Name, m.Pod.Namespace
+			ifaces = r.ifaceStore.GetContainerInterfacesByPod(entityName, ns)
 		} else if m.ExternalEntity != nil {
 			entityName, ns = m.ExternalEntity.Name, m.ExternalEntity.Namespace
+			ifaces = r.ifaceStore.GetInterfacesByEntity(entityName, ns)
 		}
-		ifaces := r.ifaceStore.GetInterfacesByEntity(entityName, ns)
 		if len(ifaces) == 0 {
 			// This might be because the container has been deleted during realization or hasn't been set up yet.
 			klog.Infof("Can't find interface for %s/%s, skipping", ns, entityName)
@@ -897,12 +899,14 @@ func (r *reconciler) getIPs(members v1beta2.GroupMemberSet) sets.String {
 	ips := sets.NewString()
 	for _, m := range members {
 		var entityName, ns string
+		var ifaces []*interfacestore.InterfaceConfig
 		if m.Pod != nil {
 			entityName, ns = m.Pod.Name, m.Pod.Namespace
+			ifaces = r.ifaceStore.GetContainerInterfacesByPod(entityName, ns)
 		} else if m.ExternalEntity != nil {
 			entityName, ns = m.ExternalEntity.Name, m.ExternalEntity.Namespace
+			ifaces = r.ifaceStore.GetInterfacesByEntity(entityName, ns)
 		}
-		ifaces := r.ifaceStore.GetInterfacesByEntity(entityName, ns)
 		if len(ifaces) == 0 {
 			// This might be because the container has been deleted during realization or hasn't been set up yet.
 			klog.Infof("Can't find interface for %s/%s, skipping", ns, entityName)

--- a/pkg/agent/interfacestore/types.go
+++ b/pkg/agent/interfacestore/types.go
@@ -33,6 +33,8 @@ const (
 	UplinkInterface
 	// HostInterface is used to mark current interface is for host
 	HostInterface
+	// ExternalEntityInterface is used to mark current interface is for ExternalEntity Endpoint
+	ExternalEntityInterface
 
 	AntreaInterfaceTypeKey = "antrea-type"
 	AntreaGateway          = "gateway"
@@ -74,6 +76,15 @@ type TunnelInterfaceConfig struct {
 	Csum bool
 }
 
+type EntityInterfaceConfig struct {
+	EntityName      string
+	EntityNamespace string
+	// UplinkPort is the OVS port configuration for the uplink, which is a pair port of this interface on OVS.
+	UplinkPort *OVSPortConfig
+	// HostIfaceIndex is the index of the host interface created by this OVS internal port.
+	HostIfaceIndex int
+}
+
 type InterfaceConfig struct {
 	Type InterfaceType
 	// Unique name of the interface, also used for the OVS port name.
@@ -85,6 +96,7 @@ type InterfaceConfig struct {
 	*OVSPortConfig
 	*ContainerInterfaceConfig
 	*TunnelInterfaceConfig
+	*EntityInterfaceConfig
 }
 
 // InterfaceStore is a service interface to create local interfaces for container, host gateway, and tunnel port.


### PR DESCRIPTION
As an ExternalEntity is generated according to one Interface defined
in an ExternalNode, one InterfaceConfig is created for the ExternalEnity
accordingly.
For ExternalNode scenario, Antrea Agent should connect the host network
interface to OVS as the uplink, and create a new host internal port to
take the uplink's network configurations. An IntefaceConfig for
ExteranlEntity uses the name of the host internal port, and maintains
the OpenFlow ports of the OVS port pair.

Signed-off-by: wenyingd <wenyingd@vmware.com>