### PR TITLE
Add localhost for VMSwitch commands to avoid potential validation issue

### DIFF
--- a/build/charts/antrea-windows/conf/ovs/VMSwitchExtension-AntreaAgent.ps1
+++ b/build/charts/antrea-windows/conf/ovs/VMSwitchExtension-AntreaAgent.ps1
@@ -7,10 +7,10 @@ if ($net -ne $null) {
     switch ($VMSwitchExtension)
     {
         "enable" {
-            Enable-VMSwitchExtension -Name "Open vSwitch Extension" -VMSwitchName $networkName
+            Enable-VMSwitchExtension -Name "Open vSwitch Extension" -VMSwitchName $networkName -ComputerName localhost
         }
         "disable" {
-            Disable-VMSwitchExtension -Name "Open vSwitch Extension" -VMSwitchName $networkName
+            Disable-VMSwitchExtension -Name "Open vSwitch Extension" -VMSwitchName $networkName -ComputerName localhost
         }
     }
 }

--- a/build/yamls/antrea-windows-with-ovs.yml
+++ b/build/yamls/antrea-windows-with-ovs.yml
@@ -107,10 +107,10 @@ data:
         switch ($VMSwitchExtension)
         {
             "enable" {
-                Enable-VMSwitchExtension -Name "Open vSwitch Extension" -VMSwitchName $networkName
+                Enable-VMSwitchExtension -Name "Open vSwitch Extension" -VMSwitchName $networkName -ComputerName localhost
             }
             "disable" {
-                Disable-VMSwitchExtension -Name "Open vSwitch Extension" -VMSwitchName $networkName
+                Disable-VMSwitchExtension -Name "Open vSwitch Extension" -VMSwitchName $networkName -ComputerName localhost
             }
         }
     }
@@ -305,7 +305,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/agent-windows: 86f999cb18501659a52d982f20b3df5cdf666ffd849f50ed183c366e75d01ac5
+        checksum/agent-windows: cd61458cbe274d2d6117702c6220c55ae75b38b71806d18e569682998ff83d79
         checksum/windows-config: 4f07164f32afc61e20b4aef984a8781142e5d99f7c58f7581e4ccfeabb34855f
         microsoft.com/hostprocess-inherit-user: "true"
       labels:

