### PR TITLE
Do not fail a build if showing docker disk usage fails

### DIFF
--- a/ci/jenkins/test-vm.sh
+++ b/ci/jenkins/test-vm.sh
@@ -114,8 +114,11 @@ function clean_antrea {
     echo "====== Cleanup Antrea Installation ======"
     clean_up_one_ns $TEST_NAMESPACE
     kubectl delete -f ${WORKDIR}/antrea.yml --ignore-not-found=true
-    docker image prune -f --filter "until=1h" || true > /dev/null
+    # The cleanup and stats are best-effort.
+    set +e
+    docker image prune -f --filter "until=1h" > /dev/null
     docker system df -v
+    set -e
 }
 
 function apply_antrea {

--- a/ci/jenkins/test-vmc.sh
+++ b/ci/jenkins/test-vmc.sh
@@ -346,11 +346,16 @@ function deliver_antrea {
     export PATH=$GOROOT/bin:$PATH
 
     make clean -C $GIT_CHECKOUT_DIR
-    docker images | grep "${JOB_NAME}" | awk '{print $3}' | uniq | xargs -r docker rmi -f || true > /dev/null
+
+    # The cleanup and stats are best-effort.
+    set +e
+    docker images | grep "${JOB_NAME}" | awk '{print $3}' | uniq | xargs -r docker rmi -f > /dev/null
     # Clean up dangling images generated in previous builds. Recent ones must be excluded
     # because they might be being used in other builds running simultaneously.
-    docker image prune -f --filter "until=1h" || true > /dev/null
+    docker image prune -f --filter "until=1h" > /dev/null
     docker system df -v
+    set -e
+
     cd $GIT_CHECKOUT_DIR
     # Ensure that files in the Docker context have the correct permissions, or Docker caching cannot
     # be leveraged successfully

--- a/ci/test-conformance-aks.sh
+++ b/ci/test-conformance-aks.sh
@@ -183,13 +183,17 @@ function deliver_antrea_to_aks() {
         GIT_CHECKOUT_DIR=..
     fi
     make clean -C ${GIT_CHECKOUT_DIR}
+
+    # The cleanup and stats are best-effort.
+    set +e
     if [[ -n ${JOB_NAME+x} ]]; then
-        docker images | grep "${JOB_NAME}" | awk '{print $3}' | xargs -r docker rmi -f || true > /dev/null
+        docker images | grep "${JOB_NAME}" | awk '{print $3}' | xargs -r docker rmi -f > /dev/null
     fi
     # Clean up dangling images generated in previous builds. Recent ones must be excluded
     # because they might be being used in other builds running simultaneously.
-    docker image prune -f --filter "until=2h" || true > /dev/null
+    docker image prune -f --filter "until=2h" > /dev/null
     docker system df -v
+    set -e
 
     cd ${GIT_CHECKOUT_DIR}
     VERSION="$CLUSTER" make

--- a/ci/test-conformance-eks.sh
+++ b/ci/test-conformance-eks.sh
@@ -261,13 +261,16 @@ function deliver_antrea_to_eks() {
     export PATH=${GOROOT}/bin:$PATH
 
     make clean -C ${GIT_CHECKOUT_DIR}
+    # The cleanup and stats are best-effort.
+    set +e
     if [[ -n ${JOB_NAME+x} ]]; then
-        docker images | grep "${JOB_NAME}" | awk '{print $3}' | xargs -r docker rmi -f || true > /dev/null
+        docker images | grep "${JOB_NAME}" | awk '{print $3}' | xargs -r docker rmi -f > /dev/null
     fi
     # Clean up dangling images generated in previous builds. Recent ones must be excluded
     # because they might be being used in other builds running simultaneously.
-    docker image prune -f --filter "until=2h" || true > /dev/null
+    docker image prune -f --filter "until=2h" > /dev/null
     docker system df -v
+    set -e
 
     cd ${GIT_CHECKOUT_DIR}
     VERSION="$CLUSTER" make

--- a/ci/test-conformance-gke.sh
+++ b/ci/test-conformance-gke.sh
@@ -195,13 +195,16 @@ function deliver_antrea_to_gke() {
     export PATH=${GOROOT}/bin:$PATH
 
     make clean -C ${GIT_CHECKOUT_DIR}
+    # The cleanup and stats are best-effort.
+    set +e
     if [[ -n ${JOB_NAME+x} ]]; then
-        docker images | grep "${JOB_NAME}" | awk '{print $3}' | xargs -r docker rmi -f || true > /dev/null
+        docker images | grep "${JOB_NAME}" | awk '{print $3}' | xargs -r docker rmi -f > /dev/null
     fi
     # Clean up dangling images generated in previous builds. Recent ones must be excluded
     # because they might be being used in other builds running simultaneously.
-    docker image prune -f --filter "until=2h" || true > /dev/null
+    docker image prune -f --filter "until=2h" > /dev/null
     docker system df -v
+    set -e
 
     cd ${GIT_CHECKOUT_DIR}
     VERSION="$CLUSTER" make -C ${GIT_CHECKOUT_DIR}


### PR DESCRIPTION
The command returns error code when the operation is already running. Like we don't fail a build when pruning images fails, there is no point to fail a build when showing docker disk usage fails.