### PR TITLE
Add more unit tests for secondarynetwork feature

### DIFF
--- a/pkg/agent/secondarynetwork/podwatch/controller.go
+++ b/pkg/agent/secondarynetwork/podwatch/controller.go
@@ -306,7 +306,7 @@ func (pc *PodController) configureSecondaryInterface(pod *corev1.Pod, network *n
 	if len(network.InterfaceRequest) == 0 {
 		var err error
 		if network.InterfaceRequest, err = generatePodSecondaryIfaceName(podCNIInfo); err != nil {
-			klog.ErrorS(err, "cannot generate interface name", "Pod", klog.KObj(pod))
+			klog.ErrorS(err, "Cannot generate interface name", "Pod", klog.KObj(pod))
 			// do not return error: no need to requeue
 			return nil
 		}


### PR DESCRIPTION
Fix one of the tests (`TestPodControllerAddPod/missing_Status.PodIPs`)
and add a few more unit tests.

For #4142

Signed-off-by: Antonin Bas <abas@vmware.com>