### PR TITLE
Always run antctl in Pod for e2e tests

### DIFF
--- a/build/images/Dockerfile.build.coverage
+++ b/build/images/Dockerfile.build.coverage
@@ -25,10 +25,9 @@ RUN go mod download
 COPY . /antrea
 
 RUN make antrea-agent antrea-controller antrea-cni antrea-controller-instr-binary antrea-agent-instr-binary
-# The e2e tests for antctl currently copy the antctl binary from the Docker container
-# to the host Node, and run the binary from the host. The host may be missing some
-# system libraries that are required to run the binary, so we need to disable CGO
-# to avoid such dependencies and ensure that the binary is portable.
+# Disable CGO for antctl in case it is copied outside of the container image. It
+# also reduces the size of the binary and aligns with how we distribute antctl
+# in release assets.
 RUN CGO_ENABLED=0 make antctl-linux antctl-instr-binary
 RUN mv bin/antctl-linux bin/antctl
 

--- a/build/images/Dockerfile.build.ubi
+++ b/build/images/Dockerfile.build.ubi
@@ -25,9 +25,9 @@ RUN go mod download
 COPY . /antrea
 
 RUN make antrea-agent antrea-controller antrea-cni
-# Disable CGO for antctl in case it is copied outside of the container image,
-# such as in e2e tests. It also reduces the size of the binary and aligns with
-# how we distribute antctl in release assets.
+# Disable CGO for antctl in case it is copied outside of the container image. It
+# also reduces the size of the binary and aligns with how we distribute antctl
+# in release assets.
 RUN CGO_ENABLED=0 make antctl-linux
 RUN mv bin/antctl-linux bin/antctl
 

--- a/build/images/Dockerfile.build.ubuntu
+++ b/build/images/Dockerfile.build.ubuntu
@@ -25,9 +25,9 @@ RUN go mod download
 COPY . /antrea
 
 RUN make antrea-agent antrea-controller antrea-cni
-# Disable CGO for antctl in case it is copied outside of the container image,
-# such as in e2e tests. It also reduces the size of the binary and aligns with
-# how we distribute antctl in release assets.
+# Disable CGO for antctl in case it is copied outside of the container image. It
+# also reduces the size of the binary and aligns with how we distribute antctl
+# in release assets.
 RUN CGO_ENABLED=0 make antctl-linux
 RUN mv bin/antctl-linux bin/antctl
 

