### PR TITLE
Add configuration toggle for FlowExporter

### DIFF
--- a/build/charts/antrea/README.md
+++ b/build/charts/antrea/README.md
@@ -71,10 +71,11 @@ Kubernetes: `>= 1.16.0-0`
 | egress.maxEgressIPsPerNode | int | `255` | The maximum number of Egress IPs that can be assigned to a Node. It's useful when the Node network restricts the number of secondary IPs a Node can have, e.g. EKS. It must not be greater than 255. |
 | enableBridgingMode | bool | `false` | Enable bridging mode of Pod network on Nodes, in which the Node's transport interface is connected to the OVS bridge. |
 | featureGates | object | `{}` | To explicitly enable or disable a FeatureGate and bypass the Antrea defaults, add an entry to the dictionary with the FeatureGate's name as the key and a boolean as the value. |
-| flowCollector.activeFlowExportTimeout | string | `"5s"` | timeout after which a flow record is sent to the collector for active flows. |
-| flowCollector.collectorAddr | string | `"flow-aggregator/flow-aggregator:4739:tls"` | IPFIX collector address as a string with format <HOST>:[<PORT>][:<PROTO>]. If the collector is running in-cluster as a Service, set <HOST> to <Service namespace>/<Service name>. |
-| flowCollector.flowPollInterval | string | `"5s"` | Determines how often the flow exporter polls for new connections. |
-| flowCollector.idleFlowExportTimeout | string | `"15s"` | timeout after which a flow record is sent to the collector for idle flows. |
+| flowExporter.activeFlowExportTimeout | string | `"5s"` | timeout after which a flow record is sent to the collector for active flows. |
+| flowExporter.enable | bool | `false` | Enable the flow exporter feature. |
+| flowExporter.flowCollectorAddr | string | `"flow-aggregator/flow-aggregator:4739:tls"` | IPFIX collector address as a string with format <HOST>:[<PORT>][:<PROTO>]. If the collector is running in-cluster as a Service, set <HOST> to <Service namespace>/<Service name>. |
+| flowExporter.flowPollInterval | string | `"5s"` | Determines how often the flow exporter polls for new connections. |
+| flowExporter.idleFlowExportTimeout | string | `"15s"` | timeout after which a flow record is sent to the collector for idle flows. |
 | hostGateway | string | `"antrea-gw0"` | Name of the interface antrea-agent will create and use for host <-> Pod communication. |
 | image | object | `{"pullPolicy":"IfNotPresent","repository":"antrea/antrea-ubuntu","tag":""}` | Container image to use for Antrea components. |
 | ipsec.authenticationMode | string | `"psk"` | The authentication mode to use for IPsec. Must be one of "psk" or "cert". |

--- a/build/charts/antrea/conf/antrea-agent.conf
+++ b/build/charts/antrea/conf/antrea-agent.conf
@@ -193,37 +193,46 @@ apiPort: {{ .Values.agent.apiPort }}
 # Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener.
 enablePrometheusMetrics: {{ .Values.agent.enablePrometheusMetrics }}
 
-# Provide the IPFIX collector address as a string with format <HOST>:[<PORT>][:<PROTO>].
-# HOST can either be the DNS name, IP, or Service name of the Flow Collector. If
-# using an IP, it can be either IPv4 or IPv6. However, IPv6 address should be
-# wrapped with []. When the collector is running in-cluster as a Service, set
-# <HOST> to <Service namespace>/<Service name>. For example,
-# "flow-aggregator/flow-aggregator" can be provided to connect to the Antrea
-# Flow Aggregator Service.
-# If PORT is empty, we default to 4739, the standard IPFIX port.
-# If no PROTO is given, we consider "tls" as default. We support "tls", "tcp" and
-# "udp" protocols. "tls" is used for securing communication between flow exporter and
-# flow aggregator.
-flowCollectorAddr: {{ .Values.flowCollector.collectorAddr | quote }}
 
-# Provide flow poll interval as a duration string. This determines how often the
-# flow exporter dumps connections from the conntrack module. Flow poll interval
-# should be greater than or equal to 1s (one second).
-# Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
-flowPollInterval: {{ .Values.flowCollector.flowPollInterval | quote }}
+flowExporter:
+  {{- with .Values.flowExporter }}
+  # Enable FlowExporter, a feature used to export polled conntrack connections as
+  # IPFIX flow records from each agent to a configured collector. To enable this
+  # feature, you need to set "enable" to true, and ensure that the FlowExporter
+  # feature gate is also enabled.
+  enable: {{ .enable }}
+  # Provide the IPFIX collector address as a string with format <HOST>:[<PORT>][:<PROTO>].
+  # HOST can either be the DNS name, IP, or Service name of the Flow Collector. If
+  # using an IP, it can be either IPv4 or IPv6. However, IPv6 address should be
+  # wrapped with []. When the collector is running in-cluster as a Service, set
+  # <HOST> to <Service namespace>/<Service name>. For example,
+  # "flow-aggregator/flow-aggregator" can be provided to connect to the Antrea
+  # Flow Aggregator Service.
+  # If PORT is empty, we default to 4739, the standard IPFIX port.
+  # If no PROTO is given, we consider "tls" as default. We support "tls", "tcp" and
+  # "udp" protocols. "tls" is used for securing communication between flow exporter and
+  # flow aggregator.
+  flowCollectorAddr: {{ .flowCollectorAddr | quote }}
 
