### PR TITLE
Use new API in ofnet to remove the unnecessary map in memory

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	antrea.io/libOpenflow v0.10.2
-	antrea.io/ofnet v0.7.1
+	antrea.io/ofnet v0.7.2
 	github.com/ClickHouse/clickhouse-go/v2 v2.6.1
 	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/Mellanox/sriovnet v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 antrea.io/libOpenflow v0.10.1/go.mod h1:drWN5iISj7G2J6MnclrFmgy0jHU1Z684WW0DxcrjNP0=
 antrea.io/libOpenflow v0.10.2 h1:HsUHwFX//FsfCxHDf2R+IdmVf7NxVWO7nXYABDkszd4=
 antrea.io/libOpenflow v0.10.2/go.mod h1:drWN5iISj7G2J6MnclrFmgy0jHU1Z684WW0DxcrjNP0=
-antrea.io/ofnet v0.7.1 h1:9FgPTkxuf/DoJADYXLulwZztS+FYgUx3e4qI9hApx68=
-antrea.io/ofnet v0.7.1/go.mod h1:DcRieON1uDeaFiSCZyD1f3Mi7q3nvycyJrt8xZAPP6s=
+antrea.io/ofnet v0.7.2 h1:TuEPc8L1bkSRfpdkK0o0aoYMs9hkRJacgSrbWGur5pM=
+antrea.io/ofnet v0.7.2/go.mod h1:DcRieON1uDeaFiSCZyD1f3Mi7q3nvycyJrt8xZAPP6s=
 bazil.org/fuse v0.0.0-20160811212531-371fbbdaa898/go.mod h1:Xbm+BRKSBEpa4q4hTSxohYNQpsxXPbPry4JJWOB3LB8=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=

--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -697,9 +697,6 @@ func (c *client) UninstallServiceGroup(groupID binding.GroupIDType) error {
 		if err := c.ofEntryOperations.DeleteOFEntries([]binding.OFEntry{gCache.(binding.Group)}); err != nil {
 			return fmt.Errorf("error when deleting Openflow entries for Service Endpoints Group %d: %w", groupID, err)
 		}
-		if err := c.bridge.DeleteGroup(groupID); err != nil {
-			return fmt.Errorf("error when deleting OFSwitch groupDb Cache for Service Endpoints Group %d: %w", groupID, err)
-		}
 		c.featureService.groupCache.Delete(groupID)
 	}
 	return nil
