### PR TITLE
Build Arm images from this repo using Github-hosted Arm runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,72 +13,115 @@ on:
       - feature/*
 
 jobs:
-  check-changes:
-    name: Check whether tests need to be run based on diff
-    runs-on: [ubuntu-latest]
+  check-env:
+    name: Compute outputs for use by other jobs
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         show-progress: false
-    - uses: antrea-io/has-changes@v2
+    - name: Check whether tests need to be run based on diff
+      uses: antrea-io/has-changes@v2
       id: check_diff
       with:
         paths-ignore: docs/* ci/jenkins/* *.md hack/.notableofcontents
+    - name: Checking if image needs to be pushed
+      id: check_push
+      run: |
+        if [ "${{ github.repository }}" == "antrea-io/antrea" ] && [ "${{ github.event_name }}" == "push" ] && [ "${{ github.ref }}" == "refs/heads/main" ]; then
+          echo "push_needed=true" >> $GITHUB_OUTPUT
+          echo "docker_driver=docker-container" >> $GITHUB_OUTPUT
+        else
+          echo "push_needed=false" >> $GITHUB_OUTPUT
+          echo "docker_driver=docker" >> $GITHUB_OUTPUT
+        fi
     outputs:
       has_changes: ${{ steps.check_diff.outputs.has_changes }}
+      push_needed: ${{ steps.check_push.outputs.push_needed }}
+      docker_driver: ${{ steps.check_push.outputs.docker_driver }}
 
   build:
-    needs: check-changes
-    if: ${{ needs.check-changes.outputs.has_changes == 'yes' || github.event_name == 'push' }}
-    runs-on: [ubuntu-latest]
+    needs: check-env
+    if: ${{ needs.check-env.outputs.has_changes == 'yes' || github.event_name == 'push' }}
+    strategy:
+      matrix:
+        include:
+        - platform: linux/amd64
+          runner: ubuntu-latest
+          suffix: amd64
+        - platform: linux/arm64
+          runner: github-arm64-2c-8gb
+          suffix: arm64
+        - platform: linux/arm/v7
+          runner: github-arm64-2c-8gb
+          suffix: arm
+    runs-on: ${{ matrix.runner }}
+    env:
+      DOCKER_TAG: latest
     steps:
     - uses: actions/checkout@v4
       with:
         show-progress: false
-    - name: Checking if image needs to be pushed
-      run: |
-        if [ "${{ github.repository }}" == "antrea-io/antrea" ] && [ "${{ github.event_name }}" == "push" ] && [ "${{ github.ref }}" == "refs/heads/main" ]; then
-          echo "push_needed=true" >> $GITHUB_ENV
-          echo "docker_driver=docker-container" >> $GITHUB_ENV
-        else
-          echo "push_needed=false" >> $GITHUB_ENV
-          echo "docker_driver=docker" >> $GITHUB_ENV
-        fi
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
       with:
-        driver: ${{ env.docker_driver }}
-    - name: Build Antrea amd64 Docker image without pushing to registry
-      if: ${{ env.push_needed == 'false' }}
+        driver: ${{ needs.check-env.outputs.docker_driver }}
+    - name: Build Antrea Docker image without pushing to registry
+      if: ${{ needs.check-env.outputs.push_needed == 'false' }}
       run: |
-        ./hack/build-antrea-linux-all.sh --pull
-    - name: Build and push Antrea amd64 Docker image to registry
-      if: ${{ env.push_needed == 'true' }}
+        ./hack/build-antrea-linux-all.sh --platform ${{ matrix.platform }} --pull
+    - name: Build and push Antrea Docker image to registry
+      if: ${{ needs.check-env.outputs.push_needed == 'true' }}
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
       run: |
         echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-        ./hack/build-antrea-linux-all.sh --pull --push-base-images
-        docker tag antrea/antrea-controller-ubuntu:latest antrea/antrea-controller-ubuntu-amd64:latest
-        docker tag antrea/antrea-agent-ubuntu:latest antrea/antrea-agent-ubuntu-amd64:latest
-        docker push antrea/antrea-controller-ubuntu-amd64:latest
-        docker push antrea/antrea-agent-ubuntu-amd64:latest
-    - name: Trigger Antrea arm builds and multi-arch manifest update
-      if: ${{ github.repository == 'antrea-io/antrea' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-      uses: benc-uk/workflow-dispatch@v1
+        ./hack/build-antrea-linux-all.sh --platform ${{ matrix.platform }} --pull --push-base-images
+        docker tag antrea/antrea-controller-ubuntu:"${DOCKER_TAG}" antrea/antrea-controller-ubuntu-${{ matrix.suffix }}:"${DOCKER_TAG}"
+        docker tag antrea/antrea-agent-ubuntu:"${DOCKER_TAG}" antrea/antrea-agent-ubuntu-${{ matrix.suffix }}:"${DOCKER_TAG}"
+        docker push antrea/antrea-controller-ubuntu-${{ matrix.suffix }}:"${DOCKER_TAG}"
+        docker push antrea/antrea-agent-ubuntu-${{ matrix.suffix }}:"${DOCKER_TAG}"
+
+  push-manifest:
+    needs: [check-env, build]
+    if: ${{ needs.check-env.outputs.push_needed == 'true' }}
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_TAG: latest
+    steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
       with:
-        repo: vmware-tanzu/antrea-build-infra
-        ref: refs/heads/main
-        workflow: Build Antrea ARM images and push manifest
-        token: ${{ secrets.ANTREA_BUILD_INFRA_WORKFLOW_DISPATCH_PAT }}
-        inputs: ${{ format('{{ "antrea-repository":"antrea-io/antrea", "antrea-ref":"{0}", "docker-tag":"{1}" }}', github.ref, 'latest') }}
+        driver: ${{ needs.check-env.outputs.docker_driver }}
+    - name: Docker login
+      env:
+        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      run: |
+        echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+    - name: Create and push manifest for controller image
+      run: |
+        docker manifest create antrea/antrea-controller-ubuntu:"${DOCKER_TAG}" \
+          antrea/antrea-controller-ubuntu-arm64:"${DOCKER_TAG}" \
+          antrea/antrea-controller-ubuntu-arm:"${DOCKER_TAG}" \
+          antrea/antrea-controller-ubuntu-amd64:"${DOCKER_TAG}"
+        docker manifest push --purge antrea/antrea-controller-ubuntu:"${DOCKER_TAG}"
+    - name: Create and push manifest for agent image
+      run: |
+        docker manifest create antrea/antrea-agent-ubuntu:"${DOCKER_TAG}" \
+          antrea/antrea-agent-ubuntu-arm64:"${DOCKER_TAG}" \
+          antrea/antrea-agent-ubuntu-arm:"${DOCKER_TAG}" \
+          antrea/antrea-agent-ubuntu-amd64:"${DOCKER_TAG}"
+        docker manifest push --purge antrea/antrea-agent-ubuntu:"${DOCKER_TAG}"
 
   build-ubi:
-    needs: check-changes
-    if: ${{ needs.check-changes.outputs.has_changes == 'yes' || github.event_name == 'push' }}
-    runs-on: [ubuntu-latest]
+    needs: check-env
+    if: ${{ needs.check-env.outputs.has_changes == 'yes' || github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_TAG: latest
     steps:
     - name: Free disk space
       # https://github.com/actions/virtual-environments/issues/709
@@ -88,40 +131,31 @@ jobs:
     - uses: actions/checkout@v4
       with:
         show-progress: false
-    - name: Checking if image needs to be pushed
-      run: |
-        if [ "${{ github.repository }}" == "antrea-io/antrea" ] && [ "${{ github.event_name }}" == "push" ] && [ "${{ github.ref }}" == "refs/heads/main" ]; then
-          echo "push_needed=true" >> $GITHUB_ENV
-          echo "docker_driver=docker-container" >> $GITHUB_ENV
-        else
-          echo "push_needed=false" >> $GITHUB_ENV
-          echo "docker_driver=docker" >> $GITHUB_ENV
-        fi
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
       with:
-        driver: ${{ env.docker_driver }}
+        driver: ${{ needs.check-env.outputs.docker_driver }}
     - uses: actions/setup-go@v5
       with:
         go-version-file: 'go.mod'
     - name: Build Antrea UBI9 Docker image without pushing to registry
-      if: ${{ env.push_needed == 'false' }}
+      if: ${{ needs.check-env.outputs.push_needed == 'false' }}
       run: |
         ./hack/build-antrea-linux-all.sh --pull --distro ubi
     - name: Build and push Antrea UBI9 Docker image to registry
-      if: ${{ env.push_needed == 'true' }}
+      if: ${{ needs.check-env.outputs.push_needed == 'true' }}
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
       run: |
         echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         ./hack/build-antrea-linux-all.sh --pull --push-base-images --distro ubi
-        docker push antrea/antrea-agent-ubi:latest
-        docker push antrea/antrea-controller-ubi:latest
+        docker push antrea/antrea-agent-ubi:"${DOCKER_TAG}"
+        docker push antrea/antrea-controller-ubi:"${DOCKER_TAG}"
 
   build-scale:
-    needs: check-changes
-    if: ${{ needs.check-changes.outputs.has_changes == 'yes' || github.event_name == 'push' }}
+    needs: check-env
+    if: ${{ needs.check-env.outputs.has_changes == 'yes' || github.event_name == 'push' }}
     runs-on: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v4
@@ -130,7 +164,7 @@ jobs:
     - name: Build Antrea Agent Simulator Docker image
       run: make build-scale-simulator
     - name: Push Antrea Agent Simulator Docker image to registry
-      if: ${{ github.repository == 'antrea-io/antrea' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      if: ${{ needs.check-env.outputs.push_needed == 'true' }}
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
@@ -139,18 +173,18 @@ jobs:
         docker push antrea/antrea-ubuntu-simulator:latest
 
   build-windows:
-    needs: check-changes
-    if: ${{ needs.check-changes.outputs.has_changes == 'yes' || github.event_name == 'push' }}
+    needs: check-env
+    if: ${{ needs.check-env.outputs.has_changes == 'yes' || github.event_name == 'push' }}
     runs-on: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v4
       with:
         show-progress: false
     - name: Build Antrea Windows Docker image
-      if: ${{ github.repository != 'antrea-io/antrea' || github.event_name != 'push' || github.ref != 'refs/heads/main' }}
+      if: ${{ needs.check-env.outputs.push_needed == 'false' }}
       run: ./hack/build-antrea-windows-all.sh --pull
     - name: Push Antrea Windows Docker image to registry
-      if: ${{ github.repository == 'antrea-io/antrea' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      if: ${{ needs.check-env.outputs.push_needed == 'true' }}
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
@@ -160,8 +194,8 @@ jobs:
       shell: bash
 
   build-antrea-mc-controller:
-    needs: check-changes
-    if: ${{ needs.check-changes.outputs.has_changes == 'yes' || github.event_name == 'push' }}
+    needs: check-env
+    if: ${{ needs.check-env.outputs.has_changes == 'yes' || github.event_name == 'push' }}
     runs-on: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v4
@@ -170,7 +204,7 @@ jobs:
     - name: Build antrea-mc-controller Docker image
       run: make build-antrea-mc-controller
     - name: Push antrea-mc-controller Docker image to registry
-      if: ${{ github.repository == 'antrea-io/antrea' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      if: ${{ needs.check-env.outputs.push_needed == 'true' }}
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
@@ -179,8 +213,8 @@ jobs:
         docker push antrea/antrea-mc-controller:latest
 
   build-flow-aggregator:
-    needs: check-changes
-    if: ${{ needs.check-changes.outputs.has_changes == 'yes' || github.event_name == 'push' }}
+    needs: check-env
+    if: ${{ needs.check-env.outputs.has_changes == 'yes' || github.event_name == 'push' }}
     runs-on: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v4
@@ -191,7 +225,7 @@ jobs:
     - name: Check flow-aggregator Docker image
       run: docker run antrea/flow-aggregator --version
     - name: Push flow-aggregator Docker image to registry
-      if: ${{ github.repository == 'antrea-io/antrea' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      if: ${{ needs.check-env.outputs.push_needed == 'true' }}
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
@@ -200,8 +234,8 @@ jobs:
         docker push antrea/flow-aggregator:latest
 
   build-antrea-migrator:
-    needs: check-changes
-    if: ${{ needs.check-changes.outputs.has_changes == 'yes' || github.event_name == 'push' }}
+    needs: check-env
+    if: ${{ needs.check-env.outputs.has_changes == 'yes' || github.event_name == 'push' }}
     runs-on: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v4
@@ -210,7 +244,7 @@ jobs:
     - name: Build antrea-migrator Docker image
       run: make build-migrator
     - name: Push antrea-migrator Docker image to registry
-      if: ${{ github.repository == 'antrea-io/antrea' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      if: ${{ needs.check-env.outputs.push_needed == 'true' }}
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/build_tag.yml
+++ b/.github/workflows/build_tag.yml
@@ -20,8 +20,22 @@ jobs:
         echo "version=$version" >> $GITHUB_OUTPUT
 
   build:
-    runs-on: [ubuntu-latest]
     needs: get-version
+    strategy:
+      matrix:
+        include:
+        - platform: linux/amd64
+          runner: ubuntu-latest
+          suffix: amd64
+        - platform: linux/arm64
+          runner: github-arm64-2c-8gb
+          suffix: arm64
+        - platform: linux/arm/v7
+          runner: github-arm64-2c-8gb
+          suffix: arm
+    runs-on: ${{ matrix.runner }}
+    env:
+      DOCKER_TAG: ${{ needs.get-version.outputs.version }}
     steps:
     - uses: actions/checkout@v4
       with:
@@ -30,26 +44,54 @@ jobs:
       uses: docker/setup-buildx-action@v3
       with:
         driver: docker
-    - name: Build and push Antrea Ubuntu amd64 Docker image to registry
+    - name: Build and push Antrea Ubuntu Docker image to registry
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        VERSION: ${{ needs.get-version.outputs.version }}
       run: |
-        ./hack/build-antrea-linux-all.sh --pull
+        ./hack/build-antrea-linux-all.sh --platform ${{ matrix.platform }} --pull
         echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-        docker tag antrea/antrea-agent-ubuntu:"${VERSION}" antrea/antrea-agent-ubuntu-amd64:"${VERSION}"
-        docker tag antrea/antrea-controller-ubuntu:"${VERSION}" antrea/antrea-controller-ubuntu-amd64:"${VERSION}"
-        docker push antrea/antrea-agent-ubuntu-amd64:"${VERSION}"
-        docker push antrea/antrea-controller-ubuntu-amd64:"${VERSION}"
-    - name: Trigger Antrea arm builds and multi-arch manifest update
+        docker tag antrea/antrea-agent-ubuntu:"${DOCKER_TAG}" antrea/antrea-agent-ubuntu-${{ matrix.suffix }}:"${DOCKER_TAG}"
+        docker tag antrea/antrea-controller-ubuntu:"${DOCKER_TAG}" antrea/antrea-controller-ubuntu-${{ matrix.suffix }}:"${DOCKER_TAG}"
+        docker push antrea/antrea-agent-ubuntu-${{ matrix.suffix }}:"${DOCKER_TAG}"
+        docker push antrea/antrea-controller-ubuntu-${{ matrix.suffix }}:"${DOCKER_TAG}"
+
+  push-manifest:
+    needs: build
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_TAG: ${{ needs.get-version.outputs.version }}
+    steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Docker login
+      env:
+        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      run: |
+        echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+    - name: Create and push manifest for controller image
+      run: |
+        docker manifest create antrea/antrea-controller-ubuntu:"${DOCKER_TAG}" \
+          antrea/antrea-controller-ubuntu-arm64:"${DOCKER_TAG}" \
+          antrea/antrea-controller-ubuntu-arm:"${DOCKER_TAG}" \
+          antrea/antrea-controller-ubuntu-amd64:"${DOCKER_TAG}"
+        docker manifest push --purge antrea/antrea-controller-ubuntu:"${DOCKER_TAG}"
+    - name: Create and push manifest for agent image
+      run: |
+        docker manifest create antrea/antrea-agent-ubuntu:"${DOCKER_TAG}" \
+          antrea/antrea-agent-ubuntu-arm64:"${DOCKER_TAG}" \
+          antrea/antrea-agent-ubuntu-arm:"${DOCKER_TAG}" \
+          antrea/antrea-agent-ubuntu-amd64:"${DOCKER_TAG}"
+        docker manifest push --purge antrea/antrea-agent-ubuntu:"${DOCKER_TAG}"
+    - name: Trigger Antrea arm tests
       uses: benc-uk/workflow-dispatch@v1
       with:
         repo: vmware-tanzu/antrea-build-infra
         ref: refs/heads/main
-        workflow: Build Antrea ARM images and push manifest
+        workflow: Test Antrea ARM images
         token: ${{ secrets.ANTREA_BUILD_INFRA_WORKFLOW_DISPATCH_PAT }}
-        inputs: ${{ format('{{ "antrea-repository":"antrea-io/antrea", "antrea-ref":"{0}", "docker-tag":"{1}" }}', github.ref, needs.get-version.outputs.version) }}
+        inputs: ${{ format('{{ "antrea-repository":"antrea-io/antrea", "antrea-ref":"{0}", "docker-tag":"{1}" }}', github.ref, env.DOCKER_TAG) }}
 
   build-ubi:
     runs-on: [ubuntu-latest]
@@ -58,6 +100,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           show-progress: false
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Build and push Antrea UBI9 amd64 Docker image to registry
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,9 @@ endif
 ifneq ($(NO_CACHE),)
 	DOCKER_BUILD_ARGS += --no-cache
 endif
+ifneq ($(DOCKER_TARGETPLATFORM),)
+	DOCKER_BUILD_ARGS += --platform $(DOCKER_TARGETPLATFORM)
+endif
 DOCKER_BUILD_ARGS += --build-arg OVS_VERSION=$(OVS_VERSION)
 DOCKER_BUILD_ARGS += --build-arg GO_VERSION=$(GO_VERSION)
 DOCKER_BUILD_ARGS += --build-arg BUILD_TAG=$(BUILD_TAG)

--- a/build/images/.gitignore
+++ b/build/images/.gitignore
@@ -1,0 +1,1 @@
+.targetarch

--- a/build/images/Dockerfile.agent.ubuntu
+++ b/build/images/Dockerfile.agent.ubuntu
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG BUILD_TAG
-FROM antrea/base-ubuntu:${BUILD_TAG}
+FROM antrea/base-ubuntu-${TARGETARCH}:${BUILD_TAG}
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="The development Docker image to deploy the antrea-agent."

--- a/build/images/Dockerfile.build.agent.coverage
+++ b/build/images/Dockerfile.build.agent.coverage
@@ -28,7 +28,7 @@ RUN make antctl-instr-binary
 
 RUN make antrea-cni antrea-agent-instr-binary
 
-FROM antrea/base-ubuntu:${BUILD_TAG}
+FROM antrea/base-ubuntu-${TARGETARCH}:${BUILD_TAG}
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="The Docker image to deploy the antrea-agent with code coverage measurement enabled (used for testing)."

--- a/build/images/Dockerfile.build.agent.ubi
+++ b/build/images/Dockerfile.build.agent.ubi
@@ -33,7 +33,7 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=cache,target=/root/.cache/go-build/ \
     make antrea-agent antrea-cni
 
-FROM antrea/base-ubi:${BUILD_TAG}
+FROM antrea/base-ubi-${TARGETARCH}:${BUILD_TAG}
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="The Docker image to deploy the antrea-agent."

--- a/build/images/Dockerfile.build.agent.ubuntu
+++ b/build/images/Dockerfile.build.agent.ubuntu
@@ -33,7 +33,7 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=cache,target=/root/.cache/go-build/ \
     make antrea-agent antrea-cni
 
-FROM antrea/base-ubuntu:${BUILD_TAG}
+FROM antrea/base-ubuntu-${TARGETARCH}:${BUILD_TAG}
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="The Docker image to deploy the antrea-agent."

--- a/build/images/Dockerfile.build.controller.coverage
+++ b/build/images/Dockerfile.build.controller.coverage
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 ARG GO_VERSION
-ARG BUILD_TAG
 FROM golang:${GO_VERSION} AS antrea-build
 
 WORKDIR /antrea

--- a/build/images/Dockerfile.build.controller.ubi
+++ b/build/images/Dockerfile.build.controller.ubi
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 ARG GO_VERSION
-ARG BUILD_TAG
 FROM golang:${GO_VERSION} AS antrea-build
 
 WORKDIR /antrea

--- a/build/images/Dockerfile.build.controller.ubuntu
+++ b/build/images/Dockerfile.build.controller.ubuntu
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 ARG GO_VERSION
-ARG BUILD_TAG
 FROM golang:${GO_VERSION} AS antrea-build
 
 WORKDIR /antrea

--- a/build/images/base/Dockerfile
+++ b/build/images/base/Dockerfile
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG BUILD_TAG
 FROM ubuntu:24.04 AS cni-binaries
 
 ARG CNI_BINARIES_VERSION
@@ -35,7 +34,7 @@ RUN set -eux; \
     mkdir -p /opt/cni/bin; \
     wget -q -O - https://github.com/containernetworking/plugins/releases/download/$CNI_BINARIES_VERSION/cni-plugins-linux-${pluginsArch}-$CNI_BINARIES_VERSION.tgz | tar xz -C /opt/cni/bin $CNI_PLUGINS
 
-FROM antrea/openvswitch:${BUILD_TAG}
+FROM antrea-openvswitch
 
 ARG SURICATA_VERSION
 

--- a/build/images/base/Dockerfile.ubi
+++ b/build/images/base/Dockerfile.ubi
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG BUILD_TAG
 FROM ubuntu:24.04 AS cni-binaries
 
 ARG CNI_BINARIES_VERSION
@@ -35,7 +34,7 @@ RUN set -eux; \
     mkdir -p /opt/cni/bin; \
     wget -q -O - https://github.com/containernetworking/plugins/releases/download/$CNI_BINARIES_VERSION/cni-plugins-linux-${pluginsArch}-$CNI_BINARIES_VERSION.tgz | tar xz -C /opt/cni/bin $CNI_PLUGINS
 
-FROM antrea/openvswitch-ubi:${BUILD_TAG}
+FROM antrea-openvswitch
 
 ARG SURICATA_VERSION
 

--- a/build/images/ovs/build.sh
+++ b/build/images/ovs/build.sh
@@ -92,15 +92,13 @@ if $PUSH && [ "$DISTRO" != "windows" ] && ! check_docker_build_driver "docker-co
     exit 1
 fi
 
-if [ "$PLATFORM" != "" ] && $PUSH; then
-    echoerr "Cannot use --platform with --push"
-    exit 1
-fi
-
 if [ "$DISTRO" != "ubuntu" ] && [ "$DISTRO" != "ubi" ] && [ "$DISTRO" != "windows" ]; then
     echoerr "Invalid distribution $DISTRO"
     exit 1
 fi
+
+TARGETARCH=$(set -e; get_target_arch "$PLATFORM" "$THIS_DIR/../.targetarch")
+echo "Target arch: $TARGETARCH"
 
 OVS_VERSION_FILE="../deps/ovs-version"
 if [ "$DISTRO" == "windows" ]; then
@@ -127,7 +125,7 @@ if $PULL; then
         if [[ ${DOCKER_REGISTRY} == "" ]]; then
             docker pull $PLATFORM_ARG ubuntu:24.04
         else
-            docker pull ${DOCKER_REGISTRY}/antrea/ubuntu:24.04
+            docker pull $PLATFORM_ARG ${DOCKER_REGISTRY}/antrea/ubuntu:24.04
             docker tag ${DOCKER_REGISTRY}/antrea/ubuntu:24.04 ubuntu:24.04
         fi
     elif [ "$DISTRO" == "ubi" ]; then
@@ -159,9 +157,9 @@ function docker_build_and_push() {
 }
 
 if [ "$DISTRO" == "ubuntu" ]; then
-    docker_build_and_push "antrea/openvswitch" "Dockerfile"
+    docker_build_and_push "antrea/openvswitch-$TARGETARCH" "Dockerfile"
 elif [ "$DISTRO" == "ubi" ]; then
-    docker_build_and_push "antrea/openvswitch-ubi" "Dockerfile.ubi"
+    docker_build_and_push "antrea/openvswitch-ubi-$TARGETARCH" "Dockerfile.ubi"
 elif [ "$DISTRO" == "windows" ]; then
     image="antrea/windows-ovs"
     build_args="--build-arg OVS_VERSION=$OVS_VERSION"

--- a/build/images/test/Dockerfile
+++ b/build/images/test/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG BUILD_TAG
-FROM antrea/openvswitch:${BUILD_TAG}
+FROM antrea/openvswitch-$TARGETARCH:$BUILD_TAG
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="A Docker image for Antrea integration tests."

--- a/hack/build-antrea-linux-all.sh
+++ b/hack/build-antrea-linux-all.sh
@@ -132,17 +132,15 @@ if [ "$BUILD_TAG" != "" ]; then
 fi
 
 # We pull all images ahead of time, instead of calling the independent build.sh
-# scripts with "--pull". We do not want to overwrite the antrea/openvswitch
-# image we just built when calling build.sh to build the antrea/base-ubuntu
-# image!
+# scripts with "--pull".
 if $PULL; then
     if [[ ${DOCKER_REGISTRY} == "" ]]; then
         docker pull $PLATFORM_ARG ubuntu:24.04
         docker pull $PLATFORM_ARG golang:$GO_VERSION
     else
-        docker pull ${DOCKER_REGISTRY}/antrea/ubuntu:24.04
+        docker pull $PLATFORM_ARG ${DOCKER_REGISTRY}/antrea/ubuntu:24.04
         docker tag ${DOCKER_REGISTRY}/antrea/ubuntu:24.04 ubuntu:24.04
-        docker pull ${DOCKER_REGISTRY}/antrea/golang:$GO_VERSION
+        docker pull $PLATFORM_ARG ${DOCKER_REGISTRY}/antrea/golang:$GO_VERSION
         docker tag ${DOCKER_REGISTRY}/antrea/golang:$GO_VERSION golang:$GO_VERSION
     fi
     if [ "$DISTRO" == "ubi" ]; then
@@ -169,6 +167,9 @@ export NO_PULL=1
 # explicitly (note that we already set DOCKER_CLI_EXPERIMENTAL=enabled at the
 # beginning of the script).
 export DOCKER_BUILDKIT=1
+if [ "$PLATFORM" != "" ]; then
+    export DOCKER_TARGETPLATFORM="$PLATFORM"
+fi
 if [ "$DISTRO" == "ubuntu" ]; then
     if $COVERAGE; then
         make build-controller-ubuntu-coverage


### PR DESCRIPTION
Github-hosted Arm runners are now in Beta for Enterprise accounts, and available to all CNCF projects. We can use them to build Antrea Arm images for the Agent and Controller, instead of relying on a private Github repo with self-hosted Arm runners.

At the moment, we only migrate the building part (along with creation of the multi-image manifest), and we use the existing workflow in vmware-tanzu/antrea-build-infra for "asynchronous" testing of the Arm images. We will handle the migration of the testing part in the future.

As part of this change, we also push "base images" (antrea/openvswitch, antrea/base-ubuntu) for arm64 and arm/v7 to the registry. This is necessary for building the Antrea images with the Docker container build driver. The base images now have the architecture as a suffix in their names. They are not available as multi-platform image manifests.

For #6453