### PR TITLE
Add addressgroup peer for in-cluster stretched NetworkPolicy enforcement

### DIFF
--- a/pkg/apis/controlplane/types.go
+++ b/pkg/apis/controlplane/types.go
@@ -323,7 +323,7 @@ type HTTPProtocol struct {
 }
 
 // NetworkPolicyPeer describes a peer of NetworkPolicyRules.
-// It could be a list of names of AddressGroups and/or a list of IPBlock.
+// It could contain one of the subfields or a combination of them.
 type NetworkPolicyPeer struct {
 	// A list of names of AddressGroups.
 	AddressGroups []string

--- a/pkg/controller/networkpolicy/crd_utils.go
+++ b/pkg/controller/networkpolicy/crd_utils.go
@@ -189,11 +189,12 @@ func (n *NetworkPolicyController) toAntreaPeerForCRD(peers []v1alpha1.NetworkPol
 		} else if peer.NodeSelector != nil {
 			addressGroup := n.createAddressGroup("", nil, nil, nil, peer.NodeSelector)
 			addressGroups = append(addressGroups, addressGroup)
-		} else if peer.Scope == v1alpha1.ScopeClusterSet {
-			clusterSetScopeSelectors = append(clusterSetScopeSelectors, antreatypes.NewGroupSelector(np.GetNamespace(), peer.PodSelector, peer.NamespaceSelector, nil, nil))
 		} else {
 			addressGroup := n.createAddressGroup(np.GetNamespace(), peer.PodSelector, peer.NamespaceSelector, peer.ExternalEntitySelector, nil)
 			addressGroups = append(addressGroups, addressGroup)
+		}
+		if peer.Scope == v1alpha1.ScopeClusterSet {
+			clusterSetScopeSelectors = append(clusterSetScopeSelectors, antreatypes.NewGroupSelector(np.GetNamespace(), peer.PodSelector, peer.NamespaceSelector, nil, nil))
 		}
 	}
 	var labelIdentities []uint32

--- a/pkg/controller/networkpolicy/crd_utils_test.go
+++ b/pkg/controller/networkpolicy/crd_utils_test.go
@@ -455,6 +455,9 @@ func TestToAntreaPeerForCRD(t *testing.T) {
 			},
 			outPeer: controlplane.NetworkPolicyPeer{
 				LabelIdentities: []uint32{1},
+				AddressGroups: []string{
+					getNormalizedUID(antreatypes.NewGroupSelector("", &selectorA, nil, nil, nil).NormalizedName),
+				},
 			},
 			direction:       controlplane.DirectionIn,
 			clusterSetScope: true,


### PR DESCRIPTION
This PR is to fix stretched networkpolicy enforcement on Pod
to MC Service traffic when the MC Service endpoint resides in
the same cluster of the client. Under current datapath design,
the packet will loose tunnel information which contains the
client's label identity, thus bypassing stretched policy
enforcement. For more details on this issue, refer to #4431

As a result, stretched NetworkPolicy enforcement need to be
divided into two parts: for in-cluster access, the Antrea Controller
will create an addressgroup matching the clusterSet-scoped
selector, just like cluster-scoped selectors. For cross-cluster
policy enforcement, label identity will be used to match
selected peers.

Signed-off-by: Dyanngg <dingyang@vmware.com>