### PR TITLE
Improve error handling and resource cleanup for PacketCapture

### DIFF
--- a/pkg/agent/packetcapture/capture/pcap_unsupported.go
+++ b/pkg/agent/packetcapture/capture/pcap_unsupported.go
@@ -1,3 +1,6 @@
+//go:build !linux
+// +build !linux
+
 // Copyright 2024 Antrea Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,9 +31,9 @@ type pcapCapture struct {
 }
 
 func NewPcapCapture() (*pcapCapture, error) {
-	return nil, errors.New("PacketCapture is not implemented on Windows")
+	return nil, errors.New("PacketCapture is not implemented")
 }
 
 func (p *pcapCapture) Capture(ctx context.Context, device string, srcIP, dstIP net.IP, packet *crdv1alpha1.Packet) (chan gopacket.Packet, error) {
-	return nil, errors.New("PacketCapture is not implemented on Windows")
+	return nil, errors.New("PacketCapture is not implemented")
 }

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -1725,14 +1725,7 @@ func (data *TestData) podWaitForIPs(timeout time.Duration, name, namespace strin
 	if pod.Status.PodIP == "" {
 		return nil, fmt.Errorf("Pod is running but has no assigned IP, which should never happen")
 	}
-	podIPStrings := sets.New[string](pod.Status.PodIP)
-	for _, podIP := range pod.Status.PodIPs {
-		ipStr := strings.TrimSpace(podIP.IP)
-		if ipStr != "" {
-			podIPStrings.Insert(ipStr)
-		}
-	}
-	ips, err := parsePodIPs(podIPStrings)
+	ips, err := parsePodIPs(pod)
 	if err != nil {
 		return nil, err
 	}
@@ -1748,7 +1741,14 @@ func (data *TestData) podWaitForIPs(timeout time.Duration, name, namespace strin
 	return ips, nil
 }
 
-func parsePodIPs(podIPStrings sets.Set[string]) (*PodIPs, error) {
+func parsePodIPs(pod *corev1.Pod) (*PodIPs, error) {
+	podIPStrings := sets.New[string](pod.Status.PodIP)
+	for _, podIP := range pod.Status.PodIPs {
+		ipStr := strings.TrimSpace(podIP.IP)
+		if ipStr != "" {
+			podIPStrings.Insert(ipStr)
+		}
+	}
 	ips := new(PodIPs)
 	for idx := range sets.List(podIPStrings) {
 		ipStr := sets.List(podIPStrings)[idx]

--- a/test/e2e/nodeportlocal_test.go
+++ b/test/e2e/nodeportlocal_test.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	npltesting "antrea.io/antrea/pkg/agent/nodeportlocal/testing"
@@ -115,15 +114,7 @@ func getNPLAnnotations(t *testing.T, data *TestData, r *require.Assertions, test
 				return false, nil
 			}
 
-			podIPStrings := sets.New[string](pod.Status.PodIP)
-			for _, podIP := range pod.Status.PodIPs {
-				ipStr := strings.TrimSpace(podIP.IP)
-				if ipStr != "" {
-					podIPStrings.Insert(ipStr)
-				}
-			}
-
-			testPodIP, err = parsePodIPs(podIPStrings)
+			testPodIP, err = parsePodIPs(pod)
 			if err != nil || testPodIP.IPv4 == nil {
 				return false, nil
 			}


### PR DESCRIPTION
The patch fixes the following issues:

1. The local pcap file was not closed on error. The patch ensures the file is closed regardless of success or failure.
2. The pcap file was not updated to `status.filePath` and was not uploaded to file server if not all packets have been captured. The patch ensures it's updated to status and uploaded as long as any packet is captured.
3. The Complete condition was not set correctly in one case. The patch uses two errors to track capturing error and uploading error separately.
4. The unit tests could report false negative as they only check that unexpected conditions don't exist, while they should check expected conditions exist.
5. Change the local pcap path's permission to 700.
6. Avoid panic when handling delete events containing DeletedFinalStateUnknown objects.
7. Reduce the min and max retry intervals to reduce the possibility of timeout.
8. Make a deepcopy before updating object got from lister, otherwise data race may happen and index may be messed up.
9. Add a readiness probe to the sftp server used in e2e test to avoid test flake.

It also makes some style improvements and simplifies a few code.

Follows up #6756