### PR TITLE
Graduate Helm support

### DIFF
--- a/docs/helm.md
+++ b/docs/helm.md
@@ -29,8 +29,6 @@ We provide the following Helm charts:
 Note that these charts are the same charts that we use to generate the YAML
 manifests for the `kubectl apply` installation method.
 
-Helm installation is currently considered Alpha.
-
 ## Prerequisites
 
 * Ensure that the necessary


### PR DESCRIPTION
There was a disclaimer in the documentation that the Helm installation method was still considered "Alpha".

We now consider this installation method stable, and we remove the disclaimer for the Antrea v2.0 release.

For #4832