### PR TITLE
Different Images for Antrea Agent and Controller

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,11 @@ jobs:
         echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         ./hack/build-antrea-linux-all.sh --pull --push-base-images
         docker tag antrea/antrea-ubuntu:latest antrea/antrea-ubuntu-amd64:latest
+        docker tag antrea/antrea-controller-ubuntu:latest antrea/antrea-controller-ubuntu-amd64:latest
+        docker tag antrea/antrea-agent-ubuntu:latest antrea/antrea-agent-ubuntu-amd64:latest
         docker push antrea/antrea-ubuntu-amd64:latest
+        docker push antrea/antrea-controller-ubuntu-amd64:latest
+        docker push antrea/antrea-agent-ubuntu-amd64:latest
     - name: Trigger Antrea arm builds and multi-arch manifest update
       if: ${{ github.repository == 'antrea-io/antrea' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       uses: benc-uk/workflow-dispatch@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,6 +85,8 @@ jobs:
         echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         ./hack/build-antrea-linux-all.sh --pull --push-base-images --distro ubi
         docker push antrea/antrea-ubi:latest
+        docker push antrea/antrea-agent-ubi:latest
+        docker push antrea/antrea-controller-ubi:latest
 
   build-scale:
     needs: check-changes

--- a/.github/workflows/build_tag.yml
+++ b/.github/workflows/build_tag.yml
@@ -65,6 +65,8 @@ jobs:
           ./hack/build-antrea-linux-all.sh --pull --distro ubi
           echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
           docker push antrea/antrea-ubi:"${VERSION}"
+          docker push antrea/antrea-agent-ubi:"${VERSION}"
+          docker push antrea/antrea-controller-ubi:"${VERSION}"
 
   build-windows:
     runs-on: [windows-2019]

--- a/.github/workflows/build_tag.yml
+++ b/.github/workflows/build_tag.yml
@@ -35,7 +35,11 @@ jobs:
         ./hack/build-antrea-linux-all.sh --pull
         echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         docker tag antrea/antrea-ubuntu:"${VERSION}" antrea/antrea-ubuntu-amd64:"${VERSION}"
+        docker tag antrea/antrea-agent-ubuntu:"${VERSION}" antrea/antrea-agent-ubuntu-amd64:"${VERSION}"
+        docker tag antrea/antrea-controller-ubuntu:"${VERSION}" antrea/antrea-controller-ubuntu-amd64:"${VERSION}"
         docker push antrea/antrea-ubuntu-amd64:"${VERSION}"
+        docker push antrea/antrea-agent-ubuntu-amd64:"${VERSION}"
+        docker push antrea/antrea-controller-ubuntu-amd64:"${VERSION}"
     - name: Trigger Antrea arm builds and multi-arch manifest update
       uses: benc-uk/workflow-dispatch@v1
       with:

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -65,7 +65,8 @@ jobs:
           sudo mv kind /usr/local/bin
       - name: Create K8s cluster
         run: |
-          # The command also loads local antrea/antrea-ubuntu:latest into Nodes if it exists.
+          # The command also loads local antrea/antrea-agent-ubuntu:latest and antrea/antrea-controller-ubuntu:latest
+          # into Nodes if it exists.
           ./ci/kind/kind-setup.sh create kind \
             --k8s-version "${{ inputs.k8s-version }}"
       - name: Install Antrea

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Create K8s cluster
         run: |
           # The command also loads local antrea/antrea-agent-ubuntu:latest and antrea/antrea-controller-ubuntu:latest
-          # into Nodes if it exists.
+          # into Nodes if they exist.
           ./ci/kind/kind-setup.sh create kind \
             --k8s-version "${{ inputs.k8s-version }}"
       - name: Install Antrea

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -41,7 +41,7 @@ jobs:
       run: |
         ./hack/build-antrea-linux-all.sh --pull --coverage
     - name: Save Antrea image to tarball
-      run:  docker save -o antrea-ubuntu.tar antrea/antrea-ubuntu-coverage:latest
+      run:  docker save -o antrea-ubuntu.tar antrea/antrea-agent-ubuntu-coverage:latest antrea/antrea-controller-ubuntu-coverage:latest
     - name: Upload Antrea image for subsequent jobs
       uses: actions/upload-artifact@v4
       with:
@@ -488,7 +488,8 @@ jobs:
     - name: Load Antrea image
       run: |
         docker load -i antrea-ubuntu.tar
-        docker tag antrea/antrea-ubuntu-coverage:latest antrea/antrea-ubuntu:latest
+        docker tag antrea/antrea-agent-ubuntu-coverage:latest antrea/antrea-agent-ubuntu:latest
+        docker tag antrea/antrea-controller-ubuntu-coverage:latest antrea/antrea-controller-ubuntu:latest
     - name: Install Kind
       run: |
         KIND_VERSION=$(head -n1 ./ci/kind/version)
@@ -533,7 +534,8 @@ jobs:
       - name: Load Antrea image
         run: |
           docker load -i antrea-ubuntu.tar
-          docker tag antrea/antrea-ubuntu-coverage:latest antrea/antrea-ubuntu:latest
+          docker tag antrea/antrea-agent-ubuntu-coverage:latest antrea/antrea-agent-ubuntu:latest
+          docker tag antrea/antrea-controller-ubuntu-coverage:latest antrea/antrea-controller-ubuntu:latest
       - name: Install Kind
         run: |
           KIND_VERSION=$(head -n1 ./ci/kind/version)
@@ -578,7 +580,8 @@ jobs:
       - name: Load Antrea image
         run: |
           docker load -i antrea-ubuntu.tar
-          docker tag antrea/antrea-ubuntu-coverage:latest antrea/antrea-ubuntu:latest
+          docker tag antrea/antrea-agent-ubuntu-coverage:latest antrea/antrea-agent-ubuntu:latest
+          docker tag antrea/antrea-controller-ubuntu-coverage:latest antrea/antrea-controller-ubuntu:latest
       - name: Install Kind
         run: |
           KIND_VERSION=$(head -n1 ./ci/kind/version)
@@ -623,7 +626,8 @@ jobs:
       - name: Load Antrea image
         run: |
           docker load -i antrea-ubuntu.tar
-          docker tag antrea/antrea-ubuntu-coverage:latest antrea/antrea-ubuntu:latest
+          docker tag antrea/antrea-agent-ubuntu-coverage:latest antrea/antrea-agent-ubuntu:latest
+          docker tag antrea/antrea-controller-ubuntu-coverage:latest antrea/antrea-controller-ubuntu:latest
       - name: Install Kind
         run: |
           KIND_VERSION=$(head -n1 ./ci/kind/version)
@@ -668,7 +672,8 @@ jobs:
       - name: Load Antrea image
         run: |
           docker load -i antrea-ubuntu.tar
-          docker tag antrea/antrea-ubuntu-coverage:latest antrea/antrea-ubuntu:latest
+          docker tag antrea/antrea-agent-ubuntu-coverage:latest antrea/antrea-agent-ubuntu:latest
+          docker tag antrea/antrea-controller-ubuntu-coverage:latest antrea/antrea-controller-ubuntu:latest
       - name: Install Kind
         run: |
           KIND_VERSION=$(head -n1 ./ci/kind/version)
@@ -710,7 +715,8 @@ jobs:
       - name: Load Antrea image
         run: |
           docker load -i antrea-ubuntu.tar
-          docker tag antrea/antrea-ubuntu-coverage:latest antrea/antrea-ubuntu:latest
+          docker tag antrea/antrea-agent-ubuntu-coverage:latest antrea/antrea-agent-ubuntu:latest
+          docker tag antrea/antrea-controller-ubuntu-coverage:latest antrea/antrea-controller-ubuntu:latest
       - name: Install Kind
         run: |
           KIND_VERSION=$(head -n1 ./ci/kind/version)

--- a/.github/workflows/trivy_scan_before_release.yml
+++ b/.github/workflows/trivy_scan_before_release.yml
@@ -14,9 +14,21 @@ jobs:
     - name: Build Antrea Docker image
       run: |
         ./hack/build-antrea-linux-all.sh --pull
-    - name: Run Trivy vulnerability scanner on Antrea Docker image
+    - name: Run Trivy vulnerability scanner on Antrea unified Docker image
       uses: aquasecurity/trivy-action@0.16.1
       with:
         scan-type: 'image'
         image-ref: 'antrea/antrea-ubuntu:latest'
+        trivy-config: '.trivy.yml'
+    - name: Run Trivy vulnerability scanner on the antrea-agent Docker image
+      uses: aquasecurity/trivy-action@0.16.1
+      with:
+        scan-type: 'image'
+        image-ref: 'antrea/antrea-agent-ubuntu:latest'
+        trivy-config: '.trivy.yml'
+    - name: Run Trivy vulnerability scanner on the antrea-controller Docker image
+      uses: aquasecurity/trivy-action@0.16.1
+      with:
+        scan-type: 'image'
+        image-ref: 'antrea/antrea-controller-ubuntu:latest'
         trivy-config: '.trivy.yml'

--- a/Makefile
+++ b/Makefile
@@ -332,6 +332,26 @@ else
 endif
 	docker tag antrea/antrea-ubuntu:$(DOCKER_IMG_VERSION) antrea/antrea-ubuntu
 
+.PHONY: build-controller-ubuntu
+build-controller-ubuntu:
+	@echo "===> Building antrea/antrea-controller-ubuntu Docker image <==="
+ifneq ($(NO_PULL),)
+	docker build -t antrea/antrea-controller-ubuntu:$(DOCKER_IMG_VERSION) -f build/images/Dockerfile.build.controller.ubuntu $(DOCKER_BUILD_ARGS) .
+else
+	docker build --pull -t antrea/antrea-controller-ubuntu:$(DOCKER_IMG_VERSION) -f build/images/Dockerfile.build.controller.ubuntu $(DOCKER_BUILD_ARGS) .
+endif
+	docker tag antrea/antrea-controller-ubuntu:$(DOCKER_IMG_VERSION) antrea/antrea-controller-ubuntu
+
+.PHONY: build-agent-ubuntu
+build-agent-ubuntu:
+	@echo "===> Building antrea/antrea-agent-ubuntu Docker image <==="
+ifneq ($(NO_PULL),)
+	docker build -t antrea/antrea-agent-ubuntu:$(DOCKER_IMG_VERSION) -f build/images/Dockerfile.build.agent.ubuntu $(DOCKER_BUILD_ARGS) .
+else
+	docker build --pull -t antrea/antrea-agent-ubuntu:$(DOCKER_IMG_VERSION) -f build/images/Dockerfile.build.agent.ubuntu $(DOCKER_BUILD_ARGS) .
+endif
+	docker tag antrea/antrea-agent-ubuntu:$(DOCKER_IMG_VERSION) antrea/antrea-agent-ubuntu
+
 # Build bins in a golang container, and build the antrea-ubuntu Docker image.
 .PHONY: build-ubuntu
 build-ubuntu:
@@ -373,6 +393,26 @@ else
 	docker build --pull -t antrea/antrea-ubuntu-coverage:$(DOCKER_IMG_VERSION) -f build/images/Dockerfile.build.coverage $(DOCKER_BUILD_ARGS) .
 endif
 	docker tag antrea/antrea-ubuntu-coverage:$(DOCKER_IMG_VERSION) antrea/antrea-ubuntu-coverage
+
+.PHONY: build-controller-ubuntu-coverage
+build-controller-ubuntu-coverage:
+	@echo "===> Building Antrea bins and antrea/antrea-controller-ubuntu-coverage Docker image <==="
+ifneq ($(NO_PULL),)
+	docker build -t antrea/antrea-controller-ubuntu-coverage:$(DOCKER_IMG_VERSION) -f build/images/Dockerfile.controller.build.coverage $(DOCKER_BUILD_ARGS) .
+else
+	docker build --pull -t antrea/antrea-controller-ubuntu-coverage:$(DOCKER_IMG_VERSION) -f build/images/Dockerfile.controller.build.coverage $(DOCKER_BUILD_ARGS) .
+endif
+	docker tag antrea/antrea-controller-ubuntu-coverage:$(DOCKER_IMG_VERSION) antrea/antrea-controller-ubuntu-coverage
+
+.PHONY: build-agent-ubuntu-coverage
+build-agent-ubuntu-coverage:
+	@echo "===> Building Antrea bins and antrea/antrea-agent-ubuntu-coverage Docker image <==="
+ifneq ($(NO_PULL),)
+	docker build -t antrea/antrea-agent-ubuntu-coverage:$(DOCKER_IMG_VERSION) -f build/images/Dockerfile.agent.build.coverage $(DOCKER_BUILD_ARGS) .
+else
+	docker build --pull -t antrea/antrea-agent-ubuntu-coverage:$(DOCKER_IMG_VERSION) -f build/images/Dockerfile.agent.build.coverage $(DOCKER_BUILD_ARGS) .
+endif
+	docker tag antrea/antrea-agent-ubuntu-coverage:$(DOCKER_IMG_VERSION) antrea/antrea-agent-ubuntu-coverage
 
 .PHONY: build-scale-simulator
 build-scale-simulator:

--- a/Makefile
+++ b/Makefile
@@ -374,6 +374,26 @@ else
 endif
 	docker tag antrea/antrea-ubi:$(DOCKER_IMG_VERSION) antrea/antrea-ubi
 
+.PHONY: build-agent-ubi
+build-agent-ubi:
+	@echo "===> Building Antrea bins and antrea/antrea-agent-ubi Docker image <==="
+ifneq ($(NO_PULL),"")
+	docker build -t antrea/antrea-agent-ubi:$(DOCKER_IMG_VERSION) -f build/images/Dockerfile.build.agent.ubi $(DOCKER_BUILD_ARGS) .
+else
+	docker build --pull -t antrea/antrea-agent-ubi:$(DOCKER_IMG_VERSION) -f build/images/Dockerfile.build.agent.ubi $(DOCKER_BUILD_ARGS) .
+endif
+	docker tag antrea/antrea-agent-ubi:$(DOCKER_IMG_VERSION) antrea/antrea-agent-ubi
+
+.PHONY: build-controller-ubi
+build-controller-ubi:
+	@echo "===> Building Antrea bins and antrea/antrea-controller-ubi Docker image <==="
+ifneq ($(NO_PULL),"")
+	docker build -t antrea/antrea-controller-ubi:$(DOCKER_IMG_VERSION) -f build/images/Dockerfile.build.controller.ubi $(DOCKER_BUILD_ARGS) .
+else
+	docker build --pull -t antrea/antrea-controller-ubi:$(DOCKER_IMG_VERSION) -f build/images/Dockerfile.build.controller.ubi $(DOCKER_BUILD_ARGS) .
+endif
+	docker tag antrea/antrea-controller-ubi:$(DOCKER_IMG_VERSION) antrea/antrea-controller-ubi
+
 .PHONY: build-windows
 build-windows:
 	@echo "===> Building Antrea bins and antrea/antrea-windows Docker image <==="

--- a/build/charts/antrea/README.md
+++ b/build/charts/antrea/README.md
@@ -52,6 +52,7 @@ Kubernetes: `>= 1.16.0-0`
 | agent.priorityClassName | string | `"system-node-critical"` | Prority class to use for the antrea-agent Pods. |
 | agent.tolerations | list | `[{"key":"CriticalAddonsOnly","operator":"Exists"},{"effect":"NoSchedule","operator":"Exists"},{"effect":"NoExecute","operator":"Exists"}]` | Tolerations for the antrea-agent Pods. |
 | agent.updateStrategy | object | `{"type":"RollingUpdate"}` | Update strategy for the antrea-agent DaemonSet. |
+| agentImage | object | `{"pullPolicy":"IfNotPresent","repository":"antrea/antrea-agent-ubuntu","tag":""}` | Container image to use for the antrea-agent component. |
 | antreaProxy.defaultLoadBalancerMode | string | `"nat"` | Determines how external traffic is processed when it's load balanced across Nodes by default. It must be one of "nat" or "dsr". |
 | antreaProxy.enable | bool | `true` | To disable AntreaProxy, set this to false. |
 | antreaProxy.nodePortAddresses | list | `[]` | String array of values which specifies the host IPv4/IPv6 addresses for NodePort. By default, all host addresses are used. |
@@ -82,6 +83,7 @@ Kubernetes: `>= 1.16.0-0`
 | controller.priorityClassName | string | `"system-cluster-critical"` | Prority class to use for the antrea-controller Pod. |
 | controller.selfSignedCert | bool | `true` | Indicates whether to use auto-generated self-signed TLS certificates. If false, a Secret named "antrea-controller-tls" must be provided with the following keys: ca.crt, tls.crt, tls.key. |
 | controller.tolerations | list | `[{"key":"CriticalAddonsOnly","operator":"Exists"},{"effect":"NoSchedule","key":"node-role.kubernetes.io/master"},{"effect":"NoSchedule","key":"node-role.kubernetes.io/control-plane"},{"effect":"NoExecute","key":"node.kubernetes.io/unreachable","operator":"Exists","tolerationSeconds":0}]` | Tolerations for the antrea-controller Pod. |
+| controllerImage | object | `{"pullPolicy":"IfNotPresent","repository":"antrea/antrea-controller-ubuntu","tag":""}` | Container image to use for the antrea-controller component. |
 | defaultMTU | int | `0` | Default MTU to use for the host gateway interface and the network interface of each Pod. By default, antrea-agent will discover the MTU of the Node's primary interface and adjust it to accommodate for tunnel encapsulation overhead if applicable. |
 | disableTXChecksumOffload | bool | `false` | Disable TX checksum offloading for container network interfaces. It's supposed to be set to true when the datapath doesn't support TX checksum offloading, which causes packets to be dropped due to bad checksum. It affects Pods running on Linux Nodes only. |
 | dnsServerOverride | string | `""` | Address of DNS server, to override the kube-dns Service. It's used to resolve hostnames in a FQDN policy. |
@@ -95,7 +97,7 @@ Kubernetes: `>= 1.16.0-0`
 | flowExporter.flowPollInterval | string | `"5s"` | Determines how often the flow exporter polls for new connections. |
 | flowExporter.idleFlowExportTimeout | string | `"15s"` | timeout after which a flow record is sent to the collector for idle flows. |
 | hostGateway | string | `"antrea-gw0"` | Name of the interface antrea-agent will create and use for host <-> Pod communication. |
-| image | object | `{"pullPolicy":"IfNotPresent","repository":"antrea/antrea-ubuntu","tag":""}` | Container image to use for Antrea components. |
+| image | object | `{}` | Container image to use for Antrea components. DEPRECATED: use agentImage and controllerImage instead. |
 | ipsec.authenticationMode | string | `"psk"` | The authentication mode to use for IPsec. Must be one of "psk" or "cert". |
 | ipsec.csrSigner.autoApprove | bool | `true` | Enable auto approval of Antrea signer for IPsec certificates. |
 | ipsec.csrSigner.selfSignedCA | bool | `true` | Whether or not to use auto-generated self-signed CA. |

--- a/build/charts/antrea/templates/_helpers.tpl
+++ b/build/charts/antrea/templates/_helpers.tpl
@@ -18,8 +18,40 @@
 {{- end }}
 {{- end -}}
 
-{{- define "antreaImage" -}}
+{{- define "antreaAgentImageTag" -}}
+{{- if .Values.agentImage.tag }}
+{{- .Values.agentImage.tag -}}
+{{- else if eq .Chart.AppVersion "latest" }}
+{{- print "latest" -}}
+{{- else }}
+{{- print "v" .Chart.AppVersion -}}
+{{- end }}
+{{- end -}}
+
+{{- define "antreaControllerImageTag" -}}
+{{- if .Values.controllerImage.tag }}
+{{- .Values.controllerImage.tag -}}
+{{- else if eq .Chart.AppVersion "latest" }}
+{{- print "latest" -}}
+{{- else }}
+{{- print "v" .Chart.AppVersion -}}
+{{- end }}
+{{- end -}}
+
+{{- define "antreaControllerImage" -}}
+{{- if .Values.image }}
 {{- print .Values.image.repository ":" (include "antreaImageTag" .) -}}
+{{- else }}
+{{- print .Values.controllerImage.repository ":" (include "antreaControllerImageTag" .) -}}
+{{- end }}
+{{- end -}}
+
+{{- define "antreaAgentImage" -}}
+{{- if .Values.image }}
+{{- print .Values.image.repository ":" (include "antreaImageTag" .) -}}
+{{- else }}
+{{- print .Values.agentImage.repository ":" (include "antreaAgentImageTag" .) -}}
+{{- end }}
 {{- end -}}
 
 {{- define "validateValues" -}}

--- a/build/charts/antrea/templates/agent/daemonset.yaml
+++ b/build/charts/antrea/templates/agent/daemonset.yaml
@@ -72,7 +72,11 @@ spec:
       {{- end }}
         - name: install-cni
           image: {{ include "antreaAgentImage" . | quote }}
+          {{- if .Values.image.pullPolicy }}
+          imagePullPolicy: {{ .Values.image }}
+          {{- else }}
           imagePullPolicy: {{ .Values.agentImage.pullPolicy }}
+          {{- end }}
           resources: {{- .Values.agent.installCNI.resources | toYaml | nindent 12 }}
           {{- if eq .Values.trafficEncapMode "networkPolicyOnly" }}
           command: ["install_cni_chaining"]
@@ -128,7 +132,11 @@ spec:
       {{- end }}
         - name: antrea-agent
           image: {{ include "antreaAgentImage" . | quote }}
+          {{- if .Values.image.pullPolicy }}
+          imagePullPolicy: {{ .Values.image }}
+          {{- else }}
           imagePullPolicy: {{ .Values.agentImage.pullPolicy }}
+          {{- end }}
           {{- if ((.Values.testing).coverage) }}
           command: ["/bin/sh"]
           args: ["-c", "sleep 2; antrea-agent-coverage -test.run=TestBincoverRunMain -test.coverprofile=antrea-agent.cov.out -args-file=/agent-arg-file; while true; do sleep 5 & wait $!; done"]
@@ -258,7 +266,11 @@ spec:
           {{- end }}
         - name: antrea-ovs
           image: {{ include "antreaAgentImage" . | quote }}
+          {{- if .Values.image.pullPolicy }}
+          imagePullPolicy: {{ .Values.image }}
+          {{- else }}
           imagePullPolicy: {{ .Values.agentImage.pullPolicy }}
+          {{- end }}
           resources: {{- .Values.agent.antreaOVS.resources | toYaml | nindent 12 }}
           command: ["start_ovs"]
           args:
@@ -314,7 +326,11 @@ spec:
         {{- if eq .Values.trafficEncryptionMode "ipsec" }}
         - name: antrea-ipsec
           image: {{ include "antreaAgentImage" . | quote }}
+          {{- if .Values.image.pullPolicy }}
+          imagePullPolicy: {{ .Values.image }}
+          {{- else }}
           imagePullPolicy: {{ .Values.agentImage.pullPolicy }}
+          {{- end }}
           resources: {{- .Values.agent.antreaIPsec.resources | toYaml | nindent 12 }}
           command: ["start_ovs_ipsec"]
           livenessProbe:

--- a/build/charts/antrea/templates/agent/daemonset.yaml
+++ b/build/charts/antrea/templates/agent/daemonset.yaml
@@ -71,8 +71,8 @@ spec:
       containers:
       {{- end }}
         - name: install-cni
-          image: {{ include "antreaImage" . | quote }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: {{ include "antreaAgentImage" . | quote }}
+          imagePullPolicy: {{ .Values.agentImage.pullPolicy }}
           resources: {{- .Values.agent.installCNI.resources | toYaml | nindent 12 }}
           {{- if eq .Values.trafficEncapMode "networkPolicyOnly" }}
           command: ["install_cni_chaining"]
@@ -127,8 +127,8 @@ spec:
       containers:
       {{- end }}
         - name: antrea-agent
-          image: {{ include "antreaImage" . | quote }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: {{ include "antreaAgentImage" . | quote }}
+          imagePullPolicy: {{ .Values.agentImage.pullPolicy }}
           {{- if ((.Values.testing).coverage) }}
           command: ["/bin/sh"]
           args: ["-c", "sleep 2; antrea-agent-coverage -test.run=TestBincoverRunMain -test.coverprofile=antrea-agent.cov.out -args-file=/agent-arg-file; while true; do sleep 5 & wait $!; done"]
@@ -257,8 +257,8 @@ spec:
           {{- toYaml . | trim | nindent 10 }}
           {{- end }}
         - name: antrea-ovs
-          image: {{ include "antreaImage" . | quote }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: {{ include "antreaAgentImage" . | quote }}
+          imagePullPolicy: {{ .Values.agentImage.pullPolicy }}
           resources: {{- .Values.agent.antreaOVS.resources | toYaml | nindent 12 }}
           command: ["start_ovs"]
           args:
@@ -313,8 +313,8 @@ spec:
             subPath: openvswitch
         {{- if eq .Values.trafficEncryptionMode "ipsec" }}
         - name: antrea-ipsec
-          image: {{ include "antreaImage" . | quote }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: {{ include "antreaAgentImage" . | quote }}
+          imagePullPolicy: {{ .Values.agentImage.pullPolicy }}
           resources: {{- .Values.agent.antreaIPsec.resources | toYaml | nindent 12 }}
           command: ["start_ovs_ipsec"]
           livenessProbe:

--- a/build/charts/antrea/templates/controller/deployment.yaml
+++ b/build/charts/antrea/templates/controller/deployment.yaml
@@ -60,8 +60,8 @@ spec:
       serviceAccountName: antrea-controller
       containers:
         - name: antrea-controller
-          image: {{ include "antreaImage" . | quote }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: {{ include "antreaControllerImage" . | quote }}
+          imagePullPolicy: {{ .Values.controllerImage.pullPolicy }}
           resources: {{- .Values.controller.antreaController.resources | toYaml | nindent 12 }}
           {{- if ((.Values.testing).coverage) }}
           command: ["/bin/sh"]

--- a/build/charts/antrea/templates/controller/deployment.yaml
+++ b/build/charts/antrea/templates/controller/deployment.yaml
@@ -61,7 +61,11 @@ spec:
       containers:
         - name: antrea-controller
           image: {{ include "antreaControllerImage" . | quote }}
+          {{- if .Values.image }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- else }}
           imagePullPolicy: {{ .Values.controllerImage.pullPolicy }}
+          {{- end }}
           resources: {{- .Values.controller.antreaController.resources | toYaml | nindent 12 }}
           {{- if ((.Values.testing).coverage) }}
           command: ["/bin/sh"]

--- a/build/charts/antrea/values.yaml
+++ b/build/charts/antrea/values.yaml
@@ -1,6 +1,14 @@
 # -- Container image to use for Antrea components.
-image:
-  repository: "antrea/antrea-ubuntu"
+# DEPRECATED: use agentImage and controllerImage instead.
+image: {}
+# -- Container image to use for the antrea-agent component.
+agentImage:
+  repository: "antrea/antrea-agent-ubuntu"
+  pullPolicy: "IfNotPresent"
+  tag: ""
+# -- Container image to use for the antrea-controller component.
+controllerImage:
+  repository: "antrea/antrea-controller-ubuntu"
   pullPolicy: "IfNotPresent"
   tag: ""
 

--- a/build/images/Dockerfile.agent.build.coverage
+++ b/build/images/Dockerfile.agent.build.coverage
@@ -1,0 +1,47 @@
+# Copyright 2024 Antrea Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG GO_VERSION
+ARG BUILD_TAG
+FROM golang:${GO_VERSION} as antrea-build
+
+WORKDIR /antrea
+
+COPY go.mod /antrea/go.mod
+
+RUN go mod download
+
+COPY . /antrea
+
+RUN make antrea-agent antrea-cni antrea-agent-instr-binary
+# Disable CGO for antctl in case it is copied outside of the container image. It
+# also reduces the size of the binary and aligns with how we distribute antctl
+# in release assets.
+RUN CGO_ENABLED=0 make antctl-linux antctl-instr-binary
+RUN mv bin/antctl-linux bin/antctl
+
+FROM antrea/base-ubuntu:${BUILD_TAG}
+
+LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
+LABEL description="The Docker image to deploy the antrea-agent with code coverage measurement enabled (used for testing)."
+
+USER root
+
+COPY build/images/scripts/* /usr/local/bin/
+COPY --from=antrea-build /antrea/bin/antrea-agent /usr/local/bin/
+COPY --from=antrea-build /antrea/bin/antrea-agent-coverage /usr/local/bin/
+COPY --from=antrea-build /antrea/bin/antrea-cni /usr/local/bin/
+COPY --from=antrea-build /antrea/bin/antctl /usr/local/bin/
+COPY --from=antrea-build /antrea/bin/antctl-coverage /usr/local/bin/
+COPY --from=antrea-build /antrea/test/e2e/coverage/agent-arg-file /

--- a/build/images/Dockerfile.build.agent.ubi
+++ b/build/images/Dockerfile.build.agent.ubi
@@ -1,0 +1,65 @@
+# Copyright 2024 Antrea Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG BUILD_TAG
+FROM registry.access.redhat.com/ubi8 as antrea-build
+
+ADD https://go.dev/dl/?mode=json&include=all go-versions.json
+
+RUN yum install ca-certificates gcc git jq make wget -y
+
+ARG GO_VERSION
+
+# GO_VERSION is a Go minor version, we use the downloaded go-versions.json file
+# to identify and install the latest patch release for this minor version.
+RUN set -eux; \
+    arch="$(uname -m)"; \
+    case "${arch##*-}" in \
+         x86_64) goArch='amd64' ;; \
+         arm) goArch='armv6l' ;; \
+         aarch64) goArch='arm64' ;; \
+         *) goArch=''; echo >&2; echo >&2 "unsupported architecture '$arch'"; echo >&2 ; exit 1 ;; \
+    esac; \
+    GO_ARCHIVE=$(jq --arg version_prefix "go${GO_VERSION}." --arg arch "$goArch" -r '. | map(select(. | .version | startswith($version_prefix))) | first | .files[] | select(.os == "linux" and .arch == $arch and .kind == "archive").filename' go-versions.json); \
+    wget -q -O - https://go.dev/dl/${GO_ARCHIVE} | tar xz -C /usr/local/
+
+# Using ENV makes the change persistent, but this is just a builder image.
+ENV PATH /usr/local/go/bin:$PATH
+
+WORKDIR /antrea
+
+COPY go.mod /antrea/go.mod
+
+RUN go mod download
+
+COPY . /antrea
+
+RUN make antrea-agent antrea-cni
+# Disable CGO for antctl in case it is copied outside of the container image. It
+# also reduces the size of the binary and aligns with how we distribute antctl
+# in release assets.
+RUN CGO_ENABLED=0 make antctl-linux
+RUN mv bin/antctl-linux bin/antctl
+
+FROM antrea/base-ubi:${BUILD_TAG}
+
+LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
+LABEL description="The Docker image to deploy the antrea-agent."
+
+USER root
+
+COPY build/images/scripts/* /usr/local/bin/
+COPY --from=antrea-build /antrea/bin/antrea-agent /usr/local/bin/
+COPY --from=antrea-build /antrea/bin/antrea-cni /usr/local/bin/
+COPY --from=antrea-build /antrea/bin/antctl /usr/local/bin/

--- a/build/images/Dockerfile.build.agent.ubuntu
+++ b/build/images/Dockerfile.build.agent.ubuntu
@@ -1,0 +1,44 @@
+# Copyright 2024 Antrea Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG GO_VERSION
+ARG BUILD_TAG
+FROM golang:${GO_VERSION} as antrea-build
+
+WORKDIR /antrea
+
+COPY go.mod /antrea/go.mod
+
+RUN go mod download
+
+COPY . /antrea
+
+RUN make antrea-agent antrea-cni
+# Disable CGO for antctl in case it is copied outside of the container image. It
+# also reduces the size of the binary and aligns with how we distribute antctl
+# in release assets.
+RUN CGO_ENABLED=0 make antctl-linux
+RUN mv bin/antctl-linux bin/antctl
+
+FROM antrea/base-ubuntu:${BUILD_TAG}
+
+LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
+LABEL description="The Docker image to deploy the antrea-agent."
+
+USER root
+
+COPY build/images/scripts/* /usr/local/bin/
+COPY --from=antrea-build /antrea/bin/antrea-agent /usr/local/bin/
+COPY --from=antrea-build /antrea/bin/antrea-cni /usr/local/bin/
+COPY --from=antrea-build /antrea/bin/antctl /usr/local/bin/

--- a/build/images/Dockerfile.build.controller.ubi
+++ b/build/images/Dockerfile.build.controller.ubi
@@ -1,0 +1,63 @@
+# Copyright 2024 Antrea Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG BUILD_TAG
+FROM registry.access.redhat.com/ubi8 as antrea-build
+
+ADD https://go.dev/dl/?mode=json&include=all go-versions.json
+
+RUN yum install ca-certificates gcc git jq make wget -y
+
+ARG GO_VERSION
+
+# GO_VERSION is a Go minor version, we use the downloaded go-versions.json file
+# to identify and install the latest patch release for this minor version.
+RUN set -eux; \
+    arch="$(uname -m)"; \
+    case "${arch##*-}" in \
+         x86_64) goArch='amd64' ;; \
+         arm) goArch='armv6l' ;; \
+         aarch64) goArch='arm64' ;; \
+         *) goArch=''; echo >&2; echo >&2 "unsupported architecture '$arch'"; echo >&2 ; exit 1 ;; \
+    esac; \
+    GO_ARCHIVE=$(jq --arg version_prefix "go${GO_VERSION}." --arg arch "$goArch" -r '. | map(select(. | .version | startswith($version_prefix))) | first | .files[] | select(.os == "linux" and .arch == $arch and .kind == "archive").filename' go-versions.json); \
+    wget -q -O - https://go.dev/dl/${GO_ARCHIVE} | tar xz -C /usr/local/
+
+# Using ENV makes the change persistent, but this is just a builder image.
+ENV PATH /usr/local/go/bin:$PATH
+
+WORKDIR /antrea
+
+COPY go.mod /antrea/go.mod
+
+RUN go mod download
+
+COPY . /antrea
+
+RUN make antrea-controller
+# Disable CGO for antctl in case it is copied outside of the container image. It
+# also reduces the size of the binary and aligns with how we distribute antctl
+# in release assets.
+RUN CGO_ENABLED=0 make antctl-linux
+RUN mv bin/antctl-linux bin/antctl
+
+FROM ubuntu:22.04
+
+LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
+LABEL description="The Docker image to deploy the antrea-controller."
+
+USER root
+
+COPY --from=antrea-build /antrea/bin/antctl /usr/local/bin/
+COPY --from=antrea-build /antrea/bin/antrea-controller /usr/local/bin/

--- a/build/images/Dockerfile.build.controller.ubuntu
+++ b/build/images/Dockerfile.build.controller.ubuntu
@@ -1,0 +1,42 @@
+# Copyright 2024 Antrea Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG GO_VERSION
+ARG BUILD_TAG
+FROM golang:${GO_VERSION} as antrea-build
+
+WORKDIR /antrea
+
+COPY go.mod /antrea/go.mod
+
+RUN go mod download
+
+COPY . /antrea
+
+RUN make antrea-controller
+# Disable CGO for antctl in case it is copied outside of the container image. It
+# also reduces the size of the binary and aligns with how we distribute antctl
+# in release assets.
+RUN CGO_ENABLED=0 make antctl-linux
+RUN mv bin/antctl-linux bin/antctl
+
+FROM ubuntu:22.04
+
+LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
+LABEL description="The Docker image to deploy the antrea-controller."
+
+USER root
+
+COPY --from=antrea-build /antrea/bin/antctl /usr/local/bin/
+COPY --from=antrea-build /antrea/bin/antrea-controller /usr/local/bin/

--- a/build/images/Dockerfile.controller.build.coverage
+++ b/build/images/Dockerfile.controller.build.coverage
@@ -1,0 +1,45 @@
+# Copyright 2024 Antrea Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG GO_VERSION
+ARG BUILD_TAG
+FROM golang:${GO_VERSION} as antrea-build
+
+WORKDIR /antrea
+
+COPY go.mod /antrea/go.mod
+
+RUN go mod download
+
+COPY . /antrea
+
+RUN make antrea-controller antrea-controller-instr-binary
+# Disable CGO for antctl in case it is copied outside of the container image. It
+# also reduces the size of the binary and aligns with how we distribute antctl
+# in release assets.
+RUN CGO_ENABLED=0 make antctl-linux antctl-instr-binary
+RUN mv bin/antctl-linux bin/antctl
+
+FROM ubuntu:22.04
+
+LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
+LABEL description="The Docker image to deploy the antrea-controller with code coverage measurement enabled (used for testing)."
+
+USER root
+
+COPY --from=antrea-build /antrea/bin/antrea-controller /usr/local/bin/
+COPY --from=antrea-build /antrea/bin/antctl /usr/local/bin/
+COPY --from=antrea-build /antrea/bin/antrea-controller-coverage /usr/local/bin/
+COPY --from=antrea-build /antrea/bin/antctl-coverage /usr/local/bin/
+COPY --from=antrea-build /antrea/test/e2e/coverage/controller-arg-file /

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -6949,7 +6949,7 @@ spec:
       initContainers:
       containers:
         - name: install-cni
-          image: "antrea/antrea-ubuntu:latest"
+          image: "antrea/antrea-agent-ubuntu:latest"
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -6982,7 +6982,7 @@ spec:
           - name: host-var-run-antrea
             mountPath: /var/run/antrea
         - name: antrea-agent
-          image: "antrea/antrea-ubuntu:latest"
+          image: "antrea/antrea-agent-ubuntu:latest"
           imagePullPolicy: IfNotPresent
           command: ["antrea-agent"]
           # Log to both "/var/log/antrea/" and stderr (so "kubectl logs" can work).-
@@ -7073,7 +7073,7 @@ spec:
           - name: xtables-lock
             mountPath: /run/xtables.lock
         - name: antrea-ovs
-          image: "antrea/antrea-ubuntu:latest"
+          image: "antrea/antrea-agent-ubuntu:latest"
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -7189,7 +7189,7 @@ spec:
       serviceAccountName: antrea-controller
       containers:
         - name: antrea-controller
-          image: "antrea/antrea-ubuntu:latest"
+          image: "antrea/antrea-controller-ubuntu:latest"
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -6948,7 +6948,7 @@ spec:
       initContainers:
       containers:
         - name: install-cni
-          image: "antrea/antrea-ubuntu:latest"
+          image: "antrea/antrea-agent-ubuntu:latest"
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -6981,7 +6981,7 @@ spec:
           - name: host-var-run-antrea
             mountPath: /var/run/antrea
         - name: antrea-agent
-          image: "antrea/antrea-ubuntu:latest"
+          image: "antrea/antrea-agent-ubuntu:latest"
           imagePullPolicy: IfNotPresent
           command: ["antrea-agent"]
           # Log to both "/var/log/antrea/" and stderr (so "kubectl logs" can work).-
@@ -7074,7 +7074,7 @@ spec:
           - name: xtables-lock
             mountPath: /run/xtables.lock
         - name: antrea-ovs
-          image: "antrea/antrea-ubuntu:latest"
+          image: "antrea/antrea-agent-ubuntu:latest"
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -7190,7 +7190,7 @@ spec:
       serviceAccountName: antrea-controller
       containers:
         - name: antrea-controller
-          image: "antrea/antrea-ubuntu:latest"
+          image: "antrea/antrea-controller-ubuntu:latest"
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -6947,7 +6947,7 @@ spec:
       serviceAccountName: antrea-agent
       initContainers:
         - name: install-cni
-          image: "antrea/antrea-ubuntu:latest"
+          image: "antrea/antrea-agent-ubuntu:latest"
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -6980,7 +6980,7 @@ spec:
             mountPath: /var/run/antrea
       containers:
         - name: antrea-agent
-          image: "antrea/antrea-ubuntu:latest"
+          image: "antrea/antrea-agent-ubuntu:latest"
           imagePullPolicy: IfNotPresent
           command: ["antrea-agent"]
           # Log to both "/var/log/antrea/" and stderr (so "kubectl logs" can work).-
@@ -7071,7 +7071,7 @@ spec:
           - name: xtables-lock
             mountPath: /run/xtables.lock
         - name: antrea-ovs
-          image: "antrea/antrea-ubuntu:latest"
+          image: "antrea/antrea-agent-ubuntu:latest"
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -7187,7 +7187,7 @@ spec:
       serviceAccountName: antrea-controller
       containers:
         - name: antrea-controller
-          image: "antrea/antrea-ubuntu:latest"
+          image: "antrea/antrea-controller-ubuntu:latest"
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -6961,7 +6961,7 @@ spec:
       serviceAccountName: antrea-agent
       initContainers:
         - name: install-cni
-          image: "antrea/antrea-ubuntu:latest"
+          image: "antrea/antrea-agent-ubuntu:latest"
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -6994,7 +6994,7 @@ spec:
             mountPath: /var/run/antrea
       containers:
         - name: antrea-agent
-          image: "antrea/antrea-ubuntu:latest"
+          image: "antrea/antrea-agent-ubuntu:latest"
           imagePullPolicy: IfNotPresent
           command: ["antrea-agent"]
           # Log to both "/var/log/antrea/" and stderr (so "kubectl logs" can work).-
@@ -7094,7 +7094,7 @@ spec:
           - name: xtables-lock
             mountPath: /run/xtables.lock
         - name: antrea-ovs
-          image: "antrea/antrea-ubuntu:latest"
+          image: "antrea/antrea-agent-ubuntu:latest"
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -7130,7 +7130,7 @@ spec:
             mountPath: /var/log/openvswitch
             subPath: openvswitch
         - name: antrea-ipsec
-          image: "antrea/antrea-ubuntu:latest"
+          image: "antrea/antrea-agent-ubuntu:latest"
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -7246,7 +7246,7 @@ spec:
       serviceAccountName: antrea-controller
       containers:
         - name: antrea-controller
-          image: "antrea/antrea-ubuntu:latest"
+          image: "antrea/antrea-controller-ubuntu:latest"
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -6947,7 +6947,7 @@ spec:
       serviceAccountName: antrea-agent
       initContainers:
         - name: install-cni
-          image: "antrea/antrea-ubuntu:latest"
+          image: "antrea/antrea-agent-ubuntu:latest"
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -6980,7 +6980,7 @@ spec:
             mountPath: /var/run/antrea
       containers:
         - name: antrea-agent
-          image: "antrea/antrea-ubuntu:latest"
+          image: "antrea/antrea-agent-ubuntu:latest"
           imagePullPolicy: IfNotPresent
           command: ["antrea-agent"]
           # Log to both "/var/log/antrea/" and stderr (so "kubectl logs" can work).-
@@ -7071,7 +7071,7 @@ spec:
           - name: xtables-lock
             mountPath: /run/xtables.lock
         - name: antrea-ovs
-          image: "antrea/antrea-ubuntu:latest"
+          image: "antrea/antrea-agent-ubuntu:latest"
           imagePullPolicy: IfNotPresent
           resources:
             requests:
@@ -7187,7 +7187,7 @@ spec:
       serviceAccountName: antrea-controller
       containers:
         - name: antrea-controller
-          image: "antrea/antrea-ubuntu:latest"
+          image: "antrea/antrea-controller-ubuntu:latest"
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/ci/jenkins/mellanox/scripts/start_ci.sh
+++ b/ci/jenkins/mellanox/scripts/start_ci.sh
@@ -27,6 +27,8 @@ export ANTREA_CNI_REPO=${ANTREA_CNI_REPO:-'https://github.com/antrea-io/antrea.g
 export ANTREA_CNI_BRANCH=${ANTREA_CNI_BRANCH:-''}
 export ANTREA_CNI_PR=${ANTREA_CNI_PR:-''}
 export ANTREA_CNI_HARBOR_IMAGE=${ANTREA_CNI_HARBOR_IMAGE:-${HARBOR_REGISTRY}/${HARBOR_PROJECT}/antrea}
+export ANTREA_AGENT_CNI_HARBOR_IMAGE=${ANTREA_AGENT_CNI_HARBOR_IMAGE:-${HARBOR_REGISTRY}/${HARBOR_PROJECT}/antrea-agent-ubuntu}
+export ANTREA_CONTROLLER_CNI_HARBOR_IMAGE=${ANTREA_CONTROLLER_CNI_HARBOR_IMAGE:-${HARBOR_REGISTRY}/${HARBOR_PROJECT}/antrea-controller-ubuntu}
 
 export GOPATH=${WORKSPACE}
 export PATH=/usr/local/go/bin/:$GOPATH/src/k8s.io/kubernetes/third_party/etcd:$PATH
@@ -110,8 +112,10 @@ EOF
     fi
 
     sudo docker tag antrea/antrea-ubuntu "$ANTREA_CNI_HARBOR_IMAGE"
+    sudo docker tag antrea/antrea-agent-ubuntu "$ANTREA_AGENT_CNI_HARBOR_IMAGE"
+    sudo docker tag antrea/antrea-controller-ubuntu "$ANTREA_CONTROLLER_CNI_HARBOR_IMAGE"
 
-    IMG_NAME="$ANTREA_CNI_HARBOR_IMAGE" bash $WORKSPACE/antrea-cni/hack/generate-manifest.sh --hw-offload > $ARTIFACTS/antrea.yml
+    AGENT_IMAGE="$ANTREA_AGENT_CNI_HARBOR_IMAGE" CONTROLLER_IMAGE="$ANTREA_CONTROLLER_CNI_HARBOR_IMAGE" bash $WORKSPACE/antrea-cni/hack/generate-manifest.sh --hw-offload > $ARTIFACTS/antrea.yml
     let status=status+$?
     if [ "$status" != 0 ]; then
         echo "ERROR: Failed to generate antrea manifest!"

--- a/ci/jenkins/test-mc.sh
+++ b/ci/jenkins/test-mc.sh
@@ -298,12 +298,13 @@ function deliver_antrea_multicluster {
 
     DOCKER_REGISTRY="${DOCKER_REGISTRY}" ./hack/build-antrea-linux-all.sh --pull
     echo "====== Delivering Antrea to all Nodes ======"
-    docker save -o ${WORKDIR}/antrea-ubuntu.tar antrea/antrea-ubuntu:latest
+    docker save -o ${WORKDIR}/antrea-ubuntu.tar antrea/antrea-agent-ubuntu:latest antrea/antrea-controller-ubuntu:latest
 
 
     if [[ ${KIND} == "true" ]]; then
         for name in ${CLUSTER_NAMES[*]}; do
-            kind load docker-image antrea/antrea-ubuntu:latest --name ${name}
+            kind load docker-image antrea/antrea-agent-ubuntu:latest --name ${name}
+            kind load docker-image antrea/antrea-controller-ubuntu:latest --name ${name}
         done
     else
         for kubeconfig in "${multicluster_kubeconfigs[@]}"

--- a/ci/jenkins/test-rancher.sh
+++ b/ci/jenkins/test-rancher.sh
@@ -155,7 +155,7 @@ function deliver_antrea {
     scp -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i "${WORKDIR}/.ssh/id_rsa" build/yamls/*.yml ubuntu@[${control_plane_ip}]:~/
 
     echo "====== Delivering Antrea to all the Nodes ======"
-    docker save -o antrea-ubuntu.tar antrea/antrea-ubuntu:latest
+    docker save -o antrea-ubuntu.tar antrea/antrea-agent-ubuntu:latest antrea/antrea-controller-ubuntu:latest
     docker save -o flow-aggregator.tar antrea/flow-aggregator:latest
     kubectl get nodes -o wide --no-headers=true | awk '{print $6}' | while read IP; do
         rsync -avr --progress --inplace -e "ssh -o StrictHostKeyChecking=no" antrea-ubuntu.tar ubuntu@[${IP}]:~/antrea-ubuntu.tar

--- a/ci/jenkins/test-vm.sh
+++ b/ci/jenkins/test-vm.sh
@@ -142,7 +142,7 @@ function apply_antrea {
         fi
     fi
     TEMP_ANTREA_TAR="antrea-image.tar"
-    docker save antrea/antrea-ubuntu:latest -o $TEMP_ANTREA_TAR
+    docker save antrea/antrea-agent-ubuntu:latest antrea/antrea-controller-ubuntu:latest -o $TEMP_ANTREA_TAR
     ctr -n k8s.io image import $TEMP_ANTREA_TAR
     rm $TEMP_ANTREA_TAR
     echo "====== Applying Antrea yaml ======"

--- a/ci/jenkins/test.sh
+++ b/ci/jenkins/test.sh
@@ -400,7 +400,7 @@ function deliver_antrea_linux {
     fi
 
     cp -f build/yamls/*.yml $WORKDIR
-    docker save -o antrea-ubuntu.tar antrea/antrea-ubuntu:latest
+    docker save -o antrea-ubuntu.tar antrea/antrea-agent-ubuntu:latest antrea/antrea-controller-ubuntu:latest
 
     echo "===== Pull necessary images on Control-Plane node ====="
     harbor_images=("agnhost:2.13" "nginx:1.15-alpine")
@@ -581,7 +581,7 @@ function deliver_antrea_linux_containerd {
 
     echo "==== Start building and delivering Linux containerd images ===="
     DOCKER_REGISTRY="${DOCKER_REGISTRY}" ./hack/build-antrea-linux-all.sh --pull
-    docker save -o antrea-ubuntu.tar antrea/antrea-ubuntu:latest
+    docker save -o antrea-ubuntu.tar antrea/antrea-agent-ubuntu:latest antrea/antrea-controller-ubuntu:latest
     echo "===== Pull necessary images on Control-Plane node ====="
     harbor_images=("agnhost:2.13" "nginx:1.15-alpine")
     antrea_images=("e2eteam/agnhost:2.13" "docker.io/library/nginx:1.15-alpine")
@@ -740,7 +740,7 @@ function deliver_antrea {
     cp -f build/yamls/*.yml $WORKDIR
 
     echo "====== Delivering Antrea to all Nodes ======"
-    docker save -o antrea-ubuntu.tar antrea/antrea-ubuntu:latest
+    docker save -o antrea-ubuntu.tar antrea/antrea-agent-ubuntu:latest antrea/antrea-controller-ubuntu:latest
     docker save -o flow-aggregator.tar antrea/flow-aggregator:latest
 
     if [[ $TESTBED_TYPE == "flexible-ipam" ]]; then
@@ -750,7 +750,8 @@ function deliver_antrea {
             ssh -o StrictHostKeyChecking=no -i "${WORKDIR}/jenkins_id_rsa" -n jenkins@${IP} "${CLEAN_STALE_IMAGES_CONTAINERD}; ${PRINT_CONTAINERD_STATUS}; ctr -n=k8s.io images import ${DEFAULT_WORKDIR}/antrea-ubuntu.tar; ctr -n=k8s.io images import ${DEFAULT_WORKDIR}/flow-aggregator.tar" || true
         done
     elif [[ $TESTBED_TYPE == "kind" ]]; then
-            kind load docker-image antrea/antrea-ubuntu:latest --name ${KIND_CLUSTER}
+            kind load docker-image antrea/antrea-agent-ubuntu:latest --name ${KIND_CLUSTER}
+            kind load docker-image antrea/antrea-controller-ubuntu:latest --name ${KIND_CLUSTER}
             kind load docker-image antrea/flow-aggregator:latest --name ${KIND_CLUSTER}
     elif [[ $TESTBED_TYPE == "jumper" ]]; then
         kubectl get nodes -o wide --no-headers=true | awk '{print $6}' | while read IP; do

--- a/ci/kind/kind-setup.sh
+++ b/ci/kind/kind-setup.sh
@@ -19,8 +19,8 @@
 # and docker bridge network connecting to worker Node.
 
 CLUSTER_NAME=""
-ANTREA_IMAGE="antrea/antrea-ubuntu:latest"
-IMAGES=$ANTREA_IMAGE
+ANTREA_IMAGES="antrea/antrea-agent-ubuntu:latest antrea/antrea-controller-ubuntu:latest"
+IMAGES=$ANTREA_IMAGES
 ANTREA_CNI=false
 ACTION=""
 UNTIL_TIME_IN_MINS=""

--- a/ci/kind/test-e2e-kind.sh
+++ b/ci/kind/test-e2e-kind.sh
@@ -235,9 +235,11 @@ done
 # The Antrea images should not be pulled, as we want to use the local build.
 if $coverage; then
     manifest_args="$manifest_args --coverage"
-    COMMON_IMAGES_LIST+=("antrea/antrea-ubuntu-coverage:latest")
+    COMMON_IMAGES_LIST+=("antrea/antrea-agent-ubuntu-coverage:latest" \
+                         "antrea/antrea-controller-ubuntu-coverage:latest")
 else
-    COMMON_IMAGES_LIST+=("antrea/antrea-ubuntu:latest")
+    COMMON_IMAGES_LIST+=("antrea/antrea-agent-ubuntu:latest" \
+                         "antrea/antrea-controller-ubuntu:latest")
 fi
 if $flow_visibility; then
     if $coverage; then

--- a/ci/kind/test-netpol-v2-conformance-kind.sh
+++ b/ci/kind/test-netpol-v2-conformance-kind.sh
@@ -106,7 +106,8 @@ if [ -n "$feature_gates" ]; then
 fi
 
 IMAGE_LIST=("registry.k8s.io/e2e-test-images/agnhost:2.43" \
-            "antrea/antrea-ubuntu:latest")
+            "antrea/antrea-agent-ubuntu:latest" \
+            "antrea/antrea-controller-ubuntu:latest")
 
 printf -v IMAGES "%s " "${IMAGE_LIST[@]}"
 

--- a/ci/kind/test-upgrade-antrea.sh
+++ b/ci/kind/test-upgrade-antrea.sh
@@ -158,7 +158,8 @@ for img in "${DOCKER_IMAGES[@]}"; do
     done
 done
 
-DOCKER_IMAGES+=("antrea/antrea-ubuntu:latest")
+DOCKER_IMAGES+=("antrea/antrea-agent-ubuntu:latest" \
+                "antrea/antrea-controller-ubuntu:latest")
 
 echo "Creating Kind cluster"
 IMAGES="${DOCKER_IMAGES[@]}"

--- a/ci/test-conformance-aks.sh
+++ b/ci/test-conformance-aks.sh
@@ -206,8 +206,9 @@ function deliver_antrea_to_aks() {
 
     antrea_image="antrea-ubuntu"
     DOCKER_IMG_VERSION=${CLUSTER}
-    DOCKER_IMG_NAME="antrea/antrea-ubuntu"
-    docker save -o ${antrea_image}.tar ${DOCKER_IMG_NAME}:${DOCKER_IMG_VERSION}
+    DOCKER_AGENT_IMG_NAME="antrea/antrea-agent-ubuntu"
+    DOCKER_CONTROLLER_IMG_NAME="antrea/antrea-controller-ubuntu"
+    docker save -o ${antrea_image}.tar ${DOCKER_AGENT_IMG_NAME}:${DOCKER_IMG_VERSION} ${DOCKER_CONTROLLER_IMG_NAME}:${DOCKER_IMG_VERSION}
 
     CLUSTER_RESOURCE_GROUP=$(az aks show --resource-group ${RESOURCE_GROUP} --name ${CLUSTER} --query nodeResourceGroup -o tsv)
     SCALE_SET_NAME=$(az vmss list --resource-group ${CLUSTER_RESOURCE_GROUP} --query [0].name -o tsv)
@@ -222,7 +223,8 @@ function deliver_antrea_to_aks() {
 
     for IP in ${NODE_IPS}; do
         scp -o StrictHostKeyChecking=no -i ${SSH_PRIVATE_KEY_PATH} ${antrea_image}.tar azureuser@${IP}:~
-        ssh -o StrictHostKeyChecking=no -i ${SSH_PRIVATE_KEY_PATH} -n azureuser@${IP} "sudo ctr -n=k8s.io images import ~/${antrea_image}.tar ; sudo ctr -n=k8s.io images tag docker.io/${DOCKER_IMG_NAME}:${DOCKER_IMG_VERSION} docker.io/${DOCKER_IMG_NAME}:latest"
+        ssh -o StrictHostKeyChecking=no -i ${SSH_PRIVATE_KEY_PATH} -n azureuser@${IP} "sudo ctr -n=k8s.io images import ~/${antrea_image}.tar ; sudo ctr -n=k8s.io images tag docker.io/${DOCKER_AGENT_IMG_NAME}:${DOCKER_IMG_VERSION} docker.io/${DOCKER_AGENT_IMG_NAME}:latest"
+        ssh -o StrictHostKeyChecking=no -i ${SSH_PRIVATE_KEY_PATH} -n azureuser@${IP} "sudo ctr -n=k8s.io images tag docker.io/${DOCKER_CONTROLLER_IMG_NAME}:${DOCKER_IMG_VERSION} docker.io/${DOCKER_CONTROLLER_IMG_NAME}:latest"
     done
     rm ${antrea_image}.tar
 

--- a/ci/test-conformance-eks.sh
+++ b/ci/test-conformance-eks.sh
@@ -282,12 +282,14 @@ function deliver_antrea_to_eks() {
     echo "=== Loading the Antrea image to each Node ==="
     antrea_image="antrea-ubuntu"
     DOCKER_IMG_VERSION=${CLUSTER}
-    DOCKER_IMG_NAME="antrea/antrea-ubuntu"
-    docker save -o ${antrea_image}.tar ${DOCKER_IMG_NAME}:${DOCKER_IMG_VERSION}
+    DOCKER_AGENT_IMG_NAME="antrea/antrea-agent-ubuntu"
+    DOCKER_CONTROLLER_IMG_NAME="antrea/antrea-controller-ubuntu"
+    docker save -o ${antrea_image}.tar ${DOCKER_AGENT_IMG_NAME}:${DOCKER_IMG_VERSION} ${DOCKER_CONTROLLER_IMG_NAME}:${DOCKER_IMG_VERSION}
 
     kubectl get nodes -o wide --no-headers=true | awk '{print $7}' | while read IP; do
         scp -o StrictHostKeyChecking=no -i ${SSH_PRIVATE_KEY_PATH} ${antrea_image}.tar ec2-user@${IP}:~
-        ssh -o StrictHostKeyChecking=no -i ${SSH_PRIVATE_KEY_PATH} -n ec2-user@${IP} "sudo ctr -n=k8s.io images import ~/${antrea_image}.tar ; sudo ctr -n=k8s.io images tag docker.io/${DOCKER_IMG_NAME}:${DOCKER_IMG_VERSION} docker.io/${DOCKER_IMG_NAME}:latest --force"
+        ssh -o StrictHostKeyChecking=no -i ${SSH_PRIVATE_KEY_PATH} -n ec2-user@${IP} "sudo ctr -n=k8s.io images import ~/${antrea_image}.tar ; sudo ctr -n=k8s.io images tag docker.io/${DOCKER_AGENT_IMG_NAME}:${DOCKER_IMG_VERSION} docker.io/${DOCKER_AGENT_IMG_NAME}:latest --force"
+        ssh -o StrictHostKeyChecking=no -i ${SSH_PRIVATE_KEY_PATH} -n ec2-user@${IP} "sudo ctr -n=k8s.io images tag docker.io/${DOCKER_CONTROLLER_IMG_NAME}:${DOCKER_IMG_VERSION} docker.io/${DOCKER_CONTROLLER_IMG_NAME}:latest --force"
     done
     rm ${antrea_image}.tar
 

--- a/ci/test-conformance-gke.sh
+++ b/ci/test-conformance-gke.sh
@@ -223,13 +223,15 @@ function deliver_antrea_to_gke() {
     echo "=== Loading the Antrea image to each Node ==="
     antrea_image="antrea-ubuntu"
     DOCKER_IMG_VERSION=${CLUSTER}
-    DOCKER_IMG_NAME="antrea/antrea-ubuntu"
-    docker save -o ${antrea_image}.tar ${DOCKER_IMG_NAME}:${DOCKER_IMG_VERSION}
+    DOCKER_AGENT_IMG_NAME="antrea/antrea-agent-ubuntu"
+    DOCKER_CONTROLLER_IMG_NAME="antrea/antrea-controller-ubuntu"
+    docker save -o ${antrea_image}.tar ${DOCKER_AGENT_IMG_NAME}:${DOCKER_IMG_VERSION} ${DOCKER_CONTROLLER_IMG_NAME}:${DOCKER_IMG_VERSION}
 
     node_names=$(kubectl get nodes -o wide --no-headers=true | awk '{print $1}')
     for node_name in ${node_names}; do
         gcloud compute scp ${antrea_image}.tar ubuntu@${node_name}:~ --zone ${GKE_ZONE}
-        gcloud compute ssh ubuntu@${node_name} --command="sudo ctr -n=k8s.io images import ~/${antrea_image}.tar ; sudo ctr -n=k8s.io images tag docker.io/${DOCKER_IMG_NAME}:${DOCKER_IMG_VERSION} docker.io/${DOCKER_IMG_NAME}:latest" --zone ${GKE_ZONE}
+        gcloud compute ssh ubuntu@${node_name} --command="sudo ctr -n=k8s.io images import ~/${antrea_image}.tar ; sudo ctr -n=k8s.io images tag docker.io/${DOCKER_AGENT_IMG_NAME}:${DOCKER_IMG_VERSION} docker.io/${DOCKER_AGENT_IMG_NAME}:latest" --zone ${GKE_ZONE}
+        gcloud compute ssh ubuntu@${node_name} --command="sudo ctr -n=k8s.io images tag docker.io/${DOCKER_CONTROLLER_IMG_NAME}:${DOCKER_IMG_VERSION} docker.io/${DOCKER_CONTROLLER_IMG_NAME}:latest" --zone ${GKE_ZONE}
     done
     rm ${antrea_image}.tar
 

--- a/hack/build-antrea-linux-all.sh
+++ b/hack/build-antrea-linux-all.sh
@@ -161,8 +161,12 @@ cd -
 export NO_PULL=1
 if [ "$DISTRO" == "ubuntu" ]; then
     if $COVERAGE; then
+        make build-controller-ubuntu-coverage
+        make build-agent-ubuntu-coverage
         make build-ubuntu-coverage
     else
+        make build-controller-ubuntu
+        make build-agent-ubuntu
         make
     fi
 elif [ "$DISTRO" == "ubi" ]; then

--- a/hack/build-antrea-linux-all.sh
+++ b/hack/build-antrea-linux-all.sh
@@ -28,7 +28,8 @@ all Dockerfiles.
         --push-base-images      Push built images to the registry. Only base images will be pushed.
         --coverage              Build the image with support for code coverage.
         --platform <PLATFORM>   Target platform for the images if server is multi-platform capable.
-        --distro <distro>       Target Linux distribution."
+        --distro <distro>       Target Linux distribution.
+        --skip-unified-image    Skips building the Antrea unified image."
 
 function print_usage {
     echoerr "$_usage"
@@ -39,6 +40,7 @@ PUSH=false
 COVERAGE=false
 PLATFORM=""
 DISTRO="ubuntu"
+UNIFIED=true
 
 while [[ $# -gt 0 ]]
 do
@@ -63,6 +65,10 @@ case $key in
     ;;
     --distro)
     DISTRO="$2"
+    shift 2
+    ;;
+    --skip-unified-image)
+    UNIFIED=false
     shift 2
     ;;
     -h|--help)
@@ -163,14 +169,22 @@ if [ "$DISTRO" == "ubuntu" ]; then
     if $COVERAGE; then
         make build-controller-ubuntu-coverage
         make build-agent-ubuntu-coverage
-        make build-ubuntu-coverage
+        if $UNIFIED; then
+            make build-ubuntu-coverage
+        fi
     else
         make build-controller-ubuntu
         make build-agent-ubuntu
-        make
+        if $UNIFIED; then
+            make
+        fi
     fi
 elif [ "$DISTRO" == "ubi" ]; then
-    make build-ubi
+    make build-controller-ubi
+    make build-agent-ubi
+    if $UNIFIED; then
+        make build-ubi
+    fi
 fi
 
 popd > /dev/null

--- a/hack/externalnode/install-vm.sh
+++ b/hack/externalnode/install-vm.sh
@@ -58,7 +58,7 @@ ANTREA_AGENT_ANTREA_KUBECONFIG="antrea-agent.antrea.kubeconfig"
 
 # Docker variables
 ANTREA_VERSION="latest"
-ANTREA_DOCKER_REGISTRY="antrea/antrea-ubuntu"
+ANTREA_DOCKER_REGISTRY="antrea/antrea-agent-ubuntu"
 ANTREA_DOCKER_IMAGE="${ANTREA_DOCKER_REGISTRY}:${ANTREA_VERSION}"
 
 NODE_NAME="$(hostname)"
@@ -227,7 +227,7 @@ version: "3"
 
 services:
   antrea-ovs:
-    image: $ANTREA_DOCKER_IMAGE
+    image: $ANTREA_AGENT_DOCKER_IMAGE
     container_name: antrea-ovs
     volumes:
         - /var/log/openvswitch:/var/log/openvswitch
@@ -248,7 +248,7 @@ services:
           window: 10s
 
   antrea-agent:
-    image: $ANTREA_DOCKER_IMAGE
+    image: $ANTREA_AGENT_DOCKER_IMAGE
     container_name: antrea-agent
     volumes:
         - /etc/antrea/:/etc/antrea
@@ -356,15 +356,15 @@ EOF
 # Function to deploy and run Antrea specific containers.
 deploy_antrea_containers() {
     set +eo pipefail
-    if [ -z "$(docker images -q $ANTREA_DOCKER_IMAGE)" ]; then
-        echo "Downloading the Docker image $ANTREA_DOCKER_IMAGE"
-        docker pull $ANTREA_DOCKER_IMAGE
+    if [ -z "$(docker images -q $ANTREA_AGENT_DOCKER_IMAGE)" ]; then
+        echo "Downloading the Docker image $ANTREA_AGENT_DOCKER_IMAGE"
+        docker pull $ANTREA_AGENT_DOCKER_IMAGE
         if [[ "$?" -ne 0 ]]; then
-            echoerr "Error, Downloading the Docker image $ANTREA_DOCKER_IMAGE"
+            echoerr "Error, Downloading the Docker image $ANTREA_AGENT_DOCKER_IMAGE"
             exit 2
         fi
     else
-        echo "$ANTREA_DOCKER_IMAGE image is already loaded to Docker"
+        echo "$ANTREA_AGENT_DOCKER_IMAGE image is already loaded to Docker"
     fi
     # Start Antrea/OVS containers as part of system startup.
     setup_antrea_agent_service

--- a/hack/generate-helm-release.sh
+++ b/hack/generate-helm-release.sh
@@ -95,6 +95,8 @@ ANTREA_CHART="$THIS_DIR/../build/charts/antrea"
 cp "$ANTREA_CHART/Chart.yaml" "$ANTREA_CHART/Chart.yaml.bak"
 yq -i '.annotations."artifacthub.io/prerelease" = strenv(PRERELEASE)' "$ANTREA_CHART/Chart.yaml"
 sed -i.bak 's=antrea/antrea-ubuntu=projects.registry.vmware.com/antrea/antrea-ubuntu=g' "$ANTREA_CHART/values.yaml"
+sed -i.bak 's=antrea/antrea-agent-ubuntu=projects.registry.vmware.com/antrea/antrea-agent-ubuntu=g' "$ANTREA_CHART/values.yaml"
+sed -i.bak 's=antrea/antrea-controller-ubuntu=projects.registry.vmware.com/antrea/antrea-controller-ubuntu=g' "$ANTREA_CHART/values.yaml"
 $HELM package --app-version $VERSION --version $VERSION $ANTREA_CHART
 mv "antrea-$VERSION.tgz" "$OUT/antrea-chart.tgz"
 mv "$ANTREA_CHART/Chart.yaml.bak" "$ANTREA_CHART/Chart.yaml"

--- a/hack/generate-manifest.sh
+++ b/hack/generate-manifest.sh
@@ -45,9 +45,9 @@ Generate a YAML manifest for Antrea using Helm and print it to stdout.
         --extra-helm-values-file      Optional extra helm values file to override the default config values
         --extra-helm-values           Optional extra helm values to override the default config values
 
-In 'release' mode, environment variables IMG_NAME and IMG_TAG must be set.
+In 'release' mode, environment variables AGENT_IMAGE, CONTROLLER_IMAGE, and IMG_TAG must be set.
 
-In 'dev' mode, environment variable IMG_NAME can be set to use a custom image.
+In 'dev' mode, environment variables AGENT_IMAGE & CONTROLLER_IMAGE can be set to use a custom image.
 
 This tool uses Helm 3 (https://helm.sh/) to generate manifests for Antrea. You can set the HELM
 environment variable to the path of the helm binary you want us to use. Otherwise we will download
@@ -201,8 +201,9 @@ if [ "$TUN_TYPE" != "geneve" ] && [ "$TUN_TYPE" != "vxlan" ] && [ "$TUN_TYPE" !=
     exit 1
 fi
 
-if [ "$MODE" == "release" ] && [ -z "$IMG_NAME" ]; then
-    echoerr "In 'release' mode, environment variable IMG_NAME must be set"
+if [ "$MODE" == "release" ] && [ -z "$AGENT_IMAGE" ] && [ -z "$CONTROLLER_IMAGE" ]; then
+    echoerr "In 'release' mode, environment variables AGENT_IMAGE and \
+             CONTROLLER_IMAGE must be set"
     print_help
     exit 1
 fi
@@ -323,12 +324,14 @@ EOF
 fi
 
 if [ "$MODE" == "dev" ]; then
-    if [[ -z "$IMG_NAME" ]]; then
+    if [[ -z "$AGENT_IMAGE" ]] || [[ -z "$CONTROLLER_IMAGE" ]]; then
         if $COVERAGE; then
-            HELM_VALUES+=("image.repository=antrea/antrea-ubuntu-coverage")
+            HELM_VALUES+=("controllerImage.repository=antrea/antrea-controller-ubuntu-coverage" \
+                          "agentImage.repository=antrea/antrea-agent-ubuntu-coverage")
         fi
     else
-        HELM_VALUES+=("image.repository=$IMG_NAME")
+        HELM_VALUES+=("agentImage.repository=$AGENT_IMAGE" \
+                      "controllerImage.repository=$CONTROLLER_IMAGE")
     fi
 
     if $VERBOSE_LOG; then
@@ -344,7 +347,7 @@ if [ "$MODE" == "dev" ]; then
 fi
 
 if [ "$MODE" == "release" ]; then
-    HELM_VALUES+=("image.repository=$IMG_NAME,image.tag=$IMG_TAG")
+    HELM_VALUES+=("--set agentImage.repository=$AGENT_IMAGE,agentImage.tag=$IMG_TAG,controllerImage.repository=$CONTROLLER_IMAGE,controllerImage.tag=$IMG_TAG")
 fi
 
 delim=""

--- a/hack/generate-standard-manifests.sh
+++ b/hack/generate-standard-manifests.sh
@@ -26,9 +26,9 @@ Generate standard YAML manifests for Antrea using Helm and writes them to output
         --out <DIR>                   Output directory for generated manifests
         --help, -h                    Print this message and exit
 
-In 'release' mode, environment variables IMG_NAME and IMG_TAG must be set.
+In 'release' mode, environment variables AGENT_IMAGE, CONTROLLER_IMAGE, and IMG_TAG must be set.
 
-In 'dev' mode, environment variable IMG_NAME can be set to use a custom image.
+In 'dev' mode, environment variables AGENT_IMAGE & CONTROLLER_IMAGE can be set to use a custom image.
 
 This tool uses Helm 3 (https://helm.sh/) to generate the \"standard\" manifests for Antrea. These
 are the manifests that are checked-in into the Antrea source tree, and that are uploaded as release
@@ -80,8 +80,9 @@ if [ "$MODE" != "dev" ] && [ "$MODE" != "release" ]; then
     exit 1
 fi
 
-if [ "$MODE" == "release" ] && [ -z "$IMG_NAME" ]; then
-    echoerr "In 'release' mode, environment variable IMG_NAME must be set"
+if [ "$MODE" == "release" ] && [ -z "$AGENT_IMAGE" ] && [ -z "$CONTROLLER_IMAGE" ]; then
+    echoerr "In 'release' mode, environment variables AGENT_IMAGE and \
+             CONTROLLER_IMAGE must be set"
     print_help
     exit 1
 fi
@@ -112,7 +113,7 @@ fi
 
 EXTRA_VALUES=""
 if [ "$MODE" == "release" ]; then
-    EXTRA_VALUES="--set image.repository=$IMG_NAME,image.tag=$IMG_TAG"
+    EXTRA_VALUES="--set agentImage.repository=$AGENT_IMAGE,agentImage.tag=$IMG_TAG,controllerImage.repository=$CONTROLLER_IMAGE,controllerImage.tag=$IMG_TAG"
 fi
 
 ANTREA_CHART="$THIS_DIR/../build/charts/antrea"

--- a/hack/netpol-generator/test-kind.sh
+++ b/hack/netpol-generator/test-kind.sh
@@ -27,7 +27,8 @@ JOB_NAME=job.batch/cyclonus
 
 
 kind create cluster --config "$KIND_CONFIG"
-kind load docker-image antrea/antrea-ubuntu:latest
+kind load docker-image antrea/antrea-agent-ubuntu:latest
+kind load docker-image antrea/antrea-controller-ubuntu:latest
 
 # pre-load cyclonus image
 docker pull mfenwick100/cyclonus:v0.4.7

--- a/hack/release/prepare-assets.sh
+++ b/hack/release/prepare-assets.sh
@@ -104,7 +104,8 @@ cp ./hack/externalnode/install-vm.ps1 "$OUTPUT_DIR/"
 
 export IMG_TAG=$VERSION
 
-export IMG_NAME=projects.registry.vmware.com/antrea/antrea-ubuntu
+export AGENT_IMAGE=projects.registry.vmware.com/antrea/antrea-agent-ubuntu
+export CONTROLLER_IMAGE=projects.registry.vmware.com/antrea/antrea-controller-ubuntu
 ./hack/generate-standard-manifests.sh --mode release --out "$OUTPUT_DIR"
 
 export IMG_NAME=projects.registry.vmware.com/antrea/antrea-windows

--- a/test/e2e/infra/vagrant/push_antrea.sh
+++ b/test/e2e/infra/vagrant/push_antrea.sh
@@ -62,7 +62,8 @@ esac
 done
 
 SAVED_ANTREA_IMG=/tmp/antrea-ubuntu.tar
-ANTREA_IMG_NAME=antrea/antrea-ubuntu:latest
+ANTREA_AGENT_IMG_NAME=antrea/antrea-agent-ubuntu:latest
+ANTREA_CONTROLLER_IMG_NAME=antrea/antrea-controller-ubuntu:latest
 
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
@@ -168,7 +169,8 @@ if [[ $FLOW_COLLECTOR != "" ]]; then
 fi
 
 # Push Antrea image and related manifest.
-pushImgToNodes "$ANTREA_IMG_NAME" "$SAVED_ANTREA_IMG"
+pushImgToNodes "$ANTREA_AGENT_IMG_NAME" "$SAVED_ANTREA_IMG"
+pushImgToNodes "$ANTREA_CONTROLLER_IMG_NAME" "$SAVED_ANTREA_IMG"
 copyManifestToNodes "$ANTREA_YML"
 copyManifestToNodes "$ANTREA_IPSEC_YML"
 


### PR DESCRIPTION
Fixes #5691.

Modified the code to build separate images for antrea-agent and antrea-controller, because there are many resources that are not required by controller and are required by agent only, and unified image for both creates a burden when starting antrea-controller and thus it takes time to start. For this reason I have create separate images for antrea-agent and antrea-controller.

```
Updated image sizes are as follows: 
antrea-controller: ~300MB
antrea-agent: ~380MB 
```