### PR TITLE
Run multi-cluster integration tests with test-integration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,7 +160,6 @@ the repo. It's a Github security mechanism.
 Here are the trigger phrases for individual checks:
 
 * `/test-integration`: Integration tests
-* `/test-multicluster-integration`: Multi-cluster integration tests
 * `/test-e2e`: Linux IPv4 e2e tests
 * `/test-conformance`: Linux IPv4 conformance tests
 * `/test-networkpolicy`: Linux IPv4 networkpolicy tests

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 ## Overview
 
 Antrea is a [Kubernetes](https://kubernetes.io) networking solution intended
-to be Kubernetes native. It operates at Layer3/4 to provide networking and
+to be Kubernetes native. It operates at Layer 3/4 to provide networking and
 security services for a Kubernetes cluster, leveraging
 [Open vSwitch](https://www.openvswitch.org/) as the networking data plane.
 

--- a/ci/jenkins/jobs/macros.yaml
+++ b/ci/jenkins/jobs/macros.yaml
@@ -15,16 +15,6 @@
             DOCKER_REGISTRY="$(head -n1 ci/docker-registry)"
             ./ci/jenkins/test-vmc.sh --testcase integration --coverage --codecov-token "${CODECOV_TOKEN}" --registry ${DOCKER_REGISTRY}
 
-
-- builder:
-      name: builder-multicluster-integration
-      builders:
-        - shell: |-
-            #!/bin/bash
-            set -e
-            DOCKER_REGISTRY="$(head -n1 ci/docker-registry)"
-            ./ci/jenkins/test-vmc.sh --testcase multicluster-integration --coverage --codecov-token "${CODECOV_TOKEN}" --registry ${DOCKER_REGISTRY}
-
 - builder:
     name: builder-eks-cluster-cleanup
     builders:

--- a/ci/jenkins/jobs/projects.yaml
+++ b/ci/jenkins/jobs/projects.yaml
@@ -248,48 +248,6 @@
           started_status: null
           wrappers: []
           publishers: []
-      - '{name}-{test_name}-integration-for-pull-request':
-          test_name: multicluster-manual
-          node: 'antrea-test-node'
-          description: 'This is the {test_name} integration test for {name}.'
-          branches:
-          - ${{sha1}}
-          builders:
-          - builder-multicluster-integration
-          trigger_phrase: ^(?!Thanks for your PR).*/test-multicluster-integration.*
-          white_list_target_branches: []
-          allow_whitelist_orgs_as_admins: true
-          admin_list: '{antrea_admin_list}'
-          org_list: '{antrea_org_list}'
-          white_list: '{antrea_white_list}'
-          only_trigger_phrase: true
-          trigger_permit_all: true
-          status_context: jenkins-multicluster-integration-tests
-          status_url: null
-          success_status: Build finished.
-          failure_status: Failed. Add comment /test-multicluster-integration to re-trigger.
-          error_status: Failed. Add comment /test-multicluster-integration to re-trigger.
-          triggered_status: null
-          started_status: null
-          wrappers:
-          - timeout:
-              fail: true
-              timeout: 20
-              type: absolute
-          - credentials-binding:
-              - text:
-                  credential-id: GOVC_URL
-                  variable: GOVC_URL
-              - text:
-                  credential-id: GOVC_USERNAME
-                  variable: GOVC_USERNAME
-              - text:
-                  credential-id: GOVC_PASSWORD
-                  variable: GOVC_PASSWORD
-              - text:
-                  credential-id: CODECOV_TOKEN # Jenkins secret that stores codecov token
-                  variable: CODECOV_TOKEN
-          publishers: []
       - '{name}-{test_name}-no-scm':
           test_name: e2e-pending-label
           node: null

--- a/ci/jenkins/test-vmc.sh
+++ b/ci/jenkins/test-vmc.sh
@@ -40,16 +40,16 @@ DOCKER_REGISTRY=""
 CONTROL_PLANE_NODE_ROLE="master|control-plane"
 
 _usage="Usage: $0 [--cluster-name <VMCClusterNameToUse>] [--kubeconfig <KubeconfigSavePath>] [--workdir <HomePath>]
-                  [--log-mode <SonobuoyResultLogLevel>] [--testcase <e2e|conformance|all-features-conformance|whole-conformance|networkpolicy>]
+                  [--log-mode <SonobuoyResultLogLevel>] [--testcase <e2e|integration|conformance|all-features-conformance|whole-conformance|networkpolicy>]
                   [--garbage-collection] [--setup-only] [--cleanup-only] [--coverage] [--test-only] [--codecov-token] [--registry]
 
-Setup a VMC cluster to run K8s e2e community tests (E2e, Conformance, all features Conformance, whole Conformance & Network Policy).
+Setup a VMC cluster to run K8s e2e community tests (E2e, Integration, Conformance, all features Conformance, whole Conformance & Network Policy).
 
         --cluster-name           The cluster name to be used for the generated VMC cluster.
         --kubeconfig             Path to save kubeconfig of generated VMC cluster.
         --workdir                Home path for Go, vSphere information and antrea_logs during cluster setup. Default is $WORKDIR.
         --log-mode               Use the flag to set either 'report', 'detail', or 'dump' level data for sonobouy results.
-        --testcase               The testcase to run: e2e, conformance, all-features-conformance, whole-conformance or networkpolicy.
+        --testcase               The testcase to run: e2e, integration, conformance, all-features-conformance, whole-conformance or networkpolicy.
         --garbage-collection     Do garbage collection to clean up some unused testbeds.
         --setup-only             Only perform setting up the cluster and run test.
         --cleanup-only           Only perform cleaning up the cluster.
@@ -478,20 +478,11 @@ function run_integration {
     VM_IP=$(govc vm.ip ${VM_NAME}) # wait for VM to be on
 
     set -x
-    if [[ ${flag} == "multicluster" ]];then
-      echo "===== Run Multi-cluster Integration tests ====="
-      # umask ensures that files are cloned with the correct permissions so that Docker caching can be leveraged
-      ${SSH_WITH_UTILS_KEY} -n jenkins@${VM_IP} "PATH=$PATH:/usr/local/go/bin && umask 0022 && git clone ${ghprbAuthorRepoGitUrl} antrea && cd antrea && git checkout ${GIT_BRANCH} && cd multicluster && NO_LOCAL=true make test-integration"
-      if [[ "$COVERAGE" == true ]]; then
-        run_codecov "mc-integration-tests" "coverage-integration.txt" "" true ${VM_IP}
-      fi
-    else
-      echo "===== Run Integration tests ====="
-      # umask ensures that files are cloned with the correct permissions so that Docker caching can be leveraged
-      ${SSH_WITH_UTILS_KEY} -n jenkins@${VM_IP} "umask 0022 && git clone ${ghprbAuthorRepoGitUrl} antrea && cd antrea && git checkout ${GIT_BRANCH} && DOCKER_REGISTRY=${DOCKER_REGISTRY} ./build/images/ovs/build.sh --pull && NO_PULL=${NO_PULL} make docker-test-integration"
-      if [[ "$COVERAGE" == true ]]; then
-        run_codecov "integration-tests" "coverage-integration.txt" "" true ${VM_IP}
-      fi
+    echo "===== Run Integration tests ====="
+    # umask ensures that files are cloned with the correct permissions so that Docker caching can be leveraged
+    ${SSH_WITH_UTILS_KEY} -n jenkins@${VM_IP} "umask 0022 && git clone ${ghprbAuthorRepoGitUrl} antrea && cd antrea && git checkout ${GIT_BRANCH} && DOCKER_REGISTRY=${DOCKER_REGISTRY} ./build/images/ovs/build.sh --pull && NO_PULL=${NO_PULL} make docker-test-integration;cd multicluster && NO_LOCAL=true make test-integration"
+    if [[ "$COVERAGE" == true ]]; then
+      run_codecov "integration-tests" "coverage-integration.txt" "" true ${VM_IP}
     fi
 }
 
@@ -716,8 +707,8 @@ if [[ "$RUN_CLEANUP_ONLY" == true ]]; then
     exit 0
 fi
 
-if [[ "$TESTCASE" != "e2e" && "$TESTCASE" != "conformance" && "$TESTCASE" != "all-features-conformance" && "$TESTCASE" != "whole-conformance" && "$TESTCASE" != "networkpolicy" && "$TESTCASE" != "integration" && "$TESTCASE" != "multicluster-integration" ]]; then
-    echoerr "testcase should be e2e, integration, multicluster-integration, conformance, whole-conformance or networkpolicy"
+if [[ "$TESTCASE" != "e2e" && "$TESTCASE" != "conformance" && "$TESTCASE" != "all-features-conformance" && "$TESTCASE" != "whole-conformance" && "$TESTCASE" != "networkpolicy" && "$TESTCASE" != "integration" ]]; then
+    echoerr "testcase should be e2e, integration, conformance, all-features-conformance, whole-conformance or networkpolicy"
     exit 1
 fi
 
@@ -735,11 +726,6 @@ fi
 
 if [[ "$TESTCASE" == "integration" ]]; then
     run_integration
-    exit 0
-fi
-
-if [[ "$TESTCASE" == "multicluster-integration" ]]; then
-    run_integration "multicluster"
     exit 0
 fi
 

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -32,10 +32,6 @@ coverage:
         target: auto
         flags:
           - kind-e2e-tests
-      antrea-mc-integration-tests:
-        target: auto
-        flags:
-          - mc-integration-tests
 
 flag_management:
   default_rules:

--- a/multicluster/Makefile
+++ b/multicluster/Makefile
@@ -70,7 +70,7 @@ test-unit: fmt vet .coverage
 	@echo "==> Running unit tests <=="
 	go test -race -coverprofile=.coverage/coverage-unit.txt -covermode=atomic -cover antrea.io/antrea/multicluster/controllers/multicluster/...
 test-integration: .coverage
-	@echo "==> Running integration tests <=="
+	@echo "==> Running Multi-cluster integration tests <=="
 ifneq ($(NO_LOCAL),)
 	@echo "===> Building Antrea Multi-cluster Integration Test Docker image <==="
 	docker build -t antrea/mc-test -f build/images/test/Dockerfile $(DOCKER_BUILD_ARGS) .


### PR DESCRIPTION
Codecov supports uploading multiple files into one flag.
Since there is no conflict between multi-cluster and antrea integration
tests, we run them in one line command and use the same flag `integration-tests` for both cases to simplify CI.

Signed-off-by: Lan Luo [luola@vmware.com](mailto:luola@vmware.com)