### PR TITLE
Automated cherry pick of #4217: Remove an event filter and add e2e test

### DIFF
--- a/multicluster/controllers/multicluster/serviceexport_controller.go
+++ b/multicluster/controllers/multicluster/serviceexport_controller.go
@@ -410,15 +410,11 @@ func (r *ServiceExportReconciler) updateSvcExportStatus(ctx context.Context, req
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ServiceExportReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	// Ignore status update event via GenerationChangedPredicate
-	ignoreStatus := predicate.GenerationChangedPredicate{}
 	// Watch events only when resource version changes
 	versionChange := predicate.ResourceVersionChangedPredicate{}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&k8smcsv1alpha1.ServiceExport{}).
-		WithEventFilter(ignoreStatus).
 		Watches(&source.Kind{Type: &corev1.Service{}}, handler.EnqueueRequestsFromMapFunc(objectMapFunc)).
-		WithEventFilter(versionChange).
 		Watches(&source.Kind{Type: &corev1.Endpoints{}}, handler.EnqueueRequestsFromMapFunc(objectMapFunc)).
 		WithEventFilter(versionChange).
 		WithOptions(controller.Options{

--- a/multicluster/test/e2e/main_test.go
+++ b/multicluster/test/e2e/main_test.go
@@ -111,6 +111,7 @@ func TestConnectivity(t *testing.T) {
 		defer tearDownForServiceExportsTest(t, data)
 		initializeForServiceExportsTest(t, data)
 		t.Run("Case=MCServiceConnectivity", func(t *testing.T) { testMCServiceConnectivity(t, data) })
+		t.Run("Case=ScaleDownMCServiceEndpoints", func(t *testing.T) { testScaleDownMCServiceEndpoints(t, data) })
 		t.Run("Case=ANPToServices", func(t *testing.T) { testANPToServices(t, data) })
 	})
 


### PR DESCRIPTION
Cherry pick of #4217 on release-1.8.

#4217: Add e2e test for Multi-cluster Service Endpoints changes
and remove GenerationChangedPredicate to watch Endpoint change events.

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.