### PR TITLE
Enhance Egress support in Traceflow

### DIFF
--- a/build/charts/antrea/crds/traceflow.yaml
+++ b/build/charts/antrea/crds/traceflow.yaml
@@ -456,6 +456,8 @@ spec:
                               type: string
                             egressNode:
                               type: string
+                            egressNodeIP:
+                              type: string
                 capturedPacket:
                   properties:
                     srcIP:

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -4987,6 +4987,8 @@ spec:
                               type: string
                             egressNode:
                               type: string
+                            egressNodeIP:
+                              type: string
                 capturedPacket:
                   properties:
                     srcIP:

--- a/build/yamls/antrea-crds.yml
+++ b/build/yamls/antrea-crds.yml
@@ -4960,6 +4960,8 @@ spec:
                               type: string
                             egressNode:
                               type: string
+                            egressNodeIP:
+                              type: string
                 capturedPacket:
                   properties:
                     srcIP:

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -4987,6 +4987,8 @@ spec:
                               type: string
                             egressNode:
                               type: string
+                            egressNodeIP:
+                              type: string
                 capturedPacket:
                   properties:
                     srcIP:

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -4987,6 +4987,8 @@ spec:
                               type: string
                             egressNode:
                               type: string
+                            egressNodeIP:
+                              type: string
                 capturedPacket:
                   properties:
                     srcIP:

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -4987,6 +4987,8 @@ spec:
                               type: string
                             egressNode:
                               type: string
+                            egressNodeIP:
+                              type: string
                 capturedPacket:
                   properties:
                     srcIP:

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -4987,6 +4987,8 @@ spec:
                               type: string
                             egressNode:
                               type: string
+                            egressNodeIP:
+                              type: string
                 capturedPacket:
                   properties:
                     srcIP:

--- a/pkg/apis/crd/v1beta1/types.go
+++ b/pkg/apis/crd/v1beta1/types.go
@@ -1187,6 +1187,8 @@ type Observation struct {
 	EgressIP    string `json:"egressIP,omitempty" yaml:"egressIP,omitempty"`
 	// EgressNode is the name of the Egress Node.
 	EgressNode string `json:"egressNode,omitempty" yaml:"egressNode,omitempty"`
+	// EgressNodeIP is the IP of Egress Node.
+	EgressNodeIP string `json:"egressNodeIP,omitempty" yaml:"egressNodeIP,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apiserver/openapi/zz_generated.openapi.go
+++ b/pkg/apiserver/openapi/zz_generated.openapi.go
@@ -5163,6 +5163,13 @@ func schema_pkg_apis_crd_v1beta1_Observation(ref common.ReferenceCallback) commo
 							Format:      "",
 						},
 					},
+					"egressNodeIP": {
+						SchemaProps: spec.SchemaProps{
+							Description: "EgressNodeIP is the IP of Egress Node.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/test/e2e/traceflow_test.go
+++ b/test/e2e/traceflow_test.go
@@ -2118,11 +2118,12 @@ func testTraceflowEgress(t *testing.T, data *TestData) {
 						Action:    v1beta1.ActionForwarded,
 					},
 					{
-						Component:  v1beta1.ComponentEgress,
-						Action:     v1beta1.ActionMarkedForSNAT,
-						Egress:     egress.Name,
-						EgressIP:   egressIP,
-						EgressNode: egressNode,
+						Component:    v1beta1.ComponentEgress,
+						Action:       v1beta1.ActionMarkedForSNAT,
+						Egress:       egress.Name,
+						EgressIP:     egressIP,
+						EgressNode:   egressNode,
+						EgressNodeIP: egressIP,
 					},
 					{
 						Component:     v1beta1.ComponentForwarding,
@@ -2211,9 +2212,11 @@ func testTraceflowEgress(t *testing.T, data *TestData) {
 						Action:    v1beta1.ActionReceived,
 					},
 					{
-						Component: v1beta1.ComponentEgress,
-						Action:    v1beta1.ActionMarkedForSNAT,
-						EgressIP:  egressIP,
+						Component:    v1beta1.ComponentEgress,
+						Action:       v1beta1.ActionMarkedForSNAT,
+						EgressIP:     egressIP,
+						EgressNode:   egressNode,
+						EgressNodeIP: egressIP,
 					},
 					{
 						Component:     v1beta1.ComponentForwarding,
@@ -2348,6 +2351,7 @@ func compareObservations(expected v1beta1.NodeResult, actual v1beta1.NodeResult)
 			exObs[i].EgressIP != acObs[i].EgressIP ||
 			exObs[i].Egress != acObs[i].Egress ||
 			exObs[i].EgressNode != acObs[i].EgressNode ||
+			exObs[i].EgressNodeIP != acObs[i].EgressNodeIP ||
 			exObs[i].Action != acObs[i].Action ||
 			exObs[i].NetworkPolicy != acObs[i].NetworkPolicy ||
 			exObs[i].NetworkPolicyRule != acObs[i].NetworkPolicyRule {


### PR DESCRIPTION
- Add `EgressNodeIP` field in Traceflow observations.

- Add `EgressNode` field in observations from Egress Node as well when Egress Node is different from source Node. Previously, `EgressNode` field was available only in observations from source Node.

For #6099