### PR TITLE
Automated cherry pick of #4592: Fix missing call of removing groupDb cache when deleting OVS

### DIFF
--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -643,7 +643,10 @@ func (c *client) UninstallServiceGroup(groupID binding.GroupIDType) error {
 	gCache, ok := c.featureService.groupCache.Load(groupID)
 	if ok {
 		if err := c.ofEntryOperations.DeleteOFEntries([]binding.OFEntry{gCache.(binding.Group)}); err != nil {
-			return fmt.Errorf("error when deleting Service Endpoints Group %d: %w", groupID, err)
+			return fmt.Errorf("error when deleting Openflow entries for Service Endpoints Group %d: %w", groupID, err)
+		}
+		if err := c.bridge.DeleteGroup(groupID); err != nil {
+			return fmt.Errorf("error when deleting OFSwitch groupDb Cache for Service Endpoints Group %d: %w", groupID, err)
 		}
 		c.featureService.groupCache.Delete(groupID)
 	}
@@ -1345,7 +1348,10 @@ func (c *client) UninstallMulticastGroup(groupID binding.GroupIDType) error {
 	gCache, ok := c.featureMulticast.groupCache.Load(groupID)
 	if ok {
 		if err := c.ofEntryOperations.DeleteOFEntries([]binding.OFEntry{gCache.(binding.Group)}); err != nil {
-			return fmt.Errorf("error when deleting Multicast receiver Group %d: %w", groupID, err)
+			return fmt.Errorf("error when deleting Openflow entries for Multicast receiver Group %d: %w", groupID, err)
+		}
+		if err := c.bridge.DeleteGroup(groupID); err != nil {
+			return fmt.Errorf("error when deleting OFSwitch groupDb Cache for Multicast receiver Group %d: %w", groupID, err)
 		}
 		c.featureMulticast.groupCache.Delete(groupID)
 	}

--- a/pkg/ovs/openflow/ofctrl_bridge.go
+++ b/pkg/ovs/openflow/ofctrl_bridge.go
@@ -224,14 +224,11 @@ func (b *OFBridge) createGroupWithType(id GroupIDType, groupType ofctrl.GroupTyp
 	return g
 }
 
+// DeleteGroup deletes a specified group in groupDb.
 func (b *OFBridge) DeleteGroup(id GroupIDType) error {
 	ofctrlGroup := b.ofSwitch.GetGroup(uint32(id))
 	if ofctrlGroup == nil {
 		return nil
-	}
-	g := &ofGroup{bridge: b, ofctrl: ofctrlGroup}
-	if err := g.Delete(); err != nil {
-		return fmt.Errorf("failed to delete the group: %w", err)
 	}
 	return b.ofSwitch.DeleteGroup(uint32(id))
 }

--- a/pkg/ovs/openflow/ofctrl_bridge_test.go
+++ b/pkg/ovs/openflow/ofctrl_bridge_test.go
@@ -22,6 +22,7 @@ import (
 
 	"antrea.io/libOpenflow/util"
 	"antrea.io/ofnet/ofctrl"
+	"github.com/stretchr/testify/assert"
 
 	"antrea.io/antrea/pkg/ovs/ovsconfig"
 )
@@ -84,4 +85,35 @@ func TestOFBridgeIsConnected(t *testing.T) {
 		b.IsConnected()
 	}()
 	wg.Wait()
+}
+
+func TestDeleteGroup(t *testing.T) {
+	b := NewOFBridge("test-br", GetMgmtAddress(ovsconfig.DefaultOVSRunDir, "test-br"))
+
+	for _, m := range []struct {
+		name            string
+		existingGroupID GroupIDType
+		deleteGroupID   GroupIDType
+		err             error
+	}{
+		{
+			name:            "delete existing group without flow",
+			existingGroupID: 20,
+			deleteGroupID:   20,
+			err:             nil,
+		},
+		{
+			name:            "delete non-existing group",
+			existingGroupID: 20,
+			deleteGroupID:   30,
+			err:             nil,
+		},
+	} {
+		t.Run(m.name, func(t *testing.T) {
+			b.ofSwitch = newFakeOFSwitch(b)
+			b.CreateGroup(m.existingGroupID)
+			err := b.DeleteGroup(m.deleteGroupID)
+			assert.Equal(t, m.err, err)
+		})
+	}
 }


### PR DESCRIPTION
Cherry pick of #4592 on release-1.10.

#4592: Fix missing call of removing groupDb cache when deleting OVS

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.