### PR TITLE
[ExternalNode] New CI test for VM agent

### DIFF
--- a/build/charts/antrea/README.md
+++ b/build/charts/antrea/README.md
@@ -54,6 +54,7 @@ Kubernetes: `>= 1.16.0-0`
 | controller.antreaController.logFileMaxNum | int | `4` | Max number of log files. |
 | controller.antreaController.logFileMaxSize | int | `100` | Max size in MBs of any single log file. |
 | controller.antreaController.resources | object | `{"requests":{"cpu":"200m"}}` | Resource requests and limits for the antrea-controller container. |
+| controller.apiNodePort | int | `0` | NodePort for the antrea-controller APIServer to server on. |
 | controller.apiPort | int | `10349` | Port for the antrea-controller APIServer to serve on. |
 | controller.enablePrometheusMetrics | bool | `true` | Enable metrics exposure via Prometheus. |
 | controller.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node selector for the antrea-controller Pod. |

--- a/build/charts/antrea/templates/controller/service.yaml
+++ b/build/charts/antrea/templates/controller/service.yaml
@@ -6,10 +6,16 @@ metadata:
   labels:
     app: antrea
 spec:
+  {{- if .Values.controller.apiNodePort }}
+  type: NodePort
+  {{- end }}
   ports:
     - port: 443
       protocol: TCP
       targetPort: api
+      {{- if .Values.controller.apiNodePort }}
+      nodePort: {{ .Values.controller.apiNodePort }}
+      {{- end }}
   selector:
     app: antrea
     component: antrea-controller

--- a/build/charts/antrea/values.yaml
+++ b/build/charts/antrea/values.yaml
@@ -207,6 +207,8 @@ agent:
 controller:
   # -- Port for the antrea-controller APIServer to serve on.
   apiPort: 10349
+  # -- NodePort for the antrea-controller APIServer to server on.
+  apiNodePort: 0
   # -- Enable metrics exposure via Prometheus.
   enablePrometheusMetrics: true
   # -- Annotations to be added to antrea-controller Pod.

--- a/ci/jenkins/jobs/macros.yaml
+++ b/ci/jenkins/jobs/macros.yaml
@@ -140,3 +140,12 @@
             echo "Whole Conformance Test failed!"
           fi
           exit $((TEST_FAIL_E2E + TEST_FAIL_NP + TEST_FAIL_CONFORMANCE))
+
+- builder:
+    name: builder-vm-e2e
+    builders:
+      - shell: |-
+          #!/bin/bash
+          set -e
+          DOCKER_REGISTRY="$(head -n1 ci/docker-registry)"
+          ./ci/jenkins/test-vm.sh  --registry ${DOCKER_REGISTRY} --kubeconfig /var/lib/jenkins/.kube/config

--- a/ci/jenkins/jobs/projects.yaml
+++ b/ci/jenkins/jobs/projects.yaml
@@ -1081,3 +1081,59 @@
              - timeout:
                  timeout: 600
                  type: absolute
+      - '{name}-{test_name}-for-pull-request':
+            test_name: vm-e2e
+            node: 'antrea-vm-node'
+            description: 'This is the {test_name} test for {name}.'
+            branches:
+                - ${{sha1}}
+            builders:
+                - builder-vm-e2e
+            trigger_phrase: ^(?!Thanks for your PR).*/test-(vm-e2e).*
+            white_list_target_branches: [ ]
+            allow_whitelist_orgs_as_admins: true
+            admin_list: '{antrea_admin_list}'
+            org_list: '{antrea_org_list}'
+            white_list: '{antrea_white_list}'
+            only_trigger_phrase: true
+            trigger_permit_all: true
+            status_context: jenkins-vm-e2e
+            status_url: --none--
+            success_status: Build finished.
+            failure_status: Failed. Add comment /test-vm-e2e to re-trigger.
+            error_status: Failed. Add comment /test-vm-e2e to re-trigger.
+            triggered_status: null
+            started_status: null
+            wrappers:
+                - credentials-binding:
+                      - text:
+                            credential-id: CODECOV_TOKEN # Jenkins secret that stores codecov token
+                            variable: CODECOV_TOKEN
+                - timeout:
+                      fail: true
+                      timeout: 150
+                      type: absolute
+                - credentials-binding:
+                      - text:
+                            credential-id: GOVC_URL
+                            variable: GOVC_URL
+                      - text:
+                            credential-id: GOVC_USERNAME
+                            variable: GOVC_USERNAME
+                      - text:
+                            credential-id: GOVC_PASSWORD
+                            variable: GOVC_PASSWORD
+                      - text:
+                            credential-id: GOVC_DATACENTER
+                            variable: GOVC_DATACENTER
+                      - text:
+                            credential-id: GOVC_DATASTORE
+                            variable: GOVC_DATASTORE
+            publishers:
+                - archive:
+                      allow-empty: true
+                      artifacts: antrea-test-logs.tar.gz, e2e-coverage.tar.gz
+                      case-sensitive: true
+                      default-excludes: true
+                      fingerprint: false
+                      only-if-success: false

