### PR TITLE
Add policy processed verification for NetworkPolicyEvaluation

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -201,7 +201,7 @@ func installAPIGroup(s *APIServer, c completedConfig) error {
 	appliedToGroupStorage := appliedtogroup.NewREST(c.extraConfig.appliedToGroupStore)
 	networkPolicyStorage := networkpolicy.NewREST(c.extraConfig.networkPolicyStore)
 	networkPolicyStatusStorage := networkpolicy.NewStatusREST(c.extraConfig.networkPolicyStatusController)
-	networkPolicyEvaluationStorage := networkpolicyevaluation.NewREST(controllernetworkpolicy.NewPolicyRuleQuerier(c.extraConfig.endpointQuerier))
+	networkPolicyEvaluationStorage := networkpolicyevaluation.NewREST(controllernetworkpolicy.NewPolicyRuleQuerier(c.extraConfig.endpointQuerier, c.extraConfig.networkPolicyController))
 	clusterGroupMembershipStorage := clustergroupmember.NewREST(c.extraConfig.networkPolicyController)
 	groupMembershipStorage := groupmember.NewREST(c.extraConfig.networkPolicyController)
 	groupAssociationStorage := groupassociation.NewREST(c.extraConfig.networkPolicyController)

--- a/pkg/controller/networkpolicy/adminnetworkpolicy_test.go
+++ b/pkg/controller/networkpolicy/adminnetworkpolicy_test.go
@@ -416,7 +416,7 @@ func TestProcessAdminNetworkPolicy(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, features.DefaultFeatureGate, features.AdminNetworkPolicy, true)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, c := newController(nil, nil)
+			_, c := newController(nil, nil, nil)
 			actualPolicy, actualAppliedToGroups, actualAddressGroups := c.processAdminNetworkPolicy(tt.inputPolicy)
 			assert.Equal(t, tt.expectedPolicy.UID, actualPolicy.UID)
 			assert.Equal(t, tt.expectedPolicy.Name, actualPolicy.Name)
@@ -712,7 +712,7 @@ func TestProcessBaselineAdminNetworkPolicy(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, features.DefaultFeatureGate, features.AdminNetworkPolicy, true)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, c := newController(nil, nil)
+			_, c := newController(nil, nil, nil)
 			actualPolicy, actualAppliedToGroups, actualAddressGroups := c.processBaselineAdminNetworkPolicy(tt.inputPolicy)
 			assert.Equal(t, tt.expectedPolicy.UID, actualPolicy.UID)
 			assert.Equal(t, tt.expectedPolicy.Name, actualPolicy.Name)

--- a/pkg/controller/networkpolicy/antreanetworkpolicy_test.go
+++ b/pkg/controller/networkpolicy/antreanetworkpolicy_test.go
@@ -739,7 +739,7 @@ func TestProcessAntreaNetworkPolicy(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, c := newController(nil, nil)
+			_, c := newController(nil, nil, nil)
 			c.serviceStore.Add(&svcA)
 			actualPolicy, actualAppliedToGroups, actualAddressGroups := c.processAntreaNetworkPolicy(tt.inputPolicy)
 			assert.Equal(t, tt.expectedPolicy, actualPolicy)
@@ -750,7 +750,7 @@ func TestProcessAntreaNetworkPolicy(t *testing.T) {
 }
 
 func TestAddANNP(t *testing.T) {
-	_, npc := newController(nil, nil)
+	_, npc := newController(nil, nil, nil)
 	annp := getANNP()
 	npc.addANNP(annp)
 	require.Equal(t, 1, npc.internalNetworkPolicyQueue.Len())
@@ -761,7 +761,7 @@ func TestAddANNP(t *testing.T) {
 }
 
 func TestUpdateANNP(t *testing.T) {
-	_, npc := newController(nil, nil)
+	_, npc := newController(nil, nil, nil)
 	annp := getANNP()
 	newANNP := annp.DeepCopy()
 	// Make a change to the ANNP.
@@ -775,7 +775,7 @@ func TestUpdateANNP(t *testing.T) {
 }
 
 func TestDeleteANNP(t *testing.T) {
-	_, npc := newController(nil, nil)
+	_, npc := newController(nil, nil, nil)
 	annp := getANNP()
 	npc.deleteANNP(annp)
 	require.Equal(t, 1, npc.internalNetworkPolicyQueue.Len())

--- a/pkg/controller/networkpolicy/clustergroup_test.go
+++ b/pkg/controller/networkpolicy/clustergroup_test.go
@@ -167,7 +167,7 @@ func TestProcessClusterGroup(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, c := newController(nil, nil)
+			_, c := newController(nil, nil, nil)
 			actualGroup := c.processClusterGroup(tt.inputGroup)
 			assert.Equal(t, tt.expectedGroup, actualGroup)
 		})
@@ -269,7 +269,7 @@ func TestAddClusterGroup(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, npc := newController(nil, nil)
+			_, npc := newController(nil, nil, nil)
 			npc.addClusterGroup(tt.inputGroup)
 			key := tt.inputGroup.Name
 			actualGroupObj, _, _ := npc.internalGroupStore.Get(key)
@@ -418,7 +418,7 @@ func TestUpdateClusterGroup(t *testing.T) {
 			},
 		},
 	}
-	_, npc := newController(nil, nil)
+	_, npc := newController(nil, nil, nil)
 	npc.addClusterGroup(&testCG)
 	key := testCG.Name
 	for _, tt := range tests {
@@ -440,7 +440,7 @@ func TestDeleteCG(t *testing.T) {
 		},
 	}
 	key := testCG.Name
-	_, npc := newController(nil, nil)
+	_, npc := newController(nil, nil, nil)
 	npc.addClusterGroup(&testCG)
 	npc.deleteClusterGroup(&testCG)
 	_, found, _ := npc.internalGroupStore.Get(key)
@@ -584,7 +584,7 @@ func TestFilterInternalGroupsForService(t *testing.T) {
 			sets.New[string]("cgC"),
 		},
 	}
-	_, npc := newController(nil, nil)
+	_, npc := newController(nil, nil, nil)
 	npc.internalGroupStore.Create(grp1)
 	npc.internalGroupStore.Create(grp2)
 	npc.internalGroupStore.Create(grp3)
@@ -688,7 +688,7 @@ func TestServiceToGroupSelector(t *testing.T) {
 			nil,
 		},
 	}
-	_, npc := newController(nil, nil)
+	_, npc := newController(nil, nil, nil)
 	npc.serviceStore.Add(svc1)
 	npc.serviceStore.Add(svc2)
 	npc.serviceStore.Add(svc3)
@@ -858,7 +858,7 @@ func TestGetAssociatedGroups(t *testing.T) {
 			[]antreatypes.Group{},
 		},
 	}
