### PR TITLE
Document steps to set up Multi-cluster ClusterSet with antctl

### DIFF
--- a/docs/multicluster/antctl.md
+++ b/docs/multicluster/antctl.md
@@ -1,14 +1,15 @@
 # Antctl Multi-cluster commands
 
 Starting from version 1.6.0, Antrea supports the `antctl mc` commands, which can
-collect information from a leader cluster in a ClusterSet for troubleshooting
-issues in an Antrea Multi-cluster ClusterSet, create and delete resources in an
-Antrea Multi-cluster ClusterSet, and so on. The command `antctl mc get` is supported
-since Antrea version 1.6.0 and other commands are supported from 1.7.0. These commands
-cannot run inside the `antrea-controller`, `antrea-agent` and `antrea-mc-controller`
-Pods. The antctl will look for your kubeconfig file at `$HOME/.kube/config` by default.
-You can select a different one by setting the `KUBECONFIG` environment variable or with
-`--kubeconfig`.
+collect information from a leader cluster for troubleshooting Antrea
+Multi-cluster issues, deploy Antrea Multi-cluster and set up ClusterSets in both
+leader and member clusters. The `antctl mc get` command is supported since
+Antrea v1.6.0, while other commands are supported since v1.8.0. These commands
+cannot run inside the `antrea-controller`, `antrea-agent` or
+`antrea-mc-controller` Pods. antctl needs a kubeconfig file to access the target
+cluster's API server, and it will look for the kubeconfig file at
+`$HOME/.kube/config` by default. You can select a different file by setting the
+`KUBECONFIG` environment variable or with the `--kubeconfig` option of antctl.
 
 ## antctl mc get
 

--- a/docs/multicluster/quick-start.md
+++ b/docs/multicluster/quick-start.md
@@ -44,9 +44,22 @@ antrea-agent.conf: |
 At the moment, Multi-cluster Gateway only works with the Antrea `encap` traffic
 mode, and all member clusters in a ClusterSet must use the same tunnel type.
 
-## Set up Leader and Member in Cluster A
+## Steps with antctl
 
