### PR TITLE
Refine Endpoint selection for multi-cluster Service

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -376,13 +376,13 @@ func run(o *Options) error {
 
 		switch {
 		case v4Enabled && v6Enabled:
-			proxier = proxy.NewDualStackProxier(nodeConfig.Name, informerFactory, ofClient, routeClient, nodePortAddressesIPv4, nodePortAddressesIPv6, proxyAll, skipServices, proxyLoadBalancerIPs, v4GroupCounter, v6GroupCounter)
+			proxier = proxy.NewDualStackProxier(nodeConfig.Name, informerFactory, ofClient, routeClient, nodePortAddressesIPv4, nodePortAddressesIPv6, proxyAll, skipServices, proxyLoadBalancerIPs, v4GroupCounter, v6GroupCounter, enableMulticlusterGW, serviceCIDRProvider)
 			groupCounters = append(groupCounters, v4GroupCounter, v6GroupCounter)
 		case v4Enabled:
-			proxier = proxy.NewProxier(nodeConfig.Name, informerFactory, ofClient, false, routeClient, nodePortAddressesIPv4, proxyAll, skipServices, proxyLoadBalancerIPs, v4GroupCounter)
+			proxier = proxy.NewProxier(nodeConfig.Name, informerFactory, ofClient, false, routeClient, nodePortAddressesIPv4, proxyAll, skipServices, proxyLoadBalancerIPs, v4GroupCounter, enableMulticlusterGW, serviceCIDRProvider)
 			groupCounters = append(groupCounters, v4GroupCounter)
 		case v6Enabled:
-			proxier = proxy.NewProxier(nodeConfig.Name, informerFactory, ofClient, true, routeClient, nodePortAddressesIPv6, proxyAll, skipServices, proxyLoadBalancerIPs, v6GroupCounter)
+			proxier = proxy.NewProxier(nodeConfig.Name, informerFactory, ofClient, true, routeClient, nodePortAddressesIPv6, proxyAll, skipServices, proxyLoadBalancerIPs, v6GroupCounter, enableMulticlusterGW, serviceCIDRProvider)
 			groupCounters = append(groupCounters, v6GroupCounter)
 		default:
 			return fmt.Errorf("at least one of IPv4 or IPv6 should be enabled")

--- a/pkg/agent/openflow/testing/mock_openflow.go
+++ b/pkg/agent/openflow/testing/mock_openflow.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Antrea Authors
+// Copyright 2023 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,7 +21,8 @@ package testing
 
 import (
 	config "antrea.io/antrea/pkg/agent/config"
-	types "antrea.io/antrea/pkg/agent/types"
+	types "antrea.io/antrea/pkg/agent/openflow/types"
+	types0 "antrea.io/antrea/pkg/agent/types"
 	v1alpha2 "antrea.io/antrea/pkg/apis/crd/v1alpha2"
 	openflow "antrea.io/antrea/pkg/ovs/openflow"
 	ip "antrea.io/antrea/pkg/util/ip"
@@ -57,7 +58,7 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // AddAddressToDNSConjunction mocks base method
-func (m *MockClient) AddAddressToDNSConjunction(arg0 uint32, arg1 []types.Address) error {
+func (m *MockClient) AddAddressToDNSConjunction(arg0 uint32, arg1 []types0.Address) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddAddressToDNSConjunction", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -71,7 +72,7 @@ func (mr *MockClientMockRecorder) AddAddressToDNSConjunction(arg0, arg1 interfac
 }
 
 // AddPolicyRuleAddress mocks base method
-func (m *MockClient) AddPolicyRuleAddress(arg0 uint32, arg1 types.AddressType, arg2 []types.Address, arg3 *uint16, arg4, arg5 bool) error {
+func (m *MockClient) AddPolicyRuleAddress(arg0 uint32, arg1 types0.AddressType, arg2 []types0.Address, arg3 *uint16, arg4, arg5 bool) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddPolicyRuleAddress", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(error)
@@ -85,7 +86,7 @@ func (mr *MockClientMockRecorder) AddPolicyRuleAddress(arg0, arg1, arg2, arg3, a
 }
 
 // BatchInstallPolicyRuleFlows mocks base method
-func (m *MockClient) BatchInstallPolicyRuleFlows(arg0 []*types.PolicyRule) error {
+func (m *MockClient) BatchInstallPolicyRuleFlows(arg0 []*types0.PolicyRule) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BatchInstallPolicyRuleFlows", arg0)
 	ret0, _ := ret[0].(error)
@@ -99,7 +100,7 @@ func (mr *MockClientMockRecorder) BatchInstallPolicyRuleFlows(arg0 interface{}) 
 }
 
 // DeleteAddressFromDNSConjunction mocks base method
-func (m *MockClient) DeleteAddressFromDNSConjunction(arg0 uint32, arg1 []types.Address) error {
+func (m *MockClient) DeleteAddressFromDNSConjunction(arg0 uint32, arg1 []types0.Address) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteAddressFromDNSConjunction", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -113,7 +114,7 @@ func (mr *MockClientMockRecorder) DeleteAddressFromDNSConjunction(arg0, arg1 int
 }
 
 // DeletePolicyRuleAddress mocks base method
-func (m *MockClient) DeletePolicyRuleAddress(arg0 uint32, arg1 types.AddressType, arg2 []types.Address, arg3 *uint16) error {
+func (m *MockClient) DeletePolicyRuleAddress(arg0 uint32, arg1 types0.AddressType, arg2 []types0.Address, arg3 *uint16) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeletePolicyRuleAddress", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
@@ -255,7 +256,7 @@ func (mr *MockClientMockRecorder) InitialTLVMap() *gomock.Call {
 }
 
 // Initialize mocks base method
-func (m *MockClient) Initialize(arg0 types.RoundInfo, arg1 *config.NodeConfig, arg2 *config.NetworkConfig, arg3 *config.EgressConfig, arg4 *config.ServiceConfig, arg5 *config.L7NetworkPolicyConfig) (<-chan struct{}, error) {
+func (m *MockClient) Initialize(arg0 types0.RoundInfo, arg1 *config.NodeConfig, arg2 *config.NetworkConfig, arg3 *config.EgressConfig, arg4 *config.ServiceConfig, arg5 *config.L7NetworkPolicyConfig) (<-chan struct{}, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Initialize", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(<-chan struct{})
@@ -424,7 +425,7 @@ func (mr *MockClientMockRecorder) InstallPolicyBypassFlows(arg0, arg1, arg2, arg
 }
 
 // InstallPolicyRuleFlows mocks base method
-func (m *MockClient) InstallPolicyRuleFlows(arg0 *types.PolicyRule) error {
+func (m *MockClient) InstallPolicyRuleFlows(arg0 *types0.PolicyRule) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "InstallPolicyRuleFlows", arg0)
 	ret0, _ := ret[0].(error)
@@ -466,17 +467,17 @@ func (mr *MockClientMockRecorder) InstallServiceFlows(arg0, arg1, arg2, arg3, ar
 }
 
 // InstallServiceGroup mocks base method
-func (m *MockClient) InstallServiceGroup(arg0 openflow.GroupIDType, arg1 bool, arg2 []proxy.Endpoint) error {
+func (m *MockClient) InstallServiceGroup(arg0 openflow.GroupIDType, arg1 bool, arg2 *types.ServiceGroupInfo, arg3 []proxy.Endpoint) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstallServiceGroup", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "InstallServiceGroup", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InstallServiceGroup indicates an expected call of InstallServiceGroup
-func (mr *MockClientMockRecorder) InstallServiceGroup(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) InstallServiceGroup(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallServiceGroup", reflect.TypeOf((*MockClient)(nil).InstallServiceGroup), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallServiceGroup", reflect.TypeOf((*MockClient)(nil).InstallServiceGroup), arg0, arg1, arg2, arg3)
 }
 
 // InstallTraceflowFlows mocks base method
@@ -550,10 +551,10 @@ func (mr *MockClientMockRecorder) IsConnected() *gomock.Call {
 }
 
 // MulticastEgressPodMetrics mocks base method
-func (m *MockClient) MulticastEgressPodMetrics() map[string]*types.RuleMetric {
+func (m *MockClient) MulticastEgressPodMetrics() map[string]*types0.RuleMetric {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MulticastEgressPodMetrics")
-	ret0, _ := ret[0].(map[string]*types.RuleMetric)
+	ret0, _ := ret[0].(map[string]*types0.RuleMetric)
 	return ret0
 }
 
@@ -564,10 +565,10 @@ func (mr *MockClientMockRecorder) MulticastEgressPodMetrics() *gomock.Call {
 }
 
 // MulticastEgressPodMetricsByIP mocks base method
-func (m *MockClient) MulticastEgressPodMetricsByIP(arg0 net.IP) *types.RuleMetric {
+func (m *MockClient) MulticastEgressPodMetricsByIP(arg0 net.IP) *types0.RuleMetric {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MulticastEgressPodMetricsByIP", arg0)
-	ret0, _ := ret[0].(*types.RuleMetric)
+	ret0, _ := ret[0].(*types0.RuleMetric)
 	return ret0
 }
 
@@ -578,10 +579,10 @@ func (mr *MockClientMockRecorder) MulticastEgressPodMetricsByIP(arg0 interface{}
 }
 
 // MulticastIngressPodMetrics mocks base method
-func (m *MockClient) MulticastIngressPodMetrics() map[uint32]*types.RuleMetric {
+func (m *MockClient) MulticastIngressPodMetrics() map[uint32]*types0.RuleMetric {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MulticastIngressPodMetrics")
-	ret0, _ := ret[0].(map[uint32]*types.RuleMetric)
+	ret0, _ := ret[0].(map[uint32]*types0.RuleMetric)
 	return ret0
 }
 
@@ -592,10 +593,10 @@ func (mr *MockClientMockRecorder) MulticastIngressPodMetrics() *gomock.Call {
 }
 
 // MulticastIngressPodMetricsByOFPort mocks base method
-func (m *MockClient) MulticastIngressPodMetricsByOFPort(arg0 int32) *types.RuleMetric {
+func (m *MockClient) MulticastIngressPodMetricsByOFPort(arg0 int32) *types0.RuleMetric {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MulticastIngressPodMetricsByOFPort", arg0)
-	ret0, _ := ret[0].(*types.RuleMetric)
+	ret0, _ := ret[0].(*types0.RuleMetric)
 	return ret0
 }
 
@@ -606,10 +607,10 @@ func (mr *MockClientMockRecorder) MulticastIngressPodMetricsByOFPort(arg0 interf
 }
 
 // NetworkPolicyMetrics mocks base method
-func (m *MockClient) NetworkPolicyMetrics() map[uint32]*types.RuleMetric {
+func (m *MockClient) NetworkPolicyMetrics() map[uint32]*types0.RuleMetric {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NetworkPolicyMetrics")
-	ret0, _ := ret[0].(map[uint32]*types.RuleMetric)
+	ret0, _ := ret[0].(map[uint32]*types0.RuleMetric)
 	return ret0
 }
 

--- a/pkg/agent/openflow/types/types.go
+++ b/pkg/agent/openflow/types/types.go
@@ -1,0 +1,29 @@
+// Copyright 2023 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	binding "antrea.io/antrea/pkg/ovs/openflow"
+	k8sproxy "antrea.io/antrea/third_party/proxy"
+)
+
+// ServiceGroupInfo is used in AntreaProxy for Multi-cluster Service load-balancing.
+// It stores a local exported Service's GroupID and its ClusterIP.
+type ServiceGroupInfo struct {
+	// GroupID of an exported Service.
+	GroupID binding.GroupIDType
+	// ClusterIP info of an exported Service.
+	Endpoint k8sproxy.Endpoint
+}

--- a/pkg/agent/proxy/proxier.go
+++ b/pkg/agent/proxy/proxier.go
@@ -34,9 +34,11 @@ import (
 
 	agentconfig "antrea.io/antrea/pkg/agent/config"
 	"antrea.io/antrea/pkg/agent/openflow"
+	openflowtypes "antrea.io/antrea/pkg/agent/openflow/types"
 	"antrea.io/antrea/pkg/agent/proxy/metrics"
 	"antrea.io/antrea/pkg/agent/proxy/types"
 	"antrea.io/antrea/pkg/agent/route"
+	"antrea.io/antrea/pkg/agent/servicecidr"
 	"antrea.io/antrea/pkg/features"
 	binding "antrea.io/antrea/pkg/ovs/openflow"
 	k8sproxy "antrea.io/antrea/third_party/proxy"
@@ -48,8 +50,10 @@ const (
 	resyncPeriod  = time.Minute
 	componentName = "antrea-agent-proxy"
 	// SessionAffinity timeout is implemented using a hard_timeout in OVS. hard_timeout is
-	// represented by a uint16 in the OpenFlow protocol,
+	// represented by a uint16 in the OpenFlow protocol.
 	maxSupportedAffinityTimeout = math.MaxUint16
+	// The prefix of multi-cluster Service name.
+	mcServiceNamePrefix = "antrea-mc-"
 )
 
 // Proxier wraps proxy.Provider and adds extra methods. It is introduced for
@@ -119,6 +123,8 @@ type proxier struct {
 	endpointSliceEnabled      bool
 	proxyLoadBalancerIPs      bool
 	topologyAwareHintsEnabled bool
+	multiclusterEnabled       bool
+	serviceCIDRProvider       servicecidr.Interface
 }
 
 func (p *proxier) SyncedOnce() bool {
@@ -346,6 +352,11 @@ func (p *proxier) uninstallLoadBalancerService(loadBalancerIPStrings []string, s
 }
 
 func (p *proxier) installServices() {
+	var serviceCIDRIPv4 *net.IPNet
+	if p.multiclusterEnabled {
+		// serviceCIDRIPv4 is required only for Multi-cluster Services.
+		serviceCIDRIPv4, _ = p.serviceCIDRProvider.GetServiceCIDR(false)
+	}
 	for svcPortName, svcPort := range p.serviceMap {
 		svcInfo := svcPort.(*types.ServiceInfo)
 		endpointsInstalled, ok := p.endpointsInstalledMap[svcPortName]
@@ -403,13 +414,17 @@ func (p *proxier) installServices() {
 			externalPolicyLocal = true
 		}
 
-		clusterEndpoints, localEndpoints, allReachableEndpoints := p.categorizeEndpoints(endpointsToInstall, svcInfo)
+		var mcsLocalService *openflowtypes.ServiceGroupInfo
+		clusterEndpoints, localEndpoints, allReachableEndpoints, mcsLocalService := p.categorizeEndpoints(endpointsToInstall, svcInfo, svcPortName, serviceCIDRIPv4)
 		// If there are new Endpoints, Endpoints installed should be updated.
 		for _, endpoint := range allReachableEndpoints {
 			if _, ok := endpointsInstalled[endpoint.String()]; !ok { // There is an expected Endpoint which is not installed.
 				needUpdateEndpoints = true
 				break
 			}
+		}
+		if mcsLocalService != nil {
+			needUpdateEndpoints = true
 		}
 		// If there are expired Endpoints, Endpoints installed should be updated.
 		if len(allReachableEndpoints) < len(endpointsInstalled) {
@@ -455,19 +470,21 @@ func (p *proxier) installServices() {
 					// of the Service are different, install two groups. One group has cluster Endpoints, the other has
 					// local Endpoints.
 					groupID := p.groupCounter.AllocateIfNotExist(svcPortName, true)
-					if err = p.ofClient.InstallServiceGroup(groupID, affinityTimeout != 0, localEndpoints); err != nil {
+					// The Multi-cluster Service supports ClusterIP type of Service only, so always set mcsLocalService to nil when
+					// the type of the Service is not ClusterIP.
+					if err = p.ofClient.InstallServiceGroup(groupID, affinityTimeout != 0, nil, localEndpoints); err != nil {
 						klog.ErrorS(err, "Error when installing Group of local Endpoints for Service", "Service", svcPortName)
 						continue
 					}
 					groupID = p.groupCounter.AllocateIfNotExist(svcPortName, false)
-					if err = p.ofClient.InstallServiceGroup(groupID, affinityTimeout != 0, clusterEndpoints); err != nil {
+					if err = p.ofClient.InstallServiceGroup(groupID, affinityTimeout != 0, nil, clusterEndpoints); err != nil {
 						klog.ErrorS(err, "Error when installing Group of all Endpoints for Service", "Service", svcPortName)
 						continue
 					}
 				} else {
 					// If the type of the Service is ClusterIP, install a group according to internalTrafficPolicy.
 					groupID := p.groupCounter.AllocateIfNotExist(svcPortName, internalPolicyLocal)
-					if err = p.ofClient.InstallServiceGroup(groupID, affinityTimeout != 0, allReachableEndpoints); err != nil {
+					if err = p.ofClient.InstallServiceGroup(groupID, affinityTimeout != 0, mcsLocalService, allReachableEndpoints); err != nil {
 						klog.ErrorS(err, "Error when installing Group of Endpoints for Service", "Service", svcPortName)
 						continue
 					}
@@ -483,7 +500,7 @@ func (p *proxier) installServices() {
 				// internalPolicyLocal.
 				bothPolicyLocal := internalPolicyLocal
 				groupID := p.groupCounter.AllocateIfNotExist(svcPortName, bothPolicyLocal)
-				if err = p.ofClient.InstallServiceGroup(groupID, affinityTimeout != 0, allReachableEndpoints); err != nil {
+				if err = p.ofClient.InstallServiceGroup(groupID, affinityTimeout != 0, mcsLocalService, allReachableEndpoints); err != nil {
 					klog.ErrorS(err, "Error when installing Group of local Endpoints for Service", "Service", svcPortName)
 					continue
 				}
@@ -496,13 +513,21 @@ func (p *proxier) installServices() {
 				}
 			}
 
-			for _, e := range allReachableEndpoints {
+			updateInstalledEndpointsMap := func(endpoint k8sproxy.Endpoint) {
 				// If the Endpoint is newly installed, add a reference.
-				if _, ok := endpointsInstalled[e.String()]; !ok {
-					key := endpointKey(e, svcInfo.OFProtocol)
+				if _, ok := endpointsInstalled[endpoint.String()]; !ok {
+					key := endpointKey(endpoint, svcInfo.OFProtocol)
 					p.endpointReferenceCounter[key] = p.endpointReferenceCounter[key] + 1
-					endpointsInstalled[e.String()] = e
+					endpointsInstalled[endpoint.String()] = endpoint
 				}
+			}
+			for _, e := range allReachableEndpoints {
+				updateInstalledEndpointsMap(e)
+			}
+			// When mcsLocalService is not nil, add its ClusterIP info into the endpointsInstalled map
+			// since the corresponding Endpoint in Multi-cluster Service is not in the endpointUpdateList.
+			if mcsLocalService != nil {
+				updateInstalledEndpointsMap(mcsLocalService.Endpoint)
 			}
 		}
 
@@ -898,7 +923,9 @@ func NewProxier(
 	proxyAllEnabled bool,
 	skipServices []string,
 	proxyLoadBalancerIPs bool,
-	groupCounter types.GroupCounter) *proxier {
+	groupCounter types.GroupCounter,
+	multiclusterEnabled bool,
+	serviceCIDRProvider servicecidr.Interface) *proxier {
 	recorder := record.NewBroadcaster().NewRecorder(
 		runtime.NewScheme(),
 		corev1.EventSource{Component: componentName, Host: hostname},
@@ -946,6 +973,8 @@ func NewProxier(
 		hostname:                  hostname,
 		serviceHealthServer:       serviceHealthServer,
 		numLocalEndpoints:         map[apimachinerytypes.NamespacedName]int{},
+		multiclusterEnabled:       multiclusterEnabled,
+		serviceCIDRProvider:       serviceCIDRProvider,
 	}
 
 	p.serviceConfig.RegisterEventHandler(p)
@@ -1005,13 +1034,15 @@ func NewDualStackProxier(
 	skipServices []string,
 	proxyLoadBalancerIPs bool,
 	v4groupCounter types.GroupCounter,
-	v6groupCounter types.GroupCounter) *metaProxierWrapper {
+	v6groupCounter types.GroupCounter,
+	multiclusterEnabled bool,
+	serviceCIDRProvider servicecidr.Interface) *metaProxierWrapper {
 
 	// Create an IPv4 instance of the single-stack proxier.
-	ipv4Proxier := NewProxier(hostname, informerFactory, ofClient, false, routeClient, nodePortAddressesIPv4, proxyAllEnabled, skipServices, proxyLoadBalancerIPs, v4groupCounter)
+	ipv4Proxier := NewProxier(hostname, informerFactory, ofClient, false, routeClient, nodePortAddressesIPv4, proxyAllEnabled, skipServices, proxyLoadBalancerIPs, v4groupCounter, multiclusterEnabled, serviceCIDRProvider)
 
 	// Create an IPv6 instance of the single-stack proxier.
-	ipv6Proxier := NewProxier(hostname, informerFactory, ofClient, true, routeClient, nodePortAddressesIPv6, proxyAllEnabled, skipServices, proxyLoadBalancerIPs, v6groupCounter)
+	ipv6Proxier := NewProxier(hostname, informerFactory, ofClient, true, routeClient, nodePortAddressesIPv6, proxyAllEnabled, skipServices, proxyLoadBalancerIPs, v6groupCounter, multiclusterEnabled, serviceCIDRProvider)
 
 	// Create a meta-proxier that dispatch calls between the two
 	// single-stack proxier instances.

--- a/pkg/agent/proxy/topology.go
+++ b/pkg/agent/proxy/topology.go
@@ -15,15 +15,28 @@
 package proxy
 
 import (
+	"net"
+	"strings"
+
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 
+	openflowtypes "antrea.io/antrea/pkg/agent/openflow/types"
 	k8sproxy "antrea.io/antrea/third_party/proxy"
 )
 
-func (p *proxier) categorizeEndpoints(endpoints map[string]k8sproxy.Endpoint, svcInfo k8sproxy.ServicePort) ([]k8sproxy.Endpoint, []k8sproxy.Endpoint, []k8sproxy.Endpoint) {
+// When Antrea Multi-cluster is enabled, the Endpoint from a local exported Service will be
+// represented as a ServiceGroupInfo instead of an element in the returned Endpoint slices.
+func (p *proxier) categorizeEndpoints(endpoints map[string]k8sproxy.Endpoint,
+	svcInfo k8sproxy.ServicePort,
+	servicePortName k8sproxy.ServicePortName,
+	serviceCIDRIPv4 *net.IPNet) ([]k8sproxy.Endpoint,
+	[]k8sproxy.Endpoint,
+	[]k8sproxy.Endpoint,
+	*openflowtypes.ServiceGroupInfo) {
 	var useTopology, useServingTerminatingEndpoints bool
 	var clusterEndpoints, localEndpoints, allReachableEndpoints []k8sproxy.Endpoint
+	var mcsLocalService *openflowtypes.ServiceGroupInfo
 
 	// If cluster Endpoints is to be used for the Service, generate a list of cluster Endpoints.
 	if svcInfo.UsesClusterEndpoints() {
@@ -31,6 +44,13 @@ func (p *proxier) categorizeEndpoints(endpoints map[string]k8sproxy.Endpoint, sv
 		clusterEndpoints = filterEndpoints(endpoints, func(ep k8sproxy.Endpoint) bool {
 			if !ep.IsReady() {
 				return false
+			}
+			if p.multiclusterEnabled {
+				tempLocalService := p.getMCSExportedServiceInfo(serviceCIDRIPv4, ep, servicePortName)
+				if tempLocalService != nil {
+					mcsLocalService = tempLocalService
+					return false
+				}
 			}
 			if useTopology && !availableForTopology(ep, p.nodeLabels) {
 				return false
@@ -55,7 +75,7 @@ func (p *proxier) categorizeEndpoints(endpoints map[string]k8sproxy.Endpoint, sv
 	// and allReachableEndpoints.
 	if !svcInfo.UsesLocalEndpoints() {
 		allReachableEndpoints = clusterEndpoints
-		return clusterEndpoints, nil, allReachableEndpoints
+		return clusterEndpoints, nil, allReachableEndpoints, mcsLocalService
 	}
 
 	localEndpoints = filterEndpoints(endpoints, func(ep k8sproxy.Endpoint) bool {
@@ -85,14 +105,14 @@ func (p *proxier) categorizeEndpoints(endpoints map[string]k8sproxy.Endpoint, sv
 	// and allReachableEndpoints.
 	if !svcInfo.UsesClusterEndpoints() {
 		allReachableEndpoints = localEndpoints
-		return nil, localEndpoints, allReachableEndpoints
+		return nil, localEndpoints, allReachableEndpoints, mcsLocalService
 	}
 
 	if !useTopology && !useServingTerminatingEndpoints {
 		// !useServingTerminatingEndpoints means that localEndpoints contains only Ready Endpoints. !useTopology means
 		// that clusterEndpoints contains *every* Ready Endpoint. So clusterEndpoints must be a superset of localEndpoints.
 		allReachableEndpoints = clusterEndpoints
-		return clusterEndpoints, localEndpoints, allReachableEndpoints
+		return clusterEndpoints, localEndpoints, allReachableEndpoints, mcsLocalService
 	}
 
 	// clusterEndpoints may contain remote Endpoints that aren't in localEndpoints, while localEndpoints may contain
@@ -110,7 +130,7 @@ func (p *proxier) categorizeEndpoints(endpoints map[string]k8sproxy.Endpoint, sv
 		allReachableEndpoints = append(allReachableEndpoints, ep)
 	}
 
-	return clusterEndpoints, localEndpoints, allReachableEndpoints
+	return clusterEndpoints, localEndpoints, allReachableEndpoints, mcsLocalService
 }
 
 // canUseTopology returns true if topology aware routing is enabled and properly configured in this cluster. That is,
@@ -152,12 +172,34 @@ func (p *proxier) canUseTopology(endpoints map[string]k8sproxy.Endpoint, svcInfo
 		}
 	}
 
-	if !hasEndpointForZone == true {
+	if !hasEndpointForZone {
 		klog.InfoS("Skipping topology aware Endpoint filtering since no hints were provided for zone", "zone", zone)
 		return false
 	}
 
 	return true
+}
+
+func (p *proxier) getMCSExportedServiceInfo(serviceCIDRIPv4 *net.IPNet, endpoint k8sproxy.Endpoint, svcPortName k8sproxy.ServicePortName) *openflowtypes.ServiceGroupInfo {
+	var mcsLocalService *openflowtypes.ServiceGroupInfo
+	// When the Endpoint is a local Service's ClusterIP, it means the corresponding local Service is
+	// a member of the Multi-cluster Service.
+	if serviceCIDRIPv4 != nil && serviceCIDRIPv4.Contains(net.ParseIP(endpoint.IP())) {
+		mcsLocalService = &openflowtypes.ServiceGroupInfo{
+			Endpoint: endpoint,
+		}
+	}
+	// For any Multi-cluster Service, its name will be a combination with prefix `antrea-mc-` and
+	// exported Service's name. So we need to remove the prefix to look up the exported Service.
+	if mcsLocalService != nil && strings.HasPrefix(svcPortName.Name, mcServiceNamePrefix) {
+		exportedSvcPortName := svcPortName
+		exportedSvcPortName.Name = strings.TrimPrefix(svcPortName.Name, mcServiceNamePrefix)
+		if _, ok := p.serviceMap[exportedSvcPortName]; ok {
+			mcsLocalService.GroupID = p.groupCounter.AllocateIfNotExist(exportedSvcPortName, false)
+			return mcsLocalService
+		}
+	}
+	return nil
 }
 
 // availableForTopology checks if this endpoint is available for use on this node, given

--- a/pkg/ovs/openflow/interfaces.go
+++ b/pkg/ovs/openflow/interfaces.go
@@ -346,6 +346,7 @@ type BucketBuilder interface {
 	LoadToRegField(field *RegField, data uint32) BucketBuilder
 	ResubmitToTable(tableID uint8) BucketBuilder
 	SetTunnelDst(addr net.IP) BucketBuilder
+	Group(groupID uint32) BucketBuilder
 	Done() Group
 }
 

--- a/pkg/ovs/openflow/ofctrl_group.go
+++ b/pkg/ovs/openflow/ofctrl_group.go
@@ -188,6 +188,12 @@ func (b *bucketBuilder) Weight(val uint16) BucketBuilder {
 	return b
 }
 
+func (b *bucketBuilder) Group(groupID uint32) BucketBuilder {
+	groupAction := openflow15.NewActionGroup(groupID)
+	b.bucket.AddAction(groupAction)
+	return b
+}
+
 func (b *bucketBuilder) Done() Group {
 	b.group.ofctrl.Buckets = append(b.group.ofctrl.Buckets, b.bucket)
 	return b.group

--- a/pkg/ovs/openflow/ofctrl_group_test.go
+++ b/pkg/ovs/openflow/ofctrl_group_test.go
@@ -1,0 +1,41 @@
+// Copyright 2023 Antrea Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openflow
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"antrea.io/libOpenflow/openflow15"
+	"antrea.io/ofnet/ofctrl"
+)
+
+func TestGroup(t *testing.T) {
+	group := &ofctrl.Group{
+		ID:      uint32(1),
+		Buckets: []*openflow15.Bucket{},
+	}
+	bktBuilder := bucketBuilder{
+		group: &ofGroup{
+			ofctrl: group,
+		},
+		bucket: &openflow15.Bucket{},
+	}
+	bktBuilder.Group(2)
+	expectedActionGroup, _ := openflow15.NewActionGroup(2).MarshalBinary()
+	actual, _ := bktBuilder.bucket.Actions[0].MarshalBinary()
+	assert.Equal(t, expectedActionGroup, actual)
+}

--- a/pkg/ovs/openflow/testing/mock_openflow.go
+++ b/pkg/ovs/openflow/testing/mock_openflow.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Antrea Authors
+// Copyright 2023 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -2339,6 +2339,20 @@ func (m *MockBucketBuilder) Done() openflow.Group {
 func (mr *MockBucketBuilderMockRecorder) Done() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Done", reflect.TypeOf((*MockBucketBuilder)(nil).Done))
+}
+
+// Group mocks base method
+func (m *MockBucketBuilder) Group(arg0 uint32) openflow.BucketBuilder {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Group", arg0)
+	ret0, _ := ret[0].(openflow.BucketBuilder)
+	return ret0
+}
+
+// Group indicates an expected call of Group
+func (mr *MockBucketBuilderMockRecorder) Group(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Group", reflect.TypeOf((*MockBucketBuilder)(nil).Group), arg0)
 }
 
 // LoadReg mocks base method

--- a/test/integration/agent/openflow_test.go
+++ b/test/integration/agent/openflow_test.go
@@ -783,7 +783,7 @@ func installServiceFlows(t *testing.T, gid uint32, svc svcConfig, endpointList [
 	groupID := ofconfig.GroupIDType(gid)
 	err := c.InstallEndpointFlows(svc.protocol, endpointList)
 	assert.NoError(t, err, "no error should return when installing flows for Endpoints")
-	err = c.InstallServiceGroup(groupID, svc.withSessionAffinity, endpointList)
+	err = c.InstallServiceGroup(groupID, svc.withSessionAffinity, nil, endpointList)
 	assert.NoError(t, err, "no error should return when installing groups for Service")
 	err = c.InstallServiceFlows(groupID, svc.ip, svc.port, svc.protocol, stickyMaxAgeSeconds, false, v1.ServiceTypeClusterIP)
 	assert.NoError(t, err, "no error should return when installing flows for Service")


### PR DESCRIPTION
When the Endpoint of Multi-cluster Service is a local Service ClusterIP, refine the action to let it go to the corresponding exported Service's group to do final Endpoint selection. This can avoid the case that the traffic goes out of antrea-gw0 and goes back to OVS again when a local Pod is trying to access a MC Service but a local Service's Endpoint is selected.

Resolve #4431 
Signed-off-by: Lan Luo <luola@vmware.com>