### PR TITLE
Fix flaky TestFlowAggregator_Run unit test

### DIFF
--- a/pkg/flowaggregator/flowaggregator.go
+++ b/pkg/flowaggregator/flowaggregator.go
@@ -282,8 +282,6 @@ func (fa *flowAggregator) Run(stopCh <-chan struct{}) {
 		// Waiting for this function to return on stop makes it easier to set expectations
 		// when testing. Without this, there is no guarantee that
 		// fa.collectingProcess.Start() was called by the time Run() returns.
-		// It also makes more sense to ensure that fa.collectingProcess.Stop() is always
-		// called after fa.collectingProcess.Start().
 		defer wg.Done()
 		// blocking function, will return when fa.collectingProcess.Stop() is called
 		fa.collectingProcess.Start()

--- a/pkg/flowaggregator/flowaggregator.go
+++ b/pkg/flowaggregator/flowaggregator.go
@@ -285,16 +285,16 @@ func (fa *flowAggregator) Run(stopCh <-chan struct{}) {
 		// It also makes more sense to ensure that fa.collectingProcess.Stop() is always
 		// called after fa.collectingProcess.Start().
 		defer wg.Done()
+		// blocking function, will return when fa.collectingProcess.Stop() is called
 		fa.collectingProcess.Start()
 	}()
-	defer fa.collectingProcess.Stop()
 	wg.Add(1)
 	go func() {
 		// Same comment as above.
 		defer wg.Done()
+		// blocking function, will return when fa.aggregationProcess.Stop() is called
 		fa.aggregationProcess.Start()
 	}()
-	defer fa.aggregationProcess.Stop()
 
 	if fa.ipfixExporter != nil {
 		fa.ipfixExporter.Start()
@@ -339,6 +339,8 @@ func (fa *flowAggregator) Run(stopCh <-chan struct{}) {
 		fa.configWatcher.Close()
 	}()
 	<-stopCh
+	fa.collectingProcess.Stop()
+	fa.aggregationProcess.Stop()
 	wg.Wait()
 }
 


### PR DESCRIPTION
The test was flaky because sometimes not all expectations were met. For example:

> mockPodStore.EXPECT().Run(gomock.Any())

The reason is that the FlowAggregator Run method can return "too quickly", while some of its goroutines are still in the process of being started. Rather than make these expectations optional, which I think is a bit hacky, we leverage WaitGroups in Run to ensure that all child goroutines complete before returning from Run.