### PR TITLE
Stop exporting KUBECONFIG in ci/test-conformance-gke.sh

### DIFF
--- a/ci/jenkins/jobs/projects-cloud.yaml
+++ b/ci/jenkins/jobs/projects-cloud.yaml
@@ -673,6 +673,7 @@
           - trigger-parameterized-builds:
             - project:
               - cloud-{name}-eks-cleanup
+              current-parameters: true
               property-file: 'ci_properties.txt'
           - email:
               notify-every-unstable-build: true
@@ -737,6 +738,7 @@
           - trigger-parameterized-builds:
             - project:
               - cloud-{name}-gke-cleanup
+              current-parameters: true
               property-file: 'ci_properties.txt'
           - email:
               notify-every-unstable-build: true
@@ -786,6 +788,7 @@
           - trigger-parameterized-builds:
             - project:
               - cloud-{name}-aks-cleanup
+              current-parameters: true
               property-file: 'ci_properties.txt'
           - email:
               notify-every-unstable-build: true


### PR DESCRIPTION
This is causing the cloud-antrea-gke-cleanup Jenkins job to fail (even though the cluster is deleted properly), because for some reason "gcloud container clusters delete" tries to create the Kubeconfig file (and the directory does not exist):

```
ERROR: (gcloud.container.clusters.delete) Unable to create private file [/home/ubuntu/jenkins/out/gke/kubeconfig]: [Errno 1] Operation not permitted: '/home/ubuntu/jenkins/out/gke/kubeconfig'
```

This issue was introduced in #4862. It was not caught during testing because the cleanup job, which is triggered by the main conformance job, was not triggered using the correct parameters. Current build parameters (ANTREA_REPO and ANTREA_GIT_REVISION) need to be propagated to the cleanup job to enable proper testing before merges. We update the cloud job definitions so that current-parameters is set to true when triggering the cleanup jobs.