### PR TITLE
Update multi-cluster manifests and add CI check

### DIFF
--- a/ci/check-manifest.sh
+++ b/ci/check-manifest.sh
@@ -40,8 +40,19 @@ rm "${YAMLS[@]}"
 make manifest
 diff="$(git status --porcelain ${YAMLS[@]})"
 
-if [ ! -z "$diff" ]; then
+MULTICLUSTER_YAMLS=(
+    "multicluster/build/yamls/antrea-multicluster-leader-global.yml"
+    "multicluster/build/yamls/antrea-multicluster-leader-namespaced.yml"
+    "multicluster/build/yamls/antrea-multicluster-member.yml"
+)
+
+rm "${MULTICLUSTER_YAMLS[@]}"
+cd multicluster; make manifests; cd ..
+mcdiff="$(git status --porcelain ${MULTICLUSTER_YAMLS[@]})"
+
+if [[ ! -z "$diff" || ! -z "$mcdiff" ]]; then
     echoerr "The generated manifest YAMLs are not up-to-date"
-    echoerr "You can regenerate them with 'make manifest' and commit the changes"
+    echoerr "Out-of-date manifests are: \n${diff}${mcdiff}"
+    echoerr "You can regenerate them with 'make manifest' or 'cd multicluster; make manifests', and commit the changes"
     exit 1
 fi

--- a/multicluster/build/yamls/antrea-multicluster-leader-global.yml
+++ b/multicluster/build/yamls/antrea-multicluster-leader-global.yml
@@ -395,15 +395,15 @@ spec:
                     description: Select workloads on which the rules will be applied
                       to. Cannot be set in conjunction with AppliedTo in each rule.
                     items:
-                      description: NetworkPolicyPeer describes the grouping selector
-                        of workloads.
+                      description: AppliedTo describes the grouping selector of workloads
+                        in AppliedTo field.
                       properties:
                         externalEntitySelector:
                           description: Select ExternalEntities from NetworkPolicy's
-                            Namespace as workloads in AppliedTo/To/From fields. If
-                            set with NamespaceSelector, ExternalEntities are matched
-                            from Namespaces matched by the NamespaceSelector. Cannot
-                            be set with any other selector except NamespaceSelector.
+                            Namespace as workloads in AppliedTo fields. If set with
+                            NamespaceSelector, ExternalEntities are matched from Namespaces
+                            matched by the NamespaceSelector. Cannot be set with any
+                            other selector except NamespaceSelector.
                           properties:
                             matchExpressions:
                               description: matchExpressions is a list of label selector
@@ -447,35 +447,14 @@ spec:
                                 contains only "value". The requirements are ANDed.
                               type: object
                           type: object
-                        fqdn:
-                          description: 'Restrict egress access to the Fully Qualified
-                            Domain Names prescribed by name or by wildcard match patterns.
-                            This field can only be set for NetworkPolicyPeer of egress
-                            rules. Supported formats are: Exact FQDNs, i.e. "google.com",
-                            "db-svc.default.svc.cluster.local" Wildcard expressions,
-                            i.e. "*wayfair.com".'
-                          type: string
                         group:
                           description: Group is the name of the ClusterGroup which
-                            can be set as an AppliedTo or within an Ingress or Egress
-                            rule in place of a stand-alone selector. A Group cannot
-                            be set with any other selector.
+                            can be set as an AppliedTo in place of a stand-alone selector.
+                            A Group cannot be set with any other selector.
                           type: string
-                        ipBlock:
-                          description: IPBlock describes the IPAddresses/IPBlocks
-                            that is matched in to/from. IPBlock cannot be set as part
-                            of the AppliedTo field. Cannot be set with any other selector.
-                          properties:
-                            cidr:
-                              description: CIDR is a string representing the IP Block
-                                Valid examples are "192.168.1.1/24".
-                              type: string
-                          required:
-                          - cidr
-                          type: object
                         namespaceSelector:
                           description: Select all Pods from Namespaces matched by
-                            this selector, as workloads in To/From fields. If set
+                            this selector, as workloads in AppliedTo fields. If set
                             with PodSelector, Pods are matched from Namespaces matched
                             by the NamespaceSelector. Cannot be set with any other
                             selector except PodSelector or ExternalEntitySelector.
@@ -523,74 +502,11 @@ spec:
                                 contains only "value". The requirements are ANDed.
                               type: object
                           type: object
-                        namespaces:
-                          description: 'Select Pod/ExternalEntity from Namespaces
-                            matched by specifc criteria. Current supported criteria
-                            is match: Self, which selects from the same Namespace
-                            of the appliedTo workloads. Cannot be set with any other
-                            selector except PodSelector or ExternalEntitySelector.
-                            This field can only be set when NetworkPolicyPeer is created
-                            for ClusterNetworkPolicy ingress/egress rules. Cannot
-                            be set with NamespaceSelector.'
-                          properties:
-                            match:
-                              description: NamespaceMatchType describes Namespace
-                                matching strategy.
-                              type: string
-                          type: object
-                        nodeSelector:
-                          description: Select certain Nodes which match the label
-                            selector. A NodeSelector cannot be set in AppliedTo field
-                            or set with any other selector.
-                          properties:
-                            matchExpressions:
-                              description: matchExpressions is a list of label selector
-                                requirements. The requirements are ANDed.
-                              items:
-                                description: A label selector requirement is a selector
-                                  that contains values, a key, and an operator that
-                                  relates the key and values.
-                                properties:
-                                  key:
-                                    description: key is the label key that the selector
-                                      applies to.
-                                    type: string
-                                  operator:
-                                    description: operator represents a key's relationship
-                                      to a set of values. Valid operators are In,
-                                      NotIn, Exists and DoesNotExist.
-                                    type: string
-                                  values:
-                                    description: values is an array of string values.
-                                      If the operator is In or NotIn, the values array
-                                      must be non-empty. If the operator is Exists
-                                      or DoesNotExist, the values array must be empty.
-                                      This array is replaced during a strategic merge
-                                      patch.
-                                    items:
-                                      type: string
-                                    type: array
-                                required:
-                                - key
-                                - operator
-                                type: object
-                              type: array
-                            matchLabels:
-                              additionalProperties:
-                                type: string
-                              description: matchLabels is a map of {key,value} pairs.
-                                A single {key,value} in the matchLabels map is equivalent
-                                to an element of matchExpressions, whose key field
-                                is "key", the operator is "In", and the values array
-                                contains only "value". The requirements are ANDed.
-                              type: object
-                          type: object
                         podSelector:
                           description: Select Pods from NetworkPolicy's Namespace
-                            as workloads in AppliedTo/To/From fields. If set with
-                            NamespaceSelector, Pods are matched from Namespaces matched
-                            by the NamespaceSelector. Cannot be set with any other
-                            selector except NamespaceSelector.
+                            as workloads in AppliedTo fields. If set with NamespaceSelector,
+                            Pods are matched from Namespaces matched by the NamespaceSelector.
+                            Cannot be set with any other selector except NamespaceSelector.
                           properties:
                             matchExpressions:
                               description: matchExpressions is a list of label selector
@@ -634,10 +550,6 @@ spec:
                                 contains only "value". The requirements are ANDed.
                               type: object
                           type: object
-                        scope:
-                          description: Define scope of the Pod/NamespaceSelector(s)
-                            of this peer. Can only be used in ingress NetworkPolicyPeers.
-                          type: string
                         service:
                           description: Select a certain Service which matches the
                             NamespacedName. A Service can only be set in either policy
@@ -653,8 +565,8 @@ spec:
                           type: object
                         serviceAccount:
                           description: Select all Pods with the ServiceAccount matched
-                            by this field, as workloads in AppliedTo/To/From fields.
-                            Cannot be set with any other selector.
+                            by this field, as workloads in AppliedTo fields. Cannot
+                            be set with any other selector.
                           properties:
                             name:
                               type: string
@@ -681,14 +593,14 @@ spec:
                           description: Select workloads on which this rule will be
                             applied to. Cannot be set in conjunction with NetworkPolicySpec/ClusterNetworkPolicySpec.AppliedTo.
                           items:
-                            description: NetworkPolicyPeer describes the grouping
-                              selector of workloads.
+                            description: AppliedTo describes the grouping selector
+                              of workloads in AppliedTo field.
                             properties:
                               externalEntitySelector:
                                 description: Select ExternalEntities from NetworkPolicy's
-                                  Namespace as workloads in AppliedTo/To/From fields.
-                                  If set with NamespaceSelector, ExternalEntities
-                                  are matched from Namespaces matched by the NamespaceSelector.
+                                  Namespace as workloads in AppliedTo fields. If set
+                                  with NamespaceSelector, ExternalEntities are matched
+                                  from Namespaces matched by the NamespaceSelector.
                                   Cannot be set with any other selector except NamespaceSelector.
                                 properties:
                                   matchExpressions:
@@ -735,36 +647,14 @@ spec:
                                       The requirements are ANDed.
                                     type: object
                                 type: object
-                              fqdn:
-                                description: 'Restrict egress access to the Fully
-                                  Qualified Domain Names prescribed by name or by
-                                  wildcard match patterns. This field can only be
-                                  set for NetworkPolicyPeer of egress rules. Supported
-                                  formats are: Exact FQDNs, i.e. "google.com", "db-svc.default.svc.cluster.local"
-                                  Wildcard expressions, i.e. "*wayfair.com".'
-                                type: string
                               group:
                                 description: Group is the name of the ClusterGroup
-                                  which can be set as an AppliedTo or within an Ingress
-                                  or Egress rule in place of a stand-alone selector.
-                                  A Group cannot be set with any other selector.
+                                  which can be set as an AppliedTo in place of a stand-alone
+                                  selector. A Group cannot be set with any other selector.
                                 type: string
-                              ipBlock:
-                                description: IPBlock describes the IPAddresses/IPBlocks
-                                  that is matched in to/from. IPBlock cannot be set
-                                  as part of the AppliedTo field. Cannot be set with
-                                  any other selector.
-                                properties:
-                                  cidr:
-                                    description: CIDR is a string representing the
-                                      IP Block Valid examples are "192.168.1.1/24".
-                                    type: string
-                                required:
-                                - cidr
-                                type: object
                               namespaceSelector:
                                 description: Select all Pods from Namespaces matched
-                                  by this selector, as workloads in To/From fields.
+                                  by this selector, as workloads in AppliedTo fields.
                                   If set with PodSelector, Pods are matched from Namespaces
                                   matched by the NamespaceSelector. Cannot be set
                                   with any other selector except PodSelector or ExternalEntitySelector.
@@ -814,76 +704,12 @@ spec:
                                       The requirements are ANDed.
                                     type: object
                                 type: object
-                              namespaces:
-                                description: 'Select Pod/ExternalEntity from Namespaces
-                                  matched by specifc criteria. Current supported criteria
-                                  is match: Self, which selects from the same Namespace
-                                  of the appliedTo workloads. Cannot be set with any
-                                  other selector except PodSelector or ExternalEntitySelector.
-                                  This field can only be set when NetworkPolicyPeer
-                                  is created for ClusterNetworkPolicy ingress/egress
-                                  rules. Cannot be set with NamespaceSelector.'
-                                properties:
-                                  match:
-                                    description: NamespaceMatchType describes Namespace
-                                      matching strategy.
-                                    type: string
-                                type: object
-                              nodeSelector:
-                                description: Select certain Nodes which match the
-                                  label selector. A NodeSelector cannot be set in
-                                  AppliedTo field or set with any other selector.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: A label selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's
-                                            relationship to a set of values. Valid
-                                            operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If
-                                            the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array
-                                            is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value".
-                                      The requirements are ANDed.
-                                    type: object
-                                type: object
                               podSelector:
                                 description: Select Pods from NetworkPolicy's Namespace
-                                  as workloads in AppliedTo/To/From fields. If set
-                                  with NamespaceSelector, Pods are matched from Namespaces
-                                  matched by the NamespaceSelector. Cannot be set
-                                  with any other selector except NamespaceSelector.
+                                  as workloads in AppliedTo fields. If set with NamespaceSelector,
+                                  Pods are matched from Namespaces matched by the
+                                  NamespaceSelector. Cannot be set with any other
+                                  selector except NamespaceSelector.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label
@@ -929,10 +755,6 @@ spec:
                                       The requirements are ANDed.
                                     type: object
                                 type: object
-                              scope:
-                                description: Define scope of the Pod/NamespaceSelector(s)
-                                  of this peer. Can only be used in ingress NetworkPolicyPeers.
-                                type: string
                               service:
                                 description: Select a certain Service which matches
                                   the NamespacedName. A Service can only be set in
@@ -949,7 +771,7 @@ spec:
                                 type: object
                               serviceAccount:
                                 description: Select all Pods with the ServiceAccount
-                                  matched by this field, as workloads in AppliedTo/To/From
+                                  matched by this field, as workloads in AppliedTo
                                   fields. Cannot be set with any other selector.
                                 properties:
                                   name:
@@ -974,9 +796,9 @@ spec:
                             properties:
                               externalEntitySelector:
                                 description: Select ExternalEntities from NetworkPolicy's
-                                  Namespace as workloads in AppliedTo/To/From fields.
-                                  If set with NamespaceSelector, ExternalEntities
-                                  are matched from Namespaces matched by the NamespaceSelector.
+                                  Namespace as workloads in To/From fields. If set
+                                  with NamespaceSelector, ExternalEntities are matched
+                                  from Namespaces matched by the NamespaceSelector.
                                   Cannot be set with any other selector except NamespaceSelector.
                                 properties:
                                   matchExpressions:
@@ -1033,9 +855,9 @@ spec:
                                 type: string
                               group:
                                 description: Group is the name of the ClusterGroup
-                                  which can be set as an AppliedTo or within an Ingress
-                                  or Egress rule in place of a stand-alone selector.
-                                  A Group cannot be set with any other selector.
+                                  which can be set within an Ingress or Egress rule
+                                  in place of a stand-alone selector. A Group cannot
+                                  be set with any other selector.
                                 type: string
                               ipBlock:
                                 description: IPBlock describes the IPAddresses/IPBlocks
@@ -1104,13 +926,13 @@ spec:
                                 type: object
                               namespaces:
                                 description: 'Select Pod/ExternalEntity from Namespaces
-                                  matched by specifc criteria. Current supported criteria
-                                  is match: Self, which selects from the same Namespace
-                                  of the appliedTo workloads. Cannot be set with any
-                                  other selector except PodSelector or ExternalEntitySelector.
-                                  This field can only be set when NetworkPolicyPeer
-                                  is created for ClusterNetworkPolicy ingress/egress
-                                  rules. Cannot be set with NamespaceSelector.'
+                                  matched by specific criteria. Current supported
+                                  criteria is match: Self, which selects from the
+                                  same Namespace of the appliedTo workloads. Cannot
+                                  be set with any other selector except PodSelector
+                                  or ExternalEntitySelector. This field can only be
+                                  set when NetworkPolicyPeer is created for ClusterNetworkPolicy
+                                  ingress/egress rules. Cannot be set with NamespaceSelector.'
                                 properties:
                                   match:
                                     description: NamespaceMatchType describes Namespace
@@ -1168,10 +990,10 @@ spec:
                                 type: object
                               podSelector:
                                 description: Select Pods from NetworkPolicy's Namespace
-                                  as workloads in AppliedTo/To/From fields. If set
-                                  with NamespaceSelector, Pods are matched from Namespaces
-                                  matched by the NamespaceSelector. Cannot be set
-                                  with any other selector except NamespaceSelector.
+                                  as workloads in To/From fields. If set with NamespaceSelector,
+                                  Pods are matched from Namespaces matched by the
+                                  NamespaceSelector. Cannot be set with any other
+                                  selector except NamespaceSelector.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label
@@ -1220,29 +1042,52 @@ spec:
                               scope:
                                 description: Define scope of the Pod/NamespaceSelector(s)
                                   of this peer. Can only be used in ingress NetworkPolicyPeers.
+                                  Defaults to "Cluster".
                                 type: string
-                              service:
-                                description: Select a certain Service which matches
-                                  the NamespacedName. A Service can only be set in
-                                  either policy level AppliedTo field in a policy
-                                  that only has ingress rules or rule level AppliedTo
-                                  field in an ingress rule. Only a NodePort Service
-                                  can be referred by this field. Cannot be set with
-                                  any other selector.
+                              serviceAccount:
+                                description: Select all Pods with the ServiceAccount
+                                  matched by this field, as workloads in To/From fields.
+                                  Cannot be set with any other selector.
                                 properties:
                                   name:
                                     type: string
                                   namespace:
                                     type: string
                                 type: object
-                              serviceAccount:
-                                description: Select all Pods with the ServiceAccount
-                                  matched by this field, as workloads in AppliedTo/To/From
-                                  fields. Cannot be set with any other selector.
+                            type: object
+                          type: array
+                        l7Protocols:
+                          description: Set of layer 7 protocols matched by the rule.
+                            If this field is set, action can only be Allow. When this
+                            field is used in a rule, any traffic matching the other
+                            layer 3/4 criteria of the rule (typically the 5-tuple)
+                            will be forwarded to an application-aware engine for protocol
+                            detection and rule enforcement, and the traffic will be
+                            allowed if the layer 7 criteria is also matched, otherwise
+                            it will be dropped. Therefore, any rules after a layer
+                            7 rule will not be enforced for the traffic.
+                          items:
+                            properties:
+                              http:
+                                description: HTTPProtocol matches HTTP requests with
+                                  specific host, method, and path. All fields could
+                                  be used alone or together. If all fields are not
+                                  provided, it matches all HTTP requests.
                                 properties:
-                                  name:
+                                  host:
+                                    description: Host represents the hostname present
+                                      in the URI or the HTTP Host header to match.
+                                      It does not contain the port associated with
+                                      the host.
                                     type: string
-                                  namespace:
+                                  method:
+                                    description: Method represents the HTTP method
+                                      to match. It could be GET, POST, PUT, HEAD,
+                                      DELETE, TRACE, OPTIONS, CONNECT and PATCH.
+                                    type: string
+                                  path:
+                                    description: Path represents the URI path to match
+                                      (Ex. "/index.html", "/admin").
                                     type: string
                                 type: object
                             type: object
