### PR TITLE
Improve AntreaProxy route syncing on Windows

### DIFF
--- a/pkg/agent/util/powershell/powershell_windows.go
+++ b/pkg/agent/util/powershell/powershell_windows.go
@@ -26,8 +26,8 @@ func RunCommand(cmd string) (string, error) {
 	// The try/catch command idea is from the following page:
 	// https://stackoverflow.com/questions/19282870/how-can-i-use-try-catch-and-get-my-script-to-stop-if-theres-an-error/19285405
 	psCmd := exec.Command("powershell.exe", "-NoLogo", "-NoProfile", "-NonInteractive", "-Command",
-		fmt.Sprintf(`$ErrorActionPreference="Stop";try {%s} catch {Write-Host $_;os.Exit(1)}`, cmd)) // #nosec G204
-	stdout, err := psCmd.Output()
+		fmt.Sprintf(`$ErrorActionPreference="Stop";try {%s} catch {Write-Host $_;Exit(1)}`, cmd)) // #nosec G204
+	stdout, err := psCmd.CombinedOutput()
 	stdoutStr := string(stdout)
 	if err != nil {
 		return "", fmt.Errorf("failed to run command '%s': output '%s', %v", cmd, stdoutStr, err)


### PR DESCRIPTION
This PR fixes the following issues:

1. AntreaAgent logs "Failed to sync route" when attempting to sync route entries
  every time.
2. AntreaAgent logs "Failed to install route for Service CIDR" err="failed to
  delete stale Service CIDR route" during startup.

For the first issue, previously, to recover the connected route of antrea-gw0
(assuming the IP address is 10.10.0.1/24) that may have been deleted by mistake,
a route with a destination 10.10.0.1/24 and gateway 10.10.0.1 was periodically
synced. However, this caused an error because an existing active route with the
same destination but a different gateway 0.0.0.0 should have already been
automatically installed when antrea-gw0 was created. To address this issue, this
PR changes the gateway of the recover route from 10.10.0.1 to 0.0.0.0, which
matches the existing installed route. This ensures that the periodic sync will
not cause any errors.

For the second issue, previously, when syncing the second ClusterIP, the stale
route entry installed for the first ClusterIP is added to the stale routes twice.
This results in the error log.

Signed-off-by: Hongliang Liu <lhongliang@vmware.com>