### PR TITLE
Change the default Namespace in leader manifest

### DIFF
--- a/ci/jenkins/test-mc.sh
+++ b/ci/jenkins/test-mc.sh
@@ -143,7 +143,7 @@ function clean_multicluster {
     for kubeconfig in "${multicluster_kubeconfigs[@]}"
     do
         cleanup_multicluster_ns "antrea-multicluster-test" $kubeconfig
-        cleanup_multicluster_ns "antrea-mcs-ns" $kubeconfig
+        cleanup_multicluster_ns "antrea-multicluster" $kubeconfig
         cleanup_multicluster_controller $kubeconfig
         cleanup_multicluster_antrea $kubeconfig
     done
@@ -160,13 +160,13 @@ function wait_for_antrea_multicluster_pods_ready {
 
 function wait_for_multicluster_controller_ready {
     echo "====== Deploying Antrea Multicluster Leader Cluster with ${LEADER_CLUSTER_CONFIG} ======"
-    kubectl create ns antrea-mcs-ns  "${LEADER_CLUSTER_CONFIG}" || true
+    kubectl create ns antrea-multicluster  "${LEADER_CLUSTER_CONFIG}" || true
     kubectl apply -f ./multicluster/test/yamls/manifest.yml "${LEADER_CLUSTER_CONFIG}"
     kubectl apply -f ./multicluster/build/yamls/antrea-multicluster-leader-global.yml "${LEADER_CLUSTER_CONFIG}"
-    kubectl rollout status deployment/antrea-mc-controller -n antrea-mcs-ns "${LEADER_CLUSTER_CONFIG}" || true
+    kubectl rollout status deployment/antrea-mc-controller -n antrea-multicluster "${LEADER_CLUSTER_CONFIG}" || true
     kubectl apply -f ./multicluster/test/yamls/manifest.yml "${LEADER_CLUSTER_CONFIG}"
     kubectl create -f ./multicluster/test/yamls/leader-access-token-secret.yml "${LEADER_CLUSTER_CONFIG}" || true
-    kubectl get secret -n antrea-mcs-ns leader-access-token "${LEADER_CLUSTER_CONFIG}" -o yaml > ./multicluster/test/yamls/leader-access-token.yml
+    kubectl get secret -n antrea-multicluster leader-access-token "${LEADER_CLUSTER_CONFIG}" -o yaml > ./multicluster/test/yamls/leader-access-token.yml
 
     sed -i '/uid:/d' ./multicluster/test/yamls/leader-access-token.yml
     sed -i '/resourceVersion/d' ./multicluster/test/yamls/leader-access-token.yml
@@ -174,7 +174,7 @@ function wait_for_multicluster_controller_ready {
     sed -i '/type/d' ./multicluster/test/yamls/leader-access-token.yml
     sed -i '/creationTimestamp/d' ./multicluster/test/yamls/leader-access-token.yml
     sed -i 's/antrea-multicluster-member-access-sa/antrea-multicluster-controller/g' ./multicluster/test/yamls/leader-access-token.yml
-    sed -i 's/antrea-mcs-ns/kube-system/g' ./multicluster/test/yamls/leader-access-token.yml
+    sed -i 's/antrea-multicluster/kube-system/g' ./multicluster/test/yamls/leader-access-token.yml
     echo "type: Opaque" >> ./multicluster/test/yamls/leader-access-token.yml
 
     for config in "${membercluster_kubeconfigs[@]}";
@@ -234,7 +234,7 @@ function deliver_multicluster_controller {
     export NO_PULL=1;make antrea-mc-controller
 
     docker save "${DOCKER_REGISTRY}"/antrea/antrea-mc-controller:latest -o "${WORKDIR}"/antrea-mcs.tar
-    ./multicluster/hack/generate-manifest.sh -l antrea-mcs-ns > ./multicluster/test/yamls/manifest.yml
+    ./multicluster/hack/generate-manifest.sh -l antrea-multicluster > ./multicluster/test/yamls/manifest.yml
 
     for kubeconfig in "${multicluster_kubeconfigs[@]}"
     do

--- a/docs/multicluster/quick-start.md
+++ b/docs/multicluster/quick-start.md
@@ -54,8 +54,7 @@ Namepsace `kube-system`.
 ```bash
 $kubectl apply -f https://github.com/antrea-io/antrea/releases/download/$TAG/antrea-multicluster-leader-global.yml
 $kubectl create ns antrea-multicluster
-$curl -L https://github.com/antrea-io/antrea/releases/download/$TAG/antrea-multicluster-leader-namespaced.yml > antrea-multicluster-leader-namespaced.yml
-$sed 's/changeme/antrea-multicluster/g' antrea-multicluster-leader-namespaced.yml | kubectl apply -f -
+$kubectl apply -f https://github.com/antrea-io/antrea/releases/download/$TAG/antrea-multicluster-leader-namespaced.yml > antrea-multicluster-leader-namespaced.yml
 $kubectl apply -f https://github.com/antrea-io/antrea/releases/download/$TAG/antrea-multicluster-member.yml
 ```
 

--- a/docs/multicluster/user-guide.md
+++ b/docs/multicluster/user-guide.md
@@ -78,7 +78,7 @@ To deploy Multi-cluster Controller in a dual-role cluster, please refer to
   kubectl apply -f https://github.com/antrea-io/antrea/releases/download/$TAG/antrea-multicluster-leader-namespaced.yml >   antrea-multicluster-leader-namespaced.yml
   ```
 
-The Multi-cluster Controller in the leader cluster will be deployed in the Namespace `antrea-multicluster`
+The Multi-cluster Controller in the leader cluster will be deployed in Namespace `antrea-multicluster`
 by default. If you'd like to use another Namespace, you can change `antrea-multicluster` to the desired
 Namespace in `antrea-multicluster-leader-namespaced.yml`, for example:
 

--- a/docs/multicluster/user-guide.md
+++ b/docs/multicluster/user-guide.md
@@ -75,9 +75,18 @@ To deploy Multi-cluster Controller in a dual-role cluster, please refer to
 
   ```bash
   kubectl create ns antrea-multicluster
-  curl -L https://github.com/antrea-io/antrea/releases/download/$TAG/antrea-multicluster-leader-namespaced.yml >   antrea-multicluster-leader-namespaced.yml
-  sed 's/changeme/antrea-multicluster/g' antrea-multicluster-leader-namespaced.yml | kubectl apply -f -
+  kubectl apply -f https://github.com/antrea-io/antrea/releases/download/$TAG/antrea-multicluster-leader-namespaced.yml >   antrea-multicluster-leader-namespaced.yml
   ```
+
+The Multi-cluster Controller in the leader cluster will be deployed in the Namespace `antrea-multicluster`
+by default. If you'd like to use another Namespace, you can change `antrea-multicluster` to the desired
+Namespace in `antrea-multicluster-leader-namespaced.yml`, for example:
+
+```bash
+$kubectl create ns '<desired-namespace>'
+$curl -L https://github.com/antrea-io/antrea/releases/download/$TAG/antrea-multicluster-leader-namespaced.yml > antrea-multicluster-leader-namespaced.yml
+$sed 's/antrea-multicluster/<desired-namespace>/g' antrea-multicluster-leader-namespaced.yml | kubectl apply -f -
+```
 
 #### Deploy in a Member Cluster
 

--- a/hack/release/prepare-assets.sh
+++ b/hack/release/prepare-assets.sh
@@ -88,7 +88,7 @@ export IMG_NAME=projects.registry.vmware.com/antrea/flow-visibility-clickhouse-m
 export IMG_NAME=projects.registry.vmware.com/antrea/antrea-mc-controller
 cd multicluster
 ./hack/generate-manifest.sh -g > "$OUTPUT_DIR"/antrea-multicluster-leader-global.yml
-./hack/generate-manifest.sh -r -l changeme > "$OUTPUT_DIR"/antrea-multicluster-leader-namespaced.yml
+./hack/generate-manifest.sh -r -l antrea-multicluster > "$OUTPUT_DIR"/antrea-multicluster-leader-namespaced.yml
 ./hack/generate-manifest.sh -r -m > "$OUTPUT_DIR"/antrea-multicluster-member.yml
 
 ls "$OUTPUT_DIR" | cat

--- a/multicluster/Makefile
+++ b/multicluster/Makefile
@@ -49,7 +49,7 @@ help: ## Display this help.
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=controller-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 	$(CURDIR)/hack/generate-manifest.sh -g > build/yamls/antrea-multicluster-leader-global.yml
-	$(CURDIR)/hack/generate-manifest.sh -l changeme > build/yamls/antrea-multicluster-leader-namespaced.yml
+	$(CURDIR)/hack/generate-manifest.sh -l antrea-multicluster > build/yamls/antrea-multicluster-leader-namespaced.yml
 	$(CURDIR)/hack/generate-manifest.sh -m > build/yamls/antrea-multicluster-member.yml
 
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/multicluster/build/yamls/antrea-multicluster-leader-global.yml
+++ b/multicluster/build/yamls/antrea-multicluster-leader-global.yml
@@ -1203,6 +1203,20 @@ spec:
                                     format: int32
                                     type: integer
                                 type: object
+                              igmp:
+                                description: 'IGMPProtocol matches IGMP traffic with
+                                  IGMPType and GroupAddress. IGMPType must be filled
+                                  with: IGMPQuery    int32 = 0x11 IGMPReportV1 int32
+                                  = 0x12 IGMPReportV2 int32 = 0x16 IGMPReportV3 int32
+                                  = 0x22 If groupAddress is empty, all groupAddresses
+                                  will be matched.'
+                                properties:
+                                  groupAddress:
+                                    type: string
+                                  igmpType:
+                                    format: int32
+                                    type: integer
+                                type: object
                             type: object
                           type: array
                         to:
@@ -2094,6 +2108,20 @@ spec:
                                     format: int32
                                     type: integer
                                   icmpType:
+                                    format: int32
+                                    type: integer
+                                type: object
+                              igmp:
+                                description: 'IGMPProtocol matches IGMP traffic with
+                                  IGMPType and GroupAddress. IGMPType must be filled
+                                  with: IGMPQuery    int32 = 0x11 IGMPReportV1 int32
+                                  = 0x12 IGMPReportV2 int32 = 0x16 IGMPReportV3 int32
+                                  = 0x22 If groupAddress is empty, all groupAddresses
+                                  will be matched.'
+                                properties:
+                                  groupAddress:
+                                    type: string
+                                  igmpType:
                                     format: int32
                                     type: integer
                                 type: object
@@ -3957,6 +3985,20 @@ spec:
                                     format: int32
                                     type: integer
                                 type: object
+                              igmp:
+                                description: 'IGMPProtocol matches IGMP traffic with
+                                  IGMPType and GroupAddress. IGMPType must be filled
+                                  with: IGMPQuery    int32 = 0x11 IGMPReportV1 int32
+                                  = 0x12 IGMPReportV2 int32 = 0x16 IGMPReportV3 int32
+                                  = 0x22 If groupAddress is empty, all groupAddresses
+                                  will be matched.'
+                                properties:
+                                  groupAddress:
+                                    type: string
+                                  igmpType:
+                                    format: int32
+                                    type: integer
+                                type: object
                             type: object
                           type: array
                         to:
@@ -4848,6 +4890,20 @@ spec:
                                     format: int32
                                     type: integer
                                   icmpType:
+                                    format: int32
+                                    type: integer
+                                type: object
+                              igmp:
+                                description: 'IGMPProtocol matches IGMP traffic with
+                                  IGMPType and GroupAddress. IGMPType must be filled
+                                  with: IGMPQuery    int32 = 0x11 IGMPReportV1 int32
+                                  = 0x12 IGMPReportV2 int32 = 0x16 IGMPReportV3 int32
+                                  = 0x22 If groupAddress is empty, all groupAddresses
+                                  will be matched.'
+                                properties:
+                                  groupAddress:
+                                    type: string
+                                  igmpType:
                                     format: int32
                                     type: integer
                                 type: object

--- a/multicluster/build/yamls/antrea-multicluster-leader-namespaced.yml
+++ b/multicluster/build/yamls/antrea-multicluster-leader-namespaced.yml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: antrea
   name: antrea-mc-controller
-  namespace: changeme
+  namespace: antrea-multicluster
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -12,7 +12,7 @@ metadata:
   labels:
     app: antrea
   name: antrea-mc-member-access-sa
-  namespace: changeme
+  namespace: antrea-multicluster
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -21,7 +21,7 @@ metadata:
   labels:
     app: antrea
   name: antrea-mc-controller-role
-  namespace: changeme
+  namespace: antrea-multicluster
 rules:
 - apiGroups:
   - ""
@@ -172,7 +172,7 @@ metadata:
   labels:
     app: antrea
   name: antrea-mc-member-cluster-role
-  namespace: changeme
+  namespace: antrea-multicluster
 rules:
 - apiGroups:
   - ""
@@ -241,13 +241,13 @@ metadata:
   creationTimestamp: null
   labels:
     app: antrea
-  name: changeme-antrea-mc-controller-webhook-role
+  name: antrea-multicluster-antrea-mc-controller-webhook-role
 rules:
 - apiGroups:
   - admissionregistration.k8s.io
   resourceNames:
-  - changeme-antrea-mc-mutating-webhook-configuration
-  - changeme-antrea-mc-validating-webhook-configuration
+  - antrea-multicluster-antrea-mc-mutating-webhook-configuration
+  - antrea-multicluster-antrea-mc-validating-webhook-configuration
   resources:
   - mutatingwebhookconfigurations
   - validatingwebhookconfigurations
@@ -261,7 +261,7 @@ metadata:
   labels:
     app: antrea
   name: antrea-mc-controller-rolebinding
-  namespace: changeme
+  namespace: antrea-multicluster
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -269,7 +269,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: antrea-mc-controller
-  namespace: changeme
+  namespace: antrea-multicluster
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -277,7 +277,7 @@ metadata:
   labels:
     app: antrea
   name: antrea-mc-member-cluster-rolebinding
-  namespace: changeme
+  namespace: antrea-multicluster
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -285,22 +285,22 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: antrea-mc-member-access-sa
-  namespace: changeme
+  namespace: antrea-multicluster
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
     app: antrea
-  name: changeme-antrea-mc-controller-webhook-rolebinding
+  name: antrea-multicluster-antrea-mc-controller-webhook-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: changeme-antrea-mc-controller-webhook-role
+  name: antrea-multicluster-antrea-mc-controller-webhook-role
 subjects:
 - kind: ServiceAccount
   name: antrea-mc-controller
-  namespace: changeme
+  namespace: antrea-multicluster
 ---
 apiVersion: v1
 data:
@@ -325,7 +325,7 @@ metadata:
   labels:
     app: antrea
   name: antrea-mc-controller-config-t2b9525b7f
-  namespace: changeme
+  namespace: antrea-multicluster
 ---
 apiVersion: v1
 kind: Service
@@ -333,7 +333,7 @@ metadata:
   labels:
     app: antrea
   name: antrea-mc-webhook-service
-  namespace: changeme
+  namespace: antrea-multicluster
 spec:
   ports:
   - port: 443
@@ -349,7 +349,7 @@ metadata:
     app: antrea
     component: antrea-mc-controller
   name: antrea-mc-controller
-  namespace: changeme
+  namespace: antrea-multicluster
 spec:
   replicas: 1
   selector:
@@ -414,7 +414,7 @@ metadata:
   creationTimestamp: null
   labels:
     app: antrea
-  name: changeme-antrea-mc-mutating-webhook-configuration
+  name: antrea-multicluster-antrea-mc-mutating-webhook-configuration
 webhooks:
 - admissionReviewVersions:
   - v1
@@ -422,13 +422,13 @@ webhooks:
   clientConfig:
     service:
       name: antrea-mc-webhook-service
-      namespace: changeme
+      namespace: antrea-multicluster
       path: /mutate-multicluster-crd-antrea-io-v1alpha1-clusterclaim
   failurePolicy: Fail
   name: mclusterclaim.kb.io
   namespaceSelector:
     matchLabels:
-      kubernetes.io/metadata.name: changeme
+      kubernetes.io/metadata.name: antrea-multicluster
   rules:
   - apiGroups:
     - multicluster.crd.antrea.io
@@ -446,13 +446,13 @@ webhooks:
   clientConfig:
     service:
       name: antrea-mc-webhook-service
-      namespace: changeme
+      namespace: antrea-multicluster
       path: /mutate-multicluster-crd-antrea-io-v1alpha1-clusterset
   failurePolicy: Fail
   name: mclusterset.kb.io
   namespaceSelector:
     matchLabels:
-      kubernetes.io/metadata.name: changeme
+      kubernetes.io/metadata.name: antrea-multicluster
   rules:
   - apiGroups:
     - multicluster.crd.antrea.io
@@ -470,13 +470,13 @@ webhooks:
   clientConfig:
     service:
       name: antrea-mc-webhook-service
-      namespace: changeme
+      namespace: antrea-multicluster
       path: /mutate-multicluster-crd-antrea-io-v1alpha1-resourceexport
   failurePolicy: Fail
   name: mresourceexport.kb.io
   namespaceSelector:
     matchLabels:
-      kubernetes.io/metadata.name: changeme
+      kubernetes.io/metadata.name: antrea-multicluster
   rules:
   - apiGroups:
     - multicluster.crd.antrea.io
@@ -494,13 +494,13 @@ webhooks:
   clientConfig:
     service:
       name: antrea-mc-webhook-service
-      namespace: changeme
+      namespace: antrea-multicluster
       path: /mutate-multicluster-crd-antrea-io-v1alpha1-resourceimport
   failurePolicy: Fail
   name: mresourceimport.kb.io
   namespaceSelector:
     matchLabels:
-      kubernetes.io/metadata.name: changeme
+      kubernetes.io/metadata.name: antrea-multicluster
   rules:
   - apiGroups:
     - multicluster.crd.antrea.io
@@ -519,7 +519,7 @@ metadata:
   creationTimestamp: null
   labels:
     app: antrea
-  name: changeme-antrea-mc-validating-webhook-configuration
+  name: antrea-multicluster-antrea-mc-validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:
   - v1
@@ -527,13 +527,13 @@ webhooks:
   clientConfig:
     service:
       name: antrea-mc-webhook-service
-      namespace: changeme
+      namespace: antrea-multicluster
       path: /validate-multicluster-crd-antrea-io-v1alpha1-clusterclaim
   failurePolicy: Fail
   name: vclusterclaim.kb.io
   namespaceSelector:
     matchLabels:
-      kubernetes.io/metadata.name: changeme
+      kubernetes.io/metadata.name: antrea-multicluster
   rules:
   - apiGroups:
     - multicluster.crd.antrea.io
@@ -551,13 +551,13 @@ webhooks:
   clientConfig:
     service:
       name: antrea-mc-webhook-service
-      namespace: changeme
+      namespace: antrea-multicluster
       path: /validate-multicluster-crd-antrea-io-v1alpha1-clusterset
   failurePolicy: Fail
   name: vclusterset.kb.io
   namespaceSelector:
     matchLabels:
-      kubernetes.io/metadata.name: changeme
+      kubernetes.io/metadata.name: antrea-multicluster
   rules:
   - apiGroups:
     - multicluster.crd.antrea.io
@@ -575,13 +575,13 @@ webhooks:
   clientConfig:
     service:
       name: antrea-mc-webhook-service
-      namespace: changeme
+      namespace: antrea-multicluster
       path: /validate-multicluster-crd-antrea-io-v1alpha1-resourceexport
   failurePolicy: Fail
   name: vresourceexport.kb.io
   namespaceSelector:
     matchLabels:
-      kubernetes.io/metadata.name: changeme
+      kubernetes.io/metadata.name: antrea-multicluster
   rules:
   - apiGroups:
     - multicluster.crd.antrea.io
@@ -599,13 +599,13 @@ webhooks:
   clientConfig:
     service:
       name: antrea-mc-webhook-service
-      namespace: changeme
+      namespace: antrea-multicluster
       path: /validate-multicluster-crd-antrea-io-v1alpha1-resourceimport
   failurePolicy: Fail
   name: vresourceimport.kb.io
   namespaceSelector:
     matchLabels:
-      kubernetes.io/metadata.name: changeme
+      kubernetes.io/metadata.name: antrea-multicluster
   rules:
   - apiGroups:
     - multicluster.crd.antrea.io
@@ -623,13 +623,13 @@ webhooks:
   clientConfig:
     service:
       name: antrea-mc-webhook-service
-      namespace: changeme
+      namespace: antrea-multicluster
       path: /validate-multicluster-crd-antrea-io-v1alpha1-memberclusterannounce
   failurePolicy: Fail
   name: vmemberclusterannounce.kb.io
   namespaceSelector:
     matchLabels:
-      kubernetes.io/metadata.name: changeme
+      kubernetes.io/metadata.name: antrea-multicluster
   rules:
   - apiGroups:
     - multicluster.crd.antrea.io

--- a/multicluster/config/crd/bases/multicluster.crd.antrea.io_resourceexports.yaml
+++ b/multicluster/config/crd/bases/multicluster.crd.antrea.io_resourceexports.yaml
@@ -922,6 +922,20 @@ spec:
                                     format: int32
                                     type: integer
                                 type: object
+                              igmp:
+                                description: 'IGMPProtocol matches IGMP traffic with
+                                  IGMPType and GroupAddress. IGMPType must be filled
+                                  with: IGMPQuery    int32 = 0x11 IGMPReportV1 int32
+                                  = 0x12 IGMPReportV2 int32 = 0x16 IGMPReportV3 int32
+                                  = 0x22 If groupAddress is empty, all groupAddresses
+                                  will be matched.'
+                                properties:
+                                  groupAddress:
+                                    type: string
+                                  igmpType:
+                                    format: int32
+                                    type: integer
+                                type: object
                             type: object
                           type: array
                         to:
@@ -1813,6 +1827,20 @@ spec:
                                     format: int32
                                     type: integer
                                   icmpType:
+                                    format: int32
+                                    type: integer
+                                type: object
+                              igmp:
+                                description: 'IGMPProtocol matches IGMP traffic with
+                                  IGMPType and GroupAddress. IGMPType must be filled
+                                  with: IGMPQuery    int32 = 0x11 IGMPReportV1 int32
+                                  = 0x12 IGMPReportV2 int32 = 0x16 IGMPReportV3 int32
+                                  = 0x22 If groupAddress is empty, all groupAddresses
+                                  will be matched.'
+                                properties:
+                                  groupAddress:
+                                    type: string
+                                  igmpType:
                                     format: int32
                                     type: integer
                                 type: object

--- a/multicluster/config/crd/bases/multicluster.crd.antrea.io_resourceimports.yaml
+++ b/multicluster/config/crd/bases/multicluster.crd.antrea.io_resourceimports.yaml
@@ -924,6 +924,20 @@ spec:
                                     format: int32
                                     type: integer
                                 type: object
+                              igmp:
+                                description: 'IGMPProtocol matches IGMP traffic with
+                                  IGMPType and GroupAddress. IGMPType must be filled
+                                  with: IGMPQuery    int32 = 0x11 IGMPReportV1 int32
+                                  = 0x12 IGMPReportV2 int32 = 0x16 IGMPReportV3 int32
+                                  = 0x22 If groupAddress is empty, all groupAddresses
+                                  will be matched.'
+                                properties:
+                                  groupAddress:
+                                    type: string
+                                  igmpType:
+                                    format: int32
+                                    type: integer
+                                type: object
                             type: object
                           type: array
                         to:
@@ -1815,6 +1829,20 @@ spec:
                                     format: int32
                                     type: integer
                                   icmpType:
+                                    format: int32
+                                    type: integer
+                                type: object
+                              igmp:
+                                description: 'IGMPProtocol matches IGMP traffic with
+                                  IGMPType and GroupAddress. IGMPType must be filled
+                                  with: IGMPQuery    int32 = 0x11 IGMPReportV1 int32
+                                  = 0x12 IGMPReportV2 int32 = 0x16 IGMPReportV3 int32
+                                  = 0x22 If groupAddress is empty, all groupAddresses
+                                  will be matched.'
+                                properties:
+                                  groupAddress:
+                                    type: string
+                                  igmpType:
                                     format: int32
                                     type: integer
                                 type: object

--- a/multicluster/config/overlays/leader-ns/kustomization.yaml
+++ b/multicluster/config/overlays/leader-ns/kustomization.yaml
@@ -1,4 +1,4 @@
-namespace: changeme
+namespace: antrea-multicluster
 
 commonLabels:
   app: antrea
@@ -21,7 +21,7 @@ patchesJson6902:
         value: RoleBinding
       - op: add
         path: /metadata/namespace
-        value: changeme
+        value: antrea-multicluster
       - op: replace
         path: /roleRef/kind
         value: Role
@@ -36,7 +36,7 @@ patchesJson6902:
         value: Role
       - op: add
         path: /metadata/namespace
-        value: changeme
+        value: antrea-multicluster
     target:
       group: rbac.authorization.k8s.io
       kind: ClusterRole

--- a/multicluster/config/overlays/leader-ns/member_cluster_role.yaml
+++ b/multicluster/config/overlays/leader-ns/member_cluster_role.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: antrea
   name: member-cluster-role
-  namespace: changeme
+  namespace: antrea-multicluster
 rules:
   - apiGroups:
       - ""

--- a/multicluster/config/overlays/leader-ns/member_cluster_rolebinding.yaml
+++ b/multicluster/config/overlays/leader-ns/member_cluster_rolebinding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: member-access-sa
-  namespace: changeme
+  namespace: antrea-multicluster

--- a/multicluster/config/overlays/leader-ns/member_cluster_serviceaccount.yaml
+++ b/multicluster/config/overlays/leader-ns/member_cluster_serviceaccount.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: member-access-sa
-  namespace: changeme
+  namespace: antrea-multicluster

--- a/multicluster/config/overlays/leader-ns/prefix_transformer.yaml
+++ b/multicluster/config/overlays/leader-ns/prefix_transformer.yaml
@@ -7,7 +7,7 @@ apiVersion: builtin
 kind: PrefixSuffixTransformer
 metadata:
   name: customPrefixer
-prefix: changeme-
+prefix: antrea-multicluster-
 fieldSpecs:
   - kind: ClusterRole
     path: metadata/name

--- a/multicluster/config/overlays/leader-ns/webhook_rbac.yaml
+++ b/multicluster/config/overlays/leader-ns/webhook_rbac.yaml
@@ -31,5 +31,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: controller
-    namespace: changeme
+    namespace: antrea-multicluster
 

--- a/multicluster/hack/generate-manifest.sh
+++ b/multicluster/hack/generate-manifest.sh
@@ -41,7 +41,7 @@ function print_help {
 }
 
 OVERLAY=member
-NAMESPACE=changeme
+NAMESPACE=antrea-multicluster
 MODE=""
 
 while [[ $# -gt 0 ]]
@@ -111,7 +111,7 @@ if [ "$OVERLAY" == "leader-ns" ] ;
 then
     mkdir config && cd config
     cp $KUSTOMIZATION_DIR/overlays/leader-ns/prefix_transformer.yaml .
-    sed -ie "s/changeme/$NAMESPACE/g" prefix_transformer.yaml
+    sed -ie "s/antrea-multicluster/$NAMESPACE/g" prefix_transformer.yaml
 
 cat << EOF > kustomization.yaml
 namespace: $NAMESPACE

--- a/multicluster/test/yamls/clusterset.yml
+++ b/multicluster/test/yamls/clusterset.yml
@@ -2,7 +2,7 @@ apiVersion: multicluster.crd.antrea.io/v1alpha1
 kind: ClusterClaim
 metadata:
   name: leadercluster-id
-  namespace: antrea-mcs-ns
+  namespace: antrea-multicluster
 name: id.k8s.io
 value: test-cluster-leader
 ---
@@ -10,7 +10,7 @@ apiVersion: multicluster.crd.antrea.io/v1alpha1
 kind: ClusterClaim
 metadata:
   name: clusterset-id
-  namespace: antrea-mcs-ns
+  namespace: antrea-multicluster
 name: clusterset.k8s.io
 value: test-clusterset
 ---
@@ -18,7 +18,7 @@ apiVersion: multicluster.crd.antrea.io/v1alpha1
 kind: ClusterSet
 metadata:
   name: test-clusterset
-  namespace: antrea-mcs-ns
+  namespace: antrea-multicluster
 spec:
   leaders:
     - clusterID: test-cluster-leader
@@ -27,5 +27,5 @@ spec:
       serviceAccount: antrea-mc-member-access-sa
     - clusterID: test-cluster-west
       serviceAccount: antrea-mc-member-access-sa
-  namespace: antrea-mcs-ns
+  namespace: antrea-multicluster
 

--- a/multicluster/test/yamls/east-member-cluster.yml
+++ b/multicluster/test/yamls/east-member-cluster.yml
@@ -26,5 +26,5 @@ spec:
       server: https://<LEADER_CLUSTER_IP>:6443
   members:
     - clusterID: test-cluster-east
-  namespace: antrea-mcs-ns
+  namespace: antrea-multicluster
 

--- a/multicluster/test/yamls/leader-access-token-secret.yml
+++ b/multicluster/test/yamls/leader-access-token-secret.yml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: leader-access-token
-  namespace: antrea-mcs-ns
+  namespace: antrea-multicluster
   annotations:
     kubernetes.io/service-account.name: antrea-mc-member-access-sa
 type: kubernetes.io/service-account-token

--- a/multicluster/test/yamls/test-acnp-copy-span-ns-isolation.yml
+++ b/multicluster/test/yamls/test-acnp-copy-span-ns-isolation.yml
@@ -2,7 +2,7 @@ apiVersion: multicluster.crd.antrea.io/v1alpha1
 kind: ResourceExport
 metadata:
   name: strict-namespace-isolation-for-test-clusterset
-  namespace: antrea-mcs-ns
+  namespace: antrea-multicluster
 spec:
   kind: AntreaClusterNetworkPolicy
   name: strict-namespace-isolation

--- a/multicluster/test/yamls/west-member-cluster.yml
+++ b/multicluster/test/yamls/west-member-cluster.yml
@@ -26,5 +26,5 @@ spec:
       server: https://<LEADER_CLUSTER_IP>:6443
   members:
     - clusterID: test-cluster-west
-  namespace: antrea-mcs-ns
+  namespace: antrea-multicluster
 

--- a/pkg/antctl/raw/multicluster/deploy/deploy_helper.go
+++ b/pkg/antctl/raw/multicluster/deploy/deploy_helper.go
@@ -170,7 +170,7 @@ func deploy(cmd *cobra.Command, role string, version string, namespace string, f
 
 			content := string(b)
 			if role == leaderRole && strings.Contains(manifest, "namespaced") {
-				content = strings.ReplaceAll(content, "changeme", namespace)
+				content = strings.ReplaceAll(content, "antrea-multicluster", namespace)
 			}
 			if role == memberRole && strings.Contains(manifest, "member") {
 				content = strings.ReplaceAll(content, "kube-system", namespace)


### PR DESCRIPTION
Change th default Namespace from `changeme` to `antrea-multicluster`
for leader manifest, so user can deploy leader controller without any Namespace
replacement step by default.

Signed-off-by: Lan Luo <luola@vmware.com>