### PR TITLE
Add antctl get fqdncache

### DIFF
--- a/pkg/agent/apis/types.go
+++ b/pkg/agent/apis/types.go
@@ -17,6 +17,7 @@ package apis
 import (
 	"strconv"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -69,6 +70,28 @@ func (r AntreaAgentInfoResponse) GetTableRow(maxColumnLength int) []string {
 }
 
 func (r AntreaAgentInfoResponse) SortRows() bool {
+	return true
+}
+
+type FQDNCacheResponse struct {
+	FQDNName       string    `json:"fqdnName,omitempty"`
+	IPAddress      string    `json:"ipAddress,omitempty"`
+	ExpirationTime time.Time `json:"expirationTime,omitempty"`
+}
+
+func (r FQDNCacheResponse) GetTableHeader() []string {
+	return []string{"FQDN", "ADDRESS", "EXPIRATION TIME"}
+}
+
+func (r FQDNCacheResponse) GetTableRow(maxColumn int) []string {
+	return []string{
+		r.FQDNName,
+		r.IPAddress,
+		r.ExpirationTime.String(),
+	}
+}
+
+func (r FQDNCacheResponse) SortRows() bool {
 	return true
 }
 

--- a/pkg/agent/apiserver/apiserver.go
+++ b/pkg/agent/apiserver/apiserver.go
@@ -40,6 +40,7 @@ import (
 	"antrea.io/antrea/pkg/agent/apiserver/handlers/bgppolicy"
 	"antrea.io/antrea/pkg/agent/apiserver/handlers/bgproute"
 	"antrea.io/antrea/pkg/agent/apiserver/handlers/featuregates"
+	"antrea.io/antrea/pkg/agent/apiserver/handlers/fqdncache"
 	"antrea.io/antrea/pkg/agent/apiserver/handlers/memberlist"
 	"antrea.io/antrea/pkg/agent/apiserver/handlers/multicast"
 	"antrea.io/antrea/pkg/agent/apiserver/handlers/networkpolicy"
@@ -104,6 +105,7 @@ func installHandlers(aq agentquerier.AgentQuerier, npq querier.AgentNetworkPolic
 	s.Handler.NonGoRestfulMux.HandleFunc("/bgppolicy", bgppolicy.HandleFunc(bgpq))
 	s.Handler.NonGoRestfulMux.HandleFunc("/bgppeers", bgppeer.HandleFunc(bgpq))
 	s.Handler.NonGoRestfulMux.HandleFunc("/bgproutes", bgproute.HandleFunc(bgpq))
+	s.Handler.NonGoRestfulMux.HandleFunc("/fqdncache", fqdncache.HandleFunc(npq))
 }
 
 func installAPIGroup(s *genericapiserver.GenericAPIServer, aq agentquerier.AgentQuerier, npq querier.AgentNetworkPolicyInfoQuerier, v4Enabled, v6Enabled bool) error {

--- a/pkg/agent/apiserver/handlers/fqdncache/handler.go
+++ b/pkg/agent/apiserver/handlers/fqdncache/handler.go
@@ -1,0 +1,73 @@
+// Copyright 2025 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fqdncache
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"k8s.io/klog/v2"
+
+	agentapi "antrea.io/antrea/pkg/agent/apis"
+	"antrea.io/antrea/pkg/querier"
+)
+
+func HandleFunc(npq querier.AgentNetworkPolicyInfoQuerier) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		fqdnFilter, err := newFilterFromURLQuery(r.URL.Query())
+		if err != nil {
+			http.Error(w, "Invalid regex: "+err.Error(), http.StatusBadRequest)
+			klog.ErrorS(err, "Invalid regex")
+			return
+		}
+		dnsEntryCache := npq.GetFQDNCache(fqdnFilter)
+		resp := make([]agentapi.FQDNCacheResponse, 0, len(dnsEntryCache))
+		for _, entry := range dnsEntryCache {
+			resp = append(resp, agentapi.FQDNCacheResponse{
+				FQDNName:       entry.FQDNName,
+				IPAddress:      entry.IPAddress.String(),
+				ExpirationTime: entry.ExpirationTime,
+			})
+		}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			http.Error(w, "Failed to encode response: "+err.Error(), http.StatusBadRequest)
+			klog.ErrorS(err, "Failed to encode response")
+			return
+		}
+	}
+}
+
+func newFilterFromURLQuery(query url.Values) (*querier.FQDNCacheFilter, error) {
+	domain := query.Get("domain")
+	if domain == "" {
+		return nil, nil
+	}
+	pattern := strings.TrimSpace(domain)
+	// Replace "." as a regex literal, since it's recogized as a separator in FQDN.
+	pattern = strings.Replace(pattern, ".", "[.]", -1)
+	// Replace "*" with ".*".
+	pattern = strings.Replace(pattern, "*", ".*", -1)
+	// Anchor the regex match expression.
+	pattern = "^" + pattern + "$"
+
+	regex, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil, err
+	}
+	return &querier.FQDNCacheFilter{DomainRegex: regex}, nil
+}

