### PR TITLE
Use Patch to update IP counters of IPPools

### DIFF
--- a/build/charts/antrea/templates/controller/clusterrole.yaml
+++ b/build/charts/antrea/templates/controller/clusterrole.yaml
@@ -270,6 +270,7 @@ rules:
       - ippools/status
     verbs:
       - update
+      - patch
   - apiGroups:
       - apps
     resources:

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -3514,6 +3514,7 @@ rules:
       - ippools/status
     verbs:
       - update
+      - patch
   - apiGroups:
       - apps
     resources:

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -3514,6 +3514,7 @@ rules:
       - ippools/status
     verbs:
       - update
+      - patch
   - apiGroups:
       - apps
     resources:

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -3514,6 +3514,7 @@ rules:
       - ippools/status
     verbs:
       - update
+      - patch
   - apiGroups:
       - apps
     resources:

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -3527,6 +3527,7 @@ rules:
       - ippools/status
     verbs:
       - update
+      - patch
   - apiGroups:
       - apps
     resources:

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -3514,6 +3514,7 @@ rules:
       - ippools/status
     verbs:
       - update
+      - patch
   - apiGroups:
       - apps
     resources:


### PR DESCRIPTION
In AntreaIPAMController, the statefulSet worker and the workers that
update IP pool counters could update IP pool status. In real-world,
update conflicts can be detected by the real kube-apiserver by checking
the resourseVersion of the object. However, this is not supported by
the fake client, and update conflicts causes one update to override
another.

Since the latter workers are only responsible for updating IP counters,
it could use Patch method to avoid overriding other status in both
real-world and tests.

The patch also changes TestStatefulSetLifecycle to use subtest to run
its test cases, otherwise it's not clear which test case fails.

Signed-off-by: Quan Tian <qtian@vmware.com>

Fixes #4081