### PR TITLE
Fix names of packages in pkg/config

### DIFF
--- a/pkg/config/agent/config.go
+++ b/pkg/config/agent/config.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package agent
 
 import (
 	componentbaseconfig "k8s.io/component-base/config"

--- a/pkg/config/controller/config.go
+++ b/pkg/config/controller/config.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package controller
 
 import (
 	componentbaseconfig "k8s.io/component-base/config"

--- a/pkg/config/flowaggregator/config.go
+++ b/pkg/config/flowaggregator/config.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package flowaggregator
 
 type AggregatorTransportProtocol string
 

--- a/pkg/config/flowaggregator/default.go
+++ b/pkg/config/flowaggregator/default.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package config
+package flowaggregator
 
 import (
 	"time"


### PR DESCRIPTION
Somehow they were named differently from the base names of their source
directories, which make code consuming them look very confusing if they
are not imported with alias. For example, code would look like the
following:

```
import "antrea.io/antrea/pkg/config/agent"

func newOptions() *Options {
	return &Options{
		config: &config.AgentConfig{},
	}
}
```

Signed-off-by: Quan Tian <qtian@vmware.com>