### PR TITLE
Import auth to support different platforms

### DIFF
--- a/pkg/antctl/runtime/runtime.go
+++ b/pkg/antctl/runtime/runtime.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"strings"
 
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 


### PR DESCRIPTION
Antctl failed to talk with GCP cluster and it shows: `Error: no Auth Provider found for name "gcp"`. According to the example of client-go, we need to import auth package to support different public platform's authentication.

Here is the sample code:
https://github.com/kubernetes/client-go/blob/master/examples/out-of-cluster-client-configuration/main.go#L33-L40

Signed-off-by: Lan Luo <luola@vmware.com>