### PR TITLE
Avoid redundant Openflow messages when syncing an updated group to OVS

### DIFF
--- a/pkg/ovs/openflow/ofctrl_group.go
+++ b/pkg/ovs/openflow/ofctrl_group.go
@@ -135,6 +135,6 @@ func (b *bucketBuilder) Weight(val uint16) BucketBuilder {
 }
 
 func (b *bucketBuilder) Done() Group {
-	b.group.ofctrl.AddBuckets(b.bucket)
+	b.group.ofctrl.Buckets = append(b.group.ofctrl.Buckets, b.bucket)
 	return b.group
 }


### PR DESCRIPTION
Fixes: #4159

This PR fixes the issue by appending buckets directly in `Done()` in
pkg/ovs/openflow/ofctrl_group.go instead of calling `AddBuckets` method
of `Group` defined in the ofnet which sends an Openflow message to install
the group.

Signed-off-by: Hongliang Liu <lhongliang@vmware.com>