### PR TITLE
Refine Node controller to support Gateway HA

### DIFF
--- a/multicluster/build/yamls/antrea-multicluster-leader-namespaced.yml
+++ b/multicluster/build/yamls/antrea-multicluster-leader-namespaced.yml
@@ -448,7 +448,6 @@ webhooks:
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  creationTimestamp: null
   labels:
     app: antrea
   name: antrea-multicluster-antrea-mc-validating-webhook-configuration

--- a/multicluster/build/yamls/antrea-multicluster-member.yml
+++ b/multicluster/build/yamls/antrea-multicluster-member.yml
@@ -1100,3 +1100,24 @@ webhooks:
     resources:
     - clustersets
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: antrea-mc-webhook-service
+      namespace: kube-system
+      path: /validate-multicluster-crd-antrea-io-v1alpha1-gateway
+  failurePolicy: Fail
+  name: vgateway.kb.io
+  rules:
+  - apiGroups:
+    - multicluster.crd.antrea.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - gateways
+  sideEffects: None

--- a/multicluster/cmd/multicluster-controller/gateway_webhook.go
+++ b/multicluster/cmd/multicluster-controller/gateway_webhook.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2022 Antrea Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	mcv1alpha1 "antrea.io/antrea/multicluster/apis/multicluster/v1alpha1"
+)
+
+//+kubebuilder:webhook:path=/validate-multicluster-crd-antrea-io-v1alpha1-gateway,mutating=false,failurePolicy=fail,sideEffects=None,groups=multicluster.crd.antrea.io,resources=gateways,verbs=create;update,versions=v1alpha1,name=vgateway.kb.io,admissionReviewVersions={v1,v1beta1}
+
+// Gateway validator
+type gatewayValidator struct {
+	Client    client.Client
+	decoder   *admission.Decoder
+	namespace string
+}
+
+// Handle handles admission requests.
+func (v *gatewayValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
+	gateway := &mcv1alpha1.Gateway{}
+	err := v.decoder.Decode(req, gateway)
+	if err != nil {
+		klog.ErrorS(err, "Error while decoding Gateway", "Gateway", req.Namespace+"/"+req.Name)
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	// Check if there is any existing Gateway.
+	gatewayList := &mcv1alpha1.GatewayList{}
+	if err := v.Client.List(context.TODO(), gatewayList, client.InNamespace(v.namespace)); err != nil {
+		klog.ErrorS(err, "Error reading Gateway", "Namespace", v.namespace)
+		return admission.Errored(http.StatusPreconditionFailed, err)
+	}
+
+	if req.Operation == admissionv1.Create && len(gatewayList.Items) > 0 {
+		err := fmt.Errorf("multiple Gateways in a Namespace are not allowed")
+		klog.ErrorS(err, "failed to create Gateway", "Gateway", klog.KObj(gateway), "Namespace", v.namespace)
+		return admission.Errored(http.StatusPreconditionFailed, err)
+	}
+	return admission.Allowed("")
+}
+
+func (v *gatewayValidator) InjectDecoder(d *admission.Decoder) error {
+	v.decoder = d
+	return nil
+}

--- a/multicluster/cmd/multicluster-controller/gateway_webhook_test.go
+++ b/multicluster/cmd/multicluster-controller/gateway_webhook_test.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2022 Antrea Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	k8smcsv1alpha1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
+
+	mcsv1alpha1 "antrea.io/antrea/multicluster/apis/multicluster/v1alpha1"
+)
+
+var gatewayWebhookUnderTest *gatewayValidator
+
+func TestWebhookGatewayEvents(t *testing.T) {
+	newGateway := &mcsv1alpha1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "node-1",
+		},
+		GatewayIP:  "1.2.3.4",
+		InternalIP: "172.168.3.4",
+	}
+	existingGateway := &mcsv1alpha1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "node-2",
+		},
+	}
+
+	newGW, _ := json.Marshal(newGateway)
+
+	newReq := admission.Request{
+		AdmissionRequest: v1.AdmissionRequest{
+			UID: "07e52e8d-4513-11e9-a716-42010a800270",
+			Kind: metav1.GroupVersionKind{
+				Group:   "multicluster.crd.antrea.io",
+				Version: "v1alpha1",
+				Kind:    "Gateway",
+			},
+			Resource: metav1.GroupVersionResource{
+				Group:    "multicluster.crd.antrea.io",
+				Version:  "v1alpha1",
+				Resource: "Gateways",
+			},
+			Name:      "node-1",
+			Namespace: "default",
+			Operation: v1.Create,
+			Object: runtime.RawExtension{
+				Raw: newGW,
+			},
+		},
+	}
+
+	newReqCopy := newReq.DeepCopy()
+	invalidReq := admission.Request{
+		AdmissionRequest: *newReqCopy,
+	}
+	invalidReq.Object = runtime.RawExtension{Raw: []byte("a")}
+
+	tests := []struct {
+		name            string
+		req             admission.Request
+		existingGateway *mcsv1alpha1.Gateway
+		newGateway      *mcsv1alpha1.Gateway
+		isAllowed       bool
+	}{
+		{
+			name:      "create a new Gateway successfully",
+			req:       newReq,
+			isAllowed: true,
+		},
+		{
+			name:            "failed to create a Gateway when there is an existing one",
+			existingGateway: existingGateway,
+			req:             newReq,
+			isAllowed:       false,
+		},
+		{
+			name:      "failed to decode request",
+			req:       invalidReq,
+			isAllowed: false,
+		},
+	}
+
+	newScheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(newScheme))
+	utilruntime.Must(k8smcsv1alpha1.AddToScheme(newScheme))
+	utilruntime.Must(mcsv1alpha1.AddToScheme(newScheme))
+	decoder, err := admission.NewDecoder(newScheme)
+	if err != nil {
+		klog.ErrorS(err, "Error constructing a decoder")
+	}
+	for _, tt := range tests {
+		fakeClient := fake.NewClientBuilder().WithScheme(newScheme).WithObjects().Build()
+		if tt.existingGateway != nil {
+			fakeClient = fake.NewClientBuilder().WithScheme(newScheme).WithObjects(tt.existingGateway).Build()
+		}
+		gatewayWebhookUnderTest = &gatewayValidator{
+			Client:    fakeClient,
+			namespace: "default"}
+		gatewayWebhookUnderTest.InjectDecoder(decoder)
+
+		t.Run(tt.name, func(t *testing.T) {
+			response := gatewayWebhookUnderTest.Handle(context.Background(), tt.req)
+			assert.Equal(t, tt.isAllowed, response.Allowed)
+		})
+	}
+}

