### PR TITLE
Disable CGO for antctl binary

### DIFF
--- a/build/images/Dockerfile.build.ubi
+++ b/build/images/Dockerfile.build.ubi
@@ -24,7 +24,11 @@ RUN go mod download
 
 COPY . /antrea
 
-RUN make antrea-agent antrea-controller antrea-cni antctl-linux
+RUN make antrea-agent antrea-controller antrea-cni
+# Disable CGO for antctl in case it is copied outside of the container image,
+# such as in e2e tests. It also reduces the size of the binary and aligns with
+# how we distribute antctl in release assets.
+RUN CGO_ENABLED=0 make antctl-linux
 RUN mv bin/antctl-linux bin/antctl
 
 FROM antrea/base-ubi:${BUILD_TAG}

--- a/build/images/Dockerfile.build.ubuntu
+++ b/build/images/Dockerfile.build.ubuntu
@@ -24,7 +24,11 @@ RUN go mod download
 
 COPY . /antrea
 
-RUN make antrea-agent antrea-controller antrea-cni antctl-linux
+RUN make antrea-agent antrea-controller antrea-cni
+# Disable CGO for antctl in case it is copied outside of the container image,
+# such as in e2e tests. It also reduces the size of the binary and aligns with
+# how we distribute antctl in release assets.
+RUN CGO_ENABLED=0 make antctl-linux
 RUN mv bin/antctl-linux bin/antctl
 
 FROM antrea/base-ubuntu:${BUILD_TAG}


### PR DESCRIPTION
Disable CGO to avoid GLIBC dependency in antctl for cross-platform compatibility. This also reduces the size of the antrea ubuntu image from 564MB to 540MB.