### PR TITLE
StretchedNetworkPolicy Agent Implementation

### DIFF
--- a/build/charts/antrea/README.md
+++ b/build/charts/antrea/README.md
@@ -85,7 +85,7 @@ Kubernetes: `>= 1.16.0-0`
 | multicast.igmpQueryInterval | string | `"125s"` | The interval at which the antrea-agent sends IGMP queries to Pods. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". |
 | multicast.multicastInterfaces | list | `[]` | Names of the interfaces on Nodes that are used to forward multicast traffic. |
 | multicluster.enable | bool | `false` | Enable Antrea Multi-cluster Gateway to support cross-cluster traffic. This feature is supported only with encap mode. |
-| multicluster.enableStretchedNetworkPolicy | bool | `false` | Enable Multicluster which allow Antrea-native policies to select peers from other clusters in a ClusterSet. This feature is supported only with encap mode when the tunnel type is Geneve. |
+| multicluster.enableStretchedNetworkPolicy | bool | `false` | Enable StretchedNetworkPolicy which allow Antrea-native policies to select peers from other clusters in a ClusterSet. This feature is supported only with encap mode when the tunnel type is Geneve. |
 | multicluster.namespace | string | `""` | The Namespace where Antrea Multi-cluster Controller is running. The default is antrea-agent's Namespace. |
 | noSNAT | bool | `false` | Whether or not to SNAT (using the Node IP) the egress traffic from a Pod to the external network. |
 | nodeIPAM.clusterCIDRs | list | `[]` | CIDR ranges to use when allocating Pod IP addresses. |

--- a/build/charts/antrea/conf/antrea-agent.conf
+++ b/build/charts/antrea/conf/antrea-agent.conf
@@ -333,4 +333,7 @@ multicluster:
 # The Namespace where Antrea Multi-cluster Controller is running.
 # The default is antrea-agent's Namespace.
   namespace: {{ .namespace | quote }}
+# Enable StretchedNetworkPolicy which could be enforced on cross-cluster traffic.
+# This feature is supported only with encap mode when the tunnel type is Geneve.
+  enableStretchedNetworkPolicy: {{ .enableStretchedNetworkPolicy }}
 {{- end }}

--- a/build/charts/antrea/conf/antrea-controller.conf
+++ b/build/charts/antrea/conf/antrea-controller.conf
@@ -111,7 +111,7 @@ ipsecCSRSigner:
 
 multicluster:
 {{- with .Values.multicluster }}
-  # Enable Multicluster which allow Antrea-native policies to select peers
+  # Enable StretchedNetworkPolicy which allow Antrea-native policies to select peers
   # from other clusters in a ClusterSet.
   enableStretchedNetworkPolicy: {{ .enableStretchedNetworkPolicy }}
 {{- end }}

--- a/build/charts/antrea/templates/agent/clusterrole.yaml
+++ b/build/charts/antrea/templates/agent/clusterrole.yaml
@@ -213,6 +213,7 @@ rules:
     - multicluster.crd.antrea.io
     resources:
     - clusterinfoimports
+    - labelidentities
     verbs:
     - get
     - list

--- a/build/charts/antrea/values.yaml
+++ b/build/charts/antrea/values.yaml
@@ -307,7 +307,7 @@ multicluster:
   # -- The Namespace where Antrea Multi-cluster Controller is running.
   # The default is antrea-agent's Namespace.
   namespace: ""
-  # -- Enable Multicluster which allow Antrea-native policies to select peers
+  # -- Enable StretchedNetworkPolicy which allow Antrea-native policies to select peers
   # from other clusters in a ClusterSet.
   # This feature is supported only with encap mode when the tunnel type is Geneve.
   enableStretchedNetworkPolicy: false

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -3220,6 +3220,9 @@ data:
     # The Namespace where Antrea Multi-cluster Controller is running.
     # The default is antrea-agent's Namespace.
       namespace: ""
+    # Enable StretchedNetworkPolicy which could be enforced on cross-cluster traffic.
+    # This feature is supported only with encap mode when the tunnel type is Geneve.
+      enableStretchedNetworkPolicy: false
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -3349,7 +3352,7 @@ data:
       selfSignedCA: true
 
     multicluster:
-      # Enable Multicluster which allow Antrea-native policies to select peers
+      # Enable StretchedNetworkPolicy which allow Antrea-native policies to select peers
       # from other clusters in a ClusterSet.
       enableStretchedNetworkPolicy: false
 ---
@@ -3699,6 +3702,7 @@ rules:
     - multicluster.crd.antrea.io
     resources:
     - clusterinfoimports
+    - labelidentities
     verbs:
     - get
     - list
@@ -4273,7 +4277,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 0bfe61fa131f03545550f3a41480c66a3122c1a87390077d700ca01df6371f9a
+        checksum/config: f06bc0519d38f9edaaa4516e816c564429500bf878c777abc41033b346e8edff
       labels:
         app: antrea
         component: antrea-agent
@@ -4514,7 +4518,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 0bfe61fa131f03545550f3a41480c66a3122c1a87390077d700ca01df6371f9a
+        checksum/config: f06bc0519d38f9edaaa4516e816c564429500bf878c777abc41033b346e8edff
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -3220,6 +3220,9 @@ data:
     # The Namespace where Antrea Multi-cluster Controller is running.
     # The default is antrea-agent's Namespace.
       namespace: ""
+    # Enable StretchedNetworkPolicy which could be enforced on cross-cluster traffic.
+    # This feature is supported only with encap mode when the tunnel type is Geneve.
+      enableStretchedNetworkPolicy: false
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -3349,7 +3352,7 @@ data:
       selfSignedCA: true
 
     multicluster:
-      # Enable Multicluster which allow Antrea-native policies to select peers
+      # Enable StretchedNetworkPolicy which allow Antrea-native policies to select peers
       # from other clusters in a ClusterSet.
       enableStretchedNetworkPolicy: false
 ---
@@ -3699,6 +3702,7 @@ rules:
     - multicluster.crd.antrea.io
     resources:
     - clusterinfoimports
+    - labelidentities
     verbs:
     - get
     - list
@@ -4273,7 +4277,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 0bfe61fa131f03545550f3a41480c66a3122c1a87390077d700ca01df6371f9a
+        checksum/config: f06bc0519d38f9edaaa4516e816c564429500bf878c777abc41033b346e8edff
       labels:
         app: antrea
         component: antrea-agent
@@ -4516,7 +4520,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 0bfe61fa131f03545550f3a41480c66a3122c1a87390077d700ca01df6371f9a
+        checksum/config: f06bc0519d38f9edaaa4516e816c564429500bf878c777abc41033b346e8edff
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -3220,6 +3220,9 @@ data:
     # The Namespace where Antrea Multi-cluster Controller is running.
     # The default is antrea-agent's Namespace.
       namespace: ""
+    # Enable StretchedNetworkPolicy which could be enforced on cross-cluster traffic.
+    # This feature is supported only with encap mode when the tunnel type is Geneve.
+      enableStretchedNetworkPolicy: false
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -3349,7 +3352,7 @@ data:
       selfSignedCA: true
 
     multicluster:
-      # Enable Multicluster which allow Antrea-native policies to select peers
+      # Enable StretchedNetworkPolicy which allow Antrea-native policies to select peers
       # from other clusters in a ClusterSet.
       enableStretchedNetworkPolicy: false
 ---
@@ -3699,6 +3702,7 @@ rules:
     - multicluster.crd.antrea.io
     resources:
     - clusterinfoimports
+    - labelidentities
     verbs:
     - get
     - list
@@ -4273,7 +4277,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: db1a9feabdabaa45a5a006e8d89bd1b3b4a4e3c67573cb98d5f3630e15d4d757
+        checksum/config: 4c94da583c601f67c4369808e59e884c0ea07d35b3f295e7a9fe3e14b80221a5
       labels:
         app: antrea
         component: antrea-agent
@@ -4513,7 +4517,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: db1a9feabdabaa45a5a006e8d89bd1b3b4a4e3c67573cb98d5f3630e15d4d757
+        checksum/config: 4c94da583c601f67c4369808e59e884c0ea07d35b3f295e7a9fe3e14b80221a5
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -3233,6 +3233,9 @@ data:
     # The Namespace where Antrea Multi-cluster Controller is running.
     # The default is antrea-agent's Namespace.
       namespace: ""
+    # Enable StretchedNetworkPolicy which could be enforced on cross-cluster traffic.
+    # This feature is supported only with encap mode when the tunnel type is Geneve.
+      enableStretchedNetworkPolicy: false
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -3362,7 +3365,7 @@ data:
       selfSignedCA: true
 
     multicluster:
-      # Enable Multicluster which allow Antrea-native policies to select peers
+      # Enable StretchedNetworkPolicy which allow Antrea-native policies to select peers
       # from other clusters in a ClusterSet.
       enableStretchedNetworkPolicy: false
 ---
@@ -3712,6 +3715,7 @@ rules:
     - multicluster.crd.antrea.io
     resources:
     - clusterinfoimports
+    - labelidentities
     verbs:
     - get
     - list
@@ -4286,7 +4290,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 1cc89e2ac8e3f6c3c1297fb1d3d8ba1f8eb1f69a7ff915fc23322d9e45237d3f
+        checksum/config: 8a0ea8f57943caf7de83015414c2bb78c4283a7280118ce3a2160e121e8829b9
         checksum/ipsec-secret: d0eb9c52d0cd4311b6d252a951126bf9bea27ec05590bed8a394f0f792dcb2a4
       labels:
         app: antrea
@@ -4572,7 +4576,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 1cc89e2ac8e3f6c3c1297fb1d3d8ba1f8eb1f69a7ff915fc23322d9e45237d3f
+        checksum/config: 8a0ea8f57943caf7de83015414c2bb78c4283a7280118ce3a2160e121e8829b9
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -3220,6 +3220,9 @@ data:
     # The Namespace where Antrea Multi-cluster Controller is running.
     # The default is antrea-agent's Namespace.
       namespace: ""
+    # Enable StretchedNetworkPolicy which could be enforced on cross-cluster traffic.
+    # This feature is supported only with encap mode when the tunnel type is Geneve.
+      enableStretchedNetworkPolicy: false
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -3349,7 +3352,7 @@ data:
       selfSignedCA: true
 
     multicluster:
-      # Enable Multicluster which allow Antrea-native policies to select peers
+      # Enable StretchedNetworkPolicy which allow Antrea-native policies to select peers
       # from other clusters in a ClusterSet.
       enableStretchedNetworkPolicy: false
 ---
@@ -3699,6 +3702,7 @@ rules:
     - multicluster.crd.antrea.io
     resources:
     - clusterinfoimports
+    - labelidentities
     verbs:
     - get
     - list
@@ -4273,7 +4277,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: bb8e267e96249bf4d28379cb852eaada9d0e8d20467d58c8e8ab54e33a29fd93
+        checksum/config: 7ef1495672b7b4b2ed3d7729f27af861e3f619bd3343488d45b9c8c3195106cd
       labels:
         app: antrea
         component: antrea-agent
