### PR TITLE
Cleanup traceflowIntraNodeANNP and followup ANNP

### DIFF
--- a/docs/external-node.md
+++ b/docs/external-node.md
@@ -551,7 +551,7 @@ other external Nodes labeled with `role=front`:
 apiVersion: crd.antrea.io/v1alpha1
 kind: NetworkPolicy
 metadata:
-  name: anp1
+  name: annp1
   namespace: vm-ns
 spec:
   priority: 9000.0

--- a/pkg/controller/networkpolicy/mutate_test.go
+++ b/pkg/controller/networkpolicy/mutate_test.go
@@ -201,7 +201,7 @@ func TestMutateAntreaNetworkPolicy(t *testing.T) {
 		expectPatch []jsonPatch
 	}{
 		{
-			name: "anp-create-mutate",
+			name: "annp-create-mutate",
 			policy: &crdv1beta1.NetworkPolicy{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "mutate-rule-name-tier",
@@ -276,7 +276,7 @@ func TestMutateAntreaNetworkPolicy(t *testing.T) {
 			},
 		},
 		{
-			name: "anp-update-mutate",
+			name: "annp-update-mutate",
 			policy: &crdv1beta1.NetworkPolicy{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "mutate-rule-name-tier",

--- a/test/e2e/k8s_util.go
+++ b/test/e2e/k8s_util.go
@@ -947,7 +947,7 @@ func (data *TestData) CleanACNPs() error {
 // CreateOrUpdateANNP is a convenience function for updating/creating Antrea NetworkPolicies.
 func (data *TestData) CreateOrUpdateANNP(annp *crdv1beta1.NetworkPolicy) (*crdv1beta1.NetworkPolicy, error) {
 	log.Infof("Creating/updating Antrea NetworkPolicy %s/%s", annp.Namespace, annp.Name)
-	cnpReturned, err := data.crdClient.CrdV1beta1().NetworkPolicies(annp.Namespace).Get(context.TODO(), annp.Name, metav1.GetOptions{})
+	npReturned, err := data.crdClient.CrdV1beta1().NetworkPolicies(annp.Namespace).Get(context.TODO(), annp.Name, metav1.GetOptions{})
 	if err != nil {
 		log.Debugf("Creating Antrea NetworkPolicy %s", annp.Name)
 		annp, err = data.crdClient.CrdV1beta1().NetworkPolicies(annp.Namespace).Create(context.TODO(), annp, metav1.CreateOptions{})
@@ -955,7 +955,7 @@ func (data *TestData) CreateOrUpdateANNP(annp *crdv1beta1.NetworkPolicy) (*crdv1
 			log.Debugf("Unable to create Antrea NetworkPolicy: %s", err)
 		}
 		return annp, err
-	} else if cnpReturned.Name != "" {
+	} else if npReturned.Name != "" {
 		log.Debugf("Antrea NetworkPolicy with name %s already exists, updating", annp.Name)
 		annp, err = data.crdClient.CrdV1beta1().NetworkPolicies(annp.Namespace).Update(context.TODO(), annp, metav1.UpdateOptions{})
 		return annp, err

--- a/test/e2e/traceflow_test.go
+++ b/test/e2e/traceflow_test.go
@@ -2288,7 +2288,8 @@ func (data *TestData) createANNPDenyIngress(key string, value string, name strin
 	}
 	annp := v1beta1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
+			Name:      name,
+			Namespace: data.testNamespace,
 			Labels: map[string]string{
 				"antrea-e2e": name,
 			},
@@ -2310,7 +2311,6 @@ func (data *TestData) createANNPDenyIngress(key string, value string, name strin
 					Action: &dropACT,
 					Ports:  []v1beta1.NetworkPolicyPort{},
 					From:   []v1beta1.NetworkPolicyPeer{},
-					To:     []v1beta1.NetworkPolicyPeer{},
 				},
 			},
 			Egress: []v1beta1.Rule{},


### PR DESCRIPTION
traceflowIntraNodeANNP failed due to Windows containerd env setup according to issue #5126 , which is closed now. But there are still some minor fixes remaining in this PR.