### PR TITLE
Fix Egress not working with kube-proxy IPVS strictARP mode

### DIFF
--- a/pkg/agent/ipassigner/ip_assigner.go
+++ b/pkg/agent/ipassigner/ip_assigner.go
@@ -24,6 +24,8 @@ type IPAssigner interface {
 	UnassignIP(ip string) error
 	// AssignedIPs return the IPs that are assigned to the system by this IPAssigner.
 	AssignedIPs() sets.String
+	// InitIPs ensures the IPs that are assigned to the system match the given IPs.
+	InitIPs(sets.String) error
 	// Run starts the IP assigner.
 	Run(<-chan struct{})
 }

--- a/pkg/agent/ipassigner/ip_assigner_windows.go
+++ b/pkg/agent/ipassigner/ip_assigner_windows.go
@@ -37,5 +37,9 @@ func (a *ipAssigner) AssignedIPs() sets.String {
 	return nil
 }
 
+func (a *ipAssigner) InitIPs(ips sets.String) error {
+	return nil
+}
+
 func (a *ipAssigner) Run(ch <-chan struct{}) {
 }

--- a/pkg/agent/ipassigner/testing/mock_ipassigner.go
+++ b/pkg/agent/ipassigner/testing/mock_ipassigner.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Antrea Authors
+// Copyright 2022 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -74,6 +74,20 @@ func (m *MockIPAssigner) AssignedIPs() sets.String {
 func (mr *MockIPAssignerMockRecorder) AssignedIPs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignedIPs", reflect.TypeOf((*MockIPAssigner)(nil).AssignedIPs))
+}
+
+// InitIPs mocks base method
+func (m *MockIPAssigner) InitIPs(arg0 sets.String) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InitIPs", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// InitIPs indicates an expected call of InitIPs
+func (mr *MockIPAssignerMockRecorder) InitIPs(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitIPs", reflect.TypeOf((*MockIPAssigner)(nil).InitIPs), arg0)
 }
 
 // Run mocks base method

--- a/test/integration/agent/ip_assigner_linux_test.go
+++ b/test/integration/agent/ip_assigner_linux_test.go
@@ -64,17 +64,25 @@ func TestIPAssigner(t *testing.T) {
 	require.NoError(t, err, "Failed to list IP addresses")
 	assert.Equal(t, desiredIPs, actualIPs, "Actual IPs don't match")
 
-	// NewIPAssigner should load existing IPs correctly.
 	newIPAssigner, err := ipassigner.NewIPAssigner(nodeLinkName, dummyDeviceName)
 	require.NoError(t, err, "Initializing new IP assigner failed")
-	assert.Equal(t, desiredIPs, newIPAssigner.AssignedIPs(), "Assigned IPs don't match")
+	assert.Equal(t, sets.NewString(), newIPAssigner.AssignedIPs(), "Assigned IPs don't match")
 
-	for ip := range desiredIPs {
-		err = ipAssigner.UnassignIP(ip)
+	ip4 := "2021:124:6020:1006:250:56ff:fea7:36c4"
+	newDesiredIPs := sets.NewString(ip1, ip2, ip4)
+	err = newIPAssigner.InitIPs(newDesiredIPs)
+	require.NoError(t, err, "InitIPs failed")
+	assert.Equal(t, newDesiredIPs, newIPAssigner.AssignedIPs(), "Assigned IPs don't match")
+
+	actualIPs, err = listIPAddresses(dummyDevice)
+	require.NoError(t, err, "Failed to list IP addresses")
+	assert.Equal(t, newDesiredIPs, actualIPs, "Actual IPs don't match")
+
+	for ip := range newDesiredIPs {
+		err = newIPAssigner.UnassignIP(ip)
 		assert.NoError(t, err, "Failed to unassign a valid IP")
 	}
-
-	assert.Equal(t, sets.NewString(), ipAssigner.AssignedIPs(), "Assigned IPs don't match")
+	assert.Equal(t, sets.NewString(), newIPAssigner.AssignedIPs(), "Assigned IPs don't match")
 
 	actualIPs, err = listIPAddresses(dummyDevice)
 	require.NoError(t, err, "Failed to list IP addresses")


### PR DESCRIPTION
Check the arp_ignore sysctl value of the transport interface
and start a userspace ARP responder if it has a value other
than 0.
Copy the assigned IPs on the dummy interface to the ARP/NDP
responders on initializing to fix an issue that the responders
may not work as expected after the agent restarts.

Fixes: #3804

Signed-off-by: Xu Liu <xliu2@vmware.com>