### PR TITLE
Change default port range for NodePortLocal on Windows and improve NPL e2e tests

### DIFF
--- a/build/yamls/antrea-windows-containerd.yml
+++ b/build/yamls/antrea-windows-containerd.yml
@@ -168,7 +168,7 @@ data:
     # from that range will be assigned whenever a Pod's container defines a specific port to be exposed
     # (each container can define a list of ports as pod.spec.containers[].ports), and all Node traffic
     # directed to that port will be forwarded to the Pod.
-    #  portRange: 61000-62000
+    #  portRange: 40000-41000
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -187,7 +187,7 @@ kind: ConfigMap
 metadata:
   labels:
     app: antrea
-  name: antrea-windows-config-8kfkb8t957
+  name: antrea-windows-config-89b7ch9t9b
   namespace: kube-system
 ---
 apiVersion: apps/v1
@@ -271,7 +271,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-windows-config-8kfkb8t957
+          name: antrea-windows-config-89b7ch9t9b
         name: antrea-windows-config
       - configMap:
           defaultMode: 420

--- a/build/yamls/antrea-windows.yml
+++ b/build/yamls/antrea-windows.yml
@@ -158,7 +158,7 @@ data:
     # from that range will be assigned whenever a Pod's container defines a specific port to be exposed
     # (each container can define a list of ports as pod.spec.containers[].ports), and all Node traffic
     # directed to that port will be forwarded to the Pod.
-    #  portRange: 61000-62000
+    #  portRange: 40000-41000
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -177,7 +177,7 @@ kind: ConfigMap
 metadata:
   labels:
     app: antrea
-  name: antrea-windows-config-cmccc6hbb4
+  name: antrea-windows-config-hc82tmf96f
   namespace: kube-system
 ---
 apiVersion: apps/v1
@@ -265,7 +265,7 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-windows-config-cmccc6hbb4
+          name: antrea-windows-config-hc82tmf96f
         name: antrea-windows-config
       - configMap:
           defaultMode: 420

--- a/build/yamls/windows/base/conf/antrea-agent.conf
+++ b/build/yamls/windows/base/conf/antrea-agent.conf
@@ -140,4 +140,4 @@ nodePortLocal:
 # from that range will be assigned whenever a Pod's container defines a specific port to be exposed
 # (each container can define a list of ports as pod.spec.containers[].ports), and all Node traffic
 # directed to that port will be forwarded to the Pod.
-#  portRange: 61000-62000
+#  portRange: 40000-41000

--- a/cmd/antrea-agent/options.go
+++ b/cmd/antrea-agent/options.go
@@ -53,7 +53,6 @@ const (
 	defaultIdleFlowExportTimeout   = "15s"
 	defaultIGMPQueryInterval       = 125 * time.Second
 	defaultStaleConnectionTimeout  = 5 * time.Minute
-	defaultNPLPortRange            = "61000-62000"
 	defaultNodeType                = config.K8sNode
 	defaultMaxEgressIPsPerNode     = 255
 )

--- a/cmd/antrea-agent/options_linux.go
+++ b/cmd/antrea-agent/options_linux.go
@@ -17,6 +17,10 @@
 
 package main
 
+const (
+	defaultNPLPortRange = "61000-62000"
+)
+
 func (o *Options) checkUnsupportedFeatures() error {
 	// All features are supported on a Linux Node.
 	return nil

--- a/cmd/antrea-agent/options_windows.go
+++ b/cmd/antrea-agent/options_windows.go
@@ -29,6 +29,10 @@ import (
 	"antrea.io/antrea/pkg/ovs/ovsconfig"
 )
 
+const (
+	defaultNPLPortRange = "40000-41000"
+)
+
 func (o *Options) checkUnsupportedFeatures() error {
 	var unsupported []string
 

--- a/pkg/agent/nodeportlocal/k8s/npl_controller.go
+++ b/pkg/agent/nodeportlocal/k8s/npl_controller.go
@@ -510,7 +510,6 @@ func (c *NPLController) handleAddUpdatePod(key string, obj interface{}) error {
 		} else {
 			nodePort = portData.NodePort
 		}
-
 		if _, ok := nplAnnotationsRequiredMap[portcache.NodePortProtoFormat(nodePort, protocol)]; !ok {
 			nplAnnotationsRequiredMap[portcache.NodePortProtoFormat(nodePort, protocol)] = types.NPLAnnotation{
 				PodPort:   port,


### PR DESCRIPTION
There were a few issues contributing to NPL tests' flake:

* testNPLAddPod failed because Windows default port range for random source
port overlaps with the port range used for NPL testing.

* testNPLChangePortRangeAgentRestart failed because it takes more than 3
seconds to execute powershell command on the testbed for each rules.
After agent restarting, when the annotation is read before it is updated,
test fails due to incorrect mapping between netnat and annotation.

* Test may fail randomly during image pulling, which occurs when the Windows
node has low disk space and randomly clean available images. This results in
a re-pull of large images when creating new pods during e2e test, causing
timeout failures

This commit fixes them via the following changes:

* Update e2e and windows NPL default port range to avoid race condition when
inserting Netnat rules.

* Add time wait after agent restarting for windows annotation update.

* Pull the test images after building image to avoid random deletion due to
host disk pressure during image building process.