### PR TITLE
Auto update ClusterSet and MemberClusterAnnounce in leader cluster

### DIFF
--- a/multicluster/build/yamls/antrea-multicluster-leader-namespaced.yml
+++ b/multicluster/build/yamls/antrea-multicluster-leader-namespaced.yml
@@ -26,6 +26,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - serviceaccounts
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   verbs:
   - get

--- a/multicluster/config/overlays/leader-ns/role.yaml
+++ b/multicluster/config/overlays/leader-ns/role.yaml
@@ -9,6 +9,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - serviceaccounts
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   verbs:
   - get

--- a/multicluster/controllers/multicluster/commonarea/remote_common_area.go
+++ b/multicluster/controllers/multicluster/commonarea/remote_common_area.go
@@ -247,6 +247,7 @@ func (r *remoteCommonArea) SendMemberAnnounce() error {
 		localClusterMemberAnnounce.Name = "member-announce-from-" + r.GetLocalClusterID()
 		localClusterMemberAnnounce.Namespace = r.Namespace
 		localClusterMemberAnnounce.ClusterSetID = string(r.ClusterSetID)
+		localClusterMemberAnnounce.LeaderClusterID = string(r.GetClusterID())
 		if err := r.Create(context.TODO(), &localClusterMemberAnnounce, &client.CreateOptions{}); err != nil {
 			klog.ErrorS(err, "Error creating MemberClusterAnnounce", "cluster", r.GetClusterID())
 			return err

--- a/multicluster/controllers/multicluster/member_clusterset_controller.go
+++ b/multicluster/controllers/multicluster/member_clusterset_controller.go
@@ -93,6 +93,8 @@ func (r *MemberClusterSetReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		klog.InfoS("Received ClusterSet delete", "clusterset", req.NamespacedName)
 		if r.remoteCommonArea != nil {
 			if err := r.deleteMemberClusterAnnounce(ctx); err != nil {
+				// MemberClusterAnnounce could be kept in the leader cluster, if antrea-mc-controller crashes after the failure.
+				// Leader cluster will delete the stale MemberClusterAnnounce with a garbage collection mechanism in this case.
 				return ctrl.Result{}, fmt.Errorf("failed to delete MemberClusterAnnounce in the leader cluster: %v", err)
 			}
 			r.remoteCommonArea.Stop()


### PR DESCRIPTION
Auto update ClusetSet and MemberClusterAnnounce in the leader cluster. 
+ When a new member cluster is added to the ClusterSet. The ClusterSet in the leader cluster will update the new member cluster in the `spec.members`.
+ When a member cluster departs the ClusterSet. The `MemberClusterAnnounce` in the leader cluster will be deleted. The member cluster will be removed from the `spec.members`.

