### PR TITLE
Push Antrea Ubuntu-based images to ghcr.io

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-    - name: Build and push Antrea Docker image to registries
+    - name: Build and push Antrea Docker images to registries
       if: ${{ needs.check-env.outputs.push_needed == 'true' }}
       run: |
         ./hack/build-antrea-linux-all.sh --platform ${{ matrix.platform }} --pull --push-base-images
@@ -182,7 +182,7 @@ jobs:
       if: ${{ needs.check-env.outputs.push_needed == 'false' }}
       run: |
         ./hack/build-antrea-linux-all.sh --pull --distro ubi
-    - name: Build and push Antrea UBI9 Docker image to registry
+    - name: Build and push Antrea UBI9 Docker images to registry
       if: ${{ needs.check-env.outputs.push_needed == 'true' }}
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,18 +71,37 @@ jobs:
       if: ${{ needs.check-env.outputs.push_needed == 'false' }}
       run: |
         ./hack/build-antrea-linux-all.sh --platform ${{ matrix.platform }} --pull
-    - name: Build and push Antrea Docker image to registry
+    - name: Login to Docker Hub
       if: ${{ needs.check-env.outputs.push_needed == 'true' }}
-      env:
-        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+    - name: Login to Github Container Registry
+      if: ${{ needs.check-env.outputs.push_needed == 'true' }}
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build and push Antrea Docker image to registries
+      if: ${{ needs.check-env.outputs.push_needed == 'true' }}
       run: |
-        echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         ./hack/build-antrea-linux-all.sh --platform ${{ matrix.platform }} --pull --push-base-images
-        docker tag antrea/antrea-controller-ubuntu:"${DOCKER_TAG}" antrea/antrea-controller-ubuntu-${{ matrix.suffix }}:"${DOCKER_TAG}"
-        docker tag antrea/antrea-agent-ubuntu:"${DOCKER_TAG}" antrea/antrea-agent-ubuntu-${{ matrix.suffix }}:"${DOCKER_TAG}"
-        docker push antrea/antrea-controller-ubuntu-${{ matrix.suffix }}:"${DOCKER_TAG}"
-        docker push antrea/antrea-agent-ubuntu-${{ matrix.suffix }}:"${DOCKER_TAG}"
+
+        targets=(
+          "docker.io antrea"
+          "ghcr.io antrea-io"
+        )
+        for target in "${targets[@]}"; do
+          t=($target)
+          registry="${t[0]}"
+          namespace="${t[1]}"
+          docker tag antrea/antrea-controller-ubuntu:"${DOCKER_TAG}" ${registry}/${namespace}/antrea-controller-ubuntu-${{ matrix.suffix }}:"${DOCKER_TAG}"
+          docker tag antrea/antrea-agent-ubuntu:"${DOCKER_TAG}" ${registry}/${namespace}/antrea-agent-ubuntu-${{ matrix.suffix }}:"${DOCKER_TAG}"
+          docker push ${registry}/${namespace}/antrea-controller-ubuntu-${{ matrix.suffix }}:"${DOCKER_TAG}"
+          docker push ${registry}/${namespace}/antrea-agent-ubuntu-${{ matrix.suffix }}:"${DOCKER_TAG}"
+        done
     # Same repository workflow dispatch to run conformance tests
     - name: Run conformance tests
       if: ${{ needs.check-env.outputs.push_needed == 'true' }}
@@ -94,6 +113,13 @@ jobs:
   push-manifest:
     needs: [check-env, build]
     if: ${{ needs.check-env.outputs.push_needed == 'true' }}
+    strategy:
+      matrix:
+        include:
+        - registry: docker.io
+          namespace: antrea
+        - registry: ghcr.io
+          namespace: antrea-io
     runs-on: ubuntu-latest
     env:
       DOCKER_TAG: latest
