### PR TITLE
Add log rotation configuration for audit logs

### DIFF
--- a/build/charts/antrea/README.md
+++ b/build/charts/antrea/README.md
@@ -47,6 +47,10 @@ Kubernetes: `>= 1.16.0-0`
 | antreaProxy.proxyLoadBalancerIPs | bool | `true` | When set to false, AntreaProxy no longer load-balances traffic destined to the External IPs of LoadBalancer Services. |
 | antreaProxy.serviceProxyName | string | `""` | The value of the "service.kubernetes.io/service-proxy-name" label for AntreaProxy to match. If it is set, then AntreaProxy will only handle Services with the label that equals the provided value. If it is not set, then AntreaProxy will only handle Services without the "service.kubernetes.io/service-proxy-name" label, but ignore Services with the label no matter what is the value. |
 | antreaProxy.skipServices | list | `[]` | List of Services which should be ignored by AntreaProxy. |
+| auditLogging.compress | bool | `true` | Compress enables gzip compression on rotated files. |
+| auditLogging.maxAge | int | `28` | MaxAge is the maximum number of days to retain old log files based on the timestamp encoded in their filename. If set to 0, old log files are not removed based on age. |
+| auditLogging.maxBackups | int | `3` | MaxBackups is the maximum number of old log files to retain. If set to 0, all log files will be retained (unless MaxAge causes them to be deleted). |
+| auditLogging.maxSize | int | `500` | MaxSize is the maximum size in MB of a log file before it gets rotated. |
 | clientCAFile | string | `""` | File path of the certificate bundle for all the signers that is recognized for incoming client certificates. |
 | cni.hostBinPath | string | `"/opt/cni/bin"` | Installation path of CNI binaries on the host. |
 | cni.plugins | object | `{"bandwidth":true,"portmap":true}` | Chained plugins to use alongside antrea-cni. |

--- a/build/charts/antrea/conf/antrea-agent.conf
+++ b/build/charts/antrea/conf/antrea-agent.conf
@@ -398,6 +398,22 @@ multicluster:
     port: {{ .wireGuard.port }}
 {{- end }}
 
+# Log rotation configuration for audit logs.
+auditLogging:
+{{- with .Values.auditLogging }}
+  # MaxSize is the maximum size in MB of a log file before it gets rotated.
+  maxSize: {{ .maxSize }}
+  # MaxBackups is the maximum number of old log files to retain. If set to 0,
+  # all log files will be retained (unless MaxAge causes them to be deleted).
+  maxBackups: {{ .maxBackups }}
+  # MaxAge is the maximum number of days to retain old log files based on the
+  # timestamp encoded in their filename. If set to 0, old log files are not
+  # removed based on age.
+  maxAge: {{ .maxAge }}
+  # Compress enables gzip compression on rotated files.
+  compress: {{ .compress }}
+{{- end }}
+
 {{- if .Values.featureGates.SecondaryNetwork }}
 
 secondaryNetwork:

--- a/build/charts/antrea/values.yaml
+++ b/build/charts/antrea/values.yaml
@@ -159,6 +159,19 @@ nodeIPAM:
   # -- Mask size for IPv6 Node CIDR in IPv6 or dual-stack cluster.
   nodeCIDRMaskSizeIPv6: 64
 
+auditLogging:
+  # -- MaxSize is the maximum size in MB of a log file before it gets rotated.
+  maxSize: 500
+  # -- MaxBackups is the maximum number of old log files to retain. If set to 0,
+  # all log files will be retained (unless MaxAge causes them to be deleted).
+  maxBackups: 3
+  # -- MaxAge is the maximum number of days to retain old log files based on the
+  # timestamp encoded in their filename. If set to 0, old log files are not
+  # removed based on age.
+  maxAge: 28
+  # -- Compress enables gzip compression on rotated files.
+  compress: true
+
 # -- Address of Kubernetes apiserver, to override any value provided in
 # kubeconfig or InClusterConfig.
 kubeAPIServerOverride: ""

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -5821,6 +5821,20 @@ data:
       wireGuard:
         # WireGuard tunnel port for cross-cluster traffic.
         port: 51821
