### PR TITLE
Add release assets needed for running Antrea on VMs (ExternalNode)

### DIFF
--- a/.github/workflows/process_release.yml
+++ b/.github/workflows/process_release.yml
@@ -218,13 +218,40 @@ jobs:
         asset_path: ./assets/antrea-multicluster-member.yml
         asset_name: antrea-multicluster-member.yml
         asset_content_type: application/octet-stream
+    - name: Upload antrea-agent-linux-x86_64
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./assets/antrea-agent-linux-x86_64
+        asset_name: antrea-agent-linux-x86_64
+        asset_content_type: application/octet-stream
+    - name: Upload antrea-agent-linux-arm64
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./assets/antrea-agent-linux-arm64
+        asset_name: antrea-agent-linux-arm64
+        asset_content_type: application/octet-stream
+    - name: Upload antrea-agent-linux-arm
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./assets/antrea-agent-linux-arm
+        asset_name: antrea-agent-linux-arm
+        asset_content_type: application/octet-stream
     - name: Upload antrea-agent-windows-x86_64.exe
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ./assets/antrea-agent.exe
+        asset_path: ./assets/antrea-agent-windows-x86_64.exe
         asset_name: antrea-agent-windows-x86_64.exe
         asset_content_type: application/octet-stream
     - name: Upload antrea-cni-windows-x86_64.exe
@@ -233,7 +260,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ./assets/antrea-cni.exe
+        asset_path: ./assets/antrea-cni-windows-x86_64.exe
         asset_name: antrea-cni-windows-x86_64.exe
         asset_content_type: application/octet-stream
     - name: Upload Start-AntreaAgent.ps1
@@ -262,6 +289,24 @@ jobs:
         upload_url: ${{ github.event.release.upload_url }}
         asset_path: ./assets/flow-aggregator-chart.tgz
         asset_name: flow-aggregator-chart.tgz
+        asset_content_type: application/octet-stream
+    - name: Upload install-vm.sh
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./assets/install-vm.sh
+        asset_name: install-vm.sh
+        asset_content_type: application/octet-stream
+    - name: Upload install-vm.ps1
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./assets/install-vm.ps1
+        asset_name: install-vm.ps1
         asset_content_type: application/octet-stream
 
   update-website:

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,11 @@ antrea-agent:
 	@mkdir -p $(BINDIR)
 	GOOS=linux $(GO) build -o $(BINDIR) $(GOFLAGS) -ldflags '$(LDFLAGS)' antrea.io/antrea/cmd/antrea-agent
 
+.PHONY: antrea-agent-release
+antrea-agent-release:
+	@mkdir -p $(BINDIR)
+	@CGO_ENABLED=0 $(GO) build -o $(BINDIR)/$(ANTREA_AGENT_BINARY_NAME) $(GOFLAGS) -ldflags '$(LDFLAGS)' antrea.io/antrea/cmd/antrea-agent
+
 .PHONY: antrea-agent-simulator
 antrea-agent-simulator:
 	@mkdir -p $(BINDIR)
@@ -85,14 +90,18 @@ antrea-cni:
 	@mkdir -p $(BINDIR)
 	GOOS=linux CGO_ENABLED=0 $(GO) build -o $(BINDIR) $(GOFLAGS) -ldflags '$(LDFLAGS)' antrea.io/antrea/cmd/antrea-cni
 
+.PHONY: antrea-cni
+antrea-cni-release:
+	@mkdir -p $(BINDIR)
+	@CGO_ENABLED=0 $(GO) build -o $(BINDIR)/$(ANTREA_CNI_BINARY_NAME) $(GOFLAGS) -ldflags '$(LDFLAGS)' antrea.io/antrea/cmd/antrea-cni
+
 .PHONY: antctl-instr-binary
 antctl-instr-binary:
 	@mkdir -p $(BINDIR)
 	GOOS=linux $(GO) test -tags testbincover -covermode count -coverpkg=antrea.io/antrea/pkg/... -c -o $(BINDIR)/antctl-coverage $(GOFLAGS) -ldflags '$(LDFLAGS)' antrea.io/antrea/cmd/antctl
 
 # diable cgo for antrea-cni and antrea-agent: antrea-cni is meant to be
-# installed on the host and the antrea-agent is run as a process on Windows
-# hosts (we also distribute it as a release binary).
+# installed on the host and the antrea-agent is run as a process on Windows.
 .PHONY: windows-bin
 windows-bin:
 	@mkdir -p $(BINDIR)
@@ -206,7 +215,7 @@ antctl: $(ANTCTL_BINARIES)
 
 .PHONY: antctl-release
 antctl-release:
-	@$(GO) build -o $(BINDIR)/$(ANTCTL_BINARY_NAME) $(GOFLAGS) -ldflags '-s -w $(LDFLAGS)' antrea.io/antrea/cmd/antctl
+	@CGO_ENABLED=0 $(GO) build -o $(BINDIR)/$(ANTCTL_BINARY_NAME) $(GOFLAGS) -ldflags '-s -w $(LDFLAGS)' antrea.io/antrea/cmd/antctl
 
 .PHONY: check-copyright
 check-copyright: 


### PR DESCRIPTION
* antrea-agent binaries for Linux
* install-vm.sh and install-vm.ps1

Fixes #4247

Signed-off-by: Antonin Bas <abas@vmware.com>