### PR TITLE
Upgrade whereabouts CNI to v0.5.4 and align secondary network IPAM with additional pluginArgs

### DIFF
--- a/build/charts/antrea/templates/whereabouts/clusterrole.yaml
+++ b/build/charts/antrea/templates/whereabouts/clusterrole.yaml
@@ -10,6 +10,7 @@ rules:
       - whereabouts.cni.cncf.io
     resources:
       - ippools
+      - overlappingrangeipreservations
     verbs:
       - get
       - put
@@ -19,4 +20,13 @@ rules:
       - patch
       - create
       - delete
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - list
+      - update
 {{- end }}

--- a/build/images/base/Dockerfile
+++ b/build/images/base/Dockerfile
@@ -2,7 +2,7 @@ ARG OVS_VERSION
 FROM ubuntu:20.04 as cni-binaries
 
 ARG CNI_BINARIES_VERSION
-ARG WHEREABOUTS_VERSION=v0.5.1
+ARG WHEREABOUTS_VERSION=v0.5.4
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends wget ca-certificates


### PR DESCRIPTION
Register Whereabouts CNI as a valid IPAMType for secondary network configuration. Whereabouts is the IPAM used to configure secondary/virtual networks for Service function chaining needs at this time.

Signed-off-by: <arunkumar.velayutham@intel.com>