### PR TITLE
Support service.kubernetes.io/service-proxy-name label in AntreaProxy

### DIFF
--- a/build/charts/antrea/README.md
+++ b/build/charts/antrea/README.md
@@ -44,6 +44,7 @@ Kubernetes: `>= 1.16.0-0`
 | antreaProxy.nodePortAddresses | list | `[]` | String array of values which specifies the host IPv4/IPv6 addresses for NodePort. By default, all host addresses are used. |
 | antreaProxy.proxyAll | bool | `false` | Proxy all Service traffic, for all Service types, regardless of where it comes from. |
 | antreaProxy.proxyLoadBalancerIPs | bool | `true` | When set to false, AntreaProxy no longer load-balances traffic destined to the External IPs of LoadBalancer Services. |
+| antreaProxy.serviceProxyName | string | `""` | The value of the "service.kubernetes.io/service-proxy-name" label for AntreaProxy to match. If it is set, then AntreaProxy will only handle Services with the label that equals the provided value. If it is not set, then AntreaProxy will only handle Services without the "service.kubernetes.io/service-proxy-name" label, but ignore Services with the label no matter what is the value. |
 | antreaProxy.skipServices | list | `[]` | List of Services which should be ignored by AntreaProxy. |
 | clientCAFile | string | `""` | File path of the certificate bundle for all the signers that is recognized for incoming client certificates. |
 | cni.hostBinPath | string | `"/opt/cni/bin"` | Installation path of CNI binaries on the host. |

--- a/build/charts/antrea/conf/antrea-agent.conf
+++ b/build/charts/antrea/conf/antrea-agent.conf
@@ -342,6 +342,11 @@ antreaProxy:
   # Note that setting ProxyLoadBalancerIPs to false usually only makes sense when ProxyAll is set to true and
   # kube-proxy is removed from the cluser, otherwise kube-proxy will still load-balance this traffic.
   proxyLoadBalancerIPs: {{ .proxyLoadBalancerIPs }}
+  # The value of the "service.kubernetes.io/service-proxy-name" label for AntreaProxy to match. If it is set,
+  # then AntreaProxy will only handle Services with the label that equals the provided value. If it is not set,
+  # then AntreaProxy will only handle Services without the "service.kubernetes.io/service-proxy-name" label,
+  # but ignore Services with the label no matter what is the value.
+  serviceProxyName: {{ .serviceProxyName | quote }}
 {{- end }}
 
 # IPsec tunnel related configurations.

--- a/build/charts/antrea/values.yaml
+++ b/build/charts/antrea/values.yaml
@@ -135,6 +135,12 @@ antreaProxy:
   # -- When set to false, AntreaProxy no longer load-balances traffic destined
   # to the External IPs of LoadBalancer Services.
   proxyLoadBalancerIPs: true
+  # -- The value of the "service.kubernetes.io/service-proxy-name" label for
+  # AntreaProxy to match. If it is set, then AntreaProxy will only handle Services
+  # with the label that equals the provided value. If it is not set, then AntreaProxy
+  # will only handle Services without the "service.kubernetes.io/service-proxy-name"
+  # label, but ignore Services with the label no matter what is the value.
+  serviceProxyName: ""
 
 nodeIPAM:
   # -- Enable Node IPAM in Antrea

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -3291,6 +3291,11 @@ data:
       # Note that setting ProxyLoadBalancerIPs to false usually only makes sense when ProxyAll is set to true and
       # kube-proxy is removed from the cluser, otherwise kube-proxy will still load-balance this traffic.
       proxyLoadBalancerIPs: true
+      # The value of the "service.kubernetes.io/service-proxy-name" label for AntreaProxy to match. If it is set,
+      # then AntreaProxy will only handle Services with the label that equals the provided value. If it is not set,
+      # then AntreaProxy will only handle Services without the "service.kubernetes.io/service-proxy-name" label,
+      # but ignore Services with the label no matter what is the value.
+      serviceProxyName: ""
 
     # IPsec tunnel related configurations.
     ipsec:
@@ -4380,7 +4385,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 994e75167f0126a535cea63fc65a5ab86361648a20bcacb06d3c588f06f6e5f6
+        checksum/config: 720e2b412e83992caf5874a01e67507617e079b896796e588c92fd75c9e06ad6
       labels:
         app: antrea
         component: antrea-agent
@@ -4621,7 +4626,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 994e75167f0126a535cea63fc65a5ab86361648a20bcacb06d3c588f06f6e5f6
+        checksum/config: 720e2b412e83992caf5874a01e67507617e079b896796e588c92fd75c9e06ad6
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -3291,6 +3291,11 @@ data:
       # Note that setting ProxyLoadBalancerIPs to false usually only makes sense when ProxyAll is set to true and
       # kube-proxy is removed from the cluser, otherwise kube-proxy will still load-balance this traffic.
       proxyLoadBalancerIPs: true
