### PR TITLE
Fix flaky TestRamStoreWatchTimeout in Windows CI

### DIFF
--- a/pkg/apiserver/storage/ram/watch.go
+++ b/pkg/apiserver/storage/ram/watch.go
@@ -17,11 +17,11 @@ package ram
 import (
 	"context"
 	"sync"
-	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/clock"
 
 	"antrea.io/antrea/pkg/apiserver/storage"
 )
@@ -81,7 +81,7 @@ func (w *storeWatcher) nonBlockingAdd(event storage.InternalEvent) bool {
 // add tries to send event to channel input. It will first use non blocking
 // way, then block until the provided timer fires, if the timer is not nil.
 // It returns true if successful, otherwise false.
-func (w *storeWatcher) add(event storage.InternalEvent, timer *time.Timer) bool {
+func (w *storeWatcher) add(event storage.InternalEvent, timer clock.Timer) bool {
 	// Try to send the event without blocking regardless of timer is fired or not.
 	// This gives the watcher a chance when other watchers exhaust the time slices.
 	if w.nonBlockingAdd(event) {
@@ -95,7 +95,7 @@ func (w *storeWatcher) add(event storage.InternalEvent, timer *time.Timer) bool 
 	select {
 	case w.input <- event:
 		return true
-	case <-timer.C:
+	case <-timer.C():
 		return false
 	}
 }

--- a/pkg/apiserver/storage/ram/watch_test.go
+++ b/pkg/apiserver/storage/ram/watch_test.go
@@ -18,12 +18,12 @@ import (
 	"context"
 	"reflect"
 	"testing"
-	"time"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/utils/clock"
 
 	"antrea.io/antrea/pkg/apiserver/storage"
 )
@@ -182,12 +182,13 @@ func TestAddTimeout(t *testing.T) {
 			ResourceVersion: 2,
 		},
 	}
-	timer := time.NewTimer(watcherAddTimeout)
+	clock := clock.RealClock{}
+	timer := clock.NewTimer(watcherAddTimeout)
 	if !w.add(events[0], timer) {
 		t.Error("add() failed, expected success")
 	}
 	// Since channel size is 1 and there's no consumer, the second add should fail.
-	timer = time.NewTimer(watcherAddTimeout)
+	timer = clock.NewTimer(watcherAddTimeout)
 	if w.add(events[1], timer) {
 		t.Error("add() succeeded, expected failure")
 	}


### PR DESCRIPTION
We refactor the test to use a virtual clock. The modified test still validates that watcherAddTimeout is enforced correctly. The new version of the test also completes faster (<100ms instead of >500ms).

Fixes #5648