### PR TITLE
Fix NodeNetworkPolicy e2e test failure

### DIFF
--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -131,6 +131,16 @@ func skipIfEncapModeIsNot(tb testing.TB, data *TestData, encapMode config.Traffi
 	}
 }
 
+func skipIfEncapModeIs(tb testing.TB, data *TestData, encapMode config.TrafficEncapModeType) {
+	currentEncapMode, err := data.GetEncapMode()
+	if err != nil {
+		tb.Fatalf("Failed to get encap mode: %v", err)
+	}
+	if currentEncapMode == encapMode {
+		tb.Skipf("Skipping test for encap mode '%s'", encapMode.String())
+	}
+}
+
 func skipIfHasWindowsNodes(tb testing.TB) {
 	if len(clusterInfo.windowsNodes) != 0 {
 		tb.Skipf("Skipping test as the cluster has Windows Nodes")

--- a/test/e2e/nodenetworkpolicy_test.go
+++ b/test/e2e/nodenetworkpolicy_test.go
@@ -22,6 +22,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"antrea.io/antrea/pkg/agent/config"
 	crdv1beta1 "antrea.io/antrea/pkg/apis/crd/v1beta1"
 	"antrea.io/antrea/pkg/features"
 	. "antrea.io/antrea/test/e2e/utils"
@@ -45,17 +46,17 @@ func initializeAntreaNodeNetworkPolicy(t *testing.T, data *TestData, toHostNetwo
 		}
 	}
 	nodes = make(map[string]string)
-	nodes["x"] = controlPlaneNodeName()
-	nodes["y"] = workerNodeName(1)
+	nodes["x"] = nodeName(0)
+	nodes["y"] = nodeName(1)
+	nodes["z"] = nodeName(0)
 	hostNetworks := make(map[string]bool)
 	hostNetworks["x"] = true
 	if toHostNetworkPod {
 		hostNetworks["y"] = true
 	} else {
 		hostNetworks["y"] = false
-		nodes["z"] = workerNodeName(1)
-		hostNetworks["z"] = false
 	}
+	hostNetworks["z"] = false
 	allPods = []Pod{}
 
 	for _, podName := range podsPerNamespace {
@@ -88,6 +89,7 @@ func TestAntreaNodeNetworkPolicy(t *testing.T) {
 		t.Fatalf("Error when setting up test: %v", err)
 	}
 	defer teardownTest(t, data)
+	skipIfEncapModeIs(t, data, config.TrafficEncapModeNetworkPolicyOnly)
 
 	initializeAntreaNodeNetworkPolicy(t, data, true)
 


### PR DESCRIPTION
In NodeNetworkPolicy e2e tests, we have the following cases:

- Node to Node. We deploy two hostNetwork Pods on different Nodes.
- Node to Pods. We deploy a hostNetwork Pod on a Node and two
  non-hostNetwork Pods on different Nodes.

For the case of Node to Pods, after creating test Pods, a full mesh
probing is run to ensure that all Pods can be reachable from each
other. However, the UDP or SCTP probing from a non-hostNetwork Pod, using
the Node external IP (the IP in the hostNetwork Pod object) as destination
IP, to the hostNetwork Pod within on the same Node will get a failure. The
reason is that due to UDP's connectionless nature, the reply traffic
may use a source IP address determined by routing decisions or outgoing
interfaces, which means that the local Antrea gateway IPs will be chosen
as source IP address, rather than the destination IP address used in
request traffic. As a result, the probing will get a failure because the
source IP address of reply traffic is unexpected.

To resolve the issue, when the target Pod is a hostNetwork Pod, we use the
local Antrea gateway IPs as the destination IP, rather than the hostNetwork
Pod IP (the Node external IP).