### PR TITLE
Check all multi-cluster manifests in check-manifest.sh

### DIFF
--- a/ci/check-manifest.sh
+++ b/ci/check-manifest.sh
@@ -39,11 +39,7 @@ rm "${YAMLS[@]}"
 make manifest
 diff="$(git status --porcelain ${YAMLS[@]})"
 
-MULTICLUSTER_YAMLS=(
-    "multicluster/build/yamls/antrea-multicluster-leader-global.yml"
-    "multicluster/build/yamls/antrea-multicluster-leader-namespaced.yml"
-    "multicluster/build/yamls/antrea-multicluster-member.yml"
-)
+MULTICLUSTER_YAMLS=($(ls multicluster/build/yamls/*.yml))
 
 rm "${MULTICLUSTER_YAMLS[@]}"
 cd multicluster; make manifests; cd ..


### PR DESCRIPTION
There was a new manifest "antrea-multicluster-leader.yml" added for Antrea Multi-cluster, but it's not added to the check list. So refine the code to check all manifests to avoid missing the new manifest.