### PR TITLE
Automated cherry pick of #3938: Use uplink interface name for host interface

### DIFF
--- a/pkg/agent/agent_windows.go
+++ b/pkg/agent/agent_windows.go
@@ -150,7 +150,7 @@ func (i *Initializer) prepareOVSBridge() error {
 		externalIDs := map[string]interface{}{
 			interfacestore.AntreaInterfaceTypeKey: interfacestore.AntreaHost,
 		}
-		if _, err = i.ovsBridgeClient.CreateInternalPort(brName, config.AutoAssignedOFPort, externalIDs); err != nil {
+		if _, err = i.ovsBridgeClient.CreateInternalPort(brName, config.AutoAssignedOFPort, "", externalIDs); err != nil {
 			return err
 		}
 	}
@@ -165,7 +165,7 @@ func (i *Initializer) prepareOVSBridge() error {
 		return nil
 	}
 	// Create uplink port.
-	freePort, err := i.getFreeOFPort(config.UplinkOFPort)
+	freePort, err := i.ovsBridgeClient.AllocateOFPort(config.UplinkOFPort)
 	if err != nil {
 		klog.ErrorS(err, "Failed to find a free port on OVS")
 		return err

--- a/pkg/agent/cniserver/pod_configuration.go
+++ b/pkg/agent/cniserver/pod_configuration.go
@@ -271,7 +271,7 @@ func (pc *podConfigurator) createOVSPort(ovsPortName string, ovsAttachInfo map[s
 	var err error
 	switch pc.ifConfigurator.getOVSInterfaceType(ovsPortName) {
 	case internalOVSInterfaceType:
-		portUUID, err = pc.ovsBridgeClient.CreateInternalPort(ovsPortName, 0, ovsAttachInfo)
+		portUUID, err = pc.ovsBridgeClient.CreateInternalPort(ovsPortName, 0, "", ovsAttachInfo)
 	default:
 		if vlanID == 0 {
 			portUUID, err = pc.ovsBridgeClient.CreatePort(ovsPortName, ovsPortName, ovsAttachInfo)

--- a/pkg/agent/controller/trafficcontrol/controller.go
+++ b/pkg/agent/controller/trafficcontrol/controller.go
@@ -585,7 +585,7 @@ func ParseTrafficControlInterfaceConfig(portData *ovsconfig.OVSPortData, portCon
 // createOVSInternalPort creates an OVS internal port on OVS and corresponding interface on host. Note that, host interface
 // might not be available immediately after creating OVS internal port.
 func (c *Controller) createOVSInternalPort(portName string) (string, error) {
-	portUUID, err := c.ovsBridgeClient.CreateInternalPort(portName, 0, trafficControlPortExternalIDs)
+	portUUID, err := c.ovsBridgeClient.CreateInternalPort(portName, 0, "", trafficControlPortExternalIDs)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/ovs/ovsconfig/interfaces.go
+++ b/pkg/ovs/ovsconfig/interfaces.go
@@ -39,7 +39,7 @@ type OVSBridgeClient interface {
 	SetInterfaceOptions(name string, options map[string]interface{}) Error
 	CreatePort(name, ifDev string, externalIDs map[string]interface{}) (string, Error)
 	CreateAccessPort(name, ifDev string, externalIDs map[string]interface{}, vlanID uint16) (string, Error)
-	CreateInternalPort(name string, ofPortRequest int32, externalIDs map[string]interface{}) (string, Error)
+	CreateInternalPort(name string, ofPortRequest int32, mac string, externalIDs map[string]interface{}) (string, Error)
 	CreateTunnelPort(name string, tunnelType TunnelType, ofPortRequest int32) (string, Error)
 	CreateTunnelPortExt(name string, tunnelType TunnelType, ofPortRequest int32, csum bool, localIP string, remoteIP string, remoteName string, psk string, extraOptions, externalIDs map[string]interface{}) (string, Error)
 	CreateUplinkPort(name string, ofPortRequest int32, externalIDs map[string]interface{}) (string, Error)
@@ -48,6 +48,7 @@ type OVSBridgeClient interface {
 	GetOFPort(ifName string, waitUntilValid bool) (int32, Error)
 	GetPortData(portUUID, ifName string) (*OVSPortData, Error)
 	GetPortList() ([]OVSPortData, Error)
+	AllocateOFPort(startPort int) (int32, error)
 	SetInterfaceMTU(name string, MTU int) error
 	GetOVSVersion() (string, Error)
 	AddOVSOtherConfig(configs map[string]interface{}) Error

--- a/pkg/ovs/ovsconfig/ovs_schema.go
+++ b/pkg/ovs/ovsconfig/ovs_schema.go
@@ -36,4 +36,5 @@ type Interface struct {
 	Type          string        `json:"type,omitempty"`
 	OFPortRequest int32         `json:"ofport_request,omitempty"`
 	Options       []interface{} `json:"options,omitempty"`
+	MAC           string        `json:"mac,omitempty"`
 }

--- a/pkg/ovs/ovsconfig/testing/mock_ovsconfig.go
+++ b/pkg/ovs/ovsconfig/testing/mock_ovsconfig.go
@@ -76,6 +76,21 @@ func (mr *MockOVSBridgeClientMockRecorder) AddOVSOtherConfig(arg0 interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddOVSOtherConfig", reflect.TypeOf((*MockOVSBridgeClient)(nil).AddOVSOtherConfig), arg0)
 }
 
+// AllocateOFPort mocks base method
+func (m *MockOVSBridgeClient) AllocateOFPort(arg0 int) (int32, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AllocateOFPort", arg0)
+	ret0, _ := ret[0].(int32)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AllocateOFPort indicates an expected call of AllocateOFPort
+func (mr *MockOVSBridgeClientMockRecorder) AllocateOFPort(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllocateOFPort", reflect.TypeOf((*MockOVSBridgeClient)(nil).AllocateOFPort), arg0)
+}
+
 // Create mocks base method
 func (m *MockOVSBridgeClient) Create() ovsconfig.Error {
 	m.ctrl.T.Helper()
@@ -106,18 +121,18 @@ func (mr *MockOVSBridgeClientMockRecorder) CreateAccessPort(arg0, arg1, arg2, ar
 }
 
 // CreateInternalPort mocks base method
-func (m *MockOVSBridgeClient) CreateInternalPort(arg0 string, arg1 int32, arg2 map[string]interface{}) (string, ovsconfig.Error) {
+func (m *MockOVSBridgeClient) CreateInternalPort(arg0 string, arg1 int32, arg2 string, arg3 map[string]interface{}) (string, ovsconfig.Error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateInternalPort", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "CreateInternalPort", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(ovsconfig.Error)
 	return ret0, ret1
 }
 
 // CreateInternalPort indicates an expected call of CreateInternalPort
-func (mr *MockOVSBridgeClientMockRecorder) CreateInternalPort(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockOVSBridgeClientMockRecorder) CreateInternalPort(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateInternalPort", reflect.TypeOf((*MockOVSBridgeClient)(nil).CreateInternalPort), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateInternalPort", reflect.TypeOf((*MockOVSBridgeClient)(nil).CreateInternalPort), arg0, arg1, arg2, arg3)
 }
 
 // CreatePort mocks base method

--- a/test/integration/ovs/ovs_client_test.go
+++ b/test/integration/ovs/ovs_client_test.go
@@ -312,7 +312,7 @@ func testCreatePort(t *testing.T, br *ovsconfig.OVSBridge, name string, ifType s
 		}
 	case "internal":
 		externalIDs = map[string]interface{}{"k1": "v1", "k2": "v2"}
-		uuid, err = br.CreateInternalPort(name, ofPortRequest, externalIDs)
+		uuid, err = br.CreateInternalPort(name, ofPortRequest, "", externalIDs)
 	case "vxlan":
 		externalIDs = map[string]interface{}{}
 		uuid, err = br.CreateTunnelPort(name, ovsconfig.VXLANTunnel, ofPortRequest)


### PR DESCRIPTION
Cherry pick of #3938 on release-1.7.

#3938: Use uplink interface name for host interface

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.