### PR TITLE
Fix antctl trace-packet arguments missing issue

### DIFF
--- a/pkg/ovs/ovsctl/appctl.go
+++ b/pkg/ovs/ovsctl/appctl.go
@@ -38,10 +38,11 @@ func (r *ovsAppctlRunner) RunAppctlCmd(cmd string, needsBridge bool, args ...str
 	if needsBridge {
 		cmdArgs = append(cmdArgs, r.bridge)
 	}
+	cmdArgs = append(cmdArgs, args...)
 	ovsCmd := exec.CommandContext(context.TODO(), "ovs-appctl", cmdArgs...)
 	out, err := ovsCmd.CombinedOutput()
 	if err != nil {
-		return nil, newExecError(err, string(out))
+		return nil, NewExecError(err, string(out))
 	}
 	return out, nil
 }

--- a/pkg/ovs/ovsctl/ovsctl.go
+++ b/pkg/ovs/ovsctl/ovsctl.go
@@ -261,7 +261,7 @@ func newBadRequestError(msg string) BadRequestError {
 	return BadRequestError(msg)
 }
 
-func newExecError(err error, errorOutput string) *ExecError {
+func NewExecError(err error, errorOutput string) *ExecError {
 	e := &ExecError{error: err}
 	if e.CommandExecuted() {
 		e.errorOutput = errorOutput


### PR DESCRIPTION
Fix the following error when running `antctl trace-packet`, which is caused by missing arguments for ovs-appctl command.

```
syntax error at br-int (or the bridge name was omitted)
ovs-appctl: /var/run/openvswitch/ovs-vswitchd.103.ctl: server returned an error
```

Fixes #5831