### PR TITLE
[e2e] Support skipping deploying Antrea

### DIFF
--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -180,9 +180,11 @@ func skipIfProxyAllDisabled(t *testing.T, data *TestData) {
 }
 
 func ensureAntreaRunning(data *TestData) error {
-	log.Println("Applying Antrea YAML")
-	if err := data.deployAntrea(deployAntreaDefault); err != nil {
-		return err
+	if testOptions.deployAntrea {
+		log.Println("Applying Antrea YAML")
+		if err := data.deployAntrea(deployAntreaDefault); err != nil {
+			return err
+		}
 	}
 	log.Println("Waiting for all Antrea DaemonSet Pods")
 	if err := data.waitForAntreaDaemonSetPods(defaultTimeout); err != nil {

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -195,6 +195,9 @@ type TestOptions struct {
 	skipCases           string
 	linuxVMs            string
 	windowsVMs          string
+	// deployAntrea determines whether to deploy Antrea before running tests. It requires antrea.yml to be present in
+	// the home directory of the control-plane Node. Note it doesn't affect the tests that redeploy Antrea themselves.
+	deployAntrea bool
 }
 
 var testOptions TestOptions

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -81,6 +81,7 @@ func testMain(m *testing.M) int {
 	flag.BoolVar(&testOptions.enableCoverage, "coverage", false, "Run tests and measure coverage")
 	flag.BoolVar(&testOptions.enableAntreaIPAM, "antrea-ipam", false, "Run tests with AntreaIPAM")
 	flag.BoolVar(&testOptions.flowVisibility, "flow-visibility", false, "Run flow visibility tests")
+	flag.BoolVar(&testOptions.deployAntrea, "deploy-antrea", true, "Deploy Antrea before running tests")
 	flag.StringVar(&testOptions.coverageDir, "coverage-dir", "", "Directory for coverage data files")
 	flag.StringVar(&testOptions.skipCases, "skip", "", "Key words to skip cases")
 	flag.StringVar(&testOptions.linuxVMs, "linuxVMs", "", "hostname of Linux VMs")


### PR DESCRIPTION
When developing something, it should be common that Antrea is already deployed and we just want to validate it with e2e tests. For example, I usually deploy Antrea using helm which is easier to set the configurations. But running e2e always deployed Antrea and required the manifest yaml to be present in the home directory of control plane node, which adds some burden to running e2e tests.

This commit adds a flag "--deploy-antrea" to support skipping deploying Antrea. It defaults to true to keep the same behavior as before. When we just want to run e2e tests and not to redeploy Antrea. We can set "--deploy-antrea=false".