### PR TITLE
Run Conformance and NetworkPolicy Tests in Kind

### DIFF
--- a/ci/jenkins/README.md
+++ b/ci/jenkins/README.md
@@ -139,6 +139,24 @@ DOCKER_REGISTRY="$(head -n1 ci/docker-registry)"
 ./ci/jenkins/test.sh --testcase e2e --registry ${DOCKER_REGISTRY} --testbed-type "flexible-ipam"
 ```
 
+* Kind conformance: conformance tests in a kind cluster
+
+```shell
+#!/bin/bash
+set -e
+DOCKER_REGISTRY="$(head -n1 ci/docker-registry)"
+./ci/jenkins/test.sh --testcase conformance --registry ${DOCKER_REGISTRY} --testbed-type "kind" --kind-cluster-name "${{JOB_NAME}}-${{BUILD_NUMBER}}"
+```
+
+* Kind NetworkPolicy: NetworkPolicy tests in a kind cluster
+
+```shell
+#!/bin/bash
+set -e
+DOCKER_REGISTRY="$(head -n1 ci/docker-registry)"
+./ci/jenkins/test.sh --testcase networkpolicy --registry ${DOCKER_REGISTRY} --testbed-type "kind" --kind-cluster-name "${{JOB_NAME}}-${{BUILD_NUMBER}}"
+```
+
 * [whole-conformance [daily]](https://jenkins.antrea-ci.rocks/job/antrea-whole-conformance-for-pull-request/):
   community tests using sonobuoy, with certified-conformance mode.
 

--- a/ci/jenkins/jobs/macros.yaml
+++ b/ci/jenkins/jobs/macros.yaml
@@ -223,3 +223,20 @@
           set -e
           DOCKER_REGISTRY="$(head -n1 ci/docker-registry)"
           ./ci/jenkins/test-vm.sh  --registry ${DOCKER_REGISTRY} --kubeconfig /var/lib/jenkins/.kube/config
+          
+- builder:
+    name: builder-conformance-kind
+    builders:
+      - shell: |-
+          #!/bin/bash
+          set -ex
+          DOCKER_REGISTRY="$(head -n1 ci/docker-registry)"
+          ./ci/kind/kind-setup.sh --antrea-cni create "${{JOB_NAME}}-${{BUILD_NUMBER}}"
+          kind export kubeconfig -n "${{JOB_NAME}}-${{BUILD_NUMBER}}" --kubeconfig ${{PWD}}/.kube/config
+          set +ex
+          ./ci/jenkins/test.sh --testcase '{conformance_type}' --registry ${{DOCKER_REGISTRY}} --kubeconfig ${{PWD}}/.kube/config --testbed-type "kind" --kind-cluster-name "${{JOB_NAME}}-${{BUILD_NUMBER}}"
+          return_code=$?
+          set -ex
+          kind delete cluster --name "${{JOB_NAME}}-${{BUILD_NUMBER}}"
+          exit $return_code
+

--- a/ci/jenkins/jobs/projects-lab.yaml
+++ b/ci/jenkins/jobs/projects-lab.yaml
@@ -820,3 +820,55 @@
               default-excludes: true
               fingerprint: false
               only-if-success: false
+      - '{name}-{test_name}-for-pull-request':
+          test_name: kind-conformance
+          node: 'antrea-kind-testbed'
+          description: 'This is for running conformance tests on kind.'
+          branches:
+          - ${{sha1}}
+          builders:
+            - builder-conformance-kind:
+               conformance_type: 'conformance'
+          trigger_phrase: ^(?!Thanks for your PR).*/test-kind-conformance.*
+          white_list_target_branches: []
+          allow_whitelist_orgs_as_admins: true
+          admin_list: '{antrea_admin_list}'
+          org_list: '{antrea_org_list}'
+          white_list: '{antrea_white_list}'
+          only_trigger_phrase: true
+          trigger_permit_all: true
+          status_context: jenkins-kind-conformance
+          status_url: --none--
+          success_status: Build finished.
+          failure_status: Failed. Add comment /test-kind-conformance to re-trigger.
+          error_status: Failed. Add comment /test-kind-conformance to re-trigger.
+          triggered_status: null
+          started_status: null
+          publishers: []
+          wrappers: []
+      - '{name}-{test_name}-for-pull-request':
+          test_name: kind-networkpolicy
+          node: 'antrea-kind-testbed'
+          description: 'This is for running networkpolicy tests on kind.'
+          branches:
+          - ${{sha1}}
+          builders:
+            - builder-conformance-kind:
+               conformance_type: 'networkpolicy'
+          trigger_phrase: ^(?!Thanks for your PR).*/test-kind-networkpolicy.*
+          white_list_target_branches: []
+          allow_whitelist_orgs_as_admins: true
+          admin_list: '{antrea_admin_list}'
+          org_list: '{antrea_org_list}'
+          white_list: '{antrea_white_list}'
+          only_trigger_phrase: true
+          trigger_permit_all: true
+          status_context: jenkins-kind-networkpolicy
+          status_url: --none--
+          success_status: Build finished.
+          failure_status: Failed. Add comment /test-kind-networkpolicy to re-trigger.
+          error_status: Failed. Add comment /test-kind-networkpolicy to re-trigger.
+          triggered_status: null
+          started_status: null
+          publishers: []
+          wrappers: []    


### PR DESCRIPTION
Signed-off-by: KMAnju-2021 <km074btcse18@igdtuw.ac.in>

 Task: build a CI script for Antrea upstream to create a kind cluster and run CI tests (conformance and NetworkPolicy ) on it.
We don't need to run Antrea E2E tests in kind via this test.sh.  because the github workflow ".github/workflows/kind.yml" also runs E2E test in kind via "./ci/kind/test-e2e-kind.sh".