### PR TITLE
Remove the limit on the number of Endpoints in AntreaProxy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module antrea.io/antrea
 go 1.19
 
 require (
-	antrea.io/libOpenflow v0.8.0
-	antrea.io/ofnet v0.6.1
+	antrea.io/libOpenflow v0.8.1
+	antrea.io/ofnet v0.6.2
 	github.com/ClickHouse/clickhouse-go v1.5.4
 	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/Mellanox/sriovnet v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
-antrea.io/libOpenflow v0.8.0 h1:Xm6mlSqdXtDD418nf1lndoDvMi8scqUan8pkEUZ2oas=
-antrea.io/libOpenflow v0.8.0/go.mod h1:CzEJZxDNAupiGxeL5VOw92PsxfyvehEAvE3PiC6gr8o=
-antrea.io/ofnet v0.6.1 h1:w/FIagCrN7dKt2A2R9grlmcSyGrqlCu+uFYPthtfXeg=
-antrea.io/ofnet v0.6.1/go.mod h1:qWqi11pI3kBYcS9SYWm92ZOiOPBx04Jx21cDmJlJhOg=
+antrea.io/libOpenflow v0.8.1 h1:uxkXvhlPRXAVw26LW6Pt2jCSEh8NR56vQW70YGvy7aU=
+antrea.io/libOpenflow v0.8.1/go.mod h1:CzEJZxDNAupiGxeL5VOw92PsxfyvehEAvE3PiC6gr8o=
+antrea.io/ofnet v0.6.2 h1:CCW2lOVBtEgpbsIT+DatHcYCfQ5+MDTHSSlQrc2Qelc=
+antrea.io/ofnet v0.6.2/go.mod h1:/gjpTqhUpyn8uZnef+ytdCCAeY5oGG1jCr/szPUqVXU=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=

--- a/pkg/agent/openflow/service.go
+++ b/pkg/agent/openflow/service.go
@@ -157,12 +157,14 @@ func (f *featureService) replayFlows() []binding.Flow {
 }
 
 func (f *featureService) replayGroups() {
+	var groups []binding.OFEntry
 	f.groupCache.Range(func(id, value interface{}) bool {
 		group := value.(binding.Group)
 		group.Reset()
-		if err := group.Add(); err != nil {
-			klog.Errorf("Error when replaying cached group %d: %v", id, err)
-		}
+		groups = append(groups, group)
 		return true
 	})
+	if err := f.bridge.AddOFEntriesInBundle(groups, nil, nil); err != nil {
+		klog.ErrorS(err, "error when replaying cached groups for Service")
+	}
 }

--- a/pkg/ovs/openflow/interfaces.go
+++ b/pkg/ovs/openflow/interfaces.go
@@ -96,7 +96,7 @@ type Bridge interface {
 	DeleteTable(id uint8) bool
 	CreateGroupTypeAll(id GroupIDType) Group
 	CreateGroup(id GroupIDType) Group
-	DeleteGroup(id GroupIDType) bool
+	DeleteGroup(id GroupIDType) error
 	CreateMeter(id MeterIDType, flags ofctrl.MeterFlag) Meter
 	DeleteMeter(id MeterIDType) bool
 	DeleteMeterAll() error
@@ -183,9 +183,9 @@ type OFEntry interface {
 	// Modify / Delete methods can be called on this object. This method
 	// should be called if a reconnection event happened.
 	Reset()
-	// GetBundleMessage returns ofctrl.OpenFlowModMessage which can be used in Bundle messages. operation specifies what
-	// operation is expected to be taken on the OFEntry.
-	GetBundleMessage(operation OFOperation) (ofctrl.OpenFlowModMessage, error)
+	// GetBundleMessages returns a slice of ofctrl.OpenFlowModMessage which can be used in Bundle messages. operation
+	// specifies what operation is expected to be taken on the OFEntry.
+	GetBundleMessages(operation OFOperation) ([]ofctrl.OpenFlowModMessage, error)
 }
 
 type Flow interface {

--- a/pkg/ovs/openflow/ofctrl_flow.go
+++ b/pkg/ovs/openflow/ofctrl_flow.go
@@ -124,7 +124,7 @@ func (f *ofFlow) FlowProtocol() Protocol {
 	return f.protocol
 }
 
-func (f *ofFlow) GetBundleMessage(entryOper OFOperation) (ofctrl.OpenFlowModMessage, error) {
+func (f *ofFlow) GetBundleMessages(entryOper OFOperation) ([]ofctrl.OpenFlowModMessage, error) {
 	var operation int
 	switch entryOper {
 	case AddMessage:
@@ -138,7 +138,7 @@ func (f *ofFlow) GetBundleMessage(entryOper OFOperation) (ofctrl.OpenFlowModMess
 	if err != nil {
 		return nil, err
 	}
-	return message, nil
+	return []ofctrl.OpenFlowModMessage{message}, nil
 }
 
 // CopyToBuilder returns a new FlowBuilder that copies the table, protocols,

--- a/pkg/ovs/openflow/ofctrl_group.go
+++ b/pkg/ovs/openflow/ofctrl_group.go
@@ -23,10 +23,13 @@ import (
 	"antrea.io/ofnet/ofctrl"
 )
 
+var (
+	MaxBucketsPerMessage = 800
+)
+
 type ofGroup struct {
-	ofctrl       *ofctrl.Group
-	bridge       *OFBridge
-	bucketsCount int
+	ofctrl *ofctrl.Group
+	bridge *OFBridge
 }
 
 // Reset creates a new ofctrl.Group object for the updated ofSwitch. The
@@ -44,15 +47,15 @@ func (g *ofGroup) Reset() {
 }
 
 func (g *ofGroup) Add() error {
-	return g.ofctrl.Install()
+	return g.bridge.AddOFEntriesInBundle([]OFEntry{g}, nil, nil)
 }
 
 func (g *ofGroup) Modify() error {
-	return g.ofctrl.Install()
+	return g.bridge.AddOFEntriesInBundle(nil, []OFEntry{g}, nil)
 }
 
 func (g *ofGroup) Delete() error {
-	return g.ofctrl.Delete()
+	return g.bridge.AddOFEntriesInBundle(nil, nil, []OFEntry{g})
 }
 
 func (g *ofGroup) Type() EntryType {
@@ -71,7 +74,7 @@ func (g *ofGroup) Bucket() BucketBuilder {
 	}
 }
 
-func (g *ofGroup) GetBundleMessage(entryOper OFOperation) (ofctrl.OpenFlowModMessage, error) {
+func (g *ofGroup) GetBundleMessages(entryOper OFOperation) ([]ofctrl.OpenFlowModMessage, error) {
 	var operation int
 	switch entryOper {
 	case AddMessage:
@@ -80,9 +83,37 @@ func (g *ofGroup) GetBundleMessage(entryOper OFOperation) (ofctrl.OpenFlowModMes
 		operation = openflow15.OFPGC_MODIFY
 	case DeleteMessage:
 		operation = openflow15.OFPGC_DELETE
+		// If the operation is to delete the group, empty the slice storing buckets since the number of buckets could
+		// be greater than MaxBucketsPerMessage.
+		g.ofctrl.Buckets = nil
 	}
-	message := g.ofctrl.GetBundleMessage(operation)
-	return message, nil
+
+	var messages []ofctrl.OpenFlowModMessage
+	for start := 0; start <= len(g.ofctrl.Buckets); start += MaxBucketsPerMessage {
+		// Get the range of buckets to generate a temp group.
+		end := start + MaxBucketsPerMessage
+		if end > len(g.ofctrl.Buckets) {
+			end = len(g.ofctrl.Buckets)
+		}
+		// For the message which is not the first, insert_buckets is used to add buckets to the group on OVS.
+		if start != 0 {
+			operation = openflow15.OFPGC_INSERT_BUCKET
+			// There is no need to generate an insert_buckets message without bucket.
+			if start == end {
+				break
+			}
+		}
+		// Generate a temp group to get an OVS message. Note that, the original group should not be modified since it is
+		// also stored in group cache, and the group cache is used when replaying groups.
+		groupMessage := &ofctrl.Group{
+			ID:        g.ofctrl.ID,
+			GroupType: g.ofctrl.GroupType,
+			Buckets:   g.ofctrl.Buckets[start:end],
+		}
+
+		messages = append(messages, groupMessage.GetBundleMessage(operation))
+	}
+	return messages, nil
 }
 
 func (g *ofGroup) ResetBuckets() Group {

--- a/pkg/ovs/openflow/ofctrl_meter.go
+++ b/pkg/ovs/openflow/ofctrl_meter.go
@@ -51,7 +51,7 @@ func (m *ofMeter) KeyString() string {
 	return fmt.Sprintf("meter_id:%d", m.ofctrl.ID)
 }
 
-func (m *ofMeter) GetBundleMessage(entryOper OFOperation) (ofctrl.OpenFlowModMessage, error) {
+func (m *ofMeter) GetBundleMessages(entryOper OFOperation) ([]ofctrl.OpenFlowModMessage, error) {
 	var operation int
 	switch entryOper {
 	case AddMessage:
@@ -62,7 +62,7 @@ func (m *ofMeter) GetBundleMessage(entryOper OFOperation) (ofctrl.OpenFlowModMes
 		operation = openflow15.MC_DELETE
 	}
 	message := m.ofctrl.GetBundleMessage(operation)
-	return message, nil
+	return []ofctrl.OpenFlowModMessage{message}, nil
 }
 
 func (m *ofMeter) ResetMeterBands() Meter {

--- a/pkg/ovs/openflow/testing/mock_openflow.go
+++ b/pkg/ovs/openflow/testing/mock_openflow.go
@@ -191,10 +191,10 @@ func (mr *MockBridgeMockRecorder) DeleteFlowsByCookie(arg0, arg1 interface{}) *g
 }
 
 // DeleteGroup mocks base method
-func (m *MockBridge) DeleteGroup(arg0 openflow.GroupIDType) bool {
+func (m *MockBridge) DeleteGroup(arg0 openflow.GroupIDType) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteGroup", arg0)
-	ret0, _ := ret[0].(bool)
+	ret0, _ := ret[0].(error)
 	return ret0
 }
 
@@ -569,19 +569,19 @@ func (mr *MockFlowMockRecorder) FlowProtocol() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FlowProtocol", reflect.TypeOf((*MockFlow)(nil).FlowProtocol))
 }
 
-// GetBundleMessage mocks base method
-func (m *MockFlow) GetBundleMessage(arg0 openflow.OFOperation) (ofctrl.OpenFlowModMessage, error) {
+// GetBundleMessages mocks base method
+func (m *MockFlow) GetBundleMessages(arg0 openflow.OFOperation) ([]ofctrl.OpenFlowModMessage, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBundleMessage", arg0)
-	ret0, _ := ret[0].(ofctrl.OpenFlowModMessage)
+	ret := m.ctrl.Call(m, "GetBundleMessages", arg0)
+	ret0, _ := ret[0].([]ofctrl.OpenFlowModMessage)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetBundleMessage indicates an expected call of GetBundleMessage
-func (mr *MockFlowMockRecorder) GetBundleMessage(arg0 interface{}) *gomock.Call {
+// GetBundleMessages indicates an expected call of GetBundleMessages
+func (mr *MockFlowMockRecorder) GetBundleMessages(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBundleMessage", reflect.TypeOf((*MockFlow)(nil).GetBundleMessage), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBundleMessages", reflect.TypeOf((*MockFlow)(nil).GetBundleMessages), arg0)
 }
 
 // IsDropFlow mocks base method
@@ -2192,19 +2192,19 @@ func (mr *MockGroupMockRecorder) Delete() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockGroup)(nil).Delete))
 }
 
-// GetBundleMessage mocks base method
-func (m *MockGroup) GetBundleMessage(arg0 openflow.OFOperation) (ofctrl.OpenFlowModMessage, error) {
+// GetBundleMessages mocks base method
+func (m *MockGroup) GetBundleMessages(arg0 openflow.OFOperation) ([]ofctrl.OpenFlowModMessage, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBundleMessage", arg0)
-	ret0, _ := ret[0].(ofctrl.OpenFlowModMessage)
+	ret := m.ctrl.Call(m, "GetBundleMessages", arg0)
+	ret0, _ := ret[0].([]ofctrl.OpenFlowModMessage)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetBundleMessage indicates an expected call of GetBundleMessage
-func (mr *MockGroupMockRecorder) GetBundleMessage(arg0 interface{}) *gomock.Call {
+// GetBundleMessages indicates an expected call of GetBundleMessages
+func (mr *MockGroupMockRecorder) GetBundleMessages(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBundleMessage", reflect.TypeOf((*MockGroup)(nil).GetBundleMessage), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBundleMessages", reflect.TypeOf((*MockGroup)(nil).GetBundleMessages), arg0)
 }
 
 // KeyString mocks base method

--- a/test/integration/ovs/ofctrl_test.go
+++ b/test/integration/ovs/ofctrl_test.go
@@ -933,6 +933,82 @@ func TestLoadToLabelFieldAction(t *testing.T) {
 	}
 }
 
+func TestBundleWithGroupInsertBucket(t *testing.T) {
+	br := "br12"
+	err := PrepareOVSBridge(br)
+	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge: %v", err))
+	defer DeleteOVSBridge(br)
+
+	bridge := newOFBridge(br)
+	table = bridge.CreateTable(t2, t3.GetID(), binding.TableMissActionNext)
+	// Set the maximum of buckets in a message to test insert_buckets.
+	binding.MaxBucketsPerMessage = 2
+	// In case it affects other tests, set the maximum of buckets in a message back to 800.
+	defer func() {
+		binding.MaxBucketsPerMessage = 800
+	}()
+
+	err = bridge.Connect(maxRetry, make(chan struct{}))
+	require.Nil(t, err, "Failed to start OFService")
+	defer bridge.Disconnect()
+
+	ovsCtlClient := ovsctl.NewClient(br)
+	groupID := binding.GroupIDType(4)
+
+	group := bridge.CreateGroup(groupID)
+	expectedGroupBuckets := []string{}
+	err = bridge.AddOFEntriesInBundle([]binding.OFEntry{group}, nil, nil)
+	require.Nil(t, err)
+	CheckGroupExists(t, ovsCtlClient, groupID, "select", expectedGroupBuckets, true)
+
+	field1 := binding.NewRegField(1, 0, 31)
+	field2 := binding.NewRegField(2, 0, 31)
+	field3 := binding.NewRegField(3, 0, 31)
+	group = group.
+		Bucket().Weight(100).
+		LoadToRegField(field1, uint32(0xa0a0002)).
+		LoadToRegField(field2, uint32(0x1)).
+		LoadToRegField(field3, uint32(0xfff1)).
+		ResubmitToTable(table.GetNext()).Done().
+		Bucket().Weight(100).
+		LoadToRegField(field1, uint32(0xa0a0202)).
+		LoadToRegField(field2, uint32(0x2)).
+		LoadToRegField(field3, uint32(0xfff1)).
+		ResubmitToTable(table.GetNext()).Done().
+		Bucket().Weight(100).
+		LoadToRegField(field1, uint32(0xa0a0202)).
+		LoadToRegField(field2, uint32(0x3)).
+		LoadToRegField(field3, uint32(0xfff1)).
+		ResubmitToTable(table.GetNext()).Done()
+
+	bucket1 := "weight:100,actions=set_field:0xa0a0002->reg1,set_field:0x1->reg2,set_field:0xfff1->reg3,resubmit(,3)"
+	bucket2 := "weight:100,actions=set_field:0xa0a0202->reg1,set_field:0x2->reg2,set_field:0xfff1->reg3,resubmit(,3)"
+	bucket3 := "weight:100,actions=set_field:0xa0a0202->reg1,set_field:0x3->reg2,set_field:0xfff1->reg3,resubmit(,3)"
+	expectedGroupBuckets = []string{bucket1, bucket2, bucket3}
+	err = bridge.AddOFEntriesInBundle(nil, []binding.OFEntry{group}, nil)
+	require.Nil(t, err)
+	CheckGroupExists(t, ovsCtlClient, groupID, "select", expectedGroupBuckets, true)
+
+	group = group.
+		Bucket().Weight(100).
+		LoadToRegField(field1, uint32(0xa0a0202)).
+		LoadToRegField(field2, uint32(0x4)).
+		LoadToRegField(field3, uint32(0xfff1)).
+		ResubmitToTable(table.GetNext()).Done()
+
+	bucket4 := "weight:100,actions=set_field:0xa0a0202->reg1,set_field:0x4->reg2,set_field:0xfff1->reg3,resubmit(,3)"
+	expectedGroupBuckets = []string{bucket1, bucket2, bucket3, bucket4}
+	err = bridge.AddOFEntriesInBundle(nil, []binding.OFEntry{group}, nil)
+	require.Nil(t, err)
+	CheckGroupExists(t, ovsCtlClient, groupID, "select", expectedGroupBuckets, true)
+
+	group.ResetBuckets()
+	expectedGroupBuckets = []string{}
+	err = bridge.AddOFEntriesInBundle(nil, []binding.OFEntry{group}, nil)
+	require.Nil(t, err)
+	CheckGroupExists(t, ovsCtlClient, groupID, "select", expectedGroupBuckets, true)
+}
+
 func prepareFlows(table binding.Table) ([]binding.Flow, []*ExpectFlow) {
 	var flows []binding.Flow
 	_, AllIPs, _ := net.ParseCIDR("0.0.0.0/0")


### PR DESCRIPTION
Fixes: #2092

Due to the message size of Openflow, the maximum number of Endpoints for
a Service in AntreaProxy is 800. Since Openflow 1.5 is used in Antrea,
the operation `insert_buckets` introduced in Openflow 1.5 can be used to
create a Service with more than 800 Endpoints. To sync Service with more
than 800 Endpoints to OVS, multiple Openflow messages will be sent to
OVS in a bundle (the first message uses `add` to sync the OVS group and
its corresponding buckets to OVS, other messages use `insert_buckets` to
sync other buckets to OVS).

Signed-off-by: Hongliang Liu <lhongliang@vmware.com>