### PR TITLE
Fix Multicluster e2e test ScaleDownMCServiceEndpoints

### DIFF
--- a/multicluster/test/e2e/framework.go
+++ b/multicluster/test/e2e/framework.go
@@ -132,6 +132,15 @@ func (data *MCTestData) createTestNamespaces() error {
 	return nil
 }
 
+func (data *MCTestData) patchPod(clusterName, namespace, name string, patch []byte) error {
+	if d, ok := data.clusterTestDataMap[clusterName]; ok {
+		if err := d.PatchPod(namespace, name, patch); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (data *MCTestData) deletePod(clusterName, namespace, name string) error {
 	if d, ok := data.clusterTestDataMap[clusterName]; ok {
 		if err := d.DeletePod(namespace, name); err != nil {

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -1386,6 +1386,16 @@ func (data *TestData) createServerPodWithLabels(name, ns string, portNum int32, 
 	return NewPodBuilder(name, ns, agnhostImage).WithContainerName(containerName).WithCommand(cmd).WithEnv([]corev1.EnvVar{env}).WithPorts([]corev1.ContainerPort{port}).WithLabels(labels).Create(data)
 }
 
+func (data *TestData) PatchPod(namespace, name string, patch []byte) error {
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		_, err := data.clientset.CoreV1().Pods(namespace).Patch(context.TODO(), name, types.MergePatchType, patch, metav1.PatchOptions{})
+		return err
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
 // DeletePod deletes a Pod in the test namespace.
 func (data *TestData) DeletePod(namespace, name string) error {
 	var gracePeriodSeconds int64 = 5


### PR DESCRIPTION
The test didn't check if the test has been deleted entirely before proceeding, causing random failures.

The commit improves the test in the following ways:

1. Update the backend Pod's label to scale down and up the number of Endpoints to fix the above issue and speed up the test.
2. Check if desired state is reached with a periodical check instead of always waiting for a mount of time.
3. Ensure the change made by the test is reverted via a deferred call.