### PR TITLE
Support L7 Network Policy Logging

### DIFF
--- a/docs/antrea-l7-network-policy.md
+++ b/docs/antrea-l7-network-policy.md
@@ -8,6 +8,7 @@
 - [Usage](#usage)
   - [HTTP](#http)
     - [More examples](#more-examples)
+  - [Logs](#logs)
 - [Limitations](#limitations)
 <!-- /toc -->
 
@@ -198,6 +199,80 @@ spec:
       action: Allow      # As the rule's "from" and "ports" are empty, which means it selects traffic from any network
       l7Protocols:       # peer to any port of the Pods this policy applies to, all inbound non-HTTP requests will be
         - http: {}       # automatically dropped, and subsequent rules will not be considered.
+```
+
+### Logs
+
+Layer 7 traffic that matches the NetworkPolicy will be logged in an event
+triggered log file (`/var/log/antrea/networkpolicy/l7engine/eve-YEAR-MONTH-DAY.json`).
+The event type for this log is `alert`. If `enableLogging` is set for the rule,
+packets that match the rule will also be logged in addition to the event with
+event type `packet`. Below is an example of the two event types.
+
+Deny ingress from client (10.10.1.5) to web (10.10.1.4/admin)
+
+```json
+{
+  "timestamp": "2023-03-09T20:00:28.210821+0000",
+  "flow_id": 627175734391745,
+  "in_iface": "antrea-l7-tap0",
+  "event_type": "alert",
+  "vlan": [
+    1
+  ],
+  "src_ip": "10.10.1.5",
+  "src_port": 43352,
+  "dest_ip": "10.10.1.4",
+  "dest_port": 80,
+  "proto": "TCP",
+  "alert": {
+    "action": "blocked",
+    "gid": 1,
+    "signature_id": 1,
+    "rev": 0,
+    "signature": "Reject by AntreaClusterNetworkPolicy:test-l7-ingress",
+    "category": "",
+    "severity": 3,
+    "tenant_id": 1
+  },
+  "http": {
+    "hostname": "10.10.1.4",
+    "url": "/admin",
+    "http_user_agent": "curl/7.74.0",
+    "http_method": "GET",
+    "protocol": "HTTP/1.1",
+    "length": 0
+  },
+  "app_proto": "http",
+  "flow": {
+    "pkts_toserver": 3,
+    "pkts_toclient": 1,
+    "bytes_toserver": 284,
+    "bytes_toclient": 74,
+    "start": "2023-03-09T20:00:28.209857+0000"
+  }
+}
+```
+
+```json
+{
+  "timestamp": "2023-03-09T20:00:28.225016+0000",
+  "flow_id": 627175734391745,
+  "in_iface": "antrea-l7-tap0",
+  "event_type": "packet",
+  "vlan": [
+    1
+  ],
+  "src_ip": "10.10.1.4",
+  "src_port": 80,
+  "dest_ip": "10.10.1.5",
+  "dest_port": 43352,
+  "proto": "TCP",
+  "packet": "/lhtPRglzmQvxnJoCABFAAAoUGYAAEAGFE4KCgEECgoBBQBQqVhIGzbi/odenlAUAfsR7QAA",
+  "packet_info": {
+    "linktype": 1
+  }
+}
 ```
 
 ## Limitations

--- a/docs/antrea-network-policy.md
+++ b/docs/antrea-network-policy.md
@@ -706,7 +706,9 @@ traffic that matches the "DropToThirdParty" egress rule, while the rule
 "AllowFromFrontend" is not logged. Specifically for drop and reject rules,
 deduplication is applied to reduce duplicated logs, and duplication buffer
 length is set to 1 second. If a rule name is not provided, an identifiable
-name will be generated for the rule and displayed in the log.
+name will be generated for the rule and displayed in the log. For rules in layer
+7 NetworkPolicy, packets are logged with action `Redirect` prior to analysis by
+the layer 7 engine, more details are available in the corresponding engine logs.
 The rules are logged in the following format:
 
 ```text

--- a/pkg/agent/controller/networkpolicy/audit_logging.go
+++ b/pkg/agent/controller/networkpolicy/audit_logging.go
@@ -195,6 +195,17 @@ func getNetworkPolicyInfo(pktIn *ofctrl.PacketIn, c *Controller, ob *logInfo) er
 	}
 	ob.disposition = openflow.DispositionToString[disposition]
 
+	// Get layer 7 NetworkPolicy redirect action, if traffic is redirected, disposition log should be overwritten.
+	if match = getMatchRegField(matchers, openflow.L7NPRegField); match != nil {
+		l7NPRegVal, err := getInfoInReg(match, openflow.L7NPRegField.GetRange().ToNXRange())
+		if err != nil {
+			return fmt.Errorf("received error while unloading l7 NP redirect value from reg: %v", err)
+		}
+		if l7NPRegVal == openflow.DispositionL7NPRedirect {
+			ob.disposition = "Redirect"
+		}
+	}
+
 	// Set match to corresponding ingress/egress reg according to disposition.
 	match = getMatch(matchers, tableID, disposition)
 

--- a/pkg/agent/controller/networkpolicy/l7engine/reconciler.go
+++ b/pkg/agent/controller/networkpolicy/l7engine/reconciler.go
@@ -36,6 +36,7 @@ import (
 const (
 	defaultSuricataConfigPath = "/etc/suricata/suricata.yaml"
 	antreaSuricataConfigPath  = "/etc/suricata/antrea.yaml"
+	antreaSuricataLogPath     = "/var/log/antrea/networkpolicy/l7engine/"
 
 	tenantConfigsDir = "/etc/suricata"
 	tenantRulesDir   = "/etc/suricata/rules"
@@ -104,12 +105,19 @@ func NewReconciler() *Reconciler {
 	}
 }
 
-func generateTenantRulesData(policyName string, protoKeywords map[string]sets.String) *bytes.Buffer {
+func generateTenantRulesData(policyName string, protoKeywords map[string]sets.String, enableLogging bool) *bytes.Buffer {
 	rulesData := bytes.NewBuffer(nil)
 	sid := 1
 
+	// Enable logging of packets in the session that set off the rule, the session is tagged for 30 seconds.
+	// Refer to Suricata detect engine in codebase for detailed tag keyword configuration.
+	var tagKeyword string
+	if enableLogging {
+		tagKeyword = " tag: session, 30, seconds;"
+	}
+
 	// Generate default reject rule.
-	allKeywords := fmt.Sprintf(`msg: "Reject by %s"; flow: to_server, established; sid: %d;`, policyName, sid)
+	allKeywords := fmt.Sprintf(`msg: "Reject by %s"; flow: to_server, established;%s sid: %d;`, policyName, tagKeyword, sid)
 	rule := fmt.Sprintf("reject ip any any -> any any (%s)\n", allKeywords)
 	rulesData.WriteString(rule)
 	sid++
@@ -120,9 +128,9 @@ func generateTenantRulesData(policyName string, protoKeywords map[string]sets.St
 			// It is a convention that the sid is provided as the last keyword (or second-to-last if there is a rev)
 			// of a rule.
 			if keywords != "" {
-				allKeywords = fmt.Sprintf(`msg: "Allow %s by %s"; %s sid: %d;`, proto, policyName, keywords, sid)
+				allKeywords = fmt.Sprintf(`msg: "Allow %s by %s"; %s%s sid: %d;`, proto, policyName, keywords, tagKeyword, sid)
 			} else {
-				allKeywords = fmt.Sprintf(`msg: "Allow %s by %s"; sid: %d;`, proto, policyName, sid)
+				allKeywords = fmt.Sprintf(`msg: "Allow %s by %s";%s sid: %d;`, proto, policyName, tagKeyword, sid)
 			}
 			rule = fmt.Sprintf("pass %s any any -> any any (%s)\n", proto, allKeywords)
 			rulesData.WriteString(rule)
@@ -187,7 +195,7 @@ func convertProtocolHTTP(http *v1beta.HTTPProtocol) string {
 	return strings.Join(keywords, " ")
 }
 
-func (r *Reconciler) AddRule(ruleID, policyName string, vlanID uint32, l7Protocols []v1beta.L7Protocol) error {
+func (r *Reconciler) AddRule(ruleID, policyName string, vlanID uint32, l7Protocols []v1beta.L7Protocol, enableLogging bool) error {
 	start := time.Now()
 	defer func() {
 		klog.V(5).Infof("AddRule took %v", time.Since(start))
@@ -212,7 +220,7 @@ func (r *Reconciler) AddRule(ruleID, policyName string, vlanID uint32, l7Protoco
 	klog.InfoS("Reconciling L7 rule", "RuleID", ruleID, "PolicyName", policyName)
 	// Write the Suricata rules to file.
 	rulesPath := generateTenantRulesPath(vlanID)
-	rulesData := generateTenantRulesData(policyName, protoKeywords)
+	rulesData := generateTenantRulesData(policyName, protoKeywords, enableLogging)
 	if err := writeConfigFile(rulesPath, rulesData); err != nil {
 		return fmt.Errorf("failed to write Suricata rules data to file %s for L7 rule %s of %s", rulesPath, ruleID, policyName)
 	}
@@ -383,6 +391,20 @@ func (r *Reconciler) startSuricata() {
 	// /etc/suricata/suricata.yaml.
 	suricataAntreaConfigData := fmt.Sprintf(`%%YAML 1.1
 ---
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular
+      filename: eve-%%Y-%%m-%%d.json
+      rotate-interval: day
+      pcap-file: false
+      community-id: false
+      community-id-seed: 0
+      xff:
+        enabled: no
+      types:
+        - alert:
+            tagged-packets: yes
 af-packet:
   - interface: %[1]s
     threads: auto
@@ -449,8 +471,12 @@ multi-detect:
 }
 
 func startSuricata() {
+	// Create log directory /var/log/antrea/networkpolicy/l7engine/ for Suricata.
+	if err := os.Mkdir(antreaSuricataLogPath, os.ModePerm); err != nil {
+		klog.ErrorS(err, "Failed to create L7 Network Policy log directory", "Directory", antreaSuricataLogPath)
+	}
 	// Start Suricata with default Suricata config file /etc/suricata/suricata.yaml.
-	cmd := exec.Command("suricata", "-c", defaultSuricataConfigPath, "--af-packet", "-D")
+	cmd := exec.Command("suricata", "-c", defaultSuricataConfigPath, "--af-packet", "-D", "-l", antreaSuricataLogPath)
 	if err := cmd.Start(); err != nil {
 		klog.ErrorS(err, "Failed to start Suricata instance")
 	}

--- a/pkg/agent/controller/networkpolicy/l7engine/reconciler_test.go
+++ b/pkg/agent/controller/networkpolicy/l7engine/reconciler_test.go
@@ -106,6 +106,20 @@ func TestStartSuricata(t *testing.T) {
 	fe.startSuricata()
 
 	ok, err := afero.FileContainsBytes(defaultFS, antreaSuricataConfigPath, []byte(`---
+outputs:
+  - eve-log:
+      enabled: yes
+      filetype: regular
+      filename: eve-%Y-%m-%d.json
+      rotate-interval: day
+      pcap-file: false
+      community-id: false
+      community-id-seed: 0
+      xff:
+        enabled: no
+      types:
+        - alert:
+            tagged-packets: yes
 af-packet:
   - interface: antrea-l7-tap0
     threads: auto
@@ -187,7 +201,7 @@ func TestRuleLifecycle(t *testing.T) {
 			fe.startSuricataFn = fs.startSuricataFn
 
 			// Test add a L7 NetworkPolicy.
-			assert.NoError(t, fe.AddRule(ruleID, policyName, vlanID, tc.l7Protocols))
+			assert.NoError(t, fe.AddRule(ruleID, policyName, vlanID, tc.l7Protocols, false))
 
 			rulesPath := generateTenantRulesPath(vlanID)
 			ok, err := afero.FileContainsBytes(defaultFS, rulesPath, []byte(tc.expectedRules))
@@ -204,7 +218,7 @@ func TestRuleLifecycle(t *testing.T) {
 			assert.Equal(t, expectedScCommands, fs.calledScCommands)
 
 			// Update the added L7 NetworkPolicy.
-			assert.NoError(t, fe.AddRule(ruleID, policyName, vlanID, tc.updatedL7Protocols))
+			assert.NoError(t, fe.AddRule(ruleID, policyName, vlanID, tc.updatedL7Protocols, false))
 			expectedScCommands.Insert("reload-tenant 1 /etc/suricata/antrea-tenant-1.yaml")
 			assert.Equal(t, expectedScCommands, fs.calledScCommands)
 

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
@@ -58,7 +58,7 @@ const (
 )
 
 type L7RuleReconciler interface {
-	AddRule(ruleID, policyName string, vlanID uint32, l7Protocols []v1beta2.L7Protocol) error
+	AddRule(ruleID, policyName string, vlanID uint32, l7Protocols []v1beta2.L7Protocol, enableLogging bool) error
 	DeleteRule(ruleID string, vlanID uint32) error
 }
 
@@ -642,7 +642,7 @@ func (c *Controller) syncRule(key string) error {
 		vlanID := c.l7VlanIDAllocator.allocate(key)
 		rule.L7RuleVlanID = &vlanID
 
-		if err := c.l7RuleReconciler.AddRule(key, rule.SourceRef.ToString(), vlanID, rule.L7Protocols); err != nil {
+		if err := c.l7RuleReconciler.AddRule(key, rule.SourceRef.ToString(), vlanID, rule.L7Protocols, rule.EnableLogging); err != nil {
 			return err
 		}
 	}
@@ -687,7 +687,7 @@ func (c *Controller) syncRules(keys []string) error {
 				vlanID := c.l7VlanIDAllocator.allocate(key)
 				rule.L7RuleVlanID = &vlanID
 
-				if err := c.l7RuleReconciler.AddRule(key, rule.SourceRef.ToString(), vlanID, rule.L7Protocols); err != nil {
+				if err := c.l7RuleReconciler.AddRule(key, rule.SourceRef.ToString(), vlanID, rule.L7Protocols, rule.EnableLogging); err != nil {
 					return err
 				}
 			}

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
@@ -47,6 +47,15 @@ import (
 
 const testNamespace = "ns1"
 
+var mockOFTables = map[*openflow.Table]uint8{
+	openflow.AntreaPolicyEgressRuleTable:  uint8(5),
+	openflow.EgressRuleTable:              uint8(6),
+	openflow.EgressDefaultTable:           uint8(7),
+	openflow.AntreaPolicyIngressRuleTable: uint8(12),
+	openflow.IngressRuleTable:             uint8(13),
+	openflow.IngressDefaultTable:          uint8(14),
+}
+
 type antreaClientGetter struct {
 	clientset versioned.Interface
 }
@@ -203,15 +212,7 @@ func newNetworkPolicyWithMultipleRules(name string, uid types.UID, from, to, app
 }
 
 func prepareMockTables() {
-	openflow.InitMockTables(
-		map[*openflow.Table]uint8{
-			openflow.AntreaPolicyEgressRuleTable:  uint8(5),
-			openflow.EgressRuleTable:              uint8(6),
-			openflow.EgressDefaultTable:           uint8(7),
-			openflow.AntreaPolicyIngressRuleTable: uint8(12),
-			openflow.IngressRuleTable:             uint8(13),
-			openflow.IngressDefaultTable:          uint8(14),
-		})
+	openflow.InitMockTables(mockOFTables)
 }
 
 func TestAddSingleGroupRule(t *testing.T) {

--- a/pkg/agent/openflow/fields.go
+++ b/pkg/agent/openflow/fields.go
@@ -82,6 +82,9 @@ var (
 	CustomReasonIGMPRegMark    = binding.NewRegMark(CustomReasonField, CustomReasonIGMP)
 	// reg0[18]: Mark to indicate remote SNAT for Egress.
 	RemoteSNATRegMark = binding.NewOneBitRegMark(0, 18)
+	// reg0[19]: Field to indicate redirect action of layer 7 NetworkPolicy.
+	L7NPRegField        = binding.NewRegField(0, 19, 19)
+	L7NPRedirectRegMark = binding.NewRegMark(L7NPRegField, DispositionL7NPRedirect)
 
 	// reg1(NXM_NX_REG1)
 	// Field to cache the ofPort of the OVS interface where to output packet.

--- a/pkg/agent/openflow/openflow_test_utils.go
+++ b/pkg/agent/openflow/openflow_test_utils.go
@@ -25,6 +25,13 @@ func InitMockTables(tableMap map[*Table]uint8) {
 	}
 }
 
+// InitOFTableCache is used to update ofTableCache in tests.
+func InitOFTableCache(tableMap map[*Table]uint8) {
+	for ft := range tableMap {
+		tableCache.Update(ft)
+	}
+}
+
 // ResetOFTable is used for integration tests.
 func ResetOFTable() {
 	binding.ResetTableID()

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -346,11 +346,10 @@ const (
 	DispositionDrop  = 0b01
 	DispositionRej   = 0b10
 	DispositionPass  = 0b11
-
-	// CustomReasonLogging is used when send packet-in to controller indicating this
+	// CustomReasonLogging is used when sending packet-in to controller indicating this
 	// packet need logging.
 	CustomReasonLogging = 0b01
-	// CustomReasonReject is not only used when send packet-in to controller indicating
+	// CustomReasonReject is not only used when sending packet-in to controller indicating
 	// that this packet should be rejected, but also used in the case that when
 	// controller send reject packet as packet-out, we want reject response to bypass
 	// the connTrack to avoid unexpected drop.
@@ -362,6 +361,10 @@ const (
 	CustomReasonDeny = 0b100
 	CustomReasonDNS  = 0b1000
 	CustomReasonIGMP = 0b10000
+	// DispositionL7NPRedirect is used when sending packet-in to controller for
+	// logging layer 7 NetworkPolicy indicating that this packet is redirected to
+	// l7 engine to determine the disposition.
+	DispositionL7NPRedirect = 0b1
 
 	// EtherTypeDot1q is used when adding 802.1Q VLAN header in OVS action
 	EtherTypeDot1q = 0x8100
@@ -1773,8 +1776,8 @@ func (f *featureNetworkPolicy) conjunctionActionFlow(conjunctionID uint32, table
 			}
 			if l7RuleVlanID != nil {
 				return fb.
-					Action().LoadToRegField(conjReg, conjunctionID).                           // Traceflow.
-					Action().LoadRegMark(DispositionAllowRegMark, CustomReasonLoggingRegMark). // AntreaPolicy, Enable logging.
+					Action().LoadToRegField(conjReg, conjunctionID).                                                // Traceflow.
+					Action().LoadRegMark(DispositionAllowRegMark, CustomReasonLoggingRegMark, L7NPRedirectRegMark). // AntreaPolicy, Enable logging.
 					Action().SendToController(uint8(PacketInReasonNP)).
 					Action().CT(true, nextTable, ctZone, f.ctZoneSrcField). // CT action requires commit flag if actions other than NAT without arguments are specified.
 					LoadToLabelField(uint64(conjunctionID), labelField).


### PR DESCRIPTION
Fix inaccurate Antrea Native Policy logging, where the L7NP will be logged as `Redirect` not `Allow`. Update UT to cover more cases.

Add event log file for Suricata at `/var/log/antrea/networkpolicy/l7engine`. Due to the limitation of available Suricata options, currently `eve.log` logs all the alerts (`reject`&`pass`) regardless of `enableLogging`, event_type: "alert". Meanwhile packets are only logged if `enableLogging: true`, "event_type: "packet".