### PR TITLE
Handle ExternalIPPool range changes in Egress controller

### DIFF
--- a/pkg/controller/egress/controller.go
+++ b/pkg/controller/egress/controller.go
@@ -255,14 +255,13 @@ func (c *EgressController) syncEgressIP(egress *egressv1beta1.Egress) (net.IP, *
 			if c.externalIPAllocator.IPPoolHasIP(prevIPPool, prevIP) {
 				return prevIP, egress, nil
 			}
-			// If the ExternalIPPool exists, but the IP is not in range, reclaim the IP from the Egress API.
-			if c.externalIPAllocator.IPPoolExists(egress.Spec.ExternalIPPool) {
-				klog.InfoS("Allocated EgressIP is no longer part of ExternalIPPool, releasing it", "egress", klog.KObj(egress), "ip", egress.Spec.EgressIP, "pool", egress.Spec.ExternalIPPool)
-				if updatedEgress, err := c.updateEgressIP(egress, ""); err != nil {
-					return nil, egress, err
-				} else {
-					egress = updatedEgress
-				}
+			// The ExternalIPPool may no longer exist, or the IP is not in range.
+			// Reclaim the IP from the Egress API.
+			klog.InfoS("Allocated EgressIP is no longer part of ExternalIPPool, releasing it", "egress", klog.KObj(egress), "ip", egress.Spec.EgressIP, "pool", egress.Spec.ExternalIPPool)
+			if updatedEgress, err := c.updateEgressIP(egress, ""); err != nil {
+				return nil, egress, err
+			} else {
+				egress = updatedEgress
 			}
 		}
 		// Either EgressIP or ExternalIPPool changes, release the previous one first.

--- a/pkg/controller/egress/controller_test.go
+++ b/pkg/controller/egress/controller_test.go
@@ -596,7 +596,7 @@ func TestRecreateExternalIPPoolWithNewRange(t *testing.T) {
 	require.True(t, cache.WaitForCacheSync(stopCh, controller.externalIPAllocator.HasSynced))
 	controller.restoreIPAllocations([]*v1beta1.Egress{egress})
 
-	getEgressIP, _, err := controller.syncEgressIP(egress)
+	getEgressIP, egress, err := controller.syncEgressIP(egress)
 	require.NoError(t, err)
 	assert.Equal(t, net.ParseIP("1.1.1.1"), getEgressIP)
 

--- a/pkg/controller/egress/controller_test.go
+++ b/pkg/controller/egress/controller_test.go
@@ -584,7 +584,7 @@ func TestRecreateExternalIPPoolWithNewRange(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, net.ParseIP("1.1.1.1"), getEgressIP)
 
-	// Delete and recreate the ExternalIPPool immediately with a diffenre IP range. We do not
+	// Delete and recreate the ExternalIPPool immediately with a different IP range. We do not
 	// call syncEgressIP in-between, so the Egress controller doesn't have a chance to process
 	// both changes independently.
 	controller.crdClient.CrdV1beta1().ExternalIPPools().Delete(context.TODO(), eipFoo1.Name, metav1.DeleteOptions{})

--- a/pkg/controller/externalippool/controller.go
+++ b/pkg/controller/externalippool/controller.go
@@ -88,6 +88,10 @@ type ExternalIPAllocator interface {
 	// UpdateIPAllocation marks the IP in the specified ExternalIPPool as occupied.
 	UpdateIPAllocation(externalIPPool string, ip net.IP) error
 	// ReleaseIP releases the IP to the IP pool.
+	// It returns ErrExternalIPPoolNotFound if the externalIPPool does not exist.
+	// Any other error indicates that the IP was not allocated, or is not currently allocated.
+	// In case of an error, there is no reason to try again with the same arguments, as
+	// transient errors are not possible.
 	ReleaseIP(externalIPPool string, ip net.IP) error
 	// HasSynced indicates ExternalIPAllocator has finished syncing all ExternalIPPool resources.
 	HasSynced() bool


### PR DESCRIPTION
The validation webhook for ExternalIPPools prevents modifications to IP address ranges. However, it is theoretically possible for an ExternalIPPool to be deleted, then recreated immediately with different IP address ranges, and for the Egress controller to only process the Egress resources referencing the pool once, *after* the CREATE event has been handled by the ExternalIPPool controller. This is because the ExternalIPPool controller is in charge of notifying the Egress controller through a callback (event handler) mechanism, and that multiple events for the same ExternalIPPool name can be merged in the workqueue.

With this change, we try to ensure the same "observable" behavior for the Egress controller, regardless of whether the DELETE and CREATE events have been merged or not. The stale Egress IP should be removed, and a new Egress IP should be allocated from the new IP ranges (regardless of whether or not the initial Egress IP was specified by the user).

Prior to this change, the change of IP address ranges would be silently ignored by the Egress controller.