### PR TITLE
Improvement for throughput calculation in flow-aggregator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -191,3 +191,5 @@ require (
 )
 
 replace antrea.io/ofnet v0.6.0 => github.com/wenyingd/ofnet v0.0.0-20220817031400-cb451467adc1
+
+replace github.com/vmware/go-ipfix v0.5.12 => github.com/yuntanghsu/go-ipfix v0.2.1-0.20220728004846-ff01b41cc7b4

--- a/go.sum
+++ b/go.sum
@@ -877,8 +877,6 @@ github.com/vishvananda/netlink v1.1.1-0.20211101163509-b10eb8fe5cf6/go.mod h1:tw
 github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae h1:4hwBBUfQCFe3Cym0ZtKyq7L16eZUtYKs+BaHDN6mAns=
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
-github.com/vmware/go-ipfix v0.5.12 h1:mqQknlvnvDY25apPNy9c27ri3FMDFIhzvO68Kk5Qp58=
-github.com/vmware/go-ipfix v0.5.12/go.mod h1:yzbG1rv+yJ8GeMrRm+MDhOV3akygNZUHLhC1pDoD2AY=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
@@ -891,6 +889,8 @@ github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
+github.com/yuntanghsu/go-ipfix v0.2.1-0.20220728004846-ff01b41cc7b4 h1:/fW21pm9Dy0HH1nyjn8ab89FFfm1sh8cozKVQyYlU6o=
+github.com/yuntanghsu/go-ipfix v0.2.1-0.20220728004846-ff01b41cc7b4/go.mod h1:yzbG1rv+yJ8GeMrRm+MDhOV3akygNZUHLhC1pDoD2AY=
 gitlab.com/golang-commonmark/puny v0.0.0-20191124015043-9f83538fa04f h1:Wku8eEdeJqIOFHtrfkYUByc4bCaTeA6fL0UJgfEiFMI=
 gitlab.com/golang-commonmark/puny v0.0.0-20191124015043-9f83538fa04f/go.mod h1:Tiuhl+njh/JIg0uS/sOJVYi0x2HEa5rc1OAaVsb5tAs=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=

--- a/pkg/agent/flowexporter/connections/conntrack_linux_test.go
+++ b/pkg/agent/flowexporter/connections/conntrack_linux_test.go
@@ -49,6 +49,9 @@ var (
 	}
 )
 
+const defaultTCPTimeoutTimeWait = 120
+const defaultTCPTimeoutClose = 10
+
 func TestConnTrackSystem_DumpFlows(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -242,7 +245,7 @@ func TestNetLinkFlowToAntreaConnection(t *testing.T) {
 		TCPState:                  "",
 	}
 
-	antreaFlow := NetlinkFlowToAntreaConnection(netlinkFlow)
+	antreaFlow := NetlinkFlowToAntreaConnection(netlinkFlow, defaultTCPTimeoutTimeWait, defaultTCPTimeoutClose)
 	// Just add the stop time directly as it will be set to the time of day at
 	// which the function was executed.
 	expectedAntreaFlow.StopTime = antreaFlow.StopTime
@@ -279,6 +282,6 @@ func TestNetLinkFlowToAntreaConnection(t *testing.T) {
 		TCPState:                  "",
 	}
 
-	antreaFlow = NetlinkFlowToAntreaConnection(netlinkFlow)
+	antreaFlow = NetlinkFlowToAntreaConnection(netlinkFlow, defaultTCPTimeoutTimeWait, defaultTCPTimeoutClose)
 	assert.Equalf(t, expectedAntreaFlow, antreaFlow, "both flows should be equal")
 }

