### PR TITLE
Configure routes via ip route add

### DIFF
--- a/docs/secondary-network.md
+++ b/docs/secondary-network.md
@@ -313,3 +313,12 @@ spec:
   annotation is added to the Pod for the first time (e.g., when creating the
   Pod), we will configure the secondary network interfaces accordingly, and no
   change is possible after that, until the Pod is deleted.
+* We don't support K8s Nodes with multi-path routes.
+
+  > A multi-path route is a route with multiple possible next hops. When listing the
+  > rules (e.g., with `ip route list`), a multi-path route may appear as multiple individual
+  > routes (one for each next hop), all with the same cost.
+
+  When the K8s Node interfaces are managed by a network manager, please make sure the default
+  routes for secondary interfaces are disabled, or configure the routes with different metrics.
+  Otherwise, you may encounter K8s Nodes connection issue. Please check issue [#7058](https://github.com/antrea-io/antrea/issues/7058) for details.

--- a/pkg/agent/util/net_linux.go
+++ b/pkg/agent/util/net_linux.go
@@ -332,7 +332,12 @@ func ConfigureLinkRoutes(link netlink.Link, routes []interface{}) error {
 	for _, r := range routes {
 		rt := r.(netlink.Route)
 		rt.LinkIndex = netlinkAttrs(link).Index
-		if err := netlinkUtil.RouteReplace(&rt); err != nil {
+		if err := netlinkUtil.RouteAdd(&rt); err != nil {
+			if strings.Contains(strings.ToLower(err.Error()), "file exists") {
+				// Route already exists
+				klog.InfoS("Route already exists, skipping", "route", rt)
+				continue
+			}
 			return err
 		}
 	}

--- a/pkg/agent/util/net_linux_test.go
+++ b/pkg/agent/util/net_linux_test.go
@@ -741,13 +741,19 @@ func TestConfigureLinkRoutes(t *testing.T) {
 		{
 			name: "Configure Link Route Success",
 			expectedCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
-				mockNetlink.RouteReplace(&routes[0]).Return(nil)
+				mockNetlink.RouteAdd(&routes[0]).Return(nil)
 			},
 		},
 		{
-			name: "Route Replace Err",
+			name: "Configure Link Route with file exists error",
 			expectedCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
-				mockNetlink.RouteReplace(&routes[0]).Return(testInvalidErr)
+				mockNetlink.RouteAdd(&routes[0]).Return(fmt.Errorf("RTNETLINK answers: File exists"))
+			},
+		},
+		{
+			name: "Route Add Err",
+			expectedCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
+				mockNetlink.RouteAdd(&routes[0]).Return(testInvalidErr)
 			},
 			wantErr: testInvalidErr,
 		},

--- a/pkg/agent/util/netlink/netlink_linux.go
+++ b/pkg/agent/util/netlink/netlink_linux.go
@@ -28,6 +28,8 @@ type Interface interface {
 
 	RuleList(family int) ([]netlink.Rule, error)
 
+	RouteAdd(route *netlink.Route) error
+
 	RouteReplace(route *netlink.Route) error
 
 	RouteList(link netlink.Link, family int) ([]netlink.Route, error)

--- a/pkg/agent/util/netlink/testing/mock_netlink_linux.go
+++ b/pkg/agent/util/netlink/testing/mock_netlink_linux.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Antrea Authors
+// Copyright 2025 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -326,6 +326,20 @@ func (m *MockInterface) NeighSet(neigh *netlink.Neigh) error {
 func (mr *MockInterfaceMockRecorder) NeighSet(neigh any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NeighSet", reflect.TypeOf((*MockInterface)(nil).NeighSet), neigh)
+}
+
+// RouteAdd mocks base method.
+func (m *MockInterface) RouteAdd(route *netlink.Route) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RouteAdd", route)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RouteAdd indicates an expected call of RouteAdd.
+func (mr *MockInterfaceMockRecorder) RouteAdd(route any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RouteAdd", reflect.TypeOf((*MockInterface)(nil).RouteAdd), route)
 }
 
 // RouteDel mocks base method.


### PR DESCRIPTION
Resolve #7058

1. Add a limitation in the doc that multi-path routes are not supported for SecondaryNetwork
2. Using `netlinkUtil.RouteAdd` to replace `netlinkUtil.RouteReplace` when recovering the secondary interfaces routes in K8s Nodes, which will help avoid conflicts when the interface is managed by a network daemon. For example, routes may be added back automatically by the daemon when we bring the interface back up, and replacing them with Antrea could potentially create issues in some edge cases (e.g., when multi-path routes are present). More details can be checked in #7058

