### PR TITLE
Upload Multi-cluster e2e coverage to codecov

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -406,6 +406,17 @@ endif
 	docker tag antrea/antrea-mc-controller:$(DOCKER_IMG_VERSION) projects.registry.vmware.com/antrea/antrea-mc-controller
 	docker tag antrea/antrea-mc-controller:$(DOCKER_IMG_VERSION) projects.registry.vmware.com/antrea/antrea-mc-controller:$(DOCKER_IMG_VERSION)
 
+.PHONY: antrea-mc-controller-coverage
+antrea-mc-controller-coverage:
+	@echo "===> Building antrea/antrea-mc-controller-coverage Docker image <==="
+ifneq ($(NO_PULL),)
+	docker build -t antrea/antrea-mc-controller-coverage:$(DOCKER_IMG_VERSION) -f multicluster/build/images/Dockerfile.build.coverage $(DOCKER_BUILD_ARGS) .
+else
+	docker build --pull -t antrea/antrea-mc-controller-coverage:$(DOCKER_IMG_VERSION) -f multicluster/build/images/Dockerfile.build.coverage $(DOCKER_BUILD_ARGS) .
+endif
+	docker tag antrea/antrea-mc-controller-coverage:$(DOCKER_IMG_VERSION) antrea/antrea-mc-controller-coverage
+	docker tag antrea/antrea-mc-controller-coverage:$(DOCKER_IMG_VERSION) projects.registry.vmware.com/antrea/antrea-mc-controller-coverage
+
 .PHONY: flow-visibility-clickhouse-monitor
 flow-visibility-clickhouse-monitor:
 	@echo "===> Building antrea/flow-visibility-clickhouse-monitor Docker image <==="

--- a/ci/jenkins/test-vmc.sh
+++ b/ci/jenkins/test-vmc.sh
@@ -41,7 +41,7 @@ CONTROL_PLANE_NODE_ROLE="master|control-plane"
 
 _usage="Usage: $0 [--cluster-name <VMCClusterNameToUse>] [--kubeconfig <KubeconfigSavePath>] [--workdir <HomePath>]
                   [--log-mode <SonobuoyResultLogLevel>] [--testcase <e2e|conformance|all-features-conformance|whole-conformance|networkpolicy>]
-                  [--garbage-collection] [--setup-only] [--cleanup-only] [--coverage] [--test-only] [--registry]
+                  [--garbage-collection] [--setup-only] [--cleanup-only] [--coverage] [--test-only] [--codecov-token] [--registry]
 
 Setup a VMC cluster to run K8s e2e community tests (E2e, Conformance, all features Conformance, whole Conformance & Network Policy).
 
@@ -300,7 +300,7 @@ function copy_image {
   ${SSH_WITH_ANTREA_CI_KEY} -n capv@${IP} "sudo crictl images | grep '<none>' | awk '{print \$3}' | xargs -r crictl rmi"
 }
 
-# We run the function in a subshell with "set -e" to ensure that it exists in
+# We run the function in a subshell with "set -e" to ensure that it exits in
 # case of error (e.g. integrity check), no matter the context in which the
 # function is called.
 function run_codecov { (set -e

--- a/multicluster/Makefile
+++ b/multicluster/Makefile
@@ -85,6 +85,10 @@ endif
 build: fmt vet ## Build manager binary.
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/antrea-mc-controller antrea.io/antrea/multicluster/cmd/...
 
+.PHONY: antrea-mc-instr-binary
+antrea-mc-instr-binary:
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go test -tags testbincover -covermode count -coverpkg=antrea.io/antrea/multicluster/... -c -o bin/antrea-mc-controller-coverage antrea.io/antrea/multicluster/cmd/...
+
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 

--- a/multicluster/build/images/Dockerfile.build.coverage
+++ b/multicluster/build/images/Dockerfile.build.coverage
@@ -1,0 +1,21 @@
+ARG GO_VERSION
+FROM golang:${GO_VERSION} as antrea-build
+
+WORKDIR /antrea
+
+COPY go.mod /antrea/go.mod
+
+RUN go mod download
+
+COPY . /antrea
+
+RUN cd multicluster && make antrea-mc-instr-binary
+
+FROM ubuntu:20.04
+
+LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
+LABEL description="The Docker image to deploy the Antrea Multicluster controller with code coverage measurement enabled (used for testing)."
+
+USER root
+
+COPY --from=antrea-build /antrea/multicluster/bin/antrea-mc-controller-coverage /

--- a/multicluster/cmd/multicluster-controller/bincover_run_main_test.go
+++ b/multicluster/cmd/multicluster-controller/bincover_run_main_test.go
@@ -1,0 +1,28 @@
+// Copyright 2022 Antrea Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build testbincover
+// +build testbincover
+
+package main
+
+import (
+	"testing"
+
+	"github.com/confluentinc/bincover"
+)
+
+func TestBincoverRunMain(t *testing.T) {
+	bincover.RunTest(main)
+}

--- a/multicluster/config/overlays/leader-ns/coverage/manager_command_patch_coverage.yaml
+++ b/multicluster/config/overlays/leader-ns/coverage/manager_command_patch_coverage.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+        - command: ["/bin/sh"]
+          args: ["-c", "/antrea-mc-controller-coverage -test.run=TestBincoverRunMain -test.coverprofile=antrea-mc-controller.cov.out leader; while true; do sleep 5 & wait $!; done"]
+          name: antrea-mc-controller
+          image: projects.registry.vmware.com/antrea/antrea-mc-controller-coverage:latest

--- a/multicluster/config/overlays/member/coverage/manager_command_patch_coverage.yaml
+++ b/multicluster/config/overlays/member/coverage/manager_command_patch_coverage.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+        - command: ["/bin/sh"]
+          args: ["-c", "/antrea-mc-controller-coverage -test.run=TestBincoverRunMain -test.coverprofile=antrea-mc-controller.cov.out member; while true; do sleep 5 & wait $!; done"]
+          name: antrea-mc-controller
+          image: projects.registry.vmware.com/antrea/antrea-mc-controller-coverage:latest


### PR DESCRIPTION
1. Add a new target on Makefile to build MC controller image with
   instrumented binary
2. Add steps on test-mc.sh to collect coverage files from leader and member cluster
   controllers and upload it to codecov

This is a part of https://github.com/antrea-io/antrea/issues/3943
Signed-off-by: Lan Luo <luola@vmware.com>