--- a/pkg/agent/apiserver/handlers/fqdncache/handler_test.go
+++ b/pkg/agent/apiserver/handlers/fqdncache/handler_test.go
@@ -1,0 +1,152 @@
+// Copyright 2025 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fqdncache
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"antrea.io/antrea/pkg/agent/apis"
+	"antrea.io/antrea/pkg/agent/types"
+	"antrea.io/antrea/pkg/querier"
+	queriertest "antrea.io/antrea/pkg/querier/testing"
+)
+
+func TestFqdnCacheQuery(t *testing.T) {
+	expirationTime := time.Now().Add(1 * time.Hour).UTC()
+	tests := []struct {
+		name                 string
+		filteredCacheEntries []types.DnsCacheEntry
+		expectedResponse     []apis.FQDNCacheResponse
+	}{
+		{
+			name: "FQDN cache exists - multiple addresses multiple domains",
+			filteredCacheEntries: []types.DnsCacheEntry{
+				{
+					FQDNName:       "example.com",
+					IPAddress:      net.ParseIP("10.0.0.1"),
+					ExpirationTime: expirationTime,
+				},
+				{
+					FQDNName:       "foo.com",
+					IPAddress:      net.ParseIP("10.0.0.4"),
+					ExpirationTime: expirationTime,
+				},
+				{
+					FQDNName:       "bar.com",
+					IPAddress:      net.ParseIP("10.0.0.5"),
+					ExpirationTime: expirationTime,
+				},
+			},
+			expectedResponse: []apis.FQDNCacheResponse{
+				{
+					FQDNName:       "example.com",
+					IPAddress:      "10.0.0.1",
+					ExpirationTime: expirationTime,
+				},
+				{
+					FQDNName:       "foo.com",
+					IPAddress:      "10.0.0.4",
+					ExpirationTime: expirationTime,
+				},
+				{
+					FQDNName:       "bar.com",
+					IPAddress:      "10.0.0.5",
+					ExpirationTime: expirationTime,
+				},
+			},
+		},
+		{
+			name:                 "FQDN cache does not exist",
+			filteredCacheEntries: []types.DnsCacheEntry{},
+			expectedResponse:     []apis.FQDNCacheResponse{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			q := queriertest.NewMockAgentNetworkPolicyInfoQuerier(ctrl)
+			q.EXPECT().GetFQDNCache(nil).Return(tt.filteredCacheEntries)
+			handler := HandleFunc(q)
+			req, err := http.NewRequest(http.MethodGet, "", nil)
+			require.NoError(t, err)
+			recorder := httptest.NewRecorder()
+			handler.ServeHTTP(recorder, req)
+			var receivedResponse []apis.FQDNCacheResponse
+			err = json.Unmarshal(recorder.Body.Bytes(), &receivedResponse)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedResponse, receivedResponse)
+		})
+	}
+}
+
+func TestNewFilterFromURLQuery(t *testing.T) {
+	tests := []struct {
+		name           string
+		queryParams    url.Values
+		expectedFilter *querier.FQDNCacheFilter
+		expectedError  string
+	}{
+		{
+			name:           "Empty query",
+			queryParams:    url.Values{},
+			expectedFilter: nil,
+		},
+		{
+			name: "Valid regex domain",
+			queryParams: url.Values{
+				"domain": {"example.com"},
+			},
+			expectedFilter: &querier.FQDNCacheFilter{DomainRegex: regexp.MustCompile("^example[.]com$")},
+		},
+		{
+			name: "Valid regex domain",
+			queryParams: url.Values{
+				"domain": {"*.example.com"},
+			},
+			expectedFilter: &querier.FQDNCacheFilter{DomainRegex: regexp.MustCompile("^.*[.]example[.]com$")},
+		},
+		{
+			name: "Invalid regex domain",
+			queryParams: url.Values{
+				"domain": {"^example(abc$"},
+			},
+			expectedFilter: nil,
+			expectedError:  "missing closing )",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := newFilterFromURLQuery(tt.queryParams)
+			if tt.expectedError != "" {
+				assert.ErrorContains(t, err, tt.expectedError)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedFilter, result)
+			}
+		})
+	}
+}

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
@@ -538,6 +538,19 @@ func NewNetworkPolicyController(antreaClientGetter client.AntreaClientProvider,
 	return c, nil
 }
 
