### PR TITLE
Ignore wireguard.com links in markdown link checker

### DIFF
--- a/hack/.md_links_config.json
+++ b/hack/.md_links_config.json
@@ -35,6 +35,9 @@
         },
         {
             "pattern": "https://twitter.com/*"
+        },
+        {
+            "pattern": "https://www.wireguard.com*"
         }
     ],
     "retryOn429": false,


### PR DESCRIPTION
Checking these links keep failing in Github Actions with an HTTP 500 code. I have noticed that when I try to access https://www.wireguard.com from my corporate network, it also fails (connection reset). When I access it from home, it works fine...