### PR TITLE
Fix running NPL unit test on MacOS

### DIFF
--- a/pkg/agent/nodeportlocal/portcache/port_table_others.go
+++ b/pkg/agent/nodeportlocal/portcache/port_table_others.go
@@ -1,5 +1,5 @@
-//go:build linux
-// +build linux
+//go:build !windows
+// +build !windows
 
 // Copyright 2022 Antrea Authors
 //


### PR DESCRIPTION
Add a portcache file to support go building across different OSs.

Fixes https://github.com/antrea-io/antrea/issues/3826

Signed-off-by: Shuyang Xin <gavinx@vmware.com>