### PR TITLE
Fix test-secondary-network workflow image

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -534,6 +534,8 @@ jobs:
     - name: Load Antrea image
       run: |
         docker load -i antrea-ubuntu.tar
+        docker tag antrea/antrea-agent-ubuntu-coverage:latest antrea/antrea-agent-ubuntu:latest
+        docker tag antrea/antrea-controller-ubuntu-coverage:latest antrea/antrea-controller-ubuntu:latest
     - name: Install Kind
       run: |
         KIND_VERSION=$(head -n1 ./ci/kind/version)

--- a/test/e2e-secondary-network/infra/prepare_cluster.sh
+++ b/test/e2e-secondary-network/infra/prepare_cluster.sh
@@ -78,7 +78,7 @@ function generateAntreaConfig() {
         if [ "$1" == "sriov" ]; then
                 $genManifest --sriov --extra-helm-values "featureGates.SecondaryNetwork=true" > $YAML_ANTREA
         elif [ "$1" == "vlan" ]; then
-                $genManifest --extra-helm-values "featureGates.SecondaryNetwork=true" > $YAML_ANTREAc
+                $genManifest --extra-helm-values "featureGates.SecondaryNetwork=true" > $YAML_ANTREA
         else
               echoerr "Incorrect network option $1. Failed to generate antrea.yml"
               exit 1


### PR DESCRIPTION
1. Fix test-secondary-network workflow image by adding the correct
tag, so that we can use the image we built instead of pulling the one
from the registry.

3. Fix typo in the script.