### PR TITLE
Make tunnel csum option configurable and default to false

### DIFF
--- a/build/charts/antrea/README.md
+++ b/build/charts/antrea/README.md
@@ -107,6 +107,7 @@ Kubernetes: `>= 1.16.0-0`
 | trafficEncryptionMode | string | `"none"` | Determines how tunnel traffic is encrypted. Currently encryption only works with encap mode.It must be one of "none", "ipsec", "wireGuard". |
 | transportInterface | string | `""` | Name of the interface on Node which is used for tunneling or routing the traffic across Nodes. |
 | transportInterfaceCIDRs | list | `[]` | Network CIDRs of the interface on Node which is used for tunneling or routing the traffic across Nodes. |
+| tunnelCsum | bool | `false` | TunnelCsum determines whether to compute UDP encapsulation header (Geneve or VXLAN) checksums on outgoing packets. For Linux kernel before Mar 2021, UDP checksum must be present to trigger GRO on the receiver for better performance of Geneve and VXLAN tunnels. The issue has been fixed by https://github.com/torvalds/linux/commit/89e5c58fc1e2857ccdaae506fb8bc5fed57ee063, thus computing UDP checksum is no longer necessary. It should only be set to true when you are using an unpatched Linux kernel and observing poor transfer performance. |
 | tunnelPort | int | `0` | TunnelPort is the destination port for UDP and TCP based tunnel protocols (Geneve, VXLAN, and STT). If zero, it will use the assigned IANA port for the protocol, i.e. 6081 for Geneve, 4789 for VXLAN, and 7471 for STT. |
 | tunnelType | string | `"geneve"` | Tunnel protocol used for encapsulating traffic across Nodes. It must be one of "geneve", "vxlan", "gre", "stt". |
 | webhooks.labelsMutator.enable | bool | `false` |  |

--- a/build/charts/antrea/conf/antrea-agent.conf
+++ b/build/charts/antrea/conf/antrea-agent.conf
@@ -112,6 +112,14 @@ tunnelType: {{ .Values.tunnelType | quote }}
 # and 7471 for STT.
 tunnelPort: {{ .Values.tunnelPort }}
 
+# TunnelCsum determines whether to compute UDP encapsulation header (Geneve or VXLAN) checksums on outgoing
+# packets. For Linux kernel before Mar 2021, UDP checksum must be present to trigger GRO on the receiver for better
+# performance of Geneve and VXLAN tunnels. The issue has been fixed by
+# https://github.com/torvalds/linux/commit/89e5c58fc1e2857ccdaae506fb8bc5fed57ee063, thus computing UDP checksum is
+# no longer necessary.
+# It should only be set to true when you are using an unpatched Linux kernel and observing poor transfer performance.
+tunnelCsum: {{ .Values.tunnelCsum }}
+
 # Determines how tunnel traffic is encrypted. Currently encryption only works with encap mode.
 # It has the following options:
 # - none (default):  Inter-node Pod traffic will not be encrypted.

--- a/build/charts/antrea/values.yaml
+++ b/build/charts/antrea/values.yaml
@@ -14,6 +14,15 @@ tunnelType: "geneve"
 # (Geneve, VXLAN, and STT). If zero, it will use the assigned IANA port for the
 # protocol, i.e. 6081 for Geneve, 4789 for VXLAN, and 7471 for STT.
 tunnelPort: 0
+# -- TunnelCsum determines whether to compute UDP encapsulation header (Geneve
+# or VXLAN) checksums on outgoing packets. For Linux kernel before Mar 2021, UDP
+# checksum must be present to trigger GRO on the receiver for better performance
+# of Geneve and VXLAN tunnels. The issue has been fixed by
+# https://github.com/torvalds/linux/commit/89e5c58fc1e2857ccdaae506fb8bc5fed57ee063,
+# thus computing UDP checksum is no longer necessary.
+# It should only be set to true when you are using an unpatched Linux kernel and
+# observing poor transfer performance.
+tunnelCsum: false
 # -- Determines how tunnel traffic is encrypted. Currently encryption only works
 # with encap mode.It must be one of "none", "ipsec", "wireGuard".
 trafficEncryptionMode: "none"

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -2952,6 +2952,14 @@ data:
     # and 7471 for STT.
     tunnelPort: 0
 
