### PR TITLE
Fix L7NP enable logging wrong packet

### DIFF
--- a/docs/antrea-l7-network-policy.md
+++ b/docs/antrea-l7-network-policy.md
@@ -329,20 +329,20 @@ Allow ingress from client (10.10.1.9) to web (10.10.1.10/public/*).
 }
 ```
 
-Deny ingress from client (10.10.1.9) to web (10.10.1.10/admin/*)
+Deny ingress from client (10.10.1.4) to web (10.10.1.3/admin/*).
 
 ```json
 {
-  "timestamp": "2024-08-26T22:38:26.019956+0000",
-  "flow_id": 642636870504569,
+  "timestamp": "2024-09-05T22:49:24.788756+0000",
+  "flow_id": 1131530446896560,
   "in_iface": "antrea-l7-tap0",
   "event_type": "alert",
   "vlan": [
     2
   ],
-  "src_ip": "10.10.1.9",
-  "src_port": 37892,
-  "dest_ip": "10.10.1.10",
+  "src_ip": "10.10.1.4",
+  "src_port": 45034,
+  "dest_ip": "10.10.1.3",
   "dest_port": 80,
   "proto": "TCP",
   "pkt_src": "wire/pcap",
@@ -362,36 +362,37 @@ Deny ingress from client (10.10.1.9) to web (10.10.1.10/admin/*)
   "flow": {
     "pkts_toserver": 3,
     "pkts_toclient": 1,
-    "bytes_toserver": 308,
+    "bytes_toserver": 307,
     "bytes_toclient": 78,
-    "start": "2024-08-26T22:38:26.018553+0000",
-    "src_ip": "10.10.1.9",
-    "dest_ip": "10.10.1.10",
-    "src_port": 37892,
+    "start": "2024-09-05T22:49:24.787742+0000",
+    "src_ip": "10.10.1.4",
+    "dest_ip": "10.10.1.3",
+    "src_port": 45034,
     "dest_port": 80
   }
 }
 ```
 
-Additional packet log when `enableLogging` is set
+Additional packet logs are available when `enableLogging` is set, which tracks all
+packets in Suricata matching the dst IP address of the packet generating the alert.
 
 ```json
 {
-  "timestamp": "2024-08-26T22:38:26.025742+0000",
-  "flow_id": 642636870504569,
+  "timestamp": "2024-09-05T22:49:24.788756+0000",
+  "flow_id": 1131530446896560,
   "in_iface": "antrea-l7-tap0",
   "event_type": "packet",
   "vlan": [
     2
   ],
-  "src_ip": "10.10.1.10",
-  "src_port": 80,
-  "dest_ip": "10.10.1.9",
-  "dest_port": 37892,
+  "src_ip": "10.10.1.4",
+  "src_port": 45034,
+  "dest_ip": "10.10.1.3",
+  "dest_port": 80,
   "proto": "TCP",
   "pkt_src": "wire/pcap",
   "tenant_id": 2,
-  "packet": "/hYGSsKknh8fnhcggQAAAggARQAAKN7MAABABoXdCgoBCgoKAQkAUJQE0EfjHLfFVXZQFAH7QroAAA==",
+  "packet": "dtwWezuaHlOhfWpNgQAAAggARQAAjU/0QABABtRcCgoBBAoKAQOv6gBQgOZTvPTauPuAGAH7TZcAAAEBCAouFZzsR8fBM0dFVCAvYWRtaW4vaW5kZXguaHRtbCBIVFRQLzEuMQ0KSG9zdDogMTAuMTAuMS4zDQpVc2VyLUFnZW50OiBjdXJsLzcuNzQuMA0KQWNjZXB0OiAqLyoNCg0K",
   "packet_info": {
     "linktype": 1
   }

--- a/pkg/agent/controller/networkpolicy/l7engine/reconciler_test.go
+++ b/pkg/agent/controller/networkpolicy/l7engine/reconciler_test.go
@@ -189,7 +189,7 @@ func TestRuleLifecycle(t *testing.T) {
 			fe.startSuricataFn = fs.startSuricataFn
 
 			// Test add a L7 NetworkPolicy.
-			assert.NoError(t, fe.AddRule(ruleID, policyName, vlanID, tc.l7Protocols, false))
+			assert.NoError(t, fe.AddRule(ruleID, policyName, vlanID, tc.l7Protocols))
 
 			rulesPath := generateTenantRulesPath(vlanID)
 			ok, err := afero.FileContainsBytes(defaultFS, rulesPath, []byte(tc.expectedRules))
@@ -206,7 +206,7 @@ func TestRuleLifecycle(t *testing.T) {
 			assert.Equal(t, expectedScCommands, fs.calledScCommands)
 
 			// Update the added L7 NetworkPolicy.
-			assert.NoError(t, fe.AddRule(ruleID, policyName, vlanID, tc.updatedL7Protocols, false))
+			assert.NoError(t, fe.AddRule(ruleID, policyName, vlanID, tc.updatedL7Protocols))
 			expectedScCommands.Insert("reload-tenant 1 /etc/suricata/antrea-tenant-1.yaml")
 			assert.Equal(t, expectedScCommands, fs.calledScCommands)
 

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
@@ -72,7 +72,7 @@ const (
 )
 
 type L7RuleReconciler interface {
-	AddRule(ruleID, policyName string, vlanID uint32, l7Protocols []v1beta2.L7Protocol, enableLogging bool) error
+	AddRule(ruleID, policyName string, vlanID uint32, l7Protocols []v1beta2.L7Protocol) error
 	DeleteRule(ruleID string, vlanID uint32) error
 }
 
@@ -797,7 +797,7 @@ func (c *Controller) syncRule(key string) error {
 		vlanID := c.l7VlanIDAllocator.allocate(key)
 		rule.L7RuleVlanID = &vlanID
 
-		if err := c.l7RuleReconciler.AddRule(key, rule.SourceRef.ToString(), vlanID, rule.L7Protocols, rule.EnableLogging); err != nil {
+		if err := c.l7RuleReconciler.AddRule(key, rule.SourceRef.ToString(), vlanID, rule.L7Protocols); err != nil {
 			return err
 		}
 	}
@@ -852,7 +852,7 @@ func (c *Controller) syncRules(keys []string) error {
 				vlanID := c.l7VlanIDAllocator.allocate(key)
 				rule.L7RuleVlanID = &vlanID
 
-				if err := c.l7RuleReconciler.AddRule(key, rule.SourceRef.ToString(), vlanID, rule.L7Protocols, rule.EnableLogging); err != nil {
+				if err := c.l7RuleReconciler.AddRule(key, rule.SourceRef.ToString(), vlanID, rule.L7Protocols); err != nil {
 					return err
 				}
 			}


### PR DESCRIPTION
Current logs by Suricata when enableLogging is set, logs the wrong packet of RST instead of the original TCP packet, and remains an existing bug in Suricata. 

This solution modifies the design to remove enableLogging in L7, keep it in L4, and instead configure Suricata to log Packet info for all alert events.

Also add Packet test to E2E tests.

Decode the packet `dtwWezuaHlOhfWpNgQAAAQgARQAAjbT0QABABm9cCgoBBAoKAQOJUgBQa2w1WZlax6yAGAH7nAIAAAEBCAorcsv8RSTwQkdFVCAvYWRtaW4vaW5kZXguaHRtbCBIVFRQLzEuMQ0KSG9zdDogMTAuMTAuMS4zDQpVc2VyLUFnZW50OiBjdXJsLzcuNzQuMA0KQWNjZXB0OiAqLyoNCg0K`

-> `10.10.1.4 → 10.10.1.3 HTTP GET /admin/index.html HTTP/1.1`

Fixes #6636.