### PR TITLE
Disable cgo for all Antrea binaries

### DIFF
--- a/build/images/Dockerfile.build.agent.coverage
+++ b/build/images/Dockerfile.build.agent.coverage
@@ -24,11 +24,7 @@ RUN go mod download
 
 COPY . /antrea
 
-# Disable CGO for antctl in case it is copied outside of the container image. It
-# also reduces the size of the binary and aligns with how we distribute antctl
-# in release assets.
-RUN CGO_ENABLED=0 make antctl-linux antctl-instr-binary
-RUN mv bin/antctl-linux bin/antctl
+RUN make antctl-linux antctl-instr-binary && mv bin/antctl-linux bin/antctl
 
 RUN make antrea-agent antrea-cni antrea-agent-instr-binary
 

--- a/build/images/Dockerfile.build.agent.ubi
+++ b/build/images/Dockerfile.build.agent.ubi
@@ -46,12 +46,9 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
 
 COPY . /antrea
 
-# Disable CGO for antctl in case it is copied outside of the container image. It
-# also reduces the size of the binary and aligns with how we distribute antctl
-# in release assets.
 RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=cache,target=/root/.cache/go-build/ \
-    CGO_ENABLED=0 make antctl-linux && mv bin/antctl-linux bin/antctl
+    make antctl-linux && mv bin/antctl-linux bin/antctl
 
 RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=cache,target=/root/.cache/go-build/ \

--- a/build/images/Dockerfile.build.agent.ubuntu
+++ b/build/images/Dockerfile.build.agent.ubuntu
@@ -25,12 +25,9 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
 
 COPY . /antrea
 
-# Disable CGO for antctl in case it is copied outside of the container image. It
-# also reduces the size of the binary and aligns with how we distribute antctl
-# in release assets.
 RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=cache,target=/root/.cache/go-build/ \
-    CGO_ENABLED=0 make antctl-linux && mv bin/antctl-linux bin/antctl
+    make antctl-linux && mv bin/antctl-linux bin/antctl
 
 RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=cache,target=/root/.cache/go-build/ \

--- a/build/images/Dockerfile.build.controller.coverage
+++ b/build/images/Dockerfile.build.controller.coverage
@@ -24,11 +24,7 @@ RUN go mod download
 
 COPY . /antrea
 
-# Disable CGO for antctl in case it is copied outside of the container image. It
-# also reduces the size of the binary and aligns with how we distribute antctl
-# in release assets.
-RUN CGO_ENABLED=0 make antctl-linux antctl-instr-binary
-RUN mv bin/antctl-linux bin/antctl
+RUN make antctl-linux antctl-instr-binary && mv bin/antctl-linux bin/antctl
 
 RUN make antrea-controller antrea-controller-instr-binary
 

--- a/build/images/Dockerfile.build.controller.ubi
+++ b/build/images/Dockerfile.build.controller.ubi
@@ -46,12 +46,9 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
 
 COPY . /antrea
 
-# Disable CGO for antctl in case it is copied outside of the container image. It
-# also reduces the size of the binary and aligns with how we distribute antctl
-# in release assets.
 RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=cache,target=/root/.cache/go-build/ \
-    CGO_ENABLED=0 make antctl-linux && mv bin/antctl-linux bin/antctl
+    make antctl-linux && mv bin/antctl-linux bin/antctl
 
 RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=cache,target=/root/.cache/go-build/ \

--- a/build/images/Dockerfile.build.controller.ubuntu
+++ b/build/images/Dockerfile.build.controller.ubuntu
@@ -25,12 +25,9 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
 
 COPY . /antrea
 
-# Disable CGO for antctl in case it is copied outside of the container image. It
-# also reduces the size of the binary and aligns with how we distribute antctl
-# in release assets.
 RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=cache,target=/root/.cache/go-build/ \
-    CGO_ENABLED=0 make antctl-linux && mv bin/antctl-linux bin/antctl
+    make antctl-linux && mv bin/antctl-linux bin/antctl
 
 RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=cache,target=/root/.cache/go-build/ \

--- a/build/images/Dockerfile.build.coverage
+++ b/build/images/Dockerfile.build.coverage
@@ -24,13 +24,11 @@ RUN go mod download
 
 COPY . /antrea
 
-# Disable CGO for antctl in case it is copied outside of the container image. It
-# also reduces the size of the binary and aligns with how we distribute antctl
-# in release assets.
-RUN CGO_ENABLED=0 make antctl-linux antctl-instr-binary
-RUN mv bin/antctl-linux bin/antctl
+# Build antctl first in order to share an extra layer with
+# build/images/Dockerfile.build.agent.coverage and build/images/Dockerfile.build.controller.coverage.
+RUN make antctl-linux antctl-instr-binary && mv bin/antctl-linux bin/antctl
 
-# Build antrea-agent and antrea-cni first in order to share an extra layer with
+# Then build antrea-agent and antrea-cni, in order to share an extra layer with
 # build/images/Dockerfile.build.agent.coverage.
 RUN make antrea-agent antrea-cni antrea-agent-instr-binary
 

--- a/build/images/Dockerfile.build.ubi
+++ b/build/images/Dockerfile.build.ubi
@@ -17,7 +17,7 @@ FROM registry.access.redhat.com/ubi8 as antrea-build
 
 ADD https://go.dev/dl/?mode=json&include=all go-versions.json
 
