### PR TITLE
Fix antctl mc deploy command usage

### DIFF
--- a/pkg/antctl/raw/multicluster/deploy/deploy_helper.go
+++ b/pkg/antctl/raw/multicluster/deploy/deploy_helper.go
@@ -56,7 +56,7 @@ func generateManifests(role string, version string) ([]string, error) {
 	var manifests []string
 	if version != "latest" && !strings.HasPrefix(version, "v") {
 		version = fmt.Sprintf("v%s", version)
-	} 
+	}
 	switch role {
 	case leaderRole:
 		manifests = []string{

--- a/pkg/antctl/raw/multicluster/deploy/deploy_helper.go
+++ b/pkg/antctl/raw/multicluster/deploy/deploy_helper.go
@@ -17,6 +17,7 @@ package deploy
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -91,6 +92,9 @@ func createResources(cmd *cobra.Command, apiGroupResources []*restmapper.APIGrou
 
 		obj, gvk, err := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme).Decode(rawObj.Raw, nil, nil)
 		if err != nil {
+			if string(content) == "Not Found" {
+				return errors.New("specified version tag is not found")
+			}
 			return err
 		}
 		unstructuredMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
@@ -169,6 +173,11 @@ func deploy(cmd *cobra.Command, role string, version string, namespace string, f
 			return err
 		}
 	} else {
+		if version != "latest" {
+			if !strings.HasPrefix(version, "v") {
+				version = fmt.Sprintf("v%s", version)
+			}
+		} 
 		manifests, err := generateManifests(role, version)
 		if err != nil {
 			return err

--- a/pkg/antctl/raw/multicluster/deploy/deploy_helper_test.go
+++ b/pkg/antctl/raw/multicluster/deploy/deploy_helper_test.go
@@ -85,6 +85,22 @@ func TestGenerateManifests(t *testing.T) {
 			},
 		},
 		{
+			name:    "generate versioned leader manifests without the prefix v in the version",
+			role:    "leader",
+			version: "1.14.0",
+			expectedManifests: []string{
+				"https://github.com/antrea-io/antrea/releases/download/v1.14.0/antrea-multicluster-leader.yml",
+			},
+		},
+		{
+			name:    "generate versioned member manifests without the prefix v in the version",
+			role:    "member",
+			version: "1.14.0",
+			expectedManifests: []string{
+				"https://github.com/antrea-io/antrea/releases/download/v1.14.0/antrea-multicluster-member.yml",
+			},
+		},
+		{
 			name:        "invalid role",
 			role:        "member1",
 			version:     "latest",


### PR DESCRIPTION
This patch ensures that `v` is optional in the version tag and improves the error message if the specified version tag is not found.

If someone provide an invalid tag the error message would be,

```
$ ./bin/antctl mc  deploy leadercluster -n antrea-multicluster --antrea-version 2.15.0
Error: specified version tag is not found
```

This PR addresses the issue #6151