### PR TITLE
Add unit test for multicluster/cmd

### DIFF
--- a/multicluster/cmd/multicluster-controller/controller.go
+++ b/multicluster/cmd/multicluster-controller/controller.go
@@ -47,6 +47,9 @@ import (
 var (
 	validationWebhooksNamePattern = "%s%santrea-mc-validating-webhook-configuration"
 	mutationWebhooksNamePattern   = "%s%santrea-mc-mutating-webhook-configuration"
+
+	// The unit test code will change the function to set up a mock manager.
+	setupManagerAndCertControllerFunc = setupManagerAndCertController
 )
 
 const (

--- a/multicluster/cmd/multicluster-controller/controller_test.go
+++ b/multicluster/cmd/multicluster-controller/controller_test.go
@@ -1,0 +1,93 @@
+// Copyright 2022 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package main under directory cmd parses and validates user input,
+// instantiates and initializes objects imported from pkg, and runs
+// the process.
+
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/rest"
+
+	"antrea.io/antrea/pkg/apiserver/certificate"
+)
+
+func TestCreateClients(t *testing.T) {
+	testCases := []struct {
+		name   string
+		config *rest.Config
+	}{
+		{
+			name:   "Create clients successfully",
+			config: &rest.Config{},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, _, err := createClients(tt.config)
+			assert.NoError(t, err, "get error when running createClients")
+		})
+	}
+}
+
+func TestGetCAConfig(t *testing.T) {
+	testCases := []struct {
+		name         string
+		controllerNS string
+		expectedRes  *certificate.CAConfig
+	}{
+		{
+			name:         "controllerNS is empty",
+			controllerNS: "",
+			expectedRes: &certificate.CAConfig{
+				CAConfigMapName:    configMapName,
+				PairName:           "tls",
+				CertDir:            certDir,
+				ServiceName:        serviceName,
+				SelfSignedCertDir:  selfSignedCertDir,
+				MutationWebhooks:   getMutationWebhooks(""),
+				ValidatingWebhooks: getValidationWebhooks(""),
+				CertReadyTimeout:   2 * time.Minute,
+				MaxRotateDuration:  time.Hour * (24 * 365),
+			},
+		},
+		{
+			name:         "controllerNS is not empty",
+			controllerNS: "testNS",
+			expectedRes: &certificate.CAConfig{
+				CAConfigMapName:    configMapName,
+				PairName:           "tls",
+				CertDir:            certDir,
+				ServiceName:        serviceName,
+				SelfSignedCertDir:  selfSignedCertDir,
+				MutationWebhooks:   getMutationWebhooks("testNS"),
+				ValidatingWebhooks: getValidationWebhooks("testNS"),
+				CertReadyTimeout:   2 * time.Minute,
+				MaxRotateDuration:  time.Hour * (24 * 365),
+			},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expectedRes, getCaConfig(tt.controllerNS))
+		})
+	}
+}

