### PR TITLE
Automated cherry pick of #5934: Add a link to CHANGELOG-1.15 (#5934)

### DIFF
--- a/CHANGELOG/README.md
+++ b/CHANGELOG/README.md
@@ -10,6 +10,7 @@ stages](https://github.com/kubernetes/community/blob/master/contributors/devel/s
 Some experimental features can be enabled / disabled using [Feature
 Gates](../docs/feature-gates.md).
 
+- [CHANGELOG-1.15](CHANGELOG-1.15.md)
 - [CHANGELOG-1.14](CHANGELOG-1.14.md)
 - [CHANGELOG-1.13](CHANGELOG-1.13.md)
 - [CHANGELOG-1.12](CHANGELOG-1.12.md)


### PR DESCRIPTION
Cherry pick of #5934 on release-1.15.

#5934: Add a link to CHANGELOG-1.15 (#5934)

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.