### PR TITLE
Fix e2e test RejectServiceTraffic

### DIFF
--- a/test/e2e/antreapolicy_test.go
+++ b/test/e2e/antreapolicy_test.go
@@ -1649,9 +1649,9 @@ func testRejectServiceTraffic(t *testing.T, data *TestData) {
 	builder1 = builder1.SetName("acnp-reject-egress-svc-traffic").
 		SetPriority(1.0).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"antrea-e2e": "agnhost-client"}}})
-	builder1.AddEgress(ProtocolTCP, &p80, nil, nil, nil, nil, nil, nil, nil, map[string]string{"antrea-e2e": "s1"}, nil,
+	builder1.AddEgress(ProtocolTCP, &p80, nil, nil, nil, nil, nil, nil, nil, svc1.Spec.Selector, nil,
 		nil, nil, false, nil, crdv1alpha1.RuleActionReject, "", "", nil)
-	builder1.AddEgress(ProtocolTCP, &p80, nil, nil, nil, nil, nil, nil, nil, map[string]string{"antrea-e2e": "s2"}, nil,
+	builder1.AddEgress(ProtocolTCP, &p80, nil, nil, nil, nil, nil, nil, nil, svc2.Spec.Selector, nil,
 		nil, nil, false, nil, crdv1alpha1.RuleActionReject, "", "", nil)
 
 	acnpEgress := builder1.Get()
@@ -1678,7 +1678,7 @@ func testRejectServiceTraffic(t *testing.T, data *TestData) {
 	builder2 := &ClusterNetworkPolicySpecBuilder{}
 	builder2 = builder2.SetName("acnp-reject-ingress-svc-traffic").
 		SetPriority(1.0).
-		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"antrea-e2e": "s1"}}, {PodSelector: map[string]string{"antrea-e2e": "s2"}}})
+		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: svc1.Spec.Selector}, {PodSelector: svc2.Spec.Selector}})
 	builder2.AddIngress(ProtocolTCP, &p80, nil, nil, nil, nil, nil, nil, nil, map[string]string{"antrea-e2e": "agnhost-client"}, nil,
 		nil, nil, false, nil, crdv1alpha1.RuleActionReject, "", "", nil)
 

--- a/test/e2e/service_test.go
+++ b/test/e2e/service_test.go
@@ -194,7 +194,7 @@ func (data *TestData) createAgnhostServiceAndBackendPods(t *testing.T, name, nam
 		ipProtocol = corev1.IPv6Protocol
 	}
 	require.NoError(t, data.podWaitForRunning(defaultTimeout, name, namespace))
-	svc, err := data.CreateService(name, namespace, 80, 80, map[string]string{"app": "agnhost"}, false, false, svcType, &ipProtocol)
+	svc, err := data.CreateService(name, namespace, 80, 80, map[string]string{"app": "agnhost", "antrea-e2e": name}, false, false, svcType, &ipProtocol)
 	require.NoError(t, err)
 
 	cleanup := func() {


### PR DESCRIPTION
createAgnhostServiceAndBackendPods should create the service with the
selector that can only selects the Pod created together with it.
Previous selector selected all Pods using agnhost image, causing
traffic destined for service to be forwarded to unexpected Pod.

This patch also changed to use same Pod selector for Service and
ClusterNetworkPolicy to avoid redundancy and inconsistency.

Signed-off-by: Quan Tian <qtian@vmware.com>