### PR TITLE
Add checksum of config file as an annotation

### DIFF
--- a/multicluster/Makefile
+++ b/multicluster/Makefile
@@ -51,6 +51,7 @@ manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and Cust
 	$(CURDIR)/hack/generate-manifest.sh -g > build/yamls/antrea-multicluster-leader-global.yml
 	$(CURDIR)/hack/generate-manifest.sh -l antrea-multicluster > build/yamls/antrea-multicluster-leader-namespaced.yml
 	$(CURDIR)/hack/generate-manifest.sh -m > build/yamls/antrea-multicluster-member.yml
+	$(CURDIR)/hack/update-checksum.sh
 
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt",year=$(YEAR) paths="./..."

--- a/multicluster/build/yamls/antrea-multicluster-leader-namespaced.yml
+++ b/multicluster/build/yamls/antrea-multicluster-leader-namespaced.yml
@@ -327,7 +327,7 @@ kind: ConfigMap
 metadata:
   labels:
     app: antrea
-  name: antrea-mc-controller-config-6b7ccgh6k9
+  name: antrea-mc-controller-config
   namespace: antrea-multicluster
 ---
 apiVersion: v1
@@ -361,6 +361,8 @@ spec:
       component: antrea-mc-controller
   template:
     metadata:
+      annotations:
+        checksum/config: 7c5790c03e84cdb0a2ea8f4fb685a604cf6a1901e241a679afe996a0141ccea0
       labels:
         app: antrea
         component: antrea-mc-controller
@@ -409,7 +411,7 @@ spec:
       terminationGracePeriodSeconds: 10
       volumes:
       - configMap:
-          name: antrea-mc-controller-config-6b7ccgh6k9
+          name: antrea-mc-controller-config
         name: antrea-mc-controller-config
 ---
 apiVersion: admissionregistration.k8s.io/v1

--- a/multicluster/build/yamls/antrea-multicluster-member.yml
+++ b/multicluster/build/yamls/antrea-multicluster-member.yml
@@ -951,7 +951,7 @@ kind: ConfigMap
 metadata:
   labels:
     app: antrea
-  name: antrea-mc-controller-config-6b7ccgh6k9
+  name: antrea-mc-controller-config
   namespace: kube-system
 ---
 apiVersion: v1
@@ -985,6 +985,8 @@ spec:
       component: antrea-mc-controller
   template:
     metadata:
+      annotations:
+        checksum/config: 7c5790c03e84cdb0a2ea8f4fb685a604cf6a1901e241a679afe996a0141ccea0
       labels:
         app: antrea
         component: antrea-mc-controller
@@ -1033,7 +1035,7 @@ spec:
       terminationGracePeriodSeconds: 10
       volumes:
       - configMap:
-          name: antrea-mc-controller-config-6b7ccgh6k9
+          name: antrea-mc-controller-config
         name: antrea-mc-controller-config
 ---
 apiVersion: admissionregistration.k8s.io/v1

--- a/multicluster/config/default/kustomization.yaml
+++ b/multicluster/config/default/kustomization.yaml
@@ -25,3 +25,5 @@ configMapGenerator:
   - name: controller-config
     files:
       - configmap/controller_manager_config.yaml
+generatorOptions:
+  disableNameSuffixHash: true

--- a/multicluster/config/manager/manager.yaml
+++ b/multicluster/config/manager/manager.yaml
@@ -14,6 +14,8 @@ spec:
     metadata:
       labels:
         component: antrea-mc-controller
+      annotations:
+        checksum/config: checksum-placeholder
     spec:
       hostNetwork: true
       containers:

--- a/multicluster/hack/update-checksum.sh
+++ b/multicluster/hack/update-checksum.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 Antrea Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+WORK_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+YAMLS_DIR="${WORK_DIR}"/../build/yamls
+MANIFESTS=$(ls $YAMLS_DIR)
+
+checksum=$(cat "${WORK_DIR}"/../config/default/configmap/controller_manager_config.yaml | sha256sum | cut -d " " -f 1)
+
+for file in ${MANIFESTS[@]}; do
+    sed -i "s/checksum-placeholder/${checksum}/g" ${YAMLS_DIR}/$file
+done


### PR DESCRIPTION
When the ConfigMap is generated with suffix by kustomize, it will
generate a manifest with new ConfigMap like 'antrea-mc-controller-config-***'.
When a new Deployment is applied, it will leave a stale ConfigMap.
To avoid stale ConfigMaps, here we add checksum of multi-cluster configuration
file as Deployment's annotation. This way can help to restart the controller Pod
automatically without the suffix of ConfigMap.

Signed-off-by: Lan Luo <luola@vmware.com>