### PR TITLE
Avoid ServiceCIDR flapping on agent start

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -222,6 +222,9 @@ func run(o *Options) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	// Must start after registering all event handlers.
+	go serviceCIDRProvider.Run(stopCh)
+
 	// Get all available NodePort addresses.
 	var nodePortAddressesIPv4, nodePortAddressesIPv6 []net.IP
 	if o.config.AntreaProxy.ProxyAll {

--- a/pkg/agent/route/route_linux.go
+++ b/pkg/agent/route/route_linux.go
@@ -41,6 +41,7 @@ import (
 	binding "antrea.io/antrea/pkg/ovs/openflow"
 	"antrea.io/antrea/pkg/ovs/ovsconfig"
 	"antrea.io/antrea/pkg/util/env"
+	utilip "antrea.io/antrea/pkg/util/ip"
 )
 
 const (
@@ -1363,7 +1364,22 @@ func (c *Client) addServiceCIDRRoute(serviceCIDR *net.IPNet) error {
 			return fmt.Errorf("error listing ip routes: %w", err)
 		}
 		for i := 0; i < len(routes); i++ {
-			if routes[i].Gw.Equal(gw) && !routes[i].Dst.IP.Equal(serviceCIDR.IP) && routes[i].Dst.Contains(serviceCIDR.IP) {
+			// Not the routes we are interested in.
+			if !routes[i].Gw.Equal(gw) {
+				continue
+			}
+			// It's the latest route we just installed.
+			if utilip.IPNetEqual(routes[i].Dst, serviceCIDR) {
+				continue
+			}
+			// The route covers the desired route. It was installed when the calculated ServiceCIDR was larger than the
+			// current one, which could happen after some Services are deleted.
+			if utilip.IPNetContains(routes[i].Dst, serviceCIDR) {
+				staleRoutes = append(staleRoutes, &routes[i])
+			}
+			// The desired route covers the route. It was installed when the calculated ServiceCIDR was smaller than the
+			// current one, which could happen after some Services are added.
+			if utilip.IPNetContains(serviceCIDR, routes[i].Dst) {
 				staleRoutes = append(staleRoutes, &routes[i])
 			}
 		}

--- a/pkg/util/ip/ip.go
+++ b/pkg/util/ip/ip.go
@@ -195,6 +195,49 @@ func MustParseCIDR(cidr string) *net.IPNet {
 	return ipNet
 }
 
+// IPNetEqual returns if the provided IPNets are the same subnet.
+func IPNetEqual(ipNet1, ipNet2 *net.IPNet) bool {
+	if ipNet1 == nil && ipNet2 == nil {
+		return true
+	}
+	if ipNet1 == nil || ipNet2 == nil {
+		return false
+	}
+	if !bytes.Equal(ipNet1.Mask, ipNet2.Mask) {
+		return false
+	}
+	if !ipNet1.IP.Equal(ipNet2.IP) {
+		return false
+	}
+	return true
+}
+
+// IPNetContains returns if the first IPNet contains the second IPNet.
+// For example:
+//
+// 10.0.0.0/24 contains 10.0.0.0/24.
+// 10.0.0.0/24 contains 10.0.0.0/25.
+// 10.0.0.0/24 contains 10.0.0.128/25.
+// 10.0.0.0/24 does not contain 10.0.0.0/23.
+// 10.0.0.0/24 does not contain 10.0.1.0/25.
+func IPNetContains(ipNet1, ipNet2 *net.IPNet) bool {
+	if ipNet1 == nil || ipNet2 == nil {
+		return false
+	}
+	ones1, bits1 := ipNet1.Mask.Size()
+	ones2, bits2 := ipNet2.Mask.Size()
+	if bits1 != bits2 {
+		return false
+	}
+	if ones1 > ones2 {
+		return false
+	}
+	if !ipNet1.Contains(ipNet2.IP) {
+		return false
+	}
+	return true
+}
+
 func MustIPv6(s string) net.IP {
 	ip := net.ParseIP(s)
 	if !utilnet.IsIPv6(ip) {

--- a/pkg/util/ip/ip_test.go
+++ b/pkg/util/ip/ip_test.go
@@ -239,3 +239,93 @@ func TestAppendPortIfMissing(t *testing.T) {
 		})
 	}
 }
+
+func TestIPNetEqual(t *testing.T) {
+	tests := []struct {
+		name   string
+		ipNet1 *net.IPNet
+		ipNet2 *net.IPNet
+		want   bool
+	}{
+		{
+			name:   "equal",
+			ipNet1: MustParseCIDR("1.1.1.0/30"),
+			ipNet2: MustParseCIDR("1.1.1.0/30"),
+			want:   true,
+		},
+		{
+			name:   "different mask",
+			ipNet1: MustParseCIDR("1.1.1.0/30"),
+			ipNet2: MustParseCIDR("1.1.1.0/29"),
+			want:   false,
+		},
+		{
+			name:   "different prefix",
+			ipNet1: MustParseCIDR("1.1.1.4/30"),
+			ipNet2: MustParseCIDR("1.1.1.0/30"),
+			want:   false,
+		},
+		{
+			name:   "different family",
+			ipNet1: MustParseCIDR("1.1.1.4/30"),
+			ipNet2: MustParseCIDR("1:1:1:4::/30"),
+			want:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IPNetEqual(tt.ipNet1, tt.ipNet2))
+		})
+	}
+}
+
+func TestIPNetContains(t *testing.T) {
+	tests := []struct {
+		name   string
+		ipNet1 *net.IPNet
+		ipNet2 *net.IPNet
+		want   bool
+	}{
+		{
+			name:   "equal",
+			ipNet1: MustParseCIDR("10.0.0.0/24"),
+			ipNet2: MustParseCIDR("10.0.0.0/24"),
+			want:   true,
+		},
+		{
+			name:   "contain smaller subnet",
+			ipNet1: MustParseCIDR("10.0.0.0/24"),
+			ipNet2: MustParseCIDR("10.0.0.0/25"),
+			want:   true,
+		},
+		{
+			name:   "contain smaller subnet with different prefix",
+			ipNet1: MustParseCIDR("10.0.0.0/24"),
+			ipNet2: MustParseCIDR("10.0.0.128/25"),
+			want:   true,
+		},
+		{
+			name:   "not contain larger subnet",
+			ipNet1: MustParseCIDR("10.0.0.0/24"),
+			ipNet2: MustParseCIDR("10.0.0.0/23"),
+			want:   false,
+		},
+		{
+			name:   "not contain smaller subnet with different prefix",
+			ipNet1: MustParseCIDR("10.0.0.0/24"),
+			ipNet2: MustParseCIDR("10.0.1.0/25"),
+			want:   false,
+		},
+		{
+			name:   "not contain subnet of different family",
+			ipNet1: MustParseCIDR("1.1.1.4/30"),
+			ipNet2: MustParseCIDR("1:1:1:4::/30"),
+			want:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IPNetContains(tt.ipNet1, tt.ipNet2))
+		})
+	}
+}


### PR DESCRIPTION
The previous implementation always generated intermediate values for ServiceCIDR on agent start, which may interrupt the Service traffic and causes difficulty for cleaning up stale routes as the value calculated at one point may not be reliable to identify all stale routes.

This commit waits for the Service Informer to be synced first, and calculates the ServiceCIDR based on all Services. Ideally the Service route won't change in most cases, and hence avoid the above issues.

Besides, it fixes an issue that stale routes on Linux were not cleaned up correctly due to incorrect check.