@@ -4513,7 +4517,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: bb8e267e96249bf4d28379cb852eaada9d0e8d20467d58c8e8ab54e33a29fd93
+        checksum/config: 7ef1495672b7b4b2ed3d7729f27af861e3f619bd3343488d45b9c8c3195106cd
       labels:
         app: antrea
         component: antrea-controller

--- a/multicluster/controllers/multicluster/label_identity_controller.go
+++ b/multicluster/controllers/multicluster/label_identity_controller.go
@@ -105,7 +105,7 @@ func (r *LabelIdentityReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		klog.ErrorS(err, "Cannot get corresponding Namespace of the Pod", "pod", req.NamespacedName)
 		return ctrl.Result{}, err
 	}
-	normalizedLabel := getNormalizedLabel(ns.Labels, pod.Labels, ns.Name)
+	normalizedLabel := GetNormalizedLabel(ns.Labels, pod.Labels, ns.Name)
 	r.onPodCreateOrUpdate(req.NamespacedName.String(), normalizedLabel)
 	return ctrl.Result{}, nil
 }
@@ -317,7 +317,7 @@ func (r *LabelIdentityReconciler) getLabelIdentityResourceExport(name, normalize
 	}
 }
 
-func getNormalizedLabel(nsLabels, podLabels map[string]string, ns string) string {
+func GetNormalizedLabel(nsLabels, podLabels map[string]string, ns string) string {
 	if _, ok := nsLabels[v1.LabelMetadataName]; !ok {
 		// NamespaceDefaultLabelName is supported from K8s v1.21. For K8s versions before v1.21,
 		// we append the Namespace name label to the Namespace label set, so that the exported

--- a/multicluster/controllers/multicluster/label_identity_controller_test.go
+++ b/multicluster/controllers/multicluster/label_identity_controller_test.go
@@ -271,7 +271,7 @@ func TestGetNormalizedLabel(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			normalizedLabel := getNormalizedLabel(tt.nsLabels, tt.podLabels, tt.namespace)
+			normalizedLabel := GetNormalizedLabel(tt.nsLabels, tt.podLabels, tt.namespace)
 			assert.Equal(t, tt.expNormalizedLabel, normalizedLabel)
 		})
 	}

--- a/multicluster/test/e2e/framework.go
+++ b/multicluster/test/e2e/framework.go
@@ -39,6 +39,8 @@ const (
 	multiClusterTestNamespace string = "antrea-multicluster-test"
 	eastClusterTestService    string = "east-nginx"
 	westClusterTestService    string = "west-nginx"
+	mcEastClusterTestService  string = "antrea-mc-east-nginx"
+	mcWestClusterTestService  string = "antrea-mc-west-nginx"
 	eastCluster               string = "east-cluster"
 	westCluster               string = "west-cluster"
 	leaderCluster             string = "leader-cluster"
@@ -168,6 +170,26 @@ func (data *MCTestData) createPod(clusterName, name, nodeName, namespace, ctrNam
 	return fmt.Errorf("clusterName %s not found", clusterName)
 }
 
+func (data *MCTestData) updatePod(clusterName string, namespace, name string, mutateFunc func(*corev1.Pod)) error {
+	if d, ok := data.clusterTestDataMap[clusterName]; ok {
+		if err := d.UpdatePod(namespace, name, mutateFunc); err != nil {
+			return err
+		}
+		return nil
+	}
+	return fmt.Errorf("clusterName %s not found", clusterName)
+}
+
+func (data *MCTestData) updateNamespace(clusterName string, namespace string, mutateFunc func(*corev1.Namespace)) error {
+	if d, ok := data.clusterTestDataMap[clusterName]; ok {
+		if err := d.UpdateNamespace(namespace, mutateFunc); err != nil {
+			return err
+		}
+		return nil
+	}
+	return fmt.Errorf("clusterName %s not found", clusterName)
+}
+
 func (data *MCTestData) createService(clusterName, serviceName, namespace string, port int32, targetPort int32,
 	protocol corev1.Protocol, selector map[string]string, affinity bool, nodeLocalExternal bool, serviceType corev1.ServiceType,
 	ipFamily *corev1.IPFamily, annotation map[string]string) (*corev1.Service, error) {
@@ -192,6 +214,21 @@ func (data *MCTestData) createOrUpdateANP(clusterName string, anp *crdv1alpha1.N
 func (data *MCTestData) deleteANP(clusterName, namespace, name string) error {
 	if d, ok := data.clusterTestDataMap[clusterName]; ok {
 		return d.DeleteANP(namespace, name)
+	}
+	return fmt.Errorf("clusterName %s not found", clusterName)
+}
+
+func (data *MCTestData) createOrUpdateACNP(clusterName string, acnp *crdv1alpha1.ClusterNetworkPolicy) (*crdv1alpha1.ClusterNetworkPolicy, error) {
+	if d, ok := data.clusterTestDataMap[clusterName]; ok {
+		return d.CreateOrUpdateACNP(acnp)
+	}
+	return nil, fmt.Errorf("clusterName %s not found", clusterName)
+}
+
+// deleteACNP is a convenience function for deleting ACNP by name.
+func (data *MCTestData) deleteACNP(clusterName, name string) error {
+	if d, ok := data.clusterTestDataMap[clusterName]; ok {
+		return d.DeleteACNP(name)
 	}
 	return fmt.Errorf("clusterName %s not found", clusterName)
 }

--- a/multicluster/test/e2e/main_test.go
+++ b/multicluster/test/e2e/main_test.go
@@ -106,12 +106,16 @@ func TestConnectivity(t *testing.T) {
 		time.Sleep(5 * time.Second)
 	}
 
-	t.Run("TestMCServiceExport", func(t *testing.T) {
+	t.Run("TestMCService", func(t *testing.T) {
 		defer tearDownForServiceExportsTest(t, data)
 		initializeForServiceExportsTest(t, data)
 		t.Run("Case=MCServiceConnectivity", func(t *testing.T) { testMCServiceConnectivity(t, data) })
 		t.Run("Case=ScaleDownMCServiceEndpoints", func(t *testing.T) { testScaleDownMCServiceEndpoints(t, data) })
 		t.Run("Case=ANPToServices", func(t *testing.T) { testANPToServices(t, data) })
+		t.Run("Case=StretchedNetworkPolicy", func(t *testing.T) { testStretchedNetworkPolicy(t, data) })
+		t.Run("Case=StretchedNetworkPolicyUpdatePod", func(t *testing.T) { testStretchedNetworkPolicyUpdatePod(t, data) })
+		t.Run("Case=StretchedNetworkPolicyUpdateNS", func(t *testing.T) { testStretchedNetworkPolicyUpdateNS(t, data) })
+		t.Run("Case=StretchedNetworkPolicyUpdatePolicy", func(t *testing.T) { testStretchedNetworkPolicyUpdatePolicy(t, data) })
 	})
 
 	t.Run("TestAntreaPolicy", func(t *testing.T) {

--- a/pkg/agent/cniserver/pod_configuration.go
+++ b/pkg/agent/cniserver/pod_configuration.go
@@ -451,6 +451,7 @@ func (pc *podConfigurator) reconcile(pods []corev1.Pod, containerAccess *contain
 				containerConfig.MAC,
 				uint32(containerConfig.OFPort),
 				containerConfig.VLANID,
+				nil,
 			); err != nil {
 				klog.Errorf("Error when re-installing flows for Pod %s", namespacedName)
 			}
@@ -491,7 +492,7 @@ func (pc *podConfigurator) connectInterfaceToOVSCommon(ovsPortName string, conta
 		return fmt.Errorf("failed to get of_port of OVS port %s: %v", ovsPortName, err)
 	}
 	klog.V(2).Infof("Setting up Openflow entries for container %s", containerID)
-	if err := pc.ofClient.InstallPodFlows(ovsPortName, containerConfig.IPs, containerConfig.MAC, uint32(ofPort), containerConfig.VLANID); err != nil {
+	if err := pc.ofClient.InstallPodFlows(ovsPortName, containerConfig.IPs, containerConfig.MAC, uint32(ofPort), containerConfig.VLANID, nil); err != nil {
 		return fmt.Errorf("failed to add Openflow entries for container %s: %v", containerID, err)
 	}
 	containerConfig.OVSPortConfig = &interfacestore.OVSPortConfig{PortUUID: portUUID, OFPort: ofPort}

--- a/pkg/agent/cniserver/pod_configuration_windows.go
+++ b/pkg/agent/cniserver/pod_configuration_windows.go
@@ -44,7 +44,7 @@ func (pc *podConfigurator) connectInterfaceToOVSAsync(ifConfig *interfacestore.I
 		}
 		containerID := ifConfig.ContainerID
 		klog.V(2).Infof("Setting up Openflow entries for container %s", containerID)
-		if err := pc.ofClient.InstallPodFlows(ovsPortName, ifConfig.IPs, ifConfig.MAC, uint32(ofPort), ifConfig.VLANID); err != nil {
+		if err := pc.ofClient.InstallPodFlows(ovsPortName, ifConfig.IPs, ifConfig.MAC, uint32(ofPort), ifConfig.VLANID, nil); err != nil {
 			return fmt.Errorf("failed to add Openflow entries for container %s: %v", containerID, err)
 		}
 		// Update interface config with the ofPort.

--- a/pkg/agent/controller/networkpolicy/cache.go
+++ b/pkg/agent/controller/networkpolicy/cache.go
@@ -30,6 +30,7 @@ import (
 
 	"antrea.io/antrea/pkg/agent/config"
 	"antrea.io/antrea/pkg/agent/metrics"
+	"antrea.io/antrea/pkg/agent/openflow"
 	agenttypes "antrea.io/antrea/pkg/agent/types"
 	v1beta "antrea.io/antrea/pkg/apis/controlplane/v1beta2"
 	crdv1alpha1 "antrea.io/antrea/pkg/apis/crd/v1alpha1"
@@ -691,6 +692,38 @@ func toRule(r *v1beta.NetworkPolicyRule, policy *v1beta.NetworkPolicy, maxPriori
 	return rule
 }
 
+// toStretchedNetworkPolicySecurityRule converts v1beta.NetworkPolicyRule to *rule
+// which is used to drop all traffic initiated from Pods with UnknownLabelIdentity.
+// Pods may have UnknownLabelIdentity when their Labels are completely new Labels
+// among the whole ClusterSet. Before the new allocated LabelIdentity is imported
+// in the Cluster, those Pods will have UnknownLabelIdentity.
+func toStretchedNetworkPolicySecurityRule(r *v1beta.NetworkPolicyRule, policy *v1beta.NetworkPolicy, maxPriority int32) *rule {
+	appliedToGroups := policy.AppliedToGroups
+	if len(r.AppliedToGroups) != 0 {
+		appliedToGroups = r.AppliedToGroups
+	}
+	snpSecDropAction := crdv1alpha1.RuleActionDrop
+	rule := &rule{
+		Direction:       r.Direction,
+		From:            v1beta.NetworkPolicyPeer{LabelIdentities: []uint32{openflow.UnknownLabelIdentity}},
+		To:              r.To,
+		Services:        r.Services,
+		Action:          &snpSecDropAction,
+		Priority:        r.Priority,
+		PolicyPriority:  policy.Priority,
+		TierPriority:    policy.TierPriority,
+		AppliedToGroups: appliedToGroups,
+		Name:            r.Name + "-security",
+		PolicyUID:       policy.UID,
+		SourceRef:       policy.SourceRef,
+		EnableLogging:   r.EnableLogging,
+	}
+	rule.ID = hashRule(rule)
+	rule.PolicyName = policy.Name
+	rule.MaxPriority = maxPriority
+	return rule
+}
+
 // getMaxPriority returns the highest rule priority for v1beta.NetworkPolicy that is created
 // by Antrea-native policies. For K8s NetworkPolicies, it always returns -1.
 func getMaxPriority(policy *v1beta.NetworkPolicy) int32 {
@@ -772,22 +805,31 @@ func (c *ruleCache) updateNetworkPolicyLocked(policy *v1beta.NetworkPolicy) bool
 	anyRuleUpdate := false
 	maxPriority := getMaxPriority(policy)
 	for i := range policy.Rules {
-		r := toRule(&policy.Rules[i], policy, maxPriority)
-		if _, exists := ruleByID[r.ID]; exists {
-			// If rule already exists, remove it from the map so the ones left finally are orphaned.
-			klog.V(2).Infof("Rule %v was not changed", r.ID)
-			delete(ruleByID, r.ID)
-		} else {
-			// If rule doesn't exist, add it to cache, mark it as dirty.
-			c.rules.Add(r)
-			// Count up antrea_agent_ingress_networkpolicy_rule_count or antrea_agent_egress_networkpolicy_rule_count
-			if r.Direction == v1beta.DirectionIn {
-				metrics.IngressNetworkPolicyRuleCount.Inc()
+		rules := []*rule{toRule(&policy.Rules[i], policy, maxPriority)}
+		if len(policy.Rules[i].From.LabelIdentities) > 0 {
+			// If the rule is a StretchedNetworkPolicy rule, we also need to add a security rule.
+			// The security rule is used to drop all traffic initiated from Pods with
+			// UnknownLabelIdentity to make sure those traffic won't sneak around the Policy.
+			rules = append(rules, toStretchedNetworkPolicySecurityRule(&policy.Rules[i], policy, maxPriority))
+		}
+		for _, r := range rules {
+			if _, exists := ruleByID[r.ID]; exists {
+				// If rule already exists, remove it from the map so the ones left are orphaned,
+				// which means those rules need to be handled by dirtyRuleHandler.
+				klog.V(2).InfoS("Rule was not changed", "id", r.ID)
+				delete(ruleByID, r.ID)
 			} else {
-				metrics.EgressNetworkPolicyRuleCount.Inc()
+				// If rule doesn't exist, add it to cache and mark it as dirty.
+				c.rules.Add(r)
+				// Count up antrea_agent_ingress_networkpolicy_rule_count or antrea_agent_egress_networkpolicy_rule_count
+				if r.Direction == v1beta.DirectionIn {
+					metrics.IngressNetworkPolicyRuleCount.Inc()
+				} else {
+					metrics.EgressNetworkPolicyRuleCount.Inc()
+				}
+				c.dirtyRuleHandler(r.ID)
+				anyRuleUpdate = true
 			}
-			c.dirtyRuleHandler(r.ID)
-			anyRuleUpdate = true
 		}
 	}
 

--- a/pkg/agent/controller/networkpolicy/reconciler_test.go
+++ b/pkg/agent/controller/networkpolicy/reconciler_test.go
@@ -445,6 +445,30 @@ func TestReconcilerReconcile(t *testing.T) {
 			false,
 		},
 		{
+			"ingress-rule-with-label-identity",
+			&CompletedRule{
+				rule: &rule{
+					ID:        "ingress-rule",
+					Direction: v1beta2.DirectionIn,
+					From:      v1beta2.NetworkPolicyPeer{LabelIdentities: []uint32{1}},
+					SourceRef: &np1,
+				},
+				FromAddresses: nil,
+				ToAddresses:   nil,
+				TargetMembers: appliedToGroup1,
+			},
+			[]*types.PolicyRule{
+				{
+					Direction: v1beta2.DirectionIn,
+					From:      labelIDToOFAddresses([]uint32{1}),
+					To:        ofPortsToOFAddresses(sets.NewInt32(1)),
+					Service:   nil,
+					PolicyRef: &np1,
+				},
+			},
+			false,
+		},
+		{
 			"egress-rule",
 			&CompletedRule{
 				rule:          &rule{ID: "egress-rule", Direction: v1beta2.DirectionOut, SourceRef: &np1},

--- a/pkg/agent/multicluster/stretched_networkpolicy_controller.go
+++ b/pkg/agent/multicluster/stretched_networkpolicy_controller.go
@@ -1,0 +1,345 @@
+// Copyright 2022 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multicluster
+
+import (
+	"fmt"
+	"reflect"
+	"sync"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+
+	"antrea.io/antrea/multicluster/apis/multicluster/v1alpha1"
+	"antrea.io/antrea/multicluster/controllers/multicluster"
+	mcinformers "antrea.io/antrea/multicluster/pkg/client/informers/externalversions/multicluster/v1alpha1"
+	mclisters "antrea.io/antrea/multicluster/pkg/client/listers/multicluster/v1alpha1"
+	"antrea.io/antrea/pkg/agent/interfacestore"
+	"antrea.io/antrea/pkg/agent/openflow"
+	antreatypes "antrea.io/antrea/pkg/agent/types"
+	"antrea.io/antrea/pkg/util/channel"
+)
+
+const (
+	stretchedNetworkPolicyWorker         = 4
+	stretchedNetworkPolicyControllerName = "AntreaAgentStretchedNetworkPolicyController"
+
+	labelIndex = "Label"
+)
+
+type podSet map[types.NamespacedName]struct{}
+
+// StretchedNetworkPolicyController is used to update classifier flows of Pods.
+// It will make sure the latest LabelIdentity of the Pod, if available, will be
+// loaded into tun_id in the classifier flow of the Pod.
+// If the LabelIdentity of the Pod is not available when updating, the
+// UnknownLabelIdentity will be loaded. When the actual LabelIdentity is created,
+// the classifier flow will be updated accordingly.
+type StretchedNetworkPolicyController struct {
+	ofClient                  openflow.Client
+	interfaceStore            interfacestore.InterfaceStore
+	podInformer               cache.SharedIndexInformer
+	podLister                 corelisters.PodLister
+	podListerSynced           cache.InformerSynced
+	namespaceInformer         coreinformers.NamespaceInformer
+	namespaceLister           corelisters.NamespaceLister
+	namespaceListerSynced     cache.InformerSynced
+	labelIdentityInformer     mcinformers.LabelIdentityInformer
+	labelIdentityLister       mclisters.LabelIdentityLister
+	LabelIdentityListerSynced cache.InformerSynced
+	queue                     workqueue.RateLimitingInterface
+	lock                      sync.RWMutex
+
+	labelToPods map[string]podSet
+	podToLabel  map[types.NamespacedName]string
+}
+
+func NewMCAgentStretchedNetworkPolicyController(
+	client openflow.Client,
+	interfaceStore interfacestore.InterfaceStore,
+	podInformer cache.SharedIndexInformer,
+	namespaceInformer coreinformers.NamespaceInformer,
+	labelIdentityInformer mcinformers.LabelIdentityInformer,
+	podUpdateSubscriber channel.Subscriber,
+) *StretchedNetworkPolicyController {
+	controller := &StretchedNetworkPolicyController{
+		ofClient:                  client,
+		interfaceStore:            interfaceStore,
+		podInformer:               podInformer,
+		podLister:                 corelisters.NewPodLister(podInformer.GetIndexer()),
+		podListerSynced:           podInformer.HasSynced,
+		namespaceInformer:         namespaceInformer,
+		namespaceLister:           namespaceInformer.Lister(),
+		namespaceListerSynced:     namespaceInformer.Informer().HasSynced,
+		labelIdentityInformer:     labelIdentityInformer,
+		labelIdentityLister:       labelIdentityInformer.Lister(),
+		LabelIdentityListerSynced: labelIdentityInformer.Informer().HasSynced,
+		queue:                     workqueue.NewNamedRateLimitingQueue(workqueue.DefaultItemBasedRateLimiter(), "stretchedNetworkPolicy"),
+		labelToPods:               map[string]podSet{},
+		podToLabel:                map[types.NamespacedName]string{},
+	}
+
+	controller.podInformer.AddEventHandlerWithResyncPeriod(
+		cache.ResourceEventHandlerFuncs{
+			// Pod add event will be handled by processPodCNIAddEvent.
+			// We choose to use events from podUpdateSubscriber instead of the informer because
+			// the controller can only update the Pod classifier flow when the Pod container
+			// config is available. Events from the Informer may be received way before the Pod
+			// container config is available, which will cause the work item be continually
+			// re-queued with an exponential increased delay time. When the Pod container
+			// config is ready, the work item could wait for a long time to be processed.
+			UpdateFunc: controller.processPodUpdate,
+			DeleteFunc: controller.processPodDelete,
+		},
+		resyncPeriod,
+	)
+	controller.namespaceInformer.Informer().AddEventHandlerWithResyncPeriod(
+		cache.ResourceEventHandlerFuncs{
+			UpdateFunc: controller.processNamespaceUpdate,
+		},
+		resyncPeriod,
+	)
+	controller.labelIdentityInformer.Informer().AddEventHandlerWithResyncPeriod(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: controller.processLabelIdentityEvent,
+			UpdateFunc: func(old, cur interface{}) {
+				controller.processLabelIdentityEvent(cur)
+			},
+			DeleteFunc: controller.processLabelIdentityEvent,
+		},
+		resyncPeriod,
+	)
+	podUpdateSubscriber.Subscribe(controller.processPodCNIAddEvent)
+
+	controller.labelIdentityInformer.Informer().AddIndexers(cache.Indexers{
+		labelIndex: func(obj interface{}) ([]string, error) {
+			labelID, ok := obj.(*v1alpha1.LabelIdentity)
+			if !ok {
+				return []string{}, nil
+			}
+			return []string{labelID.Spec.Label}, nil
+		}})
+	return controller
+}
+
+func (s *StretchedNetworkPolicyController) Run(stopCh <-chan struct{}) {
+	defer s.queue.ShutDown()
+
+	klog.InfoS("Starting controller", "controller", stretchedNetworkPolicyControllerName)
+	defer klog.InfoS("Shutting down controller", "controller", stretchedNetworkPolicyControllerName)
+	cacheSyncs := []cache.InformerSynced{s.podListerSynced, s.namespaceListerSynced, s.LabelIdentityListerSynced}
+	if !cache.WaitForNamedCacheSync(stretchedNetworkPolicyControllerName, stopCh, cacheSyncs...) {
+		return
+	}
+	s.enqueueAllPods()
+	for i := 0; i < stretchedNetworkPolicyWorker; i++ {
+		go wait.Until(s.worker, time.Second, stopCh)
+	}
+	<-stopCh
+}
+
+func (s *StretchedNetworkPolicyController) enqueueAllPods() {
+	pods, _ := s.podLister.List(labels.Everything())
+	for _, pod := range pods {
+		if pod.Spec.HostNetwork {
+			continue
+		}
+		s.queue.Add(getPodReference(pod))
+	}
+}
+
+// worker is a long-running function that will continually call the processNextWorkItem
+// function in order to read and process a message on the workqueue.
+func (s *StretchedNetworkPolicyController) worker() {
+	for s.processNextWorkItem() {
+	}
+}
+
+func (s *StretchedNetworkPolicyController) processNextWorkItem() bool {
+	obj, quit := s.queue.Get()
+	if quit {
+		return false
+	}
+	defer s.queue.Done(obj)
+
+	if podRef, ok := obj.(types.NamespacedName); !ok {
+		s.queue.Forget(obj)
+		klog.Errorf("Expected type 'NamespacedName' in work queue but got object", "object", obj)
+	} else if err := s.syncPodClassifierFlow(podRef); err == nil {
+		s.queue.Forget(podRef)
+	} else {
+		// Put the item back on the workqueue to handle any transient errors.
+		s.queue.AddRateLimited(podRef)
+		klog.ErrorS(err, "Error syncing Pod classifier flow, requeuing", "name", podRef.Name, "namespace", podRef.Namespace)
+	}
+	return true
+}
+
+// syncPodClassifierFlow gets containerConfigs and labelIdentity according to a
+// Pod reference and updates this Pod's classifierFlow.
+func (s *StretchedNetworkPolicyController) syncPodClassifierFlow(podRef types.NamespacedName) error {
+	pod, err := s.podLister.Pods(podRef.Namespace).Get(podRef.Name)
+	if err != nil || pod.Spec.HostNetwork {
+		return nil
+	}
+	containerConfigs := s.interfaceStore.GetContainerInterfacesByPod(podRef.Name, podRef.Namespace)
+	if len(containerConfigs) == 0 {
+		klog.InfoS("Pod container config not found, will retry after it's ready", "name", podRef.Name, "namespace", podRef.Namespace)
+		return nil
+	}
+	podNS, err := s.namespaceLister.Get(podRef.Namespace)
+	if err != nil {
+		return fmt.Errorf("can't get Namespace %s: %v", podRef.Namespace, err)
+	}
+	normalizedLabel := multicluster.GetNormalizedLabel(podNS.Labels, pod.Labels, podNS.Name)
+	labelID := s.getLabelIdentity(podRef, normalizedLabel)
+	return s.ofClient.InstallPodFlows(
+		containerConfigs[0].InterfaceName,
+		containerConfigs[0].IPs,
+		containerConfigs[0].MAC,
+		uint32(containerConfigs[0].OFPort),
+		containerConfigs[0].VLANID,
+		&labelID,
+	)
+}
+
+// getLabelIdentity updates labelToPods and podToLabel and returns the
+// LabelIdentity based on the normalizedLabel.
+func (s *StretchedNetworkPolicyController) getLabelIdentity(podRef types.NamespacedName, normalizedLabel string) uint32 {
+	s.lock.Lock()
+	oldNormalizedLabel, ok := s.podToLabel[podRef]
+	if ok && oldNormalizedLabel != normalizedLabel {
+		s.deleteLabelToPod(oldNormalizedLabel, podRef)
+	}
+	if !ok || oldNormalizedLabel != normalizedLabel {
+		s.addLabelToPod(normalizedLabel, podRef)
+		s.podToLabel[podRef] = normalizedLabel
+	}
+	s.lock.Unlock()
+
+	labelID := openflow.UnknownLabelIdentity
+	if objs, err := s.labelIdentityInformer.Informer().GetIndexer().ByIndex(labelIndex, normalizedLabel); err == nil && len(objs) == 1 {
+		labelIdentity := objs[0].(*v1alpha1.LabelIdentity)
+		labelID = labelIdentity.Spec.ID
+	}
+	return labelID
+}
+
+func (s *StretchedNetworkPolicyController) processPodCNIAddEvent(e interface{}) {
+	podEvent := e.(antreatypes.PodUpdate)
+	if !podEvent.IsAdd {
+		return
+	}
+	podRef := types.NamespacedName{
+		Namespace: podEvent.PodNamespace,
+		Name:      podEvent.PodName,
+	}
+	s.queue.Add(podRef)
+}
+
+// processPodUpdate handles Pod update events. It only enqueues the Pod if the
+// Labels of this Pod have been updated.
+func (s *StretchedNetworkPolicyController) processPodUpdate(old, cur interface{}) {
+	oldPod, _ := old.(*v1.Pod)
+	curPod, _ := cur.(*v1.Pod)
+	if curPod.Spec.HostNetwork {
+		klog.V(5).InfoS("Skipped processing hostNetwork Pod update event", "name", curPod.Name, "namespace", curPod.Namespace)
+		return
+	}
+	if reflect.DeepEqual(oldPod.Labels, curPod.Labels) {
+		klog.V(5).InfoS("Pod UpdateFunc received a Pod update event, "+
+			"but labels are the same. Skip it", "name", curPod.Name, "namespace", curPod.Namespace)
+		return
+	}
+	s.queue.Add(getPodReference(curPod))
+}
+
+// processPodDelete handles Pod delete events. It deletes the Pod from the
+// labelToPods and podToLabel. After Pod is deleted, its classifier flow will also
+// be deleted by podConfigurator. So no need to enqueue this Pod to update its
+// classifier flow.
+func (s *StretchedNetworkPolicyController) processPodDelete(old interface{}) {
+	oldPod, _ := old.(*v1.Pod)
+	oldPodRef := getPodReference(oldPod)
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	if podLabel, ok := s.podToLabel[oldPodRef]; ok {
+		s.deleteLabelToPod(podLabel, oldPodRef)
+		delete(s.podToLabel, oldPodRef)
+	}
+}
+
+// processNamespaceUpdate handles Namespace update events. It only enqueues all
+// Pods in this Namespace if the Labels of this Namespace have been updated.
+func (s *StretchedNetworkPolicyController) processNamespaceUpdate(old, cur interface{}) {
+	oldNS, _ := old.(*v1.Namespace)
+	curNS, _ := cur.(*v1.Namespace)
+	if reflect.DeepEqual(oldNS.Labels, curNS.Labels) {
+		klog.V(5).InfoS("Namespace UpdateFunc received a Namespace update event, but labels are the same. Skip it", "namespace", curNS.Name)
+		return
+	}
+	allPodsInNS, _ := s.podLister.Pods(curNS.Name).List(labels.Everything())
+	for _, pod := range allPodsInNS {
+		if pod.Spec.HostNetwork {
+			continue
+		}
+		s.queue.Add(getPodReference(pod))
+	}
+}
+
+// processLabelIdentityEvent handles labelIdentity add/update/delete event.
+// It will enqueue all Pods affected by this labelIdentity
+func (s *StretchedNetworkPolicyController) processLabelIdentityEvent(cur interface{}) {
+	labelIdentity, _ := cur.(*v1alpha1.LabelIdentity)
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	if podSet, ok := s.labelToPods[labelIdentity.Spec.Label]; ok {
+		for podRef := range podSet {
+			s.queue.Add(podRef)
+		}
+	}
+}
+
+func (s *StretchedNetworkPolicyController) addLabelToPod(normalizedLabel string, podRef types.NamespacedName) {
+	if _, ok := s.labelToPods[normalizedLabel]; ok {
+		s.labelToPods[normalizedLabel][podRef] = struct{}{}
+	} else {
+		s.labelToPods[normalizedLabel] = podSet{podRef: struct{}{}}
+	}
+}
+
+func (s *StretchedNetworkPolicyController) deleteLabelToPod(normalizedLabel string, podRef types.NamespacedName) {
+	if _, ok := s.labelToPods[normalizedLabel]; ok {
+		delete(s.labelToPods[normalizedLabel], podRef)
+		if len(s.labelToPods[normalizedLabel]) == 0 {
+			delete(s.labelToPods, normalizedLabel)
+		}
+	}
+}
+
+func getPodReference(pod *v1.Pod) types.NamespacedName {
+	return types.NamespacedName{
+		Name:      pod.Name,
+		Namespace: pod.Namespace,
+	}
+}

--- a/pkg/agent/multicluster/stretched_networkpolicy_controller_test.go
+++ b/pkg/agent/multicluster/stretched_networkpolicy_controller_test.go
@@ -1,0 +1,587 @@
+// Copyright 2022 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multicluster
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+
+	"antrea.io/antrea/multicluster/apis/multicluster/v1alpha1"
+	mcfake "antrea.io/antrea/multicluster/pkg/client/clientset/versioned/fake"
+	mcinformers "antrea.io/antrea/multicluster/pkg/client/informers/externalversions"
+	"antrea.io/antrea/pkg/agent/interfacestore"
+	interfacestoretest "antrea.io/antrea/pkg/agent/interfacestore/testing"
+	"antrea.io/antrea/pkg/agent/openflow"
+	oftest "antrea.io/antrea/pkg/agent/openflow/testing"
+	antreatypes "antrea.io/antrea/pkg/agent/types"
+	ovsconfigtest "antrea.io/antrea/pkg/ovs/ovsconfig/testing"
+	"antrea.io/antrea/pkg/util/channel"
+)
+
+const (
+	interval = time.Millisecond
+	timeout  = time.Second
+)
+
+type fakeStretchedNetworkPolicyController struct {
+	*StretchedNetworkPolicyController
+	clientset         *fake.Clientset
+	mcClient          *mcfake.Clientset
+	informerFactory   informers.SharedInformerFactory
+	mcInformerFactory mcinformers.SharedInformerFactory
+	ofClient          *oftest.MockClient
+	ovsClient         *ovsconfigtest.MockOVSBridgeClient
+	interfaceStore    *interfacestoretest.MockInterfaceStore
+	podUpdateChannel  *channel.SubscribableChannel
+}
+
+func newStretchedNetworkPolicyController(t *testing.T, clientset *fake.Clientset, mcClient *mcfake.Clientset) (*fakeStretchedNetworkPolicyController, func()) {
+	informerFactory := informers.NewSharedInformerFactory(clientset, 12*time.Hour)
+	listOptions := func(options *metav1.ListOptions) {
+		options.FieldSelector = fields.OneTermEqualSelector("spec.nodeName", "test-node").String()
+	}
+	podInformer := coreinformers.NewFilteredPodInformer(
+		clientset,
+		metav1.NamespaceAll,
+		0,
+		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, // NamespaceIndex is used in NPLController.
+		listOptions,
+	)
+	nsInformer := informerFactory.Core().V1().Namespaces()
+	mcInformerFactory := mcinformers.NewSharedInformerFactory(mcClient, 60*time.Second)
+	labelIDInformer := mcInformerFactory.Multicluster().V1alpha1().LabelIdentities()
+
+	podUpdateChannel := channel.NewSubscribableChannel("PodUpdate", 100)
+	ctrl := gomock.NewController(t)
+	ofClient := oftest.NewMockClient(ctrl)
+	ovsClient := ovsconfigtest.NewMockOVSBridgeClient(ctrl)
+	interfaceStore := interfacestoretest.NewMockInterfaceStore(ctrl)
+	c := NewMCAgentStretchedNetworkPolicyController(
+		ofClient,
+		interfaceStore,
+		podInformer,
+		nsInformer,
+		labelIDInformer,
+		podUpdateChannel,
+	)
+	return &fakeStretchedNetworkPolicyController{
+		StretchedNetworkPolicyController: c,
+		clientset:                        clientset,
+		mcClient:                         mcClient,
+		informerFactory:                  informerFactory,
+		mcInformerFactory:                mcInformerFactory,
+		ofClient:                         ofClient,
+		ovsClient:                        ovsClient,
+		interfaceStore:                   interfaceStore,
+		podUpdateChannel:                 podUpdateChannel,
+	}, ctrl.Finish
+}
+
+var (
+	interfaceConfig = interfacestore.InterfaceConfig{
+		InterfaceName: "foo",
+		OVSPortConfig: &interfacestore.OVSPortConfig{
+			OFPort: 2,
+		},
+		IPs: []net.IP{[]byte("1.1.1.1")},
+	}
+	unknownLabelIdentity = openflow.UnknownLabelIdentity
+)
+
+func TestEnqueueAllPods(t *testing.T) {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ns",
+			Labels: map[string]string{
+				"env": "test",
+			},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod",
+			Namespace: "ns",
+			Labels: map[string]string{
+				"foo": "bar1",
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "test-node",
+		},
+	}
+	labelIdentity := &v1alpha1.LabelIdentity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "labelIdentity1",
+		},
+		Spec: v1alpha1.LabelIdentitySpec{
+			Label: "ns:env=test,kubernetes.io/metadata.name=ns&pod:foo=bar1",
+			ID:    1,
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(ns, pod)
+	mcClient := mcfake.NewSimpleClientset(labelIdentity)
+	c, closeFn := newStretchedNetworkPolicyController(t, clientset, mcClient)
+	defer closeFn()
+	defer c.queue.ShutDown()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	c.informerFactory.Start(stopCh)
+	c.informerFactory.WaitForCacheSync(stopCh)
+	c.mcInformerFactory.Start(stopCh)
+	c.mcInformerFactory.WaitForCacheSync(stopCh)
+	go c.podInformer.Run(stopCh)
+	if err := waitForPodRealized(c, pod); err != nil {
+		t.Errorf("error when waiting for Pod '%s/%s' to be realized: %v", pod.Namespace, pod.Name, err)
+	}
+	if err := waitForLabelIdentityRealized(c, labelIdentity); err != nil {
+		t.Errorf("error when waiting for LabelIdentity '%s' to be realized: %v", labelIdentity.Name, err)
+	}
+	c.enqueueAllPods()
+
+	finishCh := make(chan struct{})
+	go func() {
+		defer close(finishCh)
+		c.interfaceStore.EXPECT().GetContainerInterfacesByPod(pod.Name, pod.Namespace).Return([]*interfacestore.InterfaceConfig{&interfaceConfig}).Times(1)
+		c.ofClient.EXPECT().InstallPodFlows(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Eq(&labelIdentity.Spec.ID)).Times(1)
+		c.processNextWorkItem()
+		assert.Equal(t, map[types.NamespacedName]string{{Name: pod.Name, Namespace: pod.Namespace}: labelIdentity.Spec.Label}, c.podToLabel)
+		assert.Equal(t, map[string]podSet{labelIdentity.Spec.Label: {types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}: struct{}{}}}, c.labelToPods)
+	}()
+	select {
+	case <-time.After(5 * time.Second):
+		t.Errorf("Test didn't finish in time")
+	case <-finishCh:
+	}
+}
+
+func TestStretchedNetworkPolicyControllerPodEvent(t *testing.T) {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ns",
+			Labels: map[string]string{
+				"env": "test",
+			},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod",
+			Namespace: "ns",
+			Labels: map[string]string{
+				"foo": "bar1",
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "test-node",
+		},
+	}
+	labelIdentity1 := &v1alpha1.LabelIdentity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "labelIdentity1",
+		},
+		Spec: v1alpha1.LabelIdentitySpec{
+			Label: "ns:env=test,kubernetes.io/metadata.name=ns&pod:foo=bar1",
+			ID:    1,
+		},
+	}
+	labelIdentity2 := &v1alpha1.LabelIdentity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "labelIdentity2",
+		},
+		Spec: v1alpha1.LabelIdentitySpec{
+			Label: "ns:env=test,kubernetes.io/metadata.name=ns&pod:foo=bar2",
+			ID:    2,
+		},
+	}
+
+	clientset := fake.NewSimpleClientset()
+	mcClient := mcfake.NewSimpleClientset()
+	c, closeFn := newStretchedNetworkPolicyController(t, clientset, mcClient)
+	defer closeFn()
+	defer c.queue.ShutDown()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	c.informerFactory.Start(stopCh)
+	c.informerFactory.WaitForCacheSync(stopCh)
+	c.mcInformerFactory.Start(stopCh)
+	c.mcInformerFactory.WaitForCacheSync(stopCh)
+	go c.podInformer.Run(stopCh)
+	go c.podUpdateChannel.Run(stopCh)
+
+	finishCh := make(chan struct{})
+	go func() {
+		defer close(finishCh)
+		c.clientset.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
+		if err := waitForNSRealized(c, ns); err != nil {
+			t.Errorf("error when waiting for Namespace '%s' to be realized: %v", ns.Name, err)
+		}
+
+		// Create a Pod whose LabelIdentity doesn't exist.
+		c.clientset.CoreV1().Pods(pod.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+		if err := waitForPodRealized(c, pod); err != nil {
+			t.Errorf("error when waiting for Pod '%s/%s' to be realized: %v", pod.Namespace, pod.Name, err)
+		}
+		c.interfaceStore.EXPECT().GetContainerInterfacesByPod(pod.Name, pod.Namespace).Return([]*interfacestore.InterfaceConfig{&interfaceConfig}).Times(1)
+		c.ofClient.EXPECT().InstallPodFlows(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Eq(&unknownLabelIdentity)).Times(1)
+		c.podUpdateChannel.Notify(toPodAddEvent(pod))
+		c.processNextWorkItem()
+		assert.Equal(t, map[types.NamespacedName]string{{Name: pod.Name, Namespace: pod.Namespace}: labelIdentity1.Spec.Label}, c.podToLabel)
+		assert.Equal(t, map[string]podSet{labelIdentity1.Spec.Label: {types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}: struct{}{}}}, c.labelToPods)
+
+		// Delete a Pod.
+		c.clientset.CoreV1().Pods(pod.Namespace).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
+
+		// Create a Pod whose LabelIdentity already exist.
+		c.mcClient.MulticlusterV1alpha1().LabelIdentities().Create(context.TODO(), labelIdentity1, metav1.CreateOptions{})
+		if err := waitForLabelIdentityRealized(c, labelIdentity1); err != nil {
+			t.Errorf("error when waiting for LabelIdentity '%s' to be realized: %v", labelIdentity1.Name, err)
+		}
+		c.interfaceStore.EXPECT().GetContainerInterfacesByPod(pod.Name, pod.Namespace).Return([]*interfacestore.InterfaceConfig{&interfaceConfig}).Times(1)
+		c.clientset.CoreV1().Pods(pod.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+		if err := waitForPodRealized(c, pod); err != nil {
+			t.Errorf("error when waiting for Pod '%s/%s' to be realized: %v", pod.Namespace, pod.Name, err)
+		}
+		c.ofClient.EXPECT().InstallPodFlows(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Eq(&labelIdentity1.Spec.ID)).Times(1)
+		c.podUpdateChannel.Notify(toPodAddEvent(pod))
+		c.processNextWorkItem()
+		assert.Equal(t, map[types.NamespacedName]string{{Name: pod.Name, Namespace: pod.Namespace}: labelIdentity1.Spec.Label}, c.podToLabel)
+		assert.Equal(t, map[string]podSet{labelIdentity1.Spec.Label: {types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}: struct{}{}}}, c.labelToPods)
+
+		// Update Pod label.
+		c.mcClient.MulticlusterV1alpha1().LabelIdentities().Create(context.TODO(), labelIdentity2, metav1.CreateOptions{})
+		if err := waitForLabelIdentityRealized(c, labelIdentity2); err != nil {
+			t.Errorf("error when waiting for LabelIdentity '%s' to be realized: %v", labelIdentity2.Name, err)
+		}
+		c.interfaceStore.EXPECT().GetContainerInterfacesByPod(pod.Name, pod.Namespace).Return([]*interfacestore.InterfaceConfig{&interfaceConfig}).Times(1)
+		pod.Labels["foo"] = "bar2"
+		c.clientset.CoreV1().Pods(pod.Namespace).Update(context.TODO(), pod, metav1.UpdateOptions{})
+		c.ofClient.EXPECT().InstallPodFlows(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Eq(&labelIdentity2.Spec.ID)).Times(1)
+		c.processNextWorkItem()
+		assert.Equal(t, map[types.NamespacedName]string{{Name: pod.Name, Namespace: pod.Namespace}: labelIdentity2.Spec.Label}, c.podToLabel)
+		assert.Equal(t, map[string]podSet{labelIdentity2.Spec.Label: {types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}: struct{}{}}}, c.labelToPods)
+	}()
+	select {
+	case <-time.After(5 * time.Second):
+		t.Errorf("Test didn't finish in time")
+	case <-finishCh:
+	}
+}
+
+func TestStretchedNetworkPolicyControllerNSEvent(t *testing.T) {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ns",
+			Labels: map[string]string{
+				"env": "test",
+			},
+		},
+	}
+	pod1 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod1",
+			Namespace: "ns",
+			Labels: map[string]string{
+				"foo": "bar1",
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "test-node",
+		},
+	}
+	pod2 := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod2",
+			Namespace: "ns",
+			Labels: map[string]string{
+				"foo": "bar2",
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "test-node",
+		},
+	}
+	labelIdentity1 := &v1alpha1.LabelIdentity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "labelIdentity1",
+		},
+		Spec: v1alpha1.LabelIdentitySpec{
+			Label: "ns:env=test,kubernetes.io/metadata.name=ns&pod:foo=bar1",
+			ID:    1,
+		},
+	}
+	labelIdentity2 := &v1alpha1.LabelIdentity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "labelIdentity2",
+		},
+		Spec: v1alpha1.LabelIdentitySpec{
+			Label: "ns:env=test,kubernetes.io/metadata.name=ns&pod:foo=bar2",
+			ID:    2,
+		},
+	}
+	labelIdentity3 := &v1alpha1.LabelIdentity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "labelIdentity3",
+		},
+		Spec: v1alpha1.LabelIdentitySpec{
+			Label: "ns:env=prod,kubernetes.io/metadata.name=ns&pod:foo=bar1",
+			ID:    3,
+		},
+	}
+	labelIdentity4 := &v1alpha1.LabelIdentity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "labelIdentity4",
+		},
+		Spec: v1alpha1.LabelIdentitySpec{
+			Label: "ns:env=prod,kubernetes.io/metadata.name=ns&pod:foo=bar2",
+			ID:    4,
+		},
+	}
+
+	clientset := fake.NewSimpleClientset()
+	mcClient := mcfake.NewSimpleClientset()
+	c, closeFn := newStretchedNetworkPolicyController(t, clientset, mcClient)
+	defer closeFn()
+	defer c.queue.ShutDown()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	c.informerFactory.Start(stopCh)
+	c.informerFactory.WaitForCacheSync(stopCh)
+	c.mcInformerFactory.Start(stopCh)
+	c.mcInformerFactory.WaitForCacheSync(stopCh)
+	go c.podInformer.Run(stopCh)
+	go c.podUpdateChannel.Run(stopCh)
+
+	finishCh := make(chan struct{})
+	go func() {
+		defer close(finishCh)
+
+		c.mcClient.MulticlusterV1alpha1().LabelIdentities().Create(context.TODO(), labelIdentity1, metav1.CreateOptions{})
+		if err := waitForLabelIdentityRealized(c, labelIdentity1); err != nil {
+			t.Errorf("error when waiting for LabelIdentity '%s' to be realized: %v", labelIdentity1.Name, err)
+		}
+		c.mcClient.MulticlusterV1alpha1().LabelIdentities().Create(context.TODO(), labelIdentity2, metav1.CreateOptions{})
+		if err := waitForLabelIdentityRealized(c, labelIdentity2); err != nil {
+			t.Errorf("error when waiting for LabelIdentity '%s' to be realized: %v", labelIdentity2.Name, err)
+		}
+		c.mcClient.MulticlusterV1alpha1().LabelIdentities().Create(context.TODO(), labelIdentity3, metav1.CreateOptions{})
+		if err := waitForLabelIdentityRealized(c, labelIdentity3); err != nil {
+			t.Errorf("error when waiting for LabelIdentity '%s' to be realized: %v", labelIdentity3.Name, err)
+		}
+		c.mcClient.MulticlusterV1alpha1().LabelIdentities().Create(context.TODO(), labelIdentity4, metav1.CreateOptions{})
+		if err := waitForLabelIdentityRealized(c, labelIdentity4); err != nil {
+			t.Errorf("error when waiting for LabelIdentity '%s' to be realized: %v", labelIdentity4.Name, err)
+		}
+
+		c.clientset.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
+		if err := waitForNSRealized(c, ns); err != nil {
+			t.Errorf("error when waiting for Namespace '%s' to be realized: %v", ns.Name, err)
+		}
+
+		c.clientset.CoreV1().Pods(pod1.Namespace).Create(context.TODO(), pod1, metav1.CreateOptions{})
+		if err := waitForPodRealized(c, pod1); err != nil {
+			t.Errorf("error when waiting for Pod '%s/%s' to be realized: %v", pod1.Namespace, pod1.Name, err)
+		}
+		c.clientset.CoreV1().Pods(pod2.Namespace).Create(context.TODO(), pod2, metav1.CreateOptions{})
+		if err := waitForPodRealized(c, pod2); err != nil {
+			t.Errorf("error when waiting for Pod '%s/%s' to be realized: %v", pod2.Namespace, pod2.Name, err)
+		}
+		c.interfaceStore.EXPECT().GetContainerInterfacesByPod(pod1.Name, pod1.Namespace).Return([]*interfacestore.InterfaceConfig{&interfaceConfig}).Times(1)
+		c.interfaceStore.EXPECT().GetContainerInterfacesByPod(pod2.Name, pod2.Namespace).Return([]*interfacestore.InterfaceConfig{&interfaceConfig}).Times(1)
+		c.ofClient.EXPECT().InstallPodFlows(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Eq(&labelIdentity1.Spec.ID)).Times(1)
+		c.ofClient.EXPECT().InstallPodFlows(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Eq(&labelIdentity2.Spec.ID)).Times(1)
+		c.podUpdateChannel.Notify(toPodAddEvent(pod1))
+		c.processNextWorkItem()
+		c.podUpdateChannel.Notify(toPodAddEvent(pod2))
+		c.processNextWorkItem()
+
+		// Update Namespace label.
+		ns.Labels["env"] = "prod"
+		c.clientset.CoreV1().Namespaces().Update(context.TODO(), ns, metav1.UpdateOptions{})
+		c.interfaceStore.EXPECT().GetContainerInterfacesByPod(pod1.Name, pod1.Namespace).Return([]*interfacestore.InterfaceConfig{&interfaceConfig}).Times(1)
+		c.interfaceStore.EXPECT().GetContainerInterfacesByPod(pod2.Name, pod2.Namespace).Return([]*interfacestore.InterfaceConfig{&interfaceConfig}).Times(1)
+		c.ofClient.EXPECT().InstallPodFlows(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Eq(&labelIdentity3.Spec.ID)).Times(1)
+		c.ofClient.EXPECT().InstallPodFlows(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Eq(&labelIdentity4.Spec.ID)).Times(1)
+		c.processNextWorkItem()
+		c.processNextWorkItem()
+		assert.Equal(t, map[types.NamespacedName]string{
+			{Name: pod1.Name, Namespace: pod1.Namespace}: labelIdentity3.Spec.Label,
+			{Name: pod2.Name, Namespace: pod2.Namespace}: labelIdentity4.Spec.Label,
+		}, c.podToLabel)
+		assert.Equal(t, map[string]podSet{
+			labelIdentity3.Spec.Label: {types.NamespacedName{Name: pod1.Name, Namespace: pod1.Namespace}: struct{}{}},
+			labelIdentity4.Spec.Label: {types.NamespacedName{Name: pod2.Name, Namespace: pod2.Namespace}: struct{}{}},
+		}, c.labelToPods)
+	}()
+	select {
+	case <-time.After(5 * time.Second):
+		t.Errorf("Test didn't finish in time")
+	case <-finishCh:
+	}
+}
+
+func TestStretchedNetworkPolicyControllerLabelIdentityEvent(t *testing.T) {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ns",
+			Labels: map[string]string{
+				"env": "test",
+			},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod",
+			Namespace: "ns",
+			Labels: map[string]string{
+				"foo": "bar1",
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "test-node",
+		},
+	}
+	labelIdentity := &v1alpha1.LabelIdentity{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "labelIdentity",
+		},
+		Spec: v1alpha1.LabelIdentitySpec{
+			Label: "ns:env=test,kubernetes.io/metadata.name=ns&pod:foo=bar1",
+			ID:    1,
+		},
+	}
+	clientset := fake.NewSimpleClientset()
+	mcClient := mcfake.NewSimpleClientset()
+	c, closeFn := newStretchedNetworkPolicyController(t, clientset, mcClient)
+	defer closeFn()
+	defer c.queue.ShutDown()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	c.informerFactory.Start(stopCh)
+	c.informerFactory.WaitForCacheSync(stopCh)
+	c.mcInformerFactory.Start(stopCh)
+	c.mcInformerFactory.WaitForCacheSync(stopCh)
+	go c.podInformer.Run(stopCh)
+	go c.podUpdateChannel.Run(stopCh)
+
+	finishCh := make(chan struct{})
+	go func() {
+		defer close(finishCh)
+		c.clientset.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
+		if err := waitForNSRealized(c, ns); err != nil {
+			t.Errorf("error when waiting for Namespace '%s' to be realized: %v", ns.Name, err)
+		}
+
+		c.clientset.CoreV1().Pods(pod.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+		if err := waitForPodRealized(c, pod); err != nil {
+			t.Errorf("error when waiting for Pod '%s/%s' to be realized: %v", pod.Namespace, pod.Name, err)
+		}
+		c.interfaceStore.EXPECT().GetContainerInterfacesByPod(pod.Name, pod.Namespace).Return([]*interfacestore.InterfaceConfig{&interfaceConfig}).Times(1)
+		c.ofClient.EXPECT().InstallPodFlows(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Eq(&unknownLabelIdentity)).Times(1)
+		c.podUpdateChannel.Notify(toPodAddEvent(pod))
+		c.processNextWorkItem()
+		assert.Equal(t, map[types.NamespacedName]string{{Name: pod.Name, Namespace: pod.Namespace}: labelIdentity.Spec.Label}, c.podToLabel)
+		assert.Equal(t, map[string]podSet{labelIdentity.Spec.Label: {types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}: struct{}{}}}, c.labelToPods)
+
+		// Create LabelIdentity
+		c.mcClient.MulticlusterV1alpha1().LabelIdentities().Create(context.TODO(), labelIdentity, metav1.CreateOptions{})
+		if err := waitForLabelIdentityRealized(c, labelIdentity); err != nil {
+			t.Errorf("error when waiting for LabelIdentity '%s' to be realized: %v", labelIdentity.Name, err)
+		}
+		c.interfaceStore.EXPECT().GetContainerInterfacesByPod(pod.Name, pod.Namespace).Return([]*interfacestore.InterfaceConfig{&interfaceConfig}).Times(1)
+		c.ofClient.EXPECT().InstallPodFlows(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Eq(&labelIdentity.Spec.ID)).Times(1)
+		c.processNextWorkItem()
+		assert.Equal(t, map[types.NamespacedName]string{{Name: pod.Name, Namespace: pod.Namespace}: labelIdentity.Spec.Label}, c.podToLabel)
+		assert.Equal(t, map[string]podSet{labelIdentity.Spec.Label: {types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}: struct{}{}}}, c.labelToPods)
+
+		// Update LabelIdentity
+		labelIdentity.Spec.ID = 2
+		c.mcClient.MulticlusterV1alpha1().LabelIdentities().Update(context.TODO(), labelIdentity, metav1.UpdateOptions{})
+		c.interfaceStore.EXPECT().GetContainerInterfacesByPod(pod.Name, pod.Namespace).Return([]*interfacestore.InterfaceConfig{&interfaceConfig}).Times(1)
+		c.ofClient.EXPECT().InstallPodFlows(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Eq(&labelIdentity.Spec.ID)).Times(1)
+		c.processNextWorkItem()
+		assert.Equal(t, map[types.NamespacedName]string{{Name: pod.Name, Namespace: pod.Namespace}: labelIdentity.Spec.Label}, c.podToLabel)
+		assert.Equal(t, map[string]podSet{labelIdentity.Spec.Label: {types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}: struct{}{}}}, c.labelToPods)
+
+		// Delete LabelIdentity
+		c.mcClient.MulticlusterV1alpha1().LabelIdentities().Delete(context.TODO(), labelIdentity.Name, metav1.DeleteOptions{})
+		c.interfaceStore.EXPECT().GetContainerInterfacesByPod(pod.Name, pod.Namespace).Return([]*interfacestore.InterfaceConfig{&interfaceConfig}).Times(1)
+		c.ofClient.EXPECT().InstallPodFlows(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Eq(&unknownLabelIdentity)).Times(1)
+		c.processNextWorkItem()
+		assert.Equal(t, map[types.NamespacedName]string{{Name: pod.Name, Namespace: pod.Namespace}: labelIdentity.Spec.Label}, c.podToLabel)
+		assert.Equal(t, map[string]podSet{labelIdentity.Spec.Label: {types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}: struct{}{}}}, c.labelToPods)
+	}()
+	select {
+	case <-time.After(5 * time.Second):
+		t.Errorf("Test didn't finish in time")
+	case <-finishCh:
+	}
+}
+
+func toPodAddEvent(pod *corev1.Pod) antreatypes.PodUpdate {
+	return antreatypes.PodUpdate{
+		PodNamespace: pod.Namespace,
+		PodName:      pod.Name,
+		IsAdd:        true,
+	}
+}
+
+func waitForPodRealized(c *fakeStretchedNetworkPolicyController, pod *corev1.Pod) error {
+	return wait.Poll(interval, timeout, func() (bool, error) {
+		_, err := c.podLister.Pods(pod.Namespace).Get(pod.Name)
+		if err != nil {
+			return false, nil
+		}
+		return true, err
+	})
+}
+
+func waitForNSRealized(c *fakeStretchedNetworkPolicyController, ns *corev1.Namespace) error {
+	return wait.Poll(interval, timeout, func() (bool, error) {
+		_, err := c.namespaceLister.Get(ns.Name)
+		if err != nil {
+			return false, nil
+		}
+		return true, err
+	})
+}
+
+func waitForLabelIdentityRealized(c *fakeStretchedNetworkPolicyController, labelIdentity *v1alpha1.LabelIdentity) error {
+	return wait.Poll(interval, timeout, func() (bool, error) {
+		_, err := c.labelIdentityLister.Get(labelIdentity.Name)
+		if err != nil {
+			return false, nil
+		}
+		return true, err
+	})
+}

