### PR TITLE
Exclude https://suricata.io/ from markdown link checker

### DIFF
--- a/hack/.md_links_config.json
+++ b/hack/.md_links_config.json
@@ -29,6 +29,9 @@
         },
         {
             "pattern": "https://avinetworks.com/*"
+        },
+        {
+            "pattern": "https://suricata.io/"
         }
     ],
     "retryOn429": false,


### PR DESCRIPTION
The HTTP requests seem to fail consistently, maybe because of some DDOS protection.

Signed-off-by: Antonin Bas <abas@vmware.com>