### PR TITLE
Update Prometheus metrics doc

### DIFF
--- a/docs/prometheus-integration.md
+++ b/docs/prometheus-integration.md
@@ -468,6 +468,9 @@ GODEBUG=randautoseed=... setting.
 - **go_godebug_non_default_behavior_tarinsecurepath_events_total:** The
 number of non-default behaviors executed by the archive/tar package due to
 a non-default GODEBUG=tarinsecurepath=... setting.
+- **go_godebug_non_default_behavior_tlsmaxrsasize_events_total:** The
+number of non-default behaviors executed by the crypto/tls package due to
+a non-default GODEBUG=tlsmaxrsasize=... setting.
 - **go_godebug_non_default_behavior_x509sha1_events_total:** The number of
 non-default behaviors executed by the crypto/x509 package due to a non-default
 GODEBUG=x509sha1=... setting.


### PR DESCRIPTION
The Prometheus metrics doc validation job is failed. Fix it by updating the metrics doc for Golang metrics change.

There is a new GODEBUG setting added which impact the metrics. https://github.com/golang/go/issues/61965.
The change has been verified here: https://github.com/antrea-io/antrea/actions/runs/6118857003/job/16608129508?pr=5475