### PR TITLE
[7067 refactor part 2]: refactor GenPortsOrProtocols

### DIFF
--- a/test/e2e/antreaipam_anp_test.go
+++ b/test/e2e/antreaipam_anp_test.go
@@ -188,12 +188,14 @@ func testAntreaIPAMACNP(t *testing.T, protocol e2eutils.AntreaPolicyProtocol, ac
 		SetPriority(1.0).
 		SetAppliedToGroup([]e2eutils.ACNPAppliedToSpec{{PodSelector: map[string]string{"pod": "c"}}})
 	if isIngress {
-		builder.AddIngress(protocol, &p80, nil, nil, nil, nil, nil, nil, nil, map[string]string{}, nil,
-			nil, nil, nil, nil, nil, nil, ruleAction, "", "", nil)
-		builder2.AddIngress(protocol, &p80, nil, nil, nil, nil, nil, nil, nil, map[string]string{}, nil,
-			nil, nil, nil, nil, nil, nil, ruleAction, "", "", nil)
-		builder3.AddIngress(protocol, &p80, nil, nil, nil, nil, nil, nil, nil, map[string]string{}, nil,
-			nil, nil, nil, nil, nil, nil, ruleAction, "", "", nil)
+		ingressBuilder := e2eutils.IngressBuilder{
+			Protoc: protocol,
+			Port:   &p80,
+			Action: ruleAction,
+		}
+		builder.AddIngressFromBuilder(ingressBuilder)
+		builder2.AddIngressFromBuilder(ingressBuilder)
+		builder3.AddIngressFromBuilder(ingressBuilder)
 	} else {
 		builder.AddEgress(protocol, &p80, nil, nil, nil, nil, nil, nil, nil, map[string]string{}, nil,
 			nil, nil, nil, nil, nil, nil, ruleAction, "", "", nil)

--- a/test/e2e/antreaipam_anp_test.go
+++ b/test/e2e/antreaipam_anp_test.go
@@ -193,9 +193,9 @@ func testAntreaIPAMACNP(t *testing.T, protocol e2eutils.AntreaPolicyProtocol, ac
 			Port:   &p80,
 			Action: ruleAction,
 		}
-		builder.AddIngressFromBuilder(ingressBuilder)
-		builder2.AddIngressFromBuilder(ingressBuilder)
-		builder3.AddIngressFromBuilder(ingressBuilder)
+		builder.AddIngress(ingressBuilder)
+		builder2.AddIngress(ingressBuilder)
+		builder3.AddIngress(ingressBuilder)
 	} else {
 		builder.AddEgress(protocol, &p80, nil, nil, nil, nil, nil, nil, nil, map[string]string{}, nil,
 			nil, nil, nil, nil, nil, nil, ruleAction, "", "", nil)

--- a/test/e2e/antreaipam_anp_test.go
+++ b/test/e2e/antreaipam_anp_test.go
@@ -197,19 +197,19 @@ func testAntreaIPAMACNP(t *testing.T, protocol e2eutils.AntreaPolicyProtocol, ac
 		builder2.AddIngress(ingressBuilder)
 		builder3.AddIngress(ingressBuilder)
 	} else {
-		builder.AddEgressWithBuilder(e2eutils.IngressBuilder{
+		builder.AddEgress(e2eutils.IngressBuilder{
 			Protoc:      protocol,
 			Port:        &p80,
 			PodSelector: map[string]string{},
 			Action:      ruleAction,
 		})
-		builder2.AddEgressWithBuilder(e2eutils.IngressBuilder{
+		builder2.AddEgress(e2eutils.IngressBuilder{
 			Protoc:      protocol,
 			Port:        &p80,
 			PodSelector: map[string]string{},
 			Action:      ruleAction,
 		})
-		builder3.AddEgressWithBuilder(e2eutils.IngressBuilder{
+		builder3.AddEgress(e2eutils.IngressBuilder{
 			Protoc:      protocol,
 			Port:        &p80,
 			PodSelector: map[string]string{},

--- a/test/e2e/antreaipam_anp_test.go
+++ b/test/e2e/antreaipam_anp_test.go
@@ -197,12 +197,24 @@ func testAntreaIPAMACNP(t *testing.T, protocol e2eutils.AntreaPolicyProtocol, ac
 		builder2.AddIngress(ingressBuilder)
 		builder3.AddIngress(ingressBuilder)
 	} else {
-		builder.AddEgress(protocol, &p80, nil, nil, nil, nil, nil, nil, nil, map[string]string{}, nil,
-			nil, nil, nil, nil, nil, nil, ruleAction, "", "", nil)
-		builder2.AddEgress(protocol, &p80, nil, nil, nil, nil, nil, nil, nil, map[string]string{}, nil,
-			nil, nil, nil, nil, nil, nil, ruleAction, "", "", nil)
-		builder3.AddEgress(protocol, &p80, nil, nil, nil, nil, nil, nil, nil, map[string]string{}, nil,
-			nil, nil, nil, nil, nil, nil, ruleAction, "", "", nil)
+		builder.AddEgressWithBuilder(e2eutils.IngressBuilder{
+			Protoc:      protocol,
+			Port:        &p80,
+			PodSelector: map[string]string{},
+			Action:      ruleAction,
+		})
+		builder2.AddEgressWithBuilder(e2eutils.IngressBuilder{
+			Protoc:      protocol,
+			Port:        &p80,
+			PodSelector: map[string]string{},
+			Action:      ruleAction,
+		})
+		builder3.AddEgressWithBuilder(e2eutils.IngressBuilder{
+			Protoc:      protocol,
+			Port:        &p80,
+			PodSelector: map[string]string{},
+			Action:      ruleAction,
+		})
 	}
 
 	reachability := NewReachability(allPods, action)

--- a/test/e2e/antreapolicy_test.go
+++ b/test/e2e/antreapolicy_test.go
@@ -248,7 +248,7 @@ func testUpdateValidationInvalidACNP(t *testing.T) {
 	builder = builder.SetName("acnp-applied-to-update").
 		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}}}).
 		SetPriority(1.0)
-	builder.AddIngressFromBuilder(
+	builder.AddIngress(
 		IngressBuilder{
 			Protoc:      ProtocolTCP,
 			PodSelector: map[string]string{"pod": "b"},
@@ -259,7 +259,7 @@ func testUpdateValidationInvalidACNP(t *testing.T) {
 	if _, err := k8sUtils.CreateOrUpdateACNP(acnp); err != nil {
 		failOnError(fmt.Errorf("create ACNP acnp-applied-to-update failed: %v", err), t)
 	}
-	builder.AddIngressFromBuilder(
+	builder.AddIngress(
 		IngressBuilder{
 			Protoc:             ProtocolTCP,
 			PodSelector:        map[string]string{"pod": "c"},
@@ -423,7 +423,7 @@ func testACNPAllowXBtoA(t *testing.T) {
 	builder = builder.SetName("acnp-allow-xb-to-a").
 		SetPriority(1.0).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}}})
-	builder.AddIngressFromBuilder(
+	builder.AddIngress(
 		IngressBuilder{
 			Protoc:      ProtocolTCP,
 			Port:        &p80,
@@ -526,7 +526,7 @@ func testACNPAllowXBtoYA(t *testing.T) {
 	builder = builder.SetName("acnp-allow-xb-to-ya").
 		SetPriority(2.0).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}, NSSelector: map[string]string{"ns": getNS("y")}}})
-	builder.AddIngressFromBuilder(
+	builder.AddIngress(
 		IngressBuilder{
 			Protoc:      ProtocolTCP,
 			PortName:    &port81Name,
@@ -562,7 +562,7 @@ func testACNPPriorityOverrideDefaultDeny(t *testing.T, data *TestData) {
 	builder1 = builder1.SetName("acnp-priority2").
 		SetPriority(2).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{NSSelector: map[string]string{"ns": getNS("x")}}})
-	builder1.AddIngressFromBuilder(
+	builder1.AddIngress(
 		IngressBuilder{
 			Protoc:     ProtocolTCP,
 			Port:       &p80,
@@ -574,7 +574,7 @@ func testACNPPriorityOverrideDefaultDeny(t *testing.T, data *TestData) {
 	builder2 = builder2.SetName("acnp-priority1").
 		SetPriority(1).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}, NSSelector: map[string]string{"ns": getNS("x")}}})
-	builder2.AddIngressFromBuilder(
+	builder2.AddIngress(
 		IngressBuilder{
 			Protoc:     ProtocolTCP,
 			Port:       &p80,
@@ -627,7 +627,7 @@ func testACNPAllowNoDefaultIsolation(t *testing.T, protocol AntreaPolicyProtocol
 	builder = builder.SetName("acnp-allow-x-ingress-y-egress-z").
 		SetPriority(1.1).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{NSSelector: map[string]string{"ns": getNS("x")}}})
-	builder.AddIngressFromBuilder(
+	builder.AddIngress(
 		IngressBuilder{
 			Protoc:     protocol,
 			Port:       &p81,
@@ -698,7 +698,7 @@ func testACNPDropIngressInSelectedNamespace(t *testing.T) {
 	builder = builder.SetName("acnp-deny-ingress-to-x").
 		SetPriority(1.0).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{NSSelector: map[string]string{"ns": getNS("x")}}})
-	builder.AddIngressFromBuilder(
+	builder.AddIngress(
 		IngressBuilder{
 			Protoc: ProtocolTCP,
 			Port:   &p80,
@@ -785,7 +785,7 @@ func testACNPNoEffectOnOtherProtocols(t *testing.T) {
 	builder = builder.SetName("acnp-deny-a-to-z-ingress").
 		SetPriority(1.0).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}}})
-	builder.AddIngressFromBuilder(
+	builder.AddIngress(
 		IngressBuilder{
 			Protoc:     ProtocolTCP,
 			Port:       &p80,
@@ -839,7 +839,7 @@ func testACNPAppliedToDenyXBtoCGWithYA(t *testing.T) {
 	builder = builder.SetName("acnp-deny-cg-with-ya-from-xb").
 		SetPriority(2.0).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{Group: cgName}})
-	builder.AddIngressFromBuilder(
+	builder.AddIngress(
 		IngressBuilder{
 			Protoc:      ProtocolTCP,
 			PortName:    &port81Name,
@@ -880,7 +880,7 @@ func testACNPIngressRuleDenyCGWithXBtoYA(t *testing.T) {
 	builder = builder.SetName("acnp-deny-cg-with-xb-to-ya").
 		SetPriority(2.0).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}, NSSelector: map[string]string{"ns": getNS("y")}}})
-	builder.AddIngressFromBuilder(
+	builder.AddIngress(
 		IngressBuilder{
 			Protoc:           ProtocolTCP,
 			PortName:         &port81Name,
@@ -1223,14 +1223,14 @@ func testACNPClusterGroupRefRuleIPBlocks(t *testing.T) {
 				NSSelector:  map[string]string{"ns": getNS("y")},
 			},
 		})
-	builder.AddIngressFromBuilder(
+	builder.AddIngress(
 		IngressBuilder{
 			Protoc:           ProtocolTCP,
 			Port:             &p80,
 			Action:           crdv1beta1.RuleActionDrop,
 			RuleClusterGroup: cgName,
 		})
-	builder.AddIngressFromBuilder(
+	builder.AddIngress(
 		IngressBuilder{
 			Protoc:           ProtocolTCP,
 			Port:             &p80,
@@ -1794,7 +1794,7 @@ func testBaselineNamespaceIsolation(t *testing.T, data *TestData) {
 		SetTier("baseline").
 		SetPriority(1.0).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{NSSelector: map[string]string{"ns": getNS("x")}}})
-	builder.AddIngressFromBuilder(
+	builder.AddIngress(
 		IngressBuilder{
 			Protoc:             ProtocolTCP,
 			Port:               &p80,
@@ -1874,7 +1874,7 @@ func testACNPPriorityOverride(t *testing.T, data *TestData) {
 		SetPriority(1.001).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}, NSSelector: map[string]string{"ns": getNS("x")}}})
 	// Highest priority. Drops traffic from z/b to x/a.
-	builder1.AddIngressFromBuilder(
+	builder1.AddIngress(
 		IngressBuilder{
 			Protoc:      ProtocolTCP,
 			Port:        &p80,
@@ -1888,7 +1888,7 @@ func testACNPPriorityOverride(t *testing.T, data *TestData) {
 		SetPriority(1.002).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}, NSSelector: map[string]string{"ns": getNS("x")}}})
 	// Medium priority. Allows traffic from z to x/a.
-	builder2.AddIngressFromBuilder(
+	builder2.AddIngress(
 		IngressBuilder{
 			Protoc:     ProtocolTCP,
 			Port:       &p80,
@@ -1901,7 +1901,7 @@ func testACNPPriorityOverride(t *testing.T, data *TestData) {
 		SetPriority(1.003).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{NSSelector: map[string]string{"ns": getNS("x")}}})
 	// Lowest priority. Drops traffic from z to x.
-	builder3.AddIngressFromBuilder(
+	builder3.AddIngress(
 		IngressBuilder{
 			Protoc:     ProtocolTCP,
 			Port:       &p80,
@@ -1974,7 +1974,7 @@ func testACNPTierOverride(t *testing.T, data *TestData) {
 		SetPriority(100).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}, NSSelector: map[string]string{"ns": getNS("x")}}})
 	// Highest priority tier. Drops traffic from z/b to x/a.
-	builder1.AddIngressFromBuilder(
+	builder1.AddIngress(
 		IngressBuilder{
 			Protoc:      ProtocolTCP,
 			Port:        &p80,
@@ -1989,7 +1989,7 @@ func testACNPTierOverride(t *testing.T, data *TestData) {
 		SetPriority(10).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}, NSSelector: map[string]string{"ns": getNS("x")}}})
 	// Medium priority tier. Allows traffic from z to x/a.
-	builder2.AddIngressFromBuilder(
+	builder2.AddIngress(
 		IngressBuilder{
 			Protoc:     ProtocolTCP,
 			Port:       &p80,
@@ -2003,7 +2003,7 @@ func testACNPTierOverride(t *testing.T, data *TestData) {
 		SetPriority(1).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{NSSelector: map[string]string{"ns": getNS("x")}}})
 	// Lowest priority tier. Drops traffic from z to x.
-	builder3.AddIngressFromBuilder(
+	builder3.AddIngress(
 		IngressBuilder{
 			Protoc:     ProtocolTCP,
 			Port:       &p80,
@@ -2083,7 +2083,7 @@ func testACNPCustomTiers(t *testing.T, data *TestData) {
 		SetPriority(100).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}, NSSelector: map[string]string{"ns": getNS("x")}}})
 	// Medium priority tier. Allows traffic from z to x/a.
-	builder1.AddIngressFromBuilder(
+	builder1.AddIngress(
 		IngressBuilder{
 			Protoc:     ProtocolTCP,
 			Port:       &p80,
@@ -2097,7 +2097,7 @@ func testACNPCustomTiers(t *testing.T, data *TestData) {
 		SetPriority(1).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{NSSelector: map[string]string{"ns": getNS("x")}}})
 	// Lowest priority tier. Drops traffic from z to x.
-	builder2.AddIngressFromBuilder(
+	builder2.AddIngress(
 		IngressBuilder{
 			Protoc:     ProtocolTCP,
 			Port:       &p80,
@@ -2145,7 +2145,7 @@ func testACNPPriorityConflictingRule(t *testing.T, data *TestData) {
 	builder1 = builder1.SetName("acnp-drop").
 		SetPriority(1).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{NSSelector: map[string]string{"ns": getNS("x")}}})
-	builder1.AddIngressFromBuilder(
+	builder1.AddIngress(
 		IngressBuilder{
 			Protoc:     ProtocolTCP,
 			Port:       &p80,
@@ -2159,7 +2159,7 @@ func testACNPPriorityConflictingRule(t *testing.T, data *TestData) {
 		SetAppliedToGroup([]ACNPAppliedToSpec{{NSSelector: map[string]string{"ns": getNS("x")}}})
 	// The following ingress rule will take no effect as it is exactly the same as ingress rule of cnp-drop,
 	// but cnp-allow has lower priority.
-	builder2.AddIngressFromBuilder(
+	builder2.AddIngress(
 		IngressBuilder{
 			Protoc:     ProtocolTCP,
 			Port:       &p80,
@@ -2315,7 +2315,7 @@ func testACNPRejectIngress(t *testing.T, protocol AntreaPolicyProtocol) {
 	builder = builder.SetName("acnp-reject-a-from-z-ingress").
 		SetPriority(1.0).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}}})
-	builder.AddIngressFromBuilder(
+	builder.AddIngress(
 		IngressBuilder{
 			Protoc:     protocol,
 			Port:       &p80,
@@ -2403,7 +2403,7 @@ func testRejectServiceTraffic(t *testing.T, data *TestData, clientNamespace, ser
 	builder2 = builder2.SetName("acnp-reject-ingress-svc-traffic").
 		SetPriority(1.0).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: svc1.Spec.Selector}, {PodSelector: svc2.Spec.Selector}})
-	builder2.AddIngressFromBuilder(
+	builder2.AddIngress(
 		IngressBuilder{
 			Protoc:      ProtocolTCP,
 			Port:        &p80,
@@ -2499,14 +2499,14 @@ func testRejectNoInfiniteLoop(t *testing.T, data *TestData, clientNamespace, ser
 	builder1 := &ClusterNetworkPolicySpecBuilder{}
 	builder1 = builder1.SetName("acnp-reject-ingress-double-dir").
 		SetPriority(1.0)
-	builder1.AddIngressFromBuilder(
+	builder1.AddIngress(
 		IngressBuilder{
 			Protoc:             ProtocolTCP,
 			PodSelector:        map[string]string{"app": "nginx"},
 			RuleAppliedToSpecs: []ACNPAppliedToSpec{{PodSelector: map[string]string{"antrea-e2e": clientName}}},
 			Action:             crdv1beta1.RuleActionReject,
 		})
-	builder1.AddIngressFromBuilder(
+	builder1.AddIngress(
 		IngressBuilder{
 			Protoc:             ProtocolTCP,
 			PodSelector:        map[string]string{"antrea-e2e": clientName},
@@ -2532,7 +2532,7 @@ func testRejectNoInfiniteLoop(t *testing.T, data *TestData, clientNamespace, ser
 	builder3 = builder3.SetName("acnp-reject-server-double-dir").
 		SetPriority(1.0).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"app": "nginx"}}})
-	builder3.AddIngressFromBuilder(
+	builder3.AddIngress(
 		IngressBuilder{
 			Protoc:      ProtocolTCP,
 			PodSelector: map[string]string{"antrea-e2e": clientName},
@@ -2548,7 +2548,7 @@ func testRejectNoInfiniteLoop(t *testing.T, data *TestData, clientNamespace, ser
 	builder4 = builder4.SetName("acnp-reject-client-double-dir").
 		SetPriority(1.0).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"antrea-e2e": clientName}}})
-	builder4.AddIngressFromBuilder(
+	builder4.AddIngress(
 		IngressBuilder{
 			Protoc:      ProtocolTCP,
 			PodSelector: map[string]string{"app": "nginx"},
@@ -3078,7 +3078,7 @@ func testAppliedToPerRule(t *testing.T) {
 	cnpATGrp2 := ACNPAppliedToSpec{
 		PodSelector: map[string]string{"pod": "b"}, NSSelector: map[string]string{"ns": getNS("y")},
 		PodSelectorMatchExp: nil, NSSelectorMatchExp: nil}
-	builder2.AddIngressFromBuilder(
+	builder2.AddIngress(
 		IngressBuilder{
 			Protoc:             ProtocolTCP,
 			Port:               &p80,
@@ -3087,7 +3087,7 @@ func testAppliedToPerRule(t *testing.T) {
 			RuleAppliedToSpecs: []ACNPAppliedToSpec{cnpATGrp1},
 			Action:             crdv1beta1.RuleActionDrop,
 		})
-	builder2.AddIngressFromBuilder(
+	builder2.AddIngress(
 		IngressBuilder{
 			Protoc:             ProtocolTCP,
 			Port:               &p80,
@@ -3130,7 +3130,7 @@ func testACNPClusterGroupServiceRefCreateAndUpdate(t *testing.T, data *TestData)
 
 	builder := &ClusterNetworkPolicySpecBuilder{}
 	builder = builder.SetName("cnp-cg-svc-ref").SetPriority(1.0).SetAppliedToGroup([]ACNPAppliedToSpec{{Group: cg1Name}})
-	builder.AddIngressFromBuilder(
+	builder.AddIngress(
 		IngressBuilder{
 			Protoc:           ProtocolTCP,
 			Port:             &p80,
@@ -3185,7 +3185,7 @@ func testACNPClusterGroupServiceRefCreateAndUpdate(t *testing.T, data *TestData)
 	builderUpdated := &ClusterNetworkPolicySpecBuilder{}
 	builderUpdated = builderUpdated.SetName("cnp-cg-svc-ref").SetPriority(1.0)
 	builderUpdated.SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}, NSSelector: map[string]string{"ns": getNS("x")}}})
-	builderUpdated.AddIngressFromBuilder(
+	builderUpdated.AddIngress(
 		IngressBuilder{
 			Protoc:      ProtocolTCP,
 			Port:        &p80,
@@ -3231,7 +3231,7 @@ func testACNPNestedClusterGroupCreateAndUpdate(t *testing.T, data *TestData) {
 	builder := &ClusterNetworkPolicySpecBuilder{}
 	builder = builder.SetName("cnp-nested-cg").SetPriority(1.0).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{NSSelector: map[string]string{"ns": getNS("z")}}}).
-		AddIngressFromBuilder(
+		AddIngress(
 			IngressBuilder{
 				Protoc:           ProtocolTCP,
 				Port:             &p80,
@@ -3331,7 +3331,7 @@ func testACNPNestedIPBlockClusterGroupCreateAndUpdate(t *testing.T) {
 				NSSelector:  map[string]string{"ns": getNS("y")},
 			},
 		})
-	builder.AddIngressFromBuilder(
+	builder.AddIngress(
 		IngressBuilder{
 			Protoc:           ProtocolTCP,
 			Port:             &p80,
@@ -3381,13 +3381,13 @@ func testACNPNamespaceIsolation(t *testing.T) {
 		SetPriority(1.0).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{NSSelector: map[string]string{}}})
 	// deny ingress traffic except from own namespace, which is always allowed.
-	builder.AddIngressFromBuilder(
+	builder.AddIngress(
 		IngressBuilder{
 			Protoc:     ProtocolTCP,
 			Namespaces: selfNamespace,
 			Action:     crdv1beta1.RuleActionAllow,
 		})
-	builder.AddIngressFromBuilder(
+	builder.AddIngress(
 		IngressBuilder{
 			Protoc:     ProtocolTCP,
 			NsSelector: map[string]string{},
@@ -3441,13 +3441,13 @@ func testACNPStrictNamespacesIsolation(t *testing.T) {
 		SetTier("securityops").
 		SetPriority(1.0).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{NSSelector: map[string]string{}}})
-	builder.AddIngressFromBuilder(
+	builder.AddIngress(
 		IngressBuilder{
 			Protoc:     ProtocolTCP,
 			Namespaces: selfNamespace,
 			Action:     crdv1beta1.RuleActionPass,
 		})
-	builder.AddIngressFromBuilder(
+	builder.AddIngress(
 		IngressBuilder{
 			Protoc:     ProtocolTCP,
 			NsSelector: map[string]string{},
@@ -3496,13 +3496,13 @@ func testACNPStrictNamespacesIsolationByLabels(t *testing.T) {
 		SetTier("securityops").
 		SetPriority(1.0).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{NSSelector: map[string]string{}}})
-	builder.AddIngressFromBuilder(
+	builder.AddIngress(
 		IngressBuilder{
 			Protoc:     ProtocolTCP,
 			Namespaces: samePurposeTierLabels,
 			Action:     crdv1beta1.RuleActionPass,
 		})
-	builder.AddIngressFromBuilder(
+	builder.AddIngress(
 		IngressBuilder{
 			Protoc: ProtocolTCP,
 			Action: crdv1beta1.RuleActionDrop,
@@ -3547,13 +3547,13 @@ func testACNPStrictNamespacesIsolationBySingleLabel(t *testing.T, data *TestData
 		SetTier("securityops").
 		SetPriority(1.0).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{NSSelector: map[string]string{}}})
-	builder.AddIngressFromBuilder(
+	builder.AddIngress(
 		IngressBuilder{
 			Protoc:     ProtocolTCP,
 			Namespaces: samePurposeTierLabels,
 			Action:     crdv1beta1.RuleActionPass,
 		})
-	builder.AddIngressFromBuilder(
+	builder.AddIngress(
 		IngressBuilder{
 			Protoc: ProtocolTCP,
 			Action: crdv1beta1.RuleActionDrop,
@@ -3936,7 +3936,7 @@ func testServiceAccountSelector(t *testing.T, data *TestData) {
 	builder = builder.SetName("acnp-service-account").
 		SetPriority(1.0).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"antrea-e2e": serverName}}})
-	builder.AddIngressFromBuilder(
+	builder.AddIngress(
 		IngressBuilder{
 			Protoc:         ProtocolTCP,
 			Port:           &p80,
@@ -4258,7 +4258,7 @@ func testACNPNodePortServiceSupport(t *testing.T, data *TestData, serverNamespac
 				},
 			},
 		})
-	builder.AddIngressFromBuilder(
+	builder.AddIngress(
 		IngressBuilder{
 			Protoc:  ProtocolTCP,
 			IpBlock: ipb,
@@ -4354,7 +4354,7 @@ func testACNPIGMPQuery(t *testing.T, data *TestData, acnpName, caseName, groupAd
 
 	// create acnp with ingress rule for IGMP query
 	igmpType := crdv1beta1.IGMPQuery
-	builder.AddIngressFromBuilder(IngressBuilder{
+	builder.AddIngress(IngressBuilder{
 		Protoc:       ProtocolIGMP,
 		IgmpType:     &igmpType,
 		GroupAddress: &queryGroupAddress,
@@ -5006,7 +5006,7 @@ func TestAntreaPolicyStatus(t *testing.T) {
 	acnpBuilder = acnpBuilder.SetName("acnp-applied-to-two-nodes").
 		SetPriority(1.0).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"app": "nginx"}}})
-	acnpBuilder.AddIngressFromBuilder(
+	acnpBuilder.AddIngress(
 		IngressBuilder{
 			Protoc:      ProtocolTCP,
 			Port:        &p80,

--- a/test/e2e/antreapolicy_test.go
+++ b/test/e2e/antreapolicy_test.go
@@ -3294,10 +3294,17 @@ func testACNPStrictNamespacesIsolationByLabels(t *testing.T) {
 		SetTier("securityops").
 		SetPriority(1.0).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{NSSelector: map[string]string{}}})
-	builder.AddIngress(ProtocolTCP, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-		samePurposeTierLabels, nil, crdv1beta1.RuleActionPass, "", "", nil)
-	builder.AddIngress(ProtocolTCP, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{}, nil, nil, nil,
-		nil, nil, crdv1beta1.RuleActionDrop, "", "", nil)
+	builder.AddIngressFromBuilder(
+		IngressBuilder{
+			Protoc:     ProtocolTCP,
+			Namespaces: samePurposeTierLabels,
+			Action:     crdv1beta1.RuleActionPass,
+		})
+	builder.AddIngressFromBuilder(
+		IngressBuilder{
+			Protoc: ProtocolTCP,
+			Action: crdv1beta1.RuleActionDrop,
+		})
 	// prod1 and prod2 Namespaces should be able to connect to each other. The same goes for dev1 and
 	// dev2 Namespaces. However, any prod Namespace should not be able to connect to any dev Namespace
 	// due to different "tier" label values. For the "no-tier" Namespace, the first ingress rule will
@@ -3338,10 +3345,17 @@ func testACNPStrictNamespacesIsolationBySingleLabel(t *testing.T, data *TestData
 		SetTier("securityops").
 		SetPriority(1.0).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{NSSelector: map[string]string{}}})
-	builder.AddIngress(ProtocolTCP, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-		samePurposeTierLabels, nil, crdv1beta1.RuleActionPass, "", "", nil)
-	builder.AddIngress(ProtocolTCP, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{}, nil, nil, nil,
-		nil, nil, crdv1beta1.RuleActionDrop, "", "", nil)
+	builder.AddIngressFromBuilder(
+		IngressBuilder{
+			Protoc:     ProtocolTCP,
+			Namespaces: samePurposeTierLabels,
+			Action:     crdv1beta1.RuleActionPass,
+		})
+	builder.AddIngressFromBuilder(
+		IngressBuilder{
+			Protoc: ProtocolTCP,
+			Action: crdv1beta1.RuleActionDrop,
+		})
 	// Namespaces are split into two logical groups, purpose=test (prod1,2 and dev1,2) and purpose=test-exclusion
 	// (no-tier). The two groups of Namespace should not be able to connect to each other.
 	reachability := NewReachability(allPods, Connected)

--- a/test/e2e/antreapolicy_test.go
+++ b/test/e2e/antreapolicy_test.go
@@ -295,15 +295,24 @@ func testUpdateValidationInvalidANNP(t *testing.T) {
 	builder = builder.SetName(getNS("x"), "annp-applied-to-update").
 		SetAppliedToGroup([]ANNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}}}).
 		SetPriority(1.0)
-	builder.AddIngress(ProtocolTCP, nil, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{"pod": "c"}, nil, nil,
-		nil, nil, nil, nil, crdv1beta1.RuleActionAllow, "", "")
+	builder.AddIngressWithBuilder(
+		IngressBuilder{
+			Protoc:      ProtocolTCP,
+			PodSelector: map[string]string{"pod": "c"},
+			Action:      crdv1beta1.RuleActionAllow,
+		})
 
 	annp := builder.Get()
 	if _, err := k8sUtils.CreateOrUpdateANNP(annp); err != nil {
 		failOnError(fmt.Errorf("create ANNP annp-applied-to-update failed: %v", err), t)
 	}
-	builder.AddIngress(ProtocolTCP, nil, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{"pod": "b"}, nil, nil,
-		nil, nil, nil, []ANNPAppliedToSpec{{PodSelector: map[string]string{"pod": "b"}}}, crdv1beta1.RuleActionAllow, "", "")
+	builder.AddIngressWithBuilder(
+		IngressBuilder{
+			Protoc:                ProtocolTCP,
+			PodSelector:           map[string]string{"pod": "b"},
+			ANPRuleAppliedToSpecs: []ANNPAppliedToSpec{{PodSelector: map[string]string{"pod": "b"}}},
+			Action:                crdv1beta1.RuleActionAllow,
+		})
 	annp = builder.Get()
 	if _, err := k8sUtils.CreateOrUpdateANNP(annp); err == nil {
 		// Above update of ANNP must fail as it is an invalid spec.
@@ -1298,9 +1307,13 @@ func testANNPIngressRuleDenyGrpWithXCtoXA(t *testing.T) {
 	builder = builder.SetName(getNS("x"), "annp-deny-grp-with-xb-to-xa").
 		SetPriority(2.0).
 		SetAppliedToGroup([]ANNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}}})
-	builder.AddIngress(ProtocolTCP, nil, &port81Name, nil, nil, nil, nil, nil, nil, nil,
-		nil, nil, nil, nil, nil, nil, nil, crdv1beta1.RuleActionDrop, grpName, "")
-
+	builder.AddIngressWithBuilder(
+		IngressBuilder{
+			Protoc:    ProtocolTCP,
+			PortName:  &port81Name,
+			Action:    crdv1beta1.RuleActionDrop,
+			RuleGroup: grpName,
+		})
 	reachability := NewReachability(allPods, Connected)
 	reachability.Expect(getPod("x", "b"), getPod("x", "a"), Dropped)
 	reachability.ExpectSelf(allPods, Connected)
@@ -1371,8 +1384,13 @@ func testANNPAppliedToDenyXBtoGrpWithXA(t *testing.T) {
 	builder = builder.SetName(getNS("x"), "annp-deny-grp-with-xa-from-xb").
 		SetPriority(2.0).
 		SetAppliedToGroup([]ANNPAppliedToSpec{{Group: grpName}})
-	builder.AddIngress(ProtocolTCP, nil, &port81Name, nil, nil, nil, nil, nil, nil, nil, map[string]string{"pod": "b"}, nil, nil,
-		nil, nil, nil, nil, crdv1beta1.RuleActionDrop, "", "")
+	builder.AddIngressWithBuilder(
+		IngressBuilder{
+			Protoc:      ProtocolTCP,
+			PortName:    &port81Name,
+			PodSelector: map[string]string{"pod": "b"},
+			Action:      crdv1beta1.RuleActionDrop,
+		})
 
 	reachability := NewReachability(allPods, Connected)
 	reachability.Expect(getPod("x", "b"), getPod("x", "a"), Dropped)
@@ -1515,8 +1533,13 @@ func testANNPGroupServiceRefPodAdd(t *testing.T, data *TestData) {
 
 	builder := &AntreaNetworkPolicySpecBuilder{}
 	builder = builder.SetName(getNS("x"), "annp-grp-svc-ref").SetPriority(1.0).SetAppliedToGroup([]ANNPAppliedToSpec{{Group: grp1Name}})
-	builder.AddIngress(ProtocolTCP, &p80, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-		nil, nil, nil, nil, crdv1beta1.RuleActionDrop, grp2Name, "")
+	builder.AddIngressWithBuilder(
+		IngressBuilder{
+			Protoc:    ProtocolTCP,
+			Port:      &p80,
+			Action:    crdv1beta1.RuleActionDrop,
+			RuleGroup: grp2Name,
+		})
 
 	svc1PodName := randName("test-pod-svc1-")
 	svc2PodName := randName("test-pod-svc2-")
@@ -1575,8 +1598,13 @@ func testANNPGroupServiceRefDelete(t *testing.T) {
 
 	builder := &AntreaNetworkPolicySpecBuilder{}
 	builder = builder.SetName(getNS("x"), "annp-grp-svc-ref").SetPriority(1.0).SetAppliedToGroup([]ANNPAppliedToSpec{{Group: grp1Name}})
-	builder.AddIngress(ProtocolTCP, &p80, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-		nil, nil, nil, nil, crdv1beta1.RuleActionDrop, grp2Name, "")
+	builder.AddIngressWithBuilder(
+		IngressBuilder{
+			Protoc:    ProtocolTCP,
+			Port:      &p80,
+			Action:    crdv1beta1.RuleActionDrop,
+			RuleGroup: grp2Name,
+		})
 	annp := builder.Get()
 	k8sUtils.CreateOrUpdateANNP(annp)
 	failOnError(waitForResourceReady(t, timeout, annp), t)
@@ -1616,8 +1644,13 @@ func testANNPGroupServiceRefCreateAndUpdate(t *testing.T) {
 
 	builder := &AntreaNetworkPolicySpecBuilder{}
 	builder = builder.SetName(getNS("x"), "annp-grp-svc-ref").SetPriority(1.0).SetAppliedToGroup([]ANNPAppliedToSpec{{Group: grp1Name}})
-	builder.AddIngress(ProtocolTCP, &p80, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-		nil, nil, nil, nil, crdv1beta1.RuleActionDrop, grp2Name, "")
+	builder.AddIngressWithBuilder(
+		IngressBuilder{
+			Protoc:    ProtocolTCP,
+			Port:      &p80,
+			Action:    crdv1beta1.RuleActionDrop,
+			RuleGroup: grp2Name,
+		})
 
 	// Pods backing svc1 (label pod=a) in Namespace x should not allow ingress from Pods backing svc2 (label pod=b) in Namespace x.
 	reachability := NewReachability(allPods, Connected)
@@ -1671,8 +1704,13 @@ func testANNPGroupRefRuleIPBlocks(t *testing.T) {
 	builder = builder.SetName(getNS("x"), "annp-deny-xb-xc-ips-ingress-for-xa").
 		SetPriority(1.0).
 		SetAppliedToGroup([]ANNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}}})
-	builder.AddIngress(ProtocolTCP, &p80, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-		nil, nil, nil, nil, crdv1beta1.RuleActionDrop, grpName, "")
+	builder.AddIngressWithBuilder(
+		IngressBuilder{
+			Protoc:    ProtocolTCP,
+			Port:      &p80,
+			Action:    crdv1beta1.RuleActionDrop,
+			RuleGroup: grpName,
+		})
 
 	reachability := NewReachability(allPods, Connected)
 	reachability.Expect(getPod("x", "b"), getPod("x", "a"), Dropped)
@@ -1709,8 +1747,13 @@ func testANNPNestedGroupCreateAndUpdate(t *testing.T, data *TestData) {
 	builder := &AntreaNetworkPolicySpecBuilder{}
 	builder = builder.SetName(getNS("x"), "annp-nested-grp").SetPriority(1.0).
 		SetAppliedToGroup([]ANNPAppliedToSpec{{}}).
-		AddIngress(ProtocolTCP, &p80, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
-			nil, nil, nil, nil, crdv1beta1.RuleActionDrop, grpNestedName, "")
+		AddIngressWithBuilder(
+			IngressBuilder{
+				Protoc:    ProtocolTCP,
+				Port:      &p80,
+				Action:    crdv1beta1.RuleActionDrop,
+				RuleGroup: grpNestedName,
+			})
 
 	// Pods in Namespace x should not allow traffic from Pods backing svc1 (label pod=a) in Namespace x.
 	// Note that in this testStep grp3 will not be created yet, so even though grp-nested selects grp1 and
@@ -2594,8 +2637,14 @@ func testANNPBasic(t *testing.T) {
 	builder = builder.SetName(getNS("y"), "np-same-name").
 		SetPriority(1.0).
 		SetAppliedToGroup([]ANNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}}})
-	builder.AddIngress(ProtocolTCP, &p80, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{"pod": "b"}, map[string]string{"ns": getNS("x")}, nil,
-		nil, nil, nil, nil, crdv1beta1.RuleActionDrop, "", "")
+	builder.AddIngressWithBuilder(
+		IngressBuilder{
+			Protoc:      ProtocolTCP,
+			Port:        &p80,
+			PodSelector: map[string]string{"pod": "b"},
+			NsSelector:  map[string]string{"ns": getNS("x")},
+			Action:      crdv1beta1.RuleActionDrop,
+		})
 
 	reachability := NewReachability(allPods, Connected)
 	reachability.Expect(getPod("x", "b"), getPod("y", "a"), Dropped)
@@ -2637,8 +2686,14 @@ func testANNPUpdate(t *testing.T, data *TestData) {
 	builder = builder.SetName(getNS("y"), "np-update").
 		SetPriority(1.0).
 		SetAppliedToGroup([]ANNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}}})
-	builder.AddIngress(ProtocolTCP, &p80, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{"pod": "b"}, map[string]string{"ns": getNS("x")}, nil,
-		nil, nil, nil, nil, crdv1beta1.RuleActionDrop, "", "")
+	builder.AddIngressWithBuilder(
+		IngressBuilder{
+			Protoc:      ProtocolTCP,
+			Port:        &p80,
+			PodSelector: map[string]string{"pod": "b"},
+			NsSelector:  map[string]string{"ns": getNS("x")},
+			Action:      crdv1beta1.RuleActionDrop,
+		})
 
 	reachability := NewReachability(allPods, Connected)
 	reachability.Expect(getPod("x", "b"), getPod("y", "a"), Dropped)
@@ -2662,8 +2717,14 @@ func testANNPUpdate(t *testing.T, data *TestData) {
 	updatedBuilder = updatedBuilder.SetName(getNS("y"), "np-update").
 		SetPriority(1.0).
 		SetAppliedToGroup([]ANNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}}})
-	updatedBuilder.AddIngress(ProtocolTCP, &p80, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{"pod": "b"}, map[string]string{"ns": getNS("x")}, nil,
-		nil, nil, nil, nil, crdv1beta1.RuleActionAllow, "", "")
+	updatedBuilder.AddIngressWithBuilder(
+		IngressBuilder{
+			Protoc:      ProtocolTCP,
+			Port:        &p80,
+			PodSelector: map[string]string{"pod": "b"},
+			NsSelector:  map[string]string{"ns": getNS("x")},
+			Action:      crdv1beta1.RuleActionAllow,
+		})
 	updatedReachability := NewReachability(allPods, Connected)
 	updatedEvaluation := NewNPEvaluation(allPods).
 		ExpectNone(getPod("x", "a"), getPod("y", "a")).
@@ -2695,13 +2756,33 @@ func testANNPMultipleAppliedTo(t *testing.T, data *TestData, singleRule bool) {
 	// See https://github.com/antrea-io/antrea/issues/2083.
 	if singleRule {
 		builder.SetAppliedToGroup([]ANNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}}, {PodSelector: map[string]string{tempLabel: ""}}})
-		builder.AddIngress(ProtocolTCP, &p80, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{"pod": "b"}, map[string]string{"ns": getNS("x")}, nil,
-			nil, nil, nil, nil, crdv1beta1.RuleActionDrop, "", "")
+		builder.AddIngressWithBuilder(
+			IngressBuilder{
+				Protoc:      ProtocolTCP,
+				Port:        &p80,
+				PodSelector: map[string]string{"pod": "b"},
+				NsSelector:  map[string]string{"ns": getNS("x")},
+				Action:      crdv1beta1.RuleActionDrop,
+			})
 	} else {
-		builder.AddIngress(ProtocolTCP, &p80, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{"pod": "b"}, map[string]string{"ns": getNS("x")}, nil,
-			nil, nil, nil, []ANNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}}}, crdv1beta1.RuleActionDrop, "", "")
-		builder.AddIngress(ProtocolTCP, &p80, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{"pod": "b"}, map[string]string{"ns": getNS("x")}, nil,
-			nil, nil, nil, []ANNPAppliedToSpec{{PodSelector: map[string]string{tempLabel: ""}}}, crdv1beta1.RuleActionDrop, "", "")
+		builder.AddIngressWithBuilder(
+			IngressBuilder{
+				Protoc:                ProtocolTCP,
+				Port:                  &p80,
+				PodSelector:           map[string]string{"pod": "b"},
+				NsSelector:            map[string]string{"ns": getNS("x")},
+				ANPRuleAppliedToSpecs: []ANNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}}},
+				Action:                crdv1beta1.RuleActionDrop,
+			})
+		builder.AddIngressWithBuilder(
+			IngressBuilder{
+				Protoc:                ProtocolTCP,
+				Port:                  &p80,
+				PodSelector:           map[string]string{"pod": "b"},
+				NsSelector:            map[string]string{"ns": getNS("x")},
+				ANPRuleAppliedToSpecs: []ANNPAppliedToSpec{{PodSelector: map[string]string{tempLabel: ""}}},
+				Action:                crdv1beta1.RuleActionDrop,
+			})
 	}
 
 	reachability := NewReachability(allPods, Connected)
@@ -3054,10 +3135,24 @@ func testAppliedToPerRule(t *testing.T) {
 	builder = builder.SetName(getNS("y"), "np1").SetPriority(1.0)
 	annpATGrp1 := ANNPAppliedToSpec{PodSelector: map[string]string{"pod": "a"}, PodSelectorMatchExp: nil}
 	annpATGrp2 := ANNPAppliedToSpec{PodSelector: map[string]string{"pod": "b"}, PodSelectorMatchExp: nil}
-	builder.AddIngress(ProtocolTCP, &p80, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{"pod": "b"}, map[string]string{"ns": getNS("x")}, nil,
-		nil, nil, nil, []ANNPAppliedToSpec{annpATGrp1}, crdv1beta1.RuleActionDrop, "", "")
-	builder.AddIngress(ProtocolTCP, &p80, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{"pod": "b"}, map[string]string{"ns": getNS("z")}, nil,
-		nil, nil, nil, []ANNPAppliedToSpec{annpATGrp2}, crdv1beta1.RuleActionDrop, "", "")
+	builder.AddIngressWithBuilder(
+		IngressBuilder{
+			Protoc:                ProtocolTCP,
+			Port:                  &p80,
+			PodSelector:           map[string]string{"pod": "b"},
+			NsSelector:            map[string]string{"ns": getNS("x")},
+			ANPRuleAppliedToSpecs: []ANNPAppliedToSpec{annpATGrp1},
+			Action:                crdv1beta1.RuleActionDrop,
+		})
+	builder.AddIngressWithBuilder(
+		IngressBuilder{
+			Protoc:                ProtocolTCP,
+			Port:                  &p80,
+			PodSelector:           map[string]string{"pod": "b"},
+			NsSelector:            map[string]string{"ns": getNS("z")},
+			ANPRuleAppliedToSpecs: []ANNPAppliedToSpec{annpATGrp2},
+			Action:                crdv1beta1.RuleActionDrop,
+		})
 
 	reachability := NewReachability(allPods, Connected)
 	reachability.Expect(getPod("x", "b"), getPod("y", "a"), Dropped)
@@ -4994,8 +5089,14 @@ func TestAntreaPolicyStatus(t *testing.T) {
 	annpBuilder = annpBuilder.SetName(data.testNamespace, "annp-applied-to-two-nodes").
 		SetPriority(1.0).
 		SetAppliedToGroup([]ANNPAppliedToSpec{{PodSelector: map[string]string{"app": "nginx"}}})
-	annpBuilder.AddIngress(ProtocolTCP, &p80, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{"pod": "b"}, map[string]string{"ns": getNS("x")}, nil,
-		nil, nil, nil, nil, crdv1beta1.RuleActionAllow, "", "")
+	annpBuilder.AddIngressWithBuilder(
+		IngressBuilder{
+			Protoc:      ProtocolTCP,
+			Port:        &p80,
+			PodSelector: map[string]string{"pod": "b"},
+			NsSelector:  map[string]string{"ns": getNS("x")},
+			Action:      crdv1beta1.RuleActionAllow,
+		})
 	annp := annpBuilder.Get()
 	log.Debugf("creating ANNP %v", annp.Name)
 	_, err = data.crdClient.CrdV1beta1().NetworkPolicies(annp.Namespace).Create(context.TODO(), annp, metav1.CreateOptions{})
@@ -5049,10 +5150,24 @@ func TestAntreaPolicyStatusWithAppliedToPerRule(t *testing.T) {
 	annpBuilder := &AntreaNetworkPolicySpecBuilder{}
 	annpBuilder = annpBuilder.SetName(data.testNamespace, "annp-applied-to-per-rule").
 		SetPriority(1.0)
-	annpBuilder.AddIngress(ProtocolTCP, &p80, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{"pod": "b"}, map[string]string{"ns": getNS("x")}, nil,
-		nil, nil, nil, []ANNPAppliedToSpec{{PodSelector: map[string]string{"antrea-e2e": server0Name}}}, crdv1beta1.RuleActionAllow, "", "")
-	annpBuilder.AddIngress(ProtocolTCP, &p80, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{"pod": "b"}, map[string]string{"ns": getNS("x")}, nil,
-		nil, nil, nil, []ANNPAppliedToSpec{{PodSelector: map[string]string{"antrea-e2e": server1Name}}}, crdv1beta1.RuleActionAllow, "", "")
+	annpBuilder.AddIngressWithBuilder(
+		IngressBuilder{
+			Protoc:                ProtocolTCP,
+			Port:                  &p80,
+			PodSelector:           map[string]string{"pod": "b"},
+			NsSelector:            map[string]string{"ns": getNS("x")},
+			ANPRuleAppliedToSpecs: []ANNPAppliedToSpec{{PodSelector: map[string]string{"antrea-e2e": server0Name}}},
+			Action:                crdv1beta1.RuleActionAllow,
+		})
+	annpBuilder.AddIngressWithBuilder(
+		IngressBuilder{
+			Protoc:                ProtocolTCP,
+			Port:                  &p80,
+			PodSelector:           map[string]string{"pod": "b"},
+			NsSelector:            map[string]string{"ns": getNS("x")},
+			ANPRuleAppliedToSpecs: []ANNPAppliedToSpec{{PodSelector: map[string]string{"antrea-e2e": server1Name}}},
+			Action:                crdv1beta1.RuleActionAllow,
+		})
 	annp := annpBuilder.Get()
 	log.Debugf("creating ANNP %v", annp.Name)
 	annp, err = data.crdClient.CrdV1beta1().NetworkPolicies(annp.Namespace).Create(context.TODO(), annp, metav1.CreateOptions{})

--- a/test/e2e/antreapolicy_test.go
+++ b/test/e2e/antreapolicy_test.go
@@ -295,7 +295,7 @@ func testUpdateValidationInvalidANNP(t *testing.T) {
 	builder = builder.SetName(getNS("x"), "annp-applied-to-update").
 		SetAppliedToGroup([]ANNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}}}).
 		SetPriority(1.0)
-	builder.AddIngressWithBuilder(
+	builder.AddIngress(
 		IngressBuilder{
 			Protoc:      ProtocolTCP,
 			PodSelector: map[string]string{"pod": "c"},
@@ -306,7 +306,7 @@ func testUpdateValidationInvalidANNP(t *testing.T) {
 	if _, err := k8sUtils.CreateOrUpdateANNP(annp); err != nil {
 		failOnError(fmt.Errorf("create ANNP annp-applied-to-update failed: %v", err), t)
 	}
-	builder.AddIngressWithBuilder(
+	builder.AddIngress(
 		IngressBuilder{
 			Protoc:                ProtocolTCP,
 			PodSelector:           map[string]string{"pod": "b"},
@@ -1356,7 +1356,7 @@ func testANNPIngressRuleDenyGrpWithXCtoXA(t *testing.T) {
 	builder = builder.SetName(getNS("x"), "annp-deny-grp-with-xb-to-xa").
 		SetPriority(2.0).
 		SetAppliedToGroup([]ANNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}}})
-	builder.AddIngressWithBuilder(
+	builder.AddIngress(
 		IngressBuilder{
 			Protoc:    ProtocolTCP,
 			PortName:  &port81Name,
@@ -1437,7 +1437,7 @@ func testANNPAppliedToDenyXBtoGrpWithXA(t *testing.T) {
 	builder = builder.SetName(getNS("x"), "annp-deny-grp-with-xa-from-xb").
 		SetPriority(2.0).
 		SetAppliedToGroup([]ANNPAppliedToSpec{{Group: grpName}})
-	builder.AddIngressWithBuilder(
+	builder.AddIngress(
 		IngressBuilder{
 			Protoc:      ProtocolTCP,
 			PortName:    &port81Name,
@@ -1599,7 +1599,7 @@ func testANNPGroupServiceRefPodAdd(t *testing.T, data *TestData) {
 
 	builder := &AntreaNetworkPolicySpecBuilder{}
 	builder = builder.SetName(getNS("x"), "annp-grp-svc-ref").SetPriority(1.0).SetAppliedToGroup([]ANNPAppliedToSpec{{Group: grp1Name}})
-	builder.AddIngressWithBuilder(
+	builder.AddIngress(
 		IngressBuilder{
 			Protoc:    ProtocolTCP,
 			Port:      &p80,
@@ -1664,7 +1664,7 @@ func testANNPGroupServiceRefDelete(t *testing.T) {
 
 	builder := &AntreaNetworkPolicySpecBuilder{}
 	builder = builder.SetName(getNS("x"), "annp-grp-svc-ref").SetPriority(1.0).SetAppliedToGroup([]ANNPAppliedToSpec{{Group: grp1Name}})
-	builder.AddIngressWithBuilder(
+	builder.AddIngress(
 		IngressBuilder{
 			Protoc:    ProtocolTCP,
 			Port:      &p80,
@@ -1710,7 +1710,7 @@ func testANNPGroupServiceRefCreateAndUpdate(t *testing.T) {
 
 	builder := &AntreaNetworkPolicySpecBuilder{}
 	builder = builder.SetName(getNS("x"), "annp-grp-svc-ref").SetPriority(1.0).SetAppliedToGroup([]ANNPAppliedToSpec{{Group: grp1Name}})
-	builder.AddIngressWithBuilder(
+	builder.AddIngress(
 		IngressBuilder{
 			Protoc:    ProtocolTCP,
 			Port:      &p80,
@@ -1770,7 +1770,7 @@ func testANNPGroupRefRuleIPBlocks(t *testing.T) {
 	builder = builder.SetName(getNS("x"), "annp-deny-xb-xc-ips-ingress-for-xa").
 		SetPriority(1.0).
 		SetAppliedToGroup([]ANNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}}})
-	builder.AddIngressWithBuilder(
+	builder.AddIngress(
 		IngressBuilder{
 			Protoc:    ProtocolTCP,
 			Port:      &p80,
@@ -1813,7 +1813,7 @@ func testANNPNestedGroupCreateAndUpdate(t *testing.T, data *TestData) {
 	builder := &AntreaNetworkPolicySpecBuilder{}
 	builder = builder.SetName(getNS("x"), "annp-nested-grp").SetPriority(1.0).
 		SetAppliedToGroup([]ANNPAppliedToSpec{{}}).
-		AddIngressWithBuilder(
+		AddIngress(
 			IngressBuilder{
 				Protoc:    ProtocolTCP,
 				Port:      &p80,
@@ -2758,7 +2758,7 @@ func testANNPBasic(t *testing.T) {
 	builder = builder.SetName(getNS("y"), "np-same-name").
 		SetPriority(1.0).
 		SetAppliedToGroup([]ANNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}}})
-	builder.AddIngressWithBuilder(
+	builder.AddIngress(
 		IngressBuilder{
 			Protoc:      ProtocolTCP,
 			Port:        &p80,
@@ -2807,7 +2807,7 @@ func testANNPUpdate(t *testing.T, data *TestData) {
 	builder = builder.SetName(getNS("y"), "np-update").
 		SetPriority(1.0).
 		SetAppliedToGroup([]ANNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}}})
-	builder.AddIngressWithBuilder(
+	builder.AddIngress(
 		IngressBuilder{
 			Protoc:      ProtocolTCP,
 			Port:        &p80,
@@ -2838,7 +2838,7 @@ func testANNPUpdate(t *testing.T, data *TestData) {
 	updatedBuilder = updatedBuilder.SetName(getNS("y"), "np-update").
 		SetPriority(1.0).
 		SetAppliedToGroup([]ANNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}}})
-	updatedBuilder.AddIngressWithBuilder(
+	updatedBuilder.AddIngress(
 		IngressBuilder{
 			Protoc:      ProtocolTCP,
 			Port:        &p80,
@@ -2877,7 +2877,7 @@ func testANNPMultipleAppliedTo(t *testing.T, data *TestData, singleRule bool) {
 	// See https://github.com/antrea-io/antrea/issues/2083.
 	if singleRule {
 		builder.SetAppliedToGroup([]ANNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}}, {PodSelector: map[string]string{tempLabel: ""}}})
-		builder.AddIngressWithBuilder(
+		builder.AddIngress(
 			IngressBuilder{
 				Protoc:      ProtocolTCP,
 				Port:        &p80,
@@ -2886,7 +2886,7 @@ func testANNPMultipleAppliedTo(t *testing.T, data *TestData, singleRule bool) {
 				Action:      crdv1beta1.RuleActionDrop,
 			})
 	} else {
-		builder.AddIngressWithBuilder(
+		builder.AddIngress(
 			IngressBuilder{
 				Protoc:                ProtocolTCP,
 				Port:                  &p80,
@@ -2895,7 +2895,7 @@ func testANNPMultipleAppliedTo(t *testing.T, data *TestData, singleRule bool) {
 				ANPRuleAppliedToSpecs: []ANNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}}},
 				Action:                crdv1beta1.RuleActionDrop,
 			})
-		builder.AddIngressWithBuilder(
+		builder.AddIngress(
 			IngressBuilder{
 				Protoc:                ProtocolTCP,
 				Port:                  &p80,
@@ -3261,7 +3261,7 @@ func testAppliedToPerRule(t *testing.T) {
 	builder = builder.SetName(getNS("y"), "np1").SetPriority(1.0)
 	annpATGrp1 := ANNPAppliedToSpec{PodSelector: map[string]string{"pod": "a"}, PodSelectorMatchExp: nil}
 	annpATGrp2 := ANNPAppliedToSpec{PodSelector: map[string]string{"pod": "b"}, PodSelectorMatchExp: nil}
-	builder.AddIngressWithBuilder(
+	builder.AddIngress(
 		IngressBuilder{
 			Protoc:                ProtocolTCP,
 			Port:                  &p80,
@@ -3270,7 +3270,7 @@ func testAppliedToPerRule(t *testing.T) {
 			ANPRuleAppliedToSpecs: []ANNPAppliedToSpec{annpATGrp1},
 			Action:                crdv1beta1.RuleActionDrop,
 		})
-	builder.AddIngressWithBuilder(
+	builder.AddIngress(
 		IngressBuilder{
 			Protoc:                ProtocolTCP,
 			Port:                  &p80,
@@ -5234,7 +5234,7 @@ func TestAntreaPolicyStatus(t *testing.T) {
 	annpBuilder = annpBuilder.SetName(data.testNamespace, "annp-applied-to-two-nodes").
 		SetPriority(1.0).
 		SetAppliedToGroup([]ANNPAppliedToSpec{{PodSelector: map[string]string{"app": "nginx"}}})
-	annpBuilder.AddIngressWithBuilder(
+	annpBuilder.AddIngress(
 		IngressBuilder{
 			Protoc:      ProtocolTCP,
 			Port:        &p80,
@@ -5295,7 +5295,7 @@ func TestAntreaPolicyStatusWithAppliedToPerRule(t *testing.T) {
 	annpBuilder := &AntreaNetworkPolicySpecBuilder{}
 	annpBuilder = annpBuilder.SetName(data.testNamespace, "annp-applied-to-per-rule").
 		SetPriority(1.0)
-	annpBuilder.AddIngressWithBuilder(
+	annpBuilder.AddIngress(
 		IngressBuilder{
 			Protoc:                ProtocolTCP,
 			Port:                  &p80,
@@ -5304,7 +5304,7 @@ func TestAntreaPolicyStatusWithAppliedToPerRule(t *testing.T) {
 			ANPRuleAppliedToSpecs: []ANNPAppliedToSpec{{PodSelector: map[string]string{"antrea-e2e": server0Name}}},
 			Action:                crdv1beta1.RuleActionAllow,
 		})
-	annpBuilder.AddIngressWithBuilder(
+	annpBuilder.AddIngress(
 		IngressBuilder{
 			Protoc:                ProtocolTCP,
 			Port:                  &p80,

--- a/test/e2e/antreapolicy_test.go
+++ b/test/e2e/antreapolicy_test.go
@@ -643,7 +643,7 @@ func testACNPAllowNoDefaultIsolation(t *testing.T, protocol AntreaPolicyProtocol
 			NsSelector: map[string]string{"ns": getNS("y")},
 			Action:     crdv1beta1.RuleActionAllow,
 		})
-	builder.AddEgressWithBuilder(IngressBuilder{
+	builder.AddEgress(IngressBuilder{
 		Protoc:     protocol,
 		Port:       &p81,
 		NsSelector: map[string]string{"ns": getNS("z")},
@@ -680,7 +680,7 @@ func testACNPDropEgress(t *testing.T, protocol AntreaPolicyProtocol) {
 	builder = builder.SetName("acnp-deny-a-to-z-egress").
 		SetPriority(1.0).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}}})
-	builder.AddEgressWithBuilder(IngressBuilder{
+	builder.AddEgress(IngressBuilder{
 		Protoc:     protocol,
 		Port:       &p80,
 		NsSelector: map[string]string{"ns": getNS("z")},
@@ -752,7 +752,7 @@ func testACNPDropIPBlockWithExcept(t *testing.T) {
 	podXBIP, _ := podIPs[getPodName("x", "b")]
 	ipBlocks := genIPBlockForAllIPsExcept(append(podXAIP, podXBIP...))
 	for i := range ipBlocks {
-		builder.AddEgressWithBuilder(IngressBuilder{
+		builder.AddEgress(IngressBuilder{
 			Protoc:  ProtocolTCP,
 			Port:    &p80,
 			IpBlock: ipBlocks[i],
@@ -778,7 +778,7 @@ func testACNPDropIPBlockWithExcept(t *testing.T) {
 	builder2 = builder2.SetName("acnp-drop-egress-from-ya-to-xa").
 		SetPriority(2.0).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}, NSSelector: map[string]string{"ns": getNS("y")}}}).
-		AddEgressWithBuilder(IngressBuilder{
+		AddEgress(IngressBuilder{
 			Protoc:      ProtocolTCP,
 			Port:        &p80,
 			PodSelector: map[string]string{"pod": "a"},
@@ -943,7 +943,7 @@ func testACNPAppliedToRuleCGWithPodsAToNsZ(t *testing.T) {
 	builder := &ClusterNetworkPolicySpecBuilder{}
 	builder = builder.SetName("acnp-deny-cg-with-a-to-z").
 		SetPriority(1.0)
-	builder.AddEgressWithBuilder(IngressBuilder{
+	builder.AddEgress(IngressBuilder{
 		Protoc:             ProtocolTCP,
 		Port:               &p80,
 		NsSelector:         map[string]string{"ns": getNS("z")},
@@ -981,7 +981,7 @@ func testACNPEgressRulePodsAToCGWithNsZ(t *testing.T) {
 	builder = builder.SetName("acnp-deny-a-to-cg-with-z-egress").
 		SetPriority(1.0).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}}})
-	builder.AddEgressWithBuilder(IngressBuilder{
+	builder.AddEgress(IngressBuilder{
 		Protoc:           ProtocolTCP,
 		Port:             &p80,
 		Action:           crdv1beta1.RuleActionDrop,
@@ -1020,7 +1020,7 @@ func testACNPClusterGroupUpdateAppliedTo(t *testing.T) {
 	builder = builder.SetName("acnp-deny-cg-with-a-to-z-egress").
 		SetPriority(1.0).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{Group: cgName}})
-	builder.AddEgressWithBuilder(IngressBuilder{
+	builder.AddEgress(IngressBuilder{
 		Protoc:     ProtocolTCP,
 		Port:       &p80,
 		NsSelector: map[string]string{"ns": getNS("z")},
@@ -1071,7 +1071,7 @@ func testACNPClusterGroupUpdate(t *testing.T) {
 	builder = builder.SetName("acnp-deny-a-to-cg-with-z-egress").
 		SetPriority(1.0).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}}})
-	builder.AddEgressWithBuilder(IngressBuilder{
+	builder.AddEgress(IngressBuilder{
 		Protoc:           ProtocolTCP,
 		Port:             &p80,
 		Action:           crdv1beta1.RuleActionDrop,
@@ -1121,7 +1121,7 @@ func testACNPClusterGroupAppliedToPodAdd(t *testing.T, data *TestData) {
 	builder = builder.SetName("acnp-deny-cg-with-zj-to-xj-egress").
 		SetPriority(1.0).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{Group: cgName}})
-	builder.AddEgressWithBuilder(IngressBuilder{
+	builder.AddEgress(IngressBuilder{
 		Protoc:      ProtocolTCP,
 		Port:        &p80,
 		PodSelector: map[string]string{"pod": "j"},
@@ -1172,7 +1172,7 @@ func testACNPClusterGroupRefRulePodAdd(t *testing.T, data *TestData) {
 				NSSelector:  map[string]string{"ns": getNS("x")},
 			},
 		})
-	builder.AddEgressWithBuilder(IngressBuilder{
+	builder.AddEgress(IngressBuilder{
 		Protoc:           ProtocolTCP,
 		Port:             &p80,
 		Action:           crdv1beta1.RuleActionDrop,
@@ -2288,14 +2288,14 @@ func testACNPRulePriority(t *testing.T, data *TestData) {
 	builder1 = builder1.SetName("acnp-deny").
 		SetPriority(5).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{NSSelector: map[string]string{"ns": getNS("x")}}})
-	builder1.AddEgressWithBuilder(IngressBuilder{
+	builder1.AddEgress(IngressBuilder{
 		Protoc:     ProtocolTCP,
 		Port:       &p80,
 		NsSelector: map[string]string{"ns": getNS("y")},
 		Action:     crdv1beta1.RuleActionDrop,
 	})
 	// This rule should take no effect as it will be overridden by the first rule of cnp-allow
-	builder1.AddEgressWithBuilder(IngressBuilder{
+	builder1.AddEgress(IngressBuilder{
 		Protoc:     ProtocolTCP,
 		Port:       &p80,
 		NsSelector: map[string]string{"ns": getNS("z")},
@@ -2307,14 +2307,14 @@ func testACNPRulePriority(t *testing.T, data *TestData) {
 	builder2 = builder2.SetName("acnp-allow").
 		SetPriority(5).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{NSSelector: map[string]string{"ns": getNS("x")}}})
-	builder2.AddEgressWithBuilder(IngressBuilder{
+	builder2.AddEgress(IngressBuilder{
 		Protoc:     ProtocolTCP,
 		Port:       &p80,
 		NsSelector: map[string]string{"ns": getNS("z")},
 		Action:     crdv1beta1.RuleActionAllow,
 	})
 	// This rule should take no effect as it will be overridden by the first rule of cnp-drop
-	builder2.AddEgressWithBuilder(IngressBuilder{
+	builder2.AddEgress(IngressBuilder{
 		Protoc:     ProtocolTCP,
 		Port:       &p80,
 		NsSelector: map[string]string{"ns": getNS("y")},
@@ -2354,7 +2354,7 @@ func testACNPPortRange(t *testing.T) {
 	builder = builder.SetName("acnp-deny-a-to-z-egress-port-range").
 		SetPriority(1.0).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}}})
-	builder.AddEgressWithBuilder(IngressBuilder{
+	builder.AddEgress(IngressBuilder{
 		Protoc:     ProtocolTCP,
 		Port:       &p8080,
 		EndPort:    &p8082,
@@ -2390,7 +2390,7 @@ func testACNPRejectEgress(t *testing.T, data *TestData) {
 	builder = builder.SetName("acnp-reject-a-to-z-egress").
 		SetPriority(1.0).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}}})
-	builder.AddEgressWithBuilder(IngressBuilder{
+	builder.AddEgress(IngressBuilder{
 		Protoc:     ProtocolTCP,
 		Port:       &p80,
 		NsSelector: map[string]string{"ns": getNS("z")},
@@ -2490,13 +2490,13 @@ func testRejectServiceTraffic(t *testing.T, data *TestData, clientNamespace, ser
 	builder1 = builder1.SetName("acnp-reject-egress-svc-traffic").
 		SetPriority(1.0).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"antrea-e2e": "agnhost-client"}}})
-	builder1.AddEgressWithBuilder(IngressBuilder{
+	builder1.AddEgress(IngressBuilder{
 		Protoc:      ProtocolTCP,
 		Port:        &p80,
 		PodSelector: map[string]string{"antrea-e2e": "s1"},
 		Action:      crdv1beta1.RuleActionReject,
 	})
-	builder1.AddEgressWithBuilder(IngressBuilder{
+	builder1.AddEgress(IngressBuilder{
 		Protoc:      ProtocolTCP,
 		Port:        &p80,
 		PodSelector: map[string]string{"antrea-e2e": "s2"},
@@ -2642,13 +2642,13 @@ func testRejectNoInfiniteLoop(t *testing.T, data *TestData, clientNamespace, ser
 	builder2 := &ClusterNetworkPolicySpecBuilder{}
 	builder2 = builder2.SetName("acnp-reject-egress-double-dir").
 		SetPriority(1.0)
-	builder2.AddEgressWithBuilder(IngressBuilder{
+	builder2.AddEgress(IngressBuilder{
 		Protoc:             ProtocolTCP,
 		PodSelector:        map[string]string{"app": "nginx"},
 		RuleAppliedToSpecs: []ACNPAppliedToSpec{{PodSelector: map[string]string{"antrea-e2e": clientName}}},
 		Action:             crdv1beta1.RuleActionReject,
 	})
-	builder2.AddEgressWithBuilder(IngressBuilder{
+	builder2.AddEgress(IngressBuilder{
 		Protoc:             ProtocolTCP,
 		PodSelector:        map[string]string{"antrea-e2e": clientName},
 		RuleAppliedToSpecs: []ACNPAppliedToSpec{{PodSelector: map[string]string{"app": "nginx"}}},
@@ -2668,7 +2668,7 @@ func testRejectNoInfiniteLoop(t *testing.T, data *TestData, clientNamespace, ser
 			PodSelector: map[string]string{"antrea-e2e": clientName},
 			Action:      crdv1beta1.RuleActionReject,
 		})
-	builder3.AddEgressWithBuilder(IngressBuilder{
+	builder3.AddEgress(IngressBuilder{
 		Protoc:      ProtocolTCP,
 		PodSelector: map[string]string{"antrea-e2e": clientName},
 		Action:      crdv1beta1.RuleActionReject,
@@ -2687,7 +2687,7 @@ func testRejectNoInfiniteLoop(t *testing.T, data *TestData, clientNamespace, ser
 			PodSelector: map[string]string{"app": "nginx"},
 			Action:      crdv1beta1.RuleActionReject,
 		})
-	builder4.AddEgressWithBuilder(IngressBuilder{
+	builder4.AddEgress(IngressBuilder{
 		Protoc:      ProtocolTCP,
 		PodSelector: map[string]string{"app": "nginx"},
 		Action:      crdv1beta1.RuleActionReject,
@@ -3034,7 +3034,7 @@ func testAuditLoggingBasic(t *testing.T, data *TestData) {
 	builder = builder.SetName(npName).
 		SetPriority(1.0).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}, NSSelector: map[string]string{"ns": getNS("x")}}})
-	builder.AddEgressWithBuilder(IngressBuilder{
+	builder.AddEgress(IngressBuilder{
 		Protoc:     ProtocolTCP,
 		Port:       &p80,
 		NsSelector: map[string]string{"ns": getNS("z")},
@@ -3601,13 +3601,13 @@ func testACNPNamespaceIsolation(t *testing.T) {
 	builder2 = builder2.SetName("test-acnp-ns-isolation-applied-to-per-rule").
 		SetTier("baseline").
 		SetPriority(1.0)
-	builder2.AddEgressWithBuilder(IngressBuilder{
+	builder2.AddEgress(IngressBuilder{
 		Protoc:             ProtocolTCP,
 		Namespaces:         selfNamespace,
 		RuleAppliedToSpecs: []ACNPAppliedToSpec{{NSSelector: map[string]string{"ns": getNS("x")}}},
 		Action:             crdv1beta1.RuleActionAllow,
 	})
-	builder2.AddEgressWithBuilder(IngressBuilder{
+	builder2.AddEgress(IngressBuilder{
 		Protoc:             ProtocolTCP,
 		NsSelector:         map[string]string{},
 		RuleAppliedToSpecs: []ACNPAppliedToSpec{{NSSelector: map[string]string{"ns": getNS("x")}}},
@@ -4356,14 +4356,14 @@ func testACNPICMPSupport(t *testing.T, data *TestData) {
 	builder := &ClusterNetworkPolicySpecBuilder{}
 	builder = builder.SetName("test-acnp-icmp").
 		SetPriority(1.0).SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"antrea-e2e": clientName}}})
-	builder.AddEgressWithBuilder(IngressBuilder{
+	builder.AddEgress(IngressBuilder{
 		Protoc:      ProtocolICMP,
 		IcmpType:    &icmpType,
 		IcmpCode:    &icmpCode,
 		PodSelector: map[string]string{"antrea-e2e": server0Name},
 		Action:      crdv1beta1.RuleActionReject,
 	})
-	builder.AddEgressWithBuilder(IngressBuilder{
+	builder.AddEgress(IngressBuilder{
 		Protoc:      ProtocolICMP,
 		PodSelector: map[string]string{"antrea-e2e": server1Name},
 		Action:      crdv1beta1.RuleActionDrop,
@@ -4649,7 +4649,7 @@ func testACNPMulticastEgress(t *testing.T, data *TestData, acnpName, caseName, g
 		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"antrea-e2e": label}}})
 	cidr := mc.group.String() + "/32"
 	ipb := &crdv1beta1.IPBlock{CIDR: cidr}
-	builder.AddEgressWithBuilder(IngressBuilder{
+	builder.AddEgress(IngressBuilder{
 		Protoc:  ProtocolUDP,
 		IpBlock: ipb,
 		Action:  action,

--- a/test/e2e/flowaggregator_test.go
+++ b/test/e2e/flowaggregator_test.go
@@ -1694,7 +1694,7 @@ func deployAntreaNetworkPolicies(t *testing.T, data *TestData, srcPod, dstPod st
 	builder1 = builder1.SetName(data.testNamespace, ingressAntreaNetworkPolicyName).
 		SetPriority(2.0).
 		SetAppliedToGroup([]utils.ANNPAppliedToSpec{{PodSelector: map[string]string{"antrea-e2e": dstPod}}})
-	builder1 = builder1.AddIngressWithBuilder(utils.
+	builder1 = builder1.AddIngress(utils.
 		IngressBuilder{
 		Protoc:      utils.ProtocolTCP,
 		PodSelector: map[string]string{"antrea-e2e": srcPod},
@@ -1749,7 +1749,7 @@ func deployDenyAntreaNetworkPolicies(t *testing.T, data *TestData, srcPod, podRe
 		builder1 = builder1.SetName(data.testNamespace, ingressRejectANPName).
 			SetPriority(2.0).
 			SetAppliedToGroup([]utils.ANNPAppliedToSpec{{PodSelector: map[string]string{"antrea-e2e": podReject}}})
-		builder1 = builder1.AddIngressWithBuilder(utils.
+		builder1 = builder1.AddIngress(utils.
 			IngressBuilder{
 			Protoc:      utils.ProtocolTCP,
 			PodSelector: map[string]string{"antrea-e2e": srcPod},
@@ -1760,7 +1760,7 @@ func deployDenyAntreaNetworkPolicies(t *testing.T, data *TestData, srcPod, podRe
 		builder2 = builder2.SetName(data.testNamespace, ingressDropANPName).
 			SetPriority(2.0).
 			SetAppliedToGroup([]utils.ANNPAppliedToSpec{{PodSelector: map[string]string{"antrea-e2e": podDrop}}})
-		builder2 = builder2.AddIngressWithBuilder(utils.
+		builder2 = builder2.AddIngress(utils.
 			IngressBuilder{
 			Protoc:      utils.ProtocolTCP,
 			PodSelector: map[string]string{"antrea-e2e": srcPod},

--- a/test/e2e/flowaggregator_test.go
+++ b/test/e2e/flowaggregator_test.go
@@ -1694,8 +1694,14 @@ func deployAntreaNetworkPolicies(t *testing.T, data *TestData, srcPod, dstPod st
 	builder1 = builder1.SetName(data.testNamespace, ingressAntreaNetworkPolicyName).
 		SetPriority(2.0).
 		SetAppliedToGroup([]utils.ANNPAppliedToSpec{{PodSelector: map[string]string{"antrea-e2e": dstPod}}})
-	builder1 = builder1.AddIngress(utils.ProtocolTCP, nil, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{"antrea-e2e": srcPod}, map[string]string{}, nil,
-		nil, nil, nil, nil, secv1beta1.RuleActionAllow, "", testIngressRuleName)
+	builder1 = builder1.AddIngressWithBuilder(utils.
+		IngressBuilder{
+		Protoc:      utils.ProtocolTCP,
+		PodSelector: map[string]string{"antrea-e2e": srcPod},
+		NsSelector:  map[string]string{},
+		Action:      secv1beta1.RuleActionAllow,
+		Name:        testIngressRuleName,
+	})
 	anp1 = builder1.Get()
 	anp1, err1 := k8sUtils.CreateOrUpdateANNP(anp1)
 	if err1 != nil {
@@ -1738,13 +1744,25 @@ func deployDenyAntreaNetworkPolicies(t *testing.T, data *TestData, srcPod, podRe
 		builder1 = builder1.SetName(data.testNamespace, ingressRejectANPName).
 			SetPriority(2.0).
 			SetAppliedToGroup([]utils.ANNPAppliedToSpec{{PodSelector: map[string]string{"antrea-e2e": podReject}}})
-		builder1 = builder1.AddIngress(utils.ProtocolTCP, nil, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{"antrea-e2e": srcPod}, map[string]string{}, nil,
-			nil, nil, nil, nil, secv1beta1.RuleActionReject, "", testIngressRuleName)
+		builder1 = builder1.AddIngressWithBuilder(utils.
+			IngressBuilder{
+			Protoc:      utils.ProtocolTCP,
+			PodSelector: map[string]string{"antrea-e2e": srcPod},
+			NsSelector:  map[string]string{},
+			Action:      secv1beta1.RuleActionReject,
+			Name:        testIngressRuleName,
+		})
 		builder2 = builder2.SetName(data.testNamespace, ingressDropANPName).
 			SetPriority(2.0).
 			SetAppliedToGroup([]utils.ANNPAppliedToSpec{{PodSelector: map[string]string{"antrea-e2e": podDrop}}})
-		builder2 = builder2.AddIngress(utils.ProtocolTCP, nil, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{"antrea-e2e": srcPod}, map[string]string{}, nil,
-			nil, nil, nil, nil, secv1beta1.RuleActionDrop, "", testIngressRuleName)
+		builder2 = builder2.AddIngressWithBuilder(utils.
+			IngressBuilder{
+			Protoc:      utils.ProtocolTCP,
+			PodSelector: map[string]string{"antrea-e2e": srcPod},
+			NsSelector:  map[string]string{},
+			Action:      secv1beta1.RuleActionDrop,
+			Name:        testIngressRuleName,
+		})
 		table = openflow.AntreaPolicyIngressRuleTable
 		flowCount = antreaIngressTableInitFlowCount + 2
 		nodeName = dstNode

--- a/test/e2e/flowaggregator_test.go
+++ b/test/e2e/flowaggregator_test.go
@@ -1713,8 +1713,13 @@ func deployAntreaNetworkPolicies(t *testing.T, data *TestData, srcPod, dstPod st
 	builder2 = builder2.SetName(data.testNamespace, egressAntreaNetworkPolicyName).
 		SetPriority(2.0).
 		SetAppliedToGroup([]utils.ANNPAppliedToSpec{{PodSelector: map[string]string{"antrea-e2e": srcPod}}})
-	builder2 = builder2.AddEgress(utils.ProtocolTCP, nil, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{"antrea-e2e": dstPod}, map[string]string{}, nil,
-		nil, nil, nil, nil, secv1beta1.RuleActionAllow, "", testEgressRuleName)
+	builder2 = builder2.AddEgress(utils.IngressBuilder{
+		Protoc:      utils.ProtocolTCP,
+		PodSelector: map[string]string{"antrea-e2e": dstPod},
+		NsSelector:  map[string]string{},
+		Action:      secv1beta1.RuleActionAllow,
+		Name:        testEgressRuleName,
+	})
 	anp2 = builder2.Get()
 	anp2, err2 := k8sUtils.CreateOrUpdateANNP(anp2)
 	if err2 != nil {
@@ -1771,13 +1776,23 @@ func deployDenyAntreaNetworkPolicies(t *testing.T, data *TestData, srcPod, podRe
 		builder1 = builder1.SetName(data.testNamespace, egressRejectANPName).
 			SetPriority(2.0).
 			SetAppliedToGroup([]utils.ANNPAppliedToSpec{{PodSelector: map[string]string{"antrea-e2e": srcPod}}})
-		builder1 = builder1.AddEgress(utils.ProtocolTCP, nil, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{"antrea-e2e": podReject}, map[string]string{}, nil,
-			nil, nil, nil, nil, secv1beta1.RuleActionReject, "", testEgressRuleName)
+		builder1 = builder1.AddEgress(utils.IngressBuilder{
+			Protoc:      utils.ProtocolTCP,
+			PodSelector: map[string]string{"antrea-e2e": podReject},
+			NsSelector:  map[string]string{},
+			Action:      secv1beta1.RuleActionReject,
+			Name:        testEgressRuleName,
+		})
 		builder2 = builder2.SetName(data.testNamespace, egressDropANPName).
 			SetPriority(2.0).
 			SetAppliedToGroup([]utils.ANNPAppliedToSpec{{PodSelector: map[string]string{"antrea-e2e": srcPod}}})
-		builder2 = builder2.AddEgress(utils.ProtocolTCP, nil, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{"antrea-e2e": podDrop}, map[string]string{}, nil,
-			nil, nil, nil, nil, secv1beta1.RuleActionDrop, "", testEgressRuleName)
+		builder2 = builder2.AddEgress(utils.IngressBuilder{
+			Protoc:      utils.ProtocolTCP,
+			PodSelector: map[string]string{"antrea-e2e": podDrop},
+			NsSelector:  map[string]string{},
+			Action:      secv1beta1.RuleActionDrop,
+			Name:        testEgressRuleName,
+		})
 		table = openflow.AntreaPolicyEgressRuleTable
 		flowCount = antreaEgressTableInitFlowCount + 2
 		nodeName = srcNode

--- a/test/e2e/l7networkpolicy_test.go
+++ b/test/e2e/l7networkpolicy_test.go
@@ -99,26 +99,14 @@ func createL7NetworkPolicy(t *testing.T,
 				Action:                crdv1beta1.RuleActionAllow,
 			})
 	} else {
-		annpBuilder.AddEgress(l4Protocol,
-			&port,
-			nil,
-			nil,
-			nil,
-			nil,
-			nil,
-			l7Protocols,
-			nil,
-			nil,
-			podSelector,
-			nil,
-			nil,
-			nil,
-			nil,
-			nil,
-			[]ANNPAppliedToSpec{{PodSelector: appliedToPodSelector}},
-			crdv1beta1.RuleActionAllow,
-			"",
-			"")
+		annpBuilder.AddEgress(IngressBuilder{
+			Protoc:                l4Protocol,
+			Port:                  &port,
+			L7Protocols:           l7Protocols,
+			PodSelector:           podSelector,
+			ANPRuleAppliedToSpecs: []ANNPAppliedToSpec{{PodSelector: appliedToPodSelector}},
+			Action:                crdv1beta1.RuleActionAllow,
+		})
 	}
 
 	annp := annpBuilder.Get()

--- a/test/e2e/l7networkpolicy_test.go
+++ b/test/e2e/l7networkpolicy_test.go
@@ -89,26 +89,15 @@ func createL7NetworkPolicy(t *testing.T,
 	annpBuilder := &AntreaNetworkPolicySpecBuilder{}
 	annpBuilder = annpBuilder.SetName(data.testNamespace, name).SetPriority(priority)
 	if isIngress {
-		annpBuilder.AddIngress(l4Protocol,
-			&port,
-			nil,
-			nil,
-			nil,
-			nil,
-			nil,
-			l7Protocols,
-			nil,
-			nil,
-			podSelector,
-			nil,
-			nil,
-			nil,
-			nil,
-			nil,
-			[]ANNPAppliedToSpec{{PodSelector: appliedToPodSelector}},
-			crdv1beta1.RuleActionAllow,
-			"",
-			"")
+		annpBuilder.AddIngressWithBuilder(
+			IngressBuilder{
+				Protoc:                l4Protocol,
+				Port:                  &port,
+				L7Protocols:           l7Protocols,
+				PodSelector:           podSelector,
+				ANPRuleAppliedToSpecs: []ANNPAppliedToSpec{{PodSelector: appliedToPodSelector}},
+				Action:                crdv1beta1.RuleActionAllow,
+			})
 	} else {
 		annpBuilder.AddEgress(l4Protocol,
 			&port,

--- a/test/e2e/l7networkpolicy_test.go
+++ b/test/e2e/l7networkpolicy_test.go
@@ -89,7 +89,7 @@ func createL7NetworkPolicy(t *testing.T,
 	annpBuilder := &AntreaNetworkPolicySpecBuilder{}
 	annpBuilder = annpBuilder.SetName(data.testNamespace, name).SetPriority(priority)
 	if isIngress {
-		annpBuilder.AddIngressWithBuilder(
+		annpBuilder.AddIngress(
 			IngressBuilder{
 				Protoc:                l4Protocol,
 				Port:                  &port,

--- a/test/e2e/nodenetworkpolicy_test.go
+++ b/test/e2e/nodenetworkpolicy_test.go
@@ -149,7 +149,7 @@ func testNodeACNPAllowNoDefaultIsolation(t *testing.T, protocol AntreaPolicyProt
 	builder1 = builder1.SetName("acnp-allow-x-from-y-ingress").
 		SetPriority(1.1).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{NodeSelector: map[string]string{labelNodeHostname: nodes["x"]}}})
-	builder1.AddIngressFromBuilder(
+	builder1.AddIngress(
 		IngressBuilder{
 			Protoc:       protocol,
 			Port:         &p81,
@@ -236,7 +236,7 @@ func testNodeACNPDropIngress(t *testing.T, protocol AntreaPolicyProtocol) {
 	builder = builder.SetName("acnp-drop-x-from-y-ingress").
 		SetPriority(1.0).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{NodeSelector: map[string]string{labelNodeHostname: nodes["x"]}}})
-	builder.AddIngressFromBuilder(
+	builder.AddIngress(
 		IngressBuilder{
 			Protoc:       protocol,
 			Port:         &p80,
@@ -405,7 +405,7 @@ func testNodeACNPRejectIngress(t *testing.T, protocol AntreaPolicyProtocol) {
 	builder = builder.SetName("acnp-reject-x-from-y-ingress").
 		SetPriority(1.0).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{NodeSelector: map[string]string{labelNodeHostname: nodes["x"]}}})
-	builder.AddIngressFromBuilder(
+	builder.AddIngress(
 		IngressBuilder{
 			Protoc:       protocol,
 			Port:         &p80,
@@ -436,7 +436,7 @@ func testNodeACNPNoEffectOnOtherProtocols(t *testing.T) {
 	builder = builder.SetName("acnp-drop-x-from-y-ingress").
 		SetPriority(1.0).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{NodeSelector: map[string]string{labelNodeHostname: nodes["x"]}}})
-	builder.AddIngressFromBuilder(
+	builder.AddIngress(
 		IngressBuilder{
 			Protoc:       ProtocolTCP,
 			Port:         &p80,
@@ -479,7 +479,7 @@ func testNodeACNPPriorityOverride(t *testing.T) {
 		SetPriority(1.001).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{NodeSelector: map[string]string{labelNodeHostname: nodes["x"]}}})
 	// Highest priority. Drops traffic from y to x.
-	builder1.AddIngressFromBuilder(
+	builder1.AddIngress(
 		IngressBuilder{
 			Protoc:       ProtocolTCP,
 			Port:         &p80,
@@ -492,7 +492,7 @@ func testNodeACNPPriorityOverride(t *testing.T) {
 		SetPriority(1.002).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{NodeSelector: map[string]string{labelNodeHostname: nodes["x"]}}})
 	// Medium priority. Allows traffic from y to x.
-	builder2.AddIngressFromBuilder(
+	builder2.AddIngress(
 		IngressBuilder{
 			Protoc:       ProtocolTCP,
 			Port:         &p80,
@@ -505,7 +505,7 @@ func testNodeACNPPriorityOverride(t *testing.T) {
 		SetPriority(1.003).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{NodeSelector: map[string]string{labelNodeHostname: nodes["x"]}}})
 	// Lowest priority. Drops traffic from y to x.
-	builder3.AddIngressFromBuilder(
+	builder3.AddIngress(
 		IngressBuilder{
 			Protoc:       ProtocolTCP,
 			Port:         &p80,
@@ -553,7 +553,7 @@ func testNodeACNPTierOverride(t *testing.T) {
 		SetPriority(100).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{NodeSelector: map[string]string{labelNodeHostname: nodes["x"]}}})
 	// Highest priority tier. Drops traffic from y to x.
-	builder1.AddIngressFromBuilder(
+	builder1.AddIngress(
 		IngressBuilder{
 			Protoc:       ProtocolTCP,
 			Port:         &p80,
@@ -567,7 +567,7 @@ func testNodeACNPTierOverride(t *testing.T) {
 		SetPriority(10).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}, NSSelector: map[string]string{"ns": getNS("x")}}})
 	// Medium priority tier. Allows traffic from y to x.
-	builder2.AddIngressFromBuilder(
+	builder2.AddIngress(
 		IngressBuilder{
 			Protoc:       ProtocolTCP,
 			Port:         &p80,
@@ -581,7 +581,7 @@ func testNodeACNPTierOverride(t *testing.T) {
 		SetPriority(1).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{NSSelector: map[string]string{"ns": getNS("x")}}})
 	// Lowest priority tier. Drops traffic from y to x.
-	builder3.AddIngressFromBuilder(
+	builder3.AddIngress(
 		IngressBuilder{
 			Protoc:       ProtocolTCP,
 			Port:         &p80,
@@ -636,7 +636,7 @@ func testNodeACNPCustomTiers(t *testing.T) {
 		SetPriority(100).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{NodeSelector: map[string]string{labelNodeHostname: nodes["x"]}}})
 	// Medium priority tier. Allows traffic from y to x.
-	builder1.AddIngressFromBuilder(
+	builder1.AddIngress(
 		IngressBuilder{
 			Protoc:       ProtocolTCP,
 			Port:         &p80,
@@ -650,7 +650,7 @@ func testNodeACNPCustomTiers(t *testing.T) {
 		SetPriority(1).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{NodeSelector: map[string]string{labelNodeHostname: nodes["x"]}}})
 	// Lowest priority tier. Drops traffic from y to x.
-	builder2.AddIngressFromBuilder(
+	builder2.AddIngress(
 		IngressBuilder{
 			Protoc:       ProtocolTCP,
 			Port:         &p80,
@@ -699,7 +699,7 @@ func testNodeACNPPriorityConflictingRule(t *testing.T) {
 	builder1 = builder1.SetName("acnp-drop").
 		SetPriority(1).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{NodeSelector: map[string]string{labelNodeHostname: nodes["x"]}}})
-	builder1.AddIngressFromBuilder(
+	builder1.AddIngress(
 		IngressBuilder{
 			Protoc:       ProtocolTCP,
 			Port:         &p80,
@@ -713,7 +713,7 @@ func testNodeACNPPriorityConflictingRule(t *testing.T) {
 		SetAppliedToGroup([]ACNPAppliedToSpec{{NodeSelector: map[string]string{labelNodeHostname: nodes["x"]}}})
 	// The following ingress rule will take no effect as it is exactly the same as ingress rule of cnp-drop,
 	// but cnp-allow has lower priority.
-	builder2.AddIngressFromBuilder(
+	builder2.AddIngress(
 		IngressBuilder{
 			Protoc:       ProtocolTCP,
 			Port:         &p80,

--- a/test/e2e/nodenetworkpolicy_test.go
+++ b/test/e2e/nodenetworkpolicy_test.go
@@ -161,7 +161,7 @@ func testNodeACNPAllowNoDefaultIsolation(t *testing.T, protocol AntreaPolicyProt
 	builder2 = builder2.SetName("acnp-allow-x-to-y-egress").
 		SetPriority(1.1).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{NodeSelector: map[string]string{labelNodeHostname: nodes["x"]}}})
-	builder2.AddEgressWithBuilder(IngressBuilder{
+	builder2.AddEgress(IngressBuilder{
 		Protoc:       protocol,
 		Port:         &p81,
 		NodeSelector: map[string]string{labelNodeHostname: nodes["y"]},
@@ -206,7 +206,7 @@ func testNodeACNPDropEgress(t *testing.T, protocol AntreaPolicyProtocol) {
 	builder = builder.SetName("acnp-drop-x-to-y-egress").
 		SetPriority(1.0).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{NodeSelector: map[string]string{labelNodeHostname: nodes["x"]}}})
-	builder.AddEgressWithBuilder(IngressBuilder{
+	builder.AddEgress(IngressBuilder{
 		Protoc:       protocol,
 		Port:         &p80,
 		NodeSelector: map[string]string{labelNodeHostname: nodes["y"]},
@@ -275,7 +275,7 @@ func testNodeACNPPortRange(t *testing.T) {
 	builder = builder.SetName("acnp-drop-x-to-y-egress-port-range").
 		SetPriority(1.0).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{NodeSelector: map[string]string{labelNodeHostname: nodes["x"]}}})
-	builder.AddEgressWithBuilder(IngressBuilder{
+	builder.AddEgress(IngressBuilder{
 		Protoc:       ProtocolTCP,
 		Port:         &p8080,
 		EndPort:      &p8082,
@@ -387,7 +387,7 @@ func testNodeACNPRejectEgress(t *testing.T, protocol AntreaPolicyProtocol) {
 	builder = builder.SetName("acnp-reject-x-to-y-egress").
 		SetPriority(1.0).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{NodeSelector: map[string]string{labelNodeHostname: nodes["x"]}}})
-	builder.AddEgressWithBuilder(IngressBuilder{
+	builder.AddEgress(IngressBuilder{
 		Protoc:       protocol,
 		Port:         &p80,
 		NodeSelector: map[string]string{labelNodeHostname: nodes["y"]},
@@ -762,7 +762,7 @@ func testNodeACNPNamespaceIsolation(t *testing.T) {
 		SetTier("baseline").
 		SetPriority(1.0).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{NodeSelector: map[string]string{labelNodeHostname: nodes["x"]}}})
-	builder1.AddEgressWithBuilder(IngressBuilder{
+	builder1.AddEgress(IngressBuilder{
 		Protoc:     ProtocolTCP,
 		NsSelector: map[string]string{"ns": getNS("y")},
 		Action:     crdv1beta1.RuleActionDrop,
@@ -795,7 +795,7 @@ func testNodeACNPClusterGroupUpdate(t *testing.T) {
 	builder = builder.SetName("acnp-deny-a-to-cg-with-z-egress").
 		SetPriority(1.0).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{NodeSelector: map[string]string{labelNodeHostname: nodes["x"]}}})
-	builder.AddEgressWithBuilder(IngressBuilder{
+	builder.AddEgress(IngressBuilder{
 		Protoc:           ProtocolTCP,
 		Port:             &p80,
 		Action:           crdv1beta1.RuleActionDrop,
@@ -862,13 +862,13 @@ func testNodeACNPClusterGroupRefRuleIPBlocks(t *testing.T) {
 	builder = builder.SetName("acnp-deny-x-to-yz-egress").
 		SetPriority(1.0).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{NodeSelector: map[string]string{labelNodeHostname: nodes["x"]}}})
-	builder.AddEgressWithBuilder(IngressBuilder{
+	builder.AddEgress(IngressBuilder{
 		Protoc:           ProtocolTCP,
 		Port:             &p80,
 		Action:           crdv1beta1.RuleActionDrop,
 		RuleClusterGroup: cgName,
 	})
-	builder.AddEgressWithBuilder(IngressBuilder{
+	builder.AddEgress(IngressBuilder{
 		Protoc:           ProtocolTCP,
 		Port:             &p80,
 		Action:           crdv1beta1.RuleActionDrop,
@@ -904,7 +904,7 @@ func testNodeACNPNestedClusterGroupCreateAndUpdate(t *testing.T, data *TestData)
 	builder := &ClusterNetworkPolicySpecBuilder{}
 	builder = builder.SetName("cnp-nested-cg").SetPriority(1.0).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{NodeSelector: map[string]string{labelNodeHostname: nodes["x"]}}}).
-		AddEgressWithBuilder(IngressBuilder{
+		AddEgress(IngressBuilder{
 			Protoc:           ProtocolTCP,
 			Port:             &p80,
 			Action:           crdv1beta1.RuleActionDrop,
@@ -974,7 +974,7 @@ func testNodeACNPNestedIPBlockClusterGroupCreateAndUpdate(t *testing.T) {
 	builder = builder.SetName("acnp-deny-x-to-yz-egress").
 		SetPriority(1.0).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{NodeSelector: map[string]string{labelNodeHostname: nodes["x"]}}})
-	builder.AddEgressWithBuilder(IngressBuilder{
+	builder.AddEgress(IngressBuilder{
 		Protoc:           ProtocolTCP,
 		Port:             &p80,
 		Action:           crdv1beta1.RuleActionDrop,
@@ -1023,7 +1023,7 @@ func testNodeACNPAuditLogging(t *testing.T, data *TestData) {
 	builder = builder.SetName("acnp-drop-x-to-y-egress").
 		SetPriority(1.0).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{NodeSelector: map[string]string{labelNodeHostname: nodes["x"]}}})
-	builder.AddEgressWithBuilder(IngressBuilder{
+	builder.AddEgress(IngressBuilder{
 		Protoc:       ProtocolTCP,
 		Port:         &p80,
 		NodeSelector: map[string]string{labelNodeHostname: nodes["y"]},

--- a/test/e2e/utils/annp_spec_builder.go
+++ b/test/e2e/utils/annp_spec_builder.go
@@ -103,24 +103,15 @@ func (b *AntreaNetworkPolicySpecBuilder) GetAppliedToPeer(podSelector map[string
 }
 
 func (b *AntreaNetworkPolicySpecBuilder) AddIngress(ib IngressBuilder) *AntreaNetworkPolicySpecBuilder {
-	var ps, ns, ees *metav1.LabelSelector
+	var ees *metav1.LabelSelector
 	var appliedTos []crdv1beta1.AppliedTo
 	if b.Spec.Ingress == nil {
 		b.Spec.Ingress = []crdv1beta1.Rule{}
 	}
 
-	if len(ib.PodSelector) > 0 || len(ib.PodSelectorMatchExp) > 0 {
-		ps = &metav1.LabelSelector{
-			MatchLabels:      ib.PodSelector,
-			MatchExpressions: ib.PodSelectorMatchExp,
-		}
-	}
-	if len(ib.NsSelector) > 0 || len(ib.NsSelectorMatchExp) > 0 {
-		ns = &metav1.LabelSelector{
-			MatchLabels:      ib.NsSelector,
-			MatchExpressions: ib.NsSelectorMatchExp,
-		}
-	}
+	ps := ib.generatePodSelector()
+	ns := ib.generateNsSelector()
+
 	if len(ib.EeSelector) > 0 || len(ib.EeSelectorMatchExp) > 0 {
 		ees = &metav1.LabelSelector{
 			MatchLabels:      ib.EeSelector,

--- a/test/e2e/utils/annp_spec_builder.go
+++ b/test/e2e/utils/annp_spec_builder.go
@@ -224,37 +224,32 @@ func (b *AntreaNetworkPolicySpecBuilder) AddIngress(protoc AntreaPolicyProtocol,
 	return b
 }
 
-func (b *AntreaNetworkPolicySpecBuilder) AddEgress(protoc AntreaPolicyProtocol,
-	port *int32, portName *string, endPort, icmpType, icmpCode, igmpType *int32, l7Protocols []crdv1beta1.L7Protocol,
-	groupAddress, cidr *string, podSelector map[string]string, nsSelector map[string]string, eeSelector map[string]string,
-	podSelectorMatchExp []metav1.LabelSelectorRequirement, nsSelectorMatchExp []metav1.LabelSelectorRequirement, eeSelectorMatchExp []metav1.LabelSelectorRequirement,
-	ruleAppliedToSpecs []ANNPAppliedToSpec, action crdv1beta1.RuleAction, ruleGroup, name string) *AntreaNetworkPolicySpecBuilder {
-
+func (b *AntreaNetworkPolicySpecBuilder) AddEgress(ib IngressBuilder) *AntreaNetworkPolicySpecBuilder {
 	// For simplicity, we just reuse the Ingress code here.  The underlying data model for ingress/egress is identical
 	// With the exception of calling the rule `To` vs. `From`.
 	c := &AntreaNetworkPolicySpecBuilder{}
 	c.AddIngressWithBuilder(
 		IngressBuilder{
-			Protoc:                protoc,
-			Port:                  port,
-			PortName:              portName,
-			EndPort:               endPort,
-			IcmpType:              icmpType,
-			IcmpCode:              icmpCode,
-			IgmpType:              igmpType,
-			L7Protocols:           l7Protocols,
-			GroupAddress:          groupAddress,
-			Cidr:                  cidr,
-			PodSelector:           podSelector,
-			NsSelector:            nsSelector,
-			EeSelector:            eeSelector,
-			PodSelectorMatchExp:   podSelectorMatchExp,
-			NsSelectorMatchExp:    nsSelectorMatchExp,
-			EeSelectorMatchExp:    eeSelectorMatchExp,
-			ANPRuleAppliedToSpecs: ruleAppliedToSpecs,
-			Action:                action,
-			RuleGroup:             ruleGroup,
-			Name:                  name,
+			Protoc:                ib.Protoc,
+			Port:                  ib.Port,
+			PortName:              ib.PortName,
+			EndPort:               ib.EndPort,
+			IcmpType:              ib.IcmpType,
+			IcmpCode:              ib.IcmpCode,
+			IgmpType:              ib.IgmpType,
+			L7Protocols:           ib.L7Protocols,
+			GroupAddress:          ib.GroupAddress,
+			Cidr:                  ib.Cidr,
+			PodSelector:           ib.PodSelector,
+			NsSelector:            ib.NsSelector,
+			EeSelector:            ib.EeSelector,
+			PodSelectorMatchExp:   ib.PodSelectorMatchExp,
+			NsSelectorMatchExp:    ib.NsSelectorMatchExp,
+			EeSelectorMatchExp:    ib.EeSelectorMatchExp,
+			ANPRuleAppliedToSpecs: ib.ANPRuleAppliedToSpecs,
+			Action:                ib.Action,
+			RuleGroup:             ib.RuleGroup,
+			Name:                  ib.Name,
 		})
 	theRule := c.Get().Spec.Ingress[0]
 

--- a/test/e2e/utils/annp_spec_builder.go
+++ b/test/e2e/utils/annp_spec_builder.go
@@ -138,7 +138,7 @@ func (b *AntreaNetworkPolicySpecBuilder) AddIngress(ib IngressBuilder) *AntreaNe
 			Group:                  ib.RuleGroup,
 		}}
 	}
-	ports, protocols := GenPortsOrProtocols(ib.Protoc, ib.Port, ib.PortName, ib.EndPort, nil, nil, ib.IcmpType, ib.IcmpCode, ib.IgmpType, ib.GroupAddress)
+	ports, protocols := GenPortsOrProtocols(ib)
 	newRule := crdv1beta1.Rule{
 		From:        policyPeer,
 		Ports:       ports,
@@ -232,7 +232,12 @@ func (b *AntreaNetworkPolicySpecBuilder) AddFQDNRule(fqdn string,
 	}
 
 	policyPeer := []crdv1beta1.NetworkPolicyPeer{{FQDN: fqdn}}
-	ports, _ := GenPortsOrProtocols(protoc, port, portName, endPort, nil, nil, nil, nil, nil, nil)
+	ports, _ := GenPortsOrProtocols(IngressBuilder{
+		Protoc:   protoc,
+		Port:     port,
+		PortName: portName,
+		EndPort:  endPort,
+	})
 	newRule := crdv1beta1.Rule{
 		To:        policyPeer,
 		Ports:     ports,

--- a/test/e2e/utils/cnp_spec_builder.go
+++ b/test/e2e/utils/cnp_spec_builder.go
@@ -375,8 +375,30 @@ func (b *ClusterNetworkPolicySpecBuilder) AddEgress(protoc AntreaPolicyProtocol,
 	// For simplicity, we just reuse the Ingress code here.  The underlying data model for ingress/egress is identical
 	// With the exception of calling the rule `To` vs. `From`.
 	c := &ClusterNetworkPolicySpecBuilder{}
-	c.AddIngress(protoc, port, portName, endPort, icmpType, icmpCode, igmpType, groupAddress, ipBlock, podSelector, nodeSelector, nsSelector,
-		podSelectorMatchExp, nodeSelectorMatchExp, nsSelectorMatchExp, namespaces, ruleAppliedToSpecs, action, ruleClusterGroup, name, serviceAccount)
+	c.AddIngressFromBuilder(
+		IngressBuilder{
+			Protoc:               protoc,
+			Port:                 port,
+			PortName:             portName,
+			EndPort:              endPort,
+			IcmpType:             icmpType,
+			IcmpCode:             icmpCode,
+			IgmpType:             igmpType,
+			GroupAddress:         groupAddress,
+			IpBlock:              ipBlock,
+			PodSelector:          podSelector,
+			NodeSelector:         nodeSelector,
+			NsSelector:           nsSelector,
+			PodSelectorMatchExp:  podSelectorMatchExp,
+			NodeSelectorMatchExp: nodeSelectorMatchExp,
+			NsSelectorMatchExp:   nsSelectorMatchExp,
+			Namespaces:           namespaces,
+			RuleAppliedToSpecs:   ruleAppliedToSpecs,
+			Action:               action,
+			RuleClusterGroup:     ruleClusterGroup,
+			Name:                 name,
+			ServiceAccount:       serviceAccount,
+		})
 	theRule := c.Get().Spec.Ingress[0]
 
 	b.Spec.Egress = append(b.Spec.Egress, crdv1beta1.Rule{

--- a/test/e2e/utils/cnp_spec_builder.go
+++ b/test/e2e/utils/cnp_spec_builder.go
@@ -154,7 +154,7 @@ type IngressBuilder struct {
 	ServiceAccount     *crdv1beta1.NamespacedName
 }
 
-func (b *ClusterNetworkPolicySpecBuilder) AddIngressFromBuilder(ib IngressBuilder) *ClusterNetworkPolicySpecBuilder {
+func (b *ClusterNetworkPolicySpecBuilder) AddIngress(ib IngressBuilder) *ClusterNetworkPolicySpecBuilder {
 	var podSel *metav1.LabelSelector
 	var nodeSel *metav1.LabelSelector
 	var nsSel *metav1.LabelSelector
@@ -212,75 +212,6 @@ func (b *ClusterNetworkPolicySpecBuilder) AddIngressFromBuilder(ib IngressBuilde
 		Protocols: protocols,
 		Action:    &ib.Action,
 		Name:      ib.Name,
-		AppliedTo: appliedTos,
-	}
-	b.Spec.Ingress = append(b.Spec.Ingress, newRule)
-	return b
-}
-
-func (b *ClusterNetworkPolicySpecBuilder) AddIngress(protoc AntreaPolicyProtocol,
-	port *int32, portName *string, endPort, icmpType, icmpCode, igmpType *int32,
-	groupAddress *string, ipBlock *crdv1beta1.IPBlock, podSelector map[string]string, nodeSelector map[string]string, nsSelector map[string]string,
-	podSelectorMatchExp []metav1.LabelSelectorRequirement, nodeSelectorMatchExp []metav1.LabelSelectorRequirement, nsSelectorMatchExp []metav1.LabelSelectorRequirement, namespaces *crdv1beta1.PeerNamespaces,
-	ruleAppliedToSpecs []ACNPAppliedToSpec, action crdv1beta1.RuleAction, ruleClusterGroup, name string, serviceAccount *crdv1beta1.NamespacedName) *ClusterNetworkPolicySpecBuilder {
-
-	var podSel *metav1.LabelSelector
-	var nodeSel *metav1.LabelSelector
-	var nsSel *metav1.LabelSelector
-	var appliedTos []crdv1beta1.AppliedTo
-
-	if b.Spec.Ingress == nil {
-		b.Spec.Ingress = []crdv1beta1.Rule{}
-	}
-
-	if podSelector != nil || podSelectorMatchExp != nil {
-		podSel = &metav1.LabelSelector{
-			MatchLabels:      podSelector,
-			MatchExpressions: podSelectorMatchExp,
-		}
-	}
-	if nodeSelector != nil || nodeSelectorMatchExp != nil {
-		nodeSel = &metav1.LabelSelector{
-			MatchLabels:      nodeSelector,
-			MatchExpressions: nodeSelectorMatchExp,
-		}
-	}
-	if nsSelector != nil || nsSelectorMatchExp != nil {
-		nsSel = &metav1.LabelSelector{
-			MatchLabels:      nsSelector,
-			MatchExpressions: nsSelectorMatchExp,
-		}
-	}
-	for _, at := range ruleAppliedToSpecs {
-		appliedTos = append(appliedTos, b.GetAppliedToPeer(at.PodSelector,
-			at.NodeSelector,
-			at.NSSelector,
-			at.PodSelectorMatchExp,
-			at.NodeSelectorMatchExp,
-			at.NSSelectorMatchExp,
-			at.Group,
-			at.Service))
-	}
-	// An empty From/To in ACNP rules evaluates to match all addresses.
-	policyPeer := make([]crdv1beta1.NetworkPolicyPeer, 0)
-	if podSel != nil || nodeSel != nil || nsSel != nil || namespaces != nil || ipBlock != nil || ruleClusterGroup != "" || serviceAccount != nil {
-		policyPeer = []crdv1beta1.NetworkPolicyPeer{{
-			PodSelector:       podSel,
-			NodeSelector:      nodeSel,
-			NamespaceSelector: nsSel,
-			Namespaces:        namespaces,
-			IPBlock:           ipBlock,
-			Group:             ruleClusterGroup,
-			ServiceAccount:    serviceAccount,
-		}}
-	}
-	ports, protocols := GenPortsOrProtocols(protoc, port, portName, endPort, nil, nil, icmpType, icmpCode, igmpType, groupAddress)
-	newRule := crdv1beta1.Rule{
-		From:      policyPeer,
-		Ports:     ports,
-		Protocols: protocols,
-		Action:    &action,
-		Name:      name,
 		AppliedTo: appliedTos,
 	}
 	b.Spec.Ingress = append(b.Spec.Ingress, newRule)
@@ -375,7 +306,7 @@ func (b *ClusterNetworkPolicySpecBuilder) AddEgress(protoc AntreaPolicyProtocol,
 	// For simplicity, we just reuse the Ingress code here.  The underlying data model for ingress/egress is identical
 	// With the exception of calling the rule `To` vs. `From`.
 	c := &ClusterNetworkPolicySpecBuilder{}
-	c.AddIngressFromBuilder(
+	c.AddIngress(
 		IngressBuilder{
 			Protoc:               protoc,
 			Port:                 port,

--- a/test/e2e/utils/cnp_spec_builder.go
+++ b/test/e2e/utils/cnp_spec_builder.go
@@ -349,6 +349,23 @@ func (b *ClusterNetworkPolicySpecBuilder) AddEgress(protoc AntreaPolicyProtocol,
 	return b
 }
 
+func (b *ClusterNetworkPolicySpecBuilder) AddEgressWithBuilder(ingressBuilder IngressBuilder) *ClusterNetworkPolicySpecBuilder {
+	// For simplicity, we just reuse the Ingress code here.  The underlying data model for ingress/egress is identical
+	// With the exception of calling the rule `To` vs. `From`.
+	c := &ClusterNetworkPolicySpecBuilder{}
+	c.AddIngress(ingressBuilder)
+	theRule := c.Get().Spec.Ingress[0]
+
+	b.Spec.Egress = append(b.Spec.Egress, crdv1beta1.Rule{
+		To:        theRule.From,
+		Ports:     theRule.Ports,
+		Action:    theRule.Action,
+		Name:      theRule.Name,
+		AppliedTo: theRule.AppliedTo,
+	})
+	return b
+}
+
 func (b *ClusterNetworkPolicySpecBuilder) AddNodeSelectorRule(nodeSelector *metav1.LabelSelector, protoc AntreaPolicyProtocol, port *int32, name string,
 	ruleAppliedToSpecs []ACNPAppliedToSpec, action crdv1beta1.RuleAction, isEgress bool) *ClusterNetworkPolicySpecBuilder {
 	var appliedTos []crdv1beta1.AppliedTo

--- a/test/e2e/utils/cnp_spec_builder.go
+++ b/test/e2e/utils/cnp_spec_builder.go
@@ -304,52 +304,7 @@ func (b *ClusterNetworkPolicySpecBuilder) AddIngressForSrcPort(protoc AntreaPoli
 	return b
 }
 
-func (b *ClusterNetworkPolicySpecBuilder) AddEgress(protoc AntreaPolicyProtocol,
-	port *int32, portName *string, endPort, icmpType, icmpCode, igmpType *int32,
-	groupAddress *string, ipBlock *crdv1beta1.IPBlock, podSelector map[string]string, nodeSelector map[string]string, nsSelector map[string]string,
-	podSelectorMatchExp []metav1.LabelSelectorRequirement, nodeSelectorMatchExp []metav1.LabelSelectorRequirement, nsSelectorMatchExp []metav1.LabelSelectorRequirement, namespaces *crdv1beta1.PeerNamespaces,
-	ruleAppliedToSpecs []ACNPAppliedToSpec, action crdv1beta1.RuleAction, ruleClusterGroup, name string, serviceAccount *crdv1beta1.NamespacedName) *ClusterNetworkPolicySpecBuilder {
-
-	// For simplicity, we just reuse the Ingress code here.  The underlying data model for ingress/egress is identical
-	// With the exception of calling the rule `To` vs. `From`.
-	c := &ClusterNetworkPolicySpecBuilder{}
-	c.AddIngress(
-		IngressBuilder{
-			Protoc:               protoc,
-			Port:                 port,
-			PortName:             portName,
-			EndPort:              endPort,
-			IcmpType:             icmpType,
-			IcmpCode:             icmpCode,
-			IgmpType:             igmpType,
-			GroupAddress:         groupAddress,
-			IpBlock:              ipBlock,
-			PodSelector:          podSelector,
-			NodeSelector:         nodeSelector,
-			NsSelector:           nsSelector,
-			PodSelectorMatchExp:  podSelectorMatchExp,
-			NodeSelectorMatchExp: nodeSelectorMatchExp,
-			NsSelectorMatchExp:   nsSelectorMatchExp,
-			Namespaces:           namespaces,
-			RuleAppliedToSpecs:   ruleAppliedToSpecs,
-			Action:               action,
-			RuleClusterGroup:     ruleClusterGroup,
-			Name:                 name,
-			ServiceAccount:       serviceAccount,
-		})
-	theRule := c.Get().Spec.Ingress[0]
-
-	b.Spec.Egress = append(b.Spec.Egress, crdv1beta1.Rule{
-		To:        theRule.From,
-		Ports:     theRule.Ports,
-		Action:    theRule.Action,
-		Name:      theRule.Name,
-		AppliedTo: theRule.AppliedTo,
-	})
-	return b
-}
-
-func (b *ClusterNetworkPolicySpecBuilder) AddEgressWithBuilder(ingressBuilder IngressBuilder) *ClusterNetworkPolicySpecBuilder {
+func (b *ClusterNetworkPolicySpecBuilder) AddEgress(ingressBuilder IngressBuilder) *ClusterNetworkPolicySpecBuilder {
 	// For simplicity, we just reuse the Ingress code here.  The underlying data model for ingress/egress is identical
 	// With the exception of calling the rule `To` vs. `From`.
 	c := &ClusterNetworkPolicySpecBuilder{}

--- a/test/e2e/utils/cnp_spec_builder.go
+++ b/test/e2e/utils/cnp_spec_builder.go
@@ -128,30 +128,37 @@ func (b *ClusterNetworkPolicySpecBuilder) GetAppliedToPeer(podSelector map[strin
 }
 
 type IngressBuilder struct {
-	Protoc   AntreaPolicyProtocol
-	Port     *int32
-	PortName *string
-	EndPort  *int32
-	IcmpType *int32
-	IcmpCode *int32
-	IgmpType *int32
-
-	GroupAddress *string
-	IpBlock      *crdv1beta1.IPBlock
-	PodSelector  map[string]string
-	NodeSelector map[string]string
-	NsSelector   map[string]string
-
+	Protoc               AntreaPolicyProtocol
+	Port                 *int32
+	PortName             *string
+	EndPort              *int32
+	IcmpType             *int32
+	IcmpCode             *int32
+	IgmpType             *int32
+	GroupAddress         *string
+	PodSelector          map[string]string
+	NsSelector           map[string]string
 	PodSelectorMatchExp  []metav1.LabelSelectorRequirement
 	NodeSelectorMatchExp []metav1.LabelSelectorRequirement
-	NsSelectorMatchExp   []metav1.LabelSelectorRequirement
-	Namespaces           *crdv1beta1.PeerNamespaces
+	Action               crdv1beta1.RuleAction
+	Name                 string
 
+	// CNP only
+	IpBlock            *crdv1beta1.IPBlock
+	NodeSelector       map[string]string
+	NsSelectorMatchExp []metav1.LabelSelectorRequirement
+	Namespaces         *crdv1beta1.PeerNamespaces
 	RuleAppliedToSpecs []ACNPAppliedToSpec
-	Action             crdv1beta1.RuleAction
-	RuleClusterGroup   string
-	Name               string
 	ServiceAccount     *crdv1beta1.NamespacedName
+	RuleClusterGroup   string
+
+	// ANP only
+	L7Protocols           []crdv1beta1.L7Protocol
+	RuleGroup             string
+	Cidr                  *string
+	EeSelector            map[string]string
+	EeSelectorMatchExp    []metav1.LabelSelectorRequirement
+	ANPRuleAppliedToSpecs []ANNPAppliedToSpec
 }
 
 func (b *ClusterNetworkPolicySpecBuilder) AddIngress(ib IngressBuilder) *ClusterNetworkPolicySpecBuilder {

--- a/test/e2e/utils/helper.go
+++ b/test/e2e/utils/helper.go
@@ -46,51 +46,51 @@ func AntreaPolicyProtocolToK8sProtocol(antreaProtocol AntreaPolicyProtocol) (v1.
 	}
 }
 
-func GenPortsOrProtocols(protoc AntreaPolicyProtocol, port *int32, portName *string, endPort, srcPort, srcEndPort, icmpType, icmpCode, igmpType *int32, groupAddress *string) ([]crdv1beta1.NetworkPolicyPort, []crdv1beta1.NetworkPolicyProtocol) {
-	if protoc == ProtocolICMP {
+func GenPortsOrProtocols(ingressBuilder IngressBuilder) ([]crdv1beta1.NetworkPolicyPort, []crdv1beta1.NetworkPolicyProtocol) {
+	if ingressBuilder.Protoc == ProtocolICMP {
 		return nil, []crdv1beta1.NetworkPolicyProtocol{
 			{
 				ICMP: &crdv1beta1.ICMPProtocol{
-					ICMPType: icmpType,
-					ICMPCode: icmpCode,
+					ICMPType: ingressBuilder.IcmpType,
+					ICMPCode: ingressBuilder.IcmpCode,
 				},
 			},
 		}
 	}
-	if protoc == ProtocolIGMP {
+	if ingressBuilder.Protoc == ProtocolIGMP {
 		return nil, []crdv1beta1.NetworkPolicyProtocol{
 			{
 				IGMP: &crdv1beta1.IGMPProtocol{
-					IGMPType:     igmpType,
-					GroupAddress: *groupAddress,
+					IGMPType:     ingressBuilder.IgmpType,
+					GroupAddress: *ingressBuilder.GroupAddress,
 				},
 			},
 		}
 	}
 	var ports []crdv1beta1.NetworkPolicyPort
-	k8sProtocol, _ := AntreaPolicyProtocolToK8sProtocol(protoc)
-	if port != nil && portName != nil {
+	k8sProtocol, _ := AntreaPolicyProtocolToK8sProtocol(ingressBuilder.Protoc)
+	if ingressBuilder.Port != nil && ingressBuilder.PortName != nil {
 		panic("specify portname or port, not both")
 	}
-	if portName != nil {
+	if ingressBuilder.PortName != nil {
 		ports = []crdv1beta1.NetworkPolicyPort{
 			{
-				Port:     &intstr.IntOrString{Type: intstr.String, StrVal: *portName},
+				Port:     &intstr.IntOrString{Type: intstr.String, StrVal: *ingressBuilder.PortName},
 				Protocol: &k8sProtocol,
 			},
 		}
 	}
-	if port != nil || endPort != nil || srcPort != nil || srcEndPort != nil {
+	if ingressBuilder.Port != nil || ingressBuilder.EndPort != nil || ingressBuilder.SrcPort != nil || ingressBuilder.SrcEndPort != nil {
 		var pVal *intstr.IntOrString
-		if port != nil {
-			pVal = &intstr.IntOrString{IntVal: *port}
+		if ingressBuilder.Port != nil {
+			pVal = &intstr.IntOrString{IntVal: *ingressBuilder.Port}
 		}
 		ports = []crdv1beta1.NetworkPolicyPort{
 			{
 				Port:          pVal,
-				EndPort:       endPort,
-				SourcePort:    srcPort,
-				SourceEndPort: srcEndPort,
+				EndPort:       ingressBuilder.EndPort,
+				SourcePort:    ingressBuilder.SrcPort,
+				SourceEndPort: ingressBuilder.SrcEndPort,
 				Protocol:      &k8sProtocol,
 			},
 		}

--- a/test/e2e/vmagent_test.go
+++ b/test/e2e/vmagent_test.go
@@ -646,7 +646,7 @@ func createANPWithFQDN(t *testing.T, data *TestData, name string, namespace stri
 	for fqdn, action := range fqdnSettings {
 		ruleName := fmt.Sprintf("name-%d", i)
 		policyPeer := []crdv1beta1.NetworkPolicyPeer{{FQDN: fqdn}}
-		ports, _ := GenPortsOrProtocols(ProtocolTCP, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		ports, _ := GenPortsOrProtocols(IngressBuilder{Protoc: ProtocolTCP})
 		newRule := crdv1beta1.Rule{
 			To:     policyPeer,
 			Ports:  ports,

--- a/test/e2e/vmagent_test.go
+++ b/test/e2e/vmagent_test.go
@@ -591,11 +591,6 @@ func createANPForExternalNode(t *testing.T, data *TestData, name, namespace stri
 		SetPriority(1.0).
 		SetAppliedToGroup([]ANNPAppliedToSpec{{ExternalEntitySelector: eeSelector}})
 
-	ruleFunc := builder.AddIngress
-	if !ingress {
-		ruleFunc = builder.AddEgress
-	}
-
 	switch proto {
 	case ProtocolTCP:
 		fallthrough
@@ -611,12 +606,34 @@ func createANPForExternalNode(t *testing.T, data *TestData, name, namespace stri
 			cidr = &peerIPCIDR
 		}
 		port := int32(iperfPort)
-		ruleFunc(proto, &port, nil, nil, nil, nil, nil, nil, nil, cidr, nil, nil, peerLabel,
-			nil, nil, nil, nil, ruleAction, "", "")
+		if ingress {
+			builder.AddIngressWithBuilder(
+				IngressBuilder{
+					Protoc:     proto,
+					Port:       &port,
+					Cidr:       cidr,
+					EeSelector: peerLabel,
+					Action:     ruleAction,
+				})
+		} else {
+			builder.AddEgress(proto, &port, nil, nil, nil, nil, nil, nil, nil, cidr, nil, nil, peerLabel,
+				nil, nil, nil, nil, ruleAction, "", "")
+		}
 	case ProtocolICMP:
 		peerIPCIDR := fmt.Sprintf("%s/32", nodeIP(0))
-		ruleFunc(ProtocolICMP, nil, nil, nil, &icmpType, &icmpCode, nil, nil, nil, &peerIPCIDR, nil, nil, nil,
-			nil, nil, nil, nil, ruleAction, "", "")
+		if ingress {
+			builder.AddIngressWithBuilder(
+				IngressBuilder{
+					Protoc:   ProtocolICMP,
+					IcmpType: &icmpType,
+					IcmpCode: &icmpCode,
+					Cidr:     &peerIPCIDR,
+					Action:   ruleAction,
+				})
+		} else {
+			builder.AddEgress(ProtocolICMP, nil, nil, nil, &icmpType, &icmpCode, nil, nil, nil, &peerIPCIDR, nil, nil, nil,
+				nil, nil, nil, nil, ruleAction, "", "")
+		}
 	}
 	anpRule := builder.Get()
 

--- a/test/e2e/vmagent_test.go
+++ b/test/e2e/vmagent_test.go
@@ -590,7 +590,10 @@ func createANPForExternalNode(t *testing.T, data *TestData, name, namespace stri
 		SetName(namespace, name).
 		SetPriority(1.0).
 		SetAppliedToGroup([]ANNPAppliedToSpec{{ExternalEntitySelector: eeSelector}})
-
+	ruleFunc := builder.AddIngress
+	if !ingress {
+		ruleFunc = builder.AddEgress
+	}
 	switch proto {
 	case ProtocolTCP:
 		fallthrough
@@ -606,34 +609,22 @@ func createANPForExternalNode(t *testing.T, data *TestData, name, namespace stri
 			cidr = &peerIPCIDR
 		}
 		port := int32(iperfPort)
-		if ingress {
-			builder.AddIngressWithBuilder(
-				IngressBuilder{
-					Protoc:     proto,
-					Port:       &port,
-					Cidr:       cidr,
-					EeSelector: peerLabel,
-					Action:     ruleAction,
-				})
-		} else {
-			builder.AddEgress(proto, &port, nil, nil, nil, nil, nil, nil, nil, cidr, nil, nil, peerLabel,
-				nil, nil, nil, nil, ruleAction, "", "")
-		}
+		ruleFunc(IngressBuilder{
+			Protoc:     proto,
+			Port:       &port,
+			Cidr:       cidr,
+			EeSelector: peerLabel,
+			Action:     ruleAction,
+		})
 	case ProtocolICMP:
 		peerIPCIDR := fmt.Sprintf("%s/32", nodeIP(0))
-		if ingress {
-			builder.AddIngressWithBuilder(
-				IngressBuilder{
-					Protoc:   ProtocolICMP,
-					IcmpType: &icmpType,
-					IcmpCode: &icmpCode,
-					Cidr:     &peerIPCIDR,
-					Action:   ruleAction,
-				})
-		} else {
-			builder.AddEgress(ProtocolICMP, nil, nil, nil, &icmpType, &icmpCode, nil, nil, nil, &peerIPCIDR, nil, nil, nil,
-				nil, nil, nil, nil, ruleAction, "", "")
-		}
+		ruleFunc(IngressBuilder{
+			Protoc:   ProtocolICMP,
+			IcmpType: &icmpType,
+			IcmpCode: &icmpCode,
+			Cidr:     &peerIPCIDR,
+			Action:   ruleAction,
+		})
 	}
 	anpRule := builder.Get()
 


### PR DESCRIPTION
* This PR is stacked on https://github.com/antrea-io/antrea/pull/7088.
  * Please review #7088 ahead of this PR as they have overlapping commits
  * Alternative, await #7088 to be merged and then this PR only has 1 new commit
* `GenPortsOrProtocol` had the same lengthly set of inputs that `AddIngress` had
  * In this PR, it leverages `IngressBuilder` to simplify usage
  * This sets us up nicely to remove this [TODO|https://github.com/antrea-io/antrea/blob/main/test/e2e/utils/cnp_spec_builder.go#L199]
* These changes were inspired while working on #7067 
   