### PR TITLE
Create new kubeconfig for SupportBundleClient

### DIFF
--- a/pkg/antctl/raw/supportbundle/command.go
+++ b/pkg/antctl/raw/supportbundle/command.go
@@ -120,13 +120,10 @@ func init() {
 	}
 }
 
-var getSupportBundleClient func(cmd *cobra.Command) (systemclientset.SupportBundleInterface, error) = setupSupportBundleClient
+var getSupportBundleClient func() (systemclientset.SupportBundleInterface, error) = setupSupportBundleClient
 
-func setupSupportBundleClient(cmd *cobra.Command) (systemclientset.SupportBundleInterface, error) {
-	kubeconfig, err := raw.ResolveKubeconfig(cmd)
-	if err != nil {
-		return nil, err
-	}
+func setupSupportBundleClient() (systemclientset.SupportBundleInterface, error) {
+	kubeconfig := &rest.Config{}
 	raw.SetupLocalKubeconfig(kubeconfig)
 	client, err := systemclientset.NewForConfig(kubeconfig)
 	return client.SupportBundles(), err
@@ -134,7 +131,7 @@ func setupSupportBundleClient(cmd *cobra.Command) (systemclientset.SupportBundle
 
 func localSupportBundleRequest(cmd *cobra.Command, mode string, writer io.Writer) error {
 	ctx := cmd.Context()
-	client, err := getSupportBundleClient(cmd)
+	client, err := getSupportBundleClient()
 	if err != nil {
 		return fmt.Errorf("error when creating system client: %w", err)
 	}

--- a/pkg/antctl/raw/supportbundle/command_test.go
+++ b/pkg/antctl/raw/supportbundle/command_test.go
@@ -136,7 +136,7 @@ func createFakeSupportBundleClient() systemclientset.SupportBundleInterface {
 }
 
 func TestLocalSupportBundleRequest(t *testing.T) {
-	getSupportBundleClient = func(cmd *cobra.Command) (systemclientset.SupportBundleInterface, error) {
+	getSupportBundleClient = func() (systemclientset.SupportBundleInterface, error) {
 		return createFakeSupportBundleClient(), nil
 	}
 	defer func() {


### PR DESCRIPTION
Fixes: https://github.com/antrea-io/antrea/issues/6687

* Create a new kubeconfig for local support bundle requests to avoid errors caused
by the absence of this file.
* For ResolveKubeconfig, detailed error messages are returned, differentiating
between kubeconfig file errors and InClusterConfig errors.