### PR TITLE
Upgrade Antrea base image to ubuntu:22.04

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,14 +12,16 @@ OVS_VERSION        := $(shell head -n 1 build/images/deps/ovs-version)
 GO_VERSION         := $(shell head -n 1 build/images/deps/go-version)
 CNI_BINARIES_VERSION := $(shell head -n 1 build/images/deps/cni-binaries-version)
 NANOSERVER_VERSION := $(shell head -n 1 build/images/deps/nanoserver-version)
+BUILD_TAG          := $(shell build/images/build-tag.sh)
 WIN_BUILD_TAG      := $(shell echo $(GO_VERSION) $(CNI_BINARIES_VERSION) $(NANOSERVER_VERSION)|md5sum|head -c 10)
 GIT_HOOKS := $(shell find hack/git_client_side_hooks -type f -print)
 DOCKER_NETWORK     ?= default
 TRIVY_TARGET_IMAGE ?=
 
-DOCKER_BUILD_ARGS = --build-arg OVS_VERSION=$(OVS_VERSION)
+DOCKER_BUILD_ARGS := --build-arg OVS_VERSION=$(OVS_VERSION)
 DOCKER_BUILD_ARGS += --build-arg GO_VERSION=$(GO_VERSION)
-WIN_BUILD_ARGS = --build-arg GO_VERSION=$(GO_VERSION)
+DOCKER_BUILD_ARGS += --build-arg BUILD_TAG=$(BUILD_TAG)
+WIN_BUILD_ARGS := --build-arg GO_VERSION=$(GO_VERSION)
 WIN_BUILD_ARGS += --build-arg CNI_BINARIES_VERSION=$(CNI_BINARIES_VERSION)
 WIN_BUILD_ARGS += --build-arg NANOSERVER_VERSION=$(NANOSERVER_VERSION)
 WIN_BUILD_ARGS += --build-arg WIN_BUILD_TAG=$(WIN_BUILD_TAG)

--- a/build/images/Dockerfile.build.coverage
+++ b/build/images/Dockerfile.build.coverage
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG GO_VERSION
-ARG OVS_VERSION
+ARG BUILD_TAG
 FROM golang:${GO_VERSION} as antrea-build
 
 WORKDIR /antrea
@@ -27,7 +27,7 @@ COPY . /antrea
 RUN make antrea-agent antrea-controller antrea-cni antctl-linux antrea-controller-instr-binary antrea-agent-instr-binary antctl-instr-binary
 RUN mv bin/antctl-linux bin/antctl
 
-FROM antrea/base-ubuntu:${OVS_VERSION}
+FROM antrea/base-ubuntu:${BUILD_TAG}
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="The Docker image to deploy the Antrea CNI with code coverage measurement enabled (used for testing)."

--- a/build/images/Dockerfile.build.ubi
+++ b/build/images/Dockerfile.build.ubi
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG GO_VERSION
-ARG OVS_VERSION
+ARG BUILD_TAG
 FROM golang:${GO_VERSION} as antrea-build
 
 WORKDIR /antrea
@@ -27,7 +27,7 @@ COPY . /antrea
 RUN make antrea-agent antrea-controller antrea-cni antctl-linux
 RUN mv bin/antctl-linux bin/antctl
 
-FROM antrea/base-ubi:${OVS_VERSION}
+FROM antrea/base-ubi:${BUILD_TAG}
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="The Docker image to deploy the Antrea CNI. "

--- a/build/images/Dockerfile.build.ubuntu
+++ b/build/images/Dockerfile.build.ubuntu
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG GO_VERSION
-ARG OVS_VERSION
+ARG BUILD_TAG
 FROM golang:${GO_VERSION} as antrea-build
 
 WORKDIR /antrea
@@ -27,7 +27,7 @@ COPY . /antrea
 RUN make antrea-agent antrea-controller antrea-cni antctl-linux
 RUN mv bin/antctl-linux bin/antctl
 
-FROM antrea/base-ubuntu:${OVS_VERSION}
+FROM antrea/base-ubuntu:${BUILD_TAG}
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="The Docker image to deploy the Antrea CNI."

