### PR TITLE
Automated cherry pick of #5737: Upgrade base image of UBI to UBI9 (#5737) #6104: Do not run tests when building OVS for UBI 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,11 +72,11 @@ jobs:
     - uses: actions/checkout@v4
       with:
         show-progress: false
-    - name: Build Antrea UBI8 Docker image without pushing to registry
+    - name: Build Antrea UBI9 Docker image without pushing to registry
       if: ${{ github.repository != 'antrea-io/antrea' || github.event_name != 'push' || github.ref != 'refs/heads/main' }}
       run: |
         ./hack/build-antrea-linux-all.sh --pull --distro ubi
-    - name: Build and push Antrea UBI8 Docker image to registry
+    - name: Build and push Antrea UBI9 Docker image to registry
       if: ${{ github.repository == 'antrea-io/antrea' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/build_tag.yml
+++ b/.github/workflows/build_tag.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           show-progress: false
-      - name: Build and push Antrea UBI8 amd64 Docker image to registry
+      - name: Build and push Antrea UBI9 amd64 Docker image to registry
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/build/images/Dockerfile.build.controller.ubi
+++ b/build/images/Dockerfile.build.controller.ubi
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG BUILD_TAG
-FROM registry.access.redhat.com/ubi8 as antrea-build
+FROM registry.access.redhat.com/ubi9 as antrea-build
 
 ADD https://go.dev/dl/?mode=json&include=all go-versions.json
 
@@ -54,7 +54,7 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=cache,target=/root/.cache/go-build/ \
     make antrea-controller
 
-FROM registry.access.redhat.com/ubi8
+FROM registry.access.redhat.com/ubi9
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="The Docker image to deploy the antrea-controller."

--- a/build/images/base/Dockerfile.ubi
+++ b/build/images/base/Dockerfile.ubi
@@ -40,7 +40,7 @@ FROM antrea/openvswitch-ubi:${BUILD_TAG}
 ARG SURICATA_VERSION
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
-LABEL description="An UBI8 based Docker base image for Antrea."
+LABEL description="An UBI9 based Docker base image for Antrea."
 
 USER root
 

--- a/build/images/ovs/CentOS.repo
+++ b/build/images/ovs/CentOS.repo
@@ -1,23 +1,27 @@
-[AppStream]
-name=CentOS-8-stream - AppStream
-mirrorlist=http://mirrorlist.centos.org/?release=8-stream&arch=$basearch&repo=AppStream&infra=$infra
-#baseurl=http://mirror.centos.org/$contentdir/8-stream/AppStream/$basearch/os/
+[appstream]
+name=CentOS Stream $releasever - AppStream
+metalink=https://mirrors.centos.org/metalink?repo=centos-appstream-9-stream&arch=$basearch&protocol=https,http
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
 gpgcheck=1
 enabled=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
 
-[BaseOS]
-name=CentOS-8-stream - Base
-mirrorlist=http://mirrorlist.centos.org/?release=8-stream&arch=$basearch&repo=BaseOS&infra=$infra
-#baseurl=http://mirror.centos.org/$contentdir/8-stream/BaseOS/$basearch/os/
+[baseos]
+name=CentOS Stream $releasever - BaseOS
+metalink=https://mirrors.centos.org/metalink?repo=centos-baseos-9-stream&arch=$basearch&protocol=https,http
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
 gpgcheck=1
 enabled=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
 
-[extras]
-name=CentOS-8-stream - Extras
-mirrorlist=http://mirrorlist.centos.org/?release=8-stream&arch=$basearch&repo=extras&infra=$infra
-#baseurl=http://mirror.centos.org/$contentdir/8-stream/extras/$basearch/os/
+[crb]
+name=CentOS Stream $releasever - CRB
+metalink=https://mirrors.centos.org/metalink?repo=centos-crb-9-stream&arch=$basearch&protocol=https,http
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
 gpgcheck=1
 enabled=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
+
+[extras-common]
+name=CentOS Stream $releasever - Extras packages
+metalink=https://mirrors.centos.org/metalink?repo=centos-extras-sig-extras-common-9-stream&arch=$basearch&protocol=https,http
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Extras
+gpgcheck=1
+enabled=1

--- a/build/images/ovs/Dockerfile.ubi
+++ b/build/images/ovs/Dockerfile.ubi
@@ -33,9 +33,9 @@ RUN cd /tmp/openvswitch* && \
     yum-builddep -y /tmp/ovs.spec && ./boot.sh && \
     ./configure --prefix=/usr --localstatedir=/var --sysconfdir=/etc && \
     # logrotate needs to run as the same user as OVS to get the proper permissions of log files.
-    # As Antrea runs OVS as root, we disable libcapng to make logrotate also run as root. 
+    # As Antrea runs OVS as root, we disable libcapng to make logrotate also run as root.
     # See https://github.com/openvswitch/ovs/blob/v2.17.7/rhel/openvswitch-fedora.spec.in#L26-L27.
-    RPMBUILD_OPT="--without libcapng" make rpm-fedora && mkdir -p /tmp/ovs-rpms && \
+    RPMBUILD_OPT="--without libcapng --without check" make rpm-fedora && mkdir -p /tmp/ovs-rpms && \
     mv /tmp/openvswitch-$OVS_VERSION/rpm/rpmbuild/RPMS/*/*.rpm  /tmp/ovs-rpms && \
     rm -rf /tmp/openvswitch*
 

--- a/build/images/ovs/Dockerfile.ubi
+++ b/build/images/ovs/Dockerfile.ubi
@@ -12,21 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# OVS build scripts are only applicable for RHEL 7.x:
-# https://docs.openvswitch.org/en/latest/intro/install/fedora/
-FROM centos:centos7 as ovs-rpms
-
+FROM quay.io/centos/centos:stream9 as ovs-rpms
 # Some patches may not apply cleanly if a non-default version is provided.
 # See build/images/deps/ovs-version for the default version.
 ARG OVS_VERSION
 
 # Install RPM tools and generic build dependencies.
-RUN yum update -y && yum install wget git yum-utils python38 rpm-build epel-release -y
+RUN yum clean all -y && yum -y install wget git yum-utils python3 rpm-build && \
+    sed -i 's/enabled=.*/enabled=1/g' /etc/yum.repos.d/centos.repo
 
 COPY apply-patches.sh /
+COPY charon-logging.conf /tmp
+COPY CentOS.repo /tmp
 
 # Download OVS source code
-RUN wget -q -O - https://www.openvswitch.org/releases/openvswitch-$OVS_VERSION.tar.gz  | tar xz -C /tmp
+RUN wget -q -O - https://www.openvswitch.org/releases/openvswitch-$OVS_VERSION.tar.gz | tar xz -C /tmp
 RUN cd /tmp/openvswitch* && \
     /apply-patches.sh && \
     sed -e "s/@VERSION@/$OVS_VERSION/" rhel/openvswitch-fedora.spec.in > /tmp/ovs.spec && \
@@ -39,30 +39,30 @@ RUN cd /tmp/openvswitch* && \
     mv /tmp/openvswitch-$OVS_VERSION/rpm/rpmbuild/RPMS/*/*.rpm  /tmp/ovs-rpms && \
     rm -rf /tmp/openvswitch*
 
-
-FROM registry.access.redhat.com/ubi8
+FROM registry.access.redhat.com/ubi9
+ARG OVS_VERSION
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
-LABEL description="A Docker image based on UBI8 which includes Open vSwitch built from source."
+LABEL description="A Docker image based on UBI9 which includes Open vSwitch built from source."
 
-# Change Repository from UBI8’s to CentOS because UBI8's repository does not contain
-# enough packages required by OVS installation.
-# Using the official RHEL repository would be the best choice but it's not publicly accessible.
-COPY CentOS.repo /tmp/CentOS.repo
-COPY charon-logging.conf /tmp
-COPY --from=ovs-rpms /tmp/ovs-rpms/* /tmp/ovs-rpms/
-RUN rm -f /etc/yum.repos.d/* && mv /tmp/CentOS.repo /etc/yum.repos.d/CentOS.repo && \
-    curl https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official -o /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial && \
+RUN --mount=type=bind,from=ovs-rpms,source=/tmp/,target=/tmp/build \
     # Disable the default redhat.repo. This substitutes `subscription-manager config --rhsm.manage_repos=0`
     # as subscription-manager is not supported running in containers.
     sed -i.bak "s/^manage_repos = .$/manage_repos = 0/g" /etc/rhsm/rhsm.conf && \
-    yum install /tmp/ovs-rpms/* -y && yum install epel-release -y && \
-    yum install iptables logrotate -y && \
+    # Change Repository from UBI to CentOS because UBI repository does not contain
+    # enough packages required by OVS installation.
+    # Using the official RHEL repository would be the best choice but it's not publicly accessible.
+    rm -f /etc/yum.repos.d/* && cp /tmp/build/CentOS.repo /etc/yum.repos.d/CentOS.repo && \
+    curl https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official -o /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial && \
+    curl https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Extras -o /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Extras && \
+    yum install iptables-nft logrotate epel-release -y && \
+    pushd /tmp/build/ovs-rpms && \
+    yum install openvswitch-${OVS_VERSION}-*.rpm openvswitch-ipsec-${OVS_VERSION}-*.rpm python3-openvswitch-${OVS_VERSION}-*.rpm -y && \
+    popd && \
     mv /etc/logrotate.d/openvswitch /etc/logrotate.d/openvswitch-switch && \
     sed -i "/rotate /a\    #size 100M" /etc/logrotate.d/openvswitch-switch && \
     # https://github.com/libreswan/libreswan/blob/main/programs/setup/setup.in
     # The init system is configured to systemd by default. Change it to namespaces
     # to spawn the ipsec process directly.
     sed -i 's/^initsystem=.*$/initsystem="namespaces"/' /usr/libexec/ipsec/setup && \
-    rm /etc/rhsm/rhsm.conf.bak && \
-    rm -rf /tmp/* && yum clean all
+    rm /etc/rhsm/rhsm.conf.bak && yum clean all

--- a/build/images/ovs/build.sh
+++ b/build/images/ovs/build.sh
@@ -117,6 +117,8 @@ if $PULL; then
         IMAGES_LIST=(
             "antrea/openvswitch-rpms:$BUILD_TAG"
             "antrea/openvswitch-ubi:$BUILD_TAG"
+            "quay.io/centos/centos:stream9"
+            "registry.access.redhat.com/ubi9"
         )
     fi
     for image in "${IMAGES_LIST[@]}"; do

--- a/hack/build-antrea-linux-all.sh
+++ b/hack/build-antrea-linux-all.sh
@@ -101,7 +101,7 @@ if [ "$DISTRO" != "ubuntu" ] && [ "$DISTRO" != "ubi" ]; then
 fi
 if [ "$DISTRO" == "ubi" ]; then
     if $COVERAGE ; then
-        echoerr "No coverage build for UBI8"
+        echoerr "No coverage build for UBI9"
         exit 1
     fi
     ARGS="$ARGS --distro ubi"
@@ -141,6 +141,8 @@ if $PULL; then
             "antrea/openvswitch-ubi:$BUILD_TAG"
             "antrea/cni-binaries:$CNI_BINARIES_VERSION"
             "antrea/base-ubi:$BUILD_TAG"
+            "quay.io/centos/centos:stream9"
+            "registry.access.redhat.com/ubi9"
         )
     fi
     for image in "${IMAGES_LIST[@]}"; do


### PR DESCRIPTION
Cherry pick of #5737 #6104 on release-1.15.

#5737: Upgrade base image of UBI to UBI9 (#5737)
#6104: Do not run tests when building OVS for UBI (#6104)

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.