### PR TITLE
Remove deadcode

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,7 +26,7 @@ linters:
   enable:
     - misspell
     - gofmt
-    - deadcode
+    - unused
     - staticcheck
     - gosec
     - goimports

--- a/ci/README.md
+++ b/ci/README.md
@@ -50,11 +50,11 @@ run them locally:
 | **e2e tests**                 | [test/e2e]            | see [test/e2e/README.md]                           | [Github Actions] ([Kind] cluster) + [Jenkins] |
 | **Kubernetes upstream tests** | [upstream Kubernetes] | see [ci/jenkins/README.md]                         | [Jenkins] |
 
-[test/integration]: /test/integration
-[test/e2e]: /test/e2e
-[test/e2e/README.md]: /test/e2e/README.md
-[ci/jenkins/README.md]: /ci/jenkins/README.md
-[Jenkins]: /ci/jenkins/README.md
+[test/integration]: ../test/integration
+[test/e2e]: ../test/e2e
+[test/e2e/README.md]: ../test/e2e/README.md
+[ci/jenkins/README.md]: jenkins/README.md
+[Jenkins]: jenkins/README.md
 [Kind]: https://kind.sigs.k8s.io/
 [upstream Kubernetes]: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/e2e-tests.md
 [`testing`]: https://golang.org/pkg/testing/