--- a/ci/jenkins/test-vm.sh
+++ b/ci/jenkins/test-vm.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 Antrea Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+function echoerr {
+    >&2 echo "$@"
+}
+
+DOCKER_REGISTRY="projects.registry.vmware.com"
+DEFAULT_WORKDIR="/var/lib/jenkins"
+DEFAULT_KUBECONFIG_PATH=$DEFAULT_WORKDIR/kube.conf
+WORKDIR=$DEFAULT_WORKDIR
+KUBECONFIG_PATH=$DEFAULT_KUBECONFIG_PATH
+TEST_FAILURE=false
+
+# VM configuration
+WINDOWS_VM_IP=""
+UBUNTU_VM_IP=""
+LIN_HOSTNAME="vmbmtest0-1"
+WIN_HOSTNAME="vmbmtest0-win-0"
+
+# Cluster configuration
+CLUSTER_NAME="kubernetes"
+TEST_NAMESPACE="vm-ns"
+SERVICE_ACCOUNT="vm-agent"
+
+CONTROL_PLANE_NODE_ROLE="control-plane"
+
+_usage="Usage: $0 [--kubeconfig <KubeconfigSavePath>] [--workdir <HomePath>]
+
+Run K8s e2e community tests (Conformance & Network Policy) or Antrea e2e tests on a remote (Jenkins) Windows or Linux cluster.
+
+        --kubeconfig             Path of cluster kubeconfig.
+        --workdir                Home path for Go, vSphere information and antrea_logs during cluster setup. Default is $WORKDIR.
+        --registry               The docker registry to use instead of dockerhub."
+
+function print_usage {
+    echoerr "$_usage"
+}
+
+function print_help {
+    echoerr "Try '$0 --help' for more information."
+}
+
+while [[ $# -gt 0 ]]
+do
+key="$1"
+
+case $key in
+    --kubeconfig)
+    KUBECONFIG_PATH="$2"
+    shift 2
+    ;;
+    --workdir)
+    WORKDIR="$2"
+    shift 2
+    ;;
+    --registry)
+    DOCKER_REGISTRY="$2"
+    shift 2
+    ;;
+    -h|--help)
+    print_usage
+    exit 0
+    ;;
+    *)    # unknown option
+    echoerr "Unknown option $1"
+    exit 1
+    ;;
+esac
+done
+
+if [[ "$WORKDIR" != "$DEFAULT_WORKDIR" && "$KUBECONFIG_PATH" == "$DEFAULT_KUBECONFIG_PATH" ]]; then
+    KUBECONFIG_PATH=${WORKDIR}/.kube/config
+fi
+
+# To run kubectl cmds
+export KUBECONFIG=${KUBECONFIG_PATH}
+
+function export_govc_env_var {
+    # This should be coming from jenkins configuration
+    export GOVC_URL=$GOVC_URL
+    export GOVC_USERNAME=$GOVC_USERNAME
+    export GOVC_PASSWORD=$GOVC_PASSWORD
+    export GOVC_INSECURE=1
+    export GOVC_DATACENTER=$GOVC_DATACENTER
+    export GOVC_DATASTORE=$GOVC_DATASTORE
+}
+
+function clean_up_one_ns {
+    ns=$1
+    kubectl get pod -n "${ns}" --no-headers=true | awk '{print $1}' | while read pod_name; do
+        kubectl delete pod "${pod_name}" -n "${ns}" --force --grace-period 0
+    done
+    kubectl delete ns "${ns}" --ignore-not-found=true || true
+}
+
+function clean_antrea {
+    echo "====== Cleanup Antrea Installation ======"
+    clean_up_one_ns $TEST_NAMESPACE
+    kubectl delete -f ${WORKDIR}/antrea.yml --ignore-not-found=true
+}
+
+function apply_antrea {
+    # Ensure that files in the Docker context have the correct permissions, or Docker caching cannot
+    # be leveraged successfully
+    chmod -R g-w build/images/ovs
+    chmod -R g-w build/images/base
+    # Pull images from Dockerhub first then try Harbor.
+    for i in `seq 3`; do
+        ./hack/build-antrea-linux-all.sh --pull && break
+    done
+    if [ $? -ne 0 ]; then
+        echoerr "Failed to build antrea images with Dockerhub"
+        for i in `seq 3`; do
+            DOCKER_REGISTRY="${DOCKER_REGISTRY}" ./hack/build-antrea-linux-all.sh --pull && break
+        done
+        if [ $? -ne 0 ]; then
+            echoerr "Failed to build antrea images with Harbor"
+            exit 1
+        fi
+    fi
+    echo "====== Applying Antrea yaml ======"
+    ./hack/generate-manifest.sh --feature-gates ExternalNode=true --extra-helm-values "controller.apiNodePort=32767" > ${WORKDIR}/antrea.yml
+    kubectl apply -f ${WORKDIR}/antrea.yml
+}
+
+function clean_vm_agent {
+    echo "====== Cleanup Antrea-Agent Installation on the VM ======"
+    echo "Revert to snapshot VMAgent"
+    govc snapshot.revert -k=true -vm=${LIN_HOSTNAME} VMAgent
+    govc snapshot.revert -k=true -vm=${WIN_HOSTNAME} VMAgent
+    echo "Get IP addresses for VMs"
+    UBUNTU_VM_IP=$(govc vm.ip -k=true -wait=1m ${LIN_HOSTNAME})
+    for i in `seq 10`; do
+        WINDOWS_VM_IP=$(govc vm.ip -k=true -wait=2m ${WIN_HOSTNAME})
+        if [[ WINDOWS_VM_IP == "" ]]; then
+            echo "Failed to retrieve IP for Windows VM ${WIN_HOSTNAME}, retry ${i}"
+            continue
+        fi
+    done
+
+    kubectl delete sa $SERVICE_ACCOUNT -n $TEST_NAMESPACE --ignore-not-found=true
+    clean_up_one_ns $TEST_NAMESPACE
+    echo "Deleting stale antrea-agent files from ${LIN_HOSTNAME} and ${WIN_HOSTNAME}"
+    ssh -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" -n ubuntu@${UBUNTU_VM_IP} "rm -rf /tmp/antrea-ci"
+    ssh -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" Administrator@${WINDOWS_VM_IP} "rm -rf /tmp/antrea-ci"
+}
+
+function configure_vm_agent {
+    echo "====== Configuring Antrea agent on the VM ======"
+    echo "Create ns $TEST_NAMESPACE"
+    kubectl create ns $TEST_NAMESPACE
+    echo "Create service account $SERVICE_ACCOUNT"
+    kubectl create sa $SERVICE_ACCOUNT -n $TEST_NAMESPACE
+    cp ./build/yamls/externalnode/vm-agent-rbac.yml ${WORKDIR}/vm-agent-rbac.yml
+    echo "Applying vm-agent rbac yaml"
+    kubectl apply -f ${WORKDIR}/vm-agent-rbac.yml
+
+    echo "Creating files antrea-agent.kubeconfig and antrea-agent.antrea.kubeconfig"
+    # Kubeconfig to access K8S API
+    APISERVER=$(kubectl config view -o jsonpath="{.clusters[?(@.name==\"$CLUSTER_NAME\")].cluster.server}")
+    TOKEN=$(kubectl -n $TEST_NAMESPACE get secrets -o jsonpath="{.items[?(@.metadata.annotations['kubernetes\.io/service-account\.name']=='$SERVICE_ACCOUNT')].data.token}"|base64 --decode)
+    kubectl config --kubeconfig=${WORKDIR}/antrea-agent.kubeconfig set-cluster kubernetes --server=$APISERVER --insecure-skip-tls-verify=true
+    kubectl config --kubeconfig=${WORKDIR}/antrea-agent.kubeconfig set-credentials antrea-agent --token=$TOKEN
+    kubectl config --kubeconfig=${WORKDIR}/antrea-agent.kubeconfig set-context antrea-agent@kubernetes --cluster=kubernetes --user=antrea-agent
+    kubectl config --kubeconfig=${WORKDIR}/antrea-agent.kubeconfig use-context antrea-agent@kubernetes
+
+    # Kubeconfig to access AntreaController
+    ANTREA_API_SERVER_IP=$(kubectl get nodes -o wide --no-headers=true | awk -v role="$CONTROL_PLANE_NODE_ROLE" '$3 != role {print $6}')
+    ANTREA_API_SERVER="https://${ANTREA_API_SERVER_IP}:32767"
+    TOKEN=$(kubectl -n $TEST_NAMESPACE get secrets -o jsonpath="{.items[?(@.metadata.annotations['kubernetes\.io/service-account\.name']=='$SERVICE_ACCOUNT')].data.token}"|base64 --decode)
+    kubectl config --kubeconfig=${WORKDIR}/antrea-agent.antrea.kubeconfig set-cluster antrea --server=$ANTREA_API_SERVER --insecure-skip-tls-verify=true
+    kubectl config --kubeconfig=${WORKDIR}/antrea-agent.antrea.kubeconfig set-credentials antrea-agent --token=$TOKEN
+    kubectl config --kubeconfig=${WORKDIR}/antrea-agent.antrea.kubeconfig set-context antrea-agent@antrea --cluster=antrea --user=antrea-agent
+    kubectl config --kubeconfig=${WORKDIR}/antrea-agent.antrea.kubeconfig use-context antrea-agent@antrea
+
+    echo "Copying kubeconfig files to Linux VM"
+    scp -q -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" ${WORKDIR}/antrea-agent.antrea.kubeconfig ubuntu@${UBUNTU_VM_IP}:/tmp/antrea-ci/antrea-agent.antrea.kubeconfig
+    scp -q -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" ${WORKDIR}/antrea-agent.kubeconfig  ubuntu@${UBUNTU_VM_IP}:/tmp/antrea-ci/antrea-agent.kubeconfig
+    echo "Copying kubeconfig files to Windows VM"
+    scp -q -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" ${WORKDIR}/antrea-agent.antrea.kubeconfig Administrator@${WINDOWS_VM_IP}:/tmp/antrea-ci/antrea-agent.antrea.kubeconfig
+    scp -q -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" ${WORKDIR}/antrea-agent.kubeconfig Administrator@${WINDOWS_VM_IP}:/tmp/antrea-ci/antrea-agent.kubeconfig
+    echo "Configure antrea-agent as a service on Linux VM"
+    ssh -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" -n ubuntu@${UBUNTU_VM_IP} "sudo cp /tmp/antrea-ci/antrea-agent /usr/sbin/"
+    ssh -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" -n ubuntu@${UBUNTU_VM_IP} "sudo cp /tmp/antrea-ci/antrea-agent.conf /var/run/antrea/"
+    ssh -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" -n ubuntu@${UBUNTU_VM_IP} "sudo cp /tmp/antrea-ci/antrea-agent.*kubeconfig /var/run/antrea/"
+    ssh -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" -n ubuntu@${UBUNTU_VM_IP} "sudo systemctl daemon-reload"
+    ssh -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" -n ubuntu@${UBUNTU_VM_IP} "sudo systemctl enable antrea-agent"
+    echo "Configure antrea-agent as a service on Windows VM"
+    # change /tmp/antrea-ci/*kubeconfig to C:\antrea-agent\*kubeconfig
+    ssh -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" Administrator@${WINDOWS_VM_IP} "sed -i 's|/tmp/antrea-ci|C:/antrea-agent|g' /tmp/antrea-ci/antrea-agent.conf"
+    ssh -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" Administrator@${WINDOWS_VM_IP} "cp /tmp/antrea-ci/antrea-agent.exe C:/antrea-agent/"
+    ssh -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" Administrator@${WINDOWS_VM_IP} "cp /tmp/antrea-ci/antrea-agent.conf C:/antrea-agent/antrea-agent.conf"
+    ssh -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" Administrator@${WINDOWS_VM_IP} "cp /tmp/antrea-ci/antrea-agent.*kubeconfig C:/antrea-agent/"
+}
+
+
+function run_e2e_vms {
+    export GO111MODULE=on
+    export GOPATH=${WORKDIR}/go
+    export GOROOT=/usr/local/go
+    export GOCACHE=${WORKDIR}/.cache/go-build
+    export PATH=$GOROOT/bin:$PATH
+
+    configure_vm_agent
+    echo "====== Running Antrea e2e Tests for VM ======"
+    mkdir -p `pwd`/antrea-test-logs
+    go test -v -timeout=100m antrea.io/antrea/test/e2e -run=TestVMAgent --logs-export-dir `pwd`/antrea-test-logs -provider=remote -windowsVMs=${WIN_HOSTNAME} -linuxVMs=${LIN_HOSTNAME}
+    if [[ "$?" != "0" ]]; then
+        TEST_FAILURE=true
+    fi
+    set -e
+
+    tar -zcf antrea-test-logs.tar.gz antrea-test-logs
+}
+
+function deliver_antrea_vm {
+    export_govc_env_var
+    clean_vm_agent
+    echo "====== Building Antrea binaries for the Following Commit ======"
+    export GO111MODULE=on
+    export GOPATH=${WORKDIR}/go
+    export GOROOT=/usr/local/go
+    export GOCACHE=${WORKSPACE}/../gocache
+    export PATH=${GOROOT}/bin:$PATH
+
+    make docker-bin
+    make docker-windows-bin
+    echo "====== Delivering Antrea to all the VMs ======"
+    cp ./build/yamls/externalnode/conf/antrea-agent.conf ${WORKDIR}/antrea-agent.conf
+    echo "Updating antrea-agent.conf"
+    sed -i 's|#externalNodeNamespace: default|externalNodeNamespace: vm-ns|g' ${WORKDIR}/antrea-agent.conf
+    sed -i 's|kubeconfig: |kubeconfig: /tmp/antrea-ci/|g' ${WORKDIR}/antrea-agent.conf
+    echo "Copying binaries and conf to VM: $LIN_HOSTNAME"
+    ssh -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" -n ubuntu@${UBUNTU_VM_IP} "mkdir -p /tmp/antrea-ci"
+    scp -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" ./bin/antrea-agent ubuntu@${UBUNTU_VM_IP}:/tmp/antrea-ci/antrea-agent
+    scp -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" ./bin/antctl ubuntu@${UBUNTU_VM_IP}:/tmp/antrea-ci/antctl
+    scp -q -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" ${WORKDIR}/antrea-agent.conf  ubuntu@${UBUNTU_VM_IP}:/tmp/antrea-ci/antrea-agent.conf
+    echo "Copying binaries and conf to VM: $WIN_HOSTNAME"
+    ssh -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" Administrator@${WINDOWS_VM_IP} "mkdir -p /tmp/antrea-ci"
+    scp -q -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" ./bin/antrea-agent.exe Administrator@${WINDOWS_VM_IP}:/tmp/antrea-ci/antrea-agent.exe
+    scp -q -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" ./bin/antctl.exe Administrator@${WINDOWS_VM_IP}:/tmp/antrea-ci/antctl.exe
+    scp -q -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" ${WORKDIR}/antrea-agent.conf  Administrator@${WINDOWS_VM_IP}:/tmp/antrea-ci/antrea-agent.conf
+}
+
+trap clean_antrea EXIT
+apply_antrea
+deliver_antrea_vm
+run_e2e_vms

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -191,6 +191,8 @@ type TestOptions struct {
 	flowVisibility      bool
 	coverageDir         string
 	skipCases           string
+	linuxVMs            string
+	windowsVMs          string
 }
 
 var testOptions TestOptions

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -84,6 +84,8 @@ func testMain(m *testing.M) int {
 	flag.BoolVar(&testOptions.flowVisibility, "flow-visibility", false, "Run flow visibility tests")
 	flag.StringVar(&testOptions.coverageDir, "coverage-dir", "", "Directory for coverage data files")
 	flag.StringVar(&testOptions.skipCases, "skip", "", "Key words to skip cases")
+	flag.StringVar(&testOptions.linuxVMs, "linuxVMs", "", "hostname of Linux VMs")
+	flag.StringVar(&testOptions.windowsVMs, "windowsVMs", "", "hostname of Windows VMs")
 	flag.Parse()
 
 	cleanupLogging := testOptions.setupLogging()

--- a/test/e2e/utils/externalnode_spec_builder.go
+++ b/test/e2e/utils/externalnode_spec_builder.go
@@ -1,0 +1,51 @@
+// Copyright 2022 Antrea Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	crdv1alpha1 "antrea.io/antrea/pkg/apis/crd/v1alpha1"
+)
+
+type ExternalNodeSpecBuilder struct {
+	Spec      crdv1alpha1.ExternalNodeSpec
+	Name      string
+	Namespace string
+}
+
+func (t *ExternalNodeSpecBuilder) SetName(namespace string, name string) *ExternalNodeSpecBuilder {
+	t.Namespace = namespace
+	t.Name = name
+	return t
+}
+
+func (t *ExternalNodeSpecBuilder) AddInterface(name string, ips []string) *ExternalNodeSpecBuilder {
+	t.Spec.Interfaces = append(t.Spec.Interfaces, crdv1alpha1.NetworkInterface{
+		Name: name,
+		IPs:  ips,
+	})
+	return t
+}
+
+func (t *ExternalNodeSpecBuilder) Get() *crdv1alpha1.ExternalNode {
+	return &crdv1alpha1.ExternalNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      t.Name,
+			Namespace: t.Namespace,
+		},
+		Spec: t.Spec,
+	}
+}