@@ -1331,9 +1176,9 @@ spec:
                             properties:
                               externalEntitySelector:
                                 description: Select ExternalEntities from NetworkPolicy's
-                                  Namespace as workloads in AppliedTo/To/From fields.
-                                  If set with NamespaceSelector, ExternalEntities
-                                  are matched from Namespaces matched by the NamespaceSelector.
+                                  Namespace as workloads in To/From fields. If set
+                                  with NamespaceSelector, ExternalEntities are matched
+                                  from Namespaces matched by the NamespaceSelector.
                                   Cannot be set with any other selector except NamespaceSelector.
                                 properties:
                                   matchExpressions:
@@ -1390,9 +1235,9 @@ spec:
                                 type: string
                               group:
                                 description: Group is the name of the ClusterGroup
-                                  which can be set as an AppliedTo or within an Ingress
-                                  or Egress rule in place of a stand-alone selector.
-                                  A Group cannot be set with any other selector.
+                                  which can be set within an Ingress or Egress rule
+                                  in place of a stand-alone selector. A Group cannot
+                                  be set with any other selector.
                                 type: string
                               ipBlock:
                                 description: IPBlock describes the IPAddresses/IPBlocks
@@ -1461,13 +1306,13 @@ spec:
                                 type: object
                               namespaces:
                                 description: 'Select Pod/ExternalEntity from Namespaces
-                                  matched by specifc criteria. Current supported criteria
-                                  is match: Self, which selects from the same Namespace
-                                  of the appliedTo workloads. Cannot be set with any
-                                  other selector except PodSelector or ExternalEntitySelector.
-                                  This field can only be set when NetworkPolicyPeer
-                                  is created for ClusterNetworkPolicy ingress/egress
-                                  rules. Cannot be set with NamespaceSelector.'
+                                  matched by specific criteria. Current supported
+                                  criteria is match: Self, which selects from the
+                                  same Namespace of the appliedTo workloads. Cannot
+                                  be set with any other selector except PodSelector
+                                  or ExternalEntitySelector. This field can only be
+                                  set when NetworkPolicyPeer is created for ClusterNetworkPolicy
+                                  ingress/egress rules. Cannot be set with NamespaceSelector.'
                                 properties:
                                   match:
                                     description: NamespaceMatchType describes Namespace
@@ -1525,10 +1370,10 @@ spec:
                                 type: object
                               podSelector:
                                 description: Select Pods from NetworkPolicy's Namespace
-                                  as workloads in AppliedTo/To/From fields. If set
-                                  with NamespaceSelector, Pods are matched from Namespaces
-                                  matched by the NamespaceSelector. Cannot be set
-                                  with any other selector except NamespaceSelector.
+                                  as workloads in To/From fields. If set with NamespaceSelector,
+                                  Pods are matched from Namespaces matched by the
+                                  NamespaceSelector. Cannot be set with any other
+                                  selector except NamespaceSelector.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label
@@ -1577,25 +1422,12 @@ spec:
                               scope:
                                 description: Define scope of the Pod/NamespaceSelector(s)
                                   of this peer. Can only be used in ingress NetworkPolicyPeers.
+                                  Defaults to "Cluster".
                                 type: string
-                              service:
-                                description: Select a certain Service which matches
-                                  the NamespacedName. A Service can only be set in
-                                  either policy level AppliedTo field in a policy
-                                  that only has ingress rules or rule level AppliedTo
-                                  field in an ingress rule. Only a NodePort Service
-                                  can be referred by this field. Cannot be set with
-                                  any other selector.
-                                properties:
-                                  name:
-                                    type: string
-                                  namespace:
-                                    type: string
-                                type: object
                               serviceAccount:
                                 description: Select all Pods with the ServiceAccount
-                                  matched by this field, as workloads in AppliedTo/To/From
-                                  fields. Cannot be set with any other selector.
+                                  matched by this field, as workloads in To/From fields.
+                                  Cannot be set with any other selector.
                                 properties:
                                   name:
                                     type: string
@@ -1643,14 +1475,14 @@ spec:
                           description: Select workloads on which this rule will be
                             applied to. Cannot be set in conjunction with NetworkPolicySpec/ClusterNetworkPolicySpec.AppliedTo.
                           items:
-                            description: NetworkPolicyPeer describes the grouping
-                              selector of workloads.
+                            description: AppliedTo describes the grouping selector
+                              of workloads in AppliedTo field.
                             properties:
                               externalEntitySelector:
                                 description: Select ExternalEntities from NetworkPolicy's
-                                  Namespace as workloads in AppliedTo/To/From fields.
-                                  If set with NamespaceSelector, ExternalEntities
-                                  are matched from Namespaces matched by the NamespaceSelector.
+                                  Namespace as workloads in AppliedTo fields. If set
+                                  with NamespaceSelector, ExternalEntities are matched
+                                  from Namespaces matched by the NamespaceSelector.
                                   Cannot be set with any other selector except NamespaceSelector.
                                 properties:
                                   matchExpressions:
@@ -1697,36 +1529,14 @@ spec:
                                       The requirements are ANDed.
                                     type: object
                                 type: object
-                              fqdn:
-                                description: 'Restrict egress access to the Fully
-                                  Qualified Domain Names prescribed by name or by
-                                  wildcard match patterns. This field can only be
-                                  set for NetworkPolicyPeer of egress rules. Supported
-                                  formats are: Exact FQDNs, i.e. "google.com", "db-svc.default.svc.cluster.local"
-                                  Wildcard expressions, i.e. "*wayfair.com".'
-                                type: string
                               group:
                                 description: Group is the name of the ClusterGroup
-                                  which can be set as an AppliedTo or within an Ingress
-                                  or Egress rule in place of a stand-alone selector.
-                                  A Group cannot be set with any other selector.
+                                  which can be set as an AppliedTo in place of a stand-alone
+                                  selector. A Group cannot be set with any other selector.
                                 type: string
-                              ipBlock:
-                                description: IPBlock describes the IPAddresses/IPBlocks
-                                  that is matched in to/from. IPBlock cannot be set
-                                  as part of the AppliedTo field. Cannot be set with
-                                  any other selector.
-                                properties:
-                                  cidr:
-                                    description: CIDR is a string representing the
-                                      IP Block Valid examples are "192.168.1.1/24".
-                                    type: string
-                                required:
-                                - cidr
-                                type: object
                               namespaceSelector:
                                 description: Select all Pods from Namespaces matched
-                                  by this selector, as workloads in To/From fields.
+                                  by this selector, as workloads in AppliedTo fields.
                                   If set with PodSelector, Pods are matched from Namespaces
                                   matched by the NamespaceSelector. Cannot be set
                                   with any other selector except PodSelector or ExternalEntitySelector.
@@ -1776,76 +1586,12 @@ spec:
                                       The requirements are ANDed.
                                     type: object
                                 type: object
-                              namespaces:
-                                description: 'Select Pod/ExternalEntity from Namespaces
-                                  matched by specifc criteria. Current supported criteria
-                                  is match: Self, which selects from the same Namespace
-                                  of the appliedTo workloads. Cannot be set with any
-                                  other selector except PodSelector or ExternalEntitySelector.
-                                  This field can only be set when NetworkPolicyPeer
-                                  is created for ClusterNetworkPolicy ingress/egress
-                                  rules. Cannot be set with NamespaceSelector.'
-                                properties:
-                                  match:
-                                    description: NamespaceMatchType describes Namespace
-                                      matching strategy.
-                                    type: string
-                                type: object
-                              nodeSelector:
-                                description: Select certain Nodes which match the
-                                  label selector. A NodeSelector cannot be set in
-                                  AppliedTo field or set with any other selector.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: A label selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's
-                                            relationship to a set of values. Valid
-                                            operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If
-                                            the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array
-                                            is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value".
-                                      The requirements are ANDed.
-                                    type: object
-                                type: object
                               podSelector:
                                 description: Select Pods from NetworkPolicy's Namespace
-                                  as workloads in AppliedTo/To/From fields. If set
-                                  with NamespaceSelector, Pods are matched from Namespaces
-                                  matched by the NamespaceSelector. Cannot be set
-                                  with any other selector except NamespaceSelector.
+                                  as workloads in AppliedTo fields. If set with NamespaceSelector,
+                                  Pods are matched from Namespaces matched by the
+                                  NamespaceSelector. Cannot be set with any other
+                                  selector except NamespaceSelector.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label
@@ -1891,10 +1637,6 @@ spec:
                                       The requirements are ANDed.
                                     type: object
                                 type: object
-                              scope:
-                                description: Define scope of the Pod/NamespaceSelector(s)
-                                  of this peer. Can only be used in ingress NetworkPolicyPeers.
-                                type: string
                               service:
                                 description: Select a certain Service which matches
                                   the NamespacedName. A Service can only be set in
@@ -1911,7 +1653,7 @@ spec:
                                 type: object
                               serviceAccount:
                                 description: Select all Pods with the ServiceAccount
-                                  matched by this field, as workloads in AppliedTo/To/From
+                                  matched by this field, as workloads in AppliedTo
                                   fields. Cannot be set with any other selector.
                                 properties:
                                   name:
@@ -1936,9 +1678,9 @@ spec:
                             properties:
                               externalEntitySelector:
                                 description: Select ExternalEntities from NetworkPolicy's
-                                  Namespace as workloads in AppliedTo/To/From fields.
-                                  If set with NamespaceSelector, ExternalEntities
-                                  are matched from Namespaces matched by the NamespaceSelector.
+                                  Namespace as workloads in To/From fields. If set
+                                  with NamespaceSelector, ExternalEntities are matched
+                                  from Namespaces matched by the NamespaceSelector.
                                   Cannot be set with any other selector except NamespaceSelector.
                                 properties:
                                   matchExpressions:
@@ -1995,9 +1737,9 @@ spec:
                                 type: string
                               group:
                                 description: Group is the name of the ClusterGroup
-                                  which can be set as an AppliedTo or within an Ingress
-                                  or Egress rule in place of a stand-alone selector.
-                                  A Group cannot be set with any other selector.
+                                  which can be set within an Ingress or Egress rule
+                                  in place of a stand-alone selector. A Group cannot
+                                  be set with any other selector.
                                 type: string
                               ipBlock:
                                 description: IPBlock describes the IPAddresses/IPBlocks
@@ -2066,13 +1808,13 @@ spec:
                                 type: object
                               namespaces:
                                 description: 'Select Pod/ExternalEntity from Namespaces
-                                  matched by specifc criteria. Current supported criteria
-                                  is match: Self, which selects from the same Namespace
-                                  of the appliedTo workloads. Cannot be set with any
-                                  other selector except PodSelector or ExternalEntitySelector.
-                                  This field can only be set when NetworkPolicyPeer
-                                  is created for ClusterNetworkPolicy ingress/egress
-                                  rules. Cannot be set with NamespaceSelector.'
+                                  matched by specific criteria. Current supported
+                                  criteria is match: Self, which selects from the
+                                  same Namespace of the appliedTo workloads. Cannot
+                                  be set with any other selector except PodSelector
+                                  or ExternalEntitySelector. This field can only be
+                                  set when NetworkPolicyPeer is created for ClusterNetworkPolicy
+                                  ingress/egress rules. Cannot be set with NamespaceSelector.'
                                 properties:
                                   match:
                                     description: NamespaceMatchType describes Namespace
@@ -2130,10 +1872,10 @@ spec:
                                 type: object
                               podSelector:
                                 description: Select Pods from NetworkPolicy's Namespace
-                                  as workloads in AppliedTo/To/From fields. If set
-                                  with NamespaceSelector, Pods are matched from Namespaces
-                                  matched by the NamespaceSelector. Cannot be set
-                                  with any other selector except NamespaceSelector.
+                                  as workloads in To/From fields. If set with NamespaceSelector,
+                                  Pods are matched from Namespaces matched by the
+                                  NamespaceSelector. Cannot be set with any other
+                                  selector except NamespaceSelector.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label
@@ -2182,29 +1924,52 @@ spec:
                               scope:
                                 description: Define scope of the Pod/NamespaceSelector(s)
                                   of this peer. Can only be used in ingress NetworkPolicyPeers.
+                                  Defaults to "Cluster".
                                 type: string
-                              service:
-                                description: Select a certain Service which matches
-                                  the NamespacedName. A Service can only be set in
-                                  either policy level AppliedTo field in a policy
-                                  that only has ingress rules or rule level AppliedTo
-                                  field in an ingress rule. Only a NodePort Service
-                                  can be referred by this field. Cannot be set with
-                                  any other selector.
+                              serviceAccount:
+                                description: Select all Pods with the ServiceAccount
+                                  matched by this field, as workloads in To/From fields.
+                                  Cannot be set with any other selector.
                                 properties:
                                   name:
                                     type: string
                                   namespace:
                                     type: string
                                 type: object
-                              serviceAccount:
-                                description: Select all Pods with the ServiceAccount
-                                  matched by this field, as workloads in AppliedTo/To/From
-                                  fields. Cannot be set with any other selector.
+                            type: object
+                          type: array
+                        l7Protocols:
+                          description: Set of layer 7 protocols matched by the rule.
+                            If this field is set, action can only be Allow. When this
+                            field is used in a rule, any traffic matching the other
+                            layer 3/4 criteria of the rule (typically the 5-tuple)
+                            will be forwarded to an application-aware engine for protocol
+                            detection and rule enforcement, and the traffic will be
+                            allowed if the layer 7 criteria is also matched, otherwise
+                            it will be dropped. Therefore, any rules after a layer
+                            7 rule will not be enforced for the traffic.
+                          items:
+                            properties:
+                              http:
+                                description: HTTPProtocol matches HTTP requests with
+                                  specific host, method, and path. All fields could
+                                  be used alone or together. If all fields are not
+                                  provided, it matches all HTTP requests.
                                 properties:
-                                  name:
+                                  host:
+                                    description: Host represents the hostname present
+                                      in the URI or the HTTP Host header to match.
+                                      It does not contain the port associated with
+                                      the host.
                                     type: string
-                                  namespace:
+                                  method:
+                                    description: Method represents the HTTP method
+                                      to match. It could be GET, POST, PUT, HEAD,
+                                      DELETE, TRACE, OPTIONS, CONNECT and PATCH.
+                                    type: string
+                                  path:
+                                    description: Path represents the URI path to match
+                                      (Ex. "/index.html", "/admin").
                                     type: string
                                 type: object
                             type: object
@@ -2293,9 +2058,9 @@ spec:
                             properties:
                               externalEntitySelector:
                                 description: Select ExternalEntities from NetworkPolicy's
-                                  Namespace as workloads in AppliedTo/To/From fields.
-                                  If set with NamespaceSelector, ExternalEntities
-                                  are matched from Namespaces matched by the NamespaceSelector.
+                                  Namespace as workloads in To/From fields. If set
+                                  with NamespaceSelector, ExternalEntities are matched
+                                  from Namespaces matched by the NamespaceSelector.
                                   Cannot be set with any other selector except NamespaceSelector.
                                 properties:
                                   matchExpressions:
@@ -2352,9 +2117,9 @@ spec:
                                 type: string
                               group:
                                 description: Group is the name of the ClusterGroup
-                                  which can be set as an AppliedTo or within an Ingress
-                                  or Egress rule in place of a stand-alone selector.
-                                  A Group cannot be set with any other selector.
+                                  which can be set within an Ingress or Egress rule
+                                  in place of a stand-alone selector. A Group cannot
+                                  be set with any other selector.
                                 type: string
                               ipBlock:
                                 description: IPBlock describes the IPAddresses/IPBlocks
@@ -2423,13 +2188,13 @@ spec:
                                 type: object
                               namespaces:
                                 description: 'Select Pod/ExternalEntity from Namespaces
-                                  matched by specifc criteria. Current supported criteria
-                                  is match: Self, which selects from the same Namespace
-                                  of the appliedTo workloads. Cannot be set with any
-                                  other selector except PodSelector or ExternalEntitySelector.
-                                  This field can only be set when NetworkPolicyPeer
-                                  is created for ClusterNetworkPolicy ingress/egress
-                                  rules. Cannot be set with NamespaceSelector.'
+                                  matched by specific criteria. Current supported
+                                  criteria is match: Self, which selects from the
+                                  same Namespace of the appliedTo workloads. Cannot
+                                  be set with any other selector except PodSelector
+                                  or ExternalEntitySelector. This field can only be
+                                  set when NetworkPolicyPeer is created for ClusterNetworkPolicy
+                                  ingress/egress rules. Cannot be set with NamespaceSelector.'
                                 properties:
                                   match:
                                     description: NamespaceMatchType describes Namespace
@@ -2487,10 +2252,10 @@ spec:
                                 type: object
                               podSelector:
                                 description: Select Pods from NetworkPolicy's Namespace
-                                  as workloads in AppliedTo/To/From fields. If set
-                                  with NamespaceSelector, Pods are matched from Namespaces
-                                  matched by the NamespaceSelector. Cannot be set
-                                  with any other selector except NamespaceSelector.
+                                  as workloads in To/From fields. If set with NamespaceSelector,
+                                  Pods are matched from Namespaces matched by the
+                                  NamespaceSelector. Cannot be set with any other
+                                  selector except NamespaceSelector.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label
@@ -2539,25 +2304,12 @@ spec:
                               scope:
                                 description: Define scope of the Pod/NamespaceSelector(s)
                                   of this peer. Can only be used in ingress NetworkPolicyPeers.
+                                  Defaults to "Cluster".
                                 type: string
-                              service:
-                                description: Select a certain Service which matches
-                                  the NamespacedName. A Service can only be set in
-                                  either policy level AppliedTo field in a policy
-                                  that only has ingress rules or rule level AppliedTo
-                                  field in an ingress rule. Only a NodePort Service
-                                  can be referred by this field. Cannot be set with
-                                  any other selector.
-                                properties:
-                                  name:
-                                    type: string
-                                  namespace:
-                                    type: string
-                                type: object
                               serviceAccount:
                                 description: Select all Pods with the ServiceAccount
