### PR TITLE
Support inspecting fragmented DNS message for FQDN policy

### DIFF
--- a/pkg/ovs/openflow/ofctrl_packetin_test.go
+++ b/pkg/ovs/openflow/ofctrl_packetin_test.go
@@ -231,9 +231,10 @@ func TestParsePacketIn(t *testing.T) {
 
 func TestGetTCPDNSData(t *testing.T) {
 	type args struct {
-		tcp        protocol.TCP
-		expectErr  error
-		expectData []byte
+		tcp          protocol.TCP
+		expectErr    error
+		expectData   []byte
+		expectLength int
 	}
 	tests := []struct {
 		name string
@@ -257,8 +258,9 @@ func TestGetTCPDNSData(t *testing.T) {
 					HdrLen: 6,
 					Data:   []byte{1, 2, 3, 4, 0, 2, 5},
 				},
-				expectErr:  fmt.Errorf("there is a non-DNS response or a fragmented DNS response in TCP payload"),
-				expectData: nil,
+				expectErr:    nil,
+				expectData:   []byte{5},
+				expectLength: 2,
 			},
 		},
 		{
@@ -268,17 +270,19 @@ func TestGetTCPDNSData(t *testing.T) {
 					HdrLen: 6,
 					Data:   []byte{1, 2, 3, 4, 0, 1, 5},
 				},
-				expectErr:  nil,
-				expectData: []byte{5},
+				expectErr:    nil,
+				expectData:   []byte{5},
+				expectLength: 1,
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tcp := tt.args.tcp
-			tcpData, err := GetTCPDNSData(&tcp)
+			tcpData, dataLength, err := GetTCPDNSData(&tcp)
 			assert.Equal(t, tt.args.expectErr, err)
 			assert.Equal(t, tt.args.expectData, tcpData)
+			assert.Equal(t, tt.args.expectLength, dataLength)
 		})
 	}
 }

--- a/third_party/dns/dns.go
+++ b/third_party/dns/dns.go
@@ -1,0 +1,194 @@
+// Copyright 2023 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This package is copied and modified from https://github.com/miekg/dns because the original function Unpack cannot
+// unpack fragmented DNS message.
+
+package dns
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	godns "github.com/miekg/dns"
+)
+
+const (
+	// Header.Bits
+	_QR = 1 << 15 // query/response (response=1)
+	_AA = 1 << 10 // authoritative
+	_TC = 1 << 9  // truncated
+	_RD = 1 << 8  // recursion desired
+	_RA = 1 << 7  // recursion available
+	_Z  = 1 << 6  // Z
+	_AD = 1 << 5  // authenticated data
+	_CD = 1 << 4  // checking disabled
+)
+
+// UnpackDNSMsgPartially is modified from https://github.com/miekg/dns/blob/6ad6301ae27dca6d7822baf1b05ff9c9e4ba56f4/msg.go#L883.
+// It can unpack a DNS response with partial data only. More specifically, it unpacks the message header, the question
+// section, and the answer section, while ignores the authority section and the additional section.
+// It's used to get the question and answer sections when a DNS response is carried by a TCP packet but is fragmented.
+func UnpackDNSMsgPartially(msg []byte, dns *godns.Msg) error {
+	dh, off, err := unpackMsgHdr(msg, 0)
+	if err != nil {
+		return err
+	}
+
+	setHdr(dns, dh)
+	return unpackPartially(dns, dh, msg, off)
+}
+
+func unpackMsgHdr(msg []byte, off int) (godns.Header, int, error) {
+	var (
+		dh  godns.Header
+		err error
+	)
+	dh.Id, off, err = unpackUint16(msg, off)
+	if err != nil {
+		return dh, off, err
+	}
+	dh.Bits, off, err = unpackUint16(msg, off)
+	if err != nil {
+		return dh, off, err
+	}
+	dh.Qdcount, off, err = unpackUint16(msg, off)
+	if err != nil {
+		return dh, off, err
+	}
+	dh.Ancount, off, err = unpackUint16(msg, off)
+	if err != nil {
+		return dh, off, err
+	}
+	dh.Nscount, off, err = unpackUint16(msg, off)
+	if err != nil {
+		return dh, off, err
+	}
+	dh.Arcount, off, err = unpackUint16(msg, off)
+	if err != nil {
+		return dh, off, err
+	}
+	return dh, off, nil
+}
+
+func unpackUint16(msg []byte, off int) (i uint16, off1 int, err error) {
+	if off+2 > len(msg) {
+		return 0, len(msg), fmt.Errorf("overflow unpacking uint16")
+	}
+	return binary.BigEndian.Uint16(msg[off:]), off + 2, nil
+}
+
+func setHdr(dns *godns.Msg, dh godns.Header) {
+	dns.Id = dh.Id
+	dns.Response = dh.Bits&_QR != 0
+	dns.Opcode = int(dh.Bits>>11) & 0xF
+	dns.Authoritative = dh.Bits&_AA != 0
+	dns.Truncated = dh.Bits&_TC != 0
+	dns.RecursionDesired = dh.Bits&_RD != 0
+	dns.RecursionAvailable = dh.Bits&_RA != 0
+	dns.Zero = dh.Bits&_Z != 0 // _Z covers the zero bit, which should be zero; not sure why we set it to the opposite.
+	dns.AuthenticatedData = dh.Bits&_AD != 0
+	dns.CheckingDisabled = dh.Bits&_CD != 0
+	dns.Rcode = int(dh.Bits & 0xF)
+}
+
+// unpackPartially is modified from https://github.com/miekg/dns/blob/6ad6301ae27dca6d7822baf1b05ff9c9e4ba56f4/msg.go#L826.
+// It unpacks the message header, the question section, and the answer section, while ignores the authority section and
+// the additional section.
+func unpackPartially(dns *godns.Msg, dh godns.Header, msg []byte, off int) (err error) {
+	// If we are at the end of the message we should return *just* the
+	// header. This can still be useful to the caller. 9.9.9.9 sends these
+	// when responding with REFUSED for instance.
+	if off == len(msg) {
+		// reset sections before returning
+		dns.Question, dns.Answer, dns.Ns, dns.Extra = nil, nil, nil, nil
+		return nil
+	}
+
+	// Qdcount, Ancount, Nscount, Arcount can't be trusted, as they are
+	// attacker controlled. This means we can't use them to pre-allocate
+	// slices.
+	dns.Question = nil
+	for i := 0; i < int(dh.Qdcount); i++ {
+		off1 := off
+		var q godns.Question
+		q, off, err = unpackQuestion(msg, off)
+		if err != nil {
+			return err
+		}
+		if off1 == off { // Offset does not increase anymore, dh.Qdcount is a lie!
+			dh.Qdcount = uint16(i)
+			break
+		}
+		dns.Question = append(dns.Question, q)
+	}
+
+	dns.Answer, off, err = unpackRRslice(int(dh.Ancount), msg, off)
+	// The header counts might have been wrong so we need to update it
+	dh.Ancount = uint16(len(dns.Answer))
+	// Skip unpacking the authority section and the additional section.
+	return err
+
+}
+
+func unpackQuestion(msg []byte, off int) (godns.Question, int, error) {
+	var (
+		q   godns.Question
+		err error
+	)
+	q.Name, off, err = godns.UnpackDomainName(msg, off)
+	if err != nil {
+		return q, off, err
+	}
+	if off == len(msg) {
+		return q, off, nil
+	}
+	q.Qtype, off, err = unpackUint16(msg, off)
+	if err != nil {
+		return q, off, err
+	}
+	if off == len(msg) {
+		return q, off, nil
+	}
+	q.Qclass, off, err = unpackUint16(msg, off)
+	if off == len(msg) {
+		return q, off, nil
+	}
+	return q, off, err
+}
+
+// unpackRRslice unpacks msg[off:] into an []RR.
+// If we cannot unpack the whole array, then it will return nil
+func unpackRRslice(l int, msg []byte, off int) (dst1 []godns.RR, off1 int, err error) {
+	var r godns.RR
+	// Don't pre-allocate, l may be under attacker control
+	var dst []godns.RR
+	for i := 0; i < l; i++ {
+		off1 := off
+		r, off, err = godns.UnpackRR(msg, off)
+		if err != nil {
+			off = len(msg)
+			break
+		}
+		// If offset does not increase anymore, l is a lie
+		if off1 == off {
+			break
+		}
+		dst = append(dst, r)
+	}
+	if err != nil && off == len(msg) {
+		dst = nil
+	}
+	return dst, off, err
+}

