### PR TITLE
Change sftp image URL to github container registry

### DIFF
--- a/hack/externalnode/sftp-deployment.yml
+++ b/hack/externalnode/sftp-deployment.yml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: sftp
-        image: antrea/sftp
+        image: ghcr.io/atmoz/sftp/debian:latest
         imagePullPolicy: IfNotPresent
         args: ["foo:pass:::upload"]
 


### PR DESCRIPTION
We don't have any intro for the image in Dockerhub, there is no clue for the args usage. So add the link to the original image.

@antoninbas do you think we can also add a reference link in the Dockerhub? and another thing is for the image sync, looks like the image in our repo is 9 months ago.