### PR TITLE
Stop picking up patch from clickhouse-go/v2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,6 @@ updates:
     - dependency-name: "antrea.io/ofnet"
     - dependency-name: "antrea.io/libOpenflow"
     - dependency-name: "github.com/ClickHouse/clickhouse-go/v2" # auto-upgrade involves dependency conflicts
-      update-types: ["version-update:semver-major", "version-update:semver-minor"]
   - package-ecosystem: "github-actions"
     # Workflow files stored in the default location of `.github/workflows`
     directory: "/"


### PR DESCRIPTION
Any version later than clickhouse-go/v2 v2.6.1 requires go.opentelemetry.io/otel v1.13.0, which conflicts with the K8s api dependencies on go.opentelemetry.io/otel. We shall wait until we upgrade Go version and K8s api version, then we may be able to upgrade clickhouse-go/v2.