### PR TITLE
Automated cherry pick of #6664: Replace unsafe.Slice with memory copying to avoid potential

### DIFF
--- a/pkg/agent/util/syscall/syscall_windows.go
+++ b/pkg/agent/util/syscall/syscall_windows.go
@@ -368,7 +368,16 @@ func (n *netIO) ListIPForwardRows(family uint16) ([]MibIPForwardRow, error) {
 	if err != nil {
 		return nil, os.NewSyscallError("iphlpapi.GetIpForwardTable", err)
 	}
-	return unsafe.Slice(&table.Table[0], table.NumEntries), nil
+	rows := make([]MibIPForwardRow, table.NumEntries, table.NumEntries)
+
+	pFirstRow := uintptr(unsafe.Pointer(&table.Table[0]))
+	rowSize := unsafe.Sizeof(table.Table[0])
+
+	for i := uint32(0); i < table.NumEntries; i++ {
+		row := *(*MibIPForwardRow)(unsafe.Pointer(pFirstRow + rowSize*uintptr(i)))
+		rows[i] = row
+	}
+	return rows, nil
 }
 
 func NewIPForwardRow() *MibIPForwardRow {


### PR DESCRIPTION
Cherry pick of #6664 on release-2.0.

#6664: Replace unsafe.Slice with memory copying to avoid potential

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.