### PR TITLE
Add shlex.Split for command parsing and support for bash in command execution.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/golang/protobuf v1.5.3
 	github.com/google/btree v1.1.2
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/google/uuid v1.3.1
 	github.com/hashicorp/memberlist v0.5.0
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.3.0
@@ -142,7 +143,6 @@ require (
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 // indirect
-	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 // indirect


### PR DESCRIPTION
This patch enhances the command execution functionality to support commands containing 'bash' in the 'cmd' parameter. Additionally, it adds functionality to split the 'cmd' parameter using shell-style rules for quoting and commenting,

