### PR TITLE
Automated cherry pick of #5583: Fix data race in FQDN ruleSyncTracker

### DIFF
--- a/pkg/agent/controller/networkpolicy/fqdn.go
+++ b/pkg/agent/controller/networkpolicy/fqdn.go
@@ -535,7 +535,8 @@ func (rst *ruleSyncTracker) subscribe(waitCh chan error, dirtyRules sets.Set[str
 func (rst *ruleSyncTracker) getDirtyRules() sets.Set[string] {
 	rst.mutex.RLock()
 	defer rst.mutex.RUnlock()
-	return rst.dirtyRules
+	// Must return a copy as the set can be updated in-place by Run func.
+	return rst.dirtyRules.Clone()
 }
 
 func (rst *ruleSyncTracker) Run(stopCh <-chan struct{}) {


### PR DESCRIPTION
Cherry pick of #5583 on release-1.13.

#5583: Fix data race in FQDN ruleSyncTracker

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.