### PR TITLE
Add hostAliases to Helm values for Flow Aggregator

### DIFF
--- a/build/charts/flow-aggregator/README.md
+++ b/build/charts/flow-aggregator/README.md
@@ -45,6 +45,7 @@ Kubernetes: `>= 1.16.0-0`
 | flowLogger.path | string | `"/tmp/antrea-flows.log"` | Path is the path to the local log file. |
 | flowLogger.prettyPrint | bool | `true` | PrettyPrint enables conversion of some numeric fields to a more meaningful string representation. |
 | flowLogger.recordFormat | string | `"CSV"` | RecordFormat defines the format of the flow records logged to file. Only "CSV" is supported at the moment. |
+| hostAliases | list | `[]` | HostAliases to be injected into the Pod's hosts file. For example: `[{"ip": "8.8.8.8", "hostnames": ["clickhouse.example.com"]}]` |
 | image | object | `{"pullPolicy":"IfNotPresent","repository":"antrea/flow-aggregator","tag":""}` | Container image used by Flow Aggregator. |
 | inactiveFlowRecordTimeout | string | `"90s"` | Provide the inactive flow record timeout as a duration string. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". |
 | logVerbosity | int | `0` | Log verbosity switch for Flow Aggregator. |

--- a/build/charts/flow-aggregator/templates/deployment.yaml
+++ b/build/charts/flow-aggregator/templates/deployment.yaml
@@ -15,6 +15,14 @@ spec:
       labels:
         app: flow-aggregator
     spec:
+      hostAliases:
+      {{- range .Values.hostAliases }}
+        - ip: {{ .ip }}
+          hostnames:
+          {{- range $hostname := .hostnames }}
+            - {{ $hostname }}
+          {{- end }}
+      {{- end }}
       containers:
       - name: flow-aggregator
         image: {{ include "flowAggregatorImage" . | quote }}

--- a/build/charts/flow-aggregator/values.yaml
+++ b/build/charts/flow-aggregator/values.yaml
@@ -18,6 +18,9 @@ flowAggregatorAddress: ""
 recordContents:
   # -- Determine whether source and destination Pod labels will be included in the flow records.
   podLabels: false
+# -- HostAliases to be injected into the Pod's hosts file.
+# For example: `[{"ip": "8.8.8.8", "hostnames": ["clickhouse.example.com"]}]`
+hostAliases: []
 # apiServer contains APIServer related configuration options.
 apiServer:
   # -- The port for the Flow Aggregator APIServer to serve on.

--- a/build/yamls/flow-aggregator.yml
+++ b/build/yamls/flow-aggregator.yml
@@ -450,6 +450,7 @@ spec:
           name: host-var-log-antrea-flow-aggregator
         - mountPath: /etc/flow-aggregator/certs
           name: clickhouse-ca
+      hostAliases: null
       nodeSelector:
         kubernetes.io/arch: amd64
         kubernetes.io/os: linux


### PR DESCRIPTION
Add hostAliases to Helm values for Flow Aggregator
User might want to use hostAliases field when connecting Flow Aggregator to ClickHouse through Ingress/LoadBalancer.
It is also convenient for e2e test.

Signed-off-by: Yun-Tang Hsu <hsuy@vmware.com>