### PR TITLE
Remove superfluous json and protobuf tags for CP internal type

### DIFF
--- a/pkg/apis/controlplane/types.go
+++ b/pkg/apis/controlplane/types.go
@@ -350,7 +350,7 @@ type HTTPProtocol struct {
 // matches all TLS handshake packets.
 type TLSProtocol struct {
 	// SNI (Server Name Indication) indicates the server domain name in the TLS/SSL hello message.
-	SNI string `json:"sni,omitempty" protobuf:"bytes,1,opt,name=sni"`
+	SNI string
 }
 
 // NetworkPolicyPeer describes a peer of NetworkPolicyRules.


### PR DESCRIPTION
The TLSProtocol control plane internal (unversioned) type had a JSON / Protobuf field tag. Internal types are never serialized, so the tag was unnecessary and misleading.