-# Provide the active flow export timeout, which is the timeout after which a flow
-# record is sent to the collector for active flows. Thus, for flows with a continuous
-# stream of packets, a flow record will be exported to the collector once the elapsed
-# time since the last export event is equal to the value of this timeout.
-# Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
-activeFlowExportTimeout: {{ .Values.flowCollector.activeFlowExportTimeout | quote }}
+  # Provide flow poll interval as a duration string. This determines how often the
+  # flow exporter dumps connections from the conntrack module. Flow poll interval
+  # should be greater than or equal to 1s (one second).
+  # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+  flowPollInterval: {{ .flowPollInterval | quote }}
 
-# Provide the idle flow export timeout, which is the timeout after which a flow
-# record is sent to the collector for idle flows. A flow is considered idle if no
-# packet matching this flow has been observed since the last export event.
-# Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
-idleFlowExportTimeout: {{ .Values.flowCollector.idleFlowExportTimeout | quote }}
+  # Provide the active flow export timeout, which is the timeout after which a flow
+  # record is sent to the collector for active flows. Thus, for flows with a continuous
+  # stream of packets, a flow record will be exported to the collector once the elapsed
+  # time since the last export event is equal to the value of this timeout.
+  # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+  activeFlowExportTimeout: {{ .activeFlowExportTimeout | quote }}
+
+  # Provide the idle flow export timeout, which is the timeout after which a flow
+  # record is sent to the collector for idle flows. A flow is considered idle if no
+  # packet matching this flow has been observed since the last export event.
+  # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+  idleFlowExportTimeout: {{ .idleFlowExportTimeout | quote }}
+{{- end }}
 
 nodePortLocal:
 {{- with .Values.nodePortLocal }}

--- a/build/charts/antrea/values.yaml
+++ b/build/charts/antrea/values.yaml
@@ -298,11 +298,13 @@ controller:
       requests:
         cpu: "200m"
 
-flowCollector:
+flowExporter:
+  # -- Enable the flow exporter feature.
+  enable: false
   # -- IPFIX collector address as a string with format <HOST>:[<PORT>][:<PROTO>].
   # If the collector is running in-cluster as a Service, set <HOST> to
   # <Service namespace>/<Service name>.
-  collectorAddr: "flow-aggregator/flow-aggregator:4739:tls"
+  flowCollectorAddr: "flow-aggregator/flow-aggregator:4739:tls"
   # -- Determines how often the flow exporter polls for new connections.
   flowPollInterval: "5s"
   # -- timeout after which a flow record is sent to the collector for active

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -3159,37 +3159,44 @@ data:
     # Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener.
     enablePrometheusMetrics: true
 
-    # Provide the IPFIX collector address as a string with format <HOST>:[<PORT>][:<PROTO>].
-    # HOST can either be the DNS name, IP, or Service name of the Flow Collector. If
-    # using an IP, it can be either IPv4 or IPv6. However, IPv6 address should be
-    # wrapped with []. When the collector is running in-cluster as a Service, set
-    # <HOST> to <Service namespace>/<Service name>. For example,
-    # "flow-aggregator/flow-aggregator" can be provided to connect to the Antrea
-    # Flow Aggregator Service.
-    # If PORT is empty, we default to 4739, the standard IPFIX port.
-    # If no PROTO is given, we consider "tls" as default. We support "tls", "tcp" and
-    # "udp" protocols. "tls" is used for securing communication between flow exporter and
-    # flow aggregator.
-    flowCollectorAddr: "flow-aggregator/flow-aggregator:4739:tls"
 
-    # Provide flow poll interval as a duration string. This determines how often the
-    # flow exporter dumps connections from the conntrack module. Flow poll interval
-    # should be greater than or equal to 1s (one second).
-    # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
-    flowPollInterval: "5s"
+    flowExporter:
+      # Enable FlowExporter, a feature used to export polled conntrack connections as
+      # IPFIX flow records from each agent to a configured collector. To enable this
+      # feature, you need to set "enable" to true, and ensure that the FlowExporter
+      # feature gate is also enabled.
+      enable: false
+      # Provide the IPFIX collector address as a string with format <HOST>:[<PORT>][:<PROTO>].
+      # HOST can either be the DNS name, IP, or Service name of the Flow Collector. If
+      # using an IP, it can be either IPv4 or IPv6. However, IPv6 address should be
+      # wrapped with []. When the collector is running in-cluster as a Service, set
+      # <HOST> to <Service namespace>/<Service name>. For example,
+      # "flow-aggregator/flow-aggregator" can be provided to connect to the Antrea
+      # Flow Aggregator Service.
+      # If PORT is empty, we default to 4739, the standard IPFIX port.
+      # If no PROTO is given, we consider "tls" as default. We support "tls", "tcp" and
+      # "udp" protocols. "tls" is used for securing communication between flow exporter and
+      # flow aggregator.
+      flowCollectorAddr: "flow-aggregator/flow-aggregator:4739:tls"
 
