### PR TITLE
Update Multi-cluster docs with more details

### DIFF
--- a/docs/multicluster/quick-start.md
+++ b/docs/multicluster/quick-start.md
@@ -114,7 +114,8 @@ Secret manifest and other ClusterSet join arguments to file `join-config.yml`
 command (with the `--config-file` option) to join the ClusterSet with these
 arguments. If you want to use a separate token for each member cluster for
 security considerations, you can run the following commands to create a token
-and use the token to join the ClusterSet:
+and use the token (together with the previously generated configuration file
+`join-config.yml`) to join the ClusterSet:
 
 ```bash
 antctl mc create membertoken test-cluster-leader-token -n antrea-multicluster -o test-cluster-leader-token.yml
@@ -313,8 +314,8 @@ kubectl annotate node node-b1 multicluster.antrea.io/gateway=true
 ### Add new member clusters
 
 If you want to add a new member cluster to your ClusterSet, you can follow the
-steps for cluster B to do so. Remember to update the member cluster ID in
-`member-clusterset-template.yml` to the new member cluster's ID in the step 2 of
+steps for cluster B to do so. Remember to update the member cluster ID `spec.clusterID`
+in `member-clusterset-template.yml` to the new member cluster's ID in step 2 of
 joining ClusterSet. For example, you can run the following commands to join the
 ClusterSet in a member cluster with ID `test-cluster-member2`:
 

--- a/docs/multicluster/quick-start.md
+++ b/docs/multicluster/quick-start.md
@@ -315,7 +315,7 @@ kubectl annotate node node-b1 multicluster.antrea.io/gateway=true
 
 If you want to add a new member cluster to your ClusterSet, you can follow the
 steps for cluster B to do so. Remember to update the member cluster ID `spec.clusterID`
-in `member-clusterset-template.yml` to the new member cluster's ID in step 2 of
+in `member-clusterset-template.yml` to the new member cluster's ID in the step 2 of
 joining ClusterSet. For example, you can run the following commands to join the
 ClusterSet in a member cluster with ID `test-cluster-member2`:
 

--- a/docs/multicluster/user-guide.md
+++ b/docs/multicluster/user-guide.md
@@ -409,7 +409,7 @@ member clusters. If WireGuard is enabled, the WireGuard interface and routes
 will be created by Antrea Agent on the Gateway Node, and all cross-cluster
 traffic will be encrypted and forwarded to the WireGuard tunnel.
 
-Please note that WireGuard encryption requires `wireguard` kernel module be
+Please note that WireGuard encryption requires the `wireguard` kernel module be
 present on the Kubernetes Nodes. `wireguard` module is part of mainline kernel
 since Linux 5.6. Or, you can compile the module from source code with a kernel
 version >= 3.10. [This WireGuard installation guide](https://www.wireguard.com/install)

--- a/docs/multicluster/user-guide.md
+++ b/docs/multicluster/user-guide.md
@@ -409,6 +409,13 @@ member clusters. If WireGuard is enabled, the WireGuard interface and routes
 will be created by Antrea Agent on the Gateway Node, and all cross-cluster
 traffic will be encrypted and forwarded to the WireGuard tunnel.
 
+Please note that WireGuard encryption requires `wireguard` kernel module be
+present on the Kubernetes Nodes. `wireguard` module is part of mainline kernel
+since Linux 5.6. Or, you can compile the module from source code with a kernel
+version >= 3.10. [This WireGuard installation guide](https://www.wireguard.com/install)
+documents how to install WireGuard together with the kernel module on various
+operating systems.
+
 To enable the WireGuard encryption, the `TrafficEncryptMode`
 in Multi-cluster configuration should be set to `wireGuard` and the `enableGateway`
 field should be set to `true` as follows:

--- a/docs/traffic-encryption.md
+++ b/docs/traffic-encryption.md
@@ -84,7 +84,7 @@ will be ignored.
 WireGuard encryption requires `wireguard` kernel module be present on the
 Kubernetes Nodes. `wireguard` module is part of mainline kernel since Linux 5.6.
 Or, you can compile the module from source code with a kernel version >= 3.10.
-[This WireGuard web page](https://www.wireguard.com/install) documents how to
+[This WireGuard installation guide](https://www.wireguard.com/install) documents how to
 install WireGuard together with the kernel module on various operating systems.
 
 ### Antrea installation

--- a/docs/traffic-encryption.md
+++ b/docs/traffic-encryption.md
@@ -81,7 +81,7 @@ will be ignored.
 
 ### Prerequisites
 
-WireGuard encryption requires `wireguard` kernel module be present on the
+WireGuard encryption requires the `wireguard` kernel module be present on the
 Kubernetes Nodes. `wireguard` module is part of mainline kernel since Linux 5.6.
 Or, you can compile the module from source code with a kernel version >= 3.10.
 [This WireGuard installation guide](https://www.wireguard.com/install) documents how to


### PR DESCRIPTION
When the QE follows the doc to set up a ClusterSet, they misunderstood the guide and failed the setup, so add a few more details to avoid misreading.

1. Update the user guide to make it clearer.
2. Update the requirement of WireGuard encryption.