### PR TITLE
Automated cherry pick of #6742: Update finalizer of ResourceExport to be domain-qualified

### DIFF
--- a/multicluster/apis/multicluster/constants/constants.go
+++ b/multicluster/apis/multicluster/constants/constants.go
@@ -24,7 +24,8 @@ const (
 	ServiceImportKind              = "ServiceImport"
 	ClusterInfoKind                = "ClusterInfo"
 
-	ResourceExportFinalizer = "resourceexport.finalizers.antrea.io"
+	LegacyResourceExportFinalizer = "resourceexport.finalizers.antrea.io"
+	ResourceExportFinalizer       = "resourceexport.antrea.io/finalizer"
 
 	// ResourceExport labels.
 	SourceName      = "sourceName"

--- a/multicluster/apis/multicluster/v1alpha1/resourceexport_webhook.go
+++ b/multicluster/apis/multicluster/v1alpha1/resourceexport_webhook.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"slices"
+
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -53,16 +55,12 @@ func (r *ResourceExport) Default() {
 	if kindLabelVal, exists := r.Labels[constants.SourceKind]; !exists || kindLabelVal != constants.AntreaClusterNetworkPolicyKind {
 		r.Labels[constants.SourceKind] = constants.AntreaClusterNetworkPolicyKind
 	}
-	if r.DeletionTimestamp.IsZero() && !stringExistsInSlice(r.Finalizers, constants.ResourceExportFinalizer) {
+	// Add domain qualified finalizer for ResourceExports to avoid Kubernetes from reporting errors:
+	//  "prefer a domain-qualified finalizer name to avoid accidental conflicts with other finalizer writers"
+	// https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#finalizers
+	// Note for ResourceExports created before Antrea v2.2, LegacyResourceExportFinalizer may still be present
+	// and needs to be removed before a ResourceExport is deleted.
+	if r.DeletionTimestamp.IsZero() && !slices.Contains(r.Finalizers, constants.ResourceExportFinalizer) {
 		r.Finalizers = append(r.Finalizers, constants.ResourceExportFinalizer)
 	}
-}
-
-func stringExistsInSlice(slice []string, s string) bool {
-	for _, item := range slice {
-		if item == s {
-			return true
-		}
-	}
-	return false
 }

--- a/multicluster/controllers/multicluster/common/helper.go
+++ b/multicluster/controllers/multicluster/common/helper.go
@@ -42,25 +42,6 @@ func ToMCResourceName(originalResourceName string) string {
 	return AntreaMCSPrefix + originalResourceName
 }
 
-func StringExistsInSlice(slice []string, s string) bool {
-	for _, item := range slice {
-		if item == s {
-			return true
-		}
-	}
-	return false
-}
-
-func RemoveStringFromSlice(slice []string, s string) (result []string) {
-	for _, item := range slice {
-		if item == s {
-			continue
-		}
-		result = append(result, item)
-	}
-	return
-}
-
 func GetServiceEndpointSubset(svc *corev1.Service) corev1.EndpointSubset {
 	var epSubset corev1.EndpointSubset
 	for _, ip := range svc.Spec.ClusterIPs {

--- a/multicluster/controllers/multicluster/leader/clusterinfo_export_handler.go
+++ b/multicluster/controllers/multicluster/leader/clusterinfo_export_handler.go
@@ -24,12 +24,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/strings/slices"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"antrea.io/antrea/multicluster/apis/multicluster/constants"
 	mcsv1alpha1 "antrea.io/antrea/multicluster/apis/multicluster/v1alpha1"
-	"antrea.io/antrea/multicluster/controllers/multicluster/common"
 )
 
 func (r *ResourceExportReconciler) handleClusterInfo(ctx context.Context, req ctrl.Request, resExport mcsv1alpha1.ResourceExport) (ctrl.Result, error) {
@@ -41,7 +41,7 @@ func (r *ResourceExportReconciler) handleClusterInfo(ctx context.Context, req ct
 	}
 
 	if !resExport.DeletionTimestamp.IsZero() {
-		if common.StringExistsInSlice(resExport.Finalizers, constants.ResourceExportFinalizer) {
+		if slices.Contains(resExport.Finalizers, constants.LegacyResourceExportFinalizer) || slices.Contains(resExport.Finalizers, constants.ResourceExportFinalizer) {
 			err := r.Client.Delete(ctx, resImport, &client.DeleteOptions{})
 			if err == nil || apierrors.IsNotFound(err) {
 				return r.deleteResourceExport(&resExport)

--- a/multicluster/controllers/multicluster/leader/memberclusterannounce_controller.go
+++ b/multicluster/controllers/multicluster/leader/memberclusterannounce_controller.go
@@ -20,6 +20,7 @@ package leader
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sync"
 	"time"
 
@@ -93,7 +94,7 @@ func (r *MemberClusterAnnounceReconciler) Reconcile(ctx context.Context, req ctr
 	}
 
 	r.addOrUpdateMemberStatus(memberID)
-	if common.StringExistsInSlice(memberAnnounce.Finalizers, finalizer) {
+	if slices.Contains(memberAnnounce.Finalizers, finalizer) {
 		return ctrl.Result{}, nil
 	}
 	klog.InfoS("Adding finalizer to MemberClusterAnnounce", "MemberClusterAnnounce", klog.KObj(memberAnnounce))

--- a/multicluster/test/integration/resourceexport_controller_test.go
+++ b/multicluster/test/integration/resourceexport_controller_test.go
@@ -72,7 +72,7 @@ var _ = Describe("ResourceExport controller", func() {
 				constants.SourceClusterID: clusteraID,
 			},
 			Generation: 1,
-			Finalizers: []string{constants.ResourceExportFinalizer},
+			Finalizers: []string{constants.LegacyResourceExportFinalizer},
 		},
 		Spec: mcsv1alpha1.ResourceExportSpec{
 			ClusterID: clusteraID,
@@ -127,7 +127,7 @@ var _ = Describe("ResourceExport controller", func() {
 				constants.SourceClusterID: clusterbID,
 			},
 			Generation: 1,
-			Finalizers: []string{constants.ResourceExportFinalizer},
+			Finalizers: []string{constants.LegacyResourceExportFinalizer},
 		},
 		Spec: mcsv1alpha1.ResourceExportSpec{
 			ClusterID: clusterbID,


### PR DESCRIPTION
Cherry pick of #6742 on release-2.1.

#6742: Update finalizer of ResourceExport to be domain-qualified

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.