### PR TITLE
[Multicast] support encap mode

### DIFF
--- a/build/charts/antrea/conf/antrea-agent.conf
+++ b/build/charts/antrea/conf/antrea-agent.conf
@@ -46,7 +46,7 @@ featureGates:
 # IPAM when configuring secondary network interfaces with Multus.
 {{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "AntreaIPAM" "default" false) }}
 
-# Enable multicast traffic. This feature is supported only with noEncap mode.
+# Enable multicast traffic.
 {{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "Multicast" "default" false) }}
 
 # Enable Antrea Multi-cluster Gateway to support cross-cluster traffic.

--- a/build/charts/antrea/conf/antrea-controller.conf
+++ b/build/charts/antrea/conf/antrea-controller.conf
@@ -17,7 +17,7 @@ featureGates:
 # Enable collecting and exposing NetworkPolicy statistics.
 {{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "NetworkPolicyStats" "default" true) }}
 
-# Enable multicast traffic. This feature is supported only with noEncap mode.
+# Enable multicast traffic.
 {{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "Multicast" "default" false) }}
 
 # Enable controlling SNAT IPs of Pod egress traffic.

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -2583,7 +2583,7 @@ data:
     # IPAM when configuring secondary network interfaces with Multus.
     #  AntreaIPAM: false
 
-    # Enable multicast traffic. This feature is supported only with noEncap mode.
+    # Enable multicast traffic.
     #  Multicast: false
 
     # Enable Antrea Multi-cluster Gateway to support cross-cluster traffic.
@@ -2872,7 +2872,7 @@ data:
     # Enable collecting and exposing NetworkPolicy statistics.
     #  NetworkPolicyStats: true
 
-    # Enable multicast traffic. This feature is supported only with noEncap mode.
+    # Enable multicast traffic.
     #  Multicast: false
 
     # Enable controlling SNAT IPs of Pod egress traffic.
@@ -3692,7 +3692,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: b82a5504883f65d32538dd4c2de4e01f4ac99203ff69191463715f67878e0745
+        checksum/config: beca655f34bfd122082c7efa73505680278a8aa97e74099ca6040bcc4311622f
       labels:
         app: antrea
         component: antrea-agent
@@ -3933,7 +3933,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: b82a5504883f65d32538dd4c2de4e01f4ac99203ff69191463715f67878e0745
+        checksum/config: beca655f34bfd122082c7efa73505680278a8aa97e74099ca6040bcc4311622f
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -2583,7 +2583,7 @@ data:
     # IPAM when configuring secondary network interfaces with Multus.
     #  AntreaIPAM: false
 
-    # Enable multicast traffic. This feature is supported only with noEncap mode.
+    # Enable multicast traffic.
     #  Multicast: false
 
     # Enable Antrea Multi-cluster Gateway to support cross-cluster traffic.
@@ -2872,7 +2872,7 @@ data:
     # Enable collecting and exposing NetworkPolicy statistics.
     #  NetworkPolicyStats: true
 
-    # Enable multicast traffic. This feature is supported only with noEncap mode.
+    # Enable multicast traffic.
     #  Multicast: false
 
     # Enable controlling SNAT IPs of Pod egress traffic.
@@ -3692,7 +3692,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: b82a5504883f65d32538dd4c2de4e01f4ac99203ff69191463715f67878e0745
+        checksum/config: beca655f34bfd122082c7efa73505680278a8aa97e74099ca6040bcc4311622f
       labels:
         app: antrea
         component: antrea-agent
@@ -3935,7 +3935,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: b82a5504883f65d32538dd4c2de4e01f4ac99203ff69191463715f67878e0745
+        checksum/config: beca655f34bfd122082c7efa73505680278a8aa97e74099ca6040bcc4311622f
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -2583,7 +2583,7 @@ data:
     # IPAM when configuring secondary network interfaces with Multus.
     #  AntreaIPAM: false
 
-    # Enable multicast traffic. This feature is supported only with noEncap mode.
+    # Enable multicast traffic.
     #  Multicast: false
 
     # Enable Antrea Multi-cluster Gateway to support cross-cluster traffic.
@@ -2872,7 +2872,7 @@ data:
     # Enable collecting and exposing NetworkPolicy statistics.
     #  NetworkPolicyStats: true
 
