### PR TITLE
Fix Improve log when agent fails to join a new Node

### DIFF
--- a/pkg/agent/memberlist/cluster.go
+++ b/pkg/agent/memberlist/cluster.go
@@ -20,7 +20,6 @@ import (
 	"io"
 	"net"
 	"reflect"
-	"strings"
 	"sync"
 	"time"
 
@@ -222,13 +221,7 @@ func (c *Cluster) handleCreateNode(obj interface{}) {
 	if member, err := c.newClusterMember(node); err == nil {
 		_, err := c.mList.Join([]string{member})
 		if err != nil {
-			// Formatting the error message.
-			errorMessage := err.Error()
-			prefixToRemove := "1 error occurred:"
-			errorMessage = strings.TrimPrefix(errorMessage, prefixToRemove)
-			errorMessage = strings.Replace(errorMessage, "\n\t* ", "", -1)
-			errorMessage = strings.TrimSpace(errorMessage)
-			klog.InfoS("Processing Node CREATE event error, join cluster failed, will retry later", "error", errorMessage, "member", member)
+			klog.InfoS("Processing Node CREATE event error, join cluster failed, will retry later", "error", errors.Unwrap(err), "member", member)
 		}
 	} else {
 		klog.ErrorS(err, "Processing Node CREATE event error", "nodeName", node.Name)

--- a/pkg/agent/memberlist/cluster.go
+++ b/pkg/agent/memberlist/cluster.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"net"
 	"reflect"
+	"strings"
 	"sync"
 	"time"
 
@@ -221,7 +222,13 @@ func (c *Cluster) handleCreateNode(obj interface{}) {
 	if member, err := c.newClusterMember(node); err == nil {
 		_, err := c.mList.Join([]string{member})
 		if err != nil {
-			klog.ErrorS(err, "Processing Node CREATE event error, join cluster failed", "member", member)
+			// Formatting the error message.
+			errorMessage := err.Error()
+			prefixToRemove := "1 error occurred:"
+			errorMessage = strings.TrimPrefix(errorMessage, prefixToRemove)
+			errorMessage = strings.Replace(errorMessage, "\n\t* ", "", -1)
+			errorMessage = strings.TrimSpace(errorMessage)
+			klog.InfoS("Processing Node CREATE event error, join cluster failed, will retry later", "error", errorMessage, "member", member)
 		}
 	} else {
 		klog.ErrorS(err, "Processing Node CREATE event error", "nodeName", node.Name)


### PR DESCRIPTION
Formatted the error logs when the agent tries to establish a cluster with others. It will recover eventually after all agents are up.

Fixes #5966