### PR TITLE
Fix wrong label normalization in stale_controller

### DIFF
--- a/multicluster/controllers/multicluster/stale_controller.go
+++ b/multicluster/controllers/multicluster/stale_controller.go
@@ -329,7 +329,7 @@ func (c *StaleResCleanupController) cleanupLabelIdentityResourceExport(commonAre
 			// we append the Namespace name label to the Namespace label set.
 			ns.Labels[corev1.LabelMetadataName] = ns.Name
 		}
-		nsLabelMap[ns.Name] = "namespace:" + labels.FormatLabels(ns.Labels)
+		nsLabelMap[ns.Name] = "ns:" + labels.FormatLabels(ns.Labels)
 	}
 	for _, p := range podList.Items {
 		podNSlabel, ok := nsLabelMap[p.Namespace]

--- a/multicluster/controllers/multicluster/stale_controller_test.go
+++ b/multicluster/controllers/multicluster/stale_controller_test.go
@@ -312,8 +312,8 @@ func TestStaleController_CleanupResourceExport(t *testing.T) {
 			},
 		},
 	}
-	labelNormalizedExist := "namespace:kubernetes.io/metadata.name=test-ns,purpose=test&pod:app=web"
-	labelNormalizedNonExist := "namespace:kubernetes.io/metadata.name=test-ns,purpose=test&pod:app=db"
+	labelNormalizedExist := "ns:kubernetes.io/metadata.name=test-ns,purpose=test&pod:app=web"
+	labelNormalizedNonExist := "ns:kubernetes.io/metadata.name=test-ns,purpose=test&pod:app=db"
 	toKeepLabelResExport := mcsv1alpha1.ResourceExport{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",


### PR DESCRIPTION
The normalized form of a label identity was changed from
'namespace:key=value.....' to 'ns:key=value' for saving data
transferred on the wire.  The change was not reflected in
stale_controller, who calculates all non-stale label identities
in a cluster by doing a Cartesian product of Namespace
labels and Pod labels.

Signed-off-by: Dyanngg <dingyang@vmware.com>