### PR TITLE
Use kubernetes-1.24.0 image for multicluster code generation

### DIFF
--- a/multicluster/hack/update-codegen.sh
+++ b/multicluster/hack/update-codegen.sh
@@ -19,7 +19,7 @@ set -o nounset
 set -o pipefail
 
 ANTREA_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../" && pwd )"
-IMAGE_NAME="antrea/codegen:kubernetes-1.21.0"
+IMAGE_NAME="antrea/codegen:kubernetes-1.24.0"
 
 function docker_run() {
   docker pull ${IMAGE_NAME}

--- a/multicluster/pkg/client/clientset/versioned/clientset.go
+++ b/multicluster/pkg/client/clientset/versioned/clientset.go
@@ -19,6 +19,7 @@ package versioned
 
 import (
 	"fmt"
+	"net/http"
 
 	multiclusterv1alpha1 "antrea.io/antrea/multicluster/pkg/client/clientset/versioned/typed/multicluster/v1alpha1"
 	discovery "k8s.io/client-go/discovery"
@@ -54,7 +55,29 @@ func (c *Clientset) Discovery() discovery.DiscoveryInterface {
 // NewForConfig creates a new Clientset for the given config.
 // If config's RateLimiter is not set and QPS and Burst are acceptable,
 // NewForConfig will generate a rate-limiter in configShallowCopy.
+// NewForConfig is equivalent to NewForConfigAndClient(c, httpClient),
+// where httpClient was generated with rest.HTTPClientFor(c).
 func NewForConfig(c *rest.Config) (*Clientset, error) {
+	configShallowCopy := *c
+
+	if configShallowCopy.UserAgent == "" {
+		configShallowCopy.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
+
+	// share the transport between all clients
+	httpClient, err := rest.HTTPClientFor(&configShallowCopy)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewForConfigAndClient(&configShallowCopy, httpClient)
+}
+
+// NewForConfigAndClient creates a new Clientset for the given config and http client.
+// Note the http client provided takes precedence over the configured transport values.
+// If config's RateLimiter is not set and QPS and Burst are acceptable,
+// NewForConfigAndClient will generate a rate-limiter in configShallowCopy.
+func NewForConfigAndClient(c *rest.Config, httpClient *http.Client) (*Clientset, error) {
 	configShallowCopy := *c
 	if configShallowCopy.RateLimiter == nil && configShallowCopy.QPS > 0 {
 		if configShallowCopy.Burst <= 0 {
@@ -62,14 +85,15 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 		}
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
 	}
+
 	var cs Clientset
 	var err error
-	cs.multiclusterV1alpha1, err = multiclusterv1alpha1.NewForConfig(&configShallowCopy)
+	cs.multiclusterV1alpha1, err = multiclusterv1alpha1.NewForConfigAndClient(&configShallowCopy, httpClient)
 	if err != nil {
 		return nil, err
 	}
 
-	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfig(&configShallowCopy)
+	cs.DiscoveryClient, err = discovery.NewDiscoveryClientForConfigAndClient(&configShallowCopy, httpClient)
 	if err != nil {
 		return nil, err
 	}
@@ -79,11 +103,11 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 // NewForConfigOrDie creates a new Clientset for the given config and
 // panics if there is an error in the config.
 func NewForConfigOrDie(c *rest.Config) *Clientset {
-	var cs Clientset
-	cs.multiclusterV1alpha1 = multiclusterv1alpha1.NewForConfigOrDie(c)
-
-	cs.DiscoveryClient = discovery.NewDiscoveryClientForConfigOrDie(c)
-	return &cs
+	cs, err := NewForConfig(c)
+	if err != nil {
+		panic(err)
+	}
+	return cs
 }
 
 // New creates a new Clientset for the given RESTClient.

--- a/multicluster/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/multicluster/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -73,7 +73,10 @@ func (c *Clientset) Tracker() testing.ObjectTracker {
 	return c.tracker
 }
 
-var _ clientset.Interface = &Clientset{}
+var (
+	_ clientset.Interface = &Clientset{}
+	_ testing.FakeClient  = &Clientset{}
+)
 
 // MulticlusterV1alpha1 retrieves the MulticlusterV1alpha1Client
 func (c *Clientset) MulticlusterV1alpha1() multiclusterv1alpha1.MulticlusterV1alpha1Interface {

--- a/multicluster/pkg/client/clientset/versioned/typed/multicluster/v1alpha1/fake/fake_clusterclaim.go
+++ b/multicluster/pkg/client/clientset/versioned/typed/multicluster/v1alpha1/fake/fake_clusterclaim.go
@@ -104,7 +104,7 @@ func (c *FakeClusterClaims) Update(ctx context.Context, clusterClaim *v1alpha1.C
 // Delete takes name of the clusterClaim and deletes it. Returns an error if one occurs.
 func (c *FakeClusterClaims) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(clusterclaimsResource, c.ns, name), &v1alpha1.ClusterClaim{})
+		Invokes(testing.NewDeleteActionWithOptions(clusterclaimsResource, c.ns, name, opts), &v1alpha1.ClusterClaim{})
 
 	return err
 }

--- a/multicluster/pkg/client/clientset/versioned/typed/multicluster/v1alpha1/fake/fake_clusterinfoimport.go
+++ b/multicluster/pkg/client/clientset/versioned/typed/multicluster/v1alpha1/fake/fake_clusterinfoimport.go
@@ -116,7 +116,7 @@ func (c *FakeClusterInfoImports) UpdateStatus(ctx context.Context, clusterInfoIm
 // Delete takes name of the clusterInfoImport and deletes it. Returns an error if one occurs.
 func (c *FakeClusterInfoImports) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(clusterinfoimportsResource, c.ns, name), &v1alpha1.ClusterInfoImport{})
+		Invokes(testing.NewDeleteActionWithOptions(clusterinfoimportsResource, c.ns, name, opts), &v1alpha1.ClusterInfoImport{})
 
 	return err
 }

--- a/multicluster/pkg/client/clientset/versioned/typed/multicluster/v1alpha1/fake/fake_clusterset.go
+++ b/multicluster/pkg/client/clientset/versioned/typed/multicluster/v1alpha1/fake/fake_clusterset.go
@@ -116,7 +116,7 @@ func (c *FakeClusterSets) UpdateStatus(ctx context.Context, clusterSet *v1alpha1
 // Delete takes name of the clusterSet and deletes it. Returns an error if one occurs.
 func (c *FakeClusterSets) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(clustersetsResource, c.ns, name), &v1alpha1.ClusterSet{})
+		Invokes(testing.NewDeleteActionWithOptions(clustersetsResource, c.ns, name, opts), &v1alpha1.ClusterSet{})
 
 	return err
 }

--- a/multicluster/pkg/client/clientset/versioned/typed/multicluster/v1alpha1/fake/fake_gateway.go
+++ b/multicluster/pkg/client/clientset/versioned/typed/multicluster/v1alpha1/fake/fake_gateway.go
@@ -104,7 +104,7 @@ func (c *FakeGateways) Update(ctx context.Context, gateway *v1alpha1.Gateway, op
 // Delete takes name of the gateway and deletes it. Returns an error if one occurs.
 func (c *FakeGateways) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(gatewaysResource, c.ns, name), &v1alpha1.Gateway{})
+		Invokes(testing.NewDeleteActionWithOptions(gatewaysResource, c.ns, name, opts), &v1alpha1.Gateway{})
 
 	return err
 }

--- a/multicluster/pkg/client/clientset/versioned/typed/multicluster/v1alpha1/fake/fake_memberclusterannounce.go
+++ b/multicluster/pkg/client/clientset/versioned/typed/multicluster/v1alpha1/fake/fake_memberclusterannounce.go
@@ -104,7 +104,7 @@ func (c *FakeMemberClusterAnnounces) Update(ctx context.Context, memberClusterAn
 // Delete takes name of the memberClusterAnnounce and deletes it. Returns an error if one occurs.
 func (c *FakeMemberClusterAnnounces) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(memberclusterannouncesResource, c.ns, name), &v1alpha1.MemberClusterAnnounce{})
+		Invokes(testing.NewDeleteActionWithOptions(memberclusterannouncesResource, c.ns, name, opts), &v1alpha1.MemberClusterAnnounce{})
 
 	return err
 }

--- a/multicluster/pkg/client/clientset/versioned/typed/multicluster/v1alpha1/fake/fake_resourceexport.go
+++ b/multicluster/pkg/client/clientset/versioned/typed/multicluster/v1alpha1/fake/fake_resourceexport.go
@@ -116,7 +116,7 @@ func (c *FakeResourceExports) UpdateStatus(ctx context.Context, resourceExport *
 // Delete takes name of the resourceExport and deletes it. Returns an error if one occurs.
 func (c *FakeResourceExports) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(resourceexportsResource, c.ns, name), &v1alpha1.ResourceExport{})
+		Invokes(testing.NewDeleteActionWithOptions(resourceexportsResource, c.ns, name, opts), &v1alpha1.ResourceExport{})
 
 	return err
 }

