### PR TITLE
Automated cherry pick of #4369: Fix base-windows Dockerfile and script

### DIFF
--- a/build/images/base-windows/Dockerfile
+++ b/build/images/base-windows/Dockerfile
@@ -28,20 +28,20 @@ WORKDIR /
 
 RUN mkdir -Force C:\opt\cni\bin
 
-RUN curl.exe -LO https://github.com/containernetworking/plugins/releases/download/${env:CNI_BINARIES_VERSION}/cni-plugins-windows-amd64-${env:CNI_BINARIES_VERSION}.tgz; \
+RUN curl.exe -fLO https://github.com/containernetworking/plugins/releases/download/${env:CNI_BINARIES_VERSION}/cni-plugins-windows-amd64-${env:CNI_BINARIES_VERSION}.tgz; \
     tar -xzf cni-plugins-windows-amd64-${env:CNI_BINARIES_VERSION}.tgz  -C C:\opt\cni\bin ${env:CNI_PLUGINS}; \
     rm cni-plugins-windows-amd64-${env:CNI_BINARIES_VERSION}.tgz
 
 # Install 7zip, git-for-windows, mingw64 to support "make tool"
-RUN curl.exe -LO https://www.7-zip.org/a/7z2107-x64.exe; \
+RUN curl.exe -fLO https://www.7-zip.org/a/7z2107-x64.exe; \
     cmd /c start /wait 7z2107-x64.exe /S; \
     del 7z2107-x64.exe;  $env:Path = $env:Path+';C:/Program Files/7-Zip'; \
-    curl.exe -Lo mingw.7z https://cfhcable.dl.sourceforge.net/project/mingw-w64/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/8.1.0/threads-posix/seh/x86_64-8.1.0-release-posix-seh-rt_v6-rev0.7z; \
+    curl.exe -fLo mingw.7z https://cfhcable.dl.sourceforge.net/project/mingw-w64/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/8.1.0/threads-posix/seh/x86_64-8.1.0-release-posix-seh-rt_v6-rev0.7z; \
     7z x mingw.7z; cp c:/mingw64/bin/mingw32-make.exe c:/mingw64/bin/make.exe; \
-    curl.exe -Lo git.exe https://github.com/git-for-windows/git/releases/download/v2.35.1.windows.2/PortableGit-2.35.1.2-64-bit.7z.exe; \
+    curl.exe -fLo git.exe https://github.com/git-for-windows/git/releases/download/v2.35.1.windows.2/PortableGit-2.35.1.2-64-bit.7z.exe; \
     7z x git.exe -oC:\git; \
     mkdir C:\wins; \
-    curl.exe -Lo C:/wins/wins.exe https://github.com/rancher/wins/releases/download/v0.0.4/wins.exe
+    curl.exe -fLo C:/wins/wins.exe https://github.com/rancher/wins/releases/download/v0.0.4/wins.exe
 
 FROM golang:${GO_VERSION}-nanoserver as windows-golang
 

--- a/hack/build-antrea-windows-all.sh
+++ b/hack/build-antrea-windows-all.sh
@@ -92,6 +92,7 @@ docker build --target windows-utility-base \
 docker build --target windows-golang \
        --cache-from antrea/windows-golang:$WIN_BUILD_TAG \
        -t antrea/windows-golang:$WIN_BUILD_TAG \
+       --build-arg CNI_BINARIES_VERSION=$CNI_BINARIES_VERSION \
        --build-arg GO_VERSION=$GO_VERSION \
        --build-arg NANOSERVER_VERSION=$NANOSERVER_VERSION .
 docker build \
@@ -99,6 +100,7 @@ docker build \
        --cache-from antrea/windows-golang:$WIN_BUILD_TAG \
        --cache-from antrea/base-windows:$WIN_BUILD_TAG \
        -t antrea/base-windows:$WIN_BUILD_TAG \
+       --build-arg CNI_BINARIES_VERSION=$CNI_BINARIES_VERSION \
        --build-arg GO_VERSION=$GO_VERSION \
        --build-arg NANOSERVER_VERSION=$NANOSERVER_VERSION .
 cd -


### PR DESCRIPTION
Cherry pick of #4369 on release-1.9.

#4369: Fix base-windows Dockerfile and script

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.