### PR TITLE
Antrea agent configuration file to enable and configure secondary network specific OVS parameters.

### DIFF
--- a/build/charts/antrea/README.md
+++ b/build/charts/antrea/README.md
@@ -98,6 +98,12 @@ Kubernetes: `>= 1.16.0-0`
 | nodePortLocal.portRange | string | `"61000-62000"` | Port range used by NodePortLocal when creating Pod port mappings. |
 | ovs.bridgeName | string | `"br-int"` | Name of the OVS bridge antrea-agent will create and use. |
 | ovs.hwOffload | bool | `false` | Enable hardware offload for the OVS bridge (required additional configuration). |
+| secondaryNetwork.ovs.datapathType | string | `"system"` | 'system' is the default value and corresponds to the kernel datapath. Use 'netdev' to run OVS in userspace mode. Userspace mode requires the tun device driver to be available. |
+| secondaryNetwork.ovs.enable | bool | `false` | Enable OVS bridge configuration for secondary network. |
+| secondaryNetwork.ovs.integrationBridgeName | string | `"br-secnet-int"` | Secondary network OVS integration bridge name. |
+| secondaryNetwork.ovs.patchPort | string | `"br-secnet-patch0"` | Name of the OVS patch port which connects the integration and transport bridge. |
+| secondaryNetwork.ovs.transportBridgeName | string | `"br-secnet-trans"` | Secondary network OVS transport bridge name. |
+| secondaryNetwork.tunnelType | string | `"geneve"` | Tunnel protocol used for encapsulating traffic across Nodes. It must be one of "geneve", "vxlan", "gre", "stt". |
 | serviceCIDR | string | `""` | IPv4 CIDR range used for Services. Required when AntreaProxy is disabled. |
 | serviceCIDRv6 | string | `""` | IPv6 CIDR range used for Services. Required when AntreaProxy is disabled. |
 | testing.coverage | bool | `false` |  |

--- a/build/charts/antrea/conf/antrea-agent.conf
+++ b/build/charts/antrea/conf/antrea-agent.conf
@@ -334,3 +334,29 @@ multicluster:
 # The default is antrea-agent's Namespace.
   namespace: {{ .namespace | quote }}
 {{- end }}
+
+{{- if .Values.featureGates.SecondaryNetwork }}
+
+secondaryNetwork:
+{{- with .Values.secondaryNetwork }}
+  # OVS bridge configuration for secondary network.
+  ovs:
+    # Enable OVS bridge configuration for secondary network.
+    enable: {{ .ovs.enable }}
+    # Secondary network OVS integration bridge name. Ensure it doesn't conflict with your existing OpenVSwitch bridges.
+    integrationBridgeName: {{ .ovs.integrationBridgeName | quote }}
+    # Secondary network OVS transport bridge name. Ensure it doesn't conflict with your existing OpenVSwitch bridges.
+    transportBridgeName: {{ .ovs.transportBridgeName | quote }}
+    # Datapath type to use for the OpenVSwitch bridge created by Antrea. Supported values are:
+    # - system
+    # - netdev
+    # 'system' is the default value and corresponds to the kernel datapath. Use 'netdev' to run
+    # OVS in userspace mode. Userspace mode requires the tun device driver to be available.
+    datapathType: {{ .ovs.datapathType | quote }}
+    # Name of the OVS patch port which connects the integration and transport bridge.
+    patchPort: {{ .ovs.patchPort | quote }}
+  # Tunnel protocol used for encapsulating traffic across Nodes. It must be one
+  # of "geneve", "vxlan", "gre", "stt".
+  tunnelType: {{ .tunnelType | quote }}
+{{- end }}
+{{- end }}

--- a/build/charts/antrea/values.yaml
+++ b/build/charts/antrea/values.yaml
@@ -67,6 +67,26 @@ ovs:
   # configuration).
   hwOffload: false
 
+secondaryNetwork:
+  ovs:
+    # -- Enable OVS bridge configuration for secondary network.
+    enable: false
+    # -- Secondary network OVS integration bridge name.
+    integrationBridgeName: "br-secnet-int"
+    # -- Secondary network OVS transport bridge name.
+    transportBridgeName: "br-secnet-trans"
+    # -- Datapath type to use for the OpenVSwitch bridge created by Antrea. Supported values are:
+    # - system
+    # - netdev
+    # -- 'system' is the default value and corresponds to the kernel datapath. Use 'netdev' to run
+    # OVS in userspace mode. Userspace mode requires the tun device driver to be available.
+    datapathType: "system"
+    # -- Name of the OVS patch port which connects the integration and transport bridge.
+    patchPort: "br-secnet-patch0"
+  # -- Tunnel protocol used for encapsulating traffic across Nodes. It must be one
+  # of "geneve", "vxlan", "gre", "stt".
+  tunnelType: "geneve"
+
 wireGuard:
   # -- Port for WireGuard to send and receive traffic.
   port: 51820

--- a/pkg/config/agent/config.go
+++ b/pkg/config/agent/config.go
@@ -214,6 +214,8 @@ type AgentConfig struct {
 	NodeType string `yaml:"nodeType,omitempty"`
 	// ExternalNode related configurations.
 	ExternalNode ExternalNodeConfig `yaml:"externalNode,omitempty"`
+	// Antrea's native secondary network configuration.
+	SecondaryNetwork SecondaryNetworkConfig `yaml:"secondaryNetwork,omitempty"`
 }
 
 type AntreaProxyConfig struct {
@@ -306,4 +308,24 @@ type PolicyBypassRule struct {
 	CIDR string `json:"cidr,omitempty"`
 	// The destination port of the given protocol.
 	Port int `yaml:"port,omitempty"`
+}
+
+type SecondaryNetworkConfig struct {
+	// Secondary network specific OVS configuration.
+	OVS SecondaryNetworkOVSConfig `yaml:"ovs,omitempty"`
+	// TunnelType to be used for node to node transport, which is part of the same virtual network.
+	TunnelType string `yaml:"tunnelType,omitempty"`
+}
+
+type SecondaryNetworkOVSConfig struct {
+	// Enable Antrea's native secondary network OVS configuration.
+	Enable bool `yaml:"enable,omitempty"`
+	// OVS integration bridge name.
+	OVSIntegrationBridgeName string `yaml:"ovsIntegrationBridgeName,omitempty"`
+	// OVS transport bridge name.
+	OVSTransportBridgeName string `yaml:"ovsTransportBridgeName,omitempty"`
+	// OVS Datapath type to use for the OpenVSwitch bridge created by Antrea.
+	OVSDatapathType string `yaml:"ovsDatapathType,omitempty"`
+	// OVS patch port which connects the integration and transport bridge.
+	OVSPatchPort string `yaml:"ovsPatchPort,omitempty"`
 }


### PR DESCRIPTION
Antrea agent configuration file to enable and configure secondary network specific OVS parameters. Required to enable service function chaining.

Signed-off-by: Adwait Patil <adwait.nilesh.patil@intel.com>