### PR TITLE
Automated cherry pick of #6000: [tests/e2e]: Remove all references to busybox in e2e tests

### DIFF
--- a/test/e2e/antreapolicy_test.go
+++ b/test/e2e/antreapolicy_test.go
@@ -4718,7 +4718,7 @@ func testANNPNetworkPolicyStatsWithDropAction(t *testing.T, data *TestData) {
 	serverName, serverIPs, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "test-server-", "", data.testNamespace, false)
 	defer cleanupFunc()
 
-	clientName, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", "", data.testNamespace, false)
+	clientName, _, cleanupFunc := createAndWaitForPod(t, data, data.createToolboxPodOnNode, "test-client-", "", data.testNamespace, false)
 	defer cleanupFunc()
 	var err error
 	k8sUtils, err = NewKubernetesUtils(data)
@@ -4737,11 +4737,11 @@ func testANNPNetworkPolicyStatsWithDropAction(t *testing.T, data *TestData) {
 	// So we need to  "warm-up" the tunnel.
 	if clusterInfo.podV4NetworkCIDR != "" {
 		cmd := []string{"/bin/sh", "-c", fmt.Sprintf("nc -vz -w 4 %s 80", serverIPs.IPv4.String())}
-		data.RunCommandFromPod(data.testNamespace, clientName, busyboxContainerName, cmd)
+		data.RunCommandFromPod(data.testNamespace, clientName, toolboxContainerName, cmd)
 	}
 	if clusterInfo.podV6NetworkCIDR != "" {
 		cmd := []string{"/bin/sh", "-c", fmt.Sprintf("nc -vz -w 4 %s 80", serverIPs.IPv6.String())}
-		data.RunCommandFromPod(data.testNamespace, clientName, busyboxContainerName, cmd)
+		data.RunCommandFromPod(data.testNamespace, clientName, toolboxContainerName, cmd)
 	}
 	var annp = &crdv1beta1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{Namespace: data.testNamespace, Name: "np1", Labels: map[string]string{"antrea-e2e": "np1"}},
@@ -4799,14 +4799,14 @@ func testANNPNetworkPolicyStatsWithDropAction(t *testing.T, data *TestData) {
 			if clusterInfo.podV4NetworkCIDR != "" {
 				cmd := []string{"/bin/sh", "-c", fmt.Sprintf("echo test | nc -w 4 -u %s 80", serverIPs.IPv4.String())}
 				cmd2 := []string{"/bin/sh", "-c", fmt.Sprintf("echo test | nc -w 4 -u %s 443", serverIPs.IPv4.String())}
-				data.RunCommandFromPod(data.testNamespace, clientName, busyboxContainerName, cmd)
-				data.RunCommandFromPod(data.testNamespace, clientName, busyboxContainerName, cmd2)
+				data.RunCommandFromPod(data.testNamespace, clientName, toolboxContainerName, cmd)
+				data.RunCommandFromPod(data.testNamespace, clientName, toolboxContainerName, cmd2)
 			}
 			if clusterInfo.podV6NetworkCIDR != "" {
 				cmd := []string{"/bin/sh", "-c", fmt.Sprintf("echo test | nc -w 4 -u %s 80", serverIPs.IPv6.String())}
 				cmd2 := []string{"/bin/sh", "-c", fmt.Sprintf("echo test | nc -w 4 -u %s 443", serverIPs.IPv6.String())}
-				data.RunCommandFromPod(data.testNamespace, clientName, busyboxContainerName, cmd)
-				data.RunCommandFromPod(data.testNamespace, clientName, busyboxContainerName, cmd2)
+				data.RunCommandFromPod(data.testNamespace, clientName, toolboxContainerName, cmd)
+				data.RunCommandFromPod(data.testNamespace, clientName, toolboxContainerName, cmd2)
 			}
 			wg.Done()
 		}()
@@ -4853,7 +4853,7 @@ func testAntreaClusterNetworkPolicyStats(t *testing.T, data *TestData) {
 	serverName, serverIPs, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "test-server-", "", data.testNamespace, false)
 	defer cleanupFunc()
 
-	clientName, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", "", data.testNamespace, false)
+	clientName, _, cleanupFunc := createAndWaitForPod(t, data, data.createToolboxPodOnNode, "test-client-", "", data.testNamespace, false)
 	defer cleanupFunc()
 	var err error
 	k8sUtils, err = NewKubernetesUtils(data)
@@ -4872,11 +4872,11 @@ func testAntreaClusterNetworkPolicyStats(t *testing.T, data *TestData) {
 	// So we need to  "warm-up" the tunnel.
 	if clusterInfo.podV4NetworkCIDR != "" {
 		cmd := []string{"/bin/sh", "-c", fmt.Sprintf("nc -vz -w 4 %s 80", serverIPs.IPv4.String())}
-		data.RunCommandFromPod(data.testNamespace, clientName, busyboxContainerName, cmd)
+		data.RunCommandFromPod(data.testNamespace, clientName, toolboxContainerName, cmd)
 	}
 	if clusterInfo.podV6NetworkCIDR != "" {
 		cmd := []string{"/bin/sh", "-c", fmt.Sprintf("nc -vz -w 4 %s 80", serverIPs.IPv6.String())}
-		data.RunCommandFromPod(data.testNamespace, clientName, busyboxContainerName, cmd)
+		data.RunCommandFromPod(data.testNamespace, clientName, toolboxContainerName, cmd)
 	}
 	var acnp = &crdv1beta1.ClusterNetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{Namespace: data.testNamespace, Name: "cnp1", Labels: map[string]string{"antrea-e2e": "cnp1"}},
@@ -4934,14 +4934,14 @@ func testAntreaClusterNetworkPolicyStats(t *testing.T, data *TestData) {
 			if clusterInfo.podV4NetworkCIDR != "" {
 				cmd := []string{"/bin/sh", "-c", fmt.Sprintf("echo test | nc -w 4 -u %s 800", serverIPs.IPv4.String())}
 				cmd2 := []string{"/bin/sh", "-c", fmt.Sprintf("echo test | nc -w 4 -u %s 4430", serverIPs.IPv4.String())}
-				data.RunCommandFromPod(data.testNamespace, clientName, busyboxContainerName, cmd)
-				data.RunCommandFromPod(data.testNamespace, clientName, busyboxContainerName, cmd2)
+				data.RunCommandFromPod(data.testNamespace, clientName, toolboxContainerName, cmd)
+				data.RunCommandFromPod(data.testNamespace, clientName, toolboxContainerName, cmd2)
 			}
 			if clusterInfo.podV6NetworkCIDR != "" {
 				cmd := []string{"/bin/sh", "-c", fmt.Sprintf("echo test | nc -w 4 -u %s 800", serverIPs.IPv6.String())}
 				cmd2 := []string{"/bin/sh", "-c", fmt.Sprintf("echo test | nc -w 4 -u %s 4430", serverIPs.IPv6.String())}
-				data.RunCommandFromPod(data.testNamespace, clientName, busyboxContainerName, cmd)
-				data.RunCommandFromPod(data.testNamespace, clientName, busyboxContainerName, cmd2)
+				data.RunCommandFromPod(data.testNamespace, clientName, toolboxContainerName, cmd)
+				data.RunCommandFromPod(data.testNamespace, clientName, toolboxContainerName, cmd2)
 			}
 			wg.Done()
 		}()

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -60,14 +60,14 @@ func TestBasic(t *testing.T) {
 }
 
 // testPodAssignIP verifies that Antrea allocates IP addresses properly to new Pods. It does this by
-// deploying a busybox Pod, then waiting for the K8s apiserver to report the new IP address for that
+// deploying a toolbox Pod, then waiting for the K8s apiserver to report the new IP address for that
 // Pod, and finally verifying that the IP address is in the Pod Network CIDR for the cluster.
 func testPodAssignIP(t *testing.T, data *TestData, namespace string, podV4NetworkCIDR, podV6NetworkCIDR string) {
 	podName := randName("test-pod-")
 
-	t.Logf("Creating a busybox test Pod")
-	if err := data.createBusyboxPodOnNode(podName, namespace, "", false); err != nil {
-		t.Fatalf("Error when creating busybox test Pod: %v", err)
+	t.Logf("Creating a toolbox test Pod")
+	if err := data.createToolboxPodOnNode(podName, namespace, "", false); err != nil {
+		t.Fatalf("Error when creating toolbox test Pod: %v", err)
 	}
 	defer deletePodWrapper(t, data, namespace, podName)
 
@@ -296,9 +296,9 @@ func testIPAMRestart(t *testing.T, data *TestData, namespace string) {
 	}()
 
 	createPodAndGetIP := func(podName string) (*PodIPs, error) {
-		t.Logf("Creating a busybox test Pod '%s' and waiting for IP", podName)
-		if err := data.createBusyboxPodOnNode(podName, namespace, nodeName, false); err != nil {
-			t.Fatalf("Error when creating busybox test Pod '%s': %v", podName, err)
+		t.Logf("Creating a toolbox test Pod '%s' and waiting for IP", podName)
+		if err := data.createToolboxPodOnNode(podName, namespace, nodeName, false); err != nil {
+			t.Fatalf("Error when creating toolbox test Pod '%s': %v", podName, err)
 			return nil, err
 		}
 		pods = append(pods, podName)
@@ -831,7 +831,7 @@ func testGratuitousARP(t *testing.T, data *TestData, namespace string) {
 	nodeName := workerNodeName(1)
 
 	t.Logf("Creating Pod '%s' on '%s'", podName, nodeName)
-	if err := data.createBusyboxPodOnNode(podName, namespace, nodeName, false); err != nil {
+	if err := data.createToolboxPodOnNode(podName, namespace, nodeName, false); err != nil {
 		t.Fatalf("Error when creating Pod '%s': %v", podName, err)
 	}
 	defer deletePodWrapper(t, data, namespace, podName)

--- a/test/e2e/batch_test.go
+++ b/test/e2e/batch_test.go
@@ -60,7 +60,7 @@ func TestBatchCreatePods(t *testing.T) {
 
 	oldFDs := getFDs()
 
-	_, _, cleanupFn := createTestBusyboxPods(t, data, batchNum, data.testNamespace, node1)
+	_, _, cleanupFn := createTestToolboxPods(t, data, batchNum, data.testNamespace, node1)
 	defer cleanupFn()
 
 	// It is possible for new FDs to be allocated temporarily by the process, for different

--- a/test/e2e/connectivity_test.go
+++ b/test/e2e/connectivity_test.go
@@ -169,7 +169,7 @@ func (data *TestData) testHostPortPodConnectivity(t *testing.T, clientNamespace,
 	hpPodHostIP := hpPod.Status.HostIP
 	// Create client Pod to test connectivity.
 	clientName := randName("test-client-")
-	if err := data.createBusyboxPodOnNode(clientName, clientNamespace, "", false); err != nil {
+	if err := data.createToolboxPodOnNode(clientName, clientNamespace, "", false); err != nil {
 		t.Fatalf("Error when creating test client Pod: %v", err)
 	}
 	defer deletePodWrapper(t, data, clientNamespace, clientName)
@@ -334,8 +334,8 @@ func testPodConnectivityAfterAntreaRestart(t *testing.T, data *TestData, namespa
 // br-int bridge is to implement normal L2 forwarding.
 func testOVSRestartSameNode(t *testing.T, data *TestData, namespace string) {
 	workerNode := workerNodeName(1)
-	t.Logf("Creating two busybox test Pods on '%s'", workerNode)
-	podNames, podIPs, cleanupFn := createTestBusyboxPods(t, data, 2, namespace, workerNode)
+	t.Logf("Creating two toolbox test Pods on '%s'", workerNode)
+	podNames, podIPs, cleanupFn := createTestToolboxPods(t, data, 2, namespace, workerNode)
 	defer cleanupFn()
 
 	resCh := make(chan error, 1)
@@ -343,10 +343,10 @@ func testOVSRestartSameNode(t *testing.T, data *TestData, namespace string) {
 	runArping := func() error {
 		// we send arp pings for 25 seconds; this duration is a bit arbitrary and we assume
 		// that restarting Antrea takes less than that time. Unfortunately, the arping
-		// utility in busybox does not let us choose a smaller interval than 1 second.
+		// utility in toolbox does not let us choose a smaller interval than 1 second.
 		count := 25
 		cmd := fmt.Sprintf("arping -c %d %s", count, podIPs[1].IPv4.String())
-		stdout, stderr, err := data.RunCommandFromPod(namespace, podNames[0], busyboxContainerName, strings.Fields(cmd))
+		stdout, stderr, err := data.RunCommandFromPod(namespace, podNames[0], toolboxContainerName, strings.Fields(cmd))
 		if err != nil {
 			return fmt.Errorf("error when running arping command: %v - stdout: %s - stderr: %s", err, stdout, stderr)
 		}

--- a/test/e2e/egress_test.go
+++ b/test/e2e/egress_test.go
@@ -134,14 +134,14 @@ func testEgressClientIP(t *testing.T, data *TestData) {
 
 			localPod := fmt.Sprintf("localpod%s", tt.name)
 			remotePod := fmt.Sprintf("remotepod%s", tt.name)
-			if err := data.createBusyboxPodOnNode(localPod, data.testNamespace, egressNode, false); err != nil {
+			if err := data.createToolboxPodOnNode(localPod, data.testNamespace, egressNode, false); err != nil {
 				t.Fatalf("Failed to create local Pod: %v", err)
 			}
 			defer deletePodWrapper(t, data, data.testNamespace, localPod)
 			if err := data.podWaitForRunning(defaultTimeout, localPod, data.testNamespace); err != nil {
 				t.Fatalf("Error when waiting for Pod '%s' to be in the Running state", localPod)
 			}
-			if err := data.createBusyboxPodOnNode(remotePod, data.testNamespace, workerNodeName(1), false); err != nil {
+			if err := data.createToolboxPodOnNode(remotePod, data.testNamespace, workerNodeName(1), false); err != nil {
 				t.Fatalf("Failed to create remote Pod: %v", err)
 			}
 			defer deletePodWrapper(t, data, data.testNamespace, remotePod)
@@ -156,8 +156,8 @@ func testEgressClientIP(t *testing.T, data *TestData) {
 
 			// As the fake server runs in a netns of the Egress Node, only egress Node can reach the server, Pods running on
 			// other Nodes cannot reach it before Egress is added.
-			assertClientIP(data, t, localPod, busyboxContainerName, serverIPStr, tt.localIP0, tt.localIP1)
-			assertConnError(data, t, remotePod, busyboxContainerName, serverIPStr)
+			assertClientIP(data, t, localPod, toolboxContainerName, serverIPStr, tt.localIP0, tt.localIP1)
+			assertConnError(data, t, remotePod, toolboxContainerName, serverIPStr)
 
 			t.Logf("Creating an Egress applying to all e2e Pods")
 			matchExpressions := []metav1.LabelSelectorRequirement{
@@ -168,8 +168,8 @@ func testEgressClientIP(t *testing.T, data *TestData) {
 			}
 			egress := data.createEgress(t, "egress-", matchExpressions, nil, "", egressNodeIP, nil)
 			defer data.crdClient.CrdV1beta1().Egresses().Delete(context.TODO(), egress.Name, metav1.DeleteOptions{})
-			assertClientIP(data, t, localPod, busyboxContainerName, serverIPStr, egressNodeIP)
-			assertClientIP(data, t, remotePod, busyboxContainerName, serverIPStr, egressNodeIP)
+			assertClientIP(data, t, localPod, toolboxContainerName, serverIPStr, egressNodeIP)
+			assertClientIP(data, t, remotePod, toolboxContainerName, serverIPStr, egressNodeIP)
 
 			var err error
 			err = wait.Poll(time.Millisecond*100, time.Second, func() (bool, error) {
@@ -210,8 +210,8 @@ func testEgressClientIP(t *testing.T, data *TestData) {
 			if err != nil {
 				t.Fatalf("Failed to update Egress %v: %v", egress, err)
 			}
-			assertClientIP(data, t, localPod, busyboxContainerName, serverIPStr, tt.localIP0, tt.localIP1)
-			assertClientIP(data, t, remotePod, busyboxContainerName, serverIPStr, egressNodeIP)
+			assertClientIP(data, t, localPod, toolboxContainerName, serverIPStr, tt.localIP0, tt.localIP1)
+			assertClientIP(data, t, remotePod, toolboxContainerName, serverIPStr, egressNodeIP)
 
 			t.Log("Updating the Egress's AppliedTo to localPod only")
 			egress.Spec.AppliedTo = v1beta1.AppliedTo{
@@ -223,8 +223,8 @@ func testEgressClientIP(t *testing.T, data *TestData) {
 			if err != nil {
 				t.Fatalf("Failed to update Egress %v: %v", egress, err)
 			}
-			assertClientIP(data, t, localPod, busyboxContainerName, serverIPStr, egressNodeIP)
-			assertConnError(data, t, remotePod, busyboxContainerName, serverIPStr)
+			assertClientIP(data, t, localPod, toolboxContainerName, serverIPStr, egressNodeIP)
+			assertConnError(data, t, remotePod, toolboxContainerName, serverIPStr)
 
 			t.Logf("Updating the Egress's EgressIP to %s", tt.localIP1)
 			egress.Spec.EgressIP = tt.localIP1
@@ -232,16 +232,16 @@ func testEgressClientIP(t *testing.T, data *TestData) {
 			if err != nil {
 				t.Fatalf("Failed to update Egress %v: %v", egress, err)
 			}
-			assertClientIP(data, t, localPod, busyboxContainerName, serverIPStr, tt.localIP1)
-			assertConnError(data, t, remotePod, busyboxContainerName, serverIPStr)
+			assertClientIP(data, t, localPod, toolboxContainerName, serverIPStr, tt.localIP1)
+			assertConnError(data, t, remotePod, toolboxContainerName, serverIPStr)
 
 			t.Log("Deleting the Egress")
 			err = data.crdClient.CrdV1beta1().Egresses().Delete(context.TODO(), egress.Name, metav1.DeleteOptions{})
 			if err != nil {
 				t.Fatalf("Failed to delete Egress %v: %v", egress, err)
 			}
-			assertClientIP(data, t, localPod, busyboxContainerName, serverIPStr, tt.localIP0, tt.localIP1)
-			assertConnError(data, t, remotePod, busyboxContainerName, serverIPStr)
+			assertClientIP(data, t, localPod, toolboxContainerName, serverIPStr, tt.localIP0, tt.localIP1)
+			assertConnError(data, t, remotePod, toolboxContainerName, serverIPStr)
 		})
 	}
 }

--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -523,17 +523,17 @@ func deletePodWrapper(tb testing.TB, data *TestData, namespace, name string) {
 	}
 }
 
-// createTestBusyboxPods creates the desired number of busybox Pods and wait for their IP address to
+// createTestToolboxPods creates the desired number of toolbox Pods and wait for their IP address to
 // become available. This is a common patter in our tests, so having this helper function makes
 // sense. It calls Fatalf in case of error, so it must be called from the goroutine running the test
 // or benchmark function. You can create all the Pods on the same Node by setting nodeName. If
 // nodeName is the empty string, each Pod will be created on an arbitrary
-// Node. createTestBusyboxPods returns the cleanupFn function which can be used to delete the
+// Node. createTestToolboxPods returns the cleanupFn function which can be used to delete the
 // created Pods. Pods are created in parallel to reduce the time required to run the tests.
-func createTestBusyboxPods(tb testing.TB, data *TestData, num int, ns string, nodeName string) (
+func createTestToolboxPods(tb testing.TB, data *TestData, num int, ns string, nodeName string) (
 	podNames []string, podIPs []*PodIPs, cleanupFn func(),
 ) {
-	return createTestPods(tb, data, num, ns, nodeName, false, data.createBusyboxPodOnNode)
+	return createTestPods(tb, data, num, ns, nodeName, false, data.createToolboxPodOnNode)
 }
 
 func createTestAgnhostPods(tb testing.TB, data *TestData, num int, ns string, nodeName string) (

--- a/test/e2e/flowaggregator_test.go
+++ b/test/e2e/flowaggregator_test.go
@@ -760,7 +760,7 @@ func testHelper(t *testing.T, data *TestData, isIPv6 bool) {
 		skipIfEncapModeIsNot(t, data, config.TrafficEncapModeEncap)
 
 		// Deploy the client Pod on the control-plane node
-		clientName, clientIPs, clientCleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", nodeName(0), data.testNamespace, false)
+		clientName, clientIPs, clientCleanupFunc := createAndWaitForPod(t, data, data.createToolboxPodOnNode, "test-client-", nodeName(0), data.testNamespace, false)
 		defer clientCleanupFunc()
 		label := "ToExternalEgressOnSourceNode"
 		addLabelToTestPods(t, data, label, []string{clientName})
@@ -772,7 +772,7 @@ func testHelper(t *testing.T, data *TestData, isIPv6 bool) {
 		} else {
 			egressNodeIP = nodeIPv6(0)
 		}
-		egress := data.createEgress(t, "test-egress", nil, map[string]string{"app": "busybox"}, "", egressNodeIP, nil)
+		egress := data.createEgress(t, "test-egress", nil, map[string]string{"app": "toolbox"}, "", egressNodeIP, nil)
 		egress, err := data.waitForEgressRealized(egress)
 		if err != nil {
 			t.Fatalf("Error when waiting for Egress to be realized: %v", err)
@@ -801,7 +801,7 @@ func testHelper(t *testing.T, data *TestData, isIPv6 bool) {
 		skipIfEncapModeIsNot(t, data, config.TrafficEncapModeEncap)
 
 		// Deploy the client Pod on the control-plane node
-		clientName, clientIPs, clientCleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", nodeName(0), data.testNamespace, false)
+		clientName, clientIPs, clientCleanupFunc := createAndWaitForPod(t, data, data.createToolboxPodOnNode, "test-client-", nodeName(0), data.testNamespace, false)
 		defer clientCleanupFunc()
 		label := "ToExternalEgressOnOtherNode"
 		addLabelToTestPods(t, data, label, []string{clientName})
@@ -813,7 +813,7 @@ func testHelper(t *testing.T, data *TestData, isIPv6 bool) {
 		} else {
 			egressNodeIP = nodeIPv6(1)
 		}
-		egress := data.createEgress(t, "test-egress", nil, map[string]string{"app": "busybox"}, "", egressNodeIP, nil)
+		egress := data.createEgress(t, "test-egress", nil, map[string]string{"app": "toolbox"}, "", egressNodeIP, nil)
 		egress, err := data.waitForEgressRealized(egress)
 		if err != nil {
 			t.Fatalf("Error when waiting for Egress to be realized: %v", err)
@@ -835,7 +835,7 @@ func testHelper(t *testing.T, data *TestData, isIPv6 bool) {
 	// sends traffic to an external IP
 	t.Run("ToExternalFlows", func(t *testing.T) {
 		// Deploy the client Pod on the control-plane node
-		clientName, clientIPs, clientCleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", nodeName(0), data.testNamespace, false)
+		clientName, clientIPs, clientCleanupFunc := createAndWaitForPod(t, data, data.createToolboxPodOnNode, "test-client-", nodeName(0), data.testNamespace, false)
 		defer clientCleanupFunc()
 		label := "ToExternalFlows"
 		addLabelToTestPods(t, data, label, []string{clientName})
@@ -1150,9 +1150,9 @@ func checkRecordsForToExternalFlows(t *testing.T, data *TestData, srcNodeName st
 	if !isIPv6 {
 		cmd = fmt.Sprintf("wget -O- %s:%d", dstIP, dstPort)
 	} else {
-		cmd = fmt.Sprintf("wget -O- [%s]:%d", dstIP, dstPort)
+		cmd = fmt.Sprintf("wget -O- http://[%s]:%d", dstIP, dstPort)
 	}
-	stdout, stderr, err := data.RunCommandFromPod(data.testNamespace, srcPodName, busyboxContainerName, strings.Fields(cmd))
+	stdout, stderr, err := data.RunCommandFromPod(data.testNamespace, srcPodName, toolboxContainerName, strings.Fields(cmd))
 	require.NoErrorf(t, err, "Error when running wget command, stdout: %s, stderr: %s", stdout, stderr)
 	_, recordSlices := getCollectorOutput(t, srcIP, dstIP, "", false, false, isIPv6, data, labelFilter)
 	for _, record := range recordSlices {
@@ -1357,7 +1357,7 @@ func checkPodAndNodeData(t *testing.T, record, srcPod, srcNode, dstPod, dstNode 
 		assert.Contains(record, fmt.Sprintf("\"antrea-e2e\":\"%s\",\"app\":\"iperf\"", srcPod), "Record does not have correct label for source Pod")
 		assert.Contains(record, fmt.Sprintf("\"antrea-e2e\":\"%s\",\"app\":\"iperf\"", dstPod), "Record does not have correct label for destination Pod")
 	} else {
-		assert.Contains(record, fmt.Sprintf("\"antrea-e2e\":\"%s\",\"app\":\"busybox\"", srcPod), "Record does not have correct label for source Pod")
+		assert.Contains(record, fmt.Sprintf("\"antrea-e2e\":\"%s\",\"app\":\"toolbox\"", srcPod), "Record does not have correct label for source Pod")
 	}
 }
 
@@ -1376,7 +1376,7 @@ func checkPodAndNodeDataClickHouse(data *TestData, t *testing.T, record *ClickHo
 		assert.Contains(record.SourcePodLabels, fmt.Sprintf("\"antrea-e2e\":\"%s\",\"app\":\"iperf\"", srcPod), "Record does not have correct label for source Pod")
 		assert.Contains(record.DestinationPodLabels, fmt.Sprintf("\"antrea-e2e\":\"%s\",\"app\":\"iperf\"", dstPod), "Record does not have correct label for destination Pod")
 	} else {
-		assert.Contains(record.SourcePodLabels, fmt.Sprintf("\"antrea-e2e\":\"%s\",\"app\":\"busybox\"", srcPod), "Record does not have correct label for source Pod")
+		assert.Contains(record.SourcePodLabels, fmt.Sprintf("\"antrea-e2e\":\"%s\",\"app\":\"toolbox\"", srcPod), "Record does not have correct label for source Pod")
 	}
 }
 

--- a/test/e2e/infra/vagrant/playbook/roles/common/tasks/busybox.yml
+++ b/test/e2e/infra/vagrant/playbook/roles/common/tasks/busybox.yml
@@ -1,9 +1,0 @@
-- name: Pull busybox:latest docker image
-  shell: |
-    ctr -n=k8s.io images check name==docker.io/library/busybox:latest > /tmp/busybox1
-    ctr -n=k8s.io image pull docker.io/library/busybox:latest
-    ctr -n=k8s.io images check name==docker.io/library/busybox:latest > /tmp/busybox2
-    diff /tmp/busybox1 /tmp/busybox2 || echo "Image updated"
-    rm -f /tmp/busybox1 /tmp/busybox2
-  register: busybox
-  changed_when: "'Image updated' in busybox.stdout"

--- a/test/e2e/infra/vagrant/playbook/roles/common/tasks/main.yml
+++ b/test/e2e/infra/vagrant/playbook/roles/common/tasks/main.yml
@@ -8,8 +8,6 @@
 
 - import_tasks: containerd.yml
 
-- import_tasks: busybox.yml
-
 - import_tasks: openvswitch.yml
 
 # Kubelet will not start if the system has swap enabled

--- a/test/e2e/networkpolicy_test.go
+++ b/test/e2e/networkpolicy_test.go
@@ -106,7 +106,7 @@ func testNetworkPolicyStats(t *testing.T, data *TestData) {
 	serverName, serverIPs, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "test-server-", "", data.testNamespace, false)
 	defer cleanupFunc()
 
-	clientName, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", "", data.testNamespace, false)
+	clientName, _, cleanupFunc := createAndWaitForPod(t, data, data.createToolboxPodOnNode, "test-client-", "", data.testNamespace, false)
 	defer cleanupFunc()
 
 	// When using the userspace OVS datapath and tunneling,
@@ -114,11 +114,11 @@ func testNetworkPolicyStats(t *testing.T, data *TestData) {
 	// So we need to  "warm-up" the tunnel.
 	if clusterInfo.podV4NetworkCIDR != "" {
 		cmd := []string{"/bin/sh", "-c", fmt.Sprintf("nc -vz -w 4 %s 80", serverIPs.IPv4.String())}
-		data.RunCommandFromPod(data.testNamespace, clientName, busyboxContainerName, cmd)
+		data.RunCommandFromPod(data.testNamespace, clientName, toolboxContainerName, cmd)
 	}
 	if clusterInfo.podV6NetworkCIDR != "" {
 		cmd := []string{"/bin/sh", "-c", fmt.Sprintf("nc -vz -w 4 %s 80", serverIPs.IPv6.String())}
-		data.RunCommandFromPod(data.testNamespace, clientName, busyboxContainerName, cmd)
+		data.RunCommandFromPod(data.testNamespace, clientName, toolboxContainerName, cmd)
 	}
 
 	np1, err := data.createNetworkPolicy("test-networkpolicy-ingress", &networkingv1.NetworkPolicySpec{
@@ -174,11 +174,11 @@ func testNetworkPolicyStats(t *testing.T, data *TestData) {
 		go func() {
 			if clusterInfo.podV4NetworkCIDR != "" {
 				cmd := []string{"/bin/sh", "-c", fmt.Sprintf("nc -vz -w 4 %s 80", serverIPs.IPv4.String())}
-				data.RunCommandFromPod(data.testNamespace, clientName, busyboxContainerName, cmd)
+				data.RunCommandFromPod(data.testNamespace, clientName, toolboxContainerName, cmd)
 			}
 			if clusterInfo.podV6NetworkCIDR != "" {
 				cmd := []string{"/bin/sh", "-c", fmt.Sprintf("nc -vz -w 4 %s 80", serverIPs.IPv6.String())}
-				data.RunCommandFromPod(data.testNamespace, clientName, busyboxContainerName, cmd)
+				data.RunCommandFromPod(data.testNamespace, clientName, toolboxContainerName, cmd)
 			}
 			wg.Done()
 		}()
@@ -257,10 +257,10 @@ func (data *TestData) setupDifferentNamedPorts(t *testing.T) (checkFn func(), cl
 	}, "test-server-", "", data.testNamespace, false)
 	cleanupFuncs = append(cleanupFuncs, cleanupFunc)
 
-	client0Name, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", "", data.testNamespace, false)
+	client0Name, _, cleanupFunc := createAndWaitForPod(t, data, data.createToolboxPodOnNode, "test-client-", "", data.testNamespace, false)
 	cleanupFuncs = append(cleanupFuncs, cleanupFunc)
 
-	client1Name, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", "", data.testNamespace, false)
+	client1Name, _, cleanupFunc := createAndWaitForPod(t, data, data.createToolboxPodOnNode, "test-client-", "", data.testNamespace, false)
 	cleanupFuncs = append(cleanupFuncs, cleanupFunc)
 
 	preCheckFunc := func(server0IP, server1IP string) {
@@ -367,11 +367,11 @@ func testDefaultDenyIngressPolicy(t *testing.T, data *TestData) {
 	defer data.deleteService(service.Namespace, service.Name)
 
 	// client1 is a host network Pod and is on the same node as the server Pod, simulating kubelet probe traffic.
-	client1Name, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-hostnetwork-client-can-connect-", serverNode, data.testNamespace, true)
+	client1Name, _, cleanupFunc := createAndWaitForPod(t, data, data.createToolboxPodOnNode, "test-hostnetwork-client-can-connect-", serverNode, data.testNamespace, true)
 	defer cleanupFunc()
 
 	// client2 is a host network Pod and is on a different node from the server Pod, accessing the server Pod via the NodePort service.
-	client2Name, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-hostnetwork-client-cannot-connect-", controlPlaneNodeName(), data.testNamespace, true)
+	client2Name, _, cleanupFunc := createAndWaitForPod(t, data, data.createToolboxPodOnNode, "test-hostnetwork-client-cannot-connect-", controlPlaneNodeName(), data.testNamespace, true)
 	defer cleanupFunc()
 
 	spec := &networkingv1.NetworkPolicySpec{
@@ -419,7 +419,7 @@ func testDefaultDenyEgressPolicy(t *testing.T, data *TestData) {
 	_, serverIPs, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "test-server-", "", data.testNamespace, false)
 	defer cleanupFunc()
 
-	clientName, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", "", data.testNamespace, false)
+	clientName, _, cleanupFunc := createAndWaitForPod(t, data, data.createToolboxPodOnNode, "test-client-", "", data.testNamespace, false)
 	defer cleanupFunc()
 
 	preCheckFunc := func(serverIP string) {
@@ -475,7 +475,7 @@ func testEgressToServerInCIDRBlock(t *testing.T, data *TestData) {
 	serverBName, serverBIPs, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "test-server-", workerNode, data.testNamespace, false)
 	defer cleanupFunc()
 
-	clientA, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", workerNode, data.testNamespace, false)
+	clientA, _, cleanupFunc := createAndWaitForPod(t, data, data.createToolboxPodOnNode, "test-client-", workerNode, data.testNamespace, false)
 	defer cleanupFunc()
 	var serverCIDR string
 	var serverAIP, serverBIP string
@@ -540,7 +540,7 @@ func testEgressToServerInCIDRBlockWithException(t *testing.T, data *TestData) {
 	serverAName, serverAIPs, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "test-server-", workerNode, data.testNamespace, false)
 	defer cleanupFunc()
 
-	clientA, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", workerNode, data.testNamespace, false)
+	clientA, _, cleanupFunc := createAndWaitForPod(t, data, data.createToolboxPodOnNode, "test-client-", workerNode, data.testNamespace, false)
 	defer cleanupFunc()
 	var serverAAllowCIDR string
 	var serverAExceptList []string
@@ -608,10 +608,10 @@ func testNetworkPolicyResyncAfterRestart(t *testing.T, data *TestData) {
 	server1Name, server1IPs, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "test-server-", workerNode, data.testNamespace, false)
 	defer cleanupFunc()
 
-	client0Name, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", workerNode, data.testNamespace, false)
+	client0Name, _, cleanupFunc := createAndWaitForPod(t, data, data.createToolboxPodOnNode, "test-client-", workerNode, data.testNamespace, false)
 	defer cleanupFunc()
 
-	client1Name, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", workerNode, data.testNamespace, false)
+	client1Name, _, cleanupFunc := createAndWaitForPod(t, data, data.createToolboxPodOnNode, "test-client-", workerNode, data.testNamespace, false)
 	defer cleanupFunc()
 
 	netpol0, err := data.createNetworkPolicy("test-isolate-server0", &networkingv1.NetworkPolicySpec{
@@ -808,10 +808,10 @@ func testIngressPolicyWithoutPortNumber(t *testing.T, data *TestData) {
 	_, serverIPs, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "test-server-", "", data.testNamespace, false)
 	defer cleanupFunc()
 
-	client0Name, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", "", data.testNamespace, false)
+	client0Name, _, cleanupFunc := createAndWaitForPod(t, data, data.createToolboxPodOnNode, "test-client-", "", data.testNamespace, false)
 	defer cleanupFunc()
 
-	client1Name, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", "", data.testNamespace, false)
+	client1Name, _, cleanupFunc := createAndWaitForPod(t, data, data.createToolboxPodOnNode, "test-client-", "", data.testNamespace, false)
 	defer cleanupFunc()
 
 	preCheckFunc := func(serverIP string) {
@@ -951,7 +951,7 @@ func testIngressPolicyWithEndPort(t *testing.T, data *TestData) {
 	serverName, serverIPs, cleanupFunc := createAndWaitForPod(t, data, createAgnhostPodOnNodeWithMultiPort, "test-server-", "", data.testNamespace, false)
 	defer cleanupFunc()
 
-	clientName, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", "", data.testNamespace, false)
+	clientName, _, cleanupFunc := createAndWaitForPod(t, data, data.createToolboxPodOnNode, "test-client-", "", data.testNamespace, false)
 	defer cleanupFunc()
 
 	preCheck := func(serverIP string) {
@@ -1045,7 +1045,7 @@ func testAllowHairpinService(t *testing.T, data *TestData) {
 	}
 	defer data.deleteService(service.Namespace, service.Name)
 
-	clientName, _, cleanupFunc := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, "test-client-", serverNode, data.testNamespace, false)
+	clientName, _, cleanupFunc := createAndWaitForPod(t, data, data.createToolboxPodOnNode, "test-client-", serverNode, data.testNamespace, false)
 	defer cleanupFunc()
 
 	spec := &networkingv1.NetworkPolicySpec{
@@ -1072,7 +1072,7 @@ func testAllowHairpinService(t *testing.T, data *TestData) {
 
 	for _, clusterIP := range service.Spec.ClusterIPs {
 		npCheck(serverName, clusterIP, nginxContainerName, serverPort, false)
-		npCheck(clientName, clusterIP, busyboxContainerName, serverPort, true)
+		npCheck(clientName, clusterIP, toolboxContainerName, serverPort, true)
 	}
 }
 
@@ -1100,7 +1100,7 @@ func createAndWaitForPodWithExactName(t *testing.T, data *TestData, createFunc f
 func createAndWaitForPodWithServiceAccount(t *testing.T, data *TestData, createFunc func(name string, ns string, nodeName string, hostNetwork bool, serviceAccountName string) error, namePrefix string, nodeName string, ns string, hostNetwork bool, serviceAccountName string) (string, *PodIPs, func()) {
 	name := randName(namePrefix)
 	if err := createFunc(name, ns, nodeName, hostNetwork, serviceAccountName); err != nil {
-		t.Fatalf("Error when creating busybox test Pod: %v", err)
+		t.Fatalf("Error when creating toolbox test Pod: %v", err)
 	}
 	cleanupFunc := func() {
 		deletePodWrapper(t, data, data.testNamespace, name)
@@ -1116,7 +1116,7 @@ func createAndWaitForPodWithServiceAccount(t *testing.T, data *TestData, createF
 
 func createAndWaitForPodWithLabels(t *testing.T, data *TestData, createFunc func(name, ns string, portNum int32, labels map[string]string) error, name, ns string, portNum int32, labels map[string]string) (string, *PodIPs, func() error) {
 	if err := createFunc(name, ns, portNum, labels); err != nil {
-		t.Fatalf("Error when creating busybox test Pod: %v", err)
+		t.Fatalf("Error when creating toolbox test Pod: %v", err)
 	}
 	cleanupFunc := func() error {
 		if err := data.DeletePod(ns, name); err != nil {

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -159,16 +159,16 @@ func testProxyLoadBalancerService(t *testing.T, isIPv6 bool) {
 	skipIfProxyDisabled(t, data)
 	skipIfProxyAllDisabled(t, data)
 
-	// Create a busybox Pod on every Node. The busybox Pod is used as a client.
+	// Create a toolbox Pod on every Node. The toolbox Pod is used as a client.
 	nodes := []string{nodeName(0), nodeName(1)}
-	var busyboxes, busyboxIPs []string
+	var toolboxes, toolboxIPs []string
 	for idx, node := range nodes {
-		podName, ips, _ := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, fmt.Sprintf("busybox-%d-", idx), node, data.testNamespace, false)
-		busyboxes = append(busyboxes, podName)
+		podName, ips, _ := createAndWaitForPod(t, data, data.createToolboxPodOnNode, fmt.Sprintf("toolbox-%d-", idx), node, data.testNamespace, false)
+		toolboxes = append(toolboxes, podName)
 		if !isIPv6 {
-			busyboxIPs = append(busyboxIPs, ips.IPv4.String())
+			toolboxIPs = append(toolboxIPs, ips.IPv4.String())
 		} else {
-			busyboxIPs = append(busyboxIPs, ips.IPv6.String())
+			toolboxIPs = append(toolboxIPs, ips.IPv6.String())
 		}
 	}
 
@@ -215,7 +215,7 @@ func testProxyLoadBalancerService(t *testing.T, isIPv6 bool) {
 		createAgnhostPod(t, data, agnhosts[idx], node, false)
 	}
 	t.Run("Non-HostNetwork Endpoints", func(t *testing.T) {
-		loadBalancerTestCases(t, data, clusterUrl, localUrl, healthExpected, nodes, healthUrls, busyboxes, busyboxIPs, agnhosts)
+		loadBalancerTestCases(t, data, clusterUrl, localUrl, healthExpected, nodes, healthUrls, toolboxes, toolboxIPs, agnhosts)
 	})
 
 	// Delete agnhost Pods which are not on host network and create new agnhost Pods which are on host network.
@@ -225,7 +225,7 @@ func testProxyLoadBalancerService(t *testing.T, isIPv6 bool) {
 		createAgnhostPod(t, data, hostAgnhosts[idx], node, true)
 	}
 	t.Run("HostNetwork Endpoints", func(t *testing.T) {
-		loadBalancerTestCases(t, data, clusterUrl, localUrl, healthExpected, nodes, healthUrls, busyboxes, busyboxIPs, nodes)
+		loadBalancerTestCases(t, data, clusterUrl, localUrl, healthExpected, nodes, healthUrls, toolboxes, toolboxIPs, nodes)
 	})
 }
 
@@ -253,7 +253,7 @@ func testLoadBalancerClusterFromNode(t *testing.T, data *TestData, nodes []strin
 
 func testLoadBalancerClusterFromPod(t *testing.T, data *TestData, pods []string, url string) {
 	for _, pod := range pods {
-		require.NoError(t, probeFromPod(data, pod, busyboxContainerName, url), "Service LoadBalancer whose externalTrafficPolicy is Cluster should be able to be connected from Pod")
+		require.NoError(t, probeFromPod(data, pod, toolboxContainerName, url), "Service LoadBalancer whose externalTrafficPolicy is Cluster should be able to be connected from Pod")
 	}
 }
 
@@ -273,7 +273,7 @@ func testLoadBalancerLocalFromNode(t *testing.T, data *TestData, nodes, healthUr
 func testLoadBalancerLocalFromPod(t *testing.T, data *TestData, pods []string, url string) {
 	errMsg := "Service NodePort whose externalTrafficPolicy is Local should be able to be connected from Pod"
 	for _, pod := range pods {
-		require.NoError(t, probeFromPod(data, pod, busyboxContainerName, url), errMsg)
+		require.NoError(t, probeFromPod(data, pod, toolboxContainerName, url), errMsg)
 	}
 }
 
@@ -307,15 +307,15 @@ func testProxyNodePortService(t *testing.T, isIPv6 bool) {
 		ipProtocol = corev1.IPv6Protocol
 	}
 
-	// Create a busybox Pod on every Node. The busybox Pod is used as a client.
-	var busyboxes, busyboxIPs []string
+	// Create a toolbox Pod on every Node. The toolbox Pod is used as a client.
+	var toolboxes, toolboxIPs []string
 	for idx, node := range nodes {
-		podName, ips, _ := createAndWaitForPod(t, data, data.createBusyboxPodOnNode, fmt.Sprintf("busybox-%d-", idx), node, data.testNamespace, false)
-		busyboxes = append(busyboxes, podName)
+		podName, ips, _ := createAndWaitForPod(t, data, data.createToolboxPodOnNode, fmt.Sprintf("toolbox-%d-", idx), node, data.testNamespace, false)
+		toolboxes = append(toolboxes, podName)
 		if !isIPv6 {
-			busyboxIPs = append(busyboxIPs, ips.IPv4.String())
+			toolboxIPs = append(toolboxIPs, ips.IPv4.String())
 		} else {
-			busyboxIPs = append(busyboxIPs, ips.IPv6.String())
+			toolboxIPs = append(toolboxIPs, ips.IPv6.String())
 		}
 	}
 
@@ -347,7 +347,7 @@ func testProxyNodePortService(t *testing.T, isIPv6 bool) {
 		createAgnhostPod(t, data, agnhosts[idx], node, false)
 	}
 	t.Run("Non-HostNetwork Endpoints", func(t *testing.T) {
-		nodePortTestCases(t, data, portCluster, portLocal, nodes, nodeIPs, busyboxes, busyboxIPs, agnhosts, false)
+		nodePortTestCases(t, data, portCluster, portLocal, nodes, nodeIPs, toolboxes, toolboxIPs, agnhosts, false)
 	})
 
 	// Delete agnhost Pods which are not on host network and create new agnhost Pods which are on host network.
@@ -357,7 +357,7 @@ func testProxyNodePortService(t *testing.T, isIPv6 bool) {
 		createAgnhostPod(t, data, hostAgnhosts[idx], node, true)
 	}
 	t.Run("HostNetwork Endpoints", func(t *testing.T) {
-		nodePortTestCases(t, data, portCluster, portLocal, nodes, nodeIPs, busyboxes, busyboxIPs, nodes, true)
+		nodePortTestCases(t, data, portCluster, portLocal, nodes, nodeIPs, toolboxes, toolboxIPs, nodes, true)
 	})
 }
 
@@ -483,7 +483,7 @@ func testNodePortClusterFromNode(t *testing.T, data *TestData, nodes, urls []str
 func testNodePortClusterFromPod(t *testing.T, data *TestData, pods, urls []string) {
 	for _, url := range urls {
 		for _, pod := range pods {
-			require.NoError(t, probeFromPod(data, pod, busyboxContainerName, url), "Service NodePort whose externalTrafficPolicy is Cluster should be able to be connected from Pod")
+			require.NoError(t, probeFromPod(data, pod, toolboxContainerName, url), "Service NodePort whose externalTrafficPolicy is Cluster should be able to be connected from Pod")
 		}
 	}
 }
@@ -511,7 +511,7 @@ func testNodePortLocalFromNode(t *testing.T, data *TestData, nodes, urls []strin
 
 func testNodePortLocalFromPod(t *testing.T, data *TestData, pods, urls []string) {
 	for idx, pod := range pods {
-		require.NoError(t, probeFromPod(data, pod, busyboxContainerName, urls[idx]), "There should be no errors when accessing to Service NodePort whose externalTrafficPolicy is Local from Pod")
+		require.NoError(t, probeFromPod(data, pod, toolboxContainerName, urls[idx]), "There should be no errors when accessing to Service NodePort whose externalTrafficPolicy is Local from Pod")
 	}
 }
 
@@ -621,14 +621,14 @@ func testProxyServiceSessionAffinity(ipFamily *corev1.IPFamily, ingressIPs []str
 	defer data.deleteServiceAndWait(defaultTimeout, nginxLBService, data.testNamespace)
 	require.NoError(t, err)
 
-	busyboxPod := randName("busybox-")
-	require.NoError(t, data.createBusyboxPodOnNode(busyboxPod, data.testNamespace, nodeName, false))
-	defer data.DeletePodAndWait(defaultTimeout, busyboxPod, data.testNamespace)
-	require.NoError(t, data.podWaitForRunning(defaultTimeout, busyboxPod, data.testNamespace))
-	stdout, stderr, err := data.runWgetCommandOnBusyboxWithRetry(busyboxPod, data.testNamespace, svc.Spec.ClusterIP, 5)
+	toolboxPod := randName("toolbox-")
+	require.NoError(t, data.createToolboxPodOnNode(toolboxPod, data.testNamespace, nodeName, false))
+	defer data.DeletePodAndWait(defaultTimeout, toolboxPod, data.testNamespace)
+	require.NoError(t, data.podWaitForRunning(defaultTimeout, toolboxPod, data.testNamespace))
+	stdout, stderr, err := data.runWgetCommandOnToolboxWithRetry(toolboxPod, data.testNamespace, svc.Spec.ClusterIP, 5)
 	require.NoError(t, err, fmt.Sprintf("ipFamily: %v\nstdout: %s\nstderr: %s\n", *ipFamily, stdout, stderr))
 	for _, ingressIP := range ingressIPs {
-		stdout, stderr, err := data.runWgetCommandOnBusyboxWithRetry(busyboxPod, data.testNamespace, ingressIP, 5)
+		stdout, stderr, err := data.runWgetCommandOnToolboxWithRetry(toolboxPod, data.testNamespace, ingressIP, 5)
 		require.NoError(t, err, fmt.Sprintf("ipFamily: %v\nstdout: %s\nstderr: %s\n", *ipFamily, stdout, stderr))
 	}
 

--- a/test/e2e/service_test.go
+++ b/test/e2e/service_test.go
@@ -157,8 +157,8 @@ func (data *TestData) testNodePort(t *testing.T, isWindows bool, clientNamespace
 	// Unlike upstream Kubernetes Conformance, here the client is on a Linux Node (nodeName(0)).
 	// It doesn't need to be the control-plane for e2e test and other Linux workers will work as well. However, in this
 	// e2e framework, nodeName(0)/Control-plane Node is guaranteed to be a Linux one.
-	clientName := "busybox-client"
-	require.NoError(t, data.createBusyboxPodOnNode(clientName, clientNamespace, nodeName(0), false))
+	clientName := "toolbox-client"
+	require.NoError(t, data.createToolboxPodOnNode(clientName, clientNamespace, nodeName(0), false))
 	defer data.DeletePodAndWait(defaultTimeout, clientName, clientNamespace)
 	podIPs, err := data.podWaitForIPs(defaultTimeout, clientName, clientNamespace)
 	require.NoError(t, err)
@@ -168,7 +168,7 @@ func (data *TestData) testNodePort(t *testing.T, isWindows bool, clientNamespace
 	nodePort := int(svc.Spec.Ports[0].NodePort)
 	url := fmt.Sprintf("http://%s:%d", nodeIP, nodePort)
 
-	stdout, stderr, err := data.runWgetCommandOnBusyboxWithRetry(clientName, clientNamespace, url, 5)
+	stdout, stderr, err := data.runWgetCommandOnToolboxWithRetry(clientName, clientNamespace, url, 5)
 	if err != nil {
 		t.Errorf("Error when running 'wget -O - %s' from Pod '%s', stdout: %s, stderr: %s, error: %v",
 			url, clientName, stdout, stderr, err)

--- a/test/e2e/wireguard_test.go
+++ b/test/e2e/wireguard_test.go
@@ -142,7 +142,7 @@ func testServiceConnectivity(t *testing.T, data *TestData) {
 	defer cleanup()
 
 	// Create the a hostNetwork Pod on a Node different from the service's backend Pod, so the service traffic will be transferred across the tunnel.
-	require.NoError(t, NewPodBuilder(clientPodName, data.testNamespace, busyboxImage).OnNode(clientPodNode).WithCommand([]string{"sleep", "3600"}).InHostNetwork().Create(data))
+	require.NoError(t, NewPodBuilder(clientPodName, data.testNamespace, toolboxImage).OnNode(clientPodNode).InHostNetwork().Create(data))
 	defer data.DeletePodAndWait(defaultTimeout, clientPodName, data.testNamespace)
 	require.NoError(t, data.podWaitForRunning(defaultTimeout, clientPodName, data.testNamespace))
 


### PR DESCRIPTION
Cherry pick of #6000 on release-1.15.

#6000: [tests/e2e]: Remove all references to busybox in e2e tests

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.