### PR TITLE
Disable metrics api for multicluster controller and clean up configs

### DIFF
--- a/multicluster/build/yamls/antrea-multicluster-leader-global.yml
+++ b/multicluster/build/yamls/antrea-multicluster-leader-global.yml
@@ -629,6 +629,19 @@ spec:
                                 contains only "value". The requirements are ANDed.
                               type: object
                           type: object
+                        service:
+                          description: Select a certain Service which matches the
+                            NamespacedName. A Service can only be set in either policy
+                            level AppliedTo field in a policy that only has ingress
+                            rules or rule level AppliedTo field in an ingress rule.
+                            Only a NodePort Service can be referred by this field.
+                            Cannot be set with any other selector.
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
                         serviceAccount:
                           description: Select all Pods with the ServiceAccount matched
                             by this field, as workloads in AppliedTo/To/From fields.
@@ -907,6 +920,20 @@ spec:
                                       The requirements are ANDed.
                                     type: object
                                 type: object
+                              service:
+                                description: Select a certain Service which matches
+                                  the NamespacedName. A Service can only be set in
+                                  either policy level AppliedTo field in a policy
+                                  that only has ingress rules or rule level AppliedTo
+                                  field in an ingress rule. Only a NodePort Service
+                                  can be referred by this field. Cannot be set with
+                                  any other selector.
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                type: object
                               serviceAccount:
                                 description: Select all Pods with the ServiceAccount
                                   matched by this field, as workloads in AppliedTo/To/From
@@ -1176,6 +1203,20 @@ spec:
                                       and the values array contains only "value".
                                       The requirements are ANDed.
                                     type: object
+                                type: object
+                              service:
+                                description: Select a certain Service which matches
+                                  the NamespacedName. A Service can only be set in
+                                  either policy level AppliedTo field in a policy
+                                  that only has ingress rules or rule level AppliedTo
+                                  field in an ingress rule. Only a NodePort Service
+                                  can be referred by this field. Cannot be set with
+                                  any other selector.
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
                                 type: object
                               serviceAccount:
                                 description: Select all Pods with the ServiceAccount
@@ -1515,6 +1556,20 @@ spec:
                                       and the values array contains only "value".
                                       The requirements are ANDed.
                                     type: object
+                                type: object
+                              service:
+                                description: Select a certain Service which matches
+                                  the NamespacedName. A Service can only be set in
+                                  either policy level AppliedTo field in a policy
+                                  that only has ingress rules or rule level AppliedTo
+                                  field in an ingress rule. Only a NodePort Service
+                                  can be referred by this field. Cannot be set with
+                                  any other selector.
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
                                 type: object
                               serviceAccount:
                                 description: Select all Pods with the ServiceAccount
@@ -1815,6 +1870,20 @@ spec:
                                       The requirements are ANDed.
                                     type: object
                                 type: object
+                              service:
+                                description: Select a certain Service which matches
+                                  the NamespacedName. A Service can only be set in
+                                  either policy level AppliedTo field in a policy
+                                  that only has ingress rules or rule level AppliedTo
+                                  field in an ingress rule. Only a NodePort Service
+                                  can be referred by this field. Cannot be set with
+                                  any other selector.
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                type: object
                               serviceAccount:
                                 description: Select all Pods with the ServiceAccount
                                   matched by this field, as workloads in AppliedTo/To/From
@@ -2084,6 +2153,20 @@ spec:
                                       and the values array contains only "value".
                                       The requirements are ANDed.
                                     type: object
+                                type: object
+                              service:
+                                description: Select a certain Service which matches
+                                  the NamespacedName. A Service can only be set in
+                                  either policy level AppliedTo field in a policy
+                                  that only has ingress rules or rule level AppliedTo
+                                  field in an ingress rule. Only a NodePort Service
+                                  can be referred by this field. Cannot be set with
+                                  any other selector.
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
                                 type: object
                               serviceAccount:
                                 description: Select all Pods with the ServiceAccount
