### PR TITLE
Increase default rate limit of antrea-controller

### DIFF
--- a/cmd/antrea-controller/options.go
+++ b/cmd/antrea-controller/options.go
@@ -31,6 +31,13 @@ import (
 )
 
 const (
+	// Use higher QPS and Burst rather than the default settings (QPS: 5, Burst: 10), otherwise synchronizing resources
+	// like ClusterNetworkPolicies and Egresses would be rather slow when they are created in bulk.
+	// The following values are recommended by RecommendedDefaultClientConnectionConfiguration.
+	// https://github.com/kubernetes/kubernetes/blob/b722d017a34b300a2284b890448e5a605f21d01e/staging/src/k8s.io/component-base/config/v1alpha1/defaults.go#L65-L75
+	defaultClientQPS   = 50
+	defaultClientBurst = 100
+
 	ipamIPv4MaskLo      = 16
 	ipamIPv4MaskHi      = 30
 	ipamIPv4MaskDefault = 24
@@ -193,6 +200,12 @@ func (o *Options) setDefaults() {
 	}
 	if o.config.IPsecCSRSignerConfig.AutoApprove == nil {
 		o.config.IPsecCSRSignerConfig.AutoApprove = ptrBool(true)
+	}
+	if o.config.ClientConnection.QPS == 0.0 {
+		o.config.ClientConnection.QPS = defaultClientQPS
+	}
+	if o.config.ClientConnection.Burst == 0 {
+		o.config.ClientConnection.Burst = defaultClientBurst
 	}
 }
 

--- a/cmd/antrea-controller/options_test.go
+++ b/cmd/antrea-controller/options_test.go
@@ -33,6 +33,8 @@ func TestNewOptions(t *testing.T) {
 	assert.Equal(t, ipamIPv6MaskDefault, op.config.NodeIPAM.NodeCIDRMaskSizeIPv6)
 	assert.Equal(t, true, *op.config.IPsecCSRSignerConfig.SelfSignedCA)
 	assert.Equal(t, true, *op.config.IPsecCSRSignerConfig.AutoApprove)
+	assert.EqualValues(t, defaultClientQPS, op.config.ClientConnection.QPS)
+	assert.EqualValues(t, defaultClientBurst, op.config.ClientConnection.Burst)
 }
 
 func TestValidateNodeIPAMControllerOptions(t *testing.T) {


### PR DESCRIPTION
Using higher QPS and Burst rather than the default settings (QPS: 5, Burst: 10), otherwise synchronizing resources like ClusterNetworkPolicies and Egresses would be rather slow when they are created in bulk.