### PR TITLE
Update golangci-lint version

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 # golangci-lint configuration used for CI
 run:
   tests: true
-  timeout: 10m
+  timeout: 15m
   skip-files:
     - ".*\\.pb\\.go"
   skip-dirs-use-default: true

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ GIT_HOOKS          := $(shell find hack/git_client_side_hooks -type f -print)
 DOCKER_NETWORK     ?= default
 TRIVY_TARGET_IMAGE ?=
 
-GOLANGCI_LINT_VERSION := v1.50.1
+GOLANGCI_LINT_VERSION := v1.52.2
 GOLANGCI_LINT_BINDIR  := $(CURDIR)/.golangci-bin
 GOLANGCI_LINT_BIN     := $(GOLANGCI_LINT_BINDIR)/$(GOLANGCI_LINT_VERSION)/golangci-lint
 

--- a/multicluster/controllers/multicluster/member/serviceexport_controller_test.go
+++ b/multicluster/controllers/multicluster/member/serviceexport_controller_test.go
@@ -37,14 +37,6 @@ import (
 )
 
 var (
-	addr1 = corev1.EndpointAddress{
-		IP:       "192.168.17.11",
-		Hostname: "pod1",
-	}
-	addr2 = corev1.EndpointAddress{
-		IP:       "192.168.17.12",
-		Hostname: "pod1",
-	}
 	epPorts80 = []corev1.EndpointPort{
 		{
 			Name:     "http",

--- a/pkg/agent/externalnode/external_node_controller_linux_test.go
+++ b/pkg/agent/externalnode/external_node_controller_linux_test.go
@@ -40,6 +40,19 @@ var (
 	hostIfName  = "hostIfName"
 	eeName      = "eeName"
 	_, cidr2, _ = net.ParseCIDR("10.20.30.50")
+	intf3       = interfacestore.InterfaceConfig{
+		InterfaceName: ifaceName1,
+		IPs:           []net.IP{net.ParseIP("10.5.6.9")},
+		OVSPortConfig: &interfacestore.OVSPortConfig{OFPort: 1, PortUUID: portUUID1},
+		EntityInterfaceConfig: &interfacestore.EntityInterfaceConfig{
+			EntityName:      "externalEntity",
+			EntityNamespace: "externalEntityNamespace",
+			UplinkPort: &interfacestore.OVSPortConfig{
+				PortUUID: ifaceUUID1,
+				OFPort:   6,
+			},
+		},
+	}
 )
 
 func TestUpdateExternalNode(t *testing.T) {

--- a/pkg/agent/externalnode/external_node_controller_test.go
+++ b/pkg/agent/externalnode/external_node_controller_test.go
@@ -81,19 +81,6 @@ var (
 			},
 		},
 	}
-	intf3 = interfacestore.InterfaceConfig{
-		InterfaceName: ifaceName1,
-		IPs:           []net.IP{net.ParseIP("10.5.6.9")},
-		OVSPortConfig: &interfacestore.OVSPortConfig{OFPort: 1, PortUUID: portUUID1},
-		EntityInterfaceConfig: &interfacestore.EntityInterfaceConfig{
-			EntityName:      "externalEntity",
-			EntityNamespace: "externalEntityNamespace",
-			UplinkPort: &interfacestore.OVSPortConfig{
-				PortUUID: ifaceUUID1,
-				OFPort:   6,
-			},
-		},
-	}
 	portData1 = &ovsconfig.OVSPortData{
 		Name: "portName",
 		ExternalIDs: map[string]string{


### PR DESCRIPTION
The timeout for golangci-lint is also increased to 15m, as I have observed some recent Gihub workflow failures caused by the 10m timeout.