### PR TITLE
Add commands to cleanup dangling images on 1.24 testbed

### DIFF
--- a/ci/jenkins/test.sh
+++ b/ci/jenkins/test.sh
@@ -141,6 +141,8 @@ function clean_antrea {
     for antrea_yml in ${WORKDIR}/*.yml; do
         kubectl delete -f $antrea_yml --ignore-not-found=true || true
     done
+    docker images | grep 'antrea' | awk '{print $3}' | xargs -r docker rmi || true
+    docker images | grep '<none>' | awk '{print $3}' | xargs -r docker rmi || true
 }
 
 function clean_for_windows_install_cni {


### PR DESCRIPTION
Add image cleanup commands on both docker and containerd nodes to prevent
the depletion of storage.

Signed-off-by: Shuyang Xin <gavinx@vmware.com>