### PR TITLE
Update codecov.yml

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -51,6 +51,8 @@ coverage:
         base: auto
         # Only post a status to pull requests.
         only_pulls: true
+        flags:
+          - unit-tests
     project:
       default:
         # `auto` will use the coverage from the base commit (pull request base or parent commit) coverage to compare against.
@@ -64,10 +66,7 @@ coverage:
 
 flag_management:
   default_rules:
-    carryforward: false
- # individual_flags:
- #   - name: unit-tests
- #     carryforward: false
+    carryforward: true
 
 # Exclude files from being collected by Codecov. Ignored files will be skipped during processing.
 ignore:

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -7,32 +7,6 @@ codecov:
   require_ci_to_pass: no
 
 comment: false
-#  # Customize comment layout by choosing the order and types of components to include.
-#  # `Reach` is a coverage graph embedded into the comment.
-#  # `Diff` is the Coverage Diff of the pull request.
-#  # `Flags` are a list of user defined Flags, and the impact on their coverage. refs: https://docs.codecov.com/docs/flags
-#  # `Files` or Tree are a list of files that are impacted by the pull request (coverage changes, file is new or removed).
-#  # `Header` is the top of the comment showing the two commits being merged, the change in coverage, and the diff coverage.
-#  # `Footer` is the bottom of a comment that contains the legend, last updated commits, and docs link.
-#  layout: "reach,diff,flags,tree,header,footer"
-#  # The way Codecov submits comments in your pull requests.`default` means update if exists.Otherwise, post new.
-#  behavior: default
-#  # If `require_changes` set true, comments will now only post when coverage changes.
-#  # Furthermore, if a comment already exists, and a newer commit results in no coverage
-#  # change for the entire pull, the comment will be deleted.
-#  require_changes: no
-#  # Force comments to post on pull requests even if Codecov doesn't
-#  # have coverage reports for either the base or head commit.
-#  require_base: no
-#  require_head: no
-#  # Codecov does not comment until at least 5 builds have been uploaded from the CI pipeline.
-#  # By default, codecov will post and/or update the pull request comment after it processes
-#  # each report uploaded for a particular pull request commit.
-#  # As the Antrea CI process uploads many reports to codecov, this can be confusing for
-#  # team members viewing the pull request as reports are processing.
-#  after_n_builds: 5
-#  # Carryforward Flags are designed for projects that do not upload total coverage for every commit.
-#  show_carryforward_flags: false
 
 github_checks:
   # Specify whether to use GitHub Checks annotations or normal statuses.

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,53 +1,75 @@
 codecov:
+  # The default branch is used to identify:
+  #  Which branch to cache the repository YAML for UI changes.
+  #  Which branch is the first branch on the repository dashboard in Codecov.
   branch: main
+  # Show the Codecov status without waiting for other status checks to complete or pass.
   require_ci_to_pass: no
 
 comment:
-  layout: "reach,diff,flags,tree"
+  # Customize comment layout by choosing the order and types of components to include.
+  # `Reach` is a coverage graph embedded into the comment.
+  # `Diff` is the Coverage Diff of the pull request.
+  # `Flags` are a list of user defined Flags, and the impact on their coverage. refs: https://docs.codecov.com/docs/flags
+  # `Files` or Tree are a list of files that are impacted by the pull request (coverage changes, file is new or removed).
+  # `Header` is the top of the comment showing the two commits being merged, the change in coverage, and the diff coverage.
+  # `Footer` is the bottom of a comment that contains the legend, last updated commits, and docs link.
+  layout: "reach,diff,flags,tree,header,footer"
+  # The way Codecov submits comments in your pull requests.`default` means update if exists.Otherwise, post new.
   behavior: default
+  # If `require_changes` set true, comments will now only post when coverage changes.
+  # Furthermore, if a comment already exists, and a newer commit results in no coverage
+  # change for the entire pull, the comment will be deleted.
   require_changes: no
+  # Force comments to post on pull requests even if Codecov doesn't
+  # have coverage reports for either the base or head commit.
   require_base: no
   require_head: no
-  after_n_builds: 1
-  show_carryforward_flags: true
+  # Codecov does not comment until at least 5 builds have been uploaded from the CI pipeline.
+  # By default, codecov will post and/or update the pull request comment after it processes
+  # each report uploaded for a particular pull request commit.
+  # As the Antrea CI process uploads many reports to codecov, this can be confusing for
+  # team members viewing the pull request as reports are processing.
+  after_n_builds: 5
+  # Carryforward Flags are designed for projects that do not upload total coverage for every commit.
+  show_carryforward_flags: false
 
 github_checks:
+  # Specify whether to use GitHub Checks annotations or normal statuses.
   annotations: true
 
 coverage:
   status:
     patch:
       default:
+        # Choose a minimum coverage ratio that the commit must meet to be considered a success.
+        # <number> specify a target of an exact coverage number.
         target: 70%
+        # Allow the coverage to drop by X%, and posting a success status.
         threshold: 5%
+        # Use the pull request base if the commit is on a pull request. If not, the parent commit will be used.
         base: auto
