### PR TITLE
Stop using k8s.io/component-base/logs to configure logging

### DIFF
--- a/cmd/antctl/main.go
+++ b/cmd/antctl/main.go
@@ -15,17 +15,15 @@
 package main
 
 import (
-	"flag"
 	"math/rand"
 	"os"
 	"path"
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
-	"k8s.io/component-base/logs"
 
 	"antrea.io/antrea/pkg/antctl"
+	"antrea.io/antrea/pkg/log"
 )
 
 var commandName = path.Base(os.Args[0])
@@ -36,24 +34,14 @@ var rootCmd = &cobra.Command{
 	Long:  commandName + " is the command line tool for Antrea that supports showing status of ${component}",
 }
 
-func init() {
-	// Add klog flags to command-line flags, must be called before InitLogs()
-	logs.AddGoFlags(flag.CommandLine)
-	// prevent any unexpected output at beginning
-	flag.Set("logtostderr", "false")
-	flag.Set("v", "0")
-	pflag.CommandLine.MarkHidden("log-flush-frequency")
-}
-
 func main() {
-	logs.InitLogs()
-	defer logs.FlushLogs()
+	defer log.FlushLogs()
 
 	rand.Seed(time.Now().UTC().UnixNano())
 	antctl.CommandList.ApplyToRootCommand(rootCmd)
 	err := rootCmd.Execute()
 	if err != nil {
-		logs.FlushLogs()
+		log.FlushLogs()
 		os.Exit(1)
 	}
 }

--- a/cmd/antrea-agent-simulator/main.go
+++ b/cmd/antrea-agent-simulator/main.go
@@ -21,7 +21,6 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"k8s.io/component-base/logs"
 	"k8s.io/klog/v2"
 
 	"antrea.io/antrea/pkg/log"
