### PR TITLE
Fix: Change IPv6 and Dual-stack jenkins job

### DIFF
--- a/ci/jenkins/jobs/macros.yaml
+++ b/ci/jenkins/jobs/macros.yaml
@@ -275,3 +275,21 @@
           set -e 
           DOCKER_REGISTRY="$(head -n1 ci/docker-registry)"
           ./ci/jenkins/test-mc.sh --testcase e2e --registry ${DOCKER_REGISTRY} --mc-gateway --codecov-token "${CODECOV_TOKEN}" --coverage --kind
+            
+- builder:
+    name: builder-e2e-jumper
+    builders:
+      - shell: |-
+          #!/bin/bash
+          set -e
+          DOCKER_REGISTRY="$(head -n1 ci/docker-registry)"
+          ./ci/jenkins/test.sh --testcase e2e --registry ${DOCKER_REGISTRY} --testbed-type jumper
+
+- builder:
+    name: builder-conformance-jumper
+    builders:
+      - shell: |-
+          #!/bin/bash
+          set -e
+          DOCKER_REGISTRY="$(head -n1 ci/docker-registry)"
+          ./ci/jenkins/test.sh --testcase '{conformance_type}' --registry ${DOCKER_REGISTRY} --testbed-type jumper

--- a/ci/jenkins/jobs/projects-lab.yaml
+++ b/ci/jenkins/jobs/projects-lab.yaml
@@ -138,7 +138,7 @@
           branches:
           - ${{sha1}}
           builders:
-            - builder-e2e
+            - builder-e2e-jumper
           trigger_phrase: ^(?!Thanks for your PR).*/test-ipv6-(e2e|all).*
           white_list_target_branches: []
           allow_whitelist_orgs_as_admins: true
@@ -198,7 +198,7 @@
           branches:
           - ${{sha1}}
           builders:
-            - builder-conformance:
+            - builder-conformance-jumper:
                 conformance_type: 'conformance'
           trigger_phrase: ^(?!Thanks for your PR).*/test-ipv6-(conformance|all).*
           white_list_target_branches: []
@@ -259,7 +259,7 @@
           branches:
           - ${{sha1}}
           builders:
-            - builder-conformance:
+            - builder-conformance-jumper:
                 conformance_type: 'networkpolicy'
           trigger_phrase: ^(?!Thanks for your PR).*/test-ipv6-(networkpolicy|all).*
           white_list_target_branches: []
@@ -320,7 +320,7 @@
           branches:
           - ${{sha1}}
           builders:
-            - builder-e2e
+            - builder-e2e-jumper
           trigger_phrase: ^(?!Thanks for your PR).*/test-ipv6-only-(e2e|all).*
           white_list_target_branches: []
           allow_whitelist_orgs_as_admins: true
@@ -380,7 +380,7 @@
           branches:
           - ${{sha1}}
           builders:
-            - builder-conformance:
+            - builder-conformance-jumper:
                 conformance_type: 'conformance'
           trigger_phrase: ^(?!Thanks for your PR).*/test-ipv6-only-(conformance|all).*
           white_list_target_branches: []
@@ -441,7 +441,7 @@
           branches:
           - ${{sha1}}
           builders:
-            - builder-conformance:
+            - builder-conformance-jumper:
                 conformance_type: 'networkpolicy'
           trigger_phrase: ^(?!Thanks for your PR).*/test-ipv6-only-(networkpolicy|all).*
           white_list_target_branches: []


### PR DESCRIPTION
Change IPv6 and dual-stack Jenkins job script from test-vms.sh to test.sh to correct the
inconsistent definitions with the actual job definitions in the Jenkins. Issue #5334 