### PR TITLE
[flexible-ipam] Fix issues and add ClusterNetworkPolicy e2e cases

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -433,6 +433,7 @@ func run(o *Options) error {
 		v6Enabled,
 		gwPort,
 		tunPort,
+		nodeConfig,
 	)
 	if err != nil {
 		return fmt.Errorf("error creating new NetworkPolicy controller: %v", err)

--- a/docs/antrea-ipam.md
+++ b/docs/antrea-ipam.md
@@ -235,7 +235,8 @@ where the underlay router will route the traffic to the destination VLAN.
 ### Requirements for this Feature
 
 As of now, this feature is supported on Linux Nodes, with IPv4, `system` OVS datapath
-type, and `noEncap`, `noSNAT` traffic mode.
+type, `noEncap`, `noSNAT` traffic mode, and `AntreaProxy` feature enabled. Configuration
+with `ProxyAll` feature enabled is not verified.
 
 The IPs in the `IPPools` without VLAN must be in the same underlay subnet as the Node
 IP, because inter-Node traffic of AntreaIPAM Pods is forwarded by the Node network.

--- a/multicluster/test/e2e/antreapolicy_test.go
+++ b/multicluster/test/e2e/antreapolicy_test.go
@@ -70,7 +70,7 @@ func initializeForPolicyTest(t *testing.T, data *MCTestData) {
 		d := data.clusterTestDataMap[clusterName]
 		k8sUtils, err := antreae2e.NewKubernetesUtils(&d)
 		failOnError(err, t)
-		_, err = k8sUtils.Bootstrap(perClusterNamespaces, perNamespacePods)
+		_, err = k8sUtils.Bootstrap(perClusterNamespaces, perNamespacePods, true)
 		failOnError(err, t)
 		clusterK8sUtilsMap[clusterName] = k8sUtils
 	}

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
@@ -125,6 +125,7 @@ type Controller struct {
 	denyConnStore *connections.DenyConnectionStore
 	gwPort        uint32
 	tunPort       uint32
+	nodeConfig    *config.NodeConfig
 }
 
 // NewNetworkPolicyController returns a new *Controller.
@@ -147,7 +148,8 @@ func NewNetworkPolicyController(antreaClientGetter agent.AntreaClientProvider,
 	nodeType config.NodeType,
 	v4Enabled bool,
 	v6Enabled bool,
-	gwPort, tunPort uint32) (*Controller, error) {
+	gwPort, tunPort uint32,
+	nodeConfig *config.NodeConfig) (*Controller, error) {
 	idAllocator := newIDAllocator(asyncRuleDeleteInterval, dnsInterceptRuleID)
 	c := &Controller{
 		antreaClientProvider:   antreaClientGetter,
@@ -162,6 +164,7 @@ func NewNetworkPolicyController(antreaClientGetter agent.AntreaClientProvider,
 		loggingEnabled:         loggingEnabled,
 		gwPort:                 gwPort,
 		tunPort:                tunPort,
+		nodeConfig:             nodeConfig,
 	}
 
 	if l7NetworkPolicyEnabled {

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
@@ -61,7 +61,7 @@ func newTestController() (*Controller, *fake.Clientset, *mockReconciler) {
 	ch2 := make(chan string, 100)
 	groupIDAllocator := openflow.NewGroupAllocator(false)
 	groupCounters := []proxytypes.GroupCounter{proxytypes.NewGroupCounter(groupIDAllocator, ch2)}
-	controller, _ := NewNetworkPolicyController(&antreaClientGetter{clientset}, nil, nil, "node1", podUpdateChannel, nil, groupCounters, ch2, true, true, true, true, false, true, testAsyncDeleteInterval, "8.8.8.8:53", config.K8sNode, true, false, config.HostGatewayOFPort, config.DefaultTunOFPort)
+	controller, _ := NewNetworkPolicyController(&antreaClientGetter{clientset}, nil, nil, "node1", podUpdateChannel, nil, groupCounters, ch2, true, true, true, true, false, true, testAsyncDeleteInterval, "8.8.8.8:53", config.K8sNode, true, false, config.HostGatewayOFPort, config.DefaultTunOFPort, &config.NodeConfig{})
 	reconciler := newMockReconciler()
 	controller.reconciler = reconciler
 	controller.antreaPolicyLogger = nil

--- a/pkg/agent/controller/networkpolicy/reject_test.go
+++ b/pkg/agent/controller/networkpolicy/reject_test.go
@@ -15,11 +15,20 @@
 package networkpolicy
 
 import (
+	"encoding/binary"
+	"net"
 	"testing"
 
+	"antrea.io/libOpenflow/openflow15"
+	"antrea.io/ofnet/ofctrl"
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
+	"antrea.io/antrea/pkg/agent/config"
 	"antrea.io/antrea/pkg/agent/interfacestore"
+	"antrea.io/antrea/pkg/agent/openflow"
+	binding "antrea.io/antrea/pkg/ovs/openflow"
+	mocks "antrea.io/antrea/pkg/ovs/openflow/testing"
 )
 
 func TestGetRejectType(t *testing.T) {
@@ -124,6 +133,102 @@ func TestGetRejectType(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			rejectType := getRejectType(tt.isServiceTraffic, tt.antreaProxyEnabled, tt.srcIsLocal, tt.dstIsLocal)
 			assert.Equal(t, tt.expectRejectType, rejectType)
+		})
+	}
+}
+
+func Test_parseFlexibleIPAMStatus(t *testing.T) {
+	ctZone := uint16(1)
+	ctZoneBytes := make([]byte, 8)
+	binary.BigEndian.PutUint16(ctZoneBytes, ctZone)
+	type args struct {
+		pktIn      *ofctrl.PacketIn
+		nodeConfig *config.NodeConfig
+		srcIP      string
+		srcIsLocal bool
+		dstIP      string
+		dstIsLocal bool
+	}
+	tests := []struct {
+		name                  string
+		args                  args
+		wantIsFlexibleIPAMSrc bool
+		wantIsFlexibleIPAMDst bool
+		wantCtZone            uint32
+		wantErr               bool
+	}{
+		{
+			name: "NoFlexibleIPAM",
+			args: args{
+				pktIn:      &ofctrl.PacketIn{},
+				nodeConfig: nil,
+				srcIP:      "",
+				srcIsLocal: false,
+				dstIP:      "",
+				dstIsLocal: false,
+			},
+			wantIsFlexibleIPAMSrc: false,
+			wantIsFlexibleIPAMDst: false,
+			wantCtZone:            0,
+			wantErr:               false,
+		},
+		{
+			name: "FlexibleIPAM",
+			args: args{
+				pktIn: &ofctrl.PacketIn{
+					Match: openflow15.Match{
+						Type:   0,
+						Length: 0,
+						Fields: []openflow15.MatchField{{
+							Class:          openflow15.OXM_CLASS_PACKET_REGS,
+							Field:          4,
+							HasMask:        false,
+							Length:         0,
+							ExperimenterID: 0,
+							Value: &openflow15.ByteArrayField{
+								Data:   []byte{0, 0, 0, 1, 0, 0, 0, 0},
+								Length: 64,
+							},
+							Mask: nil,
+						}},
+					},
+				},
+				nodeConfig: &config.NodeConfig{
+					PodIPv4CIDR: &net.IPNet{
+						IP:   net.IPv4(1, 2, 2, 0),
+						Mask: net.IPv4Mask(255, 255, 255, 0),
+					},
+				},
+				srcIP:      "1.2.3.4",
+				srcIsLocal: true,
+				dstIP:      "1.2.3.5",
+				dstIsLocal: true,
+			},
+			wantIsFlexibleIPAMSrc: true,
+			wantIsFlexibleIPAMDst: true,
+			wantCtZone:            1,
+			wantErr:               false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotIsFlexibleIPAMSrc, gotIsFlexibleIPAMDst, gotCtZone, err := parseFlexibleIPAMStatus(tt.args.pktIn, tt.args.nodeConfig, tt.args.srcIP, tt.args.srcIsLocal, tt.args.dstIP, tt.args.dstIsLocal)
+			matches := tt.args.pktIn.GetMatches()
+			match := getMatchRegField(matches, openflow.CtZoneField)
+			t.Logf("match: %+v", match)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseFlexibleIPAMStatus() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotIsFlexibleIPAMSrc != tt.wantIsFlexibleIPAMSrc {
+				t.Errorf("parseFlexibleIPAMStatus() gotIsFlexibleIPAMSrc = %v, want %v", gotIsFlexibleIPAMSrc, tt.wantIsFlexibleIPAMSrc)
+			}
+			if gotIsFlexibleIPAMDst != tt.wantIsFlexibleIPAMDst {
+				t.Errorf("parseFlexibleIPAMStatus() gotIsFlexibleIPAMDst = %v, want %v", gotIsFlexibleIPAMDst, tt.wantIsFlexibleIPAMDst)
+			}
+			if gotCtZone != tt.wantCtZone {
+				t.Errorf("parseFlexibleIPAMStatus() gotCtZone = %v, want %v", gotCtZone, tt.wantCtZone)
+			}
 		})
 	}
 }
@@ -270,6 +375,129 @@ func TestGetRejectOFPorts(t *testing.T) {
 			inPort, outPort := getRejectOFPorts(tt.rejectType, tt.srcInterface, tt.dstInterface, gwPort, tt.tunPort)
 			assert.Equal(t, tt.expectInPort, inPort)
 			assert.Equal(t, tt.expectOutPort, outPort)
+		})
+	}
+}
+
+func Test_getRejectPacketOutMutateFunc(t *testing.T) {
+	openflow.InitMockTables(
+		map[*openflow.Table]uint8{
+			openflow.ConntrackTable:        uint8(5),
+			openflow.L3ForwardingTable:     uint8(6),
+			openflow.L2ForwardingCalcTable: uint8(7),
+		})
+	conntrackTableID := openflow.ConntrackTable.GetID()
+	l3ForwardingTableID := openflow.L3ForwardingTable.GetID()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	type args struct {
+		rejectType        RejectType
+		nodeType          config.NodeType
+		isFlexibleIPAMSrc bool
+		isFlexibleIPAMDst bool
+		ctZone            uint32
+	}
+	tests := []struct {
+		name        string
+		args        args
+		prepareFunc func(builder *mocks.MockPacketOutBuilder)
+	}{
+		{
+			name: "RejectServiceLocalFlexibleIPAMSrc",
+			args: args{
+				rejectType:        RejectServiceLocal,
+				nodeType:          config.K8sNode,
+				isFlexibleIPAMSrc: true,
+				isFlexibleIPAMDst: false,
+				ctZone:            1,
+			},
+			prepareFunc: func(builder *mocks.MockPacketOutBuilder) {
+				builder.EXPECT().AddLoadRegMark(openflow.CustomReasonRejectRegMark).Return(builder)
+				builder.EXPECT().AddLoadRegMark(openflow.AntreaFlexibleIPAMRegMark).Return(builder)
+				builder.EXPECT().AddLoadRegMark(binding.NewRegMark(openflow.CtZoneField, 1)).Return(builder)
+				builder.EXPECT().AddResubmitAction(nil, &conntrackTableID).Return(builder)
+			},
+		},
+		{
+			name: "RejectServiceOtherSrc",
+			args: args{
+				rejectType:        RejectServiceLocal,
+				nodeType:          config.K8sNode,
+				isFlexibleIPAMSrc: false,
+				isFlexibleIPAMDst: false,
+				ctZone:            1,
+			},
+			prepareFunc: func(builder *mocks.MockPacketOutBuilder) {
+				builder.EXPECT().AddLoadRegMark(openflow.CustomReasonRejectRegMark).Return(builder)
+				builder.EXPECT().AddLoadRegMark(binding.NewRegMark(openflow.CtZoneField, 1)).Return(builder)
+				builder.EXPECT().AddResubmitAction(nil, &conntrackTableID).Return(builder)
+			},
+		},
+		{
+			name: "RejectLocalToRemoteFlexibleIPAMSrc",
+			args: args{
+				rejectType:        RejectPodLocalToRemote,
+				nodeType:          config.K8sNode,
+				isFlexibleIPAMSrc: true,
+				isFlexibleIPAMDst: false,
+				ctZone:            1,
+			},
+			prepareFunc: func(builder *mocks.MockPacketOutBuilder) {
+				builder.EXPECT().AddLoadRegMark(openflow.CustomReasonRejectRegMark).Return(builder)
+				builder.EXPECT().AddLoadRegMark(openflow.AntreaFlexibleIPAMRegMark).Return(builder)
+				builder.EXPECT().AddLoadRegMark(binding.NewRegMark(openflow.CtZoneField, 1)).Return(builder)
+				builder.EXPECT().AddResubmitAction(nil, &l3ForwardingTableID).Return(builder)
+			},
+		},
+		{
+			name: "RejectLocalToRemoteFlexibleIPAMSrc",
+			args: args{
+				rejectType:        RejectPodLocalToRemote,
+				nodeType:          config.K8sNode,
+				isFlexibleIPAMSrc: false,
+				isFlexibleIPAMDst: false,
+				ctZone:            1,
+			},
+			prepareFunc: func(builder *mocks.MockPacketOutBuilder) {
+				builder.EXPECT().AddLoadRegMark(openflow.CustomReasonRejectRegMark).Return(builder)
+				builder.EXPECT().AddLoadRegMark(binding.NewRegMark(openflow.CtZoneField, 1)).Return(builder)
+				builder.EXPECT().AddResubmitAction(nil, &l3ForwardingTableID).Return(builder)
+			},
+		},
+		{
+			name: "RejectServiceRemoteToLocalFlexibleIPAMDst",
+			args: args{
+				rejectType:        RejectServiceRemoteToLocal,
+				nodeType:          config.K8sNode,
+				isFlexibleIPAMSrc: false,
+				isFlexibleIPAMDst: true,
+				ctZone:            1,
+			},
+			prepareFunc: func(builder *mocks.MockPacketOutBuilder) {
+				builder.EXPECT().AddLoadRegMark(openflow.CustomReasonRejectRegMark).Return(builder)
+				builder.EXPECT().AddLoadRegMark(binding.NewRegMark(openflow.CtZoneField, 1)).Return(builder)
+				builder.EXPECT().AddResubmitAction(nil, &conntrackTableID).Return(builder)
+			},
+		},
+		{
+			name: "Default",
+			args: args{
+				rejectType:        RejectServiceRemoteToLocal,
+				nodeType:          config.K8sNode,
+				isFlexibleIPAMSrc: false,
+				isFlexibleIPAMDst: false,
+				ctZone:            0,
+			},
+			prepareFunc: func(builder *mocks.MockPacketOutBuilder) {
+				builder.EXPECT().AddLoadRegMark(openflow.CustomReasonRejectRegMark).Return(builder)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := mocks.NewMockPacketOutBuilder(ctrl)
+			tt.prepareFunc(builder)
+			getRejectPacketOutMutateFunc(tt.args.rejectType, tt.args.nodeType, tt.args.isFlexibleIPAMSrc, tt.args.isFlexibleIPAMDst, tt.args.ctZone)(builder)
 		})
 	}
 }

