### PR TITLE
antctl: unify checker image and make it configurable

### DIFF
--- a/pkg/antctl/raw/check/constants.go
+++ b/pkg/antctl/raw/check/constants.go
@@ -1,0 +1,19 @@
+// Copyright 2024 Antrea Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package check
+
+const (
+	DefaultTestImage = "antrea/toolbox:1.4-0"
+)

--- a/pkg/antctl/raw/check/installation/command_test.go
+++ b/pkg/antctl/raw/check/installation/command_test.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"antrea.io/antrea/pkg/antctl/raw/check"
 )
 
 func overrideTestsRegistry(t *testing.T, registry map[string]Test) {
@@ -103,7 +105,7 @@ func TestRun(t *testing.T) {
 			overrideTestsRegistry(t, tc.registry)
 			runFilterRegex, err := compileRunFilter(tc.runFilter)
 			require.NoError(t, err)
-			testContext := NewTestContext(nil, nil, "test-cluster", "kube-system", runFilterRegex)
+			testContext := NewTestContext(nil, nil, "test-cluster", "kube-system", runFilterRegex, check.DefaultTestImage)
 			stats := testContext.runTests(ctx)
 			assert.Equal(t, tc.expectedStats, stats)
 		})

--- a/pkg/antctl/raw/check/installation/test_denyall.go
+++ b/pkg/antctl/raw/check/installation/test_denyall.go
@@ -88,7 +88,7 @@ func (t *DenyAllConnectivityTest) Run(ctx context.Context, testContext *testCont
 	for _, clientPod := range testContext.clientPods {
 		for _, service := range services {
 			for _, clusterIP := range service.Spec.ClusterIPs {
-				if err := testContext.runAgnhostConnect(ctx, clientPod.Name, "", clusterIP, 80); err != nil {
+				if err := testContext.tcpProbe(ctx, clientPod.Name, "", clusterIP, 80); err != nil {
 					testContext.Log("NetworkPolicy is working as expected: Pod %s cannot connect to Service %s (%s)", clientPod.Name, service.Name, clusterIP)
 				} else {
 					return fmt.Errorf("NetworkPolicy is not working as expected: Pod %s connected to Service %s (%s) when it should not", clientPod.Name, service.Name, clusterIP)

--- a/pkg/antctl/raw/check/installation/test_podtointernet.go
+++ b/pkg/antctl/raw/check/installation/test_podtointernet.go
@@ -29,7 +29,7 @@ func (t *PodToInternetConnectivityTest) Run(ctx context.Context, testContext *te
 	for _, clientPod := range testContext.clientPods {
 		srcPod := testContext.namespace + "/" + clientPod.Name
 		testContext.Log("Validating connectivity from Pod %s to the world (google.com)...", srcPod)
-		if err := testContext.runAgnhostConnect(ctx, clientPod.Name, "", "google.com", 80); err != nil {
+		if err := testContext.tcpProbe(ctx, clientPod.Name, "", "google.com", 80); err != nil {
 			return fmt.Errorf("Pod %s was not able to connect to google.com: %w", srcPod, err)
 		}
 		testContext.Log("Pod %s was able to connect to google.com", srcPod)

--- a/pkg/antctl/raw/check/installation/test_podtopodinternode.go
+++ b/pkg/antctl/raw/check/installation/test_podtopodinternode.go
@@ -35,7 +35,7 @@ func (t *PodToPodInterNodeConnectivityTest) Run(ctx context.Context, testContext
 		for _, podIP := range testContext.echoOtherNodePod.Status.PodIPs {
 			echoIP := podIP.IP
 			testContext.Log("Validating from Pod %s to Pod %s at IP %s...", srcPod, dstPod, echoIP)
-			if err := testContext.runAgnhostConnect(ctx, clientPod.Name, "", echoIP, 80); err != nil {
+			if err := testContext.tcpProbe(ctx, clientPod.Name, "", echoIP, 80); err != nil {
 				return fmt.Errorf("client Pod %s was not able to communicate with echo Pod %s (%s): %w", clientPod.Name, testContext.echoOtherNodePod.Name, echoIP, err)
 			}
 			testContext.Log("client Pod %s was able to communicate with echo Pod %s (%s)", clientPod.Name, testContext.echoOtherNodePod.Name, echoIP)

--- a/pkg/antctl/raw/check/installation/test_podtopodintranode.go
+++ b/pkg/antctl/raw/check/installation/test_podtopodintranode.go
@@ -32,7 +32,7 @@ func (t *PodToPodIntraNodeConnectivityTest) Run(ctx context.Context, testContext
 		for _, podIP := range testContext.echoSameNodePod.Status.PodIPs {
 			echoIP := podIP.IP
 			testContext.Log("Validating from Pod %s to Pod %s at IP %s...", srcPod, dstPod, echoIP)
-			if err := testContext.runAgnhostConnect(ctx, clientPod.Name, "", echoIP, 80); err != nil {
+			if err := testContext.tcpProbe(ctx, clientPod.Name, "", echoIP, 80); err != nil {
 				return fmt.Errorf("client Pod %s was not able to communicate with echo Pod %s (%s): %w", clientPod.Name, testContext.echoSameNodePod.Name, echoIP, err)
 			}
 			testContext.Log("client Pod %s was able to communicate with echo Pod %s (%s)", clientPod.Name, testContext.echoSameNodePod.Name, echoIP)

--- a/pkg/antctl/raw/check/installation/test_podtoservice.go
+++ b/pkg/antctl/raw/check/installation/test_podtoservice.go
@@ -53,7 +53,7 @@ func (t *PodToServiceConnectivityTest) Run(ctx context.Context, testContext *tes
 		for _, clusterIP := range service.Spec.ClusterIPs {
 			// Service is realized asynchronously, retry a few times.
 			if err := wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 2*time.Second, true, func(ctx context.Context) (bool, error) {
-				if err := testContext.runAgnhostConnect(ctx, clientPod.Name, "", clusterIP, 80); err != nil {
+				if err := testContext.tcpProbe(ctx, clientPod.Name, "", clusterIP, 80); err != nil {
 					testContext.Log("Client Pod %s was not able to communicate with Service %s (%s): %v, retrying...", clientPod.Name, service.Name, clusterIP, err)
 					return false, nil
 				}


### PR DESCRIPTION
To support scenarios that hardcoded images are not accessible.

Depends on https://github.com/antrea-io/image-utils/pull/39