### PR TITLE
Consume Topology Mode Annotation for AntreaProxy

### DIFF
--- a/third_party/proxy/service.go
+++ b/third_party/proxy/service.go
@@ -230,7 +230,13 @@ func (sct *ServiceChangeTracker) newBaseServiceInfo(port *v1.ServicePort, servic
 		externalPolicyLocal:   externalPolicyLocal,
 		internalPolicyLocal:   internalPolicyLocal,
 		internalTrafficPolicy: service.Spec.InternalTrafficPolicy,
-		hintsAnnotation:       service.Annotations[v1.AnnotationTopologyAwareHints],
+	}
+	// TODO: Switch to v1.DeprecatedAnnotationTopologyAwareHints and v1.AnnotationTopologyMode after
+	//  upgrading Antrea K8s API to at least 1.27
+	var ok bool
+	info.hintsAnnotation, ok = service.Annotations[v1.AnnotationTopologyAwareHints]
+	if !ok {
+		info.hintsAnnotation, _ = service.Annotations["service.kubernetes.io/topology-mode"]
 	}
 
 	loadBalancerSourceRanges := make([]string, len(service.Spec.LoadBalancerSourceRanges))

--- a/third_party/proxy/types.go
+++ b/third_party/proxy/types.go
@@ -108,7 +108,8 @@ type ServicePort interface {
 	InternalPolicyLocal() bool
 	// InternalTrafficPolicy returns service InternalTrafficPolicy
 	InternalTrafficPolicy() *v1.ServiceInternalTrafficPolicyType
-	// HintsAnnotation returns the value of the v1.AnnotationTopologyAwareHints annotation.
+	// HintsAnnotation returns the value of the v1.AnnotationTopologyAwareHints annotation or
+	// service.kubernetes.io/topology-mode annotation.
 	HintsAnnotation() string
 	// ExternallyAccessible returns true if the service port is reachable via something
 	// other than ClusterIP (NodePort/ExternalIP/LoadBalancer)


### PR DESCRIPTION
New service.kubernetes.io/topology-mode annotation has been introduced as a replacement for the service.kubernetes.io/topology-aware-hints annotation. The service.kubernetes.io/topology-aware-hints annotation has been deprecated in K8s 1.27.

This change let AntreaProxy consume both annotations to support topology aware routing.

Fixes: #5122