### PR TITLE
Enabling service connectivity tests in Post-installation testing framework

### DIFF
--- a/pkg/antctl/raw/check/installation/command.go
+++ b/pkg/antctl/raw/check/installation/command.go
@@ -331,13 +331,6 @@ func (t *testContext) setup(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("unable to create Deployment %s: %s", clientDeploymentName, err)
 	}
-
-	t.Log("Deploying echo-other-node Service %s...", echoOtherNodeDeploymentName)
-	svc = newService(echoOtherNodeDeploymentName, map[string]string{"name": echoOtherNodeDeploymentName}, 80)
-	_, err = t.client.CoreV1().Services(t.namespace).Create(ctx, svc, metav1.CreateOptions{})
-	if err != nil {
-		return err
-	}
 	echoOtherNodeDeployment := newDeployment(deploymentParameters{
 		Name:    echoOtherNodeDeploymentName,
 		Role:    kindEchoName,
@@ -366,6 +359,12 @@ func (t *testContext) setup(ctx context.Context) error {
 		return fmt.Errorf("unable to list Nodes: %s", err)
 	}
 	if len(nodes.Items) >= 2 {
+		t.Log("Deploying echo-other-node Service %s...", echoOtherNodeDeploymentName)
+		svc = newService(echoOtherNodeDeploymentName, map[string]string{"name": echoOtherNodeDeploymentName}, 80)
+		_, err = t.client.CoreV1().Services(t.namespace).Create(ctx, svc, metav1.CreateOptions{})
+		if err != nil {
+			return err
+		}
 		_, err = t.client.AppsV1().Deployments(t.namespace).Create(ctx, echoOtherNodeDeployment, metav1.CreateOptions{})
 		if err != nil {
 			return fmt.Errorf("unable to create Deployment %s: %s", echoOtherNodeDeploymentName, err)

--- a/pkg/antctl/raw/check/installation/test_podtoserviceinternode.go
+++ b/pkg/antctl/raw/check/installation/test_podtoserviceinternode.go
@@ -33,9 +33,7 @@ func (t *PodToServiceInterNodeConnectivityTest) Run(ctx context.Context, testCon
 	}
 	service := echoOtherNodeDeploymentName
 	for _, clientPod := range testContext.clientPods {
-		srcPod := testContext.namespace + "/" + clientPod.Name
-		dstService := testContext.namespace + "/" + service
-		testContext.Log("Validating from Pod %s to Service %s...", srcPod, dstService)
+		testContext.Log("Validating from Pod %s to Service %s in Namespace %s...", clientPod.Name, service, testContext.namespace)
 		_, _, err := check.ExecInPod(ctx, testContext.client, testContext.config, testContext.namespace, clientPod.Name, "", agnhostConnectCommand(service, "80"))
 		if err != nil {
 			return fmt.Errorf("client Pod %s was not able to communicate with Service %s", clientPod.Name, service)

--- a/pkg/antctl/raw/check/installation/test_podtoserviceinternode.go
+++ b/pkg/antctl/raw/check/installation/test_podtoserviceinternode.go
@@ -1,0 +1,46 @@
+// Copyright 2024 Antrea Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package installation
+
+import (
+	"context"
+	"fmt"
+
+	"antrea.io/antrea/pkg/antctl/raw/check"
+)
+
+type PodToServiceInterNodeConnectivityTest struct{}
+
+func init() {
+	RegisterTest("pod-to-service-internode-connectivity", &PodToServiceInterNodeConnectivityTest{})
+}
+
+func (t *PodToServiceInterNodeConnectivityTest) Run(ctx context.Context, testContext *testContext) error {
+	if testContext.echoOtherNodePod == nil {
+		return newNotRunnableError("Inter-Node test requires multiple Nodes")
+	}
+	service := echoOtherNodeDeploymentName
+	for _, clientPod := range testContext.clientPods {
+		srcPod := testContext.namespace + "/" + clientPod.Name
+		dstService := testContext.namespace + "/" + service
+		testContext.Log("Validating from Pod %s to Service %s...", srcPod, dstService)
+		_, _, err := check.ExecInPod(ctx, testContext.client, testContext.config, testContext.namespace, clientPod.Name, "", agnhostConnectCommand(service, "80"))
+		if err != nil {
+			return fmt.Errorf("client Pod %s was not able to communicate with Service %s", clientPod.Name, service)
+		}
+		testContext.Log("client Pod %s was able to communicate with Service %s", clientPod.Name, service)
+	}
+	return nil
+}

--- a/pkg/antctl/raw/check/installation/test_podtoserviceintranode.go
+++ b/pkg/antctl/raw/check/installation/test_podtoserviceintranode.go
@@ -30,9 +30,7 @@ func init() {
 func (t *PodToServiceIntraNodeConnectivityTest) Run(ctx context.Context, testContext *testContext) error {
 	service := echoSameNodeDeploymentName
 	for _, clientPod := range testContext.clientPods {
-		srcPod := testContext.namespace + "/" + clientPod.Name
-		dstService := testContext.namespace + "/" + service
-		testContext.Log("Validating from Pod %s to Service %s...", srcPod, dstService)
+		testContext.Log("Validating from Pod %s to Service %s in Namespace %s...", clientPod.Name, service, testContext.namespace)
 		_, _, err := check.ExecInPod(ctx, testContext.client, testContext.config, testContext.namespace, clientPod.Name, "", agnhostConnectCommand(service, "80"))
 		if err != nil {
 			return fmt.Errorf("client Pod %s was not able to communicate with Service %s", clientPod.Name, service)

--- a/pkg/antctl/raw/check/installation/test_podtoserviceintranode.go
+++ b/pkg/antctl/raw/check/installation/test_podtoserviceintranode.go
@@ -1,0 +1,43 @@
+// Copyright 2024 Antrea Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package installation
+
+import (
+	"context"
+	"fmt"
+
+	"antrea.io/antrea/pkg/antctl/raw/check"
+)
+
+type PodToServiceIntraNodeConnectivityTest struct{}
+
+func init() {
+	RegisterTest("pod-to-service-intranode-connectivity", &PodToServiceIntraNodeConnectivityTest{})
+}
+
+func (t *PodToServiceIntraNodeConnectivityTest) Run(ctx context.Context, testContext *testContext) error {
+	service := echoSameNodeDeploymentName
+	for _, clientPod := range testContext.clientPods {
+		srcPod := testContext.namespace + "/" + clientPod.Name
+		dstService := testContext.namespace + "/" + service
+		testContext.Log("Validating from Pod %s to Service %s...", srcPod, dstService)
+		_, _, err := check.ExecInPod(ctx, testContext.client, testContext.config, testContext.namespace, clientPod.Name, "", agnhostConnectCommand(service, "80"))
+		if err != nil {
+			return fmt.Errorf("client Pod %s was not able to communicate with Service %s", clientPod.Name, service)
+		}
+		testContext.Log("client Pod %s was able to communicate with Service %s", clientPod.Name, service)
+	}
+	return nil
+}


### PR DESCRIPTION
Ref #6061 
This PR Enables the testing framework to test Pod to service connectivity. 
It does it by connecting the client pod to 2 services. 1 service routes the traffic to Pod of same Node deployment and 1 service routes the traffic to Pod of other Node deployment.
Situations for single Node cluster is also handled.