### PR TITLE
Add checksum/config annotation to FlowAggregator

### DIFF
--- a/build/charts/flow-aggregator/templates/deployment.yaml
+++ b/build/charts/flow-aggregator/templates/deployment.yaml
@@ -12,6 +12,10 @@ spec:
       app: flow-aggregator
   template:
     metadata:
+      annotations:
+        # Automatically restart Pod if the ConfigMap changes
+        # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       labels:
         app: flow-aggregator
     spec:

--- a/build/yamls/flow-aggregator.yml
+++ b/build/yamls/flow-aggregator.yml
@@ -400,6 +400,8 @@ spec:
       app: flow-aggregator
   template:
     metadata:
+      annotations:
+        checksum/config: 5ba1a6d1b9d3b40e2ea26e37aa2bea38fda2558c20564873936472136651de37
       labels:
         app: flow-aggregator
     spec:


### PR DESCRIPTION
When updating the config with Helm, the annotation will be automatically updated and the FlowAggregator Pod will be recreated. This is consistent with the main Helm chart for Antrea.

Note that the FlowAggregator can handle some config changes "dynamically" (i.e., without a Pod restart), but not all config updates are supported and we may want to remove that partial support altogether in the future.

The annotation can also be updated manually to roll the Deployment (e.g, if Helm is not being used).