@@ -102,26 +128,33 @@ jobs:
       uses: docker/setup-buildx-action@v3
       with:
         driver: ${{ needs.check-env.outputs.docker_driver }}
-    - name: Docker login
-      env:
-        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-      run: |
-        echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+    - name: Login to Docker Hub
+      if: ${{ needs.check-env.outputs.push_needed == 'true' && matrix.registry == 'docker.io' }}
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+    - name: Login to Github Container Registry
+      if: ${{ needs.check-env.outputs.push_needed == 'true' && matrix.registry == 'ghcr.io' }}
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     - name: Create and push manifest for controller image
       run: |
-        docker manifest create antrea/antrea-controller-ubuntu:"${DOCKER_TAG}" \
-          antrea/antrea-controller-ubuntu-arm64:"${DOCKER_TAG}" \
-          antrea/antrea-controller-ubuntu-arm:"${DOCKER_TAG}" \
-          antrea/antrea-controller-ubuntu-amd64:"${DOCKER_TAG}"
-        docker manifest push --purge antrea/antrea-controller-ubuntu:"${DOCKER_TAG}"
+        docker manifest create ${{ matrix.registry }}/${{ matrix.namespace }}/antrea-controller-ubuntu:"${DOCKER_TAG}" \
+          ${{ matrix.registry }}/${{ matrix.namespace }}/antrea-controller-ubuntu-arm64:"${DOCKER_TAG}" \
+          ${{ matrix.registry }}/${{ matrix.namespace }}/antrea-controller-ubuntu-arm:"${DOCKER_TAG}" \
+          ${{ matrix.registry }}/${{ matrix.namespace }}/antrea-controller-ubuntu-amd64:"${DOCKER_TAG}"
+        docker manifest push --purge ${{ matrix.registry }}/${{ matrix.namespace }}/antrea-controller-ubuntu:"${DOCKER_TAG}"
     - name: Create and push manifest for agent image
       run: |
-        docker manifest create antrea/antrea-agent-ubuntu:"${DOCKER_TAG}" \
-          antrea/antrea-agent-ubuntu-arm64:"${DOCKER_TAG}" \
-          antrea/antrea-agent-ubuntu-arm:"${DOCKER_TAG}" \
-          antrea/antrea-agent-ubuntu-amd64:"${DOCKER_TAG}"
-        docker manifest push --purge antrea/antrea-agent-ubuntu:"${DOCKER_TAG}"
+        docker manifest create ${{ matrix.registry }}/${{ matrix.namespace }}/antrea-agent-ubuntu:"${DOCKER_TAG}" \
+          ${{ matrix.registry }}/${{ matrix.namespace }}/antrea-agent-ubuntu-arm64:"${DOCKER_TAG}" \
+          ${{ matrix.registry }}/${{ matrix.namespace }}/antrea-agent-ubuntu-arm:"${DOCKER_TAG}" \
+          ${{ matrix.registry }}/${{ matrix.namespace }}/antrea-agent-ubuntu-amd64:"${DOCKER_TAG}"
+        docker manifest push --purge ${{ matrix.registry }}/${{ matrix.namespace }}/antrea-agent-ubuntu:"${DOCKER_TAG}"
 
   build-ubi:
     needs: check-env

--- a/.github/workflows/build_tag.yml
+++ b/.github/workflows/build_tag.yml
@@ -44,7 +44,7 @@ jobs:
       uses: docker/setup-buildx-action@v3
       with:
         driver: docker
-    - name: Build Antrea Ubuntu Docker image
+    - name: Build Antrea Ubuntu Docker images
       env:
         VERSION: ${{ needs.get-version.outputs.version }}
       run: |
