### PR TITLE
Add controller for leader cluster to GC MemberClusterAnnounce

### DIFF
--- a/multicluster/cmd/multicluster-controller/leader.go
+++ b/multicluster/cmd/multicluster-controller/leader.go
@@ -26,6 +26,7 @@ import (
 	multiclusterv1alpha1 "antrea.io/antrea/multicluster/apis/multicluster/v1alpha1"
 	multiclustercontrollers "antrea.io/antrea/multicluster/controllers/multicluster"
 	"antrea.io/antrea/pkg/log"
+	"antrea.io/antrea/pkg/signals"
 	"antrea.io/antrea/pkg/util/env"
 )
 
@@ -87,6 +88,16 @@ func runLeader(o *Options) error {
 	if err = (&multiclusterv1alpha1.ResourceExport{}).SetupWebhookWithManager(mgr); err != nil {
 		return fmt.Errorf("error creating ResourceExport webhook: %v", err)
 	}
+	stopCh := signals.RegisterSignalHandlers()
+	staleController := multiclustercontrollers.NewStaleResCleanupController(
+		mgr.GetClient(),
+		mgr.GetScheme(),
+		env.GetPodNamespace(),
+		nil,
+		multiclustercontrollers.LeaderCluster,
+	)
+
+	go staleController.Run(stopCh)
 
 	klog.InfoS("Leader MC Controller Starting Manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {

--- a/multicluster/cmd/multicluster-controller/member.go
+++ b/multicluster/cmd/multicluster-controller/member.go
@@ -95,7 +95,9 @@ func runMember(o *Options) error {
 		mgr.GetClient(),
 		mgr.GetScheme(),
 		env.GetPodNamespace(),
-		commonAreaGetter)
+		commonAreaGetter,
+		multiclustercontrollers.MemberCluster,
+	)
 
 	go staleController.Run(stopCh)
 	// Member runs ResourceImportReconciler from RemoteCommonArea only

--- a/multicluster/controllers/multicluster/commonarea/remote_common_area.go
+++ b/multicluster/controllers/multicluster/commonarea/remote_common_area.go
@@ -234,7 +234,7 @@ func (r *remoteCommonArea) SendMemberAnnounce() error {
 		}
 		// Add timestamp to force update on MemberClusterAnnounce. Leader cluster requires
 		// periodic updates to detect connectivity. Without this, no-op updates will be ignored.
-		localClusterMemberAnnounce.Annotations[TimestampAnnotationKey] = time.Now().String()
+		localClusterMemberAnnounce.Annotations[TimestampAnnotationKey] = time.Now().Format(time.RFC3339)
 		if err := r.Update(context.TODO(), &localClusterMemberAnnounce, &client.UpdateOptions{}); err != nil {
 			klog.ErrorS(err, "Error updating MemberClusterAnnounce", "cluster", r.GetClusterID())
 			return err

--- a/multicluster/test/integration/suite_test.go
+++ b/multicluster/test/integration/suite_test.go
@@ -158,7 +158,9 @@ var _ = BeforeSuite(func() {
 		k8sManager.GetClient(),
 		k8sManager.GetScheme(),
 		"default",
-		clusterSetReconciler)
+		clusterSetReconciler,
+		multiclustercontrollers.MemberCluster,
+	)
 
 	go staleController.Run(stopCh)
 	// Make sure to trigger clean up process every 5 seconds


### PR DESCRIPTION
Add a role argument for the StaleController so that it can run in both
leader and member clusters. When it runs in a member cluster, the
controller will GC Service, ACNP, and CI resources. When it runs in a
leader cluster, the controller will GC MemberClusterAnnounces.

Signed-off-by: hujiajing <hjiajing@vmware.com>