### PR TITLE
Resolve flaky failure in VM agent e2e case with ANP FQDN

### DIFF
--- a/test/e2e/vmagent_test.go
+++ b/test/e2e/vmagent_test.go
@@ -480,7 +480,7 @@ func testANPOnVMs(t *testing.T, data *TestData, vmList []vmInfo, osType string) 
 	})
 	// Test FQDN rules in ANP
 	t.Run("testANPOnExternalNodeWithFQDN", func(t *testing.T) {
-		testANPWithFQDN(t, data, "anp-vmagent-fqdn", namespace, *appliedToVM, []string{"www.facebook.com"}, []string{"docs.google.com"}, []string{"maps.google.com"})
+		testANPWithFQDN(t, data, "anp-vmagent-fqdn", namespace, *appliedToVM, []string{"www.facebook.com"}, []string{"docs.google.com"}, []string{"github.com"})
 	})
 }
 


### PR DESCRIPTION
The original test cases uses the same domain name and different applications for
both "Drop" and "Reject" actions, the two rules may be impacted by each other if
the DNS response referred to the same IP address, then the test results are also
impacted. Use different domain names in the FQDN cases to avoid such flaky
failure.