### PR TITLE
Handle stale LabelIdentities created for empty Pod labels correctly after upgrade

### DIFF
--- a/multicluster/controllers/multicluster/stale_controller.go
+++ b/multicluster/controllers/multicluster/stale_controller.go
@@ -339,7 +339,7 @@ func (c *StaleResCleanupController) cleanupLabelIdentityResourceExport(ctx conte
 		if !ok {
 			continue
 		}
-		normalizedLabel := podNSlabel + "&pod:" + labels.FormatLabels(p.Labels)
+		normalizedLabel := podNSlabel + "&pod:" + labels.Set(p.Labels).String()
 		delete(staleResExpItems, normalizedLabel)
 	}
 	for _, r := range staleResExpItems {

--- a/pkg/controller/labelidentity/label_group_index.go
+++ b/pkg/controller/labelidentity/label_group_index.go
@@ -124,7 +124,12 @@ func (l *labelIdentityMatch) matches(s *selectorItem) bool {
 // constructMapFromLabelString parses label string of format "app=client,env=dev" into a map.
 func constructMapFromLabelString(s string) map[string]string {
 	m := map[string]string{}
-	if s == "" {
+	// Before https://github.com/antrea-io/antrea/issues/5403 is fixed, LabelIdentities created
+	// for Pods with an empty label set will include a <none> string. Handling for such LabelIdentities
+	// are needed, as in multi-cluster controller upgrade cases, these LabelIdentities created by
+	// previous controller still need to be processed, but will be cleaned up by the stale controller
+	// eventually.
+	if s == "" || s == "<none>" {
 		return m
 	}
 	kvs := strings.Split(s, ",")

--- a/pkg/controller/labelidentity/label_group_index_test.go
+++ b/pkg/controller/labelidentity/label_group_index_test.go
@@ -65,10 +65,11 @@ var (
 	selectorItemG = &selectorItem{
 		selector: selectorG,
 	}
-	labelA = "ns:kubernetes.io/metadata.name=testing,purpose=test&pod:app=web"
-	labelB = "ns:kubernetes.io/metadata.name=testing,purpose=test&pod:app=db"
-	labelC = "ns:kubernetes.io/metadata.name=nomatch,purpose=nomatch&pod:app=db"
-	labelD = "ns:kubernetes.io/metadata.name=testing,purpose=test&pod:"
+	labelA     = "ns:kubernetes.io/metadata.name=testing,purpose=test&pod:app=web"
+	labelB     = "ns:kubernetes.io/metadata.name=testing,purpose=test&pod:app=db"
+	labelC     = "ns:kubernetes.io/metadata.name=nomatch,purpose=nomatch&pod:app=db"
+	labelD     = "ns:kubernetes.io/metadata.name=testing,purpose=test&pod:"
+	labelStale = "ns:kubernetes.io/metadata.name=testing,purpose=test&pod:<none>"
 )
 
 func TestLabelIdentityMatch(t *testing.T) {
@@ -171,6 +172,11 @@ func TestLabelIdentityMatch(t *testing.T) {
 			label:       labelD,
 			selector:    selectorItemG,
 			expectMatch: true,
+		},
+		{
+			label:       labelStale,
+			selector:    selectorItemA,
+			expectMatch: false,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
This is a follow-up on PR #5404 which intends to address issue #5403. 

In upgrade cases, Antrea controller will still receive LabelIdentity add events for LabelIdentities created by previous controller, which it needs to handle correctly. Also, the stale controller logic needs to be updated to ensure that LabelIdentities created with old normalization method are cleaned up after upgrade.