### PR TITLE
Fix Egress IP not advertised in some cases 

### DIFF
--- a/pkg/agent/controller/egress/egress_controller.go
+++ b/pkg/agent/controller/egress/egress_controller.go
@@ -658,8 +658,10 @@ func (c *EgressController) syncEgress(egressName string) error {
 	}
 
 	if desiredNode == c.nodeName {
-		// Ensure the Egress IP is assigned to the system.
-		if err := c.ipAssigner.AssignIP(desiredEgressIP); err != nil {
+		// Ensure the Egress IP is assigned to the system. Force advertising the IP if it was previously assigned to
+		// another Node in the Egress API. This could force refreshing other peers' neighbor cache when the Egress IP is
+		// obtained by this Node and another Node at the same time in some situations, e.g. split brain.
+		if err := c.ipAssigner.AssignIP(desiredEgressIP, egress.Status.EgressNode != c.nodeName); err != nil {
 			return err
 		}
 	} else {

--- a/pkg/agent/controller/egress/egress_controller_test.go
+++ b/pkg/agent/controller/egress/egress_controller_test.go
@@ -588,7 +588,9 @@ func TestSyncEgress(t *testing.T) {
 				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(1), net.ParseIP(fakeLocalEgressIP1), uint32(1))
 				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(2), net.ParseIP(fakeLocalEgressIP1), uint32(1))
 				mockRouteClient.EXPECT().AddSNATRule(net.ParseIP(fakeLocalEgressIP1), uint32(1))
-				mockIPAssigner.EXPECT().AssignIP(fakeLocalEgressIP2).Times(2)
+				mockIPAssigner.EXPECT().AssignIP(fakeLocalEgressIP2, true)
+				// forceAdvertise depends on how fast the Egress status update is reflected in the informer cache, which doesn't really matter.
+				mockIPAssigner.EXPECT().AssignIP(fakeLocalEgressIP2, gomock.Any())
 				mockOFClient.EXPECT().InstallSNATMarkFlows(net.ParseIP(fakeLocalEgressIP2), uint32(2))
 				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(3), net.ParseIP(fakeLocalEgressIP2), uint32(2))
 				mockRouteClient.EXPECT().AddSNATRule(net.ParseIP(fakeLocalEgressIP2), uint32(2))
@@ -631,7 +633,7 @@ func TestSyncEgress(t *testing.T) {
 				},
 			},
 			expectedCalls: func(mockOFClient *openflowtest.MockClient, mockRouteClient *routetest.MockInterface, mockIPAssigner *ipassignertest.MockIPAssigner) {
-				mockIPAssigner.EXPECT().AssignIP(fakeLocalEgressIP1)
+				mockIPAssigner.EXPECT().AssignIP(fakeLocalEgressIP1, true)
 				mockOFClient.EXPECT().InstallSNATMarkFlows(net.ParseIP(fakeLocalEgressIP1), uint32(1))
 				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(1), net.ParseIP(fakeLocalEgressIP1), uint32(1))
 				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(2), net.ParseIP(fakeLocalEgressIP1), uint32(1))
@@ -673,7 +675,7 @@ func TestSyncEgress(t *testing.T) {
 				},
 			},
 			expectedCalls: func(mockOFClient *openflowtest.MockClient, mockRouteClient *routetest.MockInterface, mockIPAssigner *ipassignertest.MockIPAssigner) {
-				mockIPAssigner.EXPECT().AssignIP(fakeLocalEgressIP1)
+				mockIPAssigner.EXPECT().AssignIP(fakeLocalEgressIP1, true)
 				mockOFClient.EXPECT().InstallSNATMarkFlows(net.ParseIP(fakeLocalEgressIP1), uint32(1))
 				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(1), net.ParseIP(fakeLocalEgressIP1), uint32(1))
 				mockOFClient.EXPECT().InstallPodSNATFlows(uint32(2), net.ParseIP(fakeLocalEgressIP1), uint32(1))

