### PR TITLE
Improve maintainability for L7FlowExporterController

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -541,7 +541,7 @@ func run(o *Options) error {
 			ifaceStore,
 			localPodInformer.Get(),
 			namespaceInformer,
-			l7Reconciler,
+			l7Reconciler.StartSuricataOnce,
 		)
 		go l7FlowExporterController.Run(stopCh)
 	}

--- a/pkg/agent/controller/l7flowexporter/l7_flow_export_controller.go
+++ b/pkg/agent/controller/l7flowexporter/l7_flow_export_controller.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/klog/v2"
 
 	"antrea.io/antrea/pkg/agent/config"
-	"antrea.io/antrea/pkg/agent/controller/networkpolicy/l7engine"
 	"antrea.io/antrea/pkg/agent/interfacestore"
 	"antrea.io/antrea/pkg/agent/openflow"
 	"antrea.io/antrea/pkg/agent/types"
@@ -77,7 +76,7 @@ func NewL7FlowExporterController(
 	interfaceStore interfacestore.InterfaceStore,
 	podInformer cache.SharedIndexInformer,
 	namespaceInformer coreinformers.NamespaceInformer,
-	l7Reconciler *l7engine.Reconciler) *L7FlowExporterController {
+	suricataStartFunc func() error) *L7FlowExporterController {
 	l7c := &L7FlowExporterController{
 		ofClient:              ofClient,
 		interfaceStore:        interfaceStore,
@@ -87,7 +86,7 @@ func NewL7FlowExporterController(
 		namespaceInformer:     namespaceInformer.Informer(),
 		namespaceLister:       namespaceInformer.Lister(),
 		namespaceListerSynced: namespaceInformer.Informer().HasSynced,
-		startSuricataOnceFn:   l7Reconciler.StartSuricataOnce,
+		startSuricataOnceFn:   suricataStartFunc,
 		podToDirectionMap:     make(map[string]v1alpha2.Direction),
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
 			workqueue.NewTypedItemExponentialFailureRateLimiter[string](minRetryDelay, maxRetryDelay),

--- a/pkg/util/sync/sync_test.go
+++ b/pkg/util/sync/sync_test.go
@@ -38,13 +38,13 @@ func TestOnceWithNoError(t *testing.T) {
 	var wg sync.WaitGroup
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
-		go func(i int) {
+		go func() {
 			defer wg.Done()
 			err := onceWithNoError.Do(f)
 			if err != nil {
 				atomic.AddInt32(&errOccurred, 1)
 			}
-		}(i)
+		}()
 	}
 	wg.Wait()
 


### PR DESCRIPTION
It doesn't need to take the whole l7Reconciler as a parameter to be able to start it.