### PR TITLE
Remove incorrect AntreaProxy warning on Windows

### DIFF
--- a/cmd/antrea-agent/options.go
+++ b/cmd/antrea-agent/options.go
@@ -604,6 +604,12 @@ func (o *Options) validateK8sNodeOptions() error {
 		return fmt.Errorf("failed to validate secondary network config: %v", err)
 	}
 
+	// Unlike checkUnsupportedFeatures, validateConfigForPlatform runs after all validations and
+	// after all fields in the Options struct have been initialized (e.g., enableProxy).
+	if err := o.validateConfigForPlatform(); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/cmd/antrea-agent/options_linux.go
+++ b/cmd/antrea-agent/options_linux.go
@@ -25,3 +25,8 @@ func (o *Options) checkUnsupportedFeatures() error {
 	// All features are supported on a Linux Node.
 	return nil
 }
+
+func (o *Options) validateConfigForPlatform() error {
+	// No additional validations for Linux Nodes.
+	return nil
+}


### PR DESCRIPTION
The code was logging an incorrect warning about AntreaProxy being disabled. This is is because checkUnsupportedFeatures was in charge of the check, but o.enableAntreaProxy is set later in the validation chain. To avoid the issue, we introduce a new function for platform-specific checks, validateConfigForPlatform, which runs after all other validations and after all fields in the Options struct have been set.

We also replace the warning message with an error message (but we do not fail Agent initialization) and we add a check for proxyAll.