### PR TITLE
Openflow1.5 integration

### DIFF
--- a/docs/antctl.md
+++ b/docs/antctl.md
@@ -282,10 +282,10 @@ Example outputs of dumping Pod and NetworkPolicy OVS flows:
 # Dump OVS flows of Pod "coredns-6955765f44-zcbwj"
 $ antctl get of -p coredns-6955765f44-zcbwj -n kube-system
 FLOW
-table=classification, n_packets=513122, n_bytes=42615080, priority=190,in_port="coredns--d0c58e" actions=load:0x2->NXM_NX_REG0[0..15],resubmit(,10)
+table=classification, n_packets=513122, n_bytes=42615080, priority=190,in_port="coredns--d0c58e" actions=set_field:0x2/0xffff->reg0,resubmit(,10)
 table=10, n_packets=513122, n_bytes=42615080, priority=200,ip,in_port="coredns--d0c58e",dl_src=52:bd:c6:e0:eb:c1,nw_src=172.100.1.7 actions=resubmit(,30)
 table=10, n_packets=0, n_bytes=0, priority=200,arp,in_port="coredns--d0c58e",arp_spa=172.100.1.7,arp_sha=52:bd:c6:e0:eb:c1 actions=resubmit(,20)
-table=80, n_packets=556468, n_bytes=166477824, priority=200,dl_dst=52:bd:c6:e0:eb:c1 actions=load:0x5->NXM_NX_REG1[],load:0x1->NXM_NX_REG0[16],resubmit(,90)
+table=80, n_packets=556468, n_bytes=166477824, priority=200,dl_dst=52:bd:c6:e0:eb:c1 actions=load:0x5->NXM_NX_REG1[],set_field:0x10000/0x10000->reg0,resubmit(,90)
 table=70, n_packets=0, n_bytes=0, priority=200,ip,dl_dst=aa:bb:cc:dd:ee:ff,nw_dst=172.100.1.7 actions=set_field:62:39:b4:e8:05:76->eth_src,set_field:52:bd:c6:e0:eb:c1->eth_dst,dec_ttl,resubmit(,80)
 
 # Get NetworkPolicies applied to Pod "coredns-6955765f44-zcbwj"
@@ -378,8 +378,8 @@ result: |
       dec_ttl
       resubmit(,80)
   80. dl_dst=52:bd:c6:e0:eb:c1, priority 200, cookie 0x5e030000000000
-      load:0x5->NXM_NX_REG1[]
-      load:0x1->NXM_NX_REG0[16]
+      set_field:0x5->reg1
+      set_field:0x10000/0x10000->reg0
       resubmit(,90)
   90. conj_id=2,ip, priority 190, cookie 0x5e050000000000
       resubmit(,105)

--- a/docs/design/windows-design.md
+++ b/docs/design/windows-design.md
@@ -160,7 +160,7 @@ table=70, priority=200,ip,nw_dst=$peerPodSubnet actions=mod_dl_dst:$peerNodeMAC,
 table=70, priority=200,ct_state=+rpl+trk,ip,nw_dst=$peerNodeIP actions=mod_dl_dst:$peerNodeMAC,resubmit(,80)
 
 L2ForwardingCalcTable: 80
