### PR TITLE
Fix PacketCapture pcapng file issue on macOS

### DIFF
--- a/pkg/agent/packetcapture/capture/pcap_unsupported.go
+++ b/pkg/agent/packetcapture/capture/pcap_unsupported.go
@@ -34,6 +34,6 @@ func NewPcapCapture() (*pcapCapture, error) {
 	return nil, errors.New("PacketCapture is not implemented")
 }
 
-func (p *pcapCapture) Capture(ctx context.Context, device string, srcIP, dstIP net.IP, packet *crdv1alpha1.Packet) (chan gopacket.Packet, error) {
+func (p *pcapCapture) Capture(ctx context.Context, device string, snapLen int, srcIP, dstIP net.IP, packet *crdv1alpha1.Packet) (chan gopacket.Packet, error) {
 	return nil, errors.New("PacketCapture is not implemented")
 }

--- a/pkg/agent/packetcapture/capture_interface.go
+++ b/pkg/agent/packetcapture/capture_interface.go
@@ -24,5 +24,5 @@ import (
 )
 
 type PacketCapturer interface {
-	Capture(ctx context.Context, device string, srcIP, dstIP net.IP, packet *crdv1alpha1.Packet) (chan gopacket.Packet, error)
+	Capture(ctx context.Context, device string, snapLen int, srcIP, dstIP net.IP, packet *crdv1alpha1.Packet) (chan gopacket.Packet, error)
 }

--- a/pkg/agent/packetcapture/packetcapture_controller_test.go
+++ b/pkg/agent/packetcapture/packetcapture_controller_test.go
@@ -186,7 +186,7 @@ func craftTestPacket() gopacket.Packet {
 type testCapture struct {
 }
 
-func (p *testCapture) Capture(ctx context.Context, device string, srcIP, dstIP net.IP, packet *crdv1alpha1.Packet) (chan gopacket.Packet, error) {
+func (p *testCapture) Capture(ctx context.Context, device string, snapLen int, srcIP, dstIP net.IP, packet *crdv1alpha1.Packet) (chan gopacket.Packet, error) {
 	ch := make(chan gopacket.Packet, testCaptureNum)
 	for i := 0; i < 15; i++ {
 		ch <- craftTestPacket()


### PR DESCRIPTION
By default, gopacket will write snap length=0 in the pcapng file header, means unlimited snaplen. tcpdump on osx(libpcap version 1.10.1) cannot recognize this and will report error. This patch will set a default value(524288) for it. This patch also add packets file verification in e2e tests.

origin error message:

```
tcpdump: pcap_loop: invalid packet capture length 74, bigger than snaplen of 524288
```

pcapng format ref: https://pcapng.com/