### PR TITLE
Refactoring docker cmd to remove dangling images on testbed.

### DIFF
--- a/ci/jenkins/test-mc.sh
+++ b/ci/jenkins/test-mc.sh
@@ -134,7 +134,7 @@ function clean_tmp() {
 }
 
 function clean_images() {
-    docker images | grep -E 'mc-controller|antrea-ubuntu' | awk '{print $3}' | xargs -r docker rmi -f || true
+    docker images --format "{{.Repository}}:{{.Tag}}" | grep -E 'mc-controller|antrea-ubuntu' | xargs -r docker rmi -f || true
     # Clean up dangling images generated in previous builds.
     docker image prune -f --filter "until=24h" || true > /dev/null
     check_and_cleanup_docker_build_cache

--- a/ci/jenkins/test-vmc.sh
+++ b/ci/jenkins/test-vmc.sh
@@ -350,7 +350,7 @@ function deliver_antrea {
 
     # The cleanup and stats are best-effort.
     set +e
-    docker images | grep "${JOB_NAME}" | awk '{print $3}' | uniq | xargs -r docker rmi -f > /dev/null
+    docker images --format "{{.Repository}}:{{.Tag}}" | grep "${JOB_NAME}" | xargs -r docker rmi -f > /dev/null
     # Clean up dangling and unused images generated in previous builds. Recent ones must be excluded
     # because they might be being used in other builds running simultaneously.
     docker image prune -af --filter "until=1h" > /dev/null

--- a/ci/jenkins/test.sh
+++ b/ci/jenkins/test.sh
@@ -184,7 +184,7 @@ function clean_antrea {
     for antrea_yml in ${WORKDIR}/*.yml; do
         kubectl delete -f $antrea_yml --ignore-not-found=true || true
     done
-    docker images | grep 'antrea' | awk '{print $3}' | xargs -r docker rmi || true
+    docker images --format "{{.Repository}}:{{.Tag}}" | grep 'antrea'| xargs -r docker rmi || true
     docker images | grep '<none>' | awk '{print $3}' | xargs -r docker rmi || true
     check_and_cleanup_docker_build_cache
 }

--- a/ci/test-conformance-aks.sh
+++ b/ci/test-conformance-aks.sh
@@ -187,7 +187,7 @@ function deliver_antrea_to_aks() {
     # The cleanup and stats are best-effort.
     set +e
     if [[ -n ${JOB_NAME+x} ]]; then
-        docker images | grep "${JOB_NAME}" | awk '{print $3}' | xargs -r docker rmi -f > /dev/null
+       docker images --format "{{.Repository}}:{{.Tag}}" | grep "${JOB_NAME}" | xargs -r docker rmi -f > /dev/null
     fi
     # Clean up dangling images generated in previous builds. Recent ones must be excluded
     # because they might be being used in other builds running simultaneously.

--- a/ci/test-conformance-eks.sh
+++ b/ci/test-conformance-eks.sh
@@ -264,7 +264,7 @@ function deliver_antrea_to_eks() {
     # The cleanup and stats are best-effort.
     set +e
     if [[ -n ${JOB_NAME+x} ]]; then
-        docker images | grep "${JOB_NAME}" | awk '{print $3}' | xargs -r docker rmi -f > /dev/null
+        docker images --format "{{.Repository}}:{{.Tag}}" | grep "${JOB_NAME}" | xargs -r docker rmi -f > /dev/null
     fi
     # Clean up dangling images generated in previous builds. Recent ones must be excluded
     # because they might be being used in other builds running simultaneously.

--- a/ci/test-conformance-gke.sh
+++ b/ci/test-conformance-gke.sh
@@ -205,7 +205,7 @@ function deliver_antrea_to_gke() {
     # The cleanup and stats are best-effort.
     set +e
     if [[ -n ${JOB_NAME+x} ]]; then
-        docker images | grep "${JOB_NAME}" | awk '{print $3}' | xargs -r docker rmi -f > /dev/null
+        docker images --format "{{.Repository}}:{{.Tag}}" | grep "${JOB_NAME}" | xargs -r docker rmi -f > /dev/null
     fi
     # Clean up dangling images generated in previous builds. Recent ones must be excluded
     # because they might be being used in other builds running simultaneously.


### PR DESCRIPTION
If same image REPOSITORY has different TAG then the cmd `docker images | grep 'antrea' | awk '{print $3}' | xargs -r docker rmi || true` will not work because you can't delete it with imageID if they referencing in multiple repositories.  in this case either we can use `-f` flag OR  delete images with tag (FullName).

:~$ docker images
REPOSITORY                                   TAG                         IMAGE ID       CREATED        SIZE
antrea/antrea-ubuntu                         latest                      138fdae0c1ea   2 days ago     506MB
antrea/antrea-ubuntu                         v2.0.0-dev-96926ede.dirty   138fdae0c1ea   2 days ago     506MB
antrea/antrea-agent-ubuntu                   latest                      6a04b1bc593a   2 days ago     416MB
antrea/antrea-agent-ubuntu                   v2.0.0-dev-96926ede.dirty   6a04b1bc593a   2 days ago     416MB
antrea/antrea-controller-ubuntu              latest                      85fb7315f9d7   2 days ago     251MB
antrea/antrea-controller-ubuntu              v2.0.0-dev-96926ede.dirty   85fb7315f9d7   2 days ago     251MB
golang                                       1.21                        603d8d7f7de0   12 days ago    815MB
projects.registry.vmware.com/antrea/golang   1.21                        603d8d7f7de0   12 days ago    815MB
ubuntu                                       22.04                       fd1d8f58e8ae   3 weeks ago    77.9MB
projects.registry.vmware.com/antrea/ubuntu   22.04                       fd1d8f58e8ae   3 weeks ago    77.9MB
kindest/node                                 <none>                      89e7dc9f9131   8 months ago   932MB

:~$ docker images | grep 'antrea' | awk '{print $3}'
138fdae0c1ea
138fdae0c1ea
6a04b1bc593a
6a04b1bc593a
85fb7315f9d7
85fb7315f9d7
603d8d7f7de0
fd1d8f58e8ae

:~$ docker images | grep 'antrea' | awk '{print $3}' | xargs -r  docker rmi 
Error response from daemon: conflict: unable to delete 138fdae0c1ea (must be forced) - image is referenced in multiple repositories
Error response from daemon: conflict: unable to delete 138fdae0c1ea (must be forced) - image is referenced in multiple repositories
Error response from daemon: conflict: unable to delete 6a04b1bc593a (must be forced) - image is referenced in multiple repositories
Error response from daemon: conflict: unable to delete 6a04b1bc593a (must be forced) - image is referenced in multiple repositories
Error response from daemon: conflict: unable to delete 85fb7315f9d7 (must be forced) - image is referenced in multiple repositories
Error response from daemon: conflict: unable to delete 85fb7315f9d7 (must be forced) - image is referenced in multiple repositories
Error response from daemon: conflict: unable to delete 603d8d7f7de0 (must be forced) - image is referenced in multiple repositories
Error response from daemon: conflict: unable to delete fd1d8f58e8ae (must be forced) - image is referenced in multiple repositories