### PR TITLE
Update Precedence config and resources output

### DIFF
--- a/docs/multicluster/quick-start.md
+++ b/docs/multicluster/quick-start.md
@@ -56,7 +56,7 @@ Namepsace `kube-system`.
 ```bash
 $kubectl apply -f https://github.com/antrea-io/antrea/releases/download/$TAG/antrea-multicluster-leader-global.yml
 $kubectl create ns antrea-multicluster
-$kubectl apply -f https://github.com/antrea-io/antrea/releases/download/$TAG/antrea-multicluster-leader-namespaced.yml > antrea-multicluster-leader-namespaced.yml
+$kubectl apply -f https://github.com/antrea-io/antrea/releases/download/$TAG/antrea-multicluster-leader-namespaced.yml
 $kubectl apply -f https://github.com/antrea-io/antrea/releases/download/$TAG/antrea-multicluster-member.yml
 ```
 

--- a/multicluster/apis/multicluster/v1alpha1/multiclusterconfig_types.go
+++ b/multicluster/apis/multicluster/v1alpha1/multiclusterconfig_types.go
@@ -25,8 +25,10 @@ import (
 type Precedence string
 
 const (
-	PrecedencePrivate = "private"
-	PrecedencePublic  = "public"
+	PrecedencePrivate  = "private"
+	PrecedencePublic   = "public"
+	PrecedenceInternal = "internal"
+	PrecedenceExternal = "external"
 )
 
 //+kubebuilder:object:root=true

--- a/multicluster/controllers/multicluster/leader_clusterset_controller.go
+++ b/multicluster/controllers/multicluster/leader_clusterset_controller.go
@@ -158,14 +158,14 @@ func (r *LeaderClusterSetReconciler) runBackgroundTasks() {
 }
 
 // updateStatus updates ClusterSet Status as follows:
-// 1. TotalClusters is the number of Leader and Member clusters
-//    in the ClusterSet resource last processed.
+// 1. TotalClusters is the number of member clusters in the
+//    ClusterSet resource last processed.
 // 2. ObservedGeneration is the Generation from the last processed
 //    ClusterSet resource.
 // 3. Individual cluster status is obtained from MemberClusterAnnounce
 //    controller.
-// 3. ReadyClusters is the number of clusters with "Ready" = "True"
-// 4. Overall condition of the ClusterSet is also computed as follows:
+// 4. ReadyClusters is the number of member clusters with "Ready" = "True"
+// 5. Overall condition of the ClusterSet is also computed as follows:
 //    a. "Ready" = "True" if all clusters have "Ready" = "True".
 //       Message & Reason will be absent.
 //    b. "Ready" = "Unknown" if all clusters have "Ready" = "Unknown".
@@ -184,7 +184,7 @@ func (r *LeaderClusterSetReconciler) updateStatus() {
 	}
 
 	status := multiclusterv1alpha1.ClusterSetStatus{}
-	status.TotalClusters = int32(len(r.clusterSetConfig.Spec.Members) + len(r.clusterSetConfig.Spec.Leaders))
+	status.TotalClusters = int32(len(r.clusterSetConfig.Spec.Members))
 	status.ObservedGeneration = r.clusterSetConfig.Generation
 	clusterStatues := r.StatusManager.GetMemberClusterStatuses()
 	status.ClusterStatuses = clusterStatues

--- a/multicluster/controllers/multicluster/leader_clusterset_controller_test.go
+++ b/multicluster/controllers/multicluster/leader_clusterset_controller_test.go
@@ -233,7 +233,7 @@ func TestLeaderClusterStatus(t *testing.T) {
 	actualStatus := clusterSet.Status
 	expectedStatus := mcsv1alpha1.ClusterSetStatus{
 		ObservedGeneration: 1,
-		TotalClusters:      3,
+		TotalClusters:      2,
 		ClusterStatuses:    statues,
 		Conditions: []mcsv1alpha1.ClusterSetCondition{
 			{

--- a/multicluster/controllers/multicluster/member_clusterset_controller.go
+++ b/multicluster/controllers/multicluster/member_clusterset_controller.go
@@ -241,7 +241,7 @@ func (r *MemberClusterSetReconciler) updateStatus() {
 	}
 
 	status := multiclusterv1alpha1.ClusterSetStatus{}
-	status.TotalClusters = int32(len(r.clusterSetConfig.Spec.Members) + len(r.clusterSetConfig.Spec.Leaders))
+	status.TotalClusters = int32(len(r.clusterSetConfig.Spec.Members))
 	status.ObservedGeneration = r.clusterSetConfig.Generation
 	status.ClusterStatuses = r.remoteCommonAreaManager.GetMemberClusterStatues()
 

--- a/multicluster/controllers/multicluster/node_controller.go
+++ b/multicluster/controllers/multicluster/node_controller.go
@@ -55,7 +55,7 @@ func NewNodeReconciler(
 	namespace string,
 	precedence mcsv1alpha1.Precedence) *NodeReconciler {
 	if string(precedence) == "" {
-		precedence = mcsv1alpha1.PrecedencePrivate
+		precedence = mcsv1alpha1.PrecedenceInternal
 	}
 	reconciler := &NodeReconciler{
 		Client:     client,
@@ -138,12 +138,13 @@ func (r *NodeReconciler) getGatawayNodeIP(node *corev1.Node) (string, string, er
 	var gatewayIP, internalIP string
 	for _, addr := range node.Status.Addresses {
 		if addr.Type == corev1.NodeInternalIP {
-			if r.precedence == mcsv1alpha1.PrecedencePrivate {
+			if r.precedence == mcsv1alpha1.PrecedencePrivate || r.precedence == mcsv1alpha1.PrecedenceInternal {
 				gatewayIP = addr.Address
 			}
 			internalIP = addr.Address
 		}
-		if r.precedence == mcsv1alpha1.PrecedencePublic && addr.Type == corev1.NodeExternalIP {
+		if (r.precedence == mcsv1alpha1.PrecedencePublic || r.precedence == mcsv1alpha1.PrecedenceExternal) &&
+			addr.Type == corev1.NodeExternalIP {
 			gatewayIP = addr.Address
 		}
 	}


### PR DESCRIPTION
1. Update GatewayIPPrecedence to support "external/internal" option
   which is equal to `public/private`.
2. Update MC doc to add more columns info.
3. Exclude leader in the totalClusters in ClusterSet status since MC
   supports one leader only.

Signed-off-by: Lan Luo <luola@vmware.com>