### PR TITLE
[FlowExporter] More efficient IP checks

### DIFF
--- a/cmd/antrea-agent/options.go
+++ b/cmd/antrea-agent/options.go
@@ -275,7 +275,10 @@ func (o *Options) validateAntreaProxyConfig(encapMode config.TrafficEncapModeTyp
 }
 
 func (o *Options) validateFlowExporterConfig() error {
-	if features.DefaultFeatureGate.Enabled(features.FlowExporter) {
+	if features.DefaultFeatureGate.Enabled(features.FlowExporter) && o.config.FlowExporter.Enable {
+		if features.DefaultFeatureGate.Enabled(features.AntreaIPAM) {
+			klog.InfoS("The FlowExporter feature does not support AntreaIPAM Pods")
+		}
 		host, port, proto, err := flowexport.ParseFlowCollectorAddr(o.config.FlowExporter.FlowCollectorAddr, defaultFlowCollectorPort, defaultFlowCollectorTransport)
 		if err != nil {
 			return err

--- a/pkg/agent/controller/noderoute/node_route_controller.go
+++ b/pkg/agent/controller/noderoute/node_route_controller.go
@@ -829,7 +829,7 @@ func (c *Controller) findPodSubnetForIP(ip netip.Addr) (netip.Prefix, bool) {
 
 // LookupIPInPodSubnets returns two boolean values. The first one indicates whether the IP can be
 // found in a PodCIDR for one of the cluster Nodes. The second one indicates whether the IP is used
-// as a gwateway IP. The second boolean value can only be true if the first one is true.
+// as a gateway IP. The second boolean value can only be true if the first one is true.
 func (c *Controller) LookupIPInPodSubnets(ip netip.Addr) (bool, bool) {
 	prefix, ok := c.findPodSubnetForIP(ip)
 	if !ok {
@@ -854,7 +854,7 @@ func getNodeMAC(node *corev1.Node) (net.HardwareAddr, error) {
 func cidrToPrefix(cidr *net.IPNet) (netip.Prefix, error) {
 	addr, ok := netip.AddrFromSlice(cidr.IP)
 	if !ok {
-		return netip.Prefix{}, fmt.Errorf("invalid IP in cidr: %v", cidr)
+		return netip.Prefix{}, fmt.Errorf("invalid IP in CIDR: %v", cidr)
 	}
 	size, _ := cidr.Mask.Size()
 	return addr.Prefix(size)

--- a/pkg/agent/flowexporter/exporter/exporter.go
+++ b/pkg/agent/flowexporter/exporter/exporter.go
@@ -648,16 +648,16 @@ func (exp *FlowExporter) findFlowType(conn flowexporter.Connection) uint8 {
 	srcIsPod, srcIsGw := exp.nodeRouteController.LookupIPInPodSubnets(conn.FlowKey.SourceAddress)
 	dstIsPod, dstIsGw := exp.nodeRouteController.LookupIPInPodSubnets(conn.FlowKey.DestinationAddress)
 	if srcIsGw || dstIsGw {
-		// This matches what we do in filterAntreaConns, but not sure whether this is the right thing to do.
-		// This ignores all flows to / from hostNetwork Pods.
+		// This matches what we do in filterAntreaConns but is more general as we consider
+		// remote gateways as well.
 		if klog.V(5).Enabled() {
-			klog.InfoS("Flows where the source or destination IP is a gateway IP are not exported")
+			klog.InfoS("Flows where the source or destination IP is a gateway IP will not be exported")
 		}
 		return flowTypeUnsupported
 	}
 	if !srcIsPod {
 		if klog.V(5).Enabled() {
-			klog.InfoS("Flows where the source is not a Pod are not exported")
+			klog.InfoS("Flows where the source is not a Pod will not be exported")
 		}
 		return flowTypeUnsupported
 	}

--- a/pkg/agent/util/net_windows.go
+++ b/pkg/agent/util/net_windows.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/Microsoft/go-winio"
 	"github.com/Microsoft/hcsshim"
-	"github.com/containernetworking/plugins/pkg/ip"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 
@@ -64,7 +63,7 @@ func GetNSPath(containerNetNS string) (string, error) {
 func CreateHNSNetwork(hnsNetName string, subnetCIDR *net.IPNet, nodeIP *net.IPNet, adapter *net.Interface) (*hcsshim.HNSNetwork, error) {
 	adapterMAC := adapter.HardwareAddr
 	adapterName := adapter.Name
-	gateway := ip.NextIP(subnetCIDR.IP.Mask(subnetCIDR.Mask))
+	gateway := GetGatewayIPForPodCIDR(subnetCIDR)
 	network := &hcsshim.HNSNetwork{
 		Name:               hnsNetName,
 		Type:               HNSNetworkType,


### PR DESCRIPTION
The FlowExporter in the Agent queries the NodeRouteController to determine whether the source / destination IPs are Pod IPs (NodeIPAM only). Prior to this change, these checks were expensive, involving an indexer lookup and conversions between different IP formats. The new implementation is about 10x faster, and performs no memory allocations.

The new implementation introduces a new set in the NodeRouteController, dedicated to storing all the PodCIDRs in the cluster. While I considered removing the dependency of the FlowExporter on the NodeRouteController altogether, it would have been a much bigger change. Additionally, in the long term, we could consider removing these checks from the FlowExporter altogether, and pushing the logic to the FlowAggregator.

We also make a few additional changes to the FlowExporter:
* more consistently ignore connections where the source / destination IP is a gateway IP
* classify Pod-to-Service traffic where the destination IP is not a Pod IP as Pod-to-External
* log a warning if FlowExporter is enabled alongside AntreaIPAM