### PR TITLE
Delete OVS port and flows before releasing Pod IP

### DIFF
--- a/pkg/agent/cniserver/ipam/ipam_service.go
+++ b/pkg/agent/cniserver/ipam/ipam_service.go
@@ -33,6 +33,7 @@ import (
 var ipamDrivers map[string][]IPAMDriver
 
 // A cache of IPAM results.
+// TODO: We should get rid of using global variables to store status, which makes testing complicated.
 var ipamResults = sync.Map{}
 
 type IPAMResult struct {
@@ -57,6 +58,10 @@ func ResetIPAMDrivers(ipamType string) {
 	if ipamDrivers != nil {
 		delete(ipamDrivers, ipamType)
 	}
+}
+
+func ResetIPAMResults() {
+	ipamResults = sync.Map{}
 }
 
 func argsFromEnv(cniArgs *cnipb.CniCmdArgs) *invoke.Args {

--- a/pkg/agent/cniserver/server_test.go
+++ b/pkg/agent/cniserver/server_test.go
@@ -687,14 +687,14 @@ func generateNetworkConfiguration(name, cniVersion, cniType, ipamType string) *t
 	if cniType == "" {
 		netCfg.Type = AntreaCNIType
 	} else {
-		netCfg.Type = "cniType"
+		netCfg.Type = cniType
 	}
 	netCfg.IPAM = &types.IPAMConfig{Type: ipamType}
 	return netCfg
 }
 
 func newRequest(args string, netCfg *types.NetworkConfig, path string, t *testing.T) (*cnipb.CniCmdRequest, string) {
-	containerID := generateUUID(t)
+	_, _, containerID := cniservertest.ParseCNIArgs(args)
 	networkConfig, err := json.Marshal(netCfg)
 	if err != nil {
 		t.Error("Failed to generate Network configuration")

--- a/pkg/agent/cniserver/testing/utils.go
+++ b/pkg/agent/cniserver/testing/utils.go
@@ -14,10 +14,31 @@
 
 package testing
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 const argsFormat = "IgnoreUnknown=1;K8S_POD_NAMESPACE=%s;K8S_POD_NAME=%s;K8S_POD_INFRA_CONTAINER_ID=%s"
 
-func GenerateCNIArgs(podName string, podNamespace string, podInfraContainerID string) string {
+func GenerateCNIArgs(podName, podNamespace, podInfraContainerID string) string {
 	return fmt.Sprintf(argsFormat, podNamespace, podName, podInfraContainerID)
+}
+
+func ParseCNIArgs(args string) (podName, podNamespace, podInfraContainerID string) {
+	strs := strings.Split(args, ";")
+	for _, str := range strs {
+		fields := strings.Split(str, "=")
+		if len(fields) == 2 {
+			switch fields[0] {
+			case "K8S_POD_NAMESPACE":
+				podNamespace = fields[1]
+			case "K8S_POD_NAME":
+				podName = fields[1]
+			case "K8S_POD_INFRA_CONTAINER_ID":
+				podInfraContainerID = fields[1]
+			}
+		}
+	}
+	return
 }


### PR DESCRIPTION
Pod IP is recorded as OVS port attribute and used in Pod specific flows. If releasing Pod IP before deleting OVS port and flows, it could happen that multiple Pod ports and flows reference to the same Pod IP as the same time in some corner cases and lead to corrupted network.

This commit ensures all resources that reference to Pod IP are deleted before releasing the IP.

---
Thanks @antoninbas for suggesting this solution.