--- a/third_party/dns/dns_test.go
+++ b/third_party/dns/dns_test.go
@@ -1,0 +1,81 @@
+// Copyright 2023 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dns
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	godns "github.com/miekg/dns"
+)
+
+func TestUnpackDNSMsgPartially(t *testing.T) {
+	name := "some-very-long-ownername.com."
+	originalMsg := &godns.Msg{
+		Compress: true,
+		Answer: []godns.RR{
+			&godns.NS{
+				Hdr: godns.RR_Header{
+					Name:     name,
+					Rrtype:   godns.TypeNS,
+					Class:    godns.ClassINET,
+					Rdlength: 13,
+				},
+				Ns: "ns1.server.com.",
+			},
+			&godns.NSEC{
+				Hdr: godns.RR_Header{
+					Name:     name,
+					Rrtype:   godns.TypeNSEC,
+					Class:    godns.ClassINET,
+					Rdlength: 15,
+				},
+				NextDomain: "a.com.",
+				TypeBitMap: []uint16{godns.TypeNS, godns.TypeNSEC},
+			},
+		},
+		Ns: []godns.RR{
+			&godns.CNAME{
+				Hdr: godns.RR_Header{
+					Name:   "foo.example.com.",
+					Rrtype: godns.TypeCNAME,
+					Class:  godns.ClassINET,
+					Ttl:    300,
+				},
+				Target: "bar.example.com.",
+			},
+		},
+	}
+
+	// Pack msg and then unpack into partialMsg
+	originalBuf, err := originalMsg.Pack()
+	require.NoError(t, err)
+	// Without the last 10 bytes, it should be unpacked successfully.
+	partialBuf := originalBuf[:len(originalBuf)-10]
+	partialMsg := new(godns.Msg)
+	err = UnpackDNSMsgPartially(partialBuf, partialMsg)
+	require.NoError(t, err)
+	assert.Equal(t, originalMsg.MsgHdr, partialMsg.MsgHdr)
+	assert.Equal(t, originalMsg.Question, partialMsg.Question)
+	assert.Equal(t, originalMsg.Answer, partialMsg.Answer)
+
+	// With the beginning 10 bytes, it should not be unpacked successfully.
+	partialBuf = originalBuf[:10]
+	partialMsg = new(godns.Msg)
+	err = UnpackDNSMsgPartially(partialBuf, partialMsg)
+	require.Error(t, err)
+}


### PR DESCRIPTION
A DNS message sent over TCP will be fragmented if its length is greater than MTU, in which case FQDN policy wouldn't work as expected because the used DNS library expects the entire message. However, it's been observed that DNS message was fragmented frequently in tests, which may be applicable to production environments as well. On the other hand, we don't really need the entire message to support FQDN policy, and the first fragment normally already contains the information we need, the question and answer sections.

This patch forks and modifies the message Unpack function to be able to handle fragmented messages.