### PR TITLE
Add timeout for sonobuoy deletion

### DIFF
--- a/ci/run-k8s-e2e-tests.sh
+++ b/ci/run-k8s-e2e-tests.sh
@@ -174,7 +174,7 @@ function run_sonobuoy() {
     local focus_regex="$1"
     local skip_regex="$2"
 
-    $SONOBUOY delete --wait $KUBECONFIG_OPTION
+    $SONOBUOY delete --wait=10 $KUBECONFIG_OPTION
     echo "Running tests with sonobuoy. While test is running, check logs with: $SONOBUOY $KUBECONFIG_OPTION logs -f."
     set -x
     if [[ "$focus_regex" == "" && "$skip_regex" == "" ]]; then
@@ -265,7 +265,7 @@ if $RUN_SIG_NETWORK; then
 fi
 
 echoerr "Deleting sonobuoy resources"
-$SONOBUOY delete --wait $KUBECONFIG_OPTION
+$SONOBUOY delete --wait=10 $KUBECONFIG_OPTION
 
 if [[ $errors -ne 0 ]]; then
     exit 1


### PR DESCRIPTION
The default timeout will be 60mins which is not necessary for a deletion action, so change it to 10mins so e2e tests can fail quicker instead of waiting for 1 hour to fail:
```
Deleting sonobuoy resources
time="2023-04-10T14:13:43Z" level=info msg="delete request issued" kind=namespace namespace=sonobuoy
time="2023-04-10T14:13:43Z" level=info msg="delete request issued" kind=clusterrolebindings
time="2023-04-10T14:13:43Z" level=info msg="delete request issued" kind=clusterroles
time="2023-04-10T15:13:43Z" level=error msg="failed to delete sonobuoy resources: waiting for delete conditions to be met: timed out waiting for the condition"
```