### PR TITLE
Enhance ClusterSet controller to support ClusterSet version upgrade

### DIFF
--- a/docs/multicluster/upgrade.md
+++ b/docs/multicluster/upgrade.md
@@ -37,6 +37,41 @@ for the feature in new version.
 It should have no impact during upgrade to those imported resources like Service, Endpoints
 or AntreaClusterNetworkPolicy.
 
+## Upgrade from a version prior to v1.13
+
+Prior to Antrea v1.13, the `ClusterClaim` CRD is used to define both the local Cluster ID and
+the ClusterSet ID. Since Antrea v1.13, the `ClusterClaim` CRD is removed, and the `ClusterSet`
+CRD solely defines a ClusterSet. The name of a `ClusterSet` CR must match the ClusterSet ID,
+and a new `clusterID` field specifies the local Cluster ID.
+
+After upgrading Antrea Multi-cluster Controller from a version older than v1.13, the new version
+Multi-cluster Controller can still recognize and work with the old version `ClusterClaim` and
+`ClusterSet` CRs. However, we still suggest updating the `ClusterSet` CR to the new version after
+upgrading Multi-cluster Controller. You just need to update the existing `ClusterSet` CR and add the
+right `clusterID` to the spec. An example `ClusterSet` CR is like the following:
+
+```yaml
+apiVersion: multicluster.crd.antrea.io/v1alpha2
+kind: ClusterSet
+metadata:
+  name: test-clusterset # This value must match the ClusterSet ID.
+  namespace: kube-system
+spec:
+  clusterID: test-cluster-north # The new added field since v1.13.
+  leaders:
+    - clusterID: test-cluster-north
+      secret: "member-north-token"
+      server: "https://172.18.0.1:6443"
+  namespace: antrea-multicluster
+```
+
+You may also delete the `ClusterClaim` CRD after the upgrade, and then all existing `ClusterClaim`
+CRs will be removed automatically after the CRD is deleted.
+
+```bash
+kubectl delete crds clusterclaims.multicluster.crd.antrea.io
+```
+
 ## APIs deprecation policy
 
 The Antrea Multi-cluster APIs are built using K8s CustomResourceDefinitions and we

--- a/docs/multicluster/user-guide.md
+++ b/docs/multicluster/user-guide.md
@@ -33,6 +33,10 @@ through tunnels among clusters. The ClusterNetworkPolicy replication feature is
 supported since Antrea v1.6.0, and Multi-cluster NetworkPolicy rules are
 supported since Antrea v1.10.0.
 
+Antrea v1.13 promoted the ClusterSet CRD version from v1alpha1 to v1alpha2. If you
+plan to upgrade from a previous version to v1.13 or later, please check
+the [upgrade guide](./upgrade.md#upgrade-from-a-version-prior-to-v113).
+
 ## Quick Start
 
 Please refer to the [Quick Start Guide](quick-start.md) to learn how to build a

--- a/multicluster/cmd/multicluster-controller/controller.go
+++ b/multicluster/cmd/multicluster-controller/controller.go
@@ -18,7 +18,9 @@ import (
 	"fmt"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -171,6 +173,14 @@ func setupManagerAndCertController(isLeader bool, o *Options) (manager.Manager, 
 		o.EnableEndpointSlice = true
 	}
 
+	// ClusterClaim CRD is removed since v1.13. Check the existence of
+	// ClusterClaim API before using ClusterClaim API.
+	clusterClaimCRDAvailable, err := clusterClaimCRDAvailable(client)
+	if err != nil {
+		return nil, fmt.Errorf("error checking if ClusterClaim API is available")
+	}
+	o.ClusterCalimCRDAvailable = clusterClaimCRDAvailable
+
 	mgr, err := ctrl.NewManager(k8sConfig, o.options)
 	if err != nil {
 		return nil, fmt.Errorf("error starting manager: %v", err)
@@ -191,4 +201,22 @@ func setupManagerAndCertController(isLeader bool, o *Options) (manager.Manager, 
 		return nil, fmt.Errorf("error setting up ready check: %v", err)
 	}
 	return mgr, nil
+}
+
+func clusterClaimCRDAvailable(k8sClient clientset.Interface) (bool, error) {
+	groupVersion := mcv1alpha2.SchemeGroupVersion.String()
+	resources, err := k8sClient.Discovery().ServerResourcesForGroupVersion(groupVersion)
+	if err != nil {
+		// The group version doesn't exist.
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("error getting server resources for GroupVersion %s: %v", groupVersion, err)
+	}
+	for _, resource := range resources.APIResources {
+		if resource.Kind == "ClusterClaim" {
+			return true, nil
+		}
+	}
+	return false, nil
 }

--- a/multicluster/cmd/multicluster-controller/leader.go
+++ b/multicluster/cmd/multicluster-controller/leader.go
@@ -77,9 +77,10 @@ func runLeader(o *Options) error {
 			namespace: env.GetPodNamespace()}})
 
 	clusterSetReconciler := &leader.LeaderClusterSetReconciler{
-		Client:        mgr.GetClient(),
-		Scheme:        mgr.GetScheme(),
-		StatusManager: memberClusterStatusManager,
+		Client:                   mgr.GetClient(),
+		Scheme:                   mgr.GetScheme(),
+		StatusManager:            memberClusterStatusManager,
+		ClusterCalimCRDAvailable: o.ClusterCalimCRDAvailable,
 	}
 	if err = clusterSetReconciler.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("error creating ClusterSet controller: %v", err)

