### PR TITLE
Add apiVersion and kind for unstructured objects in "antctl mc" code

### DIFF
--- a/pkg/antctl/raw/multicluster/common/common.go
+++ b/pkg/antctl/raw/multicluster/common/common.go
@@ -96,6 +96,8 @@ func CreateClusterClaim(cmd *cobra.Command, k8sClient client.Client, namespace s
 	} else {
 		fmt.Fprintf(cmd.OutOrStdout(), "ClusterClaim \"%s\" created in Namespace %s\n", multiclusterv1alpha2.WellKnownClusterClaimID, namespace)
 		unstructuredClusterClaim, _ = runtime.DefaultUnstructuredConverter.ToUnstructured(clusterClaim)
+		unstructuredClusterClaim["apiVersion"] = clusterClaim.APIVersion
+		unstructuredClusterClaim["kind"] = clusterClaim.Kind
 		*createdRes = append(*createdRes, unstructuredClusterClaim)
 	}
 
@@ -110,6 +112,8 @@ func CreateClusterClaim(cmd *cobra.Command, k8sClient client.Client, namespace s
 	} else {
 		fmt.Fprintf(cmd.OutOrStdout(), "ClusterClaim \"%s\" created in Namespace %s\n", multiclusterv1alpha2.WellKnownClusterClaimClusterSet, namespace)
 		unstructuredClusterClaim, _ = runtime.DefaultUnstructuredConverter.ToUnstructured(clusterClaim)
+		unstructuredClusterClaim["apiVersion"] = clusterClaim.APIVersion
+		unstructuredClusterClaim["kind"] = clusterClaim.Kind
 		*createdRes = append(*createdRes, unstructuredClusterClaim)
 	}
 
@@ -129,6 +133,8 @@ func CreateClusterSet(cmd *cobra.Command, k8sClient client.Client, namespace str
 	} else {
 		fmt.Fprintf(cmd.OutOrStdout(), "ClusterSet \"%s\" created in Namespace %s\n", clusterSet.Name, clusterSet.Namespace)
 		unstructuredClusterSet, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(clusterSet)
+		unstructuredClusterSet["apiVersion"] = clusterSet.APIVersion
+		unstructuredClusterSet["kind"] = clusterSet.Kind
 		*createdRes = append(*createdRes, unstructuredClusterSet)
 	}
 
@@ -260,6 +266,8 @@ func CreateMemberToken(cmd *cobra.Command, k8sClient client.Client, name string,
 	} else {
 		fmt.Fprintf(cmd.OutOrStdout(), "ServiceAccount \"%s\" created\n", serviceAccount.Name)
 		unstructuredSA, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(serviceAccount)
+		unstructuredSA["apiVersion"] = serviceAccount.APIVersion
+		unstructuredSA["kind"] = serviceAccount.Kind
 		*createdRes = append(*createdRes, unstructuredSA)
 	}
 
@@ -275,6 +283,8 @@ func CreateMemberToken(cmd *cobra.Command, k8sClient client.Client, name string,
 	} else {
 		fmt.Fprintf(cmd.OutOrStdout(), "RoleBinding \"%s\" created\n", roleBinding.Name)
 		unstructuredRoleBinding, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(roleBinding)
+		unstructuredRoleBinding["apiVersion"] = roleBinding.APIVersion
+		unstructuredRoleBinding["kind"] = roleBinding.Kind
 		*createdRes = append(*createdRes, unstructuredRoleBinding)
 	}
 
@@ -289,6 +299,8 @@ func CreateMemberToken(cmd *cobra.Command, k8sClient client.Client, name string,
 	} else {
 		fmt.Fprintf(cmd.OutOrStdout(), "Secret \"%s\" created\n", secret.Name)
 		unstructuredSecret, _ := runtime.DefaultUnstructuredConverter.ToUnstructured(secret)
+		unstructuredSecret["apiVersion"] = secret.APIVersion
+		unstructuredSecret["kind"] = secret.Kind
 		*createdRes = append(*createdRes, unstructuredSecret)
 	}
 	// It will take one or two seconds to wait for the Data.token to be created.


### PR DESCRIPTION
Fix a deletion error during rollback after an `antctl mc` command failed.
```
Failed to delete  kube-system/test-clusterset: Object 'Kind' is missing in
'unstructured object has no kind'
```

apiVersion and kind are required fields in unstructured object to do deletion,
but `DefaultUnstructuredConverter.ToUnstructured` will not convert them
automatically.