### PR TITLE
Reduce e2e execution time

### DIFF
--- a/test/e2e/multicast_test.go
+++ b/test/e2e/multicast_test.go
@@ -361,7 +361,7 @@ func testMulticastStatsWithSendersReceivers(t *testing.T, data *TestData, mc mul
 		if _, err = k8sUtils.CreateOrUpdateANP(np); err != nil {
 			t.Fatalf("Creating ANP %s failed: %v", np.Name, err)
 		}
-		err = data.waitForANPRealized(t, data.testNamespace, np.Name)
+		err = data.waitForANPRealized(t, data.testNamespace, np.Name, policyRealizedTimeout)
 		if err != nil {
 			t.Fatalf("Error when waiting for ANP %s to be realized: %v", np.Name, err)
 		}
@@ -399,7 +399,7 @@ func testMulticastStatsWithSendersReceivers(t *testing.T, data *TestData, mc mul
 		if _, err = k8sUtils.CreateOrUpdateANP(np); err != nil {
 			t.Fatalf("Creating ANP %s failed: %v", np.Name, err)
 		}
-		err = data.waitForANPRealized(t, data.testNamespace, np.Name)
+		err = data.waitForANPRealized(t, data.testNamespace, np.Name, policyRealizedTimeout)
 		if err != nil {
 			t.Fatalf("Error when waiting for ANP %s released: %v", np.Name, err)
 		}

--- a/test/e2e/traceflow_test.go
+++ b/test/e2e/traceflow_test.go
@@ -115,7 +115,7 @@ func testTraceflowIntraNodeANP(t *testing.T, data *TestData) {
 			t.Errorf("Error when deleting Antrea NetworkPolicy: %v", err)
 		}
 	}()
-	if err = data.waitForANPRealized(t, data.testNamespace, denyIngressName); err != nil {
+	if err = data.waitForANPRealized(t, data.testNamespace, denyIngressName, policyRealizedTimeout); err != nil {
 		t.Fatal(err)
 	}
 	var rejectIngress *v1alpha1.NetworkPolicy
@@ -128,7 +128,7 @@ func testTraceflowIntraNodeANP(t *testing.T, data *TestData) {
 			t.Errorf("Error when deleting Antrea NetworkPolicy: %v", err)
 		}
 	}()
-	if err = data.waitForANPRealized(t, data.testNamespace, rejectIngressName); err != nil {
+	if err = data.waitForANPRealized(t, data.testNamespace, rejectIngressName, policyRealizedTimeout); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
There were many unnecessary sleeps and checks in TestAntreaPolicy:

* NetworkPolicies, Services, Tiers, Groups are created and deleted synchronously. There is no point to do existence check.

* For Antrea native policies, check their realization status before traffic tests. For Kubernetes NetworkPolicy, we simply wait for 100ms instead of 2s. For Kubernetes Service, we wait for 1s because the minInterval of AntreaProxy's BoundedFrequencyRunner is 1s.

* For port range tests, test 3 ports instead of 6 ports.

With above changes, total execution time can be reduced more than 500s.

Signed-off-by: Quan Tian <qtian@vmware.com>