### PR TITLE
Update the release documentation for maintainers

### DIFF
--- a/docs/maintainers/release.md
+++ b/docs/maintainers/release.md
@@ -57,10 +57,13 @@ release. We use `<TAG>` as a placeholder for the release tag (e.g. `v1.4.0`).
 5. Make the release on Github **with the release branch as the target** and copy
    the relevant section of the CHANGELOG as the release description (make sure
    all the markdown links work). You typically should **not** be checking the
-   `pre-release` box. This would only be necessary for a release candidate
-   (e.g., `<TAG>` is `1.4.0-rc.1`), which we do not have at the moment. There is
-   no need to upload any assets as this will be done automatically by a Github
-   workflow, after you create the release.
+   `Set as a pre-release` box. This would only be necessary for a release
+   candidate (e.g., `<TAG>` is `1.4.0-rc.1`), which we do not have at the
+   moment. There is no need to upload any assets as this will be done
+   automatically by a Github workflow, after you create the release.
+   - the `Set as the latest release` box is checked by default. **If you are
+     creating a patch release for an older minor version of Antrea, you should
+     uncheck the box.**
 
 6. After a while (time for the relevant Github workflows to complete), check that:
    - the Docker image has been pushed to


### PR DESCRIPTION
Github introduced a new option when creating a release (`Set as the latest release` check box). The box is checked by default. It should be unchecked when creating a patch release for an older minor version of Antrea.

For example, assuming the most recent minor version of Antrea is 1.9:

  * when releasing 1.8.X, the box should be unchecked (not the latest release)
  * when releasing 1.9.X, the box should be checked (latest release)
  * when releasing 1.10.0, the box should be checked (latest release); after this release, the box will be unchecked for all 1.9.X patch releases.