### PR TITLE
Add checksum of windows config files as annotations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -387,6 +387,7 @@ manifest:
 	$(CURDIR)/hack/generate-manifest-windows.sh --mode dev > build/yamls/antrea-windows.yml
 	$(CURDIR)/hack/generate-manifest-windows.sh --mode dev --containerd > build/yamls/antrea-windows-containerd.yml
 	$(CURDIR)/hack/generate-manifest-windows.sh --mode dev --containerd --include-ovs > build/yamls/antrea-windows-containerd-with-ovs.yml
+	$(CURDIR)/hack/update-checksum-windows.sh
 	$(CURDIR)/hack/generate-manifest-flow-aggregator.sh --mode dev > build/yamls/flow-aggregator.yml
 
 .PHONY: manifest-scale

--- a/build/yamls/antrea-windows-containerd-with-ovs.yml
+++ b/build/yamls/antrea-windows-containerd-with-ovs.yml
@@ -73,7 +73,7 @@ kind: ConfigMap
 metadata:
   labels:
     app: antrea
-  name: antrea-agent-windows-47gftkh2c5
+  name: antrea-agent-windows
   namespace: kube-system
 ---
 apiVersion: v1
@@ -235,7 +235,7 @@ kind: ConfigMap
 metadata:
   labels:
     app: antrea
-  name: antrea-windows-config-c2c7f4kbbc
+  name: antrea-windows-config
   namespace: kube-system
 ---
 apiVersion: apps/v1
@@ -254,6 +254,8 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/agent-windows: 5afdcec25b0f1e6a241dff1bc0c7484cf5044eb33086b2a84961610fec15b461
+        checksum/windows-config: 6be75a1fcb4855e2e138e36109862d93f16e2d654312c74532bbcc64c65af3d9
         microsoft.com/hostprocess-inherit-user: "true"
       labels:
         app: antrea
@@ -350,11 +352,11 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-windows-config-c2c7f4kbbc
+          name: antrea-windows-config
         name: antrea-windows-config
       - configMap:
           defaultMode: 420
-          name: antrea-agent-windows-47gftkh2c5
+          name: antrea-agent-windows
         name: antrea-agent-windows
       - hostPath:
           path: /var/log/antrea/

--- a/build/yamls/antrea-windows-containerd.yml
+++ b/build/yamls/antrea-windows-containerd.yml
@@ -24,7 +24,7 @@ kind: ConfigMap
 metadata:
   labels:
     app: antrea
-  name: antrea-agent-windows-75tg78f7k9
+  name: antrea-agent-windows
   namespace: kube-system
 ---
 apiVersion: v1
@@ -186,7 +186,7 @@ kind: ConfigMap
 metadata:
   labels:
     app: antrea
-  name: antrea-windows-config-c2c7f4kbbc
+  name: antrea-windows-config
   namespace: kube-system
 ---
 apiVersion: apps/v1
@@ -205,6 +205,8 @@ spec:
   template:
     metadata:
       annotations:
+        checksum/agent-windows: 7749579c82f76822f449f6d6f765f07486310e8cd21cb117c8349ad1e118788b
+        checksum/windows-config: 6be75a1fcb4855e2e138e36109862d93f16e2d654312c74532bbcc64c65af3d9
         microsoft.com/hostprocess-inherit-user: "true"
       labels:
         app: antrea
@@ -270,11 +272,11 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-windows-config-c2c7f4kbbc
+          name: antrea-windows-config
         name: antrea-windows-config
       - configMap:
           defaultMode: 420
-          name: antrea-agent-windows-75tg78f7k9
+          name: antrea-agent-windows
         name: antrea-agent-windows
       - hostPath:
           path: /var/log/antrea/

--- a/build/yamls/antrea-windows.yml
+++ b/build/yamls/antrea-windows.yml
@@ -10,7 +10,7 @@ kind: ConfigMap
 metadata:
   labels:
     app: antrea
-  name: antrea-agent-windows-kht6m7hthm
+  name: antrea-agent-windows
   namespace: kube-system
 ---
 apiVersion: v1
@@ -172,7 +172,7 @@ kind: ConfigMap
 metadata:
   labels:
     app: antrea
-  name: antrea-windows-config-c2c7f4kbbc
+  name: antrea-windows-config
   namespace: kube-system
 ---
 apiVersion: apps/v1
@@ -190,6 +190,9 @@ spec:
       component: antrea-agent
   template:
     metadata:
+      annotations:
+        checksum/agent-windows: 5af94f558d39950050ce9625ca7670bcca448b9ff3080a16902a5cae5d069210
+        checksum/windows-config: 6be75a1fcb4855e2e138e36109862d93f16e2d654312c74532bbcc64c65af3d9
       labels:
         app: antrea
         component: antrea-agent
@@ -260,11 +263,11 @@ spec:
         operator: Exists
       volumes:
       - configMap:
-          name: antrea-windows-config-c2c7f4kbbc
+          name: antrea-windows-config
         name: antrea-windows-config
       - configMap:
           defaultMode: 420
-          name: antrea-agent-windows-kht6m7hthm
+          name: antrea-agent-windows
         name: antrea-agent-windows
       - hostPath:
           path: /etc/cni/net.d

