### PR TITLE
Ensure full functionality of AntreaProxy with proxyAll enabled when kube-proxy presents

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -170,6 +170,7 @@ jobs:
           --coverage \
           --encap-mode encap \
           --proxy-all \
+          --no-kube-proxy \
           --feature-gates LoadBalancerModeDSR=true \
           --load-balancer-mode dsr \
           --node-ipam

--- a/docs/antrea-proxy.md
+++ b/docs/antrea-proxy.md
@@ -42,13 +42,22 @@ the introduction of `proxyAll`, Antrea relied on userspace kube-proxy, which is
 no longer actively maintained by the K8s community and is slower than other
 kube-proxy backends.
 
-Note that on Linux, even when `proxyAll` is enabled, kube-proxy will usually
-take priority and will keep handling NodePort Service traffic (unless the source
-is a Pod, which is pretty unusual as Pods typically access Services by
-ClusterIP). This is because kube-proxy rules typically come before the rules
-installed by AntreaProxy to redirect traffic to OVS. When kube-proxy is not
-deployed or is removed from the cluster, AntreaProxy will then handle all
-Service traffic.
+Note that on Linux, before Antrea v2.1, when `proxyAll` is enabled, kube-proxy
+will usually take priority over AntreaProxy and will keep handling all kinds of
+Service traffic (unless the source is a Pod, which is pretty unusual as Pods
+typically access Services by ClusterIP). This is because kube-proxy rules typically
+come before the rules installed by AntreaProxy to redirect traffic to OVS. When
+kube-proxy is not deployed or is removed from the cluster, AntreaProxy will then
+handle all Service traffic.
+
+Starting with Antrea v2.1, when `proxyAll` is enabled, AntreaProxy will handle
+Service traffic destined to NodePort, LoadBalancerIP and ExternalIP, even if
+kube-proxy is present. This benefits users who want to take advantage of
+AntreaProxy's advanced features, such as Direct Server Return (DSR) mode, but
+lack control over kube-proxy's installation. This is accomplished by
+prioritizing the rules installed by AntreaProxy over those installed by
+kube-proxy, thus it works only with kube-proxy iptables mode. Support for other
+kube-proxy modes may be added in the future.
 
 ### Removing kube-proxy
 

--- a/pkg/agent/route/interfaces.go
+++ b/pkg/agent/route/interfaces.go
@@ -76,17 +76,19 @@ type Interface interface {
 	// DeleteEgressRule deletes the IP rule installed by AddEgressRule.
 	DeleteEgressRule(tableID uint32, mark uint32) error
 
-	// AddNodePort adds configurations when a NodePort Service is created.
-	AddNodePort(nodePortAddresses []net.IP, port uint16, protocol binding.Protocol) error
+	// AddNodePortConfigs adds routing configurations for redirecting traffic to OVS when a NodePort Service is created.
+	AddNodePortConfigs(nodePortAddresses []net.IP, port uint16, protocol binding.Protocol) error
 
-	// DeleteNodePort deletes related configurations when a NodePort Service is deleted.
-	DeleteNodePort(nodePortAddresses []net.IP, port uint16, protocol binding.Protocol) error
+	// DeleteNodePortConfigs deletes corresponding routing configurations when a NodePort Service is deleted.
+	DeleteNodePortConfigs(nodePortAddresses []net.IP, port uint16, protocol binding.Protocol) error
 
-	// AddExternalIPRoute adds a route entry when an external IP is added.
-	AddExternalIPRoute(externalIP net.IP) error
+	// AddExternalIPConfigs adds routing configurations for redirecting traffic to OVS when an external Service IP
+	// (externalIP or LoadBalancerIP) is created.
+	AddExternalIPConfigs(svcInfoStr string, externalIP net.IP) error
 
-	// DeleteExternalIPRoute deletes the related route entry when an external IP is deleted.
-	DeleteExternalIPRoute(externalIP net.IP) error
+	// DeleteExternalIPConfigs deletes corresponding routing configurations for redirecting traffic to OVS when an
+	// external Service IP (externalIP or LoadBalancerIP) is deleted.
+	DeleteExternalIPConfigs(svcInfoStr string, externalIP net.IP) error
 
 	// Run starts the sync loop.
 	Run(stopCh <-chan struct{})

--- a/pkg/agent/route/testing/mock_route.go
+++ b/pkg/agent/route/testing/mock_route.go
@@ -85,18 +85,18 @@ func (mr *MockInterfaceMockRecorder) AddEgressRule(arg0, arg1 any) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddEgressRule", reflect.TypeOf((*MockInterface)(nil).AddEgressRule), arg0, arg1)
 }
 
