### PR TITLE
Change antctl make target

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -171,8 +171,18 @@ jobs:
       run: GOARCH=arm64 make bin
     - name: Build Antrea binaries for arm
       run: GOARCH=arm make bin
-    - name: Build antctl binaries
-      run: make antctl
+    - name: Build antctl binary for linux amd64
+      run: GOOS=linux GOARCH=amd64 make antctl
+    - name: Build antctl binary for linux arm64
+      run: GOOS=linux GOARCH=arm64 make antctl
+    - name: Build antctl binary for linux arm
+      run: GOOS=linux GOARCH=arm make antctl
+    - name: Build antctl binary for windows amd64
+      run: GOOS=windows GOARCH=amd64 make antctl
+    - name: Build antctl binary for darwin amd64
+      run: GOOS=darwin GOARCH=amd64 make antctl
+    - name: Build antctl binary for darwin arm64
+      run: GOOS=darwin GOARCH=arm64 make antctl
     - name: Build Multi-cluster binaries
       run: |
         cd multicluster

--- a/Makefile
+++ b/Makefile
@@ -258,7 +258,7 @@ $(ANTCTL_BINARIES): antctl-%:
 	fi
 
 .PHONY: antctl
-antctl: $(ANTCTL_BINARIES)
+antctl: antctl-release
 
 .PHONY: antctl-release
 antctl-release:


### PR DESCRIPTION
Running "make antctl" is common when someone wants to build antctl for the current machine. The current target builds 3 versions of the antctl binary: one for Linux, one for Windows and one for Darwin (using the architecture of the current machine). This seems unnecessary and potentially confusing. We change the antctl target to be an alias of antctl-release. Running "make antctl" will now produce a single binary named "antctl", which can be run on the current machine.

For backwards-compatibility, we preserve the ability to run "make antctl-linux", "make antctl-windows", and "make antctl-darwin". These 3 targets combined will produce the 3 antctl binaries described above.

Finally, we update the Github workflow in charge of validating the antctl Go build. We now have one dedicated step for each supported OS / arch combination.