### PR TITLE
Bugfix: socket is leak on IPv6 testbed

### DIFF
--- a/pkg/agent/util/ndp/ndp.go
+++ b/pkg/agent/util/ndp/ndp.go
@@ -31,6 +31,7 @@ func GratuitousNDPOverIface(srcIP net.IP, iface *net.Interface) error {
 	if err != nil {
 		return fmt.Errorf("failed to create NDP responder for %q: %s", iface.Name, err)
 	}
+	defer conn.Close()
 
 	na := &ndp.NeighborAdvertisement{
 		Override:      true,


### PR DESCRIPTION
Agent sends IPv6 Gratuitous NDP packet on each Pod to broadcast its
address. The socket is not closed after sending packet, which introduces
socket leak.

To resolve the issue, adding a defer function to close the socket after
writing the packet into the connection.

Fixes #4086 

Signed-off-by: wenyingd <wenyingd@vmware.com>