### PR TITLE
Enhance Windows CI Compatibility with Different Docker Registry

### DIFF
--- a/build/images/Dockerfile.build.windows
+++ b/build/images/Dockerfile.build.windows
@@ -14,6 +14,7 @@
 
 ARG GO_VERSION
 ARG OVS_VERSION
+ARG DOCKER_REGISTRY="docker.io"
 
 FROM --platform=linux/amd64 golang:${GO_VERSION} AS antrea-build-windows
 ARG CNI_BINARIES_VERSION
@@ -43,7 +44,7 @@ RUN mkdir -p /go/k/antrea/bin && \
     cp /antrea/bin/antrea-cni.exe /go/k/antrea/cni/antrea.exe && \
     cp /antrea/hack/windows/Install-OVS.ps1 /go/k/antrea/
 
-FROM antrea/windows-ovs:${OVS_VERSION} AS antrea-ovs
+FROM ${DOCKER_REGISTRY}/antrea/windows-ovs:${OVS_VERSION} AS antrea-ovs
 
 FROM mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image:v1.0.0
 COPY --from=antrea-build-windows /go/k /k

--- a/build/images/build-windows.sh
+++ b/build/images/build-windows.sh
@@ -73,6 +73,9 @@ registry="antrea"
 image_name="antrea-windows"
 image="${registry}/${image_name}"
 BUILD_ARGS="--build-arg GO_VERSION=${GO_VERSION} --build-arg OVS_VERSION=${OVS_VERSION} --build-arg CNI_BINARIES_VERSION=${CNI_BINARIES_VERSION}"
+if [[ ${DOCKER_REGISTRY} != "" ]]; then
+    BUILD_ARGS+=" --build-arg DOCKER_REGISTRY=${DOCKER_REGISTRY}"
+fi
 
 ANTREA_DIR=${THIS_DIR}/../../
 pushd $ANTREA_DIR > /dev/null

--- a/build/images/ovs/build.sh
+++ b/build/images/ovs/build.sh
@@ -132,7 +132,12 @@ if $PULL; then
         docker pull $PLATFORM_ARG quay.io/centos/centos:stream9
         docker pull $PLATFORM_ARG registry.access.redhat.com/ubi9
     elif [ "$DISTRO" == "windows" ]; then
-        docker pull --platform linux/amd64 ubuntu:24.04
+        if [[ ${DOCKER_REGISTRY} == "" ]]; then
+            docker pull --platform linux/amd64 ubuntu:24.04
+        else
+            docker pull --platform linux/amd64 ${DOCKER_REGISTRY}/antrea/ubuntu:24.04
+            docker tag ${DOCKER_REGISTRY}/antrea/ubuntu:24.04 ubuntu:24.04
+        fi
     fi
 fi
 
@@ -163,6 +168,9 @@ elif [ "$DISTRO" == "ubi" ]; then
 elif [ "$DISTRO" == "windows" ]; then
     image="antrea/windows-ovs"
     build_args="--build-arg OVS_VERSION=$OVS_VERSION"
+    if [[ ${DOCKER_REGISTRY} != "" ]]; then
+        image="${DOCKER_REGISTRY}/antrea/windows-ovs"
+    fi
     docker_build_and_push_windows "${image}" "Dockerfile.windows" "${build_args}" "${OVS_VERSION}" $PUSH ""
 fi
 

--- a/ci/jenkins/test.sh
+++ b/ci/jenkins/test.sh
@@ -476,7 +476,7 @@ function deliver_antrea_linux {
 function deliver_antrea_windows {
     echo "===== Build Antrea Windows ====="
     rm -f antrea-windows.tar.gz
-    make build-windows
+    DOCKER_REGISTRY="${DOCKER_REGISTRY}" ./hack/build-antrea-windows-all.sh --pull
     if ! (test -f antrea-windows.tar); then
         echo "antrea-windows.tar wasn't built, exiting"
         exit 1
@@ -489,7 +489,7 @@ function deliver_antrea_windows {
         revert_snapshot_windows ${WORKER_NAME}
         k8s_images=("registry.k8s.io/e2e-test-images/agnhost:2.52" "registry.k8s.io/e2e-test-images/jessie-dnsutils:1.5" "registry.k8s.io/e2e-test-images/nginx:1.14-2" "registry.k8s.io/pause:3.10")
         conformance_images=("k8sprow.azurecr.io/kubernetes-e2e-test-images/agnhost:2.52" "k8sprow.azurecr.io/kubernetes-e2e-test-images/jessie-dnsutils:1.5" "k8sprow.azurecr.io/kubernetes-e2e-test-images/nginx:1.14-2" "registry.k8s.io/e2e-test-images/pause:3.10")
-        e2e_images=("${DOCKER_REGISTRY}/antrea/toolbox:1.4-0" "registry.k8s.io/e2e-test-images/agnhost:2.40")
+        e2e_images=("${DOCKER_REGISTRY}/antrea/toolbox:1.5-1" "registry.k8s.io/e2e-test-images/agnhost:2.40")
         # Pull necessary images in advance to avoid transient error
         for i in "${!k8s_images[@]}"; do
             ssh -o StrictHostKeyChecking=no -n Administrator@${IP} "ctr -n k8s.io images pull --user ${DOCKER_USERNAME}:${DOCKER_PASSWORD} ${k8s_images[i]} && ctr -n k8s.io images tag ${k8s_images[i]} ${conformance_images[i]}" || true

--- a/hack/build-antrea-windows-all.sh
+++ b/hack/build-antrea-windows-all.sh
@@ -86,6 +86,15 @@ cd build/images/ovs
 ./build.sh --distro windows $ARGS
 cd -
 
+GO_VERSION=$(head -n 1 build/images/deps/go-version)
+
+if [[ "${DOCKER_REGISTRY}" == "" ]]; then
+    docker pull --platform linux/amd64 golang:$GO_VERSION
+else
+    docker pull --platform linux/amd64 ${DOCKER_REGISTRY}/antrea/golang:$GO_VERSION
+    docker tag ${DOCKER_REGISTRY}/antrea/golang:$GO_VERSION $GO_VERSION
+fi
+
 if $PUSH_AGENT; then
     make build-and-push-windows
 else


### PR DESCRIPTION
When a user switches the Docker registry for image access, building Windows images still pulls images from the default registry. This patch improves compatibility for registry changes.