### PR TITLE
Automated cherry pick of #5409: Enable IPv6 on OVS internal port if needed in bridging mode

### DIFF
--- a/pkg/agent/agent_linux.go
+++ b/pkg/agent/agent_linux.go
@@ -37,6 +37,9 @@ import (
 var (
 	// getInterfaceByName is meant to be overridden for testing.
 	getInterfaceByName = net.InterfaceByName
+
+	// getAllIPNetsByName is meant to be overridden for testing.
+	getAllIPNetsByName = util.GetAllIPNetsByName
 )
 
 // prepareHostNetwork returns immediately on Linux.
@@ -59,7 +62,11 @@ func (i *Initializer) prepareOVSBridgeForK8sNode() error {
 	uplinkNetConfig := i.nodeConfig.UplinkNetConfig
 	uplinkNetConfig.Name = adapter.Name
 	uplinkNetConfig.MAC = adapter.HardwareAddr
-	uplinkNetConfig.IPs = []*net.IPNet{i.nodeConfig.NodeIPv4Addr}
+	uplinkIPs, err := getAllIPNetsByName(adapter.Name)
+	if err != nil {
+		return fmt.Errorf("failed to get uplink IPs: %w", err)
+	}
+	uplinkNetConfig.IPs = uplinkIPs
 	uplinkNetConfig.Index = adapter.Index
 	// Gateway and DNSServers are not configured at adapter in Linux
 	// Limitation: dynamic DNS servers will be lost after DHCP lease expired
@@ -141,7 +148,7 @@ func (i *Initializer) saveHostRoutes() error {
 			klog.V(2).Infof("Skipped host route not on uplink: %+v", route)
 			continue
 		}
-		// Skip IPv6 routes before we support IPv6 stack.
+		// Skip IPv6 routes until we support IPv6 stack.
 		// TODO(gran): support IPv6
 		if route.Gw.To4() == nil {
 			klog.V(2).Infof("Skipped IPv6 host route: %+v", route)
@@ -182,21 +189,19 @@ func (i *Initializer) ConnectUplinkToOVSBridge() error {
 	if !i.connectUplinkToBridge {
 		return nil
 	}
-	klog.Infof("Bridging uplink to OVS bridge")
+	klog.InfoS("Bridging uplink to OVS bridge")
 	var err error
 	uplinkNetConfig := i.nodeConfig.UplinkNetConfig
 	uplinkName := uplinkNetConfig.Name
 	bridgedUplinkName := util.GenerateUplinkInterfaceName(uplinkNetConfig.Name)
+	uplinkIPs := uplinkNetConfig.IPs
 
 	// If uplink is already exists, return.
 	if uplinkOFPort, err := i.ovsBridgeClient.GetOFPort(bridgedUplinkName, false); err == nil {
 		klog.InfoS("Uplink already exists, skip the configuration", "uplink", bridgedUplinkName, "port", uplinkOFPort)
 		return nil
 	}
-	uplinkIPs, err := util.GetAllIPNetsByName(uplinkName)
-	if err != nil {
-		return fmt.Errorf("failed to get uplink IPs: err=%w", err)
-	}
+
 	if err := util.RenameInterface(uplinkName, bridgedUplinkName); err != nil {
 		return fmt.Errorf("failed to change uplink interface name: err=%w", err)
 	}
@@ -243,13 +248,31 @@ func (i *Initializer) ConnectUplinkToOVSBridge() error {
 	if _, _, err = util.SetLinkUp(uplinkName); err != nil {
 		return err
 	}
+
+	// Check if uplink is configured with an IPv6 address: if it is, we need to ensure that IPv6
+	// is enabled on the OVS internal port as we need to move all IP addresses over.
+	uplinkHasIPv6Address := false
+	for _, ip := range uplinkIPs {
+		if ip.IP.To4() == nil {
+			uplinkHasIPv6Address = true
+			break
+		}
+	}
+	if uplinkHasIPv6Address {
+		klog.InfoS("Uplink has IPv6 address, ensuring that IPv6 is enabled on bridge local port", "port", uplinkName)
+		if err := util.EnsureIPv6EnabledOnInterface(uplinkName); err != nil {
+			klog.ErrorS(err, "Failed to ensure that IPv6 is enabled on bridge local port, moving uplink IPs to bridge is likely to fail", "port", uplinkName)
+		}
+	}
+
 	if err = util.ConfigureLinkAddresses(localLink.Attrs().Index, uplinkIPs); err != nil {
 		return err
 	}
 	if err = util.ConfigureLinkAddresses(uplinkNetConfig.Index, nil); err != nil {
 		return err
 	}
-	// Restore the host routes which are lost when moving the network configuration of the uplink interface to OVS bridge interface.
+	// Restore the host routes which are lost when moving the network configuration of the
+	// uplink interface to OVS bridge interface.
 	if err = i.restoreHostRoutes(); err != nil {
 		return err
 	}
@@ -263,7 +286,7 @@ func (i *Initializer) RestoreOVSBridge() {
 	if !i.connectUplinkToBridge {
 		return
 	}
-	klog.Infof("Restoring bridge config to uplink...")
+	klog.InfoS("Restoring bridge config to uplink...")
 	uplinkNetConfig := i.nodeConfig.UplinkNetConfig
 	uplinkName := ""
 	bridgedUplinkName := ""
@@ -274,10 +297,7 @@ func (i *Initializer) RestoreOVSBridge() {
 	brName := i.ovsBridge
 
 	if uplinkName != "" {
-		uplinkIPs, err := util.GetAllIPNetsByName(uplinkName)
-		if err != nil {
-			klog.ErrorS(err, "Failed to get uplink IPs")
-		}
+		uplinkIPs := uplinkNetConfig.IPs
 		if err := util.DeleteOVSPort(brName, uplinkName); err != nil {
 			klog.ErrorS(err, "Delete OVS port failed", "port", uplinkName)
 		}
@@ -294,7 +314,7 @@ func (i *Initializer) RestoreOVSBridge() {
 			klog.ErrorS(err, "Configure route to uplink interface failed", "uplink", uplinkName)
 		}
 	}
-	klog.Infof("Finished to restore bridge config to uplink...")
+	klog.InfoS("Finished to restore bridge config to uplink...")
 }
 
 func (i *Initializer) setInterfaceMTU(iface string, mtu int) error {

--- a/pkg/agent/agent_windows_test.go
+++ b/pkg/agent/agent_windows_test.go
@@ -14,12 +14,14 @@
 
 package agent
 
-func mockSetInterfaceMTU(returnErr error) func() {
+import (
+	"testing"
+)
+
+func mockSetInterfaceMTU(t *testing.T, returnErr error) {
 	originalSetInterfaceMTU := setInterfaceMTU
 	setInterfaceMTU = func(ifaceName string, mtu int) error {
 		return returnErr
 	}
-	return func() {
-		setInterfaceMTU = originalSetInterfaceMTU
-	}
+	t.Cleanup(func() { setInterfaceMTU = originalSetInterfaceMTU })
 }

--- a/pkg/agent/util/net_linux.go
+++ b/pkg/agent/util/net_linux.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/klog/v2"
 
 	utilnetlink "antrea.io/antrea/pkg/agent/util/netlink"
+	"antrea.io/antrea/pkg/agent/util/sysctl"
 )
 
 var (
@@ -329,6 +330,11 @@ func ConfigureLinkRoutes(link netlink.Link, routes []interface{}) error {
 		}
 	}
 	return nil
+}
+
+func EnsureIPv6EnabledOnInterface(ifaceName string) error {
+	path := fmt.Sprintf("ipv6/conf/%s/disable_ipv6", ifaceName)
+	return sysctl.EnsureSysctlNetValue(path, 0)
 }
 
 func getRoutesOnInterface(linkIndex int) ([]interface{}, error) {

--- a/pkg/agent/util/sysctl/sysctl_linux.go
+++ b/pkg/agent/util/sysctl/sysctl_linux.go
@@ -55,13 +55,13 @@ func EnsureSysctlNetValue(sysctl string, value int) error {
 	val, err := GetSysctlNet(sysctl)
 	if err != nil {
 		// If permission error, please provide access to sysctl setting
-		klog.Errorf("Error when getting %s: %v", sysctl, err)
+		klog.ErrorS(err, "Error when getting sysctl parameter", "path", sysctl)
 		return err
 	} else if val != value {
 		err = SetSysctlNet(sysctl, value)
 		if err != nil {
 			// If permission error, please provide access to sysctl setting
-			klog.Errorf("Error when setting %s: %v", sysctl, err)
+			klog.ErrorS(err, "Error when setting sysctl parameter", "path", sysctl, "value", value)
 			return err
 		}
 	}


### PR DESCRIPTION
Cherry pick of #5409 on release-1.13.

#5409: Enable IPv6 on OVS internal port if needed in bridging mode

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.