### PR TITLE
Add "Deprecated" annotation to Pending

### DIFF
--- a/pkg/apis/crd/v1alpha1/types.go
+++ b/pkg/apis/crd/v1alpha1/types.go
@@ -23,7 +23,7 @@ import (
 type TraceflowPhase string
 
 const (
-	// Pending is not used anymore
+	// Deprecated: Pending is not used anymore
 	Pending   TraceflowPhase = "Pending"
 	Running   TraceflowPhase = "Running"
 	Succeeded TraceflowPhase = "Succeeded"

--- a/pkg/controller/traceflow/controller.go
+++ b/pkg/controller/traceflow/controller.go
@@ -237,6 +237,8 @@ func (c *Controller) syncTraceflow(traceflowName string) error {
 		return err
 	}
 	switch tf.Status.Phase {
+	//lint:ignore SA1019 Allow existing use.
+	//nolint:staticcheck
 	case "", crdv1alpha1.Pending:
 		err = c.startTraceflow(tf)
 	case crdv1alpha1.Running:


### PR DESCRIPTION
Add a "Deprecated" annotation to Pending, so that the IDE will show hints that this phase is deprecated.