+
+    # Log rotation configuration for audit logs.
+    auditLogging:
+      # MaxSize is the maximum size in MB of a log file before it gets rotated.
+      maxSize: 500
+      # MaxBackups is the maximum number of old log files to retain. If set to 0,
+      # all log files will be retained (unless MaxAge causes them to be deleted).
+      maxBackups: 3
+      # MaxAge is the maximum number of days to retain old log files based on the
+      # timestamp encoded in their filename. If set to 0, old log files are not
+      # removed based on age.
+      maxAge: 28
+      # Compress enables gzip compression on rotated files.
+      compress: true
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -6804,7 +6818,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 07b3b1a7e87c45fa8e85c8cd5aea680835560c857761b708f01afbe4649648b1
+        checksum/config: 0c6450f352aca27be5109114dd79c2d95907f6ffc535ea93eb3e3c237fd53c81
       labels:
         app: antrea
         component: antrea-agent
@@ -7045,7 +7059,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 07b3b1a7e87c45fa8e85c8cd5aea680835560c857761b708f01afbe4649648b1
+        checksum/config: 0c6450f352aca27be5109114dd79c2d95907f6ffc535ea93eb3e3c237fd53c81
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -5821,6 +5821,20 @@ data:
       wireGuard:
         # WireGuard tunnel port for cross-cluster traffic.
         port: 51821
+
+    # Log rotation configuration for audit logs.
+    auditLogging:
+      # MaxSize is the maximum size in MB of a log file before it gets rotated.
+      maxSize: 500
+      # MaxBackups is the maximum number of old log files to retain. If set to 0,
+      # all log files will be retained (unless MaxAge causes them to be deleted).
+      maxBackups: 3
+      # MaxAge is the maximum number of days to retain old log files based on the
+      # timestamp encoded in their filename. If set to 0, old log files are not
+      # removed based on age.
+      maxAge: 28
+      # Compress enables gzip compression on rotated files.
+      compress: true
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -6804,7 +6818,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 07b3b1a7e87c45fa8e85c8cd5aea680835560c857761b708f01afbe4649648b1
+        checksum/config: 0c6450f352aca27be5109114dd79c2d95907f6ffc535ea93eb3e3c237fd53c81
       labels:
         app: antrea
         component: antrea-agent
@@ -7046,7 +7060,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 07b3b1a7e87c45fa8e85c8cd5aea680835560c857761b708f01afbe4649648b1
+        checksum/config: 0c6450f352aca27be5109114dd79c2d95907f6ffc535ea93eb3e3c237fd53c81
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -5821,6 +5821,20 @@ data:
       wireGuard:
         # WireGuard tunnel port for cross-cluster traffic.
         port: 51821
+
+    # Log rotation configuration for audit logs.
+    auditLogging:
+      # MaxSize is the maximum size in MB of a log file before it gets rotated.
+      maxSize: 500
+      # MaxBackups is the maximum number of old log files to retain. If set to 0,
+      # all log files will be retained (unless MaxAge causes them to be deleted).
+      maxBackups: 3
+      # MaxAge is the maximum number of days to retain old log files based on the
+      # timestamp encoded in their filename. If set to 0, old log files are not
+      # removed based on age.
+      maxAge: 28
+      # Compress enables gzip compression on rotated files.
+      compress: true
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -6804,7 +6818,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: ec71f227c0b41f1bfb349d25289c121f4e905531d5e6e9168275a2edc14f59b1
+        checksum/config: 0d484f5c68ab13d063a16030dd597ba786d6f1d789e10afc585617f5fd030bb0
       labels:
         app: antrea
         component: antrea-agent
@@ -7043,7 +7057,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: ec71f227c0b41f1bfb349d25289c121f4e905531d5e6e9168275a2edc14f59b1
+        checksum/config: 0d484f5c68ab13d063a16030dd597ba786d6f1d789e10afc585617f5fd030bb0
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -5834,6 +5834,20 @@ data:
       wireGuard:
         # WireGuard tunnel port for cross-cluster traffic.
         port: 51821
