### PR TITLE
Graduate feature EndpointSlice from Alpha to Beta

### DIFF
--- a/build/charts/antrea/conf/antrea-agent.conf
+++ b/build/charts/antrea/conf/antrea-agent.conf
@@ -14,7 +14,7 @@ featureGates:
 # Enable EndpointSlice support in AntreaProxy. Don't enable this feature unless that EndpointSlice
 # API version v1 is supported and set as enabled in Kubernetes. If AntreaProxy is not enabled,
 # this flag will not take effect.
-{{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "EndpointSlice" "default" false) }}
+{{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "EndpointSlice" "default" true) }}
 
 # Enable TopologyAwareHints in AntreaProxy. This requires AntreaProxy and EndpointSlice to be
 # enabled, otherwise this flag will not take effect.

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -2938,7 +2938,7 @@ data:
     # Enable EndpointSlice support in AntreaProxy. Don't enable this feature unless that EndpointSlice
     # API version v1 is supported and set as enabled in Kubernetes. If AntreaProxy is not enabled,
     # this flag will not take effect.
-    #  EndpointSlice: false
+    #  EndpointSlice: true
 
     # Enable TopologyAwareHints in AntreaProxy. This requires AntreaProxy and EndpointSlice to be
     # enabled, otherwise this flag will not take effect.
@@ -4299,7 +4299,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: be4d7318350c398a0362a44ff0d4ff779150a303e577ed1e2265aaa75c00546e
+        checksum/config: b86fde75015a44585bade9fd6e50da2fec097708142db7e5d521944b81617847
       labels:
         app: antrea
         component: antrea-agent
@@ -4540,7 +4540,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: be4d7318350c398a0362a44ff0d4ff779150a303e577ed1e2265aaa75c00546e
+        checksum/config: b86fde75015a44585bade9fd6e50da2fec097708142db7e5d521944b81617847
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -2938,7 +2938,7 @@ data:
     # Enable EndpointSlice support in AntreaProxy. Don't enable this feature unless that EndpointSlice
     # API version v1 is supported and set as enabled in Kubernetes. If AntreaProxy is not enabled,
     # this flag will not take effect.
-    #  EndpointSlice: false
+    #  EndpointSlice: true
 
     # Enable TopologyAwareHints in AntreaProxy. This requires AntreaProxy and EndpointSlice to be
     # enabled, otherwise this flag will not take effect.
@@ -4299,7 +4299,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: be4d7318350c398a0362a44ff0d4ff779150a303e577ed1e2265aaa75c00546e
+        checksum/config: b86fde75015a44585bade9fd6e50da2fec097708142db7e5d521944b81617847
       labels:
         app: antrea
         component: antrea-agent
@@ -4541,7 +4541,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: be4d7318350c398a0362a44ff0d4ff779150a303e577ed1e2265aaa75c00546e
+        checksum/config: b86fde75015a44585bade9fd6e50da2fec097708142db7e5d521944b81617847
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -2938,7 +2938,7 @@ data:
     # Enable EndpointSlice support in AntreaProxy. Don't enable this feature unless that EndpointSlice
     # API version v1 is supported and set as enabled in Kubernetes. If AntreaProxy is not enabled,
     # this flag will not take effect.
-    #  EndpointSlice: false
+    #  EndpointSlice: true
 
     # Enable TopologyAwareHints in AntreaProxy. This requires AntreaProxy and EndpointSlice to be
     # enabled, otherwise this flag will not take effect.
@@ -4299,7 +4299,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: fca1f2d4967020380202ef0c2394b560055830ee2770e41f791af76b42559659
+        checksum/config: d259115de8dc77cc70fa311cc8770631c67cc2ae23fd4ca673cba8328ac6ea0c
       labels:
         app: antrea
         component: antrea-agent
@@ -4538,7 +4538,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: fca1f2d4967020380202ef0c2394b560055830ee2770e41f791af76b42559659
+        checksum/config: d259115de8dc77cc70fa311cc8770631c67cc2ae23fd4ca673cba8328ac6ea0c
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -2951,7 +2951,7 @@ data:
     # Enable EndpointSlice support in AntreaProxy. Don't enable this feature unless that EndpointSlice
     # API version v1 is supported and set as enabled in Kubernetes. If AntreaProxy is not enabled,
     # this flag will not take effect.
