### PR TITLE
Add "-run" filter for antctl check installation command

### DIFF
--- a/pkg/antctl/raw/check/installation/command_test.go
+++ b/pkg/antctl/raw/check/installation/command_test.go
@@ -1,0 +1,106 @@
+// Copyright 2024 Antrea Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package installation
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func overrideTestsRegistry(t *testing.T, registry map[string]Test) {
+	oldRegistry := testsRegistry
+	testsRegistry = registry
+	t.Cleanup(func() {
+		testsRegistry = oldRegistry
+	})
+}
+
+type notRunnableTest struct{}
+
+func (t *notRunnableTest) Run(ctx context.Context, testContext *testContext) error {
+	return newNotRunnableError("not runnable")
+}
+
+type failedTest struct{}
+
+func (t *failedTest) Run(ctx context.Context, testContext *testContext) error {
+	return fmt.Errorf("failed")
+}
+
+type successfulTest struct{}
+
+func (t *successfulTest) Run(ctx context.Context, testContext *testContext) error {
+	return nil
+}
+
+func TestRun(t *testing.T) {
+	ctx := context.Background()
+
+	registry := map[string]Test{
+		"not-runnable": &notRunnableTest{},
+		"failure":      &failedTest{},
+		"success":      &successfulTest{},
+	}
+
+	testCases := []struct {
+		name          string
+		registry      map[string]Test
+		runFilter     string
+		expectedStats testStats
+	}{
+		{
+			name:          "no test in registry",
+			expectedStats: testStats{},
+		},
+		{
+			name:     "run all tests",
+			registry: registry,
+			expectedStats: testStats{
+				numSuccess: 1,
+				numFailure: 1,
+				numSkipped: 1,
+			},
+		},
+		{
+			name:      "run single test",
+			registry:  registry,
+			runFilter: "success",
+			expectedStats: testStats{
+				numSuccess: 1,
+			},
+		},
+		{
+			name:          "no matching test",
+			registry:      registry,
+			runFilter:     "my-test",
+			expectedStats: testStats{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			overrideTestsRegistry(t, tc.registry)
+			runFilterRegex, err := compileRunFilter(tc.runFilter)
+			require.NoError(t, err)
+			testContext := NewTestContext(nil, nil, "test-cluster", "kube-system", runFilterRegex)
+			stats := testContext.runTests(ctx)
+			assert.Equal(t, tc.expectedStats, stats)
+		})
+	}
+}

--- a/pkg/antctl/raw/check/installation/test_podtointernet.go
+++ b/pkg/antctl/raw/check/installation/test_podtointernet.go
@@ -17,8 +17,6 @@ package installation
 import (
 	"context"
 	"fmt"
-
-	"antrea.io/antrea/pkg/antctl/raw/check"
 )
 
 type PodToInternetConnectivityTest struct{}
