### PR TITLE
Disable ExternalName type of Service exporting

### DIFF
--- a/multicluster/controllers/multicluster/leader/resourceexport_controller.go
+++ b/multicluster/controllers/multicluster/leader/resourceexport_controller.go
@@ -444,7 +444,7 @@ func (r *ResourceExportReconciler) updateResourceExportStatus(resExport *mcsv1al
 				Type:               mcsv1alpha1.ResourceExportFailure,
 				Status:             corev1.ConditionFalse,
 				LastTransitionTime: metav1.Now(),
-				Reason:             "converge_failure",
+				Reason:             "ConvergeFailure",
 				Message:            "ResourceExport can't be converged to ResourceImport",
 			},
 		}

--- a/multicluster/test/integration/serviceexport_controller_test.go
+++ b/multicluster/test/integration/serviceexport_controller_test.go
@@ -178,7 +178,7 @@ var _ = Describe("ServiceExport controller", func() {
 		Expect(err).ToNot(HaveOccurred())
 		conditions := latestSvcExportNoService.Status.Conditions
 		Expect(len(conditions)).Should(Equal(1))
-		Expect(*conditions[0].Message).Should(Equal("the Service does not exist"))
+		Expect(*conditions[0].Message).Should(Equal("Service does not exist"))
 	})
 
 	It("Should delete existing ResourceExport when existing ServiceExport is deleted", func() {
@@ -248,7 +248,7 @@ var _ = Describe("ServiceExport controller", func() {
 		Expect(err).ToNot(HaveOccurred())
 		conditions := latestsvcExportDeletedService.Status.Conditions
 		Expect(len(conditions)).Should(Equal(1))
-		Expect(*conditions[0].Message).Should(Equal("the Service does not exist"))
+		Expect(*conditions[0].Message).Should(Equal("Service does not exist"))
 
 		resExp := &mcsv1alpha1.ResourceExport{}
 		Eventually(func() bool {


### PR DESCRIPTION
ExternalName type of Service shouldn't be exported since it has no ClusterIP assinged, and it's not supported by KEP1645 either. So add a few validation codes to disable ExternalName type of Service exporting.