### PR TITLE
Show IP counters when kubectl getting IPPools

### DIFF
--- a/build/charts/antrea/crds/ippool.yaml
+++ b/build/charts/antrea/crds/ippool.yaml
@@ -108,6 +108,18 @@ spec:
                       type: integer
                   type: object
               type: object
+      additionalPrinterColumns:
+        - description: The number of total IPs
+          jsonPath: .status.usage.total
+          name: Total
+          type: integer
+        - description: The number of allocated IPs
+          jsonPath: .status.usage.used
+          name: Used
+          type: integer
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
       subresources:
         status: {}
   scope: Cluster

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -1398,6 +1398,18 @@ spec:
                       type: integer
                   type: object
               type: object
+      additionalPrinterColumns:
+        - description: The number of total IPs
+          jsonPath: .status.usage.total
+          name: Total
+          type: integer
+        - description: The number of allocated IPs
+          jsonPath: .status.usage.used
+          name: Used
+          type: integer
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
       subresources:
         status: {}
   scope: Cluster

--- a/build/yamls/antrea-crds.yml
+++ b/build/yamls/antrea-crds.yml
@@ -1383,6 +1383,18 @@ spec:
                       type: integer
                   type: object
               type: object
+      additionalPrinterColumns:
+        - description: The number of total IPs
+          jsonPath: .status.usage.total
+          name: Total
+          type: integer
+        - description: The number of allocated IPs
+          jsonPath: .status.usage.used
+          name: Used
+          type: integer
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
       subresources:
         status: {}
   scope: Cluster

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -1398,6 +1398,18 @@ spec:
                       type: integer
                   type: object
               type: object
+      additionalPrinterColumns:
+        - description: The number of total IPs
+          jsonPath: .status.usage.total
+          name: Total
+          type: integer
+        - description: The number of allocated IPs
+          jsonPath: .status.usage.used
+          name: Used
+          type: integer
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
       subresources:
         status: {}
   scope: Cluster

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -1398,6 +1398,18 @@ spec:
                       type: integer
                   type: object
               type: object
+      additionalPrinterColumns:
+        - description: The number of total IPs
+          jsonPath: .status.usage.total
+          name: Total
+          type: integer
+        - description: The number of allocated IPs
+          jsonPath: .status.usage.used
+          name: Used
+          type: integer
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
       subresources:
         status: {}
   scope: Cluster

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -1398,6 +1398,18 @@ spec:
                       type: integer
                   type: object
               type: object
+      additionalPrinterColumns:
+        - description: The number of total IPs
+          jsonPath: .status.usage.total
+          name: Total
+          type: integer
+        - description: The number of allocated IPs
+          jsonPath: .status.usage.used
+          name: Used
+          type: integer
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
       subresources:
         status: {}
   scope: Cluster

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -1398,6 +1398,18 @@ spec:
                       type: integer
                   type: object
               type: object
+      additionalPrinterColumns:
+        - description: The number of total IPs
+          jsonPath: .status.usage.total
+          name: Total
+          type: integer
+        - description: The number of allocated IPs
+          jsonPath: .status.usage.used
+          name: Used
+          type: integer
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
       subresources:
         status: {}
   scope: Cluster


### PR DESCRIPTION
To make the output informative and consistent with ExternalIPPools.

Signed-off-by: Quan Tian <qtian@vmware.com>

Before:
```
# kubectl get ippools
NAME    AGE
pool1   10h
```

After:
```
# kubectl get ippools
NAME    TOTAL   USED   AGE
pool1   9       3      10h
```