### PR TITLE
Upgrade Ubuntu to 24.04 (Noble)

### DIFF
--- a/build/charts/antrea/templates/simulator/statefulset.yaml
+++ b/build/charts/antrea/templates/simulator/statefulset.yaml
@@ -32,7 +32,7 @@ spec:
       serviceAccountName: antrea-agent
       initContainers:
       - name: init-inotify-limit
-        image: antrea/ubuntu:22.04
+        image: antrea/ubuntu:24.04
         command: ['sysctl', '-w', 'fs.inotify.max_user_instances=200']
         securityContext:
           privileged: true

--- a/build/images/Dockerfile.build.controller.coverage
+++ b/build/images/Dockerfile.build.controller.coverage
@@ -28,7 +28,7 @@ RUN make antctl-instr-binary
 
 RUN make antrea-controller-instr-binary
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="The Docker image to deploy the antrea-controller with code coverage measurement enabled (used for testing)."

--- a/build/images/Dockerfile.build.controller.ubuntu
+++ b/build/images/Dockerfile.build.controller.ubuntu
@@ -33,7 +33,7 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=cache,target=/root/.cache/go-build/ \
     make antrea-controller
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="The Docker image to deploy the antrea-controller."

--- a/build/images/Dockerfile.build.migrator
+++ b/build/images/Dockerfile.build.migrator
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="The Docker image to migrate other CNIs to Antrea CNI."

--- a/build/images/Dockerfile.controller.ubuntu
+++ b/build/images/Dockerfile.controller.ubuntu
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="The development Docker image to deploy the antrea-controller."

--- a/build/images/Dockerfile.simulator.build.ubuntu
+++ b/build/images/Dockerfile.simulator.build.ubuntu
@@ -26,7 +26,7 @@ COPY . /antrea
 RUN make antrea-agent-simulator
 
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="The Docker image to deploy the Antrea simulator."

--- a/build/images/base/Dockerfile
+++ b/build/images/base/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG BUILD_TAG
-FROM ubuntu:22.04 AS cni-binaries
+FROM ubuntu:24.04 AS cni-binaries
 
 ARG CNI_BINARIES_VERSION
 

--- a/build/images/base/Dockerfile.ubi
+++ b/build/images/base/Dockerfile.ubi
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG BUILD_TAG
-FROM ubuntu:22.04 AS cni-binaries
+FROM ubuntu:24.04 AS cni-binaries
 
 ARG CNI_BINARIES_VERSION
 

--- a/build/images/base/build.sh
+++ b/build/images/base/build.sh
@@ -121,10 +121,10 @@ fi
 if $PULL; then
     # The ubuntu image is also used for the UBI build (for the cni-binaries intermediate image).
     if [[ ${DOCKER_REGISTRY} == "" ]]; then
-        docker pull $PLATFORM_ARG ubuntu:22.04
+        docker pull $PLATFORM_ARG ubuntu:24.04
     else
-        docker pull ${DOCKER_REGISTRY}/antrea/ubuntu:22.04
-        docker tag ${DOCKER_REGISTRY}/antrea/ubuntu:22.04 ubuntu:22.04
+        docker pull ${DOCKER_REGISTRY}/antrea/ubuntu:24.04
+        docker tag ${DOCKER_REGISTRY}/antrea/ubuntu:24.04 ubuntu:24.04
     fi
 
     if [ "$DISTRO" == "ubuntu" ]; then

--- a/build/images/flow-aggregator/Dockerfile
+++ b/build/images/flow-aggregator/Dockerfile
@@ -34,7 +34,7 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
     make flow-aggregator
 
 # Chose this base image so that a shell is available for users to exec into the container, run antctl and run tools like pprof easily
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="The docker image for the flow aggregator"

--- a/build/images/flow-aggregator/Dockerfile.coverage
+++ b/build/images/flow-aggregator/Dockerfile.coverage
@@ -27,7 +27,7 @@ RUN make antctl-instr-binary
 
 RUN make flow-aggregator-instr-binary
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="The docker image for the flow aggregator with code coverage measurement enabled for testing purposes."

--- a/build/images/ovs/Dockerfile
+++ b/build/images/ovs/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:22.04 AS ovs-debs
+FROM ubuntu:24.04 AS ovs-debs
 
 # Some patches may not apply cleanly if a non-default version is provided.
 # See build/images/deps/ovs-version for the default version.
