### PR TITLE
Automated cherry pick of #5536: e2e: switch from netshoot image to toolbox image

### DIFF
--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -90,8 +90,9 @@ const (
 	testAntreaIPAMNamespace12  string = "antrea-ipam-test-12"
 	busyboxContainerName       string = "busybox"
 	mcjoinContainerName        string = "mcjoin"
-	tcpdumpContainerName       string = "netshoot"
 	agnhostContainerName       string = "agnhost"
+	toolboxContainerName       string = "toolbox"
+	nginxContainerName         string = "nginx"
 	controllerContainerName    string = "antrea-controller"
 	ovsContainerName           string = "antrea-ovs"
 	agentContainerName         string = "antrea-agent"
@@ -124,11 +125,11 @@ const (
 	agnhostImage        = "registry.k8s.io/e2e-test-images/agnhost:2.29"
 	busyboxImage        = "projects.registry.vmware.com/antrea/busybox"
 	mcjoinImage         = "projects.registry.vmware.com/antrea/mcjoin:v2.9"
-	netshootImage       = "projects.registry.vmware.com/antrea/netshoot:v0.1"
 	nginxImage          = "projects.registry.vmware.com/antrea/nginx:1.21.6-alpine"
 	iisImage            = "mcr.microsoft.com/windows/servercore/iis"
 	perftoolImage       = "projects.registry.vmware.com/antrea/perftool"
 	ipfixCollectorImage = "projects.registry.vmware.com/antrea/ipfix-collector:v0.6.1"
+	toolboxImage        = "projects.registry.vmware.com/antrea/toolbox:1.2-1"
 	ipfixCollectorPort  = "4739"
 	clickHouseHTTPPort  = "8123"
 
@@ -1369,10 +1370,10 @@ func (data *TestData) createMcJoinPodOnNode(name string, ns string, nodeName str
 	return NewPodBuilder(name, ns, mcjoinImage).OnNode(nodeName).WithCommand([]string{"sleep", "3600"}).WithHostNetwork(hostNetwork).Create(data)
 }
 
-// createNetshootPodOnNode creates a Pod in the test namespace with a single netshoot container. The
+// createToolboxPodOnNode creates a Pod in the test namespace with a single toolbox container. The
 // Pod will be scheduled on the specified Node (if nodeName is not empty).
-func (data *TestData) createNetshootPodOnNode(name string, ns string, nodeName string, hostNetwork bool) error {
-	return NewPodBuilder(name, ns, netshootImage).OnNode(nodeName).WithCommand([]string{"sleep", "3600"}).WithHostNetwork(hostNetwork).Create(data)
+func (data *TestData) createToolboxPodOnNode(name string, ns string, nodeName string, hostNetwork bool) error {
+	return NewPodBuilder(name, ns, toolboxImage).OnNode(nodeName).WithCommand([]string{"sleep", "3600"}).WithHostNetwork(hostNetwork).Create(data)
 }
 
 // createNginxPodOnNode creates a Pod in the test namespace with a single nginx container. The

--- a/test/e2e/multicast_test.go
+++ b/test/e2e/multicast_test.go
@@ -548,7 +548,7 @@ func testMulticastForwardToMultipleInterfaces(t *testing.T, data *TestData, send
 	mcjoinWaitTimeout := defaultTimeout / time.Second
 	senderName, _, cleanupFunc := createAndWaitForPod(t, data, data.createMcJoinPodOnNode, "test-sender-", nodeName(senderIdx), data.testNamespace, false)
 	defer cleanupFunc()
-	tcpdumpName, _, cleanupFunc := createAndWaitForPod(t, data, data.createNetshootPodOnNode, "test-tcpdump-", nodeName(senderIdx), data.testNamespace, true)
+	tcpdumpName, _, cleanupFunc := createAndWaitForPod(t, data, data.createToolboxPodOnNode, "test-tcpdump-", nodeName(senderIdx), data.testNamespace, true)
 	defer cleanupFunc()
 	// Wait 2 seconds(-w 2) before sending multicast traffic.
 	// It sends two multicast packets for every second(-f 500 means it takes 500 milliseconds for sending one packet).
@@ -563,7 +563,7 @@ func testMulticastForwardToMultipleInterfaces(t *testing.T, data *TestData, send
 		// If multicast traffic is sent from non-HostNetwork pods, all multicast interfaces in senders should receive multicast traffic.
 		for _, multicastInterface := range senderMulticastInterfaces {
 			tcpdumpReceiveMulticastCommand := []string{"/bin/sh", "-c", fmt.Sprintf("timeout 5s tcpdump -q -i %s -c 1 -W 90 host %s", multicastInterface, senderGroup)}
-			_, stderr, err := data.RunCommandFromPod(data.testNamespace, tcpdumpName, tcpdumpContainerName, tcpdumpReceiveMulticastCommand)
+			_, stderr, err := data.RunCommandFromPod(data.testNamespace, tcpdumpName, toolboxContainerName, tcpdumpReceiveMulticastCommand)
 			if err != nil {
 				return false, err
 			}

--- a/test/e2e/performance_test.go
+++ b/test/e2e/performance_test.go
@@ -39,7 +39,6 @@ const (
 	podsConnectionNetworkPolicyName = "pods.ingress"
 	workloadNetworkPolicyName       = "workloads.ingress"
 	perftoolContainerName           = "perftool"
-	nginxContainerName              = "nginx"
 )
 
 var (


### PR DESCRIPTION
Cherry pick of #5536 on release-1.12.

#5536: e2e: switch from netshoot image to toolbox image

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.