### PR TITLE
Support limiting number of Egress IPs that can be assigned to a Node 

### DIFF
--- a/build/charts/antrea/README.md
+++ b/build/charts/antrea/README.md
@@ -67,6 +67,7 @@ Kubernetes: `>= 1.16.0-0`
 | disableTXChecksumOffload | bool | `false` | Disable TX checksum offloading for container network interfaces. It's supposed to be set to true when the datapath doesn't support TX checksum offloading, which causes packets to be dropped due to bad checksum. It affects Pods running on Linux Nodes only. |
 | dnsServerOverride | string | `""` | Address of DNS server, to override the kube-dns service. It's used to resolve hostname in FQDN policy. |
 | egress.exceptCIDRs | list | `[]` | CIDR ranges to which outbound Pod traffic will not be SNAT'd by Egresses. |
+| egress.maxEgressIPsPerNode | int | `255` | The maximum number of Egress IPs that can be assigned to a Node. It's useful when the Node network restricts the number of secondary IPs a Node can have, e.g. EKS. It must not be greater than 255. |
 | enableBridgingMode | bool | `false` | Enable bridging mode of Pod network on Nodes, in which the Node's transport interface is connected to the OVS bridge. |
 | featureGates | object | `{}` | To explicitly enable or disable a FeatureGate and bypass the Antrea defaults, add an entry to the dictionary with the FeatureGate's name as the key and a boolean as the value. |
 | flowCollector.activeFlowExportTimeout | string | `"5s"` | timeout after which a flow record is sent to the collector for active flows. |

--- a/build/charts/antrea/conf/antrea-agent.conf
+++ b/build/charts/antrea/conf/antrea-agent.conf
@@ -169,6 +169,9 @@ egress:
   {{- with .exceptCIDRs }}
   {{- toYaml . | nindent 4 }}
   {{- end }}
+  # The maximum number of Egress IPs that can be assigned to a Node. It's useful when the Node network restricts
+  # the number of secondary IPs a Node can have, e.g. EKS. It must not be greater than 255.
+  maxEgressIPsPerNode: {{ .maxEgressIPsPerNode }}
 {{- end }}
 
 # ClusterIP CIDR range for Services. It's required when AntreaProxy is not enabled, and should be

--- a/build/charts/antrea/values.yaml
+++ b/build/charts/antrea/values.yaml
@@ -107,6 +107,9 @@ ipsec:
 egress:
   # -- CIDR ranges to which outbound Pod traffic will not be SNAT'd by Egresses.
   exceptCIDRs: []
+  # -- The maximum number of Egress IPs that can be assigned to a Node. It's useful when the Node network restricts
+  # the number of secondary IPs a Node can have, e.g. EKS. It must not be greater than 255.
+  maxEgressIPsPerNode: 255
 
 nodePortLocal:
   # -- Enable the NodePortLocal feature.

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -3087,6 +3087,9 @@ data:
     egress:
       # exceptCIDRs is the CIDR ranges to which outbound Pod traffic will not be SNAT'd by Egresses.
       exceptCIDRs:
+      # The maximum number of Egress IPs that can be assigned to a Node. It's useful when the Node network restricts
+      # the number of secondary IPs a Node can have, e.g. EKS. It must not be greater than 255.
+      maxEgressIPsPerNode: 255
 
     # ClusterIP CIDR range for Services. It's required when AntreaProxy is not enabled, and should be
     # set to the same value as the one specified by --service-cluster-ip-range for kube-apiserver. When
@@ -4294,7 +4297,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: a5cdb0e182ac7ccdd59fd7f435fa07bc90d48422fbdc98cdd53359aef80bf59a
+        checksum/config: 01eb4b4048215050463f3b01c05831615c060b02d6f379d6d27a80346185d544
       labels:
         app: antrea
         component: antrea-agent
@@ -4535,7 +4538,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: a5cdb0e182ac7ccdd59fd7f435fa07bc90d48422fbdc98cdd53359aef80bf59a
+        checksum/config: 01eb4b4048215050463f3b01c05831615c060b02d6f379d6d27a80346185d544
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -3087,6 +3087,9 @@ data:
     egress:
       # exceptCIDRs is the CIDR ranges to which outbound Pod traffic will not be SNAT'd by Egresses.
       exceptCIDRs:
