### PR TITLE
Fix multicast group unit test

### DIFF
--- a/pkg/apiserver/registry/stats/multicastgroup/rest_test.go
+++ b/pkg/apiserver/registry/stats/multicastgroup/rest_test.go
@@ -135,7 +135,7 @@ func TestRESTList(t *testing.T) {
 			}
 			actualObj, err := r.List(context.TODO(), &internalversion.ListOptions{})
 			require.NoError(t, err)
-			assert.Equal(t, tt.expectedObj, actualObj)
+			assert.ElementsMatch(t, tt.expectedObj.(*statsv1alpha1.MulticastGroupList).Items, actualObj.(*statsv1alpha1.MulticastGroupList).Items)
 		})
 	}
 }


### PR DESCRIPTION
The backend storage stores items in a map, when the List method reads item list from the map, the order of items is random, which caused the test to fail sometimes. The patch fixes it by ignoring the order of the elements when validating.

Signed-off-by: Quan Tian <qtian@vmware.com>

---
Thanks @jainpulkit22 for reporting the issue.