### PR TITLE
e2e: switch from netshoot image to toolbox image

### DIFF
--- a/test/e2e/antreapolicy_test.go
+++ b/test/e2e/antreapolicy_test.go
@@ -3683,7 +3683,7 @@ func testACNPNodeSelectorIngress(t *testing.T, data *TestData) {
 }
 
 func testACNPICMPSupport(t *testing.T, data *TestData) {
-	clientName, _, cleanupFunc := createAndWaitForPod(t, data, data.createNetshootPodOnNode, "client", nodeName(1), data.testNamespace, false)
+	clientName, _, cleanupFunc := createAndWaitForPod(t, data, data.createToolboxPodOnNode, "client", nodeName(1), data.testNamespace, false)
 	defer cleanupFunc()
 
 	server0Name, server0IP, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "server0", nodeName(0), data.testNamespace, false)
@@ -3861,7 +3861,7 @@ func testACNPIGMPQuery(t *testing.T, data *TestData, acnpName, caseName, groupAd
 		data.RunCommandFromPod(testNamespace, senderName, mcjoinContainerName, sendMulticastCommand)
 	}()
 
-	tcpdumpName, _, cleanupFunc := createAndWaitForPod(t, data, data.createNetshootPodOnNode, "test-tcpdump-", nodeName(mc.receiverConfigs[0].nodeIdx), testNamespace, true)
+	tcpdumpName, _, cleanupFunc := createAndWaitForPod(t, data, data.createToolboxPodOnNode, "test-tcpdump-", nodeName(mc.receiverConfigs[0].nodeIdx), testNamespace, true)
 	defer cleanupFunc()
 
 	queryGroupAddress := "224.0.0.1"
@@ -3948,7 +3948,7 @@ func testACNPMulticastEgress(t *testing.T, data *TestData, acnpName, caseName, g
 		data.RunCommandFromPod(testNamespace, senderName, mcjoinContainerName, sendMulticastCommand)
 	}()
 	// check if receiver can receive multicast packet
