### PR TITLE
Several fixes in ci/test-conformance-gke.sh

### DIFF
--- a/ci/jenkins/test-rancher.sh
+++ b/ci/jenkins/test-rancher.sh
@@ -233,9 +233,9 @@ function run_conformance {
     kubectl rollout status daemonset/antrea-agent -n kube-system
 
     if [[ "$TESTCASE" =~ "conformance" ]]; then
-        ${WORKSPACE}/ci/run-k8s-e2e-tests.sh --e2e-conformance --log-mode $MODE --image-pull-policy ${IMAGE_PULL_POLICY} --kube-conformance-image-version "auto" > ${WORKSPACE}/test-result.log
+        ${WORKSPACE}/ci/run-k8s-e2e-tests.sh --e2e-conformance --log-mode $MODE --image-pull-policy ${IMAGE_PULL_POLICY} --kubernetes-version "auto" > ${WORKSPACE}/test-result.log
     else
-        ${WORKSPACE}/ci/run-k8s-e2e-tests.sh --e2e-network-policy --log-mode $MODE --image-pull-policy ${IMAGE_PULL_POLICY} --kube-conformance-image-version "auto" > ${WORKSPACE}/test-result.log
+        ${WORKSPACE}/ci/run-k8s-e2e-tests.sh --e2e-network-policy --log-mode $MODE --image-pull-policy ${IMAGE_PULL_POLICY} --kubernetes-version "auto" > ${WORKSPACE}/test-result.log
     fi
 
     cat ${WORKSPACE}/test-result.log

--- a/ci/jenkins/test.sh
+++ b/ci/jenkins/test.sh
@@ -719,9 +719,9 @@ function run_conformance {
     kubectl rollout status daemonset/antrea-agent -n kube-system
 
     if [[ "$TESTCASE" =~ "conformance" ]]; then
-        ${WORKSPACE}/ci/run-k8s-e2e-tests.sh --e2e-conformance --e2e-skip "$CONFORMANCE_SKIP" --log-mode $MODE --image-pull-policy ${IMAGE_PULL_POLICY} --kube-conformance-image-version "auto" > ${WORKSPACE}/test-result.log
+        ${WORKSPACE}/ci/run-k8s-e2e-tests.sh --e2e-conformance --e2e-skip "$CONFORMANCE_SKIP" --log-mode $MODE --image-pull-policy ${IMAGE_PULL_POLICY} --kubernetes-version "auto" > ${WORKSPACE}/test-result.log
     else
-        ${WORKSPACE}/ci/run-k8s-e2e-tests.sh --e2e-network-policy --e2e-skip "$NETWORKPOLICY_SKIP" --log-mode $MODE --image-pull-policy ${IMAGE_PULL_POLICY} --kube-conformance-image-version "auto" > ${WORKSPACE}/test-result.log
+        ${WORKSPACE}/ci/run-k8s-e2e-tests.sh --e2e-network-policy --e2e-skip "$NETWORKPOLICY_SKIP" --log-mode $MODE --image-pull-policy ${IMAGE_PULL_POLICY} --kubernetes-version "auto" > ${WORKSPACE}/test-result.log
     fi
 
     cat ${WORKSPACE}/test-result.log

--- a/ci/run-k8s-e2e-tests.sh
+++ b/ci/run-k8s-e2e-tests.sh
@@ -40,7 +40,6 @@ DEFAULT_E2E_SIG_NETWORK_FOCUS="\[sig-network\]"
 DEFAULT_E2E_SIG_NETWORK_SKIP="\[Slow\]|\[Serial\]|\[Disruptive\]|\[GCE\]|\[Feature:.+\]|\[Feature:IPv6DualStack\]|\[Feature:IPv6DualStackAlphaFeature\]|should create pod that uses dns|should provide Internet connection for containers"
 MODE="report"
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-KUBE_CONFORMANCE_IMAGE_OPTION=""
 KUBE_CONFORMANCE_IMAGE_VERSION_OPTION=""
 IMAGE_PULL_POLICY="Always"
 CONFORMANCE_IMAGE_CONFIG_PATH="${THIS_DIR}/conformance-image-config.yaml"
@@ -48,7 +47,7 @@ SONOBUOY_IMAGE="projects.registry.vmware.com/sonobuoy/sonobuoy:v0.56.4"
 SYSTEMD_LOGS_IMAGE="projects.registry.vmware.com/sonobuoy/systemd-logs:v0.4"
 
 _usage="Usage: $0 [--e2e-conformance] [--e2e-network-policy] [--e2e-focus <TestRegex>] [--e2e-skip <SkipRegex>]
-                  [--kubeconfig <Kubeconfig>] [--kube-conformance-image-version <ConformanceImageVersion>]
+                  [--kubeconfig <Kubeconfig>] [--kubernetes-version <ConformanceImageVersion>]
                   [--log-mode <SonobuoyResultLogLevel>]
 Run the K8s e2e community tests (Conformance & Network Policy) which are relevant to Project Antrea,
 using the sonobuoy tool. Possible exit codes are 0 (all tests pass), 1 (all tests were run, but at
@@ -61,8 +60,7 @@ least one failed) and 2 (internal error when running tests, not a test failure).
         --e2e-focus TestRegex                                     Run only tests matching a specific regex, this is useful to run a single tests for example.
         --e2e-skip TestRegex                                      Skip some tests matching a specific regex.
         --kubeconfig Kubeconfig                                   Explicit path to Kubeconfig file. You may also set the KUBECONFIG environment variable.
-        --kube-conformance-image ConformanceImage                 Container image override for the kube conformance image. Overrides --kube-conformance-image-version.
-        --kube-conformance-image-version ConformanceImageVersion  Use specific version of the Conformance tests container image. Default is $KUBE_CONFORMANCE_IMAGE_VERSION.
+        --kubernetes-version ConformanceImageVersion              Use specific version of the Conformance tests container image. Default is $KUBE_CONFORMANCE_IMAGE_VERSION.
         --log-mode                                                Use the flag to set either 'report', 'detail', or 'dump' level data for sonobouy results.
         --image-pull-policy                                       The ImagePullPolicy Sonobuoy should use for the aggregators and workers. (default Always)
         --sonobuoy-image SonobuoyImage                            Sonobuoy image to use. Default is $SONOBUOY_IMAGE.
@@ -90,12 +88,8 @@ case $key in
     KUBECONFIG_OPTION="--kubeconfig $2"
     shift 2
     ;;
-    --kube-conformance-image)
-    KUBE_CONFORMANCE_IMAGE_OPTION="--kube-conformance-image $2"
-    shift 2
-    ;;
-    --kube-conformance-image-version)
-    KUBE_CONFORMANCE_IMAGE_VERSION_OPTION="--kube-conformance-image-version $2"
+    --kubernetes-version)
+    KUBE_CONFORMANCE_IMAGE_VERSION_OPTION="--kubernetes-version $2"
     shift 2
     ;;
     --e2e-conformance)
