### PR TITLE
docs: add GitHub PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,45 @@
+<!--
+  Thank you for your contribution to project Antrea!
+  Before contributing, please get familiar with our Code of Conduct and read the Contributor Guide. 
+-->
+
+<!-- if this PR is Work in Progress please create it as a Draft Pull Request -->
+
+## PR Type
+<!-- Check all that apply -->
+- [ ] Bug fix (non-breaking change)
+- [ ] New feature (non-breaking change)
+- [ ] Breaking change (fix/feature causing existing behavior to change)
+- [ ] Documentation update (standalone)
+- [ ] Code refactor (no functional changes)
+- [ ] Test cases (added/modified)
+- [ ] CI/CD changes
+- [ ] Other (please specify: ______)
+
+## Related Issues
+<!-- If you use an issue tracker, please put references to them -->
+**Resolves:** #  
+**See also:** #
+
+## Change Description
+<!-- 
+  Summarize changes in around 50 characters or less  
+  <BLANK LINE>
+  Details description if needed
+-->
+
+## Testing
+<!-- Describe the tests you ran and/or added to verify your changes -->
+- [ ] Added new unit tests
+- [ ] Added new integration tests
+- [ ] Ran existing test suite
+- [ ] Tested manually (please provide steps)
+
+## Checklist
+- [ ] Code follows project style guidelines
+- [ ] Unit/integration tests added/updated
+- [ ] Documentation updated
+- [ ] All tests pass (local & CI)
+
+## Additional Context
+*(Optional: follow-up tasks, special considerations)*


### PR DESCRIPTION
## Proposed Changes
Adds standardized PR template to improve contribution process with:
- Conventional commits guidance
- Structured change description format
- Explicit documentation update requirements

## Documentation Updates Required
- [x] Updated markdown docs (file path: .github/PULL_REQUEST_TEMPLATE.md)