### PR TITLE
Remove the associated stale conntrack entries when UDP Endpoints are removed

### DIFF
--- a/build/charts/antrea/conf/antrea-agent.conf
+++ b/build/charts/antrea/conf/antrea-agent.conf
@@ -20,6 +20,10 @@ featureGates:
 # enabled, otherwise this flag will not take effect.
 {{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "TopologyAwareHints" "default" true) }}
 
+# Enable support for cleaning up stale UDP Service conntrack connections in AntreaProxy. This requires AntreaProxy to
+# be enabled, otherwise this flag will not take effect.
+{{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "CleanupStaleUDPSvcConntrack" "default" false) }}
+
 # Enable traceflow which provides packet tracing feature to diagnose network issue.
 {{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "Traceflow" "default" true) }}
 

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -3111,6 +3111,10 @@ data:
     # enabled, otherwise this flag will not take effect.
     #  TopologyAwareHints: true
 
+    # Enable support for cleaning up stale UDP Service conntrack connections in AntreaProxy. This requires AntreaProxy to
+    # be enabled, otherwise this flag will not take effect.
+    #  CleanupStaleUDPSvcConntrack: false
+
     # Enable traceflow which provides packet tracing feature to diagnose network issue.
     #  Traceflow: true
 
@@ -4553,7 +4557,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 4ebea7300356a753d716270575de36dd3584f67dd62607cd6c9c2a115ac92e62
+        checksum/config: e3208d24eb3232bd1fa2936e6b7a265c2ff3b462b5091828467c88f9df0e0b42
       labels:
         app: antrea
         component: antrea-agent
@@ -4794,7 +4798,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 4ebea7300356a753d716270575de36dd3584f67dd62607cd6c9c2a115ac92e62
+        checksum/config: e3208d24eb3232bd1fa2936e6b7a265c2ff3b462b5091828467c88f9df0e0b42
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -3111,6 +3111,10 @@ data:
     # enabled, otherwise this flag will not take effect.
     #  TopologyAwareHints: true
 
+    # Enable support for cleaning up stale UDP Service conntrack connections in AntreaProxy. This requires AntreaProxy to
+    # be enabled, otherwise this flag will not take effect.
+    #  CleanupStaleUDPSvcConntrack: false
+
     # Enable traceflow which provides packet tracing feature to diagnose network issue.
     #  Traceflow: true
 
@@ -4553,7 +4557,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 4ebea7300356a753d716270575de36dd3584f67dd62607cd6c9c2a115ac92e62
+        checksum/config: e3208d24eb3232bd1fa2936e6b7a265c2ff3b462b5091828467c88f9df0e0b42
       labels:
         app: antrea
         component: antrea-agent
@@ -4795,7 +4799,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 4ebea7300356a753d716270575de36dd3584f67dd62607cd6c9c2a115ac92e62
+        checksum/config: e3208d24eb3232bd1fa2936e6b7a265c2ff3b462b5091828467c88f9df0e0b42
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -3111,6 +3111,10 @@ data:
     # enabled, otherwise this flag will not take effect.
     #  TopologyAwareHints: true
 
+    # Enable support for cleaning up stale UDP Service conntrack connections in AntreaProxy. This requires AntreaProxy to
+    # be enabled, otherwise this flag will not take effect.
+    #  CleanupStaleUDPSvcConntrack: false
+
     # Enable traceflow which provides packet tracing feature to diagnose network issue.
     #  Traceflow: true
 
@@ -4553,7 +4557,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 48b346133ac76c11a6c456d99aa93c2421e5598a13b9d18d5dd58d6cce5408ff
+        checksum/config: cec624c3579d3f07e29b6842e3bcc09a12963c97da2c4e24afa646b6c3875809
       labels:
         app: antrea
         component: antrea-agent
@@ -4792,7 +4796,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 48b346133ac76c11a6c456d99aa93c2421e5598a13b9d18d5dd58d6cce5408ff
+        checksum/config: cec624c3579d3f07e29b6842e3bcc09a12963c97da2c4e24afa646b6c3875809
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -3124,6 +3124,10 @@ data:
     # enabled, otherwise this flag will not take effect.
     #  TopologyAwareHints: true
 
