### PR TITLE
Fix GKE conformance job

### DIFF
--- a/ci/test-conformance-gke.sh
+++ b/ci/test-conformance-gke.sh
@@ -272,9 +272,8 @@ function run_conformance() {
     ${GIT_CHECKOUT_DIR}/ci/run-k8s-e2e-tests.sh --e2e-conformance \
       --kubernetes-version ${KUBE_CONFORMANCE_IMAGE_VERSION} \
       --log-mode ${MODE} > ${GIT_CHECKOUT_DIR}/gke-test.log && \
-   # Skip Netpol tests for GKE as the test suite's Namespace creation function is not robust, which leads to test
-   # failures. See https://github.com/antrea-io/antrea/issues/3762#issuecomment-1195865441.
-    ${GIT_CHECKOUT_DIR}/ci/run-k8s-e2e-tests.sh --e2e-network-policy --e2e-skip "Netpol" \
+    # Skip legacy NetworkPolicy tests
+    ${GIT_CHECKOUT_DIR}/ci/run-k8s-e2e-tests.sh --e2e-network-policy --e2e-skip "NetworkPolicyLegacy" \
       --kubernetes-version ${KUBE_CONFORMANCE_IMAGE_VERSION} \
       --log-mode ${MODE} >> ${GIT_CHECKOUT_DIR}/gke-test.log || \
     TEST_SCRIPT_RC=$?

--- a/ci/test-conformance-gke.sh
+++ b/ci/test-conformance-gke.sh
@@ -151,6 +151,8 @@ pushd "$THIS_DIR" > /dev/null
 # disable gcloud prompts, e.g., when deleting resources
 export CLOUDSDK_CORE_DISABLE_PROMPTS=1
 
+export CLOUDSDK_CORE_PROJECT="$GKE_PROJECT"
+
 function setup_gke() {
     if [[ -z ${K8S_VERSION+x} ]]; then
         K8S_VERSION=$(gcloud container get-server-config --zone ${GKE_ZONE} | awk '/validMasterVersions/{getline;print}' | cut -c3- )
@@ -169,7 +171,7 @@ function setup_gke() {
     which kubectl
 
     echo '=== Creating a cluster in GKE ==='
-    gcloud container --project ${GKE_PROJECT} clusters create ${CLUSTER} \
+    gcloud container clusters create ${CLUSTER} \
         --image-type ${GKE_HOST} --machine-type ${MACHINE_TYPE} \
         --cluster-version ${K8S_VERSION} --zone ${GKE_ZONE} \
         --enable-ip-alias \
@@ -249,9 +251,11 @@ function deliver_antrea_to_gke() {
     kubectl rollout status --timeout=2m deployment.apps/antrea-controller -n kube-system
     kubectl rollout status --timeout=2m daemonset/antrea-agent -n kube-system
 
-    # Restart all Pods in all Namespaces (kube-system, etc) so they can be managed by Antrea.
-    kubectl delete pods -n kube-system $(kubectl get pods -n kube-system -o custom-columns=NAME:.metadata.name,HOSTNETWORK:.spec.hostNetwork \
-        --no-headers=true | grep '<none>' | awk '{ print $1 }')
+    # Restart all Pods in all Namespaces (kube-system, gmp-system, etc) so they can be managed by Antrea.
+    for ns in $(kubectl get ns -o=jsonpath=''{.items[*].metadata.name}'' --no-headers=true); do
+        pods=$(kubectl get pods -n $ns -o custom-columns=NAME:.metadata.name,HOSTNETWORK:.spec.hostNetwork --no-headers=true | grep '<none>' | awk '{ print $1 }')
+        [ -z "$pods" ] || kubectl delete pods -n $ns $pods
+    done
     kubectl rollout status --timeout=2m deployment.apps/kube-dns -n kube-system
     # wait for other pods in the kube-system namespace to become ready
     sleep 5

--- a/docs/gke-installation.md
+++ b/docs/gke-installation.md
@@ -110,17 +110,24 @@ you should be able to see these Pods running in your cluster:
 
 3. Restart remaining Pods
 
-    Once Antrea is up and running, restart all Pods in all Namespaces (kube-system, etc) so they can be managed by Antrea.
+    Once Antrea is up and running, restart all Pods in all Namespaces (kube-system, gmp-system, etc) so they can be managed by Antrea.
 
     ```bash
-    $ kubectl delete pods -n kube-system $(kubectl get pods -n kube-system -o custom-columns=NAME:.metadata.name,HOSTNETWORK:.spec.hostNetwork --no-headers=true | grep '<none>' | awk '{ print $1 }')
-    pod "event-exporter-gke-755c4b4d97-wqlcg" deleted
-    pod "konnectivity-agent-5cb8ff9b9-2cv5j" deleted
-    pod "konnectivity-agent-5cb8ff9b9-5jpvp" deleted
-    pod "konnectivity-agent-autoscaler-7dc78c8c9-kqn9f" deleted
-    pod "kube-dns-5b5dfcd97b-79m4c" deleted
-    pod "kube-dns-5b5dfcd97b-q49qj" deleted
-    pod "kube-dns-autoscaler-5f56f8997c-kqrgx" deleted
-    pod "l7-default-backend-d6b749b76-bsv9l" deleted
-    pod "metrics-server-v0.5.2-67864775dc-bhd9p" deleted
+    $ for ns in $(kubectl get ns -o=jsonpath=''{.items[*].metadata.name}'' --no-headers=true); do \
+        pods=$(kubectl get pods -n $ns -o custom-columns=NAME:.metadata.name,HOSTNETWORK:.spec.hostNetwork --no-headers=true | grep '<none>' | awk '{ print $1 }'); \
+        [ -z "$pods" ] || kubectl delete pods -n $ns $pods; done
+    pod "alertmanager-0" deleted
+    pod "collector-4sfvd" deleted
+    pod "collector-gtlxf" deleted
+    pod "gmp-operator-67c4678f5c-ffktp" deleted
+    pod "rule-evaluator-85b8bb96dc-trnqj" deleted
+    pod "event-exporter-gke-7bf6c99dcb-4r62c" deleted
+    pod "konnectivity-agent-autoscaler-6dfdb49cf7-hfv9g" deleted
+    pod "konnectivity-agent-cc655669b-2cjc9" deleted
+    pod "konnectivity-agent-cc655669b-d79vf" deleted
+    pod "kube-dns-5bfd847c64-ksllw" deleted
+    pod "kube-dns-5bfd847c64-qv9tq" deleted
+    pod "kube-dns-autoscaler-84b8db4dc7-2pb2b" deleted
+    pod "l7-default-backend-64679d9c86-q69lm" deleted
+    pod "metrics-server-v0.5.2-6bf74b5d5f-22gqq" deleted
     ```


### PR DESCRIPTION
The job was only deleting Pods in the kube-system Namespace after installing Antrea. However, GKE has been introducing new Namespaces (e.g., gmp-system), which are also running non-hostNetwork Pods. If we do not delete ALL non-hostNetwork Pods in ALL Namespaces after installing Antrea, it can lead to IP address reuse, and a broken GKE cluster.