### PR TITLE
Fix base image for antrea/antrea-controller-ubi

### DIFF
--- a/build/images/Dockerfile.build.controller.ubi
+++ b/build/images/Dockerfile.build.controller.ubi
@@ -54,7 +54,7 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=cache,target=/root/.cache/go-build/ \
     make antrea-controller
 
-FROM ubuntu:22.04
+FROM registry.access.redhat.com/ubi8
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="The Docker image to deploy the antrea-controller."

--- a/hack/build-antrea-linux-all.sh
+++ b/hack/build-antrea-linux-all.sh
@@ -69,7 +69,7 @@ case $key in
     ;;
     --skip-unified-image)
     UNIFIED=false
-    shift 2
+    shift
     ;;
     -h|--help)
     print_usage


### PR DESCRIPTION
The image was incorrectly using ubuntu:22.04 as the base image instead of registry.access.redhat.com/ubi8. This issue must have been present since introducing split images for the Agent and Controller in v1.15.0.

Credit goes to @xliuxu for finding this issue.