### PR TITLE
Always check for random-fully support

### DIFF
--- a/pkg/agent/route/route_linux_test.go
+++ b/pkg/agent/route/route_linux_test.go
@@ -642,6 +642,7 @@ COMMIT
 				connectUplinkToBridge:    tt.connectUplinkToBridge,
 				nodeNetworkPolicyEnabled: tt.nodeNetworkPolicyEnabled,
 				nodeSNATRandomFully:      tt.nodeSNATRandomFully,
+				iptablesHasRandomFully:   true,
 				deterministic:            true,
 			}
 			for mark, snatIP := range tt.markToSNATIP {


### PR DESCRIPTION
One rule was already using `--random-fully` unconditionally prior to it. The fact that no issue has ever been reported indicates that `--random-fully` should be supported by all systems running Antrea...