### PR TITLE
Decouple Audit logging from AntreaPolicy feature gate

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -427,18 +427,16 @@ func run(o *Options) error {
 	asyncRuleDeleteInterval := o.pollInterval
 	antreaPolicyEnabled := features.DefaultFeatureGate.Enabled(features.AntreaPolicy)
 	antreaProxyEnabled := features.DefaultFeatureGate.Enabled(features.AntreaProxy)
-	// In Antrea agent, status manager and audit logging will automatically be enabled
-	// if AntreaPolicy feature is enabled.
+	// In Antrea agent, status manager will automatically be enabled if
+	// AntreaPolicy feature is enabled.
 	statusManagerEnabled := antreaPolicyEnabled
-	loggingEnabled := antreaPolicyEnabled
-	var auditLoggerOptions *networkpolicy.AntreaPolicyLoggerOptions
-	if loggingEnabled {
-		auditLoggerOptions = &networkpolicy.AntreaPolicyLoggerOptions{
-			MaxSize:    int(o.config.AuditLogging.MaxSize),
-			MaxBackups: int(*o.config.AuditLogging.MaxBackups),
-			MaxAge:     int(*o.config.AuditLogging.MaxAge),
-			Compress:   *o.config.AuditLogging.Compress,
-		}
+
+	var auditLoggerOptions *networkpolicy.AuditLoggerOptions
+	auditLoggerOptions = &networkpolicy.AuditLoggerOptions{
+		MaxSize:    int(o.config.AuditLogging.MaxSize),
+		MaxBackups: int(*o.config.AuditLogging.MaxBackups),
+		MaxAge:     int(*o.config.AuditLogging.MaxAge),
+		Compress:   *o.config.AuditLogging.Compress,
 	}
 
 	var gwPort, tunPort uint32

--- a/cmd/antrea-agent/options.go
+++ b/cmd/antrea-agent/options.go
@@ -695,23 +695,21 @@ func (o *Options) setMulticlusterDefaultOptions() {
 }
 
 func (o *Options) setAuditLoggingDefaultOptions() {
-	if features.DefaultFeatureGate.Enabled(features.AntreaPolicy) {
-		auditLogging := &o.config.AuditLogging
-		if auditLogging.MaxSize == 0 {
-			auditLogging.MaxSize = defaultAuditLogsMaxAge
-		}
-		if auditLogging.MaxBackups == nil {
-			maxBackups := int32(defaultAuditLogsMaxBackups)
-			auditLogging.MaxBackups = &maxBackups
-		}
-		if auditLogging.MaxAge == nil {
-			maxAge := int32(defaultAuditLogsMaxAge)
-			auditLogging.MaxAge = &maxAge
-		}
-		if auditLogging.Compress == nil {
-			compress := defaultAuditLogsCompressed
-			auditLogging.Compress = &compress
-		}
+	auditLogging := &o.config.AuditLogging
+	if auditLogging.MaxSize == 0 {
+		auditLogging.MaxSize = defaultAuditLogsMaxAge
+	}
+	if auditLogging.MaxBackups == nil {
+		maxBackups := int32(defaultAuditLogsMaxBackups)
+		auditLogging.MaxBackups = &maxBackups
+	}
+	if auditLogging.MaxAge == nil {
+		maxAge := int32(defaultAuditLogsMaxAge)
+		auditLogging.MaxAge = &maxAge
+	}
+	if auditLogging.Compress == nil {
+		compress := defaultAuditLogsCompressed
+		auditLogging.Compress = &compress
 	}
 }
 

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
@@ -111,8 +111,8 @@ type Controller struct {
 	// l7VlanIDAllocator allocates a VLAN ID for every L7 rule.
 	l7VlanIDAllocator *l7VlanIDAllocator
 	// ofClient registers packetin for Antrea Policy logging.
-	ofClient           openflow.Client
-	antreaPolicyLogger *AntreaPolicyLogger
+	ofClient    openflow.Client
+	auditLogger *AuditLogger
 	// statusManager syncs NetworkPolicy statuses with the antrea-controller.
 	// It's only for Antrea NetworkPolicies.
 	statusManager         StatusManager
@@ -147,7 +147,7 @@ func NewNetworkPolicyController(antreaClientGetter agent.AntreaClientProvider,
 	antreaProxyEnabled bool,
 	statusManagerEnabled bool,
 	multicastEnabled bool,
-	loggerOptions *AntreaPolicyLoggerOptions, // use nil to disable logging
+	loggerOptions *AuditLoggerOptions, // use nil to disable logging
 	asyncRuleDeleteInterval time.Duration,
 	dnsServerOverride string,
 	nodeType config.NodeType,
@@ -198,16 +198,16 @@ func NewNetworkPolicyController(antreaClientGetter agent.AntreaClientProvider,
 	// Wait until appliedToGroupWatcher, addressGroupWatcher and networkPolicyWatcher to receive bookmark event.
 	c.fullSyncGroup.Add(3)
 
-	if c.ofClient != nil && antreaPolicyEnabled {
+	if c.ofClient != nil {
 		// Register packetInHandler
 		c.ofClient.RegisterPacketInHandler(uint8(openflow.PacketInCategoryNP), c)
 		if loggerOptions != nil {
 			// Initialize logger for Antrea Policy audit logging
-			antreaPolicyLogger, err := newAntreaPolicyLogger(loggerOptions)
+			auditLogger, err := newAuditLogger(loggerOptions)
 			if err != nil {
 				return nil, err
 			}
-			c.antreaPolicyLogger = antreaPolicyLogger
+			c.auditLogger = auditLogger
 		}
 	}
 

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
@@ -74,7 +74,7 @@ func newTestController() (*Controller, *fake.Clientset, *mockReconciler) {
 	controller, _ := NewNetworkPolicyController(&antreaClientGetter{clientset}, nil, nil, "node1", podUpdateChannel, nil, groupCounters, ch2, true, true, true, true, false, nil, testAsyncDeleteInterval, "8.8.8.8:53", config.K8sNode, true, false, config.HostGatewayOFPort, config.DefaultTunOFPort, &config.NodeConfig{})
 	reconciler := newMockReconciler()
 	controller.reconciler = reconciler
-	controller.antreaPolicyLogger = nil
+	controller.auditLogger = nil
 	return controller, clientset, reconciler
 }
 

--- a/pkg/agent/controller/networkpolicy/packetin.go
+++ b/pkg/agent/controller/networkpolicy/packetin.go
@@ -78,12 +78,12 @@ func getMatch(matchers *ofctrl.Matchers, tableID uint8, disposition uint32) *ofc
 	}
 	// Get match from ingress/egress reg if disposition is Allow or Pass.
 	for _, table := range append(openflow.GetAntreaPolicyEgressTables(), openflow.EgressRuleTable) {
-		if tableID == table.GetID() {
+		if table.IsInitialized() && tableID == table.GetID() {
 			return getMatchRegField(matchers, openflow.TFEgressConjIDField)
 		}
 	}
 	for _, table := range append(openflow.GetAntreaPolicyIngressTables(), openflow.IngressRuleTable) {
-		if tableID == table.GetID() {
+		if table.IsInitialized() && tableID == table.GetID() {
 			return getMatchRegField(matchers, openflow.TFIngressConjIDField)
 		}
 	}
@@ -189,7 +189,7 @@ func (c *Controller) storeDenyConnection(pktIn *ofctrl.PacketIn) error {
 
 func isAntreaPolicyIngressTable(tableID uint8) bool {
 	for _, table := range openflow.GetAntreaPolicyIngressTables() {
-		if table.GetID() == tableID {
+		if table.IsInitialized() && table.GetID() == tableID {
 			return true
 		}
 	}
@@ -198,7 +198,7 @@ func isAntreaPolicyIngressTable(tableID uint8) bool {
 
 func isAntreaPolicyEgressTable(tableID uint8) bool {
 	for _, table := range openflow.GetAntreaPolicyEgressTables() {
-		if table.GetID() == tableID {
+		if table.IsInitialized() && table.GetID() == tableID {
 			return true
 		}
 	}

--- a/pkg/agent/openflow/framework.go
+++ b/pkg/agent/openflow/framework.go
@@ -152,6 +152,10 @@ func newTable(tableName string, stage binding.StageID, pipeline binding.Pipeline
 	return table
 }
 
+func (t *Table) IsInitialized() bool {
+	return t.ofTable != nil
+}
+
 func (t *Table) GetID() uint8 {
 	return t.ofTable.GetID()
 }

--- a/pkg/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller.go
@@ -438,6 +438,9 @@ func NewNetworkPolicyController(kubeClient clientset.Interface,
 	n.groupingInterface.AddEventHandler(internalGroupType, n.enqueueInternalGroup)
 	n.labelIdentityInterface.AddEventHandler(n.triggerPolicyResyncForLabelIdentityUpdates)
 	// Add handlers for NetworkPolicy events.
+	n.namespaceInformer = namespaceInformer
+	n.namespaceLister = namespaceInformer.Lister()
+	n.namespaceListerSynced = namespaceInformer.Informer().HasSynced
 	networkPolicyInformer.Informer().AddEventHandlerWithResyncPeriod(
 		cache.ResourceEventHandlerFuncs{
 			AddFunc:    n.addNetworkPolicy,
@@ -466,9 +469,6 @@ func NewNetworkPolicyController(kubeClient clientset.Interface,
 	}
 	// Register Informer and add handlers for AntreaPolicy events only if the feature is enabled.
 	if features.DefaultFeatureGate.Enabled(features.AntreaPolicy) {
-		n.namespaceInformer = namespaceInformer
-		n.namespaceLister = namespaceInformer.Lister()
-		n.namespaceListerSynced = namespaceInformer.Informer().HasSynced
 		n.serviceInformer = serviceInformer
 		n.serviceLister = serviceInformer.Lister()
 		n.serviceListerSynced = serviceInformer.Informer().HasSynced


### PR DESCRIPTION
Currently Audit logging is controlled by AntreaPolicy feature gate, but it also logs K8s NetworkPolicies.
This solution decouples Audit logging with the AntreaPolicy feature gate and renames the related objects.

Fixes #5340