### PR TITLE
Optimize Docker build for Multicluster image

### DIFF
--- a/multicluster/build/images/Dockerfile.build
+++ b/multicluster/build/images/Dockerfile.build
@@ -17,13 +17,16 @@ FROM golang:${GO_VERSION} as antrea-build
 
 WORKDIR /antrea
 
-COPY go.mod /antrea/go.mod
-
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+    --mount=type=bind,source=go.sum,target=go.sum \
+    --mount=type=bind,source=go.mod,target=go.mod \
+    go mod download
 
 COPY . /antrea
 
-RUN cd multicluster && make bin
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+    --mount=type=cache,target=/root/.cache/go-build/ \
+    cd multicluster && make bin
 
 FROM gcr.io/distroless/static:nonroot
 


### PR DESCRIPTION
We use Docker cache mounts to accelerate Docker builds with Go. With cache mounts, we can cache package dependencies and the Go build cache in a persistent fashion (i.e., persists across builds).

This is similar to #5918, which implemented the same change for the "main" Antrea images.

With this change, we go from 5 minutes down to 30 seconds when re-building the antrea/antrea-mc-controller image after a minor change to the source code.