-                                  matched by this field, as workloads in AppliedTo/To/From
-                                  fields. Cannot be set with any other selector.
+                                  matched by this field, as workloads in To/From fields.
+                                  Cannot be set with any other selector.
                                 properties:
                                   name:
                                     type: string
@@ -3323,15 +3075,15 @@ spec:
                     description: Select workloads on which the rules will be applied
                       to. Cannot be set in conjunction with AppliedTo in each rule.
                     items:
-                      description: NetworkPolicyPeer describes the grouping selector
-                        of workloads.
+                      description: AppliedTo describes the grouping selector of workloads
+                        in AppliedTo field.
                       properties:
                         externalEntitySelector:
                           description: Select ExternalEntities from NetworkPolicy's
-                            Namespace as workloads in AppliedTo/To/From fields. If
-                            set with NamespaceSelector, ExternalEntities are matched
-                            from Namespaces matched by the NamespaceSelector. Cannot
-                            be set with any other selector except NamespaceSelector.
+                            Namespace as workloads in AppliedTo fields. If set with
+                            NamespaceSelector, ExternalEntities are matched from Namespaces
+                            matched by the NamespaceSelector. Cannot be set with any
+                            other selector except NamespaceSelector.
                           properties:
                             matchExpressions:
                               description: matchExpressions is a list of label selector
@@ -3375,35 +3127,14 @@ spec:
                                 contains only "value". The requirements are ANDed.
                               type: object
                           type: object
-                        fqdn:
-                          description: 'Restrict egress access to the Fully Qualified
-                            Domain Names prescribed by name or by wildcard match patterns.
-                            This field can only be set for NetworkPolicyPeer of egress
-                            rules. Supported formats are: Exact FQDNs, i.e. "google.com",
-                            "db-svc.default.svc.cluster.local" Wildcard expressions,
-                            i.e. "*wayfair.com".'
-                          type: string
                         group:
                           description: Group is the name of the ClusterGroup which
-                            can be set as an AppliedTo or within an Ingress or Egress
-                            rule in place of a stand-alone selector. A Group cannot
-                            be set with any other selector.
+                            can be set as an AppliedTo in place of a stand-alone selector.
+                            A Group cannot be set with any other selector.
                           type: string
-                        ipBlock:
-                          description: IPBlock describes the IPAddresses/IPBlocks
-                            that is matched in to/from. IPBlock cannot be set as part
-                            of the AppliedTo field. Cannot be set with any other selector.
-                          properties:
-                            cidr:
-                              description: CIDR is a string representing the IP Block
-                                Valid examples are "192.168.1.1/24".
-                              type: string
-                          required:
-                          - cidr
-                          type: object
                         namespaceSelector:
                           description: Select all Pods from Namespaces matched by
-                            this selector, as workloads in To/From fields. If set
+                            this selector, as workloads in AppliedTo fields. If set
                             with PodSelector, Pods are matched from Namespaces matched
                             by the NamespaceSelector. Cannot be set with any other
                             selector except PodSelector or ExternalEntitySelector.
@@ -3451,74 +3182,11 @@ spec:
                                 contains only "value". The requirements are ANDed.
                               type: object
                           type: object
-                        namespaces:
-                          description: 'Select Pod/ExternalEntity from Namespaces
-                            matched by specifc criteria. Current supported criteria
-                            is match: Self, which selects from the same Namespace
-                            of the appliedTo workloads. Cannot be set with any other
-                            selector except PodSelector or ExternalEntitySelector.
-                            This field can only be set when NetworkPolicyPeer is created
-                            for ClusterNetworkPolicy ingress/egress rules. Cannot
-                            be set with NamespaceSelector.'
-                          properties:
-                            match:
-                              description: NamespaceMatchType describes Namespace
-                                matching strategy.
-                              type: string
-                          type: object
-                        nodeSelector:
-                          description: Select certain Nodes which match the label
-                            selector. A NodeSelector cannot be set in AppliedTo field
-                            or set with any other selector.
-                          properties:
-                            matchExpressions:
-                              description: matchExpressions is a list of label selector
-                                requirements. The requirements are ANDed.
-                              items:
-                                description: A label selector requirement is a selector
-                                  that contains values, a key, and an operator that
-                                  relates the key and values.
-                                properties:
-                                  key:
-                                    description: key is the label key that the selector
-                                      applies to.
-                                    type: string
-                                  operator:
-                                    description: operator represents a key's relationship
-                                      to a set of values. Valid operators are In,
-                                      NotIn, Exists and DoesNotExist.
-                                    type: string
-                                  values:
-                                    description: values is an array of string values.
-                                      If the operator is In or NotIn, the values array
-                                      must be non-empty. If the operator is Exists
-                                      or DoesNotExist, the values array must be empty.
-                                      This array is replaced during a strategic merge
-                                      patch.
-                                    items:
-                                      type: string
-                                    type: array
-                                required:
-                                - key
-                                - operator
-                                type: object
-                              type: array
-                            matchLabels:
-                              additionalProperties:
-                                type: string
-                              description: matchLabels is a map of {key,value} pairs.
-                                A single {key,value} in the matchLabels map is equivalent
-                                to an element of matchExpressions, whose key field
-                                is "key", the operator is "In", and the values array
-                                contains only "value". The requirements are ANDed.
-                              type: object
-                          type: object
                         podSelector:
                           description: Select Pods from NetworkPolicy's Namespace
-                            as workloads in AppliedTo/To/From fields. If set with
-                            NamespaceSelector, Pods are matched from Namespaces matched
-                            by the NamespaceSelector. Cannot be set with any other
-                            selector except NamespaceSelector.
+                            as workloads in AppliedTo fields. If set with NamespaceSelector,
+                            Pods are matched from Namespaces matched by the NamespaceSelector.
+                            Cannot be set with any other selector except NamespaceSelector.
                           properties:
                             matchExpressions:
                               description: matchExpressions is a list of label selector
@@ -3562,10 +3230,6 @@ spec:
                                 contains only "value". The requirements are ANDed.
                               type: object
                           type: object
-                        scope:
-                          description: Define scope of the Pod/NamespaceSelector(s)
-                            of this peer. Can only be used in ingress NetworkPolicyPeers.
-                          type: string
                         service:
                           description: Select a certain Service which matches the
                             NamespacedName. A Service can only be set in either policy
@@ -3581,8 +3245,8 @@ spec:
                           type: object
                         serviceAccount:
                           description: Select all Pods with the ServiceAccount matched
-                            by this field, as workloads in AppliedTo/To/From fields.
-                            Cannot be set with any other selector.
+                            by this field, as workloads in AppliedTo fields. Cannot
+                            be set with any other selector.
                           properties:
                             name:
                               type: string
@@ -3609,14 +3273,14 @@ spec:
                           description: Select workloads on which this rule will be
                             applied to. Cannot be set in conjunction with NetworkPolicySpec/ClusterNetworkPolicySpec.AppliedTo.
                           items:
-                            description: NetworkPolicyPeer describes the grouping
-                              selector of workloads.
+                            description: AppliedTo describes the grouping selector
+                              of workloads in AppliedTo field.
                             properties:
                               externalEntitySelector:
                                 description: Select ExternalEntities from NetworkPolicy's
-                                  Namespace as workloads in AppliedTo/To/From fields.
-                                  If set with NamespaceSelector, ExternalEntities
-                                  are matched from Namespaces matched by the NamespaceSelector.
+                                  Namespace as workloads in AppliedTo fields. If set
+                                  with NamespaceSelector, ExternalEntities are matched
+                                  from Namespaces matched by the NamespaceSelector.
                                   Cannot be set with any other selector except NamespaceSelector.
                                 properties:
                                   matchExpressions:
@@ -3663,36 +3327,14 @@ spec:
                                       The requirements are ANDed.
                                     type: object
                                 type: object
-                              fqdn:
-                                description: 'Restrict egress access to the Fully
-                                  Qualified Domain Names prescribed by name or by
-                                  wildcard match patterns. This field can only be
-                                  set for NetworkPolicyPeer of egress rules. Supported
-                                  formats are: Exact FQDNs, i.e. "google.com", "db-svc.default.svc.cluster.local"
-                                  Wildcard expressions, i.e. "*wayfair.com".'
-                                type: string
                               group:
                                 description: Group is the name of the ClusterGroup
-                                  which can be set as an AppliedTo or within an Ingress
-                                  or Egress rule in place of a stand-alone selector.
-                                  A Group cannot be set with any other selector.
+                                  which can be set as an AppliedTo in place of a stand-alone
+                                  selector. A Group cannot be set with any other selector.
                                 type: string
-                              ipBlock:
-                                description: IPBlock describes the IPAddresses/IPBlocks
-                                  that is matched in to/from. IPBlock cannot be set
-                                  as part of the AppliedTo field. Cannot be set with
-                                  any other selector.
-                                properties:
-                                  cidr:
-                                    description: CIDR is a string representing the
-                                      IP Block Valid examples are "192.168.1.1/24".
-                                    type: string
-                                required:
-                                - cidr
-                                type: object
                               namespaceSelector:
                                 description: Select all Pods from Namespaces matched
-                                  by this selector, as workloads in To/From fields.
+                                  by this selector, as workloads in AppliedTo fields.
                                   If set with PodSelector, Pods are matched from Namespaces
                                   matched by the NamespaceSelector. Cannot be set
                                   with any other selector except PodSelector or ExternalEntitySelector.
@@ -3742,76 +3384,12 @@ spec:
                                       The requirements are ANDed.
                                     type: object
                                 type: object
-                              namespaces:
-                                description: 'Select Pod/ExternalEntity from Namespaces
-                                  matched by specifc criteria. Current supported criteria
-                                  is match: Self, which selects from the same Namespace
-                                  of the appliedTo workloads. Cannot be set with any
-                                  other selector except PodSelector or ExternalEntitySelector.
-                                  This field can only be set when NetworkPolicyPeer
-                                  is created for ClusterNetworkPolicy ingress/egress
-                                  rules. Cannot be set with NamespaceSelector.'
-                                properties:
-                                  match:
-                                    description: NamespaceMatchType describes Namespace
-                                      matching strategy.
-                                    type: string
-                                type: object
-                              nodeSelector:
-                                description: Select certain Nodes which match the
-                                  label selector. A NodeSelector cannot be set in
-                                  AppliedTo field or set with any other selector.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: A label selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's
-                                            relationship to a set of values. Valid
-                                            operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If
-                                            the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array
-                                            is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value".
-                                      The requirements are ANDed.
-                                    type: object
-                                type: object
                               podSelector:
                                 description: Select Pods from NetworkPolicy's Namespace
-                                  as workloads in AppliedTo/To/From fields. If set
-                                  with NamespaceSelector, Pods are matched from Namespaces
-                                  matched by the NamespaceSelector. Cannot be set
-                                  with any other selector except NamespaceSelector.
+                                  as workloads in AppliedTo fields. If set with NamespaceSelector,
+                                  Pods are matched from Namespaces matched by the
+                                  NamespaceSelector. Cannot be set with any other
+                                  selector except NamespaceSelector.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label
@@ -3857,10 +3435,6 @@ spec:
                                       The requirements are ANDed.
                                     type: object
                                 type: object
-                              scope:
-                                description: Define scope of the Pod/NamespaceSelector(s)
-                                  of this peer. Can only be used in ingress NetworkPolicyPeers.
-                                type: string
                               service:
                                 description: Select a certain Service which matches
                                   the NamespacedName. A Service can only be set in
@@ -3877,7 +3451,7 @@ spec:
                                 type: object
                               serviceAccount:
                                 description: Select all Pods with the ServiceAccount
-                                  matched by this field, as workloads in AppliedTo/To/From
+                                  matched by this field, as workloads in AppliedTo
                                   fields. Cannot be set with any other selector.
                                 properties:
                                   name:
@@ -3902,9 +3476,9 @@ spec:
                             properties:
                               externalEntitySelector:
                                 description: Select ExternalEntities from NetworkPolicy's
-                                  Namespace as workloads in AppliedTo/To/From fields.
-                                  If set with NamespaceSelector, ExternalEntities
-                                  are matched from Namespaces matched by the NamespaceSelector.
+                                  Namespace as workloads in To/From fields. If set
+                                  with NamespaceSelector, ExternalEntities are matched
+                                  from Namespaces matched by the NamespaceSelector.
                                   Cannot be set with any other selector except NamespaceSelector.
                                 properties:
                                   matchExpressions:
@@ -3961,9 +3535,9 @@ spec:
                                 type: string
                               group:
                                 description: Group is the name of the ClusterGroup
-                                  which can be set as an AppliedTo or within an Ingress
-                                  or Egress rule in place of a stand-alone selector.
-                                  A Group cannot be set with any other selector.
+                                  which can be set within an Ingress or Egress rule
+                                  in place of a stand-alone selector. A Group cannot
+                                  be set with any other selector.
                                 type: string
                               ipBlock:
                                 description: IPBlock describes the IPAddresses/IPBlocks
@@ -4032,13 +3606,13 @@ spec:
                                 type: object
                               namespaces:
                                 description: 'Select Pod/ExternalEntity from Namespaces
-                                  matched by specifc criteria. Current supported criteria
-                                  is match: Self, which selects from the same Namespace
-                                  of the appliedTo workloads. Cannot be set with any
-                                  other selector except PodSelector or ExternalEntitySelector.
-                                  This field can only be set when NetworkPolicyPeer
-                                  is created for ClusterNetworkPolicy ingress/egress
-                                  rules. Cannot be set with NamespaceSelector.'
+                                  matched by specific criteria. Current supported
+                                  criteria is match: Self, which selects from the
+                                  same Namespace of the appliedTo workloads. Cannot
+                                  be set with any other selector except PodSelector
+                                  or ExternalEntitySelector. This field can only be
+                                  set when NetworkPolicyPeer is created for ClusterNetworkPolicy
+                                  ingress/egress rules. Cannot be set with NamespaceSelector.'
                                 properties:
                                   match:
                                     description: NamespaceMatchType describes Namespace
@@ -4096,10 +3670,10 @@ spec:
                                 type: object
                               podSelector:
                                 description: Select Pods from NetworkPolicy's Namespace
-                                  as workloads in AppliedTo/To/From fields. If set
-                                  with NamespaceSelector, Pods are matched from Namespaces
-                                  matched by the NamespaceSelector. Cannot be set
-                                  with any other selector except NamespaceSelector.
+                                  as workloads in To/From fields. If set with NamespaceSelector,
+                                  Pods are matched from Namespaces matched by the
+                                  NamespaceSelector. Cannot be set with any other
+                                  selector except NamespaceSelector.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label
@@ -4148,29 +3722,52 @@ spec:
                               scope:
                                 description: Define scope of the Pod/NamespaceSelector(s)
                                   of this peer. Can only be used in ingress NetworkPolicyPeers.
+                                  Defaults to "Cluster".
                                 type: string
-                              service:
-                                description: Select a certain Service which matches
-                                  the NamespacedName. A Service can only be set in
-                                  either policy level AppliedTo field in a policy
-                                  that only has ingress rules or rule level AppliedTo
-                                  field in an ingress rule. Only a NodePort Service
-                                  can be referred by this field. Cannot be set with
-                                  any other selector.
+                              serviceAccount:
+                                description: Select all Pods with the ServiceAccount
+                                  matched by this field, as workloads in To/From fields.
+                                  Cannot be set with any other selector.
                                 properties:
                                   name:
                                     type: string
                                   namespace:
                                     type: string
                                 type: object
-                              serviceAccount:
-                                description: Select all Pods with the ServiceAccount
-                                  matched by this field, as workloads in AppliedTo/To/From
-                                  fields. Cannot be set with any other selector.
+                            type: object
+                          type: array
+                        l7Protocols:
+                          description: Set of layer 7 protocols matched by the rule.
+                            If this field is set, action can only be Allow. When this
+                            field is used in a rule, any traffic matching the other
+                            layer 3/4 criteria of the rule (typically the 5-tuple)
+                            will be forwarded to an application-aware engine for protocol
+                            detection and rule enforcement, and the traffic will be
+                            allowed if the layer 7 criteria is also matched, otherwise
+                            it will be dropped. Therefore, any rules after a layer
+                            7 rule will not be enforced for the traffic.
+                          items:
+                            properties:
+                              http:
+                                description: HTTPProtocol matches HTTP requests with
+                                  specific host, method, and path. All fields could
+                                  be used alone or together. If all fields are not
+                                  provided, it matches all HTTP requests.
                                 properties:
-                                  name:
+                                  host:
+                                    description: Host represents the hostname present
+                                      in the URI or the HTTP Host header to match.
+                                      It does not contain the port associated with
+                                      the host.
                                     type: string
-                                  namespace:
+                                  method:
+                                    description: Method represents the HTTP method
+                                      to match. It could be GET, POST, PUT, HEAD,
+                                      DELETE, TRACE, OPTIONS, CONNECT and PATCH.
+                                    type: string
+                                  path:
+                                    description: Path represents the URI path to match
+                                      (Ex. "/index.html", "/admin").
                                     type: string
                                 type: object
                             type: object
@@ -4259,9 +3856,9 @@ spec:
                             properties:
                               externalEntitySelector:
                                 description: Select ExternalEntities from NetworkPolicy's
-                                  Namespace as workloads in AppliedTo/To/From fields.
-                                  If set with NamespaceSelector, ExternalEntities
-                                  are matched from Namespaces matched by the NamespaceSelector.
+                                  Namespace as workloads in To/From fields. If set
+                                  with NamespaceSelector, ExternalEntities are matched
+                                  from Namespaces matched by the NamespaceSelector.
                                   Cannot be set with any other selector except NamespaceSelector.
                                 properties:
                                   matchExpressions:
@@ -4318,9 +3915,9 @@ spec:
                                 type: string
                               group:
                                 description: Group is the name of the ClusterGroup
