### PR TITLE
Add goroutine stack dump in support bundle

### DIFF
--- a/pkg/agent/supportbundlecollection/support_bundle_controller.go
+++ b/pkg/agent/supportbundlecollection/support_bundle_controller.go
@@ -265,6 +265,9 @@ func (c *SupportBundleController) generateSupportBundle(supportBundle *cpv1b2.Su
 	if err = agentDumper.DumpHeapPprof(basedir); err != nil {
 		return err
 	}
+	if err = agentDumper.DumpGoroutinePprof(basedir); err != nil {
+		return err
+	}
 	if err = agentDumper.DumpOVSPorts(basedir); err != nil {
 		return err
 	}

--- a/pkg/agent/supportbundlecollection/support_bundle_controller_test.go
+++ b/pkg/agent/supportbundlecollection/support_bundle_controller_test.go
@@ -148,6 +148,13 @@ func TestSupportBundleCollectionAdd(t *testing.T) {
 			agentDumper:             &mockAgentDumper{dumpOVSPortsErr: fmt.Errorf("failed to dump OVS ports")},
 			uploader:                &testUploader{},
 		},
+		{
+			name:                    "SupportBundleCollection failed to dump goroutine Pprof",
+			supportBundleCollection: generateSupportbundleCollection("supportBundle12", "sftp://10.220.175.92:22/root/supportbundle"),
+			expectedCompleted:       false,
+			agentDumper:             &mockAgentDumper{dumpGoroutinePprofErr: fmt.Errorf("failed to dump goroutine Pprof")},
+			uploader:                &testUploader{},
+		},
 	}
 
 	for _, tt := range testcases {
@@ -222,6 +229,7 @@ type mockAgentDumper struct {
 	dumpAgentInfoErr              error
 	dumpNetworkPolicyResourcesErr error
 	dumpHeapPprofErr              error
+	dumpGoroutinePprofErr         error
 	dumpOVSPortsErr               error
 	dumpMemberlistErr             error
 }
@@ -248,6 +256,10 @@ func (d *mockAgentDumper) DumpNetworkPolicyResources(basedir string) error {
 
 func (d *mockAgentDumper) DumpHeapPprof(basedir string) error {
 	return d.dumpHeapPprofErr
+}
+
+func (d *mockAgentDumper) DumpGoroutinePprof(basedir string) error {
+	return d.dumpGoroutinePprofErr
 }
 
 func (d *mockAgentDumper) DumpOVSPorts(basedir string) error {

--- a/pkg/apiserver/registry/system/supportbundle/rest.go
+++ b/pkg/apiserver/registry/system/supportbundle/rest.go
@@ -268,6 +268,7 @@ func (r *supportBundleREST) collectAgent(ctx context.Context, since string) (*sy
 		dumper.DumpNetworkPolicyResources,
 		dumper.DumpAgentInfo,
 		dumper.DumpHeapPprof,
+		dumper.DumpGoroutinePprof,
 		dumper.DumpOVSPorts,
 		dumper.DumpMemberlist,
 	)
@@ -281,6 +282,7 @@ func (r *supportBundleREST) collectController(ctx context.Context, since string)
 		dumper.DumpNetworkPolicyResources,
 		dumper.DumpControllerInfo,
 		dumper.DumpHeapPprof,
+		dumper.DumpGoroutinePprof,
 	)
 }
 

--- a/pkg/apiserver/registry/system/supportbundle/rest_test.go
+++ b/pkg/apiserver/registry/system/supportbundle/rest_test.go
@@ -233,6 +233,10 @@ func (f *fakeAgentDumper) DumpHeapPprof(basedir string) error {
 	return f.returnErr
 }
 
+func (f *fakeAgentDumper) DumpGoroutinePprof(basedir string) error {
+	return f.returnErr
+}
+
 func (f *fakeAgentDumper) DumpOVSPorts(basedir string) error {
 	return f.returnErr
 }

--- a/pkg/support/dump_test.go
+++ b/pkg/support/dump_test.go
@@ -195,3 +195,11 @@ func TestControllerDumpHeapPprof(t *testing.T) {
 	err := dumper.DumpHeapPprof(baseDir)
 	require.NoError(t, err)
 }
+
+func TestControllerDumpGoroutinePprof(t *testing.T) {
+	exe := new(testExec)
+	fs := afero.NewMemMapFs()
+	dumper := NewControllerDumper(fs, exe, "5s")
+	err := dumper.DumpGoroutinePprof(baseDir)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Fixes #5243 

This PR adds goroutine stack dump in support bundle for both agent and controller. Sample shown below for controller.

```
antrea % kubectl get pods -l app=antrea -n kube-system
NAME                                 READY   STATUS    RESTARTS   AGE
antrea-agent-lvnl6                   2/2     Running   0          57m
antrea-controller-668f6cc866-b4gxt   1/1     Running   0          57m

antrea % kubectl exec -it antrea-controller-668f6cc866-b4gxt -n kube-system -c antrea-controller bash
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
root@minikube:/# antctl supportbundle
Created bundle under /tmp
Expire time: 2023-10-01 17:07:18 +0000 UTC
root@minikube:/# tar -xzvf /tmp/bundle_269813909.tar.gz 
addressgroups
appliedtogroups
controllerinfo
goroutinestacks
logs/controller/antrea-controller.minikube.root.log.INFO.20231001-150949.1
memprofile
networkpolicies

root@minikube:/# head goroutinestacks 
goroutine 22252 [running]:
runtime/pprof.writeGoroutineStacks({0x2ab1a00, 0xc0003ac000})
        /usr/local/go/src/runtime/pprof/pprof.go:703 +0x6a
runtime/pprof.writeGoroutine({0x2ab1a00?, 0xc0003ac000?}, 0x4f3ff6?)
        /usr/local/go/src/runtime/pprof/pprof.go:692 +0x25
runtime/pprof.(*Profile).WriteTo(0x269762a?, {0x2ab1a00?, 0xc0003ac000?}, 0x4f2cbb?)
        /usr/local/go/src/runtime/pprof/pprof.go:329 +0x146
antrea.io/antrea/pkg/support.DumpGoroutinePprof({0x2af0860, 0x3f871a0}, {0xc000d211c0?, 0x19?})
        /antrea/pkg/support/dump.go:106 +0x1d5
```

The original issue also talks about addition of `/metrics` API response to support bundle but I hope it'd be fine if it's done in a follow-up PR.