### PR TITLE
Fix empty log for the failed tests in the VM e2e testbed

### DIFF
--- a/ci/jenkins/test-vm.sh
+++ b/ci/jenkins/test-vm.sh
@@ -274,6 +274,7 @@ function run_e2e_vms {
 
     configure_vm_agent
     echo "====== Running Antrea e2e Tests for VM ======"
+    set +e
     mkdir -p `pwd`/antrea-test-logs
     go test -v -timeout=100m antrea.io/antrea/test/e2e -run=TestVMAgent --logs-export-dir `pwd`/antrea-test-logs -provider=remote -windowsVMs="${WIN_HOSTNAMES[*]}" -linuxVMs="${LIN_HOSTNAMES[*]}"
     if [[ "$?" != "0" ]]; then
@@ -310,3 +311,7 @@ fetch_vm_ip
 apply_antrea
 deliver_antrea_vm
 run_e2e_vms
+
+if [[ ${TEST_FAILURE} == true ]]; then
+    exit 1
+fi

--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -407,7 +407,7 @@ func exportLogs(tb testing.TB, data *TestData, logsSubDir string, writeNodeLogs 
 	}
 
 	writeVMAgentLog := func(cmd string, targetVMs string) {
-		vms := strings.Split(targetVMs, ",")
+		vms := strings.Split(targetVMs, " ")
 		for _, vm := range vms {
 			tb.Logf("Exporting logs from %s", vm)
 			_, stdout, _, err := data.RunCommandOnNode(vm, cmd)
@@ -428,7 +428,7 @@ func exportLogs(tb testing.TB, data *TestData, logsSubDir string, writeNodeLogs 
 		writeVMAgentLog(cmd, testOptions.linuxVMs)
 	}
 	if testOptions.windowsVMs != "" {
-		cmd := "cat c:/antrea-agent/antrea-agent.log"
+		cmd := "cat c:/antrea-agent/logs/antrea-agent.log"
 		writeVMAgentLog(cmd, testOptions.windowsVMs)
 	}
 }


### PR DESCRIPTION
In vm e2e testbed, users cannot retrieve log tarball for a failed test. This pr fix such problem.