### PR TITLE
Avoid duplicate Node Results in Live Traceflow Status

### DIFF
--- a/pkg/agent/controller/traceflow/packetin.go
+++ b/pkg/agent/controller/traceflow/packetin.go
@@ -34,7 +34,7 @@ import (
 	binding "antrea.io/antrea/pkg/ovs/openflow"
 )
 
-var skipTraceflowUpdateErr = errors.New("Skip Traceflow Update")
+var skipTraceflowUpdateErr = errors.New("skip Traceflow update")
 
 func (c *Controller) HandlePacketIn(pktIn *ofctrl.PacketIn) error {
 	if !c.traceflowListerSynced() {
@@ -52,7 +52,7 @@ func (c *Controller) HandlePacketIn(pktIn *ofctrl.PacketIn) error {
 	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		tf, err := c.traceflowInformer.Lister().Get(oldTf.Name)
 		if err != nil {
-			return fmt.Errorf("Get Traceflow failed: %w", err)
+			return fmt.Errorf("get Traceflow failed: %w", err)
 		}
 		update := tf.DeepCopy()
 		update.Status.Results = append(update.Status.Results, *nodeResult)
@@ -61,7 +61,7 @@ func (c *Controller) HandlePacketIn(pktIn *ofctrl.PacketIn) error {
 		}
 		_, err = c.traceflowClient.CrdV1alpha1().Traceflows().UpdateStatus(context.TODO(), update, v1.UpdateOptions{})
 		if err != nil {
-			return fmt.Errorf("Update Traceflow failed: %w", err)
+			return fmt.Errorf("update Traceflow failed: %w", err)
 		}
 		klog.InfoS("Updated Traceflow", "tf", klog.KObj(tf), "status", update.Status)
 		return nil

--- a/pkg/agent/openflow/packetin.go
+++ b/pkg/agent/openflow/packetin.go
@@ -122,9 +122,8 @@ func (c *client) parsePacketIn(featurePacketIn *featureStartPacketIn) {
 		// Use corresponding handlers subscribed to the reason to handle PacketIn
 		for name, handler := range c.packetInHandlers[featurePacketIn.reason] {
 			klog.V(2).InfoS("Received packetIn", "reason", featurePacketIn.reason, "handler", name)
-			err := handler.HandlePacketIn(pktIn)
-			if err != nil {
-				klog.Errorf("PacketIn handler %s failed to process packet: %+v", name, err)
+			if err := handler.HandlePacketIn(pktIn); err != nil {
+				klog.ErrorS(err, "PacketIn handler failed to process packet", "handler", name)
 			}
 		}
 	}


### PR DESCRIPTION
After receiving a Packet In for a live Traceflow, the controller uninstalls the corresponding OVS flows to prevent additional Packet Ins (from different connections which also match the Live Traceflow filters).

However, if 2 connections happen within a very short time window (< 1ms in my testbed) and both match the Live Traceflow filters, it is still possible for 2 Packet In messages to be received. To avoid duplicate Node Results in the Live Traceflow Status, we need to ignore all Packet In messages received after the first one.

Fixes #4714