### PR TITLE
Add Jenkins backup job on CI pipeline

### DIFF
--- a/ci/jenkins/jobs/macros.yaml
+++ b/ci/jenkins/jobs/macros.yaml
@@ -8,6 +8,13 @@
           rm ci/jenkins/jobs/defaults.yaml
 
 - builder:
+    name: builder-jenkins-backup
+    builders:
+      - shell: |-
+          rdiff-backup ${{RDIFF_USERNAME}}@${{RDIFF_IP}}::${{RDIFF_PATH}} backup
+          rdiff-backup --remove-older-than 6M backup
+
+- builder:
     name: builder-eks-cluster-cleanup
     builders:
       - shell: |-

--- a/ci/jenkins/jobs/projects-lab.yaml
+++ b/ci/jenkins/jobs/projects-lab.yaml
@@ -20,6 +20,32 @@
           ignore_post_commit_hooks: false
           publishers: []
           wrappers: []
+      - '{name}-{test_name}-for-period':
+          test_name: jenkins-backup
+          node: 'backup-node'
+          description: 'This is for backing up all jenkins files.'
+          builders:
+            - builder-jenkins-backup
+          branches: []
+          included_regions: []
+          cron: 'H 0 1 * *'
+          ignore_post_commit_hooks: false
+          publishers: []
+          wrappers:
+          - timeout:
+              fail: true
+              timeout: 30
+              type: absolute
+          - credentials-binding:
+              - text:
+                  credential-id: RDIFF_USERNAME
+                  variable: RDIFF_USERNAME
+              - text:
+                  credential-id: RDIFF_IP
+                  variable: RDIFF_IP
+              - text:
+                  credential-id: RDIFF_PATH
+                  variable: RDIFF_PATH
       - '{name}-{test_name}-no-scm':
           test_name: flexible-ipam-e2e-pending-label
           node: null


### PR DESCRIPTION
This job utilizes the rdiff-backup tool to periodically back up all
configuration files of the Jenkins control node.