### PR TITLE
Add support for NodeNetworkPolicy datapath

### DIFF
--- a/build/charts/antrea/conf/antrea-agent.conf
+++ b/build/charts/antrea/conf/antrea-agent.conf
@@ -82,6 +82,9 @@ featureGates:
 # Allow users to allocate Egress IPs from a different subnet from the default Node subnet.
 {{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "EgressSeparateSubnet" "default" false) }}
 
+# Allow users to apply ClusterNetworkPolicy to Kubernetes Nodes.
+{{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "NodeNetworkPolicy" "default" false) }}
+
 # Name of the OpenVSwitch bridge antrea-agent will create and use.
 # Make sure it doesn't conflict with your existing OpenVSwitch bridges.
 ovsBridge: {{ .Values.ovs.bridgeName | quote }}

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -5625,6 +5625,9 @@ data:
     # Allow users to allocate Egress IPs from a different subnet from the default Node subnet.
     #  EgressSeparateSubnet: false
 
+    # Allow users to apply ClusterNetworkPolicy to Kubernetes Nodes.
+    #  NodeNetworkPolicy: false
+
     # Name of the OpenVSwitch bridge antrea-agent will create and use.
     # Make sure it doesn't conflict with your existing OpenVSwitch bridges.
     ovsBridge: "br-int"
@@ -6925,7 +6928,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: fe9081d7718e258905728726bb8f3a8d42a332d7f4e0d8faaa9731b3c4b51aa4
+        checksum/config: f4ad8910666191c02982d1b7b202e3c4bd20fb4a8179dcb5696119f3b1490a72
       labels:
         app: antrea
         component: antrea-agent
@@ -7163,7 +7166,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: fe9081d7718e258905728726bb8f3a8d42a332d7f4e0d8faaa9731b3c4b51aa4
+        checksum/config: f4ad8910666191c02982d1b7b202e3c4bd20fb4a8179dcb5696119f3b1490a72
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -5625,6 +5625,9 @@ data:
     # Allow users to allocate Egress IPs from a different subnet from the default Node subnet.
     #  EgressSeparateSubnet: false
 
+    # Allow users to apply ClusterNetworkPolicy to Kubernetes Nodes.
+    #  NodeNetworkPolicy: false
+
     # Name of the OpenVSwitch bridge antrea-agent will create and use.
     # Make sure it doesn't conflict with your existing OpenVSwitch bridges.
     ovsBridge: "br-int"
@@ -6925,7 +6928,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: fe9081d7718e258905728726bb8f3a8d42a332d7f4e0d8faaa9731b3c4b51aa4
+        checksum/config: f4ad8910666191c02982d1b7b202e3c4bd20fb4a8179dcb5696119f3b1490a72
       labels:
         app: antrea
         component: antrea-agent
@@ -7164,7 +7167,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: fe9081d7718e258905728726bb8f3a8d42a332d7f4e0d8faaa9731b3c4b51aa4
+        checksum/config: f4ad8910666191c02982d1b7b202e3c4bd20fb4a8179dcb5696119f3b1490a72
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -5625,6 +5625,9 @@ data:
     # Allow users to allocate Egress IPs from a different subnet from the default Node subnet.
     #  EgressSeparateSubnet: false
 
+    # Allow users to apply ClusterNetworkPolicy to Kubernetes Nodes.
+    #  NodeNetworkPolicy: false
+
     # Name of the OpenVSwitch bridge antrea-agent will create and use.
     # Make sure it doesn't conflict with your existing OpenVSwitch bridges.
     ovsBridge: "br-int"
@@ -6925,7 +6928,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 997259cac105a193d671880b165e203a9954f33009766df5eceed753509c46b9
+        checksum/config: a54768c79d693083be554386f268c93bbbd0fdf5b334edd9aff31c13151c4e29
       labels:
         app: antrea
         component: antrea-agent
@@ -7161,7 +7164,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 997259cac105a193d671880b165e203a9954f33009766df5eceed753509c46b9
+        checksum/config: a54768c79d693083be554386f268c93bbbd0fdf5b334edd9aff31c13151c4e29
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -5638,6 +5638,9 @@ data:
     # Allow users to allocate Egress IPs from a different subnet from the default Node subnet.
     #  EgressSeparateSubnet: false
 
+    # Allow users to apply ClusterNetworkPolicy to Kubernetes Nodes.
+    #  NodeNetworkPolicy: false
+
     # Name of the OpenVSwitch bridge antrea-agent will create and use.
     # Make sure it doesn't conflict with your existing OpenVSwitch bridges.
     ovsBridge: "br-int"
@@ -6938,7 +6941,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 4364ee1520a24d9a465a405536736498119269c0fc81d4dc01e83d7fdd462913
+        checksum/config: 7ce7d85bc08079d1cef3b1d44f31e2139961f9ae49f71d79ff3b28e7e9ad6325
         checksum/ipsec-secret: d0eb9c52d0cd4311b6d252a951126bf9bea27ec05590bed8a394f0f792dcb2a4
       labels:
         app: antrea
@@ -7220,7 +7223,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 4364ee1520a24d9a465a405536736498119269c0fc81d4dc01e83d7fdd462913
+        checksum/config: 7ce7d85bc08079d1cef3b1d44f31e2139961f9ae49f71d79ff3b28e7e9ad6325
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -5625,6 +5625,9 @@ data:
     # Allow users to allocate Egress IPs from a different subnet from the default Node subnet.
     #  EgressSeparateSubnet: false
 
+    # Allow users to apply ClusterNetworkPolicy to Kubernetes Nodes.
+    #  NodeNetworkPolicy: false
+
     # Name of the OpenVSwitch bridge antrea-agent will create and use.
     # Make sure it doesn't conflict with your existing OpenVSwitch bridges.
     ovsBridge: "br-int"
@@ -6925,7 +6928,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: d8e5dd6cc4bd55eeba224229fd8207045291ab3dfafe5f3c3e100c31003d2887
+        checksum/config: 290f0c748863a7dad1e9d53d62c74f8108a44c5cc803306d351c108062cc1378
       labels:
         app: antrea
         component: antrea-agent
@@ -7161,7 +7164,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: d8e5dd6cc4bd55eeba224229fd8207045291ab3dfafe5f3c3e100c31003d2887
+        checksum/config: 290f0c748863a7dad1e9d53d62c74f8108a44c5cc803306d351c108062cc1378
       labels:
         app: antrea
         component: antrea-controller

