### PR TITLE
Automated cherry pick of #5988: Disable cgo for all Antrea binaries (#5988)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@ SHELL              := /bin/bash
 GO                 ?= go
 LDFLAGS            :=
 GOFLAGS            :=
+# By default, disable cgo for all Go binaries.
+# For binaries meant to be published as release assets or copied to a different host, cgo should
+# always be disabled.
+CGO_ENABLED        ?= 0
 BINDIR             ?= $(CURDIR)/bin
 GO_FILES           := $(shell find . -type d -name '.cache' -prune -o -type f -name '*.go' -print)
 GOPATH             ?= $$($(GO) env GOPATH)
@@ -32,6 +36,8 @@ WIN_BUILD_ARGS += --build-arg CNI_BINARIES_VERSION=$(CNI_BINARIES_VERSION)
 WIN_BUILD_ARGS += --build-arg NANOSERVER_VERSION=$(NANOSERVER_VERSION)
 WIN_BUILD_ARGS += --build-arg WIN_BUILD_TAG=$(WIN_BUILD_TAG)
 WIN_BUILD_ARGS += --build-arg WIN_BUILD_OVS_TAG=$(WIN_BUILD_OVS_TAG)
+
+export CGO_ENABLED
 
 .PHONY: all
 all: build
@@ -78,7 +84,7 @@ antrea-agent:
 .PHONY: antrea-agent-release
 antrea-agent-release:
 	@mkdir -p $(BINDIR)
-	@CGO_ENABLED=0 $(GO) build -o $(BINDIR)/$(ANTREA_AGENT_BINARY_NAME) $(GOFLAGS) -ldflags '$(LDFLAGS)' antrea.io/antrea/cmd/antrea-agent
+	$(GO) build -o $(BINDIR)/$(ANTREA_AGENT_BINARY_NAME) $(GOFLAGS) -ldflags '$(LDFLAGS)' antrea.io/antrea/cmd/antrea-agent
 
 .PHONY: antrea-agent-simulator
 antrea-agent-simulator:
@@ -104,29 +110,25 @@ antrea-controller-instr-binary:
 	@mkdir -p $(BINDIR)
 	GOOS=linux $(GO) test -tags testbincover -covermode count -coverpkg=antrea.io/antrea/pkg/... -c -o $(BINDIR)/antrea-controller-coverage $(GOFLAGS) -ldflags '$(LDFLAGS)' antrea.io/antrea/cmd/antrea-controller
 
-# diable cgo for antrea-cni since it can be installed on some systems with
-# incompatible or missing system libraries.
 .PHONY: antrea-cni
 antrea-cni:
 	@mkdir -p $(BINDIR)
-	GOOS=linux CGO_ENABLED=0 $(GO) build -o $(BINDIR) $(GOFLAGS) -ldflags '$(LDFLAGS)' antrea.io/antrea/cmd/antrea-cni
+	GOOS=linux $(GO) build -o $(BINDIR) $(GOFLAGS) -ldflags '$(LDFLAGS)' antrea.io/antrea/cmd/antrea-cni
 
 .PHONY: antrea-cni
 antrea-cni-release:
 	@mkdir -p $(BINDIR)
-	@CGO_ENABLED=0 $(GO) build -o $(BINDIR)/$(ANTREA_CNI_BINARY_NAME) $(GOFLAGS) -ldflags '$(LDFLAGS)' antrea.io/antrea/cmd/antrea-cni
+	$(GO) build -o $(BINDIR)/$(ANTREA_CNI_BINARY_NAME) $(GOFLAGS) -ldflags '$(LDFLAGS)' antrea.io/antrea/cmd/antrea-cni
 
 .PHONY: antctl-instr-binary
 antctl-instr-binary:
 	@mkdir -p $(BINDIR)
 	GOOS=linux $(GO) test -tags testbincover -covermode count -coverpkg=antrea.io/antrea/pkg/... -c -o $(BINDIR)/antctl-coverage $(GOFLAGS) -ldflags '$(LDFLAGS)' antrea.io/antrea/cmd/antctl
 
-# diable cgo for antrea-cni and antrea-agent: antrea-cni is meant to be
-# installed on the host and the antrea-agent is run as a process on Windows.
 .PHONY: windows-bin
 windows-bin:
 	@mkdir -p $(BINDIR)
-	GOOS=windows CGO_ENABLED=0 $(GO) build -o $(BINDIR) $(GOFLAGS) -ldflags '$(LDFLAGS)' antrea.io/antrea/cmd/antrea-cni antrea.io/antrea/cmd/antrea-agent antrea.io/antrea/cmd/antctl
+	GOOS=windows $(GO) build -o $(BINDIR) $(GOFLAGS) -ldflags '$(LDFLAGS)' antrea.io/antrea/cmd/antrea-cni antrea.io/antrea/cmd/antrea-agent antrea.io/antrea/cmd/antctl
 
 .PHONY: flow-aggregator
 flow-aggregator:
@@ -234,7 +236,7 @@ antctl: $(ANTCTL_BINARIES)
 
 .PHONY: antctl-release
 antctl-release:
