### PR TITLE
Add unit test for cmd

### DIFF
--- a/cmd/antrea-controller/main.go
+++ b/cmd/antrea-controller/main.go
@@ -43,7 +43,7 @@ func newControllerCommand() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			log.InitLogs(cmd.Flags())
 			defer log.FlushLogs()
-			if err := opts.complete(args); err != nil {
+			if err := opts.complete(); err != nil {
 				klog.Fatalf("Failed to complete: %v", err)
 			}
 			if err := opts.validate(args); err != nil {

--- a/cmd/antrea-controller/options.go
+++ b/cmd/antrea-controller/options.go
@@ -124,24 +124,20 @@ func (o *Options) validateNodeIPAMControllerOptions() error {
 
 	if hasIP4 {
 		if o.config.NodeIPAM.NodeCIDRMaskSizeIPv4 < ipamIPv4MaskLo || o.config.NodeIPAM.NodeCIDRMaskSizeIPv4 > ipamIPv4MaskHi {
-			return fmt.Errorf("node IPv4 CIDR mask size %d is invalid, should be between %d and %d",
+			return fmt.Errorf("the Node IPv4 CIDR mask size %d is invalid, should be between %d and %d",
 				o.config.NodeIPAM.NodeCIDRMaskSizeIPv4, ipamIPv4MaskLo, ipamIPv4MaskHi)
 		}
 	}
 
 	if hasIP6 {
 		if o.config.NodeIPAM.NodeCIDRMaskSizeIPv6 < ipamIPv6MaskLo || o.config.NodeIPAM.NodeCIDRMaskSizeIPv6 > ipamIPv6MaskHi {
-			return fmt.Errorf("node IPv6 CIDR mask size %d is invalid, should be between %d and %d",
+			return fmt.Errorf("the Node IPv6 CIDR mask size %d is invalid, should be between %d and %d",
 				o.config.NodeIPAM.NodeCIDRMaskSizeIPv6, ipamIPv6MaskLo, ipamIPv6MaskHi)
 		}
-		// The subnet mask size cannot be greater than 16 more than the cluster mask size
-		// clusterSubnetMaxDiff limited to 16 due to the uncompressed bitmap
-		// Due to this limitation the subnet mask for IPv6 cluster cidr needs to be >= 48
-		// as default mask size for IPv6 is 64.
-		//	clusterSubnetMaxDiff = 16
-		// see also: third_party/ipam/nodeipam/ipam/cidrset/cidr_set.go:84, https://github.com/kubernetes/kubernetes/issues/44918
+		// The subnet mask size cannot be greater than 16 more than the cluster mask size.
+		// See https://github.com/kubernetes/kubernetes/issues/44918 for more information.
 		if o.config.NodeIPAM.NodeCIDRMaskSizeIPv6-ipv6Mask > 16 {
-			return fmt.Errorf("the node IPv6 CIDR size is too big, the cluster CIDR mask size cannot be greater than 16 more than the Node IPv6 CIDR mask size")
+			return fmt.Errorf("the Node IPv6 CIDR size is too big, the cluster CIDR mask size cannot be greater than 16 more than the Node IPv6 CIDR mask size")
 		}
 	}
 
@@ -149,13 +145,13 @@ func (o *Options) validateNodeIPAMControllerOptions() error {
 	if o.config.NodeIPAM.ServiceCIDR != "" {
 		_, _, err = net.ParseCIDR(o.config.NodeIPAM.ServiceCIDR)
 		if err != nil {
-			return fmt.Errorf("service CIDR %s is invalid", o.config.NodeIPAM.ServiceCIDR)
+			return fmt.Errorf("the Service CIDR %s is invalid", o.config.NodeIPAM.ServiceCIDR)
 		}
 	}
 	if o.config.NodeIPAM.ServiceCIDRv6 != "" {
 		_, _, err = net.ParseCIDR(o.config.NodeIPAM.ServiceCIDRv6)
 		if err != nil {
-			return fmt.Errorf("secondary service CIDR %s is invalid", o.config.NodeIPAM.ServiceCIDRv6)
+			return fmt.Errorf("secondary Service CIDR %s is invalid", o.config.NodeIPAM.ServiceCIDRv6)
 		}
 	}
 

--- a/cmd/antrea-controller/options_test.go
+++ b/cmd/antrea-controller/options_test.go
@@ -23,7 +23,7 @@ import (
 	controllerconfig "antrea.io/antrea/pkg/config/controller"
 )
 
-func TestOptions(t *testing.T) {
+func TestNewOptions(t *testing.T) {
 	op := newOptions()
 	op.setDefaults()
 	assert.Equal(t, apis.AntreaControllerAPIPort, op.config.APIPort, "")
@@ -63,7 +63,7 @@ func TestValidateNodeIPAMControllerOptions(t *testing.T) {
 				NodeCIDRMaskSizeIPv4: 24,
 				NodeCIDRMaskSizeIPv6: 100,
 			},
-			expectedErr: "the node IPv6 CIDR size is too big, the cluster CIDR mask size cannot be greater than 16 more than the Node IPv6 CIDR mask size",
+			expectedErr: "the Node IPv6 CIDR size is too big, the cluster CIDR mask size cannot be greater than 16 more than the Node IPv6 CIDR mask size",
 		},
 		{
 			name: "invalid ClusterCIDRs",
@@ -78,7 +78,7 @@ func TestValidateNodeIPAMControllerOptions(t *testing.T) {
 			expectedErr: "cluster CIDRs [10.10.0.0 a:b::0/64] is invalid",
 		},
 		{
-			name: "invalid ClusterCIDRs num",
+			name: "invalid empty ClusterCIDRs",
 			nodeIPAMConfig: controllerconfig.NodeIPAMConfig{
 				EnableNodeIPAM:       true,
 				ClusterCIDRs:         []string{},
@@ -90,7 +90,7 @@ func TestValidateNodeIPAMControllerOptions(t *testing.T) {
 			expectedErr: "at least one cluster CIDR must be specified",
 		},
 		{
-			name: "invalid ClusterCIDRs num",
+			name: "too many ClusterCIDRs",
 			nodeIPAMConfig: controllerconfig.NodeIPAMConfig{
 				EnableNodeIPAM:       true,
 				ClusterCIDRs:         []string{"10.10.0.0/16", "a:b::0/64", "20.20.0.0/24"},
@@ -114,8 +114,7 @@ func TestValidateNodeIPAMControllerOptions(t *testing.T) {
 			expectedErr: "at most one cluster CIDR may be specified for each IP family",
 		},
 		{
-			// 	ipamIPv4MaskLo is 16, ipamIPv4MaskHi is 30
-			name: "invalid node IPv4 CIDR mask size",
+			name: "invalid Node IPv4 CIDR mask size",
 			nodeIPAMConfig: controllerconfig.NodeIPAMConfig{
 				EnableNodeIPAM:       true,
 				ClusterCIDRs:         []string{"10.10.0.0/16", "a:b::0/64"},
@@ -124,11 +123,10 @@ func TestValidateNodeIPAMControllerOptions(t *testing.T) {
 				NodeCIDRMaskSizeIPv4: 15,
 				NodeCIDRMaskSizeIPv6: 80,
 			},
-			expectedErr: "node IPv4 CIDR mask size 15 is invalid, should be between 16 and 30",
+			expectedErr: "Node IPv4 CIDR mask size 15 is invalid, should be between 16 and 30",
 		},
 		{
-			//	ipamIPv6MaskLo is 64, ipamIPv6MaskHi is 126
-			name: "invalid node IPv6 CIDR mask size",
+			name: "invalid Node IPv6 CIDR mask size",
 			nodeIPAMConfig: controllerconfig.NodeIPAMConfig{
 				EnableNodeIPAM:       true,
 				ClusterCIDRs:         []string{"10.10.0.0/16", "a:b::0/64"},
@@ -137,10 +135,10 @@ func TestValidateNodeIPAMControllerOptions(t *testing.T) {
 				NodeCIDRMaskSizeIPv4: 24,
 				NodeCIDRMaskSizeIPv6: 63,
 			},
-			expectedErr: "node IPv6 CIDR mask size 63 is invalid, should be between 64 and 126",
+			expectedErr: "Node IPv6 CIDR mask size 63 is invalid, should be between 64 and 126",
 		},
 		{
-			name: "invalid service CIDR",
+			name: "invalid Service CIDR",
 			nodeIPAMConfig: controllerconfig.NodeIPAMConfig{
 				EnableNodeIPAM:       true,
 				ClusterCIDRs:         []string{"10.10.0.0/16", "a:b::0/64"},
@@ -149,10 +147,10 @@ func TestValidateNodeIPAMControllerOptions(t *testing.T) {
 				NodeCIDRMaskSizeIPv4: 24,
 				NodeCIDRMaskSizeIPv6: 80,
 			},
-			expectedErr: "service CIDR 1 is invalid",
+			expectedErr: "Service CIDR 1 is invalid",
 		},
 		{
-			name: "invalid secondary service CIDR",
+			name: "invalid secondary Service CIDR",
 			nodeIPAMConfig: controllerconfig.NodeIPAMConfig{
 				EnableNodeIPAM:       true,
 				ClusterCIDRs:         []string{"10.10.0.0/16", "a:b::0/64"},
@@ -161,7 +159,7 @@ func TestValidateNodeIPAMControllerOptions(t *testing.T) {
 				NodeCIDRMaskSizeIPv4: 24,
 				NodeCIDRMaskSizeIPv6: 80,
 			},
-			expectedErr: "secondary service CIDR 2 is invalid",
+			expectedErr: "secondary Service CIDR 2 is invalid",
 		},
 	}
 	for _, tc := range testCases {
@@ -171,7 +169,7 @@ func TestValidateNodeIPAMControllerOptions(t *testing.T) {
 			if tc.expectedErr == "" {
 				assert.NoError(t, err)
 			} else {
-				assert.ErrorContains(t, err, tc.expectedErr, "validate NodeIPAMControllerOptions error is not as expected")
+				assert.ErrorContains(t, err, tc.expectedErr)
 			}
 		})
 	}

--- a/cmd/antrea-controller/options_test.go
+++ b/cmd/antrea-controller/options_test.go
@@ -1,0 +1,178 @@
+// Copyright 2023 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"antrea.io/antrea/pkg/apis"
+	controllerconfig "antrea.io/antrea/pkg/config/controller"
+)
+
+func TestOptions(t *testing.T) {
+	op := newOptions()
+	op.setDefaults()
+	assert.Equal(t, apis.AntreaControllerAPIPort, op.config.APIPort, "")
+	assert.Equal(t, true, *op.config.EnablePrometheusMetrics)
+	assert.Equal(t, true, *op.config.SelfSignedCert)
+	assert.Equal(t, ipamIPv4MaskDefault, op.config.NodeIPAM.NodeCIDRMaskSizeIPv4)
+	assert.Equal(t, ipamIPv6MaskDefault, op.config.NodeIPAM.NodeCIDRMaskSizeIPv6)
+	assert.Equal(t, true, *op.config.IPsecCSRSignerConfig.SelfSignedCA)
+	assert.Equal(t, true, *op.config.IPsecCSRSignerConfig.AutoApprove)
+}
+
+func TestValidateNodeIPAMControllerOptions(t *testing.T) {
+	testCases := []struct {
+		name           string
+		nodeIPAMConfig controllerconfig.NodeIPAMConfig
+		expectedErr    string
+	}{
+		{
+			name: "valid config",
+			nodeIPAMConfig: controllerconfig.NodeIPAMConfig{
+				EnableNodeIPAM:       true,
+				ClusterCIDRs:         []string{"172.100.0.0/20", "fd00:172:100::/60"},
+				ServiceCIDR:          "172.16.0.0/16",
+				ServiceCIDRv6:        "2620:124::0/64",
+				NodeCIDRMaskSizeIPv4: 24,
+				NodeCIDRMaskSizeIPv6: 64,
+			},
+			expectedErr: "",
+		},
+		{
+			name: "invalid Node IPv6 CIDR size",
+			nodeIPAMConfig: controllerconfig.NodeIPAMConfig{
+				EnableNodeIPAM:       true,
+				ClusterCIDRs:         []string{"172.100.0.0/20", "fd00:172:100::/60"},
+				ServiceCIDR:          "172.16.0.0/16",
+				ServiceCIDRv6:        "2620:124::0/64",
+				NodeCIDRMaskSizeIPv4: 24,
+				NodeCIDRMaskSizeIPv6: 100,
+			},
+			expectedErr: "the node IPv6 CIDR size is too big, the cluster CIDR mask size cannot be greater than 16 more than the Node IPv6 CIDR mask size",
+		},
+		{
+			name: "invalid ClusterCIDRs",
+			nodeIPAMConfig: controllerconfig.NodeIPAMConfig{
+				EnableNodeIPAM:       true,
+				ClusterCIDRs:         []string{"10.10.0.0", "a:b::0/64"},
+				ServiceCIDR:          "172.16.0.0/16",
+				ServiceCIDRv6:        "2620:124::0/64",
+				NodeCIDRMaskSizeIPv4: 24,
+				NodeCIDRMaskSizeIPv6: 70,
+			},
+			expectedErr: "cluster CIDRs [10.10.0.0 a:b::0/64] is invalid",
+		},
+		{
+			name: "invalid ClusterCIDRs num",
+			nodeIPAMConfig: controllerconfig.NodeIPAMConfig{
+				EnableNodeIPAM:       true,
+				ClusterCIDRs:         []string{},
+				ServiceCIDR:          "172.16.0.0/16",
+				ServiceCIDRv6:        "2620:124::0/64",
+				NodeCIDRMaskSizeIPv4: 24,
+				NodeCIDRMaskSizeIPv6: 780,
+			},
+			expectedErr: "at least one cluster CIDR must be specified",
+		},
+		{
+			name: "invalid ClusterCIDRs num",
+			nodeIPAMConfig: controllerconfig.NodeIPAMConfig{
+				EnableNodeIPAM:       true,
+				ClusterCIDRs:         []string{"10.10.0.0/16", "a:b::0/64", "20.20.0.0/24"},
+				ServiceCIDR:          "172.16.0.0/16",
+				ServiceCIDRv6:        "2620:124::0/64",
+				NodeCIDRMaskSizeIPv4: 24,
+				NodeCIDRMaskSizeIPv6: 80,
+			},
+			expectedErr: "at most two cluster CIDRs may be specified",
+		},
+		{
+			name: "at most one cluster CIDR of each type",
+			nodeIPAMConfig: controllerconfig.NodeIPAMConfig{
+				EnableNodeIPAM:       true,
+				ClusterCIDRs:         []string{"10.10.0.0/16", "20.20.0.0/24"},
+				ServiceCIDR:          "172.16.0.0/16",
+				ServiceCIDRv6:        "2620:124::0/64",
+				NodeCIDRMaskSizeIPv4: 24,
+				NodeCIDRMaskSizeIPv6: 80,
+			},
+			expectedErr: "at most one cluster CIDR may be specified for each IP family",
+		},
+		{
+			// 	ipamIPv4MaskLo is 16, ipamIPv4MaskHi is 30
+			name: "invalid node IPv4 CIDR mask size",
+			nodeIPAMConfig: controllerconfig.NodeIPAMConfig{
+				EnableNodeIPAM:       true,
+				ClusterCIDRs:         []string{"10.10.0.0/16", "a:b::0/64"},
+				ServiceCIDR:          "172.16.0.0/16",
+				ServiceCIDRv6:        "2620:124::0/64",
+				NodeCIDRMaskSizeIPv4: 15,
+				NodeCIDRMaskSizeIPv6: 80,
+			},
+			expectedErr: "node IPv4 CIDR mask size 15 is invalid, should be between 16 and 30",
+		},
+		{
+			//	ipamIPv6MaskLo is 64, ipamIPv6MaskHi is 126
+			name: "invalid node IPv6 CIDR mask size",
+			nodeIPAMConfig: controllerconfig.NodeIPAMConfig{
+				EnableNodeIPAM:       true,
+				ClusterCIDRs:         []string{"10.10.0.0/16", "a:b::0/64"},
+				ServiceCIDR:          "172.16.0.0/16",
+				ServiceCIDRv6:        "2620:124::0/64",
+				NodeCIDRMaskSizeIPv4: 24,
+				NodeCIDRMaskSizeIPv6: 63,
+			},
+			expectedErr: "node IPv6 CIDR mask size 63 is invalid, should be between 64 and 126",
+		},
+		{
+			name: "invalid service CIDR",
+			nodeIPAMConfig: controllerconfig.NodeIPAMConfig{
+				EnableNodeIPAM:       true,
+				ClusterCIDRs:         []string{"10.10.0.0/16", "a:b::0/64"},
+				ServiceCIDR:          "1",
+				ServiceCIDRv6:        "2620:124::0/64",
+				NodeCIDRMaskSizeIPv4: 24,
+				NodeCIDRMaskSizeIPv6: 80,
+			},
+			expectedErr: "service CIDR 1 is invalid",
+		},
+		{
+			name: "invalid secondary service CIDR",
+			nodeIPAMConfig: controllerconfig.NodeIPAMConfig{
+				EnableNodeIPAM:       true,
+				ClusterCIDRs:         []string{"10.10.0.0/16", "a:b::0/64"},
+				ServiceCIDR:          "172.16.0.0/16",
+				ServiceCIDRv6:        "2",
+				NodeCIDRMaskSizeIPv4: 24,
+				NodeCIDRMaskSizeIPv6: 80,
+			},
+			expectedErr: "secondary service CIDR 2 is invalid",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			o := &Options{config: &controllerconfig.ControllerConfig{NodeIPAM: tc.nodeIPAMConfig}}
+			err := o.validateNodeIPAMControllerOptions()
+			if tc.expectedErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tc.expectedErr, "validate NodeIPAMControllerOptions error is not as expected")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add unit test for cmd/antrea-controller and improve validateNodeIPAMControllerOptions
 
Signed-off-by: Wenqi Qiu <wenqiq@vmware.com>