### PR TITLE
Automated cherry pick of #6811: Bump codecov/codecov-action from 4 to 5 (#6811)
#6819: Fix codecov-action usage after upgrading to v5 (#6819)
#7013: Fix glob pattern in codecov action (Kind tests) (#7013)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Run unit tests
       run: make test-unit
     - name: Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: .coverage/coverage-unit.txt
@@ -73,7 +73,7 @@ jobs:
       - name: Run unit tests
         run: make test-unit
       - name: Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: .coverage/coverage-unit.txt
@@ -105,7 +105,7 @@ jobs:
           cd multicluster
           make test-integration
       - name: Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: .coverage/coverage-integration.txt,multicluster/.coverage/coverage-integration.txt

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -50,7 +50,7 @@ jobs:
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: .coverage/coverage-unit.txt
+        files: .coverage/coverage-unit.txt
         disable_search: true
         flags: unit-tests
         name: codecov-unit-test
@@ -76,7 +76,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: .coverage/coverage-unit.txt
+          files: .coverage/coverage-unit.txt
           disable_search: true
           flags: unit-tests
           name: codecov-unit-test

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -116,7 +116,7 @@ jobs:
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        files: '*.cov.out*'
+        files: '**/*.cov.out'
         disable_search: true
         flags: kind-e2e-tests
         name: codecov-test-e2e-encap
@@ -186,7 +186,7 @@ jobs:
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        files: '*.cov.out*'
+        files: '**/*.cov.out'
         disable_search: true
         flags: kind-e2e-tests
         name: codecov-test-e2e-encap-non-default
@@ -258,7 +258,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: '*.cov.out*'
+          files: '**/*.cov.out'
           disable_search: true
           flags: kind-e2e-tests
           name: codecov-test-e2e-encap-all-features-enabled
@@ -321,7 +321,7 @@ jobs:
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        files: '*.cov.out*'
+        files: '**/*.cov.out'
         disable_search: true
         flags: kind-e2e-tests
         name: codecov-test-e2e-noencap
@@ -384,7 +384,7 @@ jobs:
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        files: '*.cov.out*'
+        files: '**/*.cov.out'
         disable_search: true
         flags: kind-e2e-tests
         name: codecov-test-e2e-hybrid
@@ -459,7 +459,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: '*.cov.out*'
+          files: '**/*.cov.out'
           disable_search: true
           flags: kind-e2e-tests
           name: codecov-test-e2e-fa

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -116,7 +116,7 @@ jobs:
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: '*.cov.out*'
+        files: '*.cov.out*'
         disable_search: true
         flags: kind-e2e-tests
         name: codecov-test-e2e-encap
@@ -186,7 +186,7 @@ jobs:
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: '*.cov.out*'
+        files: '*.cov.out*'
         disable_search: true
         flags: kind-e2e-tests
         name: codecov-test-e2e-encap-non-default
@@ -258,7 +258,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: '*.cov.out*'
+          files: '*.cov.out*'
           disable_search: true
           flags: kind-e2e-tests
           name: codecov-test-e2e-encap-all-features-enabled
@@ -321,7 +321,7 @@ jobs:
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: '*.cov.out*'
+        files: '*.cov.out*'
         disable_search: true
         flags: kind-e2e-tests
         name: codecov-test-e2e-noencap
@@ -384,7 +384,7 @@ jobs:
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: '*.cov.out*'
+        files: '*.cov.out*'
         disable_search: true
         flags: kind-e2e-tests
         name: codecov-test-e2e-hybrid
@@ -459,7 +459,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: '*.cov.out*'
+          files: '*.cov.out*'
           disable_search: true
           flags: kind-e2e-tests
           name: codecov-test-e2e-fa

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -113,7 +113,7 @@ jobs:
         path: test-e2e-encap-coverage.tar.gz
         retention-days: 30
     - name: Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: '*.cov.out*'
@@ -183,7 +183,7 @@ jobs:
         path: test-e2e-encap-non-default-coverage.tar.gz
         retention-days: 30
     - name: Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: '*.cov.out*'
@@ -255,7 +255,7 @@ jobs:
           path: test-e2e-encap-all-features-enabled-coverage.tar.gz
           retention-days: 30
       - name: Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: '*.cov.out*'
@@ -318,7 +318,7 @@ jobs:
         path: test-e2e-noencap-coverage.tar.gz
         retention-days: 30
     - name: Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: '*.cov.out*'
@@ -381,7 +381,7 @@ jobs:
         path: test-e2e-hybrid-coverage.tar.gz
         retention-days: 30
     - name: Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: '*.cov.out*'
@@ -456,7 +456,7 @@ jobs:
           path: test-e2e-fa-coverage.tar.gz
           retention-days: 30
       - name: Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: '*.cov.out*'


### PR DESCRIPTION
Cherry pick of #6811 #6819 #7013 on release-2.1.

#6811: Bump codecov/codecov-action from 4 to 5 (#6811)
#6819: Fix codecov-action usage after upgrading to v5 (#6819)
#7013: Fix glob pattern in codecov action (Kind tests) (#7013)

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.