### PR TITLE
Fix invalid log for memberlist creation

### DIFF
--- a/pkg/agent/memberlist/cluster.go
+++ b/pkg/agent/memberlist/cluster.go
@@ -170,7 +170,7 @@ func NewCluster(
 		conf.DeadNodeReclaimTime = 10 * time.Millisecond
 		conf.Events = &memberlist.ChannelEventDelegate{Ch: nodeEventCh}
 		conf.LogOutput = io.Discard
-		klog.V(1).InfoS("New memberlist cluster", "config", conf)
+		klog.V(1).InfoS("Creating new memberlist cluster", "name", conf.Name, "addr", conf.AdvertiseAddr, "port", conf.AdvertisePort, "deadNodeReclaimTime", conf.DeadNodeReclaimTime)
 
 		mList, err := memberlist.Create(conf)
 		if err != nil {


### PR DESCRIPTION
The config is a very large struct and some of the fields cannot be logged:

```
New memberlist cluster" config="<internal error: json: unsupported type: func(string) bool>"
```

We update the call to klog.InfoS so that only a few selected config fields are logged.