### PR TITLE
Automated cherry pick of #3340: Add method AllocateIfNotExist to interface GroupCounter in
#2792: Support InternalTrafficPolicy in AntreaProxy

### DIFF
--- a/pkg/agent/proxy/proxier.go
+++ b/pkg/agent/proxy/proxier.go
@@ -353,7 +353,6 @@ func (p *proxier) uninstallLoadBalancerService(loadBalancerIPStrings []string, s
 func (p *proxier) installServices() {
 	for svcPortName, svcPort := range p.serviceMap {
 		svcInfo := svcPort.(*types.ServiceInfo)
-		groupID := p.groupCounter.AllocateIfNotExist(svcPortName, false)
 		endpointsInstalled, ok := p.endpointsInstalledMap[svcPortName]
 		if !ok {
 			endpointsInstalled = map[string]k8sproxy.Endpoint{}
@@ -372,47 +371,88 @@ func (p *proxier) installServices() {
 			pSvcInfo = installedSvcPort.(*types.ServiceInfo)
 			needRemoval = serviceIdentityChanged(svcInfo, pSvcInfo) || (svcInfo.SessionAffinityType() != pSvcInfo.SessionAffinityType())
 			needUpdateService = needRemoval || (svcInfo.StickyMaxAgeSeconds() != pSvcInfo.StickyMaxAgeSeconds())
-			needUpdateEndpoints = pSvcInfo.SessionAffinityType() != svcInfo.SessionAffinityType() || pSvcInfo.NodeLocalExternal() != svcInfo.NodeLocalExternal()
+			needUpdateEndpoints = pSvcInfo.SessionAffinityType() != svcInfo.SessionAffinityType() ||
+				pSvcInfo.NodeLocalExternal() != svcInfo.NodeLocalExternal() ||
+				pSvcInfo.NodeLocalInternal() != svcInfo.NodeLocalInternal()
 		} else { // Need to install.
 			needUpdateService = true
 		}
 
-		var endpointUpdateList []k8sproxy.Endpoint
+		var internalNodeLocal, externalNodeLocal bool
+		if svcInfo.NodeLocalInternal() {
+			internalNodeLocal = true
+		}
+		if p.proxyAll && svcInfo.NodeLocalExternal() {
+			externalNodeLocal = true
+		}
+
+		var allEndpointUpdateList, localEndpointUpdateList []k8sproxy.Endpoint
 		if len(endpoints) > maxEndpoints {
 			if !p.oversizeServiceSet.Has(svcPortName.String()) {
 				klog.Warningf("Since Endpoints of Service %s exceeds %d, extra Endpoints will be dropped", svcPortName.String(), maxEndpoints)
 				p.oversizeServiceSet.Insert(svcPortName.String())
 			}
-			// If the length of endpoints > maxEndpoints, endpoints should be cut. However, endpoints is a map. Therefore,
-			// iterate the map and append every Endpoint to a slice endpointList. Since the iteration order of map in
-			// Golang is random, if cut directly without any sorting, some Endpoints may not be installed. So cutting
-			// slice endpointList after sorting can avoid this situation in some degree.
-			var endpointList []k8sproxy.Endpoint
+			// If the length of endpoints > maxEndpoints, endpoints should be cut. However, since endpoints is a map, iterate
+			// the map and append every Endpoint to a target slice. When the Endpoint is local, append Endpoint to slice
+			// localEndpointList, otherwise append the Endpoint to slice remoteEndpointList. Since the iteration order
+			// of map in Golang is not guaranteed, if split the Endpoints directly without any sorting, some Endpoints
+			// may not be installed, so split the endpointList after sorting.
+			var remoteEndpointList, localEndpointList []k8sproxy.Endpoint
 			for _, endpoint := range endpoints {
-				endpointList = append(endpointList, endpoint)
-			}
-			sort.Sort(byEndpoint(endpointList))
-			endpointList = endpointList[:maxEndpoints]
-
-			for _, endpoint := range endpointList { // Check if there is any installed Endpoint which is not expected anymore.
-				if _, ok := endpointsInstalled[endpoint.String()]; !ok { // There is an expected Endpoint which is not installed.
-					needUpdateEndpoints = true
+				if endpoint.GetIsLocal() {
+					localEndpointList = append(localEndpointList, endpoint)
+				} else {
+					remoteEndpointList = append(remoteEndpointList, endpoint)
 				}
-				endpointUpdateList = append(endpointUpdateList, endpoint)
+			}
+
+			sort.Sort(byEndpoint(remoteEndpointList))
+			sort.Sort(byEndpoint(localEndpointList))
+
+			if len(localEndpointList) > maxEndpoints {
+				// When the number of local Endpoints is greater than maxEndpoints, choose maxEndpoints Endpoints from
+				// localEndpointList to install.
+				allEndpointUpdateList = localEndpointList[:maxEndpoints]
+			} else {
+				// When the number of local Endpoints is smaller than maxEndpoints, choose all Endpoints of localEndpointList
+				// and part of remoteEndpointList to install.
+				localEndpointUpdateList = localEndpointList
+				allEndpointUpdateList = append(localEndpointList, remoteEndpointList[:maxEndpoints-len(localEndpointList)]...)
+			}
+			// Check if there is any installed Endpoint which is not expected anymore. If internalTrafficPolicy and externalTrafficPolicy
+			// are both Local, only local Endpoints should be installed and checked; if internalTrafficPolicy or externalTrafficPolicy
+			// is Cluster, all Endpoints should be installed and checked.
+			for _, endpoint := range allEndpointUpdateList {
+				if internalNodeLocal && externalNodeLocal && endpoint.GetIsLocal() || !internalNodeLocal || !externalNodeLocal {
+					if _, ok := endpointsInstalled[endpoint.String()]; !ok { // There is an expected Endpoint which is not installed.
+						needUpdateEndpoints = true
+						break
+					}
+				}
 			}
 		} else {
 			if p.oversizeServiceSet.Has(svcPortName.String()) {
 				p.oversizeServiceSet.Delete(svcPortName.String())
 			}
-			for _, endpoint := range endpoints { // Check if there is any installed Endpoint which is not expected anymore.
-				if _, ok := endpointsInstalled[endpoint.String()]; !ok { // There is an expected Endpoint which is not installed.
-					needUpdateEndpoints = true
+			// Check if there is any installed Endpoint which is not expected anymore. If internalTrafficPolicy and externalTrafficPolicy
+			// are both Local, only local Endpoints should be installed and checked; if internalTrafficPolicy or externalTrafficPolicy
+			// is Cluster, all Endpoints should be installed and checked.
+			for _, endpoint := range endpoints {
+				if internalNodeLocal && externalNodeLocal && endpoint.GetIsLocal() || !internalNodeLocal || !externalNodeLocal {
+					if _, ok := endpointsInstalled[endpoint.String()]; !ok { // There is an expected Endpoint which is not installed.
+						needUpdateEndpoints = true
+					}
 				}
-				endpointUpdateList = append(endpointUpdateList, endpoint)
+				allEndpointUpdateList = append(allEndpointUpdateList, endpoint)
+				if endpoint.GetIsLocal() {
+					localEndpointUpdateList = append(localEndpointUpdateList, endpoint)
+				}
 			}
 		}
 
-		if len(endpoints) < len(endpointsInstalled) { // There are Endpoints which expired.
+		// If there are expired Endpoints, Endpoints installed should be updated.
+		if internalNodeLocal && externalNodeLocal && len(localEndpointUpdateList) < len(endpointsInstalled) ||
+			!(internalNodeLocal && externalNodeLocal) && len(allEndpointUpdateList) < len(endpointsInstalled) {
 			klog.V(2).Infof("Some Endpoints of Service %s removed, updating Endpoints", svcInfo.String())
 			needUpdateEndpoints = true
 		}
@@ -443,44 +483,63 @@ func (p *proxier) installServices() {
 		}
 
 		if needUpdateEndpoints {
+			var endpointUpdateList []k8sproxy.Endpoint
+			// If the type of the Service is NodePort or LoadBalancer and both internalTrafficPolicy and externalTrafficPolicy
+			// are Local, or the type of the Service is ClusterIP and internalTrafficPolicy is Local, then only local
+			// Endpoints should be installed, otherwise all Endpoints should be installed.
+			if internalNodeLocal && (externalNodeLocal || svcInfo.NodePort() == 0) {
+				endpointUpdateList = localEndpointUpdateList
+			} else {
+				endpointUpdateList = allEndpointUpdateList
+			}
+			// Install Endpoints.
 			err := p.ofClient.InstallEndpointFlows(svcInfo.OFProtocol, endpointUpdateList)
 			if err != nil {
 				klog.ErrorS(err, "Error when installing Endpoints flows")
 				continue
 			}
-			err = p.ofClient.InstallServiceGroup(groupID, svcInfo.StickyMaxAgeSeconds() != 0, endpointUpdateList)
-			if err != nil {
-				klog.ErrorS(err, "Error when installing Endpoints groups")
-				continue
-			}
-
-			if p.proxyAll {
-				if svcInfo.NodeLocalExternal() {
-					// Install another group when Service externalTrafficPolicy is Local.
-					groupIDLocal := p.groupCounter.AllocateIfNotExist(svcPortName, true)
-					var localEndpointList []k8sproxy.Endpoint
-					for _, ed := range endpointUpdateList {
-						if !ed.GetIsLocal() {
-							continue
-						}
-						localEndpointList = append(localEndpointList, ed)
+			if internalNodeLocal != externalNodeLocal {
+				if svcInfo.NodePort() > 0 {
+					// If the type of the Service is NodePort or LoadBalancer, when internalTrafficPolicy and externalTrafficPolicy
+					// of the Service are different, install two groups. One group has all Endpoints, the other has only
+					// local Endpoints.
+					groupID := p.groupCounter.AllocateIfNotExist(svcPortName, true)
+					if err = p.ofClient.InstallServiceGroup(groupID, svcInfo.StickyMaxAgeSeconds() != 0, localEndpointUpdateList); err != nil {
+						klog.ErrorS(err, "Error when installing Group of local Endpoints for Service", "Service", svcPortName)
+						continue
 					}
-					if err = p.ofClient.InstallServiceGroup(groupIDLocal, svcInfo.StickyMaxAgeSeconds() != 0, localEndpointList); err != nil {
-						klog.ErrorS(err, "Error when installing Group for Service whose externalTrafficPolicy is Local")
+					groupID = p.groupCounter.AllocateIfNotExist(svcPortName, false)
+					if err = p.ofClient.InstallServiceGroup(groupID, svcInfo.StickyMaxAgeSeconds() != 0, allEndpointUpdateList); err != nil {
+						klog.ErrorS(err, "Error when installing Group of all Endpoints for Service", "Service", svcPortName)
 						continue
 					}
 				} else {
-					// Uninstall the group with only local Endpoints when Service externalTrafficPolicy is Cluster
-					// unconditionally. If the group doesn't exist on OVS, then the return value will be nil; if the
-					// group exists on OVS, and after it is uninstalled successfully, then the return value will be also
-					// nil.
-					if groupIDLocal, exist := p.groupCounter.Get(svcPortName, true); exist {
-						if err := p.ofClient.UninstallServiceGroup(groupIDLocal); err != nil {
-							klog.ErrorS(err, "Failed to remove Group of local Endpoints for Service", "Service", svcPortName)
-							continue
-						}
-						p.groupCounter.Recycle(svcPortName, true)
+					// If the type of the Service is ClusterIP, install a group according to internalTrafficPolicy.
+					groupID := p.groupCounter.AllocateIfNotExist(svcPortName, internalNodeLocal)
+					if err = p.ofClient.InstallServiceGroup(groupID, svcInfo.StickyMaxAgeSeconds() != 0, endpointUpdateList); err != nil {
+						klog.ErrorS(err, "Error when installing Group of Endpoints for Service", "Service", svcPortName)
+						continue
 					}
+				}
+			} else {
+				// Regardless of the type of the Service, when internalTrafficPolicy and externalTrafficPolicy of the Service
+				// are the same, only install one group and unconditionally uninstall another group. If both internalTrafficPolicy
+				// and externalTrafficPolicy are Local, install the group that has only local Endpoints and unconditionally
+				// uninstall the group which has all Endpoints; if both internalTrafficPolicy and externalTrafficPolicy are
+				// Cluster, install the group which has all Endpoints and unconditionally uninstall the group which has
+				// only local Endpoints. Note that, if a group doesn't exist on OVS, then the return value will be nil.
+				nodeLocalVal := internalNodeLocal && externalNodeLocal
+				groupID := p.groupCounter.AllocateIfNotExist(svcPortName, nodeLocalVal)
+				if err = p.ofClient.InstallServiceGroup(groupID, svcInfo.StickyMaxAgeSeconds() != 0, endpointUpdateList); err != nil {
+					klog.ErrorS(err, "Error when installing Group of local Endpoints for Service", "Service", svcPortName)
+					continue
+				}
+				if groupID, exist := p.groupCounter.Get(svcPortName, !nodeLocalVal); exist {
+					if err := p.ofClient.UninstallServiceGroup(groupID); err != nil {
+						klog.ErrorS(err, "Failed to uninstall Group of all Endpoints for Service", "Service", svcPortName)
+						continue
+					}
+					p.groupCounter.Recycle(svcPortName, !nodeLocalVal)
 				}
 			}
 
@@ -521,20 +580,15 @@ func (p *proxier) installServices() {
 				}
 			}
 
-			// Install ClusterIP flows of current Service.
-			if err := p.ofClient.InstallServiceFlows(groupID, svcInfo.ClusterIP(), uint16(svcInfo.Port()), svcInfo.OFProtocol, uint16(svcInfo.StickyMaxAgeSeconds()), false, corev1.ServiceTypeClusterIP); err != nil {
+			// Install ClusterIP flows for the Service.
+			groupID := p.groupCounter.AllocateIfNotExist(svcPortName, internalNodeLocal)
+			if err := p.ofClient.InstallServiceFlows(groupID, svcInfo.ClusterIP(), uint16(svcInfo.Port()), svcInfo.OFProtocol, uint16(svcInfo.StickyMaxAgeSeconds()), svcInfo.NodeLocalInternal(), corev1.ServiceTypeClusterIP); err != nil {
 				klog.Errorf("Error when installing Service flows: %v", err)
 				continue
 			}
 
-			// If externalTrafficPolicy of the Service is Local, Service NodePort or LoadBalancer should use the Service
-			// group whose Endpoints are local.
-			nGroupID := groupID
-			if svcInfo.NodeLocalExternal() {
-				nGroupID = p.groupCounter.AllocateIfNotExist(svcPortName, true)
-			}
-
 			if p.proxyAll {
+				nGroupID := p.groupCounter.AllocateIfNotExist(svcPortName, externalNodeLocal)
 				// Install ClusterIP route on Node so that ClusterIP can be accessed on Node. Every time a new ClusterIP
 				// is created, the routing target IP block will be recalculated for expansion to be able to route the new
 				// created ClusterIP. Deleting a ClusterIP will not shrink the target routing IP block. The Service CIDR
@@ -555,6 +609,7 @@ func (p *proxier) installServices() {
 			}
 
 			if p.proxyLoadBalancerIPs {
+				nGroupID := p.groupCounter.AllocateIfNotExist(svcPortName, externalNodeLocal)
 				// Service LoadBalancer flows can be partially updated.
 				var toDelete, toAdd []string
 				if needRemoval {

--- a/pkg/agent/proxy/proxier_test.go
+++ b/pkg/agent/proxy/proxier_test.go
@@ -195,7 +195,7 @@ func testClusterIP(t *testing.T, svcIP net.IP, epIP net.IP, isIPv6 bool, extraSv
 	}))
 	makeEndpointsMap(fp, allEps...)
 
-	groupID, _ := fp.groupCounter.Get(svcPortName, false)
+	groupID := fp.groupCounter.AllocateIfNotExist(svcPortName, false)
 	mockOFClient.EXPECT().InstallServiceGroup(groupID, false, gomock.Any()).Times(1)
 	bindingProtocol := binding.ProtocolTCP
 	if isIPv6 {
@@ -204,7 +204,6 @@ func testClusterIP(t *testing.T, svcIP net.IP, epIP net.IP, isIPv6 bool, extraSv
 	mockOFClient.EXPECT().InstallEndpointFlows(bindingProtocol, gomock.Any()).Times(1)
 	mockOFClient.EXPECT().InstallServiceFlows(groupID, svcIP, uint16(svcPort), bindingProtocol, uint16(0), false, corev1.ServiceTypeClusterIP).Times(1)
 	mockRouteClient.EXPECT().AddClusterIPRoute(svcIP).Times(1)
-	mockOFClient.EXPECT().UninstallServiceGroup(gomock.Any()).Times(1)
 
 	fp.syncProxyRules()
 }
@@ -281,8 +280,7 @@ func testLoadBalancer(t *testing.T, nodePortAddresses []net.IP, svcIP, ep1IP, ep
 		eps = append(eps, makeTestEndpoints(svcPortName.Namespace, svcPortName.Name, epFunc))
 	}
 	makeEndpointsMap(fp, eps...)
-
-	groupID, _ := fp.groupCounter.Get(svcPortName, false)
+	groupID := fp.groupCounter.AllocateIfNotExist(svcPortName, false)
 	bindingProtocol := binding.ProtocolTCP
 	if isIPv6 {
 		bindingProtocol = binding.ProtocolTCPv6
@@ -291,10 +289,8 @@ func testLoadBalancer(t *testing.T, nodePortAddresses []net.IP, svcIP, ep1IP, ep
 	mockOFClient.EXPECT().InstallEndpointFlows(bindingProtocol, gomock.Any()).Times(1)
 	mockOFClient.EXPECT().InstallServiceFlows(groupID, svcIP, uint16(svcPort), bindingProtocol, uint16(0), false, corev1.ServiceTypeClusterIP).Times(1)
 	if nodeLocalExternal {
-		groupID, _ = fp.groupCounter.Get(svcPortName, true)
+		groupID = fp.groupCounter.AllocateIfNotExist(svcPortName, true)
 		mockOFClient.EXPECT().InstallServiceGroup(groupID, false, gomock.Any()).Times(1)
-	} else {
-		mockOFClient.EXPECT().UninstallServiceGroup(gomock.Any()).Times(1)
 	}
 	if proxyLoadBalancerIPs {
 		mockOFClient.EXPECT().InstallServiceFlows(groupID, loadBalancerIP, uint16(svcPort), bindingProtocol, uint16(0), nodeLocalExternal, corev1.ServiceTypeLoadBalancer).Times(1)
@@ -378,7 +374,7 @@ func testNodePort(t *testing.T, nodePortAddresses []net.IP, svcIP, ep1IP, ep2IP 
 	}
 	makeEndpointsMap(fp, eps...)
 
-	groupID, _ := fp.groupCounter.Get(svcPortName, false)
+	groupID := fp.groupCounter.AllocateIfNotExist(svcPortName, false)
 	bindingProtocol := binding.ProtocolTCP
 	if isIPv6 {
 		bindingProtocol = binding.ProtocolTCPv6
@@ -387,10 +383,8 @@ func testNodePort(t *testing.T, nodePortAddresses []net.IP, svcIP, ep1IP, ep2IP 
 	mockOFClient.EXPECT().InstallEndpointFlows(bindingProtocol, gomock.Any()).Times(1)
 	mockOFClient.EXPECT().InstallServiceFlows(groupID, svcIP, uint16(svcPort), bindingProtocol, uint16(0), false, corev1.ServiceTypeClusterIP).Times(1)
 	if nodeLocalExternal {
-		groupID, _ = fp.groupCounter.Get(svcPortName, true)
+		groupID = fp.groupCounter.AllocateIfNotExist(svcPortName, true)
 		mockOFClient.EXPECT().InstallServiceGroup(groupID, false, gomock.Any()).Times(1)
-	} else {
-		mockOFClient.EXPECT().UninstallServiceGroup(gomock.Any()).Times(1)
 	}
 
 	mockOFClient.EXPECT().InstallServiceFlows(groupID, gomock.Any(), uint16(svcNodePort), bindingProtocol, uint16(0), nodeLocalExternal, corev1.ServiceTypeNodePort).Times(1)
@@ -565,8 +559,8 @@ func TestDualStackService(t *testing.T) {
 	metaProxier.OnEndpointsUpdate(nil, epv6)
 	metaProxier.OnEndpointsSynced()
 
-	groupIDv4, _ := fpv4.groupCounter.Get(svcPortName, false)
-	groupIDv6, _ := fpv6.groupCounter.Get(svcPortName, false)
+	groupIDv4 := fpv4.groupCounter.AllocateIfNotExist(svcPortName, false)
+	groupIDv6 := fpv6.groupCounter.AllocateIfNotExist(svcPortName, false)
 
 	mockOFClient.EXPECT().InstallServiceGroup(groupIDv4, false, gomock.Any()).Times(1)
 	mockOFClient.EXPECT().InstallEndpointFlows(binding.ProtocolTCP, gomock.Any()).Times(1)
@@ -622,14 +616,14 @@ func testClusterIPRemoval(t *testing.T, svcIP net.IP, epIP net.IP, isIPv6 bool) 
 	}
 	ep := makeTestEndpoints(svcPortName.Namespace, svcPortName.Name, epFunc)
 	makeEndpointsMap(fp, ep)
-	groupID, _ := fp.groupCounter.Get(svcPortName, false)
+	groupID := fp.groupCounter.AllocateIfNotExist(svcPortName, false)
 	mockOFClient.EXPECT().InstallServiceGroup(groupID, false, gomock.Any()).Times(1)
 	mockOFClient.EXPECT().InstallEndpointFlows(bindingProtocol, gomock.Any()).Times(1)
 	mockOFClient.EXPECT().InstallServiceFlows(groupID, svcIP, uint16(svcPort), bindingProtocol, uint16(0), false, corev1.ServiceTypeClusterIP).Times(1)
 	mockRouteClient.EXPECT().AddClusterIPRoute(svcIP).Times(1)
 	mockOFClient.EXPECT().UninstallServiceFlows(svcIP, uint16(svcPort), bindingProtocol).Times(1)
 	mockOFClient.EXPECT().UninstallEndpointFlows(bindingProtocol, gomock.Any()).Times(1)
-	mockOFClient.EXPECT().UninstallServiceGroup(gomock.Any()).Times(2)
+	mockOFClient.EXPECT().UninstallServiceGroup(gomock.Any()).Times(1)
 	fp.syncProxyRules()
 
 	fp.serviceChanges.OnServiceUpdate(service, nil)
@@ -752,8 +746,8 @@ func testClusterIPRemoveSamePortEndpoint(t *testing.T, svcIP net.IP, epIP net.IP
 	}
 	makeEndpointsMap(fp, ep, epUDP)
 
-	groupID, _ := fp.groupCounter.Get(svcPortName, false)
-	groupIDUDP, _ := fp.groupCounter.Get(svcPortNameUDP, false)
+	groupID := fp.groupCounter.AllocateIfNotExist(svcPortName, false)
+	groupIDUDP := fp.groupCounter.AllocateIfNotExist(svcPortNameUDP, false)
 	mockOFClient.EXPECT().InstallServiceGroup(groupID, false, gomock.Any()).Times(1)
 	mockOFClient.EXPECT().InstallServiceGroup(groupIDUDP, false, gomock.Any()).Times(2)
 	mockOFClient.EXPECT().InstallEndpointFlows(protocolTCP, gomock.Any()).Times(1)
@@ -816,7 +810,7 @@ func testClusterIPRemoveEndpoints(t *testing.T, svcIP net.IP, epIP net.IP, isIPv
 		bindingProtocol = binding.ProtocolTCPv6
 	}
 	makeEndpointsMap(fp, ep)
-	groupID, _ := fp.groupCounter.Get(svcPortName, false)
+	groupID := fp.groupCounter.AllocateIfNotExist(svcPortName, false)
 	mockOFClient.EXPECT().InstallServiceGroup(groupID, false, gomock.Any()).Times(2)
 	mockOFClient.EXPECT().InstallEndpointFlows(bindingProtocol, gomock.Any()).Times(2)
 	mockOFClient.EXPECT().InstallServiceFlows(groupID, svcIP, uint16(svcPort), bindingProtocol, uint16(0), false, corev1.ServiceTypeClusterIP).Times(1)
@@ -888,7 +882,7 @@ func testSessionAffinityNoEndpoint(t *testing.T, svcExternalIPs net.IP, svcIP ne
 	if isIPv6 {
 		bindingProtocol = binding.ProtocolTCPv6
 	}
-	groupID, _ := fp.groupCounter.Get(svcPortName, false)
+	groupID := fp.groupCounter.AllocateIfNotExist(svcPortName, false)
 	mockOFClient.EXPECT().InstallServiceGroup(groupID, true, gomock.Any()).Times(1)
 	mockOFClient.EXPECT().InstallEndpointFlows(bindingProtocol, gomock.Any()).Times(1)
 	mockOFClient.EXPECT().InstallServiceFlows(groupID, svcIP, uint16(svcPort), bindingProtocol, uint16(corev1.DefaultClientIPServiceAffinitySeconds), false, corev1.ServiceTypeClusterIP).Times(1)
@@ -996,7 +990,7 @@ func testPortChange(t *testing.T, svcIP net.IP, epIP net.IP, isIPv6 bool) {
 	}
 	ep := makeTestEndpoints(svcPortName.Namespace, svcPortName.Name, epFunc)
 	makeEndpointsMap(fp, ep)
-	groupID, _ := fp.groupCounter.Get(svcPortName, false)
+	groupID := fp.groupCounter.AllocateIfNotExist(svcPortName, false)
 	mockOFClient.EXPECT().InstallServiceGroup(groupID, false, gomock.Any()).Times(1)
 	mockOFClient.EXPECT().InstallEndpointFlows(bindingProtocol, gomock.Any()).Times(1)
 	mockOFClient.EXPECT().InstallServiceFlows(groupID, svcIP, uint16(svcPort1), bindingProtocol, uint16(0), false, corev1.ServiceTypeClusterIP)
@@ -1082,8 +1076,8 @@ func TestServicesWithSameEndpoints(t *testing.T) {
 	ep1 := epMapFactory(svcPortName1, epIP.String())
 	ep2 := epMapFactory(svcPortName2, epIP.String())
 
-	groupID1, _ := fp.groupCounter.Get(svcPortName1, false)
-	groupID2, _ := fp.groupCounter.Get(svcPortName2, false)
+	groupID1 := fp.groupCounter.AllocateIfNotExist(svcPortName1, false)
+	groupID2 := fp.groupCounter.AllocateIfNotExist(svcPortName2, false)
 	mockOFClient.EXPECT().InstallServiceGroup(groupID1, false, gomock.Any()).Times(1)
 	mockOFClient.EXPECT().InstallServiceGroup(groupID2, false, gomock.Any()).Times(1)
 	bindingProtocol := binding.ProtocolTCP

--- a/pkg/agent/proxy/proxier_test.go
+++ b/pkg/agent/proxy/proxier_test.go
@@ -51,6 +51,7 @@ var (
 	loadBalancerIPv6 = net.ParseIP("fec0::169:254:169:1")
 	svcNodePortIPv4  = net.ParseIP("192.168.77.100")
 	svcNodePortIPv6  = net.ParseIP("2001::192:168:77:100")
+	hostname         = "localhost"
 
 	nodePortAddressesIPv4 = []net.IP{svcNodePortIPv4}
 	nodePortAddressesIPv6 = []net.IP{svcNodePortIPv6}
@@ -157,7 +158,7 @@ func NewFakeProxier(routeClient route.Interface, ofClient openflow.Client, nodeP
 	return p
 }
 
-func testClusterIP(t *testing.T, svcIP net.IP, epIP net.IP, isIPv6 bool, extraSvcs []*corev1.Service, extraEps []*corev1.Endpoints) {
+func testClusterIP(t *testing.T, svcIP net.IP, ep1IP, ep2IP net.IP, isIPv6, nodeLocalInternal bool, extraSvcs []*corev1.Service, extraEps []*corev1.Endpoints) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockOFClient := ofmock.NewMockClient(ctrl)
@@ -170,45 +171,69 @@ func testClusterIP(t *testing.T, svcIP net.IP, epIP net.IP, isIPv6 bool, extraSv
 		Port:           "80",
 		Protocol:       corev1.ProtocolTCP,
 	}
+	internalTrafficPolicy := corev1.ServiceInternalTrafficPolicyCluster
+	if nodeLocalInternal {
+		internalTrafficPolicy = corev1.ServiceInternalTrafficPolicyLocal
+	}
 
-	allServices := append(extraSvcs, makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *corev1.Service) {
-		svc.Spec.ClusterIP = svcIP.String()
-		svc.Spec.Ports = []corev1.ServicePort{{
-			Name:     svcPortName.Port,
-			Port:     int32(svcPort),
-			Protocol: corev1.ProtocolTCP,
-		}}
-	}))
-	makeServiceMap(fp, allServices...)
-
-	allEps := append(extraEps, makeTestEndpoints(svcPortName.Namespace, svcPortName.Name, func(ept *corev1.Endpoints) {
-		ept.Subsets = []corev1.EndpointSubset{{
-			Addresses: []corev1.EndpointAddress{{
-				IP: epIP.String(),
-			}},
-			Ports: []corev1.EndpointPort{{
+	allServices := append(extraSvcs,
+		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *corev1.Service) {
+			svc.Spec.ClusterIP = svcIP.String()
+			svc.Spec.Ports = []corev1.ServicePort{{
 				Name:     svcPortName.Port,
 				Port:     int32(svcPort),
 				Protocol: corev1.ProtocolTCP,
-			}},
-		}}
-	}))
+			}}
+			svc.Spec.InternalTrafficPolicy = &internalTrafficPolicy
+		}))
+	makeServiceMap(fp, allServices...)
+
+	remoteEndpoint := corev1.EndpointSubset{
+		Addresses: []corev1.EndpointAddress{{
+			IP: ep1IP.String(),
+		}},
+		Ports: []corev1.EndpointPort{{
+			Name:     svcPortName.Port,
+			Port:     int32(svcPort),
+			Protocol: corev1.ProtocolTCP,
+		}},
+	}
+	localEndpoint := corev1.EndpointSubset{
+		Addresses: []corev1.EndpointAddress{{
+			IP:       ep2IP.String(),
+			NodeName: &hostname,
+		}},
+		Ports: []corev1.EndpointPort{{
+			Name:     svcPortName.Port,
+			Port:     int32(svcPort),
+			Protocol: corev1.ProtocolTCP,
+		}},
+	}
+	epFunc := func(ept *corev1.Endpoints) { ept.Subsets = []corev1.EndpointSubset{localEndpoint, remoteEndpoint} }
+	allEps := append(extraEps, makeTestEndpoints(svcPortName.Namespace, svcPortName.Name, epFunc))
 	makeEndpointsMap(fp, allEps...)
 
-	groupID := fp.groupCounter.AllocateIfNotExist(svcPortName, false)
-	mockOFClient.EXPECT().InstallServiceGroup(groupID, false, gomock.Any()).Times(1)
+	expectedLocalEps := []k8sproxy.Endpoint{k8sproxy.NewBaseEndpointInfo(ep2IP.String(), svcPort, true, nil)}
+	expectedAllEps := expectedLocalEps
+	if !nodeLocalInternal {
+		expectedAllEps = append(expectedAllEps, k8sproxy.NewBaseEndpointInfo(ep1IP.String(), svcPort, false, nil))
+	}
+
 	bindingProtocol := binding.ProtocolTCP
 	if isIPv6 {
 		bindingProtocol = binding.ProtocolTCPv6
 	}
-	mockOFClient.EXPECT().InstallEndpointFlows(bindingProtocol, gomock.Any()).Times(1)
-	mockOFClient.EXPECT().InstallServiceFlows(groupID, svcIP, uint16(svcPort), bindingProtocol, uint16(0), false, corev1.ServiceTypeClusterIP).Times(1)
+
+	groupID := fp.groupCounter.AllocateIfNotExist(svcPortName, nodeLocalInternal)
+	mockOFClient.EXPECT().InstallEndpointFlows(bindingProtocol, gomock.InAnyOrder(expectedAllEps)).Times(1)
+	mockOFClient.EXPECT().InstallServiceGroup(groupID, false, gomock.InAnyOrder(expectedAllEps)).Times(1)
+	mockOFClient.EXPECT().InstallServiceFlows(groupID, svcIP, uint16(svcPort), bindingProtocol, uint16(0), nodeLocalInternal, corev1.ServiceTypeClusterIP).Times(1)
 	mockRouteClient.EXPECT().AddClusterIPRoute(svcIP).Times(1)
 
 	fp.syncProxyRules()
 }
 
-func testLoadBalancer(t *testing.T, nodePortAddresses []net.IP, svcIP, ep1IP, ep2IP, loadBalancerIP net.IP, isIPv6, nodeLocalExternal, proxyLoadBalancerIPs bool) {
+func testLoadBalancer(t *testing.T, nodePortAddresses []net.IP, svcIP, ep1IP, ep2IP, loadBalancerIP net.IP, isIPv6, nodeLocalInternal, nodeLocalExternal, proxyLoadBalancerIPs bool) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockOFClient := ofmock.NewMockClient(ctrl)
@@ -230,6 +255,10 @@ func testLoadBalancer(t *testing.T, nodePortAddresses []net.IP, svcIP, ep1IP, ep
 	if nodeLocalExternal {
 		externalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeLocal
 	}
+	internalTrafficPolicy := corev1.ServiceInternalTrafficPolicyCluster
+	if nodeLocalInternal {
+		internalTrafficPolicy = corev1.ServiceInternalTrafficPolicyLocal
+	}
 
 	makeServiceMap(fp,
 		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *corev1.Service) {
@@ -245,59 +274,79 @@ func testLoadBalancer(t *testing.T, nodePortAddresses []net.IP, svcIP, ep1IP, ep
 				Protocol: corev1.ProtocolTCP,
 			}}
 			svc.Spec.ExternalTrafficPolicy = externalTrafficPolicy
+			svc.Spec.InternalTrafficPolicy = &internalTrafficPolicy
 		}),
 	)
 
-	var eps []*corev1.Endpoints
-	epFunc := func(ept *corev1.Endpoints) {
-		ept.Subsets = []corev1.EndpointSubset{{
-			Addresses: []corev1.EndpointAddress{{
-				IP:       ep1IP.String(),
-				Hostname: "localhost",
-			}},
-			Ports: []corev1.EndpointPort{{
-				Name:     svcPortName.Port,
-				Port:     int32(svcPort),
-				Protocol: corev1.ProtocolTCP,
-			}},
-		}}
+	remoteEndpoint := corev1.EndpointSubset{
+		Addresses: []corev1.EndpointAddress{{
+			IP: ep1IP.String(),
+		}},
+		Ports: []corev1.EndpointPort{{
+			Name:     svcPortName.Port,
+			Port:     int32(svcPort),
+			Protocol: corev1.ProtocolTCP,
+		}},
 	}
-	eps = append(eps, makeTestEndpoints(svcPortName.Namespace, svcPortName.Name, epFunc))
-	if nodeLocalExternal {
-		epFunc = func(ept *corev1.Endpoints) {
-			ept.Subsets = []corev1.EndpointSubset{{
-				Addresses: []corev1.EndpointAddress{{
-					IP:       ep2IP.String(),
-					Hostname: "remote",
-				}},
-				Ports: []corev1.EndpointPort{{
-					Name:     svcPortName.Port,
-					Port:     int32(svcPort),
-					Protocol: corev1.ProtocolTCP,
-				}},
-			}}
-		}
-		eps = append(eps, makeTestEndpoints(svcPortName.Namespace, svcPortName.Name, epFunc))
+	localEndpoint := corev1.EndpointSubset{
+		Addresses: []corev1.EndpointAddress{{
+			IP:       ep2IP.String(),
+			NodeName: &hostname,
+		}},
+		Ports: []corev1.EndpointPort{{
+			Name:     svcPortName.Port,
+			Port:     int32(svcPort),
+			Protocol: corev1.ProtocolTCP,
+		}},
 	}
+
+	epFunc := func(ept *corev1.Endpoints) { ept.Subsets = []corev1.EndpointSubset{localEndpoint, remoteEndpoint} }
+	eps := []*corev1.Endpoints{makeTestEndpoints(svcPortName.Namespace, svcPortName.Name, epFunc)}
 	makeEndpointsMap(fp, eps...)
-	groupID := fp.groupCounter.AllocateIfNotExist(svcPortName, false)
+
+	expectedLocalEps := []k8sproxy.Endpoint{k8sproxy.NewBaseEndpointInfo(ep2IP.String(), svcPort, true, nil)}
+	expectedAllEps := expectedLocalEps
+	if !(nodeLocalInternal && nodeLocalExternal) {
+		expectedAllEps = append(expectedAllEps, k8sproxy.NewBaseEndpointInfo(ep1IP.String(), svcPort, false, nil))
+	}
+
 	bindingProtocol := binding.ProtocolTCP
 	if isIPv6 {
 		bindingProtocol = binding.ProtocolTCPv6
 	}
-	mockOFClient.EXPECT().InstallServiceGroup(groupID, false, gomock.Any()).Times(1)
-	mockOFClient.EXPECT().InstallEndpointFlows(bindingProtocol, gomock.Any()).Times(1)
-	mockOFClient.EXPECT().InstallServiceFlows(groupID, svcIP, uint16(svcPort), bindingProtocol, uint16(0), false, corev1.ServiceTypeClusterIP).Times(1)
-	if nodeLocalExternal {
-		groupID = fp.groupCounter.AllocateIfNotExist(svcPortName, true)
-		mockOFClient.EXPECT().InstallServiceGroup(groupID, false, gomock.Any()).Times(1)
-	}
-	if proxyLoadBalancerIPs {
-		mockOFClient.EXPECT().InstallServiceFlows(groupID, loadBalancerIP, uint16(svcPort), bindingProtocol, uint16(0), nodeLocalExternal, corev1.ServiceTypeLoadBalancer).Times(1)
-	}
-	mockOFClient.EXPECT().InstallServiceFlows(groupID, gomock.Any(), uint16(svcNodePort), bindingProtocol, uint16(0), nodeLocalExternal, corev1.ServiceTypeNodePort).Times(1)
-	if proxyLoadBalancerIPs {
-		mockOFClient.EXPECT().InstallLoadBalancerServiceFromOutsideFlows(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+	mockOFClient.EXPECT().InstallEndpointFlows(bindingProtocol, gomock.InAnyOrder(expectedAllEps)).Times(1)
+	if nodeLocalInternal != nodeLocalExternal {
+		var clusterIPEps, nodePortEps []k8sproxy.Endpoint
+		if nodeLocalInternal {
+			clusterIPEps = expectedLocalEps
+			nodePortEps = expectedAllEps
+		} else {
+			clusterIPEps = expectedAllEps
+			nodePortEps = expectedLocalEps
+		}
+		groupID := fp.groupCounter.AllocateIfNotExist(svcPortName, nodeLocalInternal)
+		mockOFClient.EXPECT().InstallServiceGroup(groupID, false, gomock.InAnyOrder(clusterIPEps)).Times(1)
+		mockOFClient.EXPECT().InstallServiceFlows(groupID, svcIP, uint16(svcPort), bindingProtocol, uint16(0), nodeLocalInternal, corev1.ServiceTypeClusterIP).Times(1)
+		groupID = fp.groupCounter.AllocateIfNotExist(svcPortName, nodeLocalExternal)
+		mockOFClient.EXPECT().InstallServiceGroup(groupID, false, gomock.InAnyOrder(nodePortEps)).Times(1)
+		mockOFClient.EXPECT().InstallServiceFlows(groupID, gomock.Any(), uint16(svcNodePort), bindingProtocol, uint16(0), nodeLocalExternal, corev1.ServiceTypeNodePort).Times(1)
+		if proxyLoadBalancerIPs {
+			mockOFClient.EXPECT().InstallServiceFlows(groupID, loadBalancerIP, uint16(svcPort), bindingProtocol, uint16(0), nodeLocalExternal, corev1.ServiceTypeLoadBalancer).Times(1)
+			mockOFClient.EXPECT().InstallLoadBalancerServiceFromOutsideFlows(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+		}
+	} else {
+		nodeLocalVal := nodeLocalInternal && nodeLocalExternal
+		groupID := fp.groupCounter.AllocateIfNotExist(svcPortName, nodeLocalVal)
+		mockOFClient.EXPECT().InstallServiceGroup(groupID, false, gomock.InAnyOrder(expectedAllEps)).Times(1)
+		mockOFClient.EXPECT().InstallServiceFlows(groupID, svcIP, uint16(svcPort), bindingProtocol, uint16(0), nodeLocalVal, corev1.ServiceTypeClusterIP).Times(1)
+		mockOFClient.EXPECT().InstallServiceFlows(groupID, gomock.Any(), uint16(svcNodePort), bindingProtocol, uint16(0), nodeLocalVal, corev1.ServiceTypeNodePort).Times(1)
+		if proxyLoadBalancerIPs {
+			mockOFClient.EXPECT().InstallServiceFlows(groupID, loadBalancerIP, uint16(svcPort), bindingProtocol, uint16(0), nodeLocalVal, corev1.ServiceTypeLoadBalancer).Times(1)
+			mockOFClient.EXPECT().InstallLoadBalancerServiceFromOutsideFlows(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+		}
+		groupID = fp.groupCounter.AllocateIfNotExist(svcPortName, !nodeLocalVal)
+		mockOFClient.EXPECT().UninstallServiceGroup(groupID).Times(1)
 	}
 	mockRouteClient.EXPECT().AddClusterIPRoute(svcIP).Times(1)
 	if proxyLoadBalancerIPs {
@@ -308,7 +357,7 @@ func testLoadBalancer(t *testing.T, nodePortAddresses []net.IP, svcIP, ep1IP, ep
 	fp.syncProxyRules()
 }
 
-func testNodePort(t *testing.T, nodePortAddresses []net.IP, svcIP, ep1IP, ep2IP net.IP, isIPv6, nodeLocalExternal bool) {
+func testNodePort(t *testing.T, nodePortAddresses []net.IP, svcIP, ep1IP, ep2IP net.IP, isIPv6, nodeLocalInternal, nodeLocalExternal bool) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockOFClient := ofmock.NewMockClient(ctrl)
@@ -326,6 +375,10 @@ func testNodePort(t *testing.T, nodePortAddresses []net.IP, svcIP, ep1IP, ep2IP 
 	if nodeLocalExternal {
 		externalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeLocal
 	}
+	internalTrafficPolicy := corev1.ServiceInternalTrafficPolicyCluster
+	if nodeLocalInternal {
+		internalTrafficPolicy = corev1.ServiceInternalTrafficPolicyLocal
+	}
 
 	makeServiceMap(fp,
 		makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *corev1.Service) {
@@ -338,56 +391,81 @@ func testNodePort(t *testing.T, nodePortAddresses []net.IP, svcIP, ep1IP, ep2IP 
 				Protocol: corev1.ProtocolTCP,
 			}}
 			svc.Spec.ExternalTrafficPolicy = externalTrafficPolicy
+			svc.Spec.InternalTrafficPolicy = &internalTrafficPolicy
 		}),
 	)
 
+	remoteEndpoint := corev1.EndpointSubset{
+		Addresses: []corev1.EndpointAddress{{
+			IP: ep1IP.String(),
+		}},
+		Ports: []corev1.EndpointPort{{
+			Name:     svcPortName.Port,
+			Port:     int32(svcPort),
+			Protocol: corev1.ProtocolTCP,
+		}},
+	}
+	localEndpoint := corev1.EndpointSubset{
+		Addresses: []corev1.EndpointAddress{{
+			IP:       ep2IP.String(),
+			NodeName: &hostname,
+		}},
+		Ports: []corev1.EndpointPort{{
+			Name:     svcPortName.Port,
+			Port:     int32(svcPort),
+			Protocol: corev1.ProtocolTCP,
+		}},
+	}
+
 	var eps []*corev1.Endpoints
 	epFunc := func(ept *corev1.Endpoints) {
-		ept.Subsets = []corev1.EndpointSubset{{
-			Addresses: []corev1.EndpointAddress{{
-				IP:       ep1IP.String(),
-				Hostname: "localhost",
-			}},
-			Ports: []corev1.EndpointPort{{
-				Name:     svcPortName.Port,
-				Port:     int32(svcPort),
-				Protocol: corev1.ProtocolTCP,
-			}},
-		}}
+		if nodeLocalInternal && nodeLocalExternal {
+			ept.Subsets = []corev1.EndpointSubset{localEndpoint}
+		} else {
+			ept.Subsets = []corev1.EndpointSubset{localEndpoint, remoteEndpoint}
+		}
 	}
 	eps = append(eps, makeTestEndpoints(svcPortName.Namespace, svcPortName.Name, epFunc))
-	if nodeLocalExternal {
-		epFunc = func(ept *corev1.Endpoints) {
-			ept.Subsets = []corev1.EndpointSubset{{
-				Addresses: []corev1.EndpointAddress{{
-					IP:       ep2IP.String(),
-					Hostname: "remote",
-				}},
-				Ports: []corev1.EndpointPort{{
-					Name:     svcPortName.Port,
-					Port:     int32(svcPort),
-					Protocol: corev1.ProtocolTCP,
-				}},
-			}}
-		}
-		eps = append(eps, makeTestEndpoints(svcPortName.Namespace, svcPortName.Name, epFunc))
-	}
 	makeEndpointsMap(fp, eps...)
 
-	groupID := fp.groupCounter.AllocateIfNotExist(svcPortName, false)
+	expectedLocalEps := []k8sproxy.Endpoint{k8sproxy.NewBaseEndpointInfo(ep2IP.String(), svcPort, true, nil)}
+	expectedAllEps := expectedLocalEps
+	if !(nodeLocalInternal && nodeLocalExternal) {
+		expectedAllEps = append(expectedAllEps, k8sproxy.NewBaseEndpointInfo(ep1IP.String(), svcPort, false, nil))
+	}
+
 	bindingProtocol := binding.ProtocolTCP
 	if isIPv6 {
 		bindingProtocol = binding.ProtocolTCPv6
 	}
-	mockOFClient.EXPECT().InstallServiceGroup(groupID, false, gomock.Any()).Times(1)
-	mockOFClient.EXPECT().InstallEndpointFlows(bindingProtocol, gomock.Any()).Times(1)
-	mockOFClient.EXPECT().InstallServiceFlows(groupID, svcIP, uint16(svcPort), bindingProtocol, uint16(0), false, corev1.ServiceTypeClusterIP).Times(1)
-	if nodeLocalExternal {
-		groupID = fp.groupCounter.AllocateIfNotExist(svcPortName, true)
-		mockOFClient.EXPECT().InstallServiceGroup(groupID, false, gomock.Any()).Times(1)
-	}
 
-	mockOFClient.EXPECT().InstallServiceFlows(groupID, gomock.Any(), uint16(svcNodePort), bindingProtocol, uint16(0), nodeLocalExternal, corev1.ServiceTypeNodePort).Times(1)
+	mockOFClient.EXPECT().InstallEndpointFlows(bindingProtocol, gomock.InAnyOrder(expectedAllEps)).Times(1)
+	if nodeLocalInternal != nodeLocalExternal {
+		var clusterIPEps, nodePortEps []k8sproxy.Endpoint
+		if nodeLocalInternal {
+			clusterIPEps = expectedLocalEps
+			nodePortEps = expectedAllEps
+		} else {
+			clusterIPEps = expectedAllEps
+			nodePortEps = expectedLocalEps
+		}
+		groupID := fp.groupCounter.AllocateIfNotExist(svcPortName, nodeLocalInternal)
+		mockOFClient.EXPECT().InstallServiceGroup(groupID, false, gomock.InAnyOrder(clusterIPEps)).Times(1)
+		mockOFClient.EXPECT().InstallServiceFlows(groupID, svcIP, uint16(svcPort), bindingProtocol, uint16(0), nodeLocalInternal, corev1.ServiceTypeClusterIP).Times(1)
+
+		groupID = fp.groupCounter.AllocateIfNotExist(svcPortName, nodeLocalExternal)
+		mockOFClient.EXPECT().InstallServiceGroup(groupID, false, gomock.InAnyOrder(nodePortEps)).Times(1)
+		mockOFClient.EXPECT().InstallServiceFlows(groupID, gomock.Any(), uint16(svcNodePort), bindingProtocol, uint16(0), nodeLocalExternal, corev1.ServiceTypeNodePort).Times(1)
+	} else {
+		nodeLocalVal := nodeLocalInternal && nodeLocalExternal
+		groupID := fp.groupCounter.AllocateIfNotExist(svcPortName, nodeLocalVal)
+		mockOFClient.EXPECT().InstallServiceGroup(groupID, false, gomock.InAnyOrder(expectedAllEps)).Times(1)
+		mockOFClient.EXPECT().InstallServiceFlows(groupID, svcIP, uint16(svcPort), bindingProtocol, uint16(0), nodeLocalVal, corev1.ServiceTypeClusterIP).Times(1)
+		mockOFClient.EXPECT().InstallServiceFlows(groupID, gomock.Any(), uint16(svcNodePort), bindingProtocol, uint16(0), nodeLocalVal, corev1.ServiceTypeNodePort).Times(1)
+
+		groupID = fp.groupCounter.AllocateIfNotExist(svcPortName, !nodeLocalVal)
+		mockOFClient.EXPECT().UninstallServiceGroup(groupID).Times(1)
+	}
 	mockRouteClient.EXPECT().AddClusterIPRoute(svcIP).Times(1)
 	mockRouteClient.EXPECT().AddNodePort(gomock.Any(), uint16(svcNodePort), bindingProtocol).Times(1)
 	mockOFClient.EXPECT().InstallLoadBalancerServiceFromOutsideFlows(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
@@ -395,48 +473,91 @@ func testNodePort(t *testing.T, nodePortAddresses []net.IP, svcIP, ep1IP, ep2IP 
 	fp.syncProxyRules()
 }
 
-func TestLoadBalancerIPv4(t *testing.T) {
-	testLoadBalancer(t, nodePortAddressesIPv4, svcIPv4, ep1IPv4, nil, loadBalancerIPv4, false, false, true)
+func TestCluster(t *testing.T) {
+	t.Run("IPv4", func(t *testing.T) {
+		t.Run("InternalTrafficPolicy Cluster", func(t *testing.T) {
+			testClusterIP(t, svcIPv4, ep1IPv4, ep2IPv4, false, false, []*corev1.Service{}, []*corev1.Endpoints{})
+		})
+		t.Run("InternalTrafficPolicy Local", func(t *testing.T) {
+			testClusterIP(t, svcIPv4, ep1IPv4, ep2IPv4, false, true, []*corev1.Service{}, []*corev1.Endpoints{})
+		})
+	})
+	t.Run("IPv6", func(t *testing.T) {
+		t.Run("InternalTrafficPolicy Cluster", func(t *testing.T) {
+			testClusterIP(t, svcIPv6, ep1IPv6, ep2IPv6, true, false, []*corev1.Service{}, []*corev1.Endpoints{})
+		})
+		t.Run("InternalTrafficPolicy Local", func(t *testing.T) {
+			testClusterIP(t, svcIPv6, ep1IPv6, ep2IPv6, true, true, []*corev1.Service{}, []*corev1.Endpoints{})
+		})
+	})
 }
 
-func TestLoadBalancerIPv4ExternalLocal(t *testing.T) {
-	testLoadBalancer(t, nodePortAddressesIPv4, svcIPv4, ep1IPv4, ep2IPv4, loadBalancerIPv4, false, true, true)
+func TestLoadBalancer(t *testing.T) {
+	t.Run("IPv4", func(t *testing.T) {
+		t.Run("InternalTrafficPolicy:Cluster ExternalTrafficPolicy:Cluster", func(t *testing.T) {
+			testLoadBalancer(t, nodePortAddressesIPv4, svcIPv4, ep1IPv4, ep2IPv4, loadBalancerIPv4, false, false, false, true)
+		})
+		t.Run("InternalTrafficPolicy:Cluster ExternalTrafficPolicy:Local", func(t *testing.T) {
+			testLoadBalancer(t, nodePortAddressesIPv4, svcIPv4, ep1IPv4, ep2IPv4, loadBalancerIPv4, false, false, true, true)
+		})
+		t.Run("InternalTrafficPolicy:Local ExternalTrafficPolicy:Cluster", func(t *testing.T) {
+			testLoadBalancer(t, nodePortAddressesIPv4, svcIPv4, ep1IPv4, ep2IPv4, loadBalancerIPv4, false, true, false, true)
+		})
+		t.Run("InternalTrafficPolicy:Local ExternalTrafficPolicy:Local", func(t *testing.T) {
+			testLoadBalancer(t, nodePortAddressesIPv4, svcIPv4, ep1IPv4, ep2IPv4, loadBalancerIPv4, false, true, true, true)
+		})
+		t.Run("No External IPs", func(t *testing.T) {
+			testLoadBalancer(t, nodePortAddressesIPv4, svcIPv4, ep1IPv4, nil, loadBalancerIPv4, false, false, false, false)
+		})
+	})
+	t.Run("IPv6", func(t *testing.T) {
+		t.Run("InternalTrafficPolicy:Cluster ExternalTrafficPolicy:Cluster", func(t *testing.T) {
+			testLoadBalancer(t, nodePortAddressesIPv6, svcIPv6, ep1IPv6, ep2IPv6, loadBalancerIPv6, true, false, false, true)
+		})
+		t.Run("InternalTrafficPolicy:Cluster ExternalTrafficPolicy:Local", func(t *testing.T) {
+			testLoadBalancer(t, nodePortAddressesIPv6, svcIPv6, ep1IPv6, ep2IPv6, loadBalancerIPv6, true, false, true, true)
+		})
+		t.Run("InternalTrafficPolicy:Local ExternalTrafficPolicy:Cluster", func(t *testing.T) {
+			testLoadBalancer(t, nodePortAddressesIPv6, svcIPv6, ep1IPv6, ep2IPv6, loadBalancerIPv6, true, true, false, true)
+		})
+		t.Run("InternalTrafficPolicy:Local ExternalTrafficPolicy:Local", func(t *testing.T) {
+			testLoadBalancer(t, nodePortAddressesIPv6, svcIPv6, ep1IPv6, ep2IPv6, loadBalancerIPv6, true, true, true, true)
+		})
+		t.Run("No External IPs", func(t *testing.T) {
+			testLoadBalancer(t, nodePortAddressesIPv6, svcIPv6, ep1IPv6, nil, loadBalancerIPv6, true, false, false, false)
+		})
+	})
 }
 
-func TestLoadBalancerIPv6(t *testing.T) {
-	testLoadBalancer(t, nodePortAddressesIPv6, svcIPv6, ep1IPv6, nil, loadBalancerIPv6, true, false, true)
-}
-
-func TestLoadBalancerIPv6ExternalLocal(t *testing.T) {
-	testLoadBalancer(t, nodePortAddressesIPv6, svcIPv6, ep1IPv6, ep2IPv6, loadBalancerIPv6, true, true, true)
-}
-
-func TestLoadBalancerIPv4NoExternalIPs(t *testing.T) {
-	testLoadBalancer(t, nodePortAddressesIPv4, svcIPv4, ep1IPv4, nil, loadBalancerIPv4, false, false, false)
-}
-
-func TestNodePortIPv4(t *testing.T) {
-	testNodePort(t, nodePortAddressesIPv4, svcIPv4, ep1IPv4, nil, false, false)
-}
-
-func TestNodePortIPv4ExternalLocal(t *testing.T) {
-	testNodePort(t, nodePortAddressesIPv4, svcIPv4, ep1IPv4, ep2IPv4, false, true)
-}
-
-func TestNodePortIPv6(t *testing.T) {
-	testNodePort(t, nodePortAddressesIPv6, svcIPv6, ep1IPv6, nil, true, false)
-}
-
-func TestNodePortIPv6ExternalLocal(t *testing.T) {
-	testNodePort(t, nodePortAddressesIPv6, svcIPv6, ep1IPv6, ep2IPv6, true, true)
-}
-
-func TestClusterIPv4(t *testing.T) {
-	testClusterIP(t, svcIPv4, ep1IPv4, false, []*corev1.Service{}, []*corev1.Endpoints{})
-}
-
-func TestClusterIPv6(t *testing.T) {
-	testClusterIP(t, svcIPv6, ep1IPv6, true, []*corev1.Service{}, []*corev1.Endpoints{})
+func TestNodePort(t *testing.T) {
+	t.Run("IPv4", func(t *testing.T) {
+		t.Run("InternalTrafficPolicy:Cluster ExternalTrafficPolicy:Cluster", func(t *testing.T) {
+			testNodePort(t, nodePortAddressesIPv4, svcIPv4, ep1IPv4, ep2IPv4, false, false, false)
+		})
+		t.Run("InternalTrafficPolicy:Cluster ExternalTrafficPolicy:Local", func(t *testing.T) {
+			testNodePort(t, nodePortAddressesIPv4, svcIPv4, ep1IPv4, ep2IPv4, false, false, true)
+		})
+		t.Run("InternalTrafficPolicy:Local ExternalTrafficPolicy:Cluster", func(t *testing.T) {
+			testNodePort(t, nodePortAddressesIPv4, svcIPv4, ep1IPv4, ep2IPv4, false, true, false)
+		})
+		t.Run("InternalTrafficPolicy:Local ExternalTrafficPolicy:Local", func(t *testing.T) {
+			testNodePort(t, nodePortAddressesIPv4, svcIPv4, ep1IPv4, ep2IPv4, false, true, true)
+		})
+	})
+	t.Run("IPv6", func(t *testing.T) {
+		t.Run("InternalTrafficPolicy:Cluster ExternalTrafficPolicy:Cluster", func(t *testing.T) {
+			testNodePort(t, nodePortAddressesIPv6, svcIPv6, ep1IPv6, ep2IPv6, true, false, false)
+		})
+		t.Run("InternalTrafficPolicy:Cluster ExternalTrafficPolicy:Local", func(t *testing.T) {
+			testNodePort(t, nodePortAddressesIPv6, svcIPv6, ep1IPv6, ep2IPv6, true, false, true)
+		})
+		t.Run("InternalTrafficPolicy:Local ExternalTrafficPolicy:Cluster", func(t *testing.T) {
+			testNodePort(t, nodePortAddressesIPv6, svcIPv6, ep1IPv6, ep2IPv6, true, true, false)
+		})
+		t.Run("InternalTrafficPolicy:Local ExternalTrafficPolicy:Local", func(t *testing.T) {
+			testNodePort(t, nodePortAddressesIPv6, svcIPv6, ep1IPv6, ep2IPv6, true, true, true)
+		})
+	})
 }
 
 func TestClusterSkipServices(t *testing.T) {
@@ -495,7 +616,7 @@ func TestClusterSkipServices(t *testing.T) {
 		}}
 	})
 	eps := []*corev1.Endpoints{ep1, ep2}
-	testClusterIP(t, svcIPv4, ep1IPv4, false, svcs, eps)
+	testClusterIP(t, svcIPv4, ep1IPv4, ep2IPv4, false, false, svcs, eps)
 }
 
 func TestDualStackService(t *testing.T) {
@@ -1106,12 +1227,12 @@ func TestMetrics(t *testing.T) {
 	metrics.Register()
 
 	for _, tc := range []struct {
-		name        string
-		svcIP, epIP string
-		isIPv6      bool
+		name                string
+		svcIP, ep1IP, ep2IP net.IP
+		isIPv6              bool
 	}{
-		{"IPv4", "10.20.30.41", "10.180.0.1", false},
-		{"IPv6", "fc01::1", "fe01::1", true},
+		{"IPv4", svcIPv4, ep1IPv4, ep2IPv4, false},
+		{"IPv6", svcIPv6, ep1IPv6, ep2IPv6, true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			endpointsUpdateTotalMetric := metrics.EndpointsUpdatesTotal.CounterMetric
@@ -1124,7 +1245,7 @@ func TestMetrics(t *testing.T) {
 				endpointsInstallMetric = metrics.EndpointsInstalledTotalV6.GaugeMetric
 				servicesInstallMetric = metrics.ServicesInstalledTotalV6.GaugeMetric
 			}
-			testClusterIP(t, net.ParseIP(tc.svcIP), net.ParseIP(tc.epIP), tc.isIPv6, []*corev1.Service{}, []*corev1.Endpoints{})
+			testClusterIP(t, tc.svcIP, tc.ep1IP, tc.ep2IP, tc.isIPv6, false, []*corev1.Service{}, []*corev1.Endpoints{})
 			v, err := testutil.GetCounterMetricValue(endpointsUpdateTotalMetric)
 			assert.NoError(t, err)
 			assert.Equal(t, 0, int(v))
@@ -1135,10 +1256,10 @@ func TestMetrics(t *testing.T) {
 			assert.Equal(t, 1, int(v))
 			assert.NoError(t, err)
 			v, err = testutil.GetGaugeMetricValue(endpointsInstallMetric)
-			assert.Equal(t, 1, int(v))
+			assert.Equal(t, 2, int(v))
 			assert.NoError(t, err)
 
-			testClusterIPRemoval(t, net.ParseIP(tc.svcIP), net.ParseIP(tc.epIP), tc.isIPv6)
+			testClusterIPRemoval(t, tc.svcIP, tc.ep1IP, tc.isIPv6)
 
 			v, err = testutil.GetCounterMetricValue(endpointsUpdateTotalMetric)
 			assert.NoError(t, err)


### PR DESCRIPTION
Cherry pick of #3340 #2792 on release-1.5.

#3340: Add method AllocateIfNotExist to interface GroupCounter in
#2792: Support InternalTrafficPolicy in AntreaProxy

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.