-    # Enable multicast traffic. This feature is supported only with noEncap mode.
+    # Enable multicast traffic.
     #  Multicast: false
 
     # Enable controlling SNAT IPs of Pod egress traffic.
@@ -3692,7 +3692,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: c74fa3f40177249ad901af12a4127b31b3291f9b8bf3ce6a9be1e666e29c5447
+        checksum/config: 741b313c6ab0ed98e7d994985861722f503a93529f90a5141b8a6e0c124d8904
       labels:
         app: antrea
         component: antrea-agent
@@ -3932,7 +3932,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: c74fa3f40177249ad901af12a4127b31b3291f9b8bf3ce6a9be1e666e29c5447
+        checksum/config: 741b313c6ab0ed98e7d994985861722f503a93529f90a5141b8a6e0c124d8904
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -2596,7 +2596,7 @@ data:
     # IPAM when configuring secondary network interfaces with Multus.
     #  AntreaIPAM: false
 
-    # Enable multicast traffic. This feature is supported only with noEncap mode.
+    # Enable multicast traffic.
     #  Multicast: false
 
     # Enable Antrea Multi-cluster Gateway to support cross-cluster traffic.
@@ -2885,7 +2885,7 @@ data:
     # Enable collecting and exposing NetworkPolicy statistics.
     #  NetworkPolicyStats: true
 
-    # Enable multicast traffic. This feature is supported only with noEncap mode.
+    # Enable multicast traffic.
     #  Multicast: false
 
     # Enable controlling SNAT IPs of Pod egress traffic.
@@ -3705,7 +3705,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 1609abc57e2865390df7a7d99e4c3b342c7e097fa879fefe8e4315130eaa9019
+        checksum/config: c74f29ceba3905db50cef22ee46f73e1c101c108a70e70918b17413c174081e8
         checksum/ipsec-secret: d0eb9c52d0cd4311b6d252a951126bf9bea27ec05590bed8a394f0f792dcb2a4
       labels:
         app: antrea
@@ -3991,7 +3991,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 1609abc57e2865390df7a7d99e4c3b342c7e097fa879fefe8e4315130eaa9019
+        checksum/config: c74f29ceba3905db50cef22ee46f73e1c101c108a70e70918b17413c174081e8
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -2583,7 +2583,7 @@ data:
     # IPAM when configuring secondary network interfaces with Multus.
     #  AntreaIPAM: false
 
-    # Enable multicast traffic. This feature is supported only with noEncap mode.
+    # Enable multicast traffic.
     #  Multicast: false
 
     # Enable Antrea Multi-cluster Gateway to support cross-cluster traffic.
@@ -2872,7 +2872,7 @@ data:
     # Enable collecting and exposing NetworkPolicy statistics.
     #  NetworkPolicyStats: true
 
-    # Enable multicast traffic. This feature is supported only with noEncap mode.
+    # Enable multicast traffic.
     #  Multicast: false
 
     # Enable controlling SNAT IPs of Pod egress traffic.
@@ -3692,7 +3692,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 0814cc9f3baa94e76e83a108b04d05200485610c7f5950c584503af7151a9e86
+        checksum/config: 056a828ba2400e94aa9c43e6e74a4b007027bf6b95a68e1e15f34cd6ffeb2baa
       labels:
         app: antrea
         component: antrea-agent
@@ -3932,7 +3932,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 0814cc9f3baa94e76e83a108b04d05200485610c7f5950c584503af7151a9e86
+        checksum/config: 056a828ba2400e94aa9c43e6e74a4b007027bf6b95a68e1e15f34cd6ffeb2baa
       labels:
         app: antrea
         component: antrea-controller

--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -652,7 +652,9 @@ func run(o *Options) error {
 			ovsBridgeClient,
 			podUpdateChannel,
 			o.igmpQueryInterval,
-			validator)
+			validator,
+			networkConfig.TrafficEncapMode.SupportsEncap(),
+			informerFactory)
 		if err := mcastController.Initialize(); err != nil {
 			return err
 		}

