### PR TITLE
Update CA Bundle on the existing APIServices/Webhooks

### DIFF
--- a/build/charts/antrea/crds/clustergroup.yaml
+++ b/build/charts/antrea/crds/clustergroup.yaml
@@ -4,6 +4,7 @@ metadata:
   name: clustergroups.crd.antrea.io
   labels:
     app: antrea
+    served-by: antrea-controller
 spec:
   group: crd.antrea.io
   versions:

--- a/build/charts/antrea/templates/controller/apiservices.yaml
+++ b/build/charts/antrea/templates/controller/apiservices.yaml
@@ -4,6 +4,7 @@ metadata:
   name: v1beta2.controlplane.antrea.io
   labels:
     app: antrea
+    served-by: antrea-controller
 spec:
   group: controlplane.antrea.io
   groupPriorityMinimum: 100
@@ -19,6 +20,7 @@ metadata:
   name: v1beta1.system.antrea.io
   labels:
     app: antrea
+    served-by: antrea-controller
 spec:
   group: system.antrea.io
   groupPriorityMinimum: 100
@@ -34,6 +36,7 @@ metadata:
   name: v1alpha1.stats.antrea.io
   labels:
     app: antrea
+    served-by: antrea-controller
 spec:
   group: stats.antrea.io
   groupPriorityMinimum: 100

--- a/build/charts/antrea/templates/controller/clusterrole.yaml
+++ b/build/charts/antrea/templates/controller/clusterrole.yaml
@@ -57,6 +57,7 @@ rules:
       - customresourcedefinitions
     verbs:
       - get
+      - list
       - update
   # This is the content of built-in role kube-system/extension-apiserver-authentication-reader.
   # But it doesn't have list/watch permission before K8s v1.17.0 so the extension apiserver (antrea-controller) will
@@ -106,12 +107,8 @@ rules:
       - apiregistration.k8s.io
     resources:
       - apiservices
-    resourceNames:
-      - v1alpha1.stats.antrea.io
-      - v1beta1.system.antrea.io
-      - v1beta2.controlplane.antrea.io
     verbs:
-      - get
+      - list
       - update
   - apiGroups:
       - apiregistration.k8s.io
@@ -130,15 +127,8 @@ rules:
     resources:
       - mutatingwebhookconfigurations
       - validatingwebhookconfigurations
-    resourceNames:
-      # always give permissions for labelsmutator.antrea.io, even when the
-      # feature is disabled, to avoid errors in antrea-controller when updating
-      # the CA cert.
-      - labelsmutator.antrea.io
-      - crdmutator.antrea.io
-      - crdvalidator.antrea.io
     verbs:
-      - get
+      - list
       - update
   - apiGroups:
     - certificates.k8s.io

--- a/build/charts/antrea/templates/webhooks/mutating/crdmutator.yaml
+++ b/build/charts/antrea/templates/webhooks/mutating/crdmutator.yaml
@@ -4,6 +4,7 @@ metadata:
   name: "crdmutator.antrea.io"
   labels:
     app: antrea
+    served-by: antrea-controller
 webhooks:
   - name: "acnpmutator.antrea.io"
     clientConfig:

--- a/build/charts/antrea/templates/webhooks/mutating/labelsmutator.yaml
+++ b/build/charts/antrea/templates/webhooks/mutating/labelsmutator.yaml
@@ -5,6 +5,7 @@ metadata:
   name: "labelsmutator.antrea.io"
   labels:
     app: antrea
+    served-by: antrea-controller
 webhooks:
   - name: "namelabelmutator.antrea.io"
     clientConfig:

--- a/build/charts/antrea/templates/webhooks/validating/crdvalidator.yaml
+++ b/build/charts/antrea/templates/webhooks/validating/crdvalidator.yaml
@@ -4,6 +4,7 @@ metadata:
   name: "crdvalidator.antrea.io"
   labels:
     app: antrea
+    served-by: antrea-controller
 webhooks:
   - name: "tiervalidator.antrea.io"
     clientConfig:

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -116,6 +116,7 @@ metadata:
   name: clustergroups.crd.antrea.io
   labels:
     app: antrea
