### PR TITLE
To support new changes for Windows HostProcess Pod for K8S v1.28 and containerd 1.7

### DIFF
--- a/build/yamls/antrea-windows-containerd-with-ovs.yml
+++ b/build/yamls/antrea-windows-containerd-with-ovs.yml
@@ -5,9 +5,29 @@ data:
     mkdir -force c:/var/log/antrea
     $mountPath = $env:CONTAINER_SANDBOX_MOUNT_POINT
     $mountPath =  ($mountPath.Replace('\', '/')).TrimEnd('/')
-    mkdir -force C:/var/run/secrets/kubernetes.io/serviceaccount
-    cp $mountPath/var/run/secrets/kubernetes.io/serviceaccount/ca.crt C:/var/run/secrets/kubernetes.io/serviceaccount
-    cp $mountPath/var/run/secrets/kubernetes.io/serviceaccount/token C:/var/run/secrets/kubernetes.io/serviceaccount
+
+    # From containerd version 1.7 onwards, the servcieaccount directory, the ca.cert and token files will automatically be created.
+    $serviceAccountPath = "C:\var\run\secrets\kubernetes.io\serviceaccount"
+    if (-Not $(Test-Path $serviceAccountPath)) {
+        mkdir -force $serviceAccountPath
+    }
+
+    $localTokenFile = "$serviceAccountPath/token"
+    $localCAFile="$serviceAccountPath/ca.crt"
+
+    $tokenPath = "$mountPath/var/run/secrets/kubernetes.io/serviceaccount/token"
+    $caPath = "$mountPath/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+
+    # Check if the local token file is not present or its content is different
+    if (-Not (Test-Path $localTokenFile) -or (Get-Content -Raw $localTokenFile) -ne (Get-Content -Raw $tokenPath)) {
+        Copy-Item -Path $tokenPath -Destination $localTokenFile -Force
+    }
+
+    # Check if the local ca.crt file is not present or its content is different
+    if (-Not (Test-Path $localCAFile) -or (Get-Content -Raw $localCAFile) -ne (Get-Content -Raw $caPath)) {
+        Copy-Item -Path $caPath -Destination $localCAFile -Force
+    }
+
     mkdir -force c:/opt/cni/bin/
     mkdir -force c:/etc/cni/net.d/
     cp $mountPath/k/antrea/cni/* c:/opt/cni/bin/

--- a/build/yamls/antrea-windows-containerd.yml
+++ b/build/yamls/antrea-windows-containerd.yml
@@ -5,9 +5,29 @@ data:
     mkdir -force c:/var/log/antrea
     $mountPath = $env:CONTAINER_SANDBOX_MOUNT_POINT
     $mountPath =  ($mountPath.Replace('\', '/')).TrimEnd('/')
-    mkdir -force C:/var/run/secrets/kubernetes.io/serviceaccount
-    cp $mountPath/var/run/secrets/kubernetes.io/serviceaccount/ca.crt C:/var/run/secrets/kubernetes.io/serviceaccount
-    cp $mountPath/var/run/secrets/kubernetes.io/serviceaccount/token C:/var/run/secrets/kubernetes.io/serviceaccount
+
+    # From containerd version 1.7 onwards, the servcieaccount directory, the ca.cert and token files will automatically be created.
+    $serviceAccountPath = "C:\var\run\secrets\kubernetes.io\serviceaccount"
+    if (-Not $(Test-Path $serviceAccountPath)) {
+        mkdir -force $serviceAccountPath
+    }
+
+    $localTokenFile = "$serviceAccountPath/token"
+    $localCAFile="$serviceAccountPath/ca.crt"
+
+    $tokenPath = "$mountPath/var/run/secrets/kubernetes.io/serviceaccount/token"
+    $caPath = "$mountPath/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+
+    # Check if the local token file is not present or its content is different
+    if (-Not (Test-Path $localTokenFile) -or (Get-Content -Raw $localTokenFile) -ne (Get-Content -Raw $tokenPath)) {
+        Copy-Item -Path $tokenPath -Destination $localTokenFile -Force
+    }
+
+    # Check if the local ca.crt file is not present or its content is different
+    if (-Not (Test-Path $localCAFile) -or (Get-Content -Raw $localCAFile) -ne (Get-Content -Raw $caPath)) {
+        Copy-Item -Path $caPath -Destination $localCAFile -Force
+    }
+
     mkdir -force c:/opt/cni/bin/
     mkdir -force c:/etc/cni/net.d/
     cp $mountPath/k/antrea/cni/* c:/opt/cni/bin/

--- a/build/yamls/windows/containerd/conf/Install-WindowsCNI-Containerd.ps1
+++ b/build/yamls/windows/containerd/conf/Install-WindowsCNI-Containerd.ps1
@@ -2,9 +2,29 @@ $ErrorActionPreference = "Stop";
 mkdir -force c:/var/log/antrea
 $mountPath = $env:CONTAINER_SANDBOX_MOUNT_POINT
 $mountPath =  ($mountPath.Replace('\', '/')).TrimEnd('/')
-mkdir -force C:/var/run/secrets/kubernetes.io/serviceaccount
-cp $mountPath/var/run/secrets/kubernetes.io/serviceaccount/ca.crt C:/var/run/secrets/kubernetes.io/serviceaccount
-cp $mountPath/var/run/secrets/kubernetes.io/serviceaccount/token C:/var/run/secrets/kubernetes.io/serviceaccount
+
+# From containerd version 1.7 onwards, the servcieaccount directory, the ca.cert and token files will automatically be created.
+$serviceAccountPath = "C:\var\run\secrets\kubernetes.io\serviceaccount"
+if (-Not $(Test-Path $serviceAccountPath)) {
+    mkdir -force $serviceAccountPath
+}
+
+$localTokenFile = "$serviceAccountPath/token"
+$localCAFile="$serviceAccountPath/ca.crt"
+
+$tokenPath = "$mountPath/var/run/secrets/kubernetes.io/serviceaccount/token"
+$caPath = "$mountPath/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+
+# Check if the local token file is not present or its content is different
+if (-Not (Test-Path $localTokenFile) -or (Get-Content -Raw $localTokenFile) -ne (Get-Content -Raw $tokenPath)) {
+    Copy-Item -Path $tokenPath -Destination $localTokenFile -Force
+}
+
+# Check if the local ca.crt file is not present or its content is different
+if (-Not (Test-Path $localCAFile) -or (Get-Content -Raw $localCAFile) -ne (Get-Content -Raw $caPath)) {
+    Copy-Item -Path $caPath -Destination $localCAFile -Force
+}
+
 mkdir -force c:/opt/cni/bin/
 mkdir -force c:/etc/cni/net.d/
 cp $mountPath/k/antrea/cni/* c:/opt/cni/bin/

--- a/ci/jenkins/test.sh
+++ b/ci/jenkins/test.sh
@@ -152,7 +152,12 @@ export NO_PULL
 E2ETEST_PATH=${WORKDIR}/kubernetes/_output/dockerized/bin/linux/amd64/e2e.test
 
 function export_govc_env_var {
-    export GOVC_URL=$GOVC_URL
+    env_govc="${WORKDIR}/govc.env"
+    if [ -f "$env_govc" ]; then
+        source "$env_govc"
+    else
+        export GOVC_URL=$GOVC_URL
+    fi
     export GOVC_USERNAME=$GOVC_USERNAME
     export GOVC_PASSWORD=$GOVC_PASSWORD
     export GOVC_INSECURE=1
@@ -522,8 +527,6 @@ function  build_and_deliver_antrea_windows_and_linux_containerd_images {
     kubectl delete -f ${WORKDIR}/antrea.yml --ignore-not-found=true || true
 
     prepare_env
-    ${CLEAN_STALE_IMAGES_CONTAINERD}
-    ${PRINT_CONTAINERD_STATUS}
     chmod -R g-w build/images/ovs
     chmod -R g-w build/images/base
     # Clean docker image to save disk space.
@@ -564,8 +567,8 @@ function deliver_antrea_linux_containerd {
     harbor_images=("agnhost:2.13" "nginx:1.15-alpine")
     antrea_images=("e2eteam/agnhost:2.13" "docker.io/library/nginx:1.15-alpine")
     common_images=("registry.k8s.io/e2e-test-images/agnhost:2.29")
-    k8s_images=("registry.k8s.io/e2e-test-images/agnhost:2.40" "registry.k8s.io/e2e-test-images/jessie-dnsutils:1.5" "registry.k8s.io/e2e-test-images/nginx:1.14-2")
-    e2e_images=("k8sprow.azurecr.io/kubernetes-e2e-test-images/agnhost:2.40" "k8sprow.azurecr.io/kubernetes-e2e-test-images/jessie-dnsutils:1.5" "k8sprow.azurecr.io/kubernetes-e2e-test-images/nginx:1.14-2")
+    k8s_images=("registry.k8s.io/e2e-test-images/agnhost:2.45" "registry.k8s.io/e2e-test-images/jessie-dnsutils:1.5" "registry.k8s.io/e2e-test-images/nginx:1.14-2")
+    e2e_images=("k8sprow.azurecr.io/kubernetes-e2e-test-images/agnhost:2.45" "k8sprow.azurecr.io/kubernetes-e2e-test-images/jessie-dnsutils:1.5" "k8sprow.azurecr.io/kubernetes-e2e-test-images/nginx:1.14-2")
 
     for i in "${!harbor_images[@]}"; do
         ctr -n=k8s.io images delete "${antrea_images[i]}"
@@ -617,8 +620,8 @@ function deliver_antrea_windows_containerd {
         # Use e2eteam/agnhost:2.13 instead
         harbor_images=("sigwindowstools-kube-proxy:v1.18.0" "agnhost:2.13" "agnhost:2.13" "agnhost:2.29" "e2eteam-jessie-dnsutils:1.0" "e2eteam-pause:3.2")
         antrea_images=("sigwindowstools/kube-proxy:v1.18.0" "e2eteam/agnhost:2.13" "us.gcr.io/k8s-artifacts-prod/e2e-test-images/agnhost:2.13" "registry.k8s.io/e2e-test-images/agnhost:2.29" "e2eteam/jessie-dnsutils:1.0" "e2eteam/pause:3.2")
-        k8s_images=("registry.k8s.io/e2e-test-images/agnhost:2.40" "registry.k8s.io/e2e-test-images/jessie-dnsutils:1.5" "registry.k8s.io/e2e-test-images/nginx:1.14-2")
-        e2e_images=("k8sprow.azurecr.io/kubernetes-e2e-test-images/agnhost:2.40" "k8sprow.azurecr.io/kubernetes-e2e-test-images/jessie-dnsutils:1.5" "k8sprow.azurecr.io/kubernetes-e2e-test-images/nginx:1.14-2")
+        k8s_images=("registry.k8s.io/e2e-test-images/agnhost:2.45" "registry.k8s.io/e2e-test-images/jessie-dnsutils:1.5" "registry.k8s.io/e2e-test-images/nginx:1.14-2")
+        e2e_images=("k8sprow.azurecr.io/kubernetes-e2e-test-images/agnhost:2.45" "k8sprow.azurecr.io/kubernetes-e2e-test-images/jessie-dnsutils:1.5" "k8sprow.azurecr.io/kubernetes-e2e-test-images/nginx:1.14-2")
         # Pull necessary images in advance to avoid transient error
         for i in "${!harbor_images[@]}"; do
             ssh -o StrictHostKeyChecking=no -n Administrator@${IP} "ctr -n k8s.io images pull ${DOCKER_REGISTRY}/antrea/${harbor_images[i]} && ctr -n k8s.io images tag ${DOCKER_REGISTRY}/antrea/${harbor_images[i]} ${antrea_images[i]}" || true

--- a/hack/windows/Prepare-Node.ps1
+++ b/hack/windows/Prepare-Node.ps1
@@ -125,7 +125,9 @@ if ($InstallKubeProxy) {
 
 $StartKubeletFileContent += [Environment]::NewLine + '$global:KubeletArgs += "--cert-dir=$env:SYSTEMDRIVE\var\lib\kubelet\pki --config=/var/lib/kubelet/config.yaml --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf --hostname-override=$(hostname) --pod-infra-container-image=`"mcr.microsoft.com/oss/kubernetes/pause:1.4.1`" --enable-debugging-handlers --cgroups-per-qos=false --enforce-node-allocatable=`"`" --resolv-conf=`"`" --node-ip=$env:NODE_IP"'
 
-if ($ContainerRuntime -eq "containerd") {
+$targetVersion = [version]"1.28.0"
+
+if ($ContainerRuntime -eq "containerd" -and [version]($KubernetesVersion -replace '^v') -lt $targetVersion) {
     $StartKubeletFileContent += [Environment]::NewLine + '$global:KubeletArgs += " --feature-gates=WindowsHostProcessContainers=true"'
 }
 


### PR DESCRIPTION
The patch is required to handle following cases:-
1.To handle WindowsHostProcessContainer for k8s 1.28  and and make required adjustment in antrea-windows-containerd.yaml for containerd 1.7.
2.To change commands to clean containerd environment on jumper node from ci/jenkins.sh (since on new tested we only have docker runtime)

