### PR TITLE
Fix build-and-test-ubi not using UBI images

### DIFF
--- a/ci/kind/test-e2e-kind.sh
+++ b/ci/kind/test-e2e-kind.sh
@@ -320,6 +320,10 @@ function run_test {
   coverage_args=""
   flow_visibility_args=""
 
+  if $use_non_default_images; then
+    export AGENT_IMG_NAME=${antrea_agent_image}
+    export CONTROLLER_IMG_NAME=${antrea_controller_image}
+  fi
   if $coverage; then
       $YML_CMD --encap-mode $current_mode $manifest_args | docker exec -i kind-control-plane dd of=/root/antrea-coverage.yml
       $YML_CMD --ipsec $manifest_args | docker exec -i kind-control-plane dd of=/root/antrea-ipsec-coverage.yml


### PR DESCRIPTION
The generated manifest was using the default ubuntu images.