### PR TITLE
Add unit test for ipam

### DIFF
--- a/pkg/agent/cniserver/ipam/ipam_delegator.go
+++ b/pkg/agent/cniserver/ipam/ipam_delegator.go
@@ -36,6 +36,12 @@ type IPAMDelegator struct {
 	pluginType string
 }
 
+var (
+	// Declare these two functions as variable for test
+	execPluginWithResultFunc = invoke.ExecPluginWithResult
+	execPluginNoResultFunc   = invoke.ExecPluginWithoutResult
+)
+
 func (d *IPAMDelegator) Add(args *invoke.Args, k8sArgs *argtypes.K8sArgs, networkConfig []byte) (bool, *IPAMResult, error) {
 	var success = false
 	defer func() {
@@ -80,7 +86,7 @@ func (d *IPAMDelegator) Check(args *invoke.Args, k8sArgs *argtypes.K8sArgs, netw
 	return true, nil
 }
 
-var defaultExec = &invoke.DefaultExec{
+var defaultExec invoke.Exec = &invoke.DefaultExec{
 	RawExec: &invoke.RawExec{Stderr: os.Stderr},
 }
 
@@ -111,7 +117,7 @@ func delegateWithResult(delegatePlugin string, networkConfig []byte, args *invok
 		return nil, err
 	}
 
-	return invoke.ExecPluginWithResult(ctx, pluginPath, networkConfig, args, realExec)
+	return execPluginWithResultFunc(ctx, pluginPath, networkConfig, args, realExec)
 }
 
 func delegateNoResult(delegatePlugin string, networkConfig []byte, args *invoke.Args) error {
@@ -121,7 +127,7 @@ func delegateNoResult(delegatePlugin string, networkConfig []byte, args *invoke.
 		return err
 	}
 
-	return invoke.ExecPluginWithoutResult(ctx, pluginPath, networkConfig, args, realExec)
+	return execPluginNoResultFunc(ctx, pluginPath, networkConfig, args, realExec)
 }
 
 func init() {

--- a/pkg/agent/cniserver/ipam/ipam_delegator_test.go
+++ b/pkg/agent/cniserver/ipam/ipam_delegator_test.go
@@ -1,0 +1,240 @@
+// Copyright 2022 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipam
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/containernetworking/cni/pkg/invoke"
+	"github.com/containernetworking/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/types/current"
+	"github.com/containernetworking/cni/pkg/version"
+	"github.com/stretchr/testify/assert"
+
+	argtypes "antrea.io/antrea/pkg/agent/cniserver/types"
+)
+
+type mockPluginInfo struct{}
+
+func (m *mockPluginInfo) Encode(io.Writer) error {
+	return nil
+}
+
+func (m *mockPluginInfo) SupportedVersions() []string {
+	return []string{}
+}
+
+type mockExec struct{}
+
+func (m *mockExec) ExecPlugin(ctx context.Context, pluginPath string, stdinData []byte, environ []string) ([]byte, error) {
+	return []byte{}, nil
+}
+
+func (m *mockExec) FindInPath(plugin string, paths []string) (string, error) {
+	return "", nil
+}
+
+func (m *mockExec) Decode(jsonBytes []byte) (version.PluginInfo, error) {
+	return &mockPluginInfo{}, nil
+}
+
+var (
+	fakeExecWithResultReturnErr = func(ctx context.Context, pluginPath string, netconf []byte, args invoke.CNIArgs, exec invoke.Exec) (types.Result, error) {
+		return &current.Result{
+			CNIVersion: testCNIVersion,
+		}, fmt.Errorf("error")
+	}
+)
+
+func TestAdd(t *testing.T) {
+	defaultExec = &mockExec{}
+	defer func() {
+		defaultExec = &invoke.DefaultExec{
+			RawExec: &invoke.RawExec{Stderr: os.Stderr},
+		}
+	}()
+	testCases := []struct {
+		name               string
+		args               invoke.Args
+		k8sArgs            argtypes.K8sArgs
+		execWithResultFunc func(ctx context.Context, pluginPath string, netconf []byte, args invoke.CNIArgs, exec invoke.Exec) (types.Result, error)
+		execNoResultFunc   func(ctx context.Context, pluginPath string, netconf []byte, args invoke.CNIArgs, exec invoke.Exec) error
+		expectedRes        error
+	}{
+		{
+			name:               "Test Add",
+			args:               invoke.Args{Path: defaultCNIPath},
+			execWithResultFunc: fakeExecWithResult,
+			execNoResultFunc:   fakeExecNoResult,
+			expectedRes:        nil,
+		},
+		{
+			name:               "Test Add no success",
+			args:               invoke.Args{Path: defaultCNIPath},
+			execWithResultFunc: fakeExecWithResultReturnErr,
+			execNoResultFunc:   fakeExecNoResult,
+			expectedRes:        fmt.Errorf("error"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			execPluginWithResultFunc = testCase.execWithResultFunc
+			execPluginNoResultFunc = testCase.execNoResultFunc
+			defer func() {
+				execPluginWithResultFunc = invoke.ExecPluginWithResult
+				execPluginNoResultFunc = invoke.ExecPluginWithoutResult
+			}()
+			d := &IPAMDelegator{pluginType: ipamHostLocal}
+			_, _, err := d.Add(&testCase.args, &testCase.k8sArgs, testNetworkConfig)
+			assert.Equal(t, testCase.expectedRes, err)
+		})
+	}
+}
+
+func TestDel(t *testing.T) {
+	defaultExec = &mockExec{}
+	defer func() {
+		defaultExec = &invoke.DefaultExec{
+			RawExec: &invoke.RawExec{Stderr: os.Stderr},
+		}
+	}()
+	testCases := []struct {
+		name        string
+		args        invoke.Args
+		k8sArgs     argtypes.K8sArgs
+		expectedRes error
+	}{
+		{
+			name:        "Test Del",
+			args:        invoke.Args{Path: defaultCNIPath},
+			expectedRes: nil,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			execPluginWithResultFunc = fakeExecWithResult
+			execPluginNoResultFunc = fakeExecNoResult
+			defer func() {
+				execPluginWithResultFunc = invoke.ExecPluginWithResult
+				execPluginNoResultFunc = invoke.ExecPluginWithoutResult
+			}()
+			d := &IPAMDelegator{pluginType: ipamHostLocal}
+			_, err := d.Del(&testCase.args, &testCase.k8sArgs, testNetworkConfig)
+			assert.Equal(t, testCase.expectedRes, err)
+		})
+	}
+}
+
+func TestCheck(t *testing.T) {
+	defaultExec = &mockExec{}
+	defer func() {
+		defaultExec = &invoke.DefaultExec{
+			RawExec: &invoke.RawExec{Stderr: os.Stderr},
+		}
+	}()
+	testCases := []struct {
+		name        string
+		args        invoke.Args
+		k8sArgs     argtypes.K8sArgs
+		expectedRes error
+	}{
+		{
+			name:        "Test Check",
+			args:        invoke.Args{Path: defaultCNIPath},
+			expectedRes: nil,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			execPluginWithResultFunc = fakeExecWithResult
+			execPluginNoResultFunc = fakeExecNoResult
+			defer func() {
+				execPluginWithResultFunc = invoke.ExecPluginWithResult
+				execPluginNoResultFunc = invoke.ExecPluginWithoutResult
+			}()
+			d := &IPAMDelegator{pluginType: ipamHostLocal}
+			_, err := d.Check(&testCase.args, &testCase.k8sArgs, testNetworkConfig)
+			assert.Equal(t, testCase.expectedRes, err)
+		})
+	}
+}
+
+func TestDelegateWithResult(t *testing.T) {
+	defaultExec = &mockExec{}
+	defer func() {
+		defaultExec = &invoke.DefaultExec{
+			RawExec: &invoke.RawExec{Stderr: os.Stderr},
+		}
+	}()
+	testCases := []struct {
+		name        string
+		args        invoke.Args
+		expectedRes error
+	}{
+		{
+			name:        "Test delegateWithResult",
+			args:        invoke.Args{Path: defaultCNIPath},
+			expectedRes: nil,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			execPluginWithResultFunc = fakeExecWithResult
+			defer func() {
+				execPluginWithResultFunc = invoke.ExecPluginWithResult
+			}()
+			_, err := delegateWithResult(ipamHostLocal, testNetworkConfig, &testCase.args)
+			assert.Equal(t, testCase.expectedRes, err)
+		})
+	}
+}
+
+func TestDelegateNoResult(t *testing.T) {
+	defaultExec = &mockExec{}
+	defer func() {
+		defaultExec = &invoke.DefaultExec{
+			RawExec: &invoke.RawExec{Stderr: os.Stderr},
+		}
+	}()
+	testCases := []struct {
+		name        string
+		args        invoke.Args
+		expectedRes error
+	}{
+		{
+			name:        "Test delegateNoResult",
+			args:        invoke.Args{Path: defaultCNIPath},
+			expectedRes: nil,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			execPluginNoResultFunc = fakeExecNoResult
+			defer func() {
+				execPluginNoResultFunc = invoke.ExecPluginWithoutResult
+			}()
+			assert.Equal(t, testCase.expectedRes, delegateNoResult(ipamHostLocal, testNetworkConfig, &testCase.args))
+		})
+	}
+}

