### PR TITLE
Fix FQDN policy support for IPv6

### DIFF
--- a/build/charts/antrea/README.md
+++ b/build/charts/antrea/README.md
@@ -64,6 +64,7 @@ Kubernetes: `>= 1.16.0-0`
 | controller.tolerations | list | `[{"key":"CriticalAddonsOnly","operator":"Exists"},{"effect":"NoSchedule","key":"node-role.kubernetes.io/master"},{"effect":"NoSchedule","key":"node-role.kubernetes.io/control-plane"}]` | Tolerations for the antrea-controller Pod. |
 | defaultMTU | int | `0` | Default MTU to use for the host gateway interface and the network interface of each Pod. By default, antrea-agent will discover the MTU of the Node's primary interface and adjust it to accommodate for tunnel encapsulation overhead if applicable. |
 | disableTXChecksumOffload | bool | `false` | Disable TX checksum offloading for container network interfaces. It's supposed to be set to true when the datapath doesn't support TX checksum offloading, which causes packets to be dropped due to bad checksum. It affects Pods running on Linux Nodes only. |
+| dnsServerOverride | string | `""` | Address of DNS server, to override the kube-dns service. It's used to resolve hostname in FQDN policy. |
 | egress.exceptCIDRs | list | `[]` | CIDR ranges to which outbound Pod traffic will not be SNAT'd by Egresses. |
 | enableBridgingMode | bool | `false` | Enable bridging mode of Pod network on Nodes, in which the Node's transport interface is connected to the OVS bridge. |
 | featureGates | object | `{}` | To explicitly enable or disable a FeatureGate and bypass the Antrea defaults, add an entry to the dictionary with the FeatureGate's name as the key and a boolean as the value. |

--- a/build/charts/antrea/conf/antrea-agent.conf
+++ b/build/charts/antrea/conf/antrea-agent.conf
@@ -211,6 +211,11 @@ nodePortLocal:
 # Defaults to "". It must be a host string, a host:port pair, or a URL to the base of the apiserver.
 kubeAPIServerOverride: {{ .Values.kubeAPIServerOverride | quote }}
 
+# Provide the address of DNS server, to override the kube-dns service. It's used to resolve hostname in FQDN policy.
+# Defaults to "". It must be a host string or a host:port pair of the DNS server (e.g. 10.96.0.10, 10.96.0.10:53,
+# [fd00:10:96::a]:53).
+dnsServerOverride: {{ .Values.dnsServerOverride | quote }}
+
 # Comma-separated list of Cipher Suites. If omitted, the default Go Cipher Suites will be used.
 # https://golang.org/pkg/crypto/tls/#pkg-constants
 # Note that TLS1.3 Cipher Suites cannot be added to the list. But the apiserver will always

--- a/build/charts/antrea/values.yaml
+++ b/build/charts/antrea/values.yaml
@@ -111,6 +111,9 @@ nodeIPAM:
 # -- Address of Kubernetes apiserver, to override any value provided in
 # kubeconfig or InClusterConfig.
 kubeAPIServerOverride: ""
+# -- Address of DNS server, to override the kube-dns service. It's used to
+# resolve hostname in FQDN policy.
+dnsServerOverride: ""
 # -- IPv4 CIDR range used for Services. Required when AntreaProxy is disabled.
 serviceCIDR: ""
 # -- IPv6 CIDR range used for Services. Required when AntreaProxy is disabled.

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -260,6 +260,11 @@ data:
     # Defaults to "". It must be a host string, a host:port pair, or a URL to the base of the apiserver.
     kubeAPIServerOverride: ""
 
+    # Provide the address of DNS server, to override the kube-dns service. It's used to resolve hostname in FQDN policy.
+    # Defaults to "". It must be a host string or a host:port pair of the DNS server (e.g. 10.96.0.10, 10.96.0.10:53,
+    # [fd00:10:96::a]:53).
+    dnsServerOverride: ""
+
     # Comma-separated list of Cipher Suites. If omitted, the default Go Cipher Suites will be used.
     # https://golang.org/pkg/crypto/tls/#pkg-constants
     # Note that TLS1.3 Cipher Suites cannot be added to the list. But the apiserver will always
@@ -3653,7 +3658,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 1ede67e825b3122edca49b4f5bbb8932a921260b686a02c10c8889de24c8ae0f
+        checksum/config: 383ff5ded38b5b95e8425a1d95e1d9460b8c460beaaa3c93a89af286582fcd30
       labels:
         app: antrea
         component: antrea-agent
