### PR TITLE
Fix hack/make-metrics-doc.sh on macOS

### DIFF
--- a/ci/kind/validate-metrics-doc.sh
+++ b/ci/kind/validate-metrics-doc.sh
@@ -18,7 +18,8 @@
 
 set -eo pipefail
 
-METRICS_TMP_DOC=$(mktemp /tmp/metricsdoc.XXXXXX.md)
+# mktemp on macOS does not not support a suffix (file extension in the template)
+METRICS_TMP_DOC=$(mktemp /tmp/metricsdoc.XXXXXX)
 
 function exit_handler() {
     echo "Cleaning up..."

--- a/hack/make-metrics-doc.sh
+++ b/hack/make-metrics-doc.sh
@@ -62,20 +62,20 @@ function get_metrics_url() {
 function format_metrics() {
         sorted_metrics=$1
         # Gather list of metric names
-        metrics_types_unarranged=$(awk '/# TYPE/{print $3}' <<< $sorted_metrics)
+        metrics_types_unarranged=$(awk '/# TYPE/{print $3}' <<< "$sorted_metrics")
         # Put Antrea-specific metrics at the beginning, push 3rd parties after
-        metrics_types=$(grep antrea <<< $metrics_types_unarranged)$'\n'$(grep -v antrea <<< $metrics_types_unarranged)
+        metrics_types=$(grep antrea <<< "$metrics_types_unarranged")$'\n'$(grep -v antrea <<< "$metrics_types_unarranged")
         # Gather metrics descriptions
-        metrics_help=$(grep '# HELP' <<< $sorted_metrics | $SED_CMD 's/\[.*\] //i')
+        metrics_help=$(grep '# HELP' <<< "$sorted_metrics" | $SED_CMD 's/\[.*\] //i')
         last_pfx=""
         echo 'Below is a list of metrics, provided by the components and by 3rd parties.'
         echo
         echo "### Antrea Metrics"
         for metric in $metrics_types; do
-                metric_pfx=$($SED_CMD 's/_/ /g' <<< $metric | awk '{print $1}')
+                metric_pfx=$($SED_CMD 's/_/ /g' <<< "$metric" | awk '{print $1}')
                 if [ "$metric_pfx" == 'antrea' ]; then
                         # For Antrea metrics, add Agent, Controller to title
-                        metric_pfx=$($SED_CMD 's/_/ /g' <<< $metric | awk '{print $1" "$2}')
+                        metric_pfx=$($SED_CMD 's/_/ /g' <<< "$metric" | awk '{print $1" "$2}')
                 fi
                 if [ "$last_pfx" != "$metric_pfx" ]; then
                         echo
@@ -87,11 +87,11 @@ function format_metrics() {
                         fi
                         # Ouptut metrics title
                         # Capitalize the first letter of each word.
-                        echo "#### "$($SED_CMD "s/\b\(.\)/\u\1/g" <<< $metric_pfx)" Metrics"
+                        echo "#### "$($SED_CMD "s/\b\(.\)/\u\1/g" <<< "$metric_pfx")" Metrics"
                         echo
                         last_pfx=$metric_pfx
                 fi
-                metric_help=$(grep " $metric " <<< $metrics_help | $SED_CMD "s/.*$metric //")
+                metric_help=$(grep " $metric " <<< "$metrics_help" | $SED_CMD "s/.*$metric //")
                 echo "- **$metric:** $metric_help"
         done
 }
@@ -158,8 +158,8 @@ sorted_metrics=$(sort -u <<< "${agent_metrics}"$'\n'"${controller_metrics}")
 formatted_metrics=$(format_metrics "$sorted_metrics")
 
 if [ "$metrics_doc" == "" ]; then
-        $FMT_CMD -w 80 -s <<< $formatted_metrics
+        $FMT_CMD -w 80 -s <<< "$formatted_metrics"
 else
         $SED_CMD -i '/^Below is a list of metrics, provided by the components and by 3rd parties.$/,$d' $metrics_doc
-        $FMT_CMD -w 80 -s <<< $formatted_metrics >> $metrics_doc
+        $FMT_CMD -w 80 -s <<< "$formatted_metrics" >> $metrics_doc
 fi

--- a/hack/make-metrics-doc.sh
+++ b/hack/make-metrics-doc.sh
@@ -27,6 +27,7 @@ function echoerr {
 }
 
 FMT_CMD="fmt"
+SED_CMD="sed"
 if [[ "$OSTYPE" == "darwin"* ]]; then
     if ! command -v gfmt > /dev/null; then
         echoerr "This script requires the GNU fmt utility"
@@ -34,10 +35,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
         exit 1
     fi
     FMT_CMD="gfmt"
-fi
 
-SED_CMD="sed"
-if [[ "$OSTYPE" == "darwin"* ]]; then
     if ! command -v gsed > /dev/null; then
         echoerr "This script requires the GNU sed utility"
         echoerr "On MacOS, you can install it with 'brew install gnu-sed'"


### PR DESCRIPTION
It appears that the script was never really working on macOS, unless the built-in fmt and sed utilities were replaced by their GNU "equivalent". Instead of making this assumption, we explicitly use gfmt and gsed when macOS is detected, and give an error if they have not been installed.

While in other scripts, we try to use expressions which are compatible with both flavors of sed (GNU and FreeBSD), this script is used so rarely that it doesn't seem worth the maintenance effort. In particular, there is no simple equivalent to the GNU sed expression to capitalize every word in a sentence.

Fixes #5012