### PR TITLE
NetworkPolicy Evaluation E2E Tests

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -238,7 +238,8 @@ jobs:
             --proxy-all \
             --node-ipam \
             --extra-vlan \
-            --multicast
+            --multicast \
+            --networkpolicy-evaluation
       - name: Tar coverage files
         run: tar -czf test-e2e-encap-all-features-enabled-coverage.tar.gz test-e2e-encap-all-features-enabled-coverage
       - name: Upload coverage for test-e2e-encap-all-features-enabled-coverage

--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -675,6 +675,7 @@ func testMain(m *testing.M) int {
 	flag.BoolVar(&testOptions.enableCoverage, "coverage", false, "Run tests and measure coverage")
 	flag.BoolVar(&testOptions.enableAntreaIPAM, "antrea-ipam", false, "Run tests with AntreaIPAM")
 	flag.BoolVar(&testOptions.flowVisibility, "flow-visibility", false, "Run flow visibility tests")
+	flag.BoolVar(&testOptions.npEvaluation, "networkpolicy-evaluation", false, "Run NetworkPolicy evaluation tests")
 	flag.BoolVar(&testOptions.deployAntrea, "deploy-antrea", true, "Deploy Antrea before running tests")
 	flag.StringVar(&testOptions.coverageDir, "coverage-dir", "", "Directory for coverage data files")
 	flag.StringVar(&testOptions.skipCases, "skip-cases", "", "Key words to skip cases")

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -209,6 +209,7 @@ type TestOptions struct {
 	enableCoverage      bool
 	enableAntreaIPAM    bool
 	flowVisibility      bool
+	npEvaluation        bool
 	coverageDir         string
 	skipCases           string
 	linuxVMs            string

--- a/test/e2e/k8s_util.go
+++ b/test/e2e/k8s_util.go
@@ -64,6 +64,7 @@ type TestCase struct {
 type TestStep struct {
 	Name           string
 	Reachability   *Reachability
+	NPEvaluation   *NPEvaluation
 	TestResources  []metav1.Object
 	Ports          []int32
 	Protocol       utils.AntreaPolicyProtocol


### PR DESCRIPTION
The PR will add E2E tests for `networkpolicyevaluation` introduced in #5740 .

This framework design and test example is for discussion before moving on.