### PR TITLE
Change Multi-cluster Controller ResEx QPS and LabelID worker num

### DIFF
--- a/multicluster/cmd/multicluster-controller/controller.go
+++ b/multicluster/cmd/multicluster-controller/controller.go
@@ -39,6 +39,7 @@ import (
 
 	mcv1alpha1 "antrea.io/antrea/multicluster/apis/multicluster/v1alpha1"
 	mcv1alpha2 "antrea.io/antrea/multicluster/apis/multicluster/v1alpha2"
+	"antrea.io/antrea/multicluster/controllers/multicluster/common"
 	antreacrd "antrea.io/antrea/pkg/apis/crd/v1alpha1"
 	"antrea.io/antrea/pkg/apiserver/certificate"
 	"antrea.io/antrea/pkg/util/env"
@@ -134,6 +135,8 @@ func setupManagerAndCertController(isLeader bool, o *Options) (manager.Manager, 
 
 	// build up cert controller to manage certificate for MC Controller
 	k8sConfig := ctrl.GetConfigOrDie()
+	k8sConfig.QPS = common.ResourceExchangeQPS
+	k8sConfig.Burst = common.ResourceExchangeBurst
 	client, aggregatorClient, apiExtensionClient, err := createClients(k8sConfig)
 	if err != nil {
 		return nil, fmt.Errorf("error creating K8s clients: %v", err)

--- a/multicluster/controllers/multicluster/common/types.go
+++ b/multicluster/controllers/multicluster/common/types.go
@@ -31,7 +31,19 @@ const (
 	InvalidClusterSetID = ClusterSetID("invalid")
 
 	DefaultWorkerCount = 5
+	// LabelIdentityWorkerCount is the number of workers used by LabelIdentityReconciler,
+	// LabelIdentityExportReconciler and LabelIdentityResourceImportReconciler.
+	// Using more workers for those reconcilers could have a better performance when a
+	// lot of LabelIdentity events happen concurrently.
+	LabelIdentityWorkerCount = 10
 
 	EndpointIPTypeClusterIP = "ClusterIP"
 	EndpointIPTypePodIP     = "PodIP"
+
+	// ResourceExchangeQPS and ResourceExchangeBurst are used to configure the client-go
+	// used by Antrea Multi-cluster resource exchange pipeline. Using higher QPS and
+	// Burst, instead of default settings, could significantly improve the performance,
+	// when a lot of LabelIdentity events happen concurrently.
+	ResourceExchangeQPS   = 100
+	ResourceExchangeBurst = 200
 )

--- a/multicluster/controllers/multicluster/commonarea/remote_common_area.go
+++ b/multicluster/controllers/multicluster/commonarea/remote_common_area.go
@@ -150,6 +150,8 @@ func GetRemoteConfigAndClient(secretObj *v1.Secret, url string, clusterID common
 	config.BearerToken = string(token)
 	config.CAData = crtData
 
+	config.QPS = common.ResourceExchangeQPS
+	config.Burst = common.ResourceExchangeBurst
 	remoteCommonAreaMgr, err := ctrl.NewManager(config, ctrl.Options{
 		Scheme:             scheme,
 		MetricsBindAddress: "0",

--- a/multicluster/controllers/multicluster/leader/labelidentity_export_controller.go
+++ b/multicluster/controllers/multicluster/leader/labelidentity_export_controller.go
@@ -122,7 +122,7 @@ func (r *LabelIdentityExportReconciler) SetupWithManager(mgr ctrl.Manager) error
 		For(&mcsv1alpha1.ResourceExport{}).
 		WithEventFilter(instance).
 		WithOptions(controller.Options{
-			MaxConcurrentReconciles: common.DefaultWorkerCount,
+			MaxConcurrentReconciles: common.LabelIdentityWorkerCount,
 		}).
 		Complete(r)
 }
@@ -173,7 +173,7 @@ func (r *LabelIdentityExportReconciler) onLabelExportAdd(clusterID, labelHash, l
 func (r *LabelIdentityExportReconciler) Run(stopCh <-chan struct{}) {
 	defer r.labelQueue.ShutDown()
 
-	for i := 0; i < common.DefaultWorkerCount; i++ {
+	for i := 0; i < common.LabelIdentityWorkerCount; i++ {
 		go wait.Until(r.labelQueueWorker, time.Second, stopCh)
 	}
 	<-stopCh

--- a/multicluster/controllers/multicluster/member/labelidentity_controller.go
+++ b/multicluster/controllers/multicluster/member/labelidentity_controller.go
@@ -136,7 +136,7 @@ func (r *LabelIdentityReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			handler.EnqueueRequestsFromMapFunc(r.namespaceMapFunc),
 			builder.WithPredicates(predicate.LabelChangedPredicate{})).
 		WithOptions(controller.Options{
-			MaxConcurrentReconciles: common.DefaultWorkerCount,
+			MaxConcurrentReconciles: common.LabelIdentityWorkerCount,
 		}).
 		Complete(r)
 }
@@ -213,7 +213,7 @@ func (r *LabelIdentityReconciler) onPodCreateOrUpdate(podNamespacedName, current
 func (r *LabelIdentityReconciler) Run(stopCh <-chan struct{}) {
 	defer r.labelQueue.ShutDown()
 
-	for i := 0; i < common.DefaultWorkerCount; i++ {
+	for i := 0; i < common.LabelIdentityWorkerCount; i++ {
 		go wait.Until(r.labelQueueWorker, time.Second, stopCh)
 	}
 	<-stopCh

--- a/multicluster/controllers/multicluster/member/labelidentity_import_controller.go
+++ b/multicluster/controllers/multicluster/member/labelidentity_import_controller.go
@@ -145,7 +145,7 @@ func (r *LabelIdentityResourceImportReconciler) SetupWithManager(mgr ctrl.Manage
 		For(&multiclusterv1alpha1.ResourceImport{}).
 		WithEventFilter(instance).
 		WithOptions(controller.Options{
-			MaxConcurrentReconciles: common.DefaultWorkerCount,
+			MaxConcurrentReconciles: common.LabelIdentityWorkerCount,
 		}).
 		Complete(r)
 


### PR DESCRIPTION
After performance tests, we noticed that default QPS and Burst introduce a bad performance when a lot of LabelIdentity events concurrently occur. So this commit changes to use a higher QPS and Burst config for MultiCluster ResourceExchange pipeline and increases the worker numbers of LabelIdentity related controllers.

**Performance Test results:**

_**No LabelID sync test**_
This case is that when users create an MCNP, all the resources including all appliedTo and peers workloads are already created for a while, which means that all the LabelIdentities needed have been synced and stored in the caches of antrea-controllers and antrea-agents. So in this case, the performance of creating MCNP should have a similar result as creating a single cluster NetworkPolicy, like ACNP.

**_With LabelID sync test_**
This case is that after all resources and the MCNP are created, the selected peers of the MCNP update their Labels, which will trigger the LabelIdentity update events. The update of an MCNP is completed means all peers have updated their classifier flows and policy LabelIdentity conjunction matching flows are also updated with new LabelIdentities.

* The current config up to 200 unique LabelIdentity
<img width="860" alt="image" src="https://github.com/antrea-io/antrea/assets/19429613/8d1f6949-40c8-4d1a-a2fd-7e677b4eb309">
<img width="906" alt="image" src="https://github.com/antrea-io/antrea/assets/19429613/f522ee50-f956-47ff-8e51-7fa87c55ee0d">

As we can see with 200 LabelIdentities resync, it will take around 1m18s, which is quite slow.

* QPS Burst comparison up to 600 unique LabelIdentity.

<img width="1101" alt="image" src="https://github.com/antrea-io/antrea/assets/19429613/feacd128-88a7-4c13-b01c-b70e2a2a2921">
<img width="1158" alt="image" src="https://github.com/antrea-io/antrea/assets/19429613/ec44fa40-69d8-4f93-b756-bcac5ef4d46d">

Increasing QPS and Burst could improve the performance a lot. 200 unique LabelIdentities only take 1.5s. 600 unique LabelIdentities take 6s for 200 QPS 400 Burst.

* Number of workers comparison up to 600 unique LabelIdentity (Just to clarify: this test is run in a different env than tests above, so the same config may have different latencies across tests)

No labelIdentity sync case doesn't include labelIdentity_export/import_controller. Skip this comparison.
<img width="1154" alt="image" src="https://github.com/antrea-io/antrea/assets/19429613/1a81d4cb-146c-48e8-a943-b1f8ecafe08d">

Although more workers could have better performance, a lot of LabelIdentity updates happen concurrently is not a frequent event. Having too many idle workers spin is not a good idea. Feel free to comment with worker number suggestions.
