### PR TITLE
Remove WindowsHostProcessContainer flag from k8s 1.28 onwards

### DIFF
--- a/hack/windows/Prepare-Node.ps1
+++ b/hack/windows/Prepare-Node.ps1
@@ -125,7 +125,7 @@ if ($InstallKubeProxy) {
 
 $StartKubeletFileContent += [Environment]::NewLine + '$global:KubeletArgs += "--cert-dir=$env:SYSTEMDRIVE\var\lib\kubelet\pki --config=/var/lib/kubelet/config.yaml --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf --hostname-override=$(hostname) --pod-infra-container-image=`"mcr.microsoft.com/oss/kubernetes/pause:1.4.1`" --enable-debugging-handlers --cgroups-per-qos=false --enforce-node-allocatable=`"`" --resolv-conf=`"`" --node-ip=$env:NODE_IP"'
 
-if ($ContainerRuntime -eq "containerd") {
+if ($ContainerRuntime -eq "containerd" -and [version]($KubernetesVersion -replace '^v') -lt [version]"1.28.0") {
     $StartKubeletFileContent += [Environment]::NewLine + '$global:KubeletArgs += " --feature-gates=WindowsHostProcessContainers=true"'
 }
 


### PR DESCRIPTION
This patch removes WindowsProcessHostContainer=true flag from Start-Kubelet script if Kubernetes Version > =1.28.0 