### PR TITLE
Add networkstatus annotation to make secondarynetwork Pod IP visible

### DIFF
--- a/build/charts/antrea/templates/agent/clusterrole.yaml
+++ b/build/charts/antrea/templates/agent/clusterrole.yaml
@@ -39,6 +39,7 @@ rules:
       - pods/status
     verbs:
       - patch
+      - update
   - apiGroups:
       - ""
     resources:

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -4620,6 +4620,7 @@ rules:
       - pods/status
     verbs:
       - patch
+      - update
   - apiGroups:
       - ""
     resources:

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -4620,6 +4620,7 @@ rules:
       - pods/status
     verbs:
       - patch
+      - update
   - apiGroups:
       - ""
     resources:

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -4620,6 +4620,7 @@ rules:
       - pods/status
     verbs:
       - patch
+      - update
   - apiGroups:
       - ""
     resources:

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -4633,6 +4633,7 @@ rules:
       - pods/status
     verbs:
       - patch
+      - update
   - apiGroups:
       - ""
     resources:

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -4620,6 +4620,7 @@ rules:
       - pods/status
     verbs:
       - patch
+      - update
   - apiGroups:
       - ""
     resources:


### PR DESCRIPTION
related #7048 

Add Network Status Annotations for Pod to make Pod SecondaryNetwork IP visible. For example:
```
Annotations:        k8s.v1.cni.cncf.io/networks: macvlan-conf
                    k8s.v1.cni.cncf.io/network-status:
                      [{
                          "name": "cbr0",
                          "ips": [
                              "10.244.1.73"
                          ],
                          "default": true,
                          "dns": {}
                      },{
                          "name": "macvlan-conf",
                          "interface": "net1",
                          "ips": [
                              "192.168.1.205"
                          ],
                          "mac": "86:1d:96:ff:55:0d",
                          "dns": {}
                      }]
```

TestDone:    
kubectl get pods sriov-pod1  -n testsriovnetwork-uu5azxvs -oyaml
```
apiVersion: v1
kind: Pod
metadata:
  annotations:
    k8s.v1.cni.cncf.io/network-status: |-
      [{
          "name": "sriov-net1",
          "interface": "eth1",
          "ips": [
              "172.31.16.199"
          ],
          "mac": "02:1d:78:31:6f:c7",
          "dns": {}
      }]
    k8s.v1.cni.cncf.io/networks: '[{"name": "sriov-net1", "namespace": "default",
      "interface": "eth1"}]'
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"v1","kind":"Pod","metadata":{"annotations":{"k8s.v1.cni.cncf.io/networks":"[{\"name\": \"sriov-net1\", \"namespace\": \"default\", \"interface\": \"eth1\"}]"},"labels":{"App":"secondaryTest","antrea-e2e":"sriov-pod1","app":"toolbox"},"name":"sriov-pod1","namespace":"testsriovnetwork-uu5azxvs"},"spec":{"containers":[{"image":"antrea/toolbox:1.5-1","imagePullPolicy":"IfNotPresent","name":"toolbox","resources":{"limits":{"intel.com/intel_sriov_netdevice":"1"},"requests":{"intel.com/intel_sriov_netdevice":"1"}},"securityContext":{"privileged":false},"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","volumeMounts":[{"mountPath":"/var/run/secrets/kubernetes.io/serviceaccount","name":"kube-api-access-rllmk","readOnly":true}]}],"dnsPolicy":"ClusterFirst","enableServiceLinks":true,"nodeName":"ip-172-31-19-106","nodeSelector":{"kubernetes.io/hostname":"ip-172-31-19-106"},"preemptionPolicy":"PreemptLowerPriority","priority":0,"restartPolicy":"Never","schedulerName":"default-scheduler","securityContext":{},"serviceAccount":"default","serviceAccountName":"default","terminationGracePeriodSeconds":1,"tolerations":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/master","operator":"Exists"},{"effect":"NoSchedule","key":"node-role.kubernetes.io/control-plane","operator":"Exists"},{"effect":"NoExecute","key":"node.kubernetes.io/not-ready","operator":"Exists","tolerationSeconds":300},{"effect":"NoExecute","key":"node.kubernetes.io/unreachable","operator":"Exists","tolerationSeconds":300}],"volumes":[{"name":"kube-api-access-rllmk","projected":{"defaultMode":420,"sources":[{"serviceAccountToken":{"expirationSeconds":3607,"path":"token"}},{"configMap":{"items":[{"key":"ca.crt","path":"ca.crt"}],"name":"kube-root-ca.crt"}},{"downwardAPI":{"items":[{"fieldRef":{"apiVersion":"v1","fieldPath":"metadata.namespace"},"path":"namespace"}]}}]}}]}}
  creationTimestamp: "2025-03-25T15:23:07Z"
  labels:
    App: secondaryTest
    antrea-e2e: sriov-pod1
    app: toolbox
  name: sriov-pod1
  namespace: testsriovnetwork-uu5azxvs
  resourceVersion: "41832"
  uid: a1930238-342d-47e4-b15c-33c1e706800d
```
