### PR TITLE
pkg/agent/cniserver: fix typos in comments

### DIFF
--- a/pkg/agent/cniserver/interface_configuration_linux.go
+++ b/pkg/agent/cniserver/interface_configuration_linux.go
@@ -250,8 +250,7 @@ func (ic *ifConfigurator) configureContainerLinkVeth(
 	result *current.Result,
 ) error {
 	// Include the container veth interface name in the name generation, as one Pod can have more
-	// than one interfaces inc. secondary interfaces, while the host interface name must be
-	// be unique.
+	// than one interfaces inc. secondary interfaces, while the host interface name must be unique.
 	hostIfaceName := util.GenerateContainerHostVethName(podName, podNamespace, containerID, containerIfaceName)
 
 	hostIface := &current.Interface{Name: hostIfaceName}

--- a/pkg/agent/cniserver/pod_configuration.go
+++ b/pkg/agent/cniserver/pod_configuration.go
@@ -155,7 +155,7 @@ func getContainerIPsString(ips []net.IP) string {
 
 // ParseOVSPortInterfaceConfig reads the Pod properties saved in the OVS port
 // external_ids, initializes and returns an InterfaceConfig struct.
-// nill will be returned, if the OVS port does not have external IDs or it is
+// nil will be returned, if the OVS port does not have external IDs or it is
 // not created for a Pod interface.
 func ParseOVSPortInterfaceConfig(portData *ovsconfig.OVSPortData, portConfig *interfacestore.OVSPortConfig) *interfacestore.InterfaceConfig {
 	if portData.ExternalIDs == nil {

--- a/pkg/agent/cniserver/server.go
+++ b/pkg/agent/cniserver/server.go
@@ -58,7 +58,7 @@ const (
 	networkReadyTimeout = 30 * time.Second
 )
 
-// containerAccessArbitrator is used to ensure that concurrent goroutines cannot perfom operations
+// containerAccessArbitrator is used to ensure that concurrent goroutines cannot perform operations
 // on the same containerID. Other parts of the code make this assumption (in particular the
 // InstallPodFlows / UninstallPodFlows methods of the OpenFlow client, which are invoked
 // respectively by CmdAdd and CmdDel). The idea is to simply the locking requirements for the rest
@@ -112,7 +112,7 @@ type CNIServer struct {
 	routeClient        route.Interface
 	isChaining         bool
 	enableBridgingMode bool
-	// Enable AntreaIPAM for secondary networks implementd by other CNIs.
+	// Enable AntreaIPAM for secondary networks implemented by other CNIs.
 	enableSecondaryNetworkIPAM bool
 	disableTXChecksumOffload   bool
 	networkConfig              *config.NetworkConfig


### PR DESCRIPTION
Came accross some typos in in pkg `cniserver` while code-reading. 