### PR TITLE
Make vm agent CI script install antrea-agent service

### DIFF
--- a/ci/jenkins/test-vm.sh
+++ b/ci/jenkins/test-vm.sh
@@ -22,22 +22,18 @@ function echoerr {
 
 DOCKER_REGISTRY="projects.registry.vmware.com"
 DEFAULT_WORKDIR="/var/lib/jenkins"
+ANTREA_AGENT_KUBECONFIG="antrea-agent.kubeconfig"
+ANTREA_AGENT_ANTREA_KUBECONFIG="antrea-agent.antrea.kubeconfig"
+SNAPSHOT="InstallVMAgent"
 DEFAULT_KUBECONFIG_PATH=$DEFAULT_WORKDIR/kube.conf
 WORKDIR=$DEFAULT_WORKDIR
 KUBECONFIG_PATH=$DEFAULT_KUBECONFIG_PATH
 TEST_FAILURE=false
 
-# VM configuration
-WINDOWS_VM_IP=""
-UBUNTU_VM_IP=""
-LIN_HOSTNAME="vmbmtest0-1"
-WIN_HOSTNAME="vmbmtest0-win-0"
-
 # Cluster configuration
 CLUSTER_NAME="kubernetes"
 TEST_NAMESPACE="vm-ns"
 SERVICE_ACCOUNT="vm-agent"
-
 CONTROL_PLANE_NODE_ROLE="control-plane"
 
 _usage="Usage: $0 [--kubeconfig <KubeconfigSavePath>] [--workdir <HomePath>]
@@ -47,6 +43,17 @@ Run K8s e2e community tests (Conformance & Network Policy) or Antrea e2e tests o
         --kubeconfig             Path of cluster kubeconfig.
         --workdir                Home path for Go, vSphere information and antrea_logs during cluster setup. Default is $WORKDIR.
         --registry               The docker registry to use instead of dockerhub."
+
+# VM configuration
+declare -A LINUX_HOSTS_TO_IP
+declare -A WINDOWS_HOSTS_TO_IP
+declare -a LIN_HOSTNAMES=("vmbmtest0-1")
+declare -a WIN_HOSTNAMES=("vmbmtest0-win-0")
+declare -A LINUX_HOSTS_TO_USERNAME=(["vmbmtest0-1"]="ubuntu")
+declare -A WINDOWS_HOSTS_TO_USERNAME=(["vmbmtest0-win-0"]="Administrator")
+
+# To run kubectl cmds
+export KUBECONFIG=${KUBECONFIG_PATH}
 
 function print_usage {
     echoerr "$_usage"
@@ -88,9 +95,6 @@ if [[ "$WORKDIR" != "$DEFAULT_WORKDIR" && "$KUBECONFIG_PATH" == "$DEFAULT_KUBECO
     KUBECONFIG_PATH=${WORKDIR}/.kube/config
 fi
 
-# To run kubectl cmds
-export KUBECONFIG=${KUBECONFIG_PATH}
-
 function export_govc_env_var {
     # This should be coming from jenkins configuration
     export GOVC_URL=$GOVC_URL
@@ -103,9 +107,6 @@ function export_govc_env_var {
 
 function clean_up_one_ns {
     ns=$1
-    kubectl get pod -n "${ns}" --no-headers=true | awk '{print $1}' | while read pod_name; do
-        kubectl delete pod "${pod_name}" -n "${ns}" --force --grace-period 0
-    done
     kubectl delete ns "${ns}" --ignore-not-found=true || true
 }
 
@@ -113,6 +114,7 @@ function clean_antrea {
     echo "====== Cleanup Antrea Installation ======"
     clean_up_one_ns $TEST_NAMESPACE
     kubectl delete -f ${WORKDIR}/antrea.yml --ignore-not-found=true
+    docker image prune -f --filter "until=1h" || true > /dev/null
 }
 
 function apply_antrea {
@@ -140,25 +142,15 @@ function apply_antrea {
 }
 
 function clean_vm_agent {
-    echo "====== Cleanup Antrea-Agent Installation on the VM ======"
-    echo "Revert to snapshot VMAgent"
-    govc snapshot.revert -k=true -vm=${LIN_HOSTNAME} VMAgent
-    govc snapshot.revert -k=true -vm=${WIN_HOSTNAME} VMAgent
-    echo "Get IP addresses for VMs"
-    UBUNTU_VM_IP=$(govc vm.ip -k=true -wait=1m ${LIN_HOSTNAME})
-    for i in `seq 10`; do
-        WINDOWS_VM_IP=$(govc vm.ip -k=true -wait=2m ${WIN_HOSTNAME})
-        if [[ WINDOWS_VM_IP == "" ]]; then
-            echo "Failed to retrieve IP for Windows VM ${WIN_HOSTNAME}, retry ${i}"
-            continue
-        fi
-    done
-
+    declare -a host_names=$1
+    echo "Host names ${host_names[@]}"
     kubectl delete sa $SERVICE_ACCOUNT -n $TEST_NAMESPACE --ignore-not-found=true
     clean_up_one_ns $TEST_NAMESPACE
-    echo "Deleting stale antrea-agent files from ${LIN_HOSTNAME} and ${WIN_HOSTNAME}"
-    ssh -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" -n ubuntu@${UBUNTU_VM_IP} "rm -rf /tmp/antrea-ci"
-    ssh -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" Administrator@${WINDOWS_VM_IP} "rm -rf /tmp/antrea-ci"
+    for host_name in "${host_names[@]}"; do
+        echo "====== Cleanup Antrea-Agent Installation on the $host_name VM ======"
+        echo "Revert to snapshot $SNAPSHOT"
+        govc snapshot.revert -k=true -vm=$host_name $SNAPSHOT
+    done
 }
 
 function configure_vm_agent {
@@ -170,45 +162,108 @@ function configure_vm_agent {
     cp ./build/yamls/externalnode/vm-agent-rbac.yml ${WORKDIR}/vm-agent-rbac.yml
     echo "Applying vm-agent rbac yaml"
     kubectl apply -f ${WORKDIR}/vm-agent-rbac.yml
+    cp ./hack/externalnode/install-vm.sh ${WORKDIR}/install-vm.sh
+    cp ./hack/externalnode/install-vm.ps1 ${WORKDIR}/install-vm.ps1
+    create_kubeconfig_files
+    copy_antrea_agent_files_on_linux
+    install_on_linux
+    copy_antrea_agent_files_on_windows
+    install_on_windows
+}
 
-    echo "Creating files antrea-agent.kubeconfig and antrea-agent.antrea.kubeconfig"
+function fetch_vm_ip {
+    echo "Fetching the ip address for LINUX VMs"
+    for host_name in "${LIN_HOSTNAMES[@]}"; do
+        LINUX_HOSTS_TO_IP["$host_name"]=$(govc vm.ip -k=true -wait=1m ${host_name})
+    done
+    echo "Fetching the ip address for WINDOWS VMs"
+    for host_name in "${WIN_HOSTNAMES[@]}"; do
+        for i in `seq 10`; do
+            WINDOWS_HOSTS_TO_IP["$host_name"]=$(govc vm.ip -k=true -wait=2m ${host_name})
+            if [[ WINDOWS_HOSTS_TO_IP["$host_name"] == "" ]]; then
+                echo "Failed to retrieve IP for Windows VM ${host_name}, retry ${i}"
+                continue
+            fi
+            break
+        done
+    done
+}
+
+function create_kubeconfig_files {
+    echo "Creating files ${ANTREA_AGENT_KUBECONFIG} and ${ANTREA_AGENT_ANTREA_KUBECONFIG}"
     # Kubeconfig to access K8S API
+
     APISERVER=$(kubectl config view -o jsonpath="{.clusters[?(@.name==\"$CLUSTER_NAME\")].cluster.server}")
     TOKEN=$(kubectl -n $TEST_NAMESPACE get secrets -o jsonpath="{.items[?(@.metadata.annotations['kubernetes\.io/service-account\.name']=='$SERVICE_ACCOUNT')].data.token}"|base64 --decode)
-    kubectl config --kubeconfig=${WORKDIR}/antrea-agent.kubeconfig set-cluster kubernetes --server=$APISERVER --insecure-skip-tls-verify=true
-    kubectl config --kubeconfig=${WORKDIR}/antrea-agent.kubeconfig set-credentials antrea-agent --token=$TOKEN
-    kubectl config --kubeconfig=${WORKDIR}/antrea-agent.kubeconfig set-context antrea-agent@kubernetes --cluster=kubernetes --user=antrea-agent
-    kubectl config --kubeconfig=${WORKDIR}/antrea-agent.kubeconfig use-context antrea-agent@kubernetes
+    kubectl config --kubeconfig=${WORKDIR}/${ANTREA_AGENT_KUBECONFIG} set-cluster kubernetes --server=$APISERVER --insecure-skip-tls-verify=true
+    kubectl config --kubeconfig=${WORKDIR}/${ANTREA_AGENT_KUBECONFIG} set-credentials antrea-agent --token=$TOKEN
+    kubectl config --kubeconfig=${WORKDIR}/${ANTREA_AGENT_KUBECONFIG} set-context antrea-agent@kubernetes --cluster=kubernetes --user=antrea-agent
+    kubectl config --kubeconfig=${WORKDIR}/${ANTREA_AGENT_KUBECONFIG} use-context antrea-agent@kubernetes
 
     # Kubeconfig to access AntreaController
     ANTREA_API_SERVER_IP=$(kubectl get nodes -o wide --no-headers=true | awk -v role="$CONTROL_PLANE_NODE_ROLE" '$3 != role {print $6}')
     ANTREA_API_SERVER="https://${ANTREA_API_SERVER_IP}:32767"
     TOKEN=$(kubectl -n $TEST_NAMESPACE get secrets -o jsonpath="{.items[?(@.metadata.annotations['kubernetes\.io/service-account\.name']=='$SERVICE_ACCOUNT')].data.token}"|base64 --decode)
-    kubectl config --kubeconfig=${WORKDIR}/antrea-agent.antrea.kubeconfig set-cluster antrea --server=$ANTREA_API_SERVER --insecure-skip-tls-verify=true
-    kubectl config --kubeconfig=${WORKDIR}/antrea-agent.antrea.kubeconfig set-credentials antrea-agent --token=$TOKEN
-    kubectl config --kubeconfig=${WORKDIR}/antrea-agent.antrea.kubeconfig set-context antrea-agent@antrea --cluster=antrea --user=antrea-agent
-    kubectl config --kubeconfig=${WORKDIR}/antrea-agent.antrea.kubeconfig use-context antrea-agent@antrea
-
-    echo "Copying kubeconfig files to Linux VM"
-    scp -q -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" ${WORKDIR}/antrea-agent.antrea.kubeconfig ubuntu@${UBUNTU_VM_IP}:/tmp/antrea-ci/antrea-agent.antrea.kubeconfig
-    scp -q -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" ${WORKDIR}/antrea-agent.kubeconfig  ubuntu@${UBUNTU_VM_IP}:/tmp/antrea-ci/antrea-agent.kubeconfig
-    echo "Copying kubeconfig files to Windows VM"
-    scp -q -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" ${WORKDIR}/antrea-agent.antrea.kubeconfig Administrator@${WINDOWS_VM_IP}:/tmp/antrea-ci/antrea-agent.antrea.kubeconfig
-    scp -q -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" ${WORKDIR}/antrea-agent.kubeconfig Administrator@${WINDOWS_VM_IP}:/tmp/antrea-ci/antrea-agent.kubeconfig
-    echo "Configure antrea-agent as a service on Linux VM"
-    ssh -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" -n ubuntu@${UBUNTU_VM_IP} "sudo cp /tmp/antrea-ci/antrea-agent /usr/sbin/"
-    ssh -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" -n ubuntu@${UBUNTU_VM_IP} "sudo cp /tmp/antrea-ci/antrea-agent.conf /var/run/antrea/"
-    ssh -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" -n ubuntu@${UBUNTU_VM_IP} "sudo cp /tmp/antrea-ci/antrea-agent.*kubeconfig /var/run/antrea/"
-    ssh -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" -n ubuntu@${UBUNTU_VM_IP} "sudo systemctl daemon-reload"
-    ssh -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" -n ubuntu@${UBUNTU_VM_IP} "sudo systemctl enable antrea-agent"
-    echo "Configure antrea-agent as a service on Windows VM"
-    # change /tmp/antrea-ci/*kubeconfig to C:\antrea-agent\*kubeconfig
-    ssh -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" Administrator@${WINDOWS_VM_IP} "sed -i 's|/tmp/antrea-ci|C:/antrea-agent|g' /tmp/antrea-ci/antrea-agent.conf"
-    ssh -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" Administrator@${WINDOWS_VM_IP} "cp /tmp/antrea-ci/antrea-agent.exe C:/antrea-agent/"
-    ssh -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" Administrator@${WINDOWS_VM_IP} "cp /tmp/antrea-ci/antrea-agent.conf C:/antrea-agent/antrea-agent.conf"
-    ssh -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" Administrator@${WINDOWS_VM_IP} "cp /tmp/antrea-ci/antrea-agent.*kubeconfig C:/antrea-agent/"
+    kubectl config --kubeconfig=${WORKDIR}/${ANTREA_AGENT_ANTREA_KUBECONFIG} set-cluster antrea --server=$ANTREA_API_SERVER --insecure-skip-tls-verify=true
+    kubectl config --kubeconfig=${WORKDIR}/${ANTREA_AGENT_ANTREA_KUBECONFIG} set-credentials antrea-agent --token=$TOKEN
+    kubectl config --kubeconfig=${WORKDIR}/${ANTREA_AGENT_ANTREA_KUBECONFIG} set-context antrea-agent@antrea --cluster=antrea --user=antrea-agent
+    kubectl config --kubeconfig=${WORKDIR}/${ANTREA_AGENT_ANTREA_KUBECONFIG} use-context antrea-agent@antrea
 }
 
+function copy_antrea_agent_files_on_linux {
+    echo "====== Delivering Antrea files to all the LINUX VMs ======"
+    for host_name in "${LIN_HOSTNAMES[@]}"; do
+        echo "Copying binaries and conf to VM: $host_name"
+        USERNAME=${LINUX_HOSTS_TO_USERNAME[${host_name}]}
+        IP_ADDRESS=${LINUX_HOSTS_TO_IP[${host_name}]}
+        ssh -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" -n ${USERNAME}@${IP_ADDRESS} "mkdir -p /tmp/antrea-ci"
+        scp -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" ./bin/antrea-agent ${USERNAME}@${IP_ADDRESS}:/tmp/antrea-ci/antrea-agent
+        scp -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" ./bin/antctl ${USERNAME}@${IP_ADDRESS}:/tmp/antrea-ci/antctl
+        scp -q -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" ${WORKDIR}/antrea-agent.conf  ${USERNAME}@${IP_ADDRESS}:/tmp/antrea-ci/antrea-agent.conf
+        echo "Copying kubeconfig files to Linux VM: $host_name"
+        scp -q -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" ${WORKDIR}/${ANTREA_AGENT_ANTREA_KUBECONFIG} ${USERNAME}@${IP_ADDRESS}:/tmp/antrea-ci/${ANTREA_AGENT_ANTREA_KUBECONFIG}
+        scp -q -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" ${WORKDIR}/${ANTREA_AGENT_KUBECONFIG}  ${USERNAME}@${IP_ADDRESS}:/tmp/antrea-ci/${ANTREA_AGENT_KUBECONFIG}
+        echo "Copying install script to Linux VM: $host_name"
+        scp -q -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" ${WORKDIR}/install-vm.sh  ${USERNAME}@${IP_ADDRESS}:/tmp/antrea-ci/install-vm.sh
+    done
+}
+
+function copy_antrea_agent_files_on_windows {
+    echo "====== Delivering Antrea files to all the WINDOWS VMs ======"
+    for host_name in "${WIN_HOSTNAMES[@]}"; do
+        echo "Copying binaries and conf to VM: $host_name"
+        USERNAME=${WINDOWS_HOSTS_TO_USERNAME[${host_name}]}
+        IP_ADDRESS=${WINDOWS_HOSTS_TO_IP[${host_name}]}
+        ssh -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" ${USERNAME}@${IP_ADDRESS} "mkdir -p /tmp/antrea-ci"
+        scp -q -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" ./bin/antrea-agent.exe ${USERNAME}@${IP_ADDRESS}:/tmp/antrea-ci/antrea-agent.exe
+        scp -q -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" ./bin/antctl.exe ${USERNAME}@${IP_ADDRESS}:/tmp/antrea-ci/antctl.exe
+        scp -q -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" ${WORKDIR}/antrea-agent.conf  ${USERNAME}@${IP_ADDRESS}:/tmp/antrea-ci/antrea-agent.conf
+        echo "Copying kubeconfig files to Windows VM: $host_name"
+        scp -q -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" ${WORKDIR}/${ANTREA_AGENT_ANTREA_KUBECONFIG} ${USERNAME}@${IP_ADDRESS}:/tmp/antrea-ci/${ANTREA_AGENT_ANTREA_KUBECONFIG}
+        scp -q -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" ${WORKDIR}/${ANTREA_AGENT_KUBECONFIG} ${USERNAME}@${IP_ADDRESS}:/tmp/antrea-ci/${ANTREA_AGENT_KUBECONFIG}
+        echo "Copying install script to Windows VM: $host_name"
+        scp -q -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" ${WORKDIR}/install-vm.ps1  ${USERNAME}@${IP_ADDRESS}:/tmp/antrea-ci/install-vm.ps1
+    done
+}
+
+function install_on_linux {
+   for host_name in "${LIN_HOSTNAMES[@]}"; do
+      echo "Installing on Linux VM $host_name"
+      USERNAME=${LINUX_HOSTS_TO_USERNAME[${host_name}]}
+      IP_ADDRESS=${LINUX_HOSTS_TO_IP[${host_name}]}
+      ssh -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" -n ${USERNAME}@${IP_ADDRESS} "sudo chmod +x /tmp/antrea-ci/install-vm.sh"
+      ssh -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" -n ${USERNAME}@${IP_ADDRESS} "cd /tmp/antrea-ci && sudo ./install-vm.sh --ns vm-ns --bin ./antrea-agent --config ./antrea-agent.conf --kubeconfig ./antrea-agent.kubeconfig  --antrea-kubeconfig ./antrea-agent.antrea.kubeconfig"
+   done
+}
+
+function install_on_windows {
+   for host_name in "${WIN_HOSTNAMES[@]}"; do
+      echo "Installing on Windows VM $host_name"
+      USERNAME=${WINDOWS_HOSTS_TO_USERNAME[${host_name}]}
+      IP_ADDRESS=${WINDOWS_HOSTS_TO_IP[${host_name}]}
+      ssh -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" ${USERNAME}@${IP_ADDRESS} "cd /tmp/antrea-ci && Powershell -ExecutionPolicy Bypass -NoProfile -File install-vm.ps1 -Namespace vm-ns -BinaryPath antrea-agent.exe -ConfigPath antrea-agent.conf -KubeConfigPath antrea-agent.kubeconfig -AntreaKubeConfigPath antrea-agent.antrea.kubeconfig"
+   done
+}
 
 function run_e2e_vms {
     export GO111MODULE=on
@@ -220,7 +275,7 @@ function run_e2e_vms {
     configure_vm_agent
     echo "====== Running Antrea e2e Tests for VM ======"
     mkdir -p `pwd`/antrea-test-logs
-    go test -v -timeout=100m antrea.io/antrea/test/e2e -run=TestVMAgent --logs-export-dir `pwd`/antrea-test-logs -provider=remote -windowsVMs=${WIN_HOSTNAME} -linuxVMs=${LIN_HOSTNAME}
+    go test -v -timeout=100m antrea.io/antrea/test/e2e -run=TestVMAgent --logs-export-dir `pwd`/antrea-test-logs -provider=remote -windowsVMs="${WIN_HOSTNAMES[*]}" -linuxVMs="${LIN_HOSTNAMES[*]}"
     if [[ "$?" != "0" ]]; then
         TEST_FAILURE=true
     fi
@@ -231,7 +286,8 @@ function run_e2e_vms {
 
 function deliver_antrea_vm {
     export_govc_env_var
-    clean_vm_agent
+    clean_vm_agent ${LIN_HOSTNAMES[@]}
+    clean_vm_agent ${WIN_HOSTNAMES[@]}
     echo "====== Building Antrea binaries for the Following Commit ======"
     export GO111MODULE=on
     export GOPATH=${WORKDIR}/go
@@ -241,24 +297,12 @@ function deliver_antrea_vm {
 
     make docker-bin
     make docker-windows-bin
-    echo "====== Delivering Antrea to all the VMs ======"
+
     cp ./build/yamls/externalnode/conf/antrea-agent.conf ${WORKDIR}/antrea-agent.conf
-    echo "Updating antrea-agent.conf"
-    sed -i 's|#externalNodeNamespace: default|externalNodeNamespace: vm-ns|g' ${WORKDIR}/antrea-agent.conf
-    sed -i 's|kubeconfig: |kubeconfig: /tmp/antrea-ci/|g' ${WORKDIR}/antrea-agent.conf
-    echo "Copying binaries and conf to VM: $LIN_HOSTNAME"
-    ssh -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" -n ubuntu@${UBUNTU_VM_IP} "mkdir -p /tmp/antrea-ci"
-    scp -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" ./bin/antrea-agent ubuntu@${UBUNTU_VM_IP}:/tmp/antrea-ci/antrea-agent
-    scp -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" ./bin/antctl ubuntu@${UBUNTU_VM_IP}:/tmp/antrea-ci/antctl
-    scp -q -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" ${WORKDIR}/antrea-agent.conf  ubuntu@${UBUNTU_VM_IP}:/tmp/antrea-ci/antrea-agent.conf
-    echo "Copying binaries and conf to VM: $WIN_HOSTNAME"
-    ssh -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" Administrator@${WINDOWS_VM_IP} "mkdir -p /tmp/antrea-ci"
-    scp -q -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" ./bin/antrea-agent.exe Administrator@${WINDOWS_VM_IP}:/tmp/antrea-ci/antrea-agent.exe
-    scp -q -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" ./bin/antctl.exe Administrator@${WINDOWS_VM_IP}:/tmp/antrea-ci/antctl.exe
-    scp -q -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" ${WORKDIR}/antrea-agent.conf  Administrator@${WINDOWS_VM_IP}:/tmp/antrea-ci/antrea-agent.conf
 }
 
 trap clean_antrea EXIT
+fetch_vm_ip
 apply_antrea
 deliver_antrea_vm
 run_e2e_vms

--- a/test/e2e/vmagent_test.go
+++ b/test/e2e/vmagent_test.go
@@ -83,7 +83,7 @@ func setupVMAgentTest(t *testing.T, data *TestData) ([]vmInfo, error) {
 	t.Logf("Using ServiceAccount %s, Namespace %s", serviceAccount, namespace)
 	var vmList []vmInfo
 	if testOptions.linuxVMs != "" {
-		vms := strings.Split(testOptions.linuxVMs, ",")
+		vms := strings.Split(testOptions.linuxVMs, " ")
 		for _, vm := range vms {
 			t.Logf("Get info for Linux VM: %s", vm)
 			tempVM := getVMInfo(t, data, vm)
@@ -91,7 +91,7 @@ func setupVMAgentTest(t *testing.T, data *TestData) ([]vmInfo, error) {
 		}
 	}
 	if testOptions.windowsVMs != "" {
-		vms := strings.Split(testOptions.windowsVMs, ",")
+		vms := strings.Split(testOptions.windowsVMs, " ")
 		for _, vm := range vms {
 			t.Logf("Get info for Windows VM: %s", vm)
 			tempVM := getWindowsVMInfo(t, data, vm)


### PR DESCRIPTION
The CI currently uses a customized image, which contains the antrea-agent
service pre-created. The CI/Test only starts the antrea-agent service and
validates the status of the antrea agent service. But this commit integrates
the installations script with CI, utilizes that installation script
(like an end user), and installs the antrea-agent on both Linux and Windows VMs
and CI validates the status of the antrea-agent service in both VMs.

Also, Now the CI would support installing antrea-agent using install script
on multiple Linux and Windows VMs for testing purposes.

Signed-off-by: nithishs <nithishs@vmware.com>