### PR TITLE
Upgrade go.uber.org/mock/mockgen to v0.4.0

### DIFF
--- a/build/images/codegen/Dockerfile
+++ b/build/images/codegen/Dockerfile
@@ -46,7 +46,7 @@ RUN go install k8s.io/code-generator/cmd/client-gen@kubernetes-$K8S_VERSION && \
     go install k8s.io/kube-openapi/cmd/openapi-gen@$KUBEOPENAPI_VERSION && \
     go install k8s.io/code-generator/cmd/go-to-protobuf@kubernetes-$K8S_VERSION && \
     go install k8s.io/code-generator/cmd/go-to-protobuf/protoc-gen-gogo@kubernetes-$K8S_VERSION && \
-    go install go.uber.org/mock/mockgen@v0.3.0 && \
+    go install go.uber.org/mock/mockgen@v0.4.0 && \
     go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.33.0 && \
     go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.3.0 && \
     go install golang.org/x/tools/cmd/goimports@latest && \

--- a/build/images/codegen/README.md
+++ b/build/images/codegen/README.md
@@ -22,6 +22,7 @@ Here is the table of codegen images that have been uploaded:
 
 | Tag                       | Change                                                                        |
 | :------------------------ | ----------------------------------------------------------------------------- |
+| kubernetes-1.29.2-build.2 | Upgraded go.uber.org/mock/mockgen to v0.4.0                                   |
 | kubernetes-1.29.2-build.1 | Upgraded controller-gen to v0.14.0                                            |
 | kubernetes-1.29.2-build.0 | Upgraded protoc (v26.0), protoc-gen-go (v1.33.0), protoc-gen-go-grpc (v1.3.0) |
 | kubernetes-1.29.2         | Upgraded K8s libraries to v1.29.2                                             |

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -22,7 +22,7 @@ function echoerr {
 }
 
 ANTREA_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
-IMAGE_NAME="antrea/codegen:kubernetes-1.29.2-build.1"
+IMAGE_NAME="antrea/codegen:kubernetes-1.29.2-build.2"
 
 # We will use git clone to make a working copy of the repository into a
 # temporary directory. This requires that all changes have been committed

--- a/multicluster/controllers/multicluster/commonarea/mock_remote_common_area.go
+++ b/multicluster/controllers/multicluster/commonarea/mock_remote_common_area.go
@@ -20,6 +20,7 @@
 //
 //	mockgen -copyright_file hack/boilerplate/license_header.raw.txt -destination multicluster/controllers/multicluster/commonarea/mock_remote_common_area.go -package commonarea antrea.io/antrea/multicluster/controllers/multicluster/commonarea CommonArea,RemoteCommonArea,ImportReconciler,RemoteCommonAreaGetter
 //
+
 // Package commonarea is a generated GoMock package.
 package commonarea
 

--- a/multicluster/controllers/multicluster/leader/mock_membercluster_status_manager.go
+++ b/multicluster/controllers/multicluster/leader/mock_membercluster_status_manager.go
@@ -20,6 +20,7 @@
 //
 //	mockgen -copyright_file hack/boilerplate/license_header.raw.txt -destination multicluster/controllers/multicluster/leader/mock_membercluster_status_manager.go -package leader antrea.io/antrea/multicluster/controllers/multicluster/leader MemberClusterStatusManager
 //
+
 // Package leader is a generated GoMock package.
 package leader
 

--- a/multicluster/hack/update-codegen.sh
+++ b/multicluster/hack/update-codegen.sh
@@ -22,7 +22,7 @@ function echoerr {
 }
 
 ANTREA_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../" && pwd )"
-IMAGE_NAME="antrea/codegen:kubernetes-1.29.2-build.1"
+IMAGE_NAME="antrea/codegen:kubernetes-1.29.2-build.2"
 
 # We will use git clone to make a working copy of the repository into a
 # temporary directory. This requires that all changes have been committed