@@ -62,7 +62,7 @@ jobs:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-    - name: Push Antrea Ubuntu Docker image to registries
+    - name: Push Antrea Ubuntu Docker images to registries
       run: |
         targets=(
           "docker.io antrea"
@@ -106,7 +106,7 @@ jobs:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
     - name: Login to Github Container Registry
-      if: ${{ needs.check-env.outputs.push_needed == 'true' && matrix.registry == "ghcr.io" }}
+      if: ${{ needs.check-env.outputs.push_needed == 'true' && matrix.registry == 'ghcr.io' }}
       uses: docker/login-action@v3
       with:
         registry: ghcr.io
@@ -136,7 +136,7 @@ jobs:
           show-progress: false
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Build and push Antrea UBI9 amd64 Docker image to registry
+      - name: Build and push Antrea UBI9 amd64 Docker images to registry
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/build_tag.yml
+++ b/.github/workflows/build_tag.yml
@@ -44,53 +44,88 @@ jobs:
       uses: docker/setup-buildx-action@v3
       with:
         driver: docker
-    - name: Build and push Antrea Ubuntu Docker image to registry
+    - name: Build Antrea Ubuntu Docker image
       env:
-        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         VERSION: ${{ needs.get-version.outputs.version }}
       run: |
         ./hack/build-antrea-linux-all.sh --platform ${{ matrix.platform }} --pull
-        echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-        docker tag antrea/antrea-agent-ubuntu:"${DOCKER_TAG}" antrea/antrea-agent-ubuntu-${{ matrix.suffix }}:"${DOCKER_TAG}"
-        docker tag antrea/antrea-controller-ubuntu:"${DOCKER_TAG}" antrea/antrea-controller-ubuntu-${{ matrix.suffix }}:"${DOCKER_TAG}"
-        docker push antrea/antrea-agent-ubuntu-${{ matrix.suffix }}:"${DOCKER_TAG}"
-        docker push antrea/antrea-controller-ubuntu-${{ matrix.suffix }}:"${DOCKER_TAG}"
-
-  push-manifest:
-    needs: [get-version, build]
-    runs-on: ubuntu-latest
-    env:
-      DOCKER_TAG: ${{ needs.get-version.outputs.version }}
-    steps:
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-    - name: Docker login
-      env:
-        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+    - name: Login to Docker Hub
+      if: ${{ needs.check-env.outputs.push_needed == 'true' }}
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+    - name: Login to Github Container Registry
+      if: ${{ needs.check-env.outputs.push_needed == 'true' }}
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Push Antrea Ubuntu Docker image to registries
       run: |
-        echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-    - name: Create and push manifest for controller image
-      run: |
-        docker manifest create antrea/antrea-controller-ubuntu:"${DOCKER_TAG}" \
-          antrea/antrea-controller-ubuntu-arm64:"${DOCKER_TAG}" \
-          antrea/antrea-controller-ubuntu-arm:"${DOCKER_TAG}" \
-          antrea/antrea-controller-ubuntu-amd64:"${DOCKER_TAG}"
-        docker manifest push --purge antrea/antrea-controller-ubuntu:"${DOCKER_TAG}"
-    - name: Create and push manifest for agent image
-      run: |
-        docker manifest create antrea/antrea-agent-ubuntu:"${DOCKER_TAG}" \
-          antrea/antrea-agent-ubuntu-arm64:"${DOCKER_TAG}" \
-          antrea/antrea-agent-ubuntu-arm:"${DOCKER_TAG}" \
-          antrea/antrea-agent-ubuntu-amd64:"${DOCKER_TAG}"
-        docker manifest push --purge antrea/antrea-agent-ubuntu:"${DOCKER_TAG}"
+        targets=(
+          "docker.io antrea"
+          "ghcr.io antrea-io"
+        )
+        for target in "${targets[@]}"; do
+          t=($target)
+          registry="${t[0]}"
+          namespace="${t[1]}"
+          docker tag antrea/antrea-agent-ubuntu:"${DOCKER_TAG}" ${registry}/${namespace}/antrea-agent-ubuntu-${{ matrix.suffix }}:"${DOCKER_TAG}"
+          docker tag antrea/antrea-controller-ubuntu:"${DOCKER_TAG}" ${registry}/${namespace}/antrea-controller-ubuntu-${{ matrix.suffix }}:"${DOCKER_TAG}"
+          docker push ${registry}/${namespace}/antrea-agent-ubuntu-${{ matrix.suffix }}:"${DOCKER_TAG}"
+          docker push ${registry}/${namespace}/antrea-controller-ubuntu-${{ matrix.suffix }}:"${DOCKER_TAG}"
+        done
     # Same repository workflow dispatch to run conformance tests
     - name: Run conformance tests
       uses: benc-uk/workflow-dispatch@v1
       with:
         workflow: .github/workflows/conformance.yml
         inputs: ${{ format('{{ "antrea-version":"{0}", "antrea-image-distro":"ubuntu", "test-suite":"conformance", "runner":"{1}", "antrea-image-platform":"{2}", "always-upload-logs":true }}', github.ref, matrix.runner, matrix.platform) }}
+
+  push-manifest:
+    needs: [get-version, build]
+    strategy:
+      matrix:
+        include:
+        - registry: docker.io
+          namespace: antrea
+        - registry: ghcr.io
+          namespace: antrea-io
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_TAG: ${{ needs.get-version.outputs.version }}
+    steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Login to Docker Hub
+      if: ${{ needs.check-env.outputs.push_needed == 'true' && matrix.registry == 'docker.io' }}
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+    - name: Login to Github Container Registry
+      if: ${{ needs.check-env.outputs.push_needed == 'true' && matrix.registry == "ghcr.io" }}
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Create and push manifest for controller image
+      run: |
+        docker manifest create ${{ matrix.registry }}/${{ matrix.namespace }}/antrea-controller-ubuntu:"${DOCKER_TAG}" \
+          ${{ matrix.registry }}/${{ matrix.namespace }}/antrea-controller-ubuntu-arm64:"${DOCKER_TAG}" \
+          ${{ matrix.registry }}/${{ matrix.namespace }}/antrea-controller-ubuntu-arm:"${DOCKER_TAG}" \
+          ${{ matrix.registry }}/${{ matrix.namespace }}/antrea-controller-ubuntu-amd64:"${DOCKER_TAG}"
+        docker manifest push --purge ${{ matrix.registry }}/${{ matrix.namespace }}/antrea-controller-ubuntu:"${DOCKER_TAG}"
+    - name: Create and push manifest for agent image
+      run: |
+        docker manifest create ${{ matrix.registry }}/${{ matrix.namespace }}/antrea-agent-ubuntu:"${DOCKER_TAG}" \
+          ${{ matrix.registry }}/${{ matrix.namespace }}/antrea-agent-ubuntu-arm64:"${DOCKER_TAG}" \
+          ${{ matrix.registry }}/${{ matrix.namespace }}/antrea-agent-ubuntu-arm:"${DOCKER_TAG}" \
+          ${{ matrix.registry }}/${{ matrix.namespace }}/antrea-agent-ubuntu-amd64:"${DOCKER_TAG}"
+        docker manifest push --purge ${{ matrix.registry }}/${{ matrix.namespace }}/antrea-agent-ubuntu:"${DOCKER_TAG}"
 
   build-ubi:
     runs-on: [ubuntu-latest]


### PR DESCRIPTION
The Github Container Registry (ghcr.io) is introduced as an alternative to Docker Hub for users. There is no change to how images are pushed to Docker Hub, but antrea/antrea-agent-ubuntu and
antrea/antrea-controller-ubuntu are now also available in ghcr.io, as antrea-io/antrea-agent-ubuntu and antrea-io/antrea-controller-ubuntu respectively.

We do not retroactively push previously-released images to ghcr.io. Antrea v2.3 will be the first release also available in ghcr.io.

In the future, we may also push UBI-based images to ghcr.io.

Fixes #6454