--- a/pkg/agent/flowexporter/exporter/exporter.go
+++ b/pkg/agent/flowexporter/exporter/exporter.go
@@ -55,8 +55,8 @@ const maxConnsToExport = 64
 
 var (
 	IANAInfoElementsCommon = []string{
-		"flowStartSeconds",
-		"flowEndSeconds",
+		"flowStartMilliseconds",
+		"flowEndMilliseconds",
 		"flowEndReason",
 		"sourceTransportPort",
 		"destinationTransportPort",
@@ -391,10 +391,10 @@ func (exp *FlowExporter) addConnToSet(conn *flowexporter.Connection) error {
 	for i := range eL {
 		ie := eL[i]
 		switch ieName := ie.GetInfoElement().Name; ieName {
-		case "flowStartSeconds":
-			ie.SetUnsigned32Value(uint32(conn.StartTime.Unix()))
-		case "flowEndSeconds":
-			ie.SetUnsigned32Value(uint32(conn.StopTime.Unix()))
+		case "flowStartMilliseconds":
+			ie.SetUnsigned64Value(uint64(conn.StartTime.UnixMilli()))
+		case "flowEndMilliseconds":
+			ie.SetUnsigned64Value(uint64(conn.StopTime.UnixMilli()))
 		case "flowEndReason":
 			if flowexporter.IsConnectionDying(conn) {
 				ie.SetUnsigned8Value(ipfixregistry.EndOfFlowReason)

--- a/pkg/flowaggregator/clickhouseclient/clickhouseclient.go
+++ b/pkg/flowaggregator/clickhouseclient/clickhouseclient.go
@@ -148,53 +148,53 @@ func (ci *ClickHouseInput) getDataSourceName() (string, error) {
 }
 
 type ClickHouseFlowRow struct {
-	flowStartSeconds                     time.Time
-	flowEndSeconds                       time.Time
-	flowEndSecondsFromSourceNode         time.Time
-	flowEndSecondsFromDestinationNode    time.Time
-	flowEndReason                        uint8
-	sourceIP                             string
-	destinationIP                        string
-	sourceTransportPort                  uint16
-	destinationTransportPort             uint16
-	protocolIdentifier                   uint8
-	packetTotalCount                     uint64
-	octetTotalCount                      uint64
-	packetDeltaCount                     uint64
-	octetDeltaCount                      uint64
-	reversePacketTotalCount              uint64
-	reverseOctetTotalCount               uint64
-	reversePacketDeltaCount              uint64
-	reverseOctetDeltaCount               uint64
-	sourcePodName                        string
-	sourcePodNamespace                   string
-	sourceNodeName                       string
-	destinationPodName                   string
-	destinationPodNamespace              string
-	destinationNodeName                  string
-	destinationClusterIP                 string
-	destinationServicePort               uint16
-	destinationServicePortName           string
-	ingressNetworkPolicyName             string
-	ingressNetworkPolicyNamespace        string
-	ingressNetworkPolicyRuleName         string
-	ingressNetworkPolicyRuleAction       uint8
-	ingressNetworkPolicyType             uint8
-	egressNetworkPolicyName              string
-	egressNetworkPolicyNamespace         string
-	egressNetworkPolicyRuleName          string
-	egressNetworkPolicyRuleAction        uint8
-	egressNetworkPolicyType              uint8
-	tcpState                             string
-	flowType                             uint8
-	sourcePodLabels                      string
-	destinationPodLabels                 string
-	throughput                           uint64
-	reverseThroughput                    uint64
-	throughputFromSourceNode             uint64
-	throughputFromDestinationNode        uint64
-	reverseThroughputFromSourceNode      uint64
-	reverseThroughputFromDestinationNode uint64
+	flowStartMilliseconds                  time.Time
+	flowEndMilliseconds                    time.Time
+	flowEndMillisecondsFromSourceNode      time.Time
+	flowEndMillisecondsFromDestinationNode time.Time
+	flowEndReason                          uint8
+	sourceIP                               string
+	destinationIP                          string
+	sourceTransportPort                    uint16
+	destinationTransportPort               uint16
+	protocolIdentifier                     uint8
+	packetTotalCount                       uint64
+	octetTotalCount                        uint64
+	packetDeltaCount                       uint64
+	octetDeltaCount                        uint64
+	reversePacketTotalCount                uint64
+	reverseOctetTotalCount                 uint64
+	reversePacketDeltaCount                uint64
+	reverseOctetDeltaCount                 uint64
+	sourcePodName                          string
+	sourcePodNamespace                     string
+	sourceNodeName                         string
+	destinationPodName                     string
+	destinationPodNamespace                string
+	destinationNodeName                    string
+	destinationClusterIP                   string
+	destinationServicePort                 uint16
+	destinationServicePortName             string
+	ingressNetworkPolicyName               string
+	ingressNetworkPolicyNamespace          string
+	ingressNetworkPolicyRuleName           string
+	ingressNetworkPolicyRuleAction         uint8
+	ingressNetworkPolicyType               uint8
+	egressNetworkPolicyName                string
+	egressNetworkPolicyNamespace           string
+	egressNetworkPolicyRuleName            string
+	egressNetworkPolicyRuleAction          uint8
+	egressNetworkPolicyType                uint8
+	tcpState                               string
+	flowType                               uint8
+	sourcePodLabels                        string
+	destinationPodLabels                   string
+	throughput                             uint64
+	reverseThroughput                      uint64
+	throughputFromSourceNode               uint64
+	throughputFromDestinationNode          uint64
+	reverseThroughputFromSourceNode        uint64
+	reverseThroughputFromDestinationNode   uint64
 }
 
 func NewClickHouseClient(input ClickHouseInput) (*ClickHouseExportProcess, error) {
@@ -264,17 +264,17 @@ func (ch *ClickHouseExportProcess) stopExportProcess(flushQueue bool) {
 
 func (ch *ClickHouseExportProcess) getClickHouseFlowRow(record ipfixentities.Record) *ClickHouseFlowRow {
 	chFlowRow := ClickHouseFlowRow{}
-	if flowStartSeconds, _, ok := record.GetInfoElementWithValue("flowStartSeconds"); ok {
-		chFlowRow.flowStartSeconds = time.Unix(int64(flowStartSeconds.GetUnsigned32Value()), 0)
+	if flowStartMilliseconds, _, ok := record.GetInfoElementWithValue("flowStartMilliseconds"); ok {
+		chFlowRow.flowStartMilliseconds = time.UnixMilli(int64(flowStartMilliseconds.GetUnsigned64Value()))
 	}
-	if flowEndSeconds, _, ok := record.GetInfoElementWithValue("flowEndSeconds"); ok {
-		chFlowRow.flowEndSeconds = time.Unix(int64(flowEndSeconds.GetUnsigned32Value()), 0)
+	if flowEndMilliseconds, _, ok := record.GetInfoElementWithValue("flowEndMilliseconds"); ok {
+		chFlowRow.flowEndMilliseconds = time.UnixMilli(int64(flowEndMilliseconds.GetUnsigned64Value()))
 	}
-	if flowEndSecFromSrcNode, _, ok := record.GetInfoElementWithValue("flowEndSecondsFromSourceNode"); ok {
-		chFlowRow.flowEndSecondsFromSourceNode = time.Unix(int64(flowEndSecFromSrcNode.GetUnsigned32Value()), 0)
+	if flowEndMillisecFromSrcNode, _, ok := record.GetInfoElementWithValue("flowEndMillisecondsFromSourceNode"); ok {
+		chFlowRow.flowEndMillisecondsFromSourceNode = time.UnixMilli(int64(flowEndMillisecFromSrcNode.GetUnsigned64Value()))
 	}
-	if flowEndSecFromDstNode, _, ok := record.GetInfoElementWithValue("flowEndSecondsFromDestinationNode"); ok {
-		chFlowRow.flowEndSecondsFromDestinationNode = time.Unix(int64(flowEndSecFromDstNode.GetUnsigned32Value()), 0)
+	if flowEndMillisecFromDstNode, _, ok := record.GetInfoElementWithValue("flowEndMillisecondsFromDestinationNode"); ok {
+		chFlowRow.flowEndMillisecondsFromDestinationNode = time.UnixMilli(int64(flowEndMillisecFromDstNode.GetUnsigned64Value()))
 	}
 	if flowEndReason, _, ok := record.GetInfoElementWithValue("flowEndReason"); ok {
 		chFlowRow.flowEndReason = flowEndReason.GetUnsigned8Value()
@@ -490,10 +490,10 @@ func (ch *ClickHouseExportProcess) batchCommitAll(ctx context.Context) (int, err
 	for _, record := range recordsToExport {
 		_, err := stmt.ExecContext(
 			ctx,
-			record.flowStartSeconds,
-			record.flowEndSeconds,
-			record.flowEndSecondsFromSourceNode,
-			record.flowEndSecondsFromDestinationNode,
+			record.flowStartMilliseconds,
+			record.flowEndMilliseconds,
+			record.flowEndMillisecondsFromSourceNode,
+			record.flowEndMillisecondsFromDestinationNode,
 			record.flowEndReason,
 			record.sourceIP,
 			record.destinationIP,

--- a/pkg/flowaggregator/clickhouseclient/clickhouseclient_test.go
+++ b/pkg/flowaggregator/clickhouseclient/clickhouseclient_test.go
@@ -89,10 +89,10 @@ func TestGetClickHouseFlowRow(t *testing.T) {
 
 		chClient := &ClickHouseExportProcess{}
 		flowRow := chClient.getClickHouseFlowRow(mockRecord)
-		assert.Equal(t, time.Unix(int64(1637706961), 0), flowRow.flowStartSeconds)
-		assert.Equal(t, time.Unix(int64(1637706973), 0), flowRow.flowEndSeconds)
-		assert.Equal(t, time.Unix(int64(1637706974), 0), flowRow.flowEndSecondsFromSourceNode)
-		assert.Equal(t, time.Unix(int64(1637706975), 0), flowRow.flowEndSecondsFromDestinationNode)
+		assert.Equal(t, time.UnixMilli(1637706961), flowRow.flowStartMilliseconds)
+		assert.Equal(t, time.UnixMilli(1637706973), flowRow.flowEndMilliseconds)
+		assert.Equal(t, time.UnixMilli(1637706974), flowRow.flowEndMillisecondsFromSourceNode)
+		assert.Equal(t, time.UnixMilli(1637706975), flowRow.flowEndMillisecondsFromDestinationNode)
 		assert.Equal(t, uint8(3), flowRow.flowEndReason)
 		assert.Equal(t, uint16(44752), flowRow.sourceTransportPort)
 		assert.Equal(t, uint16(5201), flowRow.destinationTransportPort)
@@ -153,21 +153,21 @@ func createElement(name string, enterpriseID uint32) ipfixentities.InfoElementWi
 }
 
 func prepareMockRecord(mockRecord *ipfixentitiestesting.MockRecord, isIPv4 bool) {
-	flowStartSecElem := createElement("flowStartSeconds", ipfixregistry.IANAEnterpriseID)
-	flowStartSecElem.SetUnsigned32Value(uint32(1637706961))
-	mockRecord.EXPECT().GetInfoElementWithValue("flowStartSeconds").Return(flowStartSecElem, 0, true)
+	flowStartSecElem := createElement("flowStartMilliseconds", ipfixregistry.IANAEnterpriseID)
+	flowStartSecElem.SetUnsigned64Value(uint64(1637706961))
+	mockRecord.EXPECT().GetInfoElementWithValue("flowStartMilliseconds").Return(flowStartSecElem, 0, true)
 
-	flowEndSecElem := createElement("flowEndSeconds", ipfixregistry.IANAEnterpriseID)
-	flowEndSecElem.SetUnsigned32Value(uint32(1637706973))
-	mockRecord.EXPECT().GetInfoElementWithValue("flowEndSeconds").Return(flowEndSecElem, 0, true)
+	flowEndSecElem := createElement("flowEndMilliseconds", ipfixregistry.IANAEnterpriseID)
+	flowEndSecElem.SetUnsigned64Value(uint64(1637706973))
+	mockRecord.EXPECT().GetInfoElementWithValue("flowEndMilliseconds").Return(flowEndSecElem, 0, true)
 
-	flowEndSecSrcNodeElem := createElement("flowEndSecondsFromSourceNode", ipfixregistry.AntreaEnterpriseID)
-	flowEndSecSrcNodeElem.SetUnsigned32Value(uint32(1637706974))
-	mockRecord.EXPECT().GetInfoElementWithValue("flowEndSecondsFromSourceNode").Return(flowEndSecSrcNodeElem, 0, true)
+	flowEndSecSrcNodeElem := createElement("flowEndMillisecondsFromSourceNode", ipfixregistry.AntreaEnterpriseID)
+	flowEndSecSrcNodeElem.SetUnsigned64Value(uint64(1637706974))
+	mockRecord.EXPECT().GetInfoElementWithValue("flowEndMillisecondsFromSourceNode").Return(flowEndSecSrcNodeElem, 0, true)
 
-	flowEndSecDstNodeElem := createElement("flowEndSecondsFromDestinationNode", ipfixregistry.AntreaEnterpriseID)
-	flowEndSecDstNodeElem.SetUnsigned32Value(uint32(1637706975))
-	mockRecord.EXPECT().GetInfoElementWithValue("flowEndSecondsFromDestinationNode").Return(flowEndSecDstNodeElem, 0, true)
+	flowEndSecDstNodeElem := createElement("flowEndMillisecondsFromDestinationNode", ipfixregistry.AntreaEnterpriseID)
+	flowEndSecDstNodeElem.SetUnsigned64Value(uint64(1637706975))
+	mockRecord.EXPECT().GetInfoElementWithValue("flowEndMillisecondsFromDestinationNode").Return(flowEndSecDstNodeElem, 0, true)
 
 	flowEndReasonElem := createElement("flowEndReason", ipfixregistry.IANAEnterpriseID)
 	flowEndReasonElem.SetUnsigned8Value(uint8(3))
@@ -388,53 +388,53 @@ func TestCacheRecord(t *testing.T) {
 
 func getTestClickHouseFlowRow() *ClickHouseFlowRow {
 	return &ClickHouseFlowRow{
-		flowStartSeconds:                     time.Unix(int64(1637706961), 0),
-		flowEndSeconds:                       time.Unix(int64(1637706973), 0),
-		flowEndSecondsFromSourceNode:         time.Unix(int64(1637706974), 0),
-		flowEndSecondsFromDestinationNode:    time.Unix(int64(1637706975), 0),
-		flowEndReason:                        3,
-		sourceIP:                             "10.10.0.79",
-		destinationIP:                        "10.10.0.80",
-		sourceTransportPort:                  44752,
-		destinationTransportPort:             5201,
-		protocolIdentifier:                   6,
-		packetTotalCount:                     823188,
-		octetTotalCount:                      30472817041,
-		packetDeltaCount:                     241333,
-		octetDeltaCount:                      8982624938,
-		reversePacketTotalCount:              471111,
-		reverseOctetTotalCount:               24500996,
-		reversePacketDeltaCount:              136211,
-		reverseOctetDeltaCount:               7083284,
-		sourcePodName:                        "perftest-a",
-		sourcePodNamespace:                   "antrea-test",
-		sourceNodeName:                       "k8s-node-control-plane",
-		destinationPodName:                   "perftest-b",
-		destinationPodNamespace:              "antrea-test-b",
-		destinationNodeName:                  "k8s-node-control-plane-b",
-		destinationClusterIP:                 "10.10.1.10",
-		destinationServicePort:               5202,
-		destinationServicePortName:           "perftest",
-		ingressNetworkPolicyName:             "test-flow-aggregator-networkpolicy-ingress-allow",
-		ingressNetworkPolicyNamespace:        "antrea-test-ns",
-		ingressNetworkPolicyRuleName:         "test-flow-aggregator-networkpolicy-rule",
-		ingressNetworkPolicyRuleAction:       2,
-		ingressNetworkPolicyType:             1,
-		egressNetworkPolicyName:              "test-flow-aggregator-networkpolicy-egress-allow",
-		egressNetworkPolicyNamespace:         "antrea-test-ns-e",
-		egressNetworkPolicyRuleName:          "test-flow-aggregator-networkpolicy-rule-e",
-		egressNetworkPolicyRuleAction:        5,
-		egressNetworkPolicyType:              4,
-		tcpState:                             "TIME_WAIT",
-		flowType:                             11,
-		sourcePodLabels:                      "{\"antrea-e2e\":\"perftest-a\",\"app\":\"perftool\"}",
-		destinationPodLabels:                 "{\"antrea-e2e\":\"perftest-b\",\"app\":\"perftool\"}",
-		throughput:                           15902813472,
-		reverseThroughput:                    12381344,
-		throughputFromSourceNode:             15902813473,
-		throughputFromDestinationNode:        15902813474,
-		reverseThroughputFromSourceNode:      12381345,
-		reverseThroughputFromDestinationNode: 12381346,
+		flowStartMilliseconds:                  time.UnixMilli(int64(1637706961)),
+		flowEndMilliseconds:                    time.UnixMilli(int64(1637706973)),
+		flowEndMillisecondsFromSourceNode:      time.UnixMilli(int64(1637706974)),
+		flowEndMillisecondsFromDestinationNode: time.UnixMilli(int64(1637706975)),
+		flowEndReason:                          3,
+		sourceIP:                               "10.10.0.79",
+		destinationIP:                          "10.10.0.80",
+		sourceTransportPort:                    44752,
+		destinationTransportPort:               5201,
+		protocolIdentifier:                     6,
+		packetTotalCount:                       823188,
+		octetTotalCount:                        30472817041,
+		packetDeltaCount:                       241333,
+		octetDeltaCount:                        8982624938,
+		reversePacketTotalCount:                471111,
+		reverseOctetTotalCount:                 24500996,
+		reversePacketDeltaCount:                136211,
+		reverseOctetDeltaCount:                 7083284,
+		sourcePodName:                          "perftest-a",
+		sourcePodNamespace:                     "antrea-test",
+		sourceNodeName:                         "k8s-node-control-plane",
+		destinationPodName:                     "perftest-b",
+		destinationPodNamespace:                "antrea-test-b",
+		destinationNodeName:                    "k8s-node-control-plane-b",
+		destinationClusterIP:                   "10.10.1.10",
+		destinationServicePort:                 5202,
+		destinationServicePortName:             "perftest",
+		ingressNetworkPolicyName:               "test-flow-aggregator-networkpolicy-ingress-allow",
+		ingressNetworkPolicyNamespace:          "antrea-test-ns",
+		ingressNetworkPolicyRuleName:           "test-flow-aggregator-networkpolicy-rule",
+		ingressNetworkPolicyRuleAction:         2,
+		ingressNetworkPolicyType:               1,
+		egressNetworkPolicyName:                "test-flow-aggregator-networkpolicy-egress-allow",
+		egressNetworkPolicyNamespace:           "antrea-test-ns-e",
+		egressNetworkPolicyRuleName:            "test-flow-aggregator-networkpolicy-rule-e",
+		egressNetworkPolicyRuleAction:          5,
+		egressNetworkPolicyType:                4,
+		tcpState:                               "TIME_WAIT",
+		flowType:                               11,
+		sourcePodLabels:                        "{\"antrea-e2e\":\"perftest-a\",\"app\":\"perftool\"}",
+		destinationPodLabels:                   "{\"antrea-e2e\":\"perftest-b\",\"app\":\"perftool\"}",
+		throughput:                             15902813472,
+		reverseThroughput:                      12381344,
+		throughputFromSourceNode:               15902813473,
+		throughputFromDestinationNode:          15902813474,
+		reverseThroughputFromSourceNode:        12381345,
+		reverseThroughputFromDestinationNode:   12381346,
 	}
 }
 
@@ -456,10 +456,10 @@ func TestBatchCommitAll(t *testing.T) {
 	mock.ExpectBegin()
 	mock.ExpectPrepare(insertQuery).ExpectExec().
 		WithArgs(
-			time.Unix(int64(1637706961), 0),
-			time.Unix(int64(1637706973), 0),
-			time.Unix(int64(1637706974), 0),
-			time.Unix(int64(1637706975), 0),
+			time.UnixMilli(int64(1637706961)),
+			time.UnixMilli(int64(1637706973)),
+			time.UnixMilli(int64(1637706974)),
+			time.UnixMilli(int64(1637706975)),
 			3,
 			"10.10.0.79",
 			"10.10.0.80",

--- a/pkg/flowaggregator/exporter/ipfix.go
+++ b/pkg/flowaggregator/exporter/ipfix.go
@@ -304,7 +304,7 @@ func (e *IPFIXExporter) sendTemplateSet(isIPv6 bool) (int, error) {
 		}
 		elements = append(elements, ie)
 	}
-	for _, ie := range infoelements.AntreaFlowEndSecondsElementList {
+	for _, ie := range infoelements.AntreaFlowEndMillisecondsElementList {
 		ie, err := e.createInfoElementForTemplateSet(ie, ipfixregistry.AntreaEnterpriseID)
 		if err != nil {
 			return 0, err

--- a/pkg/flowaggregator/exporter/ipfix_test.go
+++ b/pkg/flowaggregator/exporter/ipfix_test.go
@@ -109,7 +109,7 @@ func TestIPFIXExporter_sendTemplateSet(t *testing.T) {
 			elemList = append(elemList, createElement(infoelements.AntreaDestinationStatsElementList[i], ipfixregistry.AntreaEnterpriseID))
 			mockIPFIXRegistry.EXPECT().GetInfoElement(infoelements.AntreaDestinationStatsElementList[i], ipfixregistry.AntreaEnterpriseID).Return(elemList[len(elemList)-1].GetInfoElement(), nil)
 		}
-		for _, ie := range infoelements.AntreaFlowEndSecondsElementList {
+		for _, ie := range infoelements.AntreaFlowEndMillisecondsElementList {
 			elemList = append(elemList, createElement(ie, ipfixregistry.AntreaEnterpriseID))
 			mockIPFIXRegistry.EXPECT().GetInfoElement(ie, ipfixregistry.AntreaEnterpriseID).Return(elemList[len(elemList)-1].GetInfoElement(), nil)
 		}

--- a/pkg/flowaggregator/flowaggregator.go
+++ b/pkg/flowaggregator/flowaggregator.go
@@ -48,7 +48,7 @@ var (
 		StatsElements:                      infoelements.StatsElementList,
 		AggregatedSourceStatsElements:      infoelements.AntreaSourceStatsElementList,
 		AggregatedDestinationStatsElements: infoelements.AntreaDestinationStatsElementList,
-		AntreaFlowEndSecondsElements:       infoelements.AntreaFlowEndSecondsElementList,
+		AntreaFlowEndMillisecondsElements:  infoelements.AntreaFlowEndMillisecondsElementList,
 		ThroughputElements:                 infoelements.AntreaThroughputElementList,
 		SourceThroughputElements:           infoelements.AntreaSourceThroughputElementList,
 		DestinationThroughputElements:      infoelements.AntreaDestinationThroughputElementList,
@@ -254,7 +254,7 @@ func (fa *flowAggregator) InitCollectingProcess() error {
 		}
 	}
 	cpInput.NumExtraElements = len(infoelements.AntreaSourceStatsElementList) + len(infoelements.AntreaDestinationStatsElementList) + len(infoelements.AntreaLabelsElementList) +
-		len(infoelements.AntreaFlowEndSecondsElementList) + len(infoelements.AntreaThroughputElementList) + len(infoelements.AntreaSourceThroughputElementList) + len(infoelements.AntreaDestinationThroughputElementList)
+		len(infoelements.AntreaFlowEndMillisecondsElementList) + len(infoelements.AntreaThroughputElementList) + len(infoelements.AntreaSourceThroughputElementList) + len(infoelements.AntreaDestinationThroughputElementList)
 	var err error
 	fa.collectingProcess, err = ipfix.NewIPFIXCollectingProcess(cpInput)
 	return err

--- a/pkg/flowaggregator/infoelements/elements.go
+++ b/pkg/flowaggregator/infoelements/elements.go
@@ -16,8 +16,8 @@ package infoelements
 
 var (
 	IANAInfoElementsCommon = []string{
-		"flowStartSeconds",
-		"flowEndSeconds",
+		"flowStartMilliseconds",
+		"flowEndMilliseconds",
 		"flowEndReason",
 		"sourceTransportPort",
 		"destinationTransportPort",
@@ -62,7 +62,7 @@ var (
 	AntreaInfoElementsIPv6 = append(AntreaInfoElementsCommon, []string{"destinationClusterIPv6"}...)
 
 	NonStatsElementList = []string{
-		"flowEndSeconds",
+		"flowEndMilliseconds",
 		"flowEndReason",
 		"tcpState",
 	}
@@ -101,9 +101,9 @@ var (
 		"sourcePodLabels",
 		"destinationPodLabels",
 	}
-	AntreaFlowEndSecondsElementList = []string{
-		"flowEndSecondsFromSourceNode",
-		"flowEndSecondsFromDestinationNode",
+	AntreaFlowEndMillisecondsElementList = []string{
+		"flowEndMillisecondsFromSourceNode",
+		"flowEndMillisecondsFromDestinationNode",
 	}
 	AntreaThroughputElementList = []string{
 		"throughput",


### PR DESCRIPTION
1. Change the stopTime definition in conntrack_linux
2. Change flowStartSeconds/flowEndSecond/... to flowStartMillisecond/flowEndMillisecond/... for throughput accuracy.

Signed-off-by: Yun-Tang Hsu <hsuy@vmware.com>

Related PR: [Improvement for the throughput calculation in flow-aggregator #286](https://github.com/vmware/go-ipfix/pull/286)