### PR TITLE
Fix flaky TestSubscribe test in pkg/util/channel

### DIFF
--- a/pkg/util/channel/channel_test.go
+++ b/pkg/util/channel/channel_test.go
@@ -68,19 +68,14 @@ func TestSubscribe(t *testing.T) {
 		desiredEvents.Insert(e)
 	}
 
-	var errReceiver int
-	var errReceivedEvents sets.Set[string]
-	assert.Eventually(t, func() bool {
+	assert.EventuallyWithT(t, func(t *assert.CollectT) {
 		for i, r := range eventReceivers {
 			receivedEvents := r.received()
-			if !receivedEvents.Equal(desiredEvents) {
-				errReceiver = i
-				errReceivedEvents = receivedEvents
-				return false
+			if !assert.True(t, receivedEvents.Equal(desiredEvents), "Receiver %d failed to receive all events, expected %d events, got %d events", i, len(desiredEvents), len(receivedEvents)) {
+				return
 			}
 		}
-		return true
-	}, 100*time.Millisecond, 10*time.Millisecond, "Receiver %d failed to receive all events, expected %d events, got %d events", errReceiver, len(desiredEvents), len(errReceivedEvents))
+	}, 500*time.Millisecond, 50*time.Millisecond, "Not all receivers received all events")
 }
 
 func TestNotify(t *testing.T) {


### PR DESCRIPTION
I have observed the test failing in Github CI, and I was able to reproduce locally by setting GOMAXPROCS=2.

When using the race detector (-race flag), it usually takes 25ms for the condition function in assert.Eventually to run successfully on my laptop. However, it sometimes spikes to 100+ms, and then the test fails, as the timeout is set to 100ms.

My take is that there could be too much contention between the channel logic and the goroutine performing the checks. The issue only occurs when using the race detector.

To avoid the issue, we use a timeout of 500ms and we set the tick period to 50ms. This is more than sufficient on my machine. If we see the failure in CI again, we can always double these values.

We also fix the error log for the test, as the previous log would never print meaningful values: the log arguments are evaluatd when assert.Eventually is called, and not after the assertion fails.