### PR TITLE
Test PR for Jenkins tests

### DIFF
--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
@@ -171,6 +171,7 @@ func NewNetworkPolicyController(antreaClientGetter agent.AntreaClientProvider,
 		nodeConfig:             nodeConfig,
 	}
 
+	fmt.Println("new NetworkPolicyController created")
 	if l7NetworkPolicyEnabled {
 		c.l7RuleReconciler = l7engine.NewReconciler()
 		c.l7VlanIDAllocator = newL7VlanIDAllocator()


### PR DESCRIPTION
This PR introduces a simple change and will be drafted in order to measure the memory consumption on the jenkins node the test runs on.