### PR TITLE
Skip TestFQDNCacheMinTTL if cluster has Windows Nodes. Fixes #6891

### DIFF
--- a/test/e2e/antreapolicy_test.go
+++ b/test/e2e/antreapolicy_test.go
@@ -5303,6 +5303,13 @@ func testAntreaClusterNetworkPolicyStats(t *testing.T, data *TestData) {
 // by TestFQDNCacheMinTTL with 2 fqdnCacheMinTTL values where `0` represents a default value
 // when fqdnCacheMinTTL is unset .
 func TestFQDNCacheMinTTL(t *testing.T) {
+	skipIfAntreaPolicyDisabled(t)
+	skipIfHasWindowsNodes(t)
+	skipIfNotIPv4Cluster(t)
+	skipIfIPv6Cluster(t)
+	skipIfNotRequired(t, "mode-irrelevant")
+
+
 	t.Run("minTTLUnset", func(t *testing.T) { testWithFQDNCacheMinTTL(t, 0) })
 	t.Run("minTTL20s", func(t *testing.T) { testWithFQDNCacheMinTTL(t, 20) })
 }
@@ -5313,12 +5320,7 @@ func testWithFQDNCacheMinTTL(t *testing.T, fqdnCacheMinTTL int) {
 		dnsPort  = 53
 		dnsTTL   = 5
 	)
-
-	skipIfAntreaPolicyDisabled(t)
-	skipIfNotIPv4Cluster(t)
-	skipIfIPv6Cluster(t)
-	skipIfNotRequired(t, "mode-irrelevant")
-
+	
 	data, err := setupTest(t)
 	if err != nil {
 		t.Fatalf("Error when setting up test: %v", err)


### PR DESCRIPTION
The TestFQDNCacheMinTTL e2e test currently does not support Windows. We skip it if any Node in the test cluster is a Windows Node, which is also consistent with other AntreaPolicy e2e tests.

As @antoninbas suggested, I have relocated the skipX condition to the beginning of TestFQDNCacheMinTTL. Now, the skip condition will execute before any subset of TestFQDNCacheMinTTL, making testWithFQDNCacheMinTTL shorter and possibly more efficient.