### PR TITLE
Prevent live updates to recordContents.podLabels

### DIFF
--- a/pkg/flowaggregator/flowaggregator.go
+++ b/pkg/flowaggregator/flowaggregator.go
@@ -698,10 +698,6 @@ func (fa *flowAggregator) updateFlowAggregator(opt *options.Options) {
 			klog.InfoS("Disabled FlowLogger")
 		}
 	}
-	if opt.Config.RecordContents.PodLabels != fa.includePodLabels {
-		fa.includePodLabels = opt.Config.RecordContents.PodLabels
-		klog.InfoS("Updated RecordContents.PodLabels configuration", "value", fa.includePodLabels)
-	}
 	var unsupportedUpdates []string
 	if opt.Config.APIServer != fa.APIServer {
 		unsupportedUpdates = append(unsupportedUpdates, "apiServer")
@@ -717,6 +713,12 @@ func (fa *flowAggregator) updateFlowAggregator(opt *options.Options) {
 	}
 	if opt.Config.FlowAggregatorAddress != fa.flowAggregatorAddress {
 		unsupportedUpdates = append(unsupportedUpdates, "flowAggregatorAddress")
+	}
+	// Updating recordContents.podLabels would require either restarting the IPFIXExporter, or
+	// adding support for sending an updated IPFIX template set. For the sake of simplicity, we
+	// forbid live updates to this configuration value.
+	if opt.Config.RecordContents.PodLabels != fa.includePodLabels {
+		unsupportedUpdates = append(unsupportedUpdates, "recordContents.podLabels")
 	}
 	if len(unsupportedUpdates) > 0 {
 		klog.ErrorS(nil, "Ignoring unsupported configuration updates, please restart FlowAggregator", "keys", unsupportedUpdates)

--- a/pkg/flowaggregator/flowaggregator_test.go
+++ b/pkg/flowaggregator/flowaggregator_test.go
@@ -441,19 +441,6 @@ func TestFlowAggregator_updateFlowAggregator(t *testing.T) {
 		mockLogExporter.EXPECT().UpdateOptions(opt)
 		flowAggregator.updateFlowAggregator(opt)
 	})
-	t.Run("includePodLabels", func(t *testing.T) {
-		flowAggregator := &flowAggregator{}
-		require.False(t, flowAggregator.includePodLabels)
-		opt := &options.Options{
-			Config: &flowaggregatorconfig.FlowAggregatorConfig{
-				RecordContents: flowaggregatorconfig.RecordContentsConfig{
-					PodLabels: true,
-				},
-			},
-		}
-		flowAggregator.updateFlowAggregator(opt)
-		assert.True(t, flowAggregator.includePodLabels)
-	})
 	t.Run("unsupportedUpdate", func(t *testing.T) {
 		flowAggregator := &flowAggregator{}
 		var b bytes.Buffer


### PR DESCRIPTION
This is a partial revert of #6378.
We cannot easily support live updates to recordContents.podLabels, as it requires re-creating the IPFIXExporter, so that a new IPFIX template set can be sent.