### PR TITLE
Fix a bug in test-e2e-kind.sh

### DIFF
--- a/ci/kind/test-e2e-kind.sh
+++ b/ci/kind/test-e2e-kind.sh
@@ -53,7 +53,7 @@ FLOW_VISIBILITY_YML=$(dirname $0)"/../../build/yamls/flow-visibility-e2e.yml"
 
 function quit {
   result=$?
-  if [[ $setup_only || $test_only ]]; then
+  if [[ "$setup_only" = true || "$test_only" = true ]]; then
     exit $result
   fi
   echoerr "Cleaning testbed"


### PR DESCRIPTION
Before this patch, the testbed clean-up is never executed because of a mistake in the "quit" function. This patch fixed this bug.

This is because in Shell, `a=false` is nothing special but assign a "false" string to variable `a`. A non-empty string is true, so `[[ $setup_only || $test_only ]]` is **always true**.