### PR TITLE
Fix a bug that ClusterSet status is no longer updated

### DIFF
--- a/multicluster/controllers/multicluster/member/clusterset_controller.go
+++ b/multicluster/controllers/multicluster/member/clusterset_controller.go
@@ -121,6 +121,18 @@ func (r *MemberClusterSetReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			return ctrl.Result{}, err
 		}
 		r.clusterSetID = common.ClusterSetID(clusterSet.Name)
+		if clusterSet.Spec.ClusterID == "" {
+			// ClusterID is a required feild, and the empty value case should only happen
+			// when Antrea Multi-cluster is upgraded from an old version prior to v1.13.
+			// Here we try to update the ClusterSet's ClusterID when it's configured in an
+			// existing ClusterClaim.
+			clusterSet.Spec.ClusterID = string(r.clusterID)
+			err = r.Update(context.TODO(), clusterSet)
+			if err != nil {
+				klog.ErrorS(err, "Failed to update ClusterSet's ClusterID", "clusterset", req.NamespacedName)
+				return ctrl.Result{}, err
+			}
+		}
 	}
 	r.clusterSetConfig = clusterSet.DeepCopy()
 
@@ -354,14 +366,7 @@ func (r *MemberClusterSetReconciler) updateStatus() {
 		status.Conditions = []mcv1alpha2.ClusterSetCondition{overallCondition}
 	}
 	clusterSet.Status = status
-	if clusterSet.Spec.ClusterID == "" {
-		// When the common area is not empty but ClusterID is empty, it means the
-		// CR was created by an old version of ClusterSet CRD. We can use the ClusterID
-		// from ClusterClaim to update the CR, otherwise, the update will fail due
-		// to invalid ClusterID.
-		clusterSet.Spec.ClusterID = string(r.clusterID)
-	}
-	err = r.Update(context.TODO(), clusterSet)
+	err = r.Status().Update(context.TODO(), clusterSet)
 	if err != nil {
 		klog.ErrorS(err, "Failed to update Status of ClusterSet", "name", namespacedName)
 	}


### PR DESCRIPTION
1. r.Update() will only update Spec but not status. Revert the change
back to update status only.
2. Update the ClusterSet's ClusterID in ClusterSet's reconciler.
3. Refine test codes for leader ClusterSet controller.