### PR TITLE
Automated cherry pick of #5075: Fix ClusterClaim deletion webhook bug

### DIFF
--- a/multicluster/cmd/multicluster-controller/clusterclaim_webhook.go
+++ b/multicluster/cmd/multicluster-controller/clusterclaim_webhook.go
@@ -43,7 +43,12 @@ type clusterClaimValidator struct {
 // Handle handles admission requests.
 func (v *clusterClaimValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
 	clusterClaim := &mcv1alpha2.ClusterClaim{}
-	err := v.decoder.Decode(req, clusterClaim)
+
+	reqObj := req.Object
+	if req.Operation == admissionv1.Delete {
+		reqObj = req.OldObject
+	}
+	err := v.decoder.DecodeRaw(reqObj, clusterClaim)
 	if err != nil {
 		klog.ErrorS(err, "Error while decoding ClusterClaim", "ClusterClaim", req.Namespace+"/"+req.Name)
 		return admission.Errored(http.StatusBadRequest, err)

--- a/multicluster/cmd/multicluster-controller/clusterclaim_webhook_test.go
+++ b/multicluster/cmd/multicluster-controller/clusterclaim_webhook_test.go
@@ -142,16 +142,16 @@ func TestWebhookClusterClaimEvents(t *testing.T) {
 
 	deleteCC1Req := validCC1Req.DeepCopy()
 	deleteCC1Req.Operation = v1.Delete
-	deleteCC1Req.Object.Raw = validCC1
+	deleteCC1Req.OldObject.Raw = validCC1
 
 	deleteCC2Req := validCC1Req.DeepCopy()
 	deleteCC2Req.Operation = v1.Delete
 	deleteCC2Req.Name = "clusterset.k8s.io"
-	deleteCC2Req.Object.Raw = validCC2
+	deleteCC2Req.OldObject.Raw = validCC2
 
 	deleteCC3Req := validCC1Req.DeepCopy()
 	deleteCC3Req.Operation = v1.Delete
-	deleteCC3Req.Object.Raw = validCC3
+	deleteCC3Req.OldObject.Raw = validCC3
 
 	tests := []struct {
 		name                 string


### PR DESCRIPTION
Cherry pick of #5075 on release-1.11.

#5075: Fix ClusterClaim deletion webhook bug

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.