@@ -180,14 +174,12 @@ function run_sonobuoy() {
     if [[ "$focus_regex" == "" && "$skip_regex" == "" ]]; then
         $SONOBUOY run --wait \
                 $KUBECONFIG_OPTION \
-                $KUBE_CONFORMANCE_IMAGE_OPTION \
                 $KUBE_CONFORMANCE_IMAGE_VERSION_OPTION \
                 --mode "certified-conformance" --image-pull-policy ${IMAGE_PULL_POLICY} \
                 --sonobuoy-image ${SONOBUOY_IMAGE} --systemd-logs-image ${SYSTEMD_LOGS_IMAGE} --e2e-repo-config ${CONFORMANCE_IMAGE_CONFIG_PATH}
     else
         $SONOBUOY run --wait \
                 $KUBECONFIG_OPTION \
-                $KUBE_CONFORMANCE_IMAGE_OPTION \
                 $KUBE_CONFORMANCE_IMAGE_VERSION_OPTION \
                 --e2e-focus "$focus_regex" --e2e-skip "$skip_regex" --image-pull-policy ${IMAGE_PULL_POLICY} \
                 --sonobuoy-image ${SONOBUOY_IMAGE} --systemd-logs-image ${SYSTEMD_LOGS_IMAGE} --e2e-repo-config ${CONFORMANCE_IMAGE_CONFIG_PATH}

--- a/ci/test-conformance-aks.sh
+++ b/ci/test-conformance-aks.sh
@@ -249,10 +249,10 @@ function run_conformance() {
     # through public IPs by default. See https://github.com/antrea-io/antrea/issues/2409
     skip_regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[sig-cli\]|\[sig-storage\]|\[sig-auth\]|\[sig-api-machinery\]|\[sig-apps\]|\[sig-node\]|\[sig-instrumentation\]|NodePort"
     ${GIT_CHECKOUT_DIR}/ci/run-k8s-e2e-tests.sh --e2e-conformance --e2e-skip ${skip_regex} \
-      --kube-conformance-image-version ${KUBE_CONFORMANCE_IMAGE_VERSION} \
+      --kubernetes-version ${KUBE_CONFORMANCE_IMAGE_VERSION} \
       --log-mode ${MODE} > ${GIT_CHECKOUT_DIR}/aks-test.log && \
     ${GIT_CHECKOUT_DIR}/ci/run-k8s-e2e-tests.sh --e2e-network-policy --e2e-skip "\[Feature:SCTPConnectivity\]|Netpol" \
-      --kube-conformance-image-version ${KUBE_CONFORMANCE_IMAGE_VERSION} \
+      --kubernetes-version ${KUBE_CONFORMANCE_IMAGE_VERSION} \
       --log-mode ${MODE} >> ${GIT_CHECKOUT_DIR}/aks-test.log || \
     TEST_SCRIPT_RC=$?
 

--- a/ci/test-conformance-eks.sh
+++ b/ci/test-conformance-eks.sh
@@ -303,10 +303,10 @@ function run_conformance() {
     # access through node external IP. See https://github.com/antrea-io/antrea/issues/690
     skip_regex="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[sig-cli\]|\[sig-storage\]|\[sig-auth\]|\[sig-api-machinery\]|\[sig-apps\]|\[sig-node\]|\[sig-instrumentation\]|NodePort"
     ${GIT_CHECKOUT_DIR}/ci/run-k8s-e2e-tests.sh --e2e-conformance --e2e-skip ${skip_regex} \
-      --kube-conformance-image-version ${KUBE_CONFORMANCE_IMAGE_VERSION} \
+      --kubernetes-version ${KUBE_CONFORMANCE_IMAGE_VERSION} \
       --log-mode ${MODE} > ${GIT_CHECKOUT_DIR}/eks-test.log && \
     ${GIT_CHECKOUT_DIR}/ci/run-k8s-e2e-tests.sh --e2e-network-policy --e2e-skip "Netpol" \
-      --kube-conformance-image-version ${KUBE_CONFORMANCE_IMAGE_VERSION} \
+      --kubernetes-version ${KUBE_CONFORMANCE_IMAGE_VERSION} \
       --log-mode ${MODE} >> ${GIT_CHECKOUT_DIR}/eks-test.log || \
     TEST_SCRIPT_RC=$?
 

--- a/docs/gke-installation.md
+++ b/docs/gke-installation.md
@@ -32,17 +32,16 @@ on both VPC-native Enable/Disable modes.
 You can use any method to create a GKE cluster (gcloud SDK, gcloud Console, etc). The example
 given here is using the Google Cloud SDK.
 
-**Note:** Antrea is supported on Ubuntu Nodes only for GKE cluster. Also, it is a must to select service
-CIDR at the time of cluster deployment.
+**Note:** Antrea is supported on Ubuntu Nodes only for GKE cluster. When creating the cluster, you
+  must use the default network provider and must *not* enable "Dataplane V2".
 
 1. Create a GKE cluster
 
     ```bash
     export GKE_ZONE="us-west1"
     export GKE_HOST="UBUNTU"
-    export GKE_SERVICE_CIDR="10.94.0.0/16"
     gcloud container --project $GKE_PROJECT clusters create cluster1 --image-type $GKE_HOST \
-       --zone $GKE_ZONE --enable-ip-alias --services-ipv4-cidr $GKE_SERVICE_CIDR
+       --zone $GKE_ZONE --enable-ip-alias
     ```
 
 2. Access your cluster
@@ -50,8 +49,8 @@ CIDR at the time of cluster deployment.
     ```bash
     kubectl get nodes
     NAME                                      STATUS   ROLES    AGE     VERSION
-    gke-cluster1-default-pool-93d7da1c-61z4   Ready    <none>   3m11s   v1.14.10-gke.17
-    gke-cluster1-default-pool-93d7da1c-rkbm   Ready    <none>   3m9s    v1.14.10-gke.17
+    gke-cluster1-default-pool-93d7da1c-61z4   Ready    <none>   3m11s   1.25.7-gke.1000
+    gke-cluster1-default-pool-93d7da1c-rkbm   Ready    <none>   3m9s    1.25.7-gke.1000
     ```
 
 3. Create a cluster-admin ClusterRoleBinding
@@ -115,13 +114,13 @@ you should be able to see these Pods running in your cluster:
 
     ```bash
     $ kubectl delete pods -n kube-system $(kubectl get pods -n kube-system -o custom-columns=NAME:.metadata.name,HOSTNETWORK:.spec.hostNetwork --no-headers=true | grep '<none>' | awk '{ print $1 }')
-    pod "event-exporter-v0.2.5-7df89f4b8f-cm5r5" deleted
-    pod "fluentd-gcp-scaler-54ccb89d5-2glmv" deleted
-    pod "heapster-gke-6dd876579c-fc7xd" deleted
-    pod "kube-dns-5877696fb4-7cfbc" deleted
-    pod "kube-dns-5877696fb4-9zdpb" deleted
-    pod "kube-dns-autoscaler-8687c64fc-h4dtg" deleted
-    pod "l7-default-backend-8f479dd9-z42mx" deleted
-    pod "metrics-server-v0.3.1-cf56c77fc-7xgvc" deleted
-    pod "stackdriver-metadata-agent-cluster-level-6d96ccfd4-5rmwh" deleted
+    pod "event-exporter-gke-755c4b4d97-wqlcg" deleted
+    pod "konnectivity-agent-5cb8ff9b9-2cv5j" deleted
+    pod "konnectivity-agent-5cb8ff9b9-5jpvp" deleted
+    pod "konnectivity-agent-autoscaler-7dc78c8c9-kqn9f" deleted
+    pod "kube-dns-5b5dfcd97b-79m4c" deleted
+    pod "kube-dns-5b5dfcd97b-q49qj" deleted
+    pod "kube-dns-autoscaler-5f56f8997c-kqrgx" deleted
+    pod "l7-default-backend-d6b749b76-bsv9l" deleted
+    pod "metrics-server-v0.5.2-67864775dc-bhd9p" deleted
     ```


### PR DESCRIPTION
* Disable auto-upgrade when creating the cluster
* Remove old sed command which is no longer relevant
* Fix Kubeconfig retrieval
* Fix retry mechanism for cluster deletion
* Remove SERVICE_CIDR (no longer needed with AntreaProxy)

In addition we do the following:

* Replace --kube-conformance-image-version (deprecated) with
  --kubernetes-version for Sonobuoy (in all conformance test scripts)
* Remove --kube-conformance-image parameter as it is unused and
  deprecated for Sonobuoy
* Bring Antrea GKE installation doc up-to-date