### PR TITLE
Remove usage of RunCommandOnNode for multicast e2e tests

### DIFF
--- a/test/e2e/multicast_test.go
+++ b/test/e2e/multicast_test.go
@@ -606,16 +606,12 @@ func runTestMulticastBetweenPods(t *testing.T, data *TestData, mc multicastTestc
 			return nil, err
 		}
 		res := make([]string, 0)
+	outer:
 		for _, line := range strings.Split(stdout, "\n") {
-			add := true
 			for _, f := range outputFilters {
 				if !strings.Contains(line, f) {
-					add = false
-					break
+					continue outer
 				}
-			}
-			if !add {
-				continue
 			}
 			res = append(res, line)
 		}


### PR DESCRIPTION
RunCommandOnNode should be avoided as much as possible, as it tends to make assumptions about software available on Nodes. In this case, we can run the same commands from the Antrea Agent Pod.

With this change, we can also remove some Kind-specific code.