### PR TITLE
Improve kind e2e tests

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -149,7 +149,7 @@ jobs:
       run: |
         mkdir log
         mkdir test-e2e-encap-no-proxy-coverage
-        ANTREA_LOG_DIR=$PWD/log ANTREA_COV_DIR=$PWD/test-e2e-encap-no-proxy-coverage ./ci/kind/test-e2e-kind.sh --encap-mode encap --no-proxy --coverage --skip mode-irrelevant
+        ANTREA_LOG_DIR=$PWD/log ANTREA_COV_DIR=$PWD/test-e2e-encap-no-proxy-coverage ./ci/kind/test-e2e-kind.sh --encap-mode encap --feature-gates AntreaProxy=false --coverage --skip mode-irrelevant
     - name: Tar coverage files
       run: tar -czf test-e2e-encap-no-proxy-coverage.tar.gz test-e2e-encap-no-proxy-coverage
     - name: Upload coverage for test-e2e-encap-no-proxy-coverage
@@ -177,10 +177,10 @@ jobs:
         path: log.tar.gz
         retention-days: 30
 
-  test-e2e-encap-proxy-all:
-    name: E2e tests on a Kind cluster on Linux with AntreaProxy all Service support
-    needs: [ build-antrea-coverage-image ]
-    runs-on: [ ubuntu-latest ]
+  test-e2e-encap-all-features-enabled:
+    name: E2e tests on a Kind cluster on Linux with all features enabled
+    needs: [build-antrea-coverage-image]
+    runs-on: [ubuntu-latest]
     steps:
       - name: Free disk space
         # https://github.com/actions/virtual-environments/issues/709
@@ -204,15 +204,16 @@ jobs:
       - name: Run e2e tests
         run: |
           mkdir log
-          mkdir test-e2e-encap-proxy-all-coverage
-          ANTREA_LOG_DIR=$PWD/log ANTREA_COV_DIR=$PWD/test-e2e-encap-proxy-all-coverage ./ci/kind/test-e2e-kind.sh --encap-mode encap --proxy-all --coverage --skip mode-irrelevant
+          mkdir test-e2e-encap-all-features-enabled-coverage
+          # Currently multicast tests require specific testbeds, exclude it for now.
+          ANTREA_LOG_DIR=$PWD/log ANTREA_COV_DIR=$PWD/test-e2e-encap-all-features-enabled-coverage ./ci/kind/test-e2e-kind.sh --encap-mode encap --coverage --feature-gates AllAlpha=true,AllBeta=true,Multicast=false --proxy-all
       - name: Tar coverage files
-        run: tar -czf test-e2e-encap-proxy-all-coverage.tar.gz test-e2e-encap-proxy-all-coverage
-      - name: Upload coverage for test-e2e-encap-proxy-all-coverage
+        run: tar -czf test-e2e-encap-all-features-enabled-coverage.tar.gz test-e2e-encap-all-features-enabled-coverage
+      - name: Upload coverage for test-e2e-encap-all-features-enabled-coverage
         uses: actions/upload-artifact@v3
         with:
-          name: test-e2e-encap-proxy-all-coverage
-          path: test-e2e-encap-proxy-all-coverage.tar.gz
+          name: test-e2e-encap-all-features-enabled-coverage
+          path: test-e2e-encap-all-features-enabled-coverage.tar.gz
           retention-days: 30
       - name: Codecov
         uses: codecov/codecov-action@v3
@@ -220,8 +221,8 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: '*.cov.out*'
           flags: kind-e2e-tests
-          name: codecov-test-e2e-encap-proxy-all
-          directory: test-e2e-encap-proxy-all-coverage
+          name: codecov-test-e2e-encap-all-features-enabled
+          directory: test-e2e-encap-all-features-enabled-coverage
       - name: Tar log files
         if: ${{ failure() }}
         run: tar -czf log.tar.gz log
@@ -229,7 +230,7 @@ jobs:
         uses: actions/upload-artifact@v3
         if: ${{ failure() }}
         with:
