### PR TITLE
Fix UBI image build error

### DIFF
--- a/build/images/ovs/Dockerfile.ubi
+++ b/build/images/ovs/Dockerfile.ubi
@@ -50,7 +50,9 @@ COPY charon-logging.conf /tmp
 COPY --from=ovs-rpms /tmp/ovs-rpms/* /tmp/ovs-rpms/
 RUN rm -f /etc/yum.repos.d/* && mv /tmp/CentOS.repo /etc/yum.repos.d/CentOS.repo && \
     curl https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official -o /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial && \
-    subscription-manager config --rhsm.manage_repos=0 && \
+    # Disable the default redhat.repo. This substitutes `subscription-manager config --rhsm.manage_repos=0`
+    # as subscription-manager is not supported running in containers.
+    sed -i.bak "s/^manage_repos = .$/manage_repos = 0/g" /etc/rhsm/rhsm.conf && \
     yum clean all -y && yum reinstall yum -y && \
     yum install /tmp/ovs-rpms/* -y && yum install epel-release -y && \
     yum install iptables logrotate -y && \
@@ -60,4 +62,5 @@ RUN rm -f /etc/yum.repos.d/* && mv /tmp/CentOS.repo /etc/yum.repos.d/CentOS.repo
     # The init system is configured to systemd by default. Change it to namespaces
     # to spawn the ipsec process directly.
     sed -i 's/^initsystem=.*$/initsystem="namespaces"/' /usr/libexec/ipsec/setup && \
+    rm /etc/rhsm/rhsm.conf.bak && \
     rm -rf /tmp/* && yum clean all


### PR DESCRIPTION
subscription-manager is disabled when running inside a container. Modify rhsm.conf to achieve the same result.

Signed-off-by: Xu Liu <xliu2@vmware.com>