+    served-by: antrea-controller
 spec:
   group: crd.antrea.io
   versions:
@@ -3930,6 +3931,7 @@ rules:
       - customresourcedefinitions
     verbs:
       - get
+      - list
       - update
   # This is the content of built-in role kube-system/extension-apiserver-authentication-reader.
   # But it doesn't have list/watch permission before K8s v1.17.0 so the extension apiserver (antrea-controller) will
@@ -3979,12 +3981,8 @@ rules:
       - apiregistration.k8s.io
     resources:
       - apiservices
-    resourceNames:
-      - v1alpha1.stats.antrea.io
-      - v1beta1.system.antrea.io
-      - v1beta2.controlplane.antrea.io
     verbs:
-      - get
+      - list
       - update
   - apiGroups:
       - apiregistration.k8s.io
@@ -4003,15 +4001,8 @@ rules:
     resources:
       - mutatingwebhookconfigurations
       - validatingwebhookconfigurations
-    resourceNames:
-      # always give permissions for labelsmutator.antrea.io, even when the
-      # feature is disabled, to avoid errors in antrea-controller when updating
-      # the CA cert.
-      - labelsmutator.antrea.io
-      - crdmutator.antrea.io
-      - crdvalidator.antrea.io
     verbs:
-      - get
+      - list
       - update
   - apiGroups:
     - certificates.k8s.io
@@ -4711,6 +4702,7 @@ metadata:
   name: v1beta2.controlplane.antrea.io
   labels:
     app: antrea
+    served-by: antrea-controller
 spec:
   group: controlplane.antrea.io
   groupPriorityMinimum: 100
@@ -4727,6 +4719,7 @@ metadata:
   name: v1beta1.system.antrea.io
   labels:
     app: antrea
+    served-by: antrea-controller
 spec:
   group: system.antrea.io
   groupPriorityMinimum: 100
@@ -4743,6 +4736,7 @@ metadata:
   name: v1alpha1.stats.antrea.io
   labels:
     app: antrea
+    served-by: antrea-controller
 spec:
   group: stats.antrea.io
   groupPriorityMinimum: 100
@@ -4759,6 +4753,7 @@ metadata:
   name: "crdmutator.antrea.io"
   labels:
     app: antrea
+    served-by: antrea-controller
 webhooks:
   - name: "acnpmutator.antrea.io"
     clientConfig:
@@ -4798,6 +4793,7 @@ metadata:
   name: "crdvalidator.antrea.io"
   labels:
     app: antrea
+    served-by: antrea-controller
 webhooks:
   - name: "tiervalidator.antrea.io"
     clientConfig:

--- a/build/yamls/antrea-crds.yml
+++ b/build/yamls/antrea-crds.yml
@@ -111,6 +111,7 @@ metadata:
   name: clustergroups.crd.antrea.io
   labels:
     app: antrea
+    served-by: antrea-controller
 spec:
   group: crd.antrea.io
   versions:

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -116,6 +116,7 @@ metadata:
   name: clustergroups.crd.antrea.io
   labels:
     app: antrea
+    served-by: antrea-controller
 spec:
   group: crd.antrea.io
   versions:
@@ -3930,6 +3931,7 @@ rules:
       - customresourcedefinitions
     verbs:
       - get
+      - list
       - update
   # This is the content of built-in role kube-system/extension-apiserver-authentication-reader.
   # But it doesn't have list/watch permission before K8s v1.17.0 so the extension apiserver (antrea-controller) will
@@ -3979,12 +3981,8 @@ rules:
       - apiregistration.k8s.io
     resources:
       - apiservices
-    resourceNames:
-      - v1alpha1.stats.antrea.io
-      - v1beta1.system.antrea.io
-      - v1beta2.controlplane.antrea.io
     verbs:
-      - get
+      - list
       - update
   - apiGroups:
       - apiregistration.k8s.io
@@ -4003,15 +4001,8 @@ rules:
     resources:
       - mutatingwebhookconfigurations
       - validatingwebhookconfigurations
-    resourceNames:
-      # always give permissions for labelsmutator.antrea.io, even when the
-      # feature is disabled, to avoid errors in antrea-controller when updating
-      # the CA cert.
-      - labelsmutator.antrea.io
-      - crdmutator.antrea.io
-      - crdvalidator.antrea.io
     verbs:
