### PR TITLE
Automated cherry pick of #6561: Add documentation for NodeLatencyMonitor feature (#6561)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -39,6 +39,7 @@ These are the CRDs currently available in `crd.antrea.io`.
 | `IPPool`| v1beta1  | v2.0.0 | N/A | N/A |
 | `Group` | v1beta1 | v1.13.0 | N/A | N/A |
 | `NetworkPolicy` | v1beta1 | v1.13.0 | N/A | N/A |
+| `NodeLatencyMonitor` | v1alpha1 | v2.1.0 | N/A | N/A |
 | `SupportBundleCollection` | v1alpha1 | v1.10.0 | N/A | N/A |
 | `Tier` | v1beta1 | v1.13.0 | N/A | N/A |
 | `Traceflow` | v1beta1 | v1.13.0 | N/A | N/A |


### PR DESCRIPTION
Cherry pick of #6561 on release-2.1.

#6561: Add documentation for NodeLatencyMonitor feature (#6561)

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.