--- a/pkg/agent/cniserver/ipam/testing/mock_ipam.go
+++ b/pkg/agent/cniserver/ipam/testing/mock_ipam.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Antrea Authors
+// Copyright 2024 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 //
 //	mockgen -copyright_file hack/boilerplate/license_header.raw.txt -destination pkg/agent/cniserver/ipam/testing/mock_ipam.go -package testing antrea.io/antrea/pkg/agent/cniserver/ipam IPAMDriver
 //
+
 // Package testing is a generated GoMock package.
 package testing
 

--- a/pkg/agent/cniserver/testing/mock_cniserver.go
+++ b/pkg/agent/cniserver/testing/mock_cniserver.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Antrea Authors
+// Copyright 2024 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 //
 //	mockgen -copyright_file hack/boilerplate/license_header.raw.txt -destination pkg/agent/cniserver/testing/mock_cniserver.go -package testing antrea.io/antrea/pkg/agent/cniserver SriovNet
 //
+
 // Package testing is a generated GoMock package.
 package testing
 

--- a/pkg/agent/flowexporter/connections/testing/mock_connections.go
+++ b/pkg/agent/flowexporter/connections/testing/mock_connections.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Antrea Authors
+// Copyright 2024 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 //
 //	mockgen -copyright_file hack/boilerplate/license_header.raw.txt -destination pkg/agent/flowexporter/connections/testing/mock_connections.go -package testing antrea.io/antrea/pkg/agent/flowexporter/connections ConnTrackDumper,NetFilterConnTrack
 //
+
 // Package testing is a generated GoMock package.
 package testing
 

--- a/pkg/agent/interfacestore/testing/mock_interfacestore.go
+++ b/pkg/agent/interfacestore/testing/mock_interfacestore.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Antrea Authors
+// Copyright 2024 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 //
 //	mockgen -copyright_file hack/boilerplate/license_header.raw.txt -destination pkg/agent/interfacestore/testing/mock_interfacestore.go -package testing antrea.io/antrea/pkg/agent/interfacestore InterfaceStore
 //
+
 // Package testing is a generated GoMock package.
 package testing
 

--- a/pkg/agent/ipassigner/testing/mock_ipassigner.go
+++ b/pkg/agent/ipassigner/testing/mock_ipassigner.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Antrea Authors
+// Copyright 2024 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 //
 //	mockgen -copyright_file hack/boilerplate/license_header.raw.txt -destination pkg/agent/ipassigner/testing/mock_ipassigner.go -package testing antrea.io/antrea/pkg/agent/ipassigner IPAssigner
 //
+
 // Package testing is a generated GoMock package.
 package testing
 

--- a/pkg/agent/memberlist/mock_memberlist_test.go
+++ b/pkg/agent/memberlist/mock_memberlist_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Antrea Authors
+// Copyright 2024 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 //
 //	mockgen -copyright_file hack/boilerplate/license_header.raw.txt -destination pkg/agent/memberlist/mock_memberlist_test.go -package memberlist antrea.io/antrea/pkg/agent/memberlist Memberlist
 //
+
 // Package memberlist is a generated GoMock package.
 package memberlist
 

--- a/pkg/agent/memberlist/testing/mock_memberlist.go
+++ b/pkg/agent/memberlist/testing/mock_memberlist.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Antrea Authors
+// Copyright 2024 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 //
 //	mockgen -copyright_file hack/boilerplate/license_header.raw.txt -destination pkg/agent/memberlist/testing/mock_memberlist.go -package testing antrea.io/antrea/pkg/agent/memberlist Interface
 //
+
 // Package testing is a generated GoMock package.
 package testing
 

--- a/pkg/agent/monitortool/testing/mock_monitortool.go
+++ b/pkg/agent/monitortool/testing/mock_monitortool.go
@@ -20,6 +20,7 @@
 //
 //	mockgen -copyright_file hack/boilerplate/license_header.raw.txt -destination pkg/agent/monitortool/testing/mock_monitortool.go -package testing antrea.io/antrea/pkg/agent/monitortool PacketListener
 //
