### PR TITLE
Automated cherry pick of #4499: Update remaining images to use ubuntu:22.04 base image

### DIFF
--- a/build/images/Dockerfile.octant.ubuntu
+++ b/build/images/Dockerfile.octant.ubuntu
@@ -24,7 +24,7 @@ WORKDIR /antrea/plugins/octant
 #14 87.20 make: *** [Makefile:16: octant-plugins] Error 2
 RUN CGO_ENABLED=0 make octant-plugins
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="A docker image to deploy octant and antrea related octant plugins."

--- a/build/images/Dockerfile.simulator.build.ubuntu
+++ b/build/images/Dockerfile.simulator.build.ubuntu
@@ -12,7 +12,7 @@ COPY . /antrea
 RUN make antrea-agent-simulator
 
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="The Docker image to deploy the Antrea simulator."

--- a/build/images/codegen/Dockerfile
+++ b/build/images/codegen/Dockerfile
@@ -1,5 +1,5 @@
 ARG GO_VERSION
-FROM ubuntu:20.04 as protoc
+FROM ubuntu:22.04 as protoc
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends wget ca-certificates unzip

--- a/build/images/codegen/README.md
+++ b/build/images/codegen/README.md
@@ -20,6 +20,9 @@ Here is the table of codegen images that have been uploaded:
 
 | Tag                            | Change                                  |
 | :----------------------------- | --------------------------------------- |
+| kubernetes-1.24.0-build.2      | Upgraded base image to ubuntu:22.04     |
+| kubernetes-1.24.0-build.1      | Upgraded Go to v1.19                    |
+| kubernetes-1.24.0-build.0      | Add controller-gen v0.9.0               |
 | kubernetes-1.24.0              | Upgraded K8s libraries to v1.24.0       |
 | kubernetes-1.21.0-build.1      | Upgraded protoc-gen-go to v1.5.2        |
 | kubernetes-1.21.0-build.0      | Upgraded Go to v1.17                    |

--- a/build/images/ethtool/Dockerfile
+++ b/build/images/ethtool/Dockerfile
@@ -1,7 +1,21 @@
-FROM ubuntu:20.04
+# Copyright 2022 Antrea Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM ubuntu:22.04
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
-LABEL description="A Docker image based on Ubuntu 20.04 which includes ethtool, ip tools and iptables."
+LABEL description="A Docker image based on Ubuntu 22.04 which includes ethtool, ip tools and iptables."
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ethtool iproute2 iptables && \

--- a/build/images/ethtool/README.md
+++ b/build/images/ethtool/README.md
@@ -1,6 +1,6 @@
 # images/ethtool
 
-This Docker image is a very lightweight image based on Ubuntu 20.04 which
+This Docker image is a very lightweight image based on Ubuntu 22.04 which
 includes ethtool, the ip tools and iptables.
 
 If you need to build a new version of the image locally, you can run the following:

--- a/build/images/flow-aggregator/Dockerfile
+++ b/build/images/flow-aggregator/Dockerfile
@@ -9,7 +9,7 @@ RUN make flow-aggregator antctl-linux
 RUN mv bin/antctl-linux bin/antctl
 
 # Chose this base image so that a shell is available for users to exec into the container, run antctl and run tools like pprof easily
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="The docker image for the flow aggregator"

--- a/build/images/flow-aggregator/Dockerfile.coverage
+++ b/build/images/flow-aggregator/Dockerfile.coverage
@@ -8,7 +8,7 @@ COPY . /antrea
 RUN make flow-aggregator antctl-linux flow-aggregator-instr-binary antctl-instr-binary
 RUN mv bin/antctl-linux bin/antctl
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="The docker image for the flow aggregator with code coverage measurement enabled for testing purposes."

--- a/build/images/perftool/Dockerfile
+++ b/build/images/perftool/Dockerfile
@@ -1,7 +1,21 @@
-FROM ubuntu:20.04
+# Copyright 2022 Antrea Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM ubuntu:22.04
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
-LABEL description="A Docker image based on Ubuntu 20.04 which is used for performance tests."
+LABEL description="A Docker image based on Ubuntu 22.04 which is used for performance tests."
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends apache2-utils iperf3 && \

--- a/build/images/perftool/README.md
+++ b/build/images/perftool/README.md
@@ -1,6 +1,6 @@
 # images/perftool
 
-This Docker image is a very lightweight image based on Ubuntu 20.04 which
+This Docker image is a very lightweight image based on Ubuntu 22.04 which
 includes the apache2-utils and iperf3 packages.
 
 If you need to build a new version of the image and push it to Dockerhub, you

