### PR TITLE
Lazily initialize localPodInformer in a more readable way

### DIFF
--- a/pkg/util/lazy/lazy.go
+++ b/pkg/util/lazy/lazy.go
@@ -1,0 +1,62 @@
+// Copyright 2023 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lazy
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// Lazy defers the evaluation of getter until it's accessed the first access.
+type Lazy[T any] interface {
+	// Get returns the value, evaluate it if necessary.
+	Get() T
+	// Evaluated returns whether the value has been evaluated or not.
+	Evaluated() bool
+}
+
+type lazy[T any] struct {
+	getter func() T
+	// res is the cached result.
+	res  T
+	done uint32
+	m    sync.Mutex
+}
+
+// New returns a new lazily evaluated value. The getter is executed only when it's accessed the first access.
+func New[T any](getter func() T) Lazy[T] {
+	return &lazy[T]{getter: getter}
+}
+
+func (l *lazy[T]) Get() T {
+	if atomic.LoadUint32(&l.done) == 0 {
+		return l.doSlow()
+	}
+	return l.res
+}
+
+func (l *lazy[T]) doSlow() T {
+	l.m.Lock()
+	defer l.m.Unlock()
+	if l.done == 0 {
+		defer atomic.StoreUint32(&l.done, 1)
+		l.res = l.getter()
+	}
+	return l.res
+}
+
+func (l *lazy[T]) Evaluated() bool {
+	return atomic.LoadUint32(&l.done) == 1
+}

--- a/pkg/util/lazy/lazy_test.go
+++ b/pkg/util/lazy/lazy_test.go
@@ -1,0 +1,48 @@
+// Copyright 2023 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lazy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type foo struct{}
+
+func TestLazy(t *testing.T) {
+	var called int
+	lazyFoo := New(func() *foo {
+		called++
+		return &foo{}
+	})
+	assert.False(t, lazyFoo.Evaluated())
+	assert.Equal(t, 0, called)
+
+	ch := make(chan *foo, 10)
+	for i := 0; i < 10; i++ {
+		go func() {
+			ch <- lazyFoo.Get()
+		}()
+	}
+	// Got the first result.
+	foo := <-ch
+	assert.True(t, lazyFoo.Evaluated())
+	// Got the rest 9 results, all of them should reference the same object.
+	for i := 1; i < 10; i++ {
+		assert.Same(t, foo, <-ch)
+	}
+	assert.Equal(t, 1, called, "The getter should only be called exactly once")
+}


### PR DESCRIPTION
Instead of checking various conditions to determine whether localPodInformer should be initialized, which is error-prone and looks ugly, this patch adds a Generic interface for lazy evaluation and uses it to initialize localPodInformer when it's necessary.