### PR TITLE
Automated cherry pick of #6630: Fix template ID error in IPFIX exporter

### DIFF
--- a/pkg/flowaggregator/exporter/ipfix.go
+++ b/pkg/flowaggregator/exporter/ipfix.go
@@ -151,16 +151,16 @@ func (e *IPFIXExporter) UpdateOptions(opt *options.Options) {
 }
 
 func (e *IPFIXExporter) sendRecord(record ipfixentities.Record, isRecordIPv6 bool) error {
-	templateID := e.templateIDv4
-	if isRecordIPv6 {
-		templateID = e.templateIDv6
-	}
-
 	if e.exportingProcess == nil {
 		if err := initIPFIXExportingProcess(e); err != nil {
 			// in case of error, the FlowAggregator flowExportLoop will retry after activeFlowRecordTimeout
 			return fmt.Errorf("error when initializing IPFIX exporting process: %v", err)
 		}
+	}
+
+	templateID := e.templateIDv4
+	if isRecordIPv6 {
+		templateID = e.templateIDv6
 	}
 
 	// TODO: more records per data set will be supported when go-ipfix supports size check when adding records


### PR DESCRIPTION
Cherry pick of #6630 on release-2.1.

#6630: Fix template ID error in IPFIX exporter

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.