### PR TITLE
Update the toolbox image to v1.3-0 and cherry-pick PR6021 to fix windows containerd e2e failure

### DIFF
--- a/ci/kind/test-e2e-kind.sh
+++ b/ci/kind/test-e2e-kind.sh
@@ -211,7 +211,7 @@ fi
 COMMON_IMAGES_LIST=("registry.k8s.io/e2e-test-images/agnhost:2.29" \
                     "projects.registry.vmware.com/antrea/busybox"  \
                     "projects.registry.vmware.com/antrea/nginx:1.21.6-alpine" \
-                    "projects.registry.vmware.com/antrea/toolbox:1.1-0")
+                    "projects.registry.vmware.com/antrea/toolbox:1.3-0")
 
 FLOW_VISIBILITY_IMAGE_LIST=("projects.registry.vmware.com/antrea/ipfix-collector:v0.8.2" \
                             "projects.registry.vmware.com/antrea/clickhouse-operator:0.21.0" \

--- a/test/e2e/connectivity_test.go
+++ b/test/e2e/connectivity_test.go
@@ -193,7 +193,7 @@ func testHostPortPodConnectivity(t *testing.T, data *TestData) {
 // alternating in this podInfo slice so that the test can cover different connectivity cases between different OSes.
 func createPodsOnDifferentNodes(t *testing.T, data *TestData, namespace, tag string) (podInfos []PodInfo, cleanup func() error) {
 	dsName := "connectivity-test" + tag
-	_, deleteDaemonSet, err := data.createDaemonSet(dsName, namespace, toolboxContainerName, toolboxImage, []string{"sleep", "3600"}, nil)
+	_, deleteDaemonSet, err := data.createDaemonSet(dsName, namespace, toolboxContainerName, toolboxImage, nil, nil)
 	if err != nil {
 		t.Fatalf("Error when creating DaemonSet '%s': %v", dsName, err)
 	}

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -133,7 +133,7 @@ const (
 	mcjoinImage         = "projects.registry.vmware.com/antrea/mcjoin:v2.9"
 	nginxImage          = "projects.registry.vmware.com/antrea/nginx:1.21.6-alpine"
 	iisImage            = "mcr.microsoft.com/windows/servercore/iis"
-	toolboxImage        = "projects.registry.vmware.com/antrea/toolbox:1.2-1"
+	toolboxImage        = "projects.registry.vmware.com/antrea/toolbox:1.3-0"
 	ipfixCollectorImage = "projects.registry.vmware.com/antrea/ipfix-collector:v0.8.2"
 	ipfixCollectorPort  = "4739"
 	clickHouseHTTPPort  = "8123"

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -1518,7 +1518,7 @@ func (data *TestData) createMcJoinPodOnNode(name string, ns string, nodeName str
 // createToolboxPodOnNode creates a Pod in the test namespace with a single toolbox container. The
 // Pod will be scheduled on the specified Node (if nodeName is not empty).
 func (data *TestData) createToolboxPodOnNode(name string, ns string, nodeName string, hostNetwork bool) error {
-	return NewPodBuilder(name, ns, toolboxImage).OnNode(nodeName).WithCommand([]string{"sleep", "3600"}).WithHostNetwork(hostNetwork).Create(data)
+	return NewPodBuilder(name, ns, toolboxImage).OnNode(nodeName).WithHostNetwork(hostNetwork).Create(data)
 }
 
 // createNginxPodOnNode creates a Pod in the test namespace with a single nginx container. The
@@ -3099,7 +3099,11 @@ func getPingCommand(count int, size int, os string, ip *net.IP, dontFragment boo
 		cmd = append(cmd, sizeOption, strconv.Itoa(size))
 	}
 	if dontFragment {
-		cmd = append(cmd, "-M", "do")
+		if os == "windows" {
+			cmd = append(cmd, "-f")
+		} else {
+			cmd = append(cmd, "-M", "do")
+		}
 	}
 
 	if ip.To4() != nil {

--- a/test/e2e/tls_test.go
+++ b/test/e2e/tls_test.go
@@ -59,7 +59,7 @@ func TestAntreaApiserverTLSConfig(t *testing.T) {
 	require.NotNil(t, node, "failed to get the Node")
 	nodeIPv4 := node.ipv4Addr
 	nodeIPv6 := node.ipv6Addr
-	clientPodName, _, cleanupFunc := createAndWaitForPod(t, data, data.createToolboxPodOnNode, "client", controllerPodNode, antreaNamespace, true)
+	clientPodName, _, cleanupFunc := createAndWaitForPod(t, data, data.createToolboxPodOnNode, "client", controllerPodNode, data.testNamespace, true)
 	defer cleanupFunc()
 
 	tests := []struct {
@@ -73,7 +73,6 @@ func TestAntreaApiserverTLSConfig(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
 			data.checkTLS(t, clientPodName, toolboxContainerName, tc.apiserver, tc.apiserverStr, nodeIPv4, nodeIPv6)
 		})
 	}
@@ -134,7 +133,7 @@ func (data *TestData) curlTestTLS(t *testing.T, pod string, container string, tl
 		if tls12 {
 			cmd = append(cmd, "--tls-max", "1.2", "--tlsv1.2")
 		}
-		stdout, stderr, err := data.RunCommandFromPod(antreaNamespace, pod, container, cmd)
+		stdout, stderr, err := data.RunCommandFromPod(data.testNamespace, pod, container, cmd)
 		assert.NoError(t, err, "failed to run curl command on Pod '%s'\nstdout: %s", pod, stdout)
 		t.Logf("Ran '%s' on Pod %s", strings.Join(cmd, " "), pod)
 		// Collect stderr as all TLS-related details such as the cipher suite are present in stderr.


### PR DESCRIPTION
Fix the antrea-windows-containerd-e2e failure in release-1.15.1 #6110 by updating the toolbox image to v1.3-0 and cherry-pick PR6021.

There is an old issue tracked the same failure: https://github.com/antrea-io/image-utils/issues/26