--- a/hack/externalnode/install-vm.ps1
+++ b/hack/externalnode/install-vm.ps1
@@ -207,7 +207,7 @@ function Log($Info) {
 function ClearOVSConfig() {
     Log "Deleting OVS bridge $OVSBridge"
     try {
-        $adapterName = (Get-VMNetworkAdapter -ComputerName $(hostname.exe) -SwitchName $AntreaSwitch -ManagementOS).Name
+        $adapterName = (Get-VMNetworkAdapter -ComputerName localhost -SwitchName $AntreaSwitch -ManagementOS).Name
         ovs-vsctl.exe del-br $OVSBridge
     }  catch {
         Log "Failed to get VMSwitch $AntreaSwitch, rc $_"
@@ -215,7 +215,7 @@ function ClearOVSConfig() {
     }
 
     try {
-        Remove-VMSwitch -ComputerName $(hostname.exe) $AntreaSwitch  -Force
+        Remove-VMSwitch -ComputerName localhost $AntreaSwitch  -Force
     } catch {
         Log "Ignore error while removing VMSwitch, rc $_"
     }

--- a/hack/windows/Clean-AntreaNetwork.ps1
+++ b/hack/windows/Clean-AntreaNetwork.ps1
@@ -97,7 +97,7 @@ function clearOVSBridge() {
 }
 
 function ClearHnsNetwork() {
-    $vmSwitch = Get-VMSwitch -Name $AntreaHnsNetworkName -ErrorAction SilentlyContinue
+    $vmSwitch = Get-VMSwitch -Name $AntreaHnsNetworkName -ComputerName localhost -ErrorAction SilentlyContinue
     if ($vmSwitch -ne $null) {
         Write-Host "Remove vNICs"
         Remove-VMNetworkAdapter -SwitchName $AntreaHnsNetworkName -ManagementOS -Confirm:$false -ErrorAction SilentlyContinue
@@ -108,7 +108,7 @@ function ClearHnsNetwork() {
             Get-HnsNetwork -Id $hnsNetwork.Id | Remove-HnsNetwork -ErrorAction Continue
             Set-NetAdapterBinding -Name $uplink -ComponentID vms_pp -Enabled $false
         }
-        Remove-VMSwitch -Name $AntreaHnsNetworkName -Force -ErrorAction SilentlyContinue
+        Remove-VMSwitch -Name $AntreaHnsNetworkName -ComputerName localhost -Force -ErrorAction SilentlyContinue
     }
 }
 

--- a/hack/windows/Helper.psm1
+++ b/hack/windows/Helper.psm1
@@ -163,9 +163,9 @@ function New-KubeProxyServiceInterface {
         Write-Host "Network adapter $INTERFACE_TO_ADD_SERVICE_IP exists, exit."
         return
     }
-    if (!(Get-VMSwitch -ComputerName $(hostname) -Name $hnsSwitchName -ErrorAction SilentlyContinue)) {
+    if (!(Get-VMSwitch -ComputerName localhost -Name $hnsSwitchName -ErrorAction SilentlyContinue)) {
         Write-Host "Creating internal switch: $hnsSwitchName for kube-proxy"
-        New-VMSwitch -name $hnsSwitchName -SwitchType Internal
+        New-VMSwitch -name $hnsSwitchName -SwitchType Internal -ComputerName localhost
     }
     Write-Host "Creating network adapter: $INTERFACE_TO_ADD_SERVICE_IP for kube-proxy"
     [Environment]::SetEnvironmentVariable("INTERFACE_TO_ADD_SERVICE_IP", $INTERFACE_TO_ADD_SERVICE_IP, [System.EnvironmentVariableTarget]::Machine)
@@ -216,7 +216,7 @@ function Start-OVSServices {
     }
     # Try to cleanup ovsdb-server configurations if the antrea-hnsnetwork is not existing. Or ovs-vswitchd service
     # will can not get started.
-    if (!(Get-VMswitch -ComputerName $(hostname) -Name "antrea-hnsnetwork" -SwitchType External -ErrorAction SilentlyContinue)) {
+    if (!(Get-VMswitch -ComputerName localhost -Name "antrea-hnsnetwork" -SwitchType External -ErrorAction SilentlyContinue)) {
         & ovs-vsctl.exe --no-wait --if-exists del-br br-int
         if ($LASTEXITCODE) {
             return $false

--- a/hack/windows/Prepare-ServiceInterface.ps1
+++ b/hack/windows/Prepare-ServiceInterface.ps1
@@ -25,7 +25,7 @@ if (Get-NetAdapter -InterfaceAlias $INTERFACE_TO_ADD_SERVICE_IP -ErrorAction Sil
     return
 }
 [Environment]::SetEnvironmentVariable("INTERFACE_TO_ADD_SERVICE_IP", $INTERFACE_TO_ADD_SERVICE_IP, [System.EnvironmentVariableTarget]::Machine)
-$hnsSwitchName = $(Get-VMSwitch -ComputerName $(hostname) -SwitchType Internal).Name
+$hnsSwitchName = $(Get-VMSwitch -ComputerName localhost -SwitchType Internal).Name
 Add-VMNetworkAdapter -ManagementOS -Name $InterfaceAlias -SwitchName $hnsSwitchName
 Set-NetIPInterface -ifAlias $INTERFACE_TO_ADD_SERVICE_IP -Forwarding Enabled
 

--- a/pkg/agent/util/winnet/net_windows_test.go
+++ b/pkg/agent/util/winnet/net_windows_test.go
@@ -727,7 +727,7 @@ func TestAddVMSwitch(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			mockRunCommand(t, []string{fmt.Sprintf(`New-VMSwitch -Name "%s" -NetAdapterName "%s" -EnableEmbeddedTeaming $true -AllowManagementOS $true -ComputerName $(hostname)| Enable-VMSwitchExtension "%s"`, testVMSwitchName, testSwitchName, ovsExtensionName)}, "", tc.commandErr, false)
+			mockRunCommand(t, []string{fmt.Sprintf(`New-VMSwitch -Name "%s" -NetAdapterName "%s" -EnableEmbeddedTeaming $true -AllowManagementOS $true -ComputerName localhost| Enable-VMSwitchExtension "%s"`, testVMSwitchName, testSwitchName, ovsExtensionName)}, "", tc.commandErr, false)
 			gotErr := h.AddVMSwitch(testSwitchName, testVMSwitchName)
 			assert.Equal(t, tc.wantErr, gotErr)
 		})
@@ -752,7 +752,7 @@ func TestEnableVMSwitchOVSExtension(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			mockRunCommand(t, []string{fmt.Sprintf(`Get-VMSwitch -Name "%s" -ComputerName $(hostname)| Enable-VMSwitchExtension "%s"`, testVMSwitchName, ovsExtensionName)}, "", tc.commandErr, false)
+			mockRunCommand(t, []string{fmt.Sprintf(`Get-VMSwitch -Name "%s" -ComputerName localhost| Enable-VMSwitchExtension "%s"`, testVMSwitchName, ovsExtensionName)}, "", tc.commandErr, false)
 			gotErr := h.EnableVMSwitchOVSExtension(testVMSwitchName)
 			assert.Equal(t, tc.wantErr, gotErr)
 		})
@@ -786,7 +786,7 @@ func TestIsVMSwitchOVSExtensionEnabled(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			mockRunCommand(t, []string{fmt.Sprintf(`Get-VMSwitchExtension -VMSwitchName "%s" -ComputerName $(hostname) | ? Id -EQ "%s"`, testVMSwitchName, OVSExtensionID)}, tc.commandOut, tc.commandErr, false)
+			mockRunCommand(t, []string{fmt.Sprintf(`Get-VMSwitchExtension -VMSwitchName "%s" -ComputerName localhost | ? Id -EQ "%s"`, testVMSwitchName, OVSExtensionID)}, tc.commandOut, tc.commandErr, false)
 			res, gotErr := h.IsVMSwitchOVSExtensionEnabled(testVMSwitchName)
 			assert.Equal(t, tc.wantRes, res)
 			assert.Equal(t, tc.wantErr, gotErr)
@@ -795,7 +795,7 @@ func TestIsVMSwitchOVSExtensionEnabled(t *testing.T) {
 }
 
 func TestGetVMSwitchInterfaceName(t *testing.T) {
-	getVMCmd := fmt.Sprintf(`Get-VMSwitchTeam -Name "%s" | select NetAdapterInterfaceDescription |  Format-Table -HideTableHeaders`, testVMSwitchName)
+	getVMCmd := fmt.Sprintf(`Get-VMSwitchTeam -Name "%s" -ComputerName localhost | select NetAdapterInterfaceDescription |  Format-Table -HideTableHeaders`, testVMSwitchName)
 	getAdapterCmd := fmt.Sprintf(`Get-NetAdapter -InterfaceDescription "%s" | select Name | Format-Table -HideTableHeaders`, "test")
 	tests := []struct {
 		name       string
@@ -830,8 +830,8 @@ func TestGetVMSwitchInterfaceName(t *testing.T) {
 }
 
 func TestRemoveVMSwitch(t *testing.T) {
-	getCmd := fmt.Sprintf(`Get-VMSwitch -Name "%s" -ComputerName $(hostname)`, testVMSwitchName)
-	removeCmd := fmt.Sprintf(`Remove-VMSwitch -Name "%s" -ComputerName $(hostname) -Force`, testVMSwitchName)
+	getCmd := fmt.Sprintf(`Get-VMSwitch -Name "%s" -ComputerName localhost`, testVMSwitchName)
+	removeCmd := fmt.Sprintf(`Remove-VMSwitch -Name "%s" -ComputerName localhost -Force`, testVMSwitchName)
 	tests := []struct {
 		name       string
 		commandOut string

--- a/test/integration/agent/net_windows_test.go
+++ b/test/integration/agent/net_windows_test.go
@@ -72,7 +72,7 @@ func skipIfOVSExtensionNotInstalled(t *testing.T) {
 func createTestInterface(t *testing.T, name string) string {
 	skipIfHyperVDisabled(t)
 	t.Logf("Creating test vSwitch and adapter '%s'", name)
-	cmd := fmt.Sprintf("New-VMSwitch %s -SwitchType Internal", name)
+	cmd := fmt.Sprintf("New-VMSwitch %s -SwitchType Internal -ComputerName localhost", name)
 	_, err := ps.RunCommand(cmd)
 	require.NoError(t, err)
 	return adapterName(name)
@@ -86,7 +86,7 @@ func setTestInterfaceUp(t *testing.T, name string) int {
 
 func deleteTestInterface(t *testing.T, name string) {
 	t.Logf("Deleting test vSwitch '%s'", name)
-	cmd := fmt.Sprintf(`Remove-VMSwitch "%s" -Force`, name)
+	cmd := fmt.Sprintf(`Remove-VMSwitch "%s" -ComputerName localhost -Force`, name)
 	_, err := ps.RunCommand(cmd)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
fixes https://github.com/antrea-io/antrea/issues/6989

To prevent error caused by long host name in Active Directory validation, all VMSwitch-related
commands have been updated to add `-ComputerName localhost` explictly. This change ensures local
execution of commands without relying on external network resolution or authentication.
