### PR TITLE
Use same name for coverage-enabled binaries and regular binaries

### DIFF
--- a/build/charts/antrea/templates/agent/daemonset.yaml
+++ b/build/charts/antrea/templates/agent/daemonset.yaml
@@ -131,7 +131,7 @@ spec:
           imagePullPolicy: {{ include "antreaAgentImagePullPolicy" . }}
           {{- if ((.Values.testing).coverage) }}
           args:
-            - "antrea-agent-coverage"
+            - "antrea-agent"
             - "--config=/etc/antrea/antrea-agent.conf"
             - "--logtostderr=false"
             - "--log_dir=/var/log/antrea"

--- a/build/charts/antrea/templates/controller/deployment.yaml
+++ b/build/charts/antrea/templates/controller/deployment.yaml
@@ -65,7 +65,7 @@ spec:
           resources: {{- .Values.controller.antreaController.resources | toYaml | nindent 12 }}
           {{- if ((.Values.testing).coverage) }}
           args:
-            - "antrea-controller-coverage"
+            - "antrea-controller"
             - "--config=/etc/antrea/antrea-controller.conf"
             - "--logtostderr=false"
             - "--log_dir=/var/log/antrea"

--- a/build/charts/flow-aggregator/templates/deployment.yaml
+++ b/build/charts/flow-aggregator/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- if ((.Values.testing).coverage) }}
         args:
-          - flow-aggregator-coverage
+          - flow-aggregator
           - --config=/etc/flow-aggregator/flow-aggregator.conf
           - --logtostderr=false
           - --log_dir=/var/log/antrea/flow-aggregator

--- a/build/images/Dockerfile.build.agent.coverage
+++ b/build/images/Dockerfile.build.agent.coverage
@@ -24,9 +24,9 @@ RUN go mod download
 
 COPY . /antrea
 
-RUN make antctl-linux antctl-instr-binary && mv bin/antctl-linux bin/antctl
+RUN make antctl-instr-binary
 
-RUN make antrea-agent antrea-cni antrea-agent-instr-binary
+RUN make antrea-cni antrea-agent-instr-binary
 
 FROM antrea/base-ubuntu:${BUILD_TAG}
 
