### PR TITLE
Fix burst of PacketInQueue

### DIFF
--- a/pkg/ovs/openflow/ofctrl_bridge.go
+++ b/pkg/ovs/openflow/ofctrl_bridge.go
@@ -645,7 +645,7 @@ type PacketInQueue struct {
 }
 
 func NewPacketInQueue(size int, r rate.Limit) *PacketInQueue {
-	return &PacketInQueue{rateLimiter: rate.NewLimiter(r, 1), packetsCh: make(chan *ofctrl.PacketIn, size)}
+	return &PacketInQueue{rateLimiter: rate.NewLimiter(r, size), packetsCh: make(chan *ofctrl.PacketIn, size)}
 }
 
 func (q *PacketInQueue) AddOrDrop(packet *ofctrl.PacketIn) bool {

--- a/pkg/ovs/openflow/ofctrl_bridge_test.go
+++ b/pkg/ovs/openflow/ofctrl_bridge_test.go
@@ -199,3 +199,13 @@ func TestOFMeterStats(t *testing.T) {
 		return packetCounts[1] == int64(100) && packetCounts[2] == int64(0)
 	}, 2*time.Second, 50*time.Millisecond)
 }
+
+func TestPacketInQueue(t *testing.T) {
+	burst := 200
+	q := NewPacketInQueue(burst, rate.Limit(100))
+	for i := 0; i < burst; i++ {
+		assert.True(t, q.AddOrDrop(nil), "Packet should not be dropped before reaching the burst")
+	}
+	assert.False(t, q.AddOrDrop(nil), "Packet should be dropped after reaching the burst")
+	assert.Equal(t, float64(burst), q.rateLimiter.Tokens())
+}


### PR DESCRIPTION
The burst was not effective because the number of tokens was hardcoded to 1, leading to 10ms delay when processing every successive DNS response. For example, in some scenario it takes a client 10 DNS queries to get a valid DNS response, the later 9 DNS responses would be delayed 90ms in total. This affected the DNS resolution delay when a Pod has any FQDN policy applied.

This commit fixes the burst setting of the PacketInQueue. The connection time of accessing a FQDN is reduced from 134ms to 41ms according to my test.

For #5446