### PR TITLE
Install script for configuring antrea-agent on VM

### DIFF
--- a/hack/externalnode/install-vm.ps1
+++ b/hack/externalnode/install-vm.ps1
@@ -1,0 +1,207 @@
+<#
+  .SYNOPSIS
+  Installs Antrea-Agent service.
+
+  .PARAMETER Namespace
+  ExternalNode Namespace to be used.
+
+  .PARAMETER BinaryPath
+  Specifies the path of the antrea-agent binary to be used.
+
+  .PARAMETER ConfigPath
+  Specifies the path of the antrea-agent configuration file to be used.
+
+  .PARAMETER KubeConfigPath
+  Specifies the path of the kubeconfig to access K8s API Server.
+
+  .PARAMETER AntreaKubeConfigPath
+  Specifies the path of the kubeconfig to access Antrea API Server.
+
+  .PARAMETER InstallDir
+  The target installation directory. The default path is "C:\antrea-agent".
+#>
+Param(
+    [parameter(Mandatory = $true)] [string] $Namespace,
+    [parameter(Mandatory = $true)] [string] $BinaryPath,
+    [parameter(Mandatory = $true)] [string] $ConfigPath,
+    [parameter(Mandatory = $true)] [string] $KubeConfigPath,
+    [parameter(Mandatory = $true)] [string] $AntreaKubeConfigPath,
+    [parameter(Mandatory = $false)] [string] $NodeName = $(hostname),
+    [parameter(Mandatory = $false)] [string] $InstallDir = "C:\antrea-agent"
+)
+
+$ErrorActionPreference = "Stop"
+
+$WorkDir = [System.IO.Path]::GetDirectoryName($myInvocation.MyCommand.Definition)
+$InstallLog = "$WorkDir\install_vm.log"
+
+# Antrea paths
+$AntreaAgentPath = [io.path]::combine($InstallDir, "antrea-agent.exe")
+$AntreaAgentConfDir = [io.path]::combine($InstallDir, "conf")
+$AntreaAgentLogDir = [io.path]::combine($InstallDir, "logs")
+$AntreaAgentConfPath = [io.path]::combine($AntreaAgentConfDir, "antrea-agent.conf")
+$AntreaAgentLogFile = [io.path]::combine($AntreaAgentLogDir, "antrea-agent.log")
+
+# Constants
+$K8sKubeconfig = "antrea-agent.kubeconfig"
+$AntreaKubeconfig = "antrea-agent.antrea.kubeconfig"
+$OVSServices = "ovsdb-server", "ovs-vswitchd"
+$AntreaAgent = "antrea-agent"
+$Kubeconfig = "kubeconfig"
+$ExternalNodeNamespace = "externalNodeNamespace"
+
+# List of supported OS versions, verified by antrea
+# Versions are named like Major.Minor.Build
+$SupportedVersions = @("10.0.17763")
+
+function Log($Info) {
+    $time = $(get-date -Format g)
+    "$time $Info " | Tee-Object $InstallLog -Append | Write-Host
+}
+
+function ServiceExists($ServiceName) {
+    If (Get-Service $ServiceName -ErrorAction SilentlyContinue) {
+        return $true
+    }
+    return $false
+}
+
+function CheckSupportedVersions() {
+    echo "Checking supported Windows OS versions"
+    $OSVersion = [System.Environment]::OSVersion.Version
+    $Version = $OSVersion.Major.ToString() + "." + $OSVersion.Minor.ToString() + "." + $OSVersion.Build.ToString()
+    foreach ($v in $SupportedVersions) {
+        if ($v -eq $Version) {
+            return
+        }
+    }
+    Log "Error only Windows $SupportedVersions is supported"
+    exit 1
+}
+
+function PrintPrerequisites()
+{
+    echo "Please execute these commands to enable Hyper-V"
+    echo "Install-WindowsFeature Hyper-V-Powershell"
+    echo "Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V -All -NoRestart"
+    exit 1
+}
+
+function CheckPrerequisites()
+{
+    CheckSupportedVersions
+    $valid = $true
+    Log "Check Hyper-v feature is enabled"
+    if ((Get-WindowsOptionalFeature -FeatureName "Microsoft-Hyper-V" -Online).State -eq "Disabled") {
+        Log "Windows optional feature Microsoft-Hyper-V is disabled"
+        $valid = $false
+    }
+
+    if ((Get-WindowsFeature -Name "Hyper-V-Powershell").InstallState -ne "Installed") {
+        Log "Windows feature Hyper-V-Powershell is not installed"
+        $valid = $false
+    }
+
+    if ($valid -eq $false) {
+        PrintPrerequisites
+    }
+
+    Log "Check OVS services are installed"
+    foreach ($daemon in $OVSServices) {
+        If (-Not (ServiceExists($daemon))) {
+            Log "Service $daemon does not exist."
+            exit 1
+        }
+    }
+}
+
+function SetupInstallDir() {
+    Log "Create install directories"
+    if (-Not (Test-Path $AntreaAgentConfDir)) {
+        New-Item $AntreaAgentConfDir -type directory -Force | Out-Null
+    }
+
+    if (-Not (Test-Path $AntreaAgentLogDir)) {
+        New-Item $AntreaAgentLogDir -type directory -Force | Out-Null
+    }
+}
+
+function CopyAntreaAgentFiles() {
+    if ( -Not (Test-Path $BinaryPath)) {
+        Log "$BinaryPath file not found"
+        exit 1
+    }
+    Log "Copying $BinaryPath to $InstallDir"
+    Copy-Item -Path "$BinaryPath" -Destination $InstallDir -Force |  Out-Null
+
+    if ( -Not (Test-Path $KubeConfigPath)) {
+        Log "$KubeConfigPath file not found"
+        exit 1
+    }
+    Log "Copying $KubeConfigPath to $AntreaAgentConfDir"
+    Copy-Item -Path "$KubeConfigPath" -Destination "$AntreaAgentConfDir\$K8sKubeconfig" -Force
+
+    if ( -Not (Test-Path $AntreaKubeConfigPath)) {
+        Log "$AntreaKubeConfigPath file not found"
+        exit 1
+    }
+    Log "Copying $AntreaKubeConfigPath to $AntreaAgentConfDir"
+    Copy-Item -Path "$AntreaKubeConfigPath" -Destination "$AntreaAgentConfDir\$AntreaKubeconfig" -Force
+}
+
+function UpdateAgentConf() {
+    if ( -Not (Test-Path $ConfigPath)) {
+        Log "$ConfigPath file not found"
+        exit 1
+    }
+    New-Item $AntreaAgentConfPath -type file -Force | Out-Null
+    $file = Get-Content $ConfigPath
+    foreach ($line in $file) {
+        if ($line -like "*$Kubeconfig") {
+            $key, $val = $line.split(":", 2).trim()
+            $newval = "${AntreaAgentConfDir}\${val}"
+            Log "Updating $AntreaAgentConfPath with ${key}: ${newval}"
+            [System.IO.File]::AppendAllText($AntreaAgentConfPath, "  ${key}: ${newval}" +
+                    ([Environment]::NewLine))
+        } elseif ($line -like "*$ExternalNodeNamespace*") {
+            Log "Updating $AntreaAgentConfPath with ${ExternalNodeNamespace}: ${Namespace}"
+            [System.IO.File]::AppendAllText($AntreaAgentConfPath, "  ${ExternalNodeNamespace}: ${Namespace}" +
+                    ([Environment]::NewLine))
+        } else {
+            [System.IO.File]::AppendAllText($AntreaAgentConfPath, $line +
+                    ([Environment]::NewLine))
+        }
+    }
+}
+
+function ConfigureAntreaAgentService() {
+    # Set environment variables
+    [Environment]::SetEnvironmentVariable("NODE_NAME", $NodeName, [System.EnvironmentVariableTarget]::Machine)
+    # Assume nssm is installed and configure service
+    $AntreaAgentArgs = "--config $AntreaAgentConfPath --log_file $AntreaAgentLogFile --logtostderr=false"
+    log "Creating service $AntreaAgent $AntreaAgentPath $AntreaAgentArgs"
+    try {
+        # Configured to auto-restart upon reboot
+        & nssm install $AntreaAgent $AntreaAgentPath $AntreaAgentArgs
+    } catch {
+        log "Failed to create service for $AntreaAgent, rc $_"
+        exit 1
+    }
+}
+
+function StartAntreaAgentService()
+{
+    try {
+        & nssm start $AntreaAgent
+    } catch {
+        log "Failed to start service for $AntreaAgent, rc $_"
+        exit 1
+    }
+}
+
+CheckPrerequisites
+SetupInstallDir
+CopyAntreaAgentFiles
+UpdateAgentConf
+ConfigureAntreaAgentService
+StartAntreaAgentService

