### PR TITLE
Automated cherry pick of #3898: Deprecate the multicastInterfaces option

### DIFF
--- a/cmd/antrea-agent/options.go
+++ b/cmd/antrea-agent/options.go
@@ -398,6 +398,10 @@ func (o *Options) validateMulticastConfig() error {
 				return err
 			}
 		}
+		if len(o.config.Multicast.MulticastInterfaces) == 0 && len(o.config.MulticastInterfaces) > 0 {
+			klog.InfoS("The multicastInterfaces option is deprecated, please use multicast.multicastInterfaces instead")
+			o.config.Multicast.MulticastInterfaces = o.config.MulticastInterfaces
+		}
 	}
 	return nil
 }

--- a/pkg/config/agent/config.go
+++ b/pkg/config/agent/config.go
@@ -187,6 +187,10 @@ type AgentConfig struct {
 	// 2. TransportInterfaceCIDRs
 	// 3. The Node IP
 	TransportInterfaceCIDRs []string `yaml:"transportInterfaceCIDRs,omitempty"`
+	// The names of the interfaces on Nodes that are used to forward multicast traffic.
+	// Defaults to transport interface if not set.
+	// Deprecated: use Multicast.MulticastInterfaces instead.
+	MulticastInterfaces []string `yaml:"multicastInterfaces,omitempty"`
 	// Multicast configuration options.
 	Multicast MulticastConfig `yaml:"multicast,omitempty"`
 	// AntreaProxy contains AntreaProxy related configuration options.


### PR DESCRIPTION
Cherry pick of #3898 on release-1.7.

#3898: Deprecate the multicastInterfaces option

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.