### PR TITLE
Fix multi-cluster e2e yaml issue

### DIFF
--- a/ci/jenkins/test-mc.sh
+++ b/ci/jenkins/test-mc.sh
@@ -417,11 +417,10 @@ EOF
 
     set -x
     go test -v antrea.io/antrea/multicluster/test/e2e --logs-export-dir `pwd`/antrea-multicluster-test-logs $options
-    set +x
-
     if [[ "$?" != "0" ]]; then
         TEST_FAILURE=true
     fi
+    set +x
     set -e
 }
 

--- a/multicluster/test/yamls/test-acnp-copy-span-ns-isolation.yml
+++ b/multicluster/test/yamls/test-acnp-copy-span-ns-isolation.yml
@@ -6,7 +6,7 @@ metadata:
 spec:
   kind: AntreaClusterNetworkPolicy
   name: strict-namespace-isolation
-  clusternetworkpolicy:
+  clusterNetworkPolicy:
     priority: 1
     tier: securityops
     appliedTo:


### PR DESCRIPTION
1. Update the yaml file for e2e after the json tag change.
2. The returned code for e2e script is not correct. Fix it by moving `set +x`
after returned code of `go test` is captured.

Signed-off-by: Lan Luo <luola@vmware.com>