### PR TITLE
Graduate features from Alpha to Beta

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -124,8 +124,9 @@ jobs:
         path: log.tar.gz
         retention-days: 30
 
-  test-e2e-encap-no-proxy:
-    name: E2e tests on a Kind cluster on Linux with AntreaProxy disabled
+  test-e2e-encap-non-default:
+    # NodeIPAM=true cannot run with proxyAll enabled due to https://github.com/antrea-io/antrea/issues/5022.
+    name: E2e tests on a Kind cluster on Linux with non default values (AntreaProxy=false, NodeIPAM=true)
     needs: [build-antrea-coverage-image]
     runs-on: [ubuntu-latest]
     steps:
@@ -153,15 +154,15 @@ jobs:
     - name: Run e2e tests
       run: |
         mkdir log
-        mkdir test-e2e-encap-no-proxy-coverage
-        ANTREA_LOG_DIR=$PWD/log ANTREA_COV_DIR=$PWD/test-e2e-encap-no-proxy-coverage ./ci/kind/test-e2e-kind.sh --encap-mode encap --feature-gates AntreaProxy=false --coverage --skip mode-irrelevant
+        mkdir test-e2e-encap-non-default-coverage
+        ANTREA_LOG_DIR=$PWD/log ANTREA_COV_DIR=$PWD/test-e2e-encap-non-default-coverage ./ci/kind/test-e2e-kind.sh --encap-mode encap --feature-gates AntreaProxy=false --node-ipam --coverage
     - name: Tar coverage files
-      run: tar -czf test-e2e-encap-no-proxy-coverage.tar.gz test-e2e-encap-no-proxy-coverage
-    - name: Upload coverage for test-e2e-encap-no-proxy-coverage
+      run: tar -czf test-e2e-encap-non-default-coverage.tar.gz test-e2e-encap-non-default-coverage
+    - name: Upload coverage for test-e2e-encap-non-default-coverage
       uses: actions/upload-artifact@v3
       with:
-        name: test-e2e-encap-no-proxy-coverage
-        path: test-e2e-encap-no-proxy-coverage.tar.gz
+        name: test-e2e-encap-non-default-coverage
+        path: test-e2e-encap-non-default-coverage.tar.gz
         retention-days: 30
     - name: Codecov
       uses: codecov/codecov-action@v3
@@ -169,8 +170,8 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: '*.cov.out*'
         flags: kind-e2e-tests
-        name: codecov-test-e2e-encap-no-proxy
-        directory: test-e2e-encap-no-proxy-coverage
+        name: codecov-test-e2e-encap-non-default
+        directory: test-e2e-encap-non-default-coverage
         fail_ci_if_error: ${{ github.event_name == 'push' }}
     - name: Tar log files
       if: ${{ failure() }}
@@ -179,7 +180,7 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ failure() }}
       with:
-        name: e2e-kind-encap-no-proxy.tar.gz
+        name: e2e-kind-encap-non-default.tar.gz
         path: log.tar.gz
         retention-days: 30
 
@@ -214,8 +215,7 @@ jobs:
           mkdir log
           mkdir test-e2e-encap-all-features-enabled-coverage
           # FlowExporter requires the FlowAggregator, so we keep it disabled.
-          # Currently multicast tests require specific testbeds, exclude it for now.
-          ANTREA_LOG_DIR=$PWD/log ANTREA_COV_DIR=$PWD/test-e2e-encap-all-features-enabled-coverage ./ci/kind/test-e2e-kind.sh --encap-mode encap --coverage --feature-gates AllAlpha=true,AllBeta=true,FlowExporter=false,Multicast=false --proxy-all
+          ANTREA_LOG_DIR=$PWD/log ANTREA_COV_DIR=$PWD/test-e2e-encap-all-features-enabled-coverage ./ci/kind/test-e2e-kind.sh --encap-mode encap --coverage --feature-gates AllAlpha=true,AllBeta=true,FlowExporter=false --proxy-all --multicast
       - name: Tar coverage files
         run: tar -czf test-e2e-encap-all-features-enabled-coverage.tar.gz test-e2e-encap-all-features-enabled-coverage
       - name: Upload coverage for test-e2e-encap-all-features-enabled-coverage
@@ -634,7 +634,7 @@ jobs:
     - build-antrea-coverage-image
     - build-flow-aggregator-coverage-image
     - test-e2e-encap
-    - test-e2e-encap-no-proxy
+    - test-e2e-encap-non-default
     - test-e2e-encap-all-features-enabled
     - test-e2e-noencap
     - test-e2e-hybrid

--- a/build/charts/antrea/README.md
+++ b/build/charts/antrea/README.md
@@ -83,6 +83,7 @@ Kubernetes: `>= 1.16.0-0`
 | ipsec.psk | string | `"changeme"` | Preshared Key (PSK) for IKE authentication. It will be stored in a secret and passed to antrea-agent as an environment variable. |
 | kubeAPIServerOverride | string | `""` | Address of Kubernetes apiserver, to override any value provided in kubeconfig or InClusterConfig. |
 | logVerbosity | int | `0` | Global log verbosity switch for all Antrea components. |
+| multicast.enable | bool | `false` | To enable Multicast, you need to set "enable" to true, and ensure that the Multicast feature gate is also enabled (which is the default). |
 | multicast.igmpQueryInterval | string | `"125s"` | The interval at which the antrea-agent sends IGMP queries to Pods. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". |
 | multicast.igmpQueryVersions | list | `[1,2,3]` | The versions of IGMP queries antrea-agent sends to Pods. Valid versions are 1, 2 and 3. |
 | multicast.multicastInterfaces | list | `[]` | Names of the interfaces on Nodes that are used to forward multicast traffic. |

