### PR TITLE
[Windows] Support OF port state "down" when installing Pod forwarding rules

### DIFF
--- a/pkg/agent/cniserver/pod_configuration_test.go
+++ b/pkg/agent/cniserver/pod_configuration_test.go
@@ -393,7 +393,7 @@ func TestProcessPortStatusMessage(t *testing.T) {
 					PortNo: 1,
 					Length: 72,
 					Name:   []byte(fmt.Sprintf("%s\x00", podIfName)),
-					State:  openflow15.PS_LINK_DOWN,
+					State:  openflow15.PS_BLOCKED,
 				},
 			},
 			ovsPortName:     podIfName,


### PR DESCRIPTION
On Windows, OVS has an issue which doesn't correctly update the port status after an OpenFlow port is successfully installed. So OVS may send out PortStatus message with Port state as LINK_DOWN, this issue doesn't impact on the datapath forwarding.

This change is a workaround to ensure Pod's OpenFlow entries are installed as long as the OpenFlow port is allocated.

Fix: #6888 