### PR TITLE
Add bidirectional packet capture

### DIFF
--- a/build/charts/antrea/crds/packetcapture.yaml
+++ b/build/charts/antrea/crds/packetcapture.yaml
@@ -152,7 +152,10 @@ spec:
                               type: integer
                               minimum: 1
                               maximum: 65535
-
+                direction:
+                  type: string
+                  enum: ["SourceToDestination", "DestinationToSource", "Both"]
+                  default: "SourceToDestination"
                 timeout:
                   type: integer
                   minimum: 1

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -3067,7 +3067,10 @@ spec:
                               type: integer
                               minimum: 1
                               maximum: 65535
-
+                direction:
+                  type: string
+                  enum: ["SourceToDestination", "DestinationToSource", "Both"]
+                  default: "SourceToDestination"
                 timeout:
                   type: integer
                   minimum: 1

--- a/build/yamls/antrea-crds.yml
+++ b/build/yamls/antrea-crds.yml
@@ -3040,7 +3040,10 @@ spec:
                               type: integer
                               minimum: 1
                               maximum: 65535
-
+                direction:
+                  type: string
+                  enum: ["SourceToDestination", "DestinationToSource", "Both"]
+                  default: "SourceToDestination"
                 timeout:
                   type: integer
                   minimum: 1

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -3067,7 +3067,10 @@ spec:
                               type: integer
                               minimum: 1
                               maximum: 65535
-
+                direction:
+                  type: string
+                  enum: ["SourceToDestination", "DestinationToSource", "Both"]
+                  default: "SourceToDestination"
                 timeout:
                   type: integer
                   minimum: 1

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -3067,7 +3067,10 @@ spec:
                               type: integer
                               minimum: 1
                               maximum: 65535
-
+                direction:
+                  type: string
+                  enum: ["SourceToDestination", "DestinationToSource", "Both"]
+                  default: "SourceToDestination"
                 timeout:
                   type: integer
                   minimum: 1

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -3067,7 +3067,10 @@ spec:
                               type: integer
                               minimum: 1
                               maximum: 65535
-
+                direction:
+                  type: string
+                  enum: ["SourceToDestination", "DestinationToSource", "Both"]
+                  default: "SourceToDestination"
                 timeout:
                   type: integer
                   minimum: 1

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -3067,7 +3067,10 @@ spec:
                               type: integer
                               minimum: 1
                               maximum: 65535
-
+                direction:
+                  type: string
+                  enum: ["SourceToDestination", "DestinationToSource", "Both"]
+                  default: "SourceToDestination"
                 timeout:
                   type: integer
                   minimum: 1

--- a/docs/packetcapture-guide.md
+++ b/docs/packetcapture-guide.md
@@ -32,6 +32,7 @@ the target traffic flow:
 * Destination Pod, or IP address
 * Transport protocol (TCP/UDP/ICMP)
 * Transport ports
+* Direction (SourceToDestination/DestinationToSource/Both)
 
 You can start a new packet capture by creating a `PacketCapture` CR. An optional `fileServer`
 field can be specified to store the generated packets file. Before that,
@@ -74,6 +75,8 @@ spec:
     pod:
       namespace: default
       name: backend
+  # Available options for direction: `SourceToDestination` (default), `DestinationToSource` or `Both`.
+  direction: SourceToDestination # optional to specify
   packet:
     ipFamily: IPv4
     protocol: TCP # support arbitrary number values and string values in [TCP,UDP,ICMP] (case insensitive)

--- a/pkg/agent/packetcapture/capture/pcap_linux.go
+++ b/pkg/agent/packetcapture/capture/pcap_linux.go
@@ -41,9 +41,9 @@ func zeroFilter() []bpf.Instruction {
 	return []bpf.Instruction{returnDrop}
 }
 
