### PR TITLE
Add "X-Load-Balancing-Endpoint-Weight" header to AntreaProxy Service healthcheck

### DIFF
--- a/third_party/proxy/healthcheck/service_health.go
+++ b/third_party/proxy/healthcheck/service_health.go
@@ -43,6 +43,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -236,6 +237,7 @@ func (h hcHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 
 	resp.Header().Set("Content-Type", "application/json")
 	resp.Header().Set("X-Content-Type-Options", "nosniff")
+	resp.Header().Set("X-Load-Balancing-Endpoint-Weight", strconv.Itoa(count))
 	if count == 0 {
 		resp.WriteHeader(http.StatusServiceUnavailable)
 	} else {


### PR DESCRIPTION
This commit adds the new header "X-Load-Balancing-Endpoint-Weight" to AntreaProxy. The header will be returned from the service health and its value will represent the number of local Endpoints. This header enables weighted load balancing and offers a faster alternative to parsing JSON from the content body.

The addition of this header is necessary for achieving parity with kube-proxy.