--- a/ci/README.md
+++ b/ci/README.md
@@ -67,7 +67,7 @@ As part of CI, we run the following linters via
 
 * [`misspell`](https://github.com/client9/misspell) - Finds commonly misspelled English words in comments.
 * [`gofmt`](https://golang.org/cmd/gofmt/) - Checks whether code was gofmt-ed.
-* [`deadcode`](https://github.com/remyoudompheng/go-misc/tree/master/deadcode) - Finds unused code.
+* [`unused`](https://github.com/dominikh/go-tools/tree/master/unused) - Finds unused code.
 * [`staticcheck`](https://staticcheck.io/) - Static analysis toolset with a large number of tests.
 * [`gosec`](https://github.com/securego/gosec) - Checks for common security problems.
 * [`goimports`](https://godoc.org/golang.org/x/tools/cmd/goimports) - A superset of `gofmt` organizes imports and checks for unused ones.

--- a/hack/netpol/.golangci.yml
+++ b/hack/netpol/.golangci.yml
@@ -11,4 +11,4 @@ linters:
   enable:
     - misspell
     - gofmt
-    - deadcode
+    - unused

--- a/pkg/agent/agent_windows.go
+++ b/pkg/agent/agent_windows.go
@@ -392,30 +392,6 @@ func (i *Initializer) saveHostRoutes() error {
 	return nil
 }
 
-// restoreHostRoutes restores the host routes which are lost when moving the IP
-// configuration of uplink interface to the OVS bridge interface during
-// the antrea network initialize stage.
-// The backup routes are restored after the IP configuration change.
-func (i *Initializer) restoreHostRoutes() error {
-	brInterface, err := net.InterfaceByName(i.ovsBridge)
-	if err != nil {
-		return nil
-	}
-	for _, route := range i.nodeConfig.UplinkNetConfig.Routes {
-		rt := route.(util.Route)
-		newRt := util.Route{
-			LinkIndex:         brInterface.Index,
-			DestinationSubnet: rt.DestinationSubnet,
-			GatewayAddress:    rt.GatewayAddress,
-			RouteMetric:       rt.RouteMetric,
-		}
-		if err := util.NewNetRoute(&newRt); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 func GetTransportIPNetDeviceByName(ifaceName string, ovsBridgeName string) (*net.IPNet, *net.IPNet, *net.Interface, error) {
 	// Find transport Interface in the order: ifaceName -> br-int. Return immediately if
 	// an interface using the specified name exists. Using br-int is for restart agent case.

--- a/pkg/agent/cniserver/server.go
+++ b/pkg/agent/cniserver/server.go
@@ -302,12 +302,6 @@ func (s *CNIServer) unsupportedFieldResponse(key string, value interface{}) *cni
 	return s.generateCNIErrorResponse(cniErrorCode, cniErrorMsg)
 }
 
-func (s *CNIServer) unknownContainerResponse(containerID string) *cnipb.CniCmdResponse {
-	cniErrorCode := cnipb.ErrorCode_UNKNOWN_CONTAINER
-	cniErrorMsg := fmt.Sprintf("Container id  %s is unknown or non-existent", containerID)
-	return s.generateCNIErrorResponse(cniErrorCode, cniErrorMsg)
-}
-
 func (s *CNIServer) tryAgainLaterResponse() *cnipb.CniCmdResponse {
 	cniErrorCode := cnipb.ErrorCode_TRY_AGAIN_LATER
 	cniErrorMsg := "Server is busy, please retry later"

--- a/pkg/agent/flowexporter/connections/connections.go
+++ b/pkg/agent/flowexporter/connections/connections.go
@@ -15,7 +15,6 @@
 package connections
 
 import (
-	"container/heap"
 	"fmt"
 	"sync"
 	"time"
@@ -141,17 +140,6 @@ func lookupServiceProtocol(protoID uint8) (corev1.Protocol, error) {
 		return "", fmt.Errorf("unknown protocol identifier: %d", protoID)
 	}
 	return serviceProto, nil
-}
-
-func (cs *connectionStore) addItemToQueue(connKey flowexporter.ConnectionKey, conn *flowexporter.Connection) {
-	currTime := time.Now()
-	pqItem := &flowexporter.ItemToExpire{
-		Conn:             conn,
-		ActiveExpireTime: currTime.Add(cs.expirePriorityQueue.ActiveFlowTimeout),
-		IdleExpireTime:   currTime.Add(cs.expirePriorityQueue.IdleFlowTimeout),
-	}
-	heap.Push(cs.expirePriorityQueue, pqItem)
-	cs.expirePriorityQueue.KeyToItem[connKey] = pqItem
 }
 
 func (cs *connectionStore) AcquireConnStoreLock() {

--- a/pkg/agent/multicast/mcast_route.go
+++ b/pkg/agent/multicast/mcast_route.go
@@ -11,6 +11,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// nolint: unused // a lot of this code is unused for Windows since the multicast feature is not implemented yet
 package multicast
 
 import (

--- a/pkg/agent/multicast/mcast_route_others.go
+++ b/pkg/agent/multicast/mcast_route_others.go
@@ -16,6 +16,7 @@
 // limitations under the License.
 package multicast
 
+// nolint: unused
 func (c *MRouteClient) parseIGMPMsg(msg []byte) (*parsedIGMPMsg, error) {
 	return nil, nil
 }

--- a/pkg/agent/nodeportlocal/testing/annotations.go
+++ b/pkg/agent/nodeportlocal/testing/annotations.go
@@ -1,6 +1,3 @@
-//go:build !windows
-// +build !windows
-
 // Copyright 2021 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -1972,6 +1972,7 @@ func (f *featureNetworkPolicy) addFlowMatch(fb binding.FlowBuilder, matchKey *ty
 
 // conjunctionExceptionFlow generates the flow to jump to a specific table if both policyRuleConjunction ID and except address are matched.
 // Keeping this for reference to generic exception flow.
+// nolint: unused
 func (f *featureNetworkPolicy) conjunctionExceptionFlow(conjunctionID uint32, tableID uint8, nextTable uint8, matchKey *types.MatchKey, matchValue interface{}) binding.Flow {
 	conjReg := TFIngressConjIDField
 	if tableID == EgressRuleTable.GetID() {

--- a/pkg/agent/proxy/endpoints.go
+++ b/pkg/agent/proxy/endpoints.go
@@ -228,16 +228,3 @@ func (t *endpointsChangesTracker) Update(em types.EndpointsMap, numLocalEndpoint
 		}
 	}
 }
-
-// byEndpoint helps sort Endpoint
-type byEndpoint []k8sproxy.Endpoint
-
-func (p byEndpoint) Len() int {
-	return len(p)
-}
-func (p byEndpoint) Swap(i, j int) {
-	p[i], p[j] = p[j], p[i]
-}
-func (p byEndpoint) Less(i, j int) bool {
-	return p[i].String() < p[j].String()
-}

--- a/pkg/agent/proxy/proxier.go
+++ b/pkg/agent/proxy/proxier.go
@@ -113,7 +113,6 @@ type proxier struct {
 	ofClient                  openflow.Client
 	routeClient               route.Interface
 	nodePortAddresses         []net.IP
-	hostGateWay               string
 	hostname                  string
 	isIPv6                    bool
 	proxyAll                  bool

--- a/pkg/agent/util/winfirewall/winfirewall.go
+++ b/pkg/agent/util/winfirewall/winfirewall.go
@@ -45,8 +45,8 @@ type fwRuleProtocol string
 
 const (
 	fwRuleIPProtocol  fwRuleProtocol = "Any"
-	fwRuleTCPProtocol fwRuleProtocol = "TCP" //nolint: deadcode
-	fwRuleUDPProtocol fwRuleProtocol = "UDP" //nolint: deadcode
+	fwRuleTCPProtocol fwRuleProtocol = "TCP" //nolint: unused
+	fwRuleUDPProtocol fwRuleProtocol = "UDP" //nolint: unused
 )
 
 const (

--- a/pkg/apiserver/registry/system/supportbundle/rest.go
+++ b/pkg/apiserver/registry/system/supportbundle/rest.go
@@ -109,7 +109,6 @@ var (
 
 // supportBundleREST implements REST interfaces for bundle status querying.
 type supportBundleREST struct {
-	bridge       string
 	mode         string
 	statusLocker sync.RWMutex
 	cancelFunc   context.CancelFunc

--- a/pkg/controller/networkpolicy/status_controller.go
+++ b/pkg/controller/networkpolicy/status_controller.go
@@ -71,14 +71,8 @@ type StatusController struct {
 	statuses     map[string]map[string]*controlplane.NetworkPolicyNodeStatus
 	statusesLock sync.RWMutex
 
-	// cnpLister is able to list/get ClusterNetworkPolicies and is populated by the shared informer passed to
-	// NewClusterNetworkPolicyController.
-	cnpLister crdlisters.ClusterNetworkPolicyLister
 	// cnpListerSynced is a function which returns true if the ClusterNetworkPolicies shared informer has been synced at least once.
 	cnpListerSynced cache.InformerSynced
-	// anpLister is able to list/get AntreaNetworkPolicies and is populated by the shared informer passed to
-	// NewNetworkPolicyController.
-	anpLister crdlisters.NetworkPolicyLister
 	// anpListerSynced is a function which returns true if the AntreaNetworkPolicies shared informer has been synced at least once.
 	anpListerSynced cache.InformerSynced
 }

--- a/pkg/flowaggregator/exporter/ipfix.go
+++ b/pkg/flowaggregator/exporter/ipfix.go
@@ -17,7 +17,6 @@ package exporter
 import (
 	"fmt"
 	"hash/fnv"
-	"sync"
 
 	"github.com/google/uuid"
 	ipfixentities "github.com/vmware/go-ipfix/pkg/entities"
@@ -49,8 +48,6 @@ type IPFIXExporter struct {
 	templateIDv6               uint16
 	set                        ipfixentities.Set
 	registry                   ipfix.IPFIXRegistry
-	// mutex protects configuration state from concurrent access
-	mutex sync.Mutex
 }
 
 // genObservationDomainID generates an IPFIX Observation Domain ID when one is not provided by the

--- a/pkg/flowaggregator/flowaggregator.go
+++ b/pkg/flowaggregator/flowaggregator.go
@@ -113,7 +113,6 @@ type flowAggregator struct {
 	k8sClient                   kubernetes.Interface
 	podInformer                 coreinformers.PodInformer
 	numRecordsExported          int64
-	numRecordsReceived          int64
 	updateCh                    chan *options.Options
 	configFile                  string
 	configWatcher               *fsnotify.Watcher

--- a/pkg/ovs/openflow/ofctrl_nxfields.go
+++ b/pkg/ovs/openflow/ofctrl_nxfields.go
@@ -70,10 +70,6 @@ func (f *XXRegField) GetNXFieldName() string {
 	return fmt.Sprintf("%s%d", NxmFieldXXReg, f.regID)
 }
 
-func (f *XXRegField) isFullRange() bool {
-	return f.rng.Length() == 128
-}
-
 func NewXXRegField(id int, start, end uint32) *XXRegField {
 	return &XXRegField{regID: id, rng: &Range{start, end}}
 }
@@ -86,10 +82,6 @@ func (m *CtMark) GetRange() *Range {
 // value of this function is 0b1000.
 func (m *CtMark) GetValue() uint32 {
 	return m.value << m.field.rng.Offset()
-}
-
-func (m *CtMark) isFullRange() bool {
-	return m.field.rng.Length() == 32
 }
 
 func NewCTMarkField(start, end uint32) *CtMarkField {

--- a/pkg/support/dump.go
+++ b/pkg/support/dump.go
@@ -32,7 +32,6 @@ import (
 
 	agentquerier "antrea.io/antrea/pkg/agent/querier"
 	clusterinformationv1beta1 "antrea.io/antrea/pkg/apis/crd/v1beta1"
-	controllerquerier "antrea.io/antrea/pkg/controller/querier"
 	"antrea.io/antrea/pkg/ovs/ovsctl"
 	"antrea.io/antrea/pkg/querier"
 	"antrea.io/antrea/pkg/util/logdir"
@@ -245,7 +244,6 @@ func writeYAMLFile(fs afero.Fs, filePath string, resource string, data interface
 type controllerDumper struct {
 	fs       afero.Fs
 	executor exec.Interface
-	cq       controllerquerier.ControllerQuerier
 	since    string
 }
 

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -728,21 +728,6 @@ func (data *TestData) deployAntrea(option deployAntreaOptions) error {
 	return data.deployAntreaCommon(option.DeployYML(), "", true)
 }
 
-// enableAntreaFlowExporter redeploys Antrea with flow exporter config params enabled.
-func (data *TestData) enableAntreaFlowExporter(ipfixCollector string) error {
-	// Enable flow exporter feature and add related config params to antrea agent configmap.
-	ac := func(config *agentconfig.AgentConfig) {
-		config.FeatureGates["FlowExporter"] = true
-		config.FlowPollInterval = exporterFlowPollInterval.String()
-		config.ActiveFlowExportTimeout = exporterActiveFlowExportTimeout.String()
-		config.IdleFlowExportTimeout = exporterIdleFlowExportTimeout.String()
-		if ipfixCollector != "" {
-			config.FlowCollectorAddr = ipfixCollector
-		}
-	}
-	return data.mutateAntreaConfigMap(nil, ac, false, true)
-}
-
 // deployFlowVisibilityClickHouse deploys ClickHouse operator and DB.
 func (data *TestData) deployFlowVisibilityClickHouse() (string, error) {
 	err := data.CreateNamespace(flowVisibilityNamespace, nil)

--- a/test/e2e/nodeportlocal_test.go
+++ b/test/e2e/nodeportlocal_test.go
@@ -1,6 +1,3 @@
-//go:build !windows
-// +build !windows
-
 // Copyright 2021 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -327,7 +324,6 @@ func checkForNPLListeningSockets(t *testing.T, data *TestData, r *require.Assert
 func deleteNPLRuleFromIPTables(t *testing.T, data *TestData, r *require.Assertions, antreaPod string, rule nplRuleData) {
 	cmd := append([]string{"iptables", "-w", "10", "-t", "nat", "-D", "ANTREA-NODE-PORT-LOCAL"}, buildRuleForPod(rule)...)
 	t.Logf("Deleting iptables rule for %v", rule)
-	const timeout = 30 * time.Second
 	_, _, err := data.RunCommandFromPod(antreaNamespace, antreaPod, agentContainerName, cmd)
 	r.NoError(err, "Error when deleting iptables rule")
 }

--- a/test/e2e/wireguard_test.go
+++ b/test/e2e/wireguard_test.go
@@ -17,7 +17,6 @@ package e2e
 import (
 	"fmt"
 	"net"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -64,38 +63,6 @@ func TestWireGuard(t *testing.T) {
 
 	t.Run("testPodConnectivity", func(t *testing.T) { testPodConnectivity(t, data) })
 	t.Run("testServiceConnectivity", func(t *testing.T) { testServiceConnectivity(t, data) })
-}
-
-func (data *TestData) getWireGuardPeerEndpointsWithHandshake(nodeName string) ([]string, error) {
-	var peerEndpoints []string
-	antreaPodName, err := data.getAntreaPodOnNode(nodeName)
-	if err != nil {
-		return peerEndpoints, err
-	}
-	cmd := []string{"wg"}
-	stdout, stderr, err := data.RunCommandFromPod(antreaNamespace, antreaPodName, "wireguard", cmd)
-	if err != nil {
-		return peerEndpoints, fmt.Errorf("error when running 'wg' on '%s': %v - stdout: %s - stderr: %s", nodeName, err, stdout, stderr)
-	}
-	peerConfigs := strings.Split(stdout, "\n\n")
-	if len(peerConfigs) < 1 {
-		return peerEndpoints, fmt.Errorf("invalid 'wg' output on '%s': %v - stdout: %s - stderr: %s", nodeName, err, stdout, stderr)
-	}
-
-	for _, p := range peerConfigs[1:] {
-		lines := strings.Split(p, "\n")
-		if len(lines) < 2 {
-			return peerEndpoints, fmt.Errorf("invalid WireGuard peer config output - %s", p)
-		}
-		peerEndpoint := strings.TrimPrefix(strings.TrimSpace(lines[1]), "endpoint: ")
-		for _, l := range lines {
-			if strings.Contains(l, "latest handshake") {
-				peerEndpoints = append(peerEndpoints, peerEndpoint)
-				break
-			}
-		}
-	}
-	return peerEndpoints, nil
 }
 
 func testPodConnectivity(t *testing.T, data *TestData) {


### PR DESCRIPTION
The "deadcode" linter is deprecated (no longer maintained) and is now replaced with "unused".
Running this new linter revealed some deadcode throughout the code base, which is being removed by this PR.
I tried to make sure that in each instance, the code was actually supposed to be removed, as opposed to indicative of a bug (e.g., function that should be called for correctness but that is not actually called).

Signed-off-by: Antonin Bas <abas@vmware.com>