### PR TITLE
Skip IPSec/WireGuard e2e test when the Multicast feature is enabled

### DIFF
--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -159,6 +159,16 @@ func skipIfNoVMs(tb testing.TB) {
 	}
 }
 
+func skipIfMulticastEnabled(tb testing.TB, data *TestData) {
+	agentConf, err := data.GetAntreaAgentConf()
+	if err != nil {
+		tb.Fatalf("Error getting option multicast.enable value")
+	}
+	if agentConf.Multicast.Enable {
+		tb.Skipf("Skipping test because option multicast.enable is true")
+	}
+}
+
 func skipIfFeatureDisabled(tb testing.TB, feature featuregate.Feature, checkAgent bool, checkController bool) {
 	if checkAgent {
 		if featureGate, err := GetAgentFeatures(); err != nil {

--- a/test/e2e/ipsec_test.go
+++ b/test/e2e/ipsec_test.go
@@ -42,6 +42,7 @@ func TestIPSec(t *testing.T) {
 		t.Fatalf("Error when setting up test: %v", err)
 	}
 	defer teardownTest(t, data)
+	skipIfMulticastEnabled(t, data)
 
 	t.Logf("Redeploy Antrea with IPsec tunnel enabled")
 	data.redeployAntrea(t, deployAntreaIPsec)

--- a/test/e2e/wireguard_test.go
+++ b/test/e2e/wireguard_test.go
@@ -40,17 +40,15 @@ func TestWireGuard(t *testing.T) {
 		t.Fatalf("Error when setting up test: %v", err)
 	}
 	defer teardownTest(t, data)
+	skipIfMulticastEnabled(t, data)
 	skipIfEncapModeIsNot(t, data, config.TrafficEncapModeEncap)
 	for _, node := range clusterInfo.nodes {
 		skipIfMissingKernelModule(t, data, node.name, []string{"wireguard"})
 	}
 	var previousTrafficEncryptionMode string
-	var previousMulticastEnabledState bool
 	ac := func(config *agentconfig.AgentConfig) {
 		previousTrafficEncryptionMode = config.TrafficEncryptionMode
 		config.TrafficEncryptionMode = "wireguard"
-		previousMulticastEnabledState = config.Multicast.Enable
-		config.Multicast.Enable = false
 	}
 	if err := data.mutateAntreaConfigMap(nil, ac, false, true); err != nil {
 		t.Fatalf("Failed to enable WireGuard tunnel: %v", err)
@@ -58,7 +56,6 @@ func TestWireGuard(t *testing.T) {
 	defer func() {
 		ac := func(config *agentconfig.AgentConfig) {
 			config.TrafficEncryptionMode = previousTrafficEncryptionMode
-			config.Multicast.Enable = previousMulticastEnabledState
 		}
 		if err := data.mutateAntreaConfigMap(nil, ac, false, true); err != nil {
 			t.Errorf("Failed to disable WireGuard tunnel: %v", err)


### PR DESCRIPTION
This is an e2e fix because of PR #5920.