### PR TITLE
Update iptables builder

### DIFF
--- a/pkg/agent/util/iptables/iptables.go
+++ b/pkg/agent/util/iptables/iptables.go
@@ -28,6 +28,8 @@ import (
 	"github.com/coreos/go-iptables/iptables"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/klog/v2"
+
+	"antrea.io/antrea/pkg/agent/util/ipset"
 )
 
 const (
@@ -109,16 +111,17 @@ type Interface interface {
 type IPTablesRuleBuilder interface {
 	MatchCIDRSrc(cidr string) IPTablesRuleBuilder
 	MatchCIDRDst(cidr string) IPTablesRuleBuilder
-	MatchIPSetSrc(ipset string) IPTablesRuleBuilder
-	MatchIPSetDst(ipset string) IPTablesRuleBuilder
+	MatchIPSetSrc(ipset string, ipsetType ipset.SetType) IPTablesRuleBuilder
+	MatchIPSetDst(ipset string, ipsetType ipset.SetType) IPTablesRuleBuilder
 	MatchTransProtocol(protocol string) IPTablesRuleBuilder
-	MatchDstPort(port *intstr.IntOrString, endPort *int32) IPTablesRuleBuilder
-	MatchSrcPort(port, endPort *int32) IPTablesRuleBuilder
+	MatchPortDst(port *intstr.IntOrString, endPort *int32) IPTablesRuleBuilder
+	MatchPortSrc(port, endPort *int32) IPTablesRuleBuilder
 	MatchICMP(icmpType, icmpCode *int32, ipProtocol Protocol) IPTablesRuleBuilder
 	MatchEstablishedOrRelated() IPTablesRuleBuilder
 	MatchInputInterface(interfaceName string) IPTablesRuleBuilder
 	MatchOutputInterface(interfaceName string) IPTablesRuleBuilder
 	SetTarget(target string) IPTablesRuleBuilder
+	SetTargetDNATToDst(dnatIP string, dnatPort *int32) IPTablesRuleBuilder
 	SetComment(comment string) IPTablesRuleBuilder
 	CopyBuilder() IPTablesRuleBuilder
 	Done() IPTablesRule


### PR DESCRIPTION
Needed by #6308

This PR adds more methods to build an iptables entries:

- `SetTargetDNATToDst`, setting DNAT destination IP and port.

This PR also updates the methods:

- `MatchCIDRSrc`, supporting an IP or CIDR as source.
- `MatchCIDRDst`, supporting an IP or CIDR as destination.
- `MatchIPSetSrc`, supporting ipset type of hashIPPort as destination IP and port.
- `MatchIPSetDst`, supporting ipset type of hashIPPort as source IP and port.
- Rename `MatchDstPort` to `MatchPortDst` to be consistent with other method.
- Rename `MatchSrcPort` to `MatchPortSrc` to be consistent with other method.