### PR TITLE
Add important limitation to SecondaryNetwork document

### DIFF
--- a/docs/secondary-network.md
+++ b/docs/secondary-network.md
@@ -165,3 +165,8 @@ spec:
  - name: toolbox
    image: antrea/toolbox:latest
 ```
+
+**At the moment, we do NOT support annotation update / removal: when the
+  annotation is added to the Pod for the first time (e.g., when creating the
+  Pod), we will configure the secondary network interfaces accordingly, and no
+  change is possible after that, until the Pod is deleted.**


### PR DESCRIPTION
At the moment, we do not support annotation update / deletion for `k8s.v1.cni.cncf.io/networks`.