### PR TITLE
Trim unneeded fields stored in informers to reduce memory footprint

### DIFF
--- a/cmd/antrea-controller/controller.go
+++ b/cmd/antrea-controller/controller.go
@@ -131,8 +131,8 @@ func run(o *Options) error {
 		return fmt.Errorf("error creating K8s clients: %v", err)
 	}
 	k8s.OverrideKubeAPIServer(o.config.KubeAPIServerOverride)
-	informerFactory := informers.NewSharedInformerFactory(client, informerDefaultResync)
-	crdInformerFactory := crdinformers.NewSharedInformerFactory(crdClient, informerDefaultResync)
+	informerFactory := informers.NewSharedInformerFactoryWithOptions(client, informerDefaultResync, informers.WithTransform(k8s.NewTrimmer(k8s.TrimPod)))
+	crdInformerFactory := crdinformers.NewSharedInformerFactoryWithOptions(crdClient, informerDefaultResync, crdinformers.WithTransform(k8s.NewTrimmer()))
 	policyInformerFactory := policyv1a1informers.NewSharedInformerFactory(policyClient, informerDefaultResync)
 	podInformer := informerFactory.Core().V1().Pods()
 	namespaceInformer := informerFactory.Core().V1().Namespaces()

--- a/pkg/util/k8s/transform.go
+++ b/pkg/util/k8s/transform.go
@@ -1,0 +1,91 @@
+// Copyright 2024 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/tools/cache"
+)
+
+// NewTrimmer returns a cache.TransformFunc that can be used to trim objects stored in informers.
+// The function must be idempotent before client-go v0.31.0 to avoid a race condition happening when objects were
+// accessed during Resync operation, see https://github.com/kubernetes/kubernetes/issues/124337.
+// But it's generally more efficient to avoid trimming the same object more than once.
+//
+// Note: be cautious when adding fields to be trimmed, ensuring they do not inadvertently clear the original values when
+// objects are updated by Antrea to kube-apiserver.
+func NewTrimmer(extraTrimmers ...cache.TransformFunc) cache.TransformFunc {
+	return func(obj interface{}) (interface{}, error) {
+		accessor, err := meta.Accessor(obj)
+		if err != nil {
+			return obj, nil
+		}
+		// It means the objects has been trimmed.
+		if accessor.GetManagedFields() == nil {
+			return obj, nil
+		}
+		// Trim common fields for all objects.
+		// According to https://kubernetes.io/docs/reference/using-api/server-side-apply/#clearing-managedfields,
+		// setting the managedFields to an empty list will not reset the field when the objects are updated, so it's
+		// safe to trim it for all objects.
+		accessor.SetManagedFields(nil)
+
+		// Trim type specific fields for each type.
+		for _, trimmer := range extraTrimmers {
+			trimmer(obj)
+		}
+		return obj, nil
+	}
+}
+
+// TrimPod clears unused fields from a Pod that are not required by Antrea.
+// It's safe to do so because Antrea only patches Pod.
+func TrimPod(obj interface{}) (interface{}, error) {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return obj, nil
+	}
+
+	pod.OwnerReferences = nil
+	pod.Spec.Volumes = nil
+	pod.Spec.InitContainers = nil
+	for i := range pod.Spec.Containers {
+		container := &pod.Spec.Containers[i]
+		container.Command = nil
+		container.Args = nil
+		container.EnvFrom = nil
+		container.Env = nil
+		container.VolumeMounts = nil
+		container.VolumeDevices = nil
+		container.LivenessProbe = nil
+		container.ReadinessProbe = nil
+		container.StartupProbe = nil
+		container.Lifecycle = nil
+		container.SecurityContext = nil
+	}
+	pod.Spec.EphemeralContainers = nil
+	pod.Spec.Affinity = nil
+	pod.Spec.Tolerations = nil
+	pod.Spec.ResourceClaims = nil
+
+	pod.Status.Conditions = nil
+	pod.Status.StartTime = nil
+	pod.Status.InitContainerStatuses = nil
+	pod.Status.ContainerStatuses = nil
+	pod.Status.EphemeralContainerStatuses = nil
+	pod.Status.ResourceClaimStatuses = nil
+	return pod, nil
+}

