### PR TITLE
Fix GKE CI job

### DIFF
--- a/ci/jenkins/jobs/projects-cloud.yaml
+++ b/ci/jenkins/jobs/projects-cloud.yaml
@@ -723,7 +723,7 @@
               # gcloud auth login requires verification code from url
               ${{GCLOUD_PATH}} auth activate-service-account --key-file=${{GCLOUD_KEY_PATH}}
               sudo ./ci/test-conformance-gke.sh --cluster-name antrea-gke-${{BUILD_NUMBER}} \
-                --svc-account antrea-gcp@antrea.iam.gserviceaccount.com --gcloud-path ${{GCLOUD_PATH}} \
+                --svc-account antrea-gcp@antrea.iam.gserviceaccount.com --gcloud-sdk-path ${{GCLOUD_SDK_PATH}} \
                 --log-mode detail --setup-only
           triggers:
           - timed: H H */2 * *


### PR DESCRIPTION
The gke-gcloud-auth-plugin binary is now required (in addition to the main gcloud binary).

As a result, we make some changes to the test-conformance-gke.sh script. The script now takes a '--gcloud-sdk-path' flag, which points to the installation directory of the gcloud SDK. The bin directory from the SDK is then added to the path.

When running the script locally, one can omit the '--gcloud-sdk-path' flag, as long as the PATH already include the SDK bin directory (which is the default hen following standard installation instructions).