### PR TITLE
Automated cherry pick of #5495: Do not apply Egress to traffic destined for ServiceCIDRs

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -498,7 +498,7 @@ func run(o *Options) error {
 	if o.enableEgress {
 		egressController, err = egress.NewEgressController(
 			ofClient, antreaClientProvider, crdClient, ifaceStore, routeClient, nodeConfig.Name, nodeConfig.NodeTransportInterfaceName,
-			memberlistCluster, egressInformer, nodeInformer, podUpdateChannel, o.config.Egress.MaxEgressIPsPerNode,
+			memberlistCluster, egressInformer, nodeInformer, podUpdateChannel, serviceCIDRProvider, o.config.Egress.MaxEgressIPsPerNode,
 		)
 		if err != nil {
 			return fmt.Errorf("error creating new Egress controller: %v", err)

--- a/pkg/agent/controller/egress/egress_controller.go
+++ b/pkg/agent/controller/egress/egress_controller.go
@@ -42,6 +42,7 @@ import (
 	"antrea.io/antrea/pkg/agent/memberlist"
 	"antrea.io/antrea/pkg/agent/openflow"
 	"antrea.io/antrea/pkg/agent/route"
+	"antrea.io/antrea/pkg/agent/servicecidr"
 	"antrea.io/antrea/pkg/agent/types"
 	cpv1b2 "antrea.io/antrea/pkg/apis/controlplane/v1beta2"
 	crdv1b1 "antrea.io/antrea/pkg/apis/crd/v1beta1"
@@ -147,6 +148,11 @@ type EgressController struct {
 	ipAssigner ipassigner.IPAssigner
 
 	egressIPScheduler *egressIPScheduler
+
+	serviceCIDRInterface servicecidr.Interface
+	serviceCIDRUpdateCh  chan struct{}
+	// Declared for testing.
+	serviceCIDRUpdateRetryDelay time.Duration
 }
 
 func NewEgressController(
@@ -161,6 +167,7 @@ func NewEgressController(
 	egressInformer crdinformers.EgressInformer,
 	nodeInformers coreinformers.NodeInformer,
 	podUpdateSubscriber channel.Subscriber,
+	serviceCIDRInterface servicecidr.Interface,
 	maxEgressIPsPerNode int,
 ) (*EgressController, error) {
 	c := &EgressController{
@@ -181,6 +188,10 @@ func NewEgressController(
 		localIPDetector:      ipassigner.NewLocalIPDetector(),
 		idAllocator:          newIDAllocator(minEgressMark, maxEgressMark),
 		cluster:              cluster,
+		serviceCIDRInterface: serviceCIDRInterface,
+		// One buffer is enough as we just use it to ensure the target handler is executed once.
+		serviceCIDRUpdateCh:         make(chan struct{}, 1),
+		serviceCIDRUpdateRetryDelay: 10 * time.Second,
 	}
 	ipAssigner, err := newIPAssigner(nodeTransportInterface, egressDummyDevice)
 	if err != nil {
@@ -223,12 +234,51 @@ func NewEgressController(
 	podUpdateSubscriber.Subscribe(c.processPodUpdate)
 	c.localIPDetector.AddEventHandler(c.onLocalIPUpdate)
 	c.egressIPScheduler.AddEventHandler(c.onEgressIPSchedule)
+	c.serviceCIDRInterface.AddEventHandler(c.onServiceCIDRUpdate)
 	return c, nil
 }
 
 // onEgressIPSchedule will be called when EgressIPScheduler reschedules an Egress's IP.
 func (c *EgressController) onEgressIPSchedule(egress string) {
 	c.queue.Add(egress)
+}
+
+// onServiceCIDRUpdate will be called when ServiceCIDRs change.
+// It ensures updateServiceCIDRs will be executed once after this call.
+func (c *EgressController) onServiceCIDRUpdate(_ []*net.IPNet) {
+	select {
+	case c.serviceCIDRUpdateCh <- struct{}{}:
+	default:
+		// The previous event is not processed yet, discard the new event.
+	}
+}
+
+func (c *EgressController) updateServiceCIDRs(stopCh <-chan struct{}) {
+	timer := time.NewTimer(0)
+	defer timer.Stop()
+	<-timer.C // Consume the first tick.
+	for {
+		select {
+		case <-stopCh:
+			return
+		case <-c.serviceCIDRUpdateCh:
+			klog.V(2).InfoS("Received service CIDR update")
+		case <-timer.C:
+			klog.V(2).InfoS("Service CIDR update timer expired")
+		}
+		serviceCIDRs, err := c.serviceCIDRInterface.GetServiceCIDRs()
+		if err != nil {
+			klog.ErrorS(err, "Failed to get Service CIDRs")
+			// No need to retry in this case as the Service CIDRs won't be available until it receives a service CIDRs update.
+			continue
+		}
+		err = c.ofClient.InstallSNATBypassServiceFlows(serviceCIDRs)
+		if err != nil {
+			klog.ErrorS(err, "Failed to install SNAT bypass flows for Service CIDRs, will retry", "serviceCIDRs", serviceCIDRs)
+			// Schedule a retry as it should be transient error.
+			timer.Reset(c.serviceCIDRUpdateRetryDelay)
+		}
+	}
 }
 
 // processPodUpdate will be called when CNIServer publishes a Pod update event.
@@ -322,6 +372,8 @@ func (c *EgressController) Run(stopCh <-chan struct{}) {
 	}
 
 	go wait.NonSlidingUntil(c.watchEgressGroup, 5*time.Second, stopCh)
+
+	go c.updateServiceCIDRs(stopCh)
 
 	for i := 0; i < defaultWorkers; i++ {
 		go wait.Until(c.worker, time.Second, stopCh)

--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -134,6 +134,12 @@ type Client interface {
 	// are removed from PolicyRule.From, else from PolicyRule.To.
 	DeletePolicyRuleAddress(ruleID uint32, addrType types.AddressType, addresses []types.Address, priority *uint16) error
 
+	// InstallSNATBypassServiceFlows installs flows to prevent traffic destined for the specified Service CIDRs from
+	// being SNAT'd. Otherwise, such Pod-to-Service traffic would be forwarded to Egress Node and be load-balanced
+	// remotely, as opposed to locally, when AntreaProxy is asked to skip some Services or is not running at all.
+	// Calling the method with new CIDRs will override the flows installed for previous CIDRs.
+	InstallSNATBypassServiceFlows(serviceCIDRs []*net.IPNet) error
+
 	// InstallSNATMarkFlows installs flows for a local SNAT IP. On Linux, a
 	// single flow is added to mark the packets tunnelled from remote Nodes
 	// that should be SNAT'd with the SNAT IP.
@@ -145,7 +151,7 @@ type Client interface {
 
 	// InstallPodSNATFlows installs the SNAT flows for a local Pod. If the
 	// SNAT IP for the Pod is on the local Node, a non-zero SNAT ID should
-	// allocated for the SNAT IP, and the installed flow sets the SNAT IP
+	// be allocated for the SNAT IP, and the installed flow sets the SNAT IP
 	// mark on the egress packets from the ofPort; if the SNAT IP is on a
 	// remote Node, snatMark should be set to 0, and the installed flow
 	// tunnels egress packets to the remote Node using the SNAT IP as the
@@ -987,6 +993,16 @@ func (c *client) generatePipelines() {
 		// generate a pipeline from the required table list.
 		c.pipelines[pipelineID] = generatePipeline(pipelineID, requiredTables)
 	}
+}
+
+func (c *client) InstallSNATBypassServiceFlows(serviceCIDRs []*net.IPNet) error {
+	var flows []binding.Flow
+	for _, serviceCIDR := range serviceCIDRs {
+		flows = append(flows, c.featureEgress.snatSkipCIDRFlow(*serviceCIDR))
+	}
+	c.replayMutex.RLock()
+	defer c.replayMutex.RUnlock()
+	return c.modifyFlows(c.featureEgress.cachedFlows, "svc-cidrs", flows)
 }
 
 func (c *client) InstallSNATMarkFlows(snatIP net.IP, mark uint32) error {

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -2277,6 +2277,18 @@ func (f *featureNetworkPolicy) ingressClassifierFlows() []binding.Flow {
 	return flows
 }
 
+// snatSkipCIDRFlow generates the flow to skip SNAT for connection destined for the provided CIDR.
+func (f *featureEgress) snatSkipCIDRFlow(cidr net.IPNet) binding.Flow {
+	ipProtocol := getIPProtocol(cidr.IP)
+	return EgressMarkTable.ofTable.BuildFlow(priorityHigh).
+		Cookie(f.cookieAllocator.Request(f.category).Raw()).
+		MatchProtocol(ipProtocol).
+		MatchDstIPNet(cidr).
+		Action().LoadRegMark(ToGatewayRegMark).
+		Action().GotoStage(stageSwitching).
+		Done()
+}
+
 // snatSkipNodeFlow generates the flow to skip SNAT for connection destined for the transport IP of a remote Node.
 func (f *featureEgress) snatSkipNodeFlow(nodeIP net.IP) binding.Flow {
 	ipProtocol := getIPProtocol(nodeIP)
@@ -2713,13 +2725,7 @@ func (f *featureEgress) externalFlows() []binding.Flow {
 		)
 		// This generates the flows to bypass the packets sourced from local Pods and destined for the except CIDRs for Egress.
 		for _, cidr := range f.exceptCIDRs[ipProtocol] {
-			flows = append(flows, EgressMarkTable.ofTable.BuildFlow(priorityHigh).
-				Cookie(cookieID).
-				MatchProtocol(ipProtocol).
-				MatchDstIPNet(cidr).
-				Action().LoadRegMark(ToGatewayRegMark).
-				Action().GotoStage(stageSwitching).
-				Done())
+			flows = append(flows, f.snatSkipCIDRFlow(cidr))
 		}
 	}
 	// This generates the flow to match the packets of tracked Egress connection and forward them to stageSwitching.

--- a/pkg/agent/openflow/testing/mock_openflow.go
+++ b/pkg/agent/openflow/testing/mock_openflow.go
@@ -442,6 +442,20 @@ func (mr *MockClientMockRecorder) InstallPolicyRuleFlows(arg0 interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallPolicyRuleFlows", reflect.TypeOf((*MockClient)(nil).InstallPolicyRuleFlows), arg0)
 }
 
+// InstallSNATBypassServiceFlows mocks base method
+func (m *MockClient) InstallSNATBypassServiceFlows(arg0 []*net.IPNet) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InstallSNATBypassServiceFlows", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// InstallSNATBypassServiceFlows indicates an expected call of InstallSNATBypassServiceFlows
+func (mr *MockClientMockRecorder) InstallSNATBypassServiceFlows(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InstallSNATBypassServiceFlows", reflect.TypeOf((*MockClient)(nil).InstallSNATBypassServiceFlows), arg0)
+}
+
 // InstallSNATMarkFlows mocks base method
 func (m *MockClient) InstallSNATMarkFlows(arg0 net.IP, arg1 uint32) error {
 	m.ctrl.T.Helper()

--- a/pkg/agent/servicecidr/testing/mock_servicecidr.go
+++ b/pkg/agent/servicecidr/testing/mock_servicecidr.go
@@ -61,17 +61,17 @@ func (mr *MockInterfaceMockRecorder) AddEventHandler(arg0 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddEventHandler", reflect.TypeOf((*MockInterface)(nil).AddEventHandler), arg0)
 }
 
-// GetServiceCIDR mocks base method
-func (m *MockInterface) GetServiceCIDR(arg0 bool) (*net.IPNet, error) {
+// GetServiceCIDRs mocks base method
+func (m *MockInterface) GetServiceCIDRs() ([]*net.IPNet, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetServiceCIDR", arg0)
-	ret0, _ := ret[0].(*net.IPNet)
+	ret := m.ctrl.Call(m, "GetServiceCIDRs")
+	ret0, _ := ret[0].([]*net.IPNet)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetServiceCIDR indicates an expected call of GetServiceCIDR
-func (mr *MockInterfaceMockRecorder) GetServiceCIDR(arg0 interface{}) *gomock.Call {
+// GetServiceCIDRs indicates an expected call of GetServiceCIDRs
+func (mr *MockInterfaceMockRecorder) GetServiceCIDRs() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceCIDR", reflect.TypeOf((*MockInterface)(nil).GetServiceCIDR), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceCIDRs", reflect.TypeOf((*MockInterface)(nil).GetServiceCIDRs))
 }


### PR DESCRIPTION
Cherry pick of #5495 on release-1.13.

#5495: Do not apply Egress to traffic destined for ServiceCIDRs

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.