### PR TITLE
Automated cherry pick of #5456: Fix burst of PacketInQueue
#5460: Increase Rate-limit config

### DIFF
--- a/pkg/agent/openflow/packetin.go
+++ b/pkg/agent/openflow/packetin.go
@@ -45,8 +45,8 @@ const (
 	PacketInMeterIDTF = 2
 	// Meter Entry Rate. It is represented as number of events per second.
 	// Packets which exceed the rate will be dropped.
-	PacketInMeterRateNP = 100
-	PacketInMeterRateTF = 100
+	PacketInMeterRateNP = 500
+	PacketInMeterRateTF = 500
 
 	// PacketIn reasons
 	PacketInReasonTF ofpPacketInReason = 1
@@ -62,10 +62,10 @@ const (
 	PacketInReasonSvcReject = PacketInReasonNP
 	// PacketInQueueSize defines the size of PacketInQueue.
 	// When PacketInQueue reaches PacketInQueueSize, new packet-in will be dropped.
-	PacketInQueueSize = 200
+	PacketInQueueSize = 1000
 	// PacketInQueueRate defines the maximum frequency of getting items from PacketInQueue.
 	// PacketInQueueRate is represented as number of events per second.
-	PacketInQueueRate = 100
+	PacketInQueueRate = 500
 )
 
 // RegisterPacketInHandler stores controller handler in a map of map with reason and name as keys.

--- a/pkg/ovs/openflow/ofctrl_bridge.go
+++ b/pkg/ovs/openflow/ofctrl_bridge.go
@@ -640,7 +640,7 @@ type PacketInQueue struct {
 }
 
 func NewPacketInQueue(size int, r rate.Limit) *PacketInQueue {
-	return &PacketInQueue{rateLimiter: rate.NewLimiter(r, 1), packetsCh: make(chan *ofctrl.PacketIn, size)}
+	return &PacketInQueue{rateLimiter: rate.NewLimiter(r, size), packetsCh: make(chan *ofctrl.PacketIn, size)}
 }
 
 func (q *PacketInQueue) AddOrDrop(packet *ofctrl.PacketIn) bool {


### PR DESCRIPTION
Cherry pick of #5456 #5460 on release-1.11.

#5456: Fix burst of PacketInQueue
#5460: Increase Rate-limit config

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.