@@ -3893,7 +3898,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 1ede67e825b3122edca49b4f5bbb8932a921260b686a02c10c8889de24c8ae0f
+        checksum/config: 383ff5ded38b5b95e8425a1d95e1d9460b8c460beaaa3c93a89af286582fcd30
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -260,6 +260,11 @@ data:
     # Defaults to "". It must be a host string, a host:port pair, or a URL to the base of the apiserver.
     kubeAPIServerOverride: ""
 
+    # Provide the address of DNS server, to override the kube-dns service. It's used to resolve hostname in FQDN policy.
+    # Defaults to "". It must be a host string or a host:port pair of the DNS server (e.g. 10.96.0.10, 10.96.0.10:53,
+    # [fd00:10:96::a]:53).
+    dnsServerOverride: ""
+
     # Comma-separated list of Cipher Suites. If omitted, the default Go Cipher Suites will be used.
     # https://golang.org/pkg/crypto/tls/#pkg-constants
     # Note that TLS1.3 Cipher Suites cannot be added to the list. But the apiserver will always
@@ -3653,7 +3658,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 1ede67e825b3122edca49b4f5bbb8932a921260b686a02c10c8889de24c8ae0f
+        checksum/config: 383ff5ded38b5b95e8425a1d95e1d9460b8c460beaaa3c93a89af286582fcd30
       labels:
         app: antrea
         component: antrea-agent
@@ -3895,7 +3900,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 1ede67e825b3122edca49b4f5bbb8932a921260b686a02c10c8889de24c8ae0f
+        checksum/config: 383ff5ded38b5b95e8425a1d95e1d9460b8c460beaaa3c93a89af286582fcd30
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -260,6 +260,11 @@ data:
     # Defaults to "". It must be a host string, a host:port pair, or a URL to the base of the apiserver.
     kubeAPIServerOverride: ""
 
+    # Provide the address of DNS server, to override the kube-dns service. It's used to resolve hostname in FQDN policy.
+    # Defaults to "". It must be a host string or a host:port pair of the DNS server (e.g. 10.96.0.10, 10.96.0.10:53,
+    # [fd00:10:96::a]:53).
+    dnsServerOverride: ""
+
     # Comma-separated list of Cipher Suites. If omitted, the default Go Cipher Suites will be used.
     # https://golang.org/pkg/crypto/tls/#pkg-constants
     # Note that TLS1.3 Cipher Suites cannot be added to the list. But the apiserver will always
@@ -3653,7 +3658,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 2f5a57b910bfb442df5abb3268308a3f4ad8f69d506e4281dddad39dab334690
+        checksum/config: 2823eb19e0a70cef89aed13b32f58289850fe096cf1ab57788f7f5fa5a8522e4
       labels:
         app: antrea
         component: antrea-agent
@@ -3893,7 +3898,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 2f5a57b910bfb442df5abb3268308a3f4ad8f69d506e4281dddad39dab334690
+        checksum/config: 2823eb19e0a70cef89aed13b32f58289850fe096cf1ab57788f7f5fa5a8522e4
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -273,6 +273,11 @@ data:
     # Defaults to "". It must be a host string, a host:port pair, or a URL to the base of the apiserver.
     kubeAPIServerOverride: ""
 
+    # Provide the address of DNS server, to override the kube-dns service. It's used to resolve hostname in FQDN policy.
+    # Defaults to "". It must be a host string or a host:port pair of the DNS server (e.g. 10.96.0.10, 10.96.0.10:53,
+    # [fd00:10:96::a]:53).
+    dnsServerOverride: ""
+
     # Comma-separated list of Cipher Suites. If omitted, the default Go Cipher Suites will be used.
     # https://golang.org/pkg/crypto/tls/#pkg-constants
     # Note that TLS1.3 Cipher Suites cannot be added to the list. But the apiserver will always
@@ -3666,7 +3671,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 009306e63cddc96c9dd51d20543783c6a94e9859581dc9db4dffacc8a78976bc
+        checksum/config: 8163f2a3f77f88fe96aa80678572ff05cf3c2c4ef328398b0757dcc97ddcd07f
         checksum/ipsec-secret: d0eb9c52d0cd4311b6d252a951126bf9bea27ec05590bed8a394f0f792dcb2a4
       labels:
         app: antrea
