### PR TITLE
Fix e2e and integration bug

### DIFF
--- a/multicluster/test/e2e/antreapolicy_test.go
+++ b/multicluster/test/e2e/antreapolicy_test.go
@@ -91,6 +91,8 @@ func (data *MCTestData) testAntreaPolicyCopySpanNSIsolation(t *testing.T) {
 	setup := func() {
 		err := data.deployACNPResourceExport(acnpIsolationResourceExport)
 		failOnError(err, t)
+		// Sleep 5s to wait resource export/import process to finish resource exchange.
+		time.Sleep(5 * time.Second)
 	}
 	teardown := func() {
 		err := data.deleteACNPResourceExport(acnpIsolationResourceExport)

--- a/multicluster/test/e2e/service_test.go
+++ b/multicluster/test/e2e/service_test.go
@@ -117,10 +117,10 @@ func (data *MCTestData) testServiceExport(t *testing.T) {
 	}
 
 	// Verfiy that ACNP works fine with new Multicluster Service.
-	data.verifyMCServiceACNP(t, clientPodName, westIP)
+	data.verifyMCServiceACNP(t, clientPodName, eastIP)
 }
 
-func (data *MCTestData) verifyMCServiceACNP(t *testing.T, clientPodName, westIP string) {
+func (data *MCTestData) verifyMCServiceACNP(t *testing.T, clientPodName, eastIP string) {
 	var err error
 	anpBuilder := &e2euttils.AntreaNetworkPolicySpecBuilder{}
 	anpBuilder = anpBuilder.SetName(multiClusterTestNamespace, "block-west-exported-service").
@@ -135,7 +135,7 @@ func (data *MCTestData) verifyMCServiceACNP(t *testing.T, clientPodName, westIP 
 	}
 	defer data.deleteANP(eastCluster, multiClusterTestNamespace, anpBuilder.Name)
 
-	connectivity := data.probeFromPodInCluster(eastCluster, multiClusterTestNamespace, clientPodName, "client", westIP, "westClusterServiceIP", 80, corev1.ProtocolTCP)
+	connectivity := data.probeFromPodInCluster(eastCluster, multiClusterTestNamespace, clientPodName, "client", eastIP, fmt.Sprintf("antrea-mc-%s", westClusterTestService), 80, corev1.ProtocolTCP)
 	if connectivity == antreae2e.Error {
 		t.Errorf("Failure -- could not complete probeFromPodInCluster: %v", err)
 	} else if connectivity != antreae2e.Dropped {

--- a/multicluster/test/integration/suite_test.go
+++ b/multicluster/test/integration/suite_test.go
@@ -99,7 +99,7 @@ var _ = BeforeSuite(func() {
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crd", "bases"),
 			filepath.Join("..", "..", "config", "crd", "k8smcs"),
-			filepath.Join("..", "..", "..", "build", "yamls", "base", "crds.yml")},
+			filepath.Join("..", "..", "..", "build", "charts", "antrea", "templates", "crds", "clusternetworkpolicy.yaml")},
 		ErrorIfCRDPathMissing: true,
 		UseExistingCluster:    &useExistingCluster,
 	}


### PR DESCRIPTION
1. Fix the crd load path in integration test
2. Fix the network policy e2e random failure issue by adding a waiting interval.
3. Fix the toService network policy test with correct target IP, the original one is actually incorrect but the result is expected because both ways caused packet drops.

Signed-off-by: Lan Luo <luola@vmware.com>