### PR TITLE
Automated cherry pick of #6077: Fix nil pointer dereference when ClusterGroup/Group is used

### DIFF
--- a/pkg/controller/networkpolicy/clustergroup.go
+++ b/pkg/controller/networkpolicy/clustergroup.go
@@ -281,17 +281,17 @@ func (c *NetworkPolicyController) triggerParentGroupUpdates(grp string) {
 
 // triggerDerivedGroupUpdates triggers processing of AppliedToGroup and AddressGroup derived from the provided group.
 func (c *NetworkPolicyController) triggerDerivedGroupUpdates(grp string) {
-	_, exists, _ := c.appliedToGroupStore.Get(grp)
-	if exists {
+	groups, _ := c.appliedToGroupStore.GetByIndex(store.SourceGroupIndex, grp)
+	for _, group := range groups {
 		// It's fine if the group is deleted after checking its existence as syncAppliedToGroup will do nothing when it
 		// doesn't find the group.
-		c.enqueueAppliedToGroup(grp)
+		c.enqueueAppliedToGroup(group.(*antreatypes.AppliedToGroup).Name)
 	}
-	_, exists, _ = c.addressGroupStore.Get(grp)
-	if exists {
+	groups, _ = c.addressGroupStore.GetByIndex(store.SourceGroupIndex, grp)
+	for _, group := range groups {
 		// It's fine if the group is deleted after checking its existence as syncAddressGroup will do nothing when it
 		// doesn't find the group.
-		c.enqueueAddressGroup(grp)
+		c.enqueueAddressGroup(group.(*antreatypes.AddressGroup).Name)
 	}
 }
 

--- a/pkg/controller/networkpolicy/clusternetworkpolicy.go
+++ b/pkg/controller/networkpolicy/clusternetworkpolicy.go
@@ -615,7 +615,7 @@ func (n *NetworkPolicyController) processRefGroupOrClusterGroup(g, namespace str
 	// up if the Group/ClusterGroup becomes ipBlocks-only.
 	createAddrGroup, ipb := n.processInternalGroupForRule(intGrp)
 	if createAddrGroup {
-		ag := &antreatypes.AddressGroup{UID: intGrp.UID, Name: key}
+		ag := &antreatypes.AddressGroup{UID: intGrp.UID, Name: key, SourceGroup: key}
 		return ag, ipb
 	}
 	return nil, ipb

--- a/pkg/controller/networkpolicy/clusternetworkpolicy_test.go
+++ b/pkg/controller/networkpolicy/clusternetworkpolicy_test.go
@@ -1961,8 +1961,12 @@ func TestProcessRefGroupOrClusterGroup(t *testing.T) {
 		{
 			name:           "cg-with-selector",
 			inputGroupName: cgA.Name,
-			expectedAG:     &antreatypes.AddressGroup{UID: cgA.UID, Name: cgA.Name},
-			expectedIPB:    nil,
+			expectedAG: &antreatypes.AddressGroup{
+				UID:         cgA.UID,
+				Name:        cgA.Name,
+				SourceGroup: cgA.Name,
+			},
+			expectedIPB: nil,
 		},
 		{
 			name:           "cg-with-selector-not-found",
@@ -1995,7 +1999,11 @@ func TestProcessRefGroupOrClusterGroup(t *testing.T) {
 		{
 			name:           "nested-cg-with-ipblock-and-selector",
 			inputGroupName: cgNested2.Name,
-			expectedAG:     &antreatypes.AddressGroup{UID: cgNested2.UID, Name: cgNested2.Name},
+			expectedAG: &antreatypes.AddressGroup{
+				UID:         cgNested2.UID,
+				Name:        cgNested2.Name,
+				SourceGroup: cgNested2.Name,
+			},
 			expectedIPB: []controlplane.IPBlock{
 				{
 					CIDR:   *cidrIPNet,
@@ -2014,8 +2022,12 @@ func TestProcessRefGroupOrClusterGroup(t *testing.T) {
 			name:           "g-with-selector",
 			inputNamespace: gA.Namespace,
 			inputGroupName: gA.Name,
-			expectedAG:     &antreatypes.AddressGroup{UID: gA.UID, Name: fmt.Sprintf("%s/%s", gA.Namespace, gA.Name)},
-			expectedIPB:    nil,
+			expectedAG: &antreatypes.AddressGroup{
+				UID:         gA.UID,
+				Name:        fmt.Sprintf("%s/%s", gA.Namespace, gA.Name),
+				SourceGroup: fmt.Sprintf("%s/%s", gA.Namespace, gA.Name),
+			},
+			expectedIPB: nil,
 		},
 		{
 			name:           "non-existing-group",

--- a/pkg/controller/networkpolicy/crd_utils.go
+++ b/pkg/controller/networkpolicy/crd_utils.go
@@ -322,7 +322,7 @@ func (n *NetworkPolicyController) createAppliedToGroupForGroup(namespace, group 
 		klog.V(2).InfoS("Group with IPBlocks can not be used as AppliedTo", "Group", key)
 		return nil
 	}
-	return &antreatypes.AppliedToGroup{UID: intGrp.UID, Name: key}
+	return &antreatypes.AppliedToGroup{UID: intGrp.UID, Name: key, SourceGroup: key}
 }
 
 // getTierPriority retrieves the priority associated with the input Tier name.

--- a/pkg/controller/networkpolicy/crd_utils_test.go
+++ b/pkg/controller/networkpolicy/crd_utils_test.go
@@ -550,9 +550,13 @@ func TestCreateAppliedToGroupsForGroup(t *testing.T) {
 			expectedATG: nil,
 		},
 		{
-			name:        "cluster group with selectors",
-			inputGroup:  clusterGroupWithSelector.Name,
-			expectedATG: &antreatypes.AppliedToGroup{UID: clusterGroupWithSelector.UID, Name: clusterGroupWithSelector.Name},
+			name:       "cluster group with selectors",
+			inputGroup: clusterGroupWithSelector.Name,
+			expectedATG: &antreatypes.AppliedToGroup{
+				UID:         clusterGroupWithSelector.UID,
+				Name:        clusterGroupWithSelector.Name,
+				SourceGroup: clusterGroupWithSelector.Name,
+			},
 		},
 		{
 			name:           "empty group name",
@@ -576,7 +580,11 @@ func TestCreateAppliedToGroupsForGroup(t *testing.T) {
 			name:           "group with selectors",
 			inputNamespace: groupWithSelector.Namespace,
 			inputGroup:     groupWithSelector.Name,
-			expectedATG:    &antreatypes.AppliedToGroup{UID: groupWithSelector.UID, Name: fmt.Sprintf("%s/%s", groupWithSelector.Namespace, groupWithSelector.Name)},
+			expectedATG: &antreatypes.AppliedToGroup{
+				UID:         groupWithSelector.UID,
+				Name:        fmt.Sprintf("%s/%s", groupWithSelector.Namespace, groupWithSelector.Name),
+				SourceGroup: fmt.Sprintf("%s/%s", groupWithSelector.Namespace, groupWithSelector.Name),
+			},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller.go
@@ -623,7 +623,7 @@ func (n *NetworkPolicyController) createAddressGroup(namespace string, podSelect
 	addressGroup := &antreatypes.AddressGroup{
 		UID:      types.UID(normalizedUID),
 		Name:     normalizedUID,
-		Selector: *groupSelector,
+		Selector: groupSelector,
 	}
 	return addressGroup
 }
@@ -1104,6 +1104,7 @@ func (n *NetworkPolicyController) syncAddressGroup(key string) error {
 		Name:         addressGroup.Name,
 		UID:          addressGroup.UID,
 		Selector:     addressGroup.Selector,
+		SourceGroup:  addressGroup.SourceGroup,
 		GroupMembers: memberSet,
 		SpanMeta:     antreatypes.SpanMeta{NodeNames: addrGroupNodeNames},
 	}
@@ -1123,17 +1124,23 @@ func (c *NetworkPolicyController) getNodeMemberSet(selector labels.Selector) con
 // getAddressGroupMemberSet knows how to construct a GroupMemberSet that contains
 // all the entities selected by an AddressGroup.
 func (n *NetworkPolicyController) getAddressGroupMemberSet(g *antreatypes.AddressGroup) controlplane.GroupMemberSet {
-	// Check if an internal Group object exists corresponding to this AddressGroup.
-	groupObj, found, _ := n.internalGroupStore.Get(g.Name)
-	if found {
-		// This AddressGroup is derived from a ClusterGroup.
-		// In case the ClusterGroup is defined by a mix of childGroup with selectors and
-		// childGroup with ipBlocks, this function only returns the aggregated GroupMemberSet
-		// computed from childGroup with selectors, as ipBlocks will be processed differently.
-		group := groupObj.(*antreatypes.Group)
-		members, _ := n.getInternalGroupMembers(group)
-		return members
+	// This AddressGroup is derived from a ClusterGroup/Group.
+	if g.SourceGroup != "" {
+		// Check if an internal Group object exists corresponding to this AddressGroup.
+		groupObj, found, _ := n.internalGroupStore.Get(g.SourceGroup)
+		if found {
+			// In case the ClusterGroup/Group is defined by a mix of childGroup with selectors and
+			// childGroup with ipBlocks, this function only returns the aggregated GroupMemberSet
+			// computed from childGroup with selectors, as ipBlocks will be processed differently.
+			group := groupObj.(*antreatypes.Group)
+			members, _ := n.getInternalGroupMembers(group)
+			return members
+		}
+		// The internal Group doesn't exist yet or has been deleted. The AddressGroup selects nothing at the moment.
+		// Once the internalGroup is created, the AddressGroup will be resynced.
+		return nil
 	}
+	// Selector can't be nil when it reaches here.
 	if g.Selector.NodeSelector != nil {
 		return n.getNodeMemberSet(g.Selector.NodeSelector)
 	}
@@ -1306,10 +1313,11 @@ func (n *NetworkPolicyController) syncAppliedToGroup(key string) error {
 		if err != nil {
 			klog.ErrorS(err, "Error when getting AppliedTo workloads for AppliedToGroup", "AppliedToGroup", appliedToGroup.Name)
 			updatedAppliedToGroup = &antreatypes.AppliedToGroup{
-				UID:       appliedToGroup.UID,
-				Name:      appliedToGroup.Name,
-				Selector:  appliedToGroup.Selector,
-				SyncError: err,
+				UID:         appliedToGroup.UID,
+				Name:        appliedToGroup.Name,
+				Selector:    appliedToGroup.Selector,
+				SourceGroup: appliedToGroup.SourceGroup,
+				SyncError:   err,
 			}
 		} else {
 			scheduledPodNum, scheduledExtEntityNum := 0, 0
@@ -1357,6 +1365,7 @@ func (n *NetworkPolicyController) syncAppliedToGroup(key string) error {
 				UID:               appliedToGroup.UID,
 				Name:              appliedToGroup.Name,
 				Selector:          appliedToGroup.Selector,
+				SourceGroup:       appliedToGroup.SourceGroup,
 				GroupMemberByNode: memberSetByNode,
 				SpanMeta:          antreatypes.SpanMeta{NodeNames: appGroupNodeNames},
 			}
@@ -1373,14 +1382,20 @@ func (n *NetworkPolicyController) syncAppliedToGroup(key string) error {
 // getAppliedToWorkloads returns a list of workloads (Pods, ExternalEntities or Nodes) selected by an AppliedToGroup
 // for standalone selectors or Pods and ExternalEntities corresponding to a ClusterGroup.
 func (n *NetworkPolicyController) getAppliedToWorkloads(g *antreatypes.AppliedToGroup) ([]*v1.Pod, []*v1alpha2.ExternalEntity, []*v1.Node, error) {
-	// Check if an internal Group object exists corresponding to this AppliedToGroup
-	group, found, _ := n.internalGroupStore.Get(g.Name)
-	if found {
-		// This AppliedToGroup is derived from a ClusterGroup.
-		grp := group.(*antreatypes.Group)
-		pods, ees, err := n.getInternalGroupWorkloads(grp)
-		return pods, ees, nil, err
+	// This AppliedToGroup is derived from a ClusterGroup/Group.
+	if g.SourceGroup != "" {
+		// Check if an internal Group object exists corresponding to this AppliedToGroup
+		group, found, _ := n.internalGroupStore.Get(g.SourceGroup)
+		if found {
+			grp := group.(*antreatypes.Group)
+			pods, ees, err := n.getInternalGroupWorkloads(grp)
+			return pods, ees, nil, err
+		}
+		// The internal Group doesn't exist yet or has been deleted. The AppliedToGroup selects nothing at the moment.
+		// Once the internalGroup is created, the AppliedToGroup will be resynced.
+		return nil, nil, nil, nil
 	}
+	// Selector can't be nil when it reaches here.
 	if g.Selector.NodeSelector != nil {
 		nodes, err := n.nodeLister.List(g.Selector.NodeSelector)
 		return nil, nil, nodes, err
@@ -1595,8 +1610,8 @@ func (n *NetworkPolicyController) syncInternalNetworkPolicy(key *controlplane.Ne
 			n.addressGroupStore.Create(addressGroup)
 			// For an AddressGroup that selects Nodes via nodeSelector, we calculate its members via NodeLister
 			// directly, instead of groupingInterface which handles Pod and ExternalEntity currently.
-			if addressGroup.Selector.NodeSelector == nil {
-				n.groupingInterface.AddGroup(addressGroupType, addressGroup.Name, &addressGroup.Selector)
+			if addressGroup.Selector != nil && addressGroup.Selector.NodeSelector == nil {
+				n.groupingInterface.AddGroup(addressGroupType, addressGroup.Name, addressGroup.Selector)
 			}
 		}
 

--- a/pkg/controller/networkpolicy/store/addressgroup.go
+++ b/pkg/controller/networkpolicy/store/addressgroup.go
@@ -157,7 +157,7 @@ func NewAddressGroupStore() storage.Interface {
 	indexers := cache.Indexers{
 		cache.NamespaceIndex: func(obj interface{}) ([]string, error) {
 			ag, ok := obj.(*types.AddressGroup)
-			if !ok {
+			if !ok || ag.Selector == nil {
 				return []string{}, nil
 			}
 			// ag.Selector.Namespace == "" means it's a cluster scoped group, we index it as it is.
@@ -165,10 +165,17 @@ func NewAddressGroupStore() storage.Interface {
 		},
 		IsNodeAddressGroupIndex: func(obj interface{}) ([]string, error) {
 			ag, ok := obj.(*types.AddressGroup)
-			if !ok || ag.Selector.NodeSelector == nil {
+			if !ok || ag.Selector == nil || ag.Selector.NodeSelector == nil {
 				return []string{}, nil
 			}
 			return []string{"true"}, nil
+		},
+		SourceGroupIndex: func(obj interface{}) ([]string, error) {
+			atg, ok := obj.(*types.AddressGroup)
+			if !ok || atg.SourceGroup == "" {
+				return []string{}, nil
+			}
+			return []string{atg.SourceGroup}, nil
 		},
 	}
 	return ram.NewStore(AddressGroupKeyFunc, indexers, genAddressGroupEvent, keyAndSpanSelectFunc, func() runtime.Object { return new(controlplane.AddressGroup) })

--- a/pkg/controller/networkpolicy/store/appliedtogroup.go
+++ b/pkg/controller/networkpolicy/store/appliedtogroup.go
@@ -28,7 +28,10 @@ import (
 	"antrea.io/antrea/pkg/controller/types"
 )
 
-const IsAppliedToServiceIndex = "isAppliedToService"
+const (
+	IsAppliedToServiceIndex = "isAppliedToService"
+	SourceGroupIndex        = "sourceGroup"
+)
 
 // appliedToGroupEvent implements storage.InternalEvent.
 type appliedToGroupEvent struct {
@@ -184,6 +187,13 @@ func NewAppliedToGroupStore() storage.Interface {
 				return []string{}, nil
 			}
 			return []string{"true"}, nil
+		},
+		SourceGroupIndex: func(obj interface{}) ([]string, error) {
+			atg, ok := obj.(*types.AppliedToGroup)
+			if !ok || atg.SourceGroup == "" {
+				return []string{}, nil
+			}
+			return []string{atg.SourceGroup}, nil
 		},
 	}
 	return ram.NewStore(AppliedToGroupKeyFunc, indexers, genAppliedToGroupEvent, keyAndSpanSelectFunc, func() runtime.Object { return new(controlplane.AppliedToGroup) })

--- a/pkg/controller/types/networkpolicy.go
+++ b/pkg/controller/types/networkpolicy.go
@@ -41,18 +41,24 @@ func (meta *SpanMeta) Has(nodeName string) bool {
 type AppliedToGroup struct {
 	SpanMeta
 	// If the AppliedToGroup is created from GroupSelector, UID is generated from the hash value of GroupSelector.NormalizedName.
-	// If the AppliedToGroup is created for a ClusterGroup, the UID is that of the corresponding ClusterGroup.
+	// If the AppliedToGroup is created for a ClusterGroup/Group, the UID is that of the corresponding ClusterGroup/Group.
 	// If the AppliedToGroup is created for a Service, the UID is generated from the hash value of NamespacedName of the Service.
 	UID types.UID
-	// Name of this group, currently it's same as UID.
+	// In case the AddressGroup is created for a ClusterGroup, it's the Name of the corresponding ClusterGroup.
+	// In case the AddressGroup is created for a Group, it's the Namespace/Name of the corresponding Group.
+	// Otherwise, it's same as UID.
 	Name string
-	// Selector describes how the group selects pods.
-	// Selector can't be used with Service.
+
+	// Selector, Service, and SourceGroup are mutually exclusive ways of selecting GroupMembers for the AppliedToGroup.
+	// For any AppliedToGroup, only one must be set.
+	// Selector describes how the group selects pods using selector.
 	Selector *GroupSelector
 	// Service refers to the Service this group selects. Only a NodePort type Service
 	// can be referred by this field.
-	// Service can't be used with Selector.
 	Service *controlplane.ServiceReference
+	// SourceGroup refers to the ClusterGroup or Group the AppliedToGroup is derived from.
+	SourceGroup string
+
 	// GroupMemberByNode is a mapping from nodeName to a set of GroupMembers on the Node,
 	// either GroupMembers or ExternalEntity on the external node.
 	// It will be converted to a slice of GroupMember for transferring according
@@ -65,14 +71,21 @@ type AppliedToGroup struct {
 // AddressGroup describes a set of addresses used as source or destination of Network Policy rules.
 type AddressGroup struct {
 	SpanMeta
-	// UID is generated from the hash value of GroupSelector.NormalizedName.
-	// In case the AddressGroup is created for a ClusterGroup, the UID is
-	// that of the corresponding ClusterGroup.
+	// If the AddressGroup is created from GroupSelector, UID is generated from the hash value of GroupSelector.NormalizedName.
+	// If the AddressGroup is created for a ClusterGroup/Group, the UID is that of the corresponding ClusterGroup/Group.
 	UID types.UID
-	// Name of this group, currently it's same as UID.
+	// In case the AddressGroup is created for a ClusterGroup, it's the Name of the corresponding ClusterGroup.
+	// In case the AddressGroup is created for a Group, it's the Namespace/Name of the corresponding ClusterGroup.
+	// Otherwise, it's same as UID.
 	Name string
+
+	// Selector and SourceGroup are mutually exclusive ways of selecting GroupMembers for the AddressGroup.
+	// For any AddressGroup, only one must be set.
 	// Selector describes how the group selects pods to get their addresses.
-	Selector GroupSelector
+	Selector *GroupSelector
+	// SourceGroup refers to the ClusterGroup or Group the AddressGroup is derived from.
+	SourceGroup string
+
 	// GroupMembers is a set of GroupMembers selected by this group.
 	// It will be converted to a slice of GroupMember for transferring according
 	// to client's selection.


### PR DESCRIPTION
Cherry pick of #6077 on release-1.15.

#6077: Fix nil pointer dereference when ClusterGroup/Group is used

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.