### PR TITLE
[ExternalNode] Agent datapath implementation

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1160,3 +1160,35 @@ func (i *Initializer) initVMLocalConfig(nodeName string) error {
 	}
 	return nil
 }
+
+// prepareOVSBridge operates OVS bridge.
+func (i *Initializer) prepareOVSBridge() error {
+	if i.nodeType == config.K8sNode {
+		return i.prepareOVSBridgeForK8sNode()
+	}
+	return i.prepareOVSBridgeForVM()
+}
+
+func (i *Initializer) prepareOVSBridgeForVM() error {
+	return i.setOVSDatapath()
+}
+
+// setOVSDatapath generates a static datapath ID for OVS bridge so that the OFSwitch identifier is not
+// changed after the physical interface is attached on the switch.
+func (i *Initializer) setOVSDatapath() error {
+	otherConfig, err := i.ovsBridgeClient.GetOVSOtherConfig()
+	if err != nil {
+		klog.ErrorS(err, "Failed to read OVS bridge other_config")
+		return err
+	}
+	if _, exists := otherConfig[ovsconfig.OVSOtherConfigDatapathIDKey]; exists {
+		return nil
+	}
+	randMAC := util.GenerateRandomMAC()
+	datapathID := "0000" + strings.Replace(randMAC.String(), ":", "", -1)
+	if err := i.ovsBridgeClient.SetDatapathID(datapathID); err != nil {
+		klog.ErrorS(err, "Failed to set OVS bridge datapath_id", "datapathID", datapathID)
+		return err
+	}
+	return nil
+}

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1181,6 +1181,10 @@ func (i *Initializer) setOVSDatapath() error {
 		klog.ErrorS(err, "Failed to read OVS bridge other_config")
 		return err
 	}
+	// Check if "datapath-id" exists in "other_config" on OVS bridge or not, and return directly if yes.
+	// Note: function `ovsBridgeClient.GetDatapathID` is not used here, because OVS always has data in "datapath_id"
+	// field. If "datapath-id" is not explicitly set in "other_config", the datapath ID in use may change when uplink
+	// is attached on OVS.
 	if _, exists := otherConfig[ovsconfig.OVSOtherConfigDatapathIDKey]; exists {
 		return nil
 	}

--- a/pkg/agent/agent_linux.go
+++ b/pkg/agent/agent_linux.go
@@ -39,8 +39,8 @@ func (i *Initializer) prepareHostNetwork() error {
 	return nil
 }
 