-          name: e2e-kind-encap-proxy-all.tar.gz
+          name: e2e-kind-encap-all-features-enabled.tar.gz
           path: log.tar.gz
           retention-days: 30
 
@@ -342,65 +343,6 @@ jobs:
       if: ${{ failure() }}
       with:
         name: e2e-kind-hybrid.tar.gz
-        path: log.tar.gz
-        retention-days: 30
-
-  # TODO: remove when https://github.com/antrea-io/antrea/issues/897 is fixed.
-  # In the mean time, we keep this test around to ensure that at least one Kind
-  # test uses a Geneve overlay.
-  test-e2e-encap-no-np:
-    name: E2e tests on a Kind cluster on Linux with Antrea-native policies disabled
-    needs: [build-antrea-coverage-image]
-    runs-on: [ubuntu-latest]
-    steps:
-    - name: Free disk space
-      # https://github.com/actions/virtual-environments/issues/709
-      run: |
-        sudo apt-get clean
-        df -h
-    - uses: actions/checkout@v3
-    - uses: actions/setup-go@v3
-      with:
-        go-version: 1.17
-    - name: Download Antrea images from previous jobs
-      uses: actions/download-artifact@v3
-    - name: Load Antrea image
-      run: |
-        docker load -i antrea-ubuntu-cov/antrea-ubuntu.tar
-    - name: Install Kind
-      run: |
-        curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
-        chmod +x ./kind
-        sudo mv kind /usr/local/bin
-    - name: Run e2e tests
-      run: |
-        mkdir log
-        mkdir test-e2e-encap-no-np-coverage
-        ANTREA_LOG_DIR=$PWD/log ANTREA_COV_DIR=$PWD/test-e2e-encap-no-np-coverage ./ci/kind/test-e2e-kind.sh --encap-mode encap --no-np --coverage --skip mode-irrelevant
-    - name: Tar coverage files
-      run: tar -czf test-e2e-encap-no-np-coverage.tar.gz test-e2e-encap-no-np-coverage
-    - name: Upload coverage for test-e2e-encap-no-np-coverage
-      uses: actions/upload-artifact@v3
-      with:
-        name: test-e2e-encap-no-np-coverage
-        path: test-e2e-encap-no-np-coverage.tar.gz
-        retention-days: 30
-    - name: Codecov
-      uses: codecov/codecov-action@v3
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        file: '*.cov.out*'
-        flags: kind-e2e-tests
-        name: codecov-test-e2e-no-np-encap
-        directory: test-e2e-encap-no-np-coverage
-    - name: Tar log files
-      if: ${{ failure() }}
-      run: tar -czf log.tar.gz log
-    - name: Upload test log
-      uses: actions/upload-artifact@v3
-      if: ${{ failure() }}
-      with:
-        name: e2e-kind-encap-no-np.tar.gz
         path: log.tar.gz
         retention-days: 30
 
@@ -536,7 +478,7 @@ jobs:
   # yet.
   artifact-cleanup:
     name: Delete uploaded images
-    needs: [build-antrea-coverage-image, build-flow-aggregator-coverage-image, test-e2e-encap, test-e2e-encap-no-proxy, test-e2e-encap-proxy-all, test-e2e-noencap, test-e2e-hybrid, test-e2e-encap-no-np, test-netpol-tmp, validate-prometheus-metrics-doc, test-e2e-flow-visibility]
+    needs: [build-antrea-coverage-image, build-flow-aggregator-coverage-image, test-e2e-encap, test-e2e-encap-no-proxy, test-e2e-encap-all-features-enabled, test-e2e-noencap, test-e2e-hybrid, test-netpol-tmp, validate-prometheus-metrics-doc, test-e2e-flow-visibility]
     if: ${{ always() &&  (needs.build-antrea-coverage-image.result == 'success' || needs.build-flow-aggregator-coverage-image.result == 'success') }}
     runs-on: [ubuntu-latest]
     steps:

