### PR TITLE
Fix EndpointSlice API availablility check

### DIFF
--- a/pkg/agent/proxy/proxier.go
+++ b/pkg/agent/proxy/proxier.go
@@ -1165,7 +1165,7 @@ func endpointSliceAPIAvailable(k8sClient clientset.Interface) (bool, error) {
 		return false, fmt.Errorf("error getting server resources for GroupVersion %s: %v", discovery.SchemeGroupVersion.String(), err)
 	}
 	for _, resource := range resources.APIResources {
-		if resource.Name == "endpointslice" {
+		if resource.Kind == "EndpointSlice" {
 			return true, nil
 		}
 	}

--- a/pkg/agent/proxy/proxier_test.go
+++ b/pkg/agent/proxy/proxier_test.go
@@ -2715,7 +2715,7 @@ func TestEndpointSliceAPIAvailable(t *testing.T) {
 			resources: []*metav1.APIResourceList{
 				{
 					GroupVersion: discovery.SchemeGroupVersion.String(),
-					APIResources: []metav1.APIResource{{Name: "endpointslice"}},
+					APIResources: []metav1.APIResource{{Kind: "EndpointSlice"}},
 				},
 			},
 			expectedAvailable: true,


### PR DESCRIPTION
The API resource name is plural. The incorrect check caused AntreaProxy to always fall back to the Endpoints API.