### PR TITLE
Cleanup readiness and liveness probe configuration

### DIFF
--- a/build/charts/antrea/templates/agent/daemonset.yaml
+++ b/build/charts/antrea/templates/agent/daemonset.yaml
@@ -203,7 +203,6 @@ spec:
               path: /readyz
               port: api
               scheme: HTTPS
-            initialDelaySeconds: 5
             timeoutSeconds: 5
             periodSeconds: 10
             # In large-scale clusters, it may take up to 40~50 seconds for the antrea-agent to reconnect to the antrea
@@ -304,7 +303,6 @@ spec:
                 - /bin/sh
                 - -c
                 - timeout 10 container_liveness_probe ovs
-            initialDelaySeconds: 5
             timeoutSeconds: 10
             periodSeconds: 10
             failureThreshold: 5

--- a/build/charts/antrea/templates/controller/deployment.yaml
+++ b/build/charts/antrea/templates/controller/deployment.yaml
@@ -125,7 +125,6 @@ spec:
               path: /readyz
               port: api
               scheme: HTTPS
-            initialDelaySeconds: 5
             timeoutSeconds: 5
             periodSeconds: 10
             failureThreshold: 5

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -5270,7 +5270,6 @@ spec:
               path: /readyz
               port: api
               scheme: HTTPS
-            initialDelaySeconds: 5
             timeoutSeconds: 5
             periodSeconds: 10
             # In large-scale clusters, it may take up to 40~50 seconds for the antrea-agent to reconnect to the antrea
@@ -5337,7 +5336,6 @@ spec:
                 - /bin/sh
                 - -c
                 - timeout 10 container_liveness_probe ovs
-            initialDelaySeconds: 5
             timeoutSeconds: 10
             periodSeconds: 10
             failureThreshold: 5
@@ -5475,7 +5473,6 @@ spec:
               path: /readyz
               port: api
               scheme: HTTPS
-            initialDelaySeconds: 5
             timeoutSeconds: 5
             periodSeconds: 10
             failureThreshold: 5

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -5271,7 +5271,6 @@ spec:
               path: /readyz
               port: api
               scheme: HTTPS
-            initialDelaySeconds: 5
             timeoutSeconds: 5
             periodSeconds: 10
             # In large-scale clusters, it may take up to 40~50 seconds for the antrea-agent to reconnect to the antrea
@@ -5338,7 +5337,6 @@ spec:
                 - /bin/sh
                 - -c
                 - timeout 10 container_liveness_probe ovs
-            initialDelaySeconds: 5
             timeoutSeconds: 10
             periodSeconds: 10
             failureThreshold: 5
@@ -5476,7 +5474,6 @@ spec:
               path: /readyz
               port: api
               scheme: HTTPS
-            initialDelaySeconds: 5
             timeoutSeconds: 5
             periodSeconds: 10
             failureThreshold: 5

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -5268,7 +5268,6 @@ spec:
               path: /readyz
               port: api
               scheme: HTTPS
-            initialDelaySeconds: 5
             timeoutSeconds: 5
             periodSeconds: 10
             # In large-scale clusters, it may take up to 40~50 seconds for the antrea-agent to reconnect to the antrea
@@ -5335,7 +5334,6 @@ spec:
                 - /bin/sh
                 - -c
                 - timeout 10 container_liveness_probe ovs
-            initialDelaySeconds: 5
             timeoutSeconds: 10
             periodSeconds: 10
             failureThreshold: 5
@@ -5473,7 +5471,6 @@ spec:
               path: /readyz
               port: api
               scheme: HTTPS
-            initialDelaySeconds: 5
             timeoutSeconds: 5
             periodSeconds: 10
             failureThreshold: 5

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -5288,7 +5288,6 @@ spec:
               path: /readyz
               port: api
               scheme: HTTPS
-            initialDelaySeconds: 5
             timeoutSeconds: 5
             periodSeconds: 10
             # In large-scale clusters, it may take up to 40~50 seconds for the antrea-agent to reconnect to the antrea
@@ -5358,7 +5357,6 @@ spec:
                 - /bin/sh
                 - -c
                 - timeout 10 container_liveness_probe ovs
-            initialDelaySeconds: 5
             timeoutSeconds: 10
             periodSeconds: 10
             failureThreshold: 5
@@ -5532,7 +5530,6 @@ spec:
               path: /readyz
               port: api
               scheme: HTTPS
-            initialDelaySeconds: 5
             timeoutSeconds: 5
             periodSeconds: 10
             failureThreshold: 5

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -5268,7 +5268,6 @@ spec:
               path: /readyz
               port: api
               scheme: HTTPS
-            initialDelaySeconds: 5
             timeoutSeconds: 5
             periodSeconds: 10
             # In large-scale clusters, it may take up to 40~50 seconds for the antrea-agent to reconnect to the antrea
@@ -5335,7 +5334,6 @@ spec:
                 - /bin/sh
                 - -c
                 - timeout 10 container_liveness_probe ovs
-            initialDelaySeconds: 5
             timeoutSeconds: 10
             periodSeconds: 10
             failureThreshold: 5
@@ -5473,7 +5471,6 @@ spec:
               path: /readyz
               port: api
               scheme: HTTPS
-            initialDelaySeconds: 5
             timeoutSeconds: 5
             periodSeconds: 10
             failureThreshold: 5

--- a/multicluster/build/yamls/antrea-multicluster-leader-namespaced.yml
+++ b/multicluster/build/yamls/antrea-multicluster-leader-namespaced.yml
@@ -376,7 +376,6 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
-          initialDelaySeconds: 15
           periodSeconds: 20
         name: antrea-mc-controller
         ports:
@@ -387,7 +386,6 @@ spec:
           httpGet:
             path: /readyz
             port: 8080
-          initialDelaySeconds: 5
           periodSeconds: 10
         resources:
           requests:

--- a/multicluster/build/yamls/antrea-multicluster-leader.yml
+++ b/multicluster/build/yamls/antrea-multicluster-leader.yml
@@ -6658,7 +6658,6 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
-          initialDelaySeconds: 15
           periodSeconds: 20
         name: antrea-mc-controller
         ports:
@@ -6669,7 +6668,6 @@ spec:
           httpGet:
             path: /readyz
             port: 8080
-          initialDelaySeconds: 5
           periodSeconds: 10
         resources:
           requests:

--- a/multicluster/build/yamls/antrea-multicluster-member.yml
+++ b/multicluster/build/yamls/antrea-multicluster-member.yml
@@ -1238,7 +1238,6 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
-          initialDelaySeconds: 15
           periodSeconds: 20
         name: antrea-mc-controller
         ports:
@@ -1249,7 +1248,6 @@ spec:
           httpGet:
             path: /readyz
             port: 8080
-          initialDelaySeconds: 5
           periodSeconds: 10
         resources:
           requests:

--- a/multicluster/config/manager/manager.yaml
+++ b/multicluster/config/manager/manager.yaml
@@ -34,13 +34,11 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
-          initialDelaySeconds: 15
           periodSeconds: 20
         readinessProbe:
           httpGet:
             path: /readyz
             port: 8080
-          initialDelaySeconds: 5
           periodSeconds: 10
         resources:
           requests:


### PR DESCRIPTION
According to K8s documentation https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes, the `initialDelaySeconds` will be ignored if value of `periodSeconds` is greater. Removing the ignored fields in Antrea probe configurations to avoid confusion.