### PR TITLE
Use -n to test if MULTICAST_INTERFACES is not empty

### DIFF
--- a/hack/generate-manifest.sh
+++ b/hack/generate-manifest.sh
@@ -267,7 +267,7 @@ if $MULTICAST; then
     HELM_VALUES+=("multicast.enable=true")
 fi
 
-if $MULTICAST_INTERFACES; then
+if [ -n "$MULTICAST_INTERFACES" ]; then
     HELM_VALUES+=("multicast.multicastInterfaces={$MULTICAST_INTERFACES}")
 fi
 


### PR DESCRIPTION
```
if $MULTICAST_INTERFACES; then ...
```
will raise the error `./hack/generate-manifest.sh: line 270: ens224: command not found`