### PR TITLE
Add information about K8s compatability

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,28 @@ Antrea has been tested with Kubernetes clusters running version 1.16 or later.
 Getting started with Antrea is very simple, and takes only a few minutes.
 See how it's done in the [Getting started](docs/getting-started.md) document.
 
+## Kubernetes Compatibility
+
+We strive to stay up-to-date with the latest Kubernetes releases and provide
+timely updates and patches to maintain compatibility with future versions as
+well. The table lists the compatibility of Antrea with different Kubernetes
+versions currently under maintenance.
+
+:white_check_mark: means that we have run the
+[Kubernetes Conformance test suite](https://github.com/kubernetes/kubernetes/blob/master/test/conformance/testdata/conformance.yaml)
+on both Linux and Windows and they passed for the versions listed.
+
+| Antrea                                                              |    Kubernetes 1.27     |    Kubernetes 1.26     |  Kubernetes 1.25   |  Kubernetes 1.24   |
+|---------------------------------------------------------------------|:----------------------:|:----------------------:|:------------------:|:------------------:|
+| [v1.12.0](https://github.com/antrea-io/antrea/releases/tag/v1.12.0) | :white_check_mark:[^1] | :white_check_mark:[^1] | :white_check_mark: | :white_check_mark: |
+| [v1.11.2](https://github.com/antrea-io/antrea/releases/tag/v1.11.2) | :white_check_mark:[^1] | :white_check_mark:[^1] | :white_check_mark: | :white_check_mark: |
+
+[^1]: antrea-agent on Windows Node was deployed with `antreaProxy.proxyAll` due to [the removal of kube-proxy userspace modes](https://kubernetes.io/blog/2022/11/18/upcoming-changes-in-kubernetes-1-26/#removal-of-kube-proxy-userspace-modes).
+
+For compatability with historical versions, check out
+[supported K8s versions](docs/versioning.md#supported-k8s-versions) for more
+information.
+
 ## Contributing
 
 The Antrea community welcomes new contributors. We are waiting for your PRs!

--- a/docs/maintainers/maintaining-k8s-compatibity.md
+++ b/docs/maintainers/maintaining-k8s-compatibity.md
@@ -1,0 +1,31 @@
+# Maintaining Kubernetes Compatibility
+
+Upon the release of a Kubernetes minor release (e.g. [v1.28.0, on 15th August 2023](https://github.com/kubernetes/sig-release/tree/master/releases/release-1.28)),
+the maintainer in charge of release should do the following to maintain
+compatibility with this K8s release.
+
+1. Check out its changelog to see if there are any changes that may affect its
+   compatibility with Antrea.
+
+2. Run Kubernetes Conformance tests with the new K8s minor release and the
+   Antrea releases under maintenance (the two most recent minor releases).
+   - For Linux, you can run the tests through [the workflow](https://github.com/antrea-io/antrea/actions/workflows/conformance.yml)
+     Click on `Run workflow`, enter the Antrea versions to test (e.g.
+     `v1.12.0`, `v1.11.2`), enter the K8s versions to test (e.g. `v1.28.0`).
+     You typically do not need to specify the Antrea Chart values and change
+     the test suite to run.
+   - For Windows, it is not automated at the moment. You need to manually
+     set up the testbed and run the tests.
+
+3. Regardless of whether a compatibility issue is found, open a PR against the
+   main branch to update [Kubernetes Compatibility](../../README.md#kubernetes-compatibility)
+   and [Supported K8s versions](../versioning.md#supported-k8s-versions) with
+   the actual results.
+
+4. If there are any compatibility issues, open issues to track them.
+
+5. If the issues are resolvable and the patches are backportable, you should
+   create Antrea patch versions to recover compatibility with this K8s release,
+   and open a PR to update [Kubernetes Compatibility](../../README.md#kubernetes-compatibility)
+   and [Supported K8s versions](../versioning.md#supported-k8s-versions) with
+   the latest results.

--- a/docs/maintainers/release.md
+++ b/docs/maintainers/release.md
@@ -41,6 +41,13 @@ release. We use `<TAG>` as a placeholder for the release tag (e.g. `v1.4.0`).
      branch as `ANTREA_GIT_REVISION`. Test starting times need to be staggered:
      if multiple jobs run at the same time, the Jenkins worker may run
      out-of-memory.
+   - Kubernetes compatibility tests need to be triggered manually through
+     [the workflow](https://github.com/antrea-io/antrea/actions/workflows/conformance.yml)
+     to ensure the release is compatible with all [active K8s releases](https://kubernetes.io/releases/)
+     at the time of release. Click on `Run workflow`, enter the Antrea release
+     to test (e.g. `release-1.12`), enter the K8s versions to test (e.g.
+     `v1.27.2, v1.26.4, v1.25.9, v1.24.13`). You typically do not need to
+     specify the Antrea Chart values and change the test suite to run.
 
 4. Request a review from the other maintainers, and anyone else who may need to
    review the release notes. In case of feedback, you may want to consider
@@ -81,10 +88,14 @@ release. We use `<TAG>` as a placeholder for the release tag (e.g. `v1.4.0`).
    contents of the PR and merge it (no need to run the tests, use admin
    privileges).
 
-8. *For a minor release* Finally, open a PR against the main branch with a
-   single commit, to update [VERSION](../../VERSION) to the next minor version
-   (with `-dev` suffix). For example, if the release was for `v1.4.0`, the
-   VERSION file should be updated to `v1.5.0-dev`. Before committing, ensure
-   that you run `make -C build/charts/ helm-docs` and include the changes. Note
-   that after a patch release, the VERSION file in the main branch is never
-   updated, so no additional commit is needed.
+8. Finally, open a PR against the main branch with a single commit, to update
+   the following:
+   - *For a minor release* update [VERSION](../../VERSION) to the next minor
+     version (with `-dev` suffix). For example, if the release was for `v1.4.0`,
+     the VERSION file should be updated to `v1.5.0-dev`. Ensure that you run
+     `make -C build/charts/ helm-docs` and include the changes. Note that after
+     a patch release, the VERSION file in the main branch is never updated, so
+     this step is not needed.
+   - update [Kubernetes Compatibility](../../README.md#kubernetes-compatibility)
+     and [Supported K8s versions](../versioning.md#supported-k8s-versions) with
+     the K8s versions that have been validated.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -136,6 +136,21 @@ also supports K8s 1.16).
 In addition, we strive to support the K8s versions used by default in
 cloud-managed K8s services ([EKS], [AKS] and [GKE] regular channel).
 
+The table lists the compatibility of Antrea with different K8s releases that
+we ever tested. In practice Antrea may work on releases that are not listed in
+the table, but we did not test them. We recommend that you run a comprehensive
+test (e.g. with [sonobuoy](https://github.com/vmware-tanzu/sonobuoy)) first
+before using a combination not listed here.
+
+| Antrea Release | Antrea Latest Patch Version                                         | Supported Kubernetes Releases        |
+|----------------|---------------------------------------------------------------------|--------------------------------------|
+| 1.12           | [v1.12.0](https://github.com/antrea-io/antrea/releases/tag/v1.12.0) | 1.27[^1], 1.26[^1], 1.25, 1.24       |
+| 1.11           | [v1.11.2](https://github.com/antrea-io/antrea/releases/tag/v1.11.2) | 1.27[^1], 1.26[^1], 1.25, 1.24, 1.23 |
+| 1.10 (EOL)     | [v1.10.1](https://github.com/antrea-io/antrea/releases/tag/v1.10.1) | 1.26[^1], 1.25, 1.24, 1.23, 1.22     |
+| 1.9 (EOL)      | [v1.9.1](https://github.com/antrea-io/antrea/releases/tag/v1.9.1)   | 1.26[^1], 1.25, 1.24, 1.23, 1.22     |
+
+[^1]: antrea-agent on Windows Node was deployed with `antreaProxy.proxyAll` due to [the removal of kube-proxy userspace modes](https://kubernetes.io/blog/2022/11/18/upcoming-changes-in-kubernetes-1-26/#removal-of-kube-proxy-userspace-modes).
+
 ## Deprecation policies
 
 ### Prometheus metrics deprecation policy


### PR DESCRIPTION
We didn't have a formal process to deal with the releases of K8s minor releases. This created potential risks of incompatibility and caused uncertainty of compatibility.

This commit adds information about K8s compatability and processes to keep them up-to-date.

------
This depends on several subtasks:

- [ ] Make [the conformance workflow](https://github.com/antrea-io/antrea/actions/workflows/conformance.yml) support running multiple tests with different K8s versions in one run.
- [ ] Validate the compatibility listed in the tables on both Linux and Windows, following the proposed workflow.
  - [ ] v1.12.0
  - [ ] v1.11.2
  - [ ] v1.10.1
  - [ ] v1.9.1 (or we can remove it from the table)