### PR TITLE
Fix antctl e2e controller-mode empty tests

### DIFF
--- a/test/e2e/antctl_test.go
+++ b/test/e2e/antctl_test.go
@@ -132,13 +132,14 @@ func testAntctlAgentLocalAccess(t *testing.T, data *TestData) {
 	if err != nil {
 		t.Fatalf("Error when getting antrea-agent pod name: %v", err)
 	}
+	antctlName := antctlName()
 	for _, c := range antctl.CommandList.GetDebugCommands(runtime.ModeAgent) {
-		args := []string{}
+		args := []string{antctlName}
 		if testOptions.enableCoverage {
-			antctlCovArgs := antctlCoverageArgs("antctl-coverage", "")
+			antctlCovArgs := antctlCoverageArgs(antctlName, "")
 			args = append(antctlCovArgs, c...)
 		} else {
-			args = append([]string{"antctl"}, c...)
+			args = append(args, c...)
 		}
 		t.Logf("args: %s", args)
 
@@ -195,6 +196,8 @@ func testAntctlControllerRemoteAccess(t *testing.T, data *TestData, antctlServic
 		if testOptions.enableCoverage {
 			antctlCovArgs := antctlCoverageArgs(antctlName, covDir)
 			cmd = append(antctlCovArgs, c...)
+		} else {
+			cmd = append(cmd, c...)
 		}
 		testCmds = append(testCmds, cmdAndReturnCode{args: cmd, expectedReturnCode: 0})
 	}


### PR DESCRIPTION
Currently when running antctl e2e tests for controller mode+coverage not enabled, the command arguments are empty. 
So commands are not tested as expected. This PR fixes the issue. (Mainly line 200)