### PR TITLE
Increase resources for antrea-mc-controller

### DIFF
--- a/multicluster/build/yamls/antrea-multicluster-leader-global.yml
+++ b/multicluster/build/yamls/antrea-multicluster-leader-global.yml
@@ -2626,11 +2626,9 @@ spec:
                                 description: The application protocol for this port.
                                   This field follows standard Kubernetes label syntax.
                                   Un-prefixed names are reserved for IANA standard
-                                  service names (as per RFC-6335 and http://www.iana.org/assignments/service-names).
+                                  service names (as per RFC-6335 and https://www.iana.org/assignments/service-names).
                                   Non-standard protocols should use prefixed names
-                                  such as mycompany.com/my-custom-protocol. This is
-                                  a beta field that is guarded by the ServiceAppProtocol
-                                  feature gate and enabled by default.
+                                  such as mycompany.com/my-custom-protocol.
                                 type: string
                               name:
                                 description: The name of this port.  This must match
@@ -2732,11 +2730,11 @@ spec:
                         description: allocateLoadBalancerNodePorts defines if NodePorts
                           will be automatically allocated for services with type LoadBalancer.  Default
                           is "true". It may be set to "false" if the cluster load-balancer
-                          does not rely on NodePorts. allocateLoadBalancerNodePorts
-                          may only be set for services with type LoadBalancer and
-                          will be cleared if the type is changed to any other type.
-                          This field is alpha-level and is only honored by servers
-                          that enable the ServiceLBNodePortControl feature.
+                          does not rely on NodePorts.  If the caller requests specific
+                          NodePorts (by specifying a value), those requests will be
+                          respected, regardless of this field. This field may only
+                          be set for services with type LoadBalancer and will be cleared
+                          if the type is changed to any other type.
                         type: boolean
                       clusterIP:
                         description: 'clusterIP is the IP address of the service and
@@ -2779,14 +2777,11 @@ spec:
                           a Service to type ExternalName.  If this field is not specified,
                           it will be initialized from the clusterIP field.  If this
                           field is specified, clients must ensure that clusterIPs[0]
-                          and clusterIP have the same value. \n Unless the \"IPv6DualStack\"
-                          feature gate is enabled, this field is limited to one value,
-                          which must be the same as the clusterIP field.  If the feature
-                          gate is enabled, this field may hold a maximum of two entries
-                          (dual-stack IPs, in either order).  These IPs must correspond
-                          to the values of the ipFamilies field. Both clusterIPs and
-                          ipFamilies are governed by the ipFamilyPolicy field. More
-                          info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies"
+                          and clusterIP have the same value. \n This field may hold
+                          a maximum of two entries (dual-stack IPs, in either order).
+                          These IPs must correspond to the values of the ipFamilies
+                          field. Both clusterIPs and ipFamilies are governed by the
+                          ipFamilyPolicy field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies"
                         items:
                           type: string
                         type: array
@@ -2841,18 +2836,17 @@ spec:
                         type: string
                       ipFamilies:
                         description: "IPFamilies is a list of IP families (e.g. IPv4,
-                          IPv6) assigned to this service, and is gated by the \"IPv6DualStack\"
-                          feature gate.  This field is usually assigned automatically
-                          based on cluster configuration and the ipFamilyPolicy field.
-                          If this field is specified manually, the requested family
-                          is available in the cluster, and ipFamilyPolicy allows it,
-                          it will be used; otherwise creation of the service will
-                          fail.  This field is conditionally mutable: it allows for
+                          IPv6) assigned to this service. This field is usually assigned
+                          automatically based on cluster configuration and the ipFamilyPolicy
+                          field. If this field is specified manually, the requested
+                          family is available in the cluster, and ipFamilyPolicy allows
+                          it, it will be used; otherwise creation of the service will
+                          fail. This field is conditionally mutable: it allows for
                           adding or removing a secondary IP family, but it does not
-                          allow changing the primary IP family of the Service.  Valid
+                          allow changing the primary IP family of the Service. Valid
                           values are \"IPv4\" and \"IPv6\".  This field only applies
                           to Services of types ClusterIP, NodePort, and LoadBalancer,
