### PR TITLE
Fix IPv6 E2E Jenkins job

### DIFF
--- a/ci/jenkins/jobs/macros.yaml
+++ b/ci/jenkins/jobs/macros.yaml
@@ -283,7 +283,7 @@
           #!/bin/bash
           set -e
           DOCKER_REGISTRY="$(head -n1 ci/docker-registry)"
-          ./ci/jenkins/test.sh --testcase e2e --registry ${{DOCKER_REGISTRY}} --testbed-type jumper
+          ./ci/jenkins/test.sh --testcase e2e --registry ${DOCKER_REGISTRY} --testbed-type jumper
 
 - builder:
     name: builder-conformance-jumper


### PR DESCRIPTION
Change double brackets to single brackets for Jenkins macro builder-e2e-jumper.