### PR TITLE
Stop serving v1alpha2 version of the ClusterGroup CRD

### DIFF
--- a/build/charts/antrea/crds/clustergroup.yaml
+++ b/build/charts/antrea/crds/clustergroup.yaml
@@ -8,7 +8,7 @@ spec:
   group: crd.antrea.io
   versions:
     - name: v1alpha2
-      served: true
+      served: false
       storage: false
       schema:
         openAPIV3Schema:

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -120,7 +120,7 @@ spec:
   group: crd.antrea.io
   versions:
     - name: v1alpha2
-      served: true
+      served: false
       storage: false
       schema:
         openAPIV3Schema:

--- a/build/yamls/antrea-crds.yml
+++ b/build/yamls/antrea-crds.yml
@@ -115,7 +115,7 @@ spec:
   group: crd.antrea.io
   versions:
     - name: v1alpha2
-      served: true
+      served: false
       storage: false
       schema:
         openAPIV3Schema:

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -120,7 +120,7 @@ spec:
   group: crd.antrea.io
   versions:
     - name: v1alpha2
-      served: true
+      served: false
       storage: false
       schema:
         openAPIV3Schema:

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -120,7 +120,7 @@ spec:
   group: crd.antrea.io
   versions:
     - name: v1alpha2
-      served: true
+      served: false
       storage: false
       schema:
         openAPIV3Schema:

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -120,7 +120,7 @@ spec:
   group: crd.antrea.io
   versions:
     - name: v1alpha2
-      served: true
+      served: false
       storage: false
       schema:
         openAPIV3Schema:

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -120,7 +120,7 @@ spec:
   group: crd.antrea.io
   versions:
     - name: v1alpha2
-      served: true
+      served: false
       storage: false
       schema:
         openAPIV3Schema:

--- a/docs/api.md
+++ b/docs/api.md
@@ -28,12 +28,12 @@ These are the CRDs currently available in `crd.antrea.io`.
 |---|---|---|---|---|
 | `AntreaAgentInfo` | v1beta1 | v1.0.0 | N/A | N/A |
 | `AntreaControllerInfo` | v1beta1 | v1.0.0 | N/A | N/A |
-| `ClusterGroup` | v1alpha2 | v1.0.0 | v1.1.0 | Feb 2022 |
 | `ClusterGroup` | v1alpha3 | v1.1.0 | N/A | N/A |
 | `ClusterNetworkPolicy` | v1alpha1 | v1.0.0 | N/A | N/A |
 | `Egress` | v1alpha2 | v1.0.0 | N/A | N/A |
 | `ExternalEntity` | v1alpha2 | v1.0.0 | N/A | N/A |
 | `ExternalIPPool` | v1alpha2 | v1.2.0 | N/A | N/A |
+| `Group` | v1alpha3 | v1.8.0 | N/A | N/A |
 | `NetworkPolicy` | v1alpha1 | v1.0.0 | N/A | N/A |
 | `Tier` | v1alpha1 | v1.0.0 | N/A | N/A |
 | `Traceflow` | v1alpha1 | v1.0.0 | N/A | N/A |
@@ -50,6 +50,8 @@ These are the API group versions which are curently available when using Antrea.
 
 ## Previously-supported
 
+### Previously-supported API groups
+
 | API group | API version | API Service? | Introduced in | Deprecated in | Removed in |
 |---|---|---|---|---|---|
 | `core.antrea.tanzu.vmware.com` | `v1alpha1` | No | v0.8.0 | v0.11.0 | v0.11.0 |
@@ -62,6 +64,15 @@ These are the API group versions which are curently available when using Antrea.
 | `security.antrea.tanzu.vmware.com` | `v1alpha1` | No | v0.8.0 | v1.0.0 | v1.6.0 |
 | `stats.antrea.tanzu.vmware.com` | `v1alpha1` | Yes | v0.10.0 | v1.0.0 | v1.6.0 |
 | `system.antrea.tanzu.vmware.com` | `v1beta1` | Yes | v0.5.0 | v1.0.0 | v1.6.0 |
+
+### Previously-supported CRDs
+
+| CRD | CRD version | Introduced in | Deprecated in | Removed in |
+|---|---|---|---|---|
+| `ClusterGroup` | v1alpha2 | v1.0.0 | v1.1.0 | v1.12.0 [^1] |
+
+[^1]: The v1alpha2 version of the `ClusterGroup` CRD is no longer served by the
+      apiserver in v1.12 and is completely removed in v1.13.
 
 ## API renaming from `*.antrea.tanzu.vmware.com` to `*.antrea.io`
 

--- a/test/e2e/clustergroup_test.go
+++ b/test/e2e/clustergroup_test.go
@@ -19,12 +19,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	crdv1alpha1 "antrea.io/antrea/pkg/apis/crd/v1alpha1"
-	crdv1alpha2 "antrea.io/antrea/pkg/apis/crd/v1alpha2"
 	crdv1alpha3 "antrea.io/antrea/pkg/apis/crd/v1alpha3"
 )
 
