### PR TITLE
Update codecov setting for test coverge check

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -11,8 +11,19 @@ comment:
   after_n_builds: 1
   show_carryforward_flags: true
 
+github_checks:
+  annotations: true
+
 coverage:
   status:
+    patch:
+      default:
+        target: 70%
+        threshold: 5%
+        base: auto
+        only_pulls: true
+        flags:
+          - unit-tests
     project:
       default:
         target: auto
@@ -38,10 +49,11 @@ flag_management:
     carryforward: true
 
 ignore:
-  - "**/testing/mock_*.go"
+  - "**/testing/*.go"
   - "**/mock_*.go"
   - "**/*generate*.go"
   - "pkg/client"
   - "**/pkg/client"
   - "**/*.pb.go"
   - "third_party"
+  - "bincover_run_main_test*"


### PR DESCRIPTION
1. Add codecov/patch status to ensure patch unit-test coverage.
Reference: https://docs.codecov.com/docs/commit-status
2. Update codecov ignore list.
3. Add `github_checks annotations`, and lines that are added 
on a commit without coverage will show up in the pull request 
files view with an annotation. You can hide annotations in the 
files view by just pressing 'a', or unselecting "Show annotations" 
in the top right of the file.
Reference: https://docs.codecov.com/docs/github-checks#hiding-annotations-in-the-files-view

For #3943 
Signed-off-by: Lan Luo <luola@vmware.com>
Signed-off-by: Wenqi Qiu <wenqiq@vmware.com>