### PR TITLE
Update Antrea Windows requirements for containerd and Kubernetes

### DIFF
--- a/ci/kind/kind-setup.sh
+++ b/ci/kind/kind-setup.sh
@@ -457,7 +457,7 @@ function printUnixTimestamp {
 
 function setup_external_server {
   if [[ $DEPLOY_EXTERNAL_SERVER == true ]]; then
-    docker run -d --name antrea-external-server-$RANDOM --network kind -it --rm registry.k8s.io/e2e-test-images/agnhost:2.29 netexec &> /dev/null
+    docker run -d --name antrea-external-server-$RANDOM --network kind -it --rm registry.k8s.io/e2e-test-images/agnhost:2.40 netexec &> /dev/null
   fi
 }
 

--- a/ci/kind/test-e2e-kind.sh
+++ b/ci/kind/test-e2e-kind.sh
@@ -240,7 +240,7 @@ if $flow_visibility; then
     manifest_args="$manifest_args --feature-gates FlowExporter=true,L7FlowExporter=true --extra-helm-values-file $FLOW_VISIBILITY_HELM_VALUES"
 fi
 
-COMMON_IMAGES_LIST=("registry.k8s.io/e2e-test-images/agnhost:2.29" \
+COMMON_IMAGES_LIST=("registry.k8s.io/e2e-test-images/agnhost:2.40" \
                     "antrea/nginx:1.21.6-alpine" \
                     "antrea/toolbox:1.3-0")
 

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -103,6 +103,22 @@ higher (containerd 1.7 or higher is recommended). It relies on support for
 [Windows HostProcess Pods](https://kubernetes.io/docs/tasks/configure-pod-container/create-hostprocess-pod/),
 which is generally available starting with K8s 1.26.
 
+More detailed containerd Version requirements are outlined below:
+
+| Kubernetes Version  | Recommended containerd Version |
+| ------------------- | ---------------- |
+| 1.26                | 1.7.0+, 1.6.18+  |
+| 1.27                | 1.7.0+, 1.6.18+  |
+| 1.28                | 1.7.0+, 1.6.18+  |
+| 1.29                | 1.7.11+, 1.6.27+ |
+| 1.30                | 1.7.13+, 1.6.28+ |
+
+Note: Starting from Antrea v2.1, Antrea Windows image is built based on the HPC (Host
+Process Containers) image, containerd version 1.6.18 or higher is required because
+versions earlier than 1.6.18 do not support importing HPC images on Windows.
+
+For more detailed information on Kubernetes-supported containerd versions, refer to the [Containerd releases page](https://containerd.io/releases/#kubernetes-support)
+
 Starting with Antrea v1.13, Antrea takes over all the responsibilities of
 kube-proxy for Windows Nodes by default, and kube-proxy should not be deployed
 on Windows Nodes with Antrea.
@@ -231,7 +247,7 @@ running the script. The following command downloads and executes
 ```powershell
 # Example:
 curl.exe -LO "https://raw.githubusercontent.com/antrea-io/antrea/main/hack/windows/Prepare-Node.ps1"
-.\Prepare-Node.ps1 -KubernetesVersion v1.29.0 -NodeIP 192.168.1.10
+.\Prepare-Node.ps1 -KubernetesVersion v1.30.0 -NodeIP 192.168.1.10
 ```
 
 ##### 4. Prepare Node environment needed by antrea-agent

--- a/hack/netpol-generator/test-kind.sh
+++ b/hack/netpol-generator/test-kind.sh
@@ -34,8 +34,8 @@ kind load docker-image antrea/antrea-controller-ubuntu:latest
 docker pull mfenwick100/cyclonus:v0.4.7
 kind load docker-image mfenwick100/cyclonus:v0.4.7
 # pre-load agnhost image
-docker pull registry.k8s.io/e2e-test-images/agnhost:2.29
-kind load docker-image registry.k8s.io/e2e-test-images/agnhost:2.29
+docker pull registry.k8s.io/e2e-test-images/agnhost:2.40
+kind load docker-image registry.k8s.io/e2e-test-images/agnhost:2.40
 
 "$ROOT_DIR"/hack/generate-manifest.sh | kubectl apply -f -
 

--- a/hack/windows/Prepare-Node.ps1
+++ b/hack/windows/Prepare-Node.ps1
@@ -34,7 +34,7 @@ Specifies whether OVS userspace processes are included in the installation. If f
 processes will not be installed as a Windows service on the host.
 
 .EXAMPLE
-PS> .\Prepare-Node.ps1 -KubernetesVersion v1.27.0 -NodeIP 192.168.1.10 -ContainerRuntime containerd 
+PS> .\Prepare-Node.ps1 -KubernetesVersion v1.30.0 -NodeIP 192.168.1.10 -ContainerRuntime containerd 
 
 #>
 

--- a/multicluster/test/e2e/framework.go
+++ b/multicluster/test/e2e/framework.go
@@ -51,7 +51,7 @@ const (
 	regularNodeClientSuffix string = "regular-client"
 
 	nginxImage   = "antrea/nginx:1.21.6-alpine"
-	agnhostImage = "registry.k8s.io/e2e-test-images/agnhost:2.29"
+	agnhostImage = "registry.k8s.io/e2e-test-images/agnhost:2.40"
 )
 
 var provider providers.ProviderInterface

--- a/pkg/antctl/raw/check/installation/command.go
+++ b/pkg/antctl/raw/check/installation/command.go
@@ -68,7 +68,7 @@ const (
 	kindEchoName                = "echo"
 	kindClientName              = "client"
 	agentDaemonSetName          = "antrea-agent"
-	deploymentImage             = "registry.k8s.io/e2e-test-images/agnhost:2.29"
+	deploymentImage             = "registry.k8s.io/e2e-test-images/agnhost:2.40"
 	podReadyTimeout             = 1 * time.Minute
 )
 

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -120,7 +120,7 @@ const (
 	antreaControllerConfName = "antrea-controller.conf"
 	flowAggregatorConfName   = "flow-aggregator.conf"
 
-	agnhostImage        = "registry.k8s.io/e2e-test-images/agnhost:2.29"
+	agnhostImage        = "registry.k8s.io/e2e-test-images/agnhost:2.40"
 	ToolboxImage        = "antrea/toolbox:1.3-0"
 	mcjoinImage         = "antrea/mcjoin:v2.9"
 	nginxImage          = "antrea/nginx:1.21.6-alpine"


### PR DESCRIPTION
* Add detailed containerd version requirements for various Kubernetes versions.
* Upgrade agnhost image for Windows2022 compatibility.