### PR TITLE
[Flow Aggregator] Determine bucket region in S3 uploader

### DIFF
--- a/pkg/flowaggregator/clickhouseclient/clickhouseclient.go
+++ b/pkg/flowaggregator/clickhouseclient/clickhouseclient.go
@@ -88,11 +88,7 @@ const (
 )
 
 // PrepareClickHouseConnection is used for unit testing
-var (
-	PrepareClickHouseConnection = func(input ClickHouseInput) (string, *sql.DB, error) {
-		return PrepareConnection(input)
-	}
-)
+var PrepareClickHouseConnection = prepareConnection
 
 type stopPayload struct {
 	flushQueue bool
@@ -380,7 +376,7 @@ func (ch *ClickHouseExportProcess) pushRecordsToFrontOfQueue(records []*flowreco
 	}
 }
 
-func PrepareConnection(input ClickHouseInput) (string, *sql.DB, error) {
+func prepareConnection(input ClickHouseInput) (string, *sql.DB, error) {
 	dsn, err := input.GetDataSourceName()
 	if err != nil {
 		return "", nil, fmt.Errorf("error when parsing ClickHouse DSN: %v", err)

--- a/pkg/flowaggregator/exporter/s3_test.go
+++ b/pkg/flowaggregator/exporter/s3_test.go
@@ -15,6 +15,7 @@
 package exporter
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -28,6 +29,13 @@ import (
 )
 
 func TestS3_UpdateOptions(t *testing.T) {
+	GetS3BucketRegionSaved := s3uploader.GetS3BucketRegion
+	s3uploader.GetS3BucketRegion = func(ctx context.Context, bucket string, regionHint string) (string, error) {
+		return "us-west-2", nil
+	}
+	defer func() {
+		s3uploader.GetS3BucketRegion = GetS3BucketRegionSaved
+	}()
 	compress := true
 	opt := &options.Options{
 		Config: &flowaggregator.FlowAggregatorConfig{


### PR DESCRIPTION
We determine the region programmatically in the S3 uploader, using the region "hint" provided in the config.
Before this change, there was a mismatch between the description of the "region" config parameter and its actual implementation in the S3 uploader.

Signed-off-by: Antonin Bas <abas@vmware.com>