### PR TITLE
Fix invalid ie registry id in docs

### DIFF
--- a/docs/network-flow-visibility.md
+++ b/docs/network-flow-visibility.md
@@ -151,7 +151,7 @@ There are 34 IPFIX IEs in each exported flow record, which are defined in the
 IANA-assigned IE registry, the Reverse IANA-assigned IE registry and the Antrea
 IE registry. The reverse IEs are used to provide bi-directional information about
 the flow. The Enterprise ID is 0 for IANA-assigned IE registry, 29305 for reverse
-IANA IE registry, 56505 for Antrea IE registry. All the IEs used by the Antrea
+IANA IE registry, 56506 for Antrea IE registry. All the IEs used by the Antrea
 Flow Exporter are listed below:
 
 #### IEs from IANA-assigned IE Registry


### PR DESCRIPTION
According to the IE registry at https://github.com/vmware/go-ipfix/blob/f5f76764c947db56138a2f0bb237534f3dd5387d/pkg/registry/registry.go#L26 the current value was incorrect.

I recently ran into this and after hours of troubleshooting I finally realized the docs are wrong. Hopefully this will prevent others from running into the same issue.