### PR TITLE
Add E2E test for Multi-cluster WireGuard encryption 

### DIFF
--- a/multicluster/test/e2e/fixtures.go
+++ b/multicluster/test/e2e/fixtures.go
@@ -63,6 +63,9 @@ func teardownTest(tb testing.TB, data *MCTestData) {
 	if empty, _ := IsDirEmpty(data.logsDirForTestCase); empty {
 		_ = os.Remove(data.logsDirForTestCase)
 	}
+	if err := data.deleteTestNamespaces(); err != nil {
+		tb.Fatalf("Failed to delete test Namespace %s", multiClusterTestNamespace)
+	}
 }
 
 func createPodWrapper(tb testing.TB, data *MCTestData, cluster string, namespace string, name string, nodeName string, image string, ctr string, command []string,

--- a/multicluster/test/e2e/framework.go
+++ b/multicluster/test/e2e/framework.go
@@ -132,6 +132,16 @@ func (data *MCTestData) createTestNamespaces() error {
 	return nil
 }
 
+func (data *MCTestData) deleteTestNamespaces() error {
+	for cluster, d := range data.clusterTestDataMap {
+		if err := d.DeleteNamespace(multiClusterTestNamespace, defaultTimeout); err != nil {
+			log.Errorf("Failed to delete Namespace %s in cluster %s", multiClusterTestNamespace, cluster)
+			return err
+		}
+	}
+	return nil
+}
+
 func (data *MCTestData) patchPod(clusterName, namespace, name string, patch []byte) error {
 	if d, ok := data.clusterTestDataMap[clusterName]; ok {
 		if err := d.PatchPod(namespace, name, patch); err != nil {

--- a/test/e2e/k8s_util.go
+++ b/test/e2e/k8s_util.go
@@ -596,6 +596,15 @@ func (data *TestData) GetService(namespace, name string) (*v1.Service, error) {
 	return data.clientset.CoreV1().Services(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 }
 
+func (data *TestData) GetConfigMap(namespace, name string) (*v1.ConfigMap, error) {
+	return data.clientset.CoreV1().ConfigMaps(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+}
+
+func (data *TestData) UpdateConfigMap(configMap *v1.ConfigMap) error {
+	_, err := data.clientset.CoreV1().ConfigMaps(configMap.Namespace).Update(context.TODO(), configMap, metav1.UpdateOptions{})
+	return err
+}
+
 // DeleteService is a convenience function for deleting a Service by Namespace and name.
 func (data *TestData) DeleteService(ns, name string) error {
 	log.Infof("Deleting Service %s in ns %s", name, ns)

--- a/test/e2e/nodeportlocal_test.go
+++ b/test/e2e/nodeportlocal_test.go
@@ -629,7 +629,7 @@ func testNPLMultiplePodsAgentRestart(t *testing.T, data *TestData) {
 		deleteNPLRuleFromNetNat(t, data, r, antreaPod, ruleToDelete)
 	}
 
-	err = data.restartAntreaAgentPods(defaultTimeout)
+	err = data.RestartAntreaAgentPods(defaultTimeout)
 	r.NoError(err, "Error when restarting Antrea Agent Pods")
 
 	antreaPod, err = data.getAntreaPodOnNode(serverNode)

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -94,7 +94,7 @@ func TestUpgrade(t *testing.T) {
 	}
 	if *controllerOnly == false {
 		t.Logf("Restarting all Antrea DaemonSet Pods")
-		if err := data.restartAntreaAgentPods(defaultTimeout); err != nil {
+		if err := data.RestartAntreaAgentPods(defaultTimeout); err != nil {
 			t.Fatalf("Error when restarting Antrea: %v", err)
 		}
 	}


### PR DESCRIPTION
Add E2E test for Multi-cluster WireGuard encryption scenario. After the original E2E test is finished, the TrafficEncryptionMode will be set to 'wireGuard' and run the test again.