+    # TunnelCsum determines whether to compute UDP encapsulation header (Geneve or VXLAN) checksums on outgoing
+    # packets. For Linux kernel before Mar 2021, UDP checksum must be present to trigger GRO on the receiver for better
+    # performance of Geneve and VXLAN tunnels. The issue has been fixed by
+    # https://github.com/torvalds/linux/commit/89e5c58fc1e2857ccdaae506fb8bc5fed57ee063, thus computing UDP checksum is
+    # no longer necessary.
+    # It should only be set to true when you are using an unpatched Linux kernel and observing poor transfer performance.
+    tunnelCsum: false
+
     # Determines how tunnel traffic is encrypted. Currently encryption only works with encap mode.
     # It has the following options:
     # - none (default):  Inter-node Pod traffic will not be encrypted.
@@ -4140,7 +4148,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 030faeb129b70e3abd5720d2262d122abea2428e342f02836846a3af26f20999
+        checksum/config: ec59529f4b774af0f12a30c31eb48e5494ac6371ce624e872d1e6b76b797325e
       labels:
         app: antrea
         component: antrea-agent
@@ -4381,7 +4389,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 030faeb129b70e3abd5720d2262d122abea2428e342f02836846a3af26f20999
+        checksum/config: ec59529f4b774af0f12a30c31eb48e5494ac6371ce624e872d1e6b76b797325e
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -2952,6 +2952,14 @@ data:
     # and 7471 for STT.
     tunnelPort: 0
 
+    # TunnelCsum determines whether to compute UDP encapsulation header (Geneve or VXLAN) checksums on outgoing
+    # packets. For Linux kernel before Mar 2021, UDP checksum must be present to trigger GRO on the receiver for better
+    # performance of Geneve and VXLAN tunnels. The issue has been fixed by
+    # https://github.com/torvalds/linux/commit/89e5c58fc1e2857ccdaae506fb8bc5fed57ee063, thus computing UDP checksum is
+    # no longer necessary.
+    # It should only be set to true when you are using an unpatched Linux kernel and observing poor transfer performance.
+    tunnelCsum: false
+
     # Determines how tunnel traffic is encrypted. Currently encryption only works with encap mode.
     # It has the following options:
     # - none (default):  Inter-node Pod traffic will not be encrypted.
@@ -4140,7 +4148,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 030faeb129b70e3abd5720d2262d122abea2428e342f02836846a3af26f20999
+        checksum/config: ec59529f4b774af0f12a30c31eb48e5494ac6371ce624e872d1e6b76b797325e
       labels:
         app: antrea
         component: antrea-agent
@@ -4383,7 +4391,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 030faeb129b70e3abd5720d2262d122abea2428e342f02836846a3af26f20999
+        checksum/config: ec59529f4b774af0f12a30c31eb48e5494ac6371ce624e872d1e6b76b797325e
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -2952,6 +2952,14 @@ data:
     # and 7471 for STT.
     tunnelPort: 0
 
+    # TunnelCsum determines whether to compute UDP encapsulation header (Geneve or VXLAN) checksums on outgoing
+    # packets. For Linux kernel before Mar 2021, UDP checksum must be present to trigger GRO on the receiver for better
+    # performance of Geneve and VXLAN tunnels. The issue has been fixed by
+    # https://github.com/torvalds/linux/commit/89e5c58fc1e2857ccdaae506fb8bc5fed57ee063, thus computing UDP checksum is
+    # no longer necessary.
+    # It should only be set to true when you are using an unpatched Linux kernel and observing poor transfer performance.
+    tunnelCsum: false
+
     # Determines how tunnel traffic is encrypted. Currently encryption only works with encap mode.
     # It has the following options:
     # - none (default):  Inter-node Pod traffic will not be encrypted.
