### PR TITLE
Fixed relative link in Kind documentation

### DIFF
--- a/docs/kind.md
+++ b/docs/kind.md
@@ -153,7 +153,7 @@ antrea-controller-775f4d79f8-6tksp   1/1     Running   0          8m56s
 ## Run the Antrea e2e tests
 
 To run the Antrea e2e test suite on your Kind cluster, please refer to [this
-document](../test/e2e/README.md#running-the-e2e-tests-on-a-kind-cluster).
+document](https://github.com/antrea-io/antrea/blob/main/test/e2e/README.md#running-the-e2e-tests-on-a-kind-cluster).
 
 ## FAQ
 


### PR DESCRIPTION
Added the direct GitHub link to the e2e tests page instead of a relative link in the Kind documentation according to the discussions with @tnqn