### PR TITLE
Automated cherry pick of #4852: Fix EndpointSlice API availablility check

### DIFF
--- a/pkg/agent/proxy/proxier.go
+++ b/pkg/agent/proxy/proxier.go
@@ -1187,7 +1187,7 @@ func endpointSliceAPIAvailable(k8sClient clientset.Interface) (bool, error) {
 		return false, fmt.Errorf("error getting server resources for GroupVersion %s: %v", discovery.SchemeGroupVersion.String(), err)
 	}
 	for _, resource := range resources.APIResources {
-		if resource.Name == "endpointslice" {
+		if resource.Kind == "EndpointSlice" {
 			return true, nil
 		}
 	}

--- a/pkg/agent/proxy/proxier_test.go
+++ b/pkg/agent/proxy/proxier_test.go
@@ -2753,7 +2753,7 @@ func TestEndpointSliceAPIAvailable(t *testing.T) {
 			resources: []*metav1.APIResourceList{
 				{
 					GroupVersion: discovery.SchemeGroupVersion.String(),
-					APIResources: []metav1.APIResource{{Name: "endpointslice"}},
+					APIResources: []metav1.APIResource{{Kind: "EndpointSlice"}},
 				},
 			},
 			expectedAvailable: true,


### PR DESCRIPTION
Cherry pick of #4852 on release-1.11.

#4852: Fix EndpointSlice API availablility check

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.