### PR TITLE
Fix Audit Logging options initialization in Agent

### DIFF
--- a/cmd/antrea-agent/options.go
+++ b/cmd/antrea-agent/options.go
@@ -192,6 +192,7 @@ func (o *Options) setDefaults() {
 	if o.config.AntreaProxy.DefaultLoadBalancerMode == "" {
 		o.config.AntreaProxy.DefaultLoadBalancerMode = config.LoadBalancerModeNAT.String()
 	}
+	o.setAuditLoggingDefaultOptions()
 }
 
 func (o *Options) validateTLSOptions() error {
@@ -486,25 +487,6 @@ func (o *Options) setK8sNodeDefaultOptions() {
 			o.config.Egress.MaxEgressIPsPerNode = defaultMaxEgressIPsPerNode
 		}
 	}
-
-	if features.DefaultFeatureGate.Enabled(features.AntreaPolicy) {
-		auditLogging := &o.config.AuditLogging
-		if auditLogging.MaxSize == 0 {
-			auditLogging.MaxSize = defaultAuditLogsMaxAge
-		}
-		if auditLogging.MaxBackups == nil {
-			maxBackups := int32(defaultAuditLogsMaxBackups)
-			auditLogging.MaxBackups = &maxBackups
-		}
-		if auditLogging.MaxAge == nil {
-			maxAge := int32(defaultAuditLogsMaxAge)
-			auditLogging.MaxAge = &maxAge
-		}
-		if auditLogging.Compress == nil {
-			compress := defaultAuditLogsCompressed
-			auditLogging.Compress = &compress
-		}
-	}
 }
 
 func (o *Options) validateEgressConfig(encapMode config.TrafficEncapModeType) error {
@@ -708,6 +690,27 @@ func (o *Options) setMulticlusterDefaultOptions() {
 	if trafficEncryptionModeType == config.TrafficEncryptionModeWireGuard {
 		if o.config.Multicluster.WireGuard.Port == 0 {
 			o.config.Multicluster.WireGuard.Port = apis.MulticlusterWireGuardListenPort
+		}
+	}
+}
+
+func (o *Options) setAuditLoggingDefaultOptions() {
+	if features.DefaultFeatureGate.Enabled(features.AntreaPolicy) {
+		auditLogging := &o.config.AuditLogging
+		if auditLogging.MaxSize == 0 {
+			auditLogging.MaxSize = defaultAuditLogsMaxAge
+		}
+		if auditLogging.MaxBackups == nil {
+			maxBackups := int32(defaultAuditLogsMaxBackups)
+			auditLogging.MaxBackups = &maxBackups
+		}
+		if auditLogging.MaxAge == nil {
+			maxAge := int32(defaultAuditLogsMaxAge)
+			auditLogging.MaxAge = &maxAge
+		}
+		if auditLogging.Compress == nil {
+			compress := defaultAuditLogsCompressed
+			auditLogging.Compress = &compress
 		}
 	}
 }

--- a/pkg/agent/controller/networkpolicy/audit_logging.go
+++ b/pkg/agent/controller/networkpolicy/audit_logging.go
@@ -193,7 +193,7 @@ func newAntreaPolicyLogger(options *AntreaPolicyLoggerOptions) (*AntreaPolicyLog
 		anpLogger:        log.New(logOutput, "", log.Ldate|log.Lmicroseconds),
 		logDeduplication: logRecordDedupMap{logMap: make(map[string]*logDedupRecord)},
 	}
-	klog.InfoS("Initialized Antrea-native Policy Logger for audit logging", "logFile", logFile)
+	klog.InfoS("Initialized Antrea-native Policy Logger for audit logging", "logFile", logFile, "options", options)
 	return antreaPolicyLogger, nil
 }
 

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
@@ -202,7 +202,7 @@ func NewNetworkPolicyController(antreaClientGetter agent.AntreaClientProvider,
 		// Register packetInHandler
 		c.ofClient.RegisterPacketInHandler(uint8(openflow.PacketInCategoryNP), c)
 		if loggerOptions != nil {
-			// Initiate logger for Antrea Policy audit logging
+			// Initialize logger for Antrea Policy audit logging
 			antreaPolicyLogger, err := newAntreaPolicyLogger(loggerOptions)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
The initialization was in setK8sNodeDefaultOptions, which is incorrect, as it also applies to the VM / ExternalNode case.