### PR TITLE
[ExternalNode] Add validations for ExternalNode

### DIFF
--- a/build/charts/antrea/crds/externalnode.yaml
+++ b/build/charts/antrea/crds/externalnode.yaml
@@ -11,17 +11,26 @@ spec:
       schema:
         openAPIV3Schema:
           type: object
+          required:
+            - spec
           properties:
             spec:
               type: object
+              required:
+                - interfaces
               properties:
                 interfaces:
                   type: array
+                  minItems: 1
+                  maxItems: 1
+                  required:
+                    - ips
                   items:
                     type: object
                     properties:
                       ips:
                         type: array
+                        minItems: 1
                         items:
                           type: string
                           oneOf:

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -1281,17 +1281,26 @@ spec:
       schema:
         openAPIV3Schema:
           type: object
+          required:
+            - spec
           properties:
             spec:
               type: object
+              required:
+                - interfaces
               properties:
                 interfaces:
                   type: array
+                  minItems: 1
+                  maxItems: 1
+                  required:
+                    - ips
                   items:
                     type: object
                     properties:
                       ips:
                         type: array
+                        minItems: 1
                         items:
                           type: string
                           oneOf:

--- a/build/yamls/antrea-crds.yml
+++ b/build/yamls/antrea-crds.yml
@@ -1266,17 +1266,26 @@ spec:
       schema:
         openAPIV3Schema:
           type: object
+          required:
+            - spec
           properties:
             spec:
               type: object
+              required:
+                - interfaces
               properties:
                 interfaces:
                   type: array
+                  minItems: 1
+                  maxItems: 1
+                  required:
+                    - ips
                   items:
                     type: object
                     properties:
                       ips:
                         type: array
+                        minItems: 1
                         items:
                           type: string
                           oneOf:
@@ -1465,6 +1474,30 @@ spec:
                     type: object
                     # Ensure that Spec.AppliedTo does not allow NamespaceSelector/IPBlock field
                     properties:
+                      externalEntitySelector:
+                        type: object
+                        properties:
+                          matchExpressions:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                key:
+                                  type: string
+                                operator:
+                                  enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                  type: string
+                                values:
+                                  type: array
+                                  items:
+                                    type: string
+                                    pattern: "^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$"
+                          matchLabels:
+                            x-kubernetes-preserve-unknown-fields: true
                       podSelector:
                         type: object
                         properties:

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -1281,17 +1281,26 @@ spec:
       schema:
         openAPIV3Schema:
           type: object
+          required:
+            - spec
           properties:
             spec:
               type: object
+              required:
+                - interfaces
               properties:
                 interfaces:
                   type: array
+                  minItems: 1
+                  maxItems: 1
+                  required:
+                    - ips
                   items:
                     type: object
                     properties:
                       ips:
                         type: array
+                        minItems: 1
                         items:
                           type: string
                           oneOf:

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -1281,17 +1281,26 @@ spec:
       schema:
         openAPIV3Schema:
           type: object
+          required:
+            - spec
           properties:
             spec:
               type: object
+              required:
+                - interfaces
               properties:
                 interfaces:
                   type: array
+                  minItems: 1
+                  maxItems: 1
+                  required:
+                    - ips
                   items:
                     type: object
                     properties:
                       ips:
                         type: array
+                        minItems: 1
                         items:
                           type: string
                           oneOf:

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -1281,17 +1281,26 @@ spec:
       schema:
         openAPIV3Schema:
           type: object
+          required:
+            - spec
           properties:
             spec:
               type: object
+              required:
+                - interfaces
               properties:
                 interfaces:
                   type: array
+                  minItems: 1
+                  maxItems: 1
+                  required:
+                    - ips
                   items:
                     type: object
                     properties:
                       ips:
                         type: array
+                        minItems: 1
                         items:
                           type: string
                           oneOf:

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -1281,17 +1281,26 @@ spec:
       schema:
         openAPIV3Schema:
           type: object
+          required:
+            - spec
           properties:
             spec:
               type: object
+              required:
+                - interfaces
               properties:
                 interfaces:
                   type: array
+                  minItems: 1
+                  maxItems: 1
+                  required:
+                    - ips
                   items:
                     type: object
                     properties:
                       ips:
                         type: array
+                        minItems: 1
                         items:
                           type: string
                           oneOf:


### PR DESCRIPTION
Update ExternalNode openAPIV3Schema to only allow create/update
ExternalNode when its interfaces exist and the ips of the interface
exist.

Signed-off-by: Mengdie Song <songm@vmware.com>