### PR TITLE
Remove redundant log in fillPodInfo/fillServiceInfo and update deny connection store.

### DIFF
--- a/pkg/agent/controller/networkpolicy/packetin.go
+++ b/pkg/agent/controller/networkpolicy/packetin.go
@@ -107,6 +107,7 @@ func (c *Controller) storeDenyConnection(pktIn *ofctrl.PacketIn) error {
 	if err != nil {
 		return fmt.Errorf("error in parsing packetIn: %v", err)
 	}
+	matchers := pktIn.GetMatches()
 
 	// Get 5-tuple information
 	sourceAddr, _ := netip.AddrFromSlice(packet.SourceIP)
@@ -124,6 +125,11 @@ func (c *Controller) storeDenyConnection(pktIn *ofctrl.PacketIn) error {
 	denyConn.FlowKey = tuple
 	denyConn.DestinationServiceAddress = tuple.DestinationAddress
 	denyConn.DestinationServicePort = tuple.DestinationPort
+	denyConn.Mark = getCTMarkValue(matchers)
+	dstSvcAddress := getSvcAddress(matchers)
+	if dstSvcAddress != nil {
+		denyConn.DestinationServiceAddress = *dstSvcAddress
+	}
 
 	// No need to obtain connection info again if it already exists in denyConnectionStore.
 	if conn, exist := c.denyConnStore.GetConnByKey(flowexporter.NewConnectionKey(&denyConn)); exist {
@@ -131,7 +137,6 @@ func (c *Controller) storeDenyConnection(pktIn *ofctrl.PacketIn) error {
 		return nil
 	}
 
-	matchers := pktIn.GetMatches()
 	var match *ofctrl.MatchField
 	// Get table ID
 	tableID := getPacketInTableID(pktIn)
@@ -222,4 +227,28 @@ func getPacketInTableID(pktIn *ofctrl.PacketIn) uint8 {
 		}
 	}
 	return tableID
+}
+
+func getCTMarkValue(matchers *ofctrl.Matchers) uint32 {
+	ctMark := matchers.GetMatchByName("NXM_NX_CT_MARK")
+	if ctMark == nil {
+		return 0
+	}
+	ctMarkValue, ok := ctMark.GetValue().(uint32)
+	if !ok {
+		return 0
+	}
+	return ctMarkValue
+}
+
+func getSvcAddress(matchers *ofctrl.Matchers) *net.IP {
+	svcIp := matchers.GetMatchByName("NXM_NX_CT_NW_DST")
+	if svcIp == nil {
+		return nil
+	}
+	svcIpValue, ok := svcIp.GetValue().(net.IP)
+	if !ok {
+		return nil
+	}
+	return &svcIpValue
 }

--- a/pkg/agent/flowexporter/connections/connections.go
+++ b/pkg/agent/flowexporter/connections/connections.go
@@ -108,9 +108,6 @@ func (cs *connectionStore) fillPodInfo(conn *flowexporter.Connection) {
 
 	srcPod, srcFound := cs.podStore.GetPodByIPAndTime(srcIP, conn.StartTime)
 	dstPod, dstFound := cs.podStore.GetPodByIPAndTime(dstIP, conn.StartTime)
-	if !srcFound && !dstFound {
-		klog.InfoS("Cannot map any of the connection IPs to a local Pod", "srcIP", srcIP, "dstIP", dstIP)
-	}
 	if srcFound {
 		conn.SourcePodName = srcPod.Name
 		conn.SourcePodNamespace = srcPod.Namespace
@@ -125,9 +122,7 @@ func (cs *connectionStore) fillServiceInfo(conn *flowexporter.Connection, servic
 	// resolve destination Service information
 	if cs.antreaProxier != nil {
 		servicePortName, exists := cs.antreaProxier.GetServiceByIP(serviceStr)
-		if !exists {
-			klog.Warningf("Could not retrieve the Service info from antrea-agent-proxier for the serviceStr: %s", serviceStr)
-		} else {
+		if exists {
 			conn.DestinationServicePortName = servicePortName.String()
 		}
 	}

--- a/pkg/agent/flowexporter/connections/connections.go
+++ b/pkg/agent/flowexporter/connections/connections.go
@@ -124,6 +124,8 @@ func (cs *connectionStore) fillServiceInfo(conn *flowexporter.Connection, servic
 		servicePortName, exists := cs.antreaProxier.GetServiceByIP(serviceStr)
 		if exists {
 			conn.DestinationServicePortName = servicePortName.String()
+		} else {
+			klog.InfoS("Could not retrieve the Service info from antrea-agent-proxier", "serviceStr", serviceStr)
 		}
 	}
 }

--- a/pkg/agent/flowexporter/connections/deny_connections.go
+++ b/pkg/agent/flowexporter/connections/deny_connections.go
@@ -23,6 +23,7 @@ import (
 	"antrea.io/antrea/pkg/agent/flowexporter"
 	"antrea.io/antrea/pkg/agent/flowexporter/priorityqueue"
 	"antrea.io/antrea/pkg/agent/metrics"
+	"antrea.io/antrea/pkg/agent/openflow"
 	"antrea.io/antrea/pkg/agent/proxy"
 	"antrea.io/antrea/pkg/util/ip"
 	"antrea.io/antrea/pkg/util/podstore"
@@ -98,7 +99,9 @@ func (ds *DenyConnectionStore) AddOrUpdateConn(conn *flowexporter.Connection, ti
 		ds.fillPodInfo(conn)
 		protocolStr := ip.IPProtocolNumberToString(conn.FlowKey.Protocol, "UnknownProtocol")
 		serviceStr := fmt.Sprintf("%s:%d/%s", conn.DestinationServiceAddress, conn.DestinationServicePort, protocolStr)
-		ds.fillServiceInfo(conn, serviceStr)
+		if conn.Mark&openflow.ServiceCTMark.GetRange().ToNXRange().ToUint32Mask() == openflow.ServiceCTMark.GetValue() {
+			ds.fillServiceInfo(conn, serviceStr)
+		}
 		metrics.TotalDenyConnections.Inc()
 		conn.IsActive = true
 		ds.connections[connKey] = conn

--- a/pkg/agent/flowexporter/connections/deny_connections_test.go
+++ b/pkg/agent/flowexporter/connections/deny_connections_test.go
@@ -27,6 +27,7 @@ import (
 
 	"antrea.io/antrea/pkg/agent/flowexporter"
 	"antrea.io/antrea/pkg/agent/metrics"
+	"antrea.io/antrea/pkg/agent/openflow"
 	proxytest "antrea.io/antrea/pkg/agent/proxy/testing"
 	podstoretest "antrea.io/antrea/pkg/util/podstore/testing"
 	k8sproxy "antrea.io/antrea/third_party/proxy"
@@ -76,7 +77,7 @@ func TestDenyConnectionStore_AddOrUpdateConn(t *testing.T) {
 				OriginalBytes:             uint64(60),
 				OriginalPackets:           uint64(1),
 				IsActive:                  true,
-				Mark:                      19,
+				Mark:                      openflow.ServiceCTMark.GetValue(),
 			},
 			isSvc: true,
 		},
@@ -92,8 +93,8 @@ func TestDenyConnectionStore_AddOrUpdateConn(t *testing.T) {
 			if c.isSvc {
 				mockProxier.EXPECT().GetServiceByIP(serviceStr).Return(servicePortName, true)
 			}
-			mockPodStore.EXPECT().GetPodByIPAndTime(tuple.SourceAddress.String(), gomock.Any()).Return(nil, false)
-			mockPodStore.EXPECT().GetPodByIPAndTime(tuple.DestinationAddress.String(), gomock.Any()).Return(nil, false)
+			mockPodStore.EXPECT().GetPodByIPAndTime(tuple.SourceAddress.String(), gomock.Any()).Return(pod1, true)
+			mockPodStore.EXPECT().GetPodByIPAndTime(tuple.DestinationAddress.String(), gomock.Any()).Return(pod1, true)
 
 			denyConnStore := NewDenyConnectionStore(mockPodStore, mockProxier, testFlowExporterOptions)
 

--- a/pkg/agent/flowexporter/exporter/exporter_test.go
+++ b/pkg/agent/flowexporter/exporter/exporter_test.go
@@ -502,7 +502,8 @@ func getDenyConnection(isIPv6 bool, protoID uint8) *flowexporter.Connection {
 		tuple = flowexporter.Tuple{SourceAddress: srcIP, DestinationAddress: dstIP, Protocol: protoID, SourcePort: 65280, DestinationPort: 255}
 	}
 	conn := &flowexporter.Connection{
-		FlowKey: tuple,
+		FlowKey:       tuple,
+		SourcePodName: "pod",
 	}
 	return conn
 }

--- a/test/e2e/bandwidth_test.go
+++ b/test/e2e/bandwidth_test.go
@@ -24,8 +24,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-const iperfPort = 5201
-
 // TestBandwidth is the top-level test which contains all subtests for
 // Bandwidth related test cases so they can share setup, teardown.
 func TestBandwidth(t *testing.T) {

--- a/test/e2e/flowaggregator_test.go
+++ b/test/e2e/flowaggregator_test.go
@@ -288,7 +288,7 @@ func checkIntraNodeFlows(t *testing.T, data *TestData, podAIPs, podBIPs *PodIPs,
 }
 
 func testHelper(t *testing.T, data *TestData, isIPv6 bool) {
-	_, svcB, svcC, svcD, svcE, err := createPerftestServices(data, false)
+	_, svcB, svcC, svcD, svcE, err := createPerftestServices(data, isIPv6)
 	if err != nil {
 		t.Fatalf("Error when creating perftest Services: %v", err)
 	}
@@ -1489,7 +1489,7 @@ func getRecordsFromOutput(t *testing.T, output string, startTime time.Time) []st
 			result = append(result, record)
 		}
 	}
-	return recordSlices
+	return result
 }
 
 func deployK8sNetworkPolicies(t *testing.T, data *TestData, srcPod, dstPod string) (np1 *networkingv1.NetworkPolicy, np2 *networkingv1.NetworkPolicy) {

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -148,6 +148,8 @@ const (
 	statefulSetRestartAnnotationKey = "antrea-e2e/restartedAt"
 
 	defaultCHDatabaseURL = "tcp://clickhouse-clickhouse.flow-visibility.svc:9000"
+	iperfPort            = 5201
+	iperfSvcPort         = 9999
 )
 
 type ClusterNode struct {


### PR DESCRIPTION
1. Remove redundant logs in fillPodInfo/fillServiceInfo to avoid Flow
   Exporter from flooding logs.
2. Add Mark field for deny connections. We were missing this field
   previously, resulting in trying to fill service information for
   non-service IPs.
3. Update the DestinationServiceAddress for deny connections when we can
   find this information in PacketIn.
4. Update e2e/unit tests to verify that the Service-relateds field are
   filled correctly.

Fixes #5573