### PR TITLE
Fix code examples in docs

### DIFF
--- a/docs/antrea-ipam.md
+++ b/docs/antrea-ipam.md
@@ -50,12 +50,16 @@ cluster. Valid range is 64 to 126. Default is 64.
 Below is a sample of needed changes in the Antrea deployment YAML:
 
 ```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: antrea-config
+  namespace: kube-system
+data:
   antrea-controller.conf: |
-    ...
     nodeIPAM:
       enableNodeIPAM: true
       clusterCIDRs: [172.100.0.0/16]
-    ...
 ```
 
 When running Antrea NodeIPAM in a particular version or scenario, you may need to
@@ -100,22 +104,21 @@ When Antrea is installed from YAML, the needed changes in the Antrea
 ConfigMap `antrea-config` YAML are as below:
 
 ```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: antrea-config
+  namespace: kube-system
+data:
   antrea-controller.conf: |
-    ...
     featureGates:
       AntreaIPAM: true
-    ...
   antrea-agent.conf: |
-    ...
     featureGates:
       AntreaIPAM: true
-    ...
     enableBridgingMode: true
-    ...
     trafficEncapMode: "noEncap"
-    ...
     noSNAT: true
-    ...
 ```
 
 Alternatively, you can use the following helm install/upgrade command to configure
@@ -154,7 +157,6 @@ kind: Namespace
 metadata:
   annotations:
     ipam.antrea.io/ippools: 'pool1'
-...
 ```
 
 #### IPPool Annotations on Pod (available since Antrea 1.5)
@@ -176,7 +178,6 @@ spec:
       annotations:
         ipam.antrea.io/ippools: 'sts-ip-pool1'  # This annotation will be set automatically on all Pods managed by this resource
         ipam.antrea.io/pod-ips: '<ip-in-sts-ip-pool1>'
-...
 ```
 
 ```yaml
@@ -188,7 +189,6 @@ spec:
       annotations:
         ipam.antrea.io/ippools: 'sts-ip-pool1'  # This annotation will be set automatically on all Pods managed by this resource
         # Do not add pod-ips annotation to PodTemplate if there is more than 1 replica
-...
 ```
 
 ```yaml
@@ -196,7 +196,6 @@ kind: Pod
 metadata:
   annotations:
     ipam.antrea.io/ippools: 'pod-ip-pool1'
-...
 ```
 
 ```yaml
@@ -205,7 +204,6 @@ metadata:
   annotations:
     ipam.antrea.io/ippools: 'pod-ip-pool1'
     ipam.antrea.io/pod-ips: '<ip-in-pod-ip-pool1>'
-...
 ```
 
 ```yaml
@@ -213,7 +211,6 @@ kind: Pod
 metadata:
   annotations:
     ipam.antrea.io/pod-ips: '<ip-in-namespace-pool>'
-...
 ```
 
 #### Persistent IP for StatefulSet Pod (available since Antrea 1.5)

--- a/docs/antrea-proxy.md
+++ b/docs/antrea-proxy.md
@@ -103,9 +103,10 @@ Service during initialization. If you are unsure about which values to use, take
 a look at your Kubeconfig file, and look for a line like this one:
 
 ```yaml
-...
+apiVersion: v1
+clusters:
+- cluster:
     server: https://192.168.77.100:6443
-...
 ```
 
 Then use this value as is (e.g., `"https://192.168.77.100:6443"`) for

--- a/docs/egress.md
+++ b/docs/egress.md
@@ -49,7 +49,7 @@ v1.6, at which time it was enabled by default. Prior to v1.6, a feature gate,
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: antrea-config-dcfb6k2hkm
+  name: antrea-config
   namespace: kube-system
 data:
   antrea-agent.conf: |

--- a/docs/external-node.md
+++ b/docs/external-node.md
@@ -68,7 +68,7 @@ configuration. The configuration for `antrea-controller` is modified in the
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: antrea-config-dcfb6k2hkm
+  name: antrea-config
   namespace: kube-system
 data:
   antrea-controller.conf: |