@@ -40,9 +39,8 @@ func newSimulatorCommand() *cobra.Command {
 		Use:  "antrea-agent-simulator",
 		Long: "The Antrea agent simulator.",
 		Run: func(cmd *cobra.Command, args []string) {
-			logs.InitLogs()
-			defer logs.FlushLogs()
-			log.Init(cmd.Flags())
+			log.InitLogs(cmd.Flags())
+			defer log.FlushLogs()
 
 			if err := run(); err != nil {
 				klog.Fatalf("Error running agent: %v", err)
@@ -52,7 +50,6 @@ func newSimulatorCommand() *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-	logs.AddFlags(flags)
 	log.AddFlags(flags)
 
 	return cmd

--- a/cmd/antrea-agent/main.go
+++ b/cmd/antrea-agent/main.go
@@ -21,7 +21,6 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"k8s.io/component-base/logs"
 	"k8s.io/klog/v2"
 
 	"antrea.io/antrea/pkg/log"
@@ -42,9 +41,8 @@ func newAgentCommand() *cobra.Command {
 		Use:  "antrea-agent",
 		Long: "The Antrea agent runs on each node.",
 		Run: func(cmd *cobra.Command, args []string) {
-			logs.InitLogs()
-			defer logs.FlushLogs()
-			log.Init(cmd.Flags())
+			log.InitLogs(cmd.Flags())
+			defer log.FlushLogs()
 			if err := opts.complete(args); err != nil {
 				klog.Fatalf("Failed to complete: %v", err)
 			}
@@ -60,7 +58,6 @@ func newAgentCommand() *cobra.Command {
 
 	flags := cmd.Flags()
 	opts.addFlags(flags)
-	logs.AddFlags(flags)
 	log.AddFlags(flags)
 	return cmd
 }

--- a/cmd/antrea-controller/main.go
+++ b/cmd/antrea-controller/main.go
@@ -21,7 +21,6 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"k8s.io/component-base/logs"
 	"k8s.io/klog/v2"
 
 	"antrea.io/antrea/pkg/log"
@@ -42,9 +41,8 @@ func newControllerCommand() *cobra.Command {
 		Use:  "antrea-controller",
 		Long: "The Antrea Controller.",
 		Run: func(cmd *cobra.Command, args []string) {
-			logs.InitLogs()
-			defer logs.FlushLogs()
-			log.Init(cmd.Flags())
+			log.InitLogs(cmd.Flags())
+			defer log.FlushLogs()
 			if err := opts.complete(args); err != nil {
 				klog.Fatalf("Failed to complete: %v", err)
 			}
@@ -60,7 +58,6 @@ func newControllerCommand() *cobra.Command {
 
 	flags := cmd.Flags()
 	opts.addFlags(flags)
-	logs.AddFlags(flags)
 	log.AddFlags(flags)
 	return cmd
 }

--- a/cmd/flow-aggregator/main.go
+++ b/cmd/flow-aggregator/main.go
@@ -21,7 +21,6 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"k8s.io/component-base/logs"
 	"k8s.io/klog/v2"
 
 	"antrea.io/antrea/pkg/log"
@@ -42,9 +41,8 @@ func newFlowAggregatorCommand() *cobra.Command {
 		Use:  "flow-aggregator",
 		Long: "The Flow Aggregator.",
 		Run: func(cmd *cobra.Command, args []string) {
-			logs.InitLogs()
-			defer logs.FlushLogs()
-			log.Init(cmd.Flags())
+			log.InitLogs(cmd.Flags())
+			defer log.FlushLogs()
 			if err := opts.complete(args); err != nil {
 				klog.Fatalf("Failed to complete args: %v", err)
 			}
@@ -60,7 +58,6 @@ func newFlowAggregatorCommand() *cobra.Command {
 
 	flags := cmd.Flags()
 	opts.addFlags(flags)
-	logs.AddFlags(flags)
 	log.AddFlags(flags)
 	return cmd
 }

--- a/multicluster/cmd/multicluster-controller/leader.go
+++ b/multicluster/cmd/multicluster-controller/leader.go
@@ -25,6 +25,7 @@ import (
 
 	multiclusterv1alpha1 "antrea.io/antrea/multicluster/apis/multicluster/v1alpha1"
 	multiclustercontrollers "antrea.io/antrea/multicluster/controllers/multicluster"
+	"antrea.io/antrea/pkg/log"
 	"antrea.io/antrea/pkg/util/env"
 )
 
@@ -34,6 +35,8 @@ func newLeaderCommand() *cobra.Command {
 		Short: "Run the MC controller in leader cluster",
 		Long:  "Run the Antrea Multi-Cluster controller for leader cluster",
 		Run: func(cmd *cobra.Command, args []string) {
+			log.InitLogs(cmd.Flags())
+			defer log.FlushLogs()
 			if err := opts.complete(args); err != nil {
 				klog.Fatalf("Failed to complete: %v", err)
 			}

--- a/multicluster/cmd/multicluster-controller/main.go
+++ b/multicluster/cmd/multicluster-controller/main.go
@@ -23,7 +23,8 @@ import (
 
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/component-base/logs"
+
+	"antrea.io/antrea/pkg/log"
 )
 
 var (
@@ -35,15 +36,11 @@ func main() {
 	command := newControllerCommand()
 	flags := command.PersistentFlags()
 	opts.addFlags(flags)
-	logs.AddFlags(flags)
+	log.AddFlags(flags)
 	command.AddCommand(newLeaderCommand())
 	command.AddCommand(newMemberCommand())
 
-	logs.InitLogs()
-	defer logs.FlushLogs()
-
 	if err := command.Execute(); err != nil {
-		logs.FlushLogs()
 		os.Exit(1)
 	}
 }

--- a/multicluster/cmd/multicluster-controller/member.go
+++ b/multicluster/cmd/multicluster-controller/member.go
@@ -23,6 +23,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	multiclustercontrollers "antrea.io/antrea/multicluster/controllers/multicluster"
+	"antrea.io/antrea/pkg/log"
 	"antrea.io/antrea/pkg/signals"
 	"antrea.io/antrea/pkg/util/env"
 )
@@ -33,6 +34,8 @@ func newMemberCommand() *cobra.Command {
 		Short: "Run the MC controller in member cluster",
 		Long:  "Run the Antrea Multi-Cluster controller for member cluster",
 		Run: func(cmd *cobra.Command, args []string) {
+			log.InitLogs(cmd.Flags())
+			defer log.FlushLogs()
 			if err := opts.complete(args); err != nil {
 				klog.Fatalf("Failed to complete: %v", err)
 			}

--- a/pkg/antctl/antctl_test.go
+++ b/pkg/antctl/antctl_test.go
@@ -16,7 +16,6 @@ package antctl
 
 import (
 	"bytes"
-	"flag"
 	"fmt"
 	"os"
 	"testing"
@@ -24,7 +23,6 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
-	"k8s.io/component-base/logs"
 
 	antreaversion "antrea.io/antrea/pkg/version"
 )
@@ -32,11 +30,6 @@ import (
 var (
 	serverError = fmt.Errorf("cannot reach server")
 )
-
-func init() {
-	// the antctl code assumes that the logtostderr flag exists
-	logs.AddGoFlags(flag.CommandLine)
-}
 
 // TestCommandListValidation ensures the command list is valid.
 func TestCommandListValidation(t *testing.T) {

--- a/pkg/antctl/command_list.go
+++ b/pkg/antctl/command_list.go
@@ -15,7 +15,6 @@
 package antctl
 
 import (
-	"flag"
 	"fmt"
 	"io"
 	"math"
@@ -57,7 +56,6 @@ func (cl *commandList) applyToRootCommand(root *cobra.Command, client AntctlClie
 			continue
 		}
 		def.applySubCommandToRoot(root, client, out)
-		klog.Infof("Added command %s", def.use)
 	}
 	cl.applyPersistentFlagsToRoot(root)
 
@@ -79,13 +77,10 @@ func (cl *commandList) applyToRootCommand(root *cobra.Command, client AntctlClie
 		if err != nil {
 			return err
 		}
-		err = flag.Set("logtostderr", fmt.Sprint(enableVerbose))
-		if err != nil {
-			return err
-		}
+		klog.LogToStderr(enableVerbose)
 		if enableVerbose {
-			err := flag.Set("v", fmt.Sprint(math.MaxInt32))
-			if err != nil {
+			var logLevel klog.Level
+			if err := logLevel.Set(fmt.Sprint(math.MaxInt32)); err != nil {
 				return err
 			}
 		}

--- a/pkg/log/log_file.go
+++ b/pkg/log/log_file.go
@@ -48,10 +48,6 @@ var (
 	executableName = filepath.Base(os.Args[0])
 )
 
-func AddFlags(fs *pflag.FlagSet) {
-	fs.Uint16Var(&maxNumArg, maxNumFlag, maxNumArg, "Maximum number of log files per severity level to be kept. Value 0 means unlimited.")
-}
-
 // initLogFileLimits initializes log file maximum size and maximum number limits based on the
 // command line flags.
 func initLogFileLimits(fs *pflag.FlagSet) {

--- a/pkg/log/log_file_test.go
+++ b/pkg/log/log_file_test.go
@@ -15,7 +15,6 @@
 package log
 
 import (
-	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -26,31 +25,34 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 
-	"k8s.io/component-base/logs"
 	"k8s.io/klog/v2"
 )
 
 const oneMB = 1 * 1024 * 1024
 
 var (
-	testFlags          = initFlags()
 	klogDefaultMaxSize = klog.MaxSize
 )
 
-func initFlags() *pflag.FlagSet {
+func getTestFlags() *pflag.FlagSet {
 	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
-	logs.AddFlags(flags)
 	AddFlags(flags)
-	flags.AddGoFlagSet(flag.CommandLine)
 	return flags
 }
 
 func restoreFlagDefaultValues() {
-	testFlags.Set(logToStdErrFlag, "true")
-	testFlags.Set(logFileFlag, "")
-	testFlags.Set(logDirFlag, "")
-	testFlags.Set(maxSizeFlag, fmt.Sprintf("%d", klogDefaultMaxSize/oneMB))
-	testFlags.Set(maxNumFlag, "0")
+	// The flag values are stored as global variables in klog and the
+	// initial values for the global variables are used as the flag default
+	// values. As a consequence, simply re-initializing the klog flags is
+	// not enough, as the default values are no longer the same after the
+	// first call to Parse. We need to explicitly set the flags to the known
+	// default values, which will in turn reset the corresponding klog
+	// global variables.
+	klogFlags.Set(logToStdErrFlag, "true")
+	klogFlags.Set(logFileFlag, "")
+	klogFlags.Set(logDirFlag, "")
+	klogFlags.Set(maxSizeFlag, fmt.Sprintf("%d", klogDefaultMaxSize/oneMB))
+	klogFlags.Set(maxNumFlag, "0")
 
 	klog.MaxSize = klogDefaultMaxSize
 	logFileMaxNum = 0
@@ -69,7 +71,7 @@ func testLogging() {
 		klog.Infof("%d: %s", i, string(line))
 		klog.Warningf("%d: %s", i, string(line))
 	}
-	logs.FlushLogs()
+	FlushLogs()
 }
 
 func TestKlogFileLimits(t *testing.T) {
@@ -83,9 +85,9 @@ func TestKlogFileLimits(t *testing.T) {
 	testMaxNum := 2
 	args := []string{"--logtostderr=false", "--log_dir=" + testLogDir, "--log_file_max_size=1",
 		fmt.Sprintf("--log_file_max_num=%d", testMaxNum)}
+	testFlags := getTestFlags()
 	testFlags.Parse(args)
-	initLogFileLimits(testFlags)
-	logs.InitLogs()
+	InitLogs(testFlags)
 	defer restoreFlagDefaultValues()
 
 	// Should generate about 5 log files (100K * 40 / 1M), though it is hard
@@ -188,8 +190,9 @@ func TestFlags(t *testing.T) {
 	}
 
 	for _, test := range testcases {
+		testFlags := getTestFlags()
 		testFlags.Parse(test.args)
-		initLogFileLimits(testFlags)
+		InitLogs(testFlags)
 		assert.Equal(t, test.maxSize, klog.MaxSize, test.name)
 		assert.Equal(t, test.maxNum, logFileMaxNum, test.name)
 		assert.Equal(t, test.logDir, logDir, test.name)


### PR DESCRIPTION
K8s is deprecating most of the klog files that we use in Antrea (e.g.,
--log_file). To avoid any disruption (and to avoid the deprecation
warnings which are now displayed when running an Antrea component), we
stop using k8s.io/component-base/logs and instead configure klog
directly.

There is no significant change in the code base, as klog is still used
as the logging facade. We use klog as the logging backend (same as
before), with the possibility to move to something else in the future.

Fixes #3786

Signed-off-by: Antonin Bas <abas@vmware.com>