### PR TITLE
Fix route deletion for Service ClusterIP and LoadBalancerIP

### DIFF
--- a/pkg/agent/route/interfaces.go
+++ b/pkg/agent/route/interfaces.go
@@ -65,11 +65,11 @@ type Interface interface {
 	// ClusterIP Service traffic from host network.
 	DeleteClusterIPRoute(svcIP net.IP) error
 
-	// AddLoadBalancer adds configurations when a LoadBalancer Service is created.
-	AddLoadBalancer(externalIPs []string) error
+	// AddLoadBalancer adds configurations when a LoadBalancer IP is added.
+	AddLoadBalancer(externalIP net.IP) error
 
-	// DeleteLoadBalancer deletes related configurations when a LoadBalancer Service is deleted.
-	DeleteLoadBalancer(externalIPs []string) error
+	// DeleteLoadBalancer deletes related configurations when a LoadBalancer IP is deleted.
+	DeleteLoadBalancer(externalIP net.IP) error
 
 	// Run starts the sync loop.
 	Run(stopCh <-chan struct{})

--- a/pkg/agent/route/route_linux.go
+++ b/pkg/agent/route/route_linux.go
@@ -1420,11 +1420,10 @@ func (c *Client) addVirtualNodePortDNATIPRoute(isIPv6 bool) error {
 	return nil
 }
 
-// addLoadBalancerIngressIPRoute is used to add routing entry which is used to route LoadBalancer ingress IP to Antrea
+// AddLoadBalancer is used to add routing entry which is used to route LoadBalancer ingress IP to Antrea
 // gateway on host.
-func (c *Client) addLoadBalancerIngressIPRoute(svcIPStr string) error {
+func (c *Client) AddLoadBalancer(svcIP net.IP) error {
 	linkIndex := c.nodeConfig.GatewayConfig.LinkIndex
-	svcIP := net.ParseIP(svcIPStr)
 	isIPv6 := utilnet.IsIPv6(svcIP)
 	var gw net.IP
 	var mask int
@@ -1446,11 +1445,10 @@ func (c *Client) addLoadBalancerIngressIPRoute(svcIPStr string) error {
 	return nil
 }
 
-// deleteLoadBalancerIngressIPRoute is used to delete routing entry which is used to route LoadBalancer ingress IP to Antrea
+// DeleteLoadBalancer is used to delete routing entry which is used to route LoadBalancer ingress IP to Antrea
 // gateway on host.
-func (c *Client) deleteLoadBalancerIngressIPRoute(svcIPStr string) error {
+func (c *Client) DeleteLoadBalancer(svcIP net.IP) error {
 	linkIndex := c.nodeConfig.GatewayConfig.LinkIndex
-	svcIP := net.ParseIP(svcIPStr)
 	isIPv6 := utilnet.IsIPv6(svcIP)
 	var gw net.IP
 	var mask int
@@ -1472,28 +1470,6 @@ func (c *Client) deleteLoadBalancerIngressIPRoute(svcIPStr string) error {
 	}
 	klog.V(4).InfoS("Deleted LoadBalancer ingress IP route", "route", route)
 	c.serviceRoutes.Delete(svcIP.String())
-
-	return nil
-}
-
-// AddLoadBalancer is used to add routing entries when a LoadBalancer Service is added.
-func (c *Client) AddLoadBalancer(externalIPs []string) error {
-	for _, svcIPStr := range externalIPs {
-		if err := c.addLoadBalancerIngressIPRoute(svcIPStr); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// DeleteLoadBalancer is used to delete routing entries when a LoadBalancer Service is deleted.
-func (c *Client) DeleteLoadBalancer(externalIPs []string) error {
-	for _, svcIPStr := range externalIPs {
-		if err := c.deleteLoadBalancerIngressIPRoute(svcIPStr); err != nil {
-			return err
-		}
-	}
 
 	return nil
 }

--- a/pkg/agent/route/route_linux_test.go
+++ b/pkg/agent/route/route_linux_test.go
@@ -1418,12 +1418,12 @@ func TestAddLoadBalancer(t *testing.T) {
 	nodeConfig := &config.NodeConfig{GatewayConfig: &config.GatewayConfig{LinkIndex: 10}}
 	tests := []struct {
 		name          string
-		externalIPs   []string
+		externalIP    string
 		expectedCalls func(mockNetlink *netlinktest.MockInterfaceMockRecorder)
 	}{
 		{
-			name:        "IPv4",
-			externalIPs: []string{"1.1.1.1", "1.1.1.2"},
+			name:       "IPv4",
+			externalIP: "1.1.1.1",
 			expectedCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
 				mockNetlink.RouteReplace(&netlink.Route{
 					Dst: &net.IPNet{
@@ -1434,29 +1434,14 @@ func TestAddLoadBalancer(t *testing.T) {
 					Scope:     netlink.SCOPE_UNIVERSE,
 					LinkIndex: 10,
 				})
-				mockNetlink.RouteReplace(&netlink.Route{
-					Dst: &net.IPNet{
-						IP:   net.ParseIP("1.1.1.2"),
-						Mask: net.CIDRMask(32, 32),
-					},
-					Gw:        config.VirtualServiceIPv4,
-					Scope:     netlink.SCOPE_UNIVERSE,
-					LinkIndex: 10,
-				})
 			},
 		},
 		{
-			name:        "IPv6",
-			externalIPs: []string{"fd00:1234:5678:dead:beaf::1", "fd00:1234:5678:dead:beaf::a"},
+			name:       "IPv6",
+			externalIP: "fd00:1234:5678:dead:beaf::1",
 			expectedCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
 				mockNetlink.RouteReplace(&netlink.Route{
 					Dst:       &net.IPNet{IP: net.ParseIP("fd00:1234:5678:dead:beaf::1"), Mask: net.CIDRMask(128, 128)},
-					Gw:        config.VirtualServiceIPv6,
-					Scope:     netlink.SCOPE_UNIVERSE,
-					LinkIndex: 10,
-				})
-				mockNetlink.RouteReplace(&netlink.Route{
-					Dst:       &net.IPNet{IP: net.ParseIP("fd00:1234:5678:dead:beaf::a"), Mask: net.CIDRMask(128, 128)},
 					Gw:        config.VirtualServiceIPv6,
 					Scope:     netlink.SCOPE_UNIVERSE,
 					LinkIndex: 10,
@@ -1475,7 +1460,7 @@ func TestAddLoadBalancer(t *testing.T) {
 			}
 			tt.expectedCalls(mockNetlink.EXPECT())
 
-			assert.NoError(t, c.AddLoadBalancer(tt.externalIPs))
+			assert.NoError(t, c.AddLoadBalancer(net.ParseIP(tt.externalIP)))
 		})
 	}
 }
@@ -1484,12 +1469,12 @@ func TestDeleteLoadBalancer(t *testing.T) {
 	nodeConfig := &config.NodeConfig{GatewayConfig: &config.GatewayConfig{LinkIndex: 10}}
 	tests := []struct {
 		name          string
-		externalIPs   []string
+		externalIP    string
 		expectedCalls func(mockNetlink *netlinktest.MockInterfaceMockRecorder)
 	}{
 		{
-			name:        "IPv4",
-			externalIPs: []string{"1.1.1.1", "1.1.1.2"},
+			name:       "IPv4",
+			externalIP: "1.1.1.1",
 			expectedCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
 				mockNetlink.RouteDel(&netlink.Route{
 					Dst: &net.IPNet{
@@ -1500,29 +1485,14 @@ func TestDeleteLoadBalancer(t *testing.T) {
 					Scope:     netlink.SCOPE_UNIVERSE,
 					LinkIndex: 10,
 				})
-				mockNetlink.RouteDel(&netlink.Route{
-					Dst: &net.IPNet{
-						IP:   net.ParseIP("1.1.1.2"),
-						Mask: net.CIDRMask(32, 32),
-					},
-					Gw:        config.VirtualServiceIPv4,
-					Scope:     netlink.SCOPE_UNIVERSE,
-					LinkIndex: 10,
-				})
 			},
 		},
 		{
-			name:        "IPv6",
-			externalIPs: []string{"fd00:1234:5678:dead:beaf::1", "fd00:1234:5678:dead:beaf::a"},
+			name:       "IPv6",
+			externalIP: "fd00:1234:5678:dead:beaf::1",
 			expectedCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
 				mockNetlink.RouteDel(&netlink.Route{
 					Dst:       &net.IPNet{IP: net.ParseIP("fd00:1234:5678:dead:beaf::1"), Mask: net.CIDRMask(128, 128)},
-					Gw:        config.VirtualServiceIPv6,
-					Scope:     netlink.SCOPE_UNIVERSE,
-					LinkIndex: 10,
-				})
-				mockNetlink.RouteDel(&netlink.Route{
-					Dst:       &net.IPNet{IP: net.ParseIP("fd00:1234:5678:dead:beaf::a"), Mask: net.CIDRMask(128, 128)},
 					Gw:        config.VirtualServiceIPv6,
 					Scope:     netlink.SCOPE_UNIVERSE,
 					LinkIndex: 10,
@@ -1541,7 +1511,7 @@ func TestDeleteLoadBalancer(t *testing.T) {
 			}
 			tt.expectedCalls(mockNetlink.EXPECT())
 
-			assert.NoError(t, c.DeleteLoadBalancer(tt.externalIPs))
+			assert.NoError(t, c.DeleteLoadBalancer(net.ParseIP(tt.externalIP)))
 		})
 	}
 }

--- a/pkg/agent/route/route_windows.go
+++ b/pkg/agent/route/route_windows.go
@@ -404,22 +404,12 @@ func (c *Client) DeleteNodePort(nodePortAddresses []net.IP, port uint16, protoco
 	return util.RemoveNetNatStaticMapping(antreaNatNodePort, "0.0.0.0", port, string(protocol))
 }
 
-func (c *Client) AddLoadBalancer(externalIPs []string) error {
-	for _, svcIPStr := range externalIPs {
-		if err := c.addServiceRoute(net.ParseIP(svcIPStr)); err != nil {
-			return err
-		}
-	}
-	return nil
+func (c *Client) AddLoadBalancer(externalIP net.IP) error {
+	return c.addServiceRoute(externalIP)
 }
 
-func (c *Client) DeleteLoadBalancer(externalIPs []string) error {
-	for _, svcIPStr := range externalIPs {
-		if err := c.deleteServiceRoute(net.ParseIP(svcIPStr)); err != nil {
-			return err
-		}
-	}
-	return nil
+func (c *Client) DeleteLoadBalancer(externalIP net.IP) error {
+	return c.deleteServiceRoute(externalIP)
 }
 
 func (c *Client) AddLocalAntreaFlexibleIPAMPodRule(podAddresses []net.IP) error {

--- a/pkg/agent/route/testing/mock_route.go
+++ b/pkg/agent/route/testing/mock_route.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Antrea Authors
+// Copyright 2023 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -65,7 +65,7 @@ func (mr *MockInterfaceMockRecorder) AddClusterIPRoute(arg0 interface{}) *gomock
 }
 
 // AddLoadBalancer mocks base method
-func (m *MockInterface) AddLoadBalancer(arg0 []string) error {
+func (m *MockInterface) AddLoadBalancer(arg0 net.IP) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddLoadBalancer", arg0)
 	ret0, _ := ret[0].(error)
@@ -149,7 +149,7 @@ func (mr *MockInterfaceMockRecorder) DeleteClusterIPRoute(arg0 interface{}) *gom
 }
 
 // DeleteLoadBalancer mocks base method
-func (m *MockInterface) DeleteLoadBalancer(arg0 []string) error {
+func (m *MockInterface) DeleteLoadBalancer(arg0 net.IP) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteLoadBalancer", arg0)
 	ret0, _ := ret[0].(error)


### PR DESCRIPTION
When proxyAll is enabled, AntreaProxy needs to install routes in the host network namespace to redirect traffic to OVS for load balancing. For a Service with multiple ports, multiple ServicePorts are generated and processed. The previous code installed the route for a ClusterIP or a LoadBalancerIP multiple times when such a Service was created, and uninstalled the route multiple times when it was deleted, leading to a few problems.

This patch adds a serviceIPRouteReferences which tracks the references of Service IPs' routes. The key is the Service IP and the value is the the set of ServiceInfo strings. With the references, we install a route exactly once as long as it's used by any ServicePorts and uninstall it exactly once when it's no longer used by any ServicePorts.

This patch also fixes an issue that the route for ClusterIP was not removed on Windows Nodes after the Service was removed.

The patch also makes shared LoadBalancerIP work correctly.

Fixes #4361