### PR TITLE
Automated cherry pick of #6076: Replace test Harbor images with DockerHub images (#6076)

### DIFF
--- a/build/charts/antrea/templates/simulator/statefulset.yaml
+++ b/build/charts/antrea/templates/simulator/statefulset.yaml
@@ -32,7 +32,7 @@ spec:
       serviceAccountName: antrea-agent
       initContainers:
       - name: init-inotify-limit
-        image: projects.registry.vmware.com/library/busybox:latest
+        image: antrea/ubuntu:22.04
         command: ['sysctl', '-w', 'fs.inotify.max_user_instances=200']
         securityContext:
           privileged: true
@@ -68,7 +68,7 @@ spec:
         - name: logs-volume
           mountPath: /var/log
       - name: hollow-kubelet
-        image: projects.registry.vmware.com/antrea/kubemark:v1.18.4
+        image: antrea/kubemark:v1.18.4
         ports:
         - containerPort: 4194
         - containerPort: 10250
@@ -106,7 +106,7 @@ spec:
         securityContext:
           privileged: true
       - name: hollow-proxy
-        image: projects.registry.vmware.com/antrea/kubemark:v1.18.4
+        image: antrea/kubemark:v1.18.4
         env:
         - name: CONTENT_TYPE
           valueFrom:

--- a/ci/docker-registry
+++ b/ci/docker-registry
@@ -1,1 +1,1 @@
-projects.registry.vmware.com
+docker.io

--- a/ci/jenkins/test-vm.sh
+++ b/ci/jenkins/test-vm.sh
@@ -20,7 +20,7 @@ function echoerr {
     >&2 echo "$@"
 }
 
-DOCKER_REGISTRY="projects.registry.vmware.com"
+DOCKER_REGISTRY=$(head -n1 "${WORKSPACE}/ci/docker-registry")
 DEFAULT_WORKDIR="/var/lib/jenkins"
 ANTREA_AGENT_KUBECONFIG="antrea-agent.kubeconfig"
 ANTREA_AGENT_ANTREA_KUBECONFIG="antrea-agent.antrea.kubeconfig"

