### PR TITLE
Change secondary network Pod controller to subscribe to CNIServer events

### DIFF
--- a/pkg/agent/cniserver/pod_configuration_linux.go
+++ b/pkg/agent/cniserver/pod_configuration_linux.go
@@ -29,6 +29,7 @@ func (pc *podConfigurator) connectInterfaceToOVS(
 	podName string,
 	podNamespace string,
 	containerID string,
+	netNS string,
 	hostIface *current.Interface,
 	containerIface *current.Interface,
 	ips []*current.IPConfig,
@@ -38,7 +39,7 @@ func (pc *podConfigurator) connectInterfaceToOVS(
 	// Use the outer veth interface name as the OVS port name.
 	ovsPortName := hostIface.Name
 	containerConfig := buildContainerConfig(ovsPortName, containerID, podName, podNamespace, containerIface, ips, vlanID)
-	return containerConfig, pc.connectInterfaceToOVSCommon(ovsPortName, containerConfig)
+	return containerConfig, pc.connectInterfaceToOVSCommon(ovsPortName, netNS, containerConfig)
 }
 
 func (pc *podConfigurator) reconcileMissingPods(ifConfigs []*interfacestore.InterfaceConfig, containerAccess *containerAccessArbitrator) {

--- a/pkg/agent/cniserver/pod_configuration_linux_test.go
+++ b/pkg/agent/cniserver/pod_configuration_linux_test.go
@@ -501,7 +501,7 @@ func createPodConfigurator(controller *gomock.Controller, testIfaceConfigurator 
 	mockOFClient = openflowtest.NewMockClient(controller)
 	ifaceStore = interfacestore.NewInterfaceStore()
 	mockRoute = routetest.NewMockInterface(controller)
-	configurator, _ := newPodConfigurator(mockOVSBridgeClient, mockOFClient, mockRoute, ifaceStore, gwMAC, "system", false, false, channel.NewSubscribableChannel("PodUpdate", 100), nil)
+	configurator, _ := newPodConfigurator(mockOVSBridgeClient, mockOFClient, mockRoute, ifaceStore, gwMAC, "system", false, false, channel.NewSubscribableChannel("PodUpdate", 100))
 	configurator.ifConfigurator = testIfaceConfigurator
 	return configurator
 }

--- a/pkg/agent/cniserver/pod_configuration_windows.go
+++ b/pkg/agent/cniserver/pod_configuration_windows.go
@@ -66,6 +66,7 @@ func (pc *podConfigurator) connectInterfaceToOVS(
 	podName string,
 	podNamespace string,
 	containerID string,
+	netNS string,
 	hostIface *current.Interface,
 	containerIface *current.Interface,
 	ips []*current.IPConfig,
@@ -87,7 +88,7 @@ func (pc *podConfigurator) connectInterfaceToOVS(
 	//   HNSEndpoint/HostComputeEndpoint, the current implementation will still work. It will choose the synchronized
 	//   way to create OVS port.
 	if hostInterfaceExistsFunc(hostIfAlias) {
-		return containerConfig, pc.connectInterfaceToOVSCommon(ovsPortName, containerConfig)
+		return containerConfig, pc.connectInterfaceToOVSCommon(ovsPortName, netNS, containerConfig)
 	}
 	klog.V(2).Infof("Adding OVS port %s for container %s", ovsPortName, containerID)
 	ovsAttachInfo := BuildOVSPortExternalIDs(containerConfig)

--- a/pkg/agent/cniserver/secondary.go
+++ b/pkg/agent/cniserver/secondary.go
@@ -24,7 +24,7 @@ import (
 )
 
 func NewSecondaryInterfaceConfigurator(ovsBridgeClient ovsconfig.OVSBridgeClient) (*podConfigurator, error) {
-	return newPodConfigurator(ovsBridgeClient, nil, nil, nil, nil, ovsconfig.OVSDatapathSystem, false, false, nil, nil)
+	return newPodConfigurator(ovsBridgeClient, nil, nil, nil, nil, ovsconfig.OVSDatapathSystem, false, false, nil)
 }
 
 // ConfigureSriovSecondaryInterface configures a SR-IOV secondary interface for a Pod.

--- a/pkg/agent/cniserver/server_windows_test.go
+++ b/pkg/agent/cniserver/server_windows_test.go
@@ -293,7 +293,7 @@ func newMockCNIServer(t *testing.T, controller *gomock.Controller, podUpdateNoti
 	gwMAC, _ := net.ParseMAC("00:00:11:11:11:11")
 	gateway := &config.GatewayConfig{Name: "", IPv4: gwIPv4, MAC: gwMAC}
 	cniServer.nodeConfig = &config.NodeConfig{Name: "node1", PodIPv4CIDR: nodePodCIDRv4, GatewayConfig: gateway}
-	cniServer.podConfigurator, _ = newPodConfigurator(mockOVSBridgeClient, mockOFClient, mockRoute, ifaceStore, gwMAC, "system", false, false, podUpdateNotifier, nil)
+	cniServer.podConfigurator, _ = newPodConfigurator(mockOVSBridgeClient, mockOFClient, mockRoute, ifaceStore, gwMAC, "system", false, false, podUpdateNotifier)
 	return cniServer
 }
 
@@ -947,7 +947,7 @@ func TestReconcile(t *testing.T) {
 	pod4IfaceName := "iface4"
 	pod4Iface := containerIfaces["iface4"]
 	waiter := newAsyncWaiter(pod4Iface.PodName, pod4Iface.ContainerID)
-	cniServer.podConfigurator, _ = newPodConfigurator(mockOVSBridgeClient, mockOFClient, mockRoute, ifaceStore, gwMAC, "system", false, false, waiter.notifier, nil)
+	cniServer.podConfigurator, _ = newPodConfigurator(mockOVSBridgeClient, mockOFClient, mockRoute, ifaceStore, gwMAC, "system", false, false, waiter.notifier)
 	cniServer.nodeConfig = &config.NodeConfig{Name: nodeName}
 
 	// Re-install Pod1 flows

--- a/pkg/agent/secondarynetwork/cnipodcache/types.go
+++ b/pkg/agent/secondarynetwork/cnipodcache/types.go
@@ -15,7 +15,6 @@
 package cnipodcache
 
 type CNIConfigInfo struct {
-	CNIVersion     string
 	PodName        string
 	PodNamespace   string
 	ContainerID    string

--- a/pkg/agent/secondarynetwork/init.go
+++ b/pkg/agent/secondarynetwork/init.go
@@ -26,10 +26,10 @@ import (
 	"k8s.io/klog/v2"
 
 	"antrea.io/antrea/pkg/agent/interfacestore"
-	"antrea.io/antrea/pkg/agent/secondarynetwork/cnipodcache"
 	"antrea.io/antrea/pkg/agent/secondarynetwork/podwatch"
 	agentconfig "antrea.io/antrea/pkg/config/agent"
 	"antrea.io/antrea/pkg/ovs/ovsconfig"
+	"antrea.io/antrea/pkg/util/channel"
 	"antrea.io/antrea/pkg/util/k8s"
 )
 
@@ -46,7 +46,7 @@ func Initialize(
 	k8sClient clientset.Interface,
 	podInformer cache.SharedIndexInformer,
 	nodeName string,
-	podCache cnipodcache.CNIPodInfoStore,
+	podUpdateSubscriber channel.Subscriber,
 	stopCh <-chan struct{},
 	config *agentconfig.SecondaryNetworkConfig, ovsdb *ovsdb.OVSDB) error {
 
@@ -66,7 +66,7 @@ func Initialize(
 	// k8s.v1.cni.cncf.io/networks Annotation defined.
 	if podWatchController, err := podwatch.NewPodController(
 		k8sClient, netAttachDefClient, podInformer,
-		nodeName, podCache, ovsBridgeClient); err != nil {
+		nodeName, podUpdateSubscriber, ovsBridgeClient); err != nil {
 		return err
 	} else {
 		go podWatchController.Run(stopCh)

--- a/pkg/agent/secondarynetwork/podwatch/controller_test.go
+++ b/pkg/agent/secondarynetwork/podwatch/controller_test.go
@@ -209,8 +209,8 @@ func TestPodControllerRun(t *testing.T) {
 		netdefclient,
 		informerFactory.Core().V1().Pods().Informer(),
 		testNode,
-		podCache,
-		nil)
+		nil, nil)
+	podController.podCache = podCache
 	podController.interfaceConfigurator = interfaceConfigurator
 	podController.ipamAllocator = mockIPAM
 

--- a/pkg/agent/types/event.go
+++ b/pkg/agent/types/event.go
@@ -17,6 +17,7 @@ package types
 type PodUpdate struct {
 	PodNamespace string
 	PodName      string
-	IsAdd        bool
 	ContainerID  string
+	NetNS        string
+	IsAdd        bool
 }

--- a/test/integration/agent/cniserver_test.go
+++ b/test/integration/agent/cniserver_test.go
@@ -574,7 +574,7 @@ func newTester() *cmdAddDelTester {
 		routeMock,
 		false, false, false, false, &config.NetworkConfig{InterfaceMTU: 1450},
 		tester.networkReadyCh)
-	tester.server.Initialize(ovsServiceMock, ofServiceMock, ifaceStore, channel.NewSubscribableChannel("PodUpdate", 100), nil)
+	tester.server.Initialize(ovsServiceMock, ofServiceMock, ifaceStore, channel.NewSubscribableChannel("PodUpdate", 100))
 	ctx := context.Background()
 	tester.ctx = ctx
 	return tester
@@ -795,7 +795,7 @@ func TestCNIServerChaining(t *testing.T) {
 			ifaceStore := interfacestore.NewInterfaceStore()
 			ovsServiceMock.EXPECT().IsHardwareOffloadEnabled().Return(false).AnyTimes()
 			ovsServiceMock.EXPECT().GetOVSDatapathType().Return(ovsconfig.OVSDatapathSystem).AnyTimes()
-			err = server.Initialize(ovsServiceMock, ofServiceMock, ifaceStore, channel.NewSubscribableChannel("PodUpdate", 100), nil)
+			err = server.Initialize(ovsServiceMock, ofServiceMock, ifaceStore, channel.NewSubscribableChannel("PodUpdate", 100))
 			testRequire.Nil(err)
 		}
 
@@ -928,7 +928,7 @@ func TestCNIServerGCForHostLocalIPAM(t *testing.T) {
 	)
 
 	// call Initialize, which will run reconciliation and perform host-local IPAM garbage collection
-	server.Initialize(ovsServiceMock, ofServiceMock, ifaceStore, channel.NewSubscribableChannel("PodUpdate", 100), nil)
+	server.Initialize(ovsServiceMock, ofServiceMock, ifaceStore, channel.NewSubscribableChannel("PodUpdate", 100))
 
 	getIPs := func(cID string) []net.IP {
 		ipamStore, err := disk.New("antrea", "")


### PR DESCRIPTION
The commit moves CNI Pod information store from CNIServer to secondary network PodController, and let PodController subscribe to CNIServer Pod events to maintain the Pod CNI information in the store. This way simplifies CNIServer and removes secondary network logic from it.

Issue: #5278 