-RUN yum install ca-certificates gcc git jq make wget -y
+RUN yum install ca-certificates gcc jq make wget -y
 
 ARG GO_VERSION
 

--- a/build/images/Dockerfile.build.ubi
+++ b/build/images/Dockerfile.build.ubi
@@ -12,30 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG BUILD_TAG
-FROM registry.access.redhat.com/ubi8 as antrea-build
-
-ADD https://go.dev/dl/?mode=json&include=all go-versions.json
-
-RUN yum install ca-certificates gcc jq make wget -y
-
 ARG GO_VERSION
-
-# GO_VERSION is a Go minor version, we use the downloaded go-versions.json file
-# to identify and install the latest patch release for this minor version.
-RUN set -eux; \
-    arch="$(uname -m)"; \
-    case "${arch##*-}" in \
-         x86_64) goArch='amd64' ;; \
-         arm) goArch='armv6l' ;; \
-         aarch64) goArch='arm64' ;; \
-         *) goArch=''; echo >&2; echo >&2 "unsupported architecture '$arch'"; echo >&2 ; exit 1 ;; \
-    esac; \
-    GO_ARCHIVE=$(jq --arg version_prefix "go${GO_VERSION}." --arg arch "$goArch" -r '. | map(select(. | .version | startswith($version_prefix))) | first | .files[] | select(.os == "linux" and .arch == $arch and .kind == "archive").filename' go-versions.json); \
-    wget -q -O - https://go.dev/dl/${GO_ARCHIVE} | tar xz -C /usr/local/
-
-# Using ENV makes the change persistent, but this is just a builder image.
-ENV PATH /usr/local/go/bin:$PATH
+ARG BUILD_TAG
+FROM golang:${GO_VERSION} as antrea-build
 
 WORKDIR /antrea
 

--- a/build/images/Dockerfile.build.ubi
+++ b/build/images/Dockerfile.build.ubi
@@ -46,14 +46,13 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
 
 COPY . /antrea
 
-# Disable CGO for antctl in case it is copied outside of the container image. It
-# also reduces the size of the binary and aligns with how we distribute antctl
-# in release assets.
+# Build antctl first in order to share an extra layer with
+# build/images/Dockerfile.build.agent.ubi and build/images/Dockerfile.build.controller.ubi.
 RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=cache,target=/root/.cache/go-build/ \
-    CGO_ENABLED=0 make antctl-linux && mv bin/antctl-linux bin/antctl
+    make antctl-linux && mv bin/antctl-linux bin/antctl
 
-# Build antrea-agent and antrea-cni first in order to share an extra layer with
+# Then build antrea-agent and antrea-cni, in order to share an extra layer with
 # build/images/Dockerfile.build.agent.ubi.
 RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=cache,target=/root/.cache/go-build/ \

--- a/build/images/Dockerfile.build.ubuntu
+++ b/build/images/Dockerfile.build.ubuntu
@@ -25,14 +25,13 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
 
 COPY . /antrea
 
-# Disable CGO for antctl in case it is copied outside of the container image. It
-# also reduces the size of the binary and aligns with how we distribute antctl
-# in release assets.
+# Build antctl first in order to share an extra layer with
+# build/images/Dockerfile.build.agent.ubuntu and build/images/Dockerfile.build.controller.ubuntu.
 RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=cache,target=/root/.cache/go-build/ \
-    CGO_ENABLED=0 make antctl-linux && mv bin/antctl-linux bin/antctl
+    make antctl-linux && mv bin/antctl-linux bin/antctl
 
-# Build antrea-agent and antrea-cni first in order to share an extra layer with
+# Then build antrea-agent and antrea-cni, in order to share an extra layer with
 # build/images/Dockerfile.build.agent.ubuntu.
 RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=cache,target=/root/.cache/go-build/ \

--- a/hack/release/prepare-assets.sh
+++ b/hack/release/prepare-assets.sh
@@ -49,6 +49,9 @@ pushd $THIS_DIR/../.. > /dev/null
 mkdir -p "$1"
 OUTPUT_DIR=$(cd "$1" && pwd)
 
+# Cgo should always be disabled for release assets.
+export CGO_ENABLED=0
+
 ANTREA_BUILDS=(
     "linux amd64 linux-x86_64"
     "linux arm64 linux-arm64"
@@ -63,8 +66,6 @@ for build in "${ANTREA_BUILDS[@]}"; do
     arch="${args[1]}"
     suffix="${args[2]}"
 
-    # all "*-release" targets disable cgo, which is appropriate when
-    # distributing release assets, for portability.
     GOOS=$os GOARCH=$arch ANTCTL_BINARY_NAME="antctl-$suffix" BINDIR="$OUTPUT_DIR" make antctl-release
 done
 


### PR DESCRIPTION
Instead of selectively disabling cgo for some binaries (e.g., release
assets), we now unconditionally disable cgo for all binaries, even those
that only run inside the container image for which they were built
(e.g., antrea-controller). After some analysis, there seems to be no
downside in doing this. We also get some benefits such as reduced build
time for the default make command.

Fixes #5724