### PR TITLE
Update Docker cleanup command and add resource usage information

### DIFF
--- a/ci/jenkins/test-vm.sh
+++ b/ci/jenkins/test-vm.sh
@@ -115,6 +115,7 @@ function clean_antrea {
     clean_up_one_ns $TEST_NAMESPACE
     kubectl delete -f ${WORKDIR}/antrea.yml --ignore-not-found=true
     docker image prune -f --filter "until=1h" || true > /dev/null
+    docker system df -v
 }
 
 function apply_antrea {

--- a/ci/jenkins/test-vmc.sh
+++ b/ci/jenkins/test-vmc.sh
@@ -350,6 +350,7 @@ function deliver_antrea {
     # Clean up dangling images generated in previous builds. Recent ones must be excluded
     # because they might be being used in other builds running simultaneously.
     docker image prune -f --filter "until=1h" || true > /dev/null
+    docker system df -v
     cd $GIT_CHECKOUT_DIR
     # Ensure that files in the Docker context have the correct permissions, or Docker caching cannot
     # be leveraged successfully

--- a/ci/test-conformance-aks.sh
+++ b/ci/test-conformance-aks.sh
@@ -189,6 +189,7 @@ function deliver_antrea_to_aks() {
     # Clean up dangling images generated in previous builds. Recent ones must be excluded
     # because they might be being used in other builds running simultaneously.
     docker image prune -f --filter "until=2h" || true > /dev/null
+    docker system df -v
 
     cd ${GIT_CHECKOUT_DIR}
     VERSION="$CLUSTER" make

--- a/ci/test-conformance-eks.sh
+++ b/ci/test-conformance-eks.sh
@@ -267,6 +267,7 @@ function deliver_antrea_to_eks() {
     # Clean up dangling images generated in previous builds. Recent ones must be excluded
     # because they might be being used in other builds running simultaneously.
     docker image prune -f --filter "until=2h" || true > /dev/null
+    docker system df -v
 
     cd ${GIT_CHECKOUT_DIR}
     VERSION="$CLUSTER" make

--- a/ci/test-conformance-gke.sh
+++ b/ci/test-conformance-gke.sh
@@ -201,6 +201,7 @@ function deliver_antrea_to_gke() {
     # Clean up dangling images generated in previous builds. Recent ones must be excluded
     # because they might be being used in other builds running simultaneously.
     docker image prune -f --filter "until=2h" || true > /dev/null
+    docker system df -v
 
     cd ${GIT_CHECKOUT_DIR}
     VERSION="$CLUSTER" make


### PR DESCRIPTION
Reduce time limit for docker system prune to 12 hours in Windows testbed for improved resource cleaning efficiency.

Add detailed information statistics for all Docker resource objects across all testbeds.