### PR TITLE
Rename Agent config option multicluster.enable to enableGateway

### DIFF
--- a/build/charts/antrea/README.md
+++ b/build/charts/antrea/README.md
@@ -84,8 +84,8 @@ Kubernetes: `>= 1.16.0-0`
 | logVerbosity | int | `0` |  |
 | multicast.igmpQueryInterval | string | `"125s"` | The interval at which the antrea-agent sends IGMP queries to Pods. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". |
 | multicast.multicastInterfaces | list | `[]` | Names of the interfaces on Nodes that are used to forward multicast traffic. |
-| multicluster.enable | bool | `false` | Enable Antrea Multi-cluster Gateway to support cross-cluster traffic. This feature is supported only with encap mode. |
-| multicluster.enableStretchedNetworkPolicy | bool | `false` | Enable StretchedNetworkPolicy which allows Antrea-native policies to select peers from other clusters in a ClusterSet. This feature is supported only with encap mode. |
+| multicluster.enableGateway | bool | `false` | Enable Antrea Multi-cluster Gateway to support cross-cluster traffic. This feature is supported only with encap mode. |
+| multicluster.enableStretchedNetworkPolicy | bool | `false` | Enable StretchedNetworkPolicy which allows Antrea-native policies to select peers from other clusters in a ClusterSet. Multi-cluster Gateway must be enabled to enable StretchedNetworkPolicy. |
 | multicluster.namespace | string | `""` | The Namespace where Antrea Multi-cluster Controller is running. The default is antrea-agent's Namespace. |
 | noSNAT | bool | `false` | Whether or not to SNAT (using the Node IP) the egress traffic from a Pod to the external network. |
 | nodeIPAM.clusterCIDRs | list | `[]` | CIDR ranges to use when allocating Pod IP addresses. |

--- a/build/charts/antrea/conf/antrea-agent.conf
+++ b/build/charts/antrea/conf/antrea-agent.conf
@@ -49,8 +49,7 @@ featureGates:
 # Enable multicast traffic.
 {{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "Multicast" "default" false) }}
 
-# Enable Antrea Multi-cluster Gateway to support cross-cluster traffic.
-# This feature is supported only with encap mode.
+# Enable Antrea Multi-cluster features.
 {{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "Multicluster" "default" false) }}
 
 # Enable support for provisioning secondary network interfaces for Pods (using
@@ -333,12 +332,13 @@ multicluster:
 {{- with .Values.multicluster }}
 # Enable Antrea Multi-cluster Gateway to support cross-cluster traffic.
 # This feature is supported only with encap mode.
-  enable: {{ .enable }}
+  enableGateway: {{ .enableGateway }}
 # The Namespace where Antrea Multi-cluster Controller is running.
 # The default is antrea-agent's Namespace.
   namespace: {{ .namespace | quote }}
-# Enable StretchedNetworkPolicy which could be enforced on cross-cluster traffic.
-# This feature is supported only with encap mode.
+# Enable StretchedNetworkPolicy which allows Antrea-native policies to select peers
+# from other clusters in a ClusterSet.
+# Multi-cluster Gateway must be enabled to enable StretchedNetworkPolicy.
   enableStretchedNetworkPolicy: {{ .enableStretchedNetworkPolicy }}
 {{- end }}
 

--- a/build/charts/antrea/conf/antrea-controller.conf
+++ b/build/charts/antrea/conf/antrea-controller.conf
@@ -43,7 +43,7 @@ featureGates:
 # Enable collecting support bundle files with SupportBundleCollection CRD.
 {{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "SupportBundleCollection" "default" false) }}
 
-# Enable multi-cluster features.
+# Enable Antrea Multi-cluster features.
 {{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "Multicluster" "default" false) }}
 
 # Enable users to protect their applications by specifying how they are allowed to communicate with others, taking

--- a/build/charts/antrea/values.yaml
+++ b/build/charts/antrea/values.yaml
@@ -323,13 +323,13 @@ whereabouts:
 multicluster:
   # -- Enable Antrea Multi-cluster Gateway to support cross-cluster traffic.
   # This feature is supported only with encap mode.
-  enable: false
+  enableGateway: false
   # -- The Namespace where Antrea Multi-cluster Controller is running.
   # The default is antrea-agent's Namespace.
   namespace: ""
   # -- Enable StretchedNetworkPolicy which allows Antrea-native policies to select peers
   # from other clusters in a ClusterSet.