--- a/pkg/agent/multicast/mcast_discovery_test.go
+++ b/pkg/agent/multicast/mcast_discovery_test.go
@@ -1,0 +1,185 @@
+// Copyright 2022 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multicast
+
+import (
+	"net"
+	"sync"
+	"testing"
+
+	"antrea.io/libOpenflow/openflow13"
+	"antrea.io/libOpenflow/protocol"
+	"antrea.io/libOpenflow/util"
+	"antrea.io/ofnet/ofctrl"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"antrea.io/antrea/pkg/agent/interfacestore"
+	ifaceStoretest "antrea.io/antrea/pkg/agent/interfacestore/testing"
+	openflowtest "antrea.io/antrea/pkg/agent/openflow/testing"
+	"antrea.io/antrea/pkg/ovs/ovsconfig"
+)
+
+var (
+	pktInSrcMAC, _ = net.ParseMAC("11:22:33:44:55:66")
+	pktInDstMAC, _ = net.ParseMAC("01:00:5e:00:00:16")
+)
+
+type snooperValidator struct {
+	eventCh          chan *mcastGroupEvent
+	groupJoinedNodes map[string]sets.String
+	groupLeftNodes   map[string]sets.String
+}
+
+func (v *snooperValidator) processPackets(expectedPackets int) {
+	appendSrcNode := func(groupKey string, groupNodes map[string]sets.String, nodeIP net.IP) map[string]sets.String {
+		_, exists := groupNodes[groupKey]
+		if !exists {
+			groupNodes[groupKey] = sets.NewString()
+		}
+		groupNodes[groupKey] = groupNodes[groupKey].Insert(nodeIP.String())
+		return groupNodes
+	}
+	for i := 0; i < expectedPackets; i++ {
+		select {
+		case e := <-v.eventCh:
+			groupKey := e.group.String()
+			if e.eType == groupJoin {
+				v.groupJoinedNodes = appendSrcNode(groupKey, v.groupJoinedNodes, e.srcNode)
+			} else {
+				v.groupLeftNodes = appendSrcNode(groupKey, v.groupLeftNodes, e.srcNode)
+			}
+		}
+	}
+}
+
+func TestIGMPRemoteReport(t *testing.T) {
+	controller := gomock.NewController(t)
+	mockOFClient := openflowtest.NewMockClient(controller)
+	mockIfaceStore := ifaceStoretest.NewMockInterfaceStore(controller)
+	eventCh := make(chan *mcastGroupEvent, 100)
+	snooper := &IGMPSnooper{ofClient: mockOFClient, eventCh: eventCh, ifaceStore: mockIfaceStore}
+
+	localNodeIP := net.ParseIP("1.2.3.4")
+	tunnelPort := uint32(1)
+	wg := sync.WaitGroup{}
+
+	generateRemotePackets := func(groups []net.IP, nodes []net.IP, igmpMsgType uint8) []ofctrl.PacketIn {
+		packets := make([]ofctrl.PacketIn, 0, len(nodes))
+		for _, srcNode := range nodes {
+			pkt := generatePacketInForRemoteReport(t, snooper, groups, srcNode, igmpMsgType, tunnelPort)
+			packets = append(packets, pkt)
+		}
+		return packets
+	}
+	validateGroupNodes := func(groups []net.IP, expectedNodesIPs []net.IP, testGroupNodes map[string]sets.String) {
+		if len(expectedNodesIPs) == 0 {
+			return
+		}
+		for _, g := range groups {
+			expectedNodes := sets.NewString()
+			for _, n := range expectedNodesIPs {
+				expectedNodes.Insert(n.String())
+			}
+			nodes, exists := testGroupNodes[g.String()]
+			assert.True(t, exists)
+			assert.True(t, nodes.HasAll(expectedNodes.List()...))
+		}
+	}
+	testPacketProcess := func(groups []net.IP, joinedNodes []net.IP, leftNodes []net.IP) {
+		validator := snooperValidator{eventCh: eventCh, groupJoinedNodes: make(map[string]sets.String), groupLeftNodes: make(map[string]sets.String)}
+		packets := make([]ofctrl.PacketIn, 0, len(joinedNodes)+len(leftNodes))
+		packets = append(packets, generateRemotePackets(groups, joinedNodes, protocol.IGMPIsEx)...)
+		packets = append(packets, generateRemotePackets(groups, leftNodes, protocol.IGMPToIn)...)
+
+		eventCount := len(groups) * len(packets)
+		wg.Add(1)
+		go func() {
+			validator.processPackets(eventCount)
+			wg.Done()
+		}()
+
+		mockIfaceStore.EXPECT().GetInterfaceByOFPort(tunnelPort).Return(createTunnelInterface(tunnelPort, localNodeIP), true).Times(len(packets))
+		for i := range packets {
+			pkt := &packets[i]
+			err := snooper.processPacketIn(pkt)
+			assert.Nil(t, err, "Failed to process IGMP Report message")
+		}
+
+		wg.Wait()
+
+		validateGroupNodes(groups, joinedNodes, validator.groupJoinedNodes)
+		validateGroupNodes(groups, leftNodes, validator.groupLeftNodes)
+	}
+
+	for _, tc := range []struct {
+		groupsStrings      []string
+		joinedNodesStrings []string
+		leftNodesStrings   []string
+	}{
+		{groupsStrings: []string{"225.1.2.3", "225.1.2.4"}, joinedNodesStrings: []string{"1.2.3.5", "1.2.3.6"}, leftNodesStrings: []string{"1.2.3.6"}},
+		{groupsStrings: []string{"225.1.2.5"}, joinedNodesStrings: []string{"1.2.3.5"}},
+		{groupsStrings: []string{"225.1.2.6"}, leftNodesStrings: []string{"1.2.3.6"}},
+	} {
+		var groups, joinedNodes, leftNodes []net.IP
+		for _, g := range tc.groupsStrings {
+			groups = append(groups, net.ParseIP(g))
+		}
+		for _, n := range tc.joinedNodesStrings {
+			joinedNodes = append(joinedNodes, net.ParseIP(n))
+		}
+		for _, n := range tc.leftNodesStrings {
+			leftNodes = append(leftNodes, net.ParseIP(n))
+		}
+		testPacketProcess(groups, joinedNodes, leftNodes)
+	}
+}
+
+func generatePacket(m util.Message, ofport uint32, srcNodeIP net.IP) ofctrl.PacketIn {
+	pkt := openflow13.NewPacketIn()
+	matchInport := openflow13.NewInPortField(ofport)
+	pkt.Match.AddField(*matchInport)
+	if srcNodeIP != nil {
+		matchTunSrc := openflow13.NewTunnelIpv4SrcField(srcNodeIP, nil)
+		pkt.Match.AddField(*matchTunSrc)
+	}
+	ipPacket := &protocol.IPv4{
+		Version:  0x4,
+		IHL:      5,
+		Protocol: IGMPProtocolNumber,
+		Length:   20 + m.Len(),
+		Data:     m,
+	}
+	pkt.Data = protocol.Ethernet{
+		HWDst:     pktInDstMAC,
+		HWSrc:     pktInSrcMAC,
+		Ethertype: protocol.IPv4_MSG,
+		Data:      ipPacket,
+	}
+	return ofctrl.PacketIn(*pkt)
+}
+
+func generatePacketInForRemoteReport(t *testing.T, snooper *IGMPSnooper, groups []net.IP, srcNode net.IP, igmpMsgType uint8, tunnelPort uint32) ofctrl.PacketIn {
+	msg, err := snooper.generateIGMPReportPacket(igmpMsgType, groups)
+	assert.Nil(t, err, "Failed to generate IGMP Report message")
+	return generatePacket(msg, tunnelPort, srcNode)
+}
+
+func createTunnelInterface(tunnelPort uint32, localNodeIP net.IP) *interfacestore.InterfaceConfig {
+	tunnelInterface := interfacestore.NewTunnelInterface("antrea-tun0", ovsconfig.GeneveTunnel, localNodeIP, false)
+	tunnelInterface.OVSPortConfig = &interfacestore.OVSPortConfig{OFPort: int32(tunnelPort)}
+	return tunnelInterface
+}

