### PR TITLE
Support EndpointSlice API for ServiceExport controller

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,7 +188,7 @@ Here are the trigger phrases for individual checks:
 Here are the trigger phrases for groups of checks:
 
 * `/test-all`: Linux IPv4 tests
-* `/test-windows-all`: Windows IPv4 tests, including e2e tests with proxyAll enabled. It also includes all Containderd runtime based Windows tests since 1.10.0.
+* `/test-windows-all`: Windows IPv4 tests, including e2e tests with proxyAll enabled. It also includes all containerd runtime based Windows tests since 1.10.0.
 * `/test-ipv6-all`: Linux dual stack tests
 * `/test-ipv6-only-all`: Linux IPv6 only tests
 

--- a/docs/antrea-proxy.md
+++ b/docs/antrea-proxy.md
@@ -121,7 +121,7 @@ Assuming you are following the steps we [documented](windows.md) to add Windows
 Nodes to your K8s cluster with Antrea, you will simply need to skip running
 kube-proxy:
 
-* Do not install or start the `kube-proxy` service [when using containderd as
+* Do not install or start the `kube-proxy` service [when using containerd as
   the container runtime](windows.md#installation-as-a-service-containerd-based-runtimes)
 * Do not create the `kube-proxy-windows` DaemonSet [when using Docker as the
   container runtime](windows.md#installation-via-wins-docker-based-runtimes)

--- a/multicluster/build/yamls/antrea-multicluster-member.yml
+++ b/multicluster/build/yamls/antrea-multicluster-member.yml
@@ -827,6 +827,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - pods

--- a/multicluster/cmd/multicluster-controller/member.go
+++ b/multicluster/cmd/multicluster-controller/member.go
@@ -77,7 +77,9 @@ func runMember(o *Options) error {
 		mgr.GetClient(),
 		mgr.GetScheme(),
 		commonAreaGetter,
-		o.EndpointIPType)
+		o.EndpointIPType,
+		o.EnableEndpointSlice,
+	)
 	if err = svcExportReconciler.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("error creating ServiceExport controller: %v", err)
 	}

--- a/multicluster/cmd/multicluster-controller/options.go
+++ b/multicluster/cmd/multicluster-controller/options.go
@@ -23,6 +23,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	mcsv1alpha1 "antrea.io/antrea/multicluster/apis/multicluster/v1alpha1"
+	"antrea.io/antrea/multicluster/controllers/multicluster/common"
 )
 
 type Options struct {
@@ -43,6 +44,8 @@ type Options struct {
 	// Enable StretchedNetworkPolicy to exchange labelIdentities info among the whole
 	// ClusterSet.
 	EnableStretchedNetworkPolicy bool
+	// Watch EndpointSlice API for exported Service if EndpointSlice API is available.
+	EnableEndpointSlice bool
 }
 
 func newOptions() *Options {
@@ -82,8 +85,11 @@ func (o *Options) complete(args []string) error {
 		o.PodCIDRs = cidrs
 		o.GatewayIPPrecedence = ctrlConfig.GatewayIPPrecedence
 		if ctrlConfig.EndpointIPType == "" {
-			o.EndpointIPType = "ClusterIP"
+			o.EndpointIPType = common.EndpointIPTypeClusterIP
 		} else {
+			if ctrlConfig.EndpointIPType != common.EndpointIPTypeClusterIP && ctrlConfig.EndpointIPType != common.EndpointIPTypePodIP {
+				return fmt.Errorf("invalid endpointIPType: %s, only 'PodIP' or 'ClusterIP' is allowed", ctrlConfig.EndpointIPType)
+			}
 			o.EndpointIPType = ctrlConfig.EndpointIPType
 		}
 		o.EnableStretchedNetworkPolicy = ctrlConfig.EnableStretchedNetworkPolicy

--- a/multicluster/cmd/multicluster-controller/options_test.go
+++ b/multicluster/cmd/multicluster-controller/options_test.go
@@ -68,6 +68,19 @@ func TestComplete(t *testing.T) {
 			},
 			exceptdErr: fmt.Errorf("failed to parse podCIDRs, invalid CIDR string 10.10a.0.0/16"),
 		},
+		{
+			name: "options with invalid endpointIPType",
+			o: Options{
+				configFile:          "./testdata/antrea-mc-config-with-invalid-endpointiptype.yml",
+				SelfSignedCert:      false,
+				options:             ctrl.Options{},
+				ServiceCIDR:         "10.100.0.0/16",
+				PodCIDRs:            nil,
+				GatewayIPPrecedence: "",
+				EndpointIPType:      "",
+			},
+			exceptdErr: fmt.Errorf("invalid endpointIPType: None, only 'PodIP' or 'ClusterIP' is allowed"),
+		},
 	}
 
 	for _, tt := range testCases {

--- a/multicluster/cmd/multicluster-controller/testdata/antrea-mc-config-with-invalid-endpointiptype.yml
+++ b/multicluster/cmd/multicluster-controller/testdata/antrea-mc-config-with-invalid-endpointiptype.yml
@@ -1,0 +1,16 @@
+apiVersion: multicluster.crd.antrea.io/v1alpha1
+kind: MultiClusterConfig
+health:
+  healthProbeBindAddress: :8080
+metrics:
+  bindAddress: "0"
+webhook:
+  port: 9443
+leaderElection:
+  leaderElect: false
+serviceCIDR: ""
+podCIDRs:
+  - "10.10.0.0/16"
+  - ""
+gatewayIPPrecedence: "private"
+endpointIPType: "None"

--- a/multicluster/config/overlays/member/role.yaml
+++ b/multicluster/config/overlays/member/role.yaml
@@ -39,6 +39,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - pods

--- a/multicluster/config/rbac/role.yaml
+++ b/multicluster/config/rbac/role.yaml
@@ -64,6 +64,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - multicluster.crd.antrea.io
   resources:
   - clusterclaims

--- a/multicluster/controllers/multicluster/common/helper.go
+++ b/multicluster/controllers/multicluster/common/helper.go
@@ -76,27 +76,6 @@ func GetServiceEndpointPorts(ports []corev1.ServicePort) []corev1.EndpointPort {
 	return epPorts
 }
 
-// FilterEndpointSubsets keeps IPs only and removes other fields from EndpointSubset
-// which are unnecessary information for other member clusters.
-func FilterEndpointSubsets(subsets []corev1.EndpointSubset) []corev1.EndpointSubset {
-	var newSubsets []corev1.EndpointSubset
-	for _, s := range subsets {
-		subset := corev1.EndpointSubset{}
-		var newAddresses []corev1.EndpointAddress
-		for _, addr := range s.Addresses {
-			newAddresses = append(newAddresses, corev1.EndpointAddress{
-				IP: addr.IP,
-			})
-		}
-		if len(newAddresses) > 0 {
-			subset.Addresses = newAddresses
-			subset.Ports = s.Ports
-			newSubsets = append(newSubsets, subset)
-		}
-	}
-	return newSubsets
-}
-
 // HashLabelIdentity generates a hash value for label identity string.
 func HashLabelIdentity(l string) string {
 	hash := sha1.New() // #nosec G401: not used for security purposes

--- a/multicluster/controllers/multicluster/common/test_data.go
+++ b/multicluster/controllers/multicluster/common/test_data.go
@@ -67,7 +67,7 @@ var (
 		IP:       "192.168.17.12",
 		Hostname: "pod1",
 	}
-	epPorts80 = []corev1.EndpointPort{
+	EPPorts80 = []corev1.EndpointPort{
 		{
 			Name:     "http",
 			Port:     80,
@@ -79,7 +79,7 @@ var (
 			Addresses: []corev1.EndpointAddress{
 				addr1,
 			},
-			Ports: epPorts80,
+			Ports: EPPorts80,
 		},
 	}
 	EPNginxSubset2 = []corev1.EndpointSubset{
@@ -87,7 +87,7 @@ var (
 			Addresses: []corev1.EndpointAddress{
 				addr2,
 			},
-			Ports: epPorts80,
+			Ports: EPPorts80,
 		},
 	}
 	EPNginx = &corev1.Endpoints{

--- a/multicluster/controllers/multicluster/common/types.go
+++ b/multicluster/controllers/multicluster/common/types.go
@@ -31,4 +31,7 @@ const (
 	InvalidClusterSetID = ClusterSetID("invalid")
 
 	DefaultWorkerCount = 5
+
+	EndpointIPTypeClusterIP = "ClusterIP"
+	EndpointIPTypePodIP     = "PodIP"
 )

--- a/multicluster/controllers/multicluster/member/serviceexport_controller.go
+++ b/multicluster/controllers/multicluster/member/serviceexport_controller.go
@@ -18,13 +18,16 @@ package member
 
 import (
 	"context"
+	"net"
 	"reflect"
 	"sync"
 
 	corev1 "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
@@ -62,16 +65,17 @@ type (
 	// ServiceExportReconciler reconciles a ServiceExport object in the member cluster.
 	ServiceExportReconciler struct {
 		client.Client
-		mutex            sync.Mutex
-		Scheme           *runtime.Scheme
-		commonAreaGetter commonarea.RemoteCommonAreaGetter
-		remoteCommonArea commonarea.RemoteCommonArea
-		installedSvcs    cache.Indexer
-		installedEps     cache.Indexer
-		leaderNamespace  string
-		leaderClusterID  string
-		localClusterID   string
-		endpointIPType   string
+		mutex                sync.Mutex
+		Scheme               *runtime.Scheme
+		commonAreaGetter     commonarea.RemoteCommonAreaGetter
+		remoteCommonArea     commonarea.RemoteCommonArea
+		installedSvcs        cache.Indexer
+		installedEps         cache.Indexer
+		leaderNamespace      string
+		leaderClusterID      string
+		localClusterID       string
+		endpointIPType       string
+		endpointSliceEnabled bool
 	}
 )
 
@@ -90,14 +94,16 @@ func NewServiceExportReconciler(
 	client client.Client,
 	scheme *runtime.Scheme,
 	commonAreaGetter commonarea.RemoteCommonAreaGetter,
-	endpointIPType string) *ServiceExportReconciler {
+	endpointIPType string,
+	endpointSliceEnabled bool) *ServiceExportReconciler {
 	reconciler := &ServiceExportReconciler{
-		Client:           client,
-		Scheme:           scheme,
-		commonAreaGetter: commonAreaGetter,
-		endpointIPType:   endpointIPType,
-		installedSvcs:    cache.NewIndexer(svcInfoKeyFunc, cache.Indexers{}),
-		installedEps:     cache.NewIndexer(epInfoKeyFunc, cache.Indexers{}),
+		Client:               client,
+		Scheme:               scheme,
+		commonAreaGetter:     commonAreaGetter,
+		endpointIPType:       endpointIPType,
+		endpointSliceEnabled: endpointSliceEnabled,
+		installedSvcs:        cache.NewIndexer(svcInfoKeyFunc, cache.Indexers{}),
+		installedEps:         cache.NewIndexer(epInfoKeyFunc, cache.Indexers{}),
 	}
 	return reconciler
 }
@@ -118,6 +124,7 @@ func epInfoKeyFunc(obj interface{}) (string, error) {
 //+kubebuilder:rbac:groups=multicluster.x-k8s.io,resources=serviceexports,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=multicluster.x-k8s.io,resources=serviceexports/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;update
+//+kubebuilder:rbac:groups="discovery.k8s.io",resources=endpointslices,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -231,19 +238,26 @@ func (r *ServiceExportReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			Namespace: req.Namespace,
 		},
 	}
-	readyAddresses := 0
-	err = r.Client.Get(ctx, req.NamespacedName, eps)
-	if err == nil {
-		for _, subsets := range eps.Subsets {
-			readyAddresses = readyAddresses + len(subsets.Addresses)
+
+	var hasReadyEndpoints bool
+	var newSubsets []corev1.EndpointSubset
+	if r.endpointSliceEnabled {
+		newSubsets, hasReadyEndpoints, err = r.getSubsetsFromEndpointSlice(ctx, req)
+		if err != nil {
+			return ctrl.Result{}, err
 		}
 	} else {
-		if !apierrors.IsNotFound(err) {
+		newSubsets, hasReadyEndpoints, err = r.checkSubsetsFromEndpoint(ctx, req, eps)
+		if err != nil {
 			klog.ErrorS(err, "Failed to get Endpoints", req.String())
 			return ctrl.Result{}, err
 		}
 	}
-	if readyAddresses == 0 || apierrors.IsNotFound(err) {
+
+	if !hasReadyEndpoints {
+		// When the controller restarts, `svcInstalled` is false as the cache will be empty, but the available Endpoints of
+		// a Service might have been decreased to zero during the controller restart, so we skip checking `svcInstalled`
+		// and try to clean up anyway.
 		if err := cleanup(); err != nil {
 			return ctrl.Result{}, err
 		}
@@ -254,23 +268,8 @@ func (r *ServiceExportReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, nil
 	}
 
-	// We also watch Service events via events mapping function.
-	// Need to check cache and compare with cache if there is any change for Service.
-	var svcNoChange, epNoChange bool
-	svcExportNSName := common.NamespacedName(r.leaderNamespace, svcResExportName)
-	epExportNSName := common.NamespacedName(r.leaderNamespace, epResExportName)
-	if svcInstalled {
-		installedSvc := svcObj.(*svcInfo)
-		if apiequality.Semantic.DeepEqual(svc.Spec.Ports, installedSvc.ports) &&
-			apiequality.Semantic.DeepEqual(svc.Spec.ClusterIPs, installedSvc.clusterIPs) {
-			klog.InfoS("Service has been converted into ResourceExport and no change, skip it", "service",
-				req.String(), "resourceexport", svcExportNSName)
-			svcNoChange = true
-		}
-	}
-
-	if r.endpointIPType == "ClusterIP" {
-		svcIPAsSubset := common.GetServiceEndpointSubset(svc)
+	if r.endpointIPType == common.EndpointIPTypeClusterIP {
+		svcIPAsSubset := getClusterIPEndpointSubset(svc)
 		if len(svcIPAsSubset.Addresses) == 0 {
 			err = r.updateSvcExportStatus(ctx, req, serviceNoClusterIP)
 			if err != nil {
@@ -278,24 +277,36 @@ func (r *ServiceExportReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			}
 			return ctrl.Result{}, nil
 		} else {
-			eps.Subsets = []corev1.EndpointSubset{svcIPAsSubset}
-		}
-	} else {
-		newSubsets := common.FilterEndpointSubsets(eps.Subsets)
-		if epsInstalled {
-			installedEp := epsObj.(*epInfo)
-			if apiequality.Semantic.DeepEqual(newSubsets, installedEp.subsets) {
-				klog.InfoS("Endpoints has been converted into ResourceExport and no change, skip it", "endpoints",
-					req.String(), "resourceexport", epExportNSName)
-				epNoChange = true
-			}
-		}
-		if !epNoChange {
-			eps.Subsets = newSubsets
+			newSubsets = []corev1.EndpointSubset{svcIPAsSubset}
 		}
 	}
 
-	if svcNoChange && epNoChange {
+	// We also watch Service events via events mapping function.
+	// Need to check cache and compare with cache if there is any change for Service.
+	var skipUpdateSvcResourceExport, skipUpdateEPResourceExport bool
+	svcExportNSName := common.NamespacedName(r.leaderNamespace, svcResExportName)
+	epExportNSName := common.NamespacedName(r.leaderNamespace, epResExportName)
+	if svcInstalled {
+		installedSvc := svcObj.(*svcInfo)
+		if apiequality.Semantic.DeepEqual(svc.Spec.Ports, installedSvc.ports) {
+			klog.InfoS("Service has been converted into ResourceExport and no change, skip it", "service",
+				req.String(), "resourceexport", svcExportNSName)
+			skipUpdateSvcResourceExport = true
+		}
+	}
+
+	if epsInstalled {
+		installedEp := epsObj.(*epInfo)
+		if apiequality.Semantic.DeepEqual(newSubsets, installedEp.subsets) {
+			klog.InfoS("Service's Endpoints (PodIP or ClusterIP) has been converted into ResourceExport and no change, skip it", "Service",
+				req.String(), "resourceexport", epExportNSName)
+			// When the EndpointIPType is EndpointIPTypeClusterIP, skipUpdateEPResourceExport should be false only
+			// when there is a ClusterIP/Port change.
+			skipUpdateEPResourceExport = true
+		}
+	}
+
+	if skipUpdateSvcResourceExport && skipUpdateEPResourceExport {
 		return ctrl.Result{}, nil
 	}
 
@@ -315,7 +326,7 @@ func (r *ServiceExportReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		},
 	}
 
-	if !svcNoChange {
+	if !skipUpdateSvcResourceExport {
 		klog.InfoS("Service has new changes, update ResourceExport", "service", req.String(),
 			"resourceexport", svcExportNSName)
 		err := r.serviceHandler(ctx, req, svc, svcResExportName, re, r.remoteCommonArea)
@@ -330,12 +341,13 @@ func (r *ServiceExportReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}
 	}
 
-	if !epNoChange {
-		klog.InfoS("Endpoints have new change, update ResourceExport", "endpoints",
+	if !skipUpdateEPResourceExport {
+		eps.Subsets = newSubsets
+		klog.InfoS("Endpoints or EndpointSlices has new changes, update ResourceExport", "Service",
 			req.String(), "resourceexport", epExportNSName)
 		err = r.endpointsHandler(ctx, req, eps, epResExportName, re, r.remoteCommonArea)
 		if err != nil {
-			klog.ErrorS(err, "Failed to handle Endpoints change", "endpoints", req.String())
+			klog.ErrorS(err, "Failed to handle Endpoints or EndpointSlices change", "service", req.String())
 			return ctrl.Result{}, err
 		}
 	}
@@ -437,6 +449,8 @@ func (r *ServiceExportReconciler) updateSvcExportStatus(ctx context.Context, req
 		newCondition.Message = getStringPointer("The Service is imported, not allowed to export")
 	case serviceExported:
 		newCondition.Status = corev1.ConditionTrue
+		newCondition.Reason = getStringPointer("Succeed")
+		newCondition.Message = getStringPointer("The Service is exported successfully")
 	}
 
 	svcExportConditions := svcExport.Status.DeepCopy().Conditions
@@ -478,6 +492,17 @@ func (r *ServiceExportReconciler) updateSvcExportStatus(ctx context.Context, req
 func (r *ServiceExportReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// Watch events only when resource version changes
 	versionChange := predicate.ResourceVersionChangedPredicate{}
+	if r.endpointSliceEnabled {
+		return ctrl.NewControllerManagedBy(mgr).
+			For(&k8smcsv1alpha1.ServiceExport{}).
+			Watches(&source.Kind{Type: &corev1.Service{}}, handler.EnqueueRequestsFromMapFunc(objectMapFunc)).
+			Watches(&source.Kind{Type: &discovery.EndpointSlice{}}, handler.EnqueueRequestsFromMapFunc(endpointSliceMapFunc)).
+			WithEventFilter(versionChange).
+			WithOptions(controller.Options{
+				MaxConcurrentReconciles: common.DefaultWorkerCount,
+			}).
+			Complete(r)
+	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&k8smcsv1alpha1.ServiceExport{}).
 		Watches(&source.Kind{Type: &corev1.Service{}}, handler.EnqueueRequestsFromMapFunc(objectMapFunc)).
@@ -504,6 +529,21 @@ func objectMapFunc(a client.Object) []reconcile.Request {
 	}
 }
 
+func endpointSliceMapFunc(a client.Object) []reconcile.Request {
+	labels := a.GetLabels()
+	svcName := labels[discovery.LabelServiceName]
+	mappedObject := types.NamespacedName{}
+	if svcName != "" {
+		mappedObject.Name = svcName
+		mappedObject.Namespace = a.GetNamespace()
+	}
+	return []reconcile.Request{
+		{
+			NamespacedName: mappedObject,
+		},
+	}
+}
+
 // serviceHandler handles Service related change.
 // ClusterIP type: update corresponding ResourceExport only when ClusterIP or Ports change.
 func (r *ServiceExportReconciler) serviceHandler(
@@ -521,7 +561,7 @@ func (r *ServiceExportReconciler) serviceHandler(
 		ports:      svc.Spec.Ports,
 		svcType:    string(svc.Spec.Type),
 	}
-	r.refreshResourceExport(resName, kind, svc, nil, &re)
+	r.resetResourceExport(resName, kind, svc, nil, &re)
 	existingResExport := &mcsv1alpha1.ResourceExport{}
 	resNamespaced := types.NamespacedName{Namespace: rc.GetNamespace(), Name: resName}
 	err := rc.Get(ctx, resNamespaced, existingResExport)
@@ -553,7 +593,7 @@ func (r *ServiceExportReconciler) endpointsHandler(
 		namespace: eps.Namespace,
 		subsets:   eps.Subsets,
 	}
-	r.refreshResourceExport(resName, kind, nil, eps, &re)
+	r.resetResourceExport(resName, kind, nil, eps, &re)
 	existingResExport := &mcsv1alpha1.ResourceExport{}
 	resNamespaced := types.NamespacedName{Namespace: rc.GetNamespace(), Name: resName}
 	err := rc.Get(ctx, resNamespaced, existingResExport)
@@ -570,7 +610,7 @@ func (r *ServiceExportReconciler) endpointsHandler(
 	return nil
 }
 
-func (r *ServiceExportReconciler) refreshResourceExport(resName, kind string,
+func (r *ServiceExportReconciler) resetResourceExport(resName, kind string,
 	svc *corev1.Service,
 	ep *corev1.Endpoints,
 	re *mcsv1alpha1.ResourceExport) mcsv1alpha1.ResourceExport {
@@ -579,7 +619,9 @@ func (r *ServiceExportReconciler) refreshResourceExport(resName, kind string,
 	case constants.ServiceKind:
 		re.ObjectMeta.Name = resName
 		re.Spec.Service = &mcsv1alpha1.ServiceExport{
-			ServiceSpec: svc.Spec,
+			ServiceSpec: corev1.ServiceSpec{
+				Ports: svc.Spec.Ports,
+			},
 		}
 		re.Labels[constants.SourceKind] = constants.ServiceKind
 	case constants.EndpointsKind:
@@ -626,10 +668,146 @@ func (r *ServiceExportReconciler) updateOrCreateResourceExport(resName string,
 	return nil
 }
 
+// getSubsetsFromEndpointSlice will get all ready endpoints from all the EndpointSlices which will
+// be merged to one Endpoints. In the future, we should change to track and export individual
+// EndpointSlices, rather than merge them to one Endpoints.
+func (r *ServiceExportReconciler) getSubsetsFromEndpointSlice(ctx context.Context, req ctrl.Request) ([]corev1.EndpointSubset, bool, error) {
+	epSliceList := &discovery.EndpointSliceList{}
+	hasReadyEndpoints := false
+	err := r.Client.List(ctx, epSliceList, &client.ListOptions{
+		LabelSelector: getEndpointSliceLabelSelector(req.Name),
+		Namespace:     req.Namespace})
+	if err != nil {
+		return nil, hasReadyEndpoints, err
+	}
+	if len(epSliceList.Items) == 0 {
+		return nil, hasReadyEndpoints, nil
+	}
+	var subsets []corev1.EndpointSubset
+	for _, eps := range epSliceList.Items {
+		if eps.AddressType == discovery.AddressTypeIPv4 {
+			var ports []corev1.EndpointPort
+			if r.endpointIPType == common.EndpointIPTypePodIP {
+				ports = convertEndpointPorts(eps.Ports)
+			}
+			subset := corev1.EndpointSubset{}
+			subset.Ports = ports
+			for _, ep := range eps.Endpoints {
+				if ep.Conditions.Ready != nil && *ep.Conditions.Ready {
+					// We only cares if there is ready Endpoints for a Service when the endpointIPType is ClusterIP,
+					// so skip handling the EndpointSubset and stop the loop early if any ready address is found.
+					if r.endpointIPType == common.EndpointIPTypeClusterIP {
+						return nil, true, nil
+					}
+					readyAddresses := ipsToEndpointAddresses(ep.Addresses)
+					if len(readyAddresses) > 0 {
+						subset.Addresses = append(subset.Addresses, readyAddresses...)
+						subsets = append(subsets, subset)
+					}
+				}
+			}
+		}
+	}
+	return subsets, len(subsets) > 0, nil
+}
+
+func (r *ServiceExportReconciler) checkSubsetsFromEndpoint(ctx context.Context, req ctrl.Request, eps *corev1.Endpoints) ([]corev1.EndpointSubset, bool, error) {
+	var newSubsets []corev1.EndpointSubset
+	err := r.Client.Get(ctx, req.NamespacedName, eps)
+	if err == nil {
+		for _, s := range eps.Subsets {
+			subset := corev1.EndpointSubset{}
+			var newAddresses []corev1.EndpointAddress
+			for _, addr := range s.Addresses {
+				newAddresses = append(newAddresses, corev1.EndpointAddress{
+					IP: addr.IP,
+				})
+			}
+			if len(newAddresses) > 0 {
+				subset.Addresses = newAddresses
+				subset.Ports = s.Ports
+				newSubsets = append(newSubsets, subset)
+			}
+		}
+		return newSubsets, len(newSubsets) > 0, nil
+	}
+	if !apierrors.IsNotFound(err) {
+		return nil, false, err
+	}
+	return nil, false, nil
+}
+
+func convertEndpointPorts(ports []discovery.EndpointPort) []corev1.EndpointPort {
+	var v1Ports []corev1.EndpointPort
+	for _, port := range ports {
+		v1Port := corev1.EndpointPort{}
+		if port.Name != nil {
+			v1Port.Name = *port.Name
+		}
+		if port.Port != nil {
+			v1Port.Port = *port.Port
+		}
+		if port.Protocol != nil {
+			v1Port.Protocol = *port.Protocol
+		}
+		v1Port.AppProtocol = port.AppProtocol
+		v1Ports = append(v1Ports, v1Port)
+	}
+	return v1Ports
+}
+
+func ipsToEndpointAddresses(ips []string) []corev1.EndpointAddress {
+	var addresses []corev1.EndpointAddress
+	for _, ip := range ips {
+		addresses = append(addresses, corev1.EndpointAddress{IP: ip})
+	}
+	return addresses
+}
+
 func getResourceExportName(clusterID string, req ctrl.Request, kind string) string {
 	return clusterID + "-" + req.Namespace + "-" + req.Name + "-" + kind
 }
 
 func getStringPointer(str string) *string {
 	return &str
+}
+
+func getEndpointSliceLabelSelector(svcName string) labels.Selector {
+	labelSelector := metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			discovery.LabelServiceName: svcName,
+		},
+	}
+	selector, _ := metav1.LabelSelectorAsSelector(&labelSelector)
+	return selector
+}
+
+func getClusterIPEndpointSubset(svc *corev1.Service) corev1.EndpointSubset {
+	var epSubset corev1.EndpointSubset
+	for _, ip := range svc.Spec.ClusterIPs {
+		parsedIP := net.ParseIP(ip)
+		if parsedIP.To4() == nil {
+			continue
+		}
+		epSubset.Addresses = append(epSubset.Addresses, corev1.EndpointAddress{IP: ip})
+	}
+
+	epSubset.Ports = getServiceEndpointPorts(svc.Spec.Ports)
+	return epSubset
+}
+
+// getServiceEndpointPorts converts Service's port to EndpointPort
+func getServiceEndpointPorts(ports []corev1.ServicePort) []corev1.EndpointPort {
+	if len(ports) == 0 {
+		return nil
+	}
+	var epPorts []corev1.EndpointPort
+	for _, p := range ports {
+		epPorts = append(epPorts, corev1.EndpointPort{
+			Name:     p.Name,
+			Port:     p.Port,
+			Protocol: p.Protocol,
+		})
+	}
+	return epPorts
 }

--- a/multicluster/test/integration/serviceexport_controller_test.go
+++ b/multicluster/test/integration/serviceexport_controller_test.go
@@ -118,7 +118,6 @@ var _ = Describe("ServiceExport controller", func() {
 			return err == nil
 		}, timeout, interval).Should(BeTrue())
 		Expect(svcResExport.ObjectMeta.Labels["sourceKind"]).Should(Equal("Service"))
-		Expect(svcResExport.Spec.Service.ServiceSpec.ClusterIP).Should(Equal(latestSvc.Spec.ClusterIP))
 		Expect(len(svcResExport.Spec.Service.ServiceSpec.Ports)).Should(Equal(len(svcPorts)))
 		expectedEpResExport.Spec.Endpoints = &mcsv1alpha1.EndpointsExport{
 			Subsets: []corev1.EndpointSubset{
@@ -162,7 +161,6 @@ var _ = Describe("ServiceExport controller", func() {
 			return err == nil
 		}, timeout, interval).Should(BeTrue())
 		Expect(svcResExport.ObjectMeta.Labels["sourceKind"]).Should(Equal("Service"))
-		Expect(svcResExport.Spec.Service.ServiceSpec.ClusterIP).Should(Equal(latestSvc.Spec.ClusterIP))
 		Expect(len(svcResExport.Spec.Service.ServiceSpec.Ports)).Should(Equal(len(newPorts)))
 	})
 

--- a/multicluster/test/integration/suite_test.go
+++ b/multicluster/test/integration/suite_test.go
@@ -152,7 +152,8 @@ var _ = BeforeSuite(func() {
 		k8sManager.GetClient(),
 		k8sManager.GetScheme(),
 		clusterSetReconciler,
-		"ClusterIP")
+		"ClusterIP",
+		false)
 	err = svcExportReconciler.SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/agent/proxy/proxier_test.go
+++ b/pkg/agent/proxy/proxier_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -2805,47 +2804,6 @@ func TestGetServiceFlowKeys(t *testing.T) {
 			_, groupIDs, found := fp.GetServiceFlowKeys("svc", "ns")
 			assert.ElementsMatch(t, expectedGroupIDs, groupIDs)
 			assert.Equal(t, tc.expectedFound, found)
-		})
-	}
-}
-
-func TestEndpointSliceAPIAvailable(t *testing.T) {
-	testCases := []struct {
-		name              string
-		resources         []*metav1.APIResourceList
-		expectedAvailable bool
-	}{
-		{
-			name:              "empty",
-			expectedAvailable: false,
-		},
-		{
-			name: "GroupVersion exists",
-			resources: []*metav1.APIResourceList{
-				{
-					GroupVersion: discovery.SchemeGroupVersion.String(),
-				},
-			},
-			expectedAvailable: false,
-		},
-		{
-			name: "API exists",
-			resources: []*metav1.APIResourceList{
-				{
-					GroupVersion: discovery.SchemeGroupVersion.String(),
-					APIResources: []metav1.APIResource{{Kind: "EndpointSlice"}},
-				},
-			},
-			expectedAvailable: true,
-		},
-	}
-	for _, tt := range testCases {
-		t.Run(tt.name, func(t *testing.T) {
-			k8sClient := fake.NewSimpleClientset()
-			k8sClient.Resources = tt.resources
-			available, err := endpointSliceAPIAvailable(k8sClient)
-			require.NoError(t, err)
-			assert.Equal(t, tt.expectedAvailable, available)
 		})
 	}
 }

--- a/pkg/util/k8s/client_test.go
+++ b/pkg/util/k8s/client_test.go
@@ -1,0 +1,66 @@
+// Copyright 2023 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	discovery "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestEndpointSliceAPIAvailable(t *testing.T) {
+	testCases := []struct {
+		name              string
+		resources         []*metav1.APIResourceList
+		expectedAvailable bool
+	}{
+		{
+			name:              "empty",
+			expectedAvailable: false,
+		},
+		{
+			name: "GroupVersion exists",
+			resources: []*metav1.APIResourceList{
+				{
+					GroupVersion: discovery.SchemeGroupVersion.String(),
+				},
+			},
+			expectedAvailable: false,
+		},
+		{
+			name: "API exists",
+			resources: []*metav1.APIResourceList{
+				{
+					GroupVersion: discovery.SchemeGroupVersion.String(),
+					APIResources: []metav1.APIResource{{Kind: "EndpointSlice"}},
+				},
+			},
+			expectedAvailable: true,
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			k8sClient := fake.NewSimpleClientset()
+			k8sClient.Resources = tt.resources
+			available, err := EndpointSliceAPIAvailable(k8sClient)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedAvailable, available)
+		})
+	}
+}


### PR DESCRIPTION
1. Process EndpointSlice API by default for exported Service's endpoint change.
2. Validate `endpointIPType` to allow 'PodIP' or 'ClusterIP' only.
3. Fix a typo

For #4730