### PR TITLE
Improve support for Egress in Traceflow

### DIFF
--- a/build/charts/antrea/crds/traceflow.yaml
+++ b/build/charts/antrea/crds/traceflow.yaml
@@ -189,6 +189,10 @@ spec:
                               type: string
                             tunnelDstIP:
                               type: string
+                            egressIP:
+                              type: string
+                            egress:
+                              type: string
                 capturedPacket:
                   properties:
                     srcIP:

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -2508,6 +2508,10 @@ spec:
                               type: string
                             tunnelDstIP:
                               type: string
+                            egressIP:
+                              type: string
+                            egress:
+                              type: string
                 capturedPacket:
                   properties:
                     srcIP:

--- a/build/yamls/antrea-crds.yml
+++ b/build/yamls/antrea-crds.yml
@@ -2483,6 +2483,10 @@ spec:
                               type: string
                             tunnelDstIP:
                               type: string
+                            egressIP:
+                              type: string
+                            egress:
+                              type: string
                 capturedPacket:
                   properties:
                     srcIP:

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -2508,6 +2508,10 @@ spec:
                               type: string
                             tunnelDstIP:
                               type: string
+                            egressIP:
+                              type: string
+                            egress:
+                              type: string
                 capturedPacket:
                   properties:
                     srcIP:

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -2508,6 +2508,10 @@ spec:
                               type: string
                             tunnelDstIP:
                               type: string
+                            egressIP:
+                              type: string
+                            egress:
+                              type: string
                 capturedPacket:
                   properties:
                     srcIP:

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -2508,6 +2508,10 @@ spec:
                               type: string
                             tunnelDstIP:
                               type: string
+                            egressIP:
+                              type: string
+                            egress:
+                              type: string
                 capturedPacket:
                   properties:
                     srcIP:

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -2508,6 +2508,10 @@ spec:
                               type: string
                             tunnelDstIP:
                               type: string
+                            egressIP:
+                              type: string
+                            egress:
+                              type: string
                 capturedPacket:
                   properties:
                     srcIP:

