### PR TITLE
Remove local ASN range limitation in BGPPolicy

### DIFF
--- a/build/charts/antrea/crds/bgppolicy.yaml
+++ b/build/charts/antrea/crds/bgppolicy.yaml
@@ -47,7 +47,7 @@ spec:
                 localASN:
                   type: integer
                   format: int32
-                  minimum: 64512
+                  minimum: 1
                   maximum: 65535
                 listenPort:
                   type: integer

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -351,7 +351,7 @@ spec:
                 localASN:
                   type: integer
                   format: int32
-                  minimum: 64512
+                  minimum: 1
                   maximum: 65535
                 listenPort:
                   type: integer

--- a/build/yamls/antrea-crds.yml
+++ b/build/yamls/antrea-crds.yml
@@ -346,7 +346,7 @@ spec:
                 localASN:
                   type: integer
                   format: int32
-                  minimum: 64512
+                  minimum: 1
                   maximum: 65535
                 listenPort:
                   type: integer

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -351,7 +351,7 @@ spec:
                 localASN:
                   type: integer
                   format: int32
-                  minimum: 64512
+                  minimum: 1
                   maximum: 65535
                 listenPort:
                   type: integer

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -351,7 +351,7 @@ spec:
                 localASN:
                   type: integer
                   format: int32
-                  minimum: 64512
+                  minimum: 1
                   maximum: 65535
                 listenPort:
                   type: integer

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -351,7 +351,7 @@ spec:
                 localASN:
                   type: integer
                   format: int32
-                  minimum: 64512
+                  minimum: 1
                   maximum: 65535
                 listenPort:
                   type: integer

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -351,7 +351,7 @@ spec:
                 localASN:
                   type: integer
                   format: int32
-                  minimum: 64512
+                  minimum: 1
                   maximum: 65535
                 listenPort:
                   type: integer

--- a/docs/bgp-policy.md
+++ b/docs/bgp-policy.md
@@ -81,8 +81,12 @@ as the effective BGPPolicy.
 
 ### LocalASN
 
-The `localASN` field defines the Autonomous System Number (ASN) that the local BGP process uses. The available private
-ASN range is `64512-65535`. The field is mandatory.
+The `localASN` field defines the Autonomous System Number (ASN) that the local BGP process uses. This field is mandatory
+and accepts values in the range of `1-65535`.
+
+Private ASNs, which are within the ranges 64512-65534 (16-bit), should be strictly limited to private networks or
+environments that do not peer with public ASNs. If public network connectivity is required, coordinate with your upstream
+provider to avoid issues caused by private ASN usage.
 
 ### ListenPort
 

--- a/pkg/apis/crd/v1alpha1/types.go
+++ b/pkg/apis/crd/v1alpha1/types.go
@@ -263,7 +263,7 @@ type BGPPolicySpec struct {
 	// will be effective and enforced; others serve as alternatives.
 	NodeSelector metav1.LabelSelector `json:"nodeSelector"`
 
-	// LocalASN is the AS number used by the BGP process. The available private AS number range is 64512-65535.
+	// LocalASN is the AS number used by the BGP process. It accepts values in the range of 1-65535.
 	LocalASN int32 `json:"localASN"`
 
 	// ListenPort is the port on which the BGP process listens, and the default value is 179.


### PR DESCRIPTION
Previously, for safety and internal using only purposes, the local ASN was restricted to the private range (64512-65535). However, based on user feedback, BGPPolicy may also be used to peer with public BGP ASNs. Therefore, this restriction is no longer justified.

To prevent potential misconfigurations that could disrupt BGP operations, we have added the follow paragraph to documentation to remind users of the implications of using unrestricted ASN ranges.

```
Private ASNs, which are within the ranges 64512-65534 (16-bit), should be strictly limited to private networks or
environments that do not peer with public ASNs. If public network connectivity is required, coordinate with your upstream
provider to avoid issues caused by private ASN usage.
```