### PR TITLE
Update Windows Jenkins Jobs to Remove Docker Testbed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,7 +168,6 @@ Here are the trigger phrases for individual checks:
 * `/test-windows-e2e`: Windows IPv4 e2e tests
 * `/test-windows-conformance`: Windows IPv4 conformance tests
 * `/test-windows-networkpolicy`: Windows IPv4 networkpolicy tests
-* `/test-windows-proxyall-e2e`: Windows IPv4 e2e tests with proxyAll enabled
 * `/test-ipv6-e2e`: Linux dual stack e2e tests
 * `/test-ipv6-conformance`: Linux dual stack conformance tests
 * `/test-ipv6-networkpolicy`: Linux dual stack networkpolicy tests

--- a/ci/jenkins/jobs/macros.yaml
+++ b/ci/jenkins/jobs/macros.yaml
@@ -122,24 +122,6 @@
           ./ci/jenkins/test.sh --testcase windows-install-ovs
 
 - builder:
-    name: builder-e2e-win
-    builders:
-      - shell: |-
-          #!/bin/bash
-          set -ex
-          DOCKER_REGISTRY="$(head -n1 ci/docker-registry)"
-          ./ci/jenkins/test.sh --testcase windows-e2e --registry ${DOCKER_REGISTRY}
-
-- builder:
-    name: builder-conformance-win
-    builders:
-      - shell: |-
-          #!/bin/bash
-          set -ex
-          DOCKER_REGISTRY="$(head -n1 ci/docker-registry)"
-          ./ci/jenkins/test.sh --testcase '{conformance_type}' --registry ${{DOCKER_REGISTRY}}
-
-- builder:
     name: builder-e2e-proxyall-win
     builders:
       - shell: |-
@@ -149,7 +131,7 @@
           ./ci/jenkins/test.sh --testcase windows-e2e --registry ${DOCKER_REGISTRY} --proxyall
 
 - builder:
-      name: builder-e2e-win-containerd
+      name: builder-e2e-win
       builders:
           - shell: |-
                 #!/bin/bash
@@ -158,7 +140,7 @@
                 ./ci/jenkins/test.sh --testcase windows-containerd-e2e --registry ${{DOCKER_REGISTRY}} --win-image-node '{win_image_node}'
 
 - builder:
-      name: builder-conformance-win-containerd
+      name: builder-conformance-win
       builders:
           - shell: |-
                 #!/bin/bash

--- a/ci/jenkins/jobs/projects-lab.yaml
+++ b/ci/jenkins/jobs/projects-lab.yaml
@@ -549,62 +549,6 @@
           started_status: null
           wrappers: []
           publishers: []
-      - '{name}-{test_name}-for-pull-request':
-          test_name: windows-conformance
-          node: 'antrea-windows-testbed'
-          description: 'This is the {test_name} test for {name}.'
-          branches:
-          - ${{sha1}}
-          builders:
-            - builder-conformance-win:
-                conformance_type: 'conformance'
-          trigger_phrase: ^(?!Thanks for your PR).*/test-windows-(conformance|all).*
-          white_list_target_branches: []
-          allow_whitelist_orgs_as_admins: true
-          admin_list: '{antrea_admin_list}'
-          org_list: '{antrea_org_list}'
-          white_list: '{antrea_white_list}'
-          only_trigger_phrase: true
-          trigger_permit_all: true
-          throttle_concurrent_builds_category:
-            - e2e-lock-per-testbed
-          throttle_concurrent_builds_enabled: 'true'
-          status_context: jenkins-windows-conformance
-          status_url: --none--
-          success_status: Build finished.
-          failure_status: Failed. Add comment /test-windows-conformance to re-trigger.
-          error_status: Failed. Add comment /test-windows-conformance to re-trigger.
-          triggered_status: null
-          started_status: null
-          wrappers:
-          - timeout:
-              fail: true
-              timeout: 120
-              type: absolute
-          - credentials-binding:
-              - text:
-                  credential-id: GOVC_URL
-                  variable: GOVC_URL
-              - text:
-                  credential-id: GOVC_USERNAME
-                  variable: GOVC_USERNAME
-              - text:
-                  credential-id: GOVC_PASSWORD
-                  variable: GOVC_PASSWORD
-              - text:
-                  credential-id: GOVC_DATACENTER
-                  variable: GOVC_DATACENTER
-              - text:
-                  credential-id: GOVC_DATASTORE
-                  variable: GOVC_DATASTORE
-          publishers:
-          - archive:
-              allow-empty: true
-              artifacts: 'windows_conformance_result_no_color.txt,network_info.tar.gz,antrea_agent_log.tar.gz,debug_logs.tar.gz'
-              case-sensitive: true
-              default-excludes: true
-              fingerprint: false
-              only-if-success: false
       - '{name}-{test_name}-no-scm':
           test_name: windows-networkpolicy-pending-label
           node: null
