### PR TITLE
Use mock network for memberlist unit tests

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -406,7 +406,7 @@ func run(o *Options) error {
 			return fmt.Errorf("invalid Node Transport IPAddr in Node config: %v", nodeConfig)
 		}
 		memberlistCluster, err = memberlist.NewCluster(nodeTransportIP, o.config.ClusterMembershipPort,
-			nodeConfig.Name, nodeInformer, externalIPPoolInformer,
+			nodeConfig.Name, nodeInformer, externalIPPoolInformer, nil,
 		)
 		if err != nil {
 			return fmt.Errorf("error creating new memberlist cluster: %v", err)

--- a/pkg/agent/memberlist/cluster.go
+++ b/pkg/agent/memberlist/cluster.go
@@ -129,6 +129,7 @@ func NewCluster(
 	nodeName string,
 	nodeInformer coreinformers.NodeInformer,
 	externalIPPoolInformer crdinformers.ExternalIPPoolInformer,
+	transport memberlist.Transport, // Parameterized for testing, could be left nil for production code.
 ) (*Cluster, error) {
 	// The Node join/leave events will be notified via it.
 	nodeEventCh := make(chan memberlist.NodeEvent, 1024)
@@ -148,6 +149,7 @@ func NewCluster(
 
 	conf := memberlist.DefaultLocalConfig()
 	conf.Name = c.nodeName
+	conf.Transport = transport
 	conf.BindPort = c.bindPort
 	conf.AdvertisePort = c.bindPort
 	conf.AdvertiseAddr = nodeIP.String()


### PR DESCRIPTION
Otherwise tests would fail if the memberlist port is already bound on
the server that runs the tests.

Signed-off-by: Quan Tian <qtian@vmware.com>