### PR TITLE
Automated cherry pick of #4873: Stop exporting KUBECONFIG in ci/test-conformance-gke.sh
#4983: Fix GKE CI job
#5298: Fix GKE conformance job

### DIFF
--- a/ci/jenkins/jobs/macros.yaml
+++ b/ci/jenkins/jobs/macros.yaml
@@ -31,7 +31,6 @@
       - shell: |-
           #!/bin/bash
           set -ex
-          source /home/ubuntu/.bashrc
           sudo ./ci/test-conformance-eks.sh --cluster-name "${CLUSTERNAME}" --cleanup-only
 
 - builder:
@@ -40,8 +39,7 @@
       - shell: |-
          #!/bin/bash
          set -ex
-         source /home/ubuntu/.bashrc
-         ./ci/test-conformance-gke.sh --gcloud-path "${GCLOUD_PATH}" --cluster-name "${CLUSTERNAME}" --cleanup-only
+         ./ci/test-conformance-gke.sh --gcloud-sdk-path "${GCLOUD_SDK_PATH}" --cluster-name "${CLUSTERNAME}" --cleanup-only
 
 - builder:
     name: builder-aks-cluster-cleanup
@@ -49,7 +47,6 @@
       - shell: |-
          #!/bin/bash
          set -ex
-         source /home/ubuntu/.bashrc
          ./ci/test-conformance-aks.sh --cluster-name "${CLUSTERNAME}" --cleanup-only
 
 - builder:

--- a/ci/jenkins/jobs/projects-cloud.yaml
+++ b/ci/jenkins/jobs/projects-cloud.yaml
@@ -874,7 +874,7 @@
               # gcloud auth login requires verification code from url
               ${{GCLOUD_PATH}} auth activate-service-account --key-file=${{GCLOUD_KEY_PATH}}
               sudo ./ci/test-conformance-gke.sh --cluster-name antrea-gke-${{BUILD_NUMBER}} \
-                --svc-account antrea-gcp@antrea.iam.gserviceaccount.com --gcloud-path ${{GCLOUD_PATH}} \
+                --svc-account antrea-gcp@antrea.iam.gserviceaccount.com --gcloud-sdk-path ${{GCLOUD_SDK_PATH}} \
                 --log-mode detail --setup-only
           triggers:
           - timed: H H */2 * *

--- a/ci/jenkins/jobs/projects-cloud.yaml
+++ b/ci/jenkins/jobs/projects-cloud.yaml
@@ -807,7 +807,6 @@
           builders:
           - shell: |-
               #!/bin/bash
-              source /home/ubuntu/.bashrc
               sudo ./ci/test-conformance-eks.sh --aws-access-key ${{AWS_ACCESS_KEY}} --aws-secret-key ${{AWS_SECRET_KEY}} \
                 --aws-service-user-role-arn ${{AWS_SERVICE_USER_ROLE_ARN}} --aws-service-user ${{AWS_SERVICE_USER_NAME}} --cluster-name ${{JOB_NAME}}-${{BUILD_NUMBER}} \
                 --log-mode detail --setup-only
@@ -870,9 +869,8 @@
           builders:
           - shell: |-
               #!/bin/bash
-              source /home/ubuntu/.bashrc
               # gcloud auth login requires verification code from url
-              ${{GCLOUD_PATH}} auth activate-service-account --key-file=${{GCLOUD_KEY_PATH}}
+              ${{GCLOUD_SDK_PATH}}/bin/gcloud auth activate-service-account --key-file=${{GCLOUD_KEY_PATH}}
               sudo ./ci/test-conformance-gke.sh --cluster-name antrea-gke-${{BUILD_NUMBER}} \
                 --svc-account antrea-gcp@antrea.iam.gserviceaccount.com --gcloud-sdk-path ${{GCLOUD_SDK_PATH}} \
                 --log-mode detail --setup-only
@@ -922,7 +920,6 @@
           builders:
           - shell: |-
               #!/bin/bash
