### PR TITLE
Don't fail codecov upload in pull request CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -67,7 +67,7 @@ jobs:
         file: .coverage/coverage-unit.txt
         flags: unit-tests
         name: codecov-unit-test
-        fail_ci_if_error: true
+        fail_ci_if_error: ${{ github.event_name == 'push' }}
 
   test-unit-windows:
     needs: check-changes
@@ -104,7 +104,7 @@ jobs:
           file: .coverage/coverage-unit.txt
           flags: unit-tests
           name: codecov-unit-test
-          fail_ci_if_error: true
+          fail_ci_if_error: ${{ github.event_name == 'push' }}
 
   test-integration:
     needs: check-changes
@@ -147,7 +147,7 @@ jobs:
           files: .coverage/coverage-integration.txt,multicluster/.coverage/coverage-integration.txt
           flags: integration-tests
           name: codecov-integration-test
-          fail_ci_if_error: true
+          fail_ci_if_error: ${{ github.event_name == 'push' }}
 
   # golangci-lint-ubuntu and golangci-lint-macos are intentionally not merged into one job with os matrix, otherwise the
   # job wouldn't be expanded if it's skipped and the report of the required check would be missing.

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -112,7 +112,7 @@ jobs:
         flags: kind-e2e-tests
         name: codecov-test-e2e-encap
         directory: test-e2e-encap-coverage
-        fail_ci_if_error: true
+        fail_ci_if_error: ${{ github.event_name == 'push' }}
     - name: Tar log files
       if: ${{ failure() }}
       run: tar -czf log.tar.gz log
@@ -171,7 +171,7 @@ jobs:
         flags: kind-e2e-tests
         name: codecov-test-e2e-encap-no-proxy
         directory: test-e2e-encap-no-proxy-coverage
-        fail_ci_if_error: true
+        fail_ci_if_error: ${{ github.event_name == 'push' }}
     - name: Tar log files
       if: ${{ failure() }}
       run: tar -czf log.tar.gz log
@@ -231,7 +231,7 @@ jobs:
           flags: kind-e2e-tests
           name: codecov-test-e2e-encap-all-features-enabled
           directory: test-e2e-encap-all-features-enabled-coverage
-          fail_ci_if_error: true
+          fail_ci_if_error: ${{ github.event_name == 'push' }}
       - name: Tar log files
         if: ${{ failure() }}
         run: tar -czf log.tar.gz log
@@ -290,7 +290,7 @@ jobs:
         flags: kind-e2e-tests
         name: codecov-test-e2e-noencap
         directory: test-e2e-noencap-coverage
-        fail_ci_if_error: true
+        fail_ci_if_error: ${{ github.event_name == 'push' }}
     - name: Tar log files
       if: ${{ failure() }}
       run: tar -czf log.tar.gz log
@@ -349,7 +349,7 @@ jobs:
         flags: kind-e2e-tests
         name: codecov-test-e2e-hybrid
         directory: test-e2e-hybrid-coverage
-        fail_ci_if_error: true
+        fail_ci_if_error: ${{ github.event_name == 'push' }}
     - name: Tar log files
       if: ${{ failure() }}
       run: tar -czf log.tar.gz log
@@ -415,7 +415,7 @@ jobs:
           flags: kind-e2e-tests
           name: codecov-test-e2e-fa
           directory: test-e2e-fa-coverage
-          fail_ci_if_error: true
+          fail_ci_if_error: ${{ github.event_name == 'push' }}
       - name: Tar log files
         if: ${{ failure() }}
         run: tar -czf log.tar.gz log


### PR DESCRIPTION
Codecov upload fail quite often due to token accessibility issue, this will block github CI.
So disable it when it's triggered in pull request.

Please check the details in #4668