### PR TITLE
Improve Egress IP scheduling

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -466,7 +466,7 @@ func run(o *Options) error {
 	if egressEnabled {
 		egressController, err = egress.NewEgressController(
 			ofClient, antreaClientProvider, crdClient, ifaceStore, routeClient, nodeConfig.Name, nodeConfig.NodeTransportInterfaceName,
-			memberlistCluster, egressInformer, podUpdateChannel, o.config.Egress.MaxEgressIPsPerNode,
+			memberlistCluster, egressInformer, nodeInformer, podUpdateChannel, o.config.Egress.MaxEgressIPsPerNode,
 		)
 		if err != nil {
 			return fmt.Errorf("error creating new Egress controller: %v", err)

--- a/pkg/agent/controller/egress/ip_scheduler.go
+++ b/pkg/agent/controller/egress/ip_scheduler.go
@@ -1,0 +1,403 @@
+// Copyright 2023 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package egress
+
+import (
+	"sort"
+	"strconv"
+	"sync"
+	"sync/atomic"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
+	corev1informers "k8s.io/client-go/informers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+
+	"antrea.io/antrea/pkg/agent/memberlist"
+	"antrea.io/antrea/pkg/agent/types"
+	crdv1a2 "antrea.io/antrea/pkg/apis/crd/v1alpha2"
+	crdinformers "antrea.io/antrea/pkg/client/informers/externalversions/crd/v1alpha2"
+	crdlisters "antrea.io/antrea/pkg/client/listers/crd/v1alpha2"
+)
+
+const (
+	// workItem is the only item that will be enqueued, used to trigger Egress IP scheduling.
+	workItem = "key"
+)
+
+// scheduleEventHandler is a callback when an Egress is rescheduled.
+type scheduleEventHandler func(egress string)
+
+// scheduleResult is the schedule result of an Egress, including the effective Egress IP and Node.
+type scheduleResult struct {
+	ip   string
+	node string
+}
+
+// egressIPScheduler is responsible for scheduling Egress IPs to appropriate Nodes according to the Node selector of the
+// IP pool, taking Node's capacity into consideration.
+type egressIPScheduler struct {
+	// cluster is responsible for selecting a Node for a given IP and pool.
+	cluster memberlist.Interface
+
+	egressLister       crdlisters.EgressLister
+	egressListerSynced cache.InformerSynced
+
+	// queue is used to trigger scheduling. Triggering multiple times before the item is consumed will only cause one
+	// execution of scheduling.
+	queue workqueue.Interface
+
+	// mutex is used to protect scheduleResults.
+	mutex           sync.RWMutex
+	scheduleResults map[string]*scheduleResult
+	// scheduledOnce indicates whether scheduling has been executed at lease once.
+	scheduledOnce *atomic.Bool
+
+	// eventHandlers is the registered callbacks.
+	eventHandlers []scheduleEventHandler
+
+	// The default maximum number of Egress IPs a Node can accommodate.
+	maxEgressIPsPerNode int
+	// nodeToMaxEgressIPs caches the maximum number of Egress IPs of each Node gotten from Node annotation.
+	// It takes precedence over the default value.
+	nodeToMaxEgressIPs      map[string]int
+	nodeToMaxEgressIPsMutex sync.RWMutex
+}
+
+func NewEgressIPScheduler(cluster memberlist.Interface, egressInformer crdinformers.EgressInformer, nodeInformer corev1informers.NodeInformer, maxEgressIPsPerNode int) *egressIPScheduler {
+	s := &egressIPScheduler{
+		cluster:             cluster,
+		egressLister:        egressInformer.Lister(),
+		egressListerSynced:  egressInformer.Informer().HasSynced,
+		scheduleResults:     map[string]*scheduleResult{},
+		scheduledOnce:       &atomic.Bool{},
+		maxEgressIPsPerNode: maxEgressIPsPerNode,
+		nodeToMaxEgressIPs:  map[string]int{},
+		queue:               workqueue.New(),
+	}
+	egressInformer.Informer().AddEventHandlerWithResyncPeriod(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc:    s.addEgress,
+			UpdateFunc: s.updateEgress,
+			DeleteFunc: s.deleteEgress,
+		},
+		resyncPeriod,
+	)
+	nodeInformer.Informer().AddEventHandlerWithResyncPeriod(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: s.updateNode,
+			UpdateFunc: func(_, newObj interface{}) {
+				s.updateNode(newObj)
+			},
+			DeleteFunc: s.deleteNode,
+		},
+		resyncPeriod,
+	)
+
+	s.cluster.AddClusterEventHandler(func(poolName string) {
+		// Trigger scheduling regardless of which pool is changed.
+		s.queue.Add(workItem)
+	})
+	return s
+}
+
+func getMaxEgressIPsFromAnnotation(node *corev1.Node) (int, bool, error) {
+	maxEgressIPsStr, exists := node.Annotations[types.NodeMaxEgressIPsAnnotationKey]
+	if !exists {
+		return 0, false, nil
+	}
+	maxEgressIPs, err := strconv.Atoi(maxEgressIPsStr)
+	if err != nil {
+		return 0, false, err
+	}
+	return maxEgressIPs, true, nil
+}
+
+// updateNode processes Node ADD and UPDATE events.
+func (s *egressIPScheduler) updateNode(obj interface{}) {
+	node := obj.(*corev1.Node)
+	maxEgressIPs, found, err := getMaxEgressIPsFromAnnotation(node)
+	if err != nil {
+		klog.ErrorS(err, "The Node's max-egress-ips annotation was invalid", "node", node.Name)
+		if s.deleteMaxEgressIPsByNode(node.Name) {
+			s.queue.Add(workItem)
+		}
+		return
+	}
+	if !found {
+		if s.deleteMaxEgressIPsByNode(node.Name) {
+			s.queue.Add(workItem)
+		}
+		return
+	}
+	if s.updateMaxEgressIPsByNode(node.Name, maxEgressIPs) {
+		s.queue.Add(workItem)
+	}
+}
+
+// deleteNode processes Node DELETE events.
+func (s *egressIPScheduler) deleteNode(obj interface{}) {
+	node, ok := obj.(*corev1.Node)
+	if !ok {
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			klog.Errorf("Received unexpected object: %v", obj)
+			return
+		}
+		node, ok = deletedState.Obj.(*corev1.Node)
+		if !ok {
+			klog.Errorf("DeletedFinalStateUnknown contains non-Node object: %v", deletedState.Obj)
+			return
+		}
+	}
+	s.deleteMaxEgressIPsByNode(node.Name)
+}
+
+// addEgress processes Egress ADD events.
+func (s *egressIPScheduler) addEgress(obj interface{}) {
+	egress := obj.(*crdv1a2.Egress)
+	if !isEgressSchedulable(egress) {
+		return
+	}
+	s.queue.Add(workItem)
+	klog.V(2).InfoS("Egress ADD event triggered Egress IP scheduling", "egress", klog.KObj(egress))
+}
+
+// updateEgress processes Egress UPDATE events.
+func (s *egressIPScheduler) updateEgress(old, cur interface{}) {
+	oldEgress := old.(*crdv1a2.Egress)
+	curEgress := cur.(*crdv1a2.Egress)
+	if !isEgressSchedulable(oldEgress) && !isEgressSchedulable(curEgress) {
+		return
+	}
+	if oldEgress.Spec.EgressIP == curEgress.Spec.EgressIP && oldEgress.Spec.ExternalIPPool == curEgress.Spec.ExternalIPPool {
+		return
+	}
+	s.queue.Add(workItem)
+	klog.V(2).InfoS("Egress UPDATE event triggered Egress IP scheduling", "egress", klog.KObj(curEgress))
+}
+
+// deleteEgress processes Egress DELETE events.
+func (s *egressIPScheduler) deleteEgress(obj interface{}) {
+	egress, ok := obj.(*crdv1a2.Egress)
+	if !ok {
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			klog.Errorf("Received unexpected object: %v", obj)
+			return
+		}
+		egress, ok = deletedState.Obj.(*crdv1a2.Egress)
+		if !ok {
+			klog.Errorf("DeletedFinalStateUnknown contains non-Egress object: %v", deletedState.Obj)
+			return
+		}
+	}
+	if !isEgressSchedulable(egress) {
+		return
+	}
+	s.queue.Add(workItem)
+	klog.V(2).InfoS("Egress DELETE event triggered Egress IP scheduling", "egress", klog.KObj(egress))
+}
+
+func (s *egressIPScheduler) Run(stopCh <-chan struct{}) {
+	klog.InfoS("Starting Egress IP scheduler")
+	defer klog.InfoS("Shutting down Egress IP scheduler")
+	defer s.queue.ShutDown()
+
+	if !cache.WaitForCacheSync(stopCh, s.egressListerSynced) {
+		return
+	}
+
+	// Schedule at least once even if there is no Egress to unblock clients waiting for HasScheduled to return true.
+	s.queue.Add(workItem)
+
+	go func() {
+		for {
+			obj, quit := s.queue.Get()
+			if quit {
+				return
+			}
+			s.schedule()
+			s.queue.Done(obj)
+		}
+	}()
+
+	<-stopCh
+}
+
+func (s *egressIPScheduler) HasScheduled() bool {
+	return s.scheduledOnce.Load()
+}
+
+func (s *egressIPScheduler) AddEventHandler(handler scheduleEventHandler) {
+	s.eventHandlers = append(s.eventHandlers, handler)
+}
+
+func (s *egressIPScheduler) GetEgressIPAndNode(egress string) (string, string, bool) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	result, exists := s.scheduleResults[egress]
+	if !exists {
+		return "", "", false
+	}
+	return result.ip, result.node, true
+}
+
+// EgressesByCreationTimestamp sorts a list of Egresses by creation timestamp.
+type EgressesByCreationTimestamp []*crdv1a2.Egress
+
+func (o EgressesByCreationTimestamp) Len() int      { return len(o) }
+func (o EgressesByCreationTimestamp) Swap(i, j int) { o[i], o[j] = o[j], o[i] }
+func (o EgressesByCreationTimestamp) Less(i, j int) bool {
+	if o[i].CreationTimestamp.Equal(&o[j].CreationTimestamp) {
+		return o[i].Name < o[j].Name
+	}
+	return o[i].CreationTimestamp.Before(&o[j].CreationTimestamp)
+}
+
+// updateMaxEgressIPsByNode updates the maxEgressIPs for a given Node in the cache.
+// It returns whether there is a real change, which indicates if rescheduling is required.
+func (s *egressIPScheduler) updateMaxEgressIPsByNode(nodeName string, maxEgressIPs int) bool {
+	s.nodeToMaxEgressIPsMutex.Lock()
+	defer s.nodeToMaxEgressIPsMutex.Unlock()
+
+	oldMaxEgressIPs, exists := s.nodeToMaxEgressIPs[nodeName]
+	if exists && oldMaxEgressIPs == maxEgressIPs {
+		return false
+	}
+	// If the value equals to the default value, no need to cache it and trigger rescheduling.
+	if !exists && s.maxEgressIPsPerNode == maxEgressIPs {
+		return false
+	}
+	s.nodeToMaxEgressIPs[nodeName] = maxEgressIPs
+	return true
+}
+
+// deleteMaxEgressIPsByNode deletes the maxEgressIPs for a given Node in the cache.
+// It returns whether there is a real change, which indicates if rescheduling is required.
+func (s *egressIPScheduler) deleteMaxEgressIPsByNode(nodeName string) bool {
+	s.nodeToMaxEgressIPsMutex.Lock()
+	defer s.nodeToMaxEgressIPsMutex.Unlock()
+
+	_, exists := s.nodeToMaxEgressIPs[nodeName]
+	if !exists {
+		return false
+	}
+	delete(s.nodeToMaxEgressIPs, nodeName)
+	return true
+}
+
+// getMaxEgressIPsByNode gets the maxEgressIPs for a given Node.
+// If there isn't a value for the Node, the default value will be returned.
+func (s *egressIPScheduler) getMaxEgressIPsByNode(nodeName string) int {
+	s.nodeToMaxEgressIPsMutex.RLock()
+	defer s.nodeToMaxEgressIPsMutex.RUnlock()
+
+	maxEgressIPs, exists := s.nodeToMaxEgressIPs[nodeName]
+	if exists {
+		return maxEgressIPs
+	}
+	return s.maxEgressIPsPerNode
+}
+
+// schedule takes the spec of Egress and ExternalIPPool and the state of memberlist cluster as inputs, generates
+// scheduling results deterministically. When every Node's capacity is sufficient, each Egress's schedule is independent
+// and is only determined by the consistent hash map. When any Node's capacity is insufficient, one Egress's schedule
+// may be affected by Egresses created before it. It will be triggerred when any schedulable Egress changes or the state
+// of memberlist cluster changes, and will notify Egress schedule event subscribers of Egresses that are rescheduled.
+//
+// Note that it's possible that different agents decide different IP - Node assignment because their caches of Egress or
+// the states of memberlist cluster are inconsistent at a moment. But all agents should get the same schedule results
+// and correct IP assignment when their caches converge.
+func (s *egressIPScheduler) schedule() {
+	var egressesToUpdate []string
+	newResults := map[string]*scheduleResult{}
+	nodeToIPs := map[string]sets.String{}
+	egresses, _ := s.egressLister.List(labels.Everything())
+	// Sort Egresses by creation timestamp to make the result deterministic and prioritize objected created earlier
+	// when the total capacity is insufficient.
+	sort.Sort(EgressesByCreationTimestamp(egresses))
+	for _, egress := range egresses {
+		// Ignore Egresses that shouldn't be scheduled.
+		if !isEgressSchedulable(egress) {
+			continue
+		}
+
+		maxEgressIPsFilter := func(node string) bool {
+			// Count the Egress IPs that are already assigned to this Node.
+			ipsOnNode, _ := nodeToIPs[node]
+			numIPs := ipsOnNode.Len()
+			// Check if this Node can accommodate the new Egress IP.
+			if !ipsOnNode.Has(egress.Spec.EgressIP) {
+				numIPs += 1
+			}
+			return numIPs <= s.getMaxEgressIPsByNode(node)
+		}
+		node, err := s.cluster.SelectNodeForIP(egress.Spec.EgressIP, egress.Spec.ExternalIPPool, maxEgressIPsFilter)
+		if err != nil {
+			if err == memberlist.ErrNoNodeAvailable {
+				klog.InfoS("No Node is eligible for Egress", "egress", klog.KObj(egress))
+			} else {
+				klog.ErrorS(err, "Failed to select Node for Egress", "egress", klog.KObj(egress))
+			}
+			continue
+		}
+		result := &scheduleResult{
+			ip:   egress.Spec.EgressIP,
+			node: node,
+		}
+		newResults[egress.Name] = result
+
+		ips, exists := nodeToIPs[node]
+		if !exists {
+			ips = sets.NewString()
+			nodeToIPs[node] = ips
+		}
+		ips.Insert(egress.Spec.EgressIP)
+	}
+
+	func() {
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
+
+		// Identify Egresses whose schedule results are updated.
+		prevResults := s.scheduleResults
+		for egress, result := range newResults {
+			prevResult, exists := prevResults[egress]
+			if !exists || prevResult.ip != result.ip || prevResult.node != result.node {
+				egressesToUpdate = append(egressesToUpdate, egress)
+			}
+			delete(prevResults, egress)
+		}
+		for egress := range prevResults {
+			egressesToUpdate = append(egressesToUpdate, egress)
+		}
+
+		// Record the new results.
+		s.scheduleResults = newResults
+	}()
+
+	for _, egress := range egressesToUpdate {
+		for _, handler := range s.eventHandlers {
+			handler(egress)
+		}
+	}
+
+	s.scheduledOnce.Store(true)
+}

