### PR TITLE
Fix manifest generation step for e2e test

### DIFF
--- a/ci/jenkins/test.sh
+++ b/ci/jenkins/test.sh
@@ -530,10 +530,10 @@ function deliver_antrea {
     chmod -R g-w build/images/base
     if [[ "$BUILD_TAG" != "latest" ]]; then
         DOCKER_REGISTRY="${DOCKER_REGISTRY}" ./hack/build-antrea-linux-all.sh --build-tag ${BUILD_TAG} --pull
-        IMG_TAG="${BUILD_TAG}" ./hack/generate-manifest.sh $MANIFEST_ARGS
+        IMG_TAG="${BUILD_TAG}" ./hack/generate-manifest.sh $MANIFEST_ARGS > build/yamls/antrea.yml
     else
         DOCKER_REGISTRY="${DOCKER_REGISTRY}" ./hack/build-antrea-linux-all.sh --pull
-        ./hack/generate-manifest.sh $MANIFEST_ARGS
+        ./hack/generate-manifest.sh $MANIFEST_ARGS > build/yamls/antrea.yml
     fi
     make flow-aggregator-image
 


### PR DESCRIPTION
generate-manifest.sh generates manifests to the standard output by default, this means all feature changes in test.sh does not take effect now without file redirection. Add it back to save the changes to the local antrea.yml.

The bug is introduced by #6010 which has been merged, we need to merge this bug fix ASAP, otherwise, our e2e tests for other PRs might not be valid.