### PR TITLE
 Clean up auto-generated resources in leader and member clusters

### DIFF
--- a/hack/.notableofcontents
+++ b/hack/.notableofcontents
@@ -32,7 +32,6 @@ docs/multicluster/architecture.md
 docs/multicluster/policy-only-mode.md
 docs/multicluster/quick-start.md
 docs/multicluster/upgrade.md
-docs/multicluster/user-guide.md
 docs/network-requirements.md
 docs/noencap-hybrid-modes.md
 docs/octant-plugin-installation.md

--- a/multicluster/cmd/multicluster-controller/clusterset_webhook.go
+++ b/multicluster/cmd/multicluster-controller/clusterset_webhook.go
@@ -33,10 +33,6 @@ import (
 
 //+kubebuilder:webhook:path=/validate-multicluster-crd-antrea-io-v1alpha2-clusterset,mutating=false,failurePolicy=fail,sideEffects=None,groups=multicluster.crd.antrea.io,resources=clustersets,verbs=create;update;delete,versions=v1alpha2,name=vclusterset.kb.io,admissionReviewVersions={v1,v1beta1}
 
-const (
-	mcControllerSAName = "antrea-mc-controller"
-)
-
 // ClusterSet validator
 type clusterSetValidator struct {
 	Client    client.Client

--- a/multicluster/cmd/multicluster-controller/gateway_webhook.go
+++ b/multicluster/cmd/multicluster-controller/gateway_webhook.go
@@ -31,7 +31,8 @@ import (
 )
 
 const (
-	antreaAgentSAName = "antrea-agent"
+	antreaAgentSAName  = "antrea-agent"
+	mcControllerSAName = "antrea-mc-controller"
 )
 
 //+kubebuilder:webhook:path=/validate-multicluster-crd-antrea-io-v1alpha1-gateway,mutating=false,failurePolicy=fail,sideEffects=None,groups=multicluster.crd.antrea.io,resources=gateways,verbs=create;update,versions=v1alpha1,name=vgateway.kb.io,admissionReviewVersions={v1,v1beta1}

--- a/multicluster/cmd/multicluster-controller/leader.go
+++ b/multicluster/cmd/multicluster-controller/leader.go
@@ -120,7 +120,7 @@ func runLeader(o *Options) error {
 	if err = staleController.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("error creating StaleResCleanupController: %v", err)
 	}
-	go staleController.RunPeriodically(stopCh)
+	go staleController.Run(stopCh)
 
 	klog.InfoS("Leader MC Controller Starting Manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {

--- a/multicluster/cmd/multicluster-controller/leader.go
+++ b/multicluster/cmd/multicluster-controller/leader.go
@@ -23,7 +23,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	multiclusterv1alpha1 "antrea.io/antrea/multicluster/apis/multicluster/v1alpha1"
-	multiclustercontrollers "antrea.io/antrea/multicluster/controllers/multicluster"
 	"antrea.io/antrea/multicluster/controllers/multicluster/leader"
 	"antrea.io/antrea/pkg/log"
 	"antrea.io/antrea/pkg/signals"
@@ -114,15 +113,14 @@ func runLeader(o *Options) error {
 		return fmt.Errorf("error creating ResourceExport webhook: %v", err)
 	}
 
-	staleController := multiclustercontrollers.NewStaleResCleanupController(
+	staleController := leader.NewStaleResCleanupController(
 		mgr.GetClient(),
 		mgr.GetScheme(),
-		env.GetPodNamespace(),
-		nil,
-		multiclustercontrollers.LeaderCluster,
 	)
-
-	go staleController.Run(stopCh)
+	if err = staleController.SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("error creating StaleResCleanupController: %v", err)
+	}
+	go staleController.RunPeriodically(stopCh)
 
 	klog.InfoS("Leader MC Controller Starting Manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {

--- a/multicluster/cmd/multicluster-controller/leader_test.go
+++ b/multicluster/cmd/multicluster-controller/leader_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache/informertest"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/config/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -59,6 +60,7 @@ func initMockManager(mockManager *mocks.MockManager) {
 	mockManager.EXPECT().Start(gomock.Any()).Return(nil).AnyTimes()
 	mockManager.EXPECT().GetConfig().Return(&rest.Config{}).AnyTimes()
 	mockManager.EXPECT().GetRESTMapper().Return(&meta.DefaultRESTMapper{}).AnyTimes()
+	mockManager.EXPECT().GetFieldIndexer().Return(&informertest.FakeInformers{}).AnyTimes()
 }
 
 func TestRunLeader(t *testing.T) {

--- a/multicluster/cmd/multicluster-controller/member.go
+++ b/multicluster/cmd/multicluster-controller/member.go
@@ -23,7 +23,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	multiclustercontrollers "antrea.io/antrea/multicluster/controllers/multicluster"
 	"antrea.io/antrea/multicluster/controllers/multicluster/member"
 	"antrea.io/antrea/pkg/log"
 	"antrea.io/antrea/pkg/signals"
@@ -70,11 +69,13 @@ func runMember(o *Options) error {
 			role:      memberRole},
 		})
 
+	commonAreaCreationCh := make(chan struct{})
 	clusterSetReconciler := member.NewMemberClusterSetReconciler(mgr.GetClient(),
 		mgr.GetScheme(),
 		env.GetPodNamespace(),
 		o.EnableStretchedNetworkPolicy,
 		o.ClusterCalimCRDAvailable,
+		commonAreaCreationCh,
 	)
 	if err = clusterSetReconciler.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("error creating ClusterSet controller: %v", err)
@@ -122,15 +123,16 @@ func runMember(o *Options) error {
 		return fmt.Errorf("error creating Node controller: %v", err)
 	}
 
-	staleController := multiclustercontrollers.NewStaleResCleanupController(
+	staleController := member.NewStaleResCleanupController(
 		mgr.GetClient(),
 		mgr.GetScheme(),
+		commonAreaCreationCh,
 		env.GetPodNamespace(),
 		commonAreaGetter,
-		multiclustercontrollers.MemberCluster,
 	)
 
 	go staleController.Run(stopCh)
+
 	// Member runs ResourceImportReconciler from RemoteCommonArea only
 
 	klog.InfoS("Member MC Controller Starting Manager")

--- a/multicluster/cmd/multicluster-controller/member.go
+++ b/multicluster/cmd/multicluster-controller/member.go
@@ -69,7 +69,7 @@ func runMember(o *Options) error {
 			role:      memberRole},
 		})
 
-	commonAreaCreationCh := make(chan struct{})
+	commonAreaCreationCh := make(chan struct{}, 1)
 	clusterSetReconciler := member.NewMemberClusterSetReconciler(mgr.GetClient(),
 		mgr.GetScheme(),
 		env.GetPodNamespace(),

--- a/multicluster/cmd/multicluster-controller/options.go
+++ b/multicluster/cmd/multicluster-controller/options.go
@@ -96,9 +96,9 @@ func (o *Options) complete(args []string) error {
 			o.EndpointIPType = ctrlConfig.EndpointIPType
 		}
 		o.EnableStretchedNetworkPolicy = ctrlConfig.EnableStretchedNetworkPolicy
-		klog.InfoS("Using config from file", "config", o.options)
+		klog.InfoS("Using config from file", "config", o.configFile)
 	} else {
-		klog.InfoS("Using default config", "config", o.options)
+		klog.InfoS("Using default config")
 	}
 	return nil
 }

