### PR TITLE
Cherry pick merge commit instead of original commits

### DIFF
--- a/hack/cherry-pick-pull.sh
+++ b/hack/cherry-pick-pull.sh
@@ -162,7 +162,8 @@ gitamcleanup=true
 for pull in "${PULLS[@]}"; do
   echo "+++ Downloading patch to /tmp/${pull}.patch (in case you need to do this again)"
 
-  curl -o "/tmp/${pull}.patch" -sSL "https://github.com/${MAIN_REPO_ORG}/${MAIN_REPO_NAME}/pull/${pull}.patch"
+  merge_commit=$(gh pr view "$pull" --json mergeCommit -t '{{(printf "%s" $.mergeCommit.oid)}}')
+  curl -o "/tmp/${pull}.patch" -sSL "https://github.com/${MAIN_REPO_ORG}/${MAIN_REPO_NAME}/commit/${merge_commit}.patch"
   echo
   echo "+++ About to attempt cherry pick of PR. To reattempt:"
   echo "  $ git am -3 /tmp/${pull}.patch"


### PR DESCRIPTION
cherry_pick_pull.sh was copied from Kubernetes which allows merge commits. It makes sense to cherry pick original commits for Kubernetes because the original commits can be found in both master and release branches. However, Antrea uses squash merging at the most time, cherry-picking original commits would cause inconsistency between master and release branches. The commit changes to cherry pick the merge commit.