### PR TITLE
Automated cherry pick of #6394: Update kube version in helm charts (#6394)

### DIFF
--- a/build/charts/antrea/Chart.yaml
+++ b/build/charts/antrea/Chart.yaml
@@ -5,7 +5,7 @@ displayName: Antrea
 home: https://antrea.io/
 version: 0.0.0
 appVersion: latest
-kubeVersion: ">= 1.16.0-0"
+kubeVersion: ">= 1.19.0-0"
 icon: https://raw.githubusercontent.com/antrea-io/antrea/main/docs/assets/logo/antrea_logo.svg
 description: Kubernetes networking based on Open vSwitch
 keywords:

--- a/build/charts/flow-aggregator/Chart.yaml
+++ b/build/charts/flow-aggregator/Chart.yaml
@@ -5,7 +5,7 @@ displayName: Antrea Flow Aggregator
 home: https://antrea.io/
 version: 0.0.0
 appVersion: latest
-kubeVersion: ">= 1.16.0-0"
+kubeVersion: ">= 1.19.0-0"
 icon: https://raw.githubusercontent.com/antrea-io/antrea/main/docs/assets/logo/antrea_logo.svg
 description: Antrea Flow Aggregator
 keywords:


### PR DESCRIPTION
Cherry pick of #6394 on release-2.0.

#6394: Update kube version in helm charts (#6394)

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.