@@ -630,62 +574,6 @@
           started_status: null
           wrappers: []
           publishers: []
-      - '{name}-{test_name}-for-pull-request':
-          test_name: windows-networkpolicy
-          node: 'antrea-windows-testbed'
-          description: 'This is the {test_name} test for {name}.'
-          branches:
-          - ${{sha1}}
-          builders:
-            - builder-conformance-win:
-                conformance_type: 'networkpolicy'
-          trigger_phrase: ^(?!Thanks for your PR).*/test-windows-(networkpolicy|all).*
-          white_list_target_branches: []
-          allow_whitelist_orgs_as_admins: true
-          admin_list: '{antrea_admin_list}'
-          org_list: '{antrea_org_list}'
-          white_list: '{antrea_white_list}'
-          only_trigger_phrase: true
-          trigger_permit_all: true
-          throttle_concurrent_builds_category:
-            - e2e-lock-per-testbed
-          throttle_concurrent_builds_enabled: 'true'
-          status_context: jenkins-windows-networkpolicy
-          status_url: --none--
-          success_status: Build finished.
-          failure_status: Failed. Add comment /test-windows-networkpolicy to re-trigger.
-          error_status: Failed. Add comment /test-windows-networkpolicy to re-trigger.
-          triggered_status: null
-          started_status: null
-          wrappers:
-          - timeout:
-              fail: true
-              timeout: 135
-              type: absolute
-          - credentials-binding:
-              - text:
-                  credential-id: GOVC_URL
-                  variable: GOVC_URL
-              - text:
-                  credential-id: GOVC_USERNAME
-                  variable: GOVC_USERNAME
-              - text:
-                  credential-id: GOVC_PASSWORD
-                  variable: GOVC_PASSWORD
-              - text:
-                  credential-id: GOVC_DATACENTER
-                  variable: GOVC_DATACENTER
-              - text:
-                  credential-id: GOVC_DATASTORE
-                  variable: GOVC_DATASTORE
-          publishers:
-          - archive:
-              allow-empty: true
-              artifacts: 'windows_conformance_result_no_color.txt,network_info.tar.gz,antrea_agent_log.tar.gz,debug_logs.tar.gz'
-              case-sensitive: true
-              default-excludes: true
-              fingerprint: false
-              only-if-success: false
       - '{name}-{test_name}-no-scm':
           test_name: windows-e2e-pending-label
           node: null
@@ -712,176 +600,16 @@
           wrappers: []
           publishers: []
       - '{name}-{test_name}-for-pull-request':
