### PR TITLE
Automated cherry pick of #3948: Fix pkill failure in e2e test

### DIFF
--- a/test/e2e/egress_test.go
+++ b/test/e2e/egress_test.go
@@ -594,6 +594,9 @@ func testEgressNodeFailure(t *testing.T, data *TestData) {
 			}
 			signalAgent := func(nodeName, signal string) {
 				cmd := fmt.Sprintf("pkill -%s antrea-agent", signal)
+				if testOptions.providerName != "kind" {
+					cmd = "sudo " + cmd
+				}
 				rc, stdout, stderr, err := data.RunCommandOnNode(nodeName, cmd)
 				if rc != 0 || err != nil {
 					t.Errorf("Error when running command '%s' on Node '%s', rc: %d, stdout: %s, stderr: %s, error: %v",

--- a/test/e2e/service_externalip_test.go
+++ b/test/e2e/service_externalip_test.go
@@ -460,9 +460,6 @@ func testServiceUpdateExternalIP(t *testing.T, data *TestData) {
 }
 
 func testServiceNodeFailure(t *testing.T, data *TestData) {
-	if testOptions.providerName != "kind" {
-		t.Skipf("Skipping test because root permission is required")
-	}
 	tests := []struct {
 		name       string
 		ipRange    v1alpha2.IPRange
@@ -488,6 +485,9 @@ func testServiceNodeFailure(t *testing.T, data *TestData) {
 			}
 			signalAgent := func(nodeName, signal string) {
 				cmd := fmt.Sprintf("pkill -%s antrea-agent", signal)
+				if testOptions.providerName != "kind" {
+					cmd = "sudo " + cmd
+				}
 				rc, stdout, stderr, err := data.RunCommandOnNode(nodeName, cmd)
 				if rc != 0 || err != nil {
 					t.Errorf("Error when running command '%s' on Node '%s', rc: %d, stdout: %s, stderr: %s, error: %v",


### PR DESCRIPTION
Cherry pick of #3948 on release-1.6.

#3948: Fix pkill failure in e2e test

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.