### PR TITLE
Automated cherry pick of #4678: Remove config for Endpoints API when feature gate

### DIFF
--- a/pkg/agent/proxy/proxier.go
+++ b/pkg/agent/proxy/proxier.go
@@ -977,7 +977,6 @@ func NewProxier(
 	}
 
 	p := &proxier{
-		endpointsConfig:           config.NewEndpointsConfig(informerFactory.Core().V1().Endpoints(), resyncPeriod),
 		serviceConfig:             config.NewServiceConfig(informerFactory.Core().V1().Services(), resyncPeriod),
 		endpointsChanges:          newEndpointsChangesTracker(hostname, endpointSliceEnabled, isIPv6),
 		serviceChanges:            newServiceChangesTracker(recorder, ipFamily, skipServices),
@@ -1002,7 +1001,6 @@ func NewProxier(
 	}
 
 	p.serviceConfig.RegisterEventHandler(p)
-	p.endpointsConfig.RegisterEventHandler(p)
 	p.runner = k8sproxy.NewBoundedFrequencyRunner(componentName, p.syncProxyRules, time.Second, 30*time.Second, 2)
 	if endpointSliceEnabled {
 		p.endpointSliceConfig = config.NewEndpointSliceConfig(informerFactory.Discovery().V1().EndpointSlices(), resyncPeriod)


### PR DESCRIPTION
Cherry pick of #4678 on release-1.8.

#4678: Remove config for Endpoints API when feature gate

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.