### PR TITLE
[ExternalNode] Install script for configuring antrea-agent on VM

### DIFF
--- a/docs/external-node.md
+++ b/docs/external-node.md
@@ -216,8 +216,8 @@ spec:
    the `antrea-controller` API server.
 
    ```bash
-   # Specify the antrea-controller API server endpoint. Antrea-Controller needs to be exposed via the Node IP or a
-   # public IP that is reachable from the VM
+   # Specify the antrea-controller API server endpoint. Antrea-Controller needs
+   # to be exposed via the Node IP or a public IP that is reachable from the VM
    export ANTREA_API_SERVER="https://172.18.0.1:443"
    export ANTREA_CLUSTER_NAME="antrea"
    TOKEN=$(kubectl -n vm-ns get secrets -o jsonpath="{.items[?(@.metadata.annotations['kubernetes\.io/service-account\.name']=='$SERVICE_ACCOUNT')].data.token}"|base64 --decode)
@@ -234,7 +234,7 @@ spec:
    apply it in the cluster.
 
    ```bash
-   $ cat << EOF | kubectl apply -f -
+   cat << EOF | kubectl apply -f -
    apiVersion: crd.antrea.io/v1alpha1
    kind: ExternalNode
    metadata:
@@ -265,56 +265,70 @@ please refer to the [getting-started guide](getting-started.md#open-vswitch).
    make docker-bin
    ```
 
-2. The `antrea-agent.conf` file specifies agent configuration parameters. Copy
-   the [agent configuration file](../build/yamls/externalnode/conf/antrea-agent.conf)
-   to the VM and edit the `antrea-agent.conf` file to set `clientConnection`,
-   `antreaClientConnection` and `externalNodeNamespace` with the correct values.
-   Copy `antrea-agent.antrea.kubeconfig` and `antrea-agent.kubeconfig` files to
-   the VM, that were generated in the step 4 and step 5 of
-   [Prerequisites on Kubernetes cluster](#prerequisites-on-kubernetes-cluster).
+2. Copy configuration files to the VM, including [antrea-agent.conf](../build/yamls/externalnode/conf/antrea-agent.conf),
+   which specifies agent configuration parameters;
+   `antrea-agent.antrea.kubeconfig` and `antrea-agent.kubeconfig`, which were
+   generated in steps 4 and 5 of [Prerequisites on Kubernetes cluster](#prerequisites-on-kubernetes-cluster).
 
-   ```bash
-   AGENT_NAMESPACE="vm-ns"
-   AGENT_CONF_PATH="/etc/antrea"
-   mkdir -p $AGENT_CONF_PATH
-   # Copy antrea-agent kubeconfig files
-   cp ./antrea-agent.kubeconfig $AGENT_CONF_PATH
-   cp ./antrea-agent.antrea.kubeconfig $AGENT_CONF_PATH
-   # Update clientConnection and antreaClientConnection
-   sed -i "s|kubeconfig: |kubeconfig: $AGENT_CONF_PATH/|g" antrea-agent.conf
-   sed -i "s|#externalNodeNamespace: default|externalNodeNamespace: $AGENT_NAMESPACE|g" antrea-agent.conf
-   # Copy antrea-agent configuration file
-   cp ./antrea-agent.conf $AGENT_CONF_PATH
-   ```
+3. Bootstrap `antrea-agent`
 
-3. Create `antrea-agent` service. Note: environment variable `NODE_NAME` is set
-   in the service configuration, if the VM's hostname is different from the name
-   defined in the `ExternalNode` resource. Below is a sample snippet to start
-   `antrea-agent` as a service on Ubuntu 18.04 or later:
+   1. Bootstrap `antrea-agent` using the [installation script](../hack/externalnode/install-vm.sh)
+      as shown below.
 
-   ```bash
-   AGENT_BIN_PATH="/usr/sbin"
-   AGENT_LOG_PATH="/var/log/antrea"
-   mkdir -p $AGENT_BIN_PATH
-   mkdir -p $AGENT_LOG_PATH
-   cat << EOF > /etc/systemd/system/antrea-agent.service
-   Description="antrea-agent as a systemd service"
-   After=network.target
-   [Service]
-   Environment="NODE_NAME=vm1"
-   ExecStart=$AGENT_BIN_PATH/antrea-agent \
-   --config=$AGENT_CONF_PATH/antrea-agent.conf \
-   --logtostderr=false \
-   --log_file=$AGENT_LOG_PATH/antrea-agent.log
-   Restart=on-failure
-   [Install]
-   WantedBy=multi-user.target
-   EOF
+      ```bash
+      ./install-vm.sh --ns vm-ns --bin ./antrea-agent --config ./antrea-agent.conf \
+      --kubeconfig ./antrea-agent.kubeconfig \
+      --antrea-kubeconfig ./antrea-agent.antrea.kubeconfig --nodename vm1
+      ```
+
+   2. Bootstrap `antrea-agent` manually. First edit the `antrea-agent.conf` file
+      to set `clientConnection`, `antreaClientConnection` and `externalNodeNamespace`
+      to the correct values.
+
+      ```bash
+      AGENT_NAMESPACE="vm-ns"
+      AGENT_CONF_PATH="/etc/antrea"
+      mkdir -p $AGENT_CONF_PATH
+      # Copy antrea-agent kubeconfig files
+      cp ./antrea-agent.kubeconfig $AGENT_CONF_PATH
+      cp ./antrea-agent.antrea.kubeconfig $AGENT_CONF_PATH
+      # Update clientConnection and antreaClientConnection
+      sed -i "s|kubeconfig: |kubeconfig: $AGENT_CONF_PATH/|g" antrea-agent.conf
+      sed -i "s|#externalNodeNamespace: default|externalNodeNamespace: $AGENT_NAMESPACE|g" antrea-agent.conf
+      # Copy antrea-agent configuration file
+      cp ./antrea-agent.conf $AGENT_CONF_PATH
+      ```
+
+      Then create `antrea-agent` service. Below is a sample snippet to start
+      `antrea-agent` as a service on Ubuntu 18.04 or later:
+
+      Note: Environment variable `NODE_NAME` needs to be set in the service
+      configuration, if the VM's hostname is different from the name defined in
+      the `ExternalNode` resource.
+
+      ```bash
+      AGENT_BIN_PATH="/usr/sbin"
+      AGENT_LOG_PATH="/var/log/antrea"
+      mkdir -p $AGENT_BIN_PATH
+      mkdir -p $AGENT_LOG_PATH
+      cat << EOF > /etc/systemd/system/antrea-agent.service
+      Description="antrea-agent as a systemd service"
+      After=network.target
+      [Service]
+      Environment="NODE_NAME=vm1"
+      ExecStart=$AGENT_BIN_PATH/antrea-agent \
+      --config=$AGENT_CONF_PATH/antrea-agent.conf \
+      --logtostderr=false \
+      --log_file=$AGENT_LOG_PATH/antrea-agent.log
+      Restart=on-failure
+      [Install]
+      WantedBy=multi-user.target
+      EOF
    
-   sudo systemctl daemon-reload
-   sudo systemctl enable antrea-agent
-   sudo systemctl start antrea-agent
-   ```
+      sudo systemctl daemon-reload
+      sudo systemctl enable antrea-agent
+      sudo systemctl start antrea-agent
+      ```
 
 ### Installation on Windows VM
 
@@ -344,8 +358,9 @@ Note: Only Windows Server 2019 is supported in the first release at the moment.
    make docker-windows-bin
    ```
 
-2. Copy `antrea-agent.conf`, `antrea-agent.kubeconfig` and `antrea-agent.antrea.kubeconfig`
-   files to the VM. Please refer to the step 2 of [Installation on Linux VM](#installation-steps-on-linux-vm)
+2. Copy [antrea-agent.conf](../build/yamls/externalnode/conf/antrea-agent.conf),
+   `antrea-agent.kubeconfig` and `antrea-agent.antrea.kubeconfig` files to the
+   VM. Please refer to the step 2 of [Installation on Linux VM](#installation-steps-on-linux-vm)
    section for more information.
 
    ```powershell
@@ -358,26 +373,41 @@ Note: Only Windows Server 2019 is supported in the first release at the moment.
    Copy-Item .\antrea-agent.conf $WIN_AGENT_CONF_PATH
    ```
 
-3. Configure environment variable `NODE_NAME` if the VM's hostname is different
-   from the name defined in the `ExternalNode` resource.
+3. Bootstrap `antrea-agent`
 
-   ```powershell
-   [Environment]::SetEnvironmentVariable("NODE_NAME", "vm1")
-   [Environment]::SetEnvironmentVariable("NODE_NAME", "vm1", [System.EnvironmentVariableTarget]::Machine)
-   ```
+   1. Bootstrap `antrea-agent` using the [installation script](../hack/externalnode/install-vm.ps1)
+       as shown below.
 
-4. Create `antrea-agent` service using nssm. Below is a sample snippet to start
-   `antrea-agent` as a service:
+      ```powershell
+      .\Install-vm.ps1 -NameSpace vm-ns -BinaryPath .\antrea-agent.exe `
+      -ConfigPath .\antrea-agent.conf -KubeConfigPath .\antrea-agent.kubeconfig `
+      -AntreaKubeConfigPath .\antrea-agent.antrea.kubeconfig `
+      -InstallDir C:\antrea-agent -NodeName vm1
+      ```
 
-   ```powershell
-   $WIN_AGENT_BIN_PATH="C:\antrea-agent"
-   $WIN_AGENT_LOG_PATH="C:\antrea-agent\logs"
-   New-Item -ItemType Directory -Force -Path $WIN_AGENT_BIN_PATH
-   New-Item -ItemType Directory -Force -Path $WIN_AGENT_LOG_PATH
-   Copy-Item .\antrea-agent.exe $WIN_AGENT_BIN_PATH
-   nssm.exe install antrea-agent $WIN_AGENT_BIN_PATH\antrea-agent.exe --config $WIN_AGENT_CONF_PATH\antrea-agent.conf --log_file $WIN_AGENT_LOG_PATH\antrea-agent.log --logtostderr=false
-   nssm.exe start antrea-agent
-   ```
+   2. Bootstrap `antrea-agent` manually. First edit the `antrea-agent.conf` file to
+      set `clientConnection`, `antreaClientConnection` and `externalNodeNamespace`
+      to the correct values.
+      Configure environment variable `NODE_NAME` if the VM's hostname is different
+      from the name defined in the `ExternalNode` resource.
+
+      ```powershell
+      [Environment]::SetEnvironmentVariable("NODE_NAME", "vm1")
+      [Environment]::SetEnvironmentVariable("NODE_NAME", "vm1", [System.EnvironmentVariableTarget]::Machine)
+      ```
+
+      Then create `antrea-agent` service using nssm. Below is a sample snippet to start
+      `antrea-agent` as a service:
+
+      ```powershell
+      $WIN_AGENT_BIN_PATH="C:\antrea-agent"
+      $WIN_AGENT_LOG_PATH="C:\antrea-agent\logs"
+      New-Item -ItemType Directory -Force -Path $WIN_AGENT_BIN_PATH
+      New-Item -ItemType Directory -Force -Path $WIN_AGENT_LOG_PATH
+      Copy-Item .\antrea-agent.exe $WIN_AGENT_BIN_PATH
+      nssm.exe install antrea-agent $WIN_AGENT_BIN_PATH\antrea-agent.exe --config $WIN_AGENT_CONF_PATH\antrea-agent.conf --log_file $WIN_AGENT_LOG_PATH\antrea-agent.log --logtostderr=false
+      nssm.exe start antrea-agent
+      ```
 
 ## VM network configuration
 

--- a/hack/externalnode/install-vm.ps1
+++ b/hack/externalnode/install-vm.ps1
@@ -1,0 +1,198 @@
+<#
+  .SYNOPSIS
+  Installs Antrea-Agent service.
+
+  .PARAMETER NameSpace
+  ExternalNode Namespace to be used.
+
+  .PARAMETER BinaryPath
+  Specifies the path of the antrea-agent binary to be used.
+
+  .PARAMETER ConfigPath
+  Specifies the path of the antrea-agent configuration file to be used.
+
+  .PARAMETER KubeConfigPath
+  Specifies the path of the kubeconfig to access K8s API Server.
+
+  .PARAMETER AntreaKubeConfigPath
+  Specifies the path of the kubeconfig to access Antrea API Server.
+
+  .PARAMETER InstallDir
+  The target installation directory. The default path is "C:\antrea-agent".
+#>
+Param(
+    [parameter(Mandatory = $true)] [string] $NameSpace,
+    [parameter(Mandatory = $true)] [string] $BinaryPath,
+    [parameter(Mandatory = $true)] [string] $ConfigPath,
+    [parameter(Mandatory = $true)] [string] $KubeConfigPath,
+    [parameter(Mandatory = $true)] [string] $AntreaKubeConfigPath,
+    [parameter(Mandatory = $false)] [string] $NodeName = $env:COMPUTERNAME,
+    [parameter(Mandatory = $false)] [string] $InstallDir = "C:\antrea-agent"
+)
+
+$ErrorActionPreference = "Stop"
+
+$WorkDir = [System.IO.Path]::GetDirectoryName($myInvocation.MyCommand.Definition)
+$InstallLog = "$WorkDir\install_vm.log"
+
+# Antrea paths
+$AntreaAgentPath = [io.path]::combine($InstallDir, "antrea-agent.exe")
+$AntreaAgentConfDir = [io.path]::combine($InstallDir, "conf")
+$AntreaAgentLogDir = [io.path]::combine($InstallDir, "logs")
+$AntreaAgentConfPath = [io.path]::combine($AntreaAgentConfDir, "antrea-agent.conf")
+$AntreaAgentLogFile = [io.path]::combine($AntreaAgentLogDir, "antrea-agent.log")
+
+# Constants
+$K8sKubeconfig = "antrea-agent.kubeconfig"
+$AntreaKubeconfig = "antrea-agent.antrea.kubeconfig"
+$OVSServices = "ovsdb-server", "ovs-vswitchd"
+$AntreaAgent = "antrea-agent"
+$Kubeconfig = "kubeconfig"
+$ExternalNodeNamespace = "externalNodeNamespace"
+
+function Log($Info) {
+    $time = $(get-date -Format g)
+    "$time $Info " | Tee-Object $InstallLog -Append | Write-Host
+}
+
+function ServiceExists($ServiceName) {
+    If (Get-Service $ServiceName -ErrorAction SilentlyContinue) {
+        return $true
+    }
+    return $false
+}
+
+function CheckSupportedVersions() {
+    $script:OS_VERSION = [System.Environment]::OSVersion.Version
+    if (-Not ($OS_VERSION.Major -eq 10 -and $OS_VERSION.Minor -eq 0 -and $OS_VERSION.Build -ge 17763)) {
+        Log "Error only Windows version 10 build 17763 onwards is supported"
+        exit 1
+    }
+}
+
+function PrintPrerequisites()
+{
+    echo "Please execute these commands to enable Hyper-V"
+    echo "Install-WindowsFeature Hyper-V-Powershell"
+    echo "Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V -All -NoRestart"
+    exit 1
+}
+
+function CheckPrerequisites()
+{
+    CheckSupportedVersions
+    $valid = $true
+    Log "Check Hyper-v feature is enabled"
+    if ((Get-WindowsOptionalFeature -FeatureName "Microsoft-Hyper-V" -Online).State -eq "Disabled") {
+        Log "Windows optional feature Microsoft-Hyper-V is disabled"
+        $valid = $false
+    }
+
+    if ((Get-WindowsFeature -Name "Hyper-V-Powershell").InstallState -ne "Installed") {
+        Log "Windows feature Hyper-V-Powershell is not installed"
+        $valid = $false
+    }
+
+    if ($valid -eq $false) {
+        PrintPrerequisites
+    }
+
+    Log "Check OVS services are installed"
+    foreach ($daemon in $OVSServices) {
+        If (-Not (ServiceExists($daemon))) {
+            Log "Service $daemon does not exist."
+            exit 1
+        }
+    }
+}
+
+function SetupInstallDir() {
+    Log "Create install directories"
+    if (-Not (Test-Path $AntreaAgentConfDir)) {
+        New-Item $AntreaAgentConfDir -type directory -Force | Out-Null
+    }
+
+    if (-Not (Test-Path $AntreaAgentLogDir)) {
+        New-Item $AntreaAgentLogDir -type directory -Force | Out-Null
+    }
+}
+
+function CopyAntreaAgentFiles() {
+    if ( -Not (Test-Path $BinaryPath)) {
+        Log "$BinaryPath file not found"
+        exit 1
+    }
+    Log "Copying $BinaryPath to $InstallDir"
+    Copy-Item -Path "$BinaryPath" -Destination $InstallDir -Force |  Out-Null
+
+    if ( -Not (Test-Path $KubeConfigPath)) {
+        Log "$KubeConfigPath file not found"
+        exit 1
+    }
+    Log "Copying $KubeConfigPath to $AntreaAgentConfDir"
+    Copy-Item -Path "$KubeConfigPath" -Destination "$AntreaAgentConfDir\$K8sKubeconfig" -Force
+
+    if ( -Not (Test-Path $AntreaKubeConfigPath)) {
+        Log "$AntreaKubeConfigPath file not found"
+        exit 1
+    }
+    Log "Copying $AntreaKubeConfigPath to $AntreaAgentConfDir"
+    Copy-Item -Path "$AntreaKubeConfigPath" -Destination "$AntreaAgentConfDir\$AntreaKubeconfig" -Force
+}
+
+function UpdateAgentConf() {
+    if ( -Not (Test-Path $ConfigPath)) {
+        Log "$ConfigPath file not found"
+        exit 1
+    }
+    New-Item $AntreaAgentConfPath -type file -Force | Out-Null
+    $file = Get-Content $ConfigPath
+    foreach ($line in $file) {
+        if ($line -like "*$Kubeconfig") {
+            $key, $val = $line.split(":", 2).trim()
+            $newval = "${AntreaAgentConfDir}\${val}"
+            Log "Updating $AntreaAgentConfPath with ${key}: ${newval}"
+            [System.IO.File]::AppendAllText($AntreaAgentConfPath, "  ${key}: ${newval}" +
+                    ([Environment]::NewLine))
+        } elseif ($line -like "*$ExternalNodeNamespace*") {
+            Log "Updating $AntreaAgentConfPath with ${ExternalNodeNamespace}: ${NameSpace}"
+            [System.IO.File]::AppendAllText($AntreaAgentConfPath, "  ${ExternalNodeNamespace}: ${NameSpace}" +
+                    ([Environment]::NewLine))
+        } else {
+            [System.IO.File]::AppendAllText($AntreaAgentConfPath, $line +
+                    ([Environment]::NewLine))
+        }
+    }
+}
+
+function ConfigureAntreaAgentService() {
+    # Set environment variables
+    [Environment]::SetEnvironmentVariable("NODE_NAME", $NodeName, [System.EnvironmentVariableTarget]::Machine)
+    # Assume nssm is installed and configure service
+    $AntreaAgentArgs = "--config $AntreaAgentConfPath --log_file $AntreaAgentLogFile --logtostderr=false"
+    log "Creating service $AntreaAgent $AntreaAgentPath $AntreaAgentArgs"
+    try {
+        # Configured to auto-restart upon reboot
+        & nssm install $AntreaAgent $AntreaAgentPath $AntreaAgentArgs
+    } catch {
+        log "Failed to create service for $AntreaAgent, rc $_"
+        exit 1
+    }
+}
+
+function StartAntreaAgentService()
+{
+    try {
+        & nssm start $AntreaAgent
+    } catch {
+        log "Failed to start service for $AntreaAgent, rc $_"
+        exit 1
+    }
+}
+
+CheckPrerequisites
+SetupInstallDir
+CopyAntreaAgentFiles
+UpdateAgentConf
+ConfigureAntreaAgentService
+StartAntreaAgentService

--- a/hack/externalnode/install-vm.sh
+++ b/hack/externalnode/install-vm.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 Antrea Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+function echoerr {
+    >&2 echo "$@"
+}
+
+_usage="Usage: $0 [--ns <NameSpace>] [--bin <AntreaAgentSavePath>] [--config <AgentConfigSavePath>] [--kubeconfig <KubeconfigSavePath>] [--antrea-kubeconfig <AntreaKubeconfigSavePath>] [--nodename <ExternalNodeName>] [--help|-h]
+        --ns                          NameSpace to be used by the antrea-agent.
+        --bin                         Path of the antrea-agent binary
+        --config                      Path of the antrea-agent configuration file
+        --kubeconfig                  Path of the kubeconfig to access K8s API Server
+        --antrea-kubeconfig           Path of the kubeconfig to access Antrea API Server
+        --nodename                    ExternalNode name to be used by the antrea-agent
+        --help, -h                    Print this message and exit"
+
+function print_usage {
+    echoerr "$_usage"
+}
+
+function print_help {
+    echoerr "Try '$0 --help' for more information."
+}
+
+INSTALL_PATH="/usr/sbin"
+AGENT_BIN_PATH=""
+CONFIG_PATH=""
+KUBECONFIG=""
+ANTREAKUBECONFIG=""
+AGENT_NAMESPACE=""
+NODE_NAME="$(hostname)"
+AGENT_LOG_DIR="/var/log/antrea"
+AGENT_CONF_PATH="/etc/antrea"
+
+check_supported_platform() {
+  echo "Checking platform supported"
+  if ! [[ $(lsb_release -rs) =~ ^(18.04|20.04)$ ]]; then
+    echoerr "Error only Ubuntu 18.04/20.04 version is supported"
+    exit 1
+  fi
+}
+
+copy_antrea_agent_files() {
+    if [[ ! -f "$CONFIG_PATH" ]]; then
+      echoerr "Error $CONFIG_PATH file not found"
+      exit 1
+    fi
+    mkdir -p $AGENT_CONF_PATH
+    echo "Copying $CONFIG_PATH to $AGENT_CONF_PATH"
+    cp $CONFIG_PATH $AGENT_CONF_PATH
+
+    if [[ ! -f "$KUBECONFIG" ]]; then
+      echoerr "Error $KUBECONFIG file not found"
+      exit 1
+    fi
+
+    echo "Copying $KUBECONFIG to $AGENT_CONF_PATH"
+    cp "$KUBECONFIG" "${AGENT_CONF_PATH}/antrea-agent.kubeconfig"
+
+    if [[ ! -f "$ANTREA_KUBECONFIG" ]]; then
+      echoerr "Error $ANTREA_KUBECONFIG file not found"
+      exit 1
+    fi
+    echo "Copying $ANTREA_KUBECONFIG to $AGENT_CONF_PATH"
+    cp "$ANTREA_KUBECONFIG" "${AGENT_CONF_PATH}/antrea-agent.antrea.kubeconfig"
+}
+
+update_antrea_agent_conf() {
+  echo "Updating clientConnection and antreaClientConnection"
+  sed -i "s|kubeconfig: |kubeconfig: $AGENT_CONF_PATH/|g" $AGENT_CONF_PATH/antrea-agent.conf
+  echo "Updating externalNodeNamespace to $AGENT_NAMESPACE"
+  sed -i "s|#externalNodeNamespace: default|externalNodeNamespace: $AGENT_NAMESPACE|g" $AGENT_CONF_PATH/antrea-agent.conf
+}
+
+start_antrea_agent_service() {
+    if [[ ! -f "$AGENT_BIN_PATH" ]]; then
+      echoerr "Error $AGENT_BIN_PATH file not found"
+      exit 1
+    fi
+    mkdir -p $AGENT_LOG_DIR
+    mkdir -p $INSTALL_PATH
+    cp "$AGENT_BIN_PATH" "$INSTALL_PATH"
+cat << EOF > /etc/systemd/system/antrea-agent.service
+Description="antrea-agent as a systemd service"
+After=network.target
+[Service]
+Environment="NODE_NAME=$NODE_NAME"
+ExecStart=$INSTALL_PATH/antrea-agent \
+--config=$AGENT_CONF_PATH/antrea-agent.conf \
+--logtostderr=false \
+--log_file=$AGENT_LOG_DIR/antrea-agent.log
+Restart=on-failure
+[Install]
+WantedBy=multi-user.target
+EOF
+    sudo systemctl daemon-reload
+    sudo systemctl enable antrea-agent
+    echo "Starting antrea-agent service"
+    sudo systemctl start antrea-agent
+    sudo systemctl status antrea-agent
+}
+
+validate_argument() {
+    if [[ $2 == --* || -z $2 ]]; then
+        echoerr "Error invalid argument for $1: <$2>"
+        print_usage
+        exit 1
+    fi
+}
+
+while [[ $# -gt 0 ]]
+do
+key="$1"
+case $key in
+    --ns)
+    AGENT_NAMESPACE="$2"
+    validate_argument $1 $2
+    shift 2
+    ;;
+    --bin)
+    AGENT_BIN_PATH="$2"
+    validate_argument $1 $2
+    shift 2
+    ;;
+    --config)
+    CONFIG_PATH="$2"
+    validate_argument $1 $2
+    shift 2
+    ;;
+    --kubeconfig)
+    KUBECONFIG="$2"
+    validate_argument $1 $2
+    shift 2
+    ;;
+    --antrea-kubeconfig)
+    ANTREA_KUBECONFIG="$2"
+    validate_argument $1 $2
+    shift 2
+    ;;
+    --nodename)
+    NODE_NAME="$2"
+    validate_argument $1, $2
+    shift 2
+    ;;
+    -h|--help)
+    print_usage
+    exit 0
+    ;;
+    *)    # unknown option
+    echoerr "Unknown option $1"
+    exit 1
+    ;;
+esac
+done
+
+check_supported_platform
+copy_antrea_agent_files
+update_antrea_agent_conf
+start_antrea_agent_service


### PR DESCRIPTION
- Provides install script for both Windows and Linux
- Expects the user to copy the antrea-agent binary, antrea-agent.conf,
antrea-agent.kubeconfig and antrea-agent.antrea.kubeconfig files to the
VM.
- Update the documentation

Signed-off-by: kumaranand <kumaranand@vmware.com>