### PR TITLE
[ExternalNode] Fix Agent log issue

### DIFF
--- a/pkg/agent/config/traffic_encap_mode.go
+++ b/pkg/agent/config/traffic_encap_mode.go
@@ -59,6 +59,9 @@ func GetTrafficEncapModes() []TrafficEncapModeType {
 
 // String returns value in string.
 func (m TrafficEncapModeType) String() string {
+	if m == TrafficEncapModeInvalid {
+		return "invalid"
+	}
 	return modeStrs[m]
 }
 

--- a/pkg/agent/config/traffic_encryption_mode.go
+++ b/pkg/agent/config/traffic_encryption_mode.go
@@ -56,5 +56,8 @@ func GetTrafficEncryptionModes() []TrafficEncryptionModeType {
 
 // String returns value in string.
 func (m TrafficEncryptionModeType) String() string {
+	if m == TrafficEncryptionModeInvalid {
+		return "invalid"
+	}
 	return encryptionModeStrs[m]
 }


### PR DESCRIPTION
Antrea Agent uses TrafficEncryptionModeInvalid in networkConfig. It may
introduce a panic when calling TrafficEncapModeInvalid.String() since
its string value is not defined in the string slice for the supported
TrafficEncryptionModeInvalid, and its value is -1 which is not a valid
index in any slice.

To resolve the issue, return a constant string when
TrafficEncapModeInvalid is used.

The same issue may exist on type TrafficEncapModeInvalid in the logging.
As a result, a defualt string value is given to TrafficEncapModeInvalid
too.

Fixes #4095 

Signed-off-by: wenyingd <wenyingd@vmware.com>