--- a/test/e2e/vmagent_test.go
+++ b/test/e2e/vmagent_test.go
@@ -1,0 +1,293 @@
+// Copyright 2022 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	crdv1alpha1 "antrea.io/antrea/pkg/apis/crd/v1alpha1"
+	"antrea.io/antrea/pkg/features"
+	"antrea.io/antrea/pkg/util/externalnode"
+	. "antrea.io/antrea/test/e2e/utils"
+)
+
+const (
+	namespace      = "vm-ns"
+	serviceAccount = "vm-agent"
+)
+
+type vmInfo struct {
+	nodeName string
+	osType   string
+	ifName   string
+	ip       string
+	eeName   string
+	ifIndex  string // Used only for Windows
+}
+
+// TestVMAgent is the top-level test which can contain some subtests for
+// VMAgent so they can share setup, teardown.
+func TestVMAgent(t *testing.T) {
+	skipIfFeatureDisabled(t, features.ExternalNode, false, true)
+	skipIfNoVMs(t)
+	data, err := setupTest(t)
+	if err != nil {
+		t.Fatalf("Error when setting up test: %v", err)
+	}
+	defer teardownTest(t, data)
+	vmList, err := setupVMAgentTest(t, data)
+	if err != nil {
+		t.Fatalf("Error when setting up VMAgent test: %v", err)
+	}
+	defer teardownVMAgentTest(t, data, vmList)
+	t.Run("testExternalNode", func(t *testing.T) { testExternalNode(t, data, vmList) })
+}
+
+// setupVMAgentTest creates ExternalNode, starts antrea-agent
+// and returns a list of VMs upon success
+func setupVMAgentTest(t *testing.T, data *TestData) ([]vmInfo, error) {
+	t.Logf("List of Windows VMs: '%s', Linux VMs: '%s'", testOptions.windowsVMs, testOptions.linuxVMs)
+	t.Logf("Using ServiceAccount %s, Namespace %s", serviceAccount, namespace)
+	var vmList []vmInfo
+	if testOptions.linuxVMs != "" {
+		vms := strings.Split(testOptions.linuxVMs, ",")
+		for _, vm := range vms {
+			t.Logf("Get info for Linux VM: %s", vm)
+			tempVM := getVMInfo(t, data, vm)
+			vmList = append(vmList, tempVM)
+		}
+	}
+	if testOptions.windowsVMs != "" {
+		vms := strings.Split(testOptions.windowsVMs, ",")
+		for _, vm := range vms {
+			t.Logf("Get info for Windows VM: %s", vm)
+			tempVM := getWindowsVMInfo(t, data, vm)
+			vmList = append(vmList, tempVM)
+		}
+	}
+	t.Logf("TestVMAgent setup")
+	for i, vm := range vmList {
+		stopAntreaAgent(t, data, vm)
+		t.Logf("Creating ExternalNode for VM: %s", vm.nodeName)
+		en, err := createExternalNodeCRD(data, vm.nodeName, vm.ifName, vm.ip)
+		require.NoError(t, err, "Failed to create ExternalNode")
+		vmList[i].eeName, err = externalnode.GenExternalEntityName(en)
+		require.NoError(t, err, "Failed to generate ExternalEntity Name for ExternalNode %s", en.Name)
+		startAntreaAgent(t, data, vm)
+	}
+	return vmList, nil
+}
+
+// teardownVMAgentTest deletes ExternalNode, verifies ExternalEntity is deleted
+// and verifies uplink configuration is restored.
+func teardownVMAgentTest(t *testing.T, data *TestData, vmList []vmInfo) {
+	verifyUpLinkAfterCleanup := func(vm vmInfo) {
+		err := wait.PollImmediate(10*time.Second, 1*time.Minute, func() (done bool, err error) {
+			var tempVM vmInfo
+			if vm.osType == "Linux" {
+				tempVM = getVMInfo(t, data, vm.nodeName)
+			} else {
+				tempVM = getWindowsVMInfo(t, data, vm.nodeName)
+			}
+			if vm.ifName != tempVM.ifName {
+				t.Logf("Retry, unexpected uplink interface name, expected %s, got %s", vm.ifName, tempVM.ifName)
+				return false, nil
+			}
+			if vm.ip != tempVM.ip {
+				t.Logf("Retry, unexpected uplink IP, expected %s, got %s", vm.ip, tempVM.ip)
+				return false, nil
+			}
+			return true, nil
+		})
+		assert.NoError(t, err, "Failed to verify uplink configuration after cleanup")
+	}
+	t.Logf("TestVMAgent teardown")
+	for _, vm := range vmList {
+		err := data.crdClient.CrdV1alpha1().ExternalNodes(namespace).Delete(context.TODO(), vm.nodeName, metav1.DeleteOptions{})
+		assert.NoError(t, err, "Failed to delete ExternalNode %s", vm.nodeName)
+		verifyExternalEntityExistence(t, data, vm.eeName, vm.nodeName, false)
+		verifyUpLinkAfterCleanup(vm)
+	}
+}
+
+func verifyExternalEntityExistence(t *testing.T, data *TestData, eeName string, vmNodeName string, expectExists bool) {
+	if err := wait.PollImmediate(10*time.Second, 1*time.Minute, func() (done bool, err error) {
+		t.Logf("Verifying ExternalEntity %s, expectExists %t", eeName, expectExists)
+		_, err = data.crdClient.CrdV1alpha2().ExternalEntities(namespace).Get(context.TODO(), eeName, metav1.GetOptions{})
+		if err != nil && !errors.IsNotFound(err) {
+			t.Errorf("Failed to get ExternalEntity %s by ExternalNode %s: %v", eeName, vmNodeName, err)
+			return false, err
+		}
+
+		if expectExists {
+			if err != nil {
+				return false, err
+			}
+			return true, nil
+		}
+		// ExternalEntity is expected to be deleted, check for error
+		if err != nil {
+			return true, nil
+		}
+		return false, nil
+
+	}); err != nil {
+		op := "created"
+		if !expectExists {
+			op = "deleted"
+		}
+		assert.NoError(t, err, "Failed to verify ExternalEntity %s %s by ExternalNode %s", eeName, op, vmNodeName)
+	}
+}
+
+func testExternalNode(t *testing.T, data *TestData, vmList []vmInfo) {
+	verifyExternalNodeRealization := func(vm vmInfo) {
+		err := wait.PollImmediate(10*time.Second, 1*time.Minute, func() (done bool, err error) {
+			t.Logf("Verify host interface configuration for VM: %s", vm.nodeName)
+			exists, err := verifyInterfaceIsInOVS(t, data, vm)
+			return exists, err
+		})
+		assert.NoError(t, err, "Failed to verify host interface in OVS, vmInfo %+v", vm)
+
+		var tempVM vmInfo
+		if vm.osType == "Windows" {
+			tempVM = getWindowsVMInfo(t, data, vm.nodeName)
+		} else {
+			tempVM = getVMInfo(t, data, vm.nodeName)
+		}
+		assert.Equal(t, vm.ifName, tempVM.ifName, "Failed to verify uplink interface")
+		assert.Equal(t, vm.ip, tempVM.ip, "Failed to verify uplink IP")
+	}
+	for _, vm := range vmList {
+		t.Logf("Running verifyExternalEntityExistence")
+		verifyExternalEntityExistence(t, data, vm.eeName, vm.nodeName, true)
+		t.Logf("Running verifyExternalNodeRealization")
+		verifyExternalNodeRealization(vm)
+	}
+}
+
+func getVMInfo(t *testing.T, data *TestData, nodeName string) (info vmInfo) {
+	var vm vmInfo
+	vm.nodeName = nodeName
+	var cmd string
+	cmd = "ip -o -4 route show to default | awk '{print $5}'"
+	vm.osType = "Linux"
+	rc, ifName, stderr, err := data.RunCommandOnNode(nodeName, cmd)
+	require.NoError(t, err, "Failed to run command <%s> on VM %s, err %v", cmd, nodeName, err)
+	require.Equal(t, 0, rc, "Failed to run command: <%s>, stdout: <%v>, stderr: <%v>", cmd, ifName, stderr)
+
+	vm.ifName = strings.TrimSpace(ifName)
+	cmd = fmt.Sprintf("ifconfig %s | awk '/inet / {print $2}'| sed 's/addr://'", vm.ifName)
+	rc, ifIP, stderr, err := data.RunCommandOnNode(nodeName, cmd)
+	require.NoError(t, err, "Failed to run command <%s> on VM %s, err %v", cmd, nodeName, err)
+	require.Equal(t, 0, rc, "Failed to run command: <%s>, stdout: <%v>, stderr: <%v>", cmd, ifIP, stderr)
+
+	vm.ip = strings.TrimSpace(ifIP)
+	return vm
+}
+
+func getWindowsVMInfo(t *testing.T, data *TestData, nodeName string) (vm vmInfo) {
+	var err error
+	vm.nodeName = nodeName
+	vm.osType = "Windows"
+	cmd := fmt.Sprintf("powershell 'Get-WmiObject -Class Win32_IP4RouteTable | Where { $_.destination -eq \"0.0.0.0\" -and $_.mask -eq \"0.0.0.0\"} | Sort-Object metric1 | select interfaceindex | ft -HideTableHeaders'")
+	rc, ifIndex, stderr, err := data.RunCommandOnNode(nodeName, cmd)
+	require.NoError(t, err, "Failed to run command <%s> on VM %s, err %v", cmd, nodeName, err)
+	require.Equal(t, 0, rc, "Failed to run command: <%s>, stdout: <%v>, stderr: <%v>", cmd, ifIndex, stderr)
+
+	vm.ifIndex = strings.TrimSpace(ifIndex)
+	cmd = fmt.Sprintf("powershell 'Get-NetAdapter -IfIndex %s | select name | ft -HideTableHeaders'", vm.ifIndex)
+	rc, ifName, stderr, err := data.RunCommandOnNode(nodeName, cmd)
+	require.NoError(t, err, "Failed to run command <%s> on VM %s, err %v", cmd, nodeName, err)
+	require.Equal(t, 0, rc, "Failed to run command: <%s>, stdout: <%v>, stderr: <%v>", cmd, ifName, stderr)
+
+	vm.ifName = strings.TrimSpace(ifName)
+	cmd = fmt.Sprintf("powershell 'Get-NetIPAddress -AddressFamily IPv4 -ifIndex %s| select IPAddress| ft -HideTableHeaders'", vm.ifIndex)
+	rc, ifIP, stderr, err := data.RunCommandOnNode(nodeName, cmd)
+	require.NoError(t, err, "Failed to run command <%s> on VM %s, err %v", cmd, nodeName, err)
+	require.Equal(t, 0, rc, "Failed to run command: <%s>, stdout: <%v>, stderr: <%v>", cmd, ifIP, stderr)
+
+	vm.ip = strings.TrimSpace(ifIP)
+	return vm
+
+}
+
+func startAntreaAgent(t *testing.T, data *TestData, vm vmInfo) {
+	t.Logf("Starting antrea-agent on VM: %s", vm.nodeName)
+	var cmd string
+	if vm.osType == "Windows" {
+		cmd = "nssm start antrea-agent"
+	} else {
+		cmd = "sudo systemctl start antrea-agent"
+	}
+	rc, stdout, stderr, err := data.RunCommandOnNode(vm.nodeName, cmd)
+	require.NoError(t, err, "Failed to run command <%s> on VM %s, err %v", cmd, vm.nodeName, err)
+	require.Equal(t, 0, rc, "Failed to run command: <%s>, stdout: <%v>, stderr: <%v>", cmd, stdout, stderr)
+}
+
+func stopAntreaAgent(t *testing.T, data *TestData, vm vmInfo) {
+	t.Logf("Stopping antrea-agent on VM: %s", vm.nodeName)
+	var cmd string
+	if vm.osType == "Windows" {
+		cmd = "nssm stop antrea-agent"
+	} else {
+		cmd = "sudo systemctl stop antrea-agent"
+	}
+	rc, stdout, stderr, err := data.RunCommandOnNode(vm.nodeName, cmd)
+	require.NoError(t, err, "Failed to run command <%s> on VM %s, err %v", cmd, vm.nodeName, err)
+	require.Equal(t, 0, rc, "Failed to run command: <%s>, stdout: <%v>, stderr: <%v>", cmd, stdout, stderr)
+}
+
+func verifyInterfaceIsInOVS(t *testing.T, data *TestData, vm vmInfo) (found bool, err error) {
+	var cmd string
+	if vm.osType == "Windows" {
+		cmd = fmt.Sprintf("ovs-vsctl --column=name list port '%s'", vm.ifName)
+	} else {
+		cmd = fmt.Sprintf("sudo ovs-vsctl --column=name list port %s", vm.ifName)
+	}
+	rc, stdout, stderr, err := data.RunCommandOnNode(vm.nodeName, cmd)
+	if err != nil {
+		return false, fmt.Errorf("failed to run command <%s> on VM %s, err %v", cmd, vm.nodeName, err)
+	}
+
+	if strings.Contains(stdout, "no row") {
+		t.Logf("Failed to find OVS port %s on VM %s, err %v, rc %d, stdout %v, stderr %v", vm.ifName, vm.nodeName, err, rc, stdout, stderr)
+		return false, nil
+	}
+
+	if strings.Contains(stdout, vm.ifName) && strings.Contains(stdout, "name") {
+		return true, nil
+	}
+	return false, nil
+}
+
+func createExternalNodeCRD(data *TestData, nodeName string, ifName string, ip string) (enode *crdv1alpha1.ExternalNode, err error) {
+	testEn := &ExternalNodeSpecBuilder{}
+	testEn.SetName(namespace, nodeName)
+	var ipList []string
+	ipList = append(ipList, ip)
+	testEn.AddInterface(ifName, ipList)
+	return data.crdClient.CrdV1alpha1().ExternalNodes(namespace).Create(context.TODO(), testEn.Get(), metav1.CreateOptions{})
+}


### PR DESCRIPTION
Adding a new test for VM/BM agent.
- Test configures namespace, serviceaccount
- Applies vm-agent-rbac.yaml
- Starts antrea service as nodeport
- Verifies create/delete externalentity, validates interface
configuration in OVS

Signed-off-by: Anand Kumar <kumaranand@vmware.com>