### PR TITLE
Fallback to Endpoints API if EndpointSlice API is unavailable

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -388,13 +388,22 @@ func run(o *Options) error {
 
 		switch {
 		case v4Enabled && v6Enabled:
-			proxier = proxy.NewDualStackProxier(nodeConfig.Name, informerFactory, ofClient, routeClient, nodePortAddressesIPv4, nodePortAddressesIPv6, proxyAll, skipServices, proxyLoadBalancerIPs, v4GroupCounter, v6GroupCounter, enableMulticlusterGW)
+			proxier, err = proxy.NewDualStackProxier(nodeConfig.Name, k8sClient, informerFactory, ofClient, routeClient, nodePortAddressesIPv4, nodePortAddressesIPv6, proxyAll, skipServices, proxyLoadBalancerIPs, v4GroupCounter, v6GroupCounter, enableMulticlusterGW)
+			if err != nil {
+				return fmt.Errorf("error when creating dual-stack proxier: %v", err)
+			}
 			groupCounters = append(groupCounters, v4GroupCounter, v6GroupCounter)
 		case v4Enabled:
-			proxier = proxy.NewProxier(nodeConfig.Name, informerFactory, ofClient, false, routeClient, nodePortAddressesIPv4, proxyAll, skipServices, proxyLoadBalancerIPs, v4GroupCounter, enableMulticlusterGW)
+			proxier, err = proxy.NewProxier(nodeConfig.Name, k8sClient, informerFactory, ofClient, false, routeClient, nodePortAddressesIPv4, proxyAll, skipServices, proxyLoadBalancerIPs, v4GroupCounter, enableMulticlusterGW)
+			if err != nil {
+				return fmt.Errorf("error when creating v4 proxier: %v", err)
+			}
 			groupCounters = append(groupCounters, v4GroupCounter)
 		case v6Enabled:
-			proxier = proxy.NewProxier(nodeConfig.Name, informerFactory, ofClient, true, routeClient, nodePortAddressesIPv6, proxyAll, skipServices, proxyLoadBalancerIPs, v6GroupCounter, enableMulticlusterGW)
+			proxier, err = proxy.NewProxier(nodeConfig.Name, k8sClient, informerFactory, ofClient, true, routeClient, nodePortAddressesIPv6, proxyAll, skipServices, proxyLoadBalancerIPs, v6GroupCounter, enableMulticlusterGW)
+			if err != nil {
+				return fmt.Errorf("error when creating v6 proxier: %v", err)
+			}
 			groupCounters = append(groupCounters, v6GroupCounter)
 		default:
 			return fmt.Errorf("at least one of IPv4 or IPv6 should be enabled")

--- a/docs/feature-gates.md
+++ b/docs/feature-gates.md
@@ -80,13 +80,12 @@ opposed to >= 4.4 without this feature).
 `EndpointSlice` enables Service EndpointSlice support in AntreaProxy. The EndpointSlice API was introduced in Kubernetes
 1.16 (alpha) and it is enabled by default in Kubernetes 1.17 (beta), promoted to GA in Kubernetes 1.21. The EndpointSlice
 feature will take no effect if AntreaProxy is not enabled. Refer to this [link](https://kubernetes.io/docs/tasks/administer-cluster/enabling-endpointslices/)
-for more information about EndpointSlice. Don't enable this feature if Kubernetes version is lower than 1.21 or EndpointSlice
-API is disabled in Kubernetes, otherwise Antrea Agent will log an error message and will not implement ClusterIP Service
-functionality as expected.
+for more information about EndpointSlice. If this feature is enabled but the EndpointSlice v1 API is not available
+(Kubernetes version is lower than 1.21), Antrea Agent will log a message and fallback to the Endpoints API.
 
 #### Requirements for this Feature
 
-- EndpointSlice API is enabled if Kubernetes version is >=1.16 and <1.21, or if it is >=1.21.
+- EndpointSlice v1 API is available (Kubernetes version >=1.21).
 - `AntreaProxy` is enabled.
 
 ### TopologyAwareHints

--- a/pkg/agent/proxy/proxier_test.go
+++ b/pkg/agent/proxy/proxier_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -335,9 +336,10 @@ func NewFakeProxier(routeClient route.Interface, ofClient openflow.Client, nodeP
 	for _, fn := range options {
 		fn(o)
 	}
-
-	p := NewProxier(hostname,
-		informers.NewSharedInformerFactory(fake.NewSimpleClientset(), 0),
+	fakeClient := fake.NewSimpleClientset()
+	p, _ := NewProxier(hostname,
+		fakeClient,
+		informers.NewSharedInformerFactory(fakeClient, 0),
 		ofClient,
 		isIPv6,
 		routeClient,
@@ -2723,6 +2725,47 @@ func TestGetServiceFlowKeys(t *testing.T) {
 			_, groupIDs, found := fp.GetServiceFlowKeys("svc", "ns")
 			assert.ElementsMatch(t, expectedGroupIDs, groupIDs)
 			assert.Equal(t, tc.expectedFound, found)
+		})
+	}
+}
+
+func TestEndpointSliceAPIAvailable(t *testing.T) {
+	testCases := []struct {
+		name              string
+		resources         []*metav1.APIResourceList
+		expectedAvailable bool
+	}{
+		{
+			name:              "empty",
+			expectedAvailable: false,
+		},
+		{
+			name: "GroupVersion exists",
+			resources: []*metav1.APIResourceList{
+				{
+					GroupVersion: discovery.SchemeGroupVersion.String(),
+				},
+			},
+			expectedAvailable: false,
+		},
+		{
+			name: "API exists",
+			resources: []*metav1.APIResourceList{
+				{
+					GroupVersion: discovery.SchemeGroupVersion.String(),
+					APIResources: []metav1.APIResource{{Name: "endpointslice"}},
+				},
+			},
+			expectedAvailable: true,
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			k8sClient := fake.NewSimpleClientset()
+			k8sClient.Resources = tt.resources
+			available, err := endpointSliceAPIAvailable(k8sClient)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedAvailable, available)
 		})
 	}
 }


### PR DESCRIPTION
When EndpointSlice feature is enabled, it required EndpointSlice v1 API to be available, otherwise it didn't work. But EndpointSlice v1 API is only available in Kubernetes >= 1.21. For earlier versions, there is no simple way to fallback to EndpointSlice v1beta1 API because the proxy library code supports one API version only.

To make Antrea compatible with earlier releases, we could check if the EndpointSlice v1 API is available and fallback to Endpoints API if it's not.

-----------
I found the issue because the K8s version of some testbeds in Antrea CI is quite old, leading to test failures.
The original statement that Antrea can work with Kubernetes version >=1.16 as long as the EndpointSlice API is enabled was wrong. The code can only work with EndpointSlice v1 API, which was added in 1.21.
Rather than asking users to disable the feature when using earlier K8s version, I think it's more convenient to fall back to Endpoints API when EndpointSlice v1 API is not available. 