--- a/build/charts/antrea/conf/antrea-agent.conf
+++ b/build/charts/antrea/conf/antrea-agent.conf
@@ -18,7 +18,7 @@ featureGates:
 
 # Enable TopologyAwareHints in AntreaProxy. This requires AntreaProxy and EndpointSlice to be
 # enabled, otherwise this flag will not take effect.
-{{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "TopologyAwareHints" "default" false) }}
+{{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "TopologyAwareHints" "default" true) }}
 
 # Enable traceflow which provides packet tracing feature to diagnose network issue.
 {{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "Traceflow" "default" true) }}
@@ -47,7 +47,7 @@ featureGates:
 {{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "AntreaIPAM" "default" false) }}
 
 # Enable multicast traffic.
-{{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "Multicast" "default" false) }}
+{{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "Multicast" "default" true) }}
 
 # Enable Antrea Multi-cluster features.
 {{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "Multicluster" "default" false) }}
@@ -267,20 +267,26 @@ transportInterface: {{ .Values.transportInterface | quote }}
 
 multicast:
 {{- with .Values.multicast }}
-# The names of the interfaces on Nodes that are used to forward multicast traffic.
-# Defaults to transport interface if not set.
+  # To enable Multicast, you need to set "enable" to true, and ensure that the
+  # Multicast feature gate is also enabled (which is the default).
+  enable: {{ .enable }}
+
+  # The names of the interfaces on Nodes that are used to forward multicast traffic.
+  # Defaults to transport interface if not set.
   multicastInterfaces:
   {{- with .multicastInterfaces }}
   {{- toYaml . | nindent 4 }}
   {{- end }}
-# The versions of IGMP queries antrea-agent sends to Pods.
-# Valid versions are 1, 2 and 3.
+
+  # The versions of IGMP queries antrea-agent sends to Pods.
+  # Valid versions are 1, 2 and 3.
   igmpQueryVersions:
   {{- with .igmpQueryVersions }}
   {{- toYaml . | nindent 4 }}
   {{- end }}
-# The interval at which the antrea-agent sends IGMP queries to Pods.
-# Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+
+  # The interval at which the antrea-agent sends IGMP queries to Pods.
+  # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
   igmpQueryInterval: {{ .igmpQueryInterval | quote }}
 {{- end}}
 

--- a/build/charts/antrea/conf/antrea-controller.conf
+++ b/build/charts/antrea/conf/antrea-controller.conf
@@ -18,13 +18,13 @@ featureGates:
 {{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "NetworkPolicyStats" "default" true) }}
 
 # Enable multicast traffic.
-{{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "Multicast" "default" false) }}
+{{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "Multicast" "default" true) }}
 
 # Enable controlling SNAT IPs of Pod egress traffic.
 {{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "Egress" "default" true) }}
 
 # Run Kubernetes NodeIPAMController with Antrea.
-{{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "NodeIPAM" "default" false) }}
+{{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "NodeIPAM" "default" true) }}
 
 # Enable AntreaIPAM, which can allocate IP addresses from IPPools. AntreaIPAM is required by the
 # bridging mode and allocates IPs to Pods in bridging mode. It is also required to use Antrea for

--- a/build/charts/antrea/values.yaml
+++ b/build/charts/antrea/values.yaml
@@ -48,6 +48,9 @@ transportInterface: ""
 transportInterfaceCIDRs: []
 
 multicast:
+  # -- To enable Multicast, you need to set "enable" to true, and ensure that the
+  # Multicast feature gate is also enabled (which is the default).
+  enable: false
   # -- Names of the interfaces on Nodes that are used to forward multicast traffic.
   multicastInterfaces: []
   # -- The versions of IGMP queries antrea-agent sends to Pods.

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -2991,7 +2991,7 @@ data:
 
     # Enable TopologyAwareHints in AntreaProxy. This requires AntreaProxy and EndpointSlice to be
     # enabled, otherwise this flag will not take effect.
-    #  TopologyAwareHints: false
+    #  TopologyAwareHints: true
 
     # Enable traceflow which provides packet tracing feature to diagnose network issue.
     #  Traceflow: true
@@ -3020,7 +3020,7 @@ data:
     #  AntreaIPAM: false
 
     # Enable multicast traffic.
-    #  Multicast: false
+    #  Multicast: true
 
     # Enable Antrea Multi-cluster features.
     #  Multicluster: false
@@ -3230,17 +3230,23 @@ data:
     transportInterface: ""
 
     multicast:
-    # The names of the interfaces on Nodes that are used to forward multicast traffic.
-    # Defaults to transport interface if not set.
+      # To enable Multicast, you need to set "enable" to true, and ensure that the
+      # Multicast feature gate is also enabled (which is the default).
+      enable: false
+
+      # The names of the interfaces on Nodes that are used to forward multicast traffic.
+      # Defaults to transport interface if not set.
       multicastInterfaces:
-    # The versions of IGMP queries antrea-agent sends to Pods.
-    # Valid versions are 1, 2 and 3.
+
+      # The versions of IGMP queries antrea-agent sends to Pods.
+      # Valid versions are 1, 2 and 3.
       igmpQueryVersions:
       - 1
       - 2
       - 3
-    # The interval at which the antrea-agent sends IGMP queries to Pods.
-    # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+
+      # The interval at which the antrea-agent sends IGMP queries to Pods.
+      # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
       igmpQueryInterval: "125s"
 
     # The network CIDRs of the interface on Node which is used for tunneling or routing the traffic across
@@ -3350,13 +3356,13 @@ data:
     #  NetworkPolicyStats: true
 
     # Enable multicast traffic.
-    #  Multicast: false
+    #  Multicast: true
 
     # Enable controlling SNAT IPs of Pod egress traffic.
     #  Egress: true
 
     # Run Kubernetes NodeIPAMController with Antrea.
-    #  NodeIPAM: false
+    #  NodeIPAM: true
 
     # Enable AntreaIPAM, which can allocate IP addresses from IPPools. AntreaIPAM is required by the
     # bridging mode and allocates IPs to Pods in bridging mode. It is also required to use Antrea for
