### PR TITLE
Specify AMI Family required by eksctl when using a custom AMI

### DIFF
--- a/ci/test-conformance-eks.sh
+++ b/ci/test-conformance-eks.sh
@@ -163,6 +163,7 @@ managedNodeGroups:
     instanceType: ${AWS_NODE_TYPE}
     desiredCapacity: 2
     ami: ${AMI_ID}
+    amiFamily: AmazonLinux2
     ssh:
       allow: true
       publicKeyPath: ${SSH_KEY_PATH}


### PR DESCRIPTION
Otherwise creaing cluster would fail with error.