### PR TITLE
Change deny connections IP address assignment methods

### DIFF
--- a/pkg/agent/controller/networkpolicy/packetin.go
+++ b/pkg/agent/controller/networkpolicy/packetin.go
@@ -17,6 +17,7 @@ package networkpolicy
 import (
 	"errors"
 	"fmt"
+	"net"
 	"time"
 
 	"antrea.io/libOpenflow/openflow13"
@@ -117,13 +118,11 @@ func (c *Controller) storeDenyConnection(pktIn *ofctrl.PacketIn) error {
 		DestinationPort: packet.DestinationPort,
 		Protocol:        packet.IPProto,
 	}
-	if packet.IsIPv6 {
-		tuple.SourceAddress = packet.SourceIP.To16()
-		tuple.DestinationAddress = packet.DestinationIP.To16()
-	} else {
-		tuple.SourceAddress = packet.SourceIP.To4()
-		tuple.DestinationAddress = packet.DestinationIP.To4()
-	}
+	// Make deep copy of IP addresses
+	tuple.SourceAddress = make(net.IP, len(packet.SourceIP))
+	tuple.DestinationAddress = make(net.IP, len(packet.DestinationIP))
+	copy(tuple.SourceAddress, packet.SourceIP)
+	copy(tuple.DestinationAddress, packet.DestinationIP)
 
 	// Generate deny connection and add to deny connection store
 	denyConn := flowexporter.Connection{}

--- a/pkg/agent/openflow/packetin.go
+++ b/pkg/agent/openflow/packetin.go
@@ -27,6 +27,9 @@ import (
 type ofpPacketInReason uint8
 
 type PacketInHandler interface {
+	// HandlePacketIn should not modify the input pktIn and should not
+	// assume that the pktIn contents(e.g. NWSrc/NWDst) will not be
+	// modified at a later time.
 	HandlePacketIn(pktIn *ofctrl.PacketIn) error
 }
 


### PR DESCRIPTION
When assign values to IP addresses, we were doing shallow copy by
assignment. This PR changes shallow copy to deep copy to avoid
unexpected IP addresses changes due to pktIn memory address reuse.

Fixes: #3795 

Signed-off-by: heanlan <hanlan@vmware.com>