### PR TITLE
Allow defining static mac adresses for SecondaryInterfaces for VLAN network

### DIFF
--- a/docs/secondary-network.md
+++ b/docs/secondary-network.md
@@ -200,6 +200,24 @@ spec:
    image: antrea/toolbox:latest
 ```
 
+You can also pass the static MAC address for secondary interfaces in annotation.
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+ name: sample-pod-secondary-network-vlan
+ annotations:
+   k8s.v1.cni.cncf.io/networks: '[
+     {"name": "vlan100"},
+     {"name": "vlan200", "namespace": "networks", "interface": "eth200", "mac": "6a:08:cb:4b:ff:d3"}
+   ]'
+spec:
+ containers:
+ - name: toolbox
+   image: antrea/toolbox:latest
+```
+
 If the Pod has only a single secondary network interface, you can also set
 the `k8s.v1.cni.cncf.io/networks` annotation to `<network-name>`,
 or `<namespace>/<network-name>` if the NetworkAttachmentDefinition CR is created

--- a/pkg/agent/cniserver/interface_configuration_linux_test.go
+++ b/pkg/agent/cniserver/interface_configuration_linux_test.go
@@ -254,7 +254,7 @@ func TestConfigureContainerLink(t *testing.T) {
 				fakeNetlink.EXPECT().LinkSetMTU(containerInterfaceLink, gomock.Any()).Return(nil).Times(1)
 				fakeNetlink.EXPECT().LinkSetUp(containerInterfaceLink).Return(nil).Times(1)
 			}