--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -502,6 +502,7 @@ func run(o *Options) error {
 			traceflowInformer,
 			ofClient,
 			networkPolicyController,
+			egressController,
 			ovsBridgeClient,
 			ifaceStore,
 			networkConfig,

--- a/pkg/agent/controller/traceflow/traceflow_controller.go
+++ b/pkg/agent/controller/traceflow/traceflow_controller.go
@@ -96,6 +96,7 @@ type Controller struct {
 	ovsBridgeClient        ovsconfig.OVSBridgeClient
 	ofClient               openflow.Client
 	networkPolicyQuerier   querier.AgentNetworkPolicyInfoQuerier
+	egressQuerier          querier.EgressQuerier
 	interfaceStore         interfacestore.InterfaceStore
 	networkConfig          *config.NetworkConfig
 	nodeConfig             *config.NodeConfig
@@ -116,6 +117,7 @@ func NewTraceflowController(
 	traceflowInformer crdinformers.TraceflowInformer,
 	client openflow.Client,
 	npQuerier querier.AgentNetworkPolicyInfoQuerier,
+	egressQuerier querier.EgressQuerier,
 	ovsBridgeClient ovsconfig.OVSBridgeClient,
 	interfaceStore interfacestore.InterfaceStore,
 	networkConfig *config.NetworkConfig,
@@ -130,6 +132,7 @@ func NewTraceflowController(
 		ovsBridgeClient:       ovsBridgeClient,
 		ofClient:              client,
 		networkPolicyQuerier:  npQuerier,
+		egressQuerier:         egressQuerier,
 		interfaceStore:        interfaceStore,
 		networkConfig:         networkConfig,
 		nodeConfig:            nodeConfig,

--- a/pkg/agent/openflow/client_test.go
+++ b/pkg/agent/openflow/client_test.go
@@ -1218,7 +1218,7 @@ func Test_client_InstallPodSNATFlows(t *testing.T) {
 		{
 			name: "SNAT on Remote",
 			expectedFlows: []string{
-				"cookie=0x1040000000000, table=EgressMark, priority=200,ip,in_port=100 actions=set_field:0a:00:00:00:00:01->eth_src,set_field:aa:bb:cc:dd:ee:ff->eth_dst,set_field:192.168.77.101->tun_dst,set_field:0x10/0xf0->reg0,goto_table:L2ForwardingCalc",
+				"cookie=0x1040000000000, table=EgressMark, priority=200,ip,in_port=100 actions=set_field:0a:00:00:00:00:01->eth_src,set_field:aa:bb:cc:dd:ee:ff->eth_dst,set_field:192.168.77.101->tun_dst,set_field:0x10/0xf0->reg0,set_field:0x40000/0x40000->reg0,goto_table:L2ForwardingCalc",
 			},
 		},
 	}

--- a/pkg/agent/openflow/fields.go
+++ b/pkg/agent/openflow/fields.go
@@ -80,6 +80,8 @@ var (
 	CustomReasonDenyRegMark    = binding.NewRegMark(CustomReasonField, CustomReasonDeny)
 	CustomReasonDNSRegMark     = binding.NewRegMark(CustomReasonField, CustomReasonDNS)
 	CustomReasonIGMPRegMark    = binding.NewRegMark(CustomReasonField, CustomReasonIGMP)
+	// reg0[18]: Mark to indicate remote SNAT for Egress.
+	RemoteSNATRegMark = binding.NewOneBitRegMark(0, 18)
 
 	// reg1(NXM_NX_REG1)
 	// Field to cache the ofPort of the OVS interface where to output packet.

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -2186,7 +2186,7 @@ func (f *featureEgress) snatRuleFlow(ofPort uint32, snatIP net.IP, snatMark uint
 		Action().SetSrcMAC(localGatewayMAC).
 		Action().SetDstMAC(GlobalVirtualMAC).
 		Action().SetTunnelDst(snatIP). // Set tunnel destination to the SNAT IP.
-		Action().LoadRegMark(ToTunnelRegMark).
+		Action().LoadRegMark(ToTunnelRegMark, RemoteSNATRegMark).
 		Action().GotoStage(stageSwitching).
 		Done()
 }

--- a/pkg/apis/crd/v1alpha1/types.go
+++ b/pkg/apis/crd/v1alpha1/types.go
@@ -38,6 +38,7 @@ const (
 	ComponentRouting       TraceflowComponent = "Routing"
 	ComponentNetworkPolicy TraceflowComponent = "NetworkPolicy"
 	ComponentForwarding    TraceflowComponent = "Forwarding"
+	ComponentEgress        TraceflowComponent = "Egress"
 )
 
 type TraceflowAction string
@@ -51,6 +52,8 @@ const (
 	// ActionForwardedOutOfOverlay indicates that the packet has been forwarded out of the network
 	// managed by Antrea. This indicates that the Traceflow request can be considered complete.
 	ActionForwardedOutOfOverlay TraceflowAction = "ForwardedOutOfOverlay"
+	ActionMarkedForSNAT         TraceflowAction = "MarkedForSNAT"
+	ActionForwardedToEgressNode TraceflowAction = "ForwardedToEgressNode"
 )
 
 // List the supported protocols and their codes in traceflow.
@@ -264,6 +267,8 @@ type Observation struct {
 	DstMAC string `json:"dstMAC,omitempty" yaml:"dstMAC,omitempty"`
 	// NetworkPolicy is the combination of Namespace and NetworkPolicyName.
 	NetworkPolicy string `json:"networkPolicy,omitempty" yaml:"networkPolicy,omitempty"`
+	// Egress is the name of the Egress.
+	Egress string `json:"egress,omitempty" yaml:"egress,omitempty"`
 	// TTL is the observation TTL.
 	TTL int32 `json:"ttl,omitempty" yaml:"ttl,omitempty"`
 	// TranslatedSrcIP is the translated source IP.
@@ -272,6 +277,7 @@ type Observation struct {
 	TranslatedDstIP string `json:"translatedDstIP,omitempty" yaml:"translatedDstIP,omitempty"`
 	// TunnelDstIP is the tunnel destination IP.
 	TunnelDstIP string `json:"tunnelDstIP,omitempty" yaml:"tunnelDstIP,omitempty"`
+	EgressIP    string `json:"egressIP,omitempty" yaml:"egressIP,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/graphviz/traceflow.go
+++ b/pkg/graphviz/traceflow.go
@@ -201,6 +201,12 @@ func getTraceflowMessage(o *crdv1alpha1.Observation, spec *crdv1alpha1.Traceflow
 	if o.Action != crdv1alpha1.ActionDropped && len(o.TunnelDstIP) > 0 {
 		str += "\nTunnel Destination IP : " + o.TunnelDstIP
 	}
+	if o.Action != crdv1alpha1.ActionDropped && len(o.EgressIP) > 0 {
+		str += "\nEgress IP : " + o.EgressIP
+	}
+	if o.Action != crdv1alpha1.ActionDropped && len(o.Egress) > 0 {
+		str += "\nEgress : " + o.Egress
+	}
 	return str
 }
 

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -60,6 +60,11 @@ type ControllerNetworkPolicyInfoQuerier interface {
 	GetConnectedAgentNum() int
 }
 
+type EgressQuerier interface {
+	GetEgressIPByMark(mark uint32) (string, error)
+	GetEgress(podNamespace, podName string) (string, error)
+}
+
 // GetSelfPod gets current pod.
 func GetSelfPod() v1.ObjectReference {
 	podName := env.GetPodName()

--- a/test/integration/agent/openflow_test.go
+++ b/test/integration/agent/openflow_test.go
@@ -1701,7 +1701,7 @@ func prepareEgressMarkFlows(snatIP net.IP, mark, podOFPort, podOFPortRemote uint
 				},
 				{
 					MatchStr: fmt.Sprintf("priority=200,%s,in_port=%d", ipProtoStr, podOFPortRemote),
-					ActStr:   fmt.Sprintf("set_field:%s->eth_src,set_field:%s->eth_dst,set_field:%s->%s,set_field:0x10/0xf0->reg0,goto_table:L2ForwardingCalc", localGwMAC.String(), vMAC.String(), snatIP, tunDstFieldName),
+					ActStr:   fmt.Sprintf("set_field:%s->eth_src,set_field:%s->eth_dst,set_field:%s->%s,set_field:0x10/0xf0->reg0,set_field:0x40000/0x40000->reg0,goto_table:L2ForwardingCalc", localGwMAC.String(), vMAC.String(), snatIP, tunDstFieldName),
 				},
 			},
 		},


### PR DESCRIPTION
Add an Observation in result of Traceflow for Egress which
include Egress component, two TraceflowAction, Egress IP
and Egress name.

Add a mark `RemoteSNATRegMark` to indicate remote SNAT for
remote Egress traffic. This mark helps to distinguish this traffic from
Inter-Node Pod-to-Pod traffic on source Node when Egress IP is 
equal to a remote Node IP (static Egress).

Add e2e test for Egress in Traceflow for two cases.
1. Egress from local Node.
2. Egress from remote Node.

Add unit tests for this patch.

Fixes #2247

Signed-off-by: Kumar Atish <atish.iaf@gmail.com>