### PR TITLE
Automated cherry pick of #4988: Bump up whereabouts to v0.6.1

### DIFF
--- a/build/images/base/Dockerfile
+++ b/build/images/base/Dockerfile
@@ -16,7 +16,7 @@ ARG BUILD_TAG
 FROM ubuntu:22.04 as cni-binaries
 
 ARG CNI_BINARIES_VERSION
-ARG WHEREABOUTS_VERSION=v0.5.4
+ARG WHEREABOUTS_VERSION=v0.6.1
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends wget ca-certificates

--- a/build/images/base/Dockerfile.ubi
+++ b/build/images/base/Dockerfile.ubi
@@ -16,7 +16,7 @@ ARG BUILD_TAG
 FROM ubuntu:22.04 as cni-binaries
 
 ARG CNI_BINARIES_VERSION
-ARG WHEREABOUTS_VERSION=v0.5.1
+ARG WHEREABOUTS_VERSION=v0.6.1
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends wget ca-certificates

--- a/test/e2e-secondary-network/infra/prepare_cluster.sh
+++ b/test/e2e-secondary-network/infra/prepare_cluster.sh
@@ -64,7 +64,7 @@ function print_help {
 
 NAMESPACE="kube-system"
 ANTREA_DS="ds/antrea-agent"
-WHEREABOUTS_CNI_REL_TAG=v0.5.4
+WHEREABOUTS_CNI_REL_TAG=v0.6.1
 export URL_WHEREABOUTS_IP_POOLS="https://raw.githubusercontent.com/k8snetworkplumbingwg/whereabouts/$WHEREABOUTS_CNI_REL_TAG/doc/crds/whereabouts.cni.cncf.io_ippools.yaml"
 export URL_WHEREABOUTS_OVERLAPPING_IP_RANGE_RES="https://raw.githubusercontent.com/k8snetworkplumbingwg/whereabouts/$WHEREABOUTS_CNI_REL_TAG/doc/crds/whereabouts.cni.cncf.io_overlappingrangeipreservations.yaml"
 export YAML_ANTREA='antrea.yml'

--- a/test/e2e-secondary-network/infra/prepare_sriov.sh
+++ b/test/e2e-secondary-network/infra/prepare_sriov.sh
@@ -63,7 +63,7 @@ function print_help {
 
 
 SRIOV_PLUGIN_REL_TAG=v3.5.1
-WHEREABOUTS_CNI_REL_TAG=v0.5.4
+WHEREABOUTS_CNI_REL_TAG=v0.6.1
 export URL_SRIOV_DP_CONFIG_MAP="https://raw.githubusercontent.com/k8snetworkplumbingwg/sriov-network-device-plugin/$SRIOV_PLUGIN_REL_TAG/deployments/configMap.yaml"
 export URL_SRIOV_DP_DAEMONSET="https://raw.githubusercontent.com/k8snetworkplumbingwg/sriov-network-device-plugin/$SRIOV_PLUGIN_REL_TAG/deployments/k8s-v1.16/sriovdp-daemonset.yaml"
 export YAML_ANTREA='antrea.yml'


### PR DESCRIPTION
Cherry pick of #4988 on release-1.10.

#4988: Bump up whereabouts to v0.6.1

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.