+      # The maximum number of Egress IPs that can be assigned to a Node. It's useful when the Node network restricts
+      # the number of secondary IPs a Node can have, e.g. EKS. It must not be greater than 255.
+      maxEgressIPsPerNode: 255
 
     # ClusterIP CIDR range for Services. It's required when AntreaProxy is not enabled, and should be
     # set to the same value as the one specified by --service-cluster-ip-range for kube-apiserver. When
@@ -4294,7 +4297,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: a5cdb0e182ac7ccdd59fd7f435fa07bc90d48422fbdc98cdd53359aef80bf59a
+        checksum/config: 01eb4b4048215050463f3b01c05831615c060b02d6f379d6d27a80346185d544
       labels:
         app: antrea
         component: antrea-agent
@@ -4536,7 +4539,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: a5cdb0e182ac7ccdd59fd7f435fa07bc90d48422fbdc98cdd53359aef80bf59a
+        checksum/config: 01eb4b4048215050463f3b01c05831615c060b02d6f379d6d27a80346185d544
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -3087,6 +3087,9 @@ data:
     egress:
       # exceptCIDRs is the CIDR ranges to which outbound Pod traffic will not be SNAT'd by Egresses.
       exceptCIDRs:
+      # The maximum number of Egress IPs that can be assigned to a Node. It's useful when the Node network restricts
+      # the number of secondary IPs a Node can have, e.g. EKS. It must not be greater than 255.
+      maxEgressIPsPerNode: 255
 
     # ClusterIP CIDR range for Services. It's required when AntreaProxy is not enabled, and should be
     # set to the same value as the one specified by --service-cluster-ip-range for kube-apiserver. When
@@ -4294,7 +4297,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 0abb3d19aa5b5e3a83d4f46868d66f1904eab0572aed86ae91eb3c0e4d6cb75a
+        checksum/config: aff837005adc6d91f4b5ace3a87c08cfa49e26c60e284ebd234eea34ce5de91f
       labels:
         app: antrea
         component: antrea-agent
@@ -4533,7 +4536,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 0abb3d19aa5b5e3a83d4f46868d66f1904eab0572aed86ae91eb3c0e4d6cb75a
+        checksum/config: aff837005adc6d91f4b5ace3a87c08cfa49e26c60e284ebd234eea34ce5de91f
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -3100,6 +3100,9 @@ data:
     egress:
       # exceptCIDRs is the CIDR ranges to which outbound Pod traffic will not be SNAT'd by Egresses.
       exceptCIDRs:
+      # The maximum number of Egress IPs that can be assigned to a Node. It's useful when the Node network restricts
+      # the number of secondary IPs a Node can have, e.g. EKS. It must not be greater than 255.
+      maxEgressIPsPerNode: 255
 
     # ClusterIP CIDR range for Services. It's required when AntreaProxy is not enabled, and should be
     # set to the same value as the one specified by --service-cluster-ip-range for kube-apiserver. When
@@ -4307,7 +4310,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 995b258674ed96418bc039673e5d725bf0dac26cabd1447bce5a995175f9a652
+        checksum/config: e3e3255bb4f4cd13bce262d8c8d5f4aead3e84e52ea1775c34898c69b80fad33
         checksum/ipsec-secret: d0eb9c52d0cd4311b6d252a951126bf9bea27ec05590bed8a394f0f792dcb2a4
       labels:
         app: antrea
@@ -4592,7 +4595,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 995b258674ed96418bc039673e5d725bf0dac26cabd1447bce5a995175f9a652
+        checksum/config: e3e3255bb4f4cd13bce262d8c8d5f4aead3e84e52ea1775c34898c69b80fad33
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -3087,6 +3087,9 @@ data:
     egress:
       # exceptCIDRs is the CIDR ranges to which outbound Pod traffic will not be SNAT'd by Egresses.
       exceptCIDRs:
