### PR TITLE
Automated cherry pick of #5689: Use Traceflow API v1beta1

### DIFF
--- a/pkg/antctl/raw/traceflow/command_test.go
+++ b/pkg/antctl/raw/traceflow/command_test.go
@@ -31,7 +31,7 @@ import (
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 
-	"antrea.io/antrea/pkg/apis/crd/v1alpha1"
+	"antrea.io/antrea/pkg/apis/crd/v1beta1"
 	antrea "antrea.io/antrea/pkg/client/clientset/versioned"
 	antreafakeclient "antrea.io/antrea/pkg/client/clientset/versioned/fake"
 )
@@ -112,19 +112,19 @@ func TestParseFlow(t *testing.T) {
 	tcs := []struct {
 		flow     string
 		success  bool
-		expected *v1alpha1.Traceflow
+		expected *v1beta1.Traceflow
 	}{
 		{
 			flow:    "udp,udp_src=1234,udp_dst=4321",
 			success: true,
-			expected: &v1alpha1.Traceflow{
-				Spec: v1alpha1.TraceflowSpec{
-					Packet: v1alpha1.Packet{
-						IPHeader: v1alpha1.IPHeader{
+			expected: &v1beta1.Traceflow{
+				Spec: v1beta1.TraceflowSpec{
+					Packet: v1beta1.Packet{
+						IPHeader: &v1beta1.IPHeader{
 							Protocol: 17,
 						},
-						TransportHeader: v1alpha1.TransportHeader{
-							UDP: &v1alpha1.UDPHeader{
+						TransportHeader: v1beta1.TransportHeader{
+							UDP: &v1beta1.UDPHeader{
 								SrcPort: 1234,
 								DstPort: 4321,
 							},
@@ -136,13 +136,13 @@ func TestParseFlow(t *testing.T) {
 		{
 			flow:    " icmp,",
 			success: true,
-			expected: &v1alpha1.Traceflow{
-				Spec: v1alpha1.TraceflowSpec{
-					Packet: v1alpha1.Packet{
-						IPHeader: v1alpha1.IPHeader{
+			expected: &v1beta1.Traceflow{
+				Spec: v1beta1.TraceflowSpec{
+					Packet: v1beta1.Packet{
+						IPHeader: &v1beta1.IPHeader{
 							Protocol: 1,
 						},
-						TransportHeader: v1alpha1.TransportHeader{},
+						TransportHeader: v1beta1.TransportHeader{},
 					},
 				},
 			},
@@ -150,14 +150,14 @@ func TestParseFlow(t *testing.T) {
 		{
 			flow:    "tcp,tcp_dst=4321",
 			success: true,
-			expected: &v1alpha1.Traceflow{
-				Spec: v1alpha1.TraceflowSpec{
-					Packet: v1alpha1.Packet{
-						IPHeader: v1alpha1.IPHeader{
+			expected: &v1beta1.Traceflow{
+				Spec: v1beta1.TraceflowSpec{
+					Packet: v1beta1.Packet{
+						IPHeader: &v1beta1.IPHeader{
 							Protocol: 6,
 						},
-						TransportHeader: v1alpha1.TransportHeader{
-							TCP: &v1alpha1.TCPHeader{
+						TransportHeader: v1beta1.TransportHeader{
+							TCP: &v1beta1.TCPHeader{
 								DstPort: 4321,
 							},
 						},
@@ -168,14 +168,14 @@ func TestParseFlow(t *testing.T) {
 		{
 			flow:    "tcp,tcp_dst=4321,ipv6",
 			success: true,
-			expected: &v1alpha1.Traceflow{
-				Spec: v1alpha1.TraceflowSpec{
-					Packet: v1alpha1.Packet{
-						IPv6Header: &v1alpha1.IPv6Header{
+			expected: &v1beta1.Traceflow{
+				Spec: v1beta1.TraceflowSpec{
+					Packet: v1beta1.Packet{
+						IPv6Header: &v1beta1.IPv6Header{
 							NextHeader: &protocolTCP,
 						},
-						TransportHeader: v1alpha1.TransportHeader{
-							TCP: &v1alpha1.TCPHeader{
+						TransportHeader: v1beta1.TransportHeader{
+							TCP: &v1beta1.TCPHeader{
 								DstPort: 4321,
 							},
 						},
@@ -279,8 +279,8 @@ source: default/pod-1
 			client := antreafakeclient.NewSimpleClientset()
 			client.PrependReactor("create", "traceflows", func(action k8stesting.Action) (bool, runtime.Object, error) {
 				createAction := action.(k8stesting.CreateAction)
-				obj := createAction.GetObject().(*v1alpha1.Traceflow)
-				obj.Status.Phase = v1alpha1.Succeeded
+				obj := createAction.GetObject().(*v1beta1.Traceflow)
+				obj.Status.Phase = v1beta1.Succeeded
 				return false, obj, nil
 			})
 
@@ -377,23 +377,23 @@ func TestNewTraceflow(t *testing.T) {
 		dst         string
 		liveTraffic string
 		droppedOnly string
-		expectedTf  *v1alpha1.Traceflow
+		expectedTf  *v1beta1.Traceflow
 	}{
 		{
 			name: "dummy-traceflow-dst-pod",
 			dst:  dstPod,
-			expectedTf: &v1alpha1.Traceflow{
-				Spec: v1alpha1.TraceflowSpec{
-					Destination: v1alpha1.Destination{
+			expectedTf: &v1beta1.Traceflow{
+				Spec: v1beta1.TraceflowSpec{
+					Destination: v1beta1.Destination{
 						Namespace: "default",
 						Pod:       "pod-2",
 					},
-					Packet: v1alpha1.Packet{
-						IPv6Header: &v1alpha1.IPv6Header{
+					Packet: v1beta1.Packet{
+						IPv6Header: &v1beta1.IPv6Header{
 							NextHeader: &protocolTCP,
 						},
-						TransportHeader: v1alpha1.TransportHeader{
-							TCP: &v1alpha1.TCPHeader{
+						TransportHeader: v1beta1.TransportHeader{
+							TCP: &v1beta1.TCPHeader{
 								DstPort: 4321,
 							},
 						},
@@ -405,18 +405,18 @@ func TestNewTraceflow(t *testing.T) {
 		{
 			name: "dummy-traceflow-src-pod",
 			src:  srcPod,
-			expectedTf: &v1alpha1.Traceflow{
-				Spec: v1alpha1.TraceflowSpec{
-					Source: v1alpha1.Source{
+			expectedTf: &v1beta1.Traceflow{
+				Spec: v1beta1.TraceflowSpec{
+					Source: v1beta1.Source{
 						Namespace: "default",
 						Pod:       "pod-1",
 					},
-					Packet: v1alpha1.Packet{
-						IPv6Header: &v1alpha1.IPv6Header{
+					Packet: v1beta1.Packet{
+						IPv6Header: &v1beta1.IPv6Header{
 							NextHeader: &protocolTCP,
 						},
-						TransportHeader: v1alpha1.TransportHeader{
-							TCP: &v1alpha1.TCPHeader{
+						TransportHeader: v1beta1.TransportHeader{
+							TCP: &v1beta1.TCPHeader{
 								DstPort: 4321,
 							},
 						},
@@ -429,21 +429,21 @@ func TestNewTraceflow(t *testing.T) {
 			name: "dummy-traceflow-pod-to-ipv4",
 			src:  "pod-1",
 			dst:  ipv4,
-			expectedTf: &v1alpha1.Traceflow{
-				Spec: v1alpha1.TraceflowSpec{
-					Source: v1alpha1.Source{
+			expectedTf: &v1beta1.Traceflow{
+				Spec: v1beta1.TraceflowSpec{
+					Source: v1beta1.Source{
 						Namespace: "default",
 						Pod:       "pod-1",
 					},
-					Destination: v1alpha1.Destination{
+					Destination: v1beta1.Destination{
 						IP: ipv4,
 					},
-					Packet: v1alpha1.Packet{
-						IPv6Header: &v1alpha1.IPv6Header{
+					Packet: v1beta1.Packet{
+						IPv6Header: &v1beta1.IPv6Header{
 							NextHeader: &protocolTCP,
 						},
-						TransportHeader: v1alpha1.TransportHeader{
-							TCP: &v1alpha1.TCPHeader{
+						TransportHeader: v1beta1.TransportHeader{
+							TCP: &v1beta1.TCPHeader{
 								DstPort: 4321,
 							},
 						},
@@ -457,21 +457,21 @@ func TestNewTraceflow(t *testing.T) {
 			src:         ipv4,
 			dst:         "pod-2",
 			liveTraffic: "1",
-			expectedTf: &v1alpha1.Traceflow{
-				Spec: v1alpha1.TraceflowSpec{
-					Source: v1alpha1.Source{
+			expectedTf: &v1beta1.Traceflow{
+				Spec: v1beta1.TraceflowSpec{
+					Source: v1beta1.Source{
 						IP: ipv4,
 					},
-					Destination: v1alpha1.Destination{
+					Destination: v1beta1.Destination{
 						Namespace: "default",
 						Pod:       "pod-2",
 					},
-					Packet: v1alpha1.Packet{
-						IPv6Header: &v1alpha1.IPv6Header{
+					Packet: v1beta1.Packet{
+						IPv6Header: &v1beta1.IPv6Header{
 							NextHeader: &protocolTCP,
 						},
-						TransportHeader: v1alpha1.TransportHeader{
-							TCP: &v1alpha1.TCPHeader{
+						TransportHeader: v1beta1.TransportHeader{
+							TCP: &v1beta1.TCPHeader{
 								DstPort: 4321,
 							},
 						},
@@ -485,22 +485,22 @@ func TestNewTraceflow(t *testing.T) {
 			name: "dummy-traceflow-pod-to-service",
 			src:  srcPod,
 			dst:  "service",
-			expectedTf: &v1alpha1.Traceflow{
-				Spec: v1alpha1.TraceflowSpec{
-					Source: v1alpha1.Source{
+			expectedTf: &v1beta1.Traceflow{
+				Spec: v1beta1.TraceflowSpec{
+					Source: v1beta1.Source{
 						Namespace: "default",
 						Pod:       "pod-1",
 					},
-					Destination: v1alpha1.Destination{
+					Destination: v1beta1.Destination{
 						Namespace: "default",
 						Service:   "service",
 					},
-					Packet: v1alpha1.Packet{
-						IPv6Header: &v1alpha1.IPv6Header{
+					Packet: v1beta1.Packet{
+						IPv6Header: &v1beta1.IPv6Header{
 							NextHeader: &protocolTCP,
 						},
-						TransportHeader: v1alpha1.TransportHeader{
-							TCP: &v1alpha1.TCPHeader{
+						TransportHeader: v1beta1.TransportHeader{
+							TCP: &v1beta1.TCPHeader{
 								DstPort: 4321,
 							},
 						},

--- a/pkg/controller/traceflow/validate.go
+++ b/pkg/controller/traceflow/validate.go
@@ -23,7 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 
-	crdv1alpha1 "antrea.io/antrea/pkg/apis/crd/v1alpha1"
+	crdv1beta1 "antrea.io/antrea/pkg/apis/crd/v1beta1"
 	"antrea.io/antrea/pkg/util/k8s"
 )
 
@@ -43,7 +43,7 @@ func (c *Controller) Validate(review *admv1.AdmissionReview) *admv1.AdmissionRes
 
 	klog.V(2).InfoS("Validating Traceflow", "request", review.Request)
 
-	var newObj crdv1alpha1.Traceflow
+	var newObj crdv1beta1.Traceflow
 	if review.Request.Object.Raw != nil {
 		if err := json.Unmarshal(review.Request.Object.Raw, &newObj); err != nil {
 			klog.ErrorS(err, "Error de-serializing current Traceflow")
@@ -67,7 +67,7 @@ func (c *Controller) Validate(review *admv1.AdmissionReview) *admv1.AdmissionRes
 	}
 }
 
-func (c *Controller) validate(tf *crdv1alpha1.Traceflow) (allowed bool, deniedReason string) {
+func (c *Controller) validate(tf *crdv1beta1.Traceflow) (allowed bool, deniedReason string) {
 	if !tf.Spec.LiveTraffic {
 		if tf.Spec.Source.Namespace == "" || tf.Spec.Source.Pod == "" {
 			return false, "source Pod must be specified in non-live-traffic Traceflow"

--- a/pkg/controller/traceflow/validate_test.go
+++ b/pkg/controller/traceflow/validate_test.go
@@ -24,7 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	crdv1alpha1 "antrea.io/antrea/pkg/apis/crd/v1alpha1"
+	crdv1beta1 "antrea.io/antrea/pkg/apis/crd/v1beta1"
 )
 
 func TestControllerValidate(t *testing.T) {
@@ -35,8 +35,8 @@ func TestControllerValidate(t *testing.T) {
 		pods []*v1.Pod
 
 		// input
-		oldSpec *crdv1alpha1.TraceflowSpec
-		newSpec *crdv1alpha1.TraceflowSpec
+		oldSpec *crdv1beta1.TraceflowSpec
+		newSpec *crdv1beta1.TraceflowSpec
 
 		// expected output
 		allowed      bool
@@ -44,22 +44,22 @@ func TestControllerValidate(t *testing.T) {
 	}{
 		{
 			name: "Source Pod must be specified in non-live-traffic Traceflow",
-			newSpec: &crdv1alpha1.TraceflowSpec{
-				Destination: crdv1alpha1.Destination{IP: "10.0.0.2"},
+			newSpec: &crdv1beta1.TraceflowSpec{
+				Destination: crdv1beta1.Destination{IP: "10.0.0.2"},
 			},
 			deniedReason: "source Pod must be specified in non-live-traffic Traceflow",
 		},
 		{
 			name: "Traceflow should have either source or destination Pod assigned",
-			newSpec: &crdv1alpha1.TraceflowSpec{
+			newSpec: &crdv1beta1.TraceflowSpec{
 				LiveTraffic: true,
 			},
 			deniedReason: "Traceflow tf has neither source nor destination Pod specified",
 		},
 		{
 			name: "Assigned source pod must exist",
-			newSpec: &crdv1alpha1.TraceflowSpec{
-				Source: crdv1alpha1.Source{
+			newSpec: &crdv1beta1.TraceflowSpec{
+				Source: crdv1beta1.Source{
 					Namespace: "test-ns",
 					Pod:       "test-pod",
 				},
@@ -74,8 +74,8 @@ func TestControllerValidate(t *testing.T) {
 					Spec:       v1.PodSpec{HostNetwork: true},
 				},
 			},
-			newSpec: &crdv1alpha1.TraceflowSpec{
-				Source: crdv1alpha1.Source{
+			newSpec: &crdv1beta1.TraceflowSpec{
+				Source: crdv1beta1.Source{
 					Namespace: "test-ns",
 					Pod:       "test-pod",
 				},
@@ -89,8 +89,8 @@ func TestControllerValidate(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{Namespace: "test-ns", Name: "test-pod"},
 				},
 			},
-			newSpec: &crdv1alpha1.TraceflowSpec{
-				Source: crdv1alpha1.Source{
+			newSpec: &crdv1beta1.TraceflowSpec{
+				Source: crdv1beta1.Source{
 					Namespace: "test-ns",
 					Pod:       "test-pod",
 				},
@@ -148,8 +148,8 @@ func TestControllerValidate(t *testing.T) {
 	}
 }
 
-func toRawExtension(spec *crdv1alpha1.TraceflowSpec) runtime.RawExtension {
-	tf := &crdv1alpha1.Traceflow{Spec: *spec}
+func toRawExtension(spec *crdv1beta1.TraceflowSpec) runtime.RawExtension {
+	tf := &crdv1beta1.Traceflow{Spec: *spec}
 	tf.Name = "tf"
 	raw, _ := json.Marshal(tf)
 	return runtime.RawExtension{Raw: raw}

--- a/test/e2e/traceflow_test.go
+++ b/test/e2e/traceflow_test.go
@@ -34,18 +34,17 @@ import (
 
 	"antrea.io/antrea/pkg/agent/config"
 	"antrea.io/antrea/pkg/apis/controlplane/v1beta2"
-	"antrea.io/antrea/pkg/apis/crd/v1alpha1"
 	"antrea.io/antrea/pkg/apis/crd/v1beta1"
 	"antrea.io/antrea/pkg/features"
 )
 
 type testcase struct {
 	name            string
-	tf              *v1alpha1.Traceflow
-	expectedPhase   v1alpha1.TraceflowPhase
+	tf              *v1beta1.Traceflow
+	expectedPhase   v1beta1.TraceflowPhase
 	expectedReasons []string
-	expectedResults []v1alpha1.NodeResult
-	expectedPktCap  *v1alpha1.Packet
+	expectedResults []v1beta1.NodeResult
+	expectedPktCap  *v1beta1.Packet
 	// required IP version, skip if not match, default is 0 (no restrict)
 	ipVersion int
 	// Source Pod to run ping for live-traffic Traceflow.
@@ -101,6 +100,7 @@ var (
 	protocolTCP    = int32(6)
 	protocolUDP    = int32(17)
 	protocolICMPv6 = int32(58)
+	tcpFlags       = int32(2) // SYN flag set
 )
 
 // testTraceflowIntraNodeANNP verifies if traceflow can trace intra node traffic with some Antrea NetworkPolicy sets.
@@ -151,46 +151,46 @@ func testTraceflowIntraNodeANNP(t *testing.T, data *TestData) {
 		{
 			name:      "ANNPDenyIngressIPv4",
 			ipVersion: 4,
-			tf: &v1alpha1.Traceflow{
+			tf: &v1beta1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: randName(fmt.Sprintf("%s-%s-to-%s-%s-", data.testNamespace, node1Pods[0], data.testNamespace, node1Pods[1])),
 				},
-				Spec: v1alpha1.TraceflowSpec{
-					Source: v1alpha1.Source{
+				Spec: v1beta1.TraceflowSpec{
+					Source: v1beta1.Source{
 						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
-					Destination: v1alpha1.Destination{
+					Destination: v1beta1.Destination{
 						Namespace: data.testNamespace,
 						Pod:       node1Pods[1],
 					},
-					Packet: v1alpha1.Packet{
-						IPHeader: v1alpha1.IPHeader{
+					Packet: v1beta1.Packet{
+						IPHeader: &v1beta1.IPHeader{
 							Protocol: protocolTCP,
 						},
-						TransportHeader: v1alpha1.TransportHeader{
-							TCP: &v1alpha1.TCPHeader{
+						TransportHeader: v1beta1.TransportHeader{
+							TCP: &v1beta1.TCPHeader{
 								DstPort: 80,
 								SrcPort: 10000,
-								Flags:   2,
+								Flags:   &tcpFlags,
 							},
 						},
 					},
 				},
 			},
-			expectedPhase: v1alpha1.Succeeded,
-			expectedResults: []v1alpha1.NodeResult{
+			expectedPhase: v1beta1.Succeeded,
+			expectedResults: []v1beta1.NodeResult{
 				{
 					Node: node1,
-					Observations: []v1alpha1.Observation{
+					Observations: []v1beta1.Observation{
 						{
-							Component: v1alpha1.ComponentSpoofGuard,
-							Action:    v1alpha1.ActionForwarded,
+							Component: v1beta1.ComponentSpoofGuard,
+							Action:    v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentNetworkPolicy,
+							Component:     v1beta1.ComponentNetworkPolicy,
 							ComponentInfo: "IngressMetric",
-							Action:        v1alpha1.ActionDropped,
+							Action:        v1beta1.ActionDropped,
 						},
 					},
 				},
@@ -199,46 +199,46 @@ func testTraceflowIntraNodeANNP(t *testing.T, data *TestData) {
 		{
 			name:      "ANNPRejectIngressIPv4",
 			ipVersion: 4,
-			tf: &v1alpha1.Traceflow{
+			tf: &v1beta1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: randName(fmt.Sprintf("%s-%s-to-%s-%s-", data.testNamespace, node1Pods[0], data.testNamespace, node1Pods[2])),
 				},
-				Spec: v1alpha1.TraceflowSpec{
-					Source: v1alpha1.Source{
+				Spec: v1beta1.TraceflowSpec{
+					Source: v1beta1.Source{
 						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
-					Destination: v1alpha1.Destination{
+					Destination: v1beta1.Destination{
 						Namespace: data.testNamespace,
 						Pod:       node1Pods[2],
 					},
-					Packet: v1alpha1.Packet{
-						IPHeader: v1alpha1.IPHeader{
+					Packet: v1beta1.Packet{
+						IPHeader: &v1beta1.IPHeader{
 							Protocol: protocolTCP,
 						},
-						TransportHeader: v1alpha1.TransportHeader{
-							TCP: &v1alpha1.TCPHeader{
+						TransportHeader: v1beta1.TransportHeader{
+							TCP: &v1beta1.TCPHeader{
 								DstPort: 80,
 								SrcPort: 10001,
-								Flags:   2,
+								Flags:   &tcpFlags,
 							},
 						},
 					},
 				},
 			},
-			expectedPhase: v1alpha1.Succeeded,
-			expectedResults: []v1alpha1.NodeResult{
+			expectedPhase: v1beta1.Succeeded,
+			expectedResults: []v1beta1.NodeResult{
 				{
 					Node: node1,
-					Observations: []v1alpha1.Observation{
+					Observations: []v1beta1.Observation{
 						{
-							Component: v1alpha1.ComponentSpoofGuard,
-							Action:    v1alpha1.ActionForwarded,
+							Component: v1beta1.ComponentSpoofGuard,
+							Action:    v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentNetworkPolicy,
+							Component:     v1beta1.ComponentNetworkPolicy,
 							ComponentInfo: "IngressMetric",
-							Action:        v1alpha1.ActionRejected,
+							Action:        v1beta1.ActionRejected,
 						},
 					},
 				},
@@ -247,46 +247,46 @@ func testTraceflowIntraNodeANNP(t *testing.T, data *TestData) {
 		{
 			name:      "ANNPDenyIngressIPv6",
 			ipVersion: 6,
-			tf: &v1alpha1.Traceflow{
+			tf: &v1beta1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: randName(fmt.Sprintf("%s-%s-to-%s-%s-", data.testNamespace, node1Pods[0], data.testNamespace, node1Pods[1])),
 				},
-				Spec: v1alpha1.TraceflowSpec{
-					Source: v1alpha1.Source{
+				Spec: v1beta1.TraceflowSpec{
+					Source: v1beta1.Source{
 						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
-					Destination: v1alpha1.Destination{
+					Destination: v1beta1.Destination{
 						Namespace: data.testNamespace,
 						Pod:       node1Pods[1],
 					},
-					Packet: v1alpha1.Packet{
-						IPv6Header: &v1alpha1.IPv6Header{
+					Packet: v1beta1.Packet{
+						IPv6Header: &v1beta1.IPv6Header{
 							NextHeader: &protocolTCP,
 						},
-						TransportHeader: v1alpha1.TransportHeader{
-							TCP: &v1alpha1.TCPHeader{
+						TransportHeader: v1beta1.TransportHeader{
+							TCP: &v1beta1.TCPHeader{
 								DstPort: 80,
 								SrcPort: 10002,
-								Flags:   2,
+								Flags:   &tcpFlags,
 							},
 						},
 					},
 				},
 			},
-			expectedPhase: v1alpha1.Succeeded,
-			expectedResults: []v1alpha1.NodeResult{
+			expectedPhase: v1beta1.Succeeded,
+			expectedResults: []v1beta1.NodeResult{
 				{
 					Node: node1,
-					Observations: []v1alpha1.Observation{
+					Observations: []v1beta1.Observation{
 						{
-							Component: v1alpha1.ComponentSpoofGuard,
-							Action:    v1alpha1.ActionForwarded,
+							Component: v1beta1.ComponentSpoofGuard,
+							Action:    v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentNetworkPolicy,
+							Component:     v1beta1.ComponentNetworkPolicy,
 							ComponentInfo: "IngressMetric",
-							Action:        v1alpha1.ActionDropped,
+							Action:        v1beta1.ActionDropped,
 						},
 					},
 				},
@@ -368,7 +368,7 @@ func testTraceflowIntraNode(t *testing.T, data *TestData) {
 	}
 
 	// default Ubuntu ping packet properties.
-	expectedLength := uint16(84)
+	expectedLength := int32(84)
 	expectedTTL := int32(64)
 	expectedFlags := int32(2)
 	if len(clusterInfo.windowsNodes) != 0 {
@@ -381,51 +381,51 @@ func testTraceflowIntraNode(t *testing.T, data *TestData) {
 		{
 			name:      "intraNodeTraceflowIPv4",
 			ipVersion: 4,
-			tf: &v1alpha1.Traceflow{
+			tf: &v1beta1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: randName(fmt.Sprintf("%s-%s-to-%s-%s-", data.testNamespace, node1Pods[0], data.testNamespace, node1Pods[1])),
 				},
-				Spec: v1alpha1.TraceflowSpec{
-					Source: v1alpha1.Source{
+				Spec: v1beta1.TraceflowSpec{
+					Source: v1beta1.Source{
 						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
-					Destination: v1alpha1.Destination{
+					Destination: v1beta1.Destination{
 						Namespace: data.testNamespace,
 						Pod:       node1Pods[1],
 					},
-					Packet: v1alpha1.Packet{
-						IPHeader: v1alpha1.IPHeader{
+					Packet: v1beta1.Packet{
+						IPHeader: &v1beta1.IPHeader{
 							Protocol: protocolTCP,
 						},
-						TransportHeader: v1alpha1.TransportHeader{
-							TCP: &v1alpha1.TCPHeader{
+						TransportHeader: v1beta1.TransportHeader{
+							TCP: &v1beta1.TCPHeader{
 								DstPort: 80,
 								SrcPort: 10003,
-								Flags:   2,
+								Flags:   &tcpFlags,
 							},
 						},
 					},
 				},
 			},
-			expectedPhase: v1alpha1.Succeeded,
-			expectedResults: []v1alpha1.NodeResult{
+			expectedPhase: v1beta1.Succeeded,
+			expectedResults: []v1beta1.NodeResult{
 				{
 					Node: node1,
-					Observations: []v1alpha1.Observation{
+					Observations: []v1beta1.Observation{
 						{
-							Component: v1alpha1.ComponentSpoofGuard,
-							Action:    v1alpha1.ActionForwarded,
+							Component: v1beta1.ComponentSpoofGuard,
+							Action:    v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentNetworkPolicy,
+							Component:     v1beta1.ComponentNetworkPolicy,
 							ComponentInfo: "EgressRule",
-							Action:        v1alpha1.ActionForwarded,
+							Action:        v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentNetworkPolicy,
+							Component:     v1beta1.ComponentNetworkPolicy,
 							ComponentInfo: "IngressDefaultRule",
-							Action:        v1alpha1.ActionDropped,
+							Action:        v1beta1.ActionDropped,
 						},
 					},
 				},
@@ -434,25 +434,25 @@ func testTraceflowIntraNode(t *testing.T, data *TestData) {
 		{
 			name:      "intraNodeUDPDstPodTraceflowIPv4",
 			ipVersion: 4,
-			tf: &v1alpha1.Traceflow{
+			tf: &v1beta1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: randName(fmt.Sprintf("%s-%s-to-%s-", data.testNamespace, node1Pods[0], node1Pods[2])),
 				},
-				Spec: v1alpha1.TraceflowSpec{
-					Source: v1alpha1.Source{
+				Spec: v1beta1.TraceflowSpec{
+					Source: v1beta1.Source{
 						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
-					Destination: v1alpha1.Destination{
+					Destination: v1beta1.Destination{
 						Namespace: data.testNamespace,
 						Pod:       node1Pods[2],
 					},
-					Packet: v1alpha1.Packet{
-						IPHeader: v1alpha1.IPHeader{
+					Packet: v1beta1.Packet{
+						IPHeader: &v1beta1.IPHeader{
 							Protocol: protocolUDP,
 						},
-						TransportHeader: v1alpha1.TransportHeader{
-							UDP: &v1alpha1.UDPHeader{
+						TransportHeader: v1beta1.TransportHeader{
+							UDP: &v1beta1.UDPHeader{
 								DstPort: 321,
 								SrcPort: 10004,
 							},
@@ -460,24 +460,24 @@ func testTraceflowIntraNode(t *testing.T, data *TestData) {
 					},
 				},
 			},
-			expectedPhase: v1alpha1.Succeeded,
-			expectedResults: []v1alpha1.NodeResult{
+			expectedPhase: v1beta1.Succeeded,
+			expectedResults: []v1beta1.NodeResult{
 				{
 					Node: node1,
-					Observations: []v1alpha1.Observation{
+					Observations: []v1beta1.Observation{
 						{
-							Component: v1alpha1.ComponentSpoofGuard,
-							Action:    v1alpha1.ActionForwarded,
+							Component: v1beta1.ComponentSpoofGuard,
+							Action:    v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentNetworkPolicy,
+							Component:     v1beta1.ComponentNetworkPolicy,
 							ComponentInfo: "EgressRule",
-							Action:        v1alpha1.ActionForwarded,
+							Action:        v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentForwarding,
+							Component:     v1beta1.ComponentForwarding,
 							ComponentInfo: "Output",
-							Action:        v1alpha1.ActionDelivered,
+							Action:        v1beta1.ActionDelivered,
 						},
 					},
 				},
@@ -486,24 +486,24 @@ func testTraceflowIntraNode(t *testing.T, data *TestData) {
 		{
 			name:      "intraNodeUDPDstIPTraceflowIPv4",
 			ipVersion: 4,
-			tf: &v1alpha1.Traceflow{
+			tf: &v1beta1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: randName(fmt.Sprintf("%s-%s-to-%s-", data.testNamespace, node1Pods[0], dstPodIPv4Str)),
 				},
-				Spec: v1alpha1.TraceflowSpec{
-					Source: v1alpha1.Source{
+				Spec: v1beta1.TraceflowSpec{
+					Source: v1beta1.Source{
 						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
-					Destination: v1alpha1.Destination{
+					Destination: v1beta1.Destination{
 						IP: dstPodIPv4Str,
 					},
-					Packet: v1alpha1.Packet{
-						IPHeader: v1alpha1.IPHeader{
+					Packet: v1beta1.Packet{
+						IPHeader: &v1beta1.IPHeader{
 							Protocol: protocolUDP,
 						},
-						TransportHeader: v1alpha1.TransportHeader{
-							UDP: &v1alpha1.UDPHeader{
+						TransportHeader: v1beta1.TransportHeader{
+							UDP: &v1beta1.UDPHeader{
 								DstPort: 321,
 								SrcPort: 10005,
 							},
@@ -511,24 +511,24 @@ func testTraceflowIntraNode(t *testing.T, data *TestData) {
 					},
 				},
 			},
-			expectedPhase: v1alpha1.Succeeded,
-			expectedResults: []v1alpha1.NodeResult{
+			expectedPhase: v1beta1.Succeeded,
+			expectedResults: []v1beta1.NodeResult{
 				{
 					Node: node1,
-					Observations: []v1alpha1.Observation{
+					Observations: []v1beta1.Observation{
 						{
-							Component: v1alpha1.ComponentSpoofGuard,
-							Action:    v1alpha1.ActionForwarded,
+							Component: v1beta1.ComponentSpoofGuard,
+							Action:    v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentNetworkPolicy,
+							Component:     v1beta1.ComponentNetworkPolicy,
 							ComponentInfo: "EgressRule",
-							Action:        v1alpha1.ActionForwarded,
+							Action:        v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentForwarding,
+							Component:     v1beta1.ComponentForwarding,
 							ComponentInfo: "Output",
-							Action:        v1alpha1.ActionDelivered,
+							Action:        v1beta1.ActionDelivered,
 						},
 					},
 				},
@@ -537,43 +537,43 @@ func testTraceflowIntraNode(t *testing.T, data *TestData) {
 		{
 			name:      "intraNodeICMPDstIPTraceflowIPv4",
 			ipVersion: 4,
-			tf: &v1alpha1.Traceflow{
+			tf: &v1beta1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: randName(fmt.Sprintf("%s-%s-to-%s-", data.testNamespace, node1Pods[0], dstPodIPv4Str)),
 				},
-				Spec: v1alpha1.TraceflowSpec{
-					Source: v1alpha1.Source{
+				Spec: v1beta1.TraceflowSpec{
+					Source: v1beta1.Source{
 						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
-					Destination: v1alpha1.Destination{
+					Destination: v1beta1.Destination{
 						IP: dstPodIPv4Str,
 					},
-					Packet: v1alpha1.Packet{
-						IPHeader: v1alpha1.IPHeader{
+					Packet: v1beta1.Packet{
+						IPHeader: &v1beta1.IPHeader{
 							Protocol: protocolICMP,
 						},
 					},
 				},
 			},
-			expectedPhase: v1alpha1.Succeeded,
-			expectedResults: []v1alpha1.NodeResult{
+			expectedPhase: v1beta1.Succeeded,
+			expectedResults: []v1beta1.NodeResult{
 				{
 					Node: node1,
-					Observations: []v1alpha1.Observation{
+					Observations: []v1beta1.Observation{
 						{
-							Component: v1alpha1.ComponentSpoofGuard,
-							Action:    v1alpha1.ActionForwarded,
+							Component: v1beta1.ComponentSpoofGuard,
+							Action:    v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentNetworkPolicy,
+							Component:     v1beta1.ComponentNetworkPolicy,
 							ComponentInfo: "EgressRule",
-							Action:        v1alpha1.ActionForwarded,
+							Action:        v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentForwarding,
+							Component:     v1beta1.ComponentForwarding,
 							ComponentInfo: "Output",
-							Action:        v1alpha1.ActionDelivered,
+							Action:        v1beta1.ActionDelivered,
 						},
 					},
 				},
@@ -582,92 +582,92 @@ func testTraceflowIntraNode(t *testing.T, data *TestData) {
 		{
 			name:      "nonExistingDstPodIPv4",
 			ipVersion: 4,
-			tf: &v1alpha1.Traceflow{
+			tf: &v1beta1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: randName(fmt.Sprintf("%s-%s-to-%s-%s-", data.testNamespace, node1Pods[0], data.testNamespace, "non-existing-pod")),
 				},
-				Spec: v1alpha1.TraceflowSpec{
-					Source: v1alpha1.Source{
+				Spec: v1beta1.TraceflowSpec{
+					Source: v1beta1.Source{
 						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
-					Destination: v1alpha1.Destination{
+					Destination: v1beta1.Destination{
 						Namespace: data.testNamespace,
 						Pod:       "non-existing-pod",
 					},
 				},
 			},
-			expectedPhase:   v1alpha1.Failed,
+			expectedPhase:   v1beta1.Failed,
 			expectedReasons: []string{fmt.Sprintf("Node: %s, error: failed to get the destination Pod: pods \"%s\" not found", node1, "non-existing-pod")},
 		},
 		{
 			name:      "intraNodeICMPDstIPLiveTraceflowIPv4",
 			ipVersion: 4,
-			tf: &v1alpha1.Traceflow{
+			tf: &v1beta1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: randName(fmt.Sprintf("%s-%s-to-%s-", data.testNamespace, node1Pods[0], dstPodIPv4Str)),
 				},
-				Spec: v1alpha1.TraceflowSpec{
-					Source: v1alpha1.Source{
+				Spec: v1beta1.TraceflowSpec{
+					Source: v1beta1.Source{
 						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
-					Destination: v1alpha1.Destination{
+					Destination: v1beta1.Destination{
 						IP: dstPodIPv4Str,
 					},
 					LiveTraffic: true,
 				},
 			},
 			srcPod:        node1Pods[0],
-			expectedPhase: v1alpha1.Succeeded,
-			expectedResults: []v1alpha1.NodeResult{
+			expectedPhase: v1beta1.Succeeded,
+			expectedResults: []v1beta1.NodeResult{
 				{
 					Node: node1,
-					Observations: []v1alpha1.Observation{
+					Observations: []v1beta1.Observation{
 						{
-							Component: v1alpha1.ComponentSpoofGuard,
-							Action:    v1alpha1.ActionForwarded,
+							Component: v1beta1.ComponentSpoofGuard,
+							Action:    v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentNetworkPolicy,
+							Component:     v1beta1.ComponentNetworkPolicy,
 							ComponentInfo: "EgressRule",
-							Action:        v1alpha1.ActionForwarded,
+							Action:        v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentForwarding,
+							Component:     v1beta1.ComponentForwarding,
 							ComponentInfo: "Output",
-							Action:        v1alpha1.ActionDelivered,
+							Action:        v1beta1.ActionDelivered,
 						},
 					},
 				},
 			},
-			expectedPktCap: &v1alpha1.Packet{
+			expectedPktCap: &v1beta1.Packet{
 				SrcIP:    pod0IPv4Str,
 				DstIP:    dstPodIPv4Str,
 				Length:   expectedLength,
-				IPHeader: v1alpha1.IPHeader{Protocol: 1, TTL: expectedTTL, Flags: expectedFlags},
-				TransportHeader: v1alpha1.TransportHeader{
-					ICMP: &v1alpha1.ICMPEchoRequestHeader{},
+				IPHeader: &v1beta1.IPHeader{Protocol: 1, TTL: expectedTTL, Flags: expectedFlags},
+				TransportHeader: v1beta1.TransportHeader{
+					ICMP: &v1beta1.ICMPEchoRequestHeader{},
 				},
 			},
 		},
 		{
 			name:      "intraNodeICMPSrcIPDroppedTraceflowIPv4",
 			ipVersion: 4,
-			tf: &v1alpha1.Traceflow{
+			tf: &v1beta1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: randName(fmt.Sprintf("%s-%s-to-%s-", data.testNamespace, pod0IPv4Str, node1Pods[1])),
 				},
-				Spec: v1alpha1.TraceflowSpec{
-					Source: v1alpha1.Source{
+				Spec: v1beta1.TraceflowSpec{
+					Source: v1beta1.Source{
 						IP: pod0IPv4Str,
 					},
-					Destination: v1alpha1.Destination{
+					Destination: v1beta1.Destination{
 						Namespace: data.testNamespace,
 						Pod:       node1Pods[1],
 					},
-					Packet: v1alpha1.Packet{
-						IPHeader: v1alpha1.IPHeader{
+					Packet: v1beta1.Packet{
+						IPHeader: &v1beta1.IPHeader{
 							Protocol: protocolICMP,
 						},
 					},
@@ -676,81 +676,81 @@ func testTraceflowIntraNode(t *testing.T, data *TestData) {
 				},
 			},
 			srcPod:        node1Pods[0],
-			expectedPhase: v1alpha1.Succeeded,
-			expectedResults: []v1alpha1.NodeResult{
+			expectedPhase: v1beta1.Succeeded,
+			expectedResults: []v1beta1.NodeResult{
 				{
 					Node: node1,
-					Observations: []v1alpha1.Observation{
+					Observations: []v1beta1.Observation{
 						{
-							Component: v1alpha1.ComponentForwarding,
-							Action:    v1alpha1.ActionReceived,
+							Component: v1beta1.ComponentForwarding,
+							Action:    v1beta1.ActionReceived,
 						},
 						{
-							Component:     v1alpha1.ComponentNetworkPolicy,
+							Component:     v1beta1.ComponentNetworkPolicy,
 							ComponentInfo: "IngressDefaultRule",
-							Action:        v1alpha1.ActionDropped,
+							Action:        v1beta1.ActionDropped,
 						},
 					},
 				},
 			},
-			expectedPktCap: &v1alpha1.Packet{
+			expectedPktCap: &v1beta1.Packet{
 				SrcIP:    pod0IPv4Str,
 				DstIP:    pod1IPv4Str,
 				Length:   expectedLength,
-				IPHeader: v1alpha1.IPHeader{Protocol: 1, TTL: expectedTTL, Flags: expectedFlags},
-				TransportHeader: v1alpha1.TransportHeader{
-					ICMP: &v1alpha1.ICMPEchoRequestHeader{},
+				IPHeader: &v1beta1.IPHeader{Protocol: 1, TTL: expectedTTL, Flags: expectedFlags},
+				TransportHeader: v1beta1.TransportHeader{
+					ICMP: &v1beta1.ICMPEchoRequestHeader{},
 				},
 			},
 		},
 		{
 			name:      "intraNodeTraceflowIPv6",
 			ipVersion: 6,
-			tf: &v1alpha1.Traceflow{
+			tf: &v1beta1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: randName(fmt.Sprintf("%s-%s-to-%s-%s-", data.testNamespace, node1Pods[0], data.testNamespace, node1Pods[1])),
 				},
-				Spec: v1alpha1.TraceflowSpec{
-					Source: v1alpha1.Source{
+				Spec: v1beta1.TraceflowSpec{
+					Source: v1beta1.Source{
 						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
-					Destination: v1alpha1.Destination{
+					Destination: v1beta1.Destination{
 						Namespace: data.testNamespace,
 						Pod:       node1Pods[1],
 					},
-					Packet: v1alpha1.Packet{
-						IPv6Header: &v1alpha1.IPv6Header{
+					Packet: v1beta1.Packet{
+						IPv6Header: &v1beta1.IPv6Header{
 							NextHeader: &protocolTCP,
 						},
-						TransportHeader: v1alpha1.TransportHeader{
-							TCP: &v1alpha1.TCPHeader{
+						TransportHeader: v1beta1.TransportHeader{
+							TCP: &v1beta1.TCPHeader{
 								DstPort: 80,
 								SrcPort: 10006,
-								Flags:   2,
+								Flags:   &tcpFlags,
 							},
 						},
 					},
 				},
 			},
-			expectedPhase: v1alpha1.Succeeded,
-			expectedResults: []v1alpha1.NodeResult{
+			expectedPhase: v1beta1.Succeeded,
+			expectedResults: []v1beta1.NodeResult{
 				{
 					Node: node1,
-					Observations: []v1alpha1.Observation{
+					Observations: []v1beta1.Observation{
 						{
-							Component: v1alpha1.ComponentSpoofGuard,
-							Action:    v1alpha1.ActionForwarded,
+							Component: v1beta1.ComponentSpoofGuard,
+							Action:    v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentNetworkPolicy,
+							Component:     v1beta1.ComponentNetworkPolicy,
 							ComponentInfo: "EgressRule",
-							Action:        v1alpha1.ActionForwarded,
+							Action:        v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentNetworkPolicy,
+							Component:     v1beta1.ComponentNetworkPolicy,
 							ComponentInfo: "IngressDefaultRule",
-							Action:        v1alpha1.ActionDropped,
+							Action:        v1beta1.ActionDropped,
 						},
 					},
 				},
@@ -759,25 +759,25 @@ func testTraceflowIntraNode(t *testing.T, data *TestData) {
 		{
 			name:      "intraNodeUDPDstPodTraceflowIPv6",
 			ipVersion: 6,
-			tf: &v1alpha1.Traceflow{
+			tf: &v1beta1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: randName(fmt.Sprintf("%s-%s-to-%s-", data.testNamespace, node1Pods[0], node1Pods[2])),
 				},
-				Spec: v1alpha1.TraceflowSpec{
-					Source: v1alpha1.Source{
+				Spec: v1beta1.TraceflowSpec{
+					Source: v1beta1.Source{
 						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
-					Destination: v1alpha1.Destination{
+					Destination: v1beta1.Destination{
 						Namespace: data.testNamespace,
 						Pod:       node1Pods[2],
 					},
-					Packet: v1alpha1.Packet{
-						IPv6Header: &v1alpha1.IPv6Header{
+					Packet: v1beta1.Packet{
+						IPv6Header: &v1beta1.IPv6Header{
 							NextHeader: &protocolUDP,
 						},
-						TransportHeader: v1alpha1.TransportHeader{
-							UDP: &v1alpha1.UDPHeader{
+						TransportHeader: v1beta1.TransportHeader{
+							UDP: &v1beta1.UDPHeader{
 								DstPort: 321,
 								SrcPort: 10007,
 							},
@@ -785,24 +785,24 @@ func testTraceflowIntraNode(t *testing.T, data *TestData) {
 					},
 				},
 			},
-			expectedPhase: v1alpha1.Succeeded,
-			expectedResults: []v1alpha1.NodeResult{
+			expectedPhase: v1beta1.Succeeded,
+			expectedResults: []v1beta1.NodeResult{
 				{
 					Node: node1,
-					Observations: []v1alpha1.Observation{
+					Observations: []v1beta1.Observation{
 						{
-							Component: v1alpha1.ComponentSpoofGuard,
-							Action:    v1alpha1.ActionForwarded,
+							Component: v1beta1.ComponentSpoofGuard,
+							Action:    v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentNetworkPolicy,
+							Component:     v1beta1.ComponentNetworkPolicy,
 							ComponentInfo: "EgressRule",
-							Action:        v1alpha1.ActionForwarded,
+							Action:        v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentForwarding,
+							Component:     v1beta1.ComponentForwarding,
 							ComponentInfo: "Output",
-							Action:        v1alpha1.ActionDelivered,
+							Action:        v1beta1.ActionDelivered,
 						},
 					},
 				},
@@ -811,24 +811,24 @@ func testTraceflowIntraNode(t *testing.T, data *TestData) {
 		{
 			name:      "intraNodeUDPDstIPTraceflowIPv6",
 			ipVersion: 6,
-			tf: &v1alpha1.Traceflow{
+			tf: &v1beta1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: randName(fmt.Sprintf("%s-%s-to-%s-", data.testNamespace, node1Pods[0], strings.ReplaceAll(dstPodIPv6Str, ":", "--"))),
 				},
-				Spec: v1alpha1.TraceflowSpec{
-					Source: v1alpha1.Source{
+				Spec: v1beta1.TraceflowSpec{
+					Source: v1beta1.Source{
 						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
-					Destination: v1alpha1.Destination{
+					Destination: v1beta1.Destination{
 						IP: dstPodIPv6Str,
 					},
-					Packet: v1alpha1.Packet{
-						IPv6Header: &v1alpha1.IPv6Header{
+					Packet: v1beta1.Packet{
+						IPv6Header: &v1beta1.IPv6Header{
 							NextHeader: &protocolUDP,
 						},
-						TransportHeader: v1alpha1.TransportHeader{
-							UDP: &v1alpha1.UDPHeader{
+						TransportHeader: v1beta1.TransportHeader{
+							UDP: &v1beta1.UDPHeader{
 								DstPort: 321,
 								SrcPort: 10008,
 							},
@@ -836,24 +836,24 @@ func testTraceflowIntraNode(t *testing.T, data *TestData) {
 					},
 				},
 			},
-			expectedPhase: v1alpha1.Succeeded,
-			expectedResults: []v1alpha1.NodeResult{
+			expectedPhase: v1beta1.Succeeded,
+			expectedResults: []v1beta1.NodeResult{
 				{
 					Node: node1,
-					Observations: []v1alpha1.Observation{
+					Observations: []v1beta1.Observation{
 						{
-							Component: v1alpha1.ComponentSpoofGuard,
-							Action:    v1alpha1.ActionForwarded,
+							Component: v1beta1.ComponentSpoofGuard,
+							Action:    v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentNetworkPolicy,
+							Component:     v1beta1.ComponentNetworkPolicy,
 							ComponentInfo: "EgressRule",
-							Action:        v1alpha1.ActionForwarded,
+							Action:        v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentForwarding,
+							Component:     v1beta1.ComponentForwarding,
 							ComponentInfo: "Output",
-							Action:        v1alpha1.ActionDelivered,
+							Action:        v1beta1.ActionDelivered,
 						},
 					},
 				},
@@ -862,43 +862,43 @@ func testTraceflowIntraNode(t *testing.T, data *TestData) {
 		{
 			name:      "intraNodeICMPDstIPTraceflowIPv6",
 			ipVersion: 6,
-			tf: &v1alpha1.Traceflow{
+			tf: &v1beta1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: randName(fmt.Sprintf("%s-%s-to-%s-", data.testNamespace, node1Pods[0], strings.ReplaceAll(dstPodIPv6Str, ":", "--"))),
 				},
-				Spec: v1alpha1.TraceflowSpec{
-					Source: v1alpha1.Source{
+				Spec: v1beta1.TraceflowSpec{
+					Source: v1beta1.Source{
 						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
-					Destination: v1alpha1.Destination{
+					Destination: v1beta1.Destination{
 						IP: dstPodIPv6Str,
 					},
-					Packet: v1alpha1.Packet{
-						IPv6Header: &v1alpha1.IPv6Header{
+					Packet: v1beta1.Packet{
+						IPv6Header: &v1beta1.IPv6Header{
 							NextHeader: &protocolICMPv6,
 						},
 					},
 				},
 			},
-			expectedPhase: v1alpha1.Succeeded,
-			expectedResults: []v1alpha1.NodeResult{
+			expectedPhase: v1beta1.Succeeded,
+			expectedResults: []v1beta1.NodeResult{
 				{
 					Node: node1,
-					Observations: []v1alpha1.Observation{
+					Observations: []v1beta1.Observation{
 						{
-							Component: v1alpha1.ComponentSpoofGuard,
-							Action:    v1alpha1.ActionForwarded,
+							Component: v1beta1.ComponentSpoofGuard,
+							Action:    v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentNetworkPolicy,
+							Component:     v1beta1.ComponentNetworkPolicy,
 							ComponentInfo: "EgressRule",
-							Action:        v1alpha1.ActionForwarded,
+							Action:        v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentForwarding,
+							Component:     v1beta1.ComponentForwarding,
 							ComponentInfo: "Output",
-							Action:        v1alpha1.ActionDelivered,
+							Action:        v1beta1.ActionDelivered,
 						},
 					},
 				},
@@ -907,46 +907,46 @@ func testTraceflowIntraNode(t *testing.T, data *TestData) {
 		{
 			name:      "nonExistingDstPodIPv6",
 			ipVersion: 6,
-			tf: &v1alpha1.Traceflow{
+			tf: &v1beta1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: randName(fmt.Sprintf("%s-%s-to-%s-%s-", data.testNamespace, node1Pods[0], data.testNamespace, "non-existing-pod")),
 				},
-				Spec: v1alpha1.TraceflowSpec{
-					Source: v1alpha1.Source{
+				Spec: v1beta1.TraceflowSpec{
+					Source: v1beta1.Source{
 						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
-					Destination: v1alpha1.Destination{
+					Destination: v1beta1.Destination{
 						Namespace: data.testNamespace,
 						Pod:       "non-existing-pod",
 					},
-					Packet: v1alpha1.Packet{
-						IPv6Header: &v1alpha1.IPv6Header{
+					Packet: v1beta1.Packet{
+						IPv6Header: &v1beta1.IPv6Header{
 							NextHeader: &protocolICMPv6,
 						},
 					},
 				},
 			},
-			expectedPhase:   v1alpha1.Failed,
+			expectedPhase:   v1beta1.Failed,
 			expectedReasons: []string{fmt.Sprintf("Node: %s, error: failed to get the destination Pod: pods \"%s\" not found", node1, "non-existing-pod")},
 		},
 		{
 			name:      "intraNodeICMPDstIPLiveTraceflowIPv6",
 			ipVersion: 6,
-			tf: &v1alpha1.Traceflow{
+			tf: &v1beta1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: randName(fmt.Sprintf("%s-%s-to-%s-", data.testNamespace, node1Pods[0], strings.ReplaceAll(dstPodIPv6Str, ":", "--"))),
 				},
-				Spec: v1alpha1.TraceflowSpec{
-					Source: v1alpha1.Source{
+				Spec: v1beta1.TraceflowSpec{
+					Source: v1beta1.Source{
 						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
-					Destination: v1alpha1.Destination{
+					Destination: v1beta1.Destination{
 						IP: dstPodIPv6Str,
 					},
-					Packet: v1alpha1.Packet{
-						IPv6Header: &v1alpha1.IPv6Header{
+					Packet: v1beta1.Packet{
+						IPv6Header: &v1beta1.IPv6Header{
 							NextHeader: &protocolICMPv6,
 						},
 					},
@@ -954,24 +954,24 @@ func testTraceflowIntraNode(t *testing.T, data *TestData) {
 				},
 			},
 			srcPod:        node1Pods[0],
-			expectedPhase: v1alpha1.Succeeded,
-			expectedResults: []v1alpha1.NodeResult{
+			expectedPhase: v1beta1.Succeeded,
+			expectedResults: []v1beta1.NodeResult{
 				{
 					Node: node1,
-					Observations: []v1alpha1.Observation{
+					Observations: []v1beta1.Observation{
 						{
-							Component: v1alpha1.ComponentSpoofGuard,
-							Action:    v1alpha1.ActionForwarded,
+							Component: v1beta1.ComponentSpoofGuard,
+							Action:    v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentNetworkPolicy,
+							Component:     v1beta1.ComponentNetworkPolicy,
 							ComponentInfo: "EgressRule",
-							Action:        v1alpha1.ActionForwarded,
+							Action:        v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentForwarding,
+							Component:     v1beta1.ComponentForwarding,
 							ComponentInfo: "Output",
-							Action:        v1alpha1.ActionDelivered,
+							Action:        v1beta1.ActionDelivered,
 						},
 					},
 				},
@@ -983,43 +983,43 @@ func testTraceflowIntraNode(t *testing.T, data *TestData) {
 		testcases = append(testcases, testcase{
 			name:      "localGatewayDestinationIPv4",
 			ipVersion: 4,
-			tf: &v1alpha1.Traceflow{
+			tf: &v1beta1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: randName(fmt.Sprintf("%s-%s-to-%s-", data.testNamespace, node1Pods[0], gwIPv4Str)),
 				},
-				Spec: v1alpha1.TraceflowSpec{
-					Source: v1alpha1.Source{
+				Spec: v1beta1.TraceflowSpec{
+					Source: v1beta1.Source{
 						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
-					Destination: v1alpha1.Destination{
+					Destination: v1beta1.Destination{
 						IP: gwIPv4Str,
 					},
-					Packet: v1alpha1.Packet{
-						IPHeader: v1alpha1.IPHeader{
+					Packet: v1beta1.Packet{
+						IPHeader: &v1beta1.IPHeader{
 							Protocol: protocolICMP,
 						},
 					},
 				},
 			},
-			expectedPhase: v1alpha1.Succeeded,
-			expectedResults: []v1alpha1.NodeResult{
+			expectedPhase: v1beta1.Succeeded,
+			expectedResults: []v1beta1.NodeResult{
 				{
 					Node: node1,
-					Observations: []v1alpha1.Observation{
+					Observations: []v1beta1.Observation{
 						{
-							Component: v1alpha1.ComponentSpoofGuard,
-							Action:    v1alpha1.ActionForwarded,
+							Component: v1beta1.ComponentSpoofGuard,
+							Action:    v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentNetworkPolicy,
+							Component:     v1beta1.ComponentNetworkPolicy,
 							ComponentInfo: "EgressRule",
-							Action:        v1alpha1.ActionForwarded,
+							Action:        v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentForwarding,
+							Component:     v1beta1.ComponentForwarding,
 							ComponentInfo: "Output",
-							Action:        v1alpha1.ActionDelivered,
+							Action:        v1beta1.ActionDelivered,
 						},
 					},
 				},
@@ -1031,43 +1031,43 @@ func testTraceflowIntraNode(t *testing.T, data *TestData) {
 		testcases = append(testcases, testcase{
 			name:      "localGatewayDestinationIPv6",
 			ipVersion: 6,
-			tf: &v1alpha1.Traceflow{
+			tf: &v1beta1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: randName(fmt.Sprintf("%s-%s-to-%s-", data.testNamespace, node1Pods[0], strings.ReplaceAll(gwIPv6Str, ":", "--"))),
 				},
-				Spec: v1alpha1.TraceflowSpec{
-					Source: v1alpha1.Source{
+				Spec: v1beta1.TraceflowSpec{
+					Source: v1beta1.Source{
 						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
-					Destination: v1alpha1.Destination{
+					Destination: v1beta1.Destination{
 						IP: gwIPv6Str,
 					},
-					Packet: v1alpha1.Packet{
-						IPv6Header: &v1alpha1.IPv6Header{
+					Packet: v1beta1.Packet{
+						IPv6Header: &v1beta1.IPv6Header{
 							NextHeader: &protocolICMPv6,
 						},
 					},
 				},
 			},
-			expectedPhase: v1alpha1.Succeeded,
-			expectedResults: []v1alpha1.NodeResult{
+			expectedPhase: v1beta1.Succeeded,
+			expectedResults: []v1beta1.NodeResult{
 				{
 					Node: node1,
-					Observations: []v1alpha1.Observation{
+					Observations: []v1beta1.Observation{
 						{
-							Component: v1alpha1.ComponentSpoofGuard,
-							Action:    v1alpha1.ActionForwarded,
+							Component: v1beta1.ComponentSpoofGuard,
+							Action:    v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentNetworkPolicy,
+							Component:     v1beta1.ComponentNetworkPolicy,
 							ComponentInfo: "EgressRule",
-							Action:        v1alpha1.ActionForwarded,
+							Action:        v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentForwarding,
+							Component:     v1beta1.ComponentForwarding,
 							ComponentInfo: "Output",
-							Action:        v1alpha1.ActionDelivered,
+							Action:        v1beta1.ActionDelivered,
 						},
 					},
 				},
@@ -1187,65 +1187,65 @@ func testTraceflowInterNode(t *testing.T, data *TestData) {
 		{
 			name:      "interNodeTraceflowIPv4",
 			ipVersion: 4,
-			tf: &v1alpha1.Traceflow{
+			tf: &v1beta1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: randName(fmt.Sprintf("%s-%s-to-%s-%s-", data.testNamespace, node1Pods[0], data.testNamespace, node2Pods[0])),
 				},
-				Spec: v1alpha1.TraceflowSpec{
-					Source: v1alpha1.Source{
+				Spec: v1beta1.TraceflowSpec{
+					Source: v1beta1.Source{
 						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
-					Destination: v1alpha1.Destination{
+					Destination: v1beta1.Destination{
 						Namespace: data.testNamespace,
 						Pod:       node2Pods[0],
 					},
-					Packet: v1alpha1.Packet{
-						IPHeader: v1alpha1.IPHeader{
+					Packet: v1beta1.Packet{
+						IPHeader: &v1beta1.IPHeader{
 							Protocol: protocolTCP,
 						},
-						TransportHeader: v1alpha1.TransportHeader{
-							TCP: &v1alpha1.TCPHeader{
+						TransportHeader: v1beta1.TransportHeader{
+							TCP: &v1beta1.TCPHeader{
 								DstPort: 80,
 								SrcPort: 10009,
-								Flags:   2,
+								Flags:   &tcpFlags,
 							},
 						},
 					},
 				},
 			},
-			expectedPhase: v1alpha1.Succeeded,
-			expectedResults: []v1alpha1.NodeResult{
+			expectedPhase: v1beta1.Succeeded,
+			expectedResults: []v1beta1.NodeResult{
 				{
 					Node: node1,
-					Observations: []v1alpha1.Observation{
+					Observations: []v1beta1.Observation{
 						{
-							Component: v1alpha1.ComponentSpoofGuard,
-							Action:    v1alpha1.ActionForwarded,
+							Component: v1beta1.ComponentSpoofGuard,
+							Action:    v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentNetworkPolicy,
+							Component:     v1beta1.ComponentNetworkPolicy,
 							ComponentInfo: "EgressRule",
-							Action:        v1alpha1.ActionForwarded,
+							Action:        v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentForwarding,
+							Component:     v1beta1.ComponentForwarding,
 							ComponentInfo: "Output",
-							Action:        v1alpha1.ActionForwarded,
+							Action:        v1beta1.ActionForwarded,
 						},
 					},
 				},
 				{
 					Node: node2,
-					Observations: []v1alpha1.Observation{
+					Observations: []v1beta1.Observation{
 						{
-							Component: v1alpha1.ComponentForwarding,
-							Action:    v1alpha1.ActionReceived,
+							Component: v1beta1.ComponentForwarding,
+							Action:    v1beta1.ActionReceived,
 						},
 						{
-							Component:     v1alpha1.ComponentForwarding,
+							Component:     v1beta1.ComponentForwarding,
 							ComponentInfo: "Output",
-							Action:        v1alpha1.ActionDelivered,
+							Action:        v1beta1.ActionDelivered,
 						},
 					},
 				},
@@ -1254,24 +1254,24 @@ func testTraceflowInterNode(t *testing.T, data *TestData) {
 		{
 			name:      "interNodeUDPDstIPTraceflowIPv4",
 			ipVersion: 4,
-			tf: &v1alpha1.Traceflow{
+			tf: &v1beta1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: randName(fmt.Sprintf("%s-%s-to-%s-", data.testNamespace, node1Pods[0], dstPodIPv4Str)),
 				},
-				Spec: v1alpha1.TraceflowSpec{
-					Source: v1alpha1.Source{
+				Spec: v1beta1.TraceflowSpec{
+					Source: v1beta1.Source{
 						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
-					Destination: v1alpha1.Destination{
+					Destination: v1beta1.Destination{
 						IP: dstPodIPv4Str,
 					},
-					Packet: v1alpha1.Packet{
-						IPHeader: v1alpha1.IPHeader{
+					Packet: v1beta1.Packet{
+						IPHeader: &v1beta1.IPHeader{
 							Protocol: protocolUDP,
 						},
-						TransportHeader: v1alpha1.TransportHeader{
-							UDP: &v1alpha1.UDPHeader{
+						TransportHeader: v1beta1.TransportHeader{
+							UDP: &v1beta1.UDPHeader{
 								DstPort: 321,
 								SrcPort: 10010,
 							},
@@ -1279,38 +1279,38 @@ func testTraceflowInterNode(t *testing.T, data *TestData) {
 					},
 				},
 			},
-			expectedPhase: v1alpha1.Succeeded,
-			expectedResults: []v1alpha1.NodeResult{
+			expectedPhase: v1beta1.Succeeded,
+			expectedResults: []v1beta1.NodeResult{
 				{
 					Node: node1,
-					Observations: []v1alpha1.Observation{
+					Observations: []v1beta1.Observation{
 						{
-							Component: v1alpha1.ComponentSpoofGuard,
-							Action:    v1alpha1.ActionForwarded,
+							Component: v1beta1.ComponentSpoofGuard,
+							Action:    v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentNetworkPolicy,
+							Component:     v1beta1.ComponentNetworkPolicy,
 							ComponentInfo: "EgressRule",
-							Action:        v1alpha1.ActionForwarded,
+							Action:        v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentForwarding,
+							Component:     v1beta1.ComponentForwarding,
 							ComponentInfo: "Output",
-							Action:        v1alpha1.ActionForwarded,
+							Action:        v1beta1.ActionForwarded,
 						},
 					},
 				},
 				{
 					Node: node2,
-					Observations: []v1alpha1.Observation{
+					Observations: []v1beta1.Observation{
 						{
-							Component: v1alpha1.ComponentForwarding,
-							Action:    v1alpha1.ActionReceived,
+							Component: v1beta1.ComponentForwarding,
+							Action:    v1beta1.ActionReceived,
 						},
 						{
-							Component:     v1alpha1.ComponentForwarding,
+							Component:     v1beta1.ComponentForwarding,
 							ComponentInfo: "Output",
-							Action:        v1alpha1.ActionDelivered,
+							Action:        v1beta1.ActionDelivered,
 						},
 					},
 				},
@@ -1319,58 +1319,58 @@ func testTraceflowInterNode(t *testing.T, data *TestData) {
 		{
 			name:      "interNodeICMPDstPodDroppedTraceflowIPv4",
 			ipVersion: 4,
-			tf: &v1alpha1.Traceflow{
+			tf: &v1beta1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: randName(fmt.Sprintf("%s-%s-to-%s-", data.testNamespace, node1Pods[0], node2Pods[1])),
 				},
-				Spec: v1alpha1.TraceflowSpec{
-					Source: v1alpha1.Source{
+				Spec: v1beta1.TraceflowSpec{
+					Source: v1beta1.Source{
 						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
-					Destination: v1alpha1.Destination{
+					Destination: v1beta1.Destination{
 						Namespace: data.testNamespace,
 						Pod:       node2Pods[1],
 					},
-					Packet: v1alpha1.Packet{
-						IPHeader: v1alpha1.IPHeader{
+					Packet: v1beta1.Packet{
+						IPHeader: &v1beta1.IPHeader{
 							Protocol: protocolICMP,
 						},
 					},
 				},
 			},
-			expectedPhase: v1alpha1.Succeeded,
-			expectedResults: []v1alpha1.NodeResult{
+			expectedPhase: v1beta1.Succeeded,
+			expectedResults: []v1beta1.NodeResult{
 				{
 					Node: node1,
-					Observations: []v1alpha1.Observation{
+					Observations: []v1beta1.Observation{
 						{
-							Component: v1alpha1.ComponentSpoofGuard,
-							Action:    v1alpha1.ActionForwarded,
+							Component: v1beta1.ComponentSpoofGuard,
+							Action:    v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentNetworkPolicy,
+							Component:     v1beta1.ComponentNetworkPolicy,
 							ComponentInfo: "EgressRule",
-							Action:        v1alpha1.ActionForwarded,
+							Action:        v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentForwarding,
+							Component:     v1beta1.ComponentForwarding,
 							ComponentInfo: "Output",
-							Action:        v1alpha1.ActionForwarded,
+							Action:        v1beta1.ActionForwarded,
 						},
 					},
 				},
 				{
 					Node: node2,
-					Observations: []v1alpha1.Observation{
+					Observations: []v1beta1.Observation{
 						{
-							Component: v1alpha1.ComponentForwarding,
-							Action:    v1alpha1.ActionReceived,
+							Component: v1beta1.ComponentForwarding,
+							Action:    v1beta1.ActionReceived,
 						},
 						{
-							Component:     v1alpha1.ComponentNetworkPolicy,
+							Component:     v1beta1.ComponentNetworkPolicy,
 							ComponentInfo: "IngressDefaultRule",
-							Action:        v1alpha1.ActionDropped,
+							Action:        v1beta1.ActionDropped,
 						},
 					},
 				},
@@ -1382,71 +1382,71 @@ func testTraceflowInterNode(t *testing.T, data *TestData) {
 				skipIfProxyDisabled(t, data)
 			},
 			ipVersion: 4,
-			tf: &v1alpha1.Traceflow{
+			tf: &v1beta1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: randName(fmt.Sprintf("%s-%s-to-svc-%s-", data.testNamespace, node1Pods[0], svcIPv4Name)),
 				},
-				Spec: v1alpha1.TraceflowSpec{
-					Source: v1alpha1.Source{
+				Spec: v1beta1.TraceflowSpec{
+					Source: v1beta1.Source{
 						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
-					Destination: v1alpha1.Destination{
+					Destination: v1beta1.Destination{
 						Namespace: data.testNamespace,
 						Service:   svcIPv4Name,
 					},
-					Packet: v1alpha1.Packet{
-						IPHeader: v1alpha1.IPHeader{
+					Packet: v1beta1.Packet{
+						IPHeader: &v1beta1.IPHeader{
 							Protocol: protocolTCP,
 						},
-						TransportHeader: v1alpha1.TransportHeader{
-							TCP: &v1alpha1.TCPHeader{
+						TransportHeader: v1beta1.TransportHeader{
+							TCP: &v1beta1.TCPHeader{
 								DstPort: 80,
 								SrcPort: 10011,
-								Flags:   2,
+								Flags:   &tcpFlags,
 							},
 						},
 					},
 				},
 			},
-			expectedPhase: v1alpha1.Succeeded,
-			expectedResults: []v1alpha1.NodeResult{
+			expectedPhase: v1beta1.Succeeded,
+			expectedResults: []v1beta1.NodeResult{
 				{
 					Node: node1,
-					Observations: []v1alpha1.Observation{
+					Observations: []v1beta1.Observation{
 						{
-							Component: v1alpha1.ComponentSpoofGuard,
-							Action:    v1alpha1.ActionForwarded,
+							Component: v1beta1.ComponentSpoofGuard,
+							Action:    v1beta1.ActionForwarded,
 						},
 						{
-							Component:       v1alpha1.ComponentLB,
+							Component:       v1beta1.ComponentLB,
 							Pod:             fmt.Sprintf("%s/%s", data.testNamespace, agnhostPodName),
 							TranslatedDstIP: agnhostIPv4Str,
-							Action:          v1alpha1.ActionForwarded,
+							Action:          v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentNetworkPolicy,
+							Component:     v1beta1.ComponentNetworkPolicy,
 							ComponentInfo: "EgressRule",
-							Action:        v1alpha1.ActionForwarded,
+							Action:        v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentForwarding,
+							Component:     v1beta1.ComponentForwarding,
 							ComponentInfo: "Output",
-							Action:        v1alpha1.ActionForwarded,
+							Action:        v1beta1.ActionForwarded,
 						},
 					},
 				},
 				{
 					Node: node2,
-					Observations: []v1alpha1.Observation{
+					Observations: []v1beta1.Observation{
 						{
-							Component: v1alpha1.ComponentForwarding,
-							Action:    v1alpha1.ActionReceived,
+							Component: v1beta1.ComponentForwarding,
+							Action:    v1beta1.ActionReceived,
 						},
 						{
-							Component:     v1alpha1.ComponentForwarding,
+							Component:     v1beta1.ComponentForwarding,
 							ComponentInfo: "Output",
-							Action:        v1alpha1.ActionDelivered,
+							Action:        v1beta1.ActionDelivered,
 						},
 					},
 				},
@@ -1458,58 +1458,58 @@ func testTraceflowInterNode(t *testing.T, data *TestData) {
 				skipIfProxyDisabled(t, data)
 			},
 			ipVersion: 4,
-			tf: &v1alpha1.Traceflow{
+			tf: &v1beta1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: randName(fmt.Sprintf("%s-%s-to-svc-%s-", data.testNamespace, agnhostPodName, svcIPv4Name)),
 				},
-				Spec: v1alpha1.TraceflowSpec{
-					Source: v1alpha1.Source{
+				Spec: v1beta1.TraceflowSpec{
+					Source: v1beta1.Source{
 						Namespace: data.testNamespace,
 						Pod:       agnhostPodName,
 					},
-					Destination: v1alpha1.Destination{
+					Destination: v1beta1.Destination{
 						Namespace: data.testNamespace,
 						Service:   svcIPv4Name,
 					},
-					Packet: v1alpha1.Packet{
-						IPHeader: v1alpha1.IPHeader{
+					Packet: v1beta1.Packet{
+						IPHeader: &v1beta1.IPHeader{
 							Protocol: protocolTCP,
 						},
-						TransportHeader: v1alpha1.TransportHeader{
-							TCP: &v1alpha1.TCPHeader{
+						TransportHeader: v1beta1.TransportHeader{
+							TCP: &v1beta1.TCPHeader{
 								DstPort: 80,
 								SrcPort: 10012,
-								Flags:   2,
+								Flags:   &tcpFlags,
 							},
 						},
 					},
 				},
 			},
-			expectedPhase: v1alpha1.Succeeded,
-			expectedResults: []v1alpha1.NodeResult{
+			expectedPhase: v1beta1.Succeeded,
+			expectedResults: []v1beta1.NodeResult{
 				{
 					Node: node2,
-					Observations: []v1alpha1.Observation{
+					Observations: []v1beta1.Observation{
 						{
-							Component: v1alpha1.ComponentSpoofGuard,
-							Action:    v1alpha1.ActionForwarded,
+							Component: v1beta1.ComponentSpoofGuard,
+							Action:    v1beta1.ActionForwarded,
 						},
 						{
-							Component:       v1alpha1.ComponentLB,
+							Component:       v1beta1.ComponentLB,
 							Pod:             fmt.Sprintf("%s/%s", data.testNamespace, agnhostPodName),
 							TranslatedSrcIP: gatewayIPv4,
 							TranslatedDstIP: agnhostIPv4Str,
-							Action:          v1alpha1.ActionForwarded,
+							Action:          v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentNetworkPolicy,
+							Component:     v1beta1.ComponentNetworkPolicy,
 							ComponentInfo: "EgressRule",
-							Action:        v1alpha1.ActionForwarded,
+							Action:        v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentForwarding,
+							Component:     v1beta1.ComponentForwarding,
 							ComponentInfo: "Output",
-							Action:        v1alpha1.ActionDelivered,
+							Action:        v1beta1.ActionDelivered,
 						},
 					},
 				},
@@ -1518,16 +1518,16 @@ func testTraceflowInterNode(t *testing.T, data *TestData) {
 		{
 			name:      "interNodeICMPDstPodLiveTraceflowIPv4",
 			ipVersion: 4,
-			tf: &v1alpha1.Traceflow{
+			tf: &v1beta1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: randName(fmt.Sprintf("%s-%s-to-%s-", data.testNamespace, node1Pods[0], node2Pods[0])),
 				},
-				Spec: v1alpha1.TraceflowSpec{
-					Source: v1alpha1.Source{
+				Spec: v1beta1.TraceflowSpec{
+					Source: v1beta1.Source{
 						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
-					Destination: v1alpha1.Destination{
+					Destination: v1beta1.Destination{
 						Namespace: data.testNamespace,
 						Pod:       node2Pods[0],
 					},
@@ -1535,38 +1535,38 @@ func testTraceflowInterNode(t *testing.T, data *TestData) {
 				},
 			},
 			srcPod:        node1Pods[0],
-			expectedPhase: v1alpha1.Succeeded,
-			expectedResults: []v1alpha1.NodeResult{
+			expectedPhase: v1beta1.Succeeded,
+			expectedResults: []v1beta1.NodeResult{
 				{
 					Node: node1,
-					Observations: []v1alpha1.Observation{
+					Observations: []v1beta1.Observation{
 						{
-							Component: v1alpha1.ComponentSpoofGuard,
-							Action:    v1alpha1.ActionForwarded,
+							Component: v1beta1.ComponentSpoofGuard,
+							Action:    v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentNetworkPolicy,
+							Component:     v1beta1.ComponentNetworkPolicy,
 							ComponentInfo: "EgressRule",
-							Action:        v1alpha1.ActionForwarded,
+							Action:        v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentForwarding,
+							Component:     v1beta1.ComponentForwarding,
 							ComponentInfo: "Output",
-							Action:        v1alpha1.ActionForwarded,
+							Action:        v1beta1.ActionForwarded,
 						},
 					},
 				},
 				{
 					Node: node2,
-					Observations: []v1alpha1.Observation{
+					Observations: []v1beta1.Observation{
 						{
-							Component: v1alpha1.ComponentForwarding,
-							Action:    v1alpha1.ActionReceived,
+							Component: v1beta1.ComponentForwarding,
+							Action:    v1beta1.ActionReceived,
 						},
 						{
-							Component:     v1alpha1.ComponentForwarding,
+							Component:     v1beta1.ComponentForwarding,
 							ComponentInfo: "Output",
-							Action:        v1alpha1.ActionDelivered,
+							Action:        v1beta1.ActionDelivered,
 						},
 					},
 				},
@@ -1575,65 +1575,65 @@ func testTraceflowInterNode(t *testing.T, data *TestData) {
 		{
 			name:      "interNodeTraceflowIPv6",
 			ipVersion: 6,
-			tf: &v1alpha1.Traceflow{
+			tf: &v1beta1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: randName(fmt.Sprintf("%s-%s-to-%s-%s-", data.testNamespace, node1Pods[0], data.testNamespace, node2Pods[0])),
 				},
-				Spec: v1alpha1.TraceflowSpec{
-					Source: v1alpha1.Source{
+				Spec: v1beta1.TraceflowSpec{
+					Source: v1beta1.Source{
 						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
-					Destination: v1alpha1.Destination{
+					Destination: v1beta1.Destination{
 						Namespace: data.testNamespace,
 						Pod:       node2Pods[0],
 					},
-					Packet: v1alpha1.Packet{
-						IPv6Header: &v1alpha1.IPv6Header{
+					Packet: v1beta1.Packet{
+						IPv6Header: &v1beta1.IPv6Header{
 							NextHeader: &protocolTCP,
 						},
-						TransportHeader: v1alpha1.TransportHeader{
-							TCP: &v1alpha1.TCPHeader{
+						TransportHeader: v1beta1.TransportHeader{
+							TCP: &v1beta1.TCPHeader{
 								DstPort: 80,
 								SrcPort: 10013,
-								Flags:   2,
+								Flags:   &tcpFlags,
 							},
 						},
 					},
 				},
 			},
-			expectedPhase: v1alpha1.Succeeded,
-			expectedResults: []v1alpha1.NodeResult{
+			expectedPhase: v1beta1.Succeeded,
+			expectedResults: []v1beta1.NodeResult{
 				{
 					Node: node1,
-					Observations: []v1alpha1.Observation{
+					Observations: []v1beta1.Observation{
 						{
-							Component: v1alpha1.ComponentSpoofGuard,
-							Action:    v1alpha1.ActionForwarded,
+							Component: v1beta1.ComponentSpoofGuard,
+							Action:    v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentNetworkPolicy,
+							Component:     v1beta1.ComponentNetworkPolicy,
 							ComponentInfo: "EgressRule",
-							Action:        v1alpha1.ActionForwarded,
+							Action:        v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentForwarding,
+							Component:     v1beta1.ComponentForwarding,
 							ComponentInfo: "Output",
-							Action:        v1alpha1.ActionForwarded,
+							Action:        v1beta1.ActionForwarded,
 						},
 					},
 				},
 				{
 					Node: node2,
-					Observations: []v1alpha1.Observation{
+					Observations: []v1beta1.Observation{
 						{
-							Component: v1alpha1.ComponentForwarding,
-							Action:    v1alpha1.ActionReceived,
+							Component: v1beta1.ComponentForwarding,
+							Action:    v1beta1.ActionReceived,
 						},
 						{
-							Component:     v1alpha1.ComponentForwarding,
+							Component:     v1beta1.ComponentForwarding,
 							ComponentInfo: "Output",
-							Action:        v1alpha1.ActionDelivered,
+							Action:        v1beta1.ActionDelivered,
 						},
 					},
 				},
@@ -1645,24 +1645,24 @@ func testTraceflowInterNode(t *testing.T, data *TestData) {
 				t.Skip("IPv6 testbed issue prevents running this test, we suspect an ESX datapath issue")
 			},
 			ipVersion: 6,
-			tf: &v1alpha1.Traceflow{
+			tf: &v1beta1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: randName(fmt.Sprintf("%s-%s-to-%s-", data.testNamespace, node1Pods[0], strings.ReplaceAll(dstPodIPv6Str, ":", "--"))),
 				},
-				Spec: v1alpha1.TraceflowSpec{
-					Source: v1alpha1.Source{
+				Spec: v1beta1.TraceflowSpec{
+					Source: v1beta1.Source{
 						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
-					Destination: v1alpha1.Destination{
+					Destination: v1beta1.Destination{
 						IP: dstPodIPv6Str,
 					},
-					Packet: v1alpha1.Packet{
-						IPv6Header: &v1alpha1.IPv6Header{
+					Packet: v1beta1.Packet{
+						IPv6Header: &v1beta1.IPv6Header{
 							NextHeader: &protocolUDP,
 						},
-						TransportHeader: v1alpha1.TransportHeader{
-							UDP: &v1alpha1.UDPHeader{
+						TransportHeader: v1beta1.TransportHeader{
+							UDP: &v1beta1.UDPHeader{
 								DstPort: 321,
 								SrcPort: 10014,
 							},
@@ -1670,38 +1670,38 @@ func testTraceflowInterNode(t *testing.T, data *TestData) {
 					},
 				},
 			},
-			expectedPhase: v1alpha1.Succeeded,
-			expectedResults: []v1alpha1.NodeResult{
+			expectedPhase: v1beta1.Succeeded,
+			expectedResults: []v1beta1.NodeResult{
 				{
 					Node: node1,
-					Observations: []v1alpha1.Observation{
+					Observations: []v1beta1.Observation{
 						{
-							Component: v1alpha1.ComponentSpoofGuard,
-							Action:    v1alpha1.ActionForwarded,
+							Component: v1beta1.ComponentSpoofGuard,
+							Action:    v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentNetworkPolicy,
+							Component:     v1beta1.ComponentNetworkPolicy,
 							ComponentInfo: "EgressRule",
-							Action:        v1alpha1.ActionForwarded,
+							Action:        v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentForwarding,
+							Component:     v1beta1.ComponentForwarding,
 							ComponentInfo: "Output",
-							Action:        v1alpha1.ActionForwarded,
+							Action:        v1beta1.ActionForwarded,
 						},
 					},
 				},
 				{
 					Node: node2,
-					Observations: []v1alpha1.Observation{
+					Observations: []v1beta1.Observation{
 						{
-							Component: v1alpha1.ComponentForwarding,
-							Action:    v1alpha1.ActionReceived,
+							Component: v1beta1.ComponentForwarding,
+							Action:    v1beta1.ActionReceived,
 						},
 						{
-							Component:     v1alpha1.ComponentForwarding,
+							Component:     v1beta1.ComponentForwarding,
 							ComponentInfo: "Output",
-							Action:        v1alpha1.ActionDelivered,
+							Action:        v1beta1.ActionDelivered,
 						},
 					},
 				},
@@ -1710,57 +1710,57 @@ func testTraceflowInterNode(t *testing.T, data *TestData) {
 		{
 			name:      "interNodeICMPDstIPTraceflowIPv6",
 			ipVersion: 6,
-			tf: &v1alpha1.Traceflow{
+			tf: &v1beta1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: randName(fmt.Sprintf("%s-%s-to-%s-", data.testNamespace, node1Pods[0], strings.ReplaceAll(dstPodIPv6Str, ":", "--"))),
 				},
-				Spec: v1alpha1.TraceflowSpec{
-					Source: v1alpha1.Source{
+				Spec: v1beta1.TraceflowSpec{
+					Source: v1beta1.Source{
 						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
-					Destination: v1alpha1.Destination{
+					Destination: v1beta1.Destination{
 						IP: dstPodIPv6Str,
 					},
-					Packet: v1alpha1.Packet{
-						IPv6Header: &v1alpha1.IPv6Header{
+					Packet: v1beta1.Packet{
+						IPv6Header: &v1beta1.IPv6Header{
 							NextHeader: &protocolICMPv6,
 						},
 					},
 				},
 			},
-			expectedPhase: v1alpha1.Succeeded,
-			expectedResults: []v1alpha1.NodeResult{
+			expectedPhase: v1beta1.Succeeded,
+			expectedResults: []v1beta1.NodeResult{
 				{
 					Node: node1,
-					Observations: []v1alpha1.Observation{
+					Observations: []v1beta1.Observation{
 						{
-							Component: v1alpha1.ComponentSpoofGuard,
-							Action:    v1alpha1.ActionForwarded,
+							Component: v1beta1.ComponentSpoofGuard,
+							Action:    v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentNetworkPolicy,
+							Component:     v1beta1.ComponentNetworkPolicy,
 							ComponentInfo: "EgressRule",
-							Action:        v1alpha1.ActionForwarded,
+							Action:        v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentForwarding,
+							Component:     v1beta1.ComponentForwarding,
 							ComponentInfo: "Output",
-							Action:        v1alpha1.ActionForwarded,
+							Action:        v1beta1.ActionForwarded,
 						},
 					},
 				},
 				{
 					Node: node2,
-					Observations: []v1alpha1.Observation{
+					Observations: []v1beta1.Observation{
 						{
-							Component: v1alpha1.ComponentForwarding,
-							Action:    v1alpha1.ActionReceived,
+							Component: v1beta1.ComponentForwarding,
+							Action:    v1beta1.ActionReceived,
 						},
 						{
-							Component:     v1alpha1.ComponentForwarding,
+							Component:     v1beta1.ComponentForwarding,
 							ComponentInfo: "Output",
-							Action:        v1alpha1.ActionDelivered,
+							Action:        v1beta1.ActionDelivered,
 						},
 					},
 				},
@@ -1769,71 +1769,71 @@ func testTraceflowInterNode(t *testing.T, data *TestData) {
 		{
 			name:      "serviceTraceflowIPv6",
 			ipVersion: 6,
-			tf: &v1alpha1.Traceflow{
+			tf: &v1beta1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: randName(fmt.Sprintf("%s-%s-to-svc-%s-", data.testNamespace, node1Pods[0], svcIPv6Name)),
 				},
-				Spec: v1alpha1.TraceflowSpec{
-					Source: v1alpha1.Source{
+				Spec: v1beta1.TraceflowSpec{
+					Source: v1beta1.Source{
 						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
-					Destination: v1alpha1.Destination{
+					Destination: v1beta1.Destination{
 						Namespace: data.testNamespace,
 						Service:   svcIPv6Name,
 					},
-					Packet: v1alpha1.Packet{
-						IPv6Header: &v1alpha1.IPv6Header{
+					Packet: v1beta1.Packet{
+						IPv6Header: &v1beta1.IPv6Header{
 							NextHeader: &protocolTCP,
 						},
-						TransportHeader: v1alpha1.TransportHeader{
-							TCP: &v1alpha1.TCPHeader{
+						TransportHeader: v1beta1.TransportHeader{
+							TCP: &v1beta1.TCPHeader{
 								DstPort: 80,
 								SrcPort: 10015,
-								Flags:   2,
+								Flags:   &tcpFlags,
 							},
 						},
 					},
 				},
 			},
-			expectedPhase: v1alpha1.Succeeded,
-			expectedResults: []v1alpha1.NodeResult{
+			expectedPhase: v1beta1.Succeeded,
+			expectedResults: []v1beta1.NodeResult{
 				{
 					Node: node1,
-					Observations: []v1alpha1.Observation{
+					Observations: []v1beta1.Observation{
 						{
-							Component: v1alpha1.ComponentSpoofGuard,
-							Action:    v1alpha1.ActionForwarded,
+							Component: v1beta1.ComponentSpoofGuard,
+							Action:    v1beta1.ActionForwarded,
 						},
 						{
-							Component:       v1alpha1.ComponentLB,
+							Component:       v1beta1.ComponentLB,
 							Pod:             fmt.Sprintf("%s/%s", data.testNamespace, agnhostPodName),
 							TranslatedDstIP: agnhostIPv6Str,
-							Action:          v1alpha1.ActionForwarded,
+							Action:          v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentNetworkPolicy,
+							Component:     v1beta1.ComponentNetworkPolicy,
 							ComponentInfo: "EgressRule",
-							Action:        v1alpha1.ActionForwarded,
+							Action:        v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentForwarding,
+							Component:     v1beta1.ComponentForwarding,
 							ComponentInfo: "Output",
-							Action:        v1alpha1.ActionForwarded,
+							Action:        v1beta1.ActionForwarded,
 						},
 					},
 				},
 				{
 					Node: node2,
-					Observations: []v1alpha1.Observation{
+					Observations: []v1beta1.Observation{
 						{
-							Component: v1alpha1.ComponentForwarding,
-							Action:    v1alpha1.ActionReceived,
+							Component: v1beta1.ComponentForwarding,
+							Action:    v1beta1.ActionReceived,
 						},
 						{
-							Component:     v1alpha1.ComponentForwarding,
+							Component:     v1beta1.ComponentForwarding,
 							ComponentInfo: "Output",
-							Action:        v1alpha1.ActionDelivered,
+							Action:        v1beta1.ActionDelivered,
 						},
 					},
 				},
@@ -1842,58 +1842,58 @@ func testTraceflowInterNode(t *testing.T, data *TestData) {
 		{
 			name:      "hairpinServiceTraceflowIPv6",
 			ipVersion: 6,
-			tf: &v1alpha1.Traceflow{
+			tf: &v1beta1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: randName(fmt.Sprintf("%s-%s-to-svc-%s-", data.testNamespace, agnhostPodName, svcIPv6Name)),
 				},
-				Spec: v1alpha1.TraceflowSpec{
-					Source: v1alpha1.Source{
+				Spec: v1beta1.TraceflowSpec{
+					Source: v1beta1.Source{
 						Namespace: data.testNamespace,
 						Pod:       agnhostPodName,
 					},
-					Destination: v1alpha1.Destination{
+					Destination: v1beta1.Destination{
 						Namespace: data.testNamespace,
 						Service:   svcIPv6Name,
 					},
-					Packet: v1alpha1.Packet{
-						IPv6Header: &v1alpha1.IPv6Header{
+					Packet: v1beta1.Packet{
+						IPv6Header: &v1beta1.IPv6Header{
 							NextHeader: &protocolTCP,
 						},
-						TransportHeader: v1alpha1.TransportHeader{
-							TCP: &v1alpha1.TCPHeader{
+						TransportHeader: v1beta1.TransportHeader{
+							TCP: &v1beta1.TCPHeader{
 								DstPort: 80,
 								SrcPort: 10016,
-								Flags:   2,
+								Flags:   &tcpFlags,
 							},
 						},
 					},
 				},
 			},
-			expectedPhase: v1alpha1.Succeeded,
-			expectedResults: []v1alpha1.NodeResult{
+			expectedPhase: v1beta1.Succeeded,
+			expectedResults: []v1beta1.NodeResult{
 				{
 					Node: node2,
-					Observations: []v1alpha1.Observation{
+					Observations: []v1beta1.Observation{
 						{
-							Component: v1alpha1.ComponentSpoofGuard,
-							Action:    v1alpha1.ActionForwarded,
+							Component: v1beta1.ComponentSpoofGuard,
+							Action:    v1beta1.ActionForwarded,
 						},
 						{
-							Component:       v1alpha1.ComponentLB,
+							Component:       v1beta1.ComponentLB,
 							Pod:             fmt.Sprintf("%s/%s", data.testNamespace, agnhostPodName),
 							TranslatedSrcIP: gatewayIPv6,
 							TranslatedDstIP: agnhostIPv6Str,
-							Action:          v1alpha1.ActionForwarded,
+							Action:          v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentNetworkPolicy,
+							Component:     v1beta1.ComponentNetworkPolicy,
 							ComponentInfo: "EgressRule",
-							Action:        v1alpha1.ActionForwarded,
+							Action:        v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentForwarding,
+							Component:     v1beta1.ComponentForwarding,
 							ComponentInfo: "Output",
-							Action:        v1alpha1.ActionDelivered,
+							Action:        v1beta1.ActionDelivered,
 						},
 					},
 				},
@@ -1902,21 +1902,21 @@ func testTraceflowInterNode(t *testing.T, data *TestData) {
 		{
 			name:      "interNodeICMPDstPodLiveTraceflowIPv6",
 			ipVersion: 6,
-			tf: &v1alpha1.Traceflow{
+			tf: &v1beta1.Traceflow{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: randName(fmt.Sprintf("%s-%s-to-%s-", data.testNamespace, node1Pods[0], node2Pods[0])),
 				},
-				Spec: v1alpha1.TraceflowSpec{
-					Source: v1alpha1.Source{
+				Spec: v1beta1.TraceflowSpec{
+					Source: v1beta1.Source{
 						Namespace: data.testNamespace,
 						Pod:       node1Pods[0],
 					},
-					Destination: v1alpha1.Destination{
+					Destination: v1beta1.Destination{
 						Namespace: data.testNamespace,
 						Pod:       node2Pods[0],
 					},
-					Packet: v1alpha1.Packet{
-						IPv6Header: &v1alpha1.IPv6Header{
+					Packet: v1beta1.Packet{
+						IPv6Header: &v1beta1.IPv6Header{
 							NextHeader: &protocolICMPv6,
 						},
 					},
@@ -1924,38 +1924,38 @@ func testTraceflowInterNode(t *testing.T, data *TestData) {
 				},
 			},
 			srcPod:        node1Pods[0],
-			expectedPhase: v1alpha1.Succeeded,
-			expectedResults: []v1alpha1.NodeResult{
+			expectedPhase: v1beta1.Succeeded,
+			expectedResults: []v1beta1.NodeResult{
 				{
 					Node: node1,
-					Observations: []v1alpha1.Observation{
+					Observations: []v1beta1.Observation{
 						{
-							Component: v1alpha1.ComponentSpoofGuard,
-							Action:    v1alpha1.ActionForwarded,
+							Component: v1beta1.ComponentSpoofGuard,
+							Action:    v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentNetworkPolicy,
+							Component:     v1beta1.ComponentNetworkPolicy,
 							ComponentInfo: "EgressRule",
-							Action:        v1alpha1.ActionForwarded,
+							Action:        v1beta1.ActionForwarded,
 						},
 						{
-							Component:     v1alpha1.ComponentForwarding,
+							Component:     v1beta1.ComponentForwarding,
 							ComponentInfo: "Output",
-							Action:        v1alpha1.ActionForwarded,
+							Action:        v1beta1.ActionForwarded,
 						},
 					},
 				},
 				{
 					Node: node2,
-					Observations: []v1alpha1.Observation{
+					Observations: []v1beta1.Observation{
 						{
-							Component: v1alpha1.ComponentForwarding,
-							Action:    v1alpha1.ActionReceived,
+							Component: v1beta1.ComponentForwarding,
+							Action:    v1beta1.ActionReceived,
 						},
 						{
-							Component:     v1alpha1.ComponentForwarding,
+							Component:     v1beta1.ComponentForwarding,
 							ComponentInfo: "Output",
-							Action:        v1alpha1.ActionDelivered,
+							Action:        v1beta1.ActionDelivered,
 						},
 					},
 				},
@@ -1995,38 +1995,38 @@ func testTraceflowExternalIP(t *testing.T, data *TestData) {
 	testcase := testcase{
 		name:      "nodeIPDestination",
 		ipVersion: 4,
-		tf: &v1alpha1.Traceflow{
+		tf: &v1beta1.Traceflow{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: randName(fmt.Sprintf("%s-%s-to-%s-%s-", data.testNamespace, podNames[0], data.testNamespace, strings.ReplaceAll(nodeIP, ":", "--"))),
 			},
-			Spec: v1alpha1.TraceflowSpec{
-				Source: v1alpha1.Source{
+			Spec: v1beta1.TraceflowSpec{
+				Source: v1beta1.Source{
 					Namespace: data.testNamespace,
 					Pod:       podNames[0],
 				},
-				Destination: v1alpha1.Destination{
+				Destination: v1beta1.Destination{
 					IP: nodeIP,
 				},
-				Packet: v1alpha1.Packet{
-					IPHeader: v1alpha1.IPHeader{
+				Packet: v1beta1.Packet{
+					IPHeader: &v1beta1.IPHeader{
 						Protocol: protocolICMP,
 					},
 				},
 			},
 		},
-		expectedPhase: v1alpha1.Succeeded,
-		expectedResults: []v1alpha1.NodeResult{
+		expectedPhase: v1beta1.Succeeded,
+		expectedResults: []v1beta1.NodeResult{
 			{
 				Node: node,
-				Observations: []v1alpha1.Observation{
+				Observations: []v1beta1.Observation{
 					{
-						Component: v1alpha1.ComponentSpoofGuard,
-						Action:    v1alpha1.ActionForwarded,
+						Component: v1beta1.ComponentSpoofGuard,
+						Action:    v1beta1.ActionForwarded,
 					},
 					{
-						Component:     v1alpha1.ComponentForwarding,
+						Component:     v1beta1.ComponentForwarding,
 						ComponentInfo: "Output",
-						Action:        v1alpha1.ActionForwardedOutOfOverlay,
+						Action:        v1beta1.ActionForwardedOutOfOverlay,
 					},
 				},
 			},
@@ -2058,44 +2058,44 @@ func testTraceflowEgress(t *testing.T, data *TestData) {
 	testcaseLocalEgress := testcase{
 		name:      "egressFromLocalNode",
 		ipVersion: 4,
-		tf: &v1alpha1.Traceflow{
+		tf: &v1beta1.Traceflow{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: randName(fmt.Sprintf("%s-%s-to-%s-%s-", data.testNamespace, localPodNames[0], data.testNamespace, strings.ReplaceAll(externalDstIP, ":", "--"))),
 			},
-			Spec: v1alpha1.TraceflowSpec{
-				Source: v1alpha1.Source{
+			Spec: v1beta1.TraceflowSpec{
+				Source: v1beta1.Source{
 					Namespace: data.testNamespace,
 					Pod:       localPodNames[0],
 				},
-				Destination: v1alpha1.Destination{
+				Destination: v1beta1.Destination{
 					IP: externalDstIP,
 				},
-				Packet: v1alpha1.Packet{
-					IPHeader: v1alpha1.IPHeader{
+				Packet: v1beta1.Packet{
+					IPHeader: &v1beta1.IPHeader{
 						Protocol: protocolICMP,
 					},
 				},
 			},
 		},
-		expectedPhase: v1alpha1.Succeeded,
-		expectedResults: []v1alpha1.NodeResult{
+		expectedPhase: v1beta1.Succeeded,
+		expectedResults: []v1beta1.NodeResult{
 			{
 				Node: egressNode,
-				Observations: []v1alpha1.Observation{
+				Observations: []v1beta1.Observation{
 					{
-						Component: v1alpha1.ComponentSpoofGuard,
-						Action:    v1alpha1.ActionForwarded,
+						Component: v1beta1.ComponentSpoofGuard,
+						Action:    v1beta1.ActionForwarded,
 					},
 					{
-						Component: v1alpha1.ComponentEgress,
-						Action:    v1alpha1.ActionMarkedForSNAT,
+						Component: v1beta1.ComponentEgress,
+						Action:    v1beta1.ActionMarkedForSNAT,
 						Egress:    egress.Name,
 						EgressIP:  egressIP,
 					},
 					{
-						Component:     v1alpha1.ComponentForwarding,
+						Component:     v1beta1.ComponentForwarding,
 						ComponentInfo: "Output",
-						Action:        v1alpha1.ActionForwardedOutOfOverlay,
+						Action:        v1beta1.ActionForwardedOutOfOverlay,
 					},
 				},
 			},
@@ -2129,63 +2129,63 @@ func testTraceflowEgress(t *testing.T, data *TestData) {
 	testcaseRemoteEgress := testcase{
 		name:      "egressFromRemoteNode",
 		ipVersion: 4,
-		tf: &v1alpha1.Traceflow{
+		tf: &v1beta1.Traceflow{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: randName(fmt.Sprintf("%s-%s-to-%s-%s-", data.testNamespace, remotePodNames[0], data.testNamespace, strings.ReplaceAll(externalDstIP, ":", "--"))),
 			},
-			Spec: v1alpha1.TraceflowSpec{
-				Source: v1alpha1.Source{
+			Spec: v1beta1.TraceflowSpec{
+				Source: v1beta1.Source{
 					Namespace: data.testNamespace,
 					Pod:       remotePodNames[0],
 				},
-				Destination: v1alpha1.Destination{
+				Destination: v1beta1.Destination{
 					IP: externalDstIP,
 				},
-				Packet: v1alpha1.Packet{
-					IPHeader: v1alpha1.IPHeader{
+				Packet: v1beta1.Packet{
+					IPHeader: &v1beta1.IPHeader{
 						Protocol: protocolICMP,
 					},
 				},
 			},
 		},
-		expectedPhase: v1alpha1.Succeeded,
-		expectedResults: []v1alpha1.NodeResult{
+		expectedPhase: v1beta1.Succeeded,
+		expectedResults: []v1beta1.NodeResult{
 			{
 				Node: remoteNode,
-				Observations: []v1alpha1.Observation{
+				Observations: []v1beta1.Observation{
 					{
-						Component: v1alpha1.ComponentSpoofGuard,
-						Action:    v1alpha1.ActionForwarded,
+						Component: v1beta1.ComponentSpoofGuard,
+						Action:    v1beta1.ActionForwarded,
 					},
 					{
-						Component: v1alpha1.ComponentEgress,
-						Action:    v1alpha1.ActionForwardedToEgressNode,
+						Component: v1beta1.ComponentEgress,
+						Action:    v1beta1.ActionForwardedToEgressNode,
 						Egress:    egress.Name,
 						EgressIP:  egressIP,
 					},
 					{
-						Component:     v1alpha1.ComponentForwarding,
+						Component:     v1beta1.ComponentForwarding,
 						ComponentInfo: "Output",
-						Action:        v1alpha1.ActionForwarded,
+						Action:        v1beta1.ActionForwarded,
 					},
 				},
 			},
 			{
 				Node: egressNode,
-				Observations: []v1alpha1.Observation{
+				Observations: []v1beta1.Observation{
 					{
-						Component: v1alpha1.ComponentForwarding,
-						Action:    v1alpha1.ActionReceived,
+						Component: v1beta1.ComponentForwarding,
+						Action:    v1beta1.ActionReceived,
 					},
 					{
-						Component: v1alpha1.ComponentEgress,
-						Action:    v1alpha1.ActionMarkedForSNAT,
+						Component: v1beta1.ComponentEgress,
+						Action:    v1beta1.ActionMarkedForSNAT,
 						EgressIP:  egressIP,
 					},
 					{
-						Component:     v1alpha1.ComponentForwarding,
+						Component:     v1beta1.ComponentForwarding,
 						ComponentInfo: "Output",
-						Action:        v1alpha1.ActionForwardedOutOfOverlay,
+						Action:        v1beta1.ActionForwardedOutOfOverlay,
 					},
 				},
 			},
@@ -2204,14 +2204,14 @@ func testTraceflowValidation(t *testing.T, data *TestData) {
 
 	testCases := []struct {
 		name         string
-		spec         v1alpha1.TraceflowSpec
+		spec         v1beta1.TraceflowSpec
 		allowed      bool
 		deniedReason string
 	}{
 		{
 			name: "Source Pod must be specified in non-live-traffic Traceflow",
-			spec: v1alpha1.TraceflowSpec{
-				Destination: v1alpha1.Destination{
+			spec: v1beta1.TraceflowSpec{
+				Destination: v1beta1.Destination{
 					Namespace: data.testNamespace,
 					Pod:       podName,
 				},
@@ -2220,15 +2220,15 @@ func testTraceflowValidation(t *testing.T, data *TestData) {
 		},
 		{
 			name: "Traceflow should have either source or destination Pod assigned",
-			spec: v1alpha1.TraceflowSpec{
+			spec: v1beta1.TraceflowSpec{
 				LiveTraffic: true,
 			},
 			deniedReason: "Traceflow {{name}} has neither source nor destination Pod specified",
 		},
 		{
 			name: "Assigned source pod must exist",
-			spec: v1alpha1.TraceflowSpec{
-				Source: v1alpha1.Source{
+			spec: v1beta1.TraceflowSpec{
+				Source: v1beta1.Source{
 					Namespace: "foo",
 					Pod:       "bar",
 				},
@@ -2237,8 +2237,8 @@ func testTraceflowValidation(t *testing.T, data *TestData) {
 		},
 		{
 			name: "Using hostNetwork Pod as source in non-live-traffic Traceflow is not supported",
-			spec: v1alpha1.TraceflowSpec{
-				Source: v1alpha1.Source{
+			spec: v1beta1.TraceflowSpec{
+				Source: v1beta1.Source{
 					Namespace: data.testNamespace,
 					Pod:       podName,
 				},
@@ -2247,9 +2247,9 @@ func testTraceflowValidation(t *testing.T, data *TestData) {
 		},
 		{
 			name: "Valid request",
-			spec: v1alpha1.TraceflowSpec{
+			spec: v1beta1.TraceflowSpec{
 				LiveTraffic: true,
-				Source: v1alpha1.Source{
+				Source: v1beta1.Source{
 					Namespace: data.testNamespace,
 					Pod:       podName,
 				},
@@ -2261,11 +2261,11 @@ func testTraceflowValidation(t *testing.T, data *TestData) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			tf := &v1alpha1.Traceflow{
+			tf := &v1beta1.Traceflow{
 				Spec: tc.spec,
 			}
 			tf.Name = randName("")
-			_, err := data.crdClient.CrdV1alpha1().Traceflows().Create(context.TODO(), tf, metav1.CreateOptions{})
+			_, err := data.crdClient.CrdV1beta1().Traceflows().Create(context.TODO(), tf, metav1.CreateOptions{})
 			if tc.allowed {
 				assert.Nil(t, err)
 			} else {
@@ -2278,12 +2278,12 @@ func testTraceflowValidation(t *testing.T, data *TestData) {
 
 }
 
-func (data *TestData) waitForTraceflow(t *testing.T, name string, phase v1alpha1.TraceflowPhase) (*v1alpha1.Traceflow, error) {
-	var tf *v1alpha1.Traceflow
+func (data *TestData) waitForTraceflow(t *testing.T, name string, phase v1beta1.TraceflowPhase) (*v1beta1.Traceflow, error) {
+	var tf *v1beta1.Traceflow
 	var err error
 	timeout := 15 * time.Second
 	if err = wait.PollImmediate(defaultInterval, timeout, func() (bool, error) {
-		tf, err = data.crdClient.CrdV1alpha1().Traceflows().Get(context.TODO(), name, metav1.GetOptions{})
+		tf, err = data.crdClient.CrdV1beta1().Traceflows().Get(context.TODO(), name, metav1.GetOptions{})
 		if err != nil || tf.Status.Phase != phase {
 			return false, nil
 		}
@@ -2298,7 +2298,7 @@ func (data *TestData) waitForTraceflow(t *testing.T, name string, phase v1alpha1
 }
 
 // compareObservations compares expected results and actual results.
-func compareObservations(expected v1alpha1.NodeResult, actual v1alpha1.NodeResult) error {
+func compareObservations(expected v1beta1.NodeResult, actual v1beta1.NodeResult) error {
 	if expected.Node != actual.Node {
 		return fmt.Errorf("NodeResult should be on %s, but is on %s", expected.Node, actual.Node)
 	}
@@ -2437,11 +2437,11 @@ func runTestTraceflow(t *testing.T, data *TestData, tc testcase) {
 	if tc.skipIfNeeded != nil {
 		tc.skipIfNeeded(t)
 	}
-	if _, err := data.crdClient.CrdV1alpha1().Traceflows().Create(context.TODO(), tc.tf, metav1.CreateOptions{}); err != nil {
+	if _, err := data.crdClient.CrdV1beta1().Traceflows().Create(context.TODO(), tc.tf, metav1.CreateOptions{}); err != nil {
 		t.Fatalf("Error when creating traceflow: %v", err)
 	}
 	defer func() {
-		if err := data.crdClient.CrdV1alpha1().Traceflows().Delete(context.TODO(), tc.tf.Name, metav1.DeleteOptions{}); err != nil {
+		if err := data.crdClient.CrdV1beta1().Traceflows().Delete(context.TODO(), tc.tf.Name, metav1.DeleteOptions{}); err != nil {
 			t.Errorf("Error when deleting traceflow: %v", err)
 		}
 	}()
@@ -2479,7 +2479,7 @@ func runTestTraceflow(t *testing.T, data *TestData, tc testcase) {
 	if err != nil {
 		t.Fatalf("Error: Get Traceflow failed: %v", err)
 	}
-	if tc.expectedPhase == v1alpha1.Failed {
+	if tc.expectedPhase == v1beta1.Failed {
 		isReasonMatch := false
 		for _, expectedReason := range tc.expectedReasons {
 			if tf.Status.Reason == expectedReason {
@@ -2498,7 +2498,7 @@ func runTestTraceflow(t *testing.T, data *TestData, tc testcase) {
 			t.Fatal(err)
 		}
 	} else if len(tc.expectedResults) > 0 {
-		if tf.Status.Results[0].Observations[0].Component == v1alpha1.ComponentSpoofGuard {
+		if tf.Status.Results[0].Observations[0].Component == v1beta1.ComponentSpoofGuard {
 			if err = compareObservations(tc.expectedResults[0], tf.Status.Results[0]); err != nil {
 				t.Fatal(err)
 			}
@@ -2518,7 +2518,7 @@ func runTestTraceflow(t *testing.T, data *TestData, tc testcase) {
 		pktCap := tf.Status.CapturedPacket
 		if tc.expectedPktCap.TransportHeader.ICMP != nil {
 			// We cannot predict ICMP echo ID and sequence number.
-			pktCap.TransportHeader.ICMP = &v1alpha1.ICMPEchoRequestHeader{}
+			pktCap.TransportHeader.ICMP = &v1beta1.ICMPEchoRequestHeader{}
 		}
 		if !reflect.DeepEqual(tc.expectedPktCap, pktCap) {
 			t.Fatalf("Captured packet should be: %+v, but got: %+v", tc.expectedPktCap, tf.Status.CapturedPacket)


### PR DESCRIPTION
Cherry pick of #5689 on release-1.14.

#5689: Use Traceflow API v1beta1

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.