### PR TITLE
Add missing whitespace in generated mock file

### DIFF
--- a/pkg/agent/bgp/testing/mock_bgp.go
+++ b/pkg/agent/bgp/testing/mock_bgp.go
@@ -20,6 +20,7 @@
 //
 //	mockgen -copyright_file hack/boilerplate/license_header.raw.txt -destination pkg/agent/bgp/testing/mock_bgp.go -package testing antrea.io/antrea/pkg/agent/bgp Interface
 //
+
 // Package testing is a generated GoMock package.
 package testing
 


### PR DESCRIPTION
PRs #6447 and #6477 got merged around the same time, and the mock file for the BGP interface was not generated using the latest mockgen version.