### PR TITLE
[e2e] Export logs for TestNetworkPolicy subtests

### DIFF
--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -274,6 +274,14 @@ func setupTestForFlowAggregator(tb testing.TB) (*TestData, bool, bool, error) {
 	return testData, v4Enabled, v6Enabled, nil
 }
 
+func exportLogsForSubtest(tb testing.TB, data *TestData) func() {
+	substrings := strings.Split(tb.Name(), "/")
+	subDir := substrings[len(substrings)-1]
+	return func() {
+		exportLogs(tb, data, subDir, true)
+	}
+}
+
 func exportLogs(tb testing.TB, data *TestData, logsSubDir string, writeNodeLogs bool) {
 	if tb.Skipped() {
 		return

--- a/test/e2e/networkpolicy_test.go
+++ b/test/e2e/networkpolicy_test.go
@@ -52,34 +52,43 @@ func TestNetworkPolicy(t *testing.T) {
 	defer teardownTest(t, data)
 
 	t.Run("testNetworkPolicyStats", func(t *testing.T) {
+		t.Cleanup(exportLogsForSubtest(t, data))
 		skipIfNotIPv4Cluster(t)
 		skipIfNetworkPolicyStatsDisabled(t)
 		testNetworkPolicyStats(t, data)
 	})
 	t.Run("testDifferentNamedPorts", func(t *testing.T) {
+		t.Cleanup(exportLogsForSubtest(t, data))
 		testDifferentNamedPorts(t, data)
 	})
 	t.Run("testDefaultDenyIngressPolicy", func(t *testing.T) {
+		t.Cleanup(exportLogsForSubtest(t, data))
 		testDefaultDenyIngressPolicy(t, data)
 	})
 	t.Run("testDefaultDenyEgressPolicy", func(t *testing.T) {
+		t.Cleanup(exportLogsForSubtest(t, data))
 		testDefaultDenyEgressPolicy(t, data)
 	})
 	t.Run("testEgressToServerInCIDRBlock", func(t *testing.T) {
+		t.Cleanup(exportLogsForSubtest(t, data))
 		skipIfNotIPv6Cluster(t)
 		testEgressToServerInCIDRBlock(t, data)
 	})
 	t.Run("testEgressToServerInCIDRBlockWithException", func(t *testing.T) {
+		t.Cleanup(exportLogsForSubtest(t, data))
 		skipIfNotIPv6Cluster(t)
 		testEgressToServerInCIDRBlockWithException(t, data)
 	})
 	t.Run("testNetworkPolicyResyncAfterRestart", func(t *testing.T) {
+		t.Cleanup(exportLogsForSubtest(t, data))
 		testNetworkPolicyResyncAfterRestart(t, data)
 	})
 	t.Run("testIngressPolicyWithoutPortNumber", func(t *testing.T) {
+		t.Cleanup(exportLogsForSubtest(t, data))
 		testIngressPolicyWithoutPortNumber(t, data)
 	})
 	t.Run("testIngressPolicyWithEndPort", func(t *testing.T) {
+		t.Cleanup(exportLogsForSubtest(t, data))
 		testIngressPolicyWithEndPort(t, data)
 	})
 }


### PR DESCRIPTION
One subtest of TestNetworkPolicy restarts antrea-controller, which causes its log missing when subtests running before it fail. To preserve component logs, we export logs for every subtest if it fails.

For https://github.com/antrea-io/antrea/actions/runs/5295909048/jobs/9586763929