### PR TITLE
Fix typo in S3Uploader

### DIFF
--- a/pkg/flowaggregator/s3uploader/s3uploader.go
+++ b/pkg/flowaggregator/s3uploader/s3uploader.go
@@ -316,7 +316,7 @@ func (p *S3UploadProcess) batchUploadAll(ctx context.Context) error {
 		reader := bytes.NewReader(buf.Bytes())
 		err := p.uploadFile(ctx, reader)
 		if err != nil {
-			p.bufferQueue = p.bufferQueue[uploaded:]
+			p.buffersToUpload = p.buffersToUpload[uploaded:]
 			return err
 		}
 		uploaded += 1


### PR DESCRIPTION
This commits fixes a typo in S3Uploader: when an upload error occurs, we should discard the successfully-uploaded buffers and keep the rest in `buffersToUpload`. Previously we were mistakenly modifying `bufferQueue`, instead of `buffersToUpload`. The typo was not caught by UT, as we currently do not have a test case to properly simulate a partial-success upload.

Signed-off-by: heanlan <hanlan@vmware.com>