### PR TITLE
Automated cherry pick of #5819: Add DHCP IP Retries in PrepareHNSNetwork

### DIFF
--- a/ci/jenkins/test.sh
+++ b/ci/jenkins/test.sh
@@ -38,6 +38,7 @@ IP_MODE=""
 K8S_VERSION="1.27.2-00"
 WINDOWS_YAML_SUFFIX="windows"
 WIN_IMAGE_NODE=""
+echo "" > WIN_DHCP
 
 WINDOWS_CONFORMANCE_FOCUS="\[sig-network\].+\[Conformance\]|\[sig-windows\]"
 WINDOWS_CONFORMANCE_SKIP="\[LinuxOnly\]|\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[sig-cli\]|\[sig-storage\]|\[sig-auth\]|\[sig-api-machinery\]|\[sig-apps\]|\[sig-node\]|\[Privileged\]|should be able to change the type from|\[sig-network\] Services should be able to create a functioning NodePort service \[Conformance\]|Service endpoints latency should not be very high|should be able to create a functioning NodePort service for Windows"
@@ -255,6 +256,19 @@ function collect_windows_network_info_and_logs {
     tar zcf debug_logs.tar.gz "${DEBUG_LOG_PATH}"
 }
 
+function check_dhcp_status {
+    echo "===== Check Interface DHCP Status ====="
+    WINIP=$(kubectl get nodes -o wide --no-headers=true | awk '$1 ~ /win-0/ {print $6}')
+    WIN_BRINT_DHCP=$(ssh -o StrictHostKeyChecking=no -n administrator@${WINIP} 'powershell.exe "(Get-NetIPInterface -InterfaceAlias br-int -AddressFamily IPv4).Dhcp"')
+    WIN_DHCP=$(<WIN_DHCP)
+    if [[ ${WIN_DHCP} == ${WIN_BRINT_DHCP} ]]; then
+        echo "Newly created uplink DHCP status is consistent with the original adapter."
+    else
+        echo "Newly created uplink DHCP status is different from the original adapter. Original DHCP: $WIN_DHCP, br-int DHCP: $WIN_BRINT_DHCP"
+        exit 1
+    fi
+}
+
 function wait_for_antrea_windows_pods_ready {
     kubectl apply -f "${WORKDIR}/antrea.yml"
     if [[ "${PROXY_ALL}" == false && ${TESTCASE} =~ "windows-e2e" ]]; then
@@ -276,6 +290,7 @@ function wait_for_antrea_windows_pods_ready {
         done
         sleep 10
     done
+    check_dhcp_status
 }
 
 function wait_for_antrea_windows_processes_ready {
@@ -294,6 +309,7 @@ function wait_for_antrea_windows_processes_ready {
         done
         sleep 10
     done
+    check_dhcp_status
 }
 
 function clean_ns {
@@ -578,6 +594,11 @@ function deliver_antrea_windows_containerd {
             ssh -o StrictHostKeyChecking=no -n Administrator@${IP} "gzip -d antrea-windows.tar.gz && ctr -n k8s.io images import antrea-windows.tar"
         fi
     done
+    # Add Windows interface DHCP check using CI script to obtain the original interface status.
+    WINIP=$(kubectl get nodes -o wide --no-headers=true | awk '$1 ~ /win-0/ {print $6}')
+    WIN_DHCP=$(ssh -o StrictHostKeyChecking=no -n administrator@${WINIP} 'powershell.exe "(Get-NetIPInterface -InterfaceAlias \"Ethernet0 2\" -AddressFamily IPv4).Dhcp"')
+    echo "Original adapter DHCP status: $WIN_DHCP"
+    echo $WIN_DHCP > WIN_DHCP
     rm -f antrea-windows.tar
 }
 


### PR DESCRIPTION
Cherry pick of #5819 on release-1.13.

#5819: Add DHCP IP Retries in PrepareHNSNetwork

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.