### PR TITLE
Reduce number of goroutines in TestConcurrentCreateGroups

### DIFF
--- a/pkg/ovs/openflow/ofctrl_bridge_test.go
+++ b/pkg/ovs/openflow/ofctrl_bridge_test.go
@@ -122,7 +122,7 @@ func TestConcurrentCreateGroups(t *testing.T) {
 	b := NewOFBridge("test-br", GetMgmtAddress(ovsconfig.DefaultOVSRunDir, "test-br"))
 	b.SwitchConnected(newFakeOFSwitch(b))
 	// Race detector on Windows has limit of 8192 simultaneously alive goroutines.
-	concurrentNum := 8000
+	concurrentNum := 7000
 	var wg sync.WaitGroup
 	for i := 0; i < concurrentNum; i++ {
 		wg.Add(1)


### PR DESCRIPTION
Currently the number of goroutines created in TestConcurrentCreateGroups is too large that sometimes the limit of 8192 goroutines of the race detector on Windows is exceeded. Reducing the number of goroutines may relieve the problem.

Fixes #5261.