--- a/docs/antrea-network-policy.md
+++ b/docs/antrea-network-policy.md
@@ -20,6 +20,7 @@
     - [ACNP for IGMP traffic](#acnp-for-igmp-traffic)
     - [ACNP for multicast egress traffic](#acnp-for-multicast-egress-traffic)
     - [ACNP for HTTP traffic](#acnp-for-http-traffic)
+    - [ACNP for Kubernetes Node traffic](#acnp-for-kubernetes-node-traffic)
     - [ACNP with log settings](#acnp-with-log-settings)
   - [Behavior of <em>to</em> and <em>from</em> selectors](#behavior-of-to-and-from-selectors)
   - [Key differences from K8s NetworkPolicy](#key-differences-from-k8s-networkpolicy)
@@ -523,6 +524,56 @@ spec:
 ```
 
 Please refer to [Antrea Layer 7 NetworkPolicy](antrea-l7-network-policy.md) for extra information.
+
+#### ACNP for Kubernetes Node traffic
+
+```yaml
+apiVersion: crd.antrea.io/v1beta1
+kind: ClusterNetworkPolicy
+metadata:
+  name: acnp-node-egress-traffic-drop
+spec:
+  priority: 5
+  tier: securityops
+  appliedTo:
+    - nodeSelector:
+        matchLabels:
+          kubernetes.io/os: linux
+  egress:
+    - action: Drop
+      to:
+        - ipBlock:                 
+            cidr: 192.168.1.0/24
+      ports:
+        - protocol: TCP
+          port: 80
+      name: dropHTTPTrafficToCIDR
+```
+
+```yaml
+apiVersion: crd.antrea.io/v1beta1
+kind: ClusterNetworkPolicy
+metadata:
+  name: acnp-node-ingress-traffic-drop
+spec:
+  priority: 5
+  tier: securityops
+  appliedTo:
+    - nodeSelector:
+        matchLabels:
+          kubernetes.io/os: linux
+  ingress:
+    - action: Drop
+      from:
+        - ipBlock:
+            cidr: 192.168.1.0/24
+      ports:
+        - protocol: TCP
+          port: 22
+      name: dropSSHTrafficFromCIDR
+```
+
+Please refer to [Antrea Node NetworkPolicy](antrea-node-network-policy.md) for more information.
 
 #### ACNP with log settings
 

--- a/docs/antrea-node-network-policy.md
+++ b/docs/antrea-node-network-policy.md
@@ -1,0 +1,116 @@
+# Antrea Node NetworkPolicy
+
+## Table of Contents
+
+<!-- toc -->
+- [Introduction](#introduction)
+- [Prerequisites](#prerequisites)
+- [Usage](#usage)
+- [Limitations](#limitations)
+<!-- /toc -->
+
+## Introduction
+
+Node NetworkPolicy is designed to secure the Kubernetes Nodes traffic. It is supported by Antrea starting with Antrea
+v1.15. This guide demonstrates how to configure Node NetworkPolicy.
+
+## Prerequisites
+
+Node NetworkPolicy was introduced in v1.15 as an alpha feature and is disabled by default. A feature gate,
+`NodeNetworkPolicy`, must be enabled in antrea-agent.conf in the `antrea-config` ConfigMap.
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: antrea-config
+  namespace: kube-system
+data:
+  antrea-agent.conf: |
+    featureGates:
+      NodeNetworkPolicy: true
+```
+
+Alternatively, you can use the following helm installation command to enable the feature gate:
+
+```bash
+helm install antrea antrea/antrea --namespace kube-system --set featureGates.NodeNetworkPolicy=true
+```
+
+## Usage
+
+Node NetworkPolicy is an extension of Antrea ClusterNetworkPolicy (ACNP). By specifying a `nodeSelector` in the
+policy-level `appliedTo` without other selectors, an ACNP is applied to the selected Kubernetes Nodes.
+
+An example Node NetworkPolicy that blocks ingress traffic from Pods with label `app=client` to Nodes with label
+`kubernetes.io/hostname: k8s-node-control-plane`:
+
+```yaml
+apiVersion: crd.antrea.io/v1beta1
+kind: ClusterNetworkPolicy
+metadata:
+  name: ingress-drop-pod-to-node
+spec:
+  priority: 5
+  tier: application
+  appliedTo:
+    - nodeSelector:
+        matchLabels:
+          kubernetes.io/hostname: k8s-node-control-plane
+  ingress:
+    - name: drop-80
+      action: Drop
+      from:
+        - podSelector:
+            matchLabels:
+              app: client
+      ports:
+        - protocol: TCP
+          port: 80
+```
+
+An example Node NetworkPolicy that blocks egress traffic from Nodes with the label
+`kubernetes.io/hostname: k8s-node-control-plane` to Nodes with the label `kubernetes.io/hostname: k8s-node-worker-1`
+and some IP blocks:
+
+```yaml
+apiVersion: crd.antrea.io/v1beta1
+kind: ClusterNetworkPolicy
+metadata:
+  name: egress-drop-node-to-node
+spec:
+  priority: 5
+  tier: application
+  appliedTo:
+    - nodeSelector:
+        matchLabels:
+          kubernetes.io/hostname: k8s-node-control-plane
+  egress:
+    - name: drop-22
+      action: Drop
+      to:
+        - nodeSelector:
+            matchLabels:
+              kubernetes.io/hostname: k8s-node-worker-1
+        - ipBlock:
+            cidr: 192.168.77.0/24
+        - ipBlock:
+            cidr: 10.10.0.0/24
+      ports:
+        - protocol: TCP
+          port: 22
+```
+
+## Limitations
+
+- This feature is currently only supported for Linux Nodes.
+- Be cautious when you configure policies to Nodes, in particular, when configuring a default-deny policy applied to
+  Nodes. You should ensure Kubernetes and Antrea control-plane communication is exempt from the deny rules, otherwise
+  the cluster may go out-of-service and you may lose connectivity to the Nodes.
+- Only ACNPs can be applied to Nodes. ANPs cannot be applied to Nodes.
+- `nodeSelector` can only be specified in the policy-level `appliedTo` field, not in the rule-level `appliedTo`, and not
+  in a `Group` or `ClusterGroup`.
+- ACNPs applied to Nodes cannot be applied to Pods at the same time.
+- FQDN is not supported for ACNPs applied to Nodes.
+- Layer 7 NetworkPolicy is not supported yet.
+- For UDP or SCTP, when the `Reject` action is specified in an egress rule, it behaves identical to the `Drop` action.

--- a/docs/feature-gates.md
+++ b/docs/feature-gates.md
@@ -57,6 +57,7 @@ edit the Agent configuration in the
 | `AdminNetworkPolicy`          | Controller         | `false` | Alpha | v1.13         | N/A          | N/A        | Yes                |                                               |
 | `EgressTrafficShaping`        | Agent              | `false` | Alpha | v1.14         | N/A          | N/A        | Yes                | OVS meters should be supported                |
 | `EgressSeparateSubnet`        | Agent              | `false` | Alpha | v1.15         | N/A          | N/A        | No                 |                                               |
+| `NodeNetworkPolicy`           | Agent              | `false` | Alpha | v1.15         | N/A          | N/A        | Yes                |                                               |
 
 ## Description and Requirements of Features
 
@@ -404,6 +405,14 @@ this [document](antrea-l7-network-policy.md#prerequisites) for more information 
 
 The `AdminNetworkPolicy` API (which currently includes the AdminNetworkPolicy and BaselineAdminNetworkPolicy objects)
 complements the Antrea-native policies and help cluster administrators to set security postures in a portable manner.
+
+### NodeNetworkPolicy
+
+`NodeNetworkPolicy` allows users to apply ClusterNetworkPolicy to Kubernetes Nodes.
+
+#### Requirements for this Feature
+
+This feature is only supported for Linux Nodes at the moment.
 
 ### EgressTrafficShaping
 

--- a/multicluster/test/e2e/antreapolicy_test.go
+++ b/multicluster/test/e2e/antreapolicy_test.go
@@ -73,7 +73,7 @@ func initializeForPolicyTest(t *testing.T, data *MCTestData) {
 		k8sUtils, err := antreae2e.NewKubernetesUtils(&d)
 		failOnError(err, t)
 		if clusterName != leaderCluster {
-			_, err = k8sUtils.Bootstrap(perClusterNamespaces, perNamespacePods, true)
+			_, err = k8sUtils.Bootstrap(perClusterNamespaces, perNamespacePods, true, nil, nil)
 			failOnError(err, t)
 		}
 		clusterK8sUtilsMap[clusterName] = k8sUtils

--- a/pkg/agent/config/node_config.go
+++ b/pkg/agent/config/node_config.go
@@ -50,6 +50,13 @@ const (
 	L7NetworkPolicyReturnPortName = "antrea-l7-tap1"
 )
 
+const (
+	NodeNetworkPolicyIngressRulesChain = "ANTREA-POL-INGRESS-RULES"
+	NodeNetworkPolicyEgressRulesChain  = "ANTREA-POL-EGRESS-RULES"
+
+	NodeNetworkPolicyPrefix = "ANTREA-POL"
+)
+
 var (
 	// VirtualServiceIPv4 or VirtualServiceIPv6 is used in the following scenarios:
 	// - The IP is used to perform SNAT for packets of Service sourced from Antrea gateway and destined for external

--- a/pkg/agent/controller/networkpolicy/cache.go
+++ b/pkg/agent/controller/networkpolicy/cache.go
@@ -182,6 +182,17 @@ func (r *CompletedRule) isIGMPEgressPolicyRule() bool {
 	return false
 }
 
+func (r *CompletedRule) isNodeNetworkPolicyRule() bool {
+	for _, m := range r.TargetMembers {
+		if m.Node != nil {
+			return true
+		} else {
+			return false
+		}
+	}
+	return false
+}
+
 // ruleCache caches Antrea AddressGroups, AppliedToGroups and NetworkPolicies,
 // can construct complete rules that can be used by reconciler to enforce.
 type ruleCache struct {

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
@@ -80,6 +80,7 @@ func newTestController() (*Controller, *fake.Clientset, *mockReconciler) {
 	controller, _ := NewNetworkPolicyController(&antreaClientGetter{clientset},
 		nil,
 		nil,
+		nil,
 		fs,
 		"node1",
 		podUpdateChannel,
@@ -88,6 +89,7 @@ func newTestController() (*Controller, *fake.Clientset, *mockReconciler) {
 		ch2,
 		true,
 		true,
+		false,
 		true,
 		true,
 		false,
@@ -102,7 +104,7 @@ func newTestController() (*Controller, *fake.Clientset, *mockReconciler) {
 		&config.NodeConfig{},
 		wait.NewGroup())
 	reconciler := newMockReconciler()
-	controller.reconciler = reconciler
+	controller.podReconciler = reconciler
 	controller.auditLogger = nil
 	return controller, clientset, reconciler
 }

--- a/pkg/agent/controller/networkpolicy/node_reconciler_linux.go
+++ b/pkg/agent/controller/networkpolicy/node_reconciler_linux.go
@@ -1,0 +1,706 @@
+//go:build linux
+// +build linux
+
+// Copyright 2024 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package networkpolicy
+
+import (
+	"fmt"
+	"net"
+	"sort"
+	"strings"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/klog/v2"
+	utilnet "k8s.io/utils/net"
+
+	"antrea.io/antrea/pkg/agent/config"
+	"antrea.io/antrea/pkg/agent/route"
+	"antrea.io/antrea/pkg/agent/types"
+	"antrea.io/antrea/pkg/agent/util/iptables"
+	"antrea.io/antrea/pkg/apis/controlplane/v1beta2"
+	secv1beta1 "antrea.io/antrea/pkg/apis/crd/v1beta1"
+	"antrea.io/antrea/pkg/util/ip"
+)
+
+const (
+	ipv4Any = "0.0.0.0/0"
+	ipv6Any = "::/0"
+)
+
+/*
+Tips:
+In the following, service describes a port to allow traffic on which is defined in pkg/apis/controlplane/v1beta2/types.go
+
+NodeNetworkPolicy data path implementation using iptables/ip6tables involves four components:
+1. Core iptables rule:
+   - Added to ANTREA-POL-INGRESS-RULES (ingress) or ANTREA-POL-EGRESS-RULES (egress).
+   - Matches an ipset created for the NodeNetworkPolicy rule as source (ingress) or destination (egress) when there are
+     multiple IP addresses; if there is only one address, matches the address directly.
+   - Targets an action (the rule with a single service) or a service chain created for the NodeNetworkPolicy rule (the
+     rule with multiple services).
+2. Service iptables chain:
+   - Created for the NodeNetworkPolicy rule to integrate service iptables rules if a rule has multiple services.
+3. Service iptables rules:
+   - Added to the service chain created for the NodeNetworkPolicy rule.
+   - Constructed from the services of the NodeNetworkPolicy rule.
+4. From/To ipset:
+   - Created for the NodeNetworkPolicy rule, containing all source IP addresses (ingress) or destination IP addresses (egress).
+
+Assuming four ingress NodeNetworkPolicy rules with IDs RULE1, RULE2, RULE3 and RULE4 prioritized in descending order.
+Core iptables rules organized by priorities in ANTREA-POL-INGRESS-RULES like the following.
+
+If the rule has multiple source IP addresses to match, then an ipset will be created for it. The name of the ipset consists
+of prefix "ANTREA-POL", rule ID and IP protocol version.
+
+If the rule has multiple services, an iptables chain and related rules will be created for it. The name the chain consists
+of prefix "ANTREA-POL" and rule ID.
+
+```
+:ANTREA-POL-INGRESS-RULES
+-A ANTREA-POL-INGRESS-RULES -m set --match-set ANTREA-POL-RULE1-4 src -j ANTREA-POL-RULE1 -m comment --comment "Antrea: for rule RULE1, policy AntreaClusterNetworkPolicy:name1"
+-A ANTREA-POL-INGRESS-RULES -m set --match-set ANTREA-POL-RULE2-4 src -p tcp --dport 8080 -j ACCEPT -m comment --comment "Antrea: for rule RULE2, policy AntreaClusterNetworkPolicy:name2"
+-A ANTREA-POL-INGRESS-RULES -s 3.3.3.3/32 src -j ANTREA-POL-RULE3 -m comment --comment "Antrea: for rule RULE3, policy AntreaClusterNetworkPolicy:name3"
+-A ANTREA-POL-INGRESS-RULES -s 4.4.4.4/32 -p tcp --dport 80 -j ACCEPT -m comment --comment "Antrea: for rule RULE4, policy AntreaClusterNetworkPolicy:name4"
+```
+
+For the first rule, it has multiple services and multiple source IP addresses to match, so there will be service iptables chain
+and service iptables rules and ipset created for it.
+
+The iptables chain is like the following:
+
+```
+:ANTREA-POL-RULE1
+-A ANTREA-POL-RULE1 -j ACCEPT -p tcp --dport 80
+-A ANTREA-POL-RULE1 -j ACCEPT -p tcp --dport 443
+```
+
+The ipset is like the following:
+
+```
+Name: ANTREA-POL-RULE1-4
+Type: hash:net
+Revision: 6
+Header: family inet hashsize 1024 maxelem 65536
+Size in memory: 472
+References: 1
+Number of entries: 2
+Members:
+1.1.1.1
+1.1.1.2
+```
+
+For the second rule, it has only one service, so there will be no service iptables chain and service iptables rules created
+for it. The core rule will match the service and target the action directly. The rule has multiple source IP addresses to
+match, so there will be an ipset `ANTREA-POL-RULE2-4` created for it.
+
+For the third rule, it has multiple services to match, so there will be service iptables chain and service iptables rules
+created for it. The rule has only one source IP address to match, so there will be no ipset created for it and just match
+the source IP address directly.
+
+For the fourth rule, it has only one service and one source IP address to match, so there will be no service iptables chain
+and service iptables rules created for it. The core rule will match the service and source IP address and target the action
+directly.
+*/
+
+// coreIPTRule is a struct to store the information of a core iptables rule.
+type coreIPTRule struct {
+	ruleID   string
+	priority *types.Priority
+	ruleStr  string
+}
+
+type chainKey struct {
+	name   string
+	isIPv6 bool
+}
+
+func newChainKey(name string, isIPv6 bool) chainKey {
+	return chainKey{
+		name:   name,
+		isIPv6: isIPv6,
+	}
+}
+
+// coreIPTChain caches the sorted iptables rules for a chain where core iptables rules are installed.
+type coreIPTChain struct {
+	rules []*coreIPTRule
+	sync.Mutex
+}
+
+func newCoreIPTChain() *coreIPTChain {
+	return &coreIPTChain{}
+}
+
+// nodePolicyLastRealized is the struct cached by nodeReconciler. It's used to track the actual state of iptables rules
+// and chains we have enforced, so that we can know how to reconcile a rule when it's updated/removed.
+type nodePolicyLastRealized struct {
+	// ipsets tracks the last realized ipset names used in core iptables rules. It cannot coexist with ipnets.
+	ipsets map[iptables.Protocol]string
+	// ipnets tracks the last realized ip nets used in core iptables rules. It cannot coexist with ipsets.
+	ipnets map[iptables.Protocol]string
+	// serviceIPTChain tracks the last realized service iptables chain if a rule has multiple services.
+	serviceIPTChain string
+	// coreIPTChain tracks the last realized iptables chain where the core iptables rule is installed.
+	coreIPTChain string
+}
+
+func newNodePolicyLastRealized() *nodePolicyLastRealized {
+	return &nodePolicyLastRealized{
+		ipsets: make(map[iptables.Protocol]string),
+		ipnets: make(map[iptables.Protocol]string),
+	}
+}
+
+type nodeReconciler struct {
+	ipProtocols   []iptables.Protocol
+	routeClient   route.Interface
+	coreIPTChains map[chainKey]*coreIPTChain
+	// lastRealizeds caches the last realized rules. It's a mapping from ruleID to *nodePolicyLastRealized.
+	lastRealizeds sync.Map
+}
+
+func newNodeReconciler(routeClient route.Interface, ipv4Enabled, ipv6Enabled bool) *nodeReconciler {
+	var ipProtocols []iptables.Protocol
+	coreIPTChains := make(map[chainKey]*coreIPTChain)
+
+	if ipv4Enabled {
+		ipProtocols = append(ipProtocols, iptables.ProtocolIPv4)
+		coreIPTChains[newChainKey(config.NodeNetworkPolicyIngressRulesChain, false)] = newCoreIPTChain()
+		coreIPTChains[newChainKey(config.NodeNetworkPolicyEgressRulesChain, false)] = newCoreIPTChain()
+	}
+	if ipv6Enabled {
+		ipProtocols = append(ipProtocols, iptables.ProtocolIPv6)
+		coreIPTChains[newChainKey(config.NodeNetworkPolicyIngressRulesChain, true)] = newCoreIPTChain()
+		coreIPTChains[newChainKey(config.NodeNetworkPolicyEgressRulesChain, true)] = newCoreIPTChain()
+	}
+
+	return &nodeReconciler{
+		ipProtocols:   ipProtocols,
+		routeClient:   routeClient,
+		coreIPTChains: coreIPTChains,
+	}
+}
+
+// Reconcile checks whether the provided rule has been enforced or not, and invoke the add or update method accordingly.
+func (r *nodeReconciler) Reconcile(rule *CompletedRule) error {
+	klog.InfoS("Reconciling Node NetworkPolicy rule", "rule", rule.ID, "policy", rule.SourceRef.ToString())
+
+	value, exists := r.lastRealizeds.Load(rule.ID)
+	var err error
+	if !exists {
+		err = r.add(rule)
+	} else {
+		err = r.update(value.(*nodePolicyLastRealized), rule)
+	}
+	return err
+}
+
+func (r *nodeReconciler) RunIDAllocatorWorker(stopCh <-chan struct{}) {
+
+}
+
+func (r *nodeReconciler) BatchReconcile(rules []*CompletedRule) error {
+	var rulesToInstall []*CompletedRule
+	for _, rule := range rules {
+		if _, exists := r.lastRealizeds.Load(rule.ID); exists {
+			klog.ErrorS(nil, "Rule should not have been realized yet: initialization phase", "rule", rule.ID)
+		} else {
+			rulesToInstall = append(rulesToInstall, rule)
+		}
+	}
+	if err := r.batchAdd(rulesToInstall); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *nodeReconciler) batchAdd(rules []*CompletedRule) error {
+	lastRealizeds := make(map[string]*nodePolicyLastRealized)
+	serviceIPTChains := make(map[iptables.Protocol][]string)
+	serviceIPTRules := make(map[iptables.Protocol][][]string)
+	ingressCoreIPTRules := make(map[iptables.Protocol][]*coreIPTRule)
+	egressCoreIPTRules := make(map[iptables.Protocol][]*coreIPTRule)
+
+	for _, rule := range rules {
+		iptRules, lastRealized := r.computeIPTRules(rule)
+		ruleID := rule.ID
+		for ipProtocol, iptRule := range iptRules {
+			// Sync all ipsets.
+			if iptRule.IPSet != "" {
+				if err := r.routeClient.AddOrUpdateNodeNetworkPolicyIPSet(iptRule.IPSet, iptRule.IPSetMembers, iptRule.IsIPv6); err != nil {
+					return err
+				}
+			}
+			// Collect all service iptables rules and chains.
+			if iptRule.ServiceIPTChain != "" {
+				serviceIPTChains[ipProtocol] = append(serviceIPTChains[ipProtocol], iptRule.ServiceIPTChain)
+				serviceIPTRules[ipProtocol] = append(serviceIPTRules[ipProtocol], iptRule.ServiceIPTRules)
+			}
+
+			// Collect all core iptables rules.
+			coreIPTRule := &coreIPTRule{ruleID, iptRule.Priority, iptRule.CoreIPTRule}
+			if rule.Direction == v1beta2.DirectionIn {
+				ingressCoreIPTRules[ipProtocol] = append(ingressCoreIPTRules[ipProtocol], coreIPTRule)
+			} else {
+				egressCoreIPTRules[ipProtocol] = append(egressCoreIPTRules[ipProtocol], coreIPTRule)
+			}
+		}
+		lastRealizeds[ruleID] = lastRealized
+	}
+	for _, ipProtocol := range r.ipProtocols {
+		isIPv6 := iptables.IsIPv6Protocol(ipProtocol)
+		if err := r.routeClient.AddOrUpdateNodeNetworkPolicyIPTables(serviceIPTChains[ipProtocol], serviceIPTRules[ipProtocol], isIPv6); err != nil {
+			return err
+		}
+		if err := r.addOrUpdateCoreIPTRules(config.NodeNetworkPolicyIngressRulesChain, isIPv6, false, ingressCoreIPTRules[ipProtocol]...); err != nil {
+			return err
+		}
+		if err := r.addOrUpdateCoreIPTRules(config.NodeNetworkPolicyEgressRulesChain, isIPv6, false, egressCoreIPTRules[ipProtocol]...); err != nil {
+			return err
+		}
+	}
+
+	for ruleID, lastRealized := range lastRealizeds {
+		r.lastRealizeds.Store(ruleID, lastRealized)
+	}
+	return nil
+}
+
+func (r *nodeReconciler) Forget(ruleID string) error {
+	klog.InfoS("Forgetting rule", "rule", ruleID)
+
+	value, exists := r.lastRealizeds.Load(ruleID)
+	if !exists {
+		return nil
+	}
+
+	lastRealized := value.(*nodePolicyLastRealized)
+	coreIPTChain := lastRealized.coreIPTChain
+
+	for _, ipProtocol := range r.ipProtocols {
+		isIPv6 := iptables.IsIPv6Protocol(ipProtocol)
+		if err := r.deleteCoreIPTRule(ruleID, coreIPTChain, isIPv6); err != nil {
+			return err
+		}
+		if lastRealized.ipsets[ipProtocol] != "" {
+			if err := r.routeClient.DeleteNodeNetworkPolicyIPSet(lastRealized.ipsets[ipProtocol], isIPv6); err != nil {
+				return err
+			}
+		}
+		if lastRealized.serviceIPTChain != "" {
+			if err := r.routeClient.DeleteNodeNetworkPolicyIPTables([]string{lastRealized.serviceIPTChain}, isIPv6); err != nil {
+				return err
+			}
+		}
+	}
+
+	r.lastRealizeds.Delete(ruleID)
+	return nil
+}
+
+func (r *nodeReconciler) GetRuleByFlowID(ruleFlowID uint32) (*types.PolicyRule, bool, error) {
+	return nil, false, nil
+}
+
+func (r *nodeReconciler) computeIPTRules(rule *CompletedRule) (map[iptables.Protocol]*types.NodePolicyRule, *nodePolicyLastRealized) {
+	ruleID := rule.ID
+	lastRealized := newNodePolicyLastRealized()
+	priority := &types.Priority{
+		TierPriority:   *rule.TierPriority,
+		PolicyPriority: *rule.PolicyPriority,
+		RulePriority:   rule.Priority,
+	}
+
+	var serviceIPTChain, serviceIPTRuleTarget, coreIPTRuleTarget string
+	var service *v1beta2.Service
+	if len(rule.Services) > 1 {
+		// If a rule has multiple services, create a chain to install iptables rules for these services, with the target
+		// of the services determined by the rule's action. The core iptables rule should target the chain.
+		serviceIPTChain = fmt.Sprintf("%s-%s", config.NodeNetworkPolicyPrefix, strings.ToUpper(ruleID))
+		serviceIPTRuleTarget = ruleActionToIPTTarget(rule.Action)
+		coreIPTRuleTarget = serviceIPTChain
+		lastRealized.serviceIPTChain = serviceIPTChain
+	} else {
+		// If a rule has no service or a single service, the target is determined by the rule's action, as there is no
+		// need to create a chain for a single-service iptables rule.
+		coreIPTRuleTarget = ruleActionToIPTTarget(rule.Action)
+		// If a rule has a single service, the core iptables rule directly incorporates the service.
+		if len(rule.Services) == 1 {
+			service = &rule.Services[0]
+		}
+	}
+	var coreIPTChain string
+	if rule.Direction == v1beta2.DirectionIn {
+		coreIPTChain = config.NodeNetworkPolicyIngressRulesChain
+	} else {
+		coreIPTChain = config.NodeNetworkPolicyEgressRulesChain
+	}
+	coreIPTRuleComment := fmt.Sprintf("Antrea: for rule %s, policy %s", ruleID, rule.SourceRef.ToString())
+	lastRealized.coreIPTChain = coreIPTChain
+
+	nodePolicyRules := make(map[iptables.Protocol]*types.NodePolicyRule)
+	for _, ipProtocol := range r.ipProtocols {
+		isIPv6 := iptables.IsIPv6Protocol(ipProtocol)
+
+		var serviceIPTRules []string
+		if serviceIPTChain != "" {
+			serviceIPTRules = buildServiceIPTRules(ipProtocol, rule.Services, serviceIPTChain, serviceIPTRuleTarget)
+		}
+
+		ipnets := getIPNetsFromRule(rule, isIPv6)
+		var ipnet string
+		var ipset string
+		if ipnets.Len() > 1 {
+			// If a rule matches multiple source or destination ipnets, create an ipset which contains these ipnets and
+			// use the ipset in core iptables rule.
+			suffix := "4"
+			if isIPv6 {
+				suffix = "6"
+			}
+			ipset = fmt.Sprintf("%s-%s-%s", config.NodeNetworkPolicyPrefix, strings.ToUpper(ruleID), suffix)
+			lastRealized.ipsets[ipProtocol] = ipset
+		} else if ipnets.Len() == 1 {
+			// If a rule matches single source or destination, use it in core iptables rule directly.
+			ipnet, _ = ipnets.PopAny()
+			lastRealized.ipnets[ipProtocol] = ipnet
+		}
+
+		coreIPTRule := buildCoreIPTRule(ipProtocol,
+			coreIPTChain,
+			ipset,
+			ipnet,
+			coreIPTRuleTarget,
+			coreIPTRuleComment,
+			service,
+			rule.Direction == v1beta2.DirectionIn)
+
+		nodePolicyRules[ipProtocol] = &types.NodePolicyRule{
+			IPSet:           ipset,
+			IPSetMembers:    ipnets,
+			Priority:        priority,
+			ServiceIPTChain: serviceIPTChain,
+			ServiceIPTRules: serviceIPTRules,
+			CoreIPTChain:    coreIPTChain,
+			CoreIPTRule:     coreIPTRule,
+			IsIPv6:          isIPv6,
+		}
+	}
+
+	return nodePolicyRules, lastRealized
+}
+
+func (r *nodeReconciler) add(rule *CompletedRule) error {
+	klog.V(2).InfoS("Adding new rule", "rule", rule)
+	ruleID := rule.ID
+	iptRules, lastRealized := r.computeIPTRules(rule)
+	for _, iptRule := range iptRules {
+		if iptRule.IPSet != "" {
+			if err := r.routeClient.AddOrUpdateNodeNetworkPolicyIPSet(iptRule.IPSet, iptRule.IPSetMembers, iptRule.IsIPv6); err != nil {
+				return err
+			}
+		}
+		if iptRule.ServiceIPTChain != "" {
+			if err := r.routeClient.AddOrUpdateNodeNetworkPolicyIPTables([]string{iptRule.ServiceIPTChain}, [][]string{iptRule.ServiceIPTRules}, iptRule.IsIPv6); err != nil {
+				return err
+			}
+		}
+		if err := r.addOrUpdateCoreIPTRules(iptRule.CoreIPTChain, iptRule.IsIPv6, false, &coreIPTRule{ruleID, iptRule.Priority, iptRule.CoreIPTRule}); err != nil {
+			return err
+		}
+	}
+	r.lastRealizeds.Store(ruleID, lastRealized)
+	return nil
+}
+
+func (r *nodeReconciler) update(lastRealized *nodePolicyLastRealized, newRule *CompletedRule) error {
+	klog.V(2).InfoS("Updating existing rule", "rule", newRule)
+	ruleID := newRule.ID
+	newIPTRules, newLastRealized := r.computeIPTRules(newRule)
+
+	for _, ipProtocol := range r.ipProtocols {
+		iptRule := newIPTRules[ipProtocol]
+
+		prevIPNet := lastRealized.ipnets[ipProtocol]
+		ipnet := newLastRealized.ipnets[ipProtocol]
+		prevIPSet := lastRealized.ipsets[ipProtocol]
+		ipset := newLastRealized.ipsets[ipProtocol]
+
+		if ipset != "" {
+			if err := r.routeClient.AddOrUpdateNodeNetworkPolicyIPSet(iptRule.IPSet, iptRule.IPSetMembers, iptRule.IsIPv6); err != nil {
+				return err
+			}
+		} else if prevIPSet != "" {
+			if err := r.routeClient.DeleteNodeNetworkPolicyIPSet(lastRealized.ipsets[ipProtocol], iptRule.IsIPv6); err != nil {
+				return err
+			}
+		}
+		if prevIPSet != ipset || prevIPNet != ipnet {
+			if err := r.addOrUpdateCoreIPTRules(iptRule.CoreIPTChain, iptRule.IsIPv6, true, &coreIPTRule{ruleID, iptRule.Priority, iptRule.CoreIPTRule}); err != nil {
+				return err
+			}
+		}
+	}
+
+	r.lastRealizeds.Store(ruleID, newLastRealized)
+	return nil
+}
+
+func (r *nodeReconciler) addOrUpdateCoreIPTRules(chain string, isIPv6 bool, isUpdate bool, newRules ...*coreIPTRule) error {
+	if len(newRules) == 0 {
+		return nil
+	}
+
+	iptChain := r.getCoreIPTChain(chain, isIPv6)
+	iptChain.Lock()
+	defer iptChain.Unlock()
+
+	rules := iptChain.rules
+	if isUpdate {
+		// Build a map to store the mapping of rule ID to rule for the rules to update.
+		rulesToUpdate := make(map[string]*coreIPTRule)
+		for _, rule := range newRules {
+			rulesToUpdate[rule.ruleID] = rule
+		}
+		// Iterate each existing rule. If an existing rule exists in rulesToUpdate, replace it with the new rule.
+		for index, rule := range rules {
+			if _, exists := rulesToUpdate[rule.ruleID]; exists {
+				rules[index] = rulesToUpdate[rule.ruleID]
+			}
+		}
+	} else {
+		// If these are new rules, append the new rules then sort all rules.
+		rules = append(rules, newRules...)
+		sort.Slice(rules, func(i, j int) bool {
+			return !rules[i].priority.Less(*rules[j].priority)
+		})
+	}
+
+	// Get all iptables rules and synchronize them.
+	var ruleStrs []string
+	for _, rule := range rules {
+		if rule.ruleStr != "" {
+			ruleStrs = append(ruleStrs, rule.ruleStr)
+		}
+	}
+	if err := r.routeClient.AddOrUpdateNodeNetworkPolicyIPTables([]string{chain}, [][]string{ruleStrs}, isIPv6); err != nil {
+		return err
+	}
+
+	// cache the updated rules.
+	iptChain.rules = rules
+	return nil
+}
+
+func (r *nodeReconciler) deleteCoreIPTRule(ruleID string, iptChain string, isIPv6 bool) error {
+	chain := r.getCoreIPTChain(iptChain, isIPv6)
+	chain.Lock()
+	defer chain.Unlock()
+
+	// Get all the cached rules, then delete the rule with the given rule ID.
+	rules := chain.rules
+	indexToDelete := -1
+	for i := 0; i < len(rules); i++ {
+		if rules[i].ruleID == ruleID {
+			indexToDelete = i
+			break
+		}
+	}
+	// If the rule is not found, return directly.
+	if indexToDelete == -1 {
+		return nil
+	}
+	// If the rule is found, delete it from the slice.
+	rules = append(rules[:indexToDelete], rules[indexToDelete+1:]...)
+
+	// Get all the iptables rules and synchronize them.
+	var ruleStrs []string
+	for _, r := range rules {
+		ruleStrs = append(ruleStrs, r.ruleStr)
+	}
+	if err := r.routeClient.AddOrUpdateNodeNetworkPolicyIPTables([]string{iptChain}, [][]string{ruleStrs}, isIPv6); err != nil {
+		return err
+	}
+
+	// cache the updated rules.
+	chain.rules = rules
+	return nil
+}
+
+func (r *nodeReconciler) getCoreIPTChain(iptChain string, isIPv6 bool) *coreIPTChain {
+	// - For IPv4 ingress rules, iptables rules are installed in chain ANTREA-INGRESS-RULES.
+	// - For IPv6 ingress rules, ip6tables rules are installed in chain ANTREA-INGRESS-RULES.
+	// - For IPv4 egress rules, iptables rules are installed in chain ANTREA-EGRESS-RULES.
+	// - For IPv6 egress rules, ip6tables rules are installed in chain ANTREA-EGRESS-RULES.
+	return r.coreIPTChains[newChainKey(iptChain, isIPv6)]
+}
+
+func groupMembersToIPNets(groups v1beta2.GroupMemberSet, isIPv6 bool) sets.Set[string] {
+	ipnets := sets.New[string]()
+	suffix := "/32"
+	if isIPv6 {
+		suffix = "/128"
+	}
+	for _, member := range groups {
+		for _, ip := range member.IPs {
+			ipAddr := net.IP(ip)
+			if isIPv6 == utilnet.IsIPv6(ipAddr) {
+				ipnets.Insert(ipAddr.String() + suffix)
+			}
+		}
+	}
+	return ipnets
+}
+
+func ipBlocksToIPNets(ipBlocks []v1beta2.IPBlock, isIPv6 bool) []string {
+	var ipnets []string
+	for _, b := range ipBlocks {
+		blockCIDR := ip.IPNetToNetIPNet(&b.CIDR)
+		if isIPv6 != utilnet.IsIPv6CIDR(blockCIDR) {
+			continue
+		}
+		exceptIPNets := make([]*net.IPNet, 0, len(b.Except))
+		for i := range b.Except {
+			c := b.Except[i]
+			except := ip.IPNetToNetIPNet(&c)
+			exceptIPNets = append(exceptIPNets, except)
+		}
+		diffCIDRs, err := ip.DiffFromCIDRs(blockCIDR, exceptIPNets)
+		if err != nil {
+			klog.ErrorS(err, "Error when computing effective CIDRs by removing except IPNets from IPBlock")
+			continue
+		}
+		for _, d := range diffCIDRs {
+			ipnets = append(ipnets, d.String())
+		}
+	}
+	return ipnets
+}
+
+func getIPNetsFromRule(rule *CompletedRule, isIPv6 bool) sets.Set[string] {
+	var set sets.Set[string]
+	if rule.Direction == v1beta2.DirectionIn {
+		set = groupMembersToIPNets(rule.FromAddresses, isIPv6)
+		set.Insert(ipBlocksToIPNets(rule.From.IPBlocks, isIPv6)...)
+	} else {
+		set = groupMembersToIPNets(rule.ToAddresses, isIPv6)
+		set.Insert(ipBlocksToIPNets(rule.To.IPBlocks, isIPv6)...)
+	}
+	// If the set contains "0.0.0.0/0" or "::/0", it means the rule matches any source or destination IP address, just
+	// return a new set only containing "0.0.0.0/0" or "::/0".
+	if isIPv6 && set.Has(ipv6Any) {
+		return sets.New[string](ipv6Any)
+	}
+	if !isIPv6 && set.Has(ipv4Any) {
+		return sets.New[string](ipv4Any)
+	}
+	return set
+}
+
+func buildCoreIPTRule(ipProtocol iptables.Protocol,
+	iptChain string,
+	ipset string,
+	ipnet string,
+	iptRuleTarget string,
+	iptRuleComment string,
+	service *v1beta2.Service,
+	isIngress bool) string {
+	builder := iptables.NewRuleBuilder(iptChain)
+	if isIngress {
+		if ipset != "" {
+			builder = builder.MatchIPSetSrc(ipset)
+		} else if ipnet != "" {
+			builder = builder.MatchCIDRSrc(ipnet)
+		} else {
+			// If no source IP address is matched, return an empty string since the core iptables will never be matched.
+			return ""
+		}
+	} else {
+		if ipset != "" {
+			builder = builder.MatchIPSetDst(ipset)
+		} else if ipnet != "" {
+			builder = builder.MatchCIDRDst(ipnet)
+		} else {
+			// If no destination IP address is matched, return an empty string since the core iptables will never be matched.
+			return ""
+		}
+	}
+	if service != nil {
+		transProtocol := getServiceTransProtocol(service.Protocol)
+		switch transProtocol {
+		case "tcp":
+			fallthrough
+		case "udp":
+			fallthrough
+		case "sctp":
+			builder = builder.MatchTransProtocol(transProtocol).
+				MatchSrcPort(service.SrcPort, service.SrcEndPort).
+				MatchDstPort(service.Port, service.EndPort)
+		case "icmp":
+			builder = builder.MatchICMP(service.ICMPType, service.ICMPCode, ipProtocol)
+		}
+	}
+	return builder.SetTarget(iptRuleTarget).
+		SetComment(iptRuleComment).
+		Done().
+		GetRule()
+}
+
+func buildServiceIPTRules(ipProtocol iptables.Protocol, services []v1beta2.Service, chain string, ruleTarget string) []string {
+	var rules []string
+	builder := iptables.NewRuleBuilder(chain)
+	for _, svc := range services {
+		copiedBuilder := builder.CopyBuilder()
+		transProtocol := getServiceTransProtocol(svc.Protocol)
+		switch transProtocol {
+		case "tcp":
+			fallthrough
+		case "udp":
+			fallthrough
+		case "sctp":
+			copiedBuilder = copiedBuilder.MatchTransProtocol(transProtocol).
+				MatchSrcPort(svc.SrcPort, svc.SrcEndPort).
+				MatchDstPort(svc.Port, svc.EndPort)
+		case "icmp":
+			copiedBuilder = copiedBuilder.MatchICMP(svc.ICMPType, svc.ICMPCode, ipProtocol)
+		}
+		rules = append(rules, copiedBuilder.SetTarget(ruleTarget).
+			Done().
+			GetRule())
+	}
+	return rules
+}
+
+func ruleActionToIPTTarget(ruleAction *secv1beta1.RuleAction) string {
+	var target string
+	switch *ruleAction {
+	case secv1beta1.RuleActionDrop:
+		target = iptables.DropTarget
+	case secv1beta1.RuleActionReject:
+		target = iptables.RejectTarget
+	case secv1beta1.RuleActionAllow:
+		target = iptables.AcceptTarget
+	}
+	return target
+}
+
+func getServiceTransProtocol(protocol *v1beta2.Protocol) string {
+	if protocol == nil {
+		return "tcp"
+	}
+	return strings.ToLower(string(*protocol))
+}

--- a/pkg/agent/controller/networkpolicy/node_reconciler_linux_test.go
+++ b/pkg/agent/controller/networkpolicy/node_reconciler_linux_test.go
@@ -1,0 +1,1090 @@
+//go:build linux
+// +build linux
+
+// Copyright 2024 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package networkpolicy
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	routetest "antrea.io/antrea/pkg/agent/route/testing"
+	"antrea.io/antrea/pkg/apis/controlplane/v1beta2"
+	secv1beta1 "antrea.io/antrea/pkg/apis/crd/v1beta1"
+)
+
+var (
+	ruleActionAllow = secv1beta1.RuleActionAllow
+
+	ipv4Net1 = newCIDR("192.168.1.0/24")
+	ipv6Net1 = newCIDR("fec0::192:168:1:0/124")
+	ipv4Net2 = newCIDR("192.168.1.128/25")
+	ipv6Net2 = newCIDR("fec0::192:168:1:1/125")
+	ipBlocks = v1beta2.NetworkPolicyPeer{
+		IPBlocks: []v1beta2.IPBlock{
+			{
+				CIDR: v1beta2.IPNet{IP: v1beta2.IPAddress(ipv4Net1.IP), PrefixLength: 24},
+				Except: []v1beta2.IPNet{
+					{IP: v1beta2.IPAddress(ipv4Net2.IP), PrefixLength: 25},
+				},
+			},
+			{
+				CIDR: v1beta2.IPNet{IP: v1beta2.IPAddress(ipv6Net1.IP), PrefixLength: 124},
+				Except: []v1beta2.IPNet{
+					{IP: v1beta2.IPAddress(ipv6Net2.IP), PrefixLength: 125},
+				},
+			},
+		},
+	}
+	ipBlocksToMatchAny = v1beta2.NetworkPolicyPeer{
+		IPBlocks: []v1beta2.IPBlock{
+			{
+				CIDR: v1beta2.IPNet{IP: v1beta2.IPAddress(net.IPv4zero), PrefixLength: 0},
+			},
+			{
+				CIDR: v1beta2.IPNet{IP: v1beta2.IPAddress(net.IPv4zero), PrefixLength: 0},
+			},
+		},
+	}
+
+	policyPriority1 = float64(1)
+	tierPriority1   = int32(1)
+	tierPriority2   = int32(2)
+
+	ingressRuleID1 = "ingressRule1"
+	ingressRuleID2 = "ingressRule2"
+	ingressRuleID3 = "ingressRule3"
+	egressRuleID1  = "egressRule1"
+	egressRuleID2  = "egressRule2"
+	ingressRule1   = &CompletedRule{
+		rule: &rule{
+			ID:             ingressRuleID1,
+			Name:           "rule-01",
+			PolicyName:     "ingress-policy",
+			From:           ipBlocks,
+			Direction:      v1beta2.DirectionIn,
+			Services:       []v1beta2.Service{serviceTCP80, serviceTCP443},
+			Action:         &ruleActionAllow,
+			Priority:       1,
+			PolicyPriority: &policyPriority1,
+			TierPriority:   &tierPriority1,
+			SourceRef:      &cnp1,
+		},
+		FromAddresses: dualAddressGroup1,
+		ToAddresses:   nil,
+	}
+	ingressRule2 = &CompletedRule{
+		rule: &rule{
+			ID:             ingressRuleID2,
+			Name:           "rule-02",
+			PolicyName:     "ingress-policy",
+			Direction:      v1beta2.DirectionIn,
+			Services:       []v1beta2.Service{serviceTCP443},
+			Action:         &ruleActionAllow,
+			Priority:       2,
+			PolicyPriority: &policyPriority1,
+			TierPriority:   &tierPriority2,
+			SourceRef:      &cnp1,
+		},
+		FromAddresses: dualAddressGroup1,
+		ToAddresses:   nil,
+	}
+	ingressRule3 = &CompletedRule{
+		rule: &rule{
+			ID:             ingressRuleID3,
+			Name:           "rule-03",
+			PolicyName:     "ingress-policy",
+			From:           ipBlocksToMatchAny,
+			Direction:      v1beta2.DirectionIn,
+			Services:       []v1beta2.Service{serviceTCP8080},
+			Action:         &ruleActionAllow,
+			Priority:       3,
+			PolicyPriority: &policyPriority1,
+			TierPriority:   &tierPriority2,
+			SourceRef:      &cnp1,
+		},
+		FromAddresses: nil,
+		ToAddresses:   nil,
+	}
+	ingressRule3WithFromAnyAddress        = ingressRule3
+	updatedIngressRule3WithOneFromAddress = &CompletedRule{
+		rule: &rule{
+			ID:             ingressRuleID3,
+			Name:           "rule-03",
+			PolicyName:     "ingress-policy",
+			Direction:      v1beta2.DirectionIn,
+			Services:       []v1beta2.Service{serviceTCP8080},
+			Action:         &ruleActionAllow,
+			Priority:       3,
+			PolicyPriority: &policyPriority1,
+			TierPriority:   &tierPriority2,
+			SourceRef:      &cnp1,
+		},
+		FromAddresses: addressGroup1,
+		ToAddresses:   nil,
+	}
+	updatedIngressRule3WithAnotherFromAddress = &CompletedRule{
+		rule: &rule{
+			ID:             ingressRuleID3,
+			Name:           "rule-03",
+			PolicyName:     "ingress-policy",
+			Direction:      v1beta2.DirectionIn,
+			Services:       []v1beta2.Service{serviceTCP8080},
+			Action:         &ruleActionAllow,
+			Priority:       3,
+			PolicyPriority: &policyPriority1,
+			TierPriority:   &tierPriority2,
+			SourceRef:      &cnp1,
+		},
+		FromAddresses: addressGroup2,
+		ToAddresses:   nil,
+	}
+	updatedIngressRule3WithMultipleFromAddresses = &CompletedRule{
+		rule: &rule{
+			ID:             ingressRuleID3,
+			Name:           "rule-03",
+			PolicyName:     "ingress-policy",
+			Direction:      v1beta2.DirectionIn,
+			Services:       []v1beta2.Service{serviceTCP8080},
+			Action:         &ruleActionAllow,
+			Priority:       3,
+			PolicyPriority: &policyPriority1,
+			TierPriority:   &tierPriority2,
+			SourceRef:      &cnp1,
+		},
+		FromAddresses: addressGroup2.Union(addressGroup1),
+		ToAddresses:   nil,
+	}
+	updatedIngressRule3WithOtherMultipleFromAddresses = &CompletedRule{
+		rule: &rule{
+			ID:             ingressRuleID3,
+			Name:           "rule-03",
+			PolicyName:     "ingress-policy",
+			Direction:      v1beta2.DirectionIn,
+			Services:       []v1beta2.Service{serviceTCP8080},
+			Action:         &ruleActionAllow,
+			Priority:       3,
+			PolicyPriority: &policyPriority1,
+			TierPriority:   &tierPriority2,
+			SourceRef:      &cnp1,
+		},
+		FromAddresses: addressGroup2.Union(v1beta2.NewGroupMemberSet(newAddressGroupMember("1.1.1.3"))),
+		ToAddresses:   nil,
+	}
+	updatedIngressRule3WithFromNoAddress = &CompletedRule{
+		rule: &rule{
+			ID:             ingressRuleID3,
+			Name:           "rule-03",
+			PolicyName:     "ingress-policy",
+			Direction:      v1beta2.DirectionIn,
+			Services:       []v1beta2.Service{serviceTCP8080},
+			Action:         &ruleActionAllow,
+			Priority:       3,
+			PolicyPriority: &policyPriority1,
+			TierPriority:   &tierPriority2,
+			SourceRef:      &cnp1,
+		},
+		FromAddresses: nil,
+		ToAddresses:   nil,
+	}
+	egressRule1 = &CompletedRule{
+		rule: &rule{
+			ID:             egressRuleID1,
+			Name:           "rule-01",
+			PolicyName:     "egress-policy",
+			Direction:      v1beta2.DirectionOut,
+			Services:       []v1beta2.Service{serviceTCP80, serviceTCP443},
+			Action:         &ruleActionAllow,
+			Priority:       1,
+			PolicyPriority: &policyPriority1,
+			TierPriority:   &tierPriority1,
+			SourceRef:      &cnp1,
+		},
+		ToAddresses:   dualAddressGroup1,
+		FromAddresses: nil,
+	}
+	egressRule2 = &CompletedRule{
+		rule: &rule{
+			ID:             egressRuleID2,
+			Name:           "rule-02",
+			PolicyName:     "egress-policy",
+			Direction:      v1beta2.DirectionOut,
+			Services:       []v1beta2.Service{serviceTCP443},
+			Action:         &ruleActionAllow,
+			Priority:       2,
+			PolicyPriority: &policyPriority1,
+			TierPriority:   &tierPriority2,
+			SourceRef:      &cnp1,
+		},
+		ToAddresses:   dualAddressGroup1,
+		FromAddresses: nil,
+	}
+)
+
+func newTestNodeReconciler(mockRouteClient *routetest.MockInterface, ipv4Enabled, ipv6Enabled bool) *nodeReconciler {
+	return newNodeReconciler(mockRouteClient, ipv4Enabled, ipv6Enabled)
+}
+
+func TestNodeReconcilerReconcileAndForget(t *testing.T) {
+	tests := []struct {
+		name          string
+		rulesToAdd    []*CompletedRule
+		rulesToForget []string
+		ipv4Enabled   bool
+		ipv6Enabled   bool
+		expectedCalls func(mockRouteClient *routetest.MockInterfaceMockRecorder)
+	}{
+		{
+			name:        "IPv4, add an ingress rule, then forget it",
+			ipv4Enabled: true,
+			ipv6Enabled: false,
+			expectedCalls: func(mockRouteClient *routetest.MockInterfaceMockRecorder) {
+				serviceRules := [][]string{
+					{
+						"-A ANTREA-POL-INGRESSRULE1 -p tcp --dport 80 -j ACCEPT",
+						"-A ANTREA-POL-INGRESSRULE1 -p tcp --dport 443 -j ACCEPT",
+					},
+				}
+				coreRules := [][]string{
+					{
+						`-A ANTREA-POL-INGRESS-RULES -m set --match-set ANTREA-POL-INGRESSRULE1-4 src -j ANTREA-POL-INGRESSRULE1 -m comment --comment "Antrea: for rule ingressRule1, policy AntreaClusterNetworkPolicy:name1"`,
+					},
+				}
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPSet("ANTREA-POL-INGRESSRULE1-4", sets.New[string]("1.1.1.1/32", "192.168.1.0/25"), false).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESSRULE1"}, serviceRules, false).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESS-RULES"}, coreRules, false).Times(1)
+				mockRouteClient.DeleteNodeNetworkPolicyIPSet("ANTREA-POL-INGRESSRULE1-4", false)
+				mockRouteClient.DeleteNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESSRULE1"}, false).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESS-RULES"}, [][]string{nil}, false).Times(1)
+			},
+			rulesToAdd: []*CompletedRule{
+				ingressRule1,
+			},
+			rulesToForget: []string{
+				ingressRuleID1,
+			},
+		},
+		{
+			name:        "IPv6, add an egress rule, then forget it",
+			ipv4Enabled: false,
+			ipv6Enabled: true,
+			expectedCalls: func(mockRouteClient *routetest.MockInterfaceMockRecorder) {
+				serviceRules := [][]string{
+					{
+						"-A ANTREA-POL-EGRESSRULE1 -p tcp --dport 80 -j ACCEPT",
+						"-A ANTREA-POL-EGRESSRULE1 -p tcp --dport 443 -j ACCEPT",
+					},
+				}
+				coreRules := [][]string{
+					{
+						`-A ANTREA-POL-EGRESS-RULES -d 2002:1a23:fb44::1/128 -j ANTREA-POL-EGRESSRULE1 -m comment --comment "Antrea: for rule egressRule1, policy AntreaClusterNetworkPolicy:name1"`,
+					},
+				}
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables([]string{"ANTREA-POL-EGRESSRULE1"}, serviceRules, true).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables([]string{"ANTREA-POL-EGRESS-RULES"}, coreRules, true).Times(1)
+				mockRouteClient.DeleteNodeNetworkPolicyIPTables([]string{"ANTREA-POL-EGRESSRULE1"}, true).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables([]string{"ANTREA-POL-EGRESS-RULES"}, [][]string{nil}, true).Times(1)
+			},
+			rulesToAdd: []*CompletedRule{
+				egressRule1,
+			},
+			rulesToForget: []string{
+				egressRuleID1,
+			},
+		},
+		{
+			name:        "Dualstack, add an ingress rule, then forget it",
+			ipv4Enabled: true,
+			ipv6Enabled: true,
+			expectedCalls: func(mockRouteClient *routetest.MockInterfaceMockRecorder) {
+				serviceRules := [][]string{
+					{
+						"-A ANTREA-POL-INGRESSRULE1 -p tcp --dport 80 -j ACCEPT",
+						"-A ANTREA-POL-INGRESSRULE1 -p tcp --dport 443 -j ACCEPT",
+					},
+				}
+				coreRulesIPv4 := [][]string{
+					{
+						`-A ANTREA-POL-INGRESS-RULES -m set --match-set ANTREA-POL-INGRESSRULE1-4 src -j ANTREA-POL-INGRESSRULE1 -m comment --comment "Antrea: for rule ingressRule1, policy AntreaClusterNetworkPolicy:name1"`,
+					},
+				}
+				coreRulesIPv6 := [][]string{
+					{
+						`-A ANTREA-POL-INGRESS-RULES -m set --match-set ANTREA-POL-INGRESSRULE1-6 src -j ANTREA-POL-INGRESSRULE1 -m comment --comment "Antrea: for rule ingressRule1, policy AntreaClusterNetworkPolicy:name1"`,
+					},
+				}
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPSet("ANTREA-POL-INGRESSRULE1-4", sets.New[string]("1.1.1.1/32", "192.168.1.0/25"), false).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESSRULE1"}, serviceRules, false).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESS-RULES"}, coreRulesIPv4, false).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPSet("ANTREA-POL-INGRESSRULE1-6", sets.New[string]("2002:1a23:fb44::1/128", "fec0::192:168:1:8/125"), true).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESSRULE1"}, serviceRules, true).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESS-RULES"}, coreRulesIPv6, true).Times(1)
+				mockRouteClient.DeleteNodeNetworkPolicyIPSet("ANTREA-POL-INGRESSRULE1-4", false)
+				mockRouteClient.DeleteNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESSRULE1"}, false).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESS-RULES"}, [][]string{nil}, false).Times(1)
+				mockRouteClient.DeleteNodeNetworkPolicyIPSet("ANTREA-POL-INGRESSRULE1-6", true)
+				mockRouteClient.DeleteNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESSRULE1"}, true).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESS-RULES"}, [][]string{nil}, true).Times(1)
+			},
+			rulesToAdd: []*CompletedRule{
+				ingressRule1,
+			},
+			rulesToForget: []string{
+				ingressRuleID1,
+			},
+		},
+		{
+			name:        "IPv4, add multiple ingress rules whose priorities are in ascending order, then forget some",
+			ipv4Enabled: true,
+			ipv6Enabled: false,
+			expectedCalls: func(mockRouteClient *routetest.MockInterfaceMockRecorder) {
+				serviceRules1 := [][]string{
+					{
+						"-A ANTREA-POL-INGRESSRULE1 -p tcp --dport 80 -j ACCEPT",
+						"-A ANTREA-POL-INGRESSRULE1 -p tcp --dport 443 -j ACCEPT",
+					},
+				}
+				coreRules1 := [][]string{
+					{
+						`-A ANTREA-POL-INGRESS-RULES -m set --match-set ANTREA-POL-INGRESSRULE1-4 src -j ANTREA-POL-INGRESSRULE1 -m comment --comment "Antrea: for rule ingressRule1, policy AntreaClusterNetworkPolicy:name1"`,
+					},
+				}
+				coreRules2 := [][]string{
+					{
+						`-A ANTREA-POL-INGRESS-RULES -m set --match-set ANTREA-POL-INGRESSRULE1-4 src -j ANTREA-POL-INGRESSRULE1 -m comment --comment "Antrea: for rule ingressRule1, policy AntreaClusterNetworkPolicy:name1"`,
+						`-A ANTREA-POL-INGRESS-RULES -s 1.1.1.1/32 -p tcp --dport 443 -j ACCEPT -m comment --comment "Antrea: for rule ingressRule2, policy AntreaClusterNetworkPolicy:name1"`,
+					},
+				}
+				coreRules3 := [][]string{
+					{
+						`-A ANTREA-POL-INGRESS-RULES -m set --match-set ANTREA-POL-INGRESSRULE1-4 src -j ANTREA-POL-INGRESSRULE1 -m comment --comment "Antrea: for rule ingressRule1, policy AntreaClusterNetworkPolicy:name1"`,
+						`-A ANTREA-POL-INGRESS-RULES -s 1.1.1.1/32 -p tcp --dport 443 -j ACCEPT -m comment --comment "Antrea: for rule ingressRule2, policy AntreaClusterNetworkPolicy:name1"`,
+						`-A ANTREA-POL-INGRESS-RULES -p tcp --dport 8080 -j ACCEPT -m comment --comment "Antrea: for rule ingressRule3, policy AntreaClusterNetworkPolicy:name1"`,
+					},
+				}
+				coreRulesDeleted3 := [][]string{
+					{
+						`-A ANTREA-POL-INGRESS-RULES -m set --match-set ANTREA-POL-INGRESSRULE1-4 src -j ANTREA-POL-INGRESSRULE1 -m comment --comment "Antrea: for rule ingressRule1, policy AntreaClusterNetworkPolicy:name1"`,
+						`-A ANTREA-POL-INGRESS-RULES -s 1.1.1.1/32 -p tcp --dport 443 -j ACCEPT -m comment --comment "Antrea: for rule ingressRule2, policy AntreaClusterNetworkPolicy:name1"`,
+					},
+				}
+				coreRulesDelete2 := [][]string{
+					{
+						`-A ANTREA-POL-INGRESS-RULES -m set --match-set ANTREA-POL-INGRESSRULE1-4 src -j ANTREA-POL-INGRESSRULE1 -m comment --comment "Antrea: for rule ingressRule1, policy AntreaClusterNetworkPolicy:name1"`,
+					},
+				}
+
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPSet("ANTREA-POL-INGRESSRULE1-4", sets.New[string]("1.1.1.1/32", "192.168.1.0/25"), false).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESSRULE1"}, serviceRules1, false).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESS-RULES"}, coreRules1, false).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESS-RULES"}, coreRules2, false).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESS-RULES"}, coreRules3, false).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESS-RULES"}, coreRulesDeleted3, false).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESS-RULES"}, coreRulesDelete2, false).Times(1)
+			},
+			rulesToAdd: []*CompletedRule{
+				ingressRule1,
+				ingressRule2,
+				ingressRule3,
+			},
+			rulesToForget: []string{
+				ingressRuleID3,
+				ingressRuleID2,
+			},
+		},
+		{
+			name:        "IPv4, add multiple ingress rules whose priorities are in descending order, then forget some",
+			ipv4Enabled: true,
+			ipv6Enabled: false,
+			expectedCalls: func(mockRouteClient *routetest.MockInterfaceMockRecorder) {
+				coreRules3 := [][]string{
+					{
+						`-A ANTREA-POL-INGRESS-RULES -p tcp --dport 8080 -j ACCEPT -m comment --comment "Antrea: for rule ingressRule3, policy AntreaClusterNetworkPolicy:name1"`,
+					},
+				}
+				coreRules2 := [][]string{
+					{
+						`-A ANTREA-POL-INGRESS-RULES -s 1.1.1.1/32 -p tcp --dport 443 -j ACCEPT -m comment --comment "Antrea: for rule ingressRule2, policy AntreaClusterNetworkPolicy:name1"`,
+						`-A ANTREA-POL-INGRESS-RULES -p tcp --dport 8080 -j ACCEPT -m comment --comment "Antrea: for rule ingressRule3, policy AntreaClusterNetworkPolicy:name1"`,
+					},
+				}
+				serviceRules1 := [][]string{
+					{
+						"-A ANTREA-POL-INGRESSRULE1 -p tcp --dport 80 -j ACCEPT",
+						"-A ANTREA-POL-INGRESSRULE1 -p tcp --dport 443 -j ACCEPT",
+					},
+				}
+				coreRules1 := [][]string{
+					{
+						`-A ANTREA-POL-INGRESS-RULES -m set --match-set ANTREA-POL-INGRESSRULE1-4 src -j ANTREA-POL-INGRESSRULE1 -m comment --comment "Antrea: for rule ingressRule1, policy AntreaClusterNetworkPolicy:name1"`,
+						`-A ANTREA-POL-INGRESS-RULES -s 1.1.1.1/32 -p tcp --dport 443 -j ACCEPT -m comment --comment "Antrea: for rule ingressRule2, policy AntreaClusterNetworkPolicy:name1"`,
+						`-A ANTREA-POL-INGRESS-RULES -p tcp --dport 8080 -j ACCEPT -m comment --comment "Antrea: for rule ingressRule3, policy AntreaClusterNetworkPolicy:name1"`,
+					},
+				}
+				coreRulesDelete3 := [][]string{
+					{
+						`-A ANTREA-POL-INGRESS-RULES -m set --match-set ANTREA-POL-INGRESSRULE1-4 src -j ANTREA-POL-INGRESSRULE1 -m comment --comment "Antrea: for rule ingressRule1, policy AntreaClusterNetworkPolicy:name1"`,
+						`-A ANTREA-POL-INGRESS-RULES -s 1.1.1.1/32 -p tcp --dport 443 -j ACCEPT -m comment --comment "Antrea: for rule ingressRule2, policy AntreaClusterNetworkPolicy:name1"`,
+					},
+				}
+				coreRulesDelete1 := [][]string{
+					{
+						`-A ANTREA-POL-INGRESS-RULES -s 1.1.1.1/32 -p tcp --dport 443 -j ACCEPT -m comment --comment "Antrea: for rule ingressRule2, policy AntreaClusterNetworkPolicy:name1"`,
+					},
+				}
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESS-RULES"}, coreRules3, false).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESS-RULES"}, coreRules2, false).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPSet("ANTREA-POL-INGRESSRULE1-4", sets.New[string]("1.1.1.1/32", "192.168.1.0/25"), false).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESSRULE1"}, serviceRules1, false).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESS-RULES"}, coreRules1, false).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESS-RULES"}, coreRulesDelete3, false).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESS-RULES"}, coreRulesDelete1, false).Times(1)
+				mockRouteClient.DeleteNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESSRULE1"}, false).Times(1)
+				mockRouteClient.DeleteNodeNetworkPolicyIPSet("ANTREA-POL-INGRESSRULE1-4", false).Times(1)
+			},
+			rulesToAdd: []*CompletedRule{
+				ingressRule3,
+				ingressRule2,
+				ingressRule1,
+			},
+			rulesToForget: []string{
+				ingressRuleID3,
+				ingressRuleID1,
+			},
+		},
+		{
+			name:        "IPv4, add multiple ingress rules whose priorities are in random order, then forget some",
+			ipv4Enabled: true,
+			ipv6Enabled: false,
+			expectedCalls: func(mockRouteClient *routetest.MockInterfaceMockRecorder) {
+				coreRules2 := [][]string{
+					{
+						`-A ANTREA-POL-INGRESS-RULES -s 1.1.1.1/32 -p tcp --dport 443 -j ACCEPT -m comment --comment "Antrea: for rule ingressRule2, policy AntreaClusterNetworkPolicy:name1"`,
+					},
+				}
+				serviceRules1 := [][]string{
+					{
+						"-A ANTREA-POL-INGRESSRULE1 -p tcp --dport 80 -j ACCEPT",
+						"-A ANTREA-POL-INGRESSRULE1 -p tcp --dport 443 -j ACCEPT",
+					},
+				}
+				coreRules1 := [][]string{
+					{
+						`-A ANTREA-POL-INGRESS-RULES -m set --match-set ANTREA-POL-INGRESSRULE1-4 src -j ANTREA-POL-INGRESSRULE1 -m comment --comment "Antrea: for rule ingressRule1, policy AntreaClusterNetworkPolicy:name1"`,
+						`-A ANTREA-POL-INGRESS-RULES -s 1.1.1.1/32 -p tcp --dport 443 -j ACCEPT -m comment --comment "Antrea: for rule ingressRule2, policy AntreaClusterNetworkPolicy:name1"`,
+					},
+				}
+				coreRules3 := [][]string{
+					{
+						`-A ANTREA-POL-INGRESS-RULES -m set --match-set ANTREA-POL-INGRESSRULE1-4 src -j ANTREA-POL-INGRESSRULE1 -m comment --comment "Antrea: for rule ingressRule1, policy AntreaClusterNetworkPolicy:name1"`,
+						`-A ANTREA-POL-INGRESS-RULES -s 1.1.1.1/32 -p tcp --dport 443 -j ACCEPT -m comment --comment "Antrea: for rule ingressRule2, policy AntreaClusterNetworkPolicy:name1"`,
+						`-A ANTREA-POL-INGRESS-RULES -p tcp --dport 8080 -j ACCEPT -m comment --comment "Antrea: for rule ingressRule3, policy AntreaClusterNetworkPolicy:name1"`,
+					},
+				}
+				coreRulesDelete2 := [][]string{
+					{
+						`-A ANTREA-POL-INGRESS-RULES -m set --match-set ANTREA-POL-INGRESSRULE1-4 src -j ANTREA-POL-INGRESSRULE1 -m comment --comment "Antrea: for rule ingressRule1, policy AntreaClusterNetworkPolicy:name1"`,
+						`-A ANTREA-POL-INGRESS-RULES -p tcp --dport 8080 -j ACCEPT -m comment --comment "Antrea: for rule ingressRule3, policy AntreaClusterNetworkPolicy:name1"`,
+					},
+				}
+				coreRulesDelete1 := [][]string{
+					{
+						`-A ANTREA-POL-INGRESS-RULES -p tcp --dport 8080 -j ACCEPT -m comment --comment "Antrea: for rule ingressRule3, policy AntreaClusterNetworkPolicy:name1"`,
+					},
+				}
+
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESS-RULES"}, coreRules2, false).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPSet("ANTREA-POL-INGRESSRULE1-4", sets.New[string]("1.1.1.1/32", "192.168.1.0/25"), false).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESSRULE1"}, serviceRules1, false).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESS-RULES"}, coreRules1, false).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESS-RULES"}, coreRules3, false).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESS-RULES"}, coreRulesDelete2, false).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESS-RULES"}, coreRulesDelete1, false).Times(1)
+				mockRouteClient.DeleteNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESSRULE1"}, false).Times(1)
+				mockRouteClient.DeleteNodeNetworkPolicyIPSet("ANTREA-POL-INGRESSRULE1-4", false).Times(1)
+			},
+			rulesToAdd: []*CompletedRule{
+				ingressRule2,
+				ingressRule1,
+				ingressRule3,
+			},
+			rulesToForget: []string{
+				ingressRuleID2,
+				ingressRuleID1,
+			},
+		},
+		{
+			name:        "IPv4, add an ingress rule, then update it several times, forget it finally",
+			ipv4Enabled: true,
+			ipv6Enabled: false,
+			expectedCalls: func(mockRouteClient *routetest.MockInterfaceMockRecorder) {
+				coreRules1 := [][]string{
+					{
+						`-A ANTREA-POL-INGRESS-RULES -p tcp --dport 8080 -j ACCEPT -m comment --comment "Antrea: for rule ingressRule3, policy AntreaClusterNetworkPolicy:name1"`,
+					},
+				}
+				coreRules2 := [][]string{
+					{
+						`-A ANTREA-POL-INGRESS-RULES -s 1.1.1.1/32 -p tcp --dport 8080 -j ACCEPT -m comment --comment "Antrea: for rule ingressRule3, policy AntreaClusterNetworkPolicy:name1"`,
+					},
+				}
+				coreRules3 := [][]string{
+					{
+						`-A ANTREA-POL-INGRESS-RULES -s 1.1.1.2/32 -p tcp --dport 8080 -j ACCEPT -m comment --comment "Antrea: for rule ingressRule3, policy AntreaClusterNetworkPolicy:name1"`,
+					},
+				}
+				coreRules4 := [][]string{
+					{
+						`-A ANTREA-POL-INGRESS-RULES -m set --match-set ANTREA-POL-INGRESSRULE3-4 src -p tcp --dport 8080 -j ACCEPT -m comment --comment "Antrea: for rule ingressRule3, policy AntreaClusterNetworkPolicy:name1"`,
+					},
+				}
+				coreRules6 := coreRules2
+				coreRules7 := coreRules1
+				coreRules8 := coreRules4
+				coreRules9 := coreRules1
+				coreRules10 := [][]string{nil}
+				coreRules11 := coreRules4
+				coreRules12 := coreRules10
+				coreRules13 := coreRules1
+
+				s1 := mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESS-RULES"}, coreRules1, false).Times(1)
+				s2 := mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESS-RULES"}, coreRules2, false).Times(1)
+				s3 := mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESS-RULES"}, coreRules3, false).Times(1)
+				s4p1 := mockRouteClient.AddOrUpdateNodeNetworkPolicyIPSet("ANTREA-POL-INGRESSRULE3-4", sets.New[string]("1.1.1.1/32", "1.1.1.2/32"), false).Times(1)
+				s4p2 := mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESS-RULES"}, coreRules4, false).Times(1)
+				s5 := mockRouteClient.AddOrUpdateNodeNetworkPolicyIPSet("ANTREA-POL-INGRESSRULE3-4", sets.New[string]("1.1.1.2/32", "1.1.1.3/32"), false).Times(1)
+				s6p1 := mockRouteClient.DeleteNodeNetworkPolicyIPSet("ANTREA-POL-INGRESSRULE3-4", false).Times(1)
+				s6p2 := mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESS-RULES"}, coreRules6, false).Times(1)
+				s7 := mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESS-RULES"}, coreRules7, false).Times(1)
+				s8p1 := mockRouteClient.AddOrUpdateNodeNetworkPolicyIPSet("ANTREA-POL-INGRESSRULE3-4", sets.New[string]("1.1.1.1/32", "1.1.1.2/32"), false).Times(1)
+				s8p2 := mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESS-RULES"}, coreRules8, false).Times(1)
+				s9p1 := mockRouteClient.DeleteNodeNetworkPolicyIPSet("ANTREA-POL-INGRESSRULE3-4", false).Times(1)
+				s9p2 := mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESS-RULES"}, coreRules9, false).Times(1)
+				s10 := mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESS-RULES"}, coreRules10, false).Times(1)
+				s11p1 := mockRouteClient.AddOrUpdateNodeNetworkPolicyIPSet("ANTREA-POL-INGRESSRULE3-4", sets.New[string]("1.1.1.1/32", "1.1.1.2/32"), false).Times(1)
+				s11p2 := mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESS-RULES"}, coreRules11, false).Times(1)
+				s12p1 := mockRouteClient.DeleteNodeNetworkPolicyIPSet("ANTREA-POL-INGRESSRULE3-4", false).Times(1)
+				s12p2 := mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESS-RULES"}, coreRules12, false).Times(1)
+				s13 := mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESS-RULES"}, coreRules13, false).Times(1)
+				s2.After(s1)
+				s3.After(s2)
+				s4p1.After(s3)
+				s4p2.After(s3)
+				s5.After(s4p2)
+				s5.After(s4p2)
+				s6p1.After(s5)
+				s6p2.After(s5)
+				s7.After(s6p2)
+				s8p1.After(s7)
+				s8p2.After(s7)
+				s9p1.After(s8p2)
+				s9p2.After(s8p2)
+				s10.After(s9p2)
+				s11p1.After(s10)
+				s11p2.After(s10)
+				s12p1.After(s11p2)
+				s12p2.After(s11p2)
+				s13.After(s12p2)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESS-RULES"}, [][]string{nil}, false).Times(1)
+			},
+			rulesToAdd: []*CompletedRule{
+				ingressRule3WithFromAnyAddress,
+				updatedIngressRule3WithOneFromAddress,
+				updatedIngressRule3WithAnotherFromAddress,
+				updatedIngressRule3WithMultipleFromAddresses,
+				updatedIngressRule3WithOtherMultipleFromAddresses,
+				updatedIngressRule3WithOneFromAddress,
+				ingressRule3WithFromAnyAddress,
+				updatedIngressRule3WithMultipleFromAddresses,
+				ingressRule3WithFromAnyAddress,
+				updatedIngressRule3WithFromNoAddress,
+				updatedIngressRule3WithMultipleFromAddresses,
+				updatedIngressRule3WithFromNoAddress,
+				ingressRule3WithFromAnyAddress,
+			},
+			rulesToForget: []string{
+				ingressRuleID3,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			controller := gomock.NewController(t)
+			mockRouteClient := routetest.NewMockInterface(controller)
+			r := newTestNodeReconciler(mockRouteClient, tt.ipv4Enabled, tt.ipv6Enabled)
+
+			tt.expectedCalls(mockRouteClient.EXPECT())
+			for _, rule := range tt.rulesToAdd {
+				assert.NoError(t, r.Reconcile(rule))
+			}
+			for _, rule := range tt.rulesToForget {
+				assert.NoError(t, r.Forget(rule))
+			}
+		})
+	}
+}
+
+func TestNodeReconcilerBatchReconcileAndForget(t *testing.T) {
+	tests := []struct {
+		name          string
+		ipv4Enabled   bool
+		ipv6Enabled   bool
+		rulesToAdd    []*CompletedRule
+		rulesToForget []string
+		expectedCalls func(mockRouteClient *routetest.MockInterfaceMockRecorder)
+	}{
+		{
+			name:        "IPv4, add ingress rules in batch, then forget one",
+			ipv4Enabled: true,
+			rulesToAdd: []*CompletedRule{
+				ingressRule1,
+				ingressRule2,
+			},
+			rulesToForget: []string{
+				ingressRuleID1,
+			},
+			expectedCalls: func(mockRouteClient *routetest.MockInterfaceMockRecorder) {
+				coreChains := []string{
+					"ANTREA-POL-INGRESS-RULES",
+				}
+				coreRules := [][]string{
+					{
+						`-A ANTREA-POL-INGRESS-RULES -m set --match-set ANTREA-POL-INGRESSRULE1-4 src -j ANTREA-POL-INGRESSRULE1 -m comment --comment "Antrea: for rule ingressRule1, policy AntreaClusterNetworkPolicy:name1"`,
+						`-A ANTREA-POL-INGRESS-RULES -s 1.1.1.1/32 -p tcp --dport 443 -j ACCEPT -m comment --comment "Antrea: for rule ingressRule2, policy AntreaClusterNetworkPolicy:name1"`,
+					},
+				}
+				svcChains := []string{
+					"ANTREA-POL-INGRESSRULE1",
+				}
+				svcRules := [][]string{
+					{
+						"-A ANTREA-POL-INGRESSRULE1 -p tcp --dport 80 -j ACCEPT",
+						"-A ANTREA-POL-INGRESSRULE1 -p tcp --dport 443 -j ACCEPT",
+					},
+				}
+				updatedCoreRules := [][]string{
+					{
+						`-A ANTREA-POL-INGRESS-RULES -s 1.1.1.1/32 -p tcp --dport 443 -j ACCEPT -m comment --comment "Antrea: for rule ingressRule2, policy AntreaClusterNetworkPolicy:name1"`,
+					},
+				}
+
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPSet("ANTREA-POL-INGRESSRULE1-4", sets.New[string]("1.1.1.1/32", "192.168.1.0/25"), false).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables(svcChains, svcRules, false).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables(coreChains, coreRules, false).Times(1)
+
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables(coreChains, updatedCoreRules, false).Times(1)
+				mockRouteClient.DeleteNodeNetworkPolicyIPSet("ANTREA-POL-INGRESSRULE1-4", false).Times(1)
+				mockRouteClient.DeleteNodeNetworkPolicyIPTables(svcChains, false).Times(1)
+			},
+		},
+		{
+			name:        "IPv6, add ingress rules in batch, then forget one",
+			ipv6Enabled: true,
+			rulesToAdd: []*CompletedRule{
+				ingressRule1,
+				ingressRule2,
+			},
+			rulesToForget: []string{
+				ingressRuleID2,
+			},
+			expectedCalls: func(mockRouteClient *routetest.MockInterfaceMockRecorder) {
+				coreChains := []string{
+					"ANTREA-POL-INGRESS-RULES",
+				}
+				coreRules := [][]string{
+					{
+						`-A ANTREA-POL-INGRESS-RULES -m set --match-set ANTREA-POL-INGRESSRULE1-6 src -j ANTREA-POL-INGRESSRULE1 -m comment --comment "Antrea: for rule ingressRule1, policy AntreaClusterNetworkPolicy:name1"`,
+						`-A ANTREA-POL-INGRESS-RULES -s 2002:1a23:fb44::1/128 -p tcp --dport 443 -j ACCEPT -m comment --comment "Antrea: for rule ingressRule2, policy AntreaClusterNetworkPolicy:name1"`,
+					},
+				}
+				svcChains := []string{
+					"ANTREA-POL-INGRESSRULE1",
+				}
+				svcRules := [][]string{
+					{
+						"-A ANTREA-POL-INGRESSRULE1 -p tcp --dport 80 -j ACCEPT",
+						"-A ANTREA-POL-INGRESSRULE1 -p tcp --dport 443 -j ACCEPT",
+					},
+				}
+				updatedCoreRules := [][]string{
+					{
+						`-A ANTREA-POL-INGRESS-RULES -m set --match-set ANTREA-POL-INGRESSRULE1-6 src -j ANTREA-POL-INGRESSRULE1 -m comment --comment "Antrea: for rule ingressRule1, policy AntreaClusterNetworkPolicy:name1"`,
+					},
+				}
+
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPSet("ANTREA-POL-INGRESSRULE1-6", sets.New[string]("2002:1a23:fb44::1/128", "fec0::192:168:1:8/125"), true).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables(svcChains, svcRules, true).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables(coreChains, coreRules, true).Times(1)
+
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables(coreChains, updatedCoreRules, true).Times(1)
+			},
+		},
+		{
+			name:        "dualstack, add ingress rules in batch, then forget one",
+			ipv4Enabled: true,
+			ipv6Enabled: true,
+			rulesToAdd: []*CompletedRule{
+				ingressRule1,
+				ingressRule2,
+			},
+			rulesToForget: []string{
+				ingressRuleID1,
+			},
+			expectedCalls: func(mockRouteClient *routetest.MockInterfaceMockRecorder) {
+				coreChains := []string{
+					"ANTREA-POL-INGRESS-RULES",
+				}
+				ipv4CoreRules := [][]string{
+					{
+						`-A ANTREA-POL-INGRESS-RULES -m set --match-set ANTREA-POL-INGRESSRULE1-4 src -j ANTREA-POL-INGRESSRULE1 -m comment --comment "Antrea: for rule ingressRule1, policy AntreaClusterNetworkPolicy:name1"`,
+						`-A ANTREA-POL-INGRESS-RULES -s 1.1.1.1/32 -p tcp --dport 443 -j ACCEPT -m comment --comment "Antrea: for rule ingressRule2, policy AntreaClusterNetworkPolicy:name1"`,
+					},
+				}
+				ipv6CoreRules := [][]string{
+					{
+						`-A ANTREA-POL-INGRESS-RULES -m set --match-set ANTREA-POL-INGRESSRULE1-6 src -j ANTREA-POL-INGRESSRULE1 -m comment --comment "Antrea: for rule ingressRule1, policy AntreaClusterNetworkPolicy:name1"`,
+						`-A ANTREA-POL-INGRESS-RULES -s 2002:1a23:fb44::1/128 -p tcp --dport 443 -j ACCEPT -m comment --comment "Antrea: for rule ingressRule2, policy AntreaClusterNetworkPolicy:name1"`,
+					},
+				}
+				svcChains := []string{
+					"ANTREA-POL-INGRESSRULE1",
+				}
+				ipv4SvcRules := [][]string{
+					{
+						"-A ANTREA-POL-INGRESSRULE1 -p tcp --dport 80 -j ACCEPT",
+						"-A ANTREA-POL-INGRESSRULE1 -p tcp --dport 443 -j ACCEPT",
+					},
+				}
+				ipv6SvcRules := ipv4SvcRules
+				updatedIPv4CoreRules := [][]string{
+					{
+						`-A ANTREA-POL-INGRESS-RULES -s 1.1.1.1/32 -p tcp --dport 443 -j ACCEPT -m comment --comment "Antrea: for rule ingressRule2, policy AntreaClusterNetworkPolicy:name1"`,
+					},
+				}
+				updatedIPv6CoreRules := [][]string{
+					{
+						`-A ANTREA-POL-INGRESS-RULES -s 2002:1a23:fb44::1/128 -p tcp --dport 443 -j ACCEPT -m comment --comment "Antrea: for rule ingressRule2, policy AntreaClusterNetworkPolicy:name1"`,
+					},
+				}
+
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPSet("ANTREA-POL-INGRESSRULE1-4", sets.New[string]("1.1.1.1/32", "192.168.1.0/25"), false).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables(svcChains, ipv4SvcRules, false).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables(coreChains, ipv4CoreRules, false).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPSet("ANTREA-POL-INGRESSRULE1-6", sets.New[string]("2002:1a23:fb44::1/128", "fec0::192:168:1:8/125"), true).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables(svcChains, ipv6SvcRules, true).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables(coreChains, ipv6CoreRules, true).Times(1)
+
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables(coreChains, updatedIPv4CoreRules, false).Times(1)
+				mockRouteClient.DeleteNodeNetworkPolicyIPSet("ANTREA-POL-INGRESSRULE1-4", false).Times(1)
+				mockRouteClient.DeleteNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESSRULE1"}, false).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables(coreChains, updatedIPv6CoreRules, true).Times(1)
+				mockRouteClient.DeleteNodeNetworkPolicyIPSet("ANTREA-POL-INGRESSRULE1-6", true).Times(1)
+				mockRouteClient.DeleteNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESSRULE1"}, true).Times(1)
+			},
+		},
+		{
+			name:        "IPv4, add egress rules in batch, then forget one",
+			ipv4Enabled: true,
+			rulesToAdd: []*CompletedRule{
+				egressRule1,
+				egressRule2,
+			},
+			rulesToForget: []string{
+				egressRuleID1,
+			},
+			expectedCalls: func(mockRouteClient *routetest.MockInterfaceMockRecorder) {
+				coreChains := []string{
+					"ANTREA-POL-EGRESS-RULES",
+				}
+				coreRules := [][]string{
+					{
+						`-A ANTREA-POL-EGRESS-RULES -d 1.1.1.1/32 -j ANTREA-POL-EGRESSRULE1 -m comment --comment "Antrea: for rule egressRule1, policy AntreaClusterNetworkPolicy:name1"`,
+						`-A ANTREA-POL-EGRESS-RULES -d 1.1.1.1/32 -p tcp --dport 443 -j ACCEPT -m comment --comment "Antrea: for rule egressRule2, policy AntreaClusterNetworkPolicy:name1"`,
+					},
+				}
+				svcChains := []string{
+					"ANTREA-POL-EGRESSRULE1",
+				}
+				svcRules := [][]string{
+					{
+						"-A ANTREA-POL-EGRESSRULE1 -p tcp --dport 80 -j ACCEPT",
+						"-A ANTREA-POL-EGRESSRULE1 -p tcp --dport 443 -j ACCEPT",
+					},
+				}
+				updatedCoreRules := [][]string{
+					{
+						`-A ANTREA-POL-EGRESS-RULES -d 1.1.1.1/32 -p tcp --dport 443 -j ACCEPT -m comment --comment "Antrea: for rule egressRule2, policy AntreaClusterNetworkPolicy:name1"`,
+					},
+				}
+
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables(svcChains, svcRules, false).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables(coreChains, coreRules, false).Times(1)
+
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables(coreChains, updatedCoreRules, false).Times(1)
+				mockRouteClient.DeleteNodeNetworkPolicyIPTables(svcChains, false).Times(1)
+			},
+		},
+		{
+			name:        "IPv6, add egress rules in batch, then forget one",
+			ipv6Enabled: true,
+			rulesToAdd: []*CompletedRule{
+				egressRule1,
+				egressRule2,
+			},
+			rulesToForget: []string{
+				egressRuleID1,
+			},
+			expectedCalls: func(mockRouteClient *routetest.MockInterfaceMockRecorder) {
+				coreChains := []string{
+					"ANTREA-POL-EGRESS-RULES",
+				}
+				coreRules := [][]string{
+					{
+						`-A ANTREA-POL-EGRESS-RULES -d 2002:1a23:fb44::1/128 -j ANTREA-POL-EGRESSRULE1 -m comment --comment "Antrea: for rule egressRule1, policy AntreaClusterNetworkPolicy:name1"`,
+						`-A ANTREA-POL-EGRESS-RULES -d 2002:1a23:fb44::1/128 -p tcp --dport 443 -j ACCEPT -m comment --comment "Antrea: for rule egressRule2, policy AntreaClusterNetworkPolicy:name1"`,
+					},
+				}
+				svcChains := []string{
+					"ANTREA-POL-EGRESSRULE1",
+				}
+				svcRules := [][]string{
+					{
+						"-A ANTREA-POL-EGRESSRULE1 -p tcp --dport 80 -j ACCEPT",
+						"-A ANTREA-POL-EGRESSRULE1 -p tcp --dport 443 -j ACCEPT",
+					},
+				}
+				updatedCoreRules := [][]string{
+					{
+						`-A ANTREA-POL-EGRESS-RULES -d 2002:1a23:fb44::1/128 -p tcp --dport 443 -j ACCEPT -m comment --comment "Antrea: for rule egressRule2, policy AntreaClusterNetworkPolicy:name1"`,
+					},
+				}
+
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables(svcChains, svcRules, true).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables(coreChains, coreRules, true).Times(1)
+
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables(coreChains, updatedCoreRules, true).Times(1)
+				mockRouteClient.DeleteNodeNetworkPolicyIPTables(svcChains, true).Times(1)
+			},
+		},
+		{
+			name:        "dualstack, only add egress rules, then forget one",
+			ipv4Enabled: true,
+			ipv6Enabled: true,
+			rulesToAdd: []*CompletedRule{
+				egressRule1,
+				egressRule2,
+			},
+			rulesToForget: []string{
+				egressRuleID1,
+			},
+			expectedCalls: func(mockRouteClient *routetest.MockInterfaceMockRecorder) {
+				coreChains := []string{
+					"ANTREA-POL-EGRESS-RULES",
+				}
+				ipv4CoreRules := [][]string{
+					{
+						`-A ANTREA-POL-EGRESS-RULES -d 1.1.1.1/32 -j ANTREA-POL-EGRESSRULE1 -m comment --comment "Antrea: for rule egressRule1, policy AntreaClusterNetworkPolicy:name1"`,
+						`-A ANTREA-POL-EGRESS-RULES -d 1.1.1.1/32 -p tcp --dport 443 -j ACCEPT -m comment --comment "Antrea: for rule egressRule2, policy AntreaClusterNetworkPolicy:name1"`,
+					},
+				}
+				ipv6CoreRules := [][]string{
+					{
+						`-A ANTREA-POL-EGRESS-RULES -d 2002:1a23:fb44::1/128 -j ANTREA-POL-EGRESSRULE1 -m comment --comment "Antrea: for rule egressRule1, policy AntreaClusterNetworkPolicy:name1"`,
+						`-A ANTREA-POL-EGRESS-RULES -d 2002:1a23:fb44::1/128 -p tcp --dport 443 -j ACCEPT -m comment --comment "Antrea: for rule egressRule2, policy AntreaClusterNetworkPolicy:name1"`,
+					},
+				}
+				svcChains := []string{
+					"ANTREA-POL-EGRESSRULE1",
+				}
+				ipv4SvcRules := [][]string{
+					{
+						"-A ANTREA-POL-EGRESSRULE1 -p tcp --dport 80 -j ACCEPT",
+						"-A ANTREA-POL-EGRESSRULE1 -p tcp --dport 443 -j ACCEPT",
+					},
+				}
+				ipv6SvcRules := ipv4SvcRules
+				updatedIPv4CoreRules := [][]string{
+					{
+						`-A ANTREA-POL-EGRESS-RULES -d 1.1.1.1/32 -p tcp --dport 443 -j ACCEPT -m comment --comment "Antrea: for rule egressRule2, policy AntreaClusterNetworkPolicy:name1"`,
+					},
+				}
+				updatedIPv6CoreRules := [][]string{
+					{
+						`-A ANTREA-POL-EGRESS-RULES -d 2002:1a23:fb44::1/128 -p tcp --dport 443 -j ACCEPT -m comment --comment "Antrea: for rule egressRule2, policy AntreaClusterNetworkPolicy:name1"`,
+					},
+				}
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables(svcChains, ipv4SvcRules, false).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables(coreChains, ipv4CoreRules, false).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables(svcChains, ipv6SvcRules, true).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables(coreChains, ipv6CoreRules, true).Times(1)
+
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables(coreChains, updatedIPv4CoreRules, false).Times(1)
+				mockRouteClient.DeleteNodeNetworkPolicyIPTables(svcChains, false).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables(coreChains, updatedIPv6CoreRules, true).Times(1)
+				mockRouteClient.DeleteNodeNetworkPolicyIPTables(svcChains, true).Times(1)
+			},
+		},
+		{
+			name:        "IPv4, add ingress and egress rules in batch, then forget some rules",
+			ipv4Enabled: true,
+			rulesToAdd: []*CompletedRule{
+				ingressRule1,
+				ingressRule2,
+				egressRule1,
+				egressRule2,
+			},
+			rulesToForget: []string{
+				ingressRuleID1,
+				egressRuleID1,
+			},
+			expectedCalls: func(mockRouteClient *routetest.MockInterfaceMockRecorder) {
+				svcChains := []string{
+					"ANTREA-POL-INGRESSRULE1",
+					"ANTREA-POL-EGRESSRULE1",
+				}
+				svcRules := [][]string{
+					{
+						"-A ANTREA-POL-INGRESSRULE1 -p tcp --dport 80 -j ACCEPT",
+						"-A ANTREA-POL-INGRESSRULE1 -p tcp --dport 443 -j ACCEPT",
+					},
+					{
+						"-A ANTREA-POL-EGRESSRULE1 -p tcp --dport 80 -j ACCEPT",
+						"-A ANTREA-POL-EGRESSRULE1 -p tcp --dport 443 -j ACCEPT",
+					},
+				}
+				ingressCoreChains := []string{"ANTREA-POL-INGRESS-RULES"}
+				egressCoreChains := []string{"ANTREA-POL-EGRESS-RULES"}
+				ingressCoreRules := [][]string{
+					{
+						`-A ANTREA-POL-INGRESS-RULES -m set --match-set ANTREA-POL-INGRESSRULE1-4 src -j ANTREA-POL-INGRESSRULE1 -m comment --comment "Antrea: for rule ingressRule1, policy AntreaClusterNetworkPolicy:name1"`,
+						`-A ANTREA-POL-INGRESS-RULES -s 1.1.1.1/32 -p tcp --dport 443 -j ACCEPT -m comment --comment "Antrea: for rule ingressRule2, policy AntreaClusterNetworkPolicy:name1"`,
+					},
+				}
+				egressCoreRules := [][]string{
+					{
+						`-A ANTREA-POL-EGRESS-RULES -d 1.1.1.1/32 -j ANTREA-POL-EGRESSRULE1 -m comment --comment "Antrea: for rule egressRule1, policy AntreaClusterNetworkPolicy:name1"`,
+						`-A ANTREA-POL-EGRESS-RULES -d 1.1.1.1/32 -p tcp --dport 443 -j ACCEPT -m comment --comment "Antrea: for rule egressRule2, policy AntreaClusterNetworkPolicy:name1"`,
+					},
+				}
+				updatedIngressCoreRules := [][]string{
+					{
+						`-A ANTREA-POL-INGRESS-RULES -s 1.1.1.1/32 -p tcp --dport 443 -j ACCEPT -m comment --comment "Antrea: for rule ingressRule2, policy AntreaClusterNetworkPolicy:name1"`,
+					},
+				}
+				updatedEgressCoreRules := [][]string{
+					{
+						`-A ANTREA-POL-EGRESS-RULES -d 1.1.1.1/32 -p tcp --dport 443 -j ACCEPT -m comment --comment "Antrea: for rule egressRule2, policy AntreaClusterNetworkPolicy:name1"`,
+					},
+				}
+
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPSet("ANTREA-POL-INGRESSRULE1-4", sets.New[string]("1.1.1.1/32", "192.168.1.0/25"), false).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables(svcChains, svcRules, false).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables(ingressCoreChains, ingressCoreRules, false).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables(egressCoreChains, egressCoreRules, false).Times(1)
+
+				mockRouteClient.DeleteNodeNetworkPolicyIPSet("ANTREA-POL-INGRESSRULE1-4", false).Times(1)
+				mockRouteClient.DeleteNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESSRULE1"}, false).Times(1)
+				mockRouteClient.DeleteNodeNetworkPolicyIPTables([]string{"ANTREA-POL-EGRESSRULE1"}, false).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables(ingressCoreChains, updatedIngressCoreRules, false).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables(egressCoreChains, updatedEgressCoreRules, false).Times(1)
+			},
+		},
+		{
+			name:        "IPv6, add ingress and egress rules in batch, then forget some rules",
+			ipv6Enabled: true,
+			rulesToAdd: []*CompletedRule{
+				ingressRule1,
+				ingressRule2,
+				egressRule1,
+				egressRule2,
+			},
+			rulesToForget: []string{
+				ingressRuleID1,
+				egressRuleID1,
+			},
+			expectedCalls: func(mockRouteClient *routetest.MockInterfaceMockRecorder) {
+				svcChains := []string{
+					"ANTREA-POL-INGRESSRULE1",
+					"ANTREA-POL-EGRESSRULE1",
+				}
+				svcRules := [][]string{
+					{
+						"-A ANTREA-POL-INGRESSRULE1 -p tcp --dport 80 -j ACCEPT",
+						"-A ANTREA-POL-INGRESSRULE1 -p tcp --dport 443 -j ACCEPT",
+					},
+					{
+						"-A ANTREA-POL-EGRESSRULE1 -p tcp --dport 80 -j ACCEPT",
+						"-A ANTREA-POL-EGRESSRULE1 -p tcp --dport 443 -j ACCEPT",
+					},
+				}
+				ingressCoreChains := []string{"ANTREA-POL-INGRESS-RULES"}
+				egressCoreChains := []string{"ANTREA-POL-EGRESS-RULES"}
+				ingressCoreRules := [][]string{
+					{
+						`-A ANTREA-POL-INGRESS-RULES -m set --match-set ANTREA-POL-INGRESSRULE1-6 src -j ANTREA-POL-INGRESSRULE1 -m comment --comment "Antrea: for rule ingressRule1, policy AntreaClusterNetworkPolicy:name1"`,
+						`-A ANTREA-POL-INGRESS-RULES -s 2002:1a23:fb44::1/128 -p tcp --dport 443 -j ACCEPT -m comment --comment "Antrea: for rule ingressRule2, policy AntreaClusterNetworkPolicy:name1"`,
+					},
+				}
+				egressCoreRules := [][]string{
+					{
+						`-A ANTREA-POL-EGRESS-RULES -d 2002:1a23:fb44::1/128 -j ANTREA-POL-EGRESSRULE1 -m comment --comment "Antrea: for rule egressRule1, policy AntreaClusterNetworkPolicy:name1"`,
+						`-A ANTREA-POL-EGRESS-RULES -d 2002:1a23:fb44::1/128 -p tcp --dport 443 -j ACCEPT -m comment --comment "Antrea: for rule egressRule2, policy AntreaClusterNetworkPolicy:name1"`,
+					},
+				}
+				updatedIngressCoreRules := [][]string{
+					{
+						`-A ANTREA-POL-INGRESS-RULES -s 2002:1a23:fb44::1/128 -p tcp --dport 443 -j ACCEPT -m comment --comment "Antrea: for rule ingressRule2, policy AntreaClusterNetworkPolicy:name1"`,
+					},
+				}
+				updatedEgressCoreRules := [][]string{
+					{
+						`-A ANTREA-POL-EGRESS-RULES -d 2002:1a23:fb44::1/128 -p tcp --dport 443 -j ACCEPT -m comment --comment "Antrea: for rule egressRule2, policy AntreaClusterNetworkPolicy:name1"`,
+					},
+				}
+
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPSet("ANTREA-POL-INGRESSRULE1-6", sets.New[string]("2002:1a23:fb44::1/128", "fec0::192:168:1:8/125"), true).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables(svcChains, svcRules, true).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables(ingressCoreChains, ingressCoreRules, true).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables(egressCoreChains, egressCoreRules, true).Times(1)
+
+				mockRouteClient.DeleteNodeNetworkPolicyIPSet("ANTREA-POL-INGRESSRULE1-6", true).Times(1)
+				mockRouteClient.DeleteNodeNetworkPolicyIPTables([]string{"ANTREA-POL-INGRESSRULE1"}, true).Times(1)
+				mockRouteClient.DeleteNodeNetworkPolicyIPTables([]string{"ANTREA-POL-EGRESSRULE1"}, true).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables(ingressCoreChains, updatedIngressCoreRules, true).Times(1)
+				mockRouteClient.AddOrUpdateNodeNetworkPolicyIPTables(egressCoreChains, updatedEgressCoreRules, true).Times(1)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			controller := gomock.NewController(t)
+			mockRouteClient := routetest.NewMockInterface(controller)
+			r := newTestNodeReconciler(mockRouteClient, tt.ipv4Enabled, tt.ipv6Enabled)
+
+			tt.expectedCalls(mockRouteClient.EXPECT())
+			assert.NoError(t, r.BatchReconcile(tt.rulesToAdd))
+
+			for _, ruleID := range tt.rulesToForget {
+				assert.NoError(t, r.Forget(ruleID))
+			}
+		})
+	}
+}

