### PR TITLE
Fix image tag for Antrea and FlowAggregator Helm charts

### DIFF
--- a/build/charts/antrea/templates/_helpers.tpl
+++ b/build/charts/antrea/templates/_helpers.tpl
@@ -7,3 +7,17 @@
   {{ printf "#  %s" $name }}: {{ $default }}
 {{- end }}
 {{- end -}}
+
+{{- define "antreaImageTag" -}}
+{{- if .Values.image.tag }}
+{{- .Values.image.tag -}}
+{{- else if eq .Chart.AppVersion "latest" }}
+{{- print "latest" -}}
+{{- else }}
+{{- print "v" .Chart.AppVersion -}}
+{{- end }}
+{{- end -}}
+
+{{- define "antreaImage" -}}
+{{- print .Values.image.repository ":" (include "antreaImageTag" .) -}}
+{{- end -}}

--- a/build/charts/antrea/templates/agent/daemonset.yaml
+++ b/build/charts/antrea/templates/agent/daemonset.yaml
@@ -67,7 +67,7 @@ spec:
       initContainers:
         {{- if .Values.whereabouts.enable }}
         - name: install-whereabouts-config
-          image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
+          image: {{ include "antreaImage" . | quote }}
           resources:
             requests:
               cpu: "100m"
@@ -82,7 +82,7 @@ spec:
       containers:
       {{- end }}
         - name: install-cni
-          image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
+          image: {{ include "antreaImage" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           resources: {{- .Values.agent.installCNI.resources | toYaml | nindent 12 }}
           {{- if eq .Values.trafficEncapMode "networkPolicyOnly" }}
@@ -121,7 +121,7 @@ spec:
       containers:
       {{- end }}
         - name: antrea-agent
-          image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
+          image: {{ include "antreaImage" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if ((.Values.testing).coverage) }}
           command: ["/bin/sh"]
@@ -248,7 +248,7 @@ spec:
           {{- toYaml . | trim | nindent 10 }}
           {{- end }}
         - name: antrea-ovs
-          image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
+          image: {{ include "antreaImage" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           resources: {{- .Values.agent.antreaOVS.resources | toYaml | nindent 12 }}
           command: ["start_ovs"]
@@ -290,7 +290,7 @@ spec:
             subPath: openvswitch
         {{- if eq .Values.trafficEncryptionMode "ipsec" }}
         - name: antrea-ipsec
-          image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
+          image: {{ include "antreaImage" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           resources: {{- .Values.agent.antreaIPsec.resources | toYaml | nindent 12 }}
           command: ["start_ovs_ipsec"]

--- a/build/charts/antrea/templates/controller/deployment.yaml
+++ b/build/charts/antrea/templates/controller/deployment.yaml
@@ -60,7 +60,7 @@ spec:
       serviceAccountName: antrea-controller
       containers:
         - name: antrea-controller
-          image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
+          image: {{ include "antreaImage" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           resources: {{- .Values.controller.antreaController.resources | toYaml | nindent 12 }}
           {{- if ((.Values.testing).coverage) }}

--- a/build/charts/flow-aggregator/templates/_helpers.tpl
+++ b/build/charts/flow-aggregator/templates/_helpers.tpl
@@ -1,0 +1,13 @@
+{{- define "flowAggregatorImageTag" -}}
+{{- if .Values.image.tag }}
+{{- .Values.image.tag -}}
+{{- else if eq .Chart.AppVersion "latest" }}
+{{- print "latest" -}}
+{{- else }}
+{{- print "v" .Chart.AppVersion -}}
+{{- end }}
+{{- end -}}
+
+{{- define "flowAggregatorImage" -}}
+{{- print .Values.image.repository ":" (include "flowAggregatorImageTag" .) -}}
+{{- end -}}

--- a/build/charts/flow-aggregator/templates/deployment.yaml
+++ b/build/charts/flow-aggregator/templates/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: flow-aggregator
-        image: {{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}
+        image: {{ include "flowAggregatorImage" . | quote }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- if .Values.testing.coverage }}
         command: [ "/bin/sh" ]


### PR DESCRIPTION
When installing a released version of a chart (for Antrea or the
FlowAggregator), the image tag was not generated correctly. It was
missing the leading "v".

I tested this change by changing the value of `appVersion` in
`Chart.yaml` to 1.8.0, and I made sure that the following images
were used:
- `projects.registry.vmware.com/antrea/antrea-ubuntu:v1.8.0`
- `projects.registry.vmware.com/antrea/flow-aggregator:v1.8.0`

Fixes #4137

Signed-off-by: Antonin Bas <abas@vmware.com>