### PR TITLE
Automated cherry pick of #5280: Sonobuoy e2e tests Enhancement

### DIFF
--- a/ci/jenkins/test.sh
+++ b/ci/jenkins/test.sh
@@ -45,7 +45,7 @@ WINDOWS_NETWORKPOLICY_FOCUS="\[Feature:NetworkPolicy\]"
 WINDOWS_NETWORKPOLICY_SKIP="SCTP"
 WINDOWS_NETWORKPOLICY_CONTAINERD_SKIP="\[sig-storage\]|SCTP"
 CONFORMANCE_SKIP="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[sig-cli\]|\[sig-storage\]|\[sig-auth\]|\[sig-api-machinery\]|\[sig-apps\]|\[sig-node\]"
-NETWORKPOLICY_SKIP="should allow egress access to server in CIDR block|should enforce except clause while egress access to server in CIDR block"
+NETWORKPOLICY_SKIP="NetworkPolicyLegacy|should allow egress access to server in CIDR block|should enforce except clause while egress access to server in CIDR block"
 
 CONTROL_PLANE_NODE_ROLE="master|control-plane"
 

--- a/ci/run-k8s-e2e-tests.sh
+++ b/ci/run-k8s-e2e-tests.sh
@@ -35,7 +35,7 @@ KUBECONFIG_OPTION=""
 DEFAULT_E2E_CONFORMANCE_FOCUS="\[Conformance\]"
 DEFAULT_E2E_CONFORMANCE_SKIP="\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[sig-cli\]|\[sig-storage\]|\[sig-auth\]|\[sig-api-machinery\]|\[sig-apps\]|\[sig-node\]|\[sig-instrumentation\]"
 DEFAULT_E2E_NETWORKPOLICY_FOCUS="\[Feature:NetworkPolicy\]"
-DEFAULT_E2E_NETWORKPOLICY_SKIP=""
+DEFAULT_E2E_NETWORKPOLICY_SKIP="NetworkPolicyLegacy"
 DEFAULT_E2E_SIG_NETWORK_FOCUS="\[sig-network\]"
 DEFAULT_E2E_SIG_NETWORK_SKIP="\[Slow\]|\[Serial\]|\[Disruptive\]|\[GCE\]|\[Feature:.+\]|\[Feature:IPv6DualStack\]|\[Feature:IPv6DualStackAlphaFeature\]|should create pod that uses dns|should provide Internet connection for containers"
 MODE="report"
@@ -180,6 +180,7 @@ function run_sonobuoy() {
     else
         $SONOBUOY run --wait \
                 $KUBECONFIG_OPTION \
+                --e2e-parallel=true \
                 $KUBE_CONFORMANCE_IMAGE_VERSION_OPTION \
                 --e2e-focus "$focus_regex" --e2e-skip "$skip_regex" --image-pull-policy ${IMAGE_PULL_POLICY} \
                 --sonobuoy-image ${SONOBUOY_IMAGE} --systemd-logs-image ${SYSTEMD_LOGS_IMAGE} --e2e-repo-config ${CONFORMANCE_IMAGE_CONFIG_PATH}


### PR DESCRIPTION
Cherry pick of #5280 on release-1.11.

#5280: Sonobuoy e2e tests Enhancement

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.