### PR TITLE
[ExternalNode]Implement SupportBundleCollection on Agent

### DIFF
--- a/build/charts/antrea/conf/antrea-agent.conf
+++ b/build/charts/antrea/conf/antrea-agent.conf
@@ -67,6 +67,9 @@ featureGates:
 # Enable certificated-based authentication for IPsec.
 {{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "IPsecCertAuth" "default" false) }}
 
+# Enable collecting support bundle files with SupportBundleCollection CRD.
+{{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "SupportBundleCollection" "default" false) }}
+
 # Name of the OpenVSwitch bridge antrea-agent will create and use.
 # Make sure it doesn't conflict with your existing OpenVSwitch bridges.
 ovsBridge: {{ .Values.ovs.bridgeName | quote }}

--- a/build/charts/antrea/templates/agent/clusterrole.yaml
+++ b/build/charts/antrea/templates/agent/clusterrole.yaml
@@ -90,6 +90,20 @@ rules:
       - create
       - get
   - apiGroups:
+      - controlplane.antrea.io
+    resources:
+      - supportbundlecollections
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - controlplane.antrea.io
+    resources:
+      - supportbundlecollections/status
+    verbs:
+      - create
+  - apiGroups:
       - authentication.k8s.io
     resources:
       - tokenreviews

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -2982,6 +2982,9 @@ data:
     # Enable certificated-based authentication for IPsec.
     #  IPsecCertAuth: false
 
+    # Enable collecting support bundle files with SupportBundleCollection CRD.
+    #  SupportBundleCollection: false
+
     # Name of the OpenVSwitch bridge antrea-agent will create and use.
     # Make sure it doesn't conflict with your existing OpenVSwitch bridges.
     ovsBridge: "br-int"
@@ -3572,6 +3575,20 @@ rules:
     verbs:
       - create
       - get
+  - apiGroups:
+      - controlplane.antrea.io
+    resources:
+      - supportbundlecollections
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - controlplane.antrea.io
+    resources:
+      - supportbundlecollections/status
+    verbs:
+      - create
   - apiGroups:
       - authentication.k8s.io
     resources:
@@ -4256,7 +4273,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 4e2311619bbb44c5903fc863c0df9616409367bdc5316eb4c8f677cbab5bad04
+        checksum/config: 5ff20899f04440bb5318887c6743bdd2cf4d784ab7d790812bdb106dde147547
       labels:
         app: antrea
         component: antrea-agent
@@ -4497,7 +4514,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 4e2311619bbb44c5903fc863c0df9616409367bdc5316eb4c8f677cbab5bad04
+        checksum/config: 5ff20899f04440bb5318887c6743bdd2cf4d784ab7d790812bdb106dde147547
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -2982,6 +2982,9 @@ data:
     # Enable certificated-based authentication for IPsec.
     #  IPsecCertAuth: false
 
+    # Enable collecting support bundle files with SupportBundleCollection CRD.
+    #  SupportBundleCollection: false
+
     # Name of the OpenVSwitch bridge antrea-agent will create and use.
     # Make sure it doesn't conflict with your existing OpenVSwitch bridges.
     ovsBridge: "br-int"
@@ -3572,6 +3575,20 @@ rules:
     verbs:
       - create
       - get
+  - apiGroups:
+      - controlplane.antrea.io
+    resources:
+      - supportbundlecollections
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - controlplane.antrea.io
+    resources:
+      - supportbundlecollections/status
+    verbs:
+      - create
   - apiGroups:
       - authentication.k8s.io
     resources:
@@ -4256,7 +4273,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 4e2311619bbb44c5903fc863c0df9616409367bdc5316eb4c8f677cbab5bad04
+        checksum/config: 5ff20899f04440bb5318887c6743bdd2cf4d784ab7d790812bdb106dde147547
       labels:
         app: antrea
         component: antrea-agent
@@ -4499,7 +4516,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 4e2311619bbb44c5903fc863c0df9616409367bdc5316eb4c8f677cbab5bad04
+        checksum/config: 5ff20899f04440bb5318887c6743bdd2cf4d784ab7d790812bdb106dde147547
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -2982,6 +2982,9 @@ data:
     # Enable certificated-based authentication for IPsec.
     #  IPsecCertAuth: false
 
+    # Enable collecting support bundle files with SupportBundleCollection CRD.
+    #  SupportBundleCollection: false
+
     # Name of the OpenVSwitch bridge antrea-agent will create and use.
     # Make sure it doesn't conflict with your existing OpenVSwitch bridges.
     ovsBridge: "br-int"
@@ -3572,6 +3575,20 @@ rules:
     verbs:
       - create
       - get
+  - apiGroups:
+      - controlplane.antrea.io
+    resources:
+      - supportbundlecollections
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - controlplane.antrea.io
+    resources:
+      - supportbundlecollections/status
+    verbs:
+      - create
   - apiGroups:
       - authentication.k8s.io
     resources:
@@ -4256,7 +4273,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 6244d1a441fcf006e951fdced30f7a591bfeb6fcb2eb1277bc1c91304f3cf1c3
+        checksum/config: 2e5482899752673a14f06dc83a064f3627322feb31db5ee8df6d8c8e5c33133b
       labels:
         app: antrea
         component: antrea-agent
