### PR TITLE
Add comment for constant "winpipe"

### DIFF
--- a/pkg/ovs/ovsconfig/default_windows.go
+++ b/pkg/ovs/ovsconfig/default_windows.go
@@ -23,6 +23,8 @@ import (
 const (
 	DefaultOVSRunDir = `C:\openvswitch\var\run\openvswitch`
 
+	// We use "winpipe" here because it is hardcoded as the socket value that is parsed in
+	// our openvswitch db library, https://github.com/TomCodeLV/OVSDB-golang-lib/tree/master/pkg/ovsdb.
 	defaultConnNetwork = "winpipe"
 	namedPipePrefix    = `\\.\pipe\`
 	// Wait up to 5 seconds when getting port.

--- a/pkg/ovs/ovsconfig/ovs_client.go
+++ b/pkg/ovs/ovsconfig/ovs_client.go
@@ -63,7 +63,7 @@ const (
 )
 
 // NewOVSDBConnectionUDS connects to the OVSDB server on the UNIX domain socket
-// specified by address.
+// or named pipe (on Windows) specified by address, never using any SSL connection option.
 // If address is set to "", the default UNIX domain socket path
 // "/run/openvswitch/db.sock" will be used.
 // Returns the OVSDB struct on success.


### PR DESCRIPTION
Improve comment to clarify that we connect to ovsdb
using unix domain socket or named pipe on windows,
never using any SSL connection option.

Fixes #4033

Signed-off-by: Kumar Atish <atish.iaf@gmail.com>