### PR TITLE
Fix OpenAPI descriptions for AntreaAgentInfo and AntreaControllerInfo

### DIFF
--- a/pkg/apis/crd/v1beta1/types.go
+++ b/pkg/apis/crd/v1beta1/types.go
@@ -26,39 +26,57 @@ import (
 type AntreaAgentInfo struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-
-	Version                     string                      `json:"version,omitempty"`                     // Antrea binary version
-	PodRef                      corev1.ObjectReference      `json:"podRef,omitempty"`                      // The Pod that Antrea Agent is running in
-	NodeRef                     corev1.ObjectReference      `json:"nodeRef,omitempty"`                     // The Node that Antrea Agent is running in
-	NodeSubnets                 []string                    `json:"nodeSubnets,omitempty"`                 // Node subnets
-	OVSInfo                     OVSInfo                     `json:"ovsInfo,omitempty"`                     // OVS Information
-	NetworkPolicyControllerInfo NetworkPolicyControllerInfo `json:"networkPolicyControllerInfo,omitempty"` // Antrea Agent NetworkPolicy information
-	LocalPodNum                 int32                       `json:"localPodNum,omitempty"`                 // The number of Pods which the agent is in charge of
-	AgentConditions             []AgentCondition            `json:"agentConditions,omitempty"`             // Agent condition contains types like AgentHealthy
-	APIPort                     int                         `json:"apiPort,omitempty"`                     // The port of antrea agent API Server
+	// Antrea binary version
+	Version string `json:"version,omitempty"`
+	// The Pod that Antrea Agent is running in
+	PodRef corev1.ObjectReference `json:"podRef,omitempty"`
+	// The Node that Antrea Agent is running in
+	NodeRef corev1.ObjectReference `json:"nodeRef,omitempty"`
+	// Node subnets
+	NodeSubnets []string `json:"nodeSubnets,omitempty"`
+	// OVS Information
+	OVSInfo OVSInfo `json:"ovsInfo,omitempty"`
+	// Antrea Agent NetworkPolicy information
+	NetworkPolicyControllerInfo NetworkPolicyControllerInfo `json:"networkPolicyControllerInfo,omitempty"`
+	// The number of Pods which the agent is in charge of
+	LocalPodNum int32 `json:"localPodNum,omitempty"`
+	// Agent condition contains types like AgentHealthy
+	AgentConditions []AgentCondition `json:"agentConditions,omitempty"`
+	// The port of antrea agent API Server
+	APIPort int `json:"apiPort,omitempty"`
 }
 
 type OVSInfo struct {
-	Version    string           `json:"version,omitempty"`
-	BridgeName string           `json:"bridgeName,omitempty"`
-	FlowTable  map[string]int32 `json:"flowTable,omitempty"` // Key: flow table name, Value: flow number
+	Version    string `json:"version,omitempty"`
+	BridgeName string `json:"bridgeName,omitempty"`
+	// Key: flow table name, Value: flow number
+	FlowTable map[string]int32 `json:"flowTable,omitempty"`
 }
 
 type AgentConditionType string
 
 const (
-	AgentHealthy           AgentConditionType = "AgentHealthy"           // Status is always set to be True and LastHeartbeatTime is used to check Agent health status.
-	ControllerConnectionUp AgentConditionType = "ControllerConnectionUp" // Status True/False is used to mark the connection status between Agent and Controller.
-	OVSDBConnectionUp      AgentConditionType = "OVSDBConnectionUp"      // Status True/False is used to mark OVSDB connection status.
-	OpenflowConnectionUp   AgentConditionType = "OpenflowConnectionUp"   // Status True/False is used to mark Openflow connection status.
+	// AgentHealthy's Status is always set to be True and its LastHeartbeatTime is used to check Agent health status.
+	AgentHealthy AgentConditionType = "AgentHealthy"
+	// ControllerConnectionUp is used to mark the connection status between Agent and Controller.
+	ControllerConnectionUp AgentConditionType = "ControllerConnectionUp"
+	// OVSDBConnectionUp is used to mark OVSDB connection status.
+	OVSDBConnectionUp AgentConditionType = "OVSDBConnectionUp"
+	// OpenflowConnectionUp is used to mark Openflow connection status.
+	OpenflowConnectionUp AgentConditionType = "OpenflowConnectionUp"
 )
 
 type AgentCondition struct {
-	Type              AgentConditionType     `json:"type"`              // One of the AgentConditionType listed above
-	Status            corev1.ConditionStatus `json:"status"`            // Mark certain type status, one of True, False, Unknown
-	LastHeartbeatTime metav1.Time            `json:"lastHeartbeatTime"` // The timestamp when AntreaAgentInfo is created/updated, ideally heartbeat interval is 60s
-	Reason            string                 `json:"reason,omitempty"`  // Brief reason
-	Message           string                 `json:"message,omitempty"` // Human readable message indicating details
+	// One of the AgentConditionType listed above
+	Type AgentConditionType `json:"type"`
+	// Mark certain type status, one of True, False, Unknown
+	Status corev1.ConditionStatus `json:"status"`
+	// The timestamp when AntreaAgentInfo is created/updated, ideally heartbeat interval is 60s
+	LastHeartbeatTime metav1.Time `json:"lastHeartbeatTime"`
+	// Brief reason
+	Reason string `json:"reason,omitempty"`
+	// Human readable message indicating details
+	Message string `json:"message,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -78,14 +96,22 @@ type AntreaControllerInfo struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Version                     string                      `json:"version,omitempty"`                     // Antrea binary version
-	PodRef                      corev1.ObjectReference      `json:"podRef,omitempty"`                      // The Pod that Antrea Controller is running in
-	NodeRef                     corev1.ObjectReference      `json:"nodeRef,omitempty"`                     // The Node that Antrea Controller is running in
-	ServiceRef                  corev1.ObjectReference      `json:"serviceRef,omitempty"`                  // Antrea Controller Service
-	NetworkPolicyControllerInfo NetworkPolicyControllerInfo `json:"networkPolicyControllerInfo,omitempty"` // Antrea Controller NetworkPolicy information
-	ConnectedAgentNum           int32                       `json:"connectedAgentNum,omitempty"`           // Number of agents which are connected to this controller
-	ControllerConditions        []ControllerCondition       `json:"controllerConditions,omitempty"`        // Controller condition contains types like ControllerHealthy
-	APIPort                     int                         `json:"apiPort,omitempty"`                     // The port of antrea controller API Server
+	// Antrea binary version
+	Version string `json:"version,omitempty"`
+	// The Pod that Antrea Controller is running in
+	PodRef corev1.ObjectReference `json:"podRef,omitempty"`
+	// The Node that Antrea Controller is running in
+	NodeRef corev1.ObjectReference `json:"nodeRef,omitempty"`
+	// Antrea Controller Service
+	ServiceRef corev1.ObjectReference `json:"serviceRef,omitempty"`
+	// Antrea Controller NetworkPolicy information
+	NetworkPolicyControllerInfo NetworkPolicyControllerInfo `json:"networkPolicyControllerInfo,omitempty"`
+	// Number of agents which are connected to this controller
+	ConnectedAgentNum int32 `json:"connectedAgentNum,omitempty"`
+	// Controller condition contains types like ControllerHealthy
+	ControllerConditions []ControllerCondition `json:"controllerConditions,omitempty"`
+	// The port of antrea controller API Server
+	APIPort int `json:"apiPort,omitempty"`
 }
 
 type NetworkPolicyControllerInfo struct {
@@ -106,13 +132,20 @@ type AntreaControllerInfoList struct {
 type ControllerConditionType string
 
 const (
-	ControllerHealthy ControllerConditionType = "ControllerHealthy" // Status is always set to be True and LastHeartbeatTime is used to check Controller health status.
+	// ControllerHealthy's Status is always set to be True and its LastHeartbeatTime is used to check Controller health
+	// status.
+	ControllerHealthy ControllerConditionType = "ControllerHealthy"
 )
 
 type ControllerCondition struct {
-	Type              ControllerConditionType `json:"type"`              // One of the ControllerConditionType listed above, controllerHealthy
-	Status            corev1.ConditionStatus  `json:"status"`            // Mark certain type status, one of True, False, Unknown
-	LastHeartbeatTime metav1.Time             `json:"lastHeartbeatTime"` // The timestamp when AntreaControllerInfo is created/updated, ideally heartbeat interval is 60s
-	Reason            string                  `json:"reason,omitempty"`  // Brief reason
-	Message           string                  `json:"message,omitempty"` // Human readable message indicating details
+	// One of the ControllerConditionType listed above, controllerHealthy
+	Type ControllerConditionType `json:"type"`
+	// Mark certain type status, one of True, False, Unknown
+	Status corev1.ConditionStatus `json:"status"`
+	// The timestamp when AntreaControllerInfo is created/updated, ideally heartbeat interval is 60s
+	LastHeartbeatTime metav1.Time `json:"lastHeartbeatTime"`
+	// Brief reason
+	Reason string `json:"reason,omitempty"`
+	// Human readable message indicating details
+	Message string `json:"message,omitempty"`
 }

--- a/pkg/apiserver/openapi/zz_generated.openapi.go
+++ b/pkg/apiserver/openapi/zz_generated.openapi.go
@@ -2246,14 +2246,15 @@ func schema_pkg_apis_crd_v1beta1_AgentCondition(ref common.ReferenceCallback) co
 				Properties: map[string]spec.Schema{
 					"type": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Description: "One of the AgentConditionType listed above",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Description: "One of the AgentConditionType listed above",
+							Description: "Mark certain type status, one of True, False, Unknown",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -2261,21 +2262,21 @@ func schema_pkg_apis_crd_v1beta1_AgentCondition(ref common.ReferenceCallback) co
 					},
 					"lastHeartbeatTime": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Mark certain type status, one of True, False, Unknown",
+							Description: "The timestamp when AntreaAgentInfo is created/updated, ideally heartbeat interval is 60s",
 							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},
 					"reason": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The timestamp when AntreaAgentInfo is created/updated, ideally heartbeat interval is 60s",
+							Description: "Brief reason",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"message": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Brief reason",
+							Description: "Human readable message indicating details",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -2317,27 +2318,28 @@ func schema_pkg_apis_crd_v1beta1_AntreaAgentInfo(ref common.ReferenceCallback) c
 					},
 					"version": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "Antrea binary version",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"podRef": {
-						SchemaProps: spec.SchemaProps{
-							Description: "Antrea binary version",
-							Default:     map[string]interface{}{},
-							Ref:         ref("k8s.io/api/core/v1.ObjectReference"),
-						},
-					},
-					"nodeRef": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The Pod that Antrea Agent is running in",
 							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.ObjectReference"),
 						},
 					},
-					"nodeSubnets": {
+					"nodeRef": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The Node that Antrea Agent is running in",
+							Default:     map[string]interface{}{},
+							Ref:         ref("k8s.io/api/core/v1.ObjectReference"),
+						},
+					},
+					"nodeSubnets": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Node subnets",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -2352,28 +2354,28 @@ func schema_pkg_apis_crd_v1beta1_AntreaAgentInfo(ref common.ReferenceCallback) c
 					},
 					"ovsInfo": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Node subnets",
+							Description: "OVS Information",
 							Default:     map[string]interface{}{},
 							Ref:         ref("antrea.io/antrea/pkg/apis/crd/v1beta1.OVSInfo"),
 						},
 					},
 					"networkPolicyControllerInfo": {
 						SchemaProps: spec.SchemaProps{
-							Description: "OVS Information",
+							Description: "Antrea Agent NetworkPolicy information",
 							Default:     map[string]interface{}{},
 							Ref:         ref("antrea.io/antrea/pkg/apis/crd/v1beta1.NetworkPolicyControllerInfo"),
 						},
 					},
 					"localPodNum": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Antrea Agent NetworkPolicy information",
+							Description: "The number of Pods which the agent is in charge of",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
 					},
 					"agentConditions": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The number of Pods which the agent is in charge of",
+							Description: "Agent condition contains types like AgentHealthy",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -2387,7 +2389,7 @@ func schema_pkg_apis_crd_v1beta1_AntreaAgentInfo(ref common.ReferenceCallback) c
 					},
 					"apiPort": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Agent condition contains types like AgentHealthy",
+							Description: "The port of antrea agent API Server",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -2476,48 +2478,49 @@ func schema_pkg_apis_crd_v1beta1_AntreaControllerInfo(ref common.ReferenceCallba
 					},
 					"version": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "Antrea binary version",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"podRef": {
-						SchemaProps: spec.SchemaProps{
-							Description: "Antrea binary version",
-							Default:     map[string]interface{}{},
-							Ref:         ref("k8s.io/api/core/v1.ObjectReference"),
-						},
-					},
-					"nodeRef": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The Pod that Antrea Controller is running in",
 							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.ObjectReference"),
 						},
 					},
-					"serviceRef": {
+					"nodeRef": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The Node that Antrea Controller is running in",
 							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.ObjectReference"),
 						},
 					},
-					"networkPolicyControllerInfo": {
+					"serviceRef": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Antrea Controller Service",
+							Default:     map[string]interface{}{},
+							Ref:         ref("k8s.io/api/core/v1.ObjectReference"),
+						},
+					},
+					"networkPolicyControllerInfo": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Antrea Controller NetworkPolicy information",
 							Default:     map[string]interface{}{},
 							Ref:         ref("antrea.io/antrea/pkg/apis/crd/v1beta1.NetworkPolicyControllerInfo"),
 						},
 					},
 					"connectedAgentNum": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Antrea Controller NetworkPolicy information",
+							Description: "Number of agents which are connected to this controller",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
 					},
 					"controllerConditions": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Number of agents which are connected to this controller",
+							Description: "Controller condition contains types like ControllerHealthy",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -2531,7 +2534,7 @@ func schema_pkg_apis_crd_v1beta1_AntreaControllerInfo(ref common.ReferenceCallba
 					},
 					"apiPort": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Controller condition contains types like ControllerHealthy",
+							Description: "The port of antrea controller API Server",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -2600,14 +2603,15 @@ func schema_pkg_apis_crd_v1beta1_ControllerCondition(ref common.ReferenceCallbac
 				Properties: map[string]spec.Schema{
 					"type": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Description: "One of the ControllerConditionType listed above, controllerHealthy",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Description: "One of the ControllerConditionType listed above, controllerHealthy",
+							Description: "Mark certain type status, one of True, False, Unknown",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -2615,21 +2619,21 @@ func schema_pkg_apis_crd_v1beta1_ControllerCondition(ref common.ReferenceCallbac
 					},
 					"lastHeartbeatTime": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Mark certain type status, one of True, False, Unknown",
+							Description: "The timestamp when AntreaControllerInfo is created/updated, ideally heartbeat interval is 60s",
 							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
 						},
 					},
 					"reason": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The timestamp when AntreaControllerInfo is created/updated, ideally heartbeat interval is 60s",
+							Description: "Brief reason",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"message": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Brief reason",
+							Description: "Human readable message indicating details",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -2693,7 +2697,8 @@ func schema_pkg_apis_crd_v1beta1_OVSInfo(ref common.ReferenceCallback) common.Op
 					},
 					"flowTable": {
 						SchemaProps: spec.SchemaProps{
-							Type: []string{"object"},
+							Description: "Key: flow table name, Value: flow number",
+							Type:        []string{"object"},
 							AdditionalProperties: &spec.SchemaOrBool{
 								Allows: true,
 								Schema: &spec.Schema{


### PR DESCRIPTION
The property descriptions were incorrectly generated because the per-field comments were not placed before the fields.

Signed-off-by: Quan Tian <qtian@vmware.com>