### PR TITLE
Fix invalid links to build/yamls/windows

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,7 +17,7 @@ The `antrea-agent` configuration file specifies the agent configuration
 parameters. For all the agent configuration parameters of a Linux Node, refer to
 this [base configuration file](../build/charts/antrea/conf/antrea-agent.conf).
 For all the configuration parameters of a Windows Node, refer to this [base
-configuration file](../build/yamls/windows/base/conf/antrea-agent.conf)
+configuration file](../build/charts/antrea-windows/conf/antrea-agent.conf).
 
 ## antrea-controller
 

--- a/hack/windows/Helper.psm1
+++ b/hack/windows/Helper.psm1
@@ -118,8 +118,8 @@ function Install-AntreaAgent {
     }
 
     New-DirectoryIfNotExist $AntreaEtc
-    Get-WebFileIfNotExist $AntreaCNIConfigFile "$AntreaRawUrlBase/build/yamls/windows/base/conf/antrea-cni.conflist"
-    Get-WebFileIfNotExist $AntreaAgentConfigPath "$AntreaRawUrlBase/build/yamls/windows/base/conf/antrea-agent.conf"
+    Get-WebFileIfNotExist $AntreaCNIConfigFile "$AntreaRawUrlBase/build/charts/antrea-windows/conf/antrea-cni.conflist"
+    Get-WebFileIfNotExist $AntreaAgentConfigPath "$AntreaRawUrlBase/build/charts/antrea-windows/conf/antrea-agent.conf"
     yq w -i $AntreaAgentConfigPath clientConnection.kubeconfig $AntreaEtc\antrea-agent.kubeconfig
     yq w -i $AntreaAgentConfigPath antreaClientConnection.kubeconfig $AntreaEtc\antrea-agent.antrea.kubeconfig
 


### PR DESCRIPTION
After merging #6360, this directory no longer exists.