### PR TITLE
Fix inconsistent namespaces used in Flow Aggregator e2e test

### DIFF
--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -401,11 +401,15 @@ func teardownFlowAggregator(tb testing.TB, data *TestData) {
 	if err := data.DeleteNamespace(flowAggregatorNamespace, defaultTimeout); err != nil {
 		tb.Logf("Error when tearing down flow aggregator: %v", err)
 	}
-
-	tb.Logf("Deleting '%s' K8s Namespace and ClickHouse Operator", flowVisibilityNamespace)
-	if err := data.DeleteNamespace(flowVisibilityNamespace, defaultTimeout); err != nil {
-		tb.Logf("Error when tearing down flow visibility: %v", err)
+	tb.Logf("Deleting K8s resources created by flow visibility YAML")
+	if err := data.deleteFlowVisibility(); err != nil {
+		tb.Logf("Error when deleting K8s resources created by flow visibility YAML: %v", err)
 	}
+	tb.Logf("Deleting '%s' K8s Namespace", flowVisibilityNamespace)
+	if err := data.DeleteNamespace(flowVisibilityNamespace, defaultTimeout); err != nil {
+		tb.Logf("Error when deleting flow-visibility namespace: %v", err)
+	}
+	tb.Logf("Deleting ClickHouse Operator")
 	if err := data.deleteClickHouseOperator(); err != nil {
 		tb.Logf("Error when removing ClickHouse Operator: %v", err)
 	}

--- a/test/e2e/flowaggregator_test.go
+++ b/test/e2e/flowaggregator_test.go
@@ -62,20 +62,20 @@ DATA SET:
     reversePacketDeltaCount: 136211
     reverseOctetDeltaCount: 7083284
     sourcePodName: perftest-a
-    sourcePodNamespace: antrea-test
+    sourcePodNamespace: testflowaggregator-b6mjmbpl
     sourceNodeName: k8s-node-control-plane
     destinationPodName: perftest-b
-    destinationPodNamespace: antrea-test
+    destinationPodNamespace: testflowaggregator-b6mjmbpl
     destinationNodeName: k8s-node-control-plane
     destinationServicePort: 0
     destinationServicePortName:
     ingressNetworkPolicyName: test-flow-aggregator-networkpolicy-ingress-allow
-    ingressNetworkPolicyNamespace: antrea-test
+    ingressNetworkPolicyNamespace: testflowaggregator-b6mjmbpl
     ingressNetworkPolicyType: 1
     ingressNetworkPolicyRuleName:
     ingressNetworkPolicyRuleAction: 1
     egressNetworkPolicyName: test-flow-aggregator-networkpolicy-egress-allow
-    egressNetworkPolicyNamespace: antrea-test
+    egressNetworkPolicyNamespace: testflowaggregator-b6mjmbpl
     egressNetworkPolicyType: 1
     egressNetworkPolicyRuleName:
     egressNetworkPolicyRuleAction: 1
@@ -719,9 +719,9 @@ func checkRecordsForFlowsClickHouse(t *testing.T, data *TestData, srcIP, dstIP, 
 		assert := assert.New(t)
 		if checkService {
 			if isIntraNode {
-				assert.Contains(record.DestinationServicePortName, "antrea-test/perftest-b", "Record with ServiceIP does not have Service name")
+				assert.Contains(record.DestinationServicePortName, data.testNamespace+"/perftest-b", "Record with ServiceIP does not have Service name")
 			} else {
-				assert.Contains(record.DestinationServicePortName, "antrea-test/perftest-c", "Record with ServiceIP does not have Service name")
+				assert.Contains(record.DestinationServicePortName, data.testNamespace+"/perftest-c", "Record with ServiceIP does not have Service name")
 			}
 		}
 		if checkK8sNetworkPolicy {

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -751,10 +751,26 @@ func (data *TestData) deployFlowVisibilityClickHouse() (string, error) {
 	return chSvc.Spec.ClusterIP, nil
 }
 
+func (data *TestData) deleteFlowVisibility() error {
+	startTime := time.Now()
+	defer func() {
+		log.Infof("Deleting K8s resources created by flow visibility YAML took %v", time.Since(startTime))
+	}()
+	rc, _, _, err := data.provider.RunCommandOnNode(controlPlaneNodeName(), fmt.Sprintf("kubectl delete -f %s", flowVisibilityYML))
+	if err != nil || rc != 0 {
+		return fmt.Errorf("error when deleting K8s resources created by flow visibility YAML: %v", err)
+	}
+	return nil
+}
+
 func (data *TestData) deleteClickHouseOperator() error {
+	startTime := time.Now()
+	defer func() {
+		log.Infof("Deleting ClickHouse Operator took %v", time.Since(startTime))
+	}()
 	rc, _, _, err := data.provider.RunCommandOnNode(controlPlaneNodeName(), fmt.Sprintf("kubectl delete -f %s -n kube-system", chOperatorYML))
 	if err != nil || rc != 0 {
-		return fmt.Errorf("error when deleting ClickHouse operator: %v", err)
+		return fmt.Errorf("error when deleting ClickHouse Operator: %v", err)
 	}
 	return nil
 }


### PR DESCRIPTION
Follow up on #3506. This PR replaced the leftover usages of
the old namespaces "antrea-test" with the new namespace, to
fix the consistent failures on the FlowAggregator e2e test.

Signed-off-by: heanlan <hanlan@vmware.com>