### PR TITLE
Automated cherry pick of #4843: Ignore script exit code for conformance test
#4833: Add timeout for sonobuoy deletion

### DIFF
--- a/ci/jenkins/test.sh
+++ b/ci/jenkins/test.sh
@@ -325,7 +325,7 @@ function revert_snapshot_windows {
 }
 
 function deliver_antrea_windows {
-    echo "====== Cleanup Antrea Installation ======"
+    echo "====== Cleanup Antrea Installation Before Delivering Antrea Windows ======"
     clean_up_one_ns "antrea-test"
     kubectl delete -f ${WORKDIR}/antrea-windows.yml --ignore-not-found=true || true
     kubectl delete -f ${WORKDIR}/kube-proxy-windows.yml --ignore-not-found=true || true
@@ -445,7 +445,7 @@ function deliver_antrea_windows {
 }
 
 function deliver_antrea_windows_containerd {
-    echo "====== Cleanup Antrea Installation ======"
+    echo "====== Cleanup Antrea Installation Before Delivering Antrea Windows Containerd ======"
     clean_up_one_ns "antrea-test"
     kubectl delete -f ${WORKDIR}/antrea-windows-containerd.yml --ignore-not-found=true || true
     kubectl delete -f ${WORKDIR}/kube-proxy-windows-containerd.yml --ignore-not-found=true || true
@@ -547,7 +547,7 @@ function deliver_antrea_windows_containerd {
 }
 
 function deliver_antrea {
-    echo "====== Cleanup Antrea Installation ======"
+    echo "====== Cleanup Antrea Installation Before Delivering Antrea ======"
     clean_up_one_ns "monitoring" || true
     clean_up_one_ns "antrea-ipam-test-11" || true
     clean_up_one_ns "antrea-ipam-test-12" || true
@@ -707,11 +707,13 @@ function run_conformance {
     kubectl rollout status deployment.apps/antrea-controller -n kube-system
     kubectl rollout status daemonset/antrea-agent -n kube-system
 
+    set +e
     if [[ "$TESTCASE" =~ "conformance" ]]; then
         ${WORKSPACE}/ci/run-k8s-e2e-tests.sh --e2e-conformance --e2e-skip "$CONFORMANCE_SKIP" --log-mode $MODE --image-pull-policy ${IMAGE_PULL_POLICY} --kube-conformance-image-version "auto" > ${WORKSPACE}/test-result.log
     else
         ${WORKSPACE}/ci/run-k8s-e2e-tests.sh --e2e-network-policy --e2e-skip "$NETWORKPOLICY_SKIP" --log-mode $MODE --image-pull-policy ${IMAGE_PULL_POLICY} --kube-conformance-image-version "auto" > ${WORKSPACE}/test-result.log
     fi
+    set -e
 
     cat ${WORKSPACE}/test-result.log
     if grep -Fxq "Failed tests:" ${WORKSPACE}/test-result.log; then

--- a/ci/run-k8s-e2e-tests.sh
+++ b/ci/run-k8s-e2e-tests.sh
@@ -174,7 +174,7 @@ function run_sonobuoy() {
     local focus_regex="$1"
     local skip_regex="$2"
 
-    $SONOBUOY delete --wait $KUBECONFIG_OPTION
+    $SONOBUOY delete --wait=10 $KUBECONFIG_OPTION
     echo "Running tests with sonobuoy. While test is running, check logs with: $SONOBUOY $KUBECONFIG_OPTION logs -f."
     set -x
     if [[ "$focus_regex" == "" && "$skip_regex" == "" ]]; then
@@ -265,7 +265,7 @@ if $RUN_SIG_NETWORK; then
 fi
 
 echoerr "Deleting sonobuoy resources"
-$SONOBUOY delete --wait $KUBECONFIG_OPTION
+$SONOBUOY delete --wait=10 $KUBECONFIG_OPTION
 
 if [[ $errors -ne 0 ]]; then
     exit 1


### PR DESCRIPTION
Cherry pick of #4843 #4833 on release-1.10.

#4843: Ignore script exit code for conformance test
#4833: Add timeout for sonobuoy deletion

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.