### PR TITLE
fix: re-adds retry in e2e kind setup

### DIFF
--- a/test/e2e/k8s_util.go
+++ b/test/e2e/k8s_util.go
@@ -1063,12 +1063,16 @@ func (k *KubernetesUtils) waitForHTTPServers(allPods []Pod) error {
 		},
 	}
 
-	if httpServerReadiness.isReady() {
-		log.Infof("All HTTP servers are ready")
-		return nil
-	} else {
-		return fmt.Errorf("HTTP servers are not ready")
+	retries := 10
+	for range retries {
+		if httpServerReadiness.isReady() {
+			log.Infof("All HTTP servers are ready")
+			return nil
+		}
+		time.Sleep(defaultInterval)
 	}
+
+	return fmt.Errorf("HTTP servers are not ready")
 }
 
 // Encapsulate the data needed to perform a probe between pods


### PR DESCRIPTION
* PR #7068 removed the 10 retries for setting up the cluster which introduced flakiness in CI