### PR TITLE
Optimize the flows for forwarding the packets with unknown destination in L3ForwardingTable

### DIFF
--- a/pkg/agent/openflow/service.go
+++ b/pkg/agent/openflow/service.go
@@ -119,7 +119,7 @@ func (f *featureService) initFlows() []binding.Flow {
 	if f.enableProxy {
 		flows = append(flows, f.conntrackFlows()...)
 		flows = append(flows, f.preRoutingClassifierFlows()...)
-		flows = append(flows, f.l3FwdFlowsToExternalEndpoint()...)
+		flows = append(flows, f.l3FwdFlowToExternalEndpoint())
 		flows = append(flows, f.gatewaySNATFlows()...)
 		flows = append(flows, f.snatConntrackFlows()...)
 		flows = append(flows, f.serviceNeedLBFlow())

--- a/test/integration/agent/openflow_test.go
+++ b/test/integration/agent/openflow_test.go
@@ -1413,7 +1413,7 @@ func prepareDefaultFlows(config *testConfig) []expectTableFlows {
 		)
 		podCIDR := config.nodeConfig.PodIPv4CIDR.String()
 		tableL3ForwardingFlows.flows = append(tableL3ForwardingFlows.flows,
-			&ofTestUtils.ExpectFlow{MatchStr: fmt.Sprintf("priority=190,ip,reg0=0/0x200%s,nw_dst=%s", matchVLANString, podCIDR), ActStr: "goto_table:L2ForwardingCalc"},
+			&ofTestUtils.ExpectFlow{MatchStr: fmt.Sprintf("priority=200,ip,reg0=0/0x200%s,nw_dst=%s", matchVLANString, podCIDR), ActStr: "goto_table:L2ForwardingCalc"},
 		)
 		tableServiceMarkFlows.flows = append(tableServiceMarkFlows.flows,
 			&ofTestUtils.ExpectFlow{MatchStr: "priority=200,ct_state=+new+trk,ip,reg0=0x22/0xff", ActStr: fmt.Sprintf("ct(commit,table=SNAT,zone=%s,exec(load:0x1->NXM_NX_CT_MARK[5],load:0x1->NXM_NX_CT_MARK[6]))", ctZone)},
@@ -1458,7 +1458,7 @@ func prepareDefaultFlows(config *testConfig) []expectTableFlows {
 		)
 		podCIDR := config.nodeConfig.PodIPv6CIDR.String()
 		tableL3ForwardingFlows.flows = append(tableL3ForwardingFlows.flows,
-			&ofTestUtils.ExpectFlow{MatchStr: fmt.Sprintf("priority=190,ipv6,reg0=0/0x200,ipv6_dst=%s", podCIDR), ActStr: "goto_table:L2ForwardingCalc"},
+			&ofTestUtils.ExpectFlow{MatchStr: fmt.Sprintf("priority=200,ipv6,reg0=0/0x200,ipv6_dst=%s", podCIDR), ActStr: "goto_table:L2ForwardingCalc"},
 		)
 		tableServiceMarkFlows.flows = append(tableServiceMarkFlows.flows,
 			&ofTestUtils.ExpectFlow{MatchStr: "priority=200,ct_state=+new+trk,ipv6,reg0=0x22/0xff", ActStr: "ct(commit,table=SNAT,zone=65510,exec(load:0x1->NXM_NX_CT_MARK[5],load:0x1->NXM_NX_CT_MARK[6]))"},
@@ -1573,7 +1573,7 @@ func expectedExternalFlows(ipProtoStr, gwMACStr string) []expectTableFlows {
 			"L3Forwarding",
 			[]*ofTestUtils.ExpectFlow{
 				{
-					MatchStr: fmt.Sprintf("priority=190,ct_state=-rpl+trk,%s,reg0=0x3/0xf", ipProtoStr),
+					MatchStr: fmt.Sprintf("priority=190,ct_state=-rpl+trk,%s,reg0=0x3/0xf,reg4=0/0x100000", ipProtoStr),
 					ActStr:   "goto_table:EgressMark",
 				},
 				{


### PR DESCRIPTION
Fix #3806

Currently, when Egress and AntreaIPAM are enabled, there are several flows in
L3ForwardingTable like the follows:

```
1. table=L3Forwarding, priority=190,ip,reg0=0/0x200,reg8=0/0xfff,nw_dst=10.10.0.0/24 actions=resubmit(,L2ForwardingCalc)
2. table=L3Forwarding, priority=190,ct_mark=0x10/0x10,reg0=0x200/0x200,reg4=0/0x100000 actions=mod_dl_dst:d2:35:24:7f:3a:f8,load:0x2->NXM_NX_REG0[4..7],resubmit(,L3DecTTL)
3. table=L3Forwarding, priority=190,ct_mark=0x10/0x10,reg4=0x100000/0x100000 actions=resubmit(,L3DecTTL)
4. table=L3Forwarding, priority=190,ct_state=-rpl+trk,ip,reg0=0x3/0xf actions=resubmit(,EgressMark)
5. table=L3Forwarding, priority=190,ct_state=-rpl+trk,ip,reg0=0x1/0xf actions=mod_dl_dst:d2:35:24:7f:3a:f8,resubmit(,EgressMark)
6. table=L3Forwarding, priority=0 actions=load:0x2->NXM_NX_REG0[4..7],resubmit(,L2ForwardingCalc)
```

- Flow 1 is used to forward the packets of non-Service connections between
  local Pods.
- Flow 2 is used to forward the packets of Service connections sourced from
  local non-AntreaIPAM Pods and destined for external network Endpoint.
- Flow 3 is used to forward the packets of Service connections sourced from
  local AntreaIPAM Pods and destined for external network Endpoint.
- Flow 4 is used to forward the packets sourced from local Pods and destined
  for external network, and the flow is for Egress.
- Flow 5 is used to forward the packets sourced from tunnel and destined for
  external network, and the flow is also for Egress.
- Flow 6 is the default flow. `load:0x2->NXM_NX_REG0[4..7]` means `to Gateway`.

For request packets sourced from a local Pod and destined for another local
Pod, they are expected to be matched by flow 1, however, they can be matched
by flow 4, and this leads the unexpected result in #3806.

In addition, when Egress is enabled, if a local Pod accesses to a Service
whose Endpoint is on external Network, the request packets are expected to
be matched by flow 4, but they can be also matched by flow 2.

To resolve above issues, the new flows are like the follows:

```
1. table=L3Forwarding, priority=200,ip,reg0=0/0x200,reg8=0/0xfff,nw_dst=10.10.0.0/24 actions=resubmit(,L2ForwardingCalc)
2. table=L3Forwarding, priority=190,ct_mark=0x10/0x10,reg0=0x202/0x20f actions=mod_dl_dst:d2:35:24:7f:3a:f8,load:0x2->NXM_NX_REG0[4..7],resubmit(,L3DecTTL)
3. table=L3Forwarding, priority=190,ct_state=-rpl+trk,ip,reg0=0x3/0xf,reg4=0/0x100000 actions=resubmit(,EgressMark)
4. table=L3Forwarding, priority=190,ct_state=-rpl+trk,ip,reg0=0x1/0xf actions=mod_dl_dst:d2:35:24:7f:3a:f8,resubmit(,EgressMark)
5. table=L3Forwarding, priority=0 actions=load:0x2->NXM_NX_REG0[4..7],resubmit(,L2ForwardingCalc)
```

Issue #3806 is fixed by raising the priority of the legacy flow 1 to
normal (200). It is the new flow 1 now.

In legacy flow 2, packets of Service connections with unknown destination
can be either sourced from local Pods or Antrea gateway. In the new flow 2,
only the packets of Service connections sourced Antrea gateway are matched.

Packets of connections sourced from local Pods and destined for external
network are matched by the new flow 3 (Egress is enabled) or the new flow
5 (Egress is disabled).

Packets of connections sourced from local AntreaIPAM Pods (AntreaIPAM is
enabled) and destined for external network are matched by the new flow 5.

Other modifications: fix some stale comments.

Signed-off-by: Hongliang Liu <lhongliang@vmware.com>