@@ -4358,7 +4364,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 7240f8d038a3365cd3167184c2d2df87d689002074cdb38db8e8b48cb4c6794b
+        checksum/config: 7b3f20e4be884c2def359ef222cf07498761ff76b66e893d9afa325761354c9f
       labels:
         app: antrea
         component: antrea-agent
@@ -4599,7 +4605,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 7240f8d038a3365cd3167184c2d2df87d689002074cdb38db8e8b48cb4c6794b
+        checksum/config: 7b3f20e4be884c2def359ef222cf07498761ff76b66e893d9afa325761354c9f
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -2991,7 +2991,7 @@ data:
 
     # Enable TopologyAwareHints in AntreaProxy. This requires AntreaProxy and EndpointSlice to be
     # enabled, otherwise this flag will not take effect.
-    #  TopologyAwareHints: false
+    #  TopologyAwareHints: true
 
     # Enable traceflow which provides packet tracing feature to diagnose network issue.
     #  Traceflow: true
@@ -3020,7 +3020,7 @@ data:
     #  AntreaIPAM: false
 
     # Enable multicast traffic.
-    #  Multicast: false
+    #  Multicast: true
 
     # Enable Antrea Multi-cluster features.
     #  Multicluster: false
@@ -3230,17 +3230,23 @@ data:
     transportInterface: ""
 
     multicast:
-    # The names of the interfaces on Nodes that are used to forward multicast traffic.
-    # Defaults to transport interface if not set.
+      # To enable Multicast, you need to set "enable" to true, and ensure that the
+      # Multicast feature gate is also enabled (which is the default).
+      enable: false
+
+      # The names of the interfaces on Nodes that are used to forward multicast traffic.
+      # Defaults to transport interface if not set.
       multicastInterfaces:
-    # The versions of IGMP queries antrea-agent sends to Pods.
-    # Valid versions are 1, 2 and 3.
+
+      # The versions of IGMP queries antrea-agent sends to Pods.
+      # Valid versions are 1, 2 and 3.
       igmpQueryVersions:
       - 1
       - 2
       - 3
-    # The interval at which the antrea-agent sends IGMP queries to Pods.
-    # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+
+      # The interval at which the antrea-agent sends IGMP queries to Pods.
+      # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
       igmpQueryInterval: "125s"
 
     # The network CIDRs of the interface on Node which is used for tunneling or routing the traffic across
@@ -3350,13 +3356,13 @@ data:
     #  NetworkPolicyStats: true
 
     # Enable multicast traffic.
-    #  Multicast: false
+    #  Multicast: true
 
     # Enable controlling SNAT IPs of Pod egress traffic.
     #  Egress: true
 
     # Run Kubernetes NodeIPAMController with Antrea.
-    #  NodeIPAM: false
+    #  NodeIPAM: true
 
     # Enable AntreaIPAM, which can allocate IP addresses from IPPools. AntreaIPAM is required by the
     # bridging mode and allocates IPs to Pods in bridging mode. It is also required to use Antrea for
@@ -4358,7 +4364,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 7240f8d038a3365cd3167184c2d2df87d689002074cdb38db8e8b48cb4c6794b
+        checksum/config: 7b3f20e4be884c2def359ef222cf07498761ff76b66e893d9afa325761354c9f
       labels:
         app: antrea
         component: antrea-agent
@@ -4600,7 +4606,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 7240f8d038a3365cd3167184c2d2df87d689002074cdb38db8e8b48cb4c6794b
+        checksum/config: 7b3f20e4be884c2def359ef222cf07498761ff76b66e893d9afa325761354c9f
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -2991,7 +2991,7 @@ data:
 
     # Enable TopologyAwareHints in AntreaProxy. This requires AntreaProxy and EndpointSlice to be
     # enabled, otherwise this flag will not take effect.
-    #  TopologyAwareHints: false
+    #  TopologyAwareHints: true
 
     # Enable traceflow which provides packet tracing feature to diagnose network issue.
     #  Traceflow: true
@@ -3020,7 +3020,7 @@ data:
     #  AntreaIPAM: false
 
     # Enable multicast traffic.
-    #  Multicast: false
+    #  Multicast: true
 
     # Enable Antrea Multi-cluster features.
     #  Multicluster: false
@@ -3230,17 +3230,23 @@ data:
     transportInterface: ""
 
     multicast:
-    # The names of the interfaces on Nodes that are used to forward multicast traffic.
-    # Defaults to transport interface if not set.
+      # To enable Multicast, you need to set "enable" to true, and ensure that the
+      # Multicast feature gate is also enabled (which is the default).
+      enable: false
+
+      # The names of the interfaces on Nodes that are used to forward multicast traffic.
+      # Defaults to transport interface if not set.
       multicastInterfaces:
-    # The versions of IGMP queries antrea-agent sends to Pods.
-    # Valid versions are 1, 2 and 3.
+
+      # The versions of IGMP queries antrea-agent sends to Pods.
+      # Valid versions are 1, 2 and 3.
       igmpQueryVersions:
       - 1
       - 2
       - 3
-    # The interval at which the antrea-agent sends IGMP queries to Pods.
-    # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+
+      # The interval at which the antrea-agent sends IGMP queries to Pods.
+      # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
       igmpQueryInterval: "125s"
 
     # The network CIDRs of the interface on Node which is used for tunneling or routing the traffic across
@@ -3350,13 +3356,13 @@ data:
     #  NetworkPolicyStats: true
 
     # Enable multicast traffic.
-    #  Multicast: false
+    #  Multicast: true
 
     # Enable controlling SNAT IPs of Pod egress traffic.
     #  Egress: true
 
     # Run Kubernetes NodeIPAMController with Antrea.
