### PR TITLE
Doc for multi-cluster in more modes

### DIFF
--- a/docs/eks-installation.md
+++ b/docs/eks-installation.md
@@ -9,7 +9,7 @@ In `networkPolicyOnly` mode, Antrea implements NetworkPolicy and other services 
 while Amazon VPC CNI takes care of IPAM and Pod traffic routing across Nodes. Refer to
 [the design document](design/policy-only.md) for more information about `networkPolicyOnly` mode.
 
-This document assumes you already have an EKS cluster, and have ``KUBECONFIG`` environment variable
+This document assumes you already have an EKS cluster, and have the `KUBECONFIG` environment variable
 point to the kubeconfig file of that cluster. You can follow [the EKS documentation](https://docs.aws.amazon.com/eks/latest/userguide/create-cluster.html)
 to create the cluster.
 

--- a/docs/multicluster/architecture.md
+++ b/docs/multicluster/architecture.md
@@ -131,9 +131,8 @@ Multi-cluster connectivity with Multi-cluster Gateways.
 
 <img src="assets/mc-gateway.svg" width="800" alt="Antrea Multi-cluster Gateway">
 
-Antrea Agent is responsible for setting up tunnels between Gateways of meamber
-clusters. At the moment, Multi-cluster Gateway only works with Antrea `encap`
-mode. The tunnels between Gateways use Antrea Agent's configured tunnel type.
+Antrea Agent is responsible for setting up tunnels between Gateways of member
+clusters. The tunnels between Gateways use Antrea Agent's configured tunnel type.
 All member clusters in a ClusterSet need to deploy Antrea with the same tunnel
 type.
 
@@ -201,3 +200,16 @@ be created as a ResourceExport in the leader cluster, and the resource
 export/import pipeline will ensure member clusters receive this ACNP spec
 to be replicated. Each member cluster's Multi-cluster Controller will then
 create an ACNP in their respective clusters.
+
+## Antrea Traffic Modes
+
+Multi-cluster Gateway supports all of `encap`, `noEncap`, `hybrid`, and
+`networkPolicyOnly` modes. In all supported modes, the cross-cluster traffic
+is routed by Multi-cluster Gateways of member clusters, and the traffic goes
+through Antrea overlay tunnels between Gateways. In `noEncap`, `hybrid`, and
+`networkPolicyOnly` modes, even when in-cluster Pod traffic does not go through
+tunnels, antrea-agent still creates tunnels between the Gateway Node and other
+Nodes, and routes cross-cluster traffic to reach the Gateway through the tunnels.
+Specially for [`networkPolicyOnly` mode](../design/policy-only.md), Antrea only
+handles multi-cluster traffic routing, while the primary CNI takes care of in-cluster
+traffic routing.

--- a/docs/multicluster/policy-only-mode.md
+++ b/docs/multicluster/policy-only-mode.md
@@ -1,0 +1,79 @@
+# Antrea Multi-cluster with NetworkPolicy Only Mode
+
+Multi-cluster Gateway works with Antrea `networkPolicyOnly` mode, in which
+cross-cluster traffic is routed by Multi-cluster Gateways of member clusters,
+and the traffic goes through Antrea overlay tunnels between Gateways and local
+cluster Pods. Pod traffic within a cluster is still handled by the primary CNI,
+not Antrea.
+
+## Deploying Antrea in `networkPolicyOnly` mode with Multi-cluster feature
+
+This section describes steps to deploy Antrea in `networkPolicyOnly` mode
+with the Multi-cluster feature enabled on an EKS cluster.
+
+You can follow [the EKS documentation](https://docs.aws.amazon.com/eks/latest/userguide/create-cluster.html)
+to create an EKS cluster, and follow the [Antrea EKS installation guide](../eks-installation.md)
+to deploy Antrea to an EKS cluster. Please note there are a few changes required
+by Antrea Multi-cluster. You should set the following configuration parameters in
+ `antrea-agent.conf` of the Antrea deployment manifest to enable the `Multicluster`
+ feature and Antrea Multi-cluster Gateway:
+
+```yaml
+antrea-agent.conf: |
+...
+  featureGates:
+...
+    Multicluster: true
+...
+  multicluster:
+    enableGateway: true
+    namespace: "" # Change to the Namespace where antrea-mc-controller is deployed.
+```
+
+Repeat the same steps to deploy Antrea for all member clusters in a ClusterSet.
+Besides the Antrea deployment, you also need to deploy Antrea Multi-cluster Controller
+in each member cluster. Make sure the Service CIDRs (ClusterIP ranges) must not overlap
+among the member clusters. Please refer to [the quick start guide](./quick-start.md)
+or [the user guide](./user-guide.md) to learn more information about how to configure
+a ClusterSet.
+
+## Connectivity between Clusters
+
+When EKS clusters of a ClusterSet are in different VPCs, you may need to enable connectivity
+between VPCs to support Multi-cluster traffic. You can check the following steps to set up VPC
+connectivity for a ClusterSet.
+
+In the following descriptions, we take a ClusterSet with two member clusters in two VPCs as
+an example to describe the VPC configuration.
+
+| Cluster ID    | PodCIDR       | Gateway IP   |
+| ------------  | ------------- | ------------ |
+| west-cluster  | 110.13.0.0/16 | 110.13.26.12 |
+| east-cluster  | 110.14.0.0/16 | 110.14.18.50 |
+
+### VPC Peering Configuration
+
+When the Gateway Nodes do not have public IPs, you may create a VPC peering connection between
+the two VPCs for the Gateways to reach each other. You can follow the
+[AWS documentation](https://docs.aws.amazon.com/vpc/latest/peering/what-is-vpc-peering.html) to
+configure VPC peering.
+
+You also need to add a route to the route tables of the Gateway Nodes' subnets, to enable
+routing across the peering connection. For `west-cluster`, the route should have `east-cluster`'s
+Pod CIDR: `110.14.0.0/16` to be the destination, and the peering connection to be the target;
+for `east-cluster`, the route should have `west-cluster`'s Pod CIDR: `110.13.0.0/16` to be the
+destination. To learn more about VPC peering routes, please refer to the [AWS documentation](https://docs.aws.amazon.com/vpc/latest/peering/vpc-peering-routing.html).
+
+### Security Groups
+
+AWS security groups may need to be configured to allow tunnel traffic to Multi-cluster Gateways,
+especially when the member clusters are in different VPCs. EKS should have already created a
+security group for each cluster, which should have a description like "EKS created security group
+applied to ENI that is attached to EKS Control Plane master nodes, as well as any managed workloads.".
+You can add a new rule to the security group for Gateway traffic. For `west-cluster`, add an inbound
+rule with source to be `east-cluster`'s Gateway IP `110.14.18.50/32`; for `east-cluster`, the source
+should be `west-cluster`'s Gateway IP `110.13.26.12/32`.
+
+By default, Multi-cluster Gateway IP should be the `InternalIP` of the Gateway Node, but you may
+configure Antrea Multi-cluster to use the Node `ExternalIP`. Please use the right Node IP address
+as the Gateway IP in the security group rule.

--- a/docs/multicluster/user-guide.md
+++ b/docs/multicluster/user-guide.md
@@ -81,8 +81,13 @@ antrea-agent.conf: |
     namespace: "" # Change to the Namespace where antrea-mc-controller is deployed.
 ```
 
-At the moment, Multi-cluster Gateway only works with the Antrea `encap` traffic
-mode, and all member clusters in a ClusterSet must use the same tunnel type.
+Prior to Antrea v1.11.0, Multi-cluster Gateway only works with Antrea `encap` traffic
+mode, and all member clusters in a ClusterSet must use the same tunnel type. Since
+Antrea v1.11.0, Multi-cluster Gateway also works with the Antrea `noEncap`, `hybrid`
+and `networkPolicyOnly` modes. For `noEncap` and `hybrid` modes, Antrea Multi-cluster
+deployment is the same as `encap` mode. For `networkPolicyOnly` mode, we need extra
+Antrea configuration changes to support Multi-cluster Gateway. Please check
+[the deployment guide](./policy-only-mode.md) for more information.
 
 ### Deploy Antrea Multi-cluster Controller
 

--- a/hack/.notableofcontents
+++ b/hack/.notableofcontents
@@ -29,6 +29,7 @@ docs/maintainers/updating-ovs-windows.md
 docs/multicluster/api.md
 docs/multicluster/antctl.md
 docs/multicluster/architecture.md
+docs/multicluster/policy-only-mode.md
 docs/multicluster/quick-start.md
 docs/multicluster/upgrade.md
 docs/multicluster/user-guide.md

--- a/multicluster/test/e2e/README.md
+++ b/multicluster/test/e2e/README.md
@@ -21,7 +21,7 @@ uploaded to all the Nodes. If you install the Multi-cluster Controller manually,
 you can run the tests from the top-level directory with `go test -v antrea.io/antrea/multicluster/test/e2e --mc-gateway`
 or run `bash ci/jenkins/test-mc.sh --testcase e2e --mc-gateway`. If you'd like
 to run test with Kind clusters, you can run `bash ci/jenkins/test-mc.sh --testcase e2e --mc-gateway --kind`.
-The command will create three Kind clusters and deploy Multi-cluster controllers
+The command will create three Kind clusters and deploy Multi-cluster Controllers
 into the Kind clusters before running e2e tests.
 
 When you use `test-mc.sh`, make sure your kubeconfig files of the clusters are placed


### PR DESCRIPTION
Since v1.11.0, MC will support `noEncap`, `hybrid` and `networkPolicyOnly` modes, this PR is for updating corresponding guides. 
 
Signed-off-by: Lan Luo <luola@vmware.com>