### PR TITLE
Improve Docker build for FlowAggregator image

### DIFF
--- a/build/images/flow-aggregator/Dockerfile
+++ b/build/images/flow-aggregator/Dockerfile
@@ -17,10 +17,21 @@ FROM golang:${GO_VERSION} as flow-aggregator-build
 
 WORKDIR /antrea
 
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+    --mount=type=bind,source=go.sum,target=go.sum \
+    --mount=type=bind,source=go.mod,target=go.mod \
+    go mod download
+
 COPY . /antrea
 
-RUN make flow-aggregator antctl-linux
-RUN mv bin/antctl-linux bin/antctl
+# Build antctl first in order to share an extra layer with other Antrea Docker images.
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+    --mount=type=cache,target=/root/.cache/go-build/ \
+    make antctl-linux && mv bin/antctl-linux bin/antctl
+
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+    --mount=type=cache,target=/root/.cache/go-build/ \
+    make flow-aggregator
 
 # Chose this base image so that a shell is available for users to exec into the container, run antctl and run tools like pprof easily
 FROM ubuntu:22.04
@@ -28,12 +39,12 @@ FROM ubuntu:22.04
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="The docker image for the flow aggregator"
 
-COPY --from=flow-aggregator-build /antrea/bin/flow-aggregator /
-COPY --from=flow-aggregator-build /antrea/bin/antctl /usr/local/bin/
-
 # install ca-certificates
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates \
     && rm -rf /var/lib/apt/lists/*
+
+COPY --from=flow-aggregator-build /antrea/bin/flow-aggregator /
+COPY --from=flow-aggregator-build /antrea/bin/antctl /usr/local/bin/
 
 ENTRYPOINT ["/flow-aggregator"]

--- a/build/images/flow-aggregator/Dockerfile.coverage
+++ b/build/images/flow-aggregator/Dockerfile.coverage
@@ -17,9 +17,15 @@ FROM golang:${GO_VERSION} as flow-aggregator-build
 
 WORKDIR /antrea
 
+COPY go.mod /antrea/go.mod
+
+RUN go mod download
+
 COPY . /antrea
 
-RUN make flow-aggregator-instr-binary antctl-instr-binary
+RUN make antctl-instr-binary
+
+RUN make flow-aggregator-instr-binary
 
 FROM ubuntu:22.04
 
@@ -28,6 +34,10 @@ LABEL description="The docker image for the flow aggregator with code coverage m
 
 USER root
 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY --from=flow-aggregator-build /antrea/bin/flow-aggregator-coverage /usr/local/bin/flow-aggregator
 COPY --from=flow-aggregator-build /antrea/bin/antctl-coverage /usr/local/bin/antctl
 COPY --from=flow-aggregator-build /antrea/test/e2e/utils/run_cov_binary.sh /
@@ -35,9 +45,5 @@ COPY --from=flow-aggregator-build /antrea/test/e2e/utils/run_cov_binary.sh /
 # This environment variable will persist when running the container, but can also be overwritten if needed
 ENV GOCOVERDIR=/tmp/coverage
 RUN mkdir -p $GOCOVERDIR
-
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT [ "/run_cov_binary.sh" ]


### PR DESCRIPTION
We have made some improvements to the "main" Antrea Docker images (Agent, Controller) in the past, which can also benefit the FlowAggregator image:

* use Docker cache mounts to accelerate builds
* improve layer sharing between images by building antctl first
* install apt packages first in the final image (before copying binaries over from the intermediate build image); this improves caching and build parallelism.