### PR TITLE
Wait for OVS bridge datapath ID to be available after creating br-int

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -212,6 +212,12 @@ func (i *Initializer) setupOVSBridge() error {
 		return err
 	}
 
+	// Wait for the datapath ID for the bridge to be available, as it indicates that the bridge
+	// has been configured and that we should be able to query supported datapath features.
+	if _, err := i.ovsBridgeClient.WaitForDatapathID(5 * time.Second); err != nil {
+		return fmt.Errorf("error when waiting for OVS bridge datapath ID: %w", err)
+	}
+
 	if err := i.validateSupportedDPFeatures(); err != nil {
 		return err
 	}

--- a/pkg/ovs/ovsconfig/interfaces.go
+++ b/pkg/ovs/ovsconfig/interfaces.go
@@ -16,6 +16,7 @@ package ovsconfig
 
 import (
 	"net"
+	"time"
 )
 
 type TunnelType string
@@ -54,6 +55,7 @@ type OVSBridgeClient interface {
 	GetExternalIDs() (map[string]string, Error)
 	SetExternalIDs(externalIDs map[string]interface{}) Error
 	GetDatapathID() (string, Error)
+	WaitForDatapathID(timeout time.Duration) (string, Error)
 	SetDatapathID(datapathID string) Error
 	GetInterfaceOptions(name string) (map[string]string, Error)
 	SetInterfaceOptions(name string, options map[string]interface{}) Error

--- a/pkg/ovs/ovsconfig/testing/mock_ovsconfig.go
+++ b/pkg/ovs/ovsconfig/testing/mock_ovsconfig.go
@@ -26,6 +26,7 @@ package testing
 import (
 	net "net"
 	reflect "reflect"
+	time "time"
 
 	ovsconfig "antrea.io/antrea/pkg/ovs/ovsconfig"
 	gomock "go.uber.org/mock/gomock"
@@ -529,4 +530,19 @@ func (m *MockOVSBridgeClient) UpdateOVSOtherConfig(arg0 map[string]any) ovsconfi
 func (mr *MockOVSBridgeClientMockRecorder) UpdateOVSOtherConfig(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateOVSOtherConfig", reflect.TypeOf((*MockOVSBridgeClient)(nil).UpdateOVSOtherConfig), arg0)
+}
+
+// WaitForDatapathID mocks base method.
+func (m *MockOVSBridgeClient) WaitForDatapathID(arg0 time.Duration) (string, ovsconfig.Error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitForDatapathID", arg0)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(ovsconfig.Error)
+	return ret0, ret1
+}
+
+// WaitForDatapathID indicates an expected call of WaitForDatapathID.
+func (mr *MockOVSBridgeClientMockRecorder) WaitForDatapathID(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForDatapathID", reflect.TypeOf((*MockOVSBridgeClient)(nil).WaitForDatapathID), arg0)
 }


### PR DESCRIPTION
We wait (for a maximum of 5s) for the datapath_id of the br-int OVS bridge to be reported in OVSDB, after creating the bridge and before checking supported datapath features. This prevents errors when querying the supported features before the ofproto-dpif provider has been initialized.

Fixes #6471