### PR TITLE
Automated cherry pick of #6163: Increase timeout to 15m for Multicluster e2e test (#6163)

### DIFF
--- a/ci/jenkins/test-mc.sh
+++ b/ci/jenkins/test-mc.sh
@@ -443,7 +443,7 @@ function run_multicluster_e2e {
     fi
 
     set -x
-    go test -v antrea.io/antrea/multicluster/test/e2e --logs-export-dir `pwd`/antrea-multicluster-test-logs $options
+    go test -v -timeout=15m antrea.io/antrea/multicluster/test/e2e --logs-export-dir `pwd`/antrea-multicluster-test-logs $options
     if [[ "$?" != "0" ]]; then
         TEST_FAILURE=true
     fi


### PR DESCRIPTION
Cherry pick of #6163 on release-1.15.

#6163: Increase timeout to 15m for Multicluster e2e test (#6163)

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.