### PR TITLE
[ExternalNode] Handle ExternalNode from Antrea agent side

### DIFF
--- a/build/charts/antrea/conf/antrea-agent.conf
+++ b/build/charts/antrea/conf/antrea-agent.conf
@@ -67,9 +67,6 @@ featureGates:
 # Enable certificated-based authentication for IPsec.
 {{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "IPsecCertAuth" "default" false) }}
 
-# Enable running agent on an unmanaged VM/BM.
-{{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "ExternalNode" "default" false) }}
-
 # Name of the OpenVSwitch bridge antrea-agent will create and use.
 # Make sure it doesn't conflict with your existing OpenVSwitch bridges.
 ovsBridge: {{ .Values.ovs.bridgeName | quote }}

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -2679,9 +2679,6 @@ data:
     # Enable certificated-based authentication for IPsec.
     #  IPsecCertAuth: false
 
-    # Enable running agent on an unmanaged VM/BM.
-    #  ExternalNode: false
-
     # Name of the OpenVSwitch bridge antrea-agent will create and use.
     # Make sure it doesn't conflict with your existing OpenVSwitch bridges.
     ovsBridge: "br-int"
@@ -3780,7 +3777,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 34d282c5003d66a4a1741b1940b64ac6eb464275eed596ebf3a4242864bbb88a
+        checksum/config: e58a0311b8ecc3d02a5c5f9ab89a6d5e98beb2a7078f5cd36e6007bb860b1018
       labels:
         app: antrea
         component: antrea-agent
@@ -4020,7 +4017,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 34d282c5003d66a4a1741b1940b64ac6eb464275eed596ebf3a4242864bbb88a
+        checksum/config: e58a0311b8ecc3d02a5c5f9ab89a6d5e98beb2a7078f5cd36e6007bb860b1018
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -2679,9 +2679,6 @@ data:
     # Enable certificated-based authentication for IPsec.
     #  IPsecCertAuth: false
 
-    # Enable running agent on an unmanaged VM/BM.
-    #  ExternalNode: false
-
     # Name of the OpenVSwitch bridge antrea-agent will create and use.
     # Make sure it doesn't conflict with your existing OpenVSwitch bridges.
     ovsBridge: "br-int"
@@ -3780,7 +3777,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 34d282c5003d66a4a1741b1940b64ac6eb464275eed596ebf3a4242864bbb88a
+        checksum/config: e58a0311b8ecc3d02a5c5f9ab89a6d5e98beb2a7078f5cd36e6007bb860b1018
       labels:
         app: antrea
         component: antrea-agent
@@ -4022,7 +4019,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 34d282c5003d66a4a1741b1940b64ac6eb464275eed596ebf3a4242864bbb88a
+        checksum/config: e58a0311b8ecc3d02a5c5f9ab89a6d5e98beb2a7078f5cd36e6007bb860b1018
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -2679,9 +2679,6 @@ data:
     # Enable certificated-based authentication for IPsec.
     #  IPsecCertAuth: false
 
-    # Enable running agent on an unmanaged VM/BM.
-    #  ExternalNode: false
-
     # Name of the OpenVSwitch bridge antrea-agent will create and use.
     # Make sure it doesn't conflict with your existing OpenVSwitch bridges.
     ovsBridge: "br-int"
@@ -3780,7 +3777,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 9b7041970d4bf7d5bbf30003b5061a7f5ec2afed8c23c02d28a59e7a22805423
+        checksum/config: 8287f6d4c3b3def5067c65e1497df876878161a0b519b6d782298aa27356aab3
       labels:
         app: antrea
         component: antrea-agent
@@ -4020,7 +4017,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 9b7041970d4bf7d5bbf30003b5061a7f5ec2afed8c23c02d28a59e7a22805423
+        checksum/config: 8287f6d4c3b3def5067c65e1497df876878161a0b519b6d782298aa27356aab3
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -2692,9 +2692,6 @@ data:
     # Enable certificated-based authentication for IPsec.
     #  IPsecCertAuth: false
 
-    # Enable running agent on an unmanaged VM/BM.
-    #  ExternalNode: false
-
     # Name of the OpenVSwitch bridge antrea-agent will create and use.
     # Make sure it doesn't conflict with your existing OpenVSwitch bridges.
     ovsBridge: "br-int"
@@ -3793,7 +3790,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 94b202753c2ed0a7e187c486ccfbeb094e05ae7ee1f7001afb55e7c45eeeaad3
+        checksum/config: c216eb3adc199d8575af41ff151ae1b566381018527dd31a46d5efbcc4c0bde6
         checksum/ipsec-secret: d0eb9c52d0cd4311b6d252a951126bf9bea27ec05590bed8a394f0f792dcb2a4
       labels:
         app: antrea
@@ -4079,7 +4076,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 94b202753c2ed0a7e187c486ccfbeb094e05ae7ee1f7001afb55e7c45eeeaad3
+        checksum/config: c216eb3adc199d8575af41ff151ae1b566381018527dd31a46d5efbcc4c0bde6
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -2679,9 +2679,6 @@ data:
     # Enable certificated-based authentication for IPsec.
     #  IPsecCertAuth: false
 
-    # Enable running agent on an unmanaged VM/BM.
-    #  ExternalNode: false
-
     # Name of the OpenVSwitch bridge antrea-agent will create and use.
     # Make sure it doesn't conflict with your existing OpenVSwitch bridges.
     ovsBridge: "br-int"
@@ -3780,7 +3777,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 17fb4f0ed9e653e3a470f41f980d2ff89a317686913f62195b6af62869779824
+        checksum/config: 745551965d4087e4a0e9854549a6d96472b6eeb12c269a432ea1ae6c873c028a
       labels:
         app: antrea
         component: antrea-agent
@@ -4020,7 +4017,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 17fb4f0ed9e653e3a470f41f980d2ff89a317686913f62195b6af62869779824
+        checksum/config: 745551965d4087e4a0e9854549a6d96472b6eeb12c269a432ea1ae6c873c028a
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/externalnode/conf/antrea-agent.conf
+++ b/build/yamls/externalnode/conf/antrea-agent.conf
@@ -32,6 +32,22 @@ featureGates:
 # Defaults to "k8sNode". Valid values include "k8sNode", and "externalNode".
 nodeType: externalNode
 
+externalNode:
+  # The expected Namespace in which the ExternalNode is created.
+  # Defaults to "default".
+  #externalNodeNamespace: default
+
+  # The policyBypassRules describes the traffic that is expected to bypass NetworkPolicy rules.
+  # Each rule contains the following four attributes:
+  # direction (ingress|egress), protocol(tcp/udp/icmp/ip), remote CIDR, dst port (ICMP doesn't require).
+  # Here is an example:
+  #  - direction: ingress
+  #    protocol: tcp
+  #    cidr: 1.1.1.1/32
+  #    port: 22
+  # It is used only when NodeType is externalNode.
+  #policyBypassRules: []
+
 # The path to access the kubeconfig file used in the connection to K8s APIServer. The file contains the K8s
 # APIServer endpoint and the token of ServiceAccount required in the connection.
 clientConnection:

