### PR TITLE
Remove deprecated v1alpha1/ExternalEntity

### DIFF
--- a/build/charts/antrea/crds/externalentity.yaml
+++ b/build/charts/antrea/crds/externalentity.yaml
@@ -43,12 +43,6 @@ spec:
                         type: string
                 externalNode:
                   type: string
-    - name: v1alpha1
-      served: false
-      storage: false
-      schema:
-        openAPIV3Schema:
-          type: object
   scope: Namespaced
   names:
     plural: externalentities

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -2384,12 +2384,6 @@ spec:
                         type: string
                 externalNode:
                   type: string
-    - name: v1alpha1
-      served: false
-      storage: false
-      schema:
-        openAPIV3Schema:
-          type: object
   scope: Namespaced
   names:
     plural: externalentities

--- a/build/yamls/antrea-crds.yml
+++ b/build/yamls/antrea-crds.yml
@@ -2373,12 +2373,6 @@ spec:
                         type: string
                 externalNode:
                   type: string
-    - name: v1alpha1
-      served: false
-      storage: false
-      schema:
-        openAPIV3Schema:
-          type: object
   scope: Namespaced
   names:
     plural: externalentities

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -2384,12 +2384,6 @@ spec:
                         type: string
                 externalNode:
                   type: string
-    - name: v1alpha1
-      served: false
-      storage: false
-      schema:
-        openAPIV3Schema:
-          type: object
   scope: Namespaced
   names:
     plural: externalentities

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -2384,12 +2384,6 @@ spec:
                         type: string
                 externalNode:
                   type: string
-    - name: v1alpha1
-      served: false
-      storage: false
-      schema:
-        openAPIV3Schema:
-          type: object
   scope: Namespaced
   names:
     plural: externalentities

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -2384,12 +2384,6 @@ spec:
                         type: string
                 externalNode:
                   type: string
-    - name: v1alpha1
-      served: false
-      storage: false
-      schema:
-        openAPIV3Schema:
-          type: object
   scope: Namespaced
   names:
     plural: externalentities

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -2384,12 +2384,6 @@ spec:
                         type: string
                 externalNode:
                   type: string
-    - name: v1alpha1
-      served: false
-      storage: false
-      schema:
-        openAPIV3Schema:
-          type: object
   scope: Namespaced
   names:
     plural: externalentities

--- a/docs/api.md
+++ b/docs/api.md
@@ -81,3 +81,4 @@ These are the API group versions which are currently available when using Antrea
 | CRD | CRD version | Introduced in | Deprecated in | Removed in |
 |---|---|---|---|---|
 | `ClusterGroup` | v1alpha2 | v1.0.0 | v1.1.0 | v2.0.0 |
+| `ExternalEntity` | v1alpha1 | v0.10.0 | v0.11.0 | v2.0.0 |


### PR DESCRIPTION
v1alpha1/ExternalEntity is not served for a long time, so it can be removed from the CRD definition.