### PR TITLE
Uniform TCP and UDP DNS interception flows

### DIFF
--- a/pkg/agent/metrics/prometheus.go
+++ b/pkg/agent/metrics/prometheus.go
@@ -24,8 +24,9 @@ const (
 	metricNamespaceAntrea = "antrea"
 	metricSubsystemAgent  = "agent"
 
-	LabelPacketInMeterNetworkPolicy = "PacketInMeterNetworkPolicy"
-	LabelPacketInMeterTraceflow     = "PacketInMeterTraceflow"
+	LabelPacketInMeterNetworkPolicy   = "PacketInMeterNetworkPolicy"
+	LabelPacketInMeterTraceflow       = "PacketInMeterTraceflow"
+	LabelPacketInMeterDNSInterception = "PacketInMeterDNSInterception"
 )
 
 var (
@@ -240,7 +241,7 @@ func InitializeOVSMetrics() {
 		OVSFlowOpsErrorCount.WithLabelValues(ops)
 		OVSFlowOpsLatency.WithLabelValues(ops)
 	}
-	for _, label := range []string{LabelPacketInMeterNetworkPolicy, LabelPacketInMeterTraceflow} {
+	for _, label := range []string{LabelPacketInMeterNetworkPolicy, LabelPacketInMeterTraceflow, LabelPacketInMeterDNSInterception} {
 		OVSMeterPacketDroppedCount.WithLabelValues(label)
 	}
 }

--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -797,6 +797,9 @@ func (c *client) initialize() error {
 		if err := c.genPacketInMeter(PacketInMeterIDTF, PacketInMeterRateTF).Add(); err != nil {
 			return fmt.Errorf("failed to install OpenFlow meter entry (meterID:%d, rate:%d) for TraceFlow packet-in rate limiting: %v", PacketInMeterIDTF, PacketInMeterRateTF, err)
 		}
+		if err := c.genPacketInMeter(PacketInMeterIDDNS, PacketInMeterRateDNS).Add(); err != nil {
+			return fmt.Errorf("failed to install OpenFlow meter entry (meterID:%d, rate:%d) for DNS interception packet-in rate limiting: %v", PacketInMeterIDDNS, PacketInMeterRateDNS, err)
+		}
 	}
 
 	for _, activeFeature := range c.activatedFeatures {
@@ -1561,6 +1564,8 @@ func (c *client) getMeterStats() {
 			metrics.OVSMeterPacketDroppedCount.WithLabelValues(metrics.LabelPacketInMeterNetworkPolicy).Set(float64(packetCount))
 		case PacketInMeterIDTF:
 			metrics.OVSMeterPacketDroppedCount.WithLabelValues(metrics.LabelPacketInMeterTraceflow).Set(float64(packetCount))
+		case PacketInMeterIDDNS:
+			metrics.OVSMeterPacketDroppedCount.WithLabelValues(metrics.LabelPacketInMeterDNSInterception).Set(float64(packetCount))
 		default:
 			klog.V(4).InfoS("Received unexpected meterID", "meterID", meterID)
 		}

--- a/pkg/agent/openflow/client_test.go
+++ b/pkg/agent/openflow/client_test.go
@@ -2611,6 +2611,7 @@ func Test_client_ReplayFlows(t *testing.T) {
 		}{
 			{id: PacketInMeterIDNP, rate: PacketInMeterRateNP},
 			{id: PacketInMeterIDTF, rate: PacketInMeterRateTF},
+			{id: PacketInMeterIDDNS, rate: PacketInMeterRateDNS},
 		} {
 			meter := ovsoftest.NewMockMeter(ctrl)
 			meterBuilder := ovsoftest.NewMockMeterBandBuilder(ctrl)

--- a/pkg/agent/openflow/packetin.go
+++ b/pkg/agent/openflow/packetin.go
@@ -78,12 +78,14 @@ const (
 
 	// We use OpenFlow Meter for packetIn rate limiting on OVS side.
 	// Meter Entry ID.
-	PacketInMeterIDNP = 1
-	PacketInMeterIDTF = 2
+	PacketInMeterIDNP  = 1
+	PacketInMeterIDTF  = 2
+	PacketInMeterIDDNS = 3
 	// Meter Entry Rate. It is represented as number of events per second.
 	// Packets which exceed the rate will be dropped.
-	PacketInMeterRateNP = 100
-	PacketInMeterRateTF = 100
+	PacketInMeterRateNP  = 100
+	PacketInMeterRateTF  = 100
+	PacketInMeterRateDNS = 100
 
 	// PacketInQueueSize defines the size of PacketInQueue.
 	// When PacketInQueue reaches PacketInQueueSize, new packetIn will be dropped.

--- a/pkg/agent/types/networkpolicy.go
+++ b/pkg/agent/types/networkpolicy.go
@@ -58,6 +58,7 @@ const (
 	IGMPAddr
 	LabelIDAddr
 	TCPFlagsAddr
+	CTStateAddr
 	UnSupported
 )
 

--- a/pkg/ovs/openflow/interfaces.go
+++ b/pkg/ovs/openflow/interfaces.go
@@ -273,6 +273,7 @@ type FlowBuilder interface {
 	MatchARPTpa(ip net.IP) FlowBuilder
 	MatchARPOp(op uint16) FlowBuilder
 	MatchIPDSCP(dscp uint8) FlowBuilder
+	MatchCTState(ctStates *openflow15.CTStates) FlowBuilder
 	MatchCTStateNew(isSet bool) FlowBuilder
 	MatchCTStateRel(isSet bool) FlowBuilder
 	MatchCTStateRpl(isSet bool) FlowBuilder

--- a/pkg/ovs/openflow/ofctrl_builder.go
+++ b/pkg/ovs/openflow/ofctrl_builder.go
@@ -123,6 +123,11 @@ func (b *ofFlowBuilder) MatchRegFieldWithValue(field *RegField, data uint32) Flo
 	return b.matchRegRange(field.regID, data, field.rng)
 }
 
+func (b *ofFlowBuilder) MatchCTState(ctStates *openflow15.CTStates) FlowBuilder {
+	b.ctStates = ctStates
+	return b
+}
+
 func (b *ofFlowBuilder) MatchCTStateNew(set bool) FlowBuilder {
 	if b.ctStates == nil {
 		b.ctStates = openflow15.NewCTStates()

--- a/pkg/ovs/openflow/testing/mock_openflow.go
+++ b/pkg/ovs/openflow/testing/mock_openflow.go
@@ -1607,6 +1607,20 @@ func (mr *MockFlowBuilderMockRecorder) MatchCTSrcPort(arg0 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MatchCTSrcPort", reflect.TypeOf((*MockFlowBuilder)(nil).MatchCTSrcPort), arg0)
 }
 
+// MatchCTState mocks base method
+func (m *MockFlowBuilder) MatchCTState(arg0 *openflow15.CTStates) openflow.FlowBuilder {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MatchCTState", arg0)
+	ret0, _ := ret[0].(openflow.FlowBuilder)
+	return ret0
+}
+
+// MatchCTState indicates an expected call of MatchCTState
+func (mr *MockFlowBuilderMockRecorder) MatchCTState(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MatchCTState", reflect.TypeOf((*MockFlowBuilder)(nil).MatchCTState), arg0)
+}
+
 // MatchCTStateDNAT mocks base method
 func (m *MockFlowBuilder) MatchCTStateDNAT(arg0 bool) openflow.FlowBuilder {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Fixes #5387

1. Change to use ct_state to match the DNS responses that need further interception.
2. Add OF meter for DNS interception.