-    # Provide the active flow export timeout, which is the timeout after which a flow
-    # record is sent to the collector for active flows. Thus, for flows with a continuous
-    # stream of packets, a flow record will be exported to the collector once the elapsed
-    # time since the last export event is equal to the value of this timeout.
-    # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
-    activeFlowExportTimeout: "5s"
+      # Provide flow poll interval as a duration string. This determines how often the
+      # flow exporter dumps connections from the conntrack module. Flow poll interval
+      # should be greater than or equal to 1s (one second).
+      # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+      flowPollInterval: "5s"
 
-    # Provide the idle flow export timeout, which is the timeout after which a flow
-    # record is sent to the collector for idle flows. A flow is considered idle if no
-    # packet matching this flow has been observed since the last export event.
-    # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
-    idleFlowExportTimeout: "15s"
+      # Provide the active flow export timeout, which is the timeout after which a flow
+      # record is sent to the collector for active flows. Thus, for flows with a continuous
+      # stream of packets, a flow record will be exported to the collector once the elapsed
+      # time since the last export event is equal to the value of this timeout.
+      # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+      activeFlowExportTimeout: "5s"
+
+      # Provide the idle flow export timeout, which is the timeout after which a flow
+      # record is sent to the collector for idle flows. A flow is considered idle if no
+      # packet matching this flow has been observed since the last export event.
+      # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+      idleFlowExportTimeout: "15s"
 
     nodePortLocal:
     # Enable NodePortLocal, a feature used to make Pods reachable using port forwarding on the host. To
@@ -4364,7 +4371,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 7b3f20e4be884c2def359ef222cf07498761ff76b66e893d9afa325761354c9f
+        checksum/config: abf7cb1c21b730664510e8a762d967df5c620467f12bf3e0bae41df73489de65
       labels:
         app: antrea
         component: antrea-agent
@@ -4605,7 +4612,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 7b3f20e4be884c2def359ef222cf07498761ff76b66e893d9afa325761354c9f
+        checksum/config: abf7cb1c21b730664510e8a762d967df5c620467f12bf3e0bae41df73489de65
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -3159,37 +3159,44 @@ data:
     # Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener.
     enablePrometheusMetrics: true
 
-    # Provide the IPFIX collector address as a string with format <HOST>:[<PORT>][:<PROTO>].
-    # HOST can either be the DNS name, IP, or Service name of the Flow Collector. If
-    # using an IP, it can be either IPv4 or IPv6. However, IPv6 address should be
-    # wrapped with []. When the collector is running in-cluster as a Service, set
-    # <HOST> to <Service namespace>/<Service name>. For example,
-    # "flow-aggregator/flow-aggregator" can be provided to connect to the Antrea
-    # Flow Aggregator Service.
-    # If PORT is empty, we default to 4739, the standard IPFIX port.
-    # If no PROTO is given, we consider "tls" as default. We support "tls", "tcp" and
-    # "udp" protocols. "tls" is used for securing communication between flow exporter and
-    # flow aggregator.
-    flowCollectorAddr: "flow-aggregator/flow-aggregator:4739:tls"
 
-    # Provide flow poll interval as a duration string. This determines how often the
-    # flow exporter dumps connections from the conntrack module. Flow poll interval
-    # should be greater than or equal to 1s (one second).
-    # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
-    flowPollInterval: "5s"
+    flowExporter:
+      # Enable FlowExporter, a feature used to export polled conntrack connections as
+      # IPFIX flow records from each agent to a configured collector. To enable this
+      # feature, you need to set "enable" to true, and ensure that the FlowExporter
+      # feature gate is also enabled.
+      enable: false
+      # Provide the IPFIX collector address as a string with format <HOST>:[<PORT>][:<PROTO>].
+      # HOST can either be the DNS name, IP, or Service name of the Flow Collector. If
+      # using an IP, it can be either IPv4 or IPv6. However, IPv6 address should be
+      # wrapped with []. When the collector is running in-cluster as a Service, set
+      # <HOST> to <Service namespace>/<Service name>. For example,
+      # "flow-aggregator/flow-aggregator" can be provided to connect to the Antrea
+      # Flow Aggregator Service.
+      # If PORT is empty, we default to 4739, the standard IPFIX port.
+      # If no PROTO is given, we consider "tls" as default. We support "tls", "tcp" and
+      # "udp" protocols. "tls" is used for securing communication between flow exporter and
+      # flow aggregator.
+      flowCollectorAddr: "flow-aggregator/flow-aggregator:4739:tls"
 
