### PR TITLE
Use hostNetwork for Multi-cluster controller

### DIFF
--- a/multicluster/build/yamls/antrea-multicluster-leader-namespaced.yml
+++ b/multicluster/build/yamls/antrea-multicluster-leader-namespaced.yml
@@ -401,6 +401,7 @@ spec:
         - mountPath: /controller_manager_config.yaml
           name: antrea-mc-controller-config
           subPath: controller_manager_config.yaml
+      hostNetwork: true
       serviceAccountName: antrea-mc-controller
       terminationGracePeriodSeconds: 10
       volumes:

--- a/multicluster/build/yamls/antrea-multicluster-member.yml
+++ b/multicluster/build/yamls/antrea-multicluster-member.yml
@@ -1028,6 +1028,7 @@ spec:
         - mountPath: /controller_manager_config.yaml
           name: antrea-mc-controller-config
           subPath: controller_manager_config.yaml
+      hostNetwork: true
       serviceAccountName: antrea-mc-controller
       terminationGracePeriodSeconds: 10
       volumes:

--- a/multicluster/config/manager/manager.yaml
+++ b/multicluster/config/manager/manager.yaml
@@ -15,6 +15,7 @@ spec:
       labels:
         component: antrea-mc-controller
     spec:
+      hostNetwork: true
       containers:
       - command:
         image: antrea/antrea-mc-controller:latest


### PR DESCRIPTION
The `hostNetwork` mode is required to run Multi-cluster controller on a public
cloud like EKS clusters.

Signed-off-by: Lan Luo <luola@vmware.com>