### PR TITLE
antctl: fix cluster checker image

### DIFF
--- a/pkg/antctl/raw/check/cluster/command.go
+++ b/pkg/antctl/raw/check/cluster/command.go
@@ -199,7 +199,7 @@ func (t *testContext) setup(ctx context.Context) error {
 
 func getAntreaAgentImage() string {
 	if version.ReleaseStatus == "released" {
-		return fmt.Sprintf("antrea/antrea-agent-ubuntu:%s", version.GetVersion())
+		return fmt.Sprintf("antrea/antrea-agent-ubuntu:%s", version.Version)
 	}
 	return "antrea/antrea-agent-ubuntu:latest"
 }


### PR DESCRIPTION
The image tag missed "v" when built for a released antctl.

The patch also makes test images configurable to support scenarios that hardcoded images are not accessible.

Fixes #6563