--- a/multicluster/cmd/multicluster-controller/leader.go
+++ b/multicluster/cmd/multicluster-controller/leader.go
@@ -54,7 +54,7 @@ func runLeader(o *Options) error {
 	o.options.Namespace = env.GetPodNamespace()
 	stopCh := signals.RegisterSignalHandlers()
 
-	mgr, err := setupManagerAndCertController(o)
+	mgr, err := setupManagerAndCertControllerFunc(o)
 	if err != nil {
 		return err
 	}

--- a/multicluster/cmd/multicluster-controller/leader_test.go
+++ b/multicluster/cmd/multicluster-controller/leader_test.go
@@ -1,0 +1,85 @@
+// Copyright 2022 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package main under directory cmd parses and validates user input,
+// instantiates and initializes objects imported from pkg, and runs
+// the process.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/config/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	k8smcsv1alpha1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
+
+	mcsv1alpha1 "antrea.io/antrea/multicluster/apis/multicluster/v1alpha1"
+	"antrea.io/antrea/multicluster/test/mocks"
+)
+
+func initMockManager(mockManager *mocks.MockManager) {
+	newScheme := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(newScheme))
+	utilruntime.Must(k8smcsv1alpha1.AddToScheme(newScheme))
+	utilruntime.Must(mcsv1alpha1.AddToScheme(newScheme))
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects().Build()
+
+	mockManager.EXPECT().GetWebhookServer().Return(&webhook.Server{}).AnyTimes()
+	mockManager.EXPECT().GetWebhookServer().Return(&webhook.Server{}).AnyTimes()
+	mockManager.EXPECT().GetClient().Return(fakeClient).AnyTimes()
+	mockManager.EXPECT().GetScheme().Return(newScheme).AnyTimes()
+	mockManager.EXPECT().GetControllerOptions().Return(v1alpha1.ControllerConfigurationSpec{}).AnyTimes()
+	mockManager.EXPECT().GetLogger().Return(klog.NewKlogr()).AnyTimes()
+	mockManager.EXPECT().SetFields(gomock.Any()).Return(nil).AnyTimes()
+	mockManager.EXPECT().Add(gomock.Any()).Return(nil).AnyTimes()
+	mockManager.EXPECT().Start(gomock.Any()).Return(nil).AnyTimes()
+	mockManager.EXPECT().GetConfig().Return(&rest.Config{}).AnyTimes()
+	mockManager.EXPECT().GetRESTMapper().Return(&meta.DefaultRESTMapper{}).AnyTimes()
+}
+
+func TestRunLeader(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	mockLeaderManager := mocks.NewMockManager(mockCtrl)
+	initMockManager(mockLeaderManager)
+
+	testCase := struct {
+		name      string
+		setupFunc func(o *Options) (ctrl.Manager, error)
+	}{
+		name: "Start leader controller successfully",
+		setupFunc: func(o *Options) (ctrl.Manager, error) {
+			return mockLeaderManager, nil
+		},
+	}
+
+	t.Run(testCase.name, func(t *testing.T) {
+		if testCase.setupFunc != nil {
+			setupManagerAndCertControllerFunc = testCase.setupFunc
+		}
+		ctrl.SetupSignalHandler = mockSetupSignalHandler
+		err := runLeader(&Options{})
+		assert.NoError(t, err, "got error when running runLeader")
+	})
+}

--- a/multicluster/cmd/multicluster-controller/member.go
+++ b/multicluster/cmd/multicluster-controller/member.go
@@ -50,7 +50,7 @@ func newMemberCommand() *cobra.Command {
 }
 
 func runMember(o *Options) error {
-	mgr, err := setupManagerAndCertController(o)
+	mgr, err := setupManagerAndCertControllerFunc(o)
 	if err != nil {
 		return err
 	}

--- a/multicluster/cmd/multicluster-controller/member_test.go
+++ b/multicluster/cmd/multicluster-controller/member_test.go
@@ -1,0 +1,86 @@
+// Copyright 2022 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package main under directory cmd parses and validates user input,
+// instantiates and initializes objects imported from pkg, and runs
+// the process.
+
+package main
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"antrea.io/antrea/multicluster/test/mocks"
+)
+
+var shutdownSignals = []os.Signal{os.Interrupt, syscall.SIGTERM}
+
+// The original signal handler function will close a channel twice. If the runLeader
+// and runMember run at the same time, there will be a panic. So we need another
+// signal handler function to avoid it.
+func mockSetupSignalHandler() context.Context {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	c := make(chan os.Signal, 2)
+	signal.Notify(c, shutdownSignals...)
+	go func() {
+		<-c
+		cancel()
+		<-c
+		os.Exit(1)
+	}()
+
+	return ctx
+}
+
+func TestCommands(t *testing.T) {
+	rootCommand := newControllerCommand()
+	rootCommand.AddCommand(newLeaderCommand())
+	rootCommand.AddCommand(newMemberCommand())
+
+	assert.Equal(t, "antrea-mc-controller", rootCommand.Use)
+	assert.Equal(t, "leader", newLeaderCommand().Use)
+	assert.Equal(t, "member", newMemberCommand().Use)
+}
+
+func TestRunMember(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	mockMemberManager := mocks.NewMockManager(mockCtrl)
+	initMockManager(mockMemberManager)
+
+	testCase := struct {
+		name      string
+		setupFunc func(o *Options) (ctrl.Manager, error)
+	}{
+		name: "Start member controller successfully",
+		setupFunc: func(o *Options) (ctrl.Manager, error) {
+			return mockMemberManager, nil
+		},
+	}
+
+	t.Run(testCase.name, func(t *testing.T) {
+		setupManagerAndCertControllerFunc = testCase.setupFunc
+		ctrl.SetupSignalHandler = mockSetupSignalHandler
+		err := runMember(&Options{})
+		assert.NoError(t, err, "got error when running runMember")
+	})
+}


### PR DESCRIPTION
Add unit test for `multicluster/cmd`. Using a func variable to mock the `setupManagerAndCertController` method. 