### PR TITLE
Validate ServiceAccount for ClusterSet member list changes

### DIFF
--- a/multicluster/cmd/multicluster-controller/clusterset_webhook.go
+++ b/multicluster/cmd/multicluster-controller/clusterset_webhook.go
@@ -17,11 +17,13 @@ limitations under the License.
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 
+	"k8s.io/apiserver/pkg/authentication/serviceaccount"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -30,6 +32,10 @@ import (
 )
 
 //+kubebuilder:webhook:path=/validate-multicluster-crd-antrea-io-v1alpha1-clusterset,mutating=false,failurePolicy=fail,sideEffects=None,groups=multicluster.crd.antrea.io,resources=clustersets,verbs=create;update,versions=v1alpha1,name=vclusterset.kb.io,admissionReviewVersions={v1,v1beta1}
+
+const (
+	mcControllerSAName = "antrea-mc-controller"
+)
 
 // ClusterSet validator
 type clusterSetValidator struct {
@@ -57,6 +63,17 @@ func (v *clusterSetValidator) Handle(ctx context.Context, req admission.Request)
 			klog.ErrorS(err, "the field 'clusterID' is immutable", "ClusterSet", klog.KObj(clusterSet))
 			return admission.Denied("the field 'clusterID' is immutable")
 		}
+
+		ui := req.UserInfo
+		_, saName, err := serviceaccount.SplitUsername(ui.Username)
+		if err != nil {
+			klog.ErrorS(err, "Error getting ServiceAccount name", "ClusterSet", req.Namespace+"/"+req.Name)
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+		// Don't allow other users to update member list.
+		if saName != mcControllerSAName && isMemberListChanged(oldClusterSet.Spec.Members, clusterSet.Spec.Members) {
+			return admission.Errored(http.StatusPreconditionFailed, fmt.Errorf("member list can only be updated by Antrea Multi-cluster Controller"))
+		}
 		return admission.Allowed("")
 	}
 
@@ -78,4 +95,13 @@ func (v *clusterSetValidator) Handle(ctx context.Context, req admission.Request)
 func (v *clusterSetValidator) InjectDecoder(d *admission.Decoder) error {
 	v.decoder = d
 	return nil
+}
+
+func isMemberListChanged(oldMembers, newMembers []mcv1alpha1.MemberCluster) bool {
+	if len(oldMembers) != len(newMembers) {
+		return true
+	}
+	rawOldMembers, _ := json.Marshal(oldMembers)
+	rawNewMembers, _ := json.Marshal(newMembers)
+	return !bytes.Equal(rawOldMembers, rawNewMembers)
 }

--- a/multicluster/cmd/multicluster-controller/memberclusterannounce_webhook.go
+++ b/multicluster/cmd/multicluster-controller/memberclusterannounce_webhook.go
@@ -52,7 +52,7 @@ func (v *memberClusterAnnounceValidator) Handle(ctx context.Context, req admissi
 	ui := req.UserInfo
 	_, saName, err := serviceaccount.SplitUsername(ui.Username)
 	if err != nil {
-		klog.ErrorS(err, "Error getting ServiceAccount name", "request", req)
+		klog.ErrorS(err, "Error getting ServiceAccount name", "MemberClusterAnnounce", req.Namespace+"/"+req.Name)
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 


### PR DESCRIPTION
Since ClusterSet's member list is maintained by MemberClusterAnnounce
controller, mc-controller should deny ClusterSet member list updates by users
manually.

Signed-off-by: Lan Luo <luola@vmware.com>