### PR TITLE
fix: batch probing in e2e test setup (#7067)

### DIFF
--- a/test/e2e/k8s_util.go
+++ b/test/e2e/k8s_util.go
@@ -1138,7 +1138,6 @@ func (hsr *httpServerReadiness) spawnProberPool(resultsCh chan *probeResult) {
 // Validates two way connectivity between all pods across all protocol and port permutations
 func (hsr *httpServerReadiness) validate() {
 	numProbes := hsr.numProbes()
-	// TODO: find better metrics, this is only for POC.
 	resultsCh := make(chan *probeResult, numProbes)
 	hsr.spawnProberPool(resultsCh)
 

--- a/test/e2e/k8s_util.go
+++ b/test/e2e/k8s_util.go
@@ -1201,29 +1201,14 @@ func (k *KubernetesUtils) Validate(allPods []Pod, reachability *Reachability, po
 }
 
 func (k *KubernetesUtils) ValidateRemoteCluster(remoteCluster *KubernetesUtils, allPods []Pod, reachability *Reachability, port int32, protocol utils.AntreaPolicyProtocol) {
-	numProbes := len(allPods) * len(allPods)
-	resultsCh := make(chan *probeResult, numProbes)
-	oneProbe := func(podFrom, podTo Pod, port int32) {
-		log.Tracef("Probing: %s -> %s", podFrom, podTo)
-		expectedResult := reachability.Expected.Get(podFrom.String(), podTo.String())
-		connectivity, err := k.Probe(podFrom.Namespace(), podFrom.PodName(), podTo.Namespace(), podTo.PodName(), port, protocol, remoteCluster, &expectedResult)
-		resultsCh <- &probeResult{podFrom, podTo, connectivity, err}
-	}
-	for _, pod1 := range allPods {
-		for _, pod2 := range allPods {
-			go oneProbe(pod1, pod2, port)
-		}
-	}
-	for i := 0; i < numProbes; i++ {
-		r := <-resultsCh
-		if r.err != nil {
-			log.Errorf("unable to perform probe %s -> %s in %s: %v", r.podFrom, r.podTo, k.ClusterName, r.err)
-		}
-		prevConn := reachability.Observed.Get(r.podFrom.String(), r.podTo.String())
-		if prevConn == Unknown {
-			reachability.Observe(r.podFrom, r.podTo, r.connectivity)
-		}
-	}
+	httpServerReadiness := k.newHttpServerReadiness(allPods,
+		map[utils.AntreaPolicyProtocol][]int32{
+			protocol: []int32{port},
+		},
+	)
+	httpServerReadiness.reachability = reachability
+	httpServerReadiness.remoteCluster = remoteCluster
+	httpServerReadiness.validateProtocol(protocol)
 }
 
 func (k *KubernetesUtils) Bootstrap(namespaces map[string]TestNamespaceMeta, podsPerNamespace []string, createNamespaces bool, nodeNames map[string]string, hostNetworks map[string]bool) (map[string][]string, error) {

--- a/test/e2e/k8s_util.go
+++ b/test/e2e/k8s_util.go
@@ -1108,7 +1108,7 @@ func (hsr *httpServerReadiness) numProbes() int {
 // Spawn a fixed set of workers to complete probing of the servers
 func (hsr *httpServerReadiness) spawnProberPool(resultsCh chan *probeResult) {
 	probes := make(chan probeVector, hsr.numProbes())
-	go hsr.buildProbeVectors(probes)
+	hsr.buildProbeVectors(probes)
 
 	probe := func(vector probeVector) {
 		podFrom := vector.fromPod

--- a/test/e2e/k8s_util.go
+++ b/test/e2e/k8s_util.go
@@ -1129,7 +1129,7 @@ func (hsr *httpServerReadiness) spawnProberPool(resultsCh chan *probeResult) {
 
 	// Tested value as the upper limit for running locally with minimal impacts to CI speeds
 	proberRateLimit := 150
-	for range proberRateLimit {
+	for range min(proberRateLimit, hsr.numProbes()) {
 		go startProber()
 	}
 }

--- a/test/e2e/k8s_util.go
+++ b/test/e2e/k8s_util.go
@@ -1107,7 +1107,8 @@ func (hsr *httpServerReadiness) numProbes() int {
 
 // Spawn a fixed set of workers to complete probing of the servers
 func (hsr *httpServerReadiness) spawnProberPool(resultsCh chan *probeResult) {
-	probes := make(chan probeVector, hsr.numProbes())
+	numProbes := hsr.numProbes()
+	probes := make(chan probeVector, numProbes)
 	hsr.buildProbeVectors(probes)
 
 	probe := func(vector probeVector) {
@@ -1129,7 +1130,7 @@ func (hsr *httpServerReadiness) spawnProberPool(resultsCh chan *probeResult) {
 
 	// Tested value as the upper limit for running locally with minimal impacts to CI speeds
 	proberRateLimit := 150
-	for range min(proberRateLimit, hsr.numProbes()) {
+	for range min(proberRateLimit, numProbes) {
 		go startProber()
 	}
 }

--- a/test/e2e/k8s_util.go
+++ b/test/e2e/k8s_util.go
@@ -1186,6 +1186,20 @@ func (hsr *httpServerReadiness) validateProtocol(protocol utils.AntreaPolicyProt
 	}
 }
 
+// Validate checks the connectivity between all Pods in both directions with a
+// list of ports and a protocol. The connectivity from a Pod to another Pod should
+// be consistent across all provided ports. Otherwise, this connectivity will be
+// treated as Error.
+func (k *KubernetesUtils) Validate(allPods []Pod, reachability *Reachability, ports []int32, protocol utils.AntreaPolicyProtocol) {
+	httpServerReadiness := k.newHttpServerReadiness(allPods,
+		map[utils.AntreaPolicyProtocol][]int32{
+			protocol: ports,
+		},
+	)
+	httpServerReadiness.reachability = reachability
+	httpServerReadiness.validateProtocol(protocol)
+}
+
 func (k *KubernetesUtils) ValidateRemoteCluster(remoteCluster *KubernetesUtils, allPods []Pod, reachability *Reachability, port int32, protocol utils.AntreaPolicyProtocol) {
 	numProbes := len(allPods) * len(allPods)
 	resultsCh := make(chan *probeResult, numProbes)


### PR DESCRIPTION
* On older machines, the tests `AntreaPolicyExtendedNamespaces` would fail but not on CI
  * The failure was due to the 1k+ simultaneous probes that the api-server would not handle
  * For that test the number of probes were ~1800:
    * n^2 x m
      * n = 5 namespace x 3 pods
        * squared for the nested for loop validating all pod to pod connections 
        * m = 8 ports
* Using a semaphore, the probing is rate limited by doing them in batches of 150
* Addresses (#7067)