### PR TITLE
Automated cherry pick of #6898: Ensure that promote_secondaries is set on IPAssigner
#6900: Ensure correct sysctl values if VLAN iface exists in

### DIFF
--- a/pkg/agent/ipassigner/ip_assigner_linux.go
+++ b/pkg/agent/ipassigner/ip_assigner_linux.go
@@ -299,7 +299,6 @@ func getARPIgnoreForInterface(iface string) (int, error) {
 		return arpIgnore, nil
 	}
 	return arpIgnoreAll, nil
-
 }
 
 // ensureDummyDevice creates the dummy device if it doesn't exist.
@@ -311,7 +310,14 @@ func ensureDummyDevice(deviceName string) (netlink.Link, error) {
 	dummy := &netlink.Dummy{
 		LinkAttrs: netlink.LinkAttrs{Name: deviceName},
 	}
-	if err = netlink.LinkAdd(dummy); err != nil {
+	if err := netlink.LinkAdd(dummy); err != nil {
+		return nil, err
+	}
+	// When the primary IP address is removed from the interface, promote a corresponding secondary IP address
+	// instead of removing all the corresponding secondary IP addresses. Otherwise, the deletion of one IP address
+	// can trigger the automatic removal of all other IP addresses in the same subnet, if the deleted IP happens to
+	// be the primary (first one assigned chronologically).
+	if err := util.EnsurePromoteSecondariesOnInterface(deviceName); err != nil {
 		return nil, err
 	}
 	return dummy, nil
@@ -506,6 +512,13 @@ func (a *ipAssigner) getAssignee(subnetInfo *crdv1b1.SubnetInfo, createIfNotExis
 	// external interface when looking up the main table. To make it look up the custom table, we will need to restore
 	// the mark on the reply traffic and turn on src_valid_mark on this interface, which is more complicated.
 	if err := util.EnsureRPFilterOnInterface(name, 2); err != nil {
+		return nil, err
+	}
+	// When the primary IP address is removed from the interface, promote a corresponding secondary IP address
+	// instead of removing all the corresponding secondary IP addresses. Otherwise, the deletion of one IP address
+	// can trigger the automatic removal of all other IP addresses in the same subnet, if the deleted IP happens to
+	// be the primary (first one assigned chronologically).
+	if err := util.EnsurePromoteSecondariesOnInterface(name); err != nil {
 		return nil, err
 	}
 	as, err := a.addVLANAssignee(vlan, subnetInfo.VLAN)

--- a/pkg/agent/util/net_linux.go
+++ b/pkg/agent/util/net_linux.go
@@ -354,6 +354,11 @@ func EnsureRPFilterOnInterface(ifaceName string, value int) error {
 	return sysctl.EnsureSysctlNetValue(path, value)
 }
 
+func EnsurePromoteSecondariesOnInterface(ifaceName string) error {
+	path := fmt.Sprintf("ipv4/conf/%s/promote_secondaries", ifaceName)
+	return sysctl.EnsureSysctlNetValue(path, 1)
+}
+
 func getRoutesOnInterface(linkIndex int) ([]interface{}, error) {
 	link, err := netlinkUtil.LinkByIndex(linkIndex)
 	if err != nil {


### PR DESCRIPTION
Cherry pick of #6898 #6900 on release-2.1.

#6898: Ensure that promote_secondaries is set on IPAssigner
#6900: Ensure correct sysctl values if VLAN iface exists in

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.