### PR TITLE
fix: fix slice init length

### DIFF
--- a/pkg/controller/networkpolicy/store/group.go
+++ b/pkg/controller/networkpolicy/store/group.go
@@ -65,7 +65,7 @@ func NewGroupStore() storage.Interface {
 				return []string{}, nil
 			}
 			if g.SourceReference.Namespace != "" {
-				namespacedCG := make([]string, len(g.ChildGroups))
+				namespacedCG := make([]string, 0, len(g.ChildGroups))
 				for _, childGroup := range g.ChildGroups {
 					namespacedCG = append(namespacedCG, g.SourceReference.Namespace+"/"+childGroup)
 				}


### PR DESCRIPTION
The intention here should be to initialize a slice with a capacity of   `len(g.ChildGroups)` rather than initializing the length of this slice. 

The online demo: https://go.dev/play/p/q1BcVCmvidW