### PR TITLE
Fix rollback invocation after CmdAdd failure in CNI server

### DIFF
--- a/pkg/agent/cniserver/ipam/ipam_service.go
+++ b/pkg/agent/cniserver/ipam/ipam_service.go
@@ -54,6 +54,12 @@ func RegisterIPAMDriver(ipamType string, ipamDriver IPAMDriver) {
 	ipamDrivers[ipamType] = append(ipamDrivers[ipamType], ipamDriver)
 }
 
+func ResetIPAMDrivers(ipamType string) {
+	if ipamDrivers != nil {
+		delete(ipamDrivers, ipamType)
+	}
+}
+
 func argsFromEnv(cniArgs *cnipb.CniCmdArgs) *invoke.Args {
 	return &invoke.Args{
 		ContainerID: cniArgs.ContainerId,

--- a/pkg/agent/cniserver/server.go
+++ b/pkg/agent/cniserver/server.go
@@ -450,7 +450,7 @@ func (s *CNIServer) CmdAdd(ctx context.Context, request *cnipb.CniCmdRequest) (*
 
 	success := false
 	defer func() {
-		// Rollback to delete configurations once ADD is failure.
+		// Rollback to delete configurations if ADD fails.
 		if !success {
 			if isInfraContainer {
 				klog.InfoS("CmdAdd for container failed, trying to rollback", "container", cniConfig.ContainerId)

--- a/pkg/agent/cniserver/server_test.go
+++ b/pkg/agent/cniserver/server_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -138,31 +139,77 @@ func checkErrorResponse(t *testing.T, resp *cnipb.CniCmdResponse, code cnipb.Err
 	}
 }
 
-func TestIPAMService(t *testing.T) {
-	controller := gomock.NewController(t)
-	ipamMock := ipamtest.NewMockIPAMDriver(controller)
-	ipam.RegisterIPAMDriver(testIpamType, ipamMock)
-	cniServer := newCNIServer(t)
-	ifaceStore := interfacestore.NewInterfaceStore()
-	cniServer.podConfigurator = &podConfigurator{ifaceStore: ifaceStore}
+// networkConfigIPAMMatcher is used to validate the IPAMConfig received by the IPAM driver mock.
+type networkConfigIPAMMatcher struct {
+	ipamConfig *types.IPAMConfig
+}
 
-	require.True(t, ipam.IsIPAMTypeValid(testIpamType), "Failed to register IPAM service")
-	require.False(t, ipam.IsIPAMTypeValid("not_a_valid_IPAM_driver"))
+func (m *networkConfigIPAMMatcher) Matches(x interface{}) bool {
+	var networkConfig types.NetworkConfig
+	if err := json.Unmarshal(x.([]byte), &networkConfig); err != nil {
+		return false
+	}
+	return reflect.DeepEqual(networkConfig.IPAM, m.ipamConfig)
+}
+
+func (m *networkConfigIPAMMatcher) String() string {
+	return fmt.Sprintf("IPAMConfig is equal to %v", m.ipamConfig)
+}
+
+func TestIPAMService(t *testing.T) {
+	networkCfg := generateNetworkConfiguration("", supportedCNIVersion, "", testIpamType)
+
+	setup := func(t *testing.T) (*ipamtest.MockIPAMDriver, *CNIServer, *cnipb.CniCmdRequest) {
+		// required to provide isolation between subtests
+		// note that subtests CANNOT share an instance of gomock.Controller
+		ipam.ResetIPAMDrivers(testIpamType)
+		controller := gomock.NewController(t)
+		ipamMock := ipamtest.NewMockIPAMDriver(controller)
+		ipam.RegisterIPAMDriver(testIpamType, ipamMock)
+		cniServer := newCNIServer(t)
+		ifaceStore := interfacestore.NewInterfaceStore()
+		cniServer.podConfigurator = &podConfigurator{ifaceStore: ifaceStore}
+
+		require.True(t, ipam.IsIPAMTypeValid(testIpamType), "Failed to register IPAM service")
+		require.False(t, ipam.IsIPAMTypeValid("not_a_valid_IPAM_driver"))
+		requestMsg, _ := newRequest(args, networkCfg, "", t)
+		return ipamMock, cniServer, requestMsg
+	}
 
 	// Test IPAM_Failure cases
 	cxt := context.Background()
-	networkCfg := generateNetworkConfiguration("", supportedCNIVersion, "", testIpamType)
-	requestMsg, _ := newRequest(args, networkCfg, "", t)
+
+	expectedIPAMConfig := &types.IPAMConfig{
+		Type: testIpamType,
+		Ranges: []types.RangeSet{
+			[]types.Range{
+				{
+					Subnet:  testNodeConfig.PodIPv4CIDR.String(),
+					Gateway: testNodeConfig.GatewayConfig.IPv4.String(),
+				},
+			},
+			[]types.Range{
+				{
+					Subnet:  testNodeConfig.PodIPv6CIDR.String(),
+					Gateway: testNodeConfig.GatewayConfig.IPv6.String(),
+				},
+			},
+		},
+	}
 
 	t.Run("Error on ADD", func(t *testing.T) {
-		ipamMock.EXPECT().Add(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil, fmt.Errorf("IPAM add error"))
-		ipamMock.EXPECT().Del(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil)
+		ipamMock, cniServer, requestMsg := setup(t)
+		ipamMock.EXPECT().Add(gomock.Any(), gomock.Any(), &networkConfigIPAMMatcher{expectedIPAMConfig}).Return(true, nil, fmt.Errorf("IPAM add error"))
+		// Del call triggered by automatic rollback.
+		// IPAMConfig should be the same for both calls (Add and Del).
+		ipamMock.EXPECT().Del(gomock.Any(), gomock.Any(), &networkConfigIPAMMatcher{expectedIPAMConfig}).Return(true, nil)
 		response, err := cniServer.CmdAdd(cxt, requestMsg)
 		require.Nil(t, err, "expected no rpc error")
 		checkErrorResponse(t, response, cnipb.ErrorCode_IPAM_FAILURE, "IPAM add error")
 	})
 
 	t.Run("Error on DEL", func(t *testing.T) {
+		ipamMock, cniServer, requestMsg := setup(t)
 		// Prepare cached IPAM result which will be deleted later.
 		ipamMock.EXPECT().Add(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil, nil)
 		cniConfig, _ := cniServer.validateRequestMessage(requestMsg)
@@ -181,6 +228,7 @@ func TestIPAMService(t *testing.T) {
 	})
 
 	t.Run("Error on CHECK", func(t *testing.T) {
+		ipamMock, cniServer, requestMsg := setup(t)
 		ipamMock.EXPECT().Check(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, fmt.Errorf("IPAM check error"))
 		response, err := cniServer.CmdCheck(cxt, requestMsg)
 		require.Nil(t, err, "expected no rpc error")
@@ -188,6 +236,7 @@ func TestIPAMService(t *testing.T) {
 	})
 
 	t.Run("Idempotent Call of IPAM ADD/DEL for the same Pod", func(t *testing.T) {
+		ipamMock, cniServer, requestMsg := setup(t)
 		ipamMock.EXPECT().Add(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil, nil)
 		ipamMock.EXPECT().Del(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(2)
 		cniConfig, response := cniServer.validateRequestMessage(requestMsg)
@@ -204,6 +253,7 @@ func TestIPAMService(t *testing.T) {
 	})
 
 	t.Run("Idempotent Call of IPAM ADD/DEL for the same Pod with different containers", func(t *testing.T) {
+		ipamMock, cniServer, requestMsg := setup(t)
 		ipamMock.EXPECT().Add(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil, nil).Times(2)
 		ipamMock.EXPECT().Del(gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).Times(2)
 		cniConfig, response := cniServer.validateRequestMessage(requestMsg)


### PR DESCRIPTION
* When performing configuration rollback after an error in CmdAdd, we do not invoke CmdDel directly. Instead, we invoke an internal version of it which does not log a "Received CmdDel request" message (the message is confusing otherwise as it implies that we received a new CNI DEL command from the container runtime), and which does not process the network config again (as it was already processed at the beginning of CmdAdd). By not processing the config a second time, we ensure that there are no duplicate CIDRs in the IPAMConfig.
* Migrate klog calls in server.go to use structured logging.
* Improve unit tests for the CNI server to validate this fix.

Fixes #5547