### PR TITLE
Use reserved OVS controller ports for default Antrea ports

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -156,7 +156,10 @@ func run(o *Options) error {
 	// Bridging mode will connect the uplink interface to the OVS bridge.
 	connectUplinkToBridge := enableBridgingMode
 	ovsDatapathType := ovsconfig.OVSDatapathType(o.config.OVSDatapathType)
-	ovsBridgeClient := ovsconfig.NewOVSBridge(o.config.OVSBridge, ovsDatapathType, ovsdbConnection)
+	// WithRequiredPortExternalIDs will ensure that whenever we create a port, the required
+	// external ID (interface type) is provided. This is a sanity check to ensure code
+	// correctness.
+	ovsBridgeClient := ovsconfig.NewOVSBridge(o.config.OVSBridge, ovsDatapathType, ovsdbConnection, ovsconfig.WithRequiredPortExternalIDs(interfacestore.AntreaInterfaceTypeKey))
 	ovsCtlClient := ovsctl.NewClient(o.config.OVSBridge)
 	ovsBridgeMgmtAddr := ofconfig.GetMgmtAddress(o.config.OVSRunDir, o.config.OVSBridge)
 	multicastEnabled := features.DefaultFeatureGate.Enabled(features.Multicast) && o.config.Multicast.Enable

--- a/docs/antctl.md
+++ b/docs/antctl.md
@@ -373,11 +373,11 @@ local (coredns) Pod:
 ```bash
 $ antctl trace-packet -S default/web-client -D kube-system/coredns-6955765f44-zcbwj -f udp,udp_dst=53
 result: |
-  Flow: udp,in_port=1,vlan_tci=0x0000,dl_src=aa:bb:cc:dd:ee:ff,dl_dst=aa:bb:cc:dd:ee:ff,nw_src=172.100.2.11,nw_dst=172.100.1.7,nw_tos=0,nw_ecn=0,nw_ttl=64,tp_src=0,tp_dst=53
+  Flow: udp,in_port=32768,vlan_tci=0x0000,dl_src=aa:bb:cc:dd:ee:ff,dl_dst=aa:bb:cc:dd:ee:ff,nw_src=172.100.2.11,nw_dst=172.100.1.7,nw_tos=0,nw_ecn=0,nw_ttl=64,tp_src=0,tp_dst=53
 
   bridge("br-int")
   ----------------
-   0. in_port=1, priority 200, cookie 0x5e000000000000
+   0. in_port=32768, priority 200, cookie 0x5e000000000000
       load:0->NXM_NX_REG0[0..15]
       resubmit(,30)
   30. ip, priority 200, cookie 0x5e000000000000
@@ -387,14 +387,14 @@ result: |
        -> Sets the packet to an untracked state, and clears all the conntrack fields.
 
   Final flow: unchanged
-  Megaflow: recirc_id=0,eth,udp,in_port=1,nw_frag=no,tp_src=0x0/0xfc00
+  Megaflow: recirc_id=0,eth,udp,in_port=32768,nw_frag=no,tp_src=0x0/0xfc00
   Datapath actions: ct(zone=65520),recirc(0x53)
 
   ===============================================================================
   recirc(0x53) - resume conntrack with default ct_state=trk|new (use --ct-next to customize)
   ===============================================================================
 
-  Flow: recirc_id=0x53,ct_state=new|trk,ct_zone=65520,eth,udp,in_port=1,vlan_tci=0x0000,dl_src=aa:bb:cc:dd:ee:ff,dl_dst=aa:bb:cc:dd:ee:ff,nw_src=172.100.2.11,nw_dst=172.100.1.7,nw_tos=0,nw_ecn=0,nw_ttl=64,tp_src=0,tp_dst=53
+  Flow: recirc_id=0x53,ct_state=new|trk,ct_zone=65520,eth,udp,in_port=32768,vlan_tci=0x0000,dl_src=aa:bb:cc:dd:ee:ff,dl_dst=aa:bb:cc:dd:ee:ff,nw_src=172.100.2.11,nw_dst=172.100.1.7,nw_tos=0,nw_ecn=0,nw_ttl=64,tp_src=0,tp_dst=53
 
   bridge("br-int")
   ----------------
@@ -425,15 +425,15 @@ result: |
        -> A clone of the packet is forked to recirculate. The forked pipeline will be resumed at table 110.
        -> Sets the packet to an untracked state, and clears all the conntrack fields.
 
-  Final flow: recirc_id=0x53,eth,udp,reg0=0x10000,reg1=0x5,in_port=1,vlan_tci=0x0000,dl_src=62:39:b4:e8:05:76,dl_dst=52:bd:c6:e0:eb:c1,nw_src=172.100.2.11,nw_dst=172.100.1.7,nw_tos=0,nw_ecn=0,nw_ttl=63,tp_src=0,tp_dst=53
-  Megaflow: recirc_id=0x53,ct_state=+new-est-inv+trk,ct_mark=0,eth,udp,in_port=1,dl_src=aa:bb:cc:dd:ee:ff,dl_dst=aa:bb:cc:dd:ee:ff,nw_src=192.0.0.0/2,nw_dst=172.100.1.7,nw_ttl=64,nw_frag=no,tp_dst=53
+  Final flow: recirc_id=0x53,eth,udp,reg0=0x10000,reg1=0x5,in_port=32768,vlan_tci=0x0000,dl_src=62:39:b4:e8:05:76,dl_dst=52:bd:c6:e0:eb:c1,nw_src=172.100.2.11,nw_dst=172.100.1.7,nw_tos=0,nw_ecn=0,nw_ttl=63,tp_src=0,tp_dst=53
+  Megaflow: recirc_id=0x53,ct_state=+new-est-inv+trk,ct_mark=0,eth,udp,in_port=32768,dl_src=aa:bb:cc:dd:ee:ff,dl_dst=aa:bb:cc:dd:ee:ff,nw_src=192.0.0.0/2,nw_dst=172.100.1.7,nw_ttl=64,nw_frag=no,tp_dst=53
   Datapath actions: set(eth(src=62:39:b4:e8:05:76,dst=52:bd:c6:e0:eb:c1)),set(ipv4(ttl=63)),ct(commit,zone=65520),recirc(0x54)
 
   ===============================================================================
   recirc(0x54) - resume conntrack with default ct_state=trk|new (use --ct-next to customize)
   ===============================================================================
 
-  Flow: recirc_id=0x54,ct_state=new|trk,ct_zone=65520,eth,udp,reg0=0x10000,reg1=0x5,in_port=1,vlan_tci=0x0000,dl_src=62:39:b4:e8:05:76,dl_dst=52:bd:c6:e0:eb:c1,nw_src=172.100.2.11,nw_dst=172.100.1.7,nw_tos=0,nw_ecn=0,nw_ttl=63,tp_src=0,tp_dst=53
+  Flow: recirc_id=0x54,ct_state=new|trk,ct_zone=65520,eth,udp,reg0=0x10000,reg1=0x5,in_port=32768,vlan_tci=0x0000,dl_src=62:39:b4:e8:05:76,dl_dst=52:bd:c6:e0:eb:c1,nw_src=172.100.2.11,nw_dst=172.100.1.7,nw_tos=0,nw_ecn=0,nw_ttl=63,tp_src=0,tp_dst=53
 
   bridge("br-int")
   ----------------
@@ -444,7 +444,7 @@ result: |
        -> output port is 5
 
   Final flow: unchanged
-  Megaflow: recirc_id=0x54,eth,ip,in_port=1,nw_frag=no
+  Megaflow: recirc_id=0x54,eth,ip,in_port=32768,nw_frag=no
   Datapath actions: 3
 ```
 

--- a/docs/design/ovs-pipeline.md
+++ b/docs/design/ovs-pipeline.md
@@ -234,10 +234,10 @@ should be performed for the packet in [L3ForwardingTable].
 If you dump the flows for this table, you may see the following:
 
 ```text
-1. table=0, priority=200,in_port=2 actions=set_field:0x1/0xf->reg0,resubmit(,10)
-2. table=0, priority=200,in_port=1 actions=set_field:0/0xf->reg0,load:0x1->NXM_NX_REG0[19],resubmit(,30)
+1. table=0, priority=200,in_port=32769 actions=set_field:0x1/0xf->reg0,resubmit(,10)
+2. table=0, priority=200,in_port=32768 actions=set_field:0/0xf->reg0,load:0x1->NXM_NX_REG0[19],resubmit(,30)
 3. table=0, priority=190,in_port=4 actions=set_field:0x2/0xf->reg0,resubmit(,10)
-4. table=0, priority=190,in_port=3 actions=set_field:0x2/0xf->reg0,resubmit(,10)
+4. table=0, priority=190,in_port=32770 actions=set_field:0x2/0xf->reg0,resubmit(,10)
 5. table=0, priority=0 actions=drop
 ```
 
@@ -275,12 +275,12 @@ the host to advertise a different MAC address on antrea-gw0.
 If you dump the flows for this table, you may see the following:
 
 ```text
-1. table=10, priority=200,ip,in_port=2 actions=resubmit(,23)
-2. table=10, priority=200,arp,in_port=2,arp_spa=10.10.0.1,arp_sha=3a:dd:79:0f:55:4c actions=resubmit(,20)
+1. table=10, priority=200,ip,in_port=32769 actions=resubmit(,23)
+2. table=10, priority=200,arp,in_port=32769,arp_spa=10.10.0.1,arp_sha=3a:dd:79:0f:55:4c actions=resubmit(,20)
 3. table=10, priority=200,arp,in_port=4,arp_spa=10.10.0.2,arp_sha=ce:99:ca:bd:62:c5 actions=resubmit(,20)
-4. table=10, priority=200,arp,in_port=3,arp_spa=10.10.0.3,arp_sha=3a:41:49:42:98:69 actions=resubmit(,20)
+4. table=10, priority=200,arp,in_port=32770,arp_spa=10.10.0.3,arp_sha=3a:41:49:42:98:69 actions=resubmit(,20)
 5. table=10, priority=200,ip,in_port=4,dl_src=ce:99:ca:bd:62:c5,nw_src=10.10.0.2 actions=resubmit(,23)
-6. table=10, priority=200,ip,in_port=3,dl_src=3a:41:49:42:98:69,nw_src=10.10.0.3 actions=resubmit(,23)
+6. table=10, priority=200,ip,in_port=32770,dl_src=3a:41:49:42:98:69,nw_src=10.10.0.3 actions=resubmit(,23)
 7. table=10, priority=0 actions=drop
 ```
 
@@ -891,10 +891,10 @@ port (tunnel port, gateway port, and local Pod ports), as you can see if you
 dump the flows:
 
 ```text
-1. table=80, priority=200,dl_dst=aa:bb:cc:dd:ee:ff actions=set_field:0x1->reg1,set_field:0x10000/0x10000->reg0,goto_table:105
-2. table=80, priority=200,dl_dst=e2:e5:a4:9b:1c:b1 actions=set_field:0x2->reg1,set_field:0x10000/0x10000->reg0,goto_table:105
+1. table=80, priority=200,dl_dst=aa:bb:cc:dd:ee:ff actions=set_field:0x8000->reg1,set_field:0x10000/0x10000->reg0,goto_table:105
+2. table=80, priority=200,dl_dst=e2:e5:a4:9b:1c:b1 actions=set_field:0x8001->reg1,set_field:0x10000/0x10000->reg0,goto_table:105
 3. table=80, priority=200,dl_dst=12:9e:a6:47:d0:70 actions=set_field:0x3->reg1,set_field:0x10000/0x10000->reg0,goto_table:90
-4. table=80, priority=200,dl_dst=ba:a8:13:ca:ed:cf actions=set_field:0x4->reg1,set_field:0x10000/0x10000->reg0,goto_table:90
+4. table=80, priority=200,dl_dst=ba:a8:13:ca:ed:cf actions=set_field:0x8002->reg1,set_field:0x10000/0x10000->reg0,goto_table:90
 5. table=80, priority=0 actions=goto_table:105
 ```
 
@@ -990,7 +990,7 @@ If you dump the flows for this table, you should see something like this:
 3. table=90, priority=200,ip,nw_src=10.10.1.2 actions=conjunction(3,1/3)
 4. table=90, priority=200,ip,nw_src=10.10.1.3 actions=conjunction(3,1/3)
 5. table=90, priority=200,ip,reg1=0x3 actions=conjunction(3,2/3)
-6. table=90, priority=200,ip,reg1=0x4 actions=conjunction(3,2/3)
+6. table=90, priority=200,ip,reg1=0x8002 actions=conjunction(3,2/3)
 7. table=90, priority=200,tcp,tp_dst=80 actions=conjunction(3,3/3)
 8. table=90, priority=190,conj_id=3,ip actions=load:0x3->NXM_NX_REG6[],ct(commit,table=101,zone=65520,exec(load:0x3->NXM_NX_CT_LABEL[0..31]))
 9. table=90, priority=0 actions=goto_table:100
@@ -1045,7 +1045,7 @@ the flows:
 
 ```text
 1. table=100, priority=200,ip,reg1=0x3 actions=drop
-2. table=100, priority=200,ip,reg1=0x4 actions=drop
+2. table=100, priority=200,ip,reg1=0x8002 actions=drop
 3. table=100, priority=0 actions=goto_table:105
 ```
 
@@ -1149,7 +1149,7 @@ across the different backends for each Service.
 If you dump the flows for this table, you should see something like this:
 
 ```text
-1. table=40, priority=200,ip,nw_dst=10.96.0.0/12 actions=set_field:0x2->reg1,load:0x1->NXM_NX_REG0[16],goto_table:105
+1. table=40, priority=200,ip,nw_dst=10.96.0.0/12 actions=set_field:0x8001->reg1,load:0x1->NXM_NX_REG0[16],goto_table:105
 2. table=40, priority=0 actions=goto_table:45
 ```
 

--- a/pkg/agent/agent_linux_test.go
+++ b/pkg/agent/agent_linux_test.go
@@ -60,17 +60,15 @@ func TestPrepareOVSBridgeForK8sNode(t *testing.T) {
 	}
 	datapathID := "0000" + strings.Replace(macAddr.String(), ":", "", -1)
 	nodeConfig := &config.NodeConfig{
-		UplinkNetConfig: new(config.AdapterNetConfig),
+		UplinkNetConfig: &config.AdapterNetConfig{},
 		NodeIPv4Addr:    nodeIPNet,
 	}
 
 	tests := []struct {
-		name                        string
-		connectUplinkToBridge       bool
-		expectedCalls               func(m *ovsconfigtest.MockOVSBridgeClient)
-		expectedHostInterfaceOFPort uint32
-		expectedUplinkOFPort        uint32
-		expectedErr                 string
+		name                  string
+		connectUplinkToBridge bool
+		expectedCalls         func(m *ovsconfigtest.MockOVSBridgeClient)
+		expectedErr           string
 	}{
 		{
 			name: "connectUplinkToBridge is false, do nothing",
@@ -84,27 +82,23 @@ func TestPrepareOVSBridgeForK8sNode(t *testing.T) {
 			expectedErr: fmt.Sprintf("failed to set datapath_id %s: err=unable to set datapath_id", datapathID),
 		},
 		{
-			name:                  "local port does not exist, allocate it",
+			name:                  "local port does not exist",
 			connectUplinkToBridge: true,
 			expectedCalls: func(m *ovsconfigtest.MockOVSBridgeClient) {
 				m.EXPECT().SetDatapathID(datapathID).Return(nil)
 				m.EXPECT().GetOFPort(ipDevice.Name, false).Return(int32(0), ovsconfig.InvalidArgumentsError("interface not found"))
-				m.EXPECT().AllocateOFPort(config.UplinkOFPort).Return(int32(2), nil)
-				m.EXPECT().AllocateOFPort(config.UplinkOFPort).Return(int32(3), nil)
 			},
-			expectedUplinkOFPort:        2,
-			expectedHostInterfaceOFPort: 3,
 		},
 		{
 			name:                  "uplink interface found",
 			connectUplinkToBridge: true,
 			expectedCalls: func(m *ovsconfigtest.MockOVSBridgeClient) {
 				m.EXPECT().SetDatapathID(datapathID).Return(nil)
-				m.EXPECT().GetOFPort(ipDevice.Name, false).Return(int32(2), nil)
-				m.EXPECT().GetOFPort(ipDevice.Name+"~", false).Return(int32(3), nil)
+				mock.InOrder(
+					m.EXPECT().GetOFPort(ipDevice.Name, false).Return(int32(config.DefaultHostInterfaceOFPort), nil),
+					m.EXPECT().GetOFPort(ipDevice.Name+"~", false).Return(int32(config.DefaultUplinkOFPort), nil),
+				)
 			},
-			expectedHostInterfaceOFPort: 2,
-			expectedUplinkOFPort:        3,
 		},
 	}
 
@@ -129,8 +123,8 @@ func TestPrepareOVSBridgeForK8sNode(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				if tt.connectUplinkToBridge {
-					assert.Equal(t, tt.expectedUplinkOFPort, initializer.nodeConfig.UplinkNetConfig.OFPort)
-					assert.Equal(t, tt.expectedHostInterfaceOFPort, initializer.nodeConfig.HostInterfaceOFPort)
+					assert.EqualValues(t, config.DefaultUplinkOFPort, initializer.nodeConfig.UplinkNetConfig.OFPort)
+					assert.EqualValues(t, config.DefaultHostInterfaceOFPort, initializer.nodeConfig.HostInterfaceOFPort)
 				}
 			}
 		})

