### PR TITLE
Update ROADMAP doc after Antrea v1.15 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ Also check out [@ProjectAntrea](https://twitter.com/ProjectAntrea) on Twitter!
   on your infrastructure and use case.
 * **Comprehensive policy model**: Antrea provides a comprehensive network policy
   model, which builds upon Kubernetes Network Policies with new features such as
-  policy tiering, rule priorities and cluster-level policies. Refer to the
-  [Antrea Network Policy documentation](docs/antrea-network-policy.md) for a
-  full list of features.
+  policy tiering, rule priorities, cluster-level policies, and Node policies.
+  Refer to the [Antrea Network Policy documentation](docs/antrea-network-policy.md)
+  for a full list of features.
 * **Windows Node support**: Thanks to the portability of Open vSwitch, Antrea
   can use the same data plane implementation on both Linux and Windows
   Kubernetes Nodes.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,12 +17,6 @@ Antrea [version 2](https://github.com/antrea-io/antrea/issues/4832) is coming in
 legacy APIs, dropping support for old K8s versions (< 1.19) to improve support
 for newer ones, and more! This is a big milestone for the project, stay tuned!
 
-### K8s Node security
-
-So far Antrea has focused on K8s Pod networking and security, but we would like
-to extend Antrea-native NetworkPolicies to cover protection of K8s Nodes
-too. There is ongoing work for this, so expect this feature very soon!
-
 ### Quality of life improvements for installation and upgrade
 
 We have a few things planned to improve basic usability:
@@ -37,9 +31,9 @@ We have a few things planned to improve basic usability:
 
 ### Core networking features
 
-We are currently working on supporting VLAN tagging for Egress traffic. In the
-long term, we plan to add BGP support to the Antrea Agent, as it is a much
-requested feature.
+We are working on adding BGP support to the Antrea Agent, as it has been a much
+requested feature. Take a look at [#5948](https://github.com/antrea-io/antrea/issues/5948)
+if this is something you are interested in.
 
 ### Windows support improvements
 


### PR DESCRIPTION
Node NetworkPolicies and support for Egress IPs in different subnets (with VLAN tagging) have been added in the latest Antrea v1.15 release, so removing these items from the ROADMAP.