### PR TITLE
Fix some issues in pkg/ovs/openflow

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	antrea.io/libOpenflow v0.8.1
-	antrea.io/ofnet v0.6.2
+	antrea.io/ofnet v0.6.5
 	github.com/ClickHouse/clickhouse-go v1.5.4
 	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/Mellanox/sriovnet v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 antrea.io/libOpenflow v0.8.1 h1:uxkXvhlPRXAVw26LW6Pt2jCSEh8NR56vQW70YGvy7aU=
 antrea.io/libOpenflow v0.8.1/go.mod h1:CzEJZxDNAupiGxeL5VOw92PsxfyvehEAvE3PiC6gr8o=
-antrea.io/ofnet v0.6.2 h1:CCW2lOVBtEgpbsIT+DatHcYCfQ5+MDTHSSlQrc2Qelc=
-antrea.io/ofnet v0.6.2/go.mod h1:/gjpTqhUpyn8uZnef+ytdCCAeY5oGG1jCr/szPUqVXU=
+antrea.io/ofnet v0.6.5 h1:jMnrU2Iva+jn/j2tyHJ1bSmC7HXtMDYVCJb7pq8L37I=
+antrea.io/ofnet v0.6.5/go.mod h1:/gjpTqhUpyn8uZnef+ytdCCAeY5oGG1jCr/szPUqVXU=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=

--- a/pkg/ovs/openflow/interfaces.go
+++ b/pkg/ovs/openflow/interfaces.go
@@ -322,7 +322,6 @@ type LearnAction interface {
 	LoadRegMark(marks ...*RegMark) LearnAction
 	LoadFieldToField(fromField, toField *RegField) LearnAction
 	LoadXXRegToXXReg(fromXXField, toXXField *XXRegField) LearnAction
-	SetDstMAC(mac net.HardwareAddr) LearnAction
 	Done() FlowBuilder
 }
 

--- a/pkg/ovs/openflow/ofctrl_action.go
+++ b/pkg/ovs/openflow/ofctrl_action.go
@@ -645,12 +645,6 @@ func (a *ofLearnAction) LoadRegMark(marks ...*RegMark) LearnAction {
 	return a
 }
 
-func (a *ofLearnAction) SetDstMAC(mac net.HardwareAddr) LearnAction {
-	toField := &ofctrl.LearnField{Name: "NXM_OF_ETH_DST"}
-	a.nxLearn.AddLoadAction(toField, 48, nil, mac)
-	return a
-}
-
 func (a *ofLearnAction) Done() FlowBuilder {
 	a.flowBuilder.ApplyAction(a.nxLearn)
 	return a.flowBuilder


### PR DESCRIPTION
- Remove `SetDstMAC` from interface `LearnAction` since it is never used.
- Optimize function `ctLabelRange`.
- Fix matcher string of `MatchCTLabelField` of `ofFlowBuilder`.
- Fix matcher string of `MatchICMPv6Type` of `ofFlowBuilder`.
- Fix matcher string of `MatchICMPv6Code` of `ofFlowBuilder`.
- Fix method `MatchCTSrcIP` of `ofFlowBuilder` for matching IPv6 address.
- Fix method `MatchCTDstIP` of `ofFlowBuilder` for matching IPv6 address.
- Fix method `MatchCTSrcIPNet` of `ofFlowBuilder` for matching IPv6 CIDR.
- Fix method `MatchCTDstIPNet` of `ofFlowBuilder` for matching IPv6 CIDR.
- Fix method `MatchCTProtocol` of `ofFlowBuilder` for matching IPv6 protocols.
- Add integration test for `MatchCTSrcIP`, `MatchCTDstIP`, `MatchCTSrcIPNet` and
  `MatchCTDstIPNet`.

Signed-off-by: Hongliang Liu <lhongliang@vmware.com>