### PR TITLE
Do not clear ownerReferences of Pod as it's used by AntreaIPAM

### DIFF
--- a/pkg/util/k8s/transform.go
+++ b/pkg/util/k8s/transform.go
@@ -59,7 +59,6 @@ func TrimPod(obj interface{}) (interface{}, error) {
 		return obj, nil
 	}
 
-	pod.OwnerReferences = nil
 	pod.Spec.Volumes = nil
 	pod.Spec.InitContainers = nil
 	for i := range pod.Spec.Containers {

--- a/pkg/util/k8s/transform_test.go
+++ b/pkg/util/k8s/transform_test.go
@@ -86,6 +86,14 @@ func TestTrimK8sObject(t *testing.T) {
 					Name:      "test-pod",
 					Namespace: "default",
 					UID:       "test-uid",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "apps/v1",
+							Kind:       "DaemonSet",
+							Name:       "test-daemonset",
+							UID:        "5a39d3c8-0f5f-4aad-94bf-315c4fe11320",
+						},
+					},
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{


### PR DESCRIPTION
AntreaIPAM uses ownerReferences to know if there is a IP reserved for the Pod by StatefulSet.

Fixes #6356