-    #  NodeIPAM: false
+    #  NodeIPAM: true
 
     # Enable AntreaIPAM, which can allocate IP addresses from IPPools. AntreaIPAM is required by the
     # bridging mode and allocates IPs to Pods in bridging mode. It is also required to use Antrea for
@@ -4358,7 +4364,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: b9d4a6c2c34e7732b3e9de600d0a2aec8d45f27c0e40815610d4243164ac03e0
+        checksum/config: b7f4a912f5e4d42314ea1667b8e2f3d97a7666e7379ed4f65f9299a3f37399c2
       labels:
         app: antrea
         component: antrea-agent
@@ -4597,7 +4603,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: b9d4a6c2c34e7732b3e9de600d0a2aec8d45f27c0e40815610d4243164ac03e0
+        checksum/config: b7f4a912f5e4d42314ea1667b8e2f3d97a7666e7379ed4f65f9299a3f37399c2
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -3004,7 +3004,7 @@ data:
 
     # Enable TopologyAwareHints in AntreaProxy. This requires AntreaProxy and EndpointSlice to be
     # enabled, otherwise this flag will not take effect.
-    #  TopologyAwareHints: false
+    #  TopologyAwareHints: true
 
     # Enable traceflow which provides packet tracing feature to diagnose network issue.
     #  Traceflow: true
@@ -3033,7 +3033,7 @@ data:
     #  AntreaIPAM: false
 
     # Enable multicast traffic.
-    #  Multicast: false
+    #  Multicast: true
 
     # Enable Antrea Multi-cluster features.
     #  Multicluster: false
@@ -3243,17 +3243,23 @@ data:
     transportInterface: ""
 
     multicast:
-    # The names of the interfaces on Nodes that are used to forward multicast traffic.
-    # Defaults to transport interface if not set.
+      # To enable Multicast, you need to set "enable" to true, and ensure that the
+      # Multicast feature gate is also enabled (which is the default).
+      enable: false
+
+      # The names of the interfaces on Nodes that are used to forward multicast traffic.
+      # Defaults to transport interface if not set.
       multicastInterfaces:
-    # The versions of IGMP queries antrea-agent sends to Pods.
-    # Valid versions are 1, 2 and 3.
+
+      # The versions of IGMP queries antrea-agent sends to Pods.
+      # Valid versions are 1, 2 and 3.
       igmpQueryVersions:
       - 1
       - 2
       - 3
-    # The interval at which the antrea-agent sends IGMP queries to Pods.
-    # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+
+      # The interval at which the antrea-agent sends IGMP queries to Pods.
+      # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
       igmpQueryInterval: "125s"
 
     # The network CIDRs of the interface on Node which is used for tunneling or routing the traffic across
@@ -3363,13 +3369,13 @@ data:
     #  NetworkPolicyStats: true
 
     # Enable multicast traffic.
-    #  Multicast: false
+    #  Multicast: true
 
     # Enable controlling SNAT IPs of Pod egress traffic.
     #  Egress: true
 
     # Run Kubernetes NodeIPAMController with Antrea.
-    #  NodeIPAM: false
+    #  NodeIPAM: true
 
     # Enable AntreaIPAM, which can allocate IP addresses from IPPools. AntreaIPAM is required by the
     # bridging mode and allocates IPs to Pods in bridging mode. It is also required to use Antrea for
@@ -4371,7 +4377,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 70e72f54b904fdcd72a0664563a42da8772ea2e1527f7d01a95079fb01826bfd
+        checksum/config: d5789c48750f03a8652da56fc0e7f6cd4b12911fff41a84c8426245270fd5ec2
         checksum/ipsec-secret: d0eb9c52d0cd4311b6d252a951126bf9bea27ec05590bed8a394f0f792dcb2a4
       labels:
         app: antrea
@@ -4656,7 +4662,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 70e72f54b904fdcd72a0664563a42da8772ea2e1527f7d01a95079fb01826bfd
+        checksum/config: d5789c48750f03a8652da56fc0e7f6cd4b12911fff41a84c8426245270fd5ec2
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -2991,7 +2991,7 @@ data:
 
     # Enable TopologyAwareHints in AntreaProxy. This requires AntreaProxy and EndpointSlice to be
     # enabled, otherwise this flag will not take effect.
-    #  TopologyAwareHints: false
+    #  TopologyAwareHints: true
 
     # Enable traceflow which provides packet tracing feature to diagnose network issue.
     #  Traceflow: true
@@ -3020,7 +3020,7 @@ data:
     #  AntreaIPAM: false
 
     # Enable multicast traffic.
-    #  Multicast: false
+    #  Multicast: true
 
     # Enable Antrea Multi-cluster features.
     #  Multicluster: false
@@ -3230,17 +3230,23 @@ data:
     transportInterface: ""
 
     multicast:
-    # The names of the interfaces on Nodes that are used to forward multicast traffic.
-    # Defaults to transport interface if not set.
+      # To enable Multicast, you need to set "enable" to true, and ensure that the
+      # Multicast feature gate is also enabled (which is the default).
+      enable: false
+
+      # The names of the interfaces on Nodes that are used to forward multicast traffic.
+      # Defaults to transport interface if not set.
       multicastInterfaces:
-    # The versions of IGMP queries antrea-agent sends to Pods.
-    # Valid versions are 1, 2 and 3.
+
+      # The versions of IGMP queries antrea-agent sends to Pods.
+      # Valid versions are 1, 2 and 3.
       igmpQueryVersions:
       - 1
       - 2
       - 3
-    # The interval at which the antrea-agent sends IGMP queries to Pods.
-    # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+
+      # The interval at which the antrea-agent sends IGMP queries to Pods.
+      # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
       igmpQueryInterval: "125s"
 
     # The network CIDRs of the interface on Node which is used for tunneling or routing the traffic across
@@ -3350,13 +3356,13 @@ data:
     #  NetworkPolicyStats: true
 
     # Enable multicast traffic.