-          test_name: windows-e2e
-          node: 'antrea-windows-testbed'
-          description: 'This is the {test_name} test for {name}.'
-          branches:
-          - ${{sha1}}
-          builders:
-            - builder-e2e-win
-          trigger_phrase: ^(?!Thanks for your PR).*/test-windows-(e2e|all).*
-          white_list_target_branches: []
-          allow_whitelist_orgs_as_admins: true
-          admin_list: '{antrea_admin_list}'
-          org_list: '{antrea_org_list}'
-          white_list: '{antrea_white_list}'
-          only_trigger_phrase: true
-          trigger_permit_all: true
-          throttle_concurrent_builds_category:
-            - e2e-lock-per-testbed
-          throttle_concurrent_builds_enabled: 'true'
-          status_context: jenkins-windows-e2e
-          status_url: --none--
-          success_status: Build finished.
-          failure_status: Failed. Add comment /test-windows-e2e to re-trigger.
-          error_status: Failed. Add comment /test-windows-e2e to re-trigger.
-          triggered_status: null
-          started_status: null
-          wrappers:
-          - timeout:
-              fail: true
-              timeout: 120
-              type: absolute
-          - credentials-binding:
-              - text:
-                  credential-id: GOVC_URL
-                  variable: GOVC_URL
-              - text:
-                  credential-id: GOVC_USERNAME
-                  variable: GOVC_USERNAME
-              - text:
-                  credential-id: GOVC_PASSWORD
-                  variable: GOVC_PASSWORD
-              - text:
-                  credential-id: GOVC_DATACENTER
-                  variable: GOVC_DATACENTER
-              - text:
-                  credential-id: GOVC_DATASTORE
-                  variable: GOVC_DATASTORE
-          publishers:
-          - archive:
-              allow-empty: true
-              artifacts: antrea-test-logs.tar.gz
-              case-sensitive: true
-              default-excludes: true
-              fingerprint: false
-              only-if-success: false
-      - '{name}-{test_name}-no-scm':
-          test_name: windows-e2e-proxyall-pending-label
-          node: null
-          description: 'This is for marking PR as pending for e2e proxyall test.'
-          builders:
-            - builder-pending-label
-          trigger_phrase: null
-          white_list_target_branches: []
-          allow_whitelist_orgs_as_admins: false
-          admin_list: []
-          org_list: []
-          white_list: []
-          only_trigger_phrase: false
-          trigger_permit_all: true
-          throttle_concurrent_builds_category:
-          throttle_concurrent_builds_enabled: 'false'
-          status_context: jenkins-windows-proxyall-e2e
-          status_url: --none--
-          success_status: Pending test. Mark as failure. Add comment /test-windows-proxyall-e2e to trigger.
-          failure_status: Pending test. Mark as failure. Add comment /test-windows-proxyall-e2e to trigger.
-          error_status: Pending test. Mark as failure. Add comment /test-windows-proxyall-e2e to trigger.
-          triggered_status: null
-          started_status: null
-          wrappers: []
-          publishers: []
-      - '{name}-{test_name}-for-pull-request':
-          test_name: windows-e2e-proxyall
-          node: 'antrea-windows-proxyall-testbed'
-          description: 'This is the {test_name} test for {name}.'
-          branches:
-          - ${{sha1}}
-          builders:
-            - builder-e2e-proxyall-win
-          trigger_phrase: ^(?!Thanks for your PR).*/test-windows-(proxyall-e2e|all).*
-          white_list_target_branches: []
-          allow_whitelist_orgs_as_admins: true
-          admin_list: '{antrea_admin_list}'
-          org_list: '{antrea_org_list}'
-          white_list: '{antrea_white_list}'
-          only_trigger_phrase: true
-          trigger_permit_all: true
-          throttle_concurrent_builds_category:
-            - e2e-lock-per-testbed
-          throttle_concurrent_builds_enabled: 'true'
-          status_context: jenkins-windows-proxyall-e2e
-          status_url: --none--
-          success_status: Build finished.
-          failure_status: Failed. Add comment /test-windows-proxyall-e2e to re-trigger.
-          error_status: Failed. Add comment /test-windows-proxyall-e2e to re-trigger.
-          triggered_status: null
-          started_status: null
-          wrappers:
-          - timeout:
-              fail: true
-              timeout: 120
-              type: absolute
-          - credentials-binding:
-              - text:
-                  credential-id: GOVC_URL
-                  variable: GOVC_URL
-              - text:
-                  credential-id: GOVC_USERNAME
-                  variable: GOVC_USERNAME
-              - text:
-                  credential-id: GOVC_PASSWORD
-                  variable: GOVC_PASSWORD
-              - text:
-                  credential-id: GOVC_DATACENTER
-                  variable: GOVC_DATACENTER
-              - text:
-                  credential-id: GOVC_DATASTORE
-                  variable: GOVC_DATASTORE
-          publishers:
-          - archive:
-              allow-empty: true
-              artifacts: antrea-test-logs.tar.gz
-              case-sensitive: true
-              default-excludes: true
-              fingerprint: false
-              only-if-success: false
-      - '{name}-{test_name}-no-scm':
-            test_name: windows-containerd-conformance-pending-label
-            node: null
-            description: 'This is for marking PR as pending for conformance test.'
-            builders:
-                - builder-pending-label
-            trigger_phrase: null
-            white_list_target_branches: [ ]
-            allow_whitelist_orgs_as_admins: false
-            admin_list: [ ]
-            org_list: [ ]
-            white_list: [ ]
-            only_trigger_phrase: false
-            trigger_permit_all: true
-            throttle_concurrent_builds_category:
-            throttle_concurrent_builds_enabled: 'false'
-            status_context: jenkins-windows-containerd-conformance
-            status_url: --none--
-            success_status: Pending test. Mark as failure. Add comment /test-windows-containerd-conformance to trigger.
-            failure_status: Pending test. Mark as failure. Add comment /test-windows-containerd-conformance to trigger.
-            error_status: Pending test. Mark as failure. Add comment /test-windows-containerd-conformance to trigger.
-            triggered_status: null
-            started_status: null
-            wrappers: [ ]
-            publishers: [ ]
-      - '{name}-{test_name}-for-pull-request':
-            test_name: windows-containerd-conformance
+            test_name: windows-conformance
             node: 'antrea-windows-containerd-testbed'
             description: 'This is the {test_name} test for {name}.'
             branches:
                 - ${{sha1}}
             builders:
