### PR TITLE
Don't create tunnel interface (antrea-tun0) when using Wireguard

### DIFF
--- a/pkg/agent/config/node_config.go
+++ b/pkg/agent/config/node_config.go
@@ -263,7 +263,14 @@ func (nc *NetworkConfig) NeedsTunnelToPeer(peerIP net.IP, localIP *net.IPNet) bo
 }
 
 func (nc *NetworkConfig) NeedsTunnelInterface() bool {
-	return nc.TrafficEncapMode.SupportsEncap() || nc.EnableMulticlusterGW
+	// For encap or hybrid mode, we need to create the tunnel interface, except if we are using
+	// WireGuard, in which case inter-Node traffic always goes through the antrea-wg0 interface,
+	// and tunneling is managed by Linux, not OVS.
+	// If multi-cluster gateway is enabled, we always need the tunnel interface. For example,
+	// cross-cluster traffic from a regular Node to the gateway Node for the source cluster
+	// always goes through antrea-tun0, regardless of the actual "traffic mode" for the source
+	// cluster.
+	return (nc.TrafficEncapMode.SupportsEncap() && nc.TrafficEncryptionMode != TrafficEncryptionModeWireGuard) || nc.EnableMulticlusterGW
 }
 
 // NeedsDirectRoutingToPeer returns true if Pod traffic to peer Node needs a direct route installed to the routing table.


### PR DESCRIPTION
When using Wireguard for inter-Node traffic, there is no need to create the OVS tunnel port (antrea-tun0) interface, as traffic will go through antrea-wg0, which is managed by Linux directly.

The exception is when using Multi-cluster (in gateway mode), as antrea-tun0 is then still used for cross-cluster traffic, for example to tunnel traffic from the source Node to the local gateway Node.

Fixes #5869