### PR TITLE
Add missing labels to namelabelmutator.antrea.io in doc

### DIFF
--- a/docs/antrea-network-policy.md
+++ b/docs/antrea-network-policy.md
@@ -1226,6 +1226,10 @@ kind: MutatingWebhookConfiguration
 metadata:
   # Do not edit this name.
   name: "labelsmutator.antrea.io"
+  # Do not remove these labels.
+  labels:
+    app: antrea
+    served-by: antrea-controller
 webhooks:
   - name: "namelabelmutator.antrea.io"
     clientConfig:


### PR DESCRIPTION
The `namelabelmutator.antrea.io` MutatingWebhookConfiguration YAML in antrea-network-policy.md is missing the necessary labels to ensure that the CA cert is synced correctly by the Antrea Controller (e.g., when the certificate is rotated).