### PR TITLE
Bump actions/setup-go from 3 to 4

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Go using version from go.mod
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,9 +6,6 @@ on:
   pull_request:
     branches: [ "main" ]
 
-env:
-  go-cache-name: go
-
 jobs:
   analyze-on-linux:
     name: Analyze on Linux
@@ -35,24 +32,9 @@ jobs:
         config-file: ./.github/codeql-config.yml
 
     - name: Set up Go using version from go.mod
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version-file: 'go.mod'
-
-    - uses: actions/cache@v3
-      with:
-        # In order:
-        # * Module download cache
-        # * Build cache (Linux)
-        # * Build cache (Mac)
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-          ~/Library/Caches/go-build
-          %LocalAppData%\go-build
-        key: ${{ runner.os }}-${{ env.go-cache-name }}-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ env.go-cache-name }}-
 
     - name: "Build Application"
       run: |
@@ -89,24 +71,10 @@ jobs:
         config-file: ./.github/codeql-config.yml
 
     - name: Set up Go using version from go.mod
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version-file: 'go.mod'
 
-    - uses: actions/cache@v3
-      with:
-        # In order:
-        # * Module download cache
-        # * Build cache (Linux)
-        # * Build cache (Mac)
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-          ~/Library/Caches/go-build
-          %LocalAppData%\go-build
-        key: ${{ runner.os }}-${{ env.go-cache-name }}-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ env.go-cache-name }}-
     - name: Build Antrea windows binaries
       run: make windows-bin
 

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -37,7 +37,7 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha }}
         token: ${{ secrets.ANTREA_BOT_WRITE_PAT }}
     - name: Set up Go using version from go.mod
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version-file: 'go.mod'
     - name: Run go mod tidy

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,9 +11,6 @@ on:
     - release-*
     - feature/*
 
-env:
-  go-cache-name: go
-
 jobs:
   check-changes:
     name: Check whether tests need to be run based on diff
@@ -41,23 +38,9 @@ jobs:
     - name: Check-out code
       uses: actions/checkout@v3
     - name: Set up Go using version from go.mod
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version-file: 'go.mod'
-    - uses: actions/cache@v3
-      with:
-        # In order:
-        # * Module download cache
-        # * Build cache (Linux)
-        # * Build cache (Mac)
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-          ~/Library/Caches/go-build
-          %LocalAppData%\go-build
-        key: ${{ runner.os }}-${{ env.go-cache-name }}-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ env.go-cache-name }}-
     - name: Run unit tests
       run: make test-unit
     - name: Codecov
@@ -78,23 +61,9 @@ jobs:
       - name: Check-out code
         uses: actions/checkout@v3
       - name: Set up Go using version from go.mod
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
-      - uses: actions/cache@v3
-        with:
-          # In order:
-          # * Module download cache
-          # * Build cache (Linux)
-          # * Build cache (Mac)
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-            ~/Library/Caches/go-build
-            %LocalAppData%\go-build
-          key: ${{ runner.os }}-${{ env.go-cache-name }}-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ env.go-cache-name }}-
       - name: Run unit tests
         run: make test-unit
       - name: Codecov
@@ -115,23 +84,9 @@ jobs:
       - name: Check-out code
         uses: actions/checkout@v3
       - name: Set up Go using version from go.mod
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
-      - uses: actions/cache@v3
-        with:
-          # In order:
-          # * Module download cache
-          # * Build cache (Linux)
-          # * Build cache (Mac)
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-            ~/Library/Caches/go-build
-            %LocalAppData%\go-build
-          key: ${{ runner.os }}-${{ env.go-cache-name }}-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ env.go-cache-name }}-
       - name: Run integration tests
         run: |
           ./build/images/ovs/build.sh
@@ -161,23 +116,11 @@ jobs:
     - name: Check-out code
       uses: actions/checkout@v3
     - name: Set up Go using version from go.mod
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version-file: 'go.mod'
-    - uses: actions/cache@v3
-      with:
-        # In order:
-        # * Module download cache
-        # * Build cache (Linux)
-        # * Build cache (Mac)
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-          ~/Library/Caches/go-build
-          %LocalAppData%\go-build
-        key: ${{ runner.os }}-${{ env.go-cache-name }}-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ env.go-cache-name }}-
+        # include all go.sum files (not just the root one), since we are also checking hack/netpol
+        cache-dependency-path: '**/go.sum'
     - name: Run golangci-lint
       run: make golangci
     - name: Run golangci-lint for netpol
@@ -193,23 +136,11 @@ jobs:
       - name: Check-out code
         uses: actions/checkout@v3
       - name: Set up Go using version from go.mod
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
-      - uses: actions/cache@v3
-        with:
-          # In order:
-          # * Module download cache
-          # * Build cache (Linux)
-          # * Build cache (Mac)
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-            ~/Library/Caches/go-build
-            %LocalAppData%\go-build
-          key: ${{ runner.os }}-${{ env.go-cache-name }}-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ env.go-cache-name }}-
+          # include all go.sum files (not just the root one), since we are also checking hack/netpol
+          cache-dependency-path: '**/go.sum'
       - name: Run golangci-lint
         run: make golangci
       - name: Run golangci-lint for netpol
@@ -225,23 +156,9 @@ jobs:
     - name: Check-out code
       uses: actions/checkout@v3
     - name: Set up Go using version from go.mod
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version-file: 'go.mod'
-    - uses: actions/cache@v3
-      with:
-        # In order:
-        # * Module download cache
-        # * Build cache (Linux)
-        # * Build cache (Mac)
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-          ~/Library/Caches/go-build
-          %LocalAppData%\go-build
-        key: ${{ runner.os }}-${{ env.go-cache-name }}-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ env.go-cache-name }}-
     - name: Build Antrea binaries for amd64
       run: GOARCH=amd64 make bin
     - name: Build Antrea binaries for arm64