--- a/pkg/agent/controller/egress/ip_scheduler_test.go
+++ b/pkg/agent/controller/egress/ip_scheduler_test.go
@@ -1,0 +1,383 @@
+// Copyright 2023 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package egress
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"antrea.io/antrea/pkg/agent/consistenthash"
+	"antrea.io/antrea/pkg/agent/memberlist"
+	agenttypes "antrea.io/antrea/pkg/agent/types"
+	crdv1a2 "antrea.io/antrea/pkg/apis/crd/v1alpha2"
+	fakeversioned "antrea.io/antrea/pkg/client/clientset/versioned/fake"
+	crdinformers "antrea.io/antrea/pkg/client/informers/externalversions"
+)
+
+type fakeMemberlistCluster struct {
+	nodes         []string
+	hashMap       *consistenthash.Map
+	eventHandlers []memberlist.ClusterNodeEventHandler
+}
+
+func newFakeMemberlistCluster(nodes []string) *fakeMemberlistCluster {
+	hashMap := memberlist.NewNodeConsistentHashMap()
+	hashMap.Add(nodes...)
+	return &fakeMemberlistCluster{
+		nodes:   nodes,
+		hashMap: hashMap,
+	}
+}
+
+func (f *fakeMemberlistCluster) updateNodes(nodes []string) {
+	hashMap := memberlist.NewNodeConsistentHashMap()
+	hashMap.Add(nodes...)
+	f.hashMap = hashMap
+	for _, h := range f.eventHandlers {
+		h("dummy")
+	}
+}
+
+func (f *fakeMemberlistCluster) AddClusterEventHandler(h memberlist.ClusterNodeEventHandler) {
+	f.eventHandlers = append(f.eventHandlers, h)
+}
+
+func (f *fakeMemberlistCluster) AliveNodes() sets.String {
+	return sets.NewString(f.nodes...)
+}
+
+func (f *fakeMemberlistCluster) SelectNodeForIP(ip, externalIPPool string, filters ...func(string) bool) (string, error) {
+	node := f.hashMap.GetWithFilters(ip, filters...)
+	if node == "" {
+		return "", memberlist.ErrNoNodeAvailable
+	}
+	return node, nil
+}
+
+func (f *fakeMemberlistCluster) ShouldSelectIP(ip string, pool string, filters ...func(node string) bool) (bool, error) {
+	return false, nil
+}
+
+func TestSchedule(t *testing.T) {
+	egresses := []runtime.Object{
+		&crdv1a2.Egress{
+			ObjectMeta: metav1.ObjectMeta{Name: "egressA", UID: "uidA", CreationTimestamp: metav1.NewTime(time.Unix(1, 0))},
+			Spec:       crdv1a2.EgressSpec{EgressIP: "1.1.1.1", ExternalIPPool: "pool1"},
+		},
+		&crdv1a2.Egress{
+			ObjectMeta: metav1.ObjectMeta{Name: "egressB", UID: "uidB", CreationTimestamp: metav1.NewTime(time.Unix(2, 0))},
+			Spec:       crdv1a2.EgressSpec{EgressIP: "1.1.1.11", ExternalIPPool: "pool1"},
+		},
+		&crdv1a2.Egress{
+			ObjectMeta: metav1.ObjectMeta{Name: "egressC", UID: "uidC", CreationTimestamp: metav1.NewTime(time.Unix(3, 0))},
+			Spec:       crdv1a2.EgressSpec{EgressIP: "1.1.1.21", ExternalIPPool: "pool1"},
+		},
+	}
+	tests := []struct {
+		name                string
+		nodes               []string
+		maxEgressIPsPerNode int
+		nodeToMaxEgressIPs  map[string]int
+		expectedResults     map[string]*scheduleResult
+	}{
+		{
+			name:                "sufficient capacity",
+			nodes:               []string{"node1", "node2", "node3"},
+			maxEgressIPsPerNode: 3,
+			expectedResults: map[string]*scheduleResult{
+				"egressA": {
+					node: "node1",
+					ip:   "1.1.1.1",
+				},
+				"egressB": {
+					node: "node3",
+					ip:   "1.1.1.11",
+				},
+				"egressC": {
+					node: "node1",
+					ip:   "1.1.1.21",
+				},
+			},
+		},
+		{
+			name:                "node specific limit",
+			nodes:               []string{"node1", "node2", "node3"},
+			maxEgressIPsPerNode: 3,
+			nodeToMaxEgressIPs: map[string]int{
+				"node1": 0,
+				"node2": 2,
+				"node3": 0,
+			},
+			expectedResults: map[string]*scheduleResult{
+				"egressA": {
+					node: "node2",
+					ip:   "1.1.1.1",
+				},
+				"egressB": {
+					node: "node2",
+					ip:   "1.1.1.11",
+				},
+			},
+		},
+		{
+			name:                "insufficient node capacity",
+			nodes:               []string{"node1", "node2", "node3"},
+			maxEgressIPsPerNode: 1,
+			// egressC was moved to node2 due to insufficient node capacity.
+			expectedResults: map[string]*scheduleResult{
+				"egressA": {
+					node: "node1",
+					ip:   "1.1.1.1",
+				},
+				"egressB": {
+					node: "node3",
+					ip:   "1.1.1.11",
+				},
+				"egressC": {
+					node: "node2",
+					ip:   "1.1.1.21",
+				},
+			},
+		},
+		{
+			name:                "insufficient cluster capacity",
+			nodes:               []string{"node1", "node3"},
+			maxEgressIPsPerNode: 1,
+			// egressC was not scheduled to any Node due to insufficient node capacity.
+			expectedResults: map[string]*scheduleResult{
+				"egressA": {
+					node: "node1",
+					ip:   "1.1.1.1",
+				},
+				"egressB": {
+					node: "node3",
+					ip:   "1.1.1.11",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeCluster := newFakeMemberlistCluster(tt.nodes)
+			crdClient := fakeversioned.NewSimpleClientset(egresses...)
+			crdInformerFactory := crdinformers.NewSharedInformerFactory(crdClient, 0)
+			egressInformer := crdInformerFactory.Crd().V1alpha2().Egresses()
+			clientset := fake.NewSimpleClientset()
+			informerFactory := informers.NewSharedInformerFactory(clientset, 0)
+			nodeInformer := informerFactory.Core().V1().Nodes()
+
+			s := NewEgressIPScheduler(fakeCluster, egressInformer, nodeInformer, tt.maxEgressIPsPerNode)
+			s.nodeToMaxEgressIPs = tt.nodeToMaxEgressIPs
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+			crdInformerFactory.Start(stopCh)
+			informerFactory.Start(stopCh)
+			crdInformerFactory.WaitForCacheSync(stopCh)
+			informerFactory.WaitForCacheSync(stopCh)
+
+			s.schedule()
+			assert.Equal(t, tt.expectedResults, s.scheduleResults)
+		})
+	}
+}
+
+func BenchmarkSchedule(b *testing.B) {
+	var egresses []runtime.Object
+	for i := 0; i < 1000; i++ {
+		egresses = append(egresses, &crdv1a2.Egress{
+			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("egress-%d", i), UID: types.UID(fmt.Sprintf("uid-%d", i)), CreationTimestamp: metav1.NewTime(time.Unix(int64(i), 0))},
+			Spec:       crdv1a2.EgressSpec{EgressIP: fmt.Sprintf("1.1.%d.%d", rand.Intn(256), rand.Intn(256)), ExternalIPPool: "pool1"},
+		})
+	}
+	var nodes []string
+	for i := 0; i < 1000; i++ {
+		nodes = append(nodes, fmt.Sprintf("node-%d", i))
+	}
+	fakeCluster := newFakeMemberlistCluster(nodes)
+	crdClient := fakeversioned.NewSimpleClientset(egresses...)
+	crdInformerFactory := crdinformers.NewSharedInformerFactory(crdClient, 0)
+	egressInformer := crdInformerFactory.Crd().V1alpha2().Egresses()
+	clientset := fake.NewSimpleClientset()
+	informerFactory := informers.NewSharedInformerFactory(clientset, 0)
+	nodeInformer := informerFactory.Core().V1().Nodes()
+
+	s := NewEgressIPScheduler(fakeCluster, egressInformer, nodeInformer, 10)
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	crdInformerFactory.Start(stopCh)
+	informerFactory.Start(stopCh)
+	crdInformerFactory.WaitForCacheSync(stopCh)
+	informerFactory.WaitForCacheSync(stopCh)
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		s.schedule()
+	}
+}
+
+func TestRun(t *testing.T) {
+	ctx := context.Background()
+	egresses := []runtime.Object{
+		&crdv1a2.Egress{
+			ObjectMeta: metav1.ObjectMeta{Name: "egressA", UID: "uidA", CreationTimestamp: metav1.NewTime(time.Unix(1, 0))},
+			Spec:       crdv1a2.EgressSpec{EgressIP: "1.1.1.1", ExternalIPPool: "pool1"},
+		},
+		&crdv1a2.Egress{
+			ObjectMeta: metav1.ObjectMeta{Name: "egressB", UID: "uidB", CreationTimestamp: metav1.NewTime(time.Unix(2, 0))},
+			Spec:       crdv1a2.EgressSpec{EgressIP: "1.1.1.11", ExternalIPPool: "pool1"},
+		},
+		&crdv1a2.Egress{
+			ObjectMeta: metav1.ObjectMeta{Name: "egressC", UID: "uidC", CreationTimestamp: metav1.NewTime(time.Unix(3, 0))},
+			Spec:       crdv1a2.EgressSpec{EgressIP: "1.1.1.21", ExternalIPPool: "pool1"},
+		},
+	}
+	node1 := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "node1",
+			Annotations: map[string]string{},
+		},
+	}
+	node2 := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "node2",
+			Annotations: map[string]string{},
+		},
+	}
+	fakeCluster := newFakeMemberlistCluster([]string{"node1", "node2"})
+	crdClient := fakeversioned.NewSimpleClientset(egresses...)
+	crdInformerFactory := crdinformers.NewSharedInformerFactory(crdClient, 0)
+	egressInformer := crdInformerFactory.Crd().V1alpha2().Egresses()
+	clientset := fake.NewSimpleClientset(node1, node2)
+	informerFactory := informers.NewSharedInformerFactory(clientset, 0)
+	nodeInformer := informerFactory.Core().V1().Nodes()
+
+	s := NewEgressIPScheduler(fakeCluster, egressInformer, nodeInformer, 2)
+	egressUpdates := make(chan string, 10)
+	s.AddEventHandler(func(egress string) {
+		egressUpdates <- egress
+	})
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	crdInformerFactory.Start(stopCh)
+	informerFactory.Start(stopCh)
+	crdInformerFactory.WaitForCacheSync(stopCh)
+	informerFactory.WaitForCacheSync(stopCh)
+
+	go s.Run(stopCh)
+
+	// The original distribution when the total capacity is sufficient.
+	assertReceivedItems(t, egressUpdates, sets.NewString("egressA", "egressB", "egressC"))
+	assertScheduleResult(t, s, "egressA", "1.1.1.1", "node1", true)
+	assertScheduleResult(t, s, "egressB", "1.1.1.11", "node2", true)
+	assertScheduleResult(t, s, "egressC", "1.1.1.21", "node1", true)
+
+	// After egressA is updated, it should be moved to node2 determined by its consistent hash result.
+	patch := map[string]interface{}{
+		"spec": map[string]string{
+			"egressIP": "1.1.1.5",
+		},
+	}
+	patchBytes, _ := json.Marshal(patch)
+	crdClient.CrdV1alpha2().Egresses().Patch(context.TODO(), "egressA", types.MergePatchType, patchBytes, metav1.PatchOptions{})
+	assertReceivedItems(t, egressUpdates, sets.NewString("egressA"))
+	assertScheduleResult(t, s, "egressA", "1.1.1.5", "node2", true)
+	assertScheduleResult(t, s, "egressB", "1.1.1.11", "node2", true)
+	assertScheduleResult(t, s, "egressC", "1.1.1.21", "node1", true)
+
+	// After node2 leaves, egress A and egressB should be moved to node1 as they were created earlier than egressC.
+	// egressC should be left unassigned.
+	fakeCluster.updateNodes([]string{"node1"})
+	assertReceivedItems(t, egressUpdates, sets.NewString("egressA", "egressB", "egressC"))
+	assertScheduleResult(t, s, "egressA", "1.1.1.5", "node1", true)
+	assertScheduleResult(t, s, "egressB", "1.1.1.11", "node1", true)
+	assertScheduleResult(t, s, "egressC", "", "", false)
+
+	// After egressA is deleted, egressC should be assigned to node1.
+	crdClient.CrdV1alpha2().Egresses().Delete(ctx, "egressA", metav1.DeleteOptions{})
+	assertReceivedItems(t, egressUpdates, sets.NewString("egressA", "egressC"))
+	assertScheduleResult(t, s, "egressA", "", "", false)
+	assertScheduleResult(t, s, "egressB", "1.1.1.11", "node1", true)
+	assertScheduleResult(t, s, "egressC", "1.1.1.21", "node1", true)
+
+	// After egressD is created, it should be left unassigned as the total capacity is insufficient.
+	crdClient.CrdV1alpha2().Egresses().Create(ctx, &crdv1a2.Egress{
+		ObjectMeta: metav1.ObjectMeta{Name: "egressD", UID: "uidD", CreationTimestamp: metav1.NewTime(time.Unix(4, 0))},
+		Spec:       crdv1a2.EgressSpec{EgressIP: "1.1.1.1", ExternalIPPool: "pool1"},
+	}, metav1.CreateOptions{})
+	assertReceivedItems(t, egressUpdates, sets.NewString())
+	assertScheduleResult(t, s, "egressD", "", "", false)
+
+	// After node2 joins, egressB should be moved to node2 determined by its consistent hash result, and egressD should be assigned to node1.
+	fakeCluster.updateNodes([]string{"node1", "node2"})
+	assertReceivedItems(t, egressUpdates, sets.NewString("egressB", "egressD"))
+	assertScheduleResult(t, s, "egressB", "1.1.1.11", "node2", true)
+	assertScheduleResult(t, s, "egressC", "1.1.1.21", "node1", true)
+	assertScheduleResult(t, s, "egressD", "1.1.1.1", "node1", true)
+
+	// Set node1's max-egress-ips annotation to invalid value, nothing should happen.
+	updatedNode1 := node1.DeepCopy()
+	updatedNode1.Annotations[agenttypes.NodeMaxEgressIPsAnnotationKey] = "invalid-value"
+	clientset.CoreV1().Nodes().Update(ctx, updatedNode1, metav1.UpdateOptions{})
+	assertReceivedItems(t, egressUpdates, sets.NewString())
+	// Set node1's max-egress-ips annotation to 1, egressD should be moved to node2.
+	updatedNode1 = node1.DeepCopy()
+	updatedNode1.Annotations[agenttypes.NodeMaxEgressIPsAnnotationKey] = "1"
+	clientset.CoreV1().Nodes().Update(ctx, updatedNode1, metav1.UpdateOptions{})
+	assertReceivedItems(t, egressUpdates, sets.NewString("egressD"))
+	assertScheduleResult(t, s, "egressD", "1.1.1.1", "node2", true)
+	// Unset node1's max-egress-ips annotation, egressD should be moved to node1.
+	clientset.CoreV1().Nodes().Update(ctx, node1, metav1.UpdateOptions{})
+	assertReceivedItems(t, egressUpdates, sets.NewString("egressD"))
+	assertScheduleResult(t, s, "egressD", "1.1.1.1", "node1", true)
+}
+
+func assertReceivedItems(t *testing.T, ch <-chan string, expectedItems sets.String) {
+	receivedItems := sets.NewString()
+	for i := 0; i < expectedItems.Len(); i++ {
+		select {
+		case <-time.After(2 * time.Second):
+			t.Fatalf("Timeout getting item #%d from the channel", i)
+		case item := <-ch:
+			receivedItems.Insert(item)
+		}
+	}
+	assert.Equal(t, expectedItems, receivedItems)
+
+	select {
+	case <-time.After(100 * time.Millisecond):
+	case item := <-ch:
+		t.Fatalf("Got unexpected item %s from the channel", item)
+	}
+}
+
+func assertScheduleResult(t *testing.T, s *egressIPScheduler, egress, egressIP, egressNode string, scheduled bool) {
+	gotEgressIP, gotEgressNode, gotScheduled := s.GetEgressIPAndNode(egress)
+	assert.Equal(t, egressIP, gotEgressIP)
+	assert.Equal(t, egressNode, gotEgressNode)
+	assert.Equal(t, scheduled, gotScheduled)
+}

