### PR TITLE
Automated cherry pick of #5194: Fix IPv4 group containing IPv6 endpoints in dual-stack

### DIFF
--- a/pkg/agent/proxy/endpointslicecache.go
+++ b/pkg/agent/proxy/endpointslicecache.go
@@ -280,7 +280,7 @@ func (cache *EndpointSliceCache) addEndpoints(serviceNN apimachinerytypes.Namesp
 
 		// Filter out the incorrect IP version case. Any endpoint port that
 		// contains incorrect IP version will be ignored.
-		if cache.isIPv6Mode && utilnet.IsIPv6String(endpoint.Addresses[0]) != cache.isIPv6Mode {
+		if utilnet.IsIPv6String(endpoint.Addresses[0]) != cache.isIPv6Mode {
 			continue
 		}
 		isLocal := false


### PR DESCRIPTION
Cherry pick of #5194 on release-1.12.

#5194: Fix IPv4 group containing IPv6 endpoints in dual-stack

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.