### PR TITLE
Add Containerd to Windows Jenkins Jobs

### DIFF
--- a/ci/jenkins/README.md
+++ b/ci/jenkins/README.md
@@ -85,7 +85,7 @@ DOCKER_REGISTRY="$(head -n1 ci/docker-registry)"
 ./ci/jenkins/test.sh --testcase networkpolicy --registry ${DOCKER_REGISTRY}
 ```
 
-* windows e2e: e2e tests in a Windows setup.
+* windows e2e: e2e tests in a Windows setup with Docker runtime.
 
 ```shell
 #!/bin/bash
@@ -93,11 +93,11 @@ DOCKER_REGISTRY="$(head -n1 ci/docker-registry)"
 ./ci/jenkins/test.sh --testcase windows-e2e --registry ${DOCKER_REGISTRY}
 ```
 
-* windows conformance: community tests on Windows cluster, focusing on "Conformance|sig-windows" and "sig-network",
-  and skipping "LinuxOnly", "Slow", "Serial", "Disruptive", "Flaky", "Feature", "sig-cli", "sig-storage", "sig-auth",
-  "sig-api-machinery", "sig-apps", "sig-node", "Privileged", "should be able to change the type from", "[sig-network]
-  Services should be able to create a functioning NodePort service [Conformance]", "Service endpoints latency should not
-  be very high".
+* windows conformance: community tests on Windows cluster with Docker runtime, focusing on "Conformance|sig-windows" and
+  "sig-network", and skipping "LinuxOnly", "Slow", "Serial", "Disruptive", "Flaky", "Feature", "sig-cli", "sig-storage",
+  "sig-auth", "sig-api-machinery", "sig-apps", "sig-node", "Privileged", "should be able to change the type from",
+  "[sig-network] Services should be able to create a functioning NodePort service [Conformance]", "Service endpoints
+  latency should not be very high".
 
 ```shell
 #!/bin/bash
@@ -105,7 +105,7 @@ DOCKER_REGISTRY="$(head -n1 ci/docker-registry)"
 ./ci/jenkins/test.sh --testcase windows-conformance --registry ${DOCKER_REGISTRY}
 ```
 
-* windows network policy: community tests on Windows cluster, focusing on "Feature:NetworkPolicy".
+* windows network policy: community tests on Windows cluster with Docker runtime, focusing on "Feature:NetworkPolicy".
 
 ```shell
 #!/bin/bash
@@ -119,6 +119,34 @@ DOCKER_REGISTRY="$(head -n1 ci/docker-registry)"
 #!/bin/bash
 DOCKER_REGISTRY="$(head -n1 ci/docker-registry)"
 ./ci/jenkins/test.sh --testcase windows-e2e --registry ${DOCKER_REGISTRY} --proxyall
