### PR TITLE
Use correct go directive in go.mod file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module antrea.io/antrea
 
-go 1.21
+go 1.21.0
 
 require (
 	antrea.io/libOpenflow v0.13.0


### PR DESCRIPTION
The version provided in the go directive must be a valid Go version. go1.21 refers to a development version of Go, not a released version. Prior to 1.21, 1.X was actually the first released version for Go language version 1.X. Starting with 1.21, the first released version is 1.X.0, and the go directive in go.mod should correspond to a valid toolchain version (unless a toolchain directive is also present).

One way to reproduce the issue is to run:
`GOTOOLCHAIN="go1.20+auto" go version`

When using the `go 1.21` directive, the above command will fail as go will try to download toolchain 1.21, which does not exist.

See https://github.com/golang/go/issues/62278 for a detailed discussion.