### PR TITLE
Always require the cluster UUID in the FlowAggregator

### DIFF
--- a/cmd/flow-aggregator/flow-aggregator.go
+++ b/cmd/flow-aggregator/flow-aggregator.go
@@ -59,8 +59,16 @@ func run(configFile string) error {
 	podInformer := informerFactory.Core().V1().Pods()
 	podStore := podstore.NewPodStore(podInformer.Informer())
 
+	klog.InfoS("Retrieving Antrea cluster UUID")
+	clusterUUID, err := aggregator.GetClusterUUID(ctx, k8sClient)
+	if err != nil {
+		return err
+	}
+	klog.InfoS("Retrieved Antrea cluster UUID", "clusterUUID", clusterUUID)
+
 	flowAggregator, err := aggregator.NewFlowAggregator(
 		k8sClient,
+		clusterUUID,
 		podStore,
 		configFile,
 	)

--- a/pkg/flowaggregator/cluster_uuid_test.go
+++ b/pkg/flowaggregator/cluster_uuid_test.go
@@ -1,0 +1,44 @@
+// Copyright 2024 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flowaggregator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"antrea.io/antrea/pkg/clusteridentity"
+)
+
+func TestGetClusterUUID(t *testing.T) {
+	ctx := context.Background()
+	client := fake.NewSimpleClientset()
+	clusterIdentityAllocator := clusteridentity.NewClusterIdentityAllocator(
+		"kube-system",
+		clusteridentity.DefaultClusterIdentityConfigMapName,
+		client,
+	)
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	go clusterIdentityAllocator.Run(stopCh)
+
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	_, err := GetClusterUUID(ctx, client)
+	require.NoError(t, err, "cluster UUID not available")
+}

--- a/pkg/flowaggregator/exporter/clickhouse.go
+++ b/pkg/flowaggregator/exporter/clickhouse.go
@@ -22,9 +22,9 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/google/uuid"
 	ipfixentities "github.com/vmware/go-ipfix/pkg/entities"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 
 	"antrea.io/antrea/pkg/flowaggregator/clickhouseclient"
@@ -57,7 +57,7 @@ func buildClickHouseConfig(opt *options.Options) clickhouseclient.ClickHouseConf
 	}
 }
 
-func NewClickHouseExporter(k8sClient kubernetes.Interface, opt *options.Options) (*ClickHouseExporter, error) {
+func NewClickHouseExporter(clusterUUID uuid.UUID, opt *options.Options) (*ClickHouseExporter, error) {
 	chConfig := buildClickHouseConfig(opt)
 	klog.InfoS("ClickHouse configuration", "database", chConfig.Database, "databaseURL", chConfig.DatabaseURL, "debug", chConfig.Debug,
 		"compress", *chConfig.Compress, "commitInterval", chConfig.CommitInterval, "insecureSkipVerify", chConfig.InsecureSkipVerify, "caCert", chConfig.CACert)
@@ -76,10 +76,6 @@ func NewClickHouseExporter(k8sClient kubernetes.Interface, opt *options.Options)
 		if err != nil {
 			return nil, fmt.Errorf("error when reading custom CA certificate: %v", errMessage)
 		}
-	}
-	clusterUUID, err := getClusterUUID(k8sClient)
-	if err != nil {
-		return nil, err
 	}
 	chExportProcess, err := clickhouseclient.NewClickHouseClient(chConfig, clusterUUID.String())
 	if err != nil {

--- a/pkg/flowaggregator/exporter/s3.go
+++ b/pkg/flowaggregator/exporter/s3.go
@@ -15,8 +15,8 @@
 package exporter
 
 import (
+	"github.com/google/uuid"
 	ipfixentities "github.com/vmware/go-ipfix/pkg/entities"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 
 	"antrea.io/antrea/pkg/flowaggregator/options"
@@ -35,13 +35,9 @@ func buildS3Input(opt *options.Options) s3uploader.S3Input {
 	}
 }
 
-func NewS3Exporter(k8sClient kubernetes.Interface, opt *options.Options) (*S3Exporter, error) {
+func NewS3Exporter(clusterUUID uuid.UUID, opt *options.Options) (*S3Exporter, error) {
 	s3Input := buildS3Input(opt)
 	klog.InfoS("S3Uploader configuration", "bucketName", s3Input.Config.BucketName, "bucketPrefix", s3Input.Config.BucketPrefix, "region", s3Input.Config.Region, "recordFormat", s3Input.Config.RecordFormat, "compress", *s3Input.Config.Compress, "maxRecordsPerFile", s3Input.Config.MaxRecordsPerFile, "uploadInterval", s3Input.UploadInterval)
-	clusterUUID, err := getClusterUUID(k8sClient)
-	if err != nil {
-		return nil, err
-	}
 	s3UploadProcess, err := s3uploader.NewS3UploadProcess(s3Input, clusterUUID.String())
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Before this change, the cluster UUID was strictly required by the S3Exporter and by the ClickHouseExporter, but somewhat optional for the IPFIXExporter (if not available after a certain timeout, a random UUID was generated and used to compute the IPFIX observation domain ID). Furthermore, every exporter by responsible for calling getClusterUUID independently, and that was the only reason for their implementations to require access to the K8s client.

I think it makes more sense to make things more uniform, and require the cluster UUID to be available regardless of which exporters are enabled. We can retrieve the cluster UUID once during FlowAggrgator initialization, then pass it along to all exporters which need it.