### PR TITLE
Remove unnecessary Namespace validation in leader

### DIFF
--- a/multicluster/controllers/multicluster/controller_utils.go
+++ b/multicluster/controllers/multicluster/controller_utils.go
@@ -96,16 +96,6 @@ func validateConfigExists(clusterID common.ClusterID, clusters []multiclusterv1a
 	return
 }
 
-func validateClusterSetNamespace(clusterSet *multiclusterv1alpha1.ClusterSet) (err error) {
-	//  validate the Namespace is the same
-	if clusterSet.Spec.Namespace != clusterSet.GetNamespace() {
-		err = fmt.Errorf("ClusterSet Namespace %s is different from %s",
-			clusterSet.Spec.Namespace, clusterSet.GetNamespace())
-		return
-	}
-	return
-}
-
 // findServiceCIDRByInvalidServiceCreation creates an invalid Service to get returned error, and analyzes
 // the error message to get Service CIDR.
 // TODO: add dual-stack support.

--- a/multicluster/controllers/multicluster/leader_clusterset_controller.go
+++ b/multicluster/controllers/multicluster/leader_clusterset_controller.go
@@ -94,9 +94,6 @@ func (r *LeaderClusterSetReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			err = fmt.Errorf("local cluster %s is not defined as leader in ClusterSet", clusterID)
 			return ctrl.Result{}, err
 		}
-		if err = validateClusterSetNamespace(clusterSet); err != nil {
-			return ctrl.Result{}, err
-		}
 		r.clusterID = clusterID
 		r.clusterSetID = clusterSetID
 	} else {


### PR DESCRIPTION
Since this leader Namespace should always be the same
as the ClusterSet's Namespace in the metadata when it's in leader
cluster, skip this Namespace validation in the leader cluster. This
allow the leader Namespace to be empty when user is trying to create
a ClusterSet in leader cluster.

Signed-off-by: Lan Luo <luola@vmware.com>