+```
+
+* windows containerd e2e: e2e tests in a Windows setup with Containerd runtime.
+
+```shell
+#!/bin/bash
+DOCKER_REGISTRY="$(head -n1 ci/docker-registry)"
+./ci/jenkins/test.sh --testcase windows-e2e --registry ${DOCKER_REGISTRY} --win-image-node {antrea_win_image_node_name}
+```
+
+* windows containerd conformance: community tests on Windows cluster with Containerd runtime, focusing on "Conformance|sig-windows" and
+  "sig-network", and skipping "LinuxOnly", "Slow", "Serial", "Disruptive", "Flaky", "Feature", "sig-cli", "sig-storage",
+  "sig-auth", "sig-api-machinery", "sig-apps", "sig-node", "Privileged", "should be able to change the type from",
+  "[sig-network] Services should be able to create a functioning NodePort service [Conformance]", "Service endpoints
+  latency should not be very high".
+
+```shell
+#!/bin/bash
+DOCKER_REGISTRY="$(head -n1 ci/docker-registry)"
+./ci/jenkins/test.sh --testcase windows-conformance --registry ${DOCKER_REGISTRY} --win-image-node {antrea_win_image_node_name}
+```
+
+* windows containerd network policy: community tests on Windows cluster with Containerd runtime, focusing on "Feature:NetworkPolicy".
+
+```shell
+#!/bin/bash
+DOCKER_REGISTRY="$(head -n1 ci/docker-registry)"
+./ci/jenkins/test.sh --testcase windows-networkpolicy --registry ${DOCKER_REGISTRY} --win-image-node {antrea_win_image_node_name}
 ```
 
 * Multicast e2e: e2e tests in a multicast cluster
@@ -296,5 +324,5 @@ updated with new code.
 
 ## Tips for Developer
 
-* [macro.yaml](jobs/macros.yaml): Use "{{}}" instead of "{}" in "builder-list-tests" and "builder-conformance".
+* [macro.yaml](jobs/macros.yaml): Use "{{}}" instead of "{}" to escape the "{" in "builder-list-tests", "builder-conformance" and "builder-*-win-containerd" because the macro has parameters.
 * While setting up the Rancher testbed, delete the cattle-cluster-agent deployment and use cattle-node-agent because cluster-agent adds extra watchers for all the resources. Antrea Controller counts connected Antrea Agent from watcher connections. Extra watchers lead to wrong Antrea Agent number in AntreaControllerInfo CR.

--- a/ci/jenkins/jobs/macros.yaml
+++ b/ci/jenkins/jobs/macros.yaml
@@ -133,7 +133,7 @@
           #!/bin/bash
           set -ex
           DOCKER_REGISTRY="$(head -n1 ci/docker-registry)"
-          ./ci/jenkins/test.sh --testcase '{conformance_type}' --registry ${{DOCKER_REGISTRY}} 
+          ./ci/jenkins/test.sh --testcase '{conformance_type}' --registry ${{DOCKER_REGISTRY}}
 
 - builder:
     name: builder-e2e-proxyall-win
@@ -143,6 +143,24 @@
           set -ex
           DOCKER_REGISTRY="$(head -n1 ci/docker-registry)"
           ./ci/jenkins/test.sh --testcase windows-e2e --registry ${DOCKER_REGISTRY} --proxyall
+
+- builder:
+      name: builder-e2e-win-containerd
+      builders:
+          - shell: |-
+                #!/bin/bash
+                set -ex
+                DOCKER_REGISTRY="$(head -n1 ci/docker-registry)"
+                ./ci/jenkins/test.sh --testcase windows-containerd-e2e --registry ${{DOCKER_REGISTRY}} --win-image-node '{win_image_node}'
+
+- builder:
+      name: builder-conformance-win-containerd
+      builders:
+          - shell: |-
+                #!/bin/bash
+                set -ex
+                DOCKER_REGISTRY="$(head -n1 ci/docker-registry)"
+                ./ci/jenkins/test.sh --testcase '{conformance_type}' --registry ${{DOCKER_REGISTRY}} --win-image-node '{win_image_node}'
 
 - builder:
     name: builder-flexible-ipam-e2e

--- a/ci/jenkins/jobs/projects-lab.yaml
+++ b/ci/jenkins/jobs/projects-lab.yaml
@@ -1,6 +1,6 @@
 - project:
-    # ghpr_auth, antrea_admin_list, antrea_org_list and antrea_white_list
-    # should be defined as a global variable somewhere else
+    # ghpr_auth, antrea_admin_list, antrea_org_list, antrea_white_list and
+    # antrea_win_image_node_name should be defined as a global variable somewhere else
     name: antrea
     git_credentials_id: ANTREA_GIT_CREDENTIAL
     org_repo: antrea-io/antrea
@@ -820,6 +820,251 @@
               default-excludes: true
               fingerprint: false
               only-if-success: false
+      - '{name}-{test_name}-no-scm':
+            test_name: windows-containerd-conformance-pending-label
+            node: null
+            description: 'This is for marking PR as pending for conformance test.'
+            builders:
+                - builder-pending-label
+            trigger_phrase: null
+            white_list_target_branches: [ ]
+            allow_whitelist_orgs_as_admins: false
+            admin_list: [ ]
+            org_list: [ ]
+            white_list: [ ]
+            only_trigger_phrase: false
+            trigger_permit_all: true
+            throttle_concurrent_builds_category:
+            throttle_concurrent_builds_enabled: 'false'
+            status_context: jenkins-windows-containerd-conformance
+            status_url: --none--
+            success_status: Pending test. Mark as failure. Add comment /test-windows-containerd-conformance to trigger.
+            failure_status: Pending test. Mark as failure. Add comment /test-windows-containerd-conformance to trigger.
+            error_status: Pending test. Mark as failure. Add comment /test-windows-containerd-conformance to trigger.
+            triggered_status: null
+            started_status: null
+            wrappers: [ ]
+            publishers: [ ]
+      - '{name}-{test_name}-for-pull-request':
+            test_name: windows-containerd-conformance
+            node: 'antrea-windows-containerd-testbed'
+            description: 'This is the {test_name} test for {name}.'
+            branches:
+                - ${{sha1}}
+            builders:
+                - builder-conformance-win-containerd:
+                      conformance_type: 'conformance'
+                      win_image_node: '{antrea_win_image_node_name}'
+            trigger_phrase: ^(?!Thanks for your PR).*/test-windows-(containerd-conformance|all).*
+            white_list_target_branches: [ ]
+            allow_whitelist_orgs_as_admins: true
+            admin_list: '{antrea_admin_list}'
+            org_list: '{antrea_org_list}'
+            white_list: '{antrea_white_list}'
+            only_trigger_phrase: true
+            trigger_permit_all: true
+            throttle_concurrent_builds_category:
+                - e2e-lock-per-testbed
+            throttle_concurrent_builds_enabled: 'true'
+            status_context: jenkins-windows-containerd-conformance
+            status_url: --none--
+            success_status: Build finished.
+            failure_status: Failed. Add comment /test-windows-containerd-conformance to re-trigger.
+            error_status: Failed. Add comment /test-windows-containerd-conformance to re-trigger.
+            triggered_status: null
+            started_status: null
+            wrappers:
+                - timeout:
+                      fail: true
+                      timeout: 120
+                      type: absolute
+                - credentials-binding:
+                      - text:
+                            credential-id: GOVC_URL
+                            variable: GOVC_URL
+                      - text:
+                            credential-id: GOVC_USERNAME
+                            variable: GOVC_USERNAME
+                      - text:
+                            credential-id: GOVC_PASSWORD
+                            variable: GOVC_PASSWORD
+                      - text:
+                            credential-id: GOVC_DATACENTER
+                            variable: GOVC_DATACENTER
+                      - text:
+                            credential-id: GOVC_DATASTORE
+                            variable: GOVC_DATASTORE
+            publishers:
+                - archive:
+                      allow-empty: true
+                      artifacts: 'windows_conformance_result_no_color.txt,network_info.tar.gz,antrea_agent_log.tar.gz,debug_logs.tar.gz'
+                      case-sensitive: true
+                      default-excludes: true
+                      fingerprint: false
+                      only-if-success: false
+      - '{name}-{test_name}-no-scm':
+            test_name: windows-containerd-networkpolicy-pending-label
+            node: null
+            description: 'This is for marking PR as pending for networkpolicy test.'
+            builders:
+                - builder-pending-label
+            trigger_phrase: null
+            white_list_target_branches: [ ]
+            allow_whitelist_orgs_as_admins: false
+            admin_list: [ ]
+            org_list: [ ]
+            white_list: [ ]
+            only_trigger_phrase: false
+            trigger_permit_all: true
+            throttle_concurrent_builds_category:
+            throttle_concurrent_builds_enabled: 'false'
+            status_context: jenkins-windows-containerd-networkpolicy
+            status_url: --none--
+            success_status: Pending test. Mark as failure. Add comment /test-windows-containerd-networkpolicy to trigger.
+            failure_status: Pending test. Mark as failure. Add comment /test-windows-containerd-networkpolicy to trigger.
+            error_status: Pending test. Mark as failure. Add comment /test-windows-containerd-networkpolicy to trigger.
+            triggered_status: null
+            started_status: null
+            wrappers: [ ]
+            publishers: [ ]
+      - '{name}-{test_name}-for-pull-request':
+            test_name: windows-containerd-networkpolicy
+            node: 'antrea-windows-containerd-testbed'
+            description: 'This is the {test_name} test for {name}.'
+            branches:
+                - ${{sha1}}
+            builders:
+                - builder-conformance-win-containerd:
+                      conformance_type: 'networkpolicy'
+                      win_image_node: '{antrea_win_image_node_name}'
+            trigger_phrase: ^(?!Thanks for your PR).*/test-windows-(containerd-networkpolicy|all).*
+            white_list_target_branches: [ ]
+            allow_whitelist_orgs_as_admins: true
+            admin_list: '{antrea_admin_list}'
+            org_list: '{antrea_org_list}'
+            white_list: '{antrea_white_list}'
+            only_trigger_phrase: true
+            trigger_permit_all: true
+            throttle_concurrent_builds_category:
+                - e2e-lock-per-testbed
+            throttle_concurrent_builds_enabled: 'true'
+            status_context: jenkins-windows-containerd-networkpolicy
+            status_url: --none--
+            success_status: Build finished.
+            failure_status: Failed. Add comment /test-windows-containerd-networkpolicy to re-trigger.
+            error_status: Failed. Add comment /test-windows-containerd-networkpolicy to re-trigger.
+            triggered_status: null
+            started_status: null
+            wrappers:
+                - timeout:
+                      fail: true
+                      timeout: 135
+                      type: absolute
+                - credentials-binding:
+                      - text:
+                            credential-id: GOVC_URL
+                            variable: GOVC_URL
+                      - text:
+                            credential-id: GOVC_USERNAME
+                            variable: GOVC_USERNAME
+                      - text:
+                            credential-id: GOVC_PASSWORD
+                            variable: GOVC_PASSWORD
+                      - text:
+                            credential-id: GOVC_DATACENTER
+                            variable: GOVC_DATACENTER
+                      - text:
+                            credential-id: GOVC_DATASTORE
+                            variable: GOVC_DATASTORE
+            publishers:
+                - archive:
+                      allow-empty: true
+                      artifacts: 'windows_conformance_result_no_color.txt,network_info.tar.gz,antrea_agent_log.tar.gz,debug_logs.tar.gz'
+                      case-sensitive: true
+                      default-excludes: true
+                      fingerprint: false
+                      only-if-success: false
+      - '{name}-{test_name}-no-scm':
+            test_name: windows-containerd-e2e-pending-label
+            node: null
+            description: 'This is for marking PR as pending for e2e test.'
+            builders:
+                - builder-pending-label
+            trigger_phrase: null
+            white_list_target_branches: [ ]
+            allow_whitelist_orgs_as_admins: false
+            admin_list: [ ]
+            org_list: [ ]
+            white_list: [ ]
+            only_trigger_phrase: false
+            trigger_permit_all: true
+            throttle_concurrent_builds_category:
+            throttle_concurrent_builds_enabled: 'false'
+            status_context: jenkins-windows-containerd-e2e
+            status_url: --none--
+            success_status: Pending test. Mark as failure. Add comment /test-windows-containerd-e2e to trigger.
+            failure_status: Pending test. Mark as failure. Add comment /test-windows-containerd-e2e to trigger.
+            error_status: Pending test. Mark as failure. Add comment /test-windows-containerd-e2e to trigger.
+            triggered_status: null
+            started_status: null
+            wrappers: [ ]
+            publishers: [ ]
+      - '{name}-{test_name}-for-pull-request':
+            test_name: windows-containerd-e2e
+            node: 'antrea-windows-containerd-testbed'
+            description: 'This is the {test_name} test for {name}.'
+            branches:
+                - ${{sha1}}
+            builders:
+                - builder-e2e-win-containerd:
+                      win_image_node: '{antrea_win_image_node_name}'
+            trigger_phrase: ^(?!Thanks for your PR).*/test-windows-(containerd-e2e|all).*
+            white_list_target_branches: [ ]
+            allow_whitelist_orgs_as_admins: true
+            admin_list: '{antrea_admin_list}'
+            org_list: '{antrea_org_list}'
+            white_list: '{antrea_white_list}'
+            only_trigger_phrase: true
+            trigger_permit_all: true
+            throttle_concurrent_builds_category:
+                - e2e-lock-per-testbed
+            throttle_concurrent_builds_enabled: 'true'
+            status_context: jenkins-windows-containerd-e2e
+            status_url: --none--
+            success_status: Build finished.
+            failure_status: Failed. Add comment /test-windows-containerd-e2e to re-trigger.
+            error_status: Failed. Add comment /test-windows-containerda-e2e to re-trigger.
+            triggered_status: null
+            started_status: null
+            wrappers:
+                - timeout:
+                      fail: true
+                      timeout: 120
+                      type: absolute
+                - credentials-binding:
+                      - text:
+                            credential-id: GOVC_URL
+                            variable: GOVC_URL
+                      - text:
+                            credential-id: GOVC_USERNAME
+                            variable: GOVC_USERNAME
+                      - text:
+                            credential-id: GOVC_PASSWORD
+                            variable: GOVC_PASSWORD
+                      - text:
+                            credential-id: GOVC_DATACENTER
+                            variable: GOVC_DATACENTER
+                      - text:
+                            credential-id: GOVC_DATASTORE
+                            variable: GOVC_DATASTORE
+            publishers:
+                - archive:
+                      allow-empty: true
+                      artifacts: antrea-test-logs.tar.gz
+                      case-sensitive: true
+                      default-excludes: true
+                      fingerprint: false
+                      only-if-success: false
       - '{name}-{test_name}-for-pull-request':
           test_name: kind-conformance
           node: 'antrea-kind-testbed'

--- a/ci/jenkins/test.sh
+++ b/ci/jenkins/test.sh
@@ -37,7 +37,7 @@ DEFAULT_IP_MODE="ipv4"
 IP_MODE=""
 K8S_VERSION="1.23.6-00"
 WINDOWS_YAML_SUFFIX="windows"
-WIN_JUMPER=""
+WIN_IMAGE_NODE=""
 
 WINDOWS_CONFORMANCE_FOCUS="\[sig-network\].+\[Conformance\]|\[sig-windows\]"
 WINDOWS_CONFORMANCE_SKIP="\[LinuxOnly\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[sig-cli\]|\[sig-storage\]|\[sig-auth\]|\[sig-api-machinery\]|\[sig-apps\]|\[sig-node\]|\[Privileged\]|should be able to change the type from|\[sig-network\] Services should be able to create a functioning NodePort service \[Conformance\]|Service endpoints latency should not be very high|should be able to create a functioning NodePort service for Windows"
@@ -64,7 +64,7 @@ Run K8s e2e community tests (Conformance & Network Policy) or Antrea e2e tests o
         --proxyall               Enable proxyAll to test AntreaProxy.
         --testbed-type           The testbed type to run tests. It can be flexible-ipam, jumper or legacy.
         --ip-mode                IP mode for flexible-ipam e2e test. Default is $DEFAULT_IP_MODE. It can also be ipv6 or ds.
-        --win-jumper             Name of the windows jumper node in containerd cluster. Images are built by docker on this node.
+        --win-image-node         Name of the windows image node in containerd cluster. Images are built by docker on this node.
         --kind-cluster-name      Name of the kind Cluster." 
 
 function print_usage {
@@ -112,8 +112,8 @@ case $key in
     IP_MODE="$2"
     shift 2
     ;;
-    --win-jumper)
-    WIN_JUMPER="$2"
+    --win-image-node)
+    WIN_IMAGE_NODE="$2"
     shift 2
     ;;
     -h|--help)
@@ -509,8 +509,8 @@ function deliver_antrea_windows_containerd {
     done
 
     echo "===== Build Antrea Windows on Windows Jumper Node ====="
-    echo "==== Reverting Windows VM ${WIN_JUMPER} ====="
-    revert_snapshot_windows ${WIN_JUMPER}
+    echo "==== Reverting Windows VM ${WIN_IMAGE_NODE} ====="
+    revert_snapshot_windows ${WIN_IMAGE_NODE}
     rm -f antrea-windows.tar.gz
     # Compress antrea repo and copy it to a Windows node
     mkdir -p jenkins
@@ -542,7 +542,7 @@ function deliver_antrea_windows_containerd {
             ssh -o StrictHostKeyChecking=no -n Administrator@${IP} "ctr -n k8s.io images pull ${k8s_images[i]} && ctr -n k8s.io images tag ${k8s_images[i]} ${e2e_images[i]}" || true
         done
         if ! (test -f antrea-windows.tar.gz); then
-            echo "Windows VM ${WIN_JUMPER} didn't build antrea-windows.tar.gz, exiting"
+            echo "Windows VM ${WIN_IMAGE_NODE} didn't build antrea-windows.tar.gz, exiting"
             exit 1
         else
             for i in `seq 2`; do


### PR DESCRIPTION
Windows containerd jobs are supported since Antrea 1.10. This solution adds description to the Jenkins job description for these jobs.

Fixes #4806