### PR TITLE
Add antctl-darwin-arm64 to release assets

### DIFF
--- a/hack/release/prepare-assets.sh
+++ b/hack/release/prepare-assets.sh
@@ -58,6 +58,7 @@ ANTREA_BUILDS=(
     "linux arm linux-arm"
     "windows amd64 windows-x86_64.exe"
     "darwin amd64 darwin-x86_64"
+    "darwin arm64 darwin-arm64"
 )
 
 for build in "${ANTREA_BUILDS[@]}"; do


### PR DESCRIPTION
It was an oversight not to distribute an antctl binary that can run on Apple ARM-based chips.

Note that macOS bundles an emulation solution (Rosetta 2) to enable x86 applications to run on their ARM-based chips, so `antctl-darwin-x86_64` can typically be used on these machines. However, it is common practice for OSS projects to provide a native arm64 binary.