### PR TITLE
Add more configuration values to the flow-aggregator chart

### DIFF
--- a/build/charts/flow-aggregator/README.md
+++ b/build/charts/flow-aggregator/README.md
@@ -32,6 +32,9 @@ Kubernetes: `>= 1.19.0-0`
 | clickHouse.enable | bool | `false` | Determine whether to enable exporting flow records to ClickHouse. |
 | clickHouse.tls.caCert | bool | `false` | Indicates whether to use custom CA certificate. Default root CAs will be used if this field is false. If true, a Secret named "clickhouse-ca" must be provided with the following keys: ca.crt: <CA certificate> |
 | clickHouse.tls.insecureSkipVerify | bool | `false` | Determine whether to skip the verification of the server's certificate chain and host name. Default is false. |
+| dnsPolicy | string | `""` | DNS Policy for the flow-aggregator Pod. If empty, the Kubernetes default will be used. |
+| flowAggregator.resources | object | `{"requests":{"cpu":"500m","memory":"256Mi"}}` | Resource requests and limits for the flow-aggregator container. |
+| flowAggregator.securityContext | object | `{}` | Configure the security context for the flow-aggregator container. |
 | flowAggregatorAddress | string | `""` | Provide an extra DNS name or IP address of flow aggregator for generating TLS certificate. |
 | flowCollector.address | string | `""` | Provide the flow collector address as string with format <IP>:<port>[:<proto>],  where proto is tcp or udp. If no L4 transport proto is given, we consider tcp as default. |
 | flowCollector.enable | bool | `false` | Determine whether to enable exporting flow records to external flow collector. |
@@ -49,11 +52,12 @@ Kubernetes: `>= 1.19.0-0`
 | flowLogger.prettyPrint | bool | `true` | PrettyPrint enables conversion of some numeric fields to a more meaningful string representation. |
 | flowLogger.recordFormat | string | `"CSV"` | RecordFormat defines the format of the flow records logged to file. Only "CSV" is supported at the moment. |
 | hostAliases | list | `[]` | HostAliases to be injected into the Pod's hosts file. For example: `[{"ip": "8.8.8.8", "hostnames": ["clickhouse.example.com"]}]` |
+| hostNetwork | bool | `false` | Run the flow-aggregator Pod in the host network. |
 | image | object | `{"pullPolicy":"IfNotPresent","repository":"antrea/flow-aggregator","tag":""}` | Container image used by Flow Aggregator. |
 | inactiveFlowRecordTimeout | string | `"90s"` | Provide the inactive flow record timeout as a duration string. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". |
 | logVerbosity | int | `0` | Log verbosity switch for Flow Aggregator. |
 | mode | string | `"Aggregate"` | Mode in which to run the flow aggregator. Must be one of "Aggregate" or "Proxy". In Aggregate mode, flow records received from source and destination are aggregated and sent as one flow record. In Proxy mode, flow records are enhanced with some additional information, then sent directly without buffering or aggregation. |
-| priorityClassName | string | `"system-cluster-critical"` | Prority class to use for the flow aggregator Pod. |
+| priorityClassName | string | `"system-cluster-critical"` | Prority class to use for the flow-aggregator Pod. |
 | recordContents.podLabels | bool | `false` | Determine whether source and destination Pod labels will be included in the flow records. |
 | s3Uploader.awsCredentials | object | `{"aws_access_key_id":"changeme","aws_secret_access_key":"changeme","aws_session_token":""}` | Credentials to authenticate to AWS. They will be stored in a Secret and injected into the Pod as environment variables. |
 | s3Uploader.bucketName | string | `""` | BucketName is the name of the S3 bucket to which flow records will be uploaded. It is required. |

--- a/build/charts/flow-aggregator/README.md
+++ b/build/charts/flow-aggregator/README.md
@@ -52,7 +52,7 @@ Kubernetes: `>= 1.19.0-0`
 | flowLogger.prettyPrint | bool | `true` | PrettyPrint enables conversion of some numeric fields to a more meaningful string representation. |
 | flowLogger.recordFormat | string | `"CSV"` | RecordFormat defines the format of the flow records logged to file. Only "CSV" is supported at the moment. |
 | hostAliases | list | `[]` | HostAliases to be injected into the Pod's hosts file. For example: `[{"ip": "8.8.8.8", "hostnames": ["clickhouse.example.com"]}]` |