--- a/build/yamls/externalnode/vm-agent-rbac.yml
+++ b/build/yamls/externalnode/vm-agent-rbac.yml
@@ -1,0 +1,112 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vm-agent
+  namespace: vm-ns # Change the Namespace to where vm-agent is expected to run.
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vm-agent
+rules:
+  # antrea-controller distributes the CA certificate as a ConfigMap named `antrea-ca` in the Antrea deployment Namespace.
+  # vm-agent needs to access `antrea-ca` to connect with antrea-controller.
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      - antrea-ca
+    verbs:
+      - get
+      - watch
+      - list
+  # This is the content of built-in role kube-system/extension-apiserver-authentication-reader.
+  # But it doesn't have list/watch permission before K8s v1.17.0 so the extension apiserver (vm-agent) will
+  # have permission issue after bumping up apiserver library to a version that supports dynamic authentication.
+  # See https://github.com/kubernetes/kubernetes/pull/85375
+  # To support K8s clusters older than v1.17.0, we grant the required permissions directly instead of relying on
+  # the extension-apiserver-authentication role.
+  - apiGroups:
+      - ""
+    resourceNames:
+      - extension-apiserver-authentication
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - crd.antrea.io
+    resources:
+      - antreaagentinfos
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - controlplane.antrea.io
+    resources:
+      - networkpolicies
+      - appliedtogroups
+      - addressgroups
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - controlplane.antrea.io
+    resources:
+      - nodestatssummaries
+    verbs:
+      - create
+  - apiGroups:
+      - controlplane.antrea.io
+    resources:
+      - networkpolicies/status
+    verbs:
+      - create
+      - get
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vm-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: vm-agent
+subjects:
+  - kind: ServiceAccount
+    name: vm-agent
+    namespace: vm-ns # Change the Namespace to where vm-agent is expected to run.
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vm-agent
+  namespace: vm-ns # Change the Namespace to where vm-agent is expected to run.
+rules:
+  - apiGroups:
+      - crd.antrea.io
+    resources:
+      - externalnodes
+    verbs:
+      - get
+      - watch
+      - list
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vm-agent
+  namespace: vm-ns # Change the Namespace to where vm-agent is expected to run.
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: vm-agent
+subjects:
+  - kind: ServiceAccount
+    name: vm-agent
+    namespace: vm-ns # Change the Namespace to where vm-agent is expected to run.