-	_, npc := newController(nil, nil)
+	_, npc := newController(nil, nil, nil)
 	for i := range testPods {
 		npc.groupingInterface.AddPod(testPods[i])
 	}
@@ -906,7 +906,7 @@ func TestGetClusterGroupMembers(t *testing.T) {
 			controlplane.GroupMemberSet{},
 		},
 	}
-	_, npc := newController(nil, nil)
+	_, npc := newController(nil, nil, nil)
 	for i := range testPods {
 		npc.groupingInterface.AddPod(testPods[i])
 	}

--- a/pkg/controller/networkpolicy/clusternetworkpolicy_test.go
+++ b/pkg/controller/networkpolicy/clusternetworkpolicy_test.go
@@ -1777,7 +1777,7 @@ func TestProcessClusterNetworkPolicy(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, c := newController(nil, nil)
+			_, c := newController(nil, nil, nil)
 			c.addClusterGroup(&cgA)
 			c.cgStore.Add(&cgA)
 			c.namespaceStore.Add(&nsA)
@@ -1800,7 +1800,7 @@ func TestProcessClusterNetworkPolicy(t *testing.T) {
 }
 
 func TestAddCNP(t *testing.T) {
-	_, npc := newController(nil, nil)
+	_, npc := newController(nil, nil, nil)
 	cnp := getCNP()
 	npc.addCNP(cnp)
 	require.Equal(t, 1, npc.internalNetworkPolicyQueue.Len())
@@ -1811,7 +1811,7 @@ func TestAddCNP(t *testing.T) {
 }
 
 func TestUpdateCNP(t *testing.T) {
-	_, npc := newController(nil, nil)
+	_, npc := newController(nil, nil, nil)
 	cnp := getCNP()
 	newCNP := cnp.DeepCopy()
 	// Make a change to the CNP.
@@ -1825,7 +1825,7 @@ func TestUpdateCNP(t *testing.T) {
 }
 
 func TestDeleteCNP(t *testing.T) {
-	_, npc := newController(nil, nil)
+	_, npc := newController(nil, nil, nil)
 	cnp := getCNP()
 	npc.deleteCNP(cnp)
 	require.Equal(t, 1, npc.internalNetworkPolicyQueue.Len())
@@ -1861,7 +1861,7 @@ func TestGetTierPriority(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, npc := newController(nil, nil)
+			_, npc := newController(nil, nil, nil)
 			name := ""
 			if tt.inputTier != nil {
 				npc.tierStore.Add(tt.inputTier)
@@ -1932,7 +1932,7 @@ func TestProcessRefGroupOrClusterGroup(t *testing.T) {
 			},
 		},
 	}
-	_, npc := newController(nil, nil)
+	_, npc := newController(nil, nil, nil)
 	npc.addClusterGroup(&cgA)
 	npc.addClusterGroup(&cgB)
 	npc.addClusterGroup(&cgNested1)
@@ -2193,7 +2193,7 @@ func TestFilterPerNamespaceRuleACNPsByNSLabels(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, c := newController(nil, nil)
+			_, c := newController(nil, nil, nil)
 			c.acnpStore.Add(cnpWithSpecAppliedTo)
 			c.acnpStore.Add(cnpWithRuleAppliedTo)
 			c.acnpStore.Add(cnpMatchAllNamespaces)

--- a/pkg/controller/networkpolicy/crd_utils_test.go
+++ b/pkg/controller/networkpolicy/crd_utils_test.go
@@ -472,7 +472,7 @@ func TestToAntreaPeerForCRD(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, npc := newController(nil, nil)
+			_, npc := newController(nil, nil, nil)
 			npc.addClusterGroup(&cgA)
 			npc.cgStore.Add(&cgA)
 			if tt.clusterSetScope {
@@ -523,7 +523,7 @@ func TestCreateAppliedToGroupsForGroup(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Namespace: "nsB", Name: "gB", UID: "uidB"},
 		Spec:       crdv1beta1.GroupSpec{IPBlocks: []crdv1beta1.IPBlock{{CIDR: cidr}}},
 	}
-	_, npc := newController(nil, nil)
+	_, npc := newController(nil, nil, nil)
 	npc.addClusterGroup(clusterGroupWithSelector)
 	npc.addClusterGroup(clusterGroupWithIPBlock)
 	npc.addGroup(groupWithSelector)

--- a/pkg/controller/networkpolicy/endpoint_querier_test.go
+++ b/pkg/controller/networkpolicy/endpoint_querier_test.go
@@ -188,7 +188,7 @@ var namespaces = []*corev1.Namespace{
 
 func makeControllerAndEndpointQuerier(objects ...runtime.Object) *EndpointQuerierImpl {
 	// create controller
-	_, c := newController(objects, nil)
+	_, c := newController(objects, nil, nil)
 	c.heartbeatCh = make(chan heartbeat, 1000)
 	stopCh := make(chan struct{})
 	// create querier with stores inside controller
@@ -574,6 +574,7 @@ func TestQueryNetworkPolicyEvaluation(t *testing.T) {
 
 	for _, tc := range testCases {
 		tc := tc
+		_, c := newController(nil, nil, nil)
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			mockQuerier := queriermock.NewMockEndpointQuerier(mockCtrl)
@@ -585,7 +586,7 @@ func TestQueryNetworkPolicyEvaluation(t *testing.T) {
 					}
 				}
 			}
-			policyRuleQuerier := NewPolicyRuleQuerier(mockQuerier)
+			policyRuleQuerier := NewPolicyRuleQuerier(mockQuerier, c.NetworkPolicyController)
 			response, err := policyRuleQuerier.QueryNetworkPolicyEvaluation(tc.request)
 			if tc.expectedErr == "" {
 				assert.Nil(t, err)

--- a/pkg/controller/networkpolicy/group_test.go
+++ b/pkg/controller/networkpolicy/group_test.go
@@ -170,7 +170,7 @@ func TestProcessGroup(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, c := newController(nil, nil)
+			_, c := newController(nil, nil, nil)
 			actualGroup := c.processGroup(tt.inputGroup)
 			assert.Equal(t, tt.expectedGroup, actualGroup)
 		})
@@ -276,7 +276,7 @@ func TestAddGroup(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, npc := newController(nil, nil)
+			_, npc := newController(nil, nil, nil)
 			npc.addGroup(tt.inputGroup)
 			key := fmt.Sprintf("%s/%s", tt.inputGroup.Namespace, tt.inputGroup.Name)
 			actualGroupObj, _, _ := npc.internalGroupStore.Get(key)
@@ -431,7 +431,7 @@ func TestUpdateGroup(t *testing.T) {
 			},
 		},
 	}
-	_, npc := newController(nil, nil)
+	_, npc := newController(nil, nil, nil)
 	npc.addGroup(&testG)
 	key := fmt.Sprintf("%s/%s", testG.Namespace, testG.Name)
 	for _, tt := range tests {
@@ -453,7 +453,7 @@ func TestDeleteG(t *testing.T) {
 		},
 	}
 	key := fmt.Sprintf("%s/%s", testG.Namespace, testG.Name)
-	_, npc := newController(nil, nil)
+	_, npc := newController(nil, nil, nil)
 	npc.addGroup(&testG)
 	npc.deleteGroup(&testG)
 	_, found, _ := npc.internalGroupStore.Get(key)
@@ -570,7 +570,7 @@ func TestGetGroupMembers(t *testing.T) {
 			controlplane.GroupMemberSet{},
 		},
 	}
-	_, npc := newController(nil, nil)
+	_, npc := newController(nil, nil, nil)
 	for i := range testPods {
 		npc.groupingInterface.AddPod(testPods[i])
 	}

--- a/pkg/controller/networkpolicy/mutate_test.go
+++ b/pkg/controller/networkpolicy/mutate_test.go
@@ -184,7 +184,7 @@ func TestMutateAntreaClusterNetworkPolicy(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, controller := newController(nil, nil)
+			_, controller := newController(nil, nil, nil)
 			mutator := NewNetworkPolicyMutator(controller.NetworkPolicyController)
 			_, _, patch := mutator.mutateAntreaPolicy(tt.operation, tt.policy.Spec.Ingress, tt.policy.Spec.Egress, tt.policy.Spec.Tier)
 			marshalExpPatch, _ := json.Marshal(tt.expectPatch)
@@ -353,7 +353,7 @@ func TestMutateAntreaNetworkPolicy(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, controller := newController(nil, nil)
+			_, controller := newController(nil, nil, nil)
 			mutator := NewNetworkPolicyMutator(controller.NetworkPolicyController)
 			_, _, patch := mutator.mutateAntreaPolicy(tt.operation, tt.policy.Spec.Ingress, tt.policy.Spec.Egress, tt.policy.Spec.Tier)
 			marshalExpPatch, _ := json.Marshal(tt.expectPatch)

--- a/pkg/controller/networkpolicy/networkpolicy_controller_perf_test.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller_perf_test.go
@@ -241,7 +241,7 @@ func testComputeNetworkPolicy(t *testing.T, maxExecutionTime time.Duration, name
 	}
 
 	k8sObjs = append(k8sObjs, toRunTimeObjects(namespaces)...)
-	_, c := newController(k8sObjs, crdObjs)
+	_, c := newController(k8sObjs, crdObjs, nil)
 	c.heartbeatCh = make(chan heartbeat, 1000)
 
 	stopCh := make(chan struct{})
@@ -533,7 +533,7 @@ func BenchmarkSyncAddressGroup(b *testing.B) {
 	objs = append(objs, pods...)
 	stopCh := make(chan struct{})
 	defer close(stopCh)
-	_, c := newController(objs, nil)
+	_, c := newController(objs, nil, nil)
 	c.informerFactory.Start(stopCh)
 	c.crdInformerFactory.Start(stopCh)
 	go c.groupingController.Run(stopCh)

--- a/pkg/controller/networkpolicy/tier_test.go
+++ b/pkg/controller/networkpolicy/tier_test.go
@@ -70,7 +70,7 @@ func TestInitTier(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			_, c := newController(nil, nil)
+			_, c := newController(nil, nil, nil)
 			if tc.reactor != nil {
 				c.crdClient.(*fake.Clientset).PrependReactor("create", "tiers", tc.reactor)
 			}

--- a/pkg/controller/networkpolicy/validate_test.go
+++ b/pkg/controller/networkpolicy/validate_test.go
@@ -1668,7 +1668,7 @@ func TestValidateAntreaClusterNetworkPolicy(t *testing.T) {
 			for feature, value := range tt.featureGates {
 				defer featuregatetesting.SetFeatureGateDuringTest(t, features.DefaultFeatureGate, feature, value)()
 			}
-			_, controller := newController(nil, nil)
+			_, controller := newController(nil, nil, nil)
 			validator := NewNetworkPolicyValidator(controller.NetworkPolicyController)
 			actualReason, allowed := validator.validateAntreaPolicy(tt.policy, "", tt.operation, authenticationv1.UserInfo{})
 			assert.Equal(t, tt.expectedReason, actualReason)
@@ -1740,7 +1740,7 @@ func TestValidateAntreaNetworkPolicy(t *testing.T) {
 			for feature, value := range tt.featureGates {
 				defer featuregatetesting.SetFeatureGateDuringTest(t, features.DefaultFeatureGate, feature, value)()
 			}
-			_, controller := newController(nil, nil)
+			_, controller := newController(nil, nil, nil)
 			validator := NewNetworkPolicyValidator(controller.NetworkPolicyController)
 			actualReason, allowed := validator.validateAntreaPolicy(tt.policy, "", tt.operation, authenticationv1.UserInfo{})
 			assert.Equal(t, tt.expectedReason, actualReason)
@@ -2023,7 +2023,7 @@ func TestValidateAntreaClusterGroup(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, controller := newController(nil, nil)
+			_, controller := newController(nil, nil, nil)
 			if tt.existGroup != nil {
 				controller.cgStore.Add(tt.existGroup)
 				controller.addClusterGroup(tt.existGroup)
@@ -2280,7 +2280,7 @@ func TestValidateAntreaGroup(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, controller := newController(nil, nil)
+			_, controller := newController(nil, nil, nil)
 			if tt.existGroup != nil {
 				controller.gStore.Add(tt.existGroup)
 				controller.addGroup(tt.existGroup)
@@ -2488,7 +2488,7 @@ func TestValidateTier(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, controller := newController(nil, nil)
+			_, controller := newController(nil, nil, nil)
 			for i := 1; i <= tt.existTierNum; i++ {
 				controller.tierStore.Add(&crdv1beta1.Tier{
 					ObjectMeta: metav1.ObjectMeta{
@@ -2710,7 +2710,7 @@ func TestValidateAdminNetworkPolicy(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, controller := newController(nil, nil)
+			_, controller := newController(nil, nil, nil)
 			validator := NewNetworkPolicyValidator(controller.NetworkPolicyController)
 			actualReason, allowed := validator.validateAdminNetworkPolicy(tt.policy, "", tt.operation, authenticationv1.UserInfo{})
 			assert.Equal(t, tt.expectedReason, actualReason)


### PR DESCRIPTION
This PR adds a function to verify that all policies in the cluster has
been processed by the Antrea controller before running the
`antctl query networkpolicyevaluation` command.