### PR TITLE
Fix ClusterIP Service processing

### DIFF
--- a/pkg/agent/openflow/groups.go
+++ b/pkg/agent/openflow/groups.go
@@ -22,6 +22,7 @@ import (
 
 type GroupAllocator interface {
 	Allocate() binding.GroupIDType
+	Next() binding.GroupIDType
 	Release(id binding.GroupIDType)
 }
 
@@ -45,6 +46,19 @@ func (a *groupAllocator) Allocate() binding.GroupIDType {
 	} else {
 		a.groupIDCounter += 1
 		id = a.groupIDCounter
+	}
+	return id
+}
+
+// Next is a readonly method which returns the next available group ID. It's useful in tests to predict the group ID.
+func (a *groupAllocator) Next() binding.GroupIDType {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	var id binding.GroupIDType
+	if len(a.recycled) != 0 {
+		id = a.recycled[len(a.recycled)-1]
+	} else {
+		id = a.groupIDCounter + 1
 	}
 	return id
 }


### PR DESCRIPTION
AntreaProxy doesn't allocate a group for cluster Endpoints if a ClusterIP Service's InternalTrafficPolicy is Local, so getting the group ID of cluster Endpoints returns nothing. The previous code stopped processing the Service and logged error mistakenly in this case, causing this Service's flows and routes never being deleted.

The patch fixes it and enhances the validation for this case.