### PR TITLE
Upgrade go-ipfix to 0.12.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	github.com/ti-mo/conntrack v0.5.1
 	github.com/vishvananda/netlink v1.3.0
-	github.com/vmware/go-ipfix v0.11.0
+	github.com/vmware/go-ipfix v0.12.0
 	go.uber.org/mock v0.5.0
 	golang.org/x/crypto v0.31.0
 	golang.org/x/mod v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -758,8 +758,8 @@ github.com/vishvananda/netlink v1.3.0/go.mod h1:i6NetklAujEcC6fK0JPjT8qSwWyO0HLn
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/vishvananda/netns v0.0.4 h1:Oeaw1EM2JMxD51g9uhtC0D7erkIjgmj8+JZc26m1YX8=
 github.com/vishvananda/netns v0.0.4/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
-github.com/vmware/go-ipfix v0.11.0 h1:565fzCjcOCaz0vjvckhJPXxV0fJ17ASzXZgirvdhcN4=
-github.com/vmware/go-ipfix v0.11.0/go.mod h1:R5S48rZai8OSJy4YCuNhAskB/ljEay02KX/GJFVBBeU=
+github.com/vmware/go-ipfix v0.12.0 h1:a4YXeCWTa251aZO7u7e9dKDOoU2eHJID45SPlq9j+HI=
+github.com/vmware/go-ipfix v0.12.0/go.mod h1:9PiutVWLhQQ6WHncRrGkH0i2Rx82DEOKhu80VSd9jds=
 github.com/wlynxg/anet v0.0.3/go.mod h1:eay5PRQr7fIVAMbTbchTnO9gG65Hg/uYGdc7mguHxoA=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=

--- a/pkg/agent/flowexporter/exporter/exporter.go
+++ b/pkg/agent/flowexporter/exporter/exporter.go
@@ -421,7 +421,7 @@ func (exp *FlowExporter) sendTemplateSet(isIPv6 bool) (int, error) {
 	if err := exp.ipfixSet.PrepareSet(ipfixentities.Template, templateID); err != nil {
 		return 0, err
 	}
-	err := exp.ipfixSet.AddRecord(elements, templateID)
+	err := exp.ipfixSet.AddRecordV2(elements, templateID)
 	if err != nil {
 		return 0, fmt.Errorf("error in adding record to template set: %v", err)
 	}
@@ -596,7 +596,7 @@ func (exp *FlowExporter) addConnToSet(conn *flowexporter.Connection) error {
 			ie.SetStringValue(conn.EgressNodeName)
 		}
 	}
-	err := exp.ipfixSet.AddRecord(eL, templateID)
+	err := exp.ipfixSet.AddRecordV2(eL, templateID)
 	if err != nil {
 		return fmt.Errorf("error in adding record to data set: %v", err)
 	}

--- a/pkg/agent/flowexporter/exporter/exporter_test.go
+++ b/pkg/agent/flowexporter/exporter/exporter_test.go
@@ -112,9 +112,9 @@ func sendTemplateSet(t *testing.T, ctrl *gomock.Controller, mockIPFIXExpProc *ip
 		mockIPFIXRegistry.EXPECT().GetInfoElement(ie, ipfixregistry.AntreaEnterpriseID).Return(elemList[i+len(ianaIE)+len(IANAReverseInfoElements)].GetInfoElement(), nil)
 	}
 	if !isIPv6 {
-		mockTempSet.EXPECT().AddRecord(elemList, testTemplateIDv4).Return(nil)
+		mockTempSet.EXPECT().AddRecordV2(elemList, testTemplateIDv4).Return(nil)
 	} else {
-		mockTempSet.EXPECT().AddRecord(elemList, testTemplateIDv6).Return(nil)
+		mockTempSet.EXPECT().AddRecordV2(elemList, testTemplateIDv6).Return(nil)
 	}
 	// Passing 0 for sentBytes as it is not used anywhere in the test. If this not a call to mock, the actual sentBytes
 	// above elements: IANAInfoElements, IANAReverseInfoElements and AntreaInfoElements.
