### PR TITLE
Do not try to update type of Secret in selfSignedCertProvider

### DIFF
--- a/pkg/apiserver/certificate/selfsignedcert_provider.go
+++ b/pkg/apiserver/certificate/selfsignedcert_provider.go
@@ -317,9 +317,11 @@ func (p *selfSignedCertProvider) saveCertKeyToSecret(secret *corev1.Secret, cert
 		if bytes.Equal(cert, secret.Data[corev1.TLSCertKey]) && bytes.Equal(key, secret.Data[corev1.TLSPrivateKeyKey]) {
 			return nil
 		}
-		secret.Type = corev1.SecretTypeTLS
+		// Do not update the existing Secret's type. Otherwise, the update would fail if it's not of type
+		// "kubernetes.io/tls" as the type field is immutable.
 		secret.Data[corev1.TLSCertKey] = cert
 		secret.Data[corev1.TLSPrivateKeyKey] = key
+		klog.InfoS("Updating Secret to persist self-signed cert", "secret", klog.KObj(secret))
 		_, err := p.client.CoreV1().Secrets(p.secretNamespace).Update(context.TODO(), secret, metav1.UpdateOptions{})
 		return err
 	}
@@ -331,6 +333,7 @@ func (p *selfSignedCertProvider) saveCertKeyToSecret(secret *corev1.Secret, cert
 			corev1.TLSPrivateKeyKey: key,
 		},
 	}
+	klog.InfoS("Creating Secret to persist self-signed cert", "secret", klog.KObj(secret))
 	_, err := p.client.CoreV1().Secrets(p.secretNamespace).Create(context.TODO(), caSecret, metav1.CreateOptions{})
 	return err
 }

--- a/pkg/apiserver/certificate/selfsignedcert_provider_test.go
+++ b/pkg/apiserver/certificate/selfsignedcert_provider_test.go
@@ -168,6 +168,12 @@ func TestSelfSignedCertProviderRotate(t *testing.T) {
 	}, 5*time.Second, 100*time.Millisecond)
 }
 
+func copyAndMutateSecret(secret *corev1.Secret, mutator func(_ *corev1.Secret)) *corev1.Secret {
+	s := secret.DeepCopy()
+	mutator(s)
+	return s
+}
+
 func TestSelfSignedCertProviderRun(t *testing.T) {
 	t.Setenv(env.PodNamespaceEnvKey, testSecretNamespace)
 	testSecret := &corev1.Secret{
@@ -220,6 +226,19 @@ func TestSelfSignedCertProviderRun(t *testing.T) {
 			tlsSecretName:    testSecretName,
 			existingSecret:   testSecret,
 			expectedSecret:   testSecret2,
+			minValidDuration: time.Hour * 24 * 370,
+			expectedCert:     testOneYearCert2,
+			expectedKey:      testOneYearKey2,
+		},
+		{
+			name:          "should not update secret type when secret is opaque",
+			tlsSecretName: testSecretName,
+			existingSecret: copyAndMutateSecret(testSecret, func(s *corev1.Secret) {
+				s.Type = corev1.SecretTypeOpaque
+			}),
+			expectedSecret: copyAndMutateSecret(testSecret2, func(s *corev1.Secret) {
+				s.Type = corev1.SecretTypeOpaque
+			}),
 			minValidDuration: time.Hour * 24 * 370,
 			expectedCert:     testOneYearCert2,
 			expectedKey:      testOneYearKey2,


### PR DESCRIPTION
If a cluster used user provided certificate and created a Secret named antrea-controller-tls of Opaque type, changing to use self-signed certificate would fail because the type field is immutable.

To support switching the certificate provider, we don't try to update the type of Secret if it already exists.

---

cert-manager has similar logic: https://github.com/cert-manager/cert-manager/commit/7a4be1edfdeb75429baf9f2b6e94c63c9b57d5a6

The following scenarios have been considered:
1. cert-manager provided certificate -> Antrea self-signed certificate: as both of them use tls type
2. user manually created certificate -> Antrea self-signed certificate: as Antrea doesn't update type
3. Antrea self-signed certificate -> cert-manager provided certificate: as cert-manager doesn't update type 
4. Antrea self-signed certificate -> user manually created certificate (type of tls): user should keep the type unchanged, or delete the secret first to specify other types.