### PR TITLE
Replace unsafe.Slice with memory copying to avoid potential fault memory issue

### DIFF
--- a/pkg/agent/util/syscall/syscall_windows.go
+++ b/pkg/agent/util/syscall/syscall_windows.go
@@ -368,7 +368,16 @@ func (n *netIO) ListIPForwardRows(family uint16) ([]MibIPForwardRow, error) {
 	if err != nil {
 		return nil, os.NewSyscallError("iphlpapi.GetIpForwardTable", err)
 	}
-	return unsafe.Slice(&table.Table[0], table.NumEntries), nil
+	rows := make([]MibIPForwardRow, table.NumEntries, table.NumEntries)
+
+	pFirstRow := uintptr(unsafe.Pointer(&table.Table[0]))
+	rowSize := unsafe.Sizeof(table.Table[0])
+
+	for i := uint32(0); i < table.NumEntries; i++ {
+		row := *(*MibIPForwardRow)(unsafe.Pointer(pFirstRow + rowSize*uintptr(i)))
+		rows[i] = row
+	}
+	return rows, nil
 }
 
 func NewIPForwardRow() *MibIPForwardRow {


### PR DESCRIPTION
* Refactored ListIPForwardRows to deep copy IP forwarding table rows.
* Removed unsafe.Slice and replaced with manual pointer dereferencing and copying.

This change addresses a potential fault memory issue when iterating through the IP forwarding table,
caused by the use of slices after corresponding memory has been freed, leading to access failure.