### PR TITLE
[SecondaryNetwork] Attach OVS uplink after removing flow-restore-wait flag

### DIFF
--- a/pkg/agent/secondarynetwork/init.go
+++ b/pkg/agent/secondarynetwork/init.go
@@ -1,0 +1,109 @@
+// Copyright 2024 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secondarynetwork
+
+import (
+	"fmt"
+
+	"github.com/TomCodeLV/OVSDB-golang-lib/pkg/ovsdb"
+	netdefclient "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/typed/k8s.cni.cncf.io/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	componentbaseconfig "k8s.io/component-base/config"
+	"k8s.io/klog/v2"
+
+	"antrea.io/antrea/pkg/agent/secondarynetwork/podwatch"
+	agentconfig "antrea.io/antrea/pkg/config/agent"
+	"antrea.io/antrea/pkg/ovs/ovsconfig"
+	"antrea.io/antrea/pkg/util/channel"
+	"antrea.io/antrea/pkg/util/k8s"
+)
+
+var (
+	newOVSBridgeFn = ovsconfig.NewOVSBridge
+)
+
+type Controller struct {
+	ovsBridgeClient ovsconfig.OVSBridgeClient
+	secNetConfig    *agentconfig.SecondaryNetworkConfig
+	podController   *podwatch.PodController
+}
+
+func NewController(
+	clientConnectionConfig componentbaseconfig.ClientConnectionConfiguration,
+	kubeAPIServerOverride string,
+	k8sClient clientset.Interface,
+	podInformer cache.SharedIndexInformer,
+	podUpdateSubscriber channel.Subscriber,
+	secNetConfig *agentconfig.SecondaryNetworkConfig, ovsdb *ovsdb.OVSDB,
+) (*Controller, error) {
+	ovsBridgeClient, err := createOVSBridge(secNetConfig.OVSBridges, ovsdb)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create the NetworkAttachmentDefinition client, which handles access to secondary network object
+	// definition from the API Server.
+	netAttachDefClient, err := createNetworkAttachDefClient(clientConnectionConfig, kubeAPIServerOverride)
+	if err != nil {
+		return nil, fmt.Errorf("NetworkAttachmentDefinition client creation failed: %v", err)
+	}
+
+	// Create podController to handle secondary network configuration for Pods with
+	// k8s.v1.cni.cncf.io/networks Annotation defined.
+	podWatchController, err := podwatch.NewPodController(
+		k8sClient, netAttachDefClient, podInformer,
+		podUpdateSubscriber, ovsBridgeClient)
+	if err != nil {
+		return nil, err
+	}
+	return &Controller{
+		ovsBridgeClient: ovsBridgeClient,
+		secNetConfig:    secNetConfig,
+		podController:   podWatchController}, nil
+}
+
+// Run starts the Pod controller for secondary networks.
+func (c *Controller) Run(stopCh <-chan struct{}) {
+	c.podController.Run(stopCh)
+}
+
+// CreateNetworkAttachDefClient creates net-attach-def client handle from the given config.
+func createNetworkAttachDefClient(config componentbaseconfig.ClientConnectionConfiguration, kubeAPIServerOverride string) (netdefclient.K8sCniCncfIoV1Interface, error) {
+	kubeConfig, err := k8s.CreateRestConfig(config, kubeAPIServerOverride)
+	if err != nil {
+		return nil, err
+	}
+
+	netAttachDefClient, err := netdefclient.NewForConfig(kubeConfig)
+	if err != nil {
+		return nil, err
+	}
+	return netAttachDefClient, nil
+}
+
+func createOVSBridge(bridges []agentconfig.OVSBridgeConfig, ovsdb *ovsdb.OVSDB) (ovsconfig.OVSBridgeClient, error) {
+	if len(bridges) == 0 {
+		return nil, nil
+	}
+	// Only one OVS bridge is supported.
+	bridgeConfig := bridges[0]
+	ovsBridgeClient := newOVSBridgeFn(bridgeConfig.BridgeName, ovsconfig.OVSDatapathSystem, ovsdb)
+	if err := ovsBridgeClient.Create(); err != nil {
+		return nil, fmt.Errorf("failed to create OVS bridge %s: %v", bridgeConfig.BridgeName, err)
+	}
+	klog.InfoS("OVS bridge created", "bridge", bridgeConfig.BridgeName)
+	return ovsBridgeClient, nil
+}

