### PR TITLE
Clean up parameters of constructors

### DIFF
--- a/pkg/agent/cniserver/ipam/antrea_ipam_test.go
+++ b/pkg/agent/cniserver/ipam/antrea_ipam_test.go
@@ -326,7 +326,7 @@ func TestAntreaIPAMDriver(t *testing.T) {
 		listOptions,
 	)
 
-	antreaIPAMController, err := InitializeAntreaIPAMController(crdClient, informerFactory, crdInformerFactory, localPodInformer, true)
+	antreaIPAMController, err := InitializeAntreaIPAMController(crdClient, informerFactory.Core().V1().Namespaces(), crdInformerFactory.Crd().V1alpha2().IPPools(), localPodInformer, true)
 	require.NoError(t, err, "Expected no error in initialization for Antrea IPAM Controller")
 	informerFactory.Start(stopCh)
 	go localPodInformer.Run(stopCh)
@@ -614,7 +614,12 @@ func TestSecondaryNetworkAdd(t *testing.T) {
 					listOptions,
 				)
 
-				antreaIPAMController, err := InitializeAntreaIPAMController(crdClient, informerFactory, crdInformerFactory, localPodInformer, true)
+				antreaIPAMController, err := InitializeAntreaIPAMController(crdClient,
+					informerFactory.Core().V1().Namespaces(),
+					crdInformerFactory.Crd().V1alpha2().IPPools(),
+					localPodInformer,
+					true,
+				)
 				require.NoError(t, err, "Expected no error in initialization for Antrea IPAM Controller")
 				createIPPools(crdClient)
 

--- a/pkg/agent/controller/noderoute/node_route_controller_test.go
+++ b/pkg/agent/controller/noderoute/node_route_controller_test.go
@@ -79,10 +79,10 @@ func newController(t *testing.T, networkConfig *config.NetworkConfig) *fakeContr
 	ipsecCertificateManager := &fakeIPsecCertificateManager{}
 	ovsCtlClient := ovsctltest.NewMockOVSCtlClient(ctrl)
 