--- a/docs/multicluster/policy-only-mode.md
+++ b/docs/multicluster/policy-only-mode.md
@@ -19,15 +19,18 @@ by Antrea Multi-cluster. You should set the following configuration parameters i
  feature and Antrea Multi-cluster Gateway:
 
 ```yaml
-antrea-agent.conf: |
-...
-  featureGates:
-...
-    Multicluster: true
-...
-  multicluster:
-    enableGateway: true
-    namespace: "" # Change to the Namespace where antrea-mc-controller is deployed.
+kind: ConfigMap
+apiVersion: v1
+metadata:
+ name: antrea-config
+ namespace: kube-system
+data:
+ antrea-agent.conf: |
+   featureGates:
+     Multicluster: true
+   multicluster:
+     enableGateway: true
+     namespace: "" # Change to the Namespace where antrea-mc-controller is deployed.
 ```
 
 Repeat the same steps to deploy Antrea for all member clusters in a ClusterSet.

--- a/docs/multicluster/quick-start.md
+++ b/docs/multicluster/quick-start.md
@@ -36,15 +36,18 @@ configuration parameters in `antrea-agent.conf` of the Antrea deployment
 manifest to enable the `Multicluster` feature:
 
 ```yaml
-antrea-agent.conf: |
-...
-  featureGates:
-...
-    Multicluster: true
-...
-  multicluster:
-    enableGateway: true
-    namespace: ""
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: antrea-config
+  namespace: kube-system
+data:
+  antrea-agent.conf: |
+    featureGates:
+      Multicluster: true
+    multicluster:
+      enableGateway: true
+      namespace: ""
 ```
 
 At the moment, Multi-cluster Gateway only works with the Antrea `encap` traffic
@@ -74,16 +77,16 @@ created by the commands), and Multi-cluster Controller for the member into
 Namepsace `kube-system`.
 
 ```bash
-$kubectl create ns antrea-multicluster
-$antctl mc deploy leadercluster -n antrea-multicluster --antrea-version $TAG
-$antctl mc deploy membercluster -n kube-system --antrea-version $TAG
+kubectl create ns antrea-multicluster
+antctl mc deploy leadercluster -n antrea-multicluster --antrea-version $TAG
+antctl mc deploy membercluster -n kube-system --antrea-version $TAG
 ```
 
 You can run the following command to verify the the leader and member
 `antrea-mc-controller` Pods are deployed and running:
 
 ```bash
-$kubectl get all -A -l="component=antrea-mc-controller"
+$ kubectl get all -A -l="component=antrea-mc-controller"
 NAMESPACE             NAME                                        READY   STATUS    RESTARTS   AGE
 antrea-multicluster   pod/antrea-mc-controller-cd7bf8f68-kh4kz    1/1     Running   0          50s
 kube-system           pod/antrea-mc-controller-85dbf58b75-pjj48   1/1     Running   0          48s
@@ -132,7 +135,7 @@ the following command to annotate the Node with:
 Node from the annotation):
 
 ```bash
-$kubectl annotate node node-a1 multicluster.antrea.io/gateway=true
+kubectl annotate node node-a1 multicluster.antrea.io/gateway=true
 ```
 
 ### Set up Cluster B
@@ -146,14 +149,14 @@ Run the following command to deploy the member Multi-cluster Controller into
 Namespace `kube-system`.
 
 ```bash
-$antctl mc deploy membercluster -n kube-system --antrea-version $TAG
+antctl mc deploy membercluster -n kube-system --antrea-version $TAG
 ```
 
 You can run the following command to verify the `antrea-mc-controller` Pod is
 deployed and running:
 
 ```bash
-$kubectl get all -A -l="component=antrea-mc-controller"
+$ kubectl get all -A -l="component=antrea-mc-controller"
 NAMESPACE             NAME                                        READY   STATUS    RESTARTS   AGE
 kube-system           pod/antrea-mc-controller-85dbf58b75-pjj48   1/1     Running   0          40s
 
