### PR TITLE
Fix redundant reconciles in FQDN controller

### DIFF
--- a/pkg/agent/controller/networkpolicy/fqdn_test.go
+++ b/pkg/agent/controller/networkpolicy/fqdn_test.go
@@ -395,6 +395,10 @@ func TestSyncDirtyRules(t *testing.T) {
 	selectorItem2 := fqdnSelectorItem{
 		matchName: testFQDN2,
 	}
+	testFQDN3 := "*antrea.io"
+	selectorItem3 := fqdnSelectorItem{
+		matchRegex: testFQDN3,
+	}
 	tests := []struct {
 		name                        string
 		fqdnsToSync                 []string
@@ -406,6 +410,17 @@ func TestSyncDirtyRules(t *testing.T) {
 		expectedDirtyRulesRemaining sets.Set[string]
 		expectErr                   bool
 	}{
+		{
+			name:                        "test non-blocking dirty rule sync without address update",
+			fqdnsToSync:                 []string{testFQDN},
+			prevDirtyRules:              sets.New[string](),
+			addressUpdates:              []bool{false},
+			waitChs:                     []chan error{nil},
+			notifications:               []ruleRealizationUpdate{},
+			expectedDirtyRuleSyncCalls:  []string{},
+			expectedDirtyRulesRemaining: sets.New[string](),
+			expectErr:                   false,
+		},
 		{
 			name:                        "test non-blocking dirty rule sync with address update",
 			fqdnsToSync:                 []string{testFQDN},
@@ -482,10 +497,13 @@ func TestSyncDirtyRules(t *testing.T) {
 				dirtyRuleSyncCalls = append(dirtyRuleSyncCalls, s)
 			}
 			f.addFQDNSelector("1", []string{testFQDN})
+			f.addFQDNSelector("1", []string{testFQDN3})
 			f.addFQDNSelector("2", []string{testFQDN})
 			f.addFQDNSelector("2", []string{testFQDN2})
 			f.setFQDNMatchSelector(testFQDN, selectorItem)
 			f.setFQDNMatchSelector(testFQDN2, selectorItem2)
+			f.setFQDNMatchSelector(testFQDN, selectorItem3)
+			f.setFQDNMatchSelector(testFQDN2, selectorItem3)
 			// This simulates failed rule syncs in previous syncDirtyRules() calls
 			if len(tc.prevDirtyRules) > 0 {
 				f.ruleSyncTracker.dirtyRules = tc.prevDirtyRules


### PR DESCRIPTION
Recently an issue was raised in the Kubernetes Antrea channel, where @krobbo sees very frequent reconciliations of the same FQDN rule in very short succession. It was also disclosed that the specific rule in questions contains several FQDN selectors, and the FQDNs are S3 endpoints which have dynamic IPs and relatively short TTL. 

From the logs excerpts, I found that for some DNS response handling, the FQDN controller actually reconciles the same rule immediately after it finishes syncing in datapath:

```
4914 I0106 10:43:51.785381       1 networkpolicy_controller.go:663] "Rule realization was done" ruleID="e7b262670e58c0ee"
4915 I0106 10:43:51.785408       1 networkpolicy_controller.go:619] "Finished syncing rule" ruleID="e7b262670e58c0ee" duration="4.593564ms"
4916 I0106 10:43:51.785430       1 reconciler.go:298] "Reconciling NetworkPolicy rule" rule="e7b262670e58c0ee" policy="AntreaNetworkPolicy:lab/egress-to-external-services"
4917 I0106 10:43:51.785449       1 reconciler.go:427] "Assigning OFPriority to rule" rule="e7b262670e58c0ee" priority=14900
4918 I0106 10:43:51.785464       1 reconciler.go:715] "Updating existing rule" rule="e7b262670e58c0ee (Direction: Out, Targets: 4, ToAddressGroups: 0, ToIPBlocks: 0, ToAddresses: 0, Services: 1, PolicyPriority:0xc000c073f0, RulePriority: 0)"
```

Upon closer look at the current code, I suspect it is due to cases where some FQDN matches several selectors in the same rule, and in the sync logic the rule ID is not deduplicated. 

This PR fixes this specific issue by deduplicating the rule IDs before syncing.