### PR TITLE
Fix glob pattern in codecov action (Kind tests)

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -118,7 +118,7 @@ jobs:
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        files: '*.cov.out*'
+        files: '**/*.cov.out'
         disable_search: true
         flags: kind-e2e-tests
         name: codecov-test-e2e-encap
@@ -188,7 +188,7 @@ jobs:
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        files: '*.cov.out*'
+        files: '**/*.cov.out'
         disable_search: true
         flags: kind-e2e-tests
         name: codecov-test-e2e-encap-non-default
@@ -260,7 +260,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: '*.cov.out*'
+          files: '**/*.cov.out'
           disable_search: true
           flags: kind-e2e-tests
           name: codecov-test-e2e-encap-all-features-enabled
@@ -323,7 +323,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: '*.cov.out*'
+          files: '**/*.cov.out'
           disable_search: true
           flags: kind-e2e-tests
           name: test-ipam-e2e-coverage
@@ -386,7 +386,7 @@ jobs:
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        files: '*.cov.out*'
+        files: '**/*.cov.out'
         disable_search: true
         flags: kind-e2e-tests
         name: codecov-test-e2e-noencap
@@ -449,7 +449,7 @@ jobs:
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        files: '*.cov.out*'
+        files: '**/*.cov.out'
         disable_search: true
         flags: kind-e2e-tests
         name: codecov-test-e2e-hybrid
@@ -524,7 +524,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: '*.cov.out*'
+          files: '**/*.cov.out'
           disable_search: true
           flags: kind-e2e-tests
           name: codecov-test-e2e-fa


### PR DESCRIPTION
The codecov CLI has been updated, and the glob translation logic is different. We need the '**' pattern to match the full path. See https://github.com/codecov/codecov-cli/pull/619

We also remove the trailing wildcard, as it seems that we only ever use the .cov.out suffix for these tests.