### PR TITLE
Add L7 Antrea native NetworkPolicy support in controller

### DIFF
--- a/pkg/controller/networkpolicy/antreanetworkpolicy.go
+++ b/pkg/controller/networkpolicy/antreanetworkpolicy.go
@@ -107,6 +107,7 @@ func (n *NetworkPolicyController) processAntreaNetworkPolicy(np *crdv1alpha1.Net
 			Priority:        int32(idx),
 			EnableLogging:   ingressRule.EnableLogging,
 			AppliedToGroups: getAppliedToGroupNames(atgs),
+			L7Protocols:     toAntreaL7ProtocolsForCRD(ingressRule.L7Protocols),
 		})
 	}
 	// Compute NetworkPolicyRule for Egress Rule.
@@ -133,6 +134,7 @@ func (n *NetworkPolicyController) processAntreaNetworkPolicy(np *crdv1alpha1.Net
 			Priority:        int32(idx),
 			EnableLogging:   egressRule.EnableLogging,
 			AppliedToGroups: getAppliedToGroupNames(atgs),
+			L7Protocols:     toAntreaL7ProtocolsForCRD(egressRule.L7Protocols),
 		})
 	}
 	tierPriority := n.getTierPriority(np.Spec.Tier)

--- a/pkg/controller/networkpolicy/antreanetworkpolicy_test.go
+++ b/pkg/controller/networkpolicy/antreanetworkpolicy_test.go
@@ -569,6 +569,56 @@ func TestProcessAntreaNetworkPolicy(t *testing.T) {
 			expectedAppliedToGroups: 1,
 			expectedAddressGroups:   1,
 		},
+		{
+			name: "with-l7Protocol",
+			inputPolicy: &crdv1alpha1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns8", Name: "npH", UID: "uidH"},
+				Spec: crdv1alpha1.NetworkPolicySpec{
+					AppliedTo: []crdv1alpha1.AppliedTo{
+						{PodSelector: &selectorA},
+					},
+					Priority: p10,
+					Ingress: []crdv1alpha1.Rule{
+						{
+							L7Protocols: []crdv1alpha1.L7Protocol{{HTTP: &crdv1alpha1.HTTPProtocol{Host: "test.com", Method: "GET", Path: "/admin"}}},
+							From: []crdv1alpha1.NetworkPolicyPeer{
+								{
+									PodSelector:       &selectorB,
+									NamespaceSelector: &selectorC,
+								},
+							},
+							Action: &allowAction,
+						},
+					},
+				},
+			},
+			expectedPolicy: &antreatypes.NetworkPolicy{
+				UID:  "uidH",
+				Name: "uidH",
+				SourceRef: &controlplane.NetworkPolicyReference{
+					Type:      controlplane.AntreaNetworkPolicy,
+					Namespace: "ns8",
+					Name:      "npH",
+					UID:       "uidH",
+				},
+				Priority:     &p10,
+				TierPriority: &DefaultTierPriority,
+				Rules: []controlplane.NetworkPolicyRule{
+					{
+						Direction: controlplane.DirectionIn,
+						From: controlplane.NetworkPolicyPeer{
+							AddressGroups: []string{getNormalizedUID(antreatypes.NewGroupSelector("", &selectorB, &selectorC, nil, nil).NormalizedName)},
+						},
+						L7Protocols: []controlplane.L7Protocol{{HTTP: &controlplane.HTTPProtocol{Host: "test.com", Method: "GET", Path: "/admin"}}},
+						Priority:    0,
+						Action:      &allowAction,
+					},
+				},
+				AppliedToGroups: []string{getNormalizedUID(antreatypes.NewGroupSelector("ns8", &selectorA, nil, nil, nil).NormalizedName)},
+			},
+			expectedAppliedToGroups: 1,
+			expectedAddressGroups:   1,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/controller/networkpolicy/clusternetworkpolicy.go
+++ b/pkg/controller/networkpolicy/clusternetworkpolicy.go
@@ -371,6 +371,7 @@ func (n *NetworkPolicyController) processClusterNetworkPolicy(cnp *crdv1alpha1.C
 					Priority:        int32(idx),
 					EnableLogging:   cnpRule.EnableLogging,
 					AppliedToGroups: getAppliedToGroupNames(ruleAppliedTos),
+					L7Protocols:     toAntreaL7ProtocolsForCRD(cnpRule.L7Protocols),
 				}
 				if dir == controlplane.DirectionIn {
 					rule.From = *peer

--- a/pkg/controller/networkpolicy/crd_utils.go
+++ b/pkg/controller/networkpolicy/crd_utils.go
@@ -108,6 +108,18 @@ func toAntreaServicesForCRD(npPorts []v1alpha1.NetworkPolicyPort, npProtocols []
 	return antreaServices, namedPortExists
 }
 
+// toAntreaL7ProtocolsForCRD converts a slice of v1alpha1.L7Protocol objects to
+// a slice of Antrea L7Protocol objects.
+func toAntreaL7ProtocolsForCRD(l7Protocols []v1alpha1.L7Protocol) []controlplane.L7Protocol {
+	var antreaL7Protocols []controlplane.L7Protocol
+	for _, l7p := range l7Protocols {
+		antreaL7Protocols = append(antreaL7Protocols, controlplane.L7Protocol{
+			HTTP: (*controlplane.HTTPProtocol)(l7p.HTTP),
+		})
+	}
+	return antreaL7Protocols
+}
+
 // toAntreaIPBlockForCRD converts a v1alpha1.IPBlock to an Antrea IPBlock.
 func toAntreaIPBlockForCRD(ipBlock *v1alpha1.IPBlock) (*controlplane.IPBlock, error) {
 	// Convert the allowed IPBlock to networkpolicy.IPNet.

--- a/pkg/controller/networkpolicy/crd_utils_test.go
+++ b/pkg/controller/networkpolicy/crd_utils_test.go
@@ -206,6 +206,26 @@ func TestToAntreaServicesForCRD(t *testing.T) {
 	}
 }
 
+func TestToAntreaL7ProtocolsForCRD(t *testing.T) {
+	tables := []struct {
+		l7Protocol []crdv1alpha1.L7Protocol
+		expValue   []controlplane.L7Protocol
+	}{
+		{
+			[]crdv1alpha1.L7Protocol{
+				{HTTP: &crdv1alpha1.HTTPProtocol{Host: "test.com", Method: "GET", Path: "/admin"}},
+			},
+			[]controlplane.L7Protocol{
+				{HTTP: &controlplane.HTTPProtocol{Host: "test.com", Method: "GET", Path: "/admin"}},
+			},
+		},
+	}
+	for _, table := range tables {
+		gotValue := toAntreaL7ProtocolsForCRD(table.l7Protocol)
+		assert.Equal(t, table.expValue, gotValue)
+	}
+}
+
 func TestToAntreaIPBlockForCRD(t *testing.T) {
 	expIPNet := controlplane.IPNet{
 		IP:           ipStrToIPAddress("10.0.0.0"),


### PR DESCRIPTION
This PR add support for L7 Antrea native NetworkPolicy in the controller side.

- Added support for passing `L7Protocols` to agent when processing ClusterNetworkPolicy and AntreaNetworkPolicy.
- Added validation for Antrea native policy that checks `L7Protocols` is only used with `Allow` action, not used with `toServices`. When `HTTP` is set, then L4Protocol is only `TCP` or unset, and not with `IGMP` or `ICMP`.
- Added UT.