### PR TITLE
[Flow Aggregator] Fix template ID error in IPFIX exporter

### DIFF
--- a/pkg/flowaggregator/exporter/ipfix.go
+++ b/pkg/flowaggregator/exporter/ipfix.go
@@ -151,16 +151,16 @@ func (e *IPFIXExporter) UpdateOptions(opt *options.Options) {
 }
 
 func (e *IPFIXExporter) sendRecord(record ipfixentities.Record, isRecordIPv6 bool) error {
-	templateID := e.templateIDv4
-	if isRecordIPv6 {
-		templateID = e.templateIDv6
-	}
-
 	if e.exportingProcess == nil {
 		if err := initIPFIXExportingProcess(e); err != nil {
 			// in case of error, the FlowAggregator flowExportLoop will retry after activeFlowRecordTimeout
 			return fmt.Errorf("error when initializing IPFIX exporting process: %v", err)
 		}
+	}
+
+	templateID := e.templateIDv4
+	if isRecordIPv6 {
+		templateID = e.templateIDv6
 	}
 
 	// TODO: more records per data set will be supported when go-ipfix supports size check when adding records


### PR DESCRIPTION
The template ID is only available after the exporter has been initialized.

With this fix, we avoid the following error for the first data record to be exported:

```
error when sending IPFIX record: error when doing sanity check:process:
templateID 0 does not exist in exporting process
```