@@ -4496,7 +4513,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 6244d1a441fcf006e951fdced30f7a591bfeb6fcb2eb1277bc1c91304f3cf1c3
+        checksum/config: 2e5482899752673a14f06dc83a064f3627322feb31db5ee8df6d8c8e5c33133b
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -2995,6 +2995,9 @@ data:
     # Enable certificated-based authentication for IPsec.
     #  IPsecCertAuth: false
 
+    # Enable collecting support bundle files with SupportBundleCollection CRD.
+    #  SupportBundleCollection: false
+
     # Name of the OpenVSwitch bridge antrea-agent will create and use.
     # Make sure it doesn't conflict with your existing OpenVSwitch bridges.
     ovsBridge: "br-int"
@@ -3585,6 +3588,20 @@ rules:
     verbs:
       - create
       - get
+  - apiGroups:
+      - controlplane.antrea.io
+    resources:
+      - supportbundlecollections
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - controlplane.antrea.io
+    resources:
+      - supportbundlecollections/status
+    verbs:
+      - create
   - apiGroups:
       - authentication.k8s.io
     resources:
@@ -4269,7 +4286,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 3276ac7809f4f3c6ab0d9b9730b46b35cd398d1f9ab7475b8bf47ad757a58f94
+        checksum/config: 4d8f8043d14832434e7a30c7c2f27952f1008fab11a01310f677b33b4be5d2c3
         checksum/ipsec-secret: d0eb9c52d0cd4311b6d252a951126bf9bea27ec05590bed8a394f0f792dcb2a4
       labels:
         app: antrea
@@ -4555,7 +4572,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 3276ac7809f4f3c6ab0d9b9730b46b35cd398d1f9ab7475b8bf47ad757a58f94
+        checksum/config: 4d8f8043d14832434e7a30c7c2f27952f1008fab11a01310f677b33b4be5d2c3
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -2982,6 +2982,9 @@ data:
     # Enable certificated-based authentication for IPsec.
     #  IPsecCertAuth: false
 
+    # Enable collecting support bundle files with SupportBundleCollection CRD.
+    #  SupportBundleCollection: false
+
     # Name of the OpenVSwitch bridge antrea-agent will create and use.
     # Make sure it doesn't conflict with your existing OpenVSwitch bridges.
     ovsBridge: "br-int"
@@ -3572,6 +3575,20 @@ rules:
     verbs:
       - create
       - get
+  - apiGroups:
+      - controlplane.antrea.io
+    resources:
+      - supportbundlecollections
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - controlplane.antrea.io
+    resources:
+      - supportbundlecollections/status
+    verbs:
+      - create
   - apiGroups:
       - authentication.k8s.io
     resources:
@@ -4256,7 +4273,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 9df2527a52bfb6aef5f0b520cde140b5434c77b3da2e85e6e4d2ca713627d1b8
+        checksum/config: a59d7053f2f5d85cc6f24c5c6fd662295e710658caa8708399f19189ae559c03
       labels:
         app: antrea
         component: antrea-agent
@@ -4496,7 +4513,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 9df2527a52bfb6aef5f0b520cde140b5434c77b3da2e85e6e4d2ca713627d1b8
+        checksum/config: a59d7053f2f5d85cc6f24c5c6fd662295e710658caa8708399f19189ae559c03
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/externalnode/conf/antrea-agent.conf
+++ b/build/yamls/externalnode/conf/antrea-agent.conf
@@ -11,6 +11,9 @@ featureGates:
 # Enable collecting and exposing NetworkPolicy statistics.
   NetworkPolicyStats: true
 
+# Enable collecting support bundle files with SupportBundleCollection CRD.
+  SupportBundleCollection: true
+
 # Name of the OpenVSwitch bridge antrea-agent will create and use.
 # Make sure it doesn't conflict with your existing OpenVSwitch bridges.
 #ovsBridge: br-int

--- a/build/yamls/externalnode/vm-agent-rbac.yml
+++ b/build/yamls/externalnode/vm-agent-rbac.yml
@@ -68,6 +68,20 @@ rules:
     verbs:
       - create
       - get
+  - apiGroups:
+      - controlplane.antrea.io
+    resources:
+      - supportbundlecollections
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - controlplane.antrea.io
+    resources:
+      - supportbundlecollections/status
+    verbs:
+      - create
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.24.1
 	github.com/pkg/errors v0.9.1
+	github.com/pkg/sftp v1.13.5
 	github.com/prometheus/client_golang v1.13.1
 	github.com/prometheus/common v0.37.0
 	github.com/sirupsen/logrus v1.9.0
@@ -151,6 +152,7 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/josharian/native v0.0.0-20200817173448-b6b71def0850 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kr/fs v0.1.0 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/mattn/go-colorable v0.1.8 // indirect
 	github.com/mattn/go-isatty v0.0.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -624,6 +624,7 @@ github.com/klauspost/compress v1.11.0/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYs
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/kr/fs v0.1.0 h1:Jskdu9ieNAYnjxsi0LbQp1ulIKZV1LAFgK1tWhpZgl8=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -788,6 +789,8 @@ github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
+github.com/pkg/sftp v1.13.5 h1:a3RLUqkyjYRtBTZJZ1VRrKbN3zhuPLlUc3sphVz81go=
+github.com/pkg/sftp v1.13.5/go.mod h1:wHDZ0IZX6JcBYRK1TH9bcVq8G7TLpVHYIGJRFnmPfxg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
@@ -1042,6 +1045,7 @@ golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm
 golang.org/x/crypto v0.0.0-20210503195802-e9a32991a82e/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20211108221036-ceb1ce70b4fa/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220214200702-86341886e292/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220427172511-eb4f295cb31f/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.1.0 h1:MDRAIl0xIo9Io2xV565hzXHw3zVseKrJKodhohM5CjU=