@@ -2423,6 +2506,20 @@ spec:
                                       and the values array contains only "value".
                                       The requirements are ANDed.
                                     type: object
+                                type: object
+                              service:
+                                description: Select a certain Service which matches
+                                  the NamespacedName. A Service can only be set in
+                                  either policy level AppliedTo field in a policy
+                                  that only has ingress rules or rule level AppliedTo
+                                  field in an ingress rule. Only a NodePort Service
+                                  can be referred by this field. Cannot be set with
+                                  any other selector.
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
                                 type: object
                               serviceAccount:
                                 description: Select all Pods with the ServiceAccount
@@ -3421,6 +3518,19 @@ spec:
                                 contains only "value". The requirements are ANDed.
                               type: object
                           type: object
+                        service:
+                          description: Select a certain Service which matches the
+                            NamespacedName. A Service can only be set in either policy
+                            level AppliedTo field in a policy that only has ingress
+                            rules or rule level AppliedTo field in an ingress rule.
+                            Only a NodePort Service can be referred by this field.
+                            Cannot be set with any other selector.
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
                         serviceAccount:
                           description: Select all Pods with the ServiceAccount matched
                             by this field, as workloads in AppliedTo/To/From fields.
@@ -3699,6 +3809,20 @@ spec:
                                       The requirements are ANDed.
                                     type: object
                                 type: object
+                              service:
+                                description: Select a certain Service which matches
+                                  the NamespacedName. A Service can only be set in
+                                  either policy level AppliedTo field in a policy
+                                  that only has ingress rules or rule level AppliedTo
+                                  field in an ingress rule. Only a NodePort Service
+                                  can be referred by this field. Cannot be set with
+                                  any other selector.
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                type: object
                               serviceAccount:
                                 description: Select all Pods with the ServiceAccount
                                   matched by this field, as workloads in AppliedTo/To/From
@@ -3968,6 +4092,20 @@ spec:
                                       and the values array contains only "value".
                                       The requirements are ANDed.
                                     type: object
+                                type: object
+                              service:
+                                description: Select a certain Service which matches
+                                  the NamespacedName. A Service can only be set in
+                                  either policy level AppliedTo field in a policy
+                                  that only has ingress rules or rule level AppliedTo
+                                  field in an ingress rule. Only a NodePort Service
+                                  can be referred by this field. Cannot be set with
+                                  any other selector.
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
                                 type: object
                               serviceAccount:
                                 description: Select all Pods with the ServiceAccount
@@ -4307,6 +4445,20 @@ spec:
                                       and the values array contains only "value".
                                       The requirements are ANDed.
                                     type: object
+                                type: object
+                              service:
+                                description: Select a certain Service which matches
+                                  the NamespacedName. A Service can only be set in
+                                  either policy level AppliedTo field in a policy
+                                  that only has ingress rules or rule level AppliedTo
+                                  field in an ingress rule. Only a NodePort Service
+                                  can be referred by this field. Cannot be set with
+                                  any other selector.
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
                                 type: object
                               serviceAccount:
                                 description: Select all Pods with the ServiceAccount
@@ -4607,6 +4759,20 @@ spec:
                                       The requirements are ANDed.
                                     type: object
                                 type: object
+                              service:
+                                description: Select a certain Service which matches
+                                  the NamespacedName. A Service can only be set in
+                                  either policy level AppliedTo field in a policy
+                                  that only has ingress rules or rule level AppliedTo
+                                  field in an ingress rule. Only a NodePort Service
+                                  can be referred by this field. Cannot be set with
+                                  any other selector.
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                type: object
                               serviceAccount:
                                 description: Select all Pods with the ServiceAccount
                                   matched by this field, as workloads in AppliedTo/To/From
@@ -4876,6 +5042,20 @@ spec:
                                       and the values array contains only "value".
                                       The requirements are ANDed.
                                     type: object
