### PR TITLE
Automated cherry pick of #4126: Add OFSwitch connection check to Agent's liveness probes

### DIFF
--- a/build/charts/antrea/templates/agent/daemonset.yaml
+++ b/build/charts/antrea/templates/agent/daemonset.yaml
@@ -175,12 +175,12 @@ spec:
               name: api
               protocol: TCP
           livenessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - -c
-                - container_liveness_probe agent
-            initialDelaySeconds: 5
+            httpGet:
+              host: localhost
+              path: /livez
+              port: api
+              scheme: HTTPS
+            initialDelaySeconds: 10
             timeoutSeconds: 5
             periodSeconds: 10
             failureThreshold: 5

--- a/build/images/scripts/container_liveness_probe
+++ b/build/images/scripts/container_liveness_probe
@@ -16,9 +16,7 @@
 
 source daemon_status
 
-if [ $1 == agent ]; then
-    exit 0
-elif [ $1 == ovs ]; then
+if [ $1 == ovs ]; then
     check_ovs_status && exit 0
 elif [ $1 == ovs-ipsec ]; then
     check_ovs_ipsec_status && exit 0

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -4082,12 +4082,12 @@ spec:
               name: api
               protocol: TCP
           livenessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - -c
-                - container_liveness_probe agent
-            initialDelaySeconds: 5
+            httpGet:
+              host: localhost
+              path: /livez
+              port: api
+              scheme: HTTPS
+            initialDelaySeconds: 10
             timeoutSeconds: 5
             periodSeconds: 10
             failureThreshold: 5

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -4084,12 +4084,12 @@ spec:
               name: api
               protocol: TCP
           livenessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - -c
-                - container_liveness_probe agent
-            initialDelaySeconds: 5
+            httpGet:
+              host: localhost
+              path: /livez
+              port: api
+              scheme: HTTPS
+            initialDelaySeconds: 10
             timeoutSeconds: 5
             periodSeconds: 10
             failureThreshold: 5

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -4081,12 +4081,12 @@ spec:
               name: api
               protocol: TCP
           livenessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - -c
-                - container_liveness_probe agent
-            initialDelaySeconds: 5
+            httpGet:
+              host: localhost
+              path: /livez
+              port: api
+              scheme: HTTPS
+            initialDelaySeconds: 10
             timeoutSeconds: 5
             periodSeconds: 10
             failureThreshold: 5

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -4101,12 +4101,12 @@ spec:
               name: api
               protocol: TCP
           livenessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - -c
-                - container_liveness_probe agent
-            initialDelaySeconds: 5
+            httpGet:
+              host: localhost
+              path: /livez
+              port: api
+              scheme: HTTPS
+            initialDelaySeconds: 10
             timeoutSeconds: 5
             periodSeconds: 10
             failureThreshold: 5

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -4081,12 +4081,12 @@ spec:
               name: api
               protocol: TCP
           livenessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - -c
-                - container_liveness_probe agent
-            initialDelaySeconds: 5
+            httpGet:
+              host: localhost
+              path: /livez
+              port: api
+              scheme: HTTPS
+            initialDelaySeconds: 10
             timeoutSeconds: 5
             periodSeconds: 10
             failureThreshold: 5

--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/server/options"
 	"k8s.io/client-go/informers"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/tools/cache"
