### PR TITLE
Add e2e test for Multi-cluster Service Endpoints changes

### DIFF
--- a/multicluster/test/e2e/main_test.go
+++ b/multicluster/test/e2e/main_test.go
@@ -110,6 +110,7 @@ func TestConnectivity(t *testing.T) {
 		defer tearDownForServiceExportsTest(t, data)
 		initializeForServiceExportsTest(t, data)
 		t.Run("Case=MCServiceConnectivity", func(t *testing.T) { testMCServiceConnectivity(t, data) })
+		t.Run("Case=ScaleDownMCServiceEndpoints", func(t *testing.T) { testScaleDownMCServiceEndpoints(t, data) })
 		t.Run("Case=ANPToServices", func(t *testing.T) { testANPToServices(t, data) })
 	})
 


### PR DESCRIPTION
Add a new e2e test to validate Endpoint change event to make sure event filter works as expected.

This fix needs to be back-ported to v1.8 with a minor change to remove GenerationChangedPredicate
in ServiceExport controller.

Signed-off-by: Lan Luo <luola@vmware.com>