### PR TITLE
Implement windows port unification on external node and kubernetes node

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -308,7 +308,7 @@ func (i *Initializer) initInterfaceStore() error {
 			case interfacestore.AntreaIPsecTunnel:
 				intf = parseTunnelInterfaceFunc(port, ovsPort)
 			case interfacestore.AntreaHost:
-				if port.Name == i.ovsBridge {
+				if i.nodeConfig.Type == config.K8sNode {
 					// Need not to load the OVS bridge port to the interfaceStore
 					intf = nil
 				} else {

--- a/pkg/agent/config/node_config.go
+++ b/pkg/agent/config/node_config.go
@@ -25,12 +25,16 @@ const (
 	// Invalid ofport_request number is in range 1 to 65,279. For ofport_request number not in the range, OVS
 	// ignore the it and automatically assign a port number.
 	// Here we use an invalid port number "0" to request for automatically port allocation.
-	AutoAssignedOFPort = 0
-	DefaultTunOFPort   = 1
-	HostGatewayOFPort  = 2
-	UplinkOFPort       = 3
+	DefaultTunOFPort  = 1
+	HostGatewayOFPort = 2
+	UplinkOFPort      = 3
+	HostOFPort        = 4
+	OfPortRange       = 65279
 	// 0xfffffffe is a reserved port number in OpenFlow protocol, which is dedicated for the Bridge interface.
 	BridgeOFPort = 0xfffffffe
+	// BridgeOFMask is a mask for port number between 65280 and 65535. Openflow supported ranges are 0 through 65279
+	// and 0xffffff00 through 0xffffffff.
+	BridgeOFMask = 0xffff0000
 )
 
 const (
@@ -166,8 +170,10 @@ type NodeConfig struct {
 	TunnelOFPort uint32
 	// HostInterfaceOFPort is the OpenFlow port number of the host interface allocated by OVS. The host interface is the
 	// one which the IP/MAC of the uplink is moved to. If the host interface is the OVS bridge interface (br-int), the
-	// value is config.BridgeOFPort.
+	// value is config.HostOFPort.
 	HostInterfaceOFPort uint32
+	// The name of the host interface
+	HostInterfaceName string
 	// The config of the gateway interface on the OVS bridge.
 	GatewayConfig *GatewayConfig
 	// The config of the OVS bridge uplink interface. Only for Windows Node.

--- a/pkg/agent/route/route_windows.go
+++ b/pkg/agent/route/route_windows.go
@@ -75,9 +75,9 @@ func NewClient(networkConfig *config.NetworkConfig, noSNAT, proxyAll, connectUpl
 func (c *Client) Initialize(nodeConfig *config.NodeConfig, done func()) error {
 	c.nodeConfig = nodeConfig
 	PodCIDRIPv4 = nodeConfig.PodIPv4CIDR
-	bridgeInf, err := net.InterfaceByName(nodeConfig.OVSBridge)
+	bridgeInf, err := net.InterfaceByName(nodeConfig.HostInterfaceName)
 	if err != nil {
-		return fmt.Errorf("failed to find the interface %s: %v", nodeConfig.OVSBridge, err)
+		return fmt.Errorf("failed to find the interface %s: %v", nodeConfig.HostInterfaceName, err)
 	}
 	c.bridgeInfIndex = bridgeInf.Index
 	if err := c.initFwRules(); err != nil {

--- a/pkg/agent/route/route_windows_test.go
+++ b/pkg/agent/route/route_windows_test.go
@@ -60,10 +60,14 @@ func TestRouteOperation(t *testing.T) {
 
 	require.Nil(t, err)
 	nodeConfig := &config.NodeConfig{
-		OVSBridge: "Loopback Pseudo-Interface 1",
+		HostInterfaceName: "Loopback Pseudo-Interface 1",
 		GatewayConfig: &config.GatewayConfig{
 			Name:      hostGateway,
 			LinkIndex: gwLink,
+		},
+		UplinkNetConfig: &config.AdapterNetConfig{
+			Name:  hostGateway,
+			Index: gwLink,
 		},
 	}
 	called := false


### PR DESCRIPTION
Rename the local br-int port and uplink port to the name of the uplink port and "uplink port~"
in order to align with the port naming conventions of the external node.

Signed-off-by: Shuyang Xin <gavinx@vmware.com>