### PR TITLE
Fix permissions for artifact cleanup in Kind workflow

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -743,6 +743,9 @@ jobs:
     - test-e2e-flow-visibility
     - test-network-policy-conformance-encap
     runs-on: [ubuntu-latest]
+    permissions:
+      # required for deleting artifacts from pull requests
+      actions: write
     steps:
     - name: Delete antrea-ubuntu-cov
       if: ${{ needs.build-antrea-coverage-image.result == 'success' }}


### PR DESCRIPTION
Because of a change in geekyeggo/delete-artifact@v4, we need to provide additional permissions to the artifact-cleanup job. Without this change, the job can never succeed.