### PR TITLE
Clean up stale images and fix e2e codes

### DIFF
--- a/ci/jenkins/test.sh
+++ b/ci/jenkins/test.sh
@@ -135,9 +135,6 @@ function clean_antrea {
     clean_up_one_ns "antrea-ipam-test-12"
     clean_up_one_ns "antrea-ipam-test"
     clean_up_one_ns "antrea-test"
-    kubectl get pod -n kube-system -l component=antrea-agent --no-headers=true | awk '{print $1}' | while read AGENTNAME; do
-        kubectl exec $AGENTNAME -c antrea-agent -n kube-system -- ovs-vsctl del-port br-int gw0 || true
-    done
     for antrea_yml in ${WORKDIR}/*.yml; do
         kubectl delete -f $antrea_yml --ignore-not-found=true || true
     done

--- a/multicluster/test/e2e/antreapolicy_test.go
+++ b/multicluster/test/e2e/antreapolicy_test.go
@@ -134,7 +134,7 @@ func executeTestsOnAllMemberClusters(t *testing.T, testList []*antreae2e.TestCas
 					}
 					start := time.Now()
 					k8sUtils.Validate(allPodsPerCluster, reachability, step.Ports, step.Protocol)
-					step.Duration = time.Now().Sub(start)
+					step.Duration = time.Since(start)
 					_, wrong, _ := step.Reachability.Summary()
 					if wrong != 0 {
 						t.Errorf("Failure in cluster %s -- %d wrong results", clusterName, wrong)
@@ -148,22 +148,18 @@ func executeTestsOnAllMemberClusters(t *testing.T, testList []*antreae2e.TestCas
 }
 
 func (data *MCTestData) deployACNPResourceExport(reFileName string) error {
-	var rc int
-	var err error
 	log.Infof("Creating ResourceExport %s in the leader cluster", reFileName)
-	rc, _, _, err = provider.RunCommandOnNode(leaderCluster, fmt.Sprintf("kubectl apply -f %s", reFileName))
-	if err != nil || rc != 0 {
-		return fmt.Errorf("error when deploying the ACNP ResourceExport in leader cluster: %v", err)
+	rc, _, stderr, err := provider.RunCommandOnNode(leaderCluster, fmt.Sprintf("kubectl apply -f %s", reFileName))
+	if err != nil || rc != 0 || stderr != "" {
+		return fmt.Errorf("error when deploying the ACNP ResourceExport in leader cluster: %v, stderr: %v", err, stderr)
 	}
 	return nil
 }
 
 func (data *MCTestData) deleteACNPResourceExport(reFileName string) error {
-	var rc int
-	var err error
-	rc, _, _, err = provider.RunCommandOnNode(leaderCluster, fmt.Sprintf("kubectl delete -f %s", reFileName))
-	if err != nil || rc != 0 {
-		return fmt.Errorf("error when deleting the ACNP ResourceExport in leader cluster: %v", err)
+	rc, _, stderr, err := provider.RunCommandOnNode(leaderCluster, fmt.Sprintf("kubectl delete -f %s", reFileName))
+	if err != nil || rc != 0 || stderr != "" {
+		return fmt.Errorf("error when deleting the ACNP ResourceExport in leader cluster: %v, stderr: %v", err, stderr)
 	}
 	return nil
 }

--- a/multicluster/test/e2e/main_test.go
+++ b/multicluster/test/e2e/main_test.go
@@ -104,4 +104,7 @@ func TestConnectivity(t *testing.T) {
 		testMCAntreaPolicy(t, data)
 		tearDownForPolicyTest()
 	})
+	// Wait 5 seconds to let both member and leader controllers clean up all resources,
+	// otherwise, Namespace deletion may stuck into termininating status.
+	time.Sleep(5 * time.Second)
 }

--- a/multicluster/test/e2e/service_test.go
+++ b/multicluster/test/e2e/service_test.go
@@ -144,22 +144,18 @@ func (data *MCTestData) verifyMCServiceACNP(t *testing.T, clientPodName, eastIP 
 }
 
 func (data *MCTestData) deployServiceExport(clusterName string) error {
-	var rc int
-	var err error
-	rc, _, _, err = provider.RunCommandOnNode(clusterName, fmt.Sprintf("kubectl apply -f %s", serviceExportYML))
-	if err != nil || rc != 0 {
-		return fmt.Errorf("error when deploying the ServiceExport: %v", err)
+	rc, _, stderr, err := provider.RunCommandOnNode(clusterName, fmt.Sprintf("kubectl apply -f %s", serviceExportYML))
+	if err != nil || rc != 0 || stderr != "" {
+		return fmt.Errorf("error when deploying the ServiceExport: %v, stderr: %v", err, stderr)
 	}
 
 	return nil
 }
 
 func (data *MCTestData) deleteServiceExport(clusterName string) error {
-	var rc int
-	var err error
-	rc, _, _, err = provider.RunCommandOnNode(clusterName, fmt.Sprintf("kubectl delete -f %s", serviceExportYML))
-	if err != nil || rc != 0 {
-		return fmt.Errorf("error when deleting the ServiceExport: %v", err)
+	rc, _, stderr, err := provider.RunCommandOnNode(clusterName, fmt.Sprintf("kubectl delete -f %s", serviceExportYML))
+	if err != nil || rc != 0 || stderr != "" {
+		return fmt.Errorf("error when deleting the ServiceExport: %v, stderr: %v", err, stderr)
 	}
 
 	return nil


### PR DESCRIPTION
1. Clean up stale images in jumper box.
2. Print stderr if there is any command error.
3. Add a waiting interval to fix random Namespace terminating issue.
4. Fix `ovs-vsctl: no port named gw0` error

Signed-off-by: Lan Luo <luola@vmware.com>