### PR TITLE
Add support for IPsec to UBI based image

### DIFF
--- a/build/images/ovs/Dockerfile.ubi
+++ b/build/images/ovs/Dockerfile.ubi
@@ -45,7 +45,6 @@ LABEL description="A Docker image based on UBI8 which includes Open vSwitch buil
 # Change Repository from UBI8’s to CentOS because UBI8's repository does not contain
 # enough packages required by OVS installation.
 # Using the official RHEL repository would be the best choice but it's not publicly accessible.
-# TODO: update the strongSwan logging config.
 COPY CentOS.repo /tmp/CentOS.repo
 COPY charon-logging.conf /tmp
 COPY --from=ovs-rpms /tmp/ovs-rpms/* /tmp/ovs-rpms/
@@ -54,7 +53,11 @@ RUN rm -f /etc/yum.repos.d/* && mv /tmp/CentOS.repo /etc/yum.repos.d/CentOS.repo
     subscription-manager config --rhsm.manage_repos=0 && \
     yum clean all -y && yum reinstall yum -y && \
     yum install /tmp/ovs-rpms/* -y && yum install epel-release -y && \
-    yum install iptables logrotate strongswan -y && \
+    yum install iptables logrotate -y && \
     mv /etc/logrotate.d/openvswitch /etc/logrotate.d/openvswitch-switch && \
     sed -i "/rotate /a\    #size 100M" /etc/logrotate.d/openvswitch-switch && \
+    # https://github.com/libreswan/libreswan/blob/main/programs/setup/setup.in
+    # The init system is configured to systemd by default. Change it to namespaces
+    # to spawn the ipsec process directly.
+    sed -i 's/^initsystem=.*$/initsystem="namespaces"/' /usr/libexec/ipsec/setup && \
     rm -rf /tmp/* && yum clean all

--- a/build/images/scripts/start_ovs_ipsec
+++ b/build/images/scripts/start_ovs_ipsec
@@ -21,12 +21,18 @@ CONTAINER_NAME="antrea-ipsec"
 
 set -euo pipefail
 
-# TODO: we assume that StrongSwan is used to provide IPsec for OVS, but in
-# theory LibreSwan is also supported.
-
-log_info $CONTAINER_NAME "Checking for StrongSwan prerequisites"
+log_info $CONTAINER_NAME "Checking for IPsec prerequisites"
 
 command -v ipsec >/dev/null 2>&1 || { log_error $CONTAINER_NAME "'ipsec' command not available - are the StrongSwan packages installed?"; exit 1; }
+
+IKE_DAEMON="strongswan"
+IPSEC_VERSION=$(ipsec --version)
+
+if [[ ${IPSEC_VERSION,,} =~ "libreswan" ]]; then
+    IKE_DAEMON="libreswan"
+    # Check the NSS database and initialize it when it is not present.
+    ipsec checknss
+fi
 
 # OVS IPsec requires that the GCM module be loaded (/etc/strongswan.d/ovs.conf),
 # and we use the presence of /etc/strongswan.d/charon/gcm.conf to determine
@@ -34,14 +40,14 @@ command -v ipsec >/dev/null 2>&1 || { log_error $CONTAINER_NAME "'ipsec' command
 # used). Just in case, we only perform the check if the /etc/strongswan.d/charon
 # directory exists. We do not use "ipsec listplugins" as it requires the IKE
 # daemon to be running already.
-if [[ -d "/etc/strongswan.d/charon" && ! -f "/etc/strongswan.d/charon/gcm.conf" ]]; then
+if [[ ${IKE_DAEMON} == "strongswan" && -d "/etc/strongswan.d/charon" && ! -f "/etc/strongswan.d/charon/gcm.conf" ]]; then
     log_error $CONTAINER_NAME "Cannot detect 'gcm' plugin for StrongSwan, make sure it is installed (libstrongswan-standard-plugins package on Debian systems)"
     exit 1
 fi
 
 function start_agents {
-    log_info $CONTAINER_NAME "Starting ovs-monitor-ipsec and strongSwan agents"
-    /usr/share/openvswitch/scripts/ovs-ctl --ike-daemon=strongswan start-ovs-ipsec
+    log_info $CONTAINER_NAME "Starting ovs-monitor-ipsec and "${IKE_DAEMON}" agents"
+    /usr/share/openvswitch/scripts/ovs-ctl --ike-daemon="${IKE_DAEMON}" start-ovs-ipsec
 }
 
 function stop_agents {


### PR DESCRIPTION
1. Do not install strongswan in UBI-based image.
2. Add support for libreswan to `start_ovs_ipsec` start script.

Fixes: #4243

Signed-off-by: Xu Liu <xliu2@vmware.com>