### PR TITLE
Fix trivy Github workflow

### DIFF
--- a/.github/workflows/trivy_scan.yml
+++ b/.github/workflows/trivy_scan.yml
@@ -47,7 +47,7 @@ jobs:
         ignore-unfixed: true
         severity: 'CRITICAL,HIGH'
         format: 'table'
-        output: 'trivy.latest.txt'
+        output: 'trivy.agent.latest.txt'
     - name: Run Trivy vulnerability scanner on latest antrea-controller Docker image
       if: ${{ always() && steps.pull.conclusion == 'success' }}
       uses: aquasecurity/trivy-action@0.20.0
@@ -60,7 +60,7 @@ jobs:
         ignore-unfixed: true
         severity: 'CRITICAL,HIGH'
         format: 'table'
-        output: 'trivy.latest.txt'
+        output: 'trivy.controller.latest.txt'
     - name: Run Trivy vulnerability scanner on antrea-agent Docker image for latest released version
       if: ${{ always() && steps.pull.conclusion == 'success' }}
       uses: aquasecurity/trivy-action@0.20.0
@@ -71,7 +71,7 @@ jobs:
         ignore-unfixed: true
         severity: 'CRITICAL,HIGH'
         format: 'table'
-        output: 'trivy.${{ steps.find-antrea-greatest-version.outputs.antrea_version }}.txt'
+        output: 'trivy.agent.${{ steps.find-antrea-greatest-version.outputs.antrea_version }}.txt'
     - name: Run Trivy vulnerability scanner on antrea-controller Docker image for latest released version
       if: ${{ always() && steps.pull.conclusion == 'success' }}
       uses: aquasecurity/trivy-action@0.20.0
@@ -82,7 +82,7 @@ jobs:
         ignore-unfixed: true
         severity: 'CRITICAL,HIGH'
         format: 'table'
-        output: 'trivy.${{ steps.find-antrea-greatest-version.outputs.antrea_version }}.txt'
+        output: 'trivy.controller.${{ steps.find-antrea-greatest-version.outputs.antrea_version }}.txt'
     - name: Upload Trivy scan reports
       if: ${{ always() && steps.pull.conclusion == 'success' }}
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
Ever since splitting up the Agent and Controller images, there was an issue with the Trivy workflow, as the same output path was used for the Trivy report for both the Agent and Controller. When generating the report for the Controller, it would overwrite the one for the Agent, meaning that incomplete information was uploaded as job artifacts.