@@ -39,10 +39,10 @@ RUN wget -q -O - https://www.openvswitch.org/releases/openvswitch-$OVS_VERSION.t
     cd / && rm -rf /tmp/openvswitch*
 
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
-LABEL description="A Docker image based on Ubuntu 22.04 which includes Open vSwitch built from source."
+LABEL description="A Docker image based on Ubuntu 24.04 which includes Open vSwitch built from source."
 
 COPY --from=ovs-debs /tmp/ovs-debs/* /tmp/ovs-debs/
 COPY charon-logging.conf /tmp

--- a/build/images/ovs/Dockerfile.windows
+++ b/build/images/ovs/Dockerfile.windows
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=linux/amd64 ubuntu:22.04 AS antrea-windows-builder
+FROM --platform=linux/amd64 ubuntu:24.04 AS antrea-windows-builder
 ARG OVS_VERSION
 
 RUN apt-get update && \

--- a/build/images/ovs/apply-patches.sh
+++ b/build/images/ovs/apply-patches.sh
@@ -107,8 +107,18 @@ if version_get "$OVS_VERSION" "2.13.0" && version_let "$OVS_VERSION" "2.17.5" ; 
     apply_patch "489553b1c21692063931a9f50b6849b23128443c"
 fi
 
+# These patches are necessary to avoid build errors on Ubuntu 24.04 (when generating manpages).
+if version_lt "$OVS_VERSION" "3.3.0"; then
+    # https://github.com/openvswitch/ovs/commit/6180fefa835c7cad36e89f77f3d9de13c680fb88
+    apply_patch "6180fefa835c7cad36e89f77f3d9de13c680fb88"
+    # https://github.com/openvswitch/ovs/commit/d542f0ea8587f9ae1cad1f9610b6f3ce62dc3b7a
+    apply_patch "d542f0ea8587f9ae1cad1f9610b6f3ce62dc3b7a"
+    # https://github.com/openvswitch/ovs/commit/e46d455201d08725687dc90d3d0ee99fe8f70ca6
+    apply_patch "e46d455201d08725687dc90d3d0ee99fe8f70ca6"
+fi
+
 # OVS hardcodes the installation path to /usr/lib/python3.7/dist-packages/ but this location
-# does not seem to be in the Python path in Ubuntu 22.04. There may be a better way to do this,
+# does not seem to be in the Python path in Ubuntu. There may be a better way to do this,
 # but this seems like an acceptable workaround.
 sed -i 's/python3\.7/python3\.10/' debian/openvswitch-test.install
 sed -i 's/python3\.7/python3\.10/' debian/python3-openvswitch.install

--- a/build/images/ovs/apply-patches.sh
+++ b/build/images/ovs/apply-patches.sh
@@ -120,5 +120,5 @@ fi
 # OVS hardcodes the installation path to /usr/lib/python3.7/dist-packages/ but this location
 # does not seem to be in the Python path in Ubuntu. There may be a better way to do this,
 # but this seems like an acceptable workaround.
-sed -i 's/python3\.7/python3\.10/' debian/openvswitch-test.install
-sed -i 's/python3\.7/python3\.10/' debian/python3-openvswitch.install
+sed -i 's/python3\.7/python3\.12/' debian/openvswitch-test.install
+sed -i 's/python3\.7/python3\.12/' debian/python3-openvswitch.install

--- a/build/images/ovs/build.sh
+++ b/build/images/ovs/build.sh
@@ -125,16 +125,16 @@ fi
 if $PULL; then
     if [ "$DISTRO" == "ubuntu" ]; then
         if [[ ${DOCKER_REGISTRY} == "" ]]; then
-            docker pull $PLATFORM_ARG ubuntu:22.04
+            docker pull $PLATFORM_ARG ubuntu:24.04
         else
-            docker pull ${DOCKER_REGISTRY}/antrea/ubuntu:22.04
-            docker tag ${DOCKER_REGISTRY}/antrea/ubuntu:22.04 ubuntu:22.04
+            docker pull ${DOCKER_REGISTRY}/antrea/ubuntu:24.04
+            docker tag ${DOCKER_REGISTRY}/antrea/ubuntu:24.04 ubuntu:24.04
         fi
     elif [ "$DISTRO" == "ubi" ]; then
         docker pull $PLATFORM_ARG quay.io/centos/centos:stream9
         docker pull $PLATFORM_ARG registry.access.redhat.com/ubi9
     elif [ "$DISTRO" == "windows" ]; then
-        docker pull --platform linux/amd64 ubuntu:22.04
+        docker pull --platform linux/amd64 ubuntu:24.04
     fi
 fi
 

--- a/hack/build-antrea-linux-all.sh
+++ b/hack/build-antrea-linux-all.sh
@@ -137,11 +137,11 @@ fi
 # image!
 if $PULL; then
     if [[ ${DOCKER_REGISTRY} == "" ]]; then
-        docker pull $PLATFORM_ARG ubuntu:22.04
+        docker pull $PLATFORM_ARG ubuntu:24.04
         docker pull $PLATFORM_ARG golang:$GO_VERSION
     else
-        docker pull ${DOCKER_REGISTRY}/antrea/ubuntu:22.04
-        docker tag ${DOCKER_REGISTRY}/antrea/ubuntu:22.04 ubuntu:22.04
+        docker pull ${DOCKER_REGISTRY}/antrea/ubuntu:24.04
+        docker tag ${DOCKER_REGISTRY}/antrea/ubuntu:24.04 ubuntu:24.04
         docker pull ${DOCKER_REGISTRY}/antrea/golang:$GO_VERSION
         docker tag ${DOCKER_REGISTRY}/antrea/golang:$GO_VERSION golang:$GO_VERSION
     fi

--- a/multicluster/build/images/Dockerfile.build.coverage
+++ b/multicluster/build/images/Dockerfile.build.coverage
@@ -25,7 +25,7 @@ COPY . /antrea
 
 RUN cd multicluster && make antrea-mc-instr-binary
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 LABEL maintainer="Antrea <projectantrea-dev@googlegroups.com>"
 LABEL description="The Docker image to deploy the Antrea Multi-cluster Controller with code coverage measurement enabled (used for testing)."


### PR DESCRIPTION
Upgrade to ubuntu:24.04 in most places (except for a few build / test
images which will be updated later on). In particular ubuntu:24.04 is
now the base image for antrea/antrea-agent-ubuntu and
antrea/controller-ubuntu.

In order for our current version of OVS (2.17.7) to build correctly on
Ubuntu 24.04, some "recent" patches have to be applied manually.

After this change, the antrea/antrea-agent-ubuntu image is slightly
bigger (344MB -> 372MB uncompressed), and the size increase seems to be
driven by some systemd libraries.