-                - builder-conformance-win-containerd:
-                      conformance_type: 'conformance'
+                - builder-conformance-win:
+                      conformance_type: 'windows-containerd-conformance'
                       win_image_node: '{antrea_win_image_node_name}'
-            trigger_phrase: ^(?!Thanks for your PR).*/test-windows-(containerd-conformance|all).*
+            trigger_phrase: ^(?!Thanks for your PR).*/test-windows-(conformance|all).*
             white_list_target_branches: [ ]
             allow_whitelist_orgs_as_admins: true
             admin_list: '{antrea_admin_list}'
@@ -892,11 +620,11 @@
             throttle_concurrent_builds_category:
                 - e2e-lock-per-testbed
             throttle_concurrent_builds_enabled: 'true'
-            status_context: jenkins-windows-containerd-conformance
+            status_context: jenkins-windows-conformance
             status_url: --none--
             success_status: Build finished.
-            failure_status: Failed. Add comment /test-windows-containerd-conformance to re-trigger.
-            error_status: Failed. Add comment /test-windows-containerd-conformance to re-trigger.
+            failure_status: Failed. Add comment /test-windows-conformance to re-trigger.
+            error_status: Failed. Add comment /test-windows-conformance to re-trigger.
             triggered_status: null
             started_status: null
             wrappers:
@@ -928,42 +656,17 @@
                       default-excludes: true
                       fingerprint: false
                       only-if-success: false
-      - '{name}-{test_name}-no-scm':
-            test_name: windows-containerd-networkpolicy-pending-label
-            node: null
-            description: 'This is for marking PR as pending for networkpolicy test.'
-            builders:
-                - builder-pending-label
-            trigger_phrase: null
-            white_list_target_branches: [ ]
-            allow_whitelist_orgs_as_admins: false
-            admin_list: [ ]
-            org_list: [ ]
-            white_list: [ ]
-            only_trigger_phrase: false
-            trigger_permit_all: true
-            throttle_concurrent_builds_category:
-            throttle_concurrent_builds_enabled: 'false'
-            status_context: jenkins-windows-containerd-networkpolicy
-            status_url: --none--
-            success_status: Pending test. Mark as failure. Add comment /test-windows-containerd-networkpolicy to trigger.
-            failure_status: Pending test. Mark as failure. Add comment /test-windows-containerd-networkpolicy to trigger.
-            error_status: Pending test. Mark as failure. Add comment /test-windows-containerd-networkpolicy to trigger.
-            triggered_status: null
-            started_status: null
-            wrappers: [ ]
-            publishers: [ ]
       - '{name}-{test_name}-for-pull-request':
-            test_name: windows-containerd-networkpolicy
+            test_name: windows-networkpolicy
             node: 'antrea-windows-containerd-testbed'
             description: 'This is the {test_name} test for {name}.'
             branches:
                 - ${{sha1}}
             builders:
