### PR TITLE
[WIP] [ExternalNode] Controller validates connection peer 

### DIFF
--- a/build/charts/antrea/crds/externalnode.yaml
+++ b/build/charts/antrea/crds/externalnode.yaml
@@ -38,6 +38,8 @@ spec:
                             - format: ipv6
                       name:
                         type: string
+                secret:
+                  type: string
       served: true
       storage: true
   scope: Namespaced

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -1382,6 +1382,8 @@ spec:
                             - format: ipv6
                       name:
                         type: string
+                secret:
+                  type: string
       served: true
       storage: true
   scope: Namespaced

--- a/build/yamls/antrea-crds.yml
+++ b/build/yamls/antrea-crds.yml
@@ -1367,6 +1367,8 @@ spec:
                             - format: ipv6
                       name:
                         type: string
+                secret:
+                  type: string
       served: true
       storage: true
   scope: Namespaced

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -1382,6 +1382,8 @@ spec:
                             - format: ipv6
                       name:
                         type: string
+                secret:
+                  type: string
       served: true
       storage: true
   scope: Namespaced

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -1382,6 +1382,8 @@ spec:
                             - format: ipv6
                       name:
                         type: string
+                secret:
+                  type: string
       served: true
       storage: true
   scope: Namespaced

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -1382,6 +1382,8 @@ spec:
                             - format: ipv6
                       name:
                         type: string
+                secret:
+                  type: string
       served: true
       storage: true
   scope: Namespaced

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -1382,6 +1382,8 @@ spec:
                             - format: ipv6
                       name:
                         type: string
+                secret:
+                  type: string
       served: true
       storage: true
   scope: Namespaced

