### PR TITLE
Add Action to NetworkPolicy Evaluation response

### DIFF
--- a/pkg/antctl/output/output.go
+++ b/pkg/antctl/output/output.go
@@ -21,7 +21,6 @@ import (
 	"io"
 	"reflect"
 	"sort"
-	"strconv"
 	"strings"
 	"text/tabwriter"
 
@@ -322,7 +321,7 @@ func TableOutputForQueryEndpoint(obj interface{}, writer io.Writer) error {
 	toStringRep := func(effectiveRules []apis.Rule) [][]string {
 		ruleStrings := make([][]string, 0)
 		for _, rule := range effectiveRules {
-			ruleStrings = append(ruleStrings, []string{rule.PolicyRef.Name, rule.PolicyRef.Namespace, strconv.Itoa(rule.RuleIndex), string(rule.PolicyRef.UID)})
+			ruleStrings = append(ruleStrings, []string{rule.PolicyRef.Name, rule.PolicyRef.Namespace, fmt.Sprint(rule.RuleIndex), string(rule.PolicyRef.UID)})
 		}
 		return ruleStrings
 	}

--- a/pkg/apiserver/apis/types.go
+++ b/pkg/apiserver/apis/types.go
@@ -24,7 +24,7 @@ type EndpointQueryResponse struct {
 type Rule struct {
 	PolicyRef v1beta2.NetworkPolicyReference `json:"policyref,omitempty"`
 	Direction v1beta2.Direction              `json:"direction,omitempty"`
-	RuleIndex int                            `json:"ruleindex,omitempty"`
+	RuleIndex int32                          `json:"ruleindex,omitempty"`
 }
 
 type Endpoint struct {

--- a/pkg/controller/networkpolicy/endpoint_querier.go
+++ b/pkg/controller/networkpolicy/endpoint_querier.go
@@ -146,7 +146,7 @@ func (eq *EndpointQuerierImpl) QueryNetworkPolicyRules(namespace, podName string
 			return nil, err
 		}
 		for _, policy := range policies {
-			egressIndex, ingressIndex := 0, 0
+			egressIndex, ingressIndex := int32(0), int32(0)
 			for _, rule := range policy.(*antreatypes.NetworkPolicy).Rules {
 				for _, addressGroupTrial := range rule.To.AddressGroups {
 					if addressGroupTrial == string(addressGroup.(*antreatypes.AddressGroup).UID) {
@@ -191,10 +191,10 @@ func processEndpointAppliedRules(appliedPolicies []*antreatypes.NetworkPolicy, i
 			// check if the Kubernetes NetworkPolicy creates ingress or egress isolationRules
 			for _, rule := range internalPolicy.Rules {
 				if rule.Direction == controlplane.DirectionIn && !isSourceEndpoint {
-					isolationRules = append(isolationRules, &antreatypes.RuleInfo{Policy: internalPolicy, Index: math.MaxInt,
+					isolationRules = append(isolationRules, &antreatypes.RuleInfo{Policy: internalPolicy, Index: math.MaxInt32,
 						Rule: &controlplane.NetworkPolicyRule{Direction: rule.Direction, Name: rule.Name, Action: rule.Action}})
 				} else if rule.Direction == controlplane.DirectionOut && isSourceEndpoint {
-					isolationRules = append(isolationRules, &antreatypes.RuleInfo{Policy: internalPolicy, Index: math.MaxInt,
+					isolationRules = append(isolationRules, &antreatypes.RuleInfo{Policy: internalPolicy, Index: math.MaxInt32,
 						Rule: &controlplane.NetworkPolicyRule{Direction: rule.Direction, Name: rule.Name, Action: rule.Action}})
 				}
 			}
@@ -313,7 +313,7 @@ func (eq *policyRuleQuerier) QueryNetworkPolicyEvaluation(entities *controlplane
 	}
 	return &controlplane.NetworkPolicyEvaluationResponse{
 		NetworkPolicy: *endpointAnalysisRule.Policy.SourceRef,
-		RuleIndex:     int32(endpointAnalysisRule.Index),
+		RuleIndex:     endpointAnalysisRule.Index,
 		Rule: controlplane.RuleRef{
 			Direction: endpointAnalysisRule.Rule.Direction,
 			Name:      endpointAnalysisRule.Rule.Name,

--- a/pkg/controller/networkpolicy/endpoint_querier_test.go
+++ b/pkg/controller/networkpolicy/endpoint_querier_test.go
@@ -16,6 +16,7 @@ package networkpolicy
 
 import (
 	"fmt"
+	"math"
 	"testing"
 	"time"
 
@@ -395,7 +396,7 @@ func TestQueryNetworkPolicyEvaluation(t *testing.T) {
 		for i := 0; i < len(policy.Rules); i++ {
 			ruleInfoMatches[i] = &antreatypes.RuleInfo{
 				Policy: policy,
-				Index:  i,
+				Index:  int32(i),
 				Rule:   &controlplane.NetworkPolicyRule{Direction: policy.Rules[i].Direction, Name: policy.Rules[i].Name, Action: policy.Rules[i].Action},
 			}
 		}
@@ -529,7 +530,7 @@ func TestQueryNetworkPolicyEvaluation(t *testing.T) {
 			},
 			expectedResult: &controlplane.NetworkPolicyEvaluationResponse{
 				NetworkPolicy: controlplane.NetworkPolicyReference{Type: controlplane.K8sNetworkPolicy, Namespace: namespace, Name: "Policy111", UID: uid1},
-				RuleIndex:     -1,
+				RuleIndex:     math.MaxInt32,
 				Rule:          controlplane.RuleRef{Direction: controlplane.DirectionOut, Name: "Policy111Rule0"},
 			},
 		},
@@ -542,7 +543,7 @@ func TestQueryNetworkPolicyEvaluation(t *testing.T) {
 			},
 			expectedResult: &controlplane.NetworkPolicyEvaluationResponse{
 				NetworkPolicy: controlplane.NetworkPolicyReference{Type: controlplane.K8sNetworkPolicy, Namespace: namespace, Name: "Policy222", UID: uid2},
-				RuleIndex:     -1,
+				RuleIndex:     math.MaxInt32,
 				Rule:          controlplane.RuleRef{Direction: controlplane.DirectionIn, Name: "Policy222Rule0"},
 			},
 		},

--- a/pkg/controller/types/networkpolicy.go
+++ b/pkg/controller/types/networkpolicy.go
@@ -139,7 +139,7 @@ func (p *NetworkPolicy) GetAppliedToGroups() sets.Set[string] {
 // corresponding ingress/egress rules, and the original rule info.
 type RuleInfo struct {
 	Policy *NetworkPolicy
-	Index  int
+	Index  int32
 	Rule   *controlplane.NetworkPolicyRule
 }
 


### PR DESCRIPTION
As necessary for `networkpolicyevaluation` consumption, this PR adds the `Action` field to the above `antctl` command response.