### PR TITLE
Automated cherry pick of #6050: Fix wrong TCP flags validation (#6050)

### DIFF
--- a/build/charts/antrea/crds/traceflow.yaml
+++ b/build/charts/antrea/crds/traceflow.yaml
@@ -390,7 +390,7 @@ spec:
                             flags:
                               type: integer
                               minimum: 0
-                              maximum: 7
+                              maximum: 255
                 liveTraffic:
                   type: boolean
                 droppedOnly:
@@ -503,7 +503,7 @@ spec:
                             flags:
                               type: integer
                               minimum: 0
-                              maximum: 7
+                              maximum: 255
                           type: object
                         udp:
                           properties:

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -5000,7 +5000,7 @@ spec:
                             flags:
                               type: integer
                               minimum: 0
-                              maximum: 7
+                              maximum: 255
                 liveTraffic:
                   type: boolean
                 droppedOnly:
@@ -5113,7 +5113,7 @@ spec:
                             flags:
                               type: integer
                               minimum: 0
-                              maximum: 7
+                              maximum: 255
                           type: object
                         udp:
                           properties:

--- a/build/yamls/antrea-crds.yml
+++ b/build/yamls/antrea-crds.yml
@@ -4973,7 +4973,7 @@ spec:
                             flags:
                               type: integer
                               minimum: 0
-                              maximum: 7
+                              maximum: 255
                 liveTraffic:
                   type: boolean
                 droppedOnly:
@@ -5086,7 +5086,7 @@ spec:
                             flags:
                               type: integer
                               minimum: 0
-                              maximum: 7
+                              maximum: 255
                           type: object
                         udp:
                           properties:

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -5000,7 +5000,7 @@ spec:
                             flags:
                               type: integer
                               minimum: 0
-                              maximum: 7
+                              maximum: 255
                 liveTraffic:
                   type: boolean
                 droppedOnly:
@@ -5113,7 +5113,7 @@ spec:
                             flags:
                               type: integer
                               minimum: 0
-                              maximum: 7
+                              maximum: 255
                           type: object
                         udp:
                           properties:

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -5000,7 +5000,7 @@ spec:
                             flags:
                               type: integer
                               minimum: 0
-                              maximum: 7
+                              maximum: 255
                 liveTraffic:
                   type: boolean
                 droppedOnly:
@@ -5113,7 +5113,7 @@ spec:
                             flags:
                               type: integer
                               minimum: 0
-                              maximum: 7
+                              maximum: 255
                           type: object
                         udp:
                           properties:

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -5000,7 +5000,7 @@ spec:
                             flags:
                               type: integer
                               minimum: 0
-                              maximum: 7
+                              maximum: 255
                 liveTraffic:
                   type: boolean
                 droppedOnly:
@@ -5113,7 +5113,7 @@ spec:
                             flags:
                               type: integer
                               minimum: 0
-                              maximum: 7
+                              maximum: 255
                           type: object
                         udp:
                           properties:

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -5000,7 +5000,7 @@ spec:
                             flags:
                               type: integer
                               minimum: 0
-                              maximum: 7
+                              maximum: 255
                 liveTraffic:
                   type: boolean
                 droppedOnly:
@@ -5113,7 +5113,7 @@ spec:
                             flags:
                               type: integer
                               minimum: 0
-                              maximum: 7
+                              maximum: 255
                           type: object
                         udp:
                           properties:


### PR DESCRIPTION
Cherry pick of #6050 on release-1.14.

#6050: Fix wrong TCP flags validation (#6050)

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.