-                                  which can be set as an AppliedTo or within an Ingress
-                                  or Egress rule in place of a stand-alone selector.
-                                  A Group cannot be set with any other selector.
+                                  which can be set within an Ingress or Egress rule
+                                  in place of a stand-alone selector. A Group cannot
+                                  be set with any other selector.
                                 type: string
                               ipBlock:
                                 description: IPBlock describes the IPAddresses/IPBlocks
@@ -4389,13 +3986,13 @@ spec:
                                 type: object
                               namespaces:
                                 description: 'Select Pod/ExternalEntity from Namespaces
-                                  matched by specifc criteria. Current supported criteria
-                                  is match: Self, which selects from the same Namespace
-                                  of the appliedTo workloads. Cannot be set with any
-                                  other selector except PodSelector or ExternalEntitySelector.
-                                  This field can only be set when NetworkPolicyPeer
-                                  is created for ClusterNetworkPolicy ingress/egress
-                                  rules. Cannot be set with NamespaceSelector.'
+                                  matched by specific criteria. Current supported
+                                  criteria is match: Self, which selects from the
+                                  same Namespace of the appliedTo workloads. Cannot
+                                  be set with any other selector except PodSelector
+                                  or ExternalEntitySelector. This field can only be
+                                  set when NetworkPolicyPeer is created for ClusterNetworkPolicy
+                                  ingress/egress rules. Cannot be set with NamespaceSelector.'
                                 properties:
                                   match:
                                     description: NamespaceMatchType describes Namespace
@@ -4453,10 +4050,10 @@ spec:
                                 type: object
                               podSelector:
                                 description: Select Pods from NetworkPolicy's Namespace
-                                  as workloads in AppliedTo/To/From fields. If set
-                                  with NamespaceSelector, Pods are matched from Namespaces
-                                  matched by the NamespaceSelector. Cannot be set
-                                  with any other selector except NamespaceSelector.
+                                  as workloads in To/From fields. If set with NamespaceSelector,
+                                  Pods are matched from Namespaces matched by the
+                                  NamespaceSelector. Cannot be set with any other
+                                  selector except NamespaceSelector.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label
@@ -4505,25 +4102,12 @@ spec:
                               scope:
                                 description: Define scope of the Pod/NamespaceSelector(s)
                                   of this peer. Can only be used in ingress NetworkPolicyPeers.
+                                  Defaults to "Cluster".
                                 type: string
-                              service:
-                                description: Select a certain Service which matches
-                                  the NamespacedName. A Service can only be set in
-                                  either policy level AppliedTo field in a policy
-                                  that only has ingress rules or rule level AppliedTo
-                                  field in an ingress rule. Only a NodePort Service
-                                  can be referred by this field. Cannot be set with
-                                  any other selector.
-                                properties:
-                                  name:
-                                    type: string
-                                  namespace:
-                                    type: string
-                                type: object
                               serviceAccount:
                                 description: Select all Pods with the ServiceAccount
-                                  matched by this field, as workloads in AppliedTo/To/From
-                                  fields. Cannot be set with any other selector.
+                                  matched by this field, as workloads in To/From fields.
+                                  Cannot be set with any other selector.
                                 properties:
                                   name:
                                     type: string
@@ -4571,14 +4155,14 @@ spec:
                           description: Select workloads on which this rule will be
                             applied to. Cannot be set in conjunction with NetworkPolicySpec/ClusterNetworkPolicySpec.AppliedTo.
                           items:
-                            description: NetworkPolicyPeer describes the grouping
-                              selector of workloads.
+                            description: AppliedTo describes the grouping selector
+                              of workloads in AppliedTo field.
                             properties:
                               externalEntitySelector:
                                 description: Select ExternalEntities from NetworkPolicy's
-                                  Namespace as workloads in AppliedTo/To/From fields.
-                                  If set with NamespaceSelector, ExternalEntities
-                                  are matched from Namespaces matched by the NamespaceSelector.
+                                  Namespace as workloads in AppliedTo fields. If set
+                                  with NamespaceSelector, ExternalEntities are matched
+                                  from Namespaces matched by the NamespaceSelector.
                                   Cannot be set with any other selector except NamespaceSelector.
                                 properties:
                                   matchExpressions:
@@ -4625,36 +4209,14 @@ spec:
                                       The requirements are ANDed.
                                     type: object
                                 type: object
-                              fqdn:
-                                description: 'Restrict egress access to the Fully
-                                  Qualified Domain Names prescribed by name or by
-                                  wildcard match patterns. This field can only be
-                                  set for NetworkPolicyPeer of egress rules. Supported
-                                  formats are: Exact FQDNs, i.e. "google.com", "db-svc.default.svc.cluster.local"
-                                  Wildcard expressions, i.e. "*wayfair.com".'
-                                type: string
                               group:
                                 description: Group is the name of the ClusterGroup
-                                  which can be set as an AppliedTo or within an Ingress
-                                  or Egress rule in place of a stand-alone selector.
-                                  A Group cannot be set with any other selector.
+                                  which can be set as an AppliedTo in place of a stand-alone
+                                  selector. A Group cannot be set with any other selector.
                                 type: string
-                              ipBlock:
-                                description: IPBlock describes the IPAddresses/IPBlocks
-                                  that is matched in to/from. IPBlock cannot be set
-                                  as part of the AppliedTo field. Cannot be set with
-                                  any other selector.
-                                properties:
-                                  cidr:
-                                    description: CIDR is a string representing the
-                                      IP Block Valid examples are "192.168.1.1/24".
-                                    type: string
-                                required:
-                                - cidr
-                                type: object
                               namespaceSelector:
                                 description: Select all Pods from Namespaces matched
-                                  by this selector, as workloads in To/From fields.
+                                  by this selector, as workloads in AppliedTo fields.
                                   If set with PodSelector, Pods are matched from Namespaces
                                   matched by the NamespaceSelector. Cannot be set
                                   with any other selector except PodSelector or ExternalEntitySelector.
@@ -4704,76 +4266,12 @@ spec:
                                       The requirements are ANDed.
                                     type: object
                                 type: object
-                              namespaces:
-                                description: 'Select Pod/ExternalEntity from Namespaces
-                                  matched by specifc criteria. Current supported criteria
-                                  is match: Self, which selects from the same Namespace
-                                  of the appliedTo workloads. Cannot be set with any
-                                  other selector except PodSelector or ExternalEntitySelector.
-                                  This field can only be set when NetworkPolicyPeer
-                                  is created for ClusterNetworkPolicy ingress/egress
-                                  rules. Cannot be set with NamespaceSelector.'
-                                properties:
-                                  match:
-                                    description: NamespaceMatchType describes Namespace
-                                      matching strategy.
-                                    type: string
-                                type: object
-                              nodeSelector:
-                                description: Select certain Nodes which match the
-                                  label selector. A NodeSelector cannot be set in
-                                  AppliedTo field or set with any other selector.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: A label selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's
-                                            relationship to a set of values. Valid
-                                            operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If
-                                            the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array
-                                            is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value".
-                                      The requirements are ANDed.
-                                    type: object
-                                type: object
                               podSelector:
                                 description: Select Pods from NetworkPolicy's Namespace
-                                  as workloads in AppliedTo/To/From fields. If set
-                                  with NamespaceSelector, Pods are matched from Namespaces
-                                  matched by the NamespaceSelector. Cannot be set
-                                  with any other selector except NamespaceSelector.
+                                  as workloads in AppliedTo fields. If set with NamespaceSelector,
+                                  Pods are matched from Namespaces matched by the
+                                  NamespaceSelector. Cannot be set with any other
+                                  selector except NamespaceSelector.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label
@@ -4819,10 +4317,6 @@ spec:
                                       The requirements are ANDed.
                                     type: object
                                 type: object
-                              scope:
-                                description: Define scope of the Pod/NamespaceSelector(s)
-                                  of this peer. Can only be used in ingress NetworkPolicyPeers.
-                                type: string
                               service:
                                 description: Select a certain Service which matches
                                   the NamespacedName. A Service can only be set in
@@ -4839,7 +4333,7 @@ spec:
                                 type: object
                               serviceAccount:
                                 description: Select all Pods with the ServiceAccount
-                                  matched by this field, as workloads in AppliedTo/To/From
+                                  matched by this field, as workloads in AppliedTo
                                   fields. Cannot be set with any other selector.
                                 properties:
                                   name:
@@ -4864,9 +4358,9 @@ spec:
                             properties:
                               externalEntitySelector:
                                 description: Select ExternalEntities from NetworkPolicy's
-                                  Namespace as workloads in AppliedTo/To/From fields.
-                                  If set with NamespaceSelector, ExternalEntities
-                                  are matched from Namespaces matched by the NamespaceSelector.
+                                  Namespace as workloads in To/From fields. If set
+                                  with NamespaceSelector, ExternalEntities are matched
+                                  from Namespaces matched by the NamespaceSelector.
                                   Cannot be set with any other selector except NamespaceSelector.
                                 properties:
                                   matchExpressions:
@@ -4923,9 +4417,9 @@ spec:
                                 type: string
                               group:
                                 description: Group is the name of the ClusterGroup
-                                  which can be set as an AppliedTo or within an Ingress
-                                  or Egress rule in place of a stand-alone selector.
-                                  A Group cannot be set with any other selector.
+                                  which can be set within an Ingress or Egress rule
+                                  in place of a stand-alone selector. A Group cannot
+                                  be set with any other selector.
                                 type: string
                               ipBlock:
                                 description: IPBlock describes the IPAddresses/IPBlocks
@@ -4994,13 +4488,13 @@ spec:
                                 type: object
                               namespaces:
                                 description: 'Select Pod/ExternalEntity from Namespaces
-                                  matched by specifc criteria. Current supported criteria
-                                  is match: Self, which selects from the same Namespace
-                                  of the appliedTo workloads. Cannot be set with any
-                                  other selector except PodSelector or ExternalEntitySelector.
-                                  This field can only be set when NetworkPolicyPeer
-                                  is created for ClusterNetworkPolicy ingress/egress
-                                  rules. Cannot be set with NamespaceSelector.'
+                                  matched by specific criteria. Current supported
+                                  criteria is match: Self, which selects from the
+                                  same Namespace of the appliedTo workloads. Cannot
+                                  be set with any other selector except PodSelector
+                                  or ExternalEntitySelector. This field can only be
+                                  set when NetworkPolicyPeer is created for ClusterNetworkPolicy
+                                  ingress/egress rules. Cannot be set with NamespaceSelector.'
                                 properties:
                                   match:
                                     description: NamespaceMatchType describes Namespace
@@ -5058,10 +4552,10 @@ spec:
                                 type: object
                               podSelector:
                                 description: Select Pods from NetworkPolicy's Namespace
-                                  as workloads in AppliedTo/To/From fields. If set
-                                  with NamespaceSelector, Pods are matched from Namespaces
-                                  matched by the NamespaceSelector. Cannot be set
-                                  with any other selector except NamespaceSelector.
+                                  as workloads in To/From fields. If set with NamespaceSelector,
+                                  Pods are matched from Namespaces matched by the
+                                  NamespaceSelector. Cannot be set with any other
+                                  selector except NamespaceSelector.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label
@@ -5110,29 +4604,52 @@ spec:
                               scope:
                                 description: Define scope of the Pod/NamespaceSelector(s)
                                   of this peer. Can only be used in ingress NetworkPolicyPeers.
+                                  Defaults to "Cluster".
                                 type: string
-                              service:
-                                description: Select a certain Service which matches
-                                  the NamespacedName. A Service can only be set in
-                                  either policy level AppliedTo field in a policy
-                                  that only has ingress rules or rule level AppliedTo
-                                  field in an ingress rule. Only a NodePort Service
-                                  can be referred by this field. Cannot be set with
-                                  any other selector.
+                              serviceAccount:
+                                description: Select all Pods with the ServiceAccount
+                                  matched by this field, as workloads in To/From fields.
+                                  Cannot be set with any other selector.
                                 properties:
                                   name:
                                     type: string
                                   namespace:
                                     type: string
                                 type: object
-                              serviceAccount:
-                                description: Select all Pods with the ServiceAccount
-                                  matched by this field, as workloads in AppliedTo/To/From
-                                  fields. Cannot be set with any other selector.
+                            type: object
+                          type: array
+                        l7Protocols:
+                          description: Set of layer 7 protocols matched by the rule.
+                            If this field is set, action can only be Allow. When this
+                            field is used in a rule, any traffic matching the other
+                            layer 3/4 criteria of the rule (typically the 5-tuple)
+                            will be forwarded to an application-aware engine for protocol
+                            detection and rule enforcement, and the traffic will be
+                            allowed if the layer 7 criteria is also matched, otherwise
+                            it will be dropped. Therefore, any rules after a layer
+                            7 rule will not be enforced for the traffic.
+                          items:
+                            properties:
+                              http:
+                                description: HTTPProtocol matches HTTP requests with
+                                  specific host, method, and path. All fields could
+                                  be used alone or together. If all fields are not
+                                  provided, it matches all HTTP requests.
                                 properties:
-                                  name:
+                                  host:
+                                    description: Host represents the hostname present
+                                      in the URI or the HTTP Host header to match.
+                                      It does not contain the port associated with
+                                      the host.
                                     type: string
-                                  namespace:
+                                  method:
+                                    description: Method represents the HTTP method
+                                      to match. It could be GET, POST, PUT, HEAD,
+                                      DELETE, TRACE, OPTIONS, CONNECT and PATCH.
+                                    type: string
+                                  path:
+                                    description: Path represents the URI path to match
+                                      (Ex. "/index.html", "/admin").
                                     type: string
                                 type: object
                             type: object
@@ -5221,9 +4738,9 @@ spec:
                             properties:
                               externalEntitySelector:
                                 description: Select ExternalEntities from NetworkPolicy's
-                                  Namespace as workloads in AppliedTo/To/From fields.
-                                  If set with NamespaceSelector, ExternalEntities
-                                  are matched from Namespaces matched by the NamespaceSelector.
+                                  Namespace as workloads in To/From fields. If set
+                                  with NamespaceSelector, ExternalEntities are matched
+                                  from Namespaces matched by the NamespaceSelector.
                                   Cannot be set with any other selector except NamespaceSelector.
                                 properties:
                                   matchExpressions:
@@ -5280,9 +4797,9 @@ spec:
                                 type: string
                               group:
                                 description: Group is the name of the ClusterGroup
-                                  which can be set as an AppliedTo or within an Ingress
-                                  or Egress rule in place of a stand-alone selector.
-                                  A Group cannot be set with any other selector.
+                                  which can be set within an Ingress or Egress rule
+                                  in place of a stand-alone selector. A Group cannot
+                                  be set with any other selector.
                                 type: string
                               ipBlock:
                                 description: IPBlock describes the IPAddresses/IPBlocks
@@ -5351,13 +4868,13 @@ spec:
                                 type: object
                               namespaces:
                                 description: 'Select Pod/ExternalEntity from Namespaces
-                                  matched by specifc criteria. Current supported criteria
-                                  is match: Self, which selects from the same Namespace
-                                  of the appliedTo workloads. Cannot be set with any
-                                  other selector except PodSelector or ExternalEntitySelector.
-                                  This field can only be set when NetworkPolicyPeer
-                                  is created for ClusterNetworkPolicy ingress/egress
-                                  rules. Cannot be set with NamespaceSelector.'
+                                  matched by specific criteria. Current supported
+                                  criteria is match: Self, which selects from the
+                                  same Namespace of the appliedTo workloads. Cannot
+                                  be set with any other selector except PodSelector
+                                  or ExternalEntitySelector. This field can only be
+                                  set when NetworkPolicyPeer is created for ClusterNetworkPolicy
+                                  ingress/egress rules. Cannot be set with NamespaceSelector.'
                                 properties:
                                   match:
                                     description: NamespaceMatchType describes Namespace
@@ -5415,10 +4932,10 @@ spec:
                                 type: object
                               podSelector:
                                 description: Select Pods from NetworkPolicy's Namespace
-                                  as workloads in AppliedTo/To/From fields. If set
-                                  with NamespaceSelector, Pods are matched from Namespaces
-                                  matched by the NamespaceSelector. Cannot be set
-                                  with any other selector except NamespaceSelector.
+                                  as workloads in To/From fields. If set with NamespaceSelector,
+                                  Pods are matched from Namespaces matched by the
+                                  NamespaceSelector. Cannot be set with any other
+                                  selector except NamespaceSelector.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label
@@ -5467,25 +4984,12 @@ spec:
                               scope:
                                 description: Define scope of the Pod/NamespaceSelector(s)
                                   of this peer. Can only be used in ingress NetworkPolicyPeers.
+                                  Defaults to "Cluster".
                                 type: string
-                              service:
-                                description: Select a certain Service which matches
-                                  the NamespacedName. A Service can only be set in
-                                  either policy level AppliedTo field in a policy
-                                  that only has ingress rules or rule level AppliedTo
-                                  field in an ingress rule. Only a NodePort Service
-                                  can be referred by this field. Cannot be set with
-                                  any other selector.
-                                properties:
-                                  name:
-                                    type: string
-                                  namespace:
-                                    type: string
-                                type: object
                               serviceAccount:
                                 description: Select all Pods with the ServiceAccount
-                                  matched by this field, as workloads in AppliedTo/To/From
-                                  fields. Cannot be set with any other selector.
+                                  matched by this field, as workloads in To/From fields.
+                                  Cannot be set with any other selector.
                                 properties:
                                   name:
                                     type: string

--- a/multicluster/build/yamls/antrea-multicluster-leader-namespaced.yml
+++ b/multicluster/build/yamls/antrea-multicluster-leader-namespaced.yml
@@ -365,7 +365,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ab74dc9fd6d27a934c61d50e51dbf331ef6d57ab28c1121df3520bef6aad1f79
+        checksum/config: 5da3da29da98cffcad8b7b40bbfcbff1273c65ce5205f4bcc9290f6bd532e9bb
       labels:
         app: antrea
         component: antrea-mc-controller