-    # Provide the active flow export timeout, which is the timeout after which a flow
-    # record is sent to the collector for active flows. Thus, for flows with a continuous
-    # stream of packets, a flow record will be exported to the collector once the elapsed
-    # time since the last export event is equal to the value of this timeout.
-    # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
-    activeFlowExportTimeout: "5s"
+      # Provide flow poll interval as a duration string. This determines how often the
+      # flow exporter dumps connections from the conntrack module. Flow poll interval
+      # should be greater than or equal to 1s (one second).
+      # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+      flowPollInterval: "5s"
 
-    # Provide the idle flow export timeout, which is the timeout after which a flow
-    # record is sent to the collector for idle flows. A flow is considered idle if no
-    # packet matching this flow has been observed since the last export event.
-    # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
-    idleFlowExportTimeout: "15s"
+      # Provide the active flow export timeout, which is the timeout after which a flow
+      # record is sent to the collector for active flows. Thus, for flows with a continuous
+      # stream of packets, a flow record will be exported to the collector once the elapsed
+      # time since the last export event is equal to the value of this timeout.
+      # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+      activeFlowExportTimeout: "5s"
+
+      # Provide the idle flow export timeout, which is the timeout after which a flow
+      # record is sent to the collector for idle flows. A flow is considered idle if no
+      # packet matching this flow has been observed since the last export event.
+      # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+      idleFlowExportTimeout: "15s"
 
     nodePortLocal:
     # Enable NodePortLocal, a feature used to make Pods reachable using port forwarding on the host. To
@@ -4364,7 +4371,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 7b3f20e4be884c2def359ef222cf07498761ff76b66e893d9afa325761354c9f
+        checksum/config: abf7cb1c21b730664510e8a762d967df5c620467f12bf3e0bae41df73489de65
       labels:
         app: antrea
         component: antrea-agent
@@ -4606,7 +4613,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 7b3f20e4be884c2def359ef222cf07498761ff76b66e893d9afa325761354c9f
+        checksum/config: abf7cb1c21b730664510e8a762d967df5c620467f12bf3e0bae41df73489de65
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -3159,37 +3159,44 @@ data:
     # Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener.
     enablePrometheusMetrics: true
 
-    # Provide the IPFIX collector address as a string with format <HOST>:[<PORT>][:<PROTO>].
-    # HOST can either be the DNS name, IP, or Service name of the Flow Collector. If
-    # using an IP, it can be either IPv4 or IPv6. However, IPv6 address should be
-    # wrapped with []. When the collector is running in-cluster as a Service, set
-    # <HOST> to <Service namespace>/<Service name>. For example,
-    # "flow-aggregator/flow-aggregator" can be provided to connect to the Antrea
-    # Flow Aggregator Service.
-    # If PORT is empty, we default to 4739, the standard IPFIX port.
-    # If no PROTO is given, we consider "tls" as default. We support "tls", "tcp" and
-    # "udp" protocols. "tls" is used for securing communication between flow exporter and
-    # flow aggregator.
-    flowCollectorAddr: "flow-aggregator/flow-aggregator:4739:tls"
 
-    # Provide flow poll interval as a duration string. This determines how often the
-    # flow exporter dumps connections from the conntrack module. Flow poll interval
-    # should be greater than or equal to 1s (one second).
-    # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
-    flowPollInterval: "5s"
+    flowExporter:
+      # Enable FlowExporter, a feature used to export polled conntrack connections as
+      # IPFIX flow records from each agent to a configured collector. To enable this
+      # feature, you need to set "enable" to true, and ensure that the FlowExporter
+      # feature gate is also enabled.
+      enable: false
+      # Provide the IPFIX collector address as a string with format <HOST>:[<PORT>][:<PROTO>].
+      # HOST can either be the DNS name, IP, or Service name of the Flow Collector. If
+      # using an IP, it can be either IPv4 or IPv6. However, IPv6 address should be
+      # wrapped with []. When the collector is running in-cluster as a Service, set
+      # <HOST> to <Service namespace>/<Service name>. For example,
+      # "flow-aggregator/flow-aggregator" can be provided to connect to the Antrea
+      # Flow Aggregator Service.
+      # If PORT is empty, we default to 4739, the standard IPFIX port.
+      # If no PROTO is given, we consider "tls" as default. We support "tls", "tcp" and
+      # "udp" protocols. "tls" is used for securing communication between flow exporter and
+      # flow aggregator.
+      flowCollectorAddr: "flow-aggregator/flow-aggregator:4739:tls"
 
-    # Provide the active flow export timeout, which is the timeout after which a flow
-    # record is sent to the collector for active flows. Thus, for flows with a continuous
-    # stream of packets, a flow record will be exported to the collector once the elapsed
-    # time since the last export event is equal to the value of this timeout.
-    # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
-    activeFlowExportTimeout: "5s"
+      # Provide flow poll interval as a duration string. This determines how often the
+      # flow exporter dumps connections from the conntrack module. Flow poll interval
+      # should be greater than or equal to 1s (one second).
+      # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+      flowPollInterval: "5s"
 
