### PR TITLE
Replace domain used for Pod internet connectivity test

### DIFF
--- a/pkg/antctl/raw/check/installation/test_podtointernet.go
+++ b/pkg/antctl/raw/check/installation/test_podtointernet.go
@@ -28,11 +28,11 @@ func init() {
 func (t *PodToInternetConnectivityTest) Run(ctx context.Context, testContext *testContext) error {
 	for _, clientPod := range testContext.clientPods {
 		srcPod := testContext.namespace + "/" + clientPod.Name
-		testContext.Log("Validating connectivity from Pod %s to the world (google.com)...", srcPod)
-		if err := testContext.tcpProbe(ctx, clientPod.Name, "", "google.com", 80); err != nil {
-			return fmt.Errorf("Pod %s was not able to connect to google.com: %w", srcPod, err)
+		testContext.Log("Validating connectivity from Pod %s to the world (api.github.com)...", srcPod)
+		if err := testContext.tcpProbe(ctx, clientPod.Name, "", "api.github.com", 80); err != nil {
+			return fmt.Errorf("Pod %s was not able to connect to api.github.com: %w", srcPod, err)
 		}
-		testContext.Log("Pod %s was able to connect to google.com", srcPod)
+		testContext.Log("Pod %s was able to connect to api.github.com", srcPod)
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes #6432
Use api.github.com as suggested to be more stable in the issue above