### PR TITLE
Tolerate unset SKIP_CNI_BINARIES env var

### DIFF
--- a/build/images/scripts/install_cni
+++ b/build/images/scripts/install_cni
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # Fetching the list of the binaries that user wants to skip installing.
-IFS=',' read -r -a binaries <<< "$SKIP_CNI_BINARIES"
+IFS=',' read -r -a binaries <<< "${SKIP_CNI_BINARIES:-}"
 # Todo: check version and continue installation only for a newer version
 
 # Install Antrea binary file


### PR DESCRIPTION
To prevent init container from crashing due to`unbound variable` when the env var is unset.

Signed-off-by: Quan Tian <qtian@vmware.com>