### PR TITLE
Cleanup Leftover Kind Cluster in Kind Testbed

### DIFF
--- a/ci/jenkins/jobs/macros.yaml
+++ b/ci/jenkins/jobs/macros.yaml
@@ -231,6 +231,10 @@
           #!/bin/bash
           set -ex
           DOCKER_REGISTRY="$(head -n1 ci/docker-registry)"
+          #  Delete all kind clusters created more than 135 mins ago. 135 minutes is the timeout 
+          #  we have configured for running conformance and NetworkPolicy tests on Kind, 
+          #  so clusters older than that can de deleted safely.
+          ./ci/kind/kind-setup.sh destroy --all --until 135
           ./ci/kind/kind-setup.sh --antrea-cni create "${{JOB_NAME}}-${{BUILD_NUMBER}}"
           kind export kubeconfig -n "${{JOB_NAME}}-${{BUILD_NUMBER}}" --kubeconfig ${{PWD}}/.kube/config
           set +ex

--- a/ci/jenkins/jobs/projects-lab.yaml
+++ b/ci/jenkins/jobs/projects-lab.yaml
@@ -844,8 +844,12 @@
           error_status: Failed. Add comment /test-kind-conformance to re-trigger.
           triggered_status: null
           started_status: null
+          wrappers:
+          - timeout:
+              fail: true
+              timeout: 135
+              type: absolute
           publishers: []
-          wrappers: []
       - '{name}-{test_name}-for-pull-request':
           test_name: kind-networkpolicy
           node: 'antrea-kind-testbed'
@@ -870,8 +874,12 @@
           error_status: Failed. Add comment /test-kind-networkpolicy to re-trigger.
           triggered_status: null
           started_status: null
+          wrappers:
+          - timeout:
+              fail: true
+              timeout: 135
+              type: absolute
           publishers: []
-          wrappers: []
       - '{name}-{test_name}-for-pull-request':
           test_name: rancher-e2e
           node: 'antrea-rancher-testbed'


### PR DESCRIPTION
Signed-off-by: KMAnju-2021 km074btcse18@igdtuw.ac.in

part of: #4460
There could be chance that Job is aborted then the kind cluster becomes garbage.
The kind test job should delete existing kind clusters before creating a new cluster.

Note:
we have set 135 minutes timeout for both conformance and NetworkPolicy tests in the jobs because sometime NetworkPolicy takes more time to finish its executions( It depends on how many test cases are running and the time of each test cases ) although we can choose 120m also, but just to be on the safe side we have set 135m just like other ci jobs in project-lab.yaml, for example "rancher-networkpolicy".

so in case if tests gets stuck during their execution then it will wait for 135m and run will aborted automatically, and in aborted cases clusters became useless and we need to delete them in next run before creating new one. 