+                                type: object
+                              service:
+                                description: Select a certain Service which matches
+                                  the NamespacedName. A Service can only be set in
+                                  either policy level AppliedTo field in a policy
+                                  that only has ingress rules or rule level AppliedTo
+                                  field in an ingress rule. Only a NodePort Service
+                                  can be referred by this field. Cannot be set with
+                                  any other selector.
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
                                 type: object
                               serviceAccount:
                                 description: Select all Pods with the ServiceAccount
@@ -5215,6 +5395,20 @@ spec:
                                       and the values array contains only "value".
                                       The requirements are ANDed.
                                     type: object
+                                type: object
+                              service:
+                                description: Select a certain Service which matches
+                                  the NamespacedName. A Service can only be set in
+                                  either policy level AppliedTo field in a policy
+                                  that only has ingress rules or rule level AppliedTo
+                                  field in an ingress rule. Only a NodePort Service
+                                  can be referred by this field. Cannot be set with
+                                  any other selector.
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
                                 type: object
                               serviceAccount:
                                 description: Select all Pods with the ServiceAccount

--- a/multicluster/build/yamls/antrea-multicluster-leader-namespaced.yml
+++ b/multicluster/build/yamls/antrea-multicluster-leader-namespaced.yml
@@ -314,23 +314,20 @@ data:
     apiVersion: multicluster.crd.antrea.io/v1alpha1
     kind: MultiClusterConfig
     health:
-      healthProbeBindAddress: :8081
+      healthProbeBindAddress: :8080
     metrics:
-      bindAddress: 127.0.0.1:8080
+      bindAddress: 0
     webhook:
       port: 9443
     leaderElection:
       leaderElect: false
-      resourceName: 6536456a.crd.antrea.io
-      leaseDuration: "30s"
-      renewDeadline: "20s"
     serviceCIDR: ""
     gatewayIPPrecedence: "private"
 kind: ConfigMap
 metadata:
   labels:
     app: antrea
-  name: antrea-mc-controller-config-t2b9525b7f
+  name: antrea-mc-controller-config-hbdmg9b87m
   namespace: antrea-multicluster
 ---
 apiVersion: v1
@@ -384,7 +381,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 8081
+            port: 8080
           initialDelaySeconds: 15
           periodSeconds: 20
         name: antrea-mc-controller
@@ -395,7 +392,7 @@ spec:
         readinessProbe:
           httpGet:
             path: /readyz
-            port: 8081
+            port: 8080
           initialDelaySeconds: 5
           periodSeconds: 10
         resources:
@@ -412,7 +409,7 @@ spec:
       terminationGracePeriodSeconds: 10
       volumes:
       - configMap:
-          name: antrea-mc-controller-config-t2b9525b7f
+          name: antrea-mc-controller-config-hbdmg9b87m
         name: antrea-mc-controller-config
 ---
 apiVersion: admissionregistration.k8s.io/v1

--- a/multicluster/build/yamls/antrea-multicluster-member.yml
+++ b/multicluster/build/yamls/antrea-multicluster-member.yml
@@ -938,23 +938,20 @@ data:
     apiVersion: multicluster.crd.antrea.io/v1alpha1
     kind: MultiClusterConfig
     health:
-      healthProbeBindAddress: :8081
+      healthProbeBindAddress: :8080
     metrics:
-      bindAddress: 127.0.0.1:8080
+      bindAddress: 0
     webhook:
       port: 9443
     leaderElection:
       leaderElect: false
-      resourceName: 6536456a.crd.antrea.io
-      leaseDuration: "30s"
-      renewDeadline: "20s"
     serviceCIDR: ""
     gatewayIPPrecedence: "private"
 kind: ConfigMap
 metadata:
   labels:
     app: antrea
-  name: antrea-mc-controller-config-t2b9525b7f
+  name: antrea-mc-controller-config-hbdmg9b87m
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1008,7 +1005,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 8081
+            port: 8080
           initialDelaySeconds: 15
           periodSeconds: 20
         name: antrea-mc-controller
@@ -1019,7 +1016,7 @@ spec:
         readinessProbe:
           httpGet:
             path: /readyz
