### PR TITLE
Update apt for Kubernetes in vagrant playbook

### DIFF
--- a/test/e2e/infra/vagrant/playbook/roles/common/tasks/kube.yml
+++ b/test/e2e/infra/vagrant/playbook/roles/common/tasks/kube.yml
@@ -1,13 +1,22 @@
+- name: Get Kubernetes stable release
+  uri:
+    url: https://dl.k8s.io/release/stable.txt
+    return_content: yes
+  register: k8sRelease
+
 - name: Add an apt signing key for Kubernetes
+  vars:
+    k8sVersion: "{{ k8sRelease.content.split('.')[0] }}.{{ k8sRelease.content.split('.')[1] }}"
   apt_key:
-    url: https://packages.cloud.google.com/apt/doc/apt-key.gpg
+    url: https://pkgs.k8s.io/core:/stable:/{{ k8sVersion }}/deb/Release.key
+    keyring: /etc/apt/keyrings/kubernetes-apt-keyring.gpg
     state: present
 
 - name: Adding apt repository for Kubernetes
+  vars:
+    k8sVersion: "{{ k8sRelease.content.split('.')[0] }}.{{ k8sRelease.content.split('.')[1] }}"
   apt_repository:
-    # kubernetes-xenial should work for Ubuntu 16.04+, there is no
-    # kubernetes-bionic
-    repo: deb https://packages.cloud.google.com/apt/ kubernetes-xenial main
+    repo: deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/{{ k8sVersion }}/deb/ /
     state: present
     filename: kubernetes.list
 


### PR DESCRIPTION
As legacy Linux package repositories for Kubernetes are frozen, the old vagrant playbook throws an error.
```
fatal: [k8s-node-control-plane]: FAILED! => {"changed": false, "msg": "Failed to update apt cache: E:The repository 'https://packages.cloud.google.com/apt kubernetes-xenial Release' does not have a Release file., W:Updating from such a repository can't be done securely, and is therefore disabled by default., W:See apt-secure(8) manpage for repository creation and user configuration details., W:https://download.docker.com/linux/ubuntu/dists/jammy/InRelease: Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details."}
```
```
E:The repository 'https://apt.kubernetes.io kubernetes-xenial Release' does not have a Release file.
```

This change updates the apt_key and apt_repository for Kubernetes in vagrant playbook.

Reference: https://kubernetes.io/blog/2023/08/15/pkgs-k8s-io-introduction/#how-to-migrate
https://dl.k8s.io/release/stable.txt