@@ -71,7 +72,6 @@ import (
 	"antrea.io/antrea/pkg/ovs/ovsctl"
 	"antrea.io/antrea/pkg/signals"
 	"antrea.io/antrea/pkg/util/channel"
-	"antrea.io/antrea/pkg/util/cipher"
 	"antrea.io/antrea/pkg/util/env"
 	"antrea.io/antrea/pkg/util/k8s"
 	"antrea.io/antrea/pkg/version"
@@ -748,25 +748,27 @@ func run(o *Options) error {
 
 	go agentMonitor.Run(stopCh)
 
-	cipherSuites, err := cipher.GenerateCipherSuitesList(o.config.TLSCipherSuites)
-	if err != nil {
-		return fmt.Errorf("error generating Cipher Suite list: %v", err)
-	}
 	bindAddress := net.IPv4zero
 	if o.nodeType == config.ExternalNode {
 		bindAddress = ipv4Localhost
 	}
+	secureServing := options.NewSecureServingOptions().WithLoopback()
+	secureServing.BindAddress = bindAddress
+	secureServing.BindPort = o.config.APIPort
+	secureServing.CipherSuites = o.tlsCipherSuites
+	secureServing.MinTLSVersion = o.config.TLSMinVersion
+	authentication := options.NewDelegatingAuthenticationOptions()
+	authorization := options.NewDelegatingAuthorizationOptions().WithAlwaysAllowPaths("/healthz", "/livez", "/readyz")
 	apiServer, err := apiserver.New(
 		agentQuerier,
 		networkPolicyController,
 		mcastController,
 		externalIPController,
-		bindAddress,
-		o.config.APIPort,
+		secureServing,
+		authentication,
+		authorization,
 		*o.config.EnablePrometheusMetrics,
 		o.config.ClientConnection.Kubeconfig,
-		cipherSuites,
-		cipher.TLSVersionMap[o.config.TLSMinVersion],
 		v4Enabled,
 		v6Enabled)
 	if err != nil {

--- a/cmd/antrea-agent/options.go
+++ b/cmd/antrea-agent/options.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/pflag"
 	"gopkg.in/yaml.v2"
 	"k8s.io/apimachinery/pkg/util/sets"
+	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/featuregate"
 	"k8s.io/klog/v2"
 
@@ -61,6 +62,8 @@ type Options struct {
 	configFile string
 	// The configuration object
 	config *agentconfig.AgentConfig
+	// tlsCipherSuites is a slice of TLSCipherSuites mapped to input provided by user.
+	tlsCipherSuites []string
 	// IPFIX flow collector address
 	flowCollectorAddr string
 	// IPFIX flow collector protocol
@@ -124,6 +127,10 @@ func (o *Options) validate(args []string) error {
 		klog.Info("OVS 'netdev' datapath is not fully supported at the moment")
 	}
 
+	if err := o.validateTLSOptions(); err != nil {
+		return err
+	}
+
 	if config.ExternalNode.String() == o.config.NodeType && !features.DefaultFeatureGate.Enabled(features.ExternalNode) {
 		return fmt.Errorf("nodeType %s requires feature gate ExternalNode to be enabled", o.config.NodeType)
 	}
@@ -169,6 +176,23 @@ func (o *Options) setDefaults() {
 	} else {
 		o.setExternalNodeDefaultOptions()
 	}
+}
+
+func (o *Options) validateTLSOptions() error {
+	_, err := cliflag.TLSVersion(o.config.TLSMinVersion)
+	if err != nil {
+		return fmt.Errorf("invalid TLSMinVersion: %v", err)
+	}
+	trimmedTLSCipherSuites := strings.ReplaceAll(o.config.TLSCipherSuites, " ", "")
+	if trimmedTLSCipherSuites != "" {
+		tlsCipherSuites := strings.Split(trimmedTLSCipherSuites, ",")
+		_, err = cliflag.TLSCipherSuites(tlsCipherSuites)
+		if err != nil {
+			return fmt.Errorf("invalid TLSCipherSuites: %v", err)
+		}
+		o.tlsCipherSuites = tlsCipherSuites
+	}
+	return nil
 }
 
 func (o *Options) validateAntreaProxyConfig() error {

--- a/cmd/antrea-agent/options_test.go
+++ b/cmd/antrea-agent/options_test.go
@@ -1,0 +1,75 @@
+// Copyright 2022 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	agentconfig "antrea.io/antrea/pkg/config/agent"
+)
+
+func TestOptionsValidateTLSOptions(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      *agentconfig.AgentConfig
+		expectedErr string
+	}{
+		{
+			name: "empty input",
+			config: &agentconfig.AgentConfig{
+				TLSCipherSuites: "",
+				TLSMinVersion:   "",
+			},
+			expectedErr: "",
+		},
+		{
+			name: "invalid TLSMinVersion",
+			config: &agentconfig.AgentConfig{
+				TLSCipherSuites: "",
+				TLSMinVersion:   "foo",
+			},
+			expectedErr: "invalid TLSMinVersion",
+		},
+		{
+			name: "invalid TLSCipherSuites",
+			config: &agentconfig.AgentConfig{
+				TLSCipherSuites: "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305, foo",
+				TLSMinVersion:   "VersionTLS10",
+			},
+			expectedErr: "invalid TLSCipherSuites",
+		},
+		{
+			name: "valid input",
+			config: &agentconfig.AgentConfig{
+				TLSCipherSuites: "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305, TLS_RSA_WITH_AES_128_GCM_SHA256",
+				TLSMinVersion:   "VersionTLS12",
+			},
+			expectedErr: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := &Options{config: tt.config}
+			err := o.validateTLSOptions()
+			if tt.expectedErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tt.expectedErr)
+			}
+		})
+	}
+}