--- a/pkg/agent/openflow/fields.go
+++ b/pkg/agent/openflow/fields.go
@@ -165,7 +165,7 @@ var (
 
 // Marks using CT.
 var (
-	//TODO: There is a bug in libOpenflow when CT_MARK range is from 0 to 0, and a wrong mask will be got. As a result,
+	// TODO: There is a bug in libOpenflow when CT_MARK range is from 0 to 0, and a wrong mask will be got. As a result,
 	// don't just use bit 0 of CT_MARK.
 
 	// CTMark (NXM_NX_CT_MARK)

--- a/pkg/agent/openflow/network_policy.go
+++ b/pkg/agent/openflow/network_policy.go
@@ -69,6 +69,7 @@ var (
 	MatchICMPv6Code     = types.NewMatchKey(binding.ProtocolICMPv6, types.ICMPAddr, "icmpv6_code")
 	MatchServiceGroupID = types.NewMatchKey(binding.ProtocolIP, types.ServiceGroupIDAddr, "reg7[0..31]")
 	MatchIGMPProtocol   = types.NewMatchKey(binding.ProtocolIGMP, types.IGMPAddr, "igmp")
+	MatchLabelID        = types.NewMatchKey(binding.ProtocolIP, types.LabelIDAddr, "tun_id")
 	Unsupported         = types.NewMatchKey(binding.ProtocolIP, types.UnSupported, "unknown")
 
 	// metricFlowIdentifier is used to identify metric flows in metric table.
@@ -271,6 +272,25 @@ func (a *CTIPNetAddress) GetValue() interface{} {
 func NewCTIPNetAddress(addr net.IPNet) *CTIPNetAddress {
 	ia := CTIPNetAddress(addr)
 	return &ia
+}
+
+type LabelIDAddress uint32
+
+func (a *LabelIDAddress) GetMatchKey(addrType types.AddressType) *types.MatchKey {
+	return MatchLabelID
+}
+
+func (a *LabelIDAddress) GetMatchValue() string {
+	return fmt.Sprintf("%d", uint32(*a))
+}
+
+func (a *LabelIDAddress) GetValue() interface{} {
+	return uint32(*a)
+}
+
+func NewLabelIDAddress(labelID uint32) *LabelIDAddress {
+	a := LabelIDAddress(labelID)
+	return &a
 }
 
 // ConjunctionNotFound is an error response when the specified policyRuleConjunction is not found from the local cache.

--- a/pkg/agent/openflow/network_policy_test.go
+++ b/pkg/agent/openflow/network_policy_test.go
@@ -69,6 +69,7 @@ var (
 	protocolICMP = v1beta2.ProtocolICMP
 	priority100  = uint16(100)
 	priority200  = uint16(200)
+	priority201  = uint16(201)
 	icmpType8    = int32(8)
 	icmpCode0    = int32(0)
 
@@ -453,6 +454,22 @@ func TestBatchInstallPolicyRuleFlows(t *testing.T) {
 						UID:       "id3",
 					},
 				},
+				{
+					Direction: v1beta2.DirectionIn,
+					From:      parseLabelIdentityAddresses([]uint32{1, 2}),
+					Action:    &actionDrop,
+					Priority:  &priority201,
+					To:        []types.Address{NewOFPortAddress(1)},
+					Service:   []v1beta2.Service{},
+					FlowID:    uint32(13),
+					TableID:   AntreaPolicyIngressRuleTable.GetID(),
+					PolicyRef: &v1beta2.NetworkPolicyReference{
+						Type:      v1beta2.AntreaNetworkPolicy,
+						Namespace: "ns1",
+						Name:      "np4",
+						UID:       "id4",
+					},
+				},
 			},
 			expectedFlowsFn: func(c *client) []binding.Flow {
 				cookiePolicy := c.cookieAllocator.Request(cookie.NetworkPolicy).Raw()
@@ -471,6 +488,11 @@ func TestBatchInstallPolicyRuleFlows(t *testing.T) {
 						Action().LoadToRegField(CNPConjIDField, 12).
 						Action().LoadRegMark(CnpDenyRegMark).
 						Action().GotoTable(IngressMetricTable.GetID()).Done(),
+					AntreaPolicyIngressRuleTable.ofTable.BuildFlow(priority201).Cookie(cookiePolicy).
+						MatchConjID(13).
+						Action().LoadToRegField(CNPConjIDField, 13).
+						Action().LoadRegMark(CnpDenyRegMark).
+						Action().GotoTable(IngressMetricTable.GetID()).Done(),
 					AntreaPolicyIngressRuleTable.ofTable.BuildFlow(priority100).Cookie(cookiePolicy).
 						MatchProtocol(binding.ProtocolIP).MatchSrcIP(net.ParseIP("192.168.1.40")).
 						Action().Conjunction(10, 1, 2).
@@ -484,6 +506,12 @@ func TestBatchInstallPolicyRuleFlows(t *testing.T) {
 					AntreaPolicyIngressRuleTable.ofTable.BuildFlow(priority100).Cookie(cookiePolicy).
 						MatchProtocol(binding.ProtocolIP).MatchSrcIP(net.ParseIP("192.168.1.51")).
 						Action().Conjunction(11, 1, 3).Done(),
+					AntreaPolicyIngressRuleTable.ofTable.BuildFlow(priority201).Cookie(cookiePolicy).
+						MatchTunnelID(1).
+						Action().Conjunction(13, 1, 3).Done(),
+					AntreaPolicyIngressRuleTable.ofTable.BuildFlow(priority201).Cookie(cookiePolicy).
+						MatchTunnelID(2).
+						Action().Conjunction(13, 1, 3).Done(),
 					AntreaPolicyIngressRuleTable.ofTable.BuildFlow(priority100).Cookie(cookiePolicy).
 						MatchRegFieldWithValue(TargetOFPortField, uint32(1)).
 						Action().Conjunction(10, 2, 2).
@@ -497,6 +525,9 @@ func TestBatchInstallPolicyRuleFlows(t *testing.T) {
 					AntreaPolicyIngressRuleTable.ofTable.BuildFlow(priority100).Cookie(cookiePolicy).
 						MatchRegFieldWithValue(TargetOFPortField, uint32(3)).
 						Action().Conjunction(11, 2, 3).Done(),
+					AntreaPolicyIngressRuleTable.ofTable.BuildFlow(priority201).Cookie(cookiePolicy).
+						MatchRegFieldWithValue(TargetOFPortField, uint32(1)).
+						Action().Conjunction(13, 2, 3).Done(),
 					AntreaPolicyIngressRuleTable.ofTable.BuildFlow(priority100).Cookie(cookiePolicy).
 						MatchProtocol(binding.ProtocolTCP).MatchDstPort(8080, nil).
 						Action().Conjunction(11, 3, 3).Done(),
@@ -517,6 +548,9 @@ func TestBatchInstallPolicyRuleFlows(t *testing.T) {
 						Action().Drop().Done(),
 					IngressMetricTable.ofTable.BuildFlow(priorityNormal).Cookie(cookiePolicy).
 						MatchRegMark(CnpDenyRegMark).MatchRegFieldWithValue(CNPConjIDField, 12).
+						Action().Drop().Done(),
+					IngressMetricTable.ofTable.BuildFlow(priorityNormal).Cookie(cookiePolicy).
+						MatchRegMark(CnpDenyRegMark).MatchRegFieldWithValue(CNPConjIDField, 13).
 						Action().Drop().Done(),
 				}
 			},
@@ -973,6 +1007,14 @@ func parseAddresses(addrs []string) []types.Address {
 			ip := net.ParseIP(addr)
 			addresses = append(addresses, NewIPAddress(ip))
 		}
+	}
+	return addresses
+}
+
+func parseLabelIdentityAddresses(labelIdentities []uint32) []types.Address {
+	var addresses = make([]types.Address, 0)
+	for _, labelIdentity := range labelIdentities {
+		addresses = append(addresses, NewLabelIDAddress(labelIdentity))
 	}
 	return addresses
 }

--- a/pkg/agent/openflow/testing/mock_openflow.go
+++ b/pkg/agent/openflow/testing/mock_openflow.go
@@ -340,31 +340,31 @@ func (mr *MockClientMockRecorder) InstallMulticlusterClassifierFlows(arg0, arg1 
 }
 
 // InstallMulticlusterGatewayFlows mocks base method
-func (m *MockClient) InstallMulticlusterGatewayFlows(arg0 string, arg1 map[*net.IPNet]net.IP, arg2, arg3 net.IP) error {
+func (m *MockClient) InstallMulticlusterGatewayFlows(arg0 string, arg1 map[*net.IPNet]net.IP, arg2, arg3 net.IP, arg4 bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstallMulticlusterGatewayFlows", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "InstallMulticlusterGatewayFlows", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InstallMulticlusterGatewayFlows indicates an expected call of InstallMulticlusterGatewayFlows
-func (mr *MockClientMockRecorder) InstallMulticlusterGatewayFlows(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) InstallMulticlusterGatewayFlows(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallMulticlusterGatewayFlows", reflect.TypeOf((*MockClient)(nil).InstallMulticlusterGatewayFlows), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallMulticlusterGatewayFlows", reflect.TypeOf((*MockClient)(nil).InstallMulticlusterGatewayFlows), arg0, arg1, arg2, arg3, arg4)
 }
 
 // InstallMulticlusterNodeFlows mocks base method
-func (m *MockClient) InstallMulticlusterNodeFlows(arg0 string, arg1 map[*net.IPNet]net.IP, arg2 net.IP) error {
+func (m *MockClient) InstallMulticlusterNodeFlows(arg0 string, arg1 map[*net.IPNet]net.IP, arg2 net.IP, arg3 bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstallMulticlusterNodeFlows", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "InstallMulticlusterNodeFlows", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InstallMulticlusterNodeFlows indicates an expected call of InstallMulticlusterNodeFlows
-func (mr *MockClientMockRecorder) InstallMulticlusterNodeFlows(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) InstallMulticlusterNodeFlows(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallMulticlusterNodeFlows", reflect.TypeOf((*MockClient)(nil).InstallMulticlusterNodeFlows), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallMulticlusterNodeFlows", reflect.TypeOf((*MockClient)(nil).InstallMulticlusterNodeFlows), arg0, arg1, arg2, arg3)
 }
 
 // InstallNodeFlows mocks base method
@@ -382,17 +382,17 @@ func (mr *MockClientMockRecorder) InstallNodeFlows(arg0, arg1, arg2, arg3, arg4 
 }
 
 // InstallPodFlows mocks base method
-func (m *MockClient) InstallPodFlows(arg0 string, arg1 []net.IP, arg2 net.HardwareAddr, arg3 uint32, arg4 uint16) error {
+func (m *MockClient) InstallPodFlows(arg0 string, arg1 []net.IP, arg2 net.HardwareAddr, arg3 uint32, arg4 uint16, arg5 *uint32) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstallPodFlows", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "InstallPodFlows", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InstallPodFlows indicates an expected call of InstallPodFlows
-func (mr *MockClientMockRecorder) InstallPodFlows(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) InstallPodFlows(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallPodFlows", reflect.TypeOf((*MockClient)(nil).InstallPodFlows), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallPodFlows", reflect.TypeOf((*MockClient)(nil).InstallPodFlows), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // InstallPodSNATFlows mocks base method

--- a/pkg/agent/types/networkpolicy.go
+++ b/pkg/agent/types/networkpolicy.go
@@ -56,6 +56,7 @@ const (
 	ICMPAddr
 	ServiceGroupIDAddr
 	IGMPAddr
+	LabelIDAddr
 	UnSupported
 )
 

--- a/pkg/config/agent/config.go
+++ b/pkg/config/agent/config.go
@@ -283,6 +283,8 @@ type MulticlusterConfig struct {
 	// The Namespace where the Antrea Multi-cluster controller is running.
 	// The default is antrea-agent's Namespace.
 	Namespace string `yaml:"namespace,omitempty"`
+	// Enable StretchedNetworkPolicy which could be enforced on cross-cluster traffic.
+	EnableStretchedNetworkPolicy bool `yaml:"enableStretchedNetworkPolicy,omitempty"`
 }
 
 type ExternalNodeConfig struct {

--- a/pkg/ovs/openflow/interfaces.go
+++ b/pkg/ovs/openflow/interfaces.go
@@ -226,6 +226,7 @@ type Action interface {
 	SetSrcIP(addr net.IP) FlowBuilder
 	SetDstIP(addr net.IP) FlowBuilder
 	SetTunnelDst(addr net.IP) FlowBuilder
+	SetTunnelID(tunnelID uint64) FlowBuilder
 	PopVLAN() FlowBuilder
 	PushVLAN(etherType uint16) FlowBuilder
 	SetVLAN(vlanID uint16) FlowBuilder
@@ -281,6 +282,7 @@ type FlowBuilder interface {
 	MatchICMPv6Type(icmp6Type byte) FlowBuilder
 	MatchICMPv6Code(icmp6Code byte) FlowBuilder
 	MatchTunnelDst(dstIP net.IP) FlowBuilder
+	MatchTunnelID(tunnelID uint64) FlowBuilder
 	MatchTunMetadata(index int, data uint32) FlowBuilder
 	MatchVLAN(nonVLAN bool, vlanId uint16, vlanMask *uint16) FlowBuilder
 	// MatchCTSrcIP matches the source IPv4 address of the connection tracker original direction tuple.

--- a/pkg/ovs/openflow/ofctrl_action.go
+++ b/pkg/ovs/openflow/ofctrl_action.go
@@ -252,6 +252,13 @@ func (a *ofFlowAction) SetTunnelDst(addr net.IP) FlowBuilder {
 	return a.builder
 }
 
+// SetTunnelID is an action to modify packet tunnel ID to the specified ID.
+func (a *ofFlowAction) SetTunnelID(tunnelID uint64) FlowBuilder {
+	setTunIDAct := &ofctrl.SetTunnelIDAction{TunnelID: tunnelID}
+	a.builder.ApplyAction(setTunIDAct)
+	return a.builder
+}
+
 // PopVLAN is an action to pop VLAN ID.
 func (a *ofFlowAction) PopVLAN() FlowBuilder {
 	popVLANAct := &ofctrl.PopVLANAction{}

--- a/pkg/ovs/openflow/ofctrl_builder.go
+++ b/pkg/ovs/openflow/ofctrl_builder.go
@@ -296,6 +296,13 @@ func (b *ofFlowBuilder) MatchTunnelDst(dstIP net.IP) FlowBuilder {
 	return b
 }
 
+// MatchTunnelID adds match condition for matching tun_id.
+func (b *ofFlowBuilder) MatchTunnelID(tunnelID uint64) FlowBuilder {
+	b.matchers = append(b.matchers, fmt.Sprintf("tun_id=%d", tunnelID))
+	b.ofFlow.Match.TunnelId = tunnelID
+	return b
+}
+
 func ctLabelRange(high, low uint64, rng *Range, match *ofctrl.FlowMatch) {
 	// [127..64] [63..0]
 	//   high     low

--- a/pkg/ovs/openflow/testing/mock_openflow.go
+++ b/pkg/ovs/openflow/testing/mock_openflow.go
@@ -1216,6 +1216,20 @@ func (mr *MockActionMockRecorder) SetTunnelDst(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTunnelDst", reflect.TypeOf((*MockAction)(nil).SetTunnelDst), arg0)
 }
 
+// SetTunnelID mocks base method
+func (m *MockAction) SetTunnelID(arg0 uint64) openflow.FlowBuilder {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetTunnelID", arg0)
+	ret0, _ := ret[0].(openflow.FlowBuilder)
+	return ret0
+}
+
+// SetTunnelID indicates an expected call of SetTunnelID
+func (mr *MockActionMockRecorder) SetTunnelID(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTunnelID", reflect.TypeOf((*MockAction)(nil).SetTunnelID), arg0)
+}
+
 // SetVLAN mocks base method
 func (m *MockAction) SetVLAN(arg0 uint16) openflow.FlowBuilder {
 	m.ctrl.T.Helper()
@@ -2070,6 +2084,20 @@ func (m *MockFlowBuilder) MatchTunnelDst(arg0 net.IP) openflow.FlowBuilder {
 func (mr *MockFlowBuilderMockRecorder) MatchTunnelDst(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MatchTunnelDst", reflect.TypeOf((*MockFlowBuilder)(nil).MatchTunnelDst), arg0)
+}
+
+// MatchTunnelID mocks base method
+func (m *MockFlowBuilder) MatchTunnelID(arg0 uint64) openflow.FlowBuilder {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MatchTunnelID", arg0)
+	ret0, _ := ret[0].(openflow.FlowBuilder)
+	return ret0
+}
+
+// MatchTunnelID indicates an expected call of MatchTunnelID
+func (mr *MockFlowBuilderMockRecorder) MatchTunnelID(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MatchTunnelID", reflect.TypeOf((*MockFlowBuilder)(nil).MatchTunnelID), arg0)
 }
 
 // MatchVLAN mocks base method

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -1275,6 +1275,20 @@ func (b *PodBuilder) Create(data *TestData) error {
 	return nil
 }
 
+func (data *TestData) UpdatePod(namespace, name string, mutateFunc func(*corev1.Pod)) error {
+	pod, err := data.clientset.CoreV1().Pods(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("error when getting '%s/%s' Pod: %v", namespace, name, err)
+	}
+	if mutateFunc != nil {
+		mutateFunc(pod)
+	}
+	if _, err := data.clientset.CoreV1().Pods(namespace).Update(context.TODO(), pod, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("error when updating '%s/%s' Pod: %v", namespace, name, err)
+	}
+	return nil
+}
+
 // createBusyboxPodOnNode creates a Pod in the test namespace with a single busybox container. The
 // Pod will be scheduled on the specified Node (if nodeName is not empty).
 func (data *TestData) createBusyboxPodOnNode(name string, ns string, nodeName string, hostNetwork bool) error {

--- a/test/integration/agent/cniserver_test.go
+++ b/test/integration/agent/cniserver_test.go
@@ -608,7 +608,7 @@ func cmdAddDelCheckTest(testNS ns.NetNS, tc testCase, dataDir string) {
 	ovsPortUUID := uuid.New().String()
 	ovsServiceMock.EXPECT().CreatePort(ovsPortname, ovsPortname, mock.Any()).Return(ovsPortUUID, nil).AnyTimes()
 	ovsServiceMock.EXPECT().GetOFPort(ovsPortname, false).Return(int32(10), nil).AnyTimes()
-	ofServiceMock.EXPECT().InstallPodFlows(ovsPortname, mock.Any(), mock.Any(), mock.Any(), uint16(0)).Return(nil)
+	ofServiceMock.EXPECT().InstallPodFlows(ovsPortname, mock.Any(), mock.Any(), mock.Any(), uint16(0), nil).Return(nil)
 
 	close(tester.networkReadyCh)
 	// Test ips allocation
@@ -827,7 +827,7 @@ func TestCNIServerChaining(t *testing.T) {
 			routeMock.EXPECT().MigrateRoutesToGw(hostVeth.Name),
 			ovsServiceMock.EXPECT().CreatePort(ovsPortname, ovsPortname, mock.Any()).Return(ovsPortUUID, nil),
 			ovsServiceMock.EXPECT().GetOFPort(ovsPortname, false).Return(testContainerOFPort, nil),
-			ofServiceMock.EXPECT().InstallPodFlows(ovsPortname, []net.IP{podIP}, containerIntf.HardwareAddr, mock.Any(), uint16(0)),
+			ofServiceMock.EXPECT().InstallPodFlows(ovsPortname, []net.IP{podIP}, containerIntf.HardwareAddr, mock.Any(), uint16(0), nil),
 		)
 		mock.InOrder(orderedCalls...)
 		cniResp, err := server.CmdAdd(ctx, cniReq)


### PR DESCRIPTION
This PR is based on https://github.com/antrea-io/antrea/pull/3913. 

1. Add implementation of Stretched NetworkPolicy in Antrea agent.
1.1 Add OVS flows with tun_id matching.
1.2 Agent also realizes a security rule using unknown LabelIdentity for each Stretched NetworkPolicy rule.
2. Add implementation of LabelIdentity on datapath
2.1 Pod will load its LabelIdentity in tun_id in ClassifierFlow.
2.2 Pod Classifier flow will have a different cacheKey for easy updates.
2.3 StretchedNetworkPolicy will sync Pod ClassifierFlow according to Pod/NS/LabelID events.
3. Add UT and E2E tests.
