### PR TITLE
Improve macros for job updater builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ bin
 .idea/
 .vscode/
 vendor
+
+ci/jenkins/jobs/defaults.yml

--- a/ci/jenkins/jobs/macros.yaml
+++ b/ci/jenkins/jobs/macros.yaml
@@ -3,7 +3,7 @@
     builders:
       - shell: |-
           cp /var/lib/jenkins/utils/defaults.yaml ci/jenkins/jobs
-          find ci/jenkins/jobs/ | grep ci/jenkins/jobs/projects | grep -v projects-{jenkins_location}.yaml | xargs rm
+          find ci/jenkins/jobs -name "projects-*" ! -name "projects-{jenkins_location}.yaml" | xargs rm
           jenkins-jobs update -r ci/jenkins/jobs
           rm ci/jenkins/jobs/defaults.yaml
 


### PR DESCRIPTION
Fixes #4841.

Current implementation of updater job builder uses find's built-in capabilities to directly filter files safely based on their names. This avoids the overhead of piping all file paths through multiple grep commands, which can slow down the process.