### PR TITLE
Fix ci/test-e2e-kind.sh script on macOS

### DIFF
--- a/ci/kind/test-e2e-kind.sh
+++ b/ci/kind/test-e2e-kind.sh
@@ -364,7 +364,9 @@ function run_test {
     RUN_OPT="-run $run"
   fi
 
-  EXTRA_ARGS="$vlan_args --external-server-ips $(docker inspect external-server -f '{{.NetworkSettings.Networks.kind.IPAddress}},{{.NetworkSettings.Networks.kind.GlobalIPv6Address}}')"
+  external_server_cid=$(docker ps -f name="^antrea-external-server" --format '{{.ID}}')
+  external_server_ips=$(docker inspect $external_server_cid -f '{{.NetworkSettings.Networks.kind.IPAddress}},{{.NetworkSettings.Networks.kind.GlobalIPv6Address}}')
+  EXTRA_ARGS="$vlan_args --external-server-ips $external_server_ips"
 
   go test -v -timeout=$timeout $RUN_OPT antrea.io/antrea/test/e2e $flow_visibility_args -provider=kind --logs-export-dir=$ANTREA_LOG_DIR --skip-cases=$skiplist $coverage_args $EXTRA_ARGS
 }


### PR DESCRIPTION
The script was failing with:
```
Deleting VLAN subnets
Option "-br" is unknown, try "ip help".
```
when cleaning-up a test cluster.

This is because the ip command on macOS only supports a subset of the command-line options supported on Linux. In any case, on macOS, the command needs be wrapped with docker_run_with_host_net, since we are looking for VLAN interfaces running in the Docker Linux VM.

As a minor improvement, we also add the "antrea" prefix to the external server container we create, along with a short random suffix ($RANDOM is sufficient for this) to avoid possible conflicts.

Fixes #6022