-    # Provide the idle flow export timeout, which is the timeout after which a flow
-    # record is sent to the collector for idle flows. A flow is considered idle if no
-    # packet matching this flow has been observed since the last export event.
-    # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
-    idleFlowExportTimeout: "15s"
+      # Provide the active flow export timeout, which is the timeout after which a flow
+      # record is sent to the collector for active flows. Thus, for flows with a continuous
+      # stream of packets, a flow record will be exported to the collector once the elapsed
+      # time since the last export event is equal to the value of this timeout.
+      # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+      activeFlowExportTimeout: "5s"
+
+      # Provide the idle flow export timeout, which is the timeout after which a flow
+      # record is sent to the collector for idle flows. A flow is considered idle if no
+      # packet matching this flow has been observed since the last export event.
+      # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+      idleFlowExportTimeout: "15s"
 
     nodePortLocal:
     # Enable NodePortLocal, a feature used to make Pods reachable using port forwarding on the host. To
@@ -4364,7 +4371,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: b7f4a912f5e4d42314ea1667b8e2f3d97a7666e7379ed4f65f9299a3f37399c2
+        checksum/config: e119a0592b2cef130a915258e9f23a8e4ed0aa28685841dc6f0d4b72a6983beb
       labels:
         app: antrea
         component: antrea-agent
@@ -4603,7 +4610,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: b7f4a912f5e4d42314ea1667b8e2f3d97a7666e7379ed4f65f9299a3f37399c2
+        checksum/config: e119a0592b2cef130a915258e9f23a8e4ed0aa28685841dc6f0d4b72a6983beb
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -3172,37 +3172,44 @@ data:
     # Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener.
     enablePrometheusMetrics: true
 
-    # Provide the IPFIX collector address as a string with format <HOST>:[<PORT>][:<PROTO>].
-    # HOST can either be the DNS name, IP, or Service name of the Flow Collector. If
-    # using an IP, it can be either IPv4 or IPv6. However, IPv6 address should be
-    # wrapped with []. When the collector is running in-cluster as a Service, set
-    # <HOST> to <Service namespace>/<Service name>. For example,
-    # "flow-aggregator/flow-aggregator" can be provided to connect to the Antrea
-    # Flow Aggregator Service.
-    # If PORT is empty, we default to 4739, the standard IPFIX port.
-    # If no PROTO is given, we consider "tls" as default. We support "tls", "tcp" and
-    # "udp" protocols. "tls" is used for securing communication between flow exporter and
-    # flow aggregator.
-    flowCollectorAddr: "flow-aggregator/flow-aggregator:4739:tls"
 
-    # Provide flow poll interval as a duration string. This determines how often the
-    # flow exporter dumps connections from the conntrack module. Flow poll interval
-    # should be greater than or equal to 1s (one second).
-    # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
-    flowPollInterval: "5s"
+    flowExporter:
+      # Enable FlowExporter, a feature used to export polled conntrack connections as
+      # IPFIX flow records from each agent to a configured collector. To enable this
+      # feature, you need to set "enable" to true, and ensure that the FlowExporter
+      # feature gate is also enabled.
+      enable: false
+      # Provide the IPFIX collector address as a string with format <HOST>:[<PORT>][:<PROTO>].
+      # HOST can either be the DNS name, IP, or Service name of the Flow Collector. If
+      # using an IP, it can be either IPv4 or IPv6. However, IPv6 address should be
+      # wrapped with []. When the collector is running in-cluster as a Service, set
+      # <HOST> to <Service namespace>/<Service name>. For example,
+      # "flow-aggregator/flow-aggregator" can be provided to connect to the Antrea
+      # Flow Aggregator Service.
+      # If PORT is empty, we default to 4739, the standard IPFIX port.
+      # If no PROTO is given, we consider "tls" as default. We support "tls", "tcp" and
+      # "udp" protocols. "tls" is used for securing communication between flow exporter and
+      # flow aggregator.
+      flowCollectorAddr: "flow-aggregator/flow-aggregator:4739:tls"
 
-    # Provide the active flow export timeout, which is the timeout after which a flow
-    # record is sent to the collector for active flows. Thus, for flows with a continuous
-    # stream of packets, a flow record will be exported to the collector once the elapsed
-    # time since the last export event is equal to the value of this timeout.
-    # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
-    activeFlowExportTimeout: "5s"
+      # Provide flow poll interval as a duration string. This determines how often the
+      # flow exporter dumps connections from the conntrack module. Flow poll interval
+      # should be greater than or equal to 1s (one second).
+      # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+      flowPollInterval: "5s"
 
