### PR TITLE
Add OVS table name as label for ovs_flow_count Prometheus metrics

### DIFF
--- a/docs/prometheus-integration.md
+++ b/docs/prometheus-integration.md
@@ -167,7 +167,7 @@ managed by the Antrea Agent.
 - **antrea_agent_networkpolicy_count:** Number of NetworkPolicies on local
 Node which are managed by the Antrea Agent.
 - **antrea_agent_ovs_flow_count:** Flow count for each OVS flow table. The
-TableID and TableName are used as a label.
+TableID and TableName are used as labels.
 - **antrea_agent_ovs_flow_ops_count:** Number of OVS flow operations,
 partitioned by operation type (add, modify and delete).
 - **antrea_agent_ovs_flow_ops_error_count:** Number of OVS flow operation

--- a/docs/prometheus-integration.md
+++ b/docs/prometheus-integration.md
@@ -167,7 +167,7 @@ managed by the Antrea Agent.
 - **antrea_agent_networkpolicy_count:** Number of NetworkPolicies on local
 Node which are managed by the Antrea Agent.
 - **antrea_agent_ovs_flow_count:** Flow count for each OVS flow table. The
-TableID is used as a label.
+TableID and TableName are used as a label.
 - **antrea_agent_ovs_flow_ops_count:** Number of OVS flow operations,
 partitioned by operation type (add, modify and delete).
 - **antrea_agent_ovs_flow_ops_error_count:** Number of OVS flow operation

--- a/pkg/agent/metrics/prometheus.go
+++ b/pkg/agent/metrics/prometheus.go
@@ -79,7 +79,7 @@ var (
 		Namespace:      metricNamespaceAntrea,
 		Subsystem:      metricSubsystemAgent,
 		Name:           "ovs_flow_count",
-		Help:           "Flow count for each OVS flow table. The TableID and TableName are used as a label.",
+		Help:           "Flow count for each OVS flow table. The TableID and TableName are used as labels.",
 		StabilityLevel: metrics.STABLE,
 	}, []string{"table_id", "table_name"})
 

--- a/pkg/agent/metrics/prometheus.go
+++ b/pkg/agent/metrics/prometheus.go
@@ -79,9 +79,9 @@ var (
 		Namespace:      metricNamespaceAntrea,
 		Subsystem:      metricSubsystemAgent,
 		Name:           "ovs_flow_count",
-		Help:           "Flow count for each OVS flow table. The TableID is used as a label.",
+		Help:           "Flow count for each OVS flow table. The TableID and TableName are used as a label.",
 		StabilityLevel: metrics.STABLE,
-	}, []string{"table_id"})
+	}, []string{"table_id", "table_name"})
 
 	OVSFlowOpsCount = metrics.NewCounterVec(
 		&metrics.CounterOpts{

--- a/pkg/ovs/openflow/ofctrl_bridge.go
+++ b/pkg/ovs/openflow/ofctrl_bridge.go
@@ -104,7 +104,7 @@ func (t *ofTable) UpdateStatus(flowCountDelta int) {
 	}
 
 	metrics.OVSTotalFlowCount.Add(float64(flowCountDelta))
-	metrics.OVSFlowCount.WithLabelValues(strconv.Itoa(int(t.id))).Add(float64(flowCountDelta))
+	metrics.OVSFlowCount.WithLabelValues(strconv.Itoa(int(t.id)), t.name).Add(float64(flowCountDelta))
 
 	t.updateTime = time.Now()
 }
@@ -115,7 +115,7 @@ func (t *ofTable) ResetStatus() {
 
 	t.flowCount = 0
 
-	metrics.OVSFlowCount.WithLabelValues(strconv.Itoa(int(t.id))).Set(0)
+	metrics.OVSFlowCount.WithLabelValues(strconv.Itoa(int(t.id)), t.name).Set(0)
 
 	t.updateTime = time.Now()
 }

--- a/test/integration/agent/openflow_test.go
+++ b/test/integration/agent/openflow_test.go
@@ -1019,13 +1019,13 @@ func getIPProtoStr(addr types.Address) (bool, string) {
 
 func checkOVSFlowMetrics(t *testing.T, client ofClient.Client) {
 	expectedFlowCount := `
-	# HELP antrea_agent_ovs_flow_count [STABLE] Flow count for each OVS flow table. The TableID is used as a label.
+	# HELP antrea_agent_ovs_flow_count [STABLE] Flow count for each OVS flow table. The TableID and TableName are used as a label.
 	# TYPE antrea_agent_ovs_flow_count gauge
 	`
 	tableStatus := client.GetFlowTableStatus()
 	totalFlowCount := 0
 	for _, table := range tableStatus {
-		expectedFlowCount = expectedFlowCount + fmt.Sprintf("antrea_agent_ovs_flow_count{table_id=\"%d\"} %d\n", table.ID, table.FlowCount)
+		expectedFlowCount = expectedFlowCount + fmt.Sprintf("antrea_agent_ovs_flow_count{table_id=\"%d\", table_name=\"%s\"} %d\n", table.ID, table.Name, table.FlowCount)
 		totalFlowCount = totalFlowCount + int(table.FlowCount)
 	}
 	expectedTotalFlowCount := `

--- a/test/integration/agent/openflow_test.go
+++ b/test/integration/agent/openflow_test.go
@@ -1019,7 +1019,7 @@ func getIPProtoStr(addr types.Address) (bool, string) {
 
 func checkOVSFlowMetrics(t *testing.T, client ofClient.Client) {
 	expectedFlowCount := `
-	# HELP antrea_agent_ovs_flow_count [STABLE] Flow count for each OVS flow table. The TableID and TableName are used as a label.
+	# HELP antrea_agent_ovs_flow_count [STABLE] Flow count for each OVS flow table. The TableID and TableName are used as labels.
 	# TYPE antrea_agent_ovs_flow_count gauge
 	`
 	tableStatus := client.GetFlowTableStatus()


### PR DESCRIPTION
Issue: https://github.com/antrea-io/antrea/issues/4566

Add the OVS table name as a label for the `antrea_agent_ovs_flow_count` metric to facilitate identifying the corresponding table for each metric.

<img width="1500" alt="image" src="https://user-images.githubusercontent.com/40051120/233893140-b2ea4545-0409-40a8-b5c9-ec072634b481.png">