-table=80, priority=200,dl_dst=$peerNodeMAC actions=load:$uplink->NXM_NX_REG1[],load:0x1->NXM_NX_REG0[16],resubmit(,105)
+table=80, priority=200,dl_dst=$peerNodeMAC actions=load:$uplink->NXM_NX_REG1[],set_field:0x10000/0x10000->reg0,resubmit(,105)
 ```
 
 ### SNAT configuration

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module antrea.io/antrea
 go 1.17
 
 require (
-	antrea.io/libOpenflow v0.6.2
-	antrea.io/ofnet v0.5.7
+	antrea.io/libOpenflow v0.8.0
+	antrea.io/ofnet v0.6.0
 	github.com/ClickHouse/clickhouse-go v1.5.4
 	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/Mellanox/sriovnet v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
-antrea.io/libOpenflow v0.6.2 h1:1JMSJ7Lp7yOhKybHey9VDtRI6JuIgkhUWJBX5GIFY9I=
-antrea.io/libOpenflow v0.6.2/go.mod h1:CzEJZxDNAupiGxeL5VOw92PsxfyvehEAvE3PiC6gr8o=
-antrea.io/ofnet v0.5.7 h1:x0q0lZqp05wu01gk1+S5S15FmIpmTGPhi/z/aIDmuMw=
-antrea.io/ofnet v0.5.7/go.mod h1:8TJVF6MLe9/gZ/KbhGUvULs9/TxssepEaYEe+o1SEgs=
+antrea.io/libOpenflow v0.8.0 h1:Xm6mlSqdXtDD418nf1lndoDvMi8scqUan8pkEUZ2oas=
+antrea.io/libOpenflow v0.8.0/go.mod h1:CzEJZxDNAupiGxeL5VOw92PsxfyvehEAvE3PiC6gr8o=
+antrea.io/ofnet v0.6.0 h1:XuZ1WjOd0R8nIdRG7bfCF1AryLLlaroFjrgnIDfR1Vg=
+antrea.io/ofnet v0.6.0/go.mod h1:qWqi11pI3kBYcS9SYWm92ZOiOPBx04Jx21cDmJlJhOg=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=

--- a/pkg/agent/controller/networkpolicy/reject.go
+++ b/pkg/agent/controller/networkpolicy/reject.go
@@ -18,7 +18,7 @@ import (
 	"encoding/binary"
 	"fmt"
 
-	"antrea.io/libOpenflow/openflow13"
+	"antrea.io/libOpenflow/openflow15"
 	"antrea.io/libOpenflow/protocol"
 	"antrea.io/ofnet/ofctrl"
 
@@ -83,8 +83,12 @@ const (
 // packet-in message.
 func (c *Controller) rejectRequest(pktIn *ofctrl.PacketIn) error {
 	// Get ethernet data.
-	srcMAC := pktIn.Data.HWDst.String()
-	dstMAC := pktIn.Data.HWSrc.String()
+	ethernetPkt, err := getEthernetPacket(pktIn)
+	if err != nil {
+		return err
+	}
+	srcMAC := ethernetPkt.HWDst.String()
+	dstMAC := ethernetPkt.HWSrc.String()
 
 	var (
 		srcIP  string
@@ -92,7 +96,7 @@ func (c *Controller) rejectRequest(pktIn *ofctrl.PacketIn) error {
 		proto  uint8
 		isIPv6 bool
 	)
-	switch ipPkt := pktIn.Data.Data.(type) {
+	switch ipPkt := ethernetPkt.Data.(type) {
 	case *protocol.IPv4:
 		// Get IP data.
 		srcIP = ipPkt.NWDst.String()
@@ -152,17 +156,17 @@ func (c *Controller) rejectRequest(pktIn *ofctrl.PacketIn) error {
 	}
 	tunPort := c.tunPort
 	if tunPort == 0 {
-		// openflow13.P_CONTROLLER is used with noEncap mode when tunnel interface is not found.
-		// It won't cause a loop with openflow13.P_CONTROLLER because it is used as the input port but not output port
+		// openflow15.P_CONTROLLER is used with noEncap mode when tunnel interface is not found.
+		// It won't cause a loop with openflow15.P_CONTROLLER because it is used as the input port but not output port
 		// in the packet out message.
-		tunPort = uint32(openflow13.P_CONTROLLER)
+		tunPort = uint32(openflow15.P_CONTROLLER)
 	}
 	inPort, outPort := getRejectOFPorts(packetOutType, sIface, dIface, c.gwPort, tunPort)
 	mutateFunc := getRejectPacketOutMutateFunc(packetOutType)
 
 	if proto == protocol.Type_TCP {
 		// Get TCP data.
-		oriTCPSrcPort, oriTCPDstPort, oriTCPSeqNum, _, _, err := binding.GetTCPHeaderData(pktIn.Data.Data)
+		oriTCPSrcPort, oriTCPDstPort, oriTCPSeqNum, _, _, err := binding.GetTCPHeaderData(ethernetPkt.Data)
 		if err != nil {
 			return err
 		}
@@ -191,7 +195,7 @@ func (c *Controller) rejectRequest(pktIn *ofctrl.PacketIn) error {
 		icmpCode = ICMPv6DstAdminProhibitedCode
 		ipHdrLen = IPv6HdrLen
 	}
-	ipHdr, _ := pktIn.Data.Data.MarshalBinary()
+	ipHdr, _ := ethernetPkt.Data.MarshalBinary()
 	icmpData := make([]byte, int(ICMPUnusedHdrLen+ipHdrLen+8))
 	// Put ICMP unused header in Data prop and set it to zero.
 	binary.BigEndian.PutUint32(icmpData[:ICMPUnusedHdrLen], 0)

--- a/pkg/agent/controller/traceflow/packetin_test.go
+++ b/pkg/agent/controller/traceflow/packetin_test.go
@@ -171,7 +171,11 @@ func TestParseCapturedPacket(t *testing.T) {
 			if tt.isIPv6 {
 				ethType = uint16(protocol.IPv6_MSG)
 			}
-			pktIn := ofctrl.PacketIn{Data: protocol.Ethernet{Ethertype: ethType, Data: tt.pktInData}}
+			etherPkt := protocol.NewEthernet()
+			etherPkt.Ethertype = ethType
+			etherPkt.Data = tt.pktInData
+			pktBytes, _ := etherPkt.MarshalBinary()
+			pktIn := ofctrl.PacketIn{Data: util.NewBuffer(pktBytes)}
 			packet := parseCapturedPacket(&pktIn)
 			assert.True(t, reflect.DeepEqual(packet, tt.pktCap), "parsed packet does not match the expected")
 		})

--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -19,7 +19,7 @@ import (
 	"math/rand"
 	"net"
 
-	"antrea.io/libOpenflow/openflow13"
+	"antrea.io/libOpenflow/openflow15"
 	"antrea.io/libOpenflow/protocol"
 	ofutil "antrea.io/libOpenflow/util"
 	v1 "k8s.io/api/core/v1"
@@ -996,8 +996,7 @@ func (c *client) SendTraceflowPacket(dataplaneTag uint8, packet *binding.Packet,
 	if outPort != -1 {
 		packetOutBuilder = packetOutBuilder.SetOutport(uint32(outPort))
 	}
-	packetOutBuilder = packetOutBuilder.AddLoadAction(binding.NxmFieldIPToS, uint64(dataplaneTag), traceflowTagToSRange)
-
+	packetOutBuilder = packetOutBuilder.AddSetIPTOSAction(dataplaneTag)
 	packetOutObj := packetOutBuilder.Done()
 	return c.bridge.SendPacketOut(packetOutObj)
 }
@@ -1023,7 +1022,7 @@ func (c *client) UninstallTraceflowFlows(dataplaneTag uint8) error {
 	return c.deleteFlows(c.featureTraceflow.cachedFlows, cacheKey)
 }
 
-// Add TLV map optClass 0x0104, optType 0x80 optLength 4 tunMetadataIndex 0 to store data plane tag
+// InitialTLVMap adds TLV map optClass 0x0104, optType 0x80 optLength 4 tunMetadataIndex 0 to store data plane tag
 // in tunnel. Data plane tag will be stored to NXM_NX_TUN_METADATA0[28..31] when packet get encapsulated
 // into geneve, and will be stored back to NXM_NX_REG9[28..31] when packet get decapsulated.
 func (c *client) InitialTLVMap() error {
@@ -1272,7 +1271,7 @@ func (c *client) SendIGMPRemoteReportPacketOut(
 	srcIP := c.nodeConfig.NodeTransportIPv4Addr.IP.String()
 	dstMACStr := dstMAC.String()
 	dstIPStr := dstIP.String()
-	packetOutBuilder, err := setBasePacketOutBuilder(c.bridge.BuildPacketOut(), srcMAC, dstMACStr, srcIP, dstIPStr, openflow13.P_CONTROLLER, 0)
+	packetOutBuilder, err := setBasePacketOutBuilder(c.bridge.BuildPacketOut(), srcMAC, dstMACStr, srcIP, dstIPStr, openflow15.P_CONTROLLER, 0)
 	if err != nil {
 		return err
 	}

--- a/pkg/agent/openflow/multicast.go
+++ b/pkg/agent/openflow/multicast.go
@@ -19,7 +19,7 @@ import (
 	"net"
 	"sync"
 
-	"antrea.io/libOpenflow/openflow13"
+	"antrea.io/libOpenflow/openflow15"
 	"k8s.io/klog/v2"
 
 	"antrea.io/antrea/pkg/agent/config"
@@ -194,14 +194,14 @@ func (f *featureMulticast) multicastRemoteReportFlows(groupID binding.GroupIDTyp
 		MulticastRoutingTable.ofTable.BuildFlow(priorityHigh).
 			Cookie(f.cookieAllocator.Request(f.category).Raw()).
 			MatchProtocol(binding.ProtocolIGMP).
-			MatchInPort(openflow13.P_CONTROLLER).
+			MatchInPort(openflow15.P_CONTROLLER).
 			Action().LoadRegMark(CustomReasonIGMPRegMark).
 			Action().Group(groupID).
 			Done(),
 		// This flow ensures the IGMP report message sent from Antrea Agent to bypass the check in SpoofGuardTable.
 		ClassifierTable.ofTable.BuildFlow(priorityNormal).
 			Cookie(f.cookieAllocator.Request(f.category).Raw()).
-			MatchInPort(openflow13.P_CONTROLLER).
+			MatchInPort(openflow15.P_CONTROLLER).
 			Action().GotoTable(SpoofGuardTable.GetNext()).
 			Done(),
 		// This flow ensures the multicast packet sent from a different Node via the tunnel port to enter Multicast

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 	"time"
 
-	"antrea.io/libOpenflow/openflow13"
+	"antrea.io/libOpenflow/openflow15"
 	"antrea.io/libOpenflow/protocol"
 	"antrea.io/ofnet/ofctrl"
 	v1 "k8s.io/api/core/v1"
@@ -370,10 +370,6 @@ var DispositionToString = map[uint32]string{
 }
 
 var (
-	// traceflowTagToSRange stores Traceflow dataplane tag to DSCP bits of
-	// IP header ToS field.
-	traceflowTagToSRange = binding.IPDSCPToSRange
-
 	// snatPktMarkRange takes an 8-bit range of pkt_mark to store the ID of
 	// a SNAT IP. The bit range must match SNATIPMarkMask.
 	snatPktMarkRange = &binding.Range{0, 7}
@@ -2869,7 +2865,7 @@ func (f *featurePodConnectivity) hostBridgeLocalFlows() []binding.Flow {
 
 // hostBridgeUplinkVLANFlows generates the flows to match VLAN packets from uplink port.
 func (f *featurePodConnectivity) hostBridgeUplinkVLANFlows() []binding.Flow {
-	vlanMask := uint16(openflow13.OFPVID_PRESENT)
+	vlanMask := uint16(openflow15.OFPVID_PRESENT)
 	return []binding.Flow{
 		VLANTable.ofTable.BuildFlow(priorityLow).
 			Cookie(f.cookieAllocator.Request(f.category).Raw()).

--- a/pkg/ovs/openflow/ofctrl_builder.go
+++ b/pkg/ovs/openflow/ofctrl_builder.go
@@ -19,7 +19,7 @@ import (
 	"net"
 	"strings"
 
-	"antrea.io/libOpenflow/openflow13"
+	"antrea.io/libOpenflow/openflow15"
 	"antrea.io/ofnet/ofctrl"
 )
 
@@ -28,7 +28,7 @@ type ofFlowBuilder struct {
 }
 
 func (b *ofFlowBuilder) MatchTunMetadata(index int, data uint32) FlowBuilder {
-	rng := openflow13.NewNXRange(0, 31)
+	rng := openflow15.NewNXRange(0, 31)
 	tm := &ofctrl.NXTunMetadata{
 		ID:    index,
 		Data:  data,
@@ -133,7 +133,7 @@ func (b *ofFlowBuilder) addCTStateString(value string) {
 
 func (b *ofFlowBuilder) MatchCTStateNew(set bool) FlowBuilder {
 	if b.ctStates == nil {
-		b.ctStates = openflow13.NewCTStates()
+		b.ctStates = openflow15.NewCTStates()
 	}
 	if set {
 		b.ctStates.SetNew()
@@ -147,7 +147,7 @@ func (b *ofFlowBuilder) MatchCTStateNew(set bool) FlowBuilder {
 
 func (b *ofFlowBuilder) MatchCTStateRel(set bool) FlowBuilder {
 	if b.ctStates == nil {
-		b.ctStates = openflow13.NewCTStates()
+		b.ctStates = openflow15.NewCTStates()
 	}
 	if set {
 		b.ctStates.SetRel()
@@ -161,7 +161,7 @@ func (b *ofFlowBuilder) MatchCTStateRel(set bool) FlowBuilder {
 
 func (b *ofFlowBuilder) MatchCTStateRpl(set bool) FlowBuilder {
 	if b.ctStates == nil {
-		b.ctStates = openflow13.NewCTStates()
+		b.ctStates = openflow15.NewCTStates()
 	}
 	if set {
 		b.ctStates.SetRpl()
@@ -175,7 +175,7 @@ func (b *ofFlowBuilder) MatchCTStateRpl(set bool) FlowBuilder {
 
 func (b *ofFlowBuilder) MatchCTStateEst(set bool) FlowBuilder {
 	if b.ctStates == nil {
-		b.ctStates = openflow13.NewCTStates()
+		b.ctStates = openflow15.NewCTStates()
 	}
 	if set {
 		b.ctStates.SetEst()
@@ -189,7 +189,7 @@ func (b *ofFlowBuilder) MatchCTStateEst(set bool) FlowBuilder {
 
 func (b *ofFlowBuilder) MatchCTStateTrk(set bool) FlowBuilder {
 	if b.ctStates == nil {
-		b.ctStates = openflow13.NewCTStates()
+		b.ctStates = openflow15.NewCTStates()
 	}
 	if set {
 		b.ctStates.SetTrk()
@@ -203,7 +203,7 @@ func (b *ofFlowBuilder) MatchCTStateTrk(set bool) FlowBuilder {
 
 func (b *ofFlowBuilder) MatchCTStateInv(set bool) FlowBuilder {
 	if b.ctStates == nil {
-		b.ctStates = openflow13.NewCTStates()
+		b.ctStates = openflow15.NewCTStates()
 	}
 	if set {
 		b.ctStates.SetInv()
@@ -217,7 +217,7 @@ func (b *ofFlowBuilder) MatchCTStateInv(set bool) FlowBuilder {
 
 func (b *ofFlowBuilder) MatchCTStateDNAT(set bool) FlowBuilder {
 	if b.ctStates == nil {
-		b.ctStates = openflow13.NewCTStates()
+		b.ctStates = openflow15.NewCTStates()
 	}
 	if set {
 		b.ctStates.SetDNAT()
@@ -231,7 +231,7 @@ func (b *ofFlowBuilder) MatchCTStateDNAT(set bool) FlowBuilder {
 
 func (b *ofFlowBuilder) MatchCTStateSNAT(set bool) FlowBuilder {
 	if b.ctStates == nil {
-		b.ctStates = openflow13.NewCTStates()
+		b.ctStates = openflow15.NewCTStates()
 	}
 	if set {
 		b.ctStates.SetSNAT()

--- a/pkg/ovs/openflow/ofctrl_flow.go
+++ b/pkg/ovs/openflow/ofctrl_flow.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"strings"
 
-	"antrea.io/libOpenflow/openflow13"
+	"antrea.io/libOpenflow/openflow15"
 	"antrea.io/ofnet/ofctrl"
 )
 
@@ -42,9 +42,9 @@ type ofFlow struct {
 	// ctStateString is a temporary variable for the readable ct_state configuration. Its value is changed when the client
 	// updates the matching condition of "ct_states". When FlowBuilder.Done is called, its value is added into the matchers.
 	ctStateString string
-	// ctStates is a temporary variable to maintain openflow13.CTStates. When FlowBuilder.Done is called, it is used to
+	// ctStates is a temporary variable to maintain openflow15.CTStates. When FlowBuilder.Done is called, it is used to
 	// set the CtStates field in ofctrl.Flow.Match.
-	ctStates *openflow13.CTStates
+	ctStates *openflow15.CTStates
 	// isDropFlow is true if this flow actions contain "drop"
 	isDropFlow bool
 }
@@ -69,7 +69,7 @@ func (f *ofFlow) Reset() {
 }
 
 func (f *ofFlow) Add() error {
-	err := f.Flow.Send(openflow13.FC_ADD)
+	err := f.Flow.Send(openflow15.FC_ADD)
 	if err != nil {
 		return err
 	}
@@ -78,7 +78,7 @@ func (f *ofFlow) Add() error {
 }
 
 func (f *ofFlow) Modify() error {
-	err := f.Flow.Send(openflow13.FC_MODIFY_STRICT)
+	err := f.Flow.Send(openflow15.FC_MODIFY_STRICT)
 	if err != nil {
 		return err
 	}
@@ -88,7 +88,7 @@ func (f *ofFlow) Modify() error {
 
 func (f *ofFlow) Delete() error {
 	f.Flow.UpdateInstallStatus(true)
-	err := f.Flow.Send(openflow13.FC_DELETE_STRICT)
+	err := f.Flow.Send(openflow15.FC_DELETE_STRICT)
 	if err != nil {
 		return err
 	}
@@ -128,11 +128,11 @@ func (f *ofFlow) GetBundleMessage(entryOper OFOperation) (ofctrl.OpenFlowModMess
 	var operation int
 	switch entryOper {
 	case AddMessage:
-		operation = openflow13.FC_ADD
+		operation = openflow15.FC_ADD
 	case ModifyMessage:
-		operation = openflow13.FC_MODIFY_STRICT
+		operation = openflow15.FC_MODIFY_STRICT
 	case DeleteMessage:
-		operation = openflow13.FC_DELETE_STRICT
+		operation = openflow15.FC_DELETE_STRICT
 	}
 	message, err := f.Flow.GetBundleMessage(operation)
 	if err != nil {
@@ -175,8 +175,8 @@ func (f *ofFlow) IsDropFlow() bool {
 	return f.isDropFlow
 }
 
-func (r *Range) ToNXRange() *openflow13.NXRange {
-	return openflow13.NewNXRange(int(r[0]), int(r[1]))
+func (r *Range) ToNXRange() *openflow15.NXRange {
+	return openflow15.NewNXRange(int(r[0]), int(r[1]))
 }
 
 func (r *Range) Length() uint32 {

--- a/pkg/ovs/openflow/ofctrl_meter.go
+++ b/pkg/ovs/openflow/ofctrl_meter.go
@@ -17,7 +17,7 @@ package openflow
 import (
 	"fmt"
 
-	"antrea.io/libOpenflow/openflow13"
+	"antrea.io/libOpenflow/openflow15"
 	"antrea.io/libOpenflow/util"
 	"antrea.io/ofnet/ofctrl"
 )
@@ -55,11 +55,11 @@ func (m *ofMeter) GetBundleMessage(entryOper OFOperation) (ofctrl.OpenFlowModMes
 	var operation int
 	switch entryOper {
 	case AddMessage:
-		operation = openflow13.OFPMC_ADD
+		operation = openflow15.MC_ADD
 	case ModifyMessage:
-		operation = openflow13.OFPMC_MODIFY
+		operation = openflow15.MC_MODIFY
 	case DeleteMessage:
-		operation = openflow13.OFPMC_DELETE
+		operation = openflow15.MC_DELETE
 	}
 	message := m.ofctrl.GetBundleMessage(operation)
 	return message, nil
@@ -73,7 +73,7 @@ func (m *ofMeter) ResetMeterBands() Meter {
 func (m *ofMeter) MeterBand() MeterBandBuilder {
 	return &meterBandBuilder{
 		meter:           m,
-		meterBandHeader: openflow13.NewMeterBandHeader(),
+		meterBandHeader: openflow15.NewMeterBandHeader(),
 		prevLevel:       0,
 		experimenter:    0,
 	}
@@ -81,7 +81,7 @@ func (m *ofMeter) MeterBand() MeterBandBuilder {
 
 type meterBandBuilder struct {
 	meter           *ofMeter
-	meterBandHeader *openflow13.MeterBandHeader
+	meterBandHeader *openflow15.MeterBandHeader
 	prevLevel       uint8
 	experimenter    uint32
 }
@@ -115,16 +115,16 @@ func (m *meterBandBuilder) Done() Meter {
 	var mb util.Message
 	switch m.meterBandHeader.Type {
 	case uint16(ofctrl.MeterDrop):
-		mbDrop := new(openflow13.MeterBandDrop)
+		mbDrop := new(openflow15.MeterBandDrop)
 		mbDrop.MeterBandHeader = *m.meterBandHeader
 		mb = mbDrop
 	case uint16(ofctrl.MeterDSCPRemark):
-		mbDscp := new(openflow13.MeterBandDSCP)
+		mbDscp := new(openflow15.MeterBandDSCP)
 		mbDscp.MeterBandHeader = *m.meterBandHeader
 		mbDscp.PrecLevel = m.prevLevel
 		mb = mbDscp
 	case uint16(ofctrl.MeterExperimenter):
-		mbExp := new(openflow13.MeterBandExperimenter)
+		mbExp := new(openflow15.MeterBandExperimenter)
 		mbExp.MeterBandHeader = *m.meterBandHeader
 		mbExp.Experimenter = m.experimenter
 	}

--- a/pkg/ovs/openflow/ofctrl_packetin_test.go
+++ b/pkg/ovs/openflow/ofctrl_packetin_test.go
@@ -168,6 +168,19 @@ func TestParsePacketIn(t *testing.T) {
 	testBytes, _ := testTCP.MarshalBinary()
 	testBuffer := new(util.Buffer)
 	testBuffer.UnmarshalBinary(testBytes)
+	ethPkt := protocol.NewEthernet()
+	ethPkt.HWDst = testMac1
+	ethPkt.HWSrc = testMac2
+	ethPkt.Ethertype = protocol.IPv6_MSG
+	ethPkt.Data = util.Message(&protocol.IPv6{
+		Length:     1,
+		NextHeader: protocol.Type_TCP,
+		HopLimit:   0,
+		NWSrc:      testIP1,
+		NWDst:      testIP2,
+		Data:       testBuffer,
+	})
+	pktBytes, _ := ethPkt.MarshalBinary()
 	tests := []struct {
 		name       string
 		pktIn      *ofctrl.PacketIn
@@ -178,19 +191,7 @@ func TestParsePacketIn(t *testing.T) {
 			"ParsePacketIn-ipv6",
 			&ofctrl.PacketIn{
 				Reason: 1,
-				Data: protocol.Ethernet{
-					Ethertype: protocol.IPv6_MSG,
-					HWDst:     testMac1,
-					HWSrc:     testMac2,
-					Data: util.Message(&protocol.IPv6{
-						Length:     1,
-						NextHeader: protocol.Type_TCP,
-						HopLimit:   0,
-						NWSrc:      testIP1,
-						NWDst:      testIP2,
-						Data:       testBuffer,
-					}),
-				},
+				Data:   util.NewBuffer(pktBytes),
 			},
 			&Packet{
 				IsIPv6:          true,

--- a/pkg/ovs/openflow/ofctrl_packetout_test.go
+++ b/pkg/ovs/openflow/ofctrl_packetout_test.go
@@ -805,7 +805,7 @@ func Test_ofPacketOutBuilder_Done(t *testing.T) {
 				t.Errorf("Done() = %v, want %v", got.ICMPHeader, tt.want.ICMPHeader)
 			}
 			if !reflect.DeepEqual(got.TCPHeader, tt.want.TCPHeader) {
-				t.Errorf("Done() = %v, want %v", got.TCPHeader, tt.want.TCPHeader)
+				t.Errorf("Done() = %+v, want %+v", got.TCPHeader, tt.want.TCPHeader)
 			}
 			if !reflect.DeepEqual(got.UDPHeader, tt.want.UDPHeader) {
 				t.Errorf("Done() = %v, want %v", got.UDPHeader, tt.want.UDPHeader)
@@ -817,7 +817,7 @@ func Test_ofPacketOutBuilder_Done(t *testing.T) {
 				t.Errorf("Done() = %v, want %v", got.IPv6Header, tt.want.IPv6Header)
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Done() = %v, want %v", got, tt.want)
+				t.Errorf("Done() = %+v, want %+v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/ovs/openflow/testing/mock_openflow.go
+++ b/pkg/ovs/openflow/testing/mock_openflow.go
@@ -917,6 +917,20 @@ func (mr *MockActionMockRecorder) Move(arg0, arg1 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Move", reflect.TypeOf((*MockAction)(nil).Move), arg0, arg1)
 }
 
+// MoveFromTunMetadata mocks base method
+func (m *MockAction) MoveFromTunMetadata(arg0 int, arg1 string, arg2, arg3 openflow.Range, arg4 byte) openflow.FlowBuilder {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MoveFromTunMetadata", arg0, arg1, arg2, arg3, arg4)
+	ret0, _ := ret[0].(openflow.FlowBuilder)
+	return ret0
+}
+
+// MoveFromTunMetadata indicates an expected call of MoveFromTunMetadata
+func (mr *MockActionMockRecorder) MoveFromTunMetadata(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MoveFromTunMetadata", reflect.TypeOf((*MockAction)(nil).MoveFromTunMetadata), arg0, arg1, arg2, arg3, arg4)
+}
+
 // MoveRange mocks base method
 func (m *MockAction) MoveRange(arg0, arg1 string, arg2, arg3 openflow.Range) openflow.FlowBuilder {
 	m.ctrl.T.Helper()

--- a/pkg/ovs/ovsconfig/ovs_client.go
+++ b/pkg/ovs/ovsconfig/ovs_client.go
@@ -54,8 +54,8 @@ const (
 	openvSwitchSchema = "Open_vSwitch"
 	// Openflow protocol version 1.0.
 	openflowProtoVersion10 = "OpenFlow10"
-	// Openflow protocol version 1.3.
-	openflowProtoVersion13 = "OpenFlow13"
+	// Openflow protocol version 1.5.
+	openflowProtoVersion15 = "OpenFlow15"
 	// Maximum allowed value of ofPortRequest.
 	ofPortRequestMax = 65279
 	hardwareOffload  = "hw-offload"
@@ -102,7 +102,7 @@ func NewOVSBridge(bridgeName string, ovsDatapathType OVSDatapathType, ovsdb *ovs
 }
 
 // Create looks up or creates the bridge. If the bridge with name bridgeName
-// does not exist, it will be created. Openflow protocol version 1.0 and 1.3
+// does not exist, it will be created. Openflow protocol version 1.0 and 1.5
 // will be enabled for the bridge.
 func (br *OVSBridge) Create() Error {
 	var err Error
@@ -150,13 +150,13 @@ func (br *OVSBridge) lookupByName() (bool, Error) {
 
 func (br *OVSBridge) updateBridgeConfiguration() Error {
 	tx := br.ovsdb.Transaction(openvSwitchSchema)
-	// Use Openflow protocol version 1.0 and 1.3.
+	// Use Openflow protocol version 1.0 and 1.5.
 	tx.Update(dbtransaction.Update{
 		Table: "Bridge",
 		Where: [][]interface{}{{"name", "==", br.name}},
 		Row: map[string]interface{}{
 			"protocols": makeOVSDBSetFromList([]string{openflowProtoVersion10,
-				openflowProtoVersion13}),
+				openflowProtoVersion15}),
 			"datapath_type": br.datapathType,
 		},
 	})
@@ -172,9 +172,9 @@ func (br *OVSBridge) create() Error {
 	tx := br.ovsdb.Transaction(openvSwitchSchema)
 	bridge := Bridge{
 		Name: br.name,
-		// Use Openflow protocol version 1.0 and 1.3.
+		// Use Openflow protocol version 1.0 and 1.5.
 		Protocols: makeOVSDBSetFromList([]string{openflowProtoVersion10,
-			openflowProtoVersion13}),
+			openflowProtoVersion15}),
 		DatapathType: string(br.datapathType),
 	}
 	namedUUID := tx.Insert(dbtransaction.Insert{

--- a/pkg/ovs/ovsctl/ofctl.go
+++ b/pkg/ovs/ovsctl/ofctl.go
@@ -84,7 +84,7 @@ func (c *ovsCtlClient) DumpGroup(groupID uint32) (string, error) {
 	// versions of OpenFlow always dump all groups. But when OpenFlow
 	// version is not specified, ovs-ofctl defaults to use OpenFlow10 but
 	// with the Nicira extensions enabled, which can support dumping a
-	// single group too. So here, we do not specify Openflow13 to run the
+	// single group too. So here, we do not specify Openflow15 to run the
 	// command.
 	groupDump, err := c.runOfctlCmd(false, "dump-groups", strconv.FormatUint(uint64(groupID), 10))
 	if err != nil {
@@ -163,11 +163,11 @@ func (c *ovsCtlClient) SetPortNoFlood(ofport int) error {
 	return nil
 }
 
-func (c *ovsCtlClient) runOfctlCmd(openflow13 bool, cmd string, args ...string) ([]byte, error) {
+func (c *ovsCtlClient) runOfctlCmd(openflow15 bool, cmd string, args ...string) ([]byte, error) {
 	cmdStr := fmt.Sprintf("ovs-ofctl %s %s", cmd, c.bridge)
 	cmdStr = cmdStr + " " + strings.Join(args, " ")
-	if openflow13 {
-		cmdStr += " -O Openflow13"
+	if openflow15 {
+		cmdStr += " -O Openflow15"
 	}
 	out, err := getOVSCommand(cmdStr).Output()
 	if err != nil {
@@ -177,7 +177,7 @@ func (c *ovsCtlClient) runOfctlCmd(openflow13 bool, cmd string, args ...string) 
 }
 
 func (c *ovsCtlClient) RunOfctlCmd(cmd string, args ...string) ([]byte, error) {
-	// Default to use Openflow13.
+	// Default to use Openflow15.
 	return c.runOfctlCmd(true, cmd, args...)
 }
 

--- a/plugins/octant/go.sum
+++ b/plugins/octant/go.sum
@@ -1,5 +1,5 @@
-antrea.io/libOpenflow v0.6.2/go.mod h1:CzEJZxDNAupiGxeL5VOw92PsxfyvehEAvE3PiC6gr8o=
-antrea.io/ofnet v0.5.7/go.mod h1:8TJVF6MLe9/gZ/KbhGUvULs9/TxssepEaYEe+o1SEgs=
+antrea.io/libOpenflow v0.8.0/go.mod h1:CzEJZxDNAupiGxeL5VOw92PsxfyvehEAvE3PiC6gr8o=
+antrea.io/ofnet v0.6.0/go.mod h1:qWqi11pI3kBYcS9SYWm92ZOiOPBx04Jx21cDmJlJhOg=
 bazil.org/fuse v0.0.0-20160811212531-371fbbdaa898/go.mod h1:Xbm+BRKSBEpa4q4hTSxohYNQpsxXPbPry4JJWOB3LB8=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -941,9 +941,10 @@ func testProxyEndpointLifeCycle(ipFamily *corev1.IPFamily, data *TestData, t *te
 
 	var groupKeywords []string
 	if *ipFamily == corev1.IPv6Protocol {
-		groupKeywords = append(groupKeywords, fmt.Sprintf("set_field:0x%s->xxreg3", strings.TrimPrefix(hex.EncodeToString(*nginxIPs.ipv6), "0")))
+		groupKeywords = append(groupKeywords,
+			fmt.Sprintf("load:0x%s->NXM_NX_XXREG3[0..63],load:0x%s->NXM_NX_XXREG3[64..127]", strings.TrimLeft(hex.EncodeToString((*nginxIPs.ipv6)[8:16]), "0"), strings.TrimLeft(hex.EncodeToString((*nginxIPs.ipv6)[:8]), "0")))
 	} else {
-		groupKeywords = append(groupKeywords, fmt.Sprintf("0x%s->NXM_NX_REG3[]", strings.TrimPrefix(hex.EncodeToString(nginxIPs.ipv4.To4()), "0")))
+		groupKeywords = append(groupKeywords, fmt.Sprintf("0x%s->NXM_NX_REG3[]", strings.TrimLeft(hex.EncodeToString(nginxIPs.ipv4.To4()), "0")))
 	}
 
 	for tableName, keyword := range keywords {
@@ -1063,7 +1064,10 @@ func testProxyServiceLifeCycle(ipFamily *corev1.IPFamily, ingressIPs []string, d
 
 	var groupKeyword string
 	if *ipFamily == corev1.IPv6Protocol {
-		groupKeyword = fmt.Sprintf("set_field:0x%s->xxreg3,load:0x%x->NXM_NX_REG4[0..15]", strings.TrimLeft(hex.EncodeToString(nginxIPs.ipv6.To16()), "0"), 80)
+		groupKeyword = fmt.Sprintf("load:0x%s->NXM_NX_XXREG3[0..63],load:0x%s->NXM_NX_XXREG3[64..127],load:0x%x->NXM_NX_REG4[0..15]",
+			strings.TrimLeft(hex.EncodeToString(nginxIPs.ipv6.To16()[8:16]), "0"),
+			strings.TrimLeft(hex.EncodeToString(nginxIPs.ipv6.To16()[:8]), "0"),
+			80)
 	} else {
 		groupKeyword = fmt.Sprintf("load:0x%s->NXM_NX_REG3[],load:0x%x->NXM_NX_REG4[0..15]", strings.TrimLeft(hex.EncodeToString(nginxIPs.ipv4.To4()), "0"), 80)
 	}

--- a/test/integration/ovs/openflow_test_utils.go
+++ b/test/integration/ovs/openflow_test_utils.go
@@ -37,7 +37,7 @@ func PrepareOVSBridge(brName string) error {
 	// using the netdev datapath type does not impact test coverage but
 	// ensures that the integration tests can be run with Docker Desktop on
 	// macOS.
-	cmdStr := fmt.Sprintf("ovs-vsctl --may-exist add-br %s -- set Bridge %s protocols='OpenFlow10,OpenFlow13' datapath_type=netdev", brName, brName)
+	cmdStr := fmt.Sprintf("ovs-vsctl --may-exist add-br %s -- set Bridge %s protocols='OpenFlow10,OpenFlow15' datapath_type=netdev", brName, brName)
 	err := exec.Command("/bin/sh", "-c", cmdStr).Run()
 	if err != nil {
 		return err
@@ -114,7 +114,12 @@ func CheckGroupExists(t *testing.T, ovsCtlClient ovsctl.OVSCtlClient, groupID bi
 		found := false
 		for _, groupElems := range groupList {
 			groupEntry := fmt.Sprintf("%s,bucket=", groupElems[0])
-			groupEntry = fmt.Sprintf("%s%s", groupEntry, strings.Join(groupElems[1:], ",bucket="))
+			var groupElemStrs []string
+			for _, elem := range groupElems[1:] {
+				elemStr := strings.Join(strings.Split(elem, ",")[1:], ",")
+				groupElemStrs = append(groupElemStrs, elemStr)
+			}
+			groupEntry = fmt.Sprintf("%s%s", groupEntry, strings.Join(groupElemStrs, ",bucket="))
 			if strings.Contains(groupEntry, groupStr) {
 				found = true
 				break
@@ -148,7 +153,7 @@ func formatFlowDump(rawFlows []string) []string {
 	for _, flow := range rawFlows {
 		felem := strings.Fields(flow)
 		if len(felem) > 2 {
-			felem = append(felem[:1], felem[3:]...)
+			felem = append(felem[:1], felem[4:]...)
 			fstr := strings.Join(felem, " ")
 			flowList = append(flowList, fstr)
 		}


### PR DESCRIPTION
1. Use set_field action to replace the original "load" action, and use "copy_field" to replace "move"
2. MatchField "NXM_NX_REGX" is removed from the Match in packetIn message, and message
    "OXM_CLASS_PACKET_REGS" is used in OpenFlow1.5 instead. OVS 64bit xreg is actually used in
    this mesage. A convension from OVS 32bit reg to 64bit xreg is needed when trying to identify
    the match settings.
3. The type of "Data" field in PacketIn and PacketOut mesage in OpenFlow1.5 uses "Message" instead
    of the original "Ethernet". A type cast is needed to parse or set Ethernet packet in these two
    messages.
4. Integration test is modified as the action changes.

Signed-off-by: wenyingd <wenyingd@vmware.com>