### PR TITLE
Automated cherry pick of #6073: Stop using projects.registry.vmware.com for user-facing

### DIFF
--- a/ci/kind/test-upgrade-antrea.sh
+++ b/ci/kind/test-upgrade-antrea.sh
@@ -148,7 +148,7 @@ fi
 
 echo "Running upgrade test for tag $FROM_TAG"
 
-DOCKER_IMAGES=("busybox" "projects.registry.vmware.com/antrea/antrea-ubuntu:$FROM_TAG")
+DOCKER_IMAGES=("antrea/antrea-ubuntu:$FROM_TAG")
 
 for img in "${DOCKER_IMAGES[@]}"; do
     echo "Pulling $img"
@@ -178,7 +178,7 @@ $ROOT_DIR/hack/generate-manifest.sh --on-delete | docker exec -i kind-control-pl
 TMP_ANTREA_DIR=$(mktemp -d)
 git clone --branch $FROM_TAG --depth 1 https://github.com/antrea-io/antrea.git $TMP_ANTREA_DIR
 pushd $TMP_ANTREA_DIR > /dev/null
-export IMG_NAME=projects.registry.vmware.com/antrea/antrea-ubuntu
+export IMG_NAME=antrea/antrea-ubuntu
 export IMG_TAG=$FROM_TAG
 ./hack/generate-manifest.sh --mode release | kubectl apply -f -
 ./hack/generate-manifest.sh --mode release | docker exec -i kind-control-plane dd of=/root/antrea.yml

--- a/docs/kind.md
+++ b/docs/kind.md
@@ -58,8 +58,8 @@ If you want to pre-load the Antrea image in each Node (to avoid having each Node
 pull from the registry), you can use:
 
 ```bash
-docker pull projects.registry.vmware.com/antrea/antrea-ubuntu:<TAG>
-./ci/kind/kind-setup.sh --images projects.registry.vmware.com/antrea/antrea-ubuntu:<TAG> create <CLUSTER_NAME>
+docker pull antrea/antrea-ubuntu:<TAG>
+./ci/kind/kind-setup.sh --images antrea/antrea-ubuntu:<TAG> create <CLUSTER_NAME>
 kubectl apply -f https://github.com/antrea-io/antrea/releases/download/<TAG>/antrea.yml
 ```
 

--- a/hack/generate-helm-release.sh
+++ b/hack/generate-helm-release.sh
@@ -94,17 +94,13 @@ ANTREA_CHART="$THIS_DIR/../build/charts/antrea"
 # ignored as per the .helmignore file.
 cp "$ANTREA_CHART/Chart.yaml" "$ANTREA_CHART/Chart.yaml.bak"
 yq -i '.annotations."artifacthub.io/prerelease" = strenv(PRERELEASE)' "$ANTREA_CHART/Chart.yaml"
-sed -i.bak 's=antrea/antrea-ubuntu=projects.registry.vmware.com/antrea/antrea-ubuntu=g' "$ANTREA_CHART/values.yaml"
 $HELM package --app-version $VERSION --version $VERSION $ANTREA_CHART
 mv "antrea-$VERSION.tgz" "$OUT/antrea-chart.tgz"
 mv "$ANTREA_CHART/Chart.yaml.bak" "$ANTREA_CHART/Chart.yaml"
-mv "$ANTREA_CHART/values.yaml.bak" "$ANTREA_CHART/values.yaml"
 
 FLOW_AGGREGATOR_CHART="$THIS_DIR/../build/charts/flow-aggregator"
 cp "$FLOW_AGGREGATOR_CHART/Chart.yaml" "$FLOW_AGGREGATOR_CHART/Chart.yaml.bak"
 yq -i '.annotations."artifacthub.io/prerelease" = strenv(PRERELEASE)' "$FLOW_AGGREGATOR_CHART/Chart.yaml"
-sed -i.bak 's=antrea/flow-aggregator=projects.registry.vmware.com/antrea/flow-aggregator=g' "$FLOW_AGGREGATOR_CHART/values.yaml"
 $HELM package --app-version $VERSION --version $VERSION $FLOW_AGGREGATOR_CHART
 mv "flow-aggregator-$VERSION.tgz" "$OUT/flow-aggregator-chart.tgz"
 mv "$FLOW_AGGREGATOR_CHART/Chart.yaml.bak" "$FLOW_AGGREGATOR_CHART/Chart.yaml"
-mv "$FLOW_AGGREGATOR_CHART/values.yaml.bak" "$FLOW_AGGREGATOR_CHART/values.yaml"

--- a/hack/release/prepare-assets.sh
+++ b/hack/release/prepare-assets.sh
@@ -104,19 +104,19 @@ cp ./hack/externalnode/install-vm.ps1 "$OUTPUT_DIR/"
 
 export IMG_TAG=$VERSION
 
-export IMG_NAME=projects.registry.vmware.com/antrea/antrea-ubuntu
+export IMG_NAME=antrea/antrea-ubuntu
 ./hack/generate-standard-manifests.sh --mode release --out "$OUTPUT_DIR"
 
-export IMG_NAME=projects.registry.vmware.com/antrea/antrea-windows
+export IMG_NAME=antrea/antrea-windows
 ./hack/generate-manifest-windows.sh --mode release > "$OUTPUT_DIR"/antrea-windows.yml
 ./hack/generate-manifest-windows.sh --mode release --containerd > "$OUTPUT_DIR"/antrea-windows-containerd.yml
 ./hack/generate-manifest-windows.sh --mode release --containerd --include-ovs > "$OUTPUT_DIR"/antrea-windows-containerd-with-ovs.yml
 
-export IMG_NAME=projects.registry.vmware.com/antrea/flow-aggregator
+export IMG_NAME=antrea/flow-aggregator
 ./hack/generate-manifest-flow-aggregator.sh --mode release > "$OUTPUT_DIR"/flow-aggregator.yml
 
 # Generate multicluster manifests
-export IMG_NAME=projects.registry.vmware.com/antrea/antrea-mc-controller
+export IMG_NAME=antrea/antrea-mc-controller
 cd multicluster
 ./hack/generate-manifest.sh -g > "$OUTPUT_DIR"/antrea-multicluster-leader-global.yml
 ./hack/generate-manifest.sh -r -l antrea-multicluster > "$OUTPUT_DIR"/antrea-multicluster-leader-namespaced.yml


### PR DESCRIPTION
Cherry pick of #6073 on release-1.13.

#6073: Stop using projects.registry.vmware.com for user-facing

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.