### PR TITLE
Add a script for drafting release

### DIFF
--- a/docs/maintainers/release.md
+++ b/docs/maintainers/release.md
@@ -56,11 +56,14 @@ release. We use `<TAG>` as a placeholder for the release tag (e.g. `v1.4.0`).
 
 5. Make the release on Github **with the release branch as the target** and copy
    the relevant section of the CHANGELOG as the release description (make sure
-   all the markdown links work). You typically should **not** be checking the
-   `Set as a pre-release` box. This would only be necessary for a release
-   candidate (e.g., `<TAG>` is `1.4.0-rc.1`), which we do not have at the
-   moment. There is no need to upload any assets as this will be done
-   automatically by a Github workflow, after you create the release.
+   all the markdown links work). The
+   [draft-release.sh](../../hack/release/draft-release.sh) script can
+   be used to create the release draft. Use `draft-release.sh -h` to get the
+   usage. You typically should **not** be checking the `Set as a pre-release`
+   box. This would only be necessary for a release candidate (e.g., `<TAG>` is
+   `1.4.0-rc.1`), which we do not have at the moment. There is no need to upload
+   any assets as this will be done automatically by a Github workflow, after you
+   create the release.
    - the `Set as the latest release` box is checked by default. **If you are
      creating a patch release for an older minor version of Antrea, you should
      uncheck the box.**

--- a/hack/release/draft-release.sh
+++ b/hack/release/draft-release.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 Antrea Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+function echoerr {
+    >&2 echo "$@"
+}
+
+_usage="Usage: $0 --release <RELEASE> [--latest]
+Draft the release in Github.
+
+Examples:
+  $0 --release 1.14.0 --latest      # Draft a release for v1.14.0 and force mark it as the latest release.
+  $0 --release 1.13.2               # Draft a release for v1.13.2 and mark it as the latest release based on date and version.
+
+Options:
+        --release <RELEASE>        The release to generate.
+        --latest                   Mark this release as \"Latest\" (default: automatic based on date and version)."
+
+function print_usage {
+  echoerr "$_usage"
+}
+
+if ! command -v gh > /dev/null; then
+  echoerr "Can't find 'gh' tool in PATH, please install from https://github.com/cli/cli"
+  exit 1
+fi
+
+repo="antrea-io/antrea"
+release=""
+latest="no"
+
+while [[ $# -gt 0 ]]
+do
+key="$1"
+
+case $key in
+  --release)
+  release="$2"
+  shift 2
+  ;;
+  --latest)
+  latest="yes"
+  shift
+  ;;
+  -h|--help)
+  print_usage
+  exit 0
+  ;;
+  *)    # unknown option
+  echoerr "Unknown option $1"
+  exit 1
+  ;;
+esac
+done
+
+if [ "$release" == "" ]; then
+  echoerr "--release must be set"
+  exit 1
+fi
+
+if [[ ! "$release" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echoerr "release must follow semantic versioning, e.g. v1.13.2, 1.14.0"
+  exit 1
+fi
+
+# Remove the first "v" if there is one.
+release="${release#v}"
+
+major_minor_number="${release%.*}"
+branch="release-${major_minor_number}"
+tag="v${release}"
+title="Release $tag"
+changelog_url="https://github.com/$repo/raw/$branch/CHANGELOG/CHANGELOG-${major_minor_number}.md"
+
+echo "+++ Downloading changelog..."
+# Get the changelog and make it github friendly.
+# In particular, we remove links for authors to make github include a "Contributors" section with an avatar list of all
+# the mentioned authors.
+changelog=$(curl -sL "$changelog_url" |
+  awk "/## ${release}/{ p = 1; next } /## [0-9]/{ p = 0 } p" | # Get the section of the target release.
+  awk 'NF {p=1} p' |            # Exclude the first blank line.
+  sed '/^\[@.*\]:/d' |          # Delete the author links.
+  sed 's/\[\(@[^]]*\)\]/\1/g')  # Delete the square brackets of author names.
+
+if [ -z "$changelog" ]; then
+  echoerr "changelog is empty, has the changelog of $tag been committed?"
+  exit 1
+fi
+
+echo "+++ Please review the following release information:"
+echo "Title:  $title"
+echo "Repo:   $repo"
+echo "Branch: $branch"
+echo "Tag:    $tag"
+echo "Notes:"
+echo "$changelog"
+echo
+echo "+++ I'm about to create a release draft on GitHub with the above information."
+read -p "+++ Proceed (anything but 'y' aborts the release)? [y/n] " -r
+if ! [[ "${REPLY}" =~ ^[yY]$ ]]; then
+  echo "Aborting." >&2
+  exit 1
+fi
+
+args=""
+
+if [ "$latest" == "yes" ]; then
+  args="${args} --latest"
+fi
+
+url=$(gh release create "$tag" --draft --repo "$repo" --target "$branch" --title "$title" --notes "$changelog" $args)
+
+echo "+++ Release draft has been created."
+echo "+++ To proceed to the release, open the URL:"
+echo ""
+echo "$url"

--- a/hack/release/prepare-changelog.sh
+++ b/hack/release/prepare-changelog.sh
@@ -36,7 +36,7 @@ function print_usage {
 }
 
 if ! command -v gh > /dev/null; then
-  echo "Can't find 'gh' tool in PATH, please install from https://github.com/cli/cli"
+  echoerr "Can't find 'gh' tool in PATH, please install from https://github.com/cli/cli"
   exit 1
 fi
 


### PR DESCRIPTION
Creating releases is an error-prone operation. Instead of relying on people to be meticulous, we can automate the process.

The commit adds a script to draft a release in Github for a given version, based on the changelog. It still leaves the final click to people before it's proven reliable.

To make Github include a "Contributors" section with an avatar list of all the mentioned contributors, the author links are removed.

For #2411

-----
Example of "Contributors" section: https://github.com/antrea-io/antrea/releases/tag/v1.13.2