--- a/test/e2e/antctl_test.go
+++ b/test/e2e/antctl_test.go
@@ -53,7 +53,7 @@ func TestAntctl(t *testing.T) {
 
 	// This is used to determine the Antrea container image being tested. We will use the same
 	// image when creating a Pod to run antctl.
-	// Note that this is the Linux image, so we will alwaus schedule the antctl Pod on the
+	// Note that this is the Linux image, so we will always schedule the antctl Pod on the
 	// control-plane Node, which is guaranteed to be a Linux Node.
 	ds, err := data.clientset.AppsV1().DaemonSets(antreaNamespace).Get(context.TODO(), antreaDaemonSet, metav1.GetOptions{})
 	require.NoError(t, err, "Error when getting antrea DaemonSet")
@@ -372,7 +372,7 @@ func createAntctlServiceAccount(t *testing.T, data *TestData, name string) {
 
 	t.Cleanup(func() {
 		err := data.clientset.CoreV1().ServiceAccounts(data.testNamespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
-		assert.NoError(t, err, "Error when deleting ClusterRoleBinding")
+		assert.NoError(t, err, "Error when deleting ServiceAccount")
 	})
 
 	clusterRoleBinding := &rbacv1.ClusterRoleBinding{

--- a/test/e2e/antctl_test.go
+++ b/test/e2e/antctl_test.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"net/url"
+	"path"
 	"strings"
 	"testing"
 	"time"
@@ -27,10 +27,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/tools/clientcmd"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"antrea.io/antrea/pkg/antctl"
 	"antrea.io/antrea/pkg/antctl/runtime"
@@ -52,17 +51,31 @@ func TestAntctl(t *testing.T) {
 	}
 	defer teardownTest(t, data)
 
+	// This is used to determine the Antrea container image being tested. We will use the same
+	// image when creating a Pod to run antctl.
+	// Note that this is the Linux image, so we will alwaus schedule the antctl Pod on the
+	// control-plane Node, which is guaranteed to be a Linux Node.
+	ds, err := data.clientset.AppsV1().DaemonSets(antreaNamespace).Get(context.TODO(), antreaDaemonSet, metav1.GetOptions{})
+	require.NoError(t, err, "Error when getting antrea DaemonSet")
+	antreaImage := ds.Spec.Template.Spec.Containers[0].Image
+
+	// This ServiceAccount is granted the antctl ClusterRole and will be used for antctl test
+	// Pods. We do not use the "default" ServiceAccount for the test Namespace, as we do not
+	// want other test Pods to be granted the antctl ClusterRole.
+	antctlServiceAccountName := randName("antctl-antrea-e2e-")
+	createAntctlServiceAccount(t, data, antctlServiceAccountName)
+
 	t.Run("testAntctlAgentLocalAccess", func(t *testing.T) {
 		testAntctlAgentLocalAccess(t, data)
 	})
 	t.Run("testAntctlControllerRemoteAccess", func(t *testing.T) {
-		testAntctlControllerRemoteAccess(t, data)
+		testAntctlControllerRemoteAccess(t, data, antctlServiceAccountName, antreaImage)
 	})
 	t.Run("testAntctlVerboseMode", func(t *testing.T) {
 		testAntctlVerboseMode(t, data)
 	})
 	t.Run("testAntctlProxy", func(t *testing.T) {
-		testAntctlProxy(t, data)
+		testAntctlProxy(t, data, antctlServiceAccountName, antreaImage)
 	})
 }
 
@@ -76,19 +89,6 @@ func antctlName() string {
 		return "antctl-coverage"
 	}
 	return "antctl"
-}
-
-func nodeAntctlPath() string {
-	if testOptions.providerName == "kind" {
-		if testOptions.enableCoverage {
-			return "/root/antctl-coverage"
-		}
-		return "/root/antctl"
-	}
-	if testOptions.enableCoverage {
-		return "~/antctl-coverage"
-	}
-	return "~/antctl"
 }
 
 // runAntctl runs antctl commands on antrea Pods, the controller, or agents.
@@ -116,10 +116,14 @@ func runAntctl(podName string, cmds []string, data *TestData) (string, string, e
 	return stdout, stderr, err
 }
 
-func antctlCoverageArgs(antctlPath string) []string {
+func antctlCoverageArgs(antctlPath string, covDir string) []string {
 	const timeFormat = "20060102T150405Z0700"
-	timeStamp := time.Now().Format(timeFormat)
-	return []string{antctlPath, "-test.run=TestBincoverRunMain", fmt.Sprintf("-test.coverprofile=antctl-%s.out", timeStamp)}
+	timestamp := time.Now().Format(timeFormat)
+	covFile := fmt.Sprintf("antctl-%s.out", timestamp)
+	if covDir != "" {
+		covFile = path.Join(covDir, covFile)
+	}
+	return []string{antctlPath, "-test.run=TestBincoverRunMain", fmt.Sprintf("-test.coverprofile=%s", covFile)}
 }
 
 // testAntctlAgentLocalAccess ensures antctl is accessible in an agent Pod.
@@ -131,7 +135,7 @@ func testAntctlAgentLocalAccess(t *testing.T, data *TestData) {
 	for _, c := range antctl.CommandList.GetDebugCommands(runtime.ModeAgent) {
 		args := []string{}
 		if testOptions.enableCoverage {
-			antctlCovArgs := antctlCoverageArgs("antctl-coverage")
+			antctlCovArgs := antctlCoverageArgs("antctl-coverage", "")
 			args = append(antctlCovArgs, c...)
 		} else {
 			args = append([]string{"antctl"}, c...)
@@ -148,99 +152,60 @@ func testAntctlAgentLocalAccess(t *testing.T, data *TestData) {
 	}
 }
 
-func copyAntctlToNode(data *TestData, nodeName string, antctlName string, nodeAntctlPath string) error {
-	pod, err := data.getAntreaController()
-	if err != nil {
-		return fmt.Errorf("error when retrieving Antrea Controller Pod: %v", err)
-	}
-	// Just try our best to clean up.
-	data.RunCommandOnNode(nodeName, fmt.Sprintf("rm -f %s", nodeAntctlPath))
-	// Copy antctl from the controller Pod to the Node.
-	cmd := fmt.Sprintf("kubectl cp %s/%s:/usr/local/bin/%s %s", antreaNamespace, pod.Name, antctlName, nodeAntctlPath)
-	rc, stdout, stderr, err := data.RunCommandOnNode(nodeName, cmd)
-	if err != nil {
-		return fmt.Errorf("error when running command '%s' on Node: %v", cmd, err)
-	}
-	if rc != 0 {
-		return fmt.Errorf("error when copying %s from %s, stdout: <%v>, stderr: <%v>", antctlName, pod.Name, stdout, stderr)
-	}
-	// Make sure the antctl binary is executable on the Node.
-	cmd = fmt.Sprintf("chmod +x %s", nodeAntctlPath)
-	rc, stdout, stderr, err = data.RunCommandOnNode(nodeName, cmd)
-	if err != nil {
-		return fmt.Errorf("error when running command '%s' on Node: %v", cmd, err)
-	}
-	if rc != 0 {
-		return fmt.Errorf("error when making antctl executable on Node, stdout: <%v>, stderr: <%v>", stdout, stderr)
-	}
-	return nil
+func runAntctlPod(t *testing.T, data *TestData, podName string, antctlServiceAccountName string, antctlImage string, covDir string) {
+	require.NoError(t, NewPodBuilder(podName, data.testNamespace, antctlImage).WithServiceAccountName(antctlServiceAccountName).
+		WithContainerName("antctl").WithCommand([]string{"sleep", "3600"}).
+		// collectAntctlCovFilesFromControlPlaneNode expects coverage data in this directory
+		MountHostPath(cpNodeCoverageDir, corev1.HostPathDirectory, covDir, "antctl-coverage").
+		OnNode(controlPlaneNodeName()).InHostNetwork().
+		Create(data))
+	t.Cleanup(func() {
+		data.DeletePod(data.testNamespace, podName)
+	})
 }
 
-// copyAntctlKubeconfigToNode writes a Kubeconfig file for the antctl ServiceAccount to the provided
-// path on the provided Node.
-func copyAntctlKubeconfigToNode(data *TestData, nodeName string, kubeconfigPath string) error {
-	// First, we create a Secret to store the Kubeconfig. Then, we use kubectl to write the
-	// Secret contents to a file. Ideally, we would use a Pod to run antctl commands instead of
-	// running it from the Node (in that case, the Secret would be mounted to the Pod).
-	kubeconfigSecretKey := "kubeconfig"
-	// No need to worry about deleting the Secret as it is created in the temporary test Namespace.
-	kubeconfigSecretName, err := createAntctlKubeconfigSecret(context.TODO(), data, kubeconfigSecretKey)
-	if err != nil {
-		return err
-	}
-	cmd := fmt.Sprintf("kubectl get -n %s secret %s --template='{{ .data.%s | base64decode }}' > %s", data.testNamespace, kubeconfigSecretName, kubeconfigSecretKey, kubeconfigPath)
-	if testOptions.providerName == "kind" {
-		cmd = "/bin/sh -c " + cmd
-	}
-	rc, stdout, stderr, err := data.RunCommandOnNode(nodeName, cmd)
-	if err != nil {
-		return fmt.Errorf("error when running command '%s' on Node: %v", cmd, err)
-	}
-	if rc != 0 {
-		return fmt.Errorf("error when getting secret contents, stdout: <%v>, stderr: <%v>", stdout, stderr)
-	}
-	return nil
+func runAntctlCommandFromPod(data *TestData, podName string, cmd []string) (string, string, error) {
+	return data.RunCommandFromPod(data.testNamespace, podName, "antctl", cmd)
 }
 
 // testAntctlControllerRemoteAccess ensures antctl is able to be run outside of
 // the kubernetes cluster. It uses the antctl client binary copied from the controller
 // Pod.
-func testAntctlControllerRemoteAccess(t *testing.T, data *TestData) {
+func testAntctlControllerRemoteAccess(t *testing.T, data *TestData, antctlServiceAccountName string, antctlImage string) {
+	const podName = "antctl"
+	const covDir = "/coverage"
 	antctlName := antctlName()
-	nodeAntctlPath := nodeAntctlPath()
-	require.NoError(t, copyAntctlToNode(data, controlPlaneNodeName(), antctlName, nodeAntctlPath), "failed to copy antctl to control-plane Node")
-	nodeAntctlKubeconfigPath := "/tmp/antctl-kubeconfig"
-	require.NoError(t, copyAntctlKubeconfigToNode(data, controlPlaneNodeName(), nodeAntctlKubeconfigPath), "failed to copy antctl Kubeconfig to control-plane Node")
+
+	runAntctlPod(t, data, podName, antctlServiceAccountName, antctlImage, covDir)
+	require.NoError(t, data.podWaitForRunning(30*time.Second, podName, data.testNamespace), "antctl Pod not in the Running state")
 
 	testCmds := []cmdAndReturnCode{}
 	// Add all controller commands.
 	for _, c := range antctl.CommandList.GetDebugCommands(runtime.ModeController) {
-		cmd := []string{nodeAntctlPath}
+		cmd := []string{antctlName}
 		if testOptions.enableCoverage {
-			antctlCovArgs := antctlCoverageArgs(nodeAntctlPath)
+			antctlCovArgs := antctlCoverageArgs(antctlName, covDir)
 			cmd = append(antctlCovArgs, c...)
 		}
-		// Add global flags after command to ensure they are recognized correctly when using
-		// the coverage binary.
-		cmd = append(cmd, "-k", nodeAntctlKubeconfigPath)
 		testCmds = append(testCmds, cmdAndReturnCode{args: cmd, expectedReturnCode: 0})
 	}
 	testCmds = append(testCmds,
-		// Malformed config
+		// Missing Kubeconfig
 		cmdAndReturnCode{
-			args:               []string{nodeAntctlPath, "version", "--kubeconfig", "/dev/null"},
+			args:               []string{antctlName, "version", "--kubeconfig", "/xyz"},
 			expectedReturnCode: 1,
 		},
 	)
 
 	for _, tc := range testCmds {
-		cmd := strings.Join(tc.args, " ")
-		t.Run(cmd, func(t *testing.T) {
-			rc, stdout, stderr, err := data.RunCommandOnNode(controlPlaneNodeName(), cmd)
-			if err != nil {
-				t.Fatalf("Error when running `%s` from %s: %v\n%s", cmd, controlPlaneNodeName(), err, antctlOutput(stdout, stderr))
+		cmd := tc.args
+		t.Run(strings.Join(cmd, " "), func(t *testing.T) {
+			stdout, stderr, err := runAntctlCommandFromPod(data, podName, cmd)
+			if tc.expectedReturnCode == 0 {
+				assert.NoError(t, err, "Command was not successful:\n%s", antctlOutput(stdout, stderr))
+			} else {
+				assert.ErrorContains(t, err, fmt.Sprintf("command terminated with exit code %d", tc.expectedReturnCode), "Command did not fail as expected:\n%s", antctlOutput(stdout, stderr))
 			}
-			assert.Equal(t, tc.expectedReturnCode, rc, "Return code is incorrect: %d\n%s", rc, antctlOutput(stdout, stderr))
 		})
 	}
 }
@@ -275,90 +240,73 @@ func testAntctlVerboseMode(t *testing.T, data *TestData) {
 	}
 }
 
-// runAntctProxy runs the antctl reverse proxy on the provided Node; to stop the
+// runAntctProxy runs the antctl reverse proxy as a host network Podon the provided Node; to stop the
 // proxy call the returned function.
 func runAntctProxy(
-	nodeName string,
-	antctlName string,
-	nodeAntctlPath string,
-	kubeconfigPath string,
+	t *testing.T,
+	data *TestData,
+	podName string,
+	serviceAccountName string,
+	containerName string,
+	containerImage string,
 	proxyPort int,
 	agentNodeName string,
 	address string,
-	data *TestData,
-) (func() error, error) {
-	waitCh := make(chan string)
-	proxyCmd := []string{nodeAntctlPath, "proxy", "--port", fmt.Sprint(proxyPort), "--address", address}
+) {
+	// Collecting coverage is currently not supported for the proxy command (no coverage data
+	// when the process is interrupted).
+	antctlName := "antctl"
+	proxyCmd := []string{antctlName, "proxy", "--port", fmt.Sprint(proxyPort), "--address", address}
 	if agentNodeName == "" {
 		proxyCmd = append(proxyCmd, "--controller")
 	} else {
 		proxyCmd = append(proxyCmd, "--agent-node", agentNodeName)
 		// Retry until AntreaAgentInfo is updated by Antrea Agent.
-		err := data.checkAntreaAgentInfo(5*time.Second, 2*time.Minute, agentNodeName)
-		if err != nil {
-			return nil, err
-		}
-	}
-	// Add global flags after command to ensure they are recognized correctly when using the
-	// coverage binary.
-	proxyCmd = append(proxyCmd, "-k", kubeconfigPath)
-	go func() {
-		_, stdout, stderr, _ := data.RunCommandOnNode(nodeName, strings.Join(proxyCmd, " "))
-		waitCh <- antctlOutput(stdout, stderr)
-	}()
-
-	// wait for the proxy to be running and retrieve the PID
-	cmd := fmt.Sprintf("pgrep %s", antctlName)
-	var pid string
-	if err := wait.Poll(1*time.Second, 10*time.Second, func() (bool, error) {
-		rc, stdout, stderr, err := data.RunCommandOnNode(nodeName, cmd)
-		if err != nil {
-			return false, fmt.Errorf("error when running command '%s' on Node: %v", cmd, err)
-		}
-		if rc == 1 {
-			// no matching process
-			return false, nil
-		} else if rc != 0 {
-			return false, fmt.Errorf("error when retrieving 'antctl proxy' PID, proxy command: '%s'\n stdout: <%v>, stderr: <%v>",
-				strings.Join(proxyCmd, " "), stdout, stderr)
-		}
-		pid = strings.TrimSpace(stdout)
-		return true, nil
-	}); err != nil {
-		if err == wait.ErrWaitTimeout {
-			select {
-			case out := <-waitCh:
-				return nil, fmt.Errorf("'antctl proxy' failed to start:\n%s", out)
-			default:
-				return nil, err
-			}
-		}
-		return nil, err
+		require.NoError(t, data.checkAntreaAgentInfo(5*time.Second, 2*time.Minute, agentNodeName))
 	}
 
-	return func() error {
-		cmd := fmt.Sprintf("kill -INT %s", pid)
-		rc, stdout, stderr, err := data.RunCommandOnNode(nodeName, cmd)
+	b := NewPodBuilder(podName, data.testNamespace, containerImage).WithServiceAccountName(serviceAccountName).
+		WithContainerName(containerName).WithCommand(proxyCmd).
+		OnNode(controlPlaneNodeName()).InHostNetwork().
+		WithReadinessProbe(&corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				// Use a TCP probe and not an HTTP probe: GET / will return a 403
+				TCPSocket: &corev1.TCPSocketAction{
+					Host: address,
+					Port: intstr.FromInt(proxyPort),
+				},
+			},
+		})
+
+	t.Logf("Starting antctl proxy")
+	require.NoError(t, b.Create(data), "error when creating antctl proxy Pod '%s'", podName)
+
+	t.Cleanup(func() {
+		t.Logf("Stopping antctl proxy")
+		if err := data.DeletePodAndWait(defaultTimeout, podName, data.testNamespace); err != nil {
+			t.Errorf("Error when stopping antctl proxy: %v", err)
+		}
+	})
+
+	if err := data.podWaitForReady(30*time.Second, podName, data.testNamespace); err != nil {
+		logs, err := data.GetPodLogs(context.TODO(), data.testNamespace, podName, "")
 		if err != nil {
-			return fmt.Errorf("error when running command '%s' on Node: %v", cmd, err)
+			logs = "LOGS MISSING"
 		}
-		if rc != 0 {
-			return fmt.Errorf("error when stopping PID %s, stdout: <%v>, stderr: <%v>", pid, stdout, stderr)
-		}
-		<-waitCh
-		return nil
-	}, nil
+		require.Fail(t, "proxy not ready", "antctl proxy Pod '%s' never became ready:\n%s", podName, logs)
+	}
 }
 
-// testAntctlProxy validates "antctl proxy" for both the Antrea Controller and
-// Agent API.
-func testAntctlProxy(t *testing.T, data *TestData) {
+// testAntctlProxy validates "antctl proxy" for both the Antrea Controller and Agent API.
+func testAntctlProxy(t *testing.T, data *TestData, antctlServiceAccountName string, antctlImage string) {
+	const testPodName = "toolbox"
+	const testContainerName = "toolbox"
+	const proxyContainerName = "proxy"
 	const proxyPort = 8001
-	antctlName := antctlName()
-	nodeAntctlPath := nodeAntctlPath()
-	require.NoError(t, copyAntctlToNode(data, controlPlaneNodeName(), antctlName, nodeAntctlPath), "failed to copy antctl to control-plane Node")
-	nodeAntctlKubeconfigPath := "/tmp/antctl-kubeconfig"
-	require.NoError(t, copyAntctlKubeconfigToNode(data, controlPlaneNodeName(), nodeAntctlKubeconfigPath), "failed to copy antctl Kubeconfig to control-plane Node")
+
+	require.NoError(t, NewPodBuilder(testPodName, data.testNamespace, toolboxImage).WithContainerName(testContainerName).OnNode(controlPlaneNodeName()).InHostNetwork().Create(data))
+	defer data.DeletePodAndWait(defaultTimeout, testPodName, data.testNamespace)
+	require.NoError(t, data.podWaitForRunning(30*time.Second, testPodName, data.testNamespace), "test Pod not in the Running state")
 
 	// getEndpointStatus will return "Success", "Failure", or the empty string when out is not a
 	// marshalled metav1.Status object.
@@ -373,13 +321,10 @@ func testAntctlProxy(t *testing.T, data *TestData) {
 
 	checkEndpointAccess := func(address string, endpoint string, checkStatus bool) error {
 		t.Logf("Checking for access to endpoint '/%s' through antctl proxy", endpoint)
-		cmd := fmt.Sprintf("curl %s/%s", net.JoinHostPort(address, fmt.Sprint(proxyPort)), endpoint)
-		rc, stdout, stderr, err := data.RunCommandOnNode(controlPlaneNodeName(), cmd)
+		cmd := []string{"curl", fmt.Sprintf("%s/%s", net.JoinHostPort(address, fmt.Sprint(proxyPort)), endpoint)}
+		stdout, stderr, err := data.RunCommandFromPod(data.testNamespace, testPodName, testContainerName, cmd)
 		if err != nil {
-			return fmt.Errorf("error when running command '%s' on Node: %v", cmd, err)
-		}
-		if rc != 0 {
-			return fmt.Errorf("error when accessing endpoint '/%s', stdout: <%v>, stderr: <%v>", endpoint, stdout, stderr)
+			return fmt.Errorf("error when running command '%s' on Pod '%s': %v, stdout: <%v>, stderr: <%v>", strings.Join(cmd, " "), testPodName, err, stdout, stderr)
 		}
 		if checkStatus && getEndpointStatus([]byte(stdout)) == "Failure" {
 			return fmt.Errorf("failure status when accessing endpoint: <%v>", stdout)
@@ -401,28 +346,13 @@ func testAntctlProxy(t *testing.T, data *TestData) {
 		{"AgentIPv6", controlPlaneNodeName(), 6, addressV6},
 	}
 
-	for _, tc := range testcases {
+	for idx, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
+			proxyPodName := fmt.Sprintf("antctl-proxy-%d", idx)
 			if clusterInfo.podV4NetworkCIDR == "" && tc.ipFamily == 4 || clusterInfo.podV6NetworkCIDR == "" && tc.ipFamily == 6 {
 				t.Skipf("Skipping this testcase since cluster network family doesn't fit")
 			}
-			t.Logf("Starting antctl proxy")
-			stopProxyFn, err := runAntctProxy(controlPlaneNodeName(), antctlName, nodeAntctlPath, nodeAntctlKubeconfigPath, proxyPort, tc.agentNodeName, tc.address, data)
-			require.NoError(t, err, "Could not start antctl proxy: %v", err)
-			defer func() {
-				t.Logf("Stopping antctl proxy")
-				if err := stopProxyFn(); err != nil {
-					t.Errorf("Error when stopping antctl proxy: %v", err)
-				}
-			}()
-
-			require.NoError(t, wait.PollImmediate(1*time.Second, 5*time.Second, func() (bool, error) {
-				if err := checkEndpointAccess(tc.address, "", false); err != nil {
-					return false, err
-				}
-				return true, nil
-			}), "Antctl proxy never became ready")
-
+			runAntctProxy(t, data, proxyPodName, antctlServiceAccountName, proxyContainerName, antctlImage, proxyPort, tc.agentNodeName, tc.address)
 			for _, endpoint := range []string{"apis", "metrics", "debug/pprof/"} {
 				assert.NoErrorf(t, checkEndpointAccess(tc.address, endpoint, true), "endpoint check failed for '%s'", endpoint)
 			}
@@ -430,73 +360,43 @@ func testAntctlProxy(t *testing.T, data *TestData) {
 	}
 }
 
-func getAntctlServiceAccountToken(ctx context.Context, data *TestData) ([]byte, []byte, error) {
-	const secretName = "antctl-service-account-token"
-	secret, err := data.clientset.CoreV1().Secrets(antreaNamespace).Get(ctx, secretName, metav1.GetOptions{})
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to retrieve secret '%s/%s' containing antctl ServiceAccount token: %w", antreaNamespace, secretName, err)
-	}
-	return secret.Data["token"], secret.Data["ca.crt"], nil
-}
-
-func generateAntctlKubeconfig(ctx context.Context, data *TestData) ([]byte, error) {
-	token, ca, err := getAntctlServiceAccountToken(ctx, data)
-	if err != nil {
-		return nil, err
-	}
-	// the clusterName is purely cosmetic and does not impact functionality
-	const clusterName = "antrea-test-e2e"
-	serverURL := url.URL{
-		Scheme: "https",
-		Host:   net.JoinHostPort(clusterInfo.k8sServiceHost, fmt.Sprint(clusterInfo.k8sServicePort)),
-	}
-	config := clientcmdapi.Config{
-		Clusters: map[string]*clientcmdapi.Cluster{
-			clusterName: {
-				Server:                   serverURL.String(),
-				CertificateAuthorityData: ca,
-			},
-		},
-		Contexts: map[string]*clientcmdapi.Context{
-			clusterName: {
-				Cluster:   clusterName,
-				Namespace: antreaNamespace,
-				AuthInfo:  clusterName,
-			},
-		},
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			clusterName: {
-				Token: string(token),
-			},
-		},
-		CurrentContext: clusterName,
-	}
-	rawConfig, err := clientcmd.Write(config)
-	if err != nil {
-		return nil, err
-	}
-	return rawConfig, nil
-}
-
-// createAntctlKubeconfigSecret creates a Secret containing the raw Kubeconfig data for the antctl
-// ServiceAccount, in the current test Namespace. It returns the randomly-generated Secret name.
-func createAntctlKubeconfigSecret(ctx context.Context, data *TestData, key string) (string, error) {
-	config, err := generateAntctlKubeconfig(ctx, data)
-	if err != nil {
-		return "", err
-	}
-	name := randName("antctl-kubeconfig-")
-	secret := &corev1.Secret{
+func createAntctlServiceAccount(t *testing.T, data *TestData, name string) {
+	serviceAccount := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: data.testNamespace,
 			Name:      name,
 		},
-		Data: map[string][]byte{
-			key: config,
+	}
+	_, err := data.clientset.CoreV1().ServiceAccounts(data.testNamespace).Create(context.TODO(), serviceAccount, metav1.CreateOptions{})
+	require.NoErrorf(t, err, "failed to create ServiceAccount '%s/%s' for antctl test Pods", data.testNamespace, name)
+
+	t.Cleanup(func() {
+		err := data.clientset.CoreV1().ServiceAccounts(data.testNamespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
+		assert.NoError(t, err, "Error when deleting ClusterRoleBinding")
+	})
+
+	clusterRoleBinding := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name, // we use the same name as for the ServiceAccount
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      name,
+				Namespace: data.testNamespace,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     "antctl",
 		},
 	}
-	if _, err := data.clientset.CoreV1().Secrets(data.testNamespace).Create(ctx, secret, metav1.CreateOptions{}); err != nil {
-		return "", fmt.Errorf("failed to create secret containing antctl Kubeconfig data: %w", err)
-	}
-	return name, nil
+	_, err = data.clientset.RbacV1().ClusterRoleBindings().Create(context.TODO(), clusterRoleBinding, metav1.CreateOptions{})
+	require.NoErrorf(t, err, "Failed to create ClusterRoleBinding to grant antctl ClusterRole to ServiceAccount '%s/%s'", data.testNamespace, name)
+
+	t.Cleanup(func() {
+		err := data.clientset.RbacV1().ClusterRoleBindings().Delete(context.TODO(), name, metav1.DeleteOptions{})
+		assert.NoError(t, err, "Error when deleting ClusterRoleBinding")
+	})
 }

--- a/test/e2e/flowaggregator_test.go
+++ b/test/e2e/flowaggregator_test.go
@@ -670,7 +670,7 @@ func testHelper(t *testing.T, data *TestData, podAIPs, podBIPs, podCIPs, podDIPs
 		for _, args := range antctl.CommandList.GetDebugCommands(runtime.ModeFlowAggregator) {
 			command := []string{}
 			if testOptions.enableCoverage {
-				antctlCovArgs := antctlCoverageArgs("antctl-coverage")
+				antctlCovArgs := antctlCoverageArgs("antctl-coverage", "")
 				command = append(antctlCovArgs, args...)
 			} else {
 				command = append([]string{"antctl", "-v"}, args...)
@@ -710,7 +710,7 @@ func checkAntctlGetFlowRecordsJson(t *testing.T, data *TestData, podName string,
 	var command []string
 	args := []string{"get", "flowrecords", "-o", "json", "--srcip", srcIP, "--srcport", srcPort}
 	if testOptions.enableCoverage {
-		antctlCovArgs := antctlCoverageArgs("antctl-coverage")
+		antctlCovArgs := antctlCoverageArgs("antctl-coverage", "")
 		command = append(antctlCovArgs, args...)
 	} else {
 		command = append([]string{"antctl"}, args...)

--- a/test/e2e/service_externalip_test.go
+++ b/test/e2e/service_externalip_test.go
@@ -522,11 +522,11 @@ func testServiceNodeFailure(t *testing.T, data *TestData) {
 			}
 			// The Agent on the original Node is paused. Run antctl from the expected migrated Node instead.
 			err = wait.PollImmediate(200*time.Millisecond, 15*time.Second, func() (done bool, err error) {
-				assigndNode, err := data.getServiceAssignedNode(expectedMigratedNode, service)
+				assignedNode, err := data.getServiceAssignedNode(expectedMigratedNode, service)
 				if err != nil {
 					return false, nil
 				}
-				return assigndNode == expectedMigratedNode, nil
+				return assignedNode == expectedMigratedNode, nil
 			})
 			assert.NoError(t, err)
 			restoreAgent(originalNode)
@@ -600,7 +600,7 @@ func testExternalIPAccess(t *testing.T, data *TestData) {
 			}
 			waitExternalIPConfigured := func(service *v1.Service) (string, string, error) {
 				var ip string
-				var assigndNode string
+				var assignedNode string
 				err := wait.PollImmediate(200*time.Millisecond, 5*time.Second, func() (done bool, err error) {
 					service, err = data.clientset.CoreV1().Services(service.Namespace).Get(context.TODO(), service.Name, metav1.GetOptions{})
 					if err != nil {
@@ -609,14 +609,14 @@ func testExternalIPAccess(t *testing.T, data *TestData) {
 					if len(service.Status.LoadBalancer.Ingress) == 0 || service.Status.LoadBalancer.Ingress[0].IP == "" {
 						return false, nil
 					}
-					assigndNode, err = data.getServiceAssignedNode("", service)
+					assignedNode, err = data.getServiceAssignedNode("", service)
 					if err != nil {
 						return false, nil
 					}
 					ip = service.Status.LoadBalancer.Ingress[0].IP
 					return true, nil
 				})
-				return ip, assigndNode, err
+				return ip, assignedNode, err
 			}
 			for _, et := range externalIPTestCases {
 				t.Run(et.name, func(t *testing.T) {


### PR DESCRIPTION
Instead of copying the antctl binary to the Node.

This simplifies tests in the following ways:
* No need to generate a Kubeconfig using the kube-system/antctl ServiceAccount token. Instead we define a ServiceAccount in the test Namepace, bind the antctl ClusterRole to it, and use it for the antctl Pod.
* No need to use different antctl binary paths for Kind and VMs.
* Easier lifecyle management when running antctl proxy.

We also remove the assumption that curl is available on the control-plane Node.