### PR TITLE
Enhance HNS network initialization

### DIFF
--- a/pkg/agent/agent_windows.go
+++ b/pkg/agent/agent_windows.go
@@ -55,6 +55,10 @@ func (i *Initializer) prepareHNSNetworkAndOVSExtension() error {
 	// If the HNS Network already exists, return immediately.
 	hnsNetwork, err := hcsshim.GetHNSNetworkByName(util.LocalHNSNetwork)
 	if err == nil {
+		// Enable OVS Extension on the HNS Network.
+		if err = util.EnableHNSNetworkExtension(hnsNetwork.Id, util.OVSExtensionID); err != nil {
+			return err
+		}
 		// Enable RSC for existing vSwitch.
 		if err = util.EnableRSCOnVSwitch(util.LocalHNSNetwork); err != nil {
 			return err

--- a/pkg/agent/util/net_windows.go
+++ b/pkg/agent/util/net_windows.go
@@ -529,6 +529,8 @@ func PrepareHNSNetwork(subnetCIDR *net.IPNet, nodeIPNet *net.IPNet, uplinkAdapte
 	}
 
 	// Enable OVS Extension on the HNS Network. If an error occurs, delete the HNS Network and return the error.
+	// While the hnsshim API allows for enabling the OVS extension when creating an HNS network, it can cause the adapter being unable
+	// to obtain a valid DHCP IP in case of network interruption. Therefore, we have to enable the OVS extension after running adapterIPExists.
 	if err = EnableHNSNetworkExtension(hnsNet.Id, OVSExtensionID); err != nil {
 		return err
 	}


### PR DESCRIPTION
The current windows agent initialization couldn't guarantee that the `EnableHNSNetworkExtension` was executed after creating the HNS network.
In certain corner cases where the Windows agent pod was restarted after creating HNS network, the agent might miss executing `EnableHNSNetworkExtension`.

To address this issue, this enhancement runs `EnableHNSNetworkExtension` even if the HNS network has been created, which ensures the OVS Extension is properly enabled.