+      # The value of the "service.kubernetes.io/service-proxy-name" label for AntreaProxy to match. If it is set,
+      # then AntreaProxy will only handle Services with the label that equals the provided value. If it is not set,
+      # then AntreaProxy will only handle Services without the "service.kubernetes.io/service-proxy-name" label,
+      # but ignore Services with the label no matter what is the value.
+      serviceProxyName: ""
 
     # IPsec tunnel related configurations.
     ipsec:
@@ -4380,7 +4385,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 994e75167f0126a535cea63fc65a5ab86361648a20bcacb06d3c588f06f6e5f6
+        checksum/config: 720e2b412e83992caf5874a01e67507617e079b896796e588c92fd75c9e06ad6
       labels:
         app: antrea
         component: antrea-agent
@@ -4622,7 +4627,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 994e75167f0126a535cea63fc65a5ab86361648a20bcacb06d3c588f06f6e5f6
+        checksum/config: 720e2b412e83992caf5874a01e67507617e079b896796e588c92fd75c9e06ad6
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -3291,6 +3291,11 @@ data:
       # Note that setting ProxyLoadBalancerIPs to false usually only makes sense when ProxyAll is set to true and
       # kube-proxy is removed from the cluser, otherwise kube-proxy will still load-balance this traffic.
       proxyLoadBalancerIPs: true
+      # The value of the "service.kubernetes.io/service-proxy-name" label for AntreaProxy to match. If it is set,
+      # then AntreaProxy will only handle Services with the label that equals the provided value. If it is not set,
+      # then AntreaProxy will only handle Services without the "service.kubernetes.io/service-proxy-name" label,
+      # but ignore Services with the label no matter what is the value.
+      serviceProxyName: ""
 
     # IPsec tunnel related configurations.
     ipsec:
@@ -4380,7 +4385,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 04761c3e699fa0f59516b557f366049b0f1acf2f390d94e6753ee017cdffcfd9
+        checksum/config: 46b91206a96d91e7e4861f20fa0e255ed660cf96e796116e562061efc09fdfcc
       labels:
         app: antrea
         component: antrea-agent
@@ -4619,7 +4624,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 04761c3e699fa0f59516b557f366049b0f1acf2f390d94e6753ee017cdffcfd9
+        checksum/config: 46b91206a96d91e7e4861f20fa0e255ed660cf96e796116e562061efc09fdfcc
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -3304,6 +3304,11 @@ data:
       # Note that setting ProxyLoadBalancerIPs to false usually only makes sense when ProxyAll is set to true and
       # kube-proxy is removed from the cluser, otherwise kube-proxy will still load-balance this traffic.
       proxyLoadBalancerIPs: true
+      # The value of the "service.kubernetes.io/service-proxy-name" label for AntreaProxy to match. If it is set,
+      # then AntreaProxy will only handle Services with the label that equals the provided value. If it is not set,
+      # then AntreaProxy will only handle Services without the "service.kubernetes.io/service-proxy-name" label,
+      # but ignore Services with the label no matter what is the value.
+      serviceProxyName: ""
 
     # IPsec tunnel related configurations.
     ipsec:
@@ -4393,7 +4398,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 6b902d5d6e9a2c0e2fde41aedf349eeee38d4530330381b01849815211ad1dd8
+        checksum/config: f7e797321f4228539c43945a503637bcabf4d4eee4f3d5393ba9e69a778a0916
         checksum/ipsec-secret: d0eb9c52d0cd4311b6d252a951126bf9bea27ec05590bed8a394f0f792dcb2a4
       labels:
         app: antrea
@@ -4678,7 +4683,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 6b902d5d6e9a2c0e2fde41aedf349eeee38d4530330381b01849815211ad1dd8
+        checksum/config: f7e797321f4228539c43945a503637bcabf4d4eee4f3d5393ba9e69a778a0916
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-windows.yml
+++ b/build/yamls/antrea-windows.yml
@@ -143,6 +143,11 @@ data:
       # Note that this option is experimental. If kube-proxy is removed, option kubeAPIServerOverride must be used to access
       # apiserver directly.
       #proxyAll: false
+      # The value of the "service.kubernetes.io/service-proxy-name" label for AntreaProxy to match. If it is set,
+      # then AntreaProxy will only handle Services with the label that equals the provided value. If it is not set,
+      # then AntreaProxy will only handle Services without the "service.kubernetes.io/service-proxy-name" label,
+      # but ignore Services with the label no matter what is the value.
+      serviceProxyName: ""
 
     nodePortLocal:
     # Enable NodePortLocal, a feature used to make Pods reachable using port forwarding on the host. To
@@ -172,7 +177,7 @@ kind: ConfigMap
 metadata:
   labels:
     app: antrea