--- a/multicluster/build/yamls/antrea-multicluster-member.yml
+++ b/multicluster/build/yamls/antrea-multicluster-member.yml
@@ -422,7 +422,19 @@ spec:
     singular: labelidentity
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Normalized string of a label identity
+      jsonPath: .spec.label
+      name: Label
+      type: string
+    - description: ID allocated for the label identity by the leader cluster
+      jsonPath: .spec.id
+      name: ID
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: LabelIdentity is an imported label identity from the ClusterSet.
@@ -457,6 +469,7 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -1076,7 +1089,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ab74dc9fd6d27a934c61d50e51dbf331ef6d57ab28c1121df3520bef6aad1f79
+        checksum/config: 5da3da29da98cffcad8b7b40bbfcbff1273c65ce5205f4bcc9290f6bd532e9bb
       labels:
         app: antrea
         component: antrea-mc-controller

--- a/multicluster/config/crd/bases/multicluster.crd.antrea.io_labelidentities.yaml
+++ b/multicluster/config/crd/bases/multicluster.crd.antrea.io_labelidentities.yaml
@@ -15,7 +15,19 @@ spec:
     singular: labelidentity
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: Normalized string of a label identity
+      jsonPath: .spec.label
+      name: Label
+      type: string
+    - description: ID allocated for the label identity by the leader cluster
+      jsonPath: .spec.id
+      name: ID
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: LabelIdentity is an imported label identity from the ClusterSet.
@@ -50,3 +62,4 @@ spec:
         type: object
     served: true
     storage: true
+    subresources: {}

--- a/multicluster/config/crd/bases/multicluster.crd.antrea.io_resourceexports.yaml
+++ b/multicluster/config/crd/bases/multicluster.crd.antrea.io_resourceexports.yaml
@@ -90,15 +90,15 @@ spec:
                     description: Select workloads on which the rules will be applied
                       to. Cannot be set in conjunction with AppliedTo in each rule.
                     items:
-                      description: NetworkPolicyPeer describes the grouping selector
-                        of workloads.
+                      description: AppliedTo describes the grouping selector of workloads
+                        in AppliedTo field.
                       properties:
                         externalEntitySelector:
                           description: Select ExternalEntities from NetworkPolicy's
-                            Namespace as workloads in AppliedTo/To/From fields. If
-                            set with NamespaceSelector, ExternalEntities are matched
-                            from Namespaces matched by the NamespaceSelector. Cannot
-                            be set with any other selector except NamespaceSelector.
+                            Namespace as workloads in AppliedTo fields. If set with
+                            NamespaceSelector, ExternalEntities are matched from Namespaces
+                            matched by the NamespaceSelector. Cannot be set with any
+                            other selector except NamespaceSelector.
                           properties:
                             matchExpressions:
                               description: matchExpressions is a list of label selector
@@ -142,35 +142,14 @@ spec:
                                 contains only "value". The requirements are ANDed.
                               type: object
                           type: object
-                        fqdn:
-                          description: 'Restrict egress access to the Fully Qualified
-                            Domain Names prescribed by name or by wildcard match patterns.
-                            This field can only be set for NetworkPolicyPeer of egress
-                            rules. Supported formats are: Exact FQDNs, i.e. "google.com",
-                            "db-svc.default.svc.cluster.local" Wildcard expressions,
-                            i.e. "*wayfair.com".'
-                          type: string
                         group:
                           description: Group is the name of the ClusterGroup which
-                            can be set as an AppliedTo or within an Ingress or Egress
-                            rule in place of a stand-alone selector. A Group cannot
-                            be set with any other selector.
+                            can be set as an AppliedTo in place of a stand-alone selector.
+                            A Group cannot be set with any other selector.
                           type: string
-                        ipBlock:
-                          description: IPBlock describes the IPAddresses/IPBlocks
-                            that is matched in to/from. IPBlock cannot be set as part
-                            of the AppliedTo field. Cannot be set with any other selector.
-                          properties:
-                            cidr:
-                              description: CIDR is a string representing the IP Block
-                                Valid examples are "192.168.1.1/24".
-                              type: string
-                          required:
-                          - cidr
-                          type: object
                         namespaceSelector:
                           description: Select all Pods from Namespaces matched by
-                            this selector, as workloads in To/From fields. If set
+                            this selector, as workloads in AppliedTo fields. If set
                             with PodSelector, Pods are matched from Namespaces matched
                             by the NamespaceSelector. Cannot be set with any other
                             selector except PodSelector or ExternalEntitySelector.
@@ -218,74 +197,11 @@ spec:
                                 contains only "value". The requirements are ANDed.
                               type: object
                           type: object
-                        namespaces:
-                          description: 'Select Pod/ExternalEntity from Namespaces
-                            matched by specifc criteria. Current supported criteria
-                            is match: Self, which selects from the same Namespace
-                            of the appliedTo workloads. Cannot be set with any other
-                            selector except PodSelector or ExternalEntitySelector.
-                            This field can only be set when NetworkPolicyPeer is created
-                            for ClusterNetworkPolicy ingress/egress rules. Cannot
-                            be set with NamespaceSelector.'
-                          properties:
-                            match:
-                              description: NamespaceMatchType describes Namespace
-                                matching strategy.
-                              type: string
-                          type: object
-                        nodeSelector:
-                          description: Select certain Nodes which match the label
-                            selector. A NodeSelector cannot be set in AppliedTo field
-                            or set with any other selector.
-                          properties:
-                            matchExpressions:
-                              description: matchExpressions is a list of label selector
-                                requirements. The requirements are ANDed.
-                              items:
-                                description: A label selector requirement is a selector
-                                  that contains values, a key, and an operator that
-                                  relates the key and values.
-                                properties:
-                                  key:
-                                    description: key is the label key that the selector
-                                      applies to.
-                                    type: string
-                                  operator:
-                                    description: operator represents a key's relationship
-                                      to a set of values. Valid operators are In,
-                                      NotIn, Exists and DoesNotExist.
-                                    type: string
-                                  values:
-                                    description: values is an array of string values.
-                                      If the operator is In or NotIn, the values array
-                                      must be non-empty. If the operator is Exists
-                                      or DoesNotExist, the values array must be empty.
-                                      This array is replaced during a strategic merge
-                                      patch.
-                                    items:
-                                      type: string
-                                    type: array
-                                required:
-                                - key
-                                - operator
-                                type: object
-                              type: array
-                            matchLabels:
-                              additionalProperties:
-                                type: string
-                              description: matchLabels is a map of {key,value} pairs.
-                                A single {key,value} in the matchLabels map is equivalent
-                                to an element of matchExpressions, whose key field
-                                is "key", the operator is "In", and the values array
-                                contains only "value". The requirements are ANDed.
-                              type: object
-                          type: object
                         podSelector:
                           description: Select Pods from NetworkPolicy's Namespace
-                            as workloads in AppliedTo/To/From fields. If set with
-                            NamespaceSelector, Pods are matched from Namespaces matched
-                            by the NamespaceSelector. Cannot be set with any other
-                            selector except NamespaceSelector.
+                            as workloads in AppliedTo fields. If set with NamespaceSelector,
+                            Pods are matched from Namespaces matched by the NamespaceSelector.
+                            Cannot be set with any other selector except NamespaceSelector.
                           properties:
                             matchExpressions:
                               description: matchExpressions is a list of label selector
@@ -329,10 +245,6 @@ spec:
                                 contains only "value". The requirements are ANDed.
                               type: object
                           type: object
-                        scope:
-                          description: Define scope of the Pod/NamespaceSelector(s)
-                            of this peer. Can only be used in ingress NetworkPolicyPeers.
-                          type: string
                         service:
                           description: Select a certain Service which matches the
                             NamespacedName. A Service can only be set in either policy
@@ -348,8 +260,8 @@ spec:
                           type: object
                         serviceAccount:
                           description: Select all Pods with the ServiceAccount matched
-                            by this field, as workloads in AppliedTo/To/From fields.
-                            Cannot be set with any other selector.
+                            by this field, as workloads in AppliedTo fields. Cannot
+                            be set with any other selector.
                           properties:
                             name:
                               type: string
@@ -376,14 +288,14 @@ spec:
                           description: Select workloads on which this rule will be
                             applied to. Cannot be set in conjunction with NetworkPolicySpec/ClusterNetworkPolicySpec.AppliedTo.
                           items:
-                            description: NetworkPolicyPeer describes the grouping
-                              selector of workloads.
+                            description: AppliedTo describes the grouping selector
+                              of workloads in AppliedTo field.
                             properties:
                               externalEntitySelector:
                                 description: Select ExternalEntities from NetworkPolicy's
-                                  Namespace as workloads in AppliedTo/To/From fields.
-                                  If set with NamespaceSelector, ExternalEntities
-                                  are matched from Namespaces matched by the NamespaceSelector.
+                                  Namespace as workloads in AppliedTo fields. If set
+                                  with NamespaceSelector, ExternalEntities are matched
+                                  from Namespaces matched by the NamespaceSelector.
                                   Cannot be set with any other selector except NamespaceSelector.
                                 properties:
                                   matchExpressions:
@@ -430,36 +342,14 @@ spec:
                                       The requirements are ANDed.
                                     type: object
                                 type: object
-                              fqdn:
-                                description: 'Restrict egress access to the Fully
-                                  Qualified Domain Names prescribed by name or by
-                                  wildcard match patterns. This field can only be
-                                  set for NetworkPolicyPeer of egress rules. Supported
-                                  formats are: Exact FQDNs, i.e. "google.com", "db-svc.default.svc.cluster.local"
-                                  Wildcard expressions, i.e. "*wayfair.com".'
-                                type: string
                               group:
                                 description: Group is the name of the ClusterGroup
-                                  which can be set as an AppliedTo or within an Ingress
-                                  or Egress rule in place of a stand-alone selector.
-                                  A Group cannot be set with any other selector.
+                                  which can be set as an AppliedTo in place of a stand-alone
+                                  selector. A Group cannot be set with any other selector.
                                 type: string
-                              ipBlock:
-                                description: IPBlock describes the IPAddresses/IPBlocks
-                                  that is matched in to/from. IPBlock cannot be set
-                                  as part of the AppliedTo field. Cannot be set with
-                                  any other selector.
-                                properties:
-                                  cidr:
-                                    description: CIDR is a string representing the
-                                      IP Block Valid examples are "192.168.1.1/24".
-                                    type: string
-                                required:
-                                - cidr
-                                type: object
                               namespaceSelector:
                                 description: Select all Pods from Namespaces matched
-                                  by this selector, as workloads in To/From fields.
+                                  by this selector, as workloads in AppliedTo fields.
                                   If set with PodSelector, Pods are matched from Namespaces
                                   matched by the NamespaceSelector. Cannot be set
                                   with any other selector except PodSelector or ExternalEntitySelector.
@@ -509,76 +399,12 @@ spec:
                                       The requirements are ANDed.
                                     type: object
                                 type: object
-                              namespaces:
-                                description: 'Select Pod/ExternalEntity from Namespaces
-                                  matched by specifc criteria. Current supported criteria
-                                  is match: Self, which selects from the same Namespace
-                                  of the appliedTo workloads. Cannot be set with any
-                                  other selector except PodSelector or ExternalEntitySelector.
-                                  This field can only be set when NetworkPolicyPeer
-                                  is created for ClusterNetworkPolicy ingress/egress
-                                  rules. Cannot be set with NamespaceSelector.'
-                                properties:
-                                  match:
-                                    description: NamespaceMatchType describes Namespace
-                                      matching strategy.
-                                    type: string
-                                type: object
-                              nodeSelector:
-                                description: Select certain Nodes which match the
-                                  label selector. A NodeSelector cannot be set in
-                                  AppliedTo field or set with any other selector.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: A label selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's
-                                            relationship to a set of values. Valid
-                                            operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If
-                                            the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array
-                                            is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value".
-                                      The requirements are ANDed.
-                                    type: object
-                                type: object
                               podSelector:
                                 description: Select Pods from NetworkPolicy's Namespace
-                                  as workloads in AppliedTo/To/From fields. If set
-                                  with NamespaceSelector, Pods are matched from Namespaces
-                                  matched by the NamespaceSelector. Cannot be set
-                                  with any other selector except NamespaceSelector.
+                                  as workloads in AppliedTo fields. If set with NamespaceSelector,
+                                  Pods are matched from Namespaces matched by the
+                                  NamespaceSelector. Cannot be set with any other
+                                  selector except NamespaceSelector.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label
@@ -624,10 +450,6 @@ spec:
                                       The requirements are ANDed.
                                     type: object
                                 type: object
-                              scope:
-                                description: Define scope of the Pod/NamespaceSelector(s)
-                                  of this peer. Can only be used in ingress NetworkPolicyPeers.
-                                type: string
                               service:
                                 description: Select a certain Service which matches
                                   the NamespacedName. A Service can only be set in
@@ -644,7 +466,7 @@ spec:
                                 type: object
                               serviceAccount:
                                 description: Select all Pods with the ServiceAccount
-                                  matched by this field, as workloads in AppliedTo/To/From
+                                  matched by this field, as workloads in AppliedTo
                                   fields. Cannot be set with any other selector.
                                 properties:
                                   name:
@@ -669,9 +491,9 @@ spec:
                             properties:
                               externalEntitySelector:
                                 description: Select ExternalEntities from NetworkPolicy's
-                                  Namespace as workloads in AppliedTo/To/From fields.
-                                  If set with NamespaceSelector, ExternalEntities
-                                  are matched from Namespaces matched by the NamespaceSelector.
+                                  Namespace as workloads in To/From fields. If set
+                                  with NamespaceSelector, ExternalEntities are matched
+                                  from Namespaces matched by the NamespaceSelector.
                                   Cannot be set with any other selector except NamespaceSelector.
                                 properties:
                                   matchExpressions:
@@ -728,9 +550,9 @@ spec:
                                 type: string
                               group:
                                 description: Group is the name of the ClusterGroup
-                                  which can be set as an AppliedTo or within an Ingress
-                                  or Egress rule in place of a stand-alone selector.
-                                  A Group cannot be set with any other selector.
+                                  which can be set within an Ingress or Egress rule
+                                  in place of a stand-alone selector. A Group cannot
+                                  be set with any other selector.
                                 type: string
                               ipBlock:
                                 description: IPBlock describes the IPAddresses/IPBlocks
@@ -799,13 +621,13 @@ spec:
                                 type: object
                               namespaces:
                                 description: 'Select Pod/ExternalEntity from Namespaces
-                                  matched by specifc criteria. Current supported criteria
-                                  is match: Self, which selects from the same Namespace
-                                  of the appliedTo workloads. Cannot be set with any
-                                  other selector except PodSelector or ExternalEntitySelector.
-                                  This field can only be set when NetworkPolicyPeer
-                                  is created for ClusterNetworkPolicy ingress/egress
-                                  rules. Cannot be set with NamespaceSelector.'
+                                  matched by specific criteria. Current supported
+                                  criteria is match: Self, which selects from the
+                                  same Namespace of the appliedTo workloads. Cannot
+                                  be set with any other selector except PodSelector
+                                  or ExternalEntitySelector. This field can only be
+                                  set when NetworkPolicyPeer is created for ClusterNetworkPolicy
+                                  ingress/egress rules. Cannot be set with NamespaceSelector.'
                                 properties:
                                   match:
                                     description: NamespaceMatchType describes Namespace
@@ -863,10 +685,10 @@ spec:
                                 type: object
                               podSelector:
                                 description: Select Pods from NetworkPolicy's Namespace
-                                  as workloads in AppliedTo/To/From fields. If set
-                                  with NamespaceSelector, Pods are matched from Namespaces
-                                  matched by the NamespaceSelector. Cannot be set
-                                  with any other selector except NamespaceSelector.
+                                  as workloads in To/From fields. If set with NamespaceSelector,
+                                  Pods are matched from Namespaces matched by the
+                                  NamespaceSelector. Cannot be set with any other
+                                  selector except NamespaceSelector.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label
@@ -915,29 +737,52 @@ spec:
                               scope:
                                 description: Define scope of the Pod/NamespaceSelector(s)
                                   of this peer. Can only be used in ingress NetworkPolicyPeers.
+                                  Defaults to "Cluster".
                                 type: string
-                              service:
-                                description: Select a certain Service which matches
-                                  the NamespacedName. A Service can only be set in
-                                  either policy level AppliedTo field in a policy
-                                  that only has ingress rules or rule level AppliedTo
-                                  field in an ingress rule. Only a NodePort Service
-                                  can be referred by this field. Cannot be set with
-                                  any other selector.
+                              serviceAccount:
+                                description: Select all Pods with the ServiceAccount
+                                  matched by this field, as workloads in To/From fields.
+                                  Cannot be set with any other selector.
                                 properties:
                                   name:
                                     type: string
                                   namespace:
                                     type: string
                                 type: object
-                              serviceAccount:
-                                description: Select all Pods with the ServiceAccount
-                                  matched by this field, as workloads in AppliedTo/To/From
-                                  fields. Cannot be set with any other selector.
+                            type: object
+                          type: array
+                        l7Protocols:
+                          description: Set of layer 7 protocols matched by the rule.
+                            If this field is set, action can only be Allow. When this
+                            field is used in a rule, any traffic matching the other
+                            layer 3/4 criteria of the rule (typically the 5-tuple)
+                            will be forwarded to an application-aware engine for protocol
+                            detection and rule enforcement, and the traffic will be
+                            allowed if the layer 7 criteria is also matched, otherwise
+                            it will be dropped. Therefore, any rules after a layer
+                            7 rule will not be enforced for the traffic.
+                          items:
+                            properties:
+                              http:
+                                description: HTTPProtocol matches HTTP requests with
+                                  specific host, method, and path. All fields could
+                                  be used alone or together. If all fields are not
+                                  provided, it matches all HTTP requests.
                                 properties:
-                                  name:
+                                  host:
+                                    description: Host represents the hostname present
+                                      in the URI or the HTTP Host header to match.
+                                      It does not contain the port associated with
+                                      the host.
                                     type: string
