### PR TITLE
[ExternalNode] Fix antctl e2e test

### DIFF
--- a/test/e2e/antctl_test.go
+++ b/test/e2e/antctl_test.go
@@ -242,6 +242,11 @@ func runAntctProxy(nodeName string, antctlName string, nodeAntctlPath string, pr
 		proxyCmd = append(proxyCmd, "--controller")
 	} else {
 		proxyCmd = append(proxyCmd, "--agent-node", agentNodeName)
+		// Retry until AntreaAgentInfo is updated by Antrea Agent.
+		err := data.checkAntreaAgentInfo(1*time.Minute, 2*time.Minute, agentNodeName)
+		if err != nil {
+			return nil, err
+		}
 	}
 	go func() {
 		data.RunCommandOnNode(nodeName, strings.Join(proxyCmd, " "))

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -2634,3 +2634,21 @@ func isConnectionLostError(err error) bool {
 func retryOnConnectionLostError(backoff wait.Backoff, fn func() error) error {
 	return retry.OnError(backoff, isConnectionLostError, fn)
 }
+
+func (data *TestData) checkAntreaAgentInfo(interval time.Duration, timeout time.Duration, name string) error {
+	err := wait.Poll(interval, timeout, func() (bool, error) {
+		aai, err := data.crdClient.CrdV1beta1().AntreaAgentInfos().Get(context.TODO(), name, metav1.GetOptions{})
+		if err != nil {
+			if errors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, fmt.Errorf("failed to get AntreaAgentInfo %s: %v", name, err)
+		}
+		if aai.NodeRef.Name == "" {
+			// keep trying
+			return false, nil
+		}
+		return true, nil
+	})
+	return err
+}


### PR DESCRIPTION
Command "antctl proxy --agent-node" requires the information from AntreaAgentInfo.
As a result, we need to make sure the content of AntreaAgentInfo is populated before
we run the command.

Since we recently move AntreaAgentInfo creation from agent to controller, agent may
not set the content for AntreaAgentInfo when it starts if controller has not created the AntreaAgentInfo.
In this case, it will take a minute for agent to update the content in its next try.

This change adds retry logics in the antctl proxy e2e test and it will only invoke the command
after AntreaAgentInfo is ready.

Fixes:https://github.com/antrea-io/antrea/issues/3856