### PR TITLE
Automated cherry pick of #4283: Adding support for aws service user parameters
#4609: Upgrade default K8s version tested in eks
#4700: Specify AMI Family required by eksctl when using a custom AMI

### DIFF
--- a/ci/jenkins/README.md
+++ b/ci/jenkins/README.md
@@ -169,7 +169,7 @@ DOCKER_REGISTRY="$(head -n1 ci/docker-registry)"
 
   |  K8s Version |    Node Type    |  Node AMI Family |  Status  |
   | :----------: | :-------------: | :--------------: | :------: |
-  |     1.21     |  EC2 t3.medium  |   AmazonLinux2   |[![Build Status](http://jenkins.antrea-ci.rocks/buildStatus/icon?job=cloud-antrea-eks-conformance-net-policy)](http://jenkins.antrea-ci.rocks/view/cloud/job/cloud-antrea-eks-conformance-net-policy/)|
+  |     1.24     |  EC2 t3.medium  |   AmazonLinux2   |[![Build Status](http://jenkins.antrea-ci.rocks/buildStatus/icon?job=cloud-antrea-eks-conformance-net-policy)](http://jenkins.antrea-ci.rocks/view/cloud/job/cloud-antrea-eks-conformance-net-policy/)|
 
 * [GKE conformance/network policy [bi-daily]](http://jenkins.antrea-ci.rocks/view/cloud/job/cloud-antrea-gke-conformance-net-policy/)
   community tests on GKE cluster using sonobuoy, focusing on "Conformance" and "Feature:NetworkPolicy", skipping the same regexes as in job __conformance__ above.\
@@ -177,7 +177,7 @@ DOCKER_REGISTRY="$(head -n1 ci/docker-registry)"
 
   |  K8s Version   |     Node OS     | VPC Native Mode (on by default) |  Status  |
   | :------------: | :-------------: | :-----------------------------: |:-------: |
-  |    1.21.6      |     Ubuntu      |  On                             |[![Build Status](http://jenkins.antrea-ci.rocks/buildStatus/icon?job=cloud-antrea-gke-conformance-net-policy)](http://jenkins.antrea-ci.rocks/view/cloud/job/cloud-antrea-gke-conformance-net-policy/)|
+  |    1.25.5      |     Ubuntu      |  On                             |[![Build Status](http://jenkins.antrea-ci.rocks/buildStatus/icon?job=cloud-antrea-gke-conformance-net-policy)](http://jenkins.antrea-ci.rocks/view/cloud/job/cloud-antrea-gke-conformance-net-policy/)|
 
 * [AKS conformance/network policy [bi-daily]](http://jenkins.antrea-ci.rocks/view/cloud/job/cloud-antrea-aks-conformance-net-policy/)
   community tests on AKS cluster using sonobuoy, focusing on "Conformance" and "Feature:NetworkPolicy", skipping the same regexes as in job __conformance__ above.\
@@ -185,7 +185,7 @@ DOCKER_REGISTRY="$(head -n1 ci/docker-registry)"
 
   |  K8s Version   |  Node Type          |  Node OS        |  Status  |
   | :------------: | :-----------------: | :-------------: | :------: |
-  |    1.21.7      |  Standard_DS2_v2    |  Ubuntu 18.04   |[![Build Status](http://jenkins.antrea-ci.rocks/buildStatus/icon?job=cloud-antrea-aks-conformance-net-policy)](http://jenkins.antrea-ci.rocks/view/cloud/job/cloud-antrea-aks-conformance-net-policy/)|
+  |    1.24.9      |  Standard_DS2_v2    |  Ubuntu 18.04   |[![Build Status](http://jenkins.antrea-ci.rocks/buildStatus/icon?job=cloud-antrea-aks-conformance-net-policy)](http://jenkins.antrea-ci.rocks/view/cloud/job/cloud-antrea-aks-conformance-net-policy/)|
 
 * [matrix-test [weekly]](https://jenkins.antrea-ci.rocks/job/antrea-weekly-matrix-compatibility-test/):
   runs Antrea e2e, K8s Conformance and NetworkPolicy tests, using different combinations of various operating systems and K8s releases.

--- a/ci/jenkins/jobs/projects-cloud.yaml
+++ b/ci/jenkins/jobs/projects-cloud.yaml
@@ -809,7 +809,8 @@
               #!/bin/bash
               source /home/ubuntu/.bashrc
               sudo ./ci/test-conformance-eks.sh --aws-access-key ${{AWS_ACCESS_KEY}} --aws-secret-key ${{AWS_SECRET_KEY}} \
-                --cluster-name ${{JOB_NAME}}-${{BUILD_NUMBER}} --log-mode detail --setup-only
+                --aws-service-user-role-arn ${{AWS_SERVICE_USER_ROLE_ARN}} --aws-service-user ${{AWS_SERVICE_USER_NAME}} --cluster-name ${{JOB_NAME}}-${{BUILD_NUMBER}} \
+                --log-mode detail --setup-only
           triggers:
           - timed: H H */2 * *
           publishers:
@@ -830,11 +831,17 @@
           wrappers:
           - credentials-binding:
             - text:
-                credential-id: AWS_ACCESS_KEY # Jenkins secret that stores aws access key
+                credential-id: AWS_SERVICE_USER_ACCESS_KEY # Jenkins secret that stores aws access key
                 variable: AWS_ACCESS_KEY
             - text:
-                credential-id: AWS_SECRET_KEY # Jenkins secret that stores aws secret key
+                credential-id: AWS_SERVICE_USER_SECRET_KEY # Jenkins secret that stores aws secret key
                 variable: AWS_SECRET_KEY
+            - text:
+                credential-id: AWS_SERVICE_USER_ROLE_ARN # Jenkins secret that stores aws role arn
+                variable: AWS_SERVICE_USER_ROLE_ARN
+            - text:
+                credential-id: AWS_SERVICE_USER_NAME # Jenkins secret that stores aws source profile
+                variable: AWS_SERVICE_USER_NAME
       - 'cloud-{name}-{test_name}-cleanup':
           test_name: eks
           description: This is for deleting EKS test clusters.

--- a/ci/test-conformance-eks.sh
+++ b/ci/test-conformance-eks.sh
@@ -21,7 +21,7 @@ function echoerr {
 }
 
 CLUSTER=""
-REGION="us-east-2"
+REGION="us-west-2"
 K8S_VERSION="1.21"
 AWS_NODE_TYPE="t3.medium"
 SSH_KEY_PATH="$HOME/.ssh/id_rsa.pub"
@@ -34,24 +34,29 @@ MODE="report"
 TEST_SCRIPT_RC=0
 KUBE_CONFORMANCE_IMAGE_VERSION=auto
 INSTALL_EKSCTL=true
+AWS_SERVICE_USER_ROLE_ARN=""
+AWS_SERVICE_USER_NAME=""
 
 _usage="Usage: $0 [--cluster-name <EKSClusterNameToUse>] [--kubeconfig <KubeconfigSavePath>] [--k8s-version <ClusterVersion>]\
-                  [--aws-access-key <AccessKey>] [--aws-secret-key <SecretKey>] [--aws-region <Region>] [--ssh-key <SSHKey] \
-                  [--ssh-private-key <SSHPrivateKey] [--log-mode <SonobuoyResultLogLevel>] [--setup-only] [--cleanup-only]
+                  [--aws-access-key <AccessKey>] [--aws-secret-key <SecretKey>] [--aws-region <Region>] [--aws-service-user <ServiceUserName>]\
+                  [--aws-service-user-role-arn <ServiceUserRoleARN>] [--ssh-key <SSHKey] [--ssh-private-key <SSHPrivateKey] [--log-mode <SonobuoyResultLogLevel>]\
+                  [--setup-only] [--cleanup-only]
 
 Setup a EKS cluster to run K8s e2e community tests (Conformance & Network Policy).
 
-        --cluster-name           The cluster name to be used for the generated EKS cluster. Must be specified if not run in Jenkins environment.
-        --kubeconfig             Path to save kubeconfig of generated EKS cluster.
-        --k8s-version            GKE K8s cluster version. Defaults to 1.17.
-        --aws-access-key         AWS Acess Key for logging in to awscli.
-        --aws-secret-key         AWS Secret Key for logging in to awscli.
-        --aws-region             The AWS region where the cluster will be initiated. Defaults to us-east-2.
-        --ssh-key                The path of key to be used for ssh access to worker nodes.
-        --log-mode               Use the flag to set either 'report', 'detail', or 'dump' level data for sonobouy results.
-        --setup-only             Only perform setting up the cluster and run test.
-        --cleanup-only           Only perform cleaning up the cluster.
-        --skip-eksctl-install    Do not install the latest eksctl version. Eksctl must be installed already."
+        --cluster-name                The cluster name to be used for the generated EKS cluster. Must be specified if not run in Jenkins environment.
+        --kubeconfig                  Path to save kubeconfig of generated EKS cluster.
+        --k8s-version                 GKE K8s cluster version. Defaults to 1.17.
+        --aws-access-key              AWS Acess Key for logging in to awscli.
+        --aws-secret-key              AWS Secret Key for logging in to awscli.
+        --aws-service-user-role-arn   AWS Service User Role ARN for logging in to awscli.
+        --aws-service-user            AWS Service User Name for logging in to awscli.
+        --aws-region                  The AWS region where the cluster will be initiated. Defaults to us-east-2.
+        --ssh-key                     The path of key to be used for ssh access to worker nodes.
+        --log-mode                    Use the flag to set either 'report', 'detail', or 'dump' level data for sonobouy results.
+        --setup-only                  Only perform setting up the cluster and run test.
+        --cleanup-only                Only perform cleaning up the cluster.
+        --skip-eksctl-install         Do not install the latest eksctl version. Eksctl must be installed already."
 
 function print_usage {
     echoerr "$_usage"
@@ -76,6 +81,14 @@ case $key in
     ;;
     --aws-secret-key)
     AWS_SECRET_KEY="$2"
+    shift 2
+    ;;
+    --aws-service-user-role-arn)
+    AWS_SERVICE_USER_ROLE_ARN="$2"
+    shift 2
+    ;;
+    --aws-service-user)
+    AWS_SERVICE_USER_NAME="$2"
     shift 2
     ;;
     --aws-region)
@@ -173,12 +186,37 @@ function setup_eks() {
     aws --version
 
     set +e
-    aws configure << EOF
-${AWS_ACCESS_KEY}
-${AWS_SECRET_KEY}
-${REGION}
-JSON
+    if [[ "$AWS_SERVICE_USER_ROLE_ARN" != "" ]] && [[ "$AWS_SERVICE_USER_NAME" != "" ]]; then
+        mkdir -p ~/.aws
+        cat > ~/.aws/config <<EOF
+[default]
+region = $REGION
+role_arn = $AWS_SERVICE_USER_ROLE_ARN
+source_profile = $AWS_SERVICE_USER_NAME
+output = json
 EOF
+        cat > ~/.aws/credentials <<EOF
+[$AWS_SERVICE_USER_NAME]
+aws_access_key_id = $AWS_ACCESS_KEY
+aws_secret_access_key = $AWS_SECRET_KEY
+EOF
+    elif [[ "$AWS_SERVICE_USER_ROLE_ARN" = "" ]] && [[ "$AWS_SERVICE_USER_NAME" = "" ]]; then
+        mkdir -p ~/.aws
+        cat > ~/.aws/config <<EOF
+[default]
+region = $REGION
+output = json
+EOF
+        cat > ~/.aws/credentials <<EOF
+[default]
+aws_access_key_id = $AWS_ACCESS_KEY
+aws_secret_access_key = $AWS_SECRET_KEY
+EOF
+    else
+        echo "Invalid input either specify both aws-service-user-role-arn and aws-service-user or none."
+        exit 1
+    fi
+
     if [[ "$INSTALL_EKSCTL" == true ]]; then
         echo "=== Installing latest version of eksctl ==="
         curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp

--- a/ci/test-conformance-eks.sh
+++ b/ci/test-conformance-eks.sh
@@ -163,6 +163,7 @@ managedNodeGroups:
     instanceType: ${AWS_NODE_TYPE}
     desiredCapacity: 2
     ami: ${AMI_ID}
+    amiFamily: AmazonLinux2
     ssh:
       allow: true
       publicKeyPath: ${SSH_KEY_PATH}

--- a/ci/test-conformance-eks.sh
+++ b/ci/test-conformance-eks.sh
@@ -22,7 +22,7 @@ function echoerr {
 
 CLUSTER=""
 REGION="us-west-2"
-K8S_VERSION="1.21"
+K8S_VERSION="1.24"
 AWS_NODE_TYPE="t3.medium"
 SSH_KEY_PATH="$HOME/.ssh/id_rsa.pub"
 SSH_PRIVATE_KEY_PATH="$HOME/.ssh/id_rsa"
@@ -46,7 +46,7 @@ Setup a EKS cluster to run K8s e2e community tests (Conformance & Network Policy
 
         --cluster-name                The cluster name to be used for the generated EKS cluster. Must be specified if not run in Jenkins environment.
         --kubeconfig                  Path to save kubeconfig of generated EKS cluster.
-        --k8s-version                 GKE K8s cluster version. Defaults to 1.17.
+        --k8s-version                 EKS K8s cluster version. Defaults to 1.24.
         --aws-access-key              AWS Acess Key for logging in to awscli.
         --aws-secret-key              AWS Secret Key for logging in to awscli.
         --aws-service-user-role-arn   AWS Service User Role ARN for logging in to awscli.


### PR DESCRIPTION
Cherry pick of #4283 #4609 #4700 on release-1.9.

#4283: Adding support for aws service user parameters
#4609: Upgrade default K8s version tested in eks
#4700: Specify AMI Family required by eksctl when using a custom AMI

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.