--- a/multicluster/pkg/client/clientset/versioned/typed/multicluster/v1alpha1/fake/fake_resourceexportfilter.go
+++ b/multicluster/pkg/client/clientset/versioned/typed/multicluster/v1alpha1/fake/fake_resourceexportfilter.go
@@ -116,7 +116,7 @@ func (c *FakeResourceExportFilters) UpdateStatus(ctx context.Context, resourceEx
 // Delete takes name of the resourceExportFilter and deletes it. Returns an error if one occurs.
 func (c *FakeResourceExportFilters) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(resourceexportfiltersResource, c.ns, name), &v1alpha1.ResourceExportFilter{})
+		Invokes(testing.NewDeleteActionWithOptions(resourceexportfiltersResource, c.ns, name, opts), &v1alpha1.ResourceExportFilter{})
 
 	return err
 }

--- a/multicluster/pkg/client/clientset/versioned/typed/multicluster/v1alpha1/fake/fake_resourceimport.go
+++ b/multicluster/pkg/client/clientset/versioned/typed/multicluster/v1alpha1/fake/fake_resourceimport.go
@@ -116,7 +116,7 @@ func (c *FakeResourceImports) UpdateStatus(ctx context.Context, resourceImport *
 // Delete takes name of the resourceImport and deletes it. Returns an error if one occurs.
 func (c *FakeResourceImports) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(resourceimportsResource, c.ns, name), &v1alpha1.ResourceImport{})
