### PR TITLE
Automated cherry pick of #6751: Update Jenkins Scripts for Testbed Migration (#6751)

### DIFF
--- a/test/e2e/vmagent_test.go
+++ b/test/e2e/vmagent_test.go
@@ -525,7 +525,7 @@ func testANPOnVMs(t *testing.T, data *TestData, vmList []vmInfo, osType string) 
 	})
 	// Test FQDN rules in ANP
 	t.Run("testANPOnExternalNodeWithFQDN", func(t *testing.T) {
-		testANPWithFQDN(t, data, "anp-vmagent-fqdn", namespace, *appliedToVM, []string{"www.facebook.com"}, []string{"docs.google.com"}, []string{"github.com"})
+		testANPWithFQDN(t, data, "anp-vmagent-fqdn", namespace, *appliedToVM, []string{"docs.amazon.com"}, []string{"docs.google.com"}, []string{"github.com"})
 	})
 }
 


### PR DESCRIPTION
Cherry pick of #6751 on release-2.1.

#6751: Update Jenkins Scripts for Testbed Migration (#6751)

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.