### PR TITLE
Fix tunnelDstIP field in traceflow on dual-stack

### DIFF
--- a/pkg/agent/controller/traceflow/packetin.go
+++ b/pkg/agent/controller/traceflow/packetin.go
@@ -237,7 +237,8 @@ func (c *Controller) parsePacketIn(pktIn *ofctrl.PacketIn) (*crdv1alpha1.Tracefl
 	if tableID == openflow.L2ForwardingOutTable.GetID() {
 		ob := new(crdv1alpha1.Observation)
 		tunnelDstIP := ""
-		isIPv6 := c.nodeConfig.NodeIPv6Addr != nil
+		// decide according to packet.
+		isIPv6 := etherData.Ethertype == protocol.IPv6_MSG
 		if match := getMatchTunnelDstField(matchers, isIPv6); match != nil {
 			tunnelDstIP, err = getTunnelDstValue(match)
 			if err != nil {


### PR DESCRIPTION
On dual-stack testbed, Inter-Node traceflow observation for 
IPv4 packet in encap mode has empty tunnelDstIP field because 
`isIPv6` variable is set.

Change the logic to set `isIPv6` variable based on the packet 
IPv4 or IPv6.

Fixes #4502

Signed-off-by: Kumar Atish <atish.iaf@gmail.com>