### PR TITLE
Stop using projects.registry.vmware.com for user-facing images

### DIFF
--- a/ci/kind/test-upgrade-antrea.sh
+++ b/ci/kind/test-upgrade-antrea.sh
@@ -152,10 +152,10 @@ function version_lt() { test "$(printf '%s\n' "$@" | sort -rV | head -n 1)" != "
 
 DOCKER_IMAGES=()
 if version_lt "$FROM_TAG" v1.15; then
-    DOCKER_IMAGES+=("projects.registry.vmware.com/antrea/antrea-ubuntu:$FROM_TAG")
+    DOCKER_IMAGES+=("antrea/antrea-ubuntu:$FROM_TAG")
 else
-    DOCKER_IMAGES+=("projects.registry.vmware.com/antrea/antrea-agent-ubuntu:$FROM_TAG" \
-                    "projects.registry.vmware.com/antrea/antrea-controller-ubuntu:$FROM_TAG")
+    DOCKER_IMAGES+=("antrea/antrea-agent-ubuntu:$FROM_TAG" \
+                    "antrea/antrea-controller-ubuntu:$FROM_TAG")
 fi
 
 # Silence CLI suggestions.
@@ -189,9 +189,9 @@ $ROOT_DIR/hack/generate-manifest.sh --on-delete | docker exec -i kind-control-pl
 TMP_ANTREA_DIR=$(mktemp -d)
 git clone --branch $FROM_TAG --depth 1 https://github.com/antrea-io/antrea.git $TMP_ANTREA_DIR
 pushd $TMP_ANTREA_DIR > /dev/null
-export IMG_NAME=projects.registry.vmware.com/antrea/antrea-ubuntu
-export AGENT_IMG_NAME=projects.registry.vmware.com/antrea/antrea-agent-ubuntu
-export CONTROLLER_IMG_NAME=projects.registry.vmware.com/antrea/antrea-controller-ubuntu
+export IMG_NAME=antrea/antrea-ubuntu
+export AGENT_IMG_NAME=antrea/antrea-agent-ubuntu
+export CONTROLLER_IMG_NAME=antrea/antrea-controller-ubuntu
 export IMG_TAG=$FROM_TAG
 ./hack/generate-manifest.sh --mode release | kubectl apply -f -
 ./hack/generate-manifest.sh --mode release | docker exec -i kind-control-plane dd of=/root/antrea.yml

--- a/docs/kind.md
+++ b/docs/kind.md
@@ -60,10 +60,10 @@ pull from the registry), you can use:
 ```bash
 tag=<TAG>
 cluster=<CLUSTER_NAME>
-docker pull projects.registry.vmware.com/antrea/antrea-controller-ubuntu:$tag
-docker pull projects.registry.vmware.com/antrea/antrea-agent-ubuntu:$tag
+docker pull antrea/antrea-controller-ubuntu:$tag
+docker pull antrea/antrea-agent-ubuntu:$tag
 ./ci/kind/kind-setup.sh \
-  --images "projects.registry.vmware.com/antrea/antrea-controller-ubuntu:$tag projects.registry.vmware.com/antrea/antrea-agent-ubuntu:$tag" \
+  --images "antrea/antrea-controller-ubuntu:$tag antrea/antrea-agent-ubuntu:$tag" \
   create $cluster
 kubectl apply -f https://github.com/antrea-io/antrea/releases/download/$tag/antrea.yml
 ```

--- a/hack/generate-helm-release.sh
+++ b/hack/generate-helm-release.sh
@@ -94,18 +94,13 @@ ANTREA_CHART="$THIS_DIR/../build/charts/antrea"
 # ignored as per the .helmignore file.
 cp "$ANTREA_CHART/Chart.yaml" "$ANTREA_CHART/Chart.yaml.bak"
 yq -i '.annotations."artifacthub.io/prerelease" = strenv(PRERELEASE)' "$ANTREA_CHART/Chart.yaml"
-sed -i.bak 's=antrea/antrea-agent-ubuntu=projects.registry.vmware.com/antrea/antrea-agent-ubuntu=g' "$ANTREA_CHART/values.yaml"
-sed -i.bak 's=antrea/antrea-controller-ubuntu=projects.registry.vmware.com/antrea/antrea-controller-ubuntu=g' "$ANTREA_CHART/values.yaml"
 $HELM package --app-version $VERSION --version $VERSION $ANTREA_CHART
 mv "antrea-$VERSION.tgz" "$OUT/antrea-chart.tgz"
 mv "$ANTREA_CHART/Chart.yaml.bak" "$ANTREA_CHART/Chart.yaml"
