### PR TITLE
[FlowAggregator] Accept configurations with no collector / sink

### DIFF
--- a/pkg/flowaggregator/options/options.go
+++ b/pkg/flowaggregator/options/options.go
@@ -19,6 +19,8 @@ import (
 	"net"
 	"time"
 
+	"k8s.io/klog/v2"
+
 	flowaggregatorconfig "antrea.io/antrea/pkg/config/flowaggregator"
 	"antrea.io/antrea/pkg/util/flowexport"
 	"antrea.io/antrea/pkg/util/yaml"
@@ -61,7 +63,7 @@ func LoadConfig(configBytes []byte) (*Options, error) {
 		return nil, fmt.Errorf("s3Uploader enabled without specifying bucket name")
 	}
 	if !opt.Config.FlowCollector.Enable && !opt.Config.ClickHouse.Enable && !opt.Config.S3Uploader.Enable && !opt.Config.FlowLogger.Enable {
-		return nil, fmt.Errorf("at least one collector / sink should be configured")
+		klog.InfoS("No collector / sink has been configured, so no flow data will be exported")
 	}
 	// Validate common parameters
 	if opt.Config.Mode != flowaggregatorconfig.AggregatorModeAggregate && opt.Config.Mode != flowaggregatorconfig.AggregatorModeProxy {


### PR DESCRIPTION
Prior to this change, the FlowAggregator would crash if the configuration didn't enable at least one collector (e.g., the IPFIX collector). While it was probably introduced to help identify misconfigurations easily, it seems like an unnecessary restriction. We should be able to deploy the FlowAggregator in such a way that IPFIX records are still received from Agents (and metrics are incremented), while discarding aggregated / proxied data instead of exporting it.