### PR TITLE
Push flow-aggregator image to ghcr.io registry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -255,23 +255,48 @@ jobs:
   build-flow-aggregator:
     needs: check-env
     if: ${{ needs.check-env.outputs.has_changes == 'yes' || github.event_name == 'push' }}
-    runs-on: [ubuntu-latest]
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_TAG: latest
     steps:
     - uses: actions/checkout@v4
       with:
         show-progress: false
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+      with:
+        driver: ${{ needs.check-env.outputs.docker_driver }}
     - name: Build flow-aggregator Docker image
       run: make flow-aggregator-image
     - name: Check flow-aggregator Docker image
       run: docker run antrea/flow-aggregator --version
-    - name: Push flow-aggregator Docker image to registry
+    - name: Login to Docker Hub
       if: ${{ needs.check-env.outputs.push_needed == 'true' }}
-      env:
-        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+    - name: Login to Github Container Registry
+      if: ${{ needs.check-env.outputs.push_needed == 'true' }}
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Push flow-aggregator Docker image to registries
+      if: ${{ needs.check-env.outputs.push_needed == 'true' }}
       run: |
-        echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-        docker push antrea/flow-aggregator:latest
+        targets=(
+          "docker.io antrea"
+          "ghcr.io antrea-io"
+        )
+        for target in "${targets[@]}"; do
+          t=($target)
+          registry="${t[0]}"
+          namespace="${t[1]}"
+          docker tag antrea/flow-aggregator:"${DOCKER_TAG}" ${registry}/${namespace}/flow-aggregator:"${DOCKER_TAG}"
+          docker push ${registry}/${namespace}/flow-aggregator:"${DOCKER_TAG}"
+        done
 
   build-antrea-migrator:
     needs: check-env

--- a/.github/workflows/build_tag.yml
+++ b/.github/workflows/build_tag.yml
@@ -108,8 +108,6 @@ jobs:
     steps:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
-      with:
-        driver: docker
     - name: Login to Docker Hub
       if: ${{ matrix.registry == 'docker.io' }}
       uses: docker/login-action@v3

--- a/.github/workflows/build_tag.yml
+++ b/.github/workflows/build_tag.yml
@@ -108,6 +108,8 @@ jobs:
     steps:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
+      with:
+        driver: docker
     - name: Login to Docker Hub
       if: ${{ matrix.registry == 'docker.io' }}
       uses: docker/login-action@v3
@@ -146,6 +148,8 @@ jobs:
           show-progress: false
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker
       - name: Build and push Antrea UBI9 amd64 Docker images to registry
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
@@ -194,19 +198,44 @@ jobs:
         docker push antrea/antrea-mc-controller:"${VERSION}"
 
   build-flow-aggregator:
-    runs-on: [ubuntu-latest]
     needs: get-version
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_TAG: ${{ needs.get-version.outputs.version }}
     steps:
     - uses: actions/checkout@v4
       with:
         ref: ${{ needs.get-version.outputs.antrea_ref }}
         show-progress: false
-    - name: Build flow-aggregator Docker image and push to registry
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+      with:
+        driver: docker
+    - name: Build flow-aggregator Docker image
       env:
-        DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-        DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         VERSION: ${{ needs.get-version.outputs.version }}
+      run: make flow-aggregator-image
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+    - name: Login to Github Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Push flow-aggregator Docker image to registries
       run: |
-        make flow-aggregator-image
-        echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-        docker push antrea/flow-aggregator:"${VERSION}"
+        targets=(
+          "docker.io antrea"
+          "ghcr.io antrea-io"
+        )
+        for target in "${targets[@]}"; do
+          t=($target)
+          registry="${t[0]}"
+          namespace="${t[1]}"
+          docker tag antrea/flow-aggregator:"${DOCKER_TAG}" ${registry}/${namespace}/flow-aggregator:"${DOCKER_TAG}"
+          docker push ${registry}/${namespace}/flow-aggregator:"${DOCKER_TAG}"
+        done


### PR DESCRIPTION
As an alternative to docker.io
This is the same change that we did previously for the "main" Antrea images (antrea-agent-ubuntu and antrea-controller-ubuntu).