### PR TITLE
Set no-flood config with ports for TrafficControl after restarting

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -271,6 +271,7 @@ func (i *Initializer) initInterfaceStore() error {
 		return intf
 	}
 	ifaceList := make([]*interfacestore.InterfaceConfig, 0, len(ovsPorts))
+	ovsCtlClient := ovsctl.NewClient(i.ovsBridge)
 	for index := range ovsPorts {
 		port := &ovsPorts[index]
 		ovsPort := &interfacestore.OVSPortConfig{
@@ -305,6 +306,9 @@ func (i *Initializer) initInterfaceStore() error {
 				intf = cniserver.ParseOVSPortInterfaceConfig(port, ovsPort, true)
 			case interfacestore.AntreaTrafficControl:
 				intf = trafficcontrol.ParseTrafficControlInterfaceConfig(port, ovsPort)
+				if err := ovsCtlClient.SetPortNoFlood(int(ovsPort.OFPort)); err != nil {
+					klog.ErrorS(err, "Failed to set port with no-flood config", "PortName", port.Name)
+				}
 			default:
 				klog.InfoS("Unknown Antrea interface type", "type", interfaceType)
 			}


### PR DESCRIPTION
OVS ports for TrafficControl is configured with no-flood when it is created. However, after restarting OVS, no-flood config is lost for the ports. This PR adds no-flood config to OVS ports for TrafficControl when initializing Antrea Agent.

Signed-off-by: Hongliang Liu <lhongliang@vmware.com>