### PR TITLE
Modify the kind builder script to perform correct kind cleanup

### DIFF
--- a/ci/jenkins/jobs/macros.yaml
+++ b/ci/jenkins/jobs/macros.yaml
@@ -246,7 +246,7 @@
           ./ci/jenkins/test.sh --testcase '{conformance_type}' --registry ${{DOCKER_REGISTRY}} --kubeconfig ${{PWD}}/.kube/config --testbed-type "kind" --kind-cluster-name "${{JOB_NAME}}-${{BUILD_NUMBER}}"
           return_code=$?
           set -ex
-          kind delete cluster --name "${{JOB_NAME}}-${{BUILD_NUMBER}}"
+          ./ci/kind/kind-setup.sh destroy "${{JOB_NAME}}-${{BUILD_NUMBER}}"
           exit $return_code
 
 - builder:

--- a/ci/kind/kind-setup.sh
+++ b/ci/kind/kind-setup.sh
@@ -383,8 +383,8 @@ function destroy {
       clean_kind
   else
       kind delete cluster --name $CLUSTER_NAME
-      delete_networks
   fi
+  delete_networks
 }
 
 function printUnixTimestamp {


### PR DESCRIPTION
Signed-off-by: KMAnju-2021 km074btcse18@igdtuw.ac.in

Modify the kind builder script and destroy function in `kind-setup.sh` to perform correct kind cleanup.
If we create a kind cluster by using `kind-setup.sh` script then we should need to delete cluster using same script.