### PR TITLE
Add Hairpin traffic limitation doc

### DIFF
--- a/docs/antrea-network-policy.md
+++ b/docs/antrea-network-policy.md
@@ -1777,3 +1777,10 @@ Similar RBAC is applied to the ClusterGroup resource.
 - NetworkPolicies are connection/flow oriented and stateful. They apply to
   connections, instead of individual packets, which means established connections
   won't be blocked by new rules.
+- For hairpin service traffic, when a Pod initiates traffic towards the service it provides,
+  and the same Pod is selected as the Endpoint, NetworkPolicies will consistently permit
+  this traffic during ingress enforcement if AntreaProxy is enabled. However, when AntreaProxy
+  is disabled, NetworkPolicies may not function as expected for hairpin service traffic.
+  This is due to kube-proxy performing SNAT, which conceals the original source IP from Antrea.
+  Consequently, NetworkPolicies are unable to differentiate between hairpin service traffic and
+  external traffic in this scenario.

--- a/test/e2e/networkpolicy_test.go
+++ b/test/e2e/networkpolicy_test.go
@@ -93,6 +93,7 @@ func TestNetworkPolicy(t *testing.T) {
 	})
 	t.Run("testAllowHairpinService", func(t *testing.T) {
 		t.Cleanup(exportLogsForSubtest(t, data))
+		skipIfProxyDisabled(t, data)
 		testAllowHairpinService(t, data)
 	})
 }


### PR DESCRIPTION
This is a follow-up PR of PR #5687.

1. Skip allowHairpinSerivce test when Antrea-Proxy is disabled.
2. Add documentation including the behavior of the hairpin service when Antrea-Proxy is enabled and disabled.