--- a/build/images/base/Dockerfile
+++ b/build/images/base/Dockerfile
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG OVS_VERSION
-FROM ubuntu:20.04 as cni-binaries
+ARG BUILD_TAG
+FROM ubuntu:22.04 as cni-binaries
 
 ARG CNI_BINARIES_VERSION
 ARG WHEREABOUTS_VERSION=v0.5.4
@@ -37,7 +37,7 @@ RUN set -eux; \
     wget -q -O - https://github.com/containernetworking/plugins/releases/download/$CNI_BINARIES_VERSION/cni-plugins-linux-${pluginsArch}-$CNI_BINARIES_VERSION.tgz | tar xz -C /opt/cni/bin $CNI_PLUGINS; \
     wget -q -O /opt/cni/bin/whereabouts https://github.com/k8snetworkplumbingwg/whereabouts/releases/download/$WHEREABOUTS_VERSION/whereabouts-${pluginsArch} && chmod +x /opt/cni/bin/whereabouts
 
-FROM antrea/openvswitch:${OVS_VERSION}
+FROM antrea/openvswitch:${BUILD_TAG}
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="An Ubuntu based Docker base image for Antrea."

--- a/build/images/base/Dockerfile.ubi
+++ b/build/images/base/Dockerfile.ubi
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG OVS_VERSION
-FROM ubuntu:20.04 as cni-binaries
+ARG BUILD_TAG
+FROM ubuntu:22.04 as cni-binaries
 
 ARG CNI_BINARIES_VERSION
 ARG WHEREABOUTS_VERSION=v0.5.1
@@ -37,7 +37,7 @@ RUN set -eux; \
     wget -q -O - https://github.com/containernetworking/plugins/releases/download/$CNI_BINARIES_VERSION/cni-plugins-linux-${pluginsArch}-$CNI_BINARIES_VERSION.tgz | tar xz -C /opt/cni/bin $CNI_PLUGINS; \
     wget -q -O /opt/cni/bin/whereabouts https://github.com/k8snetworkplumbingwg/whereabouts/releases/download/$WHEREABOUTS_VERSION/whereabouts-${pluginsArch} && chmod +x /opt/cni/bin/whereabouts
 
-FROM antrea/openvswitch-ubi:${OVS_VERSION}
+FROM antrea/openvswitch-ubi:${BUILD_TAG}
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="An UBI8 based Docker base image for Antrea."

--- a/build/images/base/build.sh
+++ b/build/images/base/build.sh
@@ -24,7 +24,7 @@ function echoerr {
 }
 
 _usage="Usage: $0 [--pull] [--push] [--platform <PLATFORM>] [--distro [ubuntu|ubi]]
-Build the antrea/base-ubuntu:<OVS_VERSION> image.
+Build the antrea base image.
         --pull                  Always attempt to pull a newer version of the base images
         --push                  Push the built image to the registry
         --platform <PLATFORM>   Target platform for the image if server is multi-platform capable
@@ -90,28 +90,29 @@ THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 pushd $THIS_DIR > /dev/null
 
-OVS_VERSION=$(head -n 1 ../deps/ovs-version)
 CNI_BINARIES_VERSION=$(head -n 1 ../deps/cni-binaries-version)
+
+BUILD_TAG=$(../build-tag.sh)
 
 if $PULL; then
     if [[ ${DOCKER_REGISTRY} == "" ]]; then
-        docker pull $PLATFORM_ARG ubuntu:20.04
+        docker pull $PLATFORM_ARG ubuntu:22.04
     else