--- a/pkg/agent/controller/serviceexternalip/controller.go
+++ b/pkg/agent/controller/serviceexternalip/controller.go
@@ -393,7 +393,7 @@ func (c *ServiceExternalIPController) assignIP(ip string, service apimachineryty
 	c.assignedIPsMutex.Lock()
 	defer c.assignedIPsMutex.Unlock()
 	if _, ok := c.assignedIPs[ip]; !ok {
-		if err := c.ipAssigner.AssignIP(ip); err != nil {
+		if err := c.ipAssigner.AssignIP(ip, true); err != nil {
 			return err
 		}
 		c.assignedIPs[ip] = sets.New[string](service.String())

--- a/pkg/agent/controller/serviceexternalip/controller_test.go
+++ b/pkg/agent/controller/serviceexternalip/controller_test.go
@@ -228,7 +228,7 @@ func TestCreateService(t *testing.T) {
 			serviceToCreate:          servicePolicyCluster,
 			healthyNodes:             []string{fakeNode1, fakeNode2},
 			expectedCalls: func(mockIPAssigner *ipassignertest.MockIPAssigner) {
-				mockIPAssigner.EXPECT().AssignIP(fakeServiceExternalIP1)
+				mockIPAssigner.EXPECT().AssignIP(fakeServiceExternalIP1, true)
 			},
 			expectedExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
 				keyFor(servicePolicyCluster): {
@@ -269,7 +269,7 @@ func TestCreateService(t *testing.T) {
 			serviceToCreate: servicePolicyLocal,
 			healthyNodes:    []string{fakeNode1, fakeNode2},
 			expectedCalls: func(mockIPAssigner *ipassignertest.MockIPAssigner) {
-				mockIPAssigner.EXPECT().AssignIP(fakeServiceExternalIP1)
+				mockIPAssigner.EXPECT().AssignIP(fakeServiceExternalIP1, true)
 			},
 			expectedExternalIPStates: map[apimachinerytypes.NamespacedName]externalIPState{
 				keyFor(servicePolicyLocal): {
@@ -454,7 +454,7 @@ func TestUpdateService(t *testing.T) {
 			healthyNodes: []string{fakeNode1, fakeNode2},
 			expectedCalls: func(mockIPAssigner *ipassignertest.MockIPAssigner) {
 				mockIPAssigner.EXPECT().UnassignIP(fakeServiceExternalIP1)
-				mockIPAssigner.EXPECT().AssignIP(fakeServiceExternalIP2)
+				mockIPAssigner.EXPECT().AssignIP(fakeServiceExternalIP2, true)
 			},
 			expectError: false,
 		},
@@ -472,7 +472,7 @@ func TestUpdateService(t *testing.T) {
 			},
 			healthyNodes: []string{fakeNode1, fakeNode2},
 			expectedCalls: func(mockIPAssigner *ipassignertest.MockIPAssigner) {
-				mockIPAssigner.EXPECT().AssignIP(fakeServiceExternalIP2)
+				mockIPAssigner.EXPECT().AssignIP(fakeServiceExternalIP2, true)
 			},
 			expectError: false,
 		},

--- a/pkg/agent/ipassigner/ip_assigner.go
+++ b/pkg/agent/ipassigner/ip_assigner.go
@@ -19,7 +19,7 @@ import "k8s.io/apimachinery/pkg/util/sets"
 // IPAssigner provides methods to assign or unassign IP.
 type IPAssigner interface {
 	// AssignIP ensures the provided IP is assigned to the system.
-	AssignIP(ip string) error
+	AssignIP(ip string, forceAdvertise bool) error
 	// UnassignIP ensures the provided IP is not assigned to the system.
 	UnassignIP(ip string) error
 	// AssignedIPs return the IPs that are assigned to the system by this IPAssigner.

--- a/pkg/agent/ipassigner/ip_assigner_linux.go
+++ b/pkg/agent/ipassigner/ip_assigner_linux.go
@@ -28,6 +28,8 @@ import (
 
 	"antrea.io/antrea/pkg/agent/ipassigner/responder"
 	"antrea.io/antrea/pkg/agent/util"
+	"antrea.io/antrea/pkg/agent/util/arping"
+	"antrea.io/antrea/pkg/agent/util/ndp"
 	"antrea.io/antrea/pkg/agent/util/sysctl"
 )
 
@@ -71,11 +73,11 @@ func NewIPAssigner(nodeTransportInterface string, dummyDeviceName string) (IPAss
 			return nil, err
 		}
 		if dummyDeviceName == "" || arpIgnore > 0 {
-			arpResonder, err := responder.NewARPResponder(externalInterface)
+			arpResponder, err := responder.NewARPResponder(externalInterface)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create ARP responder for link %s: %v", externalInterface.Name, err)
 			}
-			a.arpResponder = arpResonder
+			a.arpResponder = arpResponder
 		}
 	}
 	if ipv6 != nil {
@@ -141,7 +143,7 @@ func (a *ipAssigner) loadIPAddresses() (sets.Set[string], error) {
 }
 
 // AssignIP ensures the provided IP is assigned to the dummy device and the ARP/NDP responders.
-func (a *ipAssigner) AssignIP(ip string) error {
+func (a *ipAssigner) AssignIP(ip string, forceAdvertise bool) error {
 	parsedIP := net.ParseIP(ip)
 	if parsedIP == nil {
 		return fmt.Errorf("invalid IP %s", ip)
@@ -151,6 +153,9 @@ func (a *ipAssigner) AssignIP(ip string) error {
 
 	if a.assignedIPs.Has(ip) {
 		klog.V(2).InfoS("The IP is already assigned", "ip", ip)
+		if forceAdvertise {
+			a.advertise(parsedIP)
+		}
 		return nil
 	}
 
@@ -177,9 +182,24 @@ func (a *ipAssigner) AssignIP(ip string) error {
 			return fmt.Errorf("failed to assign IP %v to NDP responder: %v", ip, err)
 		}
 	}
-
+	// Always advertise the IP when the IP is newly assigned to this Node.
+	a.advertise(parsedIP)
 	a.assignedIPs.Insert(ip)
 	return nil
+}
+
+func (a *ipAssigner) advertise(ip net.IP) {
+	if utilnet.IsIPv4(ip) {
+		klog.V(2).InfoS("Sending gratuitous ARP", "ip", ip)
+		if err := arping.GratuitousARPOverIface(ip, a.externalInterface); err != nil {
+			klog.ErrorS(err, "Failed to send gratuitous ARP", "ip", ip)
+		}
+	} else {
+		klog.V(2).InfoS("Sending neighbor advertisement", "ip", ip)
+		if err := ndp.NeighborAdvertisement(ip, a.externalInterface); err != nil {
+			klog.ErrorS(err, "Failed to send neighbor advertisement", "ip", ip)
+		}
+	}
 }
 
 // UnassignIP ensures the provided IP is not assigned to the dummy device.
@@ -271,6 +291,7 @@ func (a *ipAssigner) InitIPs(ips sets.Set[string]) error {
 		if err != nil {
 			return err
 		}
+		a.advertise(ip)
 	}
 	a.assignedIPs = ips.Union(nil)
 	return nil

--- a/pkg/agent/ipassigner/responder/arp_responder.go
+++ b/pkg/agent/ipassigner/responder/arp_responder.go
@@ -20,7 +20,6 @@ import (
 	"sync"
 
 	"github.com/mdlayher/arp"
-	"github.com/mdlayher/ethernet"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
@@ -47,15 +46,6 @@ func NewARPResponder(iface *net.Interface) (*arpResponder, error) {
 	}, nil
 }
 
-// advertise sends an gratuitous ARP packet for the IP.
-func (r *arpResponder) advertise(ip net.IP) error {
-	pkt, err := arp.NewPacket(arp.OperationRequest, r.iface.HardwareAddr, ip, ethernet.Broadcast, ip)
-	if err != nil {
-		return err
-	}
-	return r.conn.WriteTo(pkt, ethernet.Broadcast)
-}
-
 func (r *arpResponder) InterfaceName() string {
 	return r.iface.Name
 }
@@ -66,10 +56,6 @@ func (r *arpResponder) AddIP(ip net.IP) error {
 	}
 	if r.addIP(ip) {
 		klog.InfoS("Assigned IP to ARP responder", "ip", ip, "interface", r.iface.Name)
-		err := r.advertise(ip)
-		if err != nil {
-			klog.ErrorS(err, "Failed to advertise", "ip", ip, "interface", r.iface.Name)
-		}
 	}
 	return nil
 }

--- a/pkg/agent/ipassigner/responder/arp_responder_test.go
+++ b/pkg/agent/ipassigner/responder/arp_responder_test.go
@@ -77,64 +77,6 @@ func newFakeNetworkInterface() *net.Interface {
 	}
 }
 
-func TestARPResponder_Advertise(t *testing.T) {
-	tests := []struct {
-		name          string
-		iface         *net.Interface
-		ip            net.IP
-		expectError   bool
-		expectedBytes []byte
-	}{
-		{
-			name:        "GratuitousARP for IPv4",
-			iface:       newFakeNetworkInterface(),
-			ip:          net.ParseIP("192.168.10.1").To4(),
-			expectError: false,
-			expectedBytes: []byte{
-				// ethernet header (16 bytes)
-				0xff, 0xff, 0xff, 0xff, 0xff, 0xff, // 6 bytes: destination hardware address
-				0x00, 0x11, 0x22, 0x33, 0x44, 0x55, // 6 bytes: source hardware address
-				0x08, 0x06, // 2 bytes: ethernet type
-				// arp payload (46 bytes)
-				0x00, 0x01, // 2 bytes: hardware type
-				0x08, 0x00, // 2 bytes: protocol type
-				0x06,       // 1 byte : hardware address length
-				0x04,       // 1 byte : protocol length
-				0x00, 0x01, // 2 bytes: operation
-				0x00, 0x11, 0x22, 0x33, 0x44, 0x55, // 6 bytes: source hardware address
-				0xc0, 0xa8, 0x0a, 0x01, // 4 bytes: source protocol address
-				0xff, 0xff, 0xff, 0xff, 0xff, 0xff, // 6 bytes: target hardware address
-				0xc0, 0xa8, 0x0a, 0x01, // 4 bytes: target protocol address
-				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // 18 bytes: padding
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			conn := &fakePacketConn{
-				buffer: bytes.NewBuffer(nil),
-				addr: packet.Addr{
-					HardwareAddr: tt.iface.HardwareAddr,
-				},
-			}
-			fakeARPClient, err := newFakeARPClient(tt.iface, conn)
-			require.NoError(t, err)
-
-			r := arpResponder{
-				iface: tt.iface,
-				conn:  fakeARPClient,
-			}
-			err = r.advertise(tt.ip)
-			if tt.expectError {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-				assert.Equal(t, tt.expectedBytes, conn.buffer.Bytes())
-			}
-		})
-	}
-}
-
 func TestARPResponder_HandleARPRequest(t *testing.T) {
 	tests := []struct {
 		name                 string

--- a/pkg/agent/ipassigner/responder/ndp_responder.go
+++ b/pkg/agent/ipassigner/responder/ndp_responder.go
@@ -73,21 +73,6 @@ func (r *ndpResponder) InterfaceName() string {
 	return r.iface.Name
 }
 
-// advertise sends Neighbor Advertisement for the IP.
-func (r *ndpResponder) advertise(ip net.IP) error {
-	na := &ndp.NeighborAdvertisement{
-		Override:      true,
-		TargetAddress: ip,
-		Options: []ndp.Option{
-			&ndp.LinkLayerAddress{
-				Direction: ndp.Target,
-				Addr:      r.iface.HardwareAddr,
-			},
-		},
-	}
-	return r.conn.WriteTo(na, nil, net.IPv6linklocalallnodes)
-}
-
 func (r *ndpResponder) handleNeighborSolicitation() error {
 	pkt, _, srcIP, err := r.conn.ReadFrom()
 	if err != nil {
@@ -172,9 +157,6 @@ func (r *ndpResponder) AddIP(ip net.IP) error {
 		return nil
 	}(); err != nil {
 		return err
-	}
-	if err := r.advertise(ip); err != nil {
-		klog.ErrorS(err, "Failed to advertise", "ip", ip, "interface", r.iface.Name)
 	}
 	return nil
 }

--- a/pkg/agent/ipassigner/testing/mock_ipassigner.go
+++ b/pkg/agent/ipassigner/testing/mock_ipassigner.go
@@ -49,17 +49,17 @@ func (m *MockIPAssigner) EXPECT() *MockIPAssignerMockRecorder {
 }
 
 // AssignIP mocks base method
-func (m *MockIPAssigner) AssignIP(arg0 string) error {
+func (m *MockIPAssigner) AssignIP(arg0 string, arg1 bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AssignIP", arg0)
+	ret := m.ctrl.Call(m, "AssignIP", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // AssignIP indicates an expected call of AssignIP
-func (mr *MockIPAssignerMockRecorder) AssignIP(arg0 interface{}) *gomock.Call {
+func (mr *MockIPAssignerMockRecorder) AssignIP(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignIP", reflect.TypeOf((*MockIPAssigner)(nil).AssignIP), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignIP", reflect.TypeOf((*MockIPAssigner)(nil).AssignIP), arg0, arg1)
 }
 
 // AssignedIPs mocks base method

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -2284,24 +2284,44 @@ func (data *TestData) GetMulticastInterfaces(antreaNamespace string) ([]string, 
 	return agentConf.Multicast.MulticastInterfaces, nil
 }
 
-func GetTransportInterface(data *TestData) (string, error) {
-	cmd := fmt.Sprintf("ip -br addr show | grep %s", clusterInfo.nodes[0].ipv4Addr)
-	if testOptions.providerName == "kind" {
-		cmd = "/bin/sh -c " + cmd
-	}
-	_, stdout, stderr, err := data.RunCommandOnNode(nodeName(0), cmd)
+func (data *TestData) GetTransportInterface() (string, error) {
+	// It assumes all Nodes have the same transport interface name.
+	nodeName := nodeName(0)
+	nodeIP := nodeIP(0)
+	antreaPod, err := data.getAntreaPodOnNode(nodeName)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to get Antrea Pod on Node %s: %v", nodeName, err)
 	}
-	if stdout == "" || stderr != "" {
-		return "", fmt.Errorf("failed to get transport interface, stdout: %s, stderr: %s", stdout, stderr)
+	cmd := []string{"ip", "-br", "addr", "show"}
+	stdout, stderr, err := data.RunCommandFromPod(antreaNamespace, antreaPod, agentContainerName, cmd)
+	if stdout == "" || stderr != "" || err != nil {
+		return "", fmt.Errorf("failed to show ip address, stdout: %s, stderr: %s, err: %v", stdout, stderr, err)
 	}
 	// Example stdout:
 	// eth0@if461       UP             172.18.0.2/16 fc00:f853:ccd:e793::2/64 fe80::42:acff:fe12:2/64
 	// eno1             UP             10.176.3.138/22 fe80::e643:4bff:fe43:a30e/64
-	fields := strings.Fields(stdout)
-	name, _, _ := strings.Cut(fields[0], "@")
-	return name, nil
+	lines := strings.Split(strings.TrimSpace(stdout), "\n")
+	for _, line := range lines {
+		if strings.Contains(line, nodeIP+"/") {
+			fields := strings.Fields(line)
+			name, _, _ := strings.Cut(fields[0], "@")
+			return name, nil
+		}
+	}
+	return "", fmt.Errorf("no interface was assigned with Node IP %s", nodeIP)
+}
+
+func (data *TestData) GetNodeMACAddress(node, device string) (string, error) {
+	antreaPod, err := data.getAntreaPodOnNode(node)
+	if err != nil {
+		return "", fmt.Errorf("failed to get Antrea Pod on Node %s: %v", node, err)
+	}
+	cmd := []string{"cat", fmt.Sprintf("/sys/class/net/%s/address", device)}
+	stdout, stderr, err := data.RunCommandFromPod(antreaNamespace, antreaPod, agentContainerName, cmd)
+	if stdout == "" || stderr != "" || err != nil {
+		return "", fmt.Errorf("failed to get MAC address, stdout: %s, stderr: %s, err: %v", stdout, stderr, err)
+	}
+	return strings.TrimSpace(stdout), nil
 }
 
 // mutateAntreaConfigMap will perform the specified updates on the antrea-agent config and the

--- a/test/e2e/multicast_test.go
+++ b/test/e2e/multicast_test.go
@@ -714,7 +714,7 @@ func computeMulticastInterfaces(t *testing.T, data *TestData) (map[int][]string,
 	if err != nil {
 		return nil, err
 	}
-	transportInterface, err := GetTransportInterface(data)
+	transportInterface, err := data.GetTransportInterface()
 	if err != nil {
 		t.Fatalf("Error getting transport interfaces: %v", err)
 	}

--- a/test/integration/agent/ip_assigner_linux_test.go
+++ b/test/integration/agent/ip_assigner_linux_test.go
@@ -40,7 +40,7 @@ func TestIPAssigner(t *testing.T) {
 	require.NoError(t, err, "Failed to find the dummy device")
 	defer netlink.LinkDel(dummyDevice)
 
-	err = ipAssigner.AssignIP("x")
+	err = ipAssigner.AssignIP("x", false)
 	assert.Error(t, err, "Assigning an invalid IP should fail")
 
 	ip1 := "10.10.10.10"
@@ -49,7 +49,7 @@ func TestIPAssigner(t *testing.T) {
 	desiredIPs := sets.New[string](ip1, ip2, ip3)
 
 	for ip := range desiredIPs {
-		errAssign := ipAssigner.AssignIP(ip)
+		errAssign := ipAssigner.AssignIP(ip, false)
 		cmd := exec.Command("ip", "addr")
 		out, err := cmd.CombinedOutput()
 		if err != nil {


### PR DESCRIPTION
This patch fixes two cases, in which an Egress IP is not advertised:

- When userspace ARP responder is not running (arp_ignore is 0), assigning a new Egress IP to a Node would not advertise the IP.
- When an Egress IP is obtained by multiple Nodes in some situations, e.g. split brain, the eventual winner would not advertise the IP after they are back to normal, because the IP is already assigned to the Node.

The patch moves IP advertising out of responders. Responders will only be responsible for answering neighbor queries. The IP assigner will advertise an IP when the IP is newly assigned to the Node, or the IP's Node recorded in Egress API is updated from another Node to this Node.

Fixes #5117