### PR TITLE
Minor fixes for multi-cluster manifests

### DIFF
--- a/multicluster/apis/multicluster/v1alpha1/clusterset_types.go
+++ b/multicluster/apis/multicluster/v1alpha1/clusterset_types.go
@@ -41,7 +41,8 @@ type ClusterSetSpec struct {
 	// Leaders include leader clusters known to the member clusters.
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=1
-	Leaders []MemberCluster `json:"leaders,omitempty"`
+	// +kubebuilder:validation:Required
+	Leaders []MemberCluster `json:"leaders"`
 	// The leader cluster Namespace in which the ClusterSet is defined.
 	// Used in member cluster.
 	Namespace string `json:"namespace,omitempty"`

--- a/multicluster/apis/multicluster/v1alpha1/memberclusterannounce_types.go
+++ b/multicluster/apis/multicluster/v1alpha1/memberclusterannounce_types.go
@@ -23,8 +23,8 @@ import (
 // +genclient
 //+kubebuilder:object:root=true
 
-// +kubebuilder:printcolumn:name="Cluster ID",type=string,JSONPath=`.spec.clusterID`,description="Cluster ID of the member cluster"
-// +kubebuilder:printcolumn:name="ClusterSet ID",type=string,JSONPath=`.spec.clusterSetID`,description="ClusterSet ID"
+// +kubebuilder:printcolumn:name="Cluster ID",type=string,JSONPath=`.clusterID`,description="Cluster ID of the member cluster"
+// +kubebuilder:printcolumn:name="ClusterSet ID",type=string,JSONPath=`.clusterSetID`,description="ClusterSet ID"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=`.metadata.creationTimestamp`
 // MemberClusterAnnounce is the Schema for the memberclusterannounces API
 type MemberClusterAnnounce struct {

--- a/multicluster/apis/multicluster/v1alpha2/clusterclaim_types.go
+++ b/multicluster/apis/multicluster/v1alpha2/clusterclaim_types.go
@@ -37,7 +37,8 @@ type ClusterClaim struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// Value of the ClusterClaim.
-	Value string `json:"value,omitempty"`
+	// +kubebuilder:validation:Required
+	Value string `json:"value"`
 }
 
 //+kubebuilder:object:root=true

--- a/multicluster/build/yamls/antrea-multicluster-leader-global.yml
+++ b/multicluster/build/yamls/antrea-multicluster-leader-global.yml
@@ -44,6 +44,8 @@ spec:
           value:
             description: Value of the ClusterClaim.
             type: string
+        required:
+        - value
         type: object
     served: true
     storage: true
@@ -152,6 +154,8 @@ spec:
                 description: The leader cluster Namespace in which the ClusterSet
                   is defined. Used in member cluster.
                 type: string
+            required:
+            - leaders
             type: object
           status:
             description: ClusterSetStatus defines the observed state of ClusterSet.
@@ -256,11 +260,11 @@ spec:
   versions:
   - additionalPrinterColumns:
     - description: Cluster ID of the member cluster
-      jsonPath: .spec.clusterID
+      jsonPath: .clusterID
       name: Cluster ID
       type: string
     - description: ClusterSet ID
-      jsonPath: .spec.clusterSetID
+      jsonPath: .clusterSetID
       name: ClusterSet ID
       type: string
     - jsonPath: .metadata.creationTimestamp

--- a/multicluster/build/yamls/antrea-multicluster-member.yml
+++ b/multicluster/build/yamls/antrea-multicluster-member.yml
@@ -44,6 +44,8 @@ spec:
           value:
             description: Value of the ClusterClaim.
             type: string
+        required:
+        - value
         type: object
     served: true
     storage: true
@@ -252,6 +254,8 @@ spec:
                 description: The leader cluster Namespace in which the ClusterSet
                   is defined. Used in member cluster.
                 type: string
+            required:
+            - leaders
             type: object
           status:
             description: ClusterSetStatus defines the observed state of ClusterSet.

--- a/multicluster/config/crd/bases/multicluster.crd.antrea.io_clusterclaims.yaml
+++ b/multicluster/config/crd/bases/multicluster.crd.antrea.io_clusterclaims.yaml
@@ -43,6 +43,8 @@ spec:
           value:
             description: Value of the ClusterClaim.
             type: string
+        required:
+        - value
         type: object
     served: true
     storage: true

--- a/multicluster/config/crd/bases/multicluster.crd.antrea.io_clustersets.yaml
+++ b/multicluster/config/crd/bases/multicluster.crd.antrea.io_clustersets.yaml
@@ -100,6 +100,8 @@ spec:
                 description: The leader cluster Namespace in which the ClusterSet
                   is defined. Used in member cluster.
                 type: string
+            required:
+            - leaders
             type: object
           status:
             description: ClusterSetStatus defines the observed state of ClusterSet.

--- a/multicluster/config/crd/bases/multicluster.crd.antrea.io_memberclusterannounces.yaml
+++ b/multicluster/config/crd/bases/multicluster.crd.antrea.io_memberclusterannounces.yaml
@@ -17,11 +17,11 @@ spec:
   versions:
   - additionalPrinterColumns:
     - description: Cluster ID of the member cluster
-      jsonPath: .spec.clusterID
+      jsonPath: .clusterID
       name: Cluster ID
       type: string
     - description: ClusterSet ID
-      jsonPath: .spec.clusterSetID
+      jsonPath: .clusterSetID
       name: ClusterSet ID
       type: string
     - jsonPath: .metadata.creationTimestamp

--- a/multicluster/controllers/multicluster/commonarea/acnp_resourceimport_controller_test.go
+++ b/multicluster/controllers/multicluster/commonarea/acnp_resourceimport_controller_test.go
@@ -109,7 +109,7 @@ var (
 func TestResourceImportReconciler_handleCopySpanACNPCreateEvent(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(securityOpsTier).Build()
 	fakeRemoteClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(acnpResImport, acnpResImportNoMatchingTier).Build()
-	remoteCluster := NewFakeRemoteCommonArea(scheme, fakeRemoteClient, "leader-cluster", localClusterID, "default")
+	remoteCluster := NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", localClusterID, "default")
 
 	tests := []struct {
 		name            string
@@ -168,7 +168,7 @@ func TestResourceImportReconciler_handleCopySpanACNPDeleteEvent(t *testing.T) {
 
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existingACNP).Build()
 	fakeRemoteClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-	remoteCluster := NewFakeRemoteCommonArea(scheme, fakeRemoteClient, "leader-cluster", localClusterID, "default")
+	remoteCluster := NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", localClusterID, "default")
 
 	r := NewResourceImportReconciler(fakeClient, scheme, fakeClient, localClusterID, "default", remoteCluster)
 	r.installedResImports.Add(*acnpResImport)
@@ -278,7 +278,7 @@ func TestResourceImportReconciler_handleCopySpanACNPUpdateEvent(t *testing.T) {
 
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existingACNP1, existingACNP3, existingACNP4, securityOpsTier).Build()
 	fakeRemoteClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(acnpResImport, updatedResImport2, updatedResImport3).Build()
-	remoteCluster := NewFakeRemoteCommonArea(scheme, fakeRemoteClient, "leader-cluster", localClusterID, "default")
+	remoteCluster := NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", localClusterID, "default")
 
 	r := NewResourceImportReconciler(fakeClient, scheme, fakeClient, localClusterID, "default", remoteCluster)
 	r.installedResImports.Add(*acnpResImport)

--- a/multicluster/controllers/multicluster/commonarea/clusterinfo_importer_test.go
+++ b/multicluster/controllers/multicluster/commonarea/clusterinfo_importer_test.go
@@ -165,7 +165,7 @@ func TestResourceImportReconciler_handleClusterInfo(t *testing.T) {
 			if tt.isDelete {
 				fakeRemoteClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects().Build()
 			}
-			remoteCluster := NewFakeRemoteCommonArea(scheme, fakeRemoteClient, "leader-cluster", "cluster-d", "default")
+			remoteCluster := NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", "cluster-d", "default")
 			r := NewResourceImportReconciler(fakeClient, scheme, fakeClient, "cluster-d", "default", remoteCluster)
 			if tt.isDelete {
 				r.installedResImports.Add(*ciResImportC)

--- a/multicluster/controllers/multicluster/commonarea/mock_remote_common_area_wrapper.go
+++ b/multicluster/controllers/multicluster/commonarea/mock_remote_common_area_wrapper.go
@@ -19,7 +19,6 @@ package commonarea
 import (
 	"context"
 
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	multiclusterv1alpha1 "antrea.io/antrea/multicluster/apis/multicluster/v1alpha1"
@@ -71,8 +70,7 @@ func (c *fakeRemoteCommonArea) GetLocalClusterID() string {
 }
 
 // NewFakeRemoteCommonArea creates a new fakeRemoteCommonArea for unit test purpose only
-func NewFakeRemoteCommonArea(scheme *runtime.Scheme,
-	fakeClient client.Client, clusterID string, localClusterID string, namespace string) RemoteCommonArea {
+func NewFakeRemoteCommonArea(fakeClient client.Client, clusterID string, localClusterID string, namespace string) RemoteCommonArea {
 	fakeRemoteCommonArea := &fakeRemoteCommonArea{
 		Client:         fakeClient,
 		ClusterID:      common.ClusterID(clusterID),

--- a/multicluster/controllers/multicluster/commonarea/resourceimport_controller_test.go
+++ b/multicluster/controllers/multicluster/commonarea/resourceimport_controller_test.go
@@ -121,7 +121,7 @@ func init() {
 func TestResourceImportReconciler_handleCreateEvent(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 	fakeRemoteClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(svcResImport, epResImport).Build()
-	remoteCluster := NewFakeRemoteCommonArea(scheme, fakeRemoteClient, "leader-cluster", localClusterID, "default")
+	remoteCluster := NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", localClusterID, "default")
 
 	tests := []struct {
 		name    string
@@ -191,7 +191,7 @@ func TestResourceImportReconciler_handleDeleteEvent(t *testing.T) {
 
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existSvc, existEp, existSvcImp).Build()
 	fakeRemoteClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-	remoteCluster := NewFakeRemoteCommonArea(scheme, fakeRemoteClient, "leader-cluster", localClusterID, "default")
+	remoteCluster := NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", localClusterID, "default")
 
 	tests := []struct {
 		name    string
@@ -392,7 +392,7 @@ func TestResourceImportReconciler_handleUpdateEvent(t *testing.T) {
 		existSvc, existMCSvcConflicts, existMCEpConflicts, svcWithoutAutoAnnotation, epWithoutAutoAnnotation).Build()
 	fakeRemoteClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(updatedEpResImport, updatedSvcResImport,
 		svcResImportWithConflicts, epResImportWithConflicts).Build()
-	remoteCluster := NewFakeRemoteCommonArea(scheme, fakeRemoteClient, "leader-cluster", localClusterID, "default")
+	remoteCluster := NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", localClusterID, "default")
 
 	tests := []struct {
 		name             string

--- a/multicluster/controllers/multicluster/gateway_controller_test.go
+++ b/multicluster/controllers/multicluster/gateway_controller_test.go
@@ -200,7 +200,7 @@ func TestGatewayReconciler(t *testing.T) {
 		if tt.resExport != nil {
 			fakeRemoteClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(tt.resExport).Build()
 		}
-		commonArea := commonarea.NewFakeRemoteCommonArea(scheme, fakeRemoteClient, "leader-cluster", localClusterID, leaderNamespace)
+		commonArea := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", localClusterID, leaderNamespace)
 		mcReconciler := NewMemberClusterSetReconciler(fakeClient, scheme, "default")
 		mcReconciler.SetRemoteCommonArea(commonArea)
 		commonAreaGatter := mcReconciler

--- a/multicluster/controllers/multicluster/member_clusterset_controller_test.go
+++ b/multicluster/controllers/multicluster/member_clusterset_controller_test.go
@@ -37,7 +37,7 @@ func TestMemberClusterDelete(t *testing.T) {
 	}
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects().Build()
 	fakeRemoteClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existingMemberClusterAnnounce).Build()
-	commonArea := commonarea.NewFakeRemoteCommonArea(scheme, fakeRemoteClient, "leader-cluster", localClusterID, "default")
+	commonArea := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", localClusterID, "default")
 
 	reconciler := MemberClusterSetReconciler{
 		Client:           fakeClient,

--- a/multicluster/controllers/multicluster/serviceexport_controller_test.go
+++ b/multicluster/controllers/multicluster/serviceexport_controller_test.go
@@ -67,7 +67,7 @@ func TestServiceExportReconciler_handleDeleteEvent(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(exportedSvcNginx).Build()
 	fakeRemoteClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existSvcResExport, existEpResExport).Build()
 
-	commonArea := commonarea.NewFakeRemoteCommonArea(scheme, fakeRemoteClient, "leader-cluster", localClusterID, "default")
+	commonArea := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", localClusterID, "default")
 	mcReconciler := NewMemberClusterSetReconciler(fakeClient, scheme, "default")
 	mcReconciler.SetRemoteCommonArea(commonArea)
 	r := NewServiceExportReconciler(fakeClient, scheme, mcReconciler)
@@ -203,7 +203,7 @@ func TestServiceExportReconciler_CheckExportStatus(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(mcsSvc, nginx0Svc, nginx1Svc, nginx1EP, nginx2Svc, existSvcExport,
 		nginx0SvcExport, nginx1SvcExportWithStatus, nginx2SvcExportWithStatus, mcsSvcExport).Build()
 	fakeRemoteClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-	commonArea := commonarea.NewFakeRemoteCommonArea(scheme, fakeRemoteClient, "leader-cluster", localClusterID, "default")
+	commonArea := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", localClusterID, "default")
 
 	mcReconciler := NewMemberClusterSetReconciler(fakeClient, scheme, "default")
 	mcReconciler.SetRemoteCommonArea(commonArea)
@@ -235,7 +235,7 @@ func TestServiceExportReconciler_handleServiceExportCreateEvent(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(svcNginx, epNginx, existSvcExport).Build()
 	fakeRemoteClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-	commonArea := commonarea.NewFakeRemoteCommonArea(scheme, fakeRemoteClient, "leader-cluster", localClusterID, "default")
+	commonArea := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", localClusterID, "default")
 	mcReconciler := NewMemberClusterSetReconciler(fakeClient, scheme, "default")
 	mcReconciler.SetRemoteCommonArea(commonArea)
 	r := NewServiceExportReconciler(fakeClient, scheme, mcReconciler)
@@ -309,7 +309,7 @@ func TestServiceExportReconciler_handleServiceUpdateEvent(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(newSvcNginx, svcNginxEPs, existSvcExport).Build()
 	fakeRemoteClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existSvcRe, existEpRe).Build()
 
-	commonArea := commonarea.NewFakeRemoteCommonArea(scheme, fakeRemoteClient, "leader-cluster", localClusterID, "default")
+	commonArea := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", localClusterID, "default")
 	mcReconciler := NewMemberClusterSetReconciler(fakeClient, scheme, "default")
 	mcReconciler.SetRemoteCommonArea(commonArea)
 	r := NewServiceExportReconciler(fakeClient, scheme, mcReconciler)

--- a/multicluster/controllers/multicluster/stale_controller_test.go
+++ b/multicluster/controllers/multicluster/stale_controller_test.go
@@ -92,7 +92,7 @@ func TestStaleController_CleanupService(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithLists(tt.existSvcList, tt.existSvcImpList).Build()
 			fakeRemoteClient := fake.NewClientBuilder().WithScheme(scheme).WithLists(tt.existingResImpList).Build()
-			commonArea := commonarea.NewFakeRemoteCommonArea(scheme, fakeRemoteClient, "leader-cluster", localClusterID, "default")
+			commonArea := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", localClusterID, "default")
 			mcReconciler := NewMemberClusterSetReconciler(fakeClient, scheme, "default")
 			mcReconciler.SetRemoteCommonArea(commonArea)
 			c := NewStaleResCleanupController(fakeClient, scheme, "default", mcReconciler)
@@ -186,7 +186,7 @@ func TestStaleController_CleanupACNP(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithLists(tt.existingACNPList).Build()
 			fakeRemoteClient := fake.NewClientBuilder().WithScheme(scheme).WithLists(tt.existingResImpList).Build()
-			commonArea := commonarea.NewFakeRemoteCommonArea(scheme, fakeRemoteClient, "leader-cluster", localClusterID, "default")
+			commonArea := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", localClusterID, "default")
 
 			mcReconciler := NewMemberClusterSetReconciler(fakeClient, scheme, "default")
 			mcReconciler.SetRemoteCommonArea(commonArea)
@@ -315,7 +315,7 @@ func TestStaleController_CleanupResourceExport(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithLists(tt.existSvcExpList).Build()
 			fakeRemoteClient := fake.NewClientBuilder().WithScheme(scheme).WithLists(tt.existResExpList).Build()
-			commonArea := commonarea.NewFakeRemoteCommonArea(scheme, fakeRemoteClient, "leader-cluster", localClusterID, "default")
+			commonArea := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", localClusterID, "default")
 
 			mcReconciler := NewMemberClusterSetReconciler(fakeClient, scheme, "default")
 			mcReconciler.SetRemoteCommonArea(commonArea)
@@ -396,7 +396,7 @@ func TestStaleController_CleanupClusterInfoImport(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithLists(tt.existCIImpList).Build()
 			fakeRemoteClient := fake.NewClientBuilder().WithScheme(scheme).WithLists(tt.existingResImpList).Build()
-			commonarea := commonarea.NewFakeRemoteCommonArea(scheme, fakeRemoteClient, "leader-cluster", localClusterID, "antrea-mcs")
+			commonarea := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", localClusterID, "antrea-mcs")
 
 			mcReconciler := NewMemberClusterSetReconciler(fakeClient, scheme, "default")
 			mcReconciler.SetRemoteCommonArea(commonarea)


### PR DESCRIPTION
1. Set Leaders in ClusterSet and Value in ClusterClaim as required
fields.
2. Fix the column field issue on MemberClusterAnnounce
3. Clean up some unused codes.

Signed-off-by: Lan Luo <luola@vmware.com>