-            port: 8081
+            port: 8080
           initialDelaySeconds: 5
           periodSeconds: 10
         resources:
@@ -1036,7 +1033,7 @@ spec:
       terminationGracePeriodSeconds: 10
       volumes:
       - configMap:
-          name: antrea-mc-controller-config-t2b9525b7f
+          name: antrea-mc-controller-config-hbdmg9b87m
         name: antrea-mc-controller-config
 ---
 apiVersion: admissionregistration.k8s.io/v1

--- a/multicluster/cmd/multicluster-controller/options.go
+++ b/multicluster/cmd/multicluster-controller/options.go
@@ -17,7 +17,6 @@ package main
 import (
 	"fmt"
 	"net"
-	"time"
 
 	"github.com/spf13/pflag"
 	"k8s.io/klog/v2"
@@ -77,16 +76,11 @@ func (o *Options) addFlags(fs *pflag.FlagSet) {
 }
 
 func (o *Options) setDefaults() {
-	// see https://github.com/operator-framework/operator-sdk/issues/1813
-	leaseDuration := 30 * time.Second
-	renewDeadline := 20 * time.Second
 	o.options = ctrl.Options{
 		Scheme:                 scheme,
-		MetricsBindAddress:     ":8080",
+		MetricsBindAddress:     "0",
 		Port:                   9443,
-		HealthProbeBindAddress: ":8081",
+		HealthProbeBindAddress: ":8080",
 		LeaderElection:         false,
-		LeaseDuration:          &leaseDuration,
-		RenewDeadline:          &renewDeadline,
 	}
 }

--- a/multicluster/config/crd/bases/multicluster.crd.antrea.io_resourceexports.yaml
+++ b/multicluster/config/crd/bases/multicluster.crd.antrea.io_resourceexports.yaml
@@ -324,6 +324,19 @@ spec:
                                 contains only "value". The requirements are ANDed.
                               type: object
                           type: object
+                        service:
+                          description: Select a certain Service which matches the
+                            NamespacedName. A Service can only be set in either policy
+                            level AppliedTo field in a policy that only has ingress
+                            rules or rule level AppliedTo field in an ingress rule.
+                            Only a NodePort Service can be referred by this field.
+                            Cannot be set with any other selector.
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
                         serviceAccount:
                           description: Select all Pods with the ServiceAccount matched
                             by this field, as workloads in AppliedTo/To/From fields.
@@ -602,6 +615,20 @@ spec:
                                       The requirements are ANDed.
                                     type: object
                                 type: object
+                              service:
+                                description: Select a certain Service which matches
+                                  the NamespacedName. A Service can only be set in
+                                  either policy level AppliedTo field in a policy
+                                  that only has ingress rules or rule level AppliedTo
+                                  field in an ingress rule. Only a NodePort Service
+                                  can be referred by this field. Cannot be set with
+                                  any other selector.
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                type: object
                               serviceAccount:
                                 description: Select all Pods with the ServiceAccount
                                   matched by this field, as workloads in AppliedTo/To/From
@@ -871,6 +898,20 @@ spec:
                                       and the values array contains only "value".
                                       The requirements are ANDed.
                                     type: object
+                                type: object
+                              service:
+                                description: Select a certain Service which matches
+                                  the NamespacedName. A Service can only be set in
+                                  either policy level AppliedTo field in a policy
+                                  that only has ingress rules or rule level AppliedTo
+                                  field in an ingress rule. Only a NodePort Service
+                                  can be referred by this field. Cannot be set with
+                                  any other selector.
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
                                 type: object
                               serviceAccount:
                                 description: Select all Pods with the ServiceAccount
@@ -1210,6 +1251,20 @@ spec:
                                       and the values array contains only "value".
                                       The requirements are ANDed.
                                     type: object
+                                type: object
+                              service:
+                                description: Select a certain Service which matches
+                                  the NamespacedName. A Service can only be set in
+                                  either policy level AppliedTo field in a policy
+                                  that only has ingress rules or rule level AppliedTo
+                                  field in an ingress rule. Only a NodePort Service
+                                  can be referred by this field. Cannot be set with
+                                  any other selector.
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
                                 type: object
                               serviceAccount:
                                 description: Select all Pods with the ServiceAccount
@@ -1510,6 +1565,20 @@ spec:
                                       The requirements are ANDed.
                                     type: object
                                 type: object
+                              service:
+                                description: Select a certain Service which matches
+                                  the NamespacedName. A Service can only be set in
+                                  either policy level AppliedTo field in a policy
+                                  that only has ingress rules or rule level AppliedTo
+                                  field in an ingress rule. Only a NodePort Service
+                                  can be referred by this field. Cannot be set with
+                                  any other selector.
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                type: object
                               serviceAccount:
                                 description: Select all Pods with the ServiceAccount
                                   matched by this field, as workloads in AppliedTo/To/From
@@ -1779,6 +1848,20 @@ spec:
                                       and the values array contains only "value".
                                       The requirements are ANDed.
                                     type: object
+                                type: object
+                              service:
+                                description: Select a certain Service which matches
+                                  the NamespacedName. A Service can only be set in
+                                  either policy level AppliedTo field in a policy
+                                  that only has ingress rules or rule level AppliedTo
+                                  field in an ingress rule. Only a NodePort Service
+                                  can be referred by this field. Cannot be set with
+                                  any other selector.
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
                                 type: object
                               serviceAccount:
                                 description: Select all Pods with the ServiceAccount
@@ -2118,6 +2201,20 @@ spec:
                                       and the values array contains only "value".
                                       The requirements are ANDed.
                                     type: object
+                                type: object
+                              service:
+                                description: Select a certain Service which matches
+                                  the NamespacedName. A Service can only be set in
+                                  either policy level AppliedTo field in a policy
+                                  that only has ingress rules or rule level AppliedTo
+                                  field in an ingress rule. Only a NodePort Service
+                                  can be referred by this field. Cannot be set with
+                                  any other selector.
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
                                 type: object
                               serviceAccount:
                                 description: Select all Pods with the ServiceAccount

--- a/multicluster/config/crd/bases/multicluster.crd.antrea.io_resourceimports.yaml
+++ b/multicluster/config/crd/bases/multicluster.crd.antrea.io_resourceimports.yaml
@@ -322,6 +322,19 @@ spec:
                                 contains only "value". The requirements are ANDed.
                               type: object
                           type: object
+                        service:
+                          description: Select a certain Service which matches the
+                            NamespacedName. A Service can only be set in either policy
+                            level AppliedTo field in a policy that only has ingress
+                            rules or rule level AppliedTo field in an ingress rule.
+                            Only a NodePort Service can be referred by this field.
+                            Cannot be set with any other selector.
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
                         serviceAccount:
                           description: Select all Pods with the ServiceAccount matched
                             by this field, as workloads in AppliedTo/To/From fields.
@@ -600,6 +613,20 @@ spec:
                                       The requirements are ANDed.
                                     type: object
                                 type: object
+                              service:
+                                description: Select a certain Service which matches
+                                  the NamespacedName. A Service can only be set in
+                                  either policy level AppliedTo field in a policy
+                                  that only has ingress rules or rule level AppliedTo
+                                  field in an ingress rule. Only a NodePort Service
+                                  can be referred by this field. Cannot be set with
+                                  any other selector.
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                type: object
                               serviceAccount:
                                 description: Select all Pods with the ServiceAccount
                                   matched by this field, as workloads in AppliedTo/To/From
@@ -869,6 +896,20 @@ spec:
                                       and the values array contains only "value".
                                       The requirements are ANDed.
                                     type: object
+                                type: object
+                              service:
+                                description: Select a certain Service which matches
+                                  the NamespacedName. A Service can only be set in
+                                  either policy level AppliedTo field in a policy
+                                  that only has ingress rules or rule level AppliedTo
+                                  field in an ingress rule. Only a NodePort Service
+                                  can be referred by this field. Cannot be set with
+                                  any other selector.
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
                                 type: object
                               serviceAccount:
                                 description: Select all Pods with the ServiceAccount
@@ -1208,6 +1249,20 @@ spec:
                                       and the values array contains only "value".
                                       The requirements are ANDed.
                                     type: object
+                                type: object
+                              service:
+                                description: Select a certain Service which matches
+                                  the NamespacedName. A Service can only be set in
+                                  either policy level AppliedTo field in a policy
+                                  that only has ingress rules or rule level AppliedTo
+                                  field in an ingress rule. Only a NodePort Service
+                                  can be referred by this field. Cannot be set with
+                                  any other selector.
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
                                 type: object
                               serviceAccount:
                                 description: Select all Pods with the ServiceAccount
@@ -1508,6 +1563,20 @@ spec:
                                       The requirements are ANDed.
                                     type: object
                                 type: object
+                              service:
+                                description: Select a certain Service which matches
+                                  the NamespacedName. A Service can only be set in
+                                  either policy level AppliedTo field in a policy
+                                  that only has ingress rules or rule level AppliedTo
+                                  field in an ingress rule. Only a NodePort Service
+                                  can be referred by this field. Cannot be set with
+                                  any other selector.
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                type: object
                               serviceAccount:
                                 description: Select all Pods with the ServiceAccount
                                   matched by this field, as workloads in AppliedTo/To/From
@@ -1777,6 +1846,20 @@ spec:
                                       and the values array contains only "value".
                                       The requirements are ANDed.
                                     type: object
+                                type: object
+                              service:
+                                description: Select a certain Service which matches
+                                  the NamespacedName. A Service can only be set in
+                                  either policy level AppliedTo field in a policy
+                                  that only has ingress rules or rule level AppliedTo
+                                  field in an ingress rule. Only a NodePort Service
+                                  can be referred by this field. Cannot be set with
+                                  any other selector.
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
                                 type: object
                               serviceAccount:
                                 description: Select all Pods with the ServiceAccount
@@ -2116,6 +2199,20 @@ spec:
                                       and the values array contains only "value".
                                       The requirements are ANDed.
                                     type: object
+                                type: object
+                              service:
+                                description: Select a certain Service which matches
+                                  the NamespacedName. A Service can only be set in
+                                  either policy level AppliedTo field in a policy
+                                  that only has ingress rules or rule level AppliedTo
+                                  field in an ingress rule. Only a NodePort Service
+                                  can be referred by this field. Cannot be set with
+                                  any other selector.
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
                                 type: object
                               serviceAccount:
                                 description: Select all Pods with the ServiceAccount

--- a/multicluster/config/default/configmap/controller_manager_config.yaml
+++ b/multicluster/config/default/configmap/controller_manager_config.yaml
@@ -1,15 +1,12 @@
 apiVersion: multicluster.crd.antrea.io/v1alpha1
 kind: MultiClusterConfig
 health:
-  healthProbeBindAddress: :8081
+  healthProbeBindAddress: :8080
 metrics:
-  bindAddress: 127.0.0.1:8080
+  bindAddress: 0
 webhook:
   port: 9443
 leaderElection:
   leaderElect: false
-  resourceName: 6536456a.crd.antrea.io
-  leaseDuration: "30s"
-  renewDeadline: "20s"
 serviceCIDR: ""
 gatewayIPPrecedence: "private"

--- a/multicluster/config/manager/manager.yaml
+++ b/multicluster/config/manager/manager.yaml
@@ -31,13 +31,13 @@ spec:
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 8081
+            port: 8080
           initialDelaySeconds: 15
           periodSeconds: 20
         readinessProbe:
           httpGet:
             path: /readyz
-            port: 8081
+            port: 8080
           initialDelaySeconds: 5
           periodSeconds: 10
         resources:


### PR DESCRIPTION
1. Set the metrics binding address to 0 to disable it since we do not
provide metrics.
2. Change the health binding address port to 8080.
3. Remove unused configurations.

Signed-off-by: Lan Luo <luola@vmware.com>