### PR TITLE
Add ovs meter metric

### DIFF
--- a/docs/prometheus-integration.md
+++ b/docs/prometheus-integration.md
@@ -174,6 +174,8 @@ partitioned by operation type (add, modify and delete).
 errors, partitioned by operation type (add, modify and delete).
 - **antrea_agent_ovs_flow_ops_latency_milliseconds:** The latency of OVS
 flow operations, partitioned by operation type (add, modify and delete).
+- **antrea_agent_ovs_meter_packet_dropped_count:** Number of packets dropped by
+OVS meter. The value is greater than 0 when the packets exceed the rate-limit.
 - **antrea_agent_ovs_total_flow_count:** Total flow count of all OVS flow
 tables.
 

--- a/pkg/agent/metrics/prometheus.go
+++ b/pkg/agent/metrics/prometheus.go
@@ -116,6 +116,20 @@ var (
 		[]string{"operation"},
 	)
 
+	// OVSMeterPacketDroppedCount is defined as a Gauge and not a Counter, even though this metric is monotonically
+	// increasing (only being reset to 0 on restart).  This is because we want to set its value directly using the
+	// Set method (using the value provided by OVS), and using Inc / Add is not convenient.
+	OVSMeterPacketDroppedCount = metrics.NewGaugeVec(
+		&metrics.GaugeOpts{
+			Namespace:      metricNamespaceAntrea,
+			Subsystem:      metricSubsystemAgent,
+			Name:           "ovs_meter_packet_dropped_count",
+			Help:           "Number of packets dropped by OVS meter. The value is greater than 0 when the packets exceed the rate-limit.",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"meter_id"},
+	)
+
 	TotalConnectionsInConnTrackTable = metrics.NewGauge(
 		&metrics.GaugeOpts{
 			Namespace:      metricNamespaceAntrea,
@@ -212,6 +226,9 @@ func InitializeOVSMetrics() {
 	}
 	if err := legacyregistry.Register(OVSFlowOpsLatency); err != nil {
 		klog.ErrorS(err, "Failed to register metrics with Prometheus", "metrics", "antrea_agent_ovs_flow_ops_latency_milliseconds")
+	}
+	if err := legacyregistry.Register(OVSMeterPacketDroppedCount); err != nil {
+		klog.ErrorS(err, "Failed to register metrics with Prometheus", "metrics", "antrea_agent_ovs_meter_packet_dropped_count")
 	}
 	// Initialize OpenFlow operations metrics with label add, modify and delete
 	// since those metrics won't come out until observation.

--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"antrea.io/antrea/pkg/agent/config"
+	"antrea.io/antrea/pkg/agent/metrics"
 	"antrea.io/antrea/pkg/agent/openflow/cookie"
 	"antrea.io/antrea/pkg/agent/types"
 	"antrea.io/antrea/pkg/agent/util"
@@ -1549,4 +1550,22 @@ func GetFlowModMessages(flows []binding.Flow, op binding.OFOperation) []*openflo
 func getFlowModMessage(flow binding.Flow, op binding.OFOperation) *openflow15.FlowMod {
 	messages := GetFlowModMessages([]binding.Flow{flow}, op)
 	return messages[0]
+}
+
+// getMeterStats sends a multipart request to get all the meter statistics and
+// sets values for antrea_agent_ovs_meter_packet_dropped_count.
+func (c *client) getMeterStats() {
+	handleMeterStatsReply := func(meterID int, packetCount int64) {
+		switch meterID {
+		case PacketInMeterIDNP:
+			metrics.OVSMeterPacketDroppedCount.WithLabelValues("PacketInMeterNetworkPolicy").Set(float64(packetCount))
+		case PacketInMeterIDTF:
+			metrics.OVSMeterPacketDroppedCount.WithLabelValues("PacketInMeterTraceflow").Set(float64(packetCount))
+		default:
+			klog.V(4).InfoS("Received unexpected meterID", "meterID", meterID)
+		}
+	}
+	if err := c.bridge.GetMeterStats(handleMeterStatsReply); err != nil {
+		klog.ErrorS(err, "Failed to get OVS meter stats")
+	}
 }

--- a/pkg/agent/openflow/client_test.go
+++ b/pkg/agent/openflow/client_test.go
@@ -361,7 +361,7 @@ func newFakeClient(mockOFEntryOperations *oftest.MockOFEntryOperations,
 		fn(o)
 	}
 
-	cli := NewClient(bridgeName,
+	client := NewClient(bridgeName,
 		bridgeMgmtAddr,
 		nodeiptest.NewFakeNodeIPChecker(),
 		o.enableProxy,
@@ -375,8 +375,8 @@ func newFakeClient(mockOFEntryOperations *oftest.MockOFEntryOperations,
 		o.enableMulticast,
 		o.enableTrafficControl,
 		o.enableMulticluster,
-		NewGroupAllocator())
-	client := cli.(*client)
+		NewGroupAllocator(),
+		false)
 
 	var egressExceptCIDRs []net.IPNet
 	var serviceIPv4CIDR, serviceIPv6CIDR *net.IPNet
@@ -1815,16 +1815,15 @@ func Test_client_setBasePacketOutBuilder(t *testing.T) {
 }
 
 func prepareSetBasePacketOutBuilder(ctrl *gomock.Controller, success bool) *client {
-	ofClient := NewClient(bridgeName, bridgeMgmtAddr, nodeiptest.NewFakeNodeIPChecker(), true, true, false, false, false, false, false, false, false, false, false, nil)
-	c := ofClient.(*client)
+	ofClient := NewClient(bridgeName, bridgeMgmtAddr, nodeiptest.NewFakeNodeIPChecker(), true, true, false, false, false, false, false, false, false, false, false, nil, false)
 	m := ovsoftest.NewMockBridge(ctrl)
-	c.bridge = m
+	ofClient.bridge = m
 	bridge := binding.OFBridge{}
 	m.EXPECT().BuildPacketOut().Return(bridge.BuildPacketOut()).Times(1)
 	if success {
 		m.EXPECT().SendPacketOut(gomock.Any()).Times(1)
 	}
-	return c
+	return ofClient
 }
 
 func Test_client_SendPacketOut(t *testing.T) {

--- a/pkg/ovs/openflow/interfaces.go
+++ b/pkg/ovs/openflow/interfaces.go
@@ -112,6 +112,7 @@ type Bridge interface {
 	NewGroup(id GroupIDType) Group
 	NewMeter(id MeterIDType, flags ofctrl.MeterFlag) Meter
 	DeleteMeterAll() error
+	GetMeterStats(handleMeterStatsReply func(meterID int, packetCount int64)) error
 	DumpTableStatus() []TableStatus
 	// DumpFlows queries the Openflow entries from OFSwitch. The filter of the query is Openflow cookieID; the result is
 	// a map from flow cookieID to FlowStates.

--- a/pkg/ovs/openflow/testing/mock_openflow.go
+++ b/pkg/ovs/openflow/testing/mock_openflow.go
@@ -180,6 +180,20 @@ func (mr *MockBridgeMockRecorder) DumpTableStatus() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DumpTableStatus", reflect.TypeOf((*MockBridge)(nil).DumpTableStatus))
 }
 
+// GetMeterStats mocks base method
+func (m *MockBridge) GetMeterStats(arg0 func(int, int64)) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMeterStats", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// GetMeterStats indicates an expected call of GetMeterStats
+func (mr *MockBridgeMockRecorder) GetMeterStats(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMeterStats", reflect.TypeOf((*MockBridge)(nil).GetMeterStats), arg0)
+}
+
 // GetTableByID mocks base method
 func (m *MockBridge) GetTableByID(arg0 byte) (openflow.Table, error) {
 	m.ctrl.T.Helper()

--- a/pkg/ovs/ovsctl/testing/mock_ovsctl.go
+++ b/pkg/ovs/ovsctl/testing/mock_ovsctl.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Antrea Authors
+// Copyright 2023 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -44,6 +44,7 @@ var antreaAgentMetrics = []string{
 	"antrea_agent_ovs_flow_ops_error_count",
 	"antrea_agent_ovs_flow_ops_latency_milliseconds",
 	"antrea_agent_ovs_total_flow_count",
+	"antrea_agent_ovs_meter_packet_dropped_count",
 	"antrea_agent_conntrack_total_connection_count",
 	"antrea_agent_conntrack_antrea_connection_count",
 	"antrea_agent_conntrack_max_connection_count",

--- a/test/integration/agent/openflow_test.go
+++ b/test/integration/agent/openflow_test.go
@@ -119,7 +119,7 @@ func TestConnectivityFlows(t *testing.T) {
 		antrearuntime.WindowsOS = runtime.GOOS
 	}
 
-	c = ofClient.NewClient(br, bridgeMgmtAddr, nodeiptest.NewFakeNodeIPChecker(), true, false, false, true, false, false, false, false, false, false, false, groupIDAllocator)
+	c = ofClient.NewClient(br, bridgeMgmtAddr, nodeiptest.NewFakeNodeIPChecker(), true, false, false, true, false, false, false, false, false, false, false, groupIDAllocator, false)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge: %v", err))
 	defer func() {
@@ -175,7 +175,7 @@ func TestAntreaFlexibleIPAMConnectivityFlows(t *testing.T) {
 	legacyregistry.Reset()
 	metrics.InitializeOVSMetrics()
 
-	c = ofClient.NewClient(br, bridgeMgmtAddr, nodeiptest.NewFakeNodeIPChecker(), true, false, false, true, false, false, false, true, false, false, false, groupIDAllocator)
+	c = ofClient.NewClient(br, bridgeMgmtAddr, nodeiptest.NewFakeNodeIPChecker(), true, false, false, true, false, false, false, true, false, false, false, groupIDAllocator, false)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge: %v", err))
 	defer func() {
@@ -238,7 +238,7 @@ func TestReplayFlowsConnectivityFlows(t *testing.T) {
 	legacyregistry.Reset()
 	metrics.InitializeOVSMetrics()
 
-	c = ofClient.NewClient(br, bridgeMgmtAddr, nodeiptest.NewFakeNodeIPChecker(), true, false, false, true, false, false, false, false, false, false, false, groupIDAllocator)
+	c = ofClient.NewClient(br, bridgeMgmtAddr, nodeiptest.NewFakeNodeIPChecker(), true, false, false, true, false, false, false, false, false, false, false, groupIDAllocator, false)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge: %v", err))
 
@@ -280,7 +280,7 @@ func TestReplayFlowsNetworkPolicyFlows(t *testing.T) {
 	legacyregistry.Reset()
 	metrics.InitializeOVSMetrics()
 
-	c = ofClient.NewClient(br, bridgeMgmtAddr, nodeiptest.NewFakeNodeIPChecker(), true, false, false, false, false, false, false, false, false, false, false, groupIDAllocator)
+	c = ofClient.NewClient(br, bridgeMgmtAddr, nodeiptest.NewFakeNodeIPChecker(), true, false, false, false, false, false, false, false, false, false, false, groupIDAllocator, false)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge: %v", err))
 
@@ -465,7 +465,7 @@ func TestNetworkPolicyFlows(t *testing.T) {
 	legacyregistry.Reset()
 	metrics.InitializeOVSMetrics()
 
-	c = ofClient.NewClient(br, bridgeMgmtAddr, nodeiptest.NewFakeNodeIPChecker(), true, false, false, false, false, false, false, false, false, false, false, groupIDAllocator)
+	c = ofClient.NewClient(br, bridgeMgmtAddr, nodeiptest.NewFakeNodeIPChecker(), true, false, false, false, false, false, false, false, false, false, false, groupIDAllocator, false)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge %s", br))
 
@@ -579,7 +579,7 @@ func TestIPv6ConnectivityFlows(t *testing.T) {
 	legacyregistry.Reset()
 	metrics.InitializeOVSMetrics()
 
-	c = ofClient.NewClient(br, bridgeMgmtAddr, nodeiptest.NewFakeNodeIPChecker(), true, false, false, true, false, false, false, false, false, false, false, groupIDAllocator)
+	c = ofClient.NewClient(br, bridgeMgmtAddr, nodeiptest.NewFakeNodeIPChecker(), true, false, false, true, false, false, false, false, false, false, false, groupIDAllocator, false)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge: %v", err))
 
@@ -620,7 +620,7 @@ func TestProxyServiceFlowsAntreaPolicyDisabled(t *testing.T) {
 	legacyregistry.Reset()
 	metrics.InitializeOVSMetrics()
 
-	c = ofClient.NewClient(br, bridgeMgmtAddr, nodeiptest.NewFakeNodeIPChecker(), true, false, false, false, false, false, false, false, false, false, false, groupIDAllocator)
+	c = ofClient.NewClient(br, bridgeMgmtAddr, nodeiptest.NewFakeNodeIPChecker(), true, false, false, false, false, false, false, false, false, false, false, groupIDAllocator, false)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge %s", br))
 
@@ -710,7 +710,7 @@ func TestProxyServiceFlowsAntreaPoilcyEnabled(t *testing.T) {
 	legacyregistry.Reset()
 	metrics.InitializeOVSMetrics()
 
-	c = ofClient.NewClient(br, bridgeMgmtAddr, nodeiptest.NewFakeNodeIPChecker(), true, true, false, false, false, false, false, false, false, false, false, groupIDAllocator)
+	c = ofClient.NewClient(br, bridgeMgmtAddr, nodeiptest.NewFakeNodeIPChecker(), true, true, false, false, false, false, false, false, false, false, false, groupIDAllocator, false)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge %s", br))
 
@@ -1788,7 +1788,7 @@ func TestEgressMarkFlows(t *testing.T) {
 	legacyregistry.Reset()
 	metrics.InitializeOVSMetrics()
 
-	c = ofClient.NewClient(br, bridgeMgmtAddr, nodeiptest.NewFakeNodeIPChecker(), false, false, false, true, false, false, false, false, false, false, false, groupIDAllocator)
+	c = ofClient.NewClient(br, bridgeMgmtAddr, nodeiptest.NewFakeNodeIPChecker(), false, false, false, true, false, false, false, false, false, false, false, groupIDAllocator, false)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge %s", br))
 
@@ -1845,7 +1845,7 @@ func TestTrafficControlFlows(t *testing.T) {
 	legacyregistry.Reset()
 	metrics.InitializeOVSMetrics()
 
-	c = ofClient.NewClient(br, bridgeMgmtAddr, nodeiptest.NewFakeNodeIPChecker(), false, false, false, false, false, false, false, false, false, true, false, groupIDAllocator)
+	c = ofClient.NewClient(br, bridgeMgmtAddr, nodeiptest.NewFakeNodeIPChecker(), false, false, false, false, false, false, false, false, false, true, false, groupIDAllocator, false)
 	err := ofTestUtils.PrepareOVSBridge(br)
 	require.Nil(t, err, fmt.Sprintf("Failed to prepare OVS bridge %s", br))
 


### PR DESCRIPTION
We have implemented rate-limiting for packet-in messages on NetworkPolicy audit logging and Traceflow.
This change adds a metric to show the packet count which is got from meter statistics. A separate goroutine is used here to get the statistics every 30 seconds and collect the metric. The value more than 0 indicates that current rate exceeds predefined limit(100 per second).

Fixes: #5037
Signed-off-by: Mengdie Song <songm@vmware.com>