### PR TITLE
Update Windows documentation

### DIFF
--- a/docs/design/windows-design.md
+++ b/docs/design/windows-design.md
@@ -188,18 +188,6 @@ these scenarios:
 * OpenFlow connection
 * The connection between CNI plugin and CNI server
 
-## Antrea Management on Windows
-
-### Antrea Agent Management
-
-The Antrea Agent is running as a process on the Windows Node, but it is managed using a DaemonSet. The utility
-[Rancher Wins](https://github.com/rancher/wins) is used to manage the host process from inside the DaemonSet Pod.
-The Antrea Agent is configured using a ConfigMap, and the environment variables are set by kubelet on Windows.
-
-### OVS Management
-
-OVS is running as 2 Windows Services: one for ovsdb-server and one for ovs-vswitchd.
-
 ## Traffic walkthrough
 
 ### Pod-to-Pod Traffic

--- a/docs/design/windows-design.md
+++ b/docs/design/windows-design.md
@@ -188,6 +188,15 @@ these scenarios:
 * OpenFlow connection
 * The connection between CNI plugin and CNI server
 
+## Antrea and OVS Management on Windows
+
+While we provide different installation methods for Windows, the recommended one starting with
+Antrea v1.13 is to use the `antrea-windows-containerd-with-ovs.yml` manifest. With this method, the
+antrea-agent process and the OVS daemons (ovsdb-server and ovs-vswitchd) run as a Pod on Windows
+worker Nodes, and are managed by a DaemonSet. This installation method relies on
+[Windows HostProcess Pod](https://kubernetes.io/docs/tasks/configure-pod-container/create-hostprocess-pod/)
+support.
+
 ## Traffic walkthrough
 
 ### Pod-to-Pod Traffic

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -90,14 +90,14 @@ installation method will be removed from the documentation in a later release.
   - [Hyper-V](https://docs.microsoft.com/en-us/windows-server/virtualization/hyper-v/get-started/install-the-hyper-v-role-on-windows-server)
     with management tools. If your Nodes do not have the virtualization
     capabilities required by Hyper-V, use the workaround described in the
-    [Knownissues](#known-issues) section.
+    [Known issues](#known-issues) section.
   - [containerd](https://learn.microsoft.com/en-us/virtualization/windowscontainers/quick-start/set-up-environment?tabs=containerd#windows-server-1).
 
 ### Installation as a Pod
 
 This installation method requires Antrea 1.10 or higher, and containerd 1.6 or
 higher (containerd 1.7 or higher is recommended). It relies on support for
-[Windows HostProcess containers](https://kubernetes.io/docs/tasks/configure-pod-container/create-hostprocess-pod/),
+[Windows HostProcess Pods](https://kubernetes.io/docs/tasks/configure-pod-container/create-hostprocess-pod/),
 which is generally available starting with K8s 1.26.
 
 Starting with Antrea v1.13, Antrea will take over all the responsibilities of
@@ -228,9 +228,9 @@ Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False
 
 ##### 3. Install kubelet, kubeadm and configure kubelet startup params
 
-Firstly, install kubelet and kubeadm using the script `PrepareNode.ps1` provided
-by kubernetes. Specify the Node IP, Kubernetes Version and container runtime
-while running the script. The following command downloads and executes
+Firstly, install kubelet and kubeadm using the provided `PrepareNode.ps1`
+script. Specify the Node IP, Kubernetes Version and container runtime while
+running the script. The following command downloads and executes
 `Prepare-Node.ps1`:
 
 ```powershell

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -6,7 +6,7 @@
 - [Overview](#overview)
   - [Components that run on Windows](#components-that-run-on-windows)
   - [Antrea Windows demo](#antrea-windows-demo)
-- [Deploying Antrea on Windows Worker Node](#deploying-antrea-on-windows-worker-node)
+- [Deploying Antrea on Windows worker Nodes](#deploying-antrea-on-windows-worker-nodes)
   - [Prerequisites](#prerequisites)
   - [Installation as a Pod](#installation-as-a-pod)
     - [Download &amp; Configure Antrea for Linux](#download--configure-antrea-for-linux)
@@ -25,14 +25,14 @@
   - [Add Windows kube-proxy DaemonSet (only for Kubernetes versions prior to 1.26)](#add-windows-kube-proxy-daemonset-only-for-kubernetes-versions-prior-to-126)
     - [Common steps](#common-steps)
     - [For containerd](#for-containerd)
-    - [For docker](#for-docker)
+    - [For Docker](#for-docker)
   - [Manually run kube-proxy and antrea-agent on Windows worker Nodes](#manually-run-kube-proxy-and-antrea-agent-on-windows-worker-nodes)
 - [Known issues](#known-issues)
 <!-- /toc -->
 
 ## Overview
 
-Antrea supports Windows worker Node. On Windows Node, Antrea sets up an overlay
+Antrea supports Windows worker Nodes. On Windows Nodes, Antrea sets up an overlay
 network to forward packets between Nodes and implements NetworkPolicies. Currently
 Geneve, VXLAN, and STT tunnels are supported.
 
@@ -67,7 +67,7 @@ shows the Antrea OVS bridge configuration on a Windows Node, and NetworkPolicy
 enforcement for Windows Pods. Note, OVS driver and daemons are pre-installed on
 the Windows Nodes in the demo.
 
-## Deploying Antrea on Windows Worker Node
+## Deploying Antrea on Windows worker Nodes
 
 Running Antrea on Windows Nodes requires the containerd container runtime. The
 recommended installation method is [Installation as a
@@ -400,7 +400,7 @@ Window hosts, while managing them as if they were Pods.
 #### Add Windows antrea-agent DaemonSet
 
 For example, these commands will download the antrea-agent manifest, set
-kubeAPIServerOverride, and deploy the antrea-agent DaemonSet when using the
+`kubeAPIServerOverride`, and deploy the antrea-agent DaemonSet when using the
 Docker container runtime:
 
 ```bash
@@ -418,8 +418,8 @@ containerd runtime, with the following differences:
 1. OVS containerization is not supported, so OVS userspace processes need to be
    run as Windows native services.
 2. When running the `Prepare-Node.ps1` script, you will need to explicitly
-   specify that you are using the docker container runtime. The script will then
-   take are of installing wins. For example:
+   specify that you are using the Docker container runtime. The script will then
+   take care of installing wins. For example:
 
    ```powershell
    .\Prepare-Node.ps1 -KubernetesVersion v1.23.5 -NodeIP 192.168.1.10 -ContainerRuntime docker
@@ -463,7 +463,7 @@ automatically by Windows after the Windows Node reboots
 (`Prepare-AntreaAgent.ps1` needs to run at every startup).
 
 After that, you will need to deploy a Windows-compatible version of
-kube-proxy. You can download `kube-proxy.yaml` from the Kubernetes github
+kube-proxy. You can download `kube-proxy.yml` from the Kubernetes github
 repository to deploy kube-proxy. The kube-proxy version in the YAML file must be
 set to a Windows compatible version. The following command downloads
 `kube-proxy.yml`:
@@ -533,7 +533,7 @@ spec:
         - $env:CONTAINER_SANDBOX_MOUNT_POINT/var/lib/kube-proxy-windows/run-script.ps1
 ```
 
-#### For docker
+#### For Docker
 
 Replace the content of `run-script.ps1` in the `kube-proxy-windows` ConfigMap
 with the following:


### PR DESCRIPTION
The user-facing Windows document is updated as follows:
* containerd will be the only supported container runtime on Windows Nodes, Docker support (that includes cri-dockerd, Docker Desktop) is officially deprecated.
* we split the "Installation as Pod" section into 2 new sections (one for containerd, one for Docker).
* installation methods are re-ordered, starting with the recommended / most common one: Installation as a Pod for containerd, Installation as Windows services, Installation as a Pod for Docker (deprecated).

The main idea is to make the installation instructions clearer and easier to follow for a "normal" user, deploying the latest Antrea version on a recent K8s cluster. In this situation, the recommended installation method is to use antrea-windows-containerd.yml or antrea-windows-containerd-with-ovs.yml, which leverage HostProcess Windows Pods.

There is still a lot of room for future improvements. I suggest that for Antrea v2.0 we drop all references to Docker and kube-proxy from this document.

The "Antrea Management on Windows" section is also dropped from the Windows design document, as it was stale information.

For #5624 #5630