### PR TITLE
[ExternalNode] Fix ExternalEntity name generation rules

### DIFF
--- a/pkg/util/externalnode/externalnode.go
+++ b/pkg/util/externalnode/externalnode.go
@@ -14,7 +14,15 @@
 
 package externalnode
 
-import "antrea.io/antrea/pkg/apis/crd/v1alpha1"
+import (
+	"crypto/sha1" // #nosec G505: not used for security purposes
+	"encoding/hex"
+	"io"
+
+	"antrea.io/antrea/pkg/apis/crd/v1alpha1"
+)
+
+const interfaceNameLength = 5
 
 func GenExternalEntityName(externalNode *v1alpha1.ExternalNode) string {
 	if len(externalNode.Spec.Interfaces) == 0 {
@@ -26,6 +34,9 @@ func GenExternalEntityName(externalNode *v1alpha1.ExternalNode) string {
 	if ifName == "" {
 		return externalNode.Name
 	} else {
-		return externalNode.Name + "-" + ifName
+		hash := sha1.New() // #nosec G401: not used for security purposes
+		io.WriteString(hash, ifName)
+		hashedIfName := hex.EncodeToString(hash.Sum(nil))
+		return externalNode.Name + "-" + hashedIfName[:interfaceNameLength]
 	}
 }


### PR DESCRIPTION
When ExternalNode interface name is not empty, we used to use
[ExternalNode name]-[Interface name] to be the generated ExternalEntity name.
However, interface name may be not satisfied with the regex check of Kubernetes
object name.

With this fix, when interface name is empty, we now use
[ExternalNode name]-[First four characters of hashed interface name] to ensure that
the generated ExternalEntity name is legal.

Signed-off-by: Mengdie Song <songm@vmware.com>