### PR TITLE
Fix "make mockgen"

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -42,4 +42,6 @@ function docker_run() {
 		"${IMAGE_NAME}" bash -c "git config --global --add safe.directory ${ANTREA_PATH} && $@"
 }
 
-docker_run hack/update-codegen-dockerized.sh "$@"
+# Combine hack/update-codegen-dockerized.sh and the arguments to the script as a
+# single argument to the docker_run function.
+docker_run "hack/update-codegen-dockerized.sh $@"


### PR DESCRIPTION
The mockgen target was behaving like the codegen target, and running "make mockgen" meant that all the generators were run, instead of only the mocks generator.