### PR TITLE
Use the first matching address when getting node address

### DIFF
--- a/pkg/util/k8s/node.go
+++ b/pkg/util/k8s/node.go
@@ -56,10 +56,10 @@ func GetNodeAddrsWithType(node *v1.Node, types []v1.NodeAddressType) (*ip.DualSt
 		if addr == nil {
 			return nil, fmt.Errorf("'%s' is not a valid IP address", ipAddrStrs[i])
 		}
-		if addr.To4() == nil {
-			nodeAddrs.IPv6 = addr
-		} else {
+		if addr.To4() != nil && nodeAddrs.IPv4 == nil {
 			nodeAddrs.IPv4 = addr
+		} else if addr.To4() == nil && nodeAddrs.IPv6 == nil {
+			nodeAddrs.IPv6 = addr
 		}
 	}
 	return nodeAddrs, nil


### PR DESCRIPTION
Some cloud providers can return multiple addresses of the same type for a Node. We should use the first matching address to find the correct transport interface.

Signed-off-by: Xu Liu <xliu2@vmware.com>