-func (p *pcapCapture) Capture(ctx context.Context, device string, snapLen int, srcIP, dstIP net.IP, packet *crdv1alpha1.Packet) (chan gopacket.Packet, error) {
+func (p *pcapCapture) Capture(ctx context.Context, device string, snapLen int, srcIP, dstIP net.IP, packet *crdv1alpha1.Packet, direction crdv1alpha1.CaptureDirection) (chan gopacket.Packet, error) {
 	// Compile the BPF filter in advance to reduce the time window between starting the capture and applying the filter.
-	inst := compilePacketFilter(packet, srcIP, dstIP)
+	inst := compilePacketFilter(packet, srcIP, dstIP, direction)
 	klog.V(5).InfoS("Generated bpf instructions for PacketCapture", "device", device, "srcIP", srcIP, "dstIP", dstIP, "packetSpec", packet, "bpf", inst)
 	rawInst, err := bpf.Assemble(inst)
 	if err != nil {

--- a/pkg/agent/packetcapture/capture/pcap_unsupported.go
+++ b/pkg/agent/packetcapture/capture/pcap_unsupported.go
@@ -34,6 +34,6 @@ func NewPcapCapture() (*pcapCapture, error) {
 	return nil, errors.New("PacketCapture is not implemented")
 }
 
-func (p *pcapCapture) Capture(ctx context.Context, device string, snapLen int, srcIP, dstIP net.IP, packet *crdv1alpha1.Packet) (chan gopacket.Packet, error) {
+func (p *pcapCapture) Capture(ctx context.Context, device string, snapLen int, srcIP, dstIP net.IP, packet *crdv1alpha1.Packet, direction crdv1alpha1.CaptureDirection) (chan gopacket.Packet, error) {
 	return nil, errors.New("PacketCapture is not implemented")
 }

--- a/pkg/agent/packetcapture/capture_interface.go
+++ b/pkg/agent/packetcapture/capture_interface.go
@@ -24,5 +24,5 @@ import (
 )
 
 type PacketCapturer interface {
-	Capture(ctx context.Context, device string, snapLen int, srcIP, dstIP net.IP, packet *crdv1alpha1.Packet) (chan gopacket.Packet, error)
+	Capture(ctx context.Context, device string, snapLen int, srcIP, dstIP net.IP, packet *crdv1alpha1.Packet, direction crdv1alpha1.CaptureDirection) (chan gopacket.Packet, error)
 }

--- a/pkg/agent/packetcapture/packetcapture_controller.go
+++ b/pkg/agent/packetcapture/packetcapture_controller.go
@@ -464,7 +464,7 @@ func (c *Controller) performCapture(
 	}
 	defer pcapngWriter.Flush()
 	updateRateLimiter := rate.NewLimiter(rate.Every(captureStatusUpdatePeriod), 1)
-	packets, err := c.captureInterface.Capture(ctx, device, snapLen, srcIP, dstIP, pc.Spec.Packet)
+	packets, err := c.captureInterface.Capture(ctx, device, snapLen, srcIP, dstIP, pc.Spec.Packet, pc.Spec.Direction)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/agent/packetcapture/packetcapture_controller_test.go
+++ b/pkg/agent/packetcapture/packetcapture_controller_test.go
@@ -193,7 +193,7 @@ func craftTestPacket() gopacket.Packet {
 type testCapture struct {
 }
 
-func (p *testCapture) Capture(ctx context.Context, device string, snapLen int, srcIP, dstIP net.IP, packet *crdv1alpha1.Packet) (chan gopacket.Packet, error) {
+func (p *testCapture) Capture(ctx context.Context, device string, snapLen int, srcIP, dstIP net.IP, packet *crdv1alpha1.Packet, direction crdv1alpha1.CaptureDirection) (chan gopacket.Packet, error) {
 	ch := make(chan gopacket.Packet, testCaptureNum)
 	for i := 0; i < 15; i++ {
 		ch <- craftTestPacket()

--- a/pkg/apis/crd/v1alpha1/types.go
+++ b/pkg/apis/crd/v1alpha1/types.go
@@ -442,6 +442,14 @@ type PacketCaptureFileServer struct {
 	HostPublicKey []byte `json:"hostPublicKey,omitempty"`
 }
 
+type CaptureDirection string
+
+const (
+	CaptureDirectionSourceToDestination CaptureDirection = "SourceToDestination"
+	CaptureDirectionDestinationToSource CaptureDirection = "DestinationToSource"
+	CaptureDirectionBoth                CaptureDirection = "Both"
+)
+
 type PacketCaptureSpec struct {
 	// Timeout is the timeout for this capture session. If not specified, defaults to 60s.
 	Timeout       *int32        `json:"timeout,omitempty"`
@@ -450,6 +458,9 @@ type PacketCaptureSpec struct {
 	// for a capture session, and at least one `Pod` should be present either in the source or the destination.
 	Source      Source      `json:"source"`
 	Destination Destination `json:"destination"`
+	// Direction specifies which packets to capture (source -> destination, destination -> source or both).
+	// If not specified, defaults to SourceToDestination.
+	Direction CaptureDirection `json:"direction,omitempty"`
 	// Packet defines what kind of traffic we want to capture between the source and destination. If not specified,
 	// all kinds of traffic will count.
 	Packet *Packet `json:"packet,omitempty"`


### PR DESCRIPTION
fixes: #6862 

Added `bidirectional` field in packet capture CR spec.
For testing, I created two pods and pinged one from the other. 

Screenshot of the `.pcapng` output file.
![image](https://github.com/user-attachments/assets/34262988-987f-43ba-870c-ca82cc02089d)
