### PR TITLE
Revise Multi-cluster Gateway descriptions in user docs

### DIFF
--- a/docs/multicluster/architecture.md
+++ b/docs/multicluster/architecture.md
@@ -74,7 +74,7 @@ Common Area of the leader cluster, decapsulates the resources from them, and
 creates the resources (e.g. Services, Endpoints, Antrea ClusterNetworkPolicies,
 ClusterInfoImports) in the member cluster.
 
-For more information about Multi-cluster Service export/import, please also check
+For more information about multi-cluster Service export/import, please also check
 the [Service Export and Import](#service-export-and-import) section.
 
 ## Multi-cluster Service
@@ -127,7 +127,7 @@ Antrea started to support Multi-cluster Gateway since v1.7.0. User can choose
 one K8s Node as the Multi-cluster Gateway in a member cluster. The Gateway Node
 is responsible for routing all cross-clusters traffic from the local cluster to
 other member clusters through tunnels. The diagram below depicts Antrea
-Mulit-cluster connectivity with Multi-cluster Gateways.
+Multi-cluster connectivity with Multi-cluster Gateways.
 
 <img src="assets/mc-gateway.svg" width="800" alt="Antrea Multi-cluster Gateway">
 
@@ -170,7 +170,7 @@ Endpoints:
 When the client Pod `pod-a` on cluster A tries to access the multi-cluster
 Service `antrea-mc-nginx`, the request packet will first go through the Service
 load balancing pipeline on the source Node `node-a2`, with one endpoint of the
-Multi-cluster Service being chosen as the destination. Let's say endpoint
+multi-cluster Service being chosen as the destination. Let's say endpoint
 `10.11.12.33` from cluster C is chosen, then the request packet will be DNAT'd
 with IP `10.11.12.33` and tunnelled to the local Gateway Node `node-a1`.
 `node-a1` knows from the destination IP (`10.11.12.33`) the packet is
@@ -187,7 +187,7 @@ to `pod-c`.
 ## Antrea Multi-cluster NetworkPolicy
 
 At this moment, Antrea does not support Pod-level policy enforcement for
-cross-cluster traffic. Access towards Multi-cluster Services can be regulated
+cross-cluster traffic. Access towards multi-cluster Services can be regulated
 with Antrea ClusterNetworkPolicy `toService` rules. In each member cluster,
 users can create an Antrea ClusterNetworkPolicy selecting Pods in that cluster,
 with the imported Mutli-cluster Service name and Namespace in an egress

--- a/docs/multicluster/quick-start.md
+++ b/docs/multicluster/quick-start.md
@@ -23,7 +23,7 @@ To use the latest version of Antrea Multi-cluster from the Antrea main branch,
 you can change the YAML manifest path to: `https://github.com/antrea-io/antrea/tree/main/multicluster/build/yamls/`
 when applying or downloading an Antrea YAML manifest.
 
-Antrea must be deployed in both cluster A and cluster B. To configure Antrea
+Antrea must be deployed in both cluster A and cluster B. To set up Antrea
 Multi-cluster Gateways, the `Multicluster` feature of `antrea-agent` must be
 feature enabled in both cluster A and B. Multi-cluster Gateways are required for
 routing multi-cluster Service traffic across the member clusters. Set the
@@ -41,6 +41,9 @@ antrea-agent.conf: |
     enable: true
     namespace: ""
 ```
+
+At the moment, Multi-cluster Gateway only works with the Antrea `encap` traffic
+mode, and all member clusters in a ClusterSet must use the same tunnel type.
 
 ## Set up Leader and Member in Cluster A
 
@@ -114,7 +117,7 @@ information about Multi-cluster Gatweay, please refer to the [Multi-cluster
 User Guide](user-guide.md#multi-cluster-gateway-configuration).
 
 Assuming K8s Node `node-a1` is selected for the Multi-cluster Gateway, run
-the following command to annotate the Node with
+the following command to annotate the Node with:
 `multicluster.antrea.io/gateway=true` (so Antrea can know it is the Gateway
 Node from the annotation):
 


### PR DESCRIPTION
Revise the descriptions about Multi-cluster Gateway configuration.
Add descriptions about the `gateway-ip` annotation.
Remove unnecessary descriptions about implementations from the user
documents.

Signed-off-by: Jianjun Shen <shenj@vmware.com>