+
 // Package testing is a generated GoMock package.
 package testing
 

--- a/pkg/agent/multicast/testing/mock_multicast.go
+++ b/pkg/agent/multicast/testing/mock_multicast.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Antrea Authors
+// Copyright 2024 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 //
 //	mockgen -copyright_file hack/boilerplate/license_header.raw.txt -destination pkg/agent/multicast/testing/mock_multicast.go -package testing antrea.io/antrea/pkg/agent/multicast RouteInterface
 //
+
 // Package testing is a generated GoMock package.
 package testing
 

--- a/pkg/agent/nodeportlocal/portcache/testing/mock_portcache.go
+++ b/pkg/agent/nodeportlocal/portcache/testing/mock_portcache.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Antrea Authors
+// Copyright 2024 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 //
 //	mockgen -copyright_file hack/boilerplate/license_header.raw.txt -destination pkg/agent/nodeportlocal/portcache/testing/mock_portcache.go -package testing antrea.io/antrea/pkg/agent/nodeportlocal/portcache LocalPortOpener
 //
+
 // Package testing is a generated GoMock package.
 package testing
 

--- a/pkg/agent/nodeportlocal/rules/testing/mock_rules.go
+++ b/pkg/agent/nodeportlocal/rules/testing/mock_rules.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Antrea Authors
+// Copyright 2024 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 //
 //	mockgen -copyright_file hack/boilerplate/license_header.raw.txt -destination pkg/agent/nodeportlocal/rules/testing/mock_rules.go -package testing antrea.io/antrea/pkg/agent/nodeportlocal/rules PodPortRules
 //
+
 // Package testing is a generated GoMock package.
 package testing
 

--- a/pkg/agent/openflow/operations/testing/mock_operations.go
+++ b/pkg/agent/openflow/operations/testing/mock_operations.go
@@ -20,6 +20,7 @@
 //
 //	mockgen -copyright_file hack/boilerplate/license_header.raw.txt -destination pkg/agent/openflow/operations/testing/mock_operations.go -package testing antrea.io/antrea/pkg/agent/openflow/operations OFEntryOperations
 //
+
 // Package testing is a generated GoMock package.
 package testing
 

--- a/pkg/agent/openflow/testing/mock_openflow.go
+++ b/pkg/agent/openflow/testing/mock_openflow.go
@@ -20,6 +20,7 @@
 //
 //	mockgen -copyright_file hack/boilerplate/license_header.raw.txt -destination pkg/agent/openflow/testing/mock_openflow.go -package testing antrea.io/antrea/pkg/agent/openflow Client
 //
+
 // Package testing is a generated GoMock package.
 package testing
 

--- a/pkg/agent/proxy/testing/mock_proxy.go
+++ b/pkg/agent/proxy/testing/mock_proxy.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Antrea Authors
+// Copyright 2024 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 //
 //	mockgen -copyright_file hack/boilerplate/license_header.raw.txt -destination pkg/agent/proxy/testing/mock_proxy.go -package testing antrea.io/antrea/pkg/agent/proxy Proxier
 //
+
 // Package testing is a generated GoMock package.
 package testing
 

--- a/pkg/agent/querier/testing/mock_querier.go
+++ b/pkg/agent/querier/testing/mock_querier.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Antrea Authors
+// Copyright 2024 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 //
 //	mockgen -copyright_file hack/boilerplate/license_header.raw.txt -destination pkg/agent/querier/testing/mock_querier.go -package testing antrea.io/antrea/pkg/agent/querier AgentQuerier
 //
+
 // Package testing is a generated GoMock package.
 package testing
 

--- a/pkg/agent/route/testing/mock_route.go
+++ b/pkg/agent/route/testing/mock_route.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Antrea Authors
+// Copyright 2024 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 //
 //	mockgen -copyright_file hack/boilerplate/license_header.raw.txt -destination pkg/agent/route/testing/mock_route.go -package testing antrea.io/antrea/pkg/agent/route Interface
 //
