### PR TITLE
e2e: Fix the wrong expectation of Traceflow observation

### DIFF
--- a/test/e2e/traceflow_test.go
+++ b/test/e2e/traceflow_test.go
@@ -764,7 +764,6 @@ func testTraceflowIntraNode(t *testing.T, data *TestData) {
 							Component:     v1beta1.ComponentNetworkPolicy,
 							ComponentInfo: "IngressDefaultRule",
 							Action:        v1beta1.ActionDropped,
-							NetworkPolicy: fmt.Sprintf("K8sNetworkPolicy:%s/test-networkpolicy-allow-all-egress", data.testNamespace),
 						},
 					},
 				},


### PR DESCRIPTION
Packet dropped by K8s NetworkPolicy default drop rule has never been associated with any specific K8s NetworkPolicy. The expectation added by commit 68b5a027320e ("Add NetworkPolicy rule name in Traceflow observation ") is wrong.