### PR TITLE
Automated cherry pick of #4494: Import auth to support different platforms

### DIFF
--- a/pkg/antctl/runtime/runtime.go
+++ b/pkg/antctl/runtime/runtime.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"strings"
 
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 


### PR DESCRIPTION
Cherry pick of #4494 on release-1.10.

#4494: Import auth to support different platforms

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.