--- a/pkg/agent/supportbundlecollection/support_bundle_controller.go
+++ b/pkg/agent/supportbundlecollection/support_bundle_controller.go
@@ -1,0 +1,419 @@
+// Copyright 2022 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package supportbundlecollection
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/url"
+	"path"
+	"reflect"
+	"sync"
+	"time"
+
+	"github.com/pkg/sftp"
+	"github.com/spf13/afero"
+	"golang.org/x/crypto/ssh"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/exec"
+
+	"antrea.io/antrea/pkg/agent"
+	agentquerier "antrea.io/antrea/pkg/agent/querier"
+	"antrea.io/antrea/pkg/apis/controlplane"
+	cpv1b2 "antrea.io/antrea/pkg/apis/controlplane/v1beta2"
+	"antrea.io/antrea/pkg/ovs/ovsctl"
+	"antrea.io/antrea/pkg/querier"
+	"antrea.io/antrea/pkg/support"
+	"antrea.io/antrea/pkg/util/compress"
+	"antrea.io/antrea/pkg/util/k8s"
+)
+
+type ProtocolType string
+
+const (
+	sftpProtocol ProtocolType = "sftp"
+
+	controllerName = "SupportBundleCollectionController"
+
+	uploadToFileServerTries      = 5
+	uploadToFileServerRetryDelay = 5 * time.Second
+)
+
+var (
+	emptyWatch      = watch.NewEmptyWatch()
+	defaultFS       = afero.NewOsFs()
+	defaultExecutor = exec.New()
+	// Declared as variable for testing.
+	newAgentDumper = support.NewAgentDumper
+)
+
+type SupportBundleController struct {
+	nodeName                     string
+	supportBundleNodeType        controlplane.SupportBundleCollectionNodeType
+	namespace                    string
+	antreaClientGetter           agent.AntreaClientProvider
+	queue                        workqueue.Interface
+	supportBundleCollection      *cpv1b2.SupportBundleCollection
+	supportBundleCollectionMutex sync.RWMutex
+	ovsCtlClient                 ovsctl.OVSCtlClient
+	aq                           agentquerier.AgentQuerier
+	npq                          querier.AgentNetworkPolicyInfoQuerier
+	v4Enabled                    bool
+	v6Enabled                    bool
+	sftpUploader                 uploader
+}
+
+func NewSupportBundleController(nodeName string,
+	supportBundleNodeType controlplane.SupportBundleCollectionNodeType,
+	namespace string,
+	antreaClientGetter agent.AntreaClientProvider,
+	ovsCtlClient ovsctl.OVSCtlClient,
+	aq agentquerier.AgentQuerier,
+	npq querier.AgentNetworkPolicyInfoQuerier,
+	v4Enabled,
+	v6Enabled bool) *SupportBundleController {
+	c := &SupportBundleController{
+		nodeName:              nodeName,
+		supportBundleNodeType: supportBundleNodeType,
+		namespace:             namespace,
+		antreaClientGetter:    antreaClientGetter,
+		queue:                 workqueue.NewNamed("supportbundle"),
+		ovsCtlClient:          ovsCtlClient,
+		aq:                    aq,
+		npq:                   npq,
+		v4Enabled:             v4Enabled,
+		v6Enabled:             v6Enabled,
+		sftpUploader:          &sftpUploader{},
+	}
+	return c
+}
+
+func (c *SupportBundleController) watchSupportBundleCollections() {
+	klog.Info("Starting watch for SupportBundleCollections")
+	antreaClient, err := c.antreaClientGetter.GetAntreaClient()
+	if err != nil {
+		klog.ErrorS(err, "Failed to get antrea client")
+		return
+	}
+	nodeNameSelector := c.nodeName
+	if c.supportBundleNodeType == controlplane.SupportBundleCollectionNodeTypeExternalNode {
+		nodeNameSelector = k8s.NamespacedName(c.namespace, c.nodeName)
+	}
+	options := metav1.ListOptions{
+		FieldSelector: fields.OneTermEqualSelector("nodeName", nodeNameSelector).String(),
+	}
+	watcher, err := antreaClient.ControlplaneV1beta2().SupportBundleCollections().Watch(context.TODO(), options)
+	if err != nil {
+		klog.ErrorS(err, "Failed to start watch for SupportBundleCollections")
+		return
+	}
+	// Watch method doesn't return error but "emptyWatch" in case of some partial data errors,
+	// e.g. timeout error. Make sure that watcher is not empty and log warning otherwise.
+	if reflect.TypeOf(watcher) == reflect.TypeOf(emptyWatch) {
+		klog.ErrorS(nil, "Failed to start watch for SupportBundleCollections, please ensure antrea service is reachable for the agent")
+		return
+	}
+
+	klog.Info("Started watch for SupportBundleCollections")
+	eventCount := 0
+	defer func() {
+		klog.InfoS("Stopped watch for SupportBundleCollections", "totalItemsReceived", eventCount)
+		watcher.Stop()
+	}()
+
+	for {
+		select {
+		case event, ok := <-watcher.ResultChan():
+			if !ok {
+				return
+			}
+			switch event.Type {
+			case watch.Bookmark:
+				klog.V(2).Info("Received Bookmark event")
+			case watch.Added:
+				c.addSupportBundleCollection(event.Object.(*cpv1b2.SupportBundleCollection))
+				klog.InfoS("Added SupportBundleCollection", "name", event.Object.(*cpv1b2.SupportBundleCollection).Name)
+			case watch.Deleted:
+				c.deleteSupportBundleCollection(event.Object.(*cpv1b2.SupportBundleCollection))
+				klog.InfoS("Deleted SupportBundleCollection", "name", event.Object.(*cpv1b2.SupportBundleCollection).Name)
+			default:
+				klog.ErrorS(nil, "Received unknown event", "event", event.Type)
+				return
+			}
+			eventCount++
+		}
+	}
+}
+
+func (c *SupportBundleController) addSupportBundleCollection(supportBundle *cpv1b2.SupportBundleCollection) {
+	c.supportBundleCollectionMutex.Lock()
+	c.supportBundleCollection = supportBundle
+	c.supportBundleCollectionMutex.Unlock()
+	c.queue.Add(supportBundle.Name)
+}
+
+func (c *SupportBundleController) deleteSupportBundleCollection(supportBundle *cpv1b2.SupportBundleCollection) {
+	c.supportBundleCollectionMutex.Lock()
+	c.supportBundleCollection = nil
+	c.supportBundleCollectionMutex.Unlock()
+	c.queue.Add(supportBundle.Name)
+}
+
+func (c *SupportBundleController) Run(stopCh <-chan struct{}) {
+	defer c.queue.ShutDown()
+
+	klog.InfoS("Starting", "controllerName", controllerName)
+	defer klog.InfoS("Shutting down", "controllerName", controllerName)
+
+	go wait.NonSlidingUntil(c.watchSupportBundleCollections, 5*time.Second, stopCh)
+
+	go wait.Until(c.worker, time.Second, stopCh)
+	<-stopCh
+}
+
+func (c *SupportBundleController) worker() {
+	for c.processNextWorkItem() {
+	}
+}
+
+func (c *SupportBundleController) processNextWorkItem() bool {
+	obj, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(obj)
+
+	if key, ok := obj.(string); !ok {
+		klog.Errorf("Expected string in work queue but got %#v", obj)
+		return true
+	} else if err := c.syncSupportBundleCollection(key); err == nil {
+		klog.InfoS("Successfully synced support bundle", "name", key)
+	} else {
+		// Skip retrying as the time may not meet the requirements for SupportBundle.
+		klog.ErrorS(err, "Error syncing SupportBundleCollection", "name", key)
+	}
+	return true
+}
+
+func (c *SupportBundleController) syncSupportBundleCollection(key string) error {
+	klog.InfoS("Processing support bundle collection", "name", key)
+	supportBundle := func() *cpv1b2.SupportBundleCollection {
+		c.supportBundleCollectionMutex.RLock()
+		defer c.supportBundleCollectionMutex.RUnlock()
+		return c.supportBundleCollection
+	}()
+	if supportBundle == nil {
+		return nil
+	}
+
+	err := c.generateSupportBundle(supportBundle)
+	if err != nil {
+		if updateErr := c.updateSupportBundleCollectionStatus(key, false, err); updateErr != nil {
+			return fmt.Errorf("failed to update failed collection status: %w", updateErr)
+		}
+		return fmt.Errorf("failed to generate support bundle: %w", err)
+	}
+	if updateErr := c.updateSupportBundleCollectionStatus(key, true, err); updateErr != nil {
+		return fmt.Errorf("failed to update complete collection status: %w", updateErr)
+	}
+
+	return nil
+}
+
+func (c *SupportBundleController) generateSupportBundle(supportBundle *cpv1b2.SupportBundleCollection) error {
+	klog.V(2).InfoS("Generating support bundle collection", "name", supportBundle.Name)
+	basedir, err := afero.TempDir(defaultFS, "", "bundle_tmp_")
+	if err != nil {
+		return fmt.Errorf("error when creating temp dir: %w", err)
+	}
+	defer defaultFS.RemoveAll(basedir)
+
+	agentDumper := newAgentDumper(defaultFS, defaultExecutor, c.ovsCtlClient, c.aq, c.npq, supportBundle.SinceTime, c.v4Enabled, c.v6Enabled)
+	if err = agentDumper.DumpLog(basedir); err != nil {
+		return err
+	}
+	if err = agentDumper.DumpHostNetworkInfo(basedir); err != nil {
+		return err
+	}
+	if err = agentDumper.DumpFlows(basedir); err != nil {
+		return err
+	}
+	if err = agentDumper.DumpNetworkPolicyResources(basedir); err != nil {
+		return err
+	}
+	if err = agentDumper.DumpAgentInfo(basedir); err != nil {
+		return err
+	}
+	if err = agentDumper.DumpHeapPprof(basedir); err != nil {
+		return err
+	}
+	if err = agentDumper.DumpOVSPorts(basedir); err != nil {
+		return err
+	}
+
+	outputFile, err := afero.TempFile(defaultFS, "", "bundle_*.tar.gz")
+	if err != nil {
+		return fmt.Errorf("error when creating temp file: %w", err)
+	}
+	defer func() {
+		if err = outputFile.Close(); err != nil {
+			klog.ErrorS(err, "Error when closing output tar file")
+		}
+		if err = defaultFS.Remove(outputFile.Name()); err != nil {
+			klog.ErrorS(err, "Error when removing output tar file", "file", outputFile.Name())
+		}
+
+	}()
+	klog.V(2).InfoS("Compressing support bundle collection", "name", supportBundle.Name)
+	if _, err = compress.PackDir(defaultFS, basedir, outputFile); err != nil {
+		return fmt.Errorf("error when packaging support bundle: %w", err)
+	}
+
+	return c.uploadSupportBundle(supportBundle, outputFile)
+}
+
+func (c *SupportBundleController) uploadSupportBundle(supportBundle *cpv1b2.SupportBundleCollection, outputFile afero.File) error {
+	klog.V(2).InfoS("Uploading support bundle collection", "name", supportBundle.Name)
+	uploader, err := c.getUploaderByProtocol(sftpProtocol)
+	if err != nil {
+		return fmt.Errorf("failed to upload support bundle while getting uploader: %v", err)
+	}
+	if _, err := outputFile.Seek(0, 0); err != nil {
+		return fmt.Errorf("failed to upload support bundle to file server while setting offset: %v", err)
+	}
+	// fileServer.URL should be like: 10.92.23.154:22/path or sftp://10.92.23.154:22/path
+	parsedURL, err := parseUploadUrl(supportBundle.FileServer.URL)
+	if err != nil {
+		return fmt.Errorf("failed to upload support bundle while parsing upload URL: %v", err)
+	}
+	triesLeft := uploadToFileServerTries
+	var uploadErr error
+	for triesLeft > 0 {
+		if uploadErr = c.uploadToFileServer(uploader, supportBundle.Name, parsedURL, &supportBundle.Authentication, outputFile); uploadErr == nil {
+			return nil
+		}
+		triesLeft--
+		if triesLeft == 0 {
+			return fmt.Errorf("failed to upload support bundle after %d attempts", uploadToFileServerTries)
+		}
+		klog.InfoS("Failed to upload support bundle", "UploadError", uploadErr, "TriesLeft", triesLeft)
+		time.Sleep(uploadToFileServerRetryDelay)
+	}
+	return nil
+}
+
+func parseUploadUrl(uploadUrl string) (*url.URL, error) {
+	parsedURL, err := url.Parse(uploadUrl)
+	if err != nil {
+		parsedURL, err = url.Parse("sftp://" + uploadUrl)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if parsedURL.Scheme != "sftp" {
+		return nil, fmt.Errorf("not sftp protocol")
+	}
+	return parsedURL, nil
+}
+
+func (c *SupportBundleController) uploadToFileServer(up uploader, bundleName string, parsedURL *url.URL, serverAuth *cpv1b2.BundleServerAuthConfiguration, tarGzFile io.Reader) error {
+	joinedPath := path.Join(parsedURL.Path, c.nodeName+"_"+bundleName+".tar.gz")
+	cfg := &ssh.ClientConfig{
+		User: serverAuth.BasicAuthentication.Username,
+		Auth: []ssh.AuthMethod{ssh.Password(serverAuth.BasicAuthentication.Password)},
+		// #nosec G106: skip host key check here and users can specify their own checks if needed
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         time.Second,
+	}
+	return up.upload(parsedURL.Host, joinedPath, cfg, tarGzFile)
+}
+
+func (c *SupportBundleController) getUploaderByProtocol(protocol ProtocolType) (uploader, error) {
+	if protocol == sftpProtocol {
+		return c.sftpUploader, nil
+	}
+	return nil, fmt.Errorf("unsupported protocol %s", protocol)
+}
+
+type uploader interface {
+	upload(addr string, path string, config *ssh.ClientConfig, tarGzFile io.Reader) error
+}
+
+type sftpUploader struct {
+}
+
+func (uploader *sftpUploader) upload(address string, path string, config *ssh.ClientConfig, tarGzFile io.Reader) error {
+	conn, err := ssh.Dial("tcp", address, config)
+	if err != nil {
+		return fmt.Errorf("error when connecting to fs server: %w", err)
+	}
+	sftpClient, err := sftp.NewClient(conn)
+	if err != nil {
+		return fmt.Errorf("error when setting up sftp client: %w", err)
+	}
+	defer func() {
+		if err := sftpClient.Close(); err != nil {
+			klog.ErrorS(err, "Error when closing sftp client")
+		}
+	}()
+	targetFile, err := sftpClient.Create(path)
+	if err != nil {
+		return fmt.Errorf("error when creating target file on remote: %v", err)
+	}
+	defer func() {
+		if err := targetFile.Close(); err != nil {
+			klog.ErrorS(err, "Error when closing target file on remote")
+		}
+	}()
+	if written, err := io.Copy(targetFile, tarGzFile); err != nil {
+		return fmt.Errorf("error when copying target file: %v, written: %d", err, written)
+	}
+	klog.InfoS("Successfully upload file to path", "filePath", path)
+	return nil
+}
+
+func (c *SupportBundleController) updateSupportBundleCollectionStatus(key string, complete bool, genErr error) error {
+	antreaClient, err := c.antreaClientGetter.GetAntreaClient()
+	if err != nil {
+		return fmt.Errorf("failed to get antrea client: %w", err)
+	}
+	var errMsg string
+	if genErr != nil {
+		errMsg = genErr.Error()
+	}
+	if updateErr := antreaClient.ControlplaneV1beta2().SupportBundleCollections().UpdateStatus(context.TODO(), key, &cpv1b2.SupportBundleCollectionStatus{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: key,
+		},
+		Nodes: []cpv1b2.SupportBundleCollectionNodeStatus{
+			{
+				NodeName:      c.nodeName,
+				NodeNamespace: c.namespace,
+				NodeType:      string(c.supportBundleNodeType),
+				Completed:     complete,
+				Error:         errMsg,
+			},
+		},
+	}); updateErr != nil {
+		return fmt.Errorf("failed to update collection status for bundle: %s, err: %w", key, err)
+	}
+	return nil
+}

