### PR TITLE
Automated cherry pick of #3670: Fix broken Markdown links check for main branch

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -180,10 +180,11 @@ jobs:
     - name: Run verify scripts
       run: make verify
     - name: Checking for broken Markdown links
-      uses: antoninbas/github-action-markdown-link-check@1.0.9-pre
+      uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
-        folder-path: './docs'
-        file-path: './README.md, ./CHANGELOG.md, ./CONTRIBUTING.md, ./GOVERNANCE.md, ./MAINTAINERS.md, ./ROADMAP.md, ./SECURITY.md'
+        # Check modified files only for pull requests. Cronjob "Verify docs" takes care of checking all markdown files.
+        check-modified-files-only: yes
+        base-branch: ${{ github.base_ref }}
         config-file: 'hack/.md_links_config.json'
     - name: Markdownlint
       run: |


### PR DESCRIPTION
Cherry pick of #3670 on release-1.5.

#3670: Fix broken Markdown links check for main branch

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.