### PR TITLE
Remove invalid flow when WireGuard is enabled

### DIFF
--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -1625,10 +1625,6 @@ func (c *client) InstallMulticlusterClassifierFlows(tunnelOFPort uint32, isGatew
 		c.featurePodConnectivity.l2ForwardCalcFlow(GlobalVirtualMACForMulticluster, tunnelOFPort),
 	}
 
-	if c.networkConfig.TrafficEncapMode != config.TrafficEncapModeEncap {
-		flows = append(flows, c.featurePodConnectivity.tunnelClassifierFlow(tunnelOFPort))
-	}
-
 	if isGateway {
 		flows = append(flows,
 			c.featureMulticluster.tunnelClassifierFlow(tunnelOFPort),

--- a/pkg/agent/openflow/pod_connectivity.go
+++ b/pkg/agent/openflow/pod_connectivity.go
@@ -168,7 +168,7 @@ func (f *featurePodConnectivity) initFlows() []*openflow15.FlowMod {
 	// Add flow to ensure the liveliness check packet could be forwarded correctly.
 	flows = append(flows, f.localProbeFlows()...)
 
-	if f.networkConfig.TrafficEncapMode.SupportsEncap() {
+	if f.tunnelPort != 0 {
 		flows = append(flows, f.tunnelClassifierFlow(f.tunnelPort))
 		flows = append(flows, f.l2ForwardCalcFlow(GlobalVirtualMAC, f.tunnelPort))
 	}


### PR DESCRIPTION
After merging #5885, the OVS tunnel port is no longer created when enabling WireGuard, as it is not being used. However, we were still trying to install flows referencing the tunnel port. Even though the port was non-existent, flow creation would succeed, but the condition matching on the tunnel port was being dropped silently. This would lead to invalid datapath behavior. We update the code to prevent installing these invalid flows when WireGuard is enabled.

Fixes #5905