### PR TITLE
Automated cherry pick of #4676: Update default klog verbosity value for Windows containerd

### DIFF
--- a/build/yamls/antrea-windows-containerd.yml
+++ b/build/yamls/antrea-windows-containerd.yml
@@ -18,7 +18,7 @@ data:
     $ErrorActionPreference = "Stop"
     $mountPath = $env:CONTAINER_SANDBOX_MOUNT_POINT
     $mountPath =  ($mountPath.Replace('\', '/')).TrimEnd('/')
-    & "$mountPath/k/antrea/bin/antrea-agent.exe" --config=$mountPath/etc/antrea/antrea-agent.conf --logtostderr=false --log_dir=c:/var/log/antrea --alsologtostderr --log_file_max_size=100 --log_file_max_num=4 --v=4
+    & "$mountPath/k/antrea/bin/antrea-agent.exe" --config=$mountPath/etc/antrea/antrea-agent.conf --logtostderr=false --log_dir=c:/var/log/antrea --alsologtostderr --log_file_max_size=100 --log_file_max_num=4 --v=0
 kind: ConfigMap
 metadata:
   labels:

--- a/build/yamls/windows/base/conf/Run-AntreaAgent-Containerd.ps1
+++ b/build/yamls/windows/base/conf/Run-AntreaAgent-Containerd.ps1
@@ -1,4 +1,4 @@
 $ErrorActionPreference = "Stop"
 $mountPath = $env:CONTAINER_SANDBOX_MOUNT_POINT
 $mountPath =  ($mountPath.Replace('\', '/')).TrimEnd('/')
-& "$mountPath/k/antrea/bin/antrea-agent.exe" --config=$mountPath/etc/antrea/antrea-agent.conf --logtostderr=false --log_dir=c:/var/log/antrea --alsologtostderr --log_file_max_size=100 --log_file_max_num=4 --v=4
+& "$mountPath/k/antrea/bin/antrea-agent.exe" --config=$mountPath/etc/antrea/antrea-agent.conf --logtostderr=false --log_dir=c:/var/log/antrea --alsologtostderr --log_file_max_size=100 --log_file_max_num=4 --v=0


### PR DESCRIPTION
Cherry pick of #4676 on release-1.10.

#4676: Update default klog verbosity value for Windows containerd

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.