### PR TITLE
Automated cherry pick of #4592: Fix missing call of removing groupDb cache when deleting OVS

### DIFF
--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -643,7 +643,10 @@ func (c *client) UninstallServiceGroup(groupID binding.GroupIDType) error {
 	gCache, ok := c.featureService.groupCache.Load(groupID)
 	if ok {
 		if err := c.ofEntryOperations.DeleteOFEntries([]binding.OFEntry{gCache.(binding.Group)}); err != nil {
-			return fmt.Errorf("error when deleting Service Endpoints Group %d: %w", groupID, err)
+			return fmt.Errorf("error when deleting Openflow entries for Service Endpoints Group %d: %w", groupID, err)
+		}
+		if err := c.bridge.DeleteGroup(groupID); err != nil {
+			return fmt.Errorf("error when deleting OFSwitch groupDb Cache for Service Endpoints Group %d: %w", groupID, err)
 		}
 		c.featureService.groupCache.Delete(groupID)
 	}
@@ -1345,7 +1348,10 @@ func (c *client) UninstallMulticastGroup(groupID binding.GroupIDType) error {
 	gCache, ok := c.featureMulticast.groupCache.Load(groupID)
 	if ok {
 		if err := c.ofEntryOperations.DeleteOFEntries([]binding.OFEntry{gCache.(binding.Group)}); err != nil {
-			return fmt.Errorf("error when deleting Multicast receiver Group %d: %w", groupID, err)
+			return fmt.Errorf("error when deleting Openflow entries for Multicast receiver Group %d: %w", groupID, err)
+		}
+		if err := c.bridge.DeleteGroup(groupID); err != nil {
+			return fmt.Errorf("error when deleting OFSwitch groupDb Cache for Multicast receiver Group %d: %w", groupID, err)
 		}
 		c.featureMulticast.groupCache.Delete(groupID)
 	}

--- a/pkg/agent/openflow/client_test.go
+++ b/pkg/agent/openflow/client_test.go
@@ -846,10 +846,11 @@ func Test_client_InstallServiceGroup(t *testing.T) {
 	groupID := binding.GroupIDType(100)
 
 	testCases := []struct {
-		name                string
-		withSessionAffinity bool
-		endpoints           []proxy.Endpoint
-		expectedGroup       string
+		name                 string
+		withSessionAffinity  bool
+		endpoints            []proxy.Endpoint
+		expectedGroup        string
+		deleteOFEntriesError error
 	}{
 		{
 			name: "IPv4 Endpoints",
@@ -893,6 +894,17 @@ func Test_client_InstallServiceGroup(t *testing.T) {
 				"bucket=bucket_id:0,weight:100,actions=set_field:0xfec00010001000000000000000000100->xxreg3,set_field:0x50/0xffff->reg4,resubmit:ServiceLB," +
 				"bucket=bucket_id:1,weight:100,actions=set_field:0xfec00010001000000000000000000101->xxreg3,set_field:0x50/0xffff->reg4,resubmit:ServiceLB",
 		},
+		{
+			name: "delete group failed for IPv4 Endpoints",
+			endpoints: []proxy.Endpoint{
+				proxy.NewBaseEndpointInfo("10.10.0.100", "", "", 80, false, true, false, false, nil),
+				proxy.NewBaseEndpointInfo("10.10.0.101", "", "", 80, false, true, false, false, nil),
+			},
+			expectedGroup: "group_id=100,type=select," +
+				"bucket=bucket_id:0,weight:100,actions=set_field:0xa0a0064->reg3,set_field:0x50/0xffff->reg4,resubmit:EndpointDNAT," +
+				"bucket=bucket_id:1,weight:100,actions=set_field:0xa0a0065->reg3,set_field:0x50/0xffff->reg4,resubmit:EndpointDNAT",
+			deleteOFEntriesError: fmt.Errorf("error when deleting Openflow entries for Service Endpoints Group 100"),
+		},
 	}
 
 	for _, tc := range testCases {
@@ -905,7 +917,7 @@ func Test_client_InstallServiceGroup(t *testing.T) {
 			defer resetPipelines()
 
 			m.EXPECT().AddOFEntries(gomock.Any()).Return(nil).Times(1)
-			m.EXPECT().DeleteOFEntries(gomock.Any()).Return(nil).Times(1)
+			m.EXPECT().DeleteOFEntries(gomock.Any()).Return(tc.deleteOFEntriesError).Times(1)
 
 			assert.NoError(t, fc.InstallServiceGroup(groupID, tc.withSessionAffinity, tc.endpoints))
 			gCacheI, ok := fc.featureService.groupCache.Load(groupID)
@@ -913,9 +925,15 @@ func Test_client_InstallServiceGroup(t *testing.T) {
 			group := getGroupFromCache(gCacheI.(binding.Group))
 			assert.Equal(t, tc.expectedGroup, group)
 
-			assert.NoError(t, fc.UninstallServiceGroup(groupID))
-			_, ok = fc.featureService.groupCache.Load(groupID)
-			require.False(t, ok)
+			if tc.deleteOFEntriesError == nil {
+				assert.NoError(t, fc.UninstallServiceGroup(groupID))
+				_, ok = fc.featureService.groupCache.Load(groupID)
+				require.False(t, ok)
+			} else {
+				assert.Error(t, fc.UninstallServiceGroup(groupID))
+				_, ok = fc.featureService.groupCache.Load(groupID)
+				require.True(t, ok)
+			}
 		})
 	}
 }
@@ -1977,10 +1995,11 @@ func Test_client_InstallMulticastGroup(t *testing.T) {
 	localReceivers := []uint32{50, 100}
 	remoteNodeReceivers := []net.IP{net.ParseIP("192.168.77.101"), net.ParseIP("192.168.77.102")}
 	testCases := []struct {
-		name                string
-		localReceivers      []uint32
-		remoteNodeReceivers []net.IP
-		expectedGroup       string
+		name                 string
+		localReceivers       []uint32
+		remoteNodeReceivers  []net.IP
+		expectedGroup        string
+		deleteOFEntriesError error
 	}{
 		{
 			name:           "Local Receivers",
@@ -2006,6 +2025,14 @@ func Test_client_InstallMulticastGroup(t *testing.T) {
 				"bucket=bucket_id:2,actions=set_field:0x100/0x100->reg0,set_field:0x1->reg1,set_field:192.168.77.101->tun_dst,resubmit:MulticastOutput," +
 				"bucket=bucket_id:3,actions=set_field:0x100/0x100->reg0,set_field:0x1->reg1,set_field:192.168.77.102->tun_dst,resubmit:MulticastOutput",
 		},
+		{
+			name:           "DeleteOFEntries Failed",
+			localReceivers: localReceivers,
+			expectedGroup: "group_id=101,type=all," +
+				"bucket=bucket_id:0,actions=set_field:0x100/0x100->reg0,set_field:0x32->reg1,resubmit:MulticastIngressRule," +
+				"bucket=bucket_id:1,actions=set_field:0x100/0x100->reg0,set_field:0x64->reg1,resubmit:MulticastIngressRule",
+			deleteOFEntriesError: fmt.Errorf("error when deleting Openflow entries for Multicast receiver Group 101"),
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -2017,7 +2044,7 @@ func Test_client_InstallMulticastGroup(t *testing.T) {
 			defer resetPipelines()
 
 			m.EXPECT().AddOFEntries(gomock.Any()).Return(nil).Times(1)
-			m.EXPECT().DeleteOFEntries(gomock.Any()).Return(nil).Times(1)
+			m.EXPECT().DeleteOFEntries(gomock.Any()).Return(tc.deleteOFEntriesError).Times(1)
 
 			assert.NoError(t, fc.InstallMulticastGroup(groupID, tc.localReceivers, tc.remoteNodeReceivers))
 			gCacheI, ok := fc.featureMulticast.groupCache.Load(groupID)
@@ -2025,9 +2052,15 @@ func Test_client_InstallMulticastGroup(t *testing.T) {
 			group := getGroupFromCache(gCacheI.(binding.Group))
 			assert.Equal(t, tc.expectedGroup, group)
 
-			assert.NoError(t, fc.UninstallMulticastGroup(groupID))
-			_, ok = fc.featureMulticast.groupCache.Load(groupID)
-			require.False(t, ok)
+			if tc.deleteOFEntriesError == nil {
+				assert.NoError(t, fc.UninstallMulticastGroup(groupID))
+				_, ok = fc.featureMulticast.groupCache.Load(groupID)
+				require.False(t, ok)
+			} else {
+				assert.Error(t, fc.UninstallMulticastGroup(groupID))
+				_, ok = fc.featureMulticast.groupCache.Load(groupID)
+				require.True(t, ok)
+			}
 		})
 	}
 }

--- a/pkg/ovs/openflow/ofctrl_bridge.go
+++ b/pkg/ovs/openflow/ofctrl_bridge.go
@@ -224,14 +224,11 @@ func (b *OFBridge) createGroupWithType(id GroupIDType, groupType ofctrl.GroupTyp
 	return g
 }
 
+// DeleteGroup deletes a specified group in groupDb.
 func (b *OFBridge) DeleteGroup(id GroupIDType) error {
 	ofctrlGroup := b.ofSwitch.GetGroup(uint32(id))
 	if ofctrlGroup == nil {
 		return nil
-	}
-	g := &ofGroup{bridge: b, ofctrl: ofctrlGroup}
-	if err := g.Delete(); err != nil {
-		return fmt.Errorf("failed to delete the group: %w", err)
 	}
 	return b.ofSwitch.DeleteGroup(uint32(id))
 }

--- a/pkg/ovs/openflow/ofctrl_bridge_test.go
+++ b/pkg/ovs/openflow/ofctrl_bridge_test.go
@@ -22,6 +22,7 @@ import (
 
 	"antrea.io/libOpenflow/util"
 	"antrea.io/ofnet/ofctrl"
+	"github.com/stretchr/testify/assert"
 
 	"antrea.io/antrea/pkg/ovs/ovsconfig"
 )
@@ -84,4 +85,35 @@ func TestOFBridgeIsConnected(t *testing.T) {
 		b.IsConnected()
 	}()
 	wg.Wait()
+}
+
+func TestDeleteGroup(t *testing.T) {
+	b := NewOFBridge("test-br", GetMgmtAddress(ovsconfig.DefaultOVSRunDir, "test-br"))
+
+	for _, m := range []struct {
+		name            string
+		existingGroupID GroupIDType
+		deleteGroupID   GroupIDType
+		err             error
+	}{
+		{
+			name:            "delete existing group without flow",
+			existingGroupID: 20,
+			deleteGroupID:   20,
+			err:             nil,
+		},
+		{
+			name:            "delete non-existing group",
+			existingGroupID: 20,
+			deleteGroupID:   30,
+			err:             nil,
+		},
+	} {
+		t.Run(m.name, func(t *testing.T) {
+			b.ofSwitch = newFakeOFSwitch(b)
+			b.CreateGroup(m.existingGroupID)
+			err := b.DeleteGroup(m.deleteGroupID)
+			assert.Equal(t, m.err, err)
+		})
+	}
 }


### PR DESCRIPTION
Cherry pick of #4592 on release-1.10.

#4592: Fix missing call of removing groupDb cache when deleting OVS

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.