### PR TITLE
Ignore failure when running 'kubectl cp'

### DIFF
--- a/ci/jenkins/test-mc.sh
+++ b/ci/jenkins/test-mc.sh
@@ -468,7 +468,8 @@ function collect_coverage {
       kubectl exec -i $mc_controller_pod_name -n ${namespace} ${kubeconfig} -- kill -SIGINT $controller_pid
       cov_dir="${COVERAGE_DIR}/$mc_controller_pod_name-$timestamp"
       mkdir -p $cov_dir
-      kubectl cp ${namespace}/$mc_controller_pod_name:/tmp/coverage/* $cov_dir/ ${kubeconfig}
+      sleep 1s
+      kubectl cp ${namespace}/$mc_controller_pod_name:/tmp/coverage/* $cov_dir/ ${kubeconfig} || true
       go tool covdata textfmt -i="${cov_dir}" -o "${cov_dir}.cov.out"
       rm -rf "${cov_dir}"
     done

--- a/ci/jenkins/test-vmc.sh
+++ b/ci/jenkins/test-vmc.sh
@@ -627,7 +627,8 @@ function collect_coverage() {
         timestamp=$(date +%Y%m%d%H%M%S)
         cov_dir="${GIT_CHECKOUT_DIR}/conformance-coverage/$antrea_controller_pod_name-$timestamp"
         mkdir -p $cov_dir
-        kubectl cp kube-system/$antrea_controller_pod_name:/tmp/coverage/* $cov_dir/
+        sleep 1s
+        kubectl cp kube-system/$antrea_controller_pod_name:/tmp/coverage/* $cov_dir/ || true
         go tool covdata textfmt -i="${cov_dir}" -o "${cov_dir}.cov.out"
         rm -rf "${cov_dir}"
 
@@ -639,7 +640,8 @@ function collect_coverage() {
             timestamp=$(date +%Y%m%d%H%M%S)
             cov_dir="${GIT_CHECKOUT_DIR}/conformance-coverage/$agent-$timestamp"
             mkdir -p $cov_dir
-            kubectl cp kube-system/$agent:/tmp/coverage/* -c antrea-agent $cov_dir/
+            sleep 1s
+            kubectl cp kube-system/$agent:/tmp/coverage/* -c antrea-agent $cov_dir/ || true
             go tool covdata textfmt -i="${cov_dir}" -o "${cov_dir}.cov.out"
             rm -rf "${cov_dir}"
         done


### PR DESCRIPTION
In some CI jobs, e.g. `whole-conformance`, a failure `tar: antrea-agent.cov.out: file changed as we read it` happened occasionally, the failure is caused by `kubectl cp`, this actually a warning from `tar` and can be ignored instead of failing the job since the test is actually passed.