### PR TITLE
Allow Pod IP as MC Service Endpoints

### DIFF
--- a/multicluster/apis/multicluster/v1alpha1/multiclusterconfig_types.go
+++ b/multicluster/apis/multicluster/v1alpha1/multiclusterconfig_types.go
@@ -44,6 +44,13 @@ type MultiClusterConfig struct {
 	// The precedence about which IP address (internal or external IP) of Node is preferred to
 	// be used as the cross-cluster tunnel endpoint. if not specified, internal IP will be chosen.
 	GatewayIPPrecedence Precedence `json:"gatewayIPPrecedence,omitempty"`
+	// The type of IP address (ClusterIP or PodIP) to be used as the Multi-cluster
+	// Services' Endpoints. Defaults to ClusterIP. All member clusters should use the same type
+	// in a ClusterSet. Existing ServiceExports should be re-exported after changing
+	// EndpointIPType. ClusterIP type requires that Multi-cluster Gateway is configured.
+	// PodIP type requires Multi-cluster Gateway too when there is no direct Pod-to-Pod
+	// connectivity across member clusters.
+	EndpointIPType string `json:"endpointIPType,omitempty"`
 }
 
 func init() {

--- a/multicluster/build/yamls/antrea-multicluster-leader-namespaced.yml
+++ b/multicluster/build/yamls/antrea-multicluster-leader-namespaced.yml
@@ -323,6 +323,7 @@ data:
       leaderElect: false
     serviceCIDR: ""
     gatewayIPPrecedence: "private"
+    endpointIPType: "ClusterIP"
 kind: ConfigMap
 metadata:
   labels:
@@ -362,7 +363,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7c5790c03e84cdb0a2ea8f4fb685a604cf6a1901e241a679afe996a0141ccea0
+        checksum/config: ab74dc9fd6d27a934c61d50e51dbf331ef6d57ab28c1121df3520bef6aad1f79
       labels:
         app: antrea
         component: antrea-mc-controller

--- a/multicluster/build/yamls/antrea-multicluster-member.yml
+++ b/multicluster/build/yamls/antrea-multicluster-member.yml
@@ -947,6 +947,7 @@ data:
       leaderElect: false
     serviceCIDR: ""
     gatewayIPPrecedence: "private"
+    endpointIPType: "ClusterIP"
 kind: ConfigMap
 metadata:
   labels:
@@ -986,7 +987,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 7c5790c03e84cdb0a2ea8f4fb685a604cf6a1901e241a679afe996a0141ccea0
+        checksum/config: ab74dc9fd6d27a934c61d50e51dbf331ef6d57ab28c1121df3520bef6aad1f79
       labels:
         app: antrea
         component: antrea-mc-controller

--- a/multicluster/cmd/multicluster-controller/member.go
+++ b/multicluster/cmd/multicluster-controller/member.go
@@ -73,7 +73,8 @@ func runMember(o *Options) error {
 	svcExportReconciler := multiclustercontrollers.NewServiceExportReconciler(
 		mgr.GetClient(),
 		mgr.GetScheme(),
-		commonAreaGetter)
+		commonAreaGetter,
+		o.EndpointIPType)
 	if err = svcExportReconciler.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("error creating ServiceExport controller: %v", err)
 	}

--- a/multicluster/cmd/multicluster-controller/options.go
+++ b/multicluster/cmd/multicluster-controller/options.go
@@ -35,6 +35,9 @@ type Options struct {
 	// The precedence about which IP (private or public one) of Node is preferred to
 	// be used as tunnel endpoint. If not specified, private IP will be chosen.
 	GatewayIPPrecedence mcsv1alpha1.Precedence
+	// The type of IP address (ClusterIP or PodIP) to be used as the Multi-cluster
+	// Services' Endpoints.
+	EndpointIPType string
 }
 
 func newOptions() *Options {
@@ -63,6 +66,11 @@ func (o *Options) complete(args []string) error {
 		}
 		o.ServiceCIDR = ctrlConfig.ServiceCIDR
 		o.GatewayIPPrecedence = ctrlConfig.GatewayIPPrecedence
+		if ctrlConfig.EndpointIPType == "" {
+			o.EndpointIPType = "ClusterIP"
+		} else {
+			o.EndpointIPType = ctrlConfig.EndpointIPType
+		}
 		klog.InfoS("Using config from file", "config", o.options)
 	} else {
 		klog.InfoS("Using default config", "config", o.options)

--- a/multicluster/config/default/configmap/controller_manager_config.yaml
+++ b/multicluster/config/default/configmap/controller_manager_config.yaml
@@ -10,3 +10,4 @@ leaderElection:
   leaderElect: false
 serviceCIDR: ""
 gatewayIPPrecedence: "private"
+endpointIPType: "ClusterIP"

--- a/multicluster/controllers/multicluster/common/helper.go
+++ b/multicluster/controllers/multicluster/common/helper.go
@@ -87,3 +87,24 @@ func GetServiceEndpointPorts(ports []corev1.ServicePort) []corev1.EndpointPort {
 	}
 	return epPorts
 }
+
+// FilterEndpointSubsets keeps IPs only and removes other fields from EndpointSubset
+// which are unnecessary information for other member clusters.
+func FilterEndpointSubsets(subsets []corev1.EndpointSubset) []corev1.EndpointSubset {
+	newSubsets := []corev1.EndpointSubset{}
+	for _, s := range subsets {
+		subset := corev1.EndpointSubset{}
+		newAddresses := []corev1.EndpointAddress{}
+		for _, addr := range s.Addresses {
+			newAddresses = append(newAddresses, corev1.EndpointAddress{
+				IP: addr.IP,
+			})
+		}
+		if len(newAddresses) > 0 {
+			subset.Addresses = newAddresses
+			subset.Ports = s.Ports
+			newSubsets = append(newSubsets, subset)
+		}
+	}
+	return newSubsets
+}

--- a/multicluster/test/integration/suite_test.go
+++ b/multicluster/test/integration/suite_test.go
@@ -145,7 +145,8 @@ var _ = BeforeSuite(func() {
 	svcExportReconciler := multiclustercontrollers.NewServiceExportReconciler(
 		k8sManager.GetClient(),
 		k8sManager.GetScheme(),
-		clusterSetReconciler)
+		clusterSetReconciler,
+		"ClusterIP")
 	err = svcExportReconciler.SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
Add a new config option to use Pod IP instead of exported Service's
ClusterIP as Multi-cluster Service Endpoints. This way supports the
case that Pod IPs are directly routable across member clusters,
including the Antrea noEncap or networkPolicyOnly modes in public
clouds.

Signed-off-by: Lan Luo <luola@vmware.com>