-    #  Multicast: false
+    #  Multicast: true
 
     # Enable controlling SNAT IPs of Pod egress traffic.
     #  Egress: true
 
     # Run Kubernetes NodeIPAMController with Antrea.
-    #  NodeIPAM: false
+    #  NodeIPAM: true
 
     # Enable AntreaIPAM, which can allocate IP addresses from IPPools. AntreaIPAM is required by the
     # bridging mode and allocates IPs to Pods in bridging mode. It is also required to use Antrea for
@@ -4358,7 +4364,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: aff9764ca12d8c32808cd0092d1093133f1aac942d17698c1eb744af990c6724
+        checksum/config: 1f7ec3f7c131b06c35ae624655ebbf81ca332c08abcfcddd434dd3c0a5387dab
       labels:
         app: antrea
         component: antrea-agent
@@ -4597,7 +4603,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: aff9764ca12d8c32808cd0092d1093133f1aac942d17698c1eb744af990c6724
+        checksum/config: 1f7ec3f7c131b06c35ae624655ebbf81ca332c08abcfcddd434dd3c0a5387dab
       labels:
         app: antrea
         component: antrea-controller

--- a/ci/jenkins/test.sh
+++ b/ci/jenkins/test.sh
@@ -1057,7 +1057,7 @@ if [[ $TESTBED_TYPE == "flexible-ipam" ]]; then
 fi
 
 if [[ $TESTCASE =~ "multicast" ]]; then
-    ./hack/generate-manifest.sh --multicast --multicast-interfaces "ens224" --extra-helm-values "multicast.igmpQueryInterval=10s" --verbose-log > build/yamls/antrea.yml
+    ./hack/generate-manifest.sh --encap-mode noEncap --multicast --multicast-interfaces "ens224" --verbose-log > build/yamls/antrea.yml
 fi
 
 clean_tmp

--- a/ci/kind/test-e2e-kind.sh
+++ b/ci/kind/test-e2e-kind.sh
@@ -28,6 +28,8 @@ _usage="Usage: $0 [--encap-mode <mode>] [--ip-family <v4|v6>] [--coverage] [--he
         --feature-gates               A comma-separated list of key=value pairs that describe feature gates, e.g. AntreaProxy=true,Egress=false.
         --run                         Run only tests matching the regexp.
         --proxy-all                   Enables Antrea proxy with all Service support.
+        --node-ipam                   Enables Antrea NodeIPAN.
+        --multicast                   Enables Multicast.
         --flow-visibility             Only run flow visibility related e2e tests.
         --skip                        A comma-separated list of keywords, with which tests should be skipped.
         --coverage                    Enables measure Antrea code coverage when run e2e tests on kind.
@@ -62,6 +64,8 @@ mode=""
 ipfamily="v4"
 feature_gates=""
 proxy_all=false
+node_ipam=false
+multicast=false
 flow_visibility=false
 coverage=false
 skiplist=""
@@ -84,6 +88,14 @@ case $key in
     ;;
     --proxy-all)
     proxy_all=true
+    shift
+    ;;
+    --node-ipam)
+    node_ipam=true
+    shift
+    ;;
+    --multicast)
+    multicast=true
     shift
     ;;
     --ip-family)
@@ -143,6 +155,12 @@ fi
 if $proxy_all; then
     manifest_args="$manifest_args --proxy-all"
 fi
+if $node_ipam; then
+    manifest_args="$manifest_args --extra-helm-values nodeIPAM.enable=true,nodeIPAM.clusterCIDRs={10.244.0.0/16}"
+fi
+if $multicast; then
+    manifest_args="$manifest_args --multicast"
+fi
 if $flow_visibility; then
     manifest_args="$manifest_args --feature-gates FlowExporter=true --extra-helm-values-file $FLOW_VISIBILITY_HELM_VALUES"
 fi