@@ -31,8 +29,7 @@ func (t *PodToInternetConnectivityTest) Run(ctx context.Context, testContext *te
 	for _, clientPod := range testContext.clientPods {
 		srcPod := testContext.namespace + "/" + clientPod.Name
 		testContext.Log("Validating connectivity from Pod %s to the world (google.com)...", srcPod)
-		_, _, err := check.ExecInPod(ctx, testContext.client, testContext.config, testContext.namespace, clientPod.Name, clientDeploymentName, agnhostConnectCommand("google.com", "80"))
-		if err != nil {
+		if err := testContext.runAgnhostConnect(ctx, clientPod.Name, "", "google.com", 80); err != nil {
 			return fmt.Errorf("Pod %s was not able to connect to google.com: %w", srcPod, err)
 		}
 		testContext.Log("Pod %s was able to connect to google.com", srcPod)

--- a/pkg/antctl/raw/check/installation/test_podtopodinternode.go
+++ b/pkg/antctl/raw/check/installation/test_podtopodinternode.go
@@ -17,8 +17,6 @@ package installation
 import (
 	"context"
 	"fmt"
-
-	"antrea.io/antrea/pkg/antctl/raw/check"
 )
 
 type PodToPodInterNodeConnectivityTest struct{}
@@ -37,8 +35,7 @@ func (t *PodToPodInterNodeConnectivityTest) Run(ctx context.Context, testContext
 		for _, podIP := range testContext.echoOtherNodePod.Status.PodIPs {
 			echoIP := podIP.IP
 			testContext.Log("Validating from Pod %s to Pod %s at IP %s...", srcPod, dstPod, echoIP)
-			_, _, err := check.ExecInPod(ctx, testContext.client, testContext.config, testContext.namespace, clientPod.Name, "", agnhostConnectCommand(echoIP, "80"))
-			if err != nil {
+			if err := testContext.runAgnhostConnect(ctx, clientPod.Name, "", echoIP, 80); err != nil {
 				return fmt.Errorf("client Pod %s was not able to communicate with echo Pod %s (%s): %w", clientPod.Name, testContext.echoOtherNodePod.Name, echoIP, err)
 			}
 			testContext.Log("client Pod %s was able to communicate with echo Pod %s (%s)", clientPod.Name, testContext.echoOtherNodePod.Name, echoIP)

--- a/pkg/antctl/raw/check/installation/test_podtopodintranode.go
+++ b/pkg/antctl/raw/check/installation/test_podtopodintranode.go
@@ -17,8 +17,6 @@ package installation
 import (
 	"context"
 	"fmt"
-
-	"antrea.io/antrea/pkg/antctl/raw/check"
 )
 
 type PodToPodIntraNodeConnectivityTest struct{}
@@ -34,8 +32,7 @@ func (t *PodToPodIntraNodeConnectivityTest) Run(ctx context.Context, testContext
 		for _, podIP := range testContext.echoSameNodePod.Status.PodIPs {
 			echoIP := podIP.IP
 			testContext.Log("Validating from Pod %s to Pod %s at IP %s...", srcPod, dstPod, echoIP)
-			_, _, err := check.ExecInPod(ctx, testContext.client, testContext.config, testContext.namespace, clientPod.Name, "", agnhostConnectCommand(echoIP, "80"))
-			if err != nil {
+			if err := testContext.runAgnhostConnect(ctx, clientPod.Name, "", echoIP, 80); err != nil {
 				return fmt.Errorf("client Pod %s was not able to communicate with echo Pod %s (%s): %w", clientPod.Name, testContext.echoSameNodePod.Name, echoIP, err)
 			}
 			testContext.Log("client Pod %s was able to communicate with echo Pod %s (%s)", clientPod.Name, testContext.echoSameNodePod.Name, echoIP)

--- a/pkg/antctl/raw/check/installation/test_podtoserviceinternode.go
+++ b/pkg/antctl/raw/check/installation/test_podtoserviceinternode.go
@@ -17,8 +17,6 @@ package installation
 import (
 	"context"
 	"fmt"
-
-	"antrea.io/antrea/pkg/antctl/raw/check"
 )
 
 type PodToServiceInterNodeConnectivityTest struct{}
@@ -34,8 +32,7 @@ func (t *PodToServiceInterNodeConnectivityTest) Run(ctx context.Context, testCon
 	service := echoOtherNodeDeploymentName
 	for _, clientPod := range testContext.clientPods {
 		testContext.Log("Validating from Pod %s to Service %s in Namespace %s...", clientPod.Name, service, testContext.namespace)
-		_, _, err := check.ExecInPod(ctx, testContext.client, testContext.config, testContext.namespace, clientPod.Name, "", agnhostConnectCommand(service, "80"))
-		if err != nil {
+		if err := testContext.runAgnhostConnect(ctx, clientPod.Name, "", service, 80); err != nil {
 			return fmt.Errorf("client Pod %s was not able to communicate with Service %s", clientPod.Name, service)
 		}
 		testContext.Log("client Pod %s was able to communicate with Service %s", clientPod.Name, service)

--- a/pkg/antctl/raw/check/installation/test_podtoserviceintranode.go
+++ b/pkg/antctl/raw/check/installation/test_podtoserviceintranode.go
@@ -17,8 +17,6 @@ package installation
 import (
 	"context"
 	"fmt"
-
-	"antrea.io/antrea/pkg/antctl/raw/check"
 )
 
 type PodToServiceIntraNodeConnectivityTest struct{}
@@ -31,8 +29,7 @@ func (t *PodToServiceIntraNodeConnectivityTest) Run(ctx context.Context, testCon
 	service := echoSameNodeDeploymentName
 	for _, clientPod := range testContext.clientPods {
 		testContext.Log("Validating from Pod %s to Service %s in Namespace %s...", clientPod.Name, service, testContext.namespace)
-		_, _, err := check.ExecInPod(ctx, testContext.client, testContext.config, testContext.namespace, clientPod.Name, "", agnhostConnectCommand(service, "80"))
-		if err != nil {
+		if err := testContext.runAgnhostConnect(ctx, clientPod.Name, "", service, 80); err != nil {
 			return fmt.Errorf("client Pod %s was not able to communicate with Service %s", clientPod.Name, service)
 		}
 		testContext.Log("client Pod %s was able to communicate with Service %s", clientPod.Name, service)


### PR DESCRIPTION
To support running a subset only of tests, based on which test names match the provided regex.

We also log stderr when `/agnhost connect` fails, to assist in troubleshooting. I have seen the `antctl check installation` command fail in CI, and at the moment it is impossible to troubleshoot.