### PR TITLE
Replace &clock.RealClock{} with clock.RealClock{}

### DIFF
--- a/pkg/agent/controller/networkpolicy/audit_logging.go
+++ b/pkg/agent/controller/networkpolicy/audit_logging.go
@@ -182,7 +182,7 @@ func newAntreaPolicyLogger() (*AntreaPolicyLogger, error) {
 
 	antreaPolicyLogger := &AntreaPolicyLogger{
 		bufferLength:     time.Second,
-		clock:            &clock.RealClock{},
+		clock:            clock.RealClock{},
 		anpLogger:        log.New(logOutput, "", log.Ldate|log.Lmicroseconds),
 		logDeduplication: logRecordDedupMap{logMap: make(map[string]*logDedupRecord)},
 	}

--- a/pkg/agent/controller/networkpolicy/audit_logging_test.go
+++ b/pkg/agent/controller/networkpolicy/audit_logging_test.go
@@ -114,7 +114,7 @@ func expectedLogWithCount(msg string, count int) string {
 }
 
 func TestAllowPacketLog(t *testing.T) {
-	antreaLogger, mockAnpLogger := newTestAntreaPolicyLogger(testBufferLength, &clock.RealClock{})
+	antreaLogger, mockAnpLogger := newTestAntreaPolicyLogger(testBufferLength, clock.RealClock{})
 	ob, expected := newLogInfo(actionAllow)
 
 	antreaLogger.LogDedupPacket(ob)
@@ -123,7 +123,7 @@ func TestAllowPacketLog(t *testing.T) {
 }
 
 func TestDropPacketLog(t *testing.T) {
-	antreaLogger, mockAnpLogger := newTestAntreaPolicyLogger(testBufferLength, &clock.RealClock{})
+	antreaLogger, mockAnpLogger := newTestAntreaPolicyLogger(testBufferLength, clock.RealClock{})
 	ob, expected := newLogInfo(actionDrop)
 
 	antreaLogger.LogDedupPacket(ob)
@@ -199,7 +199,7 @@ func TestDropPacketMultiDedupLog(t *testing.T) {
 }
 
 func TestRedirectPacketLog(t *testing.T) {
-	antreaLogger, mockAnpLogger := newTestAntreaPolicyLogger(testBufferLength, &clock.RealClock{})
+	antreaLogger, mockAnpLogger := newTestAntreaPolicyLogger(testBufferLength, clock.RealClock{})
 	ob, expected := newLogInfo(actionRedirect)
 
 	antreaLogger.LogDedupPacket(ob)
@@ -476,7 +476,7 @@ func BenchmarkLogDedupPacketAllow(b *testing.B) {
 	// In the allow case, there is actually no buffering.
 	antreaLogger := &AntreaPolicyLogger{
 		bufferLength:     testBufferLength,
-		clock:            &clock.RealClock{},
+		clock:            clock.RealClock{},
 		anpLogger:        log.New(io.Discard, "", log.Ldate),
 		logDeduplication: logRecordDedupMap{logMap: make(map[string]*logDedupRecord)},
 	}

--- a/pkg/apiserver/registry/system/supportbundle/rest.go
+++ b/pkg/apiserver/registry/system/supportbundle/rest.go
@@ -51,7 +51,7 @@ var (
 	defaultExecutor = exec.New()
 	newAgentDumper  = support.NewAgentDumper
 
-	clock clockutils.Clock = &clockutils.RealClock{}
+	clock clockutils.Clock = clockutils.RealClock{}
 )
 
 // NewControllerStorage creates a support bundle storage for working on antrea controller.

--- a/pkg/apiserver/registry/system/supportbundle/rest_test.go
+++ b/pkg/apiserver/registry/system/supportbundle/rest_test.go
@@ -84,7 +84,7 @@ func TestClean(t *testing.T) {
 			fakeClock := clocktesting.NewFakeClock(time.Now())
 			clock = fakeClock
 			defer func() {
-				clock = &clockutils.RealClock{}
+				clock = clockutils.RealClock{}
 			}()
 			f, err := defaultFS.Create("test.tar.gz")
 			require.NoError(t, err)


### PR DESCRIPTION
No reason to use a pointer here. RealClock is an empty object, and all its methods have a value receiver.
I tried to benchmark the change, and while there is a minor improvement, it is really insignificant.