### PR TITLE
Automated cherry pick of #5125: Fix incorrect FlowMod message passing in openflow client

### DIFF
--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -450,10 +450,10 @@ func (c *client) modifyFlows(cache *flowCategoryCache, flowCacheKey string, flow
 			var msg *openflow15.FlowMod
 			if _, ok := oldFlowCache[matchString]; ok {
 				msg = getFlowModMessage(flow, binding.ModifyMessage)
-				adds = append(adds, msg)
+				mods = append(mods, msg)
 			} else {
 				msg = getFlowModMessage(flow, binding.AddMessage)
-				mods = append(mods, msg)
+				adds = append(adds, msg)
 			}
 			fCache[matchString] = msg
 		}


### PR DESCRIPTION
Cherry pick of #5125 on release-1.12.

#5125: Fix incorrect FlowMod message passing in openflow client

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.