### PR TITLE
Bump cert-manager API version in Antrea docs

### DIFF
--- a/docs/securing-control-plane.md
+++ b/docs/securing-control-plane.md
@@ -126,7 +126,7 @@ The `Certificate` should be created in the `kube-system` namespace. For example,
 A `Certificate` may look like:
 
 ```yaml
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: antrea-controller-tls


### PR DESCRIPTION
We provide an example of a cert-manager Certificate CR in docs/securing-control-plane.md. The example was using API version v1alpha2, which was deprecated in cert-manager v1.4 and is not available in any recent cert-manager version.