### PR TITLE
Revert "Bump aquasecurity/trivy-action from 0.10.0 to 0.11.0"

### DIFF
--- a/.github/workflows/trivy_scan.yml
+++ b/.github/workflows/trivy_scan.yml
@@ -36,7 +36,7 @@ jobs:
         docker pull antrea/antrea-ubuntu:${{ steps.find-antrea-greatest-version.outputs.antrea_version }}
     - name: Run Trivy vulnerability scanner on latest Antrea Docker image
       if: ${{ always() && steps.pull.conclusion == 'success' }}
-      uses: aquasecurity/trivy-action@0.11.0
+      uses: aquasecurity/trivy-action@0.10.0
       # we cannot use .trivy.yml as we need to override some config parameters
       # and that is not supported by aquasecurity/trivy-action
       with:
@@ -51,7 +51,7 @@ jobs:
         output: 'trivy.latest.txt'
     - name: Run Trivy vulnerability scanner on Antrea Docker image for latest released version
       if: ${{ always() && steps.pull.conclusion == 'success' }}
-      uses: aquasecurity/trivy-action@0.11.0
+      uses: aquasecurity/trivy-action@0.10.0
       with:
         scan-type: 'image'
         image-ref: 'antrea/antrea-ubuntu:${{ steps.find-antrea-greatest-version.outputs.antrea_version }}'

--- a/.github/workflows/trivy_scan_before_release.yml
+++ b/.github/workflows/trivy_scan_before_release.yml
@@ -15,7 +15,7 @@ jobs:
       run: |
         ./hack/build-antrea-linux-all.sh --pull
     - name: Run Trivy vulnerability scanner on Antrea Docker image
-      uses: aquasecurity/trivy-action@0.11.0
+      uses: aquasecurity/trivy-action@0.10.0
       with:
         scan-type: 'image'
         image-ref: 'antrea/antrea-ubuntu:latest'


### PR DESCRIPTION
Reverts antrea-io/antrea#5085

Because of this bug: https://github.com/aquasecurity/trivy-action/issues/238