### PR TITLE
Remove special case for Kind in Flow Aggregator e2e test

### DIFF
--- a/test/e2e/flowaggregator_test.go
+++ b/test/e2e/flowaggregator_test.go
@@ -799,11 +799,7 @@ func checkRecordsForToExternalFlows(t *testing.T, data *TestData, srcNodeName st
 	for _, record := range clickHouseRecords {
 		checkPodAndNodeDataClickHouse(data, t, record, srcPodName, srcNodeName, "", "")
 		checkFlowTypeClickHouse(t, record, ipfixregistry.FlowTypeToExternal)
-		// Since the OVS userspace conntrack implementation doesn't maintain
-		// packet or byte counter statistics, skip the check for Kind clusters
-		if testOptions.providerName != "kind" {
-			assert.Greater(t, record.OctetDeltaCount, uint64(0), "octetDeltaCount should be non-zero")
-		}
+		assert.Greater(t, record.OctetDeltaCount, uint64(0), "octetDeltaCount should be non-zero")
 	}
 }
 


### PR DESCRIPTION
Remove the special case for Kind cluster in Flow Aggregator e2e test because we no longer use userspace OVS when running Antrea on Kind.