-    # Provide the idle flow export timeout, which is the timeout after which a flow
-    # record is sent to the collector for idle flows. A flow is considered idle if no
-    # packet matching this flow has been observed since the last export event.
-    # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
-    idleFlowExportTimeout: "15s"
+      # Provide the active flow export timeout, which is the timeout after which a flow
+      # record is sent to the collector for active flows. Thus, for flows with a continuous
+      # stream of packets, a flow record will be exported to the collector once the elapsed
+      # time since the last export event is equal to the value of this timeout.
+      # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+      activeFlowExportTimeout: "5s"
+
+      # Provide the idle flow export timeout, which is the timeout after which a flow
+      # record is sent to the collector for idle flows. A flow is considered idle if no
+      # packet matching this flow has been observed since the last export event.
+      # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+      idleFlowExportTimeout: "15s"
 
     nodePortLocal:
     # Enable NodePortLocal, a feature used to make Pods reachable using port forwarding on the host. To
@@ -4377,7 +4384,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: d5789c48750f03a8652da56fc0e7f6cd4b12911fff41a84c8426245270fd5ec2
+        checksum/config: 373bbb8d6a42a8f3e546ea446fd078c04e947093e68e0c1c973f4c696bf8d607
         checksum/ipsec-secret: d0eb9c52d0cd4311b6d252a951126bf9bea27ec05590bed8a394f0f792dcb2a4
       labels:
         app: antrea
@@ -4662,7 +4669,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: d5789c48750f03a8652da56fc0e7f6cd4b12911fff41a84c8426245270fd5ec2
+        checksum/config: 373bbb8d6a42a8f3e546ea446fd078c04e947093e68e0c1c973f4c696bf8d607
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -3159,37 +3159,44 @@ data:
     # Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener.
     enablePrometheusMetrics: true
 
-    # Provide the IPFIX collector address as a string with format <HOST>:[<PORT>][:<PROTO>].
-    # HOST can either be the DNS name, IP, or Service name of the Flow Collector. If
-    # using an IP, it can be either IPv4 or IPv6. However, IPv6 address should be
-    # wrapped with []. When the collector is running in-cluster as a Service, set
-    # <HOST> to <Service namespace>/<Service name>. For example,
-    # "flow-aggregator/flow-aggregator" can be provided to connect to the Antrea
-    # Flow Aggregator Service.
-    # If PORT is empty, we default to 4739, the standard IPFIX port.
-    # If no PROTO is given, we consider "tls" as default. We support "tls", "tcp" and
-    # "udp" protocols. "tls" is used for securing communication between flow exporter and
-    # flow aggregator.
-    flowCollectorAddr: "flow-aggregator/flow-aggregator:4739:tls"
 
-    # Provide flow poll interval as a duration string. This determines how often the
-    # flow exporter dumps connections from the conntrack module. Flow poll interval
-    # should be greater than or equal to 1s (one second).
-    # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
-    flowPollInterval: "5s"
+    flowExporter:
+      # Enable FlowExporter, a feature used to export polled conntrack connections as
+      # IPFIX flow records from each agent to a configured collector. To enable this
+      # feature, you need to set "enable" to true, and ensure that the FlowExporter
+      # feature gate is also enabled.
+      enable: false
+      # Provide the IPFIX collector address as a string with format <HOST>:[<PORT>][:<PROTO>].
+      # HOST can either be the DNS name, IP, or Service name of the Flow Collector. If
+      # using an IP, it can be either IPv4 or IPv6. However, IPv6 address should be
+      # wrapped with []. When the collector is running in-cluster as a Service, set
+      # <HOST> to <Service namespace>/<Service name>. For example,
+      # "flow-aggregator/flow-aggregator" can be provided to connect to the Antrea
+      # Flow Aggregator Service.
+      # If PORT is empty, we default to 4739, the standard IPFIX port.
+      # If no PROTO is given, we consider "tls" as default. We support "tls", "tcp" and
+      # "udp" protocols. "tls" is used for securing communication between flow exporter and
+      # flow aggregator.
+      flowCollectorAddr: "flow-aggregator/flow-aggregator:4739:tls"
 
-    # Provide the active flow export timeout, which is the timeout after which a flow
-    # record is sent to the collector for active flows. Thus, for flows with a continuous
-    # stream of packets, a flow record will be exported to the collector once the elapsed
-    # time since the last export event is equal to the value of this timeout.
-    # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
-    activeFlowExportTimeout: "5s"
+      # Provide flow poll interval as a duration string. This determines how often the
+      # flow exporter dumps connections from the conntrack module. Flow poll interval
+      # should be greater than or equal to 1s (one second).
+      # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+      flowPollInterval: "5s"
 
