### PR TITLE
multicast: make igmp query interval configurable

### DIFF
--- a/build/charts/antrea/README.md
+++ b/build/charts/antrea/README.md
@@ -75,7 +75,8 @@ Kubernetes: `>= 1.16.0-0`
 | ipsec.psk | string | `"changeme"` | Preshared Key (PSK) for IKE authentication. It will be stored in a secret and passed to antrea-agent as an environment variable. |
 | kubeAPIServerOverride | string | `""` | Address of Kubernetes apiserver, to override any value provided in kubeconfig or InClusterConfig. |
 | logVerbosity | int | `0` |  |
-| multicastInterfaces | list | `[]` | Names of the interfaces on Nodes that are used to forward multicast traffic. |
+| multicast.igmpQueryInterval | string | `"125s"` | The interval at which the antrea-agent sends IGMP queries to Pods. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". |
+| multicast.multicastInterfaces | list | `[]` | Names of the interfaces on Nodes that are used to forward multicast traffic. |
 | noSNAT | bool | `false` | Whether or not to SNAT (using the Node IP) the egress traffic from a Pod to the external network. |
 | nodeIPAM.clusterCIDRs | list | `[]` | CIDR ranges to use when allocating Pod IP addresses. |
 | nodeIPAM.enable | bool | `false` | Enable Node IPAM in Antrea |

--- a/build/charts/antrea/conf/antrea-agent.conf
+++ b/build/charts/antrea/conf/antrea-agent.conf
@@ -217,12 +217,19 @@ tlsMinVersion: {{ .Values.tlsMinVersion | quote }}
 # 3. The Node IP
 transportInterface: {{ .Values.transportInterface | quote }}
 
+multicast:
+{{- with .Values.multicast }}
 # The names of the interfaces on Nodes that are used to forward multicast traffic.
 # Defaults to transport interface if not set.
