### PR TITLE
Increase timeout for Flow Visibility e2e tests on Kind

### DIFF
--- a/ci/kind/test-e2e-kind.sh
+++ b/ci/kind/test-e2e-kind.sh
@@ -261,7 +261,7 @@ function run_test {
   fi
 
   if $flow_visibility; then
-      timeout="15m"
+      timeout="20m"
       flow_visibility_args="-run=TestFlowAggregator --flow-visibility"
       if $coverage; then
           $FLOWAGGREGATOR_YML_CMD --coverage | docker exec -i kind-control-plane dd of=/root/flow-aggregator-coverage.yml


### PR DESCRIPTION
From 15m to 20m.
I have seen the job fail a couple of times lately because of the timeout.