### PR TITLE
[Multicast] Add precheck on the encryption mode configurations

### DIFF
--- a/cmd/antrea-agent/options.go
+++ b/cmd/antrea-agent/options.go
@@ -320,9 +320,12 @@ func (o *Options) validateFlowExporterConfig() error {
 	return nil
 }
 
-func (o *Options) validateMulticastConfig() error {
-	if features.DefaultFeatureGate.Enabled(features.Multicast) {
+func (o *Options) validateMulticastConfig(encryptionMode config.TrafficEncryptionModeType) error {
+	if features.DefaultFeatureGate.Enabled(features.Multicast) && o.config.Multicast.Enable {
 		var err error
+		if encryptionMode != config.TrafficEncryptionModeNone {
+			return fmt.Errorf("Multicast feature doesn't work with the current encryption mode '%s'", encryptionMode)
+		}
 		if o.config.Multicast.IGMPQueryInterval != "" {
 			o.igmpQueryInterval, err = time.ParseDuration(o.config.Multicast.IGMPQueryInterval)
 			if err != nil {
@@ -584,7 +587,7 @@ func (o *Options) validateK8sNodeOptions() error {
 	if err := o.validateFlowExporterConfig(); err != nil {
 		return fmt.Errorf("failed to validate flow exporter config: %v", err)
 	}
-	if err := o.validateMulticastConfig(); err != nil {
+	if err := o.validateMulticastConfig(encryptionMode); err != nil {
 		return fmt.Errorf("failed to validate multicast config: %v", err)
 	}
 	if err := o.validateEgressConfig(encapMode); err != nil {

--- a/test/e2e/wireguard_test.go
+++ b/test/e2e/wireguard_test.go
@@ -45,9 +45,12 @@ func TestWireGuard(t *testing.T) {
 		skipIfMissingKernelModule(t, data, node.name, []string{"wireguard"})
 	}
 	var previousTrafficEncryptionMode string
+	var previousMulticastEnabledState bool
 	ac := func(config *agentconfig.AgentConfig) {
 		previousTrafficEncryptionMode = config.TrafficEncryptionMode
 		config.TrafficEncryptionMode = "wireguard"
+		previousMulticastEnabledState = config.Multicast.Enable
+		config.Multicast.Enable = false
 	}
 	if err := data.mutateAntreaConfigMap(nil, ac, false, true); err != nil {
 		t.Fatalf("Failed to enable WireGuard tunnel: %v", err)
@@ -55,6 +58,7 @@ func TestWireGuard(t *testing.T) {
 	defer func() {
 		ac := func(config *agentconfig.AgentConfig) {
 			config.TrafficEncryptionMode = previousTrafficEncryptionMode
+			config.Multicast.Enable = previousMulticastEnabledState
 		}
 		if err := data.mutateAntreaConfigMap(nil, ac, false, true); err != nil {
 			t.Errorf("Failed to disable WireGuard tunnel: %v", err)


### PR DESCRIPTION
Mutlicast feature can't work with WireGuard or IPSec configurations with encap mode. It will return error when Multicast feature gate is enabled and either Wireguard or IPSec is configured in the initial validations.

Fix: #5916