--- a/multicluster/cmd/multicluster-controller/member.go
+++ b/multicluster/cmd/multicluster-controller/member.go
@@ -67,6 +67,7 @@ func runMember(o *Options) error {
 		mgr.GetScheme(),
 		env.GetPodNamespace(),
 		o.EnableStretchedNetworkPolicy,
+		o.ClusterCalimCRDAvailable,
 	)
 	if err = clusterSetReconciler.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("error creating ClusterSet controller: %v", err)

--- a/multicluster/cmd/multicluster-controller/options.go
+++ b/multicluster/cmd/multicluster-controller/options.go
@@ -46,6 +46,9 @@ type Options struct {
 	EnableStretchedNetworkPolicy bool
 	// Watch EndpointSlice API for exported Service if EndpointSlice API is available.
 	EnableEndpointSlice bool
+	// ClusterCalimCRDAvailable indicates if the ClusterClaim CRD is available or not
+	// in the cluster.
+	ClusterCalimCRDAvailable bool
 }
 
 func newOptions() *Options {

--- a/multicluster/controllers/multicluster/member/gateway_controller_test.go
+++ b/multicluster/controllers/multicluster/member/gateway_controller_test.go
@@ -153,7 +153,7 @@ func TestGatewayReconciler(t *testing.T) {
 			fakeRemoteClient = fake.NewClientBuilder().WithScheme(common.TestScheme).WithObjects(tt.resExport).Build()
 		}
 		commonArea := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", common.LocalClusterID, common.LeaderNamespace, nil)
-		mcReconciler := NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false)
+		mcReconciler := NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false, false)
 		mcReconciler.SetRemoteCommonArea(commonArea)
 		commonAreaGatter := mcReconciler
 		r := NewGatewayReconciler(fakeClient, common.TestScheme, "default", []string{"10.200.1.1/16"}, commonAreaGatter)