@@ -264,23 +181,9 @@ jobs:
     - name: Check-out code
       uses: actions/checkout@v3
     - name: Set up Go using version from go.mod
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version-file: 'go.mod'
-    - uses: actions/cache@v3
-      with:
-        # In order:
-        # * Module download cache
-        # * Build cache (Linux)
-        # * Build cache (Mac)
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-          ~/Library/Caches/go-build
-          %LocalAppData%\go-build
-        key: ${{ runner.os }}-${{ env.go-cache-name }}-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ env.go-cache-name }}-
     - name: Build Antrea windows binaries
       run: make windows-bin
 
@@ -293,7 +196,7 @@ jobs:
     - name: Check-out code
       uses: actions/checkout@v3
     - name: Set up Go using version from go.mod
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version-file: 'go.mod'
     # tidy check need to be run before code generation which will regenerate codes.
@@ -313,7 +216,7 @@ jobs:
     - name: Check-out code
       uses: actions/checkout@v3
     - name: Set up Go using version from go.mod
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version-file: 'go.mod'
     - name: Run verify scripts
@@ -349,7 +252,7 @@ jobs:
       - name: Check-out code
         uses: actions/checkout@v3
       - name: Set up Go using version from go.mod
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
       - name: Run Go benchmark test

--- a/.github/workflows/golicense.yml
+++ b/.github/workflows/golicense.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Go using version from go.mod
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version-file: 'go.mod'
     - name: Cache licensing information for dependencies

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -76,7 +76,7 @@ jobs:
         sudo apt-get clean
         df -h
     - uses: actions/checkout@v3
-    - uses: actions/setup-go@v3
+    - uses: actions/setup-go@v4
       with:
         go-version-file: 'go.mod'
     - name: Download Antrea image from previous job
@@ -135,7 +135,7 @@ jobs:
         sudo apt-get clean
         df -h
     - uses: actions/checkout@v3
-    - uses: actions/setup-go@v3
+    - uses: actions/setup-go@v4
       with:
         go-version-file: 'go.mod'
     - name: Download Antrea image from previous job
@@ -194,7 +194,7 @@ jobs:
           sudo apt-get clean
           df -h
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
       - name: Download Antrea image from previous job
@@ -254,7 +254,7 @@ jobs:
         sudo apt-get clean
         df -h
     - uses: actions/checkout@v3
-    - uses: actions/setup-go@v3
+    - uses: actions/setup-go@v4
       with:
         go-version-file: 'go.mod'
     - name: Download Antrea image from previous job
@@ -313,7 +313,7 @@ jobs:
         sudo apt-get clean
         df -h
     - uses: actions/checkout@v3
-    - uses: actions/setup-go@v3
+    - uses: actions/setup-go@v4
       with:
         go-version-file: 'go.mod'
     - name: Download Antrea image from previous job
@@ -372,7 +372,7 @@ jobs:
           sudo apt-get clean
           df -h
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
       - name: Download Antrea image from previous job
@@ -438,7 +438,7 @@ jobs:
           sudo apt-get clean
           df -h
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
       - name: Download Antrea image from previous job
@@ -480,7 +480,7 @@ jobs:
           sudo apt-get clean
           df -h
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
       - name: Download Antrea image from previous job
@@ -522,7 +522,7 @@ jobs:
           sudo apt-get clean
           df -h
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
       - name: Download Antrea image from previous job
@@ -564,7 +564,7 @@ jobs:
           sudo apt-get clean
           df -h
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
       - name: Download Antrea image from previous job
@@ -606,7 +606,7 @@ jobs:
         sudo apt-get clean
         df -h
     - uses: actions/checkout@v3
-    - uses: actions/setup-go@v3
+    - uses: actions/setup-go@v4
       with:
         go-version-file: 'go.mod'
     - name: Download Antrea image from previous job
@@ -640,9 +640,6 @@ jobs:
           sudo apt-get clean
           df -h
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
-        with:
-          go-version-file: 'go.mod'
       - name: Download Antrea image from previous job
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/process_release.yml
+++ b/.github/workflows/process_release.yml
@@ -10,9 +10,13 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Go using version from go.mod
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version-file: 'go.mod'
+        # make sure the latest patch version is used
+        check-latest: true
+        # release assets include Octant plugin
+        cache-dependency-path: '**/go.sum'
     - name: Build assets
       env:
         TAG: ${{ github.ref }}

--- a/.github/workflows/trivy_scan.yml
+++ b/.github/workflows/trivy_scan.yml
@@ -12,9 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-go@v3
-      with:
-        go-version-file: 'go.mod'
     - name: Find greatest Antrea version
       id: find-antrea-greatest-version
       run: |

--- a/.github/workflows/trivy_scan_before_release.yml
+++ b/.github/workflows/trivy_scan_before_release.yml
@@ -11,9 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-go@v3
-      with:
-        go-version-file: 'go.mod'
     - name: Build Antrea Docker image
       run: |
         ./hack/build-antrea-linux-all.sh --pull

--- a/.github/workflows/verify_docs.yml
+++ b/.github/workflows/verify_docs.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Check-out code
       uses: actions/checkout@v3
     - name: Set up Go using version from go.mod
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version-file: 'go.mod'
     - name: Run verify scripts


### PR DESCRIPTION
The new version of the action enables caching by default.