### PR TITLE
Automated cherry pick of #6366: Avoid generating defunct process when starting Suricata

### DIFF
--- a/pkg/agent/controller/networkpolicy/l7engine/reconciler.go
+++ b/pkg/agent/controller/networkpolicy/l7engine/reconciler.go
@@ -515,7 +515,7 @@ func startSuricata() {
 	}
 	// Start Suricata with default Suricata config file /etc/suricata/suricata.yaml.
 	cmd := exec.Command("suricata", "-c", defaultSuricataConfigPath, "--af-packet", "-D", "-l", antreaSuricataLogPath)
-	if err := cmd.Start(); err != nil {
+	if err := cmd.Run(); err != nil {
 		klog.ErrorS(err, "Failed to start Suricata instance")
 	}
 }


### PR DESCRIPTION
Cherry pick of #6366 on release-2.0.

#6366: Avoid generating defunct process when starting Suricata

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.