### PR TITLE
[CI] Skip SCTPConnectivity test on AKS

### DIFF
--- a/ci/test-conformance-aks.sh
+++ b/ci/test-conformance-aks.sh
@@ -251,7 +251,7 @@ function run_conformance() {
     ${GIT_CHECKOUT_DIR}/ci/run-k8s-e2e-tests.sh --e2e-conformance --e2e-skip ${skip_regex} \
       --kube-conformance-image-version ${KUBE_CONFORMANCE_IMAGE_VERSION} \
       --log-mode ${MODE} > ${GIT_CHECKOUT_DIR}/aks-test.log && \
-    ${GIT_CHECKOUT_DIR}/ci/run-k8s-e2e-tests.sh --e2e-network-policy --e2e-skip "Netpol" \
+    ${GIT_CHECKOUT_DIR}/ci/run-k8s-e2e-tests.sh --e2e-network-policy --e2e-skip "\[Feature:SCTPConnectivity\]|Netpol" \
       --kube-conformance-image-version ${KUBE_CONFORMANCE_IMAGE_VERSION} \
       --log-mode ${MODE} >> ${GIT_CHECKOUT_DIR}/aks-test.log || \
     TEST_SCRIPT_RC=$?


### PR DESCRIPTION
As AKS Nodes don't support SCTP protocol.

Fixes #4132

Signed-off-by: Quan Tian <qtian@vmware.com>