--- a/pkg/agent/supportbundlecollection/support_bundle_controller_test.go
+++ b/pkg/agent/supportbundlecollection/support_bundle_controller_test.go
@@ -1,0 +1,254 @@
+// Copyright 2022 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package supportbundlecollection
+
+import (
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/crypto/ssh"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/exec"
+
+	agentquerier "antrea.io/antrea/pkg/agent/querier"
+	"antrea.io/antrea/pkg/apis/controlplane"
+	cpv1b2 "antrea.io/antrea/pkg/apis/controlplane/v1beta2"
+	"antrea.io/antrea/pkg/client/clientset/versioned"
+	fakeversioned "antrea.io/antrea/pkg/client/clientset/versioned/fake"
+	"antrea.io/antrea/pkg/ovs/ovsctl"
+	"antrea.io/antrea/pkg/querier"
+	"antrea.io/antrea/pkg/support"
+)
+
+type fakeController struct {
+	*SupportBundleController
+	mockController *gomock.Controller
+}
+
+type antreaClientGetter struct {
+	clientset versioned.Interface
+}
+
+func (g *antreaClientGetter) GetAntreaClient() (versioned.Interface, error) {
+	return g.clientset, nil
+}
+
+func newFakeController(t *testing.T) (*fakeController, *fakeversioned.Clientset) {
+	controller := gomock.NewController(t)
+	clientset := &fakeversioned.Clientset{}
+	supportBundleController := NewSupportBundleController("vm1", controlplane.SupportBundleCollectionNodeTypeExternalNode, "vm-ns", &antreaClientGetter{clientset}, nil,
+		nil, nil, true, true)
+	return &fakeController{
+		SupportBundleController: supportBundleController,
+		mockController:          controller,
+	}, clientset
+}
+
+func TestSupportBundleCollectionAdd(t *testing.T) {
+	testcases := []struct {
+		name                    string
+		supportBundleCollection *cpv1b2.SupportBundleCollection
+		expectedCompleted       bool
+		agentDumper             *mockAgentDumper
+		uploader                uploader
+	}{
+		{
+			name:                    "Add SupportBundleCollection",
+			supportBundleCollection: generateSupportbundleCollection("supportBundle1", "sftp://10.220.175.92:22/root/supportbundle"),
+			expectedCompleted:       true,
+			agentDumper:             &mockAgentDumper{},
+			uploader:                &testUploader{},
+		},
+		{
+			name:                    "Add SupportBundleCollection without url prefix",
+			supportBundleCollection: generateSupportbundleCollection("supportBundle2", "10.220.175.92:22/root/supportbundle"),
+			expectedCompleted:       true,
+			agentDumper:             &mockAgentDumper{},
+			uploader:                &testUploader{},
+		},
+		{
+			name:                    "Add SupportBundleCollection with unsupported url prefix",
+			supportBundleCollection: generateSupportbundleCollection("supportBundle3", "https://10.220.175.92:22/root/supportbundle"),
+			expectedCompleted:       false,
+			agentDumper:             &mockAgentDumper{},
+			uploader:                &testUploader{},
+		},
+		{
+			name:                    "Add SupportBundleCollection with retry logics",
+			supportBundleCollection: generateSupportbundleCollection("supportBundle4", "10.220.175.92:22/root/supportbundle"),
+			expectedCompleted:       false,
+			agentDumper:             &mockAgentDumper{},
+			uploader:                &testFailedUploader{},
+		},
+		{
+			name:                    "SupportBundleCollection failed to dump log",
+			supportBundleCollection: generateSupportbundleCollection("supportBundle5", "sftp://10.220.175.92:22/root/supportbundle"),
+			expectedCompleted:       false,
+			agentDumper:             &mockAgentDumper{dumpLogErr: fmt.Errorf("failed to dump log")},
+			uploader:                &testUploader{},
+		},
+		{
+			name:                    "SupportBundleCollection failed to dump flows",
+			supportBundleCollection: generateSupportbundleCollection("supportBundle6", "sftp://10.220.175.92:22/root/supportbundle"),
+			expectedCompleted:       false,
+			agentDumper:             &mockAgentDumper{dumpFlowsErr: fmt.Errorf("failed to dump flows")},
+			uploader:                &testUploader{},
+		},
+		{
+			name:                    "SupportBundleCollection failed to dump host network info",
+			supportBundleCollection: generateSupportbundleCollection("supportBundle7", "sftp://10.220.175.92:22/root/supportbundle"),
+			expectedCompleted:       false,
+			agentDumper:             &mockAgentDumper{dumpHostNetworkInfoErr: fmt.Errorf("failed to dump host network info")},
+			uploader:                &testUploader{},
+		},
+		{
+			name:                    "SupportBundleCollection failed to dump agent info",
+			supportBundleCollection: generateSupportbundleCollection("supportBundle8", "sftp://10.220.175.92:22/root/supportbundle"),
+			expectedCompleted:       false,
+			agentDumper:             &mockAgentDumper{dumpAgentInfoErr: fmt.Errorf("failed to dump agent info")},
+			uploader:                &testUploader{},
+		},
+		{
+			name:                    "SupportBundleCollection failed to dump network policy resources",
+			supportBundleCollection: generateSupportbundleCollection("supportBundle9", "sftp://10.220.175.92:22/root/supportbundle"),
+			expectedCompleted:       false,
+			agentDumper:             &mockAgentDumper{dumpNetworkPolicyResourcesErr: fmt.Errorf("failed to dump network policy resources")},
+			uploader:                &testUploader{},
+		},
+		{
+			name:                    "SupportBundleCollection failed to dump heap Pprof",
+			supportBundleCollection: generateSupportbundleCollection("supportBundle10", "sftp://10.220.175.92:22/root/supportbundle"),
+			expectedCompleted:       false,
+			agentDumper:             &mockAgentDumper{dumpHeapPprofErr: fmt.Errorf("failed to dump heap Pprof")},
+			uploader:                &testUploader{},
+		},
+		{
+			name:                    "SupportBundleCollection failed to dump OVS ports",
+			supportBundleCollection: generateSupportbundleCollection("supportBundle11", "sftp://10.220.175.92:22/root/supportbundle"),
+			expectedCompleted:       false,
+			agentDumper:             &mockAgentDumper{dumpOVSPortsErr: fmt.Errorf("failed to dump OVS ports")},
+			uploader:                &testUploader{},
+		},
+	}
+
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			newAgentDumper = func(fs afero.Fs, executor exec.Interface, ovsCtlClient ovsctl.OVSCtlClient, aq agentquerier.AgentQuerier, npq querier.AgentNetworkPolicyInfoQuerier, since string, v4Enabled, v6Enabled bool) support.AgentDumper {
+				return tt.agentDumper
+			}
+			defer func() {
+				newAgentDumper = support.NewAgentDumper
+			}()
+			controller, clientset := newFakeController(t)
+			controller.sftpUploader = tt.uploader
+			var bundleStatus *cpv1b2.SupportBundleCollectionStatus
+			clientset.AddReactor("update", "supportbundlecollections/status", k8stesting.ReactionFunc(func(action k8stesting.Action) (bool, runtime.Object, error) {
+				bundleStatus = action.(k8stesting.UpdateAction).GetObject().(*cpv1b2.SupportBundleCollectionStatus)
+
+				return false, bundleStatus, nil
+			}))
+			controller.addSupportBundleCollection(tt.supportBundleCollection)
+			controller.syncSupportBundleCollection(tt.supportBundleCollection.Name)
+			assert.Equal(t, tt.expectedCompleted, bundleStatus.Nodes[0].Completed)
+		})
+	}
+}
+
+func TestSupportBundleCollectionDelete(t *testing.T) {
+	controller, _ := newFakeController(t)
+	deletedBundle := generateSupportbundleCollection("deletedBundle", "sftp://10.220.175.92/root/supportbundle")
+	controller.addSupportBundleCollection(deletedBundle)
+	controller.deleteSupportBundleCollection(deletedBundle)
+	assert.NoError(t, controller.syncSupportBundleCollection("deletedBundle"))
+}
+
+type testUploader struct {
+}
+
+func (uploader *testUploader) upload(address string, path string, config *ssh.ClientConfig, tarGzFile io.Reader) error {
+	klog.Info("Called test uploader")
+	return nil
+}
+
+type testFailedUploader struct {
+}
+
+func (uploader *testFailedUploader) upload(address string, path string, config *ssh.ClientConfig, tarGzFile io.Reader) error {
+	klog.Info("Called test uploader for failed case")
+	return fmt.Errorf("uploader failed")
+}
+
+func generateSupportbundleCollection(name string, url string) *cpv1b2.SupportBundleCollection {
+	return &cpv1b2.SupportBundleCollection{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+
+		FileServer: cpv1b2.BundleFileServer{
+			URL: url,
+		},
+		Authentication: cpv1b2.BundleServerAuthConfiguration{
+			BasicAuthentication: &cpv1b2.BasicAuthentication{
+				Username: "AAA",
+				Password: "BBBCCC",
+			},
+		},
+	}
+}
+
+type mockAgentDumper struct {
+	dumpLogErr                    error
+	dumpFlowsErr                  error
+	dumpHostNetworkInfoErr        error
+	dumpAgentInfoErr              error
+	dumpNetworkPolicyResourcesErr error
+	dumpHeapPprofErr              error
+	dumpOVSPortsErr               error
+}
+
+func (d *mockAgentDumper) DumpLog(basedir string) error {
+	return d.dumpLogErr
+}
+
+func (d *mockAgentDumper) DumpFlows(basedir string) error {
+	return d.dumpFlowsErr
+}
+
+func (d *mockAgentDumper) DumpHostNetworkInfo(basedir string) error {
+	return d.dumpHostNetworkInfoErr
+}
+
+func (d *mockAgentDumper) DumpAgentInfo(basedir string) error {
+	return d.dumpAgentInfoErr
+}
+
+func (d *mockAgentDumper) DumpNetworkPolicyResources(basedir string) error {
+	return d.dumpNetworkPolicyResourcesErr
+}
+
+func (d *mockAgentDumper) DumpHeapPprof(basedir string) error {
+	return d.dumpHeapPprofErr
+}
+
+func (d *mockAgentDumper) DumpOVSPorts(basedir string) error {
+	return d.dumpOVSPortsErr
+}

