### PR TITLE
Reduce antrea cni binary size

### DIFF
--- a/pkg/agent/secondarynetwork/podwatch/sriov.go
+++ b/pkg/agent/secondarynetwork/podwatch/sriov.go
@@ -33,7 +33,6 @@ import (
 	podresourcesv1alpha1 "k8s.io/kubelet/pkg/apis/podresources/v1alpha1"
 
 	cnipodcache "antrea.io/antrea/pkg/agent/secondarynetwork/cnipodcache"
-	"antrea.io/antrea/pkg/agent/util"
 )
 
 const (
@@ -68,7 +67,7 @@ func getPodContainerDeviceIDs(podName string, podNamespace string) ([]string, er
 		path.Join(kubeletPodResourcesPath, kubeletSocket),
 		grpc.WithTransportCredentials(grpcinsecure.NewCredentials()),
 		grpc.WithContextDialer(func(ctx context.Context, addr string) (conn net.Conn, e error) {
-			return util.DialLocalSocket(addr)
+			return net.Dial("unix", addr)
 		}),
 	)
 	if err != nil {

--- a/pkg/agent/util/net.go
+++ b/pkg/agent/util/net.go
@@ -135,10 +135,6 @@ func listenUnix(address string) (net.Listener, error) {
 	return net.Listen("unix", address)
 }
 
-func dialUnix(address string) (net.Conn, error) {
-	return net.Dial("unix", address)
-}
-
 // GetIPNetDeviceFromIP returns local IPs/masks and associated device from IP, and ignores the interfaces which have
 // names in the ignoredInterfaces.
 func GetIPNetDeviceFromIP(localIPs *ip.DualStackIPs, ignoredInterfaces sets.Set[string]) (v4IPNet *net.IPNet, v6IPNet *net.IPNet, iface *net.Interface, err error) {

--- a/pkg/agent/util/net_linux.go
+++ b/pkg/agent/util/net_linux.go
@@ -230,11 +230,6 @@ func ListenLocalSocket(address string) (net.Listener, error) {
 	return listener, nil
 }
 
-// DialLocalSocket connects to a Unix domain socket.
-func DialLocalSocket(address string) (net.Conn, error) {
-	return dialUnix(address)
-}
-
 // SetAdapterMACAddress set specified MAC address on interface.
 func SetAdapterMACAddress(adapterName string, macConfig *net.HardwareAddr) error {
 	link, err := netlinkUtil.LinkByName(adapterName)

--- a/pkg/agent/util/net_windows.go
+++ b/pkg/agent/util/net_windows.go
@@ -654,16 +654,6 @@ func ListenLocalSocket(address string) (net.Listener, error) {
 	return listenUnix(address)
 }
 
-// DialLocalSocket connects to a Unix domain socket or a Windows named pipe.
-// - If the specified address starts with "\\.\pipe\",  connect to a Windows named pipe path.
-// - Else connect to a Unix domain socket.
-func DialLocalSocket(address string) (net.Conn, error) {
-	if strings.HasPrefix(address, namedPipePrefix) {
-		return winio.DialPipe(address, nil)
-	}
-	return dialUnix(address)
-}
-
 func HostInterfaceExists(ifaceName string) bool {
 	_, err := getAdapterInAllCompartmentsByName(ifaceName)
 	if err != nil {

--- a/pkg/cni/client.go
+++ b/pkg/cni/client.go
@@ -17,7 +17,6 @@ package cni
 import (
 	"context"
 	"fmt"
-	"net"
 	"os"
 
 	"github.com/containernetworking/cni/pkg/skel"
@@ -27,7 +26,6 @@ import (
 	grpcinsecure "google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 
-	"antrea.io/antrea/pkg/agent/util"
 	cnipb "antrea.io/antrea/pkg/apis/cni/v1beta1"
 )
 
@@ -91,9 +89,7 @@ func rpcClient(f func(client cnipb.CniClient) error) error {
 	conn, err := grpc.Dial(
 		AntreaCNISocketAddr,
 		grpc.WithTransportCredentials(grpcinsecure.NewCredentials()),
-		grpc.WithContextDialer(func(ctx context.Context, addr string) (conn net.Conn, e error) {
-			return util.DialLocalSocket(addr)
-		}),
+		grpc.WithContextDialer(dial),
 	)
 	if err != nil {
 		return err

--- a/pkg/cni/dial_linux.go
+++ b/pkg/cni/dial_linux.go
@@ -1,0 +1,24 @@
+// Copyright 2024 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cni
+
+import (
+	"context"
+	"net"
+)
+
+func dial(_ context.Context, address string) (net.Conn, error) {
+	return net.Dial("unix", address)
+}

--- a/pkg/cni/dial_windows.go
+++ b/pkg/cni/dial_windows.go
@@ -1,0 +1,32 @@
+// Copyright 2024 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cni
+
+import (
+	"context"
+	"net"
+	"strings"
+
+	"github.com/Microsoft/go-winio"
+)
+
+const namedPipePrefix = `\\.\pipe\`
+
+func dial(_ context.Context, address string) (net.Conn, error) {
+	if strings.HasPrefix(address, namedPipePrefix) {
+		return winio.DialPipe(address, nil)
+	}
+	return net.Dial("unix", address)
+}


### PR DESCRIPTION
It only needs a dial function but imports many unnecessary code from `pkg/agent/util`.

Removing the import reduces the binary size by 10MB, from 18MB to 8.4MB.

For https://github.com/antrea-io/antrea/issues/5883

----------
Before:
```
-rwxr-xr-x  1 root root  18M Feb 29 10:10 antrea-cni

antrea/antrea-agent-ubuntu                v2.0.0-dev-d28e282d0   7e84ada052f8   15 seconds ago   350MB
```

After:
```
-rwxr-xr-x  1 root root 8.4M Feb 29 10:19 antrea-cni

antrea/antrea-agent-ubuntu                v2.0.0-dev-d28e282d0.dirty   36526d98148d   18 seconds ago   340MB
```