### PR TITLE
Automated cherry pick of #3623: Support dynamic ofport on OVS gateway/tunnel port

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -348,7 +348,9 @@ func run(o *Options) error {
 		asyncRuleDeleteInterval,
 		o.dnsServerOverride,
 		v4Enabled,
-		v6Enabled)
+		v6Enabled,
+		nodeConfig.GatewayConfig.OFPort,
+		nodeConfig.TunnelOFPort)
 	if err != nil {
 		return fmt.Errorf("error creating new NetworkPolicy controller: %v", err)
 	}

--- a/pkg/agent/config/node_config.go
+++ b/pkg/agent/config/node_config.go
@@ -73,6 +73,9 @@ type GatewayConfig struct {
 	MAC  net.HardwareAddr
 	// LinkIndex is the link index of host gateway.
 	LinkIndex int
+
+	// OFPort is the OpenFlow port number of host gateway allocated by OVS.
+	OFPort uint32
 }
 
 func (g *GatewayConfig) String() string {
@@ -87,6 +90,8 @@ type AdapterNetConfig struct {
 	Gateway    string
 	DNSServers string
 	Routes     []interface{}
+	// OFPort is the OpenFlow port number of the uplink interface allocated by OVS.
+	OFPort uint32
 }
 
 type WireGuardConfig struct {
@@ -136,6 +141,12 @@ type NodeConfig struct {
 	// Auto discovery will use MTU value of the Node's primary interface.
 	// For Encap and Hybrid mode, Node MTU will be adjusted to account for encap header.
 	NodeMTU int
+	// TunnelOFPort is the OpenFlow port number of tunnel interface allocated by OVS. With noEncap mode, the value is 0.
+	TunnelOFPort uint32
+	// HostInterfaceOFPort is the OpenFlow port number of the host interface allocated by OVS. The host interface is the
+	// one which the IP/MAC of the uplink is moved to. If the host interface is the OVS bridge interface (br-int), the
+	// value is config.BridgeOFPort.
+	HostInterfaceOFPort uint32
 	// The config of the gateway interface on the OVS bridge.
 	GatewayConfig *GatewayConfig
 	// The config of the OVS bridge uplink interface. Only for Windows Node.

--- a/pkg/agent/controller/networkpolicy/fqdn_test.go
+++ b/pkg/agent/controller/networkpolicy/fqdn_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	"antrea.io/antrea/pkg/agent/config"
 	openflowtest "antrea.io/antrea/pkg/agent/openflow/testing"
 )
 
@@ -42,6 +43,7 @@ func newMockFQDNController(t *testing.T, controller *gomock.Controller, dnsServe
 		dirtyRuleHandler,
 		true,
 		false,
+		config.HostGatewayOFPort,
 	)
 	require.NoError(t, err)
 	return f, mockOFClient

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
@@ -111,6 +111,8 @@ type Controller struct {
 	ifaceStore            interfacestore.InterfaceStore
 	// denyConnStore is for storing deny connections for flow exporter.
 	denyConnStore *connections.DenyConnectionStore
+	gwPort        uint32
+	tunPort       uint32
 }
 
 // NewNetworkPolicyController returns a new *Controller.
@@ -129,7 +131,8 @@ func NewNetworkPolicyController(antreaClientGetter agent.AntreaClientProvider,
 	asyncRuleDeleteInterval time.Duration,
 	dnsServerOverride string,
 	v4Enabled bool,
-	v6Enabled bool) (*Controller, error) {
+	v6Enabled bool,
+	gwPort, tunPort uint32) (*Controller, error) {
 	idAllocator := newIDAllocator(asyncRuleDeleteInterval, dnsInterceptRuleID)
 	c := &Controller{
 		antreaClientProvider: antreaClientGetter,
@@ -140,11 +143,13 @@ func NewNetworkPolicyController(antreaClientGetter agent.AntreaClientProvider,
 		statusManagerEnabled: statusManagerEnabled,
 		multicastEnabled:     multicastEnabled,
 		loggingEnabled:       loggingEnabled,
+		gwPort:               gwPort,
+		tunPort:              tunPort,
 	}
 
 	if antreaPolicyEnabled {
 		var err error
-		if c.fqdnController, err = newFQDNController(ofClient, idAllocator, dnsServerOverride, c.enqueueRule, v4Enabled, v6Enabled); err != nil {
+		if c.fqdnController, err = newFQDNController(ofClient, idAllocator, dnsServerOverride, c.enqueueRule, v4Enabled, v6Enabled, gwPort); err != nil {
 			return nil, err
 		}
 

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
@@ -32,6 +32,7 @@ import (
 	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/component-base/metrics/legacyregistry"
 
+	"antrea.io/antrea/pkg/agent/config"
 	"antrea.io/antrea/pkg/agent/metrics"
 	"antrea.io/antrea/pkg/agent/openflow"
 	proxytypes "antrea.io/antrea/pkg/agent/proxy/types"
@@ -60,7 +61,7 @@ func newTestController() (*Controller, *fake.Clientset, *mockReconciler) {
 	ch2 := make(chan string, 100)
 	groupIDAllocator := openflow.NewGroupAllocator(false)
 	groupCounters := []proxytypes.GroupCounter{proxytypes.NewGroupCounter(groupIDAllocator, ch2)}
-	controller, _ := NewNetworkPolicyController(&antreaClientGetter{clientset}, nil, nil, "node1", podUpdateChannel, groupCounters, ch2, true, true, true, false, true, testAsyncDeleteInterval, "8.8.8.8:53", true, false)
+	controller, _ := NewNetworkPolicyController(&antreaClientGetter{clientset}, nil, nil, "node1", podUpdateChannel, groupCounters, ch2, true, true, true, false, true, testAsyncDeleteInterval, "8.8.8.8:53", true, false, config.HostGatewayOFPort, config.DefaultTunOFPort)
 	reconciler := newMockReconciler()
 	controller.reconciler = reconciler
 	controller.antreaPolicyLogger = nil

--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -799,7 +799,7 @@ func (c *client) generatePipelines() {
 
 	if c.enableMulticast {
 		// TODO: add support for IPv6 protocol
-		c.featureMulticast = newFeatureMulticast(c.cookieAllocator, []binding.Protocol{binding.ProtocolIP}, c.bridge, c.enableAntreaPolicy)
+		c.featureMulticast = newFeatureMulticast(c.cookieAllocator, []binding.Protocol{binding.ProtocolIP}, c.bridge, c.enableAntreaPolicy, c.nodeConfig.GatewayConfig.OFPort)
 		c.activatedFeatures = append(c.activatedFeatures, c.featureMulticast)
 	}
 
@@ -1199,7 +1199,7 @@ func (c *client) SendIGMPQueryPacketOut(
 	srcIP := c.nodeConfig.GatewayConfig.IPv4.String()
 	dstMACStr := dstMAC.String()
 	dstIPStr := dstIP.String()
-	packetOutBuilder, err := setBasePacketOutBuilder(c.bridge.BuildPacketOut(), srcMAC, dstMACStr, srcIP, dstIPStr, config.HostGatewayOFPort, outPort)
+	packetOutBuilder, err := setBasePacketOutBuilder(c.bridge.BuildPacketOut(), srcMAC, dstMACStr, srcIP, dstIPStr, c.nodeConfig.GatewayConfig.OFPort, outPort)
 	if err != nil {
 		return err
 	}

--- a/pkg/agent/openflow/fields.go
+++ b/pkg/agent/openflow/fields.go
@@ -15,7 +15,6 @@
 package openflow
 
 import (
-	"antrea.io/antrea/pkg/agent/config"
 	binding "antrea.io/antrea/pkg/ovs/openflow"
 )
 
@@ -85,10 +84,6 @@ var (
 	// reg1(NXM_NX_REG1)
 	// Field to cache the ofPort of the OVS interface where to output packet.
 	TargetOFPortField = binding.NewRegField(1, 0, 31, "TargetOFPort")
-	// OutputToBridgeRegMark marks that the output interface is OVS bridge.
-	OutputToBridgeRegMark = binding.NewRegMark(TargetOFPortField, config.BridgeOFPort)
-	// OutputToUplinkRegMark marks that the output interface is uplink.
-	OutputToUplinkRegMark = binding.NewRegMark(TargetOFPortField, config.UplinkOFPort)
 
 	// reg2(NXM_NX_REG2)
 	// Field to help swap values in two different flow fields in the OpenFlow actions. This field is only used in func

--- a/pkg/agent/openflow/multicast.go
+++ b/pkg/agent/openflow/multicast.go
@@ -30,6 +30,7 @@ type featureMulticast struct {
 	cookieAllocator cookie.Allocator
 	ipProtocols     []binding.Protocol
 	bridge          binding.Bridge
+	gatewayPort     uint32
 
 	cachedFlows        *flowCategoryCache
 	groupCache         sync.Map
@@ -42,7 +43,7 @@ func (f *featureMulticast) getFeatureName() string {
 	return "Multicast"
 }
 
-func newFeatureMulticast(cookieAllocator cookie.Allocator, ipProtocols []binding.Protocol, bridge binding.Bridge, anpEnabled bool) *featureMulticast {
+func newFeatureMulticast(cookieAllocator cookie.Allocator, ipProtocols []binding.Protocol, bridge binding.Bridge, anpEnabled bool, gwPort uint32) *featureMulticast {
 	return &featureMulticast{
 		cookieAllocator:    cookieAllocator,
 		ipProtocols:        ipProtocols,
@@ -51,6 +52,7 @@ func newFeatureMulticast(cookieAllocator cookie.Allocator, ipProtocols []binding
 		category:           cookie.Multicast,
 		groupCache:         sync.Map{},
 		enableAntreaPolicy: anpEnabled,
+		gatewayPort:        gwPort,
 	}
 }
 

--- a/pkg/agent/openflow/service.go
+++ b/pkg/agent/openflow/service.go
@@ -42,6 +42,7 @@ type featureService struct {
 	nodePortAddresses      map[binding.Protocol][]net.IP
 	serviceCIDRs           map[binding.Protocol]net.IPNet
 	networkConfig          *config.NetworkConfig
+	gatewayPort            uint32
 
 	enableProxy           bool
 	proxyAll              bool
@@ -110,6 +111,7 @@ func newFeatureService(
 		nodePortAddresses:      nodePortAddresses,
 		serviceCIDRs:           serviceCIDRs,
 		gatewayMAC:             nodeConfig.GatewayConfig.MAC,
+		gatewayPort:            nodeConfig.GatewayConfig.OFPort,
 		networkConfig:          networkConfig,
 		enableProxy:            enableProxy,
 		proxyAll:               proxyAll,


### PR DESCRIPTION
Cherry pick of #3623 on release-1.7.

#3623: Support dynamic ofport on OVS gateway/tunnel port

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.