### PR TITLE
Stop logging git fetch progress in actions/checkout

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -14,6 +14,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          show-progress: false
 
       - name: Set up Go using version from go.mod
         uses: actions/setup-go@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        show-progress: false
     - uses: antrea-io/has-changes@v2
       id: check_diff
       with:
@@ -33,6 +34,8 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v4
+      with:
+        show-progress: false
     - name: Build Antrea amd64 Docker image without pushing to registry
       if: ${{ github.repository != 'antrea-io/antrea' || github.event_name != 'push' || github.ref != 'refs/heads/main' }}
       run: |
@@ -63,6 +66,8 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v4
+      with:
+        show-progress: false
     - name: Build Antrea UBI8 Docker image without pushing to registry
       if: ${{ github.repository != 'antrea-io/antrea' || github.event_name != 'push' || github.ref != 'refs/heads/main' }}
       run: |
@@ -83,6 +88,8 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v4
+      with:
+        show-progress: false
     - name: Build Antrea Agent Simulator Docker image
       run: make build-scale-simulator
     - name: Push Antrea Agent Simulator Docker image to registry
@@ -100,6 +107,8 @@ jobs:
     runs-on: [windows-2019]
     steps:
     - uses: actions/checkout@v4
+      with:
+        show-progress: false
     - name: Build Antrea Windows Docker image
       run: make build-windows
     - name: Push Antrea Windows Docker image to registry
@@ -118,6 +127,8 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v4
+      with:
+        show-progress: false
     - name: Build antrea-mc-controller Docker image
       run: make build-antrea-mc-controller
     - name: Push antrea-mc-controller Docker image to registry
@@ -135,6 +146,8 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v4
+      with:
+        show-progress: false
     - name: Build flow-aggregator Docker image
       run: make flow-aggregator-image
     - name: Check flow-aggregator Docker image

--- a/.github/workflows/build_tag.yml
+++ b/.github/workflows/build_tag.yml
@@ -24,6 +24,8 @@ jobs:
     needs: get-version
     steps:
     - uses: actions/checkout@v4
+      with:
+        show-progress: false
     - name: Build and push Antrea Ubuntu amd64 Docker image to registry
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
@@ -48,6 +50,8 @@ jobs:
     needs: get-version
     steps:
       - uses: actions/checkout@v4
+        with:
+          show-progress: false
       - name: Build and push Antrea UBI8 amd64 Docker image to registry
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
@@ -63,6 +67,8 @@ jobs:
     needs: get-version
     steps:
     - uses: actions/checkout@v4
+      with:
+        show-progress: false
     - name: Build Antrea Windows Docker image and push to registry
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
@@ -79,6 +85,8 @@ jobs:
     needs: get-version
     steps:
     - uses: actions/checkout@v4
+      with:
+        show-progress: false
     - name: Build antrea-mc-controller Docker image and push to registry
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
@@ -94,6 +102,8 @@ jobs:
     needs: get-version
     steps:
     - uses: actions/checkout@v4
+      with:
+        show-progress: false
     - name: Build flow-aggregator Docker image and push to registry
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+        show-progress: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
@@ -63,6 +65,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+        show-progress: false
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -46,6 +46,7 @@ jobs:
         with:
           ref: ${{ inputs.antrea-version }}
           fetch-depth: 0
+          show-progress: false
       - name: Check if it is a released version
         id: check-release
         run: |

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -36,6 +36,7 @@ jobs:
         # Check out the pull request HEAD
         ref: ${{ github.event.pull_request.head.sha }}
         token: ${{ secrets.ANTREA_BOT_WRITE_PAT }}
+        show-progress: false
     - name: Set up Go using version from go.mod
       uses: actions/setup-go@v4
       with:

--- a/.github/workflows/docker_update_base_windows.yml
+++ b/.github/workflows/docker_update_base_windows.yml
@@ -29,6 +29,7 @@ jobs:
       with:
         repository: ${{ github.event.inputs.antrea-repository }}
         ref: ${{ github.event.inputs.antrea-ref }}
+        show-progress: false
     - name: Login to DockerHub
       uses: docker/login-action@v3
       with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,6 +19,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        show-progress: false
     - uses: antrea-io/has-changes@v2
       id: check_diff
       with:
@@ -37,6 +38,8 @@ jobs:
     steps:
     - name: Check-out code
       uses: actions/checkout@v4
+      with:
+        show-progress: false
     - name: Set up Go using version from go.mod
       uses: actions/setup-go@v4
       with:
@@ -60,6 +63,8 @@ jobs:
     steps:
       - name: Check-out code
         uses: actions/checkout@v4
+        with:
+          show-progress: false
       - name: Set up Go using version from go.mod
         uses: actions/setup-go@v4
         with:
@@ -83,6 +88,8 @@ jobs:
     steps:
       - name: Check-out code
         uses: actions/checkout@v4
+        with:
+          show-progress: false
       - name: Set up Go using version from go.mod
         uses: actions/setup-go@v4
         with:
@@ -115,6 +122,8 @@ jobs:
     steps:
     - name: Check-out code
       uses: actions/checkout@v4
+      with:
+        show-progress: false
     - name: Set up Go using version from go.mod
       uses: actions/setup-go@v4
       with:
@@ -130,6 +139,8 @@ jobs:
     steps:
       - name: Check-out code
         uses: actions/checkout@v4