--- a/build/images/wireguard-go/Dockerfile
+++ b/build/images/wireguard-go/Dockerfile
@@ -15,5 +15,5 @@ RUN git clone https://git.zx2c4.com/wireguard-tools && \
     make && \
     make install
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 COPY --from=builder /usr/bin/wireguard-go /usr/bin/wg /usr/bin/

--- a/build/images/wireguard-go/README.md
+++ b/build/images/wireguard-go/README.md
@@ -1,6 +1,6 @@
 # images/wireguard-go
 
-This Docker image is a very lightweight image based on Ubuntu 20.04 which
+This Docker image is a very lightweight image based on Ubuntu 22.04 which
 includes WireGuard golang implementation and wireguard-tools. It can be used
 for Kind clusters for tests when injected as a sidecar to antrea-agent.
 The version is available at <https://github.com/WireGuard/wireguard-go/releases>.

--- a/docs/cookbooks/multus/build/cni-dhcp-daemon/Dockerfile
+++ b/docs/cookbooks/multus/build/cni-dhcp-daemon/Dockerfile
@@ -1,4 +1,18 @@
-FROM ubuntu:20.04 as cni-binary
+# Copyright 2022 Antrea Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM ubuntu:22.04 as cni-binary
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="A Docker which runs the dhcp daemon from the containernetworking project."
@@ -12,7 +26,7 @@ ENV CNI_PLUGINS="./dhcp"
 RUN mkdir -p /opt/cni/bin && \
     wget -q -O - https://github.com/containernetworking/plugins/releases/download/v0.8.6/cni-plugins-linux-amd64-v0.8.6.tgz | tar xz -C /opt/cni/bin $CNI_PLUGINS
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 COPY --from=cni-binary /opt/cni/bin/* /usr/local/bin
 

--- a/docs/cookbooks/multus/resources/dhcp-daemon.yml
+++ b/docs/cookbooks/multus/resources/dhcp-daemon.yml
@@ -21,7 +21,7 @@ spec:
       hostNetwork: true
       initContainers:
       - name: sock-cleanup
-        image: ubuntu:20.04
+        image: ubuntu:22.04
         command: ["rm", "-f", "/run/cni/dhcp.sock"]
         volumeMounts:
         - name: run

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o pipefail
 
 ANTREA_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
-IMAGE_NAME="antrea/codegen:kubernetes-1.24.0"
+IMAGE_NAME="antrea/codegen:kubernetes-1.24.0-build.0"
 
 function docker_run() {
   docker pull ${IMAGE_NAME}

--- a/multicluster/build/images/Dockerfile.build.coverage
+++ b/multicluster/build/images/Dockerfile.build.coverage
@@ -11,7 +11,7 @@ COPY . /antrea
 
 RUN cd multicluster && make antrea-mc-instr-binary
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="The Docker image to deploy the Antrea Multicluster controller with code coverage measurement enabled (used for testing)."

--- a/test/e2e/infra/vagrant/Vagrantfile
+++ b/test/e2e/infra/vagrant/Vagrantfile
@@ -48,7 +48,7 @@ else
 end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "ubuntu/focal64"
+  config.vm.box = "ubuntu/jammy64"
 
   config.vm.provider "virtualbox" do |v|
     v.memory = MEMORY

--- a/test/e2e/infra/vagrant/playbook/roles/common/templates/containerd.conf.j2
+++ b/test/e2e/infra/vagrant/playbook/roles/common/templates/containerd.conf.j2
@@ -1,39 +1,261 @@
+# This is the default containerd config (generated with "containerd config default"), with a few
+# changes, which are emphasized below using comments.
+# Note that this is the recommended approach for configuring containerd: start with the default
+# config and make the necessary changes. This is because when providing a custom config, the
+# containerd behavior is not to only consider the provided changes and merge them into the default
+# config.
+# See https://github.com/containerd/containerd/issues/6964
+disabled_plugins = []
+imports = []
+oom_score = 0
+plugin_dir = ""
+required_plugins = []
 root = "/var/lib/containerd"
 state = "/run/containerd"
-oom_score = 0
+temp = ""
+version = 2
 
-[grpc]
-  address = "/run/containerd/containerd.sock"
-  uid = 1000
-  gid = 1000
+[cgroup]
+  path = ""
 
+# we configure the address and set uid / gid for the vagrant user
 [debug]
   address = "/run/containerd/debug.sock"
-  uid = 1000
+  format = ""
   gid = 1000
   level = "info"
+  uid = 1000
+
+# we set uid / gid for the vagrant user
+[grpc]
+  address = "/run/containerd/containerd.sock"
+  gid = 1000
+  max_recv_message_size = 16777216
+  max_send_message_size = 16777216
+  tcp_address = ""
+  tcp_tls_ca = ""
+  tcp_tls_cert = ""
+  tcp_tls_key = ""
+  uid = 1000
 
 [metrics]
   address = ""
   grpc_histogram = false
 
-[cgroup]
-  path = ""
-
 [plugins]
-  [plugins.cgroups]
-    no_prometheus = false
-  [plugins.diff]
-    default = ["walking"]
-  [plugins.linux]
-    shim = "containerd-shim"
-    runtime = "runc"
-    runtime_root = ""
-    no_shim = false
-    shim_debug = false
-  [plugins.scheduler]
-    pause_threshold = 0.02
+
+  [plugins."io.containerd.gc.v1.scheduler"]
     deletion_threshold = 0
     mutation_threshold = 100
-    schedule_delay = 0
+    pause_threshold = 0.02
+    schedule_delay = "0s"
     startup_delay = "100ms"
+
+  [plugins."io.containerd.grpc.v1.cri"]
+    device_ownership_from_security_context = false
+    disable_apparmor = false
+    disable_cgroup = false
+    disable_hugetlb_controller = true
+    disable_proc_mount = false
+    disable_tcp_service = true
+    enable_selinux = false
+    enable_tls_streaming = false
+    enable_unprivileged_icmp = false
+    enable_unprivileged_ports = false
+    ignore_image_defined_volumes = false
+    max_concurrent_downloads = 3
+    max_container_log_line_size = 16384
+    netns_mounts_under_state_dir = false
+    restrict_oom_score_adj = false
+    sandbox_image = "registry.k8s.io/pause:3.6"
+    selinux_category_range = 1024
+    stats_collect_period = 10
+    stream_idle_timeout = "4h0m0s"
+    stream_server_address = "127.0.0.1"
+    stream_server_port = "0"
+    systemd_cgroup = false
+    tolerate_missing_hugetlb_controller = true
+    unset_seccomp_profile = ""
+
+    [plugins."io.containerd.grpc.v1.cri".cni]
+      bin_dir = "/opt/cni/bin"
+      conf_dir = "/etc/cni/net.d"
+      conf_template = ""
+      ip_pref = ""
+      max_conf_num = 1
+
+    [plugins."io.containerd.grpc.v1.cri".containerd]
+      default_runtime_name = "runc"
+      disable_snapshot_annotations = true
+      discard_unpacked_layers = false
+      ignore_rdt_not_enabled_errors = false
+      no_pivot = false
+      snapshotter = "overlayfs"
+
+      [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime]
+        base_runtime_spec = ""
+        cni_conf_dir = ""
+        cni_max_conf_num = 0
+        container_annotations = []
+        pod_annotations = []
+        privileged_without_host_devices = false
+        runtime_engine = ""
+        runtime_path = ""
+        runtime_root = ""
+        runtime_type = ""
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime.options]
+
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+          base_runtime_spec = ""
+          cni_conf_dir = ""
+          cni_max_conf_num = 0
+          container_annotations = []
+          pod_annotations = []
+          privileged_without_host_devices = false
+          runtime_engine = ""
+          runtime_path = ""
+          runtime_root = ""
+          runtime_type = "io.containerd.runc.v2"
+
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+            BinaryName = ""
+            CriuImagePath = ""
+            CriuPath = ""
+            CriuWorkPath = ""
+            IoGid = 0
+            IoUid = 0
+            NoNewKeyring = false
+            NoPivotRoot = false
+            Root = ""
+            ShimCgroup = ""
+            # use the systemd cgroup driver, required for K8s
+            SystemdCgroup = true
+
+      [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime]
+        base_runtime_spec = ""
+        cni_conf_dir = ""
+        cni_max_conf_num = 0
+        container_annotations = []
+        pod_annotations = []
+        privileged_without_host_devices = false
+        runtime_engine = ""
+        runtime_path = ""
+        runtime_root = ""
+        runtime_type = ""
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime.options]
+
+    [plugins."io.containerd.grpc.v1.cri".image_decryption]
+      key_model = "node"
+
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      config_path = ""
+
+      [plugins."io.containerd.grpc.v1.cri".registry.auths]
+
+      [plugins."io.containerd.grpc.v1.cri".registry.configs]
+
+      [plugins."io.containerd.grpc.v1.cri".registry.headers]
+
+      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+
+    [plugins."io.containerd.grpc.v1.cri".x509_key_pair_streaming]
+      tls_cert_file = ""
+      tls_key_file = ""
+
+  [plugins."io.containerd.internal.v1.opt"]
+    path = "/opt/containerd"
+
+  [plugins."io.containerd.internal.v1.restart"]
+    interval = "10s"
+
+  [plugins."io.containerd.internal.v1.tracing"]
+    sampling_ratio = 1.0
+    service_name = "containerd"
+
+  [plugins."io.containerd.metadata.v1.bolt"]
+    content_sharing_policy = "shared"
+
+  [plugins."io.containerd.monitor.v1.cgroups"]
+    no_prometheus = false
+
+  [plugins."io.containerd.runtime.v1.linux"]
+    no_shim = false
+    runtime = "runc"
+    runtime_root = ""
+    shim = "containerd-shim"
+    shim_debug = false
+
+  # we comment this out, to avoid hardcoding a platform
+  # [plugins."io.containerd.runtime.v2.task"]
+  #   platforms = ["linux/amd64"]
+  #   sched_core = false
+
+  [plugins."io.containerd.service.v1.diff-service"]
+    default = ["walking"]
+
+  [plugins."io.containerd.service.v1.tasks-service"]
+    rdt_config_file = ""
+
+  [plugins."io.containerd.snapshotter.v1.aufs"]
+    root_path = ""
+
+  [plugins."io.containerd.snapshotter.v1.btrfs"]
+    root_path = ""
+
+  [plugins."io.containerd.snapshotter.v1.devmapper"]
+    async_remove = false
+    base_image_size = ""
+    discard_blocks = false
+    fs_options = ""
+    fs_type = ""
+    pool_name = ""
+    root_path = ""
+
+  [plugins."io.containerd.snapshotter.v1.native"]
+    root_path = ""
+
+  [plugins."io.containerd.snapshotter.v1.overlayfs"]
+    root_path = ""
+    upperdir_label = false
+
+  [plugins."io.containerd.snapshotter.v1.zfs"]
+    root_path = ""
+
+  [plugins."io.containerd.tracing.processor.v1.otlp"]
+    endpoint = ""
+    insecure = false
+    protocol = ""
+
+[proxy_plugins]
+
+[stream_processors]
+
+  [stream_processors."io.containerd.ocicrypt.decoder.v1.tar"]
+    accepts = ["application/vnd.oci.image.layer.v1.tar+encrypted"]
+    args = ["--decryption-keys-path", "/etc/containerd/ocicrypt/keys"]
+    env = ["OCICRYPT_KEYPROVIDER_CONFIG=/etc/containerd/ocicrypt/ocicrypt_keyprovider.conf"]
+    path = "ctd-decoder"
+    returns = "application/vnd.oci.image.layer.v1.tar"
+
+  [stream_processors."io.containerd.ocicrypt.decoder.v1.tar.gzip"]
+    accepts = ["application/vnd.oci.image.layer.v1.tar+gzip+encrypted"]
+    args = ["--decryption-keys-path", "/etc/containerd/ocicrypt/keys"]
+    env = ["OCICRYPT_KEYPROVIDER_CONFIG=/etc/containerd/ocicrypt/ocicrypt_keyprovider.conf"]
+    path = "ctd-decoder"
+    returns = "application/vnd.oci.image.layer.v1.tar+gzip"
+
+[timeouts]
+  "io.containerd.timeout.bolt.open" = "0s"
+  "io.containerd.timeout.shim.cleanup" = "5s"
+  "io.containerd.timeout.shim.load" = "5s"
+  "io.containerd.timeout.shim.shutdown" = "3s"
+  "io.containerd.timeout.task.state" = "2s"
+
+[ttrpc]
+  address = ""
+  gid = 0
+  uid = 0

--- a/test/e2e/infra/vagrant/playbook/roles/control-plane/templates/kubeadm.conf.j2
+++ b/test/e2e/infra/vagrant/playbook/roles/control-plane/templates/kubeadm.conf.j2
@@ -9,7 +9,7 @@ skipPhases:
 - addon/kube-proxy
 {% endif %}
 ---
-apiVersion: kubeadm.k8s.io/v1beta2
+apiVersion: kubeadm.k8s.io/v1beta3
 kind: ClusterConfiguration
 networking:
   podSubnet: "{{ k8s_pod_network_cidr }}"
@@ -29,3 +29,8 @@ ipvs:
   strictARP: true
 {% endif %}
 {% endif %}
+---
+apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+# this is the default starting with v1.22, but we prefer to set it explicitly
+cgroupDriver: systemd


### PR DESCRIPTION
Cherry pick of #4499 on release-1.7.

#4499: Update remaining images to use ubuntu:22.04 base image

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.