-      - get
+      - list
       - update
   - apiGroups:
     - certificates.k8s.io
@@ -4712,6 +4703,7 @@ metadata:
   name: v1beta2.controlplane.antrea.io
   labels:
     app: antrea
+    served-by: antrea-controller
 spec:
   group: controlplane.antrea.io
   groupPriorityMinimum: 100
@@ -4728,6 +4720,7 @@ metadata:
   name: v1beta1.system.antrea.io
   labels:
     app: antrea
+    served-by: antrea-controller
 spec:
   group: system.antrea.io
   groupPriorityMinimum: 100
@@ -4744,6 +4737,7 @@ metadata:
   name: v1alpha1.stats.antrea.io
   labels:
     app: antrea
+    served-by: antrea-controller
 spec:
   group: stats.antrea.io
   groupPriorityMinimum: 100
@@ -4760,6 +4754,7 @@ metadata:
   name: "crdmutator.antrea.io"
   labels:
     app: antrea
+    served-by: antrea-controller
 webhooks:
   - name: "acnpmutator.antrea.io"
     clientConfig:
@@ -4799,6 +4794,7 @@ metadata:
   name: "crdvalidator.antrea.io"
   labels:
     app: antrea
+    served-by: antrea-controller
 webhooks:
   - name: "tiervalidator.antrea.io"
     clientConfig:

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -116,6 +116,7 @@ metadata:
   name: clustergroups.crd.antrea.io
   labels:
     app: antrea
+    served-by: antrea-controller
 spec:
   group: crd.antrea.io
   versions:
@@ -3930,6 +3931,7 @@ rules:
       - customresourcedefinitions
     verbs:
       - get
+      - list
       - update
   # This is the content of built-in role kube-system/extension-apiserver-authentication-reader.
   # But it doesn't have list/watch permission before K8s v1.17.0 so the extension apiserver (antrea-controller) will
@@ -3979,12 +3981,8 @@ rules:
       - apiregistration.k8s.io
     resources:
       - apiservices
-    resourceNames:
-      - v1alpha1.stats.antrea.io
-      - v1beta1.system.antrea.io
-      - v1beta2.controlplane.antrea.io
     verbs:
-      - get
+      - list
       - update
   - apiGroups:
       - apiregistration.k8s.io
@@ -4003,15 +4001,8 @@ rules:
     resources:
       - mutatingwebhookconfigurations
       - validatingwebhookconfigurations
-    resourceNames:
-      # always give permissions for labelsmutator.antrea.io, even when the
-      # feature is disabled, to avoid errors in antrea-controller when updating
-      # the CA cert.
-      - labelsmutator.antrea.io
-      - crdmutator.antrea.io
-      - crdvalidator.antrea.io
     verbs:
-      - get
+      - list
       - update
   - apiGroups:
     - certificates.k8s.io
@@ -4709,6 +4700,7 @@ metadata:
   name: v1beta2.controlplane.antrea.io
   labels:
     app: antrea
+    served-by: antrea-controller
 spec:
   group: controlplane.antrea.io
   groupPriorityMinimum: 100
@@ -4725,6 +4717,7 @@ metadata:
   name: v1beta1.system.antrea.io
   labels:
     app: antrea
+    served-by: antrea-controller
 spec:
   group: system.antrea.io
   groupPriorityMinimum: 100
@@ -4741,6 +4734,7 @@ metadata:
   name: v1alpha1.stats.antrea.io
   labels:
     app: antrea
+    served-by: antrea-controller
 spec:
   group: stats.antrea.io
   groupPriorityMinimum: 100
@@ -4757,6 +4751,7 @@ metadata:
   name: "crdmutator.antrea.io"
   labels:
     app: antrea
+    served-by: antrea-controller
 webhooks:
   - name: "acnpmutator.antrea.io"
     clientConfig:
@@ -4796,6 +4791,7 @@ metadata:
   name: "crdvalidator.antrea.io"
   labels:
     app: antrea
