### PR TITLE
Use appropriate docker driver in Github workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,14 +36,25 @@ jobs:
     - uses: actions/checkout@v4
       with:
         show-progress: false
+    - name: Checking if image needs to be pushed
+      run: |
+        if [ ${{ github.repository }} == 'antrea-io/antrea' && ${{ github.event_name }} == 'push' && ${{ github.ref }} == 'refs/heads/main' ]; then
+          echo "push_needed=true" >> $GITHUB_ENV
+          echo "docker_driver=docker-container" >> $GITHUB_ENV
+        else
+          echo "push_needed=false" >> $GITHUB_ENV
+          echo "docker_driver=docker" >> $GITHUB_ENV
+        fi
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
+      with:
+        driver: ${{ env.docker_driver }}
     - name: Build Antrea amd64 Docker image without pushing to registry
-      if: ${{ github.repository != 'antrea-io/antrea' || github.event_name != 'push' || github.ref != 'refs/heads/main' }}
+      if: ${{ env.push_needed == 'false' }}
       run: |
         ./hack/build-antrea-linux-all.sh --pull
     - name: Build and push Antrea amd64 Docker image to registry
-      if: ${{ github.repository == 'antrea-io/antrea' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      if: ${{ env.push_needed == 'true' }}
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
@@ -77,17 +88,28 @@ jobs:
     - uses: actions/checkout@v4
       with:
         show-progress: false
+    - name: Checking if image needs to be pushed
+      run: |
+        if [ ${{ github.repository }} == 'antrea-io/antrea' && ${{ github.event_name }} == 'push' && ${{ github.ref }} == 'refs/heads/main' ]; then
+          echo "push_needed=true" >> $GITHUB_ENV
+          echo "docker_driver=docker-container" >> $GITHUB_ENV
+        else
+          echo "push_needed=false" >> $GITHUB_ENV
+          echo "docker_driver=docker" >> $GITHUB_ENV
+        fi
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
+      with:
+        driver: ${{ env.docker_driver }}
     - uses: actions/setup-go@v5
       with:
         go-version-file: 'go.mod'
     - name: Build Antrea UBI9 Docker image without pushing to registry
-      if: ${{ github.repository != 'antrea-io/antrea' || github.event_name != 'push' || github.ref != 'refs/heads/main' }}
+      if: ${{ env.push_needed == 'false' }}
       run: |
         ./hack/build-antrea-linux-all.sh --pull --distro ubi
     - name: Build and push Antrea UBI9 Docker image to registry
-      if: ${{ github.repository == 'antrea-io/antrea' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      if: ${{ env.push_needed == 'true' }}
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/build_tag.yml
+++ b/.github/workflows/build_tag.yml
@@ -26,6 +26,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         show-progress: false
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+      with:
+        driver: docker
     - name: Build and push Antrea Ubuntu amd64 Docker image to registry
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -65,6 +65,8 @@ jobs:
       - name: Set up Docker Buildx if required
         if: ${{ steps.check-release.outputs.released == 'false' }}
         uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker
       - name: Build Antrea image if required
         if: ${{ steps.check-release.outputs.released == 'false' }}
         run: |

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -39,6 +39,8 @@ jobs:
         show-progress: false
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
+      with:
+        driver: docker
     - name: Build Antrea Docker image with code coverage support
       run: |
         ./hack/build-antrea-linux-all.sh --pull --coverage

--- a/.github/workflows/kind_ubi.yml
+++ b/.github/workflows/kind_ubi.yml
@@ -42,6 +42,8 @@ jobs:
         show-progress: false
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
+      with:
+        driver: docker
     - uses: actions/setup-go@v5
       with:
         go-version-file: 'go.mod'

--- a/.github/workflows/trivy_scan_before_release.yml
+++ b/.github/workflows/trivy_scan_before_release.yml
@@ -13,6 +13,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
+      with:
+        driver: docker
     - name: Build Antrea Docker image
       run: |
         ./hack/build-antrea-linux-all.sh --pull


### PR DESCRIPTION
For most workflows, we want to use the "docker" driver, while the "docker-container" driver should be used when images need to be pushed to the registry (so we can use registry-based caching).

When using the "docker-container" driver, images are built in a build container, and there is no access to the docker image store (see https://github.com/moby/buildkit/issues/2343). This means that when building a new image, we cannot use "local" images as base images. This is an issue because the base image may not exist yet in the directory, and because we may want to use a modified base image which is not the same as the one in the registry.