### PR TITLE
Update cloud job cleanup scripts for correct secret access

### DIFF
--- a/ci/jenkins/jobs/macros.yaml
+++ b/ci/jenkins/jobs/macros.yaml
@@ -28,7 +28,7 @@
       - shell: |-
          #!/bin/bash
          set -ex
-         ./ci/test-conformance-gke.sh --gcloud-sdk-path "${GCLOUD_SDK_PATH}" --cluster-name "${CLUSTERNAME}" --cleanup-only
+         sudo ./ci/test-conformance-gke.sh --gcloud-sdk-path "${GCLOUD_SDK_PATH}" --cluster-name "${CLUSTERNAME}" --cleanup-only
 
 - builder:
     name: builder-aks-cluster-cleanup
@@ -36,7 +36,7 @@
       - shell: |-
          #!/bin/bash
          set -ex
-         ./ci/test-conformance-aks.sh --cluster-name "${CLUSTERNAME}" --cleanup-only
+         sudo ./ci/test-conformance-aks.sh --cluster-name "${CLUSTERNAME}" --cleanup-only
 
 - builder:
     name: builder-workload-cluster-garbage-collection


### PR DESCRIPTION
Added sudo to the clean job script to align with the login process and ensure correct access to the necessary secrets. The clean job was failing to access the correct secrets because it was not using sudo, whereas the login process used with Jenkins account.