### PR TITLE
Use the generic Set to fix golangci-lint issue

### DIFF
--- a/pkg/agent/openflow/network_policy_test.go
+++ b/pkg/agent/openflow/network_policy_test.go
@@ -538,9 +538,9 @@ func (m flowModIgnoreTxIDMatcher) Matches(x interface{}) bool {
 	if len(wanted) != len(m.flowMods) {
 		return false
 	}
-	sortFlows := func(flows []string) sets.String {
+	sortFlows := func(flows []string) sets.Set[string] {
 		sort.Strings(flows)
-		flowSet := sets.NewString()
+		flowSet := sets.New[string]()
 		getConjunctionID := func(conj string) int {
 			newStr := strings.ReplaceAll(conj, "conjunction(", "")
 			id, _ := strconv.Atoi(strings.Split(newStr, ",")[0])


### PR DESCRIPTION
Fix the golangci-lint issue:
SA1019: sets.String is deprecated: use generic Set instead