### PR TITLE
Automated cherry pick of #6889: Support OF port state "down" when installing Pod

### DIFF
--- a/pkg/agent/cniserver/pod_configuration_test.go
+++ b/pkg/agent/cniserver/pod_configuration_test.go
@@ -393,7 +393,7 @@ func TestProcessPortStatusMessage(t *testing.T) {
 					PortNo: 1,
 					Length: 72,
 					Name:   []byte(fmt.Sprintf("%s\x00", podIfName)),
-					State:  openflow15.PS_LINK_DOWN,
+					State:  openflow15.PS_BLOCKED,
 				},
 			},
 			ovsPortName:     podIfName,


### PR DESCRIPTION
Cherry pick of #6889 on release-2.2.

#6889: Support OF port state "down" when installing Pod

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.