### PR TITLE
Modify the message length limitation in ANP Condition

### DIFF
--- a/pkg/controller/networkpolicy/status_controller.go
+++ b/pkg/controller/networkpolicy/status_controller.go
@@ -51,7 +51,7 @@ var (
 	// maxConditionMessageLength defines the max length of the message field in one Condition. If the actual message
 	// length is over size, truncate the string and use "..." in the end.
 	// Use a variable for test.
-	maxConditionMessageLength = 100
+	maxConditionMessageLength = 256
 )
 
 // StatusController is responsible for synchronizing the status of Antrea ClusterNetworkPolicy and Antrea NetworkPolicy.

--- a/pkg/controller/networkpolicy/status_controller_test.go
+++ b/pkg/controller/networkpolicy/status_controller_test.go
@@ -274,10 +274,14 @@ func TestCreateAntreaNetworkPolicy(t *testing.T) {
 			},
 		},
 	}
-	maxConditionMessageLength = 45
-	defer func() {
-		maxConditionMessageLength = 100
-	}()
+	updateMaxConditionMessageLength := func() func() {
+		originalMaxConditionMessageLength := maxConditionMessageLength
+		maxConditionMessageLength = 45
+		return func() {
+			maxConditionMessageLength = originalMaxConditionMessageLength
+		}
+	}
+	defer updateMaxConditionMessageLength()()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var initObjects []runtime.Object


### PR DESCRIPTION
Modify the max length of Message field in ANP Condtion to 256

Fix #4559 

Signed-off-by: wenyingd <wenyingd@vmware.com>