--- a/multicluster/cmd/multicluster-controller/member.go
+++ b/multicluster/cmd/multicluster-controller/member.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	multiclustercontrollers "antrea.io/antrea/multicluster/controllers/multicluster"
 	"antrea.io/antrea/pkg/log"
@@ -53,6 +54,12 @@ func runMember(o *Options) error {
 	if err != nil {
 		return err
 	}
+
+	hookServer := mgr.GetWebhookServer()
+	hookServer.Register("/validate-multicluster-crd-antrea-io-v1alpha1-gateway",
+		&webhook.Admission{Handler: &gatewayValidator{
+			Client:    mgr.GetClient(),
+			namespace: env.GetPodNamespace()}})
 
 	clusterSetReconciler := multiclustercontrollers.NewMemberClusterSetReconciler(mgr.GetClient(),
 		mgr.GetScheme(),

--- a/multicluster/config/overlays/leader-ns/kustomization.yaml
+++ b/multicluster/config/overlays/leader-ns/kustomization.yaml
@@ -54,3 +54,4 @@ resources:
 
 patchesStrategicMerge:
   - manager_command_patch.yaml
+  - webhook_patch.yaml

--- a/multicluster/config/overlays/leader-ns/webhook_patch.yaml
+++ b/multicluster/config/overlays/leader-ns/webhook_patch.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  name: vgateway.kb.io
+  $patch: delete

--- a/multicluster/config/webhook/manifests.yaml
+++ b/multicluster/config/webhook/manifests.yaml
@@ -83,6 +83,27 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-multicluster-crd-antrea-io-v1alpha1-gateway
+  failurePolicy: Fail
+  name: vgateway.kb.io
+  rules:
+  - apiGroups:
+    - multicluster.crd.antrea.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - gateways
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-multicluster-crd-antrea-io-v1alpha1-memberclusterannounce
   failurePolicy: Fail
   name: vmemberclusterannounce.kb.io

--- a/multicluster/controllers/multicluster/gateway_controller.go
+++ b/multicluster/controllers/multicluster/gateway_controller.go
@@ -99,7 +99,7 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		},
 	}
 
