### PR TITLE
Add support for ExternalIP in AntreaProxy

### DIFF
--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -22,7 +22,6 @@ import (
 	"antrea.io/libOpenflow/openflow15"
 	"antrea.io/libOpenflow/protocol"
 	ofutil "antrea.io/libOpenflow/util"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
 
 	"antrea.io/antrea/pkg/agent/config"
@@ -97,14 +96,13 @@ type Client interface {
 	// InstallEndpointFlows.
 	UninstallEndpointFlows(protocol binding.Protocol, endpoints []proxy.Endpoint) error
 
-	// InstallServiceFlows installs flows for accessing Service NodePort, LoadBalancer and ClusterIP. It installs the
-	// flow that uses the group/bucket to do service LB. If the affinityTimeout is not zero, it also installs the flow
-	// which has a learn action to maintain the LB decision. The group with the groupID must be installed before,
-	// otherwise the installation will fail.
-	// nodeLocalExternal represents if the externalTrafficPolicy is Local or not. This field is meaningful only when
-	// the svcType is NodePort or LoadBalancer.
-	// nested represents if the Service has the Endpoints which is other Service's ClusterIP.
-	InstallServiceFlows(groupID binding.GroupIDType, svcIP net.IP, svcPort uint16, protocol binding.Protocol, affinityTimeout uint16, nodeLocalExternal bool, svcType v1.ServiceType, nested bool) error
+	// InstallServiceFlows installs flows for accessing Service NodePort, LoadBalancer, ExternalIP and ClusterIP. It
+	// installs the flow that uses the group/bucket to do Service LB. If the affinityTimeout is not zero, it also
+	// installs the flow which has a learn action to maintain the LB decision. The group with the groupID must be
+	// installed before, otherwise the installation will fail.
+	// externalAddress indicates that whether the Service is externally accessible, like NodePort, LoadBalancer and ExternalIP.
+	// nested, when setting to true, indicates the Service's Endpoints are ClusterIPs of other Services.
+	InstallServiceFlows(groupID binding.GroupIDType, svcIP net.IP, svcPort uint16, protocol binding.Protocol, affinityTimeout uint16, externalAddress, nested bool) error
 	// UninstallServiceFlows removes flows installed by InstallServiceFlows.
 	UninstallServiceFlows(svcIP net.IP, svcPort uint16, protocol binding.Protocol) error
 
@@ -754,15 +752,16 @@ func (c *client) UninstallEndpointFlows(protocol binding.Protocol, endpoints []p
 	return c.deleteFlowsWithMultipleKeys(c.featureService.cachedFlows, flowCacheKeys)
 }
 
-func (c *client) InstallServiceFlows(groupID binding.GroupIDType, svcIP net.IP, svcPort uint16, protocol binding.Protocol, affinityTimeout uint16, nodeLocalExternal bool, svcType v1.ServiceType, nested bool) error {
+func (c *client) InstallServiceFlows(groupID binding.GroupIDType, svcIP net.IP, svcPort uint16, protocol binding.Protocol, affinityTimeout uint16, externalAddress, nested bool) error {
 	c.replayMutex.RLock()
 	defer c.replayMutex.RUnlock()
 	var flows []binding.Flow
-	flows = append(flows, c.featureService.serviceLBFlow(groupID, svcIP, svcPort, protocol, affinityTimeout != 0, nodeLocalExternal, svcType, nested))
+	nodePortAddress := svcIP.Equal(config.VirtualNodePortDNATIPv4) || svcIP.Equal(config.VirtualNodePortDNATIPv6)
+	flows = append(flows, c.featureService.serviceLBFlow(groupID, svcIP, svcPort, protocol, affinityTimeout != 0, externalAddress, nodePortAddress, nested))
 	if affinityTimeout != 0 {
-		flows = append(flows, c.featureService.serviceLearnFlow(groupID, svcIP, svcPort, protocol, affinityTimeout, nodeLocalExternal, svcType))
+		flows = append(flows, c.featureService.serviceLearnFlow(groupID, svcIP, svcPort, protocol, affinityTimeout, externalAddress, nodePortAddress))
 	}
-	if svcType == v1.ServiceTypeClusterIP && !nested {
+	if !externalAddress && !nested {
 		flows = append(flows, c.featureService.endpointRedirectFlowForServiceIP(svcIP, svcPort, protocol, groupID))
 	}
 	cacheKey := generateServicePortFlowCacheKey(svcIP, svcPort, protocol)

--- a/pkg/agent/openflow/client_test.go
+++ b/pkg/agent/openflow/client_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
 
 	"antrea.io/antrea/pkg/agent/config"
 	"antrea.io/antrea/pkg/agent/openflow/cookie"
@@ -1078,8 +1077,7 @@ func Test_client_InstallServiceFlows(t *testing.T) {
 		protocol          binding.Protocol
 		svcIP             net.IP
 		affinityTimeout   uint16
-		nodeLocalExternal bool
-		svcType           corev1.ServiceType
+		toExternalAddress bool
 		expectedFlows     []string
 		nested            bool
 	}{
@@ -1087,19 +1085,17 @@ func Test_client_InstallServiceFlows(t *testing.T) {
 			name:     "Service ClusterIP",
 			protocol: binding.ProtocolTCP,
 			svcIP:    svcIPv4,
-			svcType:  corev1.ServiceTypeClusterIP,
 			expectedFlows: []string{
 				"cookie=0x1030000000000, table=EndpointDNAT, priority=210,tcp,reg3=0xa600064,reg4=0x1020050/0x107ffff actions=group:100",
-				"cookie=0x1030000000000, table=ServiceLB, priority=200,tcp,reg4=0x10000/0x70000,nw_dst=10.96.0.100,tp_dst=80 actions=set_field:0x20000/0x70000->reg4,set_field:0x200/0x200->reg0,set_field:0x64->reg7,group:100",
+				"cookie=0x1030000000000, table=ServiceLB, priority=200,tcp,reg4=0x10000/0x70000,nw_dst=10.96.0.100,tp_dst=80 actions=set_field:0x200/0x200->reg0,set_field:0x20000/0x70000->reg4,set_field:0x64->reg7,group:100",
 			},
 		},
 		{
 			name:     "Service ClusterIP, nested",
 			protocol: binding.ProtocolTCP,
 			svcIP:    svcIPv4,
-			svcType:  corev1.ServiceTypeClusterIP,
 			expectedFlows: []string{
-				"cookie=0x1030000000000, table=ServiceLB, priority=200,tcp,reg4=0x10000/0x70000,nw_dst=10.96.0.100,tp_dst=80 actions=set_field:0x20000/0x70000->reg4,set_field:0x200/0x200->reg0,set_field:0x64->reg7,set_field:0x1000000/0x1000000->reg4,group:100",
+				"cookie=0x1030000000000, table=ServiceLB, priority=200,tcp,reg4=0x10000/0x70000,nw_dst=10.96.0.100,tp_dst=80 actions=set_field:0x200/0x200->reg0,set_field:0x20000/0x70000->reg4,set_field:0x64->reg7,set_field:0x1000000/0x1000000->reg4,group:100",
 			},
 			nested: true,
 		},
@@ -1108,67 +1104,64 @@ func Test_client_InstallServiceFlows(t *testing.T) {
 			protocol:        binding.ProtocolTCP,
 			svcIP:           svcIPv4,
 			affinityTimeout: uint16(100),
-			svcType:         corev1.ServiceTypeClusterIP,
 			expectedFlows: []string{
 				"cookie=0x1030000000000, table=EndpointDNAT, priority=210,tcp,reg3=0xa600064,reg4=0x1020050/0x107ffff actions=group:100",
-				"cookie=0x1030000000000, table=ServiceLB, priority=200,tcp,reg4=0x10000/0x70000,nw_dst=10.96.0.100,tp_dst=80 actions=set_field:0x30000/0x70000->reg4,set_field:0x200/0x200->reg0,set_field:0x64->reg7,group:100",
-				"cookie=0x1030000000064, table=ServiceLB, priority=190,tcp,reg4=0x30000/0x70000,nw_dst=10.96.0.100,tp_dst=80 actions=learn(table=SessionAffinity,hard_timeout=100,priority=200,delete_learned,cookie=0x1030000000064,load:0x800->NXM_OF_ETH_TYPE[],load:0x6->NXM_OF_IP_PROTO[],load:OXM_OF_TCP_DST[]->OXM_OF_TCP_DST[],load:NXM_OF_IP_DST[]->NXM_OF_IP_DST[],load:NXM_OF_IP_SRC[]->NXM_OF_IP_SRC[],NXM_NX_REG3[],NXM_NX_REG4[0..15],reg4=0x2,reg0=0x1),set_field:0x20000/0x70000->reg4,goto_table:EndpointDNAT",
+				"cookie=0x1030000000000, table=ServiceLB, priority=200,tcp,reg4=0x10000/0x70000,nw_dst=10.96.0.100,tp_dst=80 actions=set_field:0x200/0x200->reg0,set_field:0x30000/0x70000->reg4,set_field:0x64->reg7,group:100",
+				"cookie=0x1030000000064, table=ServiceLB, priority=190,tcp,reg4=0x30000/0x70000,nw_dst=10.96.0.100,tp_dst=80 actions=learn(table=SessionAffinity,hard_timeout=100,priority=200,delete_learned,cookie=0x1030000000064,eth_type=0x800,nw_proto=0x6,OXM_OF_TCP_DST[],NXM_OF_IP_DST[],NXM_OF_IP_SRC[],load:NXM_NX_REG3[]->NXM_NX_REG3[],load:NXM_NX_REG4[0..15]->NXM_NX_REG4[0..15],load:0x2->NXM_NX_REG4[16..18],load:0x1->NXM_NX_REG0[9]),set_field:0x20000/0x70000->reg4,goto_table:EndpointDNAT",
 			},
 		},
 		{
-			name:            "Service ClusterIP,ExternalPolicyLocal true,SessionAffinity",
+			name:            "Service ClusterIP,IPv6,SessionAffinity",
 			protocol:        binding.ProtocolTCPv6,
 			svcIP:           svcIPv6,
 			affinityTimeout: uint16(100),
-			svcType:         corev1.ServiceTypeClusterIP,
 			expectedFlows: []string{
 				"cookie=0x1030000000000, table=EndpointDNAT, priority=210,tcp6,reg4=0x1020050/0x107ffff actions=group:100",
-				"cookie=0x1030000000000, table=ServiceLB, priority=200,tcp6,reg4=0x10000/0x70000,ipv6_dst=fec0:10:96::100,tp_dst=80 actions=set_field:0x30000/0x70000->reg4,set_field:0x200/0x200->reg0,set_field:0x64->reg7,group:100",
-				"cookie=0x1030000000064, table=ServiceLB, priority=190,tcp6,reg4=0x30000/0x70000,ipv6_dst=fec0:10:96::100,tp_dst=80 actions=learn(table=SessionAffinity,hard_timeout=100,priority=200,delete_learned,cookie=0x1030000000064,load:0x86dd->NXM_OF_ETH_TYPE[],load:0x6->NXM_OF_IP_PROTO[],load:OXM_OF_TCP_DST[]->OXM_OF_TCP_DST[],load:NXM_NX_IPV6_DST[]->NXM_NX_IPV6_DST[],load:NXM_NX_IPV6_SRC[]->NXM_NX_IPV6_SRC[],NXM_NX_XXREG3[],NXM_NX_REG4[0..15],reg4=0x2,reg0=0x1),set_field:0x20000/0x70000->reg4,goto_table:EndpointDNAT",
+				"cookie=0x1030000000000, table=ServiceLB, priority=200,tcp6,reg4=0x10000/0x70000,ipv6_dst=fec0:10:96::100,tp_dst=80 actions=set_field:0x200/0x200->reg0,set_field:0x30000/0x70000->reg4,set_field:0x64->reg7,group:100",
+				"cookie=0x1030000000064, table=ServiceLB, priority=190,tcp6,reg4=0x30000/0x70000,ipv6_dst=fec0:10:96::100,tp_dst=80 actions=learn(table=SessionAffinity,hard_timeout=100,priority=200,delete_learned,cookie=0x1030000000064,eth_type=0x86dd,nw_proto=0x6,OXM_OF_TCP_DST[],NXM_NX_IPV6_DST[],NXM_NX_IPV6_SRC[],load:NXM_NX_XXREG3[]->NXM_NX_XXREG3[],load:NXM_NX_REG4[0..15]->NXM_NX_REG4[0..15],load:0x2->NXM_NX_REG4[16..18],load:0x1->NXM_NX_REG0[9]),set_field:0x20000/0x70000->reg4,goto_table:EndpointDNAT"},
+		},
+		{
+			name:              "Service NodePort,SessionAffinity",
+			protocol:          binding.ProtocolUDP,
+			svcIP:             config.VirtualNodePortDNATIPv4,
+			affinityTimeout:   uint16(100),
+			toExternalAddress: true,
+			expectedFlows: []string{
+				"cookie=0x1030000000000, table=ServiceLB, priority=200,udp,reg4=0x90000/0xf0000,tp_dst=80 actions=set_field:0x200/0x200->reg0,set_field:0x30000/0x70000->reg4,set_field:0x200000/0x200000->reg4,set_field:0x64->reg7,group:100",
+				"cookie=0x1030000000064, table=ServiceLB, priority=190,udp,reg4=0xb0000/0xf0000,tp_dst=80 actions=learn(table=SessionAffinity,hard_timeout=100,priority=200,delete_learned,cookie=0x1030000000064,eth_type=0x800,nw_proto=0x11,OXM_OF_UDP_DST[],NXM_OF_IP_DST[],NXM_OF_IP_SRC[],load:NXM_NX_REG3[]->NXM_NX_REG3[],load:NXM_NX_REG4[0..15]->NXM_NX_REG4[0..15],load:0x2->NXM_NX_REG4[16..18],load:0x1->NXM_NX_REG0[9],load:0x1->NXM_NX_REG4[21]),set_field:0x20000/0x70000->reg4,goto_table:EndpointDNAT",
 			},
 		},
 		{
-			name:            "Service NodePort,SessionAffinity",
-			protocol:        binding.ProtocolUDP,
-			svcIP:           svcIPv4,
-			affinityTimeout: uint16(100),
-			svcType:         corev1.ServiceTypeNodePort,
+			name:              "Service NodePort,IPv6,SessionAffinity",
+			protocol:          binding.ProtocolUDPv6,
+			svcIP:             config.VirtualNodePortDNATIPv6,
+			affinityTimeout:   uint16(100),
+			toExternalAddress: true,
 			expectedFlows: []string{
-				"cookie=0x1030000000000, table=ServiceLB, priority=200,udp,reg4=0x90000/0xf0000,tp_dst=80 actions=set_field:0x30000/0x70000->reg4,set_field:0x200/0x200->reg0,set_field:0x200000/0x200000->reg4,set_field:0x64->reg7,group:100",
-				"cookie=0x1030000000064, table=ServiceLB, priority=190,udp,reg4=0xb0000/0xf0000,tp_dst=80 actions=learn(table=SessionAffinity,hard_timeout=100,priority=200,delete_learned,cookie=0x1030000000064,load:0x800->NXM_OF_ETH_TYPE[],load:0x11->NXM_OF_IP_PROTO[],load:OXM_OF_UDP_DST[]->OXM_OF_UDP_DST[],reg4=0x1,load:NXM_OF_IP_DST[]->NXM_OF_IP_DST[],load:NXM_OF_IP_SRC[]->NXM_OF_IP_SRC[],NXM_NX_REG3[],NXM_NX_REG4[0..15],reg4=0x2,reg0=0x1),set_field:0x20000/0x70000->reg4,goto_table:EndpointDNAT",
+				"cookie=0x1030000000000, table=ServiceLB, priority=200,udp6,reg4=0x90000/0xf0000,tp_dst=80 actions=set_field:0x200/0x200->reg0,set_field:0x30000/0x70000->reg4,set_field:0x200000/0x200000->reg4,set_field:0x64->reg7,group:100",
+				"cookie=0x1030000000064, table=ServiceLB, priority=190,udp6,reg4=0xb0000/0xf0000,tp_dst=80 actions=learn(table=SessionAffinity,hard_timeout=100,priority=200,delete_learned,cookie=0x1030000000064,eth_type=0x86dd,nw_proto=0x11,OXM_OF_UDP_DST[],NXM_NX_IPV6_DST[],NXM_NX_IPV6_SRC[],load:NXM_NX_XXREG3[]->NXM_NX_XXREG3[],load:NXM_NX_REG4[0..15]->NXM_NX_REG4[0..15],load:0x2->NXM_NX_REG4[16..18],load:0x1->NXM_NX_REG0[9],load:0x1->NXM_NX_REG4[21]),set_field:0x20000/0x70000->reg4,goto_table:EndpointDNAT",
 			},
 		},
 		{
-			name:            "Service NodePort,ExternalPolicyLocal true,SessionAffinity",
-			protocol:        binding.ProtocolUDPv6,
-			svcIP:           svcIPv6,
-			affinityTimeout: uint16(100),
-			svcType:         corev1.ServiceTypeNodePort,
+			name:              "Service LoadBalancer,SessionAffinity",
+			protocol:          binding.ProtocolSCTP,
+			svcIP:             svcIPv4,
+			affinityTimeout:   uint16(100),
+			toExternalAddress: true,
 			expectedFlows: []string{
-				"cookie=0x1030000000000, table=ServiceLB, priority=200,udp6,reg4=0x90000/0xf0000,tp_dst=80 actions=set_field:0x30000/0x70000->reg4,set_field:0x200/0x200->reg0,set_field:0x200000/0x200000->reg4,set_field:0x64->reg7,group:100",
-				"cookie=0x1030000000064, table=ServiceLB, priority=190,udp6,reg4=0xb0000/0xf0000,tp_dst=80 actions=learn(table=SessionAffinity,hard_timeout=100,priority=200,delete_learned,cookie=0x1030000000064,load:0x86dd->NXM_OF_ETH_TYPE[],load:0x11->NXM_OF_IP_PROTO[],load:OXM_OF_UDP_DST[]->OXM_OF_UDP_DST[],reg4=0x1,load:NXM_NX_IPV6_DST[]->NXM_NX_IPV6_DST[],load:NXM_NX_IPV6_SRC[]->NXM_NX_IPV6_SRC[],NXM_NX_XXREG3[],NXM_NX_REG4[0..15],reg4=0x2,reg0=0x1),set_field:0x20000/0x70000->reg4,goto_table:EndpointDNAT",
+				"cookie=0x1030000000000, table=ServiceLB, priority=200,sctp,reg4=0x10000/0x70000,nw_dst=10.96.0.100,tp_dst=80 actions=set_field:0x200/0x200->reg0,set_field:0x30000/0x70000->reg4,set_field:0x200000/0x200000->reg4,set_field:0x64->reg7,group:100",
+				"cookie=0x1030000000064, table=ServiceLB, priority=190,sctp,reg4=0x30000/0x70000,nw_dst=10.96.0.100,tp_dst=80 actions=learn(table=SessionAffinity,hard_timeout=100,priority=200,delete_learned,cookie=0x1030000000064,eth_type=0x800,nw_proto=0x84,OXM_OF_SCTP_DST[],NXM_OF_IP_DST[],NXM_OF_IP_SRC[],load:NXM_NX_REG3[]->NXM_NX_REG3[],load:NXM_NX_REG4[0..15]->NXM_NX_REG4[0..15],load:0x2->NXM_NX_REG4[16..18],load:0x1->NXM_NX_REG0[9],load:0x1->NXM_NX_REG4[21]),set_field:0x20000/0x70000->reg4,goto_table:EndpointDNAT",
 			},
 		},
 		{
-			name:            "Service LoadBalancer,SessionAffinity",
-			protocol:        binding.ProtocolSCTP,
-			svcIP:           svcIPv4,
-			affinityTimeout: uint16(100),
-			svcType:         corev1.ServiceTypeLoadBalancer,
+			name:              "Service LoadBalancer,IPv6,SessionAffinity",
+			protocol:          binding.ProtocolSCTPv6,
+			svcIP:             svcIPv6,
+			affinityTimeout:   uint16(100),
+			toExternalAddress: true,
 			expectedFlows: []string{
-				"cookie=0x1030000000000, table=ServiceLB, priority=200,sctp,reg4=0x10000/0x70000,nw_dst=10.96.0.100,tp_dst=80 actions=set_field:0x30000/0x70000->reg4,set_field:0x200/0x200->reg0,set_field:0x200000/0x200000->reg4,set_field:0x64->reg7,group:100",
-				"cookie=0x1030000000064, table=ServiceLB, priority=190,sctp,reg4=0x30000/0x70000,nw_dst=10.96.0.100,tp_dst=80 actions=learn(table=SessionAffinity,hard_timeout=100,priority=200,delete_learned,cookie=0x1030000000064,load:0x800->NXM_OF_ETH_TYPE[],load:0x84->NXM_OF_IP_PROTO[],load:OXM_OF_SCTP_DST[]->OXM_OF_SCTP_DST[],reg4=0x1,load:NXM_OF_IP_DST[]->NXM_OF_IP_DST[],load:NXM_OF_IP_SRC[]->NXM_OF_IP_SRC[],NXM_NX_REG3[],NXM_NX_REG4[0..15],reg4=0x2,reg0=0x1),set_field:0x20000/0x70000->reg4,goto_table:EndpointDNAT",
-			},
-		},
-		{
-			name:            "Service LoadBalancer,ExternalPolicyLocal true,SessionAffinity",
-			protocol:        binding.ProtocolSCTPv6,
-			svcIP:           svcIPv6,
-			affinityTimeout: uint16(100),
-			svcType:         corev1.ServiceTypeLoadBalancer,
-			expectedFlows: []string{
-				"cookie=0x1030000000000, table=ServiceLB, priority=200,sctp6,reg4=0x10000/0x70000,ipv6_dst=fec0:10:96::100,tp_dst=80 actions=set_field:0x30000/0x70000->reg4,set_field:0x200/0x200->reg0,set_field:0x200000/0x200000->reg4,set_field:0x64->reg7,group:100",
-				"cookie=0x1030000000064, table=ServiceLB, priority=190,sctp6,reg4=0x30000/0x70000,ipv6_dst=fec0:10:96::100,tp_dst=80 actions=learn(table=SessionAffinity,hard_timeout=100,priority=200,delete_learned,cookie=0x1030000000064,load:0x86dd->NXM_OF_ETH_TYPE[],load:0x84->NXM_OF_IP_PROTO[],load:OXM_OF_SCTP_DST[]->OXM_OF_SCTP_DST[],reg4=0x1,load:NXM_NX_IPV6_DST[]->NXM_NX_IPV6_DST[],load:NXM_NX_IPV6_SRC[]->NXM_NX_IPV6_SRC[],NXM_NX_XXREG3[],NXM_NX_REG4[0..15],reg4=0x2,reg0=0x1),set_field:0x20000/0x70000->reg4,goto_table:EndpointDNAT",
+				"cookie=0x1030000000000, table=ServiceLB, priority=200,sctp6,reg4=0x10000/0x70000,ipv6_dst=fec0:10:96::100,tp_dst=80 actions=set_field:0x200/0x200->reg0,set_field:0x30000/0x70000->reg4,set_field:0x200000/0x200000->reg4,set_field:0x64->reg7,group:100",
+				"cookie=0x1030000000064, table=ServiceLB, priority=190,sctp6,reg4=0x30000/0x70000,ipv6_dst=fec0:10:96::100,tp_dst=80 actions=learn(table=SessionAffinity,hard_timeout=100,priority=200,delete_learned,cookie=0x1030000000064,eth_type=0x86dd,nw_proto=0x84,OXM_OF_SCTP_DST[],NXM_NX_IPV6_DST[],NXM_NX_IPV6_SRC[],load:NXM_NX_XXREG3[]->NXM_NX_XXREG3[],load:NXM_NX_REG4[0..15]->NXM_NX_REG4[0..15],load:0x2->NXM_NX_REG4[16..18],load:0x1->NXM_NX_REG0[9],load:0x1->NXM_NX_REG4[21]),set_field:0x20000/0x70000->reg4,goto_table:EndpointDNAT",
 			},
 		},
 	}
@@ -1186,7 +1179,7 @@ func Test_client_InstallServiceFlows(t *testing.T) {
 
 			cacheKey := generateServicePortFlowCacheKey(tc.svcIP, port, tc.protocol)
 
-			assert.NoError(t, fc.InstallServiceFlows(groupID, tc.svcIP, port, tc.protocol, tc.affinityTimeout, tc.nodeLocalExternal, tc.svcType, tc.nested))
+			assert.NoError(t, fc.InstallServiceFlows(groupID, tc.svcIP, port, tc.protocol, tc.affinityTimeout, tc.toExternalAddress, tc.nested))
 			fCacheI, ok := fc.featureService.cachedFlows.Load(cacheKey)
 			require.True(t, ok)
 			assert.ElementsMatch(t, tc.expectedFlows, getFlowStrings(fCacheI))
@@ -1216,12 +1209,12 @@ func Test_client_GetServiceFlowKeys(t *testing.T) {
 		proxy.NewBaseEndpointInfo("10.10.0.12", "", "", 80, true, true, false, false, nil),
 	}
 
-	assert.NoError(t, fc.InstallServiceFlows(groupID, svcIP, svcPort, bindingProtocol, 100, true, corev1.ServiceTypeLoadBalancer, false))
+	assert.NoError(t, fc.InstallServiceFlows(groupID, svcIP, svcPort, bindingProtocol, 100, true, false))
 	assert.NoError(t, fc.InstallEndpointFlows(bindingProtocol, endpoints))
 	flowKeys := fc.GetServiceFlowKeys(svcIP, svcPort, bindingProtocol, endpoints)
 	expectedFlowKeys := []string{
 		"table=11,tcp,tp_dst=0x50,nw_dst=10.96.0.224,reg4=0x10000/0x70000",
-		"table=11,tcp,reg4=0x30000/0x70000,nw_dst=10.96.0.224,tp_dst=0x50",
+		"table=11,tcp,tp_dst=0x50,nw_dst=10.96.0.224,reg4=0x30000/0x70000",
 		"table=12,tcp,reg4=0x20050/0x7ffff,reg3=0xa0a000b",
 		"table=12,tcp,reg4=0x20050/0x7ffff,reg3=0xa0a000c",
 		"table=20,ip,nw_src=10.10.0.12,nw_dst=10.10.0.12,ct_state=+new+trk",

--- a/pkg/agent/openflow/fields.go
+++ b/pkg/agent/openflow/fields.go
@@ -121,20 +121,17 @@ var (
 	EpUnionField = binding.NewRegField(4, 0, 18)
 	// reg4[19]: Mark to indicate the Service type is NodePort.
 	ToNodePortAddressRegMark = binding.NewOneBitRegMark(4, 19)
-	// reg4[16..19]: Field to store the union value of Endpoint state and the mark of whether Service type is NodePort.
-	NodePortUnionField = binding.NewRegField(4, 16, 19)
 	// reg4[20]: Field to indicate whether the packet is from local Antrea IPAM Pod. NotAntreaFlexibleIPAMRegMark will
 	// be used with RewriteMACRegMark, thus the reg id must not be same due to the limitation of ofnet library.
 	AntreaFlexibleIPAMRegMark    = binding.NewOneBitRegMark(4, 20)
 	NotAntreaFlexibleIPAMRegMark = binding.NewOneBitZeroRegMark(4, 20)
-	// reg4[21]: Mark to indicate whether the packet is accessing a NodePort or a LoadBalancer IP of a Service whose
-	// externalTrafficPolicy is Cluster.
-	ToClusterServiceRegMark = binding.NewOneBitRegMark(4, 21)
+	// reg4[21]: Mark to indicate whether the packet is to a Service's external IP, like NodePort, LoadBalancerIP or ExternalIP.
+	ToExternalAddressRegMark = binding.NewOneBitRegMark(4, 21)
 	// reg4[22..23]: Field to store the action of a traffic control rule. Marks in this field include:
 	TrafficControlActionField     = binding.NewRegField(4, 22, 23)
 	TrafficControlMirrorRegMark   = binding.NewRegMark(TrafficControlActionField, 0b01)
 	TrafficControlRedirectRegMark = binding.NewRegMark(TrafficControlActionField, 0b10)
-	// reg4[24]: Mark to indicate whether the Endpoints of a Service includes another Service's ClusterIP.
+	// reg4[24]: Mark to indicate that whether the Service is backed by Service IPs of other Services.
 	NestedServiceRegMark = binding.NewOneBitRegMark(4, 24)
 
 	// reg5(NXM_NX_REG5)

--- a/pkg/agent/openflow/testing/mock_openflow.go
+++ b/pkg/agent/openflow/testing/mock_openflow.go
@@ -29,7 +29,6 @@ import (
 	protocol "antrea.io/libOpenflow/protocol"
 	util "antrea.io/libOpenflow/util"
 	gomock "github.com/golang/mock/gomock"
-	v1 "k8s.io/api/core/v1"
 	net "net"
 	reflect "reflect"
 )
@@ -467,17 +466,17 @@ func (mr *MockClientMockRecorder) InstallSNATMarkFlows(arg0, arg1 interface{}) *
 }
 
 // InstallServiceFlows mocks base method
-func (m *MockClient) InstallServiceFlows(arg0 openflow.GroupIDType, arg1 net.IP, arg2 uint16, arg3 openflow.Protocol, arg4 uint16, arg5 bool, arg6 v1.ServiceType, arg7 bool) error {
+func (m *MockClient) InstallServiceFlows(arg0 openflow.GroupIDType, arg1 net.IP, arg2 uint16, arg3 openflow.Protocol, arg4 uint16, arg5, arg6 bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InstallServiceFlows", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+	ret := m.ctrl.Call(m, "InstallServiceFlows", arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InstallServiceFlows indicates an expected call of InstallServiceFlows
-func (mr *MockClientMockRecorder) InstallServiceFlows(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) InstallServiceFlows(arg0, arg1, arg2, arg3, arg4, arg5, arg6 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallServiceFlows", reflect.TypeOf((*MockClient)(nil).InstallServiceFlows), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallServiceFlows", reflect.TypeOf((*MockClient)(nil).InstallServiceFlows), arg0, arg1, arg2, arg3, arg4, arg5, arg6)
 }
 
 // InstallServiceGroup mocks base method

--- a/pkg/agent/route/interfaces.go
+++ b/pkg/agent/route/interfaces.go
@@ -65,11 +65,11 @@ type Interface interface {
 	// DeleteNodePort deletes related configurations when a NodePort Service is deleted.
 	DeleteNodePort(nodePortAddresses []net.IP, port uint16, protocol binding.Protocol) error
 
-	// AddLoadBalancer adds configurations when a LoadBalancer IP is added.
-	AddLoadBalancer(externalIP net.IP) error
+	// AddExternalIPRoute adds a route entry when an external IP is added.
+	AddExternalIPRoute(externalIP net.IP) error
 
-	// DeleteLoadBalancer deletes related configurations when a LoadBalancer IP is deleted.
-	DeleteLoadBalancer(externalIP net.IP) error
+	// DeleteExternalIPRoute deletes the related route entry when an external IP is deleted.
+	DeleteExternalIPRoute(externalIP net.IP) error
 
 	// Run starts the sync loop.
 	Run(stopCh <-chan struct{})

--- a/pkg/agent/route/route_linux_test.go
+++ b/pkg/agent/route/route_linux_test.go
@@ -1443,7 +1443,7 @@ func TestAddServiceCIDRRoute(t *testing.T) {
 	}
 }
 
-func TestAddLoadBalancer(t *testing.T) {
+func TestAddExternalIPRoute(t *testing.T) {
 	tests := []struct {
 		name          string
 		externalIPs   []string
@@ -1487,13 +1487,13 @@ func TestAddLoadBalancer(t *testing.T) {
 			tt.expectedCalls(mockNetlink.EXPECT())
 
 			for _, externalIP := range tt.externalIPs {
-				assert.NoError(t, c.AddLoadBalancer(net.ParseIP(externalIP)))
+				assert.NoError(t, c.AddExternalIPRoute(net.ParseIP(externalIP)))
 			}
 		})
 	}
 }
 
-func TestDeleteLoadBalancer(t *testing.T) {
+func TestDeleteExternalIPRoute(t *testing.T) {
 	tests := []struct {
 		name          string
 		serviceRoutes map[string]*netlink.Route
@@ -1541,7 +1541,7 @@ func TestDeleteLoadBalancer(t *testing.T) {
 			tt.expectedCalls(mockNetlink.EXPECT())
 
 			for _, externalIP := range tt.externalIPs {
-				assert.NoError(t, c.DeleteLoadBalancer(net.ParseIP(externalIP)))
+				assert.NoError(t, c.DeleteExternalIPRoute(net.ParseIP(externalIP)))
 			}
 		})
 	}

--- a/pkg/agent/route/testing/mock_route.go
+++ b/pkg/agent/route/testing/mock_route.go
@@ -50,18 +50,18 @@ func (m *MockInterface) EXPECT() *MockInterfaceMockRecorder {
 	return m.recorder
 }
 
-// AddLoadBalancer mocks base method
-func (m *MockInterface) AddLoadBalancer(arg0 net.IP) error {
+// AddExternalIPRoute mocks base method
+func (m *MockInterface) AddExternalIPRoute(arg0 net.IP) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddLoadBalancer", arg0)
+	ret := m.ctrl.Call(m, "AddExternalIPRoute", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// AddLoadBalancer indicates an expected call of AddLoadBalancer
-func (mr *MockInterfaceMockRecorder) AddLoadBalancer(arg0 interface{}) *gomock.Call {
+// AddExternalIPRoute indicates an expected call of AddExternalIPRoute
+func (mr *MockInterfaceMockRecorder) AddExternalIPRoute(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddLoadBalancer", reflect.TypeOf((*MockInterface)(nil).AddLoadBalancer), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddExternalIPRoute", reflect.TypeOf((*MockInterface)(nil).AddExternalIPRoute), arg0)
 }
 
 // AddLocalAntreaFlexibleIPAMPodRule mocks base method
@@ -120,18 +120,18 @@ func (mr *MockInterfaceMockRecorder) AddSNATRule(arg0, arg1 interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddSNATRule", reflect.TypeOf((*MockInterface)(nil).AddSNATRule), arg0, arg1)
 }
 
-// DeleteLoadBalancer mocks base method
-func (m *MockInterface) DeleteLoadBalancer(arg0 net.IP) error {
+// DeleteExternalIPRoute mocks base method
+func (m *MockInterface) DeleteExternalIPRoute(arg0 net.IP) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteLoadBalancer", arg0)
+	ret := m.ctrl.Call(m, "DeleteExternalIPRoute", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// DeleteLoadBalancer indicates an expected call of DeleteLoadBalancer
-func (mr *MockInterfaceMockRecorder) DeleteLoadBalancer(arg0 interface{}) *gomock.Call {
+// DeleteExternalIPRoute indicates an expected call of DeleteExternalIPRoute
+func (mr *MockInterfaceMockRecorder) DeleteExternalIPRoute(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLoadBalancer", reflect.TypeOf((*MockInterface)(nil).DeleteLoadBalancer), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteExternalIPRoute", reflect.TypeOf((*MockInterface)(nil).DeleteExternalIPRoute), arg0)
 }
 
 // DeleteLocalAntreaFlexibleIPAMPodRule mocks base method

--- a/pkg/ovs/openflow/testing/utils.go
+++ b/pkg/ovs/openflow/testing/utils.go
@@ -78,6 +78,9 @@ func (m *fieldMetadata) getActionNickname() string {
 	name = strings.TrimPrefix(name, "OXM_OF_")
 	name = strings.TrimPrefix(name, "OXM_PACKET_")
 	name = strings.ToLower(name)
+	if strings.HasPrefix(name, "ip_") && name != "ip_dscp" {
+		name = strings.Replace(name, "ip_", "nw_", 1)
+	}
 	if strings.HasPrefix(name, "ipv4_") {
 		name = strings.Replace(name, "ipv4_", "ip_", 1)
 	}
@@ -804,14 +807,14 @@ func nxActionLearnToString(action openflow15.Action) string {
 	if len(a.LearnSpecs) != 0 {
 		for _, spec := range a.LearnSpecs {
 			nBits := spec.Header.NBits
-			isLoad := spec.Header.Dst == false
-			isMatch := spec.Header.Dst == true
+			isLoad := spec.Header.Dst == true
+			isMatch := spec.Header.Dst == false
 			//TODO: add isOutput
 
 			if spec.SrcValue != nil {
 				srcValueStr := strings.TrimLeft(fmt.Sprintf("%x", spec.SrcValue), "0")
 				if isMatch {
-					dstFieldStr := getFieldNameString(spec.DstField.Field.Class, spec.DstField.Field.Field, 0, 0, true, false)
+					dstFieldStr := getFieldNameString(spec.DstField.Field.Class, spec.DstField.Field.Field, spec.DstField.Ofs, nBits, true, false)
 					parts = append(parts, fmt.Sprintf("%s=0x%s", dstFieldStr, srcValueStr))
 				} else if isLoad {
 					dstFieldStr := getFieldNameString(spec.DstField.Field.Class, spec.DstField.Field.Field, spec.DstField.Ofs, nBits, false, false)

--- a/test/integration/agent/openflow_test.go
+++ b/test/integration/agent/openflow_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/component-base/metrics/legacyregistry"
 
@@ -785,7 +784,7 @@ func installServiceFlows(t *testing.T, gid uint32, svc svcConfig, endpointList [
 	assert.NoError(t, err, "no error should return when installing flows for Endpoints")
 	err = c.InstallServiceGroup(groupID, svc.withSessionAffinity, endpointList)
 	assert.NoError(t, err, "no error should return when installing groups for Service")
-	err = c.InstallServiceFlows(groupID, svc.ip, svc.port, svc.protocol, stickyMaxAgeSeconds, false, v1.ServiceTypeClusterIP, false)
+	err = c.InstallServiceFlows(groupID, svc.ip, svc.port, svc.protocol, stickyMaxAgeSeconds, false, false)
 	assert.NoError(t, err, "no error should return when installing flows for Service")
 }
 
@@ -824,7 +823,7 @@ func expectedProxyServiceGroupAndFlows(gid uint32, svc svcConfig, endpointList [
 	svcFlows := expectTableFlows{tableName: "ServiceLB", flows: []*ofTestUtils.ExpectFlow{
 		{
 			MatchStr: fmt.Sprintf("priority=200,%s,reg4=0x10000/0x70000,nw_dst=%s,tp_dst=%d", string(svc.protocol), svc.ip.String(), svc.port),
-			ActStr:   fmt.Sprintf("set_field:0x%x/0x70000->reg4,set_field:0x200/0x200->reg0,%sgroup:%d", serviceLearnReg<<16, loadGourpID, gid),
+			ActStr:   fmt.Sprintf("set_field:0x200/0x200->reg0,set_field:0x%x/0x70000->reg4,%sgroup:%d", serviceLearnReg<<16, loadGourpID, gid),
 		},
 		{
 			MatchStr: fmt.Sprintf("priority=190,%s,reg4=0x30000/0x70000,nw_dst=%s,tp_dst=%d", string(svc.protocol), svc.ip.String(), svc.port),

--- a/third_party/proxy/types.go
+++ b/third_party/proxy/types.go
@@ -138,12 +138,12 @@ type Endpoint interface {
 	// This is only set when watching EndpointSlices. If using Endpoints, this is always
 	// true since only ready endpoints are read from Endpoints.
 	IsServing() bool
-	// IsTerminating retruns true if an endpoint is terminating. For pods,
+	// IsTerminating returns true if an endpoint is terminating. For pods,
 	// that is any pod with a deletion timestamp.
 	// This is only set when watching EndpointSlices. If using Endpoints, this is always
 	// false since terminating endpoints are always excluded from Endpoints.
 	IsTerminating() bool
-	// GetZoneHint returns the zone hint for the endpoint. This is based on
+	// GetZoneHints returns the zone hint for the endpoint. This is based on
 	// endpoint.hints.forZones[0].name in the EndpointSlice API.
 	GetZoneHints() sets.String
 	// IP returns IP part of the endpoint.


### PR DESCRIPTION
This PR adds the ability to serve ExternalIP for AntreaProxy, allowing for
external client accesses to Services running in Kubernetes. In Kubernetes, an
ExternalIP is a feature that allows a Service to be accessed from outside the
cluster using a static IP address.

Signed-off-by: Hongliang Liu <lhongliang@vmware.com>