### PR TITLE
[Vagrant infra] Remove NetworkPolicyEndPort feature gate for apiserver

### DIFF
--- a/test/e2e/infra/vagrant/playbook/roles/control-plane/templates/kubeadm.conf.j2
+++ b/test/e2e/infra/vagrant/playbook/roles/control-plane/templates/kubeadm.conf.j2
@@ -17,8 +17,6 @@ networking:
 apiServer:
   certSANs:
   - "{{ k8s_api_server_ip }}"
-  extraArgs:
-    feature-gates: "NetworkPolicyEndPort=true"
 ---
 {% if kube_proxy_mode != 'none' %}
 apiVersion: kubeproxy.config.k8s.io/v1alpha1


### PR DESCRIPTION
The feature gate was GA'ed in K8s v1.25, and removed in K8s v1.27