### PR TITLE
bug: fixing `running antrea-controller --version "outside of K8s" print warnings `

### DIFF
--- a/pkg/controller/certificatesigningrequest/approving_controller.go
+++ b/pkg/controller/certificatesigningrequest/approving_controller.go
@@ -60,9 +60,7 @@ func NewCSRApprovingController(client clientset.Interface, csrInformer cache.Sha
 		csrListerSynced: csrInformer.HasSynced,
 		queue:           workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(minRetryDelay, maxRetryDelay), "certificateSigningRequest"),
 		approvers: []approver{
-			&ipsecCSRApprover{
-				client: client,
-			},
+			newIPsecCSRApprover(client),
 		},
 	}
 	csrInformer.AddEventHandlerWithResyncPeriod(

--- a/pkg/controller/certificatesigningrequest/ipsec_csr_approver.go
+++ b/pkg/controller/certificatesigningrequest/ipsec_csr_approver.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"crypto/x509"
 	"fmt"
+	"os"
 	"reflect"
 	"strings"
 
@@ -38,12 +39,6 @@ const (
 	ipsecCSRApproverName = "AntreaIPsecCSRApprover"
 )
 
-var (
-	antreaAgentServiceAccountName = strings.Join([]string{
-		"system", "serviceaccount", env.GetAntreaNamespace(), "antrea-agent",
-	}, ":")
-)
-
 type ipsecCSRApprover struct {
 	client clientset.Interface
 }
@@ -53,6 +48,22 @@ var ipsecTunnelUsages = sets.New[string](
 )
 
 var _ approver = (*ipsecCSRApprover)(nil)
+
+func getAntreaAgentServiceAccount() string {
+	antreaAgentServiceAccountNameWithoutNS := strings.Join([]string{
+		"system", "serviceaccount", "antrea-agent",
+	}, ":")
+
+	antreaAgentServiceAccountNameWithNS := strings.Join([]string{
+		"system", "serviceaccount", env.GetAntreaNamespace(), "antrea-agent",
+	}, ":")
+
+	if os.Getenv("POD_NAMESPACE") == "" {
+		return antreaAgentServiceAccountNameWithoutNS
+	} else {
+		return antreaAgentServiceAccountNameWithNS
+	}
+}
 
 func (ic *ipsecCSRApprover) recognize(csr *certificatesv1.CertificateSigningRequest) bool {
 	return csr.Spec.SignerName == antreaapis.AntreaIPsecCSRSignerName
@@ -123,7 +134,7 @@ func (ic *ipsecCSRApprover) verifyCertificateRequest(req *x509.CertificateReques
 }
 
 func (ic *ipsecCSRApprover) verifyIdentity(nodeName string, csr *certificatesv1.CertificateSigningRequest) error {
-	if csr.Spec.Username != antreaAgentServiceAccountName {
+	if csr.Spec.Username != getAntreaAgentServiceAccount() {
 		return errUserUnauthorized
 	}
 	podNameValues, podUIDValues := csr.Spec.Extra[sautil.PodNameKey], csr.Spec.Extra[sautil.PodUIDKey]

--- a/pkg/controller/certificatesigningrequest/ipsec_csr_approver.go
+++ b/pkg/controller/certificatesigningrequest/ipsec_csr_approver.go
@@ -50,16 +50,14 @@ var ipsecTunnelUsages = sets.New[string](
 var _ approver = (*ipsecCSRApprover)(nil)
 
 func getAntreaAgentServiceAccount() string {
-	agentServiceAccountName := strings.Join([]string{
+	return strings.Join([]string{
 		"system", "serviceaccount", env.GetAntreaNamespace(), "antrea-agent",
 	}, ":")
-
-	return agentServiceAccountName
 }
 
 func newIPsecCSRApprover(client clientset.Interface) *ipsecCSRApprover {
 	return &ipsecCSRApprover{
-		client: client,
+		client:                        client,
 		antreaAgentServiceAccountName: getAntreaAgentServiceAccount(),
 	}
 }

--- a/pkg/controller/certificatesigningrequest/ipsec_csr_approver.go
+++ b/pkg/controller/certificatesigningrequest/ipsec_csr_approver.go
@@ -57,8 +57,9 @@ func getAntreaAgentServiceAccount() string {
 	return agentServiceAccountName
 }
 
-func newIPsecCSRApprover() *ipsecCSRApprover {
+func newIPsecCSRApprover(client clientset.Interface) *ipsecCSRApprover {
 	return &ipsecCSRApprover{
+		client: client,
 		antreaAgentServiceAccountName: getAntreaAgentServiceAccount(),
 	}
 }
@@ -132,8 +133,7 @@ func (ic *ipsecCSRApprover) verifyCertificateRequest(req *x509.CertificateReques
 }
 
 func (ic *ipsecCSRApprover) verifyIdentity(nodeName string, csr *certificatesv1.CertificateSigningRequest) error {
-	c := newIPsecCSRApprover()
-	if csr.Spec.Username != c.antreaAgentServiceAccountName {
+	if csr.Spec.Username != ic.antreaAgentServiceAccountName {
 		return errUserUnauthorized
 	}
 	podNameValues, podUIDValues := csr.Spec.Extra[sautil.PodNameKey], csr.Spec.Extra[sautil.PodUIDKey]

--- a/pkg/controller/certificatesigningrequest/ipsec_csr_approver_test.go
+++ b/pkg/controller/certificatesigningrequest/ipsec_csr_approver_test.go
@@ -201,9 +201,7 @@ func Test_validIPSecCSR(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			client := fake.NewSimpleClientset(tt.objects...)
-			ic := &ipsecCSRApprover{
-				client: client,
-			}
+			ic := newIPsecCSRApprover(client)
 			err := ic.verifyCertificateRequest(tt.cr, tt.keyUsages)
 			if tt.expectedErr == nil {
 				assert.NoError(t, err, "validIPSecCSR should not return an error")
@@ -373,9 +371,7 @@ func Test_verifyIdentity(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			client := fake.NewSimpleClientset(tt.objects...)
-			ic := &ipsecCSRApprover{
-				client: client,
-			}
+			ic := newIPsecCSRApprover(client)
 			err := ic.verifyIdentity(tt.nodeName, tt.csr)
 			if tt.expectedErr == nil {
 				assert.NoError(t, err, "verifyPodOnNode should not return an error")
@@ -435,9 +431,7 @@ func Test_ipsecCertificateApprover_recognize(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			client := fake.NewSimpleClientset(tt.objects...)
-			ic := &ipsecCSRApprover{
-				client: client,
-			}
+			ic := newIPsecCSRApprover(client)
 			recognized := ic.recognize(tt.csr)
 			assert.Equal(t, tt.expectedResult, recognized)
 		})
@@ -590,9 +584,7 @@ func Test_ipsecCertificateApprover_verify(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			objs := append(tt.objects, tt.csr)
 			client := fake.NewSimpleClientset(objs...)
-			ic := &ipsecCSRApprover{
-				client: client,
-			}
+			ic := newIPsecCSRApprover(client)
 			approved, err := ic.verify(tt.csr)
 			if tt.expectedError != nil {
 				assert.EqualError(t, err, tt.expectedError.Error())


### PR DESCRIPTION
fix: #5990

* added a function `getAntreaAgentServiceAccount()` which fixes the warnings outside k8s

`kubectl exec -it antrea-controller-6b554d9c74-l9ms2 -n kube-system -- /bin/bash
root@kind-worker:/# antrea-controller --version`
`antrea-controller version v2.0.0-dev-43ee1f47 linux/amd64 go1.21.7`

`docker run antrea/antrea-controller-ubuntu:v2.0.0-dev-43ee1f47 antrea-controll
er --version
antrea-controller version v2.0.0-dev-43ee1f47 linux/amd64 go1.21.7`