--- a/pkg/agent/controller/networkpolicy/node_reconciler_unsupported.go
+++ b/pkg/agent/controller/networkpolicy/node_reconciler_unsupported.go
@@ -1,0 +1,49 @@
+//go:build !linux
+// +build !linux
+
+// Copyright 2024 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package networkpolicy
+
+import (
+	"antrea.io/antrea/pkg/agent/route"
+	"antrea.io/antrea/pkg/agent/types"
+)
+
+type nodeReconciler struct{}
+
+func newNodeReconciler(routeClient route.Interface, ipv4Enabled, ipv6Enabled bool) *nodeReconciler {
+	return &nodeReconciler{}
+}
+
+func (r *nodeReconciler) Reconcile(rule *CompletedRule) error {
+	return nil
+}
+
+func (r *nodeReconciler) BatchReconcile(rules []*CompletedRule) error {
+	return nil
+}
+
+func (r *nodeReconciler) Forget(ruleID string) error {
+	return nil
+}
+
+func (r *nodeReconciler) GetRuleByFlowID(ruleID uint32) (*types.PolicyRule, bool, error) {
+	return nil, false, nil
+}
+
+func (r *nodeReconciler) RunIDAllocatorWorker(stopCh <-chan struct{}) {
+
+}

--- a/pkg/agent/route/interfaces.go
+++ b/pkg/agent/route/interfaces.go
@@ -18,6 +18,8 @@ import (
 	"net"
 	"time"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	"antrea.io/antrea/pkg/agent/config"
 	binding "antrea.io/antrea/pkg/ovs/openflow"
 )
