### PR TITLE
[ExternalNode] Create Secret for vm-agent in RBAC

### DIFF
--- a/build/yamls/externalnode/vm-agent-rbac.yml
+++ b/build/yamls/externalnode/vm-agent-rbac.yml
@@ -5,6 +5,15 @@ metadata:
   name: vm-agent
   namespace: vm-ns # Change the Namespace to where vm-agent is expected to run.
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vm-agent-service-account-token
+  namespace: vm-ns  # Change the Namespace to where vm-agent is expected to run.
+  annotations:
+    kubernetes.io/service-account.name: vm-agent
+type: kubernetes.io/service-account-token
+---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/docs/external-node.md
+++ b/docs/external-node.md
@@ -208,7 +208,7 @@ spec:
    NAMESPACE="vm-ns"
    KUBECONFIG="antrea-agent.kubeconfig"
    APISERVER=$(kubectl config view -o jsonpath="{.clusters[?(@.name==\"$CLUSTER_NAME\")].cluster.server}")
-   TOKEN=$(kubectl -n $NAMESPACE get secrets -o jsonpath="{.items[?(@.metadata.annotations['kubernetes\.io/service-account\.name']=='$SERVICE_ACCOUNT')].data.token}"|base64 --decode)
+   TOKEN=$(kubectl -n $NAMESPACE get secrets -o jsonpath="{.items[?(@.metadata.name=='${SERVICE_ACCOUNT}-service-account-token')].data.token}"|base64 --decode)
    kubectl config --kubeconfig=$KUBECONFIG set-cluster $CLUSTER_NAME --server=$APISERVER --insecure-skip-tls-verify=true
    kubectl config --kubeconfig=$KUBECONFIG set-credentials antrea-agent --token=$TOKEN
    kubectl config --kubeconfig=$KUBECONFIG set-context antrea-agent@$CLUSTER_NAME --cluster=$CLUSTER_NAME --user=antrea-agent
@@ -226,7 +226,7 @@ spec:
    ANTREA_CLUSTER_NAME="antrea"
    NAMESPACE="vm-ns"
    KUBECONFIG="antrea-agent.antrea.kubeconfig"
-   TOKEN=$(kubectl -n $NAMESPACE get secrets -o jsonpath="{.items[?(@.metadata.annotations['kubernetes\.io/service-account\.name']=='$SERVICE_ACCOUNT')].data.token}"|base64 --decode)
+   TOKEN=$(kubectl -n $NAMESPACE get secrets -o jsonpath="{.items[?(@.metadata.name=='${SERVICE_ACCOUNT}-service-account-token')].data.token}"|base64 --decode)
    kubectl config --kubeconfig=$KUBECONFIG set-cluster $ANTREA_CLUSTER_NAME --server=$ANTREA_API_SERVER --insecure-skip-tls-verify=true
    kubectl config --kubeconfig=$KUBECONFIG set-credentials antrea-agent --token=$TOKEN
    kubectl config --kubeconfig=$KUBECONFIG set-context antrea-agent@$ANTREA_CLUSTER_NAME --cluster=$ANTREA_CLUSTER_NAME --user=antrea-agent


### PR DESCRIPTION
1. Crate a separate Secret for VM Agent in RBAC file, because the Secret for a ServiceAccount is not created automatically since K8s v1.24.
2. Use the manually created Secret in Agent kubeconfig file.

Fix #4558 

Signed-off-by: wenyingd <wenyingd@vmware.com>