### PR TITLE
Fix typo in NodePortLocal documentation

### DIFF
--- a/docs/node-port-local.md
+++ b/docs/node-port-local.md
@@ -81,7 +81,7 @@ spec:
   - name: web
     port: 80
     protocol: TCP
-    targetPort: 80
+    targetPort: 8080
   selector:
     app: nginx
 ---


### PR DESCRIPTION
The targetPort for the Service should be 8080 to match the NPL annotation in the example.