@@ -105,4 +107,16 @@ type Interface interface {
 
 	// ClearConntrackEntryForService deletes a conntrack entry for a Service connection.
 	ClearConntrackEntryForService(svcIP net.IP, svcPort uint16, endpointIP net.IP, protocol binding.Protocol) error
+
+	// AddOrUpdateNodeNetworkPolicyIPSet adds or updates ipset created for NodeNetworkPolicy.
+	AddOrUpdateNodeNetworkPolicyIPSet(ipsetName string, ipsetEntries sets.Set[string], isIPv6 bool) error
+
+	// DeleteNodeNetworkPolicyIPSet deletes ipset created for NodeNetworkPolicy.
+	DeleteNodeNetworkPolicyIPSet(ipsetName string, isIPv6 bool) error
+
+	// AddOrUpdateNodeNetworkPolicyIPTables adds or updates iptables chains and rules within the chains for NodeNetworkPolicy.
+	AddOrUpdateNodeNetworkPolicyIPTables(iptablesChains []string, iptablesRules [][]string, isIPv6 bool) error
+
+	// DeleteNodeNetworkPolicyIPTables deletes iptables chains and rules within the chains for NodeNetworkPolicy.
+	DeleteNodeNetworkPolicyIPTables(iptablesChains []string, isIPv6 bool) error
 }

--- a/pkg/agent/route/route_linux_test.go
+++ b/pkg/agent/route/route_linux_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/vishvananda/netlink"
 	"go.uber.org/mock/gomock"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"antrea.io/antrea/pkg/agent/config"
 	servicecidrtest "antrea.io/antrea/pkg/agent/servicecidr/testing"
