### PR TITLE
Minor fix to start_ovs script when bridging mode is enabled

### DIFF
--- a/build/images/scripts/start_ovs
+++ b/build/images/scripts/start_ovs
@@ -130,9 +130,12 @@ function quit {
     # been restored. The uplink is moved to the OVS bridge to support AntreaFlexibleIPAM mode.
     while [ "`ovsdb-client dump Port|grep antrea-type=uplink`" != "" ]; do
       log_info $CONTAINER_NAME "Uplink found on OVS, wait 1s and retry..."
-      sleep 1 &
-      SLEEP_PID=$!
-      wait $SLEEP_PID
+      # If a second signal (besides SIGKILL) is received, bash will wait for the
+      # sleep to complete, and this function will run again. There is no point
+      # in running sleep in the background here (and using wait): it would just
+      # create extra "concurrent" sleep processes in case multiple signals are
+      # received.
+      sleep 1
     done
     stop_ovs
     # terminate background sleep process


### PR DESCRIPTION
The SLEEP_PID variable (used to store the PID of the sleep process started by the "main" loop) was being overwritten in the signal handler. The 1-second sleep which runs in the signal handler and wait for uplink port deletion (when bridging mode is enabled) does not need to run in the background.