### PR TITLE
Remove unused index from AppliedToGroup and AddressGroup storages

### DIFF
--- a/pkg/controller/networkpolicy/store/addressgroup.go
+++ b/pkg/controller/networkpolicy/store/addressgroup.go
@@ -155,14 +155,6 @@ func AddressGroupKeyFunc(obj interface{}) (string, error) {
 // NewAddressGroupStore creates a store of AddressGroup.
 func NewAddressGroupStore() storage.Interface {
 	indexers := cache.Indexers{
-		cache.NamespaceIndex: func(obj interface{}) ([]string, error) {
-			ag, ok := obj.(*types.AddressGroup)
-			if !ok || ag.Selector == nil {
-				return []string{}, nil
-			}
-			// ag.Selector.Namespace == "" means it's a cluster scoped group, we index it as it is.
-			return []string{ag.Selector.Namespace}, nil
-		},
 		IsNodeAddressGroupIndex: func(obj interface{}) ([]string, error) {
 			ag, ok := obj.(*types.AddressGroup)
 			if !ok || ag.Selector == nil || ag.Selector.NodeSelector == nil {

--- a/pkg/controller/networkpolicy/store/appliedtogroup.go
+++ b/pkg/controller/networkpolicy/store/appliedtogroup.go
@@ -173,14 +173,6 @@ func AppliedToGroupKeyFunc(obj interface{}) (string, error) {
 // NewAppliedToGroupStore creates a store of AppliedToGroup.
 func NewAppliedToGroupStore() storage.Interface {
 	indexers := cache.Indexers{
-		cache.NamespaceIndex: func(obj interface{}) ([]string, error) {
-			atg, ok := obj.(*types.AppliedToGroup)
-			if !ok || atg.Selector == nil {
-				return []string{}, nil
-			}
-
-			return []string{atg.Selector.Namespace}, nil
-		},
 		IsAppliedToServiceIndex: func(obj interface{}) ([]string, error) {
 			atg, ok := obj.(*types.AppliedToGroup)
 			if !ok || atg.Service == nil {


### PR DESCRIPTION
The Namespace index was no longer needed since 46a2fc53e966 ("Extract and optimize group member calculation") was merged.