### PR TITLE
Fix ci/kind/validate-metrics-doc.sh script

### DIFF
--- a/ci/kind/validate-metrics-doc.sh
+++ b/ci/kind/validate-metrics-doc.sh
@@ -35,11 +35,11 @@ METRICS_DOC="$THIS_DIR/../../docs/prometheus-integration.md"
 
 cp -v $METRICS_DOC $METRICS_TMP_DOC
 $MAKE_CMD $METRICS_TMP_DOC
-cmp -s $METRICS_DOC $METRICS_TMP_DOC
-result=$?
+result=0
+cmp -s $METRICS_DOC $METRICS_TMP_DOC || result=$?
 if [ $result -ne 0 ]; then
     echo "Error: Prometheus metrics document should be updated"
-    echo "You can update it by building the Antrea Docker image locally (with `make`), running ./hack/make-metrics-doc.sh and committing the changes"
+    echo "You can update it by building the Antrea Docker image locally (with 'make'), running ./hack/make-metrics-doc.sh and committing the changes"
     exit 1
 fi
 


### PR DESCRIPTION
In case of failure, the script was exiting right away, without
displaying the error message.

Signed-off-by: Antonin Bas <abas@vmware.com>