### PR TITLE
Update the error message of memberlist command

### DIFF
--- a/pkg/agent/apiserver/handlers/memberlist/handler.go
+++ b/pkg/agent/apiserver/handlers/memberlist/handler.go
@@ -51,7 +51,8 @@ func HandleFunc(aq querier.AgentQuerier) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		memberlistCluster := aq.GetMemberlistCluster()
 		if reflect.ValueOf(memberlistCluster).IsNil() {
-			http.Error(w, "memberlist is not running", http.StatusServiceUnavailable)
+			// The error message must match the "FOO is not enabled" pattern to pass antctl e2e tests.
+			http.Error(w, "memberlist is not enabled", http.StatusServiceUnavailable)
 			return
 		}
 		var memberlist []Response

--- a/pkg/support/dump_others.go
+++ b/pkg/support/dump_others.go
@@ -77,7 +77,7 @@ func (d *agentDumper) dumpIPToolInfo(basedir string) error {
 
 func (d *agentDumper) DumpMemberlist(basedir string) error {
 	output, err := d.executor.Command("antctl", "-oyaml", "get", "memberlist").CombinedOutput()
-	if err != nil && !strings.Contains(string(output), "memberlist is not running") {
+	if err != nil && !strings.Contains(string(output), "memberlist is not enabled") {
 		return fmt.Errorf("error when dumping memberlist: %w", err)
 	}
 	return writeFile(d.fs, filepath.Join(basedir, "memberlist"), "memberlist", output)


### PR DESCRIPTION
The antctl test expects a command to either succeed or fail with an error message saying the feature is not enabled.