+        # Only post a status to pull requests.
         only_pulls: true
-        flags:
-          - unit-tests
     project:
       default:
+        # `auto` will use the coverage from the base commit (pull request base or parent commit) coverage to compare against.
         target: auto
       antrea-unit-tests:
         target: auto
+        # Flags are a list of user defined Flags, and the impact on their coverage.
         flags:
           - unit-tests
-      antrea-integration-tests:
-        target: auto
-        flags:
-          - integration-tests
-      antrea-e2e-tests:
-        target: auto
-        flags:
-          - e2e-tests
-      antrea-kind-e2e-tests:
-        target: auto
-        flags:
-          - kind-e2e-tests
+
 
 flag_management:
   default_rules:
-    carryforward: true
+    carryforward: false
+ # individual_flags:
+ #   - name: unit-tests
+ #     carryforward: false
 
+# Exclude files from being collected by Codecov. Ignored files will be skipped during processing.
 ignore:
   - "**/testing/*.go"
   - "**/mock_*.go"

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -6,33 +6,33 @@ codecov:
   # Show the Codecov status without waiting for other status checks to complete or pass.
   require_ci_to_pass: no
 
-comment:
-  # Customize comment layout by choosing the order and types of components to include.
-  # `Reach` is a coverage graph embedded into the comment.
-  # `Diff` is the Coverage Diff of the pull request.
-  # `Flags` are a list of user defined Flags, and the impact on their coverage. refs: https://docs.codecov.com/docs/flags
-  # `Files` or Tree are a list of files that are impacted by the pull request (coverage changes, file is new or removed).
-  # `Header` is the top of the comment showing the two commits being merged, the change in coverage, and the diff coverage.
-  # `Footer` is the bottom of a comment that contains the legend, last updated commits, and docs link.
-  layout: "reach,diff,flags,tree,header,footer"
-  # The way Codecov submits comments in your pull requests.`default` means update if exists.Otherwise, post new.
-  behavior: default
-  # If `require_changes` set true, comments will now only post when coverage changes.
-  # Furthermore, if a comment already exists, and a newer commit results in no coverage
-  # change for the entire pull, the comment will be deleted.
-  require_changes: no
-  # Force comments to post on pull requests even if Codecov doesn't
-  # have coverage reports for either the base or head commit.
-  require_base: no
-  require_head: no
-  # Codecov does not comment until at least 5 builds have been uploaded from the CI pipeline.
-  # By default, codecov will post and/or update the pull request comment after it processes
-  # each report uploaded for a particular pull request commit.
-  # As the Antrea CI process uploads many reports to codecov, this can be confusing for
-  # team members viewing the pull request as reports are processing.
-  after_n_builds: 5
-  # Carryforward Flags are designed for projects that do not upload total coverage for every commit.
-  show_carryforward_flags: false
+comment: false
+#  # Customize comment layout by choosing the order and types of components to include.
+#  # `Reach` is a coverage graph embedded into the comment.
+#  # `Diff` is the Coverage Diff of the pull request.
+#  # `Flags` are a list of user defined Flags, and the impact on their coverage. refs: https://docs.codecov.com/docs/flags
+#  # `Files` or Tree are a list of files that are impacted by the pull request (coverage changes, file is new or removed).
+#  # `Header` is the top of the comment showing the two commits being merged, the change in coverage, and the diff coverage.
+#  # `Footer` is the bottom of a comment that contains the legend, last updated commits, and docs link.
+#  layout: "reach,diff,flags,tree,header,footer"
+#  # The way Codecov submits comments in your pull requests.`default` means update if exists.Otherwise, post new.
+#  behavior: default
+#  # If `require_changes` set true, comments will now only post when coverage changes.
+#  # Furthermore, if a comment already exists, and a newer commit results in no coverage
+#  # change for the entire pull, the comment will be deleted.
+#  require_changes: no
+#  # Force comments to post on pull requests even if Codecov doesn't
+#  # have coverage reports for either the base or head commit.
+#  require_base: no
+#  require_head: no
+#  # Codecov does not comment until at least 5 builds have been uploaded from the CI pipeline.
+#  # By default, codecov will post and/or update the pull request comment after it processes
+#  # each report uploaded for a particular pull request commit.
+#  # As the Antrea CI process uploads many reports to codecov, this can be confusing for
+#  # team members viewing the pull request as reports are processing.
+#  after_n_builds: 5
+#  # Carryforward Flags are designed for projects that do not upload total coverage for every commit.
+#  show_carryforward_flags: false
 
 github_checks:
   # Specify whether to use GitHub Checks annotations or normal statuses.


### PR DESCRIPTION
Update codecov.yml

1.  Set Codecov comment to false. As the Antrea CI process uploads many
    reports to codecov, and each rebase or commit in the PR will trigger the CI
    pipeline thus uploading more reports, this can be confusing for the team 
    members viewing the pull request as the comment reports are not reliable 
    most of the time.
2. project/status ensures the project ut cov not decrease.

Signed-off-by: Wenqi Qiu <wenqiq@vmware.com>