### PR TITLE
Automated cherry pick of #4934: Fix FQDN upper-case issue

### DIFF
--- a/pkg/agent/controller/networkpolicy/fqdn.go
+++ b/pkg/agent/controller/networkpolicy/fqdn.go
@@ -191,6 +191,7 @@ func newFQDNController(client openflow.Client, allocator *idAllocator, dnsServer
 
 // fqdnToSelectorItem converts a FQDN expression to a fqdnSelectorItem.
 func fqdnToSelectorItem(fqdn string) fqdnSelectorItem {
+	fqdn = strings.ToLower(fqdn)
 	if strings.Contains(fqdn, "*") {
 		return fqdnSelectorItem{
 			matchRegex: toRegex(fqdn),
@@ -203,7 +204,6 @@ func fqdnToSelectorItem(fqdn string) fqdnSelectorItem {
 // match FQDNs against.
 func toRegex(pattern string) string {
 	pattern = strings.TrimSpace(pattern)
-	pattern = strings.ToLower(pattern)
 
 	// Replace "." as a regex literal, since it's recogized as a separator in FQDN.
 	pattern = strings.Replace(pattern, ".", "[.]", -1)

--- a/test/e2e/antreapolicy_test.go
+++ b/test/e2e/antreapolicy_test.go
@@ -3167,7 +3167,7 @@ func testFQDNPolicy(t *testing.T) {
 	log.SetLevel(log.TraceLevel)
 	defer log.SetLevel(logLevel)
 	builder := &ClusterNetworkPolicySpecBuilder{}
-	builder = builder.SetName("test-acnp-reject-all-github").
+	builder = builder.SetName("test-acnp-fqdn").
 		SetTier("application").
 		SetPriority(1.0).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{NSSelector: map[string]string{}}})
@@ -3181,7 +3181,10 @@ func testFQDNPolicy(t *testing.T) {
 	// See https://github.com/antrea-io/antrea/issues/4130 for more details.
 	builder.AddFQDNRule("*github.com", ProtocolTCP, nil, nil, nil, "r1", nil, crdv1alpha1.RuleActionReject)
 	builder.AddFQDNRule("wayfair.com", ProtocolTCP, nil, nil, nil, "r2", nil, crdv1alpha1.RuleActionDrop)
+	// Test upper-case FQDN.
+	builder.AddFQDNRule("Stackoverflow.com", ProtocolTCP, nil, nil, nil, "r3", nil, crdv1alpha1.RuleActionDrop)
 
+	// All client Pods below are randomly chosen from test Namespaces.
 	testcases := []podToAddrTestStep{
 		{
 			Pod(namespaces["x"] + "/a"),
@@ -3203,6 +3206,12 @@ func testFQDNPolicy(t *testing.T) {
 		},
 		{
 			Pod(namespaces["y"] + "/b"),
+			"stackoverflow.com",
+			80,
+			Dropped,
+		},
+		{
+			Pod(namespaces["z"] + "/a"),
 			"facebook.com",
 			80,
 			Connected,


### PR DESCRIPTION
Cherry pick of #4934 on release-1.10.

#4934: Fix FQDN upper-case issue

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.