### PR TITLE
Improve the UT coverage for portcache

### DIFF
--- a/pkg/agent/nodeportlocal/portcache/port_table_others_test.go
+++ b/pkg/agent/nodeportlocal/portcache/port_table_others_test.go
@@ -1,0 +1,79 @@
+//go:build !windows
+// +build !windows
+
+// Copyright 2021 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package portcache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+
+	portcachetesting "antrea.io/antrea/pkg/agent/nodeportlocal/portcache/testing"
+	"antrea.io/antrea/pkg/agent/nodeportlocal/rules"
+	rulestesting "antrea.io/antrea/pkg/agent/nodeportlocal/rules/testing"
+)
+
+func TestRestoreRules(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockIPTables := rulestesting.NewMockPodPortRules(mockCtrl)
+	mockPortOpener := portcachetesting.NewMockLocalPortOpener(mockCtrl)
+	portTable := newPortTable(mockIPTables, mockPortOpener)
+	allNPLPorts := []rules.PodNodePort{
+		{
+			NodePort:  nodePort1,
+			PodPort:   1001,
+			PodIP:     podIP,
+			Protocol:  "tcp",
+			Protocols: []string{"tcp"},
+		},
+		{
+			NodePort:  nodePort1,
+			PodPort:   1001,
+			PodIP:     podIP,
+			Protocol:  "udp",
+			Protocols: []string{"udp"},
+		},
+		{
+			NodePort:  nodePort2,
+			PodPort:   1002,
+			PodIP:     podIP,
+			Protocol:  "udp",
+			Protocols: []string{"udp"},
+		},
+	}
+
+	mockIPTables.EXPECT().AddAllRules(gomock.InAnyOrder(allNPLPorts))
+	gomock.InOrder(
+		mockPortOpener.EXPECT().OpenLocalPort(nodePort1, "tcp"),
+		mockPortOpener.EXPECT().OpenLocalPort(nodePort1, "udp"),
+		mockPortOpener.EXPECT().OpenLocalPort(nodePort2, "udp"),
+	)
+
+	syncedCh := make(chan struct{})
+	const timeout = 1 * time.Second
+	portTable.RestoreRules(allNPLPorts, syncedCh)
+	select {
+	case <-syncedCh:
+		break
+	case <-time.After(timeout):
+		// this will not kill the goroutine created by RestoreRules,
+		// which should be acceptable.
+		t.Fatalf("Rule restoration not complete after %v", timeout)
+	}
+}

--- a/pkg/agent/nodeportlocal/portcache/port_table_windows_test.go
+++ b/pkg/agent/nodeportlocal/portcache/port_table_windows_test.go
@@ -1,0 +1,141 @@
+//go:build windows
+// +build windows
+
+// Copyright 2022 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package portcache
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	portcachetesting "antrea.io/antrea/pkg/agent/nodeportlocal/portcache/testing"
+	"antrea.io/antrea/pkg/agent/nodeportlocal/rules"
+	rulestesting "antrea.io/antrea/pkg/agent/nodeportlocal/rules/testing"
+)
+
+func TestRestoreRules(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockPortRules := rulestesting.NewMockPodPortRules(mockCtrl)
+	mockPortOpener := portcachetesting.NewMockLocalPortOpener(mockCtrl)
+	portTable := newPortTable(mockPortRules, mockPortOpener)
+	allNPLPorts := []rules.PodNodePort{
+		{
+			NodePort: nodePort1,
+			PodPort:  1001,
+			PodIP:    podIP,
+			Protocol: "tcp",
+		},
+		{
+			NodePort: nodePort1,
+			PodPort:  1001,
+			PodIP:    podIP,
+			Protocol: "udp",
+		},
+		{
+			NodePort: nodePort2,
+			PodPort:  1002,
+			PodIP:    podIP,
+			Protocol: "udp",
+		},
+	}
+
+	mockPortRules.EXPECT().AddRule(nodePort1, podIP, 1001, "tcp")
+	mockPortRules.EXPECT().AddRule(nodePort1, podIP, 1001, "udp")
+	mockPortRules.EXPECT().AddRule(nodePort2, podIP, 1002, "udp")
+
+	syncedCh := make(chan struct{})
+	err := portTable.RestoreRules(allNPLPorts, syncedCh)
+	require.NoError(t, err)
+}
+
+func TestDeleteRule(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockPortRules := rulestesting.NewMockPodPortRules(mockCtrl)
+	mockPortOpener := portcachetesting.NewMockLocalPortOpener(mockCtrl)
+	portTable := newPortTable(mockPortRules, mockPortOpener)
+	npData := &NodePortData{
+		NodePort: startPort,
+		PodIP:    podIP,
+		PodPort:  1001,
+		Protocol: ProtocolSocketData{
+			Protocol: "tcp",
+		},
+	}
+
+	portTable.addPortTableCache(npData)
+	mockPortRules.EXPECT().DeleteRule(startPort, podIP, 1001, "tcp")
+	err := portTable.DeleteRule(podIP, 1001, "tcp")
+	require.NoError(t, err)
+}
+
+func TestDeleteRulesForPod(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockPortRules := rulestesting.NewMockPodPortRules(mockCtrl)
+	mockPortOpener := portcachetesting.NewMockLocalPortOpener(mockCtrl)
+	portTable := newPortTable(mockPortRules, mockPortOpener)
+
+	npData := []*NodePortData{
+		{
+			NodePort: startPort,
+			PodIP:    podIP,
+			PodPort:  1001,
+			Protocol: ProtocolSocketData{
+				Protocol: "tcp",
+			},
+		},
+		{
+			NodePort: startPort + 1,
+			PodIP:    podIP,
+			PodPort:  1002,
+			Protocol: ProtocolSocketData{
+				Protocol: "udp",
+			},
+		},
+	}
+
+	for _, data := range npData {
+		portTable.addPortTableCache(data)
+		mockPortRules.EXPECT().DeleteRule(data.NodePort, podIP, data.PodPort, data.Protocol.Protocol)
+	}
+
+	err := portTable.DeleteRulesForPod(podIP)
+	require.NoError(t, err)
+}
+
+func TestAddRule(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockPortRules := rulestesting.NewMockPodPortRules(mockCtrl)
+	mockPortOpener := portcachetesting.NewMockLocalPortOpener(mockCtrl)
+	portTable := newPortTable(mockPortRules, mockPortOpener)
+	podPort := 1001
+
+	// Adding the rule the first time should succeed.
+	mockPortRules.EXPECT().AddRule(startPort, podIP, podPort, "udp")
+	gotNodePort, err := portTable.AddRule(podIP, podPort, "udp")
+	require.NoError(t, err)
+	assert.Equal(t, startPort, gotNodePort)
+
+	// Add the same rule the second time should fail.
+	_, err = portTable.AddRule(podIP, podPort, "udp")
+	assert.ErrorContains(t, err, "existing Windows Nodeport entry for")
+}


### PR DESCRIPTION
Added unit test for pkg/agent/nodeportlocal/portcahce package.

For #4142 

Signed-off-by: Pulkit Jain <jainpu@vmware.com>