-                                  namespace:
+                                  method:
+                                    description: Method represents the HTTP method
+                                      to match. It could be GET, POST, PUT, HEAD,
+                                      DELETE, TRACE, OPTIONS, CONNECT and PATCH.
+                                    type: string
+                                  path:
+                                    description: Path represents the URI path to match
+                                      (Ex. "/index.html", "/admin").
                                     type: string
                                 type: object
                             type: object
@@ -1026,9 +871,9 @@ spec:
                             properties:
                               externalEntitySelector:
                                 description: Select ExternalEntities from NetworkPolicy's
-                                  Namespace as workloads in AppliedTo/To/From fields.
-                                  If set with NamespaceSelector, ExternalEntities
-                                  are matched from Namespaces matched by the NamespaceSelector.
+                                  Namespace as workloads in To/From fields. If set
+                                  with NamespaceSelector, ExternalEntities are matched
+                                  from Namespaces matched by the NamespaceSelector.
                                   Cannot be set with any other selector except NamespaceSelector.
                                 properties:
                                   matchExpressions:
@@ -1085,9 +930,9 @@ spec:
                                 type: string
                               group:
                                 description: Group is the name of the ClusterGroup
-                                  which can be set as an AppliedTo or within an Ingress
-                                  or Egress rule in place of a stand-alone selector.
-                                  A Group cannot be set with any other selector.
+                                  which can be set within an Ingress or Egress rule
+                                  in place of a stand-alone selector. A Group cannot
+                                  be set with any other selector.
                                 type: string
                               ipBlock:
                                 description: IPBlock describes the IPAddresses/IPBlocks
@@ -1156,13 +1001,13 @@ spec:
                                 type: object
                               namespaces:
                                 description: 'Select Pod/ExternalEntity from Namespaces
-                                  matched by specifc criteria. Current supported criteria
-                                  is match: Self, which selects from the same Namespace
-                                  of the appliedTo workloads. Cannot be set with any
-                                  other selector except PodSelector or ExternalEntitySelector.
-                                  This field can only be set when NetworkPolicyPeer
-                                  is created for ClusterNetworkPolicy ingress/egress
-                                  rules. Cannot be set with NamespaceSelector.'
+                                  matched by specific criteria. Current supported
+                                  criteria is match: Self, which selects from the
+                                  same Namespace of the appliedTo workloads. Cannot
+                                  be set with any other selector except PodSelector
+                                  or ExternalEntitySelector. This field can only be
+                                  set when NetworkPolicyPeer is created for ClusterNetworkPolicy
+                                  ingress/egress rules. Cannot be set with NamespaceSelector.'
                                 properties:
                                   match:
                                     description: NamespaceMatchType describes Namespace
@@ -1220,10 +1065,10 @@ spec:
                                 type: object
                               podSelector:
                                 description: Select Pods from NetworkPolicy's Namespace
-                                  as workloads in AppliedTo/To/From fields. If set
-                                  with NamespaceSelector, Pods are matched from Namespaces
-                                  matched by the NamespaceSelector. Cannot be set
-                                  with any other selector except NamespaceSelector.
+                                  as workloads in To/From fields. If set with NamespaceSelector,
+                                  Pods are matched from Namespaces matched by the
+                                  NamespaceSelector. Cannot be set with any other
+                                  selector except NamespaceSelector.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label
@@ -1272,25 +1117,12 @@ spec:
                               scope:
                                 description: Define scope of the Pod/NamespaceSelector(s)
                                   of this peer. Can only be used in ingress NetworkPolicyPeers.
+                                  Defaults to "Cluster".
                                 type: string
-                              service:
-                                description: Select a certain Service which matches
-                                  the NamespacedName. A Service can only be set in
-                                  either policy level AppliedTo field in a policy
-                                  that only has ingress rules or rule level AppliedTo
-                                  field in an ingress rule. Only a NodePort Service
-                                  can be referred by this field. Cannot be set with
-                                  any other selector.
-                                properties:
-                                  name:
-                                    type: string
-                                  namespace:
-                                    type: string
-                                type: object
                               serviceAccount:
                                 description: Select all Pods with the ServiceAccount
-                                  matched by this field, as workloads in AppliedTo/To/From
-                                  fields. Cannot be set with any other selector.
+                                  matched by this field, as workloads in To/From fields.
+                                  Cannot be set with any other selector.
                                 properties:
                                   name:
                                     type: string
@@ -1338,14 +1170,14 @@ spec:
                           description: Select workloads on which this rule will be
                             applied to. Cannot be set in conjunction with NetworkPolicySpec/ClusterNetworkPolicySpec.AppliedTo.
                           items:
-                            description: NetworkPolicyPeer describes the grouping
-                              selector of workloads.
+                            description: AppliedTo describes the grouping selector
+                              of workloads in AppliedTo field.
                             properties:
                               externalEntitySelector:
                                 description: Select ExternalEntities from NetworkPolicy's
-                                  Namespace as workloads in AppliedTo/To/From fields.
-                                  If set with NamespaceSelector, ExternalEntities
-                                  are matched from Namespaces matched by the NamespaceSelector.
+                                  Namespace as workloads in AppliedTo fields. If set
+                                  with NamespaceSelector, ExternalEntities are matched
+                                  from Namespaces matched by the NamespaceSelector.
                                   Cannot be set with any other selector except NamespaceSelector.
                                 properties:
                                   matchExpressions:
@@ -1392,36 +1224,14 @@ spec:
                                       The requirements are ANDed.
                                     type: object
                                 type: object
-                              fqdn:
-                                description: 'Restrict egress access to the Fully
-                                  Qualified Domain Names prescribed by name or by
-                                  wildcard match patterns. This field can only be
-                                  set for NetworkPolicyPeer of egress rules. Supported
-                                  formats are: Exact FQDNs, i.e. "google.com", "db-svc.default.svc.cluster.local"
-                                  Wildcard expressions, i.e. "*wayfair.com".'
-                                type: string
                               group:
                                 description: Group is the name of the ClusterGroup
-                                  which can be set as an AppliedTo or within an Ingress
-                                  or Egress rule in place of a stand-alone selector.
-                                  A Group cannot be set with any other selector.
+                                  which can be set as an AppliedTo in place of a stand-alone
+                                  selector. A Group cannot be set with any other selector.
                                 type: string
-                              ipBlock:
-                                description: IPBlock describes the IPAddresses/IPBlocks
-                                  that is matched in to/from. IPBlock cannot be set
-                                  as part of the AppliedTo field. Cannot be set with
-                                  any other selector.
-                                properties:
-                                  cidr:
-                                    description: CIDR is a string representing the
-                                      IP Block Valid examples are "192.168.1.1/24".
-                                    type: string
-                                required:
-                                - cidr
-                                type: object
                               namespaceSelector:
                                 description: Select all Pods from Namespaces matched
-                                  by this selector, as workloads in To/From fields.
+                                  by this selector, as workloads in AppliedTo fields.
                                   If set with PodSelector, Pods are matched from Namespaces
                                   matched by the NamespaceSelector. Cannot be set
                                   with any other selector except PodSelector or ExternalEntitySelector.
@@ -1471,76 +1281,12 @@ spec:
                                       The requirements are ANDed.
                                     type: object
                                 type: object
-                              namespaces:
-                                description: 'Select Pod/ExternalEntity from Namespaces
-                                  matched by specifc criteria. Current supported criteria
-                                  is match: Self, which selects from the same Namespace
-                                  of the appliedTo workloads. Cannot be set with any
-                                  other selector except PodSelector or ExternalEntitySelector.
-                                  This field can only be set when NetworkPolicyPeer
-                                  is created for ClusterNetworkPolicy ingress/egress
-                                  rules. Cannot be set with NamespaceSelector.'
-                                properties:
-                                  match:
-                                    description: NamespaceMatchType describes Namespace
-                                      matching strategy.
-                                    type: string
-                                type: object
-                              nodeSelector:
-                                description: Select certain Nodes which match the
-                                  label selector. A NodeSelector cannot be set in
-                                  AppliedTo field or set with any other selector.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: A label selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's
-                                            relationship to a set of values. Valid
-                                            operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If
-                                            the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array
-                                            is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value".
-                                      The requirements are ANDed.
-                                    type: object
-                                type: object
                               podSelector:
                                 description: Select Pods from NetworkPolicy's Namespace
-                                  as workloads in AppliedTo/To/From fields. If set
-                                  with NamespaceSelector, Pods are matched from Namespaces
-                                  matched by the NamespaceSelector. Cannot be set
-                                  with any other selector except NamespaceSelector.
+                                  as workloads in AppliedTo fields. If set with NamespaceSelector,
+                                  Pods are matched from Namespaces matched by the
+                                  NamespaceSelector. Cannot be set with any other
+                                  selector except NamespaceSelector.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label
@@ -1586,10 +1332,6 @@ spec:
                                       The requirements are ANDed.
                                     type: object
                                 type: object
-                              scope:
-                                description: Define scope of the Pod/NamespaceSelector(s)
-                                  of this peer. Can only be used in ingress NetworkPolicyPeers.
-                                type: string
                               service:
                                 description: Select a certain Service which matches
                                   the NamespacedName. A Service can only be set in
@@ -1606,7 +1348,7 @@ spec:
                                 type: object
                               serviceAccount:
                                 description: Select all Pods with the ServiceAccount
-                                  matched by this field, as workloads in AppliedTo/To/From
+                                  matched by this field, as workloads in AppliedTo
                                   fields. Cannot be set with any other selector.
                                 properties:
                                   name:
@@ -1631,9 +1373,9 @@ spec:
                             properties:
                               externalEntitySelector:
                                 description: Select ExternalEntities from NetworkPolicy's
-                                  Namespace as workloads in AppliedTo/To/From fields.
-                                  If set with NamespaceSelector, ExternalEntities
-                                  are matched from Namespaces matched by the NamespaceSelector.
+                                  Namespace as workloads in To/From fields. If set
+                                  with NamespaceSelector, ExternalEntities are matched
+                                  from Namespaces matched by the NamespaceSelector.
                                   Cannot be set with any other selector except NamespaceSelector.
                                 properties:
                                   matchExpressions:
@@ -1690,9 +1432,9 @@ spec:
                                 type: string
                               group:
                                 description: Group is the name of the ClusterGroup
-                                  which can be set as an AppliedTo or within an Ingress
-                                  or Egress rule in place of a stand-alone selector.
-                                  A Group cannot be set with any other selector.
+                                  which can be set within an Ingress or Egress rule
+                                  in place of a stand-alone selector. A Group cannot
+                                  be set with any other selector.
                                 type: string
                               ipBlock:
                                 description: IPBlock describes the IPAddresses/IPBlocks
@@ -1761,13 +1503,13 @@ spec:
                                 type: object
                               namespaces:
                                 description: 'Select Pod/ExternalEntity from Namespaces
-                                  matched by specifc criteria. Current supported criteria
-                                  is match: Self, which selects from the same Namespace
-                                  of the appliedTo workloads. Cannot be set with any
-                                  other selector except PodSelector or ExternalEntitySelector.
-                                  This field can only be set when NetworkPolicyPeer
-                                  is created for ClusterNetworkPolicy ingress/egress
-                                  rules. Cannot be set with NamespaceSelector.'
+                                  matched by specific criteria. Current supported
+                                  criteria is match: Self, which selects from the
+                                  same Namespace of the appliedTo workloads. Cannot
+                                  be set with any other selector except PodSelector
+                                  or ExternalEntitySelector. This field can only be
+                                  set when NetworkPolicyPeer is created for ClusterNetworkPolicy
+                                  ingress/egress rules. Cannot be set with NamespaceSelector.'
                                 properties:
                                   match:
                                     description: NamespaceMatchType describes Namespace
@@ -1825,10 +1567,10 @@ spec:
                                 type: object
                               podSelector:
                                 description: Select Pods from NetworkPolicy's Namespace
-                                  as workloads in AppliedTo/To/From fields. If set
-                                  with NamespaceSelector, Pods are matched from Namespaces
-                                  matched by the NamespaceSelector. Cannot be set
-                                  with any other selector except NamespaceSelector.
+                                  as workloads in To/From fields. If set with NamespaceSelector,
+                                  Pods are matched from Namespaces matched by the
+                                  NamespaceSelector. Cannot be set with any other
+                                  selector except NamespaceSelector.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label
@@ -1877,29 +1619,52 @@ spec:
                               scope:
                                 description: Define scope of the Pod/NamespaceSelector(s)
                                   of this peer. Can only be used in ingress NetworkPolicyPeers.
+                                  Defaults to "Cluster".
                                 type: string
-                              service:
-                                description: Select a certain Service which matches
-                                  the NamespacedName. A Service can only be set in
-                                  either policy level AppliedTo field in a policy
-                                  that only has ingress rules or rule level AppliedTo
-                                  field in an ingress rule. Only a NodePort Service
-                                  can be referred by this field. Cannot be set with
-                                  any other selector.
+                              serviceAccount:
+                                description: Select all Pods with the ServiceAccount
+                                  matched by this field, as workloads in To/From fields.
+                                  Cannot be set with any other selector.
                                 properties:
                                   name:
                                     type: string
                                   namespace:
                                     type: string
                                 type: object
-                              serviceAccount:
-                                description: Select all Pods with the ServiceAccount
-                                  matched by this field, as workloads in AppliedTo/To/From
-                                  fields. Cannot be set with any other selector.
+                            type: object
+                          type: array
+                        l7Protocols:
+                          description: Set of layer 7 protocols matched by the rule.
+                            If this field is set, action can only be Allow. When this
+                            field is used in a rule, any traffic matching the other
+                            layer 3/4 criteria of the rule (typically the 5-tuple)
+                            will be forwarded to an application-aware engine for protocol
+                            detection and rule enforcement, and the traffic will be
+                            allowed if the layer 7 criteria is also matched, otherwise
+                            it will be dropped. Therefore, any rules after a layer
+                            7 rule will not be enforced for the traffic.
+                          items:
+                            properties:
+                              http:
+                                description: HTTPProtocol matches HTTP requests with
+                                  specific host, method, and path. All fields could
+                                  be used alone or together. If all fields are not
+                                  provided, it matches all HTTP requests.
                                 properties:
-                                  name:
+                                  host:
+                                    description: Host represents the hostname present
+                                      in the URI or the HTTP Host header to match.
+                                      It does not contain the port associated with
+                                      the host.
                                     type: string
-                                  namespace:
+                                  method:
+                                    description: Method represents the HTTP method
+                                      to match. It could be GET, POST, PUT, HEAD,
+                                      DELETE, TRACE, OPTIONS, CONNECT and PATCH.
+                                    type: string
+                                  path:
+                                    description: Path represents the URI path to match
+                                      (Ex. "/index.html", "/admin").
                                     type: string
                                 type: object
                             type: object
@@ -1988,9 +1753,9 @@ spec:
                             properties:
                               externalEntitySelector:
                                 description: Select ExternalEntities from NetworkPolicy's
-                                  Namespace as workloads in AppliedTo/To/From fields.
-                                  If set with NamespaceSelector, ExternalEntities
-                                  are matched from Namespaces matched by the NamespaceSelector.
+                                  Namespace as workloads in To/From fields. If set
+                                  with NamespaceSelector, ExternalEntities are matched
+                                  from Namespaces matched by the NamespaceSelector.
                                   Cannot be set with any other selector except NamespaceSelector.
                                 properties:
                                   matchExpressions:
@@ -2047,9 +1812,9 @@ spec:
                                 type: string
                               group:
                                 description: Group is the name of the ClusterGroup
-                                  which can be set as an AppliedTo or within an Ingress
-                                  or Egress rule in place of a stand-alone selector.
-                                  A Group cannot be set with any other selector.
+                                  which can be set within an Ingress or Egress rule
+                                  in place of a stand-alone selector. A Group cannot
+                                  be set with any other selector.
                                 type: string
                               ipBlock:
                                 description: IPBlock describes the IPAddresses/IPBlocks
@@ -2118,13 +1883,13 @@ spec:
                                 type: object
                               namespaces:
                                 description: 'Select Pod/ExternalEntity from Namespaces
-                                  matched by specifc criteria. Current supported criteria
-                                  is match: Self, which selects from the same Namespace
-                                  of the appliedTo workloads. Cannot be set with any
-                                  other selector except PodSelector or ExternalEntitySelector.
-                                  This field can only be set when NetworkPolicyPeer
-                                  is created for ClusterNetworkPolicy ingress/egress
-                                  rules. Cannot be set with NamespaceSelector.'
+                                  matched by specific criteria. Current supported
+                                  criteria is match: Self, which selects from the
+                                  same Namespace of the appliedTo workloads. Cannot
+                                  be set with any other selector except PodSelector
+                                  or ExternalEntitySelector. This field can only be
+                                  set when NetworkPolicyPeer is created for ClusterNetworkPolicy
+                                  ingress/egress rules. Cannot be set with NamespaceSelector.'
                                 properties:
                                   match:
                                     description: NamespaceMatchType describes Namespace
@@ -2182,10 +1947,10 @@ spec:
                                 type: object
                               podSelector:
                                 description: Select Pods from NetworkPolicy's Namespace
-                                  as workloads in AppliedTo/To/From fields. If set
-                                  with NamespaceSelector, Pods are matched from Namespaces
-                                  matched by the NamespaceSelector. Cannot be set
-                                  with any other selector except NamespaceSelector.
+                                  as workloads in To/From fields. If set with NamespaceSelector,
+                                  Pods are matched from Namespaces matched by the
+                                  NamespaceSelector. Cannot be set with any other
+                                  selector except NamespaceSelector.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label
@@ -2234,25 +1999,12 @@ spec:
                               scope:
                                 description: Define scope of the Pod/NamespaceSelector(s)
                                   of this peer. Can only be used in ingress NetworkPolicyPeers.
+                                  Defaults to "Cluster".
                                 type: string