+    served-by: antrea-controller
 webhooks:
   - name: "tiervalidator.antrea.io"
     clientConfig:

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -116,6 +116,7 @@ metadata:
   name: clustergroups.crd.antrea.io
   labels:
     app: antrea
+    served-by: antrea-controller
 spec:
   group: crd.antrea.io
   versions:
@@ -3943,6 +3944,7 @@ rules:
       - customresourcedefinitions
     verbs:
       - get
+      - list
       - update
   # This is the content of built-in role kube-system/extension-apiserver-authentication-reader.
   # But it doesn't have list/watch permission before K8s v1.17.0 so the extension apiserver (antrea-controller) will
@@ -3992,12 +3994,8 @@ rules:
       - apiregistration.k8s.io
     resources:
       - apiservices
-    resourceNames:
-      - v1alpha1.stats.antrea.io
-      - v1beta1.system.antrea.io
-      - v1beta2.controlplane.antrea.io
     verbs:
-      - get
+      - list
       - update
   - apiGroups:
       - apiregistration.k8s.io
@@ -4016,15 +4014,8 @@ rules:
     resources:
       - mutatingwebhookconfigurations
       - validatingwebhookconfigurations
-    resourceNames:
-      # always give permissions for labelsmutator.antrea.io, even when the
-      # feature is disabled, to avoid errors in antrea-controller when updating
-      # the CA cert.
-      - labelsmutator.antrea.io
-      - crdmutator.antrea.io
-      - crdvalidator.antrea.io
     verbs:
-      - get
+      - list
       - update
   - apiGroups:
     - certificates.k8s.io
@@ -4768,6 +4759,7 @@ metadata:
   name: v1beta2.controlplane.antrea.io
   labels:
     app: antrea
+    served-by: antrea-controller
 spec:
   group: controlplane.antrea.io
   groupPriorityMinimum: 100
@@ -4784,6 +4776,7 @@ metadata:
   name: v1beta1.system.antrea.io
   labels:
     app: antrea
+    served-by: antrea-controller
 spec:
   group: system.antrea.io
   groupPriorityMinimum: 100
@@ -4800,6 +4793,7 @@ metadata:
   name: v1alpha1.stats.antrea.io
   labels:
     app: antrea
+    served-by: antrea-controller
 spec:
   group: stats.antrea.io
   groupPriorityMinimum: 100
@@ -4816,6 +4810,7 @@ metadata:
   name: "crdmutator.antrea.io"
   labels:
     app: antrea
+    served-by: antrea-controller
 webhooks:
   - name: "acnpmutator.antrea.io"
     clientConfig:
@@ -4855,6 +4850,7 @@ metadata:
   name: "crdvalidator.antrea.io"
   labels:
     app: antrea
+    served-by: antrea-controller
 webhooks:
   - name: "tiervalidator.antrea.io"
     clientConfig:

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -116,6 +116,7 @@ metadata:
   name: clustergroups.crd.antrea.io
   labels:
     app: antrea
+    served-by: antrea-controller
 spec:
   group: crd.antrea.io
   versions:
@@ -3930,6 +3931,7 @@ rules:
       - customresourcedefinitions
     verbs:
       - get
+      - list
       - update
   # This is the content of built-in role kube-system/extension-apiserver-authentication-reader.
   # But it doesn't have list/watch permission before K8s v1.17.0 so the extension apiserver (antrea-controller) will
@@ -3979,12 +3981,8 @@ rules:
       - apiregistration.k8s.io
     resources:
       - apiservices
-    resourceNames:
-      - v1alpha1.stats.antrea.io
-      - v1beta1.system.antrea.io
-      - v1beta2.controlplane.antrea.io
     verbs:
-      - get
+      - list
       - update
   - apiGroups:
       - apiregistration.k8s.io
@@ -4003,15 +4001,8 @@ rules:
     resources:
       - mutatingwebhookconfigurations
       - validatingwebhookconfigurations
-    resourceNames:
-      # always give permissions for labelsmutator.antrea.io, even when the
-      # feature is disabled, to avoid errors in antrea-controller when updating
-      # the CA cert.
-      - labelsmutator.antrea.io
-      - crdmutator.antrea.io
-      - crdvalidator.antrea.io
     verbs:
-      - get
+      - list
       - update
   - apiGroups:
     - certificates.k8s.io
@@ -4709,6 +4700,7 @@ metadata:
   name: v1beta2.controlplane.antrea.io
   labels:
     app: antrea
+    served-by: antrea-controller
 spec:
   group: controlplane.antrea.io
   groupPriorityMinimum: 100
@@ -4725,6 +4717,7 @@ metadata:
   name: v1beta1.system.antrea.io
   labels:
     app: antrea
+    served-by: antrea-controller
 spec:
   group: system.antrea.io
   groupPriorityMinimum: 100
@@ -4741,6 +4734,7 @@ metadata:
   name: v1alpha1.stats.antrea.io
   labels:
     app: antrea
+    served-by: antrea-controller
 spec:
   group: stats.antrea.io
   groupPriorityMinimum: 100
@@ -4757,6 +4751,7 @@ metadata:
   name: "crdmutator.antrea.io"
   labels:
     app: antrea
+    served-by: antrea-controller
 webhooks:
   - name: "acnpmutator.antrea.io"
     clientConfig:
@@ -4796,6 +4791,7 @@ metadata:
   name: "crdvalidator.antrea.io"
   labels:
     app: antrea
+    served-by: antrea-controller
 webhooks:
   - name: "tiervalidator.antrea.io"
     clientConfig:

--- a/multicluster/build/yamls/antrea-multicluster-leader-namespaced.yml
+++ b/multicluster/build/yamls/antrea-multicluster-leader-namespaced.yml
@@ -251,14 +251,11 @@ metadata:
 rules:
 - apiGroups:
   - admissionregistration.k8s.io
-  resourceNames:
-  - antrea-multicluster-antrea-mc-mutating-webhook-configuration
-  - antrea-multicluster-antrea-mc-validating-webhook-configuration
   resources:
   - mutatingwebhookconfigurations
   - validatingwebhookconfigurations
   verbs:
-  - get
+  - list
   - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -421,9 +418,11 @@ spec:
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  creationTimestamp: null
   labels:
     app: antrea
+    role: leader
+    served-by: antrea-mc-controller
+    served-in: antrea-multicluster
   name: antrea-multicluster-antrea-mc-mutating-webhook-configuration
 webhooks:
 - admissionReviewVersions:
@@ -456,6 +455,9 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app: antrea
+    role: leader
+    served-by: antrea-mc-controller
+    served-in: antrea-multicluster
   name: antrea-multicluster-antrea-mc-validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:

--- a/multicluster/build/yamls/antrea-multicluster-member.yml
+++ b/multicluster/build/yamls/antrea-multicluster-member.yml
@@ -788,14 +788,11 @@ rules:
   - watch
 - apiGroups:
   - admissionregistration.k8s.io
-  resourceNames:
-  - antrea-mc-mutating-webhook-configuration
-  - antrea-mc-validating-webhook-configuration
   resources:
   - mutatingwebhookconfigurations
   - validatingwebhookconfigurations
   verbs:
-  - get
+  - list
   - update
 - apiGroups:
   - ""
@@ -1164,6 +1161,8 @@ kind: MutatingWebhookConfiguration
 metadata:
   labels:
     app: antrea
+    role: member
+    served-by: antrea-mc-controller
   name: antrea-mc-mutating-webhook-configuration
 webhooks: []
 ---
@@ -1172,6 +1171,8 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app: antrea
+    role: member
+    served-by: antrea-mc-controller
   name: antrea-mc-validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:

