### PR TITLE
Support GroupMembers API Pagination for Client

### DIFF
--- a/pkg/apis/controlplane/types.go
+++ b/pkg/apis/controlplane/types.go
@@ -82,12 +82,12 @@ type GroupMember struct {
 	Pod *PodReference
 	// ExternalEntity maintains the reference to the ExternalEntity.
 	ExternalEntity *ExternalEntityReference
-	// Node maintains the reference to the Node.
-	Node *NodeReference
 	// IP is the IP address of the Endpoints associated with the GroupMember.
 	IPs []IPAddress
 	// Ports is the list NamedPort of the GroupMember.
 	Ports []NamedPort
+	// Node maintains the reference to the Node.
+	Node *NodeReference
 	// Service is the reference to the Service. It can only be used in an AppliedTo
 	// Group and only a NodePort type Service can be referred by this field.
 	Service *ServiceReference

--- a/pkg/apis/controlplane/v1beta2/zz_generated.conversion.go
+++ b/pkg/apis/controlplane/v1beta2/zz_generated.conversion.go
@@ -489,17 +489,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 
 func autoConvert_v1beta2_AddressGroup_To_controlplane_AddressGroup(in *AddressGroup, out *controlplane.AddressGroup, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	if in.GroupMembers != nil {
-		in, out := &in.GroupMembers, &out.GroupMembers
-		*out = make([]controlplane.GroupMember, len(*in))
-		for i := range *in {
-			if err := Convert_v1beta2_GroupMember_To_controlplane_GroupMember(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.GroupMembers = nil
-	}
+	out.GroupMembers = *(*[]controlplane.GroupMember)(unsafe.Pointer(&in.GroupMembers))
 	return nil
 }
 
@@ -510,17 +500,7 @@ func Convert_v1beta2_AddressGroup_To_controlplane_AddressGroup(in *AddressGroup,
 
 func autoConvert_controlplane_AddressGroup_To_v1beta2_AddressGroup(in *controlplane.AddressGroup, out *AddressGroup, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	if in.GroupMembers != nil {
-		in, out := &in.GroupMembers, &out.GroupMembers
-		*out = make([]GroupMember, len(*in))
-		for i := range *in {
-			if err := Convert_controlplane_GroupMember_To_v1beta2_GroupMember(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.GroupMembers = nil
-	}
+	out.GroupMembers = *(*[]GroupMember)(unsafe.Pointer(&in.GroupMembers))
 	return nil
 }
 
@@ -531,17 +511,7 @@ func Convert_controlplane_AddressGroup_To_v1beta2_AddressGroup(in *controlplane.
 
 func autoConvert_v1beta2_AddressGroupList_To_controlplane_AddressGroupList(in *AddressGroupList, out *controlplane.AddressGroupList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]controlplane.AddressGroup, len(*in))
-		for i := range *in {
-			if err := Convert_v1beta2_AddressGroup_To_controlplane_AddressGroup(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
+	out.Items = *(*[]controlplane.AddressGroup)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -552,17 +522,7 @@ func Convert_v1beta2_AddressGroupList_To_controlplane_AddressGroupList(in *Addre
 
 func autoConvert_controlplane_AddressGroupList_To_v1beta2_AddressGroupList(in *controlplane.AddressGroupList, out *AddressGroupList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]AddressGroup, len(*in))
-		for i := range *in {
-			if err := Convert_controlplane_AddressGroup_To_v1beta2_AddressGroup(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
+	out.Items = *(*[]AddressGroup)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -573,28 +533,8 @@ func Convert_controlplane_AddressGroupList_To_v1beta2_AddressGroupList(in *contr
 
 func autoConvert_v1beta2_AddressGroupPatch_To_controlplane_AddressGroupPatch(in *AddressGroupPatch, out *controlplane.AddressGroupPatch, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	if in.AddedGroupMembers != nil {
-		in, out := &in.AddedGroupMembers, &out.AddedGroupMembers
-		*out = make([]controlplane.GroupMember, len(*in))
-		for i := range *in {
-			if err := Convert_v1beta2_GroupMember_To_controlplane_GroupMember(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.AddedGroupMembers = nil
-	}
-	if in.RemovedGroupMembers != nil {
-		in, out := &in.RemovedGroupMembers, &out.RemovedGroupMembers
-		*out = make([]controlplane.GroupMember, len(*in))
-		for i := range *in {
-			if err := Convert_v1beta2_GroupMember_To_controlplane_GroupMember(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.RemovedGroupMembers = nil
-	}
+	out.AddedGroupMembers = *(*[]controlplane.GroupMember)(unsafe.Pointer(&in.AddedGroupMembers))
+	out.RemovedGroupMembers = *(*[]controlplane.GroupMember)(unsafe.Pointer(&in.RemovedGroupMembers))
 	return nil
 }
 
@@ -605,28 +545,8 @@ func Convert_v1beta2_AddressGroupPatch_To_controlplane_AddressGroupPatch(in *Add
 
 func autoConvert_controlplane_AddressGroupPatch_To_v1beta2_AddressGroupPatch(in *controlplane.AddressGroupPatch, out *AddressGroupPatch, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	if in.AddedGroupMembers != nil {
-		in, out := &in.AddedGroupMembers, &out.AddedGroupMembers
-		*out = make([]GroupMember, len(*in))
-		for i := range *in {
-			if err := Convert_controlplane_GroupMember_To_v1beta2_GroupMember(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.AddedGroupMembers = nil
-	}
-	if in.RemovedGroupMembers != nil {
-		in, out := &in.RemovedGroupMembers, &out.RemovedGroupMembers
-		*out = make([]GroupMember, len(*in))
-		for i := range *in {
-			if err := Convert_controlplane_GroupMember_To_v1beta2_GroupMember(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.RemovedGroupMembers = nil
-	}
+	out.AddedGroupMembers = *(*[]GroupMember)(unsafe.Pointer(&in.AddedGroupMembers))
+	out.RemovedGroupMembers = *(*[]GroupMember)(unsafe.Pointer(&in.RemovedGroupMembers))
 	return nil
 }
 
@@ -637,17 +557,7 @@ func Convert_controlplane_AddressGroupPatch_To_v1beta2_AddressGroupPatch(in *con
 
 func autoConvert_v1beta2_AppliedToGroup_To_controlplane_AppliedToGroup(in *AppliedToGroup, out *controlplane.AppliedToGroup, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	if in.GroupMembers != nil {
-		in, out := &in.GroupMembers, &out.GroupMembers
-		*out = make([]controlplane.GroupMember, len(*in))
-		for i := range *in {
-			if err := Convert_v1beta2_GroupMember_To_controlplane_GroupMember(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.GroupMembers = nil
-	}
+	out.GroupMembers = *(*[]controlplane.GroupMember)(unsafe.Pointer(&in.GroupMembers))
 	return nil
 }
 
@@ -658,17 +568,7 @@ func Convert_v1beta2_AppliedToGroup_To_controlplane_AppliedToGroup(in *AppliedTo
 
 func autoConvert_controlplane_AppliedToGroup_To_v1beta2_AppliedToGroup(in *controlplane.AppliedToGroup, out *AppliedToGroup, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	if in.GroupMembers != nil {
-		in, out := &in.GroupMembers, &out.GroupMembers
-		*out = make([]GroupMember, len(*in))
-		for i := range *in {
-			if err := Convert_controlplane_GroupMember_To_v1beta2_GroupMember(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.GroupMembers = nil
-	}
+	out.GroupMembers = *(*[]GroupMember)(unsafe.Pointer(&in.GroupMembers))
 	return nil
 }
 
@@ -679,17 +579,7 @@ func Convert_controlplane_AppliedToGroup_To_v1beta2_AppliedToGroup(in *controlpl
 
 func autoConvert_v1beta2_AppliedToGroupList_To_controlplane_AppliedToGroupList(in *AppliedToGroupList, out *controlplane.AppliedToGroupList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]controlplane.AppliedToGroup, len(*in))
-		for i := range *in {
-			if err := Convert_v1beta2_AppliedToGroup_To_controlplane_AppliedToGroup(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
+	out.Items = *(*[]controlplane.AppliedToGroup)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -700,17 +590,7 @@ func Convert_v1beta2_AppliedToGroupList_To_controlplane_AppliedToGroupList(in *A
 
 func autoConvert_controlplane_AppliedToGroupList_To_v1beta2_AppliedToGroupList(in *controlplane.AppliedToGroupList, out *AppliedToGroupList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]AppliedToGroup, len(*in))
-		for i := range *in {
-			if err := Convert_controlplane_AppliedToGroup_To_v1beta2_AppliedToGroup(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
+	out.Items = *(*[]AppliedToGroup)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -721,28 +601,8 @@ func Convert_controlplane_AppliedToGroupList_To_v1beta2_AppliedToGroupList(in *c
 
 func autoConvert_v1beta2_AppliedToGroupPatch_To_controlplane_AppliedToGroupPatch(in *AppliedToGroupPatch, out *controlplane.AppliedToGroupPatch, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	if in.AddedGroupMembers != nil {
-		in, out := &in.AddedGroupMembers, &out.AddedGroupMembers
-		*out = make([]controlplane.GroupMember, len(*in))
-		for i := range *in {
-			if err := Convert_v1beta2_GroupMember_To_controlplane_GroupMember(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.AddedGroupMembers = nil
-	}
-	if in.RemovedGroupMembers != nil {
-		in, out := &in.RemovedGroupMembers, &out.RemovedGroupMembers
-		*out = make([]controlplane.GroupMember, len(*in))
-		for i := range *in {
-			if err := Convert_v1beta2_GroupMember_To_controlplane_GroupMember(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.RemovedGroupMembers = nil
-	}
+	out.AddedGroupMembers = *(*[]controlplane.GroupMember)(unsafe.Pointer(&in.AddedGroupMembers))
+	out.RemovedGroupMembers = *(*[]controlplane.GroupMember)(unsafe.Pointer(&in.RemovedGroupMembers))
 	return nil
 }
 
@@ -753,28 +613,8 @@ func Convert_v1beta2_AppliedToGroupPatch_To_controlplane_AppliedToGroupPatch(in 
 
 func autoConvert_controlplane_AppliedToGroupPatch_To_v1beta2_AppliedToGroupPatch(in *controlplane.AppliedToGroupPatch, out *AppliedToGroupPatch, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	if in.AddedGroupMembers != nil {
-		in, out := &in.AddedGroupMembers, &out.AddedGroupMembers
-		*out = make([]GroupMember, len(*in))
-		for i := range *in {
-			if err := Convert_controlplane_GroupMember_To_v1beta2_GroupMember(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.AddedGroupMembers = nil
-	}
-	if in.RemovedGroupMembers != nil {
-		in, out := &in.RemovedGroupMembers, &out.RemovedGroupMembers
-		*out = make([]GroupMember, len(*in))
-		for i := range *in {
-			if err := Convert_controlplane_GroupMember_To_v1beta2_GroupMember(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.RemovedGroupMembers = nil
-	}
+	out.AddedGroupMembers = *(*[]GroupMember)(unsafe.Pointer(&in.AddedGroupMembers))
+	out.RemovedGroupMembers = *(*[]GroupMember)(unsafe.Pointer(&in.RemovedGroupMembers))
 	return nil
 }
 
@@ -851,17 +691,7 @@ func Convert_controlplane_BundleServerAuthConfiguration_To_v1beta2_BundleServerA
 
 func autoConvert_v1beta2_ClusterGroupMembers_To_controlplane_ClusterGroupMembers(in *ClusterGroupMembers, out *controlplane.ClusterGroupMembers, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	if in.EffectiveMembers != nil {
-		in, out := &in.EffectiveMembers, &out.EffectiveMembers
-		*out = make([]controlplane.GroupMember, len(*in))
-		for i := range *in {
-			if err := Convert_v1beta2_GroupMember_To_controlplane_GroupMember(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.EffectiveMembers = nil
-	}
+	out.EffectiveMembers = *(*[]controlplane.GroupMember)(unsafe.Pointer(&in.EffectiveMembers))
 	out.EffectiveIPBlocks = *(*[]controlplane.IPNet)(unsafe.Pointer(&in.EffectiveIPBlocks))
 	out.TotalMembers = in.TotalMembers
 	out.TotalPages = in.TotalPages
@@ -876,17 +706,7 @@ func Convert_v1beta2_ClusterGroupMembers_To_controlplane_ClusterGroupMembers(in 
 
 func autoConvert_controlplane_ClusterGroupMembers_To_v1beta2_ClusterGroupMembers(in *controlplane.ClusterGroupMembers, out *ClusterGroupMembers, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	if in.EffectiveMembers != nil {
-		in, out := &in.EffectiveMembers, &out.EffectiveMembers
-		*out = make([]GroupMember, len(*in))
-		for i := range *in {
-			if err := Convert_controlplane_GroupMember_To_v1beta2_GroupMember(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.EffectiveMembers = nil
-	}
+	out.EffectiveMembers = *(*[]GroupMember)(unsafe.Pointer(&in.EffectiveMembers))
 	out.EffectiveIPBlocks = *(*[]IPNet)(unsafe.Pointer(&in.EffectiveIPBlocks))
 	out.TotalMembers = in.TotalMembers
 	out.TotalPages = in.TotalPages
@@ -901,17 +721,7 @@ func Convert_controlplane_ClusterGroupMembers_To_v1beta2_ClusterGroupMembers(in 
 
 func autoConvert_v1beta2_EgressGroup_To_controlplane_EgressGroup(in *EgressGroup, out *controlplane.EgressGroup, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	if in.GroupMembers != nil {
-		in, out := &in.GroupMembers, &out.GroupMembers
-		*out = make([]controlplane.GroupMember, len(*in))
-		for i := range *in {
-			if err := Convert_v1beta2_GroupMember_To_controlplane_GroupMember(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.GroupMembers = nil
-	}
+	out.GroupMembers = *(*[]controlplane.GroupMember)(unsafe.Pointer(&in.GroupMembers))
 	return nil
 }
 
@@ -922,17 +732,7 @@ func Convert_v1beta2_EgressGroup_To_controlplane_EgressGroup(in *EgressGroup, ou
 
 func autoConvert_controlplane_EgressGroup_To_v1beta2_EgressGroup(in *controlplane.EgressGroup, out *EgressGroup, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	if in.GroupMembers != nil {
-		in, out := &in.GroupMembers, &out.GroupMembers
-		*out = make([]GroupMember, len(*in))
-		for i := range *in {
-			if err := Convert_controlplane_GroupMember_To_v1beta2_GroupMember(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.GroupMembers = nil
-	}
+	out.GroupMembers = *(*[]GroupMember)(unsafe.Pointer(&in.GroupMembers))
 	return nil
 }
 
@@ -943,17 +743,7 @@ func Convert_controlplane_EgressGroup_To_v1beta2_EgressGroup(in *controlplane.Eg
 
 func autoConvert_v1beta2_EgressGroupList_To_controlplane_EgressGroupList(in *EgressGroupList, out *controlplane.EgressGroupList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]controlplane.EgressGroup, len(*in))
-		for i := range *in {
-			if err := Convert_v1beta2_EgressGroup_To_controlplane_EgressGroup(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
+	out.Items = *(*[]controlplane.EgressGroup)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -964,17 +754,7 @@ func Convert_v1beta2_EgressGroupList_To_controlplane_EgressGroupList(in *EgressG
 
 func autoConvert_controlplane_EgressGroupList_To_v1beta2_EgressGroupList(in *controlplane.EgressGroupList, out *EgressGroupList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items != nil {
-		in, out := &in.Items, &out.Items
-		*out = make([]EgressGroup, len(*in))
-		for i := range *in {
-			if err := Convert_controlplane_EgressGroup_To_v1beta2_EgressGroup(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.Items = nil
-	}
+	out.Items = *(*[]EgressGroup)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -985,28 +765,8 @@ func Convert_controlplane_EgressGroupList_To_v1beta2_EgressGroupList(in *control
 
 func autoConvert_v1beta2_EgressGroupPatch_To_controlplane_EgressGroupPatch(in *EgressGroupPatch, out *controlplane.EgressGroupPatch, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	if in.AddedGroupMembers != nil {
-		in, out := &in.AddedGroupMembers, &out.AddedGroupMembers
-		*out = make([]controlplane.GroupMember, len(*in))
-		for i := range *in {
-			if err := Convert_v1beta2_GroupMember_To_controlplane_GroupMember(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.AddedGroupMembers = nil
-	}
-	if in.RemovedGroupMembers != nil {
-		in, out := &in.RemovedGroupMembers, &out.RemovedGroupMembers
-		*out = make([]controlplane.GroupMember, len(*in))
-		for i := range *in {
-			if err := Convert_v1beta2_GroupMember_To_controlplane_GroupMember(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.RemovedGroupMembers = nil
-	}
+	out.AddedGroupMembers = *(*[]controlplane.GroupMember)(unsafe.Pointer(&in.AddedGroupMembers))
+	out.RemovedGroupMembers = *(*[]controlplane.GroupMember)(unsafe.Pointer(&in.RemovedGroupMembers))
 	return nil
 }
 
@@ -1017,28 +777,8 @@ func Convert_v1beta2_EgressGroupPatch_To_controlplane_EgressGroupPatch(in *Egres
 
 func autoConvert_controlplane_EgressGroupPatch_To_v1beta2_EgressGroupPatch(in *controlplane.EgressGroupPatch, out *EgressGroupPatch, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	if in.AddedGroupMembers != nil {
-		in, out := &in.AddedGroupMembers, &out.AddedGroupMembers
-		*out = make([]GroupMember, len(*in))
-		for i := range *in {
-			if err := Convert_controlplane_GroupMember_To_v1beta2_GroupMember(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.AddedGroupMembers = nil
-	}
-	if in.RemovedGroupMembers != nil {
-		in, out := &in.RemovedGroupMembers, &out.RemovedGroupMembers
-		*out = make([]GroupMember, len(*in))
-		for i := range *in {
-			if err := Convert_controlplane_GroupMember_To_v1beta2_GroupMember(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.RemovedGroupMembers = nil
-	}
+	out.AddedGroupMembers = *(*[]GroupMember)(unsafe.Pointer(&in.AddedGroupMembers))
+	out.RemovedGroupMembers = *(*[]GroupMember)(unsafe.Pointer(&in.RemovedGroupMembers))
 	return nil
 }
 
@@ -1109,9 +849,9 @@ func Convert_v1beta2_GroupMember_To_controlplane_GroupMember(in *GroupMember, ou
 func autoConvert_controlplane_GroupMember_To_v1beta2_GroupMember(in *controlplane.GroupMember, out *GroupMember, s conversion.Scope) error {
 	out.Pod = (*PodReference)(unsafe.Pointer(in.Pod))
 	out.ExternalEntity = (*ExternalEntityReference)(unsafe.Pointer(in.ExternalEntity))
-	out.Node = (*NodeReference)(unsafe.Pointer(in.Node))
 	out.IPs = *(*[]IPAddress)(unsafe.Pointer(&in.IPs))
 	out.Ports = *(*[]NamedPort)(unsafe.Pointer(&in.Ports))
+	out.Node = (*NodeReference)(unsafe.Pointer(in.Node))
 	out.Service = (*ServiceReference)(unsafe.Pointer(in.Service))
 	return nil
 }
@@ -1123,17 +863,7 @@ func Convert_controlplane_GroupMember_To_v1beta2_GroupMember(in *controlplane.Gr
 
 func autoConvert_v1beta2_GroupMembers_To_controlplane_GroupMembers(in *GroupMembers, out *controlplane.GroupMembers, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	if in.EffectiveMembers != nil {
-		in, out := &in.EffectiveMembers, &out.EffectiveMembers
-		*out = make([]controlplane.GroupMember, len(*in))
-		for i := range *in {
-			if err := Convert_v1beta2_GroupMember_To_controlplane_GroupMember(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.EffectiveMembers = nil
-	}
+	out.EffectiveMembers = *(*[]controlplane.GroupMember)(unsafe.Pointer(&in.EffectiveMembers))
 	out.EffectiveIPBlocks = *(*[]controlplane.IPNet)(unsafe.Pointer(&in.EffectiveIPBlocks))
 	out.TotalMembers = in.TotalMembers
 	out.TotalPages = in.TotalPages
@@ -1148,17 +878,7 @@ func Convert_v1beta2_GroupMembers_To_controlplane_GroupMembers(in *GroupMembers,
 
 func autoConvert_controlplane_GroupMembers_To_v1beta2_GroupMembers(in *controlplane.GroupMembers, out *GroupMembers, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	if in.EffectiveMembers != nil {
-		in, out := &in.EffectiveMembers, &out.EffectiveMembers
-		*out = make([]GroupMember, len(*in))
-		for i := range *in {
-			if err := Convert_controlplane_GroupMember_To_v1beta2_GroupMember(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.EffectiveMembers = nil
-	}
+	out.EffectiveMembers = *(*[]GroupMember)(unsafe.Pointer(&in.EffectiveMembers))
 	out.EffectiveIPBlocks = *(*[]IPNet)(unsafe.Pointer(&in.EffectiveIPBlocks))
 	out.TotalMembers = in.TotalMembers
 	out.TotalPages = in.TotalPages

--- a/pkg/apis/controlplane/zz_generated.deepcopy.go
+++ b/pkg/apis/controlplane/zz_generated.deepcopy.go
@@ -497,11 +497,6 @@ func (in *GroupMember) DeepCopyInto(out *GroupMember) {
 		*out = new(ExternalEntityReference)
 		**out = **in
 	}
-	if in.Node != nil {
-		in, out := &in.Node, &out.Node
-		*out = new(NodeReference)
-		**out = **in
-	}
 	if in.IPs != nil {
 		in, out := &in.IPs, &out.IPs
 		*out = make([]IPAddress, len(*in))
@@ -517,6 +512,11 @@ func (in *GroupMember) DeepCopyInto(out *GroupMember) {
 		in, out := &in.Ports, &out.Ports
 		*out = make([]NamedPort, len(*in))
 		copy(*out, *in)
+	}
+	if in.Node != nil {
+		in, out := &in.Node, &out.Node
+		*out = new(NodeReference)
+		**out = **in
 	}
 	if in.Service != nil {
 		in, out := &in.Service, &out.Service

--- a/pkg/apiserver/registry/networkpolicy/clustergroupmember/rest.go
+++ b/pkg/apiserver/registry/networkpolicy/clustergroupmember/rest.go
@@ -94,15 +94,15 @@ func GetPaginatedMembers(querier GroupMembershipQuerier, name string, options ru
 		}
 	}
 	totalMembers = int64(len(members))
-	totalPages, currentPage, err = paginateMemberList(&members, getOptions)
+	totalPages, currentPage, err = PaginateMemberList(&members, getOptions)
 	return
 }
 
-// paginateMemberList returns paginated results if meaningful options are provided. Options should never be nil.
+// PaginateMemberList returns paginated results if meaningful options are provided. Options should never be nil.
 // Paginated results are continuous only when there is no member change across multiple calls.
 // Pagination is not enabled if either page number or limit = 0, in which the full member list is returned.
 // An error is returned for invalid options, and an empty list is returned for a page number out of the pages range.
-func paginateMemberList(effectiveMembers *[]controlplane.GroupMember, pageInfo *controlplane.PaginationGetOptions) (int64, int64, error) {
+func PaginateMemberList(effectiveMembers *[]controlplane.GroupMember, pageInfo *controlplane.PaginationGetOptions) (int64, int64, error) {
 	if pageInfo.Limit < 0 {
 		return 0, 0, errors.NewBadRequest(fmt.Sprintf("received invalid page limit %d for pagination", pageInfo.Limit))
 	} else if pageInfo.Page < 0 {

--- a/pkg/client/clientset/versioned/typed/controlplane/v1beta2/clustergroupmembers_expansion.go
+++ b/pkg/client/clientset/versioned/typed/controlplane/v1beta2/clustergroupmembers_expansion.go
@@ -1,0 +1,43 @@
+// Copyright 2023 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1beta2
+
+import (
+	"context"
+	"fmt"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"antrea.io/antrea/pkg/apis/controlplane/v1beta2"
+	"antrea.io/antrea/pkg/client/clientset/versioned/scheme"
+)
+
+// The ClusterGroupMembersExpansion interface allows manually adding extra methods to the ClusterGroupMembersInterface.
+type ClusterGroupMembersExpansion interface {
+	PaginatedGet(ctx context.Context, name string, pagination v1beta2.PaginationGetOptions, options v1.GetOptions) (result *v1beta2.ClusterGroupMembers, err error)
+}
+
+func (c *clusterGroupMembers) PaginatedGet(ctx context.Context, name string, pagination v1beta2.PaginationGetOptions, options v1.GetOptions) (result *v1beta2.ClusterGroupMembers, err error) {
+	result = &v1beta2.ClusterGroupMembers{}
+	err = c.client.Get().
+		Resource("clustergroupmembers").
+		Name(name).
+		Param("limit", fmt.Sprint(pagination.Limit)).
+		Param("page", fmt.Sprint(pagination.Page)).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do(ctx).
+		Into(result)
+	return
+}

--- a/pkg/client/clientset/versioned/typed/controlplane/v1beta2/fake/fake_clustergroupmembers_expansion.go
+++ b/pkg/client/clientset/versioned/typed/controlplane/v1beta2/fake/fake_clustergroupmembers_expansion.go
@@ -1,0 +1,41 @@
+// Copyright 2023 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fake
+
+import (
+	"context"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/testing"
+
+	"antrea.io/antrea/pkg/apis/controlplane"
+	"antrea.io/antrea/pkg/apis/controlplane/v1beta2"
+	"antrea.io/antrea/pkg/apiserver/registry/networkpolicy/clustergroupmember"
+)
+
+func (c *FakeClusterGroupMembers) PaginatedGet(ctx context.Context, name string, pagination v1beta2.PaginationGetOptions, options v1.GetOptions) (result *v1beta2.ClusterGroupMembers, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootGetAction(clustergroupmembersResource, name), &v1beta2.ClusterGroupMembers{})
+
+	if obj == nil {
+		return nil, err
+	}
+	result = obj.(*v1beta2.ClusterGroupMembers)
+	var oriMembers *controlplane.ClusterGroupMembers
+	v1beta2.Convert_v1beta2_ClusterGroupMembers_To_controlplane_ClusterGroupMembers(result, oriMembers, nil)
+	result.TotalPages, result.CurrentPage, err = clustergroupmember.PaginateMemberList(&oriMembers.EffectiveMembers, &controlplane.PaginationGetOptions{Page: pagination.Page, Limit: pagination.Limit})
+	v1beta2.Convert_controlplane_ClusterGroupMembers_To_v1beta2_ClusterGroupMembers(oriMembers, result, nil)
+	return result, err
+}

--- a/pkg/client/clientset/versioned/typed/controlplane/v1beta2/fake/fake_groupmembers_expansion.go
+++ b/pkg/client/clientset/versioned/typed/controlplane/v1beta2/fake/fake_groupmembers_expansion.go
@@ -1,0 +1,41 @@
+// Copyright 2023 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fake
+
+import (
+	"context"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/testing"
+
+	"antrea.io/antrea/pkg/apis/controlplane"
+	"antrea.io/antrea/pkg/apis/controlplane/v1beta2"
+	"antrea.io/antrea/pkg/apiserver/registry/networkpolicy/clustergroupmember"
+)
+
+func (c *FakeGroupMembers) PaginatedGet(ctx context.Context, name string, pagination v1beta2.PaginationGetOptions, options v1.GetOptions) (result *v1beta2.GroupMembers, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewGetAction(groupmembersResource, c.ns, name), &v1beta2.GroupMembers{})
+
+	if obj == nil {
+		return nil, err
+	}
+	result = obj.(*v1beta2.GroupMembers)
+	var oriMembers *controlplane.GroupMembers
+	v1beta2.Convert_v1beta2_GroupMembers_To_controlplane_GroupMembers(result, oriMembers, nil)
+	result.TotalPages, result.CurrentPage, err = clustergroupmember.PaginateMemberList(&oriMembers.EffectiveMembers, &controlplane.PaginationGetOptions{Page: pagination.Page, Limit: pagination.Limit})
+	v1beta2.Convert_controlplane_GroupMembers_To_v1beta2_GroupMembers(oriMembers, result, nil)
+	return result, err
+}

--- a/pkg/client/clientset/versioned/typed/controlplane/v1beta2/generated_expansion.go
+++ b/pkg/client/clientset/versioned/typed/controlplane/v1beta2/generated_expansion.go
@@ -20,13 +20,9 @@ type AddressGroupExpansion interface{}
 
 type AppliedToGroupExpansion interface{}
 
-type ClusterGroupMembersExpansion interface{}
-
 type EgressGroupExpansion interface{}
 
 type GroupAssociationExpansion interface{}
-
-type GroupMembersExpansion interface{}
 
 type IPGroupAssociationExpansion interface{}
 

--- a/pkg/client/clientset/versioned/typed/controlplane/v1beta2/groupmembers_expansion.go
+++ b/pkg/client/clientset/versioned/typed/controlplane/v1beta2/groupmembers_expansion.go
@@ -1,0 +1,44 @@
+// Copyright 2023 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1beta2
+
+import (
+	"context"
+	"fmt"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"antrea.io/antrea/pkg/apis/controlplane/v1beta2"
+	"antrea.io/antrea/pkg/client/clientset/versioned/scheme"
+)
+
+// The GroupMembersExpansion interface allows manually adding extra methods to the GroupMembersInterface.
+type GroupMembersExpansion interface {
+	PaginatedGet(ctx context.Context, name string, pagination v1beta2.PaginationGetOptions, options v1.GetOptions) (result *v1beta2.GroupMembers, err error)
+}
+
+func (c *groupMembers) PaginatedGet(ctx context.Context, name string, pagination v1beta2.PaginationGetOptions, options v1.GetOptions) (result *v1beta2.GroupMembers, err error) {
+	result = &v1beta2.GroupMembers{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("groupmembers").
+		Name(name).
+		Param("limit", fmt.Sprint(pagination.Limit)).
+		Param("page", fmt.Sprint(pagination.Page)).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do(ctx).
+		Into(result)
+	return
+}


### PR DESCRIPTION
GroupMembers API was introduced in #5380 , pagination was supported for proxy server, but not for client. There are usecases for client-go pagination. This solution utilizes the `GroupMembersExpansion` to provide a new method `GetPaginated`.