@@ -4140,7 +4148,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 9f057043633784b60338fda16b8a439e85a763cbabdf377c1318c56a0e0abc26
+        checksum/config: ae585cead46246e4d15fa336e081caaa51d432909dfd21a22720a1c37b2e37e9
       labels:
         app: antrea
         component: antrea-agent
@@ -4380,7 +4388,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 9f057043633784b60338fda16b8a439e85a763cbabdf377c1318c56a0e0abc26
+        checksum/config: ae585cead46246e4d15fa336e081caaa51d432909dfd21a22720a1c37b2e37e9
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -2965,6 +2965,14 @@ data:
     # and 7471 for STT.
     tunnelPort: 0
 
+    # TunnelCsum determines whether to compute UDP encapsulation header (Geneve or VXLAN) checksums on outgoing
+    # packets. For Linux kernel before Mar 2021, UDP checksum must be present to trigger GRO on the receiver for better
+    # performance of Geneve and VXLAN tunnels. The issue has been fixed by
+    # https://github.com/torvalds/linux/commit/89e5c58fc1e2857ccdaae506fb8bc5fed57ee063, thus computing UDP checksum is
+    # no longer necessary.
+    # It should only be set to true when you are using an unpatched Linux kernel and observing poor transfer performance.
+    tunnelCsum: false
+
     # Determines how tunnel traffic is encrypted. Currently encryption only works with encap mode.
     # It has the following options:
     # - none (default):  Inter-node Pod traffic will not be encrypted.
@@ -4153,7 +4161,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 0d23a6a2c5f2f815ef77b338ae72534ce3715e5f0a84de4c2910ddf2fd013f5b
+        checksum/config: 8dc962ec6575509a540500f9cc1bd399118256fc0485c02705b129922b981c4e
         checksum/ipsec-secret: d0eb9c52d0cd4311b6d252a951126bf9bea27ec05590bed8a394f0f792dcb2a4
       labels:
         app: antrea
@@ -4439,7 +4447,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 0d23a6a2c5f2f815ef77b338ae72534ce3715e5f0a84de4c2910ddf2fd013f5b
+        checksum/config: 8dc962ec6575509a540500f9cc1bd399118256fc0485c02705b129922b981c4e
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -2952,6 +2952,14 @@ data:
     # and 7471 for STT.
     tunnelPort: 0
 
+    # TunnelCsum determines whether to compute UDP encapsulation header (Geneve or VXLAN) checksums on outgoing
+    # packets. For Linux kernel before Mar 2021, UDP checksum must be present to trigger GRO on the receiver for better
+    # performance of Geneve and VXLAN tunnels. The issue has been fixed by
+    # https://github.com/torvalds/linux/commit/89e5c58fc1e2857ccdaae506fb8bc5fed57ee063, thus computing UDP checksum is
+    # no longer necessary.
+    # It should only be set to true when you are using an unpatched Linux kernel and observing poor transfer performance.
+    tunnelCsum: false
+
     # Determines how tunnel traffic is encrypted. Currently encryption only works with encap mode.
     # It has the following options:
     # - none (default):  Inter-node Pod traffic will not be encrypted.
@@ -4140,7 +4148,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: cda023525442c38c869663e4fd703a76cafa307220ae85ec0a8bd393587fa3ed
+        checksum/config: b609bc3b220de28b3fe935093fc7d99dfdc533916597e906a6c627c6233fedbc
       labels:
         app: antrea
         component: antrea-agent
@@ -4380,7 +4388,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: cda023525442c38c869663e4fd703a76cafa307220ae85ec0a8bd393587fa3ed
+        checksum/config: b609bc3b220de28b3fe935093fc7d99dfdc533916597e906a6c627c6233fedbc
       labels:
         app: antrea
         component: antrea-controller