--- a/build/charts/antrea/conf/antrea-agent.conf
+++ b/build/charts/antrea/conf/antrea-agent.conf
@@ -1,5 +1,11 @@
 # FeatureGates is a map of feature names to bools that enable or disable experimental features.
 featureGates:
+# AllAlpha is a global toggle for alpha features. Per-feature key values override the default set by AllAlpha.
+{{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "AllAlpha" "default" false) }}
+
+# AllBeta is a global toggle for beta features. Per-feature key values override the default set by AllBeta.
+{{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "AllBeta" "default" false) }}
+
 # Enable AntreaProxy which provides ServiceLB for in-cluster Services in antrea-agent.
 # It should be enabled on Windows, otherwise NetworkPolicy will not take effect on
 # Service traffic.

--- a/build/charts/antrea/conf/antrea-controller.conf
+++ b/build/charts/antrea/conf/antrea-controller.conf
@@ -1,5 +1,11 @@
 # FeatureGates is a map of feature names to bools that enable or disable experimental features.
 featureGates:
+# AllAlpha is a global toggle for alpha features. Per-feature key values override the default set by AllAlpha.
+{{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "AllAlpha" "default" false) }}
+
+# AllBeta is a global toggle for beta features. Per-feature key values override the default set by AllBeta.
+{{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "AllBeta" "default" false) }}
+
 # Enable traceflow which provides packet tracing feature to diagnose network issue.
 {{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "Traceflow" "default" true) }}
 

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -2537,6 +2537,12 @@ data:
   antrea-agent.conf: |
     # FeatureGates is a map of feature names to bools that enable or disable experimental features.
     featureGates:
+    # AllAlpha is a global toggle for alpha features. Per-feature key values override the default set by AllAlpha.
+    #  AllAlpha: false
+
+    # AllBeta is a global toggle for beta features. Per-feature key values override the default set by AllBeta.
+    #  AllBeta: false
+
     # Enable AntreaProxy which provides ServiceLB for in-cluster Services in antrea-agent.
     # It should be enabled on Windows, otherwise NetworkPolicy will not take effect on
     # Service traffic.
@@ -2845,6 +2851,12 @@ data:
   antrea-controller.conf: |
     # FeatureGates is a map of feature names to bools that enable or disable experimental features.
     featureGates:
+    # AllAlpha is a global toggle for alpha features. Per-feature key values override the default set by AllAlpha.
+    #  AllAlpha: false
+
+    # AllBeta is a global toggle for beta features. Per-feature key values override the default set by AllBeta.
+    #  AllBeta: false
+
     # Enable traceflow which provides packet tracing feature to diagnose network issue.
     #  Traceflow: true
 
@@ -3676,7 +3688,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: a4e7182f54a10234001d8baeb7d950a5053ffb97b2f6951db516244ac3620cd8
+        checksum/config: 890f1364c9b89811375830c94fab2fa9f1957518351cc52c623e22b6964e5e75
       labels:
         app: antrea
         component: antrea-agent
@@ -3916,7 +3928,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: a4e7182f54a10234001d8baeb7d950a5053ffb97b2f6951db516244ac3620cd8
+        checksum/config: 890f1364c9b89811375830c94fab2fa9f1957518351cc52c623e22b6964e5e75
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -2537,6 +2537,12 @@ data:
   antrea-agent.conf: |
     # FeatureGates is a map of feature names to bools that enable or disable experimental features.
     featureGates:
+    # AllAlpha is a global toggle for alpha features. Per-feature key values override the default set by AllAlpha.
+    #  AllAlpha: false
+
+    # AllBeta is a global toggle for beta features. Per-feature key values override the default set by AllBeta.
+    #  AllBeta: false
+
     # Enable AntreaProxy which provides ServiceLB for in-cluster Services in antrea-agent.
     # It should be enabled on Windows, otherwise NetworkPolicy will not take effect on
     # Service traffic.
@@ -2845,6 +2851,12 @@ data:
   antrea-controller.conf: |
     # FeatureGates is a map of feature names to bools that enable or disable experimental features.
     featureGates:
+    # AllAlpha is a global toggle for alpha features. Per-feature key values override the default set by AllAlpha.
+    #  AllAlpha: false
+
+    # AllBeta is a global toggle for beta features. Per-feature key values override the default set by AllBeta.
+    #  AllBeta: false
+
     # Enable traceflow which provides packet tracing feature to diagnose network issue.
     #  Traceflow: true
 
@@ -3676,7 +3688,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: a4e7182f54a10234001d8baeb7d950a5053ffb97b2f6951db516244ac3620cd8
+        checksum/config: 890f1364c9b89811375830c94fab2fa9f1957518351cc52c623e22b6964e5e75
       labels:
         app: antrea
         component: antrea-agent
@@ -3918,7 +3930,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: a4e7182f54a10234001d8baeb7d950a5053ffb97b2f6951db516244ac3620cd8
+        checksum/config: 890f1364c9b89811375830c94fab2fa9f1957518351cc52c623e22b6964e5e75
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -2537,6 +2537,12 @@ data:
   antrea-agent.conf: |
     # FeatureGates is a map of feature names to bools that enable or disable experimental features.
     featureGates:
+    # AllAlpha is a global toggle for alpha features. Per-feature key values override the default set by AllAlpha.
+    #  AllAlpha: false
+
+    # AllBeta is a global toggle for beta features. Per-feature key values override the default set by AllBeta.
+    #  AllBeta: false
+
     # Enable AntreaProxy which provides ServiceLB for in-cluster Services in antrea-agent.
     # It should be enabled on Windows, otherwise NetworkPolicy will not take effect on
     # Service traffic.
@@ -2845,6 +2851,12 @@ data:
   antrea-controller.conf: |
     # FeatureGates is a map of feature names to bools that enable or disable experimental features.
     featureGates:
+    # AllAlpha is a global toggle for alpha features. Per-feature key values override the default set by AllAlpha.
+    #  AllAlpha: false
+
+    # AllBeta is a global toggle for beta features. Per-feature key values override the default set by AllBeta.
+    #  AllBeta: false
+
     # Enable traceflow which provides packet tracing feature to diagnose network issue.
     #  Traceflow: true
 
@@ -3676,7 +3688,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: afbe6d81852e79d710d0350ab5173f7d0e05b79c75744cffb94ce2294afc328c
+        checksum/config: cc8af4219d403a137ab87500ae0ab15b681fc635e41057b5623df6154443fddf
       labels:
         app: antrea
         component: antrea-agent
@@ -3916,7 +3928,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: afbe6d81852e79d710d0350ab5173f7d0e05b79c75744cffb94ce2294afc328c
+        checksum/config: cc8af4219d403a137ab87500ae0ab15b681fc635e41057b5623df6154443fddf
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -2550,6 +2550,12 @@ data:
   antrea-agent.conf: |
     # FeatureGates is a map of feature names to bools that enable or disable experimental features.
     featureGates:
+    # AllAlpha is a global toggle for alpha features. Per-feature key values override the default set by AllAlpha.
+    #  AllAlpha: false
+
+    # AllBeta is a global toggle for beta features. Per-feature key values override the default set by AllBeta.
+    #  AllBeta: false
+
     # Enable AntreaProxy which provides ServiceLB for in-cluster Services in antrea-agent.
     # It should be enabled on Windows, otherwise NetworkPolicy will not take effect on
     # Service traffic.
@@ -2858,6 +2864,12 @@ data:
   antrea-controller.conf: |
     # FeatureGates is a map of feature names to bools that enable or disable experimental features.
     featureGates:
+    # AllAlpha is a global toggle for alpha features. Per-feature key values override the default set by AllAlpha.
+    #  AllAlpha: false
+
+    # AllBeta is a global toggle for beta features. Per-feature key values override the default set by AllBeta.
+    #  AllBeta: false
+
     # Enable traceflow which provides packet tracing feature to diagnose network issue.
     #  Traceflow: true
 
