### PR TITLE
[Multicluster] Fix cache options for controller Manager

### DIFF
--- a/multicluster/cmd/multicluster-controller/clusterset_webhook.go
+++ b/multicluster/cmd/multicluster-controller/clusterset_webhook.go
@@ -97,8 +97,3 @@ func (v *clusterSetValidator) Handle(ctx context.Context, req admission.Request)
 	}
 	return admission.Allowed("")
 }
-
-func (v *clusterSetValidator) InjectDecoder(d *admission.Decoder) error {
-	v.decoder = d
-	return nil
-}

--- a/multicluster/cmd/multicluster-controller/clusterset_webhook_test.go
+++ b/multicluster/cmd/multicluster-controller/clusterset_webhook_test.go
@@ -181,7 +181,6 @@ func TestWebhookClusterSetEvents(t *testing.T) {
 	}
 
 	decoder := admission.NewDecoder(common.TestScheme)
-
 	for _, tt := range tests {
 		objects := []client.Object{}
 		if tt.existingClusterSet != nil {
@@ -193,10 +192,10 @@ func TestWebhookClusterSetEvents(t *testing.T) {
 		fakeClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithObjects(objects...).Build()
 		clusterSetWebhookUnderTest = &clusterSetValidator{
 			Client:    fakeClient,
+			decoder:   decoder,
 			namespace: "mcs1",
 			role:      tt.role,
 		}
-		clusterSetWebhookUnderTest.InjectDecoder(decoder)
 
 		t.Run(tt.name, func(t *testing.T) {
 			response := clusterSetWebhookUnderTest.Handle(context.Background(), tt.req)

--- a/multicluster/cmd/multicluster-controller/gateway_webhook.go
+++ b/multicluster/cmd/multicluster-controller/gateway_webhook.go
@@ -67,8 +67,3 @@ func (v *gatewayValidator) Handle(ctx context.Context, req admission.Request) ad
 	}
 	return admission.Allowed("")
 }
-
-func (v *gatewayValidator) InjectDecoder(d *admission.Decoder) error {
-	v.decoder = d
-	return nil
-}

--- a/multicluster/cmd/multicluster-controller/gateway_webhook_test.go
+++ b/multicluster/cmd/multicluster-controller/gateway_webhook_test.go
@@ -180,8 +180,9 @@ func TestWebhookGatewayEvents(t *testing.T) {
 		}
 		gatewayWebhookUnderTest = &gatewayValidator{
 			Client:    fakeClient,
-			namespace: "default"}
-		gatewayWebhookUnderTest.InjectDecoder(decoder)
+			decoder:   decoder,
+			namespace: "default",
+		}
 
 		t.Run(tt.name, func(t *testing.T) {
 			response := gatewayWebhookUnderTest.Handle(context.Background(), tt.req)

--- a/multicluster/cmd/multicluster-controller/leader.go
+++ b/multicluster/cmd/multicluster-controller/leader.go
@@ -50,9 +50,7 @@ func newLeaderCommand() *cobra.Command {
 }
 
 func runLeader(o *Options) error {
-	// on the leader we want the reconciler to run for a given Namespace instead of cluster scope
 	podNamespace := env.GetPodNamespace()
-	o.Namespace = podNamespace
 	stopCh := signals.RegisterSignalHandlers()
 
 	mgr, err := setupManagerAndCertControllerFunc(true, o)

--- a/multicluster/cmd/multicluster-controller/memberclusterannounce_webhook.go
+++ b/multicluster/cmd/multicluster-controller/memberclusterannounce_webhook.go
@@ -108,8 +108,3 @@ func (v *memberClusterAnnounceValidator) Handle(ctx context.Context, req admissi
 		return admission.Allowed("")
 	}
 }
-
-func (v *memberClusterAnnounceValidator) InjectDecoder(d *admission.Decoder) error {
-	v.decoder = d
-	return nil
-}

--- a/multicluster/cmd/multicluster-controller/memberclusterannounce_webhook_test.go
+++ b/multicluster/cmd/multicluster-controller/memberclusterannounce_webhook_test.go
@@ -259,8 +259,9 @@ func TestMemberClusterAnnounceWebhook(t *testing.T) {
 		}
 		mcaWebhookUnderTest = &memberClusterAnnounceValidator{
 			Client:    fakeClient,
-			namespace: "mcs1"}
-		mcaWebhookUnderTest.InjectDecoder(decoder)
+			decoder:   decoder,
+			namespace: "mcs1",
+		}
 		t.Run(tt.name, func(t *testing.T) {
 			response := mcaWebhookUnderTest.Handle(context.Background(), tt.req)
 			assert.Equal(t, tt.isAllowed, response.Allowed)

--- a/multicluster/cmd/multicluster-controller/options.go
+++ b/multicluster/cmd/multicluster-controller/options.go
@@ -35,8 +35,8 @@ type Options struct {
 	// The path of configuration file.
 	configFile     string
 	SelfSignedCert bool
-	options        ctrl.Options
-	Namespace      string
+	// options store some base controller Manager options (initialized from the provided config).
+	options ctrl.Options
 	// The Service ClusterIP range used in the member cluster.
 	ServiceCIDR string
 	// PodCIDRs is the Pod IP address CIDRs of the member cluster.
@@ -68,14 +68,12 @@ func newOptions() *Options {
 func (o *Options) complete(args []string) error {
 	var err error
 	o.setDefaults()
-	options := ctrl.Options{Scheme: scheme}
 	ctrlConfig := &mcsv1alpha1.MultiClusterConfig{}
 	if len(o.configFile) > 0 {
 		klog.InfoS("Loading config", "file", o.configFile)
 		if err = o.loadConfigFromFile(ctrlConfig); err != nil {
 			return err
 		}
-		o.options = options
 		if ctrlConfig.ServiceCIDR != "" {
 			if _, _, err := net.ParseCIDR(ctrlConfig.ServiceCIDR); err != nil {
 				return fmt.Errorf("failed to parse serviceCIDR, invalid CIDR string %s", ctrlConfig.ServiceCIDR)

--- a/multicluster/cmd/multicluster-controller/options_test.go
+++ b/multicluster/cmd/multicluster-controller/options_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 func TestComplete(t *testing.T) {
@@ -34,7 +33,6 @@ func TestComplete(t *testing.T) {
 			o: Options{
 				configFile:          "./testdata/antrea-mc-config-with-valid-podcidrs.yml",
 				SelfSignedCert:      false,
-				options:             ctrl.Options{},
 				ServiceCIDR:         "",
 				PodCIDRs:            nil,
 				GatewayIPPrecedence: "",
@@ -47,7 +45,6 @@ func TestComplete(t *testing.T) {
 			o: Options{
 				configFile:          "./testdata/antrea-mc-config-with-empty-podcidrs.yml",
 				SelfSignedCert:      false,
-				options:             ctrl.Options{},
 				ServiceCIDR:         "",
 				PodCIDRs:            nil,
 				GatewayIPPrecedence: "",
@@ -60,7 +57,6 @@ func TestComplete(t *testing.T) {
 			o: Options{
 				configFile:          "./testdata/antrea-mc-config-with-invalid-podcidrs.yml",
 				SelfSignedCert:      false,
-				options:             ctrl.Options{},
 				ServiceCIDR:         "10.100.0.0/16",
 				PodCIDRs:            nil,
 				GatewayIPPrecedence: "",
@@ -73,7 +69,6 @@ func TestComplete(t *testing.T) {
 			o: Options{
 				configFile:          "./testdata/antrea-mc-config-with-invalid-endpointiptype.yml",
 				SelfSignedCert:      false,
-				options:             ctrl.Options{},
 				ServiceCIDR:         "10.100.0.0/16",
 				PodCIDRs:            nil,
 				GatewayIPPrecedence: "",


### PR DESCRIPTION
A few issues were introduced by #5843 because of changes in the sigs.k8s.io/controller-runtime interface.

The biggest issue was that the call to ctrl.NewManager was not using the Options object populated earlier in the setupManagerAndCertController function. Instead it was creating and using a new, incomplete Options object.

Fixes #6149