### PR TITLE
Fix route for IPv6 ClusterIPs

### DIFF
--- a/pkg/agent/util/net.go
+++ b/pkg/agent/util/net.go
@@ -291,7 +291,7 @@ func GetIPWithFamily(ips []net.IP, addrFamily uint8) (net.IP, error) {
 
 // ExtendCIDRWithIP is used for extending an IPNet with an IP.
 func ExtendCIDRWithIP(ipNet *net.IPNet, ip net.IP) (*net.IPNet, error) {
-	cpl := commonPrefixLen(ipNet.IP, ip)
+	cpl := longestCommonPrefixLen(ipNet.IP, ip)
 	if cpl == 0 {
 		return nil, fmt.Errorf("invalid common prefix length")
 	}
@@ -302,10 +302,10 @@ func ExtendCIDRWithIP(ipNet *net.IPNet, ip net.IP) (*net.IPNet, error) {
 	return newIPNet, nil
 }
 
-// This is copied from net/addrselect.go as this function cannot be used outside of standard lib net.
-// Modifies:
+// This is copied from func commonPrefixLen in net/addrselect.go and modified:
 // - Replace argument type IP with argument type net.IP.
-func commonPrefixLen(a, b net.IP) (cpl int) {
+// - Remove the prefix limit (64 bits) for IPv6.
+func longestCommonPrefixLen(a, b net.IP) (cpl int) {
 	if a4 := a.To4(); a4 != nil {
 		a = a4
 	}
@@ -314,11 +314,6 @@ func commonPrefixLen(a, b net.IP) (cpl int) {
 	}
 	if len(a) != len(b) {
 		return 0
-	}
-	// If IPv6, only up to the prefix (first 64 bits)
-	if len(a) > 8 {
-		a = a[:8]
-		b = b[:8]
 	}
 	for len(a) > 0 {
 		if a[0] == b[0] {

--- a/pkg/agent/util/net_test.go
+++ b/pkg/agent/util/net_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"antrea.io/antrea/pkg/util/ip"
@@ -65,4 +66,41 @@ func TestGetDefaultLocalNodeAddr(t *testing.T) {
 		t.Error(err)
 	}
 	t.Logf("IP obtained %s, %v", localAddr, dev)
+}
+
+func TestExtendCIDRWithIP(t *testing.T) {
+	tests := []struct {
+		name         string
+		cidr         string
+		ip           string
+		expectedCIDR string
+		expectedErr  error
+	}{
+		{
+			name:         "IPv4",
+			cidr:         "1.1.1.1/32",
+			ip:           "1.1.1.127",
+			expectedCIDR: "1.1.1.0/25",
+		},
+		{
+			name:         "IPv6",
+			cidr:         "aabb:ccdd::f0/124",
+			ip:           "aabb:ccdd::10",
+			expectedCIDR: "aabb:ccdd::/120",
+		},
+		{
+			name:        "invalid",
+			cidr:        "aabb:ccdd::f0/124",
+			ip:          "1.1.1.127",
+			expectedErr: fmt.Errorf("invalid common prefix length"),
+		},
+	}
+	for _, tt := range tests {
+		_, ipNet, _ := net.ParseCIDR(tt.cidr)
+		ip := net.ParseIP(tt.ip)
+		gotIPNet, gotErr := ExtendCIDRWithIP(ipNet, ip)
+		assert.Equal(t, tt.expectedErr, gotErr)
+		_, expectedIPNet, _ := net.ParseCIDR(tt.expectedCIDR)
+		assert.Equal(t, expectedIPNet, gotIPNet)
+	}
 }


### PR DESCRIPTION
The util function commonPrefixLen returns at most 64 bits prefix length, which leads to the calculated CIDR for IPv6 ClusterIPs being larger than actual value. For example, "aabb:ccdd::1" and "aabb:ccdd::2" should get "aabb:ccdd::/126" but got "aabb:ccdd::/64". The patch removes the 64 bits limit and changes the function name to longestCommonPrefixLen.

Signed-off-by: Quan Tian <qtian@vmware.com>