### PR TITLE
Automated cherry pick of #3995: Set up Kind clusters to run multi-cluster e2e

### DIFF
--- a/multicluster/test/e2e/README.md
+++ b/multicluster/test/e2e/README.md
@@ -2,12 +2,39 @@
 
 ## Creating the test Kubernetes ClusterSet
 
-The tests must be run on an actual Kubernetes cluster set, and there must be at least three clusters. We can create the clusters using [kubeadm](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm) or following [the e2e test instructions](https://github.com/antrea-io/antrea/blob/main/test/e2e/README.md) or through other ways.
+The tests can run either on an actual Kubernetes ClusterSet or a ClusterSet with
+Kind clusters, and there must be three clusters. You can create the clusters
+using [kubeadm](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm)
+or following [the e2e test instructions](https://github.com/antrea-io/antrea/blob/main/test/e2e/README.md)
+or through other ways.
 
-The three clusters are called leader cluster, west cluster and east cluster. Pod CIDR of each cluster should not be the same. For example, Pod CIDRs could be `192.168.0.1/22`,`192.168.4.1/22` and `192.168.8.1/22` in three clusters.
+By default, the three clusters used in the e2e tests are called `leader`, `west`
+and `east`. If you plan to use your own existing Kubernetes clusters, please make
+sure you save kubeconfig files for three clusters with the same name as cluster's
+name, and Service CIDR of each cluster must not overlap. For example, Service
+CIDRs could be `10.96.10.0/24`, `10.96.20.0/24`, and `10.96.30.0/24` for three clusters.
 
 ## Running the tests
 
-Make sure that your clusters are provisioned and that the Antrea build artifacts are pushed to all the Nodes. If you install the multicluster manually, you can then run the tests from the top-level directory with `go test -v antrea.io/antrea/multicluster/test/e2e` or you can just run `bash ci/jenkins/test-mc.sh --testcase e2e`.
+Make sure that your clusters are provisioned and the Antrea build artifacts are
+uploaded to all the Nodes. If you install the Multi-cluster Controller manually,
+you can run the tests from the top-level directory with `go test -v antrea.io/antrea/multicluster/test/e2e --mc-gateway`
+or run `bash ci/jenkins/test-mc.sh --testcase e2e --mc-gateway`. If you'd like
+to run test with Kind clusters, you can run `bash ci/jenkins/test-mc.sh --testcase e2e --mc-gateway --kind`.
+The command will create three Kind clusters and deploy Multi-cluster controllers
+into the Kind clusters before running e2e tests.
 
-When you use `test-mc.sh`, make sure your kubeconfig files of the clusters in the specific path of the script, or you can change the parameter `MULTICLUSTER_KUBECONFIG_PATH` and other parameters to your own path in the script.
+When you use `test-mc.sh`, make sure your kubeconfig files of the clusters are placed
+in the right path. The default path is `${MULTICLUSTER_KUBECONFIG_PATH}`. Please
+change the parameter `MULTICLUSTER_KUBECONFIG_PATH` to the right path where you place
+kubeconfig files. Sample commands are like below:
+
+```bash
+export WORKSPACE=`pwd`
+export MULTICLUSTER_KUBECONFIG_PATH="`pwd`/.kube"
+DOCKER_REGISTRY="$(head -n1 ci/docker-registry)"
+./ci/jenkins/test-mc.sh --testcase e2e --registry ${DOCKER_REGISTRY} --mc-gateway [--kind]
+```
+
+Notes: if you pass `--kind`, `test-mc.sh` will write kubeconfig files to the given path
+`${MULTICLUSTER_KUBECONFIG_PATH}` automatically.

--- a/multicluster/test/e2e/antreapolicy_test.go
+++ b/multicluster/test/e2e/antreapolicy_test.go
@@ -151,7 +151,7 @@ func executeTestsOnAllMemberClusters(t *testing.T, testList []*antreae2e.TestCas
 
 func (data *MCTestData) deployACNPResourceExport(t *testing.T, reFileName string) error {
 	t.Logf("Creating ResourceExport %s in the leader cluster", reFileName)
-	rc, _, stderr, err := provider.RunCommandOnNode(leaderCluster, fmt.Sprintf("kubectl apply -f %s", reFileName))
+	rc, _, stderr, err := provider.RunCommandOnNode(data.getControlPlaneNodeName(leaderCluster), fmt.Sprintf("kubectl apply -f %s", reFileName))
 	if err != nil || rc != 0 || stderr != "" {
 		return fmt.Errorf("error when deploying the ACNP ResourceExport in leader cluster: %v, stderr: %s", err, stderr)
 	}
@@ -159,7 +159,7 @@ func (data *MCTestData) deployACNPResourceExport(t *testing.T, reFileName string
 }
 
 func (data *MCTestData) deleteACNPResourceExport(reFileName string) error {
-	rc, _, stderr, err := provider.RunCommandOnNode(leaderCluster, fmt.Sprintf("kubectl delete -f %s", reFileName))
+	rc, _, stderr, err := provider.RunCommandOnNode(data.getControlPlaneNodeName(leaderCluster), fmt.Sprintf("kubectl delete -f %s", reFileName))
 	if err != nil || rc != 0 || stderr != "" {
 		return fmt.Errorf("error when deleting the ACNP ResourceExport in leader cluster: %v, stderr: %s", err, stderr)
 	}

--- a/multicluster/test/e2e/framework.go
+++ b/multicluster/test/e2e/framework.go
@@ -58,6 +58,7 @@ type TestOptions struct {
 	westClusterKubeConfigPath   string
 	eastClusterKubeConfigPath   string
 	enableGateway               bool
+	providerName                string
 	logsExportDir               string
 }
 
@@ -66,6 +67,7 @@ var testOptions TestOptions
 type MCTestData struct {
 	clusters            []string
 	clusterTestDataMap  map[string]antreae2e.TestData
+	controlPlaneNames   map[string]string
 	logsDirForTestCase  string
 	clusterGateways     map[string]string
 	clusterRegularNodes map[string]string
@@ -90,17 +92,30 @@ func (data *MCTestData) createClients() error {
 		}
 		data.clusterTestDataMap[cluster] = testData
 	}
+	data.controlPlaneNames = map[string]string{
+		"east-cluster":   "east-control-plane",
+		"west-cluster":   "west-control-plane",
+		"leader-cluster": "leader-control-plane",
+	}
 	return nil
 }
 
 func (data *MCTestData) initProviders() error {
+	providerName := "remote"
+	if testOptions.providerName == "kind" {
+		providerName = testOptions.providerName
+	}
 	for cluster, d := range data.clusterTestDataMap {
-		if err := d.InitProvider("remote", "multicluster"); err != nil {
+		if err := d.InitProvider(providerName, "multicluster"); err != nil {
 			log.Errorf("Failed to initialize provider for cluster %s", cluster)
 			return err
 		}
 	}
-	provider, _ = providers.NewRemoteProvider("multicluster")
+	if testOptions.providerName == "kind" {
+		provider, _ = providers.NewKindProvider("multicluster")
+	} else {
+		provider, _ = providers.NewRemoteProvider("multicluster")
+	}
 	return nil
 }
 
@@ -137,19 +152,6 @@ func (data *MCTestData) getService(clusterName, namespace, name string) (*corev1
 		return d.GetService(namespace, name)
 	}
 	return nil, fmt.Errorf("clusterName %s not found", clusterName)
-}
-
-func (data *MCTestData) deleteTestNamespaces(timeout time.Duration) error {
-	var failedClusters []string
-	for cluster, d := range data.clusterTestDataMap {
-		if err := d.DeleteNamespace(multiClusterTestNamespace, timeout); err != nil {
-			failedClusters = append(failedClusters, cluster)
-		}
-	}
-	if len(failedClusters) > 0 {
-		return fmt.Errorf("failed to delete Namespace %s in clusters %v", multiClusterTestNamespace, failedClusters)
-	}
-	return nil
 }
 
 func (data *MCTestData) createPod(clusterName, name, nodeName, namespace, ctrName, image string, command []string,

--- a/multicluster/test/e2e/main_test.go
+++ b/multicluster/test/e2e/main_test.go
@@ -66,6 +66,7 @@ func testMain(m *testing.M) int {
 	flag.StringVar(&testOptions.eastClusterKubeConfigPath, "east-cluster-kubeconfig-path", path.Join(homedir, ".kube", "east"), "Kubeconfig Path of the east cluster")
 	flag.StringVar(&testOptions.westClusterKubeConfigPath, "west-cluster-kubeconfig-path", path.Join(homedir, ".kube", "west"), "Kubeconfig Path of the west cluster")
 	flag.BoolVar(&testOptions.enableGateway, "mc-gateway", false, "Run tests with Multicluster Gateway")
+	flag.StringVar(&testOptions.providerName, "provider", "", "K8s test cluster provider")
 	flag.Parse()
 
 	cleanupLogging := testOptions.setupLogging()

--- a/multicluster/test/e2e/service_test.go
+++ b/multicluster/test/e2e/service_test.go
@@ -167,7 +167,7 @@ func (data *MCTestData) verifyMCServiceACNP(t *testing.T, clientPodName, eastIP 
 }
 
 func (data *MCTestData) deployServiceExport(clusterName string) error {
-	rc, _, stderr, err := provider.RunCommandOnNode(clusterName, fmt.Sprintf("kubectl apply -f %s", serviceExportYML))
+	rc, _, stderr, err := provider.RunCommandOnNode(data.getControlPlaneNodeName(clusterName), fmt.Sprintf("kubectl apply -f %s", serviceExportYML))
 	if err != nil || rc != 0 || stderr != "" {
 		return fmt.Errorf("error when deploying the ServiceExport: %v, stderr: %s", err, stderr)
 	}
@@ -176,7 +176,7 @@ func (data *MCTestData) deployServiceExport(clusterName string) error {
 }
 
 func (data *MCTestData) deleteServiceExport(clusterName string) error {
-	rc, _, stderr, err := provider.RunCommandOnNode(clusterName, fmt.Sprintf("kubectl delete -f %s", serviceExportYML))
+	rc, _, stderr, err := provider.RunCommandOnNode(data.getControlPlaneNodeName(clusterName), fmt.Sprintf("kubectl delete -f %s", serviceExportYML))
 	if err != nil || rc != 0 || stderr != "" {
 		return fmt.Errorf("error when deleting the ServiceExport: %v, stderr: %s", err, stderr)
 	}
@@ -186,8 +186,8 @@ func (data *MCTestData) deleteServiceExport(clusterName string) error {
 
 // getNodeNamesFromCluster will pick up a Node randomly as the Gateway
 // and also a regular Node from the specified cluster.
-func getNodeNamesFromCluster(clusterName string) (string, string, error) {
-	rc, output, stderr, err := provider.RunCommandOnNode(clusterName, "kubectl get node -o jsonpath='{range .items[*]}{.metadata.name}{\" \"}{end}'")
+func (data *MCTestData) getNodeNamesFromCluster(clusterName string) (string, string, error) {
+	rc, output, stderr, err := provider.RunCommandOnNode(data.getControlPlaneNodeName(clusterName), "/bin/sh -c kubectl get nodes -o custom-columns=:.metadata.name --no-headers | tr '\n' ' '")
 	if err != nil || rc != 0 || stderr != "" {
 		return "", "", fmt.Errorf("error when getting Node list: %v, stderr: %s", err, stderr)
 	}
@@ -205,7 +205,7 @@ func getNodeNamesFromCluster(clusterName string) (string, string, error) {
 
 // setGatewayNode adds an annotation to assign it as Gateway Node.
 func (data *MCTestData) setGatewayNode(t *testing.T, clusterName string, nodeName string) error {
-	rc, _, stderr, err := provider.RunCommandOnNode(clusterName, fmt.Sprintf("kubectl annotate node %s multicluster.antrea.io/gateway=true", nodeName))
+	rc, _, stderr, err := provider.RunCommandOnNode(data.getControlPlaneNodeName(clusterName), fmt.Sprintf("kubectl annotate node %s multicluster.antrea.io/gateway=true", nodeName))
 	if err != nil || rc != 0 || stderr != "" {
 		return fmt.Errorf("error when annotate the Node %s: %s, stderr: %s", nodeName, err, stderr)
 	}
@@ -214,11 +214,19 @@ func (data *MCTestData) setGatewayNode(t *testing.T, clusterName string, nodeNam
 }
 
 func (data *MCTestData) unsetGatewayNode(clusterName string, nodeName string) error {
-	rc, _, stderr, err := provider.RunCommandOnNode(clusterName, fmt.Sprintf("kubectl annotate node %s multicluster.antrea.io/gateway-", nodeName))
+	rc, _, stderr, err := provider.RunCommandOnNode(data.getControlPlaneNodeName(clusterName), fmt.Sprintf("kubectl annotate node %s multicluster.antrea.io/gateway-", nodeName))
 	if err != nil || rc != 0 || stderr != "" {
 		return fmt.Errorf("error when cleaning up annotation of the Node: %v, stderr: %s", err, stderr)
 	}
 	return nil
+}
+
+func (data *MCTestData) getControlPlaneNodeName(clusterName string) string {
+	controlplaneNodeName := clusterName
+	if testOptions.providerName == "kind" {
+		controlplaneNodeName = data.controlPlaneNames[clusterName]
+	}
+	return controlplaneNodeName
 }
 
 func initializeGateway(t *testing.T, data *MCTestData) {
@@ -230,7 +238,7 @@ func initializeGateway(t *testing.T, data *MCTestData) {
 			// Skip Gateway initialization for the leader cluster
 			continue
 		}
-		gwName, regularNode, err := getNodeNamesFromCluster(clusterName)
+		gwName, regularNode, err := data.getNodeNamesFromCluster(clusterName)
 		failOnError(err, t)
 		err = data.setGatewayNode(t, clusterName, gwName)
 		failOnError(err, t)


### PR DESCRIPTION
Cherry pick of #3995 on release-1.7.

#3995: Set up Kind clusters to run multi-cluster e2e

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.