### PR TITLE
Automated cherry pick of #5456: Fix burst of PacketInQueue
#5460: Increase Rate-limit config

### DIFF
--- a/pkg/agent/openflow/packetin.go
+++ b/pkg/agent/openflow/packetin.go
@@ -82,15 +82,15 @@ const (
 	PacketInMeterIDTF = 2
 	// Meter Entry Rate. It is represented as number of events per second.
 	// Packets which exceed the rate will be dropped.
-	PacketInMeterRateNP = 100
-	PacketInMeterRateTF = 100
+	PacketInMeterRateNP = 500
+	PacketInMeterRateTF = 500
 
 	// PacketInQueueSize defines the size of PacketInQueue.
 	// When PacketInQueue reaches PacketInQueueSize, new packetIn will be dropped.
-	PacketInQueueSize = 200
+	PacketInQueueSize = 1000
 	// PacketInQueueRate defines the maximum frequency of getting items from PacketInQueue.
 	// PacketInQueueRate is represented as number of events per second.
-	PacketInQueueRate = 100
+	PacketInQueueRate = 500
 )
 
 // RegisterPacketInHandler stores controller handler in a map with category as keys.

--- a/pkg/ovs/openflow/ofctrl_bridge.go
+++ b/pkg/ovs/openflow/ofctrl_bridge.go
@@ -664,7 +664,7 @@ type PacketInQueue struct {
 }
 
 func NewPacketInQueue(size int, r rate.Limit) *PacketInQueue {
-	return &PacketInQueue{rateLimiter: rate.NewLimiter(r, 1), packetsCh: make(chan *ofctrl.PacketIn, size)}
+	return &PacketInQueue{rateLimiter: rate.NewLimiter(r, size), packetsCh: make(chan *ofctrl.PacketIn, size)}
 }
 
 func (q *PacketInQueue) AddOrDrop(packet *ofctrl.PacketIn) bool {

--- a/pkg/ovs/openflow/ofctrl_bridge_test.go
+++ b/pkg/ovs/openflow/ofctrl_bridge_test.go
@@ -162,3 +162,13 @@ func TestOFBridgePacketRcvd(t *testing.T) {
 		}
 	}
 }
+
+func TestPacketInQueue(t *testing.T) {
+	burst := 200
+	q := NewPacketInQueue(burst, rate.Limit(100))
+	for i := 0; i < burst; i++ {
+		assert.True(t, q.AddOrDrop(nil), "Packet should not be dropped before reaching the burst")
+	}
+	assert.False(t, q.AddOrDrop(nil), "Packet should be dropped after reaching the burst")
+	assert.Equal(t, float64(burst), q.rateLimiter.Tokens())
+}


### PR DESCRIPTION
Cherry pick of #5456 #5460 on release-1.12.

#5456: Fix burst of PacketInQueue
#5460: Increase Rate-limit config

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.