### PR TITLE
Fix OpenFlow flaky errors in the integration tests

### DIFF
--- a/test/integration/ovs/ofctrl_test.go
+++ b/test/integration/ovs/ofctrl_test.go
@@ -240,10 +240,11 @@ func TestOFctrlFlow(t *testing.T) {
 		if err != nil {
 			t.Errorf("Failed to DeleteFlowsByCookie: %v", err)
 		}
-		flowList, _ = OfctlDumpTableFlowsWithoutName(ovsCtlClient, myTable.GetID())
-		if len(flowList) > 0 {
-			t.Errorf("Failed to delete flows by CookieID")
-		}
+		require.NoError(t, wait.PollImmediate(time.Millisecond*100, time.Second, func() (done bool, err error) {
+			flowList, err = OfctlDumpTableFlowsWithoutName(ovsCtlClient, myTable.GetID())
+			require.Nil(t, err)
+			return len(flowList) == 0, nil
+		}), "Failed to delete flows by CookieID")
 	}
 }
 


### PR DESCRIPTION
1. The integration test supports dump OpenFlow test with table name
    or table ID. The issue is the expected flow uses the ID to represent
    table, while the actual flow from OVS uses table name, so the
    comparison failed. The fix is using a separte variable for the
    expected table, which is overwritten in the retry.
2. Improve the test case that deleting flows with a special cookie. Add
    retry mechnism when dump flows from OVS, to avoid comparison with a
    status that OVS does not complete flow realization

Fixes #3213 

Signed-off-by: wenyingd <wenyingd@vmware.com>