### PR TITLE
Increase timeout to 15m for Multicluster e2e test

### DIFF
--- a/ci/jenkins/test-mc.sh
+++ b/ci/jenkins/test-mc.sh
@@ -444,7 +444,7 @@ function run_multicluster_e2e {
     fi
 
     set -x
-    go test -v antrea.io/antrea/multicluster/test/e2e --logs-export-dir `pwd`/antrea-multicluster-test-logs $options
+    go test -v -timeout=15m antrea.io/antrea/multicluster/test/e2e --logs-export-dir `pwd`/antrea-multicluster-test-logs $options
     if [[ "$?" != "0" ]]; then
         TEST_FAILURE=true
     fi


### PR DESCRIPTION
Multicluster e2e test was killed because the default timeout is not enough sometime, I have seen below errors in old patch releases, so increase it to 15m.

```
*** Test killed with quit: ran too long (11m0s).
```