-                              service:
-                                description: Select a certain Service which matches
-                                  the NamespacedName. A Service can only be set in
-                                  either policy level AppliedTo field in a policy
-                                  that only has ingress rules or rule level AppliedTo
-                                  field in an ingress rule. Only a NodePort Service
-                                  can be referred by this field. Cannot be set with
-                                  any other selector.
-                                properties:
-                                  name:
-                                    type: string
-                                  namespace:
-                                    type: string
-                                type: object
                               serviceAccount:
                                 description: Select all Pods with the ServiceAccount
-                                  matched by this field, as workloads in AppliedTo/To/From
-                                  fields. Cannot be set with any other selector.
+                                  matched by this field, as workloads in To/From fields.
+                                  Cannot be set with any other selector.
                                 properties:
                                   name:
                                     type: string

--- a/multicluster/config/crd/bases/multicluster.crd.antrea.io_resourceimports.yaml
+++ b/multicluster/config/crd/bases/multicluster.crd.antrea.io_resourceimports.yaml
@@ -88,15 +88,15 @@ spec:
                     description: Select workloads on which the rules will be applied
                       to. Cannot be set in conjunction with AppliedTo in each rule.
                     items:
-                      description: NetworkPolicyPeer describes the grouping selector
-                        of workloads.
+                      description: AppliedTo describes the grouping selector of workloads
+                        in AppliedTo field.
                       properties:
                         externalEntitySelector:
                           description: Select ExternalEntities from NetworkPolicy's
-                            Namespace as workloads in AppliedTo/To/From fields. If
-                            set with NamespaceSelector, ExternalEntities are matched
-                            from Namespaces matched by the NamespaceSelector. Cannot
-                            be set with any other selector except NamespaceSelector.
+                            Namespace as workloads in AppliedTo fields. If set with
+                            NamespaceSelector, ExternalEntities are matched from Namespaces
+                            matched by the NamespaceSelector. Cannot be set with any
+                            other selector except NamespaceSelector.
                           properties:
                             matchExpressions:
                               description: matchExpressions is a list of label selector
@@ -140,35 +140,14 @@ spec:
                                 contains only "value". The requirements are ANDed.
                               type: object
                           type: object
-                        fqdn:
-                          description: 'Restrict egress access to the Fully Qualified
-                            Domain Names prescribed by name or by wildcard match patterns.
-                            This field can only be set for NetworkPolicyPeer of egress
-                            rules. Supported formats are: Exact FQDNs, i.e. "google.com",
-                            "db-svc.default.svc.cluster.local" Wildcard expressions,
-                            i.e. "*wayfair.com".'
-                          type: string
                         group:
                           description: Group is the name of the ClusterGroup which
-                            can be set as an AppliedTo or within an Ingress or Egress
-                            rule in place of a stand-alone selector. A Group cannot
-                            be set with any other selector.
+                            can be set as an AppliedTo in place of a stand-alone selector.
+                            A Group cannot be set with any other selector.
                           type: string
-                        ipBlock:
-                          description: IPBlock describes the IPAddresses/IPBlocks
-                            that is matched in to/from. IPBlock cannot be set as part
-                            of the AppliedTo field. Cannot be set with any other selector.
-                          properties:
-                            cidr:
-                              description: CIDR is a string representing the IP Block
-                                Valid examples are "192.168.1.1/24".
-                              type: string
-                          required:
-                          - cidr
-                          type: object
                         namespaceSelector:
                           description: Select all Pods from Namespaces matched by
-                            this selector, as workloads in To/From fields. If set
+                            this selector, as workloads in AppliedTo fields. If set
                             with PodSelector, Pods are matched from Namespaces matched
                             by the NamespaceSelector. Cannot be set with any other
                             selector except PodSelector or ExternalEntitySelector.
@@ -216,74 +195,11 @@ spec:
                                 contains only "value". The requirements are ANDed.
                               type: object
                           type: object
-                        namespaces:
-                          description: 'Select Pod/ExternalEntity from Namespaces
-                            matched by specifc criteria. Current supported criteria
-                            is match: Self, which selects from the same Namespace
-                            of the appliedTo workloads. Cannot be set with any other
-                            selector except PodSelector or ExternalEntitySelector.
-                            This field can only be set when NetworkPolicyPeer is created
-                            for ClusterNetworkPolicy ingress/egress rules. Cannot
-                            be set with NamespaceSelector.'
-                          properties:
-                            match:
-                              description: NamespaceMatchType describes Namespace
-                                matching strategy.
-                              type: string
-                          type: object
-                        nodeSelector:
-                          description: Select certain Nodes which match the label
-                            selector. A NodeSelector cannot be set in AppliedTo field
-                            or set with any other selector.
-                          properties:
-                            matchExpressions:
-                              description: matchExpressions is a list of label selector
-                                requirements. The requirements are ANDed.
-                              items:
-                                description: A label selector requirement is a selector
-                                  that contains values, a key, and an operator that
-                                  relates the key and values.
-                                properties:
-                                  key:
-                                    description: key is the label key that the selector
-                                      applies to.
-                                    type: string
-                                  operator:
-                                    description: operator represents a key's relationship
-                                      to a set of values. Valid operators are In,
-                                      NotIn, Exists and DoesNotExist.
-                                    type: string
-                                  values:
-                                    description: values is an array of string values.
-                                      If the operator is In or NotIn, the values array
-                                      must be non-empty. If the operator is Exists
-                                      or DoesNotExist, the values array must be empty.
-                                      This array is replaced during a strategic merge
-                                      patch.
-                                    items:
-                                      type: string
-                                    type: array
-                                required:
-                                - key
-                                - operator
-                                type: object
-                              type: array
-                            matchLabels:
-                              additionalProperties:
-                                type: string
-                              description: matchLabels is a map of {key,value} pairs.
-                                A single {key,value} in the matchLabels map is equivalent
-                                to an element of matchExpressions, whose key field
-                                is "key", the operator is "In", and the values array
-                                contains only "value". The requirements are ANDed.
-                              type: object
-                          type: object
                         podSelector:
                           description: Select Pods from NetworkPolicy's Namespace
-                            as workloads in AppliedTo/To/From fields. If set with
-                            NamespaceSelector, Pods are matched from Namespaces matched
-                            by the NamespaceSelector. Cannot be set with any other
-                            selector except NamespaceSelector.
+                            as workloads in AppliedTo fields. If set with NamespaceSelector,
+                            Pods are matched from Namespaces matched by the NamespaceSelector.
+                            Cannot be set with any other selector except NamespaceSelector.
                           properties:
                             matchExpressions:
                               description: matchExpressions is a list of label selector
@@ -327,10 +243,6 @@ spec:
                                 contains only "value". The requirements are ANDed.
                               type: object
                           type: object
-                        scope:
-                          description: Define scope of the Pod/NamespaceSelector(s)
-                            of this peer. Can only be used in ingress NetworkPolicyPeers.
-                          type: string
                         service:
                           description: Select a certain Service which matches the
                             NamespacedName. A Service can only be set in either policy
@@ -346,8 +258,8 @@ spec:
                           type: object
                         serviceAccount:
                           description: Select all Pods with the ServiceAccount matched
-                            by this field, as workloads in AppliedTo/To/From fields.
-                            Cannot be set with any other selector.
+                            by this field, as workloads in AppliedTo fields. Cannot
+                            be set with any other selector.
                           properties:
                             name:
                               type: string
@@ -374,14 +286,14 @@ spec:
                           description: Select workloads on which this rule will be
                             applied to. Cannot be set in conjunction with NetworkPolicySpec/ClusterNetworkPolicySpec.AppliedTo.
                           items:
-                            description: NetworkPolicyPeer describes the grouping
-                              selector of workloads.
+                            description: AppliedTo describes the grouping selector
+                              of workloads in AppliedTo field.
                             properties:
                               externalEntitySelector:
                                 description: Select ExternalEntities from NetworkPolicy's
-                                  Namespace as workloads in AppliedTo/To/From fields.
-                                  If set with NamespaceSelector, ExternalEntities
-                                  are matched from Namespaces matched by the NamespaceSelector.
+                                  Namespace as workloads in AppliedTo fields. If set
+                                  with NamespaceSelector, ExternalEntities are matched
+                                  from Namespaces matched by the NamespaceSelector.
                                   Cannot be set with any other selector except NamespaceSelector.
                                 properties:
                                   matchExpressions:
@@ -428,36 +340,14 @@ spec:
                                       The requirements are ANDed.
                                     type: object
                                 type: object
-                              fqdn:
-                                description: 'Restrict egress access to the Fully
-                                  Qualified Domain Names prescribed by name or by
-                                  wildcard match patterns. This field can only be
-                                  set for NetworkPolicyPeer of egress rules. Supported
-                                  formats are: Exact FQDNs, i.e. "google.com", "db-svc.default.svc.cluster.local"
-                                  Wildcard expressions, i.e. "*wayfair.com".'
-                                type: string
                               group:
                                 description: Group is the name of the ClusterGroup
-                                  which can be set as an AppliedTo or within an Ingress
-                                  or Egress rule in place of a stand-alone selector.
-                                  A Group cannot be set with any other selector.
+                                  which can be set as an AppliedTo in place of a stand-alone
+                                  selector. A Group cannot be set with any other selector.
                                 type: string
-                              ipBlock:
-                                description: IPBlock describes the IPAddresses/IPBlocks
-                                  that is matched in to/from. IPBlock cannot be set
-                                  as part of the AppliedTo field. Cannot be set with
-                                  any other selector.
-                                properties:
-                                  cidr:
-                                    description: CIDR is a string representing the
-                                      IP Block Valid examples are "192.168.1.1/24".
-                                    type: string
-                                required:
-                                - cidr
-                                type: object
                               namespaceSelector:
                                 description: Select all Pods from Namespaces matched
-                                  by this selector, as workloads in To/From fields.
+                                  by this selector, as workloads in AppliedTo fields.
                                   If set with PodSelector, Pods are matched from Namespaces
                                   matched by the NamespaceSelector. Cannot be set
                                   with any other selector except PodSelector or ExternalEntitySelector.
@@ -507,76 +397,12 @@ spec:
                                       The requirements are ANDed.
                                     type: object
                                 type: object
-                              namespaces:
-                                description: 'Select Pod/ExternalEntity from Namespaces
-                                  matched by specifc criteria. Current supported criteria
-                                  is match: Self, which selects from the same Namespace
-                                  of the appliedTo workloads. Cannot be set with any
-                                  other selector except PodSelector or ExternalEntitySelector.
-                                  This field can only be set when NetworkPolicyPeer
-                                  is created for ClusterNetworkPolicy ingress/egress
-                                  rules. Cannot be set with NamespaceSelector.'
-                                properties:
-                                  match:
-                                    description: NamespaceMatchType describes Namespace
-                                      matching strategy.
-                                    type: string
-                                type: object
-                              nodeSelector:
-                                description: Select certain Nodes which match the
-                                  label selector. A NodeSelector cannot be set in
-                                  AppliedTo field or set with any other selector.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: A label selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's
-                                            relationship to a set of values. Valid
-                                            operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If
-                                            the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array
-                                            is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value".
-                                      The requirements are ANDed.
-                                    type: object
-                                type: object
                               podSelector:
                                 description: Select Pods from NetworkPolicy's Namespace
-                                  as workloads in AppliedTo/To/From fields. If set
-                                  with NamespaceSelector, Pods are matched from Namespaces
-                                  matched by the NamespaceSelector. Cannot be set
-                                  with any other selector except NamespaceSelector.
+                                  as workloads in AppliedTo fields. If set with NamespaceSelector,
+                                  Pods are matched from Namespaces matched by the
+                                  NamespaceSelector. Cannot be set with any other
+                                  selector except NamespaceSelector.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label
@@ -622,10 +448,6 @@ spec:
                                       The requirements are ANDed.
                                     type: object
                                 type: object
-                              scope:
-                                description: Define scope of the Pod/NamespaceSelector(s)
-                                  of this peer. Can only be used in ingress NetworkPolicyPeers.
-                                type: string
                               service:
                                 description: Select a certain Service which matches
                                   the NamespacedName. A Service can only be set in
@@ -642,7 +464,7 @@ spec:
                                 type: object
                               serviceAccount:
                                 description: Select all Pods with the ServiceAccount
-                                  matched by this field, as workloads in AppliedTo/To/From
+                                  matched by this field, as workloads in AppliedTo
                                   fields. Cannot be set with any other selector.
                                 properties:
                                   name:
@@ -667,9 +489,9 @@ spec:
                             properties:
                               externalEntitySelector:
                                 description: Select ExternalEntities from NetworkPolicy's
-                                  Namespace as workloads in AppliedTo/To/From fields.
-                                  If set with NamespaceSelector, ExternalEntities
-                                  are matched from Namespaces matched by the NamespaceSelector.
+                                  Namespace as workloads in To/From fields. If set
+                                  with NamespaceSelector, ExternalEntities are matched
+                                  from Namespaces matched by the NamespaceSelector.
                                   Cannot be set with any other selector except NamespaceSelector.
                                 properties:
                                   matchExpressions:
@@ -726,9 +548,9 @@ spec:
                                 type: string
                               group:
                                 description: Group is the name of the ClusterGroup
-                                  which can be set as an AppliedTo or within an Ingress
-                                  or Egress rule in place of a stand-alone selector.
-                                  A Group cannot be set with any other selector.
+                                  which can be set within an Ingress or Egress rule
+                                  in place of a stand-alone selector. A Group cannot
+                                  be set with any other selector.
                                 type: string
                               ipBlock:
                                 description: IPBlock describes the IPAddresses/IPBlocks
@@ -797,13 +619,13 @@ spec:
                                 type: object
                               namespaces:
                                 description: 'Select Pod/ExternalEntity from Namespaces
-                                  matched by specifc criteria. Current supported criteria
-                                  is match: Self, which selects from the same Namespace
-                                  of the appliedTo workloads. Cannot be set with any
-                                  other selector except PodSelector or ExternalEntitySelector.
-                                  This field can only be set when NetworkPolicyPeer
-                                  is created for ClusterNetworkPolicy ingress/egress
-                                  rules. Cannot be set with NamespaceSelector.'
+                                  matched by specific criteria. Current supported
+                                  criteria is match: Self, which selects from the
+                                  same Namespace of the appliedTo workloads. Cannot
+                                  be set with any other selector except PodSelector
+                                  or ExternalEntitySelector. This field can only be
+                                  set when NetworkPolicyPeer is created for ClusterNetworkPolicy
+                                  ingress/egress rules. Cannot be set with NamespaceSelector.'
                                 properties:
                                   match:
                                     description: NamespaceMatchType describes Namespace
@@ -861,10 +683,10 @@ spec:
                                 type: object
                               podSelector:
                                 description: Select Pods from NetworkPolicy's Namespace
-                                  as workloads in AppliedTo/To/From fields. If set
-                                  with NamespaceSelector, Pods are matched from Namespaces
-                                  matched by the NamespaceSelector. Cannot be set
-                                  with any other selector except NamespaceSelector.
+                                  as workloads in To/From fields. If set with NamespaceSelector,
+                                  Pods are matched from Namespaces matched by the
+                                  NamespaceSelector. Cannot be set with any other
+                                  selector except NamespaceSelector.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label
@@ -913,29 +735,52 @@ spec:
                               scope:
                                 description: Define scope of the Pod/NamespaceSelector(s)
                                   of this peer. Can only be used in ingress NetworkPolicyPeers.
+                                  Defaults to "Cluster".
                                 type: string
-                              service:
-                                description: Select a certain Service which matches
-                                  the NamespacedName. A Service can only be set in
-                                  either policy level AppliedTo field in a policy
-                                  that only has ingress rules or rule level AppliedTo
-                                  field in an ingress rule. Only a NodePort Service
-                                  can be referred by this field. Cannot be set with
-                                  any other selector.
+                              serviceAccount:
+                                description: Select all Pods with the ServiceAccount
+                                  matched by this field, as workloads in To/From fields.
+                                  Cannot be set with any other selector.
                                 properties:
                                   name:
                                     type: string
                                   namespace:
                                     type: string
                                 type: object
-                              serviceAccount:
-                                description: Select all Pods with the ServiceAccount
-                                  matched by this field, as workloads in AppliedTo/To/From
-                                  fields. Cannot be set with any other selector.
+                            type: object
+                          type: array
+                        l7Protocols:
+                          description: Set of layer 7 protocols matched by the rule.
+                            If this field is set, action can only be Allow. When this
+                            field is used in a rule, any traffic matching the other
+                            layer 3/4 criteria of the rule (typically the 5-tuple)
+                            will be forwarded to an application-aware engine for protocol
+                            detection and rule enforcement, and the traffic will be
+                            allowed if the layer 7 criteria is also matched, otherwise
+                            it will be dropped. Therefore, any rules after a layer
+                            7 rule will not be enforced for the traffic.
+                          items:
+                            properties:
+                              http:
+                                description: HTTPProtocol matches HTTP requests with
+                                  specific host, method, and path. All fields could
+                                  be used alone or together. If all fields are not
+                                  provided, it matches all HTTP requests.
                                 properties:
-                                  name:
+                                  host:
+                                    description: Host represents the hostname present
+                                      in the URI or the HTTP Host header to match.
+                                      It does not contain the port associated with
+                                      the host.
                                     type: string
-                                  namespace:
+                                  method:
+                                    description: Method represents the HTTP method
+                                      to match. It could be GET, POST, PUT, HEAD,
+                                      DELETE, TRACE, OPTIONS, CONNECT and PATCH.
+                                    type: string
+                                  path:
+                                    description: Path represents the URI path to match
+                                      (Ex. "/index.html", "/admin").
                                     type: string
                                 type: object
                             type: object
@@ -1024,9 +869,9 @@ spec:
                             properties:
                               externalEntitySelector:
                                 description: Select ExternalEntities from NetworkPolicy's
-                                  Namespace as workloads in AppliedTo/To/From fields.
-                                  If set with NamespaceSelector, ExternalEntities
-                                  are matched from Namespaces matched by the NamespaceSelector.
+                                  Namespace as workloads in To/From fields. If set
+                                  with NamespaceSelector, ExternalEntities are matched
+                                  from Namespaces matched by the NamespaceSelector.
                                   Cannot be set with any other selector except NamespaceSelector.
                                 properties:
                                   matchExpressions:
@@ -1083,9 +928,9 @@ spec:
                                 type: string
                               group:
                                 description: Group is the name of the ClusterGroup
-                                  which can be set as an AppliedTo or within an Ingress
-                                  or Egress rule in place of a stand-alone selector.
-                                  A Group cannot be set with any other selector.
+                                  which can be set within an Ingress or Egress rule
+                                  in place of a stand-alone selector. A Group cannot
+                                  be set with any other selector.
                                 type: string
                               ipBlock:
                                 description: IPBlock describes the IPAddresses/IPBlocks
@@ -1154,13 +999,13 @@ spec:
                                 type: object
                               namespaces:
                                 description: 'Select Pod/ExternalEntity from Namespaces
-                                  matched by specifc criteria. Current supported criteria
-                                  is match: Self, which selects from the same Namespace
-                                  of the appliedTo workloads. Cannot be set with any
-                                  other selector except PodSelector or ExternalEntitySelector.
-                                  This field can only be set when NetworkPolicyPeer
-                                  is created for ClusterNetworkPolicy ingress/egress
-                                  rules. Cannot be set with NamespaceSelector.'
+                                  matched by specific criteria. Current supported
+                                  criteria is match: Self, which selects from the
+                                  same Namespace of the appliedTo workloads. Cannot
+                                  be set with any other selector except PodSelector
+                                  or ExternalEntitySelector. This field can only be
+                                  set when NetworkPolicyPeer is created for ClusterNetworkPolicy
+                                  ingress/egress rules. Cannot be set with NamespaceSelector.'
                                 properties:
                                   match:
                                     description: NamespaceMatchType describes Namespace
@@ -1218,10 +1063,10 @@ spec:
                                 type: object
                               podSelector:
                                 description: Select Pods from NetworkPolicy's Namespace
-                                  as workloads in AppliedTo/To/From fields. If set
-                                  with NamespaceSelector, Pods are matched from Namespaces
-                                  matched by the NamespaceSelector. Cannot be set
-                                  with any other selector except NamespaceSelector.
+                                  as workloads in To/From fields. If set with NamespaceSelector,
+                                  Pods are matched from Namespaces matched by the
+                                  NamespaceSelector. Cannot be set with any other
+                                  selector except NamespaceSelector.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label
@@ -1270,25 +1115,12 @@ spec:
                               scope:
                                 description: Define scope of the Pod/NamespaceSelector(s)
                                   of this peer. Can only be used in ingress NetworkPolicyPeers.
+                                  Defaults to "Cluster".
                                 type: string
-                              service:
-                                description: Select a certain Service which matches
-                                  the NamespacedName. A Service can only be set in
-                                  either policy level AppliedTo field in a policy
-                                  that only has ingress rules or rule level AppliedTo
-                                  field in an ingress rule. Only a NodePort Service
-                                  can be referred by this field. Cannot be set with
-                                  any other selector.
-                                properties:
-                                  name:
-                                    type: string
-                                  namespace:
-                                    type: string
-                                type: object
                               serviceAccount:
                                 description: Select all Pods with the ServiceAccount
-                                  matched by this field, as workloads in AppliedTo/To/From
-                                  fields. Cannot be set with any other selector.
+                                  matched by this field, as workloads in To/From fields.
+                                  Cannot be set with any other selector.
                                 properties:
                                   name:
                                     type: string
@@ -1336,14 +1168,14 @@ spec:
                           description: Select workloads on which this rule will be
                             applied to. Cannot be set in conjunction with NetworkPolicySpec/ClusterNetworkPolicySpec.AppliedTo.
                           items:
-                            description: NetworkPolicyPeer describes the grouping
-                              selector of workloads.
+                            description: AppliedTo describes the grouping selector
+                              of workloads in AppliedTo field.
                             properties:
                               externalEntitySelector:
                                 description: Select ExternalEntities from NetworkPolicy's
-                                  Namespace as workloads in AppliedTo/To/From fields.
-                                  If set with NamespaceSelector, ExternalEntities
-                                  are matched from Namespaces matched by the NamespaceSelector.
+                                  Namespace as workloads in AppliedTo fields. If set
+                                  with NamespaceSelector, ExternalEntities are matched
+                                  from Namespaces matched by the NamespaceSelector.
                                   Cannot be set with any other selector except NamespaceSelector.
                                 properties:
                                   matchExpressions:
@@ -1390,36 +1222,14 @@ spec:
                                       The requirements are ANDed.
                                     type: object
                                 type: object
-                              fqdn:
-                                description: 'Restrict egress access to the Fully
-                                  Qualified Domain Names prescribed by name or by
-                                  wildcard match patterns. This field can only be
-                                  set for NetworkPolicyPeer of egress rules. Supported
-                                  formats are: Exact FQDNs, i.e. "google.com", "db-svc.default.svc.cluster.local"
-                                  Wildcard expressions, i.e. "*wayfair.com".'
-                                type: string
                               group:
                                 description: Group is the name of the ClusterGroup
-                                  which can be set as an AppliedTo or within an Ingress
-                                  or Egress rule in place of a stand-alone selector.
-                                  A Group cannot be set with any other selector.
+                                  which can be set as an AppliedTo in place of a stand-alone
+                                  selector. A Group cannot be set with any other selector.
                                 type: string
-                              ipBlock:
-                                description: IPBlock describes the IPAddresses/IPBlocks
-                                  that is matched in to/from. IPBlock cannot be set
-                                  as part of the AppliedTo field. Cannot be set with
-                                  any other selector.
-                                properties:
-                                  cidr:
-                                    description: CIDR is a string representing the
-                                      IP Block Valid examples are "192.168.1.1/24".
-                                    type: string
-                                required:
-                                - cidr
-                                type: object
                               namespaceSelector:
                                 description: Select all Pods from Namespaces matched
-                                  by this selector, as workloads in To/From fields.
+                                  by this selector, as workloads in AppliedTo fields.
                                   If set with PodSelector, Pods are matched from Namespaces
                                   matched by the NamespaceSelector. Cannot be set
                                   with any other selector except PodSelector or ExternalEntitySelector.
@@ -1469,76 +1279,12 @@ spec:
                                       The requirements are ANDed.
                                     type: object
                                 type: object
-                              namespaces:
-                                description: 'Select Pod/ExternalEntity from Namespaces
-                                  matched by specifc criteria. Current supported criteria
-                                  is match: Self, which selects from the same Namespace
-                                  of the appliedTo workloads. Cannot be set with any
-                                  other selector except PodSelector or ExternalEntitySelector.
-                                  This field can only be set when NetworkPolicyPeer
-                                  is created for ClusterNetworkPolicy ingress/egress
-                                  rules. Cannot be set with NamespaceSelector.'
-                                properties:
-                                  match:
-                                    description: NamespaceMatchType describes Namespace
-                                      matching strategy.
-                                    type: string
-                                type: object
-                              nodeSelector:
-                                description: Select certain Nodes which match the
-                                  label selector. A NodeSelector cannot be set in
-                                  AppliedTo field or set with any other selector.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: A label selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's
-                                            relationship to a set of values. Valid
-                                            operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If
-                                            the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array
-                                            is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value".
-                                      The requirements are ANDed.
-                                    type: object
-                                type: object
                               podSelector:
                                 description: Select Pods from NetworkPolicy's Namespace
-                                  as workloads in AppliedTo/To/From fields. If set
-                                  with NamespaceSelector, Pods are matched from Namespaces
-                                  matched by the NamespaceSelector. Cannot be set
-                                  with any other selector except NamespaceSelector.
+                                  as workloads in AppliedTo fields. If set with NamespaceSelector,
+                                  Pods are matched from Namespaces matched by the
+                                  NamespaceSelector. Cannot be set with any other
+                                  selector except NamespaceSelector.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label
@@ -1584,10 +1330,6 @@ spec:
                                       The requirements are ANDed.
                                     type: object
                                 type: object
-                              scope:
-                                description: Define scope of the Pod/NamespaceSelector(s)
-                                  of this peer. Can only be used in ingress NetworkPolicyPeers.
-                                type: string
                               service:
                                 description: Select a certain Service which matches
                                   the NamespacedName. A Service can only be set in
@@ -1604,7 +1346,7 @@ spec:
                                 type: object
                               serviceAccount:
                                 description: Select all Pods with the ServiceAccount
-                                  matched by this field, as workloads in AppliedTo/To/From
+                                  matched by this field, as workloads in AppliedTo
                                   fields. Cannot be set with any other selector.
                                 properties:
                                   name:
@@ -1629,9 +1371,9 @@ spec:
                             properties:
                               externalEntitySelector:
                                 description: Select ExternalEntities from NetworkPolicy's
-                                  Namespace as workloads in AppliedTo/To/From fields.
-                                  If set with NamespaceSelector, ExternalEntities
-                                  are matched from Namespaces matched by the NamespaceSelector.
+                                  Namespace as workloads in To/From fields. If set
+                                  with NamespaceSelector, ExternalEntities are matched
+                                  from Namespaces matched by the NamespaceSelector.
                                   Cannot be set with any other selector except NamespaceSelector.
                                 properties:
                                   matchExpressions:
@@ -1688,9 +1430,9 @@ spec:
                                 type: string
                               group:
                                 description: Group is the name of the ClusterGroup
-                                  which can be set as an AppliedTo or within an Ingress
-                                  or Egress rule in place of a stand-alone selector.
-                                  A Group cannot be set with any other selector.
+                                  which can be set within an Ingress or Egress rule
+                                  in place of a stand-alone selector. A Group cannot
+                                  be set with any other selector.
                                 type: string
                               ipBlock:
                                 description: IPBlock describes the IPAddresses/IPBlocks
@@ -1759,13 +1501,13 @@ spec:
                                 type: object
                               namespaces:
                                 description: 'Select Pod/ExternalEntity from Namespaces
-                                  matched by specifc criteria. Current supported criteria
-                                  is match: Self, which selects from the same Namespace
-                                  of the appliedTo workloads. Cannot be set with any
-                                  other selector except PodSelector or ExternalEntitySelector.
-                                  This field can only be set when NetworkPolicyPeer
-                                  is created for ClusterNetworkPolicy ingress/egress
-                                  rules. Cannot be set with NamespaceSelector.'
+                                  matched by specific criteria. Current supported
+                                  criteria is match: Self, which selects from the
+                                  same Namespace of the appliedTo workloads. Cannot
+                                  be set with any other selector except PodSelector
+                                  or ExternalEntitySelector. This field can only be
+                                  set when NetworkPolicyPeer is created for ClusterNetworkPolicy
+                                  ingress/egress rules. Cannot be set with NamespaceSelector.'
                                 properties:
                                   match:
                                     description: NamespaceMatchType describes Namespace
@@ -1823,10 +1565,10 @@ spec:
                                 type: object
                               podSelector:
                                 description: Select Pods from NetworkPolicy's Namespace
-                                  as workloads in AppliedTo/To/From fields. If set
-                                  with NamespaceSelector, Pods are matched from Namespaces
-                                  matched by the NamespaceSelector. Cannot be set
-                                  with any other selector except NamespaceSelector.
+                                  as workloads in To/From fields. If set with NamespaceSelector,
+                                  Pods are matched from Namespaces matched by the
+                                  NamespaceSelector. Cannot be set with any other
+                                  selector except NamespaceSelector.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label
@@ -1875,29 +1617,52 @@ spec:
                               scope:
                                 description: Define scope of the Pod/NamespaceSelector(s)
                                   of this peer. Can only be used in ingress NetworkPolicyPeers.
+                                  Defaults to "Cluster".
                                 type: string
-                              service:
-                                description: Select a certain Service which matches
-                                  the NamespacedName. A Service can only be set in
-                                  either policy level AppliedTo field in a policy
-                                  that only has ingress rules or rule level AppliedTo
-                                  field in an ingress rule. Only a NodePort Service
-                                  can be referred by this field. Cannot be set with
-                                  any other selector.
+                              serviceAccount:
+                                description: Select all Pods with the ServiceAccount
+                                  matched by this field, as workloads in To/From fields.
+                                  Cannot be set with any other selector.
                                 properties:
                                   name:
                                     type: string
                                   namespace:
                                     type: string
                                 type: object
-                              serviceAccount:
-                                description: Select all Pods with the ServiceAccount
-                                  matched by this field, as workloads in AppliedTo/To/From
-                                  fields. Cannot be set with any other selector.
+                            type: object
+                          type: array
+                        l7Protocols:
+                          description: Set of layer 7 protocols matched by the rule.
+                            If this field is set, action can only be Allow. When this
+                            field is used in a rule, any traffic matching the other
+                            layer 3/4 criteria of the rule (typically the 5-tuple)
+                            will be forwarded to an application-aware engine for protocol
+                            detection and rule enforcement, and the traffic will be
+                            allowed if the layer 7 criteria is also matched, otherwise
+                            it will be dropped. Therefore, any rules after a layer
+                            7 rule will not be enforced for the traffic.
+                          items:
+                            properties:
+                              http:
+                                description: HTTPProtocol matches HTTP requests with
+                                  specific host, method, and path. All fields could
+                                  be used alone or together. If all fields are not
+                                  provided, it matches all HTTP requests.
                                 properties:
-                                  name:
+                                  host:
+                                    description: Host represents the hostname present
+                                      in the URI or the HTTP Host header to match.
+                                      It does not contain the port associated with
+                                      the host.
                                     type: string
-                                  namespace:
+                                  method:
+                                    description: Method represents the HTTP method
+                                      to match. It could be GET, POST, PUT, HEAD,
+                                      DELETE, TRACE, OPTIONS, CONNECT and PATCH.
+                                    type: string
+                                  path:
+                                    description: Path represents the URI path to match
+                                      (Ex. "/index.html", "/admin").
                                     type: string
                                 type: object
                             type: object
@@ -1986,9 +1751,9 @@ spec:
                             properties:
                               externalEntitySelector:
                                 description: Select ExternalEntities from NetworkPolicy's
-                                  Namespace as workloads in AppliedTo/To/From fields.
-                                  If set with NamespaceSelector, ExternalEntities
-                                  are matched from Namespaces matched by the NamespaceSelector.
+                                  Namespace as workloads in To/From fields. If set
+                                  with NamespaceSelector, ExternalEntities are matched
+                                  from Namespaces matched by the NamespaceSelector.
                                   Cannot be set with any other selector except NamespaceSelector.
                                 properties:
                                   matchExpressions:
@@ -2045,9 +1810,9 @@ spec:
                                 type: string
                               group:
                                 description: Group is the name of the ClusterGroup
-                                  which can be set as an AppliedTo or within an Ingress
-                                  or Egress rule in place of a stand-alone selector.
-                                  A Group cannot be set with any other selector.
+                                  which can be set within an Ingress or Egress rule
+                                  in place of a stand-alone selector. A Group cannot
+                                  be set with any other selector.
                                 type: string
                               ipBlock:
                                 description: IPBlock describes the IPAddresses/IPBlocks
@@ -2116,13 +1881,13 @@ spec:
                                 type: object
                               namespaces:
                                 description: 'Select Pod/ExternalEntity from Namespaces
-                                  matched by specifc criteria. Current supported criteria
-                                  is match: Self, which selects from the same Namespace
-                                  of the appliedTo workloads. Cannot be set with any
-                                  other selector except PodSelector or ExternalEntitySelector.
-                                  This field can only be set when NetworkPolicyPeer
-                                  is created for ClusterNetworkPolicy ingress/egress
-                                  rules. Cannot be set with NamespaceSelector.'
+                                  matched by specific criteria. Current supported
+                                  criteria is match: Self, which selects from the
+                                  same Namespace of the appliedTo workloads. Cannot
+                                  be set with any other selector except PodSelector
+                                  or ExternalEntitySelector. This field can only be
+                                  set when NetworkPolicyPeer is created for ClusterNetworkPolicy
+                                  ingress/egress rules. Cannot be set with NamespaceSelector.'
                                 properties:
                                   match:
                                     description: NamespaceMatchType describes Namespace
@@ -2180,10 +1945,10 @@ spec:
                                 type: object
                               podSelector:
                                 description: Select Pods from NetworkPolicy's Namespace
-                                  as workloads in AppliedTo/To/From fields. If set
-                                  with NamespaceSelector, Pods are matched from Namespaces
-                                  matched by the NamespaceSelector. Cannot be set
-                                  with any other selector except NamespaceSelector.
+                                  as workloads in To/From fields. If set with NamespaceSelector,
+                                  Pods are matched from Namespaces matched by the
+                                  NamespaceSelector. Cannot be set with any other
+                                  selector except NamespaceSelector.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label
@@ -2232,25 +1997,12 @@ spec:
                               scope:
                                 description: Define scope of the Pod/NamespaceSelector(s)
                                   of this peer. Can only be used in ingress NetworkPolicyPeers.
+                                  Defaults to "Cluster".
                                 type: string
-                              service:
-                                description: Select a certain Service which matches
-                                  the NamespacedName. A Service can only be set in
-                                  either policy level AppliedTo field in a policy
-                                  that only has ingress rules or rule level AppliedTo
-                                  field in an ingress rule. Only a NodePort Service
-                                  can be referred by this field. Cannot be set with
-                                  any other selector.
-                                properties:
-                                  name:
-                                    type: string
-                                  namespace:
-                                    type: string
-                                type: object
                               serviceAccount:
                                 description: Select all Pods with the ServiceAccount
-                                  matched by this field, as workloads in AppliedTo/To/From
-                                  fields. Cannot be set with any other selector.
+                                  matched by this field, as workloads in To/From fields.
+                                  Cannot be set with any other selector.
                                 properties:
                                   name:
                                     type: string


### PR DESCRIPTION
1. Update the multi-cluster manifests which are introduced by stretched NetworkPolicy controller change.
2. Add new CI steps to check multi-cluster manifests change.

Signed-off-by: Lan Luo <luola@vmware.com>