### PR TITLE
Automated cherry pick of #7042: Fix crash when deleting the Secret storing BGP passwords

### DIFF
--- a/pkg/agent/controller/bgp/controller.go
+++ b/pkg/agent/controller/bgp/controller.go
@@ -923,7 +923,7 @@ func (c *Controller) updateBGPPeerPasswords(secret *corev1.Secret) {
 	defer c.bgpPeerPasswordsMutex.Unlock()
 
 	c.bgpPeerPasswords = make(map[string]string)
-	if secret.Data != nil {
+	if secret != nil && secret.Data != nil {
 		for k, v := range secret.Data {
 			c.bgpPeerPasswords[k] = string(v)
 		}


### PR DESCRIPTION
Cherry pick of #7042 on release-2.1.

#7042: Fix crash when deleting the Secret storing BGP passwords

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.