@@ -248,7 +248,7 @@ func testSendDataSet(t *testing.T, v4Enabled bool, v6Enabled bool) {
 	sendDataSet := func(elemList []ipfixentities.InfoElementWithValue, templateID uint16, conn flowexporter.Connection) {
 		mockDataSet.EXPECT().ResetSet()
 		mockDataSet.EXPECT().PrepareSet(ipfixentities.Data, templateID).Return(nil)
-		mockDataSet.EXPECT().AddRecord(ElementListMatcher(elemList), templateID).Return(nil)
+		mockDataSet.EXPECT().AddRecordV2(ElementListMatcher(elemList), templateID).Return(nil)
 		mockIPFIXExpProc.EXPECT().SendSet(mockDataSet).Return(0, nil)
 
 		err := flowExp.addConnToSet(&conn)
@@ -702,10 +702,10 @@ func runSendFlowRecordTests(t *testing.T, flowExp *FlowExporter, isIPv6 bool) {
 			mockDataSet.EXPECT().ResetSet()
 			if !isIPv6 {
 				mockDataSet.EXPECT().PrepareSet(ipfixentities.Data, flowExp.templateIDv4).Return(nil)
-				mockDataSet.EXPECT().AddRecord(flowExp.elementsListv4, flowExp.templateIDv4).Return(nil)
+				mockDataSet.EXPECT().AddRecordV2(flowExp.elementsListv4, flowExp.templateIDv4).Return(nil)
 			} else {
 				mockDataSet.EXPECT().PrepareSet(ipfixentities.Data, flowExp.templateIDv6).Return(nil)
-				mockDataSet.EXPECT().AddRecord(flowExp.elementsListv6, flowExp.templateIDv6).Return(nil)
+				mockDataSet.EXPECT().AddRecordV2(flowExp.elementsListv6, flowExp.templateIDv6).Return(nil)
 			}
 			mockIPFIXExpProc.EXPECT().SendSet(mockDataSet).Return(0, nil)
 			_, err := flowExp.sendFlowRecords()

--- a/pkg/flowaggregator/exporter/ipfix.go
+++ b/pkg/flowaggregator/exporter/ipfix.go
@@ -168,7 +168,7 @@ func (e *IPFIXExporter) sendRecord(record ipfixentities.Record, isRecordIPv6 boo
 	if err := e.set.PrepareSet(ipfixentities.Data, templateID); err != nil {
 		return err
 	}
-	if err := e.set.AddRecord(record.GetOrderedElementList(), templateID); err != nil {
+	if err := e.set.AddRecordV2(record.GetOrderedElementList(), templateID); err != nil {
 		return err
 	}
 	sentBytes, err := e.exportingProcess.SendSet(e.set)
@@ -331,7 +331,7 @@ func (e *IPFIXExporter) sendTemplateSet(isIPv6 bool) (int, error) {
 	if err := e.set.PrepareSet(ipfixentities.Template, templateID); err != nil {
 		return 0, err
 	}
-	err := e.set.AddRecord(elements, templateID)
+	err := e.set.AddRecordV2(elements, templateID)
 	if err != nil {
 		return 0, fmt.Errorf("error when adding record to set, error: %v", err)
 	}

--- a/pkg/flowaggregator/exporter/ipfix_test.go
+++ b/pkg/flowaggregator/exporter/ipfix_test.go
@@ -76,7 +76,7 @@ func TestIPFIXExporter_sendTemplateSet(t *testing.T) {
 		}
 		mockTempSet.EXPECT().ResetSet()
 		mockTempSet.EXPECT().PrepareSet(ipfixentities.Template, testTemplateID).Return(nil)
-		mockTempSet.EXPECT().AddRecord(elemList, testTemplateID).Return(nil)
+		mockTempSet.EXPECT().AddRecordV2(elemList, testTemplateID).Return(nil)
 		// Passing 0 for sentBytes as it is not used anywhere in the test. If this not a call to mock, the actual sentBytes
 		// above elements: ianaInfoElements, ianaReverseInfoElements and antreaInfoElements.
 		mockIPFIXExpProc.EXPECT().SendSet(mockTempSet).Return(0, nil)
@@ -93,7 +93,7 @@ func TestIPFIXExporter_UpdateOptions(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	mockIPFIXExpProc := ipfixtesting.NewMockIPFIXExportingProcess(ctrl)
-	mockTempSet := ipfixentitiestesting.NewMockSet(ctrl)
+	mockSet := ipfixentitiestesting.NewMockSet(ctrl)
 	mockRecord := ipfixentitiestesting.NewMockRecord(ctrl)
 
 	// we override the initIPFIXExportingProcess var function: it will
@@ -124,17 +124,17 @@ func TestIPFIXExporter_UpdateOptions(t *testing.T) {
 		externalFlowCollectorProto: "",
 		templateIDv4:               testTemplateIDv4,
 		templateIDv6:               testTemplateIDv6,
-		set:                        mockTempSet,
+		set:                        mockSet,
 		observationDomainID:        testObservationDomainID,
 	}
 	testTemplateID := testTemplateIDv4
 
 	setCount := 0
-	mockTempSet.EXPECT().ResetSet().Times(2)
-	mockTempSet.EXPECT().PrepareSet(gomock.Any(), testTemplateID).Return(nil).Times(2)
+	mockSet.EXPECT().ResetSet().Times(2)
+	mockSet.EXPECT().PrepareSet(gomock.Any(), testTemplateID).Return(nil).Times(2)
 	mockRecord.EXPECT().GetOrderedElementList().Return(nil).Times(2)
-	mockTempSet.EXPECT().AddRecord(gomock.Any(), testTemplateID).Return(nil).Times(2)
-	mockIPFIXExpProc.EXPECT().SendSet(mockTempSet).Do(func(set interface{}) {
+	mockSet.EXPECT().AddRecordV2(gomock.Any(), testTemplateID).Return(nil).Times(2)
+	mockIPFIXExpProc.EXPECT().SendSet(mockSet).Do(func(set interface{}) {
 		setCount += 1
 	}).Return(0, nil).Times(2)
 	// connection will be closed when updating the external flow collector address
@@ -170,7 +170,7 @@ func TestIPFIXExporter_AddRecord(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	mockIPFIXExpProc := ipfixtesting.NewMockIPFIXExportingProcess(ctrl)
-	mockTempSet := ipfixentitiestesting.NewMockSet(ctrl)
+	mockSet := ipfixentitiestesting.NewMockSet(ctrl)
 	mockRecord := ipfixentitiestesting.NewMockRecord(ctrl)
 
 	initIPFIXExportingProcessSaved := initIPFIXExportingProcess
@@ -187,16 +187,16 @@ func TestIPFIXExporter_AddRecord(t *testing.T) {
 		externalFlowCollectorProto: "",
 		templateIDv4:               testTemplateIDv4,
 		templateIDv6:               testTemplateIDv6,
-		set:                        mockTempSet,
+		set:                        mockSet,
 		observationDomainID:        testObservationDomainID,
 	}
 	testTemplateID := testTemplateIDv4
 
-	mockTempSet.EXPECT().ResetSet()
-	mockTempSet.EXPECT().PrepareSet(gomock.Any(), testTemplateID).Return(nil)
+	mockSet.EXPECT().ResetSet()
+	mockSet.EXPECT().PrepareSet(gomock.Any(), testTemplateID).Return(nil)
 	mockRecord.EXPECT().GetOrderedElementList().Return(nil)
-	mockTempSet.EXPECT().AddRecord(gomock.Any(), testTemplateID).Return(nil)
-	mockIPFIXExpProc.EXPECT().SendSet(mockTempSet).Return(0, nil)
+	mockSet.EXPECT().AddRecordV2(gomock.Any(), testTemplateID).Return(nil)
+	mockIPFIXExpProc.EXPECT().SendSet(mockSet).Return(0, nil)
 
 	assert.NoError(t, ipfixExporter.AddRecord(mockRecord, false))
 }
@@ -228,7 +228,7 @@ func TestIPFIXExporter_sendRecord_Error(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	mockIPFIXExpProc := ipfixtesting.NewMockIPFIXExportingProcess(ctrl)
-	mockTempSet := ipfixentitiestesting.NewMockSet(ctrl)
+	mockSet := ipfixentitiestesting.NewMockSet(ctrl)
 	mockRecord := ipfixentitiestesting.NewMockRecord(ctrl)
 
 	ipfixExporter := IPFIXExporter{
@@ -237,16 +237,16 @@ func TestIPFIXExporter_sendRecord_Error(t *testing.T) {
 		exportingProcess:           mockIPFIXExpProc,
 		templateIDv4:               testTemplateIDv4,
 		templateIDv6:               testTemplateIDv6,
-		set:                        mockTempSet,
+		set:                        mockSet,
 		observationDomainID:        testObservationDomainID,
 	}
 	testTemplateID := testTemplateIDv4
 
-	mockTempSet.EXPECT().ResetSet()
-	mockTempSet.EXPECT().PrepareSet(gomock.Any(), testTemplateID).Return(nil)
+	mockSet.EXPECT().ResetSet()
+	mockSet.EXPECT().PrepareSet(gomock.Any(), testTemplateID).Return(nil)
 	mockRecord.EXPECT().GetOrderedElementList().Return(nil)
-	mockTempSet.EXPECT().AddRecord(gomock.Any(), testTemplateID).Return(nil)
-	mockIPFIXExpProc.EXPECT().SendSet(mockTempSet).Return(0, fmt.Errorf("send error"))
+	mockSet.EXPECT().AddRecordV2(gomock.Any(), testTemplateID).Return(nil)
+	mockIPFIXExpProc.EXPECT().SendSet(mockSet).Return(0, fmt.Errorf("send error"))
 	mockIPFIXExpProc.EXPECT().CloseConnToCollector()
 
 	assert.Error(t, ipfixExporter.AddRecord(mockRecord, false))


### PR DESCRIPTION
We switch to more efficient versions of AddRecord, which generate fewer memory allocations.