### PR TITLE
Fix codecov upload for Jenkins CI scripts

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -51,6 +51,7 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: .coverage/coverage-unit.txt
+        disable_search: true
         flags: unit-tests
         name: codecov-unit-test
         fail_ci_if_error: ${{ github.event_name == 'push' }}
@@ -76,6 +77,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: .coverage/coverage-unit.txt
+          disable_search: true
           flags: unit-tests
           name: codecov-unit-test
           fail_ci_if_error: ${{ github.event_name == 'push' }}
@@ -107,6 +109,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: .coverage/coverage-integration.txt,multicluster/.coverage/coverage-integration.txt
+          disable_search: true
           flags: integration-tests
           name: codecov-integration-test
           fail_ci_if_error: ${{ github.event_name == 'push' }}

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -117,6 +117,7 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: '*.cov.out*'
+        disable_search: true
         flags: kind-e2e-tests
         name: codecov-test-e2e-encap
         directory: test-e2e-encap-coverage
@@ -185,6 +186,7 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: '*.cov.out*'
+        disable_search: true
         flags: kind-e2e-tests
         name: codecov-test-e2e-encap-non-default
         directory: test-e2e-encap-non-default-coverage
@@ -255,6 +257,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: '*.cov.out*'
+          disable_search: true
           flags: kind-e2e-tests
           name: codecov-test-e2e-encap-all-features-enabled
           directory: test-e2e-encap-all-features-enabled-coverage
@@ -317,6 +320,7 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: '*.cov.out*'
+        disable_search: true
         flags: kind-e2e-tests
         name: codecov-test-e2e-noencap
         directory: test-e2e-noencap-coverage
@@ -379,6 +383,7 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: '*.cov.out*'
+        disable_search: true
         flags: kind-e2e-tests
         name: codecov-test-e2e-hybrid
         directory: test-e2e-hybrid-coverage
@@ -453,6 +458,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: '*.cov.out*'
+          disable_search: true
           flags: kind-e2e-tests
           name: codecov-test-e2e-fa
           directory: test-e2e-fa-coverage

--- a/ci/jenkins/test-mc.sh
+++ b/ci/jenkins/test-mc.sh
@@ -258,7 +258,7 @@ function run_codecov { (set -e
     shasum -a 256 -c codecov.SHA256SUM
 
     chmod +x codecov
-    ./codecov -c -t ${CODECOV_TOKEN} -F ${flag} -f ${file} -s ${dir} -C ${GIT_COMMIT} -r antrea-io/antrea
+    ./codecov -c -t "${CODECOV_TOKEN}" -F "${flag}" -f "${file}" -s "${dir}" -C "${GIT_COMMIT}" -r "antrea-io/antrea"
 
     rm -f trustedkeys.gpg codecov
 )}


### PR DESCRIPTION
It seems that codecov upload has been broken for a while for ci/jenkins/test-vmc.sh and ci/jenkins/test-mc.sh. The file pattern must be quoted when calling the codecov binary, or the glob will be expanded by the shell instead of by codecov (which is bad because we want the glob to be expanded in the context of the search directory).

We also set "disable_search" to "true" when using the codecov-action in Github workflows. This action uses the codecov CLI and there is no need to keep search enabled when providing an explicit and comprehensive list of files to include in the report.