--- a/multicluster/controllers/multicluster/member/labelidentity_controller_test.go
+++ b/multicluster/controllers/multicluster/member/labelidentity_controller_test.go
@@ -174,7 +174,7 @@ func TestLabelIdentityReconciler(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithLists(tt.existingPods).WithObjects(ns).Build()
 			fakeRemoteClient := fake.NewClientBuilder().WithScheme(common.TestScheme).Build()
 			commonArea := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", common.LocalClusterID, common.LeaderNamespace, nil)
-			mcReconciler := NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", true)
+			mcReconciler := NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", true, false)
 			mcReconciler.SetRemoteCommonArea(commonArea)
 			r := NewLabelIdentityReconciler(fakeClient, common.TestScheme, mcReconciler)
 			go r.Run(stopCh)
@@ -241,7 +241,7 @@ func TestNamespaceMapFunc(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithObjects(podA, podC, ns).Build()
 	fakeRemoteClient := fake.NewClientBuilder().WithScheme(common.TestScheme).Build()
 	commonArea := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", common.LocalClusterID, common.LeaderNamespace, nil)
-	mcReconciler := NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", true)
+	mcReconciler := NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", true, false)
 	mcReconciler.SetRemoteCommonArea(commonArea)
 
 	r := NewLabelIdentityReconciler(fakeClient, common.TestScheme, mcReconciler)

--- a/multicluster/controllers/multicluster/member/resourceimport_controller_test.go
+++ b/multicluster/controllers/multicluster/member/resourceimport_controller_test.go
@@ -558,7 +558,7 @@ func TestStaleControllerNoRaceWithResourceImportReconciler(t *testing.T) {
 	fakeRemoteClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithLists().Build()
 	ca := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", common.LocalClusterID, "antrea-mcs", nil)
 
-	mcReconciler := NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", true)
+	mcReconciler := NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", true, false)
 	mcReconciler.SetRemoteCommonArea(ca)
 	c := multicluster.NewStaleResCleanupController(fakeClient, common.TestScheme, "default", mcReconciler, multicluster.MemberCluster)
 	r := newLabelIdentityResourceImportReconciler(fakeClient, scheme, fakeClient, localClusterID, "default", ca)

--- a/multicluster/controllers/multicluster/member/serviceexport_controller_test.go
+++ b/multicluster/controllers/multicluster/member/serviceexport_controller_test.go
@@ -78,7 +78,7 @@ func TestServiceExportReconciler_handleDeleteEvent(t *testing.T) {
 	fakeRemoteClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithObjects(existSvcResExport, existEpResExport).Build()
 
 	commonArea := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", common.LocalClusterID, "default", nil)
-	mcReconciler := NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false)
+	mcReconciler := NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false, false)
 	mcReconciler.SetRemoteCommonArea(commonArea)
 	r := NewServiceExportReconciler(fakeClient, common.TestScheme, mcReconciler, "ClusterIP", false)
 	r.installedSvcs.Add(&svcInfo{
@@ -273,7 +273,7 @@ func TestServiceExportReconciler_CheckExportStatus(t *testing.T) {
 	fakeRemoteClient := fake.NewClientBuilder().WithScheme(common.TestScheme).Build()
 	commonArea := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", common.LocalClusterID, "default", nil)
 
-	mcReconciler := NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false)
+	mcReconciler := NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false, false)
 	mcReconciler.SetRemoteCommonArea(commonArea)
 	r := NewServiceExportReconciler(fakeClient, common.TestScheme, mcReconciler, "ClusterIP", false)
 	for _, tt := range tests {
@@ -349,7 +349,7 @@ func TestServiceExportReconciler_handleServiceExportCreateEvent(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fakeRemoteClient := fake.NewClientBuilder().WithScheme(common.TestScheme).Build()
 			commonArea := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", common.LocalClusterID, "default", nil)
-			mcReconciler := NewMemberClusterSetReconciler(tt.fakeClient, common.TestScheme, "default", false)
+			mcReconciler := NewMemberClusterSetReconciler(tt.fakeClient, common.TestScheme, "default", false, false)
 			mcReconciler.SetRemoteCommonArea(commonArea)
 			r := NewServiceExportReconciler(tt.fakeClient, common.TestScheme, mcReconciler, tt.endpointIPType, tt.endpointSliceEnabled)
 			if _, err := r.Reconcile(common.TestCtx, nginxReq); err != nil {
@@ -532,7 +532,7 @@ func TestServiceExportReconciler_handleUpdateEvent(t *testing.T) {
 			fakeRemoteClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithObjects(existSvcRe, existEpRe).Build()
 
 			commonArea := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", common.LocalClusterID, "default", nil)
-			mcReconciler := NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false)
+			mcReconciler := NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false, false)
 			mcReconciler.SetRemoteCommonArea(commonArea)
 			r := NewServiceExportReconciler(fakeClient, common.TestScheme, mcReconciler, tt.endpointIPType, false)
 			r.installedSvcs.Add(sinfo)

--- a/multicluster/controllers/multicluster/stale_controller_test.go
+++ b/multicluster/controllers/multicluster/stale_controller_test.go
@@ -99,7 +99,7 @@ func TestStaleController_CleanupService(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithLists(tt.existSvcList, tt.existSvcImpList).Build()
 			fakeRemoteClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithLists(tt.existingResImpList).Build()
 			commonArea := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", common.LocalClusterID, "default", nil)
-			mcReconciler := member.NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false)
+			mcReconciler := member.NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false, false)
 			mcReconciler.SetRemoteCommonArea(commonArea)
 			c := NewStaleResCleanupController(fakeClient, common.TestScheme, "default", mcReconciler, MemberCluster)
 			if err := c.cleanup(ctx); err != nil {
@@ -194,7 +194,7 @@ func TestStaleController_CleanupACNP(t *testing.T) {
 			fakeRemoteClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithLists(tt.existingResImpList).Build()
 			commonArea := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", common.LocalClusterID, "default", nil)
 
-			mcReconciler := member.NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false)
+			mcReconciler := member.NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false, false)
 			mcReconciler.SetRemoteCommonArea(commonArea)
 			c := NewStaleResCleanupController(fakeClient, common.TestScheme, "default", mcReconciler, MemberCluster)
 			if err := c.cleanup(ctx); err != nil {
@@ -389,7 +389,7 @@ func TestStaleController_CleanupResourceExport(t *testing.T) {
 			fakeRemoteClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithLists(tt.existResExpList).Build()
 			commonArea := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", common.LocalClusterID, "default", nil)
 
-			mcReconciler := member.NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false)
+			mcReconciler := member.NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false, false)
 			mcReconciler.SetRemoteCommonArea(commonArea)
 			c := NewStaleResCleanupController(fakeClient, common.TestScheme, "default", mcReconciler, MemberCluster)
 			if err := c.cleanup(ctx); err != nil {
@@ -466,7 +466,7 @@ func TestStaleController_CleanupClusterInfoImport(t *testing.T) {
 			fakeRemoteClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithLists(tt.existingResImpList).Build()
 			commonarea := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", common.LocalClusterID, "antrea-mcs", nil)
 
-			mcReconciler := member.NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false)
+			mcReconciler := member.NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false, false)
 			mcReconciler.SetRemoteCommonArea(commonarea)
 			c := NewStaleResCleanupController(fakeClient, common.TestScheme, "default", mcReconciler, MemberCluster)
 			if err := c.cleanup(ctx); err != nil {
@@ -573,7 +573,7 @@ func TestStaleController_CleanupMemberClusterAnnounce(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithLists(tt.memberClusterAnnounceList).WithLists(tt.clusterSet).Build()
 
-			mcReconciler := member.NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false)
+			mcReconciler := member.NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false, false)
 			c := NewStaleResCleanupController(fakeClient, common.TestScheme, "default", mcReconciler, LeaderCluster)
 			assert.Equal(t, nil, c.cleanup(ctx))
 
@@ -649,7 +649,7 @@ func TestStaleController_CleanupLabelIdentites(t *testing.T) {
 			fakeRemoteClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithLists(tt.existingResImpList).Build()
 			ca := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", common.LocalClusterID, "antrea-mcs", nil)
 
-			mcReconciler := member.NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false)
+			mcReconciler := member.NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false, false)
 			mcReconciler.SetRemoteCommonArea(ca)
 			c := NewStaleResCleanupController(fakeClient, common.TestScheme, "default", mcReconciler, MemberCluster)
 			if err := c.cleanup(ctx); err != nil {

--- a/multicluster/test/integration/suite_test.go
+++ b/multicluster/test/integration/suite_test.go
@@ -143,6 +143,7 @@ var _ = BeforeSuite(func() {
 		k8sManager.GetScheme(),
 		LeaderNamespace,
 		false,
+		false,
 	)
 	err = clusterSetReconciler.SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Refine ClusterSet controller to watch ClusterClaims to handle the ClusterSet upgrade from v1alpha1 to v1alpha2. When the ClusterID is not in ClusterSet spec, controller will try to get ClusterID from ClusterClaims.