### PR TITLE
[CI] Fix NetworkPolicy tests on Clouds

### DIFF
--- a/ci/test-conformance-aks.sh
+++ b/ci/test-conformance-aks.sh
@@ -247,10 +247,14 @@ function run_conformance() {
     echo "=== Running Antrea Conformance and Network Policy Tests ==="
     # Skip NodePort related cases for AKS since as Nodes in AKS cluster seem not accessible from other Nodes
     # through public IPs by default. See https://github.com/antrea-io/antrea/issues/2409
-    skip_regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[sig-cli\]|\[sig-storage\]|\[sig-auth\]|\[sig-api-machinery\]|\[sig-apps\]|\[sig-node\]|NodePort"
-    ${GIT_CHECKOUT_DIR}/ci/run-k8s-e2e-tests.sh --e2e-conformance --e2e-network-policy --e2e-skip ${skip_regex} \
+    skip_regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[sig-cli\]|\[sig-storage\]|\[sig-auth\]|\[sig-api-machinery\]|\[sig-apps\]|\[sig-node\]|\[sig-instrumentation\]|NodePort"
+    ${GIT_CHECKOUT_DIR}/ci/run-k8s-e2e-tests.sh --e2e-conformance --e2e-skip ${skip_regex} \
       --kube-conformance-image-version ${KUBE_CONFORMANCE_IMAGE_VERSION} \
-      --log-mode ${MODE} > ${GIT_CHECKOUT_DIR}/aks-test.log || TEST_SCRIPT_RC=$?
+      --log-mode ${MODE} > ${GIT_CHECKOUT_DIR}/aks-test.log && \
+    ${GIT_CHECKOUT_DIR}/ci/run-k8s-e2e-tests.sh --e2e-network-policy --e2e-skip "Netpol" \
+      --kube-conformance-image-version ${KUBE_CONFORMANCE_IMAGE_VERSION} \
+      --log-mode ${MODE} >> ${GIT_CHECKOUT_DIR}/aks-test.log || \
+    TEST_SCRIPT_RC=$?
 
     if [[ $TEST_SCRIPT_RC -eq 0 ]]; then
         echo "All tests passed."

--- a/ci/test-conformance-eks.sh
+++ b/ci/test-conformance-eks.sh
@@ -262,10 +262,14 @@ function run_conformance() {
 
     # Skip NodePort related cases for EKS since by default eksctl does not create security groups for nodeport service
     # access through node external IP. See https://github.com/antrea-io/antrea/issues/690
-    skip_regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[sig-cli\]|\[sig-storage\]|\[sig-auth\]|\[sig-api-machinery\]|\[sig-apps\]|\[sig-node\]|NodePort"
-    ${GIT_CHECKOUT_DIR}/ci/run-k8s-e2e-tests.sh --e2e-conformance --e2e-network-policy --e2e-skip ${skip_regex} \
-       --kube-conformance-image-version ${KUBE_CONFORMANCE_IMAGE_VERSION} \
-       --log-mode ${MODE} > ${GIT_CHECKOUT_DIR}/eks-test.log || TEST_SCRIPT_RC=$?
+    skip_regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[sig-cli\]|\[sig-storage\]|\[sig-auth\]|\[sig-api-machinery\]|\[sig-apps\]|\[sig-node\]|\[sig-instrumentation\]|NodePort"
+    ${GIT_CHECKOUT_DIR}/ci/run-k8s-e2e-tests.sh --e2e-conformance --e2e-skip ${skip_regex} \
+      --kube-conformance-image-version ${KUBE_CONFORMANCE_IMAGE_VERSION} \
+      --log-mode ${MODE} > ${GIT_CHECKOUT_DIR}/eks-test.log && \
+    ${GIT_CHECKOUT_DIR}/ci/run-k8s-e2e-tests.sh --e2e-network-policy --e2e-skip "Netpol" \
+      --kube-conformance-image-version ${KUBE_CONFORMANCE_IMAGE_VERSION} \
+      --log-mode ${MODE} >> ${GIT_CHECKOUT_DIR}/eks-test.log || \
+    TEST_SCRIPT_RC=$?
 
     if [[ $TEST_SCRIPT_RC -eq 0 ]]; then
         echo "All tests passed."


### PR DESCRIPTION
GKE's cluster version now defaults to v1.24.1, which no longer creates
secret for service account automatically, the verification in old test
cases would fail. This patch makes the test determine conformance
container image version based on the cluster's version to avoid such
issue.

However, the test suite Netpol introduced in new conformance image uses
a Namespace creation function which is not robust, leanding to random
test failures in GKE test. This patch skips it temporarily.

Besides, legacy NetworkPolicy tests for AKS and EKS have been skipped
by mistake for a while because of a conflicting skip regex. This patch
fixes it.

For https://github.com/antrea-io/antrea/issues/3762

Signed-off-by: Quan Tian <qtian@vmware.com>