### PR TITLE
Temporarily install Suricata from Ubuntu PPA instead of OISF PPA

### DIFF
--- a/build/images/base/Dockerfile
+++ b/build/images/base/Dockerfile
@@ -52,9 +52,8 @@ USER root
 # chmod in the RUN command below instead.
 ADD https://raw.githubusercontent.com/kubernetes-sigs/iptables-wrappers/9e6ce59c864623ea71a6f7d59c35fcb13a919b87/iptables-wrapper-installer.sh /iptables-wrapper-installer.sh
 
-RUN apt-get update && apt-get install -y --no-install-recommends ipset jq inotify-tools gpg-agent software-properties-common && \
-    add-apt-repository ppa:oisf/suricata-${SURICATA_VERSION} && apt-get update && apt-get install -y suricata && \
-    apt-get remove -y gpg-agent software-properties-common && apt-get autoremove -y && rm -rf /var/cache/apt/* /var/lib/apt/lists/* && \
+RUN apt-get update && apt-get install -y --no-install-recommends ipset jq inotify-tools suricata && \
+    rm -rf /var/cache/apt/* /var/lib/apt/lists/* && \
     chmod +x /iptables-wrapper-installer.sh && \
     /iptables-wrapper-installer.sh
 


### PR DESCRIPTION
To avoid a known issue with Suricata 6.0.11.
The main Ubuntu PPA ships Suircata 6.0.4.

With this change, e2e tests for L7NetworkPolicy will stop failing.

We do not "fix" the UBI build at the moment, but it will be taken care of before the Antrea v1.12 release.

For #4921