+
 // Package testing is a generated GoMock package.
 package testing
 

--- a/pkg/agent/secondarynetwork/podwatch/testing/mock_podwatch.go
+++ b/pkg/agent/secondarynetwork/podwatch/testing/mock_podwatch.go
@@ -20,6 +20,7 @@
 //
 //	mockgen -copyright_file hack/boilerplate/license_header.raw.txt -destination pkg/agent/secondarynetwork/podwatch/testing/mock_podwatch.go -package testing antrea.io/antrea/pkg/agent/secondarynetwork/podwatch InterfaceConfigurator,IPAMAllocator
 //
+
 // Package testing is a generated GoMock package.
 package testing
 

--- a/pkg/agent/servicecidr/testing/mock_servicecidr.go
+++ b/pkg/agent/servicecidr/testing/mock_servicecidr.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Antrea Authors
+// Copyright 2024 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 //
 //	mockgen -copyright_file hack/boilerplate/license_header.raw.txt -destination pkg/agent/servicecidr/testing/mock_servicecidr.go -package testing antrea.io/antrea/pkg/agent/servicecidr Interface
 //
+
 // Package testing is a generated GoMock package.
 package testing
 

--- a/pkg/agent/types/testing/mock_types.go
+++ b/pkg/agent/types/testing/mock_types.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Antrea Authors
+// Copyright 2024 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 //
 //	mockgen -copyright_file hack/boilerplate/license_header.raw.txt -destination pkg/agent/types/testing/mock_types.go -package testing antrea.io/antrea/pkg/agent/types McastNetworkPolicyController
 //
+
 // Package testing is a generated GoMock package.
 package testing
 

--- a/pkg/agent/util/ipset/testing/mock_ipset.go
+++ b/pkg/agent/util/ipset/testing/mock_ipset.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Antrea Authors
+// Copyright 2024 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 //
 //	mockgen -copyright_file hack/boilerplate/license_header.raw.txt -destination pkg/agent/util/ipset/testing/mock_ipset.go -package testing antrea.io/antrea/pkg/agent/util/ipset Interface
 //
+
 // Package testing is a generated GoMock package.
 package testing
 

--- a/pkg/agent/util/iptables/testing/mock_iptables_linux.go
+++ b/pkg/agent/util/iptables/testing/mock_iptables_linux.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Antrea Authors
+// Copyright 2024 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 //
 //	mockgen -copyright_file hack/boilerplate/license_header.raw.txt -destination pkg/agent/util/iptables/testing/mock_iptables_linux.go -package testing antrea.io/antrea/pkg/agent/util/iptables Interface
 //
+
 // Package testing is a generated GoMock package.
 package testing
 

--- a/pkg/agent/util/netlink/testing/mock_netlink_linux.go
+++ b/pkg/agent/util/netlink/testing/mock_netlink_linux.go
@@ -20,6 +20,7 @@
 //
 //	mockgen -copyright_file hack/boilerplate/license_header.raw.txt -destination pkg/agent/util/netlink/testing/mock_netlink_linux.go -package testing antrea.io/antrea/pkg/agent/util/netlink Interface
 //
+
 // Package testing is a generated GoMock package.
 package testing
 

--- a/pkg/agent/util/winnet/testing/mock_net_windows.go
+++ b/pkg/agent/util/winnet/testing/mock_net_windows.go
@@ -20,6 +20,7 @@
 //
 //	mockgen -copyright_file hack/boilerplate/license_header.raw.txt -destination pkg/agent/util/winnet/testing/mock_net_windows.go -package testing antrea.io/antrea/pkg/agent/util/winnet Interface
 //
+
 // Package testing is a generated GoMock package.
 package testing
 

