### PR TITLE
Do not run tests when building OVS for UBI

### DIFF
--- a/build/images/ovs/Dockerfile.ubi
+++ b/build/images/ovs/Dockerfile.ubi
@@ -33,9 +33,9 @@ RUN cd /tmp/openvswitch* && \
     yum-builddep -y /tmp/ovs.spec && ./boot.sh && \
     ./configure --prefix=/usr --localstatedir=/var --sysconfdir=/etc && \
     # logrotate needs to run as the same user as OVS to get the proper permissions of log files.
-    # As Antrea runs OVS as root, we disable libcapng to make logrotate also run as root. 
+    # As Antrea runs OVS as root, we disable libcapng to make logrotate also run as root.
     # See https://github.com/openvswitch/ovs/blob/v2.17.7/rhel/openvswitch-fedora.spec.in#L26-L27.
-    RPMBUILD_OPT="--without libcapng" make rpm-fedora && mkdir -p /tmp/ovs-rpms && \
+    RPMBUILD_OPT="--without libcapng --without check" make rpm-fedora && mkdir -p /tmp/ovs-rpms && \
     mv /tmp/openvswitch-$OVS_VERSION/rpm/rpmbuild/RPMS/*/*.rpm  /tmp/ovs-rpms && \
     rm -rf /tmp/openvswitch*
 


### PR DESCRIPTION
This change adds back the default `RPMBUILD_OPT` option to disable unnecessary tests when building OVS rpm packages, which was previously overwritten in #6052.