-  name: antrea-windows-config-hth2gk6b96
+  name: antrea-windows-config-cmccc6hbb4
   namespace: kube-system
 ---
 apiVersion: apps/v1
@@ -260,7 +265,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-windows-config-hth2gk6b96
+          name: antrea-windows-config-cmccc6hbb4
         name: antrea-windows-config
       - configMap:
           defaultMode: 420

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -3291,6 +3291,11 @@ data:
       # Note that setting ProxyLoadBalancerIPs to false usually only makes sense when ProxyAll is set to true and
       # kube-proxy is removed from the cluser, otherwise kube-proxy will still load-balance this traffic.
       proxyLoadBalancerIPs: true
+      # The value of the "service.kubernetes.io/service-proxy-name" label for AntreaProxy to match. If it is set,
+      # then AntreaProxy will only handle Services with the label that equals the provided value. If it is not set,
+      # then AntreaProxy will only handle Services without the "service.kubernetes.io/service-proxy-name" label,
+      # but ignore Services with the label no matter what is the value.
+      serviceProxyName: ""
 
     # IPsec tunnel related configurations.
     ipsec:
@@ -4380,7 +4385,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 1bc87d7d5b568beb91ad2b29510cb5cff3613c68e51fb82abdf545046767f679
+        checksum/config: 520e5bfad080176d9e77896e35756f8f947a1777817847cad27c764ecf6e3bec
       labels:
         app: antrea
         component: antrea-agent
@@ -4619,7 +4624,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 1bc87d7d5b568beb91ad2b29510cb5cff3613c68e51fb82abdf545046767f679
+        checksum/config: 520e5bfad080176d9e77896e35756f8f947a1777817847cad27c764ecf6e3bec
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/windows/base/conf/antrea-agent.conf
+++ b/build/yamls/windows/base/conf/antrea-agent.conf
@@ -125,6 +125,11 @@ antreaProxy:
   # Note that this option is experimental. If kube-proxy is removed, option kubeAPIServerOverride must be used to access
   # apiserver directly.
   #proxyAll: false
+  # The value of the "service.kubernetes.io/service-proxy-name" label for AntreaProxy to match. If it is set,
+  # then AntreaProxy will only handle Services with the label that equals the provided value. If it is not set,
+  # then AntreaProxy will only handle Services without the "service.kubernetes.io/service-proxy-name" label,
+  # but ignore Services with the label no matter what is the value.
+  serviceProxyName: ""
 
 nodePortLocal:
 # Enable NodePortLocal, a feature used to make Pods reachable using port forwarding on the host. To

--- a/pkg/agent/proxy/service.go
+++ b/pkg/agent/proxy/service.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/record"
 
 	"antrea.io/antrea/pkg/agent/proxy/types"
@@ -31,8 +32,8 @@ type serviceChangesTracker struct {
 	initialized bool
 }
 
-func newServiceChangesTracker(recorder record.EventRecorder, ipFamily v1.IPFamily, skipServices []string) *serviceChangesTracker {
-	return &serviceChangesTracker{tracker: k8sproxy.NewServiceChangeTracker(types.NewServiceInfo, ipFamily, recorder, nil, skipServices)}
+func newServiceChangesTracker(recorder record.EventRecorder, ipFamily v1.IPFamily, serviceLabelSelector labels.Selector, skipServices []string) *serviceChangesTracker {
+	return &serviceChangesTracker{tracker: k8sproxy.NewServiceChangeTracker(types.NewServiceInfo, ipFamily, recorder, nil, serviceLabelSelector, skipServices)}
 }
 
 func (sh *serviceChangesTracker) OnServiceSynced() {

--- a/pkg/config/agent/config.go
+++ b/pkg/config/agent/config.go
@@ -218,6 +218,10 @@ type AntreaProxyConfig struct {
 	// kube-proxy is removed from the cluser, otherwise kube-proxy will still load-balance this traffic.
 	// Defaults to true.
 	ProxyLoadBalancerIPs *bool `yaml:"proxyLoadBalancerIPs,omitempty"`
+	// The value of service.kubernetes.io/service-proxy-name label for AntreaProxy to match. If it is set, then
+	// AntreaProxy only handles the Service objects matching this label. The default value is empty string, which
+	// means that AntreaProxy will manage all Service objects without the mentioned label.
+	ServiceProxyName string `yaml:"serviceProxyName,omitempty"`
 }
 
 type WireGuardConfig struct {


### PR DESCRIPTION
The service.kubernetes.io/service-proxy-name label was initially intended to offload
the kube-proxy from handling all Services already handled by a service mesh.
AntreaProxy should honor the service.kubernetes.io/service-proxy-name label, which
means that if the label is defined in a Service, AntreaProxy must not handle the
Service. Refer to this link https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/2447-Make-kube-proxy-service-abstraction-optional
for more information.