+        with:
+          show-progress: false
       - name: Set up Go using version from go.mod
         uses: actions/setup-go@v4
         with:
@@ -145,6 +156,8 @@ jobs:
     steps:
     - name: Check-out code
       uses: actions/checkout@v4
+      with:
+        show-progress: false
     - name: Set up Go using version from go.mod
       uses: actions/setup-go@v4
       with:
@@ -170,6 +183,8 @@ jobs:
     steps:
     - name: Check-out code
       uses: actions/checkout@v4
+      with:
+        show-progress: false
     - name: Set up Go using version from go.mod
       uses: actions/setup-go@v4
       with:
@@ -185,6 +200,8 @@ jobs:
     steps:
     - name: Check-out code
       uses: actions/checkout@v4
+      with:
+        show-progress: false
     - name: Set up Go using version from go.mod
       uses: actions/setup-go@v4
       with:
@@ -205,6 +222,8 @@ jobs:
     steps:
     - name: Check-out code
       uses: actions/checkout@v4
+      with:
+        show-progress: false
     - name: Set up Go using version from go.mod
       uses: actions/setup-go@v4
       with:
@@ -241,6 +260,8 @@ jobs:
     steps:
       - name: Check-out code
         uses: actions/checkout@v4
+        with:
+          show-progress: false
       - name: Set up Go using version from go.mod
         uses: actions/setup-go@v4
         with:

--- a/.github/workflows/golicense.yml
+++ b/.github/workflows/golicense.yml
@@ -21,6 +21,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        show-progress: false
     - uses: antrea-io/has-changes@v2
       id: check_diff
       with:
@@ -34,6 +35,8 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v4
+      with:
+        show-progress: false
     - name: Set up Go using version from go.mod
       uses: actions/setup-go@v4
       with:

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -22,6 +22,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        show-progress: false
     - uses: antrea-io/has-changes@v2
       id: check_diff
       with:
@@ -36,6 +37,8 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v4
+      with:
+        show-progress: false
     - name: Build Antrea Docker image with code coverage support
       run: |
         ./hack/build-antrea-linux-all.sh --pull --coverage
@@ -55,6 +58,8 @@ jobs:
     runs-on: [ ubuntu-latest ]
     steps:
     - uses: actions/checkout@v4
+      with:
+        show-progress: false
     - run: make flow-aggregator-ubuntu-coverage
     - name: Save Flow Aggregator image to tarball
       run: docker save -o flow-aggregator.tar antrea/flow-aggregator-coverage:latest
@@ -76,6 +81,8 @@ jobs:
         sudo apt-get clean
         df -h
     - uses: actions/checkout@v4
+      with:
+        show-progress: false
     - uses: actions/setup-go@v4
       with:
         go-version-file: 'go.mod'
@@ -135,6 +142,8 @@ jobs:
         sudo apt-get clean
         df -h
     - uses: actions/checkout@v4
+      with:
+        show-progress: false
     - uses: actions/setup-go@v4
       with:
         go-version-file: 'go.mod'
@@ -200,6 +209,8 @@ jobs:
           sudo apt-get clean
           df -h
       - uses: actions/checkout@v4
+        with:
+          show-progress: false
       - uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
@@ -265,6 +276,8 @@ jobs:
         sudo apt-get clean
         df -h
     - uses: actions/checkout@v4
+      with:
+        show-progress: false
     - uses: actions/setup-go@v4
       with:
         go-version-file: 'go.mod'
@@ -324,6 +337,8 @@ jobs:
         sudo apt-get clean
         df -h
     - uses: actions/checkout@v4
+      with:
+        show-progress: false
     - uses: actions/setup-go@v4
       with:
         go-version-file: 'go.mod'
@@ -388,6 +403,8 @@ jobs:
           sudo rm -rf "/usr/local/lib/android"
           df -h
       - uses: actions/checkout@v4
+        with:
+          show-progress: false
       - uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
@@ -454,6 +471,8 @@ jobs:
         sudo apt-get clean
         df -h
     - uses: actions/checkout@v4
+      with:
+        show-progress: false
     - uses: actions/setup-go@v4
       with:
         go-version-file: 'go.mod'
@@ -496,6 +515,8 @@ jobs:
           sudo apt-get clean
           df -h
       - uses: actions/checkout@v4
+        with:
+          show-progress: false
       - uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
@@ -538,6 +559,8 @@ jobs:
           sudo apt-get clean
           df -h
       - uses: actions/checkout@v4
+        with:
+          show-progress: false
       - uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
@@ -580,6 +603,8 @@ jobs:
           sudo apt-get clean
           df -h
       - uses: actions/checkout@v4
+        with:
+          show-progress: false
       - uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
@@ -622,6 +647,8 @@ jobs:
           sudo apt-get clean
           df -h
       - uses: actions/checkout@v4
+        with:
+          show-progress: false
       - uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
@@ -664,6 +691,8 @@ jobs:
           sudo apt-get clean
           df -h
       - uses: actions/checkout@v4
+        with:
+          show-progress: false
       - name: Download Antrea image from previous job
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
Now that we are using actions/checkout@v4, we can choose not to log fetch progress when using the action. The fetch progress does not add any value and can cause hundreds of unnecessary lines to be logged.