### PR TITLE
Whitelist twitter.com links in Markdown link checker config

### DIFF
--- a/hack/.md_links_config.json
+++ b/hack/.md_links_config.json
@@ -32,6 +32,9 @@
         },
         {
             "pattern": "https://suricata.io/"
+        },
+        {
+            "pattern": "https://twitter.com/*"
         }
     ],
     "retryOn429": false,


### PR DESCRIPTION
The check for https://twitter.com/ProjectAntrea has been failing, presumably because of some DDos mitigation service.