### PR TITLE
Fix incorrect FlowMod message passing in openflow client modifyFlows

### DIFF
--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -450,10 +450,10 @@ func (c *client) modifyFlows(cache *flowCategoryCache, flowCacheKey string, flow
 			var msg *openflow15.FlowMod
 			if _, ok := oldFlowCache[matchString]; ok {
 				msg = getFlowModMessage(flow, binding.ModifyMessage)
-				adds = append(adds, msg)
+				mods = append(mods, msg)
 			} else {
 				msg = getFlowModMessage(flow, binding.AddMessage)
-				mods = append(mods, msg)
+				adds = append(adds, msg)
 			}
 			fCache[matchString] = msg
 		}


### PR DESCRIPTION
In the openflow client, the `modifyFlows` function incorrectly flipped the `add` and `mod` type of `FlowMod` messages that it passes to the lower level `BundleOps` operation. This could lead to unexpected openflow state for the caller.