--- a/multicluster/controllers/multicluster/common/controller_utils.go
+++ b/multicluster/controllers/multicluster/common/controller_utils.go
@@ -105,7 +105,7 @@ func getClusterIDFromClusterClaim(c client.Client, clusterSet *mcv1alpha2.Cluste
 
 func GetClusterID(clusterCalimCRDAvailable bool, req ctrl.Request, client client.Client, clusterSet *mcv1alpha2.ClusterSet) (ClusterID, error) {
 	if clusterSet.Spec.ClusterID == "" {
-		// ClusterID is a required feild, and the empty value case should only happen
+		// ClusterID is a required field, and the empty value case should only happen
 		// when Antrea Multi-cluster is upgraded from an old version prior to v1.13.
 		// Here we try to get the ClusterID from ClusterClaim before returning any error.
 		if clusterCalimCRDAvailable {

--- a/multicluster/controllers/multicluster/common/helper.go
+++ b/multicluster/controllers/multicluster/common/helper.go
@@ -16,11 +16,22 @@ package common
 import (
 	"crypto/sha1" // #nosec G505: not used for security purposes
 	"encoding/hex"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 const labelIdentityHashLength = 16
+
+// CleanUpRetry is the retry when the clean up method
+// failed to clean up all stale resources.
+var CleanUpRetry = wait.Backoff{
+	Steps:    15,
+	Duration: 500 * time.Millisecond,
+	Factor:   2.0,
+	Jitter:   1,
+}
 
 // TODO: Use NamespacedName stringer method instead of this. e.g. nsName.String()
 func NamespacedName(namespace, name string) string {

--- a/multicluster/controllers/multicluster/common/helper.go
+++ b/multicluster/controllers/multicluster/common/helper.go
@@ -27,7 +27,7 @@ const labelIdentityHashLength = 16
 // CleanUpRetry is the retry when the clean up method
 // failed to clean up all stale resources.
 var CleanUpRetry = wait.Backoff{
-	Steps:    15,
+	Steps:    12,
 	Duration: 500 * time.Millisecond,
 	Factor:   2.0,
 	Jitter:   1,

--- a/multicluster/controllers/multicluster/leader/clusterset_controller.go
+++ b/multicluster/controllers/multicluster/leader/clusterset_controller.go
@@ -96,7 +96,7 @@ func (r *LeaderClusterSetReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		}
 
 		if clusterSet.Spec.ClusterID == "" {
-			// ClusterID is a required feild, and the empty value case should only happen
+			// ClusterID is a required field, and the empty value case should only happen
 			// when Antrea Multi-cluster is upgraded from an old version prior to v1.13.
 			// Here we try to update the ClusterSet's ClusterID when it's configured in an
 			// existing ClusterClaim.

--- a/multicluster/controllers/multicluster/leader/clusterset_controller.go
+++ b/multicluster/controllers/multicluster/leader/clusterset_controller.go
@@ -72,10 +72,12 @@ func (r *LeaderClusterSetReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			return ctrl.Result{}, err
 		}
 		klog.InfoS("Received ClusterSet delete", "clusterset", req.NamespacedName)
+		if r.clusterSetConfig != nil && r.clusterSetConfig.Name != req.Name {
+			return ctrl.Result{}, nil
+		}
 		r.clusterSetConfig = nil
 		r.clusterID = common.InvalidClusterID
 		r.clusterSetID = common.InvalidClusterSetID
-
 		return ctrl.Result{}, nil
 	}
 
@@ -120,7 +122,7 @@ func (r *LeaderClusterSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&mcv1alpha2.ClusterSet{}).
 		WithEventFilter(instance).
 		WithOptions(controller.Options{
-			MaxConcurrentReconciles: common.DefaultWorkerCount,
+			MaxConcurrentReconciles: 1,
 		}).
 		Complete(r)
 }

--- a/multicluster/controllers/multicluster/leader/clusterset_controller_test.go
+++ b/multicluster/controllers/multicluster/leader/clusterset_controller_test.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	mcv1alpha1 "antrea.io/antrea/multicluster/apis/multicluster/v1alpha1"
 	mcv1alpha2 "antrea.io/antrea/multicluster/apis/multicluster/v1alpha2"
 	"antrea.io/antrea/multicluster/controllers/multicluster/common"
 )
@@ -82,6 +83,7 @@ var (
 
 func createMockClients(t *testing.T, objects ...client.Object) (*runtime.Scheme, client.Client, *MockMemberClusterStatusManager) {
 	scheme := runtime.NewScheme()
+	mcv1alpha1.AddToScheme(scheme)
 	mcv1alpha2.AddToScheme(scheme)
 	fakeRemoteClient := fake.NewClientBuilder().WithScheme(scheme).
 		WithObjects(objects...).Build()

--- a/multicluster/controllers/multicluster/leader/stale_controller.go
+++ b/multicluster/controllers/multicluster/leader/stale_controller.go
@@ -1,0 +1,234 @@
+/*
+Copyright 2023 Antrea Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package leader
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+
+	"antrea.io/antrea/multicluster/apis/multicluster/constants"
+	mcv1alpha1 "antrea.io/antrea/multicluster/apis/multicluster/v1alpha1"
+	"antrea.io/antrea/multicluster/controllers/multicluster/common"
+	"antrea.io/antrea/multicluster/controllers/multicluster/commonarea"
+)
+
+const (
+	indexKey                       = "spec.clusterID"
+	memberClusterAnnounceStaleTime = 24 * time.Hour
+)
+
+var getResourceExportsByClusterIDFunc = getResourceExportsByClusterID
+
+// StaleResCleanupController will run periodically (memberClusterAnnounceStaleTime / 2 = 12 Hours)
+// to clean up stale MemberClusterAnnounce resources in the leader cluster if the MemberClusterAnnounce
+// timestamp annotation has not been updated for memberClusterAnnounceStaleTime (24 Hours).
+// It will remove all ResourceExports belong to a member cluster when the corresponding MemberClusterAnnounce
+// CR is deleted. It will also try to clean up all stale ResourceExports during start.
+type StaleResCleanupController struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+func NewStaleResCleanupController(
+	Client client.Client,
+	Scheme *runtime.Scheme,
+) *StaleResCleanupController {
+	reconciler := &StaleResCleanupController{
+		Client: Client,
+		Scheme: Scheme,
+	}
+	return reconciler
+}
+
+// cleanUpExpiredMemberClusterAnnounces will delete any MemberClusterAnnounce if its
+// last update timestamp is over 24 hours.
+func (c *StaleResCleanupController) cleanUpExpiredMemberClusterAnnounces(ctx context.Context) {
+	memberClusterAnnounceList := &mcv1alpha1.MemberClusterAnnounceList{}
+	if err := c.List(ctx, memberClusterAnnounceList, &client.ListOptions{}); err != nil {
+		klog.ErrorS(err, "Fail to get MemberClusterAnnounces")
+		return
+	}
+
+	for _, m := range memberClusterAnnounceList.Items {
+		memberClusterAnnounce := m
+		lastUpdateTime, err := time.Parse(time.RFC3339, memberClusterAnnounce.Annotations[commonarea.TimestampAnnotationKey])
+		if err == nil && time.Since(lastUpdateTime) < memberClusterAnnounceStaleTime {
+			continue
+		}
+		if err == nil {
+			klog.InfoS("Cleaning up stale MemberClusterAnnounce. It has not been updated within the agreed period",
+				"MemberClusterAnnounce", klog.KObj(&memberClusterAnnounce), "agreedPeriod", memberClusterAnnounceStaleTime)
+		} else {
+			klog.InfoS("Cleaning up stale MemberClusterAnnounce. The latest update time is not in RFC3339 format",
+				"MemberClusterAnnounce", klog.KObj(&memberClusterAnnounce))
+		}
+
+		if err := c.Client.Delete(ctx, &memberClusterAnnounce, &client.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			klog.ErrorS(err, "Failed to delete stale MemberClusterAnnounce", "MemberClusterAnnounce", klog.KObj(&memberClusterAnnounce))
+			return
+		}
+	}
+}
+
+func (c *StaleResCleanupController) RunPeriodically(stopCh <-chan struct{}) {
+	klog.InfoS("Starting StaleResCleanupController")
+	defer klog.InfoS("Shutting down StaleResCleanupController")
+
+	ctx, _ := wait.ContextForChannel(stopCh)
+	go wait.UntilWithContext(ctx, c.cleanUpExpiredMemberClusterAnnounces, memberClusterAnnounceStaleTime/2)
+	<-stopCh
+}
+
+func (c *StaleResCleanupController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	memberAnnounce := &mcv1alpha1.MemberClusterAnnounce{}
+	err := c.Get(ctx, req.NamespacedName, memberAnnounce)
+	if err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if err == nil && memberAnnounce.DeletionTimestamp.IsZero() {
+		// Ignore the event if it's not with non-zero DeletionTimestamp
+		return ctrl.Result{}, nil
+	}
+
+	// Clean up all corresponding ResourceExports when the member cluster's
+	// MemberClusterAnnounce is deleted.
+	clusterID := getClusterIDFromName(req.Name)
+	staleResExports, err := getResourceExportsByClusterIDFunc(c, ctx, clusterID)
+	if err != nil {
+		klog.ErrorS(err, "Failed to get ResourceExports by ClusterID", "clusterID", clusterID)
+		return ctrl.Result{}, err
+	}
+	if !deleteResourceExports(ctx, c.Client, staleResExports) {
+		return ctrl.Result{}, fmt.Errorf("failed to clean up all stale ResourceExports for the member cluster %s, retry later", clusterID)
+	}
+
+	// When cleanup is done, remove the Finalizer of this MemberClusterAnnounce.
+	finalizer := fmt.Sprintf("%s/%s", MemberClusterAnnounceFinalizer, memberAnnounce.ClusterID)
+	memberAnnounce.Finalizers = common.RemoveStringFromSlice(memberAnnounce.Finalizers, finalizer)
+	if err := c.Update(context.TODO(), memberAnnounce); err != nil {
+		klog.ErrorS(err, "Failed to update MemberClusterAnnounce", "MemberClusterAnnounce", klog.KObj(memberAnnounce))
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (c *StaleResCleanupController) SetupWithManager(mgr ctrl.Manager) error {
+	// Add an Indexer for ResourceExport, so it can be filtered by the ClusterID.
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &mcv1alpha1.ResourceExport{}, indexKey, func(rawObj client.Object) []string {
+		resExport := rawObj.(*mcv1alpha1.ResourceExport)
+		return []string{resExport.Spec.ClusterID}
+	}); err != nil {
+		klog.ErrorS(err, "Failed to create the index")
+		return err
+	}
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&mcv1alpha1.MemberClusterAnnounce{}).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: 1,
+		}).
+		Complete(c)
+}
+
+func cleanUpStaleResourceExports(ctx context.Context, mgrClient client.Client) error {
+	existingMemberClusterIDs, err := getExistingMemberClusterIDs(ctx, mgrClient)
+	if err != nil {
+		klog.ErrorS(err, "Failed to get existing member cluster's ClusterID")
+		return err
+	}
+
+	resourceExports := &mcv1alpha1.ResourceExportList{}
+	err = mgrClient.List(ctx, resourceExports, &client.ListOptions{})
+	if err != nil {
+		klog.ErrorS(err, "Failed to get ResourceExports")
+		return err
+	}
+
+	staleResExports := []mcv1alpha1.ResourceExport{}
+	for _, resExport := range resourceExports.Items {
+		// The AntreaClusterNetworkPolicy kind of ResourceExport is created in the leader directly
+		// without a ClusterID info. It's not owned by any member cluster.
+		if resExport.Spec.Kind != constants.AntreaClusterNetworkPolicyKind && !existingMemberClusterIDs.Has(resExport.Spec.ClusterID) {
+			staleResExports = append(staleResExports, resExport)
+		}
+	}
+
+	cleanUpSucceed := deleteResourceExports(ctx, mgrClient, staleResExports)
+	if !cleanUpSucceed {
+		return fmt.Errorf("stale ResourceExports are not fully cleaned up, retry later")
+	}
+	return nil
+}
+
+func getExistingMemberClusterIDs(ctx context.Context, mgrClient client.Client) (sets.Set[string], error) {
+	validMemberClusterIDs := sets.Set[string]{}
+	memberClusterAnnounces := &mcv1alpha1.MemberClusterAnnounceList{}
+	err := mgrClient.List(ctx, memberClusterAnnounces, &client.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, m := range memberClusterAnnounces.Items {
+		validMemberClusterIDs.Insert(m.ClusterID)
+	}
+	return validMemberClusterIDs, nil
+}
+
+func deleteResourceExports(ctx context.Context, mgrClient client.Client, resouceExports []mcv1alpha1.ResourceExport) bool {
+	cleanupSucceed := true
+	for _, resourceExport := range resouceExports {
+		tmpResExp := resourceExport
+		if resourceExport.DeletionTimestamp.IsZero() {
+			klog.V(2).InfoS("Clean up the stale ResourceExport from the member cluster",
+				"resourceexport", klog.KObj(&tmpResExp), "clusterID", tmpResExp.Spec.ClusterID)
+			err := mgrClient.Delete(ctx, &tmpResExp, &client.DeleteOptions{})
+			if err != nil && !apierrors.IsNotFound(err) {
+				klog.ErrorS(err, "Failed to clean up the stale ResourceExport from the member cluster",
+					"resourceexport", klog.KObj(&tmpResExp), "clusterID", tmpResExp.Spec.ClusterID)
+				cleanupSucceed = false
+			}
+		}
+	}
+	return cleanupSucceed
+}
+
+func getClusterIDFromName(name string) string {
+	return strings.TrimPrefix(name, "member-announce-from-")
+}
+
+func getResourceExportsByClusterID(c *StaleResCleanupController, ctx context.Context, clusterID string) ([]mcv1alpha1.ResourceExport, error) {
+	resourceExports := &mcv1alpha1.ResourceExportList{}
+	err := c.Client.List(ctx, resourceExports, &client.ListOptions{}, client.MatchingFields{indexKey: clusterID})
+	if err != nil {
+		klog.ErrorS(err, "Failed to get ResourceExports by ClusterID", "clusterID", clusterID)
+		return nil, err
+	}
+	return resourceExports.Items, nil
+}

--- a/multicluster/controllers/multicluster/leader/stale_controller_test.go
+++ b/multicluster/controllers/multicluster/leader/stale_controller_test.go
@@ -1,0 +1,327 @@
+/*
+Copyright 2023 Antrea Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package leader
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"antrea.io/antrea/multicluster/apis/multicluster/constants"
+	mcv1alpha1 "antrea.io/antrea/multicluster/apis/multicluster/v1alpha1"
+	mcv1alpha2 "antrea.io/antrea/multicluster/apis/multicluster/v1alpha2"
+	"antrea.io/antrea/multicluster/controllers/multicluster/common"
+	"antrea.io/antrea/multicluster/controllers/multicluster/commonarea"
+)
+
+func TestCleanUpStaleResourceExports(t *testing.T) {
+	now := time.Now().Format(time.RFC3339)
+	oldTime := time.Now().Add(-1).Format(time.RFC3339)
+	mcaList := &mcv1alpha1.MemberClusterAnnounceList{
+		Items: []mcv1alpha1.MemberClusterAnnounce{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "member-announce-from-cluster-a",
+					Namespace: "default",
+					Annotations: map[string]string{
+						commonarea.TimestampAnnotationKey: now,
+					},
+				},
+				ClusterID: "cluster-a",
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "member-announce-from-cluster-b",
+					Namespace: "default",
+					Annotations: map[string]string{
+						commonarea.TimestampAnnotationKey: oldTime,
+					},
+				},
+				ClusterID: "cluster-b",
+			},
+		},
+	}
+
+	resExports := &mcv1alpha1.ResourceExportList{
+		Items: []mcv1alpha1.ResourceExport{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "cluster-a-svc",
+				},
+				Spec: mcv1alpha1.ResourceExportSpec{
+					ClusterID: "cluster-a",
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "cluster-b-svc",
+				},
+				Spec: mcv1alpha1.ResourceExportSpec{
+					ClusterID: "cluster-b",
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "cluster-c-svc",
+				},
+				Spec: mcv1alpha1.ResourceExportSpec{
+					ClusterID: "cluster-c",
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "leader-acnp",
+				},
+				Spec: mcv1alpha1.ResourceExportSpec{
+					Kind: constants.AntreaClusterNetworkPolicyKind,
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	mcv1alpha1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithLists(mcaList, resExports).Build()
+	c := NewStaleResCleanupController(fakeClient, scheme)
+	ctx := context.Background()
+	cleanUpStaleResourceExports(ctx, c.Client)
+	latestResExports := &mcv1alpha1.ResourceExportList{}
+	err := fakeClient.List(ctx, latestResExports)
+	require.NoError(t, err)
+	assert.Equal(t, 3, len(latestResExports.Items))
+}
+
+func TestReconcile(t *testing.T) {
+	resExport1 := mcv1alpha1.ResourceExport{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "cluster-1-svc",
+		},
+		Spec: mcv1alpha1.ResourceExportSpec{
+			ClusterID: "cluster-1",
+		},
+	}
+	resExport2 := mcv1alpha1.ResourceExport{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "cluster-1-ep",
+		},
+		Spec: mcv1alpha1.ResourceExportSpec{
+			ClusterID: "cluster-1",
+		},
+	}
+	resExport3 := mcv1alpha1.ResourceExport{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "cluster-2-ep",
+		},
+		Spec: mcv1alpha1.ResourceExportSpec{
+			ClusterID: "cluster-2",
+		},
+	}
+	resExportsList := &mcv1alpha1.ResourceExportList{
+		Items: []mcv1alpha1.ResourceExport{
+			resExport1,
+			resExport2,
+			resExport3,
+		},
+	}
+	scheme := runtime.NewScheme()
+	mcv1alpha1.AddToScheme(scheme)
+	now := metav1.Now()
+	memberClusterAnnounce1 := &mcv1alpha1.MemberClusterAnnounce{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "member-announce-from-cluster-1",
+			Namespace:         "default",
+			DeletionTimestamp: &now,
+		},
+		ClusterID: "cluster-1",
+	}
+	memberClusterAnnounce2 := &mcv1alpha1.MemberClusterAnnounce{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "member-announce-from-cluster-2",
+			Namespace: "default",
+		},
+		ClusterID: "cluster-2",
+	}
+
+	tests := []struct {
+		name                          string
+		memberAnnounceName            string
+		expectedResExportsSize        int
+		expectedErr                   error
+		existingMemberAnnounce        *mcv1alpha1.MemberClusterAnnounce
+		existingResExports            *mcv1alpha1.ResourceExportList
+		getResourceExportsByClusterID func(c *StaleResCleanupController, ctx context.Context, clusterID string) ([]mcv1alpha1.ResourceExport, error)
+	}{
+		{
+			name:                   "MemberClusterAnnounce deleted",
+			memberAnnounceName:     memberClusterAnnounce1.Name,
+			existingMemberAnnounce: memberClusterAnnounce1,
+			existingResExports:     resExportsList,
+			getResourceExportsByClusterID: func(c *StaleResCleanupController, ctx context.Context, clusterID string) ([]mcv1alpha1.ResourceExport, error) {
+				return []mcv1alpha1.ResourceExport{resExport1, resExport2}, nil
+			},
+			expectedResExportsSize: 1,
+		},
+		{
+			name:                   "MemberClusterAnnounce exists",
+			memberAnnounceName:     memberClusterAnnounce2.Name,
+			existingMemberAnnounce: memberClusterAnnounce2,
+			existingResExports:     resExportsList,
+			expectedResExportsSize: 3,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			getResourceExportsByClusterIDFunc = tt.getResourceExportsByClusterID
+			defer func() {
+				getResourceExportsByClusterIDFunc = getResourceExportsByClusterID
+			}()
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithLists(tt.existingResExports).WithObjects(tt.existingMemberAnnounce).Build()
+			c := NewStaleResCleanupController(fakeClient, scheme)
+			ctx := context.Background()
+			_, err := c.Reconcile(ctx, ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: "default",
+					Name:      tt.memberAnnounceName,
+				},
+			})
+			if tt.expectedErr == nil {
+				require.NoError(t, err)
+			} else {
+				assert.Equal(t, tt.expectedErr, err.Error())
+			}
+			latestResExports := &mcv1alpha1.ResourceExportList{}
+			err = fakeClient.List(ctx, latestResExports)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedResExportsSize, len(latestResExports.Items))
+		})
+	}
+}
+
+func TestStaleController_CleanUpMemberClusterAnnounces(t *testing.T) {
+	tests := []struct {
+		name                              string
+		memberClusterAnnounceList         *mcv1alpha1.MemberClusterAnnounceList
+		clusterSet                        *mcv1alpha2.ClusterSetList
+		exceptMemberClusterAnnounceNumber int
+	}{
+		{
+			name:                              "no MemberClusterAnnounce to clean up when there is no resource",
+			clusterSet:                        &mcv1alpha2.ClusterSetList{},
+			memberClusterAnnounceList:         &mcv1alpha1.MemberClusterAnnounceList{},
+			exceptMemberClusterAnnounceNumber: 0,
+		},
+		{
+			name:                              "no MemberClusterAnnounce to clean up when the resource has a valid update time",
+			exceptMemberClusterAnnounceNumber: 1,
+			clusterSet: &mcv1alpha2.ClusterSetList{
+				Items: []mcv1alpha2.ClusterSet{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "default",
+							Name:      "clusterset",
+						},
+						Spec: mcv1alpha2.ClusterSetSpec{},
+					},
+				},
+			},
+			memberClusterAnnounceList: &mcv1alpha1.MemberClusterAnnounceList{
+				Items: []mcv1alpha1.MemberClusterAnnounce{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "default",
+							Name:      "member-cluster-from-cluster-a",
+							Annotations: map[string]string{
+								commonarea.TimestampAnnotationKey: time.Now().Format(time.RFC3339),
+							},
+						},
+						ClusterID: "cluster-a",
+					},
+				},
+			},
+		},
+		{
+			name:                              "clean up outdated MemberClusterAnnounce",
+			exceptMemberClusterAnnounceNumber: 1,
+			clusterSet: &mcv1alpha2.ClusterSetList{
+				Items: []mcv1alpha2.ClusterSet{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "default",
+							Name:      "clusterset",
+						},
+						Spec: mcv1alpha2.ClusterSetSpec{},
+					},
+				},
+			},
+			memberClusterAnnounceList: &mcv1alpha1.MemberClusterAnnounceList{
+				Items: []mcv1alpha1.MemberClusterAnnounce{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "default",
+							Name:      "member-cluster-from-cluster-a",
+							Annotations: map[string]string{
+								commonarea.TimestampAnnotationKey: time.Now().Format(time.RFC3339),
+							},
+						},
+						ClusterID: "cluster-a",
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: "default",
+							Name:      "member-cluster-from-cluster-outdated",
+							Annotations: map[string]string{
+								commonarea.TimestampAnnotationKey: time.Now().Add(-memberClusterAnnounceStaleTime - 1).Format(time.RFC3339),
+							},
+						},
+						ClusterID: "cluster-outdated",
+					},
+				},
+			},
+		},
+	}
+	ctx := context.Background()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithLists(tt.memberClusterAnnounceList).WithLists(tt.clusterSet).Build()
+			c := NewStaleResCleanupController(fakeClient, common.TestScheme)
+			c.cleanUpExpiredMemberClusterAnnounces(ctx)
+
+			memberClusterAnnounceList := &mcv1alpha1.MemberClusterAnnounceList{}
+			if err := fakeClient.List(context.TODO(), memberClusterAnnounceList, &client.ListOptions{}); err != nil {
+				t.Errorf("Should list MemberClusterAnnounce successfully but got err = %v", err)
+			}
+
+			assert.Equal(t, tt.exceptMemberClusterAnnounceNumber, len(memberClusterAnnounceList.Items))
+		})
+	}
+}

--- a/multicluster/controllers/multicluster/member/acnp_resourceimport_controller_test.go
+++ b/multicluster/controllers/multicluster/member/acnp_resourceimport_controller_test.go
@@ -123,8 +123,8 @@ var (
 )
 
 func TestResourceImportReconciler_handleCopySpanACNPCreateEvent(t *testing.T) {
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(securityOpsTier).Build()
-	fakeRemoteClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(acnpResImport, acnpResImportNoMatchingTier, acnpResImportNoSpec).Build()
+	fakeClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithObjects(securityOpsTier).Build()
+	fakeRemoteClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithObjects(acnpResImport, acnpResImportNoMatchingTier, acnpResImportNoSpec).Build()
 	remoteCluster := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", localClusterID, "default", nil)
 
 	tests := []struct {
@@ -152,7 +152,7 @@ func TestResourceImportReconciler_handleCopySpanACNPCreateEvent(t *testing.T) {
 			expectedSuccess: false,
 		},
 	}
-	r := newResourceImportReconciler(fakeClient, scheme, fakeClient, localClusterID, "default", remoteCluster)
+	r := newResourceImportReconciler(fakeClient, common.TestScheme, fakeClient, localClusterID, "default", remoteCluster)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if _, err := r.Reconcile(ctx, tt.req); err != nil {
@@ -188,11 +188,11 @@ func TestResourceImportReconciler_handleCopySpanACNPDeleteEvent(t *testing.T) {
 		},
 	}
 
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existingACNP).Build()
-	fakeRemoteClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	fakeClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithObjects(existingACNP).Build()
+	fakeRemoteClient := fake.NewClientBuilder().WithScheme(common.TestScheme).Build()
 	remoteCluster := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", localClusterID, "default", nil)
 
-	r := newResourceImportReconciler(fakeClient, scheme, fakeClient, localClusterID, "default", remoteCluster)
+	r := newResourceImportReconciler(fakeClient, common.TestScheme, fakeClient, localClusterID, "default", remoteCluster)
 	r.installedResImports.Add(*acnpResImport)
 
 	if _, err := r.Reconcile(ctx, acnpImpReq); err != nil {
@@ -301,11 +301,11 @@ func TestResourceImportReconciler_handleCopySpanACNPUpdateEvent(t *testing.T) {
 		},
 	}
 
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existingACNP1, existingACNP3, existingACNP4, securityOpsTier).Build()
-	fakeRemoteClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(acnpResImport, updatedResImport2, updatedResImport3).Build()
+	fakeClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithObjects(existingACNP1, existingACNP3, existingACNP4, securityOpsTier).Build()
+	fakeRemoteClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithObjects(acnpResImport, updatedResImport2, updatedResImport3).Build()
 	remoteCluster := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", localClusterID, "default", nil)
 
-	r := newResourceImportReconciler(fakeClient, scheme, fakeClient, localClusterID, "default", remoteCluster)
+	r := newResourceImportReconciler(fakeClient, common.TestScheme, fakeClient, localClusterID, "default", remoteCluster)
 	r.installedResImports.Add(*acnpResImport)
 	r.installedResImports.Add(*acnpResImportNoMatchingTier)
 	r.installedResImports.Add(*updatedResImport3)

--- a/multicluster/controllers/multicluster/member/clusterinfo_importer_test.go
+++ b/multicluster/controllers/multicluster/member/clusterinfo_importer_test.go
@@ -29,6 +29,7 @@ import (
 
 	"antrea.io/antrea/multicluster/apis/multicluster/constants"
 	mcsv1alpha1 "antrea.io/antrea/multicluster/apis/multicluster/v1alpha1"
+	"antrea.io/antrea/multicluster/controllers/multicluster/common"
 	"antrea.io/antrea/multicluster/controllers/multicluster/commonarea"
 )
 
@@ -200,16 +201,16 @@ func TestResourceImportReconciler_handleClusterInfo(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects().Build()
+			fakeClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithObjects().Build()
 			if tt.existingCIImport != nil {
-				fakeClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(tt.existingCIImport).Build()
+				fakeClient = fake.NewClientBuilder().WithScheme(common.TestScheme).WithObjects(tt.existingCIImport).Build()
 			}
-			fakeRemoteClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tt.existingCIResImport).Build()
+			fakeRemoteClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithObjects(tt.existingCIResImport).Build()
 			if tt.isDelete {
-				fakeRemoteClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects().Build()
+				fakeRemoteClient = fake.NewClientBuilder().WithScheme(common.TestScheme).WithObjects().Build()
 			}
 			remoteCluster := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", "cluster-d", "default", nil)
-			r := newResourceImportReconciler(fakeClient, scheme, fakeClient, "cluster-d", "default", remoteCluster)
+			r := newResourceImportReconciler(fakeClient, common.TestScheme, fakeClient, "cluster-d", "default", remoteCluster)
 			if tt.existingCIResImport != nil {
 				r.installedResImports.Add(*tt.existingCIResImport)
 			}

--- a/multicluster/controllers/multicluster/member/clusterset_controller.go
+++ b/multicluster/controllers/multicluster/member/clusterset_controller.go
@@ -54,16 +54,17 @@ type MemberClusterSetReconciler struct {
 	Scheme                   *runtime.Scheme
 	Namespace                string
 	ClusterCalimCRDAvailable bool
+
 	// commonAreaLock protects the access to RemoteCommonArea.
-	commonAreaLock sync.RWMutex
+	commonAreaLock       sync.RWMutex
+	commonAreaCreationCh chan struct{}
 
 	clusterSetConfig *mcv1alpha2.ClusterSet
 	clusterSetID     common.ClusterSetID
 	clusterID        common.ClusterID
 	installedLeader  leaderClusterInfo
 
-	remoteCommonArea commonarea.RemoteCommonArea
-
+	remoteCommonArea             commonarea.RemoteCommonArea
 	enableStretchedNetworkPolicy bool
 }
 
@@ -72,6 +73,7 @@ func NewMemberClusterSetReconciler(client client.Client,
 	namespace string,
 	enableStretchedNetworkPolicy bool,
 	clusterCalimCRDAvailable bool,
+	commonAreaCreationCh chan struct{},
 ) *MemberClusterSetReconciler {
 	return &MemberClusterSetReconciler{
 		Client:                       client,
@@ -79,6 +81,9 @@ func NewMemberClusterSetReconciler(client client.Client,
 		Namespace:                    namespace,
 		enableStretchedNetworkPolicy: enableStretchedNetworkPolicy,
 		ClusterCalimCRDAvailable:     clusterCalimCRDAvailable,
+		commonAreaCreationCh:         commonAreaCreationCh,
+		clusterID:                    common.InvalidClusterID,
+		clusterSetID:                 common.InvalidClusterSetID,
 	}
 }
 
@@ -90,35 +95,54 @@ func NewMemberClusterSetReconciler(client client.Client,
 func (r *MemberClusterSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	clusterSet := &mcv1alpha2.ClusterSet{}
 	err := r.Get(ctx, req.NamespacedName, clusterSet)
-	r.commonAreaLock.Lock()
-	defer r.commonAreaLock.Unlock()
+	var clusterSetNotFound bool
+	var clusterSetCreated bool
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
 			return ctrl.Result{}, err
 		}
-		klog.InfoS("Received ClusterSet delete", "clusterset", req.NamespacedName)
-		if r.remoteCommonArea != nil {
-			if err := r.deleteMemberClusterAnnounce(ctx); err != nil {
-				// MemberClusterAnnounce could be kept in the leader cluster, if antrea-mc-controller crashes after the failure.
-				// Leader cluster will delete the stale MemberClusterAnnounce with a garbage collection mechanism in this case.
-				return ctrl.Result{}, fmt.Errorf("failed to delete MemberClusterAnnounce in the leader cluster: %v", err)
-			}
-			r.remoteCommonArea.Stop()
-			r.remoteCommonArea = nil
-			r.clusterSetConfig = nil
-			r.clusterID = common.InvalidClusterID
-			r.clusterSetID = common.InvalidClusterSetID
-		}
-		return ctrl.Result{}, nil
+		clusterSetNotFound = true
 	}
 
-	klog.InfoS("Received ClusterSet add/update", "clusterset", klog.KObj(clusterSet))
+	processClusterSet := func() error {
+		r.commonAreaLock.Lock()
+		defer r.commonAreaLock.Unlock()
 
-	// Handle create or update
-	if r.clusterSetConfig == nil {
+		if clusterSetNotFound {
+			klog.InfoS("Received ClusterSet delete", "clusterset", req.NamespacedName)
+			if err := r.cleanUpResources(ctx); err != nil {
+				return err
+			}
+			return nil
+		}
+
+		klog.InfoS("Received ClusterSet add/update", "clusterset", klog.KObj(clusterSet))
+
+		// Handle create or update
+
+		newLeader := clusterSet.Spec.Leaders[0]
+		if r.installedLeader.clusterID == newLeader.ClusterID && r.installedLeader.serverUrl == newLeader.Server &&
+			r.installedLeader.secretName == newLeader.Secret {
+			klog.V(2).InfoS("No change for leader cluster configuration")
+			return nil
+		}
+
+		if r.clusterID != common.ClusterID(clusterSet.Spec.ClusterID) {
+			clusterSetCreated = true
+		}
+
+		// ClusterSet deletion may fail and retry, but a ClusterSet may have been created just right before the retry.
+		// ClusterSet deletion retry will become an update action, so try to delete stale resources here before
+		// initilize a new ClusterSet.
+		if clusterSetCreated {
+			if err := r.cleanUpResources(ctx); err != nil {
+				return err
+			}
+		}
+
 		r.clusterID, err = common.GetClusterID(r.ClusterCalimCRDAvailable, req, r.Client, clusterSet)
 		if err != nil {
-			return ctrl.Result{}, err
+			return err
 		}
 		r.clusterSetID = common.ClusterSetID(clusterSet.Name)
 		if clusterSet.Spec.ClusterID == "" {
@@ -130,18 +154,55 @@ func (r *MemberClusterSetReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			err = r.Update(context.TODO(), clusterSet)
 			if err != nil {
 				klog.ErrorS(err, "Failed to update ClusterSet's ClusterID", "clusterset", req.NamespacedName)
-				return ctrl.Result{}, err
+				return err
 			}
 		}
-	}
-	r.clusterSetConfig = clusterSet.DeepCopy()
 
-	err = r.createOrUpdateRemoteCommonArea(clusterSet)
-	if err != nil {
+		r.clusterSetConfig = clusterSet.DeepCopy()
+
+		err = r.createRemoteCommonArea(clusterSet)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
+	if err := processClusterSet(); err != nil {
 		return ctrl.Result{}, err
 	}
 
+	if clusterSetCreated {
+		// The CommonArea creation succeeded here and so notify StaleController to
+		// clean up stale imported resources and ResourceExports.
+		r.commonAreaCreationCh <- struct{}{}
+	}
 	return ctrl.Result{}, nil
+}
+
+func (r *MemberClusterSetReconciler) cleanUpResources(ctx context.Context) error {
+	if r.remoteCommonArea != nil {
+		// Any ResourceExports belong to this member cluster will be cleaned up by the leader cluster
+		// when the MemberClusterAnnounce is deleted.
+		if err := r.deleteMemberClusterAnnounce(ctx); err != nil {
+			// MemberClusterAnnounce could be kept in the leader cluster, if antrea-mc-controller crashes after the failure.
+			// Leader cluster will delete the stale MemberClusterAnnounce with a garbage collection mechanism in this case.
+			return fmt.Errorf("failed to delete MemberClusterAnnounce in the leader cluster: %v", err)
+		}
+		r.remoteCommonArea.Stop()
+		r.remoteCommonArea = nil
+		r.clusterSetConfig = nil
+		r.installedLeader = leaderClusterInfo{}
+		r.clusterSetID = common.InvalidClusterSetID
+	}
+
+	if r.clusterID != common.InvalidClusterID {
+		klog.InfoS("Clean up all resources created by Antrea Multi-cluster Controller")
+		if err := cleanUpResourcesCreatedByMC(ctx, r.Client); err != nil {
+			return err
+		}
+		r.clusterID = common.InvalidClusterID
+	}
+	return nil
 }
 
 func (r *MemberClusterSetReconciler) deleteMemberClusterAnnounce(ctx context.Context) error {
@@ -173,31 +234,21 @@ func (r *MemberClusterSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&mcv1alpha2.ClusterSet{}).
 		WithEventFilter(generationPredicate).
 		WithOptions(controller.Options{
-			MaxConcurrentReconciles: common.DefaultWorkerCount,
+			MaxConcurrentReconciles: 1,
 		}).
 		Complete(r)
 }
 
-func (r *MemberClusterSetReconciler) createOrUpdateRemoteCommonArea(clusterSet *mcv1alpha2.ClusterSet) error {
-	currentCommonArea := r.remoteCommonArea
-	newLeader := clusterSet.Spec.Leaders[0]
+func (r *MemberClusterSetReconciler) createRemoteCommonArea(clusterSet *mcv1alpha2.ClusterSet) error {
+	if r.remoteCommonArea != nil {
+		r.remoteCommonArea.Stop()
+		r.remoteCommonArea = nil
+	}
 
+	newLeader := clusterSet.Spec.Leaders[0]
 	clusterID := common.ClusterID(newLeader.ClusterID)
 	url := newLeader.Server
 	secretName := newLeader.Secret
-
-	if currentCommonArea != nil {
-		if r.installedLeader.clusterID == newLeader.ClusterID && r.installedLeader.serverUrl == newLeader.Server &&
-			r.installedLeader.secretName == newLeader.Secret {
-			klog.V(2).InfoS("No change for leader cluster configuration")
-			return nil
-		}
-
-		klog.InfoS("ClusterSet update", "old", currentCommonArea.GetClusterID(), "new", newLeader)
-		klog.InfoS("Stopping old RemoteCommonArea", "cluster", clusterID)
-		currentCommonArea.Stop()
-		r.remoteCommonArea = nil
-	}
 
 	klog.InfoS("Creating RemoteCommonArea", "cluster", clusterID)
 	// Read Secret to access the leader cluster. Assume Secret is present in the same Namespace as the ClusterSet.
@@ -347,7 +398,10 @@ func (r *MemberClusterSetReconciler) updateStatus() {
 	clusterSet := &mcv1alpha2.ClusterSet{}
 	err := r.Get(context.TODO(), namespacedName, clusterSet)
 	if err != nil {
-		klog.ErrorS(err, "Failed to read ClusterSet", "name", namespacedName)
+		if !apierrors.IsNotFound(err) {
+			klog.ErrorS(err, "Failed to read ClusterSet", "name", namespacedName)
+		}
+		return
 	}
 	status.Conditions = clusterSet.Status.Conditions
 	if (len(clusterSet.Status.Conditions) == 1 && clusterSet.Status.Conditions[0].Status != overallCondition.Status) ||

--- a/multicluster/controllers/multicluster/member/clusterset_controller_test.go
+++ b/multicluster/controllers/multicluster/member/clusterset_controller_test.go
@@ -23,9 +23,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	k8sscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -176,7 +174,6 @@ func TestMemberClusterStatus(t *testing.T) {
 				clusterSetID:     "clusterset1",
 				clusterID:        "east",
 			}
-
 			reconciler.updateStatus()
 			clusterSet := &mcv1alpha2.ClusterSet{}
 
@@ -237,26 +234,26 @@ func TestMemberCreateOrUpdateRemoteCommonArea(t *testing.T) {
 	fakeRemoteClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithObjects(existingClusterSet, existingSecret).Build()
 	commonArea := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader1", common.LocalClusterID, "mcs1", nil)
 	reconciler := MemberClusterSetReconciler{
-		Client:           fakeClient,
-		remoteCommonArea: commonArea,
-		clusterSetConfig: existingClusterSet,
-		clusterSetID:     "clusterset1",
-		clusterID:        "east",
+		Client:                       fakeClient,
+		remoteCommonArea:             commonArea,
+		clusterSetConfig:             existingClusterSet,
+		clusterSetID:                 "clusterset1",
+		clusterID:                    "east",
+		enableStretchedNetworkPolicy: true,
 	}
-
 	mockCtrl := gomock.NewController(t)
 	mockManager := mocks.NewMockManager(mockCtrl)
-	mockManager.EXPECT().GetClient()
-	mockManager.EXPECT().GetScheme()
+	mockManager.EXPECT().GetClient().Times(2)
+	mockManager.EXPECT().GetScheme().Times(2)
 
 	getRemoteConfigAndClient = commonarea.FuncGetFakeRemoteConfigAndClient(mockManager)
 
-	err := reconciler.createOrUpdateRemoteCommonArea(existingClusterSet)
+	err := reconciler.createRemoteCommonArea(existingClusterSet)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, expectedInstalledLeader, reconciler.installedLeader)
 }
 
-func TestLeaderClusterSetAddWithoutClusterID(t *testing.T) {
+func TestMemberClusterSetAddWithoutClusterID(t *testing.T) {
 	existingSecret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "mcs1",
@@ -289,36 +286,60 @@ func TestLeaderClusterSetAddWithoutClusterID(t *testing.T) {
 		Value: "member1",
 	}
 
-	scheme := runtime.NewScheme()
-	mcv1alpha2.AddToScheme(scheme)
-	k8sscheme.AddToScheme(scheme)
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(clusterSetWithoutClusterID, clusterClaim, existingSecret).Build()
-
-	mockCtrl := gomock.NewController(t)
-	mockManager := mocks.NewMockManager(mockCtrl)
-	mockManager.EXPECT().GetClient()
-	mockManager.EXPECT().GetScheme()
-	getRemoteConfigAndClient = commonarea.FuncGetFakeRemoteConfigAndClient(mockManager)
-
-	reconciler := MemberClusterSetReconciler{
-		Client:                   fakeClient,
-		ClusterCalimCRDAvailable: true,
-	}
-	if _, err := reconciler.Reconcile(common.TestCtx, ctrl.Request{
-		NamespacedName: types.NamespacedName{
-			Namespace: "mcs1",
-			Name:      "clusterset1",
+	tests := []struct {
+		name      string
+		clusterID common.ClusterID
+	}{
+		{
+			name: "create a new ClusterSet without a clusterID",
 		},
-	}); err != nil {
-		t.Errorf("Member ClusterSet Reconciler should handle add event successfully but got error = %v", err)
-	} else {
-		assert.Equal(t, nil, err)
-		assert.Equal(t, "clusterset1", string(reconciler.clusterSetID))
-		assert.Equal(t, "member1", string(reconciler.clusterID))
+		{
+			name:      "with non-empty clusterID",
+			clusterID: common.ClusterID("cluster-a"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithObjects(clusterSetWithoutClusterID, clusterClaim, existingSecret).Build()
 
-		clusterSet := &mcv1alpha2.ClusterSet{}
-		err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: "clusterset1", Namespace: "mcs1"}, clusterSet)
-		assert.Equal(t, nil, err)
-		assert.Equal(t, "member1", clusterSet.Spec.ClusterID)
+			mockCtrl := gomock.NewController(t)
+			mockManager := mocks.NewMockManager(mockCtrl)
+			mockManager.EXPECT().GetClient()
+			mockManager.EXPECT().GetScheme()
+			getRemoteConfigAndClient = commonarea.FuncGetFakeRemoteConfigAndClient(mockManager)
+
+			reconciler := MemberClusterSetReconciler{
+				Client:                   fakeClient,
+				ClusterCalimCRDAvailable: true,
+				commonAreaCreationCh:     make(chan struct{}),
+			}
+			go func() {
+				<-reconciler.commonAreaCreationCh
+			}()
+			if tt.clusterID != "" {
+				fakeRemoteClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithObjects().Build()
+				commonArea := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader1", "clusterset1", "mcs1", nil)
+				reconciler.remoteCommonArea = commonArea
+				reconciler.clusterID = tt.clusterID
+			}
+
+			if _, err := reconciler.Reconcile(common.TestCtx, ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: "mcs1",
+					Name:      "clusterset1",
+				},
+			}); err != nil {
+				t.Errorf("Member ClusterSet Reconciler should handle add event successfully but got error = %v", err)
+			} else {
+				assert.Equal(t, nil, err)
+				assert.Equal(t, "clusterset1", string(reconciler.clusterSetID))
+				assert.Equal(t, "member1", string(reconciler.clusterID))
+
+				clusterSet := &mcv1alpha2.ClusterSet{}
+				err = fakeClient.Get(context.TODO(), types.NamespacedName{Name: "clusterset1", Namespace: "mcs1"}, clusterSet)
+				assert.Equal(t, nil, err)
+				assert.Equal(t, "member1", clusterSet.Spec.ClusterID)
+			}
+		})
 	}
 }

--- a/multicluster/controllers/multicluster/member/gateway_controller_test.go
+++ b/multicluster/controllers/multicluster/member/gateway_controller_test.go
@@ -153,7 +153,7 @@ func TestGatewayReconciler(t *testing.T) {
 			fakeRemoteClient = fake.NewClientBuilder().WithScheme(common.TestScheme).WithObjects(tt.resExport).Build()
 		}
 		commonArea := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", common.LocalClusterID, common.LeaderNamespace, nil)
-		mcReconciler := NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false, false)
+		mcReconciler := NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false, false, make(chan struct{}))
 		mcReconciler.SetRemoteCommonArea(commonArea)
 		commonAreaGatter := mcReconciler
 		r := NewGatewayReconciler(fakeClient, common.TestScheme, "default", []string{"10.200.1.1/16"}, commonAreaGatter)

--- a/multicluster/controllers/multicluster/member/labelidentity_controller_test.go
+++ b/multicluster/controllers/multicluster/member/labelidentity_controller_test.go
@@ -174,7 +174,7 @@ func TestLabelIdentityReconciler(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithLists(tt.existingPods).WithObjects(ns).Build()
 			fakeRemoteClient := fake.NewClientBuilder().WithScheme(common.TestScheme).Build()
 			commonArea := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", common.LocalClusterID, common.LeaderNamespace, nil)
-			mcReconciler := NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", true, false)
+			mcReconciler := NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", true, false, make(chan struct{}))
 			mcReconciler.SetRemoteCommonArea(commonArea)
 			r := NewLabelIdentityReconciler(fakeClient, common.TestScheme, mcReconciler)
 			go r.Run(stopCh)
@@ -241,7 +241,7 @@ func TestNamespaceMapFunc(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithObjects(podA, podC, ns).Build()
 	fakeRemoteClient := fake.NewClientBuilder().WithScheme(common.TestScheme).Build()
 	commonArea := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", common.LocalClusterID, common.LeaderNamespace, nil)
-	mcReconciler := NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", true, false)
+	mcReconciler := NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", true, false, make(chan struct{}))
 	mcReconciler.SetRemoteCommonArea(commonArea)
 
 	r := NewLabelIdentityReconciler(fakeClient, common.TestScheme, mcReconciler)

--- a/multicluster/controllers/multicluster/member/labelidentity_import_controller_test.go
+++ b/multicluster/controllers/multicluster/member/labelidentity_import_controller_test.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	mcsv1alpha1 "antrea.io/antrea/multicluster/apis/multicluster/v1alpha1"
+	"antrea.io/antrea/multicluster/controllers/multicluster/common"
 	"antrea.io/antrea/multicluster/controllers/multicluster/commonarea"
 )
 
@@ -121,10 +122,10 @@ func TestLabelIdentityResourceImportReconcile(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tt.existLabelIdentity).Build()
-			fakeRemoteClient := fake.NewClientBuilder().WithScheme(scheme).WithLists(&tt.existResImp).Build()
+			fakeClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithObjects(tt.existLabelIdentity).Build()
+			fakeRemoteClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithLists(&tt.existResImp).Build()
 			remoteCluster := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", localClusterID, "default", nil)
-			r := newLabelIdentityResourceImportReconciler(fakeClient, scheme, fakeClient, localClusterID, "default", remoteCluster)
+			r := newLabelIdentityResourceImportReconciler(fakeClient, common.TestScheme, fakeClient, localClusterID, "default", remoteCluster)
 
 			resImpReq := ctrl.Request{NamespacedName: tt.resImportNamespacedName}
 			_, err := r.Reconcile(ctx, resImpReq)

--- a/multicluster/controllers/multicluster/member/node_controller.go
+++ b/multicluster/controllers/multicluster/member/node_controller.go
@@ -199,6 +199,10 @@ func (r *NodeReconciler) updateActiveGateway(ctx context.Context, newGateway *mc
 	// TODO: cache might be stale. Need to revisit here and other reconcilers to
 	// check if we can improve this with 'Owns' or other methods.
 	if err := r.Client.Get(ctx, types.NamespacedName{Name: newGateway.Name, Namespace: r.namespace}, existingGW); err != nil {
+		if apierrors.IsNotFound(err) {
+			r.activeGateway = ""
+			return nil
+		}
 		return err
 	}
 	if existingGW.GatewayIP == newGateway.GatewayIP && existingGW.InternalIP == newGateway.InternalIP &&

--- a/multicluster/controllers/multicluster/member/serviceexport_controller_test.go
+++ b/multicluster/controllers/multicluster/member/serviceexport_controller_test.go
@@ -78,7 +78,7 @@ func TestServiceExportReconciler_handleDeleteEvent(t *testing.T) {
 	fakeRemoteClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithObjects(existSvcResExport, existEpResExport).Build()
 
 	commonArea := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", common.LocalClusterID, "default", nil)
-	mcReconciler := NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false, false)
+	mcReconciler := NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false, false, make(chan struct{}))
 	mcReconciler.SetRemoteCommonArea(commonArea)
 	r := NewServiceExportReconciler(fakeClient, common.TestScheme, mcReconciler, "ClusterIP", false)
 	r.installedSvcs.Add(&svcInfo{
@@ -273,7 +273,7 @@ func TestServiceExportReconciler_CheckExportStatus(t *testing.T) {
 	fakeRemoteClient := fake.NewClientBuilder().WithScheme(common.TestScheme).Build()
 	commonArea := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", common.LocalClusterID, "default", nil)
 
-	mcReconciler := NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false, false)
+	mcReconciler := NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false, false, make(chan struct{}))
 	mcReconciler.SetRemoteCommonArea(commonArea)
 	r := NewServiceExportReconciler(fakeClient, common.TestScheme, mcReconciler, "ClusterIP", false)
 	for _, tt := range tests {
@@ -349,7 +349,7 @@ func TestServiceExportReconciler_handleServiceExportCreateEvent(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fakeRemoteClient := fake.NewClientBuilder().WithScheme(common.TestScheme).Build()
 			commonArea := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", common.LocalClusterID, "default", nil)
-			mcReconciler := NewMemberClusterSetReconciler(tt.fakeClient, common.TestScheme, "default", false, false)
+			mcReconciler := NewMemberClusterSetReconciler(tt.fakeClient, common.TestScheme, "default", false, false, make(chan struct{}))
 			mcReconciler.SetRemoteCommonArea(commonArea)
 			r := NewServiceExportReconciler(tt.fakeClient, common.TestScheme, mcReconciler, tt.endpointIPType, tt.endpointSliceEnabled)
 			if _, err := r.Reconcile(common.TestCtx, nginxReq); err != nil {
@@ -532,7 +532,7 @@ func TestServiceExportReconciler_handleUpdateEvent(t *testing.T) {
 			fakeRemoteClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithObjects(existSvcRe, existEpRe).Build()
 
 			commonArea := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", common.LocalClusterID, "default", nil)
-			mcReconciler := NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false, false)
+			mcReconciler := NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false, false, make(chan struct{}))
 			mcReconciler.SetRemoteCommonArea(commonArea)
 			r := NewServiceExportReconciler(fakeClient, common.TestScheme, mcReconciler, tt.endpointIPType, false)
 			r.installedSvcs.Add(sinfo)

--- a/multicluster/controllers/multicluster/member/stale_controller_test.go
+++ b/multicluster/controllers/multicluster/member/stale_controller_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 Antrea Authors.
+Copyright 2023 Antrea Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,46 +14,50 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package multicluster
+package member
 
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	k8smcsv1alpha1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
+	k8smcv1alpha1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 
 	"antrea.io/antrea/multicluster/apis/multicluster/constants"
 	mcv1alpha1 "antrea.io/antrea/multicluster/apis/multicluster/v1alpha1"
 	mcv1alpha2 "antrea.io/antrea/multicluster/apis/multicluster/v1alpha2"
 	"antrea.io/antrea/multicluster/controllers/multicluster/common"
 	"antrea.io/antrea/multicluster/controllers/multicluster/commonarea"
-	"antrea.io/antrea/multicluster/controllers/multicluster/member"
 	"antrea.io/antrea/pkg/apis/crd/v1beta1"
 )
 
-var ctx = context.Background()
+var clusterSet = &mcv1alpha2.ClusterSet{
+	ObjectMeta: metav1.ObjectMeta{
+		Namespace: "default",
+		Name:      "test-cluster",
+	},
+}
 
-func TestStaleController_CleanupService(t *testing.T) {
+func TestStaleController_CleanUpService(t *testing.T) {
 	mcSvcNginx := common.SvcNginx.DeepCopy()
 	mcSvcNginx.Name = "antrea-mc-nginx"
 	mcSvcNginx.Annotations = map[string]string{common.AntreaMCServiceAnnotation: "true"}
 	mcSvcNonNginx := common.SvcNginx.DeepCopy()
 	mcSvcNginx.Name = "antrea-mc-non-nginx"
 	mcSvcNonNginx.Annotations = map[string]string{common.AntreaMCServiceAnnotation: "true"}
-	mcSvcImpNginx := k8smcsv1alpha1.ServiceImport{
+	mcSvcImpNginx := k8smcv1alpha1.ServiceImport{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
 			Name:      "nginx",
 		},
 	}
-	mcSvcImpNonNginx := k8smcsv1alpha1.ServiceImport{
+	mcSvcImpNonNginx := k8smcv1alpha1.ServiceImport{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
 			Name:      "non-nginx",
@@ -73,7 +77,7 @@ func TestStaleController_CleanupService(t *testing.T) {
 	tests := []struct {
 		name               string
 		existSvcList       *corev1.ServiceList
-		existSvcImpList    *k8smcsv1alpha1.ServiceImportList
+		existSvcImpList    *k8smcv1alpha1.ServiceImportList
 		existingResImpList *mcv1alpha1.ResourceImportList
 		wantErr            bool
 	}{
@@ -82,8 +86,8 @@ func TestStaleController_CleanupService(t *testing.T) {
 			existSvcList: &corev1.ServiceList{
 				Items: []corev1.Service{*mcSvcNginx, *mcSvcNonNginx},
 			},
-			existSvcImpList: &k8smcsv1alpha1.ServiceImportList{
-				Items: []k8smcsv1alpha1.ServiceImport{
+			existSvcImpList: &k8smcv1alpha1.ServiceImportList{
+				Items: []k8smcv1alpha1.ServiceImport{
 					mcSvcImpNginx, mcSvcImpNonNginx,
 				},
 			},
@@ -96,13 +100,14 @@ func TestStaleController_CleanupService(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fakeClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithLists(tt.existSvcList, tt.existSvcImpList).Build()
+			fakeClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithObjects(clusterSet).
+				WithLists(tt.existSvcList, tt.existSvcImpList).Build()
 			fakeRemoteClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithLists(tt.existingResImpList).Build()
 			commonArea := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", common.LocalClusterID, "default", nil)
-			mcReconciler := member.NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false, false)
+			mcReconciler := NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false, false, make(chan struct{}))
 			mcReconciler.SetRemoteCommonArea(commonArea)
-			c := NewStaleResCleanupController(fakeClient, common.TestScheme, "default", mcReconciler, MemberCluster)
-			if err := c.cleanup(ctx); err != nil {
+			c := NewStaleResCleanupController(fakeClient, common.TestScheme, make(chan struct{}), "default", mcReconciler)
+			if err := c.cleanUpStaleResources(ctx); err != nil {
 				t.Errorf("StaleController.cleanup() should clean up all stale Service and ServiceImport but got err = %v", err)
 			}
 			ctx := context.TODO()
@@ -116,7 +121,7 @@ func TestStaleController_CleanupService(t *testing.T) {
 			} else {
 				t.Errorf("Should list Service successfully but got err = %v", err)
 			}
-			svImpList := &k8smcsv1alpha1.ServiceImportList{}
+			svImpList := &k8smcv1alpha1.ServiceImportList{}
 			err = fakeClient.List(ctx, svImpList, &client.ListOptions{})
 			svcImpLen := len(svImpList.Items)
 			if err == nil {
@@ -130,7 +135,7 @@ func TestStaleController_CleanupService(t *testing.T) {
 	}
 }
 
-func TestStaleController_CleanupACNP(t *testing.T) {
+func TestStaleController_CleanUpACNP(t *testing.T) {
 	acnpImportName := "acnp-for-isolation"
 	acnpResImportName := common.LeaderNamespace + "-" + acnpImportName
 	acnpResImport := mcv1alpha1.ResourceImport{
@@ -190,14 +195,14 @@ func TestStaleController_CleanupACNP(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fakeClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithLists(tt.existingACNPList).Build()
+			fakeClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithObjects(clusterSet).WithLists(tt.existingACNPList).Build()
 			fakeRemoteClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithLists(tt.existingResImpList).Build()
 			commonArea := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", common.LocalClusterID, "default", nil)
 
-			mcReconciler := member.NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false, false)
+			mcReconciler := NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false, false, make(chan struct{}))
 			mcReconciler.SetRemoteCommonArea(commonArea)
-			c := NewStaleResCleanupController(fakeClient, common.TestScheme, "default", mcReconciler, MemberCluster)
-			if err := c.cleanup(ctx); err != nil {
+			c := NewStaleResCleanupController(fakeClient, common.TestScheme, make(chan struct{}), "default", mcReconciler)
+			if err := c.cleanUpStaleResources(ctx); err != nil {
 				t.Errorf("StaleController.cleanup() should clean up all stale ACNPs but got err = %v", err)
 			}
 			ctx := context.TODO()
@@ -216,8 +221,8 @@ func TestStaleController_CleanupACNP(t *testing.T) {
 	}
 }
 
-func TestStaleController_CleanupResourceExport(t *testing.T) {
-	svcExpNginx := k8smcsv1alpha1.ServiceExport{
+func TestStaleController_CleanUpResourceExports(t *testing.T) {
+	svcExpNginx := k8smcv1alpha1.ServiceExport{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
 			Name:      "keep-nginx",
@@ -397,7 +402,7 @@ func TestStaleController_CleanupResourceExport(t *testing.T) {
 		existPodList           *corev1.PodList
 		existNamespaceList     *corev1.NamespaceList
 		existLabelIdentityList *mcv1alpha1.LabelIdentityList
-		existSvcExpList        *k8smcsv1alpha1.ServiceExportList
+		existSvcExpList        *k8smcv1alpha1.ServiceExportList
 		existResExpList        *mcv1alpha1.ResourceExportList
 		wantErr                bool
 	}{
@@ -405,8 +410,8 @@ func TestStaleController_CleanupResourceExport(t *testing.T) {
 			name:               "clean up ResourceExport successfully",
 			existNamespaceList: existingNamespaces,
 			existPodList:       existingPods,
-			existSvcExpList: &k8smcsv1alpha1.ServiceExportList{
-				Items: []k8smcsv1alpha1.ServiceExport{
+			existSvcExpList: &k8smcv1alpha1.ServiceExportList{
+				Items: []k8smcv1alpha1.ServiceExport{
 					svcExpNginx,
 				},
 			},
@@ -427,14 +432,15 @@ func TestStaleController_CleanupResourceExport(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fakeClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithLists(tt.existSvcExpList, tt.existPodList, tt.existNamespaceList).Build()
+			fakeClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithObjects(clusterSet).
+				WithLists(tt.existSvcExpList, tt.existPodList, tt.existNamespaceList).Build()
 			fakeRemoteClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithLists(tt.existResExpList).Build()
 			commonArea := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", common.LocalClusterID, "default", nil)
 
-			mcReconciler := member.NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false, false)
+			mcReconciler := NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false, false, make(chan struct{}))
 			mcReconciler.SetRemoteCommonArea(commonArea)
-			c := NewStaleResCleanupController(fakeClient, common.TestScheme, "default", mcReconciler, MemberCluster)
-			if err := c.cleanup(ctx); err != nil {
+			c := NewStaleResCleanupController(fakeClient, common.TestScheme, make(chan struct{}), "default", mcReconciler)
+			if err := c.cleanUpStaleResources(ctx); err != nil {
 				t.Errorf("StaleController.cleanup() should clean up all stale ResourceExports but got err = %v", err)
 			}
 			resExpList := &mcv1alpha1.ResourceExportList{}
@@ -451,7 +457,7 @@ func TestStaleController_CleanupResourceExport(t *testing.T) {
 	}
 }
 
-func TestStaleController_CleanupClusterInfoImport(t *testing.T) {
+func TestStaleController_CleanUpClusterInfoImports(t *testing.T) {
 	ci := mcv1alpha1.ClusterInfo{
 		ClusterID:   "cluster-a",
 		ServiceCIDR: "10.10.1.0/16",
@@ -504,14 +510,14 @@ func TestStaleController_CleanupClusterInfoImport(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fakeClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithLists(tt.existCIImpList).Build()
+			fakeClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithObjects(clusterSet).WithLists(tt.existCIImpList).Build()
 			fakeRemoteClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithLists(tt.existingResImpList).Build()
 			commonarea := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", common.LocalClusterID, "antrea-mcs", nil)
 
-			mcReconciler := member.NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false, false)
+			mcReconciler := NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false, false, make(chan struct{}))
 			mcReconciler.SetRemoteCommonArea(commonarea)
-			c := NewStaleResCleanupController(fakeClient, common.TestScheme, "default", mcReconciler, MemberCluster)
-			if err := c.cleanup(ctx); err != nil {
+			c := NewStaleResCleanupController(fakeClient, common.TestScheme, make(chan struct{}), "default", mcReconciler)
+			if err := c.cleanUpStaleResources(ctx); err != nil {
 				t.Errorf("StaleController.cleanup() should clean up all stale ClusterInfoImport but got err = %v", err)
 			}
 			ctx := context.TODO()
@@ -529,107 +535,7 @@ func TestStaleController_CleanupClusterInfoImport(t *testing.T) {
 	}
 }
 
-func TestStaleController_CleanupMemberClusterAnnounce(t *testing.T) {
-	tests := []struct {
-		name                              string
-		memberClusterAnnounceList         *mcv1alpha1.MemberClusterAnnounceList
-		clusterSet                        *mcv1alpha2.ClusterSetList
-		exceptMemberClusterAnnounceNumber int
-	}{
-		{
-			name:                              "no MemberClusterAnnounce to clean up when there is no resource",
-			clusterSet:                        &mcv1alpha2.ClusterSetList{},
-			memberClusterAnnounceList:         &mcv1alpha1.MemberClusterAnnounceList{},
-			exceptMemberClusterAnnounceNumber: 0,
-		},
-		{
-			name:                              "no MemberClusterAnnounce to clean up when the resource has a valid update time",
-			exceptMemberClusterAnnounceNumber: 1,
-			clusterSet: &mcv1alpha2.ClusterSetList{
-				Items: []mcv1alpha2.ClusterSet{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Namespace: "default",
-							Name:      "clusterset",
-						},
-						Spec: mcv1alpha2.ClusterSetSpec{},
-					},
-				},
-			},
-			memberClusterAnnounceList: &mcv1alpha1.MemberClusterAnnounceList{
-				Items: []mcv1alpha1.MemberClusterAnnounce{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Namespace: "default",
-							Name:      "member-cluster-from-cluster-a",
-							Annotations: map[string]string{
-								commonarea.TimestampAnnotationKey: time.Now().Format(time.RFC3339),
-							},
-						},
-						ClusterID: "cluster-a",
-					},
-				},
-			},
-		},
-		{
-			name:                              "clean up outdated MemberClusterAnnounce",
-			exceptMemberClusterAnnounceNumber: 1,
-			clusterSet: &mcv1alpha2.ClusterSetList{
-				Items: []mcv1alpha2.ClusterSet{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Namespace: "default",
-							Name:      "clusterset",
-						},
-						Spec: mcv1alpha2.ClusterSetSpec{},
-					},
-				},
-			},
-			memberClusterAnnounceList: &mcv1alpha1.MemberClusterAnnounceList{
-				Items: []mcv1alpha1.MemberClusterAnnounce{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Namespace: "default",
-							Name:      "member-cluster-from-cluster-a",
-							Annotations: map[string]string{
-								commonarea.TimestampAnnotationKey: time.Now().Format(time.RFC3339),
-							},
-						},
-						ClusterID: "cluster-a",
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Namespace: "default",
-							Name:      "member-cluster-from-cluster-outdated",
-							Annotations: map[string]string{
-								commonarea.TimestampAnnotationKey: time.Now().Add(-1 * time.Hour).Format(time.RFC3339),
-							},
-						},
-						ClusterID: "cluster-outdated",
-					},
-				},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			fakeClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithLists(tt.memberClusterAnnounceList).WithLists(tt.clusterSet).Build()
-
-			mcReconciler := member.NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false, false)
-			c := NewStaleResCleanupController(fakeClient, common.TestScheme, "default", mcReconciler, LeaderCluster)
-			assert.Equal(t, nil, c.cleanup(ctx))
-
-			memberClusterAnnounceList := &mcv1alpha1.MemberClusterAnnounceList{}
-			if err := fakeClient.List(context.TODO(), memberClusterAnnounceList, &client.ListOptions{}); err != nil {
-				t.Errorf("Should list MemberClusterAnnounce successfully but got err = %v", err)
-			}
-
-			assert.Equal(t, tt.exceptMemberClusterAnnounceNumber, len(memberClusterAnnounceList.Items))
-		})
-	}
-}
-
-func TestStaleController_CleanupLabelIdentites(t *testing.T) {
+func TestStaleController_CleanUpLabelIdentites(t *testing.T) {
 	normalizedLabelA := "namespace:kubernetes.io/metadata.name=test&pod:app=client"
 	normalizedLabelB := "namespace:kubernetes.io/metadata.name=test&pod:app=db"
 	labelHashA := common.HashLabelIdentity(normalizedLabelA)
@@ -687,14 +593,14 @@ func TestStaleController_CleanupLabelIdentites(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fakeClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithLists(tt.existLabelIdentityList).Build()
+			fakeClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithObjects(clusterSet).WithLists(tt.existLabelIdentityList).Build()
 			fakeRemoteClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithLists(tt.existingResImpList).Build()
 			ca := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", common.LocalClusterID, "antrea-mcs", nil)
 
-			mcReconciler := member.NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false, false)
+			mcReconciler := NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false, false, make(chan struct{}))
 			mcReconciler.SetRemoteCommonArea(ca)
-			c := NewStaleResCleanupController(fakeClient, common.TestScheme, "default", mcReconciler, MemberCluster)
-			if err := c.cleanup(ctx); err != nil {
+			c := NewStaleResCleanupController(fakeClient, common.TestScheme, make(chan struct{}), "default", mcReconciler)
+			if err := c.cleanUpStaleResources(ctx); err != nil {
 				t.Errorf("StaleController.cleanup() should clean up all stale LabelIdentities but got err = %v", err)
 			}
 			ctx := context.TODO()
@@ -710,4 +616,171 @@ func TestStaleController_CleanupLabelIdentites(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestStaleController_CleanupAllWithEmptyClusterSet(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().WithScheme(common.TestScheme).Build()
+	fakeRemoteClient := fake.NewClientBuilder().WithScheme(common.TestScheme).Build()
+	commonarea := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", common.LocalClusterID, "antrea-mcs", nil)
+
+	mcReconciler := NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false, false, make(chan struct{}))
+	mcReconciler.SetRemoteCommonArea(commonarea)
+	c := NewStaleResCleanupController(fakeClient, common.TestScheme, make(chan struct{}), "default", mcReconciler)
+	if err := c.CleanUp(ctx); err != nil {
+		t.Errorf("StaleController.cleanup() should clean up all stale resources but got err = %v", err)
+	}
+}
+
+func TestCleanUpMCServiceAndServiceImport(t *testing.T) {
+	existingSVCs := &corev1.ServiceList{
+		Items: []corev1.Service{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "svc-a",
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "antrea-mc-svc-b",
+				},
+			},
+		},
+	}
+	existingSVCImports := &k8smcv1alpha1.ServiceImportList{
+		Items: []k8smcv1alpha1.ServiceImport{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "svc-b",
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithLists(existingSVCImports, existingSVCs).Build()
+	ctx := context.Background()
+	err := cleanUpMCServicesAndServiceImports(ctx, fakeClient)
+	require.NoError(t, err)
+	actualSvcList := &corev1.ServiceList{}
+	err = fakeClient.List(ctx, actualSvcList)
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(actualSvcList.Items))
+
+	actualSvcImpList := &k8smcv1alpha1.ServiceImportList{}
+	err = fakeClient.List(ctx, actualSvcImpList)
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(actualSvcImpList.Items))
+}
+
+func TestCleanUpReplicatedACNP(t *testing.T) {
+	acnpList := &v1beta1.ClusterNetworkPolicyList{
+		Items: []v1beta1.ClusterNetworkPolicy{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "acnp-1",
+					Annotations: map[string]string{
+						common.AntreaMCACNPAnnotation: "true",
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "acnp-2",
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithLists(acnpList).Build()
+	ctx := context.Background()
+	err := cleanUpReplicatedACNPs(ctx, fakeClient)
+	require.NoError(t, err)
+
+	actualACNPList := &v1beta1.ClusterNetworkPolicyList{}
+	err = fakeClient.List(ctx, actualACNPList, &client.ListOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(actualACNPList.Items))
+}
+
+func TestCleanUpLabelIdentities(t *testing.T) {
+	labelIdentityList := &mcv1alpha1.LabelIdentityList{
+		Items: []mcv1alpha1.LabelIdentity{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "labelidt-1",
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "labelidt-2",
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithLists(labelIdentityList).Build()
+	ctx := context.Background()
+	err := cleanUpLabelIdentities(ctx, fakeClient)
+	require.NoError(t, err)
+
+	actualIdtList := &mcv1alpha1.LabelIdentityList{}
+	err = fakeClient.List(ctx, actualIdtList, &client.ListOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(actualIdtList.Items))
+}
+
+func TestCleanUpClusterInfoImport(t *testing.T) {
+	ciImpList := &mcv1alpha1.ClusterInfoImportList{
+		Items: []mcv1alpha1.ClusterInfoImport{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "cluster-1-import",
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "cluster-2-import",
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithLists(ciImpList).Build()
+	ctx := context.Background()
+	err := cleanUpClusterInfoImports(ctx, fakeClient)
+	require.NoError(t, err)
+
+	actualCIImpList := &mcv1alpha1.ClusterInfoImportList{}
+	err = fakeClient.List(ctx, actualCIImpList, &client.ListOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(actualCIImpList.Items))
+}
+
+func TestCleanUpGateway(t *testing.T) {
+	gwList := &mcv1alpha1.GatewayList{
+		Items: []mcv1alpha1.Gateway{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "gw-1",
+				},
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithLists(gwList).Build()
+	ctx := context.Background()
+	err := cleanUpGateways(ctx, fakeClient)
+	require.NoError(t, err)
+
+	actualGWList := &mcv1alpha1.ClusterInfoImportList{}
+	err = fakeClient.List(ctx, actualGWList, &client.ListOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(actualGWList.Items))
 }

--- a/pkg/config/controller/config.go
+++ b/pkg/config/controller/config.go
@@ -83,7 +83,7 @@ type MulticlusterConfig struct {
 	// Enable Multi-cluster NetworkPolicy, including ingress rules that select peers from all
 	// clusters in a ClusterSet, and egress rules that select Multi-cluster Services.
 	EnableStretchedNetworkPolicy bool `yaml:"enableStretchedNetworkPolicy,omitempty"`
-	// The Namespace where the Antrea Multi-cluster controller is running.
+	// The Namespace where the Antrea Multi-cluster Controller is running.
 	// The default is antrea-agent's Namespace.
 	Namespace string `yaml:"namespace,omitempty"`
 }


### PR DESCRIPTION
1. Split existing stale controller into leader and member folders.
2. The new stale controller in the leader cluster will do following things:
  * Check MemberClusterAnnounce periodically in the leader cluster and
    delete the stale CR if its last timestamp annotation `touch-ts` is over 24 hours.
  * Clean up all corresponding ResourceExports when a MemberClusterAnnounce is deleted.
  * Clean up stale ResourceExports if there is no existing MemberClusterAnnounce when
    the controller is started.
  * Clean up all MemberClusterAnnounces and corresponding ResourceExports when the controller
    is started with no ClusterSet CR.
3. The ClusterSet controller in leader will remove all remaining ResourceExports and
   MemberClusterAnnounces when the ClusterSet CR is deleted in the leader cluster.
4. The new stale controller in the member cluster will do following things:
  * Clean up any stale resources when the ClusterSet is ready.
  * Clean up any stale resources when the controller is restarted.
  * Delete all local auto-generated resources when there is no ClusterSet CR when controller starts.
5. The ClusterSet controller will be responsible to remove all imported and exported
   resources for the member cluster when the ClusterSet CR is deleted.