### PR TITLE
[e2e] Keep ubuntu:20.04 image

### DIFF
--- a/hack/build-antrea-linux-all.sh
+++ b/hack/build-antrea-linux-all.sh
@@ -114,9 +114,12 @@ echo "BUILD_TAG: $BUILD_TAG"
 # new base images in the build chain.
 if $PULL; then
     if [[ ${DOCKER_REGISTRY} == "" ]]; then
+        docker pull $PLATFORM_ARG ubuntu:20.04
         docker pull $PLATFORM_ARG ubuntu:22.04
         docker pull $PLATFORM_ARG golang:$GO_VERSION
     else
+        docker pull ${DOCKER_REGISTRY}/antrea/ubuntu:20.04
+        docker tag ${DOCKER_REGISTRY}/antrea/ubuntu:20.04 ubuntu:20.04
         docker pull ${DOCKER_REGISTRY}/antrea/ubuntu:22.04
         docker tag ${DOCKER_REGISTRY}/antrea/ubuntu:22.04 ubuntu:22.04
         docker pull ${DOCKER_REGISTRY}/antrea/golang:$GO_VERSION


### PR DESCRIPTION
Fix issue caused by #4459
Some images rely on ubuntu:20.04, keep the manual pulling step in e2e.

Signed-off-by: gran <gran@vmware.com>