--- a/pkg/agent/wireguard/testing/mock_wireguard.go
+++ b/pkg/agent/wireguard/testing/mock_wireguard.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Antrea Authors
+// Copyright 2024 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 //
 //	mockgen -copyright_file hack/boilerplate/license_header.raw.txt -destination pkg/agent/wireguard/testing/mock_wireguard.go -package testing antrea.io/antrea/pkg/agent/wireguard Interface
 //
+
 // Package testing is a generated GoMock package.
 package testing
 

--- a/pkg/antctl/mock_antctl_test.go
+++ b/pkg/antctl/mock_antctl_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Antrea Authors
+// Copyright 2024 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 //
 //	mockgen -copyright_file hack/boilerplate/license_header.raw.txt -destination pkg/antctl/mock_antctl_test.go -package antctl antrea.io/antrea/pkg/antctl AntctlClient
 //
+
 // Package antctl is a generated GoMock package.
 package antctl
 

--- a/pkg/controller/networkpolicy/testing/mock_networkpolicy.go
+++ b/pkg/controller/networkpolicy/testing/mock_networkpolicy.go
@@ -20,6 +20,7 @@
 //
 //	mockgen -copyright_file hack/boilerplate/license_header.raw.txt -destination pkg/controller/networkpolicy/testing/mock_networkpolicy.go -package testing antrea.io/antrea/pkg/controller/networkpolicy EndpointQuerier,PolicyRuleQuerier
 //
+
 // Package testing is a generated GoMock package.
 package testing
 

--- a/pkg/controller/querier/testing/mock_querier.go
+++ b/pkg/controller/querier/testing/mock_querier.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Antrea Authors
+// Copyright 2024 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 //
 //	mockgen -copyright_file hack/boilerplate/license_header.raw.txt -destination pkg/controller/querier/testing/mock_querier.go -package testing antrea.io/antrea/pkg/controller/querier ControllerQuerier
 //
+
 // Package testing is a generated GoMock package.
 package testing
 

--- a/pkg/flowaggregator/exporter/testing/mock_exporter.go
+++ b/pkg/flowaggregator/exporter/testing/mock_exporter.go
@@ -20,6 +20,7 @@
 //
 //	mockgen -copyright_file hack/boilerplate/license_header.raw.txt -destination pkg/flowaggregator/exporter/testing/mock_exporter.go -package testing antrea.io/antrea/pkg/flowaggregator/exporter Interface
 //
+
 // Package testing is a generated GoMock package.
 package testing
 

--- a/pkg/flowaggregator/querier/testing/mock_querier.go
+++ b/pkg/flowaggregator/querier/testing/mock_querier.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Antrea Authors
+// Copyright 2024 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 //
 //	mockgen -copyright_file hack/boilerplate/license_header.raw.txt -destination pkg/flowaggregator/querier/testing/mock_querier.go -package testing antrea.io/antrea/pkg/flowaggregator/querier FlowAggregatorQuerier
 //
+
 // Package testing is a generated GoMock package.
 package testing
 

--- a/pkg/flowaggregator/s3uploader/testing/mock_s3uploader.go
+++ b/pkg/flowaggregator/s3uploader/testing/mock_s3uploader.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Antrea Authors
+// Copyright 2024 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 //
 //	mockgen -copyright_file hack/boilerplate/license_header.raw.txt -destination pkg/flowaggregator/s3uploader/testing/mock_s3uploader.go -package testing antrea.io/antrea/pkg/flowaggregator/s3uploader S3UploaderAPI
 //
+
 // Package testing is a generated GoMock package.
 package testing
 

--- a/pkg/ipfix/testing/mock_ipfix.go
+++ b/pkg/ipfix/testing/mock_ipfix.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Antrea Authors
+// Copyright 2024 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 //
 //	mockgen -copyright_file hack/boilerplate/license_header.raw.txt -destination pkg/ipfix/testing/mock_ipfix.go -package testing antrea.io/antrea/pkg/ipfix IPFIXExportingProcess,IPFIXRegistry,IPFIXCollectingProcess,IPFIXAggregationProcess
 //
+
 // Package testing is a generated GoMock package.
 package testing
 

