### PR TITLE
Support more traffic modes for Multi-cluster Gateway

### DIFF
--- a/build/yamls/antrea-prometheus.yml
+++ b/build/yamls/antrea-prometheus.yml
@@ -154,7 +154,6 @@ spec:
           configMap:
             defaultMode: 420
             name: prometheus-server-conf
-
         - name: prometheus-storage-volume
           emptyDir: {}
 ---
@@ -166,7 +165,6 @@ metadata:
   annotations:
       prometheus.io/scrape: 'true'
       prometheus.io/port:   '9090'
-
 spec:
   selector:
     app: prometheus-server

--- a/cmd/antrea-agent/options_linux_test.go
+++ b/cmd/antrea-agent/options_linux_test.go
@@ -28,11 +28,12 @@ import (
 
 func TestMulticlusterOptions(t *testing.T) {
 	tests := []struct {
-		name        string
-		mcConfig    agentconfig.MulticlusterConfig
-		featureGate bool
-		encapMode   string
-		expectedErr string
+		name           string
+		mcConfig       agentconfig.MulticlusterConfig
+		featureGate    bool
+		encapMode      string
+		encryptionMode string
+		expectedErr    string
 	}{
 		{
 			name:        "empty input",
@@ -80,13 +81,14 @@ func TestMulticlusterOptions(t *testing.T) {
 			expectedErr: "Multi-cluster Gateway must be enabled to enable StretchedNetworkPolicy",
 		},
 		{
-			name: "NoEncap",
+			name: "Multicluster with in-cluster WireGuard Encryption",
 			mcConfig: agentconfig.MulticlusterConfig{
 				EnableGateway: true,
 			},
-			featureGate: true,
-			encapMode:   "NoEncap",
-			expectedErr: "Multicluster is only applicable to the encap mode",
+			featureGate:    true,
+			encapMode:      "encap",
+			encryptionMode: "wireguard",
+			expectedErr:    "Multi-cluster Gateway doesn't support in-cluster WireGuard encryption",
 		},
 		{
 			name: "NoEncap and feature disabled",
@@ -103,6 +105,9 @@ func TestMulticlusterOptions(t *testing.T) {
 				FeatureGates:     map[string]bool{"Multicluster": tt.featureGate},
 				TrafficEncapMode: tt.encapMode,
 				Multicluster:     tt.mcConfig,
+			}
+			if tt.encryptionMode != "" {
+				config.TrafficEncryptionMode = tt.encryptionMode
 			}
 			o := &Options{config: config}
 			features.DefaultMutableFeatureGate.SetFromMap(o.config.FeatureGates)

--- a/multicluster/controllers/multicluster/leader/resourceexport_controller.go
+++ b/multicluster/controllers/multicluster/leader/resourceexport_controller.go
@@ -356,12 +356,12 @@ func (r *ResourceExportReconciler) refreshEndpointsResourceImport(
 		}
 		if len(svcResExport.Status.Conditions) > 0 {
 			if svcResExport.Status.Conditions[0].Status != corev1.ConditionTrue {
-				return newResImport, false, fmt.Errorf("corresponding Service type of ResourceExport " + svcResExportName.String() +
-					"has not been converged successfully, retry later")
+				err := fmt.Errorf("the Service type of ResourceExport %s has not been converged successfully, retry later", svcResExportName.String())
+				return newResImport, false, err
 			}
 		} else {
-			return newResImport, false, fmt.Errorf("corresponding Service type of ResourceExport " + svcResExportName.String() +
-				"has not been converged yet, retry later")
+			err := fmt.Errorf("the Service type of ResourceExport %s has not been converged yet, retry later", svcResExportName.String())
+			return newResImport, false, err
 		}
 	}
 

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -385,7 +385,6 @@ func TestInitNodeLocalConfig(t *testing.T) {
 				NodeTransportInterfaceName: ipDevice.Name,
 				NodeTransportIPv4Addr:      nodeIPNet,
 				NodeTransportInterfaceMTU:  tt.expectedNodeLocalIfaceMTU,
-				NodeMTU:                    tt.expectedMTU,
 				UplinkNetConfig:            new(config.AdapterNetConfig),
 			}
 
@@ -596,12 +595,12 @@ func TestSetupGatewayInterface(t *testing.T) {
 		Type:        config.K8sNode,
 		OVSBridge:   "br-int",
 		PodIPv4CIDR: podCIDR,
-		NodeMTU:     1450,
 	}
 	networkConfig := &config.NetworkConfig{
 		TrafficEncapMode: config.TrafficEncapModeEncap,
 		TunnelType:       ovsconfig.GeneveTunnel,
 		TunnelCsum:       false,
+		InterfaceMTU:     1450,
 	}
 
 	mockOVSBridgeClient := ovsconfigtest.NewMockOVSBridgeClient(controller)
@@ -624,7 +623,7 @@ func TestSetupGatewayInterface(t *testing.T) {
 	mockOVSBridgeClient.EXPECT().CreateInternalPort(initializer.hostGateway, ofport, mock.Any(), mock.Any()).Return(portUUID, nil)
 	mockOVSBridgeClient.EXPECT().SetInterfaceMAC(initializer.hostGateway, fakeMAC).Return(nil)
 	mockOVSBridgeClient.EXPECT().GetOFPort(initializer.hostGateway, false).Return(ofport, nil)
-	mockOVSBridgeClient.EXPECT().SetInterfaceMTU(initializer.hostGateway, nodeConfig.NodeMTU).Return(nil)
+	mockOVSBridgeClient.EXPECT().SetInterfaceMTU(initializer.hostGateway, networkConfig.InterfaceMTU).Return(nil)
 	err := initializer.setupGatewayInterface()
 	assert.NoError(t, err)
 }

--- a/pkg/agent/cniserver/interface_configuration_windows.go
+++ b/pkg/agent/cniserver/interface_configuration_windows.go
@@ -189,6 +189,12 @@ func (ic *ifConfigurator) configureContainerLink(
 	return nil
 }
 
+// changeContainerMTU is only used for Antrea Multi-cluster with networkPolicyOnly
+// mode, and this mode doesn't support Windows platform yet.
+func (ic *ifConfigurator) changeContainerMTU(containerNetNS string, containerIFDev string, mtuDeduction int) error {
+	return errors.New("changeContainerMTU is unsupported on Windows")
+}
+
 // createContainerLink creates HNSEndpoint using the IP configuration in the IPAM result.
 func (ic *ifConfigurator) createContainerLink(endpointName string, result *current.Result, containerID, podName, podNamespace string) (hostLink *hcsshim.HNSEndpoint, err error) {
 	containerIP, err := findContainerIPConfig(result.IPs)

--- a/pkg/agent/cniserver/interfaces.go
+++ b/pkg/agent/cniserver/interfaces.go
@@ -31,6 +31,7 @@ type podInterfaceConfigurator interface {
 	getInterceptedInterfaces(sandbox string, containerNetNS string, containerIFDev string) (*current.Interface, *current.Interface, error)
 	checkContainerInterface(containerNetns, containerID string, containerIface *current.Interface, containerIPs []*current.IPConfig, containerRoutes []*cnitypes.Route, sriovVFDeviceID string) (interface{}, error)
 	addPostInterfaceCreateHook(containerID, endpointName string, containerAccess *containerAccessArbitrator, hook postInterfaceCreateHook) error
+	changeContainerMTU(containerNetNS string, containerIFDev string, mtuDeduction int) error
 }
 
 type SriovNet interface {

--- a/pkg/agent/cniserver/pod_configuration_linux_test.go
+++ b/pkg/agent/cniserver/pod_configuration_linux_test.go
@@ -120,6 +120,10 @@ func (c *fakeInterfaceConfigurator) checkContainerInterface(containerNetns, cont
 	return c.containerVethPair, nil
 }
 
+func (c *fakeInterfaceConfigurator) changeContainerMTU(containerNetNS string, containerIFDev string, mtuDeduction int) error {
+	return nil
+}
+
 func newTestInterfaceConfigurator() *fakeInterfaceConfigurator {
 	return &fakeInterfaceConfigurator{
 		containerMAC: "01:02:03:04:05:06",

--- a/pkg/agent/cniserver/server_linux_test.go
+++ b/pkg/agent/cniserver/server_linux_test.go
@@ -211,6 +211,7 @@ func newMockCNIServer(t *testing.T, controller *gomock.Controller, ipamDriver ip
 	if secondaryNetworkEnabled {
 		cniServer.podConfigurator.podInfoStore = cnipodcache.NewCNIPodInfoStore()
 	}
+	cniServer.networkConfig = &config.NetworkConfig{InterfaceMTU: 1450}
 	return cniServer
 }
 

--- a/pkg/agent/cniserver/server_test.go
+++ b/pkg/agent/cniserver/server_test.go
@@ -628,6 +628,7 @@ func newCNIServer(t *testing.T) *CNIServer {
 	}
 	close(networkReadyCh)
 	cniServer.supportedCNIVersions = buildVersionSet()
+	cniServer.networkConfig = &config.NetworkConfig{InterfaceMTU: 1450}
 	return cniServer
 }
 

--- a/pkg/agent/multicluster/pod_route_controller.go
+++ b/pkg/agent/multicluster/pod_route_controller.go
@@ -1,0 +1,382 @@
+// Copyright 2023 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multicluster
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/util/wait"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/kubernetes"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+
+	mcv1alpha1 "antrea.io/antrea/multicluster/apis/multicluster/v1alpha1"
+	"antrea.io/antrea/multicluster/pkg/client/informers/externalversions/multicluster/v1alpha1"
+	mclisters "antrea.io/antrea/multicluster/pkg/client/listers/multicluster/v1alpha1"
+	"antrea.io/antrea/pkg/agent/config"
+	"antrea.io/antrea/pkg/agent/openflow"
+)
+
+const (
+	// The number of workers processing a Pod change
+	podWorkerNum = 5
+
+	dummyKey               = "key"
+	podIndexKey            = "podIP"
+	podRouteControllerName = "MCPodRouteController"
+)
+
+// MCPodRouteController generates L3 forwarding flows to forward cross-cluster
+// traffic from MC Gateway to Pods on other Nodes inside a member cluster. It is
+// required when networkPolicyOnly, noEncap or hybrid mode are configured, to forward
+// the traffic through tunnels between Gateway and other Nodes, as otherwise the
+// traffic will not go through tunnels in those modes.
+type MCPodRouteController struct {
+	k8sClient   kubernetes.Interface
+	ofClient    openflow.Client
+	nodeConfig  *config.NodeConfig
+	podQueue    workqueue.RateLimitingInterface
+	gwQueue     workqueue.RateLimitingInterface
+	podInformer cache.SharedIndexInformer
+	podLister   corelisters.PodLister
+	gwInformer  cache.SharedIndexInformer
+	gwLister    mclisters.GatewayLister
+	// podWorkersStarted is a boolean which tracks if the Pod flow controller has been started.
+	podWorkersStarted      bool
+	podWorkersStartedMutex sync.RWMutex
+	podWorkerStopCh        chan struct{}
+}
+
+func NewMCPodRouteController(
+	k8sClient kubernetes.Interface,
+	gwInformer v1alpha1.GatewayInformer,
+	client openflow.Client,
+	nodeConfig *config.NodeConfig,
+) *MCPodRouteController {
+	controller := &MCPodRouteController{
+		k8sClient:       k8sClient,
+		ofClient:        client,
+		nodeConfig:      nodeConfig,
+		podQueue:        workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(minRetryDelay, maxRetryDelay), "MCPodRouteControllerForPod"),
+		gwQueue:         workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(minRetryDelay, maxRetryDelay), "MCPodRouteControllerForGateway"),
+		gwInformer:      gwInformer.Informer(),
+		gwLister:        gwInformer.Lister(),
+		podWorkerStopCh: make(chan struct{}),
+	}
+
+	controller.gwInformer.AddEventHandlerWithResyncPeriod(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: func(cur interface{}) {
+				controller.enqueueGateway(cur)
+			},
+			// Gateway UPDATE event doesn't impact Pod flows, so ignore it.
+			DeleteFunc: func(old interface{}) {
+				controller.enqueueGateway(old)
+			},
+		},
+		resyncPeriod,
+	)
+	return controller
+}
+
+func podIPIndexFunc(obj interface{}) ([]string, error) {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return nil, fmt.Errorf("obj is not Pod: %+v", obj)
+	}
+	if isValidPod(pod) {
+		return []string{pod.Status.PodIP}, nil
+	}
+	return []string{}, nil
+}
+
+func (c *MCPodRouteController) createPodInformer() {
+	listOptions := func(options *metav1.ListOptions) {
+		options.FieldSelector = fields.OneTermNotEqualSelector("spec.nodeName", c.nodeConfig.Name).String()
+	}
+	c.podInformer = coreinformers.NewFilteredPodInformer(
+		c.k8sClient,
+		metav1.NamespaceAll,
+		0,
+		cache.Indexers{podIndexKey: podIPIndexFunc},
+		listOptions,
+	)
+	c.podInformer.AddEventHandlerWithResyncPeriod(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: func(cur interface{}) {
+				c.createPod(cur)
+			},
+			UpdateFunc: func(old, cur interface{}) {
+				c.updatePod(old, cur)
+			},
+			DeleteFunc: func(old interface{}) {
+				c.deletePod(old)
+			},
+		},
+		resyncPeriod,
+	)
+	c.podLister = corelisters.NewPodLister(c.podInformer.GetIndexer())
+}
+
+func (c *MCPodRouteController) enqueueGateway(obj interface{}) {
+	_, isGW := obj.(*mcv1alpha1.Gateway)
+	if !isGW {
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			klog.ErrorS(nil, "Received unexpected object", "object", obj)
+			return
+		}
+		_, ok = deletedState.Obj.(*mcv1alpha1.Gateway)
+		if !ok {
+			klog.ErrorS(nil, "DeletedFinalStateUnknown contains non-Gateway object", "object", deletedState.Obj)
+			return
+		}
+	}
+	c.gwQueue.Add(dummyKey)
+}
+
+func (c *MCPodRouteController) createPod(obj interface{}) {
+	pod := obj.(*corev1.Pod)
+	if !isValidPod(pod) {
+		return
+	}
+	c.podQueue.Add(pod.Status.PodIP)
+}
+
+func (c *MCPodRouteController) updatePod(old, cur interface{}) {
+	oldPod := old.(*corev1.Pod)
+	curPod := cur.(*corev1.Pod)
+
+	isOldPodValid := isValidPod(oldPod)
+	isCurPodValid := isValidPod(curPod)
+	if !isCurPodValid && !isOldPodValid {
+		return
+	}
+
+	if !isOldPodValid {
+		c.podQueue.Add(curPod.Status.PodIP)
+		return
+	}
+
+	if !isCurPodValid {
+		c.podQueue.Add(oldPod.Status.PodIP)
+		return
+	}
+
+	if oldPod.Status.PodIP != curPod.Status.PodIP {
+		c.podQueue.Add(oldPod.Status.PodIP)
+		c.podQueue.Add(curPod.Status.PodIP)
+		return
+	}
+
+	if oldPod.Status.HostIP != curPod.Status.HostIP {
+		c.podQueue.Add(curPod.Status.PodIP)
+	}
+}
+
+func (c *MCPodRouteController) deletePod(obj interface{}) {
+	pod, isPod := obj.(*corev1.Pod)
+	if !isPod {
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			klog.ErrorS(nil, "Received unexpected object", "object", obj)
+			return
+		}
+		pod, ok = deletedState.Obj.(*corev1.Pod)
+		if !ok {
+			klog.ErrorS(nil, "DeletedFinalStateUnknown contains non-Pod object", "object", deletedState.Obj)
+			return
+		}
+	}
+
+	if isValidPod(pod) {
+		c.podQueue.Add(pod.Status.PodIP)
+	}
+}
+
+func isValidPod(pod *corev1.Pod) bool {
+	if pod.Status.PodIP != "" && pod.Status.HostIP != "" && !pod.Spec.HostNetwork {
+		return true
+	}
+	return false
+}
+
+func (c *MCPodRouteController) Run(stopCh <-chan struct{}) {
+	defer c.gwQueue.ShutDown()
+	defer c.podQueue.ShutDown()
+
+	klog.InfoS("Starting controller", "controller", podRouteControllerName)
+	defer klog.InfoS("Shutting down controller", "controller", podRouteControllerName)
+	if !cache.WaitForNamedCacheSync(podRouteControllerName, stopCh, c.gwInformer.HasSynced) {
+		return
+	}
+	// Run a single routine to handle Gateway events.
+	go wait.Until(c.gatewayWorker, time.Second, stopCh)
+	<-stopCh
+}
+
+func (c *MCPodRouteController) gatewayWorker() {
+	for c.processGatewayNextWorkItem() {
+	}
+}
+
+func (c *MCPodRouteController) processGatewayNextWorkItem() bool {
+	key, quit := c.gwQueue.Get()
+	if quit {
+		return false
+	}
+	defer c.gwQueue.Done(key)
+
+	if k, ok := key.(string); !ok {
+		c.gwQueue.Forget(k)
+		klog.InfoS("Expected string in work queue but got %#v", "object", k)
+		return true
+	} else if err := c.syncGateway(); err == nil {
+		c.gwQueue.Forget(key)
+	} else {
+		c.gwQueue.AddRateLimited(key)
+		klog.ErrorS(err, "Error syncing Gateway, requeuing", "key", key)
+	}
+	return true
+}
+
+func (c *MCPodRouteController) syncGateway() error {
+	activeGW, err := getActiveGateway(c.gwLister)
+	if err != nil {
+		klog.ErrorS(err, "Failed to get an active Gateway")
+		return err
+	}
+
+	c.podWorkersStartedMutex.Lock()
+	defer c.podWorkersStartedMutex.Unlock()
+
+	amIGateway := activeGW != nil && c.nodeConfig.Name == activeGW.Name
+	// Stop Pod flow controller and clean up all installed Multi-cluster Pod flows,
+	// if the Node was a Gateway before.
+	if !amIGateway {
+		if c.podWorkersStarted {
+			klog.InfoS("Shutting down Multi-cluster PodFlowController")
+			close(c.podWorkerStopCh)
+			c.podWorkerStopCh = nil
+			c.podInformer = nil
+			c.podLister = nil
+			c.podWorkersStarted = false
+		}
+	}
+
+	if !amIGateway || (amIGateway && !c.podWorkersStarted) {
+		err := c.ofClient.UninstallMulticlusterPodFlows("")
+		if err != nil {
+			return err
+		}
+	}
+
+	if amIGateway {
+		if !c.podWorkersStarted {
+			klog.InfoS("Starting Multi-cluster PodFlowController")
+			c.podWorkerStopCh = make(chan struct{})
+			c.createPodInformer()
+			go c.podInformer.Run(c.podWorkerStopCh)
+			if !cache.WaitForNamedCacheSync(podRouteControllerName, c.podWorkerStopCh, c.podInformer.HasSynced) {
+				c.podWorkerStopCh = nil
+				c.podInformer = nil
+				c.podLister = nil
+				return errors.New("failed to sync Pod cache")
+			}
+
+			for i := 0; i < podWorkerNum; i++ {
+				go wait.Until(c.podWorker, time.Second, c.podWorkerStopCh)
+			}
+			c.podWorkersStarted = true
+			return nil
+		}
+		// Do nothing when the Pod flow controller is already started since
+		// Pod flow controller will be responsible for handling Pod events to install flows.
+	}
+	return nil
+}
+
+func (c *MCPodRouteController) podWorker() {
+	for c.processPodNextWorkItem() {
+	}
+}
+
+func (c *MCPodRouteController) processPodNextWorkItem() bool {
+	obj, quit := c.podQueue.Get()
+	if quit {
+		return false
+	}
+	defer c.podQueue.Done(obj)
+
+	if k, ok := obj.(string); !ok {
+		c.podQueue.Forget(obj)
+		klog.InfoS("Expected string in work queue but got %#v", "object", obj)
+		return true
+	} else if err := c.syncPod(k); err == nil {
+		c.podQueue.Forget(k)
+	} else {
+		c.podQueue.AddRateLimited(k)
+		klog.ErrorS(err, "Error syncing key, requeuing", "key", k)
+	}
+	return true
+}
+
+func (c *MCPodRouteController) syncPod(podIP string) error {
+	c.podWorkersStartedMutex.RLock()
+	defer c.podWorkersStartedMutex.RUnlock()
+	if !c.podWorkersStarted {
+		return nil
+	}
+
+	pods, _ := c.podInformer.GetIndexer().ByIndex(podIndexKey, podIP)
+	if len(pods) == 0 {
+		klog.V(2).InfoS("Deleting Multi-cluster flows for Pod", "podIP", podIP)
+		if err := c.ofClient.UninstallMulticlusterPodFlows(podIP); err != nil {
+			klog.ErrorS(err, "Failed to uninstall Multi-cluster flows for Pod", "podIP", podIP)
+			return err
+		}
+		return nil
+	}
+
+	latestPod := c.getLatestPod(pods)
+	nodeIP := latestPod.Status.HostIP
+	klog.V(2).InfoS("Adding Multi-cluster flows for Pod", "podIP", podIP, "nodeIP", nodeIP)
+	if err := c.ofClient.InstallMulticlusterPodFlows(net.ParseIP(podIP), net.ParseIP(nodeIP)); err != nil {
+		klog.ErrorS(err, "Failed to install Multi-cluster flows for Pod", "podIP", podIP, "nodeIP", nodeIP)
+		return err
+	}
+	return nil
+}
+
+func (c *MCPodRouteController) getLatestPod(pods []interface{}) *corev1.Pod {
+	lastCreatedPod := pods[0].(*corev1.Pod)
+	for _, podObj := range pods {
+		pod := podObj.(*corev1.Pod)
+		if lastCreatedPod.CreationTimestamp.Before(&pod.CreationTimestamp) {
+			lastCreatedPod = pod
+		}
+	}
+	return lastCreatedPod
+}

