### PR TITLE
Upgrade sonobuoy from 0.56.4 to 0.56.8

### DIFF
--- a/ci/run-k8s-e2e-tests.sh
+++ b/ci/run-k8s-e2e-tests.sh
@@ -43,7 +43,7 @@ THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 KUBE_CONFORMANCE_IMAGE_VERSION_OPTION=""
 IMAGE_PULL_POLICY="Always"
 CONFORMANCE_IMAGE_CONFIG_PATH="${THIS_DIR}/conformance-image-config.yaml"
-SONOBUOY_IMAGE="projects.registry.vmware.com/sonobuoy/sonobuoy:v0.56.4"
+SONOBUOY_IMAGE="projects.registry.vmware.com/sonobuoy/sonobuoy:v0.56.8"
 SYSTEMD_LOGS_IMAGE="projects.registry.vmware.com/sonobuoy/systemd-logs:v0.4"
 
 _usage="Usage: $0 [--e2e-conformance] [--e2e-network-policy] [--e2e-focus <TestRegex>] [--e2e-skip <SkipRegex>]

--- a/ci/verify-sonobuoy.sh
+++ b/ci/verify-sonobuoy.sh
@@ -16,7 +16,7 @@
 
 _SONOBUOY_BINDIR="/tmp/antrea"
 _SONOBUOY_TARBALL="/tmp/sonobuoy.tar.gz"
-_MIN_SONOBUOY_VERSION="v0.56.4"
+_MIN_SONOBUOY_VERSION="v0.56.8"
 
 install_sonobuoy() {
     local ostype=""


### PR DESCRIPTION
sonobuoy:0.56.4 still tries to pull images from "k8s.gcr.io", which is deprecated. The default image registry should be migrated to "registry.k8s.io" to support the latest Kubernetes release. So the sonobuoy should be upgraded to 0.56.8.