-mv "$ANTREA_CHART/values.yaml.bak" "$ANTREA_CHART/values.yaml"
 
 FLOW_AGGREGATOR_CHART="$THIS_DIR/../build/charts/flow-aggregator"
 cp "$FLOW_AGGREGATOR_CHART/Chart.yaml" "$FLOW_AGGREGATOR_CHART/Chart.yaml.bak"
 yq -i '.annotations."artifacthub.io/prerelease" = strenv(PRERELEASE)' "$FLOW_AGGREGATOR_CHART/Chart.yaml"
-sed -i.bak 's=antrea/flow-aggregator=projects.registry.vmware.com/antrea/flow-aggregator=g' "$FLOW_AGGREGATOR_CHART/values.yaml"
 $HELM package --app-version $VERSION --version $VERSION $FLOW_AGGREGATOR_CHART
 mv "flow-aggregator-$VERSION.tgz" "$OUT/flow-aggregator-chart.tgz"
 mv "$FLOW_AGGREGATOR_CHART/Chart.yaml.bak" "$FLOW_AGGREGATOR_CHART/Chart.yaml"
-mv "$FLOW_AGGREGATOR_CHART/values.yaml.bak" "$FLOW_AGGREGATOR_CHART/values.yaml"

--- a/hack/release/prepare-assets.sh
+++ b/hack/release/prepare-assets.sh
@@ -105,20 +105,20 @@ cp ./hack/externalnode/install-vm.ps1 "$OUTPUT_DIR/"
 
 export IMG_TAG=$VERSION
 
-export AGENT_IMG_NAME=projects.registry.vmware.com/antrea/antrea-agent-ubuntu
-export CONTROLLER_IMG_NAME=projects.registry.vmware.com/antrea/antrea-controller-ubuntu
+export AGENT_IMG_NAME=antrea/antrea-agent-ubuntu
+export CONTROLLER_IMG_NAME=antrea/antrea-controller-ubuntu
 ./hack/generate-standard-manifests.sh --mode release --out "$OUTPUT_DIR"
 
-export IMG_NAME=projects.registry.vmware.com/antrea/antrea-windows
+export IMG_NAME=antrea/antrea-windows
 ./hack/generate-manifest-windows.sh --mode release > "$OUTPUT_DIR"/antrea-windows.yml
 ./hack/generate-manifest-windows.sh --mode release --containerd > "$OUTPUT_DIR"/antrea-windows-containerd.yml
 ./hack/generate-manifest-windows.sh --mode release --containerd --include-ovs > "$OUTPUT_DIR"/antrea-windows-containerd-with-ovs.yml
 
-export IMG_NAME=projects.registry.vmware.com/antrea/flow-aggregator
+export IMG_NAME=antrea/flow-aggregator
 ./hack/generate-manifest-flow-aggregator.sh --mode release > "$OUTPUT_DIR"/flow-aggregator.yml
 
 # Generate multicluster manifests
-export IMG_NAME=projects.registry.vmware.com/antrea/antrea-mc-controller
+export IMG_NAME=antrea/antrea-mc-controller
 cd multicluster
 ./hack/generate-manifest.sh -g > "$OUTPUT_DIR"/antrea-multicluster-leader-global.yml
 ./hack/generate-manifest.sh -r -n antrea-multicluster > "$OUTPUT_DIR"/antrea-multicluster-leader-namespaced.yml


### PR DESCRIPTION
We stop referencing the VMware Harbor registry
(projects.registry.vmware.com) in the Helm charts and K8s manifests that we release to users, with the expectation that images for future releases will not be available from that registry, as it is scheduled to be EOL'd and we won't be mirroring them there.

Because the antrea DockerHub organization is part of the "Sponsored OSS" program, there should be no concern about users running into issues because of DockerHub rate-limits. We could also consider mirroring these images to ghcr.io in the future, to offer users an alternative.

At the moment, we do not update references to other images in the projects.registry.vmware.com/antrea project (images used for testing), with the expectation that they will remain available for the foreseeable future. In other words, while we will no longer be publishing new images to projects.registry.vmware.com, we expect that existing images will remain available through the same URLs.

For #6003