### PR TITLE
Unify some functions in pkg/agent/route

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -257,8 +257,6 @@ func run(o *Options) error {
 		stopCh,
 		o.nodeType,
 		o.config.ExternalNode.ExternalNodeNamespace,
-		features.DefaultFeatureGate.Enabled(features.AntreaProxy),
-		o.config.AntreaProxy.ProxyAll,
 		connectUplinkToBridge,
 		l7NetworkPolicyEnabled)
 	err = agentInitializer.Initialize()

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -110,11 +110,9 @@ type Initializer struct {
 	serviceConfig         *config.ServiceConfig
 	l7NetworkPolicyConfig *config.L7NetworkPolicyConfig
 	enableL7NetworkPolicy bool
-	enableProxy           bool
 	connectUplinkToBridge bool
 	// networkReadyCh should be closed once the Node's network is ready.
 	// The CNI server will wait for it before handling any CNI Add requests.
-	proxyAll              bool
 	networkReadyCh        chan<- struct{}
 	stopCh                <-chan struct{}
 	nodeType              config.NodeType
@@ -140,8 +138,6 @@ func NewInitializer(
 	stopCh <-chan struct{},
 	nodeType config.NodeType,
 	externalNodeNamespace string,
-	enableProxy bool,
-	proxyAll bool,
 	connectUplinkToBridge bool,
 	enableL7NetworkPolicy bool,
 ) *Initializer {
@@ -165,8 +161,6 @@ func NewInitializer(
 		stopCh:                stopCh,
 		nodeType:              nodeType,
 		externalNodeNamespace: externalNodeNamespace,
-		enableProxy:           enableProxy,
-		proxyAll:              proxyAll,
 		connectUplinkToBridge: connectUplinkToBridge,
 		enableL7NetworkPolicy: enableL7NetworkPolicy,
 	}
@@ -177,7 +171,7 @@ func (i *Initializer) GetNodeConfig() *config.NodeConfig {
 	return i.nodeConfig
 }
 
-// GetNodeConfig returns the NodeConfig.
+// GetWireGuardClient returns the Wireguard client.
 func (i *Initializer) GetWireGuardClient() wireguard.Interface {
 	return i.wireGuardClient
 }

--- a/pkg/agent/controller/noderoute/node_route_controller.go
+++ b/pkg/agent/controller/noderoute/node_route_controller.go
@@ -204,8 +204,6 @@ func (c *Controller) removeStaleGatewayRoutes() error {
 	}
 
 	// routeClient will remove orphaned routes whose destinations are not in desiredPodCIDRs.
-	// If proxyAll enabled, it will also remove routes that are for Windows ClusterIP Services
-	// which no longer exist.
 	if err := c.routeClient.Reconcile(desiredPodCIDRs); err != nil {
 		return err
 	}

--- a/pkg/agent/nodeportlocal/rules/netnat_rule.go
+++ b/pkg/agent/nodeportlocal/rules/netnat_rule.go
@@ -19,11 +19,13 @@ package rules
 
 import (
 	"fmt"
+	"net"
 
 	"k8s.io/klog/v2"
 
 	"antrea.io/antrea/pkg/agent/route"
 	"antrea.io/antrea/pkg/agent/util"
+	binding "antrea.io/antrea/pkg/ovs/openflow"
 )
 
 // Use antrea-nat netnatstaticmapping rules as NPL implementation
@@ -68,13 +70,18 @@ func (nn *netnatRules) initRules() error {
 
 // AddRule appends a NetNatStaticMapping rule.
 func (nn *netnatRules) AddRule(nodePort int, podIP string, podPort int, protocol string) error {
-	nodePort16 := util.PortToUint16(nodePort)
-	podPort16 := util.PortToUint16(podPort)
-	podAddr := fmt.Sprintf("%s:%d", podIP, podPort16)
-	if err := util.ReplaceNetNatStaticMapping(antreaNatNPL, "0.0.0.0", nodePort16, podIP, podPort16, protocol); err != nil {
+	netNatStaticMapping := &util.NetNatStaticMapping{
+		Name:         antreaNatNPL,
+		ExternalIP:   net.ParseIP("0.0.0.0"),
+		ExternalPort: util.PortToUint16(nodePort),
+		InternalIP:   net.ParseIP(podIP),
+		InternalPort: util.PortToUint16(podPort),
+		Protocol:     binding.Protocol(protocol),
+	}
+	if err := util.ReplaceNetNatStaticMapping(netNatStaticMapping); err != nil {
 		return err
 	}
-	klog.InfoS("Successfully added NetNat rule", "podAddr", podAddr, "nodePort", nodePort16, "protocol", protocol)
+	klog.InfoS("Successfully added NetNatStaticMapping", "NetNatStaticMapping", netNatStaticMapping)
 	return nil
 }
 
@@ -90,13 +97,18 @@ func (nn *netnatRules) AddAllRules(nplList []PodNodePort) error {
 
 // DeleteRule deletes a specific NPL rule from NetNatStaticMapping table
 func (nn *netnatRules) DeleteRule(nodePort int, podIP string, podPort int, protocol string) error {
-	nodePort16 := util.PortToUint16(nodePort)
-	podPort16 := util.PortToUint16(podPort)
-	podAddr := fmt.Sprintf("%s:%d", podIP, podPort16)
-	if err := util.RemoveNetNatStaticMappingByNPLTuples(antreaNatNPL, "0.0.0.0", nodePort16, podIP, podPort16, protocol); err != nil {
+	netNatStaticMapping := &util.NetNatStaticMapping{
+		Name:         antreaNatNPL,
+		ExternalIP:   net.ParseIP("0.0.0.0"),
+		ExternalPort: util.PortToUint16(nodePort),
+		InternalIP:   net.ParseIP(podIP),
+		InternalPort: util.PortToUint16(podPort),
+		Protocol:     binding.Protocol(protocol),
+	}
+	if err := util.RemoveNetNatStaticMappingByNPLTuples(netNatStaticMapping); err != nil {
 		return err
 	}
-	klog.InfoS("Successfully deleted NetNatStaticMapping rule", "podAddr", podAddr, "nodePort", nodePort16, "protocol", protocol)
+	klog.InfoS("Successfully deleted NetNatStaticMapping", "NetNatStaticMapping", netNatStaticMapping)
 	return nil
 }
 

--- a/pkg/agent/proxy/proxier.go
+++ b/pkg/agent/proxy/proxier.go
@@ -177,12 +177,6 @@ func (p *proxier) removeStaleServices() {
 					continue
 				}
 			}
-			if svcInfo.ClusterIP() != nil {
-				if err := p.deleteRouteForServiceIP(svcInfoStr, svcInfo.ClusterIP(), p.routeClient.DeleteClusterIPRoute); err != nil {
-					klog.ErrorS(err, "Failed to remove ClusterIP Service routes", "Service", svcPortName)
-					continue
-				}
-			}
 		}
 		// Remove LoadBalancer flows and configurations.
 		if p.proxyLoadBalancerIPs && len(svcInfo.LoadBalancerIPStrings()) > 0 {
@@ -599,13 +593,6 @@ func (p *proxier) installServices() {
 							continue
 						}
 					}
-					// If previous Service which has ClusterIP should be removed, remove ClusterIP routes.
-					if pSvcInfo.ClusterIP() != nil {
-						if err := p.deleteRouteForServiceIP(pSvcInfo.String(), pSvcInfo.ClusterIP(), p.routeClient.DeleteClusterIPRoute); err != nil {
-							klog.ErrorS(err, "Error when uninstalling ClusterIP route for Service", "ServicePortName", svcPortName, "ServiceInfo", svcInfoStr)
-							continue
-						}
-					}
 				}
 			}
 
@@ -628,15 +615,6 @@ func (p *proxier) installServices() {
 			}
 
 			if p.proxyAll {
-				// Install ClusterIP route on Node so that ClusterIP can be accessed on Node. Every time a new ClusterIP
-				// is created, the routing target IP block will be recalculated for expansion to be able to route the new
-				// created ClusterIP. Deleting a ClusterIP will not shrink the target routing IP block. The Service CIDR
-				// can be finally calculated after creating enough ClusterIPs.
-				if err := p.addRouteForServiceIP(svcInfo.String(), svcInfo.ClusterIP(), p.routeClient.AddClusterIPRoute); err != nil {
-					klog.ErrorS(err, "Error when installing ClusterIP route for Service", "ServicePortName", svcPortName, "ServiceInfo", svcInfoStr)
-					continue
-				}
-
 				// If previous Service is nil or NodePort flows and configurations of previous Service have been removed,
 				// install NodePort flows and configurations for current Service.
 				if svcInfo.NodePort() > 0 && (pSvcInfo == nil || needRemoval) {

--- a/pkg/agent/proxy/proxier_test.go
+++ b/pkg/agent/proxy/proxier_test.go
@@ -416,7 +416,6 @@ func testClusterIPAdd(t *testing.T,
 	mockOFClient.EXPECT().InstallEndpointFlows(bindingProtocol, gomock.InAnyOrder(expectedAllEps)).Times(1)
 	mockOFClient.EXPECT().InstallServiceGroup(groupID, false, gomock.InAnyOrder(expectedAllEps)).Times(1)
 	mockOFClient.EXPECT().InstallServiceFlows(groupID, svcIP, uint16(svcPort), bindingProtocol, uint16(0), false, corev1.ServiceTypeClusterIP, true).Times(1)
-	mockRouteClient.EXPECT().AddClusterIPRoute(svcIP).Times(1)
 
 	fp.syncProxyRules()
 	assert.Contains(t, fp.serviceInstalledMap, svcPortName)
@@ -531,7 +530,6 @@ func testLoadBalancerAdd(t *testing.T,
 		groupID = fp.groupCounter.AllocateIfNotExist(svcPortName, !nodeLocalVal)
 		mockOFClient.EXPECT().UninstallServiceGroup(groupID).Times(1)
 	}
-	mockRouteClient.EXPECT().AddClusterIPRoute(svcIP).Times(1)
 	if proxyLoadBalancerIPs {
 		mockRouteClient.EXPECT().AddLoadBalancer(loadBalancerIP).Times(1)
 	}
@@ -640,7 +638,6 @@ func testNodePortAdd(t *testing.T,
 		groupID = fp.groupCounter.AllocateIfNotExist(svcPortName, !nodeLocalVal)
 		mockOFClient.EXPECT().UninstallServiceGroup(groupID).Times(1)
 	}
-	mockRouteClient.EXPECT().AddClusterIPRoute(svcIP).Times(1)
 	mockRouteClient.EXPECT().AddNodePort(nodePortAddresses, uint16(svcNodePort), bindingProtocol).Times(1)
 
 	fp.syncProxyRules()
@@ -879,8 +876,6 @@ func TestLoadBalancerServiceWithMultiplePorts(t *testing.T) {
 	mockOFClient.EXPECT().InstallServiceFlows(gomock.Any(), agentconfig.VirtualNodePortDNATIPv4, uint16(port30001Int32), binding.ProtocolTCP, uint16(0), true, corev1.ServiceTypeNodePort, false).Times(1)
 	mockOFClient.EXPECT().InstallServiceFlows(gomock.Any(), loadBalancerIPv4, uint16(port80Int32), binding.ProtocolTCP, uint16(0), true, corev1.ServiceTypeLoadBalancer, false).Times(1)
 	mockRouteClient.EXPECT().AddNodePort(nodePortAddresses, uint16(port30001Int32), binding.ProtocolTCP).Times(1)
-	// The route for the ClusterIP and the LoadBalancer IP should only be installed once.
-	mockRouteClient.EXPECT().AddClusterIPRoute(svc1IPv4).Times(1)
 	mockRouteClient.EXPECT().AddLoadBalancer(loadBalancerIPv4).Times(1)
 
 	mockOFClient.EXPECT().InstallEndpointFlows(binding.ProtocolTCP, gomock.InAnyOrder([]k8sproxy.Endpoint{localEndpointForPort443, remoteEndpointForPort443})).Times(1)
@@ -911,7 +906,6 @@ func TestLoadBalancerServiceWithMultiplePorts(t *testing.T) {
 	mockOFClient.EXPECT().UninstallServiceFlows(loadBalancerIPv4, uint16(port443Int32), binding.ProtocolTCP)
 	mockRouteClient.EXPECT().DeleteNodePort(nodePortAddresses, uint16(port30002Int32), binding.ProtocolTCP)
 	// The route for the ClusterIP and the LoadBalancer IP should only be uninstalled once.
-	mockRouteClient.EXPECT().DeleteClusterIPRoute(svc1IPv4)
 	mockRouteClient.EXPECT().DeleteLoadBalancer(loadBalancerIPv4)
 
 	fp.syncProxyRules()
@@ -1097,13 +1091,11 @@ func testClusterIPRemove(t *testing.T, svcIP net.IP, epIP net.IP, isIPv6 bool, n
 		mockOFClient.EXPECT().InstallEndpointFlows(bindingProtocol, gomock.Any()).Times(1)
 	}
 	mockOFClient.EXPECT().InstallServiceFlows(groupID, svcIP, uint16(svcPort), bindingProtocol, uint16(0), false, corev1.ServiceTypeClusterIP, true).Times(1)
-	mockRouteClient.EXPECT().AddClusterIPRoute(svcIP).Times(1)
 	mockOFClient.EXPECT().UninstallServiceFlows(svcIP, uint16(svcPort), bindingProtocol).Times(1)
 	if !nodeLocalInternal {
 		mockOFClient.EXPECT().UninstallEndpointFlows(bindingProtocol, gomock.Any()).Times(1)
 	}
 	mockOFClient.EXPECT().UninstallServiceGroup(gomock.Any()).Times(1)
-	mockRouteClient.EXPECT().DeleteClusterIPRoute(svcIP).Times(1)
 	fp.syncProxyRules()
 
 	assert.Contains(t, fp.serviceInstalledMap, svcPortName)
@@ -1169,14 +1161,12 @@ func testNodePortRemove(t *testing.T, nodePortAddresses []net.IP, svcIP net.IP, 
 	mockOFClient.EXPECT().InstallServiceGroup(groupID, false, gomock.Any()).Times(1)
 	mockOFClient.EXPECT().InstallServiceFlows(groupID, svcIP, uint16(svcPort), bindingProtocol, uint16(0), true, corev1.ServiceTypeClusterIP, false).Times(1)
 	mockOFClient.EXPECT().InstallServiceFlows(groupIDLocal, vIP, uint16(svcNodePort), bindingProtocol, uint16(0), true, corev1.ServiceTypeNodePort, false).Times(1)
-	mockRouteClient.EXPECT().AddClusterIPRoute(svcIP).Times(1)
 	mockRouteClient.EXPECT().AddNodePort(nodePortAddresses, uint16(svcNodePort), bindingProtocol).Times(1)
 
 	mockOFClient.EXPECT().UninstallEndpointFlows(bindingProtocol, gomock.Any()).Times(1)
 	mockOFClient.EXPECT().UninstallServiceFlows(svcIP, uint16(svcPort), bindingProtocol).Times(1)
 	mockOFClient.EXPECT().UninstallServiceFlows(vIP, uint16(svcNodePort), bindingProtocol).Times(1)
 	mockOFClient.EXPECT().UninstallServiceGroup(gomock.Any()).Times(2)
-	mockRouteClient.EXPECT().DeleteClusterIPRoute(svcIP).Times(1)
 	mockRouteClient.EXPECT().DeleteNodePort(nodePortAddresses, uint16(svcNodePort), bindingProtocol).Times(1)
 	fp.syncProxyRules()
 
@@ -1247,7 +1237,6 @@ func testLoadBalancerRemove(t *testing.T, nodePortAddresses []net.IP, svcIP net.
 	mockOFClient.EXPECT().InstallServiceFlows(groupIDLocal, vIP, uint16(svcNodePort), bindingProtocol, uint16(0), true, corev1.ServiceTypeNodePort, false).Times(1)
 	mockOFClient.EXPECT().InstallServiceFlows(groupIDLocal, loadBalancerIP, uint16(svcPort), bindingProtocol, uint16(0), true, corev1.ServiceTypeLoadBalancer, false).Times(1)
 
-	mockRouteClient.EXPECT().AddClusterIPRoute(svcIP).Times(1)
 	mockRouteClient.EXPECT().AddNodePort(nodePortAddresses, uint16(svcNodePort), bindingProtocol).Times(1)
 	mockRouteClient.EXPECT().AddLoadBalancer(loadBalancerIP).Times(1)
 
@@ -1256,7 +1245,6 @@ func testLoadBalancerRemove(t *testing.T, nodePortAddresses []net.IP, svcIP net.
 	mockOFClient.EXPECT().UninstallServiceFlows(vIP, uint16(svcNodePort), bindingProtocol).Times(1)
 	mockOFClient.EXPECT().UninstallServiceFlows(loadBalancerIP, uint16(svcPort), bindingProtocol).Times(1)
 	mockOFClient.EXPECT().UninstallServiceGroup(gomock.Any()).Times(2)
-	mockRouteClient.EXPECT().DeleteClusterIPRoute(svcIP).Times(1)
 	mockRouteClient.EXPECT().DeleteNodePort(nodePortAddresses, uint16(svcNodePort), bindingProtocol).Times(1)
 	mockRouteClient.EXPECT().DeleteLoadBalancer(loadBalancerIP).Times(1)
 	fp.syncProxyRules()
@@ -1422,17 +1410,14 @@ func testNodePortNoEndpoint(t *testing.T, nodePortAddresses []net.IP, svcIP net.
 	mockOFClient.EXPECT().InstallServiceGroup(groupIDLocal, false, gomock.Any()).Times(1)
 	mockOFClient.EXPECT().InstallServiceFlows(groupIDCluster, svcIP, uint16(svcPort), gomock.Any(), uint16(0), true, corev1.ServiceTypeClusterIP, false).Times(1)
 	mockOFClient.EXPECT().InstallServiceFlows(groupIDLocal, vIP, uint16(svcNodePort), gomock.Any(), uint16(0), true, corev1.ServiceTypeNodePort, false).Times(1)
-	mockRouteClient.EXPECT().AddClusterIPRoute(svcIP).Times(1)
 	mockRouteClient.EXPECT().AddNodePort(nodePortAddresses, uint16(svcNodePort), gomock.Any()).Times(1)
 	fp.syncProxyRules()
 
 	mockOFClient.EXPECT().UninstallServiceFlows(svcIP, uint16(svcPort), gomock.Any()).Times(1)
 	mockOFClient.EXPECT().UninstallServiceFlows(vIP, uint16(svcNodePort), gomock.Any()).Times(1)
-	mockRouteClient.EXPECT().DeleteClusterIPRoute(svcIP).Times(1)
 	mockRouteClient.EXPECT().DeleteNodePort(nodePortAddresses, uint16(svcNodePort), gomock.Any()).Times(1)
 	mockOFClient.EXPECT().InstallServiceFlows(groupIDCluster, svcIP, uint16(svcPort+1), gomock.Any(), uint16(0), true, corev1.ServiceTypeClusterIP, false).Times(1)
 	mockOFClient.EXPECT().InstallServiceFlows(groupIDLocal, vIP, uint16(svcNodePort), gomock.Any(), uint16(0), true, corev1.ServiceTypeNodePort, false).Times(1)
-	mockRouteClient.EXPECT().AddClusterIPRoute(svcIP).Times(1)
 	mockRouteClient.EXPECT().AddNodePort(nodePortAddresses, uint16(svcNodePort), gomock.Any()).Times(1)
 	fp.serviceChanges.OnServiceUpdate(svc, updatedSvc)
 	fp.syncProxyRules()
@@ -1488,7 +1473,6 @@ func testLoadBalancerNoEndpoint(t *testing.T, nodePortAddresses []net.IP, svcIP 
 	mockOFClient.EXPECT().InstallServiceFlows(groupIDCluster, svcIP, uint16(svcPort), gomock.Any(), uint16(0), true, corev1.ServiceTypeClusterIP, false).Times(1)
 	mockOFClient.EXPECT().InstallServiceFlows(groupIDLocal, vIP, uint16(svcNodePort), gomock.Any(), uint16(0), true, corev1.ServiceTypeNodePort, false).Times(1)
 	mockOFClient.EXPECT().InstallServiceFlows(groupIDLocal, loadBalancerIP, uint16(svcPort), gomock.Any(), uint16(0), true, corev1.ServiceTypeLoadBalancer, false).Times(1)
-	mockRouteClient.EXPECT().AddClusterIPRoute(svcIP).Times(1)
 	mockRouteClient.EXPECT().AddNodePort(nodePortAddresses, uint16(svcNodePort), gomock.Any()).Times(1)
 	mockRouteClient.EXPECT().AddLoadBalancer(loadBalancerIP).Times(1)
 	fp.syncProxyRules()
@@ -1496,13 +1480,11 @@ func testLoadBalancerNoEndpoint(t *testing.T, nodePortAddresses []net.IP, svcIP 
 	mockOFClient.EXPECT().UninstallServiceFlows(svcIP, uint16(svcPort), gomock.Any()).Times(1)
 	mockOFClient.EXPECT().UninstallServiceFlows(vIP, uint16(svcNodePort), gomock.Any()).Times(1)
 	mockOFClient.EXPECT().UninstallServiceFlows(loadBalancerIP, uint16(svcPort), gomock.Any()).Times(1)
-	mockRouteClient.EXPECT().DeleteClusterIPRoute(svcIP).Times(1)
 	mockRouteClient.EXPECT().DeleteNodePort(nodePortAddresses, uint16(svcNodePort), gomock.Any()).Times(1)
 	mockRouteClient.EXPECT().DeleteLoadBalancer(loadBalancerIP).Times(1)
 	mockOFClient.EXPECT().InstallServiceFlows(groupIDCluster, svcIP, uint16(svcPort+1), gomock.Any(), uint16(0), true, corev1.ServiceTypeClusterIP, false).Times(1)
 	mockOFClient.EXPECT().InstallServiceFlows(groupIDLocal, vIP, uint16(svcNodePort), gomock.Any(), uint16(0), true, corev1.ServiceTypeNodePort, false).Times(1)
 	mockOFClient.EXPECT().InstallServiceFlows(groupIDLocal, loadBalancerIP, uint16(svcPort+1), gomock.Any(), uint16(0), true, corev1.ServiceTypeLoadBalancer, false).Times(1)
-	mockRouteClient.EXPECT().AddClusterIPRoute(svcIP).Times(1)
 	mockRouteClient.EXPECT().AddNodePort(nodePortAddresses, uint16(svcNodePort), gomock.Any()).Times(1)
 	mockRouteClient.EXPECT().AddLoadBalancer(loadBalancerIP).Times(1)
 	fp.serviceChanges.OnServiceUpdate(svc, updatedSvc)
@@ -1778,13 +1760,10 @@ func testServiceClusterIPUpdate(t *testing.T,
 	mockOFClient.EXPECT().InstallEndpointFlows(bindingProtocol, expectedEps).Times(1)
 	mockOFClient.EXPECT().InstallServiceGroup(groupID, false, expectedEps).Times(1)
 	mockOFClient.EXPECT().InstallServiceFlows(groupID, svcIP, uint16(svcPort), bindingProtocol, uint16(0), false, corev1.ServiceTypeClusterIP, false).Times(1)
-	mockRouteClient.EXPECT().AddClusterIPRoute(svcIP).Times(1)
 
 	s1 := mockOFClient.EXPECT().UninstallServiceFlows(svcIP, uint16(svcPort), bindingProtocol).Times(1)
 	s2 := mockOFClient.EXPECT().InstallServiceFlows(groupID, updatedSvcIP, uint16(svcPort), bindingProtocol, uint16(0), false, corev1.ServiceTypeClusterIP, false).Times(1)
 	s2.After(s1)
-	mockRouteClient.EXPECT().DeleteClusterIPRoute(svcIP).Times(1)
-	mockRouteClient.EXPECT().AddClusterIPRoute(updatedSvcIP).Times(1)
 
 	if svcType == corev1.ServiceTypeNodePort || svcType == corev1.ServiceTypeLoadBalancer {
 		mockOFClient.EXPECT().InstallServiceFlows(groupID, vIP, uint16(svcNodePort), bindingProtocol, uint16(0), false, corev1.ServiceTypeNodePort, false).Times(1)
@@ -1883,14 +1862,10 @@ func testServicePortUpdate(t *testing.T,
 	mockOFClient.EXPECT().InstallEndpointFlows(bindingProtocol, expectedEps).Times(1)
 	mockOFClient.EXPECT().InstallServiceGroup(groupID, false, expectedEps).Times(1)
 	mockOFClient.EXPECT().InstallServiceFlows(groupID, svcIP, uint16(svcPort), bindingProtocol, uint16(0), false, corev1.ServiceTypeClusterIP, false).Times(1)
-	mockRouteClient.EXPECT().AddClusterIPRoute(svcIP).Times(1)
 
 	s1 := mockOFClient.EXPECT().UninstallServiceFlows(svcIP, uint16(svcPort), bindingProtocol).Times(1)
 	s2 := mockOFClient.EXPECT().InstallServiceFlows(groupID, svcIP, uint16(svcPort+1), bindingProtocol, uint16(0), false, corev1.ServiceTypeClusterIP, false).Times(1)
 	s2.After(s1)
-
-	mockRouteClient.EXPECT().DeleteClusterIPRoute(svcIP).Times(1)
-	mockRouteClient.EXPECT().AddClusterIPRoute(svcIP).Times(1)
 
 	if svcType == corev1.ServiceTypeNodePort || svcType == corev1.ServiceTypeLoadBalancer {
 		mockOFClient.EXPECT().InstallServiceFlows(groupID, vIP, uint16(svcNodePort), bindingProtocol, uint16(0), false, corev1.ServiceTypeNodePort, false).Times(1)
@@ -1987,12 +1962,9 @@ func testServiceNodePortUpdate(t *testing.T,
 	mockOFClient.EXPECT().InstallEndpointFlows(bindingProtocol, expectedEps).Times(1)
 	mockOFClient.EXPECT().InstallServiceGroup(groupID, false, expectedEps).Times(1)
 	mockOFClient.EXPECT().InstallServiceFlows(groupID, svcIP, uint16(svcPort), bindingProtocol, uint16(0), false, corev1.ServiceTypeClusterIP, false).Times(1)
-	mockRouteClient.EXPECT().AddClusterIPRoute(svcIP).Times(1)
 
 	mockOFClient.EXPECT().UninstallServiceFlows(svcIP, uint16(svcPort), bindingProtocol).Times(1)
 	mockOFClient.EXPECT().InstallServiceFlows(groupID, svcIP, uint16(svcPort), bindingProtocol, uint16(0), false, corev1.ServiceTypeClusterIP, false).Times(1)
-	mockRouteClient.EXPECT().DeleteClusterIPRoute(svcIP).Times(1)
-	mockRouteClient.EXPECT().AddClusterIPRoute(svcIP).Times(1)
 
 	if svcType == corev1.ServiceTypeNodePort || svcType == corev1.ServiceTypeLoadBalancer {
 		mockOFClient.EXPECT().InstallServiceFlows(groupID, vIP, uint16(svcNodePort), bindingProtocol, uint16(0), false, corev1.ServiceTypeNodePort, false).Times(1)
@@ -2090,7 +2062,6 @@ func testServiceExternalTrafficPolicyUpdate(t *testing.T,
 	mockOFClient.EXPECT().InstallEndpointFlows(bindingProtocol, gomock.InAnyOrder(expectedAllEps)).Times(1)
 	mockOFClient.EXPECT().InstallServiceGroup(groupID, false, gomock.InAnyOrder(expectedAllEps)).Times(1)
 	mockOFClient.EXPECT().InstallServiceFlows(groupID, svcIP, uint16(svcPort), bindingProtocol, uint16(0), false, corev1.ServiceTypeClusterIP, false).Times(1)
-	mockRouteClient.EXPECT().AddClusterIPRoute(svcIP).Times(1)
 
 	if svcType == corev1.ServiceTypeNodePort || svcType == corev1.ServiceTypeLoadBalancer {
 		mockOFClient.EXPECT().InstallServiceFlows(groupID, vIP, uint16(svcNodePort), bindingProtocol, uint16(0), false, corev1.ServiceTypeNodePort, false).Times(1)
@@ -2109,8 +2080,6 @@ func testServiceExternalTrafficPolicyUpdate(t *testing.T,
 
 	mockOFClient.EXPECT().UninstallServiceFlows(svcIP, uint16(svcPort), bindingProtocol).Times(1)
 	mockOFClient.EXPECT().InstallServiceFlows(groupID, svcIP, uint16(svcPort), bindingProtocol, uint16(0), true, corev1.ServiceTypeClusterIP, false).Times(1)
-	mockRouteClient.EXPECT().DeleteClusterIPRoute(svcIP).Times(1)
-	mockRouteClient.EXPECT().AddClusterIPRoute(svcIP).Times(1)
 
 	if svcType == corev1.ServiceTypeNodePort || svcType == corev1.ServiceTypeLoadBalancer {
 		mockOFClient.EXPECT().InstallEndpointFlows(bindingProtocol, gomock.InAnyOrder(expectedAllEps)).Times(1)
@@ -2196,7 +2165,6 @@ func testServiceInternalTrafficPolicyUpdate(t *testing.T,
 	mockOFClient.EXPECT().InstallEndpointFlows(bindingProtocol, gomock.InAnyOrder(expectedAllEps)).Times(1)
 	mockOFClient.EXPECT().InstallServiceGroup(groupID, false, gomock.InAnyOrder(expectedAllEps)).Times(1)
 	mockOFClient.EXPECT().InstallServiceFlows(groupID, svcIP, uint16(svcPort), bindingProtocol, uint16(0), false, corev1.ServiceTypeClusterIP, false).Times(1)
-	mockRouteClient.EXPECT().AddClusterIPRoute(svcIP).Times(1)
 	fp.syncProxyRules()
 	assert.Contains(t, fp.serviceInstalledMap, svcPortName)
 	assert.Contains(t, fp.endpointsInstalledMap, svcPortName)
@@ -2286,7 +2254,6 @@ func testServiceIngressIPsUpdate(t *testing.T,
 	for _, ip := range loadBalancerIPs {
 		mockOFClient.EXPECT().InstallServiceFlows(groupID, ip, uint16(svcPort), bindingProtocol, uint16(0), false, corev1.ServiceTypeLoadBalancer, false).Times(1)
 	}
-	mockRouteClient.EXPECT().AddClusterIPRoute(svcIP).Times(1)
 	mockRouteClient.EXPECT().AddNodePort(nodePortAddresses, uint16(svcNodePort), bindingProtocol).Times(1)
 	for _, ip := range loadBalancerIPs {
 		mockRouteClient.EXPECT().AddLoadBalancer(ip).Times(1)
@@ -2377,7 +2344,6 @@ func testServiceStickyMaxAgeSecondsUpdate(t *testing.T,
 	mockOFClient.EXPECT().InstallEndpointFlows(bindingProtocol, expectedEps).Times(1)
 	mockOFClient.EXPECT().InstallServiceGroup(groupID, true, expectedEps).Times(1)
 	mockOFClient.EXPECT().InstallServiceFlows(groupID, svcIP, uint16(svcPort), bindingProtocol, uint16(affinitySeconds), false, corev1.ServiceTypeClusterIP, false).Times(1)
-	mockRouteClient.EXPECT().AddClusterIPRoute(svcIP).Times(1)
 
 	mockOFClient.EXPECT().InstallServiceFlows(groupID, svcIP, uint16(svcPort), bindingProtocol, uint16(updatedAffinitySeconds), false, corev1.ServiceTypeClusterIP, false).Times(1)
 
@@ -2469,14 +2435,11 @@ func testServiceSessionAffinityTypeUpdate(t *testing.T,
 	mockOFClient.EXPECT().InstallEndpointFlows(bindingProtocol, expectedEps).Times(1)
 	mockOFClient.EXPECT().InstallServiceGroup(groupID, false, expectedEps).Times(1)
 	mockOFClient.EXPECT().InstallServiceFlows(groupID, svcIP, uint16(svcPort), bindingProtocol, uint16(0), false, corev1.ServiceTypeClusterIP, false).Times(1)
-	mockRouteClient.EXPECT().AddClusterIPRoute(svcIP).Times(1)
 
 	mockOFClient.EXPECT().InstallEndpointFlows(bindingProtocol, expectedEps).Times(1)
 	mockOFClient.EXPECT().InstallServiceGroup(groupID, true, expectedEps).Times(1)
 	mockOFClient.EXPECT().UninstallServiceFlows(svcIP, uint16(svcPort), bindingProtocol).Times(1)
 	mockOFClient.EXPECT().InstallServiceFlows(groupID, svcIP, uint16(svcPort), bindingProtocol, uint16(affinitySeconds), false, corev1.ServiceTypeClusterIP, false).Times(1)
-	mockRouteClient.EXPECT().DeleteClusterIPRoute(svcIP).Times(1)
-	mockRouteClient.EXPECT().AddClusterIPRoute(svcIP).Times(1)
 
 	if svcType == corev1.ServiceTypeNodePort || svcType == corev1.ServiceTypeLoadBalancer {
 		mockOFClient.EXPECT().InstallServiceFlows(groupID, vIP, uint16(svcNodePort), bindingProtocol, uint16(0), false, corev1.ServiceTypeNodePort, false).Times(1)
@@ -2706,7 +2669,6 @@ func TestGetServiceFlowKeys(t *testing.T) {
 				makeEndpointSliceMap(fp, eps)
 			}
 			if tc.svc != nil && tc.eps != nil && tc.serviceInstalled {
-				mockRouteClient.EXPECT().AddClusterIPRoute(svc1IPv4).Times(1)
 				mockRouteClient.EXPECT().AddNodePort(nodePortAddressesIPv4, uint16(svcNodePort), binding.ProtocolTCP).Times(1)
 				mockOFClient.EXPECT().InstallServiceGroup(gomock.Any(), gomock.Any(), gomock.Any()).Times(2)
 				mockOFClient.EXPECT().InstallEndpointFlows(binding.ProtocolTCP, gomock.Any()).Times(1)

--- a/pkg/agent/route/interfaces.go
+++ b/pkg/agent/route/interfaces.go
@@ -16,9 +16,16 @@ package route
 
 import (
 	"net"
+	"time"
 
 	"antrea.io/antrea/pkg/agent/config"
 	binding "antrea.io/antrea/pkg/ovs/openflow"
+)
+
+var (
+	// SyncInterval is exported so that sync interval can be configured for running integration test with
+	// smaller values. It is meant to be used internally by Run.
+	SyncInterval = 60 * time.Second
 )
 
 // Interface is the interface for routing container packets in host network.
@@ -27,7 +34,7 @@ type Interface interface {
 	// It should be idempotent and can be safely called on every startup.
 	Initialize(nodeConfig *config.NodeConfig, done func()) error
 
-	// Reconcile should remove orphaned routes and related configuration based on the desired podCIDRs and Service IPs.
+	// Reconcile should remove orphaned routes and related configuration based on the desired podCIDRs.
 	// If IPv6 is enabled in the cluster, Reconcile should also remove the orphaned IPv6 neighbors.
 	Reconcile(podCIDRs []string) error
 
@@ -57,13 +64,6 @@ type Interface interface {
 
 	// DeleteNodePort deletes related configurations when a NodePort Service is deleted.
 	DeleteNodePort(nodePortAddresses []net.IP, port uint16, protocol binding.Protocol) error
-
-	// AddClusterIPRoute adds route on K8s node for Service ClusterIP.
-	AddClusterIPRoute(svcIP net.IP) error
-
-	// DeleteClusterIPRoute deletes route for a Service IP when AntreaProxy is configured to handle
-	// ClusterIP Service traffic from host network.
-	DeleteClusterIPRoute(svcIP net.IP) error
 
 	// AddLoadBalancer adds configurations when a LoadBalancer IP is added.
 	AddLoadBalancer(externalIP net.IP) error

--- a/pkg/agent/route/route_linux.go
+++ b/pkg/agent/route/route_linux.go
@@ -73,6 +73,9 @@ const (
 	antreaPostRoutingChain = "ANTREA-POSTROUTING"
 	antreaOutputChain      = "ANTREA-OUTPUT"
 	antreaMangleChain      = "ANTREA-MANGLE"
+
+	serviceIPv4CIDRKey = "serviceIPv4CIDRKey"
+	serviceIPv6CIDRKey = "serviceIPv6CIDRKey"
 )
 
 // Client implements Interface.
@@ -82,9 +85,6 @@ var (
 	// globalVMAC is used in the IPv6 neighbor configuration to advertise ND solicitation for the IPv6 address of the
 	// host gateway interface on other Nodes.
 	globalVMAC, _ = net.ParseMAC("aa:bb:cc:dd:ee:ff")
-	// IPTablesSyncInterval is exported so that sync interval can be configured for running integration test with
-	// smaller values. It is meant to be used internally by Run.
-	IPTablesSyncInterval = 60 * time.Second
 )
 
 // Client takes care of routing container packets in host network, coordinating ip route, ip rule, iptables and ipset.
@@ -92,7 +92,7 @@ type Client struct {
 	nodeConfig    *config.NodeConfig
 	networkConfig *config.NetworkConfig
 	noSNAT        bool
-	ipt           iptables.Interface
+	iptables      iptables.Interface
 	ipset         ipset.Interface
 	netlink       utilnetlink.Interface
 	// nodeRoutes caches ip routes to remote Pods. It's a map of podCIDR to routes.
@@ -115,10 +115,6 @@ type Client struct {
 	nodePortsIPv4 sync.Map
 	// nodePortsIPv6 caches all existing IPv6 NodePorts.
 	nodePortsIPv6 sync.Map
-	// serviceIPv4CIDR stores the latest Service IPv4 CIDR from serviceCIDRProvider.
-	serviceIPv4CIDR *net.IPNet
-	// serviceIPv6CIDR stores the latest Service IPv6 CIDR from serviceCIDRProvider.
-	serviceIPv6CIDR *net.IPNet
 	// clusterNodeIPs stores the IPv4 of all other Nodes in the cluster
 	clusterNodeIPs sync.Map
 	// clusterNodeIP6s stores the IPv6 of all other Nodes in the cluster
@@ -154,7 +150,7 @@ func (c *Client) Initialize(nodeConfig *config.NodeConfig, done func()) error {
 		return fmt.Errorf("failed to initialize ipset: %v", err)
 	}
 
-	c.ipt, err = iptables.New(c.networkConfig.IPv4Enabled, c.networkConfig.IPv6Enabled)
+	c.iptables, err = iptables.New(c.networkConfig.IPv4Enabled, c.networkConfig.IPv6Enabled)
 	if err != nil {
 		return fmt.Errorf("error creating IPTables instance: %v", err)
 	}
@@ -207,28 +203,28 @@ func (c *Client) Initialize(nodeConfig *config.NodeConfig, done func()) error {
 // It will not return until stopCh is closed.
 func (c *Client) Run(stopCh <-chan struct{}) {
 	<-c.iptablesInitialized
-	klog.Infof("Starting iptables sync, with sync interval %v", IPTablesSyncInterval)
-	wait.Until(c.syncIPInfra, IPTablesSyncInterval, stopCh)
+	klog.InfoS("Starting iptables, ipset and route sync", "interval", SyncInterval)
+	wait.Until(c.syncIPInfra, SyncInterval, stopCh)
 }
 
 // syncIPInfra is idempotent and can be safely called on every sync operation.
 func (c *Client) syncIPInfra() {
 	// Sync ipset before syncing iptables rules
 	if err := c.syncIPSet(); err != nil {
-		klog.Errorf("Failed to sync ipset: %v", err)
+		klog.ErrorS(err, "Failed to sync ipset")
 		return
 	}
 	if err := c.syncIPTables(); err != nil {
-		klog.Errorf("Failed to sync iptables: %v", err)
+		klog.ErrorS(err, "Failed to sync iptables")
 		return
 	}
-	if err := c.syncRoutes(); err != nil {
-		klog.Errorf("Failed to sync routes: %v", err)
+	if err := c.syncRoute(); err != nil {
+		klog.ErrorS(err, "Failed to sync route")
 	}
-	klog.V(3).Infof("Successfully synced node iptables and routes")
+	klog.V(3).Info("Successfully synced iptables, ipset and route")
 }
 
-func (c *Client) syncRoutes() error {
+func (c *Client) syncRoute() error {
 	routeList, err := c.netlink.RouteList(nil, netlink.FAMILY_ALL)
 	if err != nil {
 		return err
@@ -247,7 +243,7 @@ func (c *Client) syncRoutes() error {
 			return true
 		}
 		if err := c.netlink.RouteReplace(route); err != nil {
-			klog.Errorf("Failed to add route to the gateway: %v", err)
+			klog.ErrorS(err, "Failed to sync route", "Route", route)
 			return false
 		}
 		return true
@@ -496,11 +492,11 @@ func (c *Client) syncIPTables() error {
 		jumpRules = append(jumpRules, jumpRule{iptables.NATTable, iptables.OutputChain, antreaOutputChain, "Antrea: jump to Antrea output rules"})
 	}
 	for _, rule := range jumpRules {
-		if err := c.ipt.EnsureChain(iptables.ProtocolDual, rule.table, rule.dstChain); err != nil {
+		if err := c.iptables.EnsureChain(iptables.ProtocolDual, rule.table, rule.dstChain); err != nil {
 			return err
 		}
 		ruleSpec := []string{"-j", rule.dstChain, "-m", "comment", "--comment", rule.comment}
-		if err := c.ipt.AppendRule(iptables.ProtocolDual, rule.table, rule.srcChain, ruleSpec); err != nil {
+		if err := c.iptables.AppendRule(iptables.ProtocolDual, rule.table, rule.srcChain, ruleSpec); err != nil {
 			return err
 		}
 	}
@@ -531,7 +527,7 @@ func (c *Client) syncIPTables() error {
 			false)
 
 		// Setting --noflush to keep the previous contents (i.e. non antrea managed chains) of the tables.
-		if err := c.ipt.Restore(iptablesData.String(), false, false); err != nil {
+		if err := c.iptables.Restore(iptablesData.String(), false, false); err != nil {
 			return err
 		}
 	}
@@ -548,7 +544,7 @@ func (c *Client) syncIPTables() error {
 			snatMarkToIPv6,
 			true)
 		// Setting --noflush to keep the previous contents (i.e. non antrea managed chains) of the tables.
-		if err := c.ipt.Restore(iptablesData.String(), false, true); err != nil {
+		if err := c.iptables.Restore(iptablesData.String(), false, true); err != nil {
 			return err
 		}
 	}
@@ -851,7 +847,7 @@ func (c *Client) initServiceIPRoutes() error {
 }
 
 // Reconcile removes orphaned podCIDRs from ipset and removes routes to orphaned podCIDRs
-// based on the desired podCIDRs. svcIPs are used for Windows only.
+// based on the desired podCIDRs.
 func (c *Client) Reconcile(podCIDRs []string) error {
 	desiredPodCIDRs := sets.NewString(podCIDRs...)
 	// Get the peer IPv6 gateways from pod CIDRs
@@ -937,9 +933,9 @@ func (c *Client) Reconcile(podCIDRs []string) error {
 }
 
 func (c *Client) isServiceRoute(route *netlink.Route) bool {
-	// If the destination IP or gateway IP is virtual Service IP , then it is a route which is added by AntreaProxy.
-	if route.Dst.IP.Equal(config.VirtualServiceIPv6) || route.Dst.IP.Equal(config.VirtualServiceIPv4) ||
-		route.Gw.Equal(config.VirtualServiceIPv6) || route.Gw.Equal(config.VirtualServiceIPv4) {
+	// If the gateway IP or the destination IP is the virtual Service IP, then it is a route added by AntreaProxy.
+	if route.Dst != nil && (route.Dst.IP.Equal(config.VirtualServiceIPv6) || route.Dst.IP.Equal(config.VirtualServiceIPv4)) ||
+		route.Gw != nil && (route.Gw.Equal(config.VirtualServiceIPv6) || route.Gw.Equal(config.VirtualServiceIPv4)) {
 		return true
 	}
 	return false
@@ -1133,10 +1129,6 @@ func (c *Client) DeleteRoutes(podCIDR *net.IPNet) error {
 	return nil
 }
 
-func (c *Client) DeleteClusterIPRoute(svcIP net.IP) error {
-	return nil
-}
-
 // Join all words with spaces, terminate with newline and write to buf.
 func writeLine(buf *bytes.Buffer, words ...string) {
 	// We avoid strings.Join for performance reasons.
@@ -1245,7 +1237,7 @@ func (c *Client) AddSNATRule(snatIP net.IP, mark uint32) error {
 		protocol = iptables.ProtocolIPv6
 	}
 	c.markToSNATIP.Store(mark, snatIP)
-	return c.ipt.InsertRule(protocol, iptables.NATTable, antreaPostRoutingChain, c.snatRuleSpec(snatIP, mark))
+	return c.iptables.InsertRule(protocol, iptables.NATTable, antreaPostRoutingChain, c.snatRuleSpec(snatIP, mark))
 }
 
 func (c *Client) DeleteSNATRule(mark uint32) error {
@@ -1260,11 +1252,11 @@ func (c *Client) DeleteSNATRule(mark uint32) error {
 	if snatIP.To4() == nil {
 		protocol = iptables.ProtocolIPv6
 	}
-	return c.ipt.DeleteRule(protocol, iptables.NATTable, antreaPostRoutingChain, c.snatRuleSpec(snatIP, mark))
+	return c.iptables.DeleteRule(protocol, iptables.NATTable, antreaPostRoutingChain, c.snatRuleSpec(snatIP, mark))
 }
 
-// addVirtualServiceIPRoute is used to add routing entry which is used to forward the packets whose destination IP is
-// virtual Service IP back to Antrea gateway on host.
+// addVirtualServiceIPRoute is used to add a route which is used to route the packets whose destination IP is a virtual
+// IP to Antrea gateway.
 func (c *Client) addVirtualServiceIPRoute(isIPv6 bool) error {
 	linkIndex := c.nodeConfig.GatewayConfig.LinkIndex
 	svcIP := config.VirtualServiceIPv4
@@ -1307,6 +1299,7 @@ func (c *Client) AddNodePort(nodePortAddresses []net.IP, port uint16, protocol b
 		} else {
 			c.nodePortsIPv4.Store(ipSetEntry, struct{}{})
 		}
+		klog.V(4).InfoS("Added ipset for NodePort", "IP", nodePortAddresses[i], "Port", port, "Protocol", protocol)
 	}
 
 	return nil
@@ -1333,41 +1326,33 @@ func (c *Client) DeleteNodePort(nodePortAddresses []net.IP, port uint16, protoco
 	return nil
 }
 
-// TODO: remove it after unifying Windows and Linux functions.
-func (c *Client) AddClusterIPRoute(svcIP net.IP) error {
-	return nil
-}
-
 func (c *Client) addServiceCIDRRoute(serviceCIDR *net.IPNet) error {
 	isIPv6 := utilnet.IsIPv6(serviceCIDR.IP)
 	linkIndex := c.nodeConfig.GatewayConfig.LinkIndex
 	scope := netlink.SCOPE_UNIVERSE
-	curServiceCIDR := c.serviceIPv4CIDR
+	serviceCIDRKey := serviceIPv4CIDRKey
 	gw := config.VirtualServiceIPv4
 	if isIPv6 {
-		curServiceCIDR = c.serviceIPv6CIDR
+		serviceCIDRKey = serviceIPv6CIDRKey
 		gw = config.VirtualServiceIPv6
 	}
 
+	oldServiceCIDRRoute, serviceCIDRRouteExists := c.serviceRoutes.Load(serviceCIDRKey)
 	// Generate a route with the new Service CIDR and install it.
 	serviceCIDRMask, _ := serviceCIDR.Mask.Size()
 	route := generateRoute(serviceCIDR.IP, serviceCIDRMask, gw, linkIndex, scope)
 	if err := c.netlink.RouteReplace(route); err != nil {
 		return fmt.Errorf("failed to install a new Service CIDR route: %w", err)
 	}
+
 	// Store the new Service CIDR.
-	if isIPv6 {
-		c.serviceIPv6CIDR = serviceCIDR
-	} else {
-		c.serviceIPv4CIDR = serviceCIDR
-	}
+	c.serviceRoutes.Store(serviceCIDRKey, route)
 
 	// Collect stale routes.
 	var staleRoutes []*netlink.Route
-	if curServiceCIDR != nil {
+	if serviceCIDRRouteExists {
 		// If current destination CIDR is not nil, the route with current destination CIDR should be uninstalled.
-		route.Dst = curServiceCIDR
-		staleRoutes = []*netlink.Route{route}
+		staleRoutes = []*netlink.Route{oldServiceCIDRRoute.(*netlink.Route)}
 	} else {
 		// If current destination CIDR is nil, which means that Antrea Agent has just started, then all existing routes
 		// whose destination CIDR contains the first ClusterIP should be uninstalled, except the newly installed route.
@@ -1390,10 +1375,10 @@ func (c *Client) addServiceCIDRRoute(serviceCIDR *net.IPNet) error {
 			if err.Error() == "no such process" {
 				klog.InfoS("Failed to delete stale Service CIDR route since the route has been deleted", "route", rt)
 			} else {
-				return fmt.Errorf("failed to uninstall stale Service CIDR route %s: %w", rt.String(), err)
+				return fmt.Errorf("failed to delete stale Service CIDR route %s: %w", rt.String(), err)
 			}
 		} else {
-			klog.V(4).InfoS("Uninstalled stale Service CIDR route successfully", "route", rt)
+			klog.V(4).InfoS("Deleted stale Service CIDR route successfully", "route", rt)
 		}
 	}
 
@@ -1412,9 +1397,9 @@ func (c *Client) addVirtualNodePortDNATIPRoute(isIPv6 bool) error {
 	}
 	route := generateRoute(vIP, mask, gw, linkIndex, netlink.SCOPE_UNIVERSE)
 	if err := c.netlink.RouteReplace(route); err != nil {
-		return fmt.Errorf("failed to install routing entry for virtual NodePort DNAT IP %s: %w", vIP.String(), err)
+		return fmt.Errorf("failed to install route for NodePort DNAT IP %s: %w", vIP.String(), err)
 	}
-	klog.V(4).InfoS("Added virtual NodePort DNAT IP route", "route", route)
+	klog.V(4).InfoS("Added NodePort DNAT IP route", "route", route)
 	c.serviceRoutes.Store(vIP.String(), route)
 
 	return nil
@@ -1437,7 +1422,7 @@ func (c *Client) AddLoadBalancer(svcIP net.IP) error {
 
 	route := generateRoute(svcIP, mask, gw, linkIndex, netlink.SCOPE_UNIVERSE)
 	if err := c.netlink.RouteReplace(route); err != nil {
-		return fmt.Errorf("failed to install routing entry for LoadBalancer ingress IP %s: %w", svcIP.String(), err)
+		return fmt.Errorf("failed to install route for LoadBalancer ingress IP %s: %w", svcIP.String(), err)
 	}
 	klog.V(4).InfoS("Added LoadBalancer ingress IP route", "route", route)
 	c.serviceRoutes.Store(svcIP.String(), route)
@@ -1448,28 +1433,21 @@ func (c *Client) AddLoadBalancer(svcIP net.IP) error {
 // DeleteLoadBalancer is used to delete routing entry which is used to route LoadBalancer ingress IP to Antrea
 // gateway on host.
 func (c *Client) DeleteLoadBalancer(svcIP net.IP) error {
-	linkIndex := c.nodeConfig.GatewayConfig.LinkIndex
-	isIPv6 := utilnet.IsIPv6(svcIP)
-	var gw net.IP
-	var mask int
-	if !isIPv6 {
-		gw = config.VirtualServiceIPv4
-		mask = net.IPv4len * 8
-	} else {
-		gw = config.VirtualServiceIPv6
-		mask = net.IPv6len * 8
+	svcIPStr := svcIP.String()
+	route, found := c.serviceRoutes.Load(svcIPStr)
+	if !found {
+		klog.V(2).InfoS("Didn't find route for LoadBalancer ingress IP", "ingressIP", svcIPStr)
+		return nil
 	}
-
-	route := generateRoute(svcIP, mask, gw, linkIndex, netlink.SCOPE_UNIVERSE)
-	if err := c.netlink.RouteDel(route); err != nil {
+	if err := c.netlink.RouteDel(route.(*netlink.Route)); err != nil {
 		if err.Error() == "no such process" {
-			klog.InfoS("Failed to delete LoadBalancer ingress IP route since the route has been deleted", "route", route)
+			klog.InfoS("Failed to delete route for LoadBalancer ingress IP since it doesn't exist", "route", route)
 		} else {
-			return fmt.Errorf("failed to delete routing entry for LoadBalancer ingress IP %s: %w", svcIP.String(), err)
+			return fmt.Errorf("failed to delete route for LoadBalancer ingress IP %s: %w", svcIPStr, err)
 		}
 	}
 	klog.V(4).InfoS("Deleted LoadBalancer ingress IP route", "route", route)
-	c.serviceRoutes.Delete(svcIP.String())
+	c.serviceRoutes.Delete(svcIPStr)
 
 	return nil
 }

--- a/pkg/agent/route/route_windows_test.go
+++ b/pkg/agent/route/route_windows_test.go
@@ -51,12 +51,6 @@ func TestRouteOperation(t *testing.T) {
 	_, destCIDR2, _ := net.ParseCIDR(dest2)
 
 	client, err := NewClient(&config.NetworkConfig{}, true, false, false, false, nil)
-	svcStr1 := "1.1.0.10"
-	svcIP1 := net.ParseIP(svcStr1)
-	svcIPNet1 := util.NewIPNet(svcIP1)
-	svcStr2 := "1.1.0.11"
-	svcIP2 := net.ParseIP(svcStr2)
-	svcIPNet2 := util.NewIPNet(svcIP2)
 
 	require.Nil(t, err)
 	nodeConfig := &config.NodeConfig{
@@ -84,24 +78,6 @@ func TestRouteOperation(t *testing.T) {
 	require.Nil(t, err)
 	assert.Equal(t, 1, len(routes2))
 
-	err = client.AddClusterIPRoute(svcIP1)
-	require.Nil(t, err)
-	route3, err := util.GetNetRoutes(gwLink, svcIPNet1)
-	require.Nil(t, err)
-	assert.Equal(t, 1, len(route3))
-	obj, found := client.hostRoutes.Load(svcIPNet1.String())
-	assert.True(t, found)
-	assert.EqualValues(t, route3[0], *obj.(*util.Route))
-
-	err = client.AddClusterIPRoute(svcIP2)
-	require.Nil(t, err)
-	route4, err := util.GetNetRoutes(gwLink, svcIPNet2)
-	require.Nil(t, err)
-	assert.Equal(t, 1, len(route4))
-	obj, found = client.hostRoutes.Load(svcIPNet2.String())
-	assert.True(t, found)
-	assert.EqualValues(t, route4[0], *obj.(*util.Route))
-
 	err = client.Reconcile([]string{dest2})
 	require.Nil(t, err)
 
@@ -109,21 +85,9 @@ func TestRouteOperation(t *testing.T) {
 	require.Nil(t, err)
 	assert.Equal(t, 0, len(routes5))
 
-	routes6, err := util.GetNetRoutes(gwLink, svcIPNet2)
-	require.Nil(t, err)
-	assert.Equal(t, 1, len(routes6))
-
 	err = client.DeleteRoutes(destCIDR2)
 	require.Nil(t, err)
 	routes7, err := util.GetNetRoutes(gwLink, destCIDR2)
 	require.Nil(t, err)
 	assert.Equal(t, 0, len(routes7))
-
-	err = client.DeleteClusterIPRoute(svcIP1)
-	require.Nil(t, err)
-	routes8, err := util.GetNetRoutes(gwLink, svcIPNet1)
-	require.Nil(t, err)
-	assert.Equal(t, 0, len(routes8))
-	_, found = client.hostRoutes.Load(svcIPNet1.String())
-	assert.False(t, found)
 }

--- a/pkg/agent/route/testing/mock_route.go
+++ b/pkg/agent/route/testing/mock_route.go
@@ -50,20 +50,6 @@ func (m *MockInterface) EXPECT() *MockInterfaceMockRecorder {
 	return m.recorder
 }
 
-// AddClusterIPRoute mocks base method
-func (m *MockInterface) AddClusterIPRoute(arg0 net.IP) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddClusterIPRoute", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// AddClusterIPRoute indicates an expected call of AddClusterIPRoute
-func (mr *MockInterfaceMockRecorder) AddClusterIPRoute(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddClusterIPRoute", reflect.TypeOf((*MockInterface)(nil).AddClusterIPRoute), arg0)
-}
-
 // AddLoadBalancer mocks base method
 func (m *MockInterface) AddLoadBalancer(arg0 net.IP) error {
 	m.ctrl.T.Helper()
@@ -132,20 +118,6 @@ func (m *MockInterface) AddSNATRule(arg0 net.IP, arg1 uint32) error {
 func (mr *MockInterfaceMockRecorder) AddSNATRule(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddSNATRule", reflect.TypeOf((*MockInterface)(nil).AddSNATRule), arg0, arg1)
-}
-
-// DeleteClusterIPRoute mocks base method
-func (m *MockInterface) DeleteClusterIPRoute(arg0 net.IP) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteClusterIPRoute", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteClusterIPRoute indicates an expected call of DeleteClusterIPRoute
-func (mr *MockInterfaceMockRecorder) DeleteClusterIPRoute(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteClusterIPRoute", reflect.TypeOf((*MockInterface)(nil).DeleteClusterIPRoute), arg0)
 }
 
 // DeleteLoadBalancer mocks base method

--- a/pkg/agent/util/net.go
+++ b/pkg/agent/util/net.go
@@ -299,6 +299,9 @@ func GetIPWithFamily(ips []net.IP, addrFamily uint8) (net.IP, error) {
 
 // ExtendCIDRWithIP is used for extending an IPNet with an IP.
 func ExtendCIDRWithIP(ipNet *net.IPNet, ip net.IP) (*net.IPNet, error) {
+	if ipNet == nil {
+		return NewIPNet(ip), nil
+	}
 	cpl := longestCommonPrefixLen(ipNet.IP, ip)
 	if cpl == 0 {
 		return nil, fmt.Errorf("invalid common prefix length")

--- a/pkg/agent/util/net_windows.go
+++ b/pkg/agent/util/net_windows.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/klog/v2"
 
 	ps "antrea.io/antrea/pkg/agent/util/powershell"
+	binding "antrea.io/antrea/pkg/ovs/openflow"
 )
 
 const (
@@ -74,6 +75,14 @@ func (r Route) String() string {
 		r.LinkIndex, r.DestinationSubnet, r.GatewayAddress, r.RouteMetric)
 }
 
+func (r Route) Equal(x Route) bool {
+	return x.LinkIndex == r.LinkIndex &&
+		x.DestinationSubnet != nil &&
+		r.DestinationSubnet != nil &&
+		x.DestinationSubnet.IP.Equal(r.DestinationSubnet.IP) &&
+		x.GatewayAddress.Equal(r.GatewayAddress)
+}
+
 type Neighbor struct {
 	LinkIndex        int
 	IPAddress        net.IP
@@ -83,6 +92,19 @@ type Neighbor struct {
 
 func (n Neighbor) String() string {
 	return fmt.Sprintf("LinkIndex: %d, IPAddress: %s, LinkLayerAddress: %s", n.LinkIndex, n.IPAddress, n.LinkLayerAddress)
+}
+
+type NetNatStaticMapping struct {
+	Name         string
+	ExternalIP   net.IP
+	ExternalPort uint16
+	InternalIP   net.IP
+	InternalPort uint16
+	Protocol     binding.Protocol
+}
+
+func (n NetNatStaticMapping) String() string {
+	return fmt.Sprintf("Name: %s, ExternalIP %s, ExternalPort: %d, InternalIP: %s, InternalPort: %d, Protocol: %s", n.Name, n.ExternalIP, n.ExternalPort, n.InternalIP, n.InternalPort, n.Protocol)
 }
 
 func GetNSPath(containerNetNS string) (string, error) {
@@ -702,10 +724,10 @@ func NewNetNat(netNatName string, subnetCIDR *net.IPNet) error {
 		}
 	} else {
 		if strings.Contains(internalNet, subnetCIDR.String()) {
-			klog.InfoS("existing netnat in CIDR", "name", internalNet, "subnetCIDR", subnetCIDR.String())
+			klog.V(4).InfoS("The existing netnat matched the subnet CIDR", "name", internalNet, "subnetCIDR", subnetCIDR.String())
 			return nil
 		}
-		klog.InfoS("Removing the existing netnat", "name", netNatName, "internalIPInterfaceAddressPrefix", internalNet)
+		klog.InfoS("Removing the existing NetNat", "name", netNatName, "internalIPInterfaceAddressPrefix", internalNet)
 		cmd = fmt.Sprintf("Remove-NetNat -Name %s -Confirm:$false", netNatName)
 		if _, err := runCommand(cmd); err != nil {
 			klog.ErrorS(err, "Failed to remove the existing netnat", "name", netNatName, "internalIPInterfaceAddressPrefix", internalNet)
@@ -721,15 +743,15 @@ func NewNetNat(netNatName string, subnetCIDR *net.IPNet) error {
 	return nil
 }
 
-func ReplaceNetNatStaticMapping(netNatName string, externalIPAddr string, externalPort uint16, internalIPAddr string, internalPort uint16, proto string) error {
-	staticMappingStr, err := GetNetNatStaticMapping(netNatName, externalIPAddr, externalPort, proto)
+func ReplaceNetNatStaticMapping(mapping *NetNatStaticMapping) error {
+	staticMappingStr, err := GetNetNatStaticMapping(mapping)
 	if err != nil {
 		return err
 	}
 	parsed := parseGetNetCmdResult(staticMappingStr, 6)
 	if len(parsed) > 0 {
 		items := parsed[0]
-		if items[4] == internalIPAddr && items[5] == strconv.Itoa(int(internalPort)) {
+		if items[4] == mapping.InternalIP.String() && items[5] == strconv.Itoa(int(mapping.InternalPort)) {
 			return nil
 		}
 		firstCol := strings.Split(items[0], ";")
@@ -737,19 +759,19 @@ func ReplaceNetNatStaticMapping(netNatName string, externalIPAddr string, extern
 		if err != nil {
 			return err
 		}
-		if err := RemoveNetNatStaticMappingByID(netNatName, id); err != nil {
+		if err := RemoveNetNatStaticMappingByID(mapping.Name, id); err != nil {
 			return err
 		}
 	}
-	return AddNetNatStaticMapping(netNatName, externalIPAddr, externalPort, internalIPAddr, internalPort, proto)
+	return AddNetNatStaticMapping(mapping)
 }
 
 // GetNetNatStaticMapping checks if a NetNatStaticMapping exists.
-func GetNetNatStaticMapping(netNatName string, externalIPAddr string, externalPort uint16, proto string) (string, error) {
-	cmd := fmt.Sprintf("Get-NetNatStaticMapping -NatName %s", netNatName) +
-		fmt.Sprintf("|? ExternalIPAddress -EQ %s", externalIPAddr) +
-		fmt.Sprintf("|? ExternalPort -EQ %d", externalPort) +
-		fmt.Sprintf("|? Protocol -EQ %s", proto) +
+func GetNetNatStaticMapping(mapping *NetNatStaticMapping) (string, error) {
+	cmd := fmt.Sprintf("Get-NetNatStaticMapping -NatName %s", mapping.Name) +
+		fmt.Sprintf("|? ExternalIPAddress -EQ %s", mapping.ExternalIP) +
+		fmt.Sprintf("|? ExternalPort -EQ %d", mapping.ExternalPort) +
+		fmt.Sprintf("|? Protocol -EQ %s", mapping.Protocol) +
 		"| Format-Table -HideTableHeaders"
 	staticMappingStr, err := runCommand(cmd)
 	if err != nil && !strings.Contains(err.Error(), "No MSFT_NetNatStaticMapping objects found") {
@@ -759,15 +781,15 @@ func GetNetNatStaticMapping(netNatName string, externalIPAddr string, externalPo
 }
 
 // AddNetNatStaticMapping adds a static mapping to a NAT instance.
-func AddNetNatStaticMapping(netNatName string, externalIPAddr string, externalPort uint16, internalIPAddr string, internalPort uint16, proto string) error {
+func AddNetNatStaticMapping(mapping *NetNatStaticMapping) error {
 	cmd := fmt.Sprintf("Add-NetNatStaticMapping -NatName %s -ExternalIPAddress %s -ExternalPort %d -InternalIPAddress %s -InternalPort %d -Protocol %s",
-		netNatName, externalIPAddr, externalPort, internalIPAddr, internalPort, proto)
+		mapping.Name, mapping.ExternalIP, mapping.ExternalPort, mapping.InternalIP, mapping.InternalPort, mapping.Protocol)
 	_, err := runCommand(cmd)
 	return err
 }
 
-func RemoveNetNatStaticMapping(netNatName string, externalIPAddr string, externalPort uint16, proto string) error {
-	staticMappingStr, err := GetNetNatStaticMapping(netNatName, externalIPAddr, externalPort, proto)
+func RemoveNetNatStaticMapping(mapping *NetNatStaticMapping) error {
+	staticMappingStr, err := GetNetNatStaticMapping(mapping)
 	if err != nil {
 		return err
 	}
@@ -781,24 +803,24 @@ func RemoveNetNatStaticMapping(netNatName string, externalIPAddr string, externa
 	if err != nil {
 		return err
 	}
-	return RemoveNetNatStaticMappingByID(netNatName, id)
+	return RemoveNetNatStaticMappingByID(mapping.Name, id)
 }
 
-func RemoveNetNatStaticMappingByNPLTuples(netNatName string, externalIPAddr string, externalPort uint16, internalIPAddr string, internalPort uint16, proto string) error {
-	staticMappingStr, err := GetNetNatStaticMapping(netNatName, externalIPAddr, externalPort, proto)
+func RemoveNetNatStaticMappingByNPLTuples(mapping *NetNatStaticMapping) error {
+	staticMappingStr, err := GetNetNatStaticMapping(mapping)
 	if err != nil {
 		return err
 	}
 	parsed := parseGetNetCmdResult(staticMappingStr, 6)
 	if len(parsed) > 0 {
 		items := parsed[0]
-		if items[4] == internalIPAddr && items[5] == strconv.Itoa(int(internalPort)) {
+		if items[4] == mapping.InternalIP.String() && items[5] == strconv.Itoa(int(mapping.InternalPort)) {
 			firstCol := strings.Split(items[0], ";")
 			id, err := strconv.Atoi(firstCol[1])
 			if err != nil {
 				return err
 			}
-			if err := RemoveNetNatStaticMappingByID(netNatName, id); err != nil {
+			if err := RemoveNetNatStaticMappingByID(mapping.Name, id); err != nil {
 				return err
 			}
 			return nil

--- a/test/integration/agent/route_test.go
+++ b/test/integration/agent/route_test.go
@@ -284,9 +284,9 @@ func TestIpTablesSync(t *testing.T) {
 		assert.Equal(t, "", string(actualData), "failed to remove iptables rule for %v", tc)
 	}
 	stopCh := make(chan struct{})
-	route.IPTablesSyncInterval = 2 * time.Second
+	route.SyncInterval = 2 * time.Second
 	go routeClient.Run(stopCh)
-	time.Sleep(route.IPTablesSyncInterval) // wait for one iteration of sync operation.
+	time.Sleep(route.SyncInterval) // wait for one iteration of sync operation.
 	for _, tc := range tcs {
 		saveCmd := fmt.Sprintf("iptables-save -t %s | grep -e '%s %s'", tc.Table, tc.Cmd, tc.Chain)
 		// #nosec G204: ignore in test code
@@ -443,9 +443,9 @@ func TestSyncRoutes(t *testing.T) {
 
 		stopCh := make(chan struct{})
 		defer close(stopCh)
-		route.IPTablesSyncInterval = 2 * time.Second
+		route.SyncInterval = 2 * time.Second
 		go routeClient.Run(stopCh)
-		time.Sleep(route.IPTablesSyncInterval) // wait for one iteration of sync operation.
+		time.Sleep(route.SyncInterval) // wait for one iteration of sync operation.
 
 		output, err := exec.Command("bash", "-c", listCmd).Output()
 		assert.NoError(t, err, "error executing ip route command: %s", listCmd)
@@ -487,10 +487,10 @@ func TestSyncGatewayKernelRoute(t *testing.T) {
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
-	route.IPTablesSyncInterval = 2 * time.Second
+	route.SyncInterval = 2 * time.Second
 	go routeClient.Run(stopCh)
 
-	err = wait.Poll(1*time.Second, 2*route.IPTablesSyncInterval, func() (done bool, err error) {
+	err = wait.Poll(1*time.Second, 2*route.SyncInterval, func() (done bool, err error) {
 		expOutput, err := exec.Command("bash", "-c", listCmd).Output()
 		if err != nil {
 			return false, err


### PR DESCRIPTION
This PR unifies the functions in route_linux.go and route_windows.go:
  - AddLoadBalancer
  - DeleteLoadBalancer

Remove:
  - DeleteClusterIPRoute
  - AddClusterIPRoute

Fix:
  - Add the route for calculated ClusterIP CIDR to Service route cache,
    then the route can be restored when it was deleted since members of
    the route cache are synchronized periodically.

Signed-off-by: Hongliang Liu <lhongliang@vmware.com>