### PR TITLE
Automated cherry pick of #5287: free more space before running flow-visibility e2e test

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -371,6 +371,11 @@ jobs:
         # https://github.com/actions/virtual-environments/issues/709
         run: |
           sudo apt-get clean
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          sudo rm -rf "/usr/local/lib/android"
           df -h
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3


### PR DESCRIPTION
Cherry pick of #5287 on release-1.11.

#5287: free more space before running flow-visibility e2e test

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.