### PR TITLE
Automated cherry pick of #6394: Update kube version in helm charts (#6394)
#6397: Update Kubernetes version in charts README (#6397)

### DIFF
--- a/build/charts/antrea/Chart.yaml
+++ b/build/charts/antrea/Chart.yaml
@@ -5,7 +5,7 @@ displayName: Antrea
 home: https://antrea.io/
 version: 0.0.0
 appVersion: latest
-kubeVersion: ">= 1.16.0-0"
+kubeVersion: ">= 1.19.0-0"
 icon: https://raw.githubusercontent.com/antrea-io/antrea/main/docs/assets/logo/antrea_logo.svg
 description: Kubernetes networking based on Open vSwitch
 keywords:

--- a/build/charts/antrea/README.md
+++ b/build/charts/antrea/README.md
@@ -12,7 +12,7 @@ Kubernetes networking based on Open vSwitch
 
 ## Requirements
 
-Kubernetes: `>= 1.16.0-0`
+Kubernetes: `>= 1.19.0-0`
 
 ## Values
 

--- a/build/charts/flow-aggregator/Chart.yaml
+++ b/build/charts/flow-aggregator/Chart.yaml
@@ -5,7 +5,7 @@ displayName: Antrea Flow Aggregator
 home: https://antrea.io/
 version: 0.0.0
 appVersion: latest
-kubeVersion: ">= 1.16.0-0"
+kubeVersion: ">= 1.19.0-0"
 icon: https://raw.githubusercontent.com/antrea-io/antrea/main/docs/assets/logo/antrea_logo.svg
 description: Antrea Flow Aggregator
 keywords:

--- a/build/charts/flow-aggregator/README.md
+++ b/build/charts/flow-aggregator/README.md
@@ -12,7 +12,7 @@ Antrea Flow Aggregator
 
 ## Requirements
 
-Kubernetes: `>= 1.16.0-0`
+Kubernetes: `>= 1.19.0-0`
 
 ## Values
 


### PR DESCRIPTION
Cherry pick of #6394 #6397 on release-2.0.

#6394: Update kube version in helm charts (#6394)
#6397: Update Kubernetes version in charts README (#6397)

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.