### PR TITLE
Add a new all-in-one manifest for the Multi-cluster leader cluster

### DIFF
--- a/ci/jenkins/test-mc.sh
+++ b/ci/jenkins/test-mc.sh
@@ -198,7 +198,6 @@ function wait_for_multicluster_controller_ready {
     export leader_cluster_pod_cidr
     perl -0777 -pi -e 's|    podCIDRs\:\n      - \"\"|    podCIDRs\:\n      - $ENV{leader_cluster_pod_cidr}|g' ./multicluster/test/yamls/leader-manifest.yml
     kubectl create ns antrea-multicluster  "${LEADER_CLUSTER_CONFIG}" || true
-    kubectl apply -f ./multicluster/build/yamls/antrea-multicluster-leader-global.yml "${LEADER_CLUSTER_CONFIG}"
     kubectl apply -f ./multicluster/test/yamls/leader-manifest.yml "${LEADER_CLUSTER_CONFIG}"
     kubectl rollout status deployment/antrea-mc-controller -n antrea-multicluster "${LEADER_CLUSTER_CONFIG}" || true
     kubectl create -f ./multicluster/test/yamls/leader-access-token-secret.yml "${LEADER_CLUSTER_CONFIG}" || true

--- a/docs/multicluster/user-guide.md
+++ b/docs/multicluster/user-guide.md
@@ -117,19 +117,13 @@ To deploy Multi-cluster Controller in a dual-role cluster, please refer to
 
 #### Deploy in a Dedicated Leader Cluster
 
-1. Run the following command to import Multi-cluster CRDs in the leader cluster:
-
-   ```bash
-   kubectl apply -f https://github.com/antrea-io/antrea/releases/download/$TAG/antrea-multicluster-leader-global.yml
-   ```
-
-2. Install Multi-cluster Controller in the leader cluster. Since Multi-cluster
-   Controller runs as a namespaced Deployment, you should create the Namespace
-   first, and then apply the deployment manifest with the Namespace.
+Run the following command to install Multi-cluster Controller in the leader cluster.
+Multi-cluster Controller is deployed into a Namespace. You must create the Namespace
+first, and then apply the deployment manifest in the Namespace.
 
    ```bash
    kubectl create ns antrea-multicluster
-   kubectl apply -f https://github.com/antrea-io/antrea/releases/download/$TAG/antrea-multicluster-leader-namespaced.yml
+   kubectl apply -f https://github.com/antrea-io/antrea/releases/download/$TAG/antrea-multicluster-leader.yml
    ```
 
 The Multi-cluster Controller in the leader cluster will be deployed in Namespace `antrea-multicluster`

--- a/hack/release/prepare-assets.sh
+++ b/hack/release/prepare-assets.sh
@@ -119,7 +119,8 @@ export IMG_NAME=projects.registry.vmware.com/antrea/flow-aggregator
 export IMG_NAME=projects.registry.vmware.com/antrea/antrea-mc-controller
 cd multicluster
 ./hack/generate-manifest.sh -g > "$OUTPUT_DIR"/antrea-multicluster-leader-global.yml
-./hack/generate-manifest.sh -r -l antrea-multicluster > "$OUTPUT_DIR"/antrea-multicluster-leader-namespaced.yml
+./hack/generate-manifest.sh -r -n antrea-multicluster > "$OUTPUT_DIR"/antrea-multicluster-leader-namespaced.yml
+./hack/generate-manifest.sh -r -l antrea-multicluster > "$OUTPUT_DIR"/antrea-multicluster-leader.yml
 ./hack/generate-manifest.sh -r -m > "$OUTPUT_DIR"/antrea-multicluster-member.yml
 cd -
 

--- a/multicluster/Makefile
+++ b/multicluster/Makefile
@@ -49,7 +49,8 @@ help: ## Display this help.
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=controller-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 	$(CURDIR)/hack/generate-manifest.sh -g > build/yamls/antrea-multicluster-leader-global.yml
-	$(CURDIR)/hack/generate-manifest.sh -l antrea-multicluster > build/yamls/antrea-multicluster-leader-namespaced.yml
+	$(CURDIR)/hack/generate-manifest.sh -n antrea-multicluster > build/yamls/antrea-multicluster-leader-namespaced.yml
+	$(CURDIR)/hack/generate-manifest.sh -l antrea-multicluster > build/yamls/antrea-multicluster-leader.yml
 	$(CURDIR)/hack/generate-manifest.sh -m > build/yamls/antrea-multicluster-member.yml
 	$(CURDIR)/hack/update-checksum.sh
 

--- a/multicluster/build/yamls/antrea-multicluster-leader.yml
+++ b/multicluster/build/yamls/antrea-multicluster-leader.yml
@@ -1,0 +1,6251 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.0
+  creationTimestamp: null
+  labels:
+    app: antrea
+  name: clustersets.multicluster.crd.antrea.io
+spec:
+  group: multicluster.crd.antrea.io
+  names:
+    kind: ClusterSet
+    listKind: ClusterSetList
+    plural: clustersets
+    singular: clusterset
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The leader cluster Namespace for the ClusterSet
+      jsonPath: .spec.namespace
+      name: Leader Cluster Namespace
+      type: string
+    - description: Total number of clusters in the ClusterSet
+      jsonPath: .status.totalClusters
+      name: Total Clusters
+      type: string
+    - description: Number of ready clusters in the ClusterSet
+      jsonPath: .status.readyClusters
+      name: Ready Clusters
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClusterSet represents a ClusterSet.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterSetSpec defines the desired state of ClusterSet.
+            properties:
+              leaders:
+                description: Leaders include leader clusters known to the member clusters.
+                items:
+                  description: MemberCluster defines member cluster information.
+                  properties:
+                    clusterID:
+                      description: Identify member cluster in ClusterSet.
+                      type: string
+                    secret:
+                      description: Secret name to access API server of the member
+                        from the leader cluster.
+                      type: string
+                    server:
+                      description: API server of the destination cluster.
+                      type: string
+                    serviceAccount:
+                      description: ServiceAccount used by the member cluster to access
+                        into leader cluster.
+                      type: string
+                  type: object
+                maxItems: 1
+                minItems: 1
+                type: array
+              members:
+                description: Members include member clusters known to the leader clusters.
+                  Used in leader cluster.
+                items:
+                  description: MemberCluster defines member cluster information.
+                  properties:
+                    clusterID:
+                      description: Identify member cluster in ClusterSet.
+                      type: string
+                    secret:
+                      description: Secret name to access API server of the member
+                        from the leader cluster.
+                      type: string
+                    server:
+                      description: API server of the destination cluster.
+                      type: string
+                    serviceAccount:
+                      description: ServiceAccount used by the member cluster to access
+                        into leader cluster.
+                      type: string
+                  type: object
+                type: array
+              namespace:
+                description: The leader cluster Namespace in which the ClusterSet
+                  is defined. Used in member cluster.
+                type: string
+            required:
+            - leaders
+            type: object
+          status:
+            description: ClusterSetStatus defines the observed state of ClusterSet.
+            properties:
+              clusterStatuses:
+                description: The status of individual member clusters.
+                items:
+                  properties:
+                    clusterID:
+                      description: ClusterID is the unique identifier of this cluster.
+                      type: string
+                    conditions:
+                      items:
+                        description: ClusterCondition indicates the readiness condition
+                          of a cluster.
+                        properties:
+                          lastTransitionTime:
+                            description: Last time the condition transited from one
+                              status to another.
+                            format: date-time
+                            type: string
+                          message:
+                            description: A human readable message indicating details
+                              about the transition.
+                            type: string
+                          reason:
+                            description: Unique, one-word, CamelCase reason for the
+                              condition's last transition.
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False,
+                              Unknown.
+                            type: string
+                          type:
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              conditions:
+                description: The overall condition of the cluster set.
+                items:
+                  description: ClusterSetCondition indicates the readiness condition
+                    of the clusterSet.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transited from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      type: string
+                  type: object
+                type: array
+              observedGeneration:
+                description: The generation observed by the controller.
+                format: int64
+                type: integer
+              readyClusters:
+                description: Total number of clusters ready and connected.
+                format: int32
+                type: integer
+              totalClusters:
+                description: Total number of member clusters configured in the ClusterSet.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: The leader cluster Namespace for the ClusterSet
+      jsonPath: .spec.namespace
+      name: Leader Cluster Namespace
+      type: string
+    - description: Total number of clusters in the ClusterSet
+      jsonPath: .status.totalClusters
+      name: Total Clusters
+      type: string
+    - description: Number of ready clusters in the ClusterSet
+      jsonPath: .status.readyClusters
+      name: Ready Clusters
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: ClusterSet represents a ClusterSet.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterSetSpec defines the desired state of ClusterSet.
+            properties:
+              clusterID:
+                description: ClusterID identifies the local cluster.
+                type: string
+              leaders:
+                description: Leaders include leader clusters known to the member clusters.
+                items:
+                  description: LeaderClusterInfo specifies information of a leader
+                    cluster.
+                  properties:
+                    clusterID:
+                      description: Identify a leader cluster in the ClusterSet.
+                      type: string
+                    secret:
+                      description: Name of the Secret resource in the member cluster,
+                        which stores the token to access the leader cluster's API
+                        server.
+                      type: string
+                    server:
+                      description: API server endpoint of the leader cluster. E.g.
+                        "https://172.18.0.1:6443", "https://example.com:6443".
+                      type: string
+                    serviceAccount:
+                      description: "ServiceAccount in the leader cluster, from which
+                        the member cluster's token is generated. This is an optional
+                        field which helps admin to check which ServiceAccount is used
+                        by a member cluster to access the leader cluster. \n DEPRECATED
+                        This field is planned to be removed in the future releases."
+                      type: string
+                  type: object
+                maxItems: 1
+                minItems: 1
+                type: array
+              namespace:
+                description: The leader cluster Namespace in which the ClusterSet
+                  is defined. Used in a member cluster.
+                type: string
+            required:
+            - clusterID
+            - leaders
+            type: object
+          status:
+            description: ClusterSetStatus defines the observed state of ClusterSet.
+            properties:
+              clusterStatuses:
+                description: The status of individual member clusters.
+                items:
+                  properties:
+                    clusterID:
+                      description: ClusterID is the unique identifier of this cluster.
+                      type: string
+                    conditions:
+                      items:
+                        description: ClusterCondition indicates the readiness condition
+                          of a cluster.
+                        properties:
+                          lastTransitionTime:
+                            description: Last time the condition transited from one
+                              status to another.
+                            format: date-time
+                            type: string
+                          message:
+                            description: A human readable message indicating details
+                              about the transition.
+                            type: string
+                          reason:
+                            description: Unique, one-word, CamelCase reason for the
+                              condition's last transition.
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False,
+                              Unknown.
+                            type: string
+                          type:
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              conditions:
+                description: The overall condition of the cluster set.
+                items:
+                  description: ClusterSetCondition indicates the readiness condition
+                    of the clusterSet.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transited from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      type: string
+                  type: object
+                type: array
+              observedGeneration:
+                description: The generation observed by the controller.
+                format: int64
+                type: integer
+              readyClusters:
+                description: Total number of clusters ready and connected.
+                format: int32
+                type: integer
+              totalClusters:
+                description: Total number of member clusters configured in the ClusterSet.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.0
+  creationTimestamp: null
+  labels:
+    app: antrea
+  name: memberclusterannounces.multicluster.crd.antrea.io
+spec:
+  group: multicluster.crd.antrea.io
+  names:
+    kind: MemberClusterAnnounce
+    listKind: MemberClusterAnnounceList
+    plural: memberclusterannounces
+    singular: memberclusterannounce
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Cluster ID of the member cluster
+      jsonPath: .clusterID
+      name: Cluster ID
+      type: string
+    - description: ClusterSet ID
+      jsonPath: .clusterSetID
+      name: ClusterSet ID
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MemberClusterAnnounce is the Schema for the memberclusterannounces
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          clusterID:
+            description: Cluster ID of the member cluster.
+            type: string
+          clusterSetID:
+            description: ClusterSet this member belongs to.
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          leaderClusterID:
+            description: Leader cluster this member has selected.
+            type: string
+          metadata:
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.0
+  creationTimestamp: null
+  labels:
+    app: antrea
+  name: resourceexports.multicluster.crd.antrea.io
+spec:
+  group: multicluster.crd.antrea.io
+  names:
+    kind: ResourceExport
+    listKind: ResourceExportList
+    plural: resourceexports
+    singular: resourceexport
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Cluster ID of the exporting cluster
+      jsonPath: .spec.clusterID
+      name: Cluster ID
+      type: string
+    - description: Kind of the exported resource
+      jsonPath: .spec.kind
+      name: Kind
+      type: string
+    - description: Namespace of the exported resource
+      jsonPath: .spec.namespace
+      name: Namespace
+      type: string
+    - description: Name of the exported resource
+      jsonPath: .spec.name
+      name: Name
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ResourceExport is the Schema for the resourceexports API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ResourceExportSpec defines the desired state of ResourceExport.
+            properties:
+              clusterID:
+                description: ClusterID specifies the member cluster this resource
+                  exported from.
+                type: string
+              clusterInfo:
+                description: If exported resource is ClusterInfo.
+                properties:
+                  clusterID:
+                    description: ClusterID of the member cluster.
+                    type: string
+                  gatewayInfos:
+                    description: GatewayInfos has information of Gateways
+                    items:
+                      description: GatewayInfo includes information of a Gateway.
+                      properties:
+                        gatewayIP:
+                          type: string
+                      type: object
+                    type: array
+                  podCIDRs:
+                    description: PodCIDRs is the Pod IP address CIDRs.
+                    items:
+                      type: string
+                    type: array
+                  serviceCIDR:
+                    description: ServiceCIDR is the IP ranges used by Service ClusterIP.
+                    type: string
+                  wireGuard:
+                    description: WireGuardInfo includes information of a WireGuard
+                      tunnel.
+                    properties:
+                      publicKey:
+                        description: Public key of the WireGuard tunnel.
+                        type: string
+                    type: object
+                type: object
+              clusterNetworkPolicy:
+                description: If exported resource is AntreaClusterNetworkPolicy.
+                properties:
+                  appliedTo:
+                    description: Select workloads on which the rules will be applied
+                      to. Cannot be set in conjunction with AppliedTo in each rule.
+                    items:
+                      description: AppliedTo describes the grouping selector of workloads
+                        in AppliedTo field.
+                      properties:
+                        externalEntitySelector:
+                          description: Select ExternalEntities from NetworkPolicy's
+                            Namespace as workloads in AppliedTo fields. If set with
+                            NamespaceSelector, ExternalEntities are matched from Namespaces
+                            matched by the NamespaceSelector. Cannot be set with any
+                            other selector except NamespaceSelector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        group:
+                          description: Group is the name of the ClusterGroup which
+                            can be set as an AppliedTo in place of a stand-alone selector.
+                            A Group cannot be set with any other selector.
+                          type: string
+                        namespaceSelector:
+                          description: Select all Pods from Namespaces matched by
+                            this selector, as workloads in AppliedTo fields. If set
+                            with PodSelector, Pods are matched from Namespaces matched
+                            by the NamespaceSelector. Cannot be set with any other
+                            selector except PodSelector or ExternalEntitySelector.
+                            Cannot be set with Namespaces.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        podSelector:
+                          description: Select Pods from NetworkPolicy's Namespace
+                            as workloads in AppliedTo fields. If set with NamespaceSelector,
+                            Pods are matched from Namespaces matched by the NamespaceSelector.
+                            Cannot be set with any other selector except NamespaceSelector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        service:
+                          description: Select a certain Service which matches the
+                            NamespacedName. A Service can only be set in either policy
+                            level AppliedTo field in a policy that only has ingress
+                            rules or rule level AppliedTo field in an ingress rule.
+                            Only a NodePort Service can be referred by this field.
+                            Cannot be set with any other selector.
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
+                        serviceAccount:
+                          description: Select all Pods with the ServiceAccount matched
+                            by this field, as workloads in AppliedTo fields. Cannot
+                            be set with any other selector.
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
+                      type: object
+                    type: array
+                  egress:
+                    description: Set of egress rules evaluated based on the order
+                      in which they are set. Currently Egress rule supports setting
+                      the `To` field but not the `From` field within a Rule.
+                    items:
+                      description: Rule describes the traffic allowed to/from the
+                        workloads selected by Spec.AppliedTo. Based on the action
+                        specified in the rule, traffic is either allowed or denied
+                        which exactly match the specified ports and protocol.
+                      properties:
+                        action:
+                          description: Action specifies the action to be applied on
+                            the rule.
+                          type: string
+                        appliedTo:
+                          description: Select workloads on which this rule will be
+                            applied to. Cannot be set in conjunction with NetworkPolicySpec/ClusterNetworkPolicySpec.AppliedTo.
+                          items:
+                            description: AppliedTo describes the grouping selector
+                              of workloads in AppliedTo field.
+                            properties:
+                              externalEntitySelector:
+                                description: Select ExternalEntities from NetworkPolicy's
+                                  Namespace as workloads in AppliedTo fields. If set
+                                  with NamespaceSelector, ExternalEntities are matched
+                                  from Namespaces matched by the NamespaceSelector.
+                                  Cannot be set with any other selector except NamespaceSelector.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              group:
+                                description: Group is the name of the ClusterGroup
+                                  which can be set as an AppliedTo in place of a stand-alone
+                                  selector. A Group cannot be set with any other selector.
+                                type: string
+                              namespaceSelector:
+                                description: Select all Pods from Namespaces matched
+                                  by this selector, as workloads in AppliedTo fields.
+                                  If set with PodSelector, Pods are matched from Namespaces
+                                  matched by the NamespaceSelector. Cannot be set
+                                  with any other selector except PodSelector or ExternalEntitySelector.
+                                  Cannot be set with Namespaces.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              podSelector:
+                                description: Select Pods from NetworkPolicy's Namespace
+                                  as workloads in AppliedTo fields. If set with NamespaceSelector,
+                                  Pods are matched from Namespaces matched by the
+                                  NamespaceSelector. Cannot be set with any other
+                                  selector except NamespaceSelector.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              service:
+                                description: Select a certain Service which matches
+                                  the NamespacedName. A Service can only be set in
+                                  either policy level AppliedTo field in a policy
+                                  that only has ingress rules or rule level AppliedTo
+                                  field in an ingress rule. Only a NodePort Service
+                                  can be referred by this field. Cannot be set with
+                                  any other selector.
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                type: object
+                              serviceAccount:
+                                description: Select all Pods with the ServiceAccount
+                                  matched by this field, as workloads in AppliedTo
+                                  fields. Cannot be set with any other selector.
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        enableLogging:
+                          description: EnableLogging is used to indicate if agent
+                            should generate logs when rules are matched. Should be
+                            default to false.
+                          type: boolean
+                        from:
+                          description: Rule is matched if traffic originates from
+                            workloads selected by this field. If this field is empty,
+                            this rule matches all sources.
+                          items:
+                            description: NetworkPolicyPeer describes the grouping
+                              selector of workloads.
+                            properties:
+                              externalEntitySelector:
+                                description: Select ExternalEntities from NetworkPolicy's
+                                  Namespace as workloads in To/From fields. If set
+                                  with NamespaceSelector, ExternalEntities are matched
+                                  from Namespaces matched by the NamespaceSelector.
+                                  Cannot be set with any other selector except NamespaceSelector.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              fqdn:
+                                description: 'Restrict egress access to the Fully
+                                  Qualified Domain Names prescribed by name or by
+                                  wildcard match patterns. This field can only be
+                                  set for NetworkPolicyPeer of egress rules. Supported
+                                  formats are: Exact FQDNs, i.e. "google.com", "db-svc.default.svc.cluster.local"
+                                  Wildcard expressions, i.e. "*wayfair.com".'
+                                type: string
+                              group:
+                                description: Group is the name of the ClusterGroup
+                                  which can be set within an Ingress or Egress rule
+                                  in place of a stand-alone selector. A Group cannot
+                                  be set with any other selector.
+                                type: string
+                              ipBlock:
+                                description: IPBlock describes the IPAddresses/IPBlocks
+                                  that is matched in to/from. IPBlock cannot be set
+                                  as part of the AppliedTo field. Cannot be set with
+                                  any other selector.
+                                properties:
+                                  cidr:
+                                    description: CIDR is a string representing the
+                                      IP Block Valid examples are "192.168.1.1/24".
+                                    type: string
+                                required:
+                                - cidr
+                                type: object
+                              namespaceSelector:
+                                description: Select all Pods from Namespaces matched
+                                  by this selector, as workloads in To/From fields.
+                                  If set with PodSelector, Pods are matched from Namespaces
+                                  matched by the NamespaceSelector. Cannot be set
+                                  with any other selector except PodSelector or ExternalEntitySelector.
+                                  Cannot be set with Namespaces.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaces:
+                                description: 'Select Pod/ExternalEntity from Namespaces
+                                  matched by specific criteria. Current supported
+                                  criteria is match: Self, which selects from the
+                                  same Namespace of the appliedTo workloads. Cannot
+                                  be set with any other selector except PodSelector
+                                  or ExternalEntitySelector. This field can only be
+                                  set when NetworkPolicyPeer is created for ClusterNetworkPolicy
+                                  ingress/egress rules. Cannot be set with NamespaceSelector.'
+                                properties:
+                                  match:
+                                    description: NamespaceMatchType describes Namespace
+                                      matching strategy.
+                                    type: string
+                                type: object
+                              nodeSelector:
+                                description: Select certain Nodes which match the
+                                  label selector. A NodeSelector cannot be set in
+                                  AppliedTo field or set with any other selector.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              podSelector:
+                                description: Select Pods from NetworkPolicy's Namespace
+                                  as workloads in To/From fields. If set with NamespaceSelector,
+                                  Pods are matched from Namespaces matched by the
+                                  NamespaceSelector. Cannot be set with any other
+                                  selector except NamespaceSelector.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              scope:
+                                description: Define scope of the Pod/NamespaceSelector(s)
+                                  of this peer. Can only be used in ingress NetworkPolicyPeers.
+                                  Defaults to "Cluster".
+                                type: string
+                              serviceAccount:
+                                description: Select all Pods with the ServiceAccount
+                                  matched by this field, as workloads in To/From fields.
+                                  Cannot be set with any other selector.
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        l7Protocols:
+                          description: Set of layer 7 protocols matched by the rule.
+                            If this field is set, action can only be Allow. When this
+                            field is used in a rule, any traffic matching the other
+                            layer 3/4 criteria of the rule (typically the 5-tuple)
+                            will be forwarded to an application-aware engine for protocol
+                            detection and rule enforcement, and the traffic will be
+                            allowed if the layer 7 criteria is also matched, otherwise
+                            it will be dropped. Therefore, any rules after a layer
+                            7 rule will not be enforced for the traffic.
+                          items:
+                            properties:
+                              http:
+                                description: HTTPProtocol matches HTTP requests with
+                                  specific host, method, and path. All fields could
+                                  be used alone or together. If all fields are not
+                                  provided, it matches all HTTP requests.
+                                properties:
+                                  host:
+                                    description: Host represents the hostname present
+                                      in the URI or the HTTP Host header to match.
+                                      It does not contain the port associated with
+                                      the host.
+                                    type: string
+                                  method:
+                                    description: Method represents the HTTP method
+                                      to match. It could be GET, POST, PUT, HEAD,
+                                      DELETE, TRACE, OPTIONS, CONNECT and PATCH.
+                                    type: string
+                                  path:
+                                    description: Path represents the URI path to match
+                                      (Ex. "/index.html", "/admin").
+                                    type: string
+                                type: object
+                              tls:
+                                description: TLSProtocol matches TLS handshake packets
+                                  with specific SNI. If the field is not provided,
+                                  this matches all TLS handshake packets.
+                                properties:
+                                  sni:
+                                    description: SNI (Server Name Indication) indicates
+                                      the server domain name in the TLS/SSL hello
+                                      message.
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        logLabel:
+                          description: LogLabel is a user-defined arbitrary string
+                            which will be printed in the NetworkPolicy logs.
+                          type: string
+                        name:
+                          description: Name describes the intention of this rule.
+                            Name should be unique within the policy.
+                          type: string
+                        ports:
+                          description: Set of ports and protocols matched by the rule.
+                            If this field and Protocols are unset or empty, this rule
+                            matches all ports.
+                          items:
+                            description: NetworkPolicyPort describes the port and
+                              protocol to match in a rule.
+                            properties:
+                              endPort:
+                                description: EndPort defines the end of the port range,
+                                  inclusive. It can only be specified when a numerical
+                                  `port` is specified.
+                                format: int32
+                                type: integer
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: The port on the given protocol. This
+                                  can be either a numerical or named port on a Pod.
+                                  If this field is not provided, this matches all
+                                  port names and numbers.
+                                x-kubernetes-int-or-string: true
+                              protocol:
+                                default: TCP
+                                description: The protocol (TCP, UDP, or SCTP) which
+                                  traffic must match. If not specified, this field
+                                  defaults to TCP.
+                                type: string
+                              sourceEndPort:
+                                description: SourceEndPort defines the end of the
+                                  source port range, inclusive. It can only be specified
+                                  when `sourcePort` is specified.
+                                format: int32
+                                type: integer
+                              sourcePort:
+                                description: The source port on the given protocol.
+                                  This can only be a numerical port. If this field
+                                  is not provided, rule matches all source ports.
+                                format: int32
+                                type: integer
+                            type: object
+                          type: array
+                        protocols:
+                          description: Set of protocols matched by the rule. If this
+                            field and Ports are unset or empty, this rule matches
+                            all protocols supported.
+                          items:
+                            description: NetworkPolicyProtocol defines additional
+                              protocols that are not supported by `ports`. All fields
+                              should be used as a standalone field.
+                            properties:
+                              icmp:
+                                description: ICMPProtocol matches ICMP traffic with
+                                  specific ICMPType and/or ICMPCode. All fields could
+                                  be used alone or together. If all fields are not
+                                  provided, this matches all ICMP traffic.
+                                properties:
+                                  icmpCode:
+                                    format: int32
+                                    type: integer
+                                  icmpType:
+                                    format: int32
+                                    type: integer
+                                type: object
+                              igmp:
+                                description: 'IGMPProtocol matches IGMP traffic with
+                                  IGMPType and GroupAddress. IGMPType must be filled
+                                  with: IGMPQuery    int32 = 0x11 IGMPReportV1 int32
+                                  = 0x12 IGMPReportV2 int32 = 0x16 IGMPReportV3 int32
+                                  = 0x22 If groupAddress is empty, all groupAddresses
+                                  will be matched.'
+                                properties:
+                                  groupAddress:
+                                    type: string
+                                  igmpType:
+                                    format: int32
+                                    type: integer
+                                type: object
+                            type: object
+                          type: array
+                        to:
+                          description: Rule is matched if traffic is intended for
+                            workloads selected by this field. This field can't be
+                            used with ToServices. If this field and ToServices are
+                            both empty or missing this rule matches all destinations.
+                          items:
+                            description: NetworkPolicyPeer describes the grouping
+                              selector of workloads.
+                            properties:
+                              externalEntitySelector:
+                                description: Select ExternalEntities from NetworkPolicy's
+                                  Namespace as workloads in To/From fields. If set
+                                  with NamespaceSelector, ExternalEntities are matched
+                                  from Namespaces matched by the NamespaceSelector.
+                                  Cannot be set with any other selector except NamespaceSelector.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              fqdn:
+                                description: 'Restrict egress access to the Fully
+                                  Qualified Domain Names prescribed by name or by
+                                  wildcard match patterns. This field can only be
+                                  set for NetworkPolicyPeer of egress rules. Supported
+                                  formats are: Exact FQDNs, i.e. "google.com", "db-svc.default.svc.cluster.local"
+                                  Wildcard expressions, i.e. "*wayfair.com".'
+                                type: string
+                              group:
+                                description: Group is the name of the ClusterGroup
+                                  which can be set within an Ingress or Egress rule
+                                  in place of a stand-alone selector. A Group cannot
+                                  be set with any other selector.
+                                type: string
+                              ipBlock:
+                                description: IPBlock describes the IPAddresses/IPBlocks
+                                  that is matched in to/from. IPBlock cannot be set
+                                  as part of the AppliedTo field. Cannot be set with
+                                  any other selector.
+                                properties:
+                                  cidr:
+                                    description: CIDR is a string representing the
+                                      IP Block Valid examples are "192.168.1.1/24".
+                                    type: string
+                                required:
+                                - cidr
+                                type: object
+                              namespaceSelector:
+                                description: Select all Pods from Namespaces matched
+                                  by this selector, as workloads in To/From fields.
+                                  If set with PodSelector, Pods are matched from Namespaces
+                                  matched by the NamespaceSelector. Cannot be set
+                                  with any other selector except PodSelector or ExternalEntitySelector.
+                                  Cannot be set with Namespaces.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaces:
+                                description: 'Select Pod/ExternalEntity from Namespaces
+                                  matched by specific criteria. Current supported
+                                  criteria is match: Self, which selects from the
+                                  same Namespace of the appliedTo workloads. Cannot
+                                  be set with any other selector except PodSelector
+                                  or ExternalEntitySelector. This field can only be
+                                  set when NetworkPolicyPeer is created for ClusterNetworkPolicy
+                                  ingress/egress rules. Cannot be set with NamespaceSelector.'
+                                properties:
+                                  match:
+                                    description: NamespaceMatchType describes Namespace
+                                      matching strategy.
+                                    type: string
+                                type: object
+                              nodeSelector:
+                                description: Select certain Nodes which match the
+                                  label selector. A NodeSelector cannot be set in
+                                  AppliedTo field or set with any other selector.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              podSelector:
+                                description: Select Pods from NetworkPolicy's Namespace
+                                  as workloads in To/From fields. If set with NamespaceSelector,
+                                  Pods are matched from Namespaces matched by the
+                                  NamespaceSelector. Cannot be set with any other
+                                  selector except NamespaceSelector.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              scope:
+                                description: Define scope of the Pod/NamespaceSelector(s)
+                                  of this peer. Can only be used in ingress NetworkPolicyPeers.
+                                  Defaults to "Cluster".
+                                type: string
+                              serviceAccount:
+                                description: Select all Pods with the ServiceAccount
+                                  matched by this field, as workloads in To/From fields.
+                                  Cannot be set with any other selector.
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        toServices:
+                          description: Rule is matched if traffic is intended for
+                            a Service listed in this field. Currently, only ClusterIP
+                            types Services are supported in this field. When scope
+                            is set to ClusterSet, it matches traffic intended for
+                            a multi-cluster Service listed in this field. Service
+                            name and Namespace provided should match the original
+                            exported Service. This field can only be used when AntreaProxy
+                            is enabled. This field can't be used with To or Ports.
+                            If this field and To are both empty or missing, this rule
+                            matches all destinations.
+                          items:
+                            description: PeerService refers to a Service, which can
+                              be a in-cluster Service or imported multi-cluster service.
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                              scope:
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  ingress:
+                    description: Set of ingress rules evaluated based on the order
+                      in which they are set. Currently Ingress rule supports setting
+                      the `From` field but not the `To` field within a Rule.
+                    items:
+                      description: Rule describes the traffic allowed to/from the
+                        workloads selected by Spec.AppliedTo. Based on the action
+                        specified in the rule, traffic is either allowed or denied
+                        which exactly match the specified ports and protocol.
+                      properties:
+                        action:
+                          description: Action specifies the action to be applied on
+                            the rule.
+                          type: string
+                        appliedTo:
+                          description: Select workloads on which this rule will be
+                            applied to. Cannot be set in conjunction with NetworkPolicySpec/ClusterNetworkPolicySpec.AppliedTo.
+                          items:
+                            description: AppliedTo describes the grouping selector
+                              of workloads in AppliedTo field.
+                            properties:
+                              externalEntitySelector:
+                                description: Select ExternalEntities from NetworkPolicy's
+                                  Namespace as workloads in AppliedTo fields. If set
+                                  with NamespaceSelector, ExternalEntities are matched
+                                  from Namespaces matched by the NamespaceSelector.
+                                  Cannot be set with any other selector except NamespaceSelector.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              group:
+                                description: Group is the name of the ClusterGroup
+                                  which can be set as an AppliedTo in place of a stand-alone
+                                  selector. A Group cannot be set with any other selector.
+                                type: string
+                              namespaceSelector:
+                                description: Select all Pods from Namespaces matched
+                                  by this selector, as workloads in AppliedTo fields.
+                                  If set with PodSelector, Pods are matched from Namespaces
+                                  matched by the NamespaceSelector. Cannot be set
+                                  with any other selector except PodSelector or ExternalEntitySelector.
+                                  Cannot be set with Namespaces.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              podSelector:
+                                description: Select Pods from NetworkPolicy's Namespace
+                                  as workloads in AppliedTo fields. If set with NamespaceSelector,
+                                  Pods are matched from Namespaces matched by the
+                                  NamespaceSelector. Cannot be set with any other
+                                  selector except NamespaceSelector.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              service:
+                                description: Select a certain Service which matches
+                                  the NamespacedName. A Service can only be set in
+                                  either policy level AppliedTo field in a policy
+                                  that only has ingress rules or rule level AppliedTo
+                                  field in an ingress rule. Only a NodePort Service
+                                  can be referred by this field. Cannot be set with
+                                  any other selector.
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                type: object
+                              serviceAccount:
+                                description: Select all Pods with the ServiceAccount
+                                  matched by this field, as workloads in AppliedTo
+                                  fields. Cannot be set with any other selector.
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        enableLogging:
+                          description: EnableLogging is used to indicate if agent
+                            should generate logs when rules are matched. Should be
+                            default to false.
+                          type: boolean
+                        from:
+                          description: Rule is matched if traffic originates from
+                            workloads selected by this field. If this field is empty,
+                            this rule matches all sources.
+                          items:
+                            description: NetworkPolicyPeer describes the grouping
+                              selector of workloads.
+                            properties:
+                              externalEntitySelector:
+                                description: Select ExternalEntities from NetworkPolicy's
+                                  Namespace as workloads in To/From fields. If set
+                                  with NamespaceSelector, ExternalEntities are matched
+                                  from Namespaces matched by the NamespaceSelector.
+                                  Cannot be set with any other selector except NamespaceSelector.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              fqdn:
+                                description: 'Restrict egress access to the Fully
+                                  Qualified Domain Names prescribed by name or by
+                                  wildcard match patterns. This field can only be
+                                  set for NetworkPolicyPeer of egress rules. Supported
+                                  formats are: Exact FQDNs, i.e. "google.com", "db-svc.default.svc.cluster.local"
+                                  Wildcard expressions, i.e. "*wayfair.com".'
+                                type: string
+                              group:
+                                description: Group is the name of the ClusterGroup
+                                  which can be set within an Ingress or Egress rule
+                                  in place of a stand-alone selector. A Group cannot
+                                  be set with any other selector.
+                                type: string
+                              ipBlock:
+                                description: IPBlock describes the IPAddresses/IPBlocks
+                                  that is matched in to/from. IPBlock cannot be set
+                                  as part of the AppliedTo field. Cannot be set with
+                                  any other selector.
+                                properties:
+                                  cidr:
+                                    description: CIDR is a string representing the
+                                      IP Block Valid examples are "192.168.1.1/24".
+                                    type: string
+                                required:
+                                - cidr
+                                type: object
+                              namespaceSelector:
+                                description: Select all Pods from Namespaces matched
+                                  by this selector, as workloads in To/From fields.
+                                  If set with PodSelector, Pods are matched from Namespaces
+                                  matched by the NamespaceSelector. Cannot be set
+                                  with any other selector except PodSelector or ExternalEntitySelector.
+                                  Cannot be set with Namespaces.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaces:
+                                description: 'Select Pod/ExternalEntity from Namespaces
+                                  matched by specific criteria. Current supported
+                                  criteria is match: Self, which selects from the
+                                  same Namespace of the appliedTo workloads. Cannot
+                                  be set with any other selector except PodSelector
+                                  or ExternalEntitySelector. This field can only be
+                                  set when NetworkPolicyPeer is created for ClusterNetworkPolicy
+                                  ingress/egress rules. Cannot be set with NamespaceSelector.'
+                                properties:
+                                  match:
+                                    description: NamespaceMatchType describes Namespace
+                                      matching strategy.
+                                    type: string
+                                type: object
+                              nodeSelector:
+                                description: Select certain Nodes which match the
+                                  label selector. A NodeSelector cannot be set in
+                                  AppliedTo field or set with any other selector.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              podSelector:
+                                description: Select Pods from NetworkPolicy's Namespace
+                                  as workloads in To/From fields. If set with NamespaceSelector,
+                                  Pods are matched from Namespaces matched by the
+                                  NamespaceSelector. Cannot be set with any other
+                                  selector except NamespaceSelector.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              scope:
+                                description: Define scope of the Pod/NamespaceSelector(s)
+                                  of this peer. Can only be used in ingress NetworkPolicyPeers.
+                                  Defaults to "Cluster".
+                                type: string
+                              serviceAccount:
+                                description: Select all Pods with the ServiceAccount
+                                  matched by this field, as workloads in To/From fields.
+                                  Cannot be set with any other selector.
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        l7Protocols:
+                          description: Set of layer 7 protocols matched by the rule.
+                            If this field is set, action can only be Allow. When this
+                            field is used in a rule, any traffic matching the other
+                            layer 3/4 criteria of the rule (typically the 5-tuple)
+                            will be forwarded to an application-aware engine for protocol
+                            detection and rule enforcement, and the traffic will be
+                            allowed if the layer 7 criteria is also matched, otherwise
+                            it will be dropped. Therefore, any rules after a layer
+                            7 rule will not be enforced for the traffic.
+                          items:
+                            properties:
+                              http:
+                                description: HTTPProtocol matches HTTP requests with
+                                  specific host, method, and path. All fields could
+                                  be used alone or together. If all fields are not
+                                  provided, it matches all HTTP requests.
+                                properties:
+                                  host:
+                                    description: Host represents the hostname present
+                                      in the URI or the HTTP Host header to match.
+                                      It does not contain the port associated with
+                                      the host.
+                                    type: string
+                                  method:
+                                    description: Method represents the HTTP method
+                                      to match. It could be GET, POST, PUT, HEAD,
+                                      DELETE, TRACE, OPTIONS, CONNECT and PATCH.
+                                    type: string
+                                  path:
+                                    description: Path represents the URI path to match
+                                      (Ex. "/index.html", "/admin").
+                                    type: string
+                                type: object
+                              tls:
+                                description: TLSProtocol matches TLS handshake packets
+                                  with specific SNI. If the field is not provided,
+                                  this matches all TLS handshake packets.
+                                properties:
+                                  sni:
+                                    description: SNI (Server Name Indication) indicates
+                                      the server domain name in the TLS/SSL hello
+                                      message.
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        logLabel:
+                          description: LogLabel is a user-defined arbitrary string
+                            which will be printed in the NetworkPolicy logs.
+                          type: string
+                        name:
+                          description: Name describes the intention of this rule.
+                            Name should be unique within the policy.
+                          type: string
+                        ports:
+                          description: Set of ports and protocols matched by the rule.
+                            If this field and Protocols are unset or empty, this rule
+                            matches all ports.
+                          items:
+                            description: NetworkPolicyPort describes the port and
+                              protocol to match in a rule.
+                            properties:
+                              endPort:
+                                description: EndPort defines the end of the port range,
+                                  inclusive. It can only be specified when a numerical
+                                  `port` is specified.
+                                format: int32
+                                type: integer
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: The port on the given protocol. This
+                                  can be either a numerical or named port on a Pod.
+                                  If this field is not provided, this matches all
+                                  port names and numbers.
+                                x-kubernetes-int-or-string: true
+                              protocol:
+                                default: TCP
+                                description: The protocol (TCP, UDP, or SCTP) which
+                                  traffic must match. If not specified, this field
+                                  defaults to TCP.
+                                type: string
+                              sourceEndPort:
+                                description: SourceEndPort defines the end of the
+                                  source port range, inclusive. It can only be specified
+                                  when `sourcePort` is specified.
+                                format: int32
+                                type: integer
+                              sourcePort:
+                                description: The source port on the given protocol.
+                                  This can only be a numerical port. If this field
+                                  is not provided, rule matches all source ports.
+                                format: int32
+                                type: integer
+                            type: object
+                          type: array
+                        protocols:
+                          description: Set of protocols matched by the rule. If this
+                            field and Ports are unset or empty, this rule matches
+                            all protocols supported.
+                          items:
+                            description: NetworkPolicyProtocol defines additional
+                              protocols that are not supported by `ports`. All fields
+                              should be used as a standalone field.
+                            properties:
+                              icmp:
+                                description: ICMPProtocol matches ICMP traffic with
+                                  specific ICMPType and/or ICMPCode. All fields could
+                                  be used alone or together. If all fields are not
+                                  provided, this matches all ICMP traffic.
+                                properties:
+                                  icmpCode:
+                                    format: int32
+                                    type: integer
+                                  icmpType:
+                                    format: int32
+                                    type: integer
+                                type: object
+                              igmp:
+                                description: 'IGMPProtocol matches IGMP traffic with
+                                  IGMPType and GroupAddress. IGMPType must be filled
+                                  with: IGMPQuery    int32 = 0x11 IGMPReportV1 int32
+                                  = 0x12 IGMPReportV2 int32 = 0x16 IGMPReportV3 int32
+                                  = 0x22 If groupAddress is empty, all groupAddresses
+                                  will be matched.'
+                                properties:
+                                  groupAddress:
+                                    type: string
+                                  igmpType:
+                                    format: int32
+                                    type: integer
+                                type: object
+                            type: object
+                          type: array
+                        to:
+                          description: Rule is matched if traffic is intended for
+                            workloads selected by this field. This field can't be
+                            used with ToServices. If this field and ToServices are
+                            both empty or missing this rule matches all destinations.
+                          items:
+                            description: NetworkPolicyPeer describes the grouping
+                              selector of workloads.
+                            properties:
+                              externalEntitySelector:
+                                description: Select ExternalEntities from NetworkPolicy's
+                                  Namespace as workloads in To/From fields. If set
+                                  with NamespaceSelector, ExternalEntities are matched
+                                  from Namespaces matched by the NamespaceSelector.
+                                  Cannot be set with any other selector except NamespaceSelector.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              fqdn:
+                                description: 'Restrict egress access to the Fully
+                                  Qualified Domain Names prescribed by name or by
+                                  wildcard match patterns. This field can only be
+                                  set for NetworkPolicyPeer of egress rules. Supported
+                                  formats are: Exact FQDNs, i.e. "google.com", "db-svc.default.svc.cluster.local"
+                                  Wildcard expressions, i.e. "*wayfair.com".'
+                                type: string
+                              group:
+                                description: Group is the name of the ClusterGroup
+                                  which can be set within an Ingress or Egress rule
+                                  in place of a stand-alone selector. A Group cannot
+                                  be set with any other selector.
+                                type: string
+                              ipBlock:
+                                description: IPBlock describes the IPAddresses/IPBlocks
+                                  that is matched in to/from. IPBlock cannot be set
+                                  as part of the AppliedTo field. Cannot be set with
+                                  any other selector.
+                                properties:
+                                  cidr:
+                                    description: CIDR is a string representing the
+                                      IP Block Valid examples are "192.168.1.1/24".
+                                    type: string
+                                required:
+                                - cidr
+                                type: object
+                              namespaceSelector:
+                                description: Select all Pods from Namespaces matched
+                                  by this selector, as workloads in To/From fields.
+                                  If set with PodSelector, Pods are matched from Namespaces
+                                  matched by the NamespaceSelector. Cannot be set
+                                  with any other selector except PodSelector or ExternalEntitySelector.
+                                  Cannot be set with Namespaces.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaces:
+                                description: 'Select Pod/ExternalEntity from Namespaces
+                                  matched by specific criteria. Current supported
+                                  criteria is match: Self, which selects from the
+                                  same Namespace of the appliedTo workloads. Cannot
+                                  be set with any other selector except PodSelector
+                                  or ExternalEntitySelector. This field can only be
+                                  set when NetworkPolicyPeer is created for ClusterNetworkPolicy
+                                  ingress/egress rules. Cannot be set with NamespaceSelector.'
+                                properties:
+                                  match:
+                                    description: NamespaceMatchType describes Namespace
+                                      matching strategy.
+                                    type: string
+                                type: object
+                              nodeSelector:
+                                description: Select certain Nodes which match the
+                                  label selector. A NodeSelector cannot be set in
+                                  AppliedTo field or set with any other selector.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              podSelector:
+                                description: Select Pods from NetworkPolicy's Namespace
+                                  as workloads in To/From fields. If set with NamespaceSelector,
+                                  Pods are matched from Namespaces matched by the
+                                  NamespaceSelector. Cannot be set with any other
+                                  selector except NamespaceSelector.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              scope:
+                                description: Define scope of the Pod/NamespaceSelector(s)
+                                  of this peer. Can only be used in ingress NetworkPolicyPeers.
+                                  Defaults to "Cluster".
+                                type: string
+                              serviceAccount:
+                                description: Select all Pods with the ServiceAccount
+                                  matched by this field, as workloads in To/From fields.
+                                  Cannot be set with any other selector.
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        toServices:
+                          description: Rule is matched if traffic is intended for
+                            a Service listed in this field. Currently, only ClusterIP
+                            types Services are supported in this field. When scope
+                            is set to ClusterSet, it matches traffic intended for
+                            a multi-cluster Service listed in this field. Service
+                            name and Namespace provided should match the original
+                            exported Service. This field can only be used when AntreaProxy
+                            is enabled. This field can't be used with To or Ports.
+                            If this field and To are both empty or missing, this rule
+                            matches all destinations.
+                          items:
+                            description: PeerService refers to a Service, which can
+                              be a in-cluster Service or imported multi-cluster service.
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                              scope:
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  priority:
+                    description: Priority specfies the order of the ClusterNetworkPolicy
+                      relative to other AntreaClusterNetworkPolicies.
+                    type: number
+                  tier:
+                    description: Tier specifies the tier to which this ClusterNetworkPolicy
+                      belongs to. The ClusterNetworkPolicy order will be determined
+                      based on the combination of the Tier's Priority and the ClusterNetworkPolicy's
+                      own Priority. If not specified, this policy will be created
+                      in the Application Tier right above the K8s NetworkPolicy which
+                      resides at the bottom.
+                    type: string
+                required:
+                - priority
+                type: object
+              endpoints:
+                description: If exported resource is Endpoints.
+                properties:
+                  subsets:
+                    items:
+                      description: "EndpointSubset is a group of addresses with a
+                        common set of ports. The expanded set of endpoints is the
+                        Cartesian product of Addresses x Ports. For example, given:
+                        \n { Addresses: [{\"ip\": \"10.10.1.1\"}, {\"ip\": \"10.10.2.2\"}],
+                        Ports:     [{\"name\": \"a\", \"port\": 8675}, {\"name\":
+                        \"b\", \"port\": 309}] } \n The resulting set of endpoints
+                        can be viewed as: \n a: [ 10.10.1.1:8675, 10.10.2.2:8675 ],
+                        b: [ 10.10.1.1:309, 10.10.2.2:309 ]"
+                      properties:
+                        addresses:
+                          description: IP addresses which offer the related ports
+                            that are marked as ready. These endpoints should be considered
+                            safe for load balancers and clients to utilize.
+                          items:
+                            description: EndpointAddress is a tuple that describes
+                              single IP address.
+                            properties:
+                              hostname:
+                                description: The Hostname of this endpoint
+                                type: string
+                              ip:
+                                description: 'The IP of this endpoint. May not be
+                                  loopback (127.0.0.0/8), link-local (169.254.0.0/16),
+                                  or link-local multicast ((224.0.0.0/24). IPv6 is
+                                  also accepted but not fully supported on all platforms.
+                                  Also, certain kubernetes components, like kube-proxy,
+                                  are not IPv6 ready. TODO: This should allow hostname
+                                  or IP, See #4447.'
+                                type: string
+                              nodeName:
+                                description: 'Optional: Node hosting this endpoint.
+                                  This can be used to determine endpoints local to
+                                  a node.'
+                                type: string
+                              targetRef:
+                                description: Reference to object providing the endpoint.
+                                properties:
+                                  apiVersion:
+                                    description: API version of the referent.
+                                    type: string
+                                  fieldPath:
+                                    description: 'If referring to a piece of an object
+                                      instead of an entire object, this string should
+                                      contain a valid JSON/Go field access statement,
+                                      such as desiredState.manifest.containers[2].
+                                      For example, if the object reference is to a
+                                      container within a pod, this would take on a
+                                      value like: "spec.containers{name}" (where "name"
+                                      refers to the name of the container that triggered
+                                      the event) or if no container name is specified
+                                      "spec.containers[2]" (container with index 2
+                                      in this pod). This syntax is chosen only to
+                                      have some well-defined way of referencing a
+                                      part of an object. TODO: this design is not
+                                      final and this field is subject to change in
+                                      the future.'
+                                    type: string
+                                  kind:
+                                    description: 'Kind of the referent. More info:
+                                      https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  namespace:
+                                    description: 'Namespace of the referent. More
+                                      info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                    type: string
+                                  resourceVersion:
+                                    description: 'Specific resourceVersion to which
+                                      this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                    type: string
+                                  uid:
+                                    description: 'UID of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                    type: string
+                                type: object
+                            required:
+                            - ip
+                            type: object
+                          type: array
+                        notReadyAddresses:
+                          description: IP addresses which offer the related ports
+                            but are not currently marked as ready because they have
+                            not yet finished starting, have recently failed a readiness
+                            check, or have recently failed a liveness check.
+                          items:
+                            description: EndpointAddress is a tuple that describes
+                              single IP address.
+                            properties:
+                              hostname:
+                                description: The Hostname of this endpoint
+                                type: string
+                              ip:
+                                description: 'The IP of this endpoint. May not be
+                                  loopback (127.0.0.0/8), link-local (169.254.0.0/16),
+                                  or link-local multicast ((224.0.0.0/24). IPv6 is
+                                  also accepted but not fully supported on all platforms.
+                                  Also, certain kubernetes components, like kube-proxy,
+                                  are not IPv6 ready. TODO: This should allow hostname
+                                  or IP, See #4447.'
+                                type: string
+                              nodeName:
+                                description: 'Optional: Node hosting this endpoint.
+                                  This can be used to determine endpoints local to
+                                  a node.'
+                                type: string
+                              targetRef:
+                                description: Reference to object providing the endpoint.
+                                properties:
+                                  apiVersion:
+                                    description: API version of the referent.
+                                    type: string
+                                  fieldPath:
+                                    description: 'If referring to a piece of an object
+                                      instead of an entire object, this string should
+                                      contain a valid JSON/Go field access statement,
+                                      such as desiredState.manifest.containers[2].
+                                      For example, if the object reference is to a
+                                      container within a pod, this would take on a
+                                      value like: "spec.containers{name}" (where "name"
+                                      refers to the name of the container that triggered
+                                      the event) or if no container name is specified
+                                      "spec.containers[2]" (container with index 2
+                                      in this pod). This syntax is chosen only to
+                                      have some well-defined way of referencing a
+                                      part of an object. TODO: this design is not
+                                      final and this field is subject to change in
+                                      the future.'
+                                    type: string
+                                  kind:
+                                    description: 'Kind of the referent. More info:
+                                      https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  namespace:
+                                    description: 'Namespace of the referent. More
+                                      info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                    type: string
+                                  resourceVersion:
+                                    description: 'Specific resourceVersion to which
+                                      this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                    type: string
+                                  uid:
+                                    description: 'UID of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                    type: string
+                                type: object
+                            required:
+                            - ip
+                            type: object
+                          type: array
+                        ports:
+                          description: Port numbers available on the related IP addresses.
+                          items:
+                            description: EndpointPort is a tuple that describes a
+                              single port.
+                            properties:
+                              appProtocol:
+                                description: The application protocol for this port.
+                                  This field follows standard Kubernetes label syntax.
+                                  Un-prefixed names are reserved for IANA standard
+                                  service names (as per RFC-6335 and https://www.iana.org/assignments/service-names).
+                                  Non-standard protocols should use prefixed names
+                                  such as mycompany.com/my-custom-protocol.
+                                type: string
+                              name:
+                                description: The name of this port.  This must match
+                                  the 'name' field in the corresponding ServicePort.
+                                  Must be a DNS_LABEL. Optional only if one port is
+                                  defined.
+                                type: string
+                              port:
+                                description: The port number of the endpoint.
+                                format: int32
+                                type: integer
+                              protocol:
+                                default: TCP
+                                description: The IP protocol for this port. Must be
+                                  UDP, TCP, or SCTP. Default is TCP.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          type: array
+                      type: object
+                    type: array
+                type: object
+              externalEntity:
+                description: If exported resource is ExternalEntity.
+                properties:
+                  externalEntitySpec:
+                    description: ExternalEntitySpec defines the desired state for
+                      ExternalEntity.
+                    properties:
+                      endpoints:
+                        description: Endpoints is a list of external endpoints associated
+                          with this entity.
+                        items:
+                          description: Endpoint refers to an endpoint associated with
+                            the ExternalEntity.
+                          properties:
+                            ip:
+                              description: IP associated with this endpoint.
+                              type: string
+                            name:
+                              description: Name identifies this endpoint. Could be
+                                the network interface name in case of VMs.
+                              type: string
+                          type: object
+                        type: array
+                      externalNode:
+                        description: ExternalNode is the opaque identifier of the
+                          agent/controller responsible for additional processing or
+                          handling of this external entity.
+                        type: string
+                      ports:
+                        description: Ports maintain the list of named ports.
+                        items:
+                          description: NamedPort describes the port and protocol to
+                            match in a rule.
+                          properties:
+                            name:
+                              description: Name associated with the Port.
+                              type: string
+                            port:
+                              description: The port on the given protocol.
+                              format: int32
+                              type: integer
+                            protocol:
+                              default: TCP
+                              description: The protocol (TCP, UDP, or SCTP) which
+                                traffic must match. If not specified, this field defaults
+                                to TCP.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              kind:
+                description: Kind of exported resource.
+                type: string
+              labelIdentity:
+                description: If exported resource is LabelIdentity of a cluster.
+                properties:
+                  normalizedLabel:
+                    type: string
+                type: object
+              name:
+                description: Name of exported resource.
+                type: string
+              namespace:
+                description: Namespace of exported resource.
+                type: string
+              raw:
+                description: If exported resource kind is unknown.
+                properties:
+                  data:
+                    format: byte
+                    type: string
+                type: object
+              service:
+                description: If exported resource is Service.
+                properties:
+                  serviceSpec:
+                    description: ServiceSpec describes the attributes that a user
+                      creates on a service.
+                    properties:
+                      allocateLoadBalancerNodePorts:
+                        description: allocateLoadBalancerNodePorts defines if NodePorts
+                          will be automatically allocated for services with type LoadBalancer.  Default
+                          is "true". It may be set to "false" if the cluster load-balancer
+                          does not rely on NodePorts.  If the caller requests specific
+                          NodePorts (by specifying a value), those requests will be
+                          respected, regardless of this field. This field may only
+                          be set for services with type LoadBalancer and will be cleared
+                          if the type is changed to any other type.
+                        type: boolean
+                      clusterIP:
+                        description: 'clusterIP is the IP address of the service and
+                          is usually assigned randomly. If an address is specified
+                          manually, is in-range (as per system configuration), and
+                          is not in use, it will be allocated to the service; otherwise
+                          creation of the service will fail. This field may not be
+                          changed through updates unless the type field is also being
+                          changed to ExternalName (which requires this field to be
+                          blank) or the type field is being changed from ExternalName
+                          (in which case this field may optionally be specified, as
+                          describe above).  Valid values are "None", empty string
+                          (""), or a valid IP address. Setting this to "None" makes
+                          a "headless service" (no virtual IP), which is useful when
+                          direct endpoint connections are preferred and proxying is
+                          not required.  Only applies to types ClusterIP, NodePort,
+                          and LoadBalancer. If this field is specified when creating
+                          a Service of type ExternalName, creation will fail. This
+                          field will be wiped when updating a Service to type ExternalName.
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                        type: string
+                      clusterIPs:
+                        description: "ClusterIPs is a list of IP addresses assigned
+                          to this service, and are usually assigned randomly.  If
+                          an address is specified manually, is in-range (as per system
+                          configuration), and is not in use, it will be allocated
+                          to the service; otherwise creation of the service will fail.
+                          This field may not be changed through updates unless the
+                          type field is also being changed to ExternalName (which
+                          requires this field to be empty) or the type field is being
+                          changed from ExternalName (in which case this field may
+                          optionally be specified, as describe above).  Valid values
+                          are \"None\", empty string (\"\"), or a valid IP address.
+                          \ Setting this to \"None\" makes a \"headless service\"
+                          (no virtual IP), which is useful when direct endpoint connections
+                          are preferred and proxying is not required.  Only applies
+                          to types ClusterIP, NodePort, and LoadBalancer. If this
+                          field is specified when creating a Service of type ExternalName,
+                          creation will fail. This field will be wiped when updating
+                          a Service to type ExternalName.  If this field is not specified,
+                          it will be initialized from the clusterIP field.  If this
+                          field is specified, clients must ensure that clusterIPs[0]
+                          and clusterIP have the same value. \n This field may hold
+                          a maximum of two entries (dual-stack IPs, in either order).
+                          These IPs must correspond to the values of the ipFamilies
+                          field. Both clusterIPs and ipFamilies are governed by the
+                          ipFamilyPolicy field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies"
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      externalIPs:
+                        description: externalIPs is a list of IP addresses for which
+                          nodes in the cluster will also accept traffic for this service.  These
+                          IPs are not managed by Kubernetes.  The user is responsible
+                          for ensuring that traffic arrives at a node with this IP.  A
+                          common example is external load-balancers that are not part
+                          of the Kubernetes system.
+                        items:
+                          type: string
+                        type: array
+                      externalName:
+                        description: externalName is the external reference that discovery
+                          mechanisms will return as an alias for this service (e.g.
+                          a DNS CNAME record). No proxying will be involved.  Must
+                          be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123)
+                          and requires `type` to be "ExternalName".
+                        type: string
+                      externalTrafficPolicy:
+                        description: externalTrafficPolicy describes how nodes distribute
+                          service traffic they receive on one of the Service's "externally-facing"
+                          addresses (NodePorts, ExternalIPs, and LoadBalancer IPs).
+                          If set to "Local", the proxy will configure the service
+                          in a way that assumes that external load balancers will
+                          take care of balancing the service traffic between nodes,
+                          and so each node will deliver traffic only to the node-local
+                          endpoints of the service, without masquerading the client
+                          source IP. (Traffic mistakenly sent to a node with no endpoints
+                          will be dropped.) The default value, "Cluster", uses the
+                          standard behavior of routing to all endpoints evenly (possibly
+                          modified by topology and other features). Note that traffic
+                          sent to an External IP or LoadBalancer IP from within the
+                          cluster will always get "Cluster" semantics, but clients
+                          sending to a NodePort from within the cluster may need to
+                          take traffic policy into account when picking a node.
+                        type: string
+                      healthCheckNodePort:
+                        description: healthCheckNodePort specifies the healthcheck
+                          nodePort for the service. This only applies when type is
+                          set to LoadBalancer and externalTrafficPolicy is set to
+                          Local. If a value is specified, is in-range, and is not
+                          in use, it will be used.  If not specified, a value will
+                          be automatically allocated.  External systems (e.g. load-balancers)
+                          can use this port to determine if a given node holds endpoints
+                          for this service or not.  If this field is specified when
+                          creating a Service which does not need it, creation will
+                          fail. This field will be wiped when updating a Service to
+                          no longer need it (e.g. changing type). This field cannot
+                          be updated once set.
+                        format: int32
+                        type: integer
+                      internalTrafficPolicy:
+                        description: InternalTrafficPolicy describes how nodes distribute
+                          service traffic they receive on the ClusterIP. If set to
+                          "Local", the proxy will assume that pods only want to talk
+                          to endpoints of the service on the same node as the pod,
+                          dropping the traffic if there are no local endpoints. The
+                          default value, "Cluster", uses the standard behavior of
+                          routing to all endpoints evenly (possibly modified by topology
+                          and other features).
+                        type: string
+                      ipFamilies:
+                        description: "IPFamilies is a list of IP families (e.g. IPv4,
+                          IPv6) assigned to this service. This field is usually assigned
+                          automatically based on cluster configuration and the ipFamilyPolicy
+                          field. If this field is specified manually, the requested
+                          family is available in the cluster, and ipFamilyPolicy allows
+                          it, it will be used; otherwise creation of the service will
+                          fail. This field is conditionally mutable: it allows for
+                          adding or removing a secondary IP family, but it does not
+                          allow changing the primary IP family of the Service. Valid
+                          values are \"IPv4\" and \"IPv6\".  This field only applies
+                          to Services of types ClusterIP, NodePort, and LoadBalancer,
+                          and does apply to \"headless\" services. This field will
+                          be wiped when updating a Service to type ExternalName. \n
+                          This field may hold a maximum of two entries (dual-stack
+                          families, in either order).  These families must correspond
+                          to the values of the clusterIPs field, if specified. Both
+                          clusterIPs and ipFamilies are governed by the ipFamilyPolicy
+                          field."
+                        items:
+                          description: IPFamily represents the IP Family (IPv4 or
+                            IPv6). This type is used to express the family of an IP
+                            expressed by a type (e.g. service.spec.ipFamilies).
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      ipFamilyPolicy:
+                        description: IPFamilyPolicy represents the dual-stack-ness
+                          requested or required by this Service. If there is no value
+                          provided, then this field will be set to SingleStack. Services
+                          can be "SingleStack" (a single IP family), "PreferDualStack"
+                          (two IP families on dual-stack configured clusters or a
+                          single IP family on single-stack clusters), or "RequireDualStack"
+                          (two IP families on dual-stack configured clusters, otherwise
+                          fail). The ipFamilies and clusterIPs fields depend on the
+                          value of this field. This field will be wiped when updating
+                          a service to type ExternalName.
+                        type: string
+                      loadBalancerClass:
+                        description: loadBalancerClass is the class of the load balancer
+                          implementation this Service belongs to. If specified, the
+                          value of this field must be a label-style identifier, with
+                          an optional prefix, e.g. "internal-vip" or "example.com/internal-vip".
+                          Unprefixed names are reserved for end-users. This field
+                          can only be set when the Service type is 'LoadBalancer'.
+                          If not set, the default load balancer implementation is
+                          used, today this is typically done through the cloud provider
+                          integration, but should apply for any default implementation.
+                          If set, it is assumed that a load balancer implementation
+                          is watching for Services with a matching class. Any default
+                          load balancer implementation (e.g. cloud providers) should
+                          ignore Services that set this field. This field can only
+                          be set when creating or updating a Service to type 'LoadBalancer'.
+                          Once set, it can not be changed. This field will be wiped
+                          when a service is updated to a non 'LoadBalancer' type.
+                        type: string
+                      loadBalancerIP:
+                        description: 'Only applies to Service Type: LoadBalancer.
+                          This feature depends on whether the underlying cloud-provider
+                          supports specifying the loadBalancerIP when a load balancer
+                          is created. This field will be ignored if the cloud-provider
+                          does not support the feature. Deprecated: This field was
+                          under-specified and its meaning varies across implementations,
+                          and it cannot support dual-stack. As of Kubernetes v1.24,
+                          users are encouraged to use implementation-specific annotations
+                          when available. This field may be removed in a future API
+                          version.'
+                        type: string
+                      loadBalancerSourceRanges:
+                        description: 'If specified and supported by the platform,
+                          this will restrict traffic through the cloud-provider load-balancer
+                          will be restricted to the specified client IPs. This field
+                          will be ignored if the cloud-provider does not support the
+                          feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/'
+                        items:
+                          type: string
+                        type: array
+                      ports:
+                        description: 'The list of ports that are exposed by this service.
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                        items:
+                          description: ServicePort contains information on service's
+                            port.
+                          properties:
+                            appProtocol:
+                              description: The application protocol for this port.
+                                This field follows standard Kubernetes label syntax.
+                                Un-prefixed names are reserved for IANA standard service
+                                names (as per RFC-6335 and https://www.iana.org/assignments/service-names).
+                                Non-standard protocols should use prefixed names such
+                                as mycompany.com/my-custom-protocol.
+                              type: string
+                            name:
+                              description: The name of this port within the service.
+                                This must be a DNS_LABEL. All ports within a ServiceSpec
+                                must have unique names. When considering the endpoints
+                                for a Service, this must match the 'name' field in
+                                the EndpointPort. Optional if only one ServicePort
+                                is defined on this service.
+                              type: string
+                            nodePort:
+                              description: 'The port on each node on which this service
+                                is exposed when type is NodePort or LoadBalancer.  Usually
+                                assigned by the system. If a value is specified, in-range,
+                                and not in use it will be used, otherwise the operation
+                                will fail.  If not specified, a port will be allocated
+                                if this Service requires one.  If this field is specified
+                                when creating a Service which does not need it, creation
+                                will fail. This field will be wiped when updating
+                                a Service to no longer need it (e.g. changing type
+                                from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                              format: int32
+                              type: integer
+                            port:
+                              description: The port that will be exposed by this service.
+                              format: int32
+                              type: integer
+                            protocol:
+                              default: TCP
+                              description: The IP protocol for this port. Supports
+                                "TCP", "UDP", and "SCTP". Default is TCP.
+                              type: string
+                            targetPort:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: 'Number or name of the port to access on
+                                the pods targeted by the service. Number must be in
+                                the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                If this is a string, it will be looked up as a named
+                                port in the target Pod''s container ports. If this
+                                is not specified, the value of the ''port'' field
+                                is used (an identity map). This field is ignored for
+                                services with clusterIP=None, and should be omitted
+                                or set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - port
+                        - protocol
+                        x-kubernetes-list-type: map
+                      publishNotReadyAddresses:
+                        description: publishNotReadyAddresses indicates that any agent
+                          which deals with endpoints for this Service should disregard
+                          any indications of ready/not-ready. The primary use case
+                          for setting this field is for a StatefulSet's Headless Service
+                          to propagate SRV DNS records for its Pods for the purpose
+                          of peer discovery. The Kubernetes controllers that generate
+                          Endpoints and EndpointSlice resources for Services interpret
+                          this to mean that all endpoints are considered "ready" even
+                          if the Pods themselves are not. Agents which consume only
+                          Kubernetes generated endpoints through the Endpoints or
+                          EndpointSlice resources can safely assume this behavior.
+                        type: boolean
+                      selector:
+                        additionalProperties:
+                          type: string
+                        description: 'Route service traffic to pods with label keys
+                          and values matching this selector. If empty or not present,
+                          the service is assumed to have an external process managing
+                          its endpoints, which Kubernetes will not modify. Only applies
+                          to types ClusterIP, NodePort, and LoadBalancer. Ignored
+                          if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      sessionAffinity:
+                        description: 'Supports "ClientIP" and "None". Used to maintain
+                          session affinity. Enable client IP based session affinity.
+                          Must be ClientIP or None. Defaults to None. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                        type: string
+                      sessionAffinityConfig:
+                        description: sessionAffinityConfig contains the configurations
+                          of session affinity.
+                        properties:
+                          clientIP:
+                            description: clientIP contains the configurations of Client
+                              IP based session affinity.
+                            properties:
+                              timeoutSeconds:
+                                description: timeoutSeconds specifies the seconds
+                                  of ClientIP type session sticky time. The value
+                                  must be >0 && <=86400(for 1 day) if ServiceAffinity
+                                  == "ClientIP". Default value is 10800(for 3 hours).
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                      type:
+                        description: 'type determines how the Service is exposed.
+                          Defaults to ClusterIP. Valid options are ExternalName, ClusterIP,
+                          NodePort, and LoadBalancer. "ClusterIP" allocates a cluster-internal
+                          IP address for load-balancing to endpoints. Endpoints are
+                          determined by the selector or if that is not specified,
+                          by manual construction of an Endpoints object or EndpointSlice
+                          objects. If clusterIP is "None", no virtual IP is allocated
+                          and the endpoints are published as a set of endpoints rather
+                          than a virtual IP. "NodePort" builds on ClusterIP and allocates
+                          a port on every node which routes to the same endpoints
+                          as the clusterIP. "LoadBalancer" builds on NodePort and
+                          creates an external load-balancer (if supported in the current
+                          cloud) which routes to the same endpoints as the clusterIP.
+                          "ExternalName" aliases this service to the specified externalName.
+                          Several other fields do not apply to ExternalName services.
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                        type: string
+                    type: object
+                type: object
+            type: object
+          status:
+            description: ResourceExportStatus defines the observed state of ResourceExport.
+            properties:
+              conditions:
+                items:
+                  description: ResourceExportCondition indicates the readiness condition
+                    of the ResourceExport.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transited from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      type: string
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.0
+  creationTimestamp: null
+  labels:
+    app: antrea
+  name: resourceimports.multicluster.crd.antrea.io
+spec:
+  group: multicluster.crd.antrea.io
+  names:
+    kind: ResourceImport
+    listKind: ResourceImportList
+    plural: resourceimports
+    singular: resourceimport
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Kind of the imported resource
+      jsonPath: .spec.kind
+      name: Kind
+      type: string
+    - description: Namespace of the imported resource
+      jsonPath: .spec.namespace
+      name: Namespace
+      type: string
+    - description: Name of the imported resource
+      jsonPath: .spec.name
+      name: Name
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ResourceImport is the Schema for the resourceimports API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ResourceImportSpec defines the desired state of ResourceImport.
+            properties:
+              clusterID:
+                description: ClusterIDs specifies the member clusters this resource
+                  to import to. When not specified, import to all member clusters.
+                items:
+                  type: string
+                type: array
+              clusterinfo:
+                description: If imported resource is ClusterInfo.
+                properties:
+                  clusterID:
+                    description: ClusterID of the member cluster.
+                    type: string
+                  gatewayInfos:
+                    description: GatewayInfos has information of Gateways
+                    items:
+                      description: GatewayInfo includes information of a Gateway.
+                      properties:
+                        gatewayIP:
+                          type: string
+                      type: object
+                    type: array
+                  podCIDRs:
+                    description: PodCIDRs is the Pod IP address CIDRs.
+                    items:
+                      type: string
+                    type: array
+                  serviceCIDR:
+                    description: ServiceCIDR is the IP ranges used by Service ClusterIP.
+                    type: string
+                  wireGuard:
+                    description: WireGuardInfo includes information of a WireGuard
+                      tunnel.
+                    properties:
+                      publicKey:
+                        description: Public key of the WireGuard tunnel.
+                        type: string
+                    type: object
+                type: object
+              clusternetworkpolicy:
+                description: If imported resource is AntreaClusterNetworkPolicy.
+                properties:
+                  appliedTo:
+                    description: Select workloads on which the rules will be applied
+                      to. Cannot be set in conjunction with AppliedTo in each rule.
+                    items:
+                      description: AppliedTo describes the grouping selector of workloads
+                        in AppliedTo field.
+                      properties:
+                        externalEntitySelector:
+                          description: Select ExternalEntities from NetworkPolicy's
+                            Namespace as workloads in AppliedTo fields. If set with
+                            NamespaceSelector, ExternalEntities are matched from Namespaces
+                            matched by the NamespaceSelector. Cannot be set with any
+                            other selector except NamespaceSelector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        group:
+                          description: Group is the name of the ClusterGroup which
+                            can be set as an AppliedTo in place of a stand-alone selector.
+                            A Group cannot be set with any other selector.
+                          type: string
+                        namespaceSelector:
+                          description: Select all Pods from Namespaces matched by
+                            this selector, as workloads in AppliedTo fields. If set
+                            with PodSelector, Pods are matched from Namespaces matched
+                            by the NamespaceSelector. Cannot be set with any other
+                            selector except PodSelector or ExternalEntitySelector.
+                            Cannot be set with Namespaces.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        podSelector:
+                          description: Select Pods from NetworkPolicy's Namespace
+                            as workloads in AppliedTo fields. If set with NamespaceSelector,
+                            Pods are matched from Namespaces matched by the NamespaceSelector.
+                            Cannot be set with any other selector except NamespaceSelector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        service:
+                          description: Select a certain Service which matches the
+                            NamespacedName. A Service can only be set in either policy
+                            level AppliedTo field in a policy that only has ingress
+                            rules or rule level AppliedTo field in an ingress rule.
+                            Only a NodePort Service can be referred by this field.
+                            Cannot be set with any other selector.
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
+                        serviceAccount:
+                          description: Select all Pods with the ServiceAccount matched
+                            by this field, as workloads in AppliedTo fields. Cannot
+                            be set with any other selector.
+                          properties:
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
+                      type: object
+                    type: array
+                  egress:
+                    description: Set of egress rules evaluated based on the order
+                      in which they are set. Currently Egress rule supports setting
+                      the `To` field but not the `From` field within a Rule.
+                    items:
+                      description: Rule describes the traffic allowed to/from the
+                        workloads selected by Spec.AppliedTo. Based on the action
+                        specified in the rule, traffic is either allowed or denied
+                        which exactly match the specified ports and protocol.
+                      properties:
+                        action:
+                          description: Action specifies the action to be applied on
+                            the rule.
+                          type: string
+                        appliedTo:
+                          description: Select workloads on which this rule will be
+                            applied to. Cannot be set in conjunction with NetworkPolicySpec/ClusterNetworkPolicySpec.AppliedTo.
+                          items:
+                            description: AppliedTo describes the grouping selector
+                              of workloads in AppliedTo field.
+                            properties:
+                              externalEntitySelector:
+                                description: Select ExternalEntities from NetworkPolicy's
+                                  Namespace as workloads in AppliedTo fields. If set
+                                  with NamespaceSelector, ExternalEntities are matched
+                                  from Namespaces matched by the NamespaceSelector.
+                                  Cannot be set with any other selector except NamespaceSelector.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              group:
+                                description: Group is the name of the ClusterGroup
+                                  which can be set as an AppliedTo in place of a stand-alone
+                                  selector. A Group cannot be set with any other selector.
+                                type: string
+                              namespaceSelector:
+                                description: Select all Pods from Namespaces matched
+                                  by this selector, as workloads in AppliedTo fields.
+                                  If set with PodSelector, Pods are matched from Namespaces
+                                  matched by the NamespaceSelector. Cannot be set
+                                  with any other selector except PodSelector or ExternalEntitySelector.
+                                  Cannot be set with Namespaces.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              podSelector:
+                                description: Select Pods from NetworkPolicy's Namespace
+                                  as workloads in AppliedTo fields. If set with NamespaceSelector,
+                                  Pods are matched from Namespaces matched by the
+                                  NamespaceSelector. Cannot be set with any other
+                                  selector except NamespaceSelector.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              service:
+                                description: Select a certain Service which matches
+                                  the NamespacedName. A Service can only be set in
+                                  either policy level AppliedTo field in a policy
+                                  that only has ingress rules or rule level AppliedTo
+                                  field in an ingress rule. Only a NodePort Service
+                                  can be referred by this field. Cannot be set with
+                                  any other selector.
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                type: object
+                              serviceAccount:
+                                description: Select all Pods with the ServiceAccount
+                                  matched by this field, as workloads in AppliedTo
+                                  fields. Cannot be set with any other selector.
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        enableLogging:
+                          description: EnableLogging is used to indicate if agent
+                            should generate logs when rules are matched. Should be
+                            default to false.
+                          type: boolean
+                        from:
+                          description: Rule is matched if traffic originates from
+                            workloads selected by this field. If this field is empty,
+                            this rule matches all sources.
+                          items:
+                            description: NetworkPolicyPeer describes the grouping
+                              selector of workloads.
+                            properties:
+                              externalEntitySelector:
+                                description: Select ExternalEntities from NetworkPolicy's
+                                  Namespace as workloads in To/From fields. If set
+                                  with NamespaceSelector, ExternalEntities are matched
+                                  from Namespaces matched by the NamespaceSelector.
+                                  Cannot be set with any other selector except NamespaceSelector.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              fqdn:
+                                description: 'Restrict egress access to the Fully
+                                  Qualified Domain Names prescribed by name or by
+                                  wildcard match patterns. This field can only be
+                                  set for NetworkPolicyPeer of egress rules. Supported
+                                  formats are: Exact FQDNs, i.e. "google.com", "db-svc.default.svc.cluster.local"
+                                  Wildcard expressions, i.e. "*wayfair.com".'
+                                type: string
+                              group:
+                                description: Group is the name of the ClusterGroup
+                                  which can be set within an Ingress or Egress rule
+                                  in place of a stand-alone selector. A Group cannot
+                                  be set with any other selector.
+                                type: string
+                              ipBlock:
+                                description: IPBlock describes the IPAddresses/IPBlocks
+                                  that is matched in to/from. IPBlock cannot be set
+                                  as part of the AppliedTo field. Cannot be set with
+                                  any other selector.
+                                properties:
+                                  cidr:
+                                    description: CIDR is a string representing the
+                                      IP Block Valid examples are "192.168.1.1/24".
+                                    type: string
+                                required:
+                                - cidr
+                                type: object
+                              namespaceSelector:
+                                description: Select all Pods from Namespaces matched
+                                  by this selector, as workloads in To/From fields.
+                                  If set with PodSelector, Pods are matched from Namespaces
+                                  matched by the NamespaceSelector. Cannot be set
+                                  with any other selector except PodSelector or ExternalEntitySelector.
+                                  Cannot be set with Namespaces.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaces:
+                                description: 'Select Pod/ExternalEntity from Namespaces
+                                  matched by specific criteria. Current supported
+                                  criteria is match: Self, which selects from the
+                                  same Namespace of the appliedTo workloads. Cannot
+                                  be set with any other selector except PodSelector
+                                  or ExternalEntitySelector. This field can only be
+                                  set when NetworkPolicyPeer is created for ClusterNetworkPolicy
+                                  ingress/egress rules. Cannot be set with NamespaceSelector.'
+                                properties:
+                                  match:
+                                    description: NamespaceMatchType describes Namespace
+                                      matching strategy.
+                                    type: string
+                                type: object
+                              nodeSelector:
+                                description: Select certain Nodes which match the
+                                  label selector. A NodeSelector cannot be set in
+                                  AppliedTo field or set with any other selector.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              podSelector:
+                                description: Select Pods from NetworkPolicy's Namespace
+                                  as workloads in To/From fields. If set with NamespaceSelector,
+                                  Pods are matched from Namespaces matched by the
+                                  NamespaceSelector. Cannot be set with any other
+                                  selector except NamespaceSelector.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              scope:
+                                description: Define scope of the Pod/NamespaceSelector(s)
+                                  of this peer. Can only be used in ingress NetworkPolicyPeers.
+                                  Defaults to "Cluster".
+                                type: string
+                              serviceAccount:
+                                description: Select all Pods with the ServiceAccount
+                                  matched by this field, as workloads in To/From fields.
+                                  Cannot be set with any other selector.
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        l7Protocols:
+                          description: Set of layer 7 protocols matched by the rule.
+                            If this field is set, action can only be Allow. When this
+                            field is used in a rule, any traffic matching the other
+                            layer 3/4 criteria of the rule (typically the 5-tuple)
+                            will be forwarded to an application-aware engine for protocol
+                            detection and rule enforcement, and the traffic will be
+                            allowed if the layer 7 criteria is also matched, otherwise
+                            it will be dropped. Therefore, any rules after a layer
+                            7 rule will not be enforced for the traffic.
+                          items:
+                            properties:
+                              http:
+                                description: HTTPProtocol matches HTTP requests with
+                                  specific host, method, and path. All fields could
+                                  be used alone or together. If all fields are not
+                                  provided, it matches all HTTP requests.
+                                properties:
+                                  host:
+                                    description: Host represents the hostname present
+                                      in the URI or the HTTP Host header to match.
+                                      It does not contain the port associated with
+                                      the host.
+                                    type: string
+                                  method:
+                                    description: Method represents the HTTP method
+                                      to match. It could be GET, POST, PUT, HEAD,
+                                      DELETE, TRACE, OPTIONS, CONNECT and PATCH.
+                                    type: string
+                                  path:
+                                    description: Path represents the URI path to match
+                                      (Ex. "/index.html", "/admin").
+                                    type: string
+                                type: object
+                              tls:
+                                description: TLSProtocol matches TLS handshake packets
+                                  with specific SNI. If the field is not provided,
+                                  this matches all TLS handshake packets.
+                                properties:
+                                  sni:
+                                    description: SNI (Server Name Indication) indicates
+                                      the server domain name in the TLS/SSL hello
+                                      message.
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        logLabel:
+                          description: LogLabel is a user-defined arbitrary string
+                            which will be printed in the NetworkPolicy logs.
+                          type: string
+                        name:
+                          description: Name describes the intention of this rule.
+                            Name should be unique within the policy.
+                          type: string
+                        ports:
+                          description: Set of ports and protocols matched by the rule.
+                            If this field and Protocols are unset or empty, this rule
+                            matches all ports.
+                          items:
+                            description: NetworkPolicyPort describes the port and
+                              protocol to match in a rule.
+                            properties:
+                              endPort:
+                                description: EndPort defines the end of the port range,
+                                  inclusive. It can only be specified when a numerical
+                                  `port` is specified.
+                                format: int32
+                                type: integer
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: The port on the given protocol. This
+                                  can be either a numerical or named port on a Pod.
+                                  If this field is not provided, this matches all
+                                  port names and numbers.
+                                x-kubernetes-int-or-string: true
+                              protocol:
+                                default: TCP
+                                description: The protocol (TCP, UDP, or SCTP) which
+                                  traffic must match. If not specified, this field
+                                  defaults to TCP.
+                                type: string
+                              sourceEndPort:
+                                description: SourceEndPort defines the end of the
+                                  source port range, inclusive. It can only be specified
+                                  when `sourcePort` is specified.
+                                format: int32
+                                type: integer
+                              sourcePort:
+                                description: The source port on the given protocol.
+                                  This can only be a numerical port. If this field
+                                  is not provided, rule matches all source ports.
+                                format: int32
+                                type: integer
+                            type: object
+                          type: array
+                        protocols:
+                          description: Set of protocols matched by the rule. If this
+                            field and Ports are unset or empty, this rule matches
+                            all protocols supported.
+                          items:
+                            description: NetworkPolicyProtocol defines additional
+                              protocols that are not supported by `ports`. All fields
+                              should be used as a standalone field.
+                            properties:
+                              icmp:
+                                description: ICMPProtocol matches ICMP traffic with
+                                  specific ICMPType and/or ICMPCode. All fields could
+                                  be used alone or together. If all fields are not
+                                  provided, this matches all ICMP traffic.
+                                properties:
+                                  icmpCode:
+                                    format: int32
+                                    type: integer
+                                  icmpType:
+                                    format: int32
+                                    type: integer
+                                type: object
+                              igmp:
+                                description: 'IGMPProtocol matches IGMP traffic with
+                                  IGMPType and GroupAddress. IGMPType must be filled
+                                  with: IGMPQuery    int32 = 0x11 IGMPReportV1 int32
+                                  = 0x12 IGMPReportV2 int32 = 0x16 IGMPReportV3 int32
+                                  = 0x22 If groupAddress is empty, all groupAddresses
+                                  will be matched.'
+                                properties:
+                                  groupAddress:
+                                    type: string
+                                  igmpType:
+                                    format: int32
+                                    type: integer
+                                type: object
+                            type: object
+                          type: array
+                        to:
+                          description: Rule is matched if traffic is intended for
+                            workloads selected by this field. This field can't be
+                            used with ToServices. If this field and ToServices are
+                            both empty or missing this rule matches all destinations.
+                          items:
+                            description: NetworkPolicyPeer describes the grouping
+                              selector of workloads.
+                            properties:
+                              externalEntitySelector:
+                                description: Select ExternalEntities from NetworkPolicy's
+                                  Namespace as workloads in To/From fields. If set
+                                  with NamespaceSelector, ExternalEntities are matched
+                                  from Namespaces matched by the NamespaceSelector.
+                                  Cannot be set with any other selector except NamespaceSelector.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              fqdn:
+                                description: 'Restrict egress access to the Fully
+                                  Qualified Domain Names prescribed by name or by
+                                  wildcard match patterns. This field can only be
+                                  set for NetworkPolicyPeer of egress rules. Supported
+                                  formats are: Exact FQDNs, i.e. "google.com", "db-svc.default.svc.cluster.local"
+                                  Wildcard expressions, i.e. "*wayfair.com".'
+                                type: string
+                              group:
+                                description: Group is the name of the ClusterGroup
+                                  which can be set within an Ingress or Egress rule
+                                  in place of a stand-alone selector. A Group cannot
+                                  be set with any other selector.
+                                type: string
+                              ipBlock:
+                                description: IPBlock describes the IPAddresses/IPBlocks
+                                  that is matched in to/from. IPBlock cannot be set
+                                  as part of the AppliedTo field. Cannot be set with
+                                  any other selector.
+                                properties:
+                                  cidr:
+                                    description: CIDR is a string representing the
+                                      IP Block Valid examples are "192.168.1.1/24".
+                                    type: string
+                                required:
+                                - cidr
+                                type: object
+                              namespaceSelector:
+                                description: Select all Pods from Namespaces matched
+                                  by this selector, as workloads in To/From fields.
+                                  If set with PodSelector, Pods are matched from Namespaces
+                                  matched by the NamespaceSelector. Cannot be set
+                                  with any other selector except PodSelector or ExternalEntitySelector.
+                                  Cannot be set with Namespaces.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaces:
+                                description: 'Select Pod/ExternalEntity from Namespaces
+                                  matched by specific criteria. Current supported
+                                  criteria is match: Self, which selects from the
+                                  same Namespace of the appliedTo workloads. Cannot
+                                  be set with any other selector except PodSelector
+                                  or ExternalEntitySelector. This field can only be
+                                  set when NetworkPolicyPeer is created for ClusterNetworkPolicy
+                                  ingress/egress rules. Cannot be set with NamespaceSelector.'
+                                properties:
+                                  match:
+                                    description: NamespaceMatchType describes Namespace
+                                      matching strategy.
+                                    type: string
+                                type: object
+                              nodeSelector:
+                                description: Select certain Nodes which match the
+                                  label selector. A NodeSelector cannot be set in
+                                  AppliedTo field or set with any other selector.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              podSelector:
+                                description: Select Pods from NetworkPolicy's Namespace
+                                  as workloads in To/From fields. If set with NamespaceSelector,
+                                  Pods are matched from Namespaces matched by the
+                                  NamespaceSelector. Cannot be set with any other
+                                  selector except NamespaceSelector.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              scope:
+                                description: Define scope of the Pod/NamespaceSelector(s)
+                                  of this peer. Can only be used in ingress NetworkPolicyPeers.
+                                  Defaults to "Cluster".
+                                type: string
+                              serviceAccount:
+                                description: Select all Pods with the ServiceAccount
+                                  matched by this field, as workloads in To/From fields.
+                                  Cannot be set with any other selector.
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        toServices:
+                          description: Rule is matched if traffic is intended for
+                            a Service listed in this field. Currently, only ClusterIP
+                            types Services are supported in this field. When scope
+                            is set to ClusterSet, it matches traffic intended for
+                            a multi-cluster Service listed in this field. Service
+                            name and Namespace provided should match the original
+                            exported Service. This field can only be used when AntreaProxy
+                            is enabled. This field can't be used with To or Ports.
+                            If this field and To are both empty or missing, this rule
+                            matches all destinations.
+                          items:
+                            description: PeerService refers to a Service, which can
+                              be a in-cluster Service or imported multi-cluster service.
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                              scope:
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  ingress:
+                    description: Set of ingress rules evaluated based on the order
+                      in which they are set. Currently Ingress rule supports setting
+                      the `From` field but not the `To` field within a Rule.
+                    items:
+                      description: Rule describes the traffic allowed to/from the
+                        workloads selected by Spec.AppliedTo. Based on the action
+                        specified in the rule, traffic is either allowed or denied
+                        which exactly match the specified ports and protocol.
+                      properties:
+                        action:
+                          description: Action specifies the action to be applied on
+                            the rule.
+                          type: string
+                        appliedTo:
+                          description: Select workloads on which this rule will be
+                            applied to. Cannot be set in conjunction with NetworkPolicySpec/ClusterNetworkPolicySpec.AppliedTo.
+                          items:
+                            description: AppliedTo describes the grouping selector
+                              of workloads in AppliedTo field.
+                            properties:
+                              externalEntitySelector:
+                                description: Select ExternalEntities from NetworkPolicy's
+                                  Namespace as workloads in AppliedTo fields. If set
+                                  with NamespaceSelector, ExternalEntities are matched
+                                  from Namespaces matched by the NamespaceSelector.
+                                  Cannot be set with any other selector except NamespaceSelector.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              group:
+                                description: Group is the name of the ClusterGroup
+                                  which can be set as an AppliedTo in place of a stand-alone
+                                  selector. A Group cannot be set with any other selector.
+                                type: string
+                              namespaceSelector:
+                                description: Select all Pods from Namespaces matched
+                                  by this selector, as workloads in AppliedTo fields.
+                                  If set with PodSelector, Pods are matched from Namespaces
+                                  matched by the NamespaceSelector. Cannot be set
+                                  with any other selector except PodSelector or ExternalEntitySelector.
+                                  Cannot be set with Namespaces.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              podSelector:
+                                description: Select Pods from NetworkPolicy's Namespace
+                                  as workloads in AppliedTo fields. If set with NamespaceSelector,
+                                  Pods are matched from Namespaces matched by the
+                                  NamespaceSelector. Cannot be set with any other
+                                  selector except NamespaceSelector.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              service:
+                                description: Select a certain Service which matches
+                                  the NamespacedName. A Service can only be set in
+                                  either policy level AppliedTo field in a policy
+                                  that only has ingress rules or rule level AppliedTo
+                                  field in an ingress rule. Only a NodePort Service
+                                  can be referred by this field. Cannot be set with
+                                  any other selector.
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                type: object
+                              serviceAccount:
+                                description: Select all Pods with the ServiceAccount
+                                  matched by this field, as workloads in AppliedTo
+                                  fields. Cannot be set with any other selector.
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        enableLogging:
+                          description: EnableLogging is used to indicate if agent
+                            should generate logs when rules are matched. Should be
+                            default to false.
+                          type: boolean
+                        from:
+                          description: Rule is matched if traffic originates from
+                            workloads selected by this field. If this field is empty,
+                            this rule matches all sources.
+                          items:
+                            description: NetworkPolicyPeer describes the grouping
+                              selector of workloads.
+                            properties:
+                              externalEntitySelector:
+                                description: Select ExternalEntities from NetworkPolicy's
+                                  Namespace as workloads in To/From fields. If set
+                                  with NamespaceSelector, ExternalEntities are matched
+                                  from Namespaces matched by the NamespaceSelector.
+                                  Cannot be set with any other selector except NamespaceSelector.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              fqdn:
+                                description: 'Restrict egress access to the Fully
+                                  Qualified Domain Names prescribed by name or by
+                                  wildcard match patterns. This field can only be
+                                  set for NetworkPolicyPeer of egress rules. Supported
+                                  formats are: Exact FQDNs, i.e. "google.com", "db-svc.default.svc.cluster.local"
+                                  Wildcard expressions, i.e. "*wayfair.com".'
+                                type: string
+                              group:
+                                description: Group is the name of the ClusterGroup
+                                  which can be set within an Ingress or Egress rule
+                                  in place of a stand-alone selector. A Group cannot
+                                  be set with any other selector.
+                                type: string
+                              ipBlock:
+                                description: IPBlock describes the IPAddresses/IPBlocks
+                                  that is matched in to/from. IPBlock cannot be set
+                                  as part of the AppliedTo field. Cannot be set with
+                                  any other selector.
+                                properties:
+                                  cidr:
+                                    description: CIDR is a string representing the
+                                      IP Block Valid examples are "192.168.1.1/24".
+                                    type: string
+                                required:
+                                - cidr
+                                type: object
+                              namespaceSelector:
+                                description: Select all Pods from Namespaces matched
+                                  by this selector, as workloads in To/From fields.
+                                  If set with PodSelector, Pods are matched from Namespaces
+                                  matched by the NamespaceSelector. Cannot be set
+                                  with any other selector except PodSelector or ExternalEntitySelector.
+                                  Cannot be set with Namespaces.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaces:
+                                description: 'Select Pod/ExternalEntity from Namespaces
+                                  matched by specific criteria. Current supported
+                                  criteria is match: Self, which selects from the
+                                  same Namespace of the appliedTo workloads. Cannot
+                                  be set with any other selector except PodSelector
+                                  or ExternalEntitySelector. This field can only be
+                                  set when NetworkPolicyPeer is created for ClusterNetworkPolicy
+                                  ingress/egress rules. Cannot be set with NamespaceSelector.'
+                                properties:
+                                  match:
+                                    description: NamespaceMatchType describes Namespace
+                                      matching strategy.
+                                    type: string
+                                type: object
+                              nodeSelector:
+                                description: Select certain Nodes which match the
+                                  label selector. A NodeSelector cannot be set in
+                                  AppliedTo field or set with any other selector.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              podSelector:
+                                description: Select Pods from NetworkPolicy's Namespace
+                                  as workloads in To/From fields. If set with NamespaceSelector,
+                                  Pods are matched from Namespaces matched by the
+                                  NamespaceSelector. Cannot be set with any other
+                                  selector except NamespaceSelector.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              scope:
+                                description: Define scope of the Pod/NamespaceSelector(s)
+                                  of this peer. Can only be used in ingress NetworkPolicyPeers.
+                                  Defaults to "Cluster".
+                                type: string
+                              serviceAccount:
+                                description: Select all Pods with the ServiceAccount
+                                  matched by this field, as workloads in To/From fields.
+                                  Cannot be set with any other selector.
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        l7Protocols:
+                          description: Set of layer 7 protocols matched by the rule.
+                            If this field is set, action can only be Allow. When this
+                            field is used in a rule, any traffic matching the other
+                            layer 3/4 criteria of the rule (typically the 5-tuple)
+                            will be forwarded to an application-aware engine for protocol
+                            detection and rule enforcement, and the traffic will be
+                            allowed if the layer 7 criteria is also matched, otherwise
+                            it will be dropped. Therefore, any rules after a layer
+                            7 rule will not be enforced for the traffic.
+                          items:
+                            properties:
+                              http:
+                                description: HTTPProtocol matches HTTP requests with
+                                  specific host, method, and path. All fields could
+                                  be used alone or together. If all fields are not
+                                  provided, it matches all HTTP requests.
+                                properties:
+                                  host:
+                                    description: Host represents the hostname present
+                                      in the URI or the HTTP Host header to match.
+                                      It does not contain the port associated with
+                                      the host.
+                                    type: string
+                                  method:
+                                    description: Method represents the HTTP method
+                                      to match. It could be GET, POST, PUT, HEAD,
+                                      DELETE, TRACE, OPTIONS, CONNECT and PATCH.
+                                    type: string
+                                  path:
+                                    description: Path represents the URI path to match
+                                      (Ex. "/index.html", "/admin").
+                                    type: string
+                                type: object
+                              tls:
+                                description: TLSProtocol matches TLS handshake packets
+                                  with specific SNI. If the field is not provided,
+                                  this matches all TLS handshake packets.
+                                properties:
+                                  sni:
+                                    description: SNI (Server Name Indication) indicates
+                                      the server domain name in the TLS/SSL hello
+                                      message.
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        logLabel:
+                          description: LogLabel is a user-defined arbitrary string
+                            which will be printed in the NetworkPolicy logs.
+                          type: string
+                        name:
+                          description: Name describes the intention of this rule.
+                            Name should be unique within the policy.
+                          type: string
+                        ports:
+                          description: Set of ports and protocols matched by the rule.
+                            If this field and Protocols are unset or empty, this rule
+                            matches all ports.
+                          items:
+                            description: NetworkPolicyPort describes the port and
+                              protocol to match in a rule.
+                            properties:
+                              endPort:
+                                description: EndPort defines the end of the port range,
+                                  inclusive. It can only be specified when a numerical
+                                  `port` is specified.
+                                format: int32
+                                type: integer
+                              port:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: The port on the given protocol. This
+                                  can be either a numerical or named port on a Pod.
+                                  If this field is not provided, this matches all
+                                  port names and numbers.
+                                x-kubernetes-int-or-string: true
+                              protocol:
+                                default: TCP
+                                description: The protocol (TCP, UDP, or SCTP) which
+                                  traffic must match. If not specified, this field
+                                  defaults to TCP.
+                                type: string
+                              sourceEndPort:
+                                description: SourceEndPort defines the end of the
+                                  source port range, inclusive. It can only be specified
+                                  when `sourcePort` is specified.
+                                format: int32
+                                type: integer
+                              sourcePort:
+                                description: The source port on the given protocol.
+                                  This can only be a numerical port. If this field
+                                  is not provided, rule matches all source ports.
+                                format: int32
+                                type: integer
+                            type: object
+                          type: array
+                        protocols:
+                          description: Set of protocols matched by the rule. If this
+                            field and Ports are unset or empty, this rule matches
+                            all protocols supported.
+                          items:
+                            description: NetworkPolicyProtocol defines additional
+                              protocols that are not supported by `ports`. All fields
+                              should be used as a standalone field.
+                            properties:
+                              icmp:
+                                description: ICMPProtocol matches ICMP traffic with
+                                  specific ICMPType and/or ICMPCode. All fields could
+                                  be used alone or together. If all fields are not
+                                  provided, this matches all ICMP traffic.
+                                properties:
+                                  icmpCode:
+                                    format: int32
+                                    type: integer
+                                  icmpType:
+                                    format: int32
+                                    type: integer
+                                type: object
+                              igmp:
+                                description: 'IGMPProtocol matches IGMP traffic with
+                                  IGMPType and GroupAddress. IGMPType must be filled
+                                  with: IGMPQuery    int32 = 0x11 IGMPReportV1 int32
+                                  = 0x12 IGMPReportV2 int32 = 0x16 IGMPReportV3 int32
+                                  = 0x22 If groupAddress is empty, all groupAddresses
+                                  will be matched.'
+                                properties:
+                                  groupAddress:
+                                    type: string
+                                  igmpType:
+                                    format: int32
+                                    type: integer
+                                type: object
+                            type: object
+                          type: array
+                        to:
+                          description: Rule is matched if traffic is intended for
+                            workloads selected by this field. This field can't be
+                            used with ToServices. If this field and ToServices are
+                            both empty or missing this rule matches all destinations.
+                          items:
+                            description: NetworkPolicyPeer describes the grouping
+                              selector of workloads.
+                            properties:
+                              externalEntitySelector:
+                                description: Select ExternalEntities from NetworkPolicy's
+                                  Namespace as workloads in To/From fields. If set
+                                  with NamespaceSelector, ExternalEntities are matched
+                                  from Namespaces matched by the NamespaceSelector.
+                                  Cannot be set with any other selector except NamespaceSelector.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              fqdn:
+                                description: 'Restrict egress access to the Fully
+                                  Qualified Domain Names prescribed by name or by
+                                  wildcard match patterns. This field can only be
+                                  set for NetworkPolicyPeer of egress rules. Supported
+                                  formats are: Exact FQDNs, i.e. "google.com", "db-svc.default.svc.cluster.local"
+                                  Wildcard expressions, i.e. "*wayfair.com".'
+                                type: string
+                              group:
+                                description: Group is the name of the ClusterGroup
+                                  which can be set within an Ingress or Egress rule
+                                  in place of a stand-alone selector. A Group cannot
+                                  be set with any other selector.
+                                type: string
+                              ipBlock:
+                                description: IPBlock describes the IPAddresses/IPBlocks
+                                  that is matched in to/from. IPBlock cannot be set
+                                  as part of the AppliedTo field. Cannot be set with
+                                  any other selector.
+                                properties:
+                                  cidr:
+                                    description: CIDR is a string representing the
+                                      IP Block Valid examples are "192.168.1.1/24".
+                                    type: string
+                                required:
+                                - cidr
+                                type: object
+                              namespaceSelector:
+                                description: Select all Pods from Namespaces matched
+                                  by this selector, as workloads in To/From fields.
+                                  If set with PodSelector, Pods are matched from Namespaces
+                                  matched by the NamespaceSelector. Cannot be set
+                                  with any other selector except PodSelector or ExternalEntitySelector.
+                                  Cannot be set with Namespaces.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaces:
+                                description: 'Select Pod/ExternalEntity from Namespaces
+                                  matched by specific criteria. Current supported
+                                  criteria is match: Self, which selects from the
+                                  same Namespace of the appliedTo workloads. Cannot
+                                  be set with any other selector except PodSelector
+                                  or ExternalEntitySelector. This field can only be
+                                  set when NetworkPolicyPeer is created for ClusterNetworkPolicy
+                                  ingress/egress rules. Cannot be set with NamespaceSelector.'
+                                properties:
+                                  match:
+                                    description: NamespaceMatchType describes Namespace
+                                      matching strategy.
+                                    type: string
+                                type: object
+                              nodeSelector:
+                                description: Select certain Nodes which match the
+                                  label selector. A NodeSelector cannot be set in
+                                  AppliedTo field or set with any other selector.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              podSelector:
+                                description: Select Pods from NetworkPolicy's Namespace
+                                  as workloads in To/From fields. If set with NamespaceSelector,
+                                  Pods are matched from Namespaces matched by the
+                                  NamespaceSelector. Cannot be set with any other
+                                  selector except NamespaceSelector.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              scope:
+                                description: Define scope of the Pod/NamespaceSelector(s)
+                                  of this peer. Can only be used in ingress NetworkPolicyPeers.
+                                  Defaults to "Cluster".
+                                type: string
+                              serviceAccount:
+                                description: Select all Pods with the ServiceAccount
+                                  matched by this field, as workloads in To/From fields.
+                                  Cannot be set with any other selector.
+                                properties:
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        toServices:
+                          description: Rule is matched if traffic is intended for
+                            a Service listed in this field. Currently, only ClusterIP
+                            types Services are supported in this field. When scope
+                            is set to ClusterSet, it matches traffic intended for
+                            a multi-cluster Service listed in this field. Service
+                            name and Namespace provided should match the original
+                            exported Service. This field can only be used when AntreaProxy
+                            is enabled. This field can't be used with To or Ports.
+                            If this field and To are both empty or missing, this rule
+                            matches all destinations.
+                          items:
+                            description: PeerService refers to a Service, which can
+                              be a in-cluster Service or imported multi-cluster service.
+                            properties:
+                              name:
+                                type: string
+                              namespace:
+                                type: string
+                              scope:
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - action
+                      type: object
+                    type: array
+                  priority:
+                    description: Priority specfies the order of the ClusterNetworkPolicy
+                      relative to other AntreaClusterNetworkPolicies.
+                    type: number
+                  tier:
+                    description: Tier specifies the tier to which this ClusterNetworkPolicy
+                      belongs to. The ClusterNetworkPolicy order will be determined
+                      based on the combination of the Tier's Priority and the ClusterNetworkPolicy's
+                      own Priority. If not specified, this policy will be created
+                      in the Application Tier right above the K8s NetworkPolicy which
+                      resides at the bottom.
+                    type: string
+                required:
+                - priority
+                type: object
+              endpoints:
+                description: If imported resource is EndPoints.
+                properties:
+                  subsets:
+                    items:
+                      description: "EndpointSubset is a group of addresses with a
+                        common set of ports. The expanded set of endpoints is the
+                        Cartesian product of Addresses x Ports. For example, given:
+                        \n { Addresses: [{\"ip\": \"10.10.1.1\"}, {\"ip\": \"10.10.2.2\"}],
+                        Ports:     [{\"name\": \"a\", \"port\": 8675}, {\"name\":
+                        \"b\", \"port\": 309}] } \n The resulting set of endpoints
+                        can be viewed as: \n a: [ 10.10.1.1:8675, 10.10.2.2:8675 ],
+                        b: [ 10.10.1.1:309, 10.10.2.2:309 ]"
+                      properties:
+                        addresses:
+                          description: IP addresses which offer the related ports
+                            that are marked as ready. These endpoints should be considered
+                            safe for load balancers and clients to utilize.
+                          items:
+                            description: EndpointAddress is a tuple that describes
+                              single IP address.
+                            properties:
+                              hostname:
+                                description: The Hostname of this endpoint
+                                type: string
+                              ip:
+                                description: 'The IP of this endpoint. May not be
+                                  loopback (127.0.0.0/8), link-local (169.254.0.0/16),
+                                  or link-local multicast ((224.0.0.0/24). IPv6 is
+                                  also accepted but not fully supported on all platforms.
+                                  Also, certain kubernetes components, like kube-proxy,
+                                  are not IPv6 ready. TODO: This should allow hostname
+                                  or IP, See #4447.'
+                                type: string
+                              nodeName:
+                                description: 'Optional: Node hosting this endpoint.
+                                  This can be used to determine endpoints local to
+                                  a node.'
+                                type: string
+                              targetRef:
+                                description: Reference to object providing the endpoint.
+                                properties:
+                                  apiVersion:
+                                    description: API version of the referent.
+                                    type: string
+                                  fieldPath:
+                                    description: 'If referring to a piece of an object
+                                      instead of an entire object, this string should
+                                      contain a valid JSON/Go field access statement,
+                                      such as desiredState.manifest.containers[2].
+                                      For example, if the object reference is to a
+                                      container within a pod, this would take on a
+                                      value like: "spec.containers{name}" (where "name"
+                                      refers to the name of the container that triggered
+                                      the event) or if no container name is specified
+                                      "spec.containers[2]" (container with index 2
+                                      in this pod). This syntax is chosen only to
+                                      have some well-defined way of referencing a
+                                      part of an object. TODO: this design is not
+                                      final and this field is subject to change in
+                                      the future.'
+                                    type: string
+                                  kind:
+                                    description: 'Kind of the referent. More info:
+                                      https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  namespace:
+                                    description: 'Namespace of the referent. More
+                                      info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                    type: string
+                                  resourceVersion:
+                                    description: 'Specific resourceVersion to which
+                                      this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                    type: string
+                                  uid:
+                                    description: 'UID of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                    type: string
+                                type: object
+                            required:
+                            - ip
+                            type: object
+                          type: array
+                        notReadyAddresses:
+                          description: IP addresses which offer the related ports
+                            but are not currently marked as ready because they have
+                            not yet finished starting, have recently failed a readiness
+                            check, or have recently failed a liveness check.
+                          items:
+                            description: EndpointAddress is a tuple that describes
+                              single IP address.
+                            properties:
+                              hostname:
+                                description: The Hostname of this endpoint
+                                type: string
+                              ip:
+                                description: 'The IP of this endpoint. May not be
+                                  loopback (127.0.0.0/8), link-local (169.254.0.0/16),
+                                  or link-local multicast ((224.0.0.0/24). IPv6 is
+                                  also accepted but not fully supported on all platforms.
+                                  Also, certain kubernetes components, like kube-proxy,
+                                  are not IPv6 ready. TODO: This should allow hostname
+                                  or IP, See #4447.'
+                                type: string
+                              nodeName:
+                                description: 'Optional: Node hosting this endpoint.
+                                  This can be used to determine endpoints local to
+                                  a node.'
+                                type: string
+                              targetRef:
+                                description: Reference to object providing the endpoint.
+                                properties:
+                                  apiVersion:
+                                    description: API version of the referent.
+                                    type: string
+                                  fieldPath:
+                                    description: 'If referring to a piece of an object
+                                      instead of an entire object, this string should
+                                      contain a valid JSON/Go field access statement,
+                                      such as desiredState.manifest.containers[2].
+                                      For example, if the object reference is to a
+                                      container within a pod, this would take on a
+                                      value like: "spec.containers{name}" (where "name"
+                                      refers to the name of the container that triggered
+                                      the event) or if no container name is specified
+                                      "spec.containers[2]" (container with index 2
+                                      in this pod). This syntax is chosen only to
+                                      have some well-defined way of referencing a
+                                      part of an object. TODO: this design is not
+                                      final and this field is subject to change in
+                                      the future.'
+                                    type: string
+                                  kind:
+                                    description: 'Kind of the referent. More info:
+                                      https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  namespace:
+                                    description: 'Namespace of the referent. More
+                                      info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                                    type: string
+                                  resourceVersion:
+                                    description: 'Specific resourceVersion to which
+                                      this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                                    type: string
+                                  uid:
+                                    description: 'UID of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                                    type: string
+                                type: object
+                            required:
+                            - ip
+                            type: object
+                          type: array
+                        ports:
+                          description: Port numbers available on the related IP addresses.
+                          items:
+                            description: EndpointPort is a tuple that describes a
+                              single port.
+                            properties:
+                              appProtocol:
+                                description: The application protocol for this port.
+                                  This field follows standard Kubernetes label syntax.
+                                  Un-prefixed names are reserved for IANA standard
+                                  service names (as per RFC-6335 and https://www.iana.org/assignments/service-names).
+                                  Non-standard protocols should use prefixed names
+                                  such as mycompany.com/my-custom-protocol.
+                                type: string
+                              name:
+                                description: The name of this port.  This must match
+                                  the 'name' field in the corresponding ServicePort.
+                                  Must be a DNS_LABEL. Optional only if one port is
+                                  defined.
+                                type: string
+                              port:
+                                description: The port number of the endpoint.
+                                format: int32
+                                type: integer
+                              protocol:
+                                default: TCP
+                                description: The IP protocol for this port. Must be
+                                  UDP, TCP, or SCTP. Default is TCP.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          type: array
+                      type: object
+                    type: array
+                type: object
+              externalentity:
+                description: If imported resource is ExternalEntity.
+                properties:
+                  externalentityspec:
+                    description: ExternalEntitySpec defines the desired state for
+                      ExternalEntity.
+                    properties:
+                      endpoints:
+                        description: Endpoints is a list of external endpoints associated
+                          with this entity.
+                        items:
+                          description: Endpoint refers to an endpoint associated with
+                            the ExternalEntity.
+                          properties:
+                            ip:
+                              description: IP associated with this endpoint.
+                              type: string
+                            name:
+                              description: Name identifies this endpoint. Could be
+                                the network interface name in case of VMs.
+                              type: string
+                          type: object
+                        type: array
+                      externalNode:
+                        description: ExternalNode is the opaque identifier of the
+                          agent/controller responsible for additional processing or
+                          handling of this external entity.
+                        type: string
+                      ports:
+                        description: Ports maintain the list of named ports.
+                        items:
+                          description: NamedPort describes the port and protocol to
+                            match in a rule.
+                          properties:
+                            name:
+                              description: Name associated with the Port.
+                              type: string
+                            port:
+                              description: The port on the given protocol.
+                              format: int32
+                              type: integer
+                            protocol:
+                              default: TCP
+                              description: The protocol (TCP, UDP, or SCTP) which
+                                traffic must match. If not specified, this field defaults
+                                to TCP.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              kind:
+                description: Kind of imported resource.
+                type: string
+              labelIdentity:
+                description: If imported resource kind is LabelIdentity.
+                properties:
+                  id:
+                    description: ID is the ID allocated for the label identity by
+                      the leader cluster.
+                    format: int32
+                    type: integer
+                  label:
+                    description: Label is the normalized string of a label identity.
+                      The format of normalized label identity is `ns:(?P<nslabels>(.)*)&pod:(?P<podlabels>(.)*)`
+                      E.g., `ns:kubernetes.io/metadata.name=kube-system&pod:app=db`
+                    type: string
+                type: object
+              name:
+                description: Name of imported resource.
+                type: string
+              namespace:
+                description: Namespace of imported resource.
+                type: string
+              raw:
+                description: If imported resource kind is unknown.
+                properties:
+                  data:
+                    format: byte
+                    type: string
+                type: object
+              serviceImport:
+                description: If imported resource is ServiceImport.
+                properties:
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this
+                      representation of an object. Servers should convert recognized
+                      schemas to the latest internal value, and may reject unrecognized
+                      values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                    type: string
+                  kind:
+                    description: 'Kind is a string value representing the REST resource
+                      this object represents. Servers may infer this from the endpoint
+                      the client submits requests to. Cannot be updated. In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  metadata:
+                    type: object
+                  spec:
+                    description: spec defines the behavior of a ServiceImport.
+                    properties:
+                      ips:
+                        description: ip will be used as the VIP for this service when
+                          type is ClusterSetIP.
+                        items:
+                          type: string
+                        maxItems: 1
+                        type: array
+                      ports:
+                        items:
+                          description: ServicePort represents the port on which the
+                            service is exposed
+                          properties:
+                            appProtocol:
+                              description: The application protocol for this port.
+                                This field follows standard Kubernetes label syntax.
+                                Un-prefixed names are reserved for IANA standard service
+                                names (as per RFC-6335 and http://www.iana.org/assignments/service-names).
+                                Non-standard protocols should use prefixed names such
+                                as mycompany.com/my-custom-protocol. Field can be
+                                enabled with ServiceAppProtocol feature gate.
+                              type: string
+                            name:
+                              description: The name of this port within the service.
+                                This must be a DNS_LABEL. All ports within a ServiceSpec
+                                must have unique names. When considering the endpoints
+                                for a Service, this must match the 'name' field in
+                                the EndpointPort. Optional if only one ServicePort
+                                is defined on this service.
+                              type: string
+                            port:
+                              description: The port that will be exposed by this service.
+                              format: int32
+                              type: integer
+                            protocol:
+                              default: TCP
+                              description: The IP protocol for this port. Supports
+                                "TCP", "UDP", and "SCTP". Default is TCP.
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      sessionAffinity:
+                        description: 'Supports "ClientIP" and "None". Used to maintain
+                          session affinity. Enable client IP based session affinity.
+                          Must be ClientIP or None. Defaults to None. Ignored when
+                          type is Headless More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
+                        type: string
+                      sessionAffinityConfig:
+                        description: sessionAffinityConfig contains session affinity
+                          configuration.
+                        properties:
+                          clientIP:
+                            description: clientIP contains the configurations of Client
+                              IP based session affinity.
+                            properties:
+                              timeoutSeconds:
+                                description: timeoutSeconds specifies the seconds
+                                  of ClientIP type session sticky time. The value
+                                  must be >0 && <=86400(for 1 day) if ServiceAffinity
+                                  == "ClientIP". Default value is 10800(for 3 hours).
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                      type:
+                        description: type defines the type of this service. Must be
+                          ClusterSetIP or Headless.
+                        enum:
+                        - ClusterSetIP
+                        - Headless
+                        type: string
+                    required:
+                    - ports
+                    - type
+                    type: object
+                  status:
+                    description: status contains information about the exported services
+                      that form the multi-cluster service referenced by this ServiceImport.
+                    properties:
+                      clusters:
+                        description: clusters is the list of exporting clusters from
+                          which this service was derived.
+                        items:
+                          description: ClusterStatus contains service configuration
+                            mapped to a specific source cluster
+                          properties:
+                            cluster:
+                              description: cluster is the name of the exporting cluster.
+                                Must be a valid RFC-1123 DNS label.
+                              type: string
+                          required:
+                          - cluster
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - cluster
+                        x-kubernetes-list-type: map
+                    type: object
+                type: object
+            type: object
+          status:
+            description: ResourceImportStatus defines the observed state of ResourceImport.
+            properties:
+              clusterStatuses:
+                items:
+                  description: ResourceImportClusterStatus indicates the readiness
+                    status of the ResourceImport in clusters.
+                  properties:
+                    clusterID:
+                      description: ClusterID is the unique identifier of this cluster.
+                      type: string
+                    conditions:
+                      items:
+                        description: ResourceImportCondition indicates the condition
+                          of the ResourceImport in a cluster.
+                        properties:
+                          lastTransitionTime:
+                            description: Last time the condition transited from one
+                              status to another.
+                            format: date-time
+                            type: string
+                          message:
+                            description: A human readable message indicating details
+                              about the transition.
+                            type: string
+                          reason:
+                            description: Unique, one-word, CamelCase reason for the
+                              condition's last transition.
+                            type: string
+                          status:
+                            description: Status of the condition, one of True, False,
+                              Unknown.
+                            type: string
+                          type:
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: antrea
+  name: antrea-mc-controller
+  namespace: antrea-multicluster
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: antrea
+  name: antrea-mc-member-access-sa
+  namespace: antrea-multicluster
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  labels:
+    app: antrea
+  name: antrea-mc-controller-role
+  namespace: antrea-multicluster
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - clusterclaims
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - clustersets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - clustersets/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - clustersets/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - memberclusterannounces
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - memberclusterannounces/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - memberclusterannounces/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - resourceexports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - resourceexports/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - resourceexports/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - resourceimports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - resourceimports/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - resourceimports/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: antrea
+  name: antrea-mc-member-cluster-role
+  namespace: antrea-multicluster
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - memberclusterannounces
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - memberclusterannounces/status
+  verbs:
+  - get
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - resourceexports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - resourceexports/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - resourceimports
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - resourceimports/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app: antrea
+  name: antrea-multicluster-antrea-mc-controller-webhook-role
+rules:
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - list
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: antrea
+  name: antrea-mc-controller-rolebinding
+  namespace: antrea-multicluster
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: antrea-mc-controller-role
+subjects:
+- kind: ServiceAccount
+  name: antrea-mc-controller
+  namespace: antrea-multicluster
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: antrea
+  name: antrea-mc-member-cluster-rolebinding
+  namespace: antrea-multicluster
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: antrea-mc-member-cluster-role
+subjects:
+- kind: ServiceAccount
+  name: antrea-mc-member-access-sa
+  namespace: antrea-multicluster
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: antrea
+  name: antrea-multicluster-antrea-mc-controller-webhook-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: antrea-multicluster-antrea-mc-controller-webhook-role
+subjects:
+- kind: ServiceAccount
+  name: antrea-mc-controller
+  namespace: antrea-multicluster
+---
+apiVersion: v1
+data:
+  controller_manager_config.yaml: |
+    apiVersion: multicluster.crd.antrea.io/v1alpha1
+    kind: MultiClusterConfig
+    health:
+      healthProbeBindAddress: :8080
+    metrics:
+      bindAddress: "0"
+    webhook:
+      port: 9443
+    leaderElection:
+      leaderElect: false
+    serviceCIDR: ""
+    podCIDRs:
+      - ""
+    gatewayIPPrecedence: "private"
+    endpointIPType: "ClusterIP"
+    enableStretchedNetworkPolicy: false
+kind: ConfigMap
+metadata:
+  labels:
+    app: antrea
+  name: antrea-mc-controller-config
+  namespace: antrea-multicluster
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    kubernetes.io/service-account.name: antrea-mc-member-access-sa
+  labels:
+    app: antrea
+  name: antrea-mc-member-access-token
+  namespace: antrea-multicluster
+type: kubernetes.io/service-account-token
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: antrea
+  name: antrea-mc-webhook-service
+  namespace: antrea-multicluster
+spec:
+  ports:
+  - port: 443
+    targetPort: 9443
+  selector:
+    app: antrea
+    component: antrea-mc-controller
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: antrea
+    component: antrea-mc-controller
+  name: antrea-mc-controller
+  namespace: antrea-multicluster
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: antrea
+      component: antrea-mc-controller
+  template:
+    metadata:
+      annotations:
+        checksum/config: 7eb0f1e65f7eb3e35b0739d6064b92b7621af0f4e41813c35bfdee71ceaefbe2
+      labels:
+        app: antrea
+        component: antrea-mc-controller
+    spec:
+      containers:
+      - args:
+        - --config=/controller_manager_config.yaml
+        command:
+        - /antrea-mc-controller
+        - leader
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: antrea/antrea-mc-controller:latest
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: antrea-mc-controller
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          requests:
+            cpu: 200m
+        securityContext:
+          allowPrivilegeEscalation: false
+        volumeMounts:
+        - mountPath: /controller_manager_config.yaml
+          name: antrea-mc-controller-config
+          subPath: controller_manager_config.yaml
+      hostNetwork: true
+      serviceAccountName: antrea-mc-controller
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - configMap:
+          name: antrea-mc-controller-config
+        name: antrea-mc-controller-config
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    app: antrea
+    role: leader
+    served-by: antrea-mc-controller
+    served-in: antrea-multicluster
+  name: antrea-multicluster-antrea-mc-mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: antrea-mc-webhook-service
+      namespace: antrea-multicluster
+      path: /mutate-multicluster-crd-antrea-io-v1alpha1-resourceexport
+  failurePolicy: Fail
+  name: mresourceexport.kb.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: antrea-multicluster
+  rules:
+  - apiGroups:
+    - multicluster.crd.antrea.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - resourceexports
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    app: antrea
+    role: leader
+    served-by: antrea-mc-controller
+    served-in: antrea-multicluster
+  name: antrea-multicluster-antrea-mc-validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: antrea-mc-webhook-service
+      namespace: antrea-multicluster
+      path: /validate-multicluster-crd-antrea-io-v1alpha2-clusterset
+  failurePolicy: Fail
+  name: vclusterset.kb.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: antrea-multicluster
+  rules:
+  - apiGroups:
+    - multicluster.crd.antrea.io
+    apiVersions:
+    - v1alpha2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clustersets
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: antrea-mc-webhook-service
+      namespace: antrea-multicluster
+      path: /validate-multicluster-crd-antrea-io-v1alpha1-memberclusterannounce
+  failurePolicy: Fail
+  name: vmemberclusterannounce.kb.io
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: antrea-multicluster
+  rules:
+  - apiGroups:
+    - multicluster.crd.antrea.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - memberclusterannounces
+  sideEffects: None

--- a/multicluster/config/overlays/leader/coverage/manager_command_patch_coverage.yaml
+++ b/multicluster/config/overlays/leader/coverage/manager_command_patch_coverage.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+        - command: ["/bin/sh"]
+          args: ["-c", "/antrea-mc-controller-coverage -test.run=TestBincoverRunMain -test.coverprofile=antrea-mc-controller.cov.out leader --config=/controller_manager_config.yaml; while true; do sleep 5 & wait $!; done"]
+          name: antrea-mc-controller
+          image: antrea/antrea-mc-controller-coverage:latest

--- a/multicluster/config/overlays/leader/crd_patch.yaml
+++ b/multicluster/config/overlays/leader/crd_patch.yaml
@@ -1,0 +1,29 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: serviceexports.multicluster.x-k8s.io
+$patch: delete
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: serviceimports.multicluster.x-k8s.io
+$patch: delete
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: gateways.multicluster.crd.antrea.io
+$patch: delete
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterinfoimports.multicluster.crd.antrea.io
+$patch: delete
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: labelidentities.multicluster.crd.antrea.io
+$patch: delete

--- a/multicluster/config/overlays/leader/kustomization.yaml
+++ b/multicluster/config/overlays/leader/kustomization.yaml
@@ -1,0 +1,60 @@
+namespace: antrea-multicluster
+
+commonLabels:
+  app: antrea
+
+namePrefix: antrea-mc-
+
+bases:
+  - ../../crd
+  - ../../default
+
+configurations:
+  - kustomizeconfig.yaml
+
+# MC controller in leader cluster runs in the scope of a single Namespace.
+# Convert the below cluster-role to role and cluster-role-binding to
+# role-binding.
+patchesJson6902:
+  - patch: |-
+      - op: replace
+        path: /kind
+        value: RoleBinding
+      - op: add
+        path: /metadata/namespace
+        value: antrea-multicluster
+      - op: replace
+        path: /roleRef/kind
+        value: Role
+    target:
+      group: rbac.authorization.k8s.io
+      kind: ClusterRoleBinding
+      name: controller-rolebinding
+      version: v1
+  - patch: |-
+      - op: replace
+        path: /kind
+        value: Role
+      - op: add
+        path: /metadata/namespace
+        value: antrea-multicluster
+    target:
+      group: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: controller-role
+      version: v1
+
+resources:
+  - webhook_rbac.yaml
+  - member_cluster_role.yaml
+  - member_cluster_rolebinding.yaml
+  - member_cluster_serviceaccount.yaml
+  - service_account.yaml
+  - role.yaml
+  - role_binding.yaml
+  - secret.yaml
+
+patchesStrategicMerge:
+  - manager_command_patch.yaml
+  - webhook_patch.yaml
+  - crd_patch.yaml

--- a/multicluster/config/overlays/leader/kustomizeconfig.yaml
+++ b/multicluster/config/overlays/leader/kustomizeconfig.yaml
@@ -1,0 +1,53 @@
+nameReference:
+  # Since mutating webhook configuration name gets prefixed during kustomization,
+  # propagate the actual names into the corresponding cluster-role that is
+  # necessary for mcs-controller to have access to the webhook configuration.
+- kind: MutatingWebhookConfiguration
+  version: v1
+  fieldSpecs:
+    - kind: ClusterRole
+      group: rbac.authorization.k8s.io
+      path: rules/resourceNames
+  # Since validating webhook configuration name gets prefixed during kustomization,
+  # propagate the actual names into the corresponding cluster-role that is
+  # necessary for mcs-controller to have access to the webhook configuration.
+- kind: ValidatingWebhookConfiguration
+  version: v1
+  fieldSpecs:
+    - kind: ClusterRole
+      group: rbac.authorization.k8s.io
+      path: rules/resourceNames
+- kind: ServiceAccount
+  version: v1
+  fieldSpecs:
+    - kind: RoleBinding
+      group: rbac.authorization.k8s.io
+      path: subjects/name
+- kind: ServiceAccount
+  version: v1
+  fieldSpecs:
+    - kind: ClusterRoleBinding
+      group: rbac.authorization.k8s.io
+      path: subjects/name
+
+namespace:
+  # MC Controller in leader cluster runs one webhook in each Namespace;
+  # since MutatingWebhookConfiguration is cluster-scoped, this allows
+  # to limit the scope to the given Namespace in which the Controller runs.
+  - kind: MutatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    path: webhooks/namespaceSelector/matchLabels/kubernetes.io\/metadata.name
+    create: true
+  # MC Controller in leader cluster runs one webhook in each Namespace;
+  # since ValidatingWebhookConfiguration is cluster-scoped, this allows
+  # to limit the scope to the given Namespace in which the Controller runs.
+  - kind: ValidatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    path: webhooks/namespaceSelector/matchLabels/kubernetes.io\/metadata.name
+    create: true
+  - kind: RoleBinding
+    group:  rbac.authorization.k8s.io
+    path: subjects/namespace
+  - kind: ClusterRoleBinding
+    group: rbac.authorization.k8s.io
+    path: subjects/namespace

--- a/multicluster/config/overlays/leader/manager_command_patch.yaml
+++ b/multicluster/config/overlays/leader/manager_command_patch.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+        - command:
+          - /antrea-mc-controller
+          - leader
+          name: antrea-mc-controller

--- a/multicluster/config/overlays/leader/member_cluster_role.yaml
+++ b/multicluster/config/overlays/leader/member_cluster_role.yaml
@@ -1,0 +1,68 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: antrea
+  name: member-cluster-role
+  namespace: antrea-multicluster
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+  - apiGroups:
+      - multicluster.crd.antrea.io
+    resources:
+      - memberclusterannounces
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - multicluster.crd.antrea.io
+    resources:
+      - memberclusterannounces/status
+    verbs:
+      - get
+  - apiGroups:
+      - multicluster.crd.antrea.io
+    resources:
+      - resourceexports
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - multicluster.crd.antrea.io
+    resources:
+      - resourceexports/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - multicluster.crd.antrea.io
+    resources:
+      - resourceimports
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - multicluster.crd.antrea.io
+    resources:
+      - resourceimports/status
+    verbs:
+      - get
+      - patch
+      - update

--- a/multicluster/config/overlays/leader/member_cluster_rolebinding.yaml
+++ b/multicluster/config/overlays/leader/member_cluster_rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: member-cluster-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: member-cluster-role
+subjects:
+- kind: ServiceAccount
+  name: member-access-sa
+  namespace: antrea-multicluster

--- a/multicluster/config/overlays/leader/member_cluster_serviceaccount.yaml
+++ b/multicluster/config/overlays/leader/member_cluster_serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: member-access-sa
+  namespace: antrea-multicluster

--- a/multicluster/config/overlays/leader/prefix_transformer.yaml
+++ b/multicluster/config/overlays/leader/prefix_transformer.yaml
@@ -1,0 +1,19 @@
+# Prefix the cluster-scoped resource Name with Namespace;
+# so they can be applied multiple times for each instance
+# of MC Controller that runs in a given namespace.
+# During the kustomization process, the prefix will change
+# to the Namespace, "changme" is only a placeholder.
+apiVersion: builtin
+kind: PrefixSuffixTransformer
+metadata:
+  name: customPrefixer
+prefix: antrea-multicluster-
+fieldSpecs:
+  - kind: ClusterRole
+    path: metadata/name
+  - kind: ClusterRoleBinding
+    path: metadata/name
+  - kind: MutatingWebhookConfiguration
+    path: metadata/name
+  - kind: ValidatingWebhookConfiguration
+    path: metadata/name

--- a/multicluster/config/overlays/leader/role.yaml
+++ b/multicluster/config/overlays/leader/role.yaml
@@ -1,0 +1,138 @@
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: controller-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - clusterclaims
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - clustersets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - clustersets/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - clustersets/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - memberclusterannounces
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - memberclusterannounces/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - memberclusterannounces/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - resourceexports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - resourceexports/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - resourceexports/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - resourceimports
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - resourceimports/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - multicluster.crd.antrea.io
+  resources:
+  - resourceimports/status
+  verbs:
+  - get
+  - patch
+  - update

--- a/multicluster/config/overlays/leader/role_binding.yaml
+++ b/multicluster/config/overlays/leader/role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: controller-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: controller-role
+subjects:
+- kind: ServiceAccount
+  name: controller
+  namespace: system

--- a/multicluster/config/overlays/leader/secret.yaml
+++ b/multicluster/config/overlays/leader/secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: member-access-token
+  namespace: system
+  annotations:
+    kubernetes.io/service-account.name: antrea-mc-member-access-sa
+type: kubernetes.io/service-account-token

--- a/multicluster/config/overlays/leader/service_account.yaml
+++ b/multicluster/config/overlays/leader/service_account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: controller
+  namespace: system

--- a/multicluster/config/overlays/leader/webhook_patch.yaml
+++ b/multicluster/config/overlays/leader/webhook_patch.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  name: vgateway.kb.io
+  $patch: delete
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+  labels:
+    role: leader
+    served-by: antrea-mc-controller
+    served-in: antrea-multicluster
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+  labels:
+    role: leader
+    served-by: antrea-mc-controller
+    served-in: antrea-multicluster

--- a/multicluster/config/overlays/leader/webhook_rbac.yaml
+++ b/multicluster/config/overlays/leader/webhook_rbac.yaml
@@ -1,0 +1,32 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app: antrea
+  name: controller-webhook-role
+rules:
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+      - validatingwebhookconfigurations
+    verbs:
+      - list
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: antrea
+  name: controller-webhook-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: controller-webhook-role
+subjects:
+  - kind: ServiceAccount
+    name: controller
+    namespace: antrea-multicluster
+

--- a/pkg/antctl/raw/multicluster/deploy/deploy_helper.go
+++ b/pkg/antctl/raw/multicluster/deploy/deploy_helper.go
@@ -43,11 +43,10 @@ const (
 	leaderRole = "leader"
 	memberRole = "member"
 
-	latestVersionURL     = "https://raw.githubusercontent.com/antrea-io/antrea/main/multicluster/build/yamls"
-	downloadURL          = "https://github.com/antrea-io/antrea/releases/download"
-	leaderGlobalYAML     = "antrea-multicluster-leader-global.yml"
-	leaderNamespacedYAML = "antrea-multicluster-leader-namespaced.yml"
-	memberYAML           = "antrea-multicluster-member.yml"
+	latestVersionURL = "https://raw.githubusercontent.com/antrea-io/antrea/main/multicluster/build/yamls"
+	downloadURL      = "https://github.com/antrea-io/antrea/releases/download"
+	leaderYAML       = "antrea-multicluster-leader.yml"
+	memberYAML       = "antrea-multicluster-member.yml"
 )
 
 var httpGet = http.Get
@@ -58,13 +57,11 @@ func generateManifests(role string, version string) ([]string, error) {
 	switch role {
 	case leaderRole:
 		manifests = []string{
-			fmt.Sprintf("%s/%s", latestVersionURL, leaderGlobalYAML),
-			fmt.Sprintf("%s/%s", latestVersionURL, leaderNamespacedYAML),
+			fmt.Sprintf("%s/%s", latestVersionURL, leaderYAML),
 		}
 		if version != "latest" {
 			manifests = []string{
-				fmt.Sprintf("%s/%s/%s", downloadURL, version, leaderGlobalYAML),
-				fmt.Sprintf("%s/%s/%s", downloadURL, version, leaderNamespacedYAML),
+				fmt.Sprintf("%s/%s/%s", downloadURL, version, leaderYAML),
 			}
 		}
 	case memberRole:

--- a/pkg/antctl/raw/multicluster/deploy/deploy_helper_test.go
+++ b/pkg/antctl/raw/multicluster/deploy/deploy_helper_test.go
@@ -44,12 +44,11 @@ func TestGenerateManifests(t *testing.T) {
 		expectedErr       string
 	}{
 		{
-			name:    "generate latest leader manifests",
+			name:    "generate latest leader manifest",
 			role:    "leader",
 			version: "latest",
 			expectedManifests: []string{
-				"https://raw.githubusercontent.com/antrea-io/antrea/main/multicluster/build/yamls/antrea-multicluster-leader-global.yml",
-				"https://raw.githubusercontent.com/antrea-io/antrea/main/multicluster/build/yamls/antrea-multicluster-leader-namespaced.yml",
+				"https://raw.githubusercontent.com/antrea-io/antrea/main/multicluster/build/yamls/antrea-multicluster-leader.yml",
 			},
 		},
 		{
@@ -63,18 +62,17 @@ func TestGenerateManifests(t *testing.T) {
 		{
 			name:    "generate versioned leader manifests",
 			role:    "leader",
-			version: "v1.7.0",
+			version: "v1.14.0",
 			expectedManifests: []string{
-				"https://github.com/antrea-io/antrea/releases/download/v1.7.0/antrea-multicluster-leader-global.yml",
-				"https://github.com/antrea-io/antrea/releases/download/v1.7.0/antrea-multicluster-leader-namespaced.yml",
+				"https://github.com/antrea-io/antrea/releases/download/v1.14.0/antrea-multicluster-leader.yml",
 			},
 		},
 		{
 			name:    "generate versioned member manifests",
 			role:    "member",
-			version: "v1.7.0",
+			version: "v1.14.0",
 			expectedManifests: []string{
-				"https://github.com/antrea-io/antrea/releases/download/v1.7.0/antrea-multicluster-member.yml",
+				"https://github.com/antrea-io/antrea/releases/download/v1.14.0/antrea-multicluster-member.yml",
 			},
 		},
 		{


### PR DESCRIPTION
For the multi-cluster leader cluster deployment, we provide two separate manifests for CRDs and Namespaced Controller deployment respectively. However, this is not a typical way for OSS users, so we add a new all-in-one manifest to simplify the deployment.