### PR TITLE
Fix the port type in the config

### DIFF
--- a/multicluster/build/yamls/antrea-multicluster-leader-namespaced.yml
+++ b/multicluster/build/yamls/antrea-multicluster-leader-namespaced.yml
@@ -316,7 +316,7 @@ data:
     health:
       healthProbeBindAddress: :8080
     metrics:
-      bindAddress: 0
+      bindAddress: "0"
     webhook:
       port: 9443
     leaderElection:
@@ -327,7 +327,7 @@ kind: ConfigMap
 metadata:
   labels:
     app: antrea
-  name: antrea-mc-controller-config-hbdmg9b87m
+  name: antrea-mc-controller-config-6b7ccgh6k9
   namespace: antrea-multicluster
 ---
 apiVersion: v1
@@ -409,7 +409,7 @@ spec:
       terminationGracePeriodSeconds: 10
       volumes:
       - configMap:
-          name: antrea-mc-controller-config-hbdmg9b87m
+          name: antrea-mc-controller-config-6b7ccgh6k9
         name: antrea-mc-controller-config
 ---
 apiVersion: admissionregistration.k8s.io/v1

--- a/multicluster/build/yamls/antrea-multicluster-member.yml
+++ b/multicluster/build/yamls/antrea-multicluster-member.yml
@@ -940,7 +940,7 @@ data:
     health:
       healthProbeBindAddress: :8080
     metrics:
-      bindAddress: 0
+      bindAddress: "0"
     webhook:
       port: 9443
     leaderElection:
@@ -951,7 +951,7 @@ kind: ConfigMap
 metadata:
   labels:
     app: antrea
-  name: antrea-mc-controller-config-hbdmg9b87m
+  name: antrea-mc-controller-config-6b7ccgh6k9
   namespace: kube-system
 ---
 apiVersion: v1
@@ -1033,7 +1033,7 @@ spec:
       terminationGracePeriodSeconds: 10
       volumes:
       - configMap:
-          name: antrea-mc-controller-config-hbdmg9b87m
+          name: antrea-mc-controller-config-6b7ccgh6k9
         name: antrea-mc-controller-config
 ---
 apiVersion: admissionregistration.k8s.io/v1

--- a/multicluster/config/default/configmap/controller_manager_config.yaml
+++ b/multicluster/config/default/configmap/controller_manager_config.yaml
@@ -3,7 +3,7 @@ kind: MultiClusterConfig
 health:
   healthProbeBindAddress: :8080
 metrics:
-  bindAddress: 0
+  bindAddress: "0"
 webhook:
   port: 9443
 leaderElection:


### PR DESCRIPTION
The type should be string instead of int.
When it's `0`, controller will fail to start due to below error:

```
Failed to load options" err="could not decode file into runtime.Object"
```

Signed-off-by: Lan Luo <luola@vmware.com>