### PR TITLE
[Windows] Remove prefix "rancher-wins" when collecting antrea-agent logs

### DIFF
--- a/pkg/support/dump_windows.go
+++ b/pkg/support/dump_windows.go
@@ -37,7 +37,7 @@ func (d *agentDumper) DumpLog(basedir string) error {
 	logDir := logdir.GetLogDir()
 	timeFilter := timestampFilter(d.since)
 
-	if err := directoryCopy(d.fs, path.Join(basedir, "logs", "agent"), logDir, "rancher-wins-antrea-agent", timeFilter); err != nil {
+	if err := directoryCopy(d.fs, path.Join(basedir, "logs", "agent"), logDir, "antrea-agent", timeFilter); err != nil {
 		return err
 	}
 	// Dump OVS logs.
@@ -106,6 +106,6 @@ func (d *agentDumper) dumpHNSResources(basedir string) error {
 }
 
 func (d *agentDumper) DumpMemberlist(basedir string) error {
-	// memberlist never runs on windows.
+	// memberlist never runs on Windows.
 	return nil
 }

--- a/pkg/support/dump_windows_test.go
+++ b/pkg/support/dump_windows_test.go
@@ -38,10 +38,11 @@ func TestDumpLog(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	logDir := logdir.GetLogDir()
 
+	agentLogFileName := "antrea-agent.exe.INFO"
 	fs.MkdirAll(logDir, os.ModePerm)
 	fs.MkdirAll(antreaWindowsOVSLogDir, os.ModePerm)
 	fs.MkdirAll(antreaWindowsKubeletLogDir, os.ModePerm)
-	fs.Create(filepath.Join(logDir, "rancher-wins-antrea-agent.log"))
+	fs.Create(filepath.Join(logDir, agentLogFileName))
 	fs.Create(filepath.Join(antreaWindowsOVSLogDir, "ovs.log"))
 	fs.Create(filepath.Join(antreaWindowsKubeletLogDir, "kubelet.log"))
 
@@ -49,7 +50,7 @@ func TestDumpLog(t *testing.T) {
 	err := dumper.DumpLog(baseDir)
 	require.NoError(t, err)
 
-	ok, err := afero.Exists(fs, filepath.Join(baseDir, "logs", "agent", "rancher-wins-antrea-agent.log"))
+	ok, err := afero.Exists(fs, filepath.Join(baseDir, "logs", "agent", agentLogFileName))
 	require.NoError(t, err)
 	assert.True(t, ok)
 	ok, err = afero.Exists(fs, filepath.Join(baseDir, "logs", "ovs", "ovs.log"))


### PR DESCRIPTION
After switching to Containerd runtime, Antrea doesn't depend on rancher-wins when running agent. So the agent log files should start with "antrea-agent".

This change has removed the prefix "rancher-wins" in the file name filters when collecting agent logs on Windows.

Fix: #6222 