@@ -3952,7 +3957,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 009306e63cddc96c9dd51d20543783c6a94e9859581dc9db4dffacc8a78976bc
+        checksum/config: 8163f2a3f77f88fe96aa80678572ff05cf3c2c4ef328398b0757dcc97ddcd07f
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -260,6 +260,11 @@ data:
     # Defaults to "". It must be a host string, a host:port pair, or a URL to the base of the apiserver.
     kubeAPIServerOverride: ""
 
+    # Provide the address of DNS server, to override the kube-dns service. It's used to resolve hostname in FQDN policy.
+    # Defaults to "". It must be a host string or a host:port pair of the DNS server (e.g. 10.96.0.10, 10.96.0.10:53,
+    # [fd00:10:96::a]:53).
+    dnsServerOverride: ""
+
     # Comma-separated list of Cipher Suites. If omitted, the default Go Cipher Suites will be used.
     # https://golang.org/pkg/crypto/tls/#pkg-constants
     # Note that TLS1.3 Cipher Suites cannot be added to the list. But the apiserver will always
@@ -3653,7 +3658,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 9f60e42d8b53705c8d6fa0f789b0b362e78e81a93f4ae71dc590b95fb4a4933d
+        checksum/config: 4b7179ecedf5e1c5c9b7e2c368de17411bfd51084f2ab7901eff2394da306dbe
       labels:
         app: antrea
         component: antrea-agent
@@ -3893,7 +3898,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 9f60e42d8b53705c8d6fa0f789b0b362e78e81a93f4ae71dc590b95fb4a4933d
+        checksum/config: 4b7179ecedf5e1c5c9b7e2c368de17411bfd51084f2ab7901eff2394da306dbe
       labels:
         app: antrea
         component: antrea-controller

--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -346,7 +346,7 @@ func run(o *Options) error {
 		multicastEnabled,
 		loggingEnabled,
 		asyncRuleDeleteInterval,
-		o.config.DNSServerOverride,
+		o.dnsServerOverride,
 		v4Enabled,
 		v6Enabled)
 	if err != nil {

--- a/cmd/antrea-agent/options.go
+++ b/cmd/antrea-agent/options.go
@@ -33,6 +33,7 @@ import (
 	"antrea.io/antrea/pkg/ovs/ovsconfig"
 	"antrea.io/antrea/pkg/util/env"
 	"antrea.io/antrea/pkg/util/flowexport"
+	"antrea.io/antrea/pkg/util/ip"
 )
 
 const (
@@ -72,6 +73,8 @@ type Options struct {
 	igmpQueryInterval      time.Duration
 	nplStartPort           int
 	nplEndPort             int
+
+	dnsServerOverride string
 }
 
 func newOptions() *Options {
@@ -198,6 +201,15 @@ func (o *Options) validate(args []string) error {
 	}
 	if err := o.validateAntreaIPAMConfig(); err != nil {
 		return fmt.Errorf("failed to validate AntreaIPAM config: %v", err)
+	}
+
+	if o.config.DNSServerOverride != "" {
+		hostPort := ip.AppendPortIfMissing(o.config.DNSServerOverride, "53")
+		_, _, err := net.SplitHostPort(hostPort)
+		if err != nil {
+			return fmt.Errorf("dnsServerOverride %s is invalid: %v", o.config.DNSServerOverride, err)
+		}
+		o.dnsServerOverride = hostPort
 	}
 	return nil
 }

--- a/pkg/agent/controller/networkpolicy/fqdn.go
+++ b/pkg/agent/controller/networkpolicy/fqdn.go
@@ -181,7 +181,7 @@ func newFQDNController(client openflow.Client, allocator *idAllocator, dnsServer
 			klog.InfoS("Unable to derive DNS server from the kube-dns Service, will fall back to local resolver")
 			controller.dnsServerAddr = ""
 		} else {
-			controller.dnsServerAddr = host + ":" + port
+			controller.dnsServerAddr = net.JoinHostPort(host, port)
 			klog.InfoS("Using kube-dns Service for DNS requests", "dnsServer", controller.dnsServerAddr)
 		}
 	}

--- a/pkg/config/agent/config.go
+++ b/pkg/config/agent/config.go
@@ -164,7 +164,8 @@ type AgentConfig struct {
 	// Defaults to "". It must be a host string, a host:port pair, or a URL to the base of the apiserver.
 	KubeAPIServerOverride string `yaml:"kubeAPIServerOverride,omitempty"`
 	// Provide the address of DNS server, to override the kube-dns service. It's used to resolve hostname in FQDN policy.
-	// Defaults to "". It must be a host string or a host:port pair of the dns server.
+	// Defaults to "". It must be a host string or a host:port pair of the DNS server (e.g. 10.96.0.10, 10.96.0.10:53,
+	// [fd00:10:96::a]:53).
 	DNSServerOverride string `yaml:"dnsServerOverride,omitempty"`
 	// Cipher suites to use.
 	TLSCipherSuites string `yaml:"tlsCipherSuites,omitempty"`

--- a/pkg/util/ip/ip.go
+++ b/pkg/util/ip/ip.go
@@ -211,3 +211,18 @@ func GetLocalBroadcastIP(ipNet *net.IPNet) net.IP {
 	binary.BigEndian.PutUint32(lastAddr, binary.BigEndian.Uint32(ipNet.IP.To4())|^binary.BigEndian.Uint32(net.IP(ipNet.Mask).To4()))
 	return lastAddr
 }
+
+// AppendPortIfMissing appends the given port to the address if the address doesn't contain any port.
+func AppendPortIfMissing(addr, port string) string {
+	if _, _, err := net.SplitHostPort(addr); err == nil {
+		return addr
+	}
+
+	ip := net.ParseIP(addr)
+	// Return the address directly if it's not a valid address.
+	if ip == nil {
+		return addr
+	}
+
+	return net.JoinHostPort(addr, port)
+}

--- a/pkg/util/ip/ip_test.go
+++ b/pkg/util/ip/ip_test.go
@@ -186,3 +186,56 @@ func TestMustIPv6(t *testing.T) {
 		})
 	}
 }
