### PR TITLE
Fix error loop caused by failure to delete a non-existing route

### DIFF
--- a/pkg/agent/route/route_linux.go
+++ b/pkg/agent/route/route_linux.go
@@ -1298,7 +1298,11 @@ func (c *Client) deleteLoadBalancerIngressIPRoute(svcIPStr string) error {
 
 	route := generateRoute(svcIP, mask, gw, linkIndex, netlink.SCOPE_UNIVERSE)
 	if err := netlink.RouteDel(route); err != nil {
-		return fmt.Errorf("failed to delete routing entry for LoadBalancer ingress IP %s: %w", svcIP.String(), err)
+		if err.Error() == "no such process" {
+			klog.InfoS("Failed to delete LoadBalancer ingress IP route since the route has been deleted", "route", route)
+		} else {
+			return fmt.Errorf("failed to delete routing entry for LoadBalancer ingress IP %s: %w", svcIP.String(), err)
+		}
 	}
 	klog.V(4).InfoS("Deleted LoadBalancer ingress IP route", "route", route)
 	c.serviceRoutes.Delete(svcIP.String())


### PR DESCRIPTION
When a LoadBalancer with ingress IP is created, corresponding route
for the ingress IP is also installed. When deleting the LoadBalancer,
corresponding route should be also uninstalled. Before uninstalling
the route, if the route is removed, then deleting the route will
get a failure and return an error. The error will trigger LoadBalancer
deletion again, and obviously, deleting the route will get a failure
and return an error another time, resulting in an error loop. This PR
fixes error loop by printing log instead of returning error when getting
the error "no such process" (such error means that the route expected to
be deleted doesn't exist).

Signed-off-by: Hongliang Liu <lhongliang@vmware.com>