### PR TITLE
Fix L7 NetworkPolicy e2e test failure

### DIFF
--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -113,12 +113,6 @@ func probeFromPod(data *TestData, pod, container string, url string) error {
 	return err
 }
 
-func probeHostnameFromPod(data *TestData, pod, container string, baseUrl string) (string, error) {
-	url := fmt.Sprintf("%s/%s", baseUrl, "hostname")
-	hostname, _, err := data.runWgetCommandFromTestPodWithRetry(pod, data.testNamespace, container, url, 5)
-	return hostname, err
-}
-
 func probeClientIPFromPod(data *TestData, pod, container string, baseUrl string) (string, error) {
 	url := fmt.Sprintf("%s/%s", baseUrl, "clientip")
 	hostPort, _, err := data.runWgetCommandFromTestPodWithRetry(pod, data.testNamespace, container, url, 5)


### PR DESCRIPTION
Fix L7 NetworkPolicy e2e test failure

Fix #6129

In the failure tests, the following function is called to
verify whether a connection should be allowed or denied.
To verify a connection should be denied, it requires 5 seconds.

```go
func probeClientIPFromPod(data *TestData, pod, container string, baseUrl string) (string, error) {
	url := fmt.Sprintf("%s/%s", baseUrl, "clientip")
	hostPort, _, err := data.runWgetCommandFromTestPodWithRetry(pod, data.testNamespace, container, url, 5)
	if err != nil {
		return "", err
	}
	host, _, err := net.SplitHostPort(hostPort)
	return host, err
}
```

Before #5843, these e2e tests utilized the function `PollImmediate`
from `k8s.io/apimachinery/pkg/util/wait`, which immediately calls an
anonymous function including the above function. Since the timeout
is 5 seconds, and the ticker time is 1 second, and the anonymous
function runs immediately, the 5-second timeout is sufficient to
verify the denied state of a connection as mentioned above. However,
after #5843, the function `Eventually` from `github.com/stretchr/testify/assert`
is used with the same parameters, which implies that the anonymous
function runs after the first ticker time, leaving 4 seconds. 4 seconds
are insufficient to verify the denied state of a connection.

To resolve the issue, `RunCommandFromPod` called in
`data.runWgetCommandFromTestPodWithRetry` is called directly in function
 `Eventually` to verify the connection state.
