### PR TITLE
Clean up code in pkg/antctl/command_message.go

### DIFF
--- a/pkg/antctl/client.go
+++ b/pkg/antctl/client.go
@@ -137,7 +137,7 @@ func (c *client) nonResourceRequest(e *nonResourceEndpoint, opt *requestOption) 
 		if !ok {
 			return nil, err
 		}
-		return nil, generateMessageForStatusErr(opt.commandDefinition, opt.args, statusErr)
+		return nil, generateMessage(opt.commandDefinition, opt.args, false /* isResourceRequest */, statusErr)
 	}
 	return bytes.NewReader(result), nil
 }
@@ -178,7 +178,7 @@ func (c *client) resourceRequest(e *resourceEndpoint, opt *requestOption) (io.Re
 	}
 	result := resGetter.Do(context.TODO())
 	if result.Error() != nil {
-		return nil, generateMessage(opt, result)
+		return nil, generateMessage(opt.commandDefinition, opt.args, true /* isResourceRequest */, result.Error())
 	}
 	raw, err := result.Raw()
 	if err != nil {

--- a/pkg/antctl/command_message.go
+++ b/pkg/antctl/command_message.go
@@ -19,40 +19,37 @@ import (
 	"net/http"
 
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/client-go/rest"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func generateMessage(opt *requestOption, result rest.Result) error {
-	var code int
-	_ = result.StatusCode(&code)
-	if errMsg := generate(opt.commandDefinition, opt.args, code, result.Error().Error()); errMsg != nil {
-		return errMsg
+func generateMessage(cd *commandDefinition, args map[string]string, isResourceRequest bool, err error) error {
+	if err == nil {
+		// no error, nothing to do
+		return nil
 	}
-	return result.Error()
+	// The rest client's Do method can return the following error types:
+	//   - If the server responds with a status: *errors.StatusError or *errors.UnexpectedObjectError
+	//   - http.Client.Do errors are returned directly.
+	// The rest client's DoRaw method can return errors of type *errors.StatusError.
+	if statusErr, ok := err.(*errors.StatusError); ok {
+		return generateMessageForStatusErr(cd, args, isResourceRequest, statusErr)
+	}
+	return fmt.Errorf("unknown error: %w", err)
 }
 
-func generateMessageForStatusErr(cd *commandDefinition, args map[string]string, statusErr *errors.StatusError) error {
-	if statusErr.ErrStatus.Details.Causes == nil || len(statusErr.ErrStatus.Details.Causes[0].Message) == 0 {
-		return generate(cd, args, int(statusErr.ErrStatus.Code), statusErr.Error())
+func generateMessageForStatusErr(cd *commandDefinition, args map[string]string, isResourceRequest bool, statusErr *errors.StatusError) error {
+	if isResourceRequest {
+		return fmt.Errorf("request to server failed: %s", statusErr.Error())
 	}
-	return fmt.Errorf("%s: %s", statusErr.ErrStatus.Reason, statusErr.ErrStatus.Details.Causes[0].Message)
-}
-
-func generate(cd *commandDefinition, args map[string]string, code int, err string) error {
-	if len(err) > 0 {
-		if len(http.StatusText(code)) == 0 {
-			return fmt.Errorf("%s", err)
-		}
-		return fmt.Errorf("%s: %s", http.StatusText(code), err)
+	code := int(statusErr.ErrStatus.Code)
+	if code == 0 {
+		return fmt.Errorf("missing code in status error: %w", statusErr)
 	}
-	switch code {
-	case http.StatusNotFound:
-		return fmt.Errorf("NotFound: %s \"%s\" not found", cd.use, args["name"])
-	case http.StatusInternalServerError:
-		return fmt.Errorf("InternalServerError: Encoding response failed for %s", cd.use)
-	case http.StatusBadRequest:
-		return fmt.Errorf("BadRequest: Please check the args for %s", cd.use)
-	default:
-		return fmt.Errorf("Unknown error")
+	// This status cause will be populated for non-resource requests, i.e., requests performed
+	// with the rest client's DoRaw method.
+	// https://github.com/kubernetes/apimachinery/blob/4b14f804a0babdcc58e695d72f77ad29f536511e/pkg/api/errors/errors.go#L499-L506
+	if cause, ok := errors.StatusCause(statusErr, metav1.CauseTypeUnexpectedServerResponse); ok && len(cause.Message) > 0 {
+		return fmt.Errorf("request to server failed: %s: %s", http.StatusText(code), cause.Message)
 	}
+	return fmt.Errorf("request to server failed: %s: %s", http.StatusText(code), statusErr.Error())
 }


### PR DESCRIPTION
I saw the following error when running golangci (only shows up with certain versions of Go and Golangci-lint).

```
===> Running golangci (linux) <===
pkg/antctl/command_message.go:28:88: SA4023: this comparison is always true (staticcheck)
	if errMsg := generate(opt.commandDefinition, opt.args, code, result.Error().Error()); errMsg != nil {
	                                                                                      ^
pkg/antctl/command_message.go:41:6: SA4023(related information): antrea.io/antrea/pkg/antctl.generate never returns a nil interface value (staticcheck)
func generate(cd *commandDefinition, args map[string]string, code int, err string) error {
     ^
make: *** [golangci] Error 1
```

When fixing the code, I realized that the code was not well-commented, and was a bit confusing, so I did some refactoring.

For resource requests, the StatusError returned by the Rest client is good enough and does not need to be transformed. For non-resource requests, it makes sense to transform the error message for the BadRequest HTTP status, as the generic one is very vague.