### PR TITLE
Fix ARP storming in TrafficControl redirect

### DIFF
--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -287,10 +287,10 @@ type Client interface {
 	// UninstallTrafficControlMarkFlows removes the flows for a traffic control rule.
 	UninstallTrafficControlMarkFlows(name string) error
 
-	// InstallTrafficControlReturnPortFlow installs the flow to classify the packets from a return port.
-	InstallTrafficControlReturnPortFlow(returnOFPort uint32) error
+	// InstallTrafficControlReturnPortFlows installs the flows for a return port.
+	InstallTrafficControlReturnPortFlows(returnOFPort uint32) error
 
-	// UninstallTrafficControlReturnPortFlow removes the flow to classify the packets from a return port.
+	// UninstallTrafficControlReturnPortFlow removes the flows for a return port.
 	UninstallTrafficControlReturnPortFlow(returnOFPort uint32) error
 
 	InstallMulticastGroup(ofGroupID binding.GroupIDType, localReceivers []uint32) error
@@ -1164,9 +1164,9 @@ func (c *client) UninstallTrafficControlMarkFlows(name string) error {
 	return c.deleteFlows(c.featurePodConnectivity.tcCachedFlows, cacheKey)
 }
 
-func (c *client) InstallTrafficControlReturnPortFlow(returnOFPort uint32) error {
+func (c *client) InstallTrafficControlReturnPortFlows(returnOFPort uint32) error {
 	cacheKey := fmt.Sprintf("tc_%d", returnOFPort)
-	flows := []binding.Flow{c.featurePodConnectivity.trafficControlReturnClassifierFlow(returnOFPort)}
+	flows := c.featurePodConnectivity.trafficControlReturnClassifierFlows(returnOFPort)
 	c.replayMutex.RLock()
 	defer c.replayMutex.RUnlock()
 	return c.addFlows(c.featurePodConnectivity.tcCachedFlows, cacheKey, flows)

--- a/pkg/agent/openflow/testing/mock_openflow.go
+++ b/pkg/agent/openflow/testing/mock_openflow.go
@@ -451,9 +451,9 @@ func (mr *MockClientMockRecorder) InstallTrafficControlMarkFlows(arg0, arg1, arg
 }
 
 // InstallTrafficControlReturnPortFlow mocks base method
-func (m *MockClient) InstallTrafficControlReturnPortFlow(arg0 uint32) error {
+func (m *MockClient) InstallTrafficControlReturnPortFlows(arg0 uint32) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstallTrafficControlReturnPortFlow", arg0)
+	ret := m.ctrl.Call(m, "InstallTrafficControlReturnPortFlows", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
@@ -461,7 +461,7 @@ func (m *MockClient) InstallTrafficControlReturnPortFlow(arg0 uint32) error {
 // InstallTrafficControlReturnPortFlow indicates an expected call of InstallTrafficControlReturnPortFlow
 func (mr *MockClientMockRecorder) InstallTrafficControlReturnPortFlow(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallTrafficControlReturnPortFlow", reflect.TypeOf((*MockClient)(nil).InstallTrafficControlReturnPortFlow), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallTrafficControlReturnPortFlows", reflect.TypeOf((*MockClient)(nil).InstallTrafficControlReturnPortFlows), arg0)
 }
 
 // IsConnected mocks base method

--- a/test/integration/agent/openflow_test.go
+++ b/test/integration/agent/openflow_test.go
@@ -1759,7 +1759,7 @@ func TestTrafficControlFlows(t *testing.T) {
 	targetOFPort := uint32(200)
 	returnOFPort := uint32(201)
 	expectedFlows := prepareTrafficControlFlows(sourceOFPorts, targetOFPort, returnOFPort)
-	c.InstallTrafficControlReturnPortFlow(returnOFPort)
+	c.InstallTrafficControlReturnPortFlows(returnOFPort)
 	c.InstallTrafficControlMarkFlows("tc", sourceOFPorts, targetOFPort, v1alpha2.DirectionBoth, v1alpha2.ActionRedirect)
 	for _, tableFlow := range expectedFlows {
 		ofTestUtils.CheckFlowExists(t, ovsCtlClient, tableFlow.tableName, 0, true, tableFlow.flows)


### PR DESCRIPTION
When a target port receives an ARP request, if the ARP request is sent back to
OVS via a return port, then the ARP request will be flooded again and the
target port will receive the ARP request again. As a result, the ARP request
will be flooded again and again. This PR fixes the issue by is by dropping ARP
packets from return ports.

Signed-off-by: Hongliang Liu <lhongliang@vmware.com>