### PR TITLE
Fix that Node controller doesn't start for TopologyAwareHints in AntreaProxy

### DIFF
--- a/pkg/agent/proxy/proxier.go
+++ b/pkg/agent/proxy/proxier.go
@@ -847,6 +847,9 @@ func (p *proxier) Run(stopCh <-chan struct{}) {
 		go p.serviceConfig.Run(stopCh)
 		if p.endpointSliceEnabled {
 			go p.endpointSliceConfig.Run(stopCh)
+			if p.topologyAwareHintsEnabled {
+				go p.nodeConfig.Run(stopCh)
+			}
 		} else {
 			go p.endpointsConfig.Run(stopCh)
 		}


### PR DESCRIPTION
Signed-off-by: Hongliang Liu <lhongliang@vmware.com>