-| hostNetwork | bool | `false` | Run the flow-aggregator Pod in the host network. |
+| hostNetwork | bool | `false` | Run the flow-aggregator Pod in the host network. With hostNetwork enabled, it is usually necessary to set dnsPolicy to ClusterFirstWithHostNet. |
 | image | object | `{"pullPolicy":"IfNotPresent","repository":"antrea/flow-aggregator","tag":""}` | Container image used by Flow Aggregator. |
 | inactiveFlowRecordTimeout | string | `"90s"` | Provide the inactive flow record timeout as a duration string. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". |
 | logVerbosity | int | `0` | Log verbosity switch for Flow Aggregator. |

--- a/build/charts/flow-aggregator/templates/deployment.yaml
+++ b/build/charts/flow-aggregator/templates/deployment.yaml
@@ -19,13 +19,19 @@ spec:
       labels:
         app: flow-aggregator
     spec:
+      hostNetwork: {{ .Values.hostNetwork }}
+      {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy }}
+      {{- end }}
+      {{- if .Values.hostAliases }}
       hostAliases:
-      {{- range .Values.hostAliases }}
+        {{- range .Values.hostAliases }}
         - ip: {{ .ip }}
           hostnames:
           {{- range $hostname := .hostnames }}
             - {{ $hostname }}
           {{- end }}
+        {{- end }}
       {{- end }}
       containers:
       - name: flow-aggregator
@@ -100,6 +106,14 @@ spec:
           name: host-var-log-antrea-flow-aggregator
         - name: clickhouse-ca
           mountPath: /etc/flow-aggregator/certs
+        {{- if .Values.flowAggregator.securityContext }}
+        securityContext:
+          {{- toYaml .Values.flowAggregator.securityContext | nindent 10 }}
+        {{- end }}
+        {{- if .Values.flowAggregator.resources }}
+        resources:
+          {{- toYaml .Values.flowAggregator.resources | nindent 10 }}
+        {{- end }}
       nodeSelector:
         kubernetes.io/os: linux
         kubernetes.io/arch: amd64

--- a/build/charts/flow-aggregator/values.yaml
+++ b/build/charts/flow-aggregator/values.yaml
@@ -6,7 +6,8 @@ image:
 
 # -- Prority class to use for the flow-aggregator Pod.
 priorityClassName: "system-cluster-critical"
-# -- Run the flow-aggregator Pod in the host network.
+# -- Run the flow-aggregator Pod in the host network. With hostNetwork enabled, it is usually
+# necessary to set dnsPolicy to ClusterFirstWithHostNet.
 hostNetwork: false
 # -- DNS Policy for the flow-aggregator Pod. If empty, the Kubernetes default will be used.
 dnsPolicy: ""

--- a/build/charts/flow-aggregator/values.yaml
+++ b/build/charts/flow-aggregator/values.yaml
@@ -4,8 +4,22 @@ image:
   pullPolicy: "IfNotPresent"
   tag: ""
 
-# -- Prority class to use for the flow aggregator Pod.
+# -- Prority class to use for the flow-aggregator Pod.
 priorityClassName: "system-cluster-critical"
+# -- Run the flow-aggregator Pod in the host network.
+hostNetwork: false
+# -- DNS Policy for the flow-aggregator Pod. If empty, the Kubernetes default will be used.
+dnsPolicy: ""
+
+# Configuration specific to the flow-aggregator container.
+flowAggregator:
+  # -- Configure the security context for the flow-aggregator container.
+  securityContext: {}
+  # -- Resource requests and limits for the flow-aggregator container.
+  resources:
+    requests:
+      cpu: "500m"
+      memory: "256Mi"
 
 # -- Mode in which to run the flow aggregator. Must be one of "Aggregate" or "Proxy". In Aggregate
 # mode, flow records received from source and destination are aggregated and sent as one flow

--- a/build/yamls/flow-aggregator.yml
+++ b/build/yamls/flow-aggregator.yml
@@ -504,6 +504,10 @@ spec:
         name: flow-aggregator
         ports:
         - containerPort: 4739
