### PR TITLE
[multicast] fix the issue multicast does not work if antreaPolicy is disabled

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -633,17 +633,8 @@ func run(o *Options) error {
 	}
 	go apiServer.Run(stopCh)
 
-	// Start PacketIn for features and specify their own reason.
-	var packetInReasons []uint8
-	if features.DefaultFeatureGate.Enabled(features.Traceflow) {
-		packetInReasons = append(packetInReasons, uint8(openflow.PacketInReasonTF))
-	}
-	if features.DefaultFeatureGate.Enabled(features.AntreaPolicy) {
-		packetInReasons = append(packetInReasons, uint8(openflow.PacketInReasonNP))
-	}
-	if len(packetInReasons) > 0 {
-		go ofClient.StartPacketInHandler(packetInReasons, stopCh)
-	}
+	// Start PacketIn
+	go ofClient.StartPacketInHandler(stopCh)
 
 	// Start the goroutine to periodically export IPFIX flow records.
 	if features.DefaultFeatureGate.Enabled(features.FlowExporter) {

--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -215,7 +215,7 @@ type Client interface {
 	// packets through registered handlers.
 	RegisterPacketInHandler(packetHandlerReason uint8, packetHandlerName string, packetInHandler interface{})
 
-	StartPacketInHandler(packetInStartedReason []uint8, stopCh <-chan struct{})
+	StartPacketInHandler(stopCh <-chan struct{})
 	// Get traffic metrics of each NetworkPolicy rule.
 	NetworkPolicyMetrics() map[uint32]*types.RuleMetric
 	// SendTCPPacketOut sends TCP packet as a packet-out to OVS.

--- a/pkg/agent/openflow/packetin.go
+++ b/pkg/agent/openflow/packetin.go
@@ -84,13 +84,13 @@ func newfeatureStartPacketIn(reason uint8, stopCh <-chan struct{}) *featureStart
 }
 
 // StartPacketInHandler is the starting point for processing feature packetin requests.
-func (c *client) StartPacketInHandler(packetInStartedReason []uint8, stopCh <-chan struct{}) {
-	if len(c.packetInHandlers) == 0 || len(packetInStartedReason) == 0 {
+func (c *client) StartPacketInHandler(stopCh <-chan struct{}) {
+	if len(c.packetInHandlers) == 0 {
 		return
 	}
 
 	// Iterate through each feature that starts packetin. Subscribe with their specified reason.
-	for _, reason := range packetInStartedReason {
+	for reason := range c.packetInHandlers {
 		featurePacketIn := newfeatureStartPacketIn(reason, stopCh)
 		err := c.subscribeFeaturePacketIn(featurePacketIn)
 		if err != nil {

--- a/pkg/agent/openflow/testing/mock_openflow.go
+++ b/pkg/agent/openflow/testing/mock_openflow.go
@@ -615,15 +615,15 @@ func (mr *MockClientMockRecorder) SendUDPPacketOut(arg0, arg1, arg2, arg3, arg4,
 }
 
 // StartPacketInHandler mocks base method
-func (m *MockClient) StartPacketInHandler(arg0 []byte, arg1 <-chan struct{}) {
+func (m *MockClient) StartPacketInHandler(arg0 <-chan struct{}) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "StartPacketInHandler", arg0, arg1)
+	m.ctrl.Call(m, "StartPacketInHandler", arg0)
 }
 
 // StartPacketInHandler indicates an expected call of StartPacketInHandler
-func (mr *MockClientMockRecorder) StartPacketInHandler(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) StartPacketInHandler(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartPacketInHandler", reflect.TypeOf((*MockClient)(nil).StartPacketInHandler), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartPacketInHandler", reflect.TypeOf((*MockClient)(nil).StartPacketInHandler), arg0)
 }
 
 // SubscribePacketIn mocks base method


### PR DESCRIPTION
Currently, packetIn reason only supports 0 and 1. There is no more available packetIn reasons
as traceflow and antreaPolicy use both. Multicast reuses packetIn reason with antreaPolicy, and
uses different register bit to indicate the real reason. There is no queue for packetIn reason
'PacketInReasonNP' if antreaPloicy is disabled. And multicast will not work then.

This patch fixes https://github.com/antrea-io/antrea/issues/3808