### PR TITLE
Automated cherry pick of #4547: Add ServiceLocalToRemote reject type

### DIFF
--- a/multicluster/test/e2e/fixtures.go
+++ b/multicluster/test/e2e/fixtures.go
@@ -86,6 +86,13 @@ func deletePodWrapper(tb testing.TB, data *MCTestData, clusterName string, names
 	}
 }
 
+func deletePodAndWaitWrapper(tb testing.TB, data *MCTestData, clusterName string, namespace string, name string) {
+	tb.Logf("Deleting Pod '%s' in Namespace %s of cluster %s", name, namespace, clusterName)
+	if err := data.deletePodAndWait(clusterName, namespace, name); err != nil {
+		tb.Logf("Error when deleting Pod: %v", err)
+	}
+}
+
 func deleteServiceWrapper(tb testing.TB, data *MCTestData, clusterName string, namespace string, name string) {
 	tb.Logf("Deleting Service '%s' in Namespace %s of cluster %s", name, namespace, clusterName)
 	if err := data.deleteService(clusterName, namespace, name); err != nil {

--- a/multicluster/test/e2e/framework.go
+++ b/multicluster/test/e2e/framework.go
@@ -141,6 +141,15 @@ func (data *MCTestData) deletePod(clusterName, namespace, name string) error {
 	return nil
 }
 
+func (data *MCTestData) deletePodAndWait(clusterName, namespace, name string) error {
+	if d, ok := data.clusterTestDataMap[clusterName]; ok {
+		if err := d.DeletePodAndWait(defaultTimeout, namespace, name); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (data *MCTestData) deleteService(clusterName, namespace, name string) error {
 	if d, ok := data.clusterTestDataMap[clusterName]; ok {
 		if err := d.DeleteService(namespace, name); err != nil {

--- a/multicluster/test/e2e/main_test.go
+++ b/multicluster/test/e2e/main_test.go
@@ -113,6 +113,7 @@ func TestConnectivity(t *testing.T) {
 		t.Run("Case=ScaleDownMCServiceEndpoints", func(t *testing.T) { testScaleDownMCServiceEndpoints(t, data) })
 		t.Run("Case=ANPToServices", func(t *testing.T) { testANPToServices(t, data) })
 		t.Run("Case=StretchedNetworkPolicy", func(t *testing.T) { testStretchedNetworkPolicy(t, data) })
+		t.Run("Case=StretchedNetworkPolicyReject", func(t *testing.T) { testStretchedNetworkPolicyReject(t, data) })
 		t.Run("Case=StretchedNetworkPolicyUpdatePod", func(t *testing.T) { testStretchedNetworkPolicyUpdatePod(t, data) })
 		t.Run("Case=StretchedNetworkPolicyUpdateNS", func(t *testing.T) { testStretchedNetworkPolicyUpdateNS(t, data) })
 		t.Run("Case=StretchedNetworkPolicyUpdatePolicy", func(t *testing.T) { testStretchedNetworkPolicyUpdatePolicy(t, data) })

--- a/pkg/agent/controller/networkpolicy/reject_test.go
+++ b/pkg/agent/controller/networkpolicy/reject_test.go
@@ -1,0 +1,275 @@
+// Copyright 2023 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package networkpolicy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"antrea.io/antrea/pkg/agent/interfacestore"
+)
+
+func TestGetRejectType(t *testing.T) {
+	tests := []struct {
+		name               string
+		isServiceTraffic   bool
+		antreaProxyEnabled bool
+		srcIsLocal         bool
+		dstIsLocal         bool
+		expectRejectType   RejectType
+	}{
+		{
+			name:               "RejectPodLocal",
+			isServiceTraffic:   false,
+			antreaProxyEnabled: true,
+			srcIsLocal:         true,
+			dstIsLocal:         true,
+			expectRejectType:   RejectPodLocal,
+		},
+		{
+			name:               "RejectPodRemoteToLocal",
+			isServiceTraffic:   false,
+			antreaProxyEnabled: true,
+			srcIsLocal:         false,
+			dstIsLocal:         true,
+			expectRejectType:   RejectPodRemoteToLocal,
+		},
+		{
+			name:               "RejectPodLocalToRemote",
+			isServiceTraffic:   false,
+			antreaProxyEnabled: true,
+			srcIsLocal:         true,
+			dstIsLocal:         false,
+			expectRejectType:   RejectPodLocalToRemote,
+		},
+		{
+			name:               "RejectServiceLocal",
+			isServiceTraffic:   true,
+			antreaProxyEnabled: true,
+			srcIsLocal:         true,
+			dstIsLocal:         true,
+			expectRejectType:   RejectServiceLocal,
+		},
+		{
+			name:               "RejectServiceRemoteToLocal",
+			isServiceTraffic:   true,
+			antreaProxyEnabled: true,
+			srcIsLocal:         false,
+			dstIsLocal:         true,
+			expectRejectType:   RejectServiceRemoteToLocal,
+		},
+		{
+			name:               "RejectServiceLocalToRemote",
+			isServiceTraffic:   true,
+			antreaProxyEnabled: true,
+			srcIsLocal:         true,
+			dstIsLocal:         false,
+			expectRejectType:   RejectServiceLocalToRemote,
+		},
+		{
+			name:               "RejectNoAPServiceLocal",
+			isServiceTraffic:   true,
+			antreaProxyEnabled: false,
+			srcIsLocal:         true,
+			dstIsLocal:         true,
+			expectRejectType:   RejectNoAPServiceLocal,
+		},
+		{
+			name:               "RejectNoAPServiceRemoteToLocal",
+			isServiceTraffic:   true,
+			antreaProxyEnabled: false,
+			srcIsLocal:         false,
+			dstIsLocal:         true,
+			expectRejectType:   RejectNoAPServiceRemoteToLocal,
+		},
+		{
+			name:               "RejectServiceRemoteToExternal",
+			isServiceTraffic:   true,
+			antreaProxyEnabled: true,
+			srcIsLocal:         false,
+			dstIsLocal:         false,
+			expectRejectType:   RejectServiceRemoteToExternal,
+		},
+		{
+			name:               "Unsupported pod2pod remote2remote",
+			isServiceTraffic:   false,
+			antreaProxyEnabled: true,
+			srcIsLocal:         false,
+			dstIsLocal:         false,
+			expectRejectType:   Unsupported,
+		},
+		{
+			name:               "Unsupported noAP remote2remote",
+			isServiceTraffic:   true,
+			antreaProxyEnabled: false,
+			srcIsLocal:         false,
+			dstIsLocal:         false,
+			expectRejectType:   Unsupported,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rejectType := getRejectType(tt.isServiceTraffic, tt.antreaProxyEnabled, tt.srcIsLocal, tt.dstIsLocal)
+			assert.Equal(t, tt.expectRejectType, rejectType)
+		})
+	}
+}
+
+func TestGetRejectOFPorts(t *testing.T) {
+	unsetPort := uint32(0)
+	tunPort := uint32(1)
+	gwPort := uint32(2)
+	srcIface := &interfacestore.InterfaceConfig{
+		OVSPortConfig: &interfacestore.OVSPortConfig{
+			OFPort: 3,
+		},
+	}
+	externalSrcIface := &interfacestore.InterfaceConfig{
+		Type: interfacestore.ExternalEntityInterface,
+		OVSPortConfig: &interfacestore.OVSPortConfig{
+			OFPort: 3,
+		},
+		EntityInterfaceConfig: &interfacestore.EntityInterfaceConfig{
+			UplinkPort: &interfacestore.OVSPortConfig{
+				OFPort: 4,
+			},
+		},
+	}
+	dstIface := &interfacestore.InterfaceConfig{
+		OVSPortConfig: &interfacestore.OVSPortConfig{
+			OFPort: 5,
+		},
+	}
+	externalDstIface := &interfacestore.InterfaceConfig{
+		Type: interfacestore.ExternalEntityInterface,
+		OVSPortConfig: &interfacestore.OVSPortConfig{
+			OFPort: 5,
+		},
+		EntityInterfaceConfig: &interfacestore.EntityInterfaceConfig{
+			UplinkPort: &interfacestore.OVSPortConfig{
+				OFPort: 6,
+			},
+		},
+	}
+	tests := []struct {
+		name          string
+		rejectType    RejectType
+		tunPort       uint32
+		srcInterface  *interfacestore.InterfaceConfig
+		dstInterface  *interfacestore.InterfaceConfig
+		expectInPort  uint32
+		expectOutPort uint32
+	}{
+		{
+			name:          "RejectPodLocal",
+			rejectType:    RejectPodLocal,
+			srcInterface:  srcIface,
+			dstInterface:  dstIface,
+			expectInPort:  uint32(srcIface.OFPort),
+			expectOutPort: uint32(dstIface.OFPort),
+		},
+		{
+			name:          "RejectPodLocalToRemote",
+			rejectType:    RejectPodLocalToRemote,
+			srcInterface:  srcIface,
+			expectInPort:  uint32(srcIface.OFPort),
+			expectOutPort: unsetPort,
+		},
+		{
+			name:          "RejectPodLocalToRemoteExternal",
+			rejectType:    RejectPodLocalToRemote,
+			srcInterface:  externalSrcIface,
+			expectInPort:  uint32(externalSrcIface.OFPort),
+			expectOutPort: uint32(externalSrcIface.UplinkPort.OFPort),
+		},
+		{
+			name:          "RejectPodRemoteToLocal",
+			rejectType:    RejectPodRemoteToLocal,
+			dstInterface:  dstIface,
+			expectInPort:  gwPort,
+			expectOutPort: uint32(dstIface.OFPort),
+		},
+		{
+			name:          "RejectPodRemoteToLocalExternal",
+			rejectType:    RejectPodRemoteToLocal,
+			dstInterface:  externalDstIface,
+			expectInPort:  uint32(externalDstIface.UplinkPort.OFPort),
+			expectOutPort: uint32(externalDstIface.OFPort),
+		},
+		{
+			name:          "RejectServiceLocal",
+			rejectType:    RejectServiceLocal,
+			srcInterface:  srcIface,
+			expectInPort:  uint32(srcIface.OFPort),
+			expectOutPort: unsetPort,
+		},
+		{
+			name:          "RejectServiceLocalToRemote",
+			rejectType:    RejectServiceLocalToRemote,
+			srcInterface:  srcIface,
+			expectInPort:  uint32(srcIface.OFPort),
+			expectOutPort: unsetPort,
+		},
+		{
+			name:          "RejectServiceRemoteToLocal",
+			rejectType:    RejectServiceRemoteToLocal,
+			expectInPort:  gwPort,
+			expectOutPort: unsetPort,
+		},
+		{
+			name:          "RejectNoAPServiceLocal",
+			rejectType:    RejectNoAPServiceLocal,
+			srcInterface:  srcIface,
+			expectInPort:  uint32(srcIface.OFPort),
+			expectOutPort: gwPort,
+		},
+		{
+			name:          "RejectNoAPServiceRemoteToLocal",
+			rejectType:    RejectNoAPServiceRemoteToLocal,
+			tunPort:       tunPort,
+			expectInPort:  tunPort,
+			expectOutPort: gwPort,
+		},
+		{
+			name:          "RejectNoAPServiceRemoteToLocalWithoutTun",
+			rejectType:    RejectNoAPServiceRemoteToLocal,
+			tunPort:       unsetPort,
+			expectInPort:  gwPort,
+			expectOutPort: gwPort,
+		},
+		{
+			name:          "RejectServiceRemoteToExternal",
+			rejectType:    RejectServiceRemoteToExternal,
+			tunPort:       tunPort,
+			expectInPort:  tunPort,
+			expectOutPort: unsetPort,
+		},
+		{
+			name:          "RejectServiceRemoteToExternalWithoutTun",
+			rejectType:    RejectServiceRemoteToExternal,
+			tunPort:       unsetPort,
+			expectInPort:  gwPort,
+			expectOutPort: unsetPort,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inPort, outPort := getRejectOFPorts(tt.rejectType, tt.srcInterface, tt.dstInterface, gwPort, tt.tunPort)
+			assert.Equal(t, tt.expectInPort, inPort)
+			assert.Equal(t, tt.expectOutPort, outPort)
+		})
+	}
+}

--- a/test/e2e/antreaipam_test.go
+++ b/test/e2e/antreaipam_test.go
@@ -336,7 +336,7 @@ func testAntreaIPAMStatefulSet(t *testing.T, data *TestData, dedicatedIPPoolKey 
 	if err != nil {
 		t.Fatalf("Error when creating Pod '%s': %v", podName, err)
 	}
-	defer data.deletePodAndWait(defaultTimeout, podName, testAntreaIPAMNamespace)
+	defer data.DeletePodAndWait(defaultTimeout, podName, testAntreaIPAMNamespace)
 	podIPs, err := data.podWaitForIPs(defaultTimeout, podName, testAntreaIPAMNamespace)
 	if err != nil {
 		t.Fatalf("Error when waiting Pod IPs: %v", err)
@@ -376,7 +376,7 @@ func testAntreaIPAMStatefulSet(t *testing.T, data *TestData, dedicatedIPPoolKey 
 	}
 	checkStatefulSetIPPoolAllocation(t, data, stsName, testAntreaIPAMNamespace, ipPoolName, ipOffsets, reservedIPOffsets)
 
-	data.deletePodAndWait(defaultTimeout, podName, testAntreaIPAMNamespace)
+	data.DeletePodAndWait(defaultTimeout, podName, testAntreaIPAMNamespace)
 	_, err = data.restartStatefulSet(stsName, testAntreaIPAMNamespace)
 	if err != nil {
 		t.Fatalf("Error when restarting StatefulSet '%s': %v", stsName, err)

--- a/test/e2e/antreapolicy_test.go
+++ b/test/e2e/antreapolicy_test.go
@@ -2219,7 +2219,7 @@ func testACNPRejectIngress(t *testing.T, protocol AntreaPolicyProtocol) {
 func testRejectServiceTraffic(t *testing.T, data *TestData) {
 	clientName := "agnhost-client"
 	require.NoError(t, data.createAgnhostPodOnNode(clientName, data.testNamespace, nodeName(0), false))
-	defer data.deletePodAndWait(defaultTimeout, clientName, data.testNamespace)
+	defer data.DeletePodAndWait(defaultTimeout, clientName, data.testNamespace)
 	_, err := data.podWaitForIPs(defaultTimeout, clientName, data.testNamespace)
 	require.NoError(t, err)
 
@@ -2301,7 +2301,7 @@ func testRejectServiceTraffic(t *testing.T, data *TestData) {
 func testRejectNoInfiniteLoop(t *testing.T, data *TestData) {
 	clientName := "agnhost-client"
 	require.NoError(t, data.createAgnhostPodOnNode(clientName, data.testNamespace, nodeName(0), false))
-	defer data.deletePodAndWait(defaultTimeout, clientName, data.testNamespace)
+	defer data.DeletePodAndWait(defaultTimeout, clientName, data.testNamespace)
 	_, err := data.podWaitForIPs(defaultTimeout, clientName, data.testNamespace)
 	require.NoError(t, err)
 
@@ -3549,7 +3549,7 @@ func testACNPNodeSelectorIngress(t *testing.T, data *TestData) {
 
 	clientName := "agnhost-client"
 	require.NoError(t, data.createAgnhostPodOnNode(clientName, namespaces["z"], controlPlaneNodeName(), true))
-	defer data.deletePodAndWait(defaultTimeout, clientName, namespaces["z"])
+	defer data.DeletePodAndWait(defaultTimeout, clientName, namespaces["z"])
 	_, err := data.podWaitForIPs(defaultTimeout, clientName, namespaces["z"])
 	require.NoError(t, err)
 
@@ -3726,7 +3726,7 @@ sleep 3600
 		if err := NewPodBuilder(clientName, data.testNamespace, agnhostImage).OnNode(nodeName(idx)).WithCommand([]string{"sh", "-c", cmd}).InHostNetwork().Privileged().Create(data); err != nil {
 			t.Fatalf("Failed to create client Pod: %v", err)
 		}
-		defer data.deletePodAndWait(defaultTimeout, clientName, data.testNamespace)
+		defer data.DeletePodAndWait(defaultTimeout, clientName, data.testNamespace)
 		err = data.podWaitForRunning(defaultTimeout, clientName, data.testNamespace)
 		failOnError(err, t)
 	}

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -211,7 +211,7 @@ func (data *TestData) testDeletePod(t *testing.T, podName string, nodeName strin
 	}
 
 	t.Logf("Deleting Pod '%s'", podName)
-	if err := data.deletePodAndWait(defaultTimeout, podName, namespace); err != nil {
+	if err := data.DeletePodAndWait(defaultTimeout, podName, namespace); err != nil {
 		t.Fatalf("Error when deleting Pod: %v", err)
 	}
 

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -1361,7 +1361,7 @@ func (data *TestData) DeletePod(namespace, name string) error {
 
 // Deletes a Pod in the test namespace then waits us to timeout for the Pod not to be visible to the
 // client anymore.
-func (data *TestData) deletePodAndWait(timeout time.Duration, name string, ns string) error {
+func (data *TestData) DeletePodAndWait(timeout time.Duration, name string, ns string) error {
 	if err := data.DeletePod(ns, name); err != nil {
 		return err
 	}

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -650,7 +650,7 @@ func testProxyServiceSessionAffinity(ipFamily *corev1.IPFamily, ingressIPs []str
 
 	require.NoError(t, data.createNginxPodOnNode(nginx, data.testNamespace, nodeName, false))
 	nginxIP, err := data.podWaitForIPs(defaultTimeout, nginx, data.testNamespace)
-	defer data.deletePodAndWait(defaultTimeout, nginx, data.testNamespace)
+	defer data.DeletePodAndWait(defaultTimeout, nginx, data.testNamespace)
 	require.NoError(t, err)
 	require.NoError(t, data.podWaitForRunning(defaultTimeout, nginx, data.testNamespace))
 	svc, err := data.createNginxClusterIPService(nginx, data.testNamespace, true, ipFamily)
@@ -662,7 +662,7 @@ func testProxyServiceSessionAffinity(ipFamily *corev1.IPFamily, ingressIPs []str
 
 	busyboxPod := randName("busybox-")
 	require.NoError(t, data.createBusyboxPodOnNode(busyboxPod, data.testNamespace, nodeName, false))
-	defer data.deletePodAndWait(defaultTimeout, busyboxPod, data.testNamespace)
+	defer data.DeletePodAndWait(defaultTimeout, busyboxPod, data.testNamespace)
 	require.NoError(t, data.podWaitForRunning(defaultTimeout, busyboxPod, data.testNamespace))
 	stdout, stderr, err := data.runWgetCommandOnBusyboxWithRetry(busyboxPod, data.testNamespace, svc.Spec.ClusterIP, 5)
 	require.NoError(t, err, fmt.Sprintf("ipFamily: %v\nstdout: %s\nstderr: %s\n", *ipFamily, stdout, stderr))
@@ -978,7 +978,7 @@ func testProxyEndpointLifeCycle(ipFamily *corev1.IPFamily, data *TestData, t *te
 		require.Contains(t, groupOutput, k)
 	}
 
-	require.NoError(t, data.deletePodAndWait(defaultTimeout, nginx, data.testNamespace))
+	require.NoError(t, data.DeletePodAndWait(defaultTimeout, nginx, data.testNamespace))
 
 	// Wait for one second to make sure the pipeline to be updated.
 	time.Sleep(time.Second)
@@ -1032,7 +1032,7 @@ func testProxyServiceLifeCycle(ipFamily *corev1.IPFamily, ingressIPs []string, d
 	nginx := randName("nginx-")
 
 	require.NoError(t, data.createNginxPodOnNode(nginx, data.testNamespace, nodeName, false))
-	defer data.deletePodAndWait(defaultTimeout, nginx, data.testNamespace)
+	defer data.DeletePodAndWait(defaultTimeout, nginx, data.testNamespace)
 	nginxIPs, err := data.podWaitForIPs(defaultTimeout, nginx, data.testNamespace)
 	require.NoError(t, err)
 	var nginxIP string

--- a/test/e2e/service_externalip_test.go
+++ b/test/e2e/service_externalip_test.go
@@ -579,7 +579,7 @@ func testExternalIPAccess(t *testing.T, data *TestData) {
 			// Create agnhost Pods on each Node.
 			for idx, node := range nodes {
 				createAgnhostPod(t, data, agnhosts[idx], node, false)
-				defer data.deletePodAndWait(defaultTimeout, agnhosts[idx], data.testNamespace)
+				defer data.DeletePodAndWait(defaultTimeout, agnhosts[idx], data.testNamespace)
 			}
 			var port int32 = 8080
 			externalIPTestCases := []struct {
@@ -670,7 +670,7 @@ sleep 3600`, tt.clientName, tt.clientIP, tt.localIP, tt.clientIPMaskLen)
 						return false, nil
 					})
 					require.NoError(t, err)
-					defer data.deletePodAndWait(defaultTimeout, tt.clientName, data.testNamespace)
+					defer data.DeletePodAndWait(defaultTimeout, tt.clientName, data.testNamespace)
 
 					hostNameUrl := fmt.Sprintf("%s/%s", baseUrl, "hostname")
 					probeCmd := fmt.Sprintf("ip netns exec %s curl --connect-timeout 1 --retry 5 --retry-connrefused %s", tt.clientName, hostNameUrl)

--- a/test/e2e/service_test.go
+++ b/test/e2e/service_test.go
@@ -157,7 +157,7 @@ func (data *TestData) testNodePort(t *testing.T, isWindows bool, clientNamespace
 	// e2e framework, nodeName(0)/Control-plane Node is guaranteed to be a Linux one.
 	clientName := "busybox-client"
 	require.NoError(t, data.createBusyboxPodOnNode(clientName, clientNamespace, nodeName(0), false))
-	defer data.deletePodAndWait(defaultTimeout, clientName, clientNamespace)
+	defer data.DeletePodAndWait(defaultTimeout, clientName, clientNamespace)
 	podIPs, err := data.podWaitForIPs(defaultTimeout, clientName, clientNamespace)
 	require.NoError(t, err)
 	t.Logf("Created client Pod IPs %v", podIPs.ipStrings)
@@ -198,7 +198,7 @@ func (data *TestData) createAgnhostServiceAndBackendPods(t *testing.T, name, nam
 	require.NoError(t, err)
 
 	cleanup := func() {
-		data.deletePodAndWait(defaultTimeout, name, namespace)
+		data.DeletePodAndWait(defaultTimeout, name, namespace)
 		data.deleteServiceAndWait(defaultTimeout, name, namespace)
 	}
 

--- a/test/e2e/wireguard_test.go
+++ b/test/e2e/wireguard_test.go
@@ -142,7 +142,7 @@ func testServiceConnectivity(t *testing.T, data *TestData) {
 
 	// Create the a hostNetwork Pod on a Node different from the service's backend Pod, so the service traffic will be transferred across the tunnel.
 	require.NoError(t, NewPodBuilder(clientPodName, data.testNamespace, busyboxImage).OnNode(clientPodNode).WithCommand([]string{"sleep", "3600"}).InHostNetwork().Create(data))
-	defer data.deletePodAndWait(defaultTimeout, clientPodName, data.testNamespace)
+	defer data.DeletePodAndWait(defaultTimeout, clientPodName, data.testNamespace)
 	require.NoError(t, data.podWaitForRunning(defaultTimeout, clientPodName, data.testNamespace))
 
 	err := data.runNetcatCommandFromTestPod(clientPodName, data.testNamespace, svc.Spec.ClusterIP, 80)


### PR DESCRIPTION
Cherry pick of #4547 on release-1.10.

#4547: Add ServiceLocalToRemote reject type

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.