@@ -193,6 +211,9 @@ function setup_cluster {
   fi
   if $proxy_all; then
     args="$args --no-kube-proxy"
+  fi
+  if $node_ipam; then
+    args="$args --no-kube-node-ipam"
   fi
 
   echo "creating test bed with args $args"

--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -144,7 +144,7 @@ func run(o *Options) error {
 	ovsBridgeClient := ovsconfig.NewOVSBridge(o.config.OVSBridge, ovsDatapathType, ovsdbConnection)
 	ovsCtlClient := ovsctl.NewClient(o.config.OVSBridge)
 	ovsBridgeMgmtAddr := ofconfig.GetMgmtAddress(o.config.OVSRunDir, o.config.OVSBridge)
-	multicastEnabled := features.DefaultFeatureGate.Enabled(features.Multicast)
+	multicastEnabled := features.DefaultFeatureGate.Enabled(features.Multicast) && o.config.Multicast.Enable
 	ofClient := openflow.NewClient(o.config.OVSBridge, ovsBridgeMgmtAddr,
 		features.DefaultFeatureGate.Enabled(features.AntreaProxy),
 		features.DefaultFeatureGate.Enabled(features.AntreaPolicy),

--- a/cmd/antrea-agent/options.go
+++ b/cmd/antrea-agent/options.go
@@ -300,6 +300,8 @@ func (o *Options) validateMulticastConfig() error {
 			klog.InfoS("The multicastInterfaces option is deprecated, please use multicast.multicastInterfaces instead")
 			o.config.Multicast.MulticastInterfaces = o.config.MulticastInterfaces
 		}
+	} else if o.config.Multicast.Enable {
+		klog.InfoS("The multicast.enable config option is set to true, but it will be ignored because the Multicast feature gate is disabled")
 	}
 	return nil
 }

--- a/docs/antrea-ipam.md
+++ b/docs/antrea-ipam.md
@@ -47,20 +47,19 @@ cluster. Valid range is 16 to 30. Default is 24.
 - `nodeCIDRMaskSizeIPv6`: Mask size for IPv6 Node CIDR in IPv6 or dual-stack
 cluster. Valid range is 64 to 126. Default is 64.
 
-To enable NodeIPAM, you need to enable the `NodeIPAM` feature gate for
-`antrea-controller` with necessary configurations. Below is a sample of needed
-changes in the Antrea deployment YAML:
+Below is a sample of needed changes in the Antrea deployment YAML:
 
 ```yaml
   antrea-controller.conf: |
     ...
-    featureGates:
-      NodeIPAM: true
     nodeIPAM:
       enableNodeIPAM: true
       clusterCIDRs: [172.100.0.0/16]
     ...
 ```
+
+Note that, prior to v1.12, a feature gate, `NodeIPAM` must also be enabled for
+`antrea-controller`.
 
 ## Antrea Flexible IPAM
 

--- a/docs/feature-gates.md
+++ b/docs/feature-gates.md
@@ -33,19 +33,19 @@ edit the Agent configuration in the
 ## List of Available Features
 
 | Feature Name              | Component          | Default | Stage | Alpha Release | Beta Release | GA Release | Extra Requirements | Notes |
-|---------------------------|--------------------| ------- | ----- |---------------| ------------ | ---------- |--------------------| ----- |
+|---------------------------|--------------------|---------|-------|---------------|--------------| ---------- |--------------------| ----- |
 | `AntreaProxy`             | Agent              | `true`  | Beta  | v0.8          | v0.11        | N/A        | Yes                | Must be enabled for Windows. |
 | `EndpointSlice`           | Agent              | `true`  | Beta  | v0.13.0       | v1.11        | N/A        | Yes                |       |
-| `TopologyAwareHints`      | Agent              | `false` | Alpha | v1.8          | N/A          | N/A        | Yes                |       |
+| `TopologyAwareHints`      | Agent              | `true`  | Beta  | v1.8          | v1.12        | N/A        | Yes                |       |
 | `AntreaPolicy`            | Agent + Controller | `true`  | Beta  | v0.8          | v1.0         | N/A        | No                 | Agent side config required from v0.9.0+. |
 | `Traceflow`               | Agent + Controller | `true`  | Beta  | v0.8          | v0.11        | N/A        | Yes                |       |
 | `FlowExporter`            | Agent              | `false` | Alpha | v0.9          | N/A          | N/A        | Yes                |       |
 | `NetworkPolicyStats`      | Agent + Controller | `true`  | Beta  | v0.10         | v1.2         | N/A        | No                 |       |
 | `NodePortLocal`           | Agent              | `true`  | Beta  | v0.13         | v1.4         | N/A        | Yes                | Important user-facing change in v1.2.0 |
 | `Egress`                  | Agent + Controller | `true`  | Beta  | v1.0          | v1.6         | N/A        | Yes                |       |
-| `NodeIPAM`                | Controller         | `false` | Alpha | v1.4          | N/A          | N/A        | Yes                |       |
+| `NodeIPAM`                | Controller         | `true`  | Beta  | v1.4          | v1.12        | N/A        | Yes                |       |
 | `AntreaIPAM`              | Agent + Controller | `false` | Alpha | v1.4          | N/A          | N/A        | Yes                |       |
-| `Multicast`               | Agent              | `false` | Alpha | v1.5          | N/A          | N/A        | Yes                |       |
+| `Multicast`               | Agent + Controller | `true`  | Beta  | v1.5          | v1.12        | N/A        | Yes                |       |
 | `SecondaryNetwork`        | Agent              | `false` | Alpha | v1.5          | N/A          | N/A        | Yes                |       |
 | `ServiceExternalIP`       | Agent + Controller | `false` | Alpha | v1.5          | N/A          | N/A        | Yes                |       |
 | `TrafficControl`          | Agent              | `false` | Alpha | v1.7          | N/A          | N/A        | No                 |       |
@@ -271,7 +271,7 @@ network connectivity for these VLANs.
 ### Multicast
 
 The `Multicast` feature enables forwarding multicast traffic within the cluster network (i.e., between Pods) and between
-the external network and the cluster network.
+the external network and the cluster network. Refer to this [document](multicast-guide.md) for more information.
 
 #### Requirements for this Feature
 

--- a/docs/multicast-guide.md
+++ b/docs/multicast-guide.md
@@ -27,31 +27,32 @@ Antrea supports multicast traffic in the following scenarios:
 
 ## Prerequisites
 
-Multicast support is introduced in Antrea v1.5.0 as an alpha feature. The feature gate
-`Multicast` must be enabled in the `antrea-controller` and `antrea-agent`
-configuration to use the feature, and three new configuration options -
-`multicastInterfaces`, `igmpQueryVersions` and `igmpQueryInterval` parameters are added for `antrea-agent`.
+Multicast support was introduced in Antrea v1.5.0 as an alpha feature, and was graduated to
+beta in v1.12.0.
+
+* Prior to v1.12.0, a feature gate, `Multicast` must be enabled in the `antrea-controller`
+  and `antrea-agent` configuration to use the feature.
+* Starting from v1.12.0, the feature gate is enabled by default, you need to set the
+  `multicast.enable` flag to true in the `antrea-agent` configuration to use the feature.
+
+There are three other configuration options -`multicastInterfaces`, `igmpQueryVersions`,
+and `igmpQueryInterval` for `antrea-agent`.
 
 ```yaml
-  antrea-controller.conf: |
-    featureGates:
-    # Enable multicast traffic.
-      Multicast: true
   antrea-agent.conf: |
-    # Enable multicast traffic.
-      Multicast: true
     multicast:
-    # The names of the interfaces on Nodes that are used to forward multicast traffic.
-    # Defaults to transport interface if not set.
+      enable: true
+      # The names of the interfaces on Nodes that are used to forward multicast traffic.
+      # Defaults to transport interface if not set.
       multicastInterfaces: 
-    # The versions of IGMP queries antrea-agent sends to Pods.
-    # Valid versions are 1, 2 and 3.
+      # The versions of IGMP queries antrea-agent sends to Pods.
+      # Valid versions are 1, 2 and 3.
       igmpQueryVersions:
       - 1
       - 2
       - 3
-    # The interval at which the antrea-agent sends IGMP queries to Pods.
-    # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+      # The interval at which the antrea-agent sends IGMP queries to Pods.
+      # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
       igmpQueryInterval: "125s"
 ```
 

--- a/hack/generate-manifest.sh
+++ b/hack/generate-manifest.sh
@@ -264,7 +264,11 @@ if $FLEXIBLE_IPAM; then
 fi
 
 if $MULTICAST; then
-    HELM_VALUES+=("trafficEncapMode=noEncap" "featureGates.Multicast=true" "multicast.multicastInterfaces={$MULTICAST_INTERFACES}")
+    HELM_VALUES+=("multicast.enable=true")
+fi
+
+if $MULTICAST_INTERFACES; then
+    HELM_VALUES+=("multicast.multicastInterfaces={$MULTICAST_INTERFACES}")
 fi
 
 IFS=',' read -r -a feature_gates <<< "$FEATURE_GATES"
@@ -344,6 +348,9 @@ if [ "$MODE" == "dev" ]; then
     if $ON_DELETE; then
         HELM_VALUES+=("agent.updateStrategy.type=OnDelete")
     fi
+
+    # To reduce test wait time.
+    HELM_VALUES+=("multicast.igmpQueryInterval=10s")
 fi
 
 if [ "$MODE" == "release" ]; then

--- a/pkg/agent/apiserver/handlers/multicast/handler.go
+++ b/pkg/agent/apiserver/handlers/multicast/handler.go
@@ -17,11 +17,11 @@ package multicast
 import (
 	"encoding/json"
 	"net/http"
+	"reflect"
 	"strconv"
 
 	"antrea.io/antrea/pkg/agent/multicast"
 	"antrea.io/antrea/pkg/antctl/transform/common"
-	"antrea.io/antrea/pkg/features"
 	"antrea.io/antrea/pkg/querier"
 )
 
@@ -45,7 +45,7 @@ func generateResponse(podName string, podNamespace string, trafficStats *multica
 // It will return Pod multicast traffic statistics for the local Node.
 func HandleFunc(mq querier.AgentMulticastInfoQuerier) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if !features.DefaultFeatureGate.Enabled(features.Multicast) {
+		if mq == nil || reflect.ValueOf(mq).IsNil() {
 			http.Error(w, "Multicast is not enabled", http.StatusServiceUnavailable)
 			return
 		}

--- a/pkg/apiserver/handlers/featuregates/handler.go
+++ b/pkg/apiserver/handlers/featuregates/handler.go
@@ -29,7 +29,7 @@ import (
 	"antrea.io/antrea/pkg/util/env"
 )
 
-var controllerGates = sets.New[string]("Traceflow", "AntreaPolicy", "Egress", "NetworkPolicyStats", "NodeIPAM", "ServiceExternalIP", "Multicluster")
+var controllerGates = sets.New[string]("Traceflow", "AntreaPolicy", "Egress", "NetworkPolicyStats", "NodeIPAM", "ServiceExternalIP", "Multicluster", "Multicast")
 var agentGates = sets.New[string]("AntreaPolicy", "AntreaProxy", "Egress", "EndpointSlice", "Traceflow", "FlowExporter", "NetworkPolicyStats",
 	"NodePortLocal", "AntreaIPAM", "Multicast", "ServiceExternalIP", "Multicluster")
 

--- a/pkg/apiserver/handlers/featuregates/handler_test.go
+++ b/pkg/apiserver/handlers/featuregates/handler_test.go
@@ -33,8 +33,8 @@ import (
 )
 
 var (
-	egressStatus string
-	nplStatus    string
+	egressStatus    string
+	multicastStatus string
 )
 
 func Test_getGatesResponse(t *testing.T) {
@@ -59,8 +59,8 @@ func Test_getGatesResponse(t *testing.T) {
 				{Component: "agent", Name: "Traceflow", Status: "Enabled", Version: "BETA"},
 				{Component: "agent", Name: "FlowExporter", Status: "Disabled", Version: "ALPHA"},
 				{Component: "agent", Name: "NetworkPolicyStats", Status: "Enabled", Version: "BETA"},
-				{Component: "agent", Name: "NodePortLocal", Status: nplStatus, Version: "BETA"},
-				{Component: "agent", Name: "Multicast", Status: "Disabled", Version: "ALPHA"},
+				{Component: "agent", Name: "NodePortLocal", Status: "Enabled", Version: "BETA"},
+				{Component: "agent", Name: "Multicast", Status: multicastStatus, Version: "BETA"},
 				{Component: "agent", Name: "ServiceExternalIP", Status: "Disabled", Version: "ALPHA"},
 				{Component: "agent", Name: "Multicluster", Status: "Disabled", Version: "ALPHA"},
 			},
@@ -183,9 +183,10 @@ func Test_getControllerGatesResponse(t *testing.T) {
 				{Component: "controller", Name: "Egress", Status: egressStatus, Version: "BETA"},
 				{Component: "controller", Name: "Traceflow", Status: "Enabled", Version: "BETA"},
 				{Component: "controller", Name: "NetworkPolicyStats", Status: "Enabled", Version: "BETA"},
-				{Component: "controller", Name: "NodeIPAM", Status: "Disabled", Version: "ALPHA"},
+				{Component: "controller", Name: "NodeIPAM", Status: "Enabled", Version: "BETA"},
 				{Component: "controller", Name: "ServiceExternalIP", Status: "Disabled", Version: "ALPHA"},
 				{Component: "controller", Name: "Multicluster", Status: "Disabled", Version: "ALPHA"},
+				{Component: "controller", Name: "Multicast", Status: multicastStatus, Version: "BETA"},
 			},
 		},
 	}
@@ -207,8 +208,9 @@ func Test_getControllerGatesResponse(t *testing.T) {
 
 func init() {
 	egressStatus = "Enabled"
-	nplStatus = "Enabled"
+	multicastStatus = "Enabled"
 	if runtime.IsWindowsPlatform() {
 		egressStatus = "Disabled"
+		multicastStatus = "Disabled"
 	}
 }

--- a/pkg/config/agent/config.go
+++ b/pkg/config/agent/config.go
@@ -261,6 +261,9 @@ type NodePortLocalConfig struct {
 }
 
 type MulticastConfig struct {
+	// To enable Multicast, you need to set "enable" to true, and ensure that the
+	// Multicast feature gate is also enabled (which is the default).
+	Enable bool `yaml:"enable,omitempty"`
 	// The names of the interfaces on Nodes that are used to forward multicast traffic.
 	// Defaults to transport interface if not set.
 	MulticastInterfaces []string `yaml:"multicastInterfaces,omitempty"`

--- a/pkg/features/antrea_features.go
+++ b/pkg/features/antrea_features.go
@@ -43,6 +43,7 @@ const (
 	EndpointSlice featuregate.Feature = "EndpointSlice"
 
 	// alpha: v1.8
+	// beta: v1.12
 	// Enable TopologyAwareHints in AntreaProxy. If EndpointSlice is not enabled, this
 	// flag will not take effect.
 	TopologyAwareHints featuregate.Feature = "TopologyAwareHints"
@@ -79,6 +80,7 @@ const (
 	Egress featuregate.Feature = "Egress"
 
 	// alpha: v1.4
+	// beta: v1.12
 	// Run Kubernetes NodeIPAM with Antrea.
 	NodeIPAM featuregate.Feature = "NodeIPAM"
 
@@ -87,6 +89,7 @@ const (
 	AntreaIPAM featuregate.Feature = "AntreaIPAM"
 
 	// alpha: v1.5
+	// beta: v1.12
 	// Enable Multicast.
 	Multicast featuregate.Feature = "Multicast"
 
@@ -140,14 +143,14 @@ var (
 		AntreaProxy:             {Default: true, PreRelease: featuregate.Beta},
 		Egress:                  {Default: true, PreRelease: featuregate.Beta},
 		EndpointSlice:           {Default: true, PreRelease: featuregate.Beta},
-		TopologyAwareHints:      {Default: false, PreRelease: featuregate.Alpha},
+		TopologyAwareHints:      {Default: true, PreRelease: featuregate.Beta},
 		Traceflow:               {Default: true, PreRelease: featuregate.Beta},
 		AntreaIPAM:              {Default: false, PreRelease: featuregate.Alpha},
 		FlowExporter:            {Default: false, PreRelease: featuregate.Alpha},
 		NetworkPolicyStats:      {Default: true, PreRelease: featuregate.Beta},
 		NodePortLocal:           {Default: true, PreRelease: featuregate.Beta},
-		NodeIPAM:                {Default: false, PreRelease: featuregate.Alpha},
-		Multicast:               {Default: false, PreRelease: featuregate.Alpha},
+		NodeIPAM:                {Default: true, PreRelease: featuregate.Beta},
+		Multicast:               {Default: true, PreRelease: featuregate.Beta},
 		Multicluster:            {Default: false, PreRelease: featuregate.Alpha},
 		SecondaryNetwork:        {Default: false, PreRelease: featuregate.Alpha},
 		ServiceExternalIP:       {Default: false, PreRelease: featuregate.Alpha},

--- a/test/e2e/antreapolicy_test.go
+++ b/test/e2e/antreapolicy_test.go
@@ -4461,7 +4461,7 @@ func TestAntreaPolicy(t *testing.T) {
 	})
 
 	t.Run("TestMulticastNP", func(t *testing.T) {
-		skipIfMulticastDisabled(t)
+		skipIfMulticastDisabled(t, data)
 		t.Run("Case=MulticastNPIGMPQueryAllow", func(t *testing.T) { testACNPIGMPQueryAllow(t, data) })
 		t.Run("Case=MulticastNPIGMPQueryDrop", func(t *testing.T) { testACNPIGMPQueryDrop(t, data) })
 		t.Run("Case=MulticastNPPolicyEgressAllow", func(t *testing.T) { testACNPMulticastEgressAllow(t, data) })

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -123,6 +123,11 @@ func testMain(m *testing.M) int {
 	if err != nil {
 		log.Fatalf("Error when deploying Antrea: %v", err)
 	}
+	// Collect PodCIDRs after Antrea is running as Antrea is responsible for allocating PodCIDRs in some cases.
+	// Polling is not needed here because antrea-agents won't be up and running if PodCIDRs of their Nodes are not set.
+	if err = testData.collectPodCIDRs(); err != nil {
+		log.Fatalf("Error collecting PodCIDRs: %v", err)
+	}
 	AntreaConfigMap, err = testData.GetAntreaConfigMap(antreaNamespace)
 	if err != nil {
 		log.Fatalf("Error when getting antrea-config configmap: %v", err)


### PR DESCRIPTION
This patch graduates the following features from Alpha to Beta.

* Multicast: it has been verified with scale tests and has been patched with a number of fixes in the development cycle of release-1.12.
* TopologyAwareHints: most of its logic references the kube-proxy implementation.
* NodeIPAM: most of its logic references the kube-controller-manager imlementation. Note that it still requires the config parameter `enableNodeIPAM` to be true to run NodeIPAM, to avoid conflicts with kube-controller-manager which runs NodeIPAM in most cases.

Besides, it makes necessary changes to make NodeIPAM and Multicast e2e tests run on some kind testbeds.