### PR TITLE
Fix hack/make-metrics-doc.sh script

### DIFF
--- a/hack/make-metrics-doc.sh
+++ b/hack/make-metrics-doc.sh
@@ -128,6 +128,8 @@ trap exit_handler INT EXIT
 $THIS_DIR/../ci/kind/kind-setup.sh create kind --prometheus --num-workers 0 --antrea-cni
 
 # Wait for Antrea components to be ready, allow Antrea inits to complete
+kubectl -n kube-system rollout status --timeout=60s daemonset/antrea-agent
+kubectl -n kube-system rollout status --timeout=60s deployment/antrea-controller
 kubectl -n kube-system wait --for=condition=ready --timeout=120s pod -l app=antrea
 sleep 30
 


### PR DESCRIPTION
From time to time, the script will fail in CI with the following error:
```
error: no matching resources found
```

This error occurs when the kubectl command used to wait for all Antrea Pods to become Ready is run but no Pod has been created yet. This is possible, especially on a slow machine, as applying the Antrea manifest does not create any Pod. Instead, it creates the antrea-agent DaemonSet and the antrea-controller Deployment, and the K8s control-plane may take some time to actually create the corresponding Pods. To fix this issue, we first wait for the rollout to complete for both antrea-agent and antrea-controller.