+func (c *Controller) GetFQDNCache(fqdnFilter *querier.FQDNCacheFilter) []types.DnsCacheEntry {
+	cacheEntryList := []types.DnsCacheEntry{}
+	for fqdn, dnsMeta := range c.fqdnController.dnsEntryCache {
+		for _, ipWithExpiration := range dnsMeta.responseIPs {
+			if fqdnFilter == nil || fqdnFilter.DomainRegex.MatchString(fqdn) {
+				entry := types.DnsCacheEntry{FQDNName: fqdn, IPAddress: ipWithExpiration.ip, ExpirationTime: ipWithExpiration.expirationTime}
+				cacheEntryList = append(cacheEntryList, entry)
+			}
+		}
+	}
+	return cacheEntryList
+}
+
 func (c *Controller) GetNetworkPolicyNum() int {
 	return c.ruleCache.GetNetworkPolicyNum()
 }

--- a/pkg/agent/types/networkpolicy.go
+++ b/pkg/agent/types/networkpolicy.go
@@ -15,12 +15,21 @@
 package types
 
 import (
+	"net"
+	"time"
+
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"antrea.io/antrea/pkg/apis/controlplane/v1beta2"
 	secv1beta1 "antrea.io/antrea/pkg/apis/crd/v1beta1"
 	binding "antrea.io/antrea/pkg/ovs/openflow"
 )
