### PR TITLE
Refactored post-installation framework labels

### DIFF
--- a/pkg/antctl/raw/check/cluster/command.go
+++ b/pkg/antctl/raw/check/cluster/command.go
@@ -116,7 +116,7 @@ func Run() error {
 
 func (t *testContext) setup(ctx context.Context) error {
 	t.Log("Creating Namespace %s for pre installation tests...", t.namespace)
-	_, err := t.client.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: t.namespace}}, metav1.CreateOptions{})
+	_, err := t.client.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: t.namespace, Labels: map[string]string{"app": "antrea", "component": "cluster-checker"}}}, metav1.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("unable to create Namespace %s: %s", t.namespace, err)
 	}

--- a/pkg/antctl/raw/check/installation/command.go
+++ b/pkg/antctl/raw/check/installation/command.go
@@ -190,7 +190,7 @@ func (t *testContext) setup(ctx context.Context) error {
 			Effect:   "NoSchedule",
 		},
 	}
-	echoDeployment := check.NewDeployment(check.DeploymentParameters{
+	echoSameNodeDeployment := check.NewDeployment(check.DeploymentParameters{
 		Name:    echoSameNodeDeploymentName,
 		Role:    kindEchoName,
 		Port:    80,
@@ -215,9 +215,9 @@ func (t *testContext) setup(ctx context.Context) error {
 			},
 		},
 		Tolerations: commonToleration,
-		Labels:      map[string]string{"app": echoSameNodeDeploymentName},
+		Labels:      map[string]string{"app": "antrea", "component": "installation-checker", "name": echoSameNodeDeploymentName},
 	})
-	_, err = t.client.AppsV1().Deployments(t.namespace).Create(ctx, echoDeployment, metav1.CreateOptions{})
+	_, err = t.client.AppsV1().Deployments(t.namespace).Create(ctx, echoSameNodeDeployment, metav1.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("unable to create Deployment %s: %s", echoSameNodeDeploymentName, err)
 	}
@@ -229,7 +229,7 @@ func (t *testContext) setup(ctx context.Context) error {
 		Command:     []string{"/agnhost", "pause"},
 		Port:        80,
 		Tolerations: commonToleration,
-		Labels:      map[string]string{"app": clientDeploymentName},
+		Labels:      map[string]string{"app": "antrea", "component": "installation-checker", "name": clientDeploymentName},
 	})
 	_, err = t.client.AppsV1().Deployments(t.namespace).Create(ctx, clientDeployment, metav1.CreateOptions{})
 	if err != nil {
@@ -256,7 +256,7 @@ func (t *testContext) setup(ctx context.Context) error {
 			},
 		},
 		Tolerations: commonToleration,
-		Labels:      map[string]string{"app": echoOtherNodeDeploymentName},
+		Labels:      map[string]string{"app": "antrea", "component": "installation-checker", "name": echoOtherNodeDeploymentName},
 	})
 	nodes, err := t.client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	if err != nil {
@@ -289,7 +289,7 @@ func (t *testContext) setup(ctx context.Context) error {
 			return err
 		}
 	}
-	podList, err := t.client.CoreV1().Pods(t.namespace).List(ctx, metav1.ListOptions{LabelSelector: "kind=" + kindClientName})
+	podList, err := t.client.CoreV1().Pods(t.namespace).List(ctx, metav1.ListOptions{LabelSelector: "name=" + clientDeploymentName})
 	if err != nil {
 		return fmt.Errorf("unable to list client Pods: %s", err)
 	}

--- a/pkg/antctl/raw/check/installation/command.go
+++ b/pkg/antctl/raw/check/installation/command.go
@@ -173,7 +173,7 @@ func (t *testContext) setup(ctx context.Context) error {
 		return fmt.Errorf("unable to determine status of Antrea DaemonSet: %w", err)
 	}
 	t.Log("Creating Namespace %s for post installation tests...", t.namespace)
-	_, err = t.client.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: t.namespace}}, metav1.CreateOptions{})
+	_, err = t.client.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: t.namespace, Labels: map[string]string{"app": "antrea", "component": "installation-checker"}}}, metav1.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("unable to create Namespace %s: %s", t.namespace, err)
 	}

--- a/pkg/antctl/raw/check/util.go
+++ b/pkg/antctl/raw/check/util.go
@@ -124,8 +124,6 @@ func NewDeployment(p DeploymentParameters) *appsv1.Deployment {
 	if p.Labels == nil {
 		p.Labels = make(map[string]string)
 	}
-	p.Labels["name"] = p.Name
-	p.Labels["kind"] = p.Role
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   p.Name,


### PR DESCRIPTION
Ref #6061 
This PR refactors the labels used in test deployments of `antctl check installation` command framework to match the label pattern with rest of the codebase.
