### PR TITLE
Update ClusterSet and ClusterClaim webhooks

### DIFF
--- a/multicluster/apis/multicluster/v1alpha2/clusterclaim_webhook.go
+++ b/multicluster/apis/multicluster/v1alpha2/clusterclaim_webhook.go
@@ -31,8 +31,6 @@ func (r *ClusterClaim) SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
-//+kubebuilder:webhook:path=/mutate-multicluster-crd-antrea-io-v1alpha2-clusterclaim,mutating=true,failurePolicy=fail,sideEffects=None,groups=multicluster.crd.antrea.io,resources=clusterclaims,verbs=create;update,versions=v1alpha2,name=mclusterclaim.kb.io,admissionReviewVersions={v1,v1beta1}
-
 var _ webhook.Defaulter = &ClusterClaim{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
@@ -49,9 +47,9 @@ var _ webhook.Validator = &ClusterClaim{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *ClusterClaim) ValidateCreate() error {
-	klog.InfoS("validate create", "name", r.Name)
+	klog.InfoS("Validate create", "name", r.Name)
 	if r.Name != WellKnownClusterClaimClusterSet && r.Name != WellKnownClusterClaimID {
-		err := fmt.Errorf("The name %s is not valid, only 'id.k8s.io' and 'clusterset.k8s.io' are valid names for ClusterClaim", r.Name)
+		err := fmt.Errorf("name %s is not valid, only 'id.k8s.io' and 'clusterset.k8s.io' are valid names for ClusterClaim", r.Name)
 		return err
 	}
 
@@ -60,15 +58,19 @@ func (r *ClusterClaim) ValidateCreate() error {
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *ClusterClaim) ValidateUpdate(old runtime.Object) error {
-	klog.InfoS("validate update", "name", r.Name)
+	klog.InfoS("Validate update", "name", r.Name)
 
-	// TODO(user): fill in your validation logic upon object update.
+	oldClusterClaim := old.(*ClusterClaim)
+	if r.Value != oldClusterClaim.Value {
+		err := fmt.Errorf("the field 'value' is immutable")
+		return err
+	}
 	return nil
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
 func (r *ClusterClaim) ValidateDelete() error {
-	klog.InfoS("validate delete", "name", r.Name)
+	klog.InfoS("Validate delete", "name", r.Name)
 
 	// TODO(user): fill in your validation logic upon object deletion.
 	return nil

--- a/multicluster/build/yamls/antrea-multicluster-leader-namespaced.yml
+++ b/multicluster/build/yamls/antrea-multicluster-leader-namespaced.yml
@@ -441,30 +441,6 @@ webhooks:
     resources:
     - resourceexports
   sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: antrea-mc-webhook-service
-      namespace: antrea-multicluster
-      path: /mutate-multicluster-crd-antrea-io-v1alpha2-clusterclaim
-  failurePolicy: Fail
-  name: mclusterclaim.kb.io
-  namespaceSelector:
-    matchLabels:
-      kubernetes.io/metadata.name: antrea-multicluster
-  rules:
-  - apiGroups:
-    - multicluster.crd.antrea.io
-    apiVersions:
-    - v1alpha2
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - clusterclaims
-  sideEffects: None
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -497,6 +473,30 @@ webhooks:
     - UPDATE
     resources:
     - clusterclaims
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: antrea-mc-webhook-service
+      namespace: antrea-multicluster
+      path: /validate-multicluster-crd-antrea-io-v1alpha1-clusterset
+  failurePolicy: Fail
+  name: vclusterset.kb.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: antrea-multicluster
+  rules:
+  - apiGroups:
+    - multicluster.crd.antrea.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clustersets
   sideEffects: None
 - admissionReviewVersions:
   - v1

--- a/multicluster/build/yamls/antrea-multicluster-member.yml
+++ b/multicluster/build/yamls/antrea-multicluster-member.yml
@@ -1041,31 +1041,7 @@ metadata:
   labels:
     app: antrea
   name: antrea-mc-mutating-webhook-configuration
-webhooks:
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: antrea-mc-webhook-service
-      namespace: kube-system
-      path: /mutate-multicluster-crd-antrea-io-v1alpha2-clusterclaim
-  failurePolicy: Fail
-  name: mclusterclaim.kb.io
-  namespaceSelector:
-    matchLabels:
-      kubernetes.io/metadata.name: kube-system
-  rules:
-  - apiGroups:
-    - multicluster.crd.antrea.io
-    apiVersions:
-    - v1alpha2
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - clusterclaims
-  sideEffects: None
+webhooks: []
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -1097,4 +1073,28 @@ webhooks:
     - UPDATE
     resources:
     - clusterclaims
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: antrea-mc-webhook-service
+      namespace: kube-system
+      path: /validate-multicluster-crd-antrea-io-v1alpha1-clusterset
+  failurePolicy: Fail
+  name: vclusterset.kb.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: kube-system
+  rules:
+  - apiGroups:
+    - multicluster.crd.antrea.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clustersets
   sideEffects: None

--- a/multicluster/cmd/multicluster-controller/clusterset_webhook_test.go
+++ b/multicluster/cmd/multicluster-controller/clusterset_webhook_test.go
@@ -1,0 +1,216 @@
+/*
+Copyright 2022 Antrea Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	j "encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	k8smcsv1alpha1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
+
+	mcsv1alpha1 "antrea.io/antrea/multicluster/apis/multicluster/v1alpha1"
+)
+
+var clusterSetWebhookUnderTest *clusterSetValidator
+
+func TestWebhookClusterSetEvents(t *testing.T) {
+	newClusterSet := &mcsv1alpha1.ClusterSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "mcs1",
+			Name:      "clusterset1",
+		},
+		Spec: mcsv1alpha1.ClusterSetSpec{
+			Leaders: []mcsv1alpha1.MemberCluster{
+				{
+					ClusterID: "leader1",
+				}},
+			Members: []mcsv1alpha1.MemberCluster{
+				{
+					ClusterID:      "east",
+					ServiceAccount: "east-access-sa",
+				},
+				{
+					ClusterID:      "west",
+					ServiceAccount: "west-access-sa",
+				},
+			},
+			Namespace: "mcs-A",
+		},
+	}
+
+	existingClusterSet1 := &mcsv1alpha1.ClusterSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "mcs1",
+			Name:      "clusterset1",
+		},
+		Spec: mcsv1alpha1.ClusterSetSpec{
+			Leaders: []mcsv1alpha1.MemberCluster{
+				{
+					ClusterID: "leader1",
+				}},
+			Members: []mcsv1alpha1.MemberCluster{
+				{
+					ClusterID:      "east",
+					ServiceAccount: "east-access-sa",
+				},
+				{
+					ClusterID:      "west",
+					ServiceAccount: "west-access-sa",
+				},
+			},
+			Namespace: "mcs-A",
+		},
+	}
+
+	existingClusterSet2 := existingClusterSet1.DeepCopy()
+	existingClusterSet2.Name = "clusterset2"
+
+	updatedClusterSet := &mcsv1alpha1.ClusterSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "mcs1",
+			Name:      "clusterset1",
+		},
+		Spec: mcsv1alpha1.ClusterSetSpec{
+			Leaders: []mcsv1alpha1.MemberCluster{
+				{
+					ClusterID: "leader1-1",
+				}},
+			Members: []mcsv1alpha1.MemberCluster{
+				{
+					ClusterID:      "east",
+					ServiceAccount: "east-access-sa",
+				},
+				{
+					ClusterID:      "west",
+					ServiceAccount: "west-access-sa",
+				},
+			},
+			Namespace: "mcs-A",
+		},
+	}
+	newCS, _ := j.Marshal(newClusterSet)
+	updatedCS, _ := j.Marshal(updatedClusterSet)
+
+	newReq := admission.Request{
+		AdmissionRequest: v1.AdmissionRequest{
+			UID: "07e52e8d-4513-11e9-a716-42010a800270",
+			Kind: metav1.GroupVersionKind{
+				Group:   "multicluster.crd.antrea.io",
+				Version: "v1alpha1",
+				Kind:    "ClusterSet",
+			},
+			Resource: metav1.GroupVersionResource{
+				Group:    "multicluster.crd.antrea.io",
+				Version:  "v1alpha1",
+				Resource: "ClusterSets",
+			},
+			Name:      "clusterset1",
+			Namespace: "mcs1",
+			Operation: v1.Create,
+			Object: runtime.RawExtension{
+				Raw: newCS,
+			},
+		},
+	}
+
+	updatedReq := admission.Request{
+		AdmissionRequest: v1.AdmissionRequest{
+			UID: "07e52e8d-4513-11e9-a716-42010a800270",
+			Kind: metav1.GroupVersionKind{
+				Group:   "multicluster.crd.antrea.io",
+				Version: "v1alpha1",
+				Kind:    "ClusterSet",
+			},
+			Resource: metav1.GroupVersionResource{
+				Group:    "multicluster.crd.antrea.io",
+				Version:  "v1alpha1",
+				Resource: "ClusterSets",
+			},
+			Name:      "clusterset1",
+			Namespace: "mcs1",
+			Operation: v1.Update,
+			Object: runtime.RawExtension{
+				Raw: updatedCS,
+			},
+			OldObject: runtime.RawExtension{
+				Raw: newCS,
+			},
+		},
+	}
+
+	tests := []struct {
+		name               string
+		req                admission.Request
+		existingClusterSet *mcsv1alpha1.ClusterSet
+		newClusterSet      *mcsv1alpha1.ClusterSet
+		isAllowed          bool
+	}{
+		{
+			name:      "create a new ClusterSet",
+			req:       newReq,
+			isAllowed: true,
+		},
+		{
+			name:               "create a new ClusterSet when there is an existing ClusterSet",
+			existingClusterSet: existingClusterSet2,
+			req:                newReq,
+			isAllowed:          false,
+		},
+		{
+			name:               "update a new ClusterSet's leader ClusterID when there is an existing ClusterSet",
+			existingClusterSet: existingClusterSet1,
+			newClusterSet:      updatedClusterSet,
+			req:                updatedReq,
+			isAllowed:          false,
+		},
+	}
+
+	newScheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(newScheme))
+	utilruntime.Must(k8smcsv1alpha1.AddToScheme(newScheme))
+	utilruntime.Must(mcsv1alpha1.AddToScheme(newScheme))
+	decoder, err := admission.NewDecoder(newScheme)
+	if err != nil {
+		klog.ErrorS(err, "Error constructing a decoder")
+	}
+
+	for _, tt := range tests {
+		fakeClient := fake.NewClientBuilder().WithScheme(newScheme).WithObjects().Build()
+		if tt.existingClusterSet != nil {
+			fakeClient = fake.NewClientBuilder().WithScheme(newScheme).WithObjects(tt.existingClusterSet).Build()
+		}
+		clusterSetWebhookUnderTest = &clusterSetValidator{
+			Client:    fakeClient,
+			namespace: "mcs1"}
+		clusterSetWebhookUnderTest.InjectDecoder(decoder)
+
+		t.Run(tt.name, func(t *testing.T) {
+			response := clusterSetWebhookUnderTest.Handle(context.Background(), tt.req)
+			assert.Equal(t, tt.isAllowed, response.Allowed)
+		})
+	}
+}

--- a/multicluster/cmd/multicluster-controller/main.go
+++ b/multicluster/cmd/multicluster-controller/main.go
@@ -48,7 +48,7 @@ func main() {
 func newControllerCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:  "antrea-mc-controller",
-		Long: "The Antrea MultiCluster Controller.",
+		Long: "The Antrea Multi-cluster Controller.",
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Println("Error: must be run in leader or member mode")
 		},

--- a/multicluster/config/overlays/member/webhook_patch.yaml
+++ b/multicluster/config/overlays/member/webhook_patch.yaml
@@ -24,13 +24,6 @@ webhooks:
 - admissionReviewVersions:
   name: mresourceimport.kb.io
   $patch: delete
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  name: mclusterclaim.kb.io
-  namespaceSelector:
-    matchLabels:
-      kubernetes.io/metadata.name: kube-system
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -41,6 +34,13 @@ webhooks:
   - v1
   - v1beta1
   name: vclusterclaim.kb.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: kube-system
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  name: vclusterset.kb.io
   namespaceSelector:
     matchLabels:
       kubernetes.io/metadata.name: kube-system

--- a/multicluster/config/webhook/manifests.yaml
+++ b/multicluster/config/webhook/manifests.yaml
@@ -26,27 +26,6 @@ webhooks:
     resources:
     - resourceexports
   sideEffects: None
-- admissionReviewVersions:
-  - v1
-  - v1beta1
-  clientConfig:
-    service:
-      name: webhook-service
-      namespace: system
-      path: /mutate-multicluster-crd-antrea-io-v1alpha2-clusterclaim
-  failurePolicy: Fail
-  name: mclusterclaim.kb.io
-  rules:
-  - apiGroups:
-    - multicluster.crd.antrea.io
-    apiVersions:
-    - v1alpha2
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - clusterclaims
-  sideEffects: None
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -74,6 +53,27 @@ webhooks:
     - UPDATE
     resources:
     - clusterclaims
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-multicluster-crd-antrea-io-v1alpha1-clusterset
+  failurePolicy: Fail
+  name: vclusterset.kb.io
+  rules:
+  - apiGroups:
+    - multicluster.crd.antrea.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clustersets
   sideEffects: None
 - admissionReviewVersions:
   - v1


### PR DESCRIPTION
1. Add a ClusterSet webhook to make Leader's ClusterID immutable, and
   allow only one ClusterSet in mc-controller's  Namespace.
2. Update ClusterClaim webhook to make `Value` field
   (ClusterID/ClusterSetID) immutable
3. Remove unused mutate webhook of ClusterClaim

Signed-off-by: Lan Luo <luola@vmware.com>