### PR TITLE
Automatically upgrade testbed golang version to antrea golang version

### DIFF
--- a/ci/jenkins/test-mc.sh
+++ b/ci/jenkins/test-mc.sh
@@ -36,6 +36,7 @@ CODECOV_TOKEN=""
 COVERAGE=false
 KIND=false
 DEBUG=false
+GOLANG_RELEASE_DIR=${WORKDIR}/golang-releases
 
 multicluster_kubeconfigs=($EAST_CLUSTER_CONFIG $LEADER_CLUSTER_CONFIG $WEST_CLUSTER_CONFIG)
 membercluster_kubeconfigs=($EAST_CLUSTER_CONFIG $WEST_CLUSTER_CONFIG)
@@ -284,7 +285,7 @@ function deliver_antrea_multicluster {
     echo "====== Building Antrea for the Following Commit ======"
     export GO111MODULE=on
     export GOPATH=${WORKDIR}/go
-    export GOROOT=/usr/local/go
+    export GOROOT=${GOLANG_RELEASE_DIR}/go
     export PATH=${GOROOT}/bin:$PATH
 
     git show --numstat
@@ -323,7 +324,7 @@ function deliver_multicluster_controller {
     echo "====== Build Antrea Multiple Cluster Controller and YAMLs ======"
     export GO111MODULE=on
     export GOPATH=${WORKDIR}/go
-    export GOROOT=/usr/local/go
+    export GOROOT=${GOLANG_RELEASE_DIR}/go
     export PATH=${GOROOT}/bin:$PATH
 
     DEFAULT_IMAGE=antrea/antrea-mc-controller:latest
@@ -387,7 +388,7 @@ function run_multicluster_e2e {
     echo "====== Running Multicluster e2e Tests ======"
     export GO111MODULE=on
     export GOPATH=${WORKDIR}/go
-    export GOROOT=/usr/local/go
+    export GOROOT=${GOLANG_RELEASE_DIR}/go
     export GOCACHE=${WORKDIR}/.cache/go-build
     export PATH=$GOROOT/bin:$PATH
 
@@ -468,6 +469,8 @@ function collect_coverage {
 }
 
 trap clean_multicluster EXIT
+source $WORKSPACE/ci/jenkins/utils.sh
+check_and_upgrade_golang
 clean_tmp
 clean_images
 

--- a/ci/jenkins/test-rancher.sh
+++ b/ci/jenkins/test-rancher.sh
@@ -29,6 +29,7 @@ MODE="report"
 DOCKER_REGISTRY=$(head -n1 "${WORKSPACE}/ci/docker-registry")
 GO_VERSION=$(head -n1 "${WORKSPACE}/build/images/deps/go-version")
 IMAGE_PULL_POLICY="Always"
+GOLANG_RELEASE_DIR=${WORKDIR}/golang-releases
 
 CLUSTER_NAME=""
 
@@ -130,7 +131,7 @@ function deliver_antrea {
     echo "====== Building Antrea for the Following Commit ======"
     export GO111MODULE=on
     export GOPATH=${WORKDIR}/go
-    export GOROOT=/usr/local/go
+    export GOROOT=${GOLANG_RELEASE_DIR}/go
     export GOCACHE="${WORKSPACE}/../gocache"
     export PATH=${GOROOT}/bin:$PATH
 
@@ -187,7 +188,7 @@ function run_e2e {
     echo "====== Running Antrea E2E Tests ======"
     export GO111MODULE=on
     export GOPATH=${WORKDIR}/go
-    export GOROOT=/usr/local/go
+    export GOROOT=${GOLANG_RELEASE_DIR}/go
     export GOCACHE=${WORKDIR}/.cache/go-build
     export PATH=$GOROOT/bin:$PATH
 
@@ -222,7 +223,7 @@ function run_conformance {
     echo "====== Running Antrea Conformance Tests ======"
     export GO111MODULE=on
     export GOPATH=${WORKDIR}/go
-    export GOROOT=/usr/local/go
+    export GOROOT=${GOLANG_RELEASE_DIR}/go
     export GOCACHE=${WORKDIR}/.cache/go-build
     export PATH=$GOROOT/bin:$PATH
 
@@ -263,6 +264,8 @@ function clean_tmp() {
 
 rancher_login
 
+source $WORKSPACE/ci/jenkins/utils.sh
+check_and_upgrade_golang
 clean_tmp
 trap clean_vm_agent EXIT
 deliver_antrea

--- a/ci/jenkins/test-vm.sh
+++ b/ci/jenkins/test-vm.sh
@@ -29,6 +29,7 @@ DEFAULT_KUBECONFIG_PATH=$DEFAULT_WORKDIR/kube.conf
 WORKDIR=$DEFAULT_WORKDIR
 KUBECONFIG_PATH=$DEFAULT_KUBECONFIG_PATH
 TEST_FAILURE=false
+GOLANG_RELEASE_DIR=${WORKDIR}/golang-releases
 
 # Cluster configuration
 CLUSTER_NAME="kubernetes"
@@ -280,7 +281,7 @@ function install_on_windows {
 function run_e2e_vms {
     export GO111MODULE=on
     export GOPATH=${WORKDIR}/go
-    export GOROOT=/usr/local/go
+    export GOROOT=${GOLANG_RELEASE_DIR}/go
     export GOCACHE=${WORKDIR}/.cache/go-build
     export PATH=$GOROOT/bin:$PATH
 
@@ -304,7 +305,7 @@ function build_antrea_binary {
     echo "====== Building Antrea binaries for the Following Commit ======"
     export GO111MODULE=on
     export GOPATH=${WORKDIR}/go
-    export GOROOT=/usr/local/go
+    export GOROOT=${GOLANG_RELEASE_DIR}/go
     export GOCACHE=${WORKSPACE}/../gocache
     export PATH=${GOROOT}/bin:$PATH
 
@@ -315,6 +316,8 @@ function build_antrea_binary {
 }
 
 trap clean_antrea EXIT
+source $WORKSPACE/ci/jenkins/utils.sh
+check_and_upgrade_golang
 fetch_vm_ip
 apply_antrea
 build_antrea_binary

--- a/ci/jenkins/test-vmc.sh
+++ b/ci/jenkins/test-vmc.sh
@@ -38,6 +38,7 @@ TEST_FAILURE=false
 CLUSTER_READY=false
 DOCKER_REGISTRY=""
 CONTROL_PLANE_NODE_ROLE="master|control-plane"
+GOLANG_RELEASE_DIR=${WORKDIR}/golang-releases
 
 _usage="Usage: $0 [--cluster-name <VMCClusterNameToUse>] [--kubeconfig <KubeconfigSavePath>] [--workdir <HomePath>]
                   [--log-mode <SonobuoyResultLogLevel>] [--testcase <e2e|conformance|all-features-conformance|whole-conformance|networkpolicy>]
@@ -341,7 +342,7 @@ function deliver_antrea {
 
     export GO111MODULE=on
     export GOPATH=$WORKDIR/go
-    export GOROOT=/usr/local/go
+    export GOROOT=${GOLANG_RELEASE_DIR}/go
     export GOCACHE=${GIT_CHECKOUT_DIR}/../gocache
     export PATH=$GOROOT/bin:$PATH
 
@@ -476,7 +477,7 @@ function run_e2e {
 
     export GO111MODULE=on
     export GOPATH=$WORKDIR/go
-    export GOROOT=/usr/local/go
+    export GOROOT=${GOLANG_RELEASE_DIR}/go
     export GOCACHE=$WORKDIR/.cache/go-build
     export PATH=$GOROOT/bin:$PATH
     export KUBECONFIG=$GIT_CHECKOUT_DIR/jenkins/out/kubeconfig
@@ -538,7 +539,7 @@ function run_conformance {
 
     export GO111MODULE=on
     export GOPATH=$WORKDIR/go
-    export GOROOT=/usr/local/go
+    export GOROOT=${GOLANG_RELEASE_DIR}/go
     export GOCACHE=$WORKDIR/.cache/go-build
     export PATH=$GOROOT/bin:$PATH
     export KUBECONFIG=$GIT_CHECKOUT_DIR/jenkins/out/kubeconfig
@@ -680,6 +681,8 @@ SSH_WITH_ANTREA_CI_KEY="ssh -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyC
 SSH_WITH_UTILS_KEY="ssh -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i ${WORKDIR}/utils/key"
 SCP_WITH_UTILS_KEY="scp -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i ${WORKDIR}/utils/key"
 
+source $WORKSPACE/ci/jenkins/utils.sh
+check_and_upgrade_golang
 clean_tmp
 if [[ "$RUN_GARBAGE_COLLECTION" == true ]]; then
     garbage_collection

--- a/ci/jenkins/test.sh
+++ b/ci/jenkins/test.sh
@@ -38,6 +38,7 @@ IP_MODE=""
 K8S_VERSION="1.27.2-00"
 WINDOWS_YAML_SUFFIX="windows"
 WIN_IMAGE_NODE=""
+GOLANG_RELEASE_DIR=${WORKDIR}/golang-releases
 
 WINDOWS_CONFORMANCE_FOCUS="\[sig-network\].+\[Conformance\]|\[sig-windows\]"
 WINDOWS_CONFORMANCE_SKIP="\[LinuxOnly\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[sig-cli\]|\[sig-storage\]|\[sig-auth\]|\[sig-api-machinery\]|\[sig-apps\]|\[sig-node\]|\[Privileged\]|should be able to change the type from|\[sig-network\] Services should be able to create a functioning NodePort service \[Conformance\]|Service endpoints latency should not be very high|should be able to create a functioning NodePort service for Windows"
@@ -311,7 +312,7 @@ function prepare_env {
     echo "====== Building Antrea for the Following Commit ======"
     export GO111MODULE=on
     export GOPATH=${WORKDIR}/go
-    export GOROOT=/usr/local/go
+    export GOROOT=${GOLANG_RELEASE_DIR}/go
     export GOCACHE=${WORKSPACE}/../gocache
     export PATH=${GOROOT}/bin:$PATH
 
@@ -653,7 +654,7 @@ function deliver_antrea {
     echo "====== Building Antrea for the Following Commit ======"
     export GO111MODULE=on
     export GOPATH=${WORKDIR}/go
-    export GOROOT=/usr/local/go
+    export GOROOT=${GOLANG_RELEASE_DIR}/go
     export GOCACHE="${WORKSPACE}/../gocache"
     export PATH=${GOROOT}/bin:$PATH
 
@@ -761,7 +762,7 @@ function run_e2e {
     echo "====== Running Antrea E2E Tests ======"
     export GO111MODULE=on
     export GOPATH=${WORKDIR}/go
-    export GOROOT=/usr/local/go
+    export GOROOT=${GOLANG_RELEASE_DIR}/go
     export GOCACHE=${WORKDIR}/.cache/go-build
     export PATH=$GOROOT/bin:$PATH
 
@@ -791,7 +792,7 @@ function run_conformance {
     echo "====== Running Antrea Conformance Tests ======"
     export GO111MODULE=on
     export GOPATH=${WORKDIR}/go
-    export GOROOT=/usr/local/go
+    export GOROOT=${GOLANG_RELEASE_DIR}/go
     export GOCACHE=${WORKDIR}/.cache/go-build
     export PATH=$GOROOT/bin:$PATH
 
@@ -822,7 +823,7 @@ function run_e2e_windows {
     echo "====== Running Antrea e2e Tests ======"
     export GO111MODULE=on
     export GOPATH=${WORKDIR}/go
-    export GOROOT=/usr/local/go
+    export GOROOT=${GOLANG_RELEASE_DIR}/go
     export GOCACHE=${WORKDIR}/.cache/go-build
     export PATH=$GOROOT/bin:$PATH
 
@@ -851,7 +852,7 @@ function run_conformance_windows {
     echo "====== Running Antrea Conformance Tests ======"
     export GO111MODULE=on
     export GOPATH=${WORKDIR}/go
-    export GOROOT=/usr/local/go
+    export GOROOT=${GOLANG_RELEASE_DIR}/go
     export GOCACHE=${WORKDIR}/.cache/go-build
     export PATH=$GOROOT/bin:$PATH
 
@@ -886,7 +887,7 @@ function run_conformance_windows_containerd {
     echo "====== Running Antrea Conformance Tests ======"
     export GO111MODULE=on
     export GOPATH=${WORKDIR}/go
-    export GOROOT=/usr/local/go
+    export GOROOT=${GOLANG_RELEASE_DIR}/go
     export GOCACHE=${WORKDIR}/.cache/go-build
     export PATH=$GOROOT/bin:$PATH
 
@@ -1136,6 +1137,8 @@ if [[ $TESTCASE =~ "multicast" ]]; then
     ./hack/generate-manifest.sh --encap-mode noEncap --multicast --multicast-interfaces "ens224" --verbose-log > build/yamls/antrea.yml
 fi
 
+source $WORKSPACE/ci/jenkins/utils.sh
+check_and_upgrade_golang
 clean_tmp
 if [[ ${TESTCASE} == "windows-install-ovs" ]]; then
     run_install_windows_ovs

--- a/ci/jenkins/utils.sh
+++ b/ci/jenkins/utils.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 Antrea Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function check_and_upgrade_golang() {
+    if [ -z "${GOLANG_RELEASE_DIR}" ]; then
+        GOLANG_RELEASE_DIR="/var/lib/jenkins/golang-releases"
+    fi
+    if [ ! -d ${GOLANG_RELEASE_DIR} ]; then
+        mkdir -p ${GOLANG_RELEASE_DIR}
+    fi
+    echo "====== Checking installed Golang version ======"
+    antrea_golang_version="go$(grep -E "^go\ " ${WORKSPACE}/go.mod | awk '{print $2}' | cut -d. -f1-2)"
+
+    while read -r i; do
+        version=$(echo ${i} | jq .version | tr -d '"')
+        if [[ "${version}" =~ "${antrea_golang_version}" ]]; then
+            if [ -d "${GOLANG_RELEASE_DIR}/${antrea_golang_version}" ]; then
+                current_version=$(${GOLANG_RELEASE_DIR}/${antrea_golang_version}/bin/go version | awk '{print $3}')
+                if [[ "${version}" == "${current_version}" ]]; then
+                    echo "====== Golang ${version} is installed on the testbed, no need to download ======"
+                    switch_golang "${version}"
+                    break
+                fi
+            fi
+            echo "====== Installing Golang version "${version}" ======"
+            install_golang "${version}"
+            switch_golang "${version}"
+            break
+        fi
+    done < <(curl -s "https://go.dev/dl/?mode=json&include=all" | jq -c -r '.[]')
+}
+
+function install_golang() {
+    golang_version=$1
+    echo "====== Downloading Golang ${golang_version} ======"
+    curl https://dl.google.com/go/${golang_version}.linux-amd64.tar.gz -o /tmp/${golang_version}.linux-amd64.tar.gz
+    rm -rf /tmp/go || true
+    tar xf /tmp/${golang_version}.linux-amd64.tar.gz -C /tmp/
+    golang_version=$(echo ${golang_version} | cut -d. -f1-2)
+    rm -rf ${GOLANG_RELEASE_DIR}/${golang_version} || true
+    mv /tmp/go ${GOLANG_RELEASE_DIR}/${golang_version}
+}
+
+function switch_golang() {
+    golang_version=$1
+    golang_version=$(echo ${golang_version} | cut -d. -f1-2)
+    rm -rf ${GOLANG_RELEASE_DIR}/go
+    echo "====== Switching to Golang ${golang_version} ======"
+    ln -s ${GOLANG_RELEASE_DIR}/${golang_version} ${GOLANG_RELEASE_DIR}/go
+}


### PR DESCRIPTION
Every time the Jenkins jobs are triggered, the jobs will check the Golang version on the testbed and compare with the Golang version in go.mod. If the Golang version is different, the jobs will automatically download and install newer Golang. (#5338)