### PR TITLE
Fix nil pointer issue when clusterset is deleted in leader

### DIFF
--- a/multicluster/controllers/multicluster/leader_clusterset_controller.go
+++ b/multicluster/controllers/multicluster/leader_clusterset_controller.go
@@ -69,7 +69,7 @@ func (r *LeaderClusterSetReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		if !errors.IsNotFound(err) {
 			return ctrl.Result{}, err
 		}
-		klog.InfoS("Received ClusterSet delete", "config", klog.KObj(clusterSet))
+		klog.InfoS("Received ClusterSet delete", "clusterset", klog.KObj(clusterSet))
 		for _, removedMember := range r.clusterSetConfig.Spec.Members {
 			r.StatusManager.RemoveMember(common.ClusterID(removedMember.ClusterID))
 		}
@@ -80,7 +80,7 @@ func (r *LeaderClusterSetReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, nil
 	}
 
-	klog.InfoS("Received ClusterSet add/update", "config", klog.KObj(clusterSet))
+	klog.InfoS("Received ClusterSet add/update", "clusterset", klog.KObj(clusterSet))
 
 	// Handle create or update
 	// If create, make sure the local ClusterClaim is part of the leader config
@@ -175,8 +175,8 @@ func (r *LeaderClusterSetReconciler) runBackgroundTasks() {
 //       statues across all clusters. Message will be empty and Reason
 //       will be "NoReadyCluster"
 func (r *LeaderClusterSetReconciler) updateStatus() {
-	defer r.mutex.Unlock()
 	r.mutex.Lock()
+	defer r.mutex.Unlock()
 
 	if r.clusterSetConfig == nil {
 		// Nothing to do.

--- a/multicluster/controllers/multicluster/member_clusterset_controller.go
+++ b/multicluster/controllers/multicluster/member_clusterset_controller.go
@@ -86,7 +86,7 @@ func (r *MemberClusterSetReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		if !apierrors.IsNotFound(err) {
 			return ctrl.Result{}, err
 		}
-		klog.InfoS("Received ClusterSet delete", "config", klog.KObj(clusterSet))
+		klog.InfoS("Received ClusterSet delete", "clusterset", klog.KObj(clusterSet))
 		stopErr := r.remoteCommonAreaManager.Stop()
 		r.remoteCommonAreaManager = nil
 		r.clusterSetConfig = nil
@@ -96,7 +96,7 @@ func (r *MemberClusterSetReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, stopErr
 	}
 
-	klog.InfoS("Received ClusterSet add/update", "config", klog.KObj(clusterSet))
+	klog.InfoS("Received ClusterSet add/update", "clusterset", klog.KObj(clusterSet))
 
 	// Handle create or update
 	if r.clusterSetConfig == nil {

--- a/multicluster/controllers/multicluster/memberclusterannounce_controller_test.go
+++ b/multicluster/controllers/multicluster/memberclusterannounce_controller_test.go
@@ -114,10 +114,22 @@ func TestStatusAfterAdd(t *testing.T) {
 		},
 	}
 
-	//[]multiclusterv1alpha1.ClusterStatus
-	status := memberClusterAnnounceReconcilerUnderTest.GetMemberClusterStatuses()
-	assert.Equal(t, 1, len(status))
-	verifyStatus(t, expectedStatus, status[0])
+	actualStatus := memberClusterAnnounceReconcilerUnderTest.GetMemberClusterStatuses()
+	actualTimerData := memberClusterAnnounceReconcilerUnderTest.timerData
+	assert.Equal(t, 1, len(actualStatus))
+	assert.Equal(t, 1, len(actualTimerData))
+	verifyStatus(t, expectedStatus, actualStatus[0])
+}
+
+func TestStatusAfterDelete(t *testing.T) {
+	setup()
+	memberClusterAnnounceReconcilerUnderTest.AddMember("east")
+	memberClusterAnnounceReconcilerUnderTest.RemoveMember("east")
+
+	actualStatus := memberClusterAnnounceReconcilerUnderTest.GetMemberClusterStatuses()
+	actualTimerData := memberClusterAnnounceReconcilerUnderTest.timerData
+	assert.Equal(t, 0, len(actualStatus))
+	assert.Equal(t, 0, len(actualTimerData))
 }
 
 func TestStatusAfterReconcile(t *testing.T) {
@@ -159,10 +171,10 @@ func TestStatusAfterReconcile(t *testing.T) {
 	}
 
 	memberClusterAnnounceReconcilerUnderTest.processMCSStatus()
-	status := memberClusterAnnounceReconcilerUnderTest.GetMemberClusterStatuses()
-	klog.V(2).InfoS("Received", "actual", status, "expected", expectedStatus)
-	assert.Equal(t, 1, len(status))
-	verifyStatus(t, expectedStatus, status[0])
+	actualStatus := memberClusterAnnounceReconcilerUnderTest.GetMemberClusterStatuses()
+	klog.V(2).InfoS("Received", "actual", actualStatus, "expected", expectedStatus)
+	assert.Equal(t, 1, len(actualStatus))
+	verifyStatus(t, expectedStatus, actualStatus[0])
 }
 
 func TestStatusAfterLeaderElection(t *testing.T) {
@@ -201,10 +213,10 @@ func TestStatusAfterLeaderElection(t *testing.T) {
 	}
 
 	memberClusterAnnounceReconcilerUnderTest.processMCSStatus()
-	status := memberClusterAnnounceReconcilerUnderTest.GetMemberClusterStatuses()
-	klog.V(2).InfoS("Received", "actual", status, "expected", expectedStatus)
-	assert.Equal(t, 1, len(status))
-	verifyStatus(t, expectedStatus, status[0])
+	actualStatus := memberClusterAnnounceReconcilerUnderTest.GetMemberClusterStatuses()
+	klog.V(2).InfoS("Received", "actual", actualStatus, "expected", expectedStatus)
+	assert.Equal(t, 1, len(actualStatus))
+	verifyStatus(t, expectedStatus, actualStatus[0])
 }
 
 func TestStatusInNonLeaderCase(t *testing.T) {
@@ -243,10 +255,10 @@ func TestStatusInNonLeaderCase(t *testing.T) {
 	}
 
 	memberClusterAnnounceReconcilerUnderTest.processMCSStatus()
-	status := memberClusterAnnounceReconcilerUnderTest.GetMemberClusterStatuses()
-	klog.V(2).InfoS("Received", "actual", status, "expected", expectedStatus)
-	assert.Equal(t, 1, len(status))
-	verifyStatus(t, expectedStatus, status[0])
+	actualStatus := memberClusterAnnounceReconcilerUnderTest.GetMemberClusterStatuses()
+	klog.V(2).InfoS("Received", "actual", actualStatus, "expected", expectedStatus)
+	assert.Equal(t, 1, len(actualStatus))
+	verifyStatus(t, expectedStatus, actualStatus[0])
 }
 
 func verifyStatus(t *testing.T, expected mcsv1alpha1.ClusterStatus, actual mcsv1alpha1.ClusterStatus) {

--- a/multicluster/controllers/multicluster/mock_membercluster_status_manager.go
+++ b/multicluster/controllers/multicluster/mock_membercluster_status_manager.go
@@ -51,15 +51,15 @@ func (m *MockMemberClusterStatusManager) EXPECT() *MockMemberClusterStatusManage
 }
 
 // AddMember mocks base method.
-func (m *MockMemberClusterStatusManager) AddMember(MemberId common.ClusterID) {
+func (m *MockMemberClusterStatusManager) AddMember(memberID common.ClusterID) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "AddMember", MemberId)
+	m.ctrl.Call(m, "AddMember", memberID)
 }
 
 // AddMember indicates an expected call of AddMember.
-func (mr *MockMemberClusterStatusManagerMockRecorder) AddMember(MemberId interface{}) *gomock.Call {
+func (mr *MockMemberClusterStatusManagerMockRecorder) AddMember(memberID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddMember", reflect.TypeOf((*MockMemberClusterStatusManager)(nil).AddMember), MemberId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddMember", reflect.TypeOf((*MockMemberClusterStatusManager)(nil).AddMember), memberID)
 }
 
 // GetMemberClusterStatuses mocks base method.
@@ -77,13 +77,13 @@ func (mr *MockMemberClusterStatusManagerMockRecorder) GetMemberClusterStatuses()
 }
 
 // RemoveMember mocks base method.
-func (m *MockMemberClusterStatusManager) RemoveMember(MemberId common.ClusterID) {
+func (m *MockMemberClusterStatusManager) RemoveMember(memberID common.ClusterID) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "RemoveMember", MemberId)
+	m.ctrl.Call(m, "RemoveMember", memberID)
 }
 
 // RemoveMember indicates an expected call of RemoveMember.
-func (mr *MockMemberClusterStatusManagerMockRecorder) RemoveMember(MemberId interface{}) *gomock.Call {
+func (mr *MockMemberClusterStatusManagerMockRecorder) RemoveMember(memberID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveMember", reflect.TypeOf((*MockMemberClusterStatusManager)(nil).RemoveMember), MemberId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveMember", reflect.TypeOf((*MockMemberClusterStatusManager)(nil).RemoveMember), memberID)
 }


### PR DESCRIPTION
When the ClusterSet is deleted in leader Namespace, there will be
a nil pointer issue due to data inconsistency. This issue will cause
leader controller crash and restart. Refined codes to make data
consistent.
    ```
    leader_clusterset_controller.go:72] "Received ClusterSet delete" config=""
    panic: runtime error: invalid memory address or nil pointer dereference
    [signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x188b9b1]

    goroutine 274 [running]:
    antrea.io/antrea/multicluster/controllers/multicluster.(*MemberClusterAnnounceReconciler).processMCSStatus(0xc00052ff20)
            /antrea/multicluster/controllers/multicluster/memberclusterannounce_controller.go:181 +0x331
    ...
    ```

Fixes #3918

Signed-off-by: Lan Luo <luola@vmware.com>