### PR TITLE
Automated cherry pick of #4318: Set no-flood config with ports for TrafficControl after

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -256,6 +256,7 @@ func (i *Initializer) initInterfaceStore() error {
 		return intf
 	}
 	ifaceList := make([]*interfacestore.InterfaceConfig, 0, len(ovsPorts))
+	ovsCtlClient := ovsctl.NewClient(i.ovsBridge)
 	for index := range ovsPorts {
 		port := &ovsPorts[index]
 		ovsPort := &interfacestore.OVSPortConfig{
@@ -283,6 +284,9 @@ func (i *Initializer) initInterfaceStore() error {
 				intf = cniserver.ParseOVSPortInterfaceConfig(port, ovsPort, true)
 			case interfacestore.AntreaTrafficControl:
 				intf = trafficcontrol.ParseTrafficControlInterfaceConfig(port, ovsPort)
+				if err := ovsCtlClient.SetPortNoFlood(int(ovsPort.OFPort)); err != nil {
+					klog.ErrorS(err, "Failed to set port with no-flood config", "PortName", port.Name)
+				}
 			default:
 				klog.InfoS("Unknown Antrea interface type", "type", interfaceType)
 			}


### PR DESCRIPTION
Cherry pick of #4318 on release-1.7.

#4318: Set no-flood config with ports for TrafficControl after

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.