--- a/build/yamls/windows/base/kustomization.yml
+++ b/build/yamls/windows/base/kustomization.yml
@@ -5,3 +5,5 @@ configMapGenerator:
   - conf/antrea-agent.conf
   - conf/antrea-cni.conflist
   name: antrea-windows-config
+generatorOptions:
+  disableNameSuffixHash: true

--- a/build/yamls/windows/containerd-with-ovs/kustomization.yml
+++ b/build/yamls/windows/containerd-with-ovs/kustomization.yml
@@ -13,3 +13,5 @@ configMapGenerator:
   name: antrea-agent-windows
   namespace: kube-system
   behavior: merge
+generatorOptions:
+  disableNameSuffixHash: true

--- a/build/yamls/windows/containerd/agent-containerd.yml
+++ b/build/yamls/windows/containerd/agent-containerd.yml
@@ -12,6 +12,8 @@ spec:
     metadata:
       annotations:
         "microsoft.com/hostprocess-inherit-user": "true"
+        checksum/windows-config: windows-config-checksum-placeholder
+        checksum/agent-windows: agent-windows-checksum-placeholder
       labels:
         component: antrea-agent
     spec:

--- a/build/yamls/windows/containerd/kustomization.yml
+++ b/build/yamls/windows/containerd/kustomization.yml
@@ -11,3 +11,5 @@ configMapGenerator:
   - conf/Run-AntreaAgent-Containerd.ps1
   - conf/Install-WindowsCNI-Containerd.ps1
   name: antrea-agent-windows
+generatorOptions:
+  disableNameSuffixHash: true

--- a/build/yamls/windows/default/agent.yml
+++ b/build/yamls/windows/default/agent.yml
@@ -12,6 +12,9 @@ spec:
     metadata:
       labels:
         component: antrea-agent
+      annotations:
+        checksum/windows-config: windows-config-checksum-placeholder
+        checksum/agent-windows: agent-windows-checksum-placeholder
     spec:
       containers:
         - command:

--- a/build/yamls/windows/default/kustomization.yml
+++ b/build/yamls/windows/default/kustomization.yml
@@ -10,3 +10,5 @@ configMapGenerator:
 - files:
   - conf/Run-AntreaAgent.ps1
   name: antrea-agent-windows
+generatorOptions:
+  disableNameSuffixHash: true

--- a/hack/update-checksum-windows.sh
+++ b/hack/update-checksum-windows.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 Antrea Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+WORK_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+YAMLS_DIR="${WORK_DIR}"/../build/yamls
+MANIFESTS=$(ls $YAMLS_DIR/antrea-windows*.yml)
+WINDOWS_DIR="${YAMLS_DIR}"/windows
+BASE_CONF_FILES="${WINDOWS_DIR}/base/conf/antrea-agent.conf ${WINDOWS_DIR}/base/conf/antrea-cni.conflist"
+DEFAULT_CONF_FILES="${WINDOWS_DIR}/default/conf/Run-AntreaAgent.ps1"
+CONTAINERD_CONF_FILES="${WINDOWS_DIR}/containerd/conf/Install-WindowsCNI-Containerd.ps1 \
+    ${WINDOWS_DIR}/containerd/conf/Run-AntreaAgent-Containerd.ps1"
+CONTAINERD_WITH_OVS_CONF_FILES="${WINDOWS_DIR}/containerd-with-ovs/conf/Run-AntreaOVS-Containerd.ps1 \
+    ${WINDOWS_DIR}/containerd-with-ovs/conf/VMSwitchExtension-AntreaAgent-Containerd.ps1"
+
+checksum_windows_config=$(cat ${BASE_CONF_FILES} | sha256sum | cut -d " " -f 1)
+
+checksum_default=$(cat ${DEFAULT_CONF_FILES} | sha256sum | cut -d " " -f 1)
+
+checksum_containerd=$( cat ${CONTAINERD_CONF_FILES} | sha256sum | cut -d " " -f 1)
+
+checksum_containerd_with_ovs=$(cat ${CONTAINERD_CONF_FILES} ${CONTAINERD_WITH_OVS_CONF_FILES} | sha256sum | cut -d " " -f 1)
+
+for file in ${MANIFESTS[@]}; do
+    sed -i.bak "s/windows-config-checksum-placeholder/${checksum_windows_config}/g" ${file}
+done
+
+sed -i.bak "s/agent-windows-checksum-placeholder/${checksum_default}/g" ${YAMLS_DIR}/antrea-windows.yml
+sed -i.bak "s/agent-windows-checksum-placeholder/${checksum_containerd}/g" ${YAMLS_DIR}/antrea-windows-containerd.yml
+sed -i.bak "s/agent-windows-checksum-placeholder/${checksum_containerd_with_ovs}/g" ${YAMLS_DIR}/antrea-windows-containerd-with-ovs.yml


### PR DESCRIPTION
When the ConfigMap is generated with suffix by kustomize, it will generate a manifest with new ConfigMap like 'antrea-windows-config-***'. When a new manifest is applied, it will leave stale ConfigMaps. To avoid stale ConfigMaps, here we add checksum of windows configuration files as annotations.