### PR TITLE
Change RemoteCommonArea localClusterID to ClusterID type

### DIFF
--- a/multicluster/controllers/multicluster/commonarea/remote_common_area.go
+++ b/multicluster/controllers/multicluster/commonarea/remote_common_area.go
@@ -81,7 +81,7 @@ type remoteCommonArea struct {
 	leaderStatus  multiclusterv1alpha1.ClusterCondition
 
 	// The ID of the local member cluster
-	localClusterID common.ClusterSetID
+	localClusterID common.ClusterID
 
 	// client that provides read/write access into the local cluster
 	localClusterClient client.Client
@@ -106,7 +106,7 @@ type remoteCommonArea struct {
 
 // NewRemoteCommonArea returns a RemoteCommonArea instance which will use access credentials from the Secret to
 // connect to the leader cluster's CommonArea.
-func NewRemoteCommonArea(clusterID common.ClusterID, clusterSetID common.ClusterSetID, localClusterID common.ClusterSetID, mgr manager.Manager, remoteClient client.Client,
+func NewRemoteCommonArea(clusterID common.ClusterID, clusterSetID common.ClusterSetID, localClusterID common.ClusterID, mgr manager.Manager, remoteClient client.Client,
 	scheme *runtime.Scheme, localClusterClient client.Client, clusterSetNamespace string, localNamespace string, config *rest.Config, enableStretchedNetworkPolicy bool) (RemoteCommonArea, error) {
 	klog.InfoS("Create a RemoteCommonArea", "cluster", clusterID)
 

--- a/multicluster/controllers/multicluster/member/acnp_resourceimport_controller_test.go
+++ b/multicluster/controllers/multicluster/member/acnp_resourceimport_controller_test.go
@@ -152,7 +152,7 @@ func TestResourceImportReconciler_handleCopySpanACNPCreateEvent(t *testing.T) {
 			expectedSuccess: false,
 		},
 	}
-	r := NewResourceImportReconciler(fakeClient, scheme, fakeClient, localClusterID, "default", remoteCluster)
+	r := newResourceImportReconciler(fakeClient, scheme, fakeClient, localClusterID, "default", remoteCluster)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if _, err := r.Reconcile(ctx, tt.req); err != nil {
@@ -192,7 +192,7 @@ func TestResourceImportReconciler_handleCopySpanACNPDeleteEvent(t *testing.T) {
 	fakeRemoteClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 	remoteCluster := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", localClusterID, "default", nil)
 
-	r := NewResourceImportReconciler(fakeClient, scheme, fakeClient, localClusterID, "default", remoteCluster)
+	r := newResourceImportReconciler(fakeClient, scheme, fakeClient, localClusterID, "default", remoteCluster)
 	r.installedResImports.Add(*acnpResImport)
 
 	if _, err := r.Reconcile(ctx, acnpImpReq); err != nil {
@@ -305,7 +305,7 @@ func TestResourceImportReconciler_handleCopySpanACNPUpdateEvent(t *testing.T) {
 	fakeRemoteClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(acnpResImport, updatedResImport2, updatedResImport3).Build()
 	remoteCluster := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", localClusterID, "default", nil)
 
-	r := NewResourceImportReconciler(fakeClient, scheme, fakeClient, localClusterID, "default", remoteCluster)
+	r := newResourceImportReconciler(fakeClient, scheme, fakeClient, localClusterID, "default", remoteCluster)
 	r.installedResImports.Add(*acnpResImport)
 	r.installedResImports.Add(*acnpResImportNoMatchingTier)
 	r.installedResImports.Add(*updatedResImport3)

--- a/multicluster/controllers/multicluster/member/clusterinfo_importer_test.go
+++ b/multicluster/controllers/multicluster/member/clusterinfo_importer_test.go
@@ -209,7 +209,7 @@ func TestResourceImportReconciler_handleClusterInfo(t *testing.T) {
 				fakeRemoteClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects().Build()
 			}
 			remoteCluster := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", "cluster-d", "default", nil)
-			r := NewResourceImportReconciler(fakeClient, scheme, fakeClient, "cluster-d", "default", remoteCluster)
+			r := newResourceImportReconciler(fakeClient, scheme, fakeClient, "cluster-d", "default", remoteCluster)
 			if tt.existingCIResImport != nil {
 				r.installedResImports.Add(*tt.existingCIResImport)
 			}

--- a/multicluster/controllers/multicluster/member/clusterset_controller.go
+++ b/multicluster/controllers/multicluster/member/clusterset_controller.go
@@ -215,8 +215,9 @@ func (r *MemberClusterSetReconciler) createOrUpdateRemoteCommonArea(clusterSet *
 	}
 
 	remoteNamespace := clusterSet.Spec.Namespace
-	r.remoteCommonArea, err = commonarea.NewRemoteCommonArea(clusterID, r.clusterSetID, common.ClusterSetID(r.clusterID), remoteCommonAreaMgr, remoteClient, r.Scheme,
-		r.Client, remoteNamespace, r.Namespace, config, r.enableStretchedNetworkPolicy)
+	r.remoteCommonArea, err = commonarea.NewRemoteCommonArea(clusterID, r.clusterSetID, r.clusterID,
+		remoteCommonAreaMgr, remoteClient, r.Scheme, r.Client, remoteNamespace, r.Namespace,
+		config, r.enableStretchedNetworkPolicy)
 	if err != nil {
 		klog.ErrorS(err, "Unable to create RemoteCommonArea", "cluster", clusterID)
 		return err
@@ -224,7 +225,7 @@ func (r *MemberClusterSetReconciler) createOrUpdateRemoteCommonArea(clusterSet *
 
 	// Create import reconcilers and add them to RemoteCommonArea (to be started with
 	// RemoteCommonArea.StartWatching).
-	resImportReconciler := NewResourceImportReconciler(
+	resImportReconciler := newResourceImportReconciler(
 		remoteCommonAreaMgr.GetClient(),
 		remoteCommonAreaMgr.GetScheme(),
 		r.Client,
@@ -235,7 +236,7 @@ func (r *MemberClusterSetReconciler) createOrUpdateRemoteCommonArea(clusterSet *
 	r.remoteCommonArea.AddImportReconciler(resImportReconciler)
 
 	if r.enableStretchedNetworkPolicy {
-		labelIdentityImpReconciler := NewLabelIdentityResourceImportReconciler(
+		labelIdentityImpReconciler := newLabelIdentityResourceImportReconciler(
 			remoteCommonAreaMgr.GetClient(),
 			remoteCommonAreaMgr.GetScheme(),
 			r.Client,

--- a/multicluster/controllers/multicluster/member/labelidentity_import_controller.go
+++ b/multicluster/controllers/multicluster/member/labelidentity_import_controller.go
@@ -47,7 +47,7 @@ type LabelIdentityResourceImportReconciler struct {
 	manager ctrl.Manager
 }
 
-func NewLabelIdentityResourceImportReconciler(client client.Client, scheme *runtime.Scheme, localClusterClient client.Client,
+func newLabelIdentityResourceImportReconciler(client client.Client, scheme *runtime.Scheme, localClusterClient client.Client,
 	localClusterID string, namespace string, remoteCommonArea commonarea.RemoteCommonArea) *LabelIdentityResourceImportReconciler {
 	return &LabelIdentityResourceImportReconciler{
 		Client:             client,

--- a/multicluster/controllers/multicluster/member/labelidentity_import_controller_test.go
+++ b/multicluster/controllers/multicluster/member/labelidentity_import_controller_test.go
@@ -124,7 +124,7 @@ func TestLabelIdentityResourceImportReconcile(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tt.existLabelIdentity).Build()
 			fakeRemoteClient := fake.NewClientBuilder().WithScheme(scheme).WithLists(&tt.existResImp).Build()
 			remoteCluster := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", localClusterID, "default", nil)
-			r := NewLabelIdentityResourceImportReconciler(fakeClient, scheme, fakeClient, localClusterID, "default", remoteCluster)
+			r := newLabelIdentityResourceImportReconciler(fakeClient, scheme, fakeClient, localClusterID, "default", remoteCluster)
 
 			resImpReq := ctrl.Request{NamespacedName: tt.resImportNamespacedName}
 			_, err := r.Reconcile(ctx, resImpReq)

--- a/multicluster/controllers/multicluster/member/resourceimport_controller.go
+++ b/multicluster/controllers/multicluster/member/resourceimport_controller.go
@@ -69,7 +69,7 @@ type ResourceImportReconciler struct {
 	manager ctrl.Manager
 }
 
-func NewResourceImportReconciler(client client.Client, scheme *runtime.Scheme, localClusterClient client.Client,
+func newResourceImportReconciler(client client.Client, scheme *runtime.Scheme, localClusterClient client.Client,
 	localClusterID string, namespace string, remoteCommonArea commonarea.RemoteCommonArea) *ResourceImportReconciler {
 	return &ResourceImportReconciler{
 		Client:             client,

--- a/multicluster/controllers/multicluster/member/resourceimport_controller_test.go
+++ b/multicluster/controllers/multicluster/member/resourceimport_controller_test.go
@@ -141,7 +141,7 @@ func TestResourceImportReconciler_handleCreateEvent(t *testing.T) {
 		},
 	}
 
-	r := NewResourceImportReconciler(fakeClient, scheme, fakeClient, localClusterID, "default", remoteCluster)
+	r := newResourceImportReconciler(fakeClient, scheme, fakeClient, localClusterID, "default", remoteCluster)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if _, err := r.Reconcile(ctx, tt.req); err != nil {
@@ -211,7 +211,7 @@ func TestResourceImportReconciler_handleDeleteEvent(t *testing.T) {
 		},
 	}
 
-	r := NewResourceImportReconciler(fakeClient, scheme, fakeClient, localClusterID, "default", remoteCluster)
+	r := newResourceImportReconciler(fakeClient, scheme, fakeClient, localClusterID, "default", remoteCluster)
 	r.installedResImports.Add(*svcResImport)
 	r.installedResImports.Add(*epResImport)
 
@@ -452,7 +452,7 @@ func TestResourceImportReconciler_handleUpdateEvent(t *testing.T) {
 		},
 	}
 
-	r := NewResourceImportReconciler(fakeClient, scheme, fakeClient, localClusterID, "default", remoteCluster)
+	r := newResourceImportReconciler(fakeClient, scheme, fakeClient, localClusterID, "default", remoteCluster)
 	r.installedResImports.Add(*svcResImport)
 	r.installedResImports.Add(*epResImport)
 


### PR DESCRIPTION
Also change NewResourceImportReconciler and
NewLabelIdentityResourceImportReconciler to private funcs.

Signed-off-by: Jianjun Shen <shenj@vmware.com>