-multicastInterfaces:
-{{- with .Values.multicastInterfaces }}
-{{- toYaml . | nindent 2 }}
-{{- end }}
+  multicastInterfaces:
+  {{- with .multicastInterfaces }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+
+# The interval at which the antrea-agent sends IGMP queries to Pods.
+# Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+  igmpQueryInterval: {{ .igmpQueryInterval | quote }}
+{{- end}}
 
 # The network CIDRs of the interface on Node which is used for tunneling or routing the traffic across
 # Nodes. If there are multiple interfaces configured the same network CIDR, the first one is used. The

--- a/build/charts/antrea/values.yaml
+++ b/build/charts/antrea/values.yaml
@@ -28,8 +28,14 @@ transportInterface: ""
 # -- Network CIDRs of the interface on Node which is used for tunneling or
 # routing the traffic across Nodes.
 transportInterfaceCIDRs: []
-# -- Names of the interfaces on Nodes that are used to forward multicast traffic.
-multicastInterfaces: []
+
+multicast:
+  # -- Names of the interfaces on Nodes that are used to forward multicast traffic.
+  multicastInterfaces: []
+  # -- The interval at which the antrea-agent sends IGMP queries to Pods.
+  # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+  igmpQueryInterval: "125s"
+
 # -- Default MTU to use for the host gateway interface and the network interface
 # of each Pod. By default, antrea-agent will discover the MTU of the Node's
 # primary interface and adjust it to accommodate for tunnel encapsulation

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -266,9 +266,14 @@ data:
     # 3. The Node IP
     transportInterface: ""
 
+    multicast:
     # The names of the interfaces on Nodes that are used to forward multicast traffic.
     # Defaults to transport interface if not set.
-    multicastInterfaces:
+      multicastInterfaces:
+
+    # The interval at which the antrea-agent sends IGMP queries to Pods.
+    # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+      igmpQueryInterval: "125s"
 
     # The network CIDRs of the interface on Node which is used for tunneling or routing the traffic across
     # Nodes. If there are multiple interfaces configured the same network CIDR, the first one is used. The
@@ -3486,7 +3491,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 4554a36b927c6e64fdbc53b4d4c64673d48c9c829ec444e3be6e699ade8481b6
+        checksum/config: 0cc20edc3fc882f0ea9bd3450fbab504858feeff47e1d3f09d8f6ebacd741dbe
       labels:
         app: antrea
         component: antrea-agent
@@ -3726,7 +3731,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 4554a36b927c6e64fdbc53b4d4c64673d48c9c829ec444e3be6e699ade8481b6
+        checksum/config: 0cc20edc3fc882f0ea9bd3450fbab504858feeff47e1d3f09d8f6ebacd741dbe
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -266,9 +266,14 @@ data:
     # 3. The Node IP
     transportInterface: ""
 
+    multicast:
     # The names of the interfaces on Nodes that are used to forward multicast traffic.
     # Defaults to transport interface if not set.
-    multicastInterfaces:
+      multicastInterfaces:
+
+    # The interval at which the antrea-agent sends IGMP queries to Pods.
+    # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+      igmpQueryInterval: "125s"
 
     # The network CIDRs of the interface on Node which is used for tunneling or routing the traffic across
     # Nodes. If there are multiple interfaces configured the same network CIDR, the first one is used. The
@@ -3486,7 +3491,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 4554a36b927c6e64fdbc53b4d4c64673d48c9c829ec444e3be6e699ade8481b6
+        checksum/config: 0cc20edc3fc882f0ea9bd3450fbab504858feeff47e1d3f09d8f6ebacd741dbe
       labels:
         app: antrea
         component: antrea-agent
@@ -3728,7 +3733,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 4554a36b927c6e64fdbc53b4d4c64673d48c9c829ec444e3be6e699ade8481b6
+        checksum/config: 0cc20edc3fc882f0ea9bd3450fbab504858feeff47e1d3f09d8f6ebacd741dbe
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -266,9 +266,14 @@ data:
     # 3. The Node IP
     transportInterface: ""
 
+    multicast:
     # The names of the interfaces on Nodes that are used to forward multicast traffic.
     # Defaults to transport interface if not set.
-    multicastInterfaces:
+      multicastInterfaces:
+
+    # The interval at which the antrea-agent sends IGMP queries to Pods.
+    # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+      igmpQueryInterval: "125s"
 
     # The network CIDRs of the interface on Node which is used for tunneling or routing the traffic across
     # Nodes. If there are multiple interfaces configured the same network CIDR, the first one is used. The
@@ -3486,7 +3491,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: edef4c00e4f28a10dc1e077086ef68641a9a3b53d0fe7d47ff3dafc2ce5d5c9b
+        checksum/config: 6b6be76fd37d8fdac7783fcd026b6f34e993630c12c339b1dafa99ba5b36cf00
       labels:
         app: antrea
         component: antrea-agent
@@ -3726,7 +3731,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: edef4c00e4f28a10dc1e077086ef68641a9a3b53d0fe7d47ff3dafc2ce5d5c9b
+        checksum/config: 6b6be76fd37d8fdac7783fcd026b6f34e993630c12c339b1dafa99ba5b36cf00
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -279,9 +279,14 @@ data:
     # 3. The Node IP
     transportInterface: ""
 
+    multicast:
     # The names of the interfaces on Nodes that are used to forward multicast traffic.
     # Defaults to transport interface if not set.
-    multicastInterfaces:
+      multicastInterfaces:
+
+    # The interval at which the antrea-agent sends IGMP queries to Pods.
+    # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+      igmpQueryInterval: "125s"
 
     # The network CIDRs of the interface on Node which is used for tunneling or routing the traffic across
     # Nodes. If there are multiple interfaces configured the same network CIDR, the first one is used. The
@@ -3499,7 +3504,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 50cc962db93c0354f5eaa088e51d690e779692979cbafac0c3e27a88fc2c0c7c
+        checksum/config: d289c621cfdc7aee9e8320c0398e76f302591b0adc12156d470320ee9839c073
         checksum/ipsec-secret: d0eb9c52d0cd4311b6d252a951126bf9bea27ec05590bed8a394f0f792dcb2a4
       labels:
         app: antrea
@@ -3775,7 +3780,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 50cc962db93c0354f5eaa088e51d690e779692979cbafac0c3e27a88fc2c0c7c
+        checksum/config: d289c621cfdc7aee9e8320c0398e76f302591b0adc12156d470320ee9839c073
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -266,9 +266,14 @@ data:
     # 3. The Node IP
     transportInterface: ""
 
+    multicast:
     # The names of the interfaces on Nodes that are used to forward multicast traffic.
     # Defaults to transport interface if not set.
-    multicastInterfaces:
+      multicastInterfaces:
+
+    # The interval at which the antrea-agent sends IGMP queries to Pods.
+    # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+      igmpQueryInterval: "125s"
 
     # The network CIDRs of the interface on Node which is used for tunneling or routing the traffic across
     # Nodes. If there are multiple interfaces configured the same network CIDR, the first one is used. The
@@ -3486,7 +3491,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: f7414e9171ab246b09dc380bc7934ebac81af7a5ef7bd3f73d661b6301040768
+        checksum/config: 976e8c918d8c411df17238dd333a51f9adfdfafe2d6d480d7652f16be02fff3c
       labels:
         app: antrea
         component: antrea-agent
@@ -3726,7 +3731,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: f7414e9171ab246b09dc380bc7934ebac81af7a5ef7bd3f73d661b6301040768
+        checksum/config: 976e8c918d8c411df17238dd333a51f9adfdfafe2d6d480d7652f16be02fff3c
       labels:
         app: antrea
         component: antrea-controller

--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -589,9 +589,10 @@ func run(o *Options) error {
 			nodeConfig,
 			ifaceStore,
 			multicastSocket,
-			sets.NewString(append(o.config.MulticastInterfaces, nodeConfig.NodeTransportInterfaceName)...),
+			sets.NewString(append(o.config.Multicast.MulticastInterfaces, nodeConfig.NodeTransportInterfaceName)...),
 			ovsBridgeClient,
-			podUpdateChannel)
+			podUpdateChannel,
+			o.igmpQueryInterval)
 		if err := mcastController.Initialize(); err != nil {
 			return err
 		}

