### PR TITLE
Fix codecov-action usage after upgrading to v5

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -50,7 +50,7 @@ jobs:
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: .coverage/coverage-unit.txt
+        files: .coverage/coverage-unit.txt
         disable_search: true
         flags: unit-tests
         name: codecov-unit-test
@@ -76,7 +76,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: .coverage/coverage-unit.txt
+          files: .coverage/coverage-unit.txt
           disable_search: true
           flags: unit-tests
           name: codecov-unit-test

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -118,7 +118,7 @@ jobs:
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: '*.cov.out*'
+        files: '*.cov.out*'
         disable_search: true
         flags: kind-e2e-tests
         name: codecov-test-e2e-encap
@@ -188,7 +188,7 @@ jobs:
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: '*.cov.out*'
+        files: '*.cov.out*'
         disable_search: true
         flags: kind-e2e-tests
         name: codecov-test-e2e-encap-non-default
@@ -260,7 +260,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: '*.cov.out*'
+          files: '*.cov.out*'
           disable_search: true
           flags: kind-e2e-tests
           name: codecov-test-e2e-encap-all-features-enabled
@@ -323,7 +323,7 @@ jobs:
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: '*.cov.out*'
+        files: '*.cov.out*'
         disable_search: true
         flags: kind-e2e-tests
         name: codecov-test-e2e-noencap
@@ -386,7 +386,7 @@ jobs:
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: '*.cov.out*'
+        files: '*.cov.out*'
         disable_search: true
         flags: kind-e2e-tests
         name: codecov-test-e2e-hybrid
@@ -461,7 +461,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: '*.cov.out*'
+          files: '*.cov.out*'
           disable_search: true
           flags: kind-e2e-tests
           name: codecov-test-e2e-fa


### PR DESCRIPTION
The "file" input has been deprecated (and is now gone) in favor of "files".