### PR TITLE
[Dependabot] Update ginkgo/v2 and gomega as a group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,10 @@ updates:
       prometheus:
         patterns:
         - "github.com/prometheus/*"
+      ginkgo:
+        patterns:
+        - "github.com/onsi/ginkgo/v2"
+        - "github.com/onsi/gomega"
     ignore:
     - dependency-name: "k8s.io/*"
     - dependency-name: "sigs.k8s.io/*"


### PR DESCRIPTION
Their releases seem to be synchronized, and ginkgo depends on gomega. It makes sense to update them together.