### PR TITLE
Revise `antctl mc deploy` to support manifest update

### DIFF
--- a/pkg/antctl/raw/multicluster/deploy/deploy_helper.go
+++ b/pkg/antctl/raw/multicluster/deploy/deploy_helper.go
@@ -118,7 +118,21 @@ func createResources(cmd *cobra.Command, apiGroupResources []*restmapper.APIGrou
 			if !kerrors.IsAlreadyExists(err) {
 				return err
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "%s/%s already exists\n", unstructuredObj.GetKind(), unstructuredObj.GetName())
+			existingRes, err := dri.Get(context.TODO(), unstructuredObj.GetName(), metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			existingVersion := existingRes.GetResourceVersion()
+			unstructuredObj.SetResourceVersion(existingVersion)
+			var updatedObj *unstructured.Unstructured
+			if updatedObj, err = dri.Update(context.TODO(), unstructuredObj, metav1.UpdateOptions{}); err != nil {
+				return err
+			}
+			if updatedObj.GetResourceVersion() != existingVersion {
+				fmt.Fprintf(cmd.OutOrStdout(), "%s/%s configured\n", unstructuredObj.GetKind(), unstructuredObj.GetName())
+			} else {
+				fmt.Fprintf(cmd.OutOrStdout(), "%s/%s unchanged\n", unstructuredObj.GetKind(), unstructuredObj.GetName())
+			}
 		} else {
 			fmt.Fprintf(cmd.OutOrStdout(), "%s/%s created\n", unstructuredObj.GetKind(), unstructuredObj.GetName())
 		}


### PR DESCRIPTION
If a resource to create already exists, the command `antctl mc deploy` will do nothing even when the manifests are changed. Revise the code to apply changes if there is any manifest update.