### PR TITLE
Set VERSION env var in workflow when building Antrea images for tag

### DIFF
--- a/.github/workflows/build_tag.yml
+++ b/.github/workflows/build_tag.yml
@@ -48,6 +48,7 @@ jobs:
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        VERSION: ${{ needs.get-version.outputs.version }}
       run: |
         ./hack/build-antrea-linux-all.sh --platform ${{ matrix.platform }} --pull
         echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin


### PR DESCRIPTION
If VERSION is not set, make will not use the correct tag, and the job will fail.