### PR TITLE
Increase timeout for flow-visibility e2e test

### DIFF
--- a/ci/kind/test-e2e-kind.sh
+++ b/ci/kind/test-e2e-kind.sh
@@ -275,7 +275,7 @@ function run_test {
   fi
 
   if $flow_visibility; then
-      timeout="20m"
+      timeout="30m"
       flow_visibility_args="-run=TestFlowAggregator --flow-visibility"
       if $coverage; then
           $FLOWAGGREGATOR_YML_CMD --coverage | docker exec -i kind-control-plane dd of=/root/flow-aggregator-coverage.yml


### PR DESCRIPTION
In this PR, we increase the timeout from 20m to 30m for flow-visibility e2e test.