+
+    # Log rotation configuration for audit logs.
+    auditLogging:
+      # MaxSize is the maximum size in MB of a log file before it gets rotated.
+      maxSize: 500
+      # MaxBackups is the maximum number of old log files to retain. If set to 0,
+      # all log files will be retained (unless MaxAge causes them to be deleted).
+      maxBackups: 3
+      # MaxAge is the maximum number of days to retain old log files based on the
+      # timestamp encoded in their filename. If set to 0, old log files are not
+      # removed based on age.
+      maxAge: 28
+      # Compress enables gzip compression on rotated files.
+      compress: true
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -6817,7 +6831,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: dce874662f16b9a7b37ec65575d517e85d4e031e6af8731f8cf92535ebf53451
+        checksum/config: 8112dfd2bdeb470b13327fb1f9ec81f325038749bcf91b8c5852709ed789267b
         checksum/ipsec-secret: d0eb9c52d0cd4311b6d252a951126bf9bea27ec05590bed8a394f0f792dcb2a4
       labels:
         app: antrea
@@ -7102,7 +7116,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: dce874662f16b9a7b37ec65575d517e85d4e031e6af8731f8cf92535ebf53451
+        checksum/config: 8112dfd2bdeb470b13327fb1f9ec81f325038749bcf91b8c5852709ed789267b
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -5821,6 +5821,20 @@ data:
       wireGuard:
         # WireGuard tunnel port for cross-cluster traffic.
         port: 51821
+
+    # Log rotation configuration for audit logs.
+    auditLogging:
+      # MaxSize is the maximum size in MB of a log file before it gets rotated.
+      maxSize: 500
+      # MaxBackups is the maximum number of old log files to retain. If set to 0,
+      # all log files will be retained (unless MaxAge causes them to be deleted).
+      maxBackups: 3
+      # MaxAge is the maximum number of days to retain old log files based on the
+      # timestamp encoded in their filename. If set to 0, old log files are not
+      # removed based on age.
+      maxAge: 28
+      # Compress enables gzip compression on rotated files.
+      compress: true
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -6804,7 +6818,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 5b6ceee228b1a04fbd605c655f7939cc03bb02f5e0b0043e5ad8083085560c41
+        checksum/config: 79fc8296df5258525c48b088ec5ce71f6c7dad28169071408a29324dee10061c
       labels:
         app: antrea
         component: antrea-agent
@@ -7043,7 +7057,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 5b6ceee228b1a04fbd605c655f7939cc03bb02f5e0b0043e5ad8083085560c41
+        checksum/config: 79fc8296df5258525c48b088ec5ce71f6c7dad28169071408a29324dee10061c
       labels:
         app: antrea
         component: antrea-controller

