### PR TITLE
[ExternalNode] Fix Agent log issue

### DIFF
--- a/pkg/agent/config/traffic_encap_mode.go
+++ b/pkg/agent/config/traffic_encap_mode.go
@@ -59,6 +59,9 @@ func GetTrafficEncapModes() []TrafficEncapModeType {
 
 // String returns value in string.
 func (m TrafficEncapModeType) String() string {
+	if m == TrafficEncapModeInvalid {
+		return "invalid"
+	}
 	return modeStrs[m]
 }
 

--- a/pkg/agent/config/traffic_encap_mode_test.go
+++ b/pkg/agent/config/traffic_encap_mode_test.go
@@ -58,6 +58,7 @@ func TestTrafficEncapModeTypeString(t *testing.T) {
 		{"no-encap-mode", 1, "noEncap"},
 		{"hybrid-mode", 2, "hybrid"},
 		{"policy-only-mode-valid", 3, "networkPolicyOnly"},
+		{"invalid-str", -1, "invalid"},
 	}
 
 	for _, tt := range tests {

--- a/pkg/agent/config/traffic_encryption_mode.go
+++ b/pkg/agent/config/traffic_encryption_mode.go
@@ -56,5 +56,8 @@ func GetTrafficEncryptionModes() []TrafficEncryptionModeType {
 
 // String returns value in string.
 func (m TrafficEncryptionModeType) String() string {
+	if m == TrafficEncryptionModeInvalid {
+		return "invalid"
+	}
 	return encryptionModeStrs[m]
 }

--- a/pkg/agent/config/traffic_encryption_mode_test.go
+++ b/pkg/agent/config/traffic_encryption_mode_test.go
@@ -57,6 +57,7 @@ func TestTrafficEncryptionModeType_String(t *testing.T) {
 		{"None", TrafficEncryptionModeNone, "None"},
 		{"IPsec", TrafficEncryptionModeIPSec, "IPsec"},
 		{"WireGuard", TrafficEncryptionModeWireGuard, "WireGuard"},
+		{"Invalid string", TrafficEncryptionModeInvalid, "invalid"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Antrea Agent uses TrafficEncryptionModeInvalid in networkConfig. It may
introduce a panic when calling TrafficEncapModeInvalid.String(), since
its string value is not defined in the string slice for the supported
TrafficEncryptionModeInvalid, and its value is -1 which is not a valid
index in any slice.

To resolve the issue, a constant string is returned when
TrafficEncapModeInvalid is used.

The same issue may exist on type TrafficEncapModeInvalid in the logging.
As a result, a default string value is given to TrafficEncapModeInvalid
too.

Fixes #4095 

Signed-off-by: wenyingd <wenyingd@vmware.com>