### PR TITLE
Automated cherry pick of #5566 and #5583 Fix deadlock when accessing dirtyRules in fqdn controller

### DIFF
--- a/pkg/agent/controller/networkpolicy/fqdn.go
+++ b/pkg/agent/controller/networkpolicy/fqdn.go
@@ -535,7 +535,8 @@ func (rst *ruleSyncTracker) subscribe(waitCh chan error, dirtyRules sets.String)
 func (rst *ruleSyncTracker) getDirtyRules() sets.String {
 	rst.mutex.RLock()
 	defer rst.mutex.RUnlock()
-	return rst.dirtyRules
+	// Must return a copy as the set can be updated in-place by Run func.
+	return rst.dirtyRules.Union(nil)
 }
 
 func (rst *ruleSyncTracker) Run(stopCh <-chan struct{}) {


### PR DESCRIPTION
Cherry pick of #5566 and #5583 on release-1.11.

#5566: Fix deadlock when accessing dirtyRules in fqdn controller
#5583: Fix data race in FQDN ruleSyncTracker

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.