### PR TITLE
Replace curl with built-in Invoke-WebRequest on Windows

### DIFF
--- a/build/images/base-windows/Dockerfile
+++ b/build/images/base-windows/Dockerfile
@@ -28,20 +28,20 @@ WORKDIR /
 
 RUN mkdir -Force C:\opt\cni\bin
 
-RUN curl.exe -fLO https://github.com/containernetworking/plugins/releases/download/${env:CNI_BINARIES_VERSION}/cni-plugins-windows-amd64-${env:CNI_BINARIES_VERSION}.tgz; \
+RUN Invoke-WebRequest -UseBasicParsing -Uri https://github.com/containernetworking/plugins/releases/download/${env:CNI_BINARIES_VERSION}/cni-plugins-windows-amd64-${env:CNI_BINARIES_VERSION}.tgz -OutFile cni-plugins-windows-amd64-${env:CNI_BINARIES_VERSION}.tgz; \
     tar -xzf cni-plugins-windows-amd64-${env:CNI_BINARIES_VERSION}.tgz  -C C:\opt\cni\bin ${env:CNI_PLUGINS}; \
     rm cni-plugins-windows-amd64-${env:CNI_BINARIES_VERSION}.tgz
 
 # Install 7zip, git-for-windows, mingw64 to support "make tool"
-RUN curl.exe -fLO https://www.7-zip.org/a/7z2107-x64.exe; \
+RUN Invoke-WebRequest -UseBasicParsing -Uri https://www.7-zip.org/a/7z2107-x64.exe -OutFile 7z2107-x64.exe; \
     cmd /c start /wait 7z2107-x64.exe /S; \
     del 7z2107-x64.exe;  $env:Path = $env:Path+';C:/Program Files/7-Zip'; \
-    curl.exe -fLo mingw.7z https://cfhcable.dl.sourceforge.net/project/mingw-w64/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/8.1.0/threads-posix/seh/x86_64-8.1.0-release-posix-seh-rt_v6-rev0.7z; \
+    Invoke-WebRequest -UseBasicParsing -Uri https://cfhcable.dl.sourceforge.net/project/mingw-w64/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/8.1.0/threads-posix/seh/x86_64-8.1.0-release-posix-seh-rt_v6-rev0.7z -OutFile mingw.7z; \
     7z x mingw.7z; cp c:/mingw64/bin/mingw32-make.exe c:/mingw64/bin/make.exe; \
-    curl.exe -fLo git.exe https://github.com/git-for-windows/git/releases/download/v2.35.1.windows.2/PortableGit-2.35.1.2-64-bit.7z.exe; \
+    Invoke-WebRequest -UseBasicParsing -Uri https://github.com/git-for-windows/git/releases/download/v2.35.1.windows.2/PortableGit-2.35.1.2-64-bit.7z.exe -OutFile git.exe; \
     7z x git.exe -oC:\git; \
     mkdir C:\wins; \
-    curl.exe -fLo C:/wins/wins.exe https://github.com/rancher/wins/releases/download/v0.0.4/wins.exe
+    Invoke-WebRequest -UseBasicParsing -Uri https://github.com/rancher/wins/releases/download/v0.0.4/wins.exe -OutFile C:/wins/wins.exe
 
 FROM golang:${GO_VERSION}-nanoserver as windows-golang
 


### PR DESCRIPTION
Recently, the curl is not working in github workflow and failed to build base Windows images. Replace the curl with `Invoke-WebRequest` to bypass the issue.