### PR TITLE
Add log rotation configuration for VM Agent

### DIFF
--- a/build/yamls/externalnode/conf/antrea-agent.conf
+++ b/build/yamls/externalnode/conf/antrea-agent.conf
@@ -14,6 +14,19 @@ featureGates:
 # Enable collecting support bundle files with SupportBundleCollection CRD.
   SupportBundleCollection: true
 
+# Log rotation configuration for audit logs.
+auditLogging:
+  # MaxSize is the maximum size in MB of a log file before it gets rotated.
+  maxSize: 500
+  # MaxBackups is the maximum number of old log files to retain. If set to 0,
+  # all log files will be retained (unless MaxAge causes them to be deleted).
+  maxBackups: 3
+  # MaxAge is the maximum number of days to retain old log files based on the
+  # timestamp encoded in their filename. If set to 0, old log files are not
+  # removed based on age.
+  maxAge: 28
+  # Compress enables gzip compression on rotated files.
+  compress: true
 # Name of the OpenVSwitch bridge antrea-agent will create and use.
 # Make sure it doesn't conflict with your existing OpenVSwitch bridges.
 #ovsBridge: br-int


### PR DESCRIPTION
VM Agent crashes because log rotation configuration is nil. 
This change adds log rotation configuration for VM Agent.