### PR TITLE
Fix unit tests for pkg/apiserver/registry/stats

### DIFF
--- a/pkg/apiserver/registry/stats/antreaclusternetworkpolicystats/rest.go
+++ b/pkg/apiserver/registry/stats/antreaclusternetworkpolicystats/rest.go
@@ -114,6 +114,10 @@ func (r *REST) Get(ctx context.Context, name string, options *metav1.GetOptions)
 
 var swaggerMetadataDescriptions = metav1.ObjectMeta{}.SwaggerDoc()
 
+func formatTimestamp(t metav1.Time) string {
+	return t.UTC().Format(time.RFC3339)
+}
+
 func (r *REST) ConvertToTable(ctx context.Context, obj runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
 	table := &metav1.Table{
 		ColumnDefinitions: tableColumnDefinitions,
@@ -131,7 +135,7 @@ func (r *REST) ConvertToTable(ctx context.Context, obj runtime.Object, tableOpti
 	var err error
 	table.Rows, err = metatable.MetaToTableRow(obj, func(obj runtime.Object, m metav1.Object, name, age string) ([]interface{}, error) {
 		stats := obj.(*statsv1alpha1.AntreaClusterNetworkPolicyStats)
-		return []interface{}{name, stats.TrafficStats.Sessions, stats.TrafficStats.Packets, stats.TrafficStats.Bytes, m.GetCreationTimestamp().Time.UTC().Format(time.RFC3339)}, nil
+		return []interface{}{name, stats.TrafficStats.Sessions, stats.TrafficStats.Packets, stats.TrafficStats.Bytes, formatTimestamp(m.GetCreationTimestamp())}, nil
 	})
 	return table, err
 }

--- a/pkg/apiserver/registry/stats/antreaclusternetworkpolicystats/rest_test.go
+++ b/pkg/apiserver/registry/stats/antreaclusternetworkpolicystats/rest_test.go
@@ -278,6 +278,7 @@ func TestRESTConvertToTable(t *testing.T) {
 			Sessions: 5,
 		},
 	}
+	expectedFormattedCreationTimestamp := stats.CreationTimestamp.UTC().Format(time.RFC3339)
 	tests := []struct {
 		name          string
 		object        runtime.Object
@@ -290,7 +291,7 @@ func TestRESTConvertToTable(t *testing.T) {
 				ColumnDefinitions: tableColumnDefinitions,
 				Rows: []metav1.TableRow{
 					{
-						Cells:  []interface{}{"bar", int64(5), int64(10), int64(2000), stats.CreationTimestamp.Format("2006-01-02T15:04:05Z")},
+						Cells:  []interface{}{"bar", int64(5), int64(10), int64(2000), expectedFormattedCreationTimestamp},
 						Object: runtime.RawExtension{Object: stats},
 					},
 				},
@@ -303,7 +304,7 @@ func TestRESTConvertToTable(t *testing.T) {
 				ColumnDefinitions: tableColumnDefinitions,
 				Rows: []metav1.TableRow{
 					{
-						Cells:  []interface{}{"bar", int64(5), int64(10), int64(2000), stats.CreationTimestamp.Format("2006-01-02T15:04:05Z")},
+						Cells:  []interface{}{"bar", int64(5), int64(10), int64(2000), expectedFormattedCreationTimestamp},
 						Object: runtime.RawExtension{Object: stats},
 					},
 				},

--- a/pkg/apiserver/registry/stats/antreanetworkpolicystats/rest.go
+++ b/pkg/apiserver/registry/stats/antreanetworkpolicystats/rest.go
@@ -120,6 +120,10 @@ func (r *REST) Get(ctx context.Context, name string, options *metav1.GetOptions)
 
 var swaggerMetadataDescriptions = metav1.ObjectMeta{}.SwaggerDoc()
 
+func formatTimestamp(t metav1.Time) string {
+	return t.UTC().Format(time.RFC3339)
+}
+
 func (r *REST) ConvertToTable(ctx context.Context, obj runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
 	table := &metav1.Table{
 		ColumnDefinitions: tableColumnDefinitions,
@@ -137,7 +141,7 @@ func (r *REST) ConvertToTable(ctx context.Context, obj runtime.Object, tableOpti
 	var err error
 	table.Rows, err = metatable.MetaToTableRow(obj, func(obj runtime.Object, m metav1.Object, name, age string) ([]interface{}, error) {
 		stats := obj.(*statsv1alpha1.AntreaNetworkPolicyStats)
-		return []interface{}{name, stats.TrafficStats.Sessions, stats.TrafficStats.Packets, stats.TrafficStats.Bytes, m.GetCreationTimestamp().Time.UTC().Format(time.RFC3339)}, nil
+		return []interface{}{name, stats.TrafficStats.Sessions, stats.TrafficStats.Packets, stats.TrafficStats.Bytes, formatTimestamp(m.GetCreationTimestamp())}, nil
 	})
 	return table, err
 }

--- a/pkg/apiserver/registry/stats/antreanetworkpolicystats/rest_test.go
+++ b/pkg/apiserver/registry/stats/antreanetworkpolicystats/rest_test.go
@@ -355,6 +355,7 @@ func TestRESTConvertToTable(t *testing.T) {
 			Sessions: 5,
 		},
 	}
+	expectedFormattedCreationTimestamp := stats.CreationTimestamp.UTC().Format(time.RFC3339)
 	tests := []struct {
 		name          string
 		object        runtime.Object
@@ -367,7 +368,7 @@ func TestRESTConvertToTable(t *testing.T) {
 				ColumnDefinitions: tableColumnDefinitions,
 				Rows: []metav1.TableRow{
 					{
-						Cells:  []interface{}{"bar", int64(5), int64(10), int64(2000), stats.CreationTimestamp.Format("2006-01-02T15:04:05Z")},
+						Cells:  []interface{}{"bar", int64(5), int64(10), int64(2000), expectedFormattedCreationTimestamp},
 						Object: runtime.RawExtension{Object: stats},
 					},
 				},
@@ -380,7 +381,7 @@ func TestRESTConvertToTable(t *testing.T) {
 				ColumnDefinitions: tableColumnDefinitions,
 				Rows: []metav1.TableRow{
 					{
-						Cells:  []interface{}{"bar", int64(5), int64(10), int64(2000), stats.CreationTimestamp.Format("2006-01-02T15:04:05Z")},
+						Cells:  []interface{}{"bar", int64(5), int64(10), int64(2000), expectedFormattedCreationTimestamp},
 						Object: runtime.RawExtension{Object: stats},
 					},
 				},

--- a/pkg/apiserver/registry/stats/networkpolicystats/rest.go
+++ b/pkg/apiserver/registry/stats/networkpolicystats/rest.go
@@ -114,6 +114,10 @@ func (r *REST) Get(ctx context.Context, name string, options *metav1.GetOptions)
 
 var swaggerMetadataDescriptions = metav1.ObjectMeta{}.SwaggerDoc()
 
+func formatTimestamp(t metav1.Time) string {
+	return t.UTC().Format(time.RFC3339)
+}
+
 func (r *REST) ConvertToTable(ctx context.Context, obj runtime.Object, tableOptions runtime.Object) (*metav1.Table, error) {
 	table := &metav1.Table{
 		ColumnDefinitions: tableColumnDefinitions,
@@ -131,7 +135,7 @@ func (r *REST) ConvertToTable(ctx context.Context, obj runtime.Object, tableOpti
 	var err error
 	table.Rows, err = metatable.MetaToTableRow(obj, func(obj runtime.Object, m metav1.Object, name, age string) ([]interface{}, error) {
 		stats := obj.(*statsv1alpha1.NetworkPolicyStats)
-		return []interface{}{name, stats.TrafficStats.Sessions, stats.TrafficStats.Packets, stats.TrafficStats.Bytes, m.GetCreationTimestamp().Time.UTC().Format(time.RFC3339)}, nil
+		return []interface{}{name, stats.TrafficStats.Sessions, stats.TrafficStats.Packets, stats.TrafficStats.Bytes, formatTimestamp(m.GetCreationTimestamp())}, nil
 	})
 	return table, err
 }

--- a/pkg/apiserver/registry/stats/networkpolicystats/rest_test.go
+++ b/pkg/apiserver/registry/stats/networkpolicystats/rest_test.go
@@ -326,6 +326,7 @@ func TestRESTConvertToTable(t *testing.T) {
 			Sessions: 5,
 		},
 	}
+	expectedFormattedCreationTimestamp := stats.CreationTimestamp.UTC().Format(time.RFC3339)
 	tests := []struct {
 		name          string
 		object        runtime.Object
@@ -338,7 +339,7 @@ func TestRESTConvertToTable(t *testing.T) {
 				ColumnDefinitions: tableColumnDefinitions,
 				Rows: []metav1.TableRow{
 					{
-						Cells:  []interface{}{"bar", int64(5), int64(10), int64(2000), stats.CreationTimestamp.Format("2006-01-02T15:04:05Z")},
+						Cells:  []interface{}{"bar", int64(5), int64(10), int64(2000), expectedFormattedCreationTimestamp},
 						Object: runtime.RawExtension{Object: stats},
 					},
 				},
@@ -351,7 +352,7 @@ func TestRESTConvertToTable(t *testing.T) {
 				ColumnDefinitions: tableColumnDefinitions,
 				Rows: []metav1.TableRow{
 					{
-						Cells:  []interface{}{"bar", int64(5), int64(10), int64(2000), stats.CreationTimestamp.Format("2006-01-02T15:04:05Z")},
+						Cells:  []interface{}{"bar", int64(5), int64(10), int64(2000), expectedFormattedCreationTimestamp},
 						Object: runtime.RawExtension{Object: stats},
 					},
 				},


### PR DESCRIPTION
Some unit tests were assuming that the clock for the test machine was using the UTC time zone. In my case, the unit tests were failing when run locally.