--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -170,6 +170,7 @@ func run(o *Options) error {
 	networkConfig := &config.NetworkConfig{
 		TunnelType:            ovsconfig.TunnelType(o.config.TunnelType),
 		TunnelPort:            o.config.TunnelPort,
+		TunnelCsum:            o.config.TunnelCsum,
 		TrafficEncapMode:      encapMode,
 		TrafficEncryptionMode: encryptionMode,
 		TransportIface:        o.config.TransportInterface,

--- a/pkg/agent/config/node_config.go
+++ b/pkg/agent/config/node_config.go
@@ -192,6 +192,7 @@ type NetworkConfig struct {
 	TrafficEncapMode      TrafficEncapModeType
 	TunnelType            ovsconfig.TunnelType
 	TunnelPort            int32
+	TunnelCsum            bool
 	TrafficEncryptionMode TrafficEncryptionModeType
 	IPsecConfig           IPsecConfig
 	TransportIface        string

--- a/pkg/agent/controller/noderoute/node_route_controller.go
+++ b/pkg/agent/controller/noderoute/node_route_controller.go
@@ -704,8 +704,8 @@ func (c *Controller) createIPSecTunnelPort(nodeName string, nodeIP net.IP) (int3
 			nodeIP,
 			psk,
 			remoteName,
+			ovsPortConfig,
 		)
-		interfaceConfig.OVSPortConfig = ovsPortConfig
 		c.interfaceStore.AddInterface(interfaceConfig)
 	}
 	// GetOFPort will wait for up to 1 second for OVSDB to report the OFPort number.
@@ -746,6 +746,7 @@ func ParseTunnelInterfaceConfig(
 			remoteIP,
 			psk,
 			remoteName,
+			portConfig,
 		)
 	} else {
 		interfaceConfig = interfacestore.NewTunnelInterface(
@@ -753,9 +754,9 @@ func ParseTunnelInterfaceConfig(
 			ovsconfig.TunnelType(portData.IFType),
 			tunnelPort,
 			localIP,
-			csum)
+			csum,
+			portConfig)
 	}
-	interfaceConfig.OVSPortConfig = portConfig
 	return interfaceConfig
 }
 

