### PR TITLE
Automated cherry pick of #5277: Re-serve v1alpha2 ClusterGroup

### DIFF
--- a/build/charts/antrea/crds/clustergroup.yaml
+++ b/build/charts/antrea/crds/clustergroup.yaml
@@ -9,7 +9,7 @@ spec:
   group: crd.antrea.io
   versions:
     - name: v1alpha2
-      served: false
+      served: true
       storage: false
       schema:
         openAPIV3Schema:

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -121,7 +121,7 @@ spec:
   group: crd.antrea.io
   versions:
     - name: v1alpha2
-      served: false
+      served: true
       storage: false
       schema:
         openAPIV3Schema:

--- a/build/yamls/antrea-crds.yml
+++ b/build/yamls/antrea-crds.yml
@@ -116,7 +116,7 @@ spec:
   group: crd.antrea.io
   versions:
     - name: v1alpha2
-      served: false
+      served: true
       storage: false
       schema:
         openAPIV3Schema:

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -121,7 +121,7 @@ spec:
   group: crd.antrea.io
   versions:
     - name: v1alpha2
-      served: false
+      served: true
       storage: false
       schema:
         openAPIV3Schema:

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -121,7 +121,7 @@ spec:
   group: crd.antrea.io
   versions:
     - name: v1alpha2
-      served: false
+      served: true
       storage: false
       schema:
         openAPIV3Schema:

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -121,7 +121,7 @@ spec:
   group: crd.antrea.io
   versions:
     - name: v1alpha2
-      served: false
+      served: true
       storage: false
       schema:
         openAPIV3Schema:

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -121,7 +121,7 @@ spec:
   group: crd.antrea.io
   versions:
     - name: v1alpha2
-      served: false
+      served: true
       storage: false
       schema:
         openAPIV3Schema:

--- a/docs/api.md
+++ b/docs/api.md
@@ -28,6 +28,7 @@ These are the CRDs currently available in `crd.antrea.io`.
 |---|---|---|---|---|
 | `AntreaAgentInfo` | v1beta1 | v1.0.0 | N/A | N/A |
 | `AntreaControllerInfo` | v1beta1 | v1.0.0 | N/A | N/A |
+| `ClusterGroup` | v1alpha2 | v1.0.0 | v1.1.0 | v2.0.0 |
 | `ClusterGroup` | v1alpha3 | v1.1.0 | N/A | N/A |
 | `ClusterNetworkPolicy` | v1alpha1 | v1.0.0 | N/A | N/A |
 | `Egress` | v1alpha2 | v1.0.0 | N/A | N/A |
@@ -69,10 +70,6 @@ These are the API group versions which are curently available when using Antrea.
 
 | CRD | CRD version | Introduced in | Deprecated in | Removed in |
 |---|---|---|---|---|
-| `ClusterGroup` | v1alpha2 | v1.0.0 | v1.1.0 | v1.12.0 [^1] |
-
-[^1]: The v1alpha2 version of the `ClusterGroup` CRD is no longer served by the
-      apiserver in v1.12 and is completely removed in v1.13.
 
 ## API renaming from `*.antrea.tanzu.vmware.com` to `*.antrea.io`
 


### PR DESCRIPTION
Cherry pick of #5277 on release-1.12.

#5277: Re-serve v1alpha2 ClusterGroup

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.