### PR TITLE
Avoid unnecessary DNS queries for FQDN rule of NetworkPolicy

### DIFF
--- a/pkg/agent/controller/networkpolicy/fqdn_test.go
+++ b/pkg/agent/controller/networkpolicy/fqdn_test.go
@@ -62,59 +62,103 @@ func TestAddFQDNRule(t *testing.T) {
 		name                       string
 		existingSelectorToRuleIDs  map[fqdnSelectorItem]sets.Set[string]
 		existingDNSCache           map[string]dnsMeta
-		existingFQDNToSelectorItem map[string]map[fqdnSelectorItem]struct{}
+		existingFQDNToSelectorItem map[string]sets.Set[fqdnSelectorItem]
+		existingFQDNToSelectedPods map[string]sets.Set[int32]
 		ruleID                     string
 		fqdns                      []string
 		podAddrs                   sets.Set[int32]
 		finalSelectorToRuleIDs     map[fqdnSelectorItem]sets.Set[string]
-		finalFQDNToSelectorItem    map[string]map[fqdnSelectorItem]struct{}
+		finalFQDNToSelectorItem    map[string]sets.Set[fqdnSelectorItem]
 		addressAdded               bool
 		addressRemoved             bool
+		enqueuedFQDNs              []string
 	}{
 		{
-			"addNewFQDNSelector",
-			nil,
-			nil,
-			nil,
-			"mockRule1",
-			[]string{"test.antrea.io"},
-			sets.New[int32](1),
-			map[fqdnSelectorItem]sets.Set[string]{
+			name:     "addNewMatchNameSelector",
+			ruleID:   "mockRule1",
+			fqdns:    []string{"test.antrea.io"},
+			podAddrs: sets.New[int32](1),
+			finalSelectorToRuleIDs: map[fqdnSelectorItem]sets.Set[string]{
 				selectorItem1: sets.New[string]("mockRule1"),
 			},
-			map[string]map[fqdnSelectorItem]struct{}{
-				"test.antrea.io": {selectorItem1: struct{}{}},
+			finalFQDNToSelectorItem: map[string]sets.Set[fqdnSelectorItem]{
+				"test.antrea.io": sets.New(selectorItem1),
 			},
-			true,
-			false,
+			addressAdded:   true,
+			addressRemoved: false,
+			enqueuedFQDNs:  []string{"test.antrea.io"},
 		},
 		{
-			"addNewFQDNSelectorMatchExisting",
-			map[fqdnSelectorItem]sets.Set[string]{
+			name: "addSameMatchNameSelector",
+			existingSelectorToRuleIDs: map[fqdnSelectorItem]sets.Set[string]{
 				selectorItem1: sets.New[string]("mockRule1"),
 			},
-			map[string]dnsMeta{
+			existingDNSCache: map[string]dnsMeta{
 				"test.antrea.io": {},
 			},
-			map[string]map[fqdnSelectorItem]struct{}{
-				"test.antrea.io": {
-					selectorItem1: struct{}{},
-				},
+			existingFQDNToSelectorItem: map[string]sets.Set[fqdnSelectorItem]{
+				"test.antrea.io": sets.New(selectorItem1),
 			},
-			"mockRule2",
-			[]string{"*antrea.io"},
-			sets.New[int32](2),
-			map[fqdnSelectorItem]sets.Set[string]{
+			existingFQDNToSelectedPods: map[string]sets.Set[int32]{
+				"test.antrea.io": sets.New[int32](1),
+			},
+			ruleID:   "mockRule1",
+			fqdns:    []string{"test.antrea.io"},
+			podAddrs: sets.New[int32](1),
+			finalSelectorToRuleIDs: map[fqdnSelectorItem]sets.Set[string]{
+				selectorItem1: sets.New[string]("mockRule1"),
+			},
+			finalFQDNToSelectorItem: map[string]sets.Set[fqdnSelectorItem]{
+				"test.antrea.io": sets.New(selectorItem1),
+			},
+			addressAdded:   false,
+			addressRemoved: false,
+		},
+		{
+			name: "addNewMatchNameSelectorMatchingExisting",
+			existingSelectorToRuleIDs: map[fqdnSelectorItem]sets.Set[string]{
+				selectorItem1: sets.New[string]("mockRule1"),
+			},
+			existingDNSCache: map[string]dnsMeta{
+				"test.antrea.io": {},
+			},
+			existingFQDNToSelectorItem: map[string]sets.Set[fqdnSelectorItem]{
+				"test.antrea.io": sets.New(selectorItem1),
+			},
+			ruleID:   "mockRule2",
+			fqdns:    []string{"test.antrea.io"},
+			podAddrs: sets.New[int32](2),
+			finalSelectorToRuleIDs: map[fqdnSelectorItem]sets.Set[string]{
+				selectorItem1: sets.New[string]("mockRule1", "mockRule2"),
+			},
+			finalFQDNToSelectorItem: map[string]sets.Set[fqdnSelectorItem]{
+				"test.antrea.io": sets.New(selectorItem1),
+			},
+			addressAdded:   true,
+			addressRemoved: false,
+		},
+		{
+			name: "addNewMatchRegexSelectorMatchExisting",
+			existingSelectorToRuleIDs: map[fqdnSelectorItem]sets.Set[string]{
+				selectorItem1: sets.New[string]("mockRule1"),
+			},
+			existingDNSCache: map[string]dnsMeta{
+				"test.antrea.io": {},
+			},
+			existingFQDNToSelectorItem: map[string]sets.Set[fqdnSelectorItem]{
+				"test.antrea.io": sets.New(selectorItem1),
+			},
+			ruleID:   "mockRule2",
+			fqdns:    []string{"*antrea.io"},
+			podAddrs: sets.New[int32](2),
+			finalSelectorToRuleIDs: map[fqdnSelectorItem]sets.Set[string]{
 				selectorItem1: sets.New[string]("mockRule1"),
 				selectorItem2: sets.New[string]("mockRule2")},
-			map[string]map[fqdnSelectorItem]struct{}{
-				"test.antrea.io": {
-					selectorItem1: struct{}{},
-					selectorItem2: struct{}{},
-				},
+			finalFQDNToSelectorItem: map[string]sets.Set[fqdnSelectorItem]{
+				"test.antrea.io": sets.New(selectorItem1, selectorItem2),
 			},
-			true,
-			false,
+			addressAdded:   true,
+			addressRemoved: false,
 		},
 	}
 	for _, tt := range tests {
@@ -131,12 +175,22 @@ func TestAddFQDNRule(t *testing.T) {
 				f.selectorItemToRuleIDs = tt.existingSelectorToRuleIDs
 				f.fqdnToSelectorItem = tt.existingFQDNToSelectorItem
 			}
+			if tt.existingFQDNToSelectedPods != nil {
+				f.fqdnRuleToSelectedPods = tt.existingFQDNToSelectedPods
+			}
 			if tt.existingDNSCache != nil {
 				f.dnsEntryCache = tt.existingDNSCache
 			}
 			require.NoError(t, f.addFQDNRule(tt.ruleID, tt.fqdns, tt.podAddrs), "Error when adding FQDN rule")
 			assert.Equal(t, tt.finalSelectorToRuleIDs, f.selectorItemToRuleIDs)
 			assert.Equal(t, tt.finalFQDNToSelectorItem, f.fqdnToSelectorItem)
+			var enqueuedFQDNs []string
+			for f.dnsQueryQueue.Len() > 0 {
+				item, _ := f.dnsQueryQueue.Get()
+				f.dnsQueryQueue.Done(item)
+				enqueuedFQDNs = append(enqueuedFQDNs, item.(string))
+			}
+			assert.ElementsMatch(t, tt.enqueuedFQDNs, enqueuedFQDNs)
 		})
 	}
 }
@@ -164,7 +218,7 @@ func TestDeleteFQDNRule(t *testing.T) {
 		ruleID                  string
 		fqdns                   []string
 		finalSelectorToRuleIDs  map[fqdnSelectorItem]sets.Set[string]
-		finalFQDNToSelectorItem map[string]map[fqdnSelectorItem]struct{}
+		finalFQDNToSelectorItem map[string]sets.Set[fqdnSelectorItem]
 		addressRemoved          bool
 	}{
 		{
@@ -182,7 +236,7 @@ func TestDeleteFQDNRule(t *testing.T) {
 			"mockRule1",
 			[]string{"test.antrea.io"},
 			map[fqdnSelectorItem]sets.Set[string]{},
-			map[string]map[fqdnSelectorItem]struct{}{},
+			map[string]sets.Set[fqdnSelectorItem]{},
 			true,
 		},
 		{
@@ -207,10 +261,8 @@ func TestDeleteFQDNRule(t *testing.T) {
 			map[fqdnSelectorItem]sets.Set[string]{
 				selectorItem1: sets.New[string]("mockRule2"),
 			},
-			map[string]map[fqdnSelectorItem]struct{}{
-				"test.antrea.io": {
-					selectorItem1: struct{}{},
-				},
+			map[string]sets.Set[fqdnSelectorItem]{
+				"test.antrea.io": sets.New(selectorItem1),
 			},
 			true,
 		},
@@ -236,10 +288,8 @@ func TestDeleteFQDNRule(t *testing.T) {
 			map[fqdnSelectorItem]sets.Set[string]{
 				selectorItem2: sets.New[string]("mockRule2"),
 			},
-			map[string]map[fqdnSelectorItem]struct{}{
-				"test.antrea.io": {
-					selectorItem2: struct{}{},
-				},
+			map[string]sets.Set[fqdnSelectorItem]{
+				"test.antrea.io": sets.New(selectorItem2),
 			},
 			true,
 		},
@@ -266,10 +316,8 @@ func TestDeleteFQDNRule(t *testing.T) {
 			map[fqdnSelectorItem]sets.Set[string]{
 				selectorItem3: sets.New[string]("mockRule1"),
 			},
-			map[string]map[fqdnSelectorItem]struct{}{
-				"maps.google.com": {
-					selectorItem3: struct{}{},
-				},
+			map[string]sets.Set[fqdnSelectorItem]{
+				"maps.google.com": sets.New(selectorItem3),
 			},
 			true,
 		},


### PR DESCRIPTION
The agent maintains DNS cache for FQDNs matching any FQDN rule of NetworkPolicy in two ways, one of which is that it periodically queries these FQDNs. However, it turned out that the current implementation made more queries than needed, for several reasons:

1. addFQDNRule() always triggered a DNS query immediately even if the FQDN was already tracked, and the function was called by podReconciler every time the rule was updated. This means if a FQDN's resolution is changed by a proactive query or a packet-in event, the FQDN would always be queried another time immediately.
2. When calculating the expiration time for proactively queried records and the delay for next query, the pre-query timestamp was used as the base. This caused the next query to likely return the same record with a very small TTL, leading to another unnecessary query eventually. Besides, this is inconsistent with the base timestamp used for records received from packet-in events.

The patch makes the following improvements:

1. Do not trigger an immediate query if the FQDN added by addFQDNRule() is already tracked.
2. Do not traverse dnsEntryCache when processing a FQDN matching name in addFQDNSelector().
3. Use post-response timestamp as the base of expiration time consistently.
4. Make logs about DNS query failure concentrated and clear.

---
Before:
```
I0408 16:26:14.259064       1 fqdn.go:696] "Making DNS request" fqdn="s3-1.amazonaws.com" dnsServer="10.96.0.10:53"
E0408 16:26:16.259953       1 fqdn.go:706] "DNS exchange failed" err="read udp 172.18.0.3:55590->10.96.0.10:53: i/o timeout"
E0408 16:26:16.261626       1 fqdn.go:649] "Error syncing FQDN, retrying" err="DNS request failed for at least one of type A or AAAA queries" fqdn="s3-1.amazonaws.com"
I0408 16:26:21.262270       1 fqdn.go:696] "Making DNS request" fqdn="s3-1.amazonaws.com" dnsServer="10.96.0.10:53"
I0408 16:26:21.288231       1 fqdn.go:617] "Received DNS Packet with valid Answer" IPs={...} TTL=5
I0408 16:26:21.288324       1 fqdn.go:496] "Reconciling dirty rule for FQDN address updates" ruleID="80d1db99cf0e001f"
I0408 16:26:21.288454       1 pod_reconciler.go:298] "Reconciling Pod NetworkPolicy rule" rule="80d1db99cf0e001f" policy="AntreaClusterNetworkPolicy:acnp-fqdn-all-foobar"
I0408 16:26:21.288858       1 fqdn.go:696] "Making DNS request" fqdn="s3-1.amazonaws.com" dnsServer="10.96.0.10:53"
I0408 16:26:21.294220       1 fqdn.go:617] "Received DNS Packet with valid Answer" IPs={...} TTL=5
I0408 16:26:26.262911       1 fqdn.go:696] "Making DNS request" fqdn="s3-1.amazonaws.com" dnsServer="10.96.0.10:53"
I0408 16:26:26.264271       1 fqdn.go:617] "Received DNS Packet with valid Answer" IPs={...} TTL=1
I0408 16:26:27.263944       1 fqdn.go:696] "Making DNS request" fqdn="s3-1.amazonaws.com" dnsServer="10.96.0.10:53"
I0408 16:26:27.273226       1 fqdn.go:617] "Received DNS Packet with valid Answer" IPs={...} TTL=5
I0408 16:26:27.273327       1 fqdn.go:496] "Reconciling dirty rule for FQDN address updates" ruleID="80d1db99cf0e001f"
I0408 16:26:27.273448       1 pod_reconciler.go:298] "Reconciling Pod NetworkPolicy rule" rule="80d1db99cf0e001f" policy="AntreaClusterNetworkPolicy:acnp-fqdn-all-foobar"
I0408 16:26:27.273830       1 fqdn.go:696] "Making DNS request" fqdn="s3-1.amazonaws.com" dnsServer="10.96.0.10:53"
I0408 16:26:27.275036       1 fqdn.go:617] "Received DNS Packet with valid Answer" IPs={...} TTL=5
I0408 16:26:32.264899       1 fqdn.go:696] "Making DNS request" fqdn="s3-1.amazonaws.com" dnsServer="10.96.0.10:53"
I0408 16:26:32.269028       1 fqdn.go:617] "Received DNS Packet with valid Answer" IPs={...} TTL=5
```
After:
```
I0408 16:21:02.457593       1 fqdn.go:692] "Making DNS request" fqdn="s3-1.amazonaws.com" dnsServer="10.96.0.10:53"
E0408 16:21:04.458702       1 fqdn.go:650] "Error syncing FQDN, retrying" err="DNS request failed for IPv4: read udp 172.18.0.3:39008->10.96.0.10:53: i/o timeout" fqdn="s3-1.amazonaws.com"
I0408 16:21:09.460192       1 fqdn.go:692] "Making DNS request" fqdn="s3-1.amazonaws.com" dnsServer="10.96.0.10:53"
I0408 16:21:09.477573       1 fqdn.go:618] "Received DNS Packet with valid Answer" IPs={...} TTL=5
I0408 16:21:09.477708       1 fqdn.go:497] "Reconciling dirty rule for FQDN address updates" ruleID="80d1db99cf0e001f"
I0408 16:21:09.477855       1 pod_reconciler.go:298] "Reconciling Pod NetworkPolicy rule" rule="80d1db99cf0e001f" policy="AntreaClusterNetworkPolicy:acnp-fqdn-all-foobar"
I0408 16:21:14.478790       1 fqdn.go:692] "Making DNS request" fqdn="s3-1.amazonaws.com" dnsServer="10.96.0.10:53"
I0408 16:21:14.495826       1 fqdn.go:618] "Received DNS Packet with valid Answer" IPs={...} TTL=5
I0408 16:21:14.495974       1 fqdn.go:497] "Reconciling dirty rule for FQDN address updates" ruleID="80d1db99cf0e001f"
I0408 16:21:14.496073       1 pod_reconciler.go:298] "Reconciling Pod NetworkPolicy rule" rule="80d1db99cf0e001f" policy="AntreaClusterNetworkPolicy:acnp-fqdn-all-foobar"
I0408 16:21:19.497120       1 fqdn.go:692] "Making DNS request" fqdn="s3-1.amazonaws.com" dnsServer="10.96.0.10:53"
I0408 16:21:19.511311       1 fqdn.go:618] "Received DNS Packet with valid Answer" IPs={...} TTL=5
I0408 16:21:19.511426       1 fqdn.go:497] "Reconciling dirty rule for FQDN address updates" ruleID="80d1db99cf0e001f"
I0408 16:21:19.511506       1 pod_reconciler.go:298] "Reconciling Pod NetworkPolicy rule" rule="80d1db99cf0e001f" policy="AntreaClusterNetworkPolicy:acnp-fqdn-all-foobar"
```