### PR TITLE
Add Namespace field selector in cache to filter Gateway and ClusterSet

### DIFF
--- a/multicluster/cmd/multicluster-controller/controller.go
+++ b/multicluster/cmd/multicluster-controller/controller.go
@@ -18,14 +18,14 @@ import (
 	"fmt"
 	"time"
 
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	apiextensionclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	genericoptions "k8s.io/apiserver/pkg/server/options"
 	clientset "k8s.io/client-go/kubernetes"
@@ -34,6 +34,7 @@ import (
 	"k8s.io/klog/v2"
 	aggregatorclientset "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -161,6 +162,18 @@ func setupManagerAndCertController(isLeader bool, o *Options) (manager.Manager, 
 	} else {
 		o.options.CertDir = certDir
 	}
+
+	namespaceFieldSelector := fields.SelectorFromSet(fields.Set{"metadata.namespace": env.GetPodNamespace()})
+	o.options.NewCache = cache.BuilderWithOptions(cache.Options{
+		SelectorsByObject: cache.SelectorsByObject{
+			&mcv1alpha1.Gateway{}: {
+				Field: namespaceFieldSelector,
+			},
+			&mcv1alpha2.ClusterSet{}: {
+				Field: namespaceFieldSelector,
+			},
+		},
+	})
 
 	// EndpointSlice is enabled in AntreaProxy by default since v1.11, so Antrea MC
 	// will use EndpointSlice API by default to keep consistent with AntreaProxy.

--- a/multicluster/controllers/multicluster/member/clusterset_controller.go
+++ b/multicluster/controllers/multicluster/member/clusterset_controller.go
@@ -167,22 +167,11 @@ func (r *MemberClusterSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		}
 	}()
 
-	// Only register this controller to reconcile the ClusterSet in the same Namespace
-	namespaceFilter := func(object client.Object) bool {
-		if clusterSet, ok := object.(*mcv1alpha2.ClusterSet); ok {
-			return clusterSet.Namespace == r.Namespace
-		}
-		return false
-	}
-	namespacePredicate := predicate.NewPredicateFuncs(namespaceFilter)
-
 	// Ignore status update event via GenerationChangedPredicate
 	generationPredicate := predicate.GenerationChangedPredicate{}
-	filter := predicate.And(generationPredicate, namespacePredicate)
-
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&mcv1alpha2.ClusterSet{}).
-		WithEventFilter(filter).
+		WithEventFilter(generationPredicate).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: common.DefaultWorkerCount,
 		}).


### PR DESCRIPTION
Use the Namespace field selector to filter Gateway and ClusterSet events
via "NewCache" to minimize unnecessary event handling.