### PR TITLE
Automated cherry pick of #4529: Fix tunnelDstIP field in traceflow on dual-stack

### DIFF
--- a/pkg/agent/controller/traceflow/packetin.go
+++ b/pkg/agent/controller/traceflow/packetin.go
@@ -237,7 +237,8 @@ func (c *Controller) parsePacketIn(pktIn *ofctrl.PacketIn) (*crdv1alpha1.Tracefl
 	if tableID == openflow.L2ForwardingOutTable.GetID() {
 		ob := new(crdv1alpha1.Observation)
 		tunnelDstIP := ""
-		isIPv6 := c.nodeConfig.NodeIPv6Addr != nil
+		// decide according to packet.
+		isIPv6 := etherData.Ethertype == protocol.IPv6_MSG
 		if match := getMatchTunnelDstField(matchers, isIPv6); match != nil {
 			tunnelDstIP, err = getTunnelDstValue(match)
 			if err != nil {


### PR DESCRIPTION
Cherry pick of #4529 on release-1.10.

#4529: Fix tunnelDstIP field in traceflow on dual-stack

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.