### PR TITLE
Add sig-network test cases to the conformance CI job

### DIFF
--- a/ci/jenkins/README.md
+++ b/ci/jenkins/README.md
@@ -204,6 +204,8 @@ subset of community tests for Antrea:
   [--kubeconfig <Kubeconfig>]`.
 * To run network policy tests: `./run-k8s-e2e-tests.sh --e2e-network-policy
   [--kubeconfig <Kubeconfig>]`.
+* To run sig-network tests: `./run-k8s-e2e-tests.sh --e2e-sig-network
+  [--kubeconfig <Kubeconfig>]`.
 * To run a single test by name: `./run-k8s-e2e-tests.sh --e2e-focus <TestRegex>
   [--kubeconfig <Kubeconfig>]`.
 

--- a/ci/jenkins/test-vmc.sh
+++ b/ci/jenkins/test-vmc.sh
@@ -584,7 +584,7 @@ function run_conformance {
     ${SCP_WITH_ANTREA_CI_KEY} $GIT_CHECKOUT_DIR/jenkins/out/kubeconfig capv@${control_plane_ip}:~/.kube/config
 
     if [[ "$TESTCASE" == "conformance" ]]; then
-        ${GIT_CHECKOUT_DIR}/ci/run-k8s-e2e-tests.sh --e2e-conformance --log-mode ${MODE} --kubeconfig ${GIT_CHECKOUT_DIR}/jenkins/out/kubeconfig > ${GIT_CHECKOUT_DIR}/vmc-test.log
+        ${GIT_CHECKOUT_DIR}/ci/run-k8s-e2e-tests.sh --e2e-conformance --e2e-sig-network --log-mode ${MODE} --kubeconfig ${GIT_CHECKOUT_DIR}/jenkins/out/kubeconfig > ${GIT_CHECKOUT_DIR}/vmc-test.log
     elif [[ "$TESTCASE" == "all-features-conformance" ]]; then
         ${GIT_CHECKOUT_DIR}/ci/run-k8s-e2e-tests.sh --e2e-conformance --log-mode ${MODE} --kubeconfig ${GIT_CHECKOUT_DIR}/jenkins/out/kubeconfig > ${GIT_CHECKOUT_DIR}/vmc-test.log
     elif [[ "$TESTCASE" == "whole-conformance" ]]; then


### PR DESCRIPTION
* Add sig-network test support for CAPV cluster.
* Skip test cases which are not supported by private lab environment.

Signed-off-by: Shuyang Xin <gavinx@vmware.com>