### PR TITLE
[Follow Up] Remove redundant mock call in UT

### DIFF
--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -57,7 +57,6 @@ func convertExternalIDMap(in map[string]interface{}) map[string]string {
 
 func TestInitstore(t *testing.T) {
 	controller := mock.NewController(t)
-	defer controller.Finish()
 	mockOVSBridgeClient := ovsconfigtest.NewMockOVSBridgeClient(controller)
 
 	mockOVSBridgeClient.EXPECT().GetPortList().Return(nil, ovsconfig.NewTransactionError(fmt.Errorf("Failed to list OVS ports"), true))
@@ -134,7 +133,6 @@ func TestPersistRoundNum(t *testing.T) {
 	const roundNum uint64 = 5555
 
 	controller := mock.NewController(t)
-	defer controller.Finish()
 	mockOVSBridgeClient := ovsconfigtest.NewMockOVSBridgeClient(controller)
 
 	transactionError := ovsconfig.NewTransactionError(fmt.Errorf("Failed to get external IDs"), true)
@@ -153,7 +151,6 @@ func TestPersistRoundNum(t *testing.T) {
 
 func TestGetRoundInfo(t *testing.T) {
 	controller := mock.NewController(t)
-	defer controller.Finish()
 	mockOVSBridgeClient := ovsconfigtest.NewMockOVSBridgeClient(controller)
 
 	mockOVSBridgeClient.EXPECT().GetExternalIDs().Return(nil, ovsconfig.NewTransactionError(fmt.Errorf("Failed to get external IDs"), true))
@@ -557,7 +554,6 @@ func TestSetupDefaultTunnelInterface(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := mock.NewController(t)
-			defer controller.Finish()
 			mockOVSBridgeClient := ovsconfigtest.NewMockOVSBridgeClient(controller)
 			client := fake.NewSimpleClientset()
 			ifaceStore := interfacestore.NewInterfaceStore()
@@ -586,7 +582,6 @@ func TestSetupGatewayInterface(t *testing.T) {
 	defer mockSetInterfaceMTU(nil)()
 
 	controller := mock.NewController(t)
-	defer controller.Finish()
 
 	podCIDRStr := "172.16.10.0/24"
 	_, podCIDR, _ := net.ParseCIDR(podCIDRStr)
@@ -696,7 +691,6 @@ func TestRestorePortConfigs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := mock.NewController(t)
-			defer controller.Finish()
 			mockOVSCtlClient := ovsctltest.NewMockOVSCtlClient(controller)
 			ifaceStore := interfacestore.NewInterfaceStore()
 			initializer := &Initializer{

--- a/pkg/agent/apiserver/apiserver_test.go
+++ b/pkg/agent/apiserver/apiserver_test.go
@@ -78,7 +78,6 @@ current-context: cluster
 	}()
 	version.Version = "v1.2.3"
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	agentQuerier := aqtest.NewMockAgentQuerier(ctrl)
 	agentQuerier.EXPECT().GetNodeConfig().Return(&config.NodeConfig{OVSBridge: "br-int"})
 	npQuerier := queriertest.NewMockAgentNetworkPolicyInfoQuerier(ctrl)

--- a/pkg/agent/apiserver/handlers/multicast/handler_test.go
+++ b/pkg/agent/apiserver/handlers/multicast/handler_test.go
@@ -35,7 +35,6 @@ func TestPodMulticastStatsQuery(t *testing.T) {
 	features.DefaultMutableFeatureGate.Set("Multicast=true")
 	defer features.DefaultMutableFeatureGate.Set("Multicast=false")
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	testcases := map[string]struct {
 		name                   string

--- a/pkg/agent/apiserver/handlers/ovsflows/handler_test.go
+++ b/pkg/agent/apiserver/handlers/ovsflows/handler_test.go
@@ -84,8 +84,6 @@ func TestBadRequests(t *testing.T) {
 
 func TestPodFlows(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	testInterface := &interfacestore.InterfaceConfig{InterfaceName: "interface0"}
 	testcases := []testCase{
 		{
@@ -129,8 +127,6 @@ func TestPodFlows(t *testing.T) {
 
 func TestServiceFlows(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	testcases := []testCase{
 		{
 			test:           "Existing Service",
@@ -174,8 +170,6 @@ func TestServiceFlows(t *testing.T) {
 
 func TestNetworkPolicyFlows(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	testNetworkPolicy := &cpv1beta.NetworkPolicy{}
 	testcases := []testCase{
 		{
@@ -220,8 +214,6 @@ func TestNetworkPolicyFlows(t *testing.T) {
 
 func TestTableFlows(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	getFlowTableName = mockGetFlowTableName
 	getFlowTableID = mockGetFlowTableID
 	testcases := []testCase{
@@ -264,8 +256,6 @@ func mockGetFlowTableID(tableName string) uint8 {
 
 func TestGroups(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	testcases := []struct {
 		testCase
 		groupIDs     []uint32

--- a/pkg/agent/apiserver/handlers/ovstracing/handler_test.go
+++ b/pkg/agent/apiserver/handlers/ovstracing/handler_test.go
@@ -82,8 +82,6 @@ type testCase struct {
 
 func TestPodFlows(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	testcases := []testCase{
 		{
 			test:           "Invalid port format",

--- a/pkg/agent/apiserver/handlers/podinterface/handler_test.go
+++ b/pkg/agent/apiserver/handlers/podinterface/handler_test.go
@@ -140,8 +140,6 @@ func parseMAC(mac string) net.HardwareAddr {
 
 func TestPodInterfaceQuery(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	testcases := map[string]struct {
 		query           string
 		expectedStatus  int
@@ -195,8 +193,6 @@ func TestPodInterfaceQuery(t *testing.T) {
 
 func TestPodInterfaceListQuery(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	testcases := map[string]struct {
 		query           string
 		expectedStatus  int

--- a/pkg/agent/cniserver/interface_configuration_linux_test.go
+++ b/pkg/agent/cniserver/interface_configuration_linux_test.go
@@ -143,8 +143,6 @@ func getFakeNS(nspath string) (ns.NetNS, error) {
 
 func TestConfigureContainerLink(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
-
 	fakeSriovNet := cniservertest.NewMockSriovNet(controller)
 	fakeNetlink := netlinktest.NewMockInterface(controller)
 
@@ -266,8 +264,6 @@ func TestConfigureContainerLink(t *testing.T) {
 
 func TestChangeContainerMTU(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
-
 	fakeNetlink := netlinktest.NewMockInterface(controller)
 	hostIfaceName := "pair0"
 	containerIfaceName := "eth0"
@@ -369,9 +365,6 @@ func TestChangeContainerMTU(t *testing.T) {
 }
 
 func TestAdvertiseContainerAddr(t *testing.T) {
-	controller := gomock.NewController(t)
-	defer controller.Finish()
-
 	interfaceID := 1
 	ipv4CIDR := net.IPNet{
 		IP:   net.ParseIP("192.168.100.100"),
@@ -485,8 +478,6 @@ func TestAdvertiseContainerAddr(t *testing.T) {
 
 func TestCheckContainerInterface(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
-
 	containerIPs := ipamResult.IPs
 	containerRoutes := ipamResult.Routes
 	sriovVfNetdeviceName := "vfDevice"
@@ -618,8 +609,6 @@ func TestCheckContainerInterface(t *testing.T) {
 
 func TestValidateVFRepInterface(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
-
 	fakeSriovNet := cniservertest.NewMockSriovNet(controller)
 	testIfConfigurator := newTestIfConfigurator(false, nil, fakeSriovNet)
 
@@ -728,8 +717,6 @@ func TestGetInterceptedInterfaces(t *testing.T) {
 
 func TestValidateContainerPeerInterface(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
-
 	fakeNetlink := netlinktest.NewMockInterface(controller)
 	testIfConfigurator := newTestIfConfigurator(false, fakeNetlink, nil)
 

--- a/pkg/agent/cniserver/pod_configuration_linux_test.go
+++ b/pkg/agent/cniserver/pod_configuration_linux_test.go
@@ -133,8 +133,6 @@ func newTestInterfaceConfigurator() *fakeInterfaceConfigurator {
 
 func TestConnectInterceptedInterface(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
-
 	testPodName := "test-pod"
 	podNamespace := testPodNamespace
 	hostInterfaceName := util.GenerateContainerInterfaceName(testPodName, testPodNamespace, testPodInfraContainerID)
@@ -241,8 +239,6 @@ func TestConnectInterceptedInterface(t *testing.T) {
 
 func TestCreateOVSPort(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
-
 	containerID := generateUUID(t)
 	podName := "p0"
 	podNameSpace := testPodNamespace
@@ -401,8 +397,6 @@ func TestParseOVSPortInterfaceConfig(t *testing.T) {
 
 func TestCheckHostInterface(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
-
 	hostIfaceName := "port1"
 	containerID := generateUUID(t)
 	containerIntf := &current.Interface{Name: ifname, Sandbox: netns, Mac: "01:02:03:04:05:06"}
@@ -460,8 +454,6 @@ func TestCheckHostInterface(t *testing.T) {
 
 func TestConfigureSriovSecondaryInterface(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
-
 	containerID := generateUUID(t)
 	containerNS := "containerNS"
 

--- a/pkg/agent/cniserver/server_linux_test.go
+++ b/pkg/agent/cniserver/server_linux_test.go
@@ -117,7 +117,6 @@ func TestValidatePrevResult(t *testing.T) {
 
 func TestRemoveInterface(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 	mockOVSBridgeClient = ovsconfigtest.NewMockOVSBridgeClient(controller)
 	mockOFClient = openflowtest.NewMockClient(controller)
 	ifaceStore = interfacestore.NewInterfaceStore()
@@ -230,7 +229,6 @@ func createCNIRequestAndInterfaceName(t *testing.T, name string, cniType string,
 
 func TestCmdAdd(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 	ipamMock := ipamtest.NewMockIPAMDriver(controller)
 	ctx := context.TODO()
 
@@ -395,8 +393,6 @@ func TestCmdAdd(t *testing.T) {
 
 func TestCmdDel(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
-
 	ipamMock := ipamtest.NewMockIPAMDriver(controller)
 	ovsPortID := generateUUID(t)
 	ovsPort := int32(100)
@@ -546,8 +542,6 @@ func TestCmdDel(t *testing.T) {
 
 func TestCmdCheck(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
-
 	ipamMock := ipamtest.NewMockIPAMDriver(controller)
 	ovsPortID := generateUUID(t)
 	ovsPort := int32(100)
@@ -637,7 +631,6 @@ func TestCmdCheck(t *testing.T) {
 
 func TestReconcile(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 	mockOVSBridgeClient = ovsconfigtest.NewMockOVSBridgeClient(controller)
 	mockOFClient = openflowtest.NewMockClient(controller)
 	ifaceStore = interfacestore.NewInterfaceStore()

--- a/pkg/agent/cniserver/server_test.go
+++ b/pkg/agent/cniserver/server_test.go
@@ -140,7 +140,6 @@ func checkErrorResponse(t *testing.T, resp *cnipb.CniCmdResponse, code cnipb.Err
 
 func TestIPAMService(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 	ipamMock := ipamtest.NewMockIPAMDriver(controller)
 	ipam.RegisterIPAMDriver(testIpamType, ipamMock)
 	cniServer := newCNIServer(t)
@@ -227,7 +226,6 @@ func TestIPAMService(t *testing.T) {
 
 func TestIPAMServiceMultiDriver(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 
 	mockDriverA := ipamtest.NewMockIPAMDriver(controller)
 	mockDriverB := ipamtest.NewMockIPAMDriver(controller)
@@ -526,8 +524,6 @@ func TestUpdateResultIfaceConfig(t *testing.T) {
 }
 
 func TestValidateOVSInterface(t *testing.T) {
-	controller := gomock.NewController(t)
-	defer controller.Finish()
 	ifaceStore := interfacestore.NewInterfaceStore()
 	podConfigurator := &podConfigurator{ifaceStore: ifaceStore}
 	containerID := uuid.New().String()

--- a/pkg/agent/cniserver/server_windows_test.go
+++ b/pkg/agent/cniserver/server_windows_test.go
@@ -318,7 +318,6 @@ func prepareSetup(t *testing.T, ipamType string, name string, containerID, infra
 
 func TestCmdAdd(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 	ipamType := "windows-test"
 	ipamMock := ipamtest.NewMockIPAMDriver(controller)
 	ipam.ResetIPAMDriver(ipamType, ipamMock)
@@ -559,7 +558,6 @@ func TestCmdAdd(t *testing.T) {
 
 func TestCmdDel(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 	ipamType := "windows-test"
 	ipamMock := ipamtest.NewMockIPAMDriver(controller)
 	ipam.ResetIPAMDriver(ipamType, ipamMock)
@@ -670,8 +668,6 @@ func TestCmdDel(t *testing.T) {
 
 func TestCmdCheck(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
-
 	ipamType := "windows-test"
 	ipamMock := ipamtest.NewMockIPAMDriver(controller)
 	ipam.ResetIPAMDriver(ipamType, ipamMock)
@@ -856,7 +852,6 @@ func newAsyncWaiter(podName, containerID string) *asyncWaiter {
 
 func TestReconcile(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 	mockOVSBridgeClient = ovsconfigtest.NewMockOVSBridgeClient(controller)
 	mockOFClient = openflowtest.NewMockClient(controller)
 	ifaceStore = interfacestore.NewInterfaceStore()

--- a/pkg/agent/controller/egress/egress_controller_test.go
+++ b/pkg/agent/controller/egress/egress_controller_test.go
@@ -644,8 +644,6 @@ func TestSyncEgress(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := newFakeController(t, []runtime.Object{tt.existingEgress})
-			defer c.mockController.Finish()
-
 			if tt.maxEgressIPsPerNode > 0 {
 				c.egressIPScheduler.maxEgressIPsPerNode = tt.maxEgressIPsPerNode
 			}
@@ -705,7 +703,6 @@ func TestPodUpdateShouldSyncEgress(t *testing.T) {
 		},
 	}
 	c := newFakeController(t, []runtime.Object{egress})
-	defer c.mockController.Finish()
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 	go c.podUpdateChannel.Run(stopCh)
@@ -780,7 +777,6 @@ func TestSyncOverlappingEgress(t *testing.T) {
 		},
 	}
 	c := newFakeController(t, []runtime.Object{egress1, egress2, egress3})
-	defer c.mockController.Finish()
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 	c.crdInformerFactory.Start(stopCh)
@@ -984,8 +980,6 @@ func TestGetEgress(t *testing.T) {
 	}
 
 	c := newFakeController(t, []runtime.Object{egress})
-	defer c.mockController.Finish()
-
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 	c.crdInformerFactory.Start(stopCh)
@@ -1047,8 +1041,6 @@ func TestGetEgressIPByMark(t *testing.T) {
 	}
 
 	c := newFakeController(t, []runtime.Object{egress})
-	defer c.mockController.Finish()
-
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 	c.crdInformerFactory.Start(stopCh)

--- a/pkg/agent/controller/ipseccertificate/ipsec_certificate_controller_test.go
+++ b/pkg/agent/controller/ipseccertificate/ipsec_certificate_controller_test.go
@@ -146,8 +146,6 @@ func newFakeController(t *testing.T) *fakeController {
 func TestController_syncConfigurations(t *testing.T) {
 	t.Run("rotate certificate if current certificates are empty", func(t *testing.T) {
 		fakeController := newFakeController(t)
-		defer fakeController.mockController.Finish()
-
 		ch := make(chan struct{})
 		fakeController.rotateCertificate = func() (*certificateKeyPair, error) {
 			close(ch)

--- a/pkg/agent/controller/networkpolicy/audit_logging_test.go
+++ b/pkg/agent/controller/networkpolicy/audit_logging_test.go
@@ -368,7 +368,6 @@ func TestGetNetworkPolicyInfo(t *testing.T) {
 			pktIn := &ofctrl.PacketIn{TableId: tc.tableID, Match: openflow15.Match{Fields: matchers}}
 
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			testClientInterface := openflowtest.NewMockClient(ctrl)
 			if tc.expectedCalls != nil {
 				tc.expectedCalls(testClientInterface.EXPECT())

--- a/pkg/agent/controller/networkpolicy/fqdn_test.go
+++ b/pkg/agent/controller/networkpolicy/fqdn_test.go
@@ -119,7 +119,6 @@ func TestAddFQDNRule(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 			f, c := newMockFQDNController(t, controller, nil)
 			if tt.addressAdded {
 				c.EXPECT().AddAddressToDNSConjunction(dnsInterceptRuleID, gomock.Any()).Times(1)
@@ -277,7 +276,6 @@ func TestDeleteFQDNRule(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 			f, c := newMockFQDNController(t, controller, nil)
 			c.EXPECT().AddAddressToDNSConjunction(dnsInterceptRuleID, gomock.Any()).Times(len(tt.previouslyAddedRules))
 			f.dnsEntryCache = tt.existingDNSCache
@@ -296,7 +294,6 @@ func TestDeleteFQDNRule(t *testing.T) {
 
 func TestLookupIPFallback(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 	dnsServer := "" // force a fallback to local resolver
 	f, _ := newMockFQDNController(t, controller, &dnsServer)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/pkg/agent/controller/networkpolicy/reconciler_test.go
+++ b/pkg/agent/controller/networkpolicy/reconciler_test.go
@@ -179,7 +179,6 @@ func TestReconcilerForget(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 			ifaceStore := interfacestore.NewInterfaceStore()
 			mockOFClient := openflowtest.NewMockClient(controller)
 			if len(tt.expectedOFRuleIDs) == 0 {
@@ -579,7 +578,6 @@ func TestReconcilerReconcile(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 			mockOFClient := openflowtest.NewMockClient(controller)
 			// TODO: mock idAllocator and priorityAssigner
 			for i := 0; i < len(tt.expectedOFRules); i++ {
@@ -817,7 +815,6 @@ func TestReconcilerReconcileServiceRelatedRule(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 			mockOFClient := openflowtest.NewMockClient(controller)
 			// TODO: mock idAllocator and priorityAssigner
 			for i := 0; i < len(tt.expectedOFRules); i++ {
@@ -885,7 +882,6 @@ func TestReconcileWithTransientError(t *testing.T) {
 	}
 
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 	mockOFClient := openflowtest.NewMockClient(controller)
 	r := newTestReconciler(t, controller, ifaceStore, mockOFClient, true, true)
 	// Set deleteInterval to verify openflow ID is released immediately.
@@ -1044,7 +1040,6 @@ func TestReconcilerBatchReconcile(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 			mockOFClient := openflowtest.NewMockClient(controller)
 			r := newTestReconciler(t, controller, ifaceStore, mockOFClient, true, true)
 			if tt.numInstalledRules > 0 {
@@ -1296,7 +1291,6 @@ func TestReconcilerUpdate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 			mockOFClient := openflowtest.NewMockClient(controller)
 			mockOFClient.EXPECT().InstallPolicyRuleFlows(gomock.Any()).MaxTimes(2)
 			priority := gomock.Any()
@@ -1816,7 +1810,6 @@ func TestReconcilerReconcileIPv6Only(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 			mockOFClient := openflowtest.NewMockClient(controller)
 			// TODO: mock idAllocator and priorityAssigner
 			for i := 0; i < len(tt.expectedOFRules); i++ {
@@ -2217,7 +2210,6 @@ func TestReconcilerReconcileDualStack(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 			mockOFClient := openflowtest.NewMockClient(controller)
 			// TODO: mock idAllocator and priorityAssigner
 			for i := 0; i < len(tt.expectedOFRules); i++ {

--- a/pkg/agent/controller/networkpolicy/reject_test.go
+++ b/pkg/agent/controller/networkpolicy/reject_test.go
@@ -389,7 +389,6 @@ func Test_getRejectPacketOutMutateFunc(t *testing.T) {
 	conntrackTableID := openflow.ConntrackTable.GetID()
 	l3ForwardingTableID := openflow.L3ForwardingTable.GetID()
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	type args struct {
 		rejectType        RejectType
 		nodeType          config.NodeType

--- a/pkg/agent/controller/serviceexternalip/controller_test.go
+++ b/pkg/agent/controller/serviceexternalip/controller_test.go
@@ -386,7 +386,6 @@ func TestCreateService(t *testing.T) {
 			}
 			objs = append(objs, tt.serviceToCreate)
 			c := newFakeController(t, objs...)
-			defer c.mockController.Finish()
 			stopCh := make(chan struct{})
 			defer close(stopCh)
 			c.informerFactory.Start(stopCh)
@@ -595,7 +594,6 @@ func TestUpdateService(t *testing.T) {
 			objs = append(objs, tt.serviceToUpdate)
 			c := newFakeController(t, objs...)
 			c.externalIPStates = tt.previousExternalIPStates
-			defer c.mockController.Finish()
 			stopCh := make(chan struct{})
 			defer close(stopCh)
 			c.informerFactory.Start(stopCh)

--- a/pkg/agent/controller/trafficcontrol/controller_test.go
+++ b/pkg/agent/controller/trafficcontrol/controller_test.go
@@ -475,7 +475,6 @@ func TestTrafficControlAdd(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 
 			c := newFakeController(t, []runtime.Object{ns1, ns2, pod1, pod2, pod3, pod4}, []runtime.Object{tt.tc}, append(interfaces, tt.extraInterfaces...))
-			defer c.mockController.Finish()
 
 			if tt.portToTCBindings != nil {
 				c.portToTCBindings = tt.portToTCBindings
@@ -572,7 +571,6 @@ func TestTrafficControlUpdate(t *testing.T) {
 	for _, tt := range testcases {
 		t.Run(tt.name, func(t *testing.T) {
 			c := newFakeController(t, []runtime.Object{ns1, ns2, pod1, pod2, pod3, pod4}, []runtime.Object{tc1}, interfaces)
-			defer c.mockController.Finish()
 
 			stopCh := make(chan struct{})
 			defer close(stopCh)
@@ -628,7 +626,6 @@ func TestSharedTargetPort(t *testing.T) {
 	}
 
 	c := newFakeController(t, []runtime.Object{pod1, pod2, pod3, pod4}, []runtime.Object{tc1, tc2}, interfaces)
-	defer c.mockController.Finish()
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
@@ -681,7 +678,6 @@ func TestPodUpdateFromCNIServer(t *testing.T) {
 	tc1 := generateTrafficControl(tc1Name, nil, labels1, directionIngress, actionMirror, targetPort1, false, nil)
 
 	c := newFakeController(t, nil, []runtime.Object{tc1}, []*interfacestore.InterfaceConfig{targetInterface1})
-	defer c.mockController.Finish()
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
@@ -822,7 +818,6 @@ func TestPodLabelsUpdate(t *testing.T) {
 	for _, tt := range testcases {
 		t.Run(tt.name, func(t *testing.T) {
 			c := newFakeController(t, []runtime.Object{testPod}, []runtime.Object{tc1, tc2, tc3}, interfaces)
-			defer c.mockController.Finish()
 
 			stopCh := make(chan struct{})
 			defer close(stopCh)
@@ -999,7 +994,6 @@ func TestNamespaceLabelsUpdate(t *testing.T) {
 	for _, tt := range testcases {
 		t.Run(tt.name, func(t *testing.T) {
 			c := newFakeController(t, []runtime.Object{testNS, testPod}, []runtime.Object{tc1, tc2, tc3}, interfaces)
-			defer c.mockController.Finish()
 
 			stopCh := make(chan struct{})
 			defer close(stopCh)
@@ -1111,7 +1105,6 @@ func TestPodDelete(t *testing.T) {
 	}
 
 	c := newFakeController(t, []runtime.Object{pod1, pod3}, []runtime.Object{tc1, tc2, tc3}, interfaces)
-	defer c.mockController.Finish()
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)

--- a/pkg/agent/externalnode/external_node_controller_linux_test.go
+++ b/pkg/agent/externalnode/external_node_controller_linux_test.go
@@ -202,7 +202,6 @@ func TestUpdateExternalNode(t *testing.T) {
 			defer mockLinkByName(t, tt.linkByNameCalledTimes)()
 
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 			mockOVSBridgeClient := ovsconfigtest.NewMockOVSBridgeClient(controller)
 			mockOFClient := openflowtest.NewMockClient(controller)
 			mockOVSCtlClient := ovsctltest.NewMockOVSCtlClient(controller)
@@ -358,7 +357,6 @@ func TestAddInterface(t *testing.T) {
 			defer mockLinkByName(t, tt.linkByNameCalledTimes)()
 
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 			mockOVSBridgeClient := ovsconfigtest.NewMockOVSBridgeClient(controller)
 			mockOFClient := openflowtest.NewMockClient(controller)
 			mockOVSCtlClient := ovsctltest.NewMockOVSCtlClient(controller)
@@ -373,7 +371,6 @@ func TestAddInterface(t *testing.T) {
 
 func TestCreateOVSPortsAndFlowsSuccess(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 	mockOVSBridgeClient := ovsconfigtest.NewMockOVSBridgeClient(controller)
 	mockOFClient := openflowtest.NewMockClient(controller)
 	mockOVSCtlClient := ovsctltest.NewMockOVSCtlClient(controller)
@@ -444,7 +441,6 @@ func TestCreateOVSPortsAndFlowsSuccess(t *testing.T) {
 
 func TestDeleteExternalNode(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 	mockOVSBridgeClient := ovsconfigtest.NewMockOVSBridgeClient(controller)
 	mockOFClient := openflowtest.NewMockClient(controller)
 	mockOVSCtlClient := ovsctltest.NewMockOVSCtlClient(controller)
@@ -489,7 +485,6 @@ func TestDeleteExternalNode(t *testing.T) {
 
 func TestMoveIFConfigurations(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 	mockOVSBridgeClient := ovsconfigtest.NewMockOVSBridgeClient(controller)
 	mockOFClient := openflowtest.NewMockClient(controller)
 	mockOVSCtlClient := ovsctltest.NewMockOVSCtlClient(controller)

--- a/pkg/agent/externalnode/external_node_controller_test.go
+++ b/pkg/agent/externalnode/external_node_controller_test.go
@@ -95,7 +95,6 @@ var (
 
 func TestCreateOVSPortsAndFlowsFailure(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 	mockOVSBridgeClient := ovsconfigtest.NewMockOVSBridgeClient(controller)
 	mockOFClient := openflowtest.NewMockClient(controller)
 	mockOVSCtlClient := ovsctltest.NewMockOVSCtlClient(controller)
@@ -139,7 +138,6 @@ func TestCreateOVSPortsAndFlowsFailure(t *testing.T) {
 
 func TestUpdateOVSPortsData(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 	mockOVSBridgeClient := ovsconfigtest.NewMockOVSBridgeClient(controller)
 	mockOFClient := openflowtest.NewMockClient(controller)
 	mockOVSCtlClient := ovsctltest.NewMockOVSCtlClient(controller)
@@ -284,7 +282,6 @@ func TestParseHostInterfaceConfig(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			controller := gomock.NewController(t)
-			defer controller.Finish()
 			mockOVSBridgeClient := ovsconfigtest.NewMockOVSBridgeClient(controller)
 			mockOVSBridgeClient.EXPECT().GetPortData(
 				tt.portData.ExternalIDs[ovsExternalIDUplinkPort],
@@ -302,7 +299,6 @@ func TestParseHostInterfaceConfig(t *testing.T) {
 
 func TestReconcile(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 	mockOVSBridgeClient := ovsconfigtest.NewMockOVSBridgeClient(controller)
 	mockOFClient := openflowtest.NewMockClient(controller)
 	mockOVSCtlClient := ovsctltest.NewMockOVSCtlClient(controller)
@@ -337,7 +333,6 @@ func TestReconcile(t *testing.T) {
 
 func TestAddExternalNode(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 	mockOVSBridgeClient := ovsconfigtest.NewMockOVSBridgeClient(controller)
 	mockOFClient := openflowtest.NewMockClient(controller)
 	mockOVSCtlClient := ovsctltest.NewMockOVSCtlClient(controller)
@@ -387,7 +382,6 @@ func TestAddExternalNode(t *testing.T) {
 
 func TestEnqueueExternalNodeUpdate(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 	mockOVSBridgeClient := ovsconfigtest.NewMockOVSBridgeClient(controller)
 	mockOFClient := openflowtest.NewMockClient(controller)
 	mockOVSCtlClient := ovsctltest.NewMockOVSCtlClient(controller)

--- a/pkg/agent/flowexporter/connections/connections_test.go
+++ b/pkg/agent/flowexporter/connections/connections_test.go
@@ -46,7 +46,6 @@ var testFlowExporterOptions = &flowexporter.FlowExporterOptions{
 
 func TestConnectionStore_ForAllConnectionsDo(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	// Create two flows; one is already in connectionStore and other one is new
 	testFlows := make([]*flowexporter.Connection, 2)
 	testFlowKeys := make([]*flowexporter.ConnectionKey, 2)
@@ -104,7 +103,6 @@ func TestConnectionStore_ForAllConnectionsDo(t *testing.T) {
 
 func TestConnectionStore_DeleteConnWithoutLock(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	metrics.InitializeConnectionMetrics()
 	// test on deny connection store
 	mockIfaceStore := interfacestoretest.NewMockInterfaceStore(ctrl)

--- a/pkg/agent/flowexporter/connections/conntrack_connections_test.go
+++ b/pkg/agent/flowexporter/connections/conntrack_connections_test.go
@@ -90,7 +90,6 @@ var (
 
 func TestConntrackConnectionStore_AddOrUpdateConn(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	metrics.InitializeConnectionMetrics()
 	refTime := time.Now()
 
@@ -260,7 +259,6 @@ func addConnToStore(cs *ConntrackConnectionStore, conn *flowexporter.Connection)
 
 func TestConnectionStore_DeleteConnectionByKey(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	metrics.InitializeConnectionMetrics()
 	// Create two flows; one is already in connectionStore and other one is new
 	testFlows := make([]*flowexporter.Connection, 2)
@@ -315,7 +313,6 @@ func TestConnectionStore_DeleteConnectionByKey(t *testing.T) {
 
 func TestConnectionStore_MetricSettingInPoll(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	metrics.InitializeConnectionMetrics()
 
 	testFlows := make([]*flowexporter.Connection, 0)

--- a/pkg/agent/flowexporter/connections/conntrack_linux_test.go
+++ b/pkg/agent/flowexporter/connections/conntrack_linux_test.go
@@ -51,7 +51,6 @@ var (
 
 func TestConnTrackSystem_DumpFlows(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	metrics.InitializeConnectionMetrics()
 	// Create flows for test
 
@@ -110,7 +109,6 @@ func TestConnTrackSystem_DumpFlows(t *testing.T) {
 
 func TestConnTrackOvsAppCtl_DumpFlows(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	metrics.InitializeConnectionMetrics()
 
 	// Create mock interface
@@ -196,7 +194,6 @@ func TestConnTrackSystem_GetMaxConnections(t *testing.T) {
 
 func TestConnTrackOvsAppCtl_GetMaxConnections(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	mockOVSCtlClient := ovsctltest.NewMockOVSCtlClient(ctrl)
 	// Set expect call of dpctl/ct-get-maxconns for mock ovsCtlClient
 	expMaxConns := 300000

--- a/pkg/agent/flowexporter/connections/deny_connections_test.go
+++ b/pkg/agent/flowexporter/connections/deny_connections_test.go
@@ -37,7 +37,6 @@ import (
 
 func TestDenyConnectionStore_AddOrUpdateConn(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	metrics.InitializeConnectionMetrics()
 	// Create flow for testing adding and updating of same connection.
 	refTime := time.Now()

--- a/pkg/agent/flowexporter/exporter/exporter_test.go
+++ b/pkg/agent/flowexporter/exporter/exporter_test.go
@@ -67,8 +67,6 @@ func TestFlowExporter_sendTemplateSet(t *testing.T) {
 
 func testSendTemplateSet(t *testing.T, v4Enabled bool, v6Enabled bool) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	mockIPFIXExpProc := ipfixtest.NewMockIPFIXExportingProcess(ctrl)
 	mockIPFIXRegistry := ipfixtest.NewMockIPFIXRegistry(ctrl)
 	flowExp := &FlowExporter{
@@ -218,8 +216,6 @@ func TestFlowExporter_sendDataSet(t *testing.T) {
 
 func testSendDataSet(t *testing.T, v4Enabled bool, v6Enabled bool) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	mockIPFIXExpProc := ipfixtest.NewMockIPFIXExportingProcess(ctrl)
 	mockDataSet := ipfixentitiestesting.NewMockSet(ctrl)
 	mockIPFIXRegistry := ipfixtest.NewMockIPFIXRegistry(ctrl)
@@ -548,8 +544,6 @@ func testSendFlowRecords(t *testing.T, v4Enabled bool, v6Enabled bool) {
 
 func runSendFlowRecordTests(t *testing.T, flowExp *FlowExporter, isIPv6 bool) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	mockIPFIXExpProc := ipfixtest.NewMockIPFIXExportingProcess(ctrl)
 	mockDataSet := ipfixentitiestesting.NewMockSet(ctrl)
 	flowExp.process = mockIPFIXExpProc

--- a/pkg/agent/memberlist/cluster_test.go
+++ b/pkg/agent/memberlist/cluster_test.go
@@ -140,7 +140,6 @@ func TestCluster_Run(t *testing.T) {
 				// Make sure mock controller is closed after Run() finishes.
 				close(stopCh)
 				<-stoppedCh
-				controller.Finish()
 			}()
 
 			nodeConfig := &config.NodeConfig{
@@ -183,7 +182,6 @@ func TestCluster_RunClusterEvents(t *testing.T) {
 		// Make sure mock controller is closed after Run() finishes.
 		close(stopCh)
 		<-stoppedCh
-		controller.Finish()
 	}()
 
 	nodeName := "localNodeName"
@@ -660,7 +658,6 @@ func TestCluster_RejoinNodes(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 	mockMemberlist := NewMockMemberlist(controller)
 	mockMemberlist.EXPECT().Join([]string{"10.0.0.2"})
 	mockMemberlist.EXPECT().Join([]string{"10.0.0.3"})

--- a/pkg/agent/multicluster/mc_route_controller_test.go
+++ b/pkg/agent/multicluster/mc_route_controller_test.go
@@ -37,7 +37,7 @@ type fakeRouteController struct {
 	ofClient        *oftest.MockClient
 }
 
-func newMCDefaultRouteController(t *testing.T, nodeConfig *config.NodeConfig) (*fakeRouteController, func()) {
+func newMCDefaultRouteController(t *testing.T, nodeConfig *config.NodeConfig) *fakeRouteController {
 	mcClient := mcfake.NewSimpleClientset()
 	mcInformerFactory := mcinformers.NewSharedInformerFactoryWithOptions(mcClient,
 		60*time.Second,
@@ -61,7 +61,7 @@ func newMCDefaultRouteController(t *testing.T, nodeConfig *config.NodeConfig) (*
 		mcClient:                 mcClient,
 		informerFactory:          mcInformerFactory,
 		ofClient:                 ofClient,
-	}, ctrl.Finish
+	}
 }
 
 var (
@@ -122,8 +122,7 @@ var (
 )
 
 func TestMCRouteControllerAsGateway(t *testing.T) {
-	c, closeFn := newMCDefaultRouteController(t, &config.NodeConfig{Name: "node-1"})
-	defer closeFn()
+	c := newMCDefaultRouteController(t, &config.NodeConfig{Name: "node-1"})
 	defer c.queue.ShutDown()
 
 	stopCh := make(chan struct{})
@@ -208,8 +207,7 @@ func TestMCRouteControllerAsGateway(t *testing.T) {
 }
 
 func TestMCRouteControllerAsRegularNode(t *testing.T) {
-	c, closeFn := newMCDefaultRouteController(t, &config.NodeConfig{Name: "node-3"})
-	defer closeFn()
+	c := newMCDefaultRouteController(t, &config.NodeConfig{Name: "node-3"})
 	defer c.queue.ShutDown()
 
 	stopCh := make(chan struct{})

--- a/pkg/agent/multicluster/pod_route_controller_test.go
+++ b/pkg/agent/multicluster/pod_route_controller_test.go
@@ -95,7 +95,7 @@ type fakeMCPodRouteController struct {
 }
 
 func newMCPodRouteController(t *testing.T, nodeConfig *config.NodeConfig,
-	k8sClient *k8sfake.Clientset) (*fakeMCPodRouteController, func()) {
+	k8sClient *k8sfake.Clientset) *fakeMCPodRouteController {
 	mcClient := mcfake.NewSimpleClientset()
 	mcInformerFactory := mcinformers.NewSharedInformerFactoryWithOptions(mcClient,
 		0,
@@ -120,13 +120,12 @@ func newMCPodRouteController(t *testing.T, nodeConfig *config.NodeConfig,
 		mcInformerFactory:    mcInformerFactory,
 		informerFactory:      informerFactory,
 		ofClient:             ofClient,
-	}, ctrl.Finish
+	}
 }
 
 func TestGatewayEvent(t *testing.T) {
 	k8sClient := k8sfake.NewSimpleClientset([]runtime.Object{nginx1NoIPs, nginx2WithIPs}...)
-	c, closeFn := newMCPodRouteController(t, &config.NodeConfig{Name: node1Name}, k8sClient)
-	defer closeFn()
+	c := newMCPodRouteController(t, &config.NodeConfig{Name: node1Name}, k8sClient)
 	defer c.podQueue.ShutDown()
 	defer c.gwQueue.ShutDown()
 
@@ -179,8 +178,7 @@ func TestGatewayEvent(t *testing.T) {
 
 func TestPodEvent(t *testing.T) {
 	k8sClient := k8sfake.NewSimpleClientset([]runtime.Object{nginx2WithIPs}...)
-	c, closeFn := newMCPodRouteController(t, &config.NodeConfig{Name: node1Name}, k8sClient)
-	defer closeFn()
+	c := newMCPodRouteController(t, &config.NodeConfig{Name: node1Name}, k8sClient)
 	defer c.podQueue.ShutDown()
 	defer c.gwQueue.ShutDown()
 

--- a/pkg/agent/multicluster/stretched_networkpolicy_controller_test.go
+++ b/pkg/agent/multicluster/stretched_networkpolicy_controller_test.go
@@ -63,7 +63,7 @@ type fakeStretchedNetworkPolicyController struct {
 	podUpdateChannel  *channel.SubscribableChannel
 }
 
-func newStretchedNetworkPolicyController(t *testing.T, clientset *fake.Clientset, mcClient *mcfake.Clientset) (*fakeStretchedNetworkPolicyController, func()) {
+func newStretchedNetworkPolicyController(t *testing.T, clientset *fake.Clientset, mcClient *mcfake.Clientset) *fakeStretchedNetworkPolicyController {
 	informerFactory := informers.NewSharedInformerFactory(clientset, 12*time.Hour)
 	listOptions := func(options *metav1.ListOptions) {
 		options.FieldSelector = fields.OneTermEqualSelector("spec.nodeName", "test-node").String()
@@ -102,7 +102,7 @@ func newStretchedNetworkPolicyController(t *testing.T, clientset *fake.Clientset
 		ovsClient:                        ovsClient,
 		interfaceStore:                   interfaceStore,
 		podUpdateChannel:                 podUpdateChannel,
-	}, ctrl.Finish
+	}
 }
 
 var (
@@ -149,8 +149,7 @@ func TestEnqueueAllPods(t *testing.T) {
 
 	clientset := fake.NewSimpleClientset(ns, pod)
 	mcClient := mcfake.NewSimpleClientset(labelIdentity)
-	c, closeFn := newStretchedNetworkPolicyController(t, clientset, mcClient)
-	defer closeFn()
+	c := newStretchedNetworkPolicyController(t, clientset, mcClient)
 	defer c.queue.ShutDown()
 
 	stopCh := make(chan struct{})
@@ -226,8 +225,7 @@ func TestStretchedNetworkPolicyControllerPodEvent(t *testing.T) {
 
 	clientset := fake.NewSimpleClientset()
 	mcClient := mcfake.NewSimpleClientset()
-	c, closeFn := newStretchedNetworkPolicyController(t, clientset, mcClient)
-	defer closeFn()
+	c := newStretchedNetworkPolicyController(t, clientset, mcClient)
 	defer c.queue.ShutDown()
 
 	stopCh := make(chan struct{})
@@ -373,8 +371,7 @@ func TestStretchedNetworkPolicyControllerNSEvent(t *testing.T) {
 
 	clientset := fake.NewSimpleClientset()
 	mcClient := mcfake.NewSimpleClientset()
-	c, closeFn := newStretchedNetworkPolicyController(t, clientset, mcClient)
-	defer closeFn()
+	c := newStretchedNetworkPolicyController(t, clientset, mcClient)
 	defer c.queue.ShutDown()
 
 	stopCh := make(chan struct{})
@@ -486,8 +483,7 @@ func TestStretchedNetworkPolicyControllerLabelIdentityEvent(t *testing.T) {
 	}
 	clientset := fake.NewSimpleClientset()
 	mcClient := mcfake.NewSimpleClientset()
-	c, closeFn := newStretchedNetworkPolicyController(t, clientset, mcClient)
-	defer closeFn()
+	c := newStretchedNetworkPolicyController(t, clientset, mcClient)
 	defer c.queue.ShutDown()
 
 	stopCh := make(chan struct{})

--- a/pkg/agent/nodeportlocal/npl_agent_test.go
+++ b/pkg/agent/nodeportlocal/npl_agent_test.go
@@ -302,7 +302,6 @@ func setUpWithTestServiceAndPod(t *testing.T, tc *testConfig, customNodePort *in
 func (t *testData) tearDown() {
 	close(t.stopCh)
 	t.wg.Wait()
-	t.ctrl.Finish()
 	os.Unsetenv("NODE_NAME")
 }
 

--- a/pkg/agent/nodeportlocal/portcache/port_table_others_test.go
+++ b/pkg/agent/nodeportlocal/portcache/port_table_others_test.go
@@ -30,7 +30,6 @@ import (
 
 func TestRestoreRules(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
 	mockIPTables := rulestesting.NewMockPodPortRules(mockCtrl)
 	mockPortOpener := portcachetesting.NewMockLocalPortOpener(mockCtrl)
 	portTable := newPortTable(mockIPTables, mockPortOpener)

--- a/pkg/agent/nodeportlocal/portcache/port_table_windows_test.go
+++ b/pkg/agent/nodeportlocal/portcache/port_table_windows_test.go
@@ -31,7 +31,6 @@ import (
 
 func TestRestoreRules(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
 	mockPortRules := rulestesting.NewMockPodPortRules(mockCtrl)
 	mockPortOpener := portcachetesting.NewMockLocalPortOpener(mockCtrl)
 	portTable := newPortTable(mockPortRules, mockPortOpener)
@@ -67,7 +66,6 @@ func TestRestoreRules(t *testing.T) {
 
 func TestDeleteRule(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
 	mockPortRules := rulestesting.NewMockPodPortRules(mockCtrl)
 	mockPortOpener := portcachetesting.NewMockLocalPortOpener(mockCtrl)
 	portTable := newPortTable(mockPortRules, mockPortOpener)
@@ -88,7 +86,6 @@ func TestDeleteRule(t *testing.T) {
 
 func TestDeleteRulesForPod(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
 	mockPortRules := rulestesting.NewMockPodPortRules(mockCtrl)
 	mockPortOpener := portcachetesting.NewMockLocalPortOpener(mockCtrl)
 	portTable := newPortTable(mockPortRules, mockPortOpener)
@@ -123,7 +120,6 @@ func TestDeleteRulesForPod(t *testing.T) {
 
 func TestAddRule(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
 	mockPortRules := rulestesting.NewMockPodPortRules(mockCtrl)
 	mockPortOpener := portcachetesting.NewMockLocalPortOpener(mockCtrl)
 	portTable := newPortTable(mockPortRules, mockPortOpener)

--- a/pkg/agent/openflow/client_test.go
+++ b/pkg/agent/openflow/client_test.go
@@ -195,7 +195,6 @@ func TestIdempotentFlowInstallation(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
 			fc := newFakeClient(m, true, false, config.K8sNode, config.TrafficEncapModeEncap)
 			defer resetPipelines()
@@ -220,7 +219,6 @@ func TestIdempotentFlowInstallation(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
 			fc := newFakeClient(m, true, false, config.K8sNode, config.TrafficEncapModeEncap)
 			defer resetPipelines()
@@ -257,7 +255,6 @@ func TestFlowInstallationFailed(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
 			fc := newFakeClient(m, true, false, config.K8sNode, config.TrafficEncapModeEncap)
 			defer resetPipelines()
@@ -288,7 +285,6 @@ func TestConcurrentFlowInstallation(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
 			fc := newFakeClient(m, true, false, config.K8sNode, config.TrafficEncapModeEncap)
 			defer resetPipelines()
@@ -602,7 +598,6 @@ func Test_client_InstallNodeFlows(t *testing.T) {
 			skipTest(t, tc.skipLinux, tc.skipWindows)
 
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
 
 			fc := newFakeClient(m, tc.enableIPv4, tc.enableIPv6, config.K8sNode, tc.trafficEncapMode, tc.clientOptions...)
@@ -778,7 +773,6 @@ func Test_client_InstallPodFlows(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
 
 			fc := newFakeClient(m, tc.enableIPv4, tc.enableIPv6, config.K8sNode, tc.trafficEncapMode, tc.clientOptions...)
@@ -818,7 +812,6 @@ func Test_client_InstallPodFlows(t *testing.T) {
 
 func Test_client_GetPodFlowKeys(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	m := oftest.NewMockOFEntryOperations(ctrl)
 
 	fc := newFakeClient(m, true, true, config.K8sNode, config.TrafficEncapModeEncap)
@@ -916,7 +909,6 @@ func Test_client_InstallServiceGroup(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
 
 			fc := newFakeClient(m, true, true, config.K8sNode, config.TrafficEncapModeEncap)
@@ -1036,7 +1028,6 @@ func Test_client_InstallEndpointFlows(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
 
 			fc := newFakeClient(m, true, true, config.K8sNode, config.TrafficEncapModeEncap)
@@ -1175,7 +1166,6 @@ func Test_client_InstallServiceFlows(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
 
 			fc := newFakeClient(m, true, true, config.K8sNode, config.TrafficEncapModeEncap)
@@ -1200,7 +1190,6 @@ func Test_client_InstallServiceFlows(t *testing.T) {
 
 func Test_client_GetServiceFlowKeys(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	m := oftest.NewMockOFEntryOperations(ctrl)
 
 	fc := newFakeClient(m, true, true, config.K8sNode, config.TrafficEncapModeEncap)
@@ -1255,7 +1244,6 @@ func Test_client_InstallSNATMarkFlows(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
 
 			fc := newFakeClient(m, true, true, config.K8sNode, config.TrafficEncapModeEncap)
@@ -1304,7 +1292,6 @@ func Test_client_InstallPodSNATFlows(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
 
 			fc := newFakeClient(m, true, true, config.K8sNode, config.TrafficEncapModeEncap)
@@ -1350,7 +1337,6 @@ func Test_client_InstallTraceflowFlows(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			c := tt.prepareFunc(ctrl)
 			if err := c.InstallTraceflowFlows(tt.args.dataplaneTag, false, false, false, nil, 0, 300); (err != nil) != tt.wantErr {
 				t.Errorf("InstallTraceflowFlows() error = %v, wantErr %v", err, tt.wantErr)
@@ -1459,7 +1445,6 @@ func Test_client_SendTraceflowPacket(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			fc := prepareSendTraceflowPacket(ctrl, !tt.wantErr)
 			if err := fc.SendTraceflowPacket(tt.args.dataplaneTag, &tt.args.Packet, tt.args.inPort, tt.args.outPort); (err != nil) != tt.wantErr {
 				t.Errorf("SendTraceflowPacket() error = %v, wantErr %v", err, tt.wantErr)
@@ -1562,7 +1547,6 @@ func Test_client_setBasePacketOutBuilder(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			c := prepareSetBasePacketOutBuilder(ctrl, !tt.wantErr)
 			_, err := setBasePacketOutBuilder(c.bridge.BuildPacketOut(), tt.args.srcMAC, tt.args.dstMAC, tt.args.srcIP, tt.args.dstIP, tt.args.inPort, tt.args.outPort)
 			if (err != nil) != tt.wantErr {
@@ -1688,7 +1672,6 @@ func Test_client_SendPacketOut(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			mockBridge := ovsoftest.NewMockBridge(ctrl)
 			fc := newFakeClient(nil, true, true, config.K8sNode, config.TrafficEncapModeEncap)
 			defer resetPipelines()
@@ -1815,7 +1798,6 @@ func Test_client_InstallMulticastFlows(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
 
 			fc := newFakeClient(m, true, true, config.K8sNode, config.TrafficEncapModeEncap, enableMulticast)
@@ -1839,7 +1821,6 @@ func Test_client_InstallMulticastFlows(t *testing.T) {
 
 func Test_client_InstallMulticastRemoteReportFlows(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	m := oftest.NewMockOFEntryOperations(ctrl)
 
 	fc := newFakeClient(m, true, false, config.K8sNode, config.TrafficEncapModeEncap, enableMulticast)
@@ -1864,7 +1845,6 @@ func Test_client_InstallMulticastRemoteReportFlows(t *testing.T) {
 
 func Test_client_SendIGMPQueryPacketOut(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	mockBridge := ovsoftest.NewMockBridge(ctrl)
 	fc := newFakeClient(nil, true, false, config.K8sNode, config.TrafficEncapModeEncap)
 	defer resetPipelines()
@@ -1978,7 +1958,6 @@ func Test_client_InstallTrafficControlMarkFlows(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
 
 			fc := newFakeClient(m, true, true, config.K8sNode, config.TrafficEncapModeEncap, enableTrafficControl)
@@ -2003,7 +1982,6 @@ func Test_client_InstallTrafficControlMarkFlows(t *testing.T) {
 
 func Test_client_InstallTrafficControlReturnPortFlow(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	m := oftest.NewMockOFEntryOperations(ctrl)
 
 	fc := newFakeClient(m, true, true, config.K8sNode, config.TrafficEncapModeEncap, enableTrafficControl)
@@ -2076,7 +2054,6 @@ func Test_client_InstallMulticastGroup(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
 
 			fc := newFakeClient(m, true, true, config.K8sNode, config.TrafficEncapModeEncap, enableMulticast)
@@ -2130,7 +2107,6 @@ func Test_client_InstallMulticlusterNodeFlows(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
 
 			fc := newFakeClient(m, true, true, config.K8sNode, config.TrafficEncapModeEncap, enableMulticluster)
@@ -2184,7 +2160,6 @@ func Test_client_InstallMulticlusterGatewayFlows(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
 
 			fc := newFakeClient(m, true, true, config.K8sNode, config.TrafficEncapModeEncap, enableMulticluster)
@@ -2209,7 +2184,6 @@ func Test_client_InstallMulticlusterGatewayFlows(t *testing.T) {
 
 func Test_client_InstallMulticlusterClassifierFlows(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	m := oftest.NewMockOFEntryOperations(ctrl)
 
 	fc := newFakeClient(m, true, false, config.K8sNode, config.TrafficEncapModeEncap, enableMulticluster)

--- a/pkg/agent/openflow/externalnode_connectivity_test.go
+++ b/pkg/agent/openflow/externalnode_connectivity_test.go
@@ -29,7 +29,6 @@ import (
 
 func Test_client_InstallVMUplinkFlows(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	m := oftest.NewMockOFEntryOperations(ctrl)
 
 	fc := newFakeClient(m, true, true, config.ExternalNode, config.TrafficEncapModeEncap)
@@ -86,7 +85,6 @@ func Test_client_InstallPolicyBypassFlows(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
 
 			fc := newFakeClient(m, true, true, config.ExternalNode, config.TrafficEncapModeEncap)

--- a/pkg/agent/openflow/network_policy_test.go
+++ b/pkg/agent/openflow/network_policy_test.go
@@ -87,7 +87,6 @@ type expectConjunctionTimes struct {
 
 func TestPolicyRuleConjunction(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	preparePipelines()
 	defer resetPipelines()
 	c = prepareClient(ctrl, false)
@@ -161,8 +160,6 @@ func TestPolicyRuleConjunction(t *testing.T) {
 
 func TestInstallPolicyRuleFlows(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	preparePipelines()
 	defer resetPipelines()
 	c = prepareClient(ctrl, false)
@@ -569,7 +566,6 @@ func TestBatchInstallPolicyRuleFlows(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			mockOperations := oftest.NewMockOFEntryOperations(ctrl)
 			ofClient := NewClient(bridgeName, bridgeMgmtAddr, false, true, false, false, false, false, false, false, false, false)
 			c = ofClient.(*client)
@@ -672,8 +668,6 @@ func BenchmarkBatchInstallPolicyRuleFlows(b *testing.B) {
 
 func TestConjMatchFlowContextKeyConflict(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	preparePipelines()
 	defer resetPipelines()
 	c = prepareClient(ctrl, false)
@@ -718,8 +712,6 @@ func TestConjMatchFlowContextKeyConflict(t *testing.T) {
 
 func TestInstallPolicyRuleFlowsInDualStackCluster(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	preparePipelines()
 	defer resetPipelines()
 	c = prepareClient(ctrl, true)
@@ -1215,8 +1207,6 @@ func TestNetworkPolicyMetrics(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
-
 			preparePipelines()
 			defer resetPipelines()
 			c = prepareClient(ctrl, false)
@@ -1234,7 +1224,6 @@ func TestNetworkPolicyMetrics(t *testing.T) {
 
 func TestGetMatchFlowUpdates(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	preparePipelines()
 	defer resetPipelines()
 	c = prepareClient(ctrl, false)
@@ -1326,7 +1315,6 @@ func setMockOFTables(ctrl *gomock.Controller, tableMap map[*Table]**mocks.MockTa
 
 func TestClient_GetPolicyInfoFromConjunction(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	preparePipelines()
 	defer resetPipelines()
 	c = prepareClient(ctrl, false)

--- a/pkg/agent/openflow/pipeline_test.go
+++ b/pkg/agent/openflow/pipeline_test.go
@@ -208,7 +208,6 @@ func Test_client_defaultFlows(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			m := oftest.NewMockOFEntryOperations(ctrl)
 
 			fc := newFakeClient(m, tc.enableIPv4, tc.enableIPv6, tc.nodeType, tc.trafficEncapMode, tc.clientOptions...)

--- a/pkg/agent/proxy/proxier_test.go
+++ b/pkg/agent/proxy/proxier_test.go
@@ -363,7 +363,6 @@ func testClusterIPAdd(t *testing.T,
 	extraEps []*corev1.Endpoints,
 	endpointSliceEnabled bool) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	mockOFClient, mockRouteClient := getMockClients(ctrl)
 	groupAllocator := openflow.NewGroupAllocator(isIPv6)
 	options := []proxyOptionsFn{withProxyAll}
@@ -434,7 +433,6 @@ func testLoadBalancerAdd(t *testing.T,
 	proxyLoadBalancerIPs bool,
 	endpointSliceEnabled bool) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	mockOFClient, mockRouteClient := getMockClients(ctrl)
 	groupAllocator := openflow.NewGroupAllocator(isIPv6)
 	options := []proxyOptionsFn{withProxyAll}
@@ -550,7 +548,6 @@ func testNodePortAdd(t *testing.T,
 	nodeLocalExternal bool,
 	endpointSliceEnabled bool) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	mockOFClient, mockRouteClient := getMockClients(ctrl)
 	groupAllocator := openflow.NewGroupAllocator(isIPv6)
 	options := []proxyOptionsFn{withProxyAll}
@@ -761,7 +758,6 @@ func TestLoadBalancerAdd(t *testing.T) {
 
 func TestLoadBalancerServiceWithMultiplePorts(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	mockOFClient, mockRouteClient := getMockClients(ctrl)
 	groupAllocator := openflow.NewGroupAllocator(false)
 	nodePortAddresses := []net.IP{net.ParseIP("0.0.0.0")}
@@ -1003,7 +999,6 @@ func TestClusterSkipServices(t *testing.T) {
 
 func TestDualStackService(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	mockOFClient, mockRouteClient := getMockClients(ctrl)
 	ipv4GroupAllocator := openflow.NewGroupAllocator(false)
 	ipv6GroupAllocator := openflow.NewGroupAllocator(true)
@@ -1052,7 +1047,6 @@ func TestDualStackService(t *testing.T) {
 
 func testClusterIPRemove(t *testing.T, svcIP net.IP, epIP net.IP, isIPv6 bool, nodeLocalInternal, endpointSliceEnabled bool) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	mockOFClient, mockRouteClient := getMockClients(ctrl)
 	groupAllocator := openflow.NewGroupAllocator(isIPv6)
 	options := []proxyOptionsFn{withProxyAll, withSupportNestedService}
@@ -1117,7 +1111,6 @@ func testClusterIPRemove(t *testing.T, svcIP net.IP, epIP net.IP, isIPv6 bool, n
 
 func testNodePortRemove(t *testing.T, nodePortAddresses []net.IP, svcIP net.IP, epIP net.IP, isIPv6 bool, endpointSliceEnabled bool) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	mockOFClient, mockRouteClient := getMockClients(ctrl)
 	groupAllocator := openflow.NewGroupAllocator(isIPv6)
 	options := []proxyOptionsFn{withProxyAll}
@@ -1187,7 +1180,6 @@ func testNodePortRemove(t *testing.T, nodePortAddresses []net.IP, svcIP net.IP, 
 
 func testLoadBalancerRemove(t *testing.T, nodePortAddresses []net.IP, svcIP net.IP, epIP net.IP, loadBalancerIP net.IP, isIPv6 bool, endpointSliceEnabled bool) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	mockOFClient, mockRouteClient := getMockClients(ctrl)
 	groupAllocator := openflow.NewGroupAllocator(isIPv6)
 	options := []proxyOptionsFn{withProxyAll}
@@ -1344,7 +1336,6 @@ func TestLoadBalancerRemove(t *testing.T) {
 
 func testClusterIPNoEndpoint(t *testing.T, svcIP net.IP, isIPv6 bool) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	mockOFClient, mockRouteClient := getMockClients(ctrl)
 	groupAllocator := openflow.NewGroupAllocator(isIPv6)
 	fp := NewFakeProxier(mockRouteClient, mockOFClient, nil, groupAllocator, isIPv6)
@@ -1377,7 +1368,6 @@ func TestClusterIPNoEndpoint(t *testing.T) {
 
 func testNodePortNoEndpoint(t *testing.T, nodePortAddresses []net.IP, svcIP net.IP, isIPv6 bool) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	mockOFClient, mockRouteClient := getMockClients(ctrl)
 	groupAllocator := openflow.NewGroupAllocator(isIPv6)
 	fp := NewFakeProxier(mockRouteClient, mockOFClient, nodePortAddresses, groupAllocator, isIPv6, withProxyAll)
@@ -1434,7 +1424,6 @@ func TestNodePortNoEndpoint(t *testing.T) {
 
 func testLoadBalancerNoEndpoint(t *testing.T, nodePortAddresses []net.IP, svcIP net.IP, loadBalancerIP net.IP, isIPv6 bool) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	mockOFClient, mockRouteClient := getMockClients(ctrl)
 	groupAllocator := openflow.NewGroupAllocator(isIPv6)
 	fp := NewFakeProxier(mockRouteClient, mockOFClient, nodePortAddresses, groupAllocator, isIPv6, withProxyAll)
@@ -1502,7 +1491,6 @@ func TestLoadBalancerNoEndpoint(t *testing.T) {
 
 func testClusterIPRemoveSamePortEndpoint(t *testing.T, svcIP net.IP, epIP net.IP, isIPv6 bool) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	mockOFClient, mockRouteClient := getMockClients(ctrl)
 	groupAllocator := openflow.NewGroupAllocator(isIPv6)
 	fp := NewFakeProxier(mockRouteClient, mockOFClient, nil, groupAllocator, isIPv6)
@@ -1560,7 +1548,6 @@ func TestClusterIPRemoveSamePortEndpoint(t *testing.T) {
 
 func testClusterIPRemoveEndpoints(t *testing.T, svcIP net.IP, epIP net.IP, isIPv6 bool) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	mockOFClient, mockRouteClient := getMockClients(ctrl)
 	groupAllocator := openflow.NewGroupAllocator(isIPv6)
 	fp := NewFakeProxier(mockRouteClient, mockOFClient, nil, groupAllocator, isIPv6)
@@ -1609,7 +1596,6 @@ func TestClusterIPRemoveEndpoints(t *testing.T) {
 
 func testSessionAffinity(t *testing.T, svcIP net.IP, epIP net.IP, affinitySeconds int32, isIPv6 bool) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	mockOFClient, mockRouteClient := getMockClients(ctrl)
 	groupAllocator := openflow.NewGroupAllocator(isIPv6)
 	fp := NewFakeProxier(mockRouteClient, mockOFClient, nil, groupAllocator, isIPv6)
@@ -1673,7 +1659,6 @@ func TestSessionAffinityOverflow(t *testing.T) {
 
 func testSessionAffinityNoEndpoint(t *testing.T, svcExternalIPs net.IP, svcIP net.IP, isIPv6 bool) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	mockOFClient, mockRouteClient := getMockClients(ctrl)
 	groupAllocator := openflow.NewGroupAllocator(isIPv6)
 	fp := NewFakeProxier(mockRouteClient, mockOFClient, nil, groupAllocator, isIPv6)
@@ -1724,7 +1709,6 @@ func testServiceClusterIPUpdate(t *testing.T,
 	svcType corev1.ServiceType,
 	isIPv6 bool) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	mockOFClient, mockRouteClient := getMockClients(ctrl)
 	groupAllocator := openflow.NewGroupAllocator(isIPv6)
 	fp := NewFakeProxier(mockRouteClient, mockOFClient, nodePortAddresses, groupAllocator, isIPv6, withProxyAll)
@@ -1826,7 +1810,6 @@ func testServicePortUpdate(t *testing.T,
 	svcType corev1.ServiceType,
 	isIPv6 bool) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	mockOFClient, mockRouteClient := getMockClients(ctrl)
 	groupAllocator := openflow.NewGroupAllocator(isIPv6)
 	fp := NewFakeProxier(mockRouteClient, mockOFClient, nodePortAddresses, groupAllocator, isIPv6, withProxyAll)
@@ -1929,7 +1912,6 @@ func testServiceNodePortUpdate(t *testing.T,
 	svcType corev1.ServiceType,
 	isIPv6 bool) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	mockOFClient, mockRouteClient := getMockClients(ctrl)
 	groupAllocator := openflow.NewGroupAllocator(isIPv6)
 	fp := NewFakeProxier(mockRouteClient, mockOFClient, nodePortAddresses, groupAllocator, isIPv6, withProxyAll)
@@ -2015,7 +1997,6 @@ func testServiceExternalTrafficPolicyUpdate(t *testing.T,
 	svcType corev1.ServiceType,
 	isIPv6 bool) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	mockOFClient, mockRouteClient := getMockClients(ctrl)
 	groupAllocator := openflow.NewGroupAllocator(isIPv6)
 	fp := NewFakeProxier(mockRouteClient, mockOFClient, nodePortAddresses, groupAllocator, isIPv6, withProxyAll)
@@ -2122,7 +2103,6 @@ func testServiceInternalTrafficPolicyUpdate(t *testing.T,
 	ep2IP net.IP,
 	isIPv6 bool) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	mockOFClient, mockRouteClient := getMockClients(ctrl)
 	groupAllocator := openflow.NewGroupAllocator(isIPv6)
 	fp := NewFakeProxier(mockRouteClient, mockOFClient, nil, groupAllocator, isIPv6, withProxyAll)
@@ -2209,7 +2189,6 @@ func testServiceIngressIPsUpdate(t *testing.T,
 	updatedLoadBalancerIPs []net.IP,
 	isIPv6 bool) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	mockOFClient, mockRouteClient := getMockClients(ctrl)
 	groupAllocator := openflow.NewGroupAllocator(isIPv6)
 	fp := NewFakeProxier(mockRouteClient, mockOFClient, nodePortAddresses, groupAllocator, isIPv6, withProxyAll)
@@ -2297,7 +2276,6 @@ func testServiceStickyMaxAgeSecondsUpdate(t *testing.T,
 	svcType corev1.ServiceType,
 	isIPv6 bool) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	mockOFClient, mockRouteClient := getMockClients(ctrl)
 	groupAllocator := openflow.NewGroupAllocator(isIPv6)
 	fp := NewFakeProxier(mockRouteClient, mockOFClient, nodePortAddresses, groupAllocator, isIPv6, withProxyAll)
@@ -2397,7 +2375,6 @@ func testServiceSessionAffinityTypeUpdate(t *testing.T,
 	svcType corev1.ServiceType,
 	isIPv6 bool) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	mockOFClient, mockRouteClient := getMockClients(ctrl)
 	groupAllocator := openflow.NewGroupAllocator(isIPv6)
 	fp := NewFakeProxier(mockRouteClient, mockOFClient, nodePortAddresses, groupAllocator, isIPv6, withProxyAll)
@@ -2494,7 +2471,6 @@ func TestServiceSessionAffinityTypeUpdate(t *testing.T) {
 
 func TestServicesWithSameEndpoints(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	mockOFClient, mockRouteClient := getMockClients(ctrl)
 	groupAllocator := openflow.NewGroupAllocator(false)
 	fp := NewFakeProxier(mockRouteClient, mockOFClient, nil, groupAllocator, false)
@@ -2603,7 +2579,6 @@ func TestMetrics(t *testing.T) {
 
 func TestGetServiceFlowKeys(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	mockOFClient, mockRouteClient := getMockClients(ctrl)
 	groupAllocator := openflow.NewGroupAllocator(false)
 	svc := makeTestNodePortService(&svcPortName,

--- a/pkg/agent/querier/querier_test.go
+++ b/pkg/agent/querier/querier_test.go
@@ -44,8 +44,6 @@ func getIPNet(ip string) *net.IPNet {
 
 func TestAgentQuerierGetAgentInfo(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	interfaceStore := interfacestoretest.NewMockInterfaceStore(ctrl)
 	interfaceStore.EXPECT().GetContainerInterfaceNum().Return(2).AnyTimes()
 

--- a/pkg/agent/route/route_linux_test.go
+++ b/pkg/agent/route/route_linux_test.go
@@ -53,7 +53,6 @@ var (
 
 func TestSyncRoutes(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	mockNetlink := netlinktest.NewMockInterface(ctrl)
 
 	nodeRoute1 := &netlink.Route{Dst: ip.MustParseCIDR("192.168.1.0/24"), Gw: net.ParseIP("1.1.1.1")}
@@ -199,7 +198,6 @@ func TestSyncIPSet(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			ipset := ipsettest.NewMockInterface(ctrl)
 			c := &Client{ipset: ipset,
 				networkConfig:         tt.networkConfig,
@@ -480,7 +478,6 @@ COMMIT
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			mockIPTables := iptablestest.NewMockInterface(ctrl)
 			c := &Client{iptables: mockIPTables,
 				networkConfig:         tt.networkConfig,
@@ -542,7 +539,6 @@ func TestInitIPRoutes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			mockNetlink := netlinktest.NewMockInterface(ctrl)
 			c := &Client{netlink: mockNetlink,
 				networkConfig: tt.networkConfig,
@@ -626,7 +622,6 @@ func TestInitServiceIPRoutes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			mockNetlink := netlinktest.NewMockInterface(ctrl)
 			mockServiceCIDRProvider := servicecidrtest.NewMockInterface(ctrl)
 			c := &Client{netlink: mockNetlink,
@@ -643,7 +638,6 @@ func TestInitServiceIPRoutes(t *testing.T) {
 
 func TestReconcile(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	mockNetlink := netlinktest.NewMockInterface(ctrl)
 	mockIPSet := ipsettest.NewMockInterface(ctrl)
 	c := &Client{netlink: mockNetlink,
@@ -909,7 +903,6 @@ func TestAddRoutes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			mockNetlink := netlinktest.NewMockInterface(ctrl)
 			mockIPSet := ipsettest.NewMockInterface(ctrl)
 			c := &Client{netlink: mockNetlink,
@@ -969,7 +962,6 @@ func TestDeleteRoutes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			mockNetlink := netlinktest.NewMockInterface(ctrl)
 			mockIPSet := ipsettest.NewMockInterface(ctrl)
 			c := &Client{netlink: mockNetlink,
@@ -994,7 +986,6 @@ func TestDeleteRoutes(t *testing.T) {
 
 func TestMigrateRoutesToGw(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	mockNetlink := netlinktest.NewMockInterface(ctrl)
 	mockIPSet := ipsettest.NewMockInterface(ctrl)
 
@@ -1075,7 +1066,6 @@ func TestUnMigrateRoutesToGw(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			mockNetlink := netlinktest.NewMockInterface(ctrl)
 			c := &Client{
 				netlink:    mockNetlink,
@@ -1136,7 +1126,6 @@ func TestAddSNATRule(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			mockIPTables := iptablestest.NewMockInterface(ctrl)
 			c := &Client{iptables: mockIPTables,
 				nodeConfig: tt.nodeConfig,
@@ -1202,7 +1191,6 @@ func TestDeleteSNATRule(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			mockIPTables := iptablestest.NewMockInterface(ctrl)
 			c := &Client{
 				iptables:     mockIPTables,
@@ -1256,7 +1244,6 @@ func TestAddNodePort(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			ipset := ipsettest.NewMockInterface(ctrl)
 			c := &Client{ipset: ipset}
 			tt.expectedCalls(ipset.EXPECT())
@@ -1303,7 +1290,6 @@ func TestDeleteNodePort(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			ipset := ipsettest.NewMockInterface(ctrl)
 			c := &Client{ipset: ipset}
 			tt.expectedCalls(ipset.EXPECT())
@@ -1408,7 +1394,6 @@ func TestAddServiceCIDRRoute(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			mockNetlink := netlinktest.NewMockInterface(ctrl)
 			c := &Client{
 				netlink:    mockNetlink,
@@ -1478,7 +1463,6 @@ func TestAddLoadBalancer(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			mockNetlink := netlinktest.NewMockInterface(ctrl)
 			c := &Client{
 				netlink:    mockNetlink,
@@ -1528,7 +1512,6 @@ func TestDeleteLoadBalancer(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			mockNetlink := netlinktest.NewMockInterface(ctrl)
 			c := &Client{
 				netlink:       mockNetlink,
@@ -1592,7 +1575,6 @@ func TestAddLocalAntreaFlexibleIPAMPodRule(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			mockIPSet := ipsettest.NewMockInterface(ctrl)
 			c := &Client{
 				ipset:                 mockIPSet,
@@ -1633,7 +1615,6 @@ func TestDeleteLocalAntreaFlexibleIPAMPodRule(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			mockIPSet := ipsettest.NewMockInterface(ctrl)
 			c := &Client{
 				ipset:                 mockIPSet,
@@ -1682,7 +1663,6 @@ func TestAddAndDeleteNodeIP(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			mockIPSet := ipsettest.NewMockInterface(ctrl)
 			c := &Client{
 				ipset:            mockIPSet,

--- a/pkg/agent/secondarynetwork/podwatch/controller_test.go
+++ b/pkg/agent/secondarynetwork/podwatch/controller_test.go
@@ -152,7 +152,6 @@ func init() {
 
 func TestPodControllerRun(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	client := fake.NewSimpleClientset()
 	netdefclient := netdefclientfake.NewSimpleClientset().K8sCniCncfIoV1()
 	informerFactory := informers.NewSharedInformerFactory(client, resyncPeriod)
@@ -262,7 +261,6 @@ func TestPodControllerAddPod(t *testing.T) {
 
 	t.Run("missing network", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 		podController, _, _ := newPodController(ctrl)
 		podController.podCache.AddCNIConfigInfo(cniConfig)
 		_, err := podController.kubeClient.CoreV1().Pods(testNamespace).Create(context.Background(), pod, metav1.CreateOptions{})
@@ -272,7 +270,6 @@ func TestPodControllerAddPod(t *testing.T) {
 
 	t.Run("multiple network interfaces", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 		podController, mockIPAM, interfaceConfigurator := newPodController(ctrl)
 
 		pod, cniConfig := testPod(
@@ -327,7 +324,6 @@ func TestPodControllerAddPod(t *testing.T) {
 
 	t.Run("no network interfaces", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 		podController, _, _ := newPodController(ctrl)
 
 		pod, cniConfig := testPod(podName, containerID, podIP)
@@ -340,7 +336,6 @@ func TestPodControllerAddPod(t *testing.T) {
 
 	t.Run("missing podcache entry", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 		podController, _, _ := newPodController(ctrl)
 
 		network := testNetwork(networkName)
@@ -354,7 +349,6 @@ func TestPodControllerAddPod(t *testing.T) {
 
 	t.Run("missing Status.PodIPs", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 		podController, _, _ := newPodController(ctrl)
 
 		pod, cniConfig := testPod(podName, containerID, "")
@@ -370,7 +364,6 @@ func TestPodControllerAddPod(t *testing.T) {
 
 	t.Run("different Namespace for Pod and NetworkAttachmentDefinition", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 		podController, mockIPAM, interfaceConfigurator := newPodController(ctrl)
 
 		networkNamespace := "nsB"
@@ -412,7 +405,6 @@ func TestPodControllerAddPod(t *testing.T) {
 
 	t.Run("no interface name", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 		podController, mockIPAM, interfaceConfigurator := newPodController(ctrl)
 
 		pod, cniConfig := testPod(
@@ -464,7 +456,6 @@ func TestPodControllerAddPod(t *testing.T) {
 
 	t.Run("error when creating interface", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 		podController, mockIPAM, interfaceConfigurator := newPodController(ctrl)
 
 		network := testNetwork(networkName)
@@ -493,7 +484,6 @@ func TestPodControllerAddPod(t *testing.T) {
 
 	t.Run("invalid networks annotation", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 		podController, _, _ := newPodController(ctrl)
 
 		pod, cniConfig := testPod(podName, containerID, podIP)
@@ -513,7 +503,6 @@ func TestPodControllerAddPod(t *testing.T) {
 
 	t.Run("Error when adding VF deviceID cache per Pod", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 		network := testNetwork(networkName)
 		podController, _, _ := newPodController(ctrl)
 		podController.podCache.AddCNIConfigInfo(cniConfig)

--- a/pkg/agent/stats/collector_test.go
+++ b/pkg/agent/stats/collector_test.go
@@ -58,8 +58,6 @@ var (
 
 func TestCollect(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	tests := []struct {
 		name                    string
 		ruleStats               map[uint32]*agenttypes.RuleMetric
@@ -338,8 +336,6 @@ func TestCalculateDiff(t *testing.T) {
 
 func TestCalculateNodeStatsSummary(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	tests := []struct {
 		name                string
 		lastStatsCollection *statsCollection
@@ -420,8 +416,6 @@ func TestCalculateNodeStatsSummary(t *testing.T) {
 }
 
 func TestConvertMulticastGroups(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	tests := []struct {
 		name                      string
 		multicastGroupMap         map[string][]cpv1beta.PodReference
@@ -454,7 +448,6 @@ func TestConvertMulticastGroups(t *testing.T) {
 
 func TestMergeStatsWithIGMPReports(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	tests := []struct {
 		name              string
 		curAnpStats       []cpv1beta.NetworkPolicyStats

--- a/pkg/agent/util/net_linux_test.go
+++ b/pkg/agent/util/net_linux_test.go
@@ -146,7 +146,6 @@ func TestGetNSPeerDevBridge(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			defer mockUtilNetlink(ctrl, tc.expectedCalls)()
 			defer mockGetNS(&mockNetNS{}, tc.getNSErr)()
 			defer mockNetNSDo()()
@@ -295,7 +294,6 @@ func TestSetLinkUp(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			defer mockUtilNetlink(ctrl, tc.expectedCalls)()
 			defer mockUtilNetlinkAttrs(testLink)()
 			gotMac, gotIndex, gotErr := SetLinkUp("antrea-en0")
@@ -393,7 +391,6 @@ func TestConfigureLinkAddresses(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			defer mockUtilNetlink(ctrl, tc.expectedCalls)()
 			defer mockUtilNetlinkAttrs(testLink)()
 			gotErr := ConfigureLinkAddresses(0, tc.ipNets)
@@ -436,7 +433,6 @@ func TestSetAdapterMACAddress(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			defer mockUtilNetlink(ctrl, tc.expectedCalls)()
 			gotErr := SetAdapterMACAddress("test-en0", &testMACAddr)
 			assert.Equal(t, tc.wantErr, gotErr)
@@ -476,7 +472,6 @@ func TestHostInterfaceExists(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			defer mockUtilNetlink(ctrl, tc.expectedCalls)()
 			gotExists := HostInterfaceExists("test-en0")
 			assert.Equal(t, tc.wantExists, gotExists)
@@ -543,7 +538,6 @@ func TestGetInterfaceConfig(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			defer mockUtilNetlink(ctrl, tc.expectedCalls)()
 			defer mockNetInterfaceByName(&testNetInterface, tc.testNetInterfaceErr)()
 			defer mockNetInterfaceAddrs(testNetInterface, tc.testNetAddrsErr)()
@@ -616,7 +610,6 @@ func TestRenameInterface(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			defer mockUtilNetlink(ctrl, tc.expectedCalls)()
 			gotErr := RenameInterface("test1", "test2")
 			assert.Equal(t, tc.wantErr, gotErr)
@@ -659,7 +652,6 @@ func TestRemoveLinkIPs(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			defer mockUtilNetlink(ctrl, tc.expectedCalls)()
 			gotErr := RemoveLinkIPs(mockLink{name: "test"})
 			assert.Equal(t, tc.wantErr, gotErr)
@@ -702,7 +694,6 @@ func TestRemoveLinkRoutes(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			defer mockUtilNetlink(ctrl, tc.expectedCalls)()
 			gotErr := RemoveLinkRoutes(mockLink{name: "test"})
 			assert.Equal(t, tc.wantErr, gotErr)
@@ -738,7 +729,6 @@ func TestConfigureLinkRoutes(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
 			defer mockUtilNetlink(ctrl, tc.expectedCalls)()
 			defer mockUtilNetlinkAttrs(testLink)()
 			gotErr := ConfigureLinkRoutes(testLink, testRoutes)

--- a/pkg/antctl/antctl_test.go
+++ b/pkg/antctl/antctl_test.go
@@ -47,7 +47,6 @@ func TestCommandVersionRequestError(t *testing.T) {
 		Use: "antctl",
 	}
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	client := NewMockAntctlClient(ctrl)
 	var bufOut bytes.Buffer
 	CommandList.applyToRootCommand(rootCmd, client, &bufOut)
@@ -70,7 +69,6 @@ func TestExtraArgs(t *testing.T) {
 		Use: "antctl",
 	}
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	client := NewMockAntctlClient(ctrl)
 	var bufOut bytes.Buffer
 	CommandList.applyToRootCommand(cmd, client, os.Stdout)

--- a/pkg/apiserver/handlers/endpoint/handler_test.go
+++ b/pkg/apiserver/handlers/endpoint/handler_test.go
@@ -87,7 +87,6 @@ var responses = []response{
 // with incomplete arguments (for now, missing pod or namespace)
 func TestIncompleteArguments(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
 	// sample selector arguments (right now, only supports podname and namespace)
 	namespace := "namespace"
 	// outline test cases with expected behavior
@@ -112,7 +111,6 @@ func TestIncompleteArguments(t *testing.T) {
 // any existing endpoint
 func TestInvalidArguments(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
 	// sample selector arguments (right now, only supports podname and namespace)
 	pod, namespace := "pod", "namespace"
 	// outline test cases with expected behavior
@@ -136,7 +134,6 @@ func TestInvalidArguments(t *testing.T) {
 // single policy response
 func TestSinglePolicyResponse(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
 	// sample selector arguments (right now, only supports podName and namespace)
 	pod, namespace := "pod", "namespace"
 	// outline test cases with expected behavior
@@ -170,7 +167,6 @@ func TestSinglePolicyResponse(t *testing.T) {
 // multiple policy responses
 func TestMultiPolicyResponse(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
 	// sample selector arguments (right now, only supports podName and namespace)
 	pod, namespace := "pod", "namespace"
 	// outline test cases with expected behavior

--- a/pkg/apiserver/registry/system/supportbundle/rest_test.go
+++ b/pkg/apiserver/registry/system/supportbundle/rest_test.go
@@ -239,7 +239,6 @@ func TestAgentStorage(t *testing.T) {
 
 	ctx := context.Background()
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	fakeOVSCtl := ovsctltest.NewMockOVSCtlClient(ctrl)
 	fakeAgentQuerier := agentqueriertest.NewMockAgentQuerier(ctrl)
 	fakeNetworkPolicyQuerier := queriertest.NewMockAgentNetworkPolicyInfoQuerier(ctrl)
@@ -299,7 +298,6 @@ func TestAgentStorageFailure(t *testing.T) {
 
 	ctx := context.Background()
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	fakeOVSCtl := ovsctltest.NewMockOVSCtlClient(ctrl)
 	fakeAgentQuerier := agentqueriertest.NewMockAgentQuerier(ctrl)
 	fakeNetworkPolicyQuerier := queriertest.NewMockAgentNetworkPolicyInfoQuerier(ctrl)

--- a/pkg/flowaggregator/apiserver/handlers/flowrecords/handler_test.go
+++ b/pkg/flowaggregator/apiserver/handlers/flowrecords/handler_test.go
@@ -145,7 +145,6 @@ func TestGetFlowRecordsQuery(t *testing.T) {
 	}
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			faq := queriertest.NewMockFlowAggregatorQuerier(ctrl)

--- a/pkg/flowaggregator/apiserver/handlers/recordmetrics/handler_test.go
+++ b/pkg/flowaggregator/apiserver/handlers/recordmetrics/handler_test.go
@@ -29,7 +29,6 @@ import (
 
 func TestRecordMetricsQuery(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	faq := queriertest.NewMockFlowAggregatorQuerier(ctrl)
 	faq.EXPECT().GetRecordMetrics().Return(querier.Metrics{
 		NumRecordsExported: 20,

--- a/pkg/flowaggregator/clickhouseclient/clickhouseclient_test.go
+++ b/pkg/flowaggregator/clickhouseclient/clickhouseclient_test.go
@@ -78,7 +78,6 @@ func TestGetDataSourceName(t *testing.T) {
 
 func TestCacheRecord(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	chExportProc := ClickHouseExportProcess{
 		deque: deque.New(),

--- a/pkg/flowaggregator/exporter/ipfix_test.go
+++ b/pkg/flowaggregator/exporter/ipfix_test.go
@@ -51,7 +51,6 @@ func createElement(name string, enterpriseID uint32) ipfixentities.InfoElementWi
 
 func TestIPFIXExporter_sendTemplateSet(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	mockIPFIXExpProc := ipfixtesting.NewMockIPFIXExportingProcess(ctrl)
 	mockIPFIXRegistry := ipfixtesting.NewMockIPFIXRegistry(ctrl)
@@ -108,7 +107,6 @@ func TestIPFIXExporter_sendTemplateSet(t *testing.T) {
 
 func TestIPFIXExporter_UpdateOptions(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	mockIPFIXExpProc := ipfixtesting.NewMockIPFIXExportingProcess(ctrl)
 	mockTempSet := ipfixentitiestesting.NewMockSet(ctrl)
@@ -169,7 +167,6 @@ func TestIPFIXExporter_UpdateOptions(t *testing.T) {
 
 func TestIPFIXExporter_AddRecord(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	mockIPFIXExpProc := ipfixtesting.NewMockIPFIXExportingProcess(ctrl)
 	mockTempSet := ipfixentitiestesting.NewMockSet(ctrl)
@@ -205,7 +202,6 @@ func TestIPFIXExporter_AddRecord(t *testing.T) {
 
 func TestIPFIXExporter_initIPFIXExportingProcess_Error(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	mockRecord := ipfixentitiestesting.NewMockRecord(ctrl)
 
@@ -229,7 +225,6 @@ func TestIPFIXExporter_initIPFIXExportingProcess_Error(t *testing.T) {
 
 func TestIPFIXExporter_sendRecord_Error(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	mockIPFIXExpProc := ipfixtesting.NewMockIPFIXExportingProcess(ctrl)
 	mockTempSet := ipfixentitiestesting.NewMockSet(ctrl)

--- a/pkg/flowaggregator/flowaggregator_test.go
+++ b/pkg/flowaggregator/flowaggregator_test.go
@@ -441,7 +441,6 @@ func TestFlowAggregator_updateFlowAggregator(t *testing.T) {
 
 func TestFlowAggregator_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	mockIPFIXExporter := exportertesting.NewMockInterface(ctrl)
 	mockClickHouseExporter := exportertesting.NewMockInterface(ctrl)
 	mockS3Exporter := exportertesting.NewMockInterface(ctrl)

--- a/pkg/flowaggregator/flowrecord/record_test.go
+++ b/pkg/flowaggregator/flowrecord/record_test.go
@@ -32,8 +32,6 @@ func init() {
 
 func TestGetFlowRecord(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	testcases := []struct {
 		isIPv4 bool
 	}{

--- a/pkg/support/dump_windows_test.go
+++ b/pkg/support/dump_windows_test.go
@@ -46,7 +46,6 @@ func (te *testExec) Command(cmd string, args ...string) exec.Cmd {
 func TestDumpHostNetworkInfo(t *testing.T) {
 	baseDir := "basedir"
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	q := aqtest.NewMockAgentQuerier(ctrl)
 
 	for _, m := range []struct {

--- a/test/integration/agent/cniserver_test.go
+++ b/test/integration/agent/cniserver_test.go
@@ -646,7 +646,6 @@ func cmdAddDelCheckTest(testNS ns.NetNS, tc testCase, dataDir string) {
 
 func TestAntreaServerFunc(t *testing.T) {
 	controller := mock.NewController(t)
-	defer controller.Finish()
 	ipamMock = ipamtest.NewMockIPAMDriver(controller)
 	ipam.RegisterIPAMDriver("mock", ipamMock)
 	ovsServiceMock = ovsconfigtest.NewMockOVSBridgeClient(controller)
@@ -766,7 +765,6 @@ func TestCNIServerChaining(t *testing.T) {
 
 	testRequire := require.New(t)
 	controller := mock.NewController(t)
-	defer controller.Finish()
 	var server *cniserver.CNIServer
 	testContainerOFPort := int32(1234)
 	testPatchPortName := "antrea-gw0"

--- a/test/integration/agent/flowexporter_test.go
+++ b/test/integration/agent/flowexporter_test.go
@@ -101,7 +101,6 @@ func prepareInterfaceConfigs(contID, podName, podNS, ifName string, ip *net.IP) 
 func TestConnectionStoreAndFlowRecords(t *testing.T) {
 	// Test setup
 	ctrl := mock.NewController(t)
-	defer ctrl.Finish()
 
 	// Prepare connections and interface config for test
 	testConns, testConnKeys := createConnsForTest()


### PR DESCRIPTION
In response to [this comment](https://github.com/antrea-io/antrea/pull/4914#discussion_r1180627997)
In go1.14+, if pass `*testing.T` into `NewController` we no longer need to call `ctrl.Finish()`, updating the current usages. [Reference](https://pkg.go.dev/github.com/golang/mock@v1.6.0/gomock#NewController)