--- a/pkg/agent/apiserver/apiserver.go
+++ b/pkg/agent/apiserver/apiserver.go
@@ -99,9 +99,19 @@ func installAPIGroup(s *genericapiserver.GenericAPIServer, aq agentquerier.Agent
 }
 
 // New creates an APIServer for running in antrea agent.
-func New(aq agentquerier.AgentQuerier, npq querier.AgentNetworkPolicyInfoQuerier, mq querier.AgentMulticastInfoQuerier, seipq querier.ServiceExternalIPStatusQuerier,
-	bindAddress net.IP, bindPort int, enableMetrics bool, kubeconfig string, cipherSuites []uint16, tlsMinVersion uint16, v4Enabled, v6Enabled bool) (*agentAPIServer, error) {
-	cfg, err := newConfig(npq, bindAddress, bindPort, enableMetrics, kubeconfig)
+func New(aq agentquerier.AgentQuerier,
+	npq querier.AgentNetworkPolicyInfoQuerier,
+	mq querier.AgentMulticastInfoQuerier,
+	seipq querier.ServiceExternalIPStatusQuerier,
+	secureServing *genericoptions.SecureServingOptionsWithLoopback,
+	authentication *genericoptions.DelegatingAuthenticationOptions,
+	authorization *genericoptions.DelegatingAuthorizationOptions,
+	enableMetrics bool,
+	kubeconfig string,
+	v4Enabled,
+	v6Enabled bool,
+) (*agentAPIServer, error) {
+	cfg, err := newConfig(aq, npq, secureServing, authentication, authorization, enableMetrics, kubeconfig)
 	if err != nil {
 		return nil, err
 	}
@@ -109,8 +119,6 @@ func New(aq agentquerier.AgentQuerier, npq querier.AgentNetworkPolicyInfoQuerier
 	if err != nil {
 		return nil, err
 	}
-	s.SecureServingInfo.CipherSuites = cipherSuites
-	s.SecureServingInfo.MinTLSVersion = tlsMinVersion
 	if err := installAPIGroup(s, aq, npq, v4Enabled, v6Enabled); err != nil {
 		return nil, err
 	}
@@ -118,11 +126,14 @@ func New(aq agentquerier.AgentQuerier, npq querier.AgentNetworkPolicyInfoQuerier
 	return &agentAPIServer{GenericAPIServer: s}, nil
 }
 
-func newConfig(npq querier.AgentNetworkPolicyInfoQuerier, bindAddress net.IP, bindPort int, enableMetrics bool, kubeconfig string) (*genericapiserver.CompletedConfig, error) {
-	secureServing := genericoptions.NewSecureServingOptions().WithLoopback()
-	authentication := genericoptions.NewDelegatingAuthenticationOptions()
-	authorization := genericoptions.NewDelegatingAuthorizationOptions().WithAlwaysAllowPaths("/healthz", "/livez", "/readyz")
-
+func newConfig(aq agentquerier.AgentQuerier,
+	npq querier.AgentNetworkPolicyInfoQuerier,
+	secureServing *genericoptions.SecureServingOptionsWithLoopback,
+	authentication *genericoptions.DelegatingAuthenticationOptions,
+	authorization *genericoptions.DelegatingAuthorizationOptions,
+	enableMetrics bool,
+	kubeconfig string,
+) (*genericapiserver.CompletedConfig, error) {
 	// kubeconfig file is useful when antrea-agent isn't running as a Pod.
 	if len(kubeconfig) > 0 {
 		authentication.RemoteKubeConfigFile = kubeconfig
@@ -132,8 +143,6 @@ func newConfig(npq querier.AgentNetworkPolicyInfoQuerier, bindAddress net.IP, bi
 	// Set the PairName but leave certificate directory blank to generate in-memory by default.
 	secureServing.ServerCert.CertDirectory = ""
 	secureServing.ServerCert.PairName = Name
-	secureServing.BindAddress = bindAddress
-	secureServing.BindPort = bindPort
 
 	if err := secureServing.MaybeDefaultWithSelfSignedCerts("localhost", nil, []net.IP{net.ParseIP("127.0.0.1"), net.IPv6loopback}); err != nil {
 		return nil, fmt.Errorf("error creating self-signed certificates: %v", err)
@@ -164,13 +173,22 @@ func newConfig(npq querier.AgentNetworkPolicyInfoQuerier, bindAddress net.IP, bi
 	}
 	serverConfig.EnableMetrics = enableMetrics
 	// Add readiness probe to check the status of watchers.
-	check := healthz.NamedCheck("watcher", func(_ *http.Request) error {
+	watcherCheck := healthz.NamedCheck("watcher", func(_ *http.Request) error {
 		if npq.GetControllerConnectionStatus() {
 			return nil
 		}
 		return fmt.Errorf("some watchers may not be connected")
 	})
-	serverConfig.ReadyzChecks = append(serverConfig.ReadyzChecks, check)
+	serverConfig.ReadyzChecks = append(serverConfig.ReadyzChecks, watcherCheck)
+	// Add liveness probe to check the connection with OFSwitch.
+	// This helps automatic recovery if some issues cause OFSwitch reconnection to not work properly, e.g. issue #4092.
+	ovsConnCheck := healthz.NamedCheck("ovs", func(_ *http.Request) error {
+		if aq.GetOpenflowClient().IsConnected() {
+			return nil
+		}
+		return fmt.Errorf("disconnected from OFSwitch")
+	})
+	serverConfig.LivezChecks = append(serverConfig.LivezChecks, ovsConnCheck)
 
 	completedServerCfg := serverConfig.Complete(nil)
 	return &completedServerCfg, nil

--- a/pkg/agent/apiserver/apiserver_test.go
+++ b/pkg/agent/apiserver/apiserver_test.go
@@ -1,0 +1,161 @@
+// Copyright 2022 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiserver
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apiserver/pkg/server/options"
+
+	"antrea.io/antrea/pkg/agent/config"
+	oftest "antrea.io/antrea/pkg/agent/openflow/testing"
+	aqtest "antrea.io/antrea/pkg/agent/querier/testing"
+	queriertest "antrea.io/antrea/pkg/querier/testing"
+	"antrea.io/antrea/pkg/version"
+)
+
+type fakeAgentAPIServer struct {
+	*agentAPIServer
+	agentQuerier *aqtest.MockAgentQuerier
+	npQuerier    *queriertest.MockAgentNetworkPolicyInfoQuerier
+	ofClient     *oftest.MockClient
+}
+
+func newFakeAPIServer(t *testing.T) *fakeAgentAPIServer {
+	kubeConfigFile, err := os.CreateTemp("", "kubeconfig")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		kubeConfigFile.Close()
+		os.Remove(kubeConfigFile.Name())
+	}()
+	if _, err := kubeConfigFile.Write([]byte(`
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: http://localhost:56789
+  name: cluster
+contexts:
+- context:
+    cluster: cluster
+  name: cluster
+current-context: cluster
+`)); err != nil {
+		t.Fatal(err)
+	}
+	originalTokenPath := TokenPath
+	tokenFile, err := os.CreateTemp("", "token")
+	require.NoError(t, err)
+	TokenPath = tokenFile.Name()
+	defer func() {
+		TokenPath = originalTokenPath
+		tokenFile.Close()
+		os.Remove(tokenFile.Name())
+	}()
+	version.Version = "v1.2.3"
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	agentQuerier := aqtest.NewMockAgentQuerier(ctrl)
+	agentQuerier.EXPECT().GetNodeConfig().Return(&config.NodeConfig{OVSBridge: "br-int"})
+	npQuerier := queriertest.NewMockAgentNetworkPolicyInfoQuerier(ctrl)
+	ofClient := oftest.NewMockClient(ctrl)
+	agentQuerier.EXPECT().GetOpenflowClient().AnyTimes().Return(ofClient)
+
+	secureServing := options.NewSecureServingOptions().WithLoopback()
+	secureServing.BindAddress = net.ParseIP("127.0.0.1")
+	secureServing.BindPort = 10000
+	authentication := options.NewDelegatingAuthenticationOptions()
+	// InClusterLookup is skipped when testing, otherwise it would always fail as there is no real cluster.
+	authentication.SkipInClusterLookup = true
+	authorization := options.NewDelegatingAuthorizationOptions().WithAlwaysAllowPaths("/healthz", "/livez", "/readyz")
+	apiServer, err := New(agentQuerier, npQuerier, nil, nil, secureServing, authentication, authorization, true, kubeConfigFile.Name(), true, true)
+	require.NoError(t, err)
+	fakeAPIServer := &fakeAgentAPIServer{
+		agentAPIServer: apiServer,
+		agentQuerier:   agentQuerier,
+		npQuerier:      npQuerier,
+		ofClient:       ofClient,
+	}
+	return fakeAPIServer
+}
+
+func TestAPIServerLivezCheck(t *testing.T) {
+	tests := []struct {
+		name         string
+		setupFunc    func(*fakeAgentAPIServer)
+		expectedCode int
+		expectedBody string
+	}{
+		{
+			name: "ovs connected",
+			setupFunc: func(apiserver *fakeAgentAPIServer) {
+				apiserver.ofClient.EXPECT().IsConnected().Return(true)
+			},
+			expectedCode: 200,
+			expectedBody: "ok",
+		},
+		{
+			name: "ovs disconnected",
+			setupFunc: func(apiserver *fakeAgentAPIServer) {
+				apiserver.ofClient.EXPECT().IsConnected().Return(false)
+			},
+			expectedCode: 500,
+			expectedBody: `[+]ping ok
+[+]log ok
+[-]ovs failed: reason withheld
+[+]poststarthook/max-in-flight-filter ok
+livez check failed
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			apiserver := newFakeAPIServer(t)
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+			go func() {
+				apiserver.Run(stopCh)
+			}()
+			// Wait for APIServer to be healthy so checks installed by default are ensured ok.
+			assert.Eventuallyf(t, func() bool {
+				response := getResponse(apiserver, "/healthz")
+				return response.Body.String() == "ok"
+			}, time.Second*5, time.Millisecond*100, "APIServer didn't become health in 5 seconds")
+
+			tt.setupFunc(apiserver)
+			response := getResponse(apiserver, "/livez")
+			assert.Equal(t, tt.expectedBody, response.Body.String())
+			assert.Equal(t, tt.expectedCode, response.Code)
+		})
+	}
+}
+
+func getResponse(apiserver *fakeAgentAPIServer, query string) *httptest.ResponseRecorder {
+	req, _ := http.NewRequest(http.MethodGet, query, nil)
+	recorder := httptest.NewRecorder()
+	apiserver.GenericAPIServer.Handler.ServeHTTP(recorder, req)
+	return recorder
+}

--- a/pkg/ovs/openflow/ofctrl_bridge_test.go
+++ b/pkg/ovs/openflow/ofctrl_bridge_test.go
@@ -1,0 +1,87 @@
+// Copyright 2022 Antrea Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openflow
+
+import (
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"antrea.io/libOpenflow/util"
+	"antrea.io/ofnet/ofctrl"
+
+	"antrea.io/antrea/pkg/ovs/ovsconfig"
+)
+
+type fakeConn struct{}
+
+func (f *fakeConn) Close() error {
+	return nil
+}
+
+func (f *fakeConn) Read(b []byte) (int, error) {
+	return len(b), nil
+}
+
+func (f *fakeConn) Write(b []byte) (int, error) {
+	return len(b), nil
+}
+
+func (f *fakeConn) LocalAddr() net.Addr {
+	return nil
+}
+
+func (f *fakeConn) RemoteAddr() net.Addr {
+	return nil
+}
+
+func (f *fakeConn) SetDeadline(t time.Time) error {
+	return nil
+}
+
+func (f *fakeConn) SetReadDeadline(t time.Time) error {
+	return nil
+}
+
+func (f *fakeConn) SetWriteDeadline(t time.Time) error {
+	return nil
+}
+
+func newFakeOFSwitch(app ofctrl.AppInterface) *ofctrl.OFSwitch {
+	stream := util.NewMessageStream(&fakeConn{}, nil)
+	dpid, _ := net.ParseMAC("01:02:03:04:05:06:07:08")
+	connCh := make(chan int)
+	sw := ofctrl.NewSwitch(stream, dpid, app, connCh, 100)
+	return sw
+}
+
+// TestOFBridgeIsConnected verifies it's thread-safe to call OFBridge's IsConnected method.
+func TestOFBridgeIsConnected(t *testing.T) {
+	b := NewOFBridge("test-br", GetMgmtAddress(ovsconfig.DefaultOVSRunDir, "test-br"))
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		sw := newFakeOFSwitch(b)
+		b.SwitchConnected(sw)
+	}()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		b.IsConnected()
+	}()
+	wg.Wait()
+}

--- a/pkg/ovs/openflow/ofctrl_packetout_test.go
+++ b/pkg/ovs/openflow/ofctrl_packetout_test.go
@@ -15,6 +15,7 @@
 package openflow
 
 import (
+	"math/rand"
 	"net"
 	"reflect"
 	"testing"
@@ -602,6 +603,9 @@ func Test_ofPacketOutBuilder_SetIPFlags(t *testing.T) {
 }
 
 func Test_ofPacketOutBuilder_Done(t *testing.T) {
+	// reset the rand seed in case there are any other test cases use math/rand to generate
+	// random numbers before running this test case.
+	rand.Seed(1)
 	type fields struct {
 		pktOut  *ofctrl.PacketOut
 		icmpID  *uint16


### PR DESCRIPTION
Cherry pick of #4126 on release-1.8.

#4126: Add OFSwitch connection check to Agent's liveness probes

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.