### PR TITLE
Use docker buildx to build base Linux images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,8 @@ jobs:
     - uses: actions/checkout@v4
       with:
         show-progress: false
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
     - name: Build Antrea amd64 Docker image without pushing to registry
       if: ${{ github.repository != 'antrea-io/antrea' || github.event_name != 'push' || github.ref != 'refs/heads/main' }}
       run: |
@@ -72,6 +74,8 @@ jobs:
     - uses: actions/checkout@v4
       with:
         show-progress: false
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
     - name: Build Antrea UBI8 Docker image without pushing to registry
       if: ${{ github.repository != 'antrea-io/antrea' || github.event_name != 'push' || github.ref != 'refs/heads/main' }}
       run: |

--- a/build/images/base/build.sh
+++ b/build/images/base/build.sh
@@ -19,23 +19,21 @@
 
 set -eo pipefail
 
-function echoerr {
-    >&2 echo "$@"
-}
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+source $THIS_DIR/../build-utils.sh
 
 _usage="Usage: $0 [--pull] [--push] [--platform <PLATFORM>] [--distro [ubuntu|ubi]]
 Build the antrea base image.
         --pull                  Always attempt to pull a newer version of the base images
         --push                  Push the built image to the registry
         --platform <PLATFORM>   Target platform for the image if server is multi-platform capable
-        --distro <distro>       Target Linux distribution"
-
-function print_usage {
-    echoerr "$_usage"
-}
+        --distro <distro>       Target Linux distribution
+        --no-cache              Do not use the local build cache nor the cached image from the registry"
 
 PULL=false
 PUSH=false
+NO_CACHE=false
 PLATFORM=""
 DISTRO="ubuntu"
 
@@ -60,6 +58,10 @@ case $key in
     DISTRO="$2"
     shift 2
     ;;
+    --no-cache)
+    NO_CACHE=true
+    shift
+    ;;
     -h|--help)
     print_usage
     exit 0
@@ -70,6 +72,15 @@ case $key in
     ;;
 esac
 done
+
+# When --push is provided, we assume that we want to use --cache-to, which will
+# push the "cache image" to the registry. This functionality is not supported
+# with the default docker driver.
+# See https://docs.docker.com/build/cache/backends/registry/
+if $PUSH && ! check_docker_build_driver "docker-container"; then
+    echoerr "--push requires the docker-container build driver"
+    exit 1
+fi
 
 if [ "$PLATFORM" != "" ] && $PUSH; then
     echoerr "Cannot use --platform with --push"
@@ -86,8 +97,6 @@ if [ "$DISTRO" != "ubuntu" ] && [ "$DISTRO" != "ubi" ]; then
     exit 1
 fi
 
-THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-
 pushd $THIS_DIR > /dev/null
 
 CNI_BINARIES_VERSION=$(head -n 1 ../deps/cni-binaries-version)
@@ -96,6 +105,7 @@ SURICATA_VERSION=$(head -n 1 ../deps/suricata-version)
 BUILD_TAG=$(../build-tag.sh)
 
 if $PULL; then
+    # The ubuntu image is also used for the UBI build (for the cni-binaries intermediate image).
     if [[ ${DOCKER_REGISTRY} == "" ]]; then
         docker pull $PLATFORM_ARG ubuntu:22.04
     else
@@ -106,14 +116,10 @@ if $PULL; then
     if [ "$DISTRO" == "ubuntu" ]; then
         IMAGES_LIST=(
             "antrea/openvswitch:$BUILD_TAG"
-            "antrea/cni-binaries:$CNI_BINARIES_VERSION"
-            "antrea/base-ubuntu:$BUILD_TAG"
         )
     elif [ "$DISTRO" == "ubi" ]; then
         IMAGES_LIST=(
             "antrea/openvswitch-ubi:$BUILD_TAG"
-            "antrea/cni-binaries:$CNI_BINARIES_VERSION"
-            "antrea/base-ubi:$BUILD_TAG"
         )
     fi
     for image in "${IMAGES_LIST[@]}"; do
@@ -129,34 +135,31 @@ if $PULL; then
     done
 fi
 
-docker build $PLATFORM_ARG --target cni-binaries \
-       --cache-from antrea/cni-binaries:$CNI_BINARIES_VERSION \
-       -t antrea/cni-binaries:$CNI_BINARIES_VERSION \
-       --build-arg CNI_BINARIES_VERSION=$CNI_BINARIES_VERSION \
-       --build-arg BUILD_TAG=$BUILD_TAG .
+function docker_build_and_push() {
+    local image="$1"
+    local dockerfile="$2"
+    local build_args="--build-arg CNI_BINARIES_VERSION=$CNI_BINARIES_VERSION --build-arg SURICATA_VERSION=$SURICATA_VERSION --build-arg BUILD_TAG=$BUILD_TAG"
+    local cache_args=""
+    if $PUSH; then
+        cache_args="$cache_args --cache-to type=registry,ref=$image-cache:$BUILD_TAG,mode=max"
+    fi
+    if $NO_CACHE; then
+        cache_args="$cache_args --no-cache"
+    else
+        cache_args="$cache_args --cache-from type=registry,ref=$image-cache:$BUILD_TAG,mode=max"
+    fi
+    docker buildx build $PLATFORM_ARG -o type=docker -t $image:$BUILD_TAG $cache_args $build_args -f $dockerfile .
+
+    if $PUSH; then
+        docker push $image:$BUILD_TAG
+    fi
+}
+
 
 if [ "$DISTRO" == "ubuntu" ]; then