+    # Enable support for cleaning up stale UDP Service conntrack connections in AntreaProxy. This requires AntreaProxy to
+    # be enabled, otherwise this flag will not take effect.
+    #  CleanupStaleUDPSvcConntrack: false
+
     # Enable traceflow which provides packet tracing feature to diagnose network issue.
     #  Traceflow: true
 
@@ -4566,7 +4570,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: c464a20c63a45190125a9bacb8d0b25cf04ad0e1f45e9bc2be76ebdb74d758bf
+        checksum/config: 711e1747ccd17b291d523080c4942e215d7499a6b00f936149c488cdaef6d342
         checksum/ipsec-secret: d0eb9c52d0cd4311b6d252a951126bf9bea27ec05590bed8a394f0f792dcb2a4
       labels:
         app: antrea
@@ -4851,7 +4855,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: c464a20c63a45190125a9bacb8d0b25cf04ad0e1f45e9bc2be76ebdb74d758bf
+        checksum/config: 711e1747ccd17b291d523080c4942e215d7499a6b00f936149c488cdaef6d342
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -3111,6 +3111,10 @@ data:
     # enabled, otherwise this flag will not take effect.
     #  TopologyAwareHints: true
 
+    # Enable support for cleaning up stale UDP Service conntrack connections in AntreaProxy. This requires AntreaProxy to
+    # be enabled, otherwise this flag will not take effect.
+    #  CleanupStaleUDPSvcConntrack: false
+
     # Enable traceflow which provides packet tracing feature to diagnose network issue.
     #  Traceflow: true
 
@@ -4553,7 +4557,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 38c3b07d25dc21a29a2e7c91aaa95475191b53ca77639ceada4a2604b6425666
+        checksum/config: 96448ab5ddc455d898d31956cc9d15fae055b4fb4bdc9acc9dc765ca125c0867
       labels:
         app: antrea
         component: antrea-agent
@@ -4792,7 +4796,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 38c3b07d25dc21a29a2e7c91aaa95475191b53ca77639ceada4a2604b6425666
+        checksum/config: 96448ab5ddc455d898d31956cc9d15fae055b4fb4bdc9acc9dc765ca125c0867
       labels:
         app: antrea
         component: antrea-controller

--- a/docs/feature-gates.md
+++ b/docs/feature-gates.md
@@ -32,28 +32,29 @@ edit the Agent configuration in the
 
 ## List of Available Features
 
