### PR TITLE
Automated cherry pick of #4992: Use LOCAL instead of CONTROLLER as the in_port of packet-out
#4986: Fix policy not being cleaned if a policy with the same name

### DIFF
--- a/pkg/agent/proxy/proxier.go
+++ b/pkg/agent/proxy/proxier.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"time"
 
+	"antrea.io/libOpenflow/openflow15"
 	"antrea.io/libOpenflow/protocol"
 	"antrea.io/ofnet/ofctrl"
 	corev1 "k8s.io/api/core/v1"
@@ -1034,12 +1035,15 @@ func (p *proxier) HandlePacketIn(pktIn *ofctrl.PacketIn) error {
 		return fmt.Errorf("error when getting match field inPort")
 	}
 	outPort := inPortField.GetValue().(uint32)
+	// It cannot use CONTROLLER (the default value when inPort is 0) as the inPort due to a bug in Windows ovsext
+	// driver, otherwise the Windows OS would crash. See https://github.com/openvswitch/ovs-issues/issues/280.
+	inPort := uint32(openflow15.P_LOCAL)
 	return openflow.SendRejectPacketOut(p.ofClient,
 		srcMAC,
 		dstMAC,
 		srcIP,
 		dstIP,
-		0,
+		inPort,
 		outPort,
 		isIPv6,
 		ethernetPkt,


### PR DESCRIPTION
Cherry pick of #4992 #4986 on release-1.11.

#4992: Use LOCAL instead of CONTROLLER as the in_port of packet-out
#4986: Fix policy not being cleaned if a policy with the same name

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.