### PR TITLE
Update kube version in Windows helm charts

### DIFF
--- a/build/charts/antrea-windows/Chart.yaml
+++ b/build/charts/antrea-windows/Chart.yaml
@@ -5,7 +5,7 @@ displayName: Antrea
 home: https://antrea.io/
 version: 0.0.0
 appVersion: latest
-kubeVersion: ">= 1.22.0-0"
+kubeVersion: ">= 1.19.0-0"
 icon: https://raw.githubusercontent.com/antrea-io/antrea/main/docs/assets/logo/antrea_logo.svg
 description: Kubernetes networking based on Open vSwitch for Windows Nodes
 keywords:


### PR DESCRIPTION
Change the minimal K8s version to v1.19 to make it consistent with Linux charts.
Otherwise, it may lead following errors when the helm tool is built with default K8s version from client-go.
```
b'Error: chart requires kubeVersion: >= 1.22.0-0 which is incompatible with Kubernetes v1.20.0'
```