--- a/hack/externalnode/install-vm.sh
+++ b/hack/externalnode/install-vm.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 Antrea Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+function echoerr {
+    >&2 echo "$@"
+}
+
+_usage="Usage: $0 [--ns <Namespace>] [--bin <AntreaAgentSavePath>] [--config <AgentConfigSavePath>] [--kubeconfig <KubeconfigSavePath>] [--antrea-kubeconfig <AntreaKubeconfigSavePath>] [--nodename <ExternalNodeName>] [--help|-h]
+        --ns                          Namespace to be used by the antrea-agent.
+        --bin                         Path of the antrea-agent binary
+        --config                      Path of the antrea-agent configuration file
+        --kubeconfig                  Path of the kubeconfig to access K8s API Server
+        --antrea-kubeconfig           Path of the kubeconfig to access Antrea API Server
+        --nodename                    ExternalNode name to be used by the antrea-agent
+        --help, -h                    Print this message and exit
+
+Please run the script as sudo user"
+
+function print_usage {
+    echoerr "$_usage"
+}
+
+function print_help {
+    echoerr "Try '$0 --help' for more information."
+}
+
+INSTALL_PATH="/usr/sbin"
+AGENT_BIN_PATH=""
+CONFIG_PATH=""
+KUBECONFIG=""
+ANTREAKUBECONFIG=""
+AGENT_NAMESPACE=""
+NODE_NAME="$(hostname)"
+AGENT_LOG_DIR="/var/log/antrea"
+AGENT_CONF_PATH="/etc/antrea"
+# List of supported OS versions, verified by antrea.
+declare -a SUPPORTED_OS=("Ubuntu 18.04", "Ubuntu 20.04")
+
+check_supported_platform() {
+  echo "Checking supported OS platform"
+  dist_version="$(lsb_release -is) $(lsb_release -rs)"
+  for ver in "${SUPPORTED_OS[@]}"; do
+    if [ "$ver" == "$dist_version" ]; then
+      return
+    fi
+  done
+  echoerr "Error ${SUPPORTED_OS[*]} are supported"
+  exit 1
+}
+
+copy_antrea_agent_files() {
+    if [[ ! -f "$CONFIG_PATH" ]]; then
+      echoerr "Error $CONFIG_PATH file not found"
+      exit 1
+    fi
+    mkdir -p $AGENT_CONF_PATH
+    echo "Copying $CONFIG_PATH to $AGENT_CONF_PATH"
+    cp $CONFIG_PATH $AGENT_CONF_PATH
+
+    if [[ ! -f "$KUBECONFIG" ]]; then
+      echoerr "Error $KUBECONFIG file not found"
+      exit 1
+    fi
+
+    echo "Copying $KUBECONFIG to $AGENT_CONF_PATH"
+    cp "$KUBECONFIG" "${AGENT_CONF_PATH}/antrea-agent.kubeconfig"
+    chmod 600 "${AGENT_CONF_PATH}/antrea-agent.kubeconfig"
+
+    if [[ ! -f "$ANTREA_KUBECONFIG" ]]; then
+      echoerr "Error $ANTREA_KUBECONFIG file not found"
+      exit 1
+    fi
+    echo "Copying $ANTREA_KUBECONFIG to $AGENT_CONF_PATH"
+    cp "$ANTREA_KUBECONFIG" "${AGENT_CONF_PATH}/antrea-agent.antrea.kubeconfig"
+    chmod 600 "${AGENT_CONF_PATH}/antrea-agent.antrea.kubeconfig"
+}
+
+update_antrea_agent_conf() {
+  echo "Updating clientConnection and antreaClientConnection"
+  sed -i "s|kubeconfig: |kubeconfig: $AGENT_CONF_PATH/|g" $AGENT_CONF_PATH/antrea-agent.conf
+  echo "Updating externalNodeNamespace to $AGENT_NAMESPACE"
+  sed -i "s|#externalNodeNamespace: default|externalNodeNamespace: $AGENT_NAMESPACE|g" $AGENT_CONF_PATH/antrea-agent.conf
+}
+
+start_antrea_agent_service() {
+    if [[ ! -f "$AGENT_BIN_PATH" ]]; then
+      echoerr "Error $AGENT_BIN_PATH file not found"
+      exit 1
+    fi
+    mkdir -p $AGENT_LOG_DIR
+    mkdir -p $INSTALL_PATH
+    cp "$AGENT_BIN_PATH" "$INSTALL_PATH"
+    cat >/etc/systemd/system/antrea-agent.service << EOF
+[Unit]
+Description="antrea-agent as a systemd service"
+After=network.target
+[Service]
+Environment="NODE_NAME=$NODE_NAME"
+ExecStart=$INSTALL_PATH/antrea-agent \
+--config=$AGENT_CONF_PATH/antrea-agent.conf \
+--logtostderr=false \
+--log_file=$AGENT_LOG_DIR/antrea-agent.log
+Restart=on-failure
+[Install]
+WantedBy=multi-user.target
+EOF
+    systemctl daemon-reload
+    systemctl enable antrea-agent
+    echo "Starting antrea-agent service"
+    systemctl start antrea-agent
+    systemctl status antrea-agent
+}
+
+validate_argument() {
+    if [[ $2 == --* || -z $2 ]]; then
+        echoerr "Error invalid argument for $1: <$2>"
+        print_usage
+        exit 1
+    fi
+}
+
+while [[ $# -gt 0 ]]
+do
+key="$1"
+case $key in
+    --ns)
+    AGENT_NAMESPACE="$2"
+    validate_argument $1 $2
+    shift 2
+    ;;
+    --bin)
+    AGENT_BIN_PATH="$2"
+    validate_argument $1 $2
+    shift 2
+    ;;
+    --config)
+    CONFIG_PATH="$2"
+    validate_argument $1 $2
+    shift 2
+    ;;
+    --kubeconfig)
+    KUBECONFIG="$2"
+    validate_argument $1 $2
+    shift 2
+    ;;
+    --antrea-kubeconfig)
+    ANTREA_KUBECONFIG="$2"
+    validate_argument $1 $2
+    shift 2
+    ;;
+    --nodename)
+    NODE_NAME="$2"
+    validate_argument $1, $2
+    shift 2
+    ;;
+    -h|--help)
+    print_usage
+    exit 0
+    ;;
+    *)    # unknown option
+    echoerr "Unknown option $1"
+    exit 1
+    ;;
+esac
+done
+
+check_supported_platform
+copy_antrea_agent_files
+update_antrea_agent_conf
+start_antrea_agent_service


### PR DESCRIPTION
- Provides install script for both Windows and Linux
- Expects the user to copy the antrea-agent binary, antrea-agent.conf,
antrea-agent.kubeconfig and antrea-agent.antrea.kubeconfig files to the
VM.
- Update the documentation

Linux usage:
./install-vm.sh --ns vm-ns --bin /tmp/antrea-agent --config /tmp/antrea-agent.conf --kubeconfig /tmp/my.kubeconfig --antrea-kubeconfig /tmp/my.antrea.kubeconfig

Windows usage:
.\Install-vm.ps1 -NameSpace vm-ns -BinaryPath C:\temp\antrea-agent.conf -ConfigPath C:\temp\antrea-agent.conf -KubeConfigPath C:\temp\my.kubeconfig -AntreaKubeConfigPath C:\temp\my.antrea.kubeconfig

Signed-off-by: kumaranand <kumaranand@vmware.com>