### PR TITLE
Automated cherry pick of #4685: Force create cni folders when starting Windows containerd

### DIFF
--- a/build/yamls/antrea-windows-containerd.yml
+++ b/build/yamls/antrea-windows-containerd.yml
@@ -9,6 +9,8 @@ data:
     mkdir -force C:/var/run/secrets/kubernetes.io/serviceaccount
     cp $mountPath/var/run/secrets/kubernetes.io/serviceaccount/ca.crt C:/var/run/secrets/kubernetes.io/serviceaccount
     cp $mountPath/var/run/secrets/kubernetes.io/serviceaccount/token C:/var/run/secrets/kubernetes.io/serviceaccount
+    mkdir -force c:/opt/cni/bin/
+    mkdir -force c:/etc/cni/net.d/
     cp $mountPath/k/antrea/cni/* c:/opt/cni/bin/
     cp $mountPath/etc/antrea/antrea-cni.conflist c:/etc/cni/net.d/10-antrea.conflist
     mkdir -force c:/k/antrea/bin

--- a/build/yamls/windows/base/conf/Install-WindowsCNI-Containerd.ps1
+++ b/build/yamls/windows/base/conf/Install-WindowsCNI-Containerd.ps1
@@ -5,6 +5,8 @@ $mountPath =  ($mountPath.Replace('\', '/')).TrimEnd('/')
 mkdir -force C:/var/run/secrets/kubernetes.io/serviceaccount
 cp $mountPath/var/run/secrets/kubernetes.io/serviceaccount/ca.crt C:/var/run/secrets/kubernetes.io/serviceaccount
 cp $mountPath/var/run/secrets/kubernetes.io/serviceaccount/token C:/var/run/secrets/kubernetes.io/serviceaccount
+mkdir -force c:/opt/cni/bin/
+mkdir -force c:/etc/cni/net.d/
 cp $mountPath/k/antrea/cni/* c:/opt/cni/bin/
 cp $mountPath/etc/antrea/antrea-cni.conflist c:/etc/cni/net.d/10-antrea.conflist
 mkdir -force c:/k/antrea/bin


### PR DESCRIPTION
Cherry pick of #4685 on release-1.10.

#4685: Force create cni folders when starting Windows containerd

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.