-                          and does apply to \"headless\" services.  This field will
+                          and does apply to \"headless\" services. This field will
                           be wiped when updating a Service to type ExternalName. \n
                           This field may hold a maximum of two entries (dual-stack
                           families, in either order).  These families must correspond
@@ -2868,15 +2862,14 @@ spec:
                         x-kubernetes-list-type: atomic
                       ipFamilyPolicy:
                         description: IPFamilyPolicy represents the dual-stack-ness
-                          requested or required by this Service, and is gated by the
-                          "IPv6DualStack" feature gate.  If there is no value provided,
-                          then this field will be set to SingleStack. Services can
-                          be "SingleStack" (a single IP family), "PreferDualStack"
+                          requested or required by this Service. If there is no value
+                          provided, then this field will be set to SingleStack. Services
+                          can be "SingleStack" (a single IP family), "PreferDualStack"
                           (two IP families on dual-stack configured clusters or a
                           single IP family on single-stack clusters), or "RequireDualStack"
                           (two IP families on dual-stack configured clusters, otherwise
                           fail). The ipFamilies and clusterIPs fields depend on the
-                          value of this field.  This field will be wiped when updating
+                          value of this field. This field will be wiped when updating
                           a service to type ExternalName.
                         type: string
                       loadBalancerClass:
@@ -2898,19 +2891,23 @@ spec:
                           when a service is updated to a non 'LoadBalancer' type.
                         type: string
                       loadBalancerIP:
-                        description: 'Only applies to Service Type: LoadBalancer LoadBalancer
-                          will get created with the IP specified in this field. This
-                          feature depends on whether the underlying cloud-provider
+                        description: 'Only applies to Service Type: LoadBalancer.
+                          This feature depends on whether the underlying cloud-provider
                           supports specifying the loadBalancerIP when a load balancer
                           is created. This field will be ignored if the cloud-provider
-                          does not support the feature.'
+                          does not support the feature. Deprecated: This field was
+                          under-specified and its meaning varies across implementations,
+                          and it cannot support dual-stack. As of Kubernetes v1.24,
+                          users are encouraged to use implementation-specific annotations
+                          when available. This field may be removed in a future API
+                          version.'
                         type: string
                       loadBalancerSourceRanges:
                         description: 'If specified and supported by the platform,
                           this will restrict traffic through the cloud-provider load-balancer
                           will be restricted to the specified client IPs. This field
                           will be ignored if the cloud-provider does not support the
-                          feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+                          feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/'
                         items:
                           type: string
                         type: array
@@ -2925,11 +2922,9 @@ spec:
                               description: The application protocol for this port.
                                 This field follows standard Kubernetes label syntax.
                                 Un-prefixed names are reserved for IANA standard service
