### PR TITLE
Update NodeLatencyMonitor unit tests

### DIFF
--- a/pkg/agent/monitortool/monitor.go
+++ b/pkg/agent/monitortool/monitor.go
@@ -452,6 +452,7 @@ func (m *NodeLatencyMonitor) monitorLoop(stopCh <-chan struct{}) {
 		case <-stopCh:
 			return
 		case latencyConfig := <-m.latencyConfigChanged:
+			klog.InfoS("NodeLatencyMonitor configuration has changed", "enabled", latencyConfig.Enable, "interval", latencyConfig.Interval)
 			// Start or stop the pingAll goroutine based on the latencyConfig
 			if latencyConfig.Enable {
 				// latencyConfig changed


### PR DESCRIPTION
* Add missing crdInformerFactory.Start call for TestNodeAddUpdateDelete to avoid cache sync error logs.
* Add extra logging for TestUpdateMonitorPingInterval, which has been failing infrequently in CI. I cannot figure out the reason for the failures, nor have I been able to reproduce it locally, so adding some logs may help.