### PR TITLE
Always initialize ovs_meter_packet_dropped_count metrics

### DIFF
--- a/pkg/agent/metrics/prometheus.go
+++ b/pkg/agent/metrics/prometheus.go
@@ -23,6 +23,9 @@ import (
 const (
 	metricNamespaceAntrea = "antrea"
 	metricSubsystemAgent  = "agent"
+
+	LabelPacketInMeterNetworkPolicy = "PacketInMeterNetworkPolicy"
+	LabelPacketInMeterTraceflow     = "PacketInMeterTraceflow"
 )
 
 var (
@@ -232,11 +235,13 @@ func InitializeOVSMetrics() {
 	}
 	// Initialize OpenFlow operations metrics with label add, modify and delete
 	// since those metrics won't come out until observation.
-	opsArray := [3]string{"add", "modify", "delete"}
-	for _, ops := range opsArray {
+	for _, ops := range []string{"add", "modify", "delete"} {
 		OVSFlowOpsCount.WithLabelValues(ops)
 		OVSFlowOpsErrorCount.WithLabelValues(ops)
 		OVSFlowOpsLatency.WithLabelValues(ops)
+	}
+	for _, label := range []string{LabelPacketInMeterNetworkPolicy, LabelPacketInMeterTraceflow} {
+		OVSMeterPacketDroppedCount.WithLabelValues(label)
 	}
 }
 

--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -1558,9 +1558,9 @@ func (c *client) getMeterStats() {
 	handleMeterStatsReply := func(meterID int, packetCount int64) {
 		switch meterID {
 		case PacketInMeterIDNP:
-			metrics.OVSMeterPacketDroppedCount.WithLabelValues("PacketInMeterNetworkPolicy").Set(float64(packetCount))
+			metrics.OVSMeterPacketDroppedCount.WithLabelValues(metrics.LabelPacketInMeterNetworkPolicy).Set(float64(packetCount))
 		case PacketInMeterIDTF:
-			metrics.OVSMeterPacketDroppedCount.WithLabelValues("PacketInMeterTraceflow").Set(float64(packetCount))
+			metrics.OVSMeterPacketDroppedCount.WithLabelValues(metrics.LabelPacketInMeterTraceflow).Set(float64(packetCount))
 		default:
 			klog.V(4).InfoS("Received unexpected meterID", "meterID", meterID)
 		}


### PR DESCRIPTION
Otherwise the metric is not showing up if OVS Meter is not supported on the system, causing e2e test failure.