### PR TITLE
Correcting link to the cookbook

### DIFF
--- a/docs/traffic-control.md
+++ b/docs/traffic-control.md
@@ -275,4 +275,4 @@ spec:
 With the `TrafficControl` capability, Antrea can be used with threat detection
 engines to provide network-based IDS/IPS to Pods. We provide a reference
 cookbook on how to implement IDS using Suricata. For more information, refer to
-the [cookbook](cookbooks/ids).
+the [cookbook](cookbooks/ids/readme).


### PR DESCRIPTION
Changed the link from pointing to the folder to pointing to the file for the page to load.
Signed-off-by: Dani Barkelew dbarkelew@vmware.com