-func (i *Initializer) prepareOVSBridge() error {
-	// Return immediately on Linux if connectUplinkToBridge is false.
+// prepareOVSBridgeForK8sNode returns immediately on Linux if connectUplinkToBridge is false.
+func (i *Initializer) prepareOVSBridgeForK8sNode() error {
 	if !i.connectUplinkToBridge {
 		return nil
 	}

--- a/pkg/agent/agent_windows.go
+++ b/pkg/agent/agent_windows.go
@@ -111,11 +111,10 @@ func (i *Initializer) prepareHNSNetworkAndOVSExtension() error {
 	return util.PrepareHNSNetwork(subnetCIDR, i.nodeConfig.NodeTransportIPv4Addr, adapter, i.nodeConfig.UplinkNetConfig.Gateway, dnsServers, i.nodeConfig.UplinkNetConfig.Routes, i.ovsBridge)
 }
 
-func (i *Initializer) prepareOVSBridge() error {
-	if i.nodeType == config.K8sNode {
-		return i.prepareOVSBridgeOnHNSNetwork()
-	}
-	return nil
+// prepareOVSBridgeForK8sNode adds local port and uplink port to OVS bridge after OVS extension is enabled on HNSNetwork.
+// This function deletes OVS bridge and HNS network created by Antrea on failure.
+func (i *Initializer) prepareOVSBridgeForK8sNode() error {
+	return i.prepareOVSBridgeOnHNSNetwork()
 }
 
 // prepareOVSBridgeOnHNSNetwork adds local port and uplink to OVS bridge after the OVS Extension is enabled on HNSNetwork.

--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -294,6 +294,18 @@ type Client interface {
 	UninstallTrafficControlReturnPortFlow(returnOFPort uint32) error
 
 	InstallMulticastGroup(ofGroupID binding.GroupIDType, localReceivers []uint32) error
+
+	// InstallVMUplinkFlows installs flows to forward packet between uplinkPort and hostPort. On a VM, the
+	// uplink and host internal port are paired directly, and no layer 2/3 forwarding flow is installed.
+	InstallVMUplinkFlows(hostInterfaceName string, hostPort int32, uplinkPort int32) error
+
+	// UninstallVMUplinkFlows removes the flows installed to forward packet between uplinkPort and hostPort.
+	UninstallVMUplinkFlows(hostInterfaceName string) error
+
+	// InstallPolicyBypassFlows installs flows to bypass the NetworkPolicy rules on the traffic with the given ipnet
+	// or ip, port, protocol and direction. It is used to bypass NetworkPolicy enforcement on a VM for the particular
+	// traffic.
+	InstallPolicyBypassFlows(protocol binding.Protocol, ipnet *net.IPNet, ip net.IP, port uint16, isIngress bool) error
 }
 
 // GetFlowTableStatus returns an array of flow table status.
@@ -732,13 +744,19 @@ func (c *client) generatePipelines() {
 		c.traceableFeatures = append(c.traceableFeatures, c.featureService)
 	}
 
+	if c.nodeType == config.ExternalNode {
+		c.featureExternalNodeConnectivity = newFeatureExternalNodeConnectivity(c.cookieAllocator, c.ipProtocols)
+		c.activatedFeatures = append(c.activatedFeatures, c.featureExternalNodeConnectivity)
+	}
+
 	c.featureNetworkPolicy = newFeatureNetworkPolicy(c.cookieAllocator,
 		c.ipProtocols,
 		c.bridge,
 		c.ovsMetersAreSupported,
 		c.enableDenyTracking,
 		c.enableAntreaPolicy,
-		c.connectUplinkToBridge)
+		c.connectUplinkToBridge,
+		c.nodeType)
 	c.activatedFeatures = append(c.activatedFeatures, c.featureNetworkPolicy)
 	c.traceableFeatures = append(c.traceableFeatures, c.featureNetworkPolicy)
 
@@ -762,6 +780,9 @@ func (c *client) generatePipelines() {
 		if c.enableMulticast {
 			pipelineIDs = append(pipelineIDs, pipelineMulticast)
 		}
+	}
+	if c.nodeType == config.ExternalNode {
+		pipelineIDs = append(pipelineIDs, pipelineNonIP)
 	}
 
 	// For every pipeline, get required tables from every active feature and store the required tables in a map to avoid

--- a/pkg/agent/openflow/cookie/allocator.go
+++ b/pkg/agent/openflow/cookie/allocator.go
@@ -37,6 +37,7 @@ const (
 	Egress
 	Multicast
 	Traceflow
+	ExternalNodeConnectivity
 )
 
 func (c Category) String() string {
@@ -55,6 +56,8 @@ func (c Category) String() string {
 		return "Multicast"
 	case Traceflow:
 		return "Traceflow"
+	case ExternalNodeConnectivity:
+		return "ExternalNodeConnectivity"
 	default:
 		return "Invalid"
 	}

--- a/pkg/agent/openflow/externalnode_connectivity.go
+++ b/pkg/agent/openflow/externalnode_connectivity.go
@@ -1,0 +1,229 @@
+// Copyright 2022 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openflow
+
+import (
+	"net"
+
+	"antrea.io/antrea/pkg/agent/openflow/cookie"
+	binding "antrea.io/antrea/pkg/ovs/openflow"
+)
+
+const (
+	policyBypassFlowsKey = "policyBypassFlows"
+)
+
+type featureExternalNodeConnectivity struct {
+	cookieAllocator cookie.Allocator
+	ipProtocols     []binding.Protocol
+	ctZones         map[binding.Protocol]int
+	category        cookie.Category
+
+	uplinkFlowCache *flowCategoryCache
+}
+
+func (f *featureExternalNodeConnectivity) getFeatureName() string {
+	return "ExternalNodeConnectivity"
+}
+
+func newFeatureExternalNodeConnectivity(
+	cookieAllocator cookie.Allocator,
+	ipProtocols []binding.Protocol) *featureExternalNodeConnectivity {
+	ctZones := make(map[binding.Protocol]int)
+	for _, ipProtocol := range ipProtocols {
+		if ipProtocol == binding.ProtocolIP {
+			ctZones[ipProtocol] = CtZone
+		} else if ipProtocol == binding.ProtocolIPv6 {
+			ctZones[ipProtocol] = CtZoneV6
+		}
+	}
+
+	return &featureExternalNodeConnectivity{
+		cookieAllocator: cookieAllocator,
+		ipProtocols:     ipProtocols,
+		uplinkFlowCache: newFlowCategoryCache(),
+		ctZones:         ctZones,
+		category:        cookie.ExternalNodeConnectivity,
+	}
+}
+
+func (f *featureExternalNodeConnectivity) vmUplinkFlows(hostOFPort, uplinkOFPort uint32) []binding.Flow {
+	cookieID := f.cookieAllocator.Request(f.category).Raw()
+	return []binding.Flow{
+		// Set the output port number with the uplink port if the IP packet enters OVS from the
+		// paired host internal port, and then enforce the packet to go through the IP pipeline.
+		L2ForwardingCalcTable.ofTable.BuildFlow(priorityNormal).
+			Cookie(cookieID).
+			MatchProtocol(binding.ProtocolIP).
+			MatchInPort(hostOFPort).
+			Action().LoadRegMark(OFPortFoundRegMark).
+			Action().LoadToRegField(TargetOFPortField, uplinkOFPort).
+			Action().NextTable().
+			Done(),
+		// Set the output port number with the paired host internal port if the IP packet enters the OVS from
+		// the uplink port, and then enforce the packet to go through the IP pipeline.
+		L2ForwardingCalcTable.ofTable.BuildFlow(priorityNormal).
+			Cookie(cookieID).
+			MatchInPort(uplinkOFPort).
+			MatchProtocol(binding.ProtocolIP).
+			Action().LoadRegMark(OFPortFoundRegMark).
+			Action().LoadToRegField(TargetOFPortField, hostOFPort).
+			Action().NextTable().
+			Done(),
+		// Output the packet to the uplink port if it is not using IP protocol, and enters OVS from the
+		// paired host internal port.
+		NonIPTable.ofTable.BuildFlow(priorityNormal).
+			Cookie(cookieID).
+			MatchInPort(hostOFPort).
+			Action().Output(uplinkOFPort).
+			Done(),
+		// Output the packet to the uplink port if it is not using IP protocol, and enters OVS from the
+		// paired host internal port.
+		NonIPTable.ofTable.BuildFlow(priorityNormal).
+			Cookie(cookieID).
+			MatchInPort(uplinkOFPort).
+			Action().Output(hostOFPort).
+			Done(),
+	}
+}
+
+func (f *featureExternalNodeConnectivity) initFlows() []binding.Flow {
+	cookieID := f.cookieAllocator.Request(f.category).Raw()
+	flows := []binding.Flow{
+		L2ForwardingOutTable.ofTable.BuildFlow(priorityNormal).
+			Cookie(cookieID).
+			MatchRegMark(OFPortFoundRegMark).
+			Action().OutputToRegField(TargetOFPortField).
+			Done(),
+	}
+	for _, ipProtocol := range f.ipProtocols {
+		ctZone := f.ctZones[ipProtocol]
+		flows = append(flows,
+			// This generates the flow to maintain tracked connections in CT zone.
+			ConntrackTable.ofTable.BuildFlow(priorityNormal).
+				Cookie(cookieID).
+				MatchProtocol(ipProtocol).
+				Action().CT(false, ConntrackTable.ofTable.GetNext(), ctZone, nil).
+				CTDone().
+				Done(),
+			ConntrackStateTable.ofTable.BuildFlow(priorityHigh).
+				Cookie(cookieID).
+				MatchProtocol(ipProtocol).
+				MatchCTStateInv(true).
+				MatchCTStateTrk(true).
+				Action().Drop().
+				Done(),
+			ConntrackCommitTable.ofTable.BuildFlow(priorityNormal).
+				Cookie(cookieID).
+				MatchProtocol(ipProtocol).
+				MatchCTStateNew(true).
+				MatchCTStateTrk(true).
+				Action().CT(true, ConntrackCommitTable.GetNext(), ctZone, nil).CTDone().
+				Done(),
+		)
+	}
+
+	return flows
+}
+
+func (f *featureExternalNodeConnectivity) replayFlows() []binding.Flow {
+	var flows []binding.Flow
+	rangeFunc := func(key, value interface{}) bool {
+		cachedFlows := value.([]binding.Flow)
+		for _, flow := range cachedFlows {
+			flow.Reset()
+			flows = append(flows, flow)
+		}
+		return true
+	}
+	f.uplinkFlowCache.Range(rangeFunc)
+	return flows
+}
+
+func (f *featureExternalNodeConnectivity) policyBypassFlow(protocol binding.Protocol, ipnet *net.IPNet, ip net.IP, port uint16, isIngress bool) binding.Flow {
+	cookieID := f.cookieAllocator.Request(f.category).Raw()
+	var flowBuilder binding.FlowBuilder
+	var nextTable *Table
+	if isIngress {
+		flowBuilder = IngressSecurityClassifierTable.ofTable.BuildFlow(priorityNormal).
+			Cookie(cookieID).
+			MatchProtocol(protocol).
+			MatchCTStateNew(true).
+			MatchCTStateTrk(true)
+		if ipnet != nil {
+			flowBuilder.MatchSrcIPNet(*ipnet)
+		}
+		if ip != nil {
+			flowBuilder.MatchSrcIP(ip)
+		}
+		nextTable = IngressMetricTable
+	} else {
+		flowBuilder = EgressSecurityClassifierTable.ofTable.BuildFlow(priorityNormal).
+			Cookie(cookieID).
+			MatchProtocol(protocol).
+			MatchCTStateNew(true).
+			MatchCTStateTrk(true)
+		if ipnet != nil {
+			flowBuilder.MatchDstIPNet(*ipnet)
+		}
+		if ip != nil {
+			flowBuilder.MatchDstIP(ip)
+		}
+		nextTable = EgressMetricTable
+	}
+	return flowBuilder.MatchDstPort(port, nil).
+		Action().GotoTable(nextTable.ofTable.GetID()).
+		Done()
+}
+
+func (f *featureExternalNodeConnectivity) addPolicyBypassFlows(flow binding.Flow) error {
+	var allFlows []binding.Flow
+	obj, ok := f.uplinkFlowCache.Load(policyBypassFlowsKey)
+	if !ok {
+		allFlows = []binding.Flow{flow}
+	} else {
+		existingFlows := obj.([]binding.Flow)
+		allFlows = append(existingFlows, flow)
+	}
+	f.uplinkFlowCache.Store(policyBypassFlowsKey, allFlows)
+	return nil
+}
+
+func (c *client) InstallVMUplinkFlows(hostIFName string, hostPort int32, uplinkPort int32) error {
+	flows := c.featureExternalNodeConnectivity.vmUplinkFlows(uint32(hostPort), uint32(uplinkPort))
+	return c.addFlows(c.featureExternalNodeConnectivity.uplinkFlowCache, hostIFName, flows)
+}
+
+func (c *client) UninstallVMUplinkFlows(hostIFName string) error {
+	return c.deleteFlows(c.featureExternalNodeConnectivity.uplinkFlowCache, hostIFName)
+}
+
+func (c *client) InstallPolicyBypassFlows(protocol binding.Protocol, ipnet *net.IPNet, ip net.IP, port uint16, isIngress bool) error {
+	flow := c.featureExternalNodeConnectivity.policyBypassFlow(protocol, ipnet, ip, port, isIngress)
+	if err := c.ofEntryOperations.Add(flow); err != nil {
+		return err
+	}
+	return c.featureExternalNodeConnectivity.addPolicyBypassFlows(flow)
+}
+
+// nonIPPipelineClassifyFlow generates a flow in PipelineClassifierTable to resubmit packets not using IP protocols to
+// pipelineNonIP.
+func nonIPPipelineClassifyFlow(cookieID uint64, pipeline binding.Pipeline) binding.Flow {
+	targetTable := pipeline.GetFirstTable()
+	return PipelineRootClassifierTable.ofTable.BuildFlow(priorityLow).
+		Cookie(cookieID).
+		Action().GotoTable(targetTable.GetID()).
+		Done()
+}

--- a/pkg/agent/openflow/framework.go
+++ b/pkg/agent/openflow/framework.go
@@ -15,6 +15,7 @@
 package openflow
 
 import (
+	"antrea.io/antrea/pkg/agent/config"
 	binding "antrea.io/antrea/pkg/ovs/openflow"
 )
 
@@ -71,9 +72,12 @@ const (
 	pipelineIP
 	// pipelineMulticast is used to process multicast packets.
 	pipelineMulticast
+	// pipelineNonIP is used to process the traffic of non-IP packets. This pipeline is used when ExternalNode feature
+	// is enabled.
+	pipelineNonIP
 
 	firstPipeline = pipelineRoot
-	lastPipeline  = pipelineMulticast
+	lastPipeline  = pipelineNonIP
 )
 
 const (
@@ -210,7 +214,11 @@ func (f *featureNetworkPolicy) getRequiredTables() []*Table {
 			AntreaPolicyIngressRuleTable,
 		)
 	}
-
+	if f.nodeType == config.ExternalNode {
+		tables = append(tables,
+			EgressSecurityClassifierTable,
+		)
+	}
 	return tables
 }
 
@@ -252,6 +260,17 @@ func (f *featureMulticast) getRequiredTables() []*Table {
 
 func (f *featureTraceflow) getRequiredTables() []*Table {
 	return nil
+}
+
+func (f *featureExternalNodeConnectivity) getRequiredTables() []*Table {
+	return []*Table{
+		ConntrackTable,
+		ConntrackStateTable,
+		L2ForwardingCalcTable,
+		ConntrackCommitTable,
+		L2ForwardingOutTable,
+		NonIPTable,
+	}
 }
 
 // traceableFeature is the interface to support Traceflow in Antrea data path. Any other feature expected to trace the

--- a/pkg/agent/openflow/network_policy.go
+++ b/pkg/agent/openflow/network_policy.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 
+	"antrea.io/antrea/pkg/agent/config"
 	"antrea.io/antrea/pkg/agent/openflow/cookie"
 	"antrea.io/antrea/pkg/agent/types"
 	"antrea.io/antrea/pkg/apis/controlplane/v1beta2"
@@ -1773,6 +1774,7 @@ type featureNetworkPolicy struct {
 	cookieAllocator cookie.Allocator
 	ipProtocols     []binding.Protocol
 	bridge          binding.Bridge
+	nodeType        config.NodeType
 
 	// globalConjMatchFlowCache is a global map for conjMatchFlowContext. The key is a string generated from the
 	// conjMatchFlowContext.
@@ -1807,11 +1809,13 @@ func newFeatureNetworkPolicy(
 	ovsMetersAreSupported,
 	enableDenyTracking,
 	enableAntreaPolicy bool,
-	connectUplinkToBridge bool) *featureNetworkPolicy {
+	connectUplinkToBridge bool,
+	nodeType config.NodeType) *featureNetworkPolicy {
 	return &featureNetworkPolicy{
 		cookieAllocator:          cookieAllocator,
 		ipProtocols:              ipProtocols,
 		bridge:                   bridge,
+		nodeType:                 nodeType,
 		globalConjMatchFlowCache: make(map[string]*conjMatchFlowContext),
 		policyCache:              cache.NewIndexer(policyConjKeyFunc, cache.Indexers{priorityIndex: priorityIndexFunc}),
 		ovsMetersAreSupported:    ovsMetersAreSupported,
@@ -1828,8 +1832,58 @@ func (f *featureNetworkPolicy) initFlows() []binding.Flow {
 		f.egressTables[AntreaPolicyEgressRuleTable.GetID()] = struct{}{}
 	}
 	var flows []binding.Flow
-	flows = append(flows, f.establishedConnectionFlows()...)
-	flows = append(flows, f.relatedConnectionFlows()...)
-	flows = append(flows, f.ingressClassifierFlows()...)
+	if f.nodeType == config.K8sNode {
+		flows = append(flows, f.ingressClassifierFlows()...)
+	}
+	flows = append(flows, f.skipPolicyRuleCheckFlows()...)
+	return flows
+}
+
+// skipPolicyRuleCheckFlows generates the flows to forward the packets in an established or related
+// connections to the metric table in the same stage directly, so that these packets would skip the flows
+// for NetworkPolicy rules.
+func (f *featureNetworkPolicy) skipPolicyRuleCheckFlows() []binding.Flow {
+	var flows []binding.Flow
+	cookieID := f.cookieAllocator.Request(f.category).Raw()
+	egressCTStateFlowTable := EgressRuleTable
+	ingressCTStateFlowTable := IngressRuleTable
+	priority := priorityHigh
+	if f.enableAntreaPolicy {
+		egressCTStateFlowTable = AntreaPolicyEgressRuleTable
+		ingressCTStateFlowTable = AntreaPolicyIngressRuleTable
+		priority = priorityTopAntreaPolicy
+	}
+	for _, ipProtocol := range f.ipProtocols {
+		flows = append(flows,
+			egressCTStateFlowTable.ofTable.BuildFlow(priority).
+				Cookie(cookieID).
+				MatchProtocol(ipProtocol).
+				MatchCTStateNew(false).
+				MatchCTStateEst(true).
+				Action().GotoTable(EgressMetricTable.GetID()).
+				Done(),
+			egressCTStateFlowTable.ofTable.BuildFlow(priority).
+				Cookie(cookieID).
+				MatchProtocol(ipProtocol).
+				MatchCTStateNew(false).
+				MatchCTStateRel(true).
+				Action().GotoTable(EgressMetricTable.GetID()).
+				Done(),
+			ingressCTStateFlowTable.ofTable.BuildFlow(priority).
+				Cookie(cookieID).
+				MatchProtocol(ipProtocol).
+				MatchCTStateNew(false).
+				MatchCTStateEst(true).
+				Action().GotoTable(IngressMetricTable.GetID()).
+				Done(),
+			ingressCTStateFlowTable.ofTable.BuildFlow(priority).
+				Cookie(cookieID).
+				MatchProtocol(ipProtocol).
+				MatchCTStateNew(false).
+				MatchCTStateRel(true).
+				Action().GotoTable(IngressMetricTable.GetID()).
+				Done(),
+		)
+	}
 	return flows
 }

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -144,10 +144,11 @@ var (
 	DNATTable = newTable("DNAT", stagePreRouting, pipelineIP)
 
 	// Tables in stageEgressSecurity:
-	AntreaPolicyEgressRuleTable = newTable("AntreaPolicyEgressRule", stageEgressSecurity, pipelineIP)
-	EgressRuleTable             = newTable("EgressRule", stageEgressSecurity, pipelineIP)
-	EgressDefaultTable          = newTable("EgressDefaultRule", stageEgressSecurity, pipelineIP)
-	EgressMetricTable           = newTable("EgressMetric", stageEgressSecurity, pipelineIP)
+	EgressSecurityClassifierTable = newTable("EgressSecurityClassifier", stageEgressSecurity, pipelineIP)
+	AntreaPolicyEgressRuleTable   = newTable("AntreaPolicyEgressRule", stageEgressSecurity, pipelineIP)
+	EgressRuleTable               = newTable("EgressRule", stageEgressSecurity, pipelineIP)
+	EgressDefaultTable            = newTable("EgressDefaultRule", stageEgressSecurity, pipelineIP)
+	EgressMetricTable             = newTable("EgressMetric", stageEgressSecurity, pipelineIP)
 
 	// Tables in stageRouting:
 	L3ForwardingTable = newTable("L3Forwarding", stageRouting, pipelineIP)
@@ -183,6 +184,10 @@ var (
 
 	// Tables in stageOutput
 	MulticastOutputTable = newTable("MulticastOutput", stageOutput, pipelineMulticast)
+
+	// NonIPTable is used when Antrea Agent is running on an external Node. It forwards the non-IP packet
+	// between the uplink and its pair port directly.
+	NonIPTable = newTable("NonIP", stageClassifier, pipelineNonIP, defaultDrop)
 
 	// Flow priority level
 	priorityHigh            = uint16(210)
@@ -391,12 +396,13 @@ type client struct {
 	cookieAllocator       cookie.Allocator
 	bridge                binding.Bridge
 
-	featurePodConnectivity *featurePodConnectivity
-	featureService         *featureService
-	featureEgress          *featureEgress
-	featureNetworkPolicy   *featureNetworkPolicy
-	featureMulticast       *featureMulticast
-	activatedFeatures      []feature
+	featurePodConnectivity          *featurePodConnectivity
+	featureService                  *featureService
+	featureEgress                   *featureEgress
+	featureNetworkPolicy            *featureNetworkPolicy
+	featureMulticast                *featureMulticast
+	featureExternalNodeConnectivity *featureExternalNodeConnectivity
+	activatedFeatures               []feature
 
 	featureTraceflow  *featureTraceflow
 	traceableFeatures []traceableFeature
@@ -559,6 +565,8 @@ func (c *client) defaultFlows() []binding.Flow {
 			// in PipelineIPClassifierTable. Note that, PipelineIPClassifierTable is in stageValidation of pipeline for IP. In another word,
 			// pipelineMulticast is forked from PipelineIPClassifierTable in pipelineIP.
 			flows = append(flows, multicastPipelineClassifyFlow(cookieID, pipeline))
+		case pipelineNonIP:
+			flows = append(flows, nonIPPipelineClassifyFlow(cookieID, pipeline))
 		}
 	}
 
@@ -1799,126 +1807,6 @@ func (c *client) Disconnect() error {
 
 func newFlowCategoryCache() *flowCategoryCache {
 	return &flowCategoryCache{}
-}
-
-// establishedConnectionFlows generates flows to ensure established connections skip the NetworkPolicy rules.
-func (f *featureNetworkPolicy) establishedConnectionFlows() []binding.Flow {
-	// egressDropTable checks the source address of packets, and drops packets sent from the AppliedToGroup but not
-	// matching the NetworkPolicy rules. Packets in the established connections need not to be checked with the
-	// egressRuleTable or the egressDropTable.
-	egressDropTable := EgressDefaultTable
-	// ingressDropTable checks the destination address of packets, and drops packets sent to the AppliedToGroup but not
-	// matching the NetworkPolicy rules. Packets in the established connections need not to be checked with the
-	// ingressRuleTable or ingressDropTable.
-	ingressDropTable := IngressDefaultTable
-	cookieID := f.cookieAllocator.Request(f.category).Raw()
-	var allEstFlows []binding.Flow
-	for _, ipProtocol := range f.ipProtocols {
-		egressEstFlow := EgressRuleTable.ofTable.BuildFlow(priorityHigh).
-			Cookie(cookieID).
-			MatchProtocol(ipProtocol).
-			MatchCTStateNew(false).
-			MatchCTStateEst(true).
-			Action().GotoTable(egressDropTable.GetNext()).
-			Done()
-		ingressEstFlow := IngressRuleTable.ofTable.BuildFlow(priorityHigh).
-			Cookie(cookieID).
-			MatchProtocol(ipProtocol).
-			MatchCTStateNew(false).
-			MatchCTStateEst(true).
-			Action().GotoTable(ingressDropTable.GetNext()).
-			Done()
-		allEstFlows = append(allEstFlows, egressEstFlow, ingressEstFlow)
-	}
-	if !f.enableAntreaPolicy {
-		return allEstFlows
-	}
-	var apFlows []binding.Flow
-	for _, table := range GetAntreaPolicyEgressTables() {
-		for _, ipProtocol := range f.ipProtocols {
-			apEgressEstFlow := table.ofTable.BuildFlow(priorityTopAntreaPolicy).
-				Cookie(cookieID).
-				MatchProtocol(ipProtocol).
-				MatchCTStateNew(false).
-				MatchCTStateEst(true).
-				Action().GotoTable(egressDropTable.GetNext()).
-				Done()
-			apFlows = append(apFlows, apEgressEstFlow)
-		}
-	}
-	for _, table := range GetAntreaPolicyIngressTables() {
-		for _, ipProtocol := range f.ipProtocols {
-			apIngressEstFlow := table.ofTable.BuildFlow(priorityTopAntreaPolicy).
-				Cookie(cookieID).
-				MatchProtocol(ipProtocol).
-				MatchCTStateNew(false).
-				MatchCTStateEst(true).
-				Action().GotoTable(ingressDropTable.GetNext()).
-				Done()
-			apFlows = append(apFlows, apIngressEstFlow)
-		}
-	}
-	allEstFlows = append(allEstFlows, apFlows...)
-	return allEstFlows
-}
-
-// relatedConnectionFlows generates flows to ensure related connections skip the NetworkPolicy rules.
-func (f *featureNetworkPolicy) relatedConnectionFlows() []binding.Flow {
-	// egressDropTable checks the source address of packets, and drops packets sent from the AppliedToGroup but not
-	// matching the NetworkPolicy rules. Packets in the related connections need not to be checked with the
-	// egressRuleTable or the egressDropTable.
-	egressDropTable := EgressDefaultTable
-	// ingressDropTable checks the destination address of packets, and drops packets sent to the AppliedToGroup but not
-	// matching the NetworkPolicy rules. Packets in the related connections need not to be checked with the
-	// ingressRuleTable or ingressDropTable.
-	ingressDropTable := IngressDefaultTable
-	cookieID := f.cookieAllocator.Request(f.category).Raw()
-	var flows []binding.Flow
-	for _, ipProtocol := range f.ipProtocols {
-		egressRelFlow := EgressRuleTable.ofTable.BuildFlow(priorityHigh).
-			Cookie(cookieID).
-			MatchProtocol(ipProtocol).
-			MatchCTStateNew(false).
-			MatchCTStateRel(true).
-			Action().GotoTable(egressDropTable.GetNext()).
-			Done()
-		ingressRelFlow := IngressRuleTable.ofTable.BuildFlow(priorityHigh).
-			Cookie(cookieID).
-			MatchProtocol(ipProtocol).
-			MatchCTStateNew(false).
-			MatchCTStateRel(true).
-			Action().GotoTable(ingressDropTable.GetNext()).
-			Done()
-		flows = append(flows, egressRelFlow, ingressRelFlow)
-	}
-	if !f.enableAntreaPolicy {
-		return flows
-	}
-	for _, table := range GetAntreaPolicyEgressTables() {
-		for _, ipProto := range f.ipProtocols {
-			apEgressRelFlow := table.ofTable.BuildFlow(priorityTopAntreaPolicy).
-				Cookie(cookieID).
-				MatchProtocol(ipProto).
-				MatchCTStateNew(false).
-				MatchCTStateRel(true).
-				Action().GotoTable(egressDropTable.GetNext()).
-				Done()
-			flows = append(flows, apEgressRelFlow)
-		}
-	}
-	for _, table := range GetAntreaPolicyIngressTables() {
-		for _, ipProto := range f.ipProtocols {
-			apIngressRelFlow := table.ofTable.BuildFlow(priorityTopAntreaPolicy).
-				Cookie(cookieID).
-				MatchProtocol(ipProto).
-				MatchCTStateNew(false).
-				MatchCTStateRel(true).
-				Action().GotoTable(ingressDropTable.GetNext()).
-				Done()
-			flows = append(flows, apIngressRelFlow)
-		}
-	}
-	return flows
 }
 
 func (f *featureNetworkPolicy) addFlowMatch(fb binding.FlowBuilder, matchKey *types.MatchKey, matchValue interface{}) binding.FlowBuilder {

--- a/pkg/agent/openflow/testing/mock_openflow.go
+++ b/pkg/agent/openflow/testing/mock_openflow.go
@@ -366,6 +366,20 @@ func (mr *MockClientMockRecorder) InstallPodSNATFlows(arg0, arg1, arg2 interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallPodSNATFlows", reflect.TypeOf((*MockClient)(nil).InstallPodSNATFlows), arg0, arg1, arg2)
 }
 
+// InstallPolicyBypassFlows mocks base method
+func (m *MockClient) InstallPolicyBypassFlows(arg0 openflow.Protocol, arg1 *net.IPNet, arg2 net.IP, arg3 uint16, arg4 bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InstallPolicyBypassFlows", arg0, arg1, arg2, arg3, arg4)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// InstallPolicyBypassFlows indicates an expected call of InstallPolicyBypassFlows
+func (mr *MockClientMockRecorder) InstallPolicyBypassFlows(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallPolicyBypassFlows", reflect.TypeOf((*MockClient)(nil).InstallPolicyBypassFlows), arg0, arg1, arg2, arg3, arg4)
+}
+
 // InstallPolicyRuleFlows mocks base method
 func (m *MockClient) InstallPolicyRuleFlows(arg0 *types.PolicyRule) error {
 	m.ctrl.T.Helper()
@@ -462,6 +476,20 @@ func (m *MockClient) InstallTrafficControlReturnPortFlow(arg0 uint32) error {
 func (mr *MockClientMockRecorder) InstallTrafficControlReturnPortFlow(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallTrafficControlReturnPortFlow", reflect.TypeOf((*MockClient)(nil).InstallTrafficControlReturnPortFlow), arg0)
+}
+
+// InstallVMUplinkFlows mocks base method
+func (m *MockClient) InstallVMUplinkFlows(arg0 string, arg1, arg2 int32) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InstallVMUplinkFlows", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// InstallVMUplinkFlows indicates an expected call of InstallVMUplinkFlows
+func (mr *MockClientMockRecorder) InstallVMUplinkFlows(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallVMUplinkFlows", reflect.TypeOf((*MockClient)(nil).InstallVMUplinkFlows), arg0, arg1, arg2)
 }
 
 // IsConnected mocks base method
@@ -807,6 +835,20 @@ func (m *MockClient) UninstallTrafficControlReturnPortFlow(arg0 uint32) error {
 func (mr *MockClientMockRecorder) UninstallTrafficControlReturnPortFlow(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UninstallTrafficControlReturnPortFlow", reflect.TypeOf((*MockClient)(nil).UninstallTrafficControlReturnPortFlow), arg0)
+}
+
+// UninstallVMUplinkFlows mocks base method
+func (m *MockClient) UninstallVMUplinkFlows(arg0 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UninstallVMUplinkFlows", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UninstallVMUplinkFlows indicates an expected call of UninstallVMUplinkFlows
+func (mr *MockClientMockRecorder) UninstallVMUplinkFlows(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UninstallVMUplinkFlows", reflect.TypeOf((*MockClient)(nil).UninstallVMUplinkFlows), arg0)
 }
 
 // MockOFEntryOperations is a mock of OFEntryOperations interface

--- a/pkg/agent/util/net.go
+++ b/pkg/agent/util/net.go
@@ -15,6 +15,7 @@
 package util
 
 import (
+	"crypto/rand"
 	"crypto/sha1" // #nosec G505: not used for security purposes
 	"encoding/hex"
 	"errors"
@@ -377,4 +378,14 @@ func PortToUint16(port int) uint16 {
 	}
 	klog.Errorf("Port value %d out-of-bounds", port)
 	return 0
+}
+
+func GenerateRandomMAC() net.HardwareAddr {
+	buf := make([]byte, 6)
+	if _, err := rand.Read(buf); err != nil {
+		klog.ErrorS(err, "Failed to generate a random MAC")
+	}
+	// Set the local bit
+	buf[0] |= 2
+	return buf
 }

--- a/pkg/ovs/ovsconfig/interfaces.go
+++ b/pkg/ovs/ovsconfig/interfaces.go
@@ -26,6 +26,8 @@ const (
 
 	OVSDatapathSystem OVSDatapathType = "system"
 	OVSDatapathNetdev OVSDatapathType = "netdev"
+
+	OVSOtherConfigDatapathIDKey string = "datapath-id"
 )
 
 type OVSBridgeClient interface {

--- a/pkg/ovs/ovsconfig/ovs_client.go
+++ b/pkg/ovs/ovsconfig/ovs_client.go
@@ -261,7 +261,7 @@ func (br *OVSBridge) SetExternalIDs(externalIDs map[string]interface{}) Error {
 // http://openvswitch.org/support/dist-docs-2.5/FAQ.md.html
 func (br *OVSBridge) SetDatapathID(datapathID string) Error {
 	tx := br.ovsdb.Transaction(openvSwitchSchema)
-	otherConfig := map[string]interface{}{"datapath-id": datapathID}
+	otherConfig := map[string]interface{}{OVSOtherConfigDatapathIDKey: datapathID}
 	tx.Update(dbtransaction.Update{
 		Table: "Bridge",
 		Where: [][]interface{}{{"name", "==", br.name}},

--- a/test/e2e/flowaggregator_test.go
+++ b/test/e2e/flowaggregator_test.go
@@ -32,6 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
+	"antrea.io/antrea/pkg/agent/openflow"
 	"antrea.io/antrea/pkg/antctl"
 	"antrea.io/antrea/pkg/antctl/runtime"
 	secv1alpha1 "antrea.io/antrea/pkg/apis/crd/v1alpha1"
@@ -133,7 +134,11 @@ const (
 	// Set target bandwidth(bits/sec) of iPerf traffic to a relatively small value
 	// (default unlimited for TCP), to reduce the variances caused by network performance
 	// during 12s, and make the throughput test more stable.
-	iperfBandwidth = "10m"
+	iperfBandwidth                  = "10m"
+	antreaEgressTableInitFlowCount  = 3
+	antreaIngressTableInitFlowCount = 6
+	ingressTableInitFlowCount       = 1
+	egressTableInitFlowCount        = 1
 )
 
 var (
@@ -225,7 +230,7 @@ func testHelper(t *testing.T, data *TestData, podAIPs, podBIPs, podCIPs, podDIPs
 	// perftest-a -> perftest-b (Ingress reject), perftest-a -> perftest-d (Ingress drop)
 	t.Run("IntraNodeDenyConnIngressANP", func(t *testing.T) {
 		skipIfAntreaPolicyDisabled(t)
-		anp1, anp2 := deployDenyAntreaNetworkPolicies(t, data, "perftest-a", "perftest-b", "perftest-d", true)
+		anp1, anp2 := deployDenyAntreaNetworkPolicies(t, data, "perftest-a", "perftest-b", "perftest-d", controlPlaneNodeName(), controlPlaneNodeName(), true)
 		defer func() {
 			if anp1 != nil {
 				if err = data.deleteAntreaNetworkpolicy(anp1); err != nil {
@@ -260,7 +265,7 @@ func testHelper(t *testing.T, data *TestData, podAIPs, podBIPs, podCIPs, podDIPs
 	// perftest-a (Egress reject) -> perftest-b , perftest-a (Egress drop) -> perftest-d
 	t.Run("IntraNodeDenyConnEgressANP", func(t *testing.T) {
 		skipIfAntreaPolicyDisabled(t)
-		anp1, anp2 := deployDenyAntreaNetworkPolicies(t, data, "perftest-a", "perftest-b", "perftest-d", false)
+		anp1, anp2 := deployDenyAntreaNetworkPolicies(t, data, "perftest-a", "perftest-b", "perftest-d", controlPlaneNodeName(), controlPlaneNodeName(), false)
 		defer func() {
 			if anp1 != nil {
 				if err = data.deleteAntreaNetworkpolicy(anp1); err != nil {
@@ -295,7 +300,7 @@ func testHelper(t *testing.T, data *TestData, podAIPs, podBIPs, podCIPs, podDIPs
 	// perftest-a -> perftest-b (Ingress deny), perftest-d (Egress deny) -> perftest-a
 	t.Run("IntraNodeDenyConnNP", func(t *testing.T) {
 		skipIfAntreaPolicyDisabled(t)
-		np1, np2 := deployDenyNetworkPolicies(t, data, "perftest-b", "perftest-d")
+		np1, np2 := deployDenyNetworkPolicies(t, data, "perftest-b", "perftest-d", controlPlaneNodeName(), controlPlaneNodeName())
 		defer func() {
 			if np1 != nil {
 				if err = data.deleteNetworkpolicy(np1); err != nil {
@@ -330,7 +335,7 @@ func testHelper(t *testing.T, data *TestData, podAIPs, podBIPs, podCIPs, podDIPs
 	// Antrea network policies are being tested here.
 	t.Run("InterNodeFlows", func(t *testing.T) {
 		skipIfAntreaPolicyDisabled(t)
-		anp1, anp2 := deployAntreaNetworkPolicies(t, data, "perftest-a", "perftest-c")
+		anp1, anp2 := deployAntreaNetworkPolicies(t, data, "perftest-a", "perftest-c", controlPlaneNodeName(), workerNodeName(1))
 		defer func() {
 			if anp1 != nil {
 				k8sUtils.DeleteANP(data.testNamespace, anp1.Name)
@@ -351,7 +356,7 @@ func testHelper(t *testing.T, data *TestData, podAIPs, podBIPs, podCIPs, podDIPs
 	// perftest-a -> perftest-c (Ingress reject), perftest-a -> perftest-e (Ingress drop)
 	t.Run("InterNodeDenyConnIngressANP", func(t *testing.T) {
 		skipIfAntreaPolicyDisabled(t)
-		anp1, anp2 := deployDenyAntreaNetworkPolicies(t, data, "perftest-a", "perftest-c", "perftest-e", true)
+		anp1, anp2 := deployDenyAntreaNetworkPolicies(t, data, "perftest-a", "perftest-c", "perftest-e", controlPlaneNodeName(), workerNodeName(1), true)
 		defer func() {
 			if anp1 != nil {
 				if err = data.deleteAntreaNetworkpolicy(anp1); err != nil {
@@ -386,7 +391,7 @@ func testHelper(t *testing.T, data *TestData, podAIPs, podBIPs, podCIPs, podDIPs
 	// perftest-a (Egress reject) -> perftest-c, perftest-a (Egress drop)-> perftest-e
 	t.Run("InterNodeDenyConnEgressANP", func(t *testing.T) {
 		skipIfAntreaPolicyDisabled(t)
-		anp1, anp2 := deployDenyAntreaNetworkPolicies(t, data, "perftest-a", "perftest-c", "perftest-e", false)
+		anp1, anp2 := deployDenyAntreaNetworkPolicies(t, data, "perftest-a", "perftest-c", "perftest-e", controlPlaneNodeName(), workerNodeName(1), false)
 		defer func() {
 			if anp1 != nil {
 				if err = data.deleteAntreaNetworkpolicy(anp1); err != nil {
@@ -421,7 +426,7 @@ func testHelper(t *testing.T, data *TestData, podAIPs, podBIPs, podCIPs, podDIPs
 	// perftest-a -> perftest-c (Ingress deny), perftest-b (Egress deny) -> perftest-e
 	t.Run("InterNodeDenyConnNP", func(t *testing.T) {
 		skipIfAntreaPolicyDisabled(t)
-		np1, np2 := deployDenyNetworkPolicies(t, data, "perftest-c", "perftest-b")
+		np1, np2 := deployDenyNetworkPolicies(t, data, "perftest-c", "perftest-b", workerNodeName(1), controlPlaneNodeName())
 		defer func() {
 			if np1 != nil {
 				if err = data.deleteNetworkpolicy(np1); err != nil {
@@ -1146,14 +1151,17 @@ func deployK8sNetworkPolicies(t *testing.T, data *TestData, srcPod, dstPod strin
 		t.Errorf("Error when creating Network Policy: %v", err)
 	}
 	// Wait for network policies to be realized.
-	if err := WaitNetworkPolicyRealize(2, data); err != nil {
-		t.Errorf("Error when waiting for Network Policy to be realized: %v", err)
+	if err := WaitNetworkPolicyRealize(controlPlaneNodeName(), openflow.IngressRuleTable, ingressTableInitFlowCount+1, data); err != nil {
+		t.Errorf("Error when waiting for ingress Network Policy to be realized: %v", err)
+	}
+	if err := WaitNetworkPolicyRealize(controlPlaneNodeName(), openflow.IngressRuleTable, egressTableInitFlowCount+1, data); err != nil {
+		t.Errorf("Error when waiting for egress Network Policy to be realized: %v", err)
 	}
 	t.Log("Network Policies are realized.")
 	return np1, np2
 }
 
-func deployAntreaNetworkPolicies(t *testing.T, data *TestData, srcPod, dstPod string) (anp1 *secv1alpha1.NetworkPolicy, anp2 *secv1alpha1.NetworkPolicy) {
+func deployAntreaNetworkPolicies(t *testing.T, data *TestData, srcPod, dstPod string, srcNode, dstNode string) (anp1 *secv1alpha1.NetworkPolicy, anp2 *secv1alpha1.NetworkPolicy) {
 	builder1 := &utils.AntreaNetworkPolicySpecBuilder{}
 	// apply anp to dstPod, allow ingress from srcPod
 	builder1 = builder1.SetName(data.testNamespace, ingressAntreaNetworkPolicyName).
@@ -1181,17 +1189,23 @@ func deployAntreaNetworkPolicies(t *testing.T, data *TestData, srcPod, dstPod st
 	}
 
 	// Wait for network policies to be realized.
-	if err := WaitNetworkPolicyRealize(2, data); err != nil {
-		t.Errorf("Error when waiting for Antrea Network Policy to be realized: %v", err)
+	if err := WaitNetworkPolicyRealize(dstNode, openflow.AntreaPolicyIngressRuleTable, antreaIngressTableInitFlowCount+1, data); err != nil {
+		t.Errorf("Error when waiting for Antrea ingress Network Policy to be realized: %v", err)
+	}
+	if err := WaitNetworkPolicyRealize(srcNode, openflow.AntreaPolicyEgressRuleTable, antreaEgressTableInitFlowCount+1, data); err != nil {
+		t.Errorf("Error when waiting for Antrea egress Network Policy to be realized: %v", err)
 	}
 	t.Log("Antrea Network Policies are realized.")
 	return anp1, anp2
 }
 
-func deployDenyAntreaNetworkPolicies(t *testing.T, data *TestData, srcPod, podReject, podDrop string, isIngress bool) (anp1 *secv1alpha1.NetworkPolicy, anp2 *secv1alpha1.NetworkPolicy) {
+func deployDenyAntreaNetworkPolicies(t *testing.T, data *TestData, srcPod, podReject, podDrop string, srcNode, dstNode string, isIngress bool) (anp1 *secv1alpha1.NetworkPolicy, anp2 *secv1alpha1.NetworkPolicy) {
 	var err error
 	builder1 := &utils.AntreaNetworkPolicySpecBuilder{}
 	builder2 := &utils.AntreaNetworkPolicySpecBuilder{}
+	var table *openflow.Table
+	var flowCount int
+	var nodeName string
 	if isIngress {
 		// apply reject and drop ingress rule to destination pods
 		builder1 = builder1.SetName(data.testNamespace, ingressRejectANPName).
@@ -1204,6 +1218,9 @@ func deployDenyAntreaNetworkPolicies(t *testing.T, data *TestData, srcPod, podRe
 			SetAppliedToGroup([]utils.ANPAppliedToSpec{{PodSelector: map[string]string{"antrea-e2e": podDrop}}})
 		builder2 = builder2.AddIngress(utils.ProtocolTCP, nil, nil, nil, nil, nil, nil, map[string]string{"antrea-e2e": srcPod}, map[string]string{},
 			nil, nil, nil, secv1alpha1.RuleActionDrop, testIngressRuleName)
+		table = openflow.AntreaPolicyIngressRuleTable
+		flowCount = antreaIngressTableInitFlowCount + 2
+		nodeName = dstNode
 	} else {
 		// apply reject and drop egress rule to source pod
 		builder1 = builder1.SetName(data.testNamespace, egressRejectANPName).
@@ -1216,6 +1233,9 @@ func deployDenyAntreaNetworkPolicies(t *testing.T, data *TestData, srcPod, podRe
 			SetAppliedToGroup([]utils.ANPAppliedToSpec{{PodSelector: map[string]string{"antrea-e2e": srcPod}}})
 		builder2 = builder2.AddEgress(utils.ProtocolTCP, nil, nil, nil, nil, nil, nil, map[string]string{"antrea-e2e": podDrop}, map[string]string{},
 			nil, nil, nil, secv1alpha1.RuleActionDrop, testEgressRuleName)
+		table = openflow.AntreaPolicyEgressRuleTable
+		flowCount = antreaEgressTableInitFlowCount + 2
+		nodeName = srcNode
 	}
 	anp1 = builder1.Get()
 	anp1, err = k8sUtils.CreateOrUpdateANP(anp1)
@@ -1228,14 +1248,14 @@ func deployDenyAntreaNetworkPolicies(t *testing.T, data *TestData, srcPod, podRe
 		failOnError(fmt.Errorf("Error when creating Antrea Network Policy: %v", err), t)
 	}
 	// Wait for Antrea NetworkPolicy to be realized.
-	if err := WaitNetworkPolicyRealize(2, data); err != nil {
+	if err := WaitNetworkPolicyRealize(nodeName, table, flowCount, data); err != nil {
 		t.Errorf("Error when waiting for Antrea Network Policy to be realized: %v", err)
 	}
 	t.Log("Antrea Network Policies are realized.")
 	return anp1, anp2
 }
 
-func deployDenyNetworkPolicies(t *testing.T, data *TestData, pod1, pod2 string) (np1 *networkingv1.NetworkPolicy, np2 *networkingv1.NetworkPolicy) {
+func deployDenyNetworkPolicies(t *testing.T, data *TestData, pod1, pod2 string, node1, node2 string) (np1 *networkingv1.NetworkPolicy, np2 *networkingv1.NetworkPolicy) {
 	np1, err := data.createNetworkPolicy(ingressDenyNPName, &networkingv1.NetworkPolicySpec{
 		PodSelector: metav1.LabelSelector{
 			MatchLabels: map[string]string{
@@ -1261,8 +1281,11 @@ func deployDenyNetworkPolicies(t *testing.T, data *TestData, pod1, pod2 string) 
 		t.Errorf("Error when creating Network Policy: %v", err)
 	}
 	// Wait for NetworkPolicy to be realized.
-	if err := WaitNetworkPolicyRealize(2, data); err != nil {
-		t.Errorf("Error when waiting for Network Policies to be realized: %v", err)
+	if err := WaitNetworkPolicyRealize(node1, openflow.IngressRuleTable, ingressTableInitFlowCount+1, data); err != nil {
+		t.Errorf("Error when waiting for ingress Network Policies to be realized: %v", err)
+	}
+	if err := WaitNetworkPolicyRealize(node2, openflow.EgressRuleTable, egressTableInitFlowCount+1, data); err != nil {
+		t.Errorf("Error when waiting for egress Network Policies to be realized: %v", err)
 	}
 	t.Log("Network Policies are realized.")
 	return np1, np2


### PR DESCRIPTION
1. Set up Openflow pipeline for ExternalNode
2. Install Openflow entries for ExternalNode connectivity
3. Install Openflow entries for ANP on ExternalNode case
4. Install Openflow entries to bypass traffic to/from special peer address on a protocol.
5. Resolve e2e test failures in flow visiblity case introduced by the OVS pipeline change.

Signed-off-by: wenyingd <wenyingd@vmware.com>