### PR TITLE
Block on stopCh in Run method of controllerMonitor

### DIFF
--- a/pkg/monitor/controller.go
+++ b/pkg/monitor/controller.go
@@ -152,6 +152,8 @@ func (monitor *controllerMonitor) Run(stopCh <-chan struct{}) {
 			go wait.Until(monitor.externalNodeWorker, time.Second, stopCh)
 		}
 	}
+
+	<-stopCh
 }
 
 func (monitor *controllerMonitor) syncControllerCRD() {


### PR DESCRIPTION
The Run method of controllers usually never returns until the stop channel is closed. The controllerMonitor seems to be the exception, as it returns after "initialization", despite the Run method being invoked in a separate goroutine. This leads to a confusing message in the Antrea Controller logs, informing us that AntreaControllerMonitor is shutting down.