--- a/pkg/agent/multicast/mcast_route_test.go
+++ b/pkg/agent/multicast/mcast_route_test.go
@@ -33,9 +33,10 @@ import (
 )
 
 var (
-	addrIf1    = &net.IPNet{IP: nodeIf1IP, Mask: net.IPv4Mask(255, 255, 255, 0)}
-	addrIf2    = &net.IPNet{IP: externalInterfaceIP, Mask: net.IPv4Mask(255, 255, 255, 0)}
-	nodeConfig = &config.NodeConfig{GatewayConfig: &config.GatewayConfig{Name: "antrea-gw0"}, NodeIPv4Addr: addrIf1}
+	externalInterfaceIP = net.ParseIP("192.168.50.23")
+	addrIf1             = &net.IPNet{IP: nodeIf1IP, Mask: net.IPv4Mask(255, 255, 255, 0)}
+	addrIf2             = &net.IPNet{IP: externalInterfaceIP, Mask: net.IPv4Mask(255, 255, 255, 0)}
+	nodeConfig          = &config.NodeConfig{GatewayConfig: &config.GatewayConfig{Name: "antrea-gw0"}, NodeIPv4Addr: addrIf1}
 )
 
 func TestParseIGMPMsg(t *testing.T) {
@@ -117,7 +118,7 @@ func newMockMulticastRouteClient(t *testing.T) *MRouteClient {
 	groupCache := cache.NewIndexer(getGroupEventKey, cache.Indexers{
 		podInterfaceIndex: podInterfaceIndexFunc,
 	})
-	return newRouteClient(nodeConfig, groupCache, mockMulticastSocket, sets.NewString(if1.InterfaceName))
+	return newRouteClient(nodeConfig, groupCache, mockMulticastSocket, sets.NewString(if1.InterfaceName), false)
 }
 
 func (c *MRouteClient) initialize(t *testing.T) error {

--- a/pkg/agent/openflow/testing/mock_openflow.go
+++ b/pkg/agent/openflow/testing/mock_openflow.go
@@ -297,17 +297,17 @@ func (mr *MockClientMockRecorder) InstallMulticastFlows(arg0, arg1 interface{}) 
 }
 
 // InstallMulticastGroup mocks base method
-func (m *MockClient) InstallMulticastGroup(arg0 openflow.GroupIDType, arg1 []uint32) error {
+func (m *MockClient) InstallMulticastGroup(arg0 openflow.GroupIDType, arg1 []uint32, arg2 []net.IP) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstallMulticastGroup", arg0, arg1)
+	ret := m.ctrl.Call(m, "InstallMulticastGroup", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InstallMulticastGroup indicates an expected call of InstallMulticastGroup
-func (mr *MockClientMockRecorder) InstallMulticastGroup(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) InstallMulticastGroup(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallMulticastGroup", reflect.TypeOf((*MockClient)(nil).InstallMulticastGroup), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallMulticastGroup", reflect.TypeOf((*MockClient)(nil).InstallMulticastGroup), arg0, arg1, arg2)
 }
 
 // InstallMulticastInitialFlows mocks base method
@@ -322,6 +322,20 @@ func (m *MockClient) InstallMulticastInitialFlows(arg0 byte) error {
 func (mr *MockClientMockRecorder) InstallMulticastInitialFlows(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallMulticastInitialFlows", reflect.TypeOf((*MockClient)(nil).InstallMulticastInitialFlows), arg0)
+}
+
+// InstallMulticastRemoteReportFlows mocks base method
+func (m *MockClient) InstallMulticastRemoteReportFlows(arg0 openflow.GroupIDType) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InstallMulticastRemoteReportFlows", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// InstallMulticastRemoteReportFlows indicates an expected call of InstallMulticastRemoteReportFlows
+func (mr *MockClientMockRecorder) InstallMulticastRemoteReportFlows(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallMulticastRemoteReportFlows", reflect.TypeOf((*MockClient)(nil).InstallMulticastRemoteReportFlows), arg0)
 }
 
 // InstallMulticlusterClassifierFlows mocks base method
@@ -668,6 +682,20 @@ func (m *MockClient) SendIGMPQueryPacketOut(arg0 net.HardwareAddr, arg1 net.IP, 
 func (mr *MockClientMockRecorder) SendIGMPQueryPacketOut(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendIGMPQueryPacketOut", reflect.TypeOf((*MockClient)(nil).SendIGMPQueryPacketOut), arg0, arg1, arg2, arg3)
+}
+
+// SendIGMPRemoteReportPacketOut mocks base method
+func (m *MockClient) SendIGMPRemoteReportPacketOut(arg0 net.HardwareAddr, arg1 net.IP, arg2 util.Message) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SendIGMPRemoteReportPacketOut", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SendIGMPRemoteReportPacketOut indicates an expected call of SendIGMPRemoteReportPacketOut
+func (mr *MockClientMockRecorder) SendIGMPRemoteReportPacketOut(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendIGMPRemoteReportPacketOut", reflect.TypeOf((*MockClient)(nil).SendIGMPRemoteReportPacketOut), arg0, arg1, arg2)
 }
 
 // SendTCPPacketOut mocks base method

--- a/pkg/agent/types/multicast.go
+++ b/pkg/agent/types/multicast.go
@@ -32,6 +32,7 @@ type IGMPNPRuleInfo struct {
 
 var (
 	McastAllHosts   = net.ParseIP("224.0.0.1").To4()
+	IGMPv3Router    = net.ParseIP("224.0.0.22").To4()
 	_, McastCIDR, _ = net.ParseCIDR("224.0.0.0/4")
 )
 

--- a/pkg/agent/util/iptables/iptables.go
+++ b/pkg/agent/util/iptables/iptables.go
@@ -36,6 +36,7 @@ const (
 	RawTable    = "raw"
 
 	AcceptTarget     = "ACCEPT"
+	DROPTarget       = "DROP"
 	MasqueradeTarget = "MASQUERADE"
 	MarkTarget       = "MARK"
 	ReturnTarget     = "RETURN"

--- a/pkg/ovs/openflow/interfaces.go
+++ b/pkg/ovs/openflow/interfaces.go
@@ -342,6 +342,7 @@ type BucketBuilder interface {
 	LoadRegRange(regID int, data uint32, rng *Range) BucketBuilder
 	LoadToRegField(field *RegField, data uint32) BucketBuilder
 	ResubmitToTable(tableID uint8) BucketBuilder
+	SetTunnelDst(addr net.IP) BucketBuilder
 	Done() Group
 }
 

--- a/pkg/ovs/openflow/ofctrl_group.go
+++ b/pkg/ovs/openflow/ofctrl_group.go
@@ -16,6 +16,7 @@ package openflow
 
 import (
 	"fmt"
+	"net"
 
 	"antrea.io/libOpenflow/openflow13"
 	"antrea.io/ofnet/ofctrl"
@@ -125,6 +126,13 @@ func (b *bucketBuilder) LoadRegMark(mark *RegMark) BucketBuilder {
 // ResubmitToTable is an action to resubmit packet to the specified table when the bucket is selected.
 func (b *bucketBuilder) ResubmitToTable(tableID uint8) BucketBuilder {
 	b.bucket.AddAction(openflow13.NewNXActionResubmitTableAction(openflow13.OFPP_IN_PORT, tableID))
+	return b
+}
+
+// SetTunnelDst is an action to set tunnel destination address when the bucket is selected.
+func (b *bucketBuilder) SetTunnelDst(addr net.IP) BucketBuilder {
+	setTunDstAct := &ofctrl.SetTunnelDstAction{IP: addr}
+	b.bucket.AddAction(setTunDstAct.GetActionMessage())
 	return b
 }
 

--- a/pkg/util/k8s/node.go
+++ b/pkg/util/k8s/node.go
@@ -145,3 +145,19 @@ func GetNodeAllAddrs(node *v1.Node) (ips sets.String, err error) {
 
 	return
 }
+
+func GetNodeTransportAddrs(node *v1.Node) (*ip.DualStackIPs, error) {
+	transportAddrs, err := GetNodeAddrsFromAnnotations(node, types.NodeTransportAddressAnnotationKey)
+	if err != nil {
+		return nil, err
+	}
+	if transportAddrs != nil {
+		return transportAddrs, nil
+	}
+	// Use NodeIP if the transport IP address is not set or not found.
+	nodeAddrs, err := GetNodeAddrs(node)
+	if err != nil {
+		return nil, err
+	}
+	return nodeAddrs, nil
+}


### PR DESCRIPTION
1. Use a single routine to send local multicast groups in an IGMP v3
    Report message to notify all the other Nodes in the cluster
2. Multicast controller maintains both local Pod members and remote
    Nodes which have Pod members for each multicast group found in the
    cluster
3. Add remote Node members in the OpenFlow group buckets.

Signed-off-by: wenyingd <wenyingd@vmware.com>
