### PR TITLE
Fix UT for pkg/flowaggregator/flowaggregator.go

### DIFF
--- a/pkg/flowaggregator/flowaggregator_test.go
+++ b/pkg/flowaggregator/flowaggregator_test.go
@@ -667,6 +667,7 @@ func TestFlowAggregator_fetchPodLabels(t *testing.T) {
 	defer close(stopCh)
 
 	informerFactory.Start(stopCh)
+	informerFactory.WaitForCacheSync(stopCh)
 	informerFactory.Core().V1().Pods().Informer().GetIndexer().Add(pod)
 
 	tests := []struct {
@@ -830,6 +831,7 @@ func TestFlowAggregator_fillK8sMetadata(t *testing.T) {
 	defer close(stopCh)
 
 	informerFactory.Start(stopCh)
+	informerFactory.WaitForCacheSync(stopCh)
 	informerFactory.Core().V1().Pods().Informer().GetIndexer().Add(srcPod)
 	informerFactory.Core().V1().Pods().Informer().GetIndexer().Add(dstPod)
 


### PR DESCRIPTION
Few unit tests for pkg/flowaggregator/flowaggregator.go fails 
sometime because informer used in unit tests was not cache synced.

Signed-off-by: Kumar Atish <atish.iaf@gmail.com>