--- a/pkg/ovs/openflow/interfaces.go
+++ b/pkg/ovs/openflow/interfaces.go
@@ -78,6 +78,7 @@ const (
 	NxmFieldDstIPv6     = "NXM_NX_IPV6_DST"
 
 	OxmFieldVLANVID = "OXM_OF_VLAN_VID"
+	OxmFieldInPort  = "OXM_OF_IN_PORT"
 )
 
 const (

--- a/test/e2e/antreaipam_anp_test.go
+++ b/test/e2e/antreaipam_anp_test.go
@@ -1,0 +1,232 @@
+// Copyright 2023 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	crdv1alpha1 "antrea.io/antrea/pkg/apis/crd/v1alpha1"
+	annotation "antrea.io/antrea/pkg/ipam"
+	e2eutils "antrea.io/antrea/test/e2e/utils"
+)
+
+// initializeAntreaIPAM must be called after Namespace in antreaIPAMNamespaces created
+func initializeAntreaIPAM(t *testing.T, data *TestData) {
+	p80 = 80
+	p81 = 81
+	p8080 = 8080
+	p8081 = 8081
+	p8082 = 8082
+	p8085 = 8085
+	pods = []string{"a", "b", "c"}
+	namespaces = make(map[string]string)
+	regularNamespaces := make(map[string]string)
+	suffix := randName("")
+	namespaces["x"] = "antrea-x-" + suffix
+	regularNamespaces["x"] = namespaces["x"]
+	// This function "initializeAntreaIPAM" will be used more than once, and variable "allPods" is global.
+	// It should be empty every time when "initializeAntreaIPAM" is performed, otherwise there will be unexpected
+	// results.
+	allPods = []Pod{}
+	podsByNamespace = make(map[string][]Pod)
+
+	for _, ns := range antreaIPAMNamespaces {
+		namespaces[ns] = ns
+	}
+
+	for _, podName := range pods {
+		for _, ns := range namespaces {
+			allPods = append(allPods, NewPod(ns, podName))
+			podsByNamespace[ns] = append(podsByNamespace[ns], NewPod(ns, podName))
+		}
+	}
+
+	var err error
+	// k8sUtils is a global var
+	k8sUtils, err = NewKubernetesUtils(data)
+	failOnError(err, t)
+	_, err = k8sUtils.Bootstrap(regularNamespaces, pods, true)
+	failOnError(err, t)
+	ips, err := k8sUtils.Bootstrap(namespaces, pods, false)
+	failOnError(err, t)
+	podIPs = *ips
+}
+
+func TestAntreaIPAMAntreaPolicy(t *testing.T) {
+	skipIfNotAntreaIPAMTest(t)
+	skipIfHasWindowsNodes(t)
+	skipIfAntreaPolicyDisabled(t)
+
+	data, err := setupTest(t)
+	if err != nil {
+		t.Fatalf("Error when setting up test: %v", err)
+	}
+	defer teardownTest(t, data)
+
+	// Create AntreaIPAM IPPool and test Namespace
+	for _, namespace := range antreaIPAMNamespaces {
+		ipPool, err := createIPPool(t, data, namespace)
+		if err != nil {
+			t.Fatalf("Creating IPPool failed, err=%+v", err)
+		}
+		defer deleteIPPoolWrapper(t, data, ipPool.Name)
+		annotations := map[string]string{}
+		annotations[annotation.AntreaIPAMAnnotationKey] = ipPool.Name
+		err = data.createNamespaceWithAnnotations(namespace, annotations)
+		if err != nil {
+			t.Fatalf("Creating AntreaIPAM Namespace failed, err=%+v", err)
+		}
+		defer deleteAntreaIPAMNamespace(t, data, namespace)
+	}
+	initializeAntreaIPAM(t, data)
+
+	t.Run("TestGroupNoK8sNP", func(t *testing.T) {
+		// testcases below do not depend on underlying default-deny K8s NetworkPolicies.
+		t.Run("Case=ACNPAllowNoDefaultIsolationTCP", func(t *testing.T) { testACNPAllowNoDefaultIsolation(t, e2eutils.ProtocolTCP) })
+		t.Run("Case=ACNPAllowNoDefaultIsolationUDP", func(t *testing.T) { testACNPAllowNoDefaultIsolation(t, e2eutils.ProtocolUDP) })
+		t.Run("Case=ACNPAllowNoDefaultIsolationSCTP", func(t *testing.T) { testACNPAllowNoDefaultIsolation(t, e2eutils.ProtocolSCTP) })
+		t.Run("Case=ACNPEgressDrop", func(t *testing.T) { testAntreaIPAMACNP(t, e2eutils.ProtocolTCP, Dropped, false) })
+		t.Run("Case=ACNPEgressDropUDP", func(t *testing.T) { testAntreaIPAMACNP(t, e2eutils.ProtocolUDP, Dropped, false) })
+		t.Run("Case=ACNPEgressDropSCTP", func(t *testing.T) { testAntreaIPAMACNP(t, e2eutils.ProtocolSCTP, Dropped, false) })
+		t.Run("Case=ACNPIngressDrop", func(t *testing.T) { testAntreaIPAMACNP(t, e2eutils.ProtocolTCP, Dropped, true) })
+		t.Run("Case=ACNPIngressDropUDP", func(t *testing.T) { testAntreaIPAMACNP(t, e2eutils.ProtocolUDP, Dropped, true) })
+		t.Run("Case=ACNPIngressDropSCTP", func(t *testing.T) { testAntreaIPAMACNP(t, e2eutils.ProtocolSCTP, Dropped, true) })
+
+		t.Run("Case=ACNPEgressReject", func(t *testing.T) { testAntreaIPAMACNP(t, e2eutils.ProtocolTCP, Rejected, false) })
+		t.Run("Case=ACNPEgressRejectUDP", func(t *testing.T) { testAntreaIPAMACNP(t, e2eutils.ProtocolUDP, Rejected, false) })
+		t.Run("Case=ACNPIngressReject", func(t *testing.T) { testAntreaIPAMACNP(t, e2eutils.ProtocolTCP, Rejected, true) })
+		t.Run("Case=ACNPIngressRejectUDP", func(t *testing.T) { testAntreaIPAMACNP(t, e2eutils.ProtocolUDP, Rejected, true) })
+
+		t.Run("Case=RejectServiceTrafficAntreaIPAMToAntreaIPAM", func(t *testing.T) {
+			testRejectServiceTraffic(t, data, testAntreaIPAMNamespace, testAntreaIPAMNamespace)
+		})
+		t.Run("Case=RejectServiceTrafficAntreaIPAMVLAN11ToAntreaIPAMVLAN11", func(t *testing.T) {
+			testRejectServiceTraffic(t, data, testAntreaIPAMNamespace11, testAntreaIPAMNamespace11)
+		})
+		t.Run("Case=RejectServiceTrafficRegularToAntreaIPAM", func(t *testing.T) { testRejectServiceTraffic(t, data, data.testNamespace, testAntreaIPAMNamespace) })
+		t.Run("Case=RejectServiceTrafficRegularToAntreaIPAMVLAN11", func(t *testing.T) { testRejectServiceTraffic(t, data, data.testNamespace, testAntreaIPAMNamespace11) })
+		t.Run("Case=RejectServiceTrafficAntreaIPAMToAntreaIPAMVLAN11", func(t *testing.T) {
+			testRejectServiceTraffic(t, data, testAntreaIPAMNamespace, testAntreaIPAMNamespace11)
+		})
+		t.Run("Case=RejectServiceTrafficAntreaIPAMToRegular", func(t *testing.T) { testRejectServiceTraffic(t, data, testAntreaIPAMNamespace, data.testNamespace) })
+		t.Run("Case=RejectServiceTrafficAntreaIPAMVLAN11ToRegular", func(t *testing.T) { testRejectServiceTraffic(t, data, testAntreaIPAMNamespace11, data.testNamespace) })
+		t.Run("Case=RejectServiceTrafficAntreaIPAMVLAN11ToAntreaIPAM", func(t *testing.T) {
+			testRejectServiceTraffic(t, data, testAntreaIPAMNamespace11, testAntreaIPAMNamespace)
+		})
+		t.Run("Case=RejectServiceTrafficAntreaIPAMVLAN11ToAntreaIPAMVLAN12", func(t *testing.T) {
+			testRejectServiceTraffic(t, data, testAntreaIPAMNamespace11, testAntreaIPAMNamespace12)
+		})
+
+		t.Run("Case=RejectNoInfiniteLoopAntreaIPAMToAntreaIPAM", func(t *testing.T) {
+			testRejectNoInfiniteLoop(t, data, testAntreaIPAMNamespace, testAntreaIPAMNamespace)
+		})
+		t.Run("Case=RejectNoInfiniteLoopAntreaIPAMVLAN11ToAntreaIPAMVLAN11", func(t *testing.T) {
+			testRejectNoInfiniteLoop(t, data, testAntreaIPAMNamespace11, testAntreaIPAMNamespace11)
+		})
+		t.Run("Case=RejectNoInfiniteLoopRegularToAntreaIPAM", func(t *testing.T) { testRejectNoInfiniteLoop(t, data, data.testNamespace, testAntreaIPAMNamespace) })
+		t.Run("Case=RejectNoInfiniteLoopRegularToAntreaIPAMVLAN11", func(t *testing.T) { testRejectNoInfiniteLoop(t, data, data.testNamespace, testAntreaIPAMNamespace11) })
+		t.Run("Case=RejectNoInfiniteLoopAntreaIPAMToAntreaIPAMVLAN11", func(t *testing.T) {
+			testRejectNoInfiniteLoop(t, data, testAntreaIPAMNamespace, testAntreaIPAMNamespace11)
+		})
+		t.Run("Case=RejectNoInfiniteLoopAntreaIPAMToRegular", func(t *testing.T) { testRejectNoInfiniteLoop(t, data, testAntreaIPAMNamespace, data.testNamespace) })
+		t.Run("Case=RejectNoInfiniteLoopAntreaIPAMVLAN11ToRegular", func(t *testing.T) { testRejectNoInfiniteLoop(t, data, testAntreaIPAMNamespace11, data.testNamespace) })
+		t.Run("Case=RejectNoInfiniteLoopAntreaIPAMVLAN11ToAntreaIPAM", func(t *testing.T) {
+			testRejectNoInfiniteLoop(t, data, testAntreaIPAMNamespace11, testAntreaIPAMNamespace)
+		})
+		t.Run("Case=RejectNoInfiniteLoopAntreaIPAMVLAN11ToAntreaIPAMVLAN12", func(t *testing.T) {
+			testRejectNoInfiniteLoop(t, data, testAntreaIPAMNamespace11, testAntreaIPAMNamespace12)
+		})
+
+		t.Run("Case=ACNPAntreaIPAMNodePortServiceSupport", func(t *testing.T) { testACNPNodePortServiceSupport(t, data, testAntreaIPAMNamespace) })
+		t.Run("Case=ACNPAntreaIPAMVLAN11NodePortServiceSupport", func(t *testing.T) { testACNPNodePortServiceSupport(t, data, testAntreaIPAMNamespace11) })
+	})
+	// print results for reachability tests
+	printResults()
+
+	k8sUtils.Cleanup(namespaces)
+}
+
+func testAntreaIPAMACNP(t *testing.T, protocol e2eutils.AntreaPolicyProtocol, action PodConnectivityMark, isIngress bool) {
+	if protocol == e2eutils.ProtocolSCTP {
+		// SCTP testing is failing on our IPv6 CI testbeds at the moment. This seems to be
+		// related to an issue with ESX networking for SCTPv6 traffic when the Pods are on
+		// different Node VMs which are themselves on different ESX hosts. We are
+		// investigating the issue and disabling the tests for IPv6 clusters in the
+		// meantime.
+		skipIfIPv6Cluster(t)
+	}
+	var ruleAction crdv1alpha1.RuleAction
+	switch action {
+	case Dropped:
+		ruleAction = crdv1alpha1.RuleActionDrop
+	case Rejected:
+		ruleAction = crdv1alpha1.RuleActionReject
+	default:
+		ruleAction = crdv1alpha1.RuleActionAllow
+	}
+	builder := &e2eutils.ClusterNetworkPolicySpecBuilder{}
+	builder = builder.SetName(fmt.Sprintf("acnp-%s-a", strings.ToLower(string(ruleAction)))).
+		SetPriority(1.0).
+		SetAppliedToGroup([]e2eutils.ACNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}}})
+	builder2 := &e2eutils.ClusterNetworkPolicySpecBuilder{}
+	builder2 = builder2.SetName(fmt.Sprintf("acnp-%s-b", strings.ToLower(string(ruleAction)))).
+		SetPriority(1.0).
+		SetAppliedToGroup([]e2eutils.ACNPAppliedToSpec{{PodSelector: map[string]string{"pod": "b"}}})
+	builder3 := &e2eutils.ClusterNetworkPolicySpecBuilder{}
+	builder3 = builder3.SetName(fmt.Sprintf("acnp-%s-c", strings.ToLower(string(ruleAction)))).
+		SetPriority(1.0).
+		SetAppliedToGroup([]e2eutils.ACNPAppliedToSpec{{PodSelector: map[string]string{"pod": "c"}}})
+	if isIngress {
+		builder.AddIngress(protocol, &p80, nil, nil, nil, nil, nil, nil, nil, map[string]string{}, nil,
+			nil, nil, false, nil, ruleAction, "", "", nil)
+		builder2.AddIngress(protocol, &p80, nil, nil, nil, nil, nil, nil, nil, map[string]string{}, nil,
+			nil, nil, false, nil, ruleAction, "", "", nil)
+		builder3.AddIngress(protocol, &p80, nil, nil, nil, nil, nil, nil, nil, map[string]string{}, nil,
+			nil, nil, false, nil, ruleAction, "", "", nil)
+	} else {
+		builder.AddEgress(protocol, &p80, nil, nil, nil, nil, nil, nil, nil, map[string]string{}, nil,
+			nil, nil, false, nil, ruleAction, "", "", nil)
+		builder2.AddEgress(protocol, &p80, nil, nil, nil, nil, nil, nil, nil, map[string]string{}, nil,
+			nil, nil, false, nil, ruleAction, "", "", nil)
+		builder3.AddEgress(protocol, &p80, nil, nil, nil, nil, nil, nil, nil, map[string]string{}, nil,
+			nil, nil, false, nil, ruleAction, "", "", nil)
+	}
+
+	reachability := NewReachability(allPods, action)
+	for _, ns := range namespaces {
+		for _, pod := range []string{"/a", "/b", "/c"} {
+			reachability.Expect(Pod(ns+pod), Pod(ns+pod), Connected)
+		}
+	}
+	testStep := []*TestStep{
+		{
+			"Port 80",
+			reachability,
+			[]metav1.Object{builder.Get(), builder2.Get(), builder3.Get()},
+			[]int32{80},
+			protocol,
+			0,
+			nil,
+		},
+	}
+	testCase := []*TestCase{
+		{fmt.Sprintf("ACNP %s for all Pods, ingress=%v", string(ruleAction), isIngress), testStep},
+	}
+	executeTests(t, testCase)
+}

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -1798,8 +1798,8 @@ func (data *TestData) createAgnhostNodePortService(serviceName string, affinity,
 }
 
 // createNginxNodePortService creates a NodePort nginx service with the given name.
