### PR TITLE
Add containerd support to PrepareNode script

### DIFF
--- a/docs/windows.md
+++ b/docs/windows.md
@@ -254,11 +254,37 @@ Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False
 Firstly, install wins, kubelet, kubeadm using script `PrepareNode.ps1` provided
 by kubernetes. The third component [`wins`](https://github.com/rancher/wins) is
 used to run kube-proxy and antrea-agent on Windows host inside the Windows
-container. The following command downloads and executes `PrepareNode.ps1`:
+container. Specify the Node IP, Kubernetes Version and container runtime while
+running the script. If you do not specify any container runtime, it will be
+containerd by default. The following command downloads and executes `Prepare-Node.ps1`:
 
 ```powershell
-curl.exe -LO "https://github.com/kubernetes-sigs/sig-windows-tools/releases/download/v0.1.5/PrepareNode.ps1"
-.\PrepareNode.ps1 -KubernetesVersion v1.23.5
+# Example:
+curl.exe -LO "https://raw.githubusercontent.com/antrea-io/antrea/main/hack/windows/Prepare-Node.ps1"
+.\Prepare-Node.ps1 -KubernetesVersion v1.27.0 -NodeIP 192.168.1.10 
+
+```
+
+You can specify the ContainerRuntime parameter as docker if you want to run kubelet
+using docker runtime on the node. (Note: Docker has been deprecated since k8s version 1.24).
+
+```powershell
+# Example:
+curl.exe -LO "https://raw.githubusercontent.com/antrea-io/antrea/main/hack/windows/Prepare-Node.ps1"
+.\Prepare-Node.ps1 -KubernetesVersion v1.23.5 -NodeIP 192.168.1.10 -ContainerRuntime
+docker
+
+```
+
+You can specify the InstallKubeProxy parameter as true if you want to install
+kube-proxy on the node. The default value of the parameter is false. (Note: since
+k8s version 1.26 kube-proxy kernel datapath has been deprecated on windows and antrea
+can only run with proxyAll enabled)
+
+```powershell
+
+.\Prepare-Node.ps1 -KubernetesVersion v1.25.0 -InstallKubeProxy:$true -NodeIP 192.168.1.10
+
 ```
 
 ##### 4. Prepare Node environment needed by antrea-agent

--- a/hack/windows/Prepare-Node.ps1
+++ b/hack/windows/Prepare-Node.ps1
@@ -10,11 +10,14 @@ script from the sig-windows-tools repo release page: https://github.com/kubernet
 - Registers wins as a service in order to run kube-proxy and antrea-agent as DaemonSets.
 - Registers kubelet as an nssm service. More info on nssm: https://nssm.cc/
 - Adds node ip in kubelet startup params.
-- Create virtual netadapter for kube-proxy.
+- (Optional) Create virtual netadapter for kube-proxy.
 - (Optional) Installs OVS kerner driver, userspace binaries. Registers ovsdb-server and ovs-vswitchd services.
 
 .PARAMETER KubernetesVersion
 Kubernetes version to download and use
+
+.PARAMETER InstallKubeProxy
+Install kube-proxy
 
 .PARAMETER InstallOVS
 Install OVS
@@ -22,16 +25,23 @@ Install OVS
 .PARAMETER NodeIP
 The node ip used by kubelet
 
+.PARAMETER ContainerRuntime
+Container runtime that Kubernetes will use. (docker or containerd)
+
 .EXAMPLE
-PS> .\Prepare-Node.ps1 -KubernetesVersion v1.18.0 -InstallOVS -NodeIP 192.168.1.10
+PS> .\Prepare-Node.ps1 -KubernetesVersion v1.27.0 -NodeIP 192.168.1.10 -ContainerRuntime containerd 
 
 #>
+
+
 
 Param(
     [parameter(Mandatory = $false, HelpMessage="Kubernetes version to use")] [string] $KubernetesVersion="v1.18.0",
     [parameter(Mandatory = $true, HelpMessage="Node IP")] [string] $NodeIP,
+    [parameter(Mandatory = $false)] [switch] $InstallKubeProxy = $false,
     [parameter(Mandatory = $false)] [switch] $InstallOVS = $false,
-    [parameter(Mandatory = $false, HelpMessage="Kubernetes download")] [string] $KubernetesURL="dl.k8s.io"
+    [parameter(Mandatory = $false, HelpMessage="Kubernetes download")] [string] $KubernetesURL="dl.k8s.io",
+    [parameter(HelpMessage="Container runtime that Kubernets will use")] [ValidateSet("containerd", "docker")] [string] $ContainerRuntime = "containerd"
 )
 $ErrorActionPreference = 'Stop'
 
@@ -50,6 +60,18 @@ If (Get-Service kubelet -ErrorAction SilentlyContinue) {
     exit 0
 }
 
+if ($ContainerRuntime -eq "docker") {
+    if (-not(Test-Path "//./pipe/docker_engine")) {
+        Write-Error "Docker service was not detected - please install and start Docker before calling Prepare-Node.ps1 with -ContainerRuntime docker"
+        exit 1
+    }
+} elseif ($ContainerRuntime -eq "containerd") {
+    if (-not(Test-Path "//./pipe/containerd-containerd")) {
+        Write-Error "Containerd service was not detected - please install and start Containerd before calling Prepare-Node.ps1 with -ContainerRuntime containerd"
+        exit 1
+    }
+}
+
 if (!$KubernetesVersion.StartsWith("v")) {
     $KubernetesVersion = "v" + $KubernetesVersion
 }
@@ -66,37 +88,47 @@ $env:Path += ";$global:KubernetesPath"
 [Environment]::SetEnvironmentVariable("Path", $env:Path, [System.EnvironmentVariableTarget]::Machine)
 [Environment]::SetEnvironmentVariable("NODE_IP", $NodeIP, [System.EnvironmentVariableTarget]::Machine)
 
-DownloadFile $kubeletBinPath "https://$KubernetesURL/$KubernetesVersion/bin/windows/amd64/kubelet.exe"
-DownloadFile "$global:KubernetesPath\kubeadm.exe" "https://$KubernetesURL/$KubernetesVersion/bin/windows/amd64/kubeadm.exe"
-DownloadFile "$global:KubernetesPath\wins.exe" https://github.com/rancher/wins/releases/download/v0.0.4/wins.exe
+DownloadFile $kubeletBinPath "https:/$KubernetesURL/$KubernetesVersion/bin/windows/amd64/kubelet.exe"
+DownloadFile "$global:KubernetesPath\kubeadm.exe" "https:/$KubernetesURL/$KubernetesVersion/bin/windows/amd64/kubeadm.exe"
 
-# Create host network to allow kubelet to schedule hostNetwork pods
-Write-Host "Creating Docker host network"
-docker network create -d nat host
+if ($ContainerRuntime -eq "docker") {
+    Write-Host "Registering wins service"
+    DownloadFile "$global:KubernetesPath\wins.exe" https://github.com/rancher/wins/releases/download/v0.0.4/wins.exe
+    wins.exe srv app run --register
+    start-service rancher-wins
+}
 
-Write-Host "Registering wins service"
-wins.exe srv app run --register
-start-service rancher-wins
 
 mkdir -force C:\var\log\kubelet
 mkdir -force C:\var\lib\kubelet\etc\kubernetes
 mkdir -force C:\etc\kubernetes\pki
 New-Item -path C:\var\lib\kubelet\etc\kubernetes\pki -type SymbolicLink -value C:\etc\kubernetes\pki\
 
-$StartKubeletFileContent = '$FileContent = Get-Content -Path "/var/lib/kubelet/kubeadm-flags.env"
-$global:KubeletArgs = $FileContent.Trim("KUBELET_KUBEADM_ARGS=`"")
 
-$netId = docker network ls -f name=host --format "{{ .ID }}"
+$StartKubeletFileContent = '$FileContent = Get-Content -Path "/var/lib/kubelet/kubeadm-flags.env"
+$global:KubeletArgs = $FileContent.Trim("KUBELET_KUBEADM_ARGS=`"")'+ [Environment]::NewLine
+
+if ($ContainerRuntime -eq "docker") {
+    $StartKubeletFileContent +=[Environment]::NewLine +'$netId = docker network ls -f name=host --format "{{ .ID }}"
 
 if ($netId.Length -lt 1) {
     docker network create -d nat host
+}' + [Environment]::NewLine
 }
 
-& C:\k\Prepare-ServiceInterface.ps1 -InterfaceAlias "HNS Internal NIC"
+if ($InstallKubeProxy) {
+    $StartKubeletFileContent += [Environment]::NewLine + '& C:\k\Prepare-ServiceInterface.ps1 -InterfaceAlias "HNS Internal NIC"' + [Environment]::NewLine
+}
 
-$cmd = "C:\k\kubelet.exe $global:KubeletArgs --cert-dir=$env:SYSTEMDRIVE\var\lib\kubelet\pki --config=/var/lib/kubelet/config.yaml --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf --hostname-override=$(hostname) --pod-infra-container-image=`"mcr.microsoft.com/oss/kubernetes/pause:1.3.0`" --enable-debugging-handlers --cgroups-per-qos=false --enforce-node-allocatable=`"`" --network-plugin=cni --resolv-conf=`"`" --log-dir=/var/log/kubelet --logtostderr=false --image-pull-progress-deadline=20m --node-ip=$env:NODE_IP"
+$StartKubeletFileContent += [Environment]::NewLine + '$global:KubeletArgs += "--cert-dir=$env:SYSTEMDRIVE\var\lib\kubelet\pki --config=/var/lib/kubelet/config.yaml --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf --hostname-override=$(hostname) --pod-infra-container-image=`"mcr.microsoft.com/oss/kubernetes/pause:1.4.1`" --enable-debugging-handlers --cgroups-per-qos=false --enforce-node-allocatable=`"`" --resolv-conf=`"`" --node-ip=$env:NODE_IP"'
 
+if ($ContainerRuntime -eq "containerd") {
+    $StartKubeletFileContent += [Environment]::NewLine + '$global:KubeletArgs += " --feature-gates=WindowsHostProcessContainers=true"'
+}
+
+$StartKubeletFileContent += [Environment]::NewLine + '$cmd = "C:\k\kubelet.exe $global:KubeletArgs"
 Invoke-Expression $cmd'
+
 Set-Content -Path $global:StartKubeletScript -Value $StartKubeletFileContent
 
 Write-Host "Installing nssm"
@@ -112,18 +144,21 @@ Remove-Item -Force .\nssm.zip
 
 $env:path += ";$global:NssmInstallDirectory"
 $newPath = "$global:NssmInstallDirectory;" +
-        [Environment]::GetEnvironmentVariable("PATH", [EnvironmentVariableTarget]::Machine)
+[Environment]::GetEnvironmentVariable("PATH", [EnvironmentVariableTarget]::Machine)
 
 [Environment]::SetEnvironmentVariable("PATH", $newPath, [EnvironmentVariableTarget]::Machine)
 
 Write-Host "Registering kubelet service"
 nssm install kubelet $global:Powershell $global:PowershellArgs $global:StartKubeletScript
-nssm set kubelet DependOnService docker
+
+nssm set kubelet DependOnService $ContainerRuntime
 
 New-NetFirewallRule -Name kubelet -DisplayName 'kubelet' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 10250
 
-# Create netadapter for kube-proxy, the default full name of the adapter is "vEthernet (HNS Internal NIC)"
-& ./Prepare-ServiceInterface.ps1
+if ($InstallKubeProxy) {
+    # Create netadapter for kube-proxy, the default full name of the adapter is "vEthernet (HNS Internal NIC)"
+    & ./Prepare-ServiceInterface.ps1
+}
 
 if ($InstallOVS) {
     Write-Host "Installing OVS"


### PR DESCRIPTION
This patch gives the user the option of using containerd runtime while using the PrepareNode.ps1 for configuring k8s on windows node.