### PR TITLE
Support running ./hack/make-metrics-doc.sh from macOS

### DIFF
--- a/ci/kind/kind-setup.sh
+++ b/ci/kind/kind-setup.sh
@@ -264,9 +264,20 @@ networking:
 nodes:
 - role: control-plane
 EOF
+
   for (( i=0; i<$NUM_WORKERS; i++ )); do
     echo -e "- role: worker" >> $config_file
   done
+
+  # When only the control plane Node is provisioned (no worker Node),
+  # we configure port mappings so that the Antrea Agent and Controller
+  # running on the control plane Node can be easily accessed, including on macOS.
+  # This is useful for accessing Antrea APIs. With worker Nodes, 
+  # we don't configure these port mappings: in particular,
+  # we wouldn't know on which Node the Controller is running.
+  if [[ $NUM_WORKERS == 0 ]]; then
+    echo -e "  extraPortMappings:\n  - containerPort: 10349\n    hostPort: 10349\n  - containerPort: 10350\n    hostPort: 10350" >> $config_file
+  fi
 
   IMAGE_OPT=""
   if [[ "$K8S_VERSION" != "" ]]; then

--- a/hack/make-metrics-doc.sh
+++ b/hack/make-metrics-doc.sh
@@ -32,10 +32,9 @@ function exit_handler() {
 
 function get_metrics_url() {
         pod_name=$1
-        host_ip=$(kubectl get pod -n kube-system $pod_name -o jsonpath="{.status.hostIP}")
         host_port=$(kubectl get pod -n kube-system $pod_name -o jsonpath="{.spec.containers[*].ports[*].hostPort}")
 
-        echo "https://$host_ip:$host_port/metrics"
+        echo "https://localhost:$host_port/metrics"
 }
 
 function format_metrics() {


### PR DESCRIPTION
Fixes #3787 

This commit adds extra port mappings for the kind control plane node so that antrea agent and antrea controller can be reached, because the nodes of the Kind cluster cannot be accessed directly from the MacOS
host, like linux.

Signed-off-by: Pulkit Jain <jainpu@vmware.com>