### PR TITLE
Increase upper bound to fix TestController_RotateCertificates unit test

### DIFF
--- a/pkg/agent/controller/ipseccertificate/ipsec_certificate_controller_test.go
+++ b/pkg/agent/controller/ipseccertificate/ipsec_certificate_controller_test.go
@@ -316,8 +316,8 @@ func TestController_RotateCertificates(t *testing.T) {
 	// truncated, which means that there can actually be less than 7s between the
 	// CreationTimestamp of the first certificate and the rotation deadline. As a result, we
 	// need to set the lower bound to 6s.
-	// b) it takes time to process the CSR request so we add one second to the upper bound.
-	assert.Less(t, delta, 10*time.Second)
+	// b) it takes time to process the CSR request so we add 3 seconds to the upper bound.
+	assert.Less(t, delta, 12*time.Second)
 	assert.LessOrEqual(t, 6*time.Second, delta)
 }
 


### PR DESCRIPTION
The TestController_RotateCertificates fails frequently in Windows OS, The `delta` is usually around 11s, so increase the upper bound to 12s to fix the flaky test.