--- a/pkg/agent/secondarynetwork/init_linux.go
+++ b/pkg/agent/secondarynetwork/init_linux.go
@@ -21,52 +21,28 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/TomCodeLV/OVSDB-golang-lib/pkg/ovsdb"
-	netdefclient "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/typed/k8s.cni.cncf.io/v1"
-	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/cache"
-	componentbaseconfig "k8s.io/component-base/config"
 	"k8s.io/klog/v2"
 
 	"antrea.io/antrea/pkg/agent/interfacestore"
-	"antrea.io/antrea/pkg/agent/secondarynetwork/podwatch"
 	"antrea.io/antrea/pkg/agent/util"
-	agentconfig "antrea.io/antrea/pkg/config/agent"
 	"antrea.io/antrea/pkg/ovs/ovsconfig"
-	"antrea.io/antrea/pkg/util/channel"
-	"antrea.io/antrea/pkg/util/k8s"
 )
 
 var (
 	// Funcs which will be overridden with mock funcs in tests.
 	interfaceByNameFn = net.InterfaceByName
-	newOVSBridgeFn    = ovsconfig.NewOVSBridge
 )
 
-// Initialize sets up OVS bridges and starts the Pod controller for secondary networks.
-func Initialize(
-	clientConnectionConfig componentbaseconfig.ClientConnectionConfiguration,
-	kubeAPIServerOverride string,
-	k8sClient clientset.Interface,
-	podInformer cache.SharedIndexInformer,
-	nodeName string,
-	podUpdateSubscriber channel.Subscriber,
-	stopCh <-chan struct{},
-	secNetConfig *agentconfig.SecondaryNetworkConfig, ovsdb *ovsdb.OVSDB) error {
-
-	ovsBridgeClient, err := createOVSBridge(secNetConfig.OVSBridges, ovsdb)
-	if err != nil {
-		return err
-	}
-
+// Initialize sets up OVS bridges.
+func (c *Controller) Initialize() error {
 	// We only support moving and restoring of interface configuration to OVS Bridge for the single physical interface case.
-	if len(secNetConfig.OVSBridges) != 0 {
-		phyInterfaces := make([]string, len(secNetConfig.OVSBridges[0].PhysicalInterfaces))
-		copy(phyInterfaces, secNetConfig.OVSBridges[0].PhysicalInterfaces)
+	if len(c.secNetConfig.OVSBridges) != 0 {
+		phyInterfaces := make([]string, len(c.secNetConfig.OVSBridges[0].PhysicalInterfaces))
+		copy(phyInterfaces, c.secNetConfig.OVSBridges[0].PhysicalInterfaces)
 		if len(phyInterfaces) == 1 {
 
 			bridgedName, _, err := util.PrepareHostInterfaceConnection(
-				ovsBridgeClient,
+				c.ovsBridgeClient,
 				phyInterfaces[0],
 				0,
 				map[string]interface{}{
@@ -78,49 +54,18 @@ func Initialize(
 			}
 			phyInterfaces[0] = bridgedName
 		}
-		if err = connectPhyInterfacesToOVSBridge(ovsBridgeClient, phyInterfaces); err != nil {
+		if err := connectPhyInterfacesToOVSBridge(c.ovsBridgeClient, phyInterfaces); err != nil {
 			return err
 		}
-	}
-
-	// Create the NetworkAttachmentDefinition client, which handles access to secondary network object
-	// definition from the API Server.
-	netAttachDefClient, err := createNetworkAttachDefClient(clientConnectionConfig, kubeAPIServerOverride)
-	if err != nil {
-		return fmt.Errorf("NetworkAttachmentDefinition client creation failed: %v", err)
-	}
-
-	// Create podController to handle secondary network configuration for Pods with
-	// k8s.v1.cni.cncf.io/networks Annotation defined.
-	if podWatchController, err := podwatch.NewPodController(
-		k8sClient, netAttachDefClient, podInformer,
-		podUpdateSubscriber, ovsBridgeClient); err != nil {
-		return err
-	} else {
-		go podWatchController.Run(stopCh)
 	}
 	return nil
 }
 
-// RestoreHostInterfaceConfiguration restores interface configuration from secondary-bridge back to host-interface.
-func RestoreHostInterfaceConfiguration(secNetConfig *agentconfig.SecondaryNetworkConfig) {
-	if len(secNetConfig.OVSBridges) != 0 && len(secNetConfig.OVSBridges[0].PhysicalInterfaces) == 1 {
-		util.RestoreHostInterfaceConfiguration(secNetConfig.OVSBridges[0].BridgeName, secNetConfig.OVSBridges[0].PhysicalInterfaces[0])
+// Restore restores interface configuration from secondary-bridge back to host-interface.
+func (c *Controller) Restore() {
+	if len(c.secNetConfig.OVSBridges) != 0 && len(c.secNetConfig.OVSBridges[0].PhysicalInterfaces) == 1 {
+		util.RestoreHostInterfaceConfiguration(c.secNetConfig.OVSBridges[0].BridgeName, c.secNetConfig.OVSBridges[0].PhysicalInterfaces[0])
 	}
-}
-
-func createOVSBridge(bridges []agentconfig.OVSBridgeConfig, ovsdb *ovsdb.OVSDB) (ovsconfig.OVSBridgeClient, error) {
-	if len(bridges) == 0 {
-		return nil, nil
-	}
-	// Only one OVS bridge is supported.
-	bridgeConfig := bridges[0]
-	ovsBridgeClient := newOVSBridgeFn(bridgeConfig.BridgeName, ovsconfig.OVSDatapathSystem, ovsdb)
-	if err := ovsBridgeClient.Create(); err != nil {
-		return nil, fmt.Errorf("failed to create OVS bridge %s: %v", bridgeConfig.BridgeName, err)
-	}
-	klog.InfoS("OVS bridge created", "bridge", bridgeConfig.BridgeName)
-	return ovsBridgeClient, nil
 }
 
 func connectPhyInterfacesToOVSBridge(ovsBridgeClient ovsconfig.OVSBridgeClient, phyInterfaces []string) error {
@@ -145,18 +90,4 @@ func connectPhyInterfacesToOVSBridge(ovsBridgeClient ovsconfig.OVSBridgeClient, 
 		klog.InfoS("Physical interface added to secondary OVS bridge", "device", phyInterface)
 	}
 	return nil
-}
-
-// CreateNetworkAttachDefClient creates net-attach-def client handle from the given config.
-func createNetworkAttachDefClient(config componentbaseconfig.ClientConnectionConfiguration, kubeAPIServerOverride string) (netdefclient.K8sCniCncfIoV1Interface, error) {
-	kubeConfig, err := k8s.CreateRestConfig(config, kubeAPIServerOverride)
-	if err != nil {
-		return nil, err
-	}
-
-	netAttachDefClient, err := netdefclient.NewForConfig(kubeConfig)
-	if err != nil {
-		return nil, err
-	}
-	return netAttachDefClient, nil
 }

--- a/pkg/agent/secondarynetwork/init_windows.go
+++ b/pkg/agent/secondarynetwork/init_windows.go
@@ -17,30 +17,10 @@
 
 package secondarynetwork
 
-import (
-	"errors"
-
-	"github.com/TomCodeLV/OVSDB-golang-lib/pkg/ovsdb"
-	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/cache"
-	componentbaseconfig "k8s.io/component-base/config"
-
-	agentconfig "antrea.io/antrea/pkg/config/agent"
-	"antrea.io/antrea/pkg/util/channel"
-)
-
-func Initialize(
-	clientConnectionConfig componentbaseconfig.ClientConnectionConfiguration,
-	kubeAPIServerOverride string,
-	k8sClient clientset.Interface,
-	podInformer cache.SharedIndexInformer,
-	nodeName string,
-	podUpdateSubscriber channel.Subscriber,
-	stopCh <-chan struct{},
-	secNetConfig *agentconfig.SecondaryNetworkConfig, ovsdb *ovsdb.OVSDB) error {
-	return errors.New("not supported on Windows")
+func (c *Controller) Initialize() error {
+	return nil
 }
 
-func RestoreHostInterfaceConfiguration(secNetConfig *agentconfig.SecondaryNetworkConfig) {
+func (c *Controller) Restore() {
 	// Not supported on Windows.
 }

--- a/pkg/agent/secondarynetwork/podwatch/controller_test.go
+++ b/pkg/agent/secondarynetwork/podwatch/controller_test.go
@@ -587,7 +587,7 @@ func TestPodControllerAddPod(t *testing.T) {
 	podKey := podKeyGet(podName, testNamespace)
 
 	// Create Pod and wait for Informer cache updated.
-	createPodFn := func(pc *podController, pod *corev1.Pod) {
+	createPodFn := func(pc *PodController, pod *corev1.Pod) {
 		_, err := pc.kubeClient.CoreV1().Pods(testNamespace).Create(context.Background(),
 			pod, metav1.CreateOptions{})
 		require.NoError(t, err, "error when creating test Pod")
@@ -596,7 +596,7 @@ func TestPodControllerAddPod(t *testing.T) {
 			return ok == true && err == nil
 		}, 1*time.Second, 10*time.Millisecond)
 	}
-	deletePodFn := func(pc *podController, podName string) {
+	deletePodFn := func(pc *PodController, podName string) {
 		require.NoError(t, pc.kubeClient.CoreV1().Pods(testNamespace).Delete(context.Background(),
 			podName, metav1.DeleteOptions{}), "error when deleting test Pod")
 		assert.Eventually(t, func() bool {
@@ -899,7 +899,7 @@ func TestPodControllerAddPod(t *testing.T) {
 }
 
 func testPodController(ctrl *gomock.Controller) (
-	*podController, *podwatchtesting.MockIPAMAllocator,
+	*PodController, *podwatchtesting.MockIPAMAllocator,
 	*podwatchtesting.MockInterfaceConfigurator) {
 	client := fake.NewSimpleClientset()
 	netdefclient := netdefclientfake.NewSimpleClientset().K8sCniCncfIoV1()
@@ -907,8 +907,8 @@ func testPodController(ctrl *gomock.Controller) (
 	interfaceConfigurator := podwatchtesting.NewMockInterfaceConfigurator(ctrl)
 	mockIPAM := podwatchtesting.NewMockIPAMAllocator(ctrl)
 
-	// podController without event handlers.
-	return &podController{
+	// PodController without event handlers.
+	return &PodController{
 		kubeClient:         client,
 		netAttachDefClient: netdefclient,
 		queue: workqueue.NewNamedRateLimitingQueue(
@@ -921,9 +921,9 @@ func testPodController(ctrl *gomock.Controller) (
 	}, mockIPAM, interfaceConfigurator
 }
 
-// Create a test podController and start informerFactory.
+// Create a test PodController and start informerFactory.
 func testPodControllerStart(ctrl *gomock.Controller) (
-	*podController, *podwatchtesting.MockIPAMAllocator,
+	*PodController, *podwatchtesting.MockIPAMAllocator,
 	*podwatchtesting.MockInterfaceConfigurator) {
 	podController, mockIPAM, interfaceConfigurator := testPodController(ctrl)
 	informerFactory := informers.NewSharedInformerFactory(podController.kubeClient, resyncPeriod)

--- a/pkg/agent/secondarynetwork/podwatch/sriov.go
+++ b/pkg/agent/secondarynetwork/podwatch/sriov.go
@@ -107,7 +107,7 @@ func getPodContainerDeviceIDs(podName string, podNamespace string) ([]string, er
 // which is still not associated with a network device name.
 // NOTE: buildVFDeviceIDListPerPod is called only if a Pod specific VF to Interface mapping cache
 // was not build earlier. Sample initial entry per Pod: "{18:01.1,""},{18:01.2,""},{18:01.3,""}"
-func (pc *podController) buildVFDeviceIDListPerPod(podName, podNamespace string) ([]podSriovVFDeviceIDInfo, error) {
+func (pc *PodController) buildVFDeviceIDListPerPod(podName, podNamespace string) ([]podSriovVFDeviceIDInfo, error) {
 	podKey := podKeyGet(podName, podNamespace)
 	deviceCache, cacheFound := pc.vfDeviceIDUsageMap.Load(podKey)
 	if cacheFound {
@@ -127,7 +127,7 @@ func (pc *podController) buildVFDeviceIDListPerPod(podName, podNamespace string)
 	return vfDeviceIDInfoCache, nil
 }
 
-func (pc *podController) deleteVFDeviceIDListPerPod(podName, podNamespace string) {
+func (pc *PodController) deleteVFDeviceIDListPerPod(podName, podNamespace string) {
 	podKey := podKeyGet(podName, podNamespace)
 	_, cacheFound := pc.vfDeviceIDUsageMap.Load(podKey)
 	if cacheFound {
@@ -137,7 +137,7 @@ func (pc *podController) deleteVFDeviceIDListPerPod(podName, podNamespace string
 	return
 }
 
-func (pc *podController) releaseSriovVFDeviceID(podName, podNamespace, interfaceName string) {
+func (pc *PodController) releaseSriovVFDeviceID(podName, podNamespace, interfaceName string) {
 	podKey := podKeyGet(podName, podNamespace)
 	obj, cacheFound := pc.vfDeviceIDUsageMap.Load(podKey)
 	if !cacheFound {
@@ -151,7 +151,7 @@ func (pc *podController) releaseSriovVFDeviceID(podName, podNamespace, interface
 	}
 }
 
-func (pc *podController) assignUnusedSriovVFDeviceID(podName, podNamespace, interfaceName string) (string, error) {
+func (pc *PodController) assignUnusedSriovVFDeviceID(podName, podNamespace, interfaceName string) (string, error) {
 	var cache []podSriovVFDeviceIDInfo
 	cache, err := pc.buildVFDeviceIDListPerPod(podName, podNamespace)
 	if err != nil {
@@ -168,7 +168,7 @@ func (pc *podController) assignUnusedSriovVFDeviceID(podName, podNamespace, inte
 }
 
 // Configure SRIOV VF as a Secondary Network Interface.
-func (pc *podController) configureSriovAsSecondaryInterface(pod *corev1.Pod, network *netdefv1.NetworkSelectionElement, podCNIInfo *podCNIInfo, mtu int, result *current.Result) error {
+func (pc *PodController) configureSriovAsSecondaryInterface(pod *corev1.Pod, network *netdefv1.NetworkSelectionElement, podCNIInfo *podCNIInfo, mtu int, result *current.Result) error {
 	podSriovVFDeviceID, err := pc.assignUnusedSriovVFDeviceID(pod.Name, pod.Namespace, network.InterfaceRequest)
 	if err != nil {
 		return err
@@ -181,7 +181,7 @@ func (pc *podController) configureSriovAsSecondaryInterface(pod *corev1.Pod, net
 	return nil
 }
 
-func (pc *podController) deleteSriovSecondaryInterface(interfaceConfig *interfacestore.InterfaceConfig) error {
+func (pc *PodController) deleteSriovSecondaryInterface(interfaceConfig *interfacestore.InterfaceConfig) error {
 	// NOTE: SR-IOV VF interface clean-up will be handled by SR-IOV device plugin. The interface
 	// is not deleted here.
 	if err := pc.interfaceConfigurator.DeleteSriovSecondaryInterface(interfaceConfig); err != nil {


### PR DESCRIPTION
Physcial network interface is attached on the OVS bridge with SecondaryNetwork feature enabled. Antrea uses a global configuration flow-restore-wait='true' to ensure that OVS OpenFlow entries can start working after the dependencies are ready. A connectivity issue exists if a setup uses the Node NIC as secondary network interface and connects the NIC to OVS bridge before removing the flow-restore-wait option.

This change ensures agent attaches the physical network interface to the secondary OVS bridge after the global flow-restore-wait option is removed.

Fix: #6448 