### PR TITLE
Automated cherry pick of #3803: Add multicast statistics e2e tests

### DIFF
--- a/test/e2e/networkpolicy_test.go
+++ b/test/e2e/networkpolicy_test.go
@@ -921,8 +921,12 @@ func testIngressPolicyWithEndPort(t *testing.T, data *TestData) {
 
 func createAndWaitForPod(t *testing.T, data *TestData, createFunc func(name string, ns string, nodeName string, hostNetwork bool) error, namePrefix string, nodeName string, ns string, hostNetwork bool) (string, *PodIPs, func()) {
 	name := randName(namePrefix)
+	return createAndWaitForPodWithExactName(t, data, createFunc, name, nodeName, ns, hostNetwork)
+}
+
+func createAndWaitForPodWithExactName(t *testing.T, data *TestData, createFunc func(name string, ns string, nodeName string, hostNetwork bool) error, name string, nodeName string, ns string, hostNetwork bool) (string, *PodIPs, func()) {
 	if err := createFunc(name, ns, nodeName, hostNetwork); err != nil {
-		t.Fatalf("Error when creating busybox test Pod: %v", err)
+		t.Fatalf("Error when creating test Pod: %v", err)
 	}
 	cleanupFunc := func() {
 		deletePodWrapper(t, data, ns, name)


### PR DESCRIPTION
Cherry pick of #3803 on release-1.7.

#3803: Add multicast statistics e2e tests

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.