### PR TITLE
Archive test log dir only when there is a failure

### DIFF
--- a/ci/jenkins/test-mc.sh
+++ b/ci/jenkins/test-mc.sh
@@ -442,14 +442,12 @@ function run_multicluster_e2e {
     fi
 
     set -x
-    go test -v antrea.io/antrea/multicluster/test/e2e --logs-export-dir `pwd`/antrea-multicluster-test-logs $options
+    go test -v antrea.io/antrea/multicluster/test/e2e $options
     if [[ "$?" != "0" ]]; then
         TEST_FAILURE=true
     fi
     set +x
     set -e
-
-    tar -zcf antrea-test-logs.tar.gz antrea-multicluster-test-logs
 }
 
 function collect_coverage {

--- a/ci/jenkins/test-rancher.sh
+++ b/ci/jenkins/test-rancher.sh
@@ -212,10 +212,9 @@ function run_e2e {
     go test -v antrea.io/antrea/test/e2e --logs-export-dir `pwd`/antrea-test-logs --provider remote -remote.kubeconfig="$KUBECONFIG_PATH" -timeout=100m --prometheus
     if [[ "$?" != "0" ]]; then
         TEST_FAILURE=true
+        tar -zcf antrea-test-logs.tar.gz antrea-test-logs
     fi
     set -e
-
-    tar -zcf antrea-test-logs.tar.gz antrea-test-logs
 }
 
 function run_conformance {

--- a/ci/jenkins/test-vm.sh
+++ b/ci/jenkins/test-vm.sh
@@ -291,10 +291,9 @@ function run_e2e_vms {
     go test -v -timeout=100m antrea.io/antrea/test/e2e -run=TestVMAgent --logs-export-dir `pwd`/antrea-test-logs -provider=remote -windowsVMs="${WIN_HOSTNAMES[*]}" -linuxVMs="${LIN_HOSTNAMES[*]}"
     if [[ "$?" != "0" ]]; then
         TEST_FAILURE=true
+        tar -zcf antrea-test-logs.tar.gz antrea-test-logs
     fi
     set -e
-
-    tar -zcf antrea-test-logs.tar.gz antrea-test-logs
 }
 
 function build_antrea_binary {

--- a/ci/jenkins/test-vmc.sh
+++ b/ci/jenkins/test-vmc.sh
@@ -522,11 +522,11 @@ function run_e2e {
     if [[ "$test_rc" != "0" ]]; then
         echo "=== TEST FAILURE !!! ==="
         TEST_FAILURE=true
+        tar -zcf ${GIT_CHECKOUT_DIR}/antrea-test-logs.tar.gz ${GIT_CHECKOUT_DIR}/antrea-test-logs
     else
         echo "=== TEST SUCCESS !!! ==="
     fi
 
-    tar -zcf ${GIT_CHECKOUT_DIR}/antrea-test-logs.tar.gz ${GIT_CHECKOUT_DIR}/antrea-test-logs
     if [[ "$COVERAGE" == true ]]; then
         tar -zcf ${GIT_CHECKOUT_DIR}/e2e-coverage.tar.gz ${GIT_CHECKOUT_DIR}/e2e-coverage
         run_codecov "e2e-tests" "*.cov.out*" "${GIT_CHECKOUT_DIR}/e2e-coverage" false ""

--- a/ci/jenkins/test.sh
+++ b/ci/jenkins/test.sh
@@ -244,10 +244,12 @@ function collect_windows_network_info_and_logs {
 
         DOCKER_LOG_PATH="${DEBUG_LOG_PATH}/${NODENAME}/docker"
         mkdir "${DOCKER_LOG_PATH}"
-        scp -q -o StrictHostKeyChecking=no -T administrator@${IP}:'/cygdrive/c/"Program Files"/Docker/dockerd.log*' "${DOCKER_LOG_PATH}"
+        if [[ ${TESTCASE} =~ "containerd" ]];then
+            scp -q -o StrictHostKeyChecking=no -T administrator@${IP}:'/cygdrive/c/"Program Files"/Docker/dockerd.log*' "${DOCKER_LOG_PATH}"
+        fi
     done
     set -e
-    tar zcf debug_logs.tar.gz "${DEBUG_LOG_PATH}"
+    tar -zcf debug_logs.tar.gz "${DEBUG_LOG_PATH}"
 }
 
 function wait_for_antrea_windows_pods_ready {
@@ -719,10 +721,9 @@ function run_e2e {
     fi
     if [[ "$?" != "0" ]]; then
         TEST_FAILURE=true
+        tar -zcf antrea-test-logs.tar.gz antrea-test-logs
     fi
     set -e
-
-    tar -zcf antrea-test-logs.tar.gz antrea-test-logs
 }
 
 function run_conformance {
@@ -779,10 +780,9 @@ function run_e2e_windows {
     go test -v antrea.io/antrea/test/e2e --logs-export-dir `pwd`/antrea-test-logs --provider remote -timeout=50m --prometheus
     if [[ "$?" != "0" ]]; then
         TEST_FAILURE=true
+        tar -zcf antrea-test-logs.tar.gz antrea-test-logs
     fi
     set -e
-
-    tar -zcf antrea-test-logs.tar.gz antrea-test-logs
 }
 
 function run_conformance_windows {


### PR DESCRIPTION
1. antrea-test-logs will always be empty when the test succeeds unless we pass `--logs-export-on-success`, there
is unnecessary to archive an empty directory, so move the archive steps
inside of failure checks.
2. Skip collecting dockerd.log* if it's Containerd runtime to avoid unnecessary "file not found" failure log.