### PR TITLE
Request basic memory for antrea-controller

### DIFF
--- a/build/charts/antrea/README.md
+++ b/build/charts/antrea/README.md
@@ -73,7 +73,7 @@ Kubernetes: `>= 1.16.0-0`
 | controller.antreaController.extraEnv | object | `{}` | Extra environment variables to be injected into antrea-controller. |
 | controller.antreaController.logFileMaxNum | int | `4` | Max number of log files. |
 | controller.antreaController.logFileMaxSize | int | `100` | Max size in MBs of any single log file. |
-| controller.antreaController.resources | object | `{"requests":{"cpu":"200m"}}` | Resource requests and limits for the antrea-controller container. |
+| controller.antreaController.resources | object | `{"requests":{"cpu":"200m","memory":"100Mi"}}` | Resource requests and limits for the antrea-controller container. |
 | controller.apiNodePort | int | `0` | NodePort for the antrea-controller APIServer to server on. |
 | controller.apiPort | int | `10349` | Port for the antrea-controller APIServer to serve on. |
 | controller.enablePrometheusMetrics | bool | `true` | Enable metrics exposure via Prometheus. |

--- a/build/charts/antrea/values.yaml
+++ b/build/charts/antrea/values.yaml
@@ -373,6 +373,7 @@ controller:
     resources:
       requests:
         cpu: "200m"
+        memory: "100Mi"
 
 flowExporter:
   # -- Enable the flow exporter feature.

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -7070,6 +7070,7 @@ spec:
           resources:
             requests:
               cpu: 200m
+              memory: 100Mi
           command: ["antrea-controller"]
           # Log to both "/var/log/antrea/" and stderr (so "kubectl logs" can work).
           args:

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -7071,6 +7071,7 @@ spec:
           resources:
             requests:
               cpu: 200m
+              memory: 100Mi
           command: ["antrea-controller"]
           # Log to both "/var/log/antrea/" and stderr (so "kubectl logs" can work).
           args:

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -7068,6 +7068,7 @@ spec:
           resources:
             requests:
               cpu: 200m
+              memory: 100Mi
           command: ["antrea-controller"]
           # Log to both "/var/log/antrea/" and stderr (so "kubectl logs" can work).
           args:

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -7127,6 +7127,7 @@ spec:
           resources:
             requests:
               cpu: 200m
+              memory: 100Mi
           command: ["antrea-controller"]
           # Log to both "/var/log/antrea/" and stderr (so "kubectl logs" can work).
           args:

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -7068,6 +7068,7 @@ spec:
           resources:
             requests:
               cpu: 200m
+              memory: 100Mi
           command: ["antrea-controller"]
           # Log to both "/var/log/antrea/" and stderr (so "kubectl logs" can work).
           args:


### PR DESCRIPTION
Starting with [K8s v1.22](https://github.com/kubernetes/kubernetes/pull/99729), system-cluster-critical Pods no longer get low OOM score like system-node-critical Pods. antrea-controller's OOM score adjustment was changed from -997 to 999 passively, which made it just have a bit higher chance of survival over best-effort Pods (OOM score adjustment: 1000). While it's hard to say how much memory it can use as it's highly related to the scale of the cluster, we can add a basic memory request which can decrease the score a bit according to [the formula for burstable Pods](https://github.com/kubernetes/kubernetes/blob/d831b13e6f6fb5efb566100286190fedca6dd340/pkg/kubelet/qos/policy.go#L71):

  oomScoreAdjust := 1000 - (1000*memoryRequest)/memoryCapacity

It should also be a bit helpful to avoid antrea-controller to be scheduled on a Node with very few available memory.