### PR TITLE
Fix data race in serviceexport_controller

### DIFF
--- a/multicluster/controllers/multicluster/gateway_controller.go
+++ b/multicluster/controllers/multicluster/gateway_controller.go
@@ -202,8 +202,8 @@ func (r *GatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&mcsv1alpha1.Gateway{}).
 		WithOptions(controller.Options{
-			// TODO: add a lock for serviceCIDR if there is any plan to
-			// increase this concurrent number.
+			// TODO: add a lock for r.serviceCIDR and r.localClusterID if
+			//  there is any plan to increase this concurrent number.
 			MaxConcurrentReconciles: 1,
 		}).
 		Complete(r)


### PR DESCRIPTION
Data race can occur if multiple workers read or write r.localClusterID at the same time. 
Refactored the Reconcile loop so that the localClusterID is only set when it is missing.

Signed-off-by: Dyanngg <dingyang@vmware.com>