### PR TITLE
kind: fix antrea-ubuntu image in build/yamls

### DIFF
--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -4014,7 +4014,7 @@ spec:
       serviceAccountName: antrea-agent
       initContainers:
         - name: install-cni
-          image: "projects.registry.vmware.com/antrea/antrea-ubuntu:latest"
+          image: "antrea/antrea-ubuntu:latest"
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -4048,7 +4048,7 @@ spec:
             mountPath: /var/run/antrea
       containers:
         - name: antrea-agent
-          image: "projects.registry.vmware.com/antrea/antrea-ubuntu:latest"
+          image: "antrea/antrea-ubuntu:latest"
           imagePullPolicy: IfNotPresent
           command: ["antrea-agent"]
           # Log to both "/var/log/antrea/" and stderr (so "kubectl logs" can work).-
@@ -4140,7 +4140,7 @@ spec:
           - name: xtables-lock
             mountPath: /run/xtables.lock
         - name: antrea-ovs
-          image: "projects.registry.vmware.com/antrea/antrea-ubuntu:latest"
+          image: "antrea/antrea-ubuntu:latest"
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -4253,7 +4253,7 @@ spec:
       serviceAccountName: antrea-controller
       containers:
         - name: antrea-controller
-          image: "projects.registry.vmware.com/antrea/antrea-ubuntu:latest"
+          image: "antrea/antrea-ubuntu:latest"
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/docs/kind.md
+++ b/docs/kind.md
@@ -58,8 +58,8 @@ If you want to pre-load the Antrea image in each Node (to avoid having each Node
 pull from the registry), you can use:
 
 ```bash
-docker pull projects.registry.vmware.com/antrea/antrea-ubuntu:<TAG>
-./ci/kind/kind-setup.sh --images projects.registry.vmware.com/antrea/antrea-ubuntu:<TAG> create <CLUSTER_NAME>
+docker pull antrea/antrea-ubuntu:<TAG>
+./ci/kind/kind-setup.sh --images antrea/antrea-ubuntu:<TAG> create <CLUSTER_NAME>
 kubectl apply -f https://github.com/antrea-io/antrea/releases/download/<TAG>/antrea.yml
 ```
 
@@ -118,9 +118,9 @@ kind create cluster --config kind-config.yml
 
 ```bash
 # pull the Antrea Docker image
-docker pull projects.registry.vmware.com/antrea/antrea-ubuntu:<TAG>
+docker pull antrea/antrea-ubuntu:<TAG>
 # load the Antrea Docker image in the Nodes
-kind load docker-image projects.registry.vmware.com/antrea/antrea-ubuntu:<TAG>
+kind load docker-image antrea/antrea-ubuntu:<TAG>
 # deploy Antrea
 kubectl apply -f https://github.com/antrea-io/antrea/releases/download/<TAG>/antrea.yml
 ```
@@ -132,7 +132,7 @@ These instructions assume that you have built the Antrea Docker image locally
 
 ```bash
 # load the Antrea Docker image in the Nodes
-kind load docker-image projects.registry.vmware.com/antrea/antrea-ubuntu:latest
+kind load docker-image antrea/antrea-ubuntu:latest
 # deploy Antrea
 kubectl apply -f build/yamls/antrea.yml
 ```


### PR DESCRIPTION
This PR fixes the docker image for `antrea-ubuntu` in `build/yamls/antrea.yml` for automatic deployment using kind, i.e
the previous image `"projects.registry.vmware.com/antrea/antrea-ubuntu:latest"` is now changed to `"antrea/antrea-ubuntu:latest"`

Additionally, the docs are updated to reflect the new image.

Signed-off-by: Ajeeta Asthana <ajita.asthana@gmail.com>