### PR TITLE
Clean up unit tests for Openflow client in Agent

### DIFF
--- a/pkg/agent/openflow/pipeline_test.go
+++ b/pkg/agent/openflow/pipeline_test.go
@@ -218,13 +218,10 @@ func Test_client_defaultFlows(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.requireMeterSupport && !OVSMetersAreSupported() {
-				t.Skipf("Skip test because OVS meters are not supported")
-			}
 			ctrl := gomock.NewController(t)
 			m := oftest.NewMockOFEntryOperations(ctrl)
-
-			fc := newFakeClient(m, tc.enableIPv4, tc.enableIPv6, tc.nodeType, tc.trafficEncapMode, tc.clientOptions...)
+			options := append(tc.clientOptions, setEnableOVSMeters(tc.requireMeterSupport))
+			fc := newFakeClient(m, tc.enableIPv4, tc.enableIPv6, tc.nodeType, tc.trafficEncapMode, options...)
 			defer resetPipelines()
 
 			assert.ElementsMatch(t, tc.expectedFlows, getFlowStrings(fc.defaultFlows()))


### PR DESCRIPTION
* There is no reason for unit tests to depend on OVSMetersAreSupported() (which is platform-dependent), we can just set the client's ovsMetersAreSupported field to the desired value.
* Run some tests in both configurations (meters supported / unsupported) regardless of platform support. Tests that require Egress traffic shaping are wlays run with ovsMetersAreSupported set to true.
* Add ability to provide a mock OF bridge when creating the test client.