@@ -180,7 +183,7 @@ Assuming K8s Node `node-b1` is chosen to be the Multi-cluster Gateway for cluste
 B, run the following command to annotate the Node:
 
 ```bash
-$kubectl annotate node node-b1 multicluster.antrea.io/gateway=true
+kubectl annotate node node-b1 multicluster.antrea.io/gateway=true
 ```
 
 ## What is Next
@@ -212,10 +215,10 @@ created by the commands), and Multi-cluster Controller for the member into
 Namepsace `kube-system`.
 
 ```bash
-$kubectl apply -f https://github.com/antrea-io/antrea/releases/download/$TAG/antrea-multicluster-leader-global.yml
-$kubectl create ns antrea-multicluster
-$kubectl apply -f https://github.com/antrea-io/antrea/releases/download/$TAG/antrea-multicluster-leader-namespaced.yml
-$kubectl apply -f https://github.com/antrea-io/antrea/releases/download/$TAG/antrea-multicluster-member.yml
+kubectl apply -f https://github.com/antrea-io/antrea/releases/download/$TAG/antrea-multicluster-leader-global.yml
+kubectl create ns antrea-multicluster
+kubectl apply -f https://github.com/antrea-io/antrea/releases/download/$TAG/antrea-multicluster-leader-namespaced.yml
+kubectl apply -f https://github.com/antrea-io/antrea/releases/download/$TAG/antrea-multicluster-member.yml
 ```
 
 #### Step 2 - initialize ClusterSet
@@ -227,9 +230,9 @@ for the member clusters (both cluster A and B in our case) to join the
 ClusterSet.
 
 ```bash
-$kubectl apply -f https://raw.githubusercontent.com/antrea-io/antrea/$TAG/multicluster/config/samples/clusterset_init/leader-clusterset-template.yml
-$kubectl apply -f https://raw.githubusercontent.com/antrea-io/antrea/$TAG/multicluster/config/samples/clusterset_init/leader-access-token-template.yml
-$kubectl get secret default-member-token -n antrea-multicluster -o yaml | grep -w -e '^apiVersion' -e '^data' -e '^metadata' -e '^ *name:' -e '^kind' -e '  ca.crt' -e '  token:' -e '^type' -e '  namespace' | sed -e 's/kubernetes.io\/service-account-token/Opaque/g' -e 's/antrea-multicluster/kube-system/g' > default-member-token.yml
+kubectl apply -f https://raw.githubusercontent.com/antrea-io/antrea/$TAG/multicluster/config/samples/clusterset_init/leader-clusterset-template.yml
+kubectl apply -f https://raw.githubusercontent.com/antrea-io/antrea/$TAG/multicluster/config/samples/clusterset_init/leader-access-token-template.yml
+kubectl get secret default-member-token -n antrea-multicluster -o yaml | grep -w -e '^apiVersion' -e '^data' -e '^metadata' -e '^ *name:' -e '^kind' -e '  ca.crt' -e '  token:' -e '^type' -e '  namespace' | sed -e 's/kubernetes.io\/service-account-token/Opaque/g' -e 's/antrea-multicluster/kube-system/g' > default-member-token.yml
 ```
 
 The last command saves the token Secret manifest to `default-member-token.yml`,
@@ -242,9 +245,9 @@ Next, run the following commands to make cluster A join the ClusterSet also as a
 member:
 
 ```bash
-$kubectl apply -f default-member-token.yml
-$curl -L https://raw.githubusercontent.com/antrea-io/antrea/$TAG/multicluster/config/samples/clusterset_init/member-clusterset-template.yml > member-clusterset.yml
-$sed -e 's/test-cluster-member/test-cluster-leader/g' -e 's/<LEADER_APISERVER_IP>/172.10.0.11/g' member-clusterset.yml | kubectl apply -f -
+kubectl apply -f default-member-token.yml
+curl -L https://raw.githubusercontent.com/antrea-io/antrea/$TAG/multicluster/config/samples/clusterset_init/member-clusterset-template.yml > member-clusterset.yml
+sed -e 's/test-cluster-member/test-cluster-leader/g' -e 's/<LEADER_APISERVER_IP>/172.10.0.11/g' member-clusterset.yml | kubectl apply -f -
 ```
 
 Here, `172.10.0.11` is the `kube-apiserver` IP of cluster A. You should replace
