### PR TITLE
Fix antrea-agent crashing with proxyAll enabled in networkPolicyOnly mode

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -730,7 +730,12 @@ func (i *Initializer) configureGatewayInterface(gatewayIface *interfacestore.Int
 			klog.ErrorS(err, "Failed to persist interface MAC address", "interface", gatewayIface.InterfaceName, "mac", gwMAC)
 		}
 	}
-	i.nodeConfig.GatewayConfig = &config.GatewayConfig{Name: i.hostGateway, MAC: gwMAC, OFPort: uint32(gatewayIface.OFPort)}
+	i.nodeConfig.GatewayConfig = &config.GatewayConfig{
+		Name:      i.hostGateway,
+		MAC:       gwMAC,
+		LinkIndex: gwLinkIdx,
+		OFPort:    uint32(gatewayIface.OFPort),
+	}
 	gatewayIface.IPs = []net.IP{}
 	if i.networkConfig.TrafficEncapMode.IsNetworkPolicyOnly() {
 		// Assign IP to gw as required by SpoofGuard.
@@ -746,7 +751,6 @@ func (i *Initializer) configureGatewayInterface(gatewayIface *interfacestore.Int
 		return nil
 	}
 
-	i.nodeConfig.GatewayConfig.LinkIndex = gwLinkIdx
 	// Allocate the gateway IP address for each Pod CIDR allocated to the Node. For each CIDR,
 	// the first address in the subnet is assigned to the host gateway interface.
 	podCIDRs := []*net.IPNet{i.nodeConfig.PodIPv4CIDR, i.nodeConfig.PodIPv6CIDR}


### PR DESCRIPTION
In networkPolicyOnly mode and proxyAll is enabled, the ifindex of antrea-gw0 in `nodeConfig`
is uninitialized, resulting in the failure to install the ip neighbor to antrea-gw0 due to
the fact that the ifindex of antrea-gw0 is wrong. Additionally, the ipsets storing the pairs
of Node IP and NodePort are not initialized and periodically synced. Consequently, this results
in the failure to sync the iptables rules that referring to the ipsets.