### PR TITLE
Disable CGO when building antctl binaries for e2e tests

### DIFF
--- a/build/images/Dockerfile.build.coverage
+++ b/build/images/Dockerfile.build.coverage
@@ -24,7 +24,12 @@ RUN go mod download
 
 COPY . /antrea
 
-RUN make antrea-agent antrea-controller antrea-cni antctl-linux antrea-controller-instr-binary antrea-agent-instr-binary antctl-instr-binary
+RUN make antrea-agent antrea-controller antrea-cni antrea-controller-instr-binary antrea-agent-instr-binary
+# The e2e test for antctl currently copy the antctl binary from the Docker container
+# to the host Node, and run the binary from the host. The host may be missing some
+# system libraries that are required to run the binary, so we need to disable CGO
+# to avoid such dependencies and ensure that the binary is portable.
+RUN CGO_ENABLED=0 make antctl-linux antctl-instr-binary
 RUN mv bin/antctl-linux bin/antctl
 
 FROM antrea/base-ubuntu:${BUILD_TAG}


### PR DESCRIPTION
The e2e tests copy the antctl binaries from the Docker image to the host node, and if the binaries are built with CGO enabled then they are not portable, and generate errors when they are used on different OS. That's the reason we are disabling CGO while creating binaries.