### PR TITLE
Optimize the updating of Endpoints for Service in AntreaProxy

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -362,6 +362,9 @@ func run(o *Options) error {
 	v6GroupIDAllocator := openflow.NewGroupAllocator(true)
 	v6GroupCounter := proxytypes.NewGroupCounter(v6GroupIDAllocator, groupIDUpdates)
 
+	v4BucketCounter := proxytypes.NewBucketCounter()
+	v6BucketCounter := proxytypes.NewBucketCounter()
+
 	v4Enabled := networkConfig.IPv4Enabled
 	v6Enabled := networkConfig.IPv6Enabled
 	var proxier proxy.Proxier
@@ -372,13 +375,13 @@ func run(o *Options) error {
 
 		switch {
 		case v4Enabled && v6Enabled:
-			proxier = proxy.NewDualStackProxier(nodeConfig.Name, informerFactory, ofClient, routeClient, nodePortAddressesIPv4, nodePortAddressesIPv6, proxyAll, skipServices, proxyLoadBalancerIPs, v4GroupCounter, v6GroupCounter)
+			proxier = proxy.NewDualStackProxier(nodeConfig.Name, informerFactory, ofClient, routeClient, nodePortAddressesIPv4, nodePortAddressesIPv6, proxyAll, skipServices, proxyLoadBalancerIPs, v4GroupCounter, v6GroupCounter, v4BucketCounter, v6BucketCounter)
 			groupCounters = append(groupCounters, v4GroupCounter, v6GroupCounter)
 		case v4Enabled:
-			proxier = proxy.NewProxier(nodeConfig.Name, informerFactory, ofClient, false, routeClient, nodePortAddressesIPv4, proxyAll, skipServices, proxyLoadBalancerIPs, v4GroupCounter)
+			proxier = proxy.NewProxier(nodeConfig.Name, informerFactory, ofClient, false, routeClient, nodePortAddressesIPv4, proxyAll, skipServices, proxyLoadBalancerIPs, v4GroupCounter, v4BucketCounter)
 			groupCounters = append(groupCounters, v4GroupCounter)
 		case v6Enabled:
-			proxier = proxy.NewProxier(nodeConfig.Name, informerFactory, ofClient, true, routeClient, nodePortAddressesIPv6, proxyAll, skipServices, proxyLoadBalancerIPs, v6GroupCounter)
+			proxier = proxy.NewProxier(nodeConfig.Name, informerFactory, ofClient, true, routeClient, nodePortAddressesIPv6, proxyAll, skipServices, proxyLoadBalancerIPs, v6GroupCounter, v4BucketCounter)
 			groupCounters = append(groupCounters, v6GroupCounter)
 		default:
 			return fmt.Errorf("at least one of IPv4 or IPv6 should be enabled")

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module antrea.io/antrea
 go 1.19
 
 require (
-	antrea.io/libOpenflow v0.9.1
+	antrea.io/libOpenflow v0.9.2
 	antrea.io/ofnet v0.6.5
 	github.com/ClickHouse/clickhouse-go v1.5.4
 	github.com/DATA-DOG/go-sqlmock v1.5.0
@@ -212,3 +212,5 @@ require (
 )
 
 replace antrea.io/ofnet v0.6.0 => github.com/wenyingd/ofnet v0.0.0-20220817031400-cb451467adc1
+
+replace antrea.io/ofnet v0.6.5 => github.com/hongliangl/ofnet v0.0.0-20230117012701-19fcf3cf4e37

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,5 @@
-antrea.io/libOpenflow v0.8.1/go.mod h1:CzEJZxDNAupiGxeL5VOw92PsxfyvehEAvE3PiC6gr8o=
-antrea.io/libOpenflow v0.9.1 h1:nrw7EpGuSgi932xriAHdMYGYdLnnjrj91qXGt/bzUUw=
-antrea.io/libOpenflow v0.9.1/go.mod h1:IM9mUfHh5hUNciRRcWYIaWZTlv1TI6QBEHlml7ALdS4=
-antrea.io/ofnet v0.6.5 h1:jMnrU2Iva+jn/j2tyHJ1bSmC7HXtMDYVCJb7pq8L37I=
-antrea.io/ofnet v0.6.5/go.mod h1:/gjpTqhUpyn8uZnef+ytdCCAeY5oGG1jCr/szPUqVXU=
+antrea.io/libOpenflow v0.9.2 h1:9W++nzaxxwY4NxyHHow/4bfum2UPIBJKmEOVTAG+x3o=
+antrea.io/libOpenflow v0.9.2/go.mod h1:IM9mUfHh5hUNciRRcWYIaWZTlv1TI6QBEHlml7ALdS4=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
@@ -565,6 +562,8 @@ github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2p
 github.com/hashicorp/memberlist v0.5.0 h1:EtYPN8DpAURiapus508I4n9CzHs2W+8NZGbmmR/prTM=
 github.com/hashicorp/memberlist v0.5.0/go.mod h1:yvyXLpo0QaGE59Y7hDTsTzDD25JYBZ4mHgHUZ8lrOI0=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
+github.com/hongliangl/ofnet v0.0.0-20230117012701-19fcf3cf4e37 h1:tmG3zb81jI0rlE90MvqcgQBfVPETx10jMOSNBMZlMZs=
+github.com/hongliangl/ofnet v0.0.0-20230117012701-19fcf3cf4e37/go.mod h1:CB/Pkt+U0Yi1sM7DZ7iS215xGL+dhRRAM0EV0LTDLnY=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/pkg/agent/openflow/client_test.go
+++ b/pkg/agent/openflow/client_test.go
@@ -840,11 +840,14 @@ func Test_client_GetPodFlowKeys(t *testing.T) {
 
 func Test_client_InstallServiceGroup(t *testing.T) {
 	groupID := binding.GroupIDType(100)
+	bucketID1 := binding.BucketIDType(100)
+	bucketID2 := binding.BucketIDType(101)
 
 	testCases := []struct {
 		name                string
 		withSessionAffinity bool
 		endpoints           []proxy.Endpoint
+		bucketIDs           map[string]*binding.BucketIDType
 		expectedGroup       string
 	}{
 		{
@@ -853,9 +856,13 @@ func Test_client_InstallServiceGroup(t *testing.T) {
 				proxy.NewBaseEndpointInfo("10.10.0.100", "", "", 80, false, true, false, false, nil),
 				proxy.NewBaseEndpointInfo("10.10.0.101", "", "", 80, false, true, false, false, nil),
 			},
+			bucketIDs: map[string]*binding.BucketIDType{
+				"10.10.0.100:80": &bucketID1,
+				"10.10.0.101:80": &bucketID2,
+			},
 			expectedGroup: "group_id=100,type=select," +
-				"bucket=bucket_id:0,weight:100,actions=set_field:0xa0a0064->reg3,set_field:0x50/0xffff->reg4,resubmit:EndpointDNAT," +
-				"bucket=bucket_id:1,weight:100,actions=set_field:0xa0a0065->reg3,set_field:0x50/0xffff->reg4,resubmit:EndpointDNAT",
+				"bucket=bucket_id:100,weight:100,actions=set_field:0xa0a0064->reg3,set_field:0x50/0xffff->reg4,resubmit:EndpointDNAT," +
+				"bucket=bucket_id:101,weight:100,actions=set_field:0xa0a0065->reg3,set_field:0x50/0xffff->reg4,resubmit:EndpointDNAT",
 		},
 		{
 			name: "IPv6 Endpoints",
@@ -863,9 +870,13 @@ func Test_client_InstallServiceGroup(t *testing.T) {
 				proxy.NewBaseEndpointInfo("fec0:10:10::100", "", "", 80, false, true, false, false, nil),
 				proxy.NewBaseEndpointInfo("fec0:10:10::101", "", "", 80, false, true, false, false, nil),
 			},
+			bucketIDs: map[string]*binding.BucketIDType{
+				"[fec0:10:10::100]:80": &bucketID1,
+				"[fec0:10:10::101]:80": &bucketID2,
+			},
 			expectedGroup: "group_id=100,type=select," +
-				"bucket=bucket_id:0,weight:100,actions=set_field:0xfec00010001000000000000000000100->xxreg3,set_field:0x50/0xffff->reg4,resubmit:EndpointDNAT," +
-				"bucket=bucket_id:1,weight:100,actions=set_field:0xfec00010001000000000000000000101->xxreg3,set_field:0x50/0xffff->reg4,resubmit:EndpointDNAT",
+				"bucket=bucket_id:100,weight:100,actions=set_field:0xfec00010001000000000000000000100->xxreg3,set_field:0x50/0xffff->reg4,resubmit:EndpointDNAT," +
+				"bucket=bucket_id:101,weight:100,actions=set_field:0xfec00010001000000000000000000101->xxreg3,set_field:0x50/0xffff->reg4,resubmit:EndpointDNAT",
 		},
 		{
 			name:                "IPv4 Endpoints,SessionAffinity",
@@ -874,9 +885,13 @@ func Test_client_InstallServiceGroup(t *testing.T) {
 				proxy.NewBaseEndpointInfo("10.10.0.100", "", "", 80, false, true, false, false, nil),
 				proxy.NewBaseEndpointInfo("10.10.0.101", "", "", 80, false, true, false, false, nil),
 			},
+			bucketIDs: map[string]*binding.BucketIDType{
+				"10.10.0.100:80": &bucketID1,
+				"10.10.0.101:80": &bucketID2,
+			},
 			expectedGroup: "group_id=100,type=select," +
-				"bucket=bucket_id:0,weight:100,actions=set_field:0xa0a0064->reg3,set_field:0x50/0xffff->reg4,resubmit:ServiceLB," +
-				"bucket=bucket_id:1,weight:100,actions=set_field:0xa0a0065->reg3,set_field:0x50/0xffff->reg4,resubmit:ServiceLB",
+				"bucket=bucket_id:100,weight:100,actions=set_field:0xa0a0064->reg3,set_field:0x50/0xffff->reg4,resubmit:ServiceLB," +
+				"bucket=bucket_id:101,weight:100,actions=set_field:0xa0a0065->reg3,set_field:0x50/0xffff->reg4,resubmit:ServiceLB",
 		},
 		{
 			name:                "IPv6 Endpoints,SessionAffinity",
@@ -885,9 +900,13 @@ func Test_client_InstallServiceGroup(t *testing.T) {
 				proxy.NewBaseEndpointInfo("fec0:10:10::100", "", "", 80, false, true, false, false, nil),
 				proxy.NewBaseEndpointInfo("fec0:10:10::101", "", "", 80, false, true, false, false, nil),
 			},
+			bucketIDs: map[string]*binding.BucketIDType{
+				"[fec0:10:10::100]:80": &bucketID1,
+				"[fec0:10:10::101]:80": &bucketID2,
+			},
 			expectedGroup: "group_id=100,type=select," +
-				"bucket=bucket_id:0,weight:100,actions=set_field:0xfec00010001000000000000000000100->xxreg3,set_field:0x50/0xffff->reg4,resubmit:ServiceLB," +
-				"bucket=bucket_id:1,weight:100,actions=set_field:0xfec00010001000000000000000000101->xxreg3,set_field:0x50/0xffff->reg4,resubmit:ServiceLB",
+				"bucket=bucket_id:100,weight:100,actions=set_field:0xfec00010001000000000000000000100->xxreg3,set_field:0x50/0xffff->reg4,resubmit:ServiceLB," +
+				"bucket=bucket_id:101,weight:100,actions=set_field:0xfec00010001000000000000000000101->xxreg3,set_field:0x50/0xffff->reg4,resubmit:ServiceLB",
 		},
 	}
 
@@ -903,7 +922,7 @@ func Test_client_InstallServiceGroup(t *testing.T) {
 			m.EXPECT().AddOFEntries(gomock.Any()).Return(nil).Times(1)
 			m.EXPECT().DeleteOFEntries(gomock.Any()).Return(nil).Times(1)
 
-			assert.NoError(t, fc.InstallServiceGroup(groupID, tc.withSessionAffinity, tc.endpoints))
+			assert.NoError(t, fc.InstallServiceGroup(groupID, tc.withSessionAffinity, tc.endpoints, tc.endpoints, nil, tc.bucketIDs))
 			gCacheI, ok := fc.featureService.groupCache.Load(groupID)
 			require.True(t, ok)
 			group := getGroupFromCache(gCacheI.(binding.Group))

--- a/pkg/agent/openflow/multicast.go
+++ b/pkg/agent/openflow/multicast.go
@@ -93,16 +93,16 @@ func (f *featureMulticast) replayFlows() []binding.Flow {
 }
 
 func (f *featureMulticast) multicastReceiversGroup(groupID binding.GroupIDType, tableID uint8, ports []uint32, remoteIPs []net.IP) binding.Group {
-	group := f.bridge.CreateGroupTypeAll(groupID).ResetBuckets()
+	group := f.bridge.CreateGroupTypeAll(groupID).ResetBuckets().ResetOFOperation()
 	for i := range ports {
-		group = group.Bucket().
+		group = group.Bucket(nil).
 			LoadToRegField(OFPortFoundRegMark.GetField(), OFPortFoundRegMark.GetValue()).
 			LoadToRegField(TargetOFPortField, ports[i]).
 			ResubmitToTable(tableID).
 			Done()
 	}
 	for _, ip := range remoteIPs {
-		group = group.Bucket().
+		group = group.Bucket(nil).
 			LoadToRegField(OFPortFoundRegMark.GetField(), OFPortFoundRegMark.GetValue()).
 			LoadToRegField(TargetOFPortField, f.tunnelPort).
 			SetTunnelDst(ip).

--- a/pkg/agent/openflow/testing/mock_openflow.go
+++ b/pkg/agent/openflow/testing/mock_openflow.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Antrea Authors
+// Copyright 2023 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -466,17 +466,17 @@ func (mr *MockClientMockRecorder) InstallServiceFlows(arg0, arg1, arg2, arg3, ar
 }
 
 // InstallServiceGroup mocks base method
-func (m *MockClient) InstallServiceGroup(arg0 openflow.GroupIDType, arg1 bool, arg2 []proxy.Endpoint) error {
+func (m *MockClient) InstallServiceGroup(arg0 openflow.GroupIDType, arg1 bool, arg2, arg3, arg4 []proxy.Endpoint, arg5 map[string]*openflow.BucketIDType) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstallServiceGroup", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "InstallServiceGroup", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InstallServiceGroup indicates an expected call of InstallServiceGroup
-func (mr *MockClientMockRecorder) InstallServiceGroup(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) InstallServiceGroup(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallServiceGroup", reflect.TypeOf((*MockClient)(nil).InstallServiceGroup), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallServiceGroup", reflect.TypeOf((*MockClient)(nil).InstallServiceGroup), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // InstallTraceflowFlows mocks base method

--- a/pkg/agent/proxy/types/bucketcounter.go
+++ b/pkg/agent/proxy/types/bucketcounter.go
@@ -1,0 +1,89 @@
+package types
+
+import (
+	"sync"
+
+	"antrea.io/antrea/pkg/agent/openflow"
+	binding "antrea.io/antrea/pkg/ovs/openflow"
+	k8sproxy "antrea.io/antrea/third_party/proxy"
+)
+
+type BucketCounter interface {
+	// AllocateIfNotExist generates a unique bucketID for an Endpoint of a Service if the bucketID has not been generated,
+	// then return the bucketID (newly allocated or already allocated).
+	AllocateIfNotExist(svcPortName k8sproxy.ServicePortName, endpoint k8sproxy.Endpoint) binding.BucketIDType
+	// Get gets the bucket ID for the Endpoint of the Service.
+	Get(svcPortName k8sproxy.ServicePortName, endpoint k8sproxy.Endpoint) (binding.BucketIDType, bool)
+	// Recycle recycles a single bucket ID allocated for an Endpoint of a Service when endpoint is not nil, or removes
+	// all bucket IDs allocated for a Service and its bucket ID allocator when endpoint is nil.
+	Recycle(svcPortName k8sproxy.ServicePortName, endpoint k8sproxy.Endpoint) bool
+}
+
+type bucketCounter struct {
+	mu               sync.Mutex
+	bucketAllocators map[string]openflow.BucketAllocator
+	bucketMap        map[string]map[string]binding.BucketIDType
+}
+
+func NewBucketCounter() *bucketCounter {
+	return &bucketCounter{
+		bucketAllocators: make(map[string]openflow.BucketAllocator),
+		bucketMap:        make(map[string]map[string]binding.BucketIDType),
+	}
+}
+
+func (c *bucketCounter) AllocateIfNotExist(svcPortName k8sproxy.ServicePortName, endpoint k8sproxy.Endpoint) binding.BucketIDType {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	serviceString := svcPortName.String()
+	if _, ok := c.bucketAllocators[serviceString]; !ok {
+		c.bucketAllocators[serviceString] = openflow.NewBucketAllocator()
+		c.bucketMap[serviceString] = make(map[string]binding.BucketIDType)
+	}
+	endpointString := endpoint.String()
+	if id, ok := c.bucketMap[serviceString][endpointString]; ok {
+		return id
+	}
+	id := c.bucketAllocators[serviceString].Allocate()
+	c.bucketMap[serviceString][endpointString] = id
+	return id
+}
+
+func (c *bucketCounter) Get(svcPortName k8sproxy.ServicePortName, endpoint k8sproxy.Endpoint) (binding.BucketIDType, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	serviceString := svcPortName.String()
+	bucketIDs, exist := c.bucketMap[serviceString]
+	if !exist {
+		return 0, exist
+	}
+	endpointString := endpoint.String()
+	id, exist := bucketIDs[endpointString]
+	return id, exist
+}
+
+func (c *bucketCounter) Recycle(svcPortName k8sproxy.ServicePortName, endpoint k8sproxy.Endpoint) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	serviceString := svcPortName.String()
+	bucketIDs, exist := c.bucketMap[serviceString]
+	if !exist {
+		return false
+	}
+	if endpoint != nil {
+		endpointString := endpoint.String()
+		if id, ok := bucketIDs[endpointString]; ok {
+			delete(bucketIDs, endpointString)
+			c.bucketAllocators[serviceString].Release(id)
+			return true
+		}
+	} else {
+		delete(c.bucketAllocators, serviceString)
+		delete(c.bucketMap, serviceString)
+	}
+
+	return false
+}

--- a/pkg/ovs/openflow/interfaces.go
+++ b/pkg/ovs/openflow/interfaces.go
@@ -24,6 +24,7 @@ import (
 
 type Protocol string
 type GroupIDType uint32
+type BucketIDType uint32
 type MeterIDType uint32
 
 type MissActionType uint32
@@ -84,6 +85,8 @@ const (
 	AddMessage OFOperation = iota
 	ModifyMessage
 	DeleteMessage
+	InsertBucketsMessage
+	RemoveBucketsMessage OFOperation = 5
 )
 
 // IPDSCPToSRange stores the DSCP bits in ToS field of IP header.
@@ -99,6 +102,7 @@ type Bridge interface {
 	DeleteTable(id uint8) bool
 	CreateGroupTypeAll(id GroupIDType) Group
 	CreateGroup(id GroupIDType) Group
+	CreateGroupToRemoveBucket(groupID GroupIDType, bucketID BucketIDType) Group
 	DeleteGroup(id GroupIDType) error
 	CreateMeter(id MeterIDType, flags ofctrl.MeterFlag) Meter
 	DeleteMeter(id MeterIDType) bool
@@ -333,7 +337,9 @@ type LearnAction interface {
 type Group interface {
 	OFEntry
 	ResetBuckets() Group
-	Bucket() BucketBuilder
+	Bucket(id *BucketIDType) BucketBuilder
+	ResetOFOperation() Group
+	OFOperation(operation *OFOperation) Group
 }
 
 type BucketBuilder interface {

--- a/pkg/ovs/openflow/testing/mock_openflow.go
+++ b/pkg/ovs/openflow/testing/mock_openflow.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Antrea Authors
+// Copyright 2023 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -133,6 +133,20 @@ func (m *MockBridge) CreateGroup(arg0 openflow.GroupIDType) openflow.Group {
 func (mr *MockBridgeMockRecorder) CreateGroup(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateGroup", reflect.TypeOf((*MockBridge)(nil).CreateGroup), arg0)
+}
+
+// CreateGroupToRemoveBucket mocks base method
+func (m *MockBridge) CreateGroupToRemoveBucket(arg0 openflow.GroupIDType, arg1 openflow.BucketIDType) openflow.Group {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateGroupToRemoveBucket", arg0, arg1)
+	ret0, _ := ret[0].(openflow.Group)
+	return ret0
+}
+
+// CreateGroupToRemoveBucket indicates an expected call of CreateGroupToRemoveBucket
+func (mr *MockBridgeMockRecorder) CreateGroupToRemoveBucket(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateGroupToRemoveBucket", reflect.TypeOf((*MockBridge)(nil).CreateGroupToRemoveBucket), arg0, arg1)
 }
 
 // CreateGroupTypeAll mocks base method
@@ -2194,17 +2208,17 @@ func (mr *MockGroupMockRecorder) Add() *gomock.Call {
 }
 
 // Bucket mocks base method
-func (m *MockGroup) Bucket() openflow.BucketBuilder {
+func (m *MockGroup) Bucket(arg0 *openflow.BucketIDType) openflow.BucketBuilder {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Bucket")
+	ret := m.ctrl.Call(m, "Bucket", arg0)
 	ret0, _ := ret[0].(openflow.BucketBuilder)
 	return ret0
 }
 
 // Bucket indicates an expected call of Bucket
-func (mr *MockGroupMockRecorder) Bucket() *gomock.Call {
+func (mr *MockGroupMockRecorder) Bucket(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bucket", reflect.TypeOf((*MockGroup)(nil).Bucket))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Bucket", reflect.TypeOf((*MockGroup)(nil).Bucket), arg0)
 }
 
 // Delete mocks base method
@@ -2264,6 +2278,20 @@ func (mr *MockGroupMockRecorder) Modify() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Modify", reflect.TypeOf((*MockGroup)(nil).Modify))
 }
 
+// OFOperation mocks base method
+func (m *MockGroup) OFOperation(arg0 *openflow.OFOperation) openflow.Group {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OFOperation", arg0)
+	ret0, _ := ret[0].(openflow.Group)
+	return ret0
+}
+
+// OFOperation indicates an expected call of OFOperation
+func (mr *MockGroupMockRecorder) OFOperation(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OFOperation", reflect.TypeOf((*MockGroup)(nil).OFOperation), arg0)
+}
+
 // Reset mocks base method
 func (m *MockGroup) Reset() {
 	m.ctrl.T.Helper()
@@ -2288,6 +2316,20 @@ func (m *MockGroup) ResetBuckets() openflow.Group {
 func (mr *MockGroupMockRecorder) ResetBuckets() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetBuckets", reflect.TypeOf((*MockGroup)(nil).ResetBuckets))
+}
+
+// ResetOFOperation mocks base method
+func (m *MockGroup) ResetOFOperation() openflow.Group {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResetOFOperation")
+	ret0, _ := ret[0].(openflow.Group)
+	return ret0
+}
+
+// ResetOFOperation indicates an expected call of ResetOFOperation
+func (mr *MockGroupMockRecorder) ResetOFOperation() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetOFOperation", reflect.TypeOf((*MockGroup)(nil).ResetOFOperation))
 }
 
 // Type mocks base method

--- a/test/integration/agent/openflow_test.go
+++ b/test/integration/agent/openflow_test.go
@@ -783,7 +783,7 @@ func installServiceFlows(t *testing.T, gid uint32, svc svcConfig, endpointList [
 	groupID := ofconfig.GroupIDType(gid)
 	err := c.InstallEndpointFlows(svc.protocol, endpointList)
 	assert.NoError(t, err, "no error should return when installing flows for Endpoints")
-	err = c.InstallServiceGroup(groupID, svc.withSessionAffinity, endpointList)
+	err = c.InstallServiceGroup(groupID, svc.withSessionAffinity, endpointList, nil, nil, nil)
 	assert.NoError(t, err, "no error should return when installing groups for Service")
 	err = c.InstallServiceFlows(groupID, svc.ip, svc.port, svc.protocol, stickyMaxAgeSeconds, false, v1.ServiceTypeClusterIP)
 	assert.NoError(t, err, "no error should return when installing flows for Service")


### PR DESCRIPTION
Before this PR, when updating the Endpoints of a Service in AntreaProxy, the corresponding OVS group for the Service will be reinstalled completely, which means every bucket which is for an Endpoint in the group will be reinstalled regardless of whether it is a new Endpoint or not. In this PR, the Endpoints to be added or removed will be synced by OVS group operations INSERT_BUCKET or REMOVE_BUCKET introduced in Openflow 1.5, instead of reinstalling the whole corresponding OVS group.

Signed-off-by: Hongliang Liu <lhongliang@vmware.com>