--- a/go.mod
+++ b/go.mod
@@ -67,6 +67,7 @@ require (
 	google.golang.org/grpc v1.50.1
 	google.golang.org/protobuf v1.28.1
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
+	gopkg.in/square/go-jose.v2 v2.2.2
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.24.0

--- a/go.sum
+++ b/go.sum
@@ -1550,6 +1550,7 @@ gopkg.in/jcmturner/rpc.v1 v1.1.0/go.mod h1:YIdkC4XfD6GXbzje11McwsDuOlZQSb9W4vfLv
 gopkg.in/natefinch/lumberjack.v2 v2.0.0 h1:1Lc07Kr7qY4U2YPouBjpCLxpiyxIVoxqXgkXLknAOE8=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
+gopkg.in/square/go-jose.v2 v2.2.2 h1:orlkJ3myw8CN1nVQHBFfloD+L3egixIa4FvUP6RosSA=
 gopkg.in/square/go-jose.v2 v2.2.2/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=

--- a/pkg/apis/crd/v1alpha1/types.go
+++ b/pkg/apis/crd/v1alpha1/types.go
@@ -761,6 +761,8 @@ type ExternalNodeSpec struct {
 	// Only one network interface is supported now.
 	// Other interfaces except interfaces[0] will be ignored if there are more than one interfaces.
 	Interfaces []NetworkInterface `json:"interfaces,omitempty"`
+	// Secret name bound with the token that Agent is using.
+	Secret string `json:"secret,omitempty"`
 }
 
 type NetworkInterface struct {

--- a/pkg/controller/externalnode/auth_handler.go
+++ b/pkg/controller/externalnode/auth_handler.go
@@ -1,0 +1,377 @@
+// Copyright 2023 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package externalnode
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"gopkg.in/square/go-jose.v2/jwt"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apiserver/pkg/authentication/authenticator"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+
+	"antrea.io/antrea/pkg/apis/crd/v1alpha1"
+	externalnodeinformers "antrea.io/antrea/pkg/client/informers/externalversions/crd/v1alpha1"
+	externalnodelisters "antrea.io/antrea/pkg/client/listers/crd/v1alpha1"
+	"antrea.io/antrea/pkg/util/k8s"
+)
+
+const (
+	secretIndexName = "namespace-secret"
+	legacyIssuer    = "kubernetes/serviceaccount"
+)
+
+type claims interface {
+	getNamespace() string
+	getServiceAccount() string
+	getSecretName() string
+	getPodName() string
+}
+
+type legacyClaims struct {
+	ServiceAccountName string `json:"kubernetes.io/serviceaccount/service-account.name"`
+	ServiceAccountUID  string `json:"kubernetes.io/serviceaccount/service-account.uid"`
+	SecretName         string `json:"kubernetes.io/serviceaccount/secret.name"`
+	Namespace          string `json:"kubernetes.io/serviceaccount/namespace"`
+}
+
+func (c *legacyClaims) getNamespace() string {
+	return c.Namespace
+}
+
+func (c *legacyClaims) getServiceAccount() string {
+	return c.ServiceAccountName
+}
+
+func (c *legacyClaims) getSecretName() string {
+	return c.SecretName
+}
+
+func (c *legacyClaims) getPodName() string {
+	return ""
+}
+
+// privateClaims is used for the manually created token on kubernetes Service
+type privateClaims struct {
+	Kubernetes kubernetes `json:"kubernetes.io,omitempty"`
+}
+
+type kubernetes struct {
+	Namespace string `json:"namespace,omitempty"`
+	Svcacct   ref    `json:"serviceaccount,omitempty"`
+	Pod       *ref   `json:"pod,omitempty"`
+	Secret    *ref   `json:"secret,omitempty"`
+}
+
+func (c *privateClaims) getNamespace() string {
+	return c.Kubernetes.Namespace
+}
+
+func (c *privateClaims) getServiceAccount() string {
+	return c.Kubernetes.Svcacct.Name
+}
+
+func (c *privateClaims) getSecretName() string {
+	if c.Kubernetes.Secret == nil {
+		return ""
+	}
+	return c.Kubernetes.Secret.Name
+}
+
+func (c *privateClaims) getPodName() string {
+	if c.Kubernetes.Pod == nil {
+		return ""
+	}
+	return c.Kubernetes.Pod.Name
+}
+
+type ref struct {
+	Name string `json:"name,omitempty"`
+	UID  string `json:"uid,omitempty"`
+}
+
+type secretTokenAuth struct {
+	externalNodeInformer     externalnodeinformers.ExternalNodeInformer
+	externalNodeLister       externalnodelisters.ExternalNodeLister
+	externalNodeListerSynced cache.InformerSynced
+	secretNodeStore          cache.Indexer
+}
+
+type secretNodePair struct {
+	namespace  string
+	secretName string
+	nodeName   string
+}
+
+func newSecretTokenAuthenticator(externalNodeInformer externalnodeinformers.ExternalNodeInformer) *secretTokenAuth {
+	auth := &secretTokenAuth{
+		externalNodeInformer:     externalNodeInformer,
+		externalNodeLister:       externalNodeInformer.Lister(),
+		externalNodeListerSynced: externalNodeInformer.Informer().HasSynced,
+		secretNodeStore: cache.NewIndexer(nodeKeyFunc, cache.Indexers{
+			secretIndexName: secretIndexFunc,
+		}),
+	}
+	auth.externalNodeInformer.Informer().AddEventHandlerWithResyncPeriod(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc:    auth.externalNodeAdd,
+			UpdateFunc: auth.externalNodeUpdate,
+			DeleteFunc: auth.externalNodeDelete,
+		},
+		resyncPeriod)
+	return auth
+}
+
+func secretIndexFunc(obj interface{}) ([]string, error) {
+	pair := obj.(*secretNodePair)
+	if pair.secretName == "" {
+		return []string{}, nil
+	}
+	namespacedName := k8s.NamespacedName(pair.namespace, pair.secretName)
+	return []string{namespacedName}, nil
+}
+
+func nodeKeyFunc(obj interface{}) (string, error) {
+	pair := obj.(*secretNodePair)
+	return k8s.NamespacedName(pair.namespace, pair.nodeName), nil
+}
+
+func (a *secretTokenAuth) validateToken(queryValues url.Values, tokenData string) ([]string, bool, error) {
+	fieldValue := queryValues.Get("fieldSelector")
+	if fieldValue == "" {
+		return nil, true, nil
+	}
+	selector, err := fields.ParseSelector(fieldValue)
+	if err != nil {
+		return nil, false, err
+	}
+	queriedNodeNames := sets.NewString()
+	for _, r := range selector.Requirements() {
+		if r.Field == "nodeName" && r.Operator == selection.Equals {
+			queriedNodeNames.Insert(r.Value)
+		}
+	}
+	if queriedNodeNames.Len() == 0 {
+		// Return true if no nodeName is set in the request.
+		return nil, true, nil
+	}
+	// Parse the claims from the token data. needCheck is false if the token is a service-account-token, which is used
+	// in the connection that is initiated from Antrea Agent on a K8s worker Node, or from Nephe Controller.
+	claim, needCheck, err := a.parseClaim(tokenData)
+	if err != nil {
+		return nil, false, fmt.Errorf("invalid token to parse authentication for ExternalNode: %v", err)
+	}
+	if !needCheck {
+		return nil, true, nil
+	}
+
+	// Get the ExternalNodes that are configured with the Secret bound with the Token. needCheck is false if the token
+	// is not bound to a Secret.
+	nodes, needCheck := a.getBoundNodes(claim)
+	if !needCheck {
+		klog.V(2).InfoS("Token in the request is not binding on Secrets")
+		return nil, true, nil
+	}
+
+	// Return false if any nodeName used in the request does not match the ExternalNodes that can use the token bound with
+	// the Secret provided in.
+	for node := range queriedNodeNames {
+		if !nodes.Has(node) {
+			klog.InfoS("The required Node name is not in the valid list according to the token", "nodeName", node)
+			return nil, false, errors.New("not able to request resources on the bound Node with the provided token")
+		}
+	}
+
+	return nodes.List(), true, nil
+}
+
+func (a *secretTokenAuth) parseClaim(tokenData string) (claims, bool, error) {
+	parts := strings.Split(tokenData, ".")
+	if len(parts) != 3 {
+		return nil, false, fmt.Errorf("token format is incorrect")
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, false, err
+	}
+	public := &jwt.Claims{}
+	if err := json.Unmarshal(payload, public); err != nil {
+		return nil, false, err
+	}
+	if public.Issuer == legacyIssuer {
+		private := &legacyClaims{}
+		if err := json.Unmarshal(payload, private); err != nil {
+			return nil, true, err
+		}
+		return private, true, nil
+	}
+	private := &privateClaims{}
+	if err := json.Unmarshal(payload, private); err != nil {
+		return nil, true, err
+	}
+	return private, true, nil
+}
+
+// getBoundNodes returns the valid ExternalNodes that are allowed to use the token, and a flag that if the token is
+// bound to a Secret or not. An empty set is returned when the token is not bound to any Secret, or the bound secret is
+// not used by any ExternalNode.
+func (a *secretTokenAuth) getBoundNodes(claims claims) (sets.String, bool) {
+	pod := claims.getPodName()
+	secret := claims.getSecretName()
+	if pod != "" {
+		klog.V(2).InfoS("Token is bound to Pod object, no need to check the bounded Nodes", "pod", pod)
+		return sets.NewString(), false
+	}
+	if secret == "" {
+		klog.V(2).InfoS("Token is not bound to Pod or Secret object, no need to check the bounded Nodes")
+		return sets.NewString(), false
+	}
+	serviceAccount := claims.getServiceAccount()
+	// A dedicated Secret with a special name "$serviceaccount-service-account-token" is created for the Service Account
+	// to maintain the token. We assume such token is not bound to a single VM, so the following validation on
+	// ExternalNode is skipped.
+	if secret == strings.Join([]string{serviceAccount, "service-account-token"}, "-") ||
+		// The token is auto generated by Kube APIServer (version <=1.24) when creating the ServiceAccount.
+		strings.HasPrefix(secret, fmt.Sprintf("%s-token-", serviceAccount)) {
+		klog.V(2).InfoS("Token is dedicated for ServiceAccount, no need to check the bounded Nodes")
+		return sets.NewString(), false
+	}
+
+	namespacedSecret := k8s.NamespacedName(claims.getNamespace(), secret)
+	objs, _ := a.secretNodeStore.ByIndex(secretIndexName, namespacedSecret)
+	validNodes := sets.NewString()
+	for _, obj := range objs {
+		pair := obj.(*secretNodePair)
+		validNodes.Insert(k8s.NamespacedName(pair.namespace, pair.nodeName))
+	}
+	return validNodes, true
+}
+
+func (a *secretTokenAuth) externalNodeAdd(obj interface{}) {
+	en := obj.(*v1alpha1.ExternalNode)
+	pair := &secretNodePair{
+		namespace:  en.Namespace,
+		nodeName:   en.Name,
+		secretName: en.Spec.Secret,
+	}
+	a.secretNodeStore.Add(pair)
+}
+
+func (a *secretTokenAuth) externalNodeDelete(obj interface{}) {
+	en := obj.(*v1alpha1.ExternalNode)
+	pair := &secretNodePair{
+		namespace:  en.Namespace,
+		nodeName:   en.Name,
+		secretName: en.Spec.Secret,
+	}
+	a.secretNodeStore.Delete(pair)
+}
+
+func (a *secretTokenAuth) externalNodeUpdate(old interface{}, new interface{}) {
+	oldEN := old.(*v1alpha1.ExternalNode)
+	newEN := new.(*v1alpha1.ExternalNode)
+	oldSecret := oldEN.Spec.Secret
+	newSecret := newEN.Spec.Secret
+	if oldSecret == newSecret {
+		return
+	}
+	oldPair := &secretNodePair{
+		namespace:  oldEN.Namespace,
+		nodeName:   oldEN.Name,
+		secretName: oldEN.Spec.Secret,
+	}
+	a.secretNodeStore.Delete(oldPair)
+	newPair := &secretNodePair{
+		namespace:  newEN.Namespace,
+		nodeName:   newEN.Name,
+		secretName: newEN.Spec.Secret,
+	}
+	a.secretNodeStore.Add(newPair)
+}
+
+type externalNodeAuthRequest struct {
+	prevAuthenticator authenticator.Request
+	secretTokenAuth   *secretTokenAuth
+}
+
+func (r *externalNodeAuthRequest) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, error) {
+	token := r.parseToken(req)
+	resp, authenticated, err := r.prevAuthenticator.AuthenticateRequest(req)
+	if len(token) == 0 || err != nil || !authenticated {
+		return resp, authenticated, err
+	}
+	nodes, authenticated, err := r.secretTokenAuth.validateToken(req.URL.Query(), token)
+	if err != nil {
+		klog.ErrorS(err, "Failed to validate token on the request")
+		return resp, false, err
+	}
+	if !authenticated {
+		klog.InfoS("The request is not authenticated")
+		return resp, false, err
+	}
+	return mergeUserInfoExtras(resp, nodes), true, nil
+}
+
+func mergeUserInfoExtras(resp *authenticator.Response, nodes []string) *authenticator.Response {
+	userInfo := resp.User
+	newUser := &user.DefaultInfo{
+		Name:   userInfo.GetName(),
+		UID:    userInfo.GetUID(),
+		Groups: userInfo.GetGroups(),
+	}
+	extras := make(map[string][]string)
+	for k, v := range userInfo.GetExtra() {
+		extras[k] = v
+	}
+	if len(nodes) > 0 {
+		extras["valid-nodes"] = nodes
+	}
+	if len(extras) > 0 {
+		newUser.Extra = extras
+	}
+	return &authenticator.Response{
+		User:      newUser,
+		Audiences: resp.Audiences,
+	}
+}
+
+func (r *externalNodeAuthRequest) parseToken(req *http.Request) string {
+	auth := strings.TrimSpace(req.Header.Get("Authorization"))
+	if auth == "" {
+		return ""
+	}
+	parts := strings.SplitN(auth, " ", 3)
+	if len(parts) < 2 || strings.ToLower(parts[0]) != "bearer" {
+		return ""
+	}
+	return parts[1]
+}
+
+func NewAuthenticator(kubeAuth authenticator.Request, externalNodeInformer externalnodeinformers.ExternalNodeInformer) authenticator.Request {
+	return &externalNodeAuthRequest{
+		prevAuthenticator: kubeAuth,
+		secretTokenAuth:   newSecretTokenAuthenticator(externalNodeInformer),
+	}
+}