-	createOrUpdate := func(gwIP string, gwInfo *mcsv1alpha1.GatewayInfo) error {
+	createOrUpdate := func(gwIP string) error {
 		existingResExport := &mcsv1alpha1.ResourceExport{}
 		if err := commonArea.Get(ctx, resExportNamespacedName, existingResExport); err != nil {
 			if !apierrors.IsNotFound(err) {
@@ -110,7 +110,7 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			}
 			return nil
 		}
-		if err = r.updateResourceExport(ctx, req, commonArea, existingResExport, gwInfo); err != nil {
+		if err = r.updateResourceExport(ctx, req, commonArea, existingResExport, &mcsv1alpha1.GatewayInfo{GatewayIP: gwIP}); err != nil {
 			return err
 		}
 		return nil
@@ -121,50 +121,16 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		if !apierrors.IsNotFound(err) {
 			return ctrl.Result{}, err
 		}
-		gwInfo, err := r.getLastCreatedGateway()
-		if err != nil {
-			klog.ErrorS(err, "Failed to get Gateways")
-			return ctrl.Result{}, err
-		}
-		if gwInfo == nil {
-			// When the last Gateway is deleted, we will remove the ClusterInfo kind of ResourceExport
-			if err := commonArea.Delete(ctx, resExport, &client.DeleteOptions{}); err != nil {
-				return ctrl.Result{}, client.IgnoreNotFound(err)
-			}
-			return ctrl.Result{}, nil
-		}
-		// When there are still Gateways exist, we should create or update existing ResourceExport
-		// with the latest Gateway in remaining Gateways.
-		if err := createOrUpdate(gwInfo.GatewayIP, gwInfo); err != nil {
-			return ctrl.Result{}, err
+		if err := commonArea.Delete(ctx, resExport, &client.DeleteOptions{}); err != nil {
+			return ctrl.Result{}, client.IgnoreNotFound(err)
 		}
 		return ctrl.Result{}, nil
 	}
-	if err := createOrUpdate(gw.GatewayIP, nil); err != nil {
+
+	if err := createOrUpdate(gw.GatewayIP); err != nil {
 		return ctrl.Result{}, err
 	}
 	return ctrl.Result{}, nil
-}
-
-func (r *GatewayReconciler) getLastCreatedGateway() (*mcsv1alpha1.GatewayInfo, error) {
-	gws := &mcsv1alpha1.GatewayList{}
-	if err := r.Client.List(ctx, gws, &client.ListOptions{}); err != nil {
-		return nil, err
-	}
-	if len(gws.Items) == 0 {
-		return nil, nil
-	}
-
-	// Comparing Gateway's CreationTimestamp to get the last created Gateway.
-	lastCreatedGW := gws.Items[0]
-	for _, gw := range gws.Items {
-		if lastCreatedGW.CreationTimestamp.Before(&gw.CreationTimestamp) {
-			lastCreatedGW = gw
-		}
-	}
-
-	// Make sure we only return the last created Gateway for now.
-	return &mcsv1alpha1.GatewayInfo{GatewayIP: lastCreatedGW.GatewayIP}, nil
 }
 
 func (r *GatewayReconciler) updateResourceExport(ctx context.Context, req ctrl.Request,
@@ -174,13 +140,6 @@ func (r *GatewayReconciler) updateResourceExport(ctx context.Context, req ctrl.R
 		ClusterID: r.localClusterID,
 		Name:      r.localClusterID,
 		Namespace: r.namespace,
-	}
-	var err error
-	if gwInfo == nil {
-		gwInfo, err = r.getLastCreatedGateway()
-		if err != nil {
-			return err
-		}
 	}
 	resExportSpec.ClusterInfo = &mcsv1alpha1.ClusterInfo{
 		ClusterID:    r.localClusterID,

--- a/multicluster/controllers/multicluster/node_controller_test.go
+++ b/multicluster/controllers/multicluster/node_controller_test.go
@@ -32,8 +32,17 @@ import (
 	"antrea.io/antrea/multicluster/controllers/multicluster/common"
 )
 
-func TestNodeReconciler(t *testing.T) {
-	node1 := &corev1.Node{
+var (
+	node1           *corev1.Node
+	node2           *corev1.Node
+	node3           *corev1.Node
+	node4           *corev1.Node
+	updatedGateway2 *mcsv1alpha1.Gateway
+	gateway3        *mcsv1alpha1.Gateway
+)
+
+func initializeCommonData() {
+	node1 = &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "node-1",
 			Annotations: map[string]string{
@@ -51,10 +60,59 @@ func TestNodeReconciler(t *testing.T) {
 					Address: "172.11.10.1",
 				},
 			},
+			Conditions: []corev1.NodeCondition{
+				{
+					Type:   corev1.NodeReady,
+					Status: corev1.ConditionTrue,
+				},
+			},
 		},
 	}
-	node1NoValidUpdate := *node1
-	node1NoValidUpdate.Labels = map[string]string{"hostname.k8s.io": "node-1"}
+
+	node2 = node1.DeepCopy()
+	node2.Name = "node-2"
+	node2.Status.Addresses = []corev1.NodeAddress{
+		{
+			Type:    corev1.NodeExternalIP,
+			Address: "10.10.10.12",
+		},
+		{
+			Type:    corev1.NodeInternalIP,
+			Address: "172.11.10.2",
+		},
+	}
+
+	node3 = node1.DeepCopy()
+	node3.Name = "node-3"
+	node3.Status.Conditions = []corev1.NodeCondition{
+		{
+			Type:   corev1.NodeReady,
+			Status: corev1.ConditionFalse,
+		},
+	}
+
+	node4 = node1.DeepCopy()
+	node4.Name = "node-4"
+	node4.Annotations = map[string]string{
+		common.GatewayAnnotation:   "true",
+		common.GatewayIPAnnotation: "invalid-gatewayip",
+	}
+
+	updatedGateway2 = &mcsv1alpha1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "node-2",
+			Namespace: "default",
+		},
+		GatewayIP:  "10.10.10.12",
+		InternalIP: "172.11.10.2",
+	}
+
+	gateway3 = gwNode1.DeepCopy()
+	gateway3.Name = "node-3"
+}
+
+func TestNodeReconciler(t *testing.T) {
+	initializeCommonData()
 	node1NoAnnotation := *node1
 	node1NoAnnotation.Annotations = map[string]string{}
 	node1WithIPAnnotation := *node1
@@ -62,26 +120,41 @@ func TestNodeReconciler(t *testing.T) {
 		common.GatewayAnnotation:   "true",
 		common.GatewayIPAnnotation: "11.11.10.10",
 	}
+	gateway4 := gwNode1.DeepCopy()
+	gateway4.Name = "node-4"
+	newGateway1 := gwNode1.DeepCopy()
+	newGateway1.GatewayIP = "172.11.10.1"
+	newNode1 := node1.DeepCopy()
+	newNode1.Name = "node-1"
+	newNode1.Status.Addresses = []corev1.NodeAddress{
+		{
+			Type:    corev1.NodeHostName,
+			Address: "node-1",
+		},
+	}
 
 	tests := []struct {
-		name        string
-		nodes       []*corev1.Node
-		req         reconcile.Request
-		existingGW  *mcsv1alpha1.Gateway
-		expectedGW  *mcsv1alpha1.Gateway
-		isDelete    bool
-		expectedErr string
+		name          string
+		nodes         []*corev1.Node
+		req           reconcile.Request
+		precedence    mcsv1alpha1.Precedence
+		existingGW    *mcsv1alpha1.Gateway
+		expectedGW    *mcsv1alpha1.Gateway
+		activeGateway string
+		candidates    map[string]bool
+		isDelete      bool
 	}{
 		{
 			name:       "create a Gateway successfully",
 			nodes:      []*corev1.Node{node1},
-			req:        reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "", Name: node1.Name}},
+			req:        reconcile.Request{NamespacedName: types.NamespacedName{Name: node1.Name}},
 			expectedGW: &gwNode1,
+			precedence: mcsv1alpha1.PrecedencePublic,
 		},
 		{
 			name:       "update a Gateway successfully by changing GatewayIP",
 			nodes:      []*corev1.Node{&node1WithIPAnnotation},
-			req:        reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "", Name: node1.Name}},
+			req:        reconcile.Request{NamespacedName: types.NamespacedName{Name: node1.Name}},
 			existingGW: &gwNode1,
 			expectedGW: &mcsv1alpha1.Gateway{
 				ObjectMeta: metav1.ObjectMeta{
@@ -91,20 +164,61 @@ func TestNodeReconciler(t *testing.T) {
 				GatewayIP:  "11.11.10.10",
 				InternalIP: "172.11.10.1",
 			},
+			activeGateway: "node-1",
+			precedence:    mcsv1alpha1.PrecedencePublic,
 		},
 		{
-			name:       "remove a Gateway Node to delete a Gateway successfully",
-			nodes:      []*corev1.Node{},
-			req:        reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "", Name: node1.Name}},
-			existingGW: &gwNode1,
-			isDelete:   true,
+			name:          "remove a Gateway Node to delete a Gateway successfully",
+			nodes:         []*corev1.Node{},
+			req:           reconcile.Request{NamespacedName: types.NamespacedName{Name: node1.Name}},
+			existingGW:    &gwNode1,
+			activeGateway: "node-1",
+			isDelete:      true,
+			precedence:    mcsv1alpha1.PrecedencePublic,
 		},
 		{
-			name:       "remove a Gateway Node's annotation to delete a Gateway successfully",
-			nodes:      []*corev1.Node{&node1NoAnnotation},
-			req:        reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "", Name: node1.Name}},
+			name:          "remove a Gateway Node's annotation to delete a Gateway successfully",
+			nodes:         []*corev1.Node{&node1NoAnnotation},
+			req:           reconcile.Request{NamespacedName: types.NamespacedName{Name: node1.Name}},
+			existingGW:    &gwNode1,
+			activeGateway: "node-1",
+			isDelete:      true,
+			precedence:    mcsv1alpha1.PrecedencePublic,
+		},
+		{
+			name:       "remote a Gateway due to no IPs",
+			nodes:      []*corev1.Node{newNode1},
+			req:        reconcile.Request{NamespacedName: types.NamespacedName{Name: newNode1.Name}},
 			existingGW: &gwNode1,
 			isDelete:   true,
+			precedence: mcsv1alpha1.PrecedencePrivate,
+		},
+		{
+			name:          "remove a Gateway Node to create a new Gateway from candidates successfully",
+			nodes:         []*corev1.Node{node2, node4},
+			req:           reconcile.Request{NamespacedName: types.NamespacedName{Name: node1.Name}},
+			existingGW:    &gwNode1,
+			expectedGW:    updatedGateway2,
+			activeGateway: "node-1",
+			precedence:    mcsv1alpha1.PrecedencePublic,
+		},
+		{
+			name:          "create a new Gateway successfully when active Gateway Node is not ready",
+			nodes:         []*corev1.Node{node2, node3},
+			req:           reconcile.Request{NamespacedName: types.NamespacedName{Name: node3.Name}},
+			existingGW:    gateway3,
+			expectedGW:    updatedGateway2,
+			activeGateway: "node-3",
+			precedence:    mcsv1alpha1.PrecedencePublic,
+		},
+		{
+			name:          "create a new Gateway successfully when active Gateway Node has no valid IP",
+			nodes:         []*corev1.Node{node2, node4},
+			req:           reconcile.Request{NamespacedName: types.NamespacedName{Name: node4.Name}},
+			existingGW:    gateway4,
+			expectedGW:    updatedGateway2,
+			activeGateway: "node-4",
+			precedence:    mcsv1alpha1.PrecedencePublic,
 		},
 	}
 	for _, tt := range tests {
@@ -117,27 +231,95 @@ func TestNodeReconciler(t *testing.T) {
 				obj = append(obj, tt.existingGW)
 			}
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(obj...).Build()
-			r := NewNodeReconciler(fakeClient, scheme, "default", mcsv1alpha1.PrecedencePublic)
+			r := NewNodeReconciler(fakeClient, scheme, "default", tt.precedence)
+			r.activeGateway = tt.activeGateway
 			if _, err := r.Reconcile(ctx, tt.req); err != nil {
-				if tt.expectedErr != "" {
-					assert.Contains(t, err.Error(), tt.expectedErr)
-				} else {
-					t.Errorf("Node Reconciler should handle Node events successfully but got error = %v", err)
-				}
+				t.Errorf("Node Reconciler should handle Node events successfully but got error = %v", err)
 			} else {
 				newGW := &mcsv1alpha1.Gateway{}
-				gwNamespcedName := types.NamespacedName{Name: "node-1", Namespace: "default"}
+				gwNamespcedName := types.NamespacedName{Name: tt.req.Name, Namespace: "default"}
+				if tt.expectedGW != nil {
+					gwNamespcedName = types.NamespacedName{Name: tt.expectedGW.Name, Namespace: "default"}
+				}
 				err := fakeClient.Get(ctx, gwNamespcedName, newGW)
-				if err != nil {
-					if tt.isDelete {
-						if !apierrors.IsNotFound(err) {
-							t.Errorf("Expected to get not found error but got err: %v", err)
-						}
-					} else {
-						t.Errorf("Expected to get Gateway but got err: %v", err)
+				if tt.isDelete {
+					if err == nil || (err != nil && !apierrors.IsNotFound(err)) {
+						t.Errorf("Expected to get not found error but got err: %v", err)
 					}
-				} else if tt.expectedGW.GatewayIP != newGW.GatewayIP || tt.expectedGW.InternalIP != newGW.InternalIP {
-					t.Errorf("Expected Gateway %v but got: %v", tt.expectedGW, newGW)
+				} else {
+					if err != nil {
+						t.Errorf("Expected to get Gateway but got err: %v", err)
+					} else {
+						if tt.expectedGW.GatewayIP != newGW.GatewayIP || tt.expectedGW.InternalIP != newGW.InternalIP {
+							t.Errorf("Expected Gateway %v but got: %v", tt.expectedGW, newGW)
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestInitialize(t *testing.T) {
+	initializeCommonData()
+	node5 := node1.DeepCopy()
+	node5.Name = "node-5"
+	node5.Annotations = map[string]string{}
+	tests := []struct {
+		name                  string
+		nodes                 []*corev1.Node
+		req                   reconcile.Request
+		existingGW            *mcsv1alpha1.Gateway
+		expectedActiveGateway string
+		isDelete              bool
+		candidatesSize        int
+	}{
+		{
+			name:                  "initialize and set active Gateway successfully",
+			nodes:                 []*corev1.Node{node1, node2, node5},
+			existingGW:            &gwNode1,
+			expectedActiveGateway: "node-1",
+			candidatesSize:        2,
+		},
+		{
+			name:                  "initialize successfully without Gateway",
+			nodes:                 []*corev1.Node{node3, node4, node5},
+			expectedActiveGateway: "",
+			candidatesSize:        2,
+		},
+		{
+			name:                  "initialize and delete Gateway successfully",
+			nodes:                 []*corev1.Node{node1, node5},
+			existingGW:            gateway3,
+			isDelete:              true,
+			expectedActiveGateway: "",
+			candidatesSize:        1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var obj []client.Object
+			for _, n := range tt.nodes {
+				obj = append(obj, n)
+			}
+			if tt.existingGW != nil {
+				obj = append(obj, tt.existingGW)
+			}
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(obj...).Build()
+			r := NewNodeReconciler(fakeClient, scheme, "default", mcsv1alpha1.PrecedencePublic)
+			if err := r.initialize(); err != nil {
+				t.Errorf("Expected initialize() successfully but got err: %v", err)
+			} else {
+				assert.Equal(t, tt.expectedActiveGateway, r.activeGateway)
+				assert.Equal(t, tt.candidatesSize, len(r.gatewayCandidates))
+				if tt.isDelete {
+					deletedGW := &mcsv1alpha1.Gateway{}
+					gwNamespcedName := types.NamespacedName{Name: tt.existingGW.Name, Namespace: "default"}
+					err := fakeClient.Get(ctx, gwNamespcedName, deletedGW)
+					if !apierrors.IsNotFound(err) {
+						t.Errorf("Expected to get not found error but got err: %v", err)
+					}
 				}
 			}
 		})


### PR DESCRIPTION
In order to support Gateway active-standby mode HA, the Node
controller has been refined to handle Node readiness changes.
There will be at most one Gateway in a given Namespace, and the
Gateway controller is updated correspondingly.

1. Check Node readiness and create a Gateway CR if Node is ready
and there is no existing Gateway.
2. Initialize active Gateway and Gateway candidate Nodes with annotation
'multicluster.antrea.io/gateway'.
3. Add Gateway webhook to allow at most one Gateway in a given
   Namespace.

For #3754
Signed-off-by: Lan Luo <luola@vmware.com>