### PR TITLE
Fix the cause of failure of multiple kind job runs on same VM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,14 +37,6 @@ TEST_ARGS ?=
 # If we have stdin we can run interactive so the tests running in docker can be interrupted.
 INTERACTIVE_ARGS := $(shell [ -t 0 ] && echo "-it")
 
-BUILD_TAG :=
-ifndef CUSTOM_BUILD_TAG
-	BUILD_TAG = $(shell build/images/build-tag.sh)
-else
-	BUILD_TAG = $(CUSTOM_BUILD_TAG)
-	DOCKER_IMG_VERSION = $(CUSTOM_BUILD_TAG)
-endif
-
 DOCKER_BUILD_ARGS :=
 ifeq ($(NO_PULL),)
 	DOCKER_BUILD_ARGS += --pull
@@ -57,7 +49,6 @@ ifneq ($(DOCKER_TARGETPLATFORM),)
 endif
 DOCKER_BUILD_ARGS += --build-arg OVS_VERSION=$(OVS_VERSION)
 DOCKER_BUILD_ARGS += --build-arg GO_VERSION=$(GO_VERSION)
-DOCKER_BUILD_ARGS += --build-arg BUILD_TAG=$(BUILD_TAG)
 
 export CGO_ENABLED
 
@@ -65,6 +56,17 @@ export CGO_ENABLED
 all: build
 
 include versioning.mk
+
+# This should be located after the include directive for versioning.mk,
+# so that we can override DOCKER_IMG_VERSION with CUSTOM_BUILD_TAG.
+BUILD_TAG :=
+ifndef CUSTOM_BUILD_TAG
+	BUILD_TAG = $(shell build/images/build-tag.sh)
+else
+	BUILD_TAG = $(CUSTOM_BUILD_TAG)
+	DOCKER_IMG_VERSION = $(CUSTOM_BUILD_TAG)
+endif
+DOCKER_BUILD_ARGS += --build-arg BUILD_TAG=$(BUILD_TAG)
 
 LDFLAGS += $(VERSION_LDFLAGS)
 

--- a/ci/jenkins/test.sh
+++ b/ci/jenkins/test.sh
@@ -73,8 +73,8 @@ Run K8s e2e community tests (Conformance & Network Policy) or Antrea e2e tests o
         --kind-cluster-name      Name of the kind Cluster.
         --proxyall               Enable proxyAll to test AntreaProxy.
         --build-tag              Custom build tag for images.
-        --docker-user             Username for Docker account.
-        --docker-password         Password for Docker account."
+        --docker-user            Username for Docker account.
+        --docker-password        Password for Docker account."
 
 function print_usage {
     echoerr "$_usage"
@@ -201,7 +201,7 @@ function clean_antrea {
     for antrea_yml in ${WORKDIR}/*.yml; do
         kubectl delete -f $antrea_yml --ignore-not-found=true || true
     done
-    docker images --format "{{.Repository}}:{{.Tag}}" | grep 'antrea'| xargs -r docker rmi -f || true
+    docker images --format "{{.Repository}}:{{.Tag}}" | grep ${BUILD_TAG} | xargs -r docker rmi || true
     docker images | grep '<none>' | awk '{print $3}' | xargs -r docker rmi || true
     check_and_cleanup_docker_build_cache
 }
@@ -666,9 +666,9 @@ function run_e2e {
     if [[ $TESTBED_TYPE == "flexible-ipam" ]]; then
         go test -v antrea.io/antrea/test/e2e --logs-export-dir `pwd`/antrea-test-logs --provider remote -timeout=100m --prometheus --antrea-ipam
     elif [[ $TESTBED_TYPE == "kind" ]]; then
-        go test -v antrea.io/antrea/test/e2e --logs-export-dir `pwd`/antrea-test-logs --provider kind -timeout=100m --prometheus
+        go test -v antrea.io/antrea/test/e2e --logs-export-dir `pwd`/antrea-test-logs --provider kind --kind.kubeconfig ${KUBECONFIG_PATH} -timeout=100m --prometheus
     elif [[ $TESTBED_TYPE == "kind-flexible-ipam" ]]; then
-        go test -v antrea.io/antrea/test/e2e --logs-export-dir `pwd`/antrea-test-logs --provider kind -timeout=100m --prometheus --antrea-ipam
+        go test -v antrea.io/antrea/test/e2e --logs-export-dir `pwd`/antrea-test-logs --provider kind --kind.kubeconfig ${KUBECONFIG_PATH} -timeout=100m --prometheus --antrea-ipam
     else
         go test -v antrea.io/antrea/test/e2e --logs-export-dir `pwd`/antrea-test-logs --provider remote -timeout=100m --prometheus
     fi

--- a/ci/kind/kind-setup.sh
+++ b/ci/kind/kind-setup.sh
@@ -565,7 +565,7 @@ function clean_kind {
       flock -x 200
 
       current_timestamp=$(date +%s)
-      touch ~/.antrea/.clusters.swp
+      > ~/.antrea/.clusters.swp
       while IFS=' ' read -r name creationTimestamp; do
           if [[ -z "$name" || -z "$creationTimestamp" ]]; then
               continue

--- a/test/e2e/providers/kind.go
+++ b/test/e2e/providers/kind.go
@@ -15,6 +15,7 @@
 package providers
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"path"
@@ -22,6 +23,8 @@ import (
 
 	"antrea.io/antrea/test/e2e/providers/exec"
 )
+
+var kindKubeconfigPath = flag.String("kind.kubeconfig", path.Join(homedir, ".kube", "config"), "Path of the kubeconfig of the cluster")
 
 type KindProvider struct {
 	controlPlaneNodeName string
@@ -47,15 +50,10 @@ func (provider *KindProvider) RunCommandOnNodeExt(nodeName, cmd string, envs map
 }
 
 func (provider *KindProvider) GetKubeconfigPath() (string, error) {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("error when retrieving user home directory: %v", err)
+	if _, err := os.Stat(*kindKubeconfigPath); os.IsNotExist(err) {
+		return "", fmt.Errorf("Kubeconfig file not found at expected location '%s'", *kindKubeconfigPath)
 	}
-	kubeconfigPath := path.Join(homeDir, ".kube", "config")
-	if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
-		return "", fmt.Errorf("Kubeconfig file not found at expected location '%s'", kubeconfigPath)
-	}
-	return kubeconfigPath, nil
+	return *kindKubeconfigPath, nil
 }
 
 // enableKubectlOnControlPlane copies the Kubeconfig file on the Kind control-plane / control-plane Node to the


### PR DESCRIPTION
There were three main causes of failure:
1) Overriding of DOCKER_IMG_VERSION in makefile.
2) Overriding of kubeconfig because of which, when
we ran multiple e2e tests together it used the
same kubeconfig which was present the default
location, so multiple jobs used the same cluster
and failed.
3) Cleanup of antrea images after test.

Refer #6446 for more details