### PR TITLE
Automated cherry pick of #6565: antctl: fix cluster checker image (#6565)

### DIFF
--- a/pkg/antctl/raw/check/cluster/command.go
+++ b/pkg/antctl/raw/check/cluster/command.go
@@ -199,7 +199,7 @@ func (t *testContext) setup(ctx context.Context) error {
 
 func getAntreaAgentImage() string {
 	if version.ReleaseStatus == "released" {
-		return fmt.Sprintf("antrea/antrea-agent-ubuntu:%s", version.GetVersion())
+		return fmt.Sprintf("antrea/antrea-agent-ubuntu:%s", version.Version)
 	}
 	return "antrea/antrea-agent-ubuntu:latest"
 }


### PR DESCRIPTION
Cherry pick of #6565 on release-2.1.

#6565: antctl: fix cluster checker image (#6565)

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.