-    # Provide the idle flow export timeout, which is the timeout after which a flow
-    # record is sent to the collector for idle flows. A flow is considered idle if no
-    # packet matching this flow has been observed since the last export event.
-    # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
-    idleFlowExportTimeout: "15s"
+      # Provide the active flow export timeout, which is the timeout after which a flow
+      # record is sent to the collector for active flows. Thus, for flows with a continuous
+      # stream of packets, a flow record will be exported to the collector once the elapsed
+      # time since the last export event is equal to the value of this timeout.
+      # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+      activeFlowExportTimeout: "5s"
+
+      # Provide the idle flow export timeout, which is the timeout after which a flow
+      # record is sent to the collector for idle flows. A flow is considered idle if no
+      # packet matching this flow has been observed since the last export event.
+      # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+      idleFlowExportTimeout: "15s"
 
     nodePortLocal:
     # Enable NodePortLocal, a feature used to make Pods reachable using port forwarding on the host. To
@@ -4364,7 +4371,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 1f7ec3f7c131b06c35ae624655ebbf81ca332c08abcfcddd434dd3c0a5387dab
+        checksum/config: 7e1d1a60a99fdbe25ff10b92e85ff234a5769c02bd9ae0ead56a3fe0a8ad118d
       labels:
         app: antrea
         component: antrea-agent
@@ -4603,7 +4610,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 1f7ec3f7c131b06c35ae624655ebbf81ca332c08abcfcddd434dd3c0a5387dab
+        checksum/config: 7e1d1a60a99fdbe25ff10b92e85ff234a5769c02bd9ae0ead56a3fe0a8ad118d
       labels:
         app: antrea
         component: antrea-controller

--- a/ci/kind/values-flow-exporter.yml
+++ b/ci/kind/values-flow-exporter.yml
@@ -1,4 +1,5 @@
-flowCollector:
+flowExporter:
+  enable: true
   flowPollInterval: "1s"
   activeFlowExportTimeout: "2s"
   idleFlowExportTimeout: "1s"

