### PR TITLE
Fix build warnings from BuildKit

### DIFF
--- a/build/images/Dockerfile.build.agent.coverage
+++ b/build/images/Dockerfile.build.agent.coverage
@@ -14,7 +14,7 @@
 
 ARG GO_VERSION
 ARG BUILD_TAG
-FROM golang:${GO_VERSION} as antrea-build
+FROM golang:${GO_VERSION} AS antrea-build
 
 WORKDIR /antrea
 

--- a/build/images/Dockerfile.build.agent.ubi
+++ b/build/images/Dockerfile.build.agent.ubi
@@ -14,7 +14,7 @@
 
 ARG GO_VERSION
 ARG BUILD_TAG
-FROM golang:${GO_VERSION} as antrea-build
+FROM golang:${GO_VERSION} AS antrea-build
 
 WORKDIR /antrea
 

--- a/build/images/Dockerfile.build.agent.ubuntu
+++ b/build/images/Dockerfile.build.agent.ubuntu
@@ -14,7 +14,7 @@
 
 ARG GO_VERSION
 ARG BUILD_TAG
-FROM golang:${GO_VERSION} as antrea-build
+FROM golang:${GO_VERSION} AS antrea-build
 
 WORKDIR /antrea
 

--- a/build/images/Dockerfile.build.controller.coverage
+++ b/build/images/Dockerfile.build.controller.coverage
@@ -14,7 +14,7 @@
 
 ARG GO_VERSION
 ARG BUILD_TAG
-FROM golang:${GO_VERSION} as antrea-build
+FROM golang:${GO_VERSION} AS antrea-build
 
 WORKDIR /antrea
 

--- a/build/images/Dockerfile.build.controller.ubi
+++ b/build/images/Dockerfile.build.controller.ubi
@@ -14,7 +14,7 @@
 
 ARG GO_VERSION
 ARG BUILD_TAG
-FROM golang:${GO_VERSION} as antrea-build
+FROM golang:${GO_VERSION} AS antrea-build
 
 WORKDIR /antrea
 

--- a/build/images/Dockerfile.build.controller.ubuntu
+++ b/build/images/Dockerfile.build.controller.ubuntu
@@ -14,7 +14,7 @@
 
 ARG GO_VERSION
 ARG BUILD_TAG
-FROM golang:${GO_VERSION} as antrea-build
+FROM golang:${GO_VERSION} AS antrea-build
 
 WORKDIR /antrea
 

--- a/build/images/Dockerfile.build.windows
+++ b/build/images/Dockerfile.build.windows
@@ -15,7 +15,7 @@
 ARG GO_VERSION
 ARG OVS_VERSION
 
-FROM --platform=linux/amd64 golang:${GO_VERSION} as antrea-build-windows
+FROM --platform=linux/amd64 golang:${GO_VERSION} AS antrea-build-windows
 ARG CNI_BINARIES_VERSION
 ENV CNI_PLUGINS="./host-local.exe"
 
@@ -42,7 +42,7 @@ RUN mkdir -p /go/k/antrea/bin && \
     cp /antrea/bin/antctl.exe /go/k/antrea/bin/ && \
     cp /antrea/bin/antrea-cni.exe /go/k/antrea/cni/antrea.exe
 
-FROM antrea/windows-ovs:${OVS_VERSION} as antrea-ovs
+FROM antrea/windows-ovs:${OVS_VERSION} AS antrea-ovs
 
 FROM mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image:v1.0.0
 COPY --from=antrea-build-windows /go/k /k

--- a/build/images/Dockerfile.simulator.build.ubuntu
+++ b/build/images/Dockerfile.simulator.build.ubuntu
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG GO_VERSION
-FROM golang:${GO_VERSION} as antrea-build
+FROM golang:${GO_VERSION} AS antrea-build
 
 WORKDIR /antrea
 

--- a/build/images/base/Dockerfile
+++ b/build/images/base/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG BUILD_TAG
-FROM ubuntu:22.04 as cni-binaries
+FROM ubuntu:22.04 AS cni-binaries
 
 ARG CNI_BINARIES_VERSION
 

--- a/build/images/base/Dockerfile.ubi
+++ b/build/images/base/Dockerfile.ubi
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG BUILD_TAG
-FROM ubuntu:22.04 as cni-binaries
+FROM ubuntu:22.04 AS cni-binaries
 
 ARG CNI_BINARIES_VERSION
 

--- a/build/images/codegen/Dockerfile
+++ b/build/images/codegen/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG GO_VERSION
-FROM ubuntu:22.04 as protoc
+FROM ubuntu:22.04 AS protoc
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends wget ca-certificates unzip

--- a/build/images/flow-aggregator/Dockerfile
+++ b/build/images/flow-aggregator/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG GO_VERSION
-FROM golang:${GO_VERSION} as flow-aggregator-build
+FROM golang:${GO_VERSION} AS flow-aggregator-build
 
 WORKDIR /antrea
 

--- a/build/images/flow-aggregator/Dockerfile.coverage
+++ b/build/images/flow-aggregator/Dockerfile.coverage
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG GO_VERSION
-FROM golang:${GO_VERSION} as flow-aggregator-build
+FROM golang:${GO_VERSION} AS flow-aggregator-build
 
 WORKDIR /antrea
 

--- a/build/images/ovs/Dockerfile
+++ b/build/images/ovs/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:22.04 as ovs-debs
+FROM ubuntu:22.04 AS ovs-debs
 
 # Some patches may not apply cleanly if a non-default version is provided.
 # See build/images/deps/ovs-version for the default version.

--- a/build/images/ovs/Dockerfile.ubi
+++ b/build/images/ovs/Dockerfile.ubi
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM quay.io/centos/centos:stream9 as ovs-rpms
+FROM quay.io/centos/centos:stream9 AS ovs-rpms
 # Some patches may not apply cleanly if a non-default version is provided.
 # See build/images/deps/ovs-version for the default version.
 ARG OVS_VERSION

--- a/build/images/ovs/Dockerfile.windows
+++ b/build/images/ovs/Dockerfile.windows
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=linux/amd64 ubuntu:22.04 as antrea-windows-builder
+FROM --platform=linux/amd64 ubuntu:22.04 AS antrea-windows-builder
 ARG OVS_VERSION
 
 RUN apt-get update && \

--- a/docs/cookbooks/multus/build/cni-dhcp-daemon/Dockerfile
+++ b/docs/cookbooks/multus/build/cni-dhcp-daemon/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:22.04 as cni-binary
+FROM ubuntu:22.04 AS cni-binary
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="A Docker which runs the dhcp daemon from the containernetworking project."

--- a/multicluster/build/images/Dockerfile.build
+++ b/multicluster/build/images/Dockerfile.build
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG GO_VERSION
-FROM golang:${GO_VERSION} as antrea-build
+FROM golang:${GO_VERSION} AS antrea-build
 
 WORKDIR /antrea
 

--- a/multicluster/build/images/Dockerfile.build.coverage
+++ b/multicluster/build/images/Dockerfile.build.coverage
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG GO_VERSION
-FROM golang:${GO_VERSION} as antrea-build
+FROM golang:${GO_VERSION} AS antrea-build
 
 WORKDIR /antrea
 


### PR DESCRIPTION
Recent versions of BuildKit supports build checks: https://docs.docker.com/reference/build-checks/

Because our Github CI uses a very recent version of buildx (through docker/setup-buildx-action), CI builds have been reporting warnings because we do not use the same casing for the "FROM" and "as" keywords in our Dockerfiles:
https://docs.docker.com/reference/build-checks/from-as-casing/

To avoid these warnings, we fix the casing in all Dockerfiles.