+      # The maximum number of Egress IPs that can be assigned to a Node. It's useful when the Node network restricts
+      # the number of secondary IPs a Node can have, e.g. EKS. It must not be greater than 255.
+      maxEgressIPsPerNode: 255
 
     # ClusterIP CIDR range for Services. It's required when AntreaProxy is not enabled, and should be
     # set to the same value as the one specified by --service-cluster-ip-range for kube-apiserver. When
@@ -4294,7 +4297,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 9d9c26964205adb87ebfdd1eac07428ad82014be6014f70d1a46bf6731e8091d
+        checksum/config: 846220b3b64851cea85fb1e374c3ffdb29376ea729a494dad1cb230b3e5efe8c
       labels:
         app: antrea
         component: antrea-agent
@@ -4533,7 +4536,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 9d9c26964205adb87ebfdd1eac07428ad82014be6014f70d1a46bf6731e8091d
+        checksum/config: 846220b3b64851cea85fb1e374c3ffdb29376ea729a494dad1cb230b3e5efe8c
       labels:
         app: antrea
         component: antrea-controller

--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -462,7 +462,7 @@ func run(o *Options) error {
 	if egressEnabled {
 		egressController, err = egress.NewEgressController(
 			ofClient, antreaClientProvider, crdClient, ifaceStore, routeClient, nodeConfig.Name, nodeConfig.NodeTransportInterfaceName,
-			memberlistCluster, egressInformer, podUpdateChannel,
+			memberlistCluster, egressInformer, podUpdateChannel, o.config.Egress.MaxEgressIPsPerNode,
 		)
 		if err != nil {
 			return fmt.Errorf("error creating new Egress controller: %v", err)

--- a/cmd/antrea-agent/options.go
+++ b/cmd/antrea-agent/options.go
@@ -55,6 +55,7 @@ const (
 	defaultStaleConnectionTimeout  = 5 * time.Minute
 	defaultNPLPortRange            = "61000-62000"
 	defaultNodeType                = config.K8sNode
+	defaultMaxEgressIPsPerNode     = 255
 )
 
 type Options struct {
@@ -409,6 +410,12 @@ func (o *Options) setK8sNodeDefaultOptions() {
 		// Multicluster.EnableGateway.
 		o.config.Multicluster.EnableGateway = true
 	}
+
+	if features.DefaultFeatureGate.Enabled(features.Egress) {
+		if o.config.Egress.MaxEgressIPsPerNode == 0 {
+			o.config.Egress.MaxEgressIPsPerNode = defaultMaxEgressIPsPerNode
+		}
+	}
 }
 
 func (o *Options) validateK8sNodeOptions() error {
@@ -506,6 +513,12 @@ func (o *Options) validateK8sNodeOptions() error {
 			return fmt.Errorf("dnsServerOverride %s is invalid: %v", o.config.DNSServerOverride, err)
 		}
 		o.dnsServerOverride = hostPort
+	}
+
+	if features.DefaultFeatureGate.Enabled(features.Egress) {
+		if o.config.Egress.MaxEgressIPsPerNode > defaultMaxEgressIPsPerNode {
+			return fmt.Errorf("maxEgressIPsPerNode cannot be greater than %d", defaultMaxEgressIPsPerNode)
+		}
 	}
 	return nil
 }

--- a/pkg/agent/controller/serviceexternalip/controller_test.go
+++ b/pkg/agent/controller/serviceexternalip/controller_test.go
@@ -101,6 +101,10 @@ func (f *fakeMemberlistCluster) SelectNodeForIP(ip, externalIPPool string, filte
 	return selectNode, nil
 }
 
+func (f *fakeMemberlistCluster) ShouldSelectIP(ip string, pool string, filters ...func(node string) bool) (bool, error) {
+	return false, nil
+}
+
 type fakeController struct {
 	*ServiceExternalIPController
 	mockController        *gomock.Controller

--- a/pkg/agent/ipassigner/ip_assigner_linux.go
+++ b/pkg/agent/ipassigner/ip_assigner_linux.go
@@ -51,7 +51,7 @@ type ipAssigner struct {
 }
 
 // NewIPAssigner returns an *ipAssigner.
-func NewIPAssigner(nodeTransportInterface string, dummyDeviceName string) (*ipAssigner, error) {
+func NewIPAssigner(nodeTransportInterface string, dummyDeviceName string) (IPAssigner, error) {
 	ipv4, ipv6, externalInterface, err := util.GetIPNetDeviceByName(nodeTransportInterface)
 	if err != nil {
 		return nil, fmt.Errorf("get IPNetDevice from name %s error: %+v", nodeTransportInterface, err)

--- a/pkg/agent/ipassigner/ip_assigner_windows.go
+++ b/pkg/agent/ipassigner/ip_assigner_windows.go
@@ -14,32 +14,8 @@
 
 package ipassigner
 
-import (
-	"k8s.io/apimachinery/pkg/util/sets"
-)
+import "errors"
 
-type ipAssigner struct {
-}
-
-func NewIPAssigner(nodeTransportInterface string, dummyDeviceName string) (*ipAssigner, error) {
-	return nil, nil
-}
-
-func (a *ipAssigner) AssignIP(ip string) error {
-	return nil
-}
-
-func (a *ipAssigner) UnassignIP(ip string) error {
-	return nil
-}
-
-func (a *ipAssigner) AssignedIPs() sets.String {
-	return nil
-}
-
-func (a *ipAssigner) InitIPs(ips sets.String) error {
-	return nil
-}
-
-func (a *ipAssigner) Run(ch <-chan struct{}) {
+func NewIPAssigner(nodeTransportInterface string, dummyDeviceName string) (IPAssigner, error) {
+	return nil, errors.New("IPAssigner is not implemented on Windows")
 }

--- a/pkg/agent/memberlist/cluster.go
+++ b/pkg/agent/memberlist/cluster.go
@@ -83,6 +83,7 @@ var mapNodeEventType = map[memberlist.NodeEventType]nodeEventType{
 type ClusterNodeEventHandler func(objName string)
 
 type Interface interface {
+	ShouldSelectIP(ip string, pool string, filters ...func(node string) bool) (bool, error)
 	SelectNodeForIP(ip, externalIPPool string, filters ...func(string) bool) (string, error)
 	AliveNodes() sets.String
 	AddClusterEventHandler(handler ClusterNodeEventHandler)
@@ -517,9 +518,6 @@ func (c *Cluster) ShouldSelectIP(ip, externalIPPool string, filters ...func(stri
 		return false, fmt.Errorf("local Node consistentHashMap has not synced, ExternalIPPool %s", externalIPPool)
 	}
 	node := consistentHash.GetWithFilters(ip, filters...)
-	if node == "" && len(filters) > 0 {
-		return false, ErrNoNodeAvailable
-	}
 	return node == c.nodeName, nil
 }
 

--- a/pkg/config/agent/config.go
+++ b/pkg/config/agent/config.go
@@ -271,6 +271,10 @@ type MulticastConfig struct {
 
 type EgressConfig struct {
 	ExceptCIDRs []string `yaml:"exceptCIDRs,omitempty"`
+	// The maximum number of Egress IPs that can be assigned to a Node. It's useful when the Node network restricts
+	// the number of secondary IPs a Node can have, e.g. EKS. It must not be greater than 255.
+	// Defaults to 255.
+	MaxEgressIPsPerNode int `yaml:"maxEgressIPsPerNode,omitempty"`
 }
 
 type IPsecConfig struct {


### PR DESCRIPTION
The current implementation of Egress uses 8 bits of pkt mark to indicate which SNAT IP the egress traffic should use, which means at most 255 Egress IPs can be assigned to a single Node. Besides, some Node network may restrict the number of secondary IPs that can be assigned to a Node, e.g. EKS.

This patch adds a configuration option maxEgressIPsPerNode and makes it default to 255. When a Node cannot accommodate more Egress IPs, the next Node will be tried, until an available Node is found or all Nodes are tried.

Signed-off-by: Quan Tian <qtian@vmware.com>