### PR TITLE
Add missing job dependency in build_tag.yml workflow

### DIFF
--- a/.github/workflows/build_tag.yml
+++ b/.github/workflows/build_tag.yml
@@ -58,7 +58,7 @@ jobs:
         docker push antrea/antrea-controller-ubuntu-${{ matrix.suffix }}:"${DOCKER_TAG}"
 
   push-manifest:
-    needs: build
+    needs: [get-version, build]
     runs-on: ubuntu-latest
     env:
       DOCKER_TAG: ${{ needs.get-version.outputs.version }}


### PR DESCRIPTION
Without the get-version dependency, the DOCKER_TAG var  will be empty.