-// AddExternalIPRoute mocks base method.
-func (m *MockInterface) AddExternalIPRoute(arg0 net.IP) error {
+// AddExternalIPConfigs mocks base method.
+func (m *MockInterface) AddExternalIPConfigs(arg0 string, arg1 net.IP) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddExternalIPRoute", arg0)
+	ret := m.ctrl.Call(m, "AddExternalIPConfigs", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// AddExternalIPRoute indicates an expected call of AddExternalIPRoute.
-func (mr *MockInterfaceMockRecorder) AddExternalIPRoute(arg0 any) *gomock.Call {
+// AddExternalIPConfigs indicates an expected call of AddExternalIPConfigs.
+func (mr *MockInterfaceMockRecorder) AddExternalIPConfigs(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddExternalIPRoute", reflect.TypeOf((*MockInterface)(nil).AddExternalIPRoute), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddExternalIPConfigs", reflect.TypeOf((*MockInterface)(nil).AddExternalIPConfigs), arg0, arg1)
 }
 
 // AddLocalAntreaFlexibleIPAMPodRule mocks base method.
@@ -113,18 +113,18 @@ func (mr *MockInterfaceMockRecorder) AddLocalAntreaFlexibleIPAMPodRule(arg0 any)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddLocalAntreaFlexibleIPAMPodRule", reflect.TypeOf((*MockInterface)(nil).AddLocalAntreaFlexibleIPAMPodRule), arg0)
 }
 
-// AddNodePort mocks base method.
-func (m *MockInterface) AddNodePort(arg0 []net.IP, arg1 uint16, arg2 openflow.Protocol) error {
+// AddNodePortConfigs mocks base method.
+func (m *MockInterface) AddNodePortConfigs(arg0 []net.IP, arg1 uint16, arg2 openflow.Protocol) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddNodePort", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "AddNodePortConfigs", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// AddNodePort indicates an expected call of AddNodePort.
-func (mr *MockInterfaceMockRecorder) AddNodePort(arg0, arg1, arg2 any) *gomock.Call {
+// AddNodePortConfigs indicates an expected call of AddNodePortConfigs.
+func (mr *MockInterfaceMockRecorder) AddNodePortConfigs(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddNodePort", reflect.TypeOf((*MockInterface)(nil).AddNodePort), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddNodePortConfigs", reflect.TypeOf((*MockInterface)(nil).AddNodePortConfigs), arg0, arg1, arg2)
 }
 
 // AddOrUpdateNodeNetworkPolicyIPSet mocks base method.
@@ -239,18 +239,18 @@ func (mr *MockInterfaceMockRecorder) DeleteEgressRule(arg0, arg1 any) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteEgressRule", reflect.TypeOf((*MockInterface)(nil).DeleteEgressRule), arg0, arg1)
 }
 
-// DeleteExternalIPRoute mocks base method.
-func (m *MockInterface) DeleteExternalIPRoute(arg0 net.IP) error {
+// DeleteExternalIPConfigs mocks base method.
+func (m *MockInterface) DeleteExternalIPConfigs(arg0 string, arg1 net.IP) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteExternalIPRoute", arg0)
+	ret := m.ctrl.Call(m, "DeleteExternalIPConfigs", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// DeleteExternalIPRoute indicates an expected call of DeleteExternalIPRoute.
-func (mr *MockInterfaceMockRecorder) DeleteExternalIPRoute(arg0 any) *gomock.Call {
+// DeleteExternalIPConfigs indicates an expected call of DeleteExternalIPConfigs.
+func (mr *MockInterfaceMockRecorder) DeleteExternalIPConfigs(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteExternalIPRoute", reflect.TypeOf((*MockInterface)(nil).DeleteExternalIPRoute), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteExternalIPConfigs", reflect.TypeOf((*MockInterface)(nil).DeleteExternalIPConfigs), arg0, arg1)
 }
 
 // DeleteLocalAntreaFlexibleIPAMPodRule mocks base method.
@@ -295,18 +295,18 @@ func (mr *MockInterfaceMockRecorder) DeleteNodeNetworkPolicyIPTables(arg0, arg1 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNodeNetworkPolicyIPTables", reflect.TypeOf((*MockInterface)(nil).DeleteNodeNetworkPolicyIPTables), arg0, arg1)
 }
 
-// DeleteNodePort mocks base method.
-func (m *MockInterface) DeleteNodePort(arg0 []net.IP, arg1 uint16, arg2 openflow.Protocol) error {
+// DeleteNodePortConfigs mocks base method.
+func (m *MockInterface) DeleteNodePortConfigs(arg0 []net.IP, arg1 uint16, arg2 openflow.Protocol) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteNodePort", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "DeleteNodePortConfigs", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// DeleteNodePort indicates an expected call of DeleteNodePort.
-func (mr *MockInterfaceMockRecorder) DeleteNodePort(arg0, arg1, arg2 any) *gomock.Call {
+// DeleteNodePortConfigs indicates an expected call of DeleteNodePortConfigs.
+func (mr *MockInterfaceMockRecorder) DeleteNodePortConfigs(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNodePort", reflect.TypeOf((*MockInterface)(nil).DeleteNodePort), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNodePortConfigs", reflect.TypeOf((*MockInterface)(nil).DeleteNodePortConfigs), arg0, arg1, arg2)
 }
 
 // DeleteRouteForLink mocks base method.

--- a/pkg/agent/util/iptables/testing/mock_iptables_linux.go
+++ b/pkg/agent/util/iptables/testing/mock_iptables_linux.go
@@ -140,18 +140,18 @@ func (mr *MockInterfaceMockRecorder) InsertRule(arg0, arg1, arg2, arg3 any) *gom
 }
 
 // ListRules mocks base method.
-func (m *MockInterface) ListRules(arg0, arg1 string) ([]string, error) {
+func (m *MockInterface) ListRules(arg0 iptables.Protocol, arg1, arg2 string) (map[iptables.Protocol][]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListRules", arg0, arg1)
-	ret0, _ := ret[0].([]string)
+	ret := m.ctrl.Call(m, "ListRules", arg0, arg1, arg2)
+	ret0, _ := ret[0].(map[iptables.Protocol][]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListRules indicates an expected call of ListRules.
-func (mr *MockInterfaceMockRecorder) ListRules(arg0, arg1 any) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) ListRules(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRules", reflect.TypeOf((*MockInterface)(nil).ListRules), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRules", reflect.TypeOf((*MockInterface)(nil).ListRules), arg0, arg1, arg2)
 }
 
 // Restore mocks base method.


### PR DESCRIPTION
Depends on #6381

Resolve #6232

To ensure full functionality of AntreaProxy, except for handling ClusterIP from Nodes,
even when kube-proxy in iptables mode is present, certain key changes are implemented
when proxyAll is enabled:

The jump rules for the chains managed by Antrea, `ANTREA-PREROUTING` and `ANTREA-OUTPUT`
in nat table, are installed by inserting instead of appending to bypass the chain
`KUBE-SERVICES` performing Service DNAT managed by kube-proxy. Antrea ensures that
the jump rules take precedence over those managed by kube-proxy.

The iptables rules of nat table chain `ANTREA-PREROUTING` are like below, and they are
similar in chain `ANTREA-OUTPUT`.

```
-A ANTREA-PREROUTING -m comment --comment "Antrea: DNAT external to NodePort packets" -m set --match-set ANTREA-NODEPORT-IP dst,dst -j DNAT --to-destination 169.254.0.252
```

The rule is to DNAT NodePort traffic, bypassing chain `KUBE-SERVICES`.

The iptables rules of raw table chains ANTREA-PREROUTING / ANTREA-OUTPUT are like
below:

```
1. -A ANTREA-PREROUTING -m comment --comment "Antrea: do not track incoming encapsulation packets" -m udp -p udp --dport 6081 -m addrtype --dst-type LOCAL -j NOTRACK
2. -A ANTREA-PREROUTING -m comment --comment "Antrea: drop Pod multicast traffic forwarded via underlay network" -m set --match-set CLUSTER-NODE-IP src -d 224.0.0.0/4 -j DROP
3. -A ANTREA-PREROUTING -m comment --comment "Antrea: do not track request packets destined to external IPs" -m set --match-set ANTREA-EXTERNAL-IP dst -j NOTRACK
4. -A ANTREA-PREROUTING -m comment --comment "Antrea: do not track reply packets sourced from external IPs" -m set --match-set ANTREA-EXTERNAL-IP src -j NOTRACK
5. -A ANTREA-OUTPUT -m comment --comment "Antrea: do not track request packets destined to external IPs" -m set --match-set ANTREA-EXTERNAL-IP dst -j NOTRACK
```

- Rules 1-2 are not new rules.
- Rule 3 is to bypass conntrack for packets sourced from external and destined to
  externalIPs, which also results in bypassing the chains managed by Antrea Proxy
  and kube-proxy in nat table.
- Rule 4 is to bypass conntrack for packets sourced from externalIPs, which also
  results in bypassing the chains managed by Antrea Proxy and kube-proxy in nat
  table.
- Rule 5 is to bypass conntrack for packets sourced from local and destined to
  externalIPs, which also results in bypassing the chains managed by Antrea Proxy
  and kube-proxy in nat table.

The following are the benchmark results of a LoadBalancer Service configured with DSR mode.
The results of TCP_STREAM and TCP_RR (single TCP connection) are almost the same as that
before. The result of TCP_CRR (multiple TCP connections) performs better than before. One
reason should be that conntrack is skipped for LoadBalancer Services.

```
Test           v2.0 proxyAll     Dev proxyAll    Delta
TCP_STREAM     4933.97           4918.35         -0.32%
TCP_RR         8095.49           8032.4         -0.78%
TCP_CRR        1645.66           1888.93         +14.79%
```

TODO:

- [x] In iptables nat table, ensure that Antrea iptables chain `ANTREA-PREROUTING` and `ANTREA-OUTPUT` are in the first rule of corresponding default iptables chains to skip kube-proxy chains.
- [x] Add unit tests
- [x] Add e2e tests? Whether to add a new Kind test [proxyAll=true, LoadBalancerMode=DSR, NodeIPAM=true, kube-proxy presents]
- [x] Update related document.
- [x] Update manifests
- [x] PR / commit description
- [x] Benchmark of LoadBalancer