--- a/pkg/apiserver/registry/system/supportbundle/rest.go
+++ b/pkg/apiserver/registry/system/supportbundle/rest.go
@@ -15,15 +15,9 @@
 package supportbundle
 
 import (
-	"archive/tar"
-	"compress/gzip"
 	"context"
-	"crypto/sha256"
 	"fmt"
 	"io"
-	"os"
-	"path/filepath"
-	"strings"
 	"sync"
 	"time"
 
@@ -41,6 +35,7 @@ import (
 	"antrea.io/antrea/pkg/ovs/ovsctl"
 	"antrea.io/antrea/pkg/querier"
 	"antrea.io/antrea/pkg/support"
+	"antrea.io/antrea/pkg/util/compress"
 )
 
 const (
@@ -226,9 +221,9 @@ func (r *supportBundleREST) collect(ctx context.Context, dumpers ...func(string)
 		return nil, fmt.Errorf("error when creating output tarfile: %w", err)
 	}
 	defer outputFile.Close()
-	hashSum, err := packDir(basedir, outputFile)
+	hashSum, err := compress.PackDir(defaultFS, basedir, outputFile)
 	if err != nil {
-		return nil, fmt.Errorf("error when packaing supportBundle: %w", err)
+		return nil, fmt.Errorf("error when packaging supportBundle: %w", err)
 	}
 
 	select {
@@ -302,42 +297,6 @@ func (r *supportBundleREST) clean(ctx context.Context, bundlePath string, durati
 		}()
 	}
 	defaultFS.Remove(bundlePath)
-}
-
-func packDir(dir string, writer io.Writer) ([]byte, error) {
-	hash := sha256.New()
-	gzWriter := gzip.NewWriter(io.MultiWriter(hash, writer))
-	targzWriter := tar.NewWriter(gzWriter)
-	err := afero.Walk(defaultFS, dir, func(filePath string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if !info.Mode().IsRegular() || info.IsDir() {
-			return nil
-		}
-		header, err := tar.FileInfoHeader(info, info.Name())
-		if err != nil {
-			return err
-		}
-		header.Name = strings.TrimPrefix(strings.ReplaceAll(filePath, dir, ""), string(filepath.Separator))
-		err = targzWriter.WriteHeader(header)
-		if err != nil {
-			return err
-		}
-		f, err := defaultFS.Open(filePath)
-		if err != nil {
-			return err
-		}
-		defer f.Close()
-		_, err = io.Copy(targzWriter, f)
-		return err
-	})
-	if err != nil {
-		return nil, err
-	}
-	targzWriter.Close()
-	gzWriter.Close()
-	return hash.Sum(nil), nil
 }
 
 var (

--- a/pkg/util/compress/compress.go
+++ b/pkg/util/compress/compress.go
@@ -1,0 +1,63 @@
+// Copyright 2022 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compress
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"crypto/sha256"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/afero"
+)
+
+func PackDir(fs afero.Fs, dir string, writer io.Writer) ([]byte, error) {
+	hash := sha256.New()
+	gzWriter := gzip.NewWriter(io.MultiWriter(hash, writer))
+	targzWriter := tar.NewWriter(gzWriter)
+	err := afero.Walk(fs, dir, func(filePath string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() || info.IsDir() {
+			return nil
+		}
+		header, err := tar.FileInfoHeader(info, info.Name())
+		if err != nil {
+			return err
+		}
+		header.Name = strings.TrimPrefix(strings.ReplaceAll(filePath, dir, ""), string(filepath.Separator))
+		err = targzWriter.WriteHeader(header)
+		if err != nil {
+			return err
+		}
+		f, err := fs.Open(filePath)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		_, err = io.Copy(targzWriter, f)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	targzWriter.Close()
+	gzWriter.Close()
+	return hash.Sum(nil), nil
+}


### PR DESCRIPTION
Implement SupportBundleCollection on Agent
    
1. Watch internal SupportBundleCollection events.
2. Refactor SupportBundle compression to util.
3. Let agent to collect SupportBundle for Node/ExternalNode.
4. Upload the collected SupportBundle to file server.
    Only SFTP and basic authentication are supported for now.
    
Signed-off-by: Mengdie Song <songm@vmware.com>
