### PR TITLE
Increase watcher termination reaction timeout to avoid flaky test

### DIFF
--- a/pkg/apiserver/storage/ram/store_test.go
+++ b/pkg/apiserver/storage/ram/store_test.go
@@ -510,7 +510,7 @@ func TestRamStoreWatchTimeout(t *testing.T) {
 	}
 
 	// Terminating watchers is asynchronous, leave it some reaction time to avoid flakes.
-	terminationReactionTime := time.Millisecond * 100
+	terminationReactionTime := time.Millisecond * 500
 	select {
 	case <-w2.(*storeWatcher).done:
 		t.Fatal("w2 was stopped, expected not stopped")


### PR DESCRIPTION
The test failure was observed several times on Windows runners, which is slower than Linux runners.

100ms is perhaps too short for the unresponsive watcher to be killed.

```
W0313 08:27:30.789254    3936 env.go:126] Failed to get Pod Namespace from environment. Using "kube-system" as the Antrea Service Namespace
--- FAIL: TestRamStoreWatchTimeout (0.75s)
    store_test.go:526: w2 was not stopped, expected stopped
    store_test.go:528: 
        	Error Trace:	D:/a/antrea/antrea/pkg/apiserver/storage/ram/store_test.go:528
        	Error:      	Not equal: 
        	            	expected: 1
        	            	actual  : 2
        	Test:       	TestRamStoreWatchTimeout
        	Messages:   	Unexpected watchers number
W0313 08:27:31.564994    3936 store.go:350] Forcing stopping watcher (selectors: &{ app=nginx }) due to unresponsiveness
```