### PR TITLE
Automated cherry pick of #6944: Reconcile host-network Pods after agent is

### DIFF
--- a/pkg/agent/cniserver/pod_configuration.go
+++ b/pkg/agent/cniserver/pod_configuration.go
@@ -448,10 +448,6 @@ func (pc *podConfigurator) reconcile(pods []corev1.Pod, containerAccess *contain
 	var podWg sync.WaitGroup
 
 	for _, pod := range pods {
-		// Skip Pods for which we are not in charge of the networking.
-		if pod.Spec.HostNetwork {
-			continue
-		}
 		desiredPods.Insert(k8s.NamespacedName(pod.Namespace, pod.Name))
 		for _, podIP := range pod.Status.PodIPs {
 			desiredPodIPs.Insert(podIP.IP)

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -121,7 +121,7 @@ const (
 	flowAggregatorConfName   = "flow-aggregator.conf"
 
 	agnhostImage        = "registry.k8s.io/e2e-test-images/agnhost:2.40"
-	ToolboxImage        = "antrea/toolbox:1.3-0"
+	ToolboxImage        = "antrea/toolbox:1.4-0"
 	mcjoinImage         = "antrea/mcjoin:v2.9"
 	nginxImage          = "antrea/nginx:1.21.6-alpine"
 	iisImage            = "mcr.microsoft.com/windows/servercore/iis"


### PR DESCRIPTION
Cherry pick of #6944 on release-2.1.

#6944: Reconcile host-network Pods after agent is

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.