### PR TITLE
Automated cherry pick of #4419: Set NO_FLOOD to IPsec tunnel ports
#4470: Fix that Service routes may get lost when starting on Windows
#4654: Restore NO_FLOOD to OVS ports after reconnecting the OVS
#4711: Fix route deletion for Service ClusterIP and LoadBalancerIP

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -254,6 +254,7 @@ func run(o *Options) error {
 		k8sClient,
 		informerFactory,
 		ofClient,
+		ovsctl.NewClient(o.config.OVSBridge),
 		ovsBridgeClient,
 		routeClient,
 		ifaceStore,

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -264,7 +264,6 @@ func (i *Initializer) initInterfaceStore() error {
 		return intf
 	}
 	ifaceList := make([]*interfacestore.InterfaceConfig, 0, len(ovsPorts))
-	ovsCtlClient := ovsctl.NewClient(i.ovsBridge)
 	for index := range ovsPorts {
 		port := &ovsPorts[index]
 		ovsPort := &interfacestore.OVSPortConfig{
@@ -282,6 +281,8 @@ func (i *Initializer) initInterfaceStore() error {
 			case interfacestore.AntreaUplink:
 				intf = parseUplinkInterfaceFunc(port, ovsPort)
 			case interfacestore.AntreaTunnel:
+				fallthrough
+			case interfacestore.AntreaIPsecTunnel:
 				intf = parseTunnelInterfaceFunc(port, ovsPort)
 			case interfacestore.AntreaHost:
 				// Not load the host interface, because it is configured on the OVS bridge port, and we don't need a
@@ -292,9 +293,6 @@ func (i *Initializer) initInterfaceStore() error {
 				intf = cniserver.ParseOVSPortInterfaceConfig(port, ovsPort, true)
 			case interfacestore.AntreaTrafficControl:
 				intf = trafficcontrol.ParseTrafficControlInterfaceConfig(port, ovsPort)
-				if err := ovsCtlClient.SetPortNoFlood(int(ovsPort.OFPort)); err != nil {
-					klog.ErrorS(err, "Failed to set port with no-flood config", "PortName", port.Name)
-				}
 			default:
 				klog.InfoS("Unknown Antrea interface type", "type", interfaceType)
 			}
@@ -318,7 +316,11 @@ func (i *Initializer) initInterfaceStore() error {
 				fallthrough
 			case port.IFType == ovsconfig.STTTunnel:
 				intf = parseTunnelInterfaceFunc(port, ovsPort)
-				antreaIFType = interfacestore.AntreaTunnel
+				if intf.Type == interfacestore.IPSecTunnelInterface {
+					antreaIFType = interfacestore.AntreaIPsecTunnel
+				} else {
+					antreaIFType = interfacestore.AntreaTunnel
+				}
 			case port.Name == i.ovsBridge:
 				intf = nil
 				antreaIFType = interfacestore.AntreaHost
@@ -345,6 +347,23 @@ func (i *Initializer) initInterfaceStore() error {
 	return nil
 }
 
+func (i *Initializer) restorePortConfigs() error {
+	ovsCtlClient := ovsctl.NewClient(i.ovsBridge)
+	interfaces := i.ifaceStore.ListInterfaces()
+	for _, intf := range interfaces {
+		switch intf.Type {
+		case interfacestore.IPSecTunnelInterface:
+			fallthrough
+		case interfacestore.TrafficControlInterface:
+			if err := ovsCtlClient.SetPortNoFlood(int(intf.OFPort)); err != nil {
+				return fmt.Errorf("failed to set port %s with no-flood: %w", intf.InterfaceName, err)
+			}
+			klog.InfoS("Set port no-flood successfully", "PortName", intf.InterfaceName)
+		}
+	}
+	return nil
+}
+
 // Initialize sets up agent initial configurations.
 func (i *Initializer) Initialize() error {
 	klog.Info("Setting up node network")
@@ -363,6 +382,10 @@ func (i *Initializer) Initialize() error {
 	}
 
 	if err := i.setupOVSBridge(); err != nil {
+		return err
+	}
+
+	if err := i.restorePortConfigs(); err != nil {
 		return err
 	}
 
@@ -460,14 +483,15 @@ func persistRoundNum(num uint64, bridgeClient ovsconfig.OVSBridgeClient, interva
 
 // initOpenFlowPipeline sets up necessary Openflow entries, including pipeline, classifiers, conn_track, and gateway flows
 // Every time the agent is (re)started, we go through the following sequence:
-//   1. agent determines the new round number (this is done by incrementing the round number
-//   persisted in OVSDB, or if it's not available by picking round 1).
-//   2. any existing flow for which the round number matches the round number obtained from step 1
-//   is deleted.
-//   3. all required flows are installed, using the round number obtained from step 1.
-//   4. after convergence, all existing flows for which the round number matches the previous round
-//   number (i.e. the round number which was persisted in OVSDB, if any) are deleted.
-//   5. the new round number obtained from step 1 is persisted to OVSDB.
+//  1. agent determines the new round number (this is done by incrementing the round number
+//     persisted in OVSDB, or if it's not available by picking round 1).
+//  2. any existing flow for which the round number matches the round number obtained from step 1
+//     is deleted.
+//  3. all required flows are installed, using the round number obtained from step 1.
+//  4. after convergence, all existing flows for which the round number matches the previous round
+//     number (i.e. the round number which was persisted in OVSDB, if any) are deleted.
+//  5. the new round number obtained from step 1 is persisted to OVSDB.
+//
 // The rationale for not persisting the new round number until after all previous flows have been
 // deleted is to avoid a situation in which some stale flows are never deleted because of successive
 // agent restarts (with the agent crashing before step 4 can be completed). With the sequence
@@ -519,6 +543,13 @@ func (i *Initializer) initOpenFlowPipeline() error {
 			i.ofClient.ReplayFlows()
 			klog.Info("Flow replay completed")
 
+			klog.InfoS("Restoring OF port configs to OVS bridge")
+			if err := i.restorePortConfigs(); err != nil {
+				klog.ErrorS(err, "Failed to restore OF port configs")
+			} else {
+				klog.InfoS("Port configs restoration completed")
+			}
+
 			if i.ovsBridgeClient.GetOVSDatapathType() == ovsconfig.OVSDatapathNetdev {
 				// we don't set flow-restore-wait when using the OVS netdev datapath
 				return
@@ -528,7 +559,7 @@ func (i *Initializer) initOpenFlowPipeline() error {
 			// happen that ovsBridgeClient's connection is not ready when ofClient completes flow replay. We retry it
 			// with a timeout that is longer time than ovsBridgeClient's maximum connecting retry interval (8 seconds)
 			// to ensure the flag can be removed successfully.
-			err := wait.PollImmediate(200*time.Millisecond, 10*time.Second, func() (done bool, err error) {
+			err = wait.PollImmediate(200*time.Millisecond, 10*time.Second, func() (done bool, err error) {
 				if err := i.FlowRestoreComplete(); err != nil {
 					return false, nil
 				}

--- a/pkg/agent/controller/noderoute/node_route_controller.go
+++ b/pkg/agent/controller/noderoute/node_route_controller.go
@@ -43,7 +43,6 @@ import (
 	"antrea.io/antrea/pkg/ovs/ovsctl"
 	utilip "antrea.io/antrea/pkg/util/ip"
 	"antrea.io/antrea/pkg/util/k8s"
-	"antrea.io/antrea/pkg/util/runtime"
 )
 
 const (
@@ -74,7 +73,6 @@ type Controller struct {
 	nodeInformer     coreinformers.NodeInformer
 	nodeLister       corelisters.NodeLister
 	nodeListerSynced cache.InformerSynced
-	svcLister        corelisters.ServiceLister
 	queue            workqueue.RateLimitingInterface
 	// installedNodes records routes and flows installation states of Nodes.
 	// The key is the host name of the Node, the value is the nodeRouteInfo of the Node.
@@ -105,7 +103,6 @@ func NewNodeRouteController(
 	ipsecCertificateManager ipseccertificate.Manager,
 ) *Controller {
 	nodeInformer := informerFactory.Core().V1().Nodes()
-	svcLister := informerFactory.Core().V1().Services()
 	controller := &Controller{
 		kubeClient:              kubeClient,
 		ovsBridgeClient:         ovsBridgeClient,
@@ -118,7 +115,6 @@ func NewNodeRouteController(
 		nodeInformer:            nodeInformer,
 		nodeLister:              nodeInformer.Lister(),
 		nodeListerSynced:        nodeInformer.Informer().HasSynced,
-		svcLister:               svcLister.Lister(),
 		queue:                   workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(minRetryDelay, maxRetryDelay), "noderoute"),
 		installedNodes:          cache.NewIndexer(nodeRouteInfoKeyFunc, cache.Indexers{nodeRouteInfoPodCIDRIndexName: nodeRouteInfoPodCIDRIndexFunc}),
 		wireGuardClient:         wireguardClient,
@@ -207,27 +203,10 @@ func (c *Controller) removeStaleGatewayRoutes() error {
 		desiredPodCIDRs = append(desiredPodCIDRs, podCIDRs...)
 	}
 
-	// TODO: This is not the best place to keep the ClusterIP Service routes.
-	desiredClusterIPSvcIPs := map[string]bool{}
-	if c.proxyAll && runtime.IsWindowsPlatform() {
-		// The route for virtual IP -> antrea-gw0 should be always kept.
-		desiredClusterIPSvcIPs[config.VirtualServiceIPv4.String()] = true
-
-		svcs, err := c.svcLister.List(labels.Everything())
-		for _, svc := range svcs {
-			for _, ip := range svc.Spec.ClusterIPs {
-				desiredClusterIPSvcIPs[ip] = true
-			}
-		}
-		if err != nil {
-			return fmt.Errorf("error when listing ClusterIP Service IPs: %v", err)
-		}
-	}
-
 	// routeClient will remove orphaned routes whose destinations are not in desiredPodCIDRs.
 	// If proxyAll enabled, it will also remove routes that are for Windows ClusterIP Services
 	// which no longer exist.
-	if err := c.routeClient.Reconcile(desiredPodCIDRs, desiredClusterIPSvcIPs); err != nil {
+	if err := c.routeClient.Reconcile(desiredPodCIDRs); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/agent/controller/noderoute/node_route_controller.go
+++ b/pkg/agent/controller/noderoute/node_route_controller.go
@@ -40,6 +40,7 @@ import (
 	"antrea.io/antrea/pkg/agent/util"
 	"antrea.io/antrea/pkg/agent/wireguard"
 	"antrea.io/antrea/pkg/ovs/ovsconfig"
+	"antrea.io/antrea/pkg/ovs/ovsctl"
 	utilip "antrea.io/antrea/pkg/util/ip"
 	"antrea.io/antrea/pkg/util/k8s"
 	"antrea.io/antrea/pkg/util/runtime"
@@ -65,6 +66,7 @@ type Controller struct {
 	kubeClient       clientset.Interface
 	ovsBridgeClient  ovsconfig.OVSBridgeClient
 	ofClient         openflow.Client
+	ovsCtlClient     ovsctl.OVSCtlClient
 	routeClient      route.Interface
 	interfaceStore   interfacestore.InterfaceStore
 	networkConfig    *config.NetworkConfig
@@ -92,6 +94,7 @@ func NewNodeRouteController(
 	kubeClient clientset.Interface,
 	informerFactory informers.SharedInformerFactory,
 	client openflow.Client,
+	ovsCtlClient ovsctl.OVSCtlClient,
 	ovsBridgeClient ovsconfig.OVSBridgeClient,
 	routeClient route.Interface,
 	interfaceStore interfacestore.InterfaceStore,
@@ -107,6 +110,7 @@ func NewNodeRouteController(
 		kubeClient:              kubeClient,
 		ovsBridgeClient:         ovsBridgeClient,
 		ofClient:                client,
+		ovsCtlClient:            ovsCtlClient,
 		routeClient:             routeClient,
 		interfaceStore:          interfaceStore,
 		networkConfig:           networkConfig,
@@ -668,11 +672,6 @@ func (c *Controller) createIPSecTunnelPort(nodeName string, nodeIP net.IP) (int3
 			}
 			c.interfaceStore.DeleteInterface(interfaceConfig)
 			exists = false
-		} else {
-			if interfaceConfig.OFPort != 0 {
-				klog.V(2).InfoS("Found cached IPsec tunnel interface", "node", nodeName, "interface", interfaceConfig.InterfaceName, "port", interfaceConfig.OFPort)
-				return interfaceConfig.OFPort, nil
-			}
 		}
 	}
 	if !exists {
@@ -712,6 +711,11 @@ func (c *Controller) createIPSecTunnelPort(nodeName string, nodeIP net.IP) (int3
 		// Let NodeRouteController retry at errors.
 		return 0, fmt.Errorf("failed to get of_port of IPsec tunnel port for Node %s", nodeName)
 	}
+	// Set the port with no-flood to reject ARP flood packets.
+	if err := c.ovsCtlClient.SetPortNoFlood(int(ofPort)); err != nil {
+		return 0, fmt.Errorf("failed to set port %s with no-flood config: %w", portName, err)
+	}
+
 	interfaceConfig.OFPort = ofPort
 	return ofPort, nil
 }

--- a/pkg/agent/controller/noderoute/node_route_controller.go
+++ b/pkg/agent/controller/noderoute/node_route_controller.go
@@ -227,7 +227,7 @@ func (c *Controller) removeStaleTunnelPorts() error {
 	// will not include it in the set.
 	desiredInterfaces := make(map[string]bool)
 	// knownInterfaces is the list of interfaces currently in the local cache.
-	knownInterfaces := c.interfaceStore.GetInterfaceKeysByType(interfacestore.TunnelInterface)
+	knownInterfaces := c.interfaceStore.GetInterfaceKeysByType(interfacestore.IPSecTunnelInterface)
 
 	if c.networkConfig.TrafficEncryptionMode == config.TrafficEncryptionModeIPSec {
 		for _, node := range nodes {
@@ -653,8 +653,12 @@ func (c *Controller) createIPSecTunnelPort(nodeName string, nodeIP net.IP) (int3
 			exists = false
 		}
 	}
+
 	if !exists {
-		ovsExternalIDs := map[string]interface{}{ovsExternalIDNodeName: nodeName}
+		ovsExternalIDs := map[string]interface{}{
+			ovsExternalIDNodeName:                 nodeName,
+			interfacestore.AntreaInterfaceTypeKey: interfacestore.AntreaIPsecTunnel,
+		}
 		portUUID, err := c.ovsBridgeClient.CreateTunnelPortExt(
 			portName,
 			c.networkConfig.TunnelType,
@@ -690,6 +694,7 @@ func (c *Controller) createIPSecTunnelPort(nodeName string, nodeIP net.IP) (int3
 		// Let NodeRouteController retry at errors.
 		return 0, fmt.Errorf("failed to get of_port of IPsec tunnel port for Node %s", nodeName)
 	}
+
 	// Set the port with no-flood to reject ARP flood packets.
 	if err := c.ovsCtlClient.SetPortNoFlood(int(ofPort)); err != nil {
 		return 0, fmt.Errorf("failed to set port %s with no-flood config: %w", portName, err)

--- a/pkg/agent/controller/noderoute/node_route_controller_test.go
+++ b/pkg/agent/controller/noderoute/node_route_controller_test.go
@@ -259,7 +259,7 @@ func setup(t *testing.T, ifaces []*interfacestore.InterfaceConfig, authenticatio
 func TestRemoveStaleTunnelPorts(t *testing.T) {
 	c, closeFn := setup(t, []*interfacestore.InterfaceConfig{
 		{
-			Type:          interfacestore.TunnelInterface,
+			Type:          interfacestore.IPSecTunnelInterface,
 			InterfaceName: util.GenerateNodeTunnelInterfaceName("xyz-k8s-0-1"),
 			TunnelInterfaceConfig: &interfacestore.TunnelInterfaceConfig{
 				NodeName: "xyz-k8s-0-1",
@@ -307,7 +307,7 @@ func TestRemoveStaleTunnelPorts(t *testing.T) {
 func TestCreateIPSecTunnelPortPSK(t *testing.T) {
 	c, closeFn := setup(t, []*interfacestore.InterfaceConfig{
 		{
-			Type:          interfacestore.TunnelInterface,
+			Type:          interfacestore.IPSecTunnelInterface,
 			InterfaceName: "mismatchedname",
 			TunnelInterfaceConfig: &interfacestore.TunnelInterfaceConfig{
 				NodeName: "xyz-k8s-0-2",
@@ -320,7 +320,7 @@ func TestCreateIPSecTunnelPortPSK(t *testing.T) {
 			},
 		},
 		{
-			Type:          interfacestore.TunnelInterface,
+			Type:          interfacestore.IPSecTunnelInterface,
 			InterfaceName: util.GenerateNodeTunnelInterfaceName("xyz-k8s-0-3"),
 			TunnelInterfaceConfig: &interfacestore.TunnelInterfaceConfig{
 				NodeName: "xyz-k8s-0-3",
@@ -348,11 +348,15 @@ func TestCreateIPSecTunnelPortPSK(t *testing.T) {
 	c.ovsClient.EXPECT().CreateTunnelPortExt(
 		node1PortName, ovsconfig.TunnelType("vxlan"), int32(0),
 		false, "", nodeIP1.String(), "", "changeme", nil,
-		map[string]interface{}{ovsExternalIDNodeName: "xyz-k8s-0-1"}).Times(1)
+		map[string]interface{}{ovsExternalIDNodeName: "xyz-k8s-0-1",
+			interfacestore.AntreaInterfaceTypeKey: interfacestore.AntreaIPsecTunnel,
+		}).Times(1)
 	c.ovsClient.EXPECT().CreateTunnelPortExt(
 		node2PortName, ovsconfig.TunnelType("vxlan"), int32(0),
 		false, "", nodeIP2.String(), "", "changeme", nil,
-		map[string]interface{}{ovsExternalIDNodeName: "xyz-k8s-0-2"}).Times(1)
+		map[string]interface{}{ovsExternalIDNodeName: "xyz-k8s-0-2",
+			interfacestore.AntreaInterfaceTypeKey: interfacestore.AntreaIPsecTunnel,
+		}).Times(1)
 	c.ovsClient.EXPECT().GetOFPort(node1PortName, false).Return(int32(1), nil)
 	c.ovsCtlClient.EXPECT().SetPortNoFlood(1)
 	c.ovsClient.EXPECT().GetOFPort(node2PortName, false).Return(int32(2), nil)
@@ -415,7 +419,9 @@ func TestCreateIPSecTunnelPortCert(t *testing.T) {
 	c.ovsClient.EXPECT().CreateTunnelPortExt(
 		node1PortName, ovsconfig.TunnelType("vxlan"), int32(0),
 		false, "", nodeIP1.String(), "xyz-k8s-0-1", "", nil,
-		map[string]interface{}{ovsExternalIDNodeName: "xyz-k8s-0-1"}).Times(1)
+		map[string]interface{}{ovsExternalIDNodeName: "xyz-k8s-0-1",
+			interfacestore.AntreaInterfaceTypeKey: interfacestore.AntreaIPsecTunnel,
+		}).Times(1)
 	c.ovsClient.EXPECT().GetOFPort(node1PortName, false).Return(int32(1), nil)
 	c.ovsCtlClient.EXPECT().SetPortNoFlood(1)
 

--- a/pkg/agent/interfacestore/interface_cache.go
+++ b/pkg/agent/interfacestore/interface_cache.go
@@ -83,8 +83,8 @@ func getInterfaceKey(obj interface{}) (string, error) {
 	var key string
 	if interfaceConfig.Type == ContainerInterface {
 		key = util.GenerateContainerInterfaceKey(interfaceConfig.ContainerID)
-	} else if interfaceConfig.Type == TunnelInterface && interfaceConfig.NodeName != "" {
-		// Tunnel interface for a Node.
+	} else if interfaceConfig.Type == IPSecTunnelInterface {
+		// IPsec tunnel interface for a Node.
 		key = util.GenerateNodeTunnelInterfaceKey(interfaceConfig.NodeName)
 	} else {
 		// Use the interface name as the key by default.
@@ -118,6 +118,15 @@ func (c *interfaceCache) GetInterface(interfaceKey string) (*InterfaceConfig, bo
 		return nil, false
 	}
 	return iface.(*InterfaceConfig), found
+}
+
+// ListInterfacesByType lists all interfaces from local cache.
+func (c *interfaceCache) ListInterfaces() []*InterfaceConfig {
+	interfaceConfigs := make([]*InterfaceConfig, 0)
+	for _, iface := range c.cache.List() {
+		interfaceConfigs = append(interfaceConfigs, iface.(*InterfaceConfig))
+	}
+	return interfaceConfigs
 }
 
 // GetInterfaceByName retrieves interface from local cache given the interface

--- a/pkg/agent/interfacestore/testing/mock_interfacestore.go
+++ b/pkg/agent/interfacestore/testing/mock_interfacestore.go
@@ -257,3 +257,17 @@ func (mr *MockInterfaceStoreMockRecorder) Len() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Len", reflect.TypeOf((*MockInterfaceStore)(nil).Len))
 }
+
+// ListInterfaces mocks base method
+func (m *MockInterfaceStore) ListInterfaces() []*interfacestore.InterfaceConfig {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListInterfaces")
+	ret0, _ := ret[0].([]*interfacestore.InterfaceConfig)
+	return ret0
+}
+
+// ListInterfaces indicates an expected call of ListInterfaces
+func (mr *MockInterfaceStoreMockRecorder) ListInterfaces() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListInterfaces", reflect.TypeOf((*MockInterfaceStore)(nil).ListInterfaces))
+}

--- a/pkg/agent/interfacestore/types.go
+++ b/pkg/agent/interfacestore/types.go
@@ -35,6 +35,8 @@ const (
 	HostInterface
 	// TrafficControlInterface is used to mark current interface is for traffic control port
 	TrafficControlInterface
+	// IPSecTunnelInterface is used to mark current interface is for IPSec tunnel port
+	IPSecTunnelInterface
 
 	AntreaInterfaceTypeKey = "antrea-type"
 	AntreaGateway          = "gateway"
@@ -43,6 +45,7 @@ const (
 	AntreaUplink           = "uplink"
 	AntreaHost             = "host"
 	AntreaTrafficControl   = "traffic-control"
+	AntreaIPsecTunnel      = "ipsec-tunnel"
 	AntreaUnset            = ""
 )
 
@@ -100,6 +103,7 @@ type InterfaceConfig struct {
 type InterfaceStore interface {
 	Initialize(interfaces []*InterfaceConfig)
 	AddInterface(interfaceConfig *InterfaceConfig)
+	ListInterfaces() []*InterfaceConfig
 	DeleteInterface(interfaceConfig *InterfaceConfig)
 	GetInterface(interfaceKey string) (*InterfaceConfig, bool)
 	GetInterfaceByName(interfaceName string) (*InterfaceConfig, bool)
@@ -154,7 +158,7 @@ func NewTunnelInterface(tunnelName string, tunnelType ovsconfig.TunnelType, loca
 // Node.
 func NewIPSecTunnelInterface(interfaceName string, tunnelType ovsconfig.TunnelType, nodeName string, nodeIP net.IP, psk, remoteName string) *InterfaceConfig {
 	tunnelConfig := &TunnelInterfaceConfig{Type: tunnelType, NodeName: nodeName, RemoteIP: nodeIP, PSK: psk, RemoteName: remoteName}
-	return &InterfaceConfig{InterfaceName: interfaceName, Type: TunnelInterface, TunnelInterfaceConfig: tunnelConfig}
+	return &InterfaceConfig{InterfaceName: interfaceName, Type: IPSecTunnelInterface, TunnelInterfaceConfig: tunnelConfig}
 }
 
 // NewUplinkInterface creates InterfaceConfig for the uplink interface.

--- a/pkg/agent/proxy/proxier_test.go
+++ b/pkg/agent/proxy/proxier_test.go
@@ -24,13 +24,17 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	apimachinerytypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/component-base/metrics/testutil"
+	"k8s.io/utils/pointer"
 
+	agentconfig "antrea.io/antrea/pkg/agent/config"
 	"antrea.io/antrea/pkg/agent/openflow"
 	ofmock "antrea.io/antrea/pkg/agent/openflow/testing"
 	"antrea.io/antrea/pkg/agent/proxy/metrics"
@@ -104,12 +108,30 @@ func makeTestEndpoints(namespace, name string, eptFunc func(*corev1.Endpoints)) 
 type proxyOptions struct {
 	proxyAllEnabled      bool
 	proxyLoadBalancerIPs bool
+	endpointSliceEnabled bool
 }
 
 type proxyOptionsFn func(*proxyOptions)
 
 func withProxyAll(o *proxyOptions) {
 	o.proxyAllEnabled = true
+}
+
+func withEndpointSlice(o *proxyOptions) {
+	o.endpointSliceEnabled = true
+}
+
+func makeEndpointSliceMap(proxier *proxier, allEndpoints ...*discovery.EndpointSlice) {
+	for i := range allEndpoints {
+		proxier.endpointsChanges.OnEndpointSliceUpdate(allEndpoints[i], false)
+	}
+	proxier.endpointsChanges.OnEndpointsSynced()
+}
+
+func getMockClients(ctrl *gomock.Controller) (*ofmock.MockClient, *routemock.MockInterface) {
+	mockOFClient := ofmock.NewMockClient(ctrl)
+	mockRouteClient := routemock.NewMockInterface(ctrl)
+	return mockOFClient, mockRouteClient
 }
 
 func withoutProxyLoadBalancerIPs(o *proxyOptions) {
@@ -132,6 +154,7 @@ func NewFakeProxier(routeClient route.Interface, ofClient openflow.Client, nodeP
 	o := &proxyOptions{
 		proxyAllEnabled:      false,
 		proxyLoadBalancerIPs: true,
+		endpointSliceEnabled: false,
 	}
 
 	for _, fn := range options {
@@ -145,6 +168,7 @@ func NewFakeProxier(routeClient route.Interface, ofClient openflow.Client, nodeP
 		serviceInstalledMap:      k8sproxy.ServiceMap{},
 		endpointsInstalledMap:    types.EndpointsMap{},
 		endpointReferenceCounter: map[string]int{},
+		serviceIPRouteReferences: map[string]sets.String{},
 		endpointsMap:             types.EndpointsMap{},
 		groupCounter:             types.NewGroupCounter(groupIDAllocator, make(chan string, 100)),
 		ofClient:                 ofClient,
@@ -154,8 +178,12 @@ func NewFakeProxier(routeClient route.Interface, ofClient openflow.Client, nodeP
 		nodePortAddresses:        nodePortAddresses,
 		proxyAll:                 o.proxyAllEnabled,
 		proxyLoadBalancerIPs:     o.proxyLoadBalancerIPs,
+		endpointSliceEnabled:     o.endpointSliceEnabled,
 	}
 	p.runner = k8sproxy.NewBoundedFrequencyRunner(componentName, p.syncProxyRules, time.Second, 30*time.Second, 2)
+	if o.endpointSliceEnabled {
+		p.endpointsChanges = newEndpointsChangesTracker(hostname, o.endpointSliceEnabled, isIPv6)
+	}
 	return p
 }
 
@@ -351,7 +379,7 @@ func testLoadBalancer(t *testing.T, nodePortAddresses []net.IP, svcIP, ep1IP, ep
 	}
 	mockRouteClient.EXPECT().AddClusterIPRoute(svcIP).Times(1)
 	if proxyLoadBalancerIPs {
-		mockRouteClient.EXPECT().AddLoadBalancer([]string{loadBalancerIP.String()}).Times(1)
+		mockRouteClient.EXPECT().AddLoadBalancer(loadBalancerIP).Times(1)
 	}
 	mockRouteClient.EXPECT().AddNodePort(nodePortAddresses, uint16(svcNodePort), bindingProtocol).Times(1)
 
@@ -749,6 +777,7 @@ func testClusterIPRemoval(t *testing.T, svcIP net.IP, epIP net.IP, isIPv6 bool) 
 	mockOFClient.EXPECT().UninstallServiceFlows(svcIP, uint16(svcPort), bindingProtocol).Times(1)
 	mockOFClient.EXPECT().UninstallEndpointFlows(bindingProtocol, gomock.Any()).Times(1)
 	mockOFClient.EXPECT().UninstallServiceGroup(gomock.Any()).Times(1)
+	mockRouteClient.EXPECT().DeleteClusterIPRoute(svcIP).Times(1)
 	fp.syncProxyRules()
 
 	fp.serviceChanges.OnServiceUpdate(service, nil)
@@ -1299,4 +1328,166 @@ func TestMetrics(t *testing.T) {
 			assert.NoError(t, err)
 		})
 	}
+}
+
+func TestLoadBalancerServiceWithMultiplePorts(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockOFClient, mockRouteClient := getMockClients(ctrl)
+	groupAllocator := openflow.NewGroupAllocator(false)
+	nodePortAddresses := []net.IP{net.ParseIP("0.0.0.0")}
+	fp := NewFakeProxier(mockRouteClient, mockOFClient, nodePortAddresses, groupAllocator, false, withProxyAll, withEndpointSlice)
+
+	port80Str := "port80"
+	port80Int32 := int32(80)
+	port443Str := "port443"
+	port443Int32 := int32(443)
+	port30001Int32 := int32(30001)
+	port30002Int32 := int32(30002)
+	protocolTCP := corev1.ProtocolTCP
+	endpoint1Address := "192.168.0.11"
+	endpoint2Address := "192.168.1.11"
+	endpoint1NodeName := "localhost"
+	endpoint2NodeName := "node2"
+	svc1IPv4 := net.ParseIP("10.20.30.41")
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc",
+			Namespace: "default",
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Name:       port80Str,
+					Protocol:   protocolTCP,
+					Port:       port80Int32,
+					TargetPort: intstr.FromInt(int(port80Int32)),
+					NodePort:   port30001Int32,
+				},
+				{
+					Name:       port443Str,
+					Protocol:   protocolTCP,
+					Port:       port443Int32,
+					TargetPort: intstr.FromInt(int(port443Int32)),
+					NodePort:   port30002Int32,
+				},
+			},
+			ClusterIP:             svc1IPv4.String(),
+			ClusterIPs:            []string{svc1IPv4.String()},
+			Type:                  corev1.ServiceTypeLoadBalancer,
+			ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyTypeLocal,
+			HealthCheckNodePort:   40000,
+			IPFamilies:            []corev1.IPFamily{corev1.IPv4Protocol},
+		},
+		Status: corev1.ServiceStatus{
+			LoadBalancer: corev1.LoadBalancerStatus{Ingress: []corev1.LoadBalancerIngress{
+				{IP: loadBalancerIPv4.String()},
+			}},
+		},
+	}
+	makeServiceMap(fp, svc)
+
+	endpointSlice := &discovery.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc-x5ks2",
+			Namespace: svc.Namespace,
+			Labels: map[string]string{
+				discovery.LabelServiceName: svc.Name,
+			},
+		},
+		AddressType: discovery.AddressTypeIPv4,
+		Endpoints: []discovery.Endpoint{
+			{
+				Addresses: []string{
+					endpoint1Address,
+				},
+				Conditions: discovery.EndpointConditions{
+					Ready:       pointer.Bool(true),
+					Serving:     pointer.Bool(false),
+					Terminating: pointer.Bool(false),
+				},
+				NodeName: &endpoint1NodeName,
+				Topology: map[string]string{"kubernetes.io/hostname": endpoint1NodeName},
+			},
+			{
+				Addresses: []string{
+					endpoint2Address,
+				},
+				Conditions: discovery.EndpointConditions{
+					Ready:       pointer.Bool(true),
+					Serving:     pointer.Bool(false),
+					Terminating: pointer.Bool(false),
+				},
+				NodeName: &endpoint2NodeName,
+				Topology: map[string]string{"kubernetes.io/hostname": endpoint2NodeName},
+			},
+		},
+		Ports: []discovery.EndpointPort{
+			{
+				Name:     &port80Str,
+				Port:     &port80Int32,
+				Protocol: &protocolTCP,
+			},
+			{
+				Name:     &port443Str,
+				Port:     &port443Int32,
+				Protocol: &protocolTCP,
+			},
+		},
+	}
+	makeEndpointSliceMap(fp, endpointSlice)
+
+	localEndpointForPort80 := k8sproxy.NewBaseEndpointInfo(endpoint1Address, int(port80Int32), true, map[string]string{"kubernetes.io/hostname": endpoint1NodeName})
+	localEndpointForPort443 := k8sproxy.NewBaseEndpointInfo(endpoint1Address, int(port443Int32), true, map[string]string{"kubernetes.io/hostname": endpoint1NodeName})
+	remoteEndpointForPort80 := k8sproxy.NewBaseEndpointInfo(endpoint2Address, int(port80Int32), false, map[string]string{"kubernetes.io/hostname": endpoint2NodeName})
+	remoteEndpointForPort443 := k8sproxy.NewBaseEndpointInfo(endpoint2Address, int(port443Int32), false, map[string]string{"kubernetes.io/hostname": endpoint2NodeName})
+
+	mockOFClient.EXPECT().InstallEndpointFlows(binding.ProtocolTCP, gomock.InAnyOrder([]k8sproxy.Endpoint{localEndpointForPort80, remoteEndpointForPort80})).Times(1)
+	mockOFClient.EXPECT().InstallServiceGroup(gomock.Any(), false, []k8sproxy.Endpoint{localEndpointForPort80}).Times(1)
+	mockOFClient.EXPECT().InstallServiceGroup(gomock.Any(), false, gomock.InAnyOrder([]k8sproxy.Endpoint{localEndpointForPort80, remoteEndpointForPort80})).Times(1)
+	mockOFClient.EXPECT().InstallServiceFlows(gomock.Any(), svc1IPv4, uint16(port80Int32), binding.ProtocolTCP, uint16(0), false, corev1.ServiceTypeClusterIP).Times(1)
+	mockOFClient.EXPECT().InstallServiceFlows(gomock.Any(), agentconfig.VirtualNodePortDNATIPv4, uint16(port30001Int32), binding.ProtocolTCP, uint16(0), true, corev1.ServiceTypeNodePort).Times(1)
+	mockOFClient.EXPECT().InstallServiceFlows(gomock.Any(), loadBalancerIPv4, uint16(port80Int32), binding.ProtocolTCP, uint16(0), true, corev1.ServiceTypeLoadBalancer).Times(1)
+	mockRouteClient.EXPECT().AddNodePort(nodePortAddresses, uint16(port30001Int32), binding.ProtocolTCP).Times(1)
+	// The route for the ClusterIP and the LoadBalancer IP should only be installed once.
+	mockRouteClient.EXPECT().AddClusterIPRoute(svc1IPv4).Times(1)
+	mockRouteClient.EXPECT().AddLoadBalancer(loadBalancerIPv4).Times(1)
+
+	mockOFClient.EXPECT().InstallEndpointFlows(binding.ProtocolTCP, gomock.InAnyOrder([]k8sproxy.Endpoint{localEndpointForPort443, remoteEndpointForPort443})).Times(1)
+	mockOFClient.EXPECT().InstallServiceGroup(gomock.Any(), false, []k8sproxy.Endpoint{localEndpointForPort443}).Times(1)
+	mockOFClient.EXPECT().InstallServiceGroup(gomock.Any(), false, gomock.InAnyOrder([]k8sproxy.Endpoint{localEndpointForPort443, remoteEndpointForPort443})).Times(1)
+	mockOFClient.EXPECT().InstallServiceFlows(gomock.Any(), svc1IPv4, uint16(port443Int32), binding.ProtocolTCP, uint16(0), false, corev1.ServiceTypeClusterIP).Times(1)
+	mockOFClient.EXPECT().InstallServiceFlows(gomock.Any(), agentconfig.VirtualNodePortDNATIPv4, uint16(port30002Int32), binding.ProtocolTCP, uint16(0), true, corev1.ServiceTypeNodePort).Times(1)
+	mockOFClient.EXPECT().InstallServiceFlows(gomock.Any(), loadBalancerIPv4, uint16(port443Int32), binding.ProtocolTCP, uint16(0), true, corev1.ServiceTypeLoadBalancer).Times(1)
+	mockRouteClient.EXPECT().AddNodePort(nodePortAddresses, uint16(port30002Int32), binding.ProtocolTCP).Times(1)
+
+	fp.syncProxyRules()
+
+	// Remove the service.
+	fp.serviceChanges.OnServiceUpdate(svc, nil)
+	fp.endpointsChanges.OnEndpointSliceUpdate(endpointSlice, true)
+
+	mockOFClient.EXPECT().UninstallEndpointFlows(binding.ProtocolTCP, localEndpointForPort80)
+	mockOFClient.EXPECT().UninstallEndpointFlows(binding.ProtocolTCP, remoteEndpointForPort80)
+	mockOFClient.EXPECT().UninstallServiceGroup(gomock.Any()).Times(2)
+	mockOFClient.EXPECT().UninstallServiceFlows(svc1IPv4, uint16(port80Int32), binding.ProtocolTCP)
+	mockOFClient.EXPECT().UninstallServiceFlows(agentconfig.VirtualNodePortDNATIPv4, uint16(port30001Int32), binding.ProtocolTCP)
+	mockOFClient.EXPECT().UninstallServiceFlows(loadBalancerIPv4, uint16(port80Int32), binding.ProtocolTCP)
+	mockRouteClient.EXPECT().DeleteNodePort(nodePortAddresses, uint16(port30001Int32), binding.ProtocolTCP)
+
+	mockOFClient.EXPECT().UninstallEndpointFlows(binding.ProtocolTCP, localEndpointForPort443)
+	mockOFClient.EXPECT().UninstallEndpointFlows(binding.ProtocolTCP, remoteEndpointForPort443)
+	mockOFClient.EXPECT().UninstallServiceGroup(gomock.Any()).Times(2)
+	mockOFClient.EXPECT().UninstallServiceFlows(svc1IPv4, uint16(port443Int32), binding.ProtocolTCP)
+	mockOFClient.EXPECT().UninstallServiceFlows(agentconfig.VirtualNodePortDNATIPv4, uint16(port30002Int32), binding.ProtocolTCP)
+	mockOFClient.EXPECT().UninstallServiceFlows(loadBalancerIPv4, uint16(port443Int32), binding.ProtocolTCP)
+	mockRouteClient.EXPECT().DeleteNodePort(nodePortAddresses, uint16(port30002Int32), binding.ProtocolTCP)
+	// The route for the ClusterIP and the LoadBalancer IP should only be uninstalled once.
+	mockRouteClient.EXPECT().DeleteClusterIPRoute(svc1IPv4)
+	mockRouteClient.EXPECT().DeleteLoadBalancer(loadBalancerIPv4)
+
+	fp.syncProxyRules()
+
+	assert.Emptyf(t, fp.serviceIPRouteReferences, "serviceIPRouteReferences was not cleaned up after Service was removed")
 }

--- a/pkg/agent/route/interfaces.go
+++ b/pkg/agent/route/interfaces.go
@@ -29,7 +29,7 @@ type Interface interface {
 
 	// Reconcile should remove orphaned routes and related configuration based on the desired podCIDRs and Service IPs.
 	// If IPv6 is enabled in the cluster, Reconcile should also remove the orphaned IPv6 neighbors.
-	Reconcile(podCIDRs []string, svcIPs map[string]bool) error
+	Reconcile(podCIDRs []string) error
 
 	// AddRoutes should add routes to the provided podCIDR.
 	// It should override the routes if they already exist, without error.

--- a/pkg/agent/route/interfaces.go
+++ b/pkg/agent/route/interfaces.go
@@ -65,11 +65,11 @@ type Interface interface {
 	// ClusterIP Service traffic from host network.
 	DeleteClusterIPRoute(svcIP net.IP) error
 
-	// AddLoadBalancer adds configurations when a LoadBalancer Service is created.
-	AddLoadBalancer(externalIPs []string) error
+	// AddLoadBalancer adds configurations when a LoadBalancer IP is added.
+	AddLoadBalancer(externalIP net.IP) error
 
-	// DeleteLoadBalancer deletes related configurations when a LoadBalancer Service is deleted.
-	DeleteLoadBalancer(externalIPs []string) error
+	// DeleteLoadBalancer deletes related configurations when a LoadBalancer IP is deleted.
+	DeleteLoadBalancer(externalIP net.IP) error
 
 	// Run starts the sync loop.
 	Run(stopCh <-chan struct{})

--- a/pkg/agent/route/route_linux.go
+++ b/pkg/agent/route/route_linux.go
@@ -1357,11 +1357,10 @@ func (c *Client) addVirtualNodePortDNATIPRoute(isIPv6 bool) error {
 	return nil
 }
 
-// addLoadBalancerIngressIPRoute is used to add routing entry which is used to route LoadBalancer ingress IP to Antrea
+// AddLoadBalancer is used to add routing entry which is used to route LoadBalancer ingress IP to Antrea
 // gateway on host.
-func (c *Client) addLoadBalancerIngressIPRoute(svcIPStr string) error {
+func (c *Client) AddLoadBalancer(svcIP net.IP) error {
 	linkIndex := c.nodeConfig.GatewayConfig.LinkIndex
-	svcIP := net.ParseIP(svcIPStr)
 	isIPv6 := utilnet.IsIPv6(svcIP)
 	var gw net.IP
 	var mask int
@@ -1383,11 +1382,10 @@ func (c *Client) addLoadBalancerIngressIPRoute(svcIPStr string) error {
 	return nil
 }
 
-// deleteLoadBalancerIngressIPRoute is used to delete routing entry which is used to route LoadBalancer ingress IP to Antrea
+// DeleteLoadBalancer is used to delete routing entry which is used to route LoadBalancer ingress IP to Antrea
 // gateway on host.
-func (c *Client) deleteLoadBalancerIngressIPRoute(svcIPStr string) error {
+func (c *Client) DeleteLoadBalancer(svcIP net.IP) error {
 	linkIndex := c.nodeConfig.GatewayConfig.LinkIndex
-	svcIP := net.ParseIP(svcIPStr)
 	isIPv6 := utilnet.IsIPv6(svcIP)
 	var gw net.IP
 	var mask int
@@ -1409,28 +1407,6 @@ func (c *Client) deleteLoadBalancerIngressIPRoute(svcIPStr string) error {
 	}
 	klog.V(4).InfoS("Deleted LoadBalancer ingress IP route", "route", route)
 	c.serviceRoutes.Delete(svcIP.String())
-
-	return nil
-}
-
-// AddLoadBalancer is used to add routing entries when a LoadBalancer Service is added.
-func (c *Client) AddLoadBalancer(externalIPs []string) error {
-	for _, svcIPStr := range externalIPs {
-		if err := c.addLoadBalancerIngressIPRoute(svcIPStr); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// DeleteLoadBalancer is used to delete routing entries when a LoadBalancer Service is deleted.
-func (c *Client) DeleteLoadBalancer(externalIPs []string) error {
-	for _, svcIPStr := range externalIPs {
-		if err := c.deleteLoadBalancerIngressIPRoute(svcIPStr); err != nil {
-			return err
-		}
-	}
 
 	return nil
 }

--- a/pkg/agent/route/route_linux.go
+++ b/pkg/agent/route/route_linux.go
@@ -786,7 +786,7 @@ func (c *Client) initServiceIPRoutes() error {
 
 // Reconcile removes orphaned podCIDRs from ipset and removes routes to orphaned podCIDRs
 // based on the desired podCIDRs. svcIPs are used for Windows only.
-func (c *Client) Reconcile(podCIDRs []string, svcIPs map[string]bool) error {
+func (c *Client) Reconcile(podCIDRs []string) error {
 	desiredPodCIDRs := sets.NewString(podCIDRs...)
 	// Get the peer IPv6 gateways from pod CIDRs
 	desiredIPv6GWs := getIPv6Gateways(podCIDRs)

--- a/pkg/agent/route/route_linux_test.go
+++ b/pkg/agent/route/route_linux_test.go
@@ -1,0 +1,1628 @@
+// Copyright 2022 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package route
+
+import (
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/vishvananda/netlink"
+
+	"antrea.io/antrea/pkg/agent/config"
+	"antrea.io/antrea/pkg/agent/types"
+	"antrea.io/antrea/pkg/agent/util/ipset"
+	ipsettest "antrea.io/antrea/pkg/agent/util/ipset/testing"
+	"antrea.io/antrea/pkg/agent/util/iptables"
+	iptablestest "antrea.io/antrea/pkg/agent/util/iptables/testing"
+	netlinktest "antrea.io/antrea/pkg/agent/util/netlink/testing"
+	"antrea.io/antrea/pkg/ovs/openflow"
+	"antrea.io/antrea/pkg/ovs/ovsconfig"
+	"antrea.io/antrea/pkg/util/ip"
+)
+
+func TestSyncRoutes(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockNetlink := netlinktest.NewMockInterface(ctrl)
+
+	nodeRoute1 := &netlink.Route{Dst: ip.MustParseCIDR("192.168.1.0/24"), Gw: net.ParseIP("1.1.1.1")}
+	nodeRoute2 := &netlink.Route{Dst: ip.MustParseCIDR("192.168.2.0/24"), Gw: net.ParseIP("1.1.1.2")}
+	serviceRoute1 := &netlink.Route{Dst: ip.MustParseCIDR("169.254.0.253/32"), LinkIndex: 10}
+	serviceRoute2 := &netlink.Route{Dst: ip.MustParseCIDR("169.254.0.252/32"), Gw: net.ParseIP("169.254.0.253")}
+	mockNetlink.EXPECT().RouteList(nil, netlink.FAMILY_ALL).Return([]netlink.Route{*nodeRoute1, *serviceRoute1}, nil)
+	mockNetlink.EXPECT().RouteReplace(nodeRoute2)
+	mockNetlink.EXPECT().RouteReplace(serviceRoute2)
+	mockNetlink.EXPECT().RouteReplace(&netlink.Route{
+		LinkIndex: 10,
+		Dst:       ip.MustParseCIDR("192.168.0.0/24"),
+		Src:       net.ParseIP("192.168.0.1"),
+		Scope:     netlink.SCOPE_LINK,
+	})
+	mockNetlink.EXPECT().RouteReplace(&netlink.Route{
+		LinkIndex: 10,
+		Dst:       ip.MustParseCIDR("aabb:ccdd::/64"),
+		Src:       net.ParseIP("aabb:ccdd::1"),
+		Scope:     netlink.SCOPE_LINK,
+	})
+
+	c := &Client{
+		netlink:       mockNetlink,
+		proxyAll:      true,
+		nodeRoutes:    sync.Map{},
+		serviceRoutes: sync.Map{},
+		nodeConfig: &config.NodeConfig{
+			GatewayConfig: &config.GatewayConfig{LinkIndex: 10, IPv4: net.ParseIP("192.168.0.1"), IPv6: net.ParseIP("aabb:ccdd::1")},
+			PodIPv4CIDR:   ip.MustParseCIDR("192.168.0.0/24"),
+			PodIPv6CIDR:   ip.MustParseCIDR("aabb:ccdd::/64"),
+		},
+	}
+	c.nodeRoutes.Store("192.168.1.0/24", []*netlink.Route{nodeRoute1})
+	c.nodeRoutes.Store("192.168.2.0/24", []*netlink.Route{nodeRoute2})
+	c.serviceRoutes.Store("169.254.0.253/32", serviceRoute1)
+	c.serviceRoutes.Store("169.254.0.252/32", serviceRoute2)
+
+	assert.NoError(t, c.syncRoutes())
+}
+
+func TestSyncIPSet(t *testing.T) {
+	podCIDRStr := "172.16.10.0/24"
+	_, podCIDR, _ := net.ParseCIDR(podCIDRStr)
+	podCIDRv6Str := "2001:ab03:cd04:55ef::/64"
+	_, podCIDRv6, _ := net.ParseCIDR(podCIDRv6Str)
+	tests := []struct {
+		name                  string
+		proxyAll              bool
+		multicastEnabled      bool
+		connectUplinkToBridge bool
+		networkConfig         *config.NetworkConfig
+		nodeConfig            *config.NodeConfig
+		nodePortsIPv4         []string
+		nodePortsIPv6         []string
+		clusterNodeIPs        map[string]string
+		clusterNodeIP6s       map[string]string
+		expectedCalls         func(ipset *ipsettest.MockInterfaceMockRecorder)
+	}{
+		{
+			name: "networkPolicyOnly",
+			networkConfig: &config.NetworkConfig{
+				TrafficEncapMode: config.TrafficEncapModeNetworkPolicyOnly,
+			},
+			expectedCalls: func(mockIPSet *ipsettest.MockInterfaceMockRecorder) {},
+		},
+		{
+			name: "noencap",
+			networkConfig: &config.NetworkConfig{
+				TrafficEncapMode: config.TrafficEncapModeNoEncap,
+				IPv4Enabled:      true,
+				IPv6Enabled:      true,
+			},
+			nodeConfig: &config.NodeConfig{
+				PodIPv4CIDR: podCIDR,
+				PodIPv6CIDR: podCIDRv6,
+			},
+			expectedCalls: func(mockIPSet *ipsettest.MockInterfaceMockRecorder) {
+				mockIPSet.CreateIPSet(antreaPodIPSet, ipset.HashNet, false)
+				mockIPSet.CreateIPSet(antreaPodIP6Set, ipset.HashNet, true)
+				mockIPSet.AddEntry(antreaPodIPSet, podCIDRStr)
+				mockIPSet.AddEntry(antreaPodIP6Set, podCIDRv6Str)
+			},
+		},
+		{
+			name:             "encap, proxyAll=true, multicastEnabled=true",
+			proxyAll:         true,
+			multicastEnabled: true,
+			networkConfig: &config.NetworkConfig{
+				TrafficEncapMode: config.TrafficEncapModeEncap,
+				IPv4Enabled:      true,
+				IPv6Enabled:      true,
+			},
+			nodeConfig: &config.NodeConfig{
+				PodIPv4CIDR: podCIDR,
+				PodIPv6CIDR: podCIDRv6,
+			},
+			nodePortsIPv4:   []string{"192.168.0.2,tcp:10000", "127.0.0.1,tcp:10000"},
+			nodePortsIPv6:   []string{"fe80::e643:4bff:fe44:ee,tcp:10000", "::1,tcp:10000"},
+			clusterNodeIPs:  map[string]string{"172.16.3.0/24": "192.168.0.3", "172.16.4.0/24": "192.168.0.4"},
+			clusterNodeIP6s: map[string]string{"2001:ab03:cd04:5503::/64": "fe80::e643:4bff:fe03", "2001:ab03:cd04:5504::/64": "fe80::e643:4bff:fe04"},
+			expectedCalls: func(mockIPSet *ipsettest.MockInterfaceMockRecorder) {
+				mockIPSet.CreateIPSet(antreaPodIPSet, ipset.HashNet, false)
+				mockIPSet.CreateIPSet(antreaPodIP6Set, ipset.HashNet, true)
+				mockIPSet.AddEntry(antreaPodIPSet, podCIDRStr)
+				mockIPSet.AddEntry(antreaPodIP6Set, podCIDRv6Str)
+				mockIPSet.CreateIPSet(antreaNodePortIPSet, ipset.HashIPPort, false)
+				mockIPSet.CreateIPSet(antreaNodePortIP6Set, ipset.HashIPPort, true)
+				mockIPSet.AddEntry(antreaNodePortIPSet, "192.168.0.2,tcp:10000")
+				mockIPSet.AddEntry(antreaNodePortIPSet, "127.0.0.1,tcp:10000")
+				mockIPSet.AddEntry(antreaNodePortIP6Set, "fe80::e643:4bff:fe44:ee,tcp:10000")
+				mockIPSet.AddEntry(antreaNodePortIP6Set, "::1,tcp:10000")
+				mockIPSet.CreateIPSet(clusterNodeIPSet, ipset.HashIP, false)
+				mockIPSet.CreateIPSet(clusterNodeIP6Set, ipset.HashIP, true)
+				mockIPSet.AddEntry(clusterNodeIPSet, "192.168.0.3")
+				mockIPSet.AddEntry(clusterNodeIPSet, "192.168.0.4")
+				mockIPSet.AddEntry(clusterNodeIP6Set, "fe80::e643:4bff:fe03")
+				mockIPSet.AddEntry(clusterNodeIP6Set, "fe80::e643:4bff:fe04")
+			},
+		},
+		{
+			name:                  "noencap, connectUplinkToBridge=true",
+			connectUplinkToBridge: true,
+			networkConfig: &config.NetworkConfig{
+				TrafficEncapMode: config.TrafficEncapModeNoEncap,
+				IPv4Enabled:      true,
+				IPv6Enabled:      true,
+			},
+			nodeConfig: &config.NodeConfig{
+				PodIPv4CIDR: podCIDR,
+				PodIPv6CIDR: podCIDRv6,
+			},
+			expectedCalls: func(mockIPSet *ipsettest.MockInterfaceMockRecorder) {
+				mockIPSet.CreateIPSet(antreaPodIPSet, ipset.HashNet, false)
+				mockIPSet.CreateIPSet(antreaPodIP6Set, ipset.HashNet, true)
+				mockIPSet.AddEntry(antreaPodIPSet, podCIDRStr)
+				mockIPSet.AddEntry(antreaPodIP6Set, podCIDRv6Str)
+				mockIPSet.CreateIPSet(localAntreaFlexibleIPAMPodIPSet, ipset.HashIP, false)
+				mockIPSet.CreateIPSet(localAntreaFlexibleIPAMPodIP6Set, ipset.HashIP, true)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			ipset := ipsettest.NewMockInterface(ctrl)
+			c := &Client{ipset: ipset,
+				networkConfig:         tt.networkConfig,
+				nodeConfig:            tt.nodeConfig,
+				proxyAll:              tt.proxyAll,
+				multicastEnabled:      tt.multicastEnabled,
+				connectUplinkToBridge: tt.connectUplinkToBridge,
+				nodePortsIPv4:         sync.Map{},
+				nodePortsIPv6:         sync.Map{},
+				clusterNodeIPs:        sync.Map{},
+				clusterNodeIP6s:       sync.Map{},
+			}
+			for _, nodePortIPv4 := range tt.nodePortsIPv4 {
+				c.nodePortsIPv4.Store(nodePortIPv4, struct{}{})
+			}
+			for _, nodePortIPv6 := range tt.nodePortsIPv6 {
+				c.nodePortsIPv6.Store(nodePortIPv6, struct{}{})
+			}
+			for cidr, nodeIP := range tt.clusterNodeIPs {
+				c.clusterNodeIPs.Store(cidr, nodeIP)
+			}
+			for cidr, nodeIP := range tt.clusterNodeIP6s {
+				c.clusterNodeIP6s.Store(cidr, nodeIP)
+			}
+			tt.expectedCalls(ipset.EXPECT())
+			assert.NoError(t, c.syncIPSet())
+		})
+	}
+}
+
+func TestSyncIPTables(t *testing.T) {
+	tests := []struct {
+		name                  string
+		isCloudEKS            bool
+		proxyAll              bool
+		multicastEnabled      bool
+		connectUplinkToBridge bool
+		networkConfig         *config.NetworkConfig
+		nodeConfig            *config.NodeConfig
+		nodePortsIPv4         []string
+		nodePortsIPv6         []string
+		markToSNATIP          map[uint32]string
+		expectedCalls         func(iptables *iptablestest.MockInterfaceMockRecorder)
+	}{
+		{
+			name:             "encap,egress=true,multicastEnabled=true,proxyAll=true",
+			proxyAll:         true,
+			multicastEnabled: true,
+			networkConfig: &config.NetworkConfig{
+				TrafficEncapMode: config.TrafficEncapModeEncap,
+				TunnelType:       ovsconfig.GeneveTunnel,
+				IPv4Enabled:      true,
+				IPv6Enabled:      true,
+			},
+			nodeConfig: &config.NodeConfig{
+				PodIPv4CIDR: ip.MustParseCIDR("172.16.10.0/24"),
+				PodIPv6CIDR: ip.MustParseCIDR("2001:ab03:cd04:55ef::/64"),
+				GatewayConfig: &config.GatewayConfig{
+					Name: "antrea-gw0",
+				},
+			},
+			markToSNATIP: map[uint32]string{
+				1: "1.1.1.1",
+				2: "fe80::e643:4bff:fe02",
+			},
+			expectedCalls: func(mockIPTables *iptablestest.MockInterfaceMockRecorder) {
+				mockIPTables.EnsureChain(iptables.ProtocolDual, iptables.RawTable, antreaPreRoutingChain)
+				mockIPTables.AppendRule(iptables.ProtocolDual, iptables.RawTable, iptables.PreRoutingChain, []string{"-j", antreaPreRoutingChain, "-m", "comment", "--comment", "Antrea: jump to Antrea prerouting rules"})
+				mockIPTables.EnsureChain(iptables.ProtocolDual, iptables.RawTable, antreaOutputChain)
+				mockIPTables.AppendRule(iptables.ProtocolDual, iptables.RawTable, iptables.OutputChain, []string{"-j", antreaOutputChain, "-m", "comment", "--comment", "Antrea: jump to Antrea output rules"})
+				mockIPTables.EnsureChain(iptables.ProtocolDual, iptables.FilterTable, antreaForwardChain)
+				mockIPTables.AppendRule(iptables.ProtocolDual, iptables.FilterTable, iptables.ForwardChain, []string{"-j", antreaForwardChain, "-m", "comment", "--comment", "Antrea: jump to Antrea forwarding rules"})
+				mockIPTables.EnsureChain(iptables.ProtocolDual, iptables.NATTable, antreaPostRoutingChain)
+				mockIPTables.AppendRule(iptables.ProtocolDual, iptables.NATTable, iptables.PostRoutingChain, []string{"-j", antreaPostRoutingChain, "-m", "comment", "--comment", "Antrea: jump to Antrea postrouting rules"})
+				mockIPTables.EnsureChain(iptables.ProtocolDual, iptables.MangleTable, antreaMangleChain)
+				mockIPTables.AppendRule(iptables.ProtocolDual, iptables.MangleTable, iptables.PreRoutingChain, []string{"-j", antreaMangleChain, "-m", "comment", "--comment", "Antrea: jump to Antrea mangle rules"})
+				mockIPTables.EnsureChain(iptables.ProtocolDual, iptables.MangleTable, antreaOutputChain)
+				mockIPTables.AppendRule(iptables.ProtocolDual, iptables.MangleTable, iptables.OutputChain, []string{"-j", antreaOutputChain, "-m", "comment", "--comment", "Antrea: jump to Antrea output rules"})
+				mockIPTables.EnsureChain(iptables.ProtocolDual, iptables.NATTable, antreaPreRoutingChain)
+				mockIPTables.AppendRule(iptables.ProtocolDual, iptables.NATTable, iptables.PreRoutingChain, []string{"-j", antreaPreRoutingChain, "-m", "comment", "--comment", "Antrea: jump to Antrea prerouting rules"})
+				mockIPTables.EnsureChain(iptables.ProtocolDual, iptables.NATTable, antreaOutputChain)
+				mockIPTables.AppendRule(iptables.ProtocolDual, iptables.NATTable, iptables.OutputChain, []string{"-j", antreaOutputChain, "-m", "comment", "--comment", "Antrea: jump to Antrea output rules"})
+				mockIPTables.Restore(`*raw
+:ANTREA-PREROUTING - [0:0]
+:ANTREA-OUTPUT - [0:0]
+-A ANTREA-PREROUTING -m comment --comment "Antrea: do not track incoming encapsulation packets" -m udp -p udp --dport 6081 -m addrtype --dst-type LOCAL -j NOTRACK
+-A ANTREA-OUTPUT -m comment --comment "Antrea: do not track outgoing encapsulation packets" -m udp -p udp --dport 6081 -m addrtype --src-type LOCAL -j NOTRACK
+-A ANTREA-PREROUTING -m comment --comment "Antrea: drop Pod multicast traffic forwarded via underlay network" -m set --match-set CLUSTER-NODE-IP src -d 224.0.0.0/4 -j DROP
+COMMIT
+*mangle
+:ANTREA-MANGLE - [0:0]
+:ANTREA-OUTPUT - [0:0]
+-A ANTREA-OUTPUT -m comment --comment "Antrea: mark LOCAL output packets" -m addrtype --src-type LOCAL -o antrea-gw0 -j MARK --or-mark 0x80000000
+COMMIT
+*filter
+:ANTREA-FORWARD - [0:0]
+-A ANTREA-FORWARD -m comment --comment "Antrea: accept packets from local Pods" -i antrea-gw0 -j ACCEPT
+-A ANTREA-FORWARD -m comment --comment "Antrea: accept packets to local Pods" -o antrea-gw0 -j ACCEPT
+COMMIT
+*nat
+:ANTREA-PREROUTING - [0:0]
+-A ANTREA-PREROUTING -m comment --comment "Antrea: DNAT external to NodePort packets" -m set --match-set ANTREA-NODEPORT-IP dst,dst -j DNAT --to-destination 169.254.0.252
+:ANTREA-OUTPUT - [0:0]
+-A ANTREA-OUTPUT -m comment --comment "Antrea: DNAT local to NodePort packets" -m set --match-set ANTREA-NODEPORT-IP dst,dst -j DNAT --to-destination 169.254.0.252
+:ANTREA-POSTROUTING - [0:0]
+-A ANTREA-POSTROUTING -m comment --comment "Antrea: SNAT Pod to external packets" ! -o antrea-gw0 -m mark --mark 0x00000001/0x000000ff -j SNAT --to 1.1.1.1
+-A ANTREA-POSTROUTING -m comment --comment "Antrea: masquerade Pod to external packets" -s 172.16.10.0/24 -m set ! --match-set ANTREA-POD-IP dst ! -o antrea-gw0 -j MASQUERADE
+-A ANTREA-POSTROUTING -m comment --comment "Antrea: masquerade LOCAL traffic" -o antrea-gw0 -m addrtype ! --src-type LOCAL --limit-iface-out -m addrtype --src-type LOCAL -j MASQUERADE --random-fully
+-A ANTREA-POSTROUTING -m comment --comment "Antrea: masquerade OVS virtual source IP" -s 169.254.0.253 -j MASQUERADE
+COMMIT
+`, false, false)
+				mockIPTables.Restore(`*raw
+:ANTREA-PREROUTING - [0:0]
+:ANTREA-OUTPUT - [0:0]
+-A ANTREA-PREROUTING -m comment --comment "Antrea: do not track incoming encapsulation packets" -m udp -p udp --dport 6081 -m addrtype --dst-type LOCAL -j NOTRACK
+-A ANTREA-OUTPUT -m comment --comment "Antrea: do not track outgoing encapsulation packets" -m udp -p udp --dport 6081 -m addrtype --src-type LOCAL -j NOTRACK
+-A ANTREA-PREROUTING -m comment --comment "Antrea: drop Pod multicast traffic forwarded via underlay network" -m set --match-set CLUSTER-NODE-IP6 src -d 224.0.0.0/4 -j DROP
+COMMIT
+*mangle
+:ANTREA-MANGLE - [0:0]
+:ANTREA-OUTPUT - [0:0]
+-A ANTREA-OUTPUT -m comment --comment "Antrea: mark LOCAL output packets" -m addrtype --src-type LOCAL -o antrea-gw0 -j MARK --or-mark 0x80000000
+COMMIT
+*filter
+:ANTREA-FORWARD - [0:0]
+-A ANTREA-FORWARD -m comment --comment "Antrea: accept packets from local Pods" -i antrea-gw0 -j ACCEPT
+-A ANTREA-FORWARD -m comment --comment "Antrea: accept packets to local Pods" -o antrea-gw0 -j ACCEPT
+COMMIT
+*nat
+:ANTREA-PREROUTING - [0:0]
+-A ANTREA-PREROUTING -m comment --comment "Antrea: DNAT external to NodePort packets" -m set --match-set ANTREA-NODEPORT-IP6 dst,dst -j DNAT --to-destination fc01::aabb:ccdd:eefe
+:ANTREA-OUTPUT - [0:0]
+-A ANTREA-OUTPUT -m comment --comment "Antrea: DNAT local to NodePort packets" -m set --match-set ANTREA-NODEPORT-IP6 dst,dst -j DNAT --to-destination fc01::aabb:ccdd:eefe
+:ANTREA-POSTROUTING - [0:0]
+-A ANTREA-POSTROUTING -m comment --comment "Antrea: SNAT Pod to external packets" ! -o antrea-gw0 -m mark --mark 0x00000002/0x000000ff -j SNAT --to fe80::e643:4bff:fe02
+-A ANTREA-POSTROUTING -m comment --comment "Antrea: masquerade Pod to external packets" -s 2001:ab03:cd04:55ef::/64 -m set ! --match-set ANTREA-POD-IP6 dst ! -o antrea-gw0 -j MASQUERADE
+-A ANTREA-POSTROUTING -m comment --comment "Antrea: masquerade LOCAL traffic" -o antrea-gw0 -m addrtype ! --src-type LOCAL --limit-iface-out -m addrtype --src-type LOCAL -j MASQUERADE --random-fully
+-A ANTREA-POSTROUTING -m comment --comment "Antrea: masquerade OVS virtual source IP" -s fc01::aabb:ccdd:eeff -j MASQUERADE
+COMMIT
+`, false, true)
+			},
+		},
+		{
+			name:       "encap,eks",
+			isCloudEKS: true,
+			networkConfig: &config.NetworkConfig{
+				TrafficEncapMode: config.TrafficEncapModeEncap,
+				TunnelType:       ovsconfig.GeneveTunnel,
+				IPv4Enabled:      true,
+				IPv6Enabled:      true,
+			},
+			nodeConfig: &config.NodeConfig{
+				PodIPv4CIDR: ip.MustParseCIDR("172.16.10.0/24"),
+				PodIPv6CIDR: ip.MustParseCIDR("2001:ab03:cd04:55ef::/64"),
+				GatewayConfig: &config.GatewayConfig{
+					Name: "antrea-gw0",
+				},
+			},
+			expectedCalls: func(mockIPTables *iptablestest.MockInterfaceMockRecorder) {
+				mockIPTables.EnsureChain(iptables.ProtocolDual, iptables.RawTable, antreaPreRoutingChain)
+				mockIPTables.AppendRule(iptables.ProtocolDual, iptables.RawTable, iptables.PreRoutingChain, []string{"-j", antreaPreRoutingChain, "-m", "comment", "--comment", "Antrea: jump to Antrea prerouting rules"})
+				mockIPTables.EnsureChain(iptables.ProtocolDual, iptables.RawTable, antreaOutputChain)
+				mockIPTables.AppendRule(iptables.ProtocolDual, iptables.RawTable, iptables.OutputChain, []string{"-j", antreaOutputChain, "-m", "comment", "--comment", "Antrea: jump to Antrea output rules"})
+				mockIPTables.EnsureChain(iptables.ProtocolDual, iptables.FilterTable, antreaForwardChain)
+				mockIPTables.AppendRule(iptables.ProtocolDual, iptables.FilterTable, iptables.ForwardChain, []string{"-j", antreaForwardChain, "-m", "comment", "--comment", "Antrea: jump to Antrea forwarding rules"})
+				mockIPTables.EnsureChain(iptables.ProtocolDual, iptables.NATTable, antreaPostRoutingChain)
+				mockIPTables.AppendRule(iptables.ProtocolDual, iptables.NATTable, iptables.PostRoutingChain, []string{"-j", antreaPostRoutingChain, "-m", "comment", "--comment", "Antrea: jump to Antrea postrouting rules"})
+				mockIPTables.EnsureChain(iptables.ProtocolDual, iptables.MangleTable, antreaMangleChain)
+				mockIPTables.AppendRule(iptables.ProtocolDual, iptables.MangleTable, iptables.PreRoutingChain, []string{"-j", antreaMangleChain, "-m", "comment", "--comment", "Antrea: jump to Antrea mangle rules"})
+				mockIPTables.EnsureChain(iptables.ProtocolDual, iptables.MangleTable, antreaOutputChain)
+				mockIPTables.AppendRule(iptables.ProtocolDual, iptables.MangleTable, iptables.OutputChain, []string{"-j", antreaOutputChain, "-m", "comment", "--comment", "Antrea: jump to Antrea output rules"})
+				mockIPTables.EnsureChain(iptables.ProtocolDual, iptables.NATTable, antreaPreRoutingChain)
+				mockIPTables.AppendRule(iptables.ProtocolDual, iptables.NATTable, iptables.PreRoutingChain, []string{"-j", antreaPreRoutingChain, "-m", "comment", "--comment", "Antrea: jump to Antrea prerouting rules"})
+				mockIPTables.Restore(`*raw
+:ANTREA-PREROUTING - [0:0]
+:ANTREA-OUTPUT - [0:0]
+-A ANTREA-PREROUTING -m comment --comment "Antrea: do not track incoming encapsulation packets" -m udp -p udp --dport 6081 -m addrtype --dst-type LOCAL -j NOTRACK
+-A ANTREA-OUTPUT -m comment --comment "Antrea: do not track outgoing encapsulation packets" -m udp -p udp --dport 6081 -m addrtype --src-type LOCAL -j NOTRACK
+COMMIT
+*mangle
+:ANTREA-MANGLE - [0:0]
+:ANTREA-OUTPUT - [0:0]
+-A ANTREA-MANGLE -m comment --comment "Antrea: AWS, primary ENI" -i antrea-gw0 -j CONNMARK --restore-mark --nfmask 0x80 --ctmask 0x80
+-A ANTREA-OUTPUT -m comment --comment "Antrea: mark LOCAL output packets" -m addrtype --src-type LOCAL -o antrea-gw0 -j MARK --or-mark 0x80000000
+COMMIT
+*filter
+:ANTREA-FORWARD - [0:0]
+-A ANTREA-FORWARD -m comment --comment "Antrea: accept packets from local Pods" -i antrea-gw0 -j ACCEPT
+-A ANTREA-FORWARD -m comment --comment "Antrea: accept packets to local Pods" -o antrea-gw0 -j ACCEPT
+COMMIT
+*nat
+:ANTREA-PREROUTING - [0:0]
+:ANTREA-POSTROUTING - [0:0]
+-A ANTREA-POSTROUTING -m comment --comment "Antrea: masquerade Pod to external packets" -s 172.16.10.0/24 -m set ! --match-set ANTREA-POD-IP dst ! -o antrea-gw0 -j MASQUERADE
+-A ANTREA-POSTROUTING -m comment --comment "Antrea: masquerade LOCAL traffic" -o antrea-gw0 -m addrtype ! --src-type LOCAL --limit-iface-out -m addrtype --src-type LOCAL -j MASQUERADE --random-fully
+-A ANTREA-PREROUTING -i antrea-gw0 -m comment --comment "Antrea: AWS, outbound connections" -j AWS-CONNMARK-CHAIN-0
+-A ANTREA-PREROUTING -m comment --comment "Antrea: AWS, CONNMARK (first packet)" -j CONNMARK --restore-mark --nfmask 0x80 --ctmask 0x80
+COMMIT
+`, false, false)
+				mockIPTables.Restore(`*raw
+:ANTREA-PREROUTING - [0:0]
+:ANTREA-OUTPUT - [0:0]
+-A ANTREA-PREROUTING -m comment --comment "Antrea: do not track incoming encapsulation packets" -m udp -p udp --dport 6081 -m addrtype --dst-type LOCAL -j NOTRACK
+-A ANTREA-OUTPUT -m comment --comment "Antrea: do not track outgoing encapsulation packets" -m udp -p udp --dport 6081 -m addrtype --src-type LOCAL -j NOTRACK
+COMMIT
+*mangle
+:ANTREA-MANGLE - [0:0]
+:ANTREA-OUTPUT - [0:0]
+-A ANTREA-OUTPUT -m comment --comment "Antrea: mark LOCAL output packets" -m addrtype --src-type LOCAL -o antrea-gw0 -j MARK --or-mark 0x80000000
+COMMIT
+*filter
+:ANTREA-FORWARD - [0:0]
+-A ANTREA-FORWARD -m comment --comment "Antrea: accept packets from local Pods" -i antrea-gw0 -j ACCEPT
+-A ANTREA-FORWARD -m comment --comment "Antrea: accept packets to local Pods" -o antrea-gw0 -j ACCEPT
+COMMIT
+*nat
+:ANTREA-PREROUTING - [0:0]
+:ANTREA-POSTROUTING - [0:0]
+-A ANTREA-POSTROUTING -m comment --comment "Antrea: masquerade Pod to external packets" -s 2001:ab03:cd04:55ef::/64 -m set ! --match-set ANTREA-POD-IP6 dst ! -o antrea-gw0 -j MASQUERADE
+-A ANTREA-POSTROUTING -m comment --comment "Antrea: masquerade LOCAL traffic" -o antrea-gw0 -m addrtype ! --src-type LOCAL --limit-iface-out -m addrtype --src-type LOCAL -j MASQUERADE --random-fully
+COMMIT
+`, false, true)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			mockIPTables := iptablestest.NewMockInterface(ctrl)
+			c := &Client{ipt: mockIPTables,
+				networkConfig:         tt.networkConfig,
+				nodeConfig:            tt.nodeConfig,
+				proxyAll:              tt.proxyAll,
+				isCloudEKS:            tt.isCloudEKS,
+				multicastEnabled:      tt.multicastEnabled,
+				connectUplinkToBridge: tt.connectUplinkToBridge,
+				markToSNATIP:          sync.Map{},
+			}
+			for mark, snatIP := range tt.markToSNATIP {
+				c.markToSNATIP.Store(mark, net.ParseIP(snatIP))
+			}
+			tt.expectedCalls(mockIPTables.EXPECT())
+			assert.NoError(t, c.syncIPTables())
+		})
+	}
+}
+
+func TestInitIPRoutes(t *testing.T) {
+	ipv4, nodeTransPortIPv4Addr, _ := net.ParseCIDR("172.16.10.2/24")
+	nodeTransPortIPv4Addr.IP = ipv4
+	ipv6, nodeTransPortIPv6Addr, _ := net.ParseCIDR("fe80::e643:4bff:fe44:ee/64")
+	nodeTransPortIPv6Addr.IP = ipv6
+
+	tests := []struct {
+		name          string
+		networkConfig *config.NetworkConfig
+		nodeConfig    *config.NodeConfig
+		expectedCalls func(mockNetlink *netlinktest.MockInterfaceMockRecorder)
+	}{
+		{
+			name:          "networkPolicyOnly",
+			networkConfig: &config.NetworkConfig{TrafficEncapMode: config.TrafficEncapModeNetworkPolicyOnly},
+			nodeConfig: &config.NodeConfig{
+				GatewayConfig:         &config.GatewayConfig{Name: "antrea-gw0"},
+				NodeTransportIPv4Addr: nodeTransPortIPv4Addr,
+				NodeTransportIPv6Addr: nodeTransPortIPv6Addr,
+			},
+			expectedCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
+				mockNetlink.LinkByName("antrea-gw0")
+				_, ipv4, _ := net.ParseCIDR("172.16.10.2/32")
+				mockNetlink.AddrReplace(gomock.Any(), &netlink.Addr{IPNet: ipv4})
+				_, ipv6, _ := net.ParseCIDR("fe80::e643:4bff:fe44:ee/128")
+				mockNetlink.AddrReplace(gomock.Any(), &netlink.Addr{IPNet: ipv6})
+			},
+		},
+		{
+			name:          "encap",
+			networkConfig: &config.NetworkConfig{TrafficEncapMode: config.TrafficEncapModeEncap},
+			nodeConfig: &config.NodeConfig{
+				GatewayConfig:         &config.GatewayConfig{Name: "antrea-gw0"},
+				NodeTransportIPv4Addr: nodeTransPortIPv4Addr,
+				NodeTransportIPv6Addr: nodeTransPortIPv6Addr,
+			},
+			expectedCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			mockNetlink := netlinktest.NewMockInterface(ctrl)
+			c := &Client{netlink: mockNetlink,
+				networkConfig: tt.networkConfig,
+				nodeConfig:    tt.nodeConfig,
+			}
+			tt.expectedCalls(mockNetlink.EXPECT())
+			assert.NoError(t, c.initIPRoutes())
+		})
+	}
+}
+
+func TestInitServiceIPRoutes(t *testing.T) {
+	tests := []struct {
+		name          string
+		networkConfig *config.NetworkConfig
+		nodeConfig    *config.NodeConfig
+		expectedCalls func(mockNetlink *netlinktest.MockInterfaceMockRecorder)
+	}{
+		{
+			name: "encap",
+			networkConfig: &config.NetworkConfig{
+				TrafficEncapMode: config.TrafficEncapModeEncap,
+				IPv4Enabled:      true,
+				IPv6Enabled:      true,
+			},
+			nodeConfig: &config.NodeConfig{
+				GatewayConfig: &config.GatewayConfig{Name: "antrea-gw0", LinkIndex: 10},
+			},
+			expectedCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
+				mockNetlink.NeighSet(&netlink.Neigh{
+					LinkIndex:    10,
+					Family:       netlink.FAMILY_V4,
+					State:        netlink.NUD_PERMANENT,
+					IP:           config.VirtualServiceIPv4,
+					HardwareAddr: globalVMAC,
+				})
+				mockNetlink.RouteReplace(&netlink.Route{
+					Dst: &net.IPNet{
+						IP:   config.VirtualServiceIPv4,
+						Mask: net.CIDRMask(32, 32),
+					},
+					Scope:     netlink.SCOPE_LINK,
+					LinkIndex: 10,
+				})
+				mockNetlink.RouteReplace(&netlink.Route{
+					Dst: &net.IPNet{
+						IP:   config.VirtualNodePortDNATIPv4,
+						Mask: net.CIDRMask(32, 32),
+					},
+					Gw:        config.VirtualServiceIPv4,
+					Scope:     netlink.SCOPE_UNIVERSE,
+					LinkIndex: 10,
+				})
+				mockNetlink.NeighSet(&netlink.Neigh{
+					LinkIndex:    10,
+					Family:       netlink.FAMILY_V6,
+					State:        netlink.NUD_PERMANENT,
+					IP:           config.VirtualServiceIPv6,
+					HardwareAddr: globalVMAC,
+				})
+				mockNetlink.RouteReplace(&netlink.Route{
+					Dst: &net.IPNet{
+						IP:   config.VirtualServiceIPv6,
+						Mask: net.CIDRMask(128, 128),
+					},
+					Scope:     netlink.SCOPE_LINK,
+					LinkIndex: 10,
+				})
+				mockNetlink.RouteReplace(&netlink.Route{
+					Dst: &net.IPNet{
+						IP:   config.VirtualNodePortDNATIPv6,
+						Mask: net.CIDRMask(128, 128),
+					},
+					Gw:        config.VirtualServiceIPv6,
+					Scope:     netlink.SCOPE_UNIVERSE,
+					LinkIndex: 10,
+				})
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			mockNetlink := netlinktest.NewMockInterface(ctrl)
+			c := &Client{netlink: mockNetlink,
+				networkConfig: tt.networkConfig,
+				nodeConfig:    tt.nodeConfig,
+			}
+			tt.expectedCalls(mockNetlink.EXPECT())
+			assert.NoError(t, c.initServiceIPRoutes())
+		})
+	}
+}
+
+func TestReconcile(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockNetlink := netlinktest.NewMockInterface(ctrl)
+	mockIPSet := ipsettest.NewMockInterface(ctrl)
+	c := &Client{netlink: mockNetlink,
+		ipset:         mockIPSet,
+		proxyAll:      true,
+		networkConfig: &config.NetworkConfig{},
+		nodeConfig: &config.NodeConfig{
+			PodIPv4CIDR:   ip.MustParseCIDR("192.168.10.0/24"),
+			PodIPv6CIDR:   ip.MustParseCIDR("2001:ab03:cd04:55ee:100a::/80"),
+			GatewayConfig: &config.GatewayConfig{LinkIndex: 10},
+		},
+	}
+	podCIDRs := []string{"192.168.0.0/24", "192.168.1.0/24", "2001:ab03:cd04:55ee:1001::/80", "2001:ab03:cd04:55ee:1002::/80"}
+
+	mockIPSet.EXPECT().ListEntries(antreaPodIPSet).Return([]string{
+		"192.168.0.0/24", // existing podCIDR, should not be deleted.
+		"192.168.2.0/24", // non-existing podCIDR, should be deleted.
+	}, nil)
+	mockIPSet.EXPECT().ListEntries(antreaPodIP6Set).Return([]string{
+		"2001:ab03:cd04:55ee:1001::/80", // existing podCIDR, should not be deleted.
+		"2001:ab03:cd04:55ee:1003::/80", // non-existing podCIDR, should be deleted.
+	}, nil)
+	mockIPSet.EXPECT().DelEntry(antreaPodIPSet, "192.168.2.0/24")
+	mockIPSet.EXPECT().DelEntry(antreaPodIP6Set, "2001:ab03:cd04:55ee:1003::/80")
+	mockNetlink.EXPECT().RouteDel(&netlink.Route{Dst: ip.MustParseCIDR("192.168.2.0/24")})
+	mockNetlink.EXPECT().RouteDel(&netlink.Route{Dst: ip.MustParseCIDR("2001:ab03:cd04:55ee:1003::/80")})
+
+	mockNetlink.EXPECT().RouteListFiltered(netlink.FAMILY_V4, &netlink.Route{LinkIndex: 10}, netlink.RT_FILTER_OIF).Return([]netlink.Route{
+		{Dst: ip.MustParseCIDR("192.168.10.0/24")},  // local podCIDR, should not be deleted.
+		{Dst: ip.MustParseCIDR("192.168.1.0/24")},   // existing podCIDR, should not be deleted.
+		{Dst: ip.MustParseCIDR("169.254.0.253/32")}, // service route, should not be deleted.
+		{Dst: ip.MustParseCIDR("192.168.11.0/24")},  // non-existing podCIDR, should be deleted.
+	}, nil)
+	mockNetlink.EXPECT().RouteListFiltered(netlink.FAMILY_V6, &netlink.Route{LinkIndex: 10}, netlink.RT_FILTER_OIF).Return([]netlink.Route{
+		{Dst: ip.MustParseCIDR("2001:ab03:cd04:55ee:100a::/80")},   // local podCIDR, should not be deleted.
+		{Dst: ip.MustParseCIDR("2001:ab03:cd04:55ee:1001::1/128")}, // existing podCIDR, should not be deleted.
+		{Dst: ip.MustParseCIDR("fc01::aabb:ccdd:eeff/128")},        // service route, should not be deleted.
+		{Dst: ip.MustParseCIDR("2001:ab03:cd04:55ee:100b::/80")},   // non-existing podCIDR, should be deleted.
+	}, nil)
+	mockNetlink.EXPECT().RouteDel(&netlink.Route{Dst: ip.MustParseCIDR("192.168.11.0/24")})
+	mockNetlink.EXPECT().RouteDel(&netlink.Route{Dst: ip.MustParseCIDR("2001:ab03:cd04:55ee:100b::/80")})
+
+	mockNetlink.EXPECT().NeighList(10, netlink.FAMILY_V6).Return([]netlink.Neigh{
+		{IP: net.ParseIP("2001:ab03:cd04:55ee:1001::1")}, // existing podCIDR, should not be deleted.
+		{IP: net.ParseIP("fc01::aabb:ccdd:eeff")},        // virtual service IP, should not be deleted.
+		{IP: net.ParseIP("2001:ab03:cd04:55ee:100b::1")}, // non-existing podCIDR, should be deleted.
+	}, nil)
+	mockNetlink.EXPECT().NeighDel(&netlink.Neigh{IP: net.ParseIP("2001:ab03:cd04:55ee:100b::1")})
+	assert.NoError(t, c.Reconcile(podCIDRs))
+}
+
+func TestAddRoutes(t *testing.T) {
+	ipv4, nodeTransPortIPv4Addr, _ := net.ParseCIDR("172.16.10.2/24")
+	nodeTransPortIPv4Addr.IP = ipv4
+	ipv6, nodeTransPortIPv6Addr, _ := net.ParseCIDR("fe80::e643:4bff:fe44:ee/64")
+	nodeTransPortIPv6Addr.IP = ipv6
+
+	tests := []struct {
+		name                 string
+		networkConfig        *config.NetworkConfig
+		nodeConfig           *config.NodeConfig
+		podCIDR              *net.IPNet
+		nodeName             string
+		nodeIP               net.IP
+		nodeGwIP             net.IP
+		expectedIPSetCalls   func(mockNetlink *ipsettest.MockInterfaceMockRecorder)
+		expectedNetlinkCalls func(mockNetlink *netlinktest.MockInterfaceMockRecorder)
+	}{
+		{
+			name: "wireGuard IPv4",
+			networkConfig: &config.NetworkConfig{
+				TrafficEncapMode:      config.TrafficEncapModeEncap,
+				TrafficEncryptionMode: config.TrafficEncryptionModeWireGuard,
+				IPv4Enabled:           true,
+			},
+			nodeConfig: &config.NodeConfig{
+				GatewayConfig: &config.GatewayConfig{
+					Name:      "antrea-gw0",
+					IPv4:      net.ParseIP("1.1.1.1"),
+					LinkIndex: 10,
+				},
+				WireGuardConfig:       &config.WireGuardConfig{LinkIndex: 11},
+				NodeTransportIPv4Addr: nodeTransPortIPv4Addr,
+			},
+			podCIDR:  ip.MustParseCIDR("192.168.10.0/24"),
+			nodeName: "node0",
+			nodeIP:   net.ParseIP("1.1.1.10"),
+			nodeGwIP: net.ParseIP("192.168.10.1"),
+			expectedIPSetCalls: func(mockIPSet *ipsettest.MockInterfaceMockRecorder) {
+				mockIPSet.AddEntry(antreaPodIPSet, "192.168.10.0/24")
+			},
+			expectedNetlinkCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
+				mockNetlink.RouteReplace(&netlink.Route{
+					Src:       net.ParseIP("1.1.1.1"),
+					Dst:       ip.MustParseCIDR("192.168.10.0/24"),
+					Scope:     netlink.SCOPE_LINK,
+					LinkIndex: 11,
+				})
+			},
+		},
+		{
+			name: "wireGuard IPv6",
+			networkConfig: &config.NetworkConfig{
+				TrafficEncapMode:      config.TrafficEncapModeEncap,
+				TrafficEncryptionMode: config.TrafficEncryptionModeWireGuard,
+				IPv6Enabled:           true,
+			},
+			nodeConfig: &config.NodeConfig{
+				GatewayConfig: &config.GatewayConfig{
+					Name:      "antrea-gw0",
+					IPv6:      net.ParseIP("fe80::e643:4bff:fe44:1"),
+					LinkIndex: 10,
+				},
+				WireGuardConfig:       &config.WireGuardConfig{LinkIndex: 11},
+				NodeTransportIPv6Addr: nodeTransPortIPv6Addr,
+			},
+			podCIDR:  ip.MustParseCIDR("2001:ab03:cd04:55ee:1001::/80"),
+			nodeName: "node0",
+			nodeIP:   net.ParseIP("fe80::e643:4bff:fe44:2"),
+			nodeGwIP: net.ParseIP("2001:ab03:cd04:55ee:1001::1"),
+			expectedIPSetCalls: func(mockIPSet *ipsettest.MockInterfaceMockRecorder) {
+				mockIPSet.AddEntry(antreaPodIP6Set, "2001:ab03:cd04:55ee:1001::/80")
+			},
+			expectedNetlinkCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
+				mockNetlink.RouteReplace(&netlink.Route{
+					Src:       net.ParseIP("fe80::e643:4bff:fe44:1"),
+					Dst:       ip.MustParseCIDR("2001:ab03:cd04:55ee:1001::/80"),
+					Scope:     netlink.SCOPE_LINK,
+					LinkIndex: 11,
+				})
+				mockNetlink.RouteDel(&netlink.Route{
+					Dst: &net.IPNet{IP: net.ParseIP("2001:ab03:cd04:55ee:1001::1"), Mask: net.CIDRMask(128, 128)},
+				})
+				mockNetlink.NeighDel(&netlink.Neigh{
+					LinkIndex: 10,
+					Family:    netlink.FAMILY_V6,
+					IP:        net.ParseIP("2001:ab03:cd04:55ee:1001::1"),
+				})
+			},
+		},
+		{
+			name: "encap IPv4",
+			networkConfig: &config.NetworkConfig{
+				TrafficEncapMode: config.TrafficEncapModeEncap,
+				IPv4Enabled:      true,
+			},
+			nodeConfig: &config.NodeConfig{
+				GatewayConfig: &config.GatewayConfig{
+					Name:      "antrea-gw0",
+					IPv4:      net.ParseIP("1.1.1.1"),
+					LinkIndex: 10,
+				},
+				NodeTransportIPv4Addr: nodeTransPortIPv4Addr,
+			},
+			podCIDR:  ip.MustParseCIDR("192.168.10.0/24"),
+			nodeName: "node0",
+			nodeIP:   net.ParseIP("1.1.1.10"),
+			nodeGwIP: net.ParseIP("192.168.10.1"),
+			expectedIPSetCalls: func(mockIPSet *ipsettest.MockInterfaceMockRecorder) {
+				mockIPSet.AddEntry(antreaPodIPSet, "192.168.10.0/24")
+			},
+			expectedNetlinkCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
+				mockNetlink.RouteReplace(&netlink.Route{
+					Gw:        net.ParseIP("192.168.10.1"),
+					Dst:       ip.MustParseCIDR("192.168.10.0/24"),
+					Flags:     int(netlink.FLAG_ONLINK),
+					LinkIndex: 10,
+				})
+			},
+		},
+		{
+			name: "encap IPv6",
+			networkConfig: &config.NetworkConfig{
+				TrafficEncapMode: config.TrafficEncapModeEncap,
+				IPv6Enabled:      true,
+			},
+			nodeConfig: &config.NodeConfig{
+				GatewayConfig: &config.GatewayConfig{
+					Name:      "antrea-gw0",
+					IPv6:      net.ParseIP("fe80::e643:4bff:fe44:1"),
+					LinkIndex: 10,
+				},
+				NodeTransportIPv6Addr: nodeTransPortIPv6Addr,
+			},
+			podCIDR:  ip.MustParseCIDR("2001:ab03:cd04:55ee:1001::/80"),
+			nodeName: "node0",
+			nodeIP:   net.ParseIP("fe80::e643:4bff:fe44:2"),
+			nodeGwIP: net.ParseIP("2001:ab03:cd04:55ee:1001::1"),
+			expectedIPSetCalls: func(mockIPSet *ipsettest.MockInterfaceMockRecorder) {
+				mockIPSet.AddEntry(antreaPodIP6Set, "2001:ab03:cd04:55ee:1001::/80")
+			},
+			expectedNetlinkCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
+				mockNetlink.RouteReplace(&netlink.Route{
+					Dst:       ip.MustParseCIDR("2001:ab03:cd04:55ee:1001::1/128"),
+					LinkIndex: 10,
+				})
+				mockNetlink.RouteReplace(&netlink.Route{
+					Gw:        net.ParseIP("2001:ab03:cd04:55ee:1001::1"),
+					Dst:       ip.MustParseCIDR("2001:ab03:cd04:55ee:1001::/80"),
+					LinkIndex: 10,
+				})
+				mockNetlink.NeighSet(&netlink.Neigh{
+					LinkIndex:    10,
+					Family:       netlink.FAMILY_V6,
+					State:        netlink.NUD_PERMANENT,
+					IP:           net.ParseIP("2001:ab03:cd04:55ee:1001::1"),
+					HardwareAddr: globalVMAC,
+				})
+			},
+		},
+		{
+			name: "noencap IPv4, direct routing",
+			networkConfig: &config.NetworkConfig{
+				TrafficEncapMode: config.TrafficEncapModeNoEncap,
+				IPv4Enabled:      true,
+			},
+			nodeConfig: &config.NodeConfig{
+				GatewayConfig: &config.GatewayConfig{
+					Name:      "antrea-gw0",
+					IPv4:      net.ParseIP("192.168.1.1"),
+					LinkIndex: 10,
+				},
+				NodeTransportIPv4Addr: nodeTransPortIPv4Addr,
+			},
+			podCIDR:  ip.MustParseCIDR("192.168.10.0/24"),
+			nodeName: "node0",
+			nodeIP:   net.ParseIP("172.16.10.3"), // In the same subnet as local Node IP.
+			nodeGwIP: net.ParseIP("192.168.10.1"),
+			expectedIPSetCalls: func(mockIPSet *ipsettest.MockInterfaceMockRecorder) {
+				mockIPSet.AddEntry(antreaPodIPSet, "192.168.10.0/24")
+			},
+			expectedNetlinkCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
+				mockNetlink.RouteReplace(&netlink.Route{
+					Gw:  net.ParseIP("172.16.10.3"),
+					Dst: ip.MustParseCIDR("192.168.10.0/24"),
+				})
+			},
+		},
+		{
+			name: "noencap IPv4, no direct routing",
+			networkConfig: &config.NetworkConfig{
+				TrafficEncapMode: config.TrafficEncapModeNoEncap,
+				IPv4Enabled:      true,
+			},
+			nodeConfig: &config.NodeConfig{
+				GatewayConfig: &config.GatewayConfig{
+					Name:      "antrea-gw0",
+					IPv4:      net.ParseIP("192.168.1.1"),
+					LinkIndex: 10,
+				},
+				NodeTransportIPv4Addr: nodeTransPortIPv4Addr,
+			},
+			podCIDR:  ip.MustParseCIDR("192.168.10.0/24"),
+			nodeName: "node0",
+			nodeIP:   net.ParseIP("172.16.11.3"), // In different subnet from local Node IP.
+			nodeGwIP: net.ParseIP("192.168.10.1"),
+			expectedIPSetCalls: func(mockIPSet *ipsettest.MockInterfaceMockRecorder) {
+				mockIPSet.AddEntry(antreaPodIPSet, "192.168.10.0/24")
+			},
+			expectedNetlinkCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			mockNetlink := netlinktest.NewMockInterface(ctrl)
+			mockIPSet := ipsettest.NewMockInterface(ctrl)
+			c := &Client{netlink: mockNetlink,
+				ipset:         mockIPSet,
+				networkConfig: tt.networkConfig,
+				nodeConfig:    tt.nodeConfig,
+			}
+			tt.expectedIPSetCalls(mockIPSet.EXPECT())
+			tt.expectedNetlinkCalls(mockNetlink.EXPECT())
+			assert.NoError(t, c.AddRoutes(tt.podCIDR, tt.nodeName, tt.nodeIP, tt.nodeGwIP))
+		})
+	}
+}
+
+func TestDeleteRoutes(t *testing.T) {
+	tests := []struct {
+		name                  string
+		networkConfig         *config.NetworkConfig
+		nodeConfig            *config.NodeConfig
+		podCIDR               *net.IPNet
+		existingNodeRoutes    map[string][]*netlink.Route
+		existingNodeNeighbors map[string]*netlink.Neigh
+		nodeName              string
+		expectedIPSetCalls    func(mockNetlink *ipsettest.MockInterfaceMockRecorder)
+		expectedNetlinkCalls  func(mockNetlink *netlinktest.MockInterfaceMockRecorder)
+	}{
+		{
+			name:    "IPv4",
+			podCIDR: ip.MustParseCIDR("192.168.10.0/24"),
+			existingNodeRoutes: map[string][]*netlink.Route{
+				"192.168.10.0/24": {{Gw: net.ParseIP("172.16.10.3"), Dst: ip.MustParseCIDR("192.168.10.0/24")}},
+				"192.168.11.0/24": {{Gw: net.ParseIP("172.16.10.4"), Dst: ip.MustParseCIDR("192.168.11.0/24")}},
+			},
+			expectedIPSetCalls: func(mockIPSet *ipsettest.MockInterfaceMockRecorder) {
+				mockIPSet.DelEntry(antreaPodIPSet, "192.168.10.0/24")
+			},
+			expectedNetlinkCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
+				mockNetlink.RouteDel(&netlink.Route{Gw: net.ParseIP("172.16.10.3"), Dst: ip.MustParseCIDR("192.168.10.0/24")})
+			},
+		},
+		{
+			name:    "IPv6",
+			podCIDR: ip.MustParseCIDR("2001:ab03:cd04:55ee:1001::/80"),
+			existingNodeRoutes: map[string][]*netlink.Route{
+				"2001:ab03:cd04:55ee:1001::/80": {{Gw: net.ParseIP("fe80::e643:4bff:fe44:1"), Dst: ip.MustParseCIDR("2001:ab03:cd04:55ee:1001::/80")}},
+				"2001:ab03:cd04:55ee:1002::/80": {{Gw: net.ParseIP("fe80::e643:4bff:fe44:2"), Dst: ip.MustParseCIDR("2001:ab03:cd04:55ee:1002::/80")}},
+			},
+			existingNodeNeighbors: map[string]*netlink.Neigh{},
+			expectedIPSetCalls: func(mockIPSet *ipsettest.MockInterfaceMockRecorder) {
+				mockIPSet.DelEntry(antreaPodIP6Set, "2001:ab03:cd04:55ee:1001::/80")
+			},
+			expectedNetlinkCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
+				mockNetlink.RouteDel(&netlink.Route{Gw: net.ParseIP("fe80::e643:4bff:fe44:1"), Dst: ip.MustParseCIDR("2001:ab03:cd04:55ee:1001::/80")})
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			mockNetlink := netlinktest.NewMockInterface(ctrl)
+			mockIPSet := ipsettest.NewMockInterface(ctrl)
+			c := &Client{netlink: mockNetlink,
+				ipset:         mockIPSet,
+				networkConfig: tt.networkConfig,
+				nodeConfig:    tt.nodeConfig,
+				nodeRoutes:    sync.Map{},
+				nodeNeighbors: sync.Map{},
+			}
+			for podCIDR, nodeRoute := range tt.existingNodeRoutes {
+				c.nodeRoutes.Store(podCIDR, nodeRoute)
+			}
+			for podCIDR, nodeNeighbor := range tt.existingNodeNeighbors {
+				c.nodeNeighbors.Store(podCIDR, nodeNeighbor)
+			}
+			tt.expectedIPSetCalls(mockIPSet.EXPECT())
+			tt.expectedNetlinkCalls(mockNetlink.EXPECT())
+			assert.NoError(t, c.DeleteRoutes(tt.podCIDR))
+		})
+	}
+}
+
+func TestMigrateRoutesToGw(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockNetlink := netlinktest.NewMockInterface(ctrl)
+	mockIPSet := ipsettest.NewMockInterface(ctrl)
+
+	gwLinkName := "antrea-gw0"
+	gwLink := &netlink.Device{LinkAttrs: netlink.LinkAttrs{Index: 11}}
+	linkName := "eth0"
+	link := &netlink.Device{LinkAttrs: netlink.LinkAttrs{Index: 10}}
+	linkAddr1, _ := netlink.ParseAddr("192.168.10.1/32")
+	linkAddr2, _ := netlink.ParseAddr("169.254.0.2/32") // LinkLocalUnicast address should not be migrated.
+	linkAddr3, _ := netlink.ParseAddr("2001:ab03:cd04:55ee:1001::1/80")
+	linkAddr4, _ := netlink.ParseAddr("fe80:ab03:cd04:55ee:1001::1/80") // LinkLocalUnicast address should not be migrated.
+
+	mockNetlink.EXPECT().LinkByName(gwLinkName).Return(gwLink, nil)
+	mockNetlink.EXPECT().LinkByName(linkName).Return(link, nil)
+	mockNetlink.EXPECT().RouteList(link, netlink.FAMILY_V4).Return([]netlink.Route{
+		{Gw: net.ParseIP("172.16.1.10"), Dst: ip.MustParseCIDR("192.168.10.0/24"), LinkIndex: 10},
+	}, nil)
+	mockNetlink.EXPECT().RouteList(link, netlink.FAMILY_V6).Return([]netlink.Route{
+		{Gw: net.ParseIP("fe80::e643:4bff:fe44:1"), Dst: ip.MustParseCIDR("2001:ab03:cd04:55ee:1001::/80"), LinkIndex: 10},
+	}, nil)
+	mockNetlink.EXPECT().RouteReplace(&netlink.Route{Gw: net.ParseIP("172.16.1.10"), Dst: ip.MustParseCIDR("192.168.10.0/24"), LinkIndex: 11})
+	mockNetlink.EXPECT().RouteReplace(&netlink.Route{Gw: net.ParseIP("fe80::e643:4bff:fe44:1"), Dst: ip.MustParseCIDR("2001:ab03:cd04:55ee:1001::/80"), LinkIndex: 11})
+	mockNetlink.EXPECT().AddrList(link, netlink.FAMILY_V4).Return([]netlink.Addr{*linkAddr1, *linkAddr2}, nil)
+	mockNetlink.EXPECT().AddrList(link, netlink.FAMILY_V6).Return([]netlink.Addr{*linkAddr3, *linkAddr4}, nil)
+	mockNetlink.EXPECT().AddrDel(link, linkAddr1)
+	mockNetlink.EXPECT().AddrReplace(gwLink, linkAddr1)
+	mockNetlink.EXPECT().AddrDel(link, linkAddr3)
+	mockNetlink.EXPECT().AddrReplace(gwLink, linkAddr3)
+
+	c := &Client{
+		netlink: mockNetlink,
+		ipset:   mockIPSet,
+		nodeConfig: &config.NodeConfig{
+			GatewayConfig: &config.GatewayConfig{Name: gwLinkName},
+		},
+	}
+	c.MigrateRoutesToGw(linkName)
+}
+
+func TestUnMigrateRoutesToGw(t *testing.T) {
+	gwLink := &netlink.Device{LinkAttrs: netlink.LinkAttrs{Index: 11}}
+	link := &netlink.Device{LinkAttrs: netlink.LinkAttrs{Index: 10}}
+	tests := []struct {
+		name          string
+		nodeConfig    *config.NodeConfig
+		route         string
+		link          string
+		expectedCalls func(mockNetlink *netlinktest.MockInterfaceMockRecorder)
+	}{
+		{
+			name:       "link provided",
+			route:      "192.168.10.0/24",
+			link:       "eth0",
+			nodeConfig: &config.NodeConfig{GatewayConfig: &config.GatewayConfig{Name: "antrea-gw0"}},
+			expectedCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
+				mockNetlink.LinkByName("antrea-gw0").Return(gwLink, nil)
+				mockNetlink.LinkByName("eth0").Return(link, nil)
+				mockNetlink.RouteList(gwLink, netlink.FAMILY_V4).Return([]netlink.Route{
+					{Gw: net.ParseIP("172.16.1.10"), Dst: ip.MustParseCIDR("192.168.10.0/24"), LinkIndex: 11},
+				}, nil)
+				mockNetlink.RouteReplace(&netlink.Route{Gw: net.ParseIP("172.16.1.10"), Dst: ip.MustParseCIDR("192.168.10.0/24"), LinkIndex: 10})
+			},
+		},
+		{
+			name:       "link not provided",
+			route:      "192.168.10.0/24",
+			link:       "",
+			nodeConfig: &config.NodeConfig{GatewayConfig: &config.GatewayConfig{Name: "antrea-gw0"}},
+			expectedCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
+				mockNetlink.LinkByName("antrea-gw0").Return(gwLink, nil)
+				mockNetlink.RouteList(gwLink, netlink.FAMILY_V4).Return([]netlink.Route{
+					{Gw: net.ParseIP("172.16.1.10"), Dst: ip.MustParseCIDR("192.168.10.0/24"), LinkIndex: 11},
+				}, nil)
+				mockNetlink.RouteDel(&netlink.Route{Gw: net.ParseIP("172.16.1.10"), Dst: ip.MustParseCIDR("192.168.10.0/24"), LinkIndex: 11})
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			mockNetlink := netlinktest.NewMockInterface(ctrl)
+			c := &Client{
+				netlink:    mockNetlink,
+				nodeConfig: tt.nodeConfig,
+			}
+			tt.expectedCalls(mockNetlink.EXPECT())
+			c.UnMigrateRoutesFromGw(ip.MustParseCIDR(tt.route), tt.link)
+		})
+	}
+}
+
+func TestAddSNATRule(t *testing.T) {
+	tests := []struct {
+		name          string
+		networkConfig *config.NetworkConfig
+		nodeConfig    *config.NodeConfig
+		snatIP        net.IP
+		mark          uint32
+		expectedCalls func(mockIPTables *iptablestest.MockInterfaceMockRecorder)
+	}{
+		{
+			name: "IPv4",
+			nodeConfig: &config.NodeConfig{
+				GatewayConfig: &config.GatewayConfig{
+					Name: "antrea-gw0",
+				},
+			},
+			snatIP: net.ParseIP("1.1.1.1"),
+			mark:   10,
+			expectedCalls: func(mockIPTables *iptablestest.MockInterfaceMockRecorder) {
+				mockIPTables.InsertRule(iptables.ProtocolIPv4, iptables.NATTable, antreaPostRoutingChain, []string{
+					"-m", "comment", "--comment", "Antrea: SNAT Pod to external packets",
+					"!", "-o", "antrea-gw0",
+					"-m", "mark", "--mark", fmt.Sprintf("%#08x/%#08x", 10, types.SNATIPMarkMask),
+					"-j", iptables.SNATTarget, "--to", "1.1.1.1",
+				})
+			},
+		},
+		{
+			name: "IPv6",
+			nodeConfig: &config.NodeConfig{
+				GatewayConfig: &config.GatewayConfig{
+					Name: "antrea-gw0",
+				},
+			},
+			snatIP: net.ParseIP("fe80::e643:4bff:fe44:1"),
+			mark:   11,
+			expectedCalls: func(mockIPTables *iptablestest.MockInterfaceMockRecorder) {
+				mockIPTables.InsertRule(iptables.ProtocolIPv6, iptables.NATTable, antreaPostRoutingChain, []string{
+					"-m", "comment", "--comment", "Antrea: SNAT Pod to external packets",
+					"!", "-o", "antrea-gw0",
+					"-m", "mark", "--mark", fmt.Sprintf("%#08x/%#08x", 11, types.SNATIPMarkMask),
+					"-j", iptables.SNATTarget, "--to", "fe80::e643:4bff:fe44:1",
+				})
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			mockIPTables := iptablestest.NewMockInterface(ctrl)
+			c := &Client{ipt: mockIPTables,
+				nodeConfig: tt.nodeConfig,
+			}
+			tt.expectedCalls(mockIPTables.EXPECT())
+			assert.NoError(t, c.AddSNATRule(tt.snatIP, tt.mark))
+		})
+	}
+}
+
+func TestDeleteSNATRule(t *testing.T) {
+	tests := []struct {
+		name          string
+		networkConfig *config.NetworkConfig
+		markToSNATIP  map[uint32]net.IP
+		nodeConfig    *config.NodeConfig
+		mark          uint32
+		expectedCalls func(mockIPTables *iptablestest.MockInterfaceMockRecorder)
+	}{
+		{
+			name: "IPv4",
+			nodeConfig: &config.NodeConfig{
+				GatewayConfig: &config.GatewayConfig{
+					Name: "antrea-gw0",
+				},
+			},
+			markToSNATIP: map[uint32]net.IP{
+				10: net.ParseIP("1.1.1.1"),
+				11: net.ParseIP("1.1.1.2"),
+			},
+			mark: 10,
+			expectedCalls: func(mockIPTables *iptablestest.MockInterfaceMockRecorder) {
+				mockIPTables.DeleteRule(iptables.ProtocolIPv4, iptables.NATTable, antreaPostRoutingChain, []string{
+					"-m", "comment", "--comment", "Antrea: SNAT Pod to external packets",
+					"!", "-o", "antrea-gw0",
+					"-m", "mark", "--mark", fmt.Sprintf("%#08x/%#08x", 10, types.SNATIPMarkMask),
+					"-j", iptables.SNATTarget, "--to", "1.1.1.1",
+				})
+			},
+		},
+		{
+			name: "IPv6",
+			nodeConfig: &config.NodeConfig{
+				GatewayConfig: &config.GatewayConfig{
+					Name: "antrea-gw0",
+				},
+			},
+			markToSNATIP: map[uint32]net.IP{
+				10: net.ParseIP("fe80::e643:4bff:fe44:1"),
+				11: net.ParseIP("fe80::e643:4bff:fe44:2"),
+			},
+			mark: 11,
+			expectedCalls: func(mockIPTables *iptablestest.MockInterfaceMockRecorder) {
+				mockIPTables.DeleteRule(iptables.ProtocolIPv6, iptables.NATTable, antreaPostRoutingChain, []string{
+					"-m", "comment", "--comment", "Antrea: SNAT Pod to external packets",
+					"!", "-o", "antrea-gw0",
+					"-m", "mark", "--mark", fmt.Sprintf("%#08x/%#08x", 11, types.SNATIPMarkMask),
+					"-j", iptables.SNATTarget, "--to", "fe80::e643:4bff:fe44:2",
+				})
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			mockIPTables := iptablestest.NewMockInterface(ctrl)
+			c := &Client{
+				ipt:          mockIPTables,
+				nodeConfig:   tt.nodeConfig,
+				markToSNATIP: sync.Map{},
+			}
+			for mark, snatIP := range tt.markToSNATIP {
+				c.markToSNATIP.Store(mark, snatIP)
+			}
+			tt.expectedCalls(mockIPTables.EXPECT())
+			assert.NoError(t, c.DeleteSNATRule(tt.mark))
+		})
+	}
+}
+
+func TestAddNodePort(t *testing.T) {
+	tests := []struct {
+		name              string
+		nodePortAddresses []net.IP
+		port              uint16
+		protocol          openflow.Protocol
+		expectedCalls     func(ipset *ipsettest.MockInterfaceMockRecorder)
+	}{
+		{
+			name: "ipv4 tcp",
+			nodePortAddresses: []net.IP{
+				net.ParseIP("1.1.1.1"),
+				net.ParseIP("1.1.2.2"),
+			},
+			port:     30000,
+			protocol: openflow.ProtocolTCP,
+			expectedCalls: func(ipset *ipsettest.MockInterfaceMockRecorder) {
+				ipset.AddEntry(antreaNodePortIPSet, "1.1.1.1,tcp:30000")
+				ipset.AddEntry(antreaNodePortIPSet, "1.1.2.2,tcp:30000")
+			},
+		},
+		{
+			name: "ipv6 udp",
+			nodePortAddresses: []net.IP{
+				net.ParseIP("fd00:1234:5678:dead:beaf::1"),
+				net.ParseIP("fd00:1234:5678:dead:beaf::2"),
+			},
+			port:     30001,
+			protocol: openflow.ProtocolUDPv6,
+			expectedCalls: func(ipset *ipsettest.MockInterfaceMockRecorder) {
+				ipset.AddEntry(antreaNodePortIP6Set, "fd00:1234:5678:dead:beaf::1,udp:30001")
+				ipset.AddEntry(antreaNodePortIP6Set, "fd00:1234:5678:dead:beaf::2,udp:30001")
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			ipset := ipsettest.NewMockInterface(ctrl)
+			c := &Client{ipset: ipset}
+			tt.expectedCalls(ipset.EXPECT())
+			assert.NoError(t, c.AddNodePort(tt.nodePortAddresses, tt.port, tt.protocol))
+		})
+	}
+}
+
+func TestDeleteNodePort(t *testing.T) {
+	tests := []struct {
+		name              string
+		nodePortAddresses []net.IP
+		port              uint16
+		protocol          openflow.Protocol
+		expectedCalls     func(ipset *ipsettest.MockInterfaceMockRecorder)
+	}{
+		{
+			name: "ipv4 tcp",
+			nodePortAddresses: []net.IP{
+				net.ParseIP("1.1.1.1"),
+				net.ParseIP("1.1.2.2"),
+			},
+			port:     30000,
+			protocol: openflow.ProtocolTCP,
+			expectedCalls: func(ipset *ipsettest.MockInterfaceMockRecorder) {
+				ipset.DelEntry(antreaNodePortIPSet, "1.1.1.1,tcp:30000")
+				ipset.DelEntry(antreaNodePortIPSet, "1.1.2.2,tcp:30000")
+			},
+		},
+		{
+			name: "ipv6 udp",
+			nodePortAddresses: []net.IP{
+				net.ParseIP("fd00:1234:5678:dead:beaf::1"),
+				net.ParseIP("fd00:1234:5678:dead:beaf::2"),
+			},
+			port:     30001,
+			protocol: openflow.ProtocolUDPv6,
+			expectedCalls: func(ipset *ipsettest.MockInterfaceMockRecorder) {
+				ipset.DelEntry(antreaNodePortIP6Set, "fd00:1234:5678:dead:beaf::1,udp:30001")
+				ipset.DelEntry(antreaNodePortIP6Set, "fd00:1234:5678:dead:beaf::2,udp:30001")
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			ipset := ipsettest.NewMockInterface(ctrl)
+			c := &Client{ipset: ipset}
+			tt.expectedCalls(ipset.EXPECT())
+			assert.NoError(t, c.DeleteNodePort(tt.nodePortAddresses, tt.port, tt.protocol))
+		})
+	}
+}
+
+func TestAddClusterIPRoute(t *testing.T) {
+	nodeConfig := &config.NodeConfig{GatewayConfig: &config.GatewayConfig{LinkIndex: 10}}
+	tests := []struct {
+		name          string
+		clusterIPs    []string
+		expectedCalls func(mockNetlink *netlinktest.MockInterfaceMockRecorder)
+	}{
+		{
+			name:       "IPv4",
+			clusterIPs: []string{"10.96.0.1", "10.96.0.10"},
+			expectedCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
+				mockNetlink.RouteReplace(&netlink.Route{
+					Dst:       &net.IPNet{IP: net.ParseIP("10.96.0.1"), Mask: net.CIDRMask(32, 32)},
+					Gw:        config.VirtualServiceIPv4,
+					Scope:     netlink.SCOPE_UNIVERSE,
+					LinkIndex: 10,
+				})
+				mockNetlink.RouteListFiltered(netlink.FAMILY_V4, &netlink.Route{LinkIndex: 10}, netlink.RT_FILTER_OIF).Return([]netlink.Route{
+					{Dst: ip.MustParseCIDR("10.96.0.0/24"), Gw: config.VirtualServiceIPv4},
+				}, nil)
+				mockNetlink.RouteListFiltered(netlink.FAMILY_V6, &netlink.Route{LinkIndex: 10}, netlink.RT_FILTER_OIF).Return([]netlink.Route{}, nil)
+				mockNetlink.RouteDel(&netlink.Route{
+					Dst: ip.MustParseCIDR("10.96.0.0/24"), Gw: config.VirtualServiceIPv4,
+				})
+				mockNetlink.RouteReplace(&netlink.Route{
+					Dst:       &net.IPNet{IP: net.ParseIP("10.96.0.0").To4(), Mask: net.CIDRMask(28, 32)},
+					Gw:        config.VirtualServiceIPv4,
+					Scope:     netlink.SCOPE_UNIVERSE,
+					LinkIndex: 10,
+				})
+				mockNetlink.RouteDel(&netlink.Route{
+					Dst:       &net.IPNet{IP: net.ParseIP("10.96.0.1"), Mask: net.CIDRMask(32, 32)},
+					Gw:        config.VirtualServiceIPv4,
+					Scope:     netlink.SCOPE_UNIVERSE,
+					LinkIndex: 10,
+				})
+			},
+		},
+		{
+			name:       "IPv6",
+			clusterIPs: []string{"fd00:1234:5678:dead:beaf::1", "fd00:1234:5678:dead:beaf::a"},
+			expectedCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
+				mockNetlink.RouteReplace(&netlink.Route{
+					Dst:       &net.IPNet{IP: net.ParseIP("fd00:1234:5678:dead:beaf::1"), Mask: net.CIDRMask(128, 128)},
+					Gw:        config.VirtualServiceIPv6,
+					Scope:     netlink.SCOPE_UNIVERSE,
+					LinkIndex: 10,
+				})
+				mockNetlink.RouteListFiltered(netlink.FAMILY_V4, &netlink.Route{LinkIndex: 10}, netlink.RT_FILTER_OIF).Return([]netlink.Route{}, nil)
+				mockNetlink.RouteListFiltered(netlink.FAMILY_V6, &netlink.Route{LinkIndex: 10}, netlink.RT_FILTER_OIF).Return([]netlink.Route{
+					{Dst: ip.MustParseCIDR("fd00:1234:5678:dead:beaf::/80"), Gw: config.VirtualServiceIPv6},
+				}, nil)
+				mockNetlink.RouteDel(&netlink.Route{
+					Dst: ip.MustParseCIDR("fd00:1234:5678:dead:beaf::/80"), Gw: config.VirtualServiceIPv6,
+				})
+				mockNetlink.RouteReplace(&netlink.Route{
+					Dst:       &net.IPNet{IP: net.ParseIP("fd00:1234:5678:dead:beaf::"), Mask: net.CIDRMask(124, 128)},
+					Gw:        config.VirtualServiceIPv6,
+					Scope:     netlink.SCOPE_UNIVERSE,
+					LinkIndex: 10,
+				})
+				mockNetlink.RouteDel(&netlink.Route{
+					Dst:       &net.IPNet{IP: net.ParseIP("fd00:1234:5678:dead:beaf::1"), Mask: net.CIDRMask(128, 128)},
+					Gw:        config.VirtualServiceIPv6,
+					Scope:     netlink.SCOPE_UNIVERSE,
+					LinkIndex: 10,
+				})
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			mockNetlink := netlinktest.NewMockInterface(ctrl)
+			c := &Client{
+				netlink:    mockNetlink,
+				nodeConfig: nodeConfig,
+			}
+			tt.expectedCalls(mockNetlink.EXPECT())
+
+			for _, clusterIP := range tt.clusterIPs {
+				assert.NoError(t, c.AddClusterIPRoute(net.ParseIP(clusterIP)))
+			}
+		})
+	}
+}
+
+func TestAddLoadBalancer(t *testing.T) {
+	nodeConfig := &config.NodeConfig{GatewayConfig: &config.GatewayConfig{LinkIndex: 10}}
+	tests := []struct {
+		name          string
+		externalIPs   []string
+		expectedCalls func(mockNetlink *netlinktest.MockInterfaceMockRecorder)
+	}{
+		{
+			name:        "IPv4",
+			externalIPs: []string{"1.1.1.1", "1.1.1.2"},
+			expectedCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
+				mockNetlink.RouteReplace(&netlink.Route{
+					Dst: &net.IPNet{
+						IP:   net.ParseIP("1.1.1.1"),
+						Mask: net.CIDRMask(32, 32),
+					},
+					Gw:        config.VirtualServiceIPv4,
+					Scope:     netlink.SCOPE_UNIVERSE,
+					LinkIndex: 10,
+				})
+				mockNetlink.RouteReplace(&netlink.Route{
+					Dst: &net.IPNet{
+						IP:   net.ParseIP("1.1.1.2"),
+						Mask: net.CIDRMask(32, 32),
+					},
+					Gw:        config.VirtualServiceIPv4,
+					Scope:     netlink.SCOPE_UNIVERSE,
+					LinkIndex: 10,
+				})
+			},
+		},
+		{
+			name:        "IPv6",
+			externalIPs: []string{"fd00:1234:5678:dead:beaf::1", "fd00:1234:5678:dead:beaf::a"},
+			expectedCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
+				mockNetlink.RouteReplace(&netlink.Route{
+					Dst:       &net.IPNet{IP: net.ParseIP("fd00:1234:5678:dead:beaf::1"), Mask: net.CIDRMask(128, 128)},
+					Gw:        config.VirtualServiceIPv6,
+					Scope:     netlink.SCOPE_UNIVERSE,
+					LinkIndex: 10,
+				})
+				mockNetlink.RouteReplace(&netlink.Route{
+					Dst:       &net.IPNet{IP: net.ParseIP("fd00:1234:5678:dead:beaf::a"), Mask: net.CIDRMask(128, 128)},
+					Gw:        config.VirtualServiceIPv6,
+					Scope:     netlink.SCOPE_UNIVERSE,
+					LinkIndex: 10,
+				})
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			mockNetlink := netlinktest.NewMockInterface(ctrl)
+			c := &Client{
+				netlink:    mockNetlink,
+				nodeConfig: nodeConfig,
+			}
+			tt.expectedCalls(mockNetlink.EXPECT())
+
+			assert.NoError(t, c.AddLoadBalancer(tt.externalIPs))
+		})
+	}
+}
+
+func TestDeleteLoadBalancer(t *testing.T) {
+	nodeConfig := &config.NodeConfig{GatewayConfig: &config.GatewayConfig{LinkIndex: 10}}
+	tests := []struct {
+		name          string
+		externalIPs   []string
+		expectedCalls func(mockNetlink *netlinktest.MockInterfaceMockRecorder)
+	}{
+		{
+			name:        "IPv4",
+			externalIPs: []string{"1.1.1.1", "1.1.1.2"},
+			expectedCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
+				mockNetlink.RouteDel(&netlink.Route{
+					Dst: &net.IPNet{
+						IP:   net.ParseIP("1.1.1.1"),
+						Mask: net.CIDRMask(32, 32),
+					},
+					Gw:        config.VirtualServiceIPv4,
+					Scope:     netlink.SCOPE_UNIVERSE,
+					LinkIndex: 10,
+				})
+				mockNetlink.RouteDel(&netlink.Route{
+					Dst: &net.IPNet{
+						IP:   net.ParseIP("1.1.1.2"),
+						Mask: net.CIDRMask(32, 32),
+					},
+					Gw:        config.VirtualServiceIPv4,
+					Scope:     netlink.SCOPE_UNIVERSE,
+					LinkIndex: 10,
+				})
+			},
+		},
+		{
+			name:        "IPv6",
+			externalIPs: []string{"fd00:1234:5678:dead:beaf::1", "fd00:1234:5678:dead:beaf::a"},
+			expectedCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
+				mockNetlink.RouteDel(&netlink.Route{
+					Dst:       &net.IPNet{IP: net.ParseIP("fd00:1234:5678:dead:beaf::1"), Mask: net.CIDRMask(128, 128)},
+					Gw:        config.VirtualServiceIPv6,
+					Scope:     netlink.SCOPE_UNIVERSE,
+					LinkIndex: 10,
+				})
+				mockNetlink.RouteDel(&netlink.Route{
+					Dst:       &net.IPNet{IP: net.ParseIP("fd00:1234:5678:dead:beaf::a"), Mask: net.CIDRMask(128, 128)},
+					Gw:        config.VirtualServiceIPv6,
+					Scope:     netlink.SCOPE_UNIVERSE,
+					LinkIndex: 10,
+				})
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			mockNetlink := netlinktest.NewMockInterface(ctrl)
+			c := &Client{
+				netlink:    mockNetlink,
+				nodeConfig: nodeConfig,
+			}
+			tt.expectedCalls(mockNetlink.EXPECT())
+
+			assert.NoError(t, c.DeleteLoadBalancer(tt.externalIPs))
+		})
+	}
+}
+
+func TestAddLocalAntreaFlexibleIPAMPodRule(t *testing.T) {
+	tests := []struct {
+		name                  string
+		nodeConfig            *config.NodeConfig
+		connectUplinkToBridge bool
+		podAddresses          []net.IP
+		expectedCalls         func(mockIPSet *ipsettest.MockInterfaceMockRecorder)
+	}{
+		{
+			name: "connectUplinkToBridge=false",
+			nodeConfig: &config.NodeConfig{
+				PodIPv4CIDR: ip.MustParseCIDR("1.1.1.0/24"),
+				PodIPv6CIDR: ip.MustParseCIDR("aabb::/64"),
+			},
+			connectUplinkToBridge: false,
+			podAddresses:          []net.IP{net.ParseIP("1.1.1.1"), net.ParseIP("aabb::1")},
+			expectedCalls:         func(mockIPSet *ipsettest.MockInterfaceMockRecorder) {},
+		},
+		{
+			name: "connectUplinkToBridge=true,nodeIPAMPod",
+			nodeConfig: &config.NodeConfig{
+				PodIPv4CIDR: ip.MustParseCIDR("1.1.1.0/24"),
+				PodIPv6CIDR: ip.MustParseCIDR("aabb::/64"),
+			},
+			connectUplinkToBridge: false,
+			podAddresses:          []net.IP{net.ParseIP("1.1.1.1"), net.ParseIP("aabb::1")},
+			expectedCalls:         func(mockIPSet *ipsettest.MockInterfaceMockRecorder) {},
+		},
+		{
+			name: "connectUplinkToBridge=true,antreaIPAMPod",
+			nodeConfig: &config.NodeConfig{
+				PodIPv4CIDR: ip.MustParseCIDR("1.1.1.0/24"),
+				PodIPv6CIDR: ip.MustParseCIDR("aabb::/64"),
+			},
+			connectUplinkToBridge: true,
+			podAddresses:          []net.IP{net.ParseIP("1.1.2.1"), net.ParseIP("aabc::1")},
+			expectedCalls: func(mockIPSet *ipsettest.MockInterfaceMockRecorder) {
+				mockIPSet.AddEntry(localAntreaFlexibleIPAMPodIPSet, "1.1.2.1")
+				mockIPSet.AddEntry(localAntreaFlexibleIPAMPodIP6Set, "aabc::1")
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			mockIPSet := ipsettest.NewMockInterface(ctrl)
+			c := &Client{
+				ipset:                 mockIPSet,
+				nodeConfig:            tt.nodeConfig,
+				connectUplinkToBridge: tt.connectUplinkToBridge,
+			}
+			tt.expectedCalls(mockIPSet.EXPECT())
+
+			assert.NoError(t, c.AddLocalAntreaFlexibleIPAMPodRule(tt.podAddresses))
+		})
+	}
+}
+
+func TestDeleteLocalAntreaFlexibleIPAMPodRule(t *testing.T) {
+	nodeConfig := &config.NodeConfig{GatewayConfig: &config.GatewayConfig{LinkIndex: 10}}
+	tests := []struct {
+		name                  string
+		connectUplinkToBridge bool
+		podAddresses          []net.IP
+		expectedCalls         func(mockIPSet *ipsettest.MockInterfaceMockRecorder)
+	}{
+		{
+			name:                  "connectUplinkToBridge=false",
+			connectUplinkToBridge: false,
+			podAddresses:          []net.IP{net.ParseIP("1.1.1.1"), net.ParseIP("aabb::1")},
+			expectedCalls:         func(mockIPSet *ipsettest.MockInterfaceMockRecorder) {},
+		},
+		{
+			name:                  "connectUplinkToBridge=true",
+			connectUplinkToBridge: true,
+			podAddresses:          []net.IP{net.ParseIP("1.1.1.1"), net.ParseIP("aabb::1")},
+			expectedCalls: func(mockIPSet *ipsettest.MockInterfaceMockRecorder) {
+				mockIPSet.DelEntry(localAntreaFlexibleIPAMPodIPSet, "1.1.1.1")
+				mockIPSet.DelEntry(localAntreaFlexibleIPAMPodIP6Set, "aabb::1")
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			mockIPSet := ipsettest.NewMockInterface(ctrl)
+			c := &Client{
+				ipset:                 mockIPSet,
+				nodeConfig:            nodeConfig,
+				connectUplinkToBridge: tt.connectUplinkToBridge,
+			}
+			tt.expectedCalls(mockIPSet.EXPECT())
+
+			assert.NoError(t, c.DeleteLocalAntreaFlexibleIPAMPodRule(tt.podAddresses))
+		})
+	}
+}
+
+func TestAddAndDeleteNodeIP(t *testing.T) {
+	tests := []struct {
+		name             string
+		multicastEnabled bool
+		networkConfig    *config.NetworkConfig
+		podCIDR          *net.IPNet
+		nodeIP           net.IP
+		expectedCalls    func(mockIPSet *ipsettest.MockInterfaceMockRecorder)
+	}{
+		{
+			name:             "IPv4",
+			multicastEnabled: true,
+			networkConfig:    &config.NetworkConfig{TrafficEncapMode: config.TrafficEncapModeEncap},
+			podCIDR:          ip.MustParseCIDR("192.168.0.0/24"),
+			nodeIP:           net.ParseIP("1.1.1.1"),
+			expectedCalls: func(mockIPSet *ipsettest.MockInterfaceMockRecorder) {
+				mockIPSet.AddEntry(clusterNodeIPSet, "1.1.1.1")
+				mockIPSet.DelEntry(clusterNodeIPSet, "1.1.1.1")
+			},
+		},
+		{
+			name:             "IPv6",
+			multicastEnabled: true,
+			networkConfig:    &config.NetworkConfig{TrafficEncapMode: config.TrafficEncapModeEncap},
+			podCIDR:          ip.MustParseCIDR("1122:3344::/80"),
+			nodeIP:           net.ParseIP("aabb:ccdd::1"),
+			expectedCalls: func(mockIPSet *ipsettest.MockInterfaceMockRecorder) {
+				mockIPSet.AddEntry(clusterNodeIP6Set, "aabb:ccdd::1")
+				mockIPSet.DelEntry(clusterNodeIP6Set, "aabb:ccdd::1")
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			mockIPSet := ipsettest.NewMockInterface(ctrl)
+			c := &Client{
+				ipset:            mockIPSet,
+				networkConfig:    tt.networkConfig,
+				multicastEnabled: tt.multicastEnabled,
+			}
+			tt.expectedCalls(mockIPSet.EXPECT())
+
+			ipv6 := tt.nodeIP.To4() == nil
+			assert.NoError(t, c.addNodeIP(tt.podCIDR, tt.nodeIP))
+			var exists bool
+			if ipv6 {
+				_, exists = c.clusterNodeIP6s.Load(tt.podCIDR.String())
+			} else {
+				_, exists = c.clusterNodeIPs.Load(tt.podCIDR.String())
+			}
+			assert.True(t, exists)
+
+			assert.NoError(t, c.deleteNodeIP(tt.podCIDR))
+			if ipv6 {
+				_, exists = c.clusterNodeIP6s.Load(tt.podCIDR.String())
+			} else {
+				_, exists = c.clusterNodeIPs.Load(tt.podCIDR.String())
+			}
+			assert.False(t, exists)
+		})
+	}
+}

--- a/pkg/agent/route/route_linux_test.go
+++ b/pkg/agent/route/route_linux_test.go
@@ -1334,12 +1334,12 @@ func TestAddLoadBalancer(t *testing.T) {
 	nodeConfig := &config.NodeConfig{GatewayConfig: &config.GatewayConfig{LinkIndex: 10}}
 	tests := []struct {
 		name          string
-		externalIPs   []string
+		externalIP    string
 		expectedCalls func(mockNetlink *netlinktest.MockInterfaceMockRecorder)
 	}{
 		{
-			name:        "IPv4",
-			externalIPs: []string{"1.1.1.1", "1.1.1.2"},
+			name:       "IPv4",
+			externalIP: "1.1.1.1",
 			expectedCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
 				mockNetlink.RouteReplace(&netlink.Route{
 					Dst: &net.IPNet{
@@ -1350,29 +1350,14 @@ func TestAddLoadBalancer(t *testing.T) {
 					Scope:     netlink.SCOPE_UNIVERSE,
 					LinkIndex: 10,
 				})
-				mockNetlink.RouteReplace(&netlink.Route{
-					Dst: &net.IPNet{
-						IP:   net.ParseIP("1.1.1.2"),
-						Mask: net.CIDRMask(32, 32),
-					},
-					Gw:        config.VirtualServiceIPv4,
-					Scope:     netlink.SCOPE_UNIVERSE,
-					LinkIndex: 10,
-				})
 			},
 		},
 		{
-			name:        "IPv6",
-			externalIPs: []string{"fd00:1234:5678:dead:beaf::1", "fd00:1234:5678:dead:beaf::a"},
+			name:       "IPv6",
+			externalIP: "fd00:1234:5678:dead:beaf::1",
 			expectedCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
 				mockNetlink.RouteReplace(&netlink.Route{
 					Dst:       &net.IPNet{IP: net.ParseIP("fd00:1234:5678:dead:beaf::1"), Mask: net.CIDRMask(128, 128)},
-					Gw:        config.VirtualServiceIPv6,
-					Scope:     netlink.SCOPE_UNIVERSE,
-					LinkIndex: 10,
-				})
-				mockNetlink.RouteReplace(&netlink.Route{
-					Dst:       &net.IPNet{IP: net.ParseIP("fd00:1234:5678:dead:beaf::a"), Mask: net.CIDRMask(128, 128)},
 					Gw:        config.VirtualServiceIPv6,
 					Scope:     netlink.SCOPE_UNIVERSE,
 					LinkIndex: 10,
@@ -1391,7 +1376,7 @@ func TestAddLoadBalancer(t *testing.T) {
 			}
 			tt.expectedCalls(mockNetlink.EXPECT())
 
-			assert.NoError(t, c.AddLoadBalancer(tt.externalIPs))
+			assert.NoError(t, c.AddLoadBalancer(net.ParseIP(tt.externalIP)))
 		})
 	}
 }
@@ -1400,12 +1385,12 @@ func TestDeleteLoadBalancer(t *testing.T) {
 	nodeConfig := &config.NodeConfig{GatewayConfig: &config.GatewayConfig{LinkIndex: 10}}
 	tests := []struct {
 		name          string
-		externalIPs   []string
+		externalIP    string
 		expectedCalls func(mockNetlink *netlinktest.MockInterfaceMockRecorder)
 	}{
 		{
-			name:        "IPv4",
-			externalIPs: []string{"1.1.1.1", "1.1.1.2"},
+			name:       "IPv4",
+			externalIP: "1.1.1.1",
 			expectedCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
 				mockNetlink.RouteDel(&netlink.Route{
 					Dst: &net.IPNet{
@@ -1416,29 +1401,14 @@ func TestDeleteLoadBalancer(t *testing.T) {
 					Scope:     netlink.SCOPE_UNIVERSE,
 					LinkIndex: 10,
 				})
-				mockNetlink.RouteDel(&netlink.Route{
-					Dst: &net.IPNet{
-						IP:   net.ParseIP("1.1.1.2"),
-						Mask: net.CIDRMask(32, 32),
-					},
-					Gw:        config.VirtualServiceIPv4,
-					Scope:     netlink.SCOPE_UNIVERSE,
-					LinkIndex: 10,
-				})
 			},
 		},
 		{
-			name:        "IPv6",
-			externalIPs: []string{"fd00:1234:5678:dead:beaf::1", "fd00:1234:5678:dead:beaf::a"},
+			name:       "IPv6",
+			externalIP: "fd00:1234:5678:dead:beaf::1",
 			expectedCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
 				mockNetlink.RouteDel(&netlink.Route{
 					Dst:       &net.IPNet{IP: net.ParseIP("fd00:1234:5678:dead:beaf::1"), Mask: net.CIDRMask(128, 128)},
-					Gw:        config.VirtualServiceIPv6,
-					Scope:     netlink.SCOPE_UNIVERSE,
-					LinkIndex: 10,
-				})
-				mockNetlink.RouteDel(&netlink.Route{
-					Dst:       &net.IPNet{IP: net.ParseIP("fd00:1234:5678:dead:beaf::a"), Mask: net.CIDRMask(128, 128)},
 					Gw:        config.VirtualServiceIPv6,
 					Scope:     netlink.SCOPE_UNIVERSE,
 					LinkIndex: 10,
@@ -1457,7 +1427,7 @@ func TestDeleteLoadBalancer(t *testing.T) {
 			}
 			tt.expectedCalls(mockNetlink.EXPECT())
 
-			assert.NoError(t, c.DeleteLoadBalancer(tt.externalIPs))
+			assert.NoError(t, c.DeleteLoadBalancer(net.ParseIP(tt.externalIP)))
 		})
 	}
 }

--- a/pkg/agent/route/route_windows.go
+++ b/pkg/agent/route/route_windows.go
@@ -122,7 +122,7 @@ func (c *Client) initServiceIPRoutes() error {
 
 // Reconcile removes the orphaned routes and related configuration based on the desired podCIDRs and Service IPs. Only
 // the route entries on the host gateway interface are stored in the cache.
-func (c *Client) Reconcile(podCIDRs []string, svcIPs map[string]bool) error {
+func (c *Client) Reconcile(podCIDRs []string) error {
 	desiredPodCIDRs := sets.NewString(podCIDRs...)
 	routes, err := c.listRoutes()
 	if err != nil {
@@ -133,8 +133,8 @@ func (c *Client) Reconcile(podCIDRs []string, svcIPs map[string]bool) error {
 			c.hostRoutes.Store(dst, rt)
 			continue
 		}
-		if _, ok := svcIPs[dst]; ok {
-			c.hostRoutes.Store(dst, rt)
+		// Don't delete the routes which are added by AntreaProxy.
+		if c.isServiceRoute(rt) {
 			continue
 		}
 		err := util.RemoveNetRoute(rt)
@@ -260,8 +260,8 @@ func (c *Client) addVirtualServiceIPRoute(isIPv6 bool) error {
 
 // TODO: Follow the code style in Linux that maintains one Service CIDR.
 func (c *Client) addServiceRoute(svcIP net.IP) error {
-	obj, found := c.hostRoutes.Load(svcIP.String())
 	svcIPNet := util.NewIPNet(svcIP)
+	obj, found := c.hostRoutes.Load(svcIPNet.String())
 
 	// Route: Service IP -> VirtualServiceIPv4 (169.254.0.253)
 	route := &util.Route{
@@ -288,7 +288,7 @@ func (c *Client) addServiceRoute(svcIP net.IP) error {
 		return err
 	}
 
-	c.hostRoutes.Store(route.DestinationSubnet.String(), route)
+	c.hostRoutes.Store(svcIPNet.String(), route)
 	klog.V(2).InfoS("Added Service route", "ServiceIP", route.DestinationSubnet, "GatewayIP", route.GatewayAddress)
 	return nil
 }
@@ -305,7 +305,7 @@ func (c *Client) deleteServiceRoute(svcIP net.IP) error {
 	if err := util.RemoveNetRoute(rt); err != nil {
 		return err
 	}
-	c.hostRoutes.Delete(svcIP.String())
+	c.hostRoutes.Delete(svcIPNet.String())
 	klog.V(2).InfoS("Deleted Service route from host gateway", "DestinationIP", svcIP)
 	return nil
 }
@@ -330,6 +330,15 @@ func (c *Client) UnMigrateRoutesFromGw(route *net.IPNet, linkName string) error 
 
 // Run is not supported on Windows and returns immediately.
 func (c *Client) Run(stopCh <-chan struct{}) {
+}
+
+func (c *Client) isServiceRoute(route *util.Route) bool {
+	// If the destination IP or gateway IP is the virtual Service IP, then it is the Service route added by AntreaProxy.
+	if route.DestinationSubnet != nil && route.DestinationSubnet.IP.Equal(config.VirtualServiceIPv4) ||
+		route.GatewayAddress != nil && route.GatewayAddress.Equal(config.VirtualServiceIPv4) {
+		return true
+	}
+	return false
 }
 
 func (c *Client) listRoutes() (map[string]*util.Route, error) {

--- a/pkg/agent/route/route_windows.go
+++ b/pkg/agent/route/route_windows.go
@@ -403,22 +403,12 @@ func (c *Client) DeleteNodePort(nodePortAddresses []net.IP, port uint16, protoco
 	return util.RemoveNetNatStaticMapping(antreaNatNodePort, "0.0.0.0", port, string(protocol))
 }
 
-func (c *Client) AddLoadBalancer(externalIPs []string) error {
-	for _, svcIPStr := range externalIPs {
-		if err := c.addServiceRoute(net.ParseIP(svcIPStr)); err != nil {
-			return err
-		}
-	}
-	return nil
+func (c *Client) AddLoadBalancer(externalIP net.IP) error {
+	return c.addServiceRoute(externalIP)
 }
 
-func (c *Client) DeleteLoadBalancer(externalIPs []string) error {
-	for _, svcIPStr := range externalIPs {
-		if err := c.deleteServiceRoute(net.ParseIP(svcIPStr)); err != nil {
-			return err
-		}
-	}
-	return nil
+func (c *Client) DeleteLoadBalancer(externalIP net.IP) error {
+	return c.deleteServiceRoute(externalIP)
 }
 
 func (c *Client) AddLocalAntreaFlexibleIPAMPodRule(podAddresses []net.IP) error {

--- a/pkg/agent/route/route_windows_test.go
+++ b/pkg/agent/route/route_windows_test.go
@@ -89,14 +89,20 @@ func TestRouteOperation(t *testing.T) {
 	route3, err := util.GetNetRoutes(gwLink, svcIPNet1)
 	require.Nil(t, err)
 	assert.Equal(t, 1, len(route3))
+	obj, found := client.hostRoutes.Load(svcIPNet1.String())
+	assert.True(t, found)
+	assert.EqualValues(t, route3[0], *obj.(*util.Route))
 
 	err = client.AddClusterIPRoute(svcIP2)
 	require.Nil(t, err)
 	route4, err := util.GetNetRoutes(gwLink, svcIPNet2)
 	require.Nil(t, err)
 	assert.Equal(t, 1, len(route4))
+	obj, found = client.hostRoutes.Load(svcIPNet2.String())
+	assert.True(t, found)
+	assert.EqualValues(t, route4[0], *obj.(*util.Route))
 
-	err = client.Reconcile([]string{dest2}, map[string]bool{svcIPNet1.String(): true})
+	err = client.Reconcile([]string{dest2})
 	require.Nil(t, err)
 
 	routes5, err := util.GetNetRoutes(gwLink, destCIDR1)
@@ -105,7 +111,7 @@ func TestRouteOperation(t *testing.T) {
 
 	routes6, err := util.GetNetRoutes(gwLink, svcIPNet2)
 	require.Nil(t, err)
-	assert.Equal(t, 0, len(routes6))
+	assert.Equal(t, 1, len(routes6))
 
 	err = client.DeleteRoutes(destCIDR2)
 	require.Nil(t, err)
@@ -118,4 +124,6 @@ func TestRouteOperation(t *testing.T) {
 	routes8, err := util.GetNetRoutes(gwLink, svcIPNet1)
 	require.Nil(t, err)
 	assert.Equal(t, 0, len(routes8))
+	_, found = client.hostRoutes.Load(svcIPNet1.String())
+	assert.False(t, found)
 }

--- a/pkg/agent/route/testing/mock_route.go
+++ b/pkg/agent/route/testing/mock_route.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Antrea Authors
+// Copyright 2022 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -247,17 +247,17 @@ func (mr *MockInterfaceMockRecorder) MigrateRoutesToGw(arg0 interface{}) *gomock
 }
 
 // Reconcile mocks base method
-func (m *MockInterface) Reconcile(arg0 []string, arg1 map[string]bool) error {
+func (m *MockInterface) Reconcile(arg0 []string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Reconcile", arg0, arg1)
+	ret := m.ctrl.Call(m, "Reconcile", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Reconcile indicates an expected call of Reconcile
-func (mr *MockInterfaceMockRecorder) Reconcile(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) Reconcile(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reconcile", reflect.TypeOf((*MockInterface)(nil).Reconcile), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reconcile", reflect.TypeOf((*MockInterface)(nil).Reconcile), arg0)
 }
 
 // Run mocks base method

--- a/pkg/agent/route/testing/mock_route.go
+++ b/pkg/agent/route/testing/mock_route.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Antrea Authors
+// Copyright 2023 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -65,7 +65,7 @@ func (mr *MockInterfaceMockRecorder) AddClusterIPRoute(arg0 interface{}) *gomock
 }
 
 // AddLoadBalancer mocks base method
-func (m *MockInterface) AddLoadBalancer(arg0 []string) error {
+func (m *MockInterface) AddLoadBalancer(arg0 net.IP) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddLoadBalancer", arg0)
 	ret0, _ := ret[0].(error)
@@ -149,7 +149,7 @@ func (mr *MockInterfaceMockRecorder) DeleteClusterIPRoute(arg0 interface{}) *gom
 }
 
 // DeleteLoadBalancer mocks base method
-func (m *MockInterface) DeleteLoadBalancer(arg0 []string) error {
+func (m *MockInterface) DeleteLoadBalancer(arg0 net.IP) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteLoadBalancer", arg0)
 	ret0, _ := ret[0].(error)

--- a/pkg/agent/util/net.go
+++ b/pkg/agent/util/net.go
@@ -388,7 +388,7 @@ func GetAllNodeAddresses(excludeDevices []string) ([]net.IP, []net.IP, error) {
 // NewIPNet generates an IPNet from an ip address using a netmask of 32 or 128.
 func NewIPNet(ip net.IP) *net.IPNet {
 	if ip.To4() != nil {
-		return &net.IPNet{IP: ip, Mask: net.CIDRMask(32, 32)}
+		return &net.IPNet{IP: ip.To4(), Mask: net.CIDRMask(32, 32)}
 	}
 	return &net.IPNet{IP: ip, Mask: net.CIDRMask(128, 128)}
 }

--- a/test/integration/agent/route_test.go
+++ b/test/integration/agent/route_test.go
@@ -514,7 +514,6 @@ func TestReconcile(t *testing.T) {
 		addedRoutes      []peer
 		desiredPeerCIDRs []string
 		desiredNodeIPs   []string
-		desiredServices  map[string]bool
 		// expectations
 		expRoutes map[string]netlink.Link
 	}{
@@ -527,7 +526,6 @@ func TestReconcile(t *testing.T) {
 			},
 			desiredPeerCIDRs: []string{"10.10.20.0/24"},
 			desiredNodeIPs:   []string{remotePeerIP.String()},
-			desiredServices:  map[string]bool{"200.200.10.10": true},
 			expRoutes:        map[string]netlink.Link{"10.10.20.0/24": gwLink, "10.10.30.0/24": nil},
 		},
 		{
@@ -539,7 +537,6 @@ func TestReconcile(t *testing.T) {
 			},
 			desiredPeerCIDRs: []string{"10.10.20.0/24"},
 			desiredNodeIPs:   []string{localPeerIP.String()},
-			desiredServices:  map[string]bool{"200.200.10.10": true},
 			expRoutes:        map[string]netlink.Link{"10.10.20.0/24": nodeLink, "10.10.30.0/24": nil},
 		},
 		{
@@ -553,7 +550,6 @@ func TestReconcile(t *testing.T) {
 			},
 			desiredPeerCIDRs: []string{"10.10.20.0/24", "10.10.40.0/24"},
 			desiredNodeIPs:   []string{localPeerIP.String(), remotePeerIP.String()},
-			desiredServices:  map[string]bool{"200.200.10.10": true},
 			expRoutes:        map[string]netlink.Link{"10.10.20.0/24": nodeLink, "10.10.30.0/24": nil, "10.10.40.0/24": gwLink, "10.10.50.0/24": nil},
 		},
 	}
@@ -571,7 +567,7 @@ func TestReconcile(t *testing.T) {
 			assert.NoError(t, routeClient.AddRoutes(peerNet, tc.nodeName, route.peerIP, peerGwIP), "adding routes failed")
 		}
 
-		assert.NoError(t, routeClient.Reconcile(tc.desiredPeerCIDRs, tc.desiredServices), "reconcile failed")
+		assert.NoError(t, routeClient.Reconcile(tc.desiredPeerCIDRs), "reconcile failed")
 
 		for dst, uplink := range tc.expRoutes {
 			expNum := 0


### PR DESCRIPTION
Cherry pick of #4419 #4470 #4654 #4711 on release-1.7.

#4419: Set NO_FLOOD to IPsec tunnel ports
#4470: Fix that Service routes may get lost when starting on Windows
#4654: Restore NO_FLOOD to OVS ports after reconnecting the OVS
#4711: Fix route deletion for Service ClusterIP and LoadBalancerIP

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.