-              source /home/ubuntu/.bashrc
               sudo ./ci/test-conformance-aks.sh --azure-app-id ${{AZURE_APP_ID}} --azure-password ${{AZURE_PASSWORD}} \
                 --azure-tenant-id ${{AZURE_TENANT_ID}} --cluster-name ${{JOB_NAME}}-${{BUILD_NUMBER}} \
                 --log-mode detail --setup-only

--- a/ci/jenkins/jobs/projects-cloud.yaml
+++ b/ci/jenkins/jobs/projects-cloud.yaml
@@ -824,6 +824,7 @@
           - trigger-parameterized-builds:
             - project:
               - cloud-{name}-eks-cleanup
+              current-parameters: true
               property-file: 'ci_properties.txt'
           - email:
               notify-every-unstable-build: true
@@ -888,6 +889,7 @@
           - trigger-parameterized-builds:
             - project:
               - cloud-{name}-gke-cleanup
+              current-parameters: true
               property-file: 'ci_properties.txt'
           - email:
               notify-every-unstable-build: true
@@ -937,6 +939,7 @@
           - trigger-parameterized-builds:
             - project:
               - cloud-{name}-aks-cleanup
+              current-parameters: true
               property-file: 'ci_properties.txt'
           - email:
               notify-every-unstable-build: true

