### PR TITLE
Remove concurrent limit for integration jobs

### DIFF
--- a/ci/jenkins/jobs/job-templates.yaml
+++ b/ci/jenkins/jobs/job-templates.yaml
@@ -113,12 +113,6 @@
         num-to-keep: 30
     - github:
         url: 'https://github.com/{org_repo}'
-    - throttle:
-        max-per-node: 1
-        max-total: 0
-        categories: '{throttle_concurrent_builds_category}'
-        option: category
-        enabled: '{throttle_concurrent_builds_enabled}'
     publishers: '{publishers}'
     scm:
     - git:

--- a/ci/jenkins/jobs/projects.yaml
+++ b/ci/jenkins/jobs/projects.yaml
@@ -148,9 +148,6 @@
           builders:
           - builder-integration
           trigger_phrase: null
-          throttle_concurrent_builds_category:
-            - integration
-          throttle_concurrent_builds_enabled: 'true'
           white_list_target_branches: []
           allow_whitelist_orgs_as_admins: false
           admin_list: []
@@ -194,9 +191,6 @@
           builders:
           - builder-integration
           trigger_phrase: ^(?!Thanks for your PR).*/test-integration.*
-          throttle_concurrent_builds_category:
-            - integration
-          throttle_concurrent_builds_enabled: 'true'
           white_list_target_branches: []
           allow_whitelist_orgs_as_admins: true
           admin_list: '{antrea_admin_list}'
@@ -263,9 +257,6 @@
           builders:
           - builder-multicluster-integration
           trigger_phrase: ^(?!Thanks for your PR).*/test-multicluster-integration.*
-          throttle_concurrent_builds_category:
-            - integration
-          throttle_concurrent_builds_enabled: 'true'
           white_list_target_branches: []
           allow_whitelist_orgs_as_admins: true
           admin_list: '{antrea_admin_list}'


### PR DESCRIPTION
The concurrent conflict is mainly introduced by multi-cluster integration test
since it's not running inside a docker container before. We can remove the
limitation since it's already supported to run multi-cluster integration
in a docker container.

Signed-off-by: Lan Luo <luola@vmware.com>