### PR TITLE
Manual cherry pick of #4845: Fix Service update processing

### DIFF
--- a/pkg/agent/proxy/proxier.go
+++ b/pkg/agent/proxy/proxier.go
@@ -272,9 +272,7 @@ func (p *proxier) removeStaleEndpoints() {
 func serviceIdentityChanged(svcInfo, pSvcInfo *types.ServiceInfo) bool {
 	return svcInfo.ClusterIP().String() != pSvcInfo.ClusterIP().String() ||
 		svcInfo.Port() != pSvcInfo.Port() ||
-		svcInfo.OFProtocol != pSvcInfo.OFProtocol ||
-		svcInfo.NodePort() != pSvcInfo.NodePort() ||
-		svcInfo.NodeLocalExternal() != pSvcInfo.NodeLocalExternal()
+		svcInfo.OFProtocol != pSvcInfo.OFProtocol
 }
 
 // smallSliceDifference builds a slice which includes all the strings from s1
@@ -419,8 +417,13 @@ func (p *proxier) installServices() {
 		var needRemoval, needUpdateService, needUpdateEndpoints bool
 		if ok { // Need to update.
 			pSvcInfo = installedSvcPort.(*types.ServiceInfo)
-			needRemoval = serviceIdentityChanged(svcInfo, pSvcInfo) || (svcInfo.SessionAffinityType() != pSvcInfo.SessionAffinityType())
-			needUpdateService = needRemoval || (svcInfo.StickyMaxAgeSeconds() != pSvcInfo.StickyMaxAgeSeconds())
+			needRemoval = serviceIdentityChanged(svcInfo, pSvcInfo) ||
+				svcInfo.NodePort() != pSvcInfo.NodePort() ||
+				svcInfo.NodeLocalExternal() != pSvcInfo.NodeLocalExternal() ||
+				svcInfo.NodeLocalInternal() != pSvcInfo.NodeLocalInternal() ||
+				svcInfo.SessionAffinityType() != pSvcInfo.SessionAffinityType() ||
+				svcInfo.StickyMaxAgeSeconds() != pSvcInfo.StickyMaxAgeSeconds()
+			needUpdateService = needRemoval
 			needUpdateEndpoints = pSvcInfo.SessionAffinityType() != svcInfo.SessionAffinityType() ||
 				pSvcInfo.NodeLocalExternal() != svcInfo.NodeLocalExternal() ||
 				pSvcInfo.NodeLocalInternal() != svcInfo.NodeLocalInternal()


### PR DESCRIPTION
This is a separate patch which backports only necessary changes in PR #4845 to release-1.10 to fix Service update processing as the original patch has too many dependencies on code not in this release. It fixes the following cases:

1. After updating stickyMaxAgeSeconds, the flow for ClusterIP isn't updated because the installServiceFlows interface skip updating flows whose cache keys already exist.
2. After updating stickyMaxAgeSeconds, the flows for NodePort and LoadBalancerIPs aren't updated because the installServiceFlows interface is not even called.
3. After updating InternalTrafficPolicy, the flows for ClusterIP isn't updated.