--- a/pkg/agent/memberlist/cluster.go
+++ b/pkg/agent/memberlist/cluster.go
@@ -452,7 +452,7 @@ func (c *Cluster) syncConsistentHash(eipName string) error {
 				aliveAndMatchedNodes = append(aliveAndMatchedNodes, nodeName)
 			}
 		}
-		consistentHashMap := newNodeConsistentHashMap()
+		consistentHashMap := NewNodeConsistentHashMap()
 		consistentHashMap.Add(aliveAndMatchedNodes...)
 		c.consistentHashRWMutex.Lock()
 		defer c.consistentHashRWMutex.Unlock()
@@ -467,7 +467,7 @@ func (c *Cluster) syncConsistentHash(eipName string) error {
 	return nil
 }
 
-func newNodeConsistentHashMap() *consistenthash.Map {
+func NewNodeConsistentHashMap() *consistenthash.Map {
 	return consistenthash.New(defaultVirtualNodeReplicas, defaultHashFn)
 }
 

--- a/pkg/agent/memberlist/cluster_test.go
+++ b/pkg/agent/memberlist/cluster_test.go
@@ -410,7 +410,7 @@ func genLocalNodeCluster(localNodeNme, eipName string, nodes []string) *Cluster 
 		nodeName:          localNodeNme,
 		consistentHashMap: make(map[string]*consistenthash.Map),
 	}