-    #  EndpointSlice: false
+    #  EndpointSlice: true
 
     # Enable TopologyAwareHints in AntreaProxy. This requires AntreaProxy and EndpointSlice to be
     # enabled, otherwise this flag will not take effect.
@@ -4312,7 +4312,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: ab53bf1e28a67ba5be2b99989a8d28b31d716d79b207a610cd5258ead514eb6b
+        checksum/config: 17ea08bd252cf05c6b57c557962bea4fed8bebebe981d53e14cfd44845ed5013
         checksum/ipsec-secret: d0eb9c52d0cd4311b6d252a951126bf9bea27ec05590bed8a394f0f792dcb2a4
       labels:
         app: antrea
@@ -4597,7 +4597,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: ab53bf1e28a67ba5be2b99989a8d28b31d716d79b207a610cd5258ead514eb6b
+        checksum/config: 17ea08bd252cf05c6b57c557962bea4fed8bebebe981d53e14cfd44845ed5013
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-windows.yml
+++ b/build/yamls/antrea-windows.yml
@@ -26,7 +26,7 @@ data:
     # Enable EndpointSlice support in AntreaProxy. Don't enable this feature unless that EndpointSlice
     # API version v1beta1 is supported and set as enabled in Kubernetes. If AntreaProxy is not enabled,
     # this flag will not take effect.
-    #  EndpointSlice: false
+    #  EndpointSlice: true
 
     # Enable NodePortLocal feature to make the Pods reachable externally through NodePort
     #  NodePortLocal: true
@@ -172,7 +172,7 @@ kind: ConfigMap
 metadata:
   labels:
     app: antrea
-  name: antrea-windows-config-db2774h9dt
+  name: antrea-windows-config-hth2gk6b96
   namespace: kube-system
 ---
 apiVersion: apps/v1
@@ -260,7 +260,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-windows-config-db2774h9dt
+          name: antrea-windows-config-hth2gk6b96
         name: antrea-windows-config
       - configMap:
           defaultMode: 420

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -2938,7 +2938,7 @@ data:
     # Enable EndpointSlice support in AntreaProxy. Don't enable this feature unless that EndpointSlice
     # API version v1 is supported and set as enabled in Kubernetes. If AntreaProxy is not enabled,
     # this flag will not take effect.
-    #  EndpointSlice: false
+    #  EndpointSlice: true
 
     # Enable TopologyAwareHints in AntreaProxy. This requires AntreaProxy and EndpointSlice to be
     # enabled, otherwise this flag will not take effect.
@@ -4299,7 +4299,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 2c1c5158b6a3ea32eff58bc1e498592e80ebecee07f51b10c722b67afce7b964
+        checksum/config: 8b0774e5e0eb1ad2807c6e5f18409d8f6a20e61317bafadb1009b9190ae163b3
       labels:
         app: antrea
         component: antrea-agent
@@ -4538,7 +4538,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 2c1c5158b6a3ea32eff58bc1e498592e80ebecee07f51b10c722b67afce7b964
+        checksum/config: 8b0774e5e0eb1ad2807c6e5f18409d8f6a20e61317bafadb1009b9190ae163b3
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/windows/base/conf/antrea-agent.conf
+++ b/build/yamls/windows/base/conf/antrea-agent.conf
@@ -8,7 +8,7 @@ featureGates:
 # Enable EndpointSlice support in AntreaProxy. Don't enable this feature unless that EndpointSlice
 # API version v1beta1 is supported and set as enabled in Kubernetes. If AntreaProxy is not enabled,
 # this flag will not take effect.
-#  EndpointSlice: false
+#  EndpointSlice: true
 
 # Enable NodePortLocal feature to make the Pods reachable externally through NodePort
 #  NodePortLocal: true