-    docker build $PLATFORM_ARG \
-           --cache-from antrea/cni-binaries:$CNI_BINARIES_VERSION \
-           --cache-from antrea/base-ubuntu:$BUILD_TAG \
-           -t antrea/base-ubuntu:$BUILD_TAG \
-           --build-arg CNI_BINARIES_VERSION=$CNI_BINARIES_VERSION \
-           --build-arg SURICATA_VERSION=$SURICATA_VERSION \
-           --build-arg BUILD_TAG=$BUILD_TAG .
+    docker_build_and_push "antrea/base-ubuntu" Dockerfile
 elif [ "$DISTRO" == "ubi" ]; then
-    docker build $PLATFORM_ARG \
-           --cache-from antrea/cni-binaries:$CNI_BINARIES_VERSION \
-           --cache-from antrea/base-ubi:$BUILD_TAG \
-           -t antrea/base-ubi:$BUILD_TAG \
-           -f Dockerfile.ubi \
-           --build-arg CNI_BINARIES_VERSION=$CNI_BINARIES_VERSION \
-           --build-arg SURICATA_VERSION=$SURICATA_VERSION \
-           --build-arg BUILD_TAG=$BUILD_TAG .
-fi
-
-if $PUSH; then
-    docker push antrea/cni-binaries:$CNI_BINARIES_VERSION
-    docker push antrea/base-$DISTRO:$BUILD_TAG
+    docker_build_and_push "antrea/base-ubi" Dockerfile.ubi
 fi
 
 popd > /dev/null

--- a/build/images/build-utils.sh
+++ b/build/images/build-utils.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# Copyright 2024 Antrea Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function echoerr {
+    >&2 echo "$@"
+}
+
+function print_usage {
+    echoerr "$_usage"
+}
+
+function check_for_buildx() {
+    local rc=0
+    docker buildx inspect > /dev/null 2>&1 || rc=1
+    return $rc
+}
+
+function get_docker_build_driver() {
+    local driver=$(docker buildx inspect | grep "^Driver:" | awk '{print $2}')
+    echo "$driver"
+}
+
+function check_docker_build_driver() {
+    local expected="$1"
+    local actual="$(get_docker_build_driver)"
+    if [ "$actual" != "$expected" ]; then
+       return 1
+    fi
+    return 0
+}

--- a/hack/build-antrea-linux-all.sh
+++ b/hack/build-antrea-linux-all.sh
@@ -16,9 +16,9 @@
 
 set -eo pipefail
 
-function echoerr {
-    >&2 echo "$@"
-}
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+source $THIS_DIR/../build/images/build-utils.sh
 
 _usage="Usage: $0 [--pull] [--push-base-images] [--coverage] [--platform <PLATFORM>] [--distro [ubuntu|ubi]]
 Build the antrea image, as well as all the base images in the build chain. This is typically used in
@@ -28,14 +28,12 @@ all Dockerfiles.
         --push-base-images      Push built images to the registry. Only base images will be pushed.
         --coverage              Build the image with support for code coverage.
         --platform <PLATFORM>   Target platform for the images if server is multi-platform capable.
-        --distro <distro>       Target Linux distribution."
-
-function print_usage {
-    echoerr "$_usage"
-}
+        --distro <distro>       Target Linux distribution.
+        --no-cache              Do not use the local build cache nor the cached image from the registry."
 
 PULL=false
 PUSH=false
+NO_CACHE=false
 COVERAGE=false
 PLATFORM=""
 DISTRO="ubuntu"
@@ -65,6 +63,10 @@ case $key in
     DISTRO="$2"
     shift 2
     ;;
+    --no-cache)
+    NO_CACHE=true
+    shift
+    ;;
     -h|--help)
     print_usage
     exit 0
@@ -76,7 +78,10 @@ case $key in
 esac
 done
 
-THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+if ! check_for_buildx; then
+    echoerr "Buildx is required to execute this script"
+    exit 1
+fi
 
 pushd "$THIS_DIR/.." > /dev/null
 
@@ -84,6 +89,9 @@ ARGS=""
 PLATFORM_ARG=""
 if $PUSH; then
    ARGS="$ARGS --push"
+fi
+if $NO_CACHE; then
+    ARGS="$ARGS --no-cache"
 fi
 if [ "$PLATFORM" != "" ]; then
     ARGS="$ARGS --platform $PLATFORM"
