### PR TITLE
Support wildcards for HTTP path and host in L7NetworkPolicy

### DIFF
--- a/test/e2e/l7networkpolicy_test.go
+++ b/test/e2e/l7networkpolicy_test.go
@@ -150,7 +150,7 @@ func testL7NetworkPolicyHTTP(t *testing.T, data *TestData) {
 		{
 			HTTP: &crdv1alpha1.HTTPProtocol{
 				Method: "GET",
-				Path:   "/hostname",
+				Path:   "/host*",
 			},
 		},
 	}


### PR DESCRIPTION
By default, suricata performs pattern-matching for provided content. To support exact match, prefix match, and suffix match, we use wildcards to indicate whether an exact match is expected.

- A string starting with `*` means suffix match. For example, `"*.foo.com"` matches `"www.foo.com"`.

- A string ending with `*` means prefix match. For example, `"/public/*"` matches `"/public/index.html"`.

- A string starting with and ending with `*` means pattern-matching. For example, `"*/v2/*"` matches `"/api/v2/pods"`.

- A string having no `*` means exact match. For example, `"/index.html"` can only match `"/index.html"`.

Signed-off-by: Quan Tian <qtian@vmware.com>

For https://github.com/antrea-io/antrea/issues/4231