-			err := testIfConfigurator.configureContainerLink(podName, testPodNamespace, podContainerID, containerNS.Path(), containerIfaceName, mtu, tc.sriovVFDeviceID, tc.podSriovVFDeviceID, ipamResult, nil)
+			err := testIfConfigurator.configureContainerLink(podName, testPodNamespace, podContainerID, containerNS.Path(), containerIfaceName, mtu, tc.sriovVFDeviceID, tc.podSriovVFDeviceID, ipamResult, nil, nil)
 			if tc.expectErr != nil {
 				assert.Error(t, err)
 				assert.Equal(t, tc.expectErr, err)

--- a/pkg/agent/cniserver/interface_configuration_windows.go
+++ b/pkg/agent/cniserver/interface_configuration_windows.go
@@ -124,6 +124,7 @@ func (ic *ifConfigurator) configureContainerLink(
 	podSriovVFDeviceID string,
 	result *current.Result,
 	containerAccess *containerAccessArbitrator,
+	mac net.HardwareAddr,
 ) error {
 	if brSriovVFDeviceID != "" {
 		return fmt.Errorf("OVS hardware offload is not supported on windows")

--- a/pkg/agent/cniserver/interfaces.go
+++ b/pkg/agent/cniserver/interfaces.go
@@ -15,6 +15,8 @@
 package cniserver
 
 import (
+	"net"
+
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	current "github.com/containernetworking/cni/pkg/types/100"
 )
@@ -23,7 +25,7 @@ type postInterfaceCreateHook func() error
 
 // podInterfaceConfigurator is for testing.
 type podInterfaceConfigurator interface {
-	configureContainerLink(podName string, podNamespace string, containerID string, containerNetNS string, containerIfaceName string, mtu int, brSriovVFDeviceID string, podSriovVFDeviceID string, result *current.Result, containerAccess *containerAccessArbitrator) error
+	configureContainerLink(podName string, podNamespace string, containerID string, containerNetNS string, containerIfaceName string, mtu int, brSriovVFDeviceID string, podSriovVFDeviceID string, result *current.Result, containerAccess *containerAccessArbitrator, mac net.HardwareAddr) error
 	removeContainerLink(containerID, hostInterfaceName string) error
 	advertiseContainerAddr(containerNetNS string, containerIfaceName string, result *current.Result) error
 	validateVFRepInterface(sriovVFDeviceID string) (string, error)

--- a/pkg/agent/cniserver/pod_configuration.go
+++ b/pkg/agent/cniserver/pod_configuration.go
@@ -244,10 +244,10 @@ func ParseOVSPortInterfaceConfig(portData *ovsconfig.OVSPortData, portConfig *in
 func (pc *podConfigurator) configureInterfacesCommon(
 	podName, podNamespace, containerID, containerNetNS string,
 	containerIFDev string, mtu int, sriovVFDeviceID string,
-	result *ipam.IPAMResult, containerAccess *containerAccessArbitrator) error {
+	result *ipam.IPAMResult, containerAccess *containerAccessArbitrator, mac net.HardwareAddr) error {
 	err := pc.ifConfigurator.configureContainerLink(
 		podName, podNamespace, containerID, containerNetNS,
-		containerIFDev, mtu, sriovVFDeviceID, "", &result.Result, containerAccess)
+		containerIFDev, mtu, sriovVFDeviceID, "", &result.Result, containerAccess, mac)
 	if err != nil {
 		return err
 	}

--- a/pkg/agent/cniserver/pod_configuration_linux.go
+++ b/pkg/agent/cniserver/pod_configuration_linux.go
@@ -19,6 +19,7 @@ package cniserver
 
 import (
 	"fmt"
+	"net"
 
 	current "github.com/containernetworking/cni/pkg/types/100"
 	"k8s.io/client-go/tools/cache"
@@ -95,9 +96,9 @@ func (pc *podConfigurator) connectInterfaceToOVSCommon(ovsPortName, netNS string
 func (pc *podConfigurator) configureInterfaces(
 	podName, podNamespace, containerID, containerNetNS string,
 	containerIFDev string, mtu int, sriovVFDeviceID string,
-	result *ipam.IPAMResult, createOVSPort bool, containerAccess *containerAccessArbitrator) error {
+	result *ipam.IPAMResult, createOVSPort bool, containerAccess *containerAccessArbitrator, mac net.HardwareAddr) error {
 	return pc.configureInterfacesCommon(podName, podNamespace, containerID, containerNetNS,
-		containerIFDev, mtu, sriovVFDeviceID, result, containerAccess)
+		containerIFDev, mtu, sriovVFDeviceID, result, containerAccess, mac)
 }
 
 // reconcileMissingPods is never called on Linux, see reconcile logic.

--- a/pkg/agent/cniserver/pod_configuration_linux_test.go
+++ b/pkg/agent/cniserver/pod_configuration_linux_test.go
@@ -58,7 +58,7 @@ type fakeInterfaceConfigurator struct {
 	containerVFLink                     interface{}
 }
 
-func (c *fakeInterfaceConfigurator) configureContainerLink(podName string, podNamespace string, containerID string, containerNetNS string, containerIfaceName string, mtu int, brSriovVFDeviceID string, podSriovVFDeviceID string, result *current.Result, containerAccess *containerAccessArbitrator) error {
+func (c *fakeInterfaceConfigurator) configureContainerLink(podName string, podNamespace string, containerID string, containerNetNS string, containerIfaceName string, mtu int, brSriovVFDeviceID string, podSriovVFDeviceID string, result *current.Result, containerAccess *containerAccessArbitrator, mac net.HardwareAddr) error {
 	if c.configureContainerLinkError != nil {
 		return c.configureContainerLinkError
 	}
@@ -633,7 +633,7 @@ func TestConfigureVLANSecondaryInterface(t *testing.T) {
 	mockOVSBridgeClient.EXPECT().CreateAccessPort(
 		containerCfg1.InterfaceName, containerCfg1.InterfaceName,
 		gomock.Any(), uint16(100)).Return(containerCfg1.PortUUID, nil).Times(1)
-	assert.NoError(t, pc.ConfigureVLANSecondaryInterface(podName, testPodNamespace, containerID, containerNS, "eth1", 1500, ipamResult))
+	assert.NoError(t, pc.ConfigureVLANSecondaryInterface(podName, testPodNamespace, containerID, containerNS, "eth1", 1500, ipamResult, nil))
 	assert.Equal(t, 1, ifaceStore.Len())
 	intfConfig, _ := ifaceStore.GetContainerInterface(containerID)
 	assert.Equal(t, containerCfg1, intfConfig)
@@ -644,7 +644,7 @@ func TestConfigureVLANSecondaryInterface(t *testing.T) {
 	mockOVSBridgeClient.EXPECT().CreatePort(
 		containerCfg2.InterfaceName, containerCfg2.InterfaceName,
 		gomock.Any()).Return(containerCfg2.PortUUID, nil).Times(1)
-	assert.NoError(t, pc.ConfigureVLANSecondaryInterface(podName, testPodNamespace, containerID, containerNS, "eth2", 1600, ipamResult))
+	assert.NoError(t, pc.ConfigureVLANSecondaryInterface(podName, testPodNamespace, containerID, containerNS, "eth2", 1600, ipamResult, nil))
 	assert.Equal(t, 2, ifaceStore.Len())
 	intfConfigs := ifaceStore.GetContainerInterfacesByPod(podName, testPodNamespace)
 	assert.Len(t, intfConfigs, 2)

--- a/pkg/agent/cniserver/pod_configuration_windows.go
+++ b/pkg/agent/cniserver/pod_configuration_windows.go
@@ -18,6 +18,7 @@
 package cniserver
 
 import (
+	"net"
 	"time"
 
 	"antrea.io/libOpenflow/openflow15"
@@ -94,12 +95,12 @@ func (pc *podConfigurator) connectInterfaceToOVS(
 func (pc *podConfigurator) configureInterfaces(
 	podName, podNamespace, containerID, containerNetNS string,
 	containerIFDev string, mtu int, sriovVFDeviceID string,
-	result *ipam.IPAMResult, createOVSPort bool, containerAccess *containerAccessArbitrator) error {
+	result *ipam.IPAMResult, createOVSPort bool, containerAccess *containerAccessArbitrator, mac net.HardwareAddr) error {
 	if !createOVSPort {
 		return pc.ifConfigurator.configureContainerLink(
 			podName, podNamespace, containerID, containerNetNS,
 			containerIFDev, mtu, sriovVFDeviceID, "",
-			&result.Result, containerAccess)
+			&result.Result, containerAccess, mac)
 	}
 	// Check if the OVS configurations for the container exists or not. If yes, return
 	// immediately. This check is used on Windows, as kubelet on Windows will call CNI ADD
@@ -126,7 +127,7 @@ func (pc *podConfigurator) configureInterfaces(
 	}
 
 	return pc.configureInterfacesCommon(podName, podNamespace, containerID, containerNetNS,
-		containerIFDev, mtu, sriovVFDeviceID, result, containerAccess)
+		containerIFDev, mtu, sriovVFDeviceID, result, containerAccess, mac)
 }
 
 // isInterfaceInvalid returns false because we now don't support detecting the disconnected host interface on Windows

--- a/pkg/agent/cniserver/secondary.go
+++ b/pkg/agent/cniserver/secondary.go
@@ -16,6 +16,7 @@ package cniserver
 
 import (
 	"fmt"
+	"net"
 
 	current "github.com/containernetworking/cni/pkg/types/100"
 	"k8s.io/klog/v2"
@@ -44,7 +45,7 @@ func (pc *podConfigurator) ConfigureSriovSecondaryInterface(
 		return fmt.Errorf("error getting the Pod SR-IOV VF device ID")
 	}
 
-	err := pc.ifConfigurator.configureContainerLink(podName, podNamespace, containerID, containerNetNS, containerInterfaceName, mtu, "", podSriovVFDeviceID, result, nil)
+	err := pc.ifConfigurator.configureContainerLink(podName, podNamespace, containerID, containerNetNS, containerInterfaceName, mtu, "", podSriovVFDeviceID, result, nil, nil)
 	if err != nil {
 		return err
 	}
@@ -80,9 +81,9 @@ func (pc *podConfigurator) DeleteSriovSecondaryInterface(interfaceConfig *interf
 func (pc *podConfigurator) ConfigureVLANSecondaryInterface(
 	podName, podNamespace string,
 	containerID, containerNetNS, containerInterfaceName string,
-	mtu int, ipamResult *ipam.IPAMResult) error {
+	mtu int, ipamResult *ipam.IPAMResult, mac net.HardwareAddr) error {
 	return pc.configureInterfacesCommon(podName, podNamespace, containerID, containerNetNS,
-		containerInterfaceName, mtu, "", ipamResult, nil)
+		containerInterfaceName, mtu, "", ipamResult, nil, mac)
 }
 
 // DeleteVLANSecondaryInterface deletes a VLAN secondary interface.

--- a/pkg/agent/cniserver/server.go
+++ b/pkg/agent/cniserver/server.go
@@ -521,6 +521,7 @@ func (s *CNIServer) CmdAdd(ctx context.Context, request *cnipb.CniCmdRequest) (*
 		result,
 		isInfraContainer,
 		s.containerAccess,
+		nil,
 	); err != nil {
 		klog.ErrorS(err, "Failed to configure interfaces for container", "container", cniConfig.ContainerId)
 		return s.configInterfaceFailureResponse(err), nil

--- a/pkg/agent/secondarynetwork/podwatch/testing/mock_podwatch.go
+++ b/pkg/agent/secondarynetwork/podwatch/testing/mock_podwatch.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Antrea Authors
+// Copyright 2025 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@
 package testing
 
 import (
+	net "net"
 	reflect "reflect"
 
 	ipam "antrea.io/antrea/pkg/agent/cniserver/ipam"
@@ -74,17 +75,17 @@ func (mr *MockInterfaceConfiguratorMockRecorder) ConfigureSriovSecondaryInterfac
 }
 
 // ConfigureVLANSecondaryInterface mocks base method.
-func (m *MockInterfaceConfigurator) ConfigureVLANSecondaryInterface(podName, podNamespace, containerID, containerNetNS, containerInterfaceName string, mtu int, ipamResult *ipam.IPAMResult) error {
+func (m *MockInterfaceConfigurator) ConfigureVLANSecondaryInterface(podName, podNamespace, containerID, containerNetNS, containerInterfaceName string, mtu int, ipamResult *ipam.IPAMResult, mac net.HardwareAddr) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConfigureVLANSecondaryInterface", podName, podNamespace, containerID, containerNetNS, containerInterfaceName, mtu, ipamResult)
+	ret := m.ctrl.Call(m, "ConfigureVLANSecondaryInterface", podName, podNamespace, containerID, containerNetNS, containerInterfaceName, mtu, ipamResult, mac)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ConfigureVLANSecondaryInterface indicates an expected call of ConfigureVLANSecondaryInterface.
-func (mr *MockInterfaceConfiguratorMockRecorder) ConfigureVLANSecondaryInterface(podName, podNamespace, containerID, containerNetNS, containerInterfaceName, mtu, ipamResult any) *gomock.Call {
+func (mr *MockInterfaceConfiguratorMockRecorder) ConfigureVLANSecondaryInterface(podName, podNamespace, containerID, containerNetNS, containerInterfaceName, mtu, ipamResult, mac any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfigureVLANSecondaryInterface", reflect.TypeOf((*MockInterfaceConfigurator)(nil).ConfigureVLANSecondaryInterface), podName, podNamespace, containerID, containerNetNS, containerInterfaceName, mtu, ipamResult)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfigureVLANSecondaryInterface", reflect.TypeOf((*MockInterfaceConfigurator)(nil).ConfigureVLANSecondaryInterface), podName, podNamespace, containerID, containerNetNS, containerInterfaceName, mtu, ipamResult, mac)
 }
 
 // DeleteSriovSecondaryInterface mocks base method.

--- a/test/e2e-secondary-network/secondary_network_test.go
+++ b/test/e2e-secondary-network/secondary_network_test.go
@@ -45,6 +45,8 @@ type testPodInfo struct {
 	nodeName string
 	// map from interface name to secondary network name.
 	interfaceNetworks map[string]string
+	// map from interface name to secondary MAC address.
+	macAddresses map[string]string
 }
 
 type testData struct {
@@ -74,17 +76,25 @@ const (
 
 // formAnnotationStringOfPod forms the annotation string, used in the generation of each Pod YAML file.
 func (data *testData) formAnnotationStringOfPod(pod *testPodInfo) string {
-	var annotationString = ""
+	var annotationString string
 	for i, n := range pod.interfaceNetworks {
-		podNetworkSpec := fmt.Sprintf("{\"name\": \"%s\", \"namespace\": \"%s\", \"interface\": \"%s\"}",
+		podNetworkSpec := fmt.Sprintf("{\"name\": \"%s\", \"namespace\": \"%s\", \"interface\": \"%s\"",
 			n, attachDefNamespace, i)
+
+		if pod.macAddresses != nil {
+			if mac, ok := pod.macAddresses[i]; ok {
+				podNetworkSpec += fmt.Sprintf(", \"mac\": \"%s\"", mac)
+			}
+		}
+		podNetworkSpec += "}"
+
 		if annotationString == "" {
 			annotationString = "[" + podNetworkSpec
 		} else {
 			annotationString = annotationString + ", " + podNetworkSpec
 		}
 	}
-	annotationString = annotationString + "]"
+	annotationString += "]"
 	return annotationString
 }
 
@@ -219,9 +229,9 @@ func (data *testData) listPodAddresses(targetPod *testPodInfo) (map[string]net.I
 	return ipv4Result, ipv6Result, macResult, nil
 }
 
-// pingBetweenInterfaces parses through all the created Pods and pings the other Pod if the two Pods
-// both have a secondary network interface on the same network.
-func (data *testData) pingBetweenInterfaces(t *testing.T) error {
+// verifySecondaryInterfaces verifies MAC addresses and tests connectivity(ping)
+// between secondary interfaces of all created Pods that are on the same network.
+func (data *testData) verifySecondaryInterfaces(t *testing.T) error {
 	e2eTestData := data.e2eTestData
 	namespace := e2eTestData.GetTestNamespace()
 
@@ -246,25 +256,37 @@ func (data *testData) pingBetweenInterfaces(t *testing.T) error {
 		}
 	}
 
-	// Collect all secondary network IPs when they are available.
+	// Collect all secondary network IPs and verify MACs when they are available.
 	for _, testPod := range data.pods {
 		_, err := e2eTestData.PodWaitFor(defaultTimeout, testPod.podName, namespace, func(pod *corev1.Pod) (bool, error) {
 			if pod.Status.Phase != corev1.PodRunning {
 				return false, nil
 			}
 			var podNetworkAttachments []*attachment
-			podIPs, _, _, err := data.listPodAddresses(testPod)
+			podIPs, _, macResult, err := data.listPodAddresses(testPod)
 			if err != nil {
 				return false, err
 			}
 			for iface, net := range testPod.interfaceNetworks {
-				if podIPs[iface] == nil {
+				ip := podIPs[iface]
+				if ip == nil {
 					return false, nil
 				}
+
+				// Verify MAC address
+				if expectedMAC, ok := testPod.macAddresses[iface]; ok {
+					actualMAC, exists := macResult[iface]
+					if !exists {
+						return false, fmt.Errorf("interface %s not found when checking MAC in Pod %s", iface, testPod.podName)
+					}
+					assert.Equal(t, expectedMAC, actualMAC, "MAC address mismatch for interface %s in Pod %s", iface, testPod.podName)
+					logs.Infof("Interface %s in Pod %s has expected MAC address: %s", iface, testPod.podName, actualMAC)
+				}
+
 				podNetworkAttachments = append(podNetworkAttachments, &attachment{
 					network: net,
 					iface:   iface,
-					ip:      podIPs[iface],
+					ip:      ip,
 				})
 			}
 			// we found all the expected secondary network interfaces / attachments
@@ -458,8 +480,8 @@ func testSecondaryNetwork(t *testing.T, networkType string, pods []*testPodInfo)
 	if err != nil {
 		t.Fatalf("Error when creating kubernetes client: %v", err)
 	}
-	if err := testData.pingBetweenInterfaces(t); err != nil {
-		t.Fatalf("Error when pinging between interfaces: %v", err)
+	if err := testData.verifySecondaryInterfaces(t); err != nil {
+		t.Fatalf("Error verifying secondary interfaces (configuration and connectivity): %v", err)
 	}
 	if err := testData.assertPodNetworkStatus(t, clientset, pods, ns); err != nil {
 		t.Fatalf("Error when checking the Pod annotation: %v", err)
@@ -480,16 +502,19 @@ func TestVLANNetwork(t *testing.T) {
 			podName:           "vlan-pod1",
 			nodeName:          node1,
 			interfaceNetworks: map[string]string{"eth1": "vlan-net1", "eth2": "vlan-net2"},
+			macAddresses:      map[string]string{"eth1": "aa:bb:cc:dd:ee:01", "eth2": "aa:bb:cc:dd:ee:02"},
 		},
 		{
 			podName:           "vlan-pod2",
 			nodeName:          node1,
 			interfaceNetworks: map[string]string{"eth1": "vlan-net1", "eth2": "vlan-net3"},
+			macAddresses:      map[string]string{"eth1": "aa:bb:cc:dd:ee:03", "eth2": "aa:bb:cc:dd:ee:04"},
 		},
 		{
 			podName:           "vlan-pod3",
 			nodeName:          node2,
 			interfaceNetworks: map[string]string{"eth1": "vlan-net2"},
+			macAddresses:      map[string]string{"eth1": "aa:bb:cc:dd:ee:05"},
 		},
 	}
 	testSecondaryNetwork(t, networkTypeVLAN, pods)
@@ -570,8 +595,8 @@ func TestSRIOVNetwork(t *testing.T) {
 	if err := testData.assignIP(clientset); err != nil {
 		t.Fatalf("Error when assign IP to ec2 instance: %v", err)
 	}
-	if err := testData.pingBetweenInterfaces(t); err != nil {
-		t.Fatalf("Error when pinging between interfaces: %v", err)
+	if err := testData.verifySecondaryInterfaces(t); err != nil {
+		t.Fatalf("Error verifying secondary interfaces (configuration and connectivity): %v", err)
 	}
 	if err := testData.assertPodNetworkStatus(t, clientset, pods, ns); err != nil {
 		t.Fatalf("Error when checking the Pod annotation: %v", err)


### PR DESCRIPTION
Allow defining static mac adresses for SecondaryInterfaces
Handling VLAN network case in this PR.
using similar approach like multus with macvlan: https://github.com/k8snetworkplumbingwg/multus-cni/blob/master/examples/macvlan-pod.yml
fixes: #6996 
