### PR TITLE
Keep the cached Endpoints the same as those installed in OVS

### DIFF
--- a/pkg/agent/openflow/client_test.go
+++ b/pkg/agent/openflow/client_test.go
@@ -1037,7 +1037,7 @@ func Test_client_InstallEndpointFlows(t *testing.T) {
 			defer resetPipelines()
 
 			m.EXPECT().AddAll(gomock.Any()).Return(nil).Times(1)
-			m.EXPECT().DeleteAll(gomock.Any()).Return(nil).Times(len(tc.endpoints))
+			m.EXPECT().DeleteAll(gomock.Any()).Return(nil).Times(1)
 
 			assert.NoError(t, fc.InstallEndpointFlows(tc.protocol, tc.endpoints))
 			var flows []string
@@ -1050,8 +1050,8 @@ func Test_client_InstallEndpointFlows(t *testing.T) {
 			}
 			assert.ElementsMatch(t, tc.expectedFlows, flows)
 
+			assert.NoError(t, fc.UninstallEndpointFlows(tc.protocol, tc.endpoints))
 			for _, ep := range tc.endpoints {
-				assert.NoError(t, fc.UninstallEndpointFlows(tc.protocol, ep))
 				endpointPort, _ := ep.Port()
 				cacheKey := generateEndpointFlowCacheKey(ep.IP(), endpointPort, tc.protocol)
 				_, ok := fc.featureService.cachedFlows.Load(cacheKey)

--- a/pkg/agent/openflow/testing/mock_openflow.go
+++ b/pkg/agent/openflow/testing/mock_openflow.go
@@ -782,7 +782,7 @@ func (mr *MockClientMockRecorder) SubscribePacketIn(arg0, arg1 interface{}) *gom
 }
 
 // UninstallEndpointFlows mocks base method
-func (m *MockClient) UninstallEndpointFlows(arg0 openflow.Protocol, arg1 proxy.Endpoint) error {
+func (m *MockClient) UninstallEndpointFlows(arg0 openflow.Protocol, arg1 []proxy.Endpoint) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UninstallEndpointFlows", arg0, arg1)
 	ret0, _ := ret[0].(error)

--- a/test/integration/agent/openflow_test.go
+++ b/test/integration/agent/openflow_test.go
@@ -795,10 +795,7 @@ func uninstallServiceFlowsFunc(t *testing.T, gid uint32, svc svcConfig, endpoint
 	assert.Nil(t, err)
 	err = c.UninstallServiceGroup(groupID)
 	assert.Nil(t, err)
-	for _, ep := range endpointList {
-		err := c.UninstallEndpointFlows(svc.protocol, ep)
-		assert.Nil(t, err)
-	}
+	assert.NoError(t, c.UninstallEndpointFlows(svc.protocol, endpointList))
 }
 
 func expectedProxyServiceGroupAndFlows(gid uint32, svc svcConfig, endpointList []k8sproxy.Endpoint, stickyAge uint16, antreaPolicyEnabled bool) (tableFlows []expectTableFlows, groupBuckets []string) {


### PR DESCRIPTION
The main purpose of this PR is to avoid potential inconsistencies between
the cached Endpoints and those installed in OVS, like #4681, #4692.

This PR also updates:

- Method UninstallEndpointFlows of ofClient, support deleting flows of
  multiple Endpoints.
- Remove possible groups when a Service is deleted.
- Log something when a group for a Service is not created.
- Optimize and unify log.

Signed-off-by: Hongliang Liu <lhongliang@vmware.com>