-  # This feature is supported only with encap mode.
+  # Multi-cluster Gateway must be enabled to enable StretchedNetworkPolicy.
   enableStretchedNetworkPolicy: false
 
 testing:

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -2972,8 +2972,7 @@ data:
     # Enable multicast traffic.
     #  Multicast: false
 
-    # Enable Antrea Multi-cluster Gateway to support cross-cluster traffic.
-    # This feature is supported only with encap mode.
+    # Enable Antrea Multi-cluster features.
     #  Multicluster: false
 
     # Enable support for provisioning secondary network interfaces for Pods (using
@@ -3228,12 +3227,13 @@ data:
     multicluster:
     # Enable Antrea Multi-cluster Gateway to support cross-cluster traffic.
     # This feature is supported only with encap mode.
-      enable: false
+      enableGateway: false
     # The Namespace where Antrea Multi-cluster Controller is running.
     # The default is antrea-agent's Namespace.
       namespace: ""
-    # Enable StretchedNetworkPolicy which could be enforced on cross-cluster traffic.
-    # This feature is supported only with encap mode.
+    # Enable StretchedNetworkPolicy which allows Antrea-native policies to select peers
+    # from other clusters in a ClusterSet.
+    # Multi-cluster Gateway must be enabled to enable StretchedNetworkPolicy.
       enableStretchedNetworkPolicy: false
   antrea-cni.conflist: |
     {
@@ -3304,7 +3304,7 @@ data:
     # Enable collecting support bundle files with SupportBundleCollection CRD.
     #  SupportBundleCollection: false
 
-    # Enable multi-cluster features.
+    # Enable Antrea Multi-cluster features.
     #  Multicluster: false
 
     # Enable users to protect their applications by specifying how they are allowed to communicate with others, taking
@@ -4293,7 +4293,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 7b21809cc047cd7464cdb8789428396de9dcf2684166821d8e5dbd7816e005c4
+        checksum/config: 5863dc7db71990f4adebcf03cd8311ce14d9a233129c909a872f2f14e0e022fa
       labels:
         app: antrea
         component: antrea-agent
@@ -4534,7 +4534,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 7b21809cc047cd7464cdb8789428396de9dcf2684166821d8e5dbd7816e005c4
+        checksum/config: 5863dc7db71990f4adebcf03cd8311ce14d9a233129c909a872f2f14e0e022fa
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -2972,8 +2972,7 @@ data:
     # Enable multicast traffic.
     #  Multicast: false
 
-    # Enable Antrea Multi-cluster Gateway to support cross-cluster traffic.
-    # This feature is supported only with encap mode.
+    # Enable Antrea Multi-cluster features.
     #  Multicluster: false
 
     # Enable support for provisioning secondary network interfaces for Pods (using
@@ -3228,12 +3227,13 @@ data:
     multicluster:
     # Enable Antrea Multi-cluster Gateway to support cross-cluster traffic.
     # This feature is supported only with encap mode.
-      enable: false
+      enableGateway: false
     # The Namespace where Antrea Multi-cluster Controller is running.
     # The default is antrea-agent's Namespace.
       namespace: ""
-    # Enable StretchedNetworkPolicy which could be enforced on cross-cluster traffic.
-    # This feature is supported only with encap mode.
+    # Enable StretchedNetworkPolicy which allows Antrea-native policies to select peers
+    # from other clusters in a ClusterSet.
+    # Multi-cluster Gateway must be enabled to enable StretchedNetworkPolicy.
       enableStretchedNetworkPolicy: false
   antrea-cni.conflist: |
     {
@@ -3304,7 +3304,7 @@ data:
     # Enable collecting support bundle files with SupportBundleCollection CRD.
     #  SupportBundleCollection: false
 
-    # Enable multi-cluster features.
+    # Enable Antrea Multi-cluster features.
     #  Multicluster: false
 
     # Enable users to protect their applications by specifying how they are allowed to communicate with others, taking
@@ -4293,7 +4293,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 7b21809cc047cd7464cdb8789428396de9dcf2684166821d8e5dbd7816e005c4
+        checksum/config: 5863dc7db71990f4adebcf03cd8311ce14d9a233129c909a872f2f14e0e022fa
       labels:
         app: antrea
         component: antrea-agent
@@ -4536,7 +4536,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 7b21809cc047cd7464cdb8789428396de9dcf2684166821d8e5dbd7816e005c4
+        checksum/config: 5863dc7db71990f4adebcf03cd8311ce14d9a233129c909a872f2f14e0e022fa
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -2972,8 +2972,7 @@ data:
     # Enable multicast traffic.
     #  Multicast: false
 
-    # Enable Antrea Multi-cluster Gateway to support cross-cluster traffic.
-    # This feature is supported only with encap mode.
+    # Enable Antrea Multi-cluster features.
     #  Multicluster: false
 
     # Enable support for provisioning secondary network interfaces for Pods (using
@@ -3228,12 +3227,13 @@ data:
     multicluster:
     # Enable Antrea Multi-cluster Gateway to support cross-cluster traffic.
     # This feature is supported only with encap mode.
-      enable: false
+      enableGateway: false
     # The Namespace where Antrea Multi-cluster Controller is running.
     # The default is antrea-agent's Namespace.
       namespace: ""
-    # Enable StretchedNetworkPolicy which could be enforced on cross-cluster traffic.
-    # This feature is supported only with encap mode.
+    # Enable StretchedNetworkPolicy which allows Antrea-native policies to select peers
+    # from other clusters in a ClusterSet.
+    # Multi-cluster Gateway must be enabled to enable StretchedNetworkPolicy.
       enableStretchedNetworkPolicy: false
   antrea-cni.conflist: |
     {
@@ -3304,7 +3304,7 @@ data:
     # Enable collecting support bundle files with SupportBundleCollection CRD.
     #  SupportBundleCollection: false
 
-    # Enable multi-cluster features.
+    # Enable Antrea Multi-cluster features.
     #  Multicluster: false
 
     # Enable users to protect their applications by specifying how they are allowed to communicate with others, taking
@@ -4293,7 +4293,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: f6d41cf17b8d26efc6cc18a1609cf3fb5f1a86c538423ae2925b689bf153937a
+        checksum/config: 91c75022e7c9a8203230275e9cccae335c2590ebd03432e97c62db5318bda8f1
       labels:
         app: antrea
         component: antrea-agent
@@ -4533,7 +4533,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: f6d41cf17b8d26efc6cc18a1609cf3fb5f1a86c538423ae2925b689bf153937a
+        checksum/config: 91c75022e7c9a8203230275e9cccae335c2590ebd03432e97c62db5318bda8f1
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -2985,8 +2985,7 @@ data:
     # Enable multicast traffic.
     #  Multicast: false
 
-    # Enable Antrea Multi-cluster Gateway to support cross-cluster traffic.
-    # This feature is supported only with encap mode.
+    # Enable Antrea Multi-cluster features.
     #  Multicluster: false
 
     # Enable support for provisioning secondary network interfaces for Pods (using
@@ -3241,12 +3240,13 @@ data:
     multicluster:
     # Enable Antrea Multi-cluster Gateway to support cross-cluster traffic.
     # This feature is supported only with encap mode.
-      enable: false
+      enableGateway: false
     # The Namespace where Antrea Multi-cluster Controller is running.
     # The default is antrea-agent's Namespace.
       namespace: ""
-    # Enable StretchedNetworkPolicy which could be enforced on cross-cluster traffic.
-    # This feature is supported only with encap mode.
+    # Enable StretchedNetworkPolicy which allows Antrea-native policies to select peers
+    # from other clusters in a ClusterSet.
+    # Multi-cluster Gateway must be enabled to enable StretchedNetworkPolicy.
       enableStretchedNetworkPolicy: false
   antrea-cni.conflist: |
     {
@@ -3317,7 +3317,7 @@ data:
     # Enable collecting support bundle files with SupportBundleCollection CRD.
     #  SupportBundleCollection: false
 
-    # Enable multi-cluster features.
+    # Enable Antrea Multi-cluster features.
     #  Multicluster: false
 
     # Enable users to protect their applications by specifying how they are allowed to communicate with others, taking
@@ -4306,7 +4306,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: f5735f8044ed27afdd88d1d3e120a60aaef5e513bfe15602f958d6f33b0c487a
+        checksum/config: f5f411ec50782205ed224633b7ff5c9c2712e2ac10666bc78ff1d2929f850999
         checksum/ipsec-secret: d0eb9c52d0cd4311b6d252a951126bf9bea27ec05590bed8a394f0f792dcb2a4
       labels:
         app: antrea
@@ -4592,7 +4592,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: f5735f8044ed27afdd88d1d3e120a60aaef5e513bfe15602f958d6f33b0c487a
+        checksum/config: f5f411ec50782205ed224633b7ff5c9c2712e2ac10666bc78ff1d2929f850999
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -2972,8 +2972,7 @@ data:
     # Enable multicast traffic.
     #  Multicast: false
 
-    # Enable Antrea Multi-cluster Gateway to support cross-cluster traffic.
-    # This feature is supported only with encap mode.
+    # Enable Antrea Multi-cluster features.
     #  Multicluster: false
 
     # Enable support for provisioning secondary network interfaces for Pods (using
@@ -3228,12 +3227,13 @@ data:
     multicluster:
     # Enable Antrea Multi-cluster Gateway to support cross-cluster traffic.
     # This feature is supported only with encap mode.
-      enable: false
+      enableGateway: false
     # The Namespace where Antrea Multi-cluster Controller is running.
     # The default is antrea-agent's Namespace.
       namespace: ""
-    # Enable StretchedNetworkPolicy which could be enforced on cross-cluster traffic.
-    # This feature is supported only with encap mode.
+    # Enable StretchedNetworkPolicy which allows Antrea-native policies to select peers
+    # from other clusters in a ClusterSet.
+    # Multi-cluster Gateway must be enabled to enable StretchedNetworkPolicy.
       enableStretchedNetworkPolicy: false
   antrea-cni.conflist: |
     {
@@ -3304,7 +3304,7 @@ data:
     # Enable collecting support bundle files with SupportBundleCollection CRD.
     #  SupportBundleCollection: false
 
-    # Enable multi-cluster features.
+    # Enable Antrea Multi-cluster features.
     #  Multicluster: false
 
     # Enable users to protect their applications by specifying how they are allowed to communicate with others, taking
@@ -4293,7 +4293,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: e89bb782608697941dc73d3b38a678483ec45559a617d8ed614c1397abb40524
+        checksum/config: 78d8f9c7ce769c65649147b1c66f47998739b3b7b73f6981ccb488f320d04452
       labels:
         app: antrea
         component: antrea-agent
@@ -4533,7 +4533,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: e89bb782608697941dc73d3b38a678483ec45559a617d8ed614c1397abb40524
+        checksum/config: 78d8f9c7ce769c65649147b1c66f47998739b3b7b73f6981ccb488f320d04452
       labels:
         app: antrea
         component: antrea-controller

--- a/ci/jenkins/test-mc.sh
+++ b/ci/jenkins/test-mc.sh
@@ -252,7 +252,7 @@ function modify_config {
   if [[ ${ENABLE_MC_GATEWAY} == "true" ]]; then
   cat > build/yamls/chart-values/antrea.yml << EOF
 multicluster:
-  enable: true
+  enableGateway: true
   enableStretchedNetworkPolicy: true
 featureGates: {
   Multicluster: true

--- a/cmd/antrea-agent/options_linux_test.go
+++ b/cmd/antrea-agent/options_linux_test.go
@@ -1,0 +1,125 @@
+//go:build linux
+// +build linux
+
+// Copyright 2023 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	agentconfig "antrea.io/antrea/pkg/config/agent"
+	"antrea.io/antrea/pkg/features"
+)
+
+func TestMulticlusterOptions(t *testing.T) {
+	tests := []struct {
+		name        string
+		mcConfig    agentconfig.MulticlusterConfig
+		featureGate bool
+		encapMode   string
+		expectedErr string
+	}{
+		{
+			name:        "empty input",
+			mcConfig:    agentconfig.MulticlusterConfig{},
+			expectedErr: "",
+		},
+		{
+			name:        "empty input with feature enabled",
+			mcConfig:    agentconfig.MulticlusterConfig{},
+			featureGate: true,
+			expectedErr: "",
+		},
+		{
+			name: "Enable",
+			mcConfig: agentconfig.MulticlusterConfig{
+				Enable: true,
+			},
+			featureGate: true,
+			expectedErr: "",
+		},
+		{
+			name: "Enable and EnableGateway",
+			mcConfig: agentconfig.MulticlusterConfig{
+				Enable:        true,
+				EnableGateway: true,
+			},
+			featureGate: true,
+			expectedErr: "",
+		},
+		{
+			name: "EnableGateway and EnableStretchedNetworkPolicy",
+			mcConfig: agentconfig.MulticlusterConfig{
+				EnableGateway:                true,
+				EnableStretchedNetworkPolicy: true,
+			},
+			featureGate: true,
+			expectedErr: "",
+		},
+		{
+			name: "EnableGateway false and EnableStretchedNetworkPolicy",
+			mcConfig: agentconfig.MulticlusterConfig{
+				EnableStretchedNetworkPolicy: true,
+			},
+			featureGate: true,
+			expectedErr: "Multi-cluster Gateway must be enabled to enable StretchedNetworkPolicy",
+		},
+		{
+			name: "NoEncap",
+			mcConfig: agentconfig.MulticlusterConfig{
+				EnableGateway: true,
+			},
+			featureGate: true,
+			encapMode:   "NoEncap",
+			expectedErr: "Multicluster is only applicable to the encap mode",
+		},
+		{
+			name: "NoEncap and feature disabled",
+			mcConfig: agentconfig.MulticlusterConfig{
+				EnableGateway: true,
+			},
+			encapMode:   "noEncap",
+			expectedErr: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &agentconfig.AgentConfig{
+				FeatureGates:     map[string]bool{"Multicluster": tt.featureGate},
+				TrafficEncapMode: tt.encapMode,
+				Multicluster:     tt.mcConfig,
+			}
+			o := &Options{config: config}
+			features.DefaultMutableFeatureGate.SetFromMap(o.config.FeatureGates)
+			o.setDefaults()
+			if tt.mcConfig.Enable && tt.featureGate {
+				assert.True(t, o.config.Multicluster.EnableGateway)
+			}
+			if !tt.mcConfig.Enable && !tt.mcConfig.EnableGateway {
+				assert.False(t, o.config.Multicluster.EnableGateway)
+			}
+
+			err := o.validate(nil)
+			if tt.expectedErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tt.expectedErr)
+			}
+		})
+	}
+}

--- a/cmd/antrea-controller/options.go
+++ b/cmd/antrea-controller/options.go
@@ -85,8 +85,8 @@ func (o *Options) validate(args []string) error {
 		klog.InfoS("The legacyCRDMirroring config option is deprecated and will be ignored (no CRD mirroring)")
 	}
 
-	if o.config.Multicluster.EnableStretchedNetworkPolicy && !features.DefaultFeatureGate.Enabled(features.Multicluster) {
-		return fmt.Errorf("EnableStretchedNetworkPolicy requires Multicluster feature gate is enabled")
+	if !features.DefaultFeatureGate.Enabled(features.Multicluster) && o.config.Multicluster.EnableStretchedNetworkPolicy {
+		klog.InfoS("Multicluster feature gate is disabled. Multicluster.EnableStretchedNetworkPolicy is ignored")
 	}
 
 	return nil

--- a/docs/feature-gates.md
+++ b/docs/feature-gates.md
@@ -319,14 +319,15 @@ for more information.
 ### Multicluster
 
 The `Multicluster` feature gate of Antrea Agent enables [Antrea Multi-cluster Gateways](multicluster/user-guide.md#multi-cluster-gateway-configuration)
-which route Multi-cluster Service and Pod traffic through tunnels across clusters. The `Multicluster` feature gate
-of Antrea Controller enables support for [Multi-cluster NetworkPolicy](multicluster/user-guide.md#networkpolicy-for-cross-cluster-traffic).
+which route Multi-cluster Service and Pod traffic through tunnels across clusters, and support for
+[ingress Multi-cluster NetworkPolicy](multicluster/user-guide.md#ingress-networkpolicy-for-cross-cluster-traffic).
+The `Multicluster` feature gate of Antrea Controller enables support for [Multi-cluster NetworkPolicy](multicluster/user-guide.md#networkpolicy-for-cross-cluster-traffic).
 
 #### Requirements for this Feature
 
-User should install Antrea Multi-cluster controllers in a ClusterSet to enable multi-cluster Service and Pod access
-across a group of member clusters. This feature is currently only supported for IPv4. Refer to this
-[document](multicluster/architecture.md) for more details.
+Antrea Multi-cluster Controller must be deployed and the cluster must join a Multi-cluster ClusterSet to configure
+Antrea Multi-cluster features. Refer to [Antrea Multi-cluster user guide](multicluster/user-guide.md) for more
+information about Multi-cluster configuration. At the moment, Antrea Multi-cluster supports only IPv4.
 
 ### ExternalNode
 

--- a/docs/multicluster/quick-start.md
+++ b/docs/multicluster/quick-start.md
@@ -43,7 +43,7 @@ antrea-agent.conf: |
     Multicluster: true
 ...
   multicluster:
-    enable: true
+    enableGateway: true
     namespace: ""
 ```
 
@@ -187,8 +187,9 @@ $kubectl annotate node node-b1 multicluster.antrea.io/gateway=true
 
 So far, we set up an Antrea Multi-cluster ClusterSet with two clusters following
 the above sections of this guide. Next, you can start to consume the Antrea
-Multi-cluster features with the ClusterSet, including [Multi-cluster Services](user-guide.md#multi-cluster-service)
-and [ClusterNetworkPolicy Replication](user-guide.md#multi-cluster-clusternetworkpolicy-replication).
+Multi-cluster features with the ClusterSet, including [Multi-cluster Services](user-guide.md#multi-cluster-service),
+[ClusterNetworkPolicy replication](user-guide.md#multi-cluster-clusternetworkpolicy-replication),
+and [NetworkPolicy for cross-cluster traffic](user-guide.md#networkpolicy-for-cross-cluster-traffic).
 Please check the relevant Antrea Multi-cluster User Guide sections to learn more.
 
 If you want to add a new member cluster to your ClusterSet, you can follow the

--- a/docs/multicluster/user-guide.md
+++ b/docs/multicluster/user-guide.md
@@ -75,8 +75,8 @@ antrea-agent.conf: |
     Multicluster: true
 ...
   multicluster:
-    enable: true
-    namespace: ""
+    enableGateway: true
+    namespace: "" # Change to the Namespace where antrea-mc-controller is deployed.
 ```
 
 At the moment, Multi-cluster Gateway only works with the Antrea `encap` traffic

--- a/multicluster/build/images/Dockerfile.build
+++ b/multicluster/build/images/Dockerfile.build
@@ -28,7 +28,7 @@ RUN cd multicluster && make build
 FROM gcr.io/distroless/static:nonroot
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
-LABEL description="The Docker image to deploy the Antrea Multicluster controller."
+LABEL description="The Docker image to deploy the Antrea Multi-cluster Controller."
 
 USER root
 

--- a/multicluster/build/images/Dockerfile.build.coverage
+++ b/multicluster/build/images/Dockerfile.build.coverage
@@ -28,7 +28,7 @@ RUN cd multicluster && make antrea-mc-instr-binary
 FROM ubuntu:22.04
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
-LABEL description="The Docker image to deploy the Antrea Multicluster controller with code coverage measurement enabled (used for testing)."
+LABEL description="The Docker image to deploy the Antrea Multi-cluster Controller with code coverage measurement enabled (used for testing)."
 
 USER root
 

--- a/pkg/config/agent/config.go
+++ b/pkg/config/agent/config.go
@@ -279,13 +279,16 @@ type IPsecConfig struct {
 }
 
 type MulticlusterConfig struct {
-	// Enable Multicluster which allows cross-cluster traffic between member clusters
-	// in a ClusterSet.
+	// Deprecated and replaced by "enableGateway". Keep the field in MulticlusterConfig to be
+	// compatible with earlier version (<= v1.10) Antrea deployment manifests.
 	Enable bool `yaml:"enable,omitempty"`
-	// The Namespace where the Antrea Multi-cluster controller is running.
+	// Enable Multi-cluster Gateway.
+	EnableGateway bool `yaml:"enableGateway,omitempty"`
+	// The Namespace where Antrea Multi-cluster Controller is running.
 	// The default is antrea-agent's Namespace.
 	Namespace string `yaml:"namespace,omitempty"`
-	// Enable StretchedNetworkPolicy which could be enforced on cross-cluster traffic.
+	// Enable StretchedNetworkPolicy which allows Antrea-native policies to select peers from
+	// other clusters in a ClusterSet.
 	EnableStretchedNetworkPolicy bool `yaml:"enableStretchedNetworkPolicy,omitempty"`
 }
 


### PR DESCRIPTION
To be compatible with earlier version deployment manifests, set multicluster.enableGateway to true if multicluster.enable is set to true.
Also change the validation logic to ingore Multi-cluster options if the Multicluster feature gate is disabled, to be consistent with other features.

Signed-off-by: Jianjun Shen <shenj@vmware.com>