-| Feature Name              | Component          | Default | Stage | Alpha Release | Beta Release | GA Release | Extra Requirements | Notes |
-|---------------------------|--------------------|---------|-------|---------------|--------------| ---------- |--------------------| ----- |
-| `AntreaProxy`             | Agent              | `true`  | Beta  | v0.8          | v0.11        | N/A        | Yes                | Must be enabled for Windows. |
-| `EndpointSlice`           | Agent              | `true`  | Beta  | v0.13.0       | v1.11        | N/A        | Yes                |       |
-| `TopologyAwareHints`      | Agent              | `true`  | Beta  | v1.8          | v1.12        | N/A        | Yes                |       |
-| `LoadBalancerModeDSR`     | Agent              | `false` | Alpha | v1.13         | N/A          | N/A        | Yes                |       |
-| `AntreaPolicy`            | Agent + Controller | `true`  | Beta  | v0.8          | v1.0         | N/A        | No                 | Agent side config required from v0.9.0+. |
-| `Traceflow`               | Agent + Controller | `true`  | Beta  | v0.8          | v0.11        | N/A        | Yes                |       |
-| `FlowExporter`            | Agent              | `false` | Alpha | v0.9          | N/A          | N/A        | Yes                |       |
-| `NetworkPolicyStats`      | Agent + Controller | `true`  | Beta  | v0.10         | v1.2         | N/A        | No                 |       |
-| `NodePortLocal`           | Agent              | `true`  | Beta  | v0.13         | v1.4         | N/A        | Yes                | Important user-facing change in v1.2.0 |
-| `Egress`                  | Agent + Controller | `true`  | Beta  | v1.0          | v1.6         | N/A        | Yes                |       |
-| `NodeIPAM`                | Controller         | `true`  | Beta  | v1.4          | v1.12        | N/A        | Yes                |       |
-| `AntreaIPAM`              | Agent + Controller | `false` | Alpha | v1.4          | N/A          | N/A        | Yes                |       |
-| `Multicast`               | Agent + Controller | `true`  | Beta  | v1.5          | v1.12        | N/A        | Yes                |       |
-| `SecondaryNetwork`        | Agent              | `false` | Alpha | v1.5          | N/A          | N/A        | Yes                |       |
-| `ServiceExternalIP`       | Agent + Controller | `false` | Alpha | v1.5          | N/A          | N/A        | Yes                |       |
-| `TrafficControl`          | Agent              | `false` | Alpha | v1.7          | N/A          | N/A        | No                 |       |
-| `Multicluster`            | Agent + Controller | `false` | Alpha | v1.7          | N/A          | N/A        | Yes                | Controller side feature gate added in v1.10.0 |
-| `ExternalNode`            | Agent              | `false` | Alpha | v1.8          | N/A          | N/A        | Yes                |       |
-| `SupportBundleCollection` | Agent + Controller | `false` | Alpha | v1.10         | N/A          | N/A        | Yes                |       |
-| `L7NetworkPolicy`         | Agent + Controller | `false` | Alpha | v1.10         | N/A          | N/A        | Yes                |       |
+| Feature Name                  | Component           | Default | Stage | Alpha Release | Beta Release | GA Release | Extra Requirements | Notes |
+|-------------------------------|---------------------|---------|-------|---------------|--------------| ---------- |--------------------| ----- |
+| `AntreaProxy`                 | Agent               | `true`  | Beta  | v0.8          | v0.11        | N/A        | Yes                | Must be enabled for Windows. |
+| `EndpointSlice`               | Agent               | `true`  | Beta  | v0.13.0       | v1.11        | N/A        | Yes                |       |
+| `TopologyAwareHints`          | Agent               | `true`  | Beta  | v1.8          | v1.12        | N/A        | Yes                |       |
+| `CleanupStaleUDPSvcConntrack` | Agent               | `false` | Alpha | v1.13         | N/A          | N/A        | Yes                |       |
+| `LoadBalancerModeDSR`         | Agent               | `false` | Alpha | v1.13         | N/A          | N/A        | Yes                |       |
+| `AntreaPolicy`                | Agent + Controller  | `true`  | Beta  | v0.8          | v1.0         | N/A        | No                 | Agent side config required from v0.9.0+. |
+| `Traceflow`                   | Agent + Controller  | `true`  | Beta  | v0.8          | v0.11        | N/A        | Yes                |       |
+| `FlowExporter`                | Agent               | `false` | Alpha | v0.9          | N/A          | N/A        | Yes                |       |
+| `NetworkPolicyStats`          | Agent + Controller  | `true`  | Beta  | v0.10         | v1.2         | N/A        | No                 |       |
+| `NodePortLocal`               | Agent               | `true`  | Beta  | v0.13         | v1.4         | N/A        | Yes                | Important user-facing change in v1.2.0 |
+| `Egress`                      | Agent + Controller  | `true`  | Beta  | v1.0          | v1.6         | N/A        | Yes                |       |
+| `NodeIPAM`                    | Controller          | `true`  | Beta  | v1.4          | v1.12        | N/A        | Yes                |       |
+| `AntreaIPAM`                  | Agent + Controller  | `false` | Alpha | v1.4          | N/A          | N/A        | Yes                |       |
+| `Multicast`                   | Agent + Controller  | `true`  | Beta  | v1.5          | v1.12        | N/A        | Yes                |       |
+| `SecondaryNetwork`            | Agent               | `false` | Alpha | v1.5          | N/A          | N/A        | Yes                |       |
+| `ServiceExternalIP`           | Agent + Controller  | `false` | Alpha | v1.5          | N/A          | N/A        | Yes                |       |
+| `TrafficControl`              | Agent               | `false` | Alpha | v1.7          | N/A          | N/A        | No                 |       |
+| `Multicluster`                | Agent + Controller  | `false` | Alpha | v1.7          | N/A          | N/A        | Yes                | Controller side feature gate added in v1.10.0 |
+| `ExternalNode`                | Agent               | `false` | Alpha | v1.8          | N/A          | N/A        | Yes                |       |
+| `SupportBundleCollection`     | Agent + Controller  | `false` | Alpha | v1.10         | N/A          | N/A        | Yes                |       |
+| `L7NetworkPolicy`             | Agent + Controller  | `false` | Alpha | v1.10         | N/A          | N/A        | Yes                |       |
 
 ## Description and Requirements of Features
 