+		Invokes(testing.NewDeleteActionWithOptions(resourceimportsResource, c.ns, name, opts), &v1alpha1.ResourceImport{})
 
 	return err
 }

--- a/multicluster/pkg/client/clientset/versioned/typed/multicluster/v1alpha1/fake/fake_resourceimportfilter.go
+++ b/multicluster/pkg/client/clientset/versioned/typed/multicluster/v1alpha1/fake/fake_resourceimportfilter.go
@@ -116,7 +116,7 @@ func (c *FakeResourceImportFilters) UpdateStatus(ctx context.Context, resourceIm
 // Delete takes name of the resourceImportFilter and deletes it. Returns an error if one occurs.
 func (c *FakeResourceImportFilters) Delete(ctx context.Context, name string, opts v1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(resourceimportfiltersResource, c.ns, name), &v1alpha1.ResourceImportFilter{})
+		Invokes(testing.NewDeleteActionWithOptions(resourceimportfiltersResource, c.ns, name, opts), &v1alpha1.ResourceImportFilter{})
 
 	return err
 }

--- a/multicluster/pkg/client/clientset/versioned/typed/multicluster/v1alpha1/multicluster_client.go
+++ b/multicluster/pkg/client/clientset/versioned/typed/multicluster/v1alpha1/multicluster_client.go
@@ -18,6 +18,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"net/http"
+
 	v1alpha1 "antrea.io/antrea/multicluster/apis/multicluster/v1alpha1"
 	"antrea.io/antrea/multicluster/pkg/client/clientset/versioned/scheme"
 	rest "k8s.io/client-go/rest"
@@ -78,12 +80,28 @@ func (c *MulticlusterV1alpha1Client) ResourceImportFilters(namespace string) Res
 }
 
 // NewForConfig creates a new MulticlusterV1alpha1Client for the given config.
+// NewForConfig is equivalent to NewForConfigAndClient(c, httpClient),
+// where httpClient was generated with rest.HTTPClientFor(c).
 func NewForConfig(c *rest.Config) (*MulticlusterV1alpha1Client, error) {
 	config := *c
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	httpClient, err := rest.HTTPClientFor(&config)
+	if err != nil {
+		return nil, err
+	}
+	return NewForConfigAndClient(&config, httpClient)
+}
+
+// NewForConfigAndClient creates a new MulticlusterV1alpha1Client for the given config and http client.
+// Note the http client provided takes precedence over the configured transport values.
+func NewForConfigAndClient(c *rest.Config, h *http.Client) (*MulticlusterV1alpha1Client, error) {
+	config := *c
+	if err := setConfigDefaults(&config); err != nil {
+		return nil, err
+	}
+	client, err := rest.RESTClientForConfigAndClient(&config, h)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
During the upgrade from K8s v1.21 dependencies to K8s v1.24, I forgot to
take care of multicluster code generation.

Signed-off-by: Antonin Bas <abas@vmware.com>