### PR TITLE
Set up Docker Buildx in workflows whenever building Antrea

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -62,6 +62,9 @@ jobs:
             echo "released=false" >> $GITHUB_OUTPUT
             echo "image-tag=latest" >> $GITHUB_OUTPUT
           fi
+      - name: Set up Docker Buildx if required
+        if: ${{ steps.check-release.outputs.released == 'false' }}
+        uses: docker/setup-buildx-action@v3
       - name: Build Antrea image if required
         if: ${{ steps.check-release.outputs.released == 'false' }}
         run: |

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -37,6 +37,8 @@ jobs:
     - uses: actions/checkout@v4
       with:
         show-progress: false
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
     - name: Build Antrea Docker image with code coverage support
       run: |
         ./hack/build-antrea-linux-all.sh --pull --coverage

--- a/.github/workflows/trivy_scan_before_release.yml
+++ b/.github/workflows/trivy_scan_before_release.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
     - name: Build Antrea Docker image
       run: |
         ./hack/build-antrea-linux-all.sh --pull


### PR DESCRIPTION
Whenever the Antrea images are built from scratch using `./hack/build-antrea-linux-all.sh` in Github CI, we should set up Docker Buildx first. It ensures that the docker-container driver is used, which enables the registry cache backend. We depend on this cache backend to speed up the build by avoiding re-building the base images if it is not necessary. Without caching, the build takes ~10 minutes instead of ~3 minutes.