### PR TITLE
Fixed the cleanup failure

### DIFF
--- a/ci/kind/kind-setup.sh
+++ b/ci/kind/kind-setup.sh
@@ -565,6 +565,7 @@ function clean_kind {
       flock -x 200
 
       current_timestamp=$(date +%s)
+      touch ~/.antrea/.clusters.swp
       while IFS=' ' read -r name creationTimestamp; do
           if [[ -z "$name" || -z "$creationTimestamp" ]]; then
               continue


### PR DESCRIPTION
If all the clusters are cleaned up then .clusters.swp file is not created and it gives an error that file not present.