### PR TITLE
Automated cherry pick of #7013: Fix glob pattern in codecov action (Kind tests) (#7013)

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -118,7 +118,7 @@ jobs:
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        files: '*.cov.out*'
+        files: '**/*.cov.out'
         disable_search: true
         flags: kind-e2e-tests
         name: codecov-test-e2e-encap
@@ -188,7 +188,7 @@ jobs:
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        files: '*.cov.out*'
+        files: '**/*.cov.out'
         disable_search: true
         flags: kind-e2e-tests
         name: codecov-test-e2e-encap-non-default
@@ -260,7 +260,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: '*.cov.out*'
+          files: '**/*.cov.out'
           disable_search: true
           flags: kind-e2e-tests
           name: codecov-test-e2e-encap-all-features-enabled
@@ -323,7 +323,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: '*.cov.out*'
+          files: '**/*.cov.out'
           disable_search: true
           flags: kind-e2e-tests
           name: test-ipam-e2e-coverage
@@ -386,7 +386,7 @@ jobs:
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        files: '*.cov.out*'
+        files: '**/*.cov.out'
         disable_search: true
         flags: kind-e2e-tests
         name: codecov-test-e2e-noencap
@@ -449,7 +449,7 @@ jobs:
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        files: '*.cov.out*'
+        files: '**/*.cov.out'
         disable_search: true
         flags: kind-e2e-tests
         name: codecov-test-e2e-hybrid
@@ -524,7 +524,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: '*.cov.out*'
+          files: '**/*.cov.out'
           disable_search: true
           flags: kind-e2e-tests
           name: codecov-test-e2e-fa


### PR DESCRIPTION
Cherry pick of #7013 on release-2.3.

#7013: Fix glob pattern in codecov action (Kind tests) (#7013)

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.