-                - builder-conformance-win-containerd:
-                      conformance_type: 'networkpolicy'
+                - builder-conformance-win:
+                      conformance_type: 'windows-containerd-networkpolicy'
                       win_image_node: '{antrea_win_image_node_name}'
-            trigger_phrase: ^(?!Thanks for your PR).*/test-windows-(containerd-networkpolicy|all).*
+            trigger_phrase: ^(?!Thanks for your PR).*/test-windows-(networkpolicy|all).*
             white_list_target_branches: [ ]
             allow_whitelist_orgs_as_admins: true
             admin_list: '{antrea_admin_list}'
@@ -974,11 +677,11 @@
             throttle_concurrent_builds_category:
                 - e2e-lock-per-testbed
             throttle_concurrent_builds_enabled: 'true'
-            status_context: jenkins-windows-containerd-networkpolicy
+            status_context: jenkins-windows-networkpolicy
             status_url: --none--
             success_status: Build finished.
-            failure_status: Failed. Add comment /test-windows-containerd-networkpolicy to re-trigger.
-            error_status: Failed. Add comment /test-windows-containerd-networkpolicy to re-trigger.
+            failure_status: Failed. Add comment /test-windows-networkpolicy to re-trigger.
+            error_status: Failed. Add comment /test-windows-networkpolicy to re-trigger.
             triggered_status: null
             started_status: null
             wrappers:
@@ -1010,41 +713,16 @@
                       default-excludes: true
                       fingerprint: false
                       only-if-success: false
-      - '{name}-{test_name}-no-scm':
-            test_name: windows-containerd-e2e-pending-label
-            node: null
-            description: 'This is for marking PR as pending for e2e test.'
-            builders:
-                - builder-pending-label
-            trigger_phrase: null
-            white_list_target_branches: [ ]
-            allow_whitelist_orgs_as_admins: false
-            admin_list: [ ]
-            org_list: [ ]
-            white_list: [ ]
-            only_trigger_phrase: false
-            trigger_permit_all: true
-            throttle_concurrent_builds_category:
-            throttle_concurrent_builds_enabled: 'false'
-            status_context: jenkins-windows-containerd-e2e
-            status_url: --none--
-            success_status: Pending test. Mark as failure. Add comment /test-windows-containerd-e2e to trigger.
-            failure_status: Pending test. Mark as failure. Add comment /test-windows-containerd-e2e to trigger.
-            error_status: Pending test. Mark as failure. Add comment /test-windows-containerd-e2e to trigger.
-            triggered_status: null
-            started_status: null
-            wrappers: [ ]
-            publishers: [ ]
       - '{name}-{test_name}-for-pull-request':
-            test_name: windows-containerd-e2e
+            test_name: windows-e2e
             node: 'antrea-windows-containerd-testbed'
             description: 'This is the {test_name} test for {name}.'
             branches:
                 - ${{sha1}}
             builders:
-                - builder-e2e-win-containerd:
+                - builder-e2e-win:
                       win_image_node: '{antrea_win_image_node_name}'
-            trigger_phrase: ^(?!Thanks for your PR).*/test-windows-(containerd-e2e|all).*
+            trigger_phrase: ^(?!Thanks for your PR).*/test-windows-(e2e|all).*
             white_list_target_branches: [ ]
             allow_whitelist_orgs_as_admins: true
             admin_list: '{antrea_admin_list}'
@@ -1055,11 +733,11 @@
             throttle_concurrent_builds_category:
                 - e2e-lock-per-testbed
             throttle_concurrent_builds_enabled: 'true'
-            status_context: jenkins-windows-containerd-e2e
+            status_context: jenkins-windows-e2e
             status_url: --none--
             success_status: Build finished.
-            failure_status: Failed. Add comment /test-windows-containerd-e2e to re-trigger.
-            error_status: Failed. Add comment /test-windows-containerda-e2e to re-trigger.
+            failure_status: Failed. Add comment /test-windows-e2e to re-trigger.
+            error_status: Failed. Add comment /test-windows-e2e to re-trigger.
             triggered_status: null
             started_status: null
             wrappers:


### PR DESCRIPTION
For #5641

* Remove all windows docker jobs.
* Rename the trigger phases of all Windows containerd jobs to normal Windows trigger phases.
* Remove windows proxyall job as we have set this feature as the default value in agent.