--- a/multicluster/cmd/multicluster-controller/controller_test.go
+++ b/multicluster/cmd/multicluster-controller/controller_test.go
@@ -50,44 +50,46 @@ func TestCreateClients(t *testing.T) {
 func TestGetCAConfig(t *testing.T) {
 	testCases := []struct {
 		name         string
+		isLeader     bool
 		controllerNS string
 		expectedRes  *certificate.CAConfig
 	}{
 		{
-			name:         "controllerNS is empty",
-			controllerNS: "",
+			name:     "member cluster",
+			isLeader: false,
 			expectedRes: &certificate.CAConfig{
-				CAConfigMapName:    configMapName,
-				PairName:           "tls",
-				CertDir:            certDir,
-				ServiceName:        serviceName,
-				SelfSignedCertDir:  selfSignedCertDir,
-				MutationWebhooks:   getMutationWebhooks(""),
-				ValidatingWebhooks: getValidationWebhooks(""),
-				CertReadyTimeout:   2 * time.Minute,
-				MaxRotateDuration:  time.Hour * (24 * 365),
+				CAConfigMapName:           configMapName,
+				PairName:                  "tls",
+				CertDir:                   certDir,
+				ServiceName:               serviceName,
+				SelfSignedCertDir:         selfSignedCertDir,
+				MutationWebhookSelector:   getWebhookLabel(false, ""),
+				ValidatingWebhookSelector: getWebhookLabel(false, ""),
+				CertReadyTimeout:          2 * time.Minute,
+				MaxRotateDuration:         time.Hour * (24 * 365),
 			},
 		},
 		{
-			name:         "controllerNS is not empty",
+			name:         "leader cluster",
+			isLeader:     true,
 			controllerNS: "testNS",
 			expectedRes: &certificate.CAConfig{
-				CAConfigMapName:    configMapName,
-				PairName:           "tls",
-				CertDir:            certDir,
-				ServiceName:        serviceName,
-				SelfSignedCertDir:  selfSignedCertDir,
-				MutationWebhooks:   getMutationWebhooks("testNS"),
-				ValidatingWebhooks: getValidationWebhooks("testNS"),
-				CertReadyTimeout:   2 * time.Minute,
-				MaxRotateDuration:  time.Hour * (24 * 365),
+				CAConfigMapName:           configMapName,
+				PairName:                  "tls",
+				CertDir:                   certDir,
+				ServiceName:               serviceName,
+				SelfSignedCertDir:         selfSignedCertDir,
+				MutationWebhookSelector:   getWebhookLabel(true, "testNS"),
+				ValidatingWebhookSelector: getWebhookLabel(true, "testNS"),
+				CertReadyTimeout:          2 * time.Minute,
+				MaxRotateDuration:         time.Hour * (24 * 365),
 			},
 		},
 	}
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expectedRes, getCaConfig(tt.controllerNS))
+			assert.Equal(t, tt.expectedRes, getCaConfig(tt.isLeader, tt.controllerNS))
 		})
 	}
 }

