### PR TITLE
Fix missing protocol in service when processing ANP named ports

### DIFF
--- a/pkg/agent/controller/networkpolicy/reconciler.go
+++ b/pkg/agent/controller/networkpolicy/reconciler.go
@@ -1292,7 +1292,12 @@ func resolveService(service *v1beta2.Service, member *v1beta2.GroupMember) *v1be
 		// as the port name is matched.
 		if port.Name == service.Port.StrVal && (service.Protocol == nil || port.Protocol == *service.Protocol) {
 			resolvedPort := intstr.FromInt(int(port.Port))
-			return &v1beta2.Service{Protocol: service.Protocol, Port: &resolvedPort}
+			resolvedProtocol := service.Protocol
+			if resolvedProtocol == nil {
+				// Derive named port protocol from the container spec
+				resolvedProtocol = &port.Protocol
+			}
+			return &v1beta2.Service{Protocol: resolvedProtocol, Port: &resolvedPort}
 		}
 	}
 	klog.InfoS("Cannot resolve Service port for endpoints", "port", service.Port.StrVal, "member", member)

--- a/pkg/controller/networkpolicy/adminnetworkpolicy.go
+++ b/pkg/controller/networkpolicy/adminnetworkpolicy.go
@@ -64,7 +64,7 @@ func getBANPReference(banp *v1alpha1.BaselineAdminNetworkPolicy) *controlplane.N
 func (n *NetworkPolicyController) addAdminNP(obj interface{}) {
 	defer n.heartbeat("addAdminNP")
 	anp := obj.(*v1alpha1.AdminNetworkPolicy)
-	klog.V(2).InfoS("Processing AdminNetworkPolicy ADD event", "anp", anp.Name)
+	klog.InfoS("Processing AdminNetworkPolicy ADD event", "anp", anp.Name)
 	n.enqueueInternalNetworkPolicy(getAdminNPReference(anp))
 }
 
@@ -73,7 +73,7 @@ func (n *NetworkPolicyController) addAdminNP(obj interface{}) {
 func (n *NetworkPolicyController) updateAdminNP(_, cur interface{}) {
 	defer n.heartbeat("updateAdminNP")
 	curANP := cur.(*v1alpha1.AdminNetworkPolicy)
-	klog.V(2).InfoS("Processing AdminNetworkPolicy UPDATE event", "anp", curANP.Name)
+	klog.InfoS("Processing AdminNetworkPolicy UPDATE event", "anp", curANP.Name)
 	n.enqueueInternalNetworkPolicy(getAdminNPReference(curANP))
 }
 
@@ -94,7 +94,7 @@ func (n *NetworkPolicyController) deleteAdminNP(old interface{}) {
 		}
 	}
 	defer n.heartbeat("deleteAdminNP")
-	klog.V(2).InfoS("Processing AdminNetworkPolicy DELETE event", "anp", anp.Name)
+	klog.InfoS("Processing AdminNetworkPolicy DELETE event", "anp", anp.Name)
 	n.enqueueInternalNetworkPolicy(getAdminNPReference(anp))
 }
 
@@ -103,7 +103,7 @@ func (n *NetworkPolicyController) deleteAdminNP(old interface{}) {
 func (n *NetworkPolicyController) addBANP(obj interface{}) {
 	defer n.heartbeat("addBANP")
 	banp := obj.(*v1alpha1.BaselineAdminNetworkPolicy)
-	klog.V(2).InfoS("Processing BaselineAdminNetworkPolicy ADD event", "banp", banp.Name)
+	klog.InfoS("Processing BaselineAdminNetworkPolicy ADD event", "banp", banp.Name)
 	n.enqueueInternalNetworkPolicy(getBANPReference(banp))
 }
 
@@ -112,7 +112,7 @@ func (n *NetworkPolicyController) addBANP(obj interface{}) {
 func (n *NetworkPolicyController) updateBANP(_, cur interface{}) {
 	defer n.heartbeat("updateBANP")
 	curBANP := cur.(*v1alpha1.BaselineAdminNetworkPolicy)
-	klog.V(2).InfoS("Processing BaselineAdminNetworkPolicy UPDATE event", "banp", curBANP.Name)
+	klog.InfoS("Processing BaselineAdminNetworkPolicy UPDATE event", "banp", curBANP.Name)
 	n.enqueueInternalNetworkPolicy(getBANPReference(curBANP))
 }
 
@@ -133,7 +133,7 @@ func (n *NetworkPolicyController) deleteBANP(old interface{}) {
 		}
 	}
 	defer n.heartbeat("deleteBANP")
-	klog.V(2).InfoS("Processing BaselineAdminNetworkPolicy DELETE event", "banp", banp.Name)
+	klog.InfoS("Processing BaselineAdminNetworkPolicy DELETE event", "banp", banp.Name)
 	n.enqueueInternalNetworkPolicy(getBANPReference(banp))
 }
 


### PR DESCRIPTION
When processing AdminNetworkPolicy and BaselineAdminNetworkPolicy named port rules, the ports section will not have protocol specified. Antrea agent should infer the protocol from the container spec so that rule can be enforced correctly in ovs.
Change has been verified with https://github.com/kubernetes-sigs/network-policy-api/pull/132