### PR TITLE
Avoid generating defunct process when starting Suricata

### DIFF
--- a/pkg/agent/controller/networkpolicy/l7engine/reconciler.go
+++ b/pkg/agent/controller/networkpolicy/l7engine/reconciler.go
@@ -515,7 +515,7 @@ func startSuricata() {
 	}
 	// Start Suricata with default Suricata config file /etc/suricata/suricata.yaml.
 	cmd := exec.Command("suricata", "-c", defaultSuricataConfigPath, "--af-packet", "-D", "-l", antreaSuricataLogPath)
-	if err := cmd.Start(); err != nil {
+	if err := cmd.Run(); err != nil {
 		klog.ErrorS(err, "Failed to start Suricata instance")
 	}
 }


### PR DESCRIPTION
When antrea-agent starts Suricata instance with the following command:

```
suricata -c /etc/suricata/suricata.yaml --af-packet -D -l /var/log/antrea/networkpolicy/l7engine/
```

The method `Run()` of `exec.Cmd` should be used instead of `Start()` to avoid generating a zombie process. The above command will exit after starting the process of Suricata instance in the background, so using `Run()` ensures that the command's resources are properly released and no defunct process remains.