@@ -256,7 +259,7 @@ Assuming K8s Node `node-a1` is selected for the Multi-cluster Gateway, run
 the following command to annotate the Node:
 
 ```bash
-$kubectl annotate node node-a1 multicluster.antrea.io/gateway=true
+kubectl annotate node node-a1 multicluster.antrea.io/gateway=true
 ```
 
 ### Set up Cluster B
@@ -270,14 +273,14 @@ Run the following command to deploy the member Multi-cluster Controller into
 Namespace `kube-system`.
 
 ```bash
-$kubectl apply -f https://github.com/antrea-io/antrea/releases/download/$TAG/antrea-multicluster-member.yml
+kubectl apply -f https://github.com/antrea-io/antrea/releases/download/$TAG/antrea-multicluster-member.yml
 ```
 
 You can run the following command to verify the `antrea-mc-controller` Pod is
 deployed and running:
 
 ```bash
-$kubectl get all -A -l="component=antrea-mc-controller"
+$ kubectl get all -A -l="component=antrea-mc-controller"
 NAMESPACE             NAME                                        READY   STATUS    RESTARTS   AGE
 kube-system           pod/antrea-mc-controller-85dbf58b75-pjj48   1/1     Running   0          40s
 
@@ -290,9 +293,9 @@ kube-system           deployment.apps/antrea-mc-controller   1/1     1          
 Run the following commands to make cluster B join the ClusterSet:
 
 ```bash
-$kubectl apply -f default-member-token.yml
-$curl -L https://raw.githubusercontent.com/antrea-io/antrea/$TAG/multicluster/config/samples/clusterset_init/member-clusterset-template.yml > member-clusterset.yml
-$sed -e 's/<LEADER_APISERVER_IP>/172.10.0.11/g' member-clusterset.yml | kubectl apply -f -
+kubectl apply -f default-member-token.yml
+curl -L https://raw.githubusercontent.com/antrea-io/antrea/$TAG/multicluster/config/samples/clusterset_init/member-clusterset-template.yml > member-clusterset.yml
+sed -e 's/<LEADER_APISERVER_IP>/172.10.0.11/g' member-clusterset.yml | kubectl apply -f -
 ```
 
 `default-member-token.yml` saves the default member token which was generated
@@ -304,7 +307,7 @@ Assuming K8s Node `node-b1` is chosen to be the Multi-cluster Gateway for cluste
 B, run the following command to annotate the Node:
 
 ```bash
-$kubectl annotate node node-b1 multicluster.antrea.io/gateway=true
+kubectl annotate node node-b1 multicluster.antrea.io/gateway=true
 ```
 
 ### Add new member clusters
@@ -316,7 +319,7 @@ joining ClusterSet. For example, you can run the following commands to join the
 ClusterSet in a member cluster with ID `test-cluster-member2`:
 
 ```bash
-$kubectl apply -f default-member-token.yml
-$curl -L https://raw.githubusercontent.com/antrea-io/antrea/$TAG/multicluster/config/samples/clusterset_init/member-clusterset-template.yml  > member-clusterset.yml
-$sed -e 's/<LEADER_APISERVER_IP>/172.10.0.11/g' -e 's/test-cluster-member/test-cluster-member2/g' member-clusterset.yml | kubectl apply -f -
+kubectl apply -f default-member-token.yml
+curl -L https://raw.githubusercontent.com/antrea-io/antrea/$TAG/multicluster/config/samples/clusterset_init/member-clusterset-template.yml  > member-clusterset.yml
+sed -e 's/<LEADER_APISERVER_IP>/172.10.0.11/g' -e 's/test-cluster-member/test-cluster-member2/g' member-clusterset.yml | kubectl apply -f -
 ```

--- a/docs/node-port-local.md
+++ b/docs/node-port-local.md
@@ -45,7 +45,7 @@ your `antrea-agent` ConfigMap should look like this:
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: antrea-config-dcfb6k2hkm
+  name: antrea-config
   namespace: kube-system
 data:
   antrea-agent.conf: |
@@ -116,7 +116,6 @@ metadata:
     app: nginx
   annotations:
     nodeportlocal.antrea.io: '[{"podPort":8080,"nodeIP":"10.10.10.10","nodePort":61002,"protocol":"tcp","protocols":["tcp"]}]'
-...
 ```
 
 This annotation indicates that port 8080 of the Pod can be reached through port
