### PR TITLE
[Followup] Fix action field in NetworkPolicyEvaluation for KNP

### DIFF
--- a/pkg/antctl/transform/networkpolicy/response.go
+++ b/pkg/antctl/transform/networkpolicy/response.go
@@ -187,14 +187,18 @@ func (r EvaluationResponse) GetTableHeader() []string {
 
 func (r EvaluationResponse) GetTableRow(_ int) []string {
 	if r.NetworkPolicyEvaluation != nil && r.Response != nil {
-		// Handle K8s NPs empty action field. "Allow" corresponds to a K8s NP
-		// allow action, and "Isolate" corresponds to a drop action because of the
-		// default isolation model. Otherwise, display the action field content.
-		action := "Allow"
+		action := ""
 		if r.Response.Rule.Action != nil {
 			action = string(*r.Response.Rule.Action)
 		} else if r.Response.RuleIndex == math.MaxInt32 {
+			// Responses from endpoint query with original rules will always have
+			// valid action fields, except for the synthetic isolation rules,
+			// identified by a MaxInt32 rule index. "Isolate" corresponds to
+			// a drop action because of the default isolation model of K8s NPs.
 			action = "Isolate"
+		} else {
+			// Should not be possible.
+			action = "Unknown"
 		}
 		return []string{
 			r.Response.NetworkPolicy.Name,

--- a/pkg/antctl/transform/networkpolicy/response_test.go
+++ b/pkg/antctl/transform/networkpolicy/response_test.go
@@ -182,7 +182,7 @@ func TestEvaluationResponseTransform(t *testing.T) {
 	assert.Equal(t, []string{"NAME", "NAMESPACE", "POLICY-TYPE", "RULE-INDEX", "DIRECTION", "ACTION"}, test.GetTableHeader())
 	assert.False(t, test.SortRows())
 	assert.Equal(t, []string{"", "", "", "", "", ""}, test.GetTableRow(32))
-	testDropAction := crdv1beta1.RuleActionDrop
+	testDropAction, testAllowAction := crdv1beta1.RuleActionDrop, crdv1beta1.RuleActionAllow
 
 	tests := []struct {
 		name           string
@@ -198,7 +198,7 @@ func TestEvaluationResponseTransform(t *testing.T) {
 					Name:      "testK8s",
 				},
 				RuleIndex: 10,
-				Rule:      cpv1beta.RuleRef{Direction: cpv1beta.DirectionIn},
+				Rule:      cpv1beta.RuleRef{Direction: cpv1beta.DirectionIn, Action: &testAllowAction},
 			},
 			expectedOutput: []string{"testK8s", "ns", "K8sNetworkPolicy", "10", "In", "Allow"},
 		},
@@ -227,6 +227,19 @@ func TestEvaluationResponseTransform(t *testing.T) {
 				Rule:      cpv1beta.RuleRef{Direction: cpv1beta.DirectionIn},
 			},
 			expectedOutput: []string{"testK8s", "ns", "K8sNetworkPolicy", fmt.Sprint(math.MaxInt32), "In", "Isolate"},
+		},
+		{
+			name: "Unknown action in response",
+			testResponse: &cpv1beta.NetworkPolicyEvaluationResponse{
+				NetworkPolicy: cpv1beta.NetworkPolicyReference{
+					Type:      cpv1beta.AntreaNetworkPolicy,
+					Namespace: "ns",
+					Name:      "testError",
+				},
+				RuleIndex: 10,
+				Rule:      cpv1beta.RuleRef{Direction: cpv1beta.DirectionIn},
+			},
+			expectedOutput: []string{"testError", "ns", "AntreaNetworkPolicy", "10", "In", "Unknown"},
 		},
 	}
 

--- a/pkg/controller/networkpolicy/endpoint_querier.go
+++ b/pkg/controller/networkpolicy/endpoint_querier.go
@@ -115,7 +115,7 @@ func (eq *EndpointQuerierImpl) QueryNetworkPolicyRules(namespace, podName string
 	appliedToGroupKeys := groups[appliedToGroupType]
 	// We iterate over all AppliedToGroups (same for AddressGroups below). This is acceptable
 	// since this implementation only supports user queries (in particular through antctl) and
-	// should resturn within a reasonable amount of time. We experimented with adding Pod
+	// should return within a reasonable amount of time. We experimented with adding Pod
 	// Indexers to the AppliedToGroup and AddressGroup stores, but we felt that this use case
 	// did not justify the memory overhead. If we can find another use for the Indexers as part
 	// of the NetworkPolicy Controller implementation, we may consider adding them back.
@@ -192,10 +192,10 @@ func processEndpointAppliedRules(appliedPolicies []*antreatypes.NetworkPolicy, i
 			for _, rule := range internalPolicy.Rules {
 				if rule.Direction == controlplane.DirectionIn && !isSourceEndpoint {
 					isolationRules = append(isolationRules, &antreatypes.RuleInfo{Policy: internalPolicy, Index: math.MaxInt32,
-						Rule: &controlplane.NetworkPolicyRule{Direction: rule.Direction, Name: rule.Name, Action: rule.Action}})
+						Rule: &controlplane.NetworkPolicyRule{Direction: rule.Direction, Name: rule.Name}})
 				} else if rule.Direction == controlplane.DirectionOut && isSourceEndpoint {
 					isolationRules = append(isolationRules, &antreatypes.RuleInfo{Policy: internalPolicy, Index: math.MaxInt32,
-						Rule: &controlplane.NetworkPolicyRule{Direction: rule.Direction, Name: rule.Name, Action: rule.Action}})
+						Rule: &controlplane.NetworkPolicyRule{Direction: rule.Direction, Name: rule.Name}})
 				}
 			}
 		}


### PR DESCRIPTION
When processing Kubernetes NetworkPolicy, a default action Allow is assigned in Antrea controller. This was not handled in NetworkPolicyEvaluation action field. This PR fixes it to differentiate from Isolate value in specific case of default isolation model.