### PR TITLE
Get the correct Antrea version in trivy_scan.yml workflow

### DIFF
--- a/.github/workflows/trivy_scan.yml
+++ b/.github/workflows/trivy_scan.yml
@@ -22,11 +22,11 @@ jobs:
     - name: Find greatest Antrea version
       id: find-antrea-greatest-version
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         VERSION=${{ github.event.inputs.antrea-version }}
         if [ -z "$VERSION" ]; then
-            VERSION=$(curl -s https://api.github.com/repos/antrea-io/antrea/releases/latest | jq -r '.tag_name')
+            VERSION=$(gh api /repos/antrea-io/antrea/releases/latest --jq '.tag_name')
         fi
         echo "antrea_version=$VERSION" >> $GITHUB_OUTPUT
     - name: Pull Antrea Docker images

--- a/.github/workflows/trivy_scan.yml
+++ b/.github/workflows/trivy_scan.yml
@@ -5,6 +5,13 @@ on:
     # every day at 10am
     - cron: '0 10 * * *'
   workflow_dispatch:
+    inputs:
+      # this is useful for testing an arbitrary released version of Antrea
+      # by default, we will use the latest release (obtained using the Github API)
+      antrea-version:
+        description: 'The released Antrea version to scan'
+        required: false
+        default: ''
 
 jobs:
   build:
@@ -14,11 +21,13 @@ jobs:
     - uses: actions/checkout@v3
     - name: Find greatest Antrea version
       id: find-antrea-greatest-version
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        VERSION=$(git ls-remote --tags --ref https://github.com/antrea-io/antrea.git | \
-          grep -v rc | \
-          awk '{print $2}' | awk -F/ '{print $3}' | \
-          sort --version-sort -r | head -n 1)
+        VERSION=${{ github.event.inputs.antrea-version }}
+        if [ -z "$VERSION" ]; then
+            VERSION=$(curl -s https://api.github.com/repos/antrea-io/antrea/releases/latest | jq -r '.tag_name')
+        fi
         echo "antrea_version=$VERSION" >> $GITHUB_OUTPUT
     - name: Pull Antrea Docker images
       id: pull

--- a/.github/workflows/trivy_scan.yml
+++ b/.github/workflows/trivy_scan.yml
@@ -6,12 +6,12 @@ on:
     - cron: '0 10 * * *'
   workflow_dispatch:
     inputs:
-      # this is useful for testing an arbitrary released version of Antrea
-      # by default, we will use the latest release (obtained using the Github API)
+      # This is useful for testing an arbitrary released version of Antrea.
+      # If left unset, we will use the latest release (obtained using the Github API).
       antrea-version:
         description: 'The released Antrea version to scan'
+        type: string
         required: false
-        default: ''
 
 jobs:
   build:


### PR DESCRIPTION
The existing logic was not ordering semantic versions correctly: it was treating v1.11.0-alpha.0 as greater than v1.11.0.
Instead we use the Github API, which will return the latest version, and always exclude all "prerelease" versions.