@@ -36,11 +36,9 @@ LABEL description="The Docker image to deploy the antrea-agent with code coverag
 USER root
 
 COPY build/images/scripts/* /usr/local/bin/
-COPY --from=antrea-build /antrea/bin/antrea-agent /usr/local/bin/
-COPY --from=antrea-build /antrea/bin/antrea-agent-coverage /usr/local/bin/
+COPY --from=antrea-build /antrea/bin/antrea-agent-coverage /usr/local/bin/antrea-agent
 COPY --from=antrea-build /antrea/bin/antrea-cni /usr/local/bin/
-COPY --from=antrea-build /antrea/bin/antctl /usr/local/bin/
-COPY --from=antrea-build /antrea/bin/antctl-coverage /usr/local/bin/
+COPY --from=antrea-build /antrea/bin/antctl-coverage /usr/local/bin/antctl
 COPY --from=antrea-build /antrea/test/e2e/utils/run_cov_binary.sh /
 
 # This environment variable will persist when running the container, but can also be overwritten if needed

--- a/build/images/Dockerfile.build.controller.coverage
+++ b/build/images/Dockerfile.build.controller.coverage
@@ -24,9 +24,9 @@ RUN go mod download
 
 COPY . /antrea
 
-RUN make antctl-linux antctl-instr-binary && mv bin/antctl-linux bin/antctl
+RUN make antctl-instr-binary
 
-RUN make antrea-controller antrea-controller-instr-binary
+RUN make antrea-controller-instr-binary
 
 FROM ubuntu:22.04
 
@@ -35,10 +35,8 @@ LABEL description="The Docker image to deploy the antrea-controller with code co
 
 USER root
 
-COPY --from=antrea-build /antrea/bin/antrea-controller /usr/local/bin/
-COPY --from=antrea-build /antrea/bin/antctl /usr/local/bin/
-COPY --from=antrea-build /antrea/bin/antrea-controller-coverage /usr/local/bin/
-COPY --from=antrea-build /antrea/bin/antctl-coverage /usr/local/bin/
+COPY --from=antrea-build /antrea/bin/antrea-controller-coverage /usr/local/bin/antrea-controller
+COPY --from=antrea-build /antrea/bin/antctl-coverage /usr/local/bin/antctl
 COPY --from=antrea-build /antrea/test/e2e/utils/run_cov_binary.sh /
 
 # This environment variable will persist when running the container, but can also be overwritten if needed

--- a/build/images/flow-aggregator/Dockerfile.coverage
+++ b/build/images/flow-aggregator/Dockerfile.coverage
@@ -19,8 +19,7 @@ WORKDIR /antrea
 
 COPY . /antrea
 
-RUN make flow-aggregator antctl-linux flow-aggregator-instr-binary antctl-instr-binary
-RUN mv bin/antctl-linux bin/antctl
+RUN make flow-aggregator-instr-binary antctl-instr-binary
 
 FROM ubuntu:22.04
 
@@ -29,8 +28,8 @@ LABEL description="The docker image for the flow aggregator with code coverage m
 
 USER root
 
-COPY --from=flow-aggregator-build /antrea/bin/flow-aggregator* /usr/local/bin/
-COPY --from=flow-aggregator-build /antrea/bin/antctl* /usr/local/bin/
+COPY --from=flow-aggregator-build /antrea/bin/flow-aggregator-coverage /usr/local/bin/flow-aggregator
+COPY --from=flow-aggregator-build /antrea/bin/antctl-coverage /usr/local/bin/antctl
 COPY --from=flow-aggregator-build /antrea/test/e2e/utils/run_cov_binary.sh /
 
 # This environment variable will persist when running the container, but can also be overwritten if needed

--- a/test/e2e/antctl_test.go
+++ b/test/e2e/antctl_test.go
@@ -160,8 +160,7 @@ func testAntctlControllerRemoteAccess(t *testing.T, data *TestData, antctlServic
 	testCmds := []cmdAndReturnCode{}
 	// Add all controller commands.
 	for _, c := range antctl.CommandList.GetDebugCommands(runtime.ModeController) {
-		cmd := []string{"antctl"}
-		cmd = append(cmd, c...)
+		cmd := append([]string{"antctl"}, c...)
 		testCmds = append(testCmds, cmdAndReturnCode{args: cmd, expectedReturnCode: 0})
 	}
 	testCmds = append(testCmds,

--- a/test/e2e/antctl_test.go
+++ b/test/e2e/antctl_test.go
@@ -83,13 +83,6 @@ func antctlOutput(stdout, stderr string) string {
 	return fmt.Sprintf("antctl stdout:\n%s\nantctl stderr:\n%s", stdout, stderr)
 }
 
-func antctlName() string {
-	if testOptions.enableCoverage {
-		return "antctl-coverage"
-	}
-	return "antctl"
-}
-
 // runAntctl runs antctl commands on antrea Pods, the controller, or agents.
 func runAntctl(podName string, cmds []string, data *TestData) (string, string, error) {
 	var containerName string
@@ -121,9 +114,8 @@ func testAntctlAgentLocalAccess(t *testing.T, data *TestData) {
 	if err != nil {
 		t.Fatalf("Error when getting antrea-agent pod name: %v", err)
 	}
-	antctlName := antctlName()
 	for _, c := range antctl.CommandList.GetDebugCommands(runtime.ModeAgent) {
-		args := []string{antctlName}
+		args := []string{"antctl"}
 		args = append(args, c...)
 		t.Logf("args: %s", args)
 
@@ -161,7 +153,6 @@ func runAntctlCommandFromPod(data *TestData, podName string, cmd []string) (stri
 func testAntctlControllerRemoteAccess(t *testing.T, data *TestData, antctlServiceAccountName string, antctlImage string) {
 	const podName = "antctl"
 	const covDir = "/tmp/coverage"
-	antctlName := antctlName()
 
 	runAntctlPod(t, data, podName, antctlServiceAccountName, antctlImage, covDir)
 	require.NoError(t, data.podWaitForRunning(30*time.Second, podName, data.testNamespace), "antctl Pod not in the Running state")
@@ -169,14 +160,14 @@ func testAntctlControllerRemoteAccess(t *testing.T, data *TestData, antctlServic
 	testCmds := []cmdAndReturnCode{}
 	// Add all controller commands.
 	for _, c := range antctl.CommandList.GetDebugCommands(runtime.ModeController) {
-		cmd := []string{antctlName}
+		cmd := []string{"antctl"}
 		cmd = append(cmd, c...)
 		testCmds = append(testCmds, cmdAndReturnCode{args: cmd, expectedReturnCode: 0})
 	}
 	testCmds = append(testCmds,
 		// Missing Kubeconfig
 		cmdAndReturnCode{
-			args:               []string{antctlName, "version", "--kubeconfig", "/xyz"},
+			args:               []string{"antctl", "version", "--kubeconfig", "/xyz"},
 			expectedReturnCode: 1,
 		},
 	)
@@ -239,8 +230,7 @@ func runAntctProxy(
 ) {
 	// Collecting coverage is currently not supported for the proxy command (no coverage data
 	// when the process is interrupted).
-	antctlName := "antctl"
-	proxyCmd := []string{antctlName, "proxy", "--port", fmt.Sprint(proxyPort), "--address", address}
+	proxyCmd := []string{"antctl", "proxy", "--port", fmt.Sprint(proxyPort), "--address", address}
 	if agentNodeName == "" {
 		proxyCmd = append(proxyCmd, "--controller")
 	} else {

--- a/test/e2e/flowaggregator_test.go
+++ b/test/e2e/flowaggregator_test.go
@@ -928,9 +928,8 @@ func checkAntctlGetFlowRecordsJson(t *testing.T, data *TestData, podName string,
 	_, srcPort, dstPort := getBandwidthAndPorts(stdout)
 
 	// run antctl command on flow aggregator to get flow records
-	var command []string
 	args := []string{"get", "flowrecords", "-o", "json", "--srcip", srcIP, "--srcport", srcPort}
-	command = append([]string{"antctl"}, args...)
+	command := append([]string{"antctl"}, args...)
 	t.Logf("Run command: %s", command)
 	stdout, stderr, err := runAntctl(podName, command, data)
 	require.NoErrorf(t, err, "Error when running 'antctl get flowrecords -o json' from %s: %v\n%s", podName, err, antctlOutput(stdout, stderr))

--- a/test/e2e/flowaggregator_test.go
+++ b/test/e2e/flowaggregator_test.go
@@ -895,13 +895,7 @@ func testHelper(t *testing.T, data *TestData, isIPv6 bool) {
 		}
 		podName := flowAggPod.Name
 		for _, args := range antctl.CommandList.GetDebugCommands(runtime.ModeFlowAggregator) {
-			command := []string{}
-			if testOptions.enableCoverage {
-				antctlCovArgs := []string{"antctl-coverage"}
-				command = append(antctlCovArgs, args...)
-			} else {
-				command = append([]string{"antctl", "-v"}, args...)
-			}
+			command := append([]string{"antctl"}, args...)
 			t.Logf("Run command: %s", command)
 
 			t.Run(strings.Join(command, " "), func(t *testing.T) {
@@ -936,12 +930,7 @@ func checkAntctlGetFlowRecordsJson(t *testing.T, data *TestData, podName string,
 	// run antctl command on flow aggregator to get flow records
 	var command []string
 	args := []string{"get", "flowrecords", "-o", "json", "--srcip", srcIP, "--srcport", srcPort}
-	if testOptions.enableCoverage {
-		antctlCovArgs := []string{"antctl-coverage"}
-		command = append(antctlCovArgs, args...)
-	} else {
-		command = append([]string{"antctl"}, args...)
-	}
+	command = append([]string{"antctl"}, args...)
 	t.Logf("Run command: %s", command)
 	stdout, stderr, err := runAntctl(podName, command, data)
 	require.NoErrorf(t, err, "Error when running 'antctl get flowrecords -o json' from %s: %v\n%s", podName, err, antctlOutput(stdout, stderr))

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -114,10 +114,7 @@ const (
 	defaultBridgeName       = "br-int"
 	monitoringNamespace     = "monitoring"
 
-	antreaControllerCovBinary = "antrea-controller-coverage"
-	antreaAgentCovBinary      = "antrea-agent-coverage"
-	flowAggregatorCovBinary   = "flow-aggregator-coverage"
-	cpNodeCoverageDir         = "/tmp/antrea-e2e-coverage"
+	cpNodeCoverageDir = "/tmp/antrea-e2e-coverage"
 
 	antreaAgentConfName      = "antrea-agent.conf"
 	antreaControllerConfName = "antrea-controller.conf"
@@ -2681,7 +2678,7 @@ func (data *TestData) gracefulExitAntreaController(covDir string) error {
 	}
 	podName := antreaController.Name
 
-	if err := data.killProcessAndCollectCovFiles(antreaNamespace, podName, "antrea-controller", antreaControllerCovBinary, covDir); err != nil {
+	if err := data.killProcessAndCollectCovFiles(antreaNamespace, podName, "antrea-controller", "antrea-controller", covDir); err != nil {
 		return fmt.Errorf("error when gracefully exiting Antrea Controller: %w", err)
 	}
 
@@ -2703,7 +2700,7 @@ func (data *TestData) gracefulExitAntreaAgent(covDir string, nodeName string) er
 	}
 	for _, pod := range pods.Items {
 		podName := pod.Name
-		if err := data.killProcessAndCollectCovFiles(antreaNamespace, podName, "antrea-agent", antreaAgentCovBinary, covDir); err != nil {
+		if err := data.killProcessAndCollectCovFiles(antreaNamespace, podName, "antrea-agent", "antrea-agent", covDir); err != nil {
 			return fmt.Errorf("error when gracefully exiting Antrea Agent: %w", err)
 		}
 	}
@@ -2718,7 +2715,7 @@ func (data *TestData) gracefulExitFlowAggregator(covDir string) error {
 	}
 	podName := flowAggPod.Name
 
-	if err := data.killProcessAndCollectCovFiles(flowAggregatorNamespace, podName, "flow-aggregator", flowAggregatorCovBinary, covDir); err != nil {
+	if err := data.killProcessAndCollectCovFiles(flowAggregatorNamespace, podName, "flow-aggregator", "flow-aggregator", covDir); err != nil {
 		return fmt.Errorf("error when gracefully exiting Flow Aggregator: %w", err)
 	}
 


### PR DESCRIPTION
This PR includes the following changes:
- Coverage binaries are now named as regular binaries, without "-coverage" suffix.
- Regular binaries are not included in coverage-enabled Dockerfiles.

cc: @antoninbas @luolanzone 