### PR TITLE
Add Controller configuration to specify client CA

### DIFF
--- a/build/charts/antrea/README.md
+++ b/build/charts/antrea/README.md
@@ -45,6 +45,7 @@ Kubernetes: `>= 1.16.0-0`
 | antreaProxy.proxyAll | bool | `false` | Proxy all Service traffic, for all Service types, regardless of where it comes from. |
 | antreaProxy.proxyLoadBalancerIPs | bool | `true` | When set to false, AntreaProxy no longer load-balances traffic destined to the External IPs of LoadBalancer Services. |
 | antreaProxy.skipServices | list | `[]` |  |
+| clientCAFile | string | `""` | File path of the certificate bundle for all the signers that is recognized for incoming client certificates. |
 | cni.hostBinPath | string | `"/opt/cni/bin"` | Installation path of CNI binaries on the host. |
 | cni.plugins | object | `{"bandwidth":true,"portmap":true}` | Chained plugins to use alongside antrea-cni. |
 | cni.skipBinaries | list | `[]` | CNI binaries shipped with Antrea for which installation should be skipped. |

--- a/build/charts/antrea/conf/antrea-controller.conf
+++ b/build/charts/antrea/conf/antrea-controller.conf
@@ -74,6 +74,10 @@ tlsCipherSuites: {{ .Values.tlsCipherSuites | quote }}
 # TLS min version from: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.
 tlsMinVersion: {{ .Values.tlsMinVersion | quote }}
 
+# File path of the certificate bundle for all the signers that is recognized for incoming client
+# certificates.
+clientCAFile: {{ .Values.clientCAFile | quote }}
+
 nodeIPAM:
 {{- with .Values.nodeIPAM }}
   # Enable the integrated Node IPAM controller within the Antrea controller.

--- a/build/charts/antrea/values.yaml
+++ b/build/charts/antrea/values.yaml
@@ -163,6 +163,10 @@ tlsCipherSuites: ""
 # VersionTLS13.
 tlsMinVersion: ""
 
+# -- File path of the certificate bundle for all the signers that is recognized
+# for incoming client certificates.
+clientCAFile: ""
+
 # -- To explicitly enable or disable a FeatureGate and bypass the Antrea
 # defaults, add an entry to the dictionary with the FeatureGate's name as the
 # key and a boolean as the value.

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -3342,6 +3342,10 @@ data:
     # TLS min version from: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.
     tlsMinVersion: ""
 
+    # File path of the certificate bundle for all the signers that is recognized for incoming client
+    # certificates.
+    clientCAFile: ""
+
     nodeIPAM:
       # Enable the integrated Node IPAM controller within the Antrea controller.
       enableNodeIPAM: false
@@ -4299,7 +4303,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: b86fde75015a44585bade9fd6e50da2fec097708142db7e5d521944b81617847
+        checksum/config: 3af5beafa4cc20ba7f963ed5409de8af66dbd1e185d98a56601d18edf74faba1
       labels:
         app: antrea
         component: antrea-agent
@@ -4540,7 +4544,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: b86fde75015a44585bade9fd6e50da2fec097708142db7e5d521944b81617847
+        checksum/config: 3af5beafa4cc20ba7f963ed5409de8af66dbd1e185d98a56601d18edf74faba1
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -3342,6 +3342,10 @@ data:
     # TLS min version from: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.
     tlsMinVersion: ""
 
+    # File path of the certificate bundle for all the signers that is recognized for incoming client
+    # certificates.
+    clientCAFile: ""
+
     nodeIPAM:
       # Enable the integrated Node IPAM controller within the Antrea controller.
       enableNodeIPAM: false
@@ -4299,7 +4303,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: b86fde75015a44585bade9fd6e50da2fec097708142db7e5d521944b81617847
+        checksum/config: 3af5beafa4cc20ba7f963ed5409de8af66dbd1e185d98a56601d18edf74faba1
       labels:
         app: antrea
         component: antrea-agent
@@ -4541,7 +4545,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: b86fde75015a44585bade9fd6e50da2fec097708142db7e5d521944b81617847
+        checksum/config: 3af5beafa4cc20ba7f963ed5409de8af66dbd1e185d98a56601d18edf74faba1
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -3342,6 +3342,10 @@ data:
     # TLS min version from: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.
     tlsMinVersion: ""
 
+    # File path of the certificate bundle for all the signers that is recognized for incoming client
+    # certificates.
+    clientCAFile: ""
+
     nodeIPAM:
       # Enable the integrated Node IPAM controller within the Antrea controller.
       enableNodeIPAM: false
@@ -4299,7 +4303,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: d259115de8dc77cc70fa311cc8770631c67cc2ae23fd4ca673cba8328ac6ea0c
+        checksum/config: 530b8f5633759918bc625c6c3e13b8927c2854687f7a5c5bfd420f1c1e15e3cf
       labels:
         app: antrea
         component: antrea-agent
