### PR TITLE
Record an event when Egress IP assignment changes

### DIFF
--- a/build/charts/antrea/templates/agent/clusterrole.yaml
+++ b/build/charts/antrea/templates/agent/clusterrole.yaml
@@ -219,3 +219,11 @@ rules:
     - get
     - list
     - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - update

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -6283,6 +6283,14 @@ rules:
     - get
     - list
     - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - update
 ---
 # Source: antrea/templates/antctl/clusterrole.yaml
 kind: ClusterRole

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -6283,6 +6283,14 @@ rules:
     - get
     - list
     - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - update
 ---
 # Source: antrea/templates/antctl/clusterrole.yaml
 kind: ClusterRole

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -6283,6 +6283,14 @@ rules:
     - get
     - list
     - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - update
 ---
 # Source: antrea/templates/antctl/clusterrole.yaml
 kind: ClusterRole

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -6296,6 +6296,14 @@ rules:
     - get
     - list
     - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - update
 ---
 # Source: antrea/templates/antctl/clusterrole.yaml
 kind: ClusterRole

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -6283,6 +6283,14 @@ rules:
     - get
     - list
     - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+      - update
 ---
 # Source: antrea/templates/antctl/clusterrole.yaml
 kind: ClusterRole

--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -516,7 +516,7 @@ func run(o *Options) error {
 	}
 	if o.enableEgress {
 		egressController, err = egress.NewEgressController(
-			ofClient, antreaClientProvider, crdClient, ifaceStore, routeClient, nodeConfig.Name, nodeConfig.NodeTransportInterfaceName,
+			ofClient, k8sClient, antreaClientProvider, crdClient, ifaceStore, routeClient, nodeConfig.Name, nodeConfig.NodeTransportInterfaceName,
 			memberlistCluster, egressInformer, nodeInformer, podUpdateChannel, serviceCIDRProvider, o.config.Egress.MaxEgressIPsPerNode,
 			features.DefaultFeatureGate.Enabled(features.EgressTrafficShaping),
 		)

--- a/pkg/agent/controller/egress/egress_controller_test.go
+++ b/pkg/agent/controller/egress/egress_controller_test.go
@@ -182,6 +182,7 @@ func newFakeController(t *testing.T, initObjects []runtime.Object) *fakeControll
 	mockServiceCIDRProvider := servicecidrtest.NewMockInterface(controller)
 	mockServiceCIDRProvider.EXPECT().AddEventHandler(gomock.Any())
 	egressController, _ := NewEgressController(mockOFClient,
+		k8sClient,
 		&antreaClientGetter{clientset},
 		crdClient,
 		ifaceStore,

--- a/pkg/agent/controller/serviceexternalip/controller.go
+++ b/pkg/agent/controller/serviceexternalip/controller.go
@@ -393,7 +393,7 @@ func (c *ServiceExternalIPController) assignIP(ip string, service apimachineryty
 	c.assignedIPsMutex.Lock()
 	defer c.assignedIPsMutex.Unlock()
 	if _, ok := c.assignedIPs[ip]; !ok {
-		if err := c.ipAssigner.AssignIP(ip, true); err != nil {
+		if _, err := c.ipAssigner.AssignIP(ip, true); err != nil {
 			return err
 		}
 		c.assignedIPs[ip] = sets.New[string](service.String())
@@ -411,7 +411,7 @@ func (c *ServiceExternalIPController) unassignIP(ip string, service apimachinery
 		return nil
 	}
 	if assigned.Len() == 1 && assigned.Has(service.String()) {
-		if err := c.ipAssigner.UnassignIP(ip); err != nil {
+		if _, err := c.ipAssigner.UnassignIP(ip); err != nil {
 			return err
 		}
 		delete(c.assignedIPs, ip)

--- a/pkg/agent/ipassigner/ip_assigner.go
+++ b/pkg/agent/ipassigner/ip_assigner.go
@@ -19,9 +19,14 @@ import "k8s.io/apimachinery/pkg/util/sets"
 // IPAssigner provides methods to assign or unassign IP.
 type IPAssigner interface {
 	// AssignIP ensures the provided IP is assigned to the system.
-	AssignIP(ip string, forceAdvertise bool) error
+	// It returns true only in the case when there is no error and the IP provided
+	// was not assigned to the interface before the operation, in all other cases it
+	// returns false.
+	AssignIP(ip string, forceAdvertise bool) (bool, error)
 	// UnassignIP ensures the provided IP is not assigned to the system.
-	UnassignIP(ip string) error
+	// It returns true only in the case when there is no error and the IP provided
+	// was assigned to the interface before the operation.
+	UnassignIP(ip string) (bool, error)
 	// AssignedIPs return the IPs that are assigned to the system by this IPAssigner.
 	AssignedIPs() sets.Set[string]
 	// InitIPs ensures the IPs that are assigned to the system match the given IPs.

--- a/pkg/agent/ipassigner/testing/mock_ipassigner.go
+++ b/pkg/agent/ipassigner/testing/mock_ipassigner.go
@@ -54,11 +54,12 @@ func (m *MockIPAssigner) EXPECT() *MockIPAssignerMockRecorder {
 }
 
 // AssignIP mocks base method.
-func (m *MockIPAssigner) AssignIP(arg0 string, arg1 bool) error {
+func (m *MockIPAssigner) AssignIP(arg0 string, arg1 bool) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AssignIP", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // AssignIP indicates an expected call of AssignIP.
@@ -108,11 +109,12 @@ func (mr *MockIPAssignerMockRecorder) Run(arg0 any) *gomock.Call {
 }
 
 // UnassignIP mocks base method.
-func (m *MockIPAssigner) UnassignIP(arg0 string) error {
+func (m *MockIPAssigner) UnassignIP(arg0 string) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UnassignIP", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // UnassignIP indicates an expected call of UnassignIP.

--- a/test/integration/agent/ip_assigner_linux_test.go
+++ b/test/integration/agent/ip_assigner_linux_test.go
@@ -40,7 +40,7 @@ func TestIPAssigner(t *testing.T) {
 	require.NoError(t, err, "Failed to find the dummy device")
 	defer netlink.LinkDel(dummyDevice)
 
-	err = ipAssigner.AssignIP("x", false)
+	_, err = ipAssigner.AssignIP("x", false)
 	assert.Error(t, err, "Assigning an invalid IP should fail")
 
 	ip1 := "10.10.10.10"
@@ -49,7 +49,7 @@ func TestIPAssigner(t *testing.T) {
 	desiredIPs := sets.New[string](ip1, ip2, ip3)
 
 	for ip := range desiredIPs {
-		errAssign := ipAssigner.AssignIP(ip, false)
+		_, errAssign := ipAssigner.AssignIP(ip, false)
 		cmd := exec.Command("ip", "addr")
 		out, err := cmd.CombinedOutput()
 		if err != nil {
@@ -79,7 +79,7 @@ func TestIPAssigner(t *testing.T) {
 	assert.Equal(t, newDesiredIPs, actualIPs, "Actual IPs don't match")
 
 	for ip := range newDesiredIPs {
-		err = newIPAssigner.UnassignIP(ip)
+		_, err = newIPAssigner.UnassignIP(ip)
 		assert.NoError(t, err, "Failed to unassign a valid IP")
 	}
 	assert.Equal(t, sets.New[string](), newIPAssigner.AssignedIPs(), "Assigned IPs don't match")


### PR DESCRIPTION
Fixes #4614.

Record event when EgressIP is assigned to the Node interface.