### PR TITLE
[e2e tests] Remove custom timeout value for coverage image

### DIFF
--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -263,13 +263,6 @@ func testAntreaGracefulExit(t *testing.T, data *TestData) {
 	var gracePeriodSeconds int64 = 60
 	t.Logf("Deleting one Antrea Pod")
 	maxDeleteTimeout := 20 * time.Second
-	// When running Antrea instrumented binary to collect e2e coverage,
-	// we need to set the maxDeleteTimeout to a larger value
-	// since it needs to collect coverage data files
-	if testOptions.enableCoverage {
-		maxDeleteTimeout = 80 * time.Second
-	}
-
 	if timeToDelete, err := data.deleteAntreaAgentOnNode(nodeName(0), gracePeriodSeconds, defaultTimeout); err != nil {
 		t.Fatalf("Error when deleting Antrea Pod: %v", err)
 	} else if timeToDelete > maxDeleteTimeout {


### PR DESCRIPTION
There should no longer be a need for a custom timeout value in testAntreaGracefulExit when coverage is enabled. The increased timeout was not actually required for code coverage collection (which is qite fast), but because of issues with the coverage-enabled image, which was not handling signals correctly. After #6090, this should have been fixed.