### PR TITLE
Refactor Pod creation for e2e tests

### DIFF
--- a/multicluster/test/e2e/framework.go
+++ b/multicluster/test/e2e/framework.go
@@ -155,7 +155,12 @@ func (data *MCTestData) deleteTestNamespaces(timeout time.Duration) error {
 func (data *MCTestData) createPod(clusterName, name, nodeName, namespace, ctrName, image string, command []string,
 	args []string, env []corev1.EnvVar, ports []corev1.ContainerPort, hostNetwork bool, mutateFunc func(pod *corev1.Pod)) error {
 	if d, ok := data.clusterTestDataMap[clusterName]; ok {
-		return d.CreatePodOnNodeInNamespace(name, namespace, nodeName, ctrName, image, command, args, env, ports, hostNetwork, mutateFunc)
+		return antreae2e.NewPodBuilder(name, namespace, image).
+			OnNode(nodeName).WithContainerName(ctrName).
+			WithCommand(command).WithArgs(args).
+			WithEnv(env).WithPorts(ports).WithHostNetwork(hostNetwork).
+			WithMutateFunc(mutateFunc).
+			Create(&d)
 	}
 	return fmt.Errorf("clusterName %s not found", clusterName)
 }

--- a/test/e2e/bandwidth_test.go
+++ b/test/e2e/bandwidth_test.go
@@ -68,14 +68,13 @@ func TestBenchmarkBandwidth(t *testing.T) {
 
 // testBenchmarkBandwidthIntraNode runs the bandwidth benchmark between Pods on same node.
 func testBenchmarkBandwidthIntraNode(t *testing.T, data *TestData) {
-
-	if err := data.createPodOnNode("perftest-a", data.testNamespace, controlPlaneNodeName(), perftoolImage, nil, nil, nil, nil, false, nil); err != nil {
+	if err := NewPodBuilder("perftest-a", data.testNamespace, perftoolImage).OnNode(controlPlaneNodeName()).Create(data); err != nil {
 		t.Fatalf("Error when creating the perftest client Pod: %v", err)
 	}
 	if err := data.podWaitForRunning(defaultTimeout, "perftest-a", data.testNamespace); err != nil {
 		t.Fatalf("Error when waiting for the perftest client Pod: %v", err)
 	}
-	if err := data.createPodOnNode("perftest-b", data.testNamespace, controlPlaneNodeName(), perftoolImage, nil, nil, nil, []v1.ContainerPort{{Protocol: v1.ProtocolTCP, ContainerPort: iperfPort}}, false, nil); err != nil {
+	if err := NewPodBuilder("perftest-b", data.testNamespace, perftoolImage).OnNode(controlPlaneNodeName()).WithPorts([]v1.ContainerPort{{Protocol: v1.ProtocolTCP, ContainerPort: iperfPort}}).Create(data); err != nil {
 		t.Fatalf("Error when creating the perftest server Pod: %v", err)
 	}
 	podBIPs, err := data.podWaitForIPs(defaultTimeout, "perftest-b", data.testNamespace)
@@ -96,13 +95,13 @@ func benchmarkBandwidthService(t *testing.T, endpointNode, clientNode string, da
 	if err != nil {
 		t.Fatalf("Error when creating perftest service: %v", err)
 	}
-	if err := data.createPodOnNode("perftest-a", data.testNamespace, clientNode, perftoolImage, nil, nil, nil, nil, false, nil); err != nil {
+	if err := NewPodBuilder("perftest-a", data.testNamespace, perftoolImage).OnNode(clientNode).Create(data); err != nil {
 		t.Fatalf("Error when creating the perftest client Pod: %v", err)
 	}
 	if err := data.podWaitForRunning(defaultTimeout, "perftest-a", data.testNamespace); err != nil {
 		t.Fatalf("Error when waiting for the perftest client Pod: %v", err)
 	}
-	if err := data.createPodOnNode("perftest-b", data.testNamespace, endpointNode, perftoolImage, nil, nil, nil, []v1.ContainerPort{{Protocol: v1.ProtocolTCP, ContainerPort: iperfPort}}, false, nil); err != nil {
+	if err := NewPodBuilder("perftest-b", data.testNamespace, perftoolImage).OnNode(clientNode).WithPorts([]v1.ContainerPort{{Protocol: v1.ProtocolTCP, ContainerPort: iperfPort}}).Create(data); err != nil {
 		t.Fatalf("Error when creating the perftest server Pod: %v", err)
 	}
 	if err := data.podWaitForRunning(defaultTimeout, "perftest-b", data.testNamespace); err != nil {
@@ -159,22 +158,22 @@ func testPodTrafficShaping(t *testing.T, data *TestData) {
 		t.Run(tt.name, func(t *testing.T) {
 			clientPodName := fmt.Sprintf("client-a-%d", i)
 			serverPodName := fmt.Sprintf("server-a-%d", i)
-			if err := data.createPodOnNode(clientPodName, data.testNamespace, nodeName, perftoolImage, nil, nil, nil, nil, false, func(pod *v1.Pod) {
-				pod.Annotations = map[string]string{
+			if err := NewPodBuilder(clientPodName, data.testNamespace, perftoolImage).OnNode(nodeName).WithAnnotations(
+				map[string]string{
 					"kubernetes.io/egress-bandwidth": fmt.Sprintf("%dM", tt.clientEgressBandwidth),
-				}
-			}); err != nil {
+				},
+			).Create(data); err != nil {
 				t.Fatalf("Error when creating the perftest client Pod: %v", err)
 			}
 			defer deletePodWrapper(t, data, data.testNamespace, clientPodName)
 			if err := data.podWaitForRunning(defaultTimeout, clientPodName, data.testNamespace); err != nil {
 				t.Fatalf("Error when waiting for the perftest client Pod: %v", err)
 			}
-			if err := data.createPodOnNode(serverPodName, data.testNamespace, nodeName, perftoolImage, nil, nil, nil, []v1.ContainerPort{{Protocol: v1.ProtocolTCP, ContainerPort: iperfPort}}, false, func(pod *v1.Pod) {
-				pod.Annotations = map[string]string{
+			if err := NewPodBuilder(serverPodName, data.testNamespace, perftoolImage).OnNode(nodeName).WithPorts([]v1.ContainerPort{{Protocol: v1.ProtocolTCP, ContainerPort: iperfPort}}).WithAnnotations(
+				map[string]string{
 					"kubernetes.io/ingress-bandwidth": fmt.Sprintf("%dM", tt.serverIngressBandwidth),
-				}
-			}); err != nil {
+				},
+			).Create(data); err != nil {
 				t.Fatalf("Error when creating the perftest server Pod: %v", err)
 			}
 			defer deletePodWrapper(t, data, data.testNamespace, serverPodName)

--- a/test/e2e/egress_test.go
+++ b/test/e2e/egress_test.go
@@ -125,10 +125,7 @@ ip netns exec %[1]s ip link set dev %[1]s-a up && \
 ip netns exec %[1]s ip route replace default via %[3]s && \
 ip netns exec %[1]s /agnhost netexec
 `, tt.fakeServer, tt.serverIP, tt.localIP0, tt.localIP1, tt.ipMaskLen)
-			if err := data.createPodOnNode(tt.fakeServer, data.testNamespace, egressNode, agnhostImage, []string{"sh", "-c", cmd}, nil, nil, nil, true, func(pod *v1.Pod) {
-				privileged := true
-				pod.Spec.Containers[0].SecurityContext = &v1.SecurityContext{Privileged: &privileged}
-			}); err != nil {
+			if err := NewPodBuilder(tt.fakeServer, data.testNamespace, agnhostImage).OnNode(egressNode).WithCommand([]string{"sh", "-c", cmd}).InHostNetwork().Privileged().Create(data); err != nil {
 				t.Fatalf("Failed to create server Pod: %v", err)
 			}
 			defer deletePodWrapper(t, data, data.testNamespace, tt.fakeServer)
@@ -239,9 +236,7 @@ ip netns exec %[1]s /agnhost netexec
 				clientIPStr = fmt.Sprintf("[%s]", clientIPStr)
 			}
 			cmd = fmt.Sprintf("wget -T 3 -O - %s:8080/clientip | grep %s:", serverIPStr, clientIPStr)
-			if err := data.createPodOnNode(initialIPChecker, data.testNamespace, egressNode, busyboxImage, []string{"sh", "-c", cmd}, nil, nil, nil, false, func(pod *v1.Pod) {
-				pod.Spec.RestartPolicy = v1.RestartPolicyNever
-			}); err != nil {
+			if err := NewPodBuilder(initialIPChecker, data.testNamespace, agnhostImage).OnNode(egressNode).WithCommand([]string{"sh", "-c", cmd}).Create(data); err != nil {
 				t.Fatalf("Failed to create Pod initial-ip-checker: %v", err)
 			}
 			defer data.DeletePod(data.testNamespace, initialIPChecker)

--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -228,7 +228,7 @@ func setupTestForFlowAggregator(tb testing.TB) (*TestData, bool, bool, error) {
 		return testData, v4Enabled, v6Enabled, err
 	}
 	// Create pod using ipfix collector image
-	if err = testData.createPodOnNode("ipfix-collector", testData.testNamespace, "", ipfixCollectorImage, nil, nil, nil, nil, true, nil); err != nil {
+	if err := NewPodBuilder("ipfix-collector", testData.testNamespace, ipfixCollectorImage).InHostNetwork().Create(testData); err != nil {
 		tb.Errorf("Error when creating the ipfix collector Pod: %v", err)
 	}
 	ipfixCollectorIP, err := testData.podWaitForIPs(defaultTimeout, "ipfix-collector", testData.testNamespace)

--- a/test/e2e/flowaggregator_test.go
+++ b/test/e2e/flowaggregator_test.go
@@ -1269,7 +1269,11 @@ func deployDenyNetworkPolicies(t *testing.T, data *TestData, pod1, pod2 string) 
 }
 
 func createPerftestPods(data *TestData) (podAIPs *PodIPs, podBIPs *PodIPs, podCIPs *PodIPs, podDIPs *PodIPs, podEIPs *PodIPs, err error) {
-	if err := data.createPodOnNode("perftest-a", data.testNamespace, controlPlaneNodeName(), perftoolImage, nil, nil, nil, nil, false, nil); err != nil {
+	create := func(name string, nodeName string, ports []corev1.ContainerPort) error {
+		return NewPodBuilder(name, data.testNamespace, perftoolImage).OnNode(nodeName).WithPorts(ports).Create(data)
+	}
+
+	if err := create("perftest-a", controlPlaneNodeName(), nil); err != nil {
 		return nil, nil, nil, nil, nil, fmt.Errorf("Error when creating the perftest client Pod: %v", err)
 	}
 	podAIPs, err = data.podWaitForIPs(defaultTimeout, "perftest-a", data.testNamespace)
@@ -1277,7 +1281,7 @@ func createPerftestPods(data *TestData) (podAIPs *PodIPs, podBIPs *PodIPs, podCI
 		return nil, nil, nil, nil, nil, fmt.Errorf("Error when waiting for the perftest client Pod: %v", err)
 	}
 
-	if err := data.createPodOnNode("perftest-b", data.testNamespace, controlPlaneNodeName(), perftoolImage, nil, nil, nil, []corev1.ContainerPort{{Protocol: corev1.ProtocolTCP, ContainerPort: iperfPort}}, false, nil); err != nil {
+	if err := create("perftest-b", controlPlaneNodeName(), []corev1.ContainerPort{{Protocol: corev1.ProtocolTCP, ContainerPort: iperfPort}}); err != nil {
 		return nil, nil, nil, nil, nil, fmt.Errorf("Error when creating the perftest server Pod: %v", err)
 	}
 	podBIPs, err = data.podWaitForIPs(defaultTimeout, "perftest-b", data.testNamespace)
@@ -1285,7 +1289,7 @@ func createPerftestPods(data *TestData) (podAIPs *PodIPs, podBIPs *PodIPs, podCI
 		return nil, nil, nil, nil, nil, fmt.Errorf("Error when getting the perftest server Pod's IPs: %v", err)
 	}
 
-	if err := data.createPodOnNode("perftest-c", data.testNamespace, workerNodeName(1), perftoolImage, nil, nil, nil, []corev1.ContainerPort{{Protocol: corev1.ProtocolTCP, ContainerPort: iperfPort}}, false, nil); err != nil {
+	if err := create("perftest-c", workerNodeName(1), []corev1.ContainerPort{{Protocol: corev1.ProtocolTCP, ContainerPort: iperfPort}}); err != nil {
 		return nil, nil, nil, nil, nil, fmt.Errorf("Error when creating the perftest server Pod: %v", err)
 	}
 	podCIPs, err = data.podWaitForIPs(defaultTimeout, "perftest-c", data.testNamespace)
@@ -1293,7 +1297,7 @@ func createPerftestPods(data *TestData) (podAIPs *PodIPs, podBIPs *PodIPs, podCI
 		return nil, nil, nil, nil, nil, fmt.Errorf("Error when getting the perftest server Pod's IPs: %v", err)
 	}
 
-	if err := data.createPodOnNode("perftest-d", data.testNamespace, controlPlaneNodeName(), perftoolImage, nil, nil, nil, []corev1.ContainerPort{{Protocol: corev1.ProtocolTCP, ContainerPort: iperfPort}}, false, nil); err != nil {
+	if err := create("perftest-d", controlPlaneNodeName(), []corev1.ContainerPort{{Protocol: corev1.ProtocolTCP, ContainerPort: iperfPort}}); err != nil {
 		return nil, nil, nil, nil, nil, fmt.Errorf("Error when creating the perftest server Pod: %v", err)
 	}
 	podDIPs, err = data.podWaitForIPs(defaultTimeout, "perftest-d", data.testNamespace)
@@ -1301,7 +1305,7 @@ func createPerftestPods(data *TestData) (podAIPs *PodIPs, podBIPs *PodIPs, podCI
 		return nil, nil, nil, nil, nil, fmt.Errorf("Error when getting the perftest server Pod's IPs: %v", err)
 	}
 
-	if err := data.createPodOnNode("perftest-e", data.testNamespace, workerNodeName(1), perftoolImage, nil, nil, nil, []corev1.ContainerPort{{Protocol: corev1.ProtocolTCP, ContainerPort: iperfPort}}, false, nil); err != nil {
+	if err := create("perftest-e", workerNodeName(1), []corev1.ContainerPort{{Protocol: corev1.ProtocolTCP, ContainerPort: iperfPort}}); err != nil {
 		return nil, nil, nil, nil, nil, fmt.Errorf("Error when creating the perftest server Pod: %v", err)
 	}
 	podEIPs, err = data.podWaitForIPs(defaultTimeout, "perftest-e", data.testNamespace)

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -1100,58 +1100,150 @@ func getImageName(uri string) string {
 	return paths[len(paths)-1]
 }
 
-// createPodOnNode creates a pod in the test namespace with a container whose type is decided by imageName.
-// Pod will be scheduled on the specified Node (if nodeName is not empty).
-// mutateFunc can be used to customize the Pod if the other parameters don't meet the requirements.
-func (data *TestData) createPodOnNode(name string, ns string, nodeName string, image string, command []string, args []string, env []corev1.EnvVar, ports []corev1.ContainerPort, hostNetwork bool, mutateFunc func(*corev1.Pod)) error {
-	// image could be a fully qualified URI which can't be used as container name and label value,
-	// extract the image name from it.
-	imageName := getImageName(image)
-	return data.CreatePodOnNodeInNamespace(name, ns, nodeName, imageName, image, command, args, env, ports, hostNetwork, mutateFunc)
+type PodBuilder struct {
+	Name               string
+	Namespace          string
+	Image              string
+	ContainerName      string
+	Command            []string
+	Args               []string
+	Env                []corev1.EnvVar
+	Ports              []corev1.ContainerPort
+	HostNetwork        bool
+	IsPrivileged       bool
+	ServiceAccountName string
+	Annotations        map[string]string
+	Labels             map[string]string
+	NodeName           string
+	MutateFunc         func(*corev1.Pod)
 }
 
-// CreatePodOnNodeInNamespace creates a pod in the provided namespace with a container whose type is decided by imageName.
-// Pod will be scheduled on the specified Node (if nodeName is not empty).
-// mutateFunc can be used to customize the Pod if the other parameters don't meet the requirements.
-func (data *TestData) CreatePodOnNodeInNamespace(name, ns string, nodeName, ctrName string, image string, command []string, args []string, env []corev1.EnvVar, ports []corev1.ContainerPort, hostNetwork bool, mutateFunc func(*corev1.Pod)) error {
+func NewPodBuilder(name, ns, image string) *PodBuilder {
+	return &PodBuilder{
+		Name:      name,
+		Namespace: ns,
+		Image:     image,
+	}
+}
+
+func (b *PodBuilder) WithContainerName(ctrName string) *PodBuilder {
+	b.ContainerName = ctrName
+	return b
+}
+
+func (b *PodBuilder) WithCommand(command []string) *PodBuilder {
+	b.Command = command
+	return b
+}
+
+func (b *PodBuilder) WithArgs(args []string) *PodBuilder {
+	b.Args = args
+	return b
+}
+
+func (b *PodBuilder) WithEnv(env []corev1.EnvVar) *PodBuilder {
+	b.Env = env
+	return b
+}
+
+func (b *PodBuilder) WithPorts(ports []corev1.ContainerPort) *PodBuilder {
+	b.Ports = ports
+	return b
+}
+
+func (b *PodBuilder) WithHostNetwork(v bool) *PodBuilder {
+	b.HostNetwork = v
+	return b
+}
+
+func (b *PodBuilder) InHostNetwork() *PodBuilder {
+	return b.WithHostNetwork(true)
+}
+
+func (b *PodBuilder) Privileged() *PodBuilder {
+	b.IsPrivileged = true
+	return b
+}
+
+func (b *PodBuilder) WithServiceAccountName(name string) *PodBuilder {
+	b.ServiceAccountName = name
+	return b
+}
+
+func (b *PodBuilder) WithAnnotations(annotations map[string]string) *PodBuilder {
+	b.Annotations = annotations
+	return b
+}
+
+func (b *PodBuilder) WithLabels(labels map[string]string) *PodBuilder {
+	b.Labels = labels
+	return b
+}
+
+func (b *PodBuilder) OnNode(nodeName string) *PodBuilder {
+	b.NodeName = nodeName
+	return b
+}
+
+func (b *PodBuilder) WithMutateFunc(f func(*corev1.Pod)) *PodBuilder {
+	b.MutateFunc = f
+	return b
+}
+
+func (b *PodBuilder) Create(data *TestData) error {
+	containerName := b.ContainerName
+	if containerName == "" {
+		containerName = getImageName(b.Image)
+	}
 	podSpec := corev1.PodSpec{
 		Containers: []corev1.Container{
 			{
-				Name:            ctrName,
-				Image:           image,
+				Name:            containerName,
+				Image:           b.Image,
 				ImagePullPolicy: corev1.PullIfNotPresent,
-				Command:         command,
-				Args:            args,
-				Env:             env,
-				Ports:           ports,
+				Command:         b.Command,
+				Args:            b.Args,
+				Env:             b.Env,
+				Ports:           b.Ports,
+				SecurityContext: &corev1.SecurityContext{
+					Privileged: &b.IsPrivileged,
+				},
 			},
 		},
-		RestartPolicy: corev1.RestartPolicyNever,
-		HostNetwork:   hostNetwork,
+		RestartPolicy:      corev1.RestartPolicyNever,
+		HostNetwork:        b.HostNetwork,
+		ServiceAccountName: b.ServiceAccountName,
 	}
-	if nodeName != "" {
+	if b.NodeName != "" {
 		podSpec.NodeSelector = map[string]string{
-			"kubernetes.io/hostname": nodeName,
+			"kubernetes.io/hostname": b.NodeName,
 		}
 	}
-	if nodeName == controlPlaneNodeName() {
+	if b.NodeName == controlPlaneNodeName() {
 		// tolerate NoSchedule taint if we want Pod to run on control-plane Node
 		podSpec.Tolerations = controlPlaneNoScheduleTolerations()
 	}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
+			Name:        b.Name,
+			Annotations: map[string]string{},
 			Labels: map[string]string{
-				"antrea-e2e": name,
-				"app":        ctrName,
+				"antrea-e2e": b.Name,
+				"app":        containerName,
 			},
 		},
 		Spec: podSpec,
 	}
-	if mutateFunc != nil {
-		mutateFunc(pod)
+	for k, v := range b.Annotations {
+		pod.Annotations[k] = v
 	}
-	if _, err := data.clientset.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{}); err != nil {
+	for k, v := range b.Labels {
+		pod.Labels[k] = v
+	}
+	if b.MutateFunc != nil {
+		b.MutateFunc(pod)
+	}
+	if _, err := data.clientset.CoreV1().Pods(b.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{}); err != nil {
 		return err
 	}
 	return nil
@@ -1160,41 +1252,35 @@ func (data *TestData) CreatePodOnNodeInNamespace(name, ns string, nodeName, ctrN
 // createBusyboxPodOnNode creates a Pod in the test namespace with a single busybox container. The
 // Pod will be scheduled on the specified Node (if nodeName is not empty).
 func (data *TestData) createBusyboxPodOnNode(name string, ns string, nodeName string, hostNetwork bool) error {
-	sleepDuration := 3600 // seconds
-	return data.createPodOnNode(name, ns, nodeName, busyboxImage, []string{"sleep", strconv.Itoa(sleepDuration)}, nil, nil, nil, hostNetwork, nil)
+	return NewPodBuilder(name, ns, busyboxImage).OnNode(nodeName).WithCommand([]string{"sleep", "3600"}).WithHostNetwork(hostNetwork).Create(data)
 }
 
 // createMcJoinPodOnNode creates a Pod in the test namespace with a single mcjoin container. The
 // Pod will be scheduled on the specified Node (if nodeName is not empty).
 func (data *TestData) createMcJoinPodOnNode(name string, ns string, nodeName string, hostNetwork bool) error {
-	sleepDuration := 3600 // seconds
-	return data.createPodOnNode(name, ns, nodeName, mcjoinImage, []string{"sleep", strconv.Itoa(sleepDuration)}, nil, nil, nil, hostNetwork, nil)
+	return NewPodBuilder(name, ns, mcjoinImage).OnNode(nodeName).WithCommand([]string{"sleep", "3600"}).WithHostNetwork(hostNetwork).Create(data)
 }
 
 // createNetshootPodOnNode creates a Pod in the test namespace with a single netshoot container. The
 // Pod will be scheduled on the specified Node (if nodeName is not empty).
 func (data *TestData) createNetshootPodOnNode(name string, ns string, nodeName string, hostNetwork bool) error {
-	sleepDuration := 3600 // seconds
-	return data.createPodOnNode(name, ns, nodeName, netshootImage, []string{"sleep", strconv.Itoa(sleepDuration)}, nil, nil, nil, hostNetwork, nil)
+	return NewPodBuilder(name, ns, netshootImage).OnNode(nodeName).WithCommand([]string{"sleep", "3600"}).WithHostNetwork(hostNetwork).Create(data)
 }
 
 // createNginxPodOnNode creates a Pod in the test namespace with a single nginx container. The
 // Pod will be scheduled on the specified Node (if nodeName is not empty).
 func (data *TestData) createNginxPodOnNode(name string, ns string, nodeName string, hostNetwork bool) error {
-	var mutateImage func(*corev1.Pod)
-	mutateImage = nil
+	image := nginxImage
 	if clusterInfo.nodesOS[nodeName] == "windows" {
-		mutateImage = func(pod *corev1.Pod) {
-			pod.Spec.Containers[0].Image = iisImage
-		}
+		image = iisImage
 	}
-	return data.createPodOnNode(name, ns, nodeName, nginxImage, []string{}, nil, nil, []corev1.ContainerPort{
+	return NewPodBuilder(name, ns, image).OnNode(nodeName).WithPorts([]corev1.ContainerPort{
 		{
 			Name:          "http",
 			ContainerPort: 80,
 			Protocol:      corev1.ProtocolTCP,
 		},
-	}, hostNetwork, mutateImage)
+	}).WithHostNetwork(hostNetwork).Create(data)
 }
 
 // createServerPod creates a Pod that can listen to specified port and have named port set.
@@ -1207,7 +1293,7 @@ func (data *TestData) createServerPod(name string, ns string, portName string, p
 		// If hostPort is to be set, it must match the container port number.
 		port.HostPort = int32(portNum)
 	}
-	return data.createPodOnNode(name, ns, "", agnhostImage, nil, []string{cmd}, []corev1.EnvVar{env}, []corev1.ContainerPort{port}, hostNetwork, nil)
+	return NewPodBuilder(name, ns, agnhostImage).WithArgs([]string{cmd}).WithEnv([]corev1.EnvVar{env}).WithPorts([]corev1.ContainerPort{port}).WithHostNetwork(hostNetwork).Create(data)
 }
 
 // createCustomPod creates a Pod in given Namespace with custom labels.
@@ -1216,12 +1302,7 @@ func (data *TestData) createServerPodWithLabels(name, ns string, portNum int32, 
 	env := corev1.EnvVar{Name: fmt.Sprintf("SERVE_PORT_%d", portNum), Value: "foo"}
 	port := corev1.ContainerPort{ContainerPort: portNum}
 	containerName := fmt.Sprintf("c%v", portNum)
-	mutateLabels := func(pod *corev1.Pod) {
-		for k, v := range labels {
-			pod.Labels[k] = v
-		}
-	}
-	return data.CreatePodOnNodeInNamespace(name, ns, "", containerName, agnhostImage, cmd, nil, []corev1.EnvVar{env}, []corev1.ContainerPort{port}, false, mutateLabels)
+	return NewPodBuilder(name, ns, agnhostImage).WithContainerName(containerName).WithCommand(cmd).WithEnv([]corev1.EnvVar{env}).WithPorts([]corev1.ContainerPort{port}).WithLabels(labels).Create(data)
 }
 
 // DeletePod deletes a Pod in the test namespace.
@@ -2428,29 +2509,18 @@ func (data *TestData) copyNodeFiles(nodeName string, fileName string, covDir str
 // createAgnhostPodOnNode creates a Pod in the test namespace with a single agnhost container. The
 // Pod will be scheduled on the specified Node (if nodeName is not empty).
 func (data *TestData) createAgnhostPodOnNode(name string, ns string, nodeName string, hostNetwork bool) error {
-	sleepDuration := 3600 // seconds
-	return data.createPodOnNode(name, ns, nodeName, agnhostImage, []string{"sleep", strconv.Itoa(sleepDuration)}, nil, nil, nil, hostNetwork, nil)
+	return NewPodBuilder(name, ns, agnhostImage).OnNode(nodeName).WithCommand([]string{"sleep", "3600"}).WithHostNetwork(hostNetwork).Create(data)
 }
 
 // createAgnhostPodWithSAOnNode creates a Pod in the test namespace with a single
 // agnhost container and a specific ServiceAccount. The Pod will be scheduled on
 // the specified Node (if nodeName is not empty).
 func (data *TestData) createAgnhostPodWithSAOnNode(name string, ns string, nodeName string, hostNetwork bool, serviceAccountName string) error {
-	sleepDuration := 3600 // seconds
-	mutateFunc := func(pod *corev1.Pod) {
-		pod.Spec.ServiceAccountName = serviceAccountName
-	}
-	return data.createPodOnNode(name, ns, nodeName, agnhostImage, []string{"sleep", strconv.Itoa(sleepDuration)}, nil, nil, nil, hostNetwork, mutateFunc)
+	return NewPodBuilder(name, ns, agnhostImage).OnNode(nodeName).WithCommand([]string{"sleep", "3600"}).WithHostNetwork(hostNetwork).WithServiceAccountName(serviceAccountName).Create(data)
 }
 
 func (data *TestData) createAgnhostPodOnNodeWithAnnotations(name string, ns string, nodeName string, annotations map[string]string) error {
-	sleepDuration := 3600 // seconds
-	mutateFunc := func(pod *corev1.Pod) {
-		for k, v := range annotations {
-			pod.Annotations[k] = v
-		}
-	}
-	return data.createPodOnNode(name, ns, nodeName, agnhostImage, []string{"sleep", strconv.Itoa(sleepDuration)}, nil, nil, nil, false, mutateFunc)
+	return NewPodBuilder(name, ns, agnhostImage).OnNode(nodeName).WithCommand([]string{"sleep", "3600"}).WithAnnotations(annotations).Create(data)
 }
 
 func (data *TestData) createDaemonSet(name string, ns string, ctrName string, image string, cmd []string, args []string) (*appsv1.DaemonSet, func() error, error) {

--- a/test/e2e/nodeportlocal_test.go
+++ b/test/e2e/nodeportlocal_test.go
@@ -425,17 +425,16 @@ func NPLTestPodAddMultiPort(t *testing.T, data *TestData) {
 	expectedAnnotations := newExpectedNPLAnnotations(defaultStartPort, defaultEndPort).
 		Add(nil, 80, "tcp").Add(nil, 8080, "tcp")
 
-	podcmd := "porter"
-
+	podCmd := "porter"
 	// Creating a Pod using agnhost image to support multiple ports, instead of nginx.
-	err := testData.createPodOnNode(testPodName, data.testNamespace, node, agnhostImage, nil, []string{podcmd}, []corev1.EnvVar{
+	err := NewPodBuilder(testPodName, data.testNamespace, agnhostImage).OnNode(node).WithArgs([]string{podCmd}).WithEnv([]corev1.EnvVar{
 		{
 			Name: fmt.Sprintf("SERVE_PORT_%d", 80), Value: "foo",
 		},
 		{
 			Name: fmt.Sprintf("SERVE_PORT_%d", 8080), Value: "bar",
 		},
-	}, []corev1.ContainerPort{
+	}).WithPorts([]corev1.ContainerPort{
 		{
 			Name:          "http1",
 			ContainerPort: 80,
@@ -446,8 +445,7 @@ func NPLTestPodAddMultiPort(t *testing.T, data *TestData) {
 			ContainerPort: 8080,
 			Protocol:      corev1.ProtocolTCP,
 		},
-	}, false, nil)
-
+	}).Create(data)
 	r.NoError(err, "Error creating test Pod: %v", err)
 
 	nplAnnotations, testPodIP := getNPLAnnotations(t, testData, r, testPodName)
@@ -500,13 +498,7 @@ func NPLTestPodAddMultiProtocol(t *testing.T, data *TestData) {
 	}
 	port := corev1.ContainerPort{ContainerPort: 8080}
 	containerName := fmt.Sprintf("c%v", 8080)
-	mutateLabels := func(pod *corev1.Pod) {
-		for k, v := range selector {
-			pod.Labels[k] = v
-		}
-	}
-	err := testData.CreatePodOnNodeInNamespace(testPodName, data.testNamespace, node, containerName, agnhostImage, cmd, args, []corev1.EnvVar{}, []corev1.ContainerPort{port}, false, mutateLabels)
-
+	err := NewPodBuilder(testPodName, data.testNamespace, agnhostImage).OnNode(node).WithContainerName(containerName).WithCommand(cmd).WithArgs(args).WithPorts([]corev1.ContainerPort{port}).WithLabels(selector).Create(testData)
 	r.NoError(err, "Error creating test Pod: %v", err)
 
 	nplAnnotations, testPodIP := getNPLAnnotations(t, testData, r, testPodName)

--- a/test/e2e/service_test.go
+++ b/test/e2e/service_test.go
@@ -178,13 +178,13 @@ func (data *TestData) testNodePort(t *testing.T, isWindows bool, clientNamespace
 func (data *TestData) createAgnhostServiceAndBackendPods(t *testing.T, name, namespace string, node string, svcType corev1.ServiceType) (*corev1.Service, func()) {
 	ipProtocol := corev1.IPv4Protocol
 	args := []string{"netexec", "--http-port=80", "--udp-port=80"}
-	require.NoError(t, data.createPodOnNode(name, namespace, node, agnhostImage, []string{}, args, nil, []corev1.ContainerPort{
+	require.NoError(t, NewPodBuilder(name, namespace, agnhostImage).OnNode(node).WithArgs(args).WithPorts([]corev1.ContainerPort{
 		{
 			Name:          "http",
 			ContainerPort: 80,
 			Protocol:      corev1.ProtocolTCP,
 		},
-	}, false, nil))
+	}).Create(data))
 	podIPs, err := data.podWaitForIPs(defaultTimeout, name, namespace)
 	require.NoError(t, err)
 	t.Logf("Created service Pod IPs %v", podIPs.ipStrings)

--- a/test/e2e/traceflow_test.go
+++ b/test/e2e/traceflow_test.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"net"
 	"reflect"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -1140,10 +1139,7 @@ func testTraceflowInterNode(t *testing.T, data *TestData) {
 	// Create Service backend Pod. The "hairpin" testcases require the Service to have a single backend Pod,
 	// and no more, in order to be deterministic.
 	agnhostPodName := "agnhost"
-	mutateFunc := func(pod *corev1.Pod) {
-		pod.Labels["app"] = "agnhost-server"
-	}
-	require.NoError(t, data.createPodOnNode(agnhostPodName, data.testNamespace, node2, agnhostImage, []string{"sleep", strconv.Itoa(3600)}, nil, nil, nil, false, mutateFunc))
+	require.NoError(t, NewPodBuilder(agnhostPodName, data.testNamespace, agnhostImage).OnNode(node2).WithCommand([]string{"sleep", "3600"}).WithLabels(map[string]string{"app": "agnhost-server"}).Create(data))
 	agnhostIP, err := data.podWaitForIPs(defaultTimeout, agnhostPodName, data.testNamespace)
 	require.NoError(t, err)
 

--- a/test/e2e/trafficcontrol_test.go
+++ b/test/e2e/trafficcontrol_test.go
@@ -88,13 +88,8 @@ func createTrafficControlTestPod(t *testing.T, data *TestData, podName string) {
 			Protocol:      corev1.ProtocolTCP,
 		},
 	}
-	mutateLabels := func(pod *corev1.Pod) {
-		for k, v := range labels {
-			pod.Labels[k] = v
-		}
-	}
 
-	require.NoError(t, data.createPodOnNode(podName, data.testNamespace, tcTestConfig.nodeName, agnhostImage, []string{}, args, nil, ports, false, mutateLabels))
+	require.NoError(t, NewPodBuilder(podName, data.testNamespace, agnhostImage).OnNode(tcTestConfig.nodeName).WithArgs(args).WithPorts(ports).WithLabels(labels).Create(data))
 	ips, err := data.podWaitForIPs(defaultTimeout, podName, data.testNamespace)
 	if err != nil {
 		t.Fatalf("Error when waiting for IP for Pod '%s': %v", podName, err)
@@ -110,10 +105,7 @@ func createTrafficControlTestPod(t *testing.T, data *TestData, podName string) {
 }
 
 func createTrafficControlPacketsCollectorPod(t *testing.T, data *TestData, podName string) {
-	require.NoError(t, data.createPodOnNode(podName, data.testNamespace, tcTestConfig.nodeName, agnhostImage, []string{"sleep"}, []string{"3600"}, nil, nil, false, func(pod *corev1.Pod) {
-		privileged := true
-		pod.Spec.Containers[0].SecurityContext = &corev1.SecurityContext{Privileged: &privileged}
-	}))
+	require.NoError(t, NewPodBuilder(podName, data.testNamespace, agnhostImage).OnNode(tcTestConfig.nodeName).WithCommand([]string{"sleep", "3600"}).Privileged().Create(data))
 	ips, err := data.podWaitForIPs(defaultTimeout, podName, data.testNamespace)
 	if err != nil {
 		t.Fatalf("Error when waiting for IP for Pod '%s': %v", podName, err)
@@ -314,10 +306,7 @@ func testRedirectToLocal(t *testing.T, data *TestData) {
 ip link add dev %[1]s type veth peer name %[2]s && \
 ip link set dev %[1]s up && \
 ip link set dev %[2]s up`, targetPortName, returnPortName)
-	if err := data.createPodOnNode(tempPodName, data.testNamespace, tcTestConfig.nodeName, agnhostImage, []string{"sleep", "3600"}, nil, nil, nil, true, func(pod *corev1.Pod) {
-		privileged := true
-		pod.Spec.Containers[0].SecurityContext = &corev1.SecurityContext{Privileged: &privileged}
-	}); err != nil {
+	if err := NewPodBuilder(tempPodName, data.testNamespace, agnhostImage).OnNode(tcTestConfig.nodeName).WithCommand([]string{"sleep", "3600"}).InHostNetwork().Privileged().Create(data); err != nil {
 		t.Fatalf("Failed to create Pod %s: %v", tempPodName, err)
 	}
 	require.NoError(t, data.podWaitForRunning(defaultTimeout, tempPodName, data.testNamespace))

--- a/test/e2e/wireguard_test.go
+++ b/test/e2e/wireguard_test.go
@@ -17,7 +17,6 @@ package e2e
 import (
 	"fmt"
 	"net"
-	"strconv"
 	"strings"
 	"testing"
 
@@ -117,7 +116,7 @@ func testServiceConnectivity(t *testing.T, data *TestData) {
 	defer cleanup()
 
 	// Create the a hostNetwork Pod on a Node different from the service's backend Pod, so the service traffic will be transferred across the tunnel.
-	require.NoError(t, data.createPodOnNode(clientPodName, data.testNamespace, clientPodNode, busyboxImage, []string{"sleep", strconv.Itoa(3600)}, nil, nil, nil, true, nil))
+	require.NoError(t, NewPodBuilder(clientPodName, data.testNamespace, busyboxImage).OnNode(clientPodNode).WithCommand([]string{"sleep", "3600"}).InHostNetwork().Create(data))
 	defer data.deletePodAndWait(defaultTimeout, clientPodName, data.testNamespace)
 	require.NoError(t, data.podWaitForRunning(defaultTimeout, clientPodName, data.testNamespace))
 


### PR DESCRIPTION
Functions createPodOnNode and CreatePodOnNodeInNamespace have long lists
of parameters, and some of them are almost never used. Their naming is
also confusing since they both let you specify an arbitrary Namespace,
and the only difference is that CreatePodOnNodeInNamespace takes a
container name as parameter, while createPodOnNode auto-generates it
based on the container image name.

We try a different approach, using a "PodBuilder" object. The advantage
is the ability to add new methods to the builder, with explicit names,
instead of adding new function parameters or using the mutate function.

Signed-off-by: Antonin Bas <abas@vmware.com>