### PR TITLE
Automated cherry pick of #4160: Avoid redundant Openflow messages when syncing an updated

### DIFF
--- a/pkg/ovs/openflow/ofctrl_group.go
+++ b/pkg/ovs/openflow/ofctrl_group.go
@@ -158,6 +158,6 @@ func (b *bucketBuilder) Weight(val uint16) BucketBuilder {
 }
 
 func (b *bucketBuilder) Done() Group {
-	b.group.ofctrl.AddBuckets(b.bucket)
+	b.group.ofctrl.Buckets = append(b.group.ofctrl.Buckets, b.bucket)
 	return b.group
 }


### PR DESCRIPTION
Cherry pick of #4160 on release-1.8.

#4160: Avoid redundant Openflow messages when syncing an updated

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.