### PR TITLE
Upgrade to go-ipfix v0.6.1

### DIFF
--- a/ci/kind/test-e2e-kind.sh
+++ b/ci/kind/test-e2e-kind.sh
@@ -152,7 +152,7 @@ COMMON_IMAGES_LIST=("registry.k8s.io/e2e-test-images/agnhost:2.29" \
                     "projects.registry.vmware.com/antrea/nginx:1.21.6-alpine" \
                     "projects.registry.vmware.com/antrea/perftool")
 
-FLOW_VISIBILITY_IMAGE_LIST=("projects.registry.vmware.com/antrea/ipfix-collector:v0.5.12" \
+FLOW_VISIBILITY_IMAGE_LIST=("projects.registry.vmware.com/antrea/ipfix-collector:v0.6.1" \
                             "projects.registry.vmware.com/antrea/theia-clickhouse-operator:0.18.2" \
                             "projects.registry.vmware.com/antrea/theia-metrics-exporter:0.18.2" \
                             "projects.registry.vmware.com/antrea/theia-clickhouse-server:21.11")

--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/stretchr/testify v1.8.2
 	github.com/ti-mo/conntrack v0.4.0
 	github.com/vishvananda/netlink v1.1.1-0.20211101163509-b10eb8fe5cf6
-	github.com/vmware/go-ipfix v0.6.0
+	github.com/vmware/go-ipfix v0.6.1
 	golang.org/x/crypto v0.9.0
 	golang.org/x/exp v0.0.0-20230321023759-10a507213a29
 	golang.org/x/mod v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -1151,8 +1151,8 @@ github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f h1:p4VB7kIXpOQvVn1ZaTIVp+3vuYAXFe3OJEvjbUYJLaA=
 github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
-github.com/vmware/go-ipfix v0.6.0 h1:AjMN54CHJ4LmUZsczSPy6TB9xaFngblh5pf2wyAllt8=
-github.com/vmware/go-ipfix v0.6.0/go.mod h1:ir9Rtu4v7Ks8IQwgjTyARzRNmcxn4KFfZde2SZpSLYA=
+github.com/vmware/go-ipfix v0.6.1 h1:6Gh4kuUkPwetEJ6dWxlz029qwgFBXtcYYVWuiqy0Zgo=
+github.com/vmware/go-ipfix v0.6.1/go.mod h1:dGCppoeqknr9o3yz9BD74mP/FPHgefb6v34xdUKxDPI=
 github.com/willf/bitset v1.1.11-0.20200630133818-d5bec3311243/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -127,7 +127,7 @@ const (
 	nginxImage          = "projects.registry.vmware.com/antrea/nginx:1.21.6-alpine"
 	iisImage            = "mcr.microsoft.com/windows/servercore/iis"
 	perftoolImage       = "projects.registry.vmware.com/antrea/perftool"
-	ipfixCollectorImage = "projects.registry.vmware.com/antrea/ipfix-collector:v0.5.12"
+	ipfixCollectorImage = "projects.registry.vmware.com/antrea/ipfix-collector:v0.6.1"
 	ipfixCollectorPort  = "4739"
 	clickHouseHTTPPort  = "8123"
 


### PR DESCRIPTION
go-ipfix v0.6.1 is a minor release with only setting a flow-aggregator log message with higher verbosity value. The logs themselves are harmless and showing up frequently. Logging them with the lowest verbosity value can be misleading. This has been noticed for a while, and has been brought up recently by users.