### PR TITLE
Bugfix: Bump up libOpenflow version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module antrea.io/antrea
 go 1.19
 
 require (
-	antrea.io/libOpenflow v0.9.2
+	antrea.io/libOpenflow v0.10.3
 	antrea.io/ofnet v0.6.10
 	github.com/ClickHouse/clickhouse-go v1.5.4
 	github.com/DATA-DOG/go-sqlmock v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
-antrea.io/libOpenflow v0.9.2 h1:9W++nzaxxwY4NxyHHow/4bfum2UPIBJKmEOVTAG+x3o=
 antrea.io/libOpenflow v0.9.2/go.mod h1:IM9mUfHh5hUNciRRcWYIaWZTlv1TI6QBEHlml7ALdS4=
+antrea.io/libOpenflow v0.10.3 h1:ZLqpwss8wqzLzRPXFV3/A2hDMpcfIPRCQKWebZ6oWRI=
+antrea.io/libOpenflow v0.10.3/go.mod h1:drWN5iISj7G2J6MnclrFmgy0jHU1Z684WW0DxcrjNP0=
 antrea.io/ofnet v0.6.10 h1:t9cMGeES10YSDJ4Ooet9gSRUoRhx111ZYWQi14uRZO8=
 antrea.io/ofnet v0.6.10/go.mod h1:CB/Pkt+U0Yi1sM7DZ7iS215xGL+dhRRAM0EV0LTDLnY=
 bazil.org/fuse v0.0.0-20160811212531-371fbbdaa898/go.mod h1:Xbm+BRKSBEpa4q4hTSxohYNQpsxXPbPry4JJWOB3LB8=


### PR DESCRIPTION
This is to resolve an issue when unmarshaling IP packet which may lead to incorrect field values in PacketIn meesages. The issue is because the existing code uses a pointer reference to set byte slice fields when unmarshaling the mesages, and libOpenlow reuses the buffer to process the next messages.