### PR TITLE
Support shared LoadBalancerIP for multiple Services

### DIFF
--- a/pkg/agent/types/annotations.go
+++ b/pkg/agent/types/annotations.go
@@ -30,6 +30,9 @@ const (
 	// ServiceExternalIPPoolAnnotationKey is the key of the Service annotation that specifies the Service's desired external IP pool.
 	ServiceExternalIPPoolAnnotationKey string = "service.antrea.io/external-ip-pool"
 
+	// ServiceAllowSharedIPAnnotationKey is the key of the Service annotation that specifies whether the Service is allowed to use a shared LoadBalancer IP.
+	ServiceAllowSharedIPAnnotationKey string = "service.antrea.io/allow-shared-load-balancer-ip"
+
 	// ServiceLoadBalancerModeAnnotationKey is the key of the Service annotation that specifies the Service's load balancer mode.
 	ServiceLoadBalancerModeAnnotationKey string = "service.antrea.io/load-balancer-mode"
 

--- a/pkg/controller/serviceexternalip/controller_test.go
+++ b/pkg/controller/serviceexternalip/controller_test.go
@@ -98,10 +98,16 @@ func newController(objects, crdObjects []runtime.Object) *loadBalancerController
 	}
 }
 
+func mutateSvc(svc *corev1.Service, mutator func(_ *corev1.Service)) *corev1.Service {
+	mutator(svc)
+	return svc
+}
+
 func TestAddService(t *testing.T) {
 	tests := []struct {
 		name               string
 		externalIPPool     []*antreacrds.ExternalIPPool
+		existingServices   []*corev1.Service
 		service            *corev1.Service
 		expectedExternalIP string
 	}{
@@ -123,12 +129,55 @@ func TestAddService(t *testing.T) {
 			expectedExternalIP: "1.2.4.4",
 		},
 		{
-			name: "Service with user specified external IP",
+			name: "Service with requested IP",
 			externalIPPool: []*antreacrds.ExternalIPPool{
 				newExternalIPPool("eip1", "", "1.2.3.4", "1.2.3.5"),
 			},
 			service:            newService("svc1", "ns1", corev1.ServiceTypeLoadBalancer, "1.2.3.5", "eip1"),
 			expectedExternalIP: "1.2.3.5",
+		},
+		{
+			name: "Service with requested IP that is occupied",
+			externalIPPool: []*antreacrds.ExternalIPPool{
+				newExternalIPPool("eip1", "", "1.2.3.4", "1.2.3.5"),
+			},
+			existingServices: []*corev1.Service{
+				mutateSvc(newService("svc2", "ns1", corev1.ServiceTypeLoadBalancer, "1.2.3.5", "eip1"), func(svc *corev1.Service) {
+					svc.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{{IP: "1.2.3.5"}}
+				}),
+			},
+			service:            newService("svc1", "ns1", corev1.ServiceTypeLoadBalancer, "1.2.3.5", "eip1"),
+			expectedExternalIP: "",
+		},
+		{
+			name: "Service with requested IP that is occupied and sharable",
+			externalIPPool: []*antreacrds.ExternalIPPool{
+				newExternalIPPool("eip1", "", "1.2.3.4", "1.2.3.5"),
+			},
+			existingServices: []*corev1.Service{
+				mutateSvc(newService("svc2", "ns1", corev1.ServiceTypeLoadBalancer, "1.2.3.5", "eip1"), func(svc *corev1.Service) {
+					svc.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{{IP: "1.2.3.5"}}
+					svc.Annotations[antreaagenttypes.ServiceAllowSharedIPAnnotationKey] = "true"
+				}),
+			},
+			service: mutateSvc(newService("svc1", "ns1", corev1.ServiceTypeLoadBalancer, "1.2.3.5", "eip1"), func(svc *corev1.Service) {
+				svc.Annotations[antreaagenttypes.ServiceAllowSharedIPAnnotationKey] = "true"
+			}),
+			expectedExternalIP: "1.2.3.5",
+		},
+		{
+			name: "Service with exclusively requested IP that is occupied and sharable",
+			externalIPPool: []*antreacrds.ExternalIPPool{
+				newExternalIPPool("eip1", "", "1.2.3.4", "1.2.3.5"),
+			},
+			existingServices: []*corev1.Service{
+				mutateSvc(newService("svc2", "ns1", corev1.ServiceTypeLoadBalancer, "1.2.3.5", "eip1"), func(svc *corev1.Service) {
+					svc.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{{IP: "1.2.3.5"}}
+					svc.Annotations[antreaagenttypes.ServiceAllowSharedIPAnnotationKey] = "true"
+				}),
+			},
+			service:            newService("svc1", "ns1", corev1.ServiceTypeLoadBalancer, "1.2.3.5", "eip1"),
+			expectedExternalIP: "",
 		},
 	}
 	for _, tt := range tests {
@@ -136,6 +185,9 @@ func TestAddService(t *testing.T) {
 			stopCh := make(chan struct{})
 			defer close(stopCh)
 			var fakeObjects []runtime.Object
+			for _, svc := range tt.existingServices {
+				fakeObjects = append(fakeObjects, svc)
+			}
 			var fakeCRDObjects []runtime.Object
 			for _, eip := range tt.externalIPPool {
 				fakeCRDObjects = append(fakeCRDObjects, eip)
@@ -162,9 +214,90 @@ func TestAddService(t *testing.T) {
 			ipPool := svcUpdated.Annotations[antreaagenttypes.ServiceExternalIPPoolAnnotationKey]
 			assert.NotEmpty(t, ipPool)
 			assert.True(t, controller.externalIPAllocator.IPPoolExists(ipPool))
-			assert.True(t, controller.externalIPAllocator.IPPoolHasIP(ipPool, net.ParseIP(externalIP)))
+			if externalIP != "" {
+				assert.True(t, controller.externalIPAllocator.IPPoolHasIP(ipPool, net.ParseIP(externalIP)))
+			}
 		})
 	}
+}
+
+func TestRestart(t *testing.T) {
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	// svc1 and svc2 allow shared IP, request 1.1.1.1, and already get it assigned.
+	// They should continue using 1.1.1.1.
+	svc1 := newService("svc1", "ns1", corev1.ServiceTypeLoadBalancer, "1.1.1.1", "eip1")
+	svc1.Annotations[antreaagenttypes.ServiceAllowSharedIPAnnotationKey] = "true"
+	svc1.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{{IP: "1.1.1.1"}}
+	svc2 := newService("svc2", "ns1", corev1.ServiceTypeLoadBalancer, "1.1.1.1", "eip1")
+	svc2.Annotations[antreaagenttypes.ServiceAllowSharedIPAnnotationKey] = "true"
+	svc2.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{{IP: "1.1.1.1"}}
+	// svc3 allows shared IP and requests 1.1.1.1.
+	// It should get the IP assigned.
+	svc3 := newService("svc3", "ns1", corev1.ServiceTypeLoadBalancer, "1.1.1.1", "eip1")
+	svc3.Annotations[antreaagenttypes.ServiceAllowSharedIPAnnotationKey] = "true"
+	// svc4 doesn't allow shared IP and requests 1.1.1.1.
+	// It shouldn't get the IP assigned.
+	svc4 := newService("svc4", "ns1", corev1.ServiceTypeLoadBalancer, "1.1.1.1", "eip1")
+
+	// svc5 allows shared IP, requests 1.1.1.2, and already gets it assigned.
+	// It should continue using 1.1.1.2.
+	svc5 := newService("svc5", "ns1", corev1.ServiceTypeLoadBalancer, "1.1.1.2", "eip1")
+	svc5.Annotations[antreaagenttypes.ServiceAllowSharedIPAnnotationKey] = "true"
+	svc5.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{{IP: "1.1.1.2"}}
+	// svc6 doesn't allow shared IP, requests 1.1.1.2, and already gets it assigned.
+	// It should continue using 1.1.1.2.
+	svc6 := newService("svc6", "ns1", corev1.ServiceTypeLoadBalancer, "1.1.1.2", "eip1")
+	svc6.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{{IP: "1.1.1.2"}}
+	// svc7 allows shared IP, requests 1.1.1.2.
+	// It shouldn't get the IP assigned.
+	svc7 := newService("svc7", "ns1", corev1.ServiceTypeLoadBalancer, "1.1.1.2", "eip1")
+	svc7.Annotations[antreaagenttypes.ServiceAllowSharedIPAnnotationKey] = "true"
+	// svc8 doesn't allow shared IP, requests 1.1.1.2.
+	// It shouldn't get the IP assigned.
+	svc8 := newService("svc8", "ns1", corev1.ServiceTypeLoadBalancer, "1.1.1.2", "eip1")
+
+	// svc9 requests 1.1.1.10 and got 1.1.1.9 assigned before.
+	// It should get the requested IP assigned.
+	svc9 := newService("svc9", "ns1", corev1.ServiceTypeLoadBalancer, "1.1.1.10", "eip1")
+	svc9.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{{IP: "1.1.1.9"}}
+
+	// svc10 doesn't request a particular IP.
+	// It should get the next available IP: 1.1.1.3.
+	svc10 := newService("svc10", "ns1", corev1.ServiceTypeLoadBalancer, "", "eip1")
+
+	// svc11 requests 1.1.2.2 from another pool.
+	// It should get the requested ip assigned.
+	svc11 := newService("svc11", "ns1", corev1.ServiceTypeLoadBalancer, "1.1.2.2", "eip2")
+
+	eip1 := newExternalIPPool("eip1", "", "1.1.1.1", "1.1.1.10")
+	eip2 := newExternalIPPool("eip2", "", "1.1.2.1", "1.1.2.10")
+
+	fakeObjects := []runtime.Object{svc1, svc2, svc3, svc4, svc5, svc6, svc7, svc8, svc9, svc10, svc11}
+	fakeCRDObjects := []runtime.Object{eip1, eip2}
+	controller := newController(fakeObjects, fakeCRDObjects)
+	controller.informerFactory.Start(stopCh)
+	controller.crdInformerFactory.Start(stopCh)
+	controller.informerFactory.WaitForCacheSync(stopCh)
+	controller.crdInformerFactory.WaitForCacheSync(stopCh)
+
+	go controller.externalIPAllocator.Run(stopCh)
+	go controller.Run(stopCh)
+
+	checkForServiceExternalIP(t, controller, svc1.Name, svc1.Namespace, "1.1.1.1")
+	checkForServiceExternalIP(t, controller, svc2.Name, svc2.Namespace, "1.1.1.1")
+	checkForServiceExternalIP(t, controller, svc3.Name, svc3.Namespace, "1.1.1.1")
+	checkForServiceExternalIP(t, controller, svc4.Name, svc4.Namespace, "")
+	checkForServiceExternalIP(t, controller, svc5.Name, svc5.Namespace, "1.1.1.2")
+	checkForServiceExternalIP(t, controller, svc6.Name, svc6.Namespace, "1.1.1.2")
+	checkForServiceExternalIP(t, controller, svc7.Name, svc7.Namespace, "")
+	checkForServiceExternalIP(t, controller, svc8.Name, svc8.Namespace, "")
+	checkForServiceExternalIP(t, controller, svc9.Name, svc9.Namespace, "1.1.1.10")
+	checkForServiceExternalIP(t, controller, svc10.Name, svc10.Namespace, "1.1.1.3")
+	checkForServiceExternalIP(t, controller, svc11.Name, svc11.Namespace, "1.1.2.2")
+	checkExternalIPPoolUsed(t, controller, "eip1", 4)
+	checkExternalIPPoolUsed(t, controller, "eip2", 1)
 }
 
 func TestSyncService(t *testing.T) {
@@ -183,12 +316,20 @@ func TestSyncService(t *testing.T) {
 
 	require.True(t, cache.WaitForCacheSync(stopCh, controller.externalIPAllocator.HasSynced))
 
-	var service *corev1.Service
 	var err error
 
-	service = newService("svc1", "ns1", corev1.ServiceTypeLoadBalancer, "", "eip1")
+	service := newService("svc1", "ns1", corev1.ServiceTypeLoadBalancer, "", "eip1")
 	_, err = controller.client.CoreV1().Services(service.Namespace).Create(context.TODO(), service, metav1.CreateOptions{})
 	require.NoError(t, err)
+
+	updateService := func(svc *corev1.Service, mutator func(svc *corev1.Service)) {
+		svc, err := controller.client.CoreV1().Services(svc.Namespace).Get(context.TODO(), svc.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+		toUpdate := svc.DeepCopy()
+		toUpdate = mutateSvc(toUpdate, mutator)
+		_, err = controller.client.CoreV1().Services(toUpdate.Namespace).Update(context.TODO(), toUpdate, metav1.UpdateOptions{})
+		require.NoError(t, err)
+	}
 
 	eip1 := newExternalIPPool("eip1", "", "1.2.3.4", "1.2.3.5")
 
@@ -213,10 +354,53 @@ func TestSyncService(t *testing.T) {
 		checkExternalIPPoolUsed(t, controller, "eip1", 1)
 	})
 
+	// svc2 doesn't allow shared IP while svc3 allows it.
+	service2 := newService("svc2", "ns1", corev1.ServiceTypeLoadBalancer, "1.2.3.4", "eip1")
+	service3 := mutateSvc(newService("svc3", "ns1", corev1.ServiceTypeLoadBalancer, "1.2.3.4", "eip1"), func(svc *corev1.Service) {
+		svc.Annotations[antreaagenttypes.ServiceAllowSharedIPAnnotationKey] = "true"
+	})
+	t.Run("svc2 and svc3 requesting the same IP", func(t *testing.T) {
+		_, err = controller.client.CoreV1().Services(service2.Namespace).Create(context.TODO(), service2, metav1.CreateOptions{})
+		require.NoError(t, err)
+		_, err = controller.client.CoreV1().Services(service3.Namespace).Create(context.TODO(), service3, metav1.CreateOptions{})
+		require.NoError(t, err)
+		checkForServiceExternalIP(t, controller, service.Name, service.Namespace, "1.2.3.4")
+		checkForServiceExternalIP(t, controller, service2.Name, service2.Namespace, "")
+		checkForServiceExternalIP(t, controller, service3.Name, service3.Namespace, "")
+		checkExternalIPPoolUsed(t, controller, "eip1", 1)
+	})
+
+	t.Run("svc1 allowing shared IP", func(t *testing.T) {
+		updateService(service, func(svc *corev1.Service) {
+			svc.Annotations[antreaagenttypes.ServiceAllowSharedIPAnnotationKey] = "true"
+		})
+		checkForServiceExternalIP(t, controller, service.Name, service.Namespace, "1.2.3.4")
+		checkForServiceExternalIP(t, controller, service2.Name, service2.Namespace, "")
+		checkForServiceExternalIP(t, controller, service3.Name, service3.Namespace, "1.2.3.4")
+		checkExternalIPPoolUsed(t, controller, "eip1", 1)
+	})
+
 	t.Run("Service changes ExternalIPPool annotation to eip2", func(t *testing.T) {
 		// Change ExternalIPPool annotation.
-		service.Annotations[antreaagenttypes.ServiceExternalIPPoolAnnotationKey] = "eip2"
-		_, err = controller.client.CoreV1().Services(service.Namespace).Update(context.TODO(), service, metav1.UpdateOptions{})
+		updateService(service, func(svc *corev1.Service) {
+			svc.Annotations[antreaagenttypes.ServiceExternalIPPoolAnnotationKey] = "eip2"
+		})
+		checkForServiceExternalIP(t, controller, service.Name, service.Namespace, "")
+		checkForServiceExternalIP(t, controller, service2.Name, service2.Namespace, "")
+		checkForServiceExternalIP(t, controller, service3.Name, service3.Namespace, "1.2.3.4")
+		checkExternalIPPoolUsed(t, controller, "eip1", 1)
+	})
+
+	t.Run("svc3 deleted", func(t *testing.T) {
+		err = controller.client.CoreV1().Services(service3.Namespace).Delete(context.TODO(), service3.Name, metav1.DeleteOptions{})
+		require.NoError(t, err)
+		checkForServiceExternalIP(t, controller, service.Name, service.Namespace, "")
+		checkForServiceExternalIP(t, controller, service2.Name, service2.Namespace, "1.2.3.4")
+		checkExternalIPPoolUsed(t, controller, "eip1", 1)
+	})
+
+	t.Run("svc2 deleted", func(t *testing.T) {
+		err = controller.client.CoreV1().Services(service2.Namespace).Delete(context.TODO(), service2.Name, metav1.DeleteOptions{})
 		require.NoError(t, err)
 		checkForServiceExternalIP(t, controller, service.Name, service.Namespace, "")
 		checkExternalIPPoolUsed(t, controller, "eip1", 0)
@@ -229,66 +413,65 @@ func TestSyncService(t *testing.T) {
 		_, err = controller.crdClient.CrdV1beta1().ExternalIPPools().Create(context.TODO(), eip2, metav1.CreateOptions{})
 		require.NoError(t, err)
 		checkForServiceExternalIP(t, controller, service.Name, service.Namespace, "1.2.4.4")
-		checkExternalIPPoolUsed(t, controller, "eip1", 0)
 		checkExternalIPPoolUsed(t, controller, "eip2", 1)
 	})
 
 	t.Run("specify another IP from IP pool eip2", func(t *testing.T) {
-		service.Spec.LoadBalancerIP = "1.2.4.5"
-		_, err = controller.client.CoreV1().Services(service.Namespace).Update(context.TODO(), service, metav1.UpdateOptions{})
-		require.NoError(t, err)
+		updateService(service, func(svc *corev1.Service) {
+			svc.Spec.LoadBalancerIP = "1.2.4.5"
+		})
 		checkForServiceExternalIP(t, controller, service.Name, service.Namespace, "1.2.4.5")
-		checkExternalIPPoolUsed(t, controller, "eip1", 0)
 		checkExternalIPPoolUsed(t, controller, "eip2", 1)
 	})
 
 	t.Run("specify an IP from IP pool eip1 without changing annotation", func(t *testing.T) {
-		service.Spec.LoadBalancerIP = "1.2.3.4"
-		_, err = controller.client.CoreV1().Services(service.Namespace).Update(context.TODO(), service, metav1.UpdateOptions{})
-		require.NoError(t, err)
+		updateService(service, func(svc *corev1.Service) {
+			svc.Spec.LoadBalancerIP = "1.2.3.5"
+		})
 		checkForServiceExternalIP(t, controller, service.Name, service.Namespace, "")
 		checkExternalIPPoolUsed(t, controller, "eip1", 0)
 		checkExternalIPPoolUsed(t, controller, "eip2", 0)
 	})
 
 	t.Run("change annotation to use IP pool eip1", func(t *testing.T) {
-		service.Annotations[antreaagenttypes.ServiceExternalIPPoolAnnotationKey] = "eip1"
-		_, err = controller.client.CoreV1().Services(service.Namespace).Update(context.TODO(), service, metav1.UpdateOptions{})
-		require.NoError(t, err)
-		checkForServiceExternalIP(t, controller, service.Name, service.Namespace, "1.2.3.4")
+		updateService(service, func(svc *corev1.Service) {
+			svc.Annotations[antreaagenttypes.ServiceExternalIPPoolAnnotationKey] = "eip1"
+		})
+		checkForServiceExternalIP(t, controller, service.Name, service.Namespace, "1.2.3.5")
 		checkExternalIPPoolUsed(t, controller, "eip1", 1)
 		checkExternalIPPoolUsed(t, controller, "eip2", 0)
 	})
 
 	t.Run("Specify non-existent IP of IP pool eip1", func(t *testing.T) {
-		service.Spec.LoadBalancerIP = "1.2.3.6"
-		service.Annotations[antreaagenttypes.ServiceExternalIPPoolAnnotationKey] = "eip1"
-		_, err = controller.client.CoreV1().Services(service.Namespace).Update(context.TODO(), service, metav1.UpdateOptions{})
-		assert.NoError(t, err)
+		updateService(service, func(svc *corev1.Service) {
+			svc.Spec.LoadBalancerIP = "1.2.3.6"
+		})
 		checkForServiceExternalIP(t, controller, service.Name, service.Namespace, "")
 		checkExternalIPPoolUsed(t, controller, "eip1", 0)
+	})
+
+	t.Run("Specify empty IP", func(t *testing.T) {
+		updateService(service, func(svc *corev1.Service) {
+			svc.Spec.LoadBalancerIP = ""
+		})
+		checkForServiceExternalIP(t, controller, service.Name, service.Namespace, "1.2.3.4")
+		checkExternalIPPoolUsed(t, controller, "eip1", 1)
 		checkExternalIPPoolUsed(t, controller, "eip2", 0)
 	})
 
 	t.Run("Change Service type", func(t *testing.T) {
-		// Change Service type.
-		service.Spec.LoadBalancerIP = ""
-		_, err = controller.client.CoreV1().Services(service.Namespace).Update(context.TODO(), service, metav1.UpdateOptions{})
-		assert.NoError(t, err)
-		checkForServiceExternalIP(t, controller, service.Name, service.Namespace, "1.2.3.4")
-
-		service.Spec.Type = corev1.ServiceTypeClusterIP
-		_, err = controller.client.CoreV1().Services(service.Namespace).Update(context.TODO(), service, metav1.UpdateOptions{})
-		assert.NoError(t, err)
+		updateService(service, func(svc *corev1.Service) {
+			svc.Spec.Type = corev1.ServiceTypeClusterIP
+		})
 		checkForServiceExternalIP(t, controller, service.Name, service.Namespace, "")
 		checkExternalIPPoolUsed(t, controller, "eip1", 0)
 		checkExternalIPPoolUsed(t, controller, "eip2", 0)
 	})
 
 	t.Run("Change Service type back", func(t *testing.T) {
-		service.Spec.Type = corev1.ServiceTypeLoadBalancer
-		_, err = controller.client.CoreV1().Services(service.Namespace).Update(context.TODO(), service, metav1.UpdateOptions{})
-		require.NoError(t, err)
+		updateService(service, func(svc *corev1.Service) {
+			svc.Spec.Type = corev1.ServiceTypeLoadBalancer
+		})
 		checkForServiceExternalIP(t, controller, service.Name, service.Namespace, "1.2.3.4")
 		checkExternalIPPoolUsed(t, controller, "eip1", 1)
 		checkExternalIPPoolUsed(t, controller, "eip2", 0)
@@ -303,6 +486,7 @@ func TestSyncService(t *testing.T) {
 }
 
 func checkForServiceExternalIP(t *testing.T, controller *loadBalancerController, name, namespace, expectedExternalIP string) {
+	t.Helper()
 	assert.Eventually(t, func() bool {
 		serviceUpdated, err := controller.client.CoreV1().Services(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 		require.NoError(t, err)
@@ -312,6 +496,7 @@ func checkForServiceExternalIP(t *testing.T, controller *loadBalancerController,
 }
 
 func checkExternalIPPoolUsed(t *testing.T, controller *loadBalancerController, poolName string, used int) {
+	t.Helper()
 	exists := controller.externalIPAllocator.IPPoolExists(poolName)
 	require.True(t, exists)
 	assert.Eventually(t, func() bool {

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -1952,7 +1952,7 @@ func (data *TestData) CreateService(serviceName, namespace string, port, targetP
 
 // CreateServiceWithAnnotations creates a service with Annotation
 func (data *TestData) CreateServiceWithAnnotations(serviceName, namespace string, port, targetPort int32, protocol corev1.Protocol, selector map[string]string, affinity, nodeLocalExternal bool,
-	serviceType corev1.ServiceType, ipFamily *corev1.IPFamily, annotations map[string]string) (*corev1.Service, error) {
+	serviceType corev1.ServiceType, ipFamily *corev1.IPFamily, annotations map[string]string, mutators ...func(service *corev1.Service)) (*corev1.Service, error) {
 	affinityType := corev1.ServiceAffinityNone
 	var ipFamilies []corev1.IPFamily
 	if ipFamily != nil {
@@ -1985,6 +1985,9 @@ func (data *TestData) CreateServiceWithAnnotations(serviceName, namespace string
 	}
 	if (serviceType == corev1.ServiceTypeNodePort || serviceType == corev1.ServiceTypeLoadBalancer) && nodeLocalExternal {
 		service.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeLocal
+	}
+	for _, mutator := range mutators {
+		mutator(&service)
 	}
 	return data.clientset.CoreV1().Services(namespace).Create(context.TODO(), &service, metav1.CreateOptions{})
 }


### PR DESCRIPTION
Users want to share LoadBalancerIP between multiple Services when they face external IP shortage. It's possible to do it when the Services sharing an IP meet the requirements:

* The Services use different ports
* The Services use the `Cluster` external traffic policy, or they have identical Endpoints.

However, the ability of using any IP that is already allocated to another Service may incur a security risk that a Service can "steal" LoadBalancer traffic intended for another Service.

To support the use case without introducing the security risk, we use the annotation `service.antrea.io/allow-shared-load-balancer-ip: true` on Services to restrict IPs that can be shared. Services without the annotation will continue to have their LoadBalancerIPs exclusively used. Services with the annotation can share an IP between themselves when requesting the same IP.

Ideally, we should also check if the Services meet the first two requirements before assigning the IP to them. However, it's difficult to prevent Services from being changed to not meet the requirements after they get the IP assigned. Therefore, we assume that users using the feature know how to configure Services properly.

Fixes #4309