### PR TITLE
Optimize disk space usage in CI by pruning all unused Docker images

### DIFF
--- a/ci/jenkins/test-mc.sh
+++ b/ci/jenkins/test-mc.sh
@@ -136,7 +136,7 @@ function clean_tmp() {
 function clean_images() {
     docker images --format "{{.Repository}}:{{.Tag}}" | grep -E 'mc-controller|antrea-ubuntu' | xargs -r docker rmi -f || true
     # Clean up dangling images generated in previous builds.
-    docker image prune -f --filter "until=24h" || true > /dev/null
+    docker image prune -af --filter "until=24h" || true > /dev/null
     check_and_cleanup_docker_build_cache
 }
 

--- a/ci/test-conformance-aks.sh
+++ b/ci/test-conformance-aks.sh
@@ -191,7 +191,7 @@ function deliver_antrea_to_aks() {
     fi
     # Clean up dangling images generated in previous builds. Recent ones must be excluded
     # because they might be being used in other builds running simultaneously.
-    docker image prune -f --filter "until=2h" > /dev/null
+    docker image prune -af --filter "until=2h" > /dev/null
     docker system df -v
     check_and_cleanup_docker_build_cache
 

--- a/ci/test-conformance-eks.sh
+++ b/ci/test-conformance-eks.sh
@@ -268,7 +268,7 @@ function deliver_antrea_to_eks() {
     fi
     # Clean up dangling images generated in previous builds. Recent ones must be excluded
     # because they might be being used in other builds running simultaneously.
-    docker image prune -f --filter "until=2h" > /dev/null
+    docker image prune -af --filter "until=2h" > /dev/null
     docker system df -v
     check_and_cleanup_docker_build_cache
     set -e

--- a/ci/test-conformance-gke.sh
+++ b/ci/test-conformance-gke.sh
@@ -216,7 +216,7 @@ function deliver_antrea_to_gke() {
     fi
     # Clean up dangling images generated in previous builds. Recent ones must be excluded
     # because they might be being used in other builds running simultaneously.
-    docker image prune -f --filter "until=2h" > /dev/null
+    docker image prune -af --filter "until=2h" > /dev/null
     docker system df -v
     check_and_cleanup_docker_build_cache
     set -e


### PR DESCRIPTION
Update Docker image pruning command to remove all unused Docker images, not just the dangling ones to optimize the disk space utilization.