+
+func TestAppendPortIfMissing(t *testing.T) {
+	tests := []struct {
+		name string
+		addr string
+		port string
+		want string
+	}{
+		{
+			name: "IPv4 address without port",
+			addr: "10.96.0.10",
+			port: "80",
+			want: "10.96.0.10:80",
+		},
+		{
+			name: "IPv4 address with port",
+			addr: "10.96.0.10:53",
+			port: "80",
+			want: "10.96.0.10:53",
+		},
+		{
+			name: "IPv6 address without port",
+			addr: "fd00:10:96::a",
+			port: "80",
+			want: "[fd00:10:96::a]:80",
+		},
+		{
+			name: "IPv6 address with port",
+			addr: "[fd00:10:96::a]:53",
+			port: "80",
+			want: "[fd00:10:96::a]:53",
+		},
+		{
+			name: "Empty address",
+			addr: "",
+			port: "80",
+			want: "",
+		},
+		{
+			name: "Invalid address",
+			addr: "10.96.0.10.6",
+			port: "80",
+			want: "10.96.0.10.6",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := AppendPortIfMissing(tt.addr, tt.port); got != tt.want {
+				t.Errorf("AppendPortIfMissing() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/test/e2e/antreapolicy_test.go
+++ b/test/e2e/antreapolicy_test.go
@@ -2580,19 +2580,22 @@ func testFQDNPolicyInClusterService(t *testing.T) {
 		eachServiceCases := []podToAddrTestStep{
 			{
 				Pod(namespaces["y"] + "/b"),
-				svcDNSName(service),
+				// To indicate the server name is a FQDN, end it with a dot. Then DNS resolver won't attempt to append
+				// domain names (e.g. svc.cluster.local, cluster.local) when resolving it, making it get resolution
+				// result more quickly.
+				svcDNSName(service) + ".",
 				80,
 				Rejected,
 			},
 			{
 				Pod(namespaces["z"] + "/c"),
-				svcDNSName(service),
+				svcDNSName(service) + ".",
 				80,
 				Dropped,
 			},
 			{
 				Pod(namespaces["x"] + "/c"),
-				svcDNSName(service),
+				svcDNSName(service) + ".",
 				80,
 				Connected,
 			},


### PR DESCRIPTION
IPv6 address must be wrapped with "[]" when used in network API.

This patch ensures that the auto-discovered and the user-provided DNS
servers use correct format. It also adds the missing configuration
"dnsServerOverride" to the configuration file.

Signed-off-by: Quan Tian <qtian@vmware.com>

Fixes #3873