### PR TITLE
Remove debug log

### DIFF
--- a/multicluster/controllers/multicluster/leader_clusterset_controller.go
+++ b/multicluster/controllers/multicluster/leader_clusterset_controller.go
@@ -159,7 +159,6 @@ func (r *LeaderClusterSetReconciler) updateStatus() {
 	status := multiclusterv1alpha1.ClusterSetStatus{}
 	status.ObservedGeneration = r.clusterSetConfig.Generation
 	clusterStatuses := r.StatusManager.GetMemberClusterStatuses()
-	klog.InfoS("size of cluster", "size", len(clusterStatuses))
 	status.ClusterStatuses = clusterStatuses
 	sizeOfMembers := len(clusterStatuses)
 	status.TotalClusters = int32(sizeOfMembers)


### PR DESCRIPTION
The `updateStatus` will be called every 30s, this debug log becomes annoying line in the controller log, need to remove this and backport to v1.8.

Signed-off-by: Lan Luo <luola@vmware.com>