### PR TITLE
Configure Pod MTU on Agent startup

### DIFF
--- a/pkg/agent/cniserver/interface_configuration_windows.go
+++ b/pkg/agent/cniserver/interface_configuration_windows.go
@@ -191,8 +191,12 @@ func (ic *ifConfigurator) configureContainerLink(
 
 // changeContainerMTU is only used for Antrea Multi-cluster with networkPolicyOnly
 // mode, and this mode doesn't support Windows platform yet.
-func (ic *ifConfigurator) changeContainerMTU(containerNetNS string, containerIFDev string, mtuDeduction int) error {
+func (ic *ifConfigurator) changeContainerMTU(containerNetNS string, containerIFDev string, mtu int, mtuOp MTUOperation) error {
 	return errors.New("changeContainerMTU is unsupported on Windows")
+}
+
+func (ic *ifConfigurator) changeContainerMTUByHostInterfaceName(hostInterfaceName string, mtu int, mtuOp MTUOperation) error {
+	return errors.New("changeContainerMTUByHostInterfaceName is unsupported on Windows")
 }
 
 // createContainerLink creates HNSEndpoint using the IP configuration in the IPAM result.

--- a/pkg/agent/cniserver/interfaces.go
+++ b/pkg/agent/cniserver/interfaces.go
@@ -21,6 +21,13 @@ import (
 
 type postInterfaceCreateHook func() error
 
+type MTUOperation int
+
+const (
+	MTUSet MTUOperation = iota
+	MTUAdd
+)
+
 // podInterfaceConfigurator is for testing.
 type podInterfaceConfigurator interface {
 	configureContainerLink(podName string, podNamespace string, containerID string, containerNetNS string, containerIfaceName string, mtu int, brSriovVFDeviceID string, podSriovVFDeviceID string, result *current.Result, containerAccess *containerAccessArbitrator) error
@@ -31,7 +38,8 @@ type podInterfaceConfigurator interface {
 	getInterceptedInterfaces(sandbox string, containerNetNS string, containerIFDev string) (*current.Interface, *current.Interface, error)
 	checkContainerInterface(containerNetns, containerID string, containerIface *current.Interface, containerIPs []*current.IPConfig, containerRoutes []*cnitypes.Route, sriovVFDeviceID string) (interface{}, error)
 	addPostInterfaceCreateHook(containerID, endpointName string, containerAccess *containerAccessArbitrator, hook postInterfaceCreateHook) error
-	changeContainerMTU(containerNetNS string, containerIFDev string, mtuDeduction int) error
+	changeContainerMTU(containerNetNS string, containerIFDev string, mtu int, mtuOp MTUOperation) error
+	changeContainerMTUByHostInterfaceName(hostInterfaceName string, mtu int, mtuOp MTUOperation) error
 }
 
 type SriovNet interface {

--- a/pkg/agent/util/netlink/netlink_linux.go
+++ b/pkg/agent/util/netlink/netlink_linux.go
@@ -59,4 +59,6 @@ type Interface interface {
 	LinkSetName(link netlink.Link, name string) error
 
 	LinkSetUp(link netlink.Link) error
+
+	GetNetNsIdByFd(fd int) (int, error)
 }

--- a/pkg/agent/util/netlink/testing/mock_netlink_linux.go
+++ b/pkg/agent/util/netlink/testing/mock_netlink_linux.go
@@ -106,6 +106,21 @@ func (mr *MockInterfaceMockRecorder) AddrReplace(arg0, arg1 interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddrReplace", reflect.TypeOf((*MockInterface)(nil).AddrReplace), arg0, arg1)
 }
 
+// GetNetNsIdByFd mocks base method
+func (m *MockInterface) GetNetNsIdByFd(arg0 int) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNetNsIdByFd", arg0)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNetNsIdByFd indicates an expected call of GetNetNsIdByFd
+func (mr *MockInterfaceMockRecorder) GetNetNsIdByFd(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetNsIdByFd", reflect.TypeOf((*MockInterface)(nil).GetNetNsIdByFd), arg0)
+}
+
 // LinkByIndex mocks base method
 func (m *MockInterface) LinkByIndex(arg0 int) (netlink.Link, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Currently, the Pods' MTU will not be updated once created. This will cause issues when the Pod's MTU need to be changed. e.g. User redeploys Antrea with IPsec or WireGuard enabled, or user sets the default MTU to a different value. For now, user must restart all Pods to set the correct MTU. This patch will fix this issue by setting the Pod's MTU on agent startup.