@@ -65,28 +63,6 @@ func testInvalidCGIPBlockWithNSSelector(t *testing.T) {
 		},
 	}
 	if _, err := k8sUtils.CreateOrUpdateV1Alpha3CG(cg); err == nil {
-		// Above creation of CG must fail as it is an invalid spec.
-		failOnError(invalidErr, t)
-	}
-}
-
-func testInvalidCGIPBlockWithIPBlocks(t *testing.T) {
-	invalidErr := fmt.Errorf("clustergroup created with ipBlock and ipBlocks")
-	cgName := "ipb-ipbs"
-	cidr := "10.0.0.10/32"
-	cidr2 := "10.0.0.20/32"
-	ipb := &crdv1alpha1.IPBlock{CIDR: cidr}
-	ipbs := []crdv1alpha1.IPBlock{{CIDR: cidr2}}
-	cg := &crdv1alpha2.ClusterGroup{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: cgName,
-		},
-		Spec: crdv1alpha2.GroupSpec{
-			IPBlocks: ipbs,
-			IPBlock:  ipb,
-		},
-	}
-	if _, err := k8sUtils.CreateOrUpdateV1Alpha2CG(cg); err == nil {
 		// Above creation of CG must fail as it is an invalid spec.
 		failOnError(invalidErr, t)
 	}
@@ -335,51 +311,6 @@ func testClusterGroupRealizationStatus(t *testing.T) {
 
 }
 
