### PR TITLE
Fix docs about SecondaryNetwork feature

### DIFF
--- a/build/charts/antrea/conf/antrea-agent.conf
+++ b/build/charts/antrea/conf/antrea-agent.conf
@@ -60,8 +60,9 @@ featureGates:
 {{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "Multicluster" "default" false) }}
 
 # Enable support for provisioning secondary network interfaces for Pods (using
-# Pod annotations). At the moment, Antrea can only create secondary network
-# interfaces using SR-IOV VFs on baremetal Nodes.
+# Pod annotations). At the moment, Antrea can create secondary network
+# interfaces either using SR-IOV VFs on bare-metal Nodes or veth interfaces
+# bridged to the underlay network, with or without VLAN tagging.
 {{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "SecondaryNetwork" "default" false) }}
 
 # Enable managing external IPs of Services of LoadBalancer type.
@@ -242,7 +243,6 @@ apiPort: {{ .Values.agent.apiPort }}
 
 # Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener.
 enablePrometheusMetrics: {{ .Values.agent.enablePrometheusMetrics }}
-
 
 flowExporter:
   {{- with .Values.flowExporter }}
@@ -458,13 +458,17 @@ auditLogging:
   compress: {{ .compress }}
 {{- end }}
 
-{{- if .Values.featureGates.SecondaryNetwork }}
-
+# SecondaryNetwork related configurations.
 secondaryNetwork:
 {{- with .Values.secondaryNetwork }}
-  # Configuration of OVS bridges for secondary network.
+  # Configuration of OVS bridges for secondary network. At the moment, at
+  # most one OVS bridge can be specified. If the specified bridge does not exist
+  # on the Node, antrea-agent will create it based on the configuration.
+  # The following configuration specifies an OVS bridge with name "br1" and a
+  # physical interface "eth1":
+  # [{bridgeName: "br1", physicalInterfaces: ["eth1"]}]
   ovsBridges:
-  {{- toYaml .ovsBridges | trim | nindent 4 }}
-{{- end }}
-
+  {{- with .ovsBridges }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -4003,8 +4003,9 @@ data:
     #  Multicluster: false
 
     # Enable support for provisioning secondary network interfaces for Pods (using
-    # Pod annotations). At the moment, Antrea can only create secondary network
-    # interfaces using SR-IOV VFs on baremetal Nodes.
+    # Pod annotations). At the moment, Antrea can create secondary network
+    # interfaces either using SR-IOV VFs on bare-metal Nodes or veth interfaces
+    # bridged to the underlay network, with or without VLAN tagging.
     #  SecondaryNetwork: false
 
     # Enable managing external IPs of Services of LoadBalancer type.
@@ -4174,7 +4175,6 @@ data:
 
     # Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener.
     enablePrometheusMetrics: true
-
 
     flowExporter:
       # Enable FlowExporter, a feature used to export polled conntrack connections as
@@ -4363,6 +4363,16 @@ data:
       maxAge: 28
       # Compress enables gzip compression on rotated files.
       compress: true
+
+    # SecondaryNetwork related configurations.
+    secondaryNetwork:
+      # Configuration of OVS bridges for secondary network. At the moment, at
+      # most one OVS bridge can be specified. If the specified bridge does not exist
+      # on the Node, antrea-agent will create it based on the configuration.
+      # The following configuration specifies an OVS bridge with name "br1" and a
+      # physical interface "eth1":
+      # [{bridgeName: "br1", physicalInterfaces: ["eth1"]}]
+      ovsBridges:
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -5384,7 +5394,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: c775d4a79675716893fc1b7b3149fa6fe24d06b56c8d76bbaeea4e8b4013418c
+        checksum/config: 5dd823245aab41ce7ca74d05693aa96e1537615f6966b6b78879cde5d3a0b215
       labels:
         app: antrea
         component: antrea-agent
@@ -5622,7 +5632,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: c775d4a79675716893fc1b7b3149fa6fe24d06b56c8d76bbaeea4e8b4013418c
+        checksum/config: 5dd823245aab41ce7ca74d05693aa96e1537615f6966b6b78879cde5d3a0b215
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -4003,8 +4003,9 @@ data:
     #  Multicluster: false
 
     # Enable support for provisioning secondary network interfaces for Pods (using
-    # Pod annotations). At the moment, Antrea can only create secondary network
-    # interfaces using SR-IOV VFs on baremetal Nodes.
+    # Pod annotations). At the moment, Antrea can create secondary network
+    # interfaces either using SR-IOV VFs on bare-metal Nodes or veth interfaces
+    # bridged to the underlay network, with or without VLAN tagging.
     #  SecondaryNetwork: false
 
     # Enable managing external IPs of Services of LoadBalancer type.
@@ -4174,7 +4175,6 @@ data:
 
     # Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener.
     enablePrometheusMetrics: true
-
 
     flowExporter:
       # Enable FlowExporter, a feature used to export polled conntrack connections as
@@ -4363,6 +4363,16 @@ data:
       maxAge: 28
       # Compress enables gzip compression on rotated files.
       compress: true
+
+    # SecondaryNetwork related configurations.
+    secondaryNetwork:
+      # Configuration of OVS bridges for secondary network. At the moment, at
+      # most one OVS bridge can be specified. If the specified bridge does not exist
+      # on the Node, antrea-agent will create it based on the configuration.
+      # The following configuration specifies an OVS bridge with name "br1" and a
+      # physical interface "eth1":
+      # [{bridgeName: "br1", physicalInterfaces: ["eth1"]}]
+      ovsBridges:
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -5384,7 +5394,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: c775d4a79675716893fc1b7b3149fa6fe24d06b56c8d76bbaeea4e8b4013418c
+        checksum/config: 5dd823245aab41ce7ca74d05693aa96e1537615f6966b6b78879cde5d3a0b215
       labels:
         app: antrea
         component: antrea-agent
@@ -5623,7 +5633,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: c775d4a79675716893fc1b7b3149fa6fe24d06b56c8d76bbaeea4e8b4013418c
+        checksum/config: 5dd823245aab41ce7ca74d05693aa96e1537615f6966b6b78879cde5d3a0b215
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -4003,8 +4003,9 @@ data:
     #  Multicluster: false
 
     # Enable support for provisioning secondary network interfaces for Pods (using
-    # Pod annotations). At the moment, Antrea can only create secondary network
-    # interfaces using SR-IOV VFs on baremetal Nodes.
+    # Pod annotations). At the moment, Antrea can create secondary network
+    # interfaces either using SR-IOV VFs on bare-metal Nodes or veth interfaces
+    # bridged to the underlay network, with or without VLAN tagging.
     #  SecondaryNetwork: false
 
     # Enable managing external IPs of Services of LoadBalancer type.
@@ -4174,7 +4175,6 @@ data:
 
     # Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener.
     enablePrometheusMetrics: true
-
 
     flowExporter:
       # Enable FlowExporter, a feature used to export polled conntrack connections as
@@ -4363,6 +4363,16 @@ data:
       maxAge: 28
       # Compress enables gzip compression on rotated files.
       compress: true
+
+    # SecondaryNetwork related configurations.
+    secondaryNetwork:
+      # Configuration of OVS bridges for secondary network. At the moment, at
+      # most one OVS bridge can be specified. If the specified bridge does not exist
+      # on the Node, antrea-agent will create it based on the configuration.
+      # The following configuration specifies an OVS bridge with name "br1" and a
+      # physical interface "eth1":
+      # [{bridgeName: "br1", physicalInterfaces: ["eth1"]}]
+      ovsBridges:
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -5384,7 +5394,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: d5912db1ec029b1a335f401b7bec529db08f165c5a9e96baa2f8a23f336d9f3f
+        checksum/config: e9ea48fa57cb11513f69a1fb2b44dd3c6cb96aa739598c1db5091ea91f097f4b
       labels:
         app: antrea
         component: antrea-agent
@@ -5620,7 +5630,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: d5912db1ec029b1a335f401b7bec529db08f165c5a9e96baa2f8a23f336d9f3f
+        checksum/config: e9ea48fa57cb11513f69a1fb2b44dd3c6cb96aa739598c1db5091ea91f097f4b
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -4016,8 +4016,9 @@ data:
     #  Multicluster: false
 
     # Enable support for provisioning secondary network interfaces for Pods (using
-    # Pod annotations). At the moment, Antrea can only create secondary network
-    # interfaces using SR-IOV VFs on baremetal Nodes.
+    # Pod annotations). At the moment, Antrea can create secondary network
+    # interfaces either using SR-IOV VFs on bare-metal Nodes or veth interfaces
+    # bridged to the underlay network, with or without VLAN tagging.
     #  SecondaryNetwork: false
 
     # Enable managing external IPs of Services of LoadBalancer type.
@@ -4187,7 +4188,6 @@ data:
 
     # Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener.
     enablePrometheusMetrics: true
-
 
     flowExporter:
       # Enable FlowExporter, a feature used to export polled conntrack connections as
@@ -4376,6 +4376,16 @@ data:
       maxAge: 28
       # Compress enables gzip compression on rotated files.
       compress: true
+
+    # SecondaryNetwork related configurations.
+    secondaryNetwork:
+      # Configuration of OVS bridges for secondary network. At the moment, at
+      # most one OVS bridge can be specified. If the specified bridge does not exist
+      # on the Node, antrea-agent will create it based on the configuration.
+      # The following configuration specifies an OVS bridge with name "br1" and a
+      # physical interface "eth1":
+      # [{bridgeName: "br1", physicalInterfaces: ["eth1"]}]
+      ovsBridges:
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -5397,7 +5407,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 2c369045727db9b1108b3f3aae7f5919f3843f9fcf72ce4dae3d136f35b39b74
+        checksum/config: 38e19ea8db3838e3f5cff4aaa2684db1586fb457d095ac3ea49e8bf405a04e41
         checksum/ipsec-secret: d0eb9c52d0cd4311b6d252a951126bf9bea27ec05590bed8a394f0f792dcb2a4
       labels:
         app: antrea
@@ -5679,7 +5689,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 2c369045727db9b1108b3f3aae7f5919f3843f9fcf72ce4dae3d136f35b39b74
+        checksum/config: 38e19ea8db3838e3f5cff4aaa2684db1586fb457d095ac3ea49e8bf405a04e41
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -4003,8 +4003,9 @@ data:
     #  Multicluster: false
 
     # Enable support for provisioning secondary network interfaces for Pods (using
-    # Pod annotations). At the moment, Antrea can only create secondary network
-    # interfaces using SR-IOV VFs on baremetal Nodes.
+    # Pod annotations). At the moment, Antrea can create secondary network
+    # interfaces either using SR-IOV VFs on bare-metal Nodes or veth interfaces
+    # bridged to the underlay network, with or without VLAN tagging.
     #  SecondaryNetwork: false
 
     # Enable managing external IPs of Services of LoadBalancer type.
@@ -4174,7 +4175,6 @@ data:
 
     # Enable metrics exposure via Prometheus. Initializes Prometheus metrics listener.
     enablePrometheusMetrics: true
-
 
     flowExporter:
       # Enable FlowExporter, a feature used to export polled conntrack connections as
@@ -4363,6 +4363,16 @@ data:
       maxAge: 28
       # Compress enables gzip compression on rotated files.
       compress: true
+
+    # SecondaryNetwork related configurations.
+    secondaryNetwork:
+      # Configuration of OVS bridges for secondary network. At the moment, at
+      # most one OVS bridge can be specified. If the specified bridge does not exist
+      # on the Node, antrea-agent will create it based on the configuration.
+      # The following configuration specifies an OVS bridge with name "br1" and a
+      # physical interface "eth1":
+      # [{bridgeName: "br1", physicalInterfaces: ["eth1"]}]
+      ovsBridges:
   antrea-cni.conflist: |
     {
         "cniVersion":"0.3.0",
@@ -5384,7 +5394,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: ee43fc8c8c5ac8097a757da0545e43b25f98d8f2d831842f7ee76e1ed7581267
+        checksum/config: 59fb1ea496577015058d4e99e4f64136aa68d5340db13c00ced565da750a22fc
       labels:
         app: antrea
         component: antrea-agent
@@ -5620,7 +5630,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: ee43fc8c8c5ac8097a757da0545e43b25f98d8f2d831842f7ee76e1ed7581267
+        checksum/config: 59fb1ea496577015058d4e99e4f64136aa68d5340db13c00ced565da750a22fc
       labels:
         app: antrea
         component: antrea-controller

--- a/docs/secondary-network.md
+++ b/docs/secondary-network.md
@@ -64,7 +64,7 @@ metadata:
 data:
   antrea-agent.conf: |
     secondaryNetwork:
-    ovsBridges: [{"bridgeName": "br-secondary", "physicalInterfaces": ["eth1"]}]
+      ovsBridges: [{"bridgeName": "br-secondary", "physicalInterfaces": ["eth1"]}]
 ```
 
 At the moment, Antrea supports only a single OVS bridge for secondary networks,
@@ -136,7 +136,7 @@ metadata:
  annotations:
    k8s.v1.cni.cncf.io/networks: '[
      {"name": "vlan100"},
-     {"name": vlan200, "namespace": "networks", "interface": "eth200"}
+     {"name": "vlan200", "namespace": "networks", "interface": "eth200"}
    ]'
 spec:
  containers:


### PR DESCRIPTION
Include SecondaryNetwork related configurations in the YAMLs to simplify usage with installation methods other than Helm, which also aligns with other features' configurations.