@@ -4538,7 +4542,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: d259115de8dc77cc70fa311cc8770631c67cc2ae23fd4ca673cba8328ac6ea0c
+        checksum/config: 530b8f5633759918bc625c6c3e13b8927c2854687f7a5c5bfd420f1c1e15e3cf
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -3355,6 +3355,10 @@ data:
     # TLS min version from: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.
     tlsMinVersion: ""
 
+    # File path of the certificate bundle for all the signers that is recognized for incoming client
+    # certificates.
+    clientCAFile: ""
+
     nodeIPAM:
       # Enable the integrated Node IPAM controller within the Antrea controller.
       enableNodeIPAM: false
@@ -4312,7 +4316,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 17ea08bd252cf05c6b57c557962bea4fed8bebebe981d53e14cfd44845ed5013
+        checksum/config: 55bb24adab5185aad87b77004a64ea6a5736a85ed5e35d3f2e565d746e26dcf6
         checksum/ipsec-secret: d0eb9c52d0cd4311b6d252a951126bf9bea27ec05590bed8a394f0f792dcb2a4
       labels:
         app: antrea
@@ -4597,7 +4601,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 17ea08bd252cf05c6b57c557962bea4fed8bebebe981d53e14cfd44845ed5013
+        checksum/config: 55bb24adab5185aad87b77004a64ea6a5736a85ed5e35d3f2e565d746e26dcf6
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -3342,6 +3342,10 @@ data:
     # TLS min version from: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13.
     tlsMinVersion: ""
 
+    # File path of the certificate bundle for all the signers that is recognized for incoming client
+    # certificates.
+    clientCAFile: ""
+
     nodeIPAM:
       # Enable the integrated Node IPAM controller within the Antrea controller.
       enableNodeIPAM: false
@@ -4299,7 +4303,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 8b0774e5e0eb1ad2807c6e5f18409d8f6a20e61317bafadb1009b9190ae163b3
+        checksum/config: ad7f3df72a2eadf6a2ab30580d81d6ffc43838b464119d100e0646c348214524
       labels:
         app: antrea
         component: antrea-agent
@@ -4538,7 +4542,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 8b0774e5e0eb1ad2807c6e5f18409d8f6a20e61317bafadb1009b9190ae163b3
+        checksum/config: ad7f3df72a2eadf6a2ab30580d81d6ffc43838b464119d100e0646c348214524
       labels:
         app: antrea
         component: antrea-controller

--- a/cmd/antrea-controller/controller.go
+++ b/cmd/antrea-controller/controller.go
@@ -258,6 +258,7 @@ func run(o *Options) error {
 	}
 
 	apiServerConfig, err := createAPIServerConfig(o.config.ClientConnection.Kubeconfig,
+		o.config.ClientCAFile,
 		client,
 		aggregatorClient,
 		apiExtensionClient,
@@ -441,6 +442,7 @@ func startNodeIPAM(client clientset.Interface,
 }
 
 func createAPIServerConfig(kubeconfig string,
+	clientCAFile string,
 	client clientset.Interface,
 	aggregatorClient aggregatorclientset.Interface,
 	apiExtensionClient apiextensionclientset.Interface,
@@ -477,6 +479,9 @@ func createAPIServerConfig(kubeconfig string,
 	if len(kubeconfig) > 0 {
 		authentication.RemoteKubeConfigFile = kubeconfig
 		authorization.RemoteKubeConfigFile = kubeconfig
+	}
+	if len(clientCAFile) > 0 {
+		authentication.ClientCert.ClientCA = clientCAFile
 	}
 
 	serverConfig := genericapiserver.NewConfig(apiserver.Codecs)

--- a/pkg/config/controller/config.go
+++ b/pkg/config/controller/config.go
@@ -61,6 +61,9 @@ type ControllerConfig struct {
 	TLSCipherSuites string `yaml:"tlsCipherSuites,omitempty"`
 	// TLS min version.
 	TLSMinVersion string `yaml:"tlsMinVersion,omitempty"`
+	// ClientCAFile is the file path of the certificate bundle for all the signers that is recognized for incoming
+	// client certificates.
+	ClientCAFile string `yaml:"clientCAFile,omitempty"`
 	// Legacy CRD mirroring (deprecated).
 	LegacyCRDMirroring *bool `yaml:"legacyCRDMirroring,omitempty"`
 	// NodeIPAM Configuration


### PR DESCRIPTION
In the existing logic, Antrea Controller retrieves the client CA from ConfigMap kube-system/extension-apiserver-authentication, which is published by kube-apiserver. In some cases, the incoming connection is from the client with a certificate signed by a different CA bundle.

This patch adds a configuration in antrea-controller to allow user to specify the client CA. Antrea Controller will use it to validate the incoming client certificate in a mTLS connection.