### PR TITLE
Allow multiple physical interface support for secondary network bridge

### DIFF
--- a/cmd/antrea-agent/options.go
+++ b/cmd/antrea-agent/options.go
@@ -734,8 +734,8 @@ func (o *Options) validateSecondaryNetworkConfig() error {
 	if brConfig.BridgeName == "" {
 		return fmt.Errorf("bridge name is not provided for the secondary network OVS bridge")
 	}
-	if len(brConfig.PhysicalInterfaces) > 1 {
-		return fmt.Errorf("at most one physical interface can be specified for the secondary network OVS bridge")
+	if len(brConfig.PhysicalInterfaces) > 8 {
+		return fmt.Errorf("at most eight physical interfaces can be specified for the secondary network OVS bridge")
 	}
 
 	return nil

--- a/cmd/antrea-agent/options_test.go
+++ b/cmd/antrea-agent/options_test.go
@@ -319,8 +319,8 @@ func TestOptionsValidateSecondaryNetworkConfig(t *testing.T) {
 			name:               "two interfaces",
 			featureGateValue:   true,
 			ovsBridges:         []string{"br1"},
-			physicalInterfaces: []string{"eth1", "eth2"},
-			expectedErr:        "at most one physical interface can be specified for the secondary network OVS bridge",
+			physicalInterfaces: []string{"eth1", "eth2", "eth3", "eth4", "eth5", "eth6", "eth7", "eth8", "eth9"},
+			expectedErr:        "at most eight physical interfaces can be specified for the secondary network OVS bridge",
 		},
 	}
 	for _, tc := range tests {

--- a/docs/secondary-network.md
+++ b/docs/secondary-network.md
@@ -68,8 +68,8 @@ data:
 ```
 
 At the moment, Antrea supports only a single OVS bridge for secondary networks,
-and supports only a single physical interface on the bridge. The physical
-interface cannot be the Node's management interface, otherwise the Node's
+and supports upto eight physical interfaces on the bridge. The physical
+interfaces cannot be the Node's management interface, otherwise the Node's
 management network connectivity can be broken after `antrea-agent` creates the
 OVS bridge and moves the management interface to the bridge.
 

--- a/pkg/agent/secondarynetwork/init_test.go
+++ b/pkg/agent/secondarynetwork/init_test.go
@@ -82,6 +82,8 @@ func TestCreateOVSBridge(t *testing.T) {
 				m.EXPECT().Create().Return(nil)
 				m.EXPECT().GetOFPort("eth1", false).Return(int32(0), ovsconfig.InvalidArgumentsError("port not found"))
 				m.EXPECT().CreateUplinkPort("eth1", int32(0), map[string]interface{}{"antrea-type": "uplink"}).Return("", nil)
+				m.EXPECT().GetOFPort("eth2", false).Return(int32(1), ovsconfig.InvalidArgumentsError("port not found"))
+				m.EXPECT().CreateUplinkPort("eth2", int32(1), map[string]interface{}{"antrea-type": "uplink"}).Return("", nil)
 			},
 		},
 		{

--- a/pkg/config/agent/config.go
+++ b/pkg/config/agent/config.go
@@ -398,7 +398,6 @@ type SecondaryNetworkConfig struct {
 
 type OVSBridgeConfig struct {
 	BridgeName string `yaml:"bridgeName"`
-	// Names of physical interfaces to be connected to the bridge. At the moment,
-	// only a single physical interface is supported.
+	// Names of physical interfaces to be connected to the bridge.
 	PhysicalInterfaces []string `yaml:"physicalInterfaces,omitempty"`
 }


### PR DESCRIPTION
Given that most SR-IOV have 8 queues, this commit allows adding at most 8 physical interfaces to the secondary OVS bridge.

Fixes: https://github.com/antrea-io/antrea/issues/5846