### PR TITLE
[FlowAggregator] Close connection to IPFIX collector on Stop

### DIFF
--- a/pkg/flowaggregator/exporter/ipfix.go
+++ b/pkg/flowaggregator/exporter/ipfix.go
@@ -104,11 +104,15 @@ func NewIPFIXExporter(
 }
 
 func (e *IPFIXExporter) Start() {
-	// no-op
+	// no-op, initIPFIXExportingProcess will be called whenever AddRecord is
+	// called as needed.
 }
 
 func (e *IPFIXExporter) Stop() {
-	// no-op
+	if e.exportingProcess != nil {
+		e.exportingProcess.CloseConnToCollector()
+		e.exportingProcess = nil
+	}
 }
 
 func (e *IPFIXExporter) AddRecord(record ipfixentities.Record, isRecordIPv6 bool) error {


### PR DESCRIPTION
When the IPFIX exporter is stopped in the Flow Aggregator, the connection to the collector should be explicitly closed.