--- a/pkg/util/k8s/transform_test.go
+++ b/pkg/util/k8s/transform_test.go
@@ -1,0 +1,112 @@
+// Copyright 2024 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+func TestTrimK8sObject(t *testing.T) {
+	tests := []struct {
+		name    string
+		trimmer cache.TransformFunc
+		obj     interface{}
+		want    interface{}
+	}{
+		{
+			name:    "pod",
+			trimmer: NewTrimmer(TrimPod),
+			obj: &corev1.Pod{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+					UID:       "test-uid",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "apps/v1",
+							Kind:       "DaemonSet",
+							Name:       "test-daemonset",
+							UID:        "5a39d3c8-0f5f-4aad-94bf-315c4fe11320",
+						},
+					},
+					ManagedFields: []metav1.ManagedFieldsEntry{
+						{
+							APIVersion: "v1",
+							FieldsType: "FieldsV1",
+						},
+					},
+				},
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{{
+						Name: "container-0",
+					}},
+					Containers: []corev1.Container{{
+						Name:    "container-1",
+						Command: []string{"foo", "bar"},
+						Args:    []string{"--a=b"},
+						Env:     []corev1.EnvVar{{Name: "foo", Value: "bar"}},
+					}},
+					NodeName: "nodeA",
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{
+							Type:   corev1.PodReady,
+							Status: corev1.ConditionTrue,
+						},
+					},
+					PodIP: "1.2.3.4",
+					PodIPs: []corev1.PodIP{
+						{IP: "1.2.3.4"},
+					},
+				},
+			},
+			want: &corev1.Pod{
+				TypeMeta: metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: "default",
+					UID:       "test-uid",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "container-1",
+					}},
+					NodeName: "nodeA",
+				},
+				Status: corev1.PodStatus{
+					PodIP: "1.2.3.4",
+					PodIPs: []corev1.PodIP{
+						{IP: "1.2.3.4"},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.trimmer(tt.obj)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Unused fields stored in informers can occupy significant memory usage. The informer provides a transform func to allow mutating the objects before they are stored, via which we can trim unneeded fields.

In general, managedFields is never used for all types of objects. In addition, we trim some unneeded fields from Pod objects given their unused fields take the most considerable space.

It can reduce the memory usage of 1k simple Pod by approximately 5m.

---
Test:
Measured the memory usage of antrea-controller with 2k, 4k, 6k Pods with the following Pod template:
```
  template:
    metadata:
      labels:
        app: client
    spec:
      containers:
      - image: k8s.gcr.io/e2e-test-images/agnhost:2.29
        imagePullPolicy: IfNotPresent
        name: agnhost
        resources: {}
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
      dnsPolicy: ClusterFirst
      nodeName: antrea-agent-simulator-0
      restartPolicy: Always
      schedulerName: default-scheduler
      securityContext: {}
      terminationGracePeriodSeconds: 30
```
After creating 2k Pods, its memory usage increases from 78.9m to 104.5m (+25.6m).
After trimming managedFields only, its memory usage decreases to 100.6m (-3.9m).
After trimming managedFields and ownerReference only, its memory usage decreases to 99.5m (-5m).
After trimming all fields covered by the patch, its memory usage decreases to 94.5m (-10m), reducing about 40% in total. 

After creating 4k Pods, its memory usage increases to 130.3m (+51.4m).
After trimming all fields covered by the patch, its memory usage decreases to 108.1m (-22.2m), reducing about 43% in total. 

After creating 6k Pods, its memory usage increases to 157.6m (+78.7m).
After trimming all fields covered by the patch, its memory usage decreases to 119.3m (-38.3m), reducing about 48% in total. 

![image](https://github.com/antrea-io/antrea/assets/5331316/eeb59731-a8fa-4f1b-95e6-2efabc27320c)






























































































