-        docker pull ${DOCKER_REGISTRY}/antrea/ubuntu:20.04
-        docker tag ${DOCKER_REGISTRY}/antrea/ubuntu:20.04 ubuntu:20.04
+        docker pull ${DOCKER_REGISTRY}/antrea/ubuntu:22.04
+        docker tag ${DOCKER_REGISTRY}/antrea/ubuntu:22.04 ubuntu:22.04
     fi
 
     if [ "$DISTRO" == "ubuntu" ]; then
         IMAGES_LIST=(
-            "antrea/openvswitch:$OVS_VERSION"
+            "antrea/openvswitch:$BUILD_TAG"
             "antrea/cni-binaries:$CNI_BINARIES_VERSION"
-            "antrea/base-ubuntu:$OVS_VERSION"
+            "antrea/base-ubuntu:$BUILD_TAG"
         )
     elif [ "$DISTRO" == "ubi" ]; then
         IMAGES_LIST=(
-            "antrea/openvswitch-ubi:$OVS_VERSION"
+            "antrea/openvswitch-ubi:$BUILD_TAG"
             "antrea/cni-binaries:$CNI_BINARIES_VERSION"
-            "antrea/base-ubi:$OVS_VERSION"
+            "antrea/base-ubi:$BUILD_TAG"
         )
     fi
     for image in "${IMAGES_LIST[@]}"; do
@@ -131,28 +132,28 @@ docker build $PLATFORM_ARG --target cni-binaries \
        --cache-from antrea/cni-binaries:$CNI_BINARIES_VERSION \
        -t antrea/cni-binaries:$CNI_BINARIES_VERSION \
        --build-arg CNI_BINARIES_VERSION=$CNI_BINARIES_VERSION \
-       --build-arg OVS_VERSION=$OVS_VERSION .
+       --build-arg BUILD_TAG=$BUILD_TAG .
 
 if [ "$DISTRO" == "ubuntu" ]; then
     docker build $PLATFORM_ARG \
            --cache-from antrea/cni-binaries:$CNI_BINARIES_VERSION \
-           --cache-from antrea/base-ubuntu:$OVS_VERSION \
-           -t antrea/base-ubuntu:$OVS_VERSION \
+           --cache-from antrea/base-ubuntu:$BUILD_TAG \
+           -t antrea/base-ubuntu:$BUILD_TAG \
            --build-arg CNI_BINARIES_VERSION=$CNI_BINARIES_VERSION \
-           --build-arg OVS_VERSION=$OVS_VERSION .
+           --build-arg BUILD_TAG=$BUILD_TAG .
 elif [ "$DISTRO" == "ubi" ]; then
     docker build $PLATFORM_ARG \
            --cache-from antrea/cni-binaries:$CNI_BINARIES_VERSION \
-           --cache-from antrea/base-ubuntu:$OVS_VERSION \
-           -t antrea/base-ubi:$OVS_VERSION \
+           --cache-from antrea/base-ubi:$BUILD_TAG \
+           -t antrea/base-ubi:$BUILD_TAG \
            -f Dockerfile.ubi \
            --build-arg CNI_BINARIES_VERSION=$CNI_BINARIES_VERSION \
-           --build-arg OVS_VERSION=$OVS_VERSION .
+           --build-arg BUILD_TAG=$BUILD_TAG .
 fi
 
 if $PUSH; then
     docker push antrea/cni-binaries:$CNI_BINARIES_VERSION
-    docker push antrea/base-$DISTRO:$OVS_VERSION
+    docker push antrea/base-$DISTRO:$BUILD_TAG
 fi
 
 popd > /dev/null

--- a/build/images/build-tag.sh
+++ b/build/images/build-tag.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Copyright 2022 Antrea Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,13 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG BUILD_TAG
-FROM antrea/base-ubuntu:${BUILD_TAG}
+# build_tag is used to generate the tag for all the base images
+# (e.g. antrea/openvswitch) used as part of the build chain to produce the
+# Antrea (Linux) images.
+function build_tag() {
+    local this_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+    local antrea_version=$(head -n 1 $this_dir/../../VERSION | cut -f1,2 -d'.')
+    local tag="antrea-${antrea_version}"
+    echo "$tag"
+}
 
-LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
-LABEL description="The Docker image to deploy the Antrea CNI."
-
-USER root
-
-COPY build/images/scripts/* /usr/local/bin/
-COPY bin/* /usr/local/bin/
+echo "$(build_tag "$@")"

--- a/build/images/ovs/Dockerfile
+++ b/build/images/ovs/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:20.04 as ovs-debs
+FROM ubuntu:22.04 as ovs-debs
 
 # Some patches may not apply cleanly if a non-default version is provided.
 # See build/images/deps/ovs-version for the default version.
@@ -39,10 +39,10 @@ RUN wget -q -O - https://www.openvswitch.org/releases/openvswitch-$OVS_VERSION.t
     cd / && rm -rf /tmp/openvswitch*
 
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
-LABEL description="A Docker image based on Ubuntu 20.04 which includes Open vSwitch built from source."
+LABEL description="A Docker image based on Ubuntu 22.04 which includes Open vSwitch built from source."
 
 COPY --from=ovs-debs /tmp/ovs-debs/* /tmp/ovs-debs/
 COPY charon-logging.conf /tmp

--- a/build/images/ovs/README.md
+++ b/build/images/ovs/README.md
@@ -2,14 +2,13 @@
 
 This directory contains utilities to build a Docker image which includes Open
 vSwitch (OVS) built from source. We build OVS from source because some features
-of Antrea (such as IPsec) require a recent version of OVS, more recent than the
-version included in Ubuntu 20.04. The built image is then used as the base image
-for the Antrea main Docker image.
+of Antrea (such as IPsec) may require a recent version of OVS, more recent than
+the version included in the base distribution. The built image is then used as
+the base image for the Antrea main Docker image.
 
-The image is re-built and pushed to Dockerhub periodically (every 12 hours) by a
-[Github workflow](/.github/workflows/update_ovs_image.yml). Therefore, there
-should be no need to update the registry image manually. If it's needed for any
-reason, you can follow the instructions below.
+The image is re-built and pushed to Dockerhub every time the main branch is
+updated. Therefore, there should be no need to update the registry image
+manually. If it's needed for any reason, you can follow the instructions below.
 
 ## Manually building the image and pushing it to Dockerhub
 
@@ -17,10 +16,6 @@ reason, you can follow the instructions below.
 cd build/images/ovs
 ./build.sh --pull --push
 ```
-
-The image will be pushed to Dockerhub as `antrea/openvswitch:<OVS_VERSION>`. The
-OVS version used is determined by the contents of the
-`build/images/deps/ovs-version` file.
 
 The script will fail if you do not have permission to push to the `antrea`
 Dockerhub repository.

--- a/build/images/ovs/apply-patches.sh
+++ b/build/images/ovs/apply-patches.sh
@@ -100,7 +100,7 @@ if version_lt "$OVS_VERSION" "2.18.0" ; then
 fi
 
 # OVS hardcodes the installation path to /usr/lib/python3.7/dist-packages/ but this location
-# does not seem to be in the Python path in Ubuntu 20.04. There may be a better way to do this,
+# does not seem to be in the Python path in Ubuntu 22.04. There may be a better way to do this,
 # but this seems like an acceptable workaround.
-sed -i 's/python3\.7/python3\.8/' debian/openvswitch-test.install
-sed -i 's/python3\.7/python3\.8/' debian/python3-openvswitch.install
+sed -i 's/python3\.7/python3\.10/' debian/openvswitch-test.install
+sed -i 's/python3\.7/python3\.10/' debian/python3-openvswitch.install

--- a/build/images/test/Dockerfile
+++ b/build/images/test/Dockerfile
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG OVS_VERSION
-FROM antrea/openvswitch:${OVS_VERSION}
+ARG BUILD_TAG
+FROM antrea/openvswitch:${BUILD_TAG}
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="A Docker image for Antrea integration tests."


### PR DESCRIPTION
Ubuntu 20.04 comes with iptables 1.8.4, which seems to have several bugs
when used with nft. In particular, we observe that iptables-restore
sometimes segfaults when restoring the ANTREA-NODE-PORT-LOCAL chain in
the nat table. Ubuntu 22.04 comes with a more recent iptables version, 1.8.7.

As part of this change, we change the tag format for base images
(antrea/openvswitch and antrea/base-ubuntu). We no longer use the OVS
version as the tag, instead we use the Antrea minor version number.

Fixes #4435

Signed-off-by: Antonin Bas <abas@vmware.com>