### PR TITLE
[VM Agent] Build antrea binaries with static link

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -551,3 +551,13 @@ markdownlint-fix:
 spelling-fix:
 	@echo "===> Updating incorrect spellings <==="
 	$(CURDIR)/hack/update-spelling.sh
+
+.PHONY: vm-bin
+vm-bin:
+	@mkdir -p $(BINDIR)
+	@CGO_ENABLED=0 $(GO) build -o $(BINDIR) $(GOFLAGS) -ldflags '$(LDFLAGS)' antrea.io/antrea/cmd/antrea-agent antrea.io/antrea/cmd/antctl
+
+.PHONY: docker-vm-bin
+docker-vm-bin: $(DOCKER_CACHE)
+	$(DOCKER_ENV) make vm-bin
+	@chmod -R 0755 $<

--- a/ci/jenkins/test-vm.sh
+++ b/ci/jenkins/test-vm.sh
@@ -309,7 +309,7 @@ function build_antrea_binary {
     export GOCACHE=${WORKSPACE}/../gocache
     export PATH=${GOROOT}/bin:$PATH
 
-    make docker-bin
+    make docker-vm-bin
     make docker-windows-bin
 
     cp ./build/yamls/externalnode/conf/antrea-agent.conf ${WORKDIR}/antrea-agent.conf

--- a/test/e2e/vmagent_test.go
+++ b/test/e2e/vmagent_test.go
@@ -216,9 +216,9 @@ func testExternalNodeSupportBundleCollection(t *testing.T, data *TestData, vmLis
 		require.NoError(t, err)
 		var expectedInfoEntries []string
 		if vm.osType == linuxOS {
-			expectedInfoEntries = []string{"address", "addressgroups", "agentinfo", "appliedtogroups", "flows", "iptables", "link", "logs", "memprofile", "networkpolicies", "ovsports", "route"}
+			expectedInfoEntries = []string{"address", "addressgroups", "agentinfo", "appliedtogroups", "flows", "goroutinestacks", "iptables", "link", "logs", "memprofile", "networkpolicies", "ovsports", "route"}
 		} else if vm.osType == windowsOS {
-			expectedInfoEntries = []string{"addressgroups", "agentinfo", "appliedtogroups", "flows", "ipconfig", "logs\\ovs\\ovs-vswitchd.log", "logs\\ovs\\ovsdb-server.log", "memprofile", "network-adapters", "networkpolicies", "ovsports", "routes"}
+			expectedInfoEntries = []string{"addressgroups", "agentinfo", "appliedtogroups", "flows", "goroutinestacks", "ipconfig", "logs\\ovs\\ovs-vswitchd.log", "logs\\ovs\\ovsdb-server.log", "memprofile", "network-adapters", "networkpolicies", "ovsports", "routes"}
 		}
 		actualExpectedInfoEntries := strings.Split(strings.Trim(stdout, "\n"), "\n")
 		t.Logf("Actual files after extracting SupportBundleCollection tarball %s_%s: %v", vm.nodeName, bundleName, actualExpectedInfoEntries)


### PR DESCRIPTION
This change is to resolve an issue that antrea-agent may not work on a VM without the linked the libraries if the runtime OS is different from the environment in which they were compiled. The solution is to support building the bits with static link when the environment variable "STATIC_LINK" is set.