### PR TITLE
Automated cherry pick of #4946: Run modules that rely on Services after AntreaProxy is ready

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -643,7 +643,6 @@ func run(o *Options) error {
 
 	go antreaClientProvider.Run(ctx)
 
-	go networkPolicyController.Run(stopCh)
 	// Initialize the NPL agent.
 	if enableNodePortLocal {
 		nplController, err := npl.InitializeNPLAgent(
@@ -713,10 +712,6 @@ func run(o *Options) error {
 		go memberlistCluster.Run(stopCh)
 	}
 
-	if o.enableEgress {
-		go egressController.Run(stopCh)
-	}
-
 	if features.DefaultFeatureGate.Enabled(features.ServiceExternalIP) {
 		go externalIPController.Run(stopCh)
 	}
@@ -742,6 +737,14 @@ func run(o *Options) error {
 			klog.InfoS("AntreaProxy is ready")
 		}
 	}
+
+	// NetworkPolicyController and EgressController accesses the "antrea" Service via its ClusterIP.
+	// Run them after AntreaProxy is ready.
+	go networkPolicyController.Run(stopCh)
+	if o.enableEgress {
+		go egressController.Run(stopCh)
+	}
+
 	var mcastController *multicast.Controller
 	if multicastEnabled {
 		multicastSocket, err := multicast.CreateMulticastSocket()


### PR DESCRIPTION
Cherry pick of #4946 on release-1.11.

#4946: Run modules that rely on Services after AntreaProxy is ready

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.