### PR TITLE
Use Windows nanoserver to build image antrea/windows-ovs

### DIFF
--- a/build/images/ovs/Dockerfile.windows
+++ b/build/images/ovs/Dockerfile.windows
@@ -14,12 +14,9 @@
 
 ARG NANOSERVER_VERSION
 
-FROM mcr.microsoft.com/windows/servercore:${NANOSERVER_VERSION} as windows-ovs
+FROM mcr.microsoft.com/windows/servercore:${NANOSERVER_VERSION} as ovs-base
 
 ARG WIN_OVS_VERSION
-
-# Switch to a privileged user
-USER ContainerAdministrator
 
 # Sets the shell to be PowerShell 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
@@ -29,19 +26,28 @@ ENV WIN_OVS_VERSION ${WIN_OVS_VERSION}
 # Install VC for ovs
 RUN curl.exe -Lo C:\vc_redist.x64.exe https://aka.ms/vs/17/release/vc_redist.x64.exe; \
     Start-Process -FilePath C:\vc_redist.x64.exe -ArgumentList ‘/install’,’/quiet’,’/norestart’ -Verb RunAs -Wait; \
-    rm C:\vc_redist.x64.exe
+    rm C:\vc_redist.x64.exe;
 
 # Download and extract OVS
 RUN curl.exe -fLo C:\ovs-${env:WIN_OVS_VERSION}-antrea.0-win64.zip https://downloads.antrea.io/ovs/ovs-${env:WIN_OVS_VERSION}-antrea.0-win64.zip; \
-    Expand-Archive C:\ovs-${env:WIN_OVS_VERSION}-antrea.0-win64.zip -DestinationPath C:\  ; \
-    rm C:\ovs-${env:WIN_OVS_VERSION}-antrea.0-win64.zip
+    Expand-Archive C:\ovs-${env:WIN_OVS_VERSION}-antrea.0-win64.zip -DestinationPath C:\; \
+    rm C:\ovs-${env:WIN_OVS_VERSION}-antrea.0-win64.zip;
 
 # Download, extract OpenSSL and copy libraries
 RUN curl.exe -Lo C:\openssl-1.0.2u-x64_86-win64.zip https://indy.fulgan.com/SSL/openssl-1.0.2u-x64_86-win64.zip; \
-    Expand-Archive C:\openssl-1.0.2u-x64_86-win64.zip -DestinationPath C:\openssl  ;  \
-    Move-Item -Path 'C:\openssl\libeay32.dll', 'C:\openssl\ssleay32.dll' -Destination 'C:\Windows\System32\' ; \
-    Remove-Item -Path 'C:\openssl-1.0.2u-x64_86-win64.zip' ;\
-    Remove-Item -Path 'C:\openssl' -Recurse -Force
+    Expand-Archive C:\openssl-1.0.2u-x64_86-win64.zip -DestinationPath C:\openssl; \
+    Remove-Item -Path 'C:\openssl-1.0.2u-x64_86-win64.zip';
 
+FROM mcr.microsoft.com/powershell:lts-nanoserver-${NANOSERVER_VERSION} as windows-ovs
 SHELL ["cmd", "/S", "/C"]
+
+# Switch to a privileged user
+USER ContainerAdministrator
+
+COPY --from=ovs-base /Windows/System32/vcruntime140.dll /Windows/System32/
+COPY --from=ovs-base /openssl/libeay32.dll /Windows/System32/
+COPY --from=ovs-base /openssl/ssleay32.dll /Windows/System32/
+
+COPY --from=ovs-base /openvswitch /openvswitch/
+
 RUN setx /m PATH "C:/openvswitch/usr/bin;C:/openvswitch/usr/sbin;%PATH%"


### PR DESCRIPTION
Use mcr.microsoft.com/powershell::lts-nanoserver-$nanoserver-version as the basic image to build OVS packages. The antrea/windows-ovs image size is reduced from 4.6GB to 596MB.

Fix: #5113 