--- a/pkg/agent/agent_linux.go
+++ b/pkg/agent/agent_linux.go
@@ -53,7 +53,7 @@ func (i *Initializer) prepareOVSBridgeForK8sNode() error {
 	uplinkNetConfig := i.nodeConfig.UplinkNetConfig
 	uplinkNetConfig.Name = adapter.Name
 	uplinkNetConfig.MAC = adapter.HardwareAddr
-	uplinkNetConfig.IP = i.nodeConfig.NodeIPv4Addr
+	uplinkNetConfig.IPs = []*net.IPNet{i.nodeConfig.NodeIPv4Addr}
 	uplinkNetConfig.Index = adapter.Index
 	// Gateway and DNSServers are not configured at adapter in Linux
 	// Limitation: dynamic DNS servers will be lost after DHCP lease expired

--- a/pkg/agent/agent_windows.go
+++ b/pkg/agent/agent_windows.go
@@ -81,7 +81,7 @@ func (i *Initializer) prepareHNSNetworkAndOVSExtension() error {
 	}
 	i.nodeConfig.UplinkNetConfig.Name = adapter.Name
 	i.nodeConfig.UplinkNetConfig.MAC = adapter.HardwareAddr
-	i.nodeConfig.UplinkNetConfig.IP = i.nodeConfig.NodeTransportIPv4Addr
+	i.nodeConfig.UplinkNetConfig.IPs = []*net.IPNet{i.nodeConfig.NodeTransportIPv4Addr}
 	i.nodeConfig.UplinkNetConfig.Index = adapter.Index
 	defaultGW, err := util.GetDefaultGatewayByInterfaceIndex(adapter.Index)
 	if err != nil {

--- a/pkg/agent/config/node_config.go
+++ b/pkg/agent/config/node_config.go
@@ -103,7 +103,8 @@ type AdapterNetConfig struct {
 	Name       string
 	Index      int
 	MAC        net.HardwareAddr
-	IP         *net.IPNet
+	IPs        []*net.IPNet
+	MTU        int
 	Gateway    string
 	DNSServers string
 	Routes     []interface{}

--- a/pkg/agent/controller/networkpolicy/cache_test.go
+++ b/pkg/agent/controller/networkpolicy/cache_test.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	"antrea.io/antrea/pkg/agent/config"
 	"antrea.io/antrea/pkg/agent/types"
 	"antrea.io/antrea/pkg/apis/controlplane/v1beta2"
 	"antrea.io/antrea/pkg/util/channel"
@@ -278,7 +279,7 @@ func newFakeRuleCache() (*ruleCache, *dirtyRuleRecorder, *channel.SubscribableCh
 	recorder := newDirtyRuleRecorder()
 	podUpdateChannel := channel.NewSubscribableChannel("PodUpdate", 100)
 	ch2 := make(chan string, 100)
-	c := newRuleCache(recorder.Record, podUpdateChannel, ch2)
+	c := newRuleCache(recorder.Record, podUpdateChannel, nil, ch2, config.K8sNode)
 	return c, recorder, podUpdateChannel
 }
 

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
@@ -61,7 +61,7 @@ func newTestController() (*Controller, *fake.Clientset, *mockReconciler) {
 	ch2 := make(chan string, 100)
 	groupIDAllocator := openflow.NewGroupAllocator(false)
 	groupCounters := []proxytypes.GroupCounter{proxytypes.NewGroupCounter(groupIDAllocator, ch2)}
-	controller, _ := NewNetworkPolicyController(&antreaClientGetter{clientset}, nil, nil, "node1", podUpdateChannel, groupCounters, ch2, true, true, true, false, true, testAsyncDeleteInterval, "8.8.8.8:53", true, false, config.HostGatewayOFPort, config.DefaultTunOFPort)
+	controller, _ := NewNetworkPolicyController(&antreaClientGetter{clientset}, nil, nil, "node1", podUpdateChannel, nil, groupCounters, ch2, true, true, true, false, true, testAsyncDeleteInterval, "8.8.8.8:53", config.K8sNode, true, false, config.HostGatewayOFPort, config.DefaultTunOFPort)
 	reconciler := newMockReconciler()
 	controller.reconciler = reconciler
 	controller.antreaPolicyLogger = nil

--- a/pkg/agent/controller/networkpolicy/status_controller_test.go
+++ b/pkg/agent/controller/networkpolicy/status_controller_test.go
@@ -24,6 +24,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
+	"antrea.io/antrea/pkg/agent/config"
 	"antrea.io/antrea/pkg/apis/controlplane/v1beta2"
 	"antrea.io/antrea/pkg/util/channel"
 )
@@ -51,7 +52,7 @@ func (c *fakeNetworkPolicyControl) getNetworkPolicyStatus() *v1beta2.NetworkPoli
 }
 
 func newTestStatusController() (*StatusController, *ruleCache, *fakeNetworkPolicyControl) {
-	ruleCache := newRuleCache(func(s string) {}, channel.NewSubscribableChannel("PodUpdate", 100), make(chan string, 100))
+	ruleCache := newRuleCache(func(s string) {}, channel.NewSubscribableChannel("PodUpdate", 100), nil, make(chan string, 100), config.K8sNode)
 	statusControl := &fakeNetworkPolicyControl{}
 	statusController := newStatusController(nil, testNode1, ruleCache)
 	statusController.statusControlInterface = statusControl

--- a/pkg/agent/externalnode/external_node_controller.go
+++ b/pkg/agent/externalnode/external_node_controller.go
@@ -1,0 +1,682 @@
+// Copyright 2022 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package externalnode
+
+import (
+	"fmt"
+	"net"
+	"reflect"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+
+	"antrea.io/antrea/pkg/agent/config"
+	"antrea.io/antrea/pkg/agent/interfacestore"
+	"antrea.io/antrea/pkg/agent/openflow"
+	"antrea.io/antrea/pkg/agent/util"
+	"antrea.io/antrea/pkg/apis/controlplane/v1beta2"
+	"antrea.io/antrea/pkg/apis/crd/v1alpha1"
+	enlister "antrea.io/antrea/pkg/client/listers/crd/v1alpha1"
+	agentConfig "antrea.io/antrea/pkg/config/agent"
+	binding "antrea.io/antrea/pkg/ovs/openflow"
+	"antrea.io/antrea/pkg/ovs/ovsconfig"
+	"antrea.io/antrea/pkg/ovs/ovsctl"
+	"antrea.io/antrea/pkg/util/channel"
+	"antrea.io/antrea/pkg/util/env"
+	"antrea.io/antrea/pkg/util/externalnode"
+	"antrea.io/antrea/pkg/util/ip"
+	"antrea.io/antrea/pkg/util/k8s"
+)
+
+const (
+	controllerName = "ExternalNodeController"
+	// How long to wait before retrying the processing of an ExternalNode change.
+	minRetryDelay = 5 * time.Second
+	maxRetryDelay = 300 * time.Second
+	// Disable resyncing.
+	resyncPeriod time.Duration = 0
+
+	ovsExternalIDUplinkName      = "uplink-name"
+	ovsExternalIDUplinkPort      = "uplink-port"
+	ovsExternalIDEntityName      = "entity-name"
+	ovsExternalIDEntityNamespace = "entity-namespace"
+	ovsExternalIDIPs             = "ip-address"
+	ipsSplitter                  = ","
+)
+
+var (
+	keyFunc      = cache.MetaNamespaceKeyFunc
+	splitKeyFunc = cache.SplitMetaNamespaceKey
+)
+
+type ExternalNodeController struct {
+	ovsBridgeClient          ovsconfig.OVSBridgeClient
+	ovsctlClient             ovsctl.OVSCtlClient
+	ofClient                 openflow.Client
+	externalNodeInformer     cache.SharedIndexInformer
+	externalNodeLister       enlister.ExternalNodeLister
+	externalNodeListerSynced cache.InformerSynced
+	queue                    workqueue.RateLimitingInterface
+	ifaceStore               interfacestore.InterfaceStore
+	syncedExternalNode       *v1alpha1.ExternalNode
+	// externalEntityUpdateNotifier is used for notifying ExternalEntity updates to NetworkPolicyController.
+	externalEntityUpdateNotifier channel.Notifier
+	nodeName                     string
+	externalNodeNamespace        string
+	policyBypassRules            []agentConfig.PolicyBypassRule
+}
+
+func NewExternalNodeController(ovsBridgeClient ovsconfig.OVSBridgeClient, ofClient openflow.Client, externalNodeInformer cache.SharedIndexInformer,
+	ifaceStore interfacestore.InterfaceStore, externalEntityUpdateNotifier channel.Notifier, externalNodeNamespace string, policyBypassRules []agentConfig.PolicyBypassRule) (*ExternalNodeController, error) {
+	c := &ExternalNodeController{
+		ovsBridgeClient:              ovsBridgeClient,
+		ovsctlClient:                 ovsctl.NewClient(ovsBridgeClient.GetBridgeName()),
+		ofClient:                     ofClient,
+		externalNodeInformer:         externalNodeInformer,
+		externalNodeLister:           enlister.NewExternalNodeLister(externalNodeInformer.GetIndexer()),
+		externalNodeListerSynced:     externalNodeInformer.HasSynced,
+		queue:                        workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(minRetryDelay, maxRetryDelay), "externalNode"),
+		ifaceStore:                   ifaceStore,
+		externalEntityUpdateNotifier: externalEntityUpdateNotifier,
+		policyBypassRules:            policyBypassRules,
+	}
+	nodeName, err := env.GetNodeName()
+	if err != nil {
+		return nil, err
+	}
+	c.nodeName = nodeName
+	c.externalNodeNamespace = externalNodeNamespace
+	c.externalNodeInformer.AddEventHandlerWithResyncPeriod(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc:    c.enqueueExternalNodeAdd,
+			UpdateFunc: c.enqueueExternalNodeUpdate,
+			DeleteFunc: c.enqueueExternalNodeDelete,
+		},
+		resyncPeriod)
+
+	return c, nil
+}
+
+// Run will create a worker (goroutine) which will process the ExternalNode events from the work queue.
+func (c *ExternalNodeController) Run(stopCh <-chan struct{}) {
+	defer c.queue.ShutDown()
+
+	klog.InfoS("Starting controller", "name", controllerName)
+	defer klog.InfoS("Shutting down controller", "name", controllerName)
+
+	if err := wait.PollImmediateUntil(5*time.Second, func() (done bool, err error) {
+		if err = c.reconcile(); err != nil {
+			klog.ErrorS(err, "ExternalNodeController failed during reconciliation")
+			return false, nil
+		}
+		return true, nil
+	}, stopCh); err != nil {
+		klog.Info("Stopped ExternalNodeController reconciliation")
+		return
+	}
+	if !cache.WaitForNamedCacheSync(controllerName, stopCh, c.externalNodeListerSynced) {
+		klog.Error("Failed to wait for syncing ExternalNodes cache")
+		return
+	}
+
+	c.queue.Add(k8s.NamespacedName(c.externalNodeNamespace, c.nodeName))
+	go wait.Until(c.worker, time.Second, stopCh)
+
+	<-stopCh
+}
+
+func (c *ExternalNodeController) enqueueExternalNodeAdd(obj interface{}) {
+	en := obj.(*v1alpha1.ExternalNode)
+	key, _ := keyFunc(en)
+	c.queue.Add(key)
+	klog.InfoS("Enqueued ExternalNode ADD event", "ExternalNode", klog.KObj(en))
+}
+
+func (c *ExternalNodeController) enqueueExternalNodeUpdate(oldObj interface{}, newObj interface{}) {
+	oldEN := oldObj.(*v1alpha1.ExternalNode)
+	newEN := newObj.(*v1alpha1.ExternalNode)
+	if reflect.DeepEqual(oldEN.Spec.Interfaces, newEN.Spec.Interfaces) {
+		klog.InfoS("Skip enqueuing ExternalNode UPDATE event as no changes for interfaces", "ExternalNode", klog.KObj(newEN))
+		return
+	}
+	key, _ := keyFunc(newEN)
+	c.queue.Add(key)
+	klog.InfoS("Enqueued ExternalNode UPDATE event", "ExternalNode", klog.KObj(newEN))
+}
+
+func (c *ExternalNodeController) enqueueExternalNodeDelete(obj interface{}) {
+	en := obj.(*v1alpha1.ExternalNode)
+	key, _ := keyFunc(en)
+	c.queue.Add(key)
+	klog.InfoS("Enqueued ExternalNode DELETE event", "ExternalNode", klog.KObj(en))
+}
+
+func (c *ExternalNodeController) reconcile() error {
+	klog.InfoS("Reconciling for controller", "name", controllerName)
+	if err := c.reconcileHostUplinkFlows(); err != nil {
+		return fmt.Errorf("failed to reconcile host uplink flows %v", err)
+	}
+	if err := c.reconcilePolicyBypassFlows(); err != nil {
+		return fmt.Errorf("failed to reconcile reserved flows %v", err)
+	}
+	klog.InfoS("Reconciled for controller", "name", controllerName)
+	return nil
+}
+
+func (c *ExternalNodeController) reconcileHostUplinkFlows() error {
+	hostIfaces := c.ifaceStore.GetInterfacesByType(interfacestore.ExternalEntityInterface)
+	for _, hostIface := range hostIfaces {
+		if err := c.ofClient.InstallVMUplinkFlows(hostIface.InterfaceName, hostIface.OVSPortConfig.OFPort, hostIface.UplinkPort.OFPort); err != nil {
+			return err
+		}
+		klog.InfoS("Reconciled host uplink flow for ExternalEntityInterface", "ifName", hostIface.InterfaceName)
+	}
+	return nil
+}
+
+func (c *ExternalNodeController) reconcilePolicyBypassFlows() error {
+	for _, rule := range c.policyBypassRules {
+		klog.V(2).InfoS("Installing policy bypass flows", "protocol", rule.Protocol, "CIDR", rule.CIDR, "port", rule.Port, "direction", rule.Direction)
+		protocol := parseProtocol(rule.Protocol)
+		_, ipNet, _ := net.ParseCIDR(rule.CIDR)
+		if err := c.ofClient.InstallPolicyBypassFlows(protocol, ipNet, uint16(rule.Port), rule.Direction == "ingress"); err != nil {
+			return err
+		}
+	}
+	klog.InfoS("Installed policy bypass flows", "RuleCount", len(c.policyBypassRules))
+	return nil
+}
+
+// worker is a long-running function that will continuously call the processNextWorkItem function in
+// order to read and process a message on the work queue.
+func (c *ExternalNodeController) worker() {
+	for c.processNextWorkItem() {
+	}
+}
+
+func (c *ExternalNodeController) processNextWorkItem() bool {
+	obj, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(obj)
+
+	if key, ok := obj.(string); !ok {
+		c.queue.Forget(obj)
+		klog.Errorf("Expected string type in work queue but got %#v", obj)
+		return true
+	} else if err := c.syncExternalNode(key); err == nil {
+		// If no error occurs, then forget this item so it does not get queued again until
+		// another change happens.
+		c.queue.Forget(key)
+	} else {
+		// Put the item back on the work queue to handle any transient errors.
+		c.queue.AddRateLimited(key)
+		klog.ErrorS(err, "Error syncing ExternalNode", "ExternalNode", key)
+	}
+	return true
+}
+
+func (c *ExternalNodeController) syncExternalNode(key string) error {
+	_, name, err := splitKeyFunc(key)
+	if err != nil {
+		// This err should not occur.
+		return err
+	}
+	en, err := c.externalNodeLister.ExternalNodes(c.externalNodeNamespace).Get(name)
+	if errors.IsNotFound(err) {
+		return c.deleteExternalNode()
+	}
+
+	if c.syncedExternalNode == nil {
+		return c.addExternalNode(en)
+	} else {
+		return c.updateExternalNode(c.syncedExternalNode, en)
+	}
+}
+
+func (c *ExternalNodeController) addExternalNode(en *v1alpha1.ExternalNode) error {
+	klog.InfoS("Adding ExternalNode", "ExternalNode", klog.KObj(en))
+	eeName, err := externalnode.GenExternalEntityName(en)
+	if err != nil {
+		return err
+	}
+	ifName, ips, err := getHostInterfaceName(en.Spec.Interfaces[0])
+	if err != nil {
+		return err
+	}
+	if err := c.addInterface(ifName, en.Namespace, eeName, ips); err != nil {
+		return err
+	}
+	c.syncedExternalNode = en
+	// Notify the ExternalEntity event to NetworkPolicyController.
+	c.externalEntityUpdateNotifier.Notify(v1beta2.ExternalEntityReference{
+		Name:      eeName,
+		Namespace: en.Namespace,
+	})
+	return nil
+}
+
+func (c *ExternalNodeController) addInterface(ifName string, eeNamespace string, eeName string, ips []string) error {
+	hostIface, ifaceExists := c.ifaceStore.GetInterfaceByName(ifName)
+	if !ifaceExists {
+		klog.InfoS("Creating OVS ports and flows for ExternalEntityInterface", "ifName", ifName, "externalEntity", eeName, "ips", ips)
+		uplinkName := util.GenerateUplinkInterfaceName(ifName)
+		iface, err := c.createOVSPortsAndFlows(uplinkName, ifName, eeNamespace, eeName, ips)
+		if err != nil {
+			return err
+		}
+		c.ifaceStore.AddInterface(iface)
+		return nil
+	}
+	klog.InfoS("Updating OVS port data", "ifName", ifName, "externalEntity", eeName, "ips", ips)
+	portUUID := hostIface.PortUUID
+	portName := hostIface.InterfaceName
+	portData, ovsErr := c.ovsBridgeClient.GetPortData(portUUID, portName)
+	if ovsErr != nil {
+		return ovsErr
+	}
+	preEEName := portData.ExternalIDs[ovsExternalIDEntityName]
+	preIPs := sets.NewString(strings.Split(portData.ExternalIDs[ovsExternalIDIPs], ipsSplitter)...)
+	if preEEName == eeName && sets.NewString(ips...).Equal(preIPs) {
+		klog.InfoS("Skipping updating OVS port data as both entity name and ip are not changed", "ifName", ifName)
+		return nil
+	}
+
+	iface, err := c.updateOVSPortsData(hostIface, portData, eeName, ips)
+	if err != nil {
+		return err
+	}
+	c.ifaceStore.AddInterface(iface)
+	return nil
+}
+
+func (c *ExternalNodeController) updateExternalNode(preEN *v1alpha1.ExternalNode, curEN *v1alpha1.ExternalNode) error {
+	klog.InfoS("Updating ExternalNode", "ExternalNode", klog.KObj(curEN))
+	if reflect.DeepEqual(preEN.Spec.Interfaces[0], curEN.Spec.Interfaces[0]) {
+		klog.InfoS("Skip processing ExternalNode update as no changes for Interface[0]", "ExternalNode", klog.KObj(curEN))
+		return nil
+	}
+	preEEName, err := externalnode.GenExternalEntityName(preEN)
+	if err != nil {
+		return err
+	}
+	preIfName, preIPs, err := getHostInterfaceName(preEN.Spec.Interfaces[0])
+	if err != nil {
+		return err
+	}
+	curEEName, err := externalnode.GenExternalEntityName(curEN)
+	if err != nil {
+		return err
+	}
+	curIfName, curIPs, err := getHostInterfaceName(curEN.Spec.Interfaces[0])
+	if err != nil {
+		return err
+	}
+	if preIfName != curIfName {
+		klog.InfoS("Found interface name is changed", "preName", preIfName, "curName", curIfName)
+		if err = c.addInterface(curIfName, curEN.Namespace, curEEName, curIPs); err != nil {
+			return err
+		}
+		ifaceConfig, ifaceExists := c.ifaceStore.GetInterfaceByName(preIfName)
+		if ifaceExists {
+			if err = c.deleteInterface(ifaceConfig); err != nil {
+				return err
+			}
+		}
+	} else if !reflect.DeepEqual(preIPs, curIPs) || preEEName != curEEName {
+		klog.InfoS("Found interface configuration is changed", "preIPs", preIPs, "preExternalEntity", preEEName,
+			"curIPs", curIPs, "curExternalEntity", curEEName)
+		if err = c.addInterface(curIfName, curEN.Namespace, curEEName, curIPs); err != nil {
+			return err
+		}
+	}
+	c.syncedExternalNode = curEN
+	// Notify the ExternalEntity event to NetworkPolicyController.
+	c.externalEntityUpdateNotifier.Notify(v1beta2.ExternalEntityReference{
+		Name:      curEEName,
+		Namespace: curEN.Namespace,
+	})
+	return nil
+}
+
+func (c *ExternalNodeController) deleteExternalNode() error {
+	if err := c.deleteInterfaces(); err != nil {
+		return err
+	}
+	c.syncedExternalNode = nil
+	return nil
+}
+
+func (c *ExternalNodeController) deleteInterfaces() error {
+	hostIfaces := c.ifaceStore.GetInterfacesByType(interfacestore.ExternalEntityInterface)
+	for _, hostIface := range hostIfaces {
+		if err := c.deleteInterface(hostIface); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *ExternalNodeController) deleteInterface(interfaceConfig *interfacestore.InterfaceConfig) error {
+	klog.InfoS("Deleting interface", "ifName", interfaceConfig.InterfaceName)
+	if err := c.removeOVSPortsAndFlows(interfaceConfig); err != nil {
+		return err
+	}
+	c.ifaceStore.DeleteInterface(interfaceConfig)
+	return nil
+}
+
+func (c *ExternalNodeController) createOVSPortsAndFlows(uplinkName, hostIFName, eeNamespace, eeName string, ips []string) (*interfacestore.InterfaceConfig, error) {
+	iface, addrs, routes, err := util.GetInterfaceConfig(hostIFName)
+	if err != nil {
+		return nil, err
+	}
+	adapterConfig := &config.AdapterNetConfig{
+		Name:   hostIFName,
+		Index:  iface.Index,
+		MAC:    iface.HardwareAddr,
+		IPs:    addrs,
+		Routes: routes,
+		MTU:    iface.MTU,
+	}
+	if err = util.RenameInterface(hostIFName, uplinkName); err != nil {
+		return nil, err
+	}
+	success := false
+	defer func() {
+		if !success {
+			if err = util.RenameInterface(uplinkName, hostIFName); err != nil {
+				klog.ErrorS(err, "Failed to restore uplink name back to host interface name. Manual cleanup is required", "uplinkName", uplinkName, "hostIFName", hostIFName)
+			}
+		}
+	}()
+
+	// Create uplink port in OVS.
+	uplinkExternalIDs := map[string]interface{}{
+		interfacestore.AntreaInterfaceTypeKey: interfacestore.AntreaUplink,
+	}
+	uplinkUUID, ovsErr := c.ovsBridgeClient.CreatePort(uplinkName, uplinkName, uplinkExternalIDs)
+	if ovsErr != nil {
+		return nil, fmt.Errorf("failed to create uplink port %s in OVS, err %v", uplinkName, ovsErr)
+	}
+	defer func() {
+		if !success {
+			if ovsErr = c.ovsBridgeClient.DeletePort(uplinkUUID); ovsErr != nil {
+				klog.ErrorS(err, "Failed to delete uplink port. Manual cleanup is required", "portUUID", uplinkUUID, "uplinkName", uplinkName)
+			}
+		}
+	}()
+	uplinkOFPort, ovsErr := c.ovsBridgeClient.GetOFPort(uplinkName, false)
+	if ovsErr != nil {
+		return nil, ovsErr
+	}
+	klog.InfoS("Added uplink port in OVS", "port", uplinkOFPort, "uplinkName", uplinkName)
+
+	// Create host port in OVS.
+	attachInfo := GetOVSAttachInfo(uplinkName, uplinkUUID, eeName, eeNamespace, ips)
+	hostIfUUID, ovsErr := c.ovsBridgeClient.CreateInternalPort(hostIFName, 0, adapterConfig.MAC.String(), attachInfo)
+	if ovsErr != nil {
+		return nil, fmt.Errorf("failed to create OVS internal port for host interface %s, err %v", hostIFName, ovsErr)
+	}
+	defer func() {
+		if !success {
+			if ovsErr = c.ovsBridgeClient.DeletePort(hostIfUUID); ovsErr != nil {
+				klog.ErrorS(err, "Failed to delete host interface port. Manual cleanup is required", "portUUID", hostIfUUID, "hostIFName", hostIFName)
+			}
+		}
+	}()
+	hostOFPort, ovsErr := c.ovsBridgeClient.GetOFPort(hostIFName, false)
+	if ovsErr != nil {
+		return nil, ovsErr
+	}
+	klog.InfoS("Created an OVS internal port for host interface", "ofPort", hostOFPort, "interfaceName", hostIFName)
+	// Move configurations from the uplink to host port
+	if err = c.moveIFConfigurations(adapterConfig, uplinkName, hostIFName); err != nil {
+		return nil, err
+	}
+	klog.InfoS("Moved configurations to the host interface", "hostInterface", hostIFName)
+	if err = c.ofClient.InstallVMUplinkFlows(hostIFName, hostOFPort, uplinkOFPort); err != nil {
+		return nil, err
+	}
+	klog.InfoS("Added uplink and host port in OVS and installed openflow entries", "uplink", uplinkName, "hostInterface", hostIFName)
+	success = true
+	ifIPs := make([]net.IP, 0)
+	for _, ip := range ips {
+		ifIPs = append(ifIPs, net.ParseIP(ip))
+	}
+	hostIFConfig := &interfacestore.InterfaceConfig{
+		Type:          interfacestore.ExternalEntityInterface,
+		InterfaceName: hostIFName,
+		IPs:           ifIPs,
+		OVSPortConfig: &interfacestore.OVSPortConfig{
+			PortUUID: hostIfUUID,
+			OFPort:   hostOFPort,
+		},
+		EntityInterfaceConfig: &interfacestore.EntityInterfaceConfig{
+			EntityName:      eeName,
+			EntityNamespace: eeNamespace,
+			UplinkPort: &interfacestore.OVSPortConfig{
+				PortUUID: uplinkUUID,
+				OFPort:   uplinkOFPort,
+			},
+		},
+	}
+	return hostIFConfig, nil
+}
+
+func GetOVSAttachInfo(uplinkName, uplinkUUID, entityName, entityNamespace string, ips []string) map[string]interface{} {
+	attachInfo := map[string]interface{}{
+		interfacestore.AntreaInterfaceTypeKey: interfacestore.AntreaHost,
+	}
+	if uplinkName != "" {
+		attachInfo[ovsExternalIDUplinkName] = uplinkName
+	}
+	if uplinkUUID != "" {
+		attachInfo[ovsExternalIDUplinkPort] = uplinkUUID
+	}
+	if entityName != "" {
+		attachInfo[ovsExternalIDEntityName] = entityName
+	}
+	if entityNamespace != "" {
+		attachInfo[ovsExternalIDEntityNamespace] = entityNamespace
+	}
+	if len(ips) != 0 {
+		attachInfo[ovsExternalIDIPs] = strings.Join(ips, ipsSplitter)
+	}
+
+	return attachInfo
+}
+
+func (c *ExternalNodeController) updateOVSPortsData(interfaceConfig *interfacestore.InterfaceConfig, portData *ovsconfig.OVSPortData, eeName string, ips []string) (*interfacestore.InterfaceConfig, error) {
+	attachInfo := map[string]interface{}{
+		ovsExternalIDUplinkName:               portData.ExternalIDs[ovsExternalIDUplinkName],
+		ovsExternalIDUplinkPort:               portData.ExternalIDs[ovsExternalIDUplinkPort],
+		ovsExternalIDEntityName:               eeName,
+		ovsExternalIDEntityNamespace:          portData.ExternalIDs[ovsExternalIDEntityNamespace],
+		ovsExternalIDIPs:                      strings.Join(ips, ipsSplitter),
+		interfacestore.AntreaInterfaceTypeKey: interfacestore.AntreaHost,
+	}
+	err := c.ovsBridgeClient.SetPortExternalIDs(interfaceConfig.InterfaceName, attachInfo)
+	if err != nil {
+		return nil, err
+	}
+	ifIPs := make([]net.IP, 0)
+	for _, ip := range ips {
+		ifIPs = append(ifIPs, net.ParseIP(ip))
+	}
+	iface := &interfacestore.InterfaceConfig{
+		InterfaceName: interfaceConfig.InterfaceName,
+		Type:          interfacestore.ExternalEntityInterface,
+		OVSPortConfig: &interfacestore.OVSPortConfig{
+			PortUUID: interfaceConfig.PortUUID,
+			OFPort:   interfaceConfig.OFPort,
+		},
+		EntityInterfaceConfig: &interfacestore.EntityInterfaceConfig{
+			EntityName:      eeName,
+			EntityNamespace: interfaceConfig.EntityNamespace,
+			UplinkPort: &interfacestore.OVSPortConfig{
+				PortUUID: interfaceConfig.UplinkPort.PortUUID,
+				OFPort:   interfaceConfig.UplinkPort.OFPort,
+			},
+		},
+		IPs: ifIPs,
+	}
+	return iface, nil
+}
+
+func (c *ExternalNodeController) removeOVSPortsAndFlows(interfaceConfig *interfacestore.InterfaceConfig) error {
+	portUUID := interfaceConfig.PortUUID
+	portName := interfaceConfig.InterfaceName
+	if err := c.ofClient.UninstallVMUplinkFlows(portName); err != nil {
+		return fmt.Errorf("failed to uninstall uplink and host port openflow entries, portName %s, err %v", portName, err)
+	}
+	klog.InfoS("Removed the flows installed to forward packet between uplinkPort and hostPort", "hostInterface", portName)
+	hostIFName := interfaceConfig.InterfaceName
+	uplinkIfName := util.GenerateUplinkInterfaceName(portName)
+	uplinkPortID := interfaceConfig.UplinkPort.PortUUID
+	iface, addrs, routes, err := util.GetInterfaceConfig(hostIFName)
+	if err != nil {
+		return err
+	}
+	adapterConfig := &config.AdapterNetConfig{
+		Name:   hostIFName,
+		Index:  iface.Index,
+		MAC:    iface.HardwareAddr,
+		IPs:    addrs,
+		Routes: routes,
+		MTU:    iface.MTU,
+	}
+	if ovsErr := c.ovsBridgeClient.DeletePort(portUUID); ovsErr != nil {
+		return fmt.Errorf("failed to delete host port %s, err %v", hostIFName, ovsErr)
+	}
+	klog.InfoS("Deleted host port in OVS", "hostInterface", hostIFName)
+	if ovsErr := c.ovsBridgeClient.DeletePort(uplinkPortID); ovsErr != nil {
+		return fmt.Errorf("failed to delete uplink port %s, err %v", uplinkIfName, ovsErr)
+	}
+	klog.InfoS("Deleted uplink port in OVS", "uplinkIfName", uplinkIfName)
+	defer func() {
+		// Delete host interface from OVS datapath if it exists.
+		// This is to resolve an issue that OVS fails to remove the interface from datapath. It might happen because the interface
+		// is busy when OVS tries to remove it with the OVSDB interface deletion event.
+		if err := c.ovsctlClient.DeleteDPInterface(hostIFName); err != nil {
+			klog.ErrorS(err, "Failed to delete host interface from OVS datapath", "interface", hostIFName)
+		}
+	}()
+
+	// Wait until the host interface created by OVS is removed.
+	if err = wait.PollImmediate(50*time.Millisecond, 2*time.Second, func() (bool, error) {
+		return !util.HostInterfaceExists(hostIFName), nil
+	}); err != nil {
+		return fmt.Errorf("failed to wait for host interface %s deletion in 2s, err %v", hostIFName, err)
+	}
+	// Recover the uplink interface's name.
+	if err = util.RenameInterface(uplinkIfName, hostIFName); err != nil {
+		return err
+	}
+	klog.InfoS("Recovered uplink name to the host interface name", "uplinkIfName", uplinkIfName, "hostInterface", hostIFName)
+	// Move the IP configurations back to the host interface.
+	if err = c.moveIFConfigurations(adapterConfig, "", hostIFName); err != nil {
+		return err
+	}
+	klog.InfoS("Moved back configuration to the host interface", "hostInterface", hostIFName)
+	return nil
+}
+
+func getHostInterfaceName(iface v1alpha1.NetworkInterface) (string, []string, error) {
+	ifName := ""
+	ips := sets.NewString()
+	for _, ipStr := range iface.IPs {
+		var ipFilter *ip.DualStackIPs
+		ifIP := net.ParseIP(ipStr)
+		if ifIP.To4() != nil {
+			ipFilter = &ip.DualStackIPs{IPv4: ifIP}
+		} else {
+			ipFilter = &ip.DualStackIPs{IPv6: ifIP}
+		}
+		_, _, link, err := util.GetIPNetDeviceFromIP(ipFilter, sets.NewString())
+		if err == nil {
+			klog.InfoS("Using the interface", "linkName", link.Name, "IP", ipStr)
+			ips.Insert(ipStr)
+			if ifName == "" {
+				ifName = link.Name
+			} else if ifName != link.Name {
+				return "", ips.List(), fmt.Errorf("find different interfaces by IPs, ifName %s, linkName %s", ifName, link.Name)
+			}
+		} else {
+			klog.ErrorS(err, "Failed to get device from IP", "ip", ifIP)
+		}
+	}
+	if ifName == "" {
+		return "", ips.List(), fmt.Errorf("cannot find interface via IPs %v", iface.IPs)
+	}
+	return ifName, ips.List(), nil
+
+}
+
+func ParseHostInterfaceConfig(ovsBridgeClient ovsconfig.OVSBridgeClient, portData *ovsconfig.OVSPortData, portConfig *interfacestore.OVSPortConfig) (*interfacestore.InterfaceConfig, error) {
+	var interfaceConfig *interfacestore.InterfaceConfig
+	interfaceConfig = &interfacestore.InterfaceConfig{
+		InterfaceName: portData.Name,
+		Type:          interfacestore.ExternalEntityInterface,
+		OVSPortConfig: portConfig,
+	}
+	var hostUplinkConfig *interfacestore.EntityInterfaceConfig
+	entityIPArr := strings.Split(portData.ExternalIDs[ovsExternalIDIPs], ipsSplitter)
+	var entityIPs []net.IP
+	for _, ipStr := range entityIPArr {
+		entityIPs = append(entityIPs, net.ParseIP(ipStr))
+	}
+	interfaceConfig.IPs = entityIPs
+	uplinkName, _ := portData.ExternalIDs[ovsExternalIDUplinkName]
+	uplinkPortUUID, _ := portData.ExternalIDs[ovsExternalIDUplinkPort]
+	uplinkPortData, ovsErr := ovsBridgeClient.GetPortData(uplinkPortUUID, uplinkName)
+	if ovsErr != nil {
+		return nil, ovsErr
+	}
+	entityName, _ := portData.ExternalIDs[ovsExternalIDEntityName]
+	entityNamespace, _ := portData.ExternalIDs[ovsExternalIDEntityNamespace]
+	hostUplinkConfig = &interfacestore.EntityInterfaceConfig{
+		EntityName:      entityName,
+		EntityNamespace: entityNamespace,
+		UplinkPort: &interfacestore.OVSPortConfig{
+			PortUUID: uplinkPortUUID,
+			OFPort:   uplinkPortData.OFPort,
+		},
+	}
+	interfaceConfig.EntityInterfaceConfig = hostUplinkConfig
+	return interfaceConfig, nil
+}
+
+func parseProtocol(protocol string) binding.Protocol {
+	var proto binding.Protocol
+	switch protocol {
+	case "tcp":
+		proto = binding.ProtocolTCP
+	case "udp":
+		proto = binding.ProtocolUDP
+	case "icmp":
+		proto = binding.ProtocolICMP
+	case "ip":
+		proto = binding.ProtocolIP
+	}
+	return proto
+}

--- a/pkg/agent/externalnode/external_node_controller_linux.go
+++ b/pkg/agent/externalnode/external_node_controller_linux.go
@@ -1,0 +1,59 @@
+// Copyright 2022 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package externalnode
+
+import (
+	"fmt"
+
+	"github.com/vishvananda/netlink"
+
+	"antrea.io/antrea/pkg/agent/config"
+	"antrea.io/antrea/pkg/agent/util"
+)
+
+func (c *ExternalNodeController) moveIFConfigurations(adapterConfig *config.AdapterNetConfig, src string, dst string) error {
+	dstLink, err := netlink.LinkByName(dst)
+	if err != nil {
+		return fmt.Errorf("failed to find link for destination %s, err %v", dst, err)
+	}
+	if src != "" {
+		srcLink, err := netlink.LinkByName(src)
+		if err != nil {
+			return fmt.Errorf("failed to find link for source %s, err %v", src, err)
+		}
+		if err := netlink.LinkSetMTU(dstLink, adapterConfig.MTU); err != nil {
+			return err
+		}
+		if err := netlink.LinkSetUp(dstLink); err != nil {
+			return err
+		}
+		if err := util.RemoveLinkIPs(srcLink); err != nil {
+			return err
+		}
+		if err := util.RemoveLinkRoutes(srcLink); err != nil {
+			return err
+		}
+	}
+	dstIndex := dstLink.Attrs().Index
+	// Configure the source interface's IPs on the destination interface.
+	if err := util.ConfigureLinkAddresses(dstIndex, adapterConfig.IPs); err != nil {
+		return err
+	}
+	// Configure the source interface's routes on the destination interface.
+	if err := util.ConfigureLinkRoutes(dstLink, adapterConfig.Routes); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/agent/externalnode/external_node_controller_windows.go
+++ b/pkg/agent/externalnode/external_node_controller_windows.go
@@ -1,0 +1,21 @@
+// Copyright 2022 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package externalnode
+
+import "antrea.io/antrea/pkg/agent/config"
+
+func (c *ExternalNodeController) moveIFConfigurations(adapterConfig *config.AdapterNetConfig, src string, dst string) error {
+	return nil
+}

--- a/pkg/agent/interfacestore/types.go
+++ b/pkg/agent/interfacestore/types.go
@@ -89,8 +89,6 @@ type EntityInterfaceConfig struct {
 	EntityNamespace string
 	// UplinkPort is the OVS port configuration for the uplink, which is a pair port of this interface on OVS.
 	UplinkPort *OVSPortConfig
-	// HostIfaceIndex is the index of the host interface created by this OVS internal port.
-	HostIfaceIndex int
 }
 
 type InterfaceConfig struct {

--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -337,7 +337,7 @@ type Client interface {
 	// InstallPolicyBypassFlows installs flows to bypass the NetworkPolicy rules on the traffic with the given ipnet
 	// or ip, port, protocol and direction. It is used to bypass NetworkPolicy enforcement on a VM for the particular
 	// traffic.
-	InstallPolicyBypassFlows(protocol binding.Protocol, ipnet *net.IPNet, ip net.IP, port uint16, isIngress bool) error
+	InstallPolicyBypassFlows(protocol binding.Protocol, ipNet *net.IPNet, port uint16, isIngress bool) error
 }
 
 // GetFlowTableStatus returns an array of flow table status.

--- a/pkg/agent/openflow/testing/mock_openflow.go
+++ b/pkg/agent/openflow/testing/mock_openflow.go
@@ -409,17 +409,17 @@ func (mr *MockClientMockRecorder) InstallPodSNATFlows(arg0, arg1, arg2 interface
 }
 
 // InstallPolicyBypassFlows mocks base method
-func (m *MockClient) InstallPolicyBypassFlows(arg0 openflow.Protocol, arg1 *net.IPNet, arg2 net.IP, arg3 uint16, arg4 bool) error {
+func (m *MockClient) InstallPolicyBypassFlows(arg0 openflow.Protocol, arg1 *net.IPNet, arg2 uint16, arg3 bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstallPolicyBypassFlows", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "InstallPolicyBypassFlows", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InstallPolicyBypassFlows indicates an expected call of InstallPolicyBypassFlows
-func (mr *MockClientMockRecorder) InstallPolicyBypassFlows(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) InstallPolicyBypassFlows(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallPolicyBypassFlows", reflect.TypeOf((*MockClient)(nil).InstallPolicyBypassFlows), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallPolicyBypassFlows", reflect.TypeOf((*MockClient)(nil).InstallPolicyBypassFlows), arg0, arg1, arg2, arg3)
 }
 
 // InstallPolicyRuleFlows mocks base method

--- a/pkg/agent/util/net.go
+++ b/pkg/agent/util/net.go
@@ -415,3 +415,17 @@ func GenerateRandomMAC() net.HardwareAddr {
 	buf[0] |= 2
 	return buf
 }
+
+func GetIPNetsByLink(link *net.Interface) ([]*net.IPNet, error) {
+	addrList, err := link.Addrs()
+	if err != nil {
+		return nil, err
+	}
+	var addrs []*net.IPNet
+	for _, a := range addrList {
+		if ipNet, ok := a.(*net.IPNet); ok {
+			addrs = append(addrs, ipNet)
+		}
+	}
+	return addrs, nil
+}

--- a/pkg/agent/util/net_windows.go
+++ b/pkg/agent/util/net_windows.go
@@ -895,3 +895,13 @@ func ReplaceNetNeighbor(neighbor *Neighbor) error {
 func VirtualAdapterName(name string) string {
 	return fmt.Sprintf("%s (%s)", ContainerVNICPrefix, name)
 }
+
+// TODO: Implement GetInterfaceConfig for Windows
+func GetInterfaceConfig(ifName string) (*net.Interface, []*net.IPNet, []interface{}, error) {
+	return nil, nil, nil, nil
+}
+
+// TODO: Implement RenameInterface for Windows
+func RenameInterface(from, to string) error {
+	return nil
+}

--- a/pkg/config/agent/config.go
+++ b/pkg/config/agent/config.go
@@ -204,6 +204,8 @@ type AgentConfig struct {
 	// NodeType is type of the Node where Antrea Agent is running.
 	// Defaults to "k8sNode". Valid values include "k8sNode", and "externalNode".
 	NodeType string `yaml:"nodeType,omitempty"`
+	// ExternalNode related configurations.
+	ExternalNode ExternalNodeConfig `yaml:"externalNode,omitempty"`
 }
 
 type AntreaProxyConfig struct {
@@ -273,4 +275,27 @@ type MulticlusterConfig struct {
 	// The Namespace where the Antrea Multi-cluster controller is running.
 	// The default is antrea-agent's Namespace.
 	Namespace string `yaml:"namespace,omitempty"`
+}
+
+type ExternalNodeConfig struct {
+	// The expected Namespace in which the ExternalNode should be created for a VM or baremetal server Node.
+	// The default value is "default".
+	// It is used only when NodeType is externalNode.
+	ExternalNodeNamespace string `yaml:"externalNodeNamespace,omitempty"`
+	// The policy bypass rules define traffic that should bypass NetworkPolicy rules.
+	// Each rule contains the following four attributes:
+	// direction (ingress|egress), protocol(tcp/udp/icmp/ip), remote CIDR, dst port (ICMP doesn't require),
+	// It is used only when NodeType is externalNode.
+	PolicyBypassRules []PolicyBypassRule `yaml:"policyBypassRules,omitempty"`
+}
+
+type PolicyBypassRule struct {
+	// The direction value can be ingress or egress.
+	Direction string `yaml:"direction,omitempty"`
+	// The protocol which traffic must match. Supported values are TCP, UDP, ICMP and IP.
+	Protocol string `yaml:"protocol,omitempty"`
+	// CIDR marks the destination CIDR for Egress and source CIDR for Ingress.
+	CIDR string `json:"cidr,omitempty"`
+	// The destination port of the given protocol.
+	Port int `yaml:"port,omitempty"`
 }

--- a/pkg/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller.go
@@ -1145,7 +1145,7 @@ func (n *NetworkPolicyController) getMemberSetForGroupType(groupType grouping.Gr
 		groupMemberSet.Insert(podToGroupMember(pod, true))
 	}
 	for _, ee := range externalEntities {
-		groupMemberSet.Insert(externalEntityToGroupMember(ee))
+		groupMemberSet.Insert(externalEntityToGroupMember(ee, true))
 	}
 	return groupMemberSet
 }
@@ -1194,10 +1194,9 @@ func nodeToGroupMember(node *v1.Node) (member *controlplane.GroupMember) {
 	return
 }
 
-func externalEntityToGroupMember(ee *v1alpha2.ExternalEntity) *controlplane.GroupMember {
+func externalEntityToGroupMember(ee *v1alpha2.ExternalEntity, includeIP bool) *controlplane.GroupMember {
 	memberEntity := &controlplane.GroupMember{}
 	namedPorts := make([]controlplane.NamedPort, len(ee.Spec.Ports))
-	var ips []controlplane.IPAddress
 	for i, port := range ee.Spec.Ports {
 		namedPorts[i] = controlplane.NamedPort{
 			Port:     port.Port,
@@ -1205,8 +1204,10 @@ func externalEntityToGroupMember(ee *v1alpha2.ExternalEntity) *controlplane.Grou
 			Protocol: controlplane.Protocol(port.Protocol),
 		}
 	}
-	for _, ep := range ee.Spec.Endpoints {
-		ips = append(ips, ipStrToIPAddress(ep.IP))
+	if includeIP {
+		for _, ep := range ee.Spec.Endpoints {
+			memberEntity.IPs = append(memberEntity.IPs, ipStrToIPAddress(ep.IP))
+		}
 	}
 	eeRef := controlplane.ExternalEntityReference{
 		Name:      ee.Name,
@@ -1214,7 +1215,6 @@ func externalEntityToGroupMember(ee *v1alpha2.ExternalEntity) *controlplane.Grou
 	}
 	memberEntity.ExternalEntity = &eeRef
 	memberEntity.Ports = namedPorts
-	memberEntity.IPs = ips
 	return memberEntity
 }
 
@@ -1266,7 +1266,7 @@ func (n *NetworkPolicyController) syncAppliedToGroup(key string) error {
 		if entitySet == nil {
 			entitySet = controlplane.GroupMemberSet{}
 		}
-		entitySet.Insert(externalEntityToGroupMember(extEntity))
+		entitySet.Insert(externalEntityToGroupMember(extEntity, false))
 		memberSetByNode[extEntity.Spec.ExternalNode] = entitySet
 		appGroupNodeNames.Insert(extEntity.Spec.ExternalNode)
 	}

--- a/pkg/ovs/ovsctl/interface.go
+++ b/pkg/ovs/ovsctl/interface.go
@@ -60,6 +60,8 @@ type OVSCtlClient interface {
 	RunAppctlCmd(cmd string, needsBridge bool, args ...string) ([]byte, *ExecError)
 	// GetDPFeatures executes "ovs-appctl dpif/show-dp-features" to check supported DP features.
 	GetDPFeatures() (map[DPFeature]bool, error)
+	// DeleteDPInterface executes "ovs-appctl dpctl/del-if ovs-system $name" to delete OVS datapath interface.
+	DeleteDPInterface(name string) error
 }
 
 type BadRequestError string

--- a/pkg/ovs/ovsctl/testing/mock_ovsctl.go
+++ b/pkg/ovs/ovsctl/testing/mock_ovsctl.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Antrea Authors
+// Copyright 2022 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -46,6 +46,20 @@ func NewMockOVSCtlClient(ctrl *gomock.Controller) *MockOVSCtlClient {
 // EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockOVSCtlClient) EXPECT() *MockOVSCtlClientMockRecorder {
 	return m.recorder
+}
+
+// DeleteDPInterface mocks base method
+func (m *MockOVSCtlClient) DeleteDPInterface(arg0 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteDPInterface", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteDPInterface indicates an expected call of DeleteDPInterface
+func (mr *MockOVSCtlClientMockRecorder) DeleteDPInterface(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDPInterface", reflect.TypeOf((*MockOVSCtlClient)(nil).DeleteDPInterface), arg0)
 }
 
 // DumpFlows mocks base method

--- a/test/integration/agent/openflow_test.go
+++ b/test/integration/agent/openflow_test.go
@@ -196,9 +196,11 @@ func TestAntreaFlexibleIPAMConnectivityFlows(t *testing.T) {
 		Name:  "fake-uplink",
 		Index: 0,
 		MAC:   uplinkMAC,
-		IP: &net.IPNet{
-			IP:   nil,
-			Mask: nil,
+		IPs: []*net.IPNet{
+			{
+				IP:   nil,
+				Mask: nil,
+			},
 		},
 		Gateway:    "",
 		DNSServers: "",


### PR DESCRIPTION
1. Provide an example RBAC yaml file for Antrea agent running
on VM with definitions of ClusterRole, ServiceAccount and
ClusterRoleBinding.

2. Add ExternalNodeController to monitor ExternalNode CRUD,
invoke interfaces to operate OVS and update interface store
with ExternalEntityInterface.

3. Implement OVS interactions related to ExternalNode CRUD.

4. Add a channel for receiving ExternalEntity updates from
ExternalNodeController and notifying NetworkPolicyController
to reconcile rules related to the updated ExternalEntities.
This is to handle the case when NetworkPolicyController reconciles
rules before ExternalEntityInterface is realized in the
interface store.

5. Support configuring policy bypass rules to skip ANP check.

Signed-off-by: Mengdie Song <songm@vmware.com>
Co-authored-by: Wenying Dong <wenyingd@vmware.com>
