### PR TITLE
Fall back to lenient decoding when strict decoding config fails

### DIFF
--- a/cmd/antrea-agent/options.go
+++ b/cmd/antrea-agent/options.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/spf13/pflag"
-	"gopkg.in/yaml.v2"
 	"k8s.io/apimachinery/pkg/util/sets"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/featuregate"
@@ -38,6 +37,7 @@ import (
 	"antrea.io/antrea/pkg/util/env"
 	"antrea.io/antrea/pkg/util/flowexport"
 	"antrea.io/antrea/pkg/util/ip"
+	"antrea.io/antrea/pkg/util/yaml"
 )
 
 const (
@@ -172,7 +172,11 @@ func (o *Options) loadConfigFromFile() error {
 		return err
 	}
 
-	return yaml.UnmarshalStrict(data, &o.config)
+	err = yaml.UnmarshalLenient(data, &o.config)
+	if err != nil {
+		return fmt.Errorf("failed to decode config file %s: %w", o.configFile, err)
+	}
+	return nil
 }
 
 func (o *Options) setDefaults() {

--- a/cmd/antrea-controller/options.go
+++ b/cmd/antrea-controller/options.go
@@ -21,13 +21,13 @@ import (
 	"os"
 
 	"github.com/spf13/pflag"
-	"gopkg.in/yaml.v2"
 	"k8s.io/klog/v2"
 	netutils "k8s.io/utils/net"
 
 	"antrea.io/antrea/pkg/apis"
 	controllerconfig "antrea.io/antrea/pkg/config/controller"
 	"antrea.io/antrea/pkg/features"
+	"antrea.io/antrea/pkg/util/yaml"
 )
 
 const (
@@ -164,7 +164,11 @@ func (o *Options) loadConfigFromFile() error {
 		return err
 	}
 
-	return yaml.UnmarshalStrict(data, &o.config)
+	err = yaml.UnmarshalLenient(data, &o.config)
+	if err != nil {
+		return fmt.Errorf("failed to decode config file %s: %w", o.configFile, err)
+	}
+	return nil
 }
 
 func (o *Options) setDefaults() {

--- a/multicluster/cmd/multicluster-controller/options.go
+++ b/multicluster/cmd/multicluster-controller/options.go
@@ -20,7 +20,6 @@ import (
 	"os"
 
 	"github.com/spf13/pflag"
-	"gopkg.in/yaml.v2"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/klog/v2"
@@ -29,6 +28,7 @@ import (
 
 	mcsv1alpha1 "antrea.io/antrea/multicluster/apis/multicluster/v1alpha1"
 	"antrea.io/antrea/multicluster/controllers/multicluster/common"
+	"antrea.io/antrea/pkg/util/yaml"
 )
 
 type Options struct {
@@ -131,7 +131,7 @@ func (o *Options) loadConfigFromFile(multiclusterConfig *mcsv1alpha1.MultiCluste
 		return err
 	}
 	codecs := serializer.NewCodecFactory(scheme)
-	if err := yaml.Unmarshal(data, multiclusterConfig); err != nil {
+	if err := yaml.UnmarshalLenient(data, multiclusterConfig); err != nil {
 		return err
 	}
 	if err = runtime.DecodeInto(codecs.UniversalDecoder(), data, multiclusterConfig); err != nil {

--- a/pkg/flowaggregator/options/options.go
+++ b/pkg/flowaggregator/options/options.go
@@ -19,10 +19,9 @@ import (
 	"net"
 	"time"
 
-	"gopkg.in/yaml.v2"
-
 	flowaggregatorconfig "antrea.io/antrea/pkg/config/flowaggregator"
 	"antrea.io/antrea/pkg/util/flowexport"
+	"antrea.io/antrea/pkg/util/yaml"
 )
 
 type Options struct {
@@ -46,7 +45,7 @@ type Options struct {
 
 func LoadConfig(configBytes []byte) (*Options, error) {
 	var opt Options
-	if err := yaml.UnmarshalStrict(configBytes, &opt.Config); err != nil {
+	if err := yaml.UnmarshalLenient(configBytes, &opt.Config); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal FlowAggregator config from ConfigMap: %v", err)
 	}
 	flowaggregatorconfig.SetConfigDefaults(opt.Config)

--- a/pkg/util/yaml/decode.go
+++ b/pkg/util/yaml/decode.go
@@ -1,0 +1,41 @@
+// Copyright 2024 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package yaml
+
+import (
+	"gopkg.in/yaml.v2"
+	"k8s.io/klog/v2"
+)
+
+// UnmarshalLenient tries strict decoding first, then fall back to lenient decoding, which tolerates unknown fields and
+// duplicate fields. It's typically used to avoid error when the provided data contains new fields that are not yet
+// known to this version of code, which may happen when doing upgrade.
+func UnmarshalLenient(data []byte, v interface{}) error {
+	strictErr := yaml.UnmarshalStrict(data, v)
+	if strictErr != nil {
+		err := yaml.Unmarshal(data, v)
+		if err != nil {
+			// The data is malformed, return the original strict error.
+			return strictErr
+		}
+		// TypeError.Error() breaks the error into multiple lines, reformat it to keep the log on one line.
+		if e, ok := strictErr.(*yaml.TypeError); ok {
+			klog.InfoS("Used lenient decoding as strict decoding failed", "err", e.Errors)
+		} else {
+			klog.InfoS("Used lenient decoding as strict decoding failed", "err", e)
+		}
+	}
+	return nil
+}

--- a/pkg/util/yaml/decode_test.go
+++ b/pkg/util/yaml/decode_test.go
@@ -1,0 +1,121 @@
+// Copyright 2024 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package yaml
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnmarshalLenient(t *testing.T) {
+	type SubConfig struct {
+		SubFoo string `yaml:"subFoo"`
+	}
+	type Config struct {
+		Foo string    `yaml:"foo"`
+		Bar int       `yaml:"bar"`
+		Baz SubConfig `yaml:"baz"`
+	}
+	tests := []struct {
+		name      string
+		data      []byte
+		expectedV *Config
+		wantErr   bool
+	}{
+		{
+			name: "correct data",
+			data: []byte(`
+foo: abc
+bar: 123
+baz:
+  subFoo: xyz
+`),
+			expectedV: &Config{
+				Foo: "abc",
+				Bar: 123,
+				Baz: SubConfig{SubFoo: "xyz"},
+			},
+		},
+		{
+			name: "unmatched type",
+			data: []byte(`
+foo: abc
+bar: abc
+`),
+			wantErr: true,
+		},
+		{
+			name: "malformed data",
+			data: []byte(`
+foo: abc
+ bar: 123
+`),
+			wantErr: true,
+		},
+		{
+			name: "duplicate field",
+			data: []byte(`
+foo: abc
+bar: 123
+foo: abcd
+`),
+			expectedV: &Config{
+				Foo: "abcd",
+				Bar: 123,
+			},
+		},
+		{
+			name: "unknown field",
+			data: []byte(`
+foo: abc
+bar: 123
+newBar: xyz
+`),
+			expectedV: &Config{
+				Foo: "abc",
+				Bar: 123,
+			},
+		},
+		{
+			name: "unknown nested field",
+			data: []byte(`
+foo: abc
+bar: 123
+baz:
+  subFoo: xyz
+  subBar: 123
+`),
+			expectedV: &Config{
+				Foo: "abc",
+				Bar: 123,
+				Baz: SubConfig{SubFoo: "xyz"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotV := &Config{}
+			err := UnmarshalLenient(tt.data, gotV)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedV, gotV)
+		})
+	}
+}


### PR DESCRIPTION
When upgrading Antrea, the config is usually updated first and there may be some new fields added to it. If a yet update agent crashes during the process, it will fail to restart due to the unknown new fields because we do strict decoding only.

The patch adds lenient decoding when strict decoding fails to tolerate unknown fields and duplicate fields. Other errors like malformed data and unmatched type are still fatal.

---

For reference, kube-proxy and kubelet have been doing this since 1.17:
https://github.com/kubernetes/kubernetes/blob/227c2e7c2b2c05a9c8b2885460e28e4da25cf558/cmd/kube-proxy/app/server.go#L491
https://github.com/kubernetes/kubernetes/blob/227c2e7c2b2c05a9c8b2885460e28e4da25cf558/pkg/kubelet/kubeletconfig/util/codec/codec.go#L76