### PR TITLE
Set AWS environment variables to access AWS resources

### DIFF
--- a/ci/test-conformance-eks.sh
+++ b/ci/test-conformance-eks.sh
@@ -193,6 +193,14 @@ function setup_eks() {
     export AWS_DEFAULT_OUTPUT=json
     export AWS_DEFAULT_REGION=$REGION
     if [[ "$AWS_SERVICE_USER_ROLE_ARN" != "" ]]; then
+      # Use AWS CLI to assume an IAM role and obtain temporary security credentials
+      # Source: AWS CLI Command Reference - https://docs.aws.amazon.com/cli/latest/reference/sts/assume-role.html
+      # When --duration-seconds is NOT specified, AWS uses DEFAULT VALUE: 3600 seconds (1 hour)
+      # Source: AWS STS AssumeRole API Documentation -
+      # https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html#API_AssumeRole_RequestParameters
+      # "By default, the value is set to 3600 seconds."
+      # From previous observations, this Jenkins job process has taken over an hour, usually within 1 hour and 10 minutes,
+      # so it's set to 2 hours here.
         TEMP_CRED=$(aws sts assume-role \
           --role-arn "$AWS_SERVICE_USER_ROLE_ARN" \
           --role-session-name "cli-session" \

--- a/ci/test-sriov-secondary-network-aws.sh
+++ b/ci/test-sriov-secondary-network-aws.sh
@@ -122,10 +122,19 @@ case $key in
 esac
 done
 
+set +ex
 export AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY
 export AWS_SECRET_ACCESS_KEY=$AWS_SECRET_KEY
 export AWS_DEFAULT_REGION=$REGION
 
+# Use AWS CLI to assume an IAM role and obtain temporary security credentials
+# Source: AWS CLI Command Reference - https://docs.aws.amazon.com/cli/latest/reference/sts/assume-role.html
+# When --duration-seconds is NOT specified, AWS uses DEFAULT VALUE: 3600 seconds (1 hour)
+# Source: AWS STS AssumeRole API Documentation -
+# https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html#API_AssumeRole_RequestParameters
+# "By default, the value is set to 3600 seconds."
+# From previous observations, this Jenkins job process has taken less than an hour, usually within 20 minutes,
+# so it's set to the default 1 hour here.
 TEMP_CRED=$(aws sts assume-role \
   --role-arn "$AWS_SERVICE_USER_ROLE_ARN" \
   --role-session-name "cli-session" \
@@ -135,6 +144,7 @@ TEMP_CRED=$(aws sts assume-role \
 export AWS_ACCESS_KEY_ID=$(echo "$TEMP_CRED" | jq -r .AccessKeyId)
 export AWS_SECRET_ACCESS_KEY=$(echo "$TEMP_CRED" | jq -r .SecretAccessKey)
 export AWS_SESSION_TOKEN=$(echo "$TEMP_CRED" | jq -r .SessionToken)
+set -ex
 
 THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 ANTREA_CHART="$THIS_DIR/../build/charts/antrea"


### PR DESCRIPTION
Set AWS environment variables to access AWS resources instead of writing the credentials to the Jenkins test machine. It would also simplify running this script locally from a dev machine.

see also: https://github.com/antrea-io/antrea/pull/6922#discussion_r1964852586

Advantages

- Avoids storing sensitive information on disk.  
- Temporary credentials expire automatically, providing enhanced security.  

test record: http://35.164.122.165/job/antrea-sriov-secondary-network-e2e-for-pull-request/29/
http://35.164.122.165/job/cloud-antrea-eks-conformance-net-policy/46
