### PR TITLE
Fix ExecInPod implementation for antctl check

### DIFF
--- a/pkg/antctl/raw/check/installation/command.go
+++ b/pkg/antctl/raw/check/installation/command.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"os"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/fatih/color"
@@ -353,7 +354,10 @@ func (t *testContext) runAgnhostConnect(ctx context.Context, clientPodName strin
 	_, stderr, err := check.ExecInPod(ctx, t.client, t.config, t.namespace, clientPodName, container, cmd)
 	if err != nil {
 		// We log the contents of stderr here for troubleshooting purposes.
-		t.Log("/agnhost command failed - stderr: %s", stderr)
+		t.Log("/agnhost command '%s' failed: %v", strings.Join(cmd, " "), err)
+		if stderr != "" {
+			t.Log("/agnhost stderr: %s", stderr)
+		}
 	}
 	return err
 }

--- a/pkg/antctl/raw/check/installation/test_podtoserviceinternode.go
+++ b/pkg/antctl/raw/check/installation/test_podtoserviceinternode.go
@@ -33,7 +33,7 @@ func (t *PodToServiceInterNodeConnectivityTest) Run(ctx context.Context, testCon
 	for _, clientPod := range testContext.clientPods {
 		testContext.Log("Validating from Pod %s to Service %s in Namespace %s...", clientPod.Name, service, testContext.namespace)
 		if err := testContext.runAgnhostConnect(ctx, clientPod.Name, "", service, 80); err != nil {
-			return fmt.Errorf("client Pod %s was not able to communicate with Service %s", clientPod.Name, service)
+			return fmt.Errorf("client Pod %s was not able to communicate with Service %s: %w", clientPod.Name, service, err)
 		}
 		testContext.Log("client Pod %s was able to communicate with Service %s", clientPod.Name, service)
 	}

--- a/pkg/antctl/raw/check/installation/test_podtoserviceintranode.go
+++ b/pkg/antctl/raw/check/installation/test_podtoserviceintranode.go
@@ -30,7 +30,7 @@ func (t *PodToServiceIntraNodeConnectivityTest) Run(ctx context.Context, testCon
 	for _, clientPod := range testContext.clientPods {
 		testContext.Log("Validating from Pod %s to Service %s in Namespace %s...", clientPod.Name, service, testContext.namespace)
 		if err := testContext.runAgnhostConnect(ctx, clientPod.Name, "", service, 80); err != nil {
-			return fmt.Errorf("client Pod %s was not able to communicate with Service %s", clientPod.Name, service)
+			return fmt.Errorf("client Pod %s was not able to communicate with Service %s: %w", clientPod.Name, service, err)
 		}
 		testContext.Log("client Pod %s was able to communicate with Service %s", clientPod.Name, service)
 	}

--- a/pkg/antctl/raw/check/util.go
+++ b/pkg/antctl/raw/check/util.go
@@ -102,10 +102,7 @@ func ExecInPod(ctx context.Context, client kubernetes.Interface, config *rest.Co
 		Stderr: &stderr,
 		Tty:    false,
 	})
-	if err != nil {
-		return "", "", fmt.Errorf("error in stream: %w", err)
-	}
-	return stdout.String(), stderr.String(), nil
+	return stdout.String(), stderr.String(), err
 }
 
 func NewDeployment(p DeploymentParameters) *appsv1.Deployment {


### PR DESCRIPTION
The function was not returning the contents of stdout / stderr in case of a command error, making troubleshooting impossible.