### PR TITLE
Introduce "Failed" phase in ANP status

### DIFF
--- a/pkg/apis/crd/v1alpha1/types.go
+++ b/pkg/apis/crd/v1alpha1/types.go
@@ -344,6 +344,8 @@ const (
 	NetworkPolicyRealizing NetworkPolicyPhase = "Realizing"
 	// NetworkPolicyRealized means the NetworkPolicy has been enforced to all Pods on all Nodes it applies to.
 	NetworkPolicyRealized NetworkPolicyPhase = "Realized"
+	// NetworkPolicyFailed means the NetworkPolicy is failed to be enforced on at least one Node.
+	NetworkPolicyFailed NetworkPolicyPhase = "Failed"
 )
 
 // These are valid conditions of a deployment.

--- a/pkg/controller/networkpolicy/status_controller.go
+++ b/pkg/controller/networkpolicy/status_controller.go
@@ -336,6 +336,8 @@ func (c *StatusController) syncHandler(key string) error {
 	phase := crdv1alpha1.NetworkPolicyRealizing
 	if currentNodes == desiredNodes {
 		phase = crdv1alpha1.NetworkPolicyRealized
+	} else if currentNodes+len(failedNodes) == desiredNodes {
+		phase = crdv1alpha1.NetworkPolicyFailed
 	}
 
 	return updateStatus(phase, currentNodes, desiredNodes, conditions)

--- a/pkg/controller/networkpolicy/status_controller_test.go
+++ b/pkg/controller/networkpolicy/status_controller_test.go
@@ -259,14 +259,14 @@ func TestCreateAntreaNetworkPolicy(t *testing.T) {
 				newNetworkPolicyStatus("cnp1", "node2", 5, "agent crash"),
 			},
 			expectedANPStatus: &crdv1alpha1.NetworkPolicyStatus{
-				Phase:                crdv1alpha1.NetworkPolicyRealizing,
+				Phase:                crdv1alpha1.NetworkPolicyFailed,
 				ObservedGeneration:   4,
 				CurrentNodesRealized: 1,
 				DesiredNodesRealized: 2,
 				Conditions:           generateRealizationFailureConditions(1, `"node1":"agent failure"`),
 			},
 			expectedCNPStatus: &crdv1alpha1.NetworkPolicyStatus{
-				Phase:                crdv1alpha1.NetworkPolicyRealizing,
+				Phase:                crdv1alpha1.NetworkPolicyFailed,
 				ObservedGeneration:   5,
 				CurrentNodesRealized: 0,
 				DesiredNodesRealized: 2,


### PR DESCRIPTION
Modify the ANP status phase as "Failed" when all Agents have reported the status and at least one failure is received.

Signed-off-by: wenyingd <wenyingd@vmware.com>