### PR TITLE
Automated cherry pick of #4210: Remove debug log in leader ClusterSet controller

### DIFF
--- a/multicluster/controllers/multicluster/leader_clusterset_controller.go
+++ b/multicluster/controllers/multicluster/leader_clusterset_controller.go
@@ -159,7 +159,6 @@ func (r *LeaderClusterSetReconciler) updateStatus() {
 	status := multiclusterv1alpha1.ClusterSetStatus{}
 	status.ObservedGeneration = r.clusterSetConfig.Generation
 	clusterStatuses := r.StatusManager.GetMemberClusterStatuses()
-	klog.InfoS("size of cluster", "size", len(clusterStatuses))
 	status.ClusterStatuses = clusterStatuses
 	sizeOfMembers := len(clusterStatuses)
 	status.TotalClusters = int32(sizeOfMembers)


### PR DESCRIPTION
Cherry pick of #4210 on release-1.8.

#4210: Remove debug log

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.