### PR TITLE
Add support for building local kind Node image

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -71,10 +71,30 @@ jobs:
           ./hack/build-antrea-linux-all.sh --pull --distro ${{ inputs.antrea-image-distro }}
       - name: Install Kind
         run: |
-          KIND_VERSION=$(head -n1 ./ci/kind/version || echo v0.20.0)
+          KIND_VERSION=$(head -n1 ./ci/kind/version || echo v0.23.0)
           curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
           chmod +x ./kind
           sudo mv kind /usr/local/bin
+      - name: Build local image for conformance test
+        run: |
+          image="kindest/node:${{ inputs.k8s-version }}"
+          if docker pull $image 2>&1; then
+            echo "Image $image exists, no need to build it."
+          else
+            echo "Image $image does not exist, preparing to build it."
+            # Building a local Kind Node image with the latest Kubernetes version will consume a lot of disk space.
+            # We need to free up some disk space before building the image.
+            sudo apt-get clean
+            sudo rm -rf /usr/share/dotnet || true
+            sudo rm -rf /opt/ghc || true
+            sudo rm -rf "/usr/local/share/boost" || true
+            sudo rm -rf "$AGENT_TOOLSDIRECTORY" || true
+
+            git clone --depth 1 --branch ${{ inputs.k8s-version }} https://github.com/kubernetes/kubernetes.git /tmp/kubernetes
+            echo "Building Kind Node image with Kubernetes version ${{ inputs.k8s-version }}"
+            kind build node-image --image kindest/node:${{ inputs.k8s-version }} /tmp/kubernetes
+            rm -rf /tmp/kubernetes
+          fi
       - name: Create K8s cluster
         run: |
           # If an image does not exist (unified vs split), a warning will be printed, but the script


### PR DESCRIPTION
When triggering Manually upstream conformance test on Linux, if the input kubernetes version has no corresponding kind node image, the job will build a kind Node image with the Kubernetes source code, and create Kind Cluster with local Node image.