### PR TITLE
Fix random NPL unit test failure

### DIFF
--- a/pkg/agent/nodeportlocal/npl_agent_test.go
+++ b/pkg/agent/nodeportlocal/npl_agent_test.go
@@ -700,20 +700,17 @@ func TestMultipleProtocols(t *testing.T) {
 	assert.NotEqual(t, pod1Value[0].NodePort, pod2Value[0].NodePort)
 	assert.True(t, testData.portTable.RuleExists(testPod2.Status.PodIP, defaultPort, protocolUDP))
 
-	// Update testSvc2 to serve TCP/80 and UDP/81 both, so pod1 is
+	// Update testSvc2 to serve TCP/80 and UDP/81 both, so pod2 is
 	// exposed on both TCP and UDP, with the same NodePort.
-	testPod2.Labels = tcpUdpSvcLabel
-	testData.updatePodOrFail(testPod2)
 
 	testSvc2.Spec.Ports = append(testSvc2.Spec.Ports, corev1.ServicePort{
-		Port:     81,
-		Protocol: corev1.ProtocolUDP,
+		Port:     80,
+		Protocol: corev1.ProtocolTCP,
 		TargetPort: intstr.IntOrString{
 			Type:   intstr.Int,
 			IntVal: 80,
 		},
 	})
-	testSvc2.Spec.Selector = tcpUdpSvcLabel
 	testData.updateServiceOrFail(testSvc2)
 
 	pod2ValueUpdate, err := testData.pollForPodAnnotation(testPod2.Name, true)


### PR DESCRIPTION
The failed case has updated both Service and Pod.
The issue happens when Service update is processed by NPL controller before Pod update.
In this case, the pod2 annotation was fully removed firstly.
Then NPL controller added a new nodeport with both tcp and udp rules to pod2 by service update.
As the result, the pod2 annotation was:
'[{80 10.10.10.10 61002 tcp [tcp]} {80 10.10.10.10 61002 udp [udp]}]'.

issue https://github.com/antrea-io/antrea/issues/3847

The fix ensures the execution sequence to avoid unexpected annotation in race condition.

Annotation after fix:
'[{80 10.10.10.10 61001 tcp [tcp]} {80 10.10.10.10 61001 udp [udp]}]'

Signed-off-by: Shuyang Xin <gavinx@vmware.com>