-	c := NewNodeRouteController(clientset, informerFactory, ofClient, ovsCtlClient, ovsClient, routeClient, interfaceStore, networkConfig, &config.NodeConfig{GatewayConfig: &config.GatewayConfig{
+	c := NewNodeRouteController(informerFactory.Core().V1().Nodes(), ofClient, ovsCtlClient, ovsClient, routeClient, interfaceStore, networkConfig, &config.NodeConfig{GatewayConfig: &config.GatewayConfig{
 		IPv4: nil,
 		MAC:  gatewayMAC,
-	}}, nil, false, ipsecCertificateManager)
+	}}, nil, ipsecCertificateManager)
 	return &fakeController{
 		Controller:      c,
 		clientset:       clientset,

--- a/pkg/agent/controller/traceflow/packetin.go
+++ b/pkg/agent/controller/traceflow/packetin.go
@@ -51,7 +51,7 @@ func (c *Controller) HandlePacketIn(pktIn *ofctrl.PacketIn) error {
 
 	// Retry when update CRD conflict which caused by multiple agents updating one CRD at same time.
 	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		tf, err := c.traceflowInformer.Lister().Get(oldTf.Name)
+		tf, err := c.traceflowLister.Get(oldTf.Name)
 		if err != nil {
 			return fmt.Errorf("get Traceflow failed: %w", err)
 		}
@@ -60,7 +60,7 @@ func (c *Controller) HandlePacketIn(pktIn *ofctrl.PacketIn) error {
 		if packet != nil {
 			update.Status.CapturedPacket = packet
 		}
-		_, err = c.traceflowClient.CrdV1beta1().Traceflows().UpdateStatus(context.TODO(), update, v1.UpdateOptions{})
+		_, err = c.crdClient.CrdV1beta1().Traceflows().UpdateStatus(context.TODO(), update, v1.UpdateOptions{})
 		if err != nil {
 			return fmt.Errorf("update Traceflow failed: %w", err)
 		}

--- a/pkg/agent/controller/traceflow/traceflow_controller_test.go
+++ b/pkg/agent/controller/traceflow/traceflow_controller_test.go
@@ -43,7 +43,6 @@ import (
 	crdinformers "antrea.io/antrea/pkg/client/informers/externalversions"
 	"antrea.io/antrea/pkg/features"
 	binding "antrea.io/antrea/pkg/ovs/openflow"
-	ovsconfigtest "antrea.io/antrea/pkg/ovs/ovsconfig/testing"
 	"antrea.io/antrea/pkg/querier"
 	"antrea.io/antrea/pkg/util/k8s"
 )
@@ -91,7 +90,6 @@ type fakeTraceflowController struct {
 	mockOFClient       *openflowtest.MockClient
 	crdClient          *fakeversioned.Clientset
 	crdInformerFactory crdinformers.SharedInformerFactory
-	ovsClient          *ovsconfigtest.MockOVSBridgeClient
 }
 
 func newFakeTraceflowController(t *testing.T, initObjects []runtime.Object, networkConfig *config.NetworkConfig, nodeConfig *config.NodeConfig, npQuerier querier.AgentNetworkPolicyInfoQuerier, egressQuerier querier.EgressQuerier) *fakeTraceflowController {
@@ -101,7 +99,6 @@ func newFakeTraceflowController(t *testing.T, initObjects []runtime.Object, netw
 	crdClient := fakeversioned.NewSimpleClientset(initObjects...)
 	crdInformerFactory := crdinformers.NewSharedInformerFactory(crdClient, 0)
 	traceflowInformer := crdInformerFactory.Crd().V1beta1().Traceflows()
-	ovsClient := ovsconfigtest.NewMockOVSBridgeClient(controller)
 
 	ifaceStore := interfacestore.NewInterfaceStore()
 	addPodInterface(ifaceStore, pod1.Namespace, pod1.Name, pod1IPv4, pod1MAC.String(), int32(ofPortPod1))
@@ -111,14 +108,13 @@ func newFakeTraceflowController(t *testing.T, initObjects []runtime.Object, netw
 
 	tfController := &Controller{
 		kubeClient:            kubeClient,
-		traceflowClient:       crdClient,
+		crdClient:             crdClient,
 		traceflowInformer:     traceflowInformer,
 		traceflowLister:       traceflowInformer.Lister(),
 		traceflowListerSynced: traceflowInformer.Informer().HasSynced,
 		ofClient:              mockOFClient,
 		networkPolicyQuerier:  npQuerier,
 		egressQuerier:         egressQuerier,
-		ovsBridgeClient:       ovsClient,
 		interfaceStore:        ifaceStore,
 		networkConfig:         networkConfig,
 		nodeConfig:            nodeConfig,
@@ -134,7 +130,6 @@ func newFakeTraceflowController(t *testing.T, initObjects []runtime.Object, netw
 		mockOFClient:       mockOFClient,
 		crdClient:          crdClient,
 		crdInformerFactory: crdInformerFactory,
-		ovsClient:          ovsClient,
 	}
 }
 

--- a/pkg/agent/proxy/proxier_test.go
+++ b/pkg/agent/proxy/proxier_test.go
@@ -392,10 +392,14 @@ func newFakeProxier(routeClient route.Interface, ofClient openflow.Client, nodeP
 	}
 	fakeClient := fake.NewSimpleClientset()
 	fakeNodeIPChecker := nodeipmock.NewFakeNodeIPChecker()
+	informerFactory := informers.NewSharedInformerFactory(fakeClient, 0)
 	p, _ := newProxier(hostname,
 		serviceProxyName,
 		fakeClient,
-		informers.NewSharedInformerFactory(fakeClient, 0),
+		informerFactory.Core().V1().Services(),
+		informerFactory.Core().V1().Endpoints(),
+		informerFactory.Discovery().V1().EndpointSlices(),
+		informerFactory.Core().V1().Nodes(),
 		ofClient,
 		isIPv6,
 		routeClient,


### PR DESCRIPTION
While checking the usage of nodeInformer, I found modules used different ways to get needed informers. Some get informers from parameters directly while some create them with the informerFactory parameter. Unifying to the first usage could help track the resource's consumer more directly, and is more in line with the principle of least priviledge: instead of giving a module the access to all resources, we give it the access needed to perform its job only.

This commit also cleans up some parameters and member variables that are never used.