--- a/ci/test-conformance-gke.sh
+++ b/ci/test-conformance-gke.sh
@@ -268,9 +268,8 @@ function run_conformance() {
     ${GIT_CHECKOUT_DIR}/ci/run-k8s-e2e-tests.sh --e2e-conformance \
       --kubernetes-version ${KUBE_CONFORMANCE_IMAGE_VERSION} \
       --log-mode ${MODE} > ${GIT_CHECKOUT_DIR}/gke-test.log && \
-   # Skip Netpol tests for GKE as the test suite's Namespace creation function is not robust, which leads to test
-   # failures. See https://github.com/antrea-io/antrea/issues/3762#issuecomment-1195865441.
-    ${GIT_CHECKOUT_DIR}/ci/run-k8s-e2e-tests.sh --e2e-network-policy --e2e-skip "Netpol" \
+    # Skip legacy NetworkPolicy tests
+    ${GIT_CHECKOUT_DIR}/ci/run-k8s-e2e-tests.sh --e2e-network-policy --e2e-skip "NetworkPolicyLegacy" \
       --kubernetes-version ${KUBE_CONFORMANCE_IMAGE_VERSION} \
       --log-mode ${MODE} >> ${GIT_CHECKOUT_DIR}/gke-test.log || \
     TEST_SCRIPT_RC=$?

--- a/ci/test-conformance-gke.sh
+++ b/ci/test-conformance-gke.sh
@@ -151,6 +151,8 @@ pushd "$THIS_DIR" > /dev/null
 # disable gcloud prompts, e.g., when deleting resources
 export CLOUDSDK_CORE_DISABLE_PROMPTS=1
 
+export CLOUDSDK_CORE_PROJECT="$GKE_PROJECT"
+
 function setup_gke() {
     if [[ -z ${K8S_VERSION+x} ]]; then
         K8S_VERSION=$(gcloud container get-server-config --zone ${GKE_ZONE} | awk '/validMasterVersions/{getline;print}' | cut -c3- )
@@ -169,7 +171,7 @@ function setup_gke() {
     which kubectl
 
     echo '=== Creating a cluster in GKE ==='
-    gcloud container --project ${GKE_PROJECT} clusters create ${CLUSTER} \
+    gcloud container clusters create ${CLUSTER} \
         --image-type ${GKE_HOST} --machine-type ${MACHINE_TYPE} \
         --cluster-version ${K8S_VERSION} --zone ${GKE_ZONE} \
         --enable-ip-alias \
@@ -245,9 +247,11 @@ function deliver_antrea_to_gke() {
     kubectl rollout status --timeout=2m deployment.apps/antrea-controller -n kube-system
     kubectl rollout status --timeout=2m daemonset/antrea-agent -n kube-system
 
-    # Restart all Pods in all Namespaces (kube-system, etc) so they can be managed by Antrea.
-    kubectl delete pods -n kube-system $(kubectl get pods -n kube-system -o custom-columns=NAME:.metadata.name,HOSTNETWORK:.spec.hostNetwork \
-        --no-headers=true | grep '<none>' | awk '{ print $1 }')
+    # Restart all Pods in all Namespaces (kube-system, gmp-system, etc) so they can be managed by Antrea.
+    for ns in $(kubectl get ns -o=jsonpath=''{.items[*].metadata.name}'' --no-headers=true); do
+        pods=$(kubectl get pods -n $ns -o custom-columns=NAME:.metadata.name,HOSTNETWORK:.spec.hostNetwork --no-headers=true | grep '<none>' | awk '{ print $1 }')
+        [ -z "$pods" ] || kubectl delete pods -n $ns $pods
+    done
     kubectl rollout status --timeout=2m deployment.apps/kube-dns -n kube-system
     # wait for other pods in the kube-system namespace to become ready
     sleep 5

--- a/ci/test-conformance-gke.sh
+++ b/ci/test-conformance-gke.sh
@@ -50,7 +50,7 @@ and create the project to be used for cluster with \`gcloud projects create\`.
         --svc-cidr            The service CIDR to be used for cluster. Defaults to 10.94.0.0/16.
         --host-type           The host type of worker node. Defaults to UBUNTU.
         --machine-type        The machine type of worker node. Defaults to e2-standard-4.
-        --gcloud-path         The path of gcloud installation. Only need to be explicitly set for Jenkins environments.
+        --gcloud-sdk-path     The path of gcloud installation. Only need to be explicitly set for Jenkins environments.
         --log-mode            Use the flag to set either 'report', 'detail', or 'dump' level data for sonobouy results.
         --setup-only          Only perform setting up the cluster and run test.
         --cleanup-only        Only perform cleaning up the cluster."
@@ -105,8 +105,8 @@ case $key in
     K8S_VERSION="$2"
     shift 2
     ;;
-    --gcloud-path)
-    GCLOUD_PATH="$2"
+    --gcloud-sdk-path)
+    GCLOUD_SDK_PATH="$2"
     shift 2
     ;;
    --log-mode)
@@ -134,8 +134,13 @@ case $key in
 esac
 done
 
-if [[ -z ${GCLOUD_PATH+x} ]]; then
-    GCLOUD_PATH=$(which gcloud)
+if [[ ! -z ${GCLOUD_SDK_PATH+x} ]]; then
+    export PATH=${GCLOUD_SDK_PATH}/bin:$PATH
+fi
+
+if ! [ -x "$(command -v gcloud)" ]; then
+    echoerr "gcloud is not available in the PATH; consider using --gcloud-sdk-path"
+    exit 1
 fi
 
 # ensures that the script can be run from anywhere
@@ -148,7 +153,7 @@ export CLOUDSDK_CORE_DISABLE_PROMPTS=1
 
 function setup_gke() {
     if [[ -z ${K8S_VERSION+x} ]]; then
-        K8S_VERSION=$(${GCLOUD_PATH} container get-server-config --zone ${GKE_ZONE} | awk '/validMasterVersions/{getline;print}' | cut -c3- )
+        K8S_VERSION=$(gcloud container get-server-config --zone ${GKE_ZONE} | awk '/validMasterVersions/{getline;print}' | cut -c3- )
     fi
 
     echo "=== This cluster to be created is named: ${CLUSTER} ==="
@@ -159,12 +164,12 @@ function setup_gke() {
     fi
 
     echo "=== Using the following gcloud version ==="
-    ${GCLOUD_PATH} --version
+    gcloud --version
     echo "=== Using the following kubectl ==="
     which kubectl
 
     echo '=== Creating a cluster in GKE ==='
-    ${GCLOUD_PATH} container --project ${GKE_PROJECT} clusters create ${CLUSTER} \
+    gcloud container --project ${GKE_PROJECT} clusters create ${CLUSTER} \
         --image-type ${GKE_HOST} --machine-type ${MACHINE_TYPE} \
         --cluster-version ${K8S_VERSION} --zone ${GKE_ZONE} \
         --enable-ip-alias \
@@ -175,7 +180,7 @@ function setup_gke() {
     fi
 
     mkdir -p ${KUBECONFIG_PATH}
-    KUBECONFIG=${KUBECONFIG_PATH}/kubeconfig ${GCLOUD_PATH} container clusters get-credentials ${CLUSTER} --zone ${GKE_ZONE}
+    KUBECONFIG=${KUBECONFIG_PATH}/kubeconfig gcloud container clusters get-credentials ${CLUSTER} --zone ${GKE_ZONE}
 
     sleep 10
     if [[ $(kubectl get nodes) ]]; then
@@ -217,17 +222,17 @@ function deliver_antrea_to_gke() {
 
     node_names=$(kubectl get nodes -o wide --no-headers=true | awk '{print $1}')
     for node_name in ${node_names}; do
-        ${GCLOUD_PATH} compute scp ${antrea_image}.tar ubuntu@${node_name}:~ --zone ${GKE_ZONE}
-        ${GCLOUD_PATH} compute ssh ubuntu@${node_name} --command="sudo ctr -n=k8s.io images import ~/${antrea_image}.tar ; sudo ctr -n=k8s.io images tag docker.io/${DOCKER_IMG_NAME}:${DOCKER_IMG_VERSION} docker.io/${DOCKER_IMG_NAME}:latest" --zone ${GKE_ZONE}
+        gcloud compute scp ${antrea_image}.tar ubuntu@${node_name}:~ --zone ${GKE_ZONE}
+        gcloud compute ssh ubuntu@${node_name} --command="sudo ctr -n=k8s.io images import ~/${antrea_image}.tar ; sudo ctr -n=k8s.io images tag docker.io/${DOCKER_IMG_NAME}:${DOCKER_IMG_VERSION} docker.io/${DOCKER_IMG_NAME}:latest" --zone ${GKE_ZONE}
     done
     rm ${antrea_image}.tar
 
     echo "=== Configuring Antrea for cluster ==="
     if [[ -n ${SVC_ACCOUNT_NAME+x} ]]; then
-        ${GCLOUD_PATH} projects add-iam-policy-binding ${GKE_PROJECT} --member serviceAccount:${SVC_ACCOUNT_NAME} --role roles/container.admin
+        gcloud projects add-iam-policy-binding ${GKE_PROJECT} --member serviceAccount:${SVC_ACCOUNT_NAME} --role roles/container.admin
         kubectl create clusterrolebinding cluster-admin-binding --clusterrole cluster-admin --user ${SVC_ACCOUNT_NAME}
     elif [[ -n ${USER_EMAIL+x} ]]; then
-        ${GCLOUD_PATH} projects add-iam-policy-binding ${GKE_PROJECT} --member user:${USER_EMAIL} --role roles/container.admin
+        gcloud projects add-iam-policy-binding ${GKE_PROJECT} --member user:${USER_EMAIL} --role roles/container.admin
         kubectl create clusterrolebinding cluster-admin-binding --clusterrole cluster-admin --user ${USER_EMAIL}
     else
         echo "Neither service account or user email info is set, cannot create cluster-admin-binding!"
@@ -254,7 +259,7 @@ function run_conformance() {
     echo "=== Running Antrea Conformance and Network Policy Tests ==="
 
     # Allow nodeport traffic by external IP
-    ${GCLOUD_PATH} compute firewall-rules create allow-nodeport --allow tcp:30000-32767
+    gcloud compute firewall-rules create allow-nodeport --allow tcp:30000-32767
 
     ${GIT_CHECKOUT_DIR}/ci/run-k8s-e2e-tests.sh --e2e-conformance \
       --kubernetes-version ${KUBE_CONFORMANCE_IMAGE_VERSION} \
@@ -277,7 +282,7 @@ function run_conformance() {
         echo "=== FAILURE !!! ==="
     fi
 
-    ${GCLOUD_PATH} compute firewall-rules delete allow-nodeport
+    gcloud compute firewall-rules delete allow-nodeport
 
     echo "=== Cleanup Antrea Installation ==="
     kubectl delete -f ${GIT_CHECKOUT_DIR}/build/yamls/antrea-gke.yml --ignore-not-found=true || true
@@ -290,7 +295,7 @@ function cleanup_cluster() {
     set +e
     retry=5
     while [[ "${retry}" -gt 0 ]]; do
-       ${GCLOUD_PATH} container clusters delete ${CLUSTER} --zone ${GKE_ZONE}
+       gcloud container clusters delete ${CLUSTER} --zone ${GKE_ZONE}
        if [[ $? -eq 0 ]]; then
          break
        fi

--- a/docs/gke-installation.md
+++ b/docs/gke-installation.md
@@ -110,17 +110,24 @@ you should be able to see these Pods running in your cluster:
 
 3. Restart remaining Pods
 
-    Once Antrea is up and running, restart all Pods in all Namespaces (kube-system, etc) so they can be managed by Antrea.
+    Once Antrea is up and running, restart all Pods in all Namespaces (kube-system, gmp-system, etc) so they can be managed by Antrea.
 
     ```bash
-    $ kubectl delete pods -n kube-system $(kubectl get pods -n kube-system -o custom-columns=NAME:.metadata.name,HOSTNETWORK:.spec.hostNetwork --no-headers=true | grep '<none>' | awk '{ print $1 }')
-    pod "event-exporter-gke-755c4b4d97-wqlcg" deleted
-    pod "konnectivity-agent-5cb8ff9b9-2cv5j" deleted
-    pod "konnectivity-agent-5cb8ff9b9-5jpvp" deleted
-    pod "konnectivity-agent-autoscaler-7dc78c8c9-kqn9f" deleted
-    pod "kube-dns-5b5dfcd97b-79m4c" deleted
-    pod "kube-dns-5b5dfcd97b-q49qj" deleted
-    pod "kube-dns-autoscaler-5f56f8997c-kqrgx" deleted
-    pod "l7-default-backend-d6b749b76-bsv9l" deleted
-    pod "metrics-server-v0.5.2-67864775dc-bhd9p" deleted
+    $ for ns in $(kubectl get ns -o=jsonpath=''{.items[*].metadata.name}'' --no-headers=true); do \
+        pods=$(kubectl get pods -n $ns -o custom-columns=NAME:.metadata.name,HOSTNETWORK:.spec.hostNetwork --no-headers=true | grep '<none>' | awk '{ print $1 }'); \
+        [ -z "$pods" ] || kubectl delete pods -n $ns $pods; done
+    pod "alertmanager-0" deleted
+    pod "collector-4sfvd" deleted
+    pod "collector-gtlxf" deleted
+    pod "gmp-operator-67c4678f5c-ffktp" deleted
+    pod "rule-evaluator-85b8bb96dc-trnqj" deleted
+    pod "event-exporter-gke-7bf6c99dcb-4r62c" deleted
+    pod "konnectivity-agent-autoscaler-6dfdb49cf7-hfv9g" deleted
+    pod "konnectivity-agent-cc655669b-2cjc9" deleted
+    pod "konnectivity-agent-cc655669b-d79vf" deleted
+    pod "kube-dns-5bfd847c64-ksllw" deleted
+    pod "kube-dns-5bfd847c64-qv9tq" deleted
+    pod "kube-dns-autoscaler-84b8db4dc7-2pb2b" deleted
+    pod "l7-default-backend-64679d9c86-q69lm" deleted
+    pod "metrics-server-v0.5.2-6bf74b5d5f-22gqq" deleted
     ```


### PR DESCRIPTION
Cherry pick of #4873 #4983 #5298 on release-1.11.

#4873: Stop exporting KUBECONFIG in ci/test-conformance-gke.sh
#4983: Fix GKE CI job
#5298: Fix GKE conformance job

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.