--- a/docs/feature-gates.md
+++ b/docs/feature-gates.md
@@ -35,7 +35,7 @@ edit the Agent configuration in the
 | Feature Name              | Component          | Default | Stage | Alpha Release | Beta Release | GA Release | Extra Requirements | Notes |
 |---------------------------|--------------------| ------- | ----- |---------------| ------------ | ---------- |--------------------| ----- |
 | `AntreaProxy`             | Agent              | `true`  | Beta  | v0.8          | v0.11        | N/A        | Yes                | Must be enabled for Windows. |
-| `EndpointSlice`           | Agent              | `false` | Alpha | v0.13.0       | N/A          | N/A        | Yes                |       |
+| `EndpointSlice`           | Agent              | `true`  | Beta  | v0.13.0       | v1.11        | N/A        | Yes                |       |
 | `TopologyAwareHints`      | Agent              | `false` | Alpha | v1.8          | N/A          | N/A        | Yes                |       |
 | `AntreaPolicy`            | Agent + Controller | `true`  | Beta  | v0.8          | v1.0         | N/A        | No                 | Agent side config required from v0.9.0+. |
 | `Traceflow`               | Agent + Controller | `true`  | Beta  | v0.8          | v0.11        | N/A        | Yes                |       |
@@ -70,35 +70,35 @@ NetworkPolicy implementation for Pod-to-Service traffic.
 
 Please refer to this [document](antrea-proxy.md) for extra information on AntreaProxy and how it can be configured.
 
