### PR TITLE
Bump up ofnet library to v0.6.10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	antrea.io/libOpenflow v0.9.2
-	antrea.io/ofnet v0.6.9
+	antrea.io/ofnet v0.6.10
 	github.com/ClickHouse/clickhouse-go v1.5.4
 	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/Mellanox/sriovnet v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 antrea.io/libOpenflow v0.9.2 h1:9W++nzaxxwY4NxyHHow/4bfum2UPIBJKmEOVTAG+x3o=
 antrea.io/libOpenflow v0.9.2/go.mod h1:IM9mUfHh5hUNciRRcWYIaWZTlv1TI6QBEHlml7ALdS4=
-antrea.io/ofnet v0.6.9 h1:ACoDhFhSHfNtuBKffvptspZDwKe+EQ5i35PuDUZ8svk=
-antrea.io/ofnet v0.6.9/go.mod h1:CB/Pkt+U0Yi1sM7DZ7iS215xGL+dhRRAM0EV0LTDLnY=
+antrea.io/ofnet v0.6.10 h1:t9cMGeES10YSDJ4Ooet9gSRUoRhx111ZYWQi14uRZO8=
+antrea.io/ofnet v0.6.10/go.mod h1:CB/Pkt+U0Yi1sM7DZ7iS215xGL+dhRRAM0EV0LTDLnY=
 bazil.org/fuse v0.0.0-20160811212531-371fbbdaa898/go.mod h1:Xbm+BRKSBEpa4q4hTSxohYNQpsxXPbPry4JJWOB3LB8=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=

--- a/pkg/ovs/openflow/ofctrl_bridge_test.go
+++ b/pkg/ovs/openflow/ofctrl_bridge_test.go
@@ -117,3 +117,19 @@ func TestDeleteGroup(t *testing.T) {
 		})
 	}
 }
+
+func TestConcurrentCreateGroups(t *testing.T) {
+	b := NewOFBridge("test-br", GetMgmtAddress(ovsconfig.DefaultOVSRunDir, "test-br"))
+	b.SwitchConnected(newFakeOFSwitch(b))
+	// Race detector on Windows has limit of 8192 simultaneously alive goroutines.
+	concurrentNum := 8000
+	var wg sync.WaitGroup
+	for i := 0; i < concurrentNum; i++ {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			b.CreateGroup(GroupIDType(index))
+		}(i)
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
Old ofnet versions do not have concurrency control over tableDb, groupDb and meterDb in OFSwitch, which will cause Antrea Agent to crash when calling ofSwitch.NewGroup concurrently.

Fixes #4847