### PR TITLE
Fix kubectl cp failure with wildcard

### DIFF
--- a/ci/jenkins/test-mc.sh
+++ b/ci/jenkins/test-mc.sh
@@ -468,7 +468,10 @@ function collect_coverage {
       kubectl exec -i $mc_controller_pod_name -n ${namespace} ${kubeconfig} -- kill -SIGINT $controller_pid
       cov_dir="${COVERAGE_DIR}/$mc_controller_pod_name-$timestamp"
       mkdir -p $cov_dir
-      kubectl cp ${namespace}/$mc_controller_pod_name:/tmp/coverage/* $cov_dir/ ${kubeconfig}
+      files=(`kubectl exec $mc_controller_pod_name -n ${namespace} ${kubeconfig} -- ls /tmp/coverage/`)
+      for file in "${files[@]}"; do
+          kubectl cp ${namespace}/$mc_controller_pod_name:/tmp/coverage/$file $cov_dir/$file ${kubeconfig}
+      done
       go tool covdata textfmt -i="${cov_dir}" -o "${cov_dir}.cov.out"
       rm -rf "${cov_dir}"
     done

--- a/ci/jenkins/test-vmc.sh
+++ b/ci/jenkins/test-vmc.sh
@@ -627,7 +627,10 @@ function collect_coverage() {
         timestamp=$(date +%Y%m%d%H%M%S)
         cov_dir="${GIT_CHECKOUT_DIR}/conformance-coverage/$antrea_controller_pod_name-$timestamp"
         mkdir -p $cov_dir
-        kubectl cp kube-system/$antrea_controller_pod_name:/tmp/coverage/* $cov_dir/
+        files=(`kubectl exec $antrea_controller_pod_name -n kube-system ${kubeconfig} -- ls /tmp/coverage/`)
+        for file in "${files[@]}"; do
+            kubectl cp kube-system/$antrea_controller_pod_name:/tmp/coverage/$file $cov_dir/$file ${kubeconfig}
+        done
         go tool covdata textfmt -i="${cov_dir}" -o "${cov_dir}.cov.out"
         rm -rf "${cov_dir}"
 
@@ -639,7 +642,10 @@ function collect_coverage() {
             timestamp=$(date +%Y%m%d%H%M%S)
             cov_dir="${GIT_CHECKOUT_DIR}/conformance-coverage/$agent-$timestamp"
             mkdir -p $cov_dir
-            kubectl cp kube-system/$agent:/tmp/coverage/* -c antrea-agent $cov_dir/
+            files=(`kubectl exec $agent -n kube-system ${kubeconfig} -c antrea-agent -- ls /tmp/coverage/`)
+            for file in "${files[@]}"; do
+                kubectl cp kube-system/$agent:/tmp/coverage/$file -c antrea-agent $cov_dir/$file ${kubeconfig}
+            done
             go tool covdata textfmt -i="${cov_dir}" -o "${cov_dir}.cov.out"
             rm -rf "${cov_dir}"
         done


### PR DESCRIPTION
It turns out kubectl cp with wildcard is not working properly. I saw following errors in our CI jobs:
```
tar: /tmp/coverage/*: Cannot stat: No such file or directory
```
Fix it by check all files on /tmp/coverage/ and copy them one by one.

Here is some discussion about the kubectl cp bug.
https://devops.stackexchange.com/questions/6669/copy-multiple-files-using-wildcard-from-kubernetes-container
