### PR TITLE
Fix integration data on codecov

### DIFF
--- a/ci/jenkins/test-vmc.sh
+++ b/ci/jenkins/test-vmc.sh
@@ -328,7 +328,7 @@ function run_codecov { (set -e
 
     if [[ $remote == true ]]; then
         ${SCP_WITH_UTILS_KEY} codecov jenkins@${ip}:~
-        ${SSH_WITH_UTILS_KEY} -n jenkins@${ip} "~/codecov -c -t ${CODECOV_TOKEN} -F ${flag} -f ${file} -C ${GIT_COMMIT} -r antrea-io/antrea"
+        ${SSH_WITH_UTILS_KEY} -n jenkins@${ip} "cd antrea; ~/codecov -c -t ${CODECOV_TOKEN} -F ${flag} -f ${file} -C ${GIT_COMMIT} -r antrea-io/antrea"
     else
         ./codecov -c -t ${CODECOV_TOKEN} -F ${flag} -f ${file} -s ${dir} -C ${GIT_COMMIT} -r antrea-io/antrea
     fi
@@ -483,14 +483,14 @@ function run_integration {
       # umask ensures that files are cloned with the correct permissions so that Docker caching can be leveraged
       ${SSH_WITH_UTILS_KEY} -n jenkins@${VM_IP} "PATH=$PATH:/usr/local/go/bin && umask 0022 && git clone ${ghprbAuthorRepoGitUrl} antrea && cd antrea && git checkout ${GIT_BRANCH} && cd multicluster && NO_LOCAL=true make test-integration"
       if [[ "$COVERAGE" == true ]]; then
-        run_codecov "mc-integration-tests" "antrea/multicluster/.coverage/coverage-integration.txt" "" true ${VM_IP}
+        run_codecov "mc-integration-tests" "coverage-integration.txt" "" true ${VM_IP}
       fi
     else
       echo "===== Run Integration tests ====="
       # umask ensures that files are cloned with the correct permissions so that Docker caching can be leveraged
       ${SSH_WITH_UTILS_KEY} -n jenkins@${VM_IP} "umask 0022 && git clone ${ghprbAuthorRepoGitUrl} antrea && cd antrea && git checkout ${GIT_BRANCH} && DOCKER_REGISTRY=${DOCKER_REGISTRY} ./build/images/ovs/build.sh --pull && NO_PULL=${NO_PULL} make docker-test-integration"
       if [[ "$COVERAGE" == true ]]; then
-        run_codecov "integration-tests" "antrea/.coverage/coverage-integration.txt" "" true ${VM_IP}
+        run_codecov "integration-tests" "coverage-integration.txt" "" true ${VM_IP}
       fi
     fi
 }


### PR DESCRIPTION
1. The crd path is changed, so fix the path in MC integration test.
2. Change the codecov caller parameters and the path to run codecov which help to correct the relative path in codecov, so integration test data can be calculated correctly with right package names. You may refer to an old PR's file lists to see the total top packages being calculated are incorrect. https://app.codecov.io/gh/antrea-io/antrea/compare/3941/tree

Part of #3943
Signed-off-by: Lan Luo <luola@vmware.com>