-	@CGO_ENABLED=0 $(GO) build -o $(BINDIR)/$(ANTCTL_BINARY_NAME) $(GOFLAGS) -ldflags '-s -w $(LDFLAGS)' antrea.io/antrea/cmd/antctl
+	$(GO) build -o $(BINDIR)/$(ANTCTL_BINARY_NAME) $(GOFLAGS) -ldflags '-s -w $(LDFLAGS)' antrea.io/antrea/cmd/antctl
 
 .PHONY: check-copyright
 check-copyright: 
@@ -244,11 +246,13 @@ check-copyright:
 add-copyright: 
 	@GO=$(GO) $(CURDIR)/hack/add-license.sh --add
 
+# Cgo is required to run the race detector.
+
 .PHONY: .linux-test-unit
 .linux-test-unit: .coverage
 	@echo
 	@echo "==> Running unit tests <=="
-	$(GO) test -race -coverpkg=antrea.io/antrea/cmd/...,antrea.io/antrea/pkg/...,antrea.io/antrea/multicluster/cmd/...,antrea.io/antrea/multicluster/controllers/... \
+	CGO_ENABLED=1 $(GO) test -race -coverpkg=antrea.io/antrea/cmd/...,antrea.io/antrea/pkg/...,antrea.io/antrea/multicluster/cmd/...,antrea.io/antrea/multicluster/controllers/... \
 	  -coverprofile=.coverage/coverage-unit.txt -covermode=atomic \
 	  antrea.io/antrea/cmd/... antrea.io/antrea/pkg/... antrea.io/antrea/multicluster/cmd/... antrea.io/antrea/multicluster/controllers/...
 
@@ -256,7 +260,7 @@ add-copyright:
 .windows-test-unit: .coverage
 	@echo
 	@echo "==> Running unit tests <=="
-	$(GO) test -race -coverpkg=antrea.io/antrea/cmd/...,antrea.io/antrea/pkg/... \
+	CGO_ENABLED=1 $(GO) test -race -coverpkg=antrea.io/antrea/cmd/...,antrea.io/antrea/pkg/... \
 	  -coverprofile=.coverage/coverage-unit.txt -covermode=atomic \
 	  antrea.io/antrea/cmd/... antrea.io/antrea/pkg/...
 

--- a/build/images/Dockerfile.build.coverage
+++ b/build/images/Dockerfile.build.coverage
@@ -25,11 +25,7 @@ RUN go mod download
 COPY . /antrea
 
 RUN make antrea-agent antrea-controller antrea-cni antrea-controller-instr-binary antrea-agent-instr-binary
-# The e2e tests for antctl currently copy the antctl binary from the Docker container
-# to the host Node, and run the binary from the host. The host may be missing some
-# system libraries that are required to run the binary, so we need to disable CGO
-# to avoid such dependencies and ensure that the binary is portable.
-RUN CGO_ENABLED=0 make antctl-linux antctl-instr-binary
+RUN make antctl-linux antctl-instr-binary
 RUN mv bin/antctl-linux bin/antctl
 
 FROM antrea/base-ubuntu:${BUILD_TAG}

--- a/build/images/Dockerfile.build.ubi
+++ b/build/images/Dockerfile.build.ubi
@@ -25,10 +25,7 @@ RUN go mod download
 COPY . /antrea
 
 RUN make antrea-agent antrea-controller antrea-cni
-# Disable CGO for antctl in case it is copied outside of the container image,
-# such as in e2e tests. It also reduces the size of the binary and aligns with
-# how we distribute antctl in release assets.
-RUN CGO_ENABLED=0 make antctl-linux
+RUN make antctl-linux
 RUN mv bin/antctl-linux bin/antctl
 
 FROM antrea/base-ubi:${BUILD_TAG}

--- a/build/images/Dockerfile.build.ubuntu
+++ b/build/images/Dockerfile.build.ubuntu
@@ -25,10 +25,7 @@ RUN go mod download
 COPY . /antrea
 
 RUN make antrea-agent antrea-controller antrea-cni
-# Disable CGO for antctl in case it is copied outside of the container image,
-# such as in e2e tests. It also reduces the size of the binary and aligns with
-# how we distribute antctl in release assets.
-RUN CGO_ENABLED=0 make antctl-linux
+RUN make antctl-linux
 RUN mv bin/antctl-linux bin/antctl
 
 FROM antrea/base-ubuntu:${BUILD_TAG}

--- a/hack/release/prepare-assets.sh
+++ b/hack/release/prepare-assets.sh
@@ -49,6 +49,9 @@ pushd $THIS_DIR/../.. > /dev/null
 mkdir -p "$1"
 OUTPUT_DIR=$(cd "$1" && pwd)
 
+# Cgo should always be disabled for release assets.
+export CGO_ENABLED=0
+
 ANTREA_BUILDS=(
     "linux amd64 linux-x86_64"
     "linux arm64 linux-arm64"
@@ -63,8 +66,6 @@ for build in "${ANTREA_BUILDS[@]}"; do
     arch="${args[1]}"
     suffix="${args[2]}"
 
-    # all "*-release" targets disable cgo, which is appropriate when
-    # distributing release assets, for portability.
     GOOS=$os GOARCH=$arch ANTCTL_BINARY_NAME="antctl-$suffix" BINDIR="$OUTPUT_DIR" make antctl-release
 done
 


### PR DESCRIPTION
Cherry pick of #5988 on release-1.13.

#5988: Disable cgo for all Antrea binaries (#5988)

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.