### PR TITLE
[WIP] Drop use of OFSwitch groupdb cache

### DIFF
--- a/pkg/ovs/openflow/ofctrl_bridge.go
+++ b/pkg/ovs/openflow/ofctrl_bridge.go
@@ -216,21 +216,13 @@ func (b *OFBridge) CreateGroup(id GroupIDType) Group {
 }
 
 func (b *OFBridge) createGroupWithType(id GroupIDType, groupType ofctrl.GroupType) Group {
-	ofctrlGroup, err := b.ofSwitch.NewGroup(uint32(id), groupType)
-	if err != nil { // group already exists
-		ofctrlGroup = b.ofSwitch.GetGroup(uint32(id))
-	}
+	ofctrlGroup := &ofctrl.Group{ID: uint32(id), GroupType: groupType, Switch: b.ofSwitch}
 	g := &ofGroup{bridge: b, ofctrl: ofctrlGroup}
 	return g
 }
 
-// DeleteGroup deletes a specified group in groupDb.
 func (b *OFBridge) DeleteGroup(id GroupIDType) error {
-	ofctrlGroup := b.ofSwitch.GetGroup(uint32(id))
-	if ofctrlGroup == nil {
-		return nil
-	}
-	return b.ofSwitch.DeleteGroup(uint32(id))
+	return nil
 }
 
 func (b *OFBridge) CreateMeter(id MeterIDType, flags ofctrl.MeterFlag) Meter {

--- a/pkg/ovs/openflow/ofctrl_group.go
+++ b/pkg/ovs/openflow/ofctrl_group.go
@@ -36,13 +36,12 @@ type ofGroup struct {
 // ofSwitch keeps a list of all Group objects, so this operation is
 // needed. Reset() should be called before replaying the Group to OVS.
 func (g *ofGroup) Reset() {
-	// An error ("group already exists") is not possible here since we are
-	// using a new instance of ofSwitch and re-creating a group which was
-	// created successfully before. There will be no duplicate group IDs. If
-	// something is wrong and there is an error, g.ofctrl will be set to nil
-	// and the Agent will crash later.
-	newGroup, _ := g.bridge.ofSwitch.NewGroup(g.ofctrl.ID, g.ofctrl.GroupType)
-	newGroup.Buckets = g.ofctrl.Buckets
+	newGroup := &ofctrl.Group{
+		ID:        g.ofctrl.ID,
+		GroupType: g.ofctrl.GroupType,
+		Switch:    g.bridge.ofSwitch,
+		Buckets:   g.ofctrl.Buckets,
+	}
 	g.ofctrl = newGroup
 }
 


### PR DESCRIPTION
The use of the groupDb cache in OFSwitch is dropped because we have already managed the group cache and group id on the caller side. In addition, the groupDb cache in OFSwitch lacks concurrency control. Remove it fixes https://github.com/antrea-io/antrea/issues/4847.