### PR TITLE
Switch the storage of the CAPV cluster to vSan

### DIFF
--- a/ci/cluster-api/vsphere/templates/cluster.yaml
+++ b/ci/cluster-api/vsphere/templates/cluster.yaml
@@ -44,7 +44,7 @@ spec:
     spec:
       cloneMode: linkedClone
       datacenter: DATACENTERNAME
-      datastore: 208.1-20TB-NFS
+      datastore: vsanDatastore
       diskGiB: 25
       folder: CI
       memoryMiB: 8192


### PR DESCRIPTION
vSan storage can provide higher efficiency for CI pipeline.

Signed-off-by: Shuyang Xin <gavinx@vmware.com>