@@ -116,6 +117,14 @@ antrea-proxy.md#configuring-load-balancer-mode-for-external-traffic) for more in
 - IPv4 only.
 - Linux Nodes only.
 - Encap mode only.
+
+### CleanupStaleUDPSvcConntrack
+
+`CleanupStaleUDPSvcConntrack` enables support for cleaning up stale UDP Service conntrack connections in AntreaProxy.
+
+#### Requirements for this Feature
+
+- `AntreaProxy` is enabled.
 
 ### AntreaPolicy
 

--- a/pkg/agent/route/interfaces.go
+++ b/pkg/agent/route/interfaces.go
@@ -87,4 +87,7 @@ type Interface interface {
 
 	// DeleteRouteForLink deletes a route entry for a specific link.
 	DeleteRouteForLink(dstCIDR *net.IPNet, linkIndex int) error
+
+	// ClearConntrackEntryForService deletes a conntrack entry for a Service connection.
+	ClearConntrackEntryForService(svcIP net.IP, svcPort uint16, endpointIP net.IP, protocol binding.Protocol) error
 }

--- a/pkg/agent/route/route_windows.go
+++ b/pkg/agent/route/route_windows.go
@@ -591,3 +591,7 @@ func (c *Client) AddRouteForLink(dstCIDR *net.IPNet, linkIndex int) error {
 func (c *Client) DeleteRouteForLink(dstCIDR *net.IPNet, linkIndex int) error {
 	return errors.New("DeleteRouteForLink is not implemented on Windows")
 }
+
+func (c *Client) ClearConntrackEntryForService(svcIP net.IP, svcPort uint16, endpointIP net.IP, protocol binding.Protocol) error {
+	return errors.New("ClearConntrackEntryForService is not implemented on Windows")
+}

--- a/pkg/agent/route/testing/mock_route.go
+++ b/pkg/agent/route/testing/mock_route.go
@@ -134,6 +134,20 @@ func (mr *MockInterfaceMockRecorder) AddSNATRule(arg0, arg1 interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddSNATRule", reflect.TypeOf((*MockInterface)(nil).AddSNATRule), arg0, arg1)
 }
 
+// ClearConntrackEntryForService mocks base method
+func (m *MockInterface) ClearConntrackEntryForService(arg0 net.IP, arg1 uint16, arg2 net.IP, arg3 openflow.Protocol) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ClearConntrackEntryForService", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ClearConntrackEntryForService indicates an expected call of ClearConntrackEntryForService
+func (mr *MockInterfaceMockRecorder) ClearConntrackEntryForService(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearConntrackEntryForService", reflect.TypeOf((*MockInterface)(nil).ClearConntrackEntryForService), arg0, arg1, arg2, arg3)
+}
+
 // DeleteExternalIPRoute mocks base method
 func (m *MockInterface) DeleteExternalIPRoute(arg0 net.IP) error {
 	m.ctrl.T.Helper()

--- a/pkg/agent/util/netlink/netlink_linux.go
+++ b/pkg/agent/util/netlink/netlink_linux.go
@@ -59,4 +59,6 @@ type Interface interface {
 	LinkSetName(link netlink.Link, name string) error
 
 	LinkSetUp(link netlink.Link) error
+
+	ConntrackDeleteFilter(table netlink.ConntrackTableType, family netlink.InetFamily, filter netlink.CustomConntrackFilter) (uint, error)
 }

--- a/pkg/agent/util/netlink/testing/mock_netlink_linux.go
+++ b/pkg/agent/util/netlink/testing/mock_netlink_linux.go
@@ -106,6 +106,21 @@ func (mr *MockInterfaceMockRecorder) AddrReplace(arg0, arg1 interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddrReplace", reflect.TypeOf((*MockInterface)(nil).AddrReplace), arg0, arg1)
 }
 
+// ConntrackDeleteFilter mocks base method
+func (m *MockInterface) ConntrackDeleteFilter(arg0 netlink.ConntrackTableType, arg1 netlink.InetFamily, arg2 netlink.CustomConntrackFilter) (uint, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ConntrackDeleteFilter", arg0, arg1, arg2)
+	ret0, _ := ret[0].(uint)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ConntrackDeleteFilter indicates an expected call of ConntrackDeleteFilter
+func (mr *MockInterfaceMockRecorder) ConntrackDeleteFilter(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConntrackDeleteFilter", reflect.TypeOf((*MockInterface)(nil).ConntrackDeleteFilter), arg0, arg1, arg2)
+}
+
 // LinkByIndex mocks base method
 func (m *MockInterface) LinkByIndex(arg0 int) (netlink.Link, error) {
 	m.ctrl.T.Helper()

--- a/pkg/features/antrea_features.go
+++ b/pkg/features/antrea_features.go
@@ -33,7 +33,7 @@ const (
 
 	// alpha: v0.8
 	// beta: v1.0
-	// Enables support for ClusterNetworkPolicy and AntreaNetworkPolicy CRDs.
+	// Enable support for ClusterNetworkPolicy and AntreaNetworkPolicy CRDs.
 	AntreaPolicy featuregate.Feature = "AntreaPolicy"
 
 	// alpha: v0.13
@@ -47,6 +47,10 @@ const (
 	// Enable TopologyAwareHints in AntreaProxy. If EndpointSlice is not enabled, this
 	// flag will not take effect.
 	TopologyAwareHints featuregate.Feature = "TopologyAwareHints"
+
+	// alpha: v1.13
+	// Enable support for cleaning up stale UDP Service conntrack connections in AntreaProxy.
+	CleanupStaleUDPSvcConntrack featuregate.Feature = "CleanupStaleUDPSvcConntrack"
 
 	// alpha: v0.8
 	// beta: v0.11
@@ -143,27 +147,28 @@ var (
 	// To add a new feature, define a key for it above and add it here. The features will be
 	// available throughout Antrea binaries.
 	DefaultAntreaFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-		AntreaPolicy:            {Default: true, PreRelease: featuregate.Beta},
-		AntreaProxy:             {Default: true, PreRelease: featuregate.Beta},
-		Egress:                  {Default: true, PreRelease: featuregate.Beta},
-		EndpointSlice:           {Default: true, PreRelease: featuregate.Beta},
-		TopologyAwareHints:      {Default: true, PreRelease: featuregate.Beta},
-		Traceflow:               {Default: true, PreRelease: featuregate.Beta},
-		AntreaIPAM:              {Default: false, PreRelease: featuregate.Alpha},
-		FlowExporter:            {Default: false, PreRelease: featuregate.Alpha},
-		NetworkPolicyStats:      {Default: true, PreRelease: featuregate.Beta},
-		NodePortLocal:           {Default: true, PreRelease: featuregate.Beta},
-		NodeIPAM:                {Default: true, PreRelease: featuregate.Beta},
-		Multicast:               {Default: true, PreRelease: featuregate.Beta},
-		Multicluster:            {Default: false, PreRelease: featuregate.Alpha},
-		SecondaryNetwork:        {Default: false, PreRelease: featuregate.Alpha},
-		ServiceExternalIP:       {Default: false, PreRelease: featuregate.Alpha},
-		TrafficControl:          {Default: false, PreRelease: featuregate.Alpha},
-		IPsecCertAuth:           {Default: false, PreRelease: featuregate.Alpha},
-		ExternalNode:            {Default: false, PreRelease: featuregate.Alpha},
-		SupportBundleCollection: {Default: false, PreRelease: featuregate.Alpha},
-		L7NetworkPolicy:         {Default: false, PreRelease: featuregate.Alpha},
-		LoadBalancerModeDSR:     {Default: false, PreRelease: featuregate.Alpha},
+		AntreaPolicy:                {Default: true, PreRelease: featuregate.Beta},
+		AntreaProxy:                 {Default: true, PreRelease: featuregate.Beta},
+		Egress:                      {Default: true, PreRelease: featuregate.Beta},
+		EndpointSlice:               {Default: true, PreRelease: featuregate.Beta},
+		TopologyAwareHints:          {Default: true, PreRelease: featuregate.Beta},
+		CleanupStaleUDPSvcConntrack: {Default: false, PreRelease: featuregate.Alpha},
+		Traceflow:                   {Default: true, PreRelease: featuregate.Beta},
+		AntreaIPAM:                  {Default: false, PreRelease: featuregate.Alpha},
+		FlowExporter:                {Default: false, PreRelease: featuregate.Alpha},
+		NetworkPolicyStats:          {Default: true, PreRelease: featuregate.Beta},
+		NodePortLocal:               {Default: true, PreRelease: featuregate.Beta},
+		NodeIPAM:                    {Default: true, PreRelease: featuregate.Beta},
+		Multicast:                   {Default: true, PreRelease: featuregate.Beta},
+		Multicluster:                {Default: false, PreRelease: featuregate.Alpha},
+		SecondaryNetwork:            {Default: false, PreRelease: featuregate.Alpha},
+		ServiceExternalIP:           {Default: false, PreRelease: featuregate.Alpha},
+		TrafficControl:              {Default: false, PreRelease: featuregate.Alpha},
+		IPsecCertAuth:               {Default: false, PreRelease: featuregate.Alpha},
+		ExternalNode:                {Default: false, PreRelease: featuregate.Alpha},
+		SupportBundleCollection:     {Default: false, PreRelease: featuregate.Alpha},
+		L7NetworkPolicy:             {Default: false, PreRelease: featuregate.Alpha},
+		LoadBalancerModeDSR:         {Default: false, PreRelease: featuregate.Alpha},
 	}
 
 	// UnsupportedFeaturesOnWindows records the features not supported on
@@ -183,11 +188,12 @@ var (
 		SecondaryNetwork:  {},
 		ServiceExternalIP: {},
 		IPsecCertAuth:     {},
-		// Multicluster feature is not validated on Windows yet. This can removed
+		// Multicluster feature is not validated on Windows yet. This can be removed
 		// in the future if it's fully tested on Windows.
-		Multicluster:        {},
-		L7NetworkPolicy:     {},
-		LoadBalancerModeDSR: {},
+		Multicluster:                {},
+		L7NetworkPolicy:             {},
+		LoadBalancerModeDSR:         {},
+		CleanupStaleUDPSvcConntrack: {},
 	}
 	// supportedFeaturesOnExternalNode records the features supported on an external
 	// Node. Antrea Agent checks the enabled features if it is running on an


### PR DESCRIPTION
Previously, when a client accessed a UDP Service through AntreaProxy, if the
selected backend Pod was deleted and no new available backend Pod was automatically
selected by AntreaProxy, the connection would always remain unavailable. This issue
occurred because a conntrack entry was generated through OVS ct action in AntreaProxy
when handling the first packet of the UDP connection. Even if the selected Endpoint
was removed, the conntrack entry's timeout would be flushed upon receiving a packet
from the client in AntreaProxy OVS pipeline. Consequently, the stale conntrack entry
would persist as long as the client continued sending packets to the UDP service,
causing AntreaProxy's OVS pipeline to direct the packets to the IP of the removed
backend Pod.

This PR addresses the issue by removing the stale conntrack entries when the
associated UDP Endpoints are removed. This ensures that a new available backend Pod
can be selected in AntreaProxy's OVS pipeline.

Please note the following:

- Currently, this implementation is only available on Linux.
- Due to the restriction of the go library 'netlink', there is no API to specify a
  target zone. As a result, when deleting a stale conntrack entry with a
  destination port (such as NodePort), not only will the conntrack entry whose
  destination port is the port added by AntreaProxy be deleted, but also the
  conntrack entry that is not added by AntreaProxy will be deleted. This behavior
  is unexpected, as only the conntrack entries added by AntreaProxy should be
  deleted.
