### PR TITLE
Update codecov.yaml to use flags section

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -44,8 +44,14 @@ coverage:
         flags:
           - kind-e2e-tests
 
-flag_management:
-  default_rules:
+flags:
+  unit-tests:
+    carryforward: true
+  integration-tests:
+    carryforward: true
+  e2e-tests:
+    carryforward: true
+  kind-e2e-tests:
     carryforward: true
 
 ignore:


### PR DESCRIPTION
I am seeing some inaccurate coverage data reported, so I am trying some
updates to codecov.yaml, based on https://docs.codecov.com/docs/flags.

Signed-off-by: Antonin Bas <abas@vmware.com>