@@ -3689,7 +3701,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 626cd437985469e9b0e55e2faacbab203aee641d8a99ff9831c2bb3319f02e95
+        checksum/config: df5271a5c42a550d3f8e73fbe8e5fad8d178884fb74d81c7322128187546db86
         checksum/ipsec-secret: d0eb9c52d0cd4311b6d252a951126bf9bea27ec05590bed8a394f0f792dcb2a4
       labels:
         app: antrea
@@ -3975,7 +3987,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 626cd437985469e9b0e55e2faacbab203aee641d8a99ff9831c2bb3319f02e95
+        checksum/config: df5271a5c42a550d3f8e73fbe8e5fad8d178884fb74d81c7322128187546db86
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -2537,6 +2537,12 @@ data:
   antrea-agent.conf: |
     # FeatureGates is a map of feature names to bools that enable or disable experimental features.
     featureGates:
+    # AllAlpha is a global toggle for alpha features. Per-feature key values override the default set by AllAlpha.
+    #  AllAlpha: false
+
+    # AllBeta is a global toggle for beta features. Per-feature key values override the default set by AllBeta.
+    #  AllBeta: false
+
     # Enable AntreaProxy which provides ServiceLB for in-cluster Services in antrea-agent.
     # It should be enabled on Windows, otherwise NetworkPolicy will not take effect on
     # Service traffic.
@@ -2845,6 +2851,12 @@ data:
   antrea-controller.conf: |
     # FeatureGates is a map of feature names to bools that enable or disable experimental features.
     featureGates:
+    # AllAlpha is a global toggle for alpha features. Per-feature key values override the default set by AllAlpha.
+    #  AllAlpha: false
+
+    # AllBeta is a global toggle for beta features. Per-feature key values override the default set by AllBeta.
+    #  AllBeta: false
+
     # Enable traceflow which provides packet tracing feature to diagnose network issue.
     #  Traceflow: true
 
@@ -3676,7 +3688,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 750097fa4ed60fda68fedf2f31b06a1a62dbbe5dc9a38e9c1f9ddc861a389401
+        checksum/config: 033b7f8c7b77a918ad1a90c3db034bbfc1df67de264a77f8aee6a035836b6812
       labels:
         app: antrea
         component: antrea-agent
@@ -3916,7 +3928,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 750097fa4ed60fda68fedf2f31b06a1a62dbbe5dc9a38e9c1f9ddc861a389401
+        checksum/config: 033b7f8c7b77a918ad1a90c3db034bbfc1df67de264a77f8aee6a035836b6812
       labels:
         app: antrea
         component: antrea-controller