@@ -1439,9 +1436,6 @@ func (c *client) UninstallMulticastGroup(groupID binding.GroupIDType) error {
 	if ok {
 		if err := c.ofEntryOperations.DeleteOFEntries([]binding.OFEntry{gCache.(binding.Group)}); err != nil {
 			return fmt.Errorf("error when deleting Openflow entries for Multicast receiver Group %d: %w", groupID, err)
-		}
-		if err := c.bridge.DeleteGroup(groupID); err != nil {
-			return fmt.Errorf("error when deleting OFSwitch groupDb Cache for Multicast receiver Group %d: %w", groupID, err)
 		}
 		c.featureMulticast.groupCache.Delete(groupID)
 	}

--- a/pkg/agent/openflow/client_test.go
+++ b/pkg/agent/openflow/client_test.go
@@ -454,7 +454,7 @@ func newFakeClient(mockOFEntryOperations *oftest.MockOFEntryOperations,
 	client.generatePipelines()
 	client.realizePipelines()
 	binding.TableNameCache = getTableNameCache()
-	client.bridge.(*binding.OFBridge).SetOFSwitch(ofctrl.NewSwitch(&util.MessageStream{}, GlobalVirtualMAC, nil, make(chan int), 32776))
+	client.bridge.(*binding.OFBridge).SetOFSwitch(ofctrl.NewSwitch(&util.MessageStream{}, GlobalVirtualMAC, client.bridge.(ofctrl.AppInterface), make(chan int), 32776))
 	client.bridge.(*binding.OFBridge).Initialize()
 	return client
 }

--- a/pkg/agent/openflow/multicast.go
+++ b/pkg/agent/openflow/multicast.go
@@ -93,7 +93,7 @@ func (f *featureMulticast) replayFlows() []*openflow15.FlowMod {
 }
 
 func (f *featureMulticast) multicastReceiversGroup(groupID binding.GroupIDType, tableID uint8, ports []uint32, remoteIPs []net.IP) binding.Group {
-	group := f.bridge.CreateGroupTypeAll(groupID).ResetBuckets()
+	group := f.bridge.NewGroupTypeAll(groupID)
 	for i := range ports {
 		group = group.Bucket().
 			LoadToRegField(OFPortFoundRegMark.GetField(), OFPortFoundRegMark.GetValue()).

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -2469,7 +2469,7 @@ func (f *featureService) endpointDNATFlow(endpointIP net.IP, endpointPort uint16
 // will resubmit packets back to ServiceLBTable to trigger the learn flow, the learn flow will then send packets to
 // EndpointDNATTable. Otherwise, buckets will resubmit packets to EndpointDNATTable directly.
 func (f *featureService) serviceEndpointGroup(groupID binding.GroupIDType, withSessionAffinity bool, endpoints ...proxy.Endpoint) binding.Group {
-	group := f.bridge.CreateGroup(groupID).ResetBuckets()
+	group := f.bridge.NewGroup(groupID)
 
 	if len(endpoints) == 0 {
 		return group.Bucket().Weight(100).
@@ -2613,8 +2613,8 @@ func priorityIndexFunc(obj interface{}) ([]string, error) {
 // `rate` is represented as number of packets per second.
 // Packets which exceed the rate will be dropped.
 func (c *client) genPacketInMeter(meterID binding.MeterIDType, rate uint32) binding.Meter {
-	meter := c.bridge.CreateMeter(meterID, ofctrl.MeterBurst|ofctrl.MeterPktps).ResetMeterBands()
-	meter = meter.MeterBand().
+	meter := c.bridge.NewMeter(meterID, ofctrl.MeterBurst|ofctrl.MeterPktps).
+		MeterBand().
 		MeterType(ofctrl.MeterDrop).
 		Rate(rate).
 		Burst(2 * rate).
@@ -2658,8 +2658,7 @@ func (c *client) realizePipelines() {
 			}
 			tables[i].SetNext(nextID)
 			tables[i].SetMissAction(missAction)
-			// Realize the table on OVS bridge.
-			c.bridge.CreateTable(tables[i], nextID, missAction)
+			c.bridge.NewTable(tables[i], nextID, missAction)
 		}
 	}
 }

--- a/pkg/ovs/openflow/interfaces.go
+++ b/pkg/ovs/openflow/interfaces.go
@@ -98,14 +98,11 @@ var VLANVIDRange = &Range{0, 11}
 
 // Bridge defines operations on an openflow bridge.
 type Bridge interface {
-	CreateTable(table Table, next uint8, missAction MissActionType) Table
-	DeleteTable(id uint8) bool
+	NewTable(table Table, next uint8, missAction MissActionType) Table
 	GetTableByID(id uint8) (Table, error)
-	CreateGroupTypeAll(id GroupIDType) Group
-	CreateGroup(id GroupIDType) Group
-	DeleteGroup(id GroupIDType) error
-	CreateMeter(id MeterIDType, flags ofctrl.MeterFlag) Meter
-	DeleteMeter(id MeterIDType) bool
+	NewGroupTypeAll(id GroupIDType) Group
+	NewGroup(id GroupIDType) Group
+	NewMeter(id MeterIDType, flags ofctrl.MeterFlag) Meter
 	DeleteMeterAll() error
 	DumpTableStatus() []TableStatus
 	// DumpFlows queries the Openflow entries from OFSwitch. The filter of the query is Openflow cookieID; the result is

--- a/pkg/ovs/openflow/ofctrl_bridge_test.go
+++ b/pkg/ovs/openflow/ofctrl_bridge_test.go
@@ -113,9 +113,7 @@ func TestDeleteGroup(t *testing.T) {
 	} {
 		t.Run(m.name, func(t *testing.T) {
 			b.ofSwitch = newFakeOFSwitch(b)
-			b.CreateGroup(m.existingGroupID)
-			err := b.DeleteGroup(m.deleteGroupID)
-			assert.Equal(t, m.err, err)
+			b.NewGroup(m.existingGroupID)
 		})
 	}
 }
@@ -130,7 +128,7 @@ func TestConcurrentCreateGroups(t *testing.T) {
 		wg.Add(1)
 		go func(index int) {
 			defer wg.Done()
-			b.CreateGroup(GroupIDType(index))
+			b.NewGroup(GroupIDType(index))
 		}(i)
 	}
 	wg.Wait()

--- a/pkg/ovs/openflow/ofctrl_group.go
+++ b/pkg/ovs/openflow/ofctrl_group.go
@@ -32,18 +32,9 @@ type ofGroup struct {
 	bridge *OFBridge
 }
 
-// Reset creates a new ofctrl.Group object for the updated ofSwitch. The
-// ofSwitch keeps a list of all Group objects, so this operation is
-// needed. Reset() should be called before replaying the Group to OVS.
+// Reset updates ofctrl.Group.Switch with the updated ofSwitch.
 func (g *ofGroup) Reset() {
-	// An error ("group already exists") is not possible here since we are
-	// using a new instance of ofSwitch and re-creating a group which was
-	// created successfully before. There will be no duplicate group IDs. If
-	// something is wrong and there is an error, g.ofctrl will be set to nil
-	// and the Agent will crash later.
-	newGroup, _ := g.bridge.ofSwitch.NewGroup(g.ofctrl.ID, g.ofctrl.GroupType)
-	newGroup.Buckets = g.ofctrl.Buckets
-	g.ofctrl = newGroup
+	g.ofctrl.Switch = g.bridge.ofSwitch
 }
 
 func (g *ofGroup) Add() error {

--- a/pkg/ovs/openflow/ofctrl_meter.go
+++ b/pkg/ovs/openflow/ofctrl_meter.go
@@ -29,16 +29,23 @@ func (m *ofMeter) Reset() {
 	m.ofctrl.Switch = m.bridge.ofSwitch
 }
 
+// Note: use OFSwitch to directly send MeterModification message rather than bundle message is because the
+// current ofnet implementation for OpenFlow bundle does not support adding MeterModification.
 func (m *ofMeter) Add() error {
-	return m.ofctrl.Install()
+	msg := m.ofctrl.GetBundleMessage(openflow15.MC_ADD)
+	return m.ofctrl.Switch.Send(msg.GetMessage())
 }
 
 func (m *ofMeter) Modify() error {
-	return m.ofctrl.Install()
+	msg := m.ofctrl.GetBundleMessage(openflow15.MC_MODIFY)
+	return m.ofctrl.Switch.Send(msg.GetMessage())
 }
 
 func (m *ofMeter) Delete() error {
-	return m.ofctrl.Delete()
+	meterMod := openflow15.NewMeterMod()
+	meterMod.MeterId = m.ofctrl.ID
+	meterMod.Command = openflow15.MC_DELETE
+	return m.ofctrl.Switch.Send(meterMod)
 }
 
 func (m *ofMeter) Type() EntryType {

--- a/pkg/ovs/openflow/testing/mock_openflow.go
+++ b/pkg/ovs/openflow/testing/mock_openflow.go
@@ -109,62 +109,6 @@ func (mr *MockBridgeMockRecorder) Connect(arg0, arg1 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Connect", reflect.TypeOf((*MockBridge)(nil).Connect), arg0, arg1)
 }
 
-// CreateGroup mocks base method
-func (m *MockBridge) CreateGroup(arg0 openflow.GroupIDType) openflow.Group {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateGroup", arg0)
-	ret0, _ := ret[0].(openflow.Group)
-	return ret0
-}
-
-// CreateGroup indicates an expected call of CreateGroup
-func (mr *MockBridgeMockRecorder) CreateGroup(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateGroup", reflect.TypeOf((*MockBridge)(nil).CreateGroup), arg0)
-}
-
-// CreateGroupTypeAll mocks base method
-func (m *MockBridge) CreateGroupTypeAll(arg0 openflow.GroupIDType) openflow.Group {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateGroupTypeAll", arg0)
-	ret0, _ := ret[0].(openflow.Group)
-	return ret0
-}
-
-// CreateGroupTypeAll indicates an expected call of CreateGroupTypeAll
-func (mr *MockBridgeMockRecorder) CreateGroupTypeAll(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateGroupTypeAll", reflect.TypeOf((*MockBridge)(nil).CreateGroupTypeAll), arg0)
-}
-
-// CreateMeter mocks base method
-func (m *MockBridge) CreateMeter(arg0 openflow.MeterIDType, arg1 ofctrl.MeterFlag) openflow.Meter {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateMeter", arg0, arg1)
-	ret0, _ := ret[0].(openflow.Meter)
-	return ret0
-}
-
-// CreateMeter indicates an expected call of CreateMeter
-func (mr *MockBridgeMockRecorder) CreateMeter(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateMeter", reflect.TypeOf((*MockBridge)(nil).CreateMeter), arg0, arg1)
-}
-
-// CreateTable mocks base method
-func (m *MockBridge) CreateTable(arg0 openflow.Table, arg1 byte, arg2 openflow.MissActionType) openflow.Table {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateTable", arg0, arg1, arg2)
-	ret0, _ := ret[0].(openflow.Table)
-	return ret0
-}
-
-// CreateTable indicates an expected call of CreateTable
-func (mr *MockBridgeMockRecorder) CreateTable(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTable", reflect.TypeOf((*MockBridge)(nil).CreateTable), arg0, arg1, arg2)
-}
-
 // DeleteFlowsByCookie mocks base method
 func (m *MockBridge) DeleteFlowsByCookie(arg0, arg1 uint64) error {
 	m.ctrl.T.Helper()
@@ -179,34 +123,6 @@ func (mr *MockBridgeMockRecorder) DeleteFlowsByCookie(arg0, arg1 interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFlowsByCookie", reflect.TypeOf((*MockBridge)(nil).DeleteFlowsByCookie), arg0, arg1)
 }
 
-// DeleteGroup mocks base method
-func (m *MockBridge) DeleteGroup(arg0 openflow.GroupIDType) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteGroup", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteGroup indicates an expected call of DeleteGroup
-func (mr *MockBridgeMockRecorder) DeleteGroup(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteGroup", reflect.TypeOf((*MockBridge)(nil).DeleteGroup), arg0)
-}
-
-// DeleteMeter mocks base method
-func (m *MockBridge) DeleteMeter(arg0 openflow.MeterIDType) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteMeter", arg0)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// DeleteMeter indicates an expected call of DeleteMeter
-func (mr *MockBridgeMockRecorder) DeleteMeter(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMeter", reflect.TypeOf((*MockBridge)(nil).DeleteMeter), arg0)
-}
-
 // DeleteMeterAll mocks base method
 func (m *MockBridge) DeleteMeterAll() error {
 	m.ctrl.T.Helper()
@@ -219,20 +135,6 @@ func (m *MockBridge) DeleteMeterAll() error {
 func (mr *MockBridgeMockRecorder) DeleteMeterAll() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMeterAll", reflect.TypeOf((*MockBridge)(nil).DeleteMeterAll))
-}
-
-// DeleteTable mocks base method
-func (m *MockBridge) DeleteTable(arg0 byte) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteTable", arg0)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// DeleteTable indicates an expected call of DeleteTable
-func (mr *MockBridgeMockRecorder) DeleteTable(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTable", reflect.TypeOf((*MockBridge)(nil).DeleteTable), arg0)
 }
 
 // Disconnect mocks base method
@@ -305,6 +207,62 @@ func (m *MockBridge) IsConnected() bool {
 func (mr *MockBridgeMockRecorder) IsConnected() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsConnected", reflect.TypeOf((*MockBridge)(nil).IsConnected))
+}
+
+// NewGroup mocks base method
+func (m *MockBridge) NewGroup(arg0 openflow.GroupIDType) openflow.Group {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewGroup", arg0)
+	ret0, _ := ret[0].(openflow.Group)
+	return ret0
+}
+
+// NewGroup indicates an expected call of NewGroup
+func (mr *MockBridgeMockRecorder) NewGroup(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewGroup", reflect.TypeOf((*MockBridge)(nil).NewGroup), arg0)
+}
+
+// NewGroupTypeAll mocks base method
+func (m *MockBridge) NewGroupTypeAll(arg0 openflow.GroupIDType) openflow.Group {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewGroupTypeAll", arg0)
+	ret0, _ := ret[0].(openflow.Group)
+	return ret0
+}
+
+// NewGroupTypeAll indicates an expected call of NewGroupTypeAll
+func (mr *MockBridgeMockRecorder) NewGroupTypeAll(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewGroupTypeAll", reflect.TypeOf((*MockBridge)(nil).NewGroupTypeAll), arg0)
+}
+
+// NewMeter mocks base method
+func (m *MockBridge) NewMeter(arg0 openflow.MeterIDType, arg1 ofctrl.MeterFlag) openflow.Meter {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewMeter", arg0, arg1)
+	ret0, _ := ret[0].(openflow.Meter)
+	return ret0
+}
+
+// NewMeter indicates an expected call of NewMeter
+func (mr *MockBridgeMockRecorder) NewMeter(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewMeter", reflect.TypeOf((*MockBridge)(nil).NewMeter), arg0, arg1)
+}
+
+// NewTable mocks base method
+func (m *MockBridge) NewTable(arg0 openflow.Table, arg1 byte, arg2 openflow.MissActionType) openflow.Table {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewTable", arg0, arg1, arg2)
+	ret0, _ := ret[0].(openflow.Table)
+	return ret0
+}
+
+// NewTable indicates an expected call of NewTable
+func (mr *MockBridgeMockRecorder) NewTable(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewTable", reflect.TypeOf((*MockBridge)(nil).NewTable), arg0, arg1, arg2)
 }
 
 // ResumePacket mocks base method

--- a/test/integration/ovs/ofctrl_test.go
+++ b/test/integration/ovs/ofctrl_test.go
@@ -94,7 +94,7 @@ func TestDeleteFlowStrict(t *testing.T) {
 	}()
 
 	bridge := newOFBridge(br)
-	table = bridge.CreateTable(t3, t4.GetID(), binding.TableMissActionNext)
+	table = bridge.NewTable(t3, t4.GetID(), binding.TableMissActionNext)
 
 	err = bridge.Connect(maxRetry, make(chan struct{}))
 	if err != nil {
@@ -183,8 +183,8 @@ func TestOFctrlFlow(t *testing.T) {
 	}()
 
 	bridge := newOFBridge(br)
-	table1 := bridge.CreateTable(t1, t2.GetID(), binding.TableMissActionNext)
-	table2 := bridge.CreateTable(t2, t3.GetID(), binding.TableMissActionNext)
+	table1 := bridge.NewTable(t1, t2.GetID(), binding.TableMissActionNext)
+	table2 := bridge.NewTable(t2, t3.GetID(), binding.TableMissActionNext)
 
 	err = bridge.Connect(maxRetry, make(chan struct{}))
 	if err != nil {
@@ -290,9 +290,9 @@ func TestOFctrlGroup(t *testing.T) {
 			var group binding.Group
 			gid := binding.GroupIDType(id)
 			if name == "TypeAll" {
-				group = br.CreateGroupTypeAll(gid)
+				group = br.NewGroupTypeAll(gid)
 			} else {
-				group = br.CreateGroup(gid)
+				group = br.NewGroup(gid)
 			}
 			for _, bucket := range buckets {
 				require.NotZero(t, bucket.weight, "Weight value of a bucket must be specified")
@@ -362,7 +362,7 @@ func TestTransactions(t *testing.T) {
 	}()
 
 	bridge := newOFBridge(br)
-	table = bridge.CreateTable(t2, t3.GetID(), binding.TableMissActionNext)
+	table = bridge.NewTable(t2, t3.GetID(), binding.TableMissActionNext)
 
 	err = bridge.Connect(maxRetry, make(chan struct{}))
 	require.Nil(t, err, "Failed to start OFService")
@@ -421,7 +421,7 @@ func TestBundleErrorWhenOVSRestart(t *testing.T) {
 	}()
 
 	bridge := newOFBridge(br)
-	table = bridge.CreateTable(t2, t3.GetID(), binding.TableMissActionNext)
+	table = bridge.NewTable(t2, t3.GetID(), binding.TableMissActionNext)
 
 	err = bridge.Connect(maxRetry, make(chan struct{}))
 	require.Nil(t, err, "Failed to start OFService")
@@ -540,7 +540,7 @@ func TestBundleWithGroupAndFlow(t *testing.T) {
 	defer DeleteOVSBridge(br)
 
 	bridge := newOFBridge(br)
-	table = bridge.CreateTable(t2, t3.GetID(), binding.TableMissActionNext)
+	table = bridge.NewTable(t2, t3.GetID(), binding.TableMissActionNext)
 
 	err = bridge.Connect(maxRetry, make(chan struct{}))
 	require.Nil(t, err, "Failed to start OFService")
@@ -552,7 +552,7 @@ func TestBundleWithGroupAndFlow(t *testing.T) {
 	field1 := binding.NewRegField(1, 0, 31)
 	field2 := binding.NewRegField(2, 0, 31)
 	field3 := binding.NewRegField(3, 0, 31)
-	group := bridge.CreateGroup(groupID).
+	group := bridge.NewGroup(groupID).
 		Bucket().Weight(100).
 		LoadToRegField(field1, uint32(0xa0a0002)).
 		LoadToRegField(field2, uint32(0x35)).
@@ -600,8 +600,8 @@ func TestPacketOutIn(t *testing.T) {
 	defer DeleteOVSBridge(br)
 
 	bridge := newOFBridge(br)
-	table0 := bridge.CreateTable(t0, t1.GetID(), binding.TableMissActionNext)
-	table1 := bridge.CreateTable(t1, t2.GetID(), binding.TableMissActionNext)
+	table0 := bridge.NewTable(t0, t1.GetID(), binding.TableMissActionNext)
+	table1 := bridge.NewTable(t1, t2.GetID(), binding.TableMissActionNext)
 
 	err = bridge.Connect(maxRetry, make(chan struct{}))
 	require.Nil(t, err, "Failed to start OFService")
@@ -694,7 +694,7 @@ func TestFlowWithCTMatchers(t *testing.T) {
 	defer DeleteOVSBridge(br)
 
 	bridge := newOFBridge(br)
-	table = bridge.CreateTable(t2, t3.GetID(), binding.TableMissActionNext)
+	table = bridge.NewTable(t2, t3.GetID(), binding.TableMissActionNext)
 
 	err = bridge.Connect(maxRetry, make(chan struct{}))
 	require.Nil(t, err, "Failed to start OFService")
@@ -783,7 +783,7 @@ func TestNoteAction(t *testing.T) {
 	defer DeleteOVSBridge(br)
 
 	bridge := newOFBridge(br)
-	table = bridge.CreateTable(t2, t3.GetID(), binding.TableMissActionNext)
+	table = bridge.NewTable(t2, t3.GetID(), binding.TableMissActionNext)
 
 	err = bridge.Connect(maxRetry, make(chan struct{}))
 	require.Nil(t, err, "Failed to start OFService")
@@ -834,7 +834,7 @@ func TestLoadToLabelFieldAction(t *testing.T) {
 	defer DeleteOVSBridge(br)
 
 	bridge := newOFBridge(br)
-	table = bridge.CreateTable(t2, t3.GetID(), binding.TableMissActionNext)
+	table = bridge.NewTable(t2, t3.GetID(), binding.TableMissActionNext)
 
 	err = bridge.Connect(maxRetry, make(chan struct{}))
 	require.Nil(t, err, "Failed to start OFService")
@@ -900,7 +900,7 @@ func TestBundleWithGroupInsertBucket(t *testing.T) {
 	defer DeleteOVSBridge(br)
 
 	bridge := newOFBridge(br)
-	table = bridge.CreateTable(t2, t3.GetID(), binding.TableMissActionNext)
+	table = bridge.NewTable(t2, t3.GetID(), binding.TableMissActionNext)
 	// Set the maximum of buckets in a message to test insert_buckets.
 	binding.MaxBucketsPerMessage = 2
 	// In case it affects other tests, set the maximum of buckets in a message back to 800.
@@ -915,7 +915,7 @@ func TestBundleWithGroupInsertBucket(t *testing.T) {
 	ovsCtlClient := ovsctl.NewClient(br)
 	groupID := binding.GroupIDType(4)
 
-	group := bridge.CreateGroup(groupID)
+	group := bridge.NewGroup(groupID)
 	expectedGroupBuckets := []string{}
 	err = bridge.AddOFEntriesInBundle([]binding.OFEntry{group}, nil, nil)
 	require.Nil(t, err)


### PR DESCRIPTION
The existing code call APIs in ofnet to create Table/Group/Meter on OpenFlow Switch. Since antrea agent also maintains these resources in its memory, the usage of ofctrl.tableDb/groupDb/meterDb is duplicated.

This change only creates the Table/Group/Meter resources using ofnet APIs but do not save them in a second map.