### PR TITLE
Fix Windows AddNodePort parameter error

### DIFF
--- a/pkg/agent/config/node_config.go
+++ b/pkg/agent/config/node_config.go
@@ -51,7 +51,6 @@ var (
 	// - The IP is used as destination IP in host routing entry to forward replied SNATed Service packets back to Antrea
 	//   gateway.
 	// - The IP is used as the next hop of host routing entry for ClusterIP and virtual NodePort DNAT IP.
-	// - The IP is used for InternalIPAddress parameter of Add-NetNatStaticMapping on Windows.
 	//   The IP cannot be one used in the network, and cannot be within the 169.254.1.0 - 169.254.254.255 range
 	//   according to https://datatracker.ietf.org/doc/html/rfc3927#section-2.1
 	VirtualServiceIPv4 = net.ParseIP("169.254.0.253")

--- a/pkg/agent/route/route_windows.go
+++ b/pkg/agent/route/route_windows.go
@@ -387,7 +387,7 @@ func (c *Client) DeleteSNATRule(mark uint32) error {
 
 // TODO: nodePortAddresses is not supported currently.
 func (c *Client) AddNodePort(nodePortAddresses []net.IP, port uint16, protocol binding.Protocol) error {
-	return util.ReplaceNetNatStaticMapping(antreaNatNodePort, "0.0.0.0", port, config.VirtualServiceIPv4.String(), port, string(protocol))
+	return util.ReplaceNetNatStaticMapping(antreaNatNodePort, "0.0.0.0", port, config.VirtualNodePortDNATIPv4.String(), port, string(protocol))
 }
 
 func (c *Client) DeleteNodePort(nodePortAddresses []net.IP, port uint16, protocol binding.Protocol) error {


### PR DESCRIPTION
VirtualServiceIPv4 is the wrong parameter for AddNodePort.
It should be replaced by VirtualNodePortDNATIPv4 to match the
correct IP destination.

Signed-off-by: Shuyang Xin <gavinx@vmware.com>