--- a/ci/jenkins/test-vmc.sh
+++ b/ci/jenkins/test-vmc.sh
@@ -574,10 +574,10 @@ function run_conformance {
 
     if [[ "$TESTCASE" == "all-features-conformance" ]]; then
       if [[ "$COVERAGE" == true ]]; then
-        $GIT_CHECKOUT_DIR/hack/generate-manifest.sh --mode dev --all-features --coverage > $GIT_CHECKOUT_DIR/build/yamls/antrea-all-coverage.yml
+        $GIT_CHECKOUT_DIR/hack/generate-manifest.sh --mode dev --feature-gates AllAlpha=true,AllBeta=true --proxy-all --coverage > $GIT_CHECKOUT_DIR/build/yamls/antrea-all-coverage.yml
         antrea_yml="antrea-all-coverage.yml"
       else
-        $GIT_CHECKOUT_DIR/hack/generate-manifest.sh --mode dev --all-features --verbose-log > $GIT_CHECKOUT_DIR/build/yamls/antrea-all.yml
+        $GIT_CHECKOUT_DIR/hack/generate-manifest.sh --mode dev --feature-gates AllAlpha=true,AllBeta=true --proxy-all --verbose-log > $GIT_CHECKOUT_DIR/build/yamls/antrea-all.yml
         antrea_yml="antrea-all.yml"
       fi
     fi

--- a/test/e2e/antreapolicy_test.go
+++ b/test/e2e/antreapolicy_test.go
@@ -75,6 +75,7 @@ const (
 func TestAntreaPolicyStats(t *testing.T) {
 	skipIfHasWindowsNodes(t)
 	skipIfAntreaPolicyDisabled(t)
+	skipIfNetworkPolicyStatsDisabled(t)
 
 	data, err := setupTest(t)
 	if err != nil {
@@ -83,11 +84,9 @@ func TestAntreaPolicyStats(t *testing.T) {
 	defer teardownTest(t, data)
 
 	t.Run("testANPNetworkPolicyStatsWithDropAction", func(t *testing.T) {
-		skipIfNetworkPolicyStatsDisabled(t)
 		testANPNetworkPolicyStatsWithDropAction(t, data)
 	})
 	t.Run("testAntreaClusterNetworkPolicyStats", func(t *testing.T) {
-		skipIfNetworkPolicyStatsDisabled(t)
 		testAntreaClusterNetworkPolicyStats(t, data)
 	})
 }

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -1981,32 +1981,30 @@ func (data *TestData) isProxyAll() (bool, error) {
 	return agentConf.AntreaProxy.ProxyAll, nil
 }
 
-func getFeatures(confName string) (featuregate.FeatureGate, error) {
+func GetAgentFeatures() (featuregate.FeatureGate, error) {
 	featureGate := features.DefaultMutableFeatureGate.DeepCopy()
-	var cfg interface{}
-	if err := yaml.Unmarshal([]byte(AntreaConfigMap.Data[confName]), &cfg); err != nil {
+	var cfg agentconfig.AgentConfig
+	if err := yaml.Unmarshal([]byte(AntreaConfigMap.Data[antreaAgentConfName]), &cfg); err != nil {
 		return nil, err
 	}
-	rawFeatureGateMap, ok := cfg.(map[interface{}]interface{})["featureGates"]
-	if !ok || rawFeatureGateMap == nil {
-		return featureGate, nil
-	}
-	featureGateMap := make(map[string]bool)
-	for k, v := range rawFeatureGateMap.(map[interface{}]interface{}) {
-		featureGateMap[k.(string)] = v.(bool)
-	}
-	if err := featureGate.SetFromMap(featureGateMap); err != nil {
+	err := featureGate.SetFromMap(cfg.FeatureGates)
+	if err != nil {
 		return nil, err
 	}
 	return featureGate, nil
 }
 
-func GetAgentFeatures() (featuregate.FeatureGate, error) {
-	return getFeatures(antreaAgentConfName)
-}
-
 func GetControllerFeatures() (featuregate.FeatureGate, error) {
-	return getFeatures(antreaControllerConfName)
+	featureGate := features.DefaultMutableFeatureGate.DeepCopy()
+	var cfg controllerconfig.ControllerConfig
+	if err := yaml.Unmarshal([]byte(AntreaConfigMap.Data[antreaControllerConfName]), &cfg); err != nil {
+		return nil, err
+	}
+	err := featureGate.SetFromMap(cfg.FeatureGates)
+	if err != nil {
+		return nil, err
+	}
+	return featureGate, nil
 }
 
 func (data *TestData) GetAntreaWindowsConfigMap(antreaNamespace string) (*corev1.ConfigMap, error) {

--- a/test/e2e/infra/vagrant/push_antrea.sh
+++ b/test/e2e/infra/vagrant/push_antrea.sh
@@ -170,7 +170,7 @@ FLOW_VIS_YML="/tmp/flow-visibility.yml"
 # manifest to enable FlowExporter.
 if [[ $FLOW_COLLECTOR != "" ]]; then
     echo "Generating manifest with FlowExporter enabled"
-    $THIS_DIR/../../../../hack/generate-manifest.sh --mode dev --flow-exporter > "${ANTREA_YML}"
+    $THIS_DIR/../../../../hack/generate-manifest.sh --mode dev --feature-gates FlowExporter=true > "${ANTREA_YML}"
 fi
 
 # Push Antrea image and related manifest.

--- a/test/e2e/ipsec_test.go
+++ b/test/e2e/ipsec_test.go
@@ -25,6 +25,7 @@ import (
 	"antrea.io/antrea/pkg/agent/util"
 	agentconfig "antrea.io/antrea/pkg/config/agent"
 	controllerconfig "antrea.io/antrea/pkg/config/controller"
+	"antrea.io/antrea/pkg/features"
 )
 
 // TestIPSec is the top-level test which contains all subtests for
@@ -60,15 +61,8 @@ func TestIPSec(t *testing.T) {
 	})
 
 	t.Run("testIPSecCertificateAuth", func(t *testing.T) {
-		// restart the Controller first as Agent needs to get the CSR signed.
-		cc := func(config *controllerconfig.ControllerConfig) {
-			config.FeatureGates["IPsecCertAuth"] = true
-		}
-		if err := data.mutateAntreaConfigMap(cc, nil, true, false); err != nil {
-			t.Fatalf("Failed to enable IPsecCertAuth feature: %v", err)
-		}
+		skipIfFeatureDisabled(t, features.IPsecCertAuth, true, true)
 		ac := func(config *agentconfig.AgentConfig) {
-			config.FeatureGates["IPsecCertAuth"] = true
 			config.IPsec.AuthenticationMode = "cert"
 		}
 		if err := data.mutateAntreaConfigMap(nil, ac, false, true); err != nil {

--- a/test/e2e/nodeportlocal_test.go
+++ b/test/e2e/nodeportlocal_test.go
@@ -78,13 +78,14 @@ func configureNPLForAgent(t *testing.T, data *TestData, startPort, endPort int) 
 func TestNodePortLocal(t *testing.T) {
 	skipIfNotIPv4Cluster(t)
 	skipIfHasWindowsNodes(t)
+	skipIfNodePortLocalDisabled(t)
 
 	data, err := setupTest(t)
 	if err != nil {
 		t.Fatalf("Error when setting up test: %v", err)
 	}
 	defer teardownTest(t, data)
-	skipIfNodePortLocalDisabled(t)
+
 	configureNPLForAgent(t, data, defaultStartPort, defaultEndPort)
 	t.Run("testNPLAddPod", func(t *testing.T) { testNPLAddPod(t, data) })
 	t.Run("testNPLMultiplePodsAgentRestart", func(t *testing.T) { testNPLMultiplePodsAgentRestart(t, data) })

--- a/test/e2e/secondary_network_ipam_test.go
+++ b/test/e2e/secondary_network_ipam_test.go
@@ -22,8 +22,7 @@ import (
 
 	"antrea.io/antrea/pkg/agent/config"
 	crdv1alpha2 "antrea.io/antrea/pkg/apis/crd/v1alpha2"
-	agentconfig "antrea.io/antrea/pkg/config/agent"
-	controllerconfig "antrea.io/antrea/pkg/config/controller"
+	"antrea.io/antrea/pkg/features"
 )
 
 var (
@@ -242,6 +241,7 @@ func TestSecondaryNetworkIPAM(t *testing.T) {
 	skipIfProxyDisabled(t)
 	skipIfNotIPv4Cluster(t)
 	skipIfAntreaIPAMTest(t)
+	skipIfFeatureDisabled(t, features.AntreaIPAM, true, true)
 
 	data, err := setupTest(t)
 	if err != nil {
@@ -249,16 +249,6 @@ func TestSecondaryNetworkIPAM(t *testing.T) {
 	}
 	defer teardownTest(t, data)
 	skipIfEncapModeIsNot(t, data, config.TrafficEncapModeEncap)
-
-	cc := func(config *controllerconfig.ControllerConfig) {
-		config.FeatureGates["AntreaIPAM"] = true
-	}
-	ac := func(config *agentconfig.AgentConfig) {
-		config.FeatureGates["AntreaIPAM"] = true
-	}
-	if err = data.mutateAntreaConfigMap(cc, ac, true, true); err != nil {
-		t.Fatalf("Failed to enable AntreaIPAM feature: %v", err)
-	}
 
 	_, err = data.crdClient.CrdV1alpha2().IPPools().Create(context.TODO(), testIPPoolv4, metav1.CreateOptions{})
 	defer deleteIPPoolWrapper(t, data, testIPPoolv4.Name)

--- a/test/e2e/service_externalip_test.go
+++ b/test/e2e/service_externalip_test.go
@@ -37,8 +37,7 @@ import (
 
 	antreaagenttypes "antrea.io/antrea/pkg/agent/types"
 	"antrea.io/antrea/pkg/apis/crd/v1alpha2"
-	agentconfig "antrea.io/antrea/pkg/config/agent"
-	controllerconfig "antrea.io/antrea/pkg/config/controller"
+	"antrea.io/antrea/pkg/features"
 	"antrea.io/antrea/pkg/querier"
 )
 
@@ -46,23 +45,13 @@ func TestServiceExternalIP(t *testing.T) {
 	skipIfHasWindowsNodes(t)
 	skipIfNumNodesLessThan(t, 2)
 	skipIfAntreaIPAMTest(t)
+	skipIfFeatureDisabled(t, features.ServiceExternalIP, true, true)
 
 	data, err := setupTest(t)
 	if err != nil {
 		t.Fatalf("Error when setting up test: %v", err)
 	}
 	defer teardownTest(t, data)
-
-	cc := func(config *controllerconfig.ControllerConfig) {
-		config.FeatureGates["ServiceExternalIP"] = true
-	}
-	ac := func(config *agentconfig.AgentConfig) {
-		config.FeatureGates["ServiceExternalIP"] = true
-	}
-
-	if err := data.mutateAntreaConfigMap(cc, ac, true, true); err != nil {
-		t.Fatalf("Failed to enable ServiceExternalIP feature: %v", err)
-	}
 
 	t.Run("testServiceWithExternalIPCRUD", func(t *testing.T) { testServiceWithExternalIPCRUD(t, data) })
 	t.Run("testServiceUpdateExternalIP", func(t *testing.T) { testServiceUpdateExternalIP(t, data) })

--- a/test/e2e/trafficcontrol_test.go
+++ b/test/e2e/trafficcontrol_test.go
@@ -28,7 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"antrea.io/antrea/pkg/apis/crd/v1alpha2"
-	agentconfig "antrea.io/antrea/pkg/config/agent"
+	"antrea.io/antrea/pkg/features"
 )
 
 type trafficControlTestConfig struct {
@@ -54,20 +54,13 @@ var (
 
 func TestTrafficControl(t *testing.T) {
 	skipIfHasWindowsNodes(t)
+	skipIfFeatureDisabled(t, features.TrafficControl, true, false)
 
 	data, err := setupTest(t)
 	if err != nil {
 		t.Fatalf("Error when setting up test: %v", err)
 	}
 	defer teardownTest(t, data)
-
-	ac := func(config *agentconfig.AgentConfig) {
-		config.FeatureGates["TrafficControl"] = true
-	}
-
-	if err = data.mutateAntreaConfigMap(nil, ac, true, true); err != nil {
-		t.Fatalf("Failed to enable TrafficControl feature: %v", err)
-	}
 
 	tcTestConfig.nodeName = controlPlaneNodeName()
 


### PR DESCRIPTION
There were 3 feature specific jobs running e2e tests with AntreaProxy
disabled, AntreaProxy and proxyAll enabled, and AntreaPolicy disabled
separately. Having a job for each feature is not extensible and
requires maintenance efforts to configure the job along with the
feature's lifecycle. There is a lot of redundancy between these jobs as
unrelated tests ran repeatedly in them.

There were other feature specific test cases enabling the features at
runtime, which doesn't cover the scenario when two features are enabled
at the same time.

This patch removes some feature specific jobs and creates one job
running tests with all features enabled, which can test all features'
interaction. The patch also makes necessary changes to kind test script
and manifest generating script to achieve it.

Signed-off-by: Quan Tian <qtian@vmware.com>