### PR TITLE
Remove deprecated set-output command

### DIFF
--- a/.github/workflows/build_tag.yml
+++ b/.github/workflows/build_tag.yml
@@ -17,7 +17,7 @@ jobs:
         TAG: ${{ github.ref }}
       run: |
         version=${TAG:10}
-        echo "::set-output name=version::$version"
+        echo "version=$version" >> $GITHUB_OUTPUT
 
   build:
     runs-on: [ubuntu-latest]

--- a/.github/workflows/process_release.yml
+++ b/.github/workflows/process_release.yml
@@ -37,7 +37,7 @@ jobs:
         TAG: ${{ github.ref }}
       run: |
         version=${TAG:10}
-        echo "::set-output name=version::$version"
+        echo "version=$version" >> $GITHUB_OUTPUT
     - name: Update website source
       uses: benc-uk/workflow-dispatch@v1
       with:

--- a/.github/workflows/update_changelog.yml
+++ b/.github/workflows/update_changelog.yml
@@ -22,7 +22,7 @@ jobs:
           echo "$version is a release candidate or a pre-release"
           exit 0
         fi
-        echo "::set-output name=version::$version"
+        echo "version=$version" >> $GITHUB_OUTPUT
 
   pr-update-changelog:
     runs-on: [ubuntu-latest]


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/