--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -150,7 +150,7 @@ func run(o *Options) error {
 		features.DefaultFeatureGate.Enabled(features.AntreaPolicy),
 		l7NetworkPolicyEnabled,
 		o.enableEgress,
-		features.DefaultFeatureGate.Enabled(features.FlowExporter),
+		features.DefaultFeatureGate.Enabled(features.FlowExporter) && o.config.FlowExporter.Enable,
 		o.config.AntreaProxy.ProxyAll,
 		connectUplinkToBridge,
 		multicastEnabled,
@@ -596,7 +596,7 @@ func run(o *Options) error {
 	}
 
 	var flowExporter *exporter.FlowExporter
-	if features.DefaultFeatureGate.Enabled(features.FlowExporter) {
+	if features.DefaultFeatureGate.Enabled(features.FlowExporter) && o.config.FlowExporter.Enable {
 		flowExporterOptions := &flowexporter.FlowExporterOptions{
 			FlowCollectorAddr:      o.flowCollectorAddr,
 			FlowCollectorProto:     o.flowCollectorProto,
@@ -859,7 +859,7 @@ func run(o *Options) error {
 	go ofClient.StartPacketInHandler(stopCh)
 
 	// Start the goroutine to periodically export IPFIX flow records.
-	if features.DefaultFeatureGate.Enabled(features.FlowExporter) {
+	if features.DefaultFeatureGate.Enabled(features.FlowExporter) && o.config.FlowExporter.Enable {
 		go flowExporter.Run(stopCh)
 	}
 

--- a/pkg/config/agent/config.go
+++ b/pkg/config/agent/config.go
@@ -133,43 +133,20 @@ type AgentConfig struct {
 	// Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener
 	// Defaults to true.
 	EnablePrometheusMetrics *bool `yaml:"enablePrometheusMetrics,omitempty"`
-	// Provide the IPFIX collector address as a string with format <HOST>:[<PORT>][:<PROTO>].
-	// HOST can either be the DNS name, IP, or Service name of the Flow Collector. If
-	// using an IP, it can be either IPv4 or IPv6. However, IPv6 address should be
-	// wrapped with []. When the collector is running in-cluster as a Service, set
-	// <HOST> to <Service namespace>/<Service name>. For example,
-	// "flow-aggregator/flow-aggregator" can be provided to connect to the Antrea
-	// Flow Aggregator Service.
-	// If PORT is empty, we default to 4739, the standard IPFIX port.
-	// If no PROTO is given, we consider "tcp" as default. We support "tcp" and
-	// "udp" L4 transport protocols.
-	// Defaults to "flow-aggregator/flow-aggregator:4739:tcp".
+	// Deprecated. Use the FlowExporter config options instead.
 	FlowCollectorAddr string `yaml:"flowCollectorAddr,omitempty"`
-	// Provide flow poll interval in format "0s". This determines how often flow
-	// exporter dumps connections in conntrack module. Flow poll interval should
-	// be greater than or equal to 1s(one second).
-	// Defaults to "5s". Valid time units are "ns", "us" (or "µs"), "ms", "s",
-	// "m", "h".
+	// Deprecated. Use the FlowExporter config options instead.
 	FlowPollInterval string `yaml:"flowPollInterval,omitempty"`
-	// Provide the active flow export timeout, which is the timeout after which
-	// a flow record is sent to the collector for active flows. Thus, for flows
-	// with a continuous stream of packets, a flow record will be exported to the
-	// collector once the elapsed time since the last export event is equal to the
-	// value of this timeout.
-	// Defaults to "30s". Valid time units are "ns", "us" (or "µs"), "ms", "s",
-	// "m", "h".
+	// Deprecated. Use the FlowExporter config options instead.
 	ActiveFlowExportTimeout string `yaml:"activeFlowExportTimeout,omitempty"`
-	// Provide the idle flow export timeout, which is the timeout after which a
-	// flow record is sent to the collector for idle flows. A flow is considered
-	// idle if no packet matching this flow has been observed since the last export
-	// event.
-	// Defaults to "15s". Valid time units are "ns", "us" (or "µs"), "ms", "s",
-	// "m", "h".
+	// Deprecated. Use the FlowExporter config options instead.
 	IdleFlowExportTimeout string `yaml:"idleFlowExportTimeout,omitempty"`
 	// Deprecated. Use the NodePortLocal config options instead.
 	NPLPortRange string `yaml:"nplPortRange,omitempty"`
 	// NodePortLocal (NPL) configuration options.
 	NodePortLocal NodePortLocalConfig `yaml:"nodePortLocal,omitempty"`
+	// FlowExporter configuration options.
+	FlowExporter FlowExporterConfig `yaml:"flowExporter,omitempty"`
 	// Provide the address of Kubernetes apiserver, to override any value provided in kubeconfig or InClusterConfig.
 	// Defaults to "". It must be a host string, a host:port pair, or a URL to the base of the apiserver.
 	KubeAPIServerOverride string `yaml:"kubeAPIServerOverride,omitempty"`
@@ -258,6 +235,47 @@ type NodePortLocalConfig struct {
 	// pod.spec.containers[].ports), and all Node traffic directed to that port will be
 	// forwarded to the Pod.
 	PortRange string `yaml:"portRange,omitempty"`
+}
+
+type FlowExporterConfig struct {
+	// Enable FlowExporter, a feature used to export polled conntrack connections as
+	// IPFIX flow records from each agent to a configured collector. To enable this
+	// feature, you need to set "enable" to true, and ensure that the FlowExporter
+	// feature gate is also enabled.
+	Enable bool `yaml:"enable,omitempty"`
+	// Provide the IPFIX collector address as a string with format <HOST>:[<PORT>][:<PROTO>].
+	// HOST can either be the DNS name, IP, or Service name of the Flow Collector. If
+	// using an IP, it can be either IPv4 or IPv6. However, IPv6 address should be
+	// wrapped with []. When the collector is running in-cluster as a Service, set
+	// <HOST> to <Service namespace>/<Service name>. For example,
+	// "flow-aggregator/flow-aggregator" can be provided to connect to the Antrea
+	// Flow Aggregator Service.
+	// If PORT is empty, we default to 4739, the standard IPFIX port.
+	// If no PROTO is given, we consider "tcp" as default. We support "tcp" and
+	// "udp" L4 transport protocols.
+	// Defaults to "flow-aggregator/flow-aggregator:4739:tcp".
+	FlowCollectorAddr string `yaml:"flowCollectorAddr,omitempty"`
+	// Provide flow poll interval in format "0s". This determines how often flow
+	// exporter dumps connections in conntrack module. Flow poll interval should
+	// be greater than or equal to 1s(one second).
+	// Defaults to "5s". Valid time units are "ns", "us" (or "µs"), "ms", "s",
+	// "m", "h".
+	FlowPollInterval string `yaml:"flowPollInterval,omitempty"`
+	// Provide the active flow export timeout, which is the timeout after which
+	// a flow record is sent to the collector for active flows. Thus, for flows
+	// with a continuous stream of packets, a flow record will be exported to the
+	// collector once the elapsed time since the last export event is equal to the
+	// value of this timeout.
+	// Defaults to "30s". Valid time units are "ns", "us" (or "µs"), "ms", "s",
+	// "m", "h".
+	ActiveFlowExportTimeout string `yaml:"activeFlowExportTimeout,omitempty"`
+	// Provide the idle flow export timeout, which is the timeout after which a
+	// flow record is sent to the collector for idle flows. A flow is considered
+	// idle if no packet matching this flow has been observed since the last export
+	// event.
+	// Defaults to "15s". Valid time units are "ns", "us" (or "µs"), "ms", "s",
+	// "m", "h".
+	IdleFlowExportTimeout string `yaml:"idleFlowExportTimeout,omitempty"`
 }
 
 type MulticastConfig struct {


### PR DESCRIPTION
Adding configuration toggle for flow exporter to prevent antrea agent from showing error in log, which happens when user enable flow exporter feature gate without installing flow aggregator.

Fixes [#4953](https://github.com/antrea-io/antrea/issues/4953)
Signed-off-by: Yun-Tang Hsu <hsuy@vmware.com>