### PR TITLE
Automated cherry pick of #5657: Set net.ipv4.conf.antrea-gw0.arp_announce to 1

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -726,6 +726,14 @@ func (i *Initializer) setupGatewayInterface() error {
 	if err := i.setInterfaceMTU(i.hostGateway, i.networkConfig.InterfaceMTU); err != nil {
 		return err
 	}
+	// Set arp_announce to 1 on Linux platform to make the ARP requests sent on the gateway
+	// interface always use the gateway IP as the source IP, otherwise the ARP requests would be
+	// dropped by ARP SpoofGuard flow.
+	if i.nodeConfig.GatewayConfig.IPv4 != nil {
+		if err := setInterfaceARPAnnounce(gatewayIface.InterfaceName, 1); err != nil {
+			return err
+		}
+	}
 
 	return nil
 }

--- a/pkg/agent/agent_linux.go
+++ b/pkg/agent/agent_linux.go
@@ -40,6 +40,9 @@ var (
 
 	// getAllIPNetsByName is meant to be overridden for testing.
 	getAllIPNetsByName = util.GetAllIPNetsByName
+
+	// setInterfaceARPAnnounce is meant to be overridden for testing.
+	setInterfaceARPAnnounce = util.EnsureARPAnnounceOnInterface
 )
 
 // prepareHostNetwork returns immediately on Linux.

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -587,6 +587,7 @@ func TestSetupGatewayInterface(t *testing.T) {
 	mockSetLinkUp(t, fakeMAC, 10, nil)
 	mockConfigureLinkAddress(t, nil)
 	mockSetInterfaceMTU(t, nil)
+	mockSetInterfaceARPAnnounce(t, nil)
 
 	controller := mock.NewController(t)
 
@@ -644,6 +645,14 @@ func mockConfigureLinkAddress(t *testing.T, returnedErr error) {
 		return returnedErr
 	}
 	t.Cleanup(func() { configureLinkAddresses = originalConfigureLinkAddresses })
+}
+
+func mockSetInterfaceARPAnnounce(t *testing.T, returnedErr error) {
+	originalSetInterfaceARPAnnounce := setInterfaceARPAnnounce
+	setInterfaceARPAnnounce = func(ifaceName string, value int) error {
+		return returnedErr
+	}
+	t.Cleanup(func() { setInterfaceARPAnnounce = originalSetInterfaceARPAnnounce })
 }
 
 func TestRestorePortConfigs(t *testing.T) {

--- a/pkg/agent/agent_windows.go
+++ b/pkg/agent/agent_windows.go
@@ -37,6 +37,9 @@ import (
 var (
 	// setInterfaceMTU is meant to be overridden for testing
 	setInterfaceMTU = util.SetInterfaceMTU
+
+	// setInterfaceARPAnnounce is meant to be overridden for testing.
+	setInterfaceARPAnnounce = func(ifaceName string, value int) error { return nil }
 )
 
 func (i *Initializer) prepareHostNetwork() error {

--- a/pkg/agent/openflow/pod_connectivity.go
+++ b/pkg/agent/openflow/pod_connectivity.go
@@ -143,7 +143,6 @@ func (f *featurePodConnectivity) initFlows() []*openflow15.FlowMod {
 			flows = append(flows, f.arpSpoofGuardFlow(f.gatewayIPs[ipProtocol], gatewayMAC, f.gatewayPort))
 			if f.connectUplinkToBridge {
 				flows = append(flows, f.arpResponderFlow(f.gatewayIPs[ipProtocol], gatewayMAC))
-				flows = append(flows, f.arpSpoofGuardFlow(f.nodeConfig.NodeIPv4Addr.IP, gatewayMAC, f.gatewayPort))
 				flows = append(flows, f.hostBridgeUplinkVLANFlows()...)
 			}
 			if runtime.IsWindowsPlatform() || f.connectUplinkToBridge {

--- a/pkg/agent/openflow/pod_connectivity_test.go
+++ b/pkg/agent/openflow/pod_connectivity_test.go
@@ -167,7 +167,6 @@ func podConnectivityInitFlows(trafficEncapMode config.TrafficEncapModeType, conn
 				flows = append(flows,
 					"cookie=0x1010000000000, table=ARPSpoofGuard, priority=210,arp,in_port=4 actions=NORMAL",
 					"cookie=0x1010000000000, table=ARPSpoofGuard, priority=210,arp,in_port=4294967294 actions=NORMAL",
-					"cookie=0x1010000000000, table=ARPSpoofGuard, priority=200,arp,in_port=2,arp_spa=192.168.77.100,arp_sha=0a:00:00:00:00:01 actions=goto_table:ARPResponder",
 					"cookie=0x1010000000000, table=ARPResponder, priority=200,arp,arp_tpa=10.10.0.1,arp_op=1 actions=move:NXM_OF_ETH_SRC[]->NXM_OF_ETH_DST[],set_field:0a:00:00:00:00:01->eth_src,set_field:2->arp_op,move:NXM_NX_ARP_SHA[]->NXM_NX_ARP_THA[],set_field:0a:00:00:00:00:01->arp_sha,move:NXM_OF_ARP_SPA[]->NXM_OF_ARP_TPA[],set_field:10.10.0.1->arp_spa,IN_PORT",
 					"cookie=0x1010000000000, table=Classifier, priority=200,in_port=4 actions=output:4294967294",
 					"cookie=0x1010000000000, table=Classifier, priority=200,in_port=4294967294 actions=output:4",

--- a/pkg/agent/util/net_linux.go
+++ b/pkg/agent/util/net_linux.go
@@ -337,6 +337,11 @@ func EnsureIPv6EnabledOnInterface(ifaceName string) error {
 	return sysctl.EnsureSysctlNetValue(path, 0)
 }
 
+func EnsureARPAnnounceOnInterface(ifaceName string, value int) error {
+	path := fmt.Sprintf("ipv4/conf/%s/arp_announce", ifaceName)
+	return sysctl.EnsureSysctlNetValue(path, value)
+}
+
 func getRoutesOnInterface(linkIndex int) ([]interface{}, error) {
 	link, err := netlinkUtil.LinkByIndex(linkIndex)
 	if err != nil {

--- a/test/integration/agent/openflow_test.go
+++ b/test/integration/agent/openflow_test.go
@@ -1303,12 +1303,6 @@ func prepareGatewayFlows(gwIPs []net.IP, gwMAC net.HardwareAddr, vMAC net.Hardwa
 					},
 				},
 			)
-			if connectUplinkToBridge {
-				flows[len(flows)-1].flows = append(flows[len(flows)-1].flows, &ofTestUtils.ExpectFlow{
-					MatchStr: fmt.Sprintf("priority=200,arp,in_port=%d,arp_spa=%s,arp_sha=%s", agentconfig.HostGatewayOFPort, nodeConfig.NodeIPv4Addr.IP.String(), gwMAC),
-					ActStr:   "goto_table:ARPResponder",
-				})
-			}
 		} else {
 			ipProtoStr = "ipv6"
 			nwSrcStr = "ipv6_src"


### PR DESCRIPTION
Cherry pick of #5657 on release-1.13.

#5657: Set net.ipv4.conf.antrea-gw0.arp_announce to 1

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.