--- a/pkg/agent/multicluster/pod_route_controller_test.go
+++ b/pkg/agent/multicluster/pod_route_controller_test.go
@@ -1,0 +1,338 @@
+// Copyright 2023 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package multicluster
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	v1 "k8s.io/client-go/listers/core/v1"
+
+	mcv1alpha1 "antrea.io/antrea/multicluster/apis/multicluster/v1alpha1"
+	mcfake "antrea.io/antrea/multicluster/pkg/client/clientset/versioned/fake"
+	mcinformers "antrea.io/antrea/multicluster/pkg/client/informers/externalversions"
+	mclisters "antrea.io/antrea/multicluster/pkg/client/listers/multicluster/v1alpha1"
+	"antrea.io/antrea/pkg/agent/config"
+	oftest "antrea.io/antrea/pkg/agent/openflow/testing"
+)
+
+var (
+	defaultNs = "default"
+	node1Name = "node-1"
+	ctx       = context.TODO()
+
+	nginx1NoIPs = &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: defaultNs,
+			Name:      "nginx1",
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "node-2",
+		},
+	}
+
+	nginx2WithIPs = &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: defaultNs,
+			Name:      "nginx2",
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "node-2",
+		},
+		Status: corev1.PodStatus{
+			PodIP:  "192.168.1.12",
+			HostIP: "10.170.10.11",
+		},
+	}
+
+	nginx2PodIP  = net.ParseIP("192.168.1.12")
+	nginx2HostIP = net.ParseIP("10.170.10.11")
+
+	nginxWithHostNetwork = &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: defaultNs,
+			Name:      "nginx-hostnetwork",
+		},
+		Spec: corev1.PodSpec{
+			NodeName:    "node-2",
+			HostNetwork: true,
+		},
+		Status: corev1.PodStatus{
+			PodIP:  "10.170.10.15",
+			HostIP: "10.170.10.15",
+		},
+	}
+)
+
+type fakeMCPodRouteController struct {
+	*MCPodRouteController
+	mcClient          *mcfake.Clientset
+	k8sClient         *k8sfake.Clientset
+	informerFactory   informers.SharedInformerFactory
+	mcInformerFactory mcinformers.SharedInformerFactory
+	ofClient          *oftest.MockClient
+}
+
+func newMCPodRouteController(t *testing.T, nodeConfig *config.NodeConfig,
+	k8sClient *k8sfake.Clientset) (*fakeMCPodRouteController, func()) {
+	mcClient := mcfake.NewSimpleClientset()
+	mcInformerFactory := mcinformers.NewSharedInformerFactoryWithOptions(mcClient,
+		0,
+		mcinformers.WithNamespace(defaultNs),
+	)
+	gwInformer := mcInformerFactory.Multicluster().V1alpha1().Gateways()
+
+	informerFactory := informers.NewSharedInformerFactory(k8sClient, 0)
+
+	ctrl := gomock.NewController(t)
+	ofClient := oftest.NewMockClient(ctrl)
+	c := NewMCPodRouteController(
+		k8sClient,
+		gwInformer,
+		ofClient,
+		nodeConfig,
+	)
+	return &fakeMCPodRouteController{
+		MCPodRouteController: c,
+		mcClient:             mcClient,
+		k8sClient:            k8sClient,
+		mcInformerFactory:    mcInformerFactory,
+		informerFactory:      informerFactory,
+		ofClient:             ofClient,
+	}, ctrl.Finish
+}
+
+func TestGatewayEvent(t *testing.T) {
+	k8sClient := k8sfake.NewSimpleClientset([]runtime.Object{nginx1NoIPs, nginx2WithIPs}...)
+	c, closeFn := newMCPodRouteController(t, &config.NodeConfig{Name: node1Name}, k8sClient)
+	defer closeFn()
+	defer c.podQueue.ShutDown()
+	defer c.gwQueue.ShutDown()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	c.informerFactory.Start(stopCh)
+	c.informerFactory.WaitForCacheSync(stopCh)
+	c.mcInformerFactory.Start(stopCh)
+	c.mcInformerFactory.WaitForCacheSync(stopCh)
+	c.createPodInformer()
+	go c.podInformer.Run(stopCh)
+	c.podWorkersStarted = true
+
+	for _, pod := range []*corev1.Pod{nginx1NoIPs, nginx2WithIPs} {
+		if err := waitForPodRealized(c.podLister, pod); err != nil {
+			t.Errorf("Error when waiting for Pod '%s/%s' to be realized, err: %v", pod.Namespace, pod.Name, err)
+		}
+	}
+
+	finishCh := make(chan struct{})
+	go func() {
+		defer close(finishCh)
+
+		// Create a Gateway node-2 in the default Namespace
+		c.mcClient.MulticlusterV1alpha1().Gateways(defaultNs).Create(ctx, &gateway2, metav1.CreateOptions{})
+		// Delete a Gateway node-2 in the default Namespace
+		c.mcClient.MulticlusterV1alpha1().Gateways(defaultNs).Delete(ctx, gateway2.Name, metav1.DeleteOptions{})
+
+		// Create a Gateway node-1
+		c.mcClient.MulticlusterV1alpha1().Gateways(defaultNs).Create(ctx, &gateway1, metav1.CreateOptions{})
+		if err := waitForGatewayRealized(c.gwLister, &gateway1); err != nil {
+			t.Errorf("Error when waiting for Gateway '%s/%s' to be realized, err: %v", gateway1.Namespace, gateway1.Name, err)
+		}
+		c.processGatewayNextWorkItem()
+
+		c.ofClient.EXPECT().InstallMulticlusterPodFlows(nginx2PodIP, nginx2HostIP)
+		c.processPodNextWorkItem()
+
+		// Delete a Gateway node-1
+		c.mcClient.MulticlusterV1alpha1().Gateways(defaultNs).Delete(ctx, gateway1.Name, metav1.DeleteOptions{})
+		c.ofClient.EXPECT().UninstallMulticlusterPodFlows("")
+		c.processGatewayNextWorkItem()
+	}()
+	select {
+	case <-time.After(5 * time.Second):
+		t.Errorf("Test didn't finish in time")
+	case <-finishCh:
+	}
+}
+
+func TestPodEvent(t *testing.T) {
+	k8sClient := k8sfake.NewSimpleClientset([]runtime.Object{nginx2WithIPs}...)
+	c, closeFn := newMCPodRouteController(t, &config.NodeConfig{Name: node1Name}, k8sClient)
+	defer closeFn()
+	defer c.podQueue.ShutDown()
+	defer c.gwQueue.ShutDown()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	c.informerFactory.Start(stopCh)
+	c.informerFactory.WaitForCacheSync(stopCh)
+	c.mcInformerFactory.Start(stopCh)
+	c.mcInformerFactory.WaitForCacheSync(stopCh)
+	c.createPodInformer()
+	go c.podInformer.Run(stopCh)
+	c.podWorkersStarted = true
+
+	if err := waitForPodRealized(c.podLister, nginx2WithIPs); err != nil {
+		t.Errorf("Error when waiting for Pod '%s/%s' to be realized, err: %v", nginx2WithIPs.Namespace, nginx2WithIPs.Name, err)
+	}
+
+	finishCh := make(chan struct{})
+	go func() {
+		defer close(finishCh)
+		// Create a Gateway
+		c.mcClient.MulticlusterV1alpha1().Gateways(defaultNs).Create(ctx, &gateway1, metav1.CreateOptions{})
+		c.ofClient.EXPECT().InstallMulticlusterPodFlows(nginx2PodIP, nginx2HostIP)
+		c.processPodNextWorkItem()
+
+		// Create a Pod without IPs
+		c.k8sClient.CoreV1().Pods(defaultNs).Create(ctx, nginx1NoIPs, metav1.CreateOptions{})
+		if err := waitForPodRealized(c.podLister, nginx1NoIPs); err != nil {
+			t.Errorf("Error when waiting for Pod '%s/%s' to be realized, err: %v", nginx1NoIPs.Namespace, nginx1NoIPs.Name, err)
+		}
+
+		// Update a Pod's label
+		nginx1NoIPsWithLabel := nginx1NoIPs.DeepCopy()
+		nginx1NoIPsWithLabel.Labels = map[string]string{"pod": "noip"}
+		c.k8sClient.CoreV1().Pods(defaultNs).Update(ctx, nginx1NoIPsWithLabel, metav1.UpdateOptions{})
+		if err := waitForPodLabelUpdate(c.podLister, nginx1NoIPsWithLabel); err != nil {
+			t.Errorf("Error when waiting for Pod '%s/%s' to be updated, err: %v", nginx1NoIPsWithLabel.Namespace, nginx1NoIPsWithLabel.Name, err)
+		}
+
+		// Create a Pod with hostNetwork
+		c.k8sClient.CoreV1().Pods(defaultNs).Create(ctx, nginxWithHostNetwork, metav1.CreateOptions{})
+		if err := waitForPodRealized(c.podLister, nginxWithHostNetwork); err != nil {
+			t.Errorf("Error when waiting for Pod '%s/%s' to be realized, err: %v", nginxWithHostNetwork.Namespace, nginxWithHostNetwork.Name, err)
+		}
+
+		// Update a Pod with empty host IP
+		nginx2WithIPsNew := nginx2WithIPs.DeepCopy()
+		nginx2WithIPsNew.Status.HostIP = ""
+		c.k8sClient.CoreV1().Pods(defaultNs).Update(ctx, nginx2WithIPsNew, metav1.UpdateOptions{})
+		if err := waitForPodIPUpdate(c.podLister, nginx2WithIPsNew); err != nil {
+			t.Errorf("Error when waiting for Pod '%s/%s' to be updated, err: %v", nginx2WithIPsNew.Namespace, nginx2WithIPsNew.Name, err)
+		}
+		c.ofClient.EXPECT().UninstallMulticlusterPodFlows("192.168.1.12")
+		c.processPodNextWorkItem()
+
+		// Delete an invalid Pod
+		c.k8sClient.CoreV1().Pods(defaultNs).Delete(ctx, nginx2WithIPsNew.Name, metav1.DeleteOptions{})
+
+		// Update a Pod with IPs
+		nginx1Updated := nginx1NoIPs.DeepCopy()
+		nginx1Updated.Status.PodIP = "192.168.10.11"
+		nginx1Updated.Status.HostIP = "172.16.10.11"
+		c.k8sClient.CoreV1().Pods(defaultNs).Update(ctx, nginx1Updated, metav1.UpdateOptions{})
+		if err := waitForPodIPUpdate(c.podLister, nginx1Updated); err != nil {
+			t.Errorf("Error when waiting for Pod '%s/%s' to be updated, err: %v", nginx1Updated.Namespace, nginx1Updated.Name, err)
+		}
+		c.ofClient.EXPECT().InstallMulticlusterPodFlows(net.ParseIP("192.168.10.11"), net.ParseIP("172.16.10.11"))
+		c.processPodNextWorkItem()
+
+		// Update a Pod with new host IP
+		nginx1UpdatedHostIP := nginx1Updated.DeepCopy()
+		nginx1UpdatedHostIP.Status.HostIP = "172.16.12.12"
+		c.k8sClient.CoreV1().Pods(defaultNs).Update(ctx, nginx1UpdatedHostIP, metav1.UpdateOptions{})
+		if err := waitForPodIPUpdate(c.podLister, nginx1UpdatedHostIP); err != nil {
+			t.Errorf("Error when waiting for Pod '%s/%s' to be updated, err: %v", nginx1UpdatedHostIP.Namespace, nginx1UpdatedHostIP.Name, err)
+		}
+		c.ofClient.EXPECT().InstallMulticlusterPodFlows(net.ParseIP("192.168.10.11"), net.ParseIP("172.16.12.12"))
+		c.processPodNextWorkItem()
+
+		// Update a Pod's label
+		nginx1UpdatedLabel := nginx1Updated.DeepCopy()
+		nginx1UpdatedLabel.Labels = map[string]string{"env": "test"}
+		c.k8sClient.CoreV1().Pods(defaultNs).Update(ctx, nginx1UpdatedLabel, metav1.UpdateOptions{})
+		if err := waitForPodLabelUpdate(c.podLister, nginx1UpdatedLabel); err != nil {
+			t.Errorf("Error when waiting for Pod '%s/%s' to be updated, err: %v", nginx1UpdatedLabel.Namespace, nginx1UpdatedLabel.Name, err)
+		}
+
+		// Update the old Pod with a new IP
+		nginx1UpdatedWithNewIP := nginx1NoIPs.DeepCopy()
+		nginx1UpdatedWithNewIP.Status.PodIP = "192.168.110.10"
+		nginx1UpdatedWithNewIP.Status.HostIP = "172.16.10.11"
+		nginx1UpdatedWithNewIP.CreationTimestamp = metav1.NewTime(time.Now())
+		c.k8sClient.CoreV1().Pods(defaultNs).Update(ctx, nginx1UpdatedWithNewIP, metav1.UpdateOptions{})
+		if err := waitForPodIPUpdate(c.podLister, nginx1UpdatedWithNewIP); err != nil {
+			t.Errorf("Error when waiting for Pod '%s/%s' to be updated, err: %v", nginx1UpdatedWithNewIP.Namespace, nginx1UpdatedWithNewIP.Name, err)
+		}
+		c.ofClient.EXPECT().UninstallMulticlusterPodFlows("192.168.10.11")
+		c.ofClient.EXPECT().InstallMulticlusterPodFlows(net.ParseIP("192.168.110.10"), net.ParseIP("172.16.10.11"))
+		c.processPodNextWorkItem()
+		c.processPodNextWorkItem()
+
+		// Create a Pod with the same Pod IP
+		nginx1DupIP := nginx1UpdatedWithNewIP.DeepCopy()
+		nginx1DupIP.Name = "nginx-1-dup-ip"
+		nginx1DupIP.Status.HostIP = "172.16.10.11"
+		nginx1DupIP.CreationTimestamp = metav1.NewTime(time.Now().Add(5 * time.Minute))
+		c.k8sClient.CoreV1().Pods(defaultNs).Create(ctx, nginx1DupIP, metav1.CreateOptions{})
+		if err := waitForPodRealized(c.podLister, nginx1DupIP); err != nil {
+			t.Errorf("Error when waiting for Pod '%s/%s' to be realized, err: %v", nginx1DupIP.Namespace, nginx1DupIP.Name, err)
+		}
+
+		// Update the old Pod with an empty IP
+		nginx1UpdatedWithEmptyIP := nginx1UpdatedWithNewIP.DeepCopy()
+		nginx1UpdatedWithEmptyIP.Status.HostIP = "172.16.10.11"
+		c.k8sClient.CoreV1().Pods(defaultNs).Update(ctx, nginx1UpdatedWithEmptyIP, metav1.UpdateOptions{})
+		if err := waitForPodIPUpdate(c.podLister, nginx1UpdatedWithEmptyIP); err != nil {
+			t.Errorf("Error when waiting for Pod '%s/%s' to be updated, err: %v", nginx1UpdatedWithEmptyIP.Namespace, nginx1UpdatedWithEmptyIP.Name, err)
+		}
+		c.ofClient.EXPECT().InstallMulticlusterPodFlows(net.ParseIP("192.168.110.10"), net.ParseIP("172.16.10.11"))
+		c.processPodNextWorkItem()
+
+		// Delete the old Pod
+		c.k8sClient.CoreV1().Pods(defaultNs).Delete(ctx, nginx1UpdatedWithEmptyIP.Name, metav1.DeleteOptions{})
+
+		// Delete the new Pod
+		c.k8sClient.CoreV1().Pods(defaultNs).Delete(ctx, nginx1DupIP.Name, metav1.DeleteOptions{})
+		c.ofClient.EXPECT().UninstallMulticlusterPodFlows("192.168.110.10")
+		c.processPodNextWorkItem()
+	}()
+	select {
+	case <-time.After(5 * time.Second):
+		t.Errorf("Test didn't finish in time")
+	case <-finishCh:
+	}
+}
+
+func waitForGatewayRealized(gwLister mclisters.GatewayLister, gateway *mcv1alpha1.Gateway) error {
+	return wait.Poll(interval, timeout, func() (bool, error) {
+		_, err := gwLister.Gateways(gateway.Namespace).Get(gateway.Name)
+		if err != nil {
+			return false, nil
+		}
+		return true, err
+	})
+}
+
+func waitForPodIPUpdate(podLister v1.PodLister, pod *corev1.Pod) error {
+	return wait.Poll(interval, timeout, func() (bool, error) {
+		getPod, err := podLister.Pods(pod.Namespace).Get(pod.Name)
+		if err != nil || pod.Status.PodIP != getPod.Status.PodIP || pod.Status.HostIP != getPod.Status.HostIP {
+			return false, nil
+		}
+		return true, err
+	})
+}

