### PR TITLE
Remove stale reference to Ubuntu 20.04 in CONTRIBUTING doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -243,7 +243,7 @@ do:
 2. Run `make`
 
 The second step will compile the Antrea code in a `golang` container, and build
-a `Ubuntu 20.04` Docker image that includes all the generated binaries. [`Docker`](https://docs.docker.com/install)
+an Ubuntu-based Docker image that includes all the generated binaries. [`Docker`](https://docs.docker.com/install)
 must be installed on your local machine in advance. If you are a macOS user and
 cannot use [Docker Desktop](https://www.docker.com/products/docker-desktop) to
 contribute to Antrea for licensing reasons, check out this


### PR DESCRIPTION
Our container images have been using Ubuntu 22.04 for a while. I removed the reference to the Ubuntu version in the doc, so that we no longer need to update it in the future.