### PR TITLE
Force create cni folders when starting Windows containerd agent

### DIFF
--- a/build/yamls/antrea-windows-containerd.yml
+++ b/build/yamls/antrea-windows-containerd.yml
@@ -9,6 +9,8 @@ data:
     mkdir -force C:/var/run/secrets/kubernetes.io/serviceaccount
     cp $mountPath/var/run/secrets/kubernetes.io/serviceaccount/ca.crt C:/var/run/secrets/kubernetes.io/serviceaccount
     cp $mountPath/var/run/secrets/kubernetes.io/serviceaccount/token C:/var/run/secrets/kubernetes.io/serviceaccount
+    mkdir -force c:/opt/cni/bin/
+    mkdir -force c:/etc/cni/net.d/
     cp $mountPath/k/antrea/cni/* c:/opt/cni/bin/
     cp $mountPath/etc/antrea/antrea-cni.conflist c:/etc/cni/net.d/10-antrea.conflist
     mkdir -force c:/k/antrea/bin

--- a/build/yamls/windows/containerd/conf/Install-WindowsCNI-Containerd.ps1
+++ b/build/yamls/windows/containerd/conf/Install-WindowsCNI-Containerd.ps1
@@ -5,6 +5,8 @@ $mountPath =  ($mountPath.Replace('\', '/')).TrimEnd('/')
 mkdir -force C:/var/run/secrets/kubernetes.io/serviceaccount
 cp $mountPath/var/run/secrets/kubernetes.io/serviceaccount/ca.crt C:/var/run/secrets/kubernetes.io/serviceaccount
 cp $mountPath/var/run/secrets/kubernetes.io/serviceaccount/token C:/var/run/secrets/kubernetes.io/serviceaccount
+mkdir -force c:/opt/cni/bin/
+mkdir -force c:/etc/cni/net.d/
 cp $mountPath/k/antrea/cni/* c:/opt/cni/bin/
 cp $mountPath/etc/antrea/antrea-cni.conflist c:/etc/cni/net.d/10-antrea.conflist
 mkdir -force c:/k/antrea/bin


### PR DESCRIPTION
Create /opt/cni/bin/ and /etc/cni/net.d/ folders to avoid errors caused by non-existent paths.

Fixes #4680