@@ -110,8 +118,7 @@ echo "BUILD_TAG: $BUILD_TAG"
 # We pull all images ahead of time, instead of calling the independent build.sh
 # scripts with "--pull". We do not want to overwrite the antrea/openvswitch
 # image we just built when calling build.sh to build the antrea/base-ubuntu
-# image! This is a bit more inconvenient to maintain, but we rarely introduce
-# new base images in the build chain.
+# image!
 if $PULL; then
     if [[ ${DOCKER_REGISTRY} == "" ]]; then
         docker pull $PLATFORM_ARG ubuntu:22.04
@@ -122,32 +129,10 @@ if $PULL; then
         docker pull ${DOCKER_REGISTRY}/antrea/golang:$GO_VERSION
         docker tag ${DOCKER_REGISTRY}/antrea/golang:$GO_VERSION golang:$GO_VERSION
     fi
-    if [ "$DISTRO" == "ubuntu" ]; then
-        IMAGES_LIST=(
-            "antrea/openvswitch-debs:$BUILD_TAG"
-            "antrea/openvswitch:$BUILD_TAG"
-            "antrea/cni-binaries:$CNI_BINARIES_VERSION"
-            "antrea/base-ubuntu:$BUILD_TAG"
-        )
-    elif [ "$DISTRO" == "ubi" ]; then
-        IMAGES_LIST=(
-            "antrea/openvswitch-rpms:$BUILD_TAG"
-            "antrea/openvswitch-ubi:$BUILD_TAG"
-            "antrea/cni-binaries:$CNI_BINARIES_VERSION"
-            "antrea/base-ubi:$BUILD_TAG"
-        )
+    if [ "$DISTRO" == "ubi" ]; then
+        docker pull $PLATFORM_ARG centos:centos7
+        docker pull $PLATFORM_ARG registry.access.redhat.com/ubi8
     fi
-    for image in "${IMAGES_LIST[@]}"; do
-        if [[ ${DOCKER_REGISTRY} == "" ]]; then
-            docker pull $PLATFORM_ARG "${image}" || true
-        else
-            rc=0
-            docker pull "${DOCKER_REGISTRY}/${image}" || rc=$?
-            if [[ $rc -eq 0 ]]; then
-                docker tag "${DOCKER_REGISTRY}/${image}" "${image}"
-            fi
-        fi
-    done
 fi
 
 cd build/images/ovs
@@ -158,7 +143,13 @@ cd build/images/base
 ./build.sh $ARGS
 cd -
 
+if $NO_CACHE; then
+    export NO_CACHE=1
+fi
 export NO_PULL=1
+# To support Docker versions where buildx is not the default build client (i.e.,
+# versions prior to Docker Engine 23.0 and Docker Desktop 4.19).
+# This can be removed when the Makefile is updated to use "docker buildx" explicitly.
 export DOCKER_BUILDKIT=1
 if [ "$DISTRO" == "ubuntu" ]; then
     if $COVERAGE; then

--- a/hack/build-antrea-linux-all.sh
+++ b/hack/build-antrea-linux-all.sh
@@ -78,6 +78,10 @@ case $key in
 esac
 done
 
+# To support Docker versions where buildx is not the default build client (i.e.,
+# versions prior to Docker Engine 23.0 and Docker Desktop 4.19).
+export DOCKER_CLI_EXPERIMENTAL=enabled
+
 if ! check_for_buildx; then
     echoerr "Buildx is required to execute this script"
     exit 1
@@ -149,7 +153,9 @@ fi
 export NO_PULL=1
 # To support Docker versions where buildx is not the default build client (i.e.,
 # versions prior to Docker Engine 23.0 and Docker Desktop 4.19).
-# This can be removed when the Makefile is updated to use "docker buildx" explicitly.
+# This can be removed when the Makefile is updated to use "docker buildx"
+# explicitly (note that we already set DOCKER_CLI_EXPERIMENTAL=enabled at the
+# beginning of the script).
 export DOCKER_BUILDKIT=1
 if [ "$DISTRO" == "ubuntu" ]; then
     if $COVERAGE; then


### PR DESCRIPTION
We use "docker buildx" when building the base Linux images for Antrea. This gives us access to all the BuildKit capabilities, in particular exporting the build cache to the registry as a separate image, when using the docker-container driver. Exporting the cache means that the base images won't need to be rebuilt from scratch every time (whether it is for local builds or CI builds).

Using buildx with Docker requires Docker Engine 19.03 or newer, but that version came out in 2019. Note that we already require buildx / BuildKit since merging https://github.com/antrea-io/antrea/pull/5918.

Note that in recent Docker versions (starting with Docker Engine 23.0 and Docker Desktop 4.19), "docker build" is an alias for "docker buildx build" (buildx is the default build client). However, explicitly using "docker buildx build" lets us support older versions as well.

While exporting the cache to the registry requires using the docker-container driver, and will not work with the default docker driver, developers are not supposed to export the cache anyway. This is reserved for Github CI jobs.

We also add a new "--no-cache" option to force re-building from scratch. That option should not be required for normal workflows.

The Makefile is improved to reduce verbosity.

Fixes #5944