### PR TITLE
Fix build failure caused by different source directory ownership

### DIFF
--- a/build/images/Dockerfile.build.agent.coverage
+++ b/build/images/Dockerfile.build.agent.coverage
@@ -24,6 +24,8 @@ RUN go mod download
 
 COPY . /antrea
 
+RUN chown -R root:root /antrea
+
 RUN make antctl-instr-binary
 
 RUN make antrea-cni antrea-agent-instr-binary

--- a/build/images/Dockerfile.build.agent.ubi
+++ b/build/images/Dockerfile.build.agent.ubi
@@ -25,6 +25,8 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
 
 COPY . /antrea
 
+RUN chown -R root:root /antrea
+
 RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=cache,target=/root/.cache/go-build/ \
     make antctl-linux && mv bin/antctl-linux bin/antctl

--- a/build/images/Dockerfile.build.agent.ubuntu
+++ b/build/images/Dockerfile.build.agent.ubuntu
@@ -25,6 +25,8 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
 
 COPY . /antrea
 
+RUN chown -R root:root /antrea
+
 RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=cache,target=/root/.cache/go-build/ \
     make antctl-linux && mv bin/antctl-linux bin/antctl

--- a/build/images/Dockerfile.build.controller.coverage
+++ b/build/images/Dockerfile.build.controller.coverage
@@ -24,6 +24,8 @@ RUN go mod download
 
 COPY . /antrea
 
+RUN chown -R root:root /antrea
+
 RUN make antctl-instr-binary
 
 RUN make antrea-controller-instr-binary

--- a/build/images/Dockerfile.build.controller.ubi
+++ b/build/images/Dockerfile.build.controller.ubi
@@ -25,6 +25,8 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
 
 COPY . /antrea
 
+RUN chown -R root:root /antrea
+
 RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=cache,target=/root/.cache/go-build/ \
     make antctl-linux && mv bin/antctl-linux bin/antctl

--- a/build/images/Dockerfile.build.controller.ubuntu
+++ b/build/images/Dockerfile.build.controller.ubuntu
@@ -25,6 +25,8 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
 
 COPY . /antrea
 
+RUN chown -R root:root /antrea
+
 RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=cache,target=/root/.cache/go-build/ \
     make antctl-linux && mv bin/antctl-linux bin/antctl

--- a/build/images/Dockerfile.build.windows
+++ b/build/images/Dockerfile.build.windows
@@ -33,6 +33,8 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
 
 COPY . /antrea
 
+RUN chown -R root:root /antrea
+
 RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=cache,target=/root/.cache/go-build/ \
     make windows-bin

--- a/build/images/Dockerfile.simulator.build.ubuntu
+++ b/build/images/Dockerfile.simulator.build.ubuntu
@@ -23,6 +23,8 @@ RUN go mod download
 
 COPY . /antrea
 
+RUN chown -R root:root /antrea
+
 RUN make antrea-agent-simulator
 
 

--- a/build/images/flow-aggregator/Dockerfile
+++ b/build/images/flow-aggregator/Dockerfile
@@ -24,6 +24,8 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
 
 COPY . /antrea
 
+RUN chown -R root:root /antrea
+
 # Build antctl first in order to share an extra layer with other Antrea Docker images.
 RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=cache,target=/root/.cache/go-build/ \

--- a/build/images/flow-aggregator/Dockerfile.coverage
+++ b/build/images/flow-aggregator/Dockerfile.coverage
@@ -23,6 +23,8 @@ RUN go mod download
 
 COPY . /antrea
 
+RUN chown -R root:root /antrea
+
 RUN make antctl-instr-binary
 
 RUN make flow-aggregator-instr-binary

--- a/multicluster/build/images/Dockerfile.build
+++ b/multicluster/build/images/Dockerfile.build
@@ -24,6 +24,8 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
 
 COPY . /antrea
 
+RUN chown -R root:root /antrea
+
 RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=cache,target=/root/.cache/go-build/ \
     cd multicluster && make bin

--- a/multicluster/build/images/Dockerfile.build.coverage
+++ b/multicluster/build/images/Dockerfile.build.coverage
@@ -23,6 +23,8 @@ RUN go mod download
 
 COPY . /antrea
 
+RUN chown -R root:root /antrea
+
 RUN cd multicluster && make antrea-mc-instr-binary
 
 FROM ubuntu:24.04


### PR DESCRIPTION
Fix the error "fatal: detected dubious ownership in repository at '/antrea'" when run docker build commands like 'make build-controller-ubuntu'. 
The root cause is the directory ownership difference. In the newer Docker (e.g. 27.3.1), the COPY directive will keep the source ownership info which might be 'jenkins' or other users. But the default user is root in the golang base image, the user difference will fail the git check.