### PR TITLE
Use config file to start controller with coverage

### DIFF
--- a/multicluster/config/overlays/leader-ns/coverage/manager_command_patch_coverage.yaml
+++ b/multicluster/config/overlays/leader-ns/coverage/manager_command_patch_coverage.yaml
@@ -8,6 +8,6 @@ spec:
     spec:
       containers:
         - command: ["/bin/sh"]
-          args: ["-c", "/antrea-mc-controller-coverage -test.run=TestBincoverRunMain -test.coverprofile=antrea-mc-controller.cov.out leader; while true; do sleep 5 & wait $!; done"]
+          args: ["-c", "/antrea-mc-controller-coverage -test.run=TestBincoverRunMain -test.coverprofile=antrea-mc-controller.cov.out leader --config=/controller_manager_config.yaml; while true; do sleep 5 & wait $!; done"]
           name: antrea-mc-controller
           image: projects.registry.vmware.com/antrea/antrea-mc-controller-coverage:latest

--- a/multicluster/config/overlays/member/coverage/manager_command_patch_coverage.yaml
+++ b/multicluster/config/overlays/member/coverage/manager_command_patch_coverage.yaml
@@ -8,6 +8,6 @@ spec:
     spec:
       containers:
         - command: ["/bin/sh"]
-          args: ["-c", "/antrea-mc-controller-coverage -test.run=TestBincoverRunMain -test.coverprofile=antrea-mc-controller.cov.out member; while true; do sleep 5 & wait $!; done"]
+          args: ["-c", "/antrea-mc-controller-coverage -test.run=TestBincoverRunMain -test.coverprofile=antrea-mc-controller.cov.out member --config=/controller_manager_config.yaml; while true; do sleep 5 & wait $!; done"]
           name: antrea-mc-controller
           image: projects.registry.vmware.com/antrea/antrea-mc-controller-coverage:latest


### PR DESCRIPTION
Use a config file to run multi-cluster e2e tests with coverage. Without
the config file, the multi-cluster controller will use the default
configuration which means we can't verify config file related changes by
e2e since multi-cluster e2e enabled coverage and used in-flight
generated manifests.

Signed-off-by: Lan Luo <luola@vmware.com>