### PR TITLE
Ensure that promote_secondaries is set on IPAssigner interfaces

### DIFF
--- a/pkg/agent/ipassigner/ip_assigner_linux.go
+++ b/pkg/agent/ipassigner/ip_assigner_linux.go
@@ -294,7 +294,6 @@ func getARPIgnoreForInterface(iface string) (int, error) {
 		return arpIgnore, nil
 	}
 	return arpIgnoreAll, nil
-
 }
 
 // ensureDummyDevice creates the dummy device if it doesn't exist.
@@ -306,7 +305,14 @@ func ensureDummyDevice(deviceName string) (netlink.Link, error) {
 	dummy := &netlink.Dummy{
 		LinkAttrs: netlink.LinkAttrs{Name: deviceName},
 	}
-	if err = netlink.LinkAdd(dummy); err != nil {
+	if err := netlink.LinkAdd(dummy); err != nil {
+		return nil, err
+	}
+	// When the primary IP address is removed from the interface, promote a corresponding secondary IP address
+	// instead of removing all the corresponding secondary IP addresses. Otherwise, the deletion of one IP address
+	// can trigger the automatic removal of all other IP addresses in the same subnet, if the deleted IP happens to
+	// be the primary (first one assigned chronologically).
+	if err := util.EnsurePromoteSecondariesOnInterface(deviceName); err != nil {
 		return nil, err
 	}
 	return dummy, nil
@@ -501,6 +507,13 @@ func (a *ipAssigner) getAssignee(subnetInfo *crdv1b1.SubnetInfo, createIfNotExis
 	// external interface when looking up the main table. To make it look up the custom table, we will need to restore
 	// the mark on the reply traffic and turn on src_valid_mark on this interface, which is more complicated.
 	if err := util.EnsureRPFilterOnInterface(name, 2); err != nil {
+		return nil, err
+	}
+	// When the primary IP address is removed from the interface, promote a corresponding secondary IP address
+	// instead of removing all the corresponding secondary IP addresses. Otherwise, the deletion of one IP address
+	// can trigger the automatic removal of all other IP addresses in the same subnet, if the deleted IP happens to
+	// be the primary (first one assigned chronologically).
+	if err := util.EnsurePromoteSecondariesOnInterface(name); err != nil {
 		return nil, err
 	}
 	as, err := a.addVLANAssignee(vlan, subnetInfo.VLAN)

--- a/pkg/agent/util/net_linux.go
+++ b/pkg/agent/util/net_linux.go
@@ -354,6 +354,11 @@ func EnsureRPFilterOnInterface(ifaceName string, value int) error {
 	return sysctl.EnsureSysctlNetValue(path, value)
 }
 
+func EnsurePromoteSecondariesOnInterface(ifaceName string) error {
+	path := fmt.Sprintf("ipv4/conf/%s/promote_secondaries", ifaceName)
+	return sysctl.EnsureSysctlNetValue(path, 1)
+}
+
 func getRoutesOnInterface(linkIndex int) ([]interface{}, error) {
 	link, err := netlinkUtil.LinkByIndex(linkIndex)
 	if err != nil {


### PR DESCRIPTION
The IPAssigner should ensure that the promote_secondaries sysctl variable is always set when creating an interface. This ensures that When the primary IP address is removed from the interface, a secondary IP address is promoted, instead of removing all the corresponding secondary IP addresses. Otherwise, the deletion of one IP address can trigger the automatic removal of all other IP addresses in the same subnet, if the deleted IP happens to be the primary (first one assigned chronologically). For example, this can affect the Egress feature (when EgressSeparateSubnet is used).

Fixes #6890