### PR TITLE
Fix flaky e2e tests

### DIFF
--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -104,36 +104,19 @@ func probeClientIPFromNode(node string, baseUrl string, data *TestData) (string,
 }
 
 func probeFromPod(data *TestData, pod, container string, url string) error {
-	var err error
-	if container == busyboxContainerName {
-		_, _, err = data.runWgetCommandOnBusyboxWithRetry(pod, data.testNamespace, url, 5)
-	} else {
-		_, _, err = data.RunCommandFromPod(data.testNamespace, pod, container, []string{"wget", "-O", "-", url, "-T", "5"})
-	}
+	_, _, err := data.runWgetCommandFromTestPodWithRetry(pod, data.testNamespace, container, url, 5)
 	return err
 }
 
 func probeHostnameFromPod(data *TestData, pod, container string, baseUrl string) (string, error) {
 	url := fmt.Sprintf("%s/%s", baseUrl, "hostname")
-	var err error
-	var hostname string
-	if container == busyboxContainerName {
-		hostname, _, err = data.runWgetCommandOnBusyboxWithRetry(pod, data.testNamespace, url, 5)
-	} else {
-		hostname, _, err = data.RunCommandFromPod(data.testNamespace, pod, container, []string{"wget", "-O", "-", url, "-T", "5"})
-	}
+	hostname, _, err := data.runWgetCommandFromTestPodWithRetry(pod, data.testNamespace, container, url, 5)
 	return hostname, err
 }
 
 func probeClientIPFromPod(data *TestData, pod, container string, baseUrl string) (string, error) {
 	url := fmt.Sprintf("%s/%s", baseUrl, "clientip")
-	var err error
-	var hostPort string
-	if container == busyboxContainerName {
-		hostPort, _, err = data.runWgetCommandOnBusyboxWithRetry(pod, data.testNamespace, url, 5)
-	} else {
-		hostPort, _, err = data.RunCommandFromPod(data.testNamespace, pod, container, []string{"wget", "-O", "-", url, "-T", "5"})
-	}
+	hostPort, _, err := data.runWgetCommandFromTestPodWithRetry(pod, data.testNamespace, container, url, 5)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
In e2e tests like TestProxyHairpinIPv4:

- A test Service is created
- A test Pod for the Service is created
- Probe the Service using code `data.RunCommandFromPod(data.testNamespace, pod, container, []string{"wget", "-O", "-", url, "-T", "5"})`

When using the command wget -O url -T 5 to connect to a Service without an Endpoint, which is implemented by AntreaProxy, a rejection message will be received, and no retry will be attempted. There is a chance that even if the test Pod is ready, the Service may not be fully synced, resulting in a rejection message and a failed test. This PR fixes the flaky test by adding retry logic.