### PR TITLE
Report NetworkPolicy destined for Services as invalid when proxyAll is disabled

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -470,6 +470,7 @@ func run(o *Options) error {
 		antreaPolicyEnabled,
 		l7NetworkPolicyEnabled,
 		o.enableAntreaProxy,
+		o.config.AntreaProxy.ProxyAll,
 		statusManagerEnabled,
 		multicastEnabled,
 		auditLoggerOptions,

--- a/pkg/agent/controller/networkpolicy/cache.go
+++ b/pkg/agent/controller/networkpolicy/cache.go
@@ -182,6 +182,20 @@ func (r *CompletedRule) isIGMPEgressPolicyRule() bool {
 	return false
 }
 
+func (r *CompletedRule) isAppliedToServicesIngressPolicyRule() bool {
+	if r.Direction == v1beta.DirectionIn && isRuleAppliedToService(r.TargetMembers) {
+		return true
+	}
+	return false
+}
+
+func (r *CompletedRule) isToServicesEgressPolicyRule() bool {
+	if r.Direction == v1beta.DirectionOut && len(r.To.ToServices) != 0 {
+		return true
+	}
+	return false
+}
+
 // ruleCache caches Antrea AddressGroups, AppliedToGroups and NetworkPolicies,
 // can construct complete rules that can be used by reconciler to enforce.
 type ruleCache struct {

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
@@ -71,7 +71,7 @@ func newTestController() (*Controller, *fake.Clientset, *mockReconciler) {
 	ch2 := make(chan string, 100)
 	groupIDAllocator := openflow.NewGroupAllocator()
 	groupCounters := []proxytypes.GroupCounter{proxytypes.NewGroupCounter(groupIDAllocator, ch2)}
-	controller, _ := NewNetworkPolicyController(&antreaClientGetter{clientset}, nil, nil, "node1", podUpdateChannel, nil, groupCounters, ch2, true, true, true, true, false, nil, testAsyncDeleteInterval, "8.8.8.8:53", config.K8sNode, true, false, config.HostGatewayOFPort, config.DefaultTunOFPort, &config.NodeConfig{})
+	controller, _ := NewNetworkPolicyController(&antreaClientGetter{clientset}, nil, nil, "node1", podUpdateChannel, nil, groupCounters, ch2, true, true, true, true, true, false, nil, testAsyncDeleteInterval, "8.8.8.8:53", config.K8sNode, true, false, config.HostGatewayOFPort, config.DefaultTunOFPort, &config.NodeConfig{})
 	reconciler := newMockReconciler()
 	controller.reconciler = reconciler
 	controller.auditLogger = nil

--- a/pkg/agent/controller/networkpolicy/reconciler_test.go
+++ b/pkg/agent/controller/networkpolicy/reconciler_test.go
@@ -112,7 +112,7 @@ func newTestReconciler(t *testing.T, controller *gomock.Controller, ifaceStore i
 	ch := make(chan string, 100)
 	groupIDAllocator := openflow.NewGroupAllocator()
 	groupCounters := []proxytypes.GroupCounter{proxytypes.NewGroupCounter(groupIDAllocator, ch)}
-	r := newReconciler(ofClient, ifaceStore, newIDAllocator(testAsyncDeleteInterval), f, groupCounters, v4Enabled, v6Enabled, true, false)
+	r := newReconciler(ofClient, ifaceStore, newIDAllocator(testAsyncDeleteInterval), f, groupCounters, v4Enabled, v6Enabled, true, false, false)
 	return r
 }
 

--- a/pkg/agent/controller/networkpolicy/status_controller_test.go
+++ b/pkg/agent/controller/networkpolicy/status_controller_test.go
@@ -164,7 +164,7 @@ func TestSyncStatusUpForUpdatedPolicy(t *testing.T) {
 	policy.Generation = 1
 	ruleCache.AddNetworkPolicy(policy)
 	rule1 := ruleCache.getEffectiveRulesByNetworkPolicy(string(policy.UID))[0]
-	statusController.SetRuleRealization(rule1.ID, policy.UID, "")
+	statusController.SetRuleRealization(rule1.ID, policy.UID, reconcileErrorNil)
 
 	matchGeneration := func(generation int64) error {
 		return wait.PollImmediate(100*time.Millisecond, 1*time.Second, func() (done bool, err error) {
@@ -187,7 +187,7 @@ func TestSyncStatusUpForUpdatedPolicy(t *testing.T) {
 	for _, rule := range rules {
 		// Only call SetRuleRealization for new rule.
 		if rule.ID != rule1.ID {
-			statusController.SetRuleRealization(rule.ID, policy.UID, "")
+			statusController.SetRuleRealization(rule.ID, policy.UID, reconcileErrorNil)
 		}
 	}
 	assert.NoError(t, matchGeneration(policy.Generation), "The generation should be updated to %v but was not updated", policy.Generation)
@@ -220,7 +220,7 @@ func BenchmarkSyncHandler(b *testing.B) {
 	ruleCache.AddNetworkPolicy(policy)
 	rules := ruleCache.getEffectiveRulesByNetworkPolicy(string(policy.UID))
 	for _, rule := range rules {
-		statusController.SetRuleRealization(rule.ID, policy.UID, "")
+		statusController.SetRuleRealization(rule.ID, policy.UID, reconcileErrorNil)
 	}
 
 	b.ReportAllocs()


### PR DESCRIPTION
When AntreaProxy proxyAll is not enabled, the following usages are invalid:

- For an ingress NetworkPolicy, which is applied to Services. Note that,
  such ingress NetworkPolicy can be only applied to NodePort Services. As
  a result, proxyAll should be also enabled.
- For an egress NetworkPolicy, which is to Services. Note that, headless
  Services are not supported.

Signed-off-by: Hongliang Liu <lhongliang@vmware.com>