### PR TITLE
Add error log if FlowAggregator mode is updated dynamically

### DIFF
--- a/pkg/flowaggregator/flowaggregator_test.go
+++ b/pkg/flowaggregator/flowaggregator_test.go
@@ -753,6 +753,7 @@ func TestFlowAggregator_Run(t *testing.T) {
 
 	makeOptions := func(config *flowaggregatorconfig.FlowAggregatorConfig) *options.Options {
 		return &options.Options{
+			AggregatorMode:          flowAggregator.aggregatorMode,
 			ActiveFlowRecordTimeout: flowAggregator.activeFlowRecordTimeout,
 			Config:                  config,
 		}


### PR DESCRIPTION
And ignore any additional config update.
A restart is required to change the mode.