### PR TITLE
Add a flag for antctl to print OVS table names only

### DIFF
--- a/pkg/agent/apiserver/handlers/ovsflows/handler_test.go
+++ b/pkg/agent/apiserver/handlers/ovsflows/handler_test.go
@@ -240,6 +240,19 @@ func TestTableFlows(t *testing.T) {
 
 }
 
+func TestTableNamesOnly(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	getFlowTableList = mockGetTableList
+	tc := testCase{
+		test:           "Get table names only",
+		query:          "?table-names-only",
+		expectedStatus: http.StatusOK,
+		resps:          []Response{{"table0"}, {"table1"}},
+	}
+	q := aqtest.NewMockAgentQuerier(ctrl)
+	runHTTPTest(t, &tc, q)
+}
+
 func mockGetFlowTableName(id uint8) string {
 	if id == 80 {
 		return "IngressRule"
@@ -252,6 +265,13 @@ func mockGetFlowTableID(tableName string) uint8 {
 		return 80
 	}
 	return binding.TableIDAll
+}
+
+func mockGetTableList() []binding.Table {
+	return []binding.Table{
+		binding.NewOFTable(0, "table0", 0, 0, 0),
+		binding.NewOFTable(0, "table1", 0, 0, 0),
+	}
 }
 
 func TestGroups(t *testing.T) {

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -293,7 +293,7 @@ func GetFlowTableID(tableName string) uint8 {
 func GetTableList() []binding.Table {
 	tables := make([]binding.Table, 0)
 	for _, obj := range tableCache.List() {
-		t := obj.(binding.Table)
+		t := obj.(*Table).ofTable
 		tables = append(tables, t)
 	}
 	return tables

--- a/pkg/antctl/antctl.go
+++ b/pkg/antctl/antctl.go
@@ -15,7 +15,6 @@
 package antctl
 
 import (
-	"fmt"
 	"reflect"
 
 	"antrea.io/antrea/pkg/agent/apiserver/handlers/agentinfo"
@@ -24,7 +23,6 @@ import (
 	"antrea.io/antrea/pkg/agent/apiserver/handlers/ovsflows"
 	"antrea.io/antrea/pkg/agent/apiserver/handlers/podinterface"
 	"antrea.io/antrea/pkg/agent/apiserver/handlers/serviceexternalip"
-	"antrea.io/antrea/pkg/agent/openflow"
 	fallbackversion "antrea.io/antrea/pkg/antctl/fallback/version"
 	"antrea.io/antrea/pkg/antctl/raw/featuregates"
 	"antrea.io/antrea/pkg/antctl/raw/multicluster"
@@ -370,6 +368,8 @@ $ antctl get podmulticaststats pod -n namespace`,
 			long:    "Dump all the OVS flows or the flows installed for the specified entity.",
 			example: `  Dump all OVS flows
   $ antctl get ovsflows
+  Dump OVS table names only
+  $ antctl get ovsflows --table-names-only
   Dump OVS flows of a local Pod
   $ antctl get ovsflows -p pod1 -n ns1
   Dump OVS flows of a Service
@@ -381,9 +381,7 @@ $ antctl get podmulticaststats pod -n namespace`,
   Dump OVS groups
   $ antctl get ovsflows -G 10,20
   Dump all OVS groups
-  $ antctl get ovsflows -G all
-
-  Antrea OVS Flow Tables:` + generateFlowTableHelpMsg(),
+  $ antctl get ovsflows -G all`,
 			agentEndpoint: &endpoint{
 				nonResourceEndpoint: &nonResourceEndpoint{
 					path: "/ovsflows",
@@ -412,6 +410,11 @@ $ antctl get podmulticaststats pod -n namespace`,
 							name:      "table",
 							usage:     "Comma separated Antrea OVS flow table names or numbers",
 							shorthand: "T",
+						},
+						{
+							name:   "table-names-only",
+							usage:  "Print all Antrea OVS flow table names only, and nothing else",
+							isBool: true,
 						},
 						{
 							name:      "groups",
@@ -688,12 +691,4 @@ $ antctl get podmulticaststats pod -n namespace`,
 		},
 	},
 	codec: scheme.Codecs,
-}
-
-func generateFlowTableHelpMsg() string {
-	msg := ""
-	for _, t := range openflow.GetTableList() {
-		msg += fmt.Sprintf("\n  %d\t%s", uint32(t.GetID()), t.GetName())
-	}
-	return msg
 }

--- a/pkg/antctl/command_definition_test.go
+++ b/pkg/antctl/command_definition_test.go
@@ -1056,6 +1056,11 @@ func TestCollectFlags(t *testing.T) {
 								shorthand:    "T",
 							},
 							{
+								name:   "table-names-only",
+								usage:  "Print all Antrea OVS flow table names only, and nothing else",
+								isBool: true,
+							},
+							{
 								name:         "groups",
 								defaultValue: "Groups",
 								usage:        "Comma separated OVS group IDs. Use 'all' to dump all groups",


### PR DESCRIPTION
Add a new flag to print OVS table names only.  Fixes #5810

```
./antctl get ovsflows --table-names-only

ARPResponder
ARPSpoofGuard
AntreaPolicyEgressRule
AntreaPolicyIngressRule
Classifier
ConntrackCommit
ConntrackState
ConntrackZone
EgressDefaultRule
EgressMark
EgressMetric
EgressRule
EndpointDNAT
IngressDefaultRule
IngressMetric
IngressRule
IngressSecurityClassifier
L2ForwardingCalc
L3DecTTL
L3Forwarding
Output
PipelineRootClassifier
PreRoutingClassifier
SNAT
SNATMark
ServiceLB
SessionAffinity
SpoofGuard
UnSNAT
```