### PR TITLE
Make disabling TX checksum for Antrea gateway

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -247,7 +247,8 @@ func run(o *Options) error {
 		o.config.ExternalNode.ExternalNodeNamespace,
 		features.DefaultFeatureGate.Enabled(features.AntreaProxy),
 		o.config.AntreaProxy.ProxyAll,
-		connectUplinkToBridge)
+		connectUplinkToBridge,
+		o.config.DisableTXChecksumOffload)
 	err = agentInitializer.Initialize()
 	if err != nil {
 		return fmt.Errorf("error initializing agent: %v", err)

--- a/pkg/agent/agent_linux.go
+++ b/pkg/agent/agent_linux.go
@@ -30,6 +30,7 @@ import (
 	"antrea.io/antrea/pkg/agent/config"
 	"antrea.io/antrea/pkg/agent/interfacestore"
 	"antrea.io/antrea/pkg/agent/util"
+	"antrea.io/antrea/pkg/agent/util/ethtool"
 	"antrea.io/antrea/pkg/apis/crd/v1alpha1"
 	utilip "antrea.io/antrea/pkg/util/ip"
 )
@@ -310,5 +311,14 @@ func (i *Initializer) prepareOVSBridgeForVM() error {
 }
 
 func (i *Initializer) installVMInitialFlows() error {
+	return nil
+}
+
+func (i *Initializer) setTXChecksumOffload() error {
+	if i.disableTXChecksumOffload {
+		if err := ethtool.EthtoolTXHWCsumOff(i.hostGateway); err != nil {
+			return fmt.Errorf("error when disabling TX checksum offload on %s: %v", i.hostGateway, err)
+		}
+	}
 	return nil
 }

--- a/pkg/agent/agent_windows.go
+++ b/pkg/agent/agent_windows.go
@@ -499,3 +499,7 @@ func (i *Initializer) installVMInitialFlows() error {
 	}
 	return nil
 }
+
+func (i *Initializer) setTXChecksumOffload() error {
+	return nil
+}


### PR DESCRIPTION
This is a supplement to PR #3832. When `disableTXChecksumOffload`
is true, TX checksum offload of Antrea gateway should be also
disabled, otherwise for the cases in which the datapath doesn't
support TX checksum offloading, packets sent from Antrea gateway
could be dropped due to bad checksum.

Note that, when changing `disableTXChecksumOffload` from true back
to false, TX checksum offload of Antrea gateway will not be enabled
automatically, and TX checksum offload can be enabled manually with
ethtool. Another way is to remove Antrea gateway interface before
updating `disableTXChecksumOffload`.

Signed-off-by: Hongliang Liu <lhongliang@vmware.com>