### PR TITLE
Update dependabot.yml to also include docker images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,29 +1,62 @@
 version: 2
 updates:
-  - package-ecosystem: "gomod"
-    directory: "/" # Location of package manifests
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 5
-    groups:
-      golang.org/x:
-        patterns:
-        - "golang.org/x/*"
-    ignore:
-    - dependency-name: "k8s.io/*"
-    - dependency-name: "sigs.k8s.io/*"
-    - dependency-name: "github.com/containernetworking/*"
-    - dependency-name: "github.com/k8snetworkplumbingwg/*"
-      update-types: ["version-update:semver-major", "version-update:semver-minor"] # ignore all except for patch updates
-    - dependency-name: "github.com/vmware/go-ipfix"
-    - dependency-name: "github.com/TomCodeLV/OVSDB-golang-lib"
-    - dependency-name: "github.com/aws/*" # updates are too frequent
-    - dependency-name: "antrea.io/ofnet"
-    - dependency-name: "antrea.io/libOpenflow"
-    - dependency-name: "github.com/ClickHouse/clickhouse-go/v2" # auto-upgrade involves dependency conflicts
-  - package-ecosystem: "github-actions"
-    # Workflow files stored in the default location of `.github/workflows`
-    directory: "/"
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 5
+- package-ecosystem: gomod
+  directory: /
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 5
+  groups:
+    golang.org/x:
+      patterns:
+      - golang.org/x/*
+  ignore:
+  - dependency-name: k8s.io/*
+  - dependency-name: sigs.k8s.io/*
+  - dependency-name: github.com/containernetworking/*
+  - dependency-name: github.com/k8snetworkplumbingwg/*
+    update-types:
+    - version-update:semver-major
+    - version-update:semver-minor
+  - dependency-name: github.com/vmware/go-ipfix
+  - dependency-name: github.com/TomCodeLV/OVSDB-golang-lib
+  - dependency-name: github.com/aws/*
+  - dependency-name: antrea.io/ofnet
+  - dependency-name: antrea.io/libOpenflow
+  - dependency-name: github.com/ClickHouse/clickhouse-go/v2
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 5
+- package-ecosystem: docker
+  directory: /build/images/codegen
+  schedule:
+    interval: weekly
+- package-ecosystem: docker
+  directory: /build/images/base-windows
+  schedule:
+    interval: weekly
+- package-ecosystem: docker
+  directory: /build/images/flow-aggregator
+  schedule:
+    interval: weekly
+- package-ecosystem: docker
+  directory: /multicluster/build/images
+  schedule:
+    interval: weekly
+- package-ecosystem: docker
+  directory: /build/images/base
+  schedule:
+    interval: weekly
+- package-ecosystem: docker
+  directory: /build/images
+  schedule:
+    interval: weekly
+- package-ecosystem: docker
+  directory: /build/images/ovs
+  schedule:
+    interval: weekly
+- package-ecosystem: docker
+  directory: /docs/cookbooks/multus/build/cni-dhcp-daemon
+  schedule:
+    interval: weekly


### PR DESCRIPTION
Enable Dependabot for Dockerfile updates.
This will update images in Dockerfile `FROM` statements, and go modules.

The purpose is to drastically reduce number of vulnerabilities that affect this repo, 
by keeping dependencies up-to-date. 

This PR is created by a script. Please let me know if we should modify any values.

