### PR TITLE
Add L7 Network Policy Logs for Allowed HTTP

### DIFF
--- a/pkg/agent/controller/networkpolicy/l7engine/reconciler.go
+++ b/pkg/agent/controller/networkpolicy/l7engine/reconciler.go
@@ -76,6 +76,11 @@ outputs:
       types:
         - alert:
             tagged-packets: yes
+        - http:
+            extended: yes
+            tagged-packets: yes
+        - tls:
+            extended: yes
   - eve-log:
       enabled: yes
       filetype: unix_stream


### PR DESCRIPTION
For allowed http traffic, log in "eve-YYYY-MM-DD.json" shows `event_type: http`
```
{"timestamp":"2024-02-22T21:26:07.074791+0000","flow_id":757085628206447,"in_iface":"antrea-l7-tap0","event_type":"http","vlan":[1],"src_ip":"10.10.1.8","src_port":44132,"dest_ip":"10.10.1.7","dest_port":80,"proto":"TCP","tx_id":0,"http":{"hostname":"10.10.1.7","url":"/public/main.html","http_user_agent":"Wget/1.21.1","http_content_type":"text/html","http_method":"GET","protocol":"HTTP/1.1","status":404,"length":153}}
```
For dropped packets, `event_type: alert` and `event_type: packet` are stilled logged as before.
```
{"timestamp":"2024-02-22T21:26:26.141099+0000","flow_id":647971985302376,"in_iface":"antrea-l7-tap0","event_type":"alert","vlan":[1],"src_ip":"10.10.1.8","src_port":58174,"dest_ip":"10.10.1.7","dest_port":80,"proto":"TCP","alert":{"action":"blocked","gid":1,"signature_id":1,"rev":0,"signature":"Reject by AntreaClusterNetworkPolicy:test-l7-ingress","category":"","severity":3,"tenant_id":1},"http":{"hostname":"10.10.1.7","url":"/private/test.html","http_user_agent":"Wget/1.21.1","http_method":"GET","protocol":"HTTP/1.1","length":0},"app_proto":"http","flow":{"pkts_toserver":3,"pkts_toclient":1,"bytes_toserver":347,"bytes_toclient":74,"start":"2024-02-22T21:26:26.140136+0000"}}
{"timestamp":"2024-02-22T21:26:26.145548+0000","flow_id":647971985302376,"in_iface":"antrea-l7-tap0","event_type":"packet","vlan":[1],"src_ip":"10.10.1.7","src_port":80,"dest_ip":"10.10.1.8","dest_port":58174,"proto":"TCP","packet":"csSAgSaXRkVL3D/tCABFAAAomhoAAEAGypMKCgEHCgoBCABQ4z5/g/HZ99gCJ1AUAftIxwAA","packet_info":{"linktype":1}}
```

Fixes #5982 