### PR TITLE
Fix pkill failure in e2e test

### DIFF
--- a/test/e2e/egress_test.go
+++ b/test/e2e/egress_test.go
@@ -600,6 +600,9 @@ func testEgressNodeFailure(t *testing.T, data *TestData) {
 			}
 			signalAgent := func(nodeName, signal string) {
 				cmd := fmt.Sprintf("pkill -%s antrea-agent", signal)
+				if testOptions.providerName != "kind" {
+					cmd = "sudo " + cmd
+				}
 				rc, stdout, stderr, err := data.RunCommandOnNode(nodeName, cmd)
 				if rc != 0 || err != nil {
 					t.Errorf("Error when running command '%s' on Node '%s', rc: %d, stdout: %s, stderr: %s, error: %v",

--- a/test/e2e/service_externalip_test.go
+++ b/test/e2e/service_externalip_test.go
@@ -460,9 +460,6 @@ func testServiceUpdateExternalIP(t *testing.T, data *TestData) {
 }
 
 func testServiceNodeFailure(t *testing.T, data *TestData) {
-	if testOptions.providerName != "kind" {
-		t.Skipf("Skipping test because root permission is required")
-	}
 	tests := []struct {
 		name       string
 		ipRange    v1alpha2.IPRange
@@ -488,6 +485,9 @@ func testServiceNodeFailure(t *testing.T, data *TestData) {
 			}
 			signalAgent := func(nodeName, signal string) {
 				cmd := fmt.Sprintf("pkill -%s antrea-agent", signal)
+				if testOptions.providerName != "kind" {
+					cmd = "sudo " + cmd
+				}
 				rc, stdout, stderr, err := data.RunCommandOnNode(nodeName, cmd)
 				if rc != 0 || err != nil {
 					t.Errorf("Error when running command '%s' on Node '%s', rc: %d, stdout: %s, stderr: %s, error: %v",


### PR DESCRIPTION
Before pkill v3.3.13, the return value could be 0 even if the operation failed,
which led to a false positive result for RunCommandOnNode function in e2e test.

The command should be run with root privilege in CAPV environment because the
user of antrea-agent process is root.

Signed-off-by: Shuyang Xin <gavinx@vmware.com>