### PR TITLE
Add appliedTo Pod namespace / name to audit logs

### DIFF
--- a/pkg/agent/openflow/network_policy.go
+++ b/pkg/agent/openflow/network_policy.go
@@ -1537,16 +1537,16 @@ func (f *featureNetworkPolicy) getPolicyRuleConjunction(ruleID uint32) *policyRu
 	return conj.(*policyRuleConjunction)
 }
 
-func (c *client) GetPolicyInfoFromConjunction(ruleID uint32) (string, string, string, string) {
+func (c *client) GetPolicyInfoFromConjunction(ruleID uint32) (bool, *v1beta2.NetworkPolicyReference, string, string, string) {
 	conjunction := c.featureNetworkPolicy.getPolicyRuleConjunction(ruleID)
-	if conjunction == nil {
-		return "", "", "", ""
+	if conjunction == nil || conjunction.npRef == nil {
+		return false, nil, "", "", ""
 	}
 	priorities := conjunction.ActionFlowPriorities()
 	if len(priorities) == 0 {
-		return "", "", "", ""
+		return false, nil, "", "", ""
 	}
-	return conjunction.npRef.ToString(), priorities[0], conjunction.ruleName, conjunction.ruleLogLabel
+	return true, conjunction.npRef, priorities[0], conjunction.ruleName, conjunction.ruleLogLabel
 }
 
 // UninstallPolicyRuleFlows removes the Openflow entry relevant to the specified NetworkPolicy rule.

--- a/pkg/agent/openflow/network_policy_test.go
+++ b/pkg/agent/openflow/network_policy_test.go
@@ -1320,6 +1320,7 @@ func TestClient_GetPolicyInfoFromConjunction(t *testing.T) {
 	tests := []struct {
 		name             string
 		ruleID           uint32
+		valid            bool
 		wantNpRef        string
 		wantPriority     string
 		wantRuleName     string
@@ -1328,14 +1329,17 @@ func TestClient_GetPolicyInfoFromConjunction(t *testing.T) {
 		{
 			name:   "conjunction not found",
 			ruleID: uint32(100),
+			valid:  false,
 		},
 		{
 			name:   "conjunction empty priorities",
 			ruleID: ruleID1,
+			valid:  false,
 		},
 		{
 			name:             "conjunction no error",
 			ruleID:           ruleID2,
+			valid:            true,
 			wantNpRef:        "K8sNetworkPolicy:ns1/np1",
 			wantPriority:     "100",
 			wantRuleName:     fmt.Sprint(ruleID2),
@@ -1345,11 +1349,14 @@ func TestClient_GetPolicyInfoFromConjunction(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			gotNpRef, gotPriority, gotRuleName, gotRuleLogLabel := c.GetPolicyInfoFromConjunction(tc.ruleID)
-			assert.Equal(t, tc.wantNpRef, gotNpRef)
-			assert.Equal(t, tc.wantPriority, gotPriority)
-			assert.Equal(t, tc.wantRuleName, gotRuleName)
-			assert.Equal(t, tc.wantRuleLogLabel, gotRuleLogLabel)
+			ok, gotNpRef, gotPriority, gotRuleName, gotRuleLogLabel := c.GetPolicyInfoFromConjunction(tc.ruleID)
+			require.Equal(t, tc.valid, ok)
+			if tc.valid {
+				assert.Equal(t, tc.wantNpRef, gotNpRef.ToString())
+				assert.Equal(t, tc.wantPriority, gotPriority)
+				assert.Equal(t, tc.wantRuleName, gotRuleName)
+				assert.Equal(t, tc.wantRuleLogLabel, gotRuleLogLabel)
+			}
 		})
 	}
 }

--- a/pkg/agent/openflow/testing/mock_openflow.go
+++ b/pkg/agent/openflow/testing/mock_openflow.go
@@ -22,6 +22,7 @@ package testing
 import (
 	config "antrea.io/antrea/pkg/agent/config"
 	types "antrea.io/antrea/pkg/agent/types"
+	v1beta2 "antrea.io/antrea/pkg/apis/controlplane/v1beta2"
 	v1alpha2 "antrea.io/antrea/pkg/apis/crd/v1alpha2"
 	openflow "antrea.io/antrea/pkg/ovs/openflow"
 	ip "antrea.io/antrea/pkg/util/ip"
@@ -199,14 +200,15 @@ func (mr *MockClientMockRecorder) GetPodFlowKeys(arg0 interface{}) *gomock.Call 
 }
 
 // GetPolicyInfoFromConjunction mocks base method
-func (m *MockClient) GetPolicyInfoFromConjunction(arg0 uint32) (string, string, string, string) {
+func (m *MockClient) GetPolicyInfoFromConjunction(arg0 uint32) (bool, *v1beta2.NetworkPolicyReference, string, string, string) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPolicyInfoFromConjunction", arg0)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(string)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(*v1beta2.NetworkPolicyReference)
 	ret2, _ := ret[2].(string)
 	ret3, _ := ret[3].(string)
-	return ret0, ret1, ret2, ret3
+	ret4, _ := ret[4].(string)
+	return ret0, ret1, ret2, ret3, ret4
 }
 
 // GetPolicyInfoFromConjunction indicates an expected call of GetPolicyInfoFromConjunction

--- a/test/e2e/antreaipam_anp_test.go
+++ b/test/e2e/antreaipam_anp_test.go
@@ -65,7 +65,7 @@ func initializeAntreaIPAM(t *testing.T, data *TestData) {
 	failOnError(err, t)
 	ips, err := k8sUtils.Bootstrap(namespaces, pods, false)
 	failOnError(err, t)
-	podIPs = *ips
+	podIPs = ips
 }
 
 func TestAntreaIPAMAntreaPolicy(t *testing.T) {

--- a/test/e2e/antreapolicy_test.go
+++ b/test/e2e/antreapolicy_test.go
@@ -4140,7 +4140,8 @@ func testACNPMulticastEgress(t *testing.T, data *TestData, acnpName, caseName, g
 	}
 }
 
-// the logMatcher parameter takes as input the srcIP and destIP of the connection and returns a regex that should match the log entry
+// the matchers parameter is a list of regular expressions which will be matched against the
+// contents of the audit logs. The call will "succeed" if all matches are successful.
 func checkAuditLoggingResult(t *testing.T, data *TestData, nodeName, logLocator string, matchers []*regexp.Regexp) {
 	antreaPodName, err := data.getAntreaPodOnNode(nodeName)
 	if err != nil {

--- a/test/e2e/k8s_util.go
+++ b/test/e2e/k8s_util.go
@@ -1202,7 +1202,7 @@ func (k *KubernetesUtils) ValidateRemoteCluster(remoteCluster *KubernetesUtils, 
 	}
 }
 
-func (k *KubernetesUtils) Bootstrap(namespaces map[string]string, pods []string, createNamespaces bool) (*map[string][]string, error) {
+func (k *KubernetesUtils) Bootstrap(namespaces map[string]string, pods []string, createNamespaces bool) (map[string][]string, error) {
 	for _, ns := range namespaces {
 		if createNamespaces {
 			_, err := k.CreateOrUpdateNamespace(ns, map[string]string{"ns": ns})
@@ -1240,7 +1240,7 @@ func (k *KubernetesUtils) Bootstrap(namespaces map[string]string, pods []string,
 		return nil, err
 	}
 
-	return &podIPs, nil
+	return podIPs, nil
 }
 
 func (k *KubernetesUtils) Cleanup(namespaces map[string]string) {

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -16,6 +16,7 @@ package e2e
 
 import (
 	"io"
+	"net"
 	"os"
 	"time"
 
@@ -42,5 +43,16 @@ func timeCost() func(string) {
 	return func(status string) {
 		tc := time.Since(start)
 		klog.Infof("Confirming %s status costs %v", status, tc)
+	}
+}
+
+func IPFamily(ip string) string {
+	switch {
+	case net.ParseIP(ip).To4() != nil:
+		return "v4"
+	case net.ParseIP(ip).To16() != nil:
+		return "v6"
+	default:
+		return ""
 	}
 }


### PR DESCRIPTION
We include 2 new fields in the audit logs:

* the "direction" of the NP rule (`Ingress` or `Egress`)
* the reference of the Pod to which the NP rule is applied (as
  `<namespace>/<name>`).

These new fields are *NOT* added to the end of the logs, which could
break existing consumers.

We also refactor the e2e tests for AuditLogging to improve correctness
and readbility. Some logs were not validated properly because of an
early "break" statement, and some log fields (e.g., logLabel) were not
validated.

Fixes #3794