### PR TITLE
Mark v1alpha2.Egress as deprecated

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -31,7 +31,7 @@ These are the CRDs currently available in `crd.antrea.io`.
 | `ClusterGroup` | v1alpha3 | v1.1.0 | v1.13.0 | N/A |
 | `ClusterGroup` | v1beta1 | v1.13.0 | N/A | N/A |
 | `ClusterNetworkPolicy` | v1beta1 | v1.13.0 | N/A | N/A |
-| `Egress` | v1alpha2 | v1.0.0 | N/A | N/A |
+| `Egress` | v1alpha2 | v1.0.0 | v2.0.0 | v2.3.0 |
 | `Egress` | v1beta1 | v1.13.0 | N/A | N/A |
 | `ExternalEntity` | v1alpha2 | v1.0.0 | N/A | N/A |
 | `ExternalIPPool` | v1alpha2 | v1.2.0 | v1.13.0 | N/A |


### PR DESCRIPTION
With a scheduled removal in Antrea v2.3.0