### PR TITLE
Use longer timeout in MCNP UT

### DIFF
--- a/pkg/agent/multicluster/stretched_networkpolicy_controller_test.go
+++ b/pkg/agent/multicluster/stretched_networkpolicy_controller_test.go
@@ -45,8 +45,8 @@ import (
 )
 
 const (
-	interval = time.Millisecond
-	timeout  = time.Second
+	interval = 10 * time.Millisecond
+	timeout  = 2 * time.Second
 )
 
 type fakeStretchedNetworkPolicyController struct {


### PR DESCRIPTION
This PR change to use a longer timeout in Multi-cluster NetworkPolicy UT.

Recently, we notice that Multi-cluster NetworkPolicy UT is flaky. The err shows that it timeout while waiting for the Pod to be created.

One flake example:
https://github.com/antrea-io/antrea/actions/runs/3733157661/jobs/6333694462

Signed-off-by: graysonwu <wgrayson@vmware.com>