### PR TITLE
Clean up deprecated APIServices

### DIFF
--- a/build/charts/antrea/templates/controller/clusterrole.yaml
+++ b/build/charts/antrea/templates/controller/clusterrole.yaml
@@ -113,18 +113,6 @@ rules:
       - list
       - update
   - apiGroups:
-      - apiregistration.k8s.io
-    resources:
-      - apiservices
-    resourceNames:
-      - v1beta1.networking.antrea.tanzu.vmware.com
-      - v1beta1.controlplane.antrea.tanzu.vmware.com
-      - v1alpha1.stats.antrea.tanzu.vmware.com
-      - v1beta1.system.antrea.tanzu.vmware.com
-      - v1beta2.controlplane.antrea.tanzu.vmware.com
-    verbs:
-      - delete
-  - apiGroups:
       - admissionregistration.k8s.io
     resources:
       - mutatingwebhookconfigurations

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -6557,18 +6557,6 @@ rules:
       - list
       - update
   - apiGroups:
-      - apiregistration.k8s.io
-    resources:
-      - apiservices
-    resourceNames:
-      - v1beta1.networking.antrea.tanzu.vmware.com
-      - v1beta1.controlplane.antrea.tanzu.vmware.com
-      - v1alpha1.stats.antrea.tanzu.vmware.com
-      - v1beta1.system.antrea.tanzu.vmware.com
-      - v1beta2.controlplane.antrea.tanzu.vmware.com
-    verbs:
-      - delete
-  - apiGroups:
       - admissionregistration.k8s.io
     resources:
       - mutatingwebhookconfigurations

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -6557,18 +6557,6 @@ rules:
       - list
       - update
   - apiGroups:
-      - apiregistration.k8s.io
-    resources:
-      - apiservices
-    resourceNames:
-      - v1beta1.networking.antrea.tanzu.vmware.com
-      - v1beta1.controlplane.antrea.tanzu.vmware.com
-      - v1alpha1.stats.antrea.tanzu.vmware.com
-      - v1beta1.system.antrea.tanzu.vmware.com
-      - v1beta2.controlplane.antrea.tanzu.vmware.com
-    verbs:
-      - delete
-  - apiGroups:
       - admissionregistration.k8s.io
     resources:
       - mutatingwebhookconfigurations

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -6557,18 +6557,6 @@ rules:
       - list
       - update
   - apiGroups:
-      - apiregistration.k8s.io
-    resources:
-      - apiservices
-    resourceNames:
-      - v1beta1.networking.antrea.tanzu.vmware.com
-      - v1beta1.controlplane.antrea.tanzu.vmware.com
-      - v1alpha1.stats.antrea.tanzu.vmware.com
-      - v1beta1.system.antrea.tanzu.vmware.com
-      - v1beta2.controlplane.antrea.tanzu.vmware.com
-    verbs:
-      - delete
-  - apiGroups:
       - admissionregistration.k8s.io
     resources:
       - mutatingwebhookconfigurations

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -6570,18 +6570,6 @@ rules:
       - list
       - update
   - apiGroups:
-      - apiregistration.k8s.io
-    resources:
-      - apiservices
-    resourceNames:
-      - v1beta1.networking.antrea.tanzu.vmware.com
-      - v1beta1.controlplane.antrea.tanzu.vmware.com
-      - v1alpha1.stats.antrea.tanzu.vmware.com
-      - v1beta1.system.antrea.tanzu.vmware.com
-      - v1beta2.controlplane.antrea.tanzu.vmware.com
-    verbs:
-      - delete
-  - apiGroups:
       - admissionregistration.k8s.io
     resources:
       - mutatingwebhookconfigurations

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -6557,18 +6557,6 @@ rules:
       - list
       - update
   - apiGroups:
-      - apiregistration.k8s.io
-    resources:
-      - apiservices
-    resourceNames:
-      - v1beta1.networking.antrea.tanzu.vmware.com
-      - v1beta1.controlplane.antrea.tanzu.vmware.com
-      - v1alpha1.stats.antrea.tanzu.vmware.com
-      - v1beta1.system.antrea.tanzu.vmware.com
-      - v1beta2.controlplane.antrea.tanzu.vmware.com
-    verbs:
-      - delete
-  - apiGroups:
       - admissionregistration.k8s.io
     resources:
       - mutatingwebhookconfigurations

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -277,13 +277,7 @@ func CleanupDeprecatedAPIServices(aggregatorClient clientset.Interface) error {
 	// deprecates a registered APIService, the APIService should be deleted,
 	// otherwise K8s will fail to delete an existing Namespace.
 	// Also check: https://github.com/antrea-io/antrea/issues/494
-	deprecatedAPIServices := []string{
-		"v1beta1.networking.antrea.tanzu.vmware.com",
-		"v1beta1.controlplane.antrea.tanzu.vmware.com",
-		"v1alpha1.stats.antrea.tanzu.vmware.com",
-		"v1beta1.system.antrea.tanzu.vmware.com",
-		"v1beta2.controlplane.antrea.tanzu.vmware.com",
-	}
+	deprecatedAPIServices := []string{}
 	for _, as := range deprecatedAPIServices {
 		err := aggregatorClient.ApiregistrationV1().APIServices().Delete(context.TODO(), as, metav1.DeleteOptions{})
 		if err == nil {


### PR DESCRIPTION
These APIServices were removed in Antrea v1.6 and it's safe to assume none of them still exists in the cluster when deploying the upcoming Antrea v2.0.