### PR TITLE
Only try to build local image if K8s version is specified

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -76,6 +76,7 @@ jobs:
           chmod +x ./kind
           sudo mv kind /usr/local/bin
       - name: Build local image for conformance test
+        if: ${{ inputs.k8s-version != '' }}
         run: |
           image="kindest/node:${{ inputs.k8s-version }}"
           if docker pull $image 2>&1; then


### PR DESCRIPTION
When K8s version is not specified, it's supposed to use default version. The step of building local image is not implemented to support empty input, it should be skipped when K8s version is empty.