-func (data *TestData) createNginxNodePortService(serviceName string, affinity, nodeLocalExternal bool, ipFamily *corev1.IPFamily) (*corev1.Service, error) {
-	return data.CreateService(serviceName, data.testNamespace, 80, 80, map[string]string{"app": "nginx"}, affinity, nodeLocalExternal, corev1.ServiceTypeNodePort, ipFamily)
+func (data *TestData) createNginxNodePortService(serviceName, namespace string, affinity, nodeLocalExternal bool, ipFamily *corev1.IPFamily) (*corev1.Service, error) {
+	return data.CreateService(serviceName, namespace, 80, 80, map[string]string{"app": "nginx"}, affinity, nodeLocalExternal, corev1.ServiceTypeNodePort, ipFamily)
 }
 
 func (data *TestData) updateServiceExternalTrafficPolicy(serviceName string, nodeLocalExternal bool) (*corev1.Service, error) {

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -431,7 +431,7 @@ func TestNodePortAndEgressWithTheSameBackendPod(t *testing.T) {
 	nodePortIP := controlPlaneNodeIPv4()
 	ipProtocol := corev1.IPv4Protocol
 	var portStr string
-	nodePortSvc, err := data.createNginxNodePortService("test-nodeport-svc", true, false, &ipProtocol)
+	nodePortSvc, err := data.createNginxNodePortService("test-nodeport-svc", data.testNamespace, true, false, &ipProtocol)
 	require.NoError(t, err)
 	for _, port := range nodePortSvc.Spec.Ports {
 		if port.NodePort != 0 {

--- a/test/e2e/service_test.go
+++ b/test/e2e/service_test.go
@@ -194,8 +194,9 @@ func (data *TestData) createAgnhostServiceAndBackendPods(t *testing.T, name, nam
 		ipProtocol = corev1.IPv6Protocol
 	}
 	require.NoError(t, data.podWaitForRunning(defaultTimeout, name, namespace))
-	svc, err := data.CreateService(name, namespace, 80, 80, map[string]string{"app": "agnhost"}, false, false, svcType, &ipProtocol)
+	svc, err := data.CreateService(name, namespace, 80, 80, map[string]string{"app": "agnhost", "antrea-e2e": name}, false, false, svcType, &ipProtocol)
 	require.NoError(t, err)
+	t.Logf("Created service Cluster IP %v", svc.Spec.ClusterIP)
 
 	cleanup := func() {
 		data.DeletePodAndWait(defaultTimeout, name, namespace)


### PR DESCRIPTION
Fixed issues:
    Unexpected SNAT from local regular Pod to local FlexibleIPAM Pod.
    ANP/ACNP reject failed on some cases when src/dst is FlexibleIPAM Pod.

e2e enhancement:
    Added AntreaIPAMAntreaPolicy e2e cases.
    Fixed wrong Pod labels on createAgnhostServiceAndBackendPods

doc enhancement:
    Added missing requirements.

Signed-off-by: gran <gran@vmware.com>