@@ -153,7 +152,6 @@ metadata:
     app: nginx
   annotations:
     nodeportlocal.antrea.io: '[{"podPort":8080,"nodeIP":"10.10.10.10","nodePort":61002}, "protocols":["tcp","udp"]]'
-...
 ```
 
 This annotation indicates that port 8080 of the Pod can be reached through port

--- a/docs/noencap-hybrid-modes.md
+++ b/docs/noencap-hybrid-modes.md
@@ -26,11 +26,9 @@ metadata:
 spec:
   containers:
     - name: antrea-agent
-      ... ...
       env:
         - name: ALLOW_NO_ENCAP_WITHOUT_ANTREA_PROXY
           value: "true"
-      ... ...
 ```
 
 ## Hybrid Mode
@@ -60,9 +58,7 @@ parameter is defined in `antrea-agent.conf` of the `antrea` ConfigMap in the
 
 ```yaml
   antrea-agent.conf: |
-    ... ...
     trafficEncapMode: hybrid
-    ... ...
 ```
 
 After changing the config parameter, you can deploy Antrea in `Hybrid` mode with
@@ -109,12 +105,15 @@ parameters are defined in `antrea-agent.conf` of the `antrea` ConfigMap in the
 [Antrea deployment yaml](https://github.com/antrea-io/antrea/blob/main/build/yamls/antrea.yml).
 
 ```yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: antrea-config
+  namespace: kube-system
+data:
   antrea-agent.conf: |
-    ... ...
     trafficEncapMode: noEncap
-
     noSNAT: false # Set to true to disable Antrea SNAT for external traffic
-    ... ...
 ```
 
 After changing the parameters, you can deploy Antrea in `noEncap` mode by applying

--- a/docs/service-loadbalancer.md
+++ b/docs/service-loadbalancer.md
@@ -73,19 +73,15 @@ the Antrea deployment YAML:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: antrea-config-dcfb6k2hkm
+  name: antrea-config
   namespace: kube-system
 data:
   antrea-agent.conf: |
     featureGates:
-...
       ServiceExternalIP: true
-...
   antrea-controller.conf: |
     featureGates:
-...
       ServiceExternalIP: true
-...
 ```
 
 The feature works with both `AntreaProxy` and `kube-proxy`, including the

--- a/docs/traffic-encryption.md
+++ b/docs/traffic-encryption.md
@@ -112,10 +112,14 @@ defined in `antrea-agent.conf` of `antrea` ConfigMap in the Antrea deployment
 yaml:
 
 ```yaml
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: antrea-config
+  namespace: kube-system
+data:
   antrea-agent.conf: |
-    ... ...
     trafficEncryptionMode: wireGuard
-    ... ...
 ```
 
 After saving the yaml file change, deploy Antrea with:


### PR DESCRIPTION
1. Remove "..." from yaml examples, otherwise [the examples are displayed in a weird way in website](https://antrea.io/docs/v1.12.0/docs/service-loadbalancer/#enable-service-external-ip-management-feature).
2. Remove leading "$" from bash examples which contain only commands, to make the example to be copied and executed easier.
3. Insert a space between "$" and command for bash examples which contain both commands and outputs, to avoid ambiguity of dollar sign.
4. Remove the random suffix of Antrea ConfigMap name which is no longer used.
5. Fix a few wrong examples.