### PR TITLE
Update Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,11 +9,15 @@ updates:
     - dependency-name: "k8s.io/*"
     - dependency-name: "sigs.k8s.io/*"
     - dependency-name: "github.com/containernetworking/*"
+    - dependency-name: "github.com/k8snetworkplumbingwg/*"
+      update-types: ["version-update:semver-major", "version-update:semver-minor"] # ignore all except for patch updates
     - dependency-name: "github.com/vmware/go-ipfix"
     - dependency-name: "github.com/TomCodeLV/OVSDB-golang-lib"
     - dependency-name: "github.com/vmware-tanzu/octant"
       update-types: ["version-update:semver-major", "version-update:semver-minor"] # ignore all except for patch updates
-    - dependency-name: "github.com/Microsoft/hcsshim" # we use a replace directive for this dependency
+    - dependency-name: "github.com/aws/*" # updates are too frequent
+    - dependency-name: "antrea.io/ofnet"
+    - dependency-name: "antrea.io/libOpenflow"
   - package-ecosystem: "github-actions"
     # Workflow files stored in the default location of `.github/workflows`
     directory: "/"


### PR DESCRIPTION
* Ignore non-patch version updates for github.com/k8snetworkplumbingwg/*:
  minor updates may require updating github.com/containernetworking/cni
  as well.
* Ignore version updates for antrea.io/ofnet and antrea.io/libOpenflow:
  history shows that we prefer to update these manually.
* Ignore version updates for github.com/aws/*: releases for the AWS SDK
  are too frequent.

Signed-off-by: Antonin Bas <abas@vmware.com>