-### EndpointSlice
-
-`EndpointSlice` enables Service EndpointSlice support in AntreaProxy. The EndpointSlice API was introduced in Kubernetes
-1.16 (alpha) and it is enabled by default in Kubernetes 1.17 (beta). The EndpointSlice feature gate will take no effect
-if AntreaProxy is not enabled. The endpoint conditions of `Serving` and
-`Terminating` are not supported currently. ServiceTopology is not supported either. Refer to
-this [link](https://kubernetes.io/docs/tasks/administer-cluster/enabling-endpointslices/)
-for more information. The EndpointSlice API version that AntreaProxy supports is v1beta1 currently, and other
-EndpointSlice API versions are not supported. If EndpointSlice is enabled in AntreaProxy, but EndpointSlice API is
-disabled in Kubernetes or EndpointSlice API version v1beta1 is not supported in Kubernetes, Antrea Agent will log an
-error message and will not implement Cluster IP functionality as expected.
-
 #### Requirements for this Feature
 
 When using the OVS built-in kernel module (which is the most common case), your kernel version must be >= 4.6 (as
 opposed to >= 4.4 without this feature).
 
-### TopologyAwareHints
+### EndpointSlice
 
-`TopologyAwareHints` enables TopologyAwareHints support in AntreaProxy. The feature
-TopologyAwareHints is at beta stage in Kubernetes 1.23 (beta), and it is enabled by
-default in Kubernetes 1.24. For AntreaProxy, traffic can be routed to the Endpoint
-which is closer to its origin with this feature. Refer to this
-[link](https://kubernetes.io/docs/concepts/services-networking/topology-aware-hints/)
-for more information.
+`EndpointSlice` enables Service EndpointSlice support in AntreaProxy. The EndpointSlice API was introduced in Kubernetes
+1.16 (alpha) and it is enabled by default in Kubernetes 1.17 (beta), promoted to GA in Kubernetes 1.21. The EndpointSlice
+feature will take no effect if AntreaProxy is not enabled. Refer to this [link](https://kubernetes.io/docs/tasks/administer-cluster/enabling-endpointslices/)
+for more information about EndpointSlice. Don't enable this feature if Kubernetes version is lower than 1.21 or EndpointSlice
+API is disabled in Kubernetes, otherwise Antrea Agent will log an error message and will not implement ClusterIP Service
+functionality as expected.
 
 #### Requirements for this Feature
 
-Feature EndpointSlice is enabled.
+- EndpointSlice API is enabled if Kubernetes version is >=1.16 and <1.21, or if it is >=1.21.
+- `AntreaProxy` is enabled.
+
+### TopologyAwareHints
+
+`TopologyAwareHints` enables TopologyAwareHints support in AntreaProxy. For AntreaProxy, traffic can be routed to the
+Endpoint which is closer to where it originated when this feature is enabled. Refer to this [link](https://kubernetes.io/docs/concepts/services-networking/topology-aware-hints/)
+for more information about TopologyAwareHints.
+
+#### Requirements for this Feature
+
+- `AntreaProxy` is enabled.
+- `EndpointSlice` is enabled.
 
 ### AntreaPolicy
 

--- a/pkg/agent/proxy/proxier.go
+++ b/pkg/agent/proxy/proxier.go
@@ -783,10 +783,14 @@ func (p *proxier) SyncLoop() {
 }
 
 func (p *proxier) OnEndpointsAdd(endpoints *corev1.Endpoints) {
+	klog.V(2).InfoS("Processing Endpoints ADD event", "Endpoints", klog.KObj(endpoints))
 	p.OnEndpointsUpdate(nil, endpoints)
 }
 
 func (p *proxier) OnEndpointsUpdate(oldEndpoints, endpoints *corev1.Endpoints) {
+	if oldEndpoints != nil && endpoints != nil {
+		klog.V(2).InfoS("Processing Endpoints UPDATE event", "Endpoints", klog.KObj(endpoints))
+	}
 	if p.isIPv6 {
 		metrics.EndpointsUpdatesTotalV6.Inc()
 	} else {
@@ -798,6 +802,7 @@ func (p *proxier) OnEndpointsUpdate(oldEndpoints, endpoints *corev1.Endpoints) {
 }
 
 func (p *proxier) OnEndpointsDelete(endpoints *corev1.Endpoints) {
+	klog.V(2).InfoS("Processing Endpoints DELETE event", "Endpoints", klog.KObj(endpoints))
 	p.OnEndpointsUpdate(endpoints, nil)
 }
 
@@ -809,18 +814,21 @@ func (p *proxier) OnEndpointsSynced() {
 }
 
 func (p *proxier) OnEndpointSliceAdd(endpointSlice *discovery.EndpointSlice) {
+	klog.V(2).InfoS("Processing EndpointSlice ADD event", "EndpointSlice", klog.KObj(endpointSlice))
 	if p.endpointsChanges.OnEndpointSliceUpdate(endpointSlice, false) && p.isInitialized() {
 		p.runner.Run()
 	}
 }
 
 func (p *proxier) OnEndpointSliceUpdate(oldEndpointSlice, newEndpointSlice *discovery.EndpointSlice) {
+	klog.V(2).InfoS("Processing EndpointSlice UPDATE event", "EndpointSlice", klog.KObj(newEndpointSlice))
 	if p.endpointsChanges.OnEndpointSliceUpdate(newEndpointSlice, false) && p.isInitialized() {
 		p.runner.Run()
 	}
 }
 
 func (p *proxier) OnEndpointSliceDelete(endpointSlice *discovery.EndpointSlice) {
+	klog.V(2).InfoS("Processing EndpointSlice DELETE event", "EndpointSlice", klog.KObj(endpointSlice))
 	if p.endpointsChanges.OnEndpointSliceUpdate(endpointSlice, true) && p.isInitialized() {
 		p.runner.Run()
 	}
@@ -834,10 +842,14 @@ func (p *proxier) OnEndpointSlicesSynced() {
 }
 
 func (p *proxier) OnServiceAdd(service *corev1.Service) {
+	klog.V(2).InfoS("Processing Service ADD event", "Service", klog.KObj(service))
 	p.OnServiceUpdate(nil, service)
 }
 
 func (p *proxier) OnServiceUpdate(oldService, service *corev1.Service) {
+	if oldService != nil && service != nil {
+		klog.V(2).InfoS("Processing Service UPDATE event", "Service", klog.KObj(service))
+	}
 	if p.isIPv6 {
 		metrics.ServicesUpdatesTotalV6.Inc()
 	} else {
@@ -851,6 +863,7 @@ func (p *proxier) OnServiceUpdate(oldService, service *corev1.Service) {
 }
 
 func (p *proxier) OnServiceDelete(service *corev1.Service) {
+	klog.V(2).InfoS("Processing Service DELETE event", "Service", klog.KObj(service))
 	p.OnServiceUpdate(service, nil)
 }
 

--- a/pkg/apiserver/handlers/featuregates/handler_test.go
+++ b/pkg/apiserver/handlers/featuregates/handler_test.go
@@ -54,7 +54,7 @@ func Test_getGatesResponse(t *testing.T) {
 				{Component: "agent", Name: "AntreaPolicy", Status: "Disabled", Version: "BETA"},
 				{Component: "agent", Name: "AntreaProxy", Status: "Enabled", Version: "BETA"},
 				{Component: "agent", Name: "Egress", Status: egressStatus, Version: "BETA"},
-				{Component: "agent", Name: "EndpointSlice", Status: "Disabled", Version: "ALPHA"},
+				{Component: "agent", Name: "EndpointSlice", Status: "Enabled", Version: "BETA"},
 				{Component: "agent", Name: "AntreaIPAM", Status: "Disabled", Version: "ALPHA"},
 				{Component: "agent", Name: "Traceflow", Status: "Enabled", Version: "BETA"},
 				{Component: "agent", Name: "FlowExporter", Status: "Disabled", Version: "ALPHA"},

--- a/pkg/features/antrea_features.go
+++ b/pkg/features/antrea_features.go
@@ -37,6 +37,7 @@ const (
 	AntreaPolicy featuregate.Feature = "AntreaPolicy"
 
 	// alpha: v0.13
+	// beta: v1.11
 	// Enable EndpointSlice support in AntreaProxy. If AntreaProxy is not enabled, this
 	// flag will not take effect.
 	EndpointSlice featuregate.Feature = "EndpointSlice"
@@ -138,7 +139,7 @@ var (
 		AntreaPolicy:            {Default: true, PreRelease: featuregate.Beta},
 		AntreaProxy:             {Default: true, PreRelease: featuregate.Beta},
 		Egress:                  {Default: true, PreRelease: featuregate.Beta},
-		EndpointSlice:           {Default: false, PreRelease: featuregate.Alpha},
+		EndpointSlice:           {Default: true, PreRelease: featuregate.Beta},
 		TopologyAwareHints:      {Default: false, PreRelease: featuregate.Alpha},
 		Traceflow:               {Default: true, PreRelease: featuregate.Beta},
 		AntreaIPAM:              {Default: false, PreRelease: featuregate.Alpha},


### PR DESCRIPTION
Test environment:
 - Kubernetes version: v.1.24.0
 - AntreaProxy options:
   - with proxyAll enabled, and with kube-proxy removed
 - IPv4 only

Passed tests:

Kubernetes whole Conformance tests, **356/356** passed.

Kubernetes sig-network tests, **11/172** passed with skip argument `\[Slow\]|\[Serial\]|\[Disruptive\]|\[GCE\]|\[Feature:IPv6DualStack\]|\[Feature:IPv6DualStackAlphaFeature\]|should create pod that uses dns|should provide Internet connection for containers`. 

The following tests are not related to EndpointSlice.

```
    [sig-network] KubeProxy should set TCP CLOSE_WAIT timeout [Privileged]
    [sig-network] Networking should check kube-proxy urls
    [sig-network] Services should implement service.kubernetes.io/headless
    [sig-network] Conntrack should be able to preserve UDP traffic when server pod cycles for a ClusterIP service
    [sig-network] Services should be possible to connect to a service via ExternalIP when the external IP is not assigned to a node
    [sig-network] Conntrack should be able to preserve UDP traffic when server pod cycles for a NodePort service
    [sig-network] Services should implement service.kubernetes.io/service-proxy-name
    [sig-network] Services should be rejected for evicted pods (no endpoints exist)
    [sig-network] Conntrack should be able to preserve UDP traffic when initial unready endpoints get ready
    [sig-network] Services should be rejected when no endpoints exist.
    [sig-network] Services should fallback to local terminating endpoints when there are no ready endpoints with externalTrafficPolicy=Local [Feature:ProxyTerminatingEndpoints]

```

For test ` [sig-network] Services should create endpoints for unready pods`, fixed by #4691

Depends on #4641


Signed-off-by: Hongliang Liu <lhongliang@vmware.com>