### PR TITLE
Automated cherry pick of #3975: Fix Pod-to-external traffic on EKS in policyOnly mode

### DIFF
--- a/pkg/agent/util/iptables/iptables.go
+++ b/pkg/agent/util/iptables/iptables.go
@@ -173,7 +173,7 @@ func (c *Client) AppendRule(protocol Protocol, table string, chain string, ruleS
 	return nil
 }
 
-// InsertRule checks if target rule already exists, inserts it if not.
+// InsertRule checks if target rule already exists, inserts it at the beginning of the chain if not.
 func (c *Client) InsertRule(protocol Protocol, table string, chain string, ruleSpec []string) error {
 	for p := range c.ipts {
 		ipt := c.ipts[p]
@@ -190,7 +190,7 @@ func (c *Client) InsertRule(protocol Protocol, table string, chain string, ruleS
 		if err := ipt.Insert(table, chain, 1, ruleSpec...); err != nil {
 			return fmt.Errorf("error inserting rule %v to table %s chain %s: %v", ruleSpec, table, chain, err)
 		}
-		klog.V(2).InfoS("Inserted a rule", "rule", ruleSpec, "table", table, "chain", chain)
+		klog.V(2).InfoS("Inserted a rule", "rule", ruleSpec, "table", table, "chain", chain, "index", 1)
 	}
 	return nil
 }


### PR DESCRIPTION
Cherry pick of #3975 on release-1.7.

#3975: Fix Pod-to-external traffic on EKS in policyOnly mode

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.