### PR TITLE
Support local multi-cluster image build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,7 +136,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Build antrea-mc-controller Docker image
-      run: make antrea-mc-controller
+      run: make build-antrea-mc-controller
     - name: Push antrea-mc-controller Docker image to registry
       if: ${{ github.repository == 'antrea-io/antrea' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       env:

--- a/.github/workflows/build_tag.yml
+++ b/.github/workflows/build_tag.yml
@@ -100,7 +100,7 @@ jobs:
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         VERSION: ${{ needs.get-version.outputs.version }}
       run: |
-        make antrea-mc-controller
+        make build-antrea-mc-controller
         echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         docker push antrea/antrea-mc-controller:"${VERSION}"
 

--- a/Makefile
+++ b/Makefile
@@ -420,14 +420,25 @@ octant-antrea-ubuntu:
 antrea-mc-controller:
 	@echo "===> Building antrea/antrea-mc-controller Docker image <==="
 ifneq ($(NO_PULL),)
+	docker build -t antrea/antrea-mc-controller:$(DOCKER_IMG_VERSION) -f multicluster/build/images/Dockerfile $(DOCKER_BUILD_ARGS) .
+else
+	docker build --pull -t antrea/antrea-mc-controller:$(DOCKER_IMG_VERSION) -f multicluster/build/images/Dockerfile $(DOCKER_BUILD_ARGS) .
+endif
+	docker tag antrea/antrea-mc-controller:$(DOCKER_IMG_VERSION) antrea/antrea-mc-controller
+
+# Build bins in a golang container, and build the antrea-mc-controller Docker image.
+.PHONY: build-antrea-mc-controller
+build-antrea-mc-controller:
+	@echo "===> Building antrea/antrea-mc-controller Docker image <==="
+ifneq ($(NO_PULL),)
 	docker build -t antrea/antrea-mc-controller:$(DOCKER_IMG_VERSION) -f multicluster/build/images/Dockerfile.build $(DOCKER_BUILD_ARGS) .
 else
 	docker build --pull -t antrea/antrea-mc-controller:$(DOCKER_IMG_VERSION) -f multicluster/build/images/Dockerfile.build $(DOCKER_BUILD_ARGS) .
 endif
 	docker tag antrea/antrea-mc-controller:$(DOCKER_IMG_VERSION) antrea/antrea-mc-controller
 
-.PHONY: antrea-mc-controller-coverage
-antrea-mc-controller-coverage:
+.PHONY: build-antrea-mc-controller-coverage
+build-antrea-mc-controller-coverage:
 	@echo "===> Building antrea/antrea-mc-controller-coverage Docker image <==="
 ifneq ($(NO_PULL),)
 	docker build -t antrea/antrea-mc-controller-coverage:$(DOCKER_IMG_VERSION) -f multicluster/build/images/Dockerfile.build.coverage $(DOCKER_BUILD_ARGS) .

--- a/ci/jenkins/test-mc.sh
+++ b/ci/jenkins/test-mc.sh
@@ -325,13 +325,13 @@ function deliver_multicluster_controller {
 
     DEFAULT_IMAGE=antrea/antrea-mc-controller:latest
     if $COVERAGE;then
-        export NO_PULL=1;make antrea-mc-controller-coverage
+        export NO_PULL=1;make build-antrea-mc-controller-coverage
         DEFAULT_IMAGE=antrea/antrea-mc-controller-coverage:latest
         docker save "${DEFAULT_IMAGE}" -o "${WORKDIR}"/antrea-mcs.tar
         ./multicluster/hack/generate-manifest.sh -l antrea-multicluster -c > ./multicluster/test/yamls/leader-manifest.yml
         ./multicluster/hack/generate-manifest.sh -m -c > ./multicluster/test/yamls/member-manifest.yml
     else
-        export NO_PULL=1;make antrea-mc-controller
+        export NO_PULL=1;make build-antrea-mc-controller
         docker save "${DEFAULT_IMAGE}" -o "${WORKDIR}"/antrea-mcs.tar
         ./multicluster/hack/generate-manifest.sh -l antrea-multicluster > ./multicluster/test/yamls/leader-manifest.yml
         ./multicluster/hack/generate-manifest.sh -m > ./multicluster/test/yamls/member-manifest.yml

--- a/docs/multicluster/user-guide.md
+++ b/docs/multicluster/user-guide.md
@@ -800,7 +800,7 @@ Multi-cluster NetworkPolicies to be enforced in the ClusterSet.
 If you'd like to build Multi-cluster Controller Docker image locally, you can
 follow the following steps:
 
-1. Go to your local `antrea` source tree, run `make antrea-mc-controller`, and you
+1. Go to your local `antrea` source tree, run `make build-antrea-mc-controller`, and you
 will get a new image named `antrea/antrea-mc-controller:latest` locally.
 2. Run `docker save antrea/antrea-mc-controller:latest > antrea-mcs.tar` to save
 the image.

--- a/multicluster/build/images/Dockerfile
+++ b/multicluster/build/images/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2023 Antrea Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/distroless/static:nonroot
+
+LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
+LABEL description="The Docker image to deploy the Antrea Multi-cluster Controller."
+
+USER root
+
+COPY multicluster/bin/antrea-mc-controller /


### PR DESCRIPTION
1. Add a new build image target in Makefile to support local multi-cluster image build.
2. Rename targets to align with other target name format.