--- a/pkg/agent/openflow/testing/mock_openflow.go
+++ b/pkg/agent/openflow/testing/mock_openflow.go
@@ -367,6 +367,20 @@ func (mr *MockClientMockRecorder) InstallMulticlusterNodeFlows(arg0, arg1, arg2,
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallMulticlusterNodeFlows", reflect.TypeOf((*MockClient)(nil).InstallMulticlusterNodeFlows), arg0, arg1, arg2, arg3)
 }
 
+// InstallMulticlusterPodFlows mocks base method
+func (m *MockClient) InstallMulticlusterPodFlows(arg0, arg1 net.IP) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InstallMulticlusterPodFlows", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// InstallMulticlusterPodFlows indicates an expected call of InstallMulticlusterPodFlows
+func (mr *MockClientMockRecorder) InstallMulticlusterPodFlows(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallMulticlusterPodFlows", reflect.TypeOf((*MockClient)(nil).InstallMulticlusterPodFlows), arg0, arg1)
+}
+
 // InstallNodeFlows mocks base method
 func (m *MockClient) InstallNodeFlows(arg0 string, arg1 map[*net.IPNet]net.IP, arg2 *ip.DualStackIPs, arg3 uint32, arg4 net.HardwareAddr) error {
 	m.ctrl.T.Helper()
@@ -835,6 +849,20 @@ func (m *MockClient) UninstallMulticlusterFlows(arg0 string) error {
 func (mr *MockClientMockRecorder) UninstallMulticlusterFlows(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UninstallMulticlusterFlows", reflect.TypeOf((*MockClient)(nil).UninstallMulticlusterFlows), arg0)
+}
+
+// UninstallMulticlusterPodFlows mocks base method
+func (m *MockClient) UninstallMulticlusterPodFlows(arg0 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UninstallMulticlusterPodFlows", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UninstallMulticlusterPodFlows indicates an expected call of UninstallMulticlusterPodFlows
+func (mr *MockClientMockRecorder) UninstallMulticlusterPodFlows(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UninstallMulticlusterPodFlows", reflect.TypeOf((*MockClient)(nil).UninstallMulticlusterPodFlows), arg0)
 }
 
 // UninstallNodeFlows mocks base method

--- a/test/integration/agent/cniserver_test.go
+++ b/test/integration/agent/cniserver_test.go
@@ -564,14 +564,13 @@ func (tester *cmdAddDelTester) cmdDelTest(tc testCase, dataDir string) {
 func newTester() *cmdAddDelTester {
 	tester := &cmdAddDelTester{}
 	ifaceStore := interfacestore.NewInterfaceStore()
-	testNodeConfig.NodeMTU = 1450
 	tester.networkReadyCh = make(chan struct{})
 	tester.server = cniserver.New(testSock,
 		"",
 		testNodeConfig,
 		k8sFake.NewSimpleClientset(),
 		routeMock,
-		false, false, false, false,
+		false, false, false, false, &config.NetworkConfig{InterfaceMTU: 1450},
 		tester.networkReadyCh)
 	tester.server.Initialize(ovsServiceMock, ofServiceMock, ifaceStore, channel.NewSubscribableChannel("PodUpdate", 100), nil)
 	ctx := context.Background()
@@ -735,7 +734,7 @@ func setupChainTest(
 			testNodeConfig,
 			k8sFake.NewSimpleClientset(),
 			routeMock,
-			true, false, false, false,
+			true, false, false, false, &config.NetworkConfig{InterfaceMTU: 1450},
 			networkReadyCh)
 	} else {
 		server = inServer
@@ -859,7 +858,6 @@ func init() {
 	gwMAC, _ = net.ParseMAC("11:11:11:11:11:11")
 	nodeGateway := &config.GatewayConfig{IPv4: gwIP, MAC: gwMAC, Name: ""}
 	_, nodePodCIDR, _ := net.ParseCIDR("192.168.1.0/24")
-	nodeMTU := 1500
 
-	testNodeConfig = &config.NodeConfig{Name: nodeName, PodIPv4CIDR: nodePodCIDR, NodeMTU: nodeMTU, GatewayConfig: nodeGateway}
+	testNodeConfig = &config.NodeConfig{Name: nodeName, PodIPv4CIDR: nodePodCIDR, GatewayConfig: nodeGateway}
 }


### PR DESCRIPTION
In order to support multi-cluster traffic when the member cluster is deployed with networkPolicyOnly, noEncap and hybrid mode, antrea-agent will be responsible for the following:

1. Create tunnel interface `antrea-tun0` for cross-cluster traffic
2. Watch all Pods on the Gateway and set up one rule per Pod in L3Fowarding table as long as the Pod is running on a regular Node instead of the Gateway.
3. Update container interface's MTU with the tunnel header size deducted.

For #4383 
The change is based on PR #4508, please review the top commit, thanks.

Signed-off-by: Lan Luo <luola@vmware.com>