### PR TITLE
Fix antrea/base-windows image building workflow

### DIFF
--- a/.github/workflows/docker_update_base_windows.yml
+++ b/.github/workflows/docker_update_base_windows.yml
@@ -35,12 +35,12 @@ jobs:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
     - name: Build and push Docker images
-      if: ${{ github.event.inputs.push == "true" }}
+      if: ${{ github.event.inputs.push }}
       run: |
         ./hack/build-antrea-windows-all.sh --pull --push-base-images
       shell: bash
     - name: Build Docker images without pushing
-      if: ${{ github.event.inputs.push == "false" }}
+      if: ${{ !github.event.inputs.push }}
       run: |
         ./hack/build-antrea-windows-all.sh --pull
       shell: bash


### PR DESCRIPTION
Wrapping string with double quotes will throw an error. The patch fixes it by using the boolean variable itself as the expression.

Signed-off-by: Quan Tian <qtian@vmware.com>

See https://docs.github.com/en/actions/learn-github-actions/expressions#literals
> You don't need to enclose strings in ${{ and }}. However, if you do, you must use single quotes (') around the string. To use a literal single quote, escape the literal single quote using an additional single quote (''). Wrapping with double quotes (") will throw an error.