### PR TITLE
Fix code coverage reporting for unit tests (#4172)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,14 +220,17 @@ add-copyright:
 .linux-test-unit: .coverage
 	@echo
 	@echo "==> Running unit tests <=="
-	$(GO) test -race -coverprofile=.coverage/coverage-unit.txt -covermode=atomic -cover antrea.io/antrea/cmd/... antrea.io/antrea/pkg/... \
-	 antrea.io/antrea/multicluster/cmd/... antrea.io/antrea/multicluster/controllers/...
+	$(GO) test -race -coverpkg=antrea.io/antrea/cmd/...,antrea.io/antrea/pkg/...,antrea.io/antrea/multicluster/cmd/...,antrea.io/antrea/multicluster/controllers/... \
+	  -coverprofile=.coverage/coverage-unit.txt -covermode=atomic \
+	  antrea.io/antrea/cmd/... antrea.io/antrea/pkg/... antrea.io/antrea/multicluster/cmd/... antrea.io/antrea/multicluster/controllers/...
 
 .PHONY: .windows-test-unit
-.windows-test-unit:
+.windows-test-unit: .coverage
 	@echo
 	@echo "==> Running unit tests <=="
-	$(GO) test -race antrea.io/antrea/cmd/... antrea.io/antrea/pkg/...
+	$(GO) test -race -coverpkg=antrea.io/antrea/cmd/...,antrea.io/antrea/pkg/... \
+	  -coverprofile=.coverage/coverage-unit.txt -covermode=atomic \
+	  antrea.io/antrea/cmd/... antrea.io/antrea/pkg/...
 
 .PHONY: tidy
 tidy:
@@ -241,7 +244,7 @@ tidy:
 	@echo
 	@echo "==> Running integration tests <=="
 	@echo "SOME TESTS WILL FAIL IF NOT RUN AS ROOT!"
-	$(GO) test -v -coverpkg=antrea.io/antrea/pkg/... -coverprofile=.coverage/coverage-integration.txt -covermode=atomic -cover antrea.io/antrea/test/integration/...
+	$(GO) test -v -coverpkg=antrea.io/antrea/pkg/... -coverprofile=.coverage/coverage-integration.txt -covermode=atomic antrea.io/antrea/test/integration/...
 
 test-tidy:
 	@echo


### PR DESCRIPTION
* -coverpkg was not set, causing coverage to be missed for some packages with no unit tests, but exercised by unit tests from another package. This is often the case for some deeply nested packages, e.g., `pkg/agent/secondarynetwork/cnipodcache/` is exercised by unit tests defined in `pkg/agent/secondarynetwork/podwatch`.
* coverage was not enabled for Windows unit tests

Signed-off-by: Antonin Bas <abas@vmware.com>

Just to check unit test coverage of release-1.8