### PR TITLE
Refine the flow matching packets from local gateway in SpoofGuardTable

### DIFF
--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -1661,6 +1661,7 @@ func (f *featurePodConnectivity) gatewayIPSpoofGuardFlows() []binding.Flow {
 			Cookie(cookieID).
 			MatchProtocol(ipProtocol).
 			MatchInPort(f.gatewayPort).
+			MatchSrcMAC(f.nodeConfig.GatewayConfig.MAC).
 			Action().LoadRegMark(regMarksToLoad...).
 			Action().GotoTable(targetTables[ipProtocol]).
 			Done(),

--- a/pkg/agent/openflow/pod_connectivity_test.go
+++ b/pkg/agent/openflow/pod_connectivity_test.go
@@ -33,7 +33,7 @@ func podConnectivityInitFlows(trafficEncapMode config.TrafficEncapModeType, conn
 				"cookie=0x1010000000000, table=Classifier, priority=210,ipv6,in_port=2,ipv6_src=fec0:10:10::1 actions=set_field:0x2/0xf->reg0,goto_table:SpoofGuard",
 				"cookie=0x1010000000000, table=Classifier, priority=200,in_port=2 actions=set_field:0x2/0xf->reg0,set_field:0x8000000/0x8000000->reg4,goto_table:SpoofGuard",
 				"cookie=0x1010000000000, table=SpoofGuard, priority=200,ipv6,ipv6_src=fe80::/10 actions=goto_table:IPv6",
-				"cookie=0x1010000000000, table=SpoofGuard, priority=200,ipv6,in_port=2 actions=goto_table:IPv6",
+				"cookie=0x1010000000000, table=SpoofGuard, priority=200,ipv6,in_port=2,dl_src=0a:00:00:00:00:01 actions=goto_table:IPv6",
 				"cookie=0x1010000000000, table=IPv6, priority=200,icmp6,icmp_type=135,icmp_code=0 actions=NORMAL",
 				"cookie=0x1010000000000, table=IPv6, priority=200,icmp6,icmp_type=136,icmp_code=0 actions=NORMAL",
 				"cookie=0x1010000000000, table=IPv6, priority=200,ipv6,ipv6_dst=ff00::/8 actions=NORMAL",
@@ -74,9 +74,9 @@ func podConnectivityInitFlows(trafficEncapMode config.TrafficEncapModeType, conn
 			"cookie=0x1010000000000, table=Output, priority=200,reg0=0x200000/0x600000 actions=output:NXM_NX_REG1[]",
 		}
 		if !multicastEnabled {
-			flows = append(flows, "cookie=0x1010000000000, table=SpoofGuard, priority=200,ip,in_port=2 actions=goto_table:UnSNAT")
+			flows = append(flows, "cookie=0x1010000000000, table=SpoofGuard, priority=200,ip,in_port=2,dl_src=0a:00:00:00:00:01 actions=goto_table:UnSNAT")
 		} else {
-			flows = append(flows, "cookie=0x1010000000000, table=SpoofGuard, priority=200,ip,in_port=2 actions=goto_table:PipelineIPClassifier")
+			flows = append(flows, "cookie=0x1010000000000, table=SpoofGuard, priority=200,ip,in_port=2,dl_src=0a:00:00:00:00:01 actions=goto_table:PipelineIPClassifier")
 		}
 		if runtime.IsWindowsPlatform() {
 			flows = append(flows,
@@ -109,7 +109,7 @@ func podConnectivityInitFlows(trafficEncapMode config.TrafficEncapModeType, conn
 		if !isIPv4 {
 			return []string{
 				"cookie=0x1010000000000, table=SpoofGuard, priority=200,ipv6,ipv6_src=fe80::/10 actions=goto_table:IPv6",
-				"cookie=0x1010000000000, table=SpoofGuard, priority=200,ipv6,in_port=2 actions=goto_table:IPv6",
+				"cookie=0x1010000000000, table=SpoofGuard, priority=200,ipv6,in_port=2,dl_src=0a:00:00:00:00:01 actions=goto_table:IPv6",
 				"cookie=0x1010000000000, table=IPv6, priority=200,icmp6,icmp_type=135,icmp_code=0 actions=NORMAL",
 				"cookie=0x1010000000000, table=IPv6, priority=200,icmp6,icmp_type=136,icmp_code=0 actions=NORMAL",
 				"cookie=0x1010000000000, table=IPv6, priority=200,ipv6,ipv6_dst=ff00::/8 actions=NORMAL",
@@ -182,11 +182,11 @@ func podConnectivityInitFlows(trafficEncapMode config.TrafficEncapModeType, conn
 				)
 				if !multicastEnabled {
 					flows = append(flows,
-						"cookie=0x1010000000000, table=SpoofGuard, priority=200,ip,in_port=2 actions=set_field:0x1000/0xf000->reg8,goto_table:UnSNAT",
+						"cookie=0x1010000000000, table=SpoofGuard, priority=200,ip,in_port=2,dl_src=0a:00:00:00:00:01 actions=set_field:0x1000/0xf000->reg8,goto_table:UnSNAT",
 					)
 				} else {
 					flows = append(flows,
-						"cookie=0x1010000000000, table=SpoofGuard, priority=200,ip,in_port=2 actions=set_field:0x1000/0xf000->reg8,goto_table:PipelineIPClassifier",
+						"cookie=0x1010000000000, table=SpoofGuard, priority=200,ip,in_port=2,dl_src=0a:00:00:00:00:01 actions=set_field:0x1000/0xf000->reg8,goto_table:PipelineIPClassifier",
 					)
 				}
 			} else {
@@ -197,11 +197,11 @@ func podConnectivityInitFlows(trafficEncapMode config.TrafficEncapModeType, conn
 				)
 				if !multicastEnabled {
 					flows = append(flows,
-						"cookie=0x1010000000000, table=SpoofGuard, priority=200,ip,in_port=2 actions=goto_table:UnSNAT",
+						"cookie=0x1010000000000, table=SpoofGuard, priority=200,ip,in_port=2,dl_src=0a:00:00:00:00:01 actions=goto_table:UnSNAT",
 					)
 				} else {
 					flows = append(flows,
-						"cookie=0x1010000000000, table=SpoofGuard, priority=200,ip,in_port=2 actions=goto_table:PipelineIPClassifier",
+						"cookie=0x1010000000000, table=SpoofGuard, priority=200,ip,in_port=2,dl_src=0a:00:00:00:00:01 actions=goto_table:PipelineIPClassifier",
 					)
 				}
 			}
@@ -222,7 +222,7 @@ func podConnectivityInitFlows(trafficEncapMode config.TrafficEncapModeType, conn
 		if !isIPv4 {
 			return []string{
 				"cookie=0x1010000000000, table=SpoofGuard, priority=200,ipv6,ipv6_src=fe80::/10 actions=goto_table:IPv6",
-				"cookie=0x1010000000000, table=SpoofGuard, priority=200,ipv6,in_port=2 actions=goto_table:IPv6",
+				"cookie=0x1010000000000, table=SpoofGuard, priority=200,ipv6,in_port=2,dl_src=0a:00:00:00:00:01 actions=goto_table:IPv6",
 				"cookie=0x1010000000000, table=IPv6, priority=200,icmp6,icmp_type=135,icmp_code=0 actions=NORMAL",
 				"cookie=0x1010000000000, table=IPv6, priority=200,icmp6,icmp_type=136,icmp_code=0 actions=NORMAL",
 				"cookie=0x1010000000000, table=IPv6, priority=200,ipv6,ipv6_dst=ff00::/8 actions=NORMAL",
@@ -250,7 +250,7 @@ func podConnectivityInitFlows(trafficEncapMode config.TrafficEncapModeType, conn
 			"cookie=0x1010000000000, table=ARPResponder, priority=190,arp actions=NORMAL",
 			"cookie=0x1010000000000, table=Classifier, priority=210,ip,in_port=2,nw_src=10.10.0.1 actions=set_field:0x2/0xf->reg0,goto_table:SpoofGuard",
 			"cookie=0x1010000000000, table=Classifier, priority=200,in_port=2 actions=set_field:0x2/0xf->reg0,set_field:0x8000000/0x8000000->reg4,goto_table:SpoofGuard",
-			"cookie=0x1010000000000, table=SpoofGuard, priority=200,ip,in_port=2 actions=goto_table:UnSNAT",
+			"cookie=0x1010000000000, table=SpoofGuard, priority=200,ip,in_port=2,dl_src=0a:00:00:00:00:01 actions=goto_table:UnSNAT",
 			"cookie=0x1010000000000, table=ConntrackZone, priority=200,ip actions=ct(table=ConntrackState,zone=65520,nat)",
 			"cookie=0x1010000000000, table=ConntrackState, priority=200,ct_state=+inv+trk,ip actions=drop",
 			"cookie=0x1010000000000, table=ConntrackState, priority=190,ct_state=-new+trk,ct_mark=0x0/0x10,ip actions=goto_table:AntreaPolicyEgressRule",


### PR DESCRIPTION
For regular packets through local Antrea gateway, the source MAC address should be local gateway's, but the source IP address could be:

- Local Antrea gateway IP.
- Local Pod IP. When Antrea deployed with kube-proxy, packets from local Pods destined to Services will first go through the gateway, get load-balanced by the kube-proxy datapath (DNAT) then sent back through the gateway. This means that legitimate traffic can be received on the gateway port with a source IP belonging to a local Pod.
- Remote client IP. When both AntreaProxy and proxyAll are enabled, packets from external client destined to Services' external IPs will go through the gateway without changing source IP address.
- Remote Pod or remote gateway IP. When noEncap is enabled, packets from remote Pods or remote gateway destined for local Pods will go through the gateway.

As a result, we should check the source MAC address of the packets through local gateway. Since the source IP address of the packets could be different and unpredictable in some cases, we don't check it.