-	tcpdumpName, _, cleanupFunc := createAndWaitForPod(t, data, data.createNetshootPodOnNode, "test-tcpdump-", nodeName(mc.receiverConfigs[0].nodeIdx), testNamespace, true)
+	tcpdumpName, _, cleanupFunc := createAndWaitForPod(t, data, data.createToolboxPodOnNode, "test-tcpdump-", nodeName(mc.receiverConfigs[0].nodeIdx), testNamespace, true)
 	defer cleanupFunc()
 	cmd, err := generatePacketCaptureCmd(t, data, 5, mc.group.String(), nodeName(mc.receiverConfigs[0].nodeIdx), receiverNames[0])
 	if err != nil {
@@ -4048,14 +4048,14 @@ func generatePacketCaptureCmd(t *testing.T, data *TestData, timeout int, hostIP,
 	if err != nil {
 		return "", err
 	}
-
-	cmd := fmt.Sprintf("timeout %ds tcpdump -q -i %s -c 1 -W 90 host %s", timeout, podInterfaceInfo[0].InterfaceName, hostIP)
+	// Set "--preserve-status" to get the exit code of "tcpdump" as opposed to "timeout".
+	cmd := fmt.Sprintf("timeout --preserve-status %ds tcpdump -q -i %s -c 1 -W 90 host %s", timeout, podInterfaceInfo[0].InterfaceName, hostIP)
 	return cmd, nil
 }
 
 func checkPacketCaptureResult(t *testing.T, data *TestData, tcpdumpName, cmd string) (captured bool, err error) {
 	stdout, stderr := "", ""
-	stdout, stderr, err = data.RunCommandFromPod(data.testNamespace, tcpdumpName, tcpdumpContainerName, []string{"/bin/sh", "-c", cmd})
+	stdout, stderr, err = data.RunCommandFromPod(data.testNamespace, tcpdumpName, toolboxContainerName, []string{"/bin/sh", "-c", cmd})
 	t.Logf("%s returned: stdout %v, stderr : %v", cmd, stdout, stderr)
 	if err != nil {
 		return false, err

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -92,8 +92,9 @@ const (
 	testAntreaIPAMNamespace12  = "antrea-ipam-test-12"
 	busyboxContainerName       = "busybox"
 	mcjoinContainerName        = "mcjoin"
-	tcpdumpContainerName       = "netshoot"
 	agnhostContainerName       = "agnhost"
+	toolboxContainerName       = "toolbox"
+	nginxContainerName         = "nginx"
 	controllerContainerName    = "antrea-controller"
 	ovsContainerName           = "antrea-ovs"
 	agentContainerName         = "antrea-agent"
@@ -128,10 +129,9 @@ const (
 	agnhostImage        = "registry.k8s.io/e2e-test-images/agnhost:2.29"
 	busyboxImage        = "projects.registry.vmware.com/antrea/busybox"
 	mcjoinImage         = "projects.registry.vmware.com/antrea/mcjoin:v2.9"
-	netshootImage       = "projects.registry.vmware.com/antrea/netshoot:v0.1"
 	nginxImage          = "projects.registry.vmware.com/antrea/nginx:1.21.6-alpine"
 	iisImage            = "mcr.microsoft.com/windows/servercore/iis"
-	toolboxImage        = "projects.registry.vmware.com/antrea/toolbox:1.1-0"
+	toolboxImage        = "projects.registry.vmware.com/antrea/toolbox:1.2-1"
 	ipfixCollectorImage = "projects.registry.vmware.com/antrea/ipfix-collector:v0.6.2"
 	ipfixCollectorPort  = "4739"
 	clickHouseHTTPPort  = "8123"
@@ -1457,10 +1457,10 @@ func (data *TestData) createMcJoinPodOnNode(name string, ns string, nodeName str
 	return NewPodBuilder(name, ns, mcjoinImage).OnNode(nodeName).WithCommand([]string{"sleep", "3600"}).WithHostNetwork(hostNetwork).Create(data)
 }
 
-// createNetshootPodOnNode creates a Pod in the test namespace with a single netshoot container. The
+// createToolboxPodOnNode creates a Pod in the test namespace with a single toolbox container. The
 // Pod will be scheduled on the specified Node (if nodeName is not empty).
-func (data *TestData) createNetshootPodOnNode(name string, ns string, nodeName string, hostNetwork bool) error {
-	return NewPodBuilder(name, ns, netshootImage).OnNode(nodeName).WithCommand([]string{"sleep", "3600"}).WithHostNetwork(hostNetwork).Create(data)
+func (data *TestData) createToolboxPodOnNode(name string, ns string, nodeName string, hostNetwork bool) error {
+	return NewPodBuilder(name, ns, toolboxImage).OnNode(nodeName).WithCommand([]string{"sleep", "3600"}).WithHostNetwork(hostNetwork).Create(data)
 }
 
 // createNginxPodOnNode creates a Pod in the test namespace with a single nginx container. The

--- a/test/e2e/multicast_test.go
+++ b/test/e2e/multicast_test.go
@@ -548,7 +548,7 @@ func testMulticastForwardToMultipleInterfaces(t *testing.T, data *TestData, send
 	mcjoinWaitTimeout := defaultTimeout / time.Second
 	senderName, _, cleanupFunc := createAndWaitForPod(t, data, data.createMcJoinPodOnNode, "test-sender-", nodeName(senderIdx), data.testNamespace, false)
 	defer cleanupFunc()
-	tcpdumpName, _, cleanupFunc := createAndWaitForPod(t, data, data.createNetshootPodOnNode, "test-tcpdump-", nodeName(senderIdx), data.testNamespace, true)
+	tcpdumpName, _, cleanupFunc := createAndWaitForPod(t, data, data.createToolboxPodOnNode, "test-tcpdump-", nodeName(senderIdx), data.testNamespace, true)
 	defer cleanupFunc()
 	// Wait 2 seconds(-w 2) before sending multicast traffic.
 	// It sends two multicast packets for every second(-f 500 means it takes 500 milliseconds for sending one packet).
@@ -563,7 +563,7 @@ func testMulticastForwardToMultipleInterfaces(t *testing.T, data *TestData, send
 		// If multicast traffic is sent from non-HostNetwork pods, all multicast interfaces in senders should receive multicast traffic.
 		for _, multicastInterface := range senderMulticastInterfaces {
 			tcpdumpReceiveMulticastCommand := []string{"/bin/sh", "-c", fmt.Sprintf("timeout 5s tcpdump -q -i %s -c 1 -W 90 host %s", multicastInterface, senderGroup)}
-			_, stderr, err := data.RunCommandFromPod(data.testNamespace, tcpdumpName, tcpdumpContainerName, tcpdumpReceiveMulticastCommand)
+			_, stderr, err := data.RunCommandFromPod(data.testNamespace, tcpdumpName, toolboxContainerName, tcpdumpReceiveMulticastCommand)
 			if err != nil {
 				return false, err
 			}

--- a/test/e2e/performance_test.go
+++ b/test/e2e/performance_test.go
@@ -38,8 +38,6 @@ const (
 	perfTestAppLabel                = "antrea-perf-test"
 	podsConnectionNetworkPolicyName = "pods.ingress"
 	workloadNetworkPolicyName       = "workloads.ingress"
-	toolboxContainerName            = "toolbox"
-	nginxContainerName              = "nginx"
 )
 
 var (


### PR DESCRIPTION
The test testACNPICMPSupport failed a few times because pulling the netshoot image took in excess of 90s. The toolbox image also has ping tool and is smaller than netshoot (169MB vs. 432MB). The patch switches to the toolbox image for all e2e tests.

---
The netshoot image can be removed from antrea's dockerhub repo after the patch is backported to all releases in maintenance.