### PR TITLE
Remove saved ClusterSet from Multi-cluster ClusterSet reconciler

### DIFF
--- a/multicluster/cmd/multicluster-controller/leader.go
+++ b/multicluster/cmd/multicluster-controller/leader.go
@@ -85,13 +85,9 @@ func runLeader(o *Options) error {
 			role:      leaderRole},
 		})
 
-	clusterSetReconciler := &leader.LeaderClusterSetReconciler{
-		Client:                   mgrClient,
-		Scheme:                   mgrScheme,
-		StatusManager:            memberClusterStatusManager,
-		ClusterCalimCRDAvailable: o.ClusterCalimCRDAvailable,
-	}
-	if err = clusterSetReconciler.SetupWithManager(mgr); err != nil {
+	clusterSetReconciler := leader.NewLeaderClusterSetReconciler(mgrClient, podNamespace,
+		o.ClusterCalimCRDAvailable, memberClusterStatusManager)
+	if err := clusterSetReconciler.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("error creating ClusterSet controller: %v", err)
 	}
 

--- a/multicluster/controllers/multicluster/member/clusterset_controller.go
+++ b/multicluster/controllers/multicluster/member/clusterset_controller.go
@@ -51,18 +51,17 @@ var getRemoteConfigAndClient = commonarea.GetRemoteConfigAndClient
 // MemberClusterSetReconciler reconciles a ClusterSet object in the member cluster deployment.
 type MemberClusterSetReconciler struct {
 	client.Client
-	Scheme                   *runtime.Scheme
-	Namespace                string
-	ClusterCalimCRDAvailable bool
+	scheme                   *runtime.Scheme
+	namespace                string
+	clusterCalimCRDAvailable bool
 
 	// commonAreaLock protects the access to RemoteCommonArea.
 	commonAreaLock       sync.RWMutex
 	commonAreaCreationCh chan struct{}
 
-	clusterSetConfig *mcv1alpha2.ClusterSet
-	clusterSetID     common.ClusterSetID
-	clusterID        common.ClusterID
-	installedLeader  leaderClusterInfo
+	clusterSetID    common.ClusterSetID
+	clusterID       common.ClusterID
+	installedLeader leaderClusterInfo
 
 	remoteCommonArea             commonarea.RemoteCommonArea
 	enableStretchedNetworkPolicy bool
@@ -77,10 +76,10 @@ func NewMemberClusterSetReconciler(client client.Client,
 ) *MemberClusterSetReconciler {
 	return &MemberClusterSetReconciler{
 		Client:                       client,
-		Scheme:                       scheme,
-		Namespace:                    namespace,
+		scheme:                       scheme,
+		namespace:                    namespace,
 		enableStretchedNetworkPolicy: enableStretchedNetworkPolicy,
-		ClusterCalimCRDAvailable:     clusterCalimCRDAvailable,
+		clusterCalimCRDAvailable:     clusterCalimCRDAvailable,
 		commonAreaCreationCh:         commonAreaCreationCh,
 		clusterID:                    common.InvalidClusterID,
 		clusterSetID:                 common.InvalidClusterSetID,
@@ -125,7 +124,6 @@ func (r *MemberClusterSetReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		clusterSetCreated = r.clusterID != common.ClusterID(clusterSet.Spec.ClusterID) || r.clusterSetID != common.ClusterSetID(clusterSet.Name)
 		leaderChanged := r.installedLeader.clusterID != newLeader.ClusterID || r.installedLeader.serverUrl != newLeader.Server ||
 			r.installedLeader.secretName != newLeader.Secret
-		r.clusterSetConfig = clusterSet.DeepCopy()
 
 		if !leaderChanged && !clusterSetCreated {
 			klog.V(2).InfoS("No change for leader cluster configuration")
@@ -140,7 +138,7 @@ func (r *MemberClusterSetReconciler) Reconcile(ctx context.Context, req ctrl.Req
 				return err
 			}
 
-			r.clusterID, err = common.GetClusterID(r.ClusterCalimCRDAvailable, req, r.Client, clusterSet)
+			r.clusterID, err = common.GetClusterID(r.clusterCalimCRDAvailable, req, r.Client, clusterSet)
 			if err != nil {
 				return err
 			}
@@ -189,11 +187,10 @@ func (r *MemberClusterSetReconciler) cleanUpResources(ctx context.Context) error
 		}
 		r.remoteCommonArea.Stop()
 		r.remoteCommonArea = nil
-		r.clusterSetConfig = nil
 		r.installedLeader = leaderClusterInfo{}
 	}
 
-	if r.clusterID != common.InvalidClusterID || r.clusterSetID != common.InvalidClusterSetID {
+	if r.clusterID != common.InvalidClusterID {
 		klog.InfoS("Clean up all resources created by Antrea Multi-cluster Controller")
 		if err := cleanUpResourcesCreatedByMC(ctx, r.Client); err != nil {
 			return err
@@ -257,14 +254,14 @@ func (r *MemberClusterSetReconciler) createRemoteCommonArea(clusterSet *mcv1alph
 		return err
 	}
 
-	config, remoteCommonAreaMgr, remoteClient, err := getRemoteConfigAndClient(secret, url, clusterID, clusterSet, r.Scheme)
+	config, remoteCommonAreaMgr, remoteClient, err := getRemoteConfigAndClient(secret, url, clusterID, clusterSet, r.scheme)
 	if err != nil {
 		return err
 	}
 
 	remoteNamespace := clusterSet.Spec.Namespace
 	r.remoteCommonArea, err = commonarea.NewRemoteCommonArea(clusterID, r.clusterSetID, r.clusterID,
-		remoteCommonAreaMgr, remoteClient, r.Scheme, r.Client, remoteNamespace, r.Namespace,
+		remoteCommonAreaMgr, remoteClient, r.scheme, r.Client, remoteNamespace, r.namespace,
 		config, r.enableStretchedNetworkPolicy)
 	if err != nil {
 		klog.ErrorS(err, "Unable to create RemoteCommonArea", "cluster", clusterID)
@@ -278,7 +275,7 @@ func (r *MemberClusterSetReconciler) createRemoteCommonArea(clusterSet *mcv1alph
 		remoteCommonAreaMgr.GetScheme(),
 		r.Client,
 		string(r.clusterID),
-		r.Namespace,
+		r.namespace,
 		r.remoteCommonArea,
 	)
 	r.remoteCommonArea.AddImportReconciler(resImportReconciler)
@@ -328,13 +325,26 @@ func (r *MemberClusterSetReconciler) getSecretForLeader(secretName string, secre
 }
 
 func (r *MemberClusterSetReconciler) updateStatus() {
-	if r.clusterSetConfig == nil {
+	if r.clusterID == common.InvalidClusterID {
 		// Nothing to do.
 		return
 	}
 
+	namespacedName := types.NamespacedName{
+		Namespace: r.namespace,
+		Name:      string(r.clusterSetID),
+	}
+	clusterSet := &mcv1alpha2.ClusterSet{}
+	err := r.Get(context.TODO(), namespacedName, clusterSet)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			klog.ErrorS(err, "Failed to get ClusterSet", "name", namespacedName)
+		}
+		return
+	}
+
 	status := mcv1alpha2.ClusterSetStatus{}
-	status.ObservedGeneration = r.clusterSetConfig.Generation
+	status.ObservedGeneration = clusterSet.Generation
 	status.ClusterStatuses = []mcv1alpha2.ClusterStatus{}
 	r.commonAreaLock.RLock()
 	if r.remoteCommonArea != nil {
@@ -390,18 +400,6 @@ func (r *MemberClusterSetReconciler) updateStatus() {
 	status.TotalClusters = 1
 	status.ReadyClusters = int32(readyClusters)
 
-	namespacedName := types.NamespacedName{
-		Namespace: r.clusterSetConfig.Namespace,
-		Name:      r.clusterSetConfig.Name,
-	}
-	clusterSet := &mcv1alpha2.ClusterSet{}
-	err := r.Get(context.TODO(), namespacedName, clusterSet)
-	if err != nil {
-		if !apierrors.IsNotFound(err) {
-			klog.ErrorS(err, "Failed to read ClusterSet", "name", namespacedName)
-		}
-		return
-	}
 	status.Conditions = clusterSet.Status.Conditions
 	if (len(clusterSet.Status.Conditions) == 1 && clusterSet.Status.Conditions[0].Status != overallCondition.Status) ||
 		len(clusterSet.Status.Conditions) == 0 {

--- a/multicluster/controllers/multicluster/member/clusterset_controller_test.go
+++ b/multicluster/controllers/multicluster/member/clusterset_controller_test.go
@@ -170,9 +170,9 @@ func TestMemberClusterStatus(t *testing.T) {
 			reconciler := MemberClusterSetReconciler{
 				Client:           fakeClient,
 				remoteCommonArea: commonArea,
-				clusterSetConfig: existingClusterSet,
 				clusterSetID:     "clusterset1",
 				clusterID:        "east",
+				namespace:        "mcs1",
 			}
 			reconciler.updateStatus()
 			clusterSet := &mcv1alpha2.ClusterSet{}
@@ -236,7 +236,6 @@ func TestMemberCreateOrUpdateRemoteCommonArea(t *testing.T) {
 	reconciler := MemberClusterSetReconciler{
 		Client:                       fakeClient,
 		remoteCommonArea:             commonArea,
-		clusterSetConfig:             existingClusterSet,
 		clusterSetID:                 "clusterset1",
 		clusterID:                    "east",
 		enableStretchedNetworkPolicy: true,
@@ -310,7 +309,7 @@ func TestMemberClusterSetAddWithoutClusterID(t *testing.T) {
 
 			reconciler := MemberClusterSetReconciler{
 				Client:                   fakeClient,
-				ClusterCalimCRDAvailable: true,
+				clusterCalimCRDAvailable: true,
 				commonAreaCreationCh:     make(chan struct{}),
 			}
 			go func() {


### PR DESCRIPTION
The ClusterSet resource saved in the leader and member ClusterSet reconcilers is not really useful. This commit removes this field from the reconcilers and uses other fields to read ClusterSet information instead.