### PR TITLE
Upgrade Kind to v0.20.0

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -12,7 +12,7 @@ on:
     - feature/*
 
 env:
-  KIND_VERSION: v0.18.0
+  KIND_VERSION: v0.20.0
 
 jobs:
   check-changes:

--- a/.github/workflows/netpol_cyclonus.yml
+++ b/.github/workflows/netpol_cyclonus.yml
@@ -5,7 +5,7 @@ on:
     - cron: '0 0 * * *'
 
 env:
-  KIND_VERSION: v0.18.0
+  KIND_VERSION: v0.20.0
 
 jobs:
   test-netpol-cyclonus:

--- a/multicluster/hack/verify-tools.sh
+++ b/multicluster/hack/verify-tools.sh
@@ -22,7 +22,7 @@ WORKDIR=$1
 os=$(echo $(uname) | tr '[:upper:]' '[:lower:]')
 if ! which kind > /dev/null; then
     if [[ ${os} == 'darwin' || ${os} == 'linux' ]]; then
-        curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/v0.18.0/kind-${os}-amd64
+        curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/v0.20.0/kind-${os}-amd64
         chmod +x ./kind
         if [[ "$WORKDIR" != "" ]];then
           mv kind "$WORKDIR"
@@ -34,7 +34,7 @@ fi
 
 if ! which kubectl > /dev/null; then
     if [[ ${os} == 'darwin' || ${os} == 'linux' ]]; then
-        curl -LO https://dl.k8s.io/release/v1.26.3/bin/${os}/amd64/kubectl
+        curl -LO https://dl.k8s.io/release/v1.27.3/bin/${os}/amd64/kubectl
         chmod +x ./kubectl
         if [[ "$WORKDIR" != "" ]];then
           mv kubectl "$WORKDIR"


### PR DESCRIPTION
Upgrade Kind from v0.18.0 (K8s v1.26.3) to v0.20.0 (K8s v1.27.3)

Since all CI testbeds upgrades from old versions to K8s 1.27+ are in progress, it's better to upgrade Kind to latest v0.20.0
which will also use K8s v1.27.3 as default node image.