### PR TITLE
Cascading --pull to build.sh

### DIFF
--- a/ci/jenkins/test-mc.sh
+++ b/ci/jenkins/test-mc.sh
@@ -296,7 +296,6 @@ function deliver_antrea_multicluster {
     echo "====== Delivering Antrea to all Nodes ======"
     docker save -o ${WORKDIR}/antrea-ubuntu.tar antrea/antrea-ubuntu:latest
 
-
     if [[ ${KIND} == "true" ]]; then
         for name in ${CLUSTER_NAMES[*]}; do
             kind load docker-image antrea/antrea-ubuntu:latest --name ${name}

--- a/hack/build-antrea-linux-all.sh
+++ b/hack/build-antrea-linux-all.sh
@@ -82,6 +82,9 @@ pushd "$THIS_DIR/.." > /dev/null
 
 ARGS=""
 PLATFORM_ARG=""
+if $PULL; then
+   ARGS="$ARGS --pull"
+fi
 if $PUSH; then
    ARGS="$ARGS --push"
 fi


### PR DESCRIPTION
When e2e test scripts call build-antrea-linux-all.sh with `--pull`, it actually doesn't pass this option to build.sh for base images building. Fix it by cascading `--pull` to build.sh in `build/images/ovs` and `build/images/base` folder, which can help to reduce image building time.