### PR TITLE
Fail CI when codecov upload failed

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -67,6 +67,7 @@ jobs:
         file: .coverage/coverage-unit.txt
         flags: unit-tests
         name: codecov-unit-test
+        fail_ci_if_error: true
 
   test-unit-windows:
     needs: check-changes
@@ -103,6 +104,7 @@ jobs:
           file: .coverage/coverage-unit.txt
           flags: unit-tests
           name: codecov-unit-test
+          fail_ci_if_error: true
 
   test-integration:
     needs: check-changes
@@ -145,6 +147,7 @@ jobs:
           files: .coverage/coverage-integration.txt,multicluster/.coverage/coverage-integration.txt
           flags: integration-tests
           name: codecov-integration-test
+          fail_ci_if_error: true
 
   # golangci-lint-ubuntu and golangci-lint-macos are intentionally not merged into one job with os matrix, otherwise the
   # job wouldn't be expanded if it's skipped and the report of the required check would be missing.

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -112,6 +112,7 @@ jobs:
         flags: kind-e2e-tests
         name: codecov-test-e2e-encap
         directory: test-e2e-encap-coverage
+        fail_ci_if_error: true
     - name: Tar log files
       if: ${{ failure() }}
       run: tar -czf log.tar.gz log
@@ -170,6 +171,7 @@ jobs:
         flags: kind-e2e-tests
         name: codecov-test-e2e-encap-no-proxy
         directory: test-e2e-encap-no-proxy-coverage
+        fail_ci_if_error: true
     - name: Tar log files
       if: ${{ failure() }}
       run: tar -czf log.tar.gz log
@@ -229,6 +231,7 @@ jobs:
           flags: kind-e2e-tests
           name: codecov-test-e2e-encap-all-features-enabled
           directory: test-e2e-encap-all-features-enabled-coverage
+          fail_ci_if_error: true
       - name: Tar log files
         if: ${{ failure() }}
         run: tar -czf log.tar.gz log
@@ -287,6 +290,7 @@ jobs:
         flags: kind-e2e-tests
         name: codecov-test-e2e-noencap
         directory: test-e2e-noencap-coverage
+        fail_ci_if_error: true
     - name: Tar log files
       if: ${{ failure() }}
       run: tar -czf log.tar.gz log
@@ -345,6 +349,7 @@ jobs:
         flags: kind-e2e-tests
         name: codecov-test-e2e-hybrid
         directory: test-e2e-hybrid-coverage
+        fail_ci_if_error: true
     - name: Tar log files
       if: ${{ failure() }}
       run: tar -czf log.tar.gz log
@@ -410,6 +415,7 @@ jobs:
           flags: kind-e2e-tests
           name: codecov-test-e2e-fa
           directory: test-e2e-fa-coverage
+          fail_ci_if_error: true
       - name: Tar log files
         if: ${{ failure() }}
         run: tar -czf log.tar.gz log


### PR DESCRIPTION
The codecov upload step will still show success when coverage report uploading is actually failed, so set the `fail_ci_if_error` to true to make sure developers be aware that the report upload job need to be re-run when it's failed.

Signed-off-by: Lan Luo <luola@vmware.com>