--- a/pkg/agent/interfacestore/types.go
+++ b/pkg/agent/interfacestore/types.go
@@ -155,16 +155,16 @@ func NewGatewayInterface(gatewayName string) *InterfaceConfig {
 
 // NewTunnelInterface creates InterfaceConfig for the default tunnel port
 // interface.
-func NewTunnelInterface(tunnelName string, tunnelType ovsconfig.TunnelType, destinationPort int32, localIP net.IP, csum bool) *InterfaceConfig {
+func NewTunnelInterface(tunnelName string, tunnelType ovsconfig.TunnelType, destinationPort int32, localIP net.IP, csum bool, ovsPortConfig *OVSPortConfig) *InterfaceConfig {
 	tunnelConfig := &TunnelInterfaceConfig{Type: tunnelType, DestinationPort: destinationPort, LocalIP: localIP, Csum: csum}
-	return &InterfaceConfig{InterfaceName: tunnelName, Type: TunnelInterface, TunnelInterfaceConfig: tunnelConfig}
+	return &InterfaceConfig{InterfaceName: tunnelName, Type: TunnelInterface, TunnelInterfaceConfig: tunnelConfig, OVSPortConfig: ovsPortConfig}
 }
 
 // NewIPSecTunnelInterface creates InterfaceConfig for the IPsec tunnel to the
 // Node.
-func NewIPSecTunnelInterface(interfaceName string, tunnelType ovsconfig.TunnelType, nodeName string, nodeIP net.IP, psk, remoteName string) *InterfaceConfig {
+func NewIPSecTunnelInterface(interfaceName string, tunnelType ovsconfig.TunnelType, nodeName string, nodeIP net.IP, psk, remoteName string, ovsPortConfig *OVSPortConfig) *InterfaceConfig {
 	tunnelConfig := &TunnelInterfaceConfig{Type: tunnelType, NodeName: nodeName, RemoteIP: nodeIP, PSK: psk, RemoteName: remoteName}
-	return &InterfaceConfig{InterfaceName: interfaceName, Type: TunnelInterface, TunnelInterfaceConfig: tunnelConfig}
+	return &InterfaceConfig{InterfaceName: interfaceName, Type: TunnelInterface, TunnelInterfaceConfig: tunnelConfig, OVSPortConfig: ovsPortConfig}
 }
 
 // NewUplinkInterface creates InterfaceConfig for the uplink interface.

--- a/pkg/agent/multicast/mcast_discovery_test.go
+++ b/pkg/agent/multicast/mcast_discovery_test.go
@@ -180,7 +180,6 @@ func generatePacketInForRemoteReport(t *testing.T, snooper *IGMPSnooper, groups 
 }
 
 func createTunnelInterface(tunnelPort uint32, localNodeIP net.IP) *interfacestore.InterfaceConfig {
-	tunnelInterface := interfacestore.NewTunnelInterface("antrea-tun0", ovsconfig.GeneveTunnel, 6081, localNodeIP, false)
-	tunnelInterface.OVSPortConfig = &interfacestore.OVSPortConfig{OFPort: int32(tunnelPort)}
+	tunnelInterface := interfacestore.NewTunnelInterface("antrea-tun0", ovsconfig.GeneveTunnel, 6081, localNodeIP, false, &interfacestore.OVSPortConfig{OFPort: int32(tunnelPort)})
 	return tunnelInterface
 }

--- a/pkg/config/agent/config.go
+++ b/pkg/config/agent/config.go
@@ -71,6 +71,14 @@ type AgentConfig struct {
 	// If zero, it will use the assigned IANA port for the protocol, i.e. 6081 for Geneve, 4789 for VXLAN,
 	// and 7471 for STT.
 	TunnelPort int32 `yaml:"tunnelPort,omitempty"`
+	// TunnelCsum determines whether to compute UDP encapsulation header (Geneve or VXLAN) checksums on outgoing
+	// packets. For Linux kernel before Mar 2021, UDP checksum must be present to trigger GRO on the receiver for better
+	// performance of Geneve and VXLAN tunnels. The issue has been fixed by
+	// https://github.com/torvalds/linux/commit/89e5c58fc1e2857ccdaae506fb8bc5fed57ee063, thus computing UDP checksum is
+	// no longer necessary.
+	// Default is false. It should only be set to true when you are using an unpatched Linux kernel and observing poor
+	// transfer performance.
+	TunnelCsum bool `yaml:"tunnelCsum,omitempty"`
 	// Default MTU to use for the host gateway interface and the network interface of each Pod.
 	// If omitted, antrea-agent will discover the MTU of the Node's primary interface and
 	// also adjust MTU to accommodate for tunnel encapsulation overhead (if applicable).


### PR DESCRIPTION
For Linux kernel before Mar 2021, UDP checksum must be present to trigger GRO on the receiver for better performance of Geneve and VXLAN tunnels. The issue has been fixed in Linux kernel [1], thus computing UDP checksum is no longer necessary.

This patch exposes a configuration parameter TunnelCsum which determines whether to compute UDP encapsulation header (Geneve or VXLAN) checksums on outgoing packets and makes it default to false. It should only be set to true when Nodes run an unpatched Linux kernel and poor transfer performance is observed.

[1] https://github.com/torvalds/linux/commit/89e5c58fc1e2857ccdaae506fb8bc5fed57ee063

Signed-off-by: Quan Tian <qtian@vmware.com>

I have confirmed the following distributions have included the above patch:

- Ubuntu 20.04.3 LTS (Focal Fossa), kernel: 5.4.0-104.118-generic 5.4.166 (>5.4.106 https://lwn.net/Articles/849644/)
- Photon OS 3.0, kernel: 4.19.198-1.ph3-esx (>4.19.181 https://lwn.net/Articles/849645/)

Making it default to false could avoid UDP checksum issues caused by checksum offload in some virtual and physical network adapters. 