### PR TITLE
Automated cherry pick of #4016: Fix unit test flaky for IPsec controller
#4060: Fix race condition in unit test for IPsec
#4241: Fix flaky TestController_RotateCertificates unit test

### DIFF
--- a/pkg/agent/controller/ipseccertificate/ipsec_certificate_controller_test.go
+++ b/pkg/agent/controller/ipseccertificate/ipsec_certificate_controller_test.go
@@ -312,10 +312,16 @@ func TestController_RotateCertificates(t *testing.T) {
 	if delta < 0 {
 		delta = -delta
 	}
-	// the rotation interval should be in [7s, 9s], but it takes time to process the CSR request,
-	// so add one second to the upper bound.
-	assert.Less(t, delta, time.Second*10)
-	assert.LessOrEqual(t, time.Second*7, delta)
+	// the rotation interval is determined by nextRotationDeadline as notBefore + (notAfter -
+	// notBefore) * k, where k is >= 0.7 and <= 0.9. We would therefore expect the delta to
+	// fall in the interval [7s, 9s]. However we have to account for the following:
+	// a) the accuracy of notAfter is at the second level, which means that it will be
+	// truncated, which means that there can actually be less than 7s between the
+	// CreationTimestamp of the first certificate and the rotation deadline. As a result, we
+	// need to set the lower bound to 6s.
+	// b) it takes time to process the CSR request so we add one second to the upper bound.
+	assert.Less(t, delta, 10*time.Second)
+	assert.LessOrEqual(t, 6*time.Second, delta)
 }
 
 func newIPsecCertTemplate(t *testing.T, nodeName string, notBefore, notAfter time.Time) *x509.Certificate {


### PR DESCRIPTION
Cherry pick of #4016 #4060 #4241 on release-1.7.

#4016: Fix unit test flaky for IPsec controller
#4060: Fix race condition in unit test for IPsec
#4241: Fix flaky TestController_RotateCertificates unit test

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.