--- a/pkg/agent/apiserver/handlers/ovstracing/handler_test.go
+++ b/pkg/agent/apiserver/handlers/ovstracing/handler_test.go
@@ -197,7 +197,7 @@ func TestPodFlows(t *testing.T) {
 		},
 		{
 			test:           "Flow expression",
-			query:          "?flow=in_port=3,tcp,nw_src=192.0.2.2,tcp_dst=22",
+			query:          "?flow=in_port=32770,tcp,nw_src=192.0.2.2,tcp_dst=22",
 			calledTrace:    true,
 			expectedStatus: http.StatusOK,
 		},

--- a/pkg/agent/config/node_config.go
+++ b/pkg/agent/config/node_config.go
@@ -22,15 +22,19 @@ import (
 )
 
 const (
-	// Invalid ofport_request number is in range 1 to 65,279. For ofport_request number not in the range, OVS
-	// ignore the it and automatically assign a port number.
-	// Here we use an invalid port number "0" to request for automatically port allocation.
-	AutoAssignedOFPort = 0
-	DefaultTunOFPort   = 1
-	HostGatewayOFPort  = 2
-	UplinkOFPort       = 3
-	// 0xfffffffe is a reserved port number in OpenFlow protocol, which is dedicated for the Bridge interface.
-	BridgeOFPort = 0xfffffffe
+	// Open vSwitch limits the port numbers that it automatically assigns to the range 1 through
+	// 32,767, inclusive. Controllers therefore have free use of ports 32,768 and up.
+	// When requesting a specific port number with ofport_request, it is better to use one of
+	// these "controller ports", to avoid unexpected ofport changes. The Antrea datapath assumes
+	// that once a port number has been assigned, it will stay the same throughout the lifetime
+	// of the port, but when using ofport_request it is not guaranteed.
+	// See https://github.com/antrea-io/antrea/issues/6192 for more details.
+	// We will request these default port values when initializing the agent, unless the ports
+	// already exist.
+	DefaultTunOFPort = ovsconfig.FirstControllerOFPort + iota
+	DefaultHostGatewayOFPort
+	DefaultUplinkOFPort
+	DefaultHostInterfaceOFPort
 )
 
 const (

--- a/pkg/agent/controller/networkpolicy/fqdn_test.go
+++ b/pkg/agent/controller/networkpolicy/fqdn_test.go
@@ -45,7 +45,7 @@ func newMockFQDNController(t *testing.T, controller *gomock.Controller, dnsServe
 		dirtyRuleHandler,
 		true,
 		false,
-		config.HostGatewayOFPort,
+		config.DefaultHostGatewayOFPort,
 	)
 	require.NoError(t, err)
 	return f, mockOFClient

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
@@ -101,7 +101,7 @@ func newTestController() (*Controller, *fake.Clientset, *mockReconciler) {
 		config.K8sNode,
 		true,
 		false,
-		config.HostGatewayOFPort,
+		config.DefaultHostGatewayOFPort,
 		config.DefaultTunOFPort,
 		&config.NodeConfig{},
 		wait.NewGroup(),

--- a/pkg/agent/multicast/mcast_controller.go
+++ b/pkg/agent/multicast/mcast_controller.go
@@ -460,9 +460,9 @@ func (c *Controller) syncGroup(groupKey string) error {
 	status := obj.(*GroupMemberStatus)
 	memberPorts := make([]uint32, 0, len(status.localMembers)+1)
 	if c.flexibleIPAMEnabled {
-		memberPorts = append(memberPorts, config.UplinkOFPort, c.nodeConfig.HostInterfaceOFPort)
+		memberPorts = append(memberPorts, c.nodeConfig.UplinkNetConfig.OFPort, c.nodeConfig.HostInterfaceOFPort)
 	} else {
-		memberPorts = append(memberPorts, config.HostGatewayOFPort)
+		memberPorts = append(memberPorts, c.nodeConfig.GatewayConfig.OFPort)
 	}
 	for memberInterfaceName := range status.localMembers {
 		obj, found := c.ifaceStore.GetInterfaceByName(memberInterfaceName)

--- a/pkg/agent/multicluster/mc_route_controller.go
+++ b/pkg/agent/multicluster/mc_route_controller.go
@@ -457,7 +457,7 @@ func (c *MCDefaultRouteController) syncMCFlows() error {
 	}
 
 	if activeGW != nil {
-		if err := c.ofClient.InstallMulticlusterClassifierFlows(config.DefaultTunOFPort, activeGW.Name == c.nodeConfig.Name); err != nil {
+		if err := c.ofClient.InstallMulticlusterClassifierFlows(c.nodeConfig.TunnelOFPort, activeGW.Name == c.nodeConfig.Name); err != nil {
 			return err
 		}
 		c.installedActiveGW = activeGW

--- a/pkg/agent/multicluster/mc_route_controller_test.go
+++ b/pkg/agent/multicluster/mc_route_controller_test.go
@@ -197,6 +197,7 @@ func TestMCRouteControllerAsWireGuardGateway(t *testing.T) {
 			PodIPv4CIDR: &net.IPNet{
 				IP: net.ParseIP("10.10.0.0"),
 			},
+			TunnelOFPort: config.DefaultTunOFPort,
 		},
 		networkConfig,
 		agent.WireGuardConfig{},
@@ -223,7 +224,7 @@ func TestMCRouteControllerAsWireGuardGateway(t *testing.T) {
 			&gateway4, metav1.CreateOptions{})
 		c.wireGuardClient.EXPECT().CleanUp().AnyTimes()
 		c.wireGuardClient.EXPECT().Init(net.ParseIP("10.100.0.0"), nil)
-		c.ofClient.EXPECT().InstallMulticlusterClassifierFlows(uint32(1), true).Times(1)
+		c.ofClient.EXPECT().InstallMulticlusterClassifierFlows(uint32(config.DefaultTunOFPort), true).Times(1)
 		c.processNextWorkItem()
 		c.processNextWorkItem()
 
@@ -256,7 +257,10 @@ func TestMCRouteControllerAsWireGuardGateway(t *testing.T) {
 func TestMCRouteControllerAsGateway(t *testing.T) {
 	c := newMCDefaultRouteController(
 		t,
-		&config.NodeConfig{Name: "node-1"},
+		&config.NodeConfig{
+			Name:         "node-1",
+			TunnelOFPort: config.DefaultTunOFPort,
+		},
 		&config.NetworkConfig{},
 		agent.WireGuardConfig{},
 		nil,
@@ -277,7 +281,7 @@ func TestMCRouteControllerAsGateway(t *testing.T) {
 		// Create Gateway1
 		c.mcClient.MulticlusterV1alpha1().Gateways(gateway1.GetNamespace()).Create(context.TODO(),
 			&gateway1, metav1.CreateOptions{})
-		c.ofClient.EXPECT().InstallMulticlusterClassifierFlows(uint32(1), true).Times(1)
+		c.ofClient.EXPECT().InstallMulticlusterClassifierFlows(uint32(config.DefaultTunOFPort), true).Times(1)
 		c.processNextWorkItem()
 
 		// Create two ClusterInfoImports
@@ -335,7 +339,7 @@ func TestMCRouteControllerAsGateway(t *testing.T) {
 		// Create Gateway2 as active Gateway
 		c.mcClient.MulticlusterV1alpha1().Gateways(gateway2.GetNamespace()).Create(context.TODO(),
 			&gateway2, metav1.CreateOptions{})
-		c.ofClient.EXPECT().InstallMulticlusterClassifierFlows(uint32(1), false).Times(1)
+		c.ofClient.EXPECT().InstallMulticlusterClassifierFlows(uint32(config.DefaultTunOFPort), false).Times(1)
 		c.ofClient.EXPECT().InstallMulticlusterNodeFlows(clusterInfoImport1.Name, gomock.Any(), gw2InternalIP, true).Times(1)
 		c.processNextWorkItem()
 	}()
@@ -349,7 +353,10 @@ func TestMCRouteControllerAsGateway(t *testing.T) {
 func TestMCRouteControllerAsRegularNode(t *testing.T) {
 	c := newMCDefaultRouteController(
 		t,
-		&config.NodeConfig{Name: "node-3"},
+		&config.NodeConfig{
+			Name:         "node-3",
+			TunnelOFPort: config.DefaultTunOFPort,
+		},
 		&config.NetworkConfig{},
 		agent.WireGuardConfig{},
 		nil,
@@ -372,7 +379,7 @@ func TestMCRouteControllerAsRegularNode(t *testing.T) {
 		// Create Gateway1
 		c.mcClient.MulticlusterV1alpha1().Gateways(gateway1.GetNamespace()).Create(context.TODO(),
 			&gateway1, metav1.CreateOptions{})
-		c.ofClient.EXPECT().InstallMulticlusterClassifierFlows(uint32(1), false).Times(1)
+		c.ofClient.EXPECT().InstallMulticlusterClassifierFlows(uint32(config.DefaultTunOFPort), false).Times(1)
 		c.processNextWorkItem()
 
 		// Create two ClusterInfoImports
@@ -428,7 +435,7 @@ func TestMCRouteControllerAsRegularNode(t *testing.T) {
 		// Create Gateway2 as the active Gateway
 		c.mcClient.MulticlusterV1alpha1().Gateways(gateway2.GetNamespace()).Create(context.TODO(),
 			&gateway2, metav1.CreateOptions{})
-		c.ofClient.EXPECT().InstallMulticlusterClassifierFlows(uint32(1), false).Times(1)
+		c.ofClient.EXPECT().InstallMulticlusterClassifierFlows(uint32(config.DefaultTunOFPort), false).Times(1)
 		c.ofClient.EXPECT().InstallMulticlusterNodeFlows(clusterInfoImport1.Name, gomock.Any(), peerNodeIP2, true).Times(1)
 		c.processNextWorkItem()
 	}()

--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -978,7 +978,7 @@ func (c *client) generatePipelines() {
 		}
 
 		// TODO: add support for IPv6 protocol
-		c.featureMulticast = newFeatureMulticast(c.cookieAllocator, []binding.Protocol{binding.ProtocolIP}, c.bridge, c.enableAntreaPolicy, c.nodeConfig.GatewayConfig.OFPort, c.networkConfig.TrafficEncapMode.SupportsEncap(), config.DefaultTunOFPort, uplinkPort, c.nodeConfig.HostInterfaceOFPort, c.connectUplinkToBridge)
+		c.featureMulticast = newFeatureMulticast(c.cookieAllocator, []binding.Protocol{binding.ProtocolIP}, c.bridge, c.enableAntreaPolicy, c.nodeConfig.GatewayConfig.OFPort, c.networkConfig.TrafficEncapMode.SupportsEncap(), c.nodeConfig.TunnelOFPort, uplinkPort, c.nodeConfig.HostInterfaceOFPort, c.connectUplinkToBridge)
 		c.activatedFeatures = append(c.activatedFeatures, c.featureMulticast)
 	}
 

--- a/pkg/agent/openflow/multicast.go
+++ b/pkg/agent/openflow/multicast.go
@@ -20,7 +20,6 @@ import (
 
 	"antrea.io/libOpenflow/openflow15"
 
-	"antrea.io/antrea/pkg/agent/config"
 	"antrea.io/antrea/pkg/agent/openflow/cookie"
 	"antrea.io/antrea/pkg/agent/types"
 	binding "antrea.io/antrea/pkg/ovs/openflow"
@@ -48,7 +47,18 @@ func (f *featureMulticast) getFeatureName() string {
 	return "Multicast"
 }
 
-func newFeatureMulticast(cookieAllocator cookie.Allocator, ipProtocols []binding.Protocol, bridge binding.Bridge, anpEnabled bool, gwPort uint32, encapEnabled bool, tunnelPort uint32, uplinkPort uint32, hostOFPort uint32, flexibleIPAMEnabled bool) *featureMulticast {
+func newFeatureMulticast(
+	cookieAllocator cookie.Allocator,
+	ipProtocols []binding.Protocol,
+	bridge binding.Bridge,
+	anpEnabled bool,
+	gwPort uint32,
+	encapEnabled bool,
+	tunnelPort uint32,
+	uplinkPort uint32,
+	hostOFPort uint32,
+	flexibleIPAMEnabled bool,
+) *featureMulticast {
 	return &featureMulticast{
 		cookieAllocator:     cookieAllocator,
 		ipProtocols:         ipProtocols,
@@ -138,14 +148,14 @@ func (f *featureMulticast) multicastOutputFlows() []binding.Flow {
 			Cookie(cookieID).
 			MatchRegMark(FromTunnelRegMark).
 			MatchRegMark(OutputToOFPortRegMark).
-			MatchRegFieldWithValue(TargetOFPortField, config.HostGatewayOFPort).
+			MatchRegFieldWithValue(TargetOFPortField, f.gatewayPort).
 			Action().Drop().
 			Done(),
 			MulticastOutputTable.ofTable.BuildFlow(priorityHigh).
 				Cookie(cookieID).
 				MatchRegMark(FromGatewayRegMark).
 				MatchRegMark(OutputToOFPortRegMark).
-				MatchRegFieldWithValue(TargetOFPortField, config.DefaultTunOFPort).
+				MatchRegFieldWithValue(TargetOFPortField, f.tunnelPort).
 				Action().Drop().
 				Done(),
 		)

--- a/pkg/agent/openflow/multicast_test.go
+++ b/pkg/agent/openflow/multicast_test.go
@@ -36,17 +36,17 @@ func multicastInitFlows(isEncap bool) []string {
 			"cookie=0x1050000000000, table=MulticastEgressPodMetric, priority=210,igmp actions=goto_table:MulticastRouting",
 			"cookie=0x1050000000000, table=MulticastRouting, priority=210,igmp,reg0=0x3/0xf actions=controller(id=32776,reason=no_match,userdata=03,max_len=65535)",
 			"cookie=0x1050000000000, table=MulticastRouting, priority=210,igmp,reg0=0x1/0xf actions=controller(id=32776,reason=no_match,userdata=03,max_len=65535)",
-			"cookie=0x1050000000000, table=MulticastRouting, priority=190,ip actions=output:2",
+			"cookie=0x1050000000000, table=MulticastRouting, priority=190,ip actions=output:32769",
 			"cookie=0x1050000000000, table=MulticastIngressPodMetric, priority=210,igmp actions=goto_table:MulticastOutput",
-			"cookie=0x1050000000000, table=MulticastOutput, priority=210,reg0=0x200001/0x60000f,reg1=0x2 actions=drop",
-			"cookie=0x1050000000000, table=MulticastOutput, priority=210,reg0=0x200002/0x60000f,reg1=0x1 actions=drop",
+			"cookie=0x1050000000000, table=MulticastOutput, priority=210,reg0=0x200001/0x60000f,reg1=0x8001 actions=drop",
+			"cookie=0x1050000000000, table=MulticastOutput, priority=210,reg0=0x200002/0x60000f,reg1=0x8000 actions=drop",
 			"cookie=0x1050000000000, table=MulticastOutput, priority=200,reg0=0x200000/0x600000 actions=output:NXM_NX_REG1[]",
 		}
 	}
 	return []string{
 		"cookie=0x1050000000000, table=MulticastIngressPodMetric, priority=210,igmp actions=goto_table:MulticastOutput",
 		"cookie=0x1050000000000, table=MulticastRouting, priority=210,igmp,reg0=0x3/0xf actions=controller(id=32776,reason=no_match,userdata=03,max_len=65535)",
-		"cookie=0x1050000000000, table=MulticastRouting, priority=190,ip actions=output:2",
+		"cookie=0x1050000000000, table=MulticastRouting, priority=190,ip actions=output:32769",
 		"cookie=0x1050000000000, table=MulticastEgressPodMetric, priority=210,igmp actions=goto_table:MulticastRouting",
 		"cookie=0x1050000000000, table=MulticastEgressRule, priority=64990,igmp,reg0=0x3/0xf actions=goto_table:MulticastRouting",
 		"cookie=0x1050000000000, table=MulticastOutput, priority=200,reg0=0x200000/0x600000 actions=output:NXM_NX_REG1[]",

--- a/pkg/agent/openflow/network_policy_test.go
+++ b/pkg/agent/openflow/network_policy_test.go
@@ -464,7 +464,6 @@ func TestBatchInstallPolicyRuleFlows(t *testing.T) {
 				"cookie=0x1020000000000, table=AntreaPolicyIngressRule, priority=201,reg1=0x2 actions=conjunction(13,2/3)",
 				"cookie=0x1020000000000, table=AntreaPolicyIngressRule, priority=100,reg1=0x3 actions=conjunction(11,2/3)",
 				"cookie=0x1020000000000, table=AntreaPolicyIngressRule, priority=200,ip,nw_src=192.168.1.40 actions=conjunction(12,1/3)",
-
 				"cookie=0x1020000000000, table=AntreaPolicyIngressRule, priority=100,tcp,tp_src=32800 actions=conjunction(14,3/3)",
 				"cookie=0x1020000000000, table=IngressDefaultRule, priority=200,reg1=0x1,tun_id=16777215 actions=drop",
 				"cookie=0x1020000000000, table=IngressDefaultRule, priority=200,reg1=0x2,tun_id=16777215 actions=drop",

--- a/pkg/agent/openflow/pod_connectivity.go
+++ b/pkg/agent/openflow/pod_connectivity.go
@@ -97,7 +97,7 @@ func newFeaturePodConnectivity(
 		}
 	}
 
-	gatewayPort := uint32(config.HostGatewayOFPort)
+	gatewayPort := uint32(config.DefaultHostGatewayOFPort)
 	if nodeConfig.GatewayConfig != nil {
 		gatewayPort = nodeConfig.GatewayConfig.OFPort
 	}

--- a/pkg/agent/openflow/pod_connectivity_test.go
+++ b/pkg/agent/openflow/pod_connectivity_test.go
@@ -33,11 +33,11 @@ func podConnectivityInitFlows(
 	case config.TrafficEncapModeEncap:
 		if !isIPv4 {
 			return []string{
-				"cookie=0x1010000000000, table=Classifier, priority=200,in_port=1 actions=set_field:0x1/0xf->reg0,set_field:0x200/0x200->reg0,goto_table:UnSNAT",
-				"cookie=0x1010000000000, table=Classifier, priority=210,ipv6,in_port=2,ipv6_src=fec0:10:10::1 actions=set_field:0x2/0xf->reg0,goto_table:SpoofGuard",
-				"cookie=0x1010000000000, table=Classifier, priority=200,in_port=2 actions=set_field:0x2/0xf->reg0,set_field:0x8000000/0x8000000->reg4,goto_table:SpoofGuard",
+				"cookie=0x1010000000000, table=Classifier, priority=200,in_port=32768 actions=set_field:0x1/0xf->reg0,set_field:0x200/0x200->reg0,goto_table:UnSNAT",
+				"cookie=0x1010000000000, table=Classifier, priority=210,ipv6,in_port=32769,ipv6_src=fec0:10:10::1 actions=set_field:0x2/0xf->reg0,goto_table:SpoofGuard",
+				"cookie=0x1010000000000, table=Classifier, priority=200,in_port=32769 actions=set_field:0x2/0xf->reg0,set_field:0x8000000/0x8000000->reg4,goto_table:SpoofGuard",
 				"cookie=0x1010000000000, table=SpoofGuard, priority=200,ipv6,ipv6_src=fe80::/10 actions=goto_table:IPv6",
-				"cookie=0x1010000000000, table=SpoofGuard, priority=200,ipv6,in_port=2 actions=goto_table:IPv6",
+				"cookie=0x1010000000000, table=SpoofGuard, priority=200,ipv6,in_port=32769 actions=goto_table:IPv6",
 				"cookie=0x1010000000000, table=IPv6, priority=200,icmp6,icmp_type=135,icmp_code=0 actions=NORMAL",
 				"cookie=0x1010000000000, table=IPv6, priority=200,icmp6,icmp_type=136,icmp_code=0 actions=NORMAL",
 				"cookie=0x1010000000000, table=IPv6, priority=200,ipv6,ipv6_dst=ff00::/8 actions=NORMAL",
@@ -51,18 +51,18 @@ func podConnectivityInitFlows(
 				"cookie=0x1010000000000, table=L3Forwarding, priority=0 actions=set_field:0x20/0xf0->reg0,goto_table:L2ForwardingCalc",
 				"cookie=0x1010000000000, table=L3DecTTL, priority=210,ipv6,reg0=0x2/0xf actions=goto_table:SNATMark",
 				"cookie=0x1010000000000, table=L3DecTTL, priority=200,ipv6 actions=dec_ttl,goto_table:SNATMark",
-				"cookie=0x1010000000000, table=L2ForwardingCalc, priority=200,dl_dst=0a:00:00:00:00:01 actions=set_field:0x2->reg1,set_field:0x200000/0x600000->reg0,goto_table:IngressSecurityClassifier",
-				"cookie=0x1010000000000, table=L2ForwardingCalc, priority=200,dl_dst=aa:bb:cc:dd:ee:ff actions=set_field:0x1->reg1,set_field:0x200000/0x600000->reg0,goto_table:IngressSecurityClassifier",
+				"cookie=0x1010000000000, table=L2ForwardingCalc, priority=200,dl_dst=0a:00:00:00:00:01 actions=set_field:0x8001->reg1,set_field:0x200000/0x600000->reg0,goto_table:IngressSecurityClassifier",
+				"cookie=0x1010000000000, table=L2ForwardingCalc, priority=200,dl_dst=aa:bb:cc:dd:ee:ff actions=set_field:0x8000->reg1,set_field:0x200000/0x600000->reg0,goto_table:IngressSecurityClassifier",
 				"cookie=0x1010000000000, table=IngressSecurityClassifier, priority=210,pkt_mark=0x80000000/0x80000000,ct_state=-rpl+trk,ipv6 actions=goto_table:ConntrackCommit",
 				"cookie=0x1010000000000, table=ConntrackCommit, priority=200,ct_state=+new+trk-snat,ct_mark=0x0/0x10,ipv6 actions=ct(commit,table=Output,zone=65510,exec(move:NXM_NX_REG0[0..3]->NXM_NX_CT_MARK[0..3]))",
 				"cookie=0x1010000000000, table=Output, priority=200,reg0=0x200000/0x600000 actions=output:NXM_NX_REG1[]",
 			}
 		}
 		flows = []string{
-			"cookie=0x1010000000000, table=ARPSpoofGuard, priority=200,arp,in_port=2,arp_spa=10.10.0.1,arp_sha=0a:00:00:00:00:01 actions=goto_table:ARPResponder",
+			"cookie=0x1010000000000, table=ARPSpoofGuard, priority=200,arp,in_port=32769,arp_spa=10.10.0.1,arp_sha=0a:00:00:00:00:01 actions=goto_table:ARPResponder",
 			"cookie=0x1010000000000, table=ARPResponder, priority=190,arp actions=NORMAL",
-			"cookie=0x1010000000000, table=Classifier, priority=210,ip,in_port=2,nw_src=10.10.0.1 actions=set_field:0x2/0xf->reg0,goto_table:SpoofGuard",
-			"cookie=0x1010000000000, table=Classifier, priority=200,in_port=2 actions=set_field:0x2/0xf->reg0,set_field:0x8000000/0x8000000->reg4,goto_table:SpoofGuard",
+			"cookie=0x1010000000000, table=Classifier, priority=210,ip,in_port=32769,nw_src=10.10.0.1 actions=set_field:0x2/0xf->reg0,goto_table:SpoofGuard",
+			"cookie=0x1010000000000, table=Classifier, priority=200,in_port=32769 actions=set_field:0x2/0xf->reg0,set_field:0x8000000/0x8000000->reg4,goto_table:SpoofGuard",
 			"cookie=0x1010000000000, table=ConntrackZone, priority=200,ip actions=ct(table=ConntrackState,zone=65520,nat)",
 			"cookie=0x1010000000000, table=ConntrackState, priority=200,ct_state=+inv+trk,ip actions=drop",
 			"cookie=0x1010000000000, table=ConntrackState, priority=190,ct_state=-new+trk,ct_mark=0x0/0x10,ip actions=goto_table:AntreaPolicyEgressRule",
@@ -78,20 +78,20 @@ func podConnectivityInitFlows(
 		}
 		if trafficEncryptionMode != config.TrafficEncryptionModeWireGuard {
 			flows = append(flows,
-				"cookie=0x1010000000000, table=Classifier, priority=200,in_port=1 actions=set_field:0x1/0xf->reg0,set_field:0x200/0x200->reg0,goto_table:UnSNAT",
+				"cookie=0x1010000000000, table=Classifier, priority=200,in_port=32768 actions=set_field:0x1/0xf->reg0,set_field:0x200/0x200->reg0,goto_table:UnSNAT",
 			)
 		}
 		if !multicastEnabled {
-			flows = append(flows, "cookie=0x1010000000000, table=SpoofGuard, priority=200,ip,in_port=2 actions=goto_table:UnSNAT")
+			flows = append(flows, "cookie=0x1010000000000, table=SpoofGuard, priority=200,ip,in_port=32769 actions=goto_table:UnSNAT")
 		} else {
-			flows = append(flows, "cookie=0x1010000000000, table=SpoofGuard, priority=200,ip,in_port=2 actions=goto_table:PipelineIPClassifier")
+			flows = append(flows, "cookie=0x1010000000000, table=SpoofGuard, priority=200,ip,in_port=32769 actions=goto_table:PipelineIPClassifier")
 		}
 		if runtime.IsWindowsPlatform() {
 			flows = append(flows,
-				"cookie=0x1010000000000, table=ARPSpoofGuard, priority=200,in_port=4 actions=output:4294967294",
-				"cookie=0x1010000000000, table=ARPSpoofGuard, priority=200,in_port=4294967294 actions=output:4",
-				"cookie=0x1010000000000, table=Classifier, priority=200,in_port=4 actions=output:4294967294",
-				"cookie=0x1010000000000, table=Classifier, priority=200,in_port=4294967294 actions=output:4",
+				"cookie=0x1010000000000, table=ARPSpoofGuard, priority=200,in_port=32770 actions=output:4294967294",
+				"cookie=0x1010000000000, table=ARPSpoofGuard, priority=200,in_port=4294967294 actions=output:32770",
+				"cookie=0x1010000000000, table=Classifier, priority=200,in_port=32770 actions=output:4294967294",
+				"cookie=0x1010000000000, table=Classifier, priority=200,in_port=4294967294 actions=output:32770",
 				"cookie=0x1010000000000, table=IngressSecurityClassifier, priority=210,ct_state=-rpl+trk,ip,nw_src=10.10.0.1 actions=goto_table:ConntrackCommit",
 			)
 		} else {
@@ -101,30 +101,30 @@ func podConnectivityInitFlows(
 		}
 		if trafficControlEnabled {
 			flows = append(flows,
-				"cookie=0x1010000000000, table=L2ForwardingCalc, priority=200,dl_dst=0a:00:00:00:00:01 actions=set_field:0x2->reg1,set_field:0x200000/0x600000->reg0,goto_table:TrafficControl",
+				"cookie=0x1010000000000, table=L2ForwardingCalc, priority=200,dl_dst=0a:00:00:00:00:01 actions=set_field:0x8001->reg1,set_field:0x200000/0x600000->reg0,goto_table:TrafficControl",
 				"cookie=0x1010000000000, table=TrafficControl, priority=210,reg0=0x200006/0x60000f actions=goto_table:Output",
 				"cookie=0x1010000000000, table=Output, priority=211,reg0=0x200000/0x600000,reg4=0x400000/0xc00000 actions=output:NXM_NX_REG1[],output:NXM_NX_REG9[]",
 				"cookie=0x1010000000000, table=Output, priority=211,reg0=0x200000/0x600000,reg4=0x800000/0xc00000 actions=output:NXM_NX_REG9[]",
 			)
 			if trafficEncryptionMode != config.TrafficEncryptionModeWireGuard {
-				flows = append(flows, "cookie=0x1010000000000, table=L2ForwardingCalc, priority=200,dl_dst=aa:bb:cc:dd:ee:ff actions=set_field:0x1->reg1,set_field:0x200000/0x600000->reg0,goto_table:TrafficControl")
+				flows = append(flows, "cookie=0x1010000000000, table=L2ForwardingCalc, priority=200,dl_dst=aa:bb:cc:dd:ee:ff actions=set_field:0x8000->reg1,set_field:0x200000/0x600000->reg0,goto_table:TrafficControl")
 			}
 		} else {
-			flows = append(flows, "cookie=0x1010000000000, table=L2ForwardingCalc, priority=200,dl_dst=0a:00:00:00:00:01 actions=set_field:0x2->reg1,set_field:0x200000/0x600000->reg0,goto_table:IngressSecurityClassifier")
+			flows = append(flows, "cookie=0x1010000000000, table=L2ForwardingCalc, priority=200,dl_dst=0a:00:00:00:00:01 actions=set_field:0x8001->reg1,set_field:0x200000/0x600000->reg0,goto_table:IngressSecurityClassifier")
 			if trafficEncryptionMode != config.TrafficEncryptionModeWireGuard {
-				flows = append(flows, "cookie=0x1010000000000, table=L2ForwardingCalc, priority=200,dl_dst=aa:bb:cc:dd:ee:ff actions=set_field:0x1->reg1,set_field:0x200000/0x600000->reg0,goto_table:IngressSecurityClassifier")
+				flows = append(flows, "cookie=0x1010000000000, table=L2ForwardingCalc, priority=200,dl_dst=aa:bb:cc:dd:ee:ff actions=set_field:0x8000->reg1,set_field:0x200000/0x600000->reg0,goto_table:IngressSecurityClassifier")
 			}
 		}
 	case config.TrafficEncapModeNoEncap:
 		if !isIPv4 {
 			return []string{
 				"cookie=0x1010000000000, table=SpoofGuard, priority=200,ipv6,ipv6_src=fe80::/10 actions=goto_table:IPv6",
-				"cookie=0x1010000000000, table=SpoofGuard, priority=200,ipv6,in_port=2 actions=goto_table:IPv6",
+				"cookie=0x1010000000000, table=SpoofGuard, priority=200,ipv6,in_port=32769 actions=goto_table:IPv6",
 				"cookie=0x1010000000000, table=IPv6, priority=200,icmp6,icmp_type=135,icmp_code=0 actions=NORMAL",
 				"cookie=0x1010000000000, table=IPv6, priority=200,icmp6,icmp_type=136,icmp_code=0 actions=NORMAL",
 				"cookie=0x1010000000000, table=IPv6, priority=200,ipv6,ipv6_dst=ff00::/8 actions=NORMAL",
-				"cookie=0x1010000000000, table=Classifier, priority=210,ipv6,in_port=2,ipv6_src=fec0:10:10::1 actions=set_field:0x2/0xf->reg0,goto_table:SpoofGuard",
-				"cookie=0x1010000000000, table=Classifier, priority=200,in_port=2 actions=set_field:0x2/0xf->reg0,set_field:0x8000000/0x8000000->reg4,goto_table:SpoofGuard",
+				"cookie=0x1010000000000, table=Classifier, priority=210,ipv6,in_port=32769,ipv6_src=fec0:10:10::1 actions=set_field:0x2/0xf->reg0,goto_table:SpoofGuard",
+				"cookie=0x1010000000000, table=Classifier, priority=200,in_port=32769 actions=set_field:0x2/0xf->reg0,set_field:0x8000000/0x8000000->reg4,goto_table:SpoofGuard",
 				"cookie=0x1010000000000, table=ConntrackZone, priority=200,ipv6 actions=ct(table=ConntrackState,zone=65510,nat)",
 				"cookie=0x1010000000000, table=ConntrackState, priority=200,ct_state=+inv+trk,ipv6 actions=drop",
 				"cookie=0x1010000000000, table=ConntrackState, priority=190,ct_state=-new+trk,ct_mark=0x0/0x10,ipv6 actions=goto_table:AntreaPolicyEgressRule",
@@ -135,17 +135,17 @@ func podConnectivityInitFlows(
 				"cookie=0x1010000000000, table=L3Forwarding, priority=0 actions=set_field:0x20/0xf0->reg0,goto_table:L2ForwardingCalc",
 				"cookie=0x1010000000000, table=L3DecTTL, priority=210,ipv6,reg0=0x2/0xf actions=goto_table:SNATMark",
 				"cookie=0x1010000000000, table=L3DecTTL, priority=200,ipv6 actions=dec_ttl,goto_table:SNATMark",
-				"cookie=0x1010000000000, table=L2ForwardingCalc, priority=200,dl_dst=0a:00:00:00:00:01 actions=set_field:0x2->reg1,set_field:0x200000/0x600000->reg0,goto_table:IngressSecurityClassifier",
+				"cookie=0x1010000000000, table=L2ForwardingCalc, priority=200,dl_dst=0a:00:00:00:00:01 actions=set_field:0x8001->reg1,set_field:0x200000/0x600000->reg0,goto_table:IngressSecurityClassifier",
 				"cookie=0x1010000000000, table=IngressSecurityClassifier, priority=210,pkt_mark=0x80000000/0x80000000,ct_state=-rpl+trk,ipv6 actions=goto_table:ConntrackCommit",
 				"cookie=0x1010000000000, table=ConntrackCommit, priority=200,ct_state=+new+trk-snat,ct_mark=0x0/0x10,ipv6 actions=ct(commit,table=Output,zone=65510,exec(move:NXM_NX_REG0[0..3]->NXM_NX_CT_MARK[0..3]))",
 				"cookie=0x1010000000000, table=Output, priority=200,reg0=0x200000/0x600000 actions=output:NXM_NX_REG1[]",
 			}
 		}
 		flows = []string{
-			"cookie=0x1010000000000, table=ARPSpoofGuard, priority=200,arp,in_port=2,arp_spa=10.10.0.1,arp_sha=0a:00:00:00:00:01 actions=goto_table:ARPResponder",
+			"cookie=0x1010000000000, table=ARPSpoofGuard, priority=200,arp,in_port=32769,arp_spa=10.10.0.1,arp_sha=0a:00:00:00:00:01 actions=goto_table:ARPResponder",
 			"cookie=0x1010000000000, table=ARPResponder, priority=190,arp actions=NORMAL",
-			"cookie=0x1010000000000, table=Classifier, priority=210,ip,in_port=2,nw_src=10.10.0.1 actions=set_field:0x2/0xf->reg0,goto_table:SpoofGuard",
-			"cookie=0x1010000000000, table=Classifier, priority=200,in_port=2 actions=set_field:0x2/0xf->reg0,set_field:0x8000000/0x8000000->reg4,goto_table:SpoofGuard",
+			"cookie=0x1010000000000, table=Classifier, priority=210,ip,in_port=32769,nw_src=10.10.0.1 actions=set_field:0x2/0xf->reg0,goto_table:SpoofGuard",
+			"cookie=0x1010000000000, table=Classifier, priority=200,in_port=32769 actions=set_field:0x2/0xf->reg0,set_field:0x8000000/0x8000000->reg4,goto_table:SpoofGuard",
 			"cookie=0x1010000000000, table=ConntrackState, priority=200,ct_state=+inv+trk,ip actions=drop",
 			"cookie=0x1010000000000, table=ConntrackState, priority=190,ct_state=-new+trk,ct_mark=0x0/0x10,ip actions=goto_table:AntreaPolicyEgressRule",
 			"cookie=0x1010000000000, table=ConntrackState, priority=0 actions=goto_table:PreRoutingClassifier",
@@ -158,12 +158,12 @@ func podConnectivityInitFlows(
 		}
 		if runtime.IsWindowsPlatform() {
 			flows = append(flows,
-				"cookie=0x1010000000000, table=ARPSpoofGuard, priority=200,in_port=4 actions=output:4294967294",
-				"cookie=0x1010000000000, table=ARPSpoofGuard, priority=200,in_port=4294967294 actions=output:4",
-				"cookie=0x1010000000000, table=Classifier, priority=210,ip,in_port=4,nw_dst=10.10.0.0/24 actions=set_field:0x4/0xf->reg0,set_field:0x200/0x200->reg0,goto_table:UnSNAT",
-				"cookie=0x1010000000000, table=Classifier, priority=200,in_port=4 actions=output:4294967294",
-				"cookie=0x1010000000000, table=Classifier, priority=200,in_port=4294967294 actions=output:4",
-				"cookie=0x1010000000000, table=SpoofGuard, priority=200,ip,in_port=2 actions=goto_table:UnSNAT",
+				"cookie=0x1010000000000, table=ARPSpoofGuard, priority=200,in_port=32770 actions=output:4294967294",
+				"cookie=0x1010000000000, table=ARPSpoofGuard, priority=200,in_port=4294967294 actions=output:32770",
+				"cookie=0x1010000000000, table=Classifier, priority=210,ip,in_port=32770,nw_dst=10.10.0.0/24 actions=set_field:0x4/0xf->reg0,set_field:0x200/0x200->reg0,goto_table:UnSNAT",
+				"cookie=0x1010000000000, table=Classifier, priority=200,in_port=32770 actions=output:4294967294",
+				"cookie=0x1010000000000, table=Classifier, priority=200,in_port=4294967294 actions=output:32770",
+				"cookie=0x1010000000000, table=SpoofGuard, priority=200,ip,in_port=32769 actions=goto_table:UnSNAT",
 				"cookie=0x1010000000000, table=ConntrackZone, priority=200,ip actions=ct(table=ConntrackState,zone=65520,nat)",
 				"cookie=0x1010000000000, table=L3Forwarding, priority=200,ip,reg0=0x0/0x200,nw_dst=10.10.0.0/24 actions=goto_table:L2ForwardingCalc",
 				"cookie=0x1010000000000, table=IngressSecurityClassifier, priority=210,ct_state=-rpl+trk,ip,nw_src=10.10.0.1 actions=goto_table:ConntrackCommit",
@@ -175,27 +175,27 @@ func podConnectivityInitFlows(
 			)
 			if connectUplinkToBridge {
 				flows = append(flows,
-					"cookie=0x1010000000000, table=ARPSpoofGuard, priority=210,arp,in_port=4 actions=NORMAL",
+					"cookie=0x1010000000000, table=ARPSpoofGuard, priority=210,arp,in_port=32770 actions=NORMAL",
 					"cookie=0x1010000000000, table=ARPSpoofGuard, priority=210,arp,in_port=4294967294 actions=NORMAL",
 					"cookie=0x1010000000000, table=ARPResponder, priority=200,arp,arp_tpa=10.10.0.1,arp_op=1 actions=move:NXM_OF_ETH_SRC[]->NXM_OF_ETH_DST[],set_field:0a:00:00:00:00:01->eth_src,set_field:2->arp_op,move:NXM_NX_ARP_SHA[]->NXM_NX_ARP_THA[],set_field:0a:00:00:00:00:01->arp_sha,move:NXM_OF_ARP_SPA[]->NXM_OF_ARP_TPA[],set_field:10.10.0.1->arp_spa,IN_PORT",
-					"cookie=0x1010000000000, table=Classifier, priority=200,in_port=4 actions=output:4294967294",
-					"cookie=0x1010000000000, table=Classifier, priority=200,in_port=4294967294 actions=output:4",
+					"cookie=0x1010000000000, table=Classifier, priority=200,in_port=32770 actions=output:4294967294",
+					"cookie=0x1010000000000, table=Classifier, priority=200,in_port=4294967294 actions=output:32770",
 					"cookie=0x1010000000000, table=ConntrackZone, priority=200,ip actions=ct(table=ConntrackState,zone=NXM_NX_REG8[0..15],nat)",
 					"cookie=0x1010000000000, table=L3Forwarding, priority=210,ct_state=+rpl+trk,ct_mark=0x5/0xf,ip,reg8=0x0/0xfff actions=set_field:0a:00:00:00:00:02->eth_dst,goto_table:L2ForwardingCalc",
 					"cookie=0x1010000000000, table=L3Forwarding, priority=210,ip,reg4=0x100000/0x100000,reg8=0x0/0xfff,nw_dst=192.168.77.100 actions=set_field:0a:00:00:00:00:02->eth_dst,goto_table:L2ForwardingCalc",
 					"cookie=0x1010000000000, table=L3Forwarding, priority=200,ip,reg0=0x0/0x200,reg8=0x0/0xfff,nw_dst=10.10.0.0/24 actions=goto_table:L2ForwardingCalc", "cookie=0x1010000000000, table=L2ForwardingCalc, priority=200,dl_dst=0a:00:00:00:00:02 actions=set_field:0xfffffffe->reg1,set_field:0x200000/0x600000->reg0,goto_table:ConntrackCommit",
-					"cookie=0x1010000000000, table=L2ForwardingCalc, priority=190,reg4=0x100000/0x100000 actions=set_field:0x4->reg1,set_field:0x200000/0x600000->reg0,goto_table:ConntrackCommit",
+					"cookie=0x1010000000000, table=L2ForwardingCalc, priority=190,reg4=0x100000/0x100000 actions=set_field:0x8002->reg1,set_field:0x200000/0x600000->reg0,goto_table:ConntrackCommit",
 					"cookie=0x1010000000000, table=ConntrackCommit, priority=200,ct_state=+new+trk-snat,ct_mark=0x0/0x10,ip actions=ct(commit,table=VLAN,zone=NXM_NX_REG8[0..15],exec(move:NXM_NX_REG0[0..3]->NXM_NX_CT_MARK[0..3]))",
-					"cookie=0x1010000000000, table=VLAN, priority=190,in_port=4,vlan_tci=0x1000/0x1000 actions=pop_vlan,goto_table:Output",
+					"cookie=0x1010000000000, table=VLAN, priority=190,in_port=32770,vlan_tci=0x1000/0x1000 actions=pop_vlan,goto_table:Output",
 					"cookie=0x1010000000000, table=Output, priority=210,ip,reg0=0x200000/0x600000,reg1=0xfffffffe actions=output:4294967294",
 				)
 				if !multicastEnabled {
 					flows = append(flows,
-						"cookie=0x1010000000000, table=SpoofGuard, priority=200,ip,in_port=2 actions=set_field:0x1000/0xf000->reg8,goto_table:UnSNAT",
+						"cookie=0x1010000000000, table=SpoofGuard, priority=200,ip,in_port=32769 actions=set_field:0x1000/0xf000->reg8,goto_table:UnSNAT",
 					)
 				} else {
 					flows = append(flows,
-						"cookie=0x1010000000000, table=SpoofGuard, priority=200,ip,in_port=2 actions=set_field:0x1000/0xf000->reg8,goto_table:PipelineIPClassifier",
+						"cookie=0x1010000000000, table=SpoofGuard, priority=200,ip,in_port=32769 actions=set_field:0x1000/0xf000->reg8,goto_table:PipelineIPClassifier",
 					)
 				}
 			} else {
@@ -206,37 +206,37 @@ func podConnectivityInitFlows(
 				)
 				if !multicastEnabled {
 					flows = append(flows,
-						"cookie=0x1010000000000, table=SpoofGuard, priority=200,ip,in_port=2 actions=goto_table:UnSNAT",
+						"cookie=0x1010000000000, table=SpoofGuard, priority=200,ip,in_port=32769 actions=goto_table:UnSNAT",
 					)
 				} else {
 					flows = append(flows,
-						"cookie=0x1010000000000, table=SpoofGuard, priority=200,ip,in_port=2 actions=goto_table:PipelineIPClassifier",
+						"cookie=0x1010000000000, table=SpoofGuard, priority=200,ip,in_port=32769 actions=goto_table:PipelineIPClassifier",
 					)
 				}
 			}
 		}
 		if trafficControlEnabled {
 			flows = append(flows,
-				"cookie=0x1010000000000, table=L2ForwardingCalc, priority=200,dl_dst=0a:00:00:00:00:01 actions=set_field:0x2->reg1,set_field:0x200000/0x600000->reg0,goto_table:TrafficControl",
+				"cookie=0x1010000000000, table=L2ForwardingCalc, priority=200,dl_dst=0a:00:00:00:00:01 actions=set_field:0x8001->reg1,set_field:0x200000/0x600000->reg0,goto_table:TrafficControl",
 				"cookie=0x1010000000000, table=TrafficControl, priority=210,reg0=0x200006/0x60000f actions=goto_table:Output",
 				"cookie=0x1010000000000, table=Output, priority=211,reg0=0x200000/0x600000,reg4=0x400000/0xc00000 actions=output:NXM_NX_REG1[],output:NXM_NX_REG9[]",
 				"cookie=0x1010000000000, table=Output, priority=211,reg0=0x200000/0x600000,reg4=0x800000/0xc00000 actions=output:NXM_NX_REG9[]",
 			)
 		} else {
 			flows = append(flows,
-				"cookie=0x1010000000000, table=L2ForwardingCalc, priority=200,dl_dst=0a:00:00:00:00:01 actions=set_field:0x2->reg1,set_field:0x200000/0x600000->reg0,goto_table:IngressSecurityClassifier",
+				"cookie=0x1010000000000, table=L2ForwardingCalc, priority=200,dl_dst=0a:00:00:00:00:01 actions=set_field:0x8001->reg1,set_field:0x200000/0x600000->reg0,goto_table:IngressSecurityClassifier",
 			)
 		}
 	case config.TrafficEncapModeNetworkPolicyOnly:
 		if !isIPv4 {
 			return []string{
 				"cookie=0x1010000000000, table=SpoofGuard, priority=200,ipv6,ipv6_src=fe80::/10 actions=goto_table:IPv6",
-				"cookie=0x1010000000000, table=SpoofGuard, priority=200,ipv6,in_port=2 actions=goto_table:IPv6",
+				"cookie=0x1010000000000, table=SpoofGuard, priority=200,ipv6,in_port=32769 actions=goto_table:IPv6",
 				"cookie=0x1010000000000, table=IPv6, priority=200,icmp6,icmp_type=135,icmp_code=0 actions=NORMAL",
 				"cookie=0x1010000000000, table=IPv6, priority=200,icmp6,icmp_type=136,icmp_code=0 actions=NORMAL",
 				"cookie=0x1010000000000, table=IPv6, priority=200,ipv6,ipv6_dst=ff00::/8 actions=NORMAL",
-				"cookie=0x1010000000000, table=Classifier, priority=210,ipv6,in_port=2,ipv6_src=fec0:10:10::1 actions=set_field:0x2/0xf->reg0,goto_table:SpoofGuard",
-				"cookie=0x1010000000000, table=Classifier, priority=200,in_port=2 actions=set_field:0x2/0xf->reg0,set_field:0x8000000/0x8000000->reg4,goto_table:SpoofGuard",
+				"cookie=0x1010000000000, table=Classifier, priority=210,ipv6,in_port=32769,ipv6_src=fec0:10:10::1 actions=set_field:0x2/0xf->reg0,goto_table:SpoofGuard",
+				"cookie=0x1010000000000, table=Classifier, priority=200,in_port=32769 actions=set_field:0x2/0xf->reg0,set_field:0x8000000/0x8000000->reg4,goto_table:SpoofGuard",
 				"cookie=0x1010000000000, table=ConntrackZone, priority=200,ipv6 actions=ct(table=ConntrackState,zone=65510,nat)",
 				"cookie=0x1010000000000, table=ConntrackState, priority=200,ct_state=+inv+trk,ipv6 actions=drop",
 				"cookie=0x1010000000000, table=ConntrackState, priority=190,ct_state=-new+trk,ct_mark=0x0/0x10,ipv6 actions=goto_table:AntreaPolicyEgressRule",
@@ -247,19 +247,19 @@ func podConnectivityInitFlows(
 				"cookie=0x1010000000000, table=L3Forwarding, priority=0 actions=set_field:0x20/0xf0->reg0,goto_table:L2ForwardingCalc",
 				"cookie=0x1010000000000, table=L3DecTTL, priority=210,ipv6,reg0=0x2/0xf actions=goto_table:SNATMark",
 				"cookie=0x1010000000000, table=L3DecTTL, priority=200,ipv6 actions=dec_ttl,goto_table:SNATMark",
-				"cookie=0x1010000000000, table=L2ForwardingCalc, priority=200,dl_dst=0a:00:00:00:00:01 actions=set_field:0x2->reg1,set_field:0x200000/0x600000->reg0,goto_table:IngressSecurityClassifier",
+				"cookie=0x1010000000000, table=L2ForwardingCalc, priority=200,dl_dst=0a:00:00:00:00:01 actions=set_field:0x8001->reg1,set_field:0x200000/0x600000->reg0,goto_table:IngressSecurityClassifier",
 				"cookie=0x1010000000000, table=IngressSecurityClassifier, priority=210,pkt_mark=0x80000000/0x80000000,ct_state=-rpl+trk,ipv6 actions=goto_table:ConntrackCommit",
 				"cookie=0x1010000000000, table=ConntrackCommit, priority=200,ct_state=+new+trk-snat,ct_mark=0x0/0x10,ipv6 actions=ct(commit,table=Output,zone=65510,exec(move:NXM_NX_REG0[0..3]->NXM_NX_CT_MARK[0..3]))",
 				"cookie=0x1010000000000, table=Output, priority=200,reg0=0x200000/0x600000 actions=output:NXM_NX_REG1[]",
 			}
 		}
 		return []string{
-			"cookie=0x1010000000000, table=ARPSpoofGuard, priority=200,arp,in_port=2,arp_spa=10.10.0.1,arp_sha=0a:00:00:00:00:01 actions=goto_table:ARPResponder",
+			"cookie=0x1010000000000, table=ARPSpoofGuard, priority=200,arp,in_port=32769,arp_spa=10.10.0.1,arp_sha=0a:00:00:00:00:01 actions=goto_table:ARPResponder",
 			"cookie=0x1010000000000, table=ARPResponder, priority=200,arp,arp_op=1 actions=move:NXM_OF_ETH_SRC[]->NXM_OF_ETH_DST[],set_field:aa:bb:cc:dd:ee:ff->eth_src,set_field:2->arp_op,move:NXM_NX_ARP_SHA[]->NXM_NX_ARP_THA[],set_field:aa:bb:cc:dd:ee:ff->arp_sha,move:NXM_OF_ARP_TPA[]->NXM_NX_REG2[],move:NXM_OF_ARP_SPA[]->NXM_OF_ARP_TPA[],move:NXM_NX_REG2[]->NXM_OF_ARP_SPA[],IN_PORT",
 			"cookie=0x1010000000000, table=ARPResponder, priority=190,arp actions=NORMAL",
-			"cookie=0x1010000000000, table=Classifier, priority=210,ip,in_port=2,nw_src=10.10.0.1 actions=set_field:0x2/0xf->reg0,goto_table:SpoofGuard",
-			"cookie=0x1010000000000, table=Classifier, priority=200,in_port=2 actions=set_field:0x2/0xf->reg0,set_field:0x8000000/0x8000000->reg4,goto_table:SpoofGuard",
-			"cookie=0x1010000000000, table=SpoofGuard, priority=200,ip,in_port=2 actions=goto_table:UnSNAT",
+			"cookie=0x1010000000000, table=Classifier, priority=210,ip,in_port=32769,nw_src=10.10.0.1 actions=set_field:0x2/0xf->reg0,goto_table:SpoofGuard",
+			"cookie=0x1010000000000, table=Classifier, priority=200,in_port=32769 actions=set_field:0x2/0xf->reg0,set_field:0x8000000/0x8000000->reg4,goto_table:SpoofGuard",
+			"cookie=0x1010000000000, table=SpoofGuard, priority=200,ip,in_port=32769 actions=goto_table:UnSNAT",
 			"cookie=0x1010000000000, table=ConntrackZone, priority=200,ip actions=ct(table=ConntrackState,zone=65520,nat)",
 			"cookie=0x1010000000000, table=ConntrackState, priority=200,ct_state=+inv+trk,ip actions=drop",
 			"cookie=0x1010000000000, table=ConntrackState, priority=190,ct_state=-new+trk,ct_mark=0x0/0x10,ip actions=goto_table:AntreaPolicyEgressRule",
@@ -269,7 +269,7 @@ func podConnectivityInitFlows(
 			"cookie=0x1010000000000, table=L3Forwarding, priority=0 actions=set_field:0x20/0xf0->reg0,goto_table:L2ForwardingCalc",
 			"cookie=0x1010000000000, table=L3DecTTL, priority=210,ip,reg0=0x2/0xf actions=goto_table:SNATMark",
 			"cookie=0x1010000000000, table=L3DecTTL, priority=200,ip actions=dec_ttl,goto_table:SNATMark",
-			"cookie=0x1010000000000, table=L2ForwardingCalc, priority=200,dl_dst=0a:00:00:00:00:01 actions=set_field:0x2->reg1,set_field:0x200000/0x600000->reg0,goto_table:IngressSecurityClassifier",
+			"cookie=0x1010000000000, table=L2ForwardingCalc, priority=200,dl_dst=0a:00:00:00:00:01 actions=set_field:0x8001->reg1,set_field:0x200000/0x600000->reg0,goto_table:IngressSecurityClassifier",
 			"cookie=0x1010000000000, table=IngressSecurityClassifier, priority=210,pkt_mark=0x80000000/0x80000000,ct_state=-rpl+trk,ip actions=goto_table:ConntrackCommit",
 			"cookie=0x1010000000000, table=ConntrackCommit, priority=200,ct_state=+new+trk-snat,ct_mark=0x0/0x10,ip actions=ct(commit,table=Output,zone=65520,exec(move:NXM_NX_REG0[0..3]->NXM_NX_CT_MARK[0..3]))",
 			"cookie=0x1010000000000, table=ConntrackState, priority=0 actions=goto_table:PreRoutingClassifier",

--- a/pkg/agent/openflow/service_test.go
+++ b/pkg/agent/openflow/service_test.go
@@ -25,8 +25,8 @@ import (
 func serviceInitFlows(proxyEnabled, isIPv4, proxyAllEnabled, dsrEnabled bool) []string {
 	if !proxyEnabled {
 		return []string{
-			"cookie=0x1030000000000, table=DNAT, priority=200,ip,nw_dst=10.96.0.0/16 actions=set_field:0x2->reg1,set_field:0x200000/0x600000->reg0,goto_table:ConntrackCommit",
-			"cookie=0x1030000000000, table=DNAT, priority=200,ipv6,ipv6_dst=fec0:10:96::/64 actions=set_field:0x2->reg1,set_field:0x200000/0x600000->reg0,goto_table:ConntrackCommit",
+			"cookie=0x1030000000000, table=DNAT, priority=200,ip,nw_dst=10.96.0.0/16 actions=set_field:0x8001->reg1,set_field:0x200000/0x600000->reg0,goto_table:ConntrackCommit",
+			"cookie=0x1030000000000, table=DNAT, priority=200,ipv6,ipv6_dst=fec0:10:96::/64 actions=set_field:0x8001->reg1,set_field:0x200000/0x600000->reg0,goto_table:ConntrackCommit",
 		}
 	}
 	var flows []string

--- a/pkg/agent/secondarynetwork/init_test.go
+++ b/pkg/agent/secondarynetwork/init_test.go
@@ -158,7 +158,7 @@ func mockInterfaceByName(t *testing.T) {
 
 func mockNewOVSBridge(t *testing.T, brClient ovsconfig.OVSBridgeClient) {
 	prevFunc := newOVSBridgeFn
-	newOVSBridgeFn = func(bridgeName string, ovsDatapathType ovsconfig.OVSDatapathType, ovsdb *ovsdb.OVSDB) ovsconfig.OVSBridgeClient {
+	newOVSBridgeFn = func(bridgeName string, ovsDatapathType ovsconfig.OVSDatapathType, ovsdb *ovsdb.OVSDB, options ...ovsconfig.OVSBridgeOption) ovsconfig.OVSBridgeClient {
 		return brClient
 	}
 	t.Cleanup(func() { newOVSBridgeFn = prevFunc })

--- a/pkg/ovs/ovsconfig/interfaces.go
+++ b/pkg/ovs/ovsconfig/interfaces.go
@@ -80,5 +80,6 @@ type OVSBridgeClient interface {
 	GetOVSDatapathType() OVSDatapathType
 	SetInterfaceType(name, ifType string) Error
 	SetPortExternalIDs(portName string, externalIDs map[string]interface{}) Error
+	GetPortExternalIDs(portName string) (map[string]string, Error)
 	SetInterfaceMAC(name string, mac net.HardwareAddr) Error
 }

--- a/pkg/ovs/ovsconfig/interfaces.go
+++ b/pkg/ovs/ovsconfig/interfaces.go
@@ -32,6 +32,20 @@ const (
 	OVSDatapathSystem OVSDatapathType = "system"
 
 	OVSOtherConfigDatapathIDKey string = "datapath-id"
+
+	// Valid ofport_request values are in the range 1 to 65,279. For ofport_request value not in
+	// this range, OVS ignores it and automatically assigns a port number.
+	// Here we use invalid port number "0" to explicitly request automatic port allocation.
+	AutoAssignedOFPort = 0
+	// Open vSwitch limits the port numbers that it automatically assigns to the range 1 through
+	// 32,767, inclusive. Controllers therefore have free use of ports 32,768 and up.
+	// When requesting a specific port number with ofport_request, it is better to use one of
+	// these "controller ports", to avoid unexpected ofport changes.
+	FirstControllerOFPort = 32768
+	// 0xfffffffe (OFPP_LOCAL) is a reserved port number in OpenFlow protocol, which is reserved
+	// for the Bridge interface.
+	// In OVS, it is equivalent to 0xfffe / 65534.
+	BridgeOFPort = 0xfffffffe
 )
 
 type OVSBridgeClient interface {
@@ -54,7 +68,6 @@ type OVSBridgeClient interface {
 	GetOFPort(ifName string, waitUntilValid bool) (int32, Error)
 	GetPortData(portUUID, ifName string) (*OVSPortData, Error)
 	GetPortList() ([]OVSPortData, Error)
-	AllocateOFPort(startPort int) (int32, error)
 	SetInterfaceMTU(name string, MTU int) error
 	GetOVSVersion() (string, Error)
 	AddOVSOtherConfig(configs map[string]interface{}) Error

--- a/pkg/ovs/ovsconfig/ovs_client.go
+++ b/pkg/ovs/ovsconfig/ovs_client.go
@@ -23,7 +23,6 @@ import (
 	"github.com/TomCodeLV/OVSDB-golang-lib/pkg/dbtransaction"
 	"github.com/TomCodeLV/OVSDB-golang-lib/pkg/helpers"
 	"github.com/TomCodeLV/OVSDB-golang-lib/pkg/ovsdb"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 )
 
@@ -35,7 +34,7 @@ type OVSBridge struct {
 	datapathType             OVSDatapathType
 	uuid                     string
 	isHardwareOffloadEnabled bool
-	allocatedOFPorts         []int32
+	requiredPortExternalIDs  []string
 }
 
 type OVSPortData struct {
@@ -97,9 +96,25 @@ func NewOVSDBConnectionUDS(address string) (*ovsdb.OVSDB, Error) {
 	return db, nil
 }
 
+type OVSBridgeOption func(*OVSBridge)
+
+func WithRequiredPortExternalIDs(keys ...string) OVSBridgeOption {
+	return func(br *OVSBridge) {
+		br.requiredPortExternalIDs = append(br.requiredPortExternalIDs, keys...)
+	}
+}
+
 // NewOVSBridge creates and returns a new OVSBridge struct.
-func NewOVSBridge(bridgeName string, ovsDatapathType OVSDatapathType, ovsdb *ovsdb.OVSDB) OVSBridgeClient {
-	return &OVSBridge{ovsdb, bridgeName, ovsDatapathType, "", false, []int32{}}
+func NewOVSBridge(bridgeName string, ovsDatapathType OVSDatapathType, ovsdb *ovsdb.OVSDB, options ...OVSBridgeOption) OVSBridgeClient {
+	br := &OVSBridge{
+		ovsdb:        ovsdb,
+		name:         bridgeName,
+		datapathType: ovsDatapathType,
+	}
+	for _, option := range options {
+		option(br)
+	}
+	return br
 }
 
 // Create looks up or creates the bridge. If the bridge with name bridgeName
@@ -564,6 +579,12 @@ func (br *OVSBridge) createPort(name, ifName, ifType string, ofPortRequest int32
 		optionMap = helpers.MakeOVSDBMap(options)
 	}
 
+	for _, id := range br.requiredPortExternalIDs {
+		if _, ok := externalIDs[id]; !ok {
+			return "", newInvalidArgumentsError(fmt.Sprintf("missing required externalID '%s' for port '%s'", id, name))
+		}
+	}
+
 	tx := br.ovsdb.Transaction(openvSwitchSchema)
 
 	interf := Interface{
@@ -815,31 +836,6 @@ func (br *OVSBridge) GetPortList() ([]OVSPortData, Error) {
 	}
 
 	return portList, nil
-}
-
-// AllocateOFPort returns an OpenFlow port number which is not allocated or used by any existing OVS port. Note that,
-// the returned port number is cached locally but not saved in OVSDB yet before the real port is created, so it might
-// introduce an issue of conflict if the OFPort is occupied by another port creation.
-func (br *OVSBridge) AllocateOFPort(startPort int) (int32, error) {
-	existingOFPorts := sets.New[int32]()
-	for _, allocatedOFPort := range br.allocatedOFPorts {
-		existingOFPorts.Insert(allocatedOFPort)
-	}
-	ports, err := br.GetPortList()
-	if err != nil {
-		return 0, err
-	}
-	for _, p := range ports {
-		existingOFPorts.Insert(p.OFPort)
-	}
-	port := int32(startPort)
-	for ; ; port++ {
-		if !existingOFPorts.Has(port) {
-			break
-		}
-	}
-	br.allocatedOFPorts = append(br.allocatedOFPorts, port)
-	return port, nil
 }
 
 // GetOVSVersion either returns the version of OVS, or an error.

--- a/pkg/ovs/ovsconfig/ovs_client.go
+++ b/pkg/ovs/ovsconfig/ovs_client.go
@@ -1068,6 +1068,22 @@ func (br *OVSBridge) SetPortExternalIDs(portName string, externalIDs map[string]
 	return nil
 }
 
+func (br *OVSBridge) GetPortExternalIDs(portName string) (map[string]string, Error) {
+	tx := br.ovsdb.Transaction(openvSwitchSchema)
+	tx.Select(dbtransaction.Select{
+		Table:   "Port",
+		Columns: []string{"external_ids"},
+		Where:   [][]interface{}{{"name", "==", portName}},
+	})
+	res, err, temporary := tx.Commit()
+	if err != nil {
+		klog.Error("Transaction failed", err)
+		return nil, NewTransactionError(err, temporary)
+	}
+	extIDRes := res[0].Rows[0].(map[string]interface{})["external_ids"].([]interface{})
+	return buildMapFromOVSDBMap(extIDRes), nil
+}
+
 func (br *OVSBridge) SetInterfaceMTU(name string, MTU int) error {
 	tx := br.ovsdb.Transaction(openvSwitchSchema)
 

--- a/pkg/ovs/ovsconfig/testing/mock_ovsconfig.go
+++ b/pkg/ovs/ovsconfig/testing/mock_ovsconfig.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Antrea Authors
+// Copyright 2024 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -80,21 +80,6 @@ func (m *MockOVSBridgeClient) AddOVSOtherConfig(arg0 map[string]any) ovsconfig.E
 func (mr *MockOVSBridgeClientMockRecorder) AddOVSOtherConfig(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddOVSOtherConfig", reflect.TypeOf((*MockOVSBridgeClient)(nil).AddOVSOtherConfig), arg0)
-}
-
-// AllocateOFPort mocks base method.
-func (m *MockOVSBridgeClient) AllocateOFPort(arg0 int) (int32, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AllocateOFPort", arg0)
-	ret0, _ := ret[0].(int32)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// AllocateOFPort indicates an expected call of AllocateOFPort.
-func (mr *MockOVSBridgeClientMockRecorder) AllocateOFPort(arg0 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllocateOFPort", reflect.TypeOf((*MockOVSBridgeClient)(nil).AllocateOFPort), arg0)
 }
 
 // Create mocks base method.

--- a/pkg/ovs/ovsconfig/testing/mock_ovsconfig.go
+++ b/pkg/ovs/ovsconfig/testing/mock_ovsconfig.go
@@ -375,6 +375,21 @@ func (mr *MockOVSBridgeClientMockRecorder) GetPortData(arg0, arg1 any) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPortData", reflect.TypeOf((*MockOVSBridgeClient)(nil).GetPortData), arg0, arg1)
 }
 
+// GetPortExternalIDs mocks base method.
+func (m *MockOVSBridgeClient) GetPortExternalIDs(arg0 string) (map[string]string, ovsconfig.Error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPortExternalIDs", arg0)
+	ret0, _ := ret[0].(map[string]string)
+	ret1, _ := ret[1].(ovsconfig.Error)
+	return ret0, ret1
+}
+
+// GetPortExternalIDs indicates an expected call of GetPortExternalIDs.
+func (mr *MockOVSBridgeClientMockRecorder) GetPortExternalIDs(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPortExternalIDs", reflect.TypeOf((*MockOVSBridgeClient)(nil).GetPortExternalIDs), arg0)
+}
+
 // GetPortList mocks base method.
 func (m *MockOVSBridgeClient) GetPortList() ([]ovsconfig.OVSPortData, ovsconfig.Error) {
 	m.ctrl.T.Helper()

--- a/pkg/ovs/ovsctl/ovsctl_test.go
+++ b/pkg/ovs/ovsctl/ovsctl_test.go
@@ -46,15 +46,15 @@ port 2: gre_sys (gre)
 port 3: net2`)
 	testDumpFlows = []string{
 		"cookie=0xa000000000000, duration=13489003.061s, table=0, priority=200, n_packets=143, n_bytes=6006, idle_age=15512, hard_age=65534,arp actions=resubmit(,1)",
-		"cookie=0xa010000000000, duration=13489003.042s, table=1, priority=200, n_packets=12, n_bytes=504, idle_age=17282, hard_age=65534,arp,in_port=2,arp_spa=192.168.1.1,arp_sha=16:92:82:a4:69:50 actions=resubmit(,2)",
+		"cookie=0xa010000000000, duration=13489003.042s, table=1, priority=200, n_packets=12, n_bytes=504, idle_age=17282, hard_age=65534,arp,in_port=32769,arp_spa=192.168.1.1,arp_sha=16:92:82:a4:69:50 actions=resubmit(,2)",
 		"cookie=0xa000000000000, duration=13489003.061s, table=2, priority=0, n_packets=0, n_bytes=0, idle_age=65534, hard_age=65534, actions=drop",
-		"cookie=0xa010000000000, duration=13489003.042s, table=3, priority=200, n_packets=29233419, n_bytes=2703471860, idle_age=8, hard_age=65534,in_port=2 actions=load:0x2->NXM_NX_REG0[0..3],resubmit(,4)",
-		"cookie=0xa010000000000, duration=13489003.042s, table=3, priority=200, n_packets=0, n_bytes=0, idle_age=65534, hard_age=65534,in_port=1 actions=load:0x1->reg0",
+		"cookie=0xa010000000000, duration=13489003.042s, table=3, priority=200, n_packets=29233419, n_bytes=2703471860, idle_age=8, hard_age=65534,in_port=32769 actions=load:0x2->NXM_NX_REG0[0..3],resubmit(,4)",
+		"cookie=0xa010000000000, duration=13489003.042s, table=3, priority=200, n_packets=0, n_bytes=0, idle_age=65534, hard_age=65534,in_port=32768 actions=load:0x1->reg0",
 	}
 	testDumpFlowsWithoutTableNames = []string{
 		"cookie=0xa000000000000, duration=13489003.061s, table=0, priority=200, n_packets=143, n_bytes=6006, idle_age=15512, hard_age=65534,arp actions=resubmit(,1)",
-		"cookie=0xa010000000000, duration=13489003.042s, table=1, priority=200, n_packets=12, n_bytes=504, idle_age=17282, hard_age=65534,arp,in_port=2,arp_spa=192.168.1.1,arp_sha=16:92:82:a4:69:50 actions=resubmit(,2)",
-		"cookie=0xa010000000000, duration=13489003.042s, table=3, priority=200, n_packets=29233419, n_bytes=2703471860, idle_age=8, hard_age=65534,in_port=2 actions=load:0x2->NXM_NX_REG0[0..3],resubmit(,4)",
+		"cookie=0xa010000000000, duration=13489003.042s, table=1, priority=200, n_packets=12, n_bytes=504, idle_age=17282, hard_age=65534,arp,in_port=32769,arp_spa=192.168.1.1,arp_sha=16:92:82:a4:69:50 actions=resubmit(,2)",
+		"cookie=0xa010000000000, duration=13489003.042s, table=3, priority=200, n_packets=29233419, n_bytes=2703471860, idle_age=8, hard_age=65534,in_port=32769 actions=load:0x2->NXM_NX_REG0[0..3],resubmit(,4)",
 	}
 	testDumpGroups = []string{
 		"",
@@ -194,10 +194,10 @@ func TestTrace(t *testing.T) {
 				DstIP:               dstIP,
 				SrcMAC:              srcMAC,
 				DstMAC:              dstMAC,
-				Flow:                "in_port=3,tcp,tcp_dst=22,",
+				Flow:                "in_port=32770,tcp,tcp_dst=22,",
 				AllowOverrideInPort: true,
 			},
-			expectedFlow: "dl_src=11:11:11:11:11:11,dl_dst=11:11:11:11:11:22,in_port=3,tcp,tcp_dst=22,,nw_ttl=64,nw_src=1.1.1.2,nw_dst=2.2.2.2,",
+			expectedFlow: "dl_src=11:11:11:11:11:11,dl_dst=11:11:11:11:11:22,in_port=32770,tcp,tcp_dst=22,,nw_ttl=64,nw_src=1.1.1.2,nw_dst=2.2.2.2,",
 		},
 		{
 			name: "no-ops due to source and destination IP error for non-IP packet",
@@ -230,7 +230,7 @@ func TestTrace(t *testing.T) {
 			name: "no-ops due to duplicated in_port error",
 			req: &TracingRequest{
 				InPort:              "9",
-				Flow:                "in_port=3,tcp,tcp_dst=22,",
+				Flow:                "in_port=32770,tcp,tcp_dst=22,",
 				AllowOverrideInPort: false,
 			},
 			expectedError: "duplicated 'in_port' in flow",
@@ -301,10 +301,10 @@ func TestOfCtl(t *testing.T) {
 		require.NoError(err)
 		expectedFlows := []string{
 			"table=0, priority=200, n_packets=143, n_bytes=6006, idle_age=15512, hard_age=65534,arp actions=resubmit(,1)",
-			"table=1, priority=200, n_packets=12, n_bytes=504, idle_age=17282, hard_age=65534,arp,in_port=2,arp_spa=192.168.1.1,arp_sha=16:92:82:a4:69:50 actions=resubmit(,2)",
+			"table=1, priority=200, n_packets=12, n_bytes=504, idle_age=17282, hard_age=65534,arp,in_port=32769,arp_spa=192.168.1.1,arp_sha=16:92:82:a4:69:50 actions=resubmit(,2)",
 			"table=2, priority=0, n_packets=0, n_bytes=0, idle_age=65534, hard_age=65534, actions=drop",
-			"table=3, priority=200, n_packets=29233419, n_bytes=2703471860, idle_age=8, hard_age=65534,in_port=2 actions=load:0x2->NXM_NX_REG0[0..3],resubmit(,4)",
-			"table=3, priority=200, n_packets=0, n_bytes=0, idle_age=65534, hard_age=65534,in_port=1 actions=load:0x1->reg0",
+			"table=3, priority=200, n_packets=29233419, n_bytes=2703471860, idle_age=8, hard_age=65534,in_port=32769 actions=load:0x2->NXM_NX_REG0[0..3],resubmit(,4)",
+			"table=3, priority=200, n_packets=0, n_bytes=0, idle_age=65534, hard_age=65534,in_port=32768 actions=load:0x1->reg0",
 		}
 		assert.Equal(expectedFlows, got)
 	})
@@ -323,8 +323,8 @@ func TestOfCtl(t *testing.T) {
 		require.NoError(err)
 		expectedFlows := []string{
 			"table=0, priority=200, n_packets=143, n_bytes=6006, idle_age=15512, hard_age=65534,arp actions=resubmit(,1)",
-			"table=1, priority=200, n_packets=12, n_bytes=504, idle_age=17282, hard_age=65534,arp,in_port=2,arp_spa=192.168.1.1,arp_sha=16:92:82:a4:69:50 actions=resubmit(,2)",
-			"table=3, priority=200, n_packets=29233419, n_bytes=2703471860, idle_age=8, hard_age=65534,in_port=2 actions=load:0x2->NXM_NX_REG0[0..3],resubmit(,4)",
+			"table=1, priority=200, n_packets=12, n_bytes=504, idle_age=17282, hard_age=65534,arp,in_port=32769,arp_spa=192.168.1.1,arp_sha=16:92:82:a4:69:50 actions=resubmit(,2)",
+			"table=3, priority=200, n_packets=29233419, n_bytes=2703471860, idle_age=8, hard_age=65534,in_port=32769 actions=load:0x2->NXM_NX_REG0[0..3],resubmit(,4)",
 		}
 		assert.Equal(expectedFlows, got)
 	})
@@ -369,8 +369,8 @@ func TestOfCtl(t *testing.T) {
 		out, err := client.DumpTableFlows(uint8(3))
 		require.NoError(err)
 		expectedFlows := []string{
-			"table=3, priority=200, n_packets=29233419, n_bytes=2703471860, idle_age=8, hard_age=65534,in_port=2 actions=load:0x2->NXM_NX_REG0[0..3],resubmit(,4)",
-			"table=3, priority=200, n_packets=0, n_bytes=0, idle_age=65534, hard_age=65534,in_port=1 actions=load:0x1->reg0",
+			"table=3, priority=200, n_packets=29233419, n_bytes=2703471860, idle_age=8, hard_age=65534,in_port=32769 actions=load:0x2->NXM_NX_REG0[0..3],resubmit(,4)",
+			"table=3, priority=200, n_packets=0, n_bytes=0, idle_age=65534, hard_age=65534,in_port=32768 actions=load:0x1->reg0",
 		}
 		assert.Equal(expectedFlows, out)
 	})

--- a/test/integration/ovs/ovs_client_test.go
+++ b/test/integration/ovs/ovs_client_test.go
@@ -159,8 +159,6 @@ func TestOVSCreatePortRequiredExternalIDs(t *testing.T) {
 	data.setup(t)
 	defer data.teardown(t)
 
-	deleteAllPorts(t, data.br)
-
 	name := "p1"
 	externalIDs := map[string]interface{}{}
 	_, err := data.br.CreatePort(name, name, externalIDs)
@@ -169,6 +167,39 @@ func TestOVSCreatePortRequiredExternalIDs(t *testing.T) {
 	externalIDs["k1"] = "v1"
 	_, err = data.br.CreatePort(name, name, externalIDs)
 	assert.NoError(t, err)
+
+	deleteAllPorts(t, data.br)
+}
+
+// TestOVSPortExternalIDs tests getting and setting external IDs of OVS ports.
+func TestOVSPortExternalIDs(t *testing.T) {
+	data := &testData{}
+	data.setup(t)
+	defer data.teardown(t)
+
+	name := "p1"
+	externalIDs := map[string]interface{}{
+		"k1": "v1",
+	}
+	_, err := data.br.CreatePort(name, name, externalIDs)
+	require.NoError(t, err)
+
+	actualExternalIDs, err := data.br.GetPortExternalIDs(name)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{
+		"k1": "v1",
+	}, actualExternalIDs)
+
+	externalIDs["k2"] = "v2"
+
+	require.NoError(t, data.br.SetPortExternalIDs(name, externalIDs))
+
+	actualExternalIDs, err = data.br.GetPortExternalIDs(name)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{
+		"k1": "v1",
+		"k2": "v2",
+	}, actualExternalIDs)
 
 	deleteAllPorts(t, data.br)
 }


### PR DESCRIPTION
Use reserved OVS controller ports for default Antrea ports

Tunnel port, gateway port and uplink port.
These reserved port numbers (starting from 32,768) will never be
auto-assigned by OVS. By using them, we can avoid surprising ofport
changes in some edge cases.

Note that if these ports already exist when the Agent starts, we will
not re-create them or mutate their ofport. The new ofport values will
only be used when creating the OVS ports for the first time (e.g., on a
new K8s Node, or after a Node restart). That is the simplest solution
and is consistent with existing behavior. It should also be sufficient
for avoiding #6192, which was typically triggered by creating a new
tunnel port when updating the Antrea configuration in an existing
cluster.

After this change, we will also assume that br-int ports stored in OVSDB
always have the "antrea-type" external ID. This external ID became
required in Antrea v1.5, so this should be an acceptable change,
especially considering that this change is destined for the Antrea v2
release, which is a major version bump. Users will not be able to
upgrade from Antrea v1.5 to Antrea v2.0, but that this is not a
supported upgrade path anyway (for other reasons).
We also add some logic to prevent creating a port on the OVS bridge if a
required external ID is missing.

Fixes #6192