+        resources:
+          requests:
+            cpu: 500m
+            memory: 256Mi
         volumeMounts:
         - mountPath: /etc/flow-aggregator
           name: flow-aggregator-config
@@ -512,7 +516,7 @@ spec:
           name: host-var-log-antrea-flow-aggregator
         - mountPath: /etc/flow-aggregator/certs
           name: clickhouse-ca
-      hostAliases: null
+      hostNetwork: false
       nodeSelector:
         kubernetes.io/arch: amd64
         kubernetes.io/os: linux

--- a/hack/generate-manifest-flow-aggregator.sh
+++ b/hack/generate-manifest-flow-aggregator.sh
@@ -27,6 +27,7 @@ Generate a YAML manifest for the Flow Aggregator, using Helm and Kustomize, and 
                                         It should be given in format IP:port:proto. Example: 192.168.1.100:4739:udp.
         --clickhouse, -ch               Enable exporting flow records to default ClickHouse service address.
         --coverage                      Generate a manifest which supports measuring code coverage of the Flow Aggregator binaries.
+        --host-network                  Run Flow Aggregator in hostNetwork mode.
         --verbose-log                   Generate a manifest with increased log-level (level 4) for the Flow Aggregator.
                                         This option will work only with 'dev' mode.
         --help, -h                      Print this message and exit.
@@ -54,6 +55,7 @@ MODE="dev"
 FLOW_COLLECTOR=""
 CLICKHOUSE=false
 COVERAGE=false
+HOST_NETWORK=false
 VERBOSE_LOG=false
 
 while [[ $# -gt 0 ]]
@@ -75,6 +77,10 @@ case $key in
     ;;
     --coverage)
     COVERAGE=true
+    shift
+    ;;
+    --host-network)
+    HOST_NETWORK=true
     shift
     ;;
     --verbose-log)
@@ -155,7 +161,11 @@ fi
 
 if $COVERAGE; then
     HELM_VALUES+=("testing.coverage=true")
-fi 
+fi
+
+if $HOST_NETWORK; then
+    HELM_VALUES+=("hostNetwork=true,dnsPolicy=ClusterFirstWithHostNet")
+fi
 
 if [ "$MODE" == "dev" ]; then
     if [[ -z "$IMG_NAME" ]]; then

--- a/test/e2e/fixtures.go
+++ b/test/e2e/fixtures.go
@@ -293,7 +293,7 @@ func setupTest(tb testing.TB) (*TestData, error) {
 
 func setupFlowAggregator(tb testing.TB, testData *TestData, o flowVisibilityTestOptions) error {
 	// Create pod using ipfix collector image
-	if err := NewPodBuilder("ipfix-collector", testData.testNamespace, ipfixCollectorImage).InHostNetwork().Create(testData); err != nil {
+	if err := NewPodBuilder("ipfix-collector", testData.testNamespace, ipfixCollectorImage).WithArgs([]string{"--ipfix.port", ipfixCollectorPort}).InHostNetwork().Create(testData); err != nil {
 		tb.Errorf("Error when creating the ipfix collector Pod: %v", err)
 	}
 	ipfixCollectorIP, err := testData.podWaitForIPs(defaultTimeout, "ipfix-collector", testData.testNamespace)

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -133,7 +133,10 @@ const (
 
 	nginxLBService = "nginx-loadbalancer"
 
-	ipfixCollectorPort                  = "4739"
+	// Need a non-default (4739) port when testing the FA in hostNetwork mode.
+	// Otherwise we end up with 2 different hostNetwork Pods listening on the same port, with a
+	// conflict if they are scheduled on the same Node.
+	ipfixCollectorPort                  = "14739"
 	exporterFlowPollInterval            = 1 * time.Second
 	exporterActiveFlowExportTimeout     = 2 * time.Second
 	exporterIdleFlowExportTimeout       = 1 * time.Second


### PR DESCRIPTION
* hostNetwork
* dnsPolicy
* securityContext for the flow-aggregator container
* resources (requests and limits) for the flow-aggregator container

We also set some reasonable default resource requests for the
flow-aggregator container, even though actual resource usage will
be highly dependent on the cluster size, workloads, and on the
flow-aggregator configuration.