### PR TITLE
[WIP]Add multicluster test data coverage

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -64,7 +64,7 @@ jobs:
       uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: .coverage/coverage-unit.txt
+        files: .coverage/coverage-unit.txt,multicluster/.coverage/coverage-unit.txt
         flags: unit-tests
         name: codecov-unit-test
 


### PR DESCRIPTION
The multicluster unit test is called when test job run `make test-unit`,
but the data is not included in the report.

Signed-off-by: Lan Luo <luola@vmware.com>