### PR TITLE
Fix e2e TestAntctl on windows testbed

### DIFF
--- a/pkg/support/dump.go
+++ b/pkg/support/dump.go
@@ -292,10 +292,6 @@ func (d *agentDumper) DumpAgentInfo(basedir string) error {
 	return writeYAMLFile(d.fs, filepath.Join(basedir, "agentinfo"), "agentinfo", ai)
 }
 
-func (d *agentDumper) DumpMemberlist(basedir string) error {
-	return dumpAntctlGet(d.fs, d.executor, "memberlist", basedir)
-}
-
 func (d *agentDumper) DumpNetworkPolicyResources(basedir string) error {
 	dump := func(o interface{}, name string) error {
 		return writeYAMLFile(d.fs, filepath.Join(basedir, name), name, o)

--- a/pkg/support/dump_others.go
+++ b/pkg/support/dump_others.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"path"
 	"path/filepath"
+	"strings"
 
 	"antrea.io/antrea/pkg/agent/util/iptables"
 	"antrea.io/antrea/pkg/util/logdir"
@@ -72,4 +73,12 @@ func (d *agentDumper) dumpIPToolInfo(basedir string) error {
 		}
 	}
 	return nil
+}
+
+func (d *agentDumper) DumpMemberlist(basedir string) error {
+	output, err := d.executor.Command("antctl", "-oyaml", "get", "memberlist").CombinedOutput()
+	if err != nil && !strings.Contains(string(output), "memberlist is not running") {
+		return fmt.Errorf("error when dumping memberlist: %w", err)
+	}
+	return writeFile(d.fs, filepath.Join(basedir, "memberlist"), "memberlist", output)
 }

--- a/pkg/support/dump_windows.go
+++ b/pkg/support/dump_windows.go
@@ -101,3 +101,8 @@ func (d *agentDumper) dumpHNSResources(basedir string) error {
 	}
 	return nil
 }
+
+func (d *agentDumper) DumpMemberlist(basedir string) error {
+	// memberlist never runs on windows.
+	return nil
+}


### PR DESCRIPTION
TestAntctl/testAntctlControllerRemoteAccess failed
on all windows testbed because it cannot get
output of `antctl get memberlist` while collecting
supportbundle from outside on windows testbed as
memberlist is not running.

This PR handles the above case as success on linux
and writes output to file that memberlist is not running.

On Windows, don't collect memberlist as it never runs on Windows.

Fixes #4659