### PR TITLE
Fix RestoreHostInterfaceConfiguration for SecondaryNetwork

### DIFF
--- a/pkg/agent/secondarynetwork/init_linux.go
+++ b/pkg/agent/secondarynetwork/init_linux.go
@@ -104,7 +104,7 @@ func Initialize(
 
 // RestoreHostInterfaceConfiguration restores interface configuration from secondary-bridge back to host-interface.
 func RestoreHostInterfaceConfiguration(secNetConfig *agentconfig.SecondaryNetworkConfig) {
-	if len(secNetConfig.OVSBridges[0].PhysicalInterfaces) == 1 {
+	if len(secNetConfig.OVSBridges) != 0 && len(secNetConfig.OVSBridges[0].PhysicalInterfaces) == 1 {
 		util.RestoreHostInterfaceConfiguration(secNetConfig.OVSBridges[0].BridgeName, secNetConfig.OVSBridges[0].PhysicalInterfaces[0])
 	}
 }


### PR DESCRIPTION
When SecondaryNetwork is enabled, but the ovsBridges list is empty, the antrea-agent currently panics during graceful termination. This is because the RestoreHostInterfaceConfiguration was assuming that there was alwasy one OVS bridge.

The panic is not really impactful, as it happens during Pod termination. However, for code coverage collection in e2e tests, it can have an impact, so we want to make sure it doesn't happen.