### PR TITLE
[Dependabot] Group golang.org/x updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 5
+    groups:
+      golang.org/x:
+        patterns:
+        - "golang.org/x/*"
     ignore:
     - dependency-name: "k8s.io/*"
     - dependency-name: "sigs.k8s.io/*"


### PR DESCRIPTION
Instead of having 3+ Dependabot PRs every time there is a new patch release for golang.org/x packages, there will be a single PR to update all of them at the same time.