--- a/hack/generate-manifest.sh
+++ b/hack/generate-manifest.sh
@@ -307,7 +307,7 @@ if $FLEXIBLE_IPAM; then
 fi
 
 if $MULTICAST; then
-    HELM_VALUES+=("trafficEncapMode=noEncap" "featureGates.Multicast=true" "multicastInterfaces={$MULTICAST_INTERFACES}")
+    HELM_VALUES+=("trafficEncapMode=noEncap" "featureGates.Multicast=true" "multicast.multicastInterfaces={$MULTICAST_INTERFACES}")
 fi
 
 if $ALLFEATURES; then

--- a/pkg/agent/multicast/mcast_controller_test.go
+++ b/pkg/agent/multicast/mcast_controller_test.go
@@ -217,7 +217,7 @@ func TestClearStaleGroups(t *testing.T) {
 		wg.Done()
 	}()
 	now := time.Now()
-	validUpdateTime := now.Add(-queryInterval)
+	validUpdateTime := now.Add(-mctrl.queryInterval)
 	validGroups := []*GroupMemberStatus{
 		{
 			group:          net.ParseIP("224.96.1.2"),
@@ -230,7 +230,7 @@ func TestClearStaleGroups(t *testing.T) {
 			lastIGMPReport: validUpdateTime,
 		},
 	}
-	staleUpdateTime := now.Add(-mcastGroupTimeout - time.Second)
+	staleUpdateTime := now.Add(-mctrl.mcastGroupTimeout - time.Second)
 	staleGroups := []*GroupMemberStatus{
 		{
 			group:          net.ParseIP("224.96.1.4"),
@@ -364,7 +364,8 @@ func newMockMulticastController(t *testing.T) *Controller {
 	mockOFClient.EXPECT().RegisterPacketInHandler(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 	groupAllocator := openflow.NewGroupAllocator(false)
 	podUpdateSubscriber := channel.NewSubscribableChannel("PodUpdate", 100)
-	mctrl := NewMulticastController(mockOFClient, groupAllocator, nodeConfig, mockIfaceStore, mockMulticastSocket, sets.NewString(), ovsClient, podUpdateSubscriber)
+	queryInterval := 5 * time.Second
+	mctrl := NewMulticastController(mockOFClient, groupAllocator, nodeConfig, mockIfaceStore, mockMulticastSocket, sets.NewString(), ovsClient, podUpdateSubscriber, queryInterval)
 	return mctrl
 }
 

--- a/pkg/config/agent/config.go
+++ b/pkg/config/agent/config.go
@@ -182,9 +182,8 @@ type AgentConfig struct {
 	// 2. TransportInterfaceCIDRs
 	// 3. The Node IP
 	TransportInterfaceCIDRs []string `yaml:"transportInterfaceCIDRs,omitempty"`
-	// The names of the interfaces on Nodes that are used to forward multicast traffic.
-	// Defaults to transport interface if not set.
-	MulticastInterfaces []string `yaml:"multicastInterfaces,omitempty"`
+	// Multicast configuration options.
+	Multicast MulticastConfig `yaml:"multicast,omitempty"`
 	// AntreaProxy contains AntreaProxy related configuration options.
 	AntreaProxy AntreaProxyConfig `yaml:"antreaProxy,omitempty"`
 	// Egress related configurations.
@@ -229,6 +228,15 @@ type NodePortLocalConfig struct {
 	// pod.spec.containers[].ports), and all Node traffic directed to that port will be
 	// forwarded to the Pod.
 	PortRange string `yaml:"portRange,omitempty"`
+}
+
+type MulticastConfig struct {
+	// The names of the interfaces on Nodes that are used to forward multicast traffic.
+	// Defaults to transport interface if not set.
+	MulticastInterfaces []string `yaml:"multicastInterfaces,omitempty"`
+	// The interval for antrea-agent to send IGMP queries to Pods.
+	// Defaults to 125 seconds.
+	IGMPQueryInterval string `yaml:"igmpQueryInterval"`
 }
 
 type EgressConfig struct {

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -2042,7 +2042,7 @@ func (data *TestData) GetMulticastInterfaces(antreaNamespace string) ([]string, 
 	if err != nil {
 		return []string{}, err
 	}
-	return agentConf.MulticastInterfaces, nil
+	return agentConf.Multicast.MulticastInterfaces, nil
 }
 
 func GetTransportInterface(data *TestData) (string, error) {


### PR DESCRIPTION
For multicast, IGMP query is sent by antrea-agent every 125 seconds. This patch makes IGMP query interval configurable.