### PR TITLE
free more space before running the flow-visibility e2e test

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -381,6 +381,11 @@ jobs:
         # https://github.com/actions/virtual-environments/issues/709
         run: |
           sudo apt-get clean
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          sudo rm -rf "/usr/local/lib/android"
           df -h
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4


### PR DESCRIPTION
flow-visibility e2e test is recently failed because the error: ”No space left on device“.
Release more space as a workaround before running the flow-visibility e2e test.

resolve https://github.com/antrea-io/antrea/issues/5268