-                                names (as per RFC-6335 and http://www.iana.org/assignments/service-names).
+                                names (as per RFC-6335 and https://www.iana.org/assignments/service-names).
                                 Non-standard protocols should use prefixed names such
-                                as mycompany.com/my-custom-protocol. This is a beta
-                                field that is guarded by the ServiceAppProtocol feature
-                                gate and enabled by default.
+                                as mycompany.com/my-custom-protocol.
                               type: string
                             name:
                               description: The name of this port within the service.
@@ -3006,6 +3001,7 @@ spec:
                           to types ClusterIP, NodePort, and LoadBalancer. Ignored
                           if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
                         type: object
+                        x-kubernetes-map-type: atomic
                       sessionAffinity:
                         description: 'Supports "ClientIP" and "None". Used to maintain
                           session affinity. Enable client IP based session affinity.
@@ -3028,26 +3024,6 @@ spec:
                                 type: integer
                             type: object
                         type: object
-                      topologyKeys:
-                        description: topologyKeys is a preference-order list of topology
-                          keys which implementations of services should use to preferentially
-                          sort endpoints when accessing this Service, it can not be
-                          used at the same time as externalTrafficPolicy=Local. Topology
-                          keys must be valid label keys and at most 16 keys may be
-                          specified. Endpoints are chosen based on the first topology
-                          key with available backends. If this field is specified
-                          and all entries have no backends that match the topology
-                          of the client, the service has no backends for that client
-                          and connections should fail. The special value "*" may be
-                          used to mean "any topology". This catch-all value, if used,
-                          only makes sense as the last value in the list. If this
-                          is not specified or empty, no topology constraints will
-                          be applied. This field is alpha-level and is only honored
-                          by servers that enable the ServiceTopology feature. This
-                          field is deprecated and will be removed in a future version.
-                        items:
-                          type: string
-                        type: array
                       type:
                         description: 'type determines how the Service is exposed.
                           Defaults to ClusterIP. Valid options are ExternalName, ClusterIP,
@@ -5459,11 +5435,9 @@ spec:
                                 description: The application protocol for this port.
                                   This field follows standard Kubernetes label syntax.
                                   Un-prefixed names are reserved for IANA standard
-                                  service names (as per RFC-6335 and http://www.iana.org/assignments/service-names).
+                                  service names (as per RFC-6335 and https://www.iana.org/assignments/service-names).
                                   Non-standard protocols should use prefixed names
-                                  such as mycompany.com/my-custom-protocol. This is
-                                  a beta field that is guarded by the ServiceAppProtocol
-                                  feature gate and enabled by default.
+                                  such as mycompany.com/my-custom-protocol.
                                 type: string
                               name:
                                 description: The name of this port.  This must match

--- a/multicluster/build/yamls/antrea-multicluster-leader-namespaced.yml
+++ b/multicluster/build/yamls/antrea-multicluster-leader-namespaced.yml
@@ -445,12 +445,8 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
         resources:
-          limits:
-            cpu: 100m
-            memory: 30Mi
           requests:
-            cpu: 100m
-            memory: 20Mi
+            cpu: 200m
         securityContext:
           allowPrivilegeEscalation: false
         volumeMounts:

--- a/multicluster/build/yamls/antrea-multicluster-member.yml
+++ b/multicluster/build/yamls/antrea-multicluster-member.yml
@@ -1132,12 +1132,8 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
         resources:
-          limits:
-            cpu: 100m
-            memory: 30Mi
           requests:
-            cpu: 100m
-            memory: 20Mi
+            cpu: 200m
         securityContext:
           allowPrivilegeEscalation: false
         volumeMounts:

--- a/multicluster/config/crd/bases/multicluster.crd.antrea.io_resourceexports.yaml
+++ b/multicluster/config/crd/bases/multicluster.crd.antrea.io_resourceexports.yaml
@@ -2290,11 +2290,9 @@ spec:
                                 description: The application protocol for this port.
                                   This field follows standard Kubernetes label syntax.
                                   Un-prefixed names are reserved for IANA standard
-                                  service names (as per RFC-6335 and http://www.iana.org/assignments/service-names).
+                                  service names (as per RFC-6335 and https://www.iana.org/assignments/service-names).
                                   Non-standard protocols should use prefixed names
-                                  such as mycompany.com/my-custom-protocol. This is
-                                  a beta field that is guarded by the ServiceAppProtocol
-                                  feature gate and enabled by default.
+                                  such as mycompany.com/my-custom-protocol.
                                 type: string
                               name:
                                 description: The name of this port.  This must match
@@ -2396,11 +2394,11 @@ spec:
                         description: allocateLoadBalancerNodePorts defines if NodePorts
                           will be automatically allocated for services with type LoadBalancer.  Default
                           is "true". It may be set to "false" if the cluster load-balancer
-                          does not rely on NodePorts. allocateLoadBalancerNodePorts
-                          may only be set for services with type LoadBalancer and
-                          will be cleared if the type is changed to any other type.
-                          This field is alpha-level and is only honored by servers
-                          that enable the ServiceLBNodePortControl feature.
+                          does not rely on NodePorts.  If the caller requests specific
+                          NodePorts (by specifying a value), those requests will be
+                          respected, regardless of this field. This field may only
+                          be set for services with type LoadBalancer and will be cleared
+                          if the type is changed to any other type.
                         type: boolean
                       clusterIP:
                         description: 'clusterIP is the IP address of the service and
@@ -2443,14 +2441,11 @@ spec:
                           a Service to type ExternalName.  If this field is not specified,
                           it will be initialized from the clusterIP field.  If this
                           field is specified, clients must ensure that clusterIPs[0]
-                          and clusterIP have the same value. \n Unless the \"IPv6DualStack\"
-                          feature gate is enabled, this field is limited to one value,
-                          which must be the same as the clusterIP field.  If the feature
-                          gate is enabled, this field may hold a maximum of two entries
-                          (dual-stack IPs, in either order).  These IPs must correspond
-                          to the values of the ipFamilies field. Both clusterIPs and
-                          ipFamilies are governed by the ipFamilyPolicy field. More
-                          info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies"
+                          and clusterIP have the same value. \n This field may hold
+                          a maximum of two entries (dual-stack IPs, in either order).
+                          These IPs must correspond to the values of the ipFamilies
+                          field. Both clusterIPs and ipFamilies are governed by the
+                          ipFamilyPolicy field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies"
                         items:
                           type: string
                         type: array
@@ -2505,18 +2500,17 @@ spec:
                         type: string
                       ipFamilies:
                         description: "IPFamilies is a list of IP families (e.g. IPv4,
-                          IPv6) assigned to this service, and is gated by the \"IPv6DualStack\"
-                          feature gate.  This field is usually assigned automatically
-                          based on cluster configuration and the ipFamilyPolicy field.
-                          If this field is specified manually, the requested family
-                          is available in the cluster, and ipFamilyPolicy allows it,
-                          it will be used; otherwise creation of the service will
-                          fail.  This field is conditionally mutable: it allows for
+                          IPv6) assigned to this service. This field is usually assigned
+                          automatically based on cluster configuration and the ipFamilyPolicy
+                          field. If this field is specified manually, the requested
+                          family is available in the cluster, and ipFamilyPolicy allows
+                          it, it will be used; otherwise creation of the service will
+                          fail. This field is conditionally mutable: it allows for
                           adding or removing a secondary IP family, but it does not
-                          allow changing the primary IP family of the Service.  Valid
+                          allow changing the primary IP family of the Service. Valid
                           values are \"IPv4\" and \"IPv6\".  This field only applies
                           to Services of types ClusterIP, NodePort, and LoadBalancer,
-                          and does apply to \"headless\" services.  This field will
+                          and does apply to \"headless\" services. This field will
                           be wiped when updating a Service to type ExternalName. \n
                           This field may hold a maximum of two entries (dual-stack
                           families, in either order).  These families must correspond
@@ -2532,15 +2526,14 @@ spec:
                         x-kubernetes-list-type: atomic
                       ipFamilyPolicy:
                         description: IPFamilyPolicy represents the dual-stack-ness
-                          requested or required by this Service, and is gated by the
-                          "IPv6DualStack" feature gate.  If there is no value provided,
-                          then this field will be set to SingleStack. Services can
-                          be "SingleStack" (a single IP family), "PreferDualStack"
+                          requested or required by this Service. If there is no value
+                          provided, then this field will be set to SingleStack. Services
+                          can be "SingleStack" (a single IP family), "PreferDualStack"
                           (two IP families on dual-stack configured clusters or a
                           single IP family on single-stack clusters), or "RequireDualStack"
                           (two IP families on dual-stack configured clusters, otherwise
                           fail). The ipFamilies and clusterIPs fields depend on the
-                          value of this field.  This field will be wiped when updating
+                          value of this field. This field will be wiped when updating
                           a service to type ExternalName.
                         type: string
                       loadBalancerClass:
@@ -2562,19 +2555,23 @@ spec:
                           when a service is updated to a non 'LoadBalancer' type.
                         type: string
                       loadBalancerIP:
-                        description: 'Only applies to Service Type: LoadBalancer LoadBalancer
-                          will get created with the IP specified in this field. This
-                          feature depends on whether the underlying cloud-provider
+                        description: 'Only applies to Service Type: LoadBalancer.
+                          This feature depends on whether the underlying cloud-provider
                           supports specifying the loadBalancerIP when a load balancer
                           is created. This field will be ignored if the cloud-provider
-                          does not support the feature.'
+                          does not support the feature. Deprecated: This field was
+                          under-specified and its meaning varies across implementations,
+                          and it cannot support dual-stack. As of Kubernetes v1.24,
+                          users are encouraged to use implementation-specific annotations
+                          when available. This field may be removed in a future API
+                          version.'
                         type: string
                       loadBalancerSourceRanges:
                         description: 'If specified and supported by the platform,
                           this will restrict traffic through the cloud-provider load-balancer
                           will be restricted to the specified client IPs. This field
                           will be ignored if the cloud-provider does not support the
-                          feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/'
+                          feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/'
                         items:
                           type: string
                         type: array
@@ -2589,11 +2586,9 @@ spec:
                               description: The application protocol for this port.
                                 This field follows standard Kubernetes label syntax.
                                 Un-prefixed names are reserved for IANA standard service
-                                names (as per RFC-6335 and http://www.iana.org/assignments/service-names).
+                                names (as per RFC-6335 and https://www.iana.org/assignments/service-names).
                                 Non-standard protocols should use prefixed names such
-                                as mycompany.com/my-custom-protocol. This is a beta
-                                field that is guarded by the ServiceAppProtocol feature
-                                gate and enabled by default.
+                                as mycompany.com/my-custom-protocol.
                               type: string
                             name:
                               description: The name of this port within the service.
@@ -2670,6 +2665,7 @@ spec:
                           to types ClusterIP, NodePort, and LoadBalancer. Ignored
                           if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
                         type: object
+                        x-kubernetes-map-type: atomic
                       sessionAffinity:
                         description: 'Supports "ClientIP" and "None". Used to maintain
                           session affinity. Enable client IP based session affinity.
@@ -2692,26 +2688,6 @@ spec:
                                 type: integer
                             type: object
                         type: object
-                      topologyKeys:
-                        description: topologyKeys is a preference-order list of topology
-                          keys which implementations of services should use to preferentially
-                          sort endpoints when accessing this Service, it can not be
-                          used at the same time as externalTrafficPolicy=Local. Topology
-                          keys must be valid label keys and at most 16 keys may be
-                          specified. Endpoints are chosen based on the first topology
-                          key with available backends. If this field is specified
-                          and all entries have no backends that match the topology
-                          of the client, the service has no backends for that client
-                          and connections should fail. The special value "*" may be
-                          used to mean "any topology". This catch-all value, if used,
-                          only makes sense as the last value in the list. If this
-                          is not specified or empty, no topology constraints will
-                          be applied. This field is alpha-level and is only honored
-                          by servers that enable the ServiceTopology feature. This
-                          field is deprecated and will be removed in a future version.
-                        items:
-                          type: string
-                        type: array
                       type:
                         description: 'type determines how the Service is exposed.
                           Defaults to ClusterIP. Valid options are ExternalName, ClusterIP,

--- a/multicluster/config/crd/bases/multicluster.crd.antrea.io_resourceimports.yaml
+++ b/multicluster/config/crd/bases/multicluster.crd.antrea.io_resourceimports.yaml
@@ -2292,11 +2292,9 @@ spec:
                                 description: The application protocol for this port.
                                   This field follows standard Kubernetes label syntax.
                                   Un-prefixed names are reserved for IANA standard
-                                  service names (as per RFC-6335 and http://www.iana.org/assignments/service-names).
+                                  service names (as per RFC-6335 and https://www.iana.org/assignments/service-names).
                                   Non-standard protocols should use prefixed names
-                                  such as mycompany.com/my-custom-protocol. This is
-                                  a beta field that is guarded by the ServiceAppProtocol
-                                  feature gate and enabled by default.
+                                  such as mycompany.com/my-custom-protocol.
                                 type: string
                               name:
                                 description: The name of this port.  This must match

--- a/multicluster/config/manager/manager.yaml
+++ b/multicluster/config/manager/manager.yaml
@@ -40,11 +40,7 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
         resources:
-          limits:
-            cpu: 100m
-            memory: 30Mi
           requests:
-            cpu: 100m
-            memory: 20Mi
+            cpu: 200m
       serviceAccountName: controller
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
The default resources created by kube-builder are not enough,
The step to create self-signed certificates may take up to 10s
per my observation, so increase the cpu and leave memory to
K8s default one.

Signed-off-by: Lan Luo <luola@vmware.com>