### PR TITLE
Stop checking upgrades for clickhouse-go/v2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,8 @@ updates:
     - dependency-name: "github.com/aws/*" # updates are too frequent
     - dependency-name: "antrea.io/ofnet"
     - dependency-name: "antrea.io/libOpenflow"
+    - dependency-name: "github.com/ClickHouse/clickhouse-go/v2" # auto-upgrade involves dependency conflicts
+      update-types: ["version-update:semver-major", "version-update:semver-minor"]
   - package-ecosystem: "github-actions"
     # Workflow files stored in the default location of `.github/workflows`
     directory: "/"


### PR DESCRIPTION
We stop auto-upgrade from Dependabot on the package as it will involve dependency conflicts. We should upgrade the package manually when needed.