--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -431,6 +431,15 @@ func run(o *Options) error {
 	// if AntreaPolicy feature is enabled.
 	statusManagerEnabled := antreaPolicyEnabled
 	loggingEnabled := antreaPolicyEnabled
+	var auditLoggerOptions *networkpolicy.AntreaPolicyLoggerOptions
+	if loggingEnabled {
+		auditLoggerOptions = &networkpolicy.AntreaPolicyLoggerOptions{
+			MaxSize:    int(o.config.AuditLogging.MaxSize),
+			MaxBackups: int(*o.config.AuditLogging.MaxBackups),
+			MaxAge:     int(*o.config.AuditLogging.MaxAge),
+			Compress:   *o.config.AuditLogging.Compress,
+		}
+	}
 
 	var gwPort, tunPort uint32
 	if o.nodeType == config.K8sNode {
@@ -456,7 +465,7 @@ func run(o *Options) error {
 		antreaProxyEnabled,
 		statusManagerEnabled,
 		multicastEnabled,
-		loggingEnabled,
+		auditLoggerOptions,
 		asyncRuleDeleteInterval,
 		o.dnsServerOverride,
 		o.nodeType,

--- a/cmd/antrea-agent/options.go
+++ b/cmd/antrea-agent/options.go
@@ -55,6 +55,10 @@ const (
 	defaultStaleConnectionTimeout  = 5 * time.Minute
 	defaultNodeType                = config.K8sNode
 	defaultMaxEgressIPsPerNode     = 255
+	defaultAuditLogsMaxSize        = 100
+	defaultAuditLogsMaxBackups     = 3
+	defaultAuditLogsMaxAge         = 28
+	defaultAuditLogsCompressed     = true
 )
 
 var defaultIGMPQueryVersions = []int{1, 2, 3}
@@ -480,6 +484,25 @@ func (o *Options) setK8sNodeDefaultOptions() {
 	if features.DefaultFeatureGate.Enabled(features.Egress) {
 		if o.config.Egress.MaxEgressIPsPerNode == 0 {
 			o.config.Egress.MaxEgressIPsPerNode = defaultMaxEgressIPsPerNode
+		}
+	}
+
+	if features.DefaultFeatureGate.Enabled(features.AntreaPolicy) {
+		auditLogging := &o.config.AuditLogging
+		if auditLogging.MaxSize == 0 {
+			auditLogging.MaxSize = defaultAuditLogsMaxAge
+		}
+		if auditLogging.MaxBackups == nil {
+			maxBackups := int32(defaultAuditLogsMaxBackups)
+			auditLogging.MaxBackups = &maxBackups
+		}
+		if auditLogging.MaxAge == nil {
+			maxAge := int32(defaultAuditLogsMaxAge)
+			auditLogging.MaxAge = &maxAge
+		}
+		if auditLogging.Compress == nil {
+			compress := defaultAuditLogsCompressed
+			auditLogging.Compress = &compress
 		}
 	}
 }

--- a/pkg/agent/controller/networkpolicy/audit_logging.go
+++ b/pkg/agent/controller/networkpolicy/audit_logging.go
@@ -52,6 +52,13 @@ type AntreaPolicyLogger struct {
 	logDeduplication logRecordDedupMap
 }
 
+type AntreaPolicyLoggerOptions struct {
+	MaxSize    int
+	MaxBackups int
+	MaxAge     int
+	Compress   bool
+}
+
 // logInfo will be set by retrieving info from packetin and register.
 type logInfo struct {
 	tableName    string // name of the table sending packetin
@@ -161,7 +168,7 @@ func (l *AntreaPolicyLogger) LogDedupPacket(ob *logInfo) {
 
 // newAntreaPolicyLogger is called while newing Antrea network policy agent controller.
 // Customize AntreaPolicyLogger specifically for Antrea Policies audit logging.
-func newAntreaPolicyLogger() (*AntreaPolicyLogger, error) {
+func newAntreaPolicyLogger(options *AntreaPolicyLoggerOptions) (*AntreaPolicyLogger, error) {
 	logDir := filepath.Join(logdir.GetLogDir(), logfileSubdir)
 	logFile := filepath.Join(logDir, logfileName)
 	_, err := os.Stat(logDir)
@@ -174,10 +181,10 @@ func newAntreaPolicyLogger() (*AntreaPolicyLogger, error) {
 	// Use lumberjack log file rotation.
 	logOutput := &lumberjack.Logger{
 		Filename:   logFile,
-		MaxSize:    500,  // allow max 500 megabytes for one log file
-		MaxBackups: 3,    // allow max 3 old log file backups
-		MaxAge:     28,   // allow max 28 days maintenance of old log files
-		Compress:   true, // compress the old log files for backup
+		MaxSize:    options.MaxSize,
+		MaxBackups: options.MaxBackups,
+		MaxAge:     options.MaxAge,
+		Compress:   options.Compress,
 	}
 
 	antreaPolicyLogger := &AntreaPolicyLogger{

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
@@ -88,8 +88,6 @@ type Controller struct {
 	statusManagerEnabled bool
 	// multicastEnabled indicates whether multicast is enabled.
 	multicastEnabled bool
-	// loggingEnabled indicates where Antrea policy audit logging is enabled.
-	loggingEnabled bool
 	// nodeType indicates type of the Node where Antrea Agent is running on.
 	nodeType config.NodeType
 	// antreaClientProvider provides interfaces to get antreaClient, which can be
@@ -149,7 +147,7 @@ func NewNetworkPolicyController(antreaClientGetter agent.AntreaClientProvider,
 	antreaProxyEnabled bool,
 	statusManagerEnabled bool,
 	multicastEnabled bool,
-	loggingEnabled bool,
+	loggerOptions *AntreaPolicyLoggerOptions, // use nil to disable logging
 	asyncRuleDeleteInterval time.Duration,
 	dnsServerOverride string,
 	nodeType config.NodeType,
@@ -168,7 +166,6 @@ func NewNetworkPolicyController(antreaClientGetter agent.AntreaClientProvider,
 		antreaProxyEnabled:     antreaProxyEnabled,
 		statusManagerEnabled:   statusManagerEnabled,
 		multicastEnabled:       multicastEnabled,
-		loggingEnabled:         loggingEnabled,
 		gwPort:                 gwPort,
 		tunPort:                tunPort,
 		nodeConfig:             nodeConfig,
@@ -204,9 +201,9 @@ func NewNetworkPolicyController(antreaClientGetter agent.AntreaClientProvider,
 	if c.ofClient != nil && antreaPolicyEnabled {
 		// Register packetInHandler
 		c.ofClient.RegisterPacketInHandler(uint8(openflow.PacketInCategoryNP), c)
-		if loggingEnabled {
+		if loggerOptions != nil {
 			// Initiate logger for Antrea Policy audit logging
-			antreaPolicyLogger, err := newAntreaPolicyLogger()
+			antreaPolicyLogger, err := newAntreaPolicyLogger(loggerOptions)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
@@ -71,7 +71,7 @@ func newTestController() (*Controller, *fake.Clientset, *mockReconciler) {
 	ch2 := make(chan string, 100)
 	groupIDAllocator := openflow.NewGroupAllocator()
 	groupCounters := []proxytypes.GroupCounter{proxytypes.NewGroupCounter(groupIDAllocator, ch2)}
-	controller, _ := NewNetworkPolicyController(&antreaClientGetter{clientset}, nil, nil, "node1", podUpdateChannel, nil, groupCounters, ch2, true, true, true, true, false, true, testAsyncDeleteInterval, "8.8.8.8:53", config.K8sNode, true, false, config.HostGatewayOFPort, config.DefaultTunOFPort, &config.NodeConfig{})
+	controller, _ := NewNetworkPolicyController(&antreaClientGetter{clientset}, nil, nil, "node1", podUpdateChannel, nil, groupCounters, ch2, true, true, true, true, false, nil, testAsyncDeleteInterval, "8.8.8.8:53", config.K8sNode, true, false, config.HostGatewayOFPort, config.DefaultTunOFPort, &config.NodeConfig{})
 	reconciler := newMockReconciler()
 	controller.reconciler = reconciler
 	controller.antreaPolicyLogger = nil

--- a/pkg/config/agent/config.go
+++ b/pkg/config/agent/config.go
@@ -196,6 +196,8 @@ type AgentConfig struct {
 	ExternalNode ExternalNodeConfig `yaml:"externalNode,omitempty"`
 	// Antrea's native secondary network configuration.
 	SecondaryNetwork SecondaryNetworkConfig `yaml:"secondaryNetwork,omitempty"`
+	// AuditLogging supports configuring log rotation for audit logs.
+	AuditLogging AuditLoggingConfig `yaml:"auditLogging,omitempty"`
 }
 
 type AntreaProxyConfig struct {
@@ -386,4 +388,18 @@ type SecondaryNetworkOVSConfig struct {
 	OVSDatapathType string `yaml:"ovsDatapathType,omitempty"`
 	// OVS patch port which connects the integration and transport bridge.
 	OVSPatchPort string `yaml:"ovsPatchPort,omitempty"`
+}
+
+type AuditLoggingConfig struct {
+	// MaxSize is the maximum size in MB of a log file before it gets rotated. Defaults to 500MB.
+	MaxSize int32 `yaml:"maxSize,omitempty"`
+	// MaxBackups is the maximum number of old log files to retain. If set to 0, all log files
+	// will be retained (unless MaxAge causes them to be deleted). Defaults to 3.
+	MaxBackups *int32 `yaml:"maxBackups,omitempty"`
+	// MaxAge is the maximum number of days to retain old log files based on the timestamp
+	// encoded in their filename. If set to 0, old log files are not removed based on age.
+	// Defaults to 28.
+	MaxAge *int32 `yaml:"maxAge,omitempty"`
+	// Compress enables gzip compression on rotated files. Defaults to true.
+	Compress *bool `yaml:"compress,omitempty"`
 }


### PR DESCRIPTION
Users can now configure log rotation for audit logs in the antrea-agent config.

The default values for log rotation parameters are the same as the hardcoded values in previous Antrea versions. Even if the user omits the auditLogging section in the configuration, default values will be used.

Fixes #5262