### PR TITLE
Remove redundant flow in IngressSecurityClassifierTable

### DIFF
--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -2113,15 +2113,6 @@ func (f *featureNetworkPolicy) ingressClassifierFlows() []binding.Flow {
 			Action().GotoTable(IngressMetricTable.GetID()).
 			Done(),
 	}
-	if f.proxyAll {
-		// This generates the flow to match the NodePort Service packets and forward them to AntreaPolicyIngressRuleTable.
-		// Policies applied on NodePort Service will be enforced in AntreaPolicyIngressRuleTable.
-		flows = append(flows, IngressSecurityClassifierTable.ofTable.BuildFlow(priorityNormal+1).
-			Cookie(cookieID).
-			MatchRegMark(ToNodePortAddressRegMark).
-			Action().GotoTable(AntreaPolicyIngressRuleTable.GetID()).
-			Done())
-	}
 	return flows
 }
 


### PR DESCRIPTION
In IngressSecurityClassifierTable, flows for forwarding the packets destined for Antrea gateway, tunnel and uplink to IngressMetricTable are installed (to bypass IngressMetricTable). The removed flow is used to enforce the +new+trk (only +new+trk packet has ToNodePortAddressRegMark) NodePort to AntreaPolicyIngressRuleTable. However, if the packet needs to be forwarded to the selected Endpoint through Antrea gateway, tunnel and uplink, in another word, the selected Endpoint is not a local Pod, as a result, it is not necessary to enforce the packet to AntreaPolicyIngressRuleTable. If the Endpoint is a local Pod, the packet can be forwarded AntreaPolicyIngressRuleTable since its destination is not Antrea gateway, tunnel or uplink.

Signed-off-by: Hongliang Liu <lhongliang@vmware.com>