### PR TITLE
Fix dead links to docs.openvswitch.org

### DIFF
--- a/build/images/ovs/Dockerfile.ubi
+++ b/build/images/ovs/Dockerfile.ubi
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # OVS build scripts are only applicable for RHEL 7.x:
-# https://docs.openvswitch.org/en/latest/intro/install/fedora
+# https://docs.openvswitch.org/en/latest/intro/install/fedora.html
 FROM centos:centos7 as ovs-rpms
 
 # Some patches may not apply cleanly if a non-default version is provided.

--- a/docs/antctl.md
+++ b/docs/antctl.md
@@ -328,7 +328,7 @@ table=100, n_packets=0, n_bytes=0, priority=200,ip,reg1=0x5 actions=drop
 ### OVS packet tracing
 
 Starting from version 0.7.0, Antrea Agent supports tracing the OVS flows that a
-specified packet traverses, leveraging the [OVS packet tracing tool](http://docs.openvswitch.org/en/latest/topics/tracing).
+specified packet traverses, leveraging the [OVS packet tracing tool](https://docs.openvswitch.org/en/latest/topics/tracing.html).
 
 `antctl trace-packet` command starts a packet tracing operation.
 `antctl help trace-packet` shows the usage of the command. This section lists a

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -329,7 +329,7 @@ to the local Pods on their Nodes.
 
 Antrea supports encrypting Pod traffic across Linux Nodes with IPsec ESP. The
 IPsec implementation leverages [OVS
-IPsec](http://docs.openvswitch.org/en/latest/tutorials/ipsec) and leverages
+IPsec](https://docs.openvswitch.org/en/latest/tutorials/ipsec.html) and leverages
 [strongSwan](https://www.strongswan.org) as the IKE daemon. By default GRE
 tunnels are used but other tunnel types are also supported.
 

--- a/docs/design/ovs-pipeline.md
+++ b/docs/design/ovs-pipeline.md
@@ -34,7 +34,7 @@
   more information.
 * *conntrack*: a connection tracking module that can be used by OVS to match on
   the state of a TCP, UDP, ICMP, etc., connection. See the [OVS Conntrack
-  tutorial](http://docs.openvswitch.org/en/latest/tutorials/ovs-conntrack/) for
+  tutorial](https://docs.openvswitch.org/en/latest/tutorials/ovs-conntrack.html) for
   more information.
 * *dmac table*: a traditional L2 switch has a "dmac" table which maps
   learned destination MAC address to the appropriate egress port. It is often
@@ -42,7 +42,7 @@
   address and initiate MAC learning if the address is unknown).
 * *group action*: an action which is used to process forwarding decisions
   on multiple OVS ports. Examples include: load-balancing, multicast, and active/standby.
-  See [OVS group action](https://docs.openvswitch.org/en/latest/ref/ovs-actions.7/?highlight=group#the-group-action)
+  See [OVS group action](https://docs.openvswitch.org/en/latest/ref/ovs-actions.7.html#the-group-action)
   for more information.
 * *IN_PORT action*: an action to output the packet to the port on which it was
   received. This is the only standard way to output the packet to the input port.
@@ -373,11 +373,11 @@ specific to conntrack and has less overhead.
 
 After invoking the ct action, packets will be in the "tracked" (`trk`) state and
 all [connection tracking
-fields](http://www.openvswitch.org//support/dist-docs/ovs-fields.7.txt) will be
+fields](https://www.openvswitch.org/support/dist-docs/ovs-fields.7.txt) will be
 set to the correct value. Packets will then move on to [ConntrackStateTable].
 
 Refer to [this
-document](http://docs.openvswitch.org/en/latest/tutorials/ovs-conntrack/) for
+document](https://docs.openvswitch.org/en/latest/tutorials/ovs-conntrack.html) for
 more information on connection tracking in OVS.
 
 ### ConntrackStateTable (31)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -54,7 +54,7 @@ should work with Antrea, starting with version 7.4.
 
 In case a node does not have a supported OVS module installed,
 you can install it following the instructions at:
-[Installing Open vSwitch](https://docs.openvswitch.org/en/latest/intro/install).
+[Installing Open vSwitch](https://docs.openvswitch.org/en/latest/intro/install/index.html).
 Please be aware that the `vport-stt` module is not in the Linux tree and needs to be
 built from source, please build and load it manually before STT tunneling is enabled.
 

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -74,7 +74,7 @@ the Windows Nodes in the demo.
   capabilities required by Hyper-V, you could try the workaround
   described in the [Known issues](#Known-issues) section.
 * Install [Docker](https://docs.microsoft.com/en-us/virtualization/windowscontainers/quick-start/set-up-environment?tabs=Windows-Server).
-* [Install OVS](http://docs.openvswitch.org/en/latest/intro/install/windows/)
+* [Install OVS](https://docs.openvswitch.org/en/latest/intro/install/windows.html)
   and configure the daemons as Windows service.
   - The kernel driver of OVS should be [signed by Windows Hardware Dev Center](https://docs.microsoft.com/en-us/windows-hardware/drivers/install/driver-signing).
   - If OVS driver is not signed, please refer to the Windows doc about how to

--- a/pkg/agent/openflow/meters_linux.go
+++ b/pkg/agent/openflow/meters_linux.go
@@ -26,7 +26,7 @@ import (
 
 func ovsMetersAreSupported() bool {
 	// According to the OVS documentation, meters are supported in the kernel module since 4.15
-	// (https://docs.openvswitch.org/en/latest/faq/releases/). However, it turns out that
+	// (https://docs.openvswitch.org/en/latest/faq/releases.html). However, it turns out that
 	// because of a bug meters cannot be used with kernel versions older than 4.18, which is
 	// when this patch was merged: https://github.com/torvalds/linux/commit/25432eba9cd.
 	// To avoid increasing the minimum required kernel version for Antrea, we will avoid using


### PR DESCRIPTION
It seems that OVS has changed how its website is generated, and we are left with a lot of dead links in the documentation.

See https://github.com/openvswitch/ovs-issues/issues/310