--- a/multicluster/cmd/multicluster-controller/leader.go
+++ b/multicluster/cmd/multicluster-controller/leader.go
@@ -55,7 +55,7 @@ func runLeader(o *Options) error {
 	o.options.Namespace = env.GetPodNamespace()
 	stopCh := signals.RegisterSignalHandlers()
 
-	mgr, err := setupManagerAndCertControllerFunc(o)
+	mgr, err := setupManagerAndCertControllerFunc(true, o)
 	if err != nil {
 		return err
 	}

--- a/multicluster/cmd/multicluster-controller/leader_test.go
+++ b/multicluster/cmd/multicluster-controller/leader_test.go
@@ -78,7 +78,7 @@ func TestRunLeader(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		mockLeaderManager := mocks.NewMockManager(mockCtrl)
 		initMockManager(mockLeaderManager)
-		setupManagerAndCertControllerFunc = func(o *Options) (ctrl.Manager, error) {
+		setupManagerAndCertControllerFunc = func(isLeader bool, o *Options) (ctrl.Manager, error) {
 			return mockLeaderManager, nil
 		}
 		ctrl.SetupSignalHandler = mockSetupSignalHandler

--- a/multicluster/cmd/multicluster-controller/member.go
+++ b/multicluster/cmd/multicluster-controller/member.go
@@ -51,7 +51,7 @@ func newMemberCommand() *cobra.Command {
 }
 
 func runMember(o *Options) error {
-	mgr, err := setupManagerAndCertControllerFunc(o)
+	mgr, err := setupManagerAndCertControllerFunc(false, o)
 	if err != nil {
 		return err
 	}

--- a/multicluster/cmd/multicluster-controller/member_test.go
+++ b/multicluster/cmd/multicluster-controller/member_test.go
@@ -89,7 +89,7 @@ func TestRunMember(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		mockMemberManager := mocks.NewMockManager(mockCtrl)
 		initMockManager(mockMemberManager)
-		setupManagerAndCertControllerFunc = func(o *Options) (ctrl.Manager, error) {
+		setupManagerAndCertControllerFunc = func(isLeader bool, o *Options) (ctrl.Manager, error) {
 			return mockMemberManager, nil
 		}
 		member.ServiceCIDRDiscoverFn = func(ctx context.Context, k8sClient client.Client, namespace string) (string, error) {

--- a/multicluster/config/overlays/leader-ns/webhook_patch.yaml
+++ b/multicluster/config/overlays/leader-ns/webhook_patch.yaml
@@ -7,3 +7,21 @@ webhooks:
 - admissionReviewVersions:
   name: vgateway.kb.io
   $patch: delete
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+  labels:
+    role: leader
+    served-by: antrea-mc-controller
+    served-in: antrea-multicluster
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+  labels:
+    role: leader
+    served-by: antrea-mc-controller
+    served-in: antrea-multicluster

--- a/multicluster/config/overlays/leader-ns/webhook_rbac.yaml
+++ b/multicluster/config/overlays/leader-ns/webhook_rbac.yaml
@@ -8,14 +8,11 @@ metadata:
 rules:
   - apiGroups:
       - admissionregistration.k8s.io
-    resourceNames:
-      - mutating-webhook-configuration
-      - validating-webhook-configuration
     resources:
       - mutatingwebhookconfigurations
       - validatingwebhookconfigurations
     verbs:
-      - get
+      - list
       - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/multicluster/config/overlays/member/additional_role_patch.yaml
+++ b/multicluster/config/overlays/member/additional_role_patch.yaml
@@ -7,11 +7,8 @@
     resources:
     - mutatingwebhookconfigurations
     - validatingwebhookconfigurations
-    resourceNames:
-    - mutating-webhook-configuration
-    - validating-webhook-configuration
     verbs:
-    - get
+    - list
     - update
 - op: add
   path: /rules/0

--- a/multicluster/config/overlays/member/webhook_patch.yaml
+++ b/multicluster/config/overlays/member/webhook_patch.yaml
@@ -14,6 +14,14 @@ webhooks:
   $patch: delete
 ---
 apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+  labels:
+    served-by: antrea-mc-controller
+    role: member
+---
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: mutating-webhook-configuration
@@ -24,6 +32,14 @@ webhooks:
 - admissionReviewVersions:
   name: mresourceimport.kb.io
   $patch: delete
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+  labels:
+    served-by: antrea-mc-controller
+    role: member
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/multicluster/hack/generate-manifest.sh
+++ b/multicluster/hack/generate-manifest.sh
@@ -118,6 +118,8 @@ then
     mkdir config && cd config
     cp $KUSTOMIZATION_DIR/overlays/leader-ns/prefix_transformer.yaml .
     sed -ie "s/antrea-multicluster/$NAMESPACE/g" prefix_transformer.yaml
+    cp $KUSTOMIZATION_DIR/overlays/leader-ns/webhook_patch.yaml .
+    sed -ie "s/antrea-multicluster/$NAMESPACE/g" webhook_patch.yaml
 
     cat << EOF > kustomization.yaml
 namespace: $NAMESPACE

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -80,6 +80,12 @@ var (
 	parameterCodec = runtime.NewParameterCodec(Scheme)
 	// #nosec G101: false positive triggered by variable name which includes "token"
 	TokenPath = "/var/run/antrea/apiserver/loopback-client-token"
+
+	// antreaServedLabel includes the labels used to select resources served by antrea-controller
+	antreaServedLabel = map[string]string{
+		"app":       "antrea",
+		"served-by": "antrea-controller",
+	}
 )
 
 func init() {
@@ -330,22 +336,17 @@ func installHandlers(c *ExtraConfig, s *genericapiserver.GenericAPIServer) {
 func DefaultCAConfig() *certificate.CAConfig {
 	return &certificate.CAConfig{
 		CAConfigMapName: certificate.AntreaCAConfigMapName,
-		APIServiceNames: []string{
-			"v1alpha1.stats.antrea.io",
-			"v1beta1.system.antrea.io",
-			"v1beta2.controlplane.antrea.io",
+		APIServiceSelector: &metav1.LabelSelector{
+			MatchLabels: antreaServedLabel,
 		},
-		ValidatingWebhooks: []string{
-			"crdvalidator.antrea.io",
+		ValidatingWebhookSelector: &metav1.LabelSelector{
+			MatchLabels: antreaServedLabel,
 		},
-		MutationWebhooks: []string{
-			"crdmutator.antrea.io",
+		MutationWebhookSelector: &metav1.LabelSelector{
+			MatchLabels: antreaServedLabel,
 		},
-		OptionalMutationWebhooks: []string{
-			"labelsmutator.antrea.io",
-		},
-		CRDsWithConversionWebhooks: []string{
-			"clustergroups.crd.antrea.io",
+		CRDConversionWebhookSelector: &metav1.LabelSelector{
+			MatchLabels: antreaServedLabel,
 		},
 		CertDir:           "/var/run/antrea/antrea-controller-tls",
 		SelfSignedCertDir: "/var/run/antrea/antrea-controller-self-signed",

--- a/pkg/apiserver/certificate/config.go
+++ b/pkg/apiserver/certificate/config.go
@@ -14,7 +14,11 @@
 
 package certificate
 
-import "time"
+import (
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
 
 const (
 	AntreaCAConfigMapName = "antrea-ca"
@@ -26,20 +30,19 @@ type CAConfig struct {
 	// certificate of antrea-controller.
 	CAConfigMapName string
 
-	// APIServiceNames contains all the APIServices backed by antrea-controller.
-	APIServiceNames []string
+	// APIServiceSelector provides the label to select APIServices backed by antrea-controller. Using labels as a filter
+	// to select APIServices is more flexible than maintaining a list of APIService names, e.g., cluster admin can remove
+	// unneeded APIServices in a setup without Antrea code changes.
+	APIServiceSelector *metav1.LabelSelector
 
-	// ValidatingWebhooks contains all the ValidatingWebhookConfigurations backed by antrea-controller.
-	ValidatingWebhooks []string
+	// ValidatingWebhookSelector provides the label to select ValidatingWebhookConfigurations backed by antrea-controller.
+	ValidatingWebhookSelector *metav1.LabelSelector
 
-	// MutationWebhooks contains all the MutationWebhooks backed by antrea-controller.
-	MutationWebhooks []string
+	// MutationWebhookSelector provides the label to select MutatingWebhookConfigurations backed by antrea-controller.
+	MutationWebhookSelector *metav1.LabelSelector
 
-	// OptionalMutationWebhooks contains all the OptionalMutationWebhooks backed by antrea-controller.
-	OptionalMutationWebhooks []string
-
-	// CRDsWithConversionWebhooks contains all the ConversionWebhooks backed by antrea-controller.
-	CRDsWithConversionWebhooks []string
+	// CRDConversionWebhookSelector provides the label to select the ConversionWebhooks backed by antrea-controller.
+	CRDConversionWebhookSelector *metav1.LabelSelector
 
 	// CertDir is the directory that the TLS Secret should be mounted to. Declaring it as a variable for testing.
 	CertDir string


### PR DESCRIPTION
Antrea APIServices/Webhooks are not needed in some scenarios, e.g., Nephe
watches internal resources from Antrea Controller directly in agentless mode.
The existing code may report errors when updating CA bundle in these
non-existing reosurces.
    
This change tries to list the existing APIServices/Webhooks with label filters
first, and then to update Controller CA Bundle on them. Except for antrea's
general label "app: antrea", the below principle is used,
- For general case, antrea-controller updates CA bundle on the resources labeled
   with "served-by: antrea-controller"
 - For multi-cluster case, antrea-mc-controller updates CA bundle on these
   resource:
    - leader controller updates resources labeled with both "role: leader" and
      "served-by: antrea-mc-controller"
    - member controller updates resources labeled with "role: member",
      "served-by: antrea-mc-controller" and "served-in: $controllerNS"

Signed-off-by: wenyingd <wenyingd@vmware.com>