--- a/pkg/agent/cniserver/ipam/ipam_service_test.go
+++ b/pkg/agent/cniserver/ipam/ipam_service_test.go
@@ -1,0 +1,320 @@
+// Copyright 2022 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipam
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/containernetworking/cni/pkg/invoke"
+	"github.com/containernetworking/cni/pkg/types"
+	"github.com/containernetworking/cni/pkg/types/current"
+	"github.com/stretchr/testify/assert"
+
+	argtypes "antrea.io/antrea/pkg/agent/cniserver/types"
+	cnipb "antrea.io/antrea/pkg/apis/cni/v1beta1"
+)
+
+type networkConf struct {
+	CNIVersion string `json:"cniVersion"`
+}
+
+var (
+	testNetworkConfig, _ = json.Marshal(networkConf{CNIVersion: testCNIVersion})
+	fakeExecWithResult   = func(ctx context.Context, pluginPath string, netconf []byte, args invoke.CNIArgs, exec invoke.Exec) (types.Result, error) {
+		return &current.Result{
+			CNIVersion: testCNIVersion,
+		}, nil
+	}
+	fakeExecNoResult = func(ctx context.Context, pluginPath string, netconf []byte, args invoke.CNIArgs, exec invoke.Exec) error {
+		return nil
+	}
+)
+
+func TestArgsFromEnv(t *testing.T) {
+	testCases := []struct {
+		name        string
+		cniArgs     *cnipb.CniCmdArgs
+		exceptedRes *invoke.Args
+	}{
+		{
+			name: "Test argsFromEnv",
+			cniArgs: &cnipb.CniCmdArgs{
+				ContainerId: "container-id",
+				Netns:       "net-ns",
+				Ifname:      "if-name",
+				Path:        "path",
+			},
+			exceptedRes: &invoke.Args{
+				ContainerID: "container-id",
+				NetNS:       "net-ns",
+				IfName:      "if-name",
+				Path:        "path",
+			},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, *tt.exceptedRes, *argsFromEnv(tt.cniArgs))
+		})
+	}
+}
+
+func TestGetIPFromCache(t *testing.T) {
+	testCases := []struct {
+		name        string
+		resultKey   string
+		result      *IPAMResult
+		exceptedRes *IPAMResult
+	}{
+		{
+			name:      "Test ipamResults is not empty",
+			resultKey: "key",
+			result: &IPAMResult{
+				Result: current.Result{
+					CNIVersion: testCNIVersion,
+				},
+				VLANID: 0,
+			},
+			exceptedRes: &IPAMResult{
+				Result: current.Result{
+					CNIVersion: testCNIVersion,
+				},
+				VLANID: 0,
+			},
+		},
+		{
+			name:      "Test ipamResults is empty",
+			resultKey: "emptyKey",
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.result != nil {
+				ipamResults.Store(tt.resultKey, tt.result)
+			}
+
+			res, _ := GetIPFromCache(tt.resultKey)
+			assert.Equal(t, tt.exceptedRes, res)
+		})
+	}
+}
+
+func TestGetAntreaIPAMDriver(t *testing.T) {
+	testCases := []struct {
+		name        string
+		antreaIPAM  *AntreaIPAM
+		expectedRes *AntreaIPAM
+	}{
+		{
+			name: "Get the AntreaIPAM",
+			antreaIPAM: &AntreaIPAM{
+				controller: &AntreaIPAMController{},
+			},
+			expectedRes: &AntreaIPAM{
+				controller: &AntreaIPAMController{},
+			},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.antreaIPAM != nil {
+				ipamDrivers[AntreaIPAMType] = []IPAMDriver{tt.antreaIPAM}
+			}
+			assert.Equal(t, *tt.expectedRes.controller, *getAntreaIPAMDriver().controller)
+		})
+	}
+}
+
+func TestExecIPAMAdd(t *testing.T) {
+	defaultExec = &mockExec{}
+	defer func() {
+		defaultExec = &invoke.DefaultExec{
+			RawExec: &invoke.RawExec{Stderr: os.Stderr},
+		}
+	}()
+	testCases := []struct {
+		name        string
+		cniArgs     *cnipb.CniCmdArgs
+		k8sArgs     *argtypes.K8sArgs
+		ipamType    string
+		resultKey   string
+		exceptedRes error
+	}{
+		{
+			name:        "No suitable IPAM driver found",
+			cniArgs:     &cnipb.CniCmdArgs{},
+			k8sArgs:     &argtypes.K8sArgs{},
+			ipamType:    "",
+			resultKey:   "",
+			exceptedRes: fmt.Errorf("No suitable IPAM driver found"),
+		},
+		{
+			name: "Exec successfully",
+			cniArgs: &cnipb.CniCmdArgs{
+				ContainerId:          "container-id",
+				Netns:                "net-ns",
+				Ifname:               "if-name",
+				Path:                 "path",
+				NetworkConfiguration: testNetworkConfig,
+			},
+			k8sArgs:     &argtypes.K8sArgs{},
+			ipamType:    ipamHostLocal,
+			resultKey:   "",
+			exceptedRes: nil,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			RegisterIPAMDriver(ipamHostLocal, &IPAMDelegator{pluginType: ipamHostLocal})
+			execPluginWithResultFunc = fakeExecWithResult
+			_, err := ExecIPAMAdd(tt.cniArgs, tt.k8sArgs, tt.ipamType, tt.resultKey)
+			assert.Equal(t, tt.exceptedRes, err)
+		})
+	}
+}
+
+func TestExecIPAMDelete(t *testing.T) {
+	defaultExec = &mockExec{}
+	defer func() {
+		defaultExec = &invoke.DefaultExec{
+			RawExec: &invoke.RawExec{Stderr: os.Stderr},
+		}
+	}()
+	testCases := []struct {
+		name        string
+		cniArgs     *cnipb.CniCmdArgs
+		k8sArgs     *argtypes.K8sArgs
+		ipamType    string
+		resultKey   string
+		exceptedRes error
+	}{
+		{
+			name:        "No suitable IPAM driver found",
+			cniArgs:     &cnipb.CniCmdArgs{},
+			k8sArgs:     &argtypes.K8sArgs{},
+			ipamType:    "",
+			resultKey:   "",
+			exceptedRes: fmt.Errorf("No suitable IPAM driver found"),
+		},
+		{
+			name: "Exec successfully",
+			cniArgs: &cnipb.CniCmdArgs{
+				ContainerId:          "container-id",
+				Netns:                "net-ns",
+				Ifname:               "if-name",
+				Path:                 "path",
+				NetworkConfiguration: testNetworkConfig,
+			},
+			k8sArgs:     &argtypes.K8sArgs{},
+			ipamType:    ipamHostLocal,
+			resultKey:   "",
+			exceptedRes: nil,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			RegisterIPAMDriver(ipamHostLocal, &IPAMDelegator{pluginType: ipamHostLocal})
+			execPluginNoResultFunc = fakeExecNoResult
+			err := ExecIPAMDelete(tt.cniArgs, tt.k8sArgs, tt.ipamType, tt.resultKey)
+			assert.Equal(t, tt.exceptedRes, err)
+		})
+	}
+}
+
+func TestExecIPAMCheck(t *testing.T) {
+	defaultExec = &mockExec{}
+	defer func() {
+		defaultExec = &invoke.DefaultExec{
+			RawExec: &invoke.RawExec{Stderr: os.Stderr},
+		}
+	}()
+	testCases := []struct {
+		name        string
+		cniArgs     *cnipb.CniCmdArgs
+		k8sArgs     *argtypes.K8sArgs
+		ipamType    string
+		exceptedRes error
+	}{
+		{
+			name:        "No suitable IPAM driver found",
+			cniArgs:     &cnipb.CniCmdArgs{},
+			k8sArgs:     &argtypes.K8sArgs{},
+			ipamType:    "",
+			exceptedRes: fmt.Errorf("No suitable IPAM driver found"),
+		},
+		{
+			name: "Exec successfully",
+			cniArgs: &cnipb.CniCmdArgs{
+				ContainerId:          "container-id",
+				Netns:                "net-ns",
+				Ifname:               "if-name",
+				Path:                 "path",
+				NetworkConfiguration: testNetworkConfig,
+			},
+			k8sArgs:     &argtypes.K8sArgs{},
+			ipamType:    ipamHostLocal,
+			exceptedRes: nil,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			RegisterIPAMDriver(ipamHostLocal, &IPAMDelegator{pluginType: ipamHostLocal})
+			execPluginNoResultFunc = fakeExecNoResult
+			err := ExecIPAMCheck(tt.cniArgs, tt.k8sArgs, tt.ipamType)
+			assert.Equal(t, tt.exceptedRes, err)
+		})
+	}
+}
+
+func TestIsIPAMTypeValid(t *testing.T) {
+	testCases := []struct {
+		name         string
+		existingType string
+		ipamType     string
+		exceptedRes  bool
+	}{
+		{
+			"Test valid ipam type",
+			"existingType",
+			"existingType",
+			true,
+		},
+		{
+			"Test invalid ipam type",
+			"",
+			"invalidType",
+			false,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.existingType != "" {
+				ipamDrivers[tt.existingType] = []IPAMDriver{}
+			}
+			assert.Equal(t, tt.exceptedRes, IsIPAMTypeValid(tt.ipamType))
+		})
+	}
+}


### PR DESCRIPTION
Add unit test for `antrea/pkg/agent/cniserver/ipam`. The code coverage has improved from 30% to about 79%. 