--- a/pkg/ovs/openflow/testing/mock_openflow.go
+++ b/pkg/ovs/openflow/testing/mock_openflow.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Antrea Authors
+// Copyright 2024 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 //
 //	mockgen -copyright_file hack/boilerplate/license_header.raw.txt -destination pkg/ovs/openflow/testing/mock_openflow.go -package testing antrea.io/antrea/pkg/ovs/openflow Bridge,Table,Flow,Action,CTAction,FlowBuilder,Group,BucketBuilder,PacketOutBuilder,Meter,MeterBandBuilder
 //
+
 // Package testing is a generated GoMock package.
 package testing
 

--- a/pkg/ovs/ovsconfig/testing/mock_ovsconfig.go
+++ b/pkg/ovs/ovsconfig/testing/mock_ovsconfig.go
@@ -20,6 +20,7 @@
 //
 //	mockgen -copyright_file hack/boilerplate/license_header.raw.txt -destination pkg/ovs/ovsconfig/testing/mock_ovsconfig.go -package testing antrea.io/antrea/pkg/ovs/ovsconfig OVSBridgeClient
 //
+
 // Package testing is a generated GoMock package.
 package testing
 

--- a/pkg/ovs/ovsctl/mock_ovsctl_test.go
+++ b/pkg/ovs/ovsctl/mock_ovsctl_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Antrea Authors
+// Copyright 2024 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 //
 //	mockgen -copyright_file hack/boilerplate/license_header.raw.txt -destination pkg/ovs/ovsctl/mock_ovsctl_test.go -package ovsctl antrea.io/antrea/pkg/ovs/ovsctl OVSOfctlRunner,OVSAppctlRunner
 //
+
 // Package ovsctl is a generated GoMock package.
 package ovsctl
 

--- a/pkg/ovs/ovsctl/testing/mock_ovsctl.go
+++ b/pkg/ovs/ovsctl/testing/mock_ovsctl.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Antrea Authors
+// Copyright 2024 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 //
 //	mockgen -copyright_file hack/boilerplate/license_header.raw.txt -destination pkg/ovs/ovsctl/testing/mock_ovsctl.go -package testing antrea.io/antrea/pkg/ovs/ovsctl OVSCtlClient
 //
+
 // Package testing is a generated GoMock package.
 package testing
 

--- a/pkg/querier/testing/mock_querier.go
+++ b/pkg/querier/testing/mock_querier.go
@@ -20,6 +20,7 @@
 //
 //	mockgen -copyright_file hack/boilerplate/license_header.raw.txt -destination pkg/querier/testing/mock_querier.go -package testing antrea.io/antrea/pkg/querier AgentNetworkPolicyInfoQuerier,AgentMulticastInfoQuerier,EgressQuerier
 //
+
 // Package testing is a generated GoMock package.
 package testing
 

--- a/pkg/util/podstore/testing/mock_podstore.go
+++ b/pkg/util/podstore/testing/mock_podstore.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Antrea Authors
+// Copyright 2024 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 //
 //	mockgen -copyright_file hack/boilerplate/license_header.raw.txt -destination pkg/util/podstore/testing/mock_podstore.go -package testing antrea.io/antrea/pkg/util/podstore Interface
 //
+
 // Package testing is a generated GoMock package.
 package testing
 

--- a/third_party/proxy/testing/mock_proxy.go
+++ b/third_party/proxy/testing/mock_proxy.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Antrea Authors
+// Copyright 2024 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 //
 //	mockgen -copyright_file hack/boilerplate/license_header.raw.txt -destination third_party/proxy/testing/mock_proxy.go -package testing antrea.io/antrea/third_party/proxy Provider
 //
+
 // Package testing is a generated GoMock package.
 package testing
 


### PR DESCRIPTION
The version of the mockgen binary included in the codegen image should match the version of the go.uber.org/mock module that we use.

There was a small change in formatting of generated files (extra empty line), which is why all generated mock files are updated as part of this PR...