### PR TITLE
Update BuildKit configurations to enhance compatibility

### DIFF
--- a/ci/jenkins/test-mc.sh
+++ b/ci/jenkins/test-mc.sh
@@ -137,6 +137,7 @@ function clean_images() {
     docker images | grep -E 'mc-controller|antrea-ubuntu' | awk '{print $3}' | xargs -r docker rmi -f || true
     # Clean up dangling images generated in previous builds.
     docker image prune -f --filter "until=24h" || true > /dev/null
+    check_and_cleanup_docker_build_cache
 }
 
 function cleanup_multicluster_ns {

--- a/ci/jenkins/test-rancher.sh
+++ b/ci/jenkins/test-rancher.sh
@@ -138,6 +138,7 @@ function deliver_antrea {
     git show --numstat
     make clean
     ${CLEAN_STALE_IMAGES}
+    check_and_upgrade_golang
     chmod -R g-w build/images/ovs
     chmod -R g-w build/images/base
     DOCKER_REGISTRY="${DOCKER_REGISTRY}" ./hack/build-antrea-linux-all.sh --pull

--- a/ci/jenkins/test-vmc.sh
+++ b/ci/jenkins/test-vmc.sh
@@ -355,6 +355,7 @@ function deliver_antrea {
     # because they might be being used in other builds running simultaneously.
     docker image prune -af --filter "until=1h" > /dev/null
     docker system df -v
+    check_and_cleanup_docker_build_cache
     set -e
 
     cd $GIT_CHECKOUT_DIR

--- a/ci/jenkins/test.sh
+++ b/ci/jenkins/test.sh
@@ -186,6 +186,7 @@ function clean_antrea {
     done
     docker images | grep 'antrea' | awk '{print $3}' | xargs -r docker rmi || true
     docker images | grep '<none>' | awk '{print $3}' | xargs -r docker rmi || true
+    check_and_cleanup_docker_build_cache
 }
 
 function clean_for_windows_install_cni {

--- a/ci/test-conformance-aks.sh
+++ b/ci/test-conformance-aks.sh
@@ -193,10 +193,12 @@ function deliver_antrea_to_aks() {
     # because they might be being used in other builds running simultaneously.
     docker image prune -f --filter "until=2h" > /dev/null
     docker system df -v
+    check_and_cleanup_docker_build_cache
+
     set -e
 
     cd ${GIT_CHECKOUT_DIR}
-    VERSION="$CLUSTER" make
+    VERSION="$CLUSTER" ./hack/build-antrea-linux-all.sh --pull
     if [[ "$?" -ne "0" ]]; then
         echo "=== Antrea Image build failed ==="
         exit 1

--- a/ci/test-conformance-eks.sh
+++ b/ci/test-conformance-eks.sh
@@ -270,10 +270,11 @@ function deliver_antrea_to_eks() {
     # because they might be being used in other builds running simultaneously.
     docker image prune -f --filter "until=2h" > /dev/null
     docker system df -v
+    check_and_cleanup_docker_build_cache
     set -e
 
     cd ${GIT_CHECKOUT_DIR}
-    VERSION="$CLUSTER" make
+    VERSION="$CLUSTER" ./hack/build-antrea-linux-all.sh --pull
     if [[ "$?" -ne "0" ]]; then
         echo "=== Antrea Image build failed ==="
         exit 1

--- a/ci/test-conformance-gke.sh
+++ b/ci/test-conformance-gke.sh
@@ -211,10 +211,11 @@ function deliver_antrea_to_gke() {
     # because they might be being used in other builds running simultaneously.
     docker image prune -f --filter "until=2h" > /dev/null
     docker system df -v
+    check_and_cleanup_docker_build_cache
     set -e
 
     cd ${GIT_CHECKOUT_DIR}
-    VERSION="$CLUSTER" make -C ${GIT_CHECKOUT_DIR}
+    VERSION="$CLUSTER" ./hack/build-antrea-linux-all.sh --pull
     if [[ "$?" -ne "0" ]]; then
         echo "=== Antrea Image build failed ==="
         exit 1

--- a/docs/minikube.md
+++ b/docs/minikube.md
@@ -26,7 +26,7 @@ minikube start --cni=antrea.yml --network-plugin=cni
 
 These instructions assume that you have built the Antrea Docker image locally
 (e.g. by running `make` from the root of the repository, or in case of arm64 architecture by running
-`DOCKER_BUILDKIT=1 ./hack/build-antrea-ubuntu-all.sh --platform linux/arm64`).
+`./hack/build-antrea-linux-all.sh --platform linux/arm64`).
 
 ```bash
 # load the Antrea Docker image in the minikube nodes

--- a/hack/build-antrea-linux-all.sh
+++ b/hack/build-antrea-linux-all.sh
@@ -165,6 +165,7 @@ cd build/images/base
 cd -
 
 export NO_PULL=1
+export DOCKER_BUILDKIT=1
 if [ "$DISTRO" == "ubuntu" ]; then
     if $COVERAGE; then
         make build-controller-ubuntu-coverage


### PR DESCRIPTION
* Add BuildKit cache cleanup in CI
* Declare DOCKER_BUILDKIT when building image for docker compatibility.

fixes https://github.com/antrea-io/antrea/issues/5941