@@ -147,17 +148,20 @@ func TestSyncIPSet(t *testing.T) {
 	podCIDRv6Str := "2001:ab03:cd04:55ef::/64"
 	_, podCIDRv6, _ := net.ParseCIDR(podCIDRv6Str)
 	tests := []struct {
-		name                  string
-		proxyAll              bool
-		multicastEnabled      bool
-		connectUplinkToBridge bool
-		networkConfig         *config.NetworkConfig
-		nodeConfig            *config.NodeConfig
-		nodePortsIPv4         []string
-		nodePortsIPv6         []string
-		clusterNodeIPs        map[string]string
-		clusterNodeIP6s       map[string]string
-		expectedCalls         func(ipset *ipsettest.MockInterfaceMockRecorder)
+		name                        string
+		proxyAll                    bool
+		multicastEnabled            bool
+		connectUplinkToBridge       bool
+		nodeNetworkPolicyEnabled    bool
+		networkConfig               *config.NetworkConfig
+		nodeConfig                  *config.NodeConfig
+		nodePortsIPv4               []string
+		nodePortsIPv6               []string
+		clusterNodeIPs              map[string]string
+		clusterNodeIP6s             map[string]string
+		nodeNetworkPolicyIPSetsIPv4 map[string]sets.Set[string]
+		nodeNetworkPolicyIPSetsIPv6 map[string]sets.Set[string]
+		expectedCalls               func(ipset *ipsettest.MockInterfaceMockRecorder)
 	}{
 		{
 			name: "networkPolicyOnly",
@@ -185,9 +189,10 @@ func TestSyncIPSet(t *testing.T) {
 			},
 		},
 		{
-			name:             "encap, proxyAll=true, multicastEnabled=true",
-			proxyAll:         true,
-			multicastEnabled: true,
+			name:                     "encap, proxyAll=true, multicastEnabled=true, nodeNetworkPolicy=true",
+			proxyAll:                 true,
+			multicastEnabled:         true,
+			nodeNetworkPolicyEnabled: true,
 			networkConfig: &config.NetworkConfig{
 				TrafficEncapMode: config.TrafficEncapModeEncap,
 				IPv4Enabled:      true,
@@ -197,10 +202,12 @@ func TestSyncIPSet(t *testing.T) {
 				PodIPv4CIDR: podCIDR,
 				PodIPv6CIDR: podCIDRv6,
 			},
-			nodePortsIPv4:   []string{"192.168.0.2,tcp:10000", "127.0.0.1,tcp:10000"},
-			nodePortsIPv6:   []string{"fe80::e643:4bff:fe44:ee,tcp:10000", "::1,tcp:10000"},
-			clusterNodeIPs:  map[string]string{"172.16.3.0/24": "192.168.0.3", "172.16.4.0/24": "192.168.0.4"},
-			clusterNodeIP6s: map[string]string{"2001:ab03:cd04:5503::/64": "fe80::e643:4bff:fe03", "2001:ab03:cd04:5504::/64": "fe80::e643:4bff:fe04"},
+			nodePortsIPv4:               []string{"192.168.0.2,tcp:10000", "127.0.0.1,tcp:10000"},
+			nodePortsIPv6:               []string{"fe80::e643:4bff:fe44:ee,tcp:10000", "::1,tcp:10000"},
+			clusterNodeIPs:              map[string]string{"172.16.3.0/24": "192.168.0.3", "172.16.4.0/24": "192.168.0.4"},
+			clusterNodeIP6s:             map[string]string{"2001:ab03:cd04:5503::/64": "fe80::e643:4bff:fe03", "2001:ab03:cd04:5504::/64": "fe80::e643:4bff:fe04"},
+			nodeNetworkPolicyIPSetsIPv4: map[string]sets.Set[string]{"ANTREA-POL-RULE1-4": sets.New[string]("1.1.1.1/32", "2.2.2.2/32")},
+			nodeNetworkPolicyIPSetsIPv6: map[string]sets.Set[string]{"ANTREA-POL-RULE1-6": sets.New[string]("fec0::1111/128", "fec0::2222/128")},
 			expectedCalls: func(mockIPSet *ipsettest.MockInterfaceMockRecorder) {
 				mockIPSet.CreateIPSet(antreaPodIPSet, ipset.HashNet, false)
 				mockIPSet.CreateIPSet(antreaPodIP6Set, ipset.HashNet, true)
@@ -218,6 +225,12 @@ func TestSyncIPSet(t *testing.T) {
 				mockIPSet.AddEntry(clusterNodeIPSet, "192.168.0.4")
 				mockIPSet.AddEntry(clusterNodeIP6Set, "fe80::e643:4bff:fe03")
 				mockIPSet.AddEntry(clusterNodeIP6Set, "fe80::e643:4bff:fe04")
+				mockIPSet.CreateIPSet("ANTREA-POL-RULE1-4", ipset.HashNet, false)
+				mockIPSet.CreateIPSet("ANTREA-POL-RULE1-6", ipset.HashNet, true)
+				mockIPSet.AddEntry("ANTREA-POL-RULE1-4", "1.1.1.1/32")
+				mockIPSet.AddEntry("ANTREA-POL-RULE1-4", "2.2.2.2/32")
+				mockIPSet.AddEntry("ANTREA-POL-RULE1-6", "fec0::1111/128")
+				mockIPSet.AddEntry("ANTREA-POL-RULE1-6", "fec0::2222/128")
 			},
 		},
 		{
@@ -247,15 +260,16 @@ func TestSyncIPSet(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			ipset := ipsettest.NewMockInterface(ctrl)
 			c := &Client{ipset: ipset,
-				networkConfig:         tt.networkConfig,
-				nodeConfig:            tt.nodeConfig,
-				proxyAll:              tt.proxyAll,
-				multicastEnabled:      tt.multicastEnabled,
-				connectUplinkToBridge: tt.connectUplinkToBridge,
-				nodePortsIPv4:         sync.Map{},
-				nodePortsIPv6:         sync.Map{},
-				clusterNodeIPs:        sync.Map{},
-				clusterNodeIP6s:       sync.Map{},
+				networkConfig:            tt.networkConfig,
+				nodeConfig:               tt.nodeConfig,
+				proxyAll:                 tt.proxyAll,
+				multicastEnabled:         tt.multicastEnabled,
+				connectUplinkToBridge:    tt.connectUplinkToBridge,
+				nodeNetworkPolicyEnabled: tt.nodeNetworkPolicyEnabled,
+				nodePortsIPv4:            sync.Map{},
+				nodePortsIPv6:            sync.Map{},
+				clusterNodeIPs:           sync.Map{},
+				clusterNodeIP6s:          sync.Map{},
 			}
 			for _, nodePortIPv4 := range tt.nodePortsIPv4 {
 				c.nodePortsIPv4.Store(nodePortIPv4, struct{}{})
@@ -269,6 +283,12 @@ func TestSyncIPSet(t *testing.T) {
 			for cidr, nodeIP := range tt.clusterNodeIP6s {
 				c.clusterNodeIP6s.Store(cidr, nodeIP)
 			}
+			for set, ips := range tt.nodeNetworkPolicyIPSetsIPv4 {
+				c.nodeNetworkPolicyIPSetsIPv4.Store(set, ips)
+			}
+			for set, ips := range tt.nodeNetworkPolicyIPSetsIPv6 {
+				c.nodeNetworkPolicyIPSetsIPv6.Store(set, ips)
+			}
 			tt.expectedCalls(ipset.EXPECT())
 			assert.NoError(t, c.syncIPSet())
 		})
@@ -277,22 +297,24 @@ func TestSyncIPSet(t *testing.T) {
 
 func TestSyncIPTables(t *testing.T) {
 	tests := []struct {
-		name                  string
-		isCloudEKS            bool
-		proxyAll              bool
-		multicastEnabled      bool
-		connectUplinkToBridge bool
-		networkConfig         *config.NetworkConfig
-		nodeConfig            *config.NodeConfig
-		nodePortsIPv4         []string
-		nodePortsIPv6         []string
-		markToSNATIP          map[uint32]string
-		expectedCalls         func(iptables *iptablestest.MockInterfaceMockRecorder)
+		name                     string
+		isCloudEKS               bool
+		proxyAll                 bool
+		multicastEnabled         bool
+		connectUplinkToBridge    bool
+		nodeNetworkPolicyEnabled bool
+		networkConfig            *config.NetworkConfig
+		nodeConfig               *config.NodeConfig
+		nodePortsIPv4            []string
+		nodePortsIPv6            []string
+		markToSNATIP             map[uint32]string
+		expectedCalls            func(iptables *iptablestest.MockInterfaceMockRecorder)
 	}{
 		{
-			name:             "encap,egress=true,multicastEnabled=true,proxyAll=true",
-			proxyAll:         true,
-			multicastEnabled: true,
+			name:                     "encap,egress=true,multicastEnabled=true,proxyAll=true,nodeNetworkPolicy=true",
+			proxyAll:                 true,
+			multicastEnabled:         true,
+			nodeNetworkPolicyEnabled: true,
 			networkConfig: &config.NetworkConfig{
 				TrafficEncapMode: config.TrafficEncapModeEncap,
 				TunnelType:       ovsconfig.GeneveTunnel,
@@ -327,6 +349,10 @@ func TestSyncIPTables(t *testing.T) {
 				mockIPTables.AppendRule(iptables.ProtocolDual, iptables.NATTable, iptables.PreRoutingChain, []string{"-j", antreaPreRoutingChain, "-m", "comment", "--comment", "Antrea: jump to Antrea prerouting rules"})
 				mockIPTables.EnsureChain(iptables.ProtocolDual, iptables.NATTable, antreaOutputChain)
 				mockIPTables.AppendRule(iptables.ProtocolDual, iptables.NATTable, iptables.OutputChain, []string{"-j", antreaOutputChain, "-m", "comment", "--comment", "Antrea: jump to Antrea output rules"})
+				mockIPTables.EnsureChain(iptables.ProtocolDual, iptables.FilterTable, antreaInputChain)
+				mockIPTables.AppendRule(iptables.ProtocolDual, iptables.FilterTable, iptables.InputChain, []string{"-j", antreaInputChain, "-m", "comment", "--comment", "Antrea: jump to Antrea input rules"})
+				mockIPTables.EnsureChain(iptables.ProtocolDual, iptables.FilterTable, antreaOutputChain)
+				mockIPTables.AppendRule(iptables.ProtocolDual, iptables.FilterTable, iptables.OutputChain, []string{"-j", antreaOutputChain, "-m", "comment", "--comment", "Antrea: jump to Antrea output rules"})
 				mockIPTables.Restore(`*raw
 :ANTREA-PREROUTING - [0:0]
 :ANTREA-OUTPUT - [0:0]
@@ -341,8 +367,23 @@ COMMIT
 COMMIT
 *filter
 :ANTREA-FORWARD - [0:0]
+:ANTREA-INPUT - [0:0]
+:ANTREA-OUTPUT - [0:0]
+:ANTREA-POL-EGRESS-RULES - [0:0]
+:ANTREA-POL-INGRESS-RULES - [0:0]
+:ANTREA-POL-PRE-EGRESS-RULES - [0:0]
+:ANTREA-POL-PRE-INGRESS-RULES - [0:0]
 -A ANTREA-FORWARD -m comment --comment "Antrea: accept packets from local Pods" -i antrea-gw0 -j ACCEPT
 -A ANTREA-FORWARD -m comment --comment "Antrea: accept packets to local Pods" -o antrea-gw0 -j ACCEPT
+-A ANTREA-INPUT -m comment --comment "Antrea: jump to static ingress NodeNetworkPolicy rules" -j ANTREA-POL-PRE-INGRESS-RULES
+-A ANTREA-INPUT -m comment --comment "Antrea: jump to ingress NodeNetworkPolicy rules" -j ANTREA-POL-INGRESS-RULES
+-A ANTREA-OUTPUT -m comment --comment "Antrea: jump to static egress NodeNetworkPolicy rules" -j ANTREA-POL-PRE-EGRESS-RULES
+-A ANTREA-OUTPUT -m comment --comment "Antrea: jump to egress NodeNetworkPolicy rules" -j ANTREA-POL-EGRESS-RULES
+-A ANTREA-POL-INGRESS-RULES -j ACCEPT -m comment --comment "mock rule"
+-A ANTREA-POL-PRE-EGRESS-RULES -m conntrack --ctstate ESTABLISHED,RELATED -m comment --comment "Antrea: allow egress established or related packets" -j ACCEPT
+-A ANTREA-POL-PRE-EGRESS-RULES -o lo -m comment --comment "Antrea: allow egress packets to loopback" -j ACCEPT
+-A ANTREA-POL-PRE-INGRESS-RULES -m conntrack --ctstate ESTABLISHED,RELATED -m comment --comment "Antrea: allow ingress established or related packets" -j ACCEPT
+-A ANTREA-POL-PRE-INGRESS-RULES -i lo -m comment --comment "Antrea: allow ingress packets from loopback" -j ACCEPT
 COMMIT
 *nat
 :ANTREA-PREROUTING - [0:0]
@@ -370,8 +411,23 @@ COMMIT
 COMMIT
 *filter
 :ANTREA-FORWARD - [0:0]
+:ANTREA-INPUT - [0:0]
+:ANTREA-OUTPUT - [0:0]
+:ANTREA-POL-EGRESS-RULES - [0:0]
+:ANTREA-POL-INGRESS-RULES - [0:0]
+:ANTREA-POL-PRE-EGRESS-RULES - [0:0]
+:ANTREA-POL-PRE-INGRESS-RULES - [0:0]
 -A ANTREA-FORWARD -m comment --comment "Antrea: accept packets from local Pods" -i antrea-gw0 -j ACCEPT
 -A ANTREA-FORWARD -m comment --comment "Antrea: accept packets to local Pods" -o antrea-gw0 -j ACCEPT
+-A ANTREA-INPUT -m comment --comment "Antrea: jump to static ingress NodeNetworkPolicy rules" -j ANTREA-POL-PRE-INGRESS-RULES
+-A ANTREA-INPUT -m comment --comment "Antrea: jump to ingress NodeNetworkPolicy rules" -j ANTREA-POL-INGRESS-RULES
+-A ANTREA-OUTPUT -m comment --comment "Antrea: jump to static egress NodeNetworkPolicy rules" -j ANTREA-POL-PRE-EGRESS-RULES
+-A ANTREA-OUTPUT -m comment --comment "Antrea: jump to egress NodeNetworkPolicy rules" -j ANTREA-POL-EGRESS-RULES
+-A ANTREA-POL-INGRESS-RULES -j ACCEPT -m comment --comment "mock rule"
+-A ANTREA-POL-PRE-EGRESS-RULES -m conntrack --ctstate ESTABLISHED,RELATED -m comment --comment "Antrea: allow egress established or related packets" -j ACCEPT
+-A ANTREA-POL-PRE-EGRESS-RULES -o lo -m comment --comment "Antrea: allow egress packets to loopback" -j ACCEPT
+-A ANTREA-POL-PRE-INGRESS-RULES -m conntrack --ctstate ESTABLISHED,RELATED -m comment --comment "Antrea: allow ingress established or related packets" -j ACCEPT
+-A ANTREA-POL-PRE-INGRESS-RULES -i lo -m comment --comment "Antrea: allow ingress packets from loopback" -j ACCEPT
 COMMIT
 *nat
 :ANTREA-PREROUTING - [0:0]
@@ -527,16 +583,24 @@ COMMIT
 			ctrl := gomock.NewController(t)
 			mockIPTables := iptablestest.NewMockInterface(ctrl)
 			c := &Client{iptables: mockIPTables,
-				networkConfig:         tt.networkConfig,
-				nodeConfig:            tt.nodeConfig,
-				proxyAll:              tt.proxyAll,
-				isCloudEKS:            tt.isCloudEKS,
-				multicastEnabled:      tt.multicastEnabled,
-				connectUplinkToBridge: tt.connectUplinkToBridge,
-				markToSNATIP:          sync.Map{},
+				networkConfig:            tt.networkConfig,
+				nodeConfig:               tt.nodeConfig,
+				proxyAll:                 tt.proxyAll,
+				isCloudEKS:               tt.isCloudEKS,
+				multicastEnabled:         tt.multicastEnabled,
+				connectUplinkToBridge:    tt.connectUplinkToBridge,
+				nodeNetworkPolicyEnabled: tt.nodeNetworkPolicyEnabled,
+				deterministic:            true,
 			}
 			for mark, snatIP := range tt.markToSNATIP {
 				c.markToSNATIP.Store(mark, net.ParseIP(snatIP))
+			}
+			if tt.nodeNetworkPolicyEnabled {
+				c.initNodeNetworkPolicy()
+				c.nodeNetworkPolicyIPTablesIPv4.Store(config.NodeNetworkPolicyIngressRulesChain, []string{
+					`-A ANTREA-POL-INGRESS-RULES -j ACCEPT -m comment --comment "mock rule"`})
+				c.nodeNetworkPolicyIPTablesIPv6.Store(config.NodeNetworkPolicyIngressRulesChain, []string{
+					`-A ANTREA-POL-INGRESS-RULES -j ACCEPT -m comment --comment "mock rule"`})
 			}
 			tt.expectedCalls(mockIPTables.EXPECT())
 			assert.NoError(t, c.syncIPTables())
@@ -1868,6 +1932,228 @@ func TestEgressRule(t *testing.T) {
 
 			assert.NoError(t, c.AddEgressRule(tt.tableID, tt.mark))
 			assert.NoError(t, c.DeleteEgressRule(tt.tableID, tt.mark))
+		})
+	}
+}
+
+func TestAddAndDeleteNodeNetworkPolicyIPSet(t *testing.T) {
+	ipv4SetName := "TEST-IPSET-4"
+	ipv4Net1 := "1.1.1.1/32"
+	ipv4Net2 := "2.2.2.2/32"
+	ipv4Net3 := "3.3.3.3/32"
+	ipv6SetName := "TEST-IPSET-6"
+	ipv6Net1 := "fec0::1111/128"
+	ipv6Net2 := "fec0::2222/128"
+	ipv6Net3 := "fec0::3333/128"
+
+	tests := []struct {
+		name             string
+		ipsetName        string
+		prevIPSetEntries sets.Set[string]
+		curIPSetEntries  sets.Set[string]
+		isIPv6           bool
+		expectedCalls    func(mockIPSet *ipsettest.MockInterfaceMockRecorder)
+	}{
+		{
+			name:            "IPv4, add an ipset and delete it",
+			ipsetName:       ipv4SetName,
+			curIPSetEntries: sets.New[string](ipv4Net1, ipv4Net3),
+			isIPv6:          false,
+			expectedCalls: func(mockIPSet *ipsettest.MockInterfaceMockRecorder) {
+				mockIPSet.CreateIPSet(ipv4SetName, ipset.HashNet, false).Times(1)
+				mockIPSet.AddEntry(ipv4SetName, ipv4Net1).Times(1)
+				mockIPSet.AddEntry(ipv4SetName, ipv4Net3).Times(1)
+				mockIPSet.DestroyIPSet(ipv4SetName).Times(1)
+			},
+		},
+		{
+			name:             "IPv4, update an ipset and delete it",
+			ipsetName:        ipv4SetName,
+			prevIPSetEntries: sets.New[string](ipv4Net1, ipv4Net2),
+			curIPSetEntries:  sets.New[string](ipv4Net1, ipv4Net3),
+			isIPv6:           false,
+			expectedCalls: func(mockIPSet *ipsettest.MockInterfaceMockRecorder) {
+				mockIPSet.CreateIPSet(ipv4SetName, ipset.HashNet, false).Times(1)
+				mockIPSet.AddEntry(ipv4SetName, ipv4Net3).Times(1)
+				mockIPSet.DelEntry(ipv4SetName, ipv4Net2).Times(1)
+				mockIPSet.DestroyIPSet(ipv4SetName).Times(1)
+			},
+		},
+		{
+			name:            "IPv6, add an ipset and delete it",
+			ipsetName:       ipv6SetName,
+			curIPSetEntries: sets.New[string](ipv6Net1, ipv6Net3),
+			isIPv6:          true,
+			expectedCalls: func(mockIPSet *ipsettest.MockInterfaceMockRecorder) {
+				mockIPSet.CreateIPSet(ipv6SetName, ipset.HashNet, true).Times(1)
+				mockIPSet.AddEntry(ipv6SetName, ipv6Net1).Times(1)
+				mockIPSet.AddEntry(ipv6SetName, ipv6Net3).Times(1)
+				mockIPSet.DestroyIPSet(ipv6SetName).Times(1)
+			},
+		},
+		{
+			name:             "IPv6, update an ipset and delete it",
+			ipsetName:        ipv6SetName,
+			prevIPSetEntries: sets.New[string](ipv6Net1, ipv6Net2),
+			curIPSetEntries:  sets.New[string](ipv6Net1, ipv6Net3),
+			isIPv6:           true,
+			expectedCalls: func(mockIPSet *ipsettest.MockInterfaceMockRecorder) {
+				mockIPSet.CreateIPSet(ipv6SetName, ipset.HashNet, true).Times(1)
+				mockIPSet.AddEntry(ipv6SetName, ipv6Net3).Times(1)
+				mockIPSet.DelEntry(ipv6SetName, ipv6Net2).Times(1)
+				mockIPSet.DestroyIPSet(ipv6SetName).Times(1)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockIPSet := ipsettest.NewMockInterface(ctrl)
+			c := &Client{ipset: mockIPSet}
+			tt.expectedCalls(mockIPSet.EXPECT())
+
+			if tt.prevIPSetEntries != nil {
+				if tt.isIPv6 {
+					c.nodeNetworkPolicyIPSetsIPv6.Store(tt.ipsetName, tt.prevIPSetEntries)
+				} else {
+					c.nodeNetworkPolicyIPSetsIPv4.Store(tt.ipsetName, tt.prevIPSetEntries)
+				}
+			}
+
+			assert.NoError(t, c.AddOrUpdateNodeNetworkPolicyIPSet(tt.ipsetName, tt.curIPSetEntries, tt.isIPv6))
+			var exists bool
+			if tt.isIPv6 {
+				_, exists = c.nodeNetworkPolicyIPSetsIPv6.Load(tt.ipsetName)
+			} else {
+				_, exists = c.nodeNetworkPolicyIPSetsIPv4.Load(tt.ipsetName)
+			}
+			assert.True(t, exists)
+
+			assert.NoError(t, c.DeleteNodeNetworkPolicyIPSet(tt.ipsetName, tt.isIPv6))
+			if tt.isIPv6 {
+				_, exists = c.nodeNetworkPolicyIPSetsIPv6.Load(tt.ipsetName)
+			} else {
+				_, exists = c.nodeNetworkPolicyIPSetsIPv4.Load(tt.ipsetName)
+			}
+			assert.False(t, exists)
+		})
+	}
+}
+
+func TestAddAndDeleteNodeNetworkPolicyIPTables(t *testing.T) {
+	ingressChain := config.NodeNetworkPolicyIngressRulesChain
+	ingressRules := []string{
+		"-A ANTREA-POL-INGRESS-RULES -p tcp --dport 80 -j ACCEPT",
+	}
+	svcChain := "ANTREA-POL-12619C0214FB0845"
+	svcRules := []string{
+		"-A ANTREA-POL-12619C0214FB0845 -p tcp --dport 80 -j ACCEPT",
+		"-A ANTREA-POL-12619C0214FB0845 -p tcp --dport 443 -j ACCEPT",
+	}
+
+	tests := []struct {
+		name          string
+		isIPv6        bool
+		expectedCalls func(mockIPTables *iptablestest.MockInterfaceMockRecorder)
+		expectedRules map[string][]string
+	}{
+		{
+			name:   "IPv4",
+			isIPv6: false,
+			expectedCalls: func(mockIPTables *iptablestest.MockInterfaceMockRecorder) {
+				mockIPTables.Restore(`*filter
+:ANTREA-POL-INGRESS-RULES - [0:0]
+-A ANTREA-POL-INGRESS-RULES -p tcp --dport 80 -j ACCEPT
+COMMIT
+`, false, false)
+				mockIPTables.Restore(`*filter
+:ANTREA-POL-12619C0214FB0845 - [0:0]
+-A ANTREA-POL-12619C0214FB0845 -p tcp --dport 80 -j ACCEPT
+-A ANTREA-POL-12619C0214FB0845 -p tcp --dport 443 -j ACCEPT
+COMMIT
+`, false, false)
+				mockIPTables.DeleteChain(iptables.ProtocolIPv4, iptables.FilterTable, svcChain).Times(1)
+				mockIPTables.Restore(`*filter
+:ANTREA-POL-INGRESS-RULES - [0:0]
+COMMIT
+`, false, false)
+			},
+		},
+
+		{
+			name:   "IPv6",
+			isIPv6: true,
+			expectedCalls: func(mockIPTables *iptablestest.MockInterfaceMockRecorder) {
+				mockIPTables.Restore(`*filter
+:ANTREA-POL-INGRESS-RULES - [0:0]
+-A ANTREA-POL-INGRESS-RULES -p tcp --dport 80 -j ACCEPT
+COMMIT
+`, false, true)
+				mockIPTables.Restore(`*filter
+:ANTREA-POL-12619C0214FB0845 - [0:0]
+-A ANTREA-POL-12619C0214FB0845 -p tcp --dport 80 -j ACCEPT
+-A ANTREA-POL-12619C0214FB0845 -p tcp --dport 443 -j ACCEPT
+COMMIT
+`, false, true)
+				mockIPTables.DeleteChain(iptables.ProtocolIPv6, iptables.FilterTable, svcChain).Times(1)
+				mockIPTables.Restore(`*filter
+:ANTREA-POL-INGRESS-RULES - [0:0]
+COMMIT
+`, false, true)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockIPTables := iptablestest.NewMockInterface(ctrl)
+			c := &Client{iptables: mockIPTables,
+				networkConfig: &config.NetworkConfig{
+					IPv4Enabled: true,
+					IPv6Enabled: true,
+				},
+			}
+			c.initNodeNetworkPolicy()
+
+			tt.expectedCalls(mockIPTables.EXPECT())
+
+			assert.NoError(t, c.AddOrUpdateNodeNetworkPolicyIPTables([]string{ingressChain}, [][]string{ingressRules}, tt.isIPv6))
+			var gotRules any
+			var exists bool
+			if tt.isIPv6 {
+				gotRules, exists = c.nodeNetworkPolicyIPTablesIPv6.Load(ingressChain)
+			} else {
+				gotRules, exists = c.nodeNetworkPolicyIPTablesIPv4.Load(ingressChain)
+			}
+			assert.True(t, exists)
+			assert.EqualValues(t, ingressRules, gotRules)
+
+			assert.NoError(t, c.AddOrUpdateNodeNetworkPolicyIPTables([]string{svcChain}, [][]string{svcRules}, tt.isIPv6))
+			if tt.isIPv6 {
+				gotRules, exists = c.nodeNetworkPolicyIPTablesIPv6.Load(svcChain)
+			} else {
+				gotRules, exists = c.nodeNetworkPolicyIPTablesIPv4.Load(svcChain)
+			}
+			assert.True(t, exists)
+			assert.EqualValues(t, svcRules, gotRules)
+
+			assert.NoError(t, c.DeleteNodeNetworkPolicyIPTables([]string{svcChain}, tt.isIPv6))
+			if tt.isIPv6 {
+				_, exists = c.nodeNetworkPolicyIPTablesIPv6.Load(svcChain)
+			} else {
+				_, exists = c.nodeNetworkPolicyIPTablesIPv4.Load(svcChain)
+			}
+			assert.False(t, exists)
+
+			assert.NoError(t, c.AddOrUpdateNodeNetworkPolicyIPTables([]string{ingressChain}, [][]string{nil}, tt.isIPv6))
+			if tt.isIPv6 {
+				gotRules, exists = c.nodeNetworkPolicyIPTablesIPv6.Load(ingressChain)
+			} else {
+				gotRules, exists = c.nodeNetworkPolicyIPTablesIPv4.Load(ingressChain)
+			}
+			assert.True(t, exists)
+			assert.EqualValues(t, []string(nil), gotRules)
 		})
 	}
 }

--- a/pkg/agent/route/route_windows.go
+++ b/pkg/agent/route/route_windows.go
@@ -71,7 +71,13 @@ type Client struct {
 }
 
 // NewClient returns a route client.
-func NewClient(networkConfig *config.NetworkConfig, noSNAT, proxyAll, connectUplinkToBridge, multicastEnabled bool, serviceCIDRProvider servicecidr.Interface) (*Client, error) {
+func NewClient(networkConfig *config.NetworkConfig,
+	noSNAT bool,
+	proxyAll bool,
+	connectUplinkToBridge bool,
+	nodeNetworkPolicyEnabled bool,
+	multicastEnabled bool,
+	serviceCIDRProvider servicecidr.Interface) (*Client, error) {
 	return &Client{
 		networkConfig:        networkConfig,
 		nodeRoutes:           &sync.Map{},
@@ -592,4 +598,20 @@ func (c *Client) AddEgressRule(tableID uint32, mark uint32) error {
 
 func (c *Client) DeleteEgressRule(tableID uint32, mark uint32) error {
 	return errors.New("DeleteEgressRule is not implemented on Windows")
+}
+
+func (c *Client) AddOrUpdateNodeNetworkPolicyIPSet(ipsetName string, ipsetEntries sets.Set[string], isIPv6 bool) error {
+	return errors.New("AddOrUpdateNodeNetworkPolicyIPSet is not implemented on Windows")
+}
+
+func (c *Client) DeleteNodeNetworkPolicyIPSet(ipsetName string, isIPv6 bool) error {
+	return errors.New("DeleteNodeNetworkPolicyIPSet is not implemented on Windows")
+}
+
+func (c *Client) AddOrUpdateNodeNetworkPolicyIPTables(iptablesChains []string, iptablesRules [][]string, isIPv6 bool) error {
+	return errors.New("AddOrUpdateNodeNetworkPolicyIPTables is not implemented on Windows")
+}
+
+func (c *Client) DeleteNodeNetworkPolicyIPTables(iptablesChains []string, isIPv6 bool) error {
+	return errors.New("DeleteNodeNetworkPolicyIPTables is not implemented on Windows")
 }

--- a/pkg/agent/route/route_windows_test.go
+++ b/pkg/agent/route/route_windows_test.go
@@ -61,7 +61,7 @@ func TestRouteOperation(t *testing.T) {
 	gwIP2 := net.ParseIP("192.168.3.1")
 	_, destCIDR2, _ := net.ParseCIDR(dest2)
 
-	client, err := NewClient(&config.NetworkConfig{}, true, false, false, false, nil)
+	client, err := NewClient(&config.NetworkConfig{}, true, false, false, false, false, nil)
 
 	require.Nil(t, err)
 	called := false

--- a/pkg/agent/route/testing/mock_route.go
+++ b/pkg/agent/route/testing/mock_route.go
@@ -30,6 +30,7 @@ import (
 	config "antrea.io/antrea/pkg/agent/config"
 	openflow "antrea.io/antrea/pkg/ovs/openflow"
 	gomock "go.uber.org/mock/gomock"
+	sets "k8s.io/apimachinery/pkg/util/sets"
 )
 
 // MockInterface is a mock of Interface interface.
@@ -123,6 +124,34 @@ func (m *MockInterface) AddNodePort(arg0 []net.IP, arg1 uint16, arg2 openflow.Pr
 func (mr *MockInterfaceMockRecorder) AddNodePort(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddNodePort", reflect.TypeOf((*MockInterface)(nil).AddNodePort), arg0, arg1, arg2)
+}
+
+// AddOrUpdateNodeNetworkPolicyIPSet mocks base method.
+func (m *MockInterface) AddOrUpdateNodeNetworkPolicyIPSet(arg0 string, arg1 sets.Set[string], arg2 bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddOrUpdateNodeNetworkPolicyIPSet", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddOrUpdateNodeNetworkPolicyIPSet indicates an expected call of AddOrUpdateNodeNetworkPolicyIPSet.
+func (mr *MockInterfaceMockRecorder) AddOrUpdateNodeNetworkPolicyIPSet(arg0, arg1, arg2 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddOrUpdateNodeNetworkPolicyIPSet", reflect.TypeOf((*MockInterface)(nil).AddOrUpdateNodeNetworkPolicyIPSet), arg0, arg1, arg2)
+}
+
+// AddOrUpdateNodeNetworkPolicyIPTables mocks base method.
+func (m *MockInterface) AddOrUpdateNodeNetworkPolicyIPTables(arg0 []string, arg1 [][]string, arg2 bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddOrUpdateNodeNetworkPolicyIPTables", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddOrUpdateNodeNetworkPolicyIPTables indicates an expected call of AddOrUpdateNodeNetworkPolicyIPTables.
+func (mr *MockInterfaceMockRecorder) AddOrUpdateNodeNetworkPolicyIPTables(arg0, arg1, arg2 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddOrUpdateNodeNetworkPolicyIPTables", reflect.TypeOf((*MockInterface)(nil).AddOrUpdateNodeNetworkPolicyIPTables), arg0, arg1, arg2)
 }
 
 // AddRouteForLink mocks base method.
@@ -235,6 +264,34 @@ func (m *MockInterface) DeleteLocalAntreaFlexibleIPAMPodRule(arg0 []net.IP) erro
 func (mr *MockInterfaceMockRecorder) DeleteLocalAntreaFlexibleIPAMPodRule(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteLocalAntreaFlexibleIPAMPodRule", reflect.TypeOf((*MockInterface)(nil).DeleteLocalAntreaFlexibleIPAMPodRule), arg0)
+}
+
+// DeleteNodeNetworkPolicyIPSet mocks base method.
+func (m *MockInterface) DeleteNodeNetworkPolicyIPSet(arg0 string, arg1 bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteNodeNetworkPolicyIPSet", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteNodeNetworkPolicyIPSet indicates an expected call of DeleteNodeNetworkPolicyIPSet.
+func (mr *MockInterfaceMockRecorder) DeleteNodeNetworkPolicyIPSet(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNodeNetworkPolicyIPSet", reflect.TypeOf((*MockInterface)(nil).DeleteNodeNetworkPolicyIPSet), arg0, arg1)
+}
+
+// DeleteNodeNetworkPolicyIPTables mocks base method.
+func (m *MockInterface) DeleteNodeNetworkPolicyIPTables(arg0 []string, arg1 bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteNodeNetworkPolicyIPTables", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteNodeNetworkPolicyIPTables indicates an expected call of DeleteNodeNetworkPolicyIPTables.
+func (mr *MockInterfaceMockRecorder) DeleteNodeNetworkPolicyIPTables(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNodeNetworkPolicyIPTables", reflect.TypeOf((*MockInterface)(nil).DeleteNodeNetworkPolicyIPTables), arg0, arg1)
 }
 
 // DeleteNodePort mocks base method.

--- a/pkg/agent/types/networkpolicy.go
+++ b/pkg/agent/types/networkpolicy.go
@@ -15,6 +15,8 @@
 package types
 
 import (
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	"antrea.io/antrea/pkg/apis/controlplane/v1beta2"
 	secv1beta1 "antrea.io/antrea/pkg/apis/crd/v1beta1"
 	binding "antrea.io/antrea/pkg/ovs/openflow"
@@ -73,6 +75,17 @@ type Address interface {
 	GetMatchValue() string
 	GetMatchKey(addrType AddressType) *MatchKey
 	GetValue() interface{}
+}
+
+type NodePolicyRule struct {
+	IPSet           string
+	IPSetMembers    sets.Set[string]
+	Priority        *Priority
+	ServiceIPTChain string
+	ServiceIPTRules []string
+	CoreIPTChain    string
+	CoreIPTRule     string
+	IsIPv6          bool
 }
 
 // PolicyRule groups configurations to set up conjunctive match for egress/ingress policy rules.

--- a/pkg/agent/util/iptables/builder.go
+++ b/pkg/agent/util/iptables/builder.go
@@ -1,0 +1,211 @@
+//go:build !windows
+// +build !windows
+
+// Copyright 2024 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iptables
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+type iptablesRule struct {
+	chain string
+	specs *strings.Builder
+}
+
+type iptablesRuleBuilder struct {
+	iptablesRule
+}
+
+func NewRuleBuilder(chain string) IPTablesRuleBuilder {
+	builder := &iptablesRuleBuilder{
+		iptablesRule{
+			chain: chain,
+			specs: &strings.Builder{},
+		},
+	}
+	return builder
+}
+
+func (b *iptablesRuleBuilder) writeSpec(spec string) {
+	b.specs.WriteString(spec)
+	b.specs.WriteByte(' ')
+}
+
+func (b *iptablesRuleBuilder) MatchCIDRSrc(cidr string) IPTablesRuleBuilder {
+	if cidr == "" || cidr == "0.0.0.0/0" || cidr == "::/0" {
+		return b
+	}
+	matchStr := fmt.Sprintf("-s %s", cidr)
+	b.writeSpec(matchStr)
+	return b
+}
+
+func (b *iptablesRuleBuilder) MatchCIDRDst(cidr string) IPTablesRuleBuilder {
+	if cidr == "" || cidr == "0.0.0.0/0" || cidr == "::/0" {
+		return b
+	}
+	matchStr := fmt.Sprintf("-d %s", cidr)
+	b.writeSpec(matchStr)
+	return b
+}
+
+func (b *iptablesRuleBuilder) MatchIPSetSrc(ipset string) IPTablesRuleBuilder {
+	if ipset == "" {
+		return b
+	}
+	matchStr := fmt.Sprintf("-m set --match-set %s src", ipset)
+	b.writeSpec(matchStr)
+	return b
+}
+
+func (b *iptablesRuleBuilder) MatchIPSetDst(ipset string) IPTablesRuleBuilder {
+	if ipset == "" {
+		return b
+	}
+	matchStr := fmt.Sprintf("-m set --match-set %s dst", ipset)
+	b.writeSpec(matchStr)
+	return b
+}
+
+func (b *iptablesRuleBuilder) MatchTransProtocol(protocol string) IPTablesRuleBuilder {
+	if protocol == "" {
+		return b
+	}
+	matchStr := fmt.Sprintf("-p %s", protocol)
+	b.writeSpec(matchStr)
+	return b
+}
+
+func (b *iptablesRuleBuilder) MatchDstPort(port *intstr.IntOrString, endPort *int32) IPTablesRuleBuilder {
+	if port == nil {
+		return b
+	}
+	var matchStr string
+	if endPort != nil {
+		matchStr = fmt.Sprintf("--dport %s:%d", port.String(), *endPort)
+	} else {
+		matchStr = fmt.Sprintf("--dport %s", port.String())
+	}
+	b.writeSpec(matchStr)
+	return b
+}
+
+func (b *iptablesRuleBuilder) MatchSrcPort(port, endPort *int32) IPTablesRuleBuilder {
+	if port == nil {
+		return b
+	}
+	var matchStr string
+	if endPort != nil {
+		matchStr = fmt.Sprintf("--sport %d:%d", *port, *endPort)
+	} else {
+		matchStr = fmt.Sprintf("--sport %d", *port)
+	}
+	b.writeSpec(matchStr)
+	return b
+}
+
+func (b *iptablesRuleBuilder) MatchICMP(icmpType, icmpCode *int32, ipProtocol Protocol) IPTablesRuleBuilder {
+	parts := []string{"-p"}
+	icmpTypeStr := "icmp"
+	if ipProtocol != ProtocolIPv4 {
+		icmpTypeStr = "icmpv6"
+	}
+	parts = append(parts, icmpTypeStr)
+
+	if icmpType != nil {
+		icmpTypeFlag := "--icmp-type"
+		if ipProtocol != ProtocolIPv4 {
+			icmpTypeFlag = "--icmpv6-type"
+		}
+
+		if icmpCode != nil {
+			parts = append(parts, icmpTypeFlag, fmt.Sprintf("%d/%d", *icmpType, *icmpCode))
+		} else {
+			parts = append(parts, icmpTypeFlag, strconv.Itoa(int(*icmpType)))
+		}
+	}
+	b.writeSpec(strings.Join(parts, " "))
+	return b
+}
+
+func (b *iptablesRuleBuilder) MatchEstablishedOrRelated() IPTablesRuleBuilder {
+	b.writeSpec("-m conntrack --ctstate ESTABLISHED,RELATED")
+	return b
+}
+
+func (b *iptablesRuleBuilder) MatchInputInterface(interfaceName string) IPTablesRuleBuilder {
+	if interfaceName == "" {
+		return b
+	}
+	specStr := fmt.Sprintf("-i %s", interfaceName)
+	b.writeSpec(specStr)
+	return b
+}
+
+func (b *iptablesRuleBuilder) MatchOutputInterface(interfaceName string) IPTablesRuleBuilder {
+	if interfaceName == "" {
+		return b
+	}
+	specStr := fmt.Sprintf("-o %s", interfaceName)
+	b.writeSpec(specStr)
+	return b
+}
+
+func (b *iptablesRuleBuilder) SetTarget(target string) IPTablesRuleBuilder {
+	if target == "" {
+		return b
+	}
+	targetStr := fmt.Sprintf("-j %s", target)
+	b.writeSpec(targetStr)
+	return b
+}
+
+func (b *iptablesRuleBuilder) SetComment(comment string) IPTablesRuleBuilder {
+	if comment == "" {
+		return b
+	}
+
+	commentStr := fmt.Sprintf("-m comment --comment \"%s\"", comment)
+	b.writeSpec(commentStr)
+	return b
+}
+
+func (b *iptablesRuleBuilder) CopyBuilder() IPTablesRuleBuilder {
+	var copiedSpec strings.Builder
+	copiedSpec.Grow(b.specs.Len())
+	copiedSpec.WriteString(b.specs.String())
+	builder := &iptablesRuleBuilder{
+		iptablesRule{
+			chain: b.chain,
+			specs: &copiedSpec,
+		},
+	}
+	return builder
+}
+
+func (b *iptablesRuleBuilder) Done() IPTablesRule {
+	return &b.iptablesRule
+}
+
+func (e *iptablesRule) GetRule() string {
+	ruleStr := fmt.Sprintf("-A %s %s", e.chain, e.specs.String())
+	return ruleStr[:len(ruleStr)-1]
+}

--- a/pkg/agent/util/iptables/builder_test.go
+++ b/pkg/agent/util/iptables/builder_test.go
@@ -1,0 +1,135 @@
+//go:build !windows
+// +build !windows
+
+// Copyright 2024 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iptables
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+var (
+	ipsetAlfa  = "alfa"
+	ipsetBravo = "bravo"
+	eth0       = "eth0"
+	eth1       = "eth1"
+	port8080   = &intstr.IntOrString{Type: intstr.Int, IntVal: 8080}
+	port137    = &intstr.IntOrString{Type: intstr.Int, IntVal: 137}
+	port139    = int32(139)
+	port40000  = int32(40000)
+	port50000  = int32(50000)
+	icmpType0  = int32(0)
+	icmpCode0  = int32(0)
+	cidr       = "192.168.1.0/24"
+)
+
+func TestBuilders(t *testing.T) {
+	testCases := []struct {
+		name      string
+		chain     string
+		buildFunc func(IPTablesRuleBuilder) IPTablesRule
+		expected  string
+	}{
+		{
+			name:  "Accept TCP destination 8080 in FORWARD",
+			chain: ForwardChain,
+			buildFunc: func(builder IPTablesRuleBuilder) IPTablesRule {
+				return builder.MatchIPSetSrc(ipsetAlfa).
+					MatchIPSetDst(ipsetBravo).
+					MatchInputInterface(eth0).
+					MatchTransProtocol(ProtocolTCP).
+					MatchDstPort(port8080, nil).
+					MatchCIDRSrc(cidr).
+					SetComment("Accept TCP 8080").
+					SetTarget(AcceptTarget).
+					Done()
+			},
+			expected: `-A FORWARD -m set --match-set alfa src -m set --match-set bravo dst -i eth0 -p tcp --dport 8080 -s 192.168.1.0/24 -m comment --comment "Accept TCP 8080" -j ACCEPT`,
+		},
+		{
+			name:  "Drop UDP destination 137-139 in INPUT",
+			chain: "INPUT",
+			buildFunc: func(builder IPTablesRuleBuilder) IPTablesRule {
+				return builder.MatchIPSetSrc(ipsetAlfa).
+					MatchInputInterface(eth0).
+					MatchTransProtocol(ProtocolUDP).
+					MatchDstPort(port137, &port139).
+					MatchCIDRDst(cidr).
+					SetComment("Drop UDP 137-139").
+					SetTarget(DropTarget).
+					Done()
+			},
+			expected: `-A INPUT -m set --match-set alfa src -i eth0 -p udp --dport 137:139 -d 192.168.1.0/24 -m comment --comment "Drop UDP 137-139" -j DROP`,
+		},
+		{
+			name:  "Reject SCTP source 40000-50000 in OUTPUT",
+			chain: OutputChain,
+			buildFunc: func(builder IPTablesRuleBuilder) IPTablesRule {
+				return builder.MatchOutputInterface(eth1).
+					MatchTransProtocol(ProtocolSCTP).
+					MatchSrcPort(&port40000, &port50000).
+					SetComment("Drop SCTP 40000-50000").
+					SetTarget(DropTarget).
+					Done()
+			},
+			expected: `-A OUTPUT -o eth1 -p sctp --sport 40000:50000 -m comment --comment "Drop SCTP 40000-50000" -j DROP`,
+		},
+		{
+			name:  "Accept ICMP IPv4",
+			chain: ForwardChain,
+			buildFunc: func(builder IPTablesRuleBuilder) IPTablesRule {
+				return builder.MatchInputInterface(eth0).
+					MatchICMP(&icmpType0, &icmpCode0, ProtocolIPv4).
+					SetTarget(AcceptTarget).
+					Done()
+			},
+			expected: `-A FORWARD -i eth0 -p icmp --icmp-type 0/0 -j ACCEPT`,
+		},
+		{
+			name:  "Accept ICMP IPv6",
+			chain: ForwardChain,
+			buildFunc: func(builder IPTablesRuleBuilder) IPTablesRule {
+				return builder.MatchInputInterface(eth0).
+					MatchICMP(&icmpType0, nil, ProtocolIPv6).
+					SetTarget(AcceptTarget).
+					Done()
+			},
+			expected: `-A FORWARD -i eth0 -p icmpv6 --icmpv6-type 0 -j ACCEPT`,
+		},
+		{
+			name:  "Accept packets of established TCP connections",
+			chain: InputChain,
+			buildFunc: func(builder IPTablesRuleBuilder) IPTablesRule {
+				return builder.MatchTransProtocol(ProtocolTCP).
+					MatchEstablishedOrRelated().
+					SetTarget(AcceptTarget).
+					Done()
+			},
+			expected: `-A INPUT -p tcp -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			builder := NewRuleBuilder(tc.chain)
+			rule := tc.buildFunc(builder)
+			assert.Equal(t, tc.expected, rule.GetRule())
+		})
+	}
+}

--- a/pkg/apiserver/handlers/featuregates/handler_test.go
+++ b/pkg/apiserver/handlers/featuregates/handler_test.go
@@ -67,6 +67,7 @@ func Test_getGatesResponse(t *testing.T) {
 				{Component: "agent", Name: "Multicast", Status: multicastStatus, Version: "BETA"},
 				{Component: "agent", Name: "Multicluster", Status: "Disabled", Version: "ALPHA"},
 				{Component: "agent", Name: "NetworkPolicyStats", Status: "Enabled", Version: "BETA"},
+				{Component: "agent", Name: "NodeNetworkPolicy", Status: "Disabled", Version: "ALPHA"},
 				{Component: "agent", Name: "NodePortLocal", Status: "Enabled", Version: "GA"},
 				{Component: "agent", Name: "SecondaryNetwork", Status: "Disabled", Version: "ALPHA"},
 				{Component: "agent", Name: "ServiceExternalIP", Status: "Disabled", Version: "ALPHA"},

--- a/pkg/features/antrea_features.go
+++ b/pkg/features/antrea_features.go
@@ -150,6 +150,10 @@ const (
 	// alpha: v1.15
 	// Allow users to allocate Egress IPs from a different subnet from the default Node subnet.
 	EgressSeparateSubnet featuregate.Feature = "EgressSeparateSubnet"
+
+	// alpha: v1.15
+	// Allows users to apply ClusterNetworkPolicy to Kubernetes Nodes.
+	NodeNetworkPolicy featuregate.Feature = "NodeNetworkPolicy"
 )
 
 var (
@@ -189,6 +193,7 @@ var (
 		AdminNetworkPolicy:          {Default: false, PreRelease: featuregate.Alpha},
 		EgressTrafficShaping:        {Default: false, PreRelease: featuregate.Alpha},
 		EgressSeparateSubnet:        {Default: false, PreRelease: featuregate.Alpha},
+		NodeNetworkPolicy:           {Default: false, PreRelease: featuregate.Alpha},
 	}
 
 	// AgentGates consists of all known feature gates for the Antrea Agent.
@@ -217,6 +222,7 @@ var (
 		TrafficControl,
 		EgressTrafficShaping,
 		EgressSeparateSubnet,
+		NodeNetworkPolicy,
 	)
 
 	// ControllerGates consists of all known feature gates for the Antrea Controller.
@@ -262,6 +268,7 @@ var (
 		CleanupStaleUDPSvcConntrack: {},
 		EgressTrafficShaping:        {},
 		EgressSeparateSubnet:        {},
+		NodeNetworkPolicy:           {},
 	}
 	// supportedFeaturesOnExternalNode records the features supported on an external
 	// Node. Antrea Agent checks the enabled features if it is running on an

--- a/test/e2e/antreaipam_anp_test.go
+++ b/test/e2e/antreaipam_anp_test.go
@@ -61,9 +61,9 @@ func initializeAntreaIPAM(t *testing.T, data *TestData) {
 	// k8sUtils is a global var
 	k8sUtils, err = NewKubernetesUtils(data)
 	failOnError(err, t)
-	_, err = k8sUtils.Bootstrap(regularNamespaces, pods, true)
+	_, err = k8sUtils.Bootstrap(regularNamespaces, pods, true, nil, nil)
 	failOnError(err, t)
-	ips, err := k8sUtils.Bootstrap(namespaces, pods, false)
+	ips, err := k8sUtils.Bootstrap(namespaces, pods, false, nil, nil)
 	failOnError(err, t)
 	podIPs = ips
 }
@@ -195,18 +195,18 @@ func testAntreaIPAMACNP(t *testing.T, protocol e2eutils.AntreaPolicyProtocol, ac
 		SetAppliedToGroup([]e2eutils.ACNPAppliedToSpec{{PodSelector: map[string]string{"pod": "c"}}})
 	if isIngress {
 		builder.AddIngress(protocol, &p80, nil, nil, nil, nil, nil, nil, nil, map[string]string{}, nil,
-			nil, nil, false, nil, ruleAction, "", "", nil)
+			nil, nil, nil, nil, false, nil, ruleAction, "", "", nil)
 		builder2.AddIngress(protocol, &p80, nil, nil, nil, nil, nil, nil, nil, map[string]string{}, nil,
-			nil, nil, false, nil, ruleAction, "", "", nil)
+			nil, nil, nil, nil, false, nil, ruleAction, "", "", nil)
 		builder3.AddIngress(protocol, &p80, nil, nil, nil, nil, nil, nil, nil, map[string]string{}, nil,
-			nil, nil, false, nil, ruleAction, "", "", nil)
+			nil, nil, nil, nil, false, nil, ruleAction, "", "", nil)
 	} else {
 		builder.AddEgress(protocol, &p80, nil, nil, nil, nil, nil, nil, nil, map[string]string{}, nil,
-			nil, nil, false, nil, ruleAction, "", "", nil)
+			nil, nil, nil, nil, false, nil, ruleAction, "", "", nil)
 		builder2.AddEgress(protocol, &p80, nil, nil, nil, nil, nil, nil, nil, map[string]string{}, nil,
-			nil, nil, false, nil, ruleAction, "", "", nil)
+			nil, nil, nil, nil, false, nil, ruleAction, "", "", nil)
 		builder3.AddEgress(protocol, &p80, nil, nil, nil, nil, nil, nil, nil, map[string]string{}, nil,
-			nil, nil, false, nil, ruleAction, "", "", nil)
+			nil, nil, nil, nil, false, nil, ruleAction, "", "", nil)
 	}
 
 	reachability := NewReachability(allPods, action)

--- a/test/e2e/nodenetworkpolicy_test.go
+++ b/test/e2e/nodenetworkpolicy_test.go
@@ -1,0 +1,941 @@
+// Copyright 2024 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	crdv1beta1 "antrea.io/antrea/pkg/apis/crd/v1beta1"
+	"antrea.io/antrea/pkg/features"
+	. "antrea.io/antrea/test/e2e/utils"
+)
+
+const labelNodeHostname = "kubernetes.io/hostname"
+
+func initializeAntreaNodeNetworkPolicy(t *testing.T, data *TestData, toHostNetworkPod bool) {
+	p80 = 80
+	p81 = 81
+	p8080 = 8080
+	p8081 = 8081
+	p8082 = 8082
+	p8085 = 8085
+	pods = []string{"a"}
+	suffix := randName("")
+	namespaces = make(map[string]string)
+	namespaces["x"] = "x-" + suffix
+	namespaces["y"] = "y-" + suffix
+	nodes = make(map[string]string)
+	nodes["x"] = controlPlaneNodeName()
+	nodes["y"] = workerNodeName(1)
+	hostNetworks := make(map[string]bool)
+	hostNetworks["x"] = true
+	if toHostNetworkPod {
+		hostNetworks["y"] = true
+	} else {
+		hostNetworks["y"] = false
+		namespaces["z"] = "z-" + suffix
+		nodes["z"] = workerNodeName(1)
+		hostNetworks["z"] = false
+	}
+	allPods = []Pod{}
+
+	for _, podName := range pods {
+		for _, ns := range namespaces {
+			allPods = append(allPods, NewPod(ns, podName))
+		}
+	}
+
+	var err error
+	// k8sUtils is a global var
+	k8sUtils, err = NewKubernetesUtils(data)
+	failOnError(err, t)
+	ips, err := k8sUtils.Bootstrap(namespaces, pods, true, nodes, hostNetworks)
+	failOnError(err, t)
+	podIPs = ips
+}
+
+func skipIfNodeNetworkPolicyDisabled(tb testing.TB) {
+	skipIfFeatureDisabled(tb, features.NodeNetworkPolicy, true, false)
+}
+
+func TestAntreaNodeNetworkPolicy(t *testing.T) {
+	skipIfAntreaPolicyDisabled(t)
+	skipIfNodeNetworkPolicyDisabled(t)
+	skipIfHasWindowsNodes(t)
+	skipIfNumNodesLessThan(t, 2)
+
+	data, err := setupTest(t)
+	if err != nil {
+		t.Fatalf("Error when setting up test: %v", err)
+	}
+	defer teardownTest(t, data)
+
+	initializeAntreaNodeNetworkPolicy(t, data, true)
+
+	t.Run("Case=ACNPAllowNoDefaultIsolationTCP", func(t *testing.T) { testNodeACNPAllowNoDefaultIsolation(t, ProtocolTCP) })
+	t.Run("Case=ACNPAllowNoDefaultIsolationUDP", func(t *testing.T) { testNodeACNPAllowNoDefaultIsolation(t, ProtocolUDP) })
+	t.Run("Case=ACNPAllowNoDefaultIsolationSCTP", func(t *testing.T) { testNodeACNPAllowNoDefaultIsolation(t, ProtocolSCTP) })
+	t.Run("Case=ACNPDropEgress", func(t *testing.T) { testNodeACNPDropEgress(t, ProtocolTCP) })
+	t.Run("Case=ACNPDropEgressUDP", func(t *testing.T) { testNodeACNPDropEgress(t, ProtocolUDP) })
+	t.Run("Case=ACNPDropEgressSCTP", func(t *testing.T) { testNodeACNPDropEgress(t, ProtocolSCTP) })
+	t.Run("Case=ACNPDropIngress", func(t *testing.T) { testNodeACNPDropIngress(t, ProtocolTCP) })
+	t.Run("Case=ACNPDropIngressUDP", func(t *testing.T) { testNodeACNPDropIngress(t, ProtocolUDP) })
+	t.Run("Case=ACNPDropIngressSCTP", func(t *testing.T) { testNodeACNPDropIngress(t, ProtocolSCTP) })
+	t.Run("Case=ACNPPortRange", func(t *testing.T) { testNodeACNPPortRange(t) })
+	t.Run("Case=ACNPSourcePort", func(t *testing.T) { testNodeACNPSourcePort(t) })
+	t.Run("Case=ACNPRejectEgress", func(t *testing.T) { testNodeACNPRejectEgress(t, ProtocolTCP) })
+	t.Run("Case=ACNPRejectEgressUDP", func(t *testing.T) { testNodeACNPRejectEgress(t, ProtocolUDP) })
+	t.Run("Case=ACNPRejectEgressSCTP", func(t *testing.T) { testNodeACNPRejectEgress(t, ProtocolSCTP) })
+	t.Run("Case=ACNPRejectIngress", func(t *testing.T) { testNodeACNPRejectIngress(t, ProtocolTCP) })
+	t.Run("Case=ACNPRejectIngressUDP", func(t *testing.T) { testNodeACNPRejectIngress(t, ProtocolUDP) })
+	t.Run("Case=ACNPNoEffectOnOtherProtocols", func(t *testing.T) { testNodeACNPNoEffectOnOtherProtocols(t) })
+	t.Run("Case=ACNPPriorityOverride", func(t *testing.T) { testNodeACNPPriorityOverride(t) })
+	t.Run("Case=ACNPTierOverride", func(t *testing.T) { testNodeACNPTierOverride(t) })
+	t.Run("Case=ACNPCustomTiers", func(t *testing.T) { testNodeACNPCustomTiers(t) })
+	t.Run("Case=ACNPPriorityConflictingRule", func(t *testing.T) { testNodeACNPPriorityConflictingRule(t) })
+
+	k8sUtils.Cleanup(namespaces)
+
+	initializeAntreaNodeNetworkPolicy(t, data, false)
+
+	t.Run("Case=ACNPNamespaceIsolation", func(t *testing.T) { testNodeACNPNamespaceIsolation(t) })
+	t.Run("Case=ACNPClusterGroupUpdate", func(t *testing.T) { testNodeACNPClusterGroupUpdate(t) })
+	t.Run("Case=ACNPClusterGroupRefRuleIPBlocks", func(t *testing.T) { testNodeACNPClusterGroupRefRuleIPBlocks(t) })
+	t.Run("Case=ACNPNestedClusterGroup", func(t *testing.T) { testNodeACNPNestedClusterGroupCreateAndUpdate(t, data) })
+	t.Run("Case=ACNPNestedIPBlockClusterGroup", func(t *testing.T) { testNodeACNPNestedIPBlockClusterGroupCreateAndUpdate(t) })
+
+	k8sUtils.Cleanup(namespaces)
+}
+
+// testNodeACNPAllowNoDefaultIsolation tests that no default isolation rules are created for ACNPs applied to Node.
+func testNodeACNPAllowNoDefaultIsolation(t *testing.T, protocol AntreaPolicyProtocol) {
+	if protocol == ProtocolSCTP {
+		// SCTP testing is failing on our IPv6 CI testbeds at the moment. This seems to be
+		// related to an issue with ESX networking for SCTPv6 traffic when the Pods are on
+		// different Node VMs which are themselves on different ESX hosts. We are
+		// investigating the issue and disabling the tests for IPv6 clusters in the
+		// meantime.
+		skipIfIPv6Cluster(t)
+	}
+	builder1 := &ClusterNetworkPolicySpecBuilder{}
+	builder1 = builder1.SetName("acnp-allow-x-from-y-ingress").
+		SetPriority(1.1).
+		SetAppliedToGroup([]ACNPAppliedToSpec{{NodeSelector: map[string]string{labelNodeHostname: nodes["x"]}}})
+	builder1.AddIngress(protocol, &p81, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{labelNodeHostname: nodes["y"]}, nil,
+		nil, nil, nil, false, nil, crdv1beta1.RuleActionAllow, "", "", nil)
+
+	builder2 := &ClusterNetworkPolicySpecBuilder{}
+	builder2 = builder2.SetName("acnp-allow-x-to-y-egress").
+		SetPriority(1.1).
+		SetAppliedToGroup([]ACNPAppliedToSpec{{NodeSelector: map[string]string{labelNodeHostname: nodes["x"]}}})
+	builder2.AddEgress(protocol, &p81, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{labelNodeHostname: nodes["y"]}, nil,
+		nil, nil, nil, false, nil, crdv1beta1.RuleActionAllow, "", "", nil)
+
+	reachability := NewReachability(allPods, Connected)
+	testStep := []*TestStep{
+		{
+			"Port 81",
+			reachability,
+			[]metav1.Object{builder1.Get(), builder2.Get()},
+			[]int32{81},
+			protocol,
+			0,
+			nil,
+		},
+	}
+	testCase := []*TestCase{
+		{"ACNP Allow No Default Isolation", testStep},
+	}
+	executeTests(t, testCase)
+}
+
+// testNodeACNPDropEgress tests that an ACNP applied to Node is able to drop egress traffic from Node x to Node y.
+func testNodeACNPDropEgress(t *testing.T, protocol AntreaPolicyProtocol) {
+	if protocol == ProtocolSCTP {
+		// SCTP testing is failing on our IPv6 CI testbeds at the moment. This seems to be
+		// related to an issue with ESX networking for SCTPv6 traffic when the Pods are on
+		// different Node VMs which are themselves on different ESX hosts. We are
+		// investigating the issue and disabling the tests for IPv6 clusters in the
+		// meantime.
+		skipIfIPv6Cluster(t)
+	}
+	if protocol == ProtocolUDP {
+		// For UDP, when action `Reject` or `Drop` is specified in an egress rule, agnhost got the unexpected message immediately
+		// like the follows.
+		//   UNKNOWN: write udp 172.18.0.3:58150->172.18.0.2:80: write: operation not permitted
+		//   UNKNOWN: write udp 172.18.0.3:58150->172.18.0.2:80: write: operation not permitted
+		//   UNKNOWN: write udp 172.18.0.3:58150->172.18.0.2:80: write: operation not permitted
+		t.Skip("Skipping test as dropping UDP egress traffic doesn't return the expected stdout or stderr message")
+	}
+	builder := &ClusterNetworkPolicySpecBuilder{}
+	builder = builder.SetName("acnp-drop-x-to-y-egress").
+		SetPriority(1.0).
+		SetAppliedToGroup([]ACNPAppliedToSpec{{NodeSelector: map[string]string{labelNodeHostname: nodes["x"]}}})
+	builder.AddEgress(protocol, &p80, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{labelNodeHostname: nodes["y"]}, nil,
+		nil, nil, nil, false, nil, crdv1beta1.RuleActionDrop, "", "", nil)
+
+	reachability := NewReachability(allPods, Connected)
+	reachability.Expect(Pod(namespaces["x"]+"/a"), Pod(namespaces["y"]+"/a"), Dropped)
+	testStep := []*TestStep{
+		{
+			"Port 80",
+			reachability,
+			[]metav1.Object{builder.Get()},
+			[]int32{80},
+			protocol,
+			0,
+			nil,
+		},
+	}
+	testCase := []*TestCase{
+		{"ACNP Drop Egress From Node:x to Node:y", testStep},
+	}
+	executeTests(t, testCase)
+}
+
+// testNodeACNPDropIngress tests that an ACNP applied to Node is able to drop ingress traffic from Node y to Node x.
+func testNodeACNPDropIngress(t *testing.T, protocol AntreaPolicyProtocol) {
+	if protocol == ProtocolSCTP {
+		// SCTP testing is failing on our IPv6 CI testbeds at the moment. This seems to be
+		// related to an issue with ESX networking for SCTPv6 traffic when the Pods are on
+		// different Node VMs which are themselves on different ESX hosts. We are
+		// investigating the issue and disabling the tests for IPv6 clusters in the
+		// meantime.
+		skipIfIPv6Cluster(t)
+	}
+	builder := &ClusterNetworkPolicySpecBuilder{}
+	builder = builder.SetName("acnp-drop-x-from-y-ingress").
+		SetPriority(1.0).
+		SetAppliedToGroup([]ACNPAppliedToSpec{{NodeSelector: map[string]string{labelNodeHostname: nodes["x"]}}})
+	builder.AddIngress(protocol, &p80, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{labelNodeHostname: nodes["y"]}, nil,
+		nil, nil, nil, false, nil, crdv1beta1.RuleActionDrop, "", "", nil)
+
+	reachability := NewReachability(allPods, Connected)
+	reachability.Expect(Pod(namespaces["y"]+"/a"), Pod(namespaces["x"]+"/a"), Dropped)
+	testStep := []*TestStep{
+		{
+			"Port 80",
+			reachability,
+			[]metav1.Object{builder.Get()},
+			[]int32{80},
+			protocol,
+			0,
+			nil,
+		},
+	}
+	testCase := []*TestCase{
+		{"ACNP Drop Ingress From Node:y to Node:x", testStep},
+	}
+	executeTests(t, testCase)
+}
+
+// testACNPPortRange tests the port range in an ACNP applied to Node can work.
+func testNodeACNPPortRange(t *testing.T) {
+	builder := &ClusterNetworkPolicySpecBuilder{}
+	builder = builder.SetName("acnp-drop-x-to-y-egress-port-range").
+		SetPriority(1.0).
+		SetAppliedToGroup([]ACNPAppliedToSpec{{NodeSelector: map[string]string{labelNodeHostname: nodes["x"]}}})
+	builder.AddEgress(ProtocolTCP, &p8080, nil, &p8082, nil, nil, nil, nil, nil, nil, map[string]string{labelNodeHostname: nodes["y"]}, nil,
+		nil, nil, nil, false, nil, crdv1beta1.RuleActionDrop, "", "acnp-port-range", nil)
+
+	reachability := NewReachability(allPods, Connected)
+	reachability.Expect(Pod(namespaces["x"]+"/a"), Pod(namespaces["y"]+"/a"), Dropped)
+	testSteps := []*TestStep{
+		{
+			fmt.Sprintf("ACNP Drop Ports 8080:8082"),
+			reachability,
+			[]metav1.Object{builder.Get()},
+			[]int32{8080, 8081, 8082},
+			ProtocolTCP,
+			0,
+			nil,
+		},
+	}
+
+	testCase := []*TestCase{
+		{"ACNP Drop Egress From Node:x to Node:y with a portRange", testSteps},
+	}
+	executeTests(t, testCase)
+}
+
+// testNodeACNPSourcePort tests ACNP applied to Node source port filtering. The agnhost image used in E2E tests uses
+// ephemeral ports to initiate TCP connections, which should be 32768–60999 by default  (https://en.wikipedia.org/wiki/Ephemeral_port).
+// This test retrieves the port range from the client Pod and uses it in sourcePort and sourceEndPort of an ACNP rule to
+// verify that packets can be matched by source port.
+func testNodeACNPSourcePort(t *testing.T) {
+	portStart, portEnd, err := k8sUtils.getTCPv4SourcePortRangeFromPod(namespaces["x"], "a")
+	failOnError(err, t)
+	builder := &ClusterNetworkPolicySpecBuilder{}
+	builder = builder.SetName("acnp-source-port").
+		SetPriority(1.0).
+		SetAppliedToGroup([]ACNPAppliedToSpec{{NodeSelector: map[string]string{labelNodeHostname: nodes["x"]}}})
+	builder.AddIngressForSrcPort(ProtocolTCP, nil, nil, &portStart, &portEnd, nil, nil, nil, nil, nil, nil, map[string]string{labelNodeHostname: nodes["y"]}, nil,
+		nil, nil, nil, false, nil, crdv1beta1.RuleActionDrop, "", "", nil)
+
+	builder2 := &ClusterNetworkPolicySpecBuilder{}
+	builder2 = builder2.SetName("acnp-source-port").
+		SetPriority(1.0).
+		SetAppliedToGroup([]ACNPAppliedToSpec{{NodeSelector: map[string]string{labelNodeHostname: nodes["x"]}}})
+	builder2.AddIngressForSrcPort(ProtocolTCP, &p80, nil, &portStart, &portEnd, nil, nil, nil, nil, nil, nil, map[string]string{labelNodeHostname: nodes["y"]}, nil,
+		nil, nil, nil, false, nil, crdv1beta1.RuleActionDrop, "", "", nil)
+
+	builder3 := &ClusterNetworkPolicySpecBuilder{}
+	builder3 = builder3.SetName("acnp-source-port").
+		SetPriority(1.0).
+		SetAppliedToGroup([]ACNPAppliedToSpec{{NodeSelector: map[string]string{labelNodeHostname: nodes["x"]}}})
+	builder3.AddIngressForSrcPort(ProtocolTCP, &p80, &p81, &portStart, &portEnd, nil, nil, nil, nil, nil, nil, map[string]string{labelNodeHostname: nodes["y"]}, nil,
+		nil, nil, nil, false, nil, crdv1beta1.RuleActionDrop, "", "", nil)
+
+	reachability := NewReachability(allPods, Connected)
+	reachability.Expect(Pod(namespaces["y"]+"/a"), Pod(namespaces["x"]+"/a"), Dropped)
+	// After adding the dst port constraint of port 80, traffic on port 81 should not be affected.
+	updatedReachability := NewReachability(allPods, Connected)
+
+	testSteps := []*TestStep{
+		{
+			"Port 80",
+			reachability,
+			[]metav1.Object{builder.Get()},
+			[]int32{80},
+			ProtocolTCP,
+			0,
+			nil,
+		},
+		{
+			"Port 81",
+			updatedReachability,
+			[]metav1.Object{builder2.Get()},
+			[]int32{81},
+			ProtocolTCP,
+			0,
+			nil,
+		},
+		{
+			"Port range 80-81",
+			reachability,
+			[]metav1.Object{builder3.Get()},
+			[]int32{80, 81},
+			ProtocolTCP,
+			0,
+			nil,
+		},
+	}
+	testCase := []*TestCase{
+		{"ACNP Drop Node:y to Node:x based on source port", testSteps},
+	}
+	executeTests(t, testCase)
+}
+
+// testNodeACNPRejectEgress tests that an ACNP applied to Node is able to reject egress traffic from Node x to Node y.
+func testNodeACNPRejectEgress(t *testing.T, protocol AntreaPolicyProtocol) {
+	if protocol == ProtocolSCTP {
+		// SCTP testing is failing on our IPv6 CI testbeds at the moment. This seems to be
+		// related to an issue with ESX networking for SCTPv6 traffic when the Pods are on
+		// different Node VMs which are themselves on different ESX hosts. We are
+		// investigating the issue and disabling the tests for IPv6 clusters in the
+		// meantime.
+		skipIfIPv6Cluster(t)
+	}
+	if protocol == ProtocolUDP {
+		// For UDP, when action `Reject` or `Drop` is specified in an egress rule, agnhost got the unexpected message immediately
+		// like the follows.
+		//   UNKNOWN: write udp 172.18.0.3:58150->172.18.0.2:80: write: operation not permitted
+		//   UNKNOWN: write udp 172.18.0.3:58150->172.18.0.2:80: write: operation not permitted
+		//   UNKNOWN: write udp 172.18.0.3:58150->172.18.0.2:80: write: operation not permitted
+		t.Skip("Skipping test as dropping UDP egress traffic doesn't return the expected stdout or stderr message")
+	}
+
+	builder := &ClusterNetworkPolicySpecBuilder{}
+	builder = builder.SetName("acnp-reject-x-to-y-egress").
+		SetPriority(1.0).
+		SetAppliedToGroup([]ACNPAppliedToSpec{{NodeSelector: map[string]string{labelNodeHostname: nodes["x"]}}})
+	builder.AddEgress(protocol, &p80, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{labelNodeHostname: nodes["y"]}, nil,
+		nil, nil, nil, false, nil, crdv1beta1.RuleActionReject, "", "", nil)
+
+	reachability := NewReachability(allPods, Connected)
+
+	expectedResult := Rejected
+	// For SCTP, when action `Rejected` is specified in an egress rule, it behaves identical to action `Dropped`.
+	if protocol == ProtocolSCTP {
+		expectedResult = Dropped
+	}
+	reachability.Expect(Pod(namespaces["x"]+"/a"), Pod(namespaces["y"]+"/a"), expectedResult)
+	testStep := []*TestStep{
+		{
+			"Port 80",
+			reachability,
+			[]metav1.Object{builder.Get()},
+			[]int32{80},
+			protocol,
+			0,
+			nil,
+		},
+	}
+	testCase := []*TestCase{
+		{"ACNP Reject Egress From Node:x to Node:y", testStep},
+	}
+	executeTests(t, testCase)
+}
+
+// testNodeACNPRejectIngress tests that an ACNP applied Node to is able to reject ingress traffic from Node y to Node x.
+func testNodeACNPRejectIngress(t *testing.T, protocol AntreaPolicyProtocol) {
+	builder := &ClusterNetworkPolicySpecBuilder{}
+	builder = builder.SetName("acnp-reject-x-from-y-ingress").
+		SetPriority(1.0).
+		SetAppliedToGroup([]ACNPAppliedToSpec{{NodeSelector: map[string]string{labelNodeHostname: nodes["x"]}}})
+	builder.AddIngress(protocol, &p80, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{labelNodeHostname: nodes["y"]}, nil,
+		nil, nil, nil, false, nil, crdv1beta1.RuleActionReject, "", "", nil)
+
+	reachability := NewReachability(allPods, Connected)
+	reachability.Expect(Pod(namespaces["y"]+"/a"), Pod(namespaces["x"]+"/a"), Rejected)
+	testStep := []*TestStep{
+		{
+			"Port 80",
+			reachability,
+			[]metav1.Object{builder.Get()},
+			[]int32{80},
+			protocol,
+			0,
+			nil,
+		},
+	}
+	testCase := []*TestCase{
+		{"ACNP Reject ingress from Node:y to Node:x", testStep},
+	}
+	executeTests(t, testCase)
+}
+
+// testNodeACNPNoEffectOnOtherProtocols tests that an ACNP applied Node which drops TCP traffic won't affect other protocols (e.g. UDP).
+func testNodeACNPNoEffectOnOtherProtocols(t *testing.T) {
+	builder := &ClusterNetworkPolicySpecBuilder{}
+	builder = builder.SetName("acnp-drop-x-from-y-ingress").
+		SetPriority(1.0).
+		SetAppliedToGroup([]ACNPAppliedToSpec{{NodeSelector: map[string]string{labelNodeHostname: nodes["x"]}}})
+	builder.AddIngress(ProtocolTCP, &p80, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{labelNodeHostname: nodes["y"]}, nil,
+		nil, nil, nil, false, nil, crdv1beta1.RuleActionDrop, "", "", nil)
+
+	reachability1 := NewReachability(allPods, Connected)
+	reachability1.Expect(Pod(namespaces["y"]+"/a"), Pod(namespaces["x"]+"/a"), Dropped)
+
+	reachability2 := NewReachability(allPods, Connected)
+
+	testStep := []*TestStep{
+		{
+			"Port 80",
+			reachability1,
+			[]metav1.Object{builder.Get()},
+			[]int32{80},
+			ProtocolTCP,
+			0,
+			nil,
+		},
+		{
+			"Port 80",
+			reachability2,
+			[]metav1.Object{builder.Get()},
+			[]int32{80},
+			ProtocolUDP,
+			0,
+			nil,
+		},
+	}
+	testCase := []*TestCase{
+		{"ACNP Drop Ingress From Node:y to Node:x TCP Not UDP", testStep},
+	}
+	executeTests(t, testCase)
+}
+
+// testNodeACNPPriorityOverride tests priority overriding in three ACNPs applied to Node. Those three ACNPs are synced in
+// a specific order to test priority reassignment, and each controls a smaller set of traffic patterns as priority increases.
+func testNodeACNPPriorityOverride(t *testing.T) {
+	builder1 := &ClusterNetworkPolicySpecBuilder{}
+	builder1 = builder1.SetName("acnp-priority1").
+		SetPriority(1.001).
+		SetAppliedToGroup([]ACNPAppliedToSpec{{NodeSelector: map[string]string{labelNodeHostname: nodes["x"]}}})
+	// Highest priority. Drops traffic from y to x.
+	builder1.AddIngress(ProtocolTCP, &p80, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{labelNodeHostname: nodes["y"]}, nil,
+		nil, nil, nil, false, nil, crdv1beta1.RuleActionDrop, "", "", nil)
+
+	builder2 := &ClusterNetworkPolicySpecBuilder{}
+	builder2 = builder2.SetName("acnp-priority2").
+		SetPriority(1.002).
+		SetAppliedToGroup([]ACNPAppliedToSpec{{NodeSelector: map[string]string{labelNodeHostname: nodes["x"]}}})
+	// Medium priority. Allows traffic from y to x.
+	builder2.AddIngress(ProtocolTCP, &p80, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{labelNodeHostname: nodes["y"]}, nil,
+		nil, nil, nil, false, nil, crdv1beta1.RuleActionAllow, "", "", nil)
+
+	builder3 := &ClusterNetworkPolicySpecBuilder{}
+	builder3 = builder3.SetName("acnp-priority3").
+		SetPriority(1.003).
+		SetAppliedToGroup([]ACNPAppliedToSpec{{NodeSelector: map[string]string{labelNodeHostname: nodes["x"]}}})
+	// Lowest priority. Drops traffic from y to x.
+	builder3.AddIngress(ProtocolTCP, &p80, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{labelNodeHostname: nodes["y"]}, nil,
+		nil, nil, nil, false, nil, crdv1beta1.RuleActionDrop, "", "", nil)
+
+	reachabilityTwoACNPs := NewReachability(allPods, Connected)
+
+	reachabilityAllACNPs := NewReachability(allPods, Connected)
+	reachabilityAllACNPs.Expect(Pod(namespaces["y"]+"/a"), Pod(namespaces["x"]+"/a"), Dropped)
+
+	testStepTwoACNP := []*TestStep{
+		{
+			"Two Policies with different priorities",
+			reachabilityTwoACNPs,
+			[]metav1.Object{builder3.Get(), builder2.Get()},
+			[]int32{80},
+			ProtocolTCP,
+			0,
+			nil,
+		},
+	}
+	// Create the Policies in specific order to make sure that priority re-assignments work as expected.
+	testStepAll := []*TestStep{
+		{
+			"All three Policies",
+			reachabilityAllACNPs,
+			[]metav1.Object{builder3.Get(), builder1.Get(), builder2.Get()},
+			[]int32{80},
+			ProtocolTCP,
+			0,
+			nil,
+		},
+	}
+	testCase := []*TestCase{
+		{"ACNP PriorityOverride Intermediate", testStepTwoACNP},
+		{"ACNP PriorityOverride All", testStepAll},
+	}
+	executeTests(t, testCase)
+}
+
+// testNodeACNPTierOverride tests tier priority overriding in three ACNPs applied to Node. Each ACNP controls a smaller
+// set of traffic patterns as tier priority increases.
+func testNodeACNPTierOverride(t *testing.T) {
+	builder1 := &ClusterNetworkPolicySpecBuilder{}
+	builder1 = builder1.SetName("acnp-tier-emergency").
+		SetTier("emergency").
+		SetPriority(100).
+		SetAppliedToGroup([]ACNPAppliedToSpec{{NodeSelector: map[string]string{labelNodeHostname: nodes["x"]}}})
+	// Highest priority tier. Drops traffic from y to x.
+	builder1.AddIngress(ProtocolTCP, &p80, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{labelNodeHostname: nodes["y"]}, nil,
+		nil, nil, nil, false, nil, crdv1beta1.RuleActionDrop, "", "", nil)
+
+	builder2 := &ClusterNetworkPolicySpecBuilder{}
+	builder2 = builder2.SetName("acnp-tier-securityops").
+		SetTier("securityops").
+		SetPriority(10).
+		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}, NSSelector: map[string]string{"ns": namespaces["x"]}}})
+	// Medium priority tier. Allows traffic from y to x.
+	builder2.AddIngress(ProtocolTCP, &p80, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{labelNodeHostname: nodes["y"]}, nil,
+		nil, nil, nil, false, nil, crdv1beta1.RuleActionAllow, "", "", nil)
+
+	builder3 := &ClusterNetworkPolicySpecBuilder{}
+	builder3 = builder3.SetName("acnp-tier-application").
+		SetTier("application").
+		SetPriority(1).
+		SetAppliedToGroup([]ACNPAppliedToSpec{{NSSelector: map[string]string{"ns": namespaces["x"]}}})
+	// Lowest priority tier. Drops traffic from y to x.
+	builder3.AddIngress(ProtocolTCP, &p80, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{labelNodeHostname: nodes["y"]}, nil,
+		nil, nil, nil, false, nil, crdv1beta1.RuleActionDrop, "", "", nil)
+
+	reachabilityTwoACNPs := NewReachability(allPods, Connected)
+
+	reachabilityAllACNPs := NewReachability(allPods, Connected)
+	reachabilityAllACNPs.Expect(Pod(namespaces["y"]+"/a"), Pod(namespaces["x"]+"/a"), Dropped)
+
+	testStepTwoACNP := []*TestStep{
+		{
+			"Two Policies in different tiers",
+			reachabilityTwoACNPs,
+			[]metav1.Object{builder3.Get(), builder2.Get()},
+			[]int32{80},
+			ProtocolTCP,
+			0,
+			nil,
+		},
+	}
+	testStepAll := []*TestStep{
+		{
+			"All three Policies in different tiers",
+			reachabilityAllACNPs,
+			[]metav1.Object{builder3.Get(), builder1.Get(), builder2.Get()},
+			[]int32{80},
+			ProtocolTCP,
+			0,
+			nil,
+		},
+	}
+	testCase := []*TestCase{
+		{"ACNP TierOverride Intermediate", testStepTwoACNP},
+		{"ACNP TierOverride All", testStepAll},
+	}
+	executeTests(t, testCase)
+}
+
+// testNodeACNPCustomTiers tests tier priority overriding in two ACNPs applied to Node with custom created tiers. Each ACNP
+// controls a smaller set of traffic patterns as tier priority increases.
+func testNodeACNPCustomTiers(t *testing.T) {
+	k8sUtils.DeleteTier("high-priority")
+	k8sUtils.DeleteTier("low-priority")
+	// Create two custom tiers with tier priority immediately next to each other.
+	_, err := k8sUtils.CreateNewTier("high-priority", 245)
+	failOnError(err, t)
+	_, err = k8sUtils.CreateNewTier("low-priority", 246)
+	failOnError(err, t)
+
+	builder1 := &ClusterNetworkPolicySpecBuilder{}
+	builder1 = builder1.SetName("acnp-tier-high").
+		SetTier("high-priority").
+		SetPriority(100).
+		SetAppliedToGroup([]ACNPAppliedToSpec{{NodeSelector: map[string]string{labelNodeHostname: nodes["x"]}}})
+	// Medium priority tier. Allows traffic from y to x.
+	builder1.AddIngress(ProtocolTCP, &p80, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{labelNodeHostname: nodes["y"]}, nil,
+		nil, nil, nil, false, nil, crdv1beta1.RuleActionAllow, "", "", nil)
+
+	builder2 := &ClusterNetworkPolicySpecBuilder{}
+	builder2 = builder2.SetName("acnp-tier-low").
+		SetTier("low-priority").
+		SetPriority(1).
+		SetAppliedToGroup([]ACNPAppliedToSpec{{NodeSelector: map[string]string{labelNodeHostname: nodes["x"]}}})
+	// Lowest priority tier. Drops traffic from y to x.
+	builder2.AddIngress(ProtocolTCP, &p80, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{labelNodeHostname: nodes["y"]}, nil,
+		nil, nil, nil, false, nil, crdv1beta1.RuleActionDrop, "", "", nil)
+
+	reachabilityOneACNP := NewReachability(allPods, Connected)
+	reachabilityOneACNP.Expect(Pod(namespaces["y"]+"/a"), Pod(namespaces["x"]+"/a"), Dropped)
+	testStepOneACNP := []*TestStep{
+		{
+			"One Policy",
+			reachabilityOneACNP,
+			[]metav1.Object{builder2.Get()},
+			[]int32{80},
+			ProtocolTCP,
+			0,
+			nil,
+		},
+	}
+
+	reachabilityTwoACNPs := NewReachability(allPods, Connected)
+	testStepTwoACNP := []*TestStep{
+		{
+			"Two Policies in different tiers",
+			reachabilityTwoACNPs,
+			[]metav1.Object{builder2.Get(), builder1.Get()},
+			[]int32{80},
+			ProtocolTCP,
+			0,
+			nil,
+		},
+	}
+	testCase := []*TestCase{
+		{"ACNP Custom Tier priority with one policy", testStepOneACNP},
+		{"ACNP Custom Tier priority with two policies", testStepTwoACNP},
+	}
+	executeTests(t, testCase)
+	// Cleanup customized tiers. ACNPs created in those tiers need to be deleted first.
+	failOnError(k8sUtils.CleanACNPs(), t)
+	failOnError(k8sUtils.DeleteTier("high-priority"), t)
+	failOnError(k8sUtils.DeleteTier("low-priority"), t)
+	time.Sleep(networkPolicyDelay)
+}
+
+// testNodeACNPPriorityConflictingRule tests that if there are two ACNPs applied to Node in the cluster with rules that
+// conflicts with each other, the ACNP with higher priority will prevail.
+func testNodeACNPPriorityConflictingRule(t *testing.T) {
+	builder1 := &ClusterNetworkPolicySpecBuilder{}
+	builder1 = builder1.SetName("acnp-drop").
+		SetPriority(1).
+		SetAppliedToGroup([]ACNPAppliedToSpec{{NodeSelector: map[string]string{labelNodeHostname: nodes["x"]}}})
+	builder1.AddIngress(ProtocolTCP, &p80, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{labelNodeHostname: nodes["y"]}, nil,
+		nil, nil, nil, false, nil, crdv1beta1.RuleActionDrop, "", "", nil)
+
+	builder2 := &ClusterNetworkPolicySpecBuilder{}
+	builder2 = builder2.SetName("acnp-allow").
+		SetPriority(2).
+		SetAppliedToGroup([]ACNPAppliedToSpec{{NodeSelector: map[string]string{labelNodeHostname: nodes["x"]}}})
+	// The following ingress rule will take no effect as it is exactly the same as ingress rule of cnp-drop,
+	// but cnp-allow has lower priority.
+	builder2.AddIngress(ProtocolTCP, &p80, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{labelNodeHostname: nodes["y"]}, nil,
+		nil, nil, nil, false, nil, crdv1beta1.RuleActionAllow, "", "", nil)
+
+	reachabilityBothACNP := NewReachability(allPods, Connected)
+	reachabilityBothACNP.Expect(Pod(namespaces["y"]+"/a"), Pod(namespaces["x"]+"/a"), Dropped)
+	testStep := []*TestStep{
+		{
+			"Both ACNP",
+			reachabilityBothACNP,
+			[]metav1.Object{builder1.Get(), builder2.Get()},
+			[]int32{80},
+			ProtocolTCP,
+			0,
+			nil,
+		},
+	}
+	testCase := []*TestCase{
+		{"ACNP Priority Conflicting Rule", testStep},
+	}
+	executeTests(t, testCase)
+}
+
+func testNodeACNPNamespaceIsolation(t *testing.T) {
+	builder1 := &ClusterNetworkPolicySpecBuilder{}
+	builder1 = builder1.SetName("test-acnp-ns-isolation").
+		SetTier("baseline").
+		SetPriority(1.0).
+		SetAppliedToGroup([]ACNPAppliedToSpec{{NodeSelector: map[string]string{labelNodeHostname: nodes["x"]}}})
+	builder1.AddEgress(ProtocolTCP, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{"ns": namespaces["y"]}, nil, nil, nil,
+		false, nil, crdv1beta1.RuleActionDrop, "", "", nil)
+
+	reachability1 := NewReachability(allPods, Connected)
+	reachability1.ExpectEgressToNamespace(Pod(namespaces["x"]+"/a"), namespaces["y"], Dropped)
+	testStep1 := &TestStep{
+		"Port 80",
+		reachability1,
+		[]metav1.Object{builder1.Get()},
+		[]int32{80},
+		ProtocolTCP,
+		0,
+		nil,
+	}
+
+	testCase := []*TestCase{
+		{"ACNP Namespace isolation for namespace y", []*TestStep{testStep1}},
+	}
+	executeTests(t, testCase)
+}
+
+func testNodeACNPClusterGroupUpdate(t *testing.T) {
+	cgName := "cg-ns-z-then-y"
+	cgBuilder := &ClusterGroupSpecBuilder{}
+	cgBuilder = cgBuilder.SetName(cgName).SetNamespaceSelector(map[string]string{"ns": namespaces["z"]}, nil)
+	// Update CG NS selector to group Pods from Namespace Y
+	updatedCgBuilder := &ClusterGroupSpecBuilder{}
+	updatedCgBuilder = updatedCgBuilder.SetName(cgName).SetNamespaceSelector(map[string]string{"ns": namespaces["y"]}, nil)
+	builder := &ClusterNetworkPolicySpecBuilder{}
+	builder = builder.SetName("acnp-deny-a-to-cg-with-z-egress").
+		SetPriority(1.0).
+		SetAppliedToGroup([]ACNPAppliedToSpec{{NodeSelector: map[string]string{labelNodeHostname: nodes["x"]}}})
+	builder.AddEgress(ProtocolTCP, &p80, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+		nil, nil, nil, false, nil, crdv1beta1.RuleActionDrop, cgName, "", nil)
+
+	reachability := NewReachability(allPods, Connected)
+	reachability.ExpectEgressToNamespace(Pod(namespaces["x"]+"/a"), namespaces["z"], Dropped)
+
+	updatedReachability := NewReachability(allPods, Connected)
+	updatedReachability.ExpectEgressToNamespace(Pod(namespaces["x"]+"/a"), namespaces["y"], Dropped)
+	testStep := []*TestStep{
+		{
+			"Port 80",
+			reachability,
+			[]metav1.Object{cgBuilder.Get(), builder.Get()},
+			[]int32{80},
+			ProtocolTCP,
+			0,
+			nil,
+		},
+		{
+			"Port 80 - update",
+			updatedReachability,
+			[]metav1.Object{updatedCgBuilder.Get()},
+			[]int32{80},
+			ProtocolTCP,
+			0,
+			nil,
+		},
+	}
+	testCase := []*TestCase{
+		{"ACNP Drop Egress From Node:x to ClusterGroup with NS:z updated to ClusterGroup with NS:y", testStep},
+	}
+	executeTests(t, testCase)
+}
+
+func testNodeACNPClusterGroupRefRuleIPBlocks(t *testing.T) {
+	podYAIP, _ := podIPs[namespaces["y"]+"/a"]
+	podZAIP, _ := podIPs[namespaces["z"]+"/a"]
+	// There are three situations of a Pod's IP(s):
+	// 1. Only one IPv4 address.
+	// 2. Only one IPv6 address.
+	// 3. One IPv4 and one IPv6 address, and we don't know the order in list.
+	// We need to add all IP(s) of Pods as CIDR to IPBlock.
+	genCIDR := func(ip string) string {
+		if strings.Contains(ip, ".") {
+			return ip + "/32"
+		}
+		return ip + "/128"
+	}
+	var ipBlock1, ipBlock2 []crdv1beta1.IPBlock
+	for i := 0; i < len(podYAIP); i++ {
+		ipBlock1 = append(ipBlock1, crdv1beta1.IPBlock{CIDR: genCIDR(podYAIP[i])})
+		ipBlock2 = append(ipBlock2, crdv1beta1.IPBlock{CIDR: genCIDR(podZAIP[i])})
+	}
+
+	cgName := "cg-ipblocks-pod-in-ns-y"
+	cgBuilder := &ClusterGroupSpecBuilder{}
+	cgBuilder = cgBuilder.SetName(cgName).
+		SetIPBlocks(ipBlock1)
+	cgName2 := "cg-ipblock-pod-in-ns-z"
+	cgBuilder2 := &ClusterGroupSpecBuilder{}
+	cgBuilder2 = cgBuilder2.SetName(cgName2).
+		SetIPBlocks(ipBlock2)
+
+	builder := &ClusterNetworkPolicySpecBuilder{}
+	builder = builder.SetName("acnp-deny-x-to-yz-egress").
+		SetPriority(1.0).
+		SetAppliedToGroup([]ACNPAppliedToSpec{{NodeSelector: map[string]string{labelNodeHostname: nodes["x"]}}})
+	builder.AddEgress(ProtocolTCP, &p80, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+		nil, nil, nil, false, nil, crdv1beta1.RuleActionDrop, cgName, "", nil)
+	builder.AddEgress(ProtocolTCP, &p80, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+		nil, nil, nil, false, nil, crdv1beta1.RuleActionDrop, cgName2, "", nil)
+
+	reachability := NewReachability(allPods, Connected)
+	reachability.Expect(Pod(namespaces["x"]+"/a"), Pod(namespaces["y"]+"/a"), Dropped)
+	reachability.Expect(Pod(namespaces["x"]+"/a"), Pod(namespaces["z"]+"/a"), Dropped)
+	testStep := []*TestStep{
+		{
+			"Port 80",
+			reachability,
+			[]metav1.Object{builder.Get(), cgBuilder.Get(), cgBuilder2.Get()},
+			[]int32{80},
+			ProtocolTCP,
+			0,
+			nil,
+		},
+	}
+	testCase := []*TestCase{
+		{"ACNP Drop Egress From Node x to Pod y/a and z/a to ClusterGroup with ipBlocks", testStep},
+	}
+	executeTests(t, testCase)
+}
+
+func testNodeACNPNestedClusterGroupCreateAndUpdate(t *testing.T, data *TestData) {
+	cg1Name := "cg-1"
+	cgBuilder1 := &ClusterGroupSpecBuilder{}
+	cgBuilder1 = cgBuilder1.SetName(cg1Name).SetNamespaceSelector(map[string]string{"ns": namespaces["y"]}, nil)
+	cgNestedName := "cg-nested"
+	cgBuilderNested := &ClusterGroupSpecBuilder{}
+	cgBuilderNested = cgBuilderNested.SetName(cgNestedName).SetChildGroups([]string{cg1Name})
+
+	builder := &ClusterNetworkPolicySpecBuilder{}
+	builder = builder.SetName("cnp-nested-cg").SetPriority(1.0).
+		SetAppliedToGroup([]ACNPAppliedToSpec{{NodeSelector: map[string]string{labelNodeHostname: nodes["x"]}}}).
+		AddEgress(ProtocolTCP, &p80, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+			false, nil, crdv1beta1.RuleActionDrop, cgNestedName, "", nil)
+
+	reachability := NewReachability(allPods, Connected)
+	reachability.ExpectEgressToNamespace(Pod(namespaces["x"]+"/a"), namespaces["y"], Dropped)
+	testStep1 := &TestStep{
+		"Port 80",
+		reachability,
+		// Note in this testcase the ClusterGroup is created after the ACNP
+		[]metav1.Object{builder.Get(), cgBuilder1.Get(), cgBuilderNested.Get()},
+		[]int32{80},
+		ProtocolTCP,
+		0,
+		nil,
+	}
+
+	cg2Name := "cg-2"
+	cgBuilder2 := &ClusterGroupSpecBuilder{}
+	cgBuilder2 = cgBuilder2.SetName(cg2Name).SetNamespaceSelector(map[string]string{"ns": namespaces["z"]}, nil)
+	cgBuilderNested = cgBuilderNested.SetChildGroups([]string{cg2Name})
+	reachability2 := NewReachability(allPods, Connected)
+	reachability2.ExpectEgressToNamespace(Pod(namespaces["x"]+"/a"), namespaces["z"], Dropped)
+	testStep2 := &TestStep{
+		"Port 80 updated",
+		reachability2,
+		[]metav1.Object{cgBuilder2.Get(), cgBuilderNested.Get()},
+		[]int32{80},
+		ProtocolTCP,
+		0,
+		nil,
+	}
+
+	testSteps := []*TestStep{testStep1, testStep2}
+	testCase := []*TestCase{
+		{"ACNP nested ClusterGroup create and update", testSteps},
+	}
+	executeTestsWithData(t, testCase, data)
+}
+
+func testNodeACNPNestedIPBlockClusterGroupCreateAndUpdate(t *testing.T) {
+	podYAIP, _ := podIPs[namespaces["y"]+"/a"]
+	podZAIP, _ := podIPs[namespaces["z"]+"/a"]
+	genCIDR := func(ip string) string {
+		switch IPFamily(ip) {
+		case "v4":
+			return ip + "/32"
+		case "v6":
+			return ip + "/128"
+		default:
+			return ""
+		}
+	}
+	cg1Name, cg2Name := "cg-y", "cg-z"
+	cgParentName := "cg-parent"
+	var ipBlockYA, ipBlockZA []crdv1beta1.IPBlock
+	for i := 0; i < len(podYAIP); i++ {
+		ipBlockYA = append(ipBlockYA, crdv1beta1.IPBlock{CIDR: genCIDR(podYAIP[i])})
+		ipBlockZA = append(ipBlockZA, crdv1beta1.IPBlock{CIDR: genCIDR(podZAIP[i])})
+	}
+	cgBuilder1 := &ClusterGroupSpecBuilder{}
+	cgBuilder1 = cgBuilder1.SetName(cg1Name).SetIPBlocks(ipBlockYA)
+	cgBuilder2 := &ClusterGroupSpecBuilder{}
+	cgBuilder2 = cgBuilder2.SetName(cg2Name).SetIPBlocks(ipBlockZA)
+	cgParent := &ClusterGroupSpecBuilder{}
+	cgParent = cgParent.SetName(cgParentName).SetChildGroups([]string{cg1Name, cg2Name})
+
+	builder := &ClusterNetworkPolicySpecBuilder{}
+	builder = builder.SetName("acnp-deny-x-to-yz-egress").
+		SetPriority(1.0).
+		SetAppliedToGroup([]ACNPAppliedToSpec{{NodeSelector: map[string]string{labelNodeHostname: nodes["x"]}}})
+	builder.AddEgress(ProtocolTCP, &p80, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+		nil, nil, nil, false, nil, crdv1beta1.RuleActionDrop, cgParentName, "", nil)
+
+	reachability := NewReachability(allPods, Connected)
+	reachability.Expect(Pod(namespaces["x"]+"/a"), Pod(namespaces["y"]+"/a"), Dropped)
+	reachability.Expect(Pod(namespaces["x"]+"/a"), Pod(namespaces["z"]+"/a"), Dropped)
+	testStep := &TestStep{
+		"Port 80",
+		reachability,
+		[]metav1.Object{builder.Get(), cgBuilder1.Get(), cgBuilder2.Get(), cgParent.Get()},
+		[]int32{80},
+		ProtocolTCP,
+		0,
+		nil,
+	}
+
+	cgParent = cgParent.SetChildGroups([]string{cg1Name})
+
+	reachability2 := NewReachability(allPods, Connected)
+	reachability2.Expect(Pod(namespaces["x"]+"/a"), Pod(namespaces["y"]+"/a"), Dropped)
+	testStep2 := &TestStep{
+		"Port 80, updated",
+		reachability2,
+		[]metav1.Object{cgParent.Get()},
+		[]int32{80},
+		ProtocolTCP,
+		0,
+		nil,
+	}
+
+	testCase := []*TestCase{
+		{"ACNP Drop Ingress From Node x to Pod y/a and z/a with nested ClusterGroup with ipBlocks", []*TestStep{testStep, testStep2}},
+	}
+	executeTests(t, testCase)
+}

--- a/test/integration/agent/route_test.go
+++ b/test/integration/agent/route_test.go
@@ -145,7 +145,7 @@ func TestInitialize(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Logf("Running Initialize test with mode %s node config %s", tc.networkConfig.TrafficEncapMode, nodeConfig)
-		routeClient, err := route.NewClient(tc.networkConfig, tc.noSNAT, false, false, false, nil)
+		routeClient, err := route.NewClient(tc.networkConfig, tc.noSNAT, false, false, false, false, nil)
 		assert.NoError(t, err)
 
 		var xtablesReleasedTime, initializedTime time.Time
@@ -252,7 +252,7 @@ func TestIpTablesSync(t *testing.T) {
 	gwLink := createDummyGW(t)
 	defer netlink.LinkDel(gwLink)
 
-	routeClient, err := route.NewClient(&config.NetworkConfig{TrafficEncapMode: config.TrafficEncapModeEncap, IPv4Enabled: true}, false, false, false, false, nil)
+	routeClient, err := route.NewClient(&config.NetworkConfig{TrafficEncapMode: config.TrafficEncapModeEncap, IPv4Enabled: true}, false, false, false, false, false, nil)
 	assert.Nil(t, err)
 
 	inited := make(chan struct{})
@@ -303,7 +303,7 @@ func TestAddAndDeleteSNATRule(t *testing.T) {
 	gwLink := createDummyGW(t)
 	defer netlink.LinkDel(gwLink)
 
-	routeClient, err := route.NewClient(&config.NetworkConfig{TrafficEncapMode: config.TrafficEncapModeEncap, IPv4Enabled: true}, false, false, false, false, nil)
+	routeClient, err := route.NewClient(&config.NetworkConfig{TrafficEncapMode: config.TrafficEncapModeEncap, IPv4Enabled: true}, false, false, false, false, false, nil)
 	assert.Nil(t, err)
 
 	inited := make(chan struct{})
@@ -357,7 +357,7 @@ func TestAddAndDeleteRoutes(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Logf("Running test with mode %s peer cidr %s peer ip %s node config %s", tc.mode, tc.peerCIDR, tc.peerIP, nodeConfig)
-		routeClient, err := route.NewClient(&config.NetworkConfig{TrafficEncapMode: tc.mode, IPv4Enabled: true}, false, false, false, false, nil)
+		routeClient, err := route.NewClient(&config.NetworkConfig{TrafficEncapMode: tc.mode, IPv4Enabled: true}, false, false, false, false, false, nil)
 		assert.NoError(t, err)
 		err = routeClient.Initialize(nodeConfig, func() {})
 		assert.NoError(t, err)
@@ -422,7 +422,7 @@ func TestSyncRoutes(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Logf("Running test with mode %s peer cidr %s peer ip %s node config %s", tc.mode, tc.peerCIDR, tc.peerIP, nodeConfig)
-		routeClient, err := route.NewClient(&config.NetworkConfig{TrafficEncapMode: tc.mode, IPv4Enabled: true}, false, false, false, false, nil)
+		routeClient, err := route.NewClient(&config.NetworkConfig{TrafficEncapMode: tc.mode, IPv4Enabled: true}, false, false, false, false, false, nil)
 		assert.NoError(t, err)
 		err = routeClient.Initialize(nodeConfig, func() {})
 		assert.NoError(t, err)
@@ -465,7 +465,7 @@ func TestSyncGatewayKernelRoute(t *testing.T) {
 	}
 	require.NoError(t, netlink.AddrAdd(gwLink, &netlink.Addr{IPNet: gwNet}), "configuring gw IP failed")
 
-	routeClient, err := route.NewClient(&config.NetworkConfig{TrafficEncapMode: config.TrafficEncapModeEncap}, false, false, false, false, nil)
+	routeClient, err := route.NewClient(&config.NetworkConfig{TrafficEncapMode: config.TrafficEncapModeEncap}, false, false, false, false, false, nil)
 	assert.NoError(t, err)
 	err = routeClient.Initialize(nodeConfig, func() {})
 	assert.NoError(t, err)
@@ -559,7 +559,7 @@ func TestReconcile(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Logf("Running test with mode %s added routes %v desired routes %v", tc.mode, tc.addedRoutes, tc.desiredPeerCIDRs)
-		routeClient, err := route.NewClient(&config.NetworkConfig{TrafficEncapMode: tc.mode, IPv4Enabled: true}, false, false, false, false, nil)
+		routeClient, err := route.NewClient(&config.NetworkConfig{TrafficEncapMode: tc.mode, IPv4Enabled: true}, false, false, false, false, false, nil)
 		assert.NoError(t, err)
 		err = routeClient.Initialize(nodeConfig, func() {})
 		assert.NoError(t, err)
@@ -598,7 +598,7 @@ func TestRouteTablePolicyOnly(t *testing.T) {
 	gwLink := createDummyGW(t)
 	defer netlink.LinkDel(gwLink)
 
-	routeClient, err := route.NewClient(&config.NetworkConfig{TrafficEncapMode: config.TrafficEncapModeNetworkPolicyOnly, IPv4Enabled: true}, false, false, false, false, nil)
+	routeClient, err := route.NewClient(&config.NetworkConfig{TrafficEncapMode: config.TrafficEncapModeNetworkPolicyOnly, IPv4Enabled: true}, false, false, false, false, false, nil)
 	assert.NoError(t, err)
 	err = routeClient.Initialize(nodeConfig, func() {})
 	assert.NoError(t, err)
@@ -654,7 +654,7 @@ func TestIPv6RoutesAndNeighbors(t *testing.T) {
 	gwLink := createDummyGW(t)
 	defer netlink.LinkDel(gwLink)
 
-	routeClient, err := route.NewClient(&config.NetworkConfig{TrafficEncapMode: config.TrafficEncapModeEncap, IPv4Enabled: true, IPv6Enabled: true}, false, false, false, false, nil)
+	routeClient, err := route.NewClient(&config.NetworkConfig{TrafficEncapMode: config.TrafficEncapModeEncap, IPv4Enabled: true, IPv6Enabled: true}, false, false, false, false, false, nil)
 	assert.Nil(t, err)
 	_, ipv6Subnet, _ := net.ParseCIDR("fd74:ca9b:172:19::/64")
 	gwIPv6 := net.ParseIP("fd74:ca9b:172:19::1")


### PR DESCRIPTION
This PR introduces support for the NodeNetworkPolicy datapath, extending Antrea
ClusterNetworkPolicy (ACNP). The implementation leverages iptables and ipset for
enforcing rules, safeguarding Kubernetes Nodes.

There are four key components to implement the data path:

- Core iptables rule
  - Integrated into static chains ANTREA-POL-INGRESS-RULES (ingress) or
    ANTREA-POL-EGRESS-RULES (egress).
  - Matches an ipset that includes NodeNetworkPolicy rule source or
    destination IPs, or directly matches a single IP.
  - Targets an action or a service chain created for NodeNetworkPolicy
    rule with multiple services.
- Service iptables chain
  - Created for NodeNetworkPolicy rule with multiple services.
- Service iptables rules:
  - Added to the service chain for NodeNetworkPolicy rule, constructed from
    rule services.
- From/To ipset:
  - Created for a NodeNetworkPolicy rule, containing source (ingress) or
   destination (egress) IPs.

Example ingress or egress core iptables rules organized by priorities:

```
:ANTREA-POL-INGRESS-RULES
-A ANTREA-POL-INGRESS-RULES -m set --match-set ANTREA-POL-RULE1-4 src -j ANTREA-POL-RULE1 -m comment --comment "Antrea: for rule RULE1, policy AntreaClusterNetworkPolicy:name1"
-A ANTREA-POL-INGRESS-RULES -m set --match-set ANTREA-POL-RULE2-4 src -p tcp --dport 8080 -j ACCEPT -m comment --comment "Antrea: for rule RULE2, policy AntreaClusterNetworkPolicy:name2"
-A ANTREA-POL-INGRESS-RULES -s 3.3.3.3/32 src -j ANTREA-POL-RULE3 -m comment --comment "Antrea: for rule RULE3, policy AntreaClusterNetworkPolicy:name3"
-A ANTREA-POL-INGRESS-RULES -s 4.4.4.4/32 -p tcp --dport 80 -j ACCEPT -m comment --comment "Antrea: for rule RULE4, policy AntreaClusterNetworkPolicy:name4"
```

Example service chain (for rule with multiple services)::

```
:ANTREA-POL-RULE1
-A ANTREA-POL-RULE1 -j ACCEPT -p tcp --dport 80
-A ANTREA-POL-RULE1 -j ACCEPT -p tcp --dport 443
```

Example ipset (for rule with multiple source or destination IPs)

```
Name: ANTREA-POL-RULE1-4
Type: hash:net
Revision: 6
Header: family inet hashsize 1024 maxelem 65536
Size in memory: 472
References: 1
Number of entries: 2
Members:
1.1.1.1
1.1.1.2
```

Signed-off-by: Hongliang Liu <lhongliang@vmware.com>