### PR TITLE
Fix windows deployment manifest

### DIFF
--- a/build/yamls/antrea-windows-containerd-with-ovs.yml
+++ b/build/yamls/antrea-windows-containerd-with-ovs.yml
@@ -199,7 +199,7 @@ data:
     antreaProxy:
       # To disable AntreaProxy, set this to false. It should be enabled on Windows, otherwise NetworkPolicy will
       # not take effect on Service traffic.
-      enable: {{.enable}}
+      enable: true
       # ProxyAll tells antrea-agent to proxy ClusterIP Service traffic, regardless of where they come from.
       # Therefore, running kube-proxy is no longer required. This requires the AntreaProxy feature to be enabled.
       # Note that this option is experimental. If kube-proxy is removed, option kubeAPIServerOverride must be used to access
@@ -259,7 +259,7 @@ spec:
     metadata:
       annotations:
         checksum/agent-windows: 5afdcec25b0f1e6a241dff1bc0c7484cf5044eb33086b2a84961610fec15b461
-        checksum/windows-config: 6bd9e27a05233439f0012137ccfa6dc3817f99df9e394c9d07922c3277e433d1
+        checksum/windows-config: 6ff4f8bd0b310ebe4d4612bdd9697ffb3d79e0e0eab3936420417dd5a8fc128d
         microsoft.com/hostprocess-inherit-user: "true"
       labels:
         app: antrea

--- a/build/yamls/antrea-windows-containerd.yml
+++ b/build/yamls/antrea-windows-containerd.yml
@@ -150,7 +150,7 @@ data:
     antreaProxy:
       # To disable AntreaProxy, set this to false. It should be enabled on Windows, otherwise NetworkPolicy will
       # not take effect on Service traffic.
-      enable: {{.enable}}
+      enable: true
       # ProxyAll tells antrea-agent to proxy ClusterIP Service traffic, regardless of where they come from.
       # Therefore, running kube-proxy is no longer required. This requires the AntreaProxy feature to be enabled.
       # Note that this option is experimental. If kube-proxy is removed, option kubeAPIServerOverride must be used to access
@@ -210,7 +210,7 @@ spec:
     metadata:
       annotations:
         checksum/agent-windows: 7749579c82f76822f449f6d6f765f07486310e8cd21cb117c8349ad1e118788b
-        checksum/windows-config: 6bd9e27a05233439f0012137ccfa6dc3817f99df9e394c9d07922c3277e433d1
+        checksum/windows-config: 6ff4f8bd0b310ebe4d4612bdd9697ffb3d79e0e0eab3936420417dd5a8fc128d
         microsoft.com/hostprocess-inherit-user: "true"
       labels:
         app: antrea

--- a/build/yamls/antrea-windows.yml
+++ b/build/yamls/antrea-windows.yml
@@ -136,7 +136,7 @@ data:
     antreaProxy:
       # To disable AntreaProxy, set this to false. It should be enabled on Windows, otherwise NetworkPolicy will
       # not take effect on Service traffic.
-      enable: {{.enable}}
+      enable: true
       # ProxyAll tells antrea-agent to proxy ClusterIP Service traffic, regardless of where they come from.
       # Therefore, running kube-proxy is no longer required. This requires the AntreaProxy feature to be enabled.
       # Note that this option is experimental. If kube-proxy is removed, option kubeAPIServerOverride must be used to access
@@ -196,7 +196,7 @@ spec:
     metadata:
       annotations:
         checksum/agent-windows: 5af94f558d39950050ce9625ca7670bcca448b9ff3080a16902a5cae5d069210
-        checksum/windows-config: 6bd9e27a05233439f0012137ccfa6dc3817f99df9e394c9d07922c3277e433d1
+        checksum/windows-config: 6ff4f8bd0b310ebe4d4612bdd9697ffb3d79e0e0eab3936420417dd5a8fc128d
       labels:
         app: antrea
         component: antrea-agent

--- a/build/yamls/windows/base/conf/antrea-agent.conf
+++ b/build/yamls/windows/base/conf/antrea-agent.conf
@@ -118,7 +118,7 @@ featureGates:
 antreaProxy:
   # To disable AntreaProxy, set this to false. It should be enabled on Windows, otherwise NetworkPolicy will
   # not take effect on Service traffic.
-  enable: {{.enable}}
+  enable: true
   # ProxyAll tells antrea-agent to proxy ClusterIP Service traffic, regardless of where they come from.
   # Therefore, running kube-proxy is no longer required. This requires the AntreaProxy feature to be enabled.
   # Note that this option is experimental. If kube-proxy is removed, option kubeAPIServerOverride must be used to access


### PR DESCRIPTION
Helm varible shouldn't be used in windows manifest. 

Fix what https://github.com/antrea-io/antrea/pull/5401 broke.