### PR TITLE
Support updating the antrea/base-windows image with Github Actions

### DIFF
--- a/.github/workflows/docker_update_base_windows.yml
+++ b/.github/workflows/docker_update_base_windows.yml
@@ -1,0 +1,46 @@
+# Anyone with write permissions to the antrea-io/antrea Github repository can
+# trigger this workflow manually, but please check with a maintainer first. The
+# workflow will build and push the antrea/base-windows image.
+name: Manually update antrea/base-windows Docker image
+
+on:
+  workflow_dispatch:
+    inputs:
+      antrea-repository:
+        description: 'The Antrea repository to check-out'
+        required: true
+        type: string
+      antrea-ref:
+        description: 'The Git ref to use when checking-out the Antrea repository'
+        required: true
+        type: string
+      push:
+        description: 'Whether to push built base images to the Docker registry'
+        required: false
+        default: true
+        type: boolean
+
+jobs:
+  build:
+    runs-on: windows-2019
+    steps:
+    - name: Check-out code
+      uses: actions/checkout@v3
+      with:
+        repository: ${{ github.event.inputs.antrea-repository }}
+        ref: ${{ github.event.inputs.antrea-ref }}
+    - name: Login to DockerHub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+    - name: Build and push Docker images
+      if: ${{ github.event.inputs.push == true }}
+      run: |
+        ./hack/build-antrea-windows-all.sh --pull --push-base-images
+      shell: bash
+    - name: Build Docker images without pushing
+      if: ${{ github.event.inputs.push == false }}
+      run: |
+        ./hack/build-antrea-windows-all.sh --pull
+      shell: bash

--- a/build/images/base-windows/Dockerfile
+++ b/build/images/base-windows/Dockerfile
@@ -43,7 +43,7 @@ RUN curl.exe -LO https://www.7-zip.org/a/7z2107-x64.exe; \
     mkdir C:\wins; \
     curl.exe -Lo C:/wins/wins.exe https://github.com/rancher/wins/releases/download/v0.0.4/wins.exe
 
-FROM golang:${GO_VERSION}-nanoserver as antrea-golang
+FROM golang:${GO_VERSION}-nanoserver as windows-golang
 
 FROM mcr.microsoft.com/windows/nanoserver:${NANOSERVER_VERSION}
 