+
+type DnsCacheEntry struct {
+	FQDNName       string
+	IPAddress      net.IP
+	ExpirationTime time.Time
+}
 
 type MatchKey struct {
 	ofProtocol    binding.Protocol

--- a/pkg/antctl/antctl.go
+++ b/pkg/antctl/antctl.go
@@ -726,6 +726,32 @@ $ antctl get podmulticaststats pod -n namespace`,
 			commandGroup:        get,
 			transformedResponse: reflect.TypeOf(agentapis.BGPRouteResponse{}),
 		},
+		{
+			use:   "fqdncache",
+			short: "Print fqdn cache",
+			long:  "Print effective fqdn cache information including fqdn name, IP addresses, and expiration time",
+			example: `	Get the list of all fqdn rules currently applied
+			$ antctl get fqdncache
+			Get the list of all fqdn rules currently applied for a given domain name (wildcard supported)
+			$ antctl get fqdncache --domain example.com
+			$ antctl get fqdncache --domain *.antrea.io
+			`,
+			agentEndpoint: &endpoint{
+				nonResourceEndpoint: &nonResourceEndpoint{
+					path: "/fqdncache",
+					params: []flagInfo{
+						{
+							name:      "domain",
+							usage:     "Get fqdn cache for only a specific domain",
+							shorthand: "d",
+						},
+					},
+					outputType: multiple,
+				},
+			},
+			commandGroup:        get,
+			transformedResponse: reflect.TypeOf(agentapis.FQDNCacheResponse{}),
+		},
 	},
 	rawCommands: []rawCommand{
 		{

--- a/pkg/antctl/command_list_test.go
+++ b/pkg/antctl/command_list_test.go
@@ -70,7 +70,7 @@ func TestGetDebugCommands(t *testing.T) {
 		{
 			name:     "Antctl running against agent mode",
 			mode:     "agent",
-			expected: [][]string{{"version"}, {"get", "podmulticaststats"}, {"log-level"}, {"get", "networkpolicy"}, {"get", "appliedtogroup"}, {"get", "addressgroup"}, {"get", "agentinfo"}, {"get", "podinterface"}, {"get", "ovsflows"}, {"trace-packet"}, {"get", "serviceexternalip"}, {"get", "memberlist"}, {"get", "bgppolicy"}, {"get", "bgppeers"}, {"get", "bgproutes"}, {"supportbundle"}, {"traceflow"}, {"get", "featuregates"}},
+			expected: [][]string{{"version"}, {"get", "podmulticaststats"}, {"log-level"}, {"get", "networkpolicy"}, {"get", "appliedtogroup"}, {"get", "addressgroup"}, {"get", "agentinfo"}, {"get", "podinterface"}, {"get", "ovsflows"}, {"trace-packet"}, {"get", "serviceexternalip"}, {"get", "memberlist"}, {"get", "bgppolicy"}, {"get", "bgppeers"}, {"get", "bgproutes"}, {"get", "fqdncache"}, {"supportbundle"}, {"traceflow"}, {"get", "featuregates"}},
 		},
 		{
 			name:     "Antctl running against flow-aggregator mode",

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -16,6 +16,7 @@ package querier
 
 import (
 	"context"
+	"regexp"
 
 	v1 "k8s.io/api/core/v1"
 	apitypes "k8s.io/apimachinery/pkg/types"
@@ -47,6 +48,7 @@ type AgentNetworkPolicyInfoQuerier interface {
 	GetAppliedNetworkPolicies(pod, namespace string, npFilter *NetworkPolicyQueryFilter) []cpv1beta.NetworkPolicy
 	GetNetworkPolicyByRuleFlowID(ruleFlowID uint32) *cpv1beta.NetworkPolicyReference
 	GetRuleByFlowID(ruleFlowID uint32) *types.PolicyRule
+	GetFQDNCache(fqdnFilter *FQDNCacheFilter) []types.DnsCacheEntry
 }
 
 type AgentMulticastInfoQuerier interface {
@@ -99,6 +101,12 @@ func GetSelfNode(isAgent bool, node string) v1.ObjectReference {
 // GetVersion gets current version.
 func GetVersion() string {
 	return version.GetFullVersion()
+}
+
+// FQDNCacheFilter is used to filter the result while retrieving FQDN cache
+type FQDNCacheFilter struct {
+	// The Name or wildcard matching expression of the domain that is being filtered
+	DomainRegex *regexp.Regexp
 }
 
 // NetworkPolicyQueryFilter is used to filter the result while retrieve network policy

--- a/pkg/querier/testing/mock_querier.go
+++ b/pkg/querier/testing/mock_querier.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Antrea Authors
+// Copyright 2025 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -145,6 +145,20 @@ func (m *MockAgentNetworkPolicyInfoQuerier) GetControllerConnectionStatus() bool
 func (mr *MockAgentNetworkPolicyInfoQuerierMockRecorder) GetControllerConnectionStatus() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetControllerConnectionStatus", reflect.TypeOf((*MockAgentNetworkPolicyInfoQuerier)(nil).GetControllerConnectionStatus))
+}
+
+// GetFQDNCache mocks base method.
+func (m *MockAgentNetworkPolicyInfoQuerier) GetFQDNCache(fqdnFilter *querier.FQDNCacheFilter) []types.DnsCacheEntry {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetFQDNCache", fqdnFilter)
+	ret0, _ := ret[0].([]types.DnsCacheEntry)
+	return ret0
+}
+
+// GetFQDNCache indicates an expected call of GetFQDNCache.
+func (mr *MockAgentNetworkPolicyInfoQuerierMockRecorder) GetFQDNCache(fqdnFilter any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFQDNCache", reflect.TypeOf((*MockAgentNetworkPolicyInfoQuerier)(nil).GetFQDNCache), fqdnFilter)
 }
 
 // GetNetworkPolicies mocks base method.


### PR DESCRIPTION
This PR adds functionality for a new antctl command: antctl get fqdncache This command fetches the DNS mapping entries for FQDN policies by reading the cache for DNS entries and outputting FQDN name, associated IP, and expiration time. It can also be used with a --domain (-d) flag that can be specified to filter the result for only a certain FQDN name.