### PR TITLE
Remove flows which are never used

### DIFF
--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -2399,6 +2399,11 @@ func (f *featureService) nodePortMarkFlows() []binding.Flow {
 		// This generates a flow for every NodePort IP. The flows are used to mark the first packet of NodePort connection
 		// from a local Pod.
 		for i := range nodePortAddresses {
+			// From the perspective of a local Pod, the traffic destined to loopback is not NodePort traffic, so we skip
+			// the loopback address.
+			if nodePortAddresses[i].IsLoopback() {
+				continue
+			}
 			flows = append(flows,
 				NodePortMarkTable.ofTable.BuildFlow(priorityNormal).
 					Cookie(cookieID).

--- a/pkg/agent/openflow/service_test.go
+++ b/pkg/agent/openflow/service_test.go
@@ -51,7 +51,6 @@ func serviceInitFlows(proxyEnabled, isIPv4, proxyAllEnabled, dsrEnabled bool) []
 			flows = append(flows,
 				"cookie=0x1030000000000, table=PreRoutingClassifier, priority=200,ip actions=resubmit:NodePortMark,resubmit:SessionAffinity,resubmit:ServiceLB",
 				"cookie=0x1030000000000, table=NodePortMark, priority=200,ip,nw_dst=192.168.77.100 actions=set_field:0x80000/0x80000->reg4",
-				"cookie=0x1030000000000, table=NodePortMark, priority=200,ip,nw_dst=127.0.0.1 actions=set_field:0x80000/0x80000->reg4",
 				"cookie=0x1030000000000, table=NodePortMark, priority=200,ip,nw_dst=169.254.0.252 actions=set_field:0x80000/0x80000->reg4",
 			)
 		} else {
@@ -85,7 +84,6 @@ func serviceInitFlows(proxyEnabled, isIPv4, proxyAllEnabled, dsrEnabled bool) []
 			flows = append(flows,
 				"cookie=0x1030000000000, table=PreRoutingClassifier, priority=200,ipv6 actions=resubmit:NodePortMark,resubmit:SessionAffinity,resubmit:ServiceLB",
 				"cookie=0x1030000000000, table=NodePortMark, priority=200,ipv6,ipv6_dst=fec0:192:168:77::100 actions=set_field:0x80000/0x80000->reg4",
-				"cookie=0x1030000000000, table=NodePortMark, priority=200,ipv6,ipv6_dst=::1 actions=set_field:0x80000/0x80000->reg4",
 				"cookie=0x1030000000000, table=NodePortMark, priority=200,ipv6,ipv6_dst=fc01::aabb:ccdd:eefe actions=set_field:0x80000/0x80000->reg4",
 			)
 		} else {


### PR DESCRIPTION
```
1. table=NodePortMark, priority=200,ipv6,nw_dst=::1 actions=set_field:0x80000/0x80000->reg4"
2. table=NodePortMark, priority=200,ip,nw_dst=127.0.0.1 actions=set_field:0x80000/0x80000->reg4
3. table=NodePortMark, priority=200,ip,nw_dst=192.168.77.102 actions=set_field:0x80000/0x80000->reg4
4. table=NodePortMark, priority=200,ip,nw_dst=172.17.0.1 actions=set_field:0x80000/0x80000->reg4
5. table=NodePortMark, priority=200,ip,nw_dst=169.254.0.252 actions=set_field:0x80000/0x80000->reg4
6. table=NodePortMark, priority=0 actions=goto_table:SessionAffinity
```

In table NodePortMark:

- Flows 1-2, which were intended to match NodePort traffic from local Pods to loopback IP addresses, have been removed as they are never used.
- Flows 3-5 are kept intact, as they are intended to match NodePort traffic from local Pods to specific Node IP addresses.
- Flow 5 is to match NodePort traffic from local Node or external network, DNAT'd in Node by iptables.

Since that flows 1-2 are never used, remove them.