### PR TITLE
Automated cherry pick of #6123: Install Multicast related iptables rules only on

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -818,7 +818,9 @@ func run(o *Options) error {
 			validator,
 			networkConfig.TrafficEncapMode.SupportsEncap(),
 			nodeInformer,
-			enableBridgingMode)
+			enableBridgingMode,
+			v4Enabled,
+			v6Enabled)
 		if err := mcastController.Initialize(); err != nil {
 			return err
 		}

--- a/pkg/agent/multicast/mcast_controller_test.go
+++ b/pkg/agent/multicast/mcast_controller_test.go
@@ -92,7 +92,7 @@ func TestAddGroupMemberStatus(t *testing.T) {
 		iface: if1,
 	}
 	mctrl := newMockMulticastController(t, false, false)
-	err := mctrl.initialize(t)
+	err := mctrl.initialize()
 	mctrl.mRouteClient.multicastInterfaceConfigs = []multicastInterfaceConfig{
 		{Name: if1.InterfaceName, IPv4Addr: &net.IPNet{IP: nodeIf1IP, Mask: net.IPv4Mask(255, 255, 255, 0)}},
 	}
@@ -115,7 +115,7 @@ func TestAddGroupMemberStatus(t *testing.T) {
 
 func TestUpdateGroupMemberStatus(t *testing.T) {
 	mctrl := newMockMulticastController(t, false, false)
-	err := mctrl.initialize(t)
+	err := mctrl.initialize()
 	assert.NoError(t, err)
 	mgroup := net.ParseIP("224.96.1.4")
 	event := &mcastGroupEvent{
@@ -181,7 +181,7 @@ func TestUpdateGroupMemberStatus(t *testing.T) {
 
 func TestCheckNodeUpdate(t *testing.T) {
 	mockController := newMockMulticastController(t, false, false)
-	err := mockController.initialize(t)
+	err := mockController.initialize()
 	require.NoError(t, err)
 
 	for _, tc := range []struct {
@@ -349,7 +349,7 @@ func TestGetGroupPods(t *testing.T) {
 	now := time.Now()
 
 	mctrl := newMockMulticastController(t, false, false)
-	err := mctrl.initialize(t)
+	err := mctrl.initialize()
 	require.NoError(t, err)
 	groupMemberStatuses := []*GroupMemberStatus{
 		{
@@ -385,7 +385,7 @@ func TestGetGroupPods(t *testing.T) {
 
 func TestGetPodStats(t *testing.T) {
 	mctrl := newMockMulticastController(t, false, false)
-	err := mctrl.initialize(t)
+	err := mctrl.initialize()
 	require.NoError(t, err)
 
 	iface := if1
@@ -402,7 +402,7 @@ func TestGetPodStats(t *testing.T) {
 
 func TestGetAllPodStats(t *testing.T) {
 	mctrl := newMockMulticastController(t, false, false)
-	err := mctrl.initialize(t)
+	err := mctrl.initialize()
 	require.NoError(t, err)
 
 	for _, tc := range []struct {
@@ -447,7 +447,7 @@ func TestGetAllPodStats(t *testing.T) {
 func TestClearStaleGroupsCreatingLeaveEvent(t *testing.T) {
 	mctrl := newMockMulticastController(t, false, false)
 	workerCount = 1
-	err := mctrl.initialize(t)
+	err := mctrl.initialize()
 	require.NoError(t, err)
 	now := time.Now()
 	staleTime := now.Add(-mctrl.mcastGroupTimeout - time.Second)
@@ -483,7 +483,7 @@ func TestClearStaleGroupsCreatingLeaveEvent(t *testing.T) {
 func TestClearStaleGroups(t *testing.T) {
 	mctrl := newMockMulticastController(t, false, false)
 	workerCount = 1
-	err := mctrl.initialize(t)
+	err := mctrl.initialize()
 	require.NoError(t, err)
 	mctrl.mRouteClient.multicastInterfaceConfigs = []multicastInterfaceConfig{
 		{Name: if1.InterfaceName, IPv4Addr: &net.IPNet{IP: nodeIf1IP, Mask: net.IPv4Mask(255, 255, 255, 0)}},
@@ -734,13 +734,13 @@ func TestProcessPacketIn(t *testing.T) {
 func TestEncapModeInitialize(t *testing.T) {
 	mockController := newMockMulticastController(t, true, false)
 	assert.NotZero(t, mockController.nodeGroupID)
-	err := mockController.initialize(t)
+	err := mockController.initialize()
 	assert.NoError(t, err)
 }
 
 func TestEncapLocalReportAndNotifyRemote(t *testing.T) {
 	mockController := newMockMulticastController(t, true, false)
-	_ = mockController.initialize(t)
+	_ = mockController.initialize()
 	mockController.mRouteClient.multicastInterfaceConfigs = []multicastInterfaceConfig{
 		{Name: if1.InterfaceName, IPv4Addr: &net.IPNet{IP: nodeIf1IP, Mask: net.IPv4Mask(255, 255, 255, 0)}},
 	}
@@ -942,7 +942,7 @@ func TestNodeUpdate(t *testing.T) {
 
 func TestMemberChanged(t *testing.T) {
 	mockController := newMockMulticastController(t, false, false)
-	_ = mockController.initialize(t)
+	_ = mockController.initialize()
 
 	containerA := &interfacestore.ContainerInterfaceConfig{PodNamespace: "nameA", PodName: "podA", ContainerID: "tttt"}
 	containerB := &interfacestore.ContainerInterfaceConfig{PodNamespace: "nameA", PodName: "podB", ContainerID: "mmmm"}
@@ -1085,7 +1085,7 @@ func TestConcurrentEventHandlerAndWorkers(t *testing.T) {
 
 func TestRemoteMemberJoinLeave(t *testing.T) {
 	mockController := newMockMulticastController(t, true, false)
-	_ = mockController.initialize(t)
+	_ = mockController.initialize()
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
@@ -1255,17 +1255,58 @@ func newMockMulticastController(t *testing.T, isEncap bool, enableFlexibleIPAM b
 	clientset = fake.NewSimpleClientset()
 	informerFactory = informers.NewSharedInformerFactory(clientset, 12*time.Hour)
 	nodeInformer := informerFactory.Core().V1().Nodes()
-	mctrl := NewMulticastController(mockOFClient, groupAllocator, nodeConfig, mockIfaceStore, mockMulticastSocket, sets.New[string](), podUpdateSubscriber, time.Second*5, []uint8{1, 2, 3}, mockMulticastValidator, isEncap, nodeInformer, enableFlexibleIPAM)
+	mctrl := NewMulticastController(mockOFClient, groupAllocator, nodeConfig, mockIfaceStore, mockMulticastSocket, sets.New[string](), podUpdateSubscriber, time.Second*5, []uint8{1, 2, 3}, mockMulticastValidator, isEncap, nodeInformer, enableFlexibleIPAM, true, false)
 	return mctrl
 }
 
 func TestFlexibleIPAMModeInitialize(t *testing.T) {
 	mockController := newMockMulticastController(t, false, true)
-	err := mockController.initialize(t)
+	err := mockController.initialize()
 	assert.NoError(t, err)
 }
 
-func (c *Controller) initialize(t *testing.T) error {
+func TestMulticastControllerOnIPv6Cluster(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		ipv4Enabled bool
+		ipv6Enabled bool
+		expErr      string
+	}{
+		{
+			name:        "Fails on IPv6-only cluster",
+			ipv4Enabled: false,
+			ipv6Enabled: true,
+			expErr:      "Multicast is not supported on an IPv6-only cluster",
+		},
+		{
+			name:        "Succeeds on dual-stack cluster",
+			ipv4Enabled: true,
+			ipv6Enabled: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mockController := newMockMulticastController(t, true, false)
+			mockController.ipv4Enabled = tc.ipv4Enabled
+			mockController.ipv6Enabled = tc.ipv6Enabled
+			if tc.expErr == "" {
+				mockController.initMocks()
+			}
+			err := mockController.Initialize()
+			if tc.expErr != "" {
+				assert.EqualError(t, err, tc.expErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func (c *Controller) initialize() error {
+	c.initMocks()
+	return c.Initialize()
+}
+
+func (c *Controller) initMocks() {
 	mockOFClient.EXPECT().InstallMulticastGroup(c.queryGroupId, gomock.Any(), gomock.Any()).Times(1)
 	mockOFClient.EXPECT().InstallMulticastFlows(gomock.Any(), gomock.Any())
 	mockIfaceStore.EXPECT().GetInterfacesByType(interfacestore.InterfaceType(0)).Times(1).Return([]*interfacestore.InterfaceConfig{})
@@ -1278,7 +1319,6 @@ func (c *Controller) initialize(t *testing.T) error {
 	if c.flexibleIPAMEnabled {
 		mockOFClient.EXPECT().InstallMulticastFlexibleIPAMFlows().Times(1)
 	}
-	return c.Initialize()
 }
 
 func createInterface(name string, ofport uint32) *interfacestore.InterfaceConfig {

--- a/pkg/agent/route/route_linux_test.go
+++ b/pkg/agent/route/route_linux_test.go
@@ -402,7 +402,6 @@ COMMIT
 :ANTREA-OUTPUT - [0:0]
 -A ANTREA-PREROUTING -m comment --comment "Antrea: do not track incoming encapsulation packets" -m udp -p udp --dport 6081 -m addrtype --dst-type LOCAL -j NOTRACK
 -A ANTREA-OUTPUT -m comment --comment "Antrea: do not track outgoing encapsulation packets" -m udp -p udp --dport 6081 -m addrtype --src-type LOCAL -j NOTRACK
--A ANTREA-PREROUTING -m comment --comment "Antrea: drop Pod multicast traffic forwarded via underlay network" -m set --match-set CLUSTER-NODE-IP6 src -d 224.0.0.0/4 -j DROP
 COMMIT
 *mangle
 :ANTREA-MANGLE - [0:0]


### PR DESCRIPTION
Cherry pick of #6123 on release-1.15.

#6123: Install Multicast related iptables rules only on

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.