--- a/pkg/controller/externalnode/auth_handler_test.go
+++ b/pkg/controller/externalnode/auth_handler_test.go
@@ -1,0 +1,328 @@
+// Copyright 2023 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package externalnode
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apiserver/pkg/authentication/authenticator"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/client-go/rest"
+
+	"antrea.io/antrea/pkg/apis/crd/v1alpha1"
+	fakeclientset "antrea.io/antrea/pkg/client/clientset/versioned/fake"
+	"antrea.io/antrea/pkg/client/clientset/versioned/scheme"
+	crdinformers "antrea.io/antrea/pkg/client/informers/externalversions"
+	"antrea.io/antrea/pkg/util/k8s"
+)
+
+type fakeAuthenticator struct {
+	response      *authenticator.Response
+	authenticated bool
+	err           error
+}
+
+func (a *fakeAuthenticator) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, error) {
+	return a.response, a.authenticated, a.err
+}
+
+func TestAuthenAuthenticateRequest(t *testing.T) {
+	testUser := &user.DefaultInfo{
+		Name: "test1",
+		UID:  "12cc944e-291a-4f55-9300-0654622254ac",
+		Groups: []string{
+			"system:serviceaccount:kube-system:test1",
+			"system:serviceaccount",
+		},
+	}
+	prevResponse := &authenticator.Response{
+		User: testUser,
+		Audiences: []string{
+			"https://kubernetes.default.svc.cluster.local",
+		},
+	}
+	// validToken is bound to Secret "secret-for-test"
+	// #nosec G101: false positive triggered by variable name which includes "token". The token is only for test.
+	validToken := "eyJhbGciOiJSUzI1NiIsImtpZCI6ImQweWxibl9sNG00WC1yemQ1WnYtYUJBUW9kSUhIWlVVeHhHS2hRUXQtSXcifQ.eyJhdWQiOlsiaHR0cHM6Ly9rdWJlcm5ldGVzLmRlZmF1bHQuc3ZjLmNsdXN0ZXIubG9jYWwiXSwiZXhwIjoxNjczNTc2MzM1LCJpYXQiOjE2NzM1NzI3MzUsImlzcyI6Imh0dHBzOi8va3ViZXJuZXRlcy5kZWZhdWx0LnN2Yy5jbHVzdGVyLmxvY2FsIiwia3ViZXJuZXRlcy5pbyI6eyJuYW1lc3BhY2UiOiJrdWJlLXN5c3RlbSIsInNlY3JldCI6eyJuYW1lIjoic2VjcmV0LWZvci10ZXN0IiwidWlkIjoiYTg1ODVjOGItMThjZS00YWNjLWFiODAtYzRjZWQwYTEyZjJmIn0sInNlcnZpY2VhY2NvdW50Ijp7Im5hbWUiOiJ0ZXN0MSIsInVpZCI6IjEyY2M5NDRlLTI5MWEtNGY1NS05MzAwLTA2NTQ2MjIyNTRhYyJ9fSwibmJmIjoxNjczNTcyNzM1LCJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6a3ViZS1zeXN0ZW06dGVzdDEifQ.bCRre_iPgvkO_NiYVIUwnVbX9yrb2kg0EMouPzGIwFSBdBIGVwlJvfEwF2G20eaiqhfzXdNDZeQQ07Gn-SNohS_KVyjF9a3qup7-2WkTTnl20KUZ0jrFTKGglirDxRAdkR81AvsUCXlCWxmEYHLGxC9cqONaQQYUo2rAhgVFlZYe04RY9l3jvnfamppDEs56hDbpStJHCPAB-So2QDGnIzNWMedo7ZYvIGnZ2Mxf-9el3lFfUBTnvEiYU8nzgcxsmh9ytzUwIc-FNhpp3sVIH4JzVBroY8RjhjF1rZKxG-HBXEqhDWQbNzRJAaqUYy72An9LyAFIjvcr05Z7PbbIfA"
+	// podToken is bound to Secret "secret-for-invalid"
+	// #nosec G101: false positive triggered by variable name which includes "token". The token is only for test.
+	podToken := "eyJhbGciOiJSUzI1NiIsImtpZCI6ImQweWxibl9sNG00WC1yemQ1WnYtYUJBUW9kSUhIWlVVeHhHS2hRUXQtSXcifQ.eyJhdWQiOlsiaHR0cHM6Ly9rdWJlcm5ldGVzLmRlZmF1bHQuc3ZjLmNsdXN0ZXIubG9jYWwiXSwiZXhwIjoxNjczNTg1NDkwLCJpYXQiOjE2NzM1ODE4OTAsImlzcyI6Imh0dHBzOi8va3ViZXJuZXRlcy5kZWZhdWx0LnN2Yy5jbHVzdGVyLmxvY2FsIiwia3ViZXJuZXRlcy5pbyI6eyJuYW1lc3BhY2UiOiJrdWJlLXN5c3RlbSIsInBvZCI6eyJuYW1lIjoibmdpbngiLCJ1aWQiOiI0N2NiNGZmZS1mZWFjLTQ3MjMtODQ2MC05NzZjNzZhYzhhOWQifSwic2VydmljZWFjY291bnQiOnsibmFtZSI6InRlc3QxIiwidWlkIjoiMTJjYzk0NGUtMjkxYS00ZjU1LTkzMDAtMDY1NDYyMjI1NGFjIn19LCJuYmYiOjE2NzM1ODE4OTAsInN1YiI6InN5c3RlbTpzZXJ2aWNlYWNjb3VudDprdWJlLXN5c3RlbTp0ZXN0MSJ9.ga7TJ3a8L_Jp6Q4brLjpgiZd5LEWxjgUTdajCji9W-QQ3yKAGEZZ2TTgbPI9pewyQaDM0S4Zz9twKFpslZGu5Ik0kKgWCg9Fbn3yGN-MBwRTnpqN2_7az1dPq4KXYozyUrtIeCdZFMYoM3Be0vebmjqCy0L1vvmihL2e_fe_JOAaFSJUK_OKbyeisQf2uD-xYFHBYS-tFqCGFWu08iot8cXsq6R1ufE1BW7PeUdYJD9ep39_Lk6oezgHxlUmXSJZoSR9iavPX_4gVEIvfV9kcjYogf-RRba9rMBDUJpbz6tViZATM2qWH_0t0bqo-FjahNVpIWkzONQReLe5H-Da1g"
+	// serviceAccountToken is a token created for ServiceAccount
+	// #nosec G101: false positive triggered by variable name which includes "token". The token is only for test.
+	serviceAccountToken := "eyJhbGciOiJSUzI1NiIsImtpZCI6ImQweWxibl9sNG00WC1yemQ1WnYtYUJBUW9kSUhIWlVVeHhHS2hRUXQtSXcifQ.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJrdWJlLXN5c3RlbSIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VjcmV0Lm5hbWUiOiJhbnRyZWEtYWdlbnQtc2VydmljZS1hY2NvdW50LXRva2VuIiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZXJ2aWNlLWFjY291bnQubmFtZSI6ImFudHJlYS1hZ2VudCIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VydmljZS1hY2NvdW50LnVpZCI6ImRhN2U0MWY1LTZmMTQtNGU2MC1hZWE0LTJhNDhjYjRlMjVmYiIsInN1YiI6InN5c3RlbTpzZXJ2aWNlYWNjb3VudDprdWJlLXN5c3RlbTphbnRyZWEtYWdlbnQifQ.FnSPpgTE4cJtlW35-NQ-Jl_FKrkDNDcsRaPylhyvCWNPqy2rBSz_KJEmDX1xYMWtUR_dwSJwt8ZRXFyXPzmel8oGX-zs2L9Ba9uWtdOq0ThGtQboixOEea2gR96jYj5QH4f5_ODPRSzxnzfvWlq0U-0mevh2_Rg_cwq8S9_viI3c04Z89vt703xYSmsNmG0wP7ar0ub-HKt4JDhgX23zhIsLqt2SGs0jTbiTWWWm2_RNprw4W8UWoxLeG5wV4VfqcBSurdYx2dr7R7-dPoFYBSCVLJOD7DBu2IjQLrn0efOpctQemJZ69HnhMBgvq0jbMF6xUdcC6qQq2k4BNrAwlA"
+	// legacyServiceAccountToken is a token generated in the Secret along with the SA creation, it is the legacy implementation for SA token.
+	// #nosec G101: false positive triggered by variable name which includes "token". The token is only for test.
+	legacyServiceAccountToken := "eyJhbGciOiJSUzI1NiIsImtpZCI6ImQweWxibl9sNG00WC1yemQ1WnYtYUJBUW9kSUhIWlVVeHhHS2hRUXQtSXcifQ.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJrdWJlLXN5c3RlbSIsImt1YmVybmV0ZXMuaW8vc2VydmljZWFjY291bnQvc2VjcmV0Lm5hbWUiOiJhbnRyZWEtYWdlbnQtdG9rZW4temp4eHIiLCJrdWJlcm5ldGVzLmlvL3NlcnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC5uYW1lIjoiYW50cmVhLWFnZW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZXJ2aWNlLWFjY291bnQudWlkIjoiZGE3ZTQxZjUtNmYxNC00ZTYwLWFlYTQtMmE0OGNiNGUyNWZiIiwic3ViIjoic3lzdGVtOnNlcnZpY2VhY2NvdW50Omt1YmUtc3lzdGVtOmFudHJlYS1hZ2VudCJ9.hRvfHlDWFsJ-iM4wvSD2XXonvGhnH21HMLAXd77aFiXmnGcecixK87mrGLx8chT1nPQ0rdEZgJCFBxarc4-KRZYMq24hibDXC7UDUUModlhnOfEGAy-nvZf12RNLWW2FRFX9fcWOHsiiYfHKusPGVT69WC3Dkknt5zwrNVfn2N6E4p7Ky5XMPp-iOlq7054PJCZ-qYVbKQ2yCfYMLFXoS1eV25tTTImEoYxzBxBbeKrS2BNkMLuNljSl9bsHJwm7vL2Q299pp_xEGi_TgwC0UfXx-5VUsP3Hf90qeIkKzRcESNPM1K7muzN_kNlQrSUwFoL8sk7UzOMC9aa33y5Xtw"
+	for _, tc := range []struct {
+		name        string
+		token       string
+		queryNode   string
+		secretNodes []*secretNodePair
+
+		prevAuth bool
+		prevErr  error
+
+		expUser user.Info
+		expAuth bool
+		expErr  error
+	}{
+		{
+			name:      "valid request",
+			token:     validToken,
+			queryNode: "kube-system/vm1",
+			secretNodes: []*secretNodePair{
+				{
+					namespace:  "kube-system",
+					nodeName:   "vm1",
+					secretName: "secret-for-test",
+				},
+			},
+			prevAuth: true,
+			prevErr:  nil,
+			expUser: &user.DefaultInfo{
+				Name:   testUser.GetName(),
+				UID:    testUser.GetUID(),
+				Groups: testUser.GetGroups(),
+				Extra:  map[string][]string{"valid-nodes": {"kube-system/vm1"}},
+			},
+			expAuth: true,
+			expErr:  nil,
+		},
+		{
+			name:      "secret bound on multiple nodes",
+			token:     validToken,
+			queryNode: "kube-system/vm1",
+			secretNodes: []*secretNodePair{
+				{
+					namespace:  "kube-system",
+					nodeName:   "vm1",
+					secretName: "secret-for-test",
+				}, {
+					namespace:  "kube-system",
+					nodeName:   "vm2",
+					secretName: "secret-for-test",
+				},
+			},
+			prevAuth: true,
+			prevErr:  nil,
+			expUser: &user.DefaultInfo{
+				Name:   testUser.GetName(),
+				UID:    testUser.GetUID(),
+				Groups: testUser.GetGroups(),
+				Extra:  map[string][]string{"valid-nodes": {"kube-system/vm1", "kube-system/vm2"}},
+			},
+			expAuth: true,
+			expErr:  nil,
+		},
+		{
+			name:      "failed in previous validation",
+			token:     validToken,
+			queryNode: "kube-system/vm1",
+			secretNodes: []*secretNodePair{
+				{
+					namespace:  "kube-system",
+					nodeName:   "vm1",
+					secretName: "secret-for-test",
+				},
+			},
+			prevAuth: false,
+			prevErr:  errors.New("invalid token"),
+			expUser:  testUser,
+			expAuth:  false,
+			expErr:   errors.New("invalid token"),
+		},
+		{
+			name:      "invalid parameter in query",
+			token:     validToken,
+			queryNode: "kube-system/vm2",
+			secretNodes: []*secretNodePair{
+				{
+					namespace:  "kube-system",
+					nodeName:   "vm1",
+					secretName: "secret-for-test",
+				},
+			},
+			prevAuth: true,
+			prevErr:  nil,
+			expUser:  prevResponse.User,
+			expAuth:  false,
+			expErr:   errors.New("not able to request resources on the bound Node with the provided token"),
+		},
+		{
+			name:      "secret bound no nodes",
+			token:     validToken,
+			queryNode: "kube-system/vm1",
+			prevAuth:  true,
+			prevErr:   nil,
+			expUser:   prevResponse.User,
+			expAuth:   false,
+			expErr:    errors.New("not able to request resources on the bound Node with the provided token"),
+		},
+		{
+			name:      "valid request with token on pod",
+			token:     podToken,
+			queryNode: "worker1",
+			prevAuth:  true,
+			prevErr:   nil,
+			expUser: &user.DefaultInfo{
+				Name:   testUser.GetName(),
+				UID:    testUser.GetUID(),
+				Groups: testUser.GetGroups(),
+			},
+			expAuth: true,
+			expErr:  nil,
+		},
+		{
+			name:      "request from service-account token",
+			token:     serviceAccountToken,
+			queryNode: "worker2",
+			prevAuth:  true,
+			prevErr:   nil,
+			expUser: &user.DefaultInfo{
+				Name:   testUser.GetName(),
+				UID:    testUser.GetUID(),
+				Groups: testUser.GetGroups(),
+			},
+			expAuth: true,
+			expErr:  nil,
+		}, {
+			name:      "request from legacy service-account token",
+			token:     legacyServiceAccountToken,
+			queryNode: "worker2",
+			prevAuth:  true,
+			prevErr:   nil,
+			expUser: &user.DefaultInfo{
+				Name:   testUser.GetName(),
+				UID:    testUser.GetUID(),
+				Groups: testUser.GetGroups(),
+			},
+			expAuth: true,
+			expErr:  nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			crdClient := fakeclientset.NewSimpleClientset()
+			informerFactory = crdinformers.NewSharedInformerFactory(crdClient, resyncPeriod)
+			externalNodeInformer := informerFactory.Crd().V1alpha1().ExternalNodes()
+			fakeAuth := &fakeAuthenticator{prevResponse, tc.prevAuth, tc.prevErr}
+			request, err := generateRequest(tc.token, tc.queryNode)
+			require.NoError(t, err)
+			auth := NewAuthenticator(fakeAuth, externalNodeInformer)
+			if len(tc.secretNodes) > 0 {
+				for _, s := range tc.secretNodes {
+					auth.(*externalNodeAuthRequest).secretTokenAuth.secretNodeStore.Add(s)
+				}
+			}
+			response, authenticated, err := auth.AuthenticateRequest(request)
+			assert.Equal(t, tc.expAuth, authenticated)
+			assert.Equal(t, tc.expErr, err)
+			if tc.expUser != nil {
+				assert.NotNil(t, response)
+				newUser := response.User
+				assert.Equal(t, tc.expUser.GetUID(), newUser.GetUID())
+				assert.Equal(t, tc.expUser.GetGroups(), newUser.GetGroups())
+				assert.Equal(t, tc.expUser.GetName(), newUser.GetName())
+				key := "valid-nodes"
+				if expNodes, ok := tc.expUser.GetExtra()[key]; ok {
+					actNodes, exist := newUser.GetExtra()[key]
+					assert.True(t, exist)
+					assert.ElementsMatch(t, expNodes, actNodes)
+				}
+				assert.Equal(t, tc.expUser.GetExtra(), newUser.GetExtra())
+			}
+		})
+	}
+}
+
+func TestExternalNodeEvent(t *testing.T) {
+	crdClient := fakeclientset.NewSimpleClientset()
+	informerFactory = crdinformers.NewSharedInformerFactory(crdClient, resyncPeriod)
+	externalNodeInformer := informerFactory.Crd().V1alpha1().ExternalNodes()
+	auth := newSecretTokenAuthenticator(externalNodeInformer)
+	informerFactory.Start(make(chan struct{}))
+	secretName := "sec1"
+	ns := "ns1"
+	enName := "vm1"
+	en := &v1alpha1.ExternalNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns,
+			Name:      enName,
+		},
+		Spec: v1alpha1.ExternalNodeSpec{
+			Secret: secretName,
+		},
+	}
+	key := k8s.NamespacedName(ns, enName)
+	auth.externalNodeAdd(en)
+	namespacedSecret := k8s.NamespacedName(ns, secretName)
+	objs, err := auth.secretNodeStore.ByIndex(secretIndexName, namespacedSecret)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(objs))
+	assert.Equal(t, enName, objs[0].(*secretNodePair).nodeName)
+
+	updatedSecret := "sec2"
+	updatedEn := &v1alpha1.ExternalNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns,
+			Name:      enName,
+		},
+		Spec: v1alpha1.ExternalNodeSpec{
+			Secret: updatedSecret,
+		},
+	}
+	auth.externalNodeUpdate(en, updatedEn)
+	obj, exists, err := auth.secretNodeStore.GetByKey(key)
+	assert.NoError(t, err)
+	assert.True(t, exists)
+	secNode := obj.(*secretNodePair)
+	assert.Equal(t, updatedSecret, secNode.secretName)
+	updatedNamespacedSecret := k8s.NamespacedName(ns, updatedSecret)
+	objs, err = auth.secretNodeStore.ByIndex(secretIndexName, updatedNamespacedSecret)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(objs))
+
+	auth.externalNodeDelete(updatedEn)
+	_, exists, err = auth.secretNodeStore.GetByKey(key)
+	assert.NoError(t, err)
+	assert.False(t, exists)
+}
+
+func generateRequest(token string, queryNode string) (*http.Request, error) {
+	restClient, err := rest.NewRESTClient(&url.URL{Host: "1.1.1.1:443"}, "apis/v1", rest.ClientContentConfig{GroupVersion: corev1.SchemeGroupVersion}, nil, http.DefaultClient)
+	if err != nil {
+		return nil, err
+	}
+	options := metav1.ListOptions{
+		FieldSelector: fields.OneTermEqualSelector("nodeName", queryNode).String(),
+	}
+	r := restClient.Get().
+		Resource("networkpolicies").
+		VersionedParams(&options, scheme.ParameterCodec)
+	request, err := http.NewRequest("GET", r.URL().String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+	return request, nil
+}


### PR DESCRIPTION
1. A single token is created and used on Antrea Agent per VM, which is bound to a separate Secret. The Secret name is added in ExternalNode Spec.
2. When a connection comes to Antrea Controller with Node/ExternalNode name as a parameter in the request, Controller validates the used token to read the bound Secret. Then Controller compares it with the valid ExternalNodes which have been configured with the Secret.
3. The check is bypassed if a connection is using the token generated for the ServiceAccount, e.g., from Antrea Agent on a K8s worker Node, or from Nephe Controller.

Signed-off-by: wenyingd <wenyingd@vmware.com>