### PR TITLE
Extend "antctl mc get joinconfig" to print member token Secret

### DIFF
--- a/docs/multicluster/antctl.md
+++ b/docs/multicluster/antctl.md
@@ -35,7 +35,7 @@ output format.
 antctl mc get clusterset [NAME] [-n NAMESPACE] [-o json|yaml] [-A]
 antctl mc get resourceimport [NAME] [-n NAMESPACE] [-o json|yaml] [-A]
 antctl mc get resourceexport [NAME] [-n NAMESPACE] [-clusterid CLUSTERID] [-o json|yaml] [-A]
-antctl mc get joinconfig [-n NAMESPACE]
+antctl mc get joinconfig [--member-token TOKEN_NAME] [-n NAMESPACE]
 antctl mc get membertoken [NAME] [-n NAMESPACE] [-o json|yaml] [-A]
 ```
 

--- a/pkg/antctl/raw/multicluster/common/common_test.go
+++ b/pkg/antctl/raw/multicluster/common/common_test.go
@@ -17,8 +17,6 @@ package common
 import (
 	"bytes"
 	"context"
-	"log"
-	"os"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -418,13 +416,8 @@ func TestCreateMemberToken(t *testing.T) {
 			if tt.existingSecret != nil {
 				obj = append(obj, tt.existingSecret)
 			}
-			file, err := os.CreateTemp("", "membertoken")
-			if err != nil {
-				log.Fatal(err)
-			}
-			defer os.Remove(file.Name())
 			fakeClient := fake.NewClientBuilder().WithScheme(multiclusterscheme.Scheme).WithObjects(obj...).Build()
-			_ = CreateMemberToken(cmd, fakeClient, "membertoken", "default", file, &createdRes)
+			_ = CreateMemberToken(cmd, fakeClient, "membertoken", "default", &createdRes)
 			assert.Equal(t, tt.expectedResLen, len(createdRes))
 		})
 	}

--- a/pkg/antctl/raw/multicluster/create/member_token_test.go
+++ b/pkg/antctl/raw/multicluster/create/member_token_test.go
@@ -37,7 +37,7 @@ func TestCreateAccessToken(t *testing.T) {
 		Data: map[string][]byte{"token": []byte("12345")},
 	}
 
-	secretContent := []byte(`# Manifest to create a Secret for an Antrea Multi-cluster  member cluster token.
+	secretContent := []byte(`# Manifest to create a Secret for an Antrea Multi-cluster member token.
 ---
 apiVersion: v1
 data:
@@ -46,7 +46,6 @@ kind: Secret
 metadata:
   creationTimestamp: null
   name: default-member-token
-  namespace: default
 type: Opaque
 `)
 

--- a/pkg/antctl/raw/multicluster/get/member_token_test.go
+++ b/pkg/antctl/raw/multicluster/get/member_token_test.go
@@ -76,7 +76,7 @@ func TestGetAccessToken(t *testing.T) {
 			args:            []string{"default-member-token"},
 			namespace:       "default",
 			output:          "json",
-			expectedOutput:  "[\n  {\n    \"kind\": \"Secret\",\n    \"apiVersion\": \"v1\",\n    \"metadata\": {\n      \"name\": \"default-member-token\",\n      \"namespace\": \"default\",\n      \"creationTimestamp\": null\n    },\n    \"data\": {\n      \"token\": \"MTIzNDU=\"\n    },\n    \"type\": \"Opaque\"\n  }\n]\n",
+			expectedOutput:  "[\n  {\n    \"kind\": \"Secret\",\n    \"apiVersion\": \"v1\",\n    \"metadata\": {\n      \"name\": \"default-member-token\",\n      \"creationTimestamp\": null\n    },\n    \"data\": {\n      \"token\": \"MTIzNDU=\"\n    },\n    \"type\": \"Opaque\"\n  }\n]\n",
 		},
 		{
 			name:            "get single Secret with yaml output",
@@ -84,7 +84,7 @@ func TestGetAccessToken(t *testing.T) {
 			args:            []string{"default-member-token"},
 			namespace:       "default",
 			output:          "yaml",
-			expectedOutput:  "- apiVersion: v1\n  data:\n    token: MTIzNDU=\n  kind: Secret\n  metadata:\n    creationTimestamp: null\n    name: default-member-token\n    namespace: default\n  type: Opaque\n",
+			expectedOutput:  "- apiVersion: v1\n  data:\n    token: MTIzNDU=\n  kind: Secret\n  metadata:\n    creationTimestamp: null\n    name: default-member-token\n  type: Opaque\n",
 		},
 		{
 			name:           "get non-existing Secret",

--- a/pkg/antctl/raw/multicluster/init_test.go
+++ b/pkg/antctl/raw/multicluster/init_test.go
@@ -83,9 +83,17 @@ kind: Config`)
 		outputToFile   bool
 	}{
 		{
-			name:           "init successfully",
-			namespace:      "default",
-			expectedOutput: "ClusterClaim \"id.k8s.io\" created in Namespace default\nClusterClaim \"clusterset.k8s.io\" created in Namespace default\nClusterSet \"test-clusterset\" created in Namespace default\nSuccessfully initialized ClusterSet test-clusterset\nServiceAccount \"default-member-token\" created\nRoleBinding \"default-member-token\" created\nSecret \"default-member-token\" already exists\nSecret \"default-member-token\" created\n",
+			name:      "init successfully",
+			namespace: "default",
+			expectedOutput: `ClusterClaim "id.k8s.io" created in Namespace default
+ClusterClaim "clusterset.k8s.io" created in Namespace default
+ClusterSet "test-clusterset" created in Namespace default
+Successfully initialized ClusterSet test-clusterset
+You can run command "antctl mc get joinconfig -n default" to print the parameters needed for a member cluster to join the ClusterSet.
+ServiceAccount "default-member-token" created
+RoleBinding "default-member-token" created
+Secret "default-member-token" already exists
+`,
 		},
 		{
 			name:           "init fail due to empty Namespace",
@@ -101,7 +109,7 @@ kind: Config`)
 		{
 			name:           "init successfully with output",
 			namespace:      "default",
-			expectedOutput: "Member token saved to",
+			expectedOutput: "Saved ClusterSet join parameters to file:",
 			outputToFile:   true,
 		},
 	}

--- a/pkg/antctl/raw/multicluster/join_test.go
+++ b/pkg/antctl/raw/multicluster/join_test.go
@@ -100,13 +100,13 @@ type: Opaque`)
 		{
 			name:           "join successfully with Secret file",
 			clusterID:      "cluster-a",
-			expectedOutput: "Created the Secret from the config file",
+			expectedOutput: "Created member token Secret token-secret",
 			secretFile:     true,
 		},
 		{
 			name:           "join successfully with config file",
 			clusterID:      "cluster-a",
-			expectedOutput: "Created the Secret from the config file",
+			expectedOutput: "Created member token Secret token-secret",
 			configFile:     true,
 		},
 		{


### PR DESCRIPTION
Add a "--member-token TOKEN" option to print the token Secret manifest with the member join parameters.
Also fixed the "get membertoken" YAML output and "join" command code to support creating the token Secret from the "get membertoken" output.

Signed-off-by: Jianjun Shen <shenj@vmware.com>