### PR TITLE
Some minor updates to Multi-cluster documentation

### DIFF
--- a/build/charts/antrea/README.md
+++ b/build/charts/antrea/README.md
@@ -106,11 +106,11 @@ Kubernetes: `>= 1.16.0-0`
 | multicast.igmpQueryInterval | string | `"125s"` | The interval at which the antrea-agent sends IGMP queries to Pods. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". |
 | multicast.igmpQueryVersions | list | `[1,2,3]` | The versions of IGMP queries antrea-agent sends to Pods. Valid versions are 1, 2 and 3. |
 | multicast.multicastInterfaces | list | `[]` | Names of the interfaces on Nodes that are used to forward multicast traffic. |
-| multicluster.enableGateway | bool | `false` | Enable Antrea Multi-cluster Gateway to support cross-cluster traffic. This feature is supported only with encap mode. |
+| multicluster.enableGateway | bool | `false` | Enable Antrea Multi-cluster Gateway to support cross-cluster traffic. |
 | multicluster.enablePodToPodConnectivity | bool | `false` | Enable Multi-cluster Pod to Pod connectivity. |
 | multicluster.enableStretchedNetworkPolicy | bool | `false` | Enable Multi-cluster NetworkPolicy. Multi-cluster Gateway must be enabled to enable StretchedNetworkPolicy. |
 | multicluster.namespace | string | `""` | The Namespace where Antrea Multi-cluster Controller is running. The default is antrea-agent's Namespace. |
-| multicluster.trafficEncryptionMode | string | `"none"` | Determines how cross-cluster traffic is encrypted. It has the following options: - none (default):  Cross-cluster traffic will not be encrypted. - wireGuard:       Enable WireGuard for tunnel traffic encryption. |
+| multicluster.trafficEncryptionMode | string | `"none"` | Determines how cross-cluster traffic is encrypted. It can be one of "none" (default) or "wireGuard". When set to "none", cross-cluster traffic will not be encrypted. When set to "wireGuard", cross-cluster traffic will be sent over encrypted WireGuard tunnels. "wireGuard" requires Multi-cluster Gateway to be enabled. Note that when using WireGuard for cross-cluster traffic, encryption is no longer supported for in-cluster traffic. |
 | multicluster.wireGuard.port | int | `51821` | WireGuard tunnel port for cross-cluster traffic. |
 | noSNAT | bool | `false` | Whether or not to SNAT (using the Node IP) the egress traffic from a Pod to the external network. |
 | nodeIPAM.clusterCIDRs | list | `[]` | CIDR ranges to use when allocating Pod IP addresses. |

--- a/build/charts/antrea/values.yaml
+++ b/build/charts/antrea/values.yaml
@@ -402,7 +402,6 @@ logVerbosity: 0
 # Configure Multicluster defaults for both Antrea Controller and Agent.
 multicluster:
   # -- Enable Antrea Multi-cluster Gateway to support cross-cluster traffic.
-  # This feature is supported only with encap mode.
   enableGateway: false
   # -- The Namespace where Antrea Multi-cluster Controller is running.
   # The default is antrea-agent's Namespace.
@@ -412,10 +411,12 @@ multicluster:
   enableStretchedNetworkPolicy: false
   # -- Enable Multi-cluster Pod to Pod connectivity.
   enablePodToPodConnectivity: false
-  # -- Determines how cross-cluster traffic is encrypted.
-  # It has the following options:
-  # - none (default):  Cross-cluster traffic will not be encrypted.
-  # - wireGuard:       Enable WireGuard for tunnel traffic encryption.
+  # -- Determines how cross-cluster traffic is encrypted. It can be one of
+  # "none" (default) or "wireGuard". When set to "none", cross-cluster traffic
+  # will not be encrypted. When set to "wireGuard", cross-cluster traffic will
+  # be sent over encrypted WireGuard tunnels. "wireGuard" requires Multi-cluster
+  # Gateway to be enabled. Note that when using WireGuard for cross-cluster
+  # traffic, encryption is no longer supported for in-cluster traffic.
   trafficEncryptionMode: "none"
   # WireGuard tunnel configuration for cross-cluster traffic.
   wireGuard:

--- a/docs/multicluster/user-guide.md
+++ b/docs/multicluster/user-guide.md
@@ -110,7 +110,11 @@ Antrea v1.11.0, Multi-cluster Gateway also works with the Antrea `noEncap`, `hyb
 and `networkPolicyOnly` modes. For `noEncap` and `hybrid` modes, Antrea Multi-cluster
 deployment is the same as `encap` mode. For `networkPolicyOnly` mode, we need extra
 Antrea configuration changes to support Multi-cluster Gateway. Please check
-[the deployment guide](./policy-only-mode.md) for more information.
+[the deployment guide](./policy-only-mode.md) for more information. When using
+Multi-cluster Gateway, it is not possible to enable WireGuard for inter-Node
+traffic within the same member cluster. It is however possible to [enable
+WireGuard for cross-cluster traffic](#multi-cluster-wireguard-encryption)
+between member clusters.
 
 ### Deploy Antrea Multi-cluster Controller
 
@@ -449,6 +453,10 @@ data:
       wireGuard:
         port: 51821
 ```
+
+When WireGuard encryption is enabled for cross-cluster traffic as part of the
+Multi-cluster feature, in-cluster encryption (for traffic within a given member
+cluster) is no longer supported, not even with IPsec.
 
 ## Multi-cluster Service
 


### PR DESCRIPTION
* Indicate that cross-cluster WireGuard is not compatible with in-cluster encryption.
* Indicate that Multi-cluster Gateway is not compatible with in-cluster WireGuard.
* Remove stale information from Helm doc about "encap" mode being required for Multi-cluster Gatway.