### PR TITLE
Fix leak in resourceimport_controller.go

### DIFF
--- a/multicluster/controllers/multicluster/commonarea/acnp_resourceimport_controller.go
+++ b/multicluster/controllers/multicluster/commonarea/acnp_resourceimport_controller.go
@@ -120,9 +120,12 @@ func (r *ResourceImportReconciler) handleResImpDeleteForClusterNetworkPolicy(ctx
 			Name: acnpName,
 		},
 	}
-	if err := r.localClusterClient.Delete(ctx, acnp, &client.DeleteOptions{}); err != nil {
-		return ctrl.Result{}, client.IgnoreNotFound(err)
+	err := client.IgnoreNotFound(r.localClusterClient.Delete(ctx, acnp, &client.DeleteOptions{}))
+	if err != nil {
+		klog.ErrorS(err, "Failed to delete imported ACNP", "acnp", acnpName)
+		return ctrl.Result{}, err
 	}
+	r.installedResImports.Delete(*resImp)
 	return ctrl.Result{}, nil
 }
 

--- a/multicluster/controllers/multicluster/commonarea/acnp_resourceimport_controller_test.go
+++ b/multicluster/controllers/multicluster/commonarea/acnp_resourceimport_controller_test.go
@@ -200,6 +200,9 @@ func TestResourceImportReconciler_handleCopySpanACNPDeleteEvent(t *testing.T) {
 	if err := fakeClient.Get(ctx, types.NamespacedName{Namespace: "", Name: common.AntreaMCSPrefix + acnpImportName}, acnp); !apierrors.IsNotFound(err) {
 		t.Errorf("ResourceImport Reconciler should delete ACNP successfully but got error = %v", err)
 	}
+	if _, exists, _ := r.installedResImports.Get(*acnpResImport); exists {
+		t.Errorf("Reconciler should delete ResImport from installedResImports after successful resource deletion")
+	}
 }
 
 func TestResourceImportReconciler_handleCopySpanACNPUpdateEvent(t *testing.T) {

--- a/multicluster/controllers/multicluster/commonarea/resourceimport_controller_test.go
+++ b/multicluster/controllers/multicluster/commonarea/resourceimport_controller_test.go
@@ -229,10 +229,16 @@ func TestResourceImportReconciler_handleDeleteEvent(t *testing.T) {
 					if err := fakeClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "nginx"}, svcImp); !apierrors.IsNotFound(err) {
 						t.Errorf("ResourceImport Reconciler should delete a ServiceImport successfully but got error = %v", err)
 					}
+					if _, exists, _ := r.installedResImports.Get(*svcResImport); exists {
+						t.Errorf("Reconciler should delete ResImport from installedResImports after successful resource deletion")
+					}
 				case "Endpoints":
 					ep := &corev1.Endpoints{}
 					if err := fakeClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "antrea-mc-nginx"}, ep); !apierrors.IsNotFound(err) {
 						t.Errorf("ResourceImport Reconciler should delete an Endpoint successfully but got error = %v", err)
+					}
+					if _, exists, _ := r.installedResImports.Get(*epResImport); exists {
+						t.Errorf("Reconciler should delete ResImport from installedResImports after successful resource deletion")
 					}
 				}
 			}


### PR DESCRIPTION
The ResourceImport reconciler only adds/updates installed ResourceImports to the installedResImports cache, but never removes them when they are deleted from the K8s API and all corresponding resources are deleted successfully. This PR fixes the above issue.

Signed-off-by: Dyanngg <dingyang@vmware.com>