-func testClusterGroupConversionV1A2AndV1A3(t *testing.T) {
-	cgName1, cgName2 := "cg-v1a2", "cg-v1a3"
-	ipb1 := crdv1alpha1.IPBlock{
-		CIDR: "192.168.1.0/24",
-	}
-	ipb2 := crdv1alpha1.IPBlock{
-		CIDR: "192.168.2.0/24",
-	}
-	cg1 := &crdv1alpha2.ClusterGroup{
-		ObjectMeta: metav1.ObjectMeta{Name: cgName1},
-		Spec: crdv1alpha2.GroupSpec{
-			IPBlock: &ipb1,
-		},
-	}
-	cg2 := &crdv1alpha3.ClusterGroup{
-		ObjectMeta: metav1.ObjectMeta{Name: cgName2},
-		Spec: crdv1alpha3.GroupSpec{
-			IPBlocks: []crdv1alpha1.IPBlock{
-				ipb1,
-				ipb2,
-			},
-		},
-	}
-	if _, err := k8sUtils.CreateOrUpdateV1Alpha2CG(cg1); err != nil {
-		// Above creation of CG must succeed as it is a valid spec.
-		failOnError(err, t)
-	}
-	// Get v1alpha3 version of ClusterGroup, which was created as v1alpha2
-	cg1Returned, err := k8sUtils.GetV1Alpha3CG(cgName1)
-	if err != nil {
-		failOnError(err, t)
-	}
-	assert.ElementsMatch(t, cg1Returned.Spec.IPBlocks, []crdv1alpha1.IPBlock{ipb1})
-	if _, err := k8sUtils.CreateOrUpdateV1Alpha3CG(cg2); err != nil {
-		// Above creation of CG must succeed as it is a valid spec.
-		failOnError(err, t)
-	}
-	// Get v1alpha2 version of ClusterGroup, which was created as v1alpha3
-	cg2Returned, err := k8sUtils.GetV1Alpha2CG(cgName2)
-	if err != nil {
-		failOnError(err, t)
-	}
-	assert.ElementsMatch(t, cg2Returned.Spec.IPBlocks, []crdv1alpha1.IPBlock{ipb1, ipb2})
-}
-
 func TestClusterGroup(t *testing.T) {
 	skipIfHasWindowsNodes(t)
 	skipIfAntreaPolicyDisabled(t)
@@ -395,7 +326,6 @@ func TestClusterGroup(t *testing.T) {
 	t.Run("TestGroupClusterGroupValidate", func(t *testing.T) {
 		t.Run("Case=IPBlockWithPodSelectorDenied", func(t *testing.T) { testInvalidCGIPBlockWithPodSelector(t) })
 		t.Run("Case=IPBlockWithNamespaceSelectorDenied", func(t *testing.T) { testInvalidCGIPBlockWithNSSelector(t) })
-		t.Run("Case=IPBlockWithIPBlocksDenied", func(t *testing.T) { testInvalidCGIPBlockWithIPBlocks(t) })
 		t.Run("Case=ServiceRefWithPodSelectorDenied", func(t *testing.T) { testInvalidCGServiceRefWithPodSelector(t) })
 		t.Run("Case=ServiceRefWithNamespaceSelectorDenied", func(t *testing.T) { testInvalidCGServiceRefWithNSSelector(t) })
 		t.Run("Case=ServiceRefWithIPBlockDenied", func(t *testing.T) { testInvalidCGServiceRefWithIPBlock(t) })
@@ -407,9 +337,6 @@ func TestClusterGroup(t *testing.T) {
 		t.Run("Case=ChildGroupExceedMaxNestedLevel", func(t *testing.T) { testInvalidCGMaxNestedLevel(t) })
 		t.Run("Case=ClusterGroupRealizationStatusWithChildGroups", func(t *testing.T) { testClusterGroupRealizationStatus(t) })
 		cleanupChildCGForTest(t)
-	})
-	t.Run("TestGroupClusterGroupConversion", func(t *testing.T) {
-		t.Run("Case=ConvertBetweenV1A2AndV1A3", func(t *testing.T) { testClusterGroupConversionV1A2AndV1A3(t) })
 	})
 	k8sUtils.Cleanup(namespaces) // clean up all cluster-scope resources, including CGs
 }

--- a/test/e2e/utils/cg_spec_builder.go
+++ b/test/e2e/utils/cg_spec_builder.go
@@ -18,84 +18,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	crdv1alpha1 "antrea.io/antrea/pkg/apis/crd/v1alpha1"
-	crdv1alpha2 "antrea.io/antrea/pkg/apis/crd/v1alpha2"
 	crdv1alpha3 "antrea.io/antrea/pkg/apis/crd/v1alpha3"
 )
-
-type ClusterGroupV1Alpha2SpecBuilder struct {
-	Spec crdv1alpha2.GroupSpec
-	Name string
-}
-
-func (b *ClusterGroupV1Alpha2SpecBuilder) Get() *crdv1alpha2.ClusterGroup {
-	return &crdv1alpha2.ClusterGroup{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: b.Name,
-		},
-		Spec: b.Spec,
-	}
-}
-
-func (b *ClusterGroupV1Alpha2SpecBuilder) SetName(name string) *ClusterGroupV1Alpha2SpecBuilder {
-	b.Name = name
-	return b
-}
-
-func (b *ClusterGroupV1Alpha2SpecBuilder) SetPodSelector(podSelector map[string]string, podSelectorMatchExp []metav1.LabelSelectorRequirement) *ClusterGroupV1Alpha2SpecBuilder {
-	var ps *metav1.LabelSelector
-	if podSelector != nil {
-		ps = &metav1.LabelSelector{
-			MatchLabels: podSelector,
-		}
-		if podSelectorMatchExp != nil {
-			ps.MatchExpressions = podSelectorMatchExp
-		}
-	}
-	b.Spec.PodSelector = ps
-	return b
-}
-
-func (b *ClusterGroupV1Alpha2SpecBuilder) SetNamespaceSelector(nsSelector map[string]string, nsSelectorMatchExp []metav1.LabelSelectorRequirement) *ClusterGroupV1Alpha2SpecBuilder {
-	var ns *metav1.LabelSelector
-	if nsSelector != nil {
-		ns = &metav1.LabelSelector{
-			MatchLabels: nsSelector,
-		}
-		if nsSelectorMatchExp != nil {
-			ns.MatchExpressions = nsSelectorMatchExp
-		}
-	}
-	b.Spec.NamespaceSelector = ns
-	return b
-}
-
-func (b *ClusterGroupV1Alpha2SpecBuilder) SetIPBlock(ipb *crdv1alpha1.IPBlock) *ClusterGroupV1Alpha2SpecBuilder {
-	b.Spec.IPBlock = ipb
-	return b
-}
-
-func (b *ClusterGroupV1Alpha2SpecBuilder) SetIPBlocks(ipBlocks []crdv1alpha1.IPBlock) *ClusterGroupV1Alpha2SpecBuilder {
-	b.Spec.IPBlocks = ipBlocks
-	return b
-}
-
-func (b *ClusterGroupV1Alpha2SpecBuilder) SetServiceReference(svcNS, svcName string) *ClusterGroupV1Alpha2SpecBuilder {
-	svcRef := &crdv1alpha1.NamespacedName{
-		Namespace: svcNS,
-		Name:      svcName,
-	}
-	b.Spec.ServiceReference = svcRef
-	return b
-}
-
-func (b *ClusterGroupV1Alpha2SpecBuilder) SetChildGroups(cgs []string) *ClusterGroupV1Alpha2SpecBuilder {
-	var childGroups []crdv1alpha2.ClusterGroupReference
-	for _, c := range cgs {
-		childGroups = append(childGroups, crdv1alpha2.ClusterGroupReference(c))
-	}
-	b.Spec.ChildGroups = childGroups
-	return b
-}
 
 // ClusterGroupV1Alpha3SpecBuilder builds a core/v1alpha3 ClusterGroup object.
 type ClusterGroupV1Alpha3SpecBuilder struct {


### PR DESCRIPTION
The API was scheduled for deletion a year ago.
My proposal is to stop serving the API in the next release (v1.12), and remove it completely in the release after that (v1.13). If someone upgrades to Antrea v1.12 and gets errors, they can easily edit the CRD to re-enable serving for the older version (and then convert all their existing resources).