### PR TITLE
Automated cherry pick of #3846: Switch the storage of CAPV cluster to vSan

### DIFF
--- a/ci/cluster-api/vsphere/templates/cluster.yaml
+++ b/ci/cluster-api/vsphere/templates/cluster.yaml
@@ -44,7 +44,7 @@ spec:
     spec:
       cloneMode: linkedClone
       datacenter: DATACENTERNAME
-      datastore: 208.1-20TB-NFS
+      datastore: vsanDatastore
       diskGiB: 25
       folder: CI
       memoryMiB: 8192


### PR DESCRIPTION
Cherry pick of #3846 on release-1.5.

#3846: Switch the storage of CAPV cluster to vSan

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.