--- a/ci/jenkins/test.sh
+++ b/ci/jenkins/test.sh
@@ -690,8 +690,8 @@ function deliver_antrea {
     ${CLEAN_STALE_IMAGES}
     ${PRINT_DOCKER_STATUS}
     if [[ ! "${TESTCASE}" =~ "e2e" && "${DOCKER_REGISTRY}" != "" ]]; then
-        docker pull "${DOCKER_REGISTRY}/antrea/sonobuoy-systemd-logs:v0.3"
-        docker tag "${DOCKER_REGISTRY}/antrea/sonobuoy-systemd-logs:v0.3" "sonobuoy/systemd-logs:v0.3"
+        docker pull "${DOCKER_REGISTRY}/antrea/systemd-logs:v0.4"
+        docker tag "${DOCKER_REGISTRY}/antrea/systemd-logs:v0.4" "antrea/systemd-logs:v0.4"
     fi
     chmod -R g-w build/images/ovs
     chmod -R g-w build/images/base
@@ -755,7 +755,7 @@ function deliver_antrea {
             rsync -avr --progress --inplace -e "ssh -o StrictHostKeyChecking=no" flow-aggregator.tar jenkins@[${IP}]:${WORKDIR}/flow-aggregator.tar
             ssh -o StrictHostKeyChecking=no -n jenkins@${IP} "${CLEAN_STALE_IMAGES}; ${PRINT_DOCKER_STATUS}; docker load -i ${WORKDIR}/antrea-ubuntu.tar; docker load -i ${WORKDIR}/flow-aggregator.tar" || true
             if [[ ! "${TESTCASE}" =~ "e2e" && "${DOCKER_REGISTRY}" != "" ]]; then
-                ssh -o StrictHostKeyChecking=no -n jenkins@${IP} "docker pull ${DOCKER_REGISTRY}/antrea/sonobuoy-systemd-logs:v0.3 ; docker tag ${DOCKER_REGISTRY}/antrea/sonobuoy-systemd-logs:v0.3 sonobuoy/systemd-logs:v0.3"
+                ssh -o StrictHostKeyChecking=no -n jenkins@${IP} "docker pull ${DOCKER_REGISTRY}/antrea/systemd-logs:v0.4 ; docker tag ${DOCKER_REGISTRY}/antrea/systemd-logs:v0.4 antrea/systemd-logs:v0.4"
             fi
         done
     fi

--- a/ci/kind/test-e2e-kind.sh
+++ b/ci/kind/test-e2e-kind.sh
@@ -197,14 +197,13 @@ if $flow_visibility; then
 fi
 
 COMMON_IMAGES_LIST=("registry.k8s.io/e2e-test-images/agnhost:2.29" \
-                    "projects.registry.vmware.com/antrea/busybox"  \
-                    "projects.registry.vmware.com/antrea/nginx:1.21.6-alpine" \
-                    "projects.registry.vmware.com/antrea/toolbox:1.3-0")
+                    "antrea/nginx:1.21.6-alpine" \
+                    "antrea/toolbox:1.3-0")
 
-FLOW_VISIBILITY_IMAGE_LIST=("projects.registry.vmware.com/antrea/ipfix-collector:v0.8.2" \
-                            "projects.registry.vmware.com/antrea/clickhouse-operator:0.21.0" \
-                            "projects.registry.vmware.com/antrea/metrics-exporter:0.21.0" \
-                            "projects.registry.vmware.com/antrea/clickhouse-server:23.4")
+FLOW_VISIBILITY_IMAGE_LIST=("antrea/ipfix-collector:v0.9.0" \
+                            "antrea/clickhouse-operator:0.21.0" \
+                            "antrea/metrics-exporter:0.21.0" \
+                            "antrea/clickhouse-server:23.4")
 if $proxy_all; then
     COMMON_IMAGES_LIST+=("registry.k8s.io/echoserver:1.10")
 fi
@@ -286,9 +285,9 @@ function run_test {
       $HELM template "$FLOW_VISIBILITY_CHART" --set "secureConnection.enable=true" | docker exec -i kind-control-plane dd of=/root/flow-visibility-tls.yml
 
       curl -o $CH_OPERATOR_YML https://raw.githubusercontent.com/Altinity/clickhouse-operator/release-0.21.0/deploy/operator/clickhouse-operator-install-bundle.yaml
-      sed -i -e "s|\"image\": \"clickhouse/clickhouse-server:22.3\"|\"image\": \"projects.registry.vmware.com/antrea/clickhouse-server:23.4\"|g" $CH_OPERATOR_YML
-      sed -i -e "s|image: altinity/clickhouse-operator:0.21.0|image: projects.registry.vmware.com/antrea/clickhouse-operator:0.21.0|g" $CH_OPERATOR_YML
-      sed -i -e "s|image: altinity/metrics-exporter:0.21.0|image: projects.registry.vmware.com/antrea/metrics-exporter:0.21.0|g" $CH_OPERATOR_YML
+      sed -i -e "s|\"image\": \"clickhouse/clickhouse-server:22.3\"|\"image\": \"antrea/clickhouse-server:23.4\"|g" $CH_OPERATOR_YML
+      sed -i -e "s|image: altinity/clickhouse-operator:0.21.0|image: antrea/clickhouse-operator:0.21.0|g" $CH_OPERATOR_YML
+      sed -i -e "s|image: altinity/metrics-exporter:0.21.0|image: antrea/metrics-exporter:0.21.0|g" $CH_OPERATOR_YML
       cat $CH_OPERATOR_YML | docker exec -i kind-control-plane dd of=/root/clickhouse-operator-install-bundle.yml
   fi
 

--- a/ci/run-k8s-e2e-tests.sh
+++ b/ci/run-k8s-e2e-tests.sh
@@ -43,8 +43,8 @@ THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 KUBE_CONFORMANCE_IMAGE_VERSION_OPTION=""
 IMAGE_PULL_POLICY="Always"
 CONFORMANCE_IMAGE_CONFIG_PATH="${THIS_DIR}/conformance-image-config.yaml"
-SONOBUOY_IMAGE="projects.registry.vmware.com/sonobuoy/sonobuoy:v0.56.16"
-SYSTEMD_LOGS_IMAGE="projects.registry.vmware.com/sonobuoy/systemd-logs:v0.4"
+SONOBUOY_IMAGE="antrea/sonobuoy:v0.56.16"
+SYSTEMD_LOGS_IMAGE="antrea/systemd-logs:v0.4"
 
 _usage="Usage: $0 [--e2e-conformance] [--e2e-network-policy] [--e2e-focus <TestRegex>] [--e2e-skip <SkipRegex>]
                   [--kubeconfig <Kubeconfig>] [--kubernetes-version <ConformanceImageVersion>]

--- a/hack/externalnode/sftp-deployment.yml
+++ b/hack/externalnode/sftp-deployment.yml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: sftp
-        image: projects.registry.vmware.com/antrea/sftp
+        image: antrea/sftp
         imagePullPolicy: IfNotPresent
         args: ["foo:pass:::upload"]
 

--- a/multicluster/test/e2e/framework.go
+++ b/multicluster/test/e2e/framework.go
@@ -50,7 +50,7 @@ const (
 	gatewayNodeClientSuffix string = "gateway-client"
 	regularNodeClientSuffix string = "regular-client"
 
-	nginxImage   = "projects.registry.vmware.com/antrea/nginx:1.21.6-alpine"
+	nginxImage   = "antrea/nginx:1.21.6-alpine"
 	agnhostImage = "registry.k8s.io/e2e-test-images/agnhost:2.29"
 )
 

--- a/test/e2e/charts/flow-visibility/templates/clickhouseinstallation.yaml
+++ b/test/e2e/charts/flow-visibility/templates/clickhouseinstallation.yaml
@@ -65,7 +65,7 @@ spec:
         spec:
           containers:
             - name: clickhouse
-              image: projects.registry.vmware.com/antrea/clickhouse-server:23.4
+              image: antrea/clickhouse-server:23.4
               imagePullPolicy: IfNotPresent
               volumeMounts:
                 - name: clickhouse-configmap-volume

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -129,12 +129,12 @@ const (
 	nameSuffixLength = 8
 
 	agnhostImage        = "registry.k8s.io/e2e-test-images/agnhost:2.29"
-	busyboxImage        = "projects.registry.vmware.com/antrea/busybox"
-	mcjoinImage         = "projects.registry.vmware.com/antrea/mcjoin:v2.9"
-	nginxImage          = "projects.registry.vmware.com/antrea/nginx:1.21.6-alpine"
+	busyboxImage        = "antrea/busybox"
+	mcjoinImage         = "antrea/mcjoin:v2.9"
+	nginxImage          = "antrea/nginx:1.21.6-alpine"
 	iisImage            = "mcr.microsoft.com/windows/servercore/iis"
-	toolboxImage        = "projects.registry.vmware.com/antrea/toolbox:1.3-0"
-	ipfixCollectorImage = "projects.registry.vmware.com/antrea/ipfix-collector:v0.8.2"
+	toolboxImage        = "antrea/toolbox:1.3-0"
+	ipfixCollectorImage = "antrea/ipfix-collector:v0.8.2"
 	ipfixCollectorPort  = "4739"
 	clickHouseHTTPPort  = "8123"
 


### PR DESCRIPTION
Cherry pick of #6076 on release-1.14.

#6076: Replace test Harbor images with DockerHub images (#6076)

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.