### PR TITLE
Set carryforward flag to true on codecov configuration

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -9,6 +9,7 @@ comment:
   require_base: no
   require_head: no
   after_n_builds: 1
+  show_carryforward_flags: true
 
 coverage:
   status:
@@ -35,6 +36,10 @@ coverage:
         target: auto
         flags:
           - mc-integration-tests
+
+flag_management:
+  default_rules:
+    carryforward: true
 
 ignore:
   - "**/testing/mock_*.go"


### PR DESCRIPTION
Set carryforward flag to true to use a reference of past coverage for tests
that are not run on the current commit.
You can refer to https://docs.codecov.com/docs/carryforward-flags to
learn more details.

This is a part of #3943
Signed-off-by: Lan Luo <luola@vmware.com>