-### Step 1 - deploy Antrea Multi-cluster Controllers for leader and member
+`antctl` provides a couple of commands to facilitate deployment, configuration,
+and troubleshooting of Antrea Multi-cluster. This section describes the steps
+to deploy Antrea Multi-cluster and set up the example ClusterSet using `antctl`.
+A [further section](#steps-with-yaml-manifests) will describe the steps to
+achieve the same using YAML manifests.
+
+To execute any command in this section, `antctl` needs access to the target
+cluster's API server, and it needs a kubeconfig file for that. Please refer to
+the [`antctl` Multi-cluster manual](antctl.md) to learn more about the
+kubeconfig file configuration, and the `antctl` Multi-cluster commands.
+
+### Set up Leader and Member in Cluster A
+
+#### Step 1 - deploy Antrea Multi-cluster Controllers for leader and member
 
 Run the following commands to deploy Multi-cluster Controller for the leader
 into Namespace `antrea-multicluster` (Namespace `antrea-multicluster` will be
@@ -54,10 +67,9 @@ created by the commands), and Multi-cluster Controller for the member into
 Namepsace `kube-system`.
 
 ```bash
-$kubectl apply -f https://github.com/antrea-io/antrea/releases/download/$TAG/antrea-multicluster-leader-global.yml
 $kubectl create ns antrea-multicluster
-$kubectl apply -f https://github.com/antrea-io/antrea/releases/download/$TAG/antrea-multicluster-leader-namespaced.yml
-$kubectl apply -f https://github.com/antrea-io/antrea/releases/download/$TAG/antrea-multicluster-member.yml
+$antctl mc deploy leadercluster -n antrea-multicluster --antrea-version $TAG
+$antctl mc deploy membercluster -n kube-system --antrea-version $TAG
 ```
 
 You can run the following command to verify the the leader and member
@@ -74,45 +86,37 @@ antrea-multicluster   deployment.apps/antrea-mc-controller   1/1     1          
 kube-system           deployment.apps/antrea-mc-controller   1/1     1            1           48s
 ```
 
-### Step 2 - initialize ClusterSet
+#### Step 2 - initialize ClusterSet
 
-Antrea provides several template YAML manifests to set up a ClusterSet quicker.
-You can run the following commands that use the template manifests to create a
-ClusterSet named `test-clusteraset` in the leader cluster and get a
-ServiceAccount token for the member clusters (both cluster A and B in our case)
-to access the leader cluster (cluster A in our case) API server.
+Run the following commands to create a ClusterSet with cluster A to be the
+leader, and also join the ClusterSet as a member.
 
 ```bash
-$kubectl apply -f https://raw.githubusercontent.com/antrea-io/antrea/$TAG/multicluster/config/samples/clusterset_init/leader-clusterset-template.yml
-$kubectl apply -f https://raw.githubusercontent.com/antrea-io/antrea/$TAG/multicluster/config/samples/clusterset_init/leader-access-token-template.yml
-$kubectl get secret leader-access-token -n antrea-multicluster -o yaml | grep -w -e '^apiVersion' -e '^data' -e '^metadata' -e '^ *name:' -e '^kind' -e '  ca.crt' -e '  token:' -e '^type' -e '  namespace' | sed -e 's/kubernetes.io\/service-account-token/Opaque/g' -e 's/antrea-multicluster/kube-system/g' > leader-access-token.yml
+antctl mc init --clusterset test-clusterset --clusterid test-cluster-leader -n antrea-multicluster --create-token -o join-config.yml
+antctl mc join --clusterid test-cluster-leader -n kube-system --config-file join-config.yml
 ```
 
-The last command saves the ServiceAccount token to `leader-access-token.yml`
-which will be needed for member clusters to join the ClusterSet. Note, in this
-guide, we use a shared default ServiceAccount `antrea-mc-member-access-sa` for
-all member clusters. If you want to create a separate ServiceAccount for each
-member cluster for security considerations, you can follow the instructions in
-the [Multi-cluster User Guide](user-guide.md#set-up-access-to-leader-cluster).
-
-Next, run the following commands to make cluster A join the ClusterSet also as a
-member:
+The above `antctl mc init` command creates a default token (with the
+`--create-token` flag) for member clusters to join the ClusterSet and
+authenticate to the leader cluster API server, and the command saves the token
+Secret manifest and other ClusterSet join arguments to file `join-config.yml`
+(specified with the `-o` option), which can be provided to the `antctl mc join`
+command (with the `--config-file` option) to join the ClusterSet with these
+arguments. If you want to use a separate token for each member cluster for
+security considerations, you can run the following commands to create a token
+and use the token to join the ClusterSet:
 
 ```bash
-$kubectl apply -f leader-access-token.yml
-$curl -L https://raw.githubusercontent.com/antrea-io/antrea/$TAG/multicluster/config/samples/clusterset_init/member-clusterset-template.yml > member-clusterset.yml
-$sed -e 's/test-cluster-member/test-cluster-leader/g' -e 's/<LEADER_CLUSTER_IP>/172.10.0.11/g' member-clusterset.yml | kubectl apply -f -
+antctl mc create membertoken test-cluster-leader-token -n antrea-multicluster -o test-cluster-leader-token.yml
+antctl mc join --clusterid test-cluster-leader -n kube-system --config-file join-config.yml --token-secret-file test-cluster-leader-token.yml
 ```
 
-Here, `172.10.0.11` is the `kube-apiserver` IP of cluster A. You should replace
-it with the `kube-apiserver` IP of your leader cluster.
-
-### Step 3 - specify Multi-cluster Gateway Node
+#### Step 3 - specify Multi-cluster Gateway Node
 
 Last, you need to choose a Node in cluster A to serve as the Multi-cluster
 Gateway. The Node should have an IP that is reachable from the cluster B's
 Gateway Node, so a tunnel can be created between the two Gateways. For more
-information about Multi-cluster Gatweay, please refer to the [Multi-cluster
+information about Multi-cluster Gateway, please refer to the [Multi-cluster
 User Guide](user-guide.md#multi-cluster-gateway-configuration).
 
 Assuming K8s Node `node-a1` is selected for the Multi-cluster Gateway, run
@@ -124,12 +128,135 @@ Node from the annotation):
 $kubectl annotate node node-a1 multicluster.antrea.io/gateway=true
 ```
 
-## Set up Cluster B
+### Set up Cluster B
+
+Let us switch to cluster B. All the `kubectl` and `antctl` commands in the
+following steps should be run with the `kubeconfig` for cluster B.
+
+#### Step 1 - deploy Antrea Multi-cluster Controller for member
+
+Run the following command to deploy the member Multi-cluster Controller into
+Namespace `kube-system`.
+
+```bash
+$antctl mc deploy membercluster -n kube-system --antrea-version $TAG
+```
+
+You can run the following command to verify the `antrea-mc-controller` Pod is
+deployed and running:
+
+```bash
+$kubectl get all -A -l="component=antrea-mc-controller"
+NAMESPACE             NAME                                        READY   STATUS    RESTARTS   AGE
+kube-system           pod/antrea-mc-controller-85dbf58b75-pjj48   1/1     Running   0          40s
+
+NAMESPACE             NAME                                   READY   UP-TO-DATE   AVAILABLE   AGE
+kube-system           deployment.apps/antrea-mc-controller   1/1     1            1           40s
+```
+
+#### Step 2 - join ClusterSet
+
+Run the following command to make cluster B join the ClusterSet:
+
+```bash
+antctl mc join --clusterid test-cluster-member -n kube-system --config-file join-config.yml
+```
+
+`join-config.yml` is generated when creating the ClusterSet in cluster A. Again,
+you can also run the `antctl mc create membertoken` in the leader cluster
+(cluster A) to create a separate token for cluster B, and join using that token,
+rather than the default token in `join-config.yml`.
+
+#### Step 3 - specify Multi-cluster Gateway Node
+
+Assuming K8s Node `node-b1` is chosen to be the Multi-cluster Gateway for cluster
+B, run the following command to annotate the Node:
+
+```bash
+$kubectl annotate node node-b1 multicluster.antrea.io/gateway=true
+```
+
+## What is Next
+
+So far, we set up an Antrea Multi-cluster ClusterSet with two clusters following
+the above sections of this guide. Next, you can start to consume the Antrea
+Multi-cluster features with the ClusterSet, including [Multi-cluster Services](user-guide.md#multi-cluster-service)
+and [ClusterNetworkPolicy Replication](user-guide.md#multi-cluster-clusternetworkpolicy-replication).
+Please check the relevant Antrea Multi-cluster User Guide sections to learn more.
+
+If you want to add a new member cluster to your ClusterSet, you can follow the
+steps for cluster B to do so. For example, you can run the following command to
+join the ClusterSet in a member cluster with ID `test-cluster-member2`:
+
+```bash
+antctl mc join --clusterid test-cluster-member2 -n kube-system --config-file join-config.yml
+```
+
+## Steps with YAML Manifests
+
+### Set up Leader and Member in Cluster A
+
+#### Step 1 - deploy Antrea Multi-cluster Controllers for leader and member
+
+Run the following commands to deploy Multi-cluster Controller for the leader
+into Namespace `antrea-multicluster` (Namespace `antrea-multicluster` will be
+created by the commands), and Multi-cluster Controller for the member into
+Namepsace `kube-system`.
+
+```bash
+$kubectl apply -f https://github.com/antrea-io/antrea/releases/download/$TAG/antrea-multicluster-leader-global.yml
+$kubectl create ns antrea-multicluster
+$kubectl apply -f https://github.com/antrea-io/antrea/releases/download/$TAG/antrea-multicluster-leader-namespaced.yml
+$kubectl apply -f https://github.com/antrea-io/antrea/releases/download/$TAG/antrea-multicluster-member.yml
+```
+
+#### Step 2 - initialize ClusterSet
+
+Antrea provides several template YAML manifests to set up a ClusterSet quicker.
+You can run the following commands that use the template manifests to create a
+ClusterSet named `test-clusterset` in the leader cluster and a default token
+for the member clusters (both cluster A and B in our case) to join the
+ClusterSet.
+
+```bash
+$kubectl apply -f https://raw.githubusercontent.com/antrea-io/antrea/$TAG/multicluster/config/samples/clusterset_init/leader-clusterset-template.yml
+$kubectl apply -f https://raw.githubusercontent.com/antrea-io/antrea/$TAG/multicluster/config/samples/clusterset_init/leader-access-token-template.yml
+$kubectl get secret default-member-token -n antrea-multicluster -o yaml | grep -w -e '^apiVersion' -e '^data' -e '^metadata' -e '^ *name:' -e '^kind' -e '  ca.crt' -e '  token:' -e '^type' -e '  namespace' | sed -e 's/kubernetes.io\/service-account-token/Opaque/g' -e 's/antrea-multicluster/kube-system/g' > default-member-token.yml
+```
+
+The last command saves the token Secret manifest to `default-member-token.yml`,
+which will be needed for member clusters to join the ClusterSet. Note, in this
+example, we use a shared token for all member clusters. If you want to use a
+separate token for each member cluster for security considerations, you can
+follow the instructions in the [Multi-cluster User Guide](user-guide.md#set-up-access-to-leader-cluster).
+
+Next, run the following commands to make cluster A join the ClusterSet also as a
+member:
+
+```bash
+$kubectl apply -f default-member-token.yml
+$curl -L https://raw.githubusercontent.com/antrea-io/antrea/$TAG/multicluster/config/samples/clusterset_init/member-clusterset-template.yml > member-clusterset.yml
+$sed -e 's/test-cluster-member/test-cluster-leader/g' -e 's/<LEADER_APISERVER_IP>/172.10.0.11/g' member-clusterset.yml | kubectl apply -f -
+```
+
+Here, `172.10.0.11` is the `kube-apiserver` IP of cluster A. You should replace
+it with the `kube-apiserver` IP of your leader cluster.
+
+#### Step 3 - specify Multi-cluster Gateway Node
+
+Assuming K8s Node `node-a1` is selected for the Multi-cluster Gateway, run
+the following command to annotate the Node:
+
+```bash
+$kubectl annotate node node-a1 multicluster.antrea.io/gateway=true
+```
+
+### Set up Cluster B
 
 Let us switch to cluster B. All the `kubectl` commands in the following steps
 should be run with the `kubeconfig` for cluster B.
 
-### Step 1 - deploy Antrea Multi-cluster Controller for member
+#### Step 1 - deploy Antrea Multi-cluster Controller for member
 
 Run the following command to deploy the member Multi-cluster Controller into
 Namespace `kube-system`.
@@ -150,20 +277,20 @@ NAMESPACE             NAME                                   READY   UP-TO-DATE 
 kube-system           deployment.apps/antrea-mc-controller   1/1     1            1           40s
 ```
 
-### Step 2 - join ClusterSet
+#### Step 2 - join ClusterSet
 
 Run the following commands to make cluster B join the ClusterSet:
 
 ```bash
-$kubectl apply -f leader-access-token.yml
+$kubectl apply -f default-member-token.yml
 $curl -L https://raw.githubusercontent.com/antrea-io/antrea/$TAG/multicluster/config/samples/clusterset_init/member-clusterset-template.yml > member-clusterset.yml
-$sed -e 's/<LEADER_CLUSTER_IP>/172.10.0.11/g' member-clusterset.yml | kubectl apply -f -
+$sed -e 's/<LEADER_APISERVER_IP>/172.10.0.11/g' member-clusterset.yml | kubectl apply -f -
 ```
 
-`leader-access-token.yml` saves the leader cluster ServiceAccount token which
-was generated when initializing the ClusterSet in cluster A.
+`default-member-token.yml` saves the default member token which was generated
+when initializing the ClusterSet in cluster A.
 
-### Step 3 - specify Multi-cluster Gateway Node
+#### Step 3 - specify Multi-cluster Gateway Node
 
 Assuming K8s Node `node-b1` is chosen to be the Multi-cluster Gateway for cluster
 B, run the following command to annotate the Node:
@@ -172,13 +299,7 @@ B, run the following command to annotate the Node:
 $kubectl annotate node node-b1 multicluster.antrea.io/gateway=true
 ```
 
-## What is Next
-
-So far, we set up an Antrea Multi-cluster ClusterSet with two clusters following
-the above sections of this guide. Next, you can start to consume the Antrea
-Multi-cluster features with the ClusterSet, including [Multi-cluster Services](user-guide.md#multi-cluster-service)
-and [ClusterNetworkPolicy Replication](user-guide.md#multi-cluster-clusternetworkpolicy-replication).
-Please check the relevant Antrea Multi-cluster User Guide sections to learn more.
+### Add new member clusters
 
 If you want to add a new member cluster to your ClusterSet, you can follow the
 steps for cluster B to do so. Remember to update the member cluster ID in
@@ -187,7 +308,7 @@ joining ClusterSet. For example, you can run the following commands to join the
 ClusterSet in a member cluster with ID `test-cluster-member2`:
 
 ```bash
-$kubectl apply -f leader-access-token.yml
+$kubectl apply -f default-member-token.yml
 $curl -L https://raw.githubusercontent.com/antrea-io/antrea/$TAG/multicluster/config/samples/clusterset_init/member-clusterset-template.yml  > member-clusterset.yml
-$sed -e 's/<LEADER_CLUSTER_IP>/172.10.0.11/g' -e 's/test-cluster-member/test-cluster-member2/g' member-clusterset.yml | kubectl apply -f -
+$sed -e 's/<LEADER_APISERVER_IP>/172.10.0.11/g' -e 's/test-cluster-member/test-cluster-member2/g' member-clusterset.yml | kubectl apply -f -
 ```

--- a/docs/multicluster/user-guide.md
+++ b/docs/multicluster/user-guide.md
@@ -152,22 +152,22 @@ fine-grained access control.
    apiVersion: v1
    kind: ServiceAccount
    metadata:
-     name: member-east-access-sa
+     name: member-east
      namespace: antrea-multicluster
    ---
    apiVersion: v1
    kind: Secret
    metadata:
-     name: member-east-access-token
+     name: member-east-token
      namespace: antrea-multicluster
      annotations:
-       kubernetes.io/service-account.name: member-east-access-sa
+       kubernetes.io/service-account.name: member-east
    type: kubernetes.io/service-account-token
    ---
    apiVersion: rbac.authorization.k8s.io/v1
    kind: RoleBinding
    metadata:
-     name: member-east-access-rolebinding
+     name: member-east
      namespace: antrea-multicluster
    roleRef:
      apiGroup: rbac.authorization.k8s.io
@@ -175,18 +175,18 @@ fine-grained access control.
      name: antrea-mc-member-cluster-role
    subjects:
      - kind: ServiceAccount
-       name: member-east-access-sa
+       name: member-east
        namespace: antrea-multicluster
    ```
 
-2. Generate the access token file from the leader cluster, and create a Secret
-   with the token in member cluster `test-cluster-east`, e.g.:
+2. Generate the token Secret manifest from the leader cluster, and create a
+   Secret with the manifest in member cluster `test-cluster-east`, e.g.:
 
    ```bash
-   # Generate the file 'member-east-access-token.yml' from your leader cluster
-   kubectl get secret member-east-access-token -n antrea-multicluster -o yaml | grep -w -e '^apiVersion' -e '^data' -e '^metadata' -e '^ *name:'  -e   '^kind' -e '  ca.crt' -e '  token:' -e '^type' -e '  namespace' | sed -e 's/kubernetes.io\/service-account-token/Opaque/g' -e 's/antrea-multicluster/kube-system/g' >  member-east-access-token.yml
-   # Apply 'member-east-access-token.yml' to the member cluster.
-   kubectl apply -f member-east-access-token.yml --kubeconfig=/path/to/kubeconfig-of-member-test-cluster-east
+   # Generate the file 'member-east-token.yml' from your leader cluster
+   kubectl get secret member-east-token -n antrea-multicluster -o yaml | grep -w -e '^apiVersion' -e '^data' -e '^metadata' -e '^ *name:'  -e   '^kind' -e '  ca.crt' -e '  token:' -e '^type' -e '  namespace' | sed -e 's/kubernetes.io\/service-account-token/Opaque/g' -e 's/antrea-multicluster/kube-system/g' >  member-east-token.yml
+   # Apply 'member-east-token.yml' to the member cluster.
+   kubectl apply -f member-east-token.yml --kubeconfig=/path/to/kubeconfig-of-member-test-cluster-east
    ```
 
 3. Replace all `east` to `west` and repeat step 1/2 for the other member cluster
@@ -254,7 +254,7 @@ metadata:
 spec:
   leaders:
     - clusterID: test-cluster-north
-      secret: "member-east-access-token"
+      secret: "member-east-token"
       server: "https://172.18.0.1:6443"
   namespace: antrea-multicluster
 ```
@@ -287,7 +287,7 @@ metadata:
 spec:
   leaders:
     - clusterID: test-cluster-north
-      secret: "member-west-access-token"
+      secret: "member-west-token"
       server: "https://172.18.0.1:6443"
   namespace: antrea-multicluster
 ```
@@ -327,7 +327,7 @@ metadata:
 spec:
   leaders:
     - clusterID: test-cluster-north
-      secret: "member-north-access-token"
+      secret: "member-north-token"
       server: "https://172.18.0.1:6443"
   namespace: antrea-multicluster
 ```

--- a/multicluster/config/samples/clusterset_init/leader-access-token-template.yml
+++ b/multicluster/config/samples/clusterset_init/leader-access-token-template.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: leader-access-token
+  name: default-member-token
   namespace: antrea-multicluster
   annotations:
     kubernetes.io/service-account.name: antrea-mc-member-access-sa

--- a/multicluster/config/samples/clusterset_init/member-clusterset-template.yml
+++ b/multicluster/config/samples/clusterset_init/member-clusterset-template.yml
@@ -20,6 +20,6 @@ metadata:
 spec:
   leaders:
     - clusterID: test-cluster-leader
-      secret: leader-access-token
-      server: https://<LEADER_CLUSTER_IP>:6443
+      secret: default-member-token
+      server: https://<LEADER_APISERVER_IP>:6443
   namespace: antrea-multicluster


### PR DESCRIPTION
Add steps to set up a set up Multi-cluster ClusterSet using antctl
commands to the Multi-cluster quick-start guide.
Also made minor revisions to the Multi-cluster antctl and user guides,
and the sample YAML template for creating a member token.

Signed-off-by: Jianjun Shen <shenj@vmware.com>