### PR TITLE
README: Update zoom meeting link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,11 @@ Your feedback is more than welcome!
 [#antrea](https://kubernetes.slack.com/messages/CR2J23M0X) channel.
 * Check the [Antrea Team Calendar](https://calendar.google.com/calendar/embed?src=uuillgmcb1cu3rmv7r7jrhcrco%40group.calendar.google.com)
   and join the developer and user communities!
-  + The [Antrea community meeting](https://VMware.zoom.us/j/823654111?pwd=MEV6blNtUUtqallVSkVFSGZtQ1kwUT09),
+  + The [Antrea community meeting](https://broadcom.zoom.us/j/94648245414?pwd=TWEyMFpjQnFNT2RhSzUvTVg2TllFUT09),
 every two weeks on Tuesday at 5AM GMT+1 (United Kingdom time). See Antrea team calendar for localized times.
     - [Meeting minutes](https://github.com/antrea-io/antrea/wiki/Community-Meetings)
     - [Meeting recordings](https://www.youtube.com/playlist?list=PLuzde2hYeDBdw0BuQCYbYqxzoJYY1hfwv)
-  + [Antrea live office hours](https://antrea.io/live),
-every two weeks on Tuesday at 10PM GMT+1 (United Kingdom time). See Antrea team calendar for localized times.
+  + [Antrea live office hours](https://antrea.io/live) archives.
 * Join our mailing lists to always stay up-to-date with Antrea development:
   + [projectantrea-announce](https://groups.google.com/forum/#!forum/projectantrea-announce)
 for important project announcements.


### PR DESCRIPTION
Update zoom meeting for Antrea community meeting.
Also remove reference to Antrea live office hour call, but let event archive available.