-	cluster.consistentHashMap[eipName] = newNodeConsistentHashMap()
+	cluster.consistentHashMap[eipName] = NewNodeConsistentHashMap()
 	cluster.consistentHashMap[eipName].Add(nodes...)
 	return cluster
 }
@@ -520,7 +520,7 @@ func TestCluster_ShouldSelectEgress(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "fakeEgress"},
 				Spec:       crdv1a2.EgressSpec{ExternalIPPool: fakeEIPName, EgressIP: tCase.egressIP},
 			}
-			consistentHashMap := newNodeConsistentHashMap()
+			consistentHashMap := NewNodeConsistentHashMap()
 			consistentHashMap.Add(genNodes(tCase.nodeNum)...)
 
 			fakeCluster := &Cluster{
@@ -585,7 +585,7 @@ func TestCluster_SelectNodeForIP(t *testing.T) {
 	for _, tCase := range testCases {
 		t.Run(tCase.name, func(t *testing.T) {
 			fakeEIPName := "fakeExternalIPPool"
-			consistentHashMap := newNodeConsistentHashMap()
+			consistentHashMap := NewNodeConsistentHashMap()
 			consistentHashMap.Add(genNodes(tCase.nodeNum)...)
 
 			fakeCluster := &Cluster{

--- a/pkg/agent/types/annotations.go
+++ b/pkg/agent/types/annotations.go
@@ -24,6 +24,9 @@ const (
 	// NodeWireGuardPublicAnnotationKey represents the key of the Node's WireGuard public key in the Annotations of the Node.
 	NodeWireGuardPublicAnnotationKey string = "node.antrea.io/wireguard-public-key"
 
+	// NodeMaxEgressIPsAnnotationKey represents the key of maximum Egress IP number in the Annotations of the Node.
+	NodeMaxEgressIPsAnnotationKey string = "node.antrea.io/max-egress-ips"
+
 	// ServiceExternalIPPoolAnnotationKey is the key of the Service annotation that specifies the Service's desired external IP pool.
 	ServiceExternalIPPoolAnnotationKey string = "service.antrea.io/external-ip-pool"
 )


### PR DESCRIPTION
PR #4593 introduced maxEgressIPsPerNode to limit the number of Egress IPs that can be assigned to a Node. However, it used the EgressInformer cache to check whether a Node can accommodate new Egress IPs and did the calculation for different Egresses concurrently, which may cause inconsistent schedule results among agents. For instance:

When Nodes' capacity is 1 and two Egresses, e1 and e2, are created concurrently, different agents may process them in different orders, with different contexts:

- agent a1 may process Egress e1 first and assign it to Node n1; it then processes Egress e2 and think it should be assigned to Node n2 by agent a2 because n1 is out of space.
- agent a2 may process Egress e1 and e2 faster, before any of their status is updated in Egress API, and would think both Egresses should be assigned to Node n1 by agent a1.

As a result, Egress e2 will be left unassigned.

To fix the problem, the Egress IP scheduling should be deterministic accross agents and time. This patch adds an egressIPScheduler, which takes the spec of Egress and ExternalIPPool and the state of memberlist cluster as inputs, generates scheduling results deterministically.

According to the benchmark test, scheduling 1,000 Egresses among 1,000 Nodes once takes less than 3ms.

The PR also includes the following improvement:

A global max-egress-ips may not work for the case that the cluster consists of different instance types of Nodes. It adds support for per-Node max-egress-ips annotation, with which Nodes can be configured with different capacity via their annotations. It also makes dynamically adjusting a Node's capacity at runtime and configuring Node capacity post-deployment possible.