@@ -58,6 +58,6 @@ COPY --from=windows-utility-base ["C:\\\\Program Files\\\\7-Zip","C:\\\\Program 
 COPY --from=windows-utility-base ["C:\\\\git","C:\\\\git"]
 COPY --from=windows-utility-base ["C:\\\\mingw64","C:\\\\mingw64"]
 COPY --from=windows-utility-base ["C:\\\\wins","C:\\\\wins"]
-COPY --from=antrea-golang ["C:\\\\Program Files\\\\Go", "C:\\\\Program Files\\\\Go"]
+COPY --from=windows-golang ["C:\\\\Program Files\\\\Go", "C:\\\\Program Files\\\\Go"]
 
 RUN setx /m PATH "C:\Program Files\7-Zip;C:\git\bin;C:\git\usr\bin;C:\mingw64\bin;C:\Program Files\Go\bin;%GOPATH\bin%;%PATH%"

--- a/build/images/base-windows/README.md
+++ b/build/images/base-windows/README.md
@@ -18,7 +18,8 @@ docker push antrea/base-windows:$WIN_BUILD_TAG
 The `docker push` command will fail if you do not have permission to push to the
 `antrea` Dockerhub repository.
 
-However, the easiest way topush a new image on Dockerhub is to run the `Manually
-update antrea/base-windows Docker image` Github workflow. Only contributors with
-`write` access to the antrea-io/antrea Github repository can trigger the
-workflow. If you need to update the image, please check with a maintainer first.
+However, the easiest way to push a new image on Dockerhub is to run the
+`Manually update antrea/base-windows Docker image` Github workflow. Only
+contributors with `write` access to the antrea-io/antrea Github repository can
+trigger the workflow. If you need to update the image, please check with a
+maintainer first.

--- a/build/images/base-windows/README.md
+++ b/build/images/base-windows/README.md
@@ -11,15 +11,14 @@ GO_VERSION=$(head -n 1 ../deps/go-version)
 CNI_BINARIES_VERSION=$(head -n 1 ../deps/cni-binaries-version)
 NANOSERVER_VERSION=$(head -n 1 ../deps/nanoserver-version)
 WIN_BUILD_TAG=$(echo $GO_VERSION $CNI_BINARIES_VERSION $NANOSERVER_VERSION| md5sum| head -c 10)
-docker build -t antrea/base-windows:$WIN_BUILD_TAG --network host --build-arg GO_VERSION=$GO_VERSION --build-arg CNI_BINARIES_VERSION=$CNI_BINARIES_VERSION --build-arg NANOSERVER_VERSION=$NANOSERVER_VERSION .
+docker build -t antrea/base-windows:$WIN_BUILD_TAG --build-arg GO_VERSION=$GO_VERSION --build-arg CNI_BINARIES_VERSION=$CNI_BINARIES_VERSION --build-arg NANOSERVER_VERSION=$NANOSERVER_VERSION .
 docker push antrea/base-windows:$WIN_BUILD_TAG
 ```
 
 The `docker push` command will fail if you do not have permission to push to the
 `antrea` Dockerhub repository.
 
-Here is the table of codegen images that have been uploaded:
-
-| Tag                              | Change                                  |
-| :-----------------------------   | --------------------------------------- |
-| a43c77d755                       | The first image based on nanoserver-1809 |
+However, the easiest way topush a new image on Dockerhub is to run the `Manually
+update antrea/base-windows Docker image` Github workflow. Only contributors with
+`write` access to the antrea-io/antrea Github repository can trigger the
+workflow. If you need to update the image, please check with a maintainer first.

--- a/hack/build-antrea-windows-all.sh
+++ b/hack/build-antrea-windows-all.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 Antrea Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script must be run on a Windows machine and requires a Bash shell to be
+# available, e.g., Git Bash (https://gitforwindows.org/).
+
+set -eo pipefail
+
+function echoerr {
+    >&2 echo "$@"
+}
+
+_usage="Usage: $0 [--pull] [--push-base-images]
+Build the antrea/antrea-windows image, as well as all the base images in the build chain. This is
+typically used in CI to build the image with the latest version of all dependencies, taking into
+account changes to all Dockerfiles.
+        --pull                  Always attempt to pull a newer version of the base images.
+        --push-base-images      Push built images to the registry. Only base images will be pushed.
+This script must run on a Windows machine!"
+
+function print_usage {
+    echoerr "$_usage"
+}
+
+PULL=false
+PUSH=false
+
+while [[ $# -gt 0 ]]
+do
+key="$1"
+
+case $key in
+    --pull)
+    PULL=true
+    shift
+    ;;
+    --push-base-images)
+    PUSH=true
+    shift
+    ;;
+    -h|--help)
+    print_usage
+    exit 0
+    ;;
+    *)    # unknown option
+    echoerr "Unknown option $1"
+    exit 1
+    ;;
+esac
+done
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+pushd "$THIS_DIR/.." > /dev/null
+
+NANOSERVER_VERSION=$(head -n 1 build/images/deps/nanoserver-version)
+CNI_BINARIES_VERSION=$(head -n 1 build/images/deps/cni-binaries-version)
+GO_VERSION=$(head -n 1 build/images/deps/go-version)
+WIN_BUILD_TAG=$(echo $GO_VERSION $CNI_BINARIES_VERSION $NANOSERVER_VERSION| md5sum| head -c 10)
+
+echo "WIN_BUILD_TAG=$WIN_BUILD_TAG"
+
+if $PULL; then
+    docker pull mcr.microsoft.com/windows/servercore:$NANOSERVER_VERSION
+    docker pull golang:$GO_VERSION-nanoserver
+    docker pull mcr.microsoft.com/windows/nanoserver:$NANOSERVER_VERSION
+    docker pull mcr.microsoft.com/powershell:lts-nanoserver-$NANOSERVER_VERSION
+    docker pull antrea/windows-utility-base:$WIN_BUILD_TAG || true
+    docker pull antrea/windows-golang:$WIN_BUILD_TAG || true
+    docker pull antrea/base-windows:$WIN_BUILD_TAG || true
+fi
+
+cd build/images/base-windows
+docker build --target windows-utility-base \
+       --cache-from antrea/windows-utility-base:$WIN_BUILD_TAG \
+       -t antrea/windows-utility-base:$WIN_BUILD_TAG \
+       --build-arg CNI_BINARIES_VERSION=$CNI_BINARIES_VERSION \
+       --build-arg NANOSERVER_VERSION=$NANOSERVER_VERSION .
+docker build --target windows-golang \
+       --cache-from antrea/windows-golang:$WIN_BUILD_TAG \
+       --build-arg GO_VERSION=$GO_VERSION \
+       --build-arg NANOSERVER_VERSION=$NANOSERVER_VERSION .
+docker build \
+       --cache-from antrea/windows-utility-base:$WIN_BUILD_TAG \
+       --cache-from antrea/windows-golang:$WIN_BUILD_TAG \
+       --cache-from antrea/base-windows:$WIN_BUILD_TAG \
+       -t antrea/base-windows:$WIN_BUILD_TAG \
+       --build-arg GO_VERSION=$GO_VERSION \
+       --build-arg NANOSERVER_VERSION=$NANOSERVER_VERSION .
+cd -
+
+if $PUSH; then
+    docker push antrea/windows-utility-base:$WIN_BUILD_TAG
+    docker push antrea/windows-golang:$WIN_BUILD_TAG
+    docker push antrea/base-windows:$WIN_BUILD_TAG
+fi
+
+export NO_PULL=1
+
+make build-windows
+
+popd > /dev/null


### PR DESCRIPTION
At the moment, updating this image is a very manual process and requires
access to a Windows machine. To simplify this process, we add a new
Github Workflow which can be used to manually trigger a Docker image
build and push on Github hosted Windows workers.

Ideally, the workflow would not need to be triggered manually and would
run as part of CI (like we do for Linux base images). However this is a
good compromise / first step. Even with Docker caching, running
./hack/build-antrea-windows-all.sh for every pull request and push event
may be a bit too expensive. Something that can be investigated later.

Signed-off-by: Antonin Bas <abas@vmware.com>