### PR TITLE
Delay removal of flow-restore-wait

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -856,7 +856,7 @@ func run(o *Options) error {
 	if err := agentInitializer.FlowRestoreComplete(); err != nil {
 		return err
 	}
-	klog.InfoS("Flow restoration complete")
+	klog.InfoS("Flow restoration has completed")
 	// ConnectUplinkToOVSBridge must be run immediately after FlowRestoreComplete
 	if connectUplinkToBridge {
 		// Restore network config before shutdown. ovsdbConnection must be alive when restore.

--- a/pkg/agent/cniserver/server_test.go
+++ b/pkg/agent/cniserver/server_test.go
@@ -761,11 +761,12 @@ func translateRawPrevResult(prevResult *current.Result, cniVersion string) (map[
 
 func newCNIServer(t *testing.T) *CNIServer {
 	cniServer := &CNIServer{
-		cniSocket:       testSocket,
-		nodeConfig:      testNodeConfig,
-		serverVersion:   cni.AntreaCNIVersion,
-		containerAccess: newContainerAccessArbitrator(),
-		podNetworkWait:  wait.NewGroup(),
+		cniSocket:               testSocket,
+		nodeConfig:              testNodeConfig,
+		serverVersion:           cni.AntreaCNIVersion,
+		containerAccess:         newContainerAccessArbitrator(),
+		podNetworkWait:          wait.NewGroup(),
+		flowRestoreCompleteWait: wait.NewGroup().Increment(),
 	}
 	cniServer.networkConfig = &config.NetworkConfig{InterfaceMTU: 1450}
 	return cniServer

--- a/pkg/agent/controller/noderoute/node_route_controller.go
+++ b/pkg/agent/controller/noderoute/node_route_controller.go
@@ -15,6 +15,7 @@
 package noderoute
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"time"
@@ -26,6 +27,7 @@ import (
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/cache/synctrack"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 
@@ -41,6 +43,7 @@ import (
 	"antrea.io/antrea/pkg/ovs/ovsctl"
 	utilip "antrea.io/antrea/pkg/util/ip"
 	"antrea.io/antrea/pkg/util/k8s"
+	utilwait "antrea.io/antrea/pkg/util/wait"
 )
 
 const (
@@ -80,6 +83,12 @@ type Controller struct {
 	// or not when IPsec is enabled with "cert" mode. The NodeRouteController must wait for the certificate
 	// to be configured before installing routes/flows to peer Nodes to prevent unencrypted traffic across Nodes.
 	ipsecCertificateManager ipseccertificate.Manager
+	// flowRestoreCompleteWait is to be decremented after installing flows for initial Nodes.
+	flowRestoreCompleteWait *utilwait.Group
+	// hasProcessedInitialList keeps track of whether the initial informer list has been
+	// processed by workers.
+	// See https://github.com/kubernetes/apiserver/blob/v0.30.1/pkg/admission/plugin/policy/internal/generic/controller.go
+	hasProcessedInitialList synctrack.AsyncTracker[string]
 }
 
 // NewNodeRouteController instantiates a new Controller object which will process Node events
@@ -95,6 +104,7 @@ func NewNodeRouteController(
 	nodeConfig *config.NodeConfig,
 	wireguardClient wireguard.Interface,
 	ipsecCertificateManager ipseccertificate.Manager,
+	flowRestoreCompleteWait *utilwait.Group,
 ) *Controller {
 	controller := &Controller{
 		ovsBridgeClient:         ovsBridgeClient,
@@ -111,21 +121,25 @@ func NewNodeRouteController(
 		installedNodes:          cache.NewIndexer(nodeRouteInfoKeyFunc, cache.Indexers{nodeRouteInfoPodCIDRIndexName: nodeRouteInfoPodCIDRIndexFunc}),
 		wireGuardClient:         wireguardClient,
 		ipsecCertificateManager: ipsecCertificateManager,
+		flowRestoreCompleteWait: flowRestoreCompleteWait.Increment(),
 	}
-	nodeInformer.Informer().AddEventHandlerWithResyncPeriod(
-		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(cur interface{}) {
-				controller.enqueueNode(cur)
+	registration, _ := nodeInformer.Informer().AddEventHandlerWithResyncPeriod(
+		cache.ResourceEventHandlerDetailedFuncs{
+			AddFunc: func(cur interface{}, isInInitialList bool) {
+				controller.enqueueNode(cur, isInInitialList)
 			},
 			UpdateFunc: func(old, cur interface{}) {
-				controller.enqueueNode(cur)
+				controller.enqueueNode(cur, false)
 			},
 			DeleteFunc: func(old interface{}) {
-				controller.enqueueNode(old)
+				controller.enqueueNode(old, false)
 			},
 		},
 		nodeResyncPeriod,
 	)
+	// UpstreamHasSynced is used by hasProcessedInitialList to determine whether even handlers
+	// have been called for the initial list.
+	controller.hasProcessedInitialList.UpstreamHasSynced = registration.HasSynced
 	return controller
 }
 
@@ -153,7 +167,7 @@ type nodeRouteInfo struct {
 
 // enqueueNode adds an object to the controller work queue
 // obj could be a *corev1.Node, or a DeletionFinalStateUnknown item.
-func (c *Controller) enqueueNode(obj interface{}) {
+func (c *Controller) enqueueNode(obj interface{}, isInInitialList bool) {
 	node, isNode := obj.(*corev1.Node)
 	if !isNode {
 		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
@@ -170,6 +184,9 @@ func (c *Controller) enqueueNode(obj interface{}) {
 
 	// Ignore notifications for this Node, no need to establish connectivity to itself.
 	if node.Name != c.nodeConfig.Name {
+		if isInInitialList {
+			c.hasProcessedInitialList.Start(node.Name)
+		}
 		c.queue.Add(node.Name)
 	}
 }
@@ -327,6 +344,7 @@ func (c *Controller) Run(stopCh <-chan struct{}) {
 	// underlying network. Therefore it needs not know the routes to
 	// peer Pod CIDRs.
 	if c.networkConfig.TrafficEncapMode.IsNetworkPolicyOnly() {
+		c.flowRestoreCompleteWait.Done()
 		<-stopCh
 		return
 	}
@@ -352,6 +370,16 @@ func (c *Controller) Run(stopCh <-chan struct{}) {
 	for i := 0; i < defaultWorkers; i++ {
 		go wait.Until(c.worker, time.Second, stopCh)
 	}
+
+	go func() {
+		// When the initial list of Nodes has been processed, we decrement flowRestoreCompleteWait.
+		defer c.flowRestoreCompleteWait.Done()
+		wait.PollUntilContextCancel(wait.ContextForChannel(stopCh), 100*time.Millisecond, true, func(ctx context.Context) (done bool, err error) {
+			return c.hasProcessedInitialList.HasSynced(), nil
+		})
+		klog.V(2).InfoS("Initial list of Nodes has been processed")
+	}()
+
 	<-stopCh
 }
 
@@ -380,14 +408,21 @@ func (c *Controller) processNextWorkItem() bool {
 	defer c.queue.Done(obj)
 
 	// We expect strings (Node name) to come off the workqueue.
-	if key, ok := obj.(string); !ok {
+	key, ok := obj.(string)
+	if !ok {
 		// As the item in the workqueue is actually invalid, we call Forget here else we'd
 		// go into a loop of attempting to process a work item that is invalid.
 		// This should not happen: enqueueNode only enqueues strings.
 		c.queue.Forget(obj)
 		klog.Errorf("Expected string in work queue but got %#v", obj)
 		return true
-	} else if err := c.syncNodeRoute(key); err == nil {
+	}
+
+	// We call Finished unconditionally even if this only matters for the initial list of
+	// Nodes. There is no harm in calling Finished without a corresponding call to Start.
+	defer c.hasProcessedInitialList.Finished(key)
+
+	if err := c.syncNodeRoute(key); err == nil {
 		// If no error occurs we Forget this item so it does not get queued again until
 		// another change happens.
 		c.queue.Forget(key)

--- a/pkg/agent/controller/noderoute/node_route_controller_test.go
+++ b/pkg/agent/controller/noderoute/node_route_controller_test.go
@@ -41,6 +41,7 @@ import (
 	ovsconfigtest "antrea.io/antrea/pkg/ovs/ovsconfig/testing"
 	ovsctltest "antrea.io/antrea/pkg/ovs/ovsctl/testing"
 	utilip "antrea.io/antrea/pkg/util/ip"
+	utilwait "antrea.io/antrea/pkg/util/wait"
 )
 
 var (
@@ -109,7 +110,7 @@ func newController(t *testing.T, networkConfig *config.NetworkConfig, objects ..
 	c := NewNodeRouteController(informerFactory.Core().V1().Nodes(), ofClient, ovsCtlClient, ovsClient, routeClient, interfaceStore, networkConfig, &config.NodeConfig{GatewayConfig: &config.GatewayConfig{
 		IPv4: nil,
 		MAC:  gatewayMAC,
-	}}, wireguardClient, ipsecCertificateManager)
+	}}, wireguardClient, ipsecCertificateManager, utilwait.NewGroup())
 	return &fakeController{
 		Controller:      c,
 		clientset:       clientset,
@@ -732,4 +733,22 @@ func TestDeleteNodeRoute(t *testing.T) {
 			assert.NoError(t, err)
 		})
 	}
+}
+
+func TestInitialListHasSynced(t *testing.T) {
+	c := newController(t, &config.NetworkConfig{}, node1)
+	defer c.queue.ShutDown()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	c.informerFactory.Start(stopCh)
+	c.informerFactory.WaitForCacheSync(stopCh)
+
+	require.Error(t, c.flowRestoreCompleteWait.WaitWithTimeout(100*time.Millisecond))
+
+	c.ofClient.EXPECT().InstallNodeFlows("node1", gomock.Any(), &dsIPs1, uint32(0), nil).Times(1)
+	c.routeClient.EXPECT().AddRoutes(podCIDR, "node1", nodeIP1, podCIDRGateway).Times(1)
+	c.processNextWorkItem()
+
+	assert.True(t, c.hasProcessedInitialList.HasSynced())
 }

--- a/test/e2e/connectivity_test.go
+++ b/test/e2e/connectivity_test.go
@@ -60,7 +60,6 @@ func TestConnectivity(t *testing.T) {
 	t.Run("testOVSRestartSameNode", func(t *testing.T) {
 		skipIfNotIPv4Cluster(t)
 		skipIfHasWindowsNodes(t)
-		t.Skip("Skipping test for now as it fails consistently")
 		testOVSRestartSameNode(t, data, data.testNamespace)
 	})
 	t.Run("testOVSFlowReplay", func(t *testing.T) {
@@ -327,12 +326,7 @@ func testPodConnectivityAfterAntreaRestart(t *testing.T, data *TestData, namespa
 
 // testOVSRestartSameNode verifies that datapath flows are not removed when the Antrea Agent Pod is
 // stopped gracefully (e.g. as part of a RollingUpdate). The test sends ARP requests every 1s and
-// checks that there is no packet loss during the restart. This test does not apply to the userspace
-// ndetdev datapath, since in this case the datapath functionality is implemented by the
-// ovs-vswitchd daemon itself. When ovs-vswitchd restarts, datapath flows are flushed and it may
-// take some time for the Agent to replay the flows. This will not impact this test, since we are
-// just testing L2 connectivity between 2 Pods on the same Node, and the default behavior of the
-// br-int bridge is to implement normal L2 forwarding.
+// checks that there is no packet loss during the restart.
 func testOVSRestartSameNode(t *testing.T, data *TestData, namespace string) {
 	workerNode := workerNodeName(1)
 	t.Logf("Creating two toolbox test Pods on '%s'", workerNode)
@@ -364,7 +358,7 @@ func testOVSRestartSameNode(t *testing.T, data *TestData, namespace string) {
 			maxLossRate = 10
 		}
 		if lossRate > maxLossRate {
-			t.Logf(stdout)
+			t.Log(stdout)
 			return fmt.Errorf("arping loss rate is %f%%", lossRate)
 		}
 		return nil


### PR DESCRIPTION
Until a set of "essential" flows has been installed. At the moment, we include NetworkPolicy flows (using podNetworkWait as the signal), Pod forwarding flows (reconciled by the CNIServer), and Node routing flows (installed by the NodeRouteController). This set can be extended in the future if desired.

We leverage the wrapper around sync.WaitGroup which was introduced previously in #5777. It simplifies unit testing, and we can achieve some symmetry with podNetworkWait.

We can also start leveraging this new wait group
(flowRestoreCompleteWait) as the signal to delete flows from previous rounds. However, at the moment this is incomplete, as we don't wait for all controllers to signal that they have installed initial flows.

Because the NodeRouteController does not have an initial "reconcile" operation (like the CNIServer) to install flows for the initial Node list, we instead rely on a different mechanims provided by upstream K8s for controllers. When registering event handlers, we can request for the ADD handler to include a boolean flag indicating whether the object is part of the initial list retrieved by the informer. Using this mechanism, we can reliably signal through flowRestoreCompleteWait when this initial list of Nodes has been synced at least once.

This change is possible because of #6361, which removed the dependency on the proxy (kube-proxy or AntreaProxy) to access the Antrea Controller. Prior to #6361, there would have been a circular dependency in the case where kube-proxy was removed: flow-restore-wait will not be removed until the Pod network is "ready", which will not happen until the NetworkPolicy controller has started its watchers, and that depends on antrea Service reachability which depends on flow-restore-wait being removed.

Fixes #6338