### PR TITLE
Add a ClusterSet deletion webhook for the leader cluster

### DIFF
--- a/multicluster/build/yamls/antrea-multicluster-leader-namespaced.yml
+++ b/multicluster/build/yamls/antrea-multicluster-leader-namespaced.yml
@@ -474,6 +474,7 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
+    - DELETE
     resources:
     - clustersets
   sideEffects: None

--- a/multicluster/build/yamls/antrea-multicluster-leader.yml
+++ b/multicluster/build/yamls/antrea-multicluster-leader.yml
@@ -6222,6 +6222,7 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
+    - DELETE
     resources:
     - clustersets
   sideEffects: None

--- a/multicluster/build/yamls/antrea-multicluster-member.yml
+++ b/multicluster/build/yamls/antrea-multicluster-member.yml
@@ -1291,6 +1291,7 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
+    - DELETE
     resources:
     - clustersets
   sideEffects: None

--- a/multicluster/cmd/multicluster-controller/controller.go
+++ b/multicluster/cmd/multicluster-controller/controller.go
@@ -37,7 +37,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	k8smcsv1alpha1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 
 	mcv1alpha1 "antrea.io/antrea/multicluster/apis/multicluster/v1alpha1"
@@ -200,12 +199,6 @@ func setupManagerAndCertController(isLeader bool, o *Options) (manager.Manager, 
 	if err != nil {
 		return nil, fmt.Errorf("error starting manager: %v", err)
 	}
-
-	hookServer := mgr.GetWebhookServer()
-	hookServer.Register("/validate-multicluster-crd-antrea-io-v1alpha2-clusterset",
-		&webhook.Admission{Handler: &clusterSetValidator{
-			Client:    mgr.GetClient(),
-			namespace: env.GetPodNamespace()}})
 
 	//+kubebuilder:scaffold:builder
 

--- a/multicluster/cmd/multicluster-controller/leader.go
+++ b/multicluster/cmd/multicluster-controller/leader.go
@@ -76,6 +76,13 @@ func runLeader(o *Options) error {
 			Client:    noCachedClient,
 			namespace: env.GetPodNamespace()}})
 
+	hookServer.Register("/validate-multicluster-crd-antrea-io-v1alpha2-clusterset",
+		&webhook.Admission{Handler: &clusterSetValidator{
+			Client:    mgr.GetClient(),
+			namespace: env.GetPodNamespace(),
+			role:      leaderRole},
+		})
+
 	clusterSetReconciler := &leader.LeaderClusterSetReconciler{
 		Client:                   mgr.GetClient(),
 		Scheme:                   mgr.GetScheme(),

--- a/multicluster/cmd/multicluster-controller/member.go
+++ b/multicluster/cmd/multicluster-controller/member.go
@@ -63,6 +63,13 @@ func runMember(o *Options) error {
 			Client:    mgr.GetClient(),
 			namespace: env.GetPodNamespace()}})
 
+	hookServer.Register("/validate-multicluster-crd-antrea-io-v1alpha2-clusterset",
+		&webhook.Admission{Handler: &clusterSetValidator{
+			Client:    mgr.GetClient(),
+			namespace: env.GetPodNamespace(),
+			role:      memberRole},
+		})
+
 	clusterSetReconciler := member.NewMemberClusterSetReconciler(mgr.GetClient(),
 		mgr.GetScheme(),
 		env.GetPodNamespace(),

--- a/multicluster/config/webhook/manifests.yaml
+++ b/multicluster/config/webhook/manifests.yaml
@@ -51,6 +51,7 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
+    - DELETE
     resources:
     - clustersets
   sideEffects: None


### PR DESCRIPTION
Add a ClusterSet deletion webhook to fail the ClusterSet deletion request
in the leader cluster when any MemberClusterAnnounce exists.
