### PR TITLE
Fix packetcapture bpf filter issue (#6815)

### DIFF
--- a/pkg/agent/packetcapture/capture/bpf.go
+++ b/pkg/agent/packetcapture/capture/bpf.go
@@ -72,6 +72,12 @@ func compareProtocol(protocol uint32, skipTrue, skipFalse uint8) bpf.Instruction
 	return bpf.JumpIf{Cond: bpf.JumpEqual, Val: protocol, SkipTrue: skipTrue, SkipFalse: skipFalse}
 }
 
+// zeroFilter is a filter that will drop all packets.
+// see: https://github.com/antrea-io/antrea/issues/6815 for the user case.
+func zeroFilter() []bpf.Instruction {
+	return []bpf.Instruction{returnDrop}
+}
+
 // compilePacketFilter compiles the CRD spec to bpf instructions. For now, we only focus on
 // ipv4 traffic. Compared to the raw BPF filter supported by libpcap, we only need to support
 // limited use cases, so an expression parser is not needed.


### PR DESCRIPTION
In PacketCapture, packets which don’t match the target BPF can be received after the socket is created and before the bpf filter is applied.This patch use a zero bpf filter(match no packet), then empty out any packets that arrived before the “zero-BPF” filter was applied.At this point the socket is definitely empty and it can’t fill up with junk because the zero-BPF is in place. Then we replace the zero-BPF with the real BPF we want.