### PR TITLE
Bump golangcilint to v2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,45 +1,67 @@
 # golangci-lint configuration used for CI
+version: "2"
 run:
   tests: true
   timeout: 15m
-
-linters-settings:
-  goimports:
-    local-prefixes: antrea.io/antrea
-  gosec:
-    excludes:
-      # At the time of writing this, the G115 rule is not even part of an
-      # official release of gosec. This rule causes a lot of errors to be
-      # reported in the codebase. While some of the reported errors should be
-      # addressed, a lot can also be ignored and there are also some clear false
-      # positives that should not be flagged by gosec in the first place (see
-      # https://github.com/securego/gosec/issues/1187). We will re-enable this
-      # rule in the future when it becomes more accurate.
-      - G115 # Potential integer overflow when converting between integer types
-  misspell:
-    ignore-words:
-      - creater
-  revive:
-    ignore-generated-header: false
-    severity: warning
-    confidence: 0.8
-    rules:
-      - name: unreachable-code
-      - name: errorf
-      - name: range
-      - name: superfluous-else
-      - name: var-declaration
-      - name: duplicated-imports
-
 linters:
-  disable-all: true
+  default: none
   enable:
-    - misspell
-    - gofmt
-    - unused
-    - staticcheck
     - gosec
-    - goimports
     - govet
-    - revive
     - loggercheck
+    - misspell
+    - revive
+    - staticcheck
+    - unused
+  settings:
+    gosec:
+      excludes:
+       # At the time of writing this, the G115 rule is not even part of an
+       # official release of gosec. This rule causes a lot of errors to be
+       # reported in the codebase. While some of the reported errors should be
+       # addressed, a lot can also be ignored and there are also some clear false
+       # positives that should not be flagged by gosec in the first place (see
+       # https://github.com/securego/gosec/issues/1187). We will re-enable this
+       # rule in the future when it becomes more accurate.
+        - G115 # Potential integer overflow when converting between integer types
+    misspell:
+      ignore-rules:
+        - creater
+    revive:
+      confidence: 0.8
+      severity: warning
+      rules:
+        - name: unreachable-code
+        - name: errorf
+        - name: range
+        - name: superfluous-else
+        - name: var-declaration
+        - name: duplicated-imports
+  exclusions:
+    presets:
+      - legacy
+      - common-false-positives
+    paths:
+      - ^third_party/.*
+    rules:
+      - linters:
+          - staticcheck
+        # ST1005: error strings must be capitalized
+        # QF1008: unneccessary use of embedded struct name before field e.g:
+        #   ClusterNetworkPolicy.Metadata.Name vs ClusterNetworkPolicy.Name
+        text: "(ST1005:|QF1008:)"
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - antrea.io/antrea
+  exclusions:
+    paths:
+      - ^third_party/.*
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ GIT_HOOKS          := $(shell find hack/git_client_side_hooks -type f -print)
 DOCKER_NETWORK     ?= default
 TRIVY_TARGET_IMAGE ?=
 
-GOLANGCI_LINT_VERSION := v1.64.5
+GOLANGCI_LINT_VERSION := v2.1.6
 GOLANGCI_LINT_BINDIR  := $(CURDIR)/.golangci-bin
 GOLANGCI_LINT_BIN     := $(GOLANGCI_LINT_BINDIR)/$(GOLANGCI_LINT_VERSION)/golangci-lint
 

--- a/cmd/antrea-agent-simulator/simulator.go
+++ b/cmd/antrea-agent-simulator/simulator.go
@@ -159,19 +159,17 @@ func (w *watchWrapper) watch() {
 	// Watch the init events from chan, and log the events
 loop:
 	for {
-		select {
-		case event, ok := <-watcher.ResultChan():
-			if !ok {
-				klog.Warningf("Result channel for %s was closed", w.name)
-				return
-			}
-			switch event.Type {
-			case watch.Added:
-				klog.V(2).Infof("Added %s (%#v)", w.name, event.Object)
-				initCount++
-			case watch.Bookmark:
-				break loop
-			}
+		event, ok := <-watcher.ResultChan()
+		if !ok {
+			klog.Warningf("Result channel for %s was closed", w.name)
+			return
+		}
+		switch event.Type {
+		case watch.Added:
+			klog.V(2).Infof("Added %s (%#v)", w.name, event.Object)
+			initCount++
+		case watch.Bookmark:
+			break loop
 		}
 	}
 	klog.Infof("Received %d init events for %s", initCount, w.name)
@@ -179,23 +177,21 @@ loop:
 
 	// Watch the events from chan, and log the events
 	for {
-		select {
-		case event, ok := <-watcher.ResultChan():
-			if !ok {
-				return
-			}
-			switch event.Type {
-			case watch.Added:
-				klog.V(2).Infof("Added %s (%#v)", w.name, event.Object)
-			case watch.Modified:
-				klog.V(2).Infof("Updated %s (%#v)", w.name, event.Object)
-			case watch.Deleted:
-				klog.V(2).Infof("Removed %s (%#v)", w.name, event.Object)
-			default:
-				klog.Errorf("Unknown event: %v", event)
-				return
-			}
-			eventCount++
+		event, ok := <-watcher.ResultChan()
+		if !ok {
+			return
 		}
+		switch event.Type {
+		case watch.Added:
+			klog.V(2).Infof("Added %s (%#v)", w.name, event.Object)
+		case watch.Modified:
+			klog.V(2).Infof("Updated %s (%#v)", w.name, event.Object)
+		case watch.Deleted:
+			klog.V(2).Infof("Removed %s (%#v)", w.name, event.Object)
+		default:
+			klog.Errorf("Unknown event: %v", event)
+			return
+		}
+		eventCount++
 	}
 }

--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -483,8 +483,7 @@ func run(o *Options) error {
 	// AntreaPolicy feature is enabled.
 	statusManagerEnabled := antreaPolicyEnabled
 
-	var auditLoggerOptions *networkpolicy.AuditLoggerOptions
-	auditLoggerOptions = &networkpolicy.AuditLoggerOptions{
+	var auditLoggerOptions = &networkpolicy.AuditLoggerOptions{
 		MaxSize:    int(o.config.AuditLogging.MaxSize),
 		MaxBackups: int(*o.config.AuditLogging.MaxBackups),
 		MaxAge:     int(*o.config.AuditLogging.MaxAge),

--- a/cmd/antrea-agent/options.go
+++ b/cmd/antrea-agent/options.go
@@ -576,7 +576,7 @@ func (o *Options) validateK8sNodeOptions() error {
 			return fmt.Errorf("TrafficEncryptionMode %s may only be enabled in %s mode", encryptionMode, config.TrafficEncapModeEncap)
 		}
 	}
-	if o.config.NoSNAT && !(encapMode == config.TrafficEncapModeNoEncap || encapMode == config.TrafficEncapModeNetworkPolicyOnly) {
+	if o.config.NoSNAT && (encapMode != config.TrafficEncapModeNoEncap && encapMode != config.TrafficEncapModeNetworkPolicyOnly) {
 		return fmt.Errorf("noSNAT is only applicable to the %s mode", config.TrafficEncapModeNoEncap)
 	}
 	if encapMode == config.TrafficEncapModeNetworkPolicyOnly {

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -743,7 +743,7 @@ func (i *Initializer) configureGatewayInterface(gatewayIface *interfacestore.Int
 	// happen in upgrade case.
 	// Note the "mac" field in Windows OVS internal Interface has no impact on the network adapter's actual MAC,
 	// set it to the same value just to keep consistency.
-	if bytes.Compare(gatewayIface.MAC, gwMAC) != 0 {
+	if !bytes.Equal(gatewayIface.MAC, gwMAC) {
 		gatewayIface.MAC = gwMAC
 		if err := i.ovsBridgeClient.SetInterfaceMAC(gatewayIface.InterfaceName, gwMAC); err != nil {
 			klog.ErrorS(err, "Failed to persist interface MAC address", "interface", gatewayIface.InterfaceName, "mac", gwMAC)

--- a/pkg/agent/agent_linux_test.go
+++ b/pkg/agent/agent_linux_test.go
@@ -50,7 +50,7 @@ func TestPrepareOVSBridgeForK8sNode(t *testing.T) {
 		Name:         "ens160",
 		HardwareAddr: macAddr,
 	}
-	datapathID := "0000" + strings.Replace(macAddr.String(), ":", "", -1)
+	datapathID := "0000" + strings.ReplaceAll(macAddr.String(), ":", "")
 	nodeConfig := &config.NodeConfig{
 		UplinkNetConfig: &config.AdapterNetConfig{},
 		NodeIPv4Addr:    nodeIPNet,

--- a/pkg/agent/agent_windows.go
+++ b/pkg/agent/agent_windows.go
@@ -191,7 +191,7 @@ func (i *Initializer) prepareVMNetworkAndOVSExtension() error {
 		}
 	}()
 
-	uplinkMACStr := strings.Replace(uplinkIface.HardwareAddr.String(), ":", "", -1)
+	uplinkMACStr := strings.ReplaceAll(uplinkIface.HardwareAddr.String(), ":", "")
 	if err = winnetUtil.RenameVMNetworkAdapter(util.LocalVMSwitch, uplinkMACStr, hostIFName, true); err != nil {
 		return fmt.Errorf("failed to rename VMNetworkAdapter as %s: %v", hostIFName, err)
 	}

--- a/pkg/agent/apiserver/handlers/fqdncache/handler.go
+++ b/pkg/agent/apiserver/handlers/fqdncache/handler.go
@@ -59,9 +59,9 @@ func newFilterFromURLQuery(query url.Values) (*querier.FQDNCacheFilter, error) {
 	}
 	pattern := strings.TrimSpace(domain)
 	// Replace "." as a regex literal, since it's recogized as a separator in FQDN.
-	pattern = strings.Replace(pattern, ".", "[.]", -1)
+	pattern = strings.ReplaceAll(pattern, ".", "[.]")
 	// Replace "*" with ".*".
-	pattern = strings.Replace(pattern, "*", ".*", -1)
+	pattern = strings.ReplaceAll(pattern, "*", ".*")
 	// Anchor the regex match expression.
 	pattern = "^" + pattern + "$"
 

--- a/pkg/agent/apiserver/handlers/ovstracing/handler_test.go
+++ b/pkg/agent/apiserver/handlers/ovstracing/handler_test.go
@@ -232,11 +232,12 @@ func TestPodFlows(t *testing.T) {
 
 		if tc.expectedStatus == http.StatusNotFound {
 			q.EXPECT().GetInterfaceStore().Return(i).Times(1)
-			if tc.port == "pod" {
+			switch tc.port {
+			case "pod":
 				i.EXPECT().GetContainerInterfacesByPod("inPod", "inNS").Return(nil).Times(1)
-			} else if tc.port == "srcPod" {
+			case "srcPod":
 				i.EXPECT().GetContainerInterfacesByPod("srcPod", "srcNS").Return([]*interfacestore.InterfaceConfig{srcPodInterface}).Times(1)
-			} else {
+			default:
 				i.EXPECT().GetInterfaceByName(tc.port).Return(nil, false).Times(1)
 			}
 		}

--- a/pkg/agent/cniserver/interface_configuration_linux.go
+++ b/pkg/agent/cniserver/interface_configuration_linux.go
@@ -625,12 +625,13 @@ func (ic *ifConfigurator) validateInterface(intf *current.Interface, inNetns boo
 	if err != nil {
 		return nil, fmt.Errorf("failed to find link for interface %s", intf.Name)
 	}
-	if ifType == netDeviceTypeVeth {
+	switch ifType {
+	case netDeviceTypeVeth:
 		if !isVeth(link) {
 			return nil, fmt.Errorf("interface %s is not of type veth", intf.Name)
 		}
 		return link, nil
-	} else if ifType == netDeviceTypeVF {
+	case netDeviceTypeVF:
 		return link, nil
 	}
 	return nil, fmt.Errorf("unknown device type %s", ifType)

--- a/pkg/agent/cniserver/ipam/antrea_ipam_controller.go
+++ b/pkg/agent/cniserver/ipam/antrea_ipam_controller.go
@@ -149,7 +149,7 @@ func (c *AntreaIPAMController) getIPPoolsByPod(namespace, name string) ([]string
 	}
 
 	// Collect specified IPs if exist
-	ipStrings, _ := pod.Annotations[annotation.AntreaIPAMPodIPAnnotationKey]
+	ipStrings := pod.Annotations[annotation.AntreaIPAMPodIPAnnotationKey]
 	ipStrings = strings.ReplaceAll(ipStrings, " ", "")
 	var ipErr error
 	if ipStrings != "" {
@@ -167,7 +167,7 @@ func (c *AntreaIPAMController) getIPPoolsByPod(namespace, name string) ([]string
 
 ownerReferenceLoop:
 	for _, ownerReference := range pod.OwnerReferences {
-		if ownerReference.Controller != nil && *ownerReference.Controller == true {
+		if ownerReference.Controller != nil && *ownerReference.Controller {
 			switch ownerReference.Kind {
 			case "StatefulSet":
 				// Parse StatefulSet name/index from Pod name

--- a/pkg/agent/cniserver/pod_configuration.go
+++ b/pkg/agent/cniserver/pod_configuration.go
@@ -218,9 +218,9 @@ func ParseOVSPortInterfaceConfig(portData *ovsconfig.OVSPortData, portConfig *in
 	if err != nil {
 		klog.ErrorS(err, "Failed to parse MAC address from OVS external config")
 	}
-	podName, _ := portData.ExternalIDs[ovsExternalIDPodName]
-	podNamespace, _ := portData.ExternalIDs[ovsExternalIDPodNamespace]
-	ifDev, _ := portData.ExternalIDs[ovsExternalIDIFDev]
+	podName := portData.ExternalIDs[ovsExternalIDPodName]
+	podNamespace := portData.ExternalIDs[ovsExternalIDPodNamespace]
+	ifDev := portData.ExternalIDs[ovsExternalIDIFDev]
 
 	interfaceConfig := interfacestore.NewContainerInterface(
 		portData.Name,

--- a/pkg/agent/cniserver/pod_configuration_windows.go
+++ b/pkg/agent/cniserver/pod_configuration_windows.go
@@ -41,8 +41,8 @@ var (
 )
 
 const (
-	podNotReadyTimeInSeconds = 30 * time.Second
-	ovsInterfaceTypeForPod   = "internal"
+	podNotReadyTime        = 30 * time.Second
+	ovsInterfaceTypeForPod = "internal"
 )
 
 // connectInterfaceToOVSAsync waits for an interface to be created and connects it to OVS br-int asynchronously
@@ -55,7 +55,7 @@ func (pc *podConfigurator) connectInterfaceToOVSAsync(ifConfig *interfacestore.I
 	// need to think about the race condition between the current goroutine with the listener.
 	// It may generate a duplicated PodIsReady event if the Pod's OpenFlow entries are installed
 	// before the time, then the library shall merge the event.
-	pc.unreadyPortQueue.AddAfter(ovsPortName, podNotReadyTimeInSeconds)
+	pc.unreadyPortQueue.AddAfter(ovsPortName, podNotReadyTime)
 	return pc.ifConfigurator.addPostInterfaceCreateHook(ifConfig.ContainerID, ovsPortName, containerAccess, func() error {
 		if err := pc.ovsBridgeClient.SetInterfaceType(ovsPortName, ovsInterfaceTypeForPod); err != nil {
 			return err

--- a/pkg/agent/cniserver/server_windows_test.go
+++ b/pkg/agent/cniserver/server_windows_test.go
@@ -263,10 +263,9 @@ func (t *hnsTestUtil) addHostInterface() {
 		return
 	}
 	go func() {
-		select {
-		case <-time.After(time.Millisecond * 650):
+		time.AfterFunc(time.Millisecond*650, func() {
 			hostIfaces.Store(t.hostIfaceName, false)
-		}
+		})
 	}()
 }
 

--- a/pkg/agent/config/node_config.go
+++ b/pkg/agent/config/node_config.go
@@ -293,13 +293,14 @@ func (nc *NetworkConfig) NeedsDirectRoutingToPeer(peerIP net.IP, localIP *net.IP
 
 func (nc *NetworkConfig) getEncapMTUDeduction(isIPv6 bool) int {
 	var deduction int
-	if nc.TunnelType == ovsconfig.VXLANTunnel {
+	switch nc.TunnelType {
+	case ovsconfig.VXLANTunnel:
 		deduction = vxlanOverhead
-	} else if nc.TunnelType == ovsconfig.GeneveTunnel {
+	case ovsconfig.GeneveTunnel:
 		deduction = geneveOverhead
-	} else if nc.TunnelType == ovsconfig.GRETunnel {
+	case ovsconfig.GRETunnel:
 		deduction = greOverhead
-	} else {
+	default:
 		return 0
 	}
 	if isIPv6 {
@@ -326,10 +327,11 @@ func (nc *NetworkConfig) CalculateMTUDeduction(isIPv6 bool) int {
 	if nc.TrafficEncapMode.SupportsEncap() {
 		nc.MTUDeduction = nc.getEncapMTUDeduction(isIPv6)
 	}
-	if nc.TrafficEncryptionMode == TrafficEncryptionModeWireGuard {
+	switch nc.TrafficEncryptionMode {
+	case TrafficEncryptionModeWireGuard:
 		// When WireGuard is enabled, cross-node traffic will only be encrypted, just reduce MTU for encryption.
 		nc.MTUDeduction = nc.WireGuardMTUDeduction
-	} else if nc.TrafficEncryptionMode == TrafficEncryptionModeIPSec {
+	case TrafficEncryptionModeIPSec:
 		// When IPsec is enabled, cross-node traffic will be encapsulated and encrypted, we need to reduce MTU for both
 		// encapsulation and encryption.
 		nc.MTUDeduction += IPSecESPOverhead

--- a/pkg/agent/controller/egress/egress_controller.go
+++ b/pkg/agent/controller/egress/egress_controller.go
@@ -1245,19 +1245,17 @@ func (c *EgressController) watchEgressGroup() {
 	var initObjects []*cpv1b2.EgressGroup
 loop:
 	for {
-		select {
-		case event, ok := <-watcher.ResultChan():
-			if !ok {
-				klog.Warningf("Result channel for EgressGroup was closed")
-				return
-			}
-			switch event.Type {
-			case watch.Added:
-				klog.V(2).Infof("Added EgressGroup (%#v)", event.Object)
-				initObjects = append(initObjects, event.Object.(*cpv1b2.EgressGroup))
-			case watch.Bookmark:
-				break loop
-			}
+		event, ok := <-watcher.ResultChan()
+		if !ok {
+			klog.Warningf("Result channel for EgressGroup was closed")
+			return
+		}
+		switch event.Type {
+		case watch.Added:
+			klog.V(2).Infof("Added EgressGroup (%#v)", event.Object)
+			initObjects = append(initObjects, event.Object.(*cpv1b2.EgressGroup))
+		case watch.Bookmark:
+			break loop
 		}
 	}
 	klog.Infof("Received %d init events for EgressGroup", len(initObjects))
@@ -1266,27 +1264,25 @@ loop:
 	c.replaceEgressGroups(initObjects)
 
 	for {
-		select {
-		case event, ok := <-watcher.ResultChan():
-			if !ok {
-				return
-			}
-			switch event.Type {
-			case watch.Added:
-				c.addEgressGroup(event.Object.(*cpv1b2.EgressGroup))
-				klog.V(2).Infof("Added EgressGroup (%#v)", event.Object)
-			case watch.Modified:
-				c.patchEgressGroup(event.Object.(*cpv1b2.EgressGroupPatch))
-				klog.V(2).Infof("Updated EgressGroup (%#v)", event.Object)
-			case watch.Deleted:
-				c.deleteEgressGroup(event.Object.(*cpv1b2.EgressGroup))
-				klog.V(2).Infof("Removed EgressGroup (%#v)", event.Object)
-			default:
-				klog.Errorf("Unknown event: %v", event)
-				return
-			}
-			eventCount++
+		event, ok := <-watcher.ResultChan()
+		if !ok {
+			return
 		}
+		switch event.Type {
+		case watch.Added:
+			c.addEgressGroup(event.Object.(*cpv1b2.EgressGroup))
+			klog.V(2).Infof("Added EgressGroup (%#v)", event.Object)
+		case watch.Modified:
+			c.patchEgressGroup(event.Object.(*cpv1b2.EgressGroupPatch))
+			klog.V(2).Infof("Updated EgressGroup (%#v)", event.Object)
+		case watch.Deleted:
+			c.deleteEgressGroup(event.Object.(*cpv1b2.EgressGroup))
+			klog.V(2).Infof("Removed EgressGroup (%#v)", event.Object)
+		default:
+			klog.Errorf("Unknown event: %v", event)
+			return
+		}
+		eventCount++
 	}
 }
 

--- a/pkg/agent/controller/egress/egress_controller_test.go
+++ b/pkg/agent/controller/egress/egress_controller_test.go
@@ -92,7 +92,6 @@ func (d *fakeLocalIPDetector) Run(stopCh <-chan struct{}) {
 }
 
 func (d *fakeLocalIPDetector) AddEventHandler(handler ipassigner.LocalIPEventHandler) {
-	return
 }
 
 func (d *fakeLocalIPDetector) HasSynced() bool {

--- a/pkg/agent/controller/egress/ip_scheduler.go
+++ b/pkg/agent/controller/egress/ip_scheduler.go
@@ -345,7 +345,7 @@ func (s *egressIPScheduler) schedule() {
 
 		maxEgressIPsFilter := func(node string) bool {
 			// Count the Egress IPs that are already assigned to this Node.
-			ipsOnNode, _ := nodeToIPs[node]
+			ipsOnNode := nodeToIPs[node]
 			numIPs := ipsOnNode.Len()
 			// Check if this Node can accommodate the new Egress IP.
 			if !ipsOnNode.Has(egress.Spec.EgressIP) {

--- a/pkg/agent/controller/networkpolicy/audit_logging_test.go
+++ b/pkg/agent/controller/networkpolicy/audit_logging_test.go
@@ -211,7 +211,7 @@ func TestRedirectPacketLog(t *testing.T) {
 func TestGetNetworkPolicyInfo(t *testing.T) {
 	prepareMockOFTablesWithCache()
 	generateMatch := func(regID int, data []byte) openflow15.MatchField {
-		baseData := make([]byte, 8, 8)
+		baseData := make([]byte, 8)
 		if regID%2 == 0 {
 			copy(baseData[0:4], data)
 		} else {
@@ -441,7 +441,7 @@ func TestGetNetworkPolicyInfo(t *testing.T) {
 			}
 			if tc.tableIDInReg != nil {
 				tableMatchRegID := openflow.PacketInTableField.GetRegID()
-				tableRegData := make([]byte, 4, 4)
+				tableRegData := make([]byte, 4)
 				binary.BigEndian.PutUint32(tableRegData[0:], uint32(*tc.tableIDInReg))
 				found := false
 				for _, m := range matchers {

--- a/pkg/agent/controller/networkpolicy/cache.go
+++ b/pkg/agent/controller/networkpolicy/cache.go
@@ -492,10 +492,8 @@ func (c *ruleCache) processExternalEntityUpdate(e interface{}) {
 // ToServices field and use dirtyRuleHandler to re-queue these rules.
 func (c *ruleCache) processGroupIDUpdates() {
 	for {
-		select {
-		case svcStr := <-c.groupIDUpdates:
-			c.processServiceGroupIDUpdate(svcStr)
-		}
+		svcStr := <-c.groupIDUpdates
+		c.processServiceGroupIDUpdate(svcStr)
 	}
 }
 
@@ -527,7 +525,6 @@ func (c *ruleCache) ReplaceAddressGroups(groups []*v1beta.AddressGroup) {
 	for key := range oldGroupKeys {
 		delete(c.addressSetByGroup, key)
 	}
-	return
 }
 
 // AddAddressGroup adds a new *v1beta.AddressGroup to the cache. The rules
@@ -630,7 +627,6 @@ func (c *ruleCache) ReplaceAppliedToGroups(groups []*v1beta.AppliedToGroup) {
 	for key := range oldGroupKeys {
 		delete(c.appliedToSetByGroup, key)
 	}
-	return
 }
 
 // AddAppliedToGroup adds a new *v1beta.AppliedToGroup to the cache. The rules
@@ -775,7 +771,6 @@ func (c *ruleCache) ReplaceNetworkPolicies(policies []*v1beta.NetworkPolicy) {
 	for key := range oldKeys {
 		c.deleteNetworkPolicyLocked(key)
 	}
-	return
 }
 
 // AddNetworkPolicy adds a new *v1beta.NetworkPolicy to the cache.

--- a/pkg/agent/controller/networkpolicy/cache_test.go
+++ b/pkg/agent/controller/networkpolicy/cache_test.go
@@ -1054,7 +1054,7 @@ func TestRuleCachePatchAppliedToGroup(t *testing.T) {
 			if !recorder.rules.Equal(tt.expectedDirtyRules) {
 				t.Errorf("Got dirty rules %v, expected %v", recorder.rules, tt.expectedDirtyRules)
 			}
-			actualPods, _ := c.appliedToSetByGroup[tt.args.Name]
+			actualPods := c.appliedToSetByGroup[tt.args.Name]
 			assert.ElementsMatch(t, tt.expectedPods, actualPods.Items(), "stored Pods not equal")
 			if !tt.expectedErr {
 				assert.Equal(t, len(ret.GroupMembers), len(actualPods))
@@ -1134,7 +1134,7 @@ func TestRuleCachePatchAddressGroup(t *testing.T) {
 			if !recorder.rules.Equal(tt.expectedDirtyRules) {
 				t.Errorf("Got dirty rules %v, expected %v", recorder.rules, tt.expectedDirtyRules)
 			}
-			actualAddresses, _ := c.addressSetByGroup[tt.args.Name]
+			actualAddresses := c.addressSetByGroup[tt.args.Name]
 			assert.ElementsMatch(t, tt.expectedAddresses, actualAddresses.Items(), "stored addresses not equal")
 			if !tt.expectedErr {
 				assert.Equal(t, len(ret.GroupMembers), len(actualAddresses))

--- a/pkg/agent/controller/networkpolicy/fqdn.go
+++ b/pkg/agent/controller/networkpolicy/fqdn.go
@@ -223,9 +223,9 @@ func toRegex(pattern string) string {
 	pattern = strings.TrimSpace(pattern)
 
 	// Replace "." as a regex literal, since it's recogized as a separator in FQDN.
-	pattern = strings.Replace(pattern, ".", "[.]", -1)
+	pattern = strings.ReplaceAll(pattern, ".", "[.]")
 	// Replace "*" with ".*".
-	pattern = strings.Replace(pattern, "*", ".*", -1)
+	pattern = strings.ReplaceAll(pattern, "*", ".*")
 
 	// Anchor the regex match expression.
 	return "^" + pattern + "$"
@@ -661,9 +661,7 @@ func (f *fqdnController) parseDNSResponse(msg *dns.Msg) (string, map[string]ipWi
 	if len(responseIPs) > 0 {
 		klog.V(4).InfoS("Received DNS Packet with valid Answer", "IPs", responseIPs)
 	}
-	if strings.HasSuffix(fqdn, ".") {
-		fqdn = fqdn[:len(fqdn)-1]
-	}
+	fqdn = strings.TrimSuffix(fqdn, ".")
 	return fqdn, responseIPs, nil
 }
 

--- a/pkg/agent/controller/networkpolicy/fqdn_test.go
+++ b/pkg/agent/controller/networkpolicy/fqdn_test.go
@@ -579,13 +579,8 @@ func TestSyncDirtyRules(t *testing.T) {
 			for _, waitCh := range tc.waitChs {
 				if waitCh != nil {
 					assert.Eventually(t, func() bool {
-						select {
-						case err := <-waitCh:
-							if err != nil && !tc.expectErr {
-								return false
-							}
-						}
-						return true
+						err := <-waitCh
+						return err == nil || tc.expectErr
 					}, ruleRealizationTimeout, time.Millisecond*10, "Failed to successfully wait for rule syncs")
 				}
 			}
@@ -725,7 +720,7 @@ func TestOnDNSResponse(t *testing.T) {
 
 			f.onDNSResponse(testFQDN, tc.dnsResponseIPs, nil)
 
-			cachedDnsMetaData, _ := f.dnsEntryCache[testFQDN]
+			cachedDnsMetaData := f.dnsEntryCache[testFQDN]
 
 			assert.Equal(t, tc.expectedIPs, cachedDnsMetaData.responseIPs, "FQDN cache doesn't match expected entries")
 

--- a/pkg/agent/controller/networkpolicy/l7engine/reconciler.go
+++ b/pkg/agent/controller/networkpolicy/l7engine/reconciler.go
@@ -494,7 +494,7 @@ func (r *Reconciler) startSuricata() error {
 	}
 	defer f.Close()
 	// Include the config file /etc/suricata/antrea.yaml for Antrea in the default Suricata config file /etc/suricata/suricata.yaml.
-	if _, err = f.WriteString(fmt.Sprintf("include: %s\n", antreaSuricataConfigPath)); err != nil {
+	if _, err = fmt.Fprintf(f, "include: %s\n", antreaSuricataConfigPath); err != nil {
 		return fmt.Errorf("failed to update default Suricata config file %s: %w", defaultSuricataConfigPath, err)
 	}
 

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
@@ -160,7 +160,6 @@ func (r *mockReconciler) Forget(ruleID string) error {
 }
 
 func (r *mockReconciler) RunIDAllocatorWorker(_ <-chan struct{}) {
-	return
 }
 
 func (r *mockReconciler) RegisterFQDNController(fc *fqdnController) {

--- a/pkg/agent/controller/networkpolicy/pod_reconciler.go
+++ b/pkg/agent/controller/networkpolicy/pod_reconciler.go
@@ -301,7 +301,7 @@ func (r *podReconciler) Reconcile(rule *CompletedRule) error {
 
 	value, exists := r.lastRealizeds.Load(rule.ID)
 	ruleTable := r.getOFRuleTable(rule)
-	priorityAssigner, _ := r.priorityAssigners[ruleTable]
+	priorityAssigner := r.priorityAssigners[ruleTable]
 	// IGMP Egress policy is enforced in userspace via packet-in message, there won't be OpenFlow
 	// rules created for such rules. Therefore, assigning priority is not required.
 	if rule.isAntreaNetworkPolicyRule() && !rule.isIGMPEgressPolicyRule() {
@@ -994,7 +994,7 @@ func (r *podReconciler) uninstallOFRule(ofID uint32, table uint8) error {
 				return err
 			}
 			// If there are stalePriorities, priorityAssigners[table] must not be nil.
-			priorityAssigner, _ := r.priorityAssigners[table]
+			priorityAssigner := r.priorityAssigners[table]
 			priorityAssigner.assigner.release(uint16(priorityNum))
 		}
 	}
@@ -1035,11 +1035,9 @@ func (r *podReconciler) Forget(ruleID string) error {
 }
 
 func (r *podReconciler) isIGMPRule(rule *CompletedRule) bool {
-	isIGMP := false
-	if len(rule.Services) > 0 && (rule.Services[0].Protocol != nil) &&
-		(*rule.Services[0].Protocol == v1beta2.ProtocolIGMP) {
-		isIGMP = true
-	}
+	isIGMP := len(rule.Services) > 0 && (rule.Services[0].Protocol != nil) &&
+		(*rule.Services[0].Protocol == v1beta2.ProtocolIGMP)
+
 	return isIGMP
 }
 

--- a/pkg/agent/controller/networkpolicy/pod_reconciler_test.go
+++ b/pkg/agent/controller/networkpolicy/pod_reconciler_test.go
@@ -99,7 +99,7 @@ var (
 		UID:  "uid2",
 	}
 
-	transientError = errors.New("Transient OVS error")
+	errTransient = errors.New("Transient OVS error")
 )
 
 func newCIDR(cidrStr string) *net.IPNet {
@@ -919,7 +919,7 @@ func TestReconcileWithTransientError(t *testing.T) {
 	r.idAllocator.deleteInterval = 0
 
 	// Make the first call fail.
-	mockOFClient.EXPECT().InstallPolicyRuleFlows(gomock.Any()).Return(transientError).Times(1)
+	mockOFClient.EXPECT().InstallPolicyRuleFlows(gomock.Any()).Return(errTransient).Times(1)
 	err := r.Reconcile(egressRule)
 	assert.Error(t, err)
 	// Ensure the openflow ID is not persistent in podPolicyLastRealized and is released to idAllocator upon error.

--- a/pkg/agent/controller/traceflow/packetin.go
+++ b/pkg/agent/controller/traceflow/packetin.go
@@ -35,14 +35,14 @@ import (
 	binding "antrea.io/antrea/pkg/ovs/openflow"
 )
 
-var skipTraceflowUpdateErr = errors.New("skip Traceflow update")
+var errSkipTraceflowUpdate = errors.New("skip Traceflow update")
 
 func (c *Controller) HandlePacketIn(pktIn *ofctrl.PacketIn) error {
 	if !c.traceflowListerSynced() {
 		return errors.New("Traceflow controller is not started")
 	}
 	oldTf, nodeResult, packet, err := c.parsePacketIn(pktIn)
-	if err == skipTraceflowUpdateErr {
+	if err == errSkipTraceflowUpdate {
 		return nil
 	}
 	if err != nil {
@@ -85,7 +85,8 @@ func (c *Controller) parsePacketIn(pktIn *ofctrl.PacketIn) (*crdv1beta1.Traceflo
 	if err := etherData.UnmarshalBinary(pktIn.Data.(*util.Buffer).Bytes()); err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to parse Ethernet packet from packet-in message: %v", err)
 	}
-	if etherData.Ethertype == protocol.IPv4_MSG {
+	switch etherData.Ethertype {
+	case protocol.IPv4_MSG:
 		ipPacket, ok := etherData.Data.(*protocol.IPv4)
 		if !ok {
 			return nil, nil, nil, errors.New("invalid traceflow IPv4 packet")
@@ -101,7 +102,7 @@ func (c *Controller) parsePacketIn(pktIn *ofctrl.PacketIn) (*crdv1beta1.Traceflo
 		}
 		ipDst = ipPacket.NWDst.String()
 		ipSrc = ipPacket.NWSrc.String()
-	} else if etherData.Ethertype == protocol.IPv6_MSG {
+	case protocol.IPv6_MSG:
 		ipv6Packet, ok := etherData.Data.(*protocol.IPv6)
 		if !ok {
 			return nil, nil, nil, errors.New("invalid traceflow IPv6 packet")
@@ -117,7 +118,7 @@ func (c *Controller) parsePacketIn(pktIn *ofctrl.PacketIn) (*crdv1beta1.Traceflo
 		}
 		ipDst = ipv6Packet.NWDst.String()
 		ipSrc = ipv6Packet.NWSrc.String()
-	} else {
+	default:
 		return nil, nil, nil, fmt.Errorf("unsupported traceflow packet Ethertype: %d", etherData.Ethertype)
 	}
 
@@ -145,7 +146,7 @@ func (c *Controller) parsePacketIn(pktIn *ofctrl.PacketIn) (*crdv1beta1.Traceflo
 		// request does not specify source / destination ports.
 		if !firstPacket {
 			klog.InfoS("An additional Traceflow packet was received unexpectedly for Live Traceflow, ignoring it")
-			return nil, nil, nil, skipTraceflowUpdateErr
+			return nil, nil, nil, errSkipTraceflowUpdate
 		}
 		// Uninstall the OVS flows after receiving the first packet, to
 		// avoid capturing too many matched packets.
@@ -484,11 +485,12 @@ func parseCapturedPacket(pktIn *ofctrl.PacketIn) *crdv1beta1.Packet {
 	} else {
 		capturedPacket.IPHeader = &crdv1beta1.IPHeader{Protocol: int32(pkt.IPProto), TTL: int32(pkt.TTL), Flags: int32(pkt.IPFlags)}
 	}
-	if pkt.IPProto == protocol.Type_TCP {
+	switch pkt.IPProto {
+	case protocol.Type_TCP:
 		capturedPacket.TransportHeader.TCP = &crdv1beta1.TCPHeader{SrcPort: int32(pkt.SourcePort), DstPort: int32(pkt.DestinationPort), Flags: ptr.To(int32(pkt.TCPFlags))}
-	} else if pkt.IPProto == protocol.Type_UDP {
+	case protocol.Type_UDP:
 		capturedPacket.TransportHeader.UDP = &crdv1beta1.UDPHeader{SrcPort: int32(pkt.SourcePort), DstPort: int32(pkt.DestinationPort)}
-	} else if pkt.IPProto == protocol.Type_ICMP || pkt.IPProto == protocol.Type_IPv6ICMP {
+	case protocol.Type_ICMP, protocol.Type_IPv6ICMP:
 		capturedPacket.TransportHeader.ICMP = &crdv1beta1.ICMPEchoRequestHeader{ID: int32(pkt.ICMPEchoID), Sequence: int32(pkt.ICMPEchoSeq)}
 	}
 	return &capturedPacket

--- a/pkg/agent/controller/traceflow/packetin_test.go
+++ b/pkg/agent/controller/traceflow/packetin_test.go
@@ -730,5 +730,5 @@ func TestParsePacketInLiveDuplicates(t *testing.T) {
 	tfc.runningTraceflows[tfState.tag] = tfState
 
 	_, _, _, err := tfc.parsePacketIn(pktIn)
-	assert.ErrorIs(t, err, skipTraceflowUpdateErr)
+	assert.ErrorIs(t, err, errSkipTraceflowUpdate)
 }

--- a/pkg/agent/controller/trafficcontrol/controller.go
+++ b/pkg/agent/controller/trafficcontrol/controller.go
@@ -649,11 +649,12 @@ func (c *Controller) createERSPANPort(portName string, tunnelConfig *v1alpha2.ER
 	if tunnelConfig.SessionID != nil {
 		extraOptions["key"] = strconv.Itoa(int(*tunnelConfig.SessionID))
 	}
-	if tunnelConfig.Version == 1 {
+	switch tunnelConfig.Version {
+	case 1:
 		if tunnelConfig.Index != nil {
 			extraOptions["erspan_idx"] = strconv.FormatInt(int64(*tunnelConfig.Index), 16)
 		}
-	} else if tunnelConfig.Version == 2 {
+	case 2:
 		if tunnelConfig.Dir != nil {
 			extraOptions["erspan_dir"] = strconv.Itoa(int(*tunnelConfig.Dir))
 		}

--- a/pkg/agent/controller/trafficcontrol/controller_test.go
+++ b/pkg/agent/controller/trafficcontrol/controller_test.go
@@ -240,28 +240,28 @@ func generateTrafficControl(name string,
 	if podSelector != nil {
 		tc.Spec.AppliedTo.PodSelector = &metav1.LabelSelector{MatchLabels: podSelector}
 	}
-	switch targetPort.(type) {
+	switch targetPort := targetPort.(type) {
 	case *v1alpha2.OVSInternalPort:
-		tc.Spec.TargetPort.OVSInternal = targetPort.(*v1alpha2.OVSInternalPort)
+		tc.Spec.TargetPort.OVSInternal = targetPort
 	case *v1alpha2.NetworkDevice:
-		tc.Spec.TargetPort.Device = targetPort.(*v1alpha2.NetworkDevice)
+		tc.Spec.TargetPort.Device = targetPort
 	case *v1alpha2.UDPTunnel:
 		if isTargetPortVXLAN {
-			tc.Spec.TargetPort.VXLAN = targetPort.(*v1alpha2.UDPTunnel)
+			tc.Spec.TargetPort.VXLAN = targetPort
 		} else {
-			tc.Spec.TargetPort.GENEVE = targetPort.(*v1alpha2.UDPTunnel)
+			tc.Spec.TargetPort.GENEVE = targetPort
 		}
 	case *v1alpha2.GRETunnel:
-		tc.Spec.TargetPort.GRE = targetPort.(*v1alpha2.GRETunnel)
+		tc.Spec.TargetPort.GRE = targetPort
 	case *v1alpha2.ERSPANTunnel:
-		tc.Spec.TargetPort.ERSPAN = targetPort.(*v1alpha2.ERSPANTunnel)
+		tc.Spec.TargetPort.ERSPAN = targetPort
 	}
 
-	switch returnPort.(type) {
+	switch returnPort := returnPort.(type) {
 	case *v1alpha2.OVSInternalPort:
-		tc.Spec.ReturnPort.OVSInternal = returnPort.(*v1alpha2.OVSInternalPort)
+		tc.Spec.ReturnPort.OVSInternal = returnPort
 	case *v1alpha2.NetworkDevice:
-		tc.Spec.ReturnPort.Device = returnPort.(*v1alpha2.NetworkDevice)
+		tc.Spec.ReturnPort.Device = returnPort
 	default:
 		tc.Spec.ReturnPort = nil
 	}

--- a/pkg/agent/externalnode/external_node_controller.go
+++ b/pkg/agent/externalnode/external_node_controller.go
@@ -663,14 +663,14 @@ func ParseHostInterfaceConfig(ovsBridgeClient ovsconfig.OVSBridgeClient, portDat
 		entityIPs = append(entityIPs, net.ParseIP(ipStr))
 	}
 	interfaceConfig.IPs = entityIPs
-	uplinkName, _ := portData.ExternalIDs[ovsExternalIDUplinkName]
-	uplinkPortUUID, _ := portData.ExternalIDs[ovsExternalIDUplinkPort]
+	uplinkName := portData.ExternalIDs[ovsExternalIDUplinkName]
+	uplinkPortUUID := portData.ExternalIDs[ovsExternalIDUplinkPort]
 	uplinkPortData, ovsErr := ovsBridgeClient.GetPortData(uplinkPortUUID, uplinkName)
 	if ovsErr != nil {
 		return nil, ovsErr
 	}
-	entityName, _ := portData.ExternalIDs[ovsExternalIDEntityName]
-	entityNamespace, _ := portData.ExternalIDs[ovsExternalIDEntityNamespace]
+	entityName := portData.ExternalIDs[ovsExternalIDEntityName]
+	entityNamespace := portData.ExternalIDs[ovsExternalIDEntityNamespace]
 	hostUplinkConfig = &interfacestore.EntityInterfaceConfig{
 		EntityName:      entityName,
 		EntityNamespace: entityNamespace,

--- a/pkg/agent/flowexporter/connections/conntrack_ovs.go
+++ b/pkg/agent/flowexporter/connections/conntrack_ovs.go
@@ -248,7 +248,7 @@ func flowStringToAntreaConnection(flow string, zoneFilter uint16) (*flowexporter
 			conn.Timeout = uint32(val)
 		case strings.Contains(fs, "labels"):
 			fields := strings.Split(fs, "=")
-			labelStr := strings.Replace(fields[len(fields)-1], "0x", "", -1)
+			labelStr := strings.ReplaceAll(fields[len(fields)-1], "0x", "")
 			// Add leading zeros since DecodeString() expects the input string has even length
 			if len(labelStr) < 16 {
 				labelStr = strings.Repeat("0", 16-len(labelStr)) + labelStr

--- a/pkg/agent/flowexporter/exporter/exporter_test.go
+++ b/pkg/agent/flowexporter/exporter/exporter_test.go
@@ -90,8 +90,7 @@ func testSendTemplateSet(t *testing.T, v4Enabled bool, v6Enabled bool) {
 }
 
 func sendTemplateSet(t *testing.T, ctrl *gomock.Controller, mockIPFIXExpProc *ipfixtest.MockIPFIXExportingProcess, mockIPFIXRegistry *ipfixtest.MockIPFIXRegistry, flowExp *FlowExporter, isIPv6 bool) {
-	var mockTempSet *ipfixentitiestesting.MockSet
-	mockTempSet = ipfixentitiestesting.NewMockSet(ctrl)
+	var mockTempSet = ipfixentitiestesting.NewMockSet(ctrl)
 	flowExp.ipfixSet = mockTempSet
 	// Following consists of all elements that are in IANAInfoElements and AntreaInfoElements (globals)
 	// Only the element name is needed, other arguments have dummy values.

--- a/pkg/agent/interfacestore/interface_cache.go
+++ b/pkg/agent/interfacestore/interface_cache.go
@@ -84,12 +84,13 @@ func (c *interfaceCache) Initialize(interfaces []*InterfaceConfig) {
 func getInterfaceKey(obj interface{}) (string, error) {
 	interfaceConfig := obj.(*InterfaceConfig)
 	var key string
-	if interfaceConfig.Type == ContainerInterface {
+	switch interfaceConfig.Type {
+	case ContainerInterface:
 		key = util.GenerateContainerInterfaceKey(interfaceConfig.ContainerID, interfaceConfig.IFDev)
-	} else if interfaceConfig.Type == IPSecTunnelInterface {
+	case IPSecTunnelInterface:
 		// IPsec tunnel interface for a Node.
 		key = util.GenerateNodeTunnelInterfaceKey(interfaceConfig.NodeName)
-	} else {
+	default:
 		// Use the interface name as the key by default.
 		key = interfaceConfig.InterfaceName
 	}

--- a/pkg/agent/ipassigner/local_ip_detector_windows.go
+++ b/pkg/agent/ipassigner/local_ip_detector_windows.go
@@ -22,11 +22,9 @@ func (d *localIPDetector) IsLocalIP(ip string) bool {
 }
 
 func (d *localIPDetector) Run(stopCh <-chan struct{}) {
-	return
 }
 
 func (d *localIPDetector) AddEventHandler(handler LocalIPEventHandler) {
-	return
 }
 
 func (d *localIPDetector) HasSynced() bool {

--- a/pkg/agent/multicast/mcast_controller.go
+++ b/pkg/agent/multicast/mcast_controller.go
@@ -861,9 +861,10 @@ func (c *Controller) processNextNodeItem() bool {
 
 func memberExists(status *GroupMemberStatus, e *mcastGroupEvent) bool {
 	var exist bool
-	if e.iface.Type == interfacestore.ContainerInterface {
+	switch e.iface.Type {
+	case interfacestore.ContainerInterface:
 		_, exist = status.localMembers[e.iface.InterfaceName]
-	} else if e.iface.Type == interfacestore.TunnelInterface {
+	case interfacestore.TunnelInterface:
 		exist = status.remoteMembers.Has(e.srcNode.String())
 	}
 	return exist

--- a/pkg/agent/multicast/mcast_discovery.go
+++ b/pkg/agent/multicast/mcast_discovery.go
@@ -160,11 +160,12 @@ func (s *IGMPSnooper) addToIGMPReportNPStatsMap(item types.IGMPNPRuleInfo, packe
 		t.Bytes += packetLen
 	}
 	ruleType := *item.NPType
-	if ruleType == v1beta2.AntreaNetworkPolicy {
+	switch ruleType {
+	case v1beta2.AntreaNetworkPolicy:
 		s.igmpReportANNPStatsMutex.Lock()
 		updateRuleStats(s.igmpReportANNPStats, item.UUID, item.Name)
 		s.igmpReportANNPStatsMutex.Unlock()
-	} else if ruleType == v1beta2.AntreaClusterNetworkPolicy {
+	case v1beta2.AntreaClusterNetworkPolicy:
 		s.igmpReportACNPStatsMutex.Lock()
 		updateRuleStats(s.igmpReportACNPStats, item.UUID, item.Name)
 		s.igmpReportACNPStatsMutex.Unlock()
@@ -229,9 +230,10 @@ func (s *IGMPSnooper) HandlePacketIn(pktIn *ofctrl.PacketIn) error {
 	klog.V(2).InfoS("Received PacketIn for IGMP packet", "in_port", iface.OFPort)
 	podName := "unknown"
 	var srcNode net.IP
-	if iface.Type == interfacestore.ContainerInterface {
+	switch iface.Type {
+	case interfacestore.ContainerInterface:
 		podName = iface.PodName
-	} else if iface.Type == interfacestore.TunnelInterface {
+	case interfacestore.TunnelInterface:
 		var err error
 		srcNode, err = s.parseSrcNode(pktIn)
 		if err != nil {

--- a/pkg/agent/multicast/mcast_discovery_test.go
+++ b/pkg/agent/multicast/mcast_discovery_test.go
@@ -57,14 +57,12 @@ func (v *snooperValidator) processPackets(expectedPackets int) {
 		return groupNodes
 	}
 	for i := 0; i < expectedPackets; i++ {
-		select {
-		case e := <-v.eventCh:
-			groupKey := e.group.String()
-			if e.eType == groupJoin {
-				v.groupJoinedNodes = appendSrcNode(groupKey, v.groupJoinedNodes, e.srcNode)
-			} else {
-				v.groupLeftNodes = appendSrcNode(groupKey, v.groupLeftNodes, e.srcNode)
-			}
+		e := <-v.eventCh
+		groupKey := e.group.String()
+		if e.eType == groupJoin {
+			v.groupJoinedNodes = appendSrcNode(groupKey, v.groupJoinedNodes, e.srcNode)
+		} else {
+			v.groupLeftNodes = appendSrcNode(groupKey, v.groupLeftNodes, e.srcNode)
 		}
 	}
 }

--- a/pkg/agent/nodeportlocal/npl_agent_test.go
+++ b/pkg/agent/nodeportlocal/npl_agent_test.go
@@ -850,7 +850,7 @@ func TestInitInvalidPod(t *testing.T) {
 }
 
 var (
-	portTakenError = fmt.Errorf("Port taken")
+	errPortTaken = fmt.Errorf("Port taken")
 )
 
 // TestNodePortAlreadyBoundTo validates that when a port with TCP protocol is already bound to,
@@ -861,7 +861,7 @@ func TestNodePortAlreadyBoundTo(t *testing.T) {
 	testConfig := newTestConfig().withCustomPortOpenerExpectations(func(mockPortOpener *portcachetesting.MockLocalPortOpener) {
 		gomock.InOrder(
 			// 1. port1 is checked for TCP availability -> error
-			mockPortOpener.EXPECT().OpenLocalPort(nodePort1, protocolTCP).Return(nil, portTakenError),
+			mockPortOpener.EXPECT().OpenLocalPort(nodePort1, protocolTCP).Return(nil, errPortTaken),
 			// 2. port2 is checked for TCP availability -> success
 			mockPortOpener.EXPECT().OpenLocalPort(nodePort2, protocolTCP).Return(&fakeSocket{}, nil),
 		)

--- a/pkg/agent/nodeportlocal/portcache/port_table.go
+++ b/pkg/agent/nodeportlocal/portcache/port_table.go
@@ -177,7 +177,7 @@ func (pt *PortTable) GetDataForPod(podKey string) []*NodePortData {
 
 func (pt *PortTable) getDataForPod(podKey string) []*NodePortData {
 	allData, exist := pt.getPortTableCacheFromPodKeyIndex(podKey)
-	if exist == false {
+	if !exist {
 		return nil
 	}
 	return allData

--- a/pkg/agent/openflow/client_test.go
+++ b/pkg/agent/openflow/client_test.go
@@ -2239,9 +2239,10 @@ func Test_client_SendPacketOut(t *testing.T) {
 					nil))
 			case binding.ProtocolIGMP:
 				mockPacketOutBuilder.EXPECT().SetL4Packet(tc.igmp).Return(mockPacketOutBuilder)
-				if tc.name == "SendIGMPQueryPacketOut" {
+				switch tc.name {
+				case "SendIGMPQueryPacketOut":
 					assert.NoError(t, fc.SendIGMPQueryPacketOut(dstMAC, dstIP, outPort, tc.igmp))
-				} else if tc.name == "SendIGMPRemoteReportPacketOut" {
+				case "SendIGMPRemoteReportPacketOut":
 					assert.NoError(t, fc.SendIGMPRemoteReportPacketOut(dstMAC, dstIP, tc.igmp))
 				}
 			}

--- a/pkg/agent/openflow/egress.go
+++ b/pkg/agent/openflow/egress.go
@@ -60,9 +60,10 @@ func newFeatureEgress(cookieAllocator cookie.Allocator,
 
 	nodeIPs := make(map[binding.Protocol]net.IP)
 	for _, ipProtocol := range ipProtocols {
-		if ipProtocol == binding.ProtocolIP {
+		switch ipProtocol {
+		case binding.ProtocolIP:
 			nodeIPs[ipProtocol] = nodeConfig.NodeIPv4Addr.IP
-		} else if ipProtocol == binding.ProtocolIPv6 {
+		case binding.ProtocolIPv6:
 			nodeIPs[ipProtocol] = nodeConfig.NodeIPv6Addr.IP
 		}
 	}

--- a/pkg/agent/openflow/externalnode_connectivity.go
+++ b/pkg/agent/openflow/externalnode_connectivity.go
@@ -45,9 +45,10 @@ func newFeatureExternalNodeConnectivity(
 	ipProtocols []binding.Protocol) *featureExternalNodeConnectivity {
 	ctZones := make(map[binding.Protocol]int)
 	for _, ipProtocol := range ipProtocols {
-		if ipProtocol == binding.ProtocolIP {
+		switch ipProtocol {
+		case binding.ProtocolIP:
 			ctZones[ipProtocol] = CtZone
-		} else if ipProtocol == binding.ProtocolIPv6 {
+		case binding.ProtocolIPv6:
 			ctZones[ipProtocol] = CtZoneV6
 		}
 	}
@@ -144,9 +145,7 @@ func (f *featureExternalNodeConnectivity) replayFlows() []*openflow15.FlowMod {
 	var flows []*openflow15.FlowMod
 	rangeFunc := func(key, value interface{}) bool {
 		cachedFlows := value.([]*openflow15.FlowMod)
-		for _, flow := range cachedFlows {
-			flows = append(flows, flow)
-		}
+		flows = append(flows, cachedFlows...)
 		return true
 	}
 	f.uplinkFlowCache.Range(rangeFunc)

--- a/pkg/agent/openflow/network_policy.go
+++ b/pkg/agent/openflow/network_policy.go
@@ -747,7 +747,8 @@ func (c *client) NewDNSPacketInConjunction(id uint32) error {
 				},
 			},
 		}
-		if proto == binding.ProtocolIP {
+		switch proto {
+		case binding.ProtocolIP:
 			tcpMatch.matchPairs = append(tcpMatch.matchPairs, matchPair{
 				matchKey:   MatchTCPSrcPort,
 				matchValue: dnsPortMatchValue,
@@ -756,7 +757,7 @@ func (c *client) NewDNSPacketInConjunction(id uint32) error {
 				matchKey:   MatchUDPSrcPort,
 				matchValue: dnsPortMatchValue,
 			})
-		} else if proto == binding.ProtocolIPv6 {
+		case binding.ProtocolIPv6:
 			tcpMatch.matchPairs = append(tcpMatch.matchPairs, matchPair{
 				matchKey:   MatchTCPv6SrcPort,
 				matchValue: dnsPortMatchValue,
@@ -1168,9 +1169,7 @@ func (c *client) InstallPolicyRuleFlows(rule *types.PolicyRule) error {
 	ctxChanges := c.featureNetworkPolicy.calculateMatchFlowChangesForRule(conj, rule)
 
 	var flowMessages []*openflow15.FlowMod
-	for _, fm := range append(conj.metricFlows, conj.actionFlows...) {
-		flowMessages = append(flowMessages, fm)
-	}
+	flowMessages = append(flowMessages, append(conj.metricFlows, conj.actionFlows...)...)
 	if err := c.ofEntryOperations.AddAll(flowMessages); err != nil {
 		return err
 	}
@@ -1317,9 +1316,7 @@ func (c *client) BatchInstallPolicyRuleFlows(ofPolicyRules []*types.PolicyRule) 
 	for _, rule := range ofPolicyRules {
 		conj := c.featureNetworkPolicy.calculateActionFlowChangesForRule(rule)
 		c.featureNetworkPolicy.addRuleToConjunctiveMatch(conj, rule)
-		for _, msg := range append(conj.actionFlows, conj.metricFlows...) {
-			allFlowMessages = append(allFlowMessages, msg)
-		}
+		allFlowMessages = append(allFlowMessages, append(conj.actionFlows, conj.metricFlows...)...)
 		conjunctions = append(conjunctions, conj)
 	}
 
@@ -1626,14 +1623,10 @@ func (f *featureNetworkPolicy) getStalePriorities(conj *policyRuleConjunction) (
 func (f *featureNetworkPolicy) replayFlows() []*openflow15.FlowMod {
 	var flows []*openflow15.FlowMod
 	addActionFlows := func(conj *policyRuleConjunction) {
-		for _, flow := range conj.actionFlows {
-			flows = append(flows, flow)
-		}
+		flows = append(flows, conj.actionFlows...)
 	}
 	addMetricFlows := func(conj *policyRuleConjunction) {
-		for _, flow := range conj.metricFlows {
-			flows = append(flows, flow)
-		}
+		flows = append(flows, conj.metricFlows...)
 	}
 
 	for _, conj := range f.policyCache.List() {

--- a/pkg/agent/openflow/operations/operations.go
+++ b/pkg/agent/openflow/operations/operations.go
@@ -127,13 +127,14 @@ func (c *ofEntryOperations) changeOFEntries(ofEntries []binding.OFEntry, action 
 		return nil
 	}
 	var adds, mods, dels []binding.OFEntry
-	if action == add {
+	switch action {
+	case add:
 		adds = ofEntries
-	} else if action == mod {
+	case mod:
 		mods = ofEntries
-	} else if action == del {
+	case del:
 		dels = ofEntries
-	} else {
+	default:
 		return fmt.Errorf("OF Entries Action not exists: %s", action)
 	}
 	startTime := time.Now()

--- a/pkg/agent/openflow/packetin_test.go
+++ b/pkg/agent/openflow/packetin_test.go
@@ -109,10 +109,8 @@ func Test_StartPacketInHandler(t *testing.T) {
 				UserData: tt.userData,
 			}
 			bridge.PacketRcvd(nil, packetIn)
-			select {
-			case value := <-callChannel:
-				assert.Equal(t, value, tt.expectValue)
-			}
+			value := <-callChannel
+			assert.Equal(t, value, tt.expectValue)
 		})
 	}
 }

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -580,10 +580,8 @@ func (f *featurePodConnectivity) podClassifierFlow(podOFPort uint32, isAntreaFle
 func (f *featurePodConnectivity) podUplinkClassifierFlows(dstMAC net.HardwareAddr, vlanID uint16) []binding.Flow {
 	cookieID := f.cookieAllocator.Request(f.category).Raw()
 	var flows []binding.Flow
-	nonVLAN := true
-	if vlanID > 0 {
-		nonVLAN = false
-	}
+	nonVLAN := vlanID <= 0
+
 	for _, ipProtocol := range f.ipProtocols {
 		flows = append(flows,
 			// This generates the flow to mark the packets from uplink port.
@@ -2576,10 +2574,11 @@ func (f *featureService) serviceEndpointGroup(groupID binding.GroupIDType, withS
 		if !endpoint.GetIsLocal() && endpoint.GetNodeName() != "" && !f.nodeIPChecker.IsNodeIP(endpoint.IP()) {
 			bucketBuilder = bucketBuilder.LoadRegMark(RemoteEndpointRegMark)
 		}
-		if ipProtocol == binding.ProtocolIP {
+		switch ipProtocol {
+		case binding.ProtocolIP:
 			ipVal := binary.BigEndian.Uint32(endpointIP.To4())
 			bucketBuilder = bucketBuilder.LoadToRegField(EndpointIPField, ipVal)
-		} else if ipProtocol == binding.ProtocolIPv6 {
+		case binding.ProtocolIPv6:
 			ipVal := []byte(endpointIP)
 			bucketBuilder = bucketBuilder.LoadXXReg(EndpointIP6Field.GetRegID(), ipVal)
 		}

--- a/pkg/agent/openflow/pod_connectivity.go
+++ b/pkg/agent/openflow/pod_connectivity.go
@@ -78,7 +78,8 @@ func newFeaturePodConnectivity(
 	nodeIPs := make(map[binding.Protocol]net.IP)
 	ipCtZoneTypeRegMarks := make(map[binding.Protocol]*binding.RegMark)
 	for _, ipProtocol := range ipProtocols {
-		if ipProtocol == binding.ProtocolIP {
+		switch ipProtocol {
+		case binding.ProtocolIP:
 			ctZones[ipProtocol] = CtZone
 			gatewayIPs[ipProtocol] = nodeConfig.GatewayConfig.IPv4
 			nodeIPs[ipProtocol] = nodeConfig.NodeIPv4Addr.IP
@@ -86,7 +87,7 @@ func newFeaturePodConnectivity(
 				localCIDRs[ipProtocol] = *nodeConfig.PodIPv4CIDR
 			}
 			ipCtZoneTypeRegMarks[ipProtocol] = IPCtZoneTypeRegMark
-		} else if ipProtocol == binding.ProtocolIPv6 {
+		case binding.ProtocolIPv6:
 			ctZones[ipProtocol] = CtZoneV6
 			gatewayIPs[ipProtocol] = nodeConfig.GatewayConfig.IPv6
 			nodeIPs[ipProtocol] = nodeConfig.NodeIPv6Addr.IP
@@ -139,9 +140,10 @@ func (f *featurePodConnectivity) initFlows() []*openflow15.FlowMod {
 	gatewayMAC := f.nodeConfig.GatewayConfig.MAC
 
 	for _, ipProtocol := range f.ipProtocols {
-		if ipProtocol == binding.ProtocolIPv6 {
+		switch ipProtocol {
+		case binding.ProtocolIPv6:
 			flows = append(flows, f.ipv6Flows()...)
-		} else if ipProtocol == binding.ProtocolIP {
+		case binding.ProtocolIP:
 			flows = append(flows, f.arpNormalFlow())
 			flows = append(flows, f.arpSpoofGuardFlow(f.gatewayIPs[ipProtocol], gatewayMAC, f.gatewayPort))
 			if f.connectUplinkToBridge {
@@ -210,9 +212,10 @@ func (f *featurePodConnectivity) trafficControlMarkFlows(sourceOFPorts []uint32,
 	priority uint16) []binding.Flow {
 	cookieID := f.cookieAllocator.Request(f.category).Raw()
 	var actionRegMark *binding.RegMark
-	if action == v1alpha2.ActionRedirect {
+	switch action {
+	case v1alpha2.ActionRedirect:
 		actionRegMark = TrafficControlRedirectRegMark
-	} else if action == v1alpha2.ActionMirror {
+	case v1alpha2.ActionMirror:
 		actionRegMark = TrafficControlMirrorRegMark
 	}
 	var flows []binding.Flow

--- a/pkg/agent/openflow/service.go
+++ b/pkg/agent/openflow/service.go
@@ -81,7 +81,8 @@ func newFeatureService(
 	nodePortAddresses := make(map[binding.Protocol][]net.IP)
 	serviceCIDRs := make(map[binding.Protocol]net.IPNet)
 	for _, ipProtocol := range ipProtocols {
-		if ipProtocol == binding.ProtocolIP {
+		switch ipProtocol {
+		case binding.ProtocolIP:
 			gatewayIPs[ipProtocol] = nodeConfig.GatewayConfig.IPv4
 			virtualIPs[ipProtocol] = config.VirtualServiceIPv4
 			virtualNodePortDNATIPs[ipProtocol] = config.VirtualNodePortDNATIPv4
@@ -91,7 +92,7 @@ func newFeatureService(
 			if serviceConfig.ServiceCIDR != nil {
 				serviceCIDRs[ipProtocol] = *serviceConfig.ServiceCIDR
 			}
-		} else if ipProtocol == binding.ProtocolIPv6 {
+		case binding.ProtocolIPv6:
 			gatewayIPs[ipProtocol] = nodeConfig.GatewayConfig.IPv6
 			virtualIPs[ipProtocol] = config.VirtualServiceIPv6
 			virtualNodePortDNATIPs[ipProtocol] = config.VirtualNodePortDNATIPv6

--- a/pkg/agent/packetcapture/capture/bpf.go
+++ b/pkg/agent/packetcapture/capture/bpf.go
@@ -224,11 +224,12 @@ func compilePacketFilter(packetSpec *crdv1alpha1.Packet, srcIP, dstIP net.IP, di
 
 	inst = append(inst, loadIPv4SourceAddress)
 
-	if direction == crdv1alpha1.CaptureDirectionSourceToDestination {
+	switch direction {
+	case crdv1alpha1.CaptureDirectionSourceToDestination:
 		inst = append(inst, compileIPPortFilter(srcAddrVal, dstAddrVal, size, uint8(len(inst)), srcPort, dstPort, tcpFlags, false)...)
-	} else if direction == crdv1alpha1.CaptureDirectionDestinationToSource {
+	case crdv1alpha1.CaptureDirectionDestinationToSource:
 		inst = append(inst, compileIPPortFilter(dstAddrVal, srcAddrVal, size, uint8(len(inst)), dstPort, srcPort, tcpFlags, false)...)
-	} else {
+	default:
 		inst = append(inst, compileIPPortFilter(srcAddrVal, dstAddrVal, size, uint8(len(inst)), srcPort, dstPort, tcpFlags, true)...)
 		inst = append(inst, compileIPPortFilter(dstAddrVal, srcAddrVal, size, uint8(len(inst)), dstPort, srcPort, tcpFlags, false)...)
 	}

--- a/pkg/agent/proxy/types/types.go
+++ b/pkg/agent/proxy/types/types.go
@@ -58,16 +58,18 @@ func NewServiceInfo(port *corev1.ServicePort, service *corev1.Service, baseInfo 
 	info.LoadBalancerMode = getLoadBalancerMode(service)
 	if utilnet.IsIPv6(baseInfo.ClusterIP()) {
 		info.OFProtocol = openflow.ProtocolTCPv6
-		if port.Protocol == corev1.ProtocolUDP {
+		switch port.Protocol {
+		case corev1.ProtocolUDP:
 			info.OFProtocol = openflow.ProtocolUDPv6
-		} else if port.Protocol == corev1.ProtocolSCTP {
+		case corev1.ProtocolSCTP:
 			info.OFProtocol = openflow.ProtocolSCTPv6
 		}
 	} else {
 		info.OFProtocol = openflow.ProtocolTCP
-		if port.Protocol == corev1.ProtocolUDP {
+		switch port.Protocol {
+		case corev1.ProtocolUDP:
 			info.OFProtocol = openflow.ProtocolUDP
-		} else if port.Protocol == corev1.ProtocolSCTP {
+		case corev1.ProtocolSCTP:
 			info.OFProtocol = openflow.ProtocolSCTP
 		}
 	}

--- a/pkg/agent/secondarynetwork/podwatch/sriov.go
+++ b/pkg/agent/secondarynetwork/podwatch/sriov.go
@@ -131,7 +131,6 @@ func (pc *PodController) deleteVFDeviceIDListPerPod(podName, podNamespace string
 		pc.vfDeviceIDUsageMap.Delete(podKey)
 		klog.V(2).InfoS("Pod specific SRIOV VF cache cleared", "Key", podKey)
 	}
-	return
 }
 
 func (pc *PodController) releaseSriovVFDeviceID(podName, podNamespace, interfaceName string) {

--- a/pkg/agent/supportbundlecollection/support_bundle_controller.go
+++ b/pkg/agent/supportbundlecollection/support_bundle_controller.go
@@ -135,26 +135,24 @@ func (c *SupportBundleController) watchSupportBundleCollections() {
 	}()
 
 	for {
-		select {
-		case event, ok := <-watcher.ResultChan():
-			if !ok {
-				return
-			}
-			switch event.Type {
-			case watch.Bookmark:
-				klog.V(2).Info("Received Bookmark event")
-			case watch.Added:
-				c.addSupportBundleCollection(event.Object.(*cpv1b2.SupportBundleCollection))
-				klog.InfoS("Added SupportBundleCollection", "name", event.Object.(*cpv1b2.SupportBundleCollection).Name)
-			case watch.Deleted:
-				c.deleteSupportBundleCollection(event.Object.(*cpv1b2.SupportBundleCollection))
-				klog.InfoS("Deleted SupportBundleCollection", "name", event.Object.(*cpv1b2.SupportBundleCollection).Name)
-			default:
-				klog.ErrorS(nil, "Received unknown event", "event", event.Type)
-				return
-			}
-			eventCount++
+		event, ok := <-watcher.ResultChan()
+		if !ok {
+			return
 		}
+		switch event.Type {
+		case watch.Bookmark:
+			klog.V(2).Info("Received Bookmark event")
+		case watch.Added:
+			c.addSupportBundleCollection(event.Object.(*cpv1b2.SupportBundleCollection))
+			klog.InfoS("Added SupportBundleCollection", "name", event.Object.(*cpv1b2.SupportBundleCollection).Name)
+		case watch.Deleted:
+			c.deleteSupportBundleCollection(event.Object.(*cpv1b2.SupportBundleCollection))
+			klog.InfoS("Deleted SupportBundleCollection", "name", event.Object.(*cpv1b2.SupportBundleCollection).Name)
+		default:
+			klog.ErrorS(nil, "Received unknown event", "event", event.Type)
+			return
+		}
+		eventCount++
 	}
 }
 

--- a/pkg/agent/util/net.go
+++ b/pkg/agent/util/net.go
@@ -438,7 +438,7 @@ func GenerateOVSDatapathID(macString string) string {
 	if macString == "" {
 		macString = GenerateRandomMAC().String()
 	}
-	return "0000" + strings.Replace(macString, ":", "", -1)
+	return "0000" + strings.ReplaceAll(macString, ":", "")
 }
 
 // GetGatewayIPForPodCIDR returns the gateway IP for a given Pod CIDR.

--- a/pkg/agent/util/net_linux_test.go
+++ b/pkg/agent/util/net_linux_test.go
@@ -102,23 +102,23 @@ func TestGetNSPeerDevBridge(t *testing.T) {
 		},
 		{
 			name:       "Get NS Err",
-			getNSErr:   testInvalidErr,
+			getNSErr:   errTestInvalid,
 			wantErrStr: "failed to get NS for path",
 		},
 		{
 			name:           "Get V-eth Peer Err",
-			getVethPeerErr: testInvalidErr,
+			getVethPeerErr: errTestInvalid,
 			wantErrStr:     "failed to get peer idx for dev",
 		},
 		{
 			name:                "Get Interface Err",
-			testNetInterfaceErr: testInvalidErr,
+			testNetInterfaceErr: errTestInvalid,
 			wantErrStr:          "failed to get interface for idx",
 		},
 		{
 			name: "Get Link Err",
 			expectedCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
-				mockNetlink.LinkByIndex(2).Return(nil, testInvalidErr)
+				mockNetlink.LinkByIndex(2).Return(nil, errTestInvalid)
 			},
 			wantErrStr: "failed to get link for idx",
 		},
@@ -132,7 +132,7 @@ func TestGetNSPeerDevBridge(t *testing.T) {
 			name: "Get Bridge Err",
 			expectedCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
 				mockNetlink.LinkByIndex(2).Return(mockLink{masterIndex: 1}, nil)
-				mockNetlink.LinkByIndex(1).Return(nil, testInvalidErr)
+				mockNetlink.LinkByIndex(1).Return(nil, errTestInvalid)
 			},
 			wantErrStr: "failed to get master link for dev",
 		},
@@ -179,12 +179,12 @@ func TestGetNSDevInterface(t *testing.T) {
 		},
 		{
 			name:       "Get NS Err",
-			getNSErr:   testInvalidErr,
+			getNSErr:   errTestInvalid,
 			wantErrStr: "failed to get NS for path",
 		},
 		{
 			name:                "Get Interface Err",
-			testNetInterfaceErr: testInvalidErr,
+			testNetInterfaceErr: errTestInvalid,
 			wantErrStr:          "failed to get interface",
 		},
 	}
@@ -221,7 +221,7 @@ func TestGetNSPath(t *testing.T) {
 		},
 		{
 			name:       "Get NS Err",
-			getNSErr:   testInvalidErr,
+			getNSErr:   errTestInvalid,
 			wantErrStr: "failed to open netns",
 		},
 	}
@@ -267,9 +267,9 @@ func TestSetLinkUp(t *testing.T) {
 		{
 			name: "Get Link Err",
 			expectedCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
-				mockNetlink.LinkByName("antrea-en0").Return(nil, testInvalidErr)
+				mockNetlink.LinkByName("antrea-en0").Return(nil, errTestInvalid)
 			},
-			wantErr:   testInvalidErr,
+			wantErr:   errTestInvalid,
 			wantIndex: 0,
 		},
 		{
@@ -286,9 +286,9 @@ func TestSetLinkUp(t *testing.T) {
 			name: "Setup Link Err",
 			expectedCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
 				mockNetlink.LinkByName("antrea-en0").Return(testLink, nil)
-				mockNetlink.LinkSetUp(testLink).Return(testInvalidErr)
+				mockNetlink.LinkSetUp(testLink).Return(errTestInvalid)
 			},
-			wantErr:   testInvalidErr,
+			wantErr:   errTestInvalid,
 			wantIndex: 0,
 		},
 	}
@@ -346,16 +346,16 @@ func TestConfigureLinkAddresses(t *testing.T) {
 			name:   "Net Interface Err",
 			ipNets: []*net.IPNet{},
 			expectedCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
-				mockNetlink.LinkByIndex(0).Return(testLink, testInvalidErr)
+				mockNetlink.LinkByIndex(0).Return(testLink, errTestInvalid)
 			},
-			wantErr: testInvalidErr,
+			wantErr: errTestInvalid,
 		},
 		{
 			name:   "Link Addr Err",
 			ipNets: []*net.IPNet{},
 			expectedCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
 				mockNetlink.LinkByIndex(0).Return(testLink, nil)
-				mockNetlink.AddrList(testLink, netlink.FAMILY_ALL).Return(testPublicAddrList, testInvalidErr)
+				mockNetlink.AddrList(testLink, netlink.FAMILY_ALL).Return(testPublicAddrList, errTestInvalid)
 			},
 			wantErr: fmt.Errorf("failed to query address list for interface test-en0: invalid"),
 		},
@@ -373,7 +373,7 @@ func TestConfigureLinkAddresses(t *testing.T) {
 			expectedCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
 				mockNetlink.LinkByIndex(0).Return(testLink, nil)
 				mockNetlink.AddrList(testLink, netlink.FAMILY_ALL).Return(testPublicAddrList, nil)
-				mockNetlink.AddrDel(testLink, &testPublicAddr).Return(testInvalidErr)
+				mockNetlink.AddrDel(testLink, &testPublicAddr).Return(errTestInvalid)
 			},
 			wantErr: fmt.Errorf("failed to remove address 8.8.8.8/32 from interface test-en0: invalid"),
 		},
@@ -384,7 +384,7 @@ func TestConfigureLinkAddresses(t *testing.T) {
 				mockNetlink.LinkByIndex(0).Return(testLink, nil)
 				mockNetlink.AddrList(testLink, netlink.FAMILY_ALL).Return(testPublicAddrList, nil)
 				mockNetlink.AddrDel(testLink, &testPublicAddr).Return(nil)
-				mockNetlink.AddrAdd(testLink, &testZeroAddr).Return(testInvalidErr)
+				mockNetlink.AddrAdd(testLink, &testZeroAddr).Return(errTestInvalid)
 			},
 			wantErr: fmt.Errorf("failed to add address 0.0.0.0/32 to interface test-en0: invalid"),
 		},
@@ -418,17 +418,17 @@ func TestSetAdapterMACAddress(t *testing.T) {
 		{
 			name: "Get Link Err",
 			expectedCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
-				mockNetlink.LinkByName("test-en0").Return(nil, testInvalidErr)
+				mockNetlink.LinkByName("test-en0").Return(nil, errTestInvalid)
 			},
-			wantErr: testInvalidErr,
+			wantErr: errTestInvalid,
 		},
 		{
 			name: "Set Hardware Addr Err",
 			expectedCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
 				mockNetlink.LinkByName("test-en0").Return(testLink, nil)
-				mockNetlink.LinkSetHardwareAddr(testLink, testMACAddr).Return(testInvalidErr)
+				mockNetlink.LinkSetHardwareAddr(testLink, testMACAddr).Return(errTestInvalid)
 			},
-			wantErr: testInvalidErr,
+			wantErr: errTestInvalid,
 		},
 	}
 
@@ -458,7 +458,7 @@ func TestHostInterfaceExists(t *testing.T) {
 		{
 			name: "Interface Fail",
 			expectedCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
-				mockNetlink.LinkByName("test-en0").Return(nil, testInvalidErr)
+				mockNetlink.LinkByName("test-en0").Return(nil, errTestInvalid)
 			},
 			wantExists: false,
 		},
@@ -512,18 +512,18 @@ func TestGetInterfaceConfig(t *testing.T) {
 		},
 		{
 			name:                "Interface Err",
-			testNetInterfaceErr: testInvalidErr,
+			testNetInterfaceErr: errTestInvalid,
 			wantErrStr:          "failed to get interface by name 0",
 		},
 		{
 			name:            "Get Address Err",
-			testNetAddrsErr: testInvalidErr,
+			testNetAddrsErr: errTestInvalid,
 			wantErrStr:      "failed to get address for interface 0",
 		},
 		{
 			name: "Net Link Err",
 			expectedCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
-				mockNetlink.LinkByIndex(0).Return(nil, testInvalidErr)
+				mockNetlink.LinkByIndex(0).Return(nil, errTestInvalid)
 			},
 			wantErrStr: "failed to get routes for iface.Index 0",
 		},
@@ -531,7 +531,7 @@ func TestGetInterfaceConfig(t *testing.T) {
 			name: "Route List Err",
 			expectedCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
 				mockNetlink.LinkByIndex(0).Return(mockLink{name: "test-en0"}, nil)
-				mockNetlink.RouteList(mockLink{name: "test-en0"}, netlink.FAMILY_ALL).Return(nil, testInvalidErr)
+				mockNetlink.RouteList(mockLink{name: "test-en0"}, netlink.FAMILY_ALL).Return(nil, errTestInvalid)
 			},
 			wantErrStr: "failed to get routes for iface.Index 0",
 		},
@@ -559,7 +559,7 @@ func TestGetInterfaceConfig(t *testing.T) {
 
 func TestRenameInterface(t *testing.T) {
 	renameFailErr := fmt.Errorf("failed to rename host interface name test1 to test2")
-	removeAltNameFailErr := fmt.Errorf("failed to remove AltName test1 on interface test2: %w", testInvalidErr)
+	removeAltNameFailErr := fmt.Errorf("failed to remove AltName test1 on interface test2: %w", errTestInvalid)
 	tests := []struct {
 		name          string
 		expectedCalls func(mockNetlink *netlinktest.MockInterfaceMockRecorder)
@@ -589,7 +589,7 @@ func TestRenameInterface(t *testing.T) {
 		{
 			name: "Interface Err",
 			expectedCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
-				mockNetlink.LinkByName("test1").Return(mockLink{name: "test1"}, testInvalidErr).AnyTimes()
+				mockNetlink.LinkByName("test1").Return(mockLink{name: "test1"}, errTestInvalid).AnyTimes()
 			},
 			wantErr: renameFailErr,
 		},
@@ -597,7 +597,7 @@ func TestRenameInterface(t *testing.T) {
 			name: "Set Down Err",
 			expectedCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
 				mockNetlink.LinkByName("test1").Return(mockLink{name: "test1"}, nil).AnyTimes()
-				mockNetlink.LinkSetDown(mockLink{name: "test1"}).Return(testInvalidErr).AnyTimes()
+				mockNetlink.LinkSetDown(mockLink{name: "test1"}).Return(errTestInvalid).AnyTimes()
 			},
 			wantErr: renameFailErr,
 		},
@@ -606,7 +606,7 @@ func TestRenameInterface(t *testing.T) {
 			expectedCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
 				mockNetlink.LinkByName("test1").Return(mockLink{name: "test1"}, nil).AnyTimes()
 				mockNetlink.LinkSetDown(mockLink{name: "test1"}).Return(nil).AnyTimes()
-				mockNetlink.LinkSetName(mockLink{name: "test1"}, "test2").Return(testInvalidErr).AnyTimes()
+				mockNetlink.LinkSetName(mockLink{name: "test1"}, "test2").Return(errTestInvalid).AnyTimes()
 			},
 			wantErr: renameFailErr,
 		},
@@ -616,7 +616,7 @@ func TestRenameInterface(t *testing.T) {
 				mockNetlink.LinkByName("test1").Return(mockLink{name: "test1"}, nil).AnyTimes()
 				mockNetlink.LinkSetDown(mockLink{name: "test1"}).Return(nil).AnyTimes()
 				mockNetlink.LinkSetName(mockLink{name: "test1"}, "test2").Return(nil).AnyTimes()
-				mockNetlink.LinkSetUp(mockLink{name: "test1"}).Return(testInvalidErr).AnyTimes()
+				mockNetlink.LinkSetUp(mockLink{name: "test1"}).Return(errTestInvalid).AnyTimes()
 			},
 			wantErr: renameFailErr,
 		},
@@ -628,7 +628,7 @@ func TestRenameInterface(t *testing.T) {
 				mockNetlink.LinkSetName(mockLink{name: "test1"}, "test2").Return(nil)
 				mockNetlink.LinkSetUp(mockLink{name: "test1"}).Return(nil)
 				mockNetlink.LinkByName("test2").Return(mockLink{name: "test2", altNames: []string{"test1"}}, nil)
-				mockNetlink.LinkDelAltName(mockLink{name: "test2", altNames: []string{"test1"}}, "test1").Return(testInvalidErr)
+				mockNetlink.LinkDelAltName(mockLink{name: "test2", altNames: []string{"test1"}}, "test1").Return(errTestInvalid)
 			},
 			wantErr: removeAltNameFailErr,
 		},
@@ -662,17 +662,17 @@ func TestRemoveLinkIPs(t *testing.T) {
 		{
 			name: "Addr List Err",
 			expectedCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
-				mockNetlink.AddrList(testLink, netlink.FAMILY_ALL).Return(testAddrList, testInvalidErr)
+				mockNetlink.AddrList(testLink, netlink.FAMILY_ALL).Return(testAddrList, errTestInvalid)
 			},
-			wantErr: testInvalidErr,
+			wantErr: errTestInvalid,
 		},
 		{
 			name: "Addr Del Err",
 			expectedCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
 				mockNetlink.AddrList(testLink, netlink.FAMILY_ALL).Return(testAddrList, nil)
-				mockNetlink.AddrDel(testLink, &testAddrList[0]).Return(testInvalidErr)
+				mockNetlink.AddrDel(testLink, &testAddrList[0]).Return(errTestInvalid)
 			},
-			wantErr: testInvalidErr,
+			wantErr: errTestInvalid,
 		},
 	}
 
@@ -704,17 +704,17 @@ func TestRemoveLinkRoutes(t *testing.T) {
 		{
 			name: "Route List Err",
 			expectedCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
-				mockNetlink.RouteList(testLink, netlink.FAMILY_ALL).Return(nil, testInvalidErr)
+				mockNetlink.RouteList(testLink, netlink.FAMILY_ALL).Return(nil, errTestInvalid)
 			},
-			wantErr: testInvalidErr,
+			wantErr: errTestInvalid,
 		},
 		{
 			name: "Route Del Err",
 			expectedCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
 				mockNetlink.RouteList(testLink, netlink.FAMILY_ALL).Return([]netlink.Route{testRoute}, nil)
-				mockNetlink.RouteDel(&testRoute).Return(testInvalidErr)
+				mockNetlink.RouteDel(&testRoute).Return(errTestInvalid)
 			},
-			wantErr: testInvalidErr,
+			wantErr: errTestInvalid,
 		},
 	}
 
@@ -753,9 +753,9 @@ func TestConfigureLinkRoutes(t *testing.T) {
 		{
 			name: "Route Add Err",
 			expectedCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
-				mockNetlink.RouteAdd(&routes[0]).Return(testInvalidErr)
+				mockNetlink.RouteAdd(&routes[0]).Return(errTestInvalid)
 			},
-			wantErr: testInvalidErr,
+			wantErr: errTestInvalid,
 		},
 	}
 

--- a/pkg/agent/util/net_test.go
+++ b/pkg/agent/util/net_test.go
@@ -42,7 +42,7 @@ var (
 
 	testMACAddr, _ = net.ParseMAC("aa:bb:cc:dd:ee:ff")
 
-	testInvalidErr = fmt.Errorf("invalid")
+	errTestInvalid = fmt.Errorf("invalid")
 )
 
 func TestGenerateContainerInterfaceName(t *testing.T) {
@@ -210,7 +210,7 @@ func TestGetIPNetDeviceFromIP(t *testing.T) {
 		},
 		{
 			name:                "Invalid",
-			testNetInterfaceErr: testInvalidErr,
+			testNetInterfaceErr: errTestInvalid,
 		},
 	}
 
@@ -251,7 +251,7 @@ func TestGetIPNetDeviceByName(t *testing.T) {
 		{
 			name:                 "Invalid",
 			testNetInterfaceName: "0",
-			testNetInterfaceErr:  testInvalidErr,
+			testNetInterfaceErr:  errTestInvalid,
 		},
 	}
 
@@ -303,7 +303,7 @@ func TestGetIPNetDeviceByCIDRs(t *testing.T) {
 		},
 		{
 			name:                "Invalid",
-			testNetInterfaceErr: testInvalidErr,
+			testNetInterfaceErr: errTestInvalid,
 		},
 	}
 
@@ -442,7 +442,7 @@ func TestGetAllNodeAddresses(t *testing.T) {
 		},
 		{
 			name:                "Invalid",
-			testNetInterfaceErr: testInvalidErr,
+			testNetInterfaceErr: errTestInvalid,
 		},
 	}
 
@@ -495,7 +495,7 @@ func TestGetIPNetsByLink(t *testing.T) {
 		},
 		{
 			name:                "Invalid",
-			testNetInterfaceErr: testInvalidErr,
+			testNetInterfaceErr: errTestInvalid,
 		},
 	}
 

--- a/pkg/agent/util/net_windows.go
+++ b/pkg/agent/util/net_windows.go
@@ -304,7 +304,7 @@ func PrepareHNSNetwork(subnetCIDR *net.IPNet, nodeIPNet *net.IPNet, uplinkAdapte
 	}
 	if newName != "" {
 		// Rename the vnic created by Windows host with the given newName, then it can be used by OVS when creating bridge port.
-		uplinkMACStr := strings.Replace(uplinkAdapter.HardwareAddr.String(), ":", "", -1)
+		uplinkMACStr := strings.ReplaceAll(uplinkAdapter.HardwareAddr.String(), ":", "")
 		// Rename NetAdapter in the meanwhile, then the network adapter can be treated as a host network adapter other than
 		// a vm network adapter.
 		if err = winnetUtil.RenameVMNetworkAdapter(LocalHNSNetwork, uplinkMACStr, newName, true); err != nil {

--- a/pkg/agent/util/net_windows_test.go
+++ b/pkg/agent/util/net_windows_test.go
@@ -72,7 +72,7 @@ func TestSetLinkUp(t *testing.T) {
 		{
 			name:           "Get Interface Err",
 			gwInterface:    &net.Interface{Index: 0},
-			gwInterfaceErr: testInvalidErr,
+			gwInterfaceErr: errTestInvalid,
 			expectedCalls: func(mockUtil *winnettesting.MockInterfaceMockRecorder) {
 				mockUtil.EnableNetAdapter(testName).Return(nil).MinTimes(1)
 				mockUtil.IsNetAdapterStatusUp(testName).Return(true, nil).Times(1)
@@ -118,13 +118,13 @@ func TestConfigureLinkAddresses(t *testing.T) {
 		{
 			name:                "Net Interface Err",
 			ipNets:              []*net.IPNet{},
-			testNetInterfaceErr: testInvalidErr,
-			wantErr:             testInvalidErr,
+			testNetInterfaceErr: errTestInvalid,
+			wantErr:             errTestInvalid,
 		},
 		{
 			name:            "Link Addr Err",
 			ipNets:          []*net.IPNet{},
-			testNetAddrsErr: testInvalidErr,
+			testNetAddrsErr: errTestInvalid,
 			wantErr:         fmt.Errorf("failed to query IPv4 address list for interface 0: invalid"),
 		},
 		{
@@ -195,7 +195,7 @@ func TestPrepareHNSNetwork(t *testing.T) {
 		Index:        0,
 		HardwareAddr: testMACAddr,
 	}
-	testUplinkMACStr := strings.Replace(testUplinkAdapter.HardwareAddr.String(), ":", "", -1)
+	testUplinkMACStr := strings.ReplaceAll(testUplinkAdapter.HardwareAddr.String(), ":", "")
 	testDNSServer := "192.168.1.21"
 	testNetInterfaces := generateNetInterfaces()
 	for i, itf := range testNetInterfaces {
@@ -230,7 +230,7 @@ func TestPrepareHNSNetwork(t *testing.T) {
 			nodeIPNet:           &ipv4PublicIPNet,
 			dnsServers:          testDNSServer,
 			ipFound:             true,
-			hnsNetworkCreateErr: testInvalidErr,
+			hnsNetworkCreateErr: errTestInvalid,
 			wantErr:             fmt.Errorf("error creating HNSNetwork: invalid"),
 		},
 		{
@@ -238,8 +238,8 @@ func TestPrepareHNSNetwork(t *testing.T) {
 			nodeIPNet:           &ipv4PublicIPNet,
 			dnsServers:          testDNSServer,
 			ipFound:             true,
-			testNetInterfaceErr: testInvalidErr,
-			wantErr:             testInvalidErr,
+			testNetInterfaceErr: errTestInvalid,
+			wantErr:             errTestInvalid,
 		},
 		{
 			name:       "Rename Err",
@@ -248,17 +248,17 @@ func TestPrepareHNSNetwork(t *testing.T) {
 			newName:    testNewName,
 			ipFound:    true,
 			expectedCalls: func(mockUtil *winnettesting.MockInterfaceMockRecorder) {
-				mockUtil.RenameVMNetworkAdapter(LocalHNSNetwork, testUplinkMACStr, testNewName, true).Return(testInvalidErr).Times(1)
+				mockUtil.RenameVMNetworkAdapter(LocalHNSNetwork, testUplinkMACStr, testNewName, true).Return(errTestInvalid).Times(1)
 			},
-			wantErr: testInvalidErr,
+			wantErr: errTestInvalid,
 		},
 		{
 			name:                   "Enable HNS Err",
 			nodeIPNet:              &ipv4PublicIPNet,
 			dnsServers:             testDNSServer,
 			ipFound:                true,
-			hnsNetworkRequestError: testInvalidErr,
-			wantErr:                testInvalidErr,
+			hnsNetworkRequestError: errTestInvalid,
+			wantErr:                errTestInvalid,
 		},
 		{
 			name:       "Enable RSC Err",
@@ -266,9 +266,9 @@ func TestPrepareHNSNetwork(t *testing.T) {
 			dnsServers: testDNSServer,
 			ipFound:    true,
 			expectedCalls: func(mockUtil *winnettesting.MockInterfaceMockRecorder) {
-				mockUtil.EnableRSCOnVSwitch(LocalHNSNetwork).Return(testInvalidErr).Times(1)
+				mockUtil.EnableRSCOnVSwitch(LocalHNSNetwork).Return(errTestInvalid).Times(1)
 			},
-			wantErr: testInvalidErr,
+			wantErr: errTestInvalid,
 		},
 		{
 			name:       "IP Not Found",
@@ -424,8 +424,8 @@ func TestGetInterfaceConfig(t *testing.T) {
 		},
 		{
 			name:                "Interface Err",
-			testNetInterfaceErr: testInvalidErr,
-			wantErr:             fmt.Errorf("failed to get interface %s: %v", "0", testInvalidErr),
+			testNetInterfaceErr: errTestInvalid,
+			wantErr:             fmt.Errorf("failed to get interface %s: %v", "0", errTestInvalid),
 		},
 		{
 			name:    "Route Err",

--- a/pkg/agent/util/syscall/syscall_windows.go
+++ b/pkg/agent/util/syscall/syscall_windows.go
@@ -355,7 +355,6 @@ func (n *netIO) DeleteIPForwardEntry(ipForwardEntry *MibIPForwardRow) (errcode e
 
 func (n *netIO) freeMibTable(table unsafe.Pointer) {
 	n.syscallN(procFreeMibTable.Addr(), uintptr(table))
-	return
 }
 
 func getIPForwardTable(family uint16, ipForwardTable **MibIPForwardTable) (errcode error) {

--- a/pkg/agent/util/winnet/net_windows.go
+++ b/pkg/agent/util/winnet/net_windows.go
@@ -252,10 +252,7 @@ func (h *Handle) SetNetAdapterDNSServers(adapterName, dnsServers string) error {
 
 func (h *Handle) NetAdapterExists(adapterName string) bool {
 	_, err := getAdapterInAllCompartmentsByName(adapterName)
-	if err != nil {
-		return false
-	}
-	return true
+	return err == nil
 }
 
 // IsNetAdapterIPv4DHCPEnabled returns the IPv4 DHCP status on the specified network adapter.
@@ -711,10 +708,7 @@ func parseOVSExtensionOutput(s string) bool {
 		temp := strings.Fields(scanner.Text())
 		line := strings.Join(temp, "")
 		if strings.Contains(line, "Enabled") {
-			if strings.Contains(line, "True") {
-				return true
-			}
-			return false
+			return strings.Contains(line, "True")
 		}
 	}
 	return false

--- a/pkg/agent/util/winnet/net_windows_test.go
+++ b/pkg/agent/util/winnet/net_windows_test.go
@@ -39,7 +39,7 @@ var (
 	ipv4Public      = net.ParseIP("8.8.8.8")
 	ipv4PublicIPNet = ip.MustParseCIDR("8.8.8.8/32")
 
-	testInvalidErr = fmt.Errorf("invalid")
+	errTestInvalid = fmt.Errorf("invalid")
 
 	h = &Handle{}
 )
@@ -101,7 +101,7 @@ func TestIsVirtualNetAdapter(t *testing.T) {
 		},
 		{
 			name:          "Virtual adapter Err",
-			commandErr:    testInvalidErr,
+			commandErr:    errTestInvalid,
 			wantIsVirtual: false,
 		},
 	}
@@ -134,7 +134,7 @@ func TestGetDNServersByNetAdapterIndex(t *testing.T) {
 		{
 			name:       "Index Error",
 			commandOut: "fail",
-			commandErr: testInvalidErr,
+			commandErr: errTestInvalid,
 		},
 	}
 
@@ -468,9 +468,9 @@ func TestAddNetNat(t *testing.T) {
 		},
 		{
 			name:       "Net Nat Not Found",
-			commandErr: testInvalidErr,
+			commandErr: errTestInvalid,
 			wantCmds:   []string{getCmd},
-			wantErr:    fmt.Errorf("failed to check the existing netnat '%s': %w", testNetNat, testInvalidErr),
+			wantErr:    fmt.Errorf("failed to check the existing netnat '%s': %w", testNetNat, errTestInvalid),
 		},
 		{
 			name:       "Net Nat Exist",
@@ -532,9 +532,9 @@ func TestReplaceNetNatStaticMapping(t *testing.T) {
 		},
 		{
 			name:       "Get Net Nat Err",
-			commandErr: testInvalidErr,
+			commandErr: errTestInvalid,
 			wantCmds:   []string{getCmd},
-			wantErr:    testInvalidErr,
+			wantErr:    errTestInvalid,
 		},
 		{
 			name:       "Remove Net Nat Err",
@@ -595,9 +595,9 @@ func TestRemoveNetNatStaticMapping(t *testing.T) {
 		},
 		{
 			name:       "Remove Err",
-			commandErr: testInvalidErr,
+			commandErr: errTestInvalid,
 			wantCmds:   []string{getCmd, removeCmd},
-			wantErr:    testInvalidErr,
+			wantErr:    errTestInvalid,
 		},
 	}
 
@@ -641,9 +641,9 @@ func TestReplaceNetNeighbor(t *testing.T) {
 		},
 		{
 			name:       "Get Net Neighbor Err",
-			commandErr: testInvalidErr,
+			commandErr: errTestInvalid,
 			wantCmds:   []string{getCmd},
-			wantErr:    testInvalidErr,
+			wantErr:    errTestInvalid,
 		},
 		{
 			name:       "Remove Net Neighbor Err",
@@ -692,7 +692,7 @@ func TestRenameNetAdapter(t *testing.T) {
 		},
 		{
 			name:       "Rename Err",
-			commandErr: testInvalidErr,
+			commandErr: errTestInvalid,
 			wantErr:    fmt.Errorf("invalid"),
 		},
 	}
@@ -720,7 +720,7 @@ func TestAddVMSwitch(t *testing.T) {
 		},
 		{
 			name:       "Error",
-			commandErr: testInvalidErr,
+			commandErr: errTestInvalid,
 			wantErr:    fmt.Errorf("invalid"),
 		},
 	}
@@ -745,7 +745,7 @@ func TestEnableVMSwitchOVSExtension(t *testing.T) {
 		},
 		{
 			name:       "Error",
-			commandErr: testInvalidErr,
+			commandErr: errTestInvalid,
 			wantErr:    fmt.Errorf("invalid"),
 		},
 	}
@@ -779,7 +779,7 @@ func TestIsVMSwitchOVSExtensionEnabled(t *testing.T) {
 		},
 		{
 			name:       "Error",
-			commandErr: testInvalidErr,
+			commandErr: errTestInvalid,
 			wantErr:    fmt.Errorf("invalid"),
 		},
 	}
@@ -813,9 +813,9 @@ func TestGetVMSwitchInterfaceName(t *testing.T) {
 		},
 		{
 			name:       "Get Err",
-			commandErr: testInvalidErr,
+			commandErr: errTestInvalid,
 			wantCmds:   []string{getVMCmd},
-			wantErr:    testInvalidErr,
+			wantErr:    errTestInvalid,
 		},
 	}
 
@@ -846,9 +846,9 @@ func TestRemoveVMSwitch(t *testing.T) {
 		},
 		{
 			name:       "Get Err",
-			commandErr: testInvalidErr,
+			commandErr: errTestInvalid,
 			wantCmds:   []string{getCmd},
-			wantErr:    testInvalidErr,
+			wantErr:    errTestInvalid,
 		},
 	}
 

--- a/pkg/antctl/antctl_test.go
+++ b/pkg/antctl/antctl_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 var (
-	serverError = fmt.Errorf("cannot reach server")
+	errServer = fmt.Errorf("cannot reach server")
 )
 
 // TestCommandListValidation ensures the command list is valid.
@@ -51,7 +51,7 @@ func TestCommandVersionRequestError(t *testing.T) {
 	var bufOut bytes.Buffer
 	CommandList.applyToRootCommand(rootCmd, client, &bufOut)
 
-	client.EXPECT().request(gomock.Any()).Return(nil, serverError)
+	client.EXPECT().request(gomock.Any()).Return(nil, errServer)
 
 	rootCmd.SetOut(&bufOut)
 	rootCmd.SetErr(&bufOut)
@@ -59,7 +59,7 @@ func TestCommandVersionRequestError(t *testing.T) {
 	rootCmd.Execute()
 	expected := fmt.Sprintf("antctlVersion: %s", antreaversion.GetFullVersion())
 	assert.Contains(t, bufOut.String(), expected)
-	assert.Contains(t, bufOut.String(), serverError.Error())
+	assert.Contains(t, bufOut.String(), errServer.Error())
 }
 
 // TestExtraArgs ensures that there will be an error if extra positional

--- a/pkg/antctl/client.go
+++ b/pkg/antctl/client.go
@@ -74,11 +74,12 @@ func (c *client) resolveKubeconfig(opt *requestOption) (*rest.Config, error) {
 		kubeconfig.CAFile = ""
 		kubeconfig.CAData = nil
 		kubeconfig.BearerTokenFile = apis.APIServerLoopbackTokenPath
-		if runtime.Mode == runtime.ModeAgent {
+		switch runtime.Mode {
+		case runtime.ModeAgent:
 			kubeconfig.Host = net.JoinHostPort("127.0.0.1", fmt.Sprint(apis.AntreaAgentAPIPort))
-		} else if runtime.Mode == runtime.ModeController {
+		case runtime.ModeController:
 			kubeconfig.Host = net.JoinHostPort("127.0.0.1", fmt.Sprint(apis.AntreaControllerAPIPort))
-		} else if runtime.Mode == runtime.ModeFlowAggregator {
+		case runtime.ModeFlowAggregator:
 			kubeconfig.Host = net.JoinHostPort("127.0.0.1", fmt.Sprint(apis.FlowAggregatorAPIPort))
 		}
 	} else {
@@ -93,11 +94,12 @@ func (c *client) resolveKubeconfig(opt *requestOption) (*rest.Config, error) {
 
 func (c *client) request(opt *requestOption) (io.Reader, error) {
 	var e *endpoint
-	if runtime.Mode == runtime.ModeAgent {
+	switch runtime.Mode {
+	case runtime.ModeAgent:
 		e = opt.commandDefinition.agentEndpoint
-	} else if runtime.Mode == runtime.ModeFlowAggregator {
+	case runtime.ModeFlowAggregator:
 		e = opt.commandDefinition.flowAggregatorEndpoint
-	} else {
+	default:
 		e = opt.commandDefinition.controllerEndpoint
 	}
 	if e.resourceEndpoint != nil {
@@ -156,9 +158,10 @@ func (c *client) resourceRequest(e *resourceEndpoint, opt *requestOption) (io.Re
 	restClient.Client.Timeout = opt.timeout
 
 	var restRequest *rest.Request
-	if e.restMethod == restGet {
+	switch e.restMethod {
+	case restGet:
 		restRequest = restClient.Get()
-	} else if e.restMethod == restPost {
+	case restPost:
 		restRequest = restClient.Post()
 	}
 

--- a/pkg/antctl/raw/featuregates/command.go
+++ b/pkg/antctl/raw/featuregates/command.go
@@ -193,7 +193,7 @@ func output(resps []apis.FeatureGateResponse, component string, output io.Writer
 	}
 
 	formatter := fmt.Sprintf("%%-%ds%%-%ds%%-s\n", maxNameLen+5, maxStatusLen+5)
-	output.Write([]byte(fmt.Sprintf(formatter, "FEATUREGATE", "STATUS", "VERSION")))
+	fmt.Fprintf(output, formatter, "FEATUREGATE", "STATUS", "VERSION")
 	for _, r := range resps {
 		fmt.Fprintf(output, formatter, r.Name, r.Status, r.Version)
 	}

--- a/pkg/antctl/raw/multicluster/get/resourceexport.go
+++ b/pkg/antctl/raw/multicluster/get/resourceexport.go
@@ -102,10 +102,7 @@ func runEResourceExport(cmd *cobra.Command, args []string) error {
 	}
 
 	var resExports interface{}
-	singleResource := false
-	if len(args) > 0 {
-		singleResource = true
-	}
+	singleResource := len(args) > 0
 
 	if optionsResourceExport.allNamespaces && singleResource {
 		return fmt.Errorf("a resource cannot be retrieved by name across all Namespaces")

--- a/pkg/antctl/raw/multicluster/get/resourceimport.go
+++ b/pkg/antctl/raw/multicluster/get/resourceimport.go
@@ -99,10 +99,7 @@ func runE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	argsNum := len(args)
-	singleResource := false
-	if argsNum > 0 {
-		singleResource = true
-	}
+	singleResource := argsNum > 0
 
 	if options.allNamespaces && singleResource {
 		return fmt.Errorf("a resource cannot be retrieved by name across all Namespaces")

--- a/pkg/antctl/raw/supportbundle/command_test.go
+++ b/pkg/antctl/raw/supportbundle/command_test.go
@@ -465,7 +465,7 @@ func TestProcessResults(t *testing.T) {
 
 					unpackError := compress.UnpackDir(defaultFS, filepath.Join(option.dir, tgzFileName), option.dir)
 					require.NoError(t, unpackError)
-					files, _ := tt.expectFileList[node]
+					files := tt.expectFileList[node]
 					for _, expectFileName := range files {
 						ok, checkErr = afero.Exists(defaultFS, filepath.Join(option.dir, expectFileName))
 						require.NoError(t, checkErr)

--- a/pkg/antctl/raw/traceflow/command.go
+++ b/pkg/antctl/raw/traceflow/command.go
@@ -420,15 +420,16 @@ func output(tf *v1beta1.Traceflow, writer io.Writer) error {
 		}
 	}
 
-	if option.outputType == "json" {
+	switch option.outputType {
+	case "json":
 		if err := jsonOutput(&r, writer); err != nil {
 			return fmt.Errorf("error when converting output to json: %w", err)
 		}
-	} else if option.outputType == "yaml" {
+	case "yaml":
 		if err := yamlOutput(&r, writer); err != nil {
 			return fmt.Errorf("error when converting output to yaml: %w", err)
 		}
-	} else {
+	default:
 		return fmt.Errorf("output types should be yaml or json")
 	}
 	return nil

--- a/pkg/apiserver/registry/stats/antreanetworkpolicystats/rest_test.go
+++ b/pkg/apiserver/registry/stats/antreanetworkpolicystats/rest_test.go
@@ -45,7 +45,7 @@ func (p *fakeStatsProvider) ListAntreaNetworkPolicyStats(namespace string) []sta
 			}
 		}
 	} else {
-		m1, _ := p.stats[namespace]
+		m1 := p.stats[namespace]
 		for _, m2 := range m1 {
 			list = append(list, m2)
 		}

--- a/pkg/apiserver/registry/stats/networkpolicystats/rest_test.go
+++ b/pkg/apiserver/registry/stats/networkpolicystats/rest_test.go
@@ -45,7 +45,7 @@ func (p *fakeStatsProvider) ListNetworkPolicyStats(namespace string) []statsv1al
 			}
 		}
 	} else {
-		m1, _ := p.stats[namespace]
+		m1 := p.stats[namespace]
 		for _, m2 := range m1 {
 			list = append(list, m2)
 		}

--- a/pkg/apiserver/registry/system/supportbundle/rest.go
+++ b/pkg/apiserver/registry/system/supportbundle/rest.go
@@ -144,9 +144,10 @@ func (r *supportBundleREST) Create(ctx context.Context, obj runtime.Object, _ re
 	go func(since string) {
 		var err error
 		var b *systemv1beta1.SupportBundle
-		if r.mode == modeAgent {
+		switch r.mode {
+		case modeAgent:
 			b, err = r.collectAgent(ctx, since)
-		} else if r.mode == modeController {
+		case modeController:
 			b, err = r.collectController(ctx, since)
 		}
 		func() {

--- a/pkg/controller/egress/controller_test.go
+++ b/pkg/controller/egress/controller_test.go
@@ -523,10 +523,7 @@ func TestUpdateEgress(t *testing.T) {
 			return false
 		}
 		ip := getEgressIP()
-		if ip != "" {
-			return false
-		}
-		return true
+		return ip == ""
 	}, time.Second, 50*time.Millisecond, "EgressIP was not deleted after the ExternalIPPool was deleted")
 
 	// Recreate the ExternalIPPool. An EgressIP should be allocated.

--- a/pkg/controller/externalippool/validate.go
+++ b/pkg/controller/externalippool/validate.go
@@ -177,7 +177,7 @@ func validateIPRangesAndSubnetInfo(externalIPPool crdv1beta1.ExternalIPPool, exi
 		}
 
 		// validate if range is subset of given subnet info
-		if subnet != nil && !(subnet.Contains(start) && subnet.Contains(end)) {
+		if subnet != nil && (!subnet.Contains(start) || !subnet.Contains(end)) {
 			return fmt.Sprintf("%s must be a strict subset of the subnet %s/%d",
 				key, subnetInfo.Gateway, subnetInfo.PrefixLength), false
 		}
@@ -185,7 +185,7 @@ func validateIPRangesAndSubnetInfo(externalIPPool crdv1beta1.ExternalIPPool, exi
 		// validate if the range overlaps with ranges of any existing pool or already processed
 		// range of current pool.
 		for combinedKey, combinedRange := range combinedRanges {
-			if !(start.Compare(combinedRange[1]) == 1 || end.Compare(combinedRange[0]) == -1) {
+			if start.Compare(combinedRange[1]) != 1 && end.Compare(combinedRange[0]) != -1 {
 				return fmt.Sprintf("%s overlaps with %s", key, combinedKey), false
 			}
 		}

--- a/pkg/controller/grouping/controller.go
+++ b/pkg/controller/grouping/controller.go
@@ -46,7 +46,7 @@ func PodIPsIndexFunc(obj interface{}) ([]string, error) {
 	if !ok {
 		return nil, fmt.Errorf("obj is not pod: %+v", obj)
 	}
-	if pod.Status.PodIPs != nil && len(pod.Status.PodIPs) > 0 && pod.Status.Phase != v1.PodSucceeded && pod.Status.Phase != v1.PodFailed {
+	if len(pod.Status.PodIPs) > 0 && pod.Status.Phase != v1.PodSucceeded && pod.Status.Phase != v1.PodFailed {
 		indexes := make([]string, len(pod.Status.PodIPs))
 		for i := range pod.Status.PodIPs {
 			indexes[i] = pod.Status.PodIPs[i].IP

--- a/pkg/controller/grouping/group_entity_index.go
+++ b/pkg/controller/grouping/group_entity_index.go
@@ -233,15 +233,15 @@ func (i *GroupEntityIndex) GetEntities(groupType GroupType, name string) ([]*v1.
 	}
 
 	// Get the selectorItem the group is associated with.
-	sItem, _ := i.selectorItems[gItem.selectorItemKey]
+	sItem := i.selectorItems[gItem.selectorItemKey]
 	var pods []*v1.Pod
 	var externalEntities []*v1alpha2.ExternalEntity
 	// Get the keys of the labelItems the selectorItem matches.
 	for lKey := range sItem.labelItemKeys {
-		lItem, _ := i.labelItems[lKey]
+		lItem := i.labelItems[lKey]
 		// Collect the entityItems that share the labelItem.
 		for entityItemKey := range lItem.entityItemKeys {
-			eItem, _ := i.entityItems[entityItemKey]
+			eItem := i.entityItems[entityItemKey]
 			switch entity := eItem.entity.(type) {
 			case *v1.Pod:
 				pods = append(pods, entity)
@@ -274,13 +274,13 @@ func (i *GroupEntityIndex) getGroups(entityType entityType, namespace, name stri
 	}
 
 	groups := map[GroupType][]string{}
-	lItem, _ := i.labelItems[eItem.labelItemKey]
+	lItem := i.labelItems[eItem.labelItemKey]
 	// Get the keys of the selectorItems the labelItem matches.
 	for sKey := range lItem.selectorItemKeys {
-		sItem, _ := i.selectorItems[sKey]
+		sItem := i.selectorItems[sKey]
 		// Collect the groupItems that share the selectorItem.
 		for gKey := range sItem.groupItemKeys {
-			gItem, _ := i.groupItems[gKey]
+			gItem := i.groupItems[gKey]
 			groups[gItem.groupType] = append(groups[gItem.groupType], gItem.name)
 		}
 	}
@@ -337,7 +337,7 @@ func (i *GroupEntityIndex) DeleteNamespace(namespace *v1.Namespace) {
 // deleteEntityFromLabelItem disconnects an entityItem from a labelItem.
 // The labelItem will be deleted if it's no longer used by any entityItem.
 func (i *GroupEntityIndex) deleteEntityFromLabelItem(label, entity string) *labelItem {
-	lItem, _ := i.labelItems[label]
+	lItem := i.labelItems[label]
 	lItem.entityItemKeys.Delete(entity)
 	// If the labelItem is still used by any entities, keep it. Otherwise delete it.
 	if len(lItem.entityItemKeys) > 0 {
@@ -392,10 +392,10 @@ func (i *GroupEntityIndex) createLabelItem(entityType entityType, eItem *entityI
 		}
 	}
 	// SelectorItems in the same Namespace may match the labelItem.
-	localSelectorItemKeys, _ := i.selectorItemIndex[entityType][eItem.entity.GetNamespace()]
+	localSelectorItemKeys := i.selectorItemIndex[entityType][eItem.entity.GetNamespace()]
 	scanSelectorItems(localSelectorItemKeys)
 	// Cluster scoped selectorItems may match the labelItem.
-	clusterSelectorItemKeys, _ := i.selectorItemIndex[entityType][emptyNamespace]
+	clusterSelectorItemKeys := i.selectorItemIndex[entityType][emptyNamespace]
 	scanSelectorItems(clusterSelectorItemKeys)
 	return lItem
 }
@@ -508,7 +508,7 @@ func (i *GroupEntityIndex) deleteEntity(entityType entityType, entity metav1.Obj
 // deleteGroupFromSelectorItem disconnects a groupItem from a selectorItem.
 // The selectorItem will be deleted if it's no longer used by any groupItem.
 func (i *GroupEntityIndex) deleteGroupFromSelectorItem(sKey, gKey string) *selectorItem {
-	sItem, _ := i.selectorItems[sKey]
+	sItem := i.selectorItems[sKey]
 	sItem.groupItemKeys.Delete(gKey)
 	// If the selectorItem is still used by any groups, keep it. Otherwise delete it.
 	if len(sItem.groupItemKeys) > 0 {
@@ -560,7 +560,7 @@ func (i *GroupEntityIndex) createSelectorItem(gItem *groupItem) *selectorItem {
 	// Scan potential labelItems and associates the new selectorItem with the matched ones.
 	if sItem.selector.Namespace != "" {
 		// The selector is Namespace scoped, it can only match labelItems in this Namespace.
-		labelItemKeys, _ := i.labelItemIndex[entityType][sItem.selector.Namespace]
+		labelItemKeys := i.labelItemIndex[entityType][sItem.selector.Namespace]
 		i.scanLabelItems(labelItemKeys, sItem)
 	} else if sItem.selector.NamespaceSelector != nil && !sItem.selector.NamespaceSelector.Empty() {
 		// The selector is Cluster scoped and has non-empty NamespaceSelector, scan labelItems in a Namespace only if

--- a/pkg/controller/ipam/antrea_ipam_controller.go
+++ b/pkg/controller/ipam/antrea_ipam_controller.go
@@ -267,7 +267,7 @@ func (c *AntreaIPAMController) cleanIPPoolForStatefulSet(namespacedName string) 
 func (c *AntreaIPAMController) getIPPoolsForStatefulSet(ss *appsv1.StatefulSet) ([]string, []net.IP) {
 
 	// Inspect IP annotation for the Pods
-	ipStrings, _ := ss.Spec.Template.Annotations[annotation.AntreaIPAMPodIPAnnotationKey]
+	ipStrings := ss.Spec.Template.Annotations[annotation.AntreaIPAMPodIPAnnotationKey]
 	ipStrings = strings.ReplaceAll(ipStrings, " ", "")
 	var ips []net.IP
 	if ipStrings != "" {

--- a/pkg/controller/ipam/validate.go
+++ b/pkg/controller/ipam/validate.go
@@ -191,15 +191,16 @@ func ipInRange(rangeStart, rangeEnd, ip net.IP) bool {
 func validateIPRange(r crdv1beta1.IPRange, subnetInfo crdv1beta1.SubnetInfo) (bool, string) {
 	// Verify that prefix length matches IP version
 	gatewayIPVersion := utilnet.IPFamilyOfString(subnetInfo.Gateway)
-	if gatewayIPVersion == utilnet.IPv4 {
+	switch gatewayIPVersion {
+	case utilnet.IPv4:
 		if subnetInfo.PrefixLength <= 0 || subnetInfo.PrefixLength >= 32 {
 			return false, fmt.Sprintf("Invalid prefix length %d", subnetInfo.PrefixLength)
 		}
-	} else if gatewayIPVersion == utilnet.IPv6 {
+	case utilnet.IPv6:
 		if subnetInfo.PrefixLength <= 0 || subnetInfo.PrefixLength >= 128 {
 			return false, fmt.Sprintf("Invalid prefix length %d", subnetInfo.PrefixLength)
 		}
-	} else {
+	default:
 		return false, fmt.Sprintf("Invalid IP version for gateway %s", subnetInfo.Gateway)
 	}
 

--- a/pkg/controller/labelidentity/label_group_index.go
+++ b/pkg/controller/labelidentity/label_group_index.go
@@ -313,11 +313,7 @@ func (i *LabelIdentityIndex) RemoveStalePolicySelectors(selectorKeys sets.Set[st
 	}
 	if selectorKeys.Len() > 0 {
 		for selKey := range selectorKeys {
-			if _, exists := originalSelectors[selKey]; exists {
-				// Remove matched ClusterSet-scoped selectors of the policy before and after the update.
-				// The selectors remaining in originalSelectors will need to be unbounded from the policy.
-				delete(originalSelectors, selKey)
-			}
+			delete(originalSelectors, selKey)
 		}
 	}
 	// The policy no longer has these selectors.

--- a/pkg/controller/networkpolicy/adminnetworkpolicy.go
+++ b/pkg/controller/networkpolicy/adminnetworkpolicy.go
@@ -255,12 +255,12 @@ func (n *NetworkPolicyController) processClusterSubject(subject v1alpha1.AdminNe
 }
 
 func anpActionToCRDAction(action v1alpha1.AdminNetworkPolicyRuleAction) *antreacrd.RuleAction {
-	antreaAction, _ := anpActionToAntreaActionMap[action]
+	antreaAction := anpActionToAntreaActionMap[action]
 	return &antreaAction
 }
 
 func banpActionToCRDAction(action v1alpha1.BaselineAdminNetworkPolicyRuleAction) *antreacrd.RuleAction {
-	antreaAction, _ := banpActionToAntreaActionMap[action]
+	antreaAction := banpActionToAntreaActionMap[action]
 	return &antreaAction
 }
 

--- a/pkg/controller/networkpolicy/clusternetworkpolicy.go
+++ b/pkg/controller/networkpolicy/clusternetworkpolicy.go
@@ -418,9 +418,10 @@ func (n *NetworkPolicyController) processClusterNetworkPolicy(cnp *crdv1beta1.Cl
 					L7Protocols:     toAntreaL7ProtocolsForCRD(cnpRule.L7Protocols),
 					LogLabel:        cnpRule.LogLabel,
 				}
-				if dir == controlplane.DirectionIn {
+				switch dir {
+				case controlplane.DirectionIn:
 					rule.From = *peer
-				} else if dir == controlplane.DirectionOut {
+				case controlplane.DirectionOut:
 					rule.To = *peer
 				}
 				rules = append(rules, rule)
@@ -689,7 +690,7 @@ func (n *NetworkPolicyController) toAntreaPeerForSameLabelNamespaces(peer crdv1b
 	var atgs []*antreatypes.AppliedToGroup
 	sort.Strings(namespacesByLabelValues)
 	for _, ns := range namespacesByLabelValues {
-		atgForNamespace, _ := atgPerAffectedNS[ns]
+		atgForNamespace := atgPerAffectedNS[ns]
 		atgs = append(atgs, atgForNamespace)
 	}
 	return antreaPeer, atgs, addressGroups, clusterSetScopeSelectorKeys

--- a/pkg/controller/networkpolicy/crd_utils_test.go
+++ b/pkg/controller/networkpolicy/crd_utils_test.go
@@ -271,7 +271,7 @@ func TestToAntreaIPBlockForCRD(t *testing.T) {
 			continue
 		}
 		ipNet := antreaIPBlock.CIDR
-		if bytes.Compare(ipNet.IP, table.expValue.CIDR.IP) != 0 {
+		if !bytes.Equal(ipNet.IP, table.expValue.CIDR.IP) {
 			t.Errorf("Unexpected IP in Antrea IPBlock conversion. Expected %v, got %v", table.expValue.CIDR.IP, ipNet.IP)
 		}
 		if table.expValue.CIDR.PrefixLength != ipNet.PrefixLength {

--- a/pkg/controller/networkpolicy/endpoint_querier.go
+++ b/pkg/controller/networkpolicy/endpoint_querier.go
@@ -221,12 +221,8 @@ func predictEndpointsRules(srcEndpointRules, dstEndpointRules *antreatypes.Endpo
 				commonRules = append(commonRules, rule)
 			}
 		}
-		for _, defaultDropRule := range srcIsolated {
-			commonRules = append(commonRules, defaultDropRule)
-		}
-		for _, defaultDropRule := range dstIsolated {
-			commonRules = append(commonRules, defaultDropRule)
-		}
+		commonRules = append(commonRules, srcIsolated...)
+		commonRules = append(commonRules, dstIsolated...)
 	}
 
 	// sort the common rules based on multiple closures, the top rule has the highest precedence

--- a/pkg/controller/networkpolicy/endpoint_querier_test.go
+++ b/pkg/controller/networkpolicy/endpoint_querier_test.go
@@ -317,7 +317,6 @@ func TestQueryNetworkPolicyRules(t *testing.T) {
 			assert.Equal(t, expectedRules[idx].Index, responseRules[idx].Index)
 			assert.Equal(t, expectedRules[idx].Policy.SourceRef, responseRules[idx].Policy.SourceRef)
 		}
-		return
 	}
 
 	for _, tc := range testCases {
@@ -407,9 +406,10 @@ func TestQueryNetworkPolicyEvaluation(t *testing.T) {
 			Name:            fmt.Sprintf("pod%d", podID),
 			AppliedPolicies: appliedPolicies,
 		}
-		if podID == 1 {
+		switch podID {
+		case 1:
 			endpointRule.EndpointAsIngressSrcRules = matchedRules
-		} else if podID == 2 {
+		case 2:
 			endpointRule.EndpointAsEgressDstRules = matchedRules
 		}
 		return endpointRule

--- a/pkg/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller.go
@@ -758,9 +758,10 @@ func (n *NetworkPolicyController) processNetworkPolicy(np *networkingv1.NetworkP
 	// Traffic in a direction must be isolated if Spec.PolicyTypes specify it explicitly.
 	var ingressIsolated, egressIsolated bool
 	for _, policyType := range np.Spec.PolicyTypes {
-		if policyType == networkingv1.PolicyTypeIngress {
+		switch policyType {
+		case networkingv1.PolicyTypeIngress:
 			ingressIsolated = true
-		} else if policyType == networkingv1.PolicyTypeEgress {
+		case networkingv1.PolicyTypeEgress:
 			egressIsolated = true
 		}
 	}

--- a/pkg/controller/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller_test.go
@@ -1708,7 +1708,7 @@ func TestToAntreaIPBlock(t *testing.T) {
 			continue
 		}
 		ipNet := antreaIPBlock.CIDR
-		if bytes.Compare(ipNet.IP, table.expValue.CIDR.IP) != 0 {
+		if !bytes.Equal(ipNet.IP, table.expValue.CIDR.IP) {
 			t.Errorf("Unexpected IP in Antrea IPBlock conversion. Expected %v, got %v", table.expValue.CIDR.IP, ipNet.IP)
 		}
 		if table.expValue.CIDR.PrefixLength != ipNet.PrefixLength {
@@ -2499,7 +2499,7 @@ func comparePodIPs(actIPs, expIPs []controlplane.IPAddress) bool {
 
 func containsPodIP(expIPs []controlplane.IPAddress, actIP controlplane.IPAddress) bool {
 	for _, expIP := range expIPs {
-		if bytes.Compare(actIP, expIP) == 0 {
+		if bytes.Equal(actIP, expIP) {
 			return true
 		}
 	}
@@ -2590,7 +2590,7 @@ func TestIPStrToIPAddress(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			actIP := ipStrToIPAddress(tt.ipStr)
-			if bytes.Compare(actIP, tt.expIP) != 0 {
+			if !bytes.Equal(actIP, tt.expIP) {
 				t.Errorf("ipStrToIPAddress() got unexpected IPAddress %v, want %v", actIP, tt.expIP)
 			}
 		})
@@ -3101,7 +3101,7 @@ func compareIPBlocks(ipb1, ipb2 *controlplane.IPBlock) bool {
 
 // compareIPNet is a util function to compare the contents of two IPNets.
 func compareIPNet(ipn1, ipn2 controlplane.IPNet) bool {
-	if bytes.Compare(ipn1.IP, ipn2.IP) != 0 {
+	if !bytes.Equal(ipn1.IP, ipn2.IP) {
 		return false
 	}
 	if ipn1.PrefixLength != ipn2.PrefixLength {

--- a/pkg/controller/networkpolicy/status_controller.go
+++ b/pkg/controller/networkpolicy/status_controller.go
@@ -218,21 +218,19 @@ func (c *StatusController) watchInternalNetworkPolicy() {
 	defer watcher.Stop()
 	resultCh := watcher.ResultChan()
 	for {
-		select {
-		case event, ok := <-resultCh:
-			if !ok {
-				return
-			}
-			// Skip handling Bookmark events.
-			if event.Type == watch.Bookmark {
-				continue
-			}
-			np := event.Object.(*controlplane.NetworkPolicy)
-			if !controlplane.IsSourceAntreaNativePolicy(np.SourceRef) {
-				continue
-			}
-			c.queue.Add(np.Name)
+		event, ok := <-resultCh
+		if !ok {
+			return
 		}
+		// Skip handling Bookmark events.
+		if event.Type == watch.Bookmark {
+			continue
+		}
+		np := event.Object.(*controlplane.NetworkPolicy)
+		if !controlplane.IsSourceAntreaNativePolicy(np.SourceRef) {
+			continue
+		}
+		c.queue.Add(np.Name)
 	}
 }
 

--- a/pkg/controller/networkpolicy/status_controller_test.go
+++ b/pkg/controller/networkpolicy/status_controller_test.go
@@ -103,10 +103,8 @@ func newInternalNetworkPolicy(name string, generation int64, nodes []string, ref
 }
 
 func newNetworkPolicyStatus(name string, nodeName string, generation int64, errorMessage string) *controlplane.NetworkPolicyStatus {
-	failed := false
-	if errorMessage != "" {
-		failed = true
-	}
+	failed := errorMessage != ""
+
 	return &controlplane.NetworkPolicyStatus{
 		ObjectMeta: v1.ObjectMeta{
 			Name: name,

--- a/pkg/controller/networkpolicy/store/networkpolicy.go
+++ b/pkg/controller/networkpolicy/store/networkpolicy.go
@@ -157,9 +157,10 @@ func NewNetworkPolicyStore() storage.Interface {
 				return []string{}, nil
 			}
 			for _, rule := range fp.Rules {
-				if rule.Direction == controlplane.DirectionIn {
+				switch rule.Direction {
+				case controlplane.DirectionIn:
 					groupNames = append(groupNames, rule.From.AddressGroups...)
-				} else if rule.Direction == controlplane.DirectionOut {
+				case controlplane.DirectionOut:
 					groupNames = append(groupNames, rule.To.AddressGroups...)
 				}
 			}

--- a/pkg/controller/networkpolicy/validate.go
+++ b/pkg/controller/networkpolicy/validate.go
@@ -527,19 +527,17 @@ func (v *antreaPolicyValidator) validatePolicy(curObj interface{}) ([]string, st
 	var ingress, egress []crdv1beta1.Rule
 	var specAppliedTo []crdv1beta1.AppliedTo
 	var warnings []string
-	switch curObj.(type) {
+	switch curObj := curObj.(type) {
 	case *crdv1beta1.ClusterNetworkPolicy:
-		curACNP := curObj.(*crdv1beta1.ClusterNetworkPolicy)
-		tier = curACNP.Spec.Tier
-		ingress = curACNP.Spec.Ingress
-		egress = curACNP.Spec.Egress
-		specAppliedTo = curACNP.Spec.AppliedTo
+		tier = curObj.Spec.Tier
+		ingress = curObj.Spec.Ingress
+		egress = curObj.Spec.Egress
+		specAppliedTo = curObj.Spec.AppliedTo
 	case *crdv1beta1.NetworkPolicy:
-		curANNP := curObj.(*crdv1beta1.NetworkPolicy)
-		tier = curANNP.Spec.Tier
-		ingress = curANNP.Spec.Ingress
-		egress = curANNP.Spec.Egress
-		specAppliedTo = curANNP.Spec.AppliedTo
+		tier = curObj.Spec.Tier
+		ingress = curObj.Spec.Ingress
+		egress = curObj.Spec.Egress
+		specAppliedTo = curObj.Spec.AppliedTo
 	}
 	reason, allowed := v.validateTierForPolicy(tier)
 	if !allowed {
@@ -733,7 +731,7 @@ func (v *antreaPolicyValidator) validatePeers(ingress, egress []crdv1beta1.Rule)
 	}
 	for _, rule := range egress {
 		if rule.ToServices != nil {
-			if (rule.To != nil && len(rule.To) > 0) || rule.Ports != nil || rule.Protocols != nil {
+			if (len(rule.To) > 0) || rule.Ports != nil || rule.Protocols != nil {
 				return "`toServices` cannot be used with `to`, `ports` or `protocols`", false
 			}
 		}
@@ -1055,7 +1053,7 @@ func validateAntreaClusterGroupSpec(s crdv1beta1.GroupSpec) (string, bool) {
 		return errMsg, false
 	} else if setFieldNum == 2 {
 		// If two fields are set, only nsSel+pSel and nsSel+eeSel are valid.
-		if !(s.NamespaceSelector != nil && (s.PodSelector != nil || s.ExternalEntitySelector != nil)) {
+		if s.NamespaceSelector == nil || (s.PodSelector == nil && s.ExternalEntitySelector == nil) {
 			return errMsg, false
 		}
 	}
@@ -1074,7 +1072,7 @@ func validateAntreaGroupSpec(s crdv1beta1.GroupSpec) (string, bool) {
 		return errMsg, false
 	} else if setFieldNum == 2 {
 		// If two fields are set, only nsSel+pSel and nsSel+eeSel are valid.
-		if !(s.NamespaceSelector != nil && (s.PodSelector != nil || s.ExternalEntitySelector != nil)) {
+		if s.NamespaceSelector == nil || (s.PodSelector == nil && s.ExternalEntitySelector == nil) {
 			return errMsg, false
 		}
 	}
@@ -1184,17 +1182,13 @@ func (g *groupValidator) updateValidate(curObj, oldObj interface{}, userInfo aut
 
 // validateGroup validates the CREATE and UPDATE events of Group, ClusterGroup resources.
 func (g *groupValidator) validateGroup(curObj interface{}) ([]string, string, bool) {
-	var curCG *crdv1beta1.ClusterGroup
-	var curG *crdv1beta1.Group
 	var reason string
 	var allowed bool
-	switch curObj.(type) {
+	switch curObj := curObj.(type) {
 	case *crdv1beta1.ClusterGroup:
-		curCG = curObj.(*crdv1beta1.ClusterGroup)
-		reason, allowed = g.validateCG(curCG)
+		reason, allowed = g.validateCG(curObj)
 	case *crdv1beta1.Group:
-		curG = curObj.(*crdv1beta1.Group)
-		reason, allowed = g.validateG(curG)
+		reason, allowed = g.validateG(curObj)
 	}
 	return nil, reason, allowed
 }
@@ -1221,13 +1215,11 @@ func (a *adminPolicyValidator) validateBANP(banp *v1alpha1.BaselineAdminNetworkP
 func (a *adminPolicyValidator) createValidate(curObj interface{}, userInfo authenticationv1.UserInfo) ([]string, string, bool) {
 	var reason string
 	var allowed bool
-	switch curObj.(type) {
+	switch curObj := curObj.(type) {
 	case *v1alpha1.AdminNetworkPolicy:
-		curANP := curObj.(*v1alpha1.AdminNetworkPolicy)
-		reason, allowed = a.validateAdminNP(curANP)
+		reason, allowed = a.validateAdminNP(curObj)
 	case *v1alpha1.BaselineAdminNetworkPolicy:
-		curBANP := curObj.(*v1alpha1.BaselineAdminNetworkPolicy)
-		reason, allowed = a.validateBANP(curBANP)
+		reason, allowed = a.validateBANP(curObj)
 	}
 	return nil, reason, allowed
 }

--- a/pkg/controller/supportbundlecollection/controller_test.go
+++ b/pkg/controller/supportbundlecollection/controller_test.go
@@ -97,9 +97,7 @@ func TestReconcileSupportBundles(t *testing.T) {
 	nodeConfigs, externalNodeConfigs := parseDependentResources(testConfigs)
 	coreObjects := prepareNodes(nodeConfigs)
 	crdObjects := prepareExternalNodes(externalNodeConfigs)
-	for _, c := range prepareBundleCollections(testConfigs) {
-		crdObjects = append(crdObjects, c)
-	}
+	crdObjects = append(crdObjects, prepareBundleCollections(testConfigs)...)
 
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1680,7 +1678,7 @@ func TestUpdateStatus(t *testing.T) {
 		prepareController(collectionName, desiredNodes)
 		reportedNodes := 1
 		agentReportStatus(reportedNodes, 0, collectionName)
-		statusPerNode, _ := controller.statuses[collectionName]
+		statusPerNode := controller.statuses[collectionName]
 		assert.Equal(t, reportedNodes, len(statusPerNode))
 		syncSupportBundleCollection()
 		assert.Equal(t, reportedNodes, len(statusPerNode))
@@ -1690,10 +1688,10 @@ func TestUpdateStatus(t *testing.T) {
 			NodeType:  controlplane.SupportBundleCollectionNodeTypeNode,
 			Completed: true,
 		})
-		statusPerNode, _ = controller.statuses[collectionName]
+		statusPerNode = controller.statuses[collectionName]
 		assert.Equal(t, reportedNodes+1, len(statusPerNode))
 		syncSupportBundleCollection()
-		statusPerNode, _ = controller.statuses[collectionName]
+		statusPerNode = controller.statuses[collectionName]
 		assert.Equal(t, reportedNodes, len(statusPerNode))
 	})
 
@@ -1966,24 +1964,20 @@ func prepareSecrets(ns string, secretConfigs []secretConfig) []*corev1.Secret {
 
 func prepareTopology() ([]runtime.Object, []runtime.Object) {
 	var coreObjects, crdObjects []runtime.Object
-	for _, n := range prepareNodes([]nodeConfig{
+	coreObjects = append(coreObjects, prepareNodes([]nodeConfig{
 		{name: "n1"},
 		{name: "n2"},
 		{name: "n3", labels: map[string]string{"test": "selected"}},
 		{name: "n4", labels: map[string]string{"test": "selected"}},
 		{name: "n5", labels: map[string]string{"test": "not-selected"}},
-	}) {
-		coreObjects = append(coreObjects, n)
-	}
-	for _, en := range prepareExternalNodes([]externalNodeConfig{
+	})...)
+	crdObjects = append(crdObjects, prepareExternalNodes([]externalNodeConfig{
 		{namespace: "ns1", name: "en1"},
 		{namespace: "ns1", name: "en2"},
 		{namespace: "ns1", name: "en3", labels: map[string]string{"test": "selected"}},
 		{namespace: "ns1", name: "en4", labels: map[string]string{"test": "not-selected"}},
 		{namespace: "ns2", name: "en5", labels: map[string]string{"test": "selected"}},
-	}) {
-		crdObjects = append(crdObjects, en)
-	}
+	})...)
 
 	apiKey := []byte(testKeyString)
 	token := []byte(testTokenString)

--- a/pkg/controller/traceflow/controller_test.go
+++ b/pkg/controller/traceflow/controller_test.go
@@ -141,7 +141,7 @@ func TestTraceflow(t *testing.T) {
 		assert.NotNil(t, res)
 		res, _ = tfc.waitForTraceflow("tf1", crdv1beta1.Failed, defaultTimeoutDuration*2)
 		assert.NotNil(t, res)
-		assert.True(t, time.Now().Sub(startTime) >= time.Second*time.Duration(tf1.Spec.Timeout))
+		assert.True(t, time.Since(startTime) >= time.Second*time.Duration(tf1.Spec.Timeout))
 		assert.Equal(t, res.Status.Reason, traceflowTimeout)
 		assert.True(t, res.Status.DataplaneTag == 0)
 		assert.Equal(t, numRunningTraceflows(), 0)

--- a/pkg/flowaggregator/flowaggregator.go
+++ b/pkg/flowaggregator/flowaggregator.go
@@ -223,7 +223,8 @@ func NewFlowAggregator(
 
 func (fa *flowAggregator) InitCollectingProcess() error {
 	var cpInput collector.CollectorInput
-	if fa.aggregatorTransportProtocol == flowaggregatorconfig.AggregatorTransportProtocolTLS {
+	switch fa.aggregatorTransportProtocol {
+	case flowaggregatorconfig.AggregatorTransportProtocolTLS:
 		parentCert, privateKey, caCert, err := generateCACertKey()
 		if err != nil {
 			return fmt.Errorf("error when generating CA certificate: %v", err)
@@ -251,7 +252,7 @@ func (fa *flowAggregator) InitCollectingProcess() error {
 			ServerKey:     serverKey,
 			ServerCert:    serverCert,
 		}
-	} else if fa.aggregatorTransportProtocol == flowaggregatorconfig.AggregatorTransportProtocolTCP {
+	case flowaggregatorconfig.AggregatorTransportProtocolTCP:
 		cpInput = collector.CollectorInput{
 			Address:       collectorAddress,
 			Protocol:      tcpTransport,
@@ -259,7 +260,7 @@ func (fa *flowAggregator) InitCollectingProcess() error {
 			TemplateTTL:   0, // use default value from go-ipfix library
 			IsEncrypted:   false,
 		}
-	} else {
+	default:
 		cpInput = collector.CollectorInput{
 			Address:       collectorAddress,
 			Protocol:      udpTransport,
@@ -456,9 +457,10 @@ func (fa *flowAggregator) flowExportLoop(stopCh <-chan struct{}) {
 			fa.logExporter.Stop()
 		}
 	}()
-	if fa.aggregatorMode == flowaggregatorconfig.AggregatorModeAggregate {
+	switch fa.aggregatorMode {
+	case flowaggregatorconfig.AggregatorModeAggregate:
 		fa.flowExportLoopAggregate(stopCh)
-	} else if fa.aggregatorMode == flowaggregatorconfig.AggregatorModeProxy {
+	case flowaggregatorconfig.AggregatorModeProxy:
 		fa.flowExportLoopProxy(stopCh)
 	}
 }

--- a/pkg/ovs/openflow/default_windows.go
+++ b/pkg/ovs/openflow/default_windows.go
@@ -24,6 +24,6 @@ const namedPipePrefix = `\\.\pipe\`
 func GetMgmtAddress(ovsRunDir, brName string) string {
 	sockFile := brName + ".mgmt"
 	addr := filepath.Join(filepath.FromSlash(ovsRunDir), sockFile)
-	addr = strings.Replace(addr, string(filepath.Separator), "", -1)
+	addr = strings.ReplaceAll(addr, string(filepath.Separator), "")
 	return namedPipePrefix + addr
 }

--- a/pkg/ovs/openflow/ofctrl_bridge.go
+++ b/pkg/ovs/openflow/ofctrl_bridge.go
@@ -794,33 +794,31 @@ func (b *OFBridge) processTableFeatures(ch chan *openflow15.MultipartReply) {
 	// features in the reply. Here we complete the loop after we receive all the reply messages, while the reply message
 	// is configured with Flags=0.
 	for {
-		select {
-		case rpl := <-ch:
-			request := &openflow15.MultipartRequest{
-				Header: header,
-				Type:   openflow15.MultipartType_TableFeatures,
-				Flags:  rpl.Flags,
+		rpl := <-ch
+		request := &openflow15.MultipartRequest{
+			Header: header,
+			Type:   openflow15.MultipartType_TableFeatures,
+			Flags:  rpl.Flags,
+		}
+		// A MultipartReply message may have one or many OFPTableFeatures messages, and MultipartReply.Body is a
+		// slice of these messages.
+		for _, body := range rpl.Body {
+			tableFeature := body.(*openflow15.TableFeatures)
+			// Modify table name if the table is in the pipeline, otherwise use the default table features.
+			// OVS doesn't allow to skip any table except the hidden table (always the last table) in a table_features
+			// request. So use the existing table features for the tables that Antrea doesn't define in the pipeline.
+			if t, ok := b.tableCache[tableFeature.TableID]; ok {
+				// Set table name with the configured value.
+				copy(tableFeature.Name[0:], t.name)
 			}
-			// A MultipartReply message may have one or many OFPTableFeatures messages, and MultipartReply.Body is a
-			// slice of these messages.
-			for _, body := range rpl.Body {
-				tableFeature := body.(*openflow15.TableFeatures)
-				// Modify table name if the table is in the pipeline, otherwise use the default table features.
-				// OVS doesn't allow to skip any table except the hidden table (always the last table) in a table_features
-				// request. So use the existing table features for the tables that Antrea doesn't define in the pipeline.
-				if t, ok := b.tableCache[tableFeature.TableID]; ok {
-					// Set table name with the configured value.
-					copy(tableFeature.Name[0:], t.name)
-				}
-				request.Body = append(request.Body, tableFeature)
-			}
-			request.Length = request.Len()
-			b.ofSwitch.Send(request)
-			// OVS uses "Flags=0" in the last MultipartReply message to indicate all tables' features have been sent.
-			// Here use this mark to identify all related messages are received and complete the loop.
-			if rpl.Flags == 0 {
-				break
-			}
+			request.Body = append(request.Body, tableFeature)
+		}
+		request.Length = request.Len()
+		b.ofSwitch.Send(request)
+		// OVS uses "Flags=0" in the last MultipartReply message to indicate all tables' features have been sent.
+		// Here use this mark to identify all related messages are received and complete the loop.
+		if rpl.Flags == 0 {
+			break
 		}
 	}
 }

--- a/pkg/ovs/openflow/utils.go
+++ b/pkg/ovs/openflow/utils.go
@@ -482,51 +482,51 @@ func trimLeadingZero(s string) string {
 func getFieldDataString(field *openflow15.MatchField) string {
 	value, mask := field.Value, field.Mask
 	var fieldStr string
-	switch value.(type) {
+	switch value := value.(type) {
 	case *util.Buffer:
-		fieldStr = fmt.Sprintf("0x%s", trimLeadingZero(fmt.Sprintf("%x", value.(*util.Buffer).Bytes())))
+		fieldStr = fmt.Sprintf("0x%s", trimLeadingZero(fmt.Sprintf("%x", value.Bytes())))
 		if mask != nil {
 			fieldStr = fmt.Sprintf("%s/0x%s", fieldStr, trimLeadingZero(fmt.Sprintf("%x", mask.(*util.Buffer).Bytes())))
 		}
 	case *openflow15.ByteArrayField:
-		fieldStr = fmt.Sprintf("0x%s", trimLeadingZero(fmt.Sprintf("%x", value.(*openflow15.ByteArrayField).Data)))
+		fieldStr = fmt.Sprintf("0x%s", trimLeadingZero(fmt.Sprintf("%x", value.Data)))
 		if mask != nil {
 			fieldStr = fmt.Sprintf("%s/0x%s", fieldStr, trimLeadingZero(fmt.Sprintf("%x", mask.(*openflow15.ByteArrayField).Data)))
 		}
 	case *openflow15.Uint32Message:
-		fieldStr = fmt.Sprintf("0x%x", value.(*openflow15.Uint32Message).Data)
+		fieldStr = fmt.Sprintf("0x%x", value.Data)
 		if mask != nil && mask.(*openflow15.Uint32Message).Data != 0xffffffff {
 			fieldStr = fmt.Sprintf("%s/0x%x", fieldStr, mask.(*openflow15.Uint32Message).Data)
 		}
 	case *openflow15.CTLabel:
-		fieldStr = fmt.Sprintf("0x%s", trimLeadingZero(fmt.Sprintf("%x", value.(*openflow15.CTLabel).Data)))
+		fieldStr = fmt.Sprintf("0x%s", trimLeadingZero(fmt.Sprintf("%x", value.Data)))
 		if mask != nil && mask.(*openflow15.CTLabel).Data != [16]byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff} {
 			fieldStr = fmt.Sprintf("%s/0x%s", fieldStr, trimLeadingZero(fmt.Sprintf("%x", mask.(*openflow15.CTLabel).Data)))
 		}
 	case *openflow15.PortField:
-		fieldStr = fmt.Sprintf("%d", value.(*openflow15.PortField).Port)
+		fieldStr = fmt.Sprintf("%d", value.Port)
 		if mask != nil && mask.(*openflow15.PortField).Port != 0xffff {
-			fieldStr = fmt.Sprintf("0x%x/0x%x", value.(*openflow15.PortField).Port, mask.(*openflow15.PortField).Port)
+			fieldStr = fmt.Sprintf("0x%x/0x%x", value.Port, mask.(*openflow15.PortField).Port)
 		}
 	case *ofctrl.PortField:
-		fieldStr = fmt.Sprintf("%d", value.(*ofctrl.PortField).Port)
+		fieldStr = fmt.Sprintf("%d", value.Port)
 		if mask != nil && mask.(*ofctrl.PortField).Port != 0xffff {
-			fieldStr = fmt.Sprintf("0x%x/0x%x", value.(*ofctrl.PortField).Port, mask.(*ofctrl.PortField).Port)
+			fieldStr = fmt.Sprintf("0x%x/0x%x", value.Port, mask.(*ofctrl.PortField).Port)
 		}
 	case *ofctrl.ProtocolField:
-		fieldStr = fmt.Sprintf("%d", value.(*ofctrl.ProtocolField).Protocol)
+		fieldStr = fmt.Sprintf("%d", value.Protocol)
 	case *openflow15.IpDscpField:
-		fieldStr = fmt.Sprintf("%d", value.(*openflow15.IpDscpField).Dscp)
+		fieldStr = fmt.Sprintf("%d", value.Dscp)
 	case *openflow15.EthSrcField:
-		fieldStr = value.(*openflow15.EthSrcField).EthSrc.String()
+		fieldStr = value.EthSrc.String()
 	case *openflow15.EthDstField:
-		fieldStr = value.(*openflow15.EthDstField).EthDst.String()
+		fieldStr = value.EthDst.String()
 	case *openflow15.ArpXHaField:
-		fieldStr = value.(*openflow15.ArpXHaField).ArpHa.String()
+		fieldStr = value.ArpHa.String()
 	case *openflow15.ArpXPaField:
-		fieldStr = value.(*openflow15.ArpXPaField).ArpPa.String()
+		fieldStr = value.ArpPa.String()
 	case *openflow15.Ipv4SrcField:
-		fieldStr = value.(*openflow15.Ipv4SrcField).Ipv4Src.String()
+		fieldStr = value.Ipv4Src.String()
 		if mask != nil {
 			prefix, _ := net.IPMask(mask.(*openflow15.Ipv4SrcField).Ipv4Src).Size()
 			if prefix < 32 {
@@ -534,7 +534,7 @@ func getFieldDataString(field *openflow15.MatchField) string {
 			}
 		}
 	case *openflow15.Ipv4DstField:
-		fieldStr = value.(*openflow15.Ipv4DstField).Ipv4Dst.String()
+		fieldStr = value.Ipv4Dst.String()
 		if mask != nil {
 			prefix, _ := net.IPMask(mask.(*openflow15.Ipv4DstField).Ipv4Dst).Size()
 			if prefix < 32 {
@@ -542,7 +542,7 @@ func getFieldDataString(field *openflow15.MatchField) string {
 			}
 		}
 	case *openflow15.Ipv6SrcField:
-		fieldStr = value.(*openflow15.Ipv6SrcField).Ipv6Src.String()
+		fieldStr = value.Ipv6Src.String()
 		if mask != nil {
 			prefix, _ := net.IPMask(mask.(*openflow15.Ipv6SrcField).Ipv6Src).Size()
 			if prefix < 128 {
@@ -550,7 +550,7 @@ func getFieldDataString(field *openflow15.MatchField) string {
 			}
 		}
 	case *openflow15.Ipv6DstField:
-		fieldStr = value.(*openflow15.Ipv6DstField).Ipv6Dst.String()
+		fieldStr = value.Ipv6Dst.String()
 		if mask != nil {
 			prefix, _ := net.IPMask(mask.(*openflow15.Ipv6DstField).Ipv6Dst).Size()
 			if prefix < 128 {
@@ -558,24 +558,24 @@ func getFieldDataString(field *openflow15.MatchField) string {
 			}
 		}
 	case *openflow15.TunnelIpv4DstField:
-		fieldStr = value.(*openflow15.TunnelIpv4DstField).TunnelIpv4Dst.String()
+		fieldStr = value.TunnelIpv4Dst.String()
 	case *openflow15.TunnelIdField:
-		fieldStr = fmt.Sprintf("%d", value.(*openflow15.TunnelIdField).TunnelId)
+		fieldStr = fmt.Sprintf("%d", value.TunnelId)
 	case *openflow15.VlanIdField:
-		fieldStr = fmt.Sprintf("%d", value.(*openflow15.VlanIdField).VlanId)
+		fieldStr = fmt.Sprintf("%d", value.VlanId)
 	case *openflow15.ArpOperField:
-		fieldStr = fmt.Sprintf("%d", value.(*openflow15.ArpOperField).ArpOper)
+		fieldStr = fmt.Sprintf("%d", value.ArpOper)
 	case *openflow15.MatchField:
-		fieldStr = fmt.Sprintf("0x%x", value.(*openflow15.MatchField).Value)
+		fieldStr = fmt.Sprintf("0x%x", value.Value)
 		if mask != nil {
 			fieldStr = fmt.Sprintf("%s/0x%x", fieldStr, mask.(*openflow15.MatchField).Value)
 		}
 	case *openflow15.InPortField:
-		fieldStr = fmt.Sprintf("%d", value.(*openflow15.InPortField).InPort)
+		fieldStr = fmt.Sprintf("%d", value.InPort)
 	case *openflow15.IcmpTypeField:
-		fieldStr = fmt.Sprintf("%d", value.(*openflow15.IcmpTypeField).Type)
+		fieldStr = fmt.Sprintf("%d", value.Type)
 	case *openflow15.IcmpCodeField:
-		fieldStr = fmt.Sprintf("%d", value.(*openflow15.IcmpCodeField).Code)
+		fieldStr = fmt.Sprintf("%d", value.Code)
 	}
 	return fieldStr
 }
@@ -868,8 +868,8 @@ func nxActionLearnToString(action openflow15.Action) string {
 	if len(a.LearnSpecs) != 0 {
 		for _, spec := range a.LearnSpecs {
 			nBits := spec.Header.NBits
-			isLoad := spec.Header.Dst == true
-			isMatch := spec.Header.Dst == false
+			isLoad := spec.Header.Dst
+			isMatch := !spec.Header.Dst
 			//TODO: add isOutput
 
 			if spec.SrcValue != nil {

--- a/pkg/ovs/ovsconfig/default_windows.go
+++ b/pkg/ovs/ovsconfig/default_windows.go
@@ -34,6 +34,6 @@ const (
 
 func GetConnAddress(ovsRunDir string) string {
 	addr := filepath.Join(filepath.FromSlash(ovsRunDir), defaultOVSDBFile)
-	addr = strings.Replace(addr, string(filepath.Separator), "", -1)
+	addr = strings.ReplaceAll(addr, string(filepath.Separator), "")
 	return namedPipePrefix + addr
 }

--- a/pkg/ovs/ovsconfig/ovs_client.go
+++ b/pkg/ovs/ovsconfig/ovs_client.go
@@ -309,9 +309,9 @@ func (br *OVSBridge) GetDatapathID() (string, Error) {
 		return "", NewTransactionError(err, temporary)
 	}
 	datapathID := res[0].Rows[0].(map[string]interface{})["datapath_id"]
-	switch datapathID.(type) {
+	switch datapathID := datapathID.(type) {
 	case string:
-		return datapathID.(string), nil
+		return datapathID, nil
 	default:
 		return "", nil
 	}
@@ -348,9 +348,9 @@ func (br *OVSBridge) WaitForDatapathID(timeout time.Duration) (string, Error) {
 	}
 
 	datapathID := res[1].Rows[0].(map[string]interface{})["datapath_id"]
-	switch datapathID.(type) {
+	switch datapathID := datapathID.(type) {
 	case string:
-		return datapathID.(string), nil
+		return datapathID, nil
 	default:
 		return "", nil
 	}

--- a/pkg/ovs/ovsctl/ovsctl.go
+++ b/pkg/ovs/ovsctl/ovsctl.go
@@ -209,11 +209,12 @@ func (c *ovsCtlClient) GetDPFeatures() (map[DPFeature]bool, error) {
 		}
 		value := strings.TrimSpace(fields[1])
 		var supported bool
-		if value == "Yes" {
+		switch value {
+		case "Yes":
 			supported = true
-		} else if value == "No" {
+		case "No":
 			supported = false
-		} else {
+		default:
 			klog.InfoS("Unexpected non boolean value", "feature", feature, "value", value)
 			continue
 		}

--- a/pkg/util/compress/compress.go
+++ b/pkg/util/compress/compress.go
@@ -68,7 +68,7 @@ func UnpackReader(fs afero.Fs, file io.Reader, useGzip bool, targetDir string) e
 	}
 	tarReader := tar.NewReader(reader)
 
-	for true {
+	for {
 		header, err := tarReader.Next()
 		if err == io.EOF {
 			break

--- a/pkg/util/k8s/client.go
+++ b/pkg/util/k8s/client.go
@@ -117,7 +117,7 @@ func OverrideKubeAPIServer(kubeAPIServerOverride string) {
 	if len(kubeAPIServerOverride) == 0 {
 		return
 	}
-	hostPort := strings.Replace(kubeAPIServerOverride, "https://", "", -1)
+	hostPort := strings.ReplaceAll(kubeAPIServerOverride, "https://", "")
 	var host, port string
 	var err error
 	if host, port, err = net.SplitHostPort(hostPort); err != nil {

--- a/test/e2e-secondary-network/secondary_network_test.go
+++ b/test/e2e-secondary-network/secondary_network_test.go
@@ -153,10 +153,10 @@ func (data *testData) createPodForSecondaryNetwork(ns string, pod *testPodInfo) 
 	podBuilder := antreae2e.NewPodBuilder(pod.podName, ns, antreae2e.ToolboxImage).
 		OnNode(pod.nodeName).WithContainerName(containerName).
 		WithAnnotations(map[string]string{
-			nadv1.NetworkAttachmentAnnot: fmt.Sprintf("%s", data.formAnnotationStringOfPod(pod)),
+			nadv1.NetworkAttachmentAnnot: data.formAnnotationStringOfPod(pod),
 		}).
 		WithLabels(map[string]string{
-			"App": fmt.Sprintf("%s", podApp),
+			"App": podApp,
 		})
 
 	if data.networkType == networkTypeSriov {

--- a/test/e2e/antctl_test.go
+++ b/test/e2e/antctl_test.go
@@ -122,7 +122,7 @@ func testAntctlAgentLocalAccess(t *testing.T, data *TestData) {
 		cmd := strings.Join(args, " ")
 		t.Run(cmd, func(t *testing.T) {
 			stdout, stderr, err := runAntctl(podName, args, data)
-			if err != nil && !(strings.HasSuffix(stderr, "not enabled\n") || strings.HasSuffix(stderr, "there is no effective bgp policy applied to the Node\n")) {
+			if err != nil && (!strings.HasSuffix(stderr, "not enabled\n") && !strings.HasSuffix(stderr, "there is no effective bgp policy applied to the Node\n")) {
 				t.Fatalf("Error when running `antctl %s` from %s: %v\n%s", c, podName, err, antctlOutput(stdout, stderr))
 			}
 		})

--- a/test/e2e/antreapolicy_test.go
+++ b/test/e2e/antreapolicy_test.go
@@ -690,8 +690,8 @@ func testACNPDropIPBlockWithExcept(t *testing.T) {
 	builder = builder.SetName("acnp-drop-all-egress-from-ya-except-xa-xb-ip").
 		SetPriority(1.0).
 		SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"pod": "a"}, NSSelector: map[string]string{"ns": getNS("y")}}})
-	podXAIP, _ := podIPs[getPodName("x", "a")]
-	podXBIP, _ := podIPs[getPodName("x", "b")]
+	podXAIP := podIPs[getPodName("x", "a")]
+	podXBIP := podIPs[getPodName("x", "b")]
 	ipBlocks := genIPBlockForAllIPsExcept(append(podXAIP, podXBIP...))
 	for i := range ipBlocks {
 		builder.AddEgress(ProtocolTCP, &p80, nil, nil, nil, nil, nil, nil, ipBlocks[i], nil, nil, nil, nil, nil, nil, nil, nil,
@@ -1137,10 +1137,10 @@ func genIPBlockForAllIPsExcept(except []string) []*crdv1beta1.IPBlock {
 }
 
 func testACNPClusterGroupRefRuleIPBlocks(t *testing.T) {
-	podXAIP, _ := podIPs[getPodName("x", "a")]
-	podXBIP, _ := podIPs[getPodName("x", "b")]
-	podXCIP, _ := podIPs[getPodName("x", "c")]
-	podZAIP, _ := podIPs[getPodName("z", "a")]
+	podXAIP := podIPs[getPodName("x", "a")]
+	podXBIP := podIPs[getPodName("x", "b")]
+	podXCIP := podIPs[getPodName("x", "c")]
+	podZAIP := podIPs[getPodName("z", "a")]
 	var ipBlock1, ipBlock2 []crdv1beta1.IPBlock
 	for i := 0; i < len(podXAIP); i++ {
 		for _, ips := range [][]string{podXAIP, podXBIP, podXCIP} {
@@ -1587,8 +1587,8 @@ func testANNPGroupServiceRefCreateAndUpdate(t *testing.T) {
 }
 
 func testANNPGroupRefRuleIPBlocks(t *testing.T) {
-	podXBIP, _ := podIPs[getPodName("x", "b")]
-	podXCIP, _ := podIPs[getPodName("x", "c")]
+	podXBIP := podIPs[getPodName("x", "b")]
+	podXCIP := podIPs[getPodName("x", "c")]
 	var ipBlock []crdv1beta1.IPBlock
 	for i := 0; i < len(podXBIP); i++ {
 		for _, podIP := range []string{podXBIP[i], podXCIP[i]} {
@@ -2137,7 +2137,7 @@ func testACNPPortRange(t *testing.T) {
 	reachability.Expect(getPod("z", "a"), getPod("z", "c"), Dropped)
 	testSteps := []*TestStep{
 		{
-			Name:          fmt.Sprintf("ACNP Drop Ports 8080:8082"),
+			Name:          "ACNP Drop Ports 8080:8082",
 			Reachability:  reachability,
 			TestResources: []metav1.Object{builder.Get()},
 			Ports:         []int32{8080, 8081, 8082},
@@ -2423,7 +2423,7 @@ func testANNPPortRange(t *testing.T) {
 
 	var testSteps []*TestStep
 	testSteps = append(testSteps, &TestStep{
-		Name:          fmt.Sprintf("ANNP Drop Ports 8080:8082"),
+		Name:          "ANNP Drop Ports 8080:8082",
 		Reachability:  reachability,
 		TestResources: []metav1.Object{builder.Get()},
 		Ports:         []int32{8080, 8081, 8082},
@@ -2672,8 +2672,8 @@ func (m *auditLogMatcher) add(appliedToRef, srcIP, destIP string, destPort int32
 }
 
 func (m *auditLogMatcher) AddProbe(appliedToRef, ns1, pod1, ns2, pod2 string, destPort int32) {
-	srcIPs, _ := podIPs[fmt.Sprintf("%s/%s", ns1, pod1)]
-	destIPs, _ := podIPs[fmt.Sprintf("%s/%s", ns2, pod2)]
+	srcIPs := podIPs[fmt.Sprintf("%s/%s", ns1, pod1)]
+	destIPs := podIPs[fmt.Sprintf("%s/%s", ns2, pod2)]
 	for _, srcIP := range srcIPs {
 		for _, destIP := range destIPs {
 			// only look for an entry in the audit log file if srcIP and dstIP are of the same family
@@ -2686,7 +2686,7 @@ func (m *auditLogMatcher) AddProbe(appliedToRef, ns1, pod1, ns2, pod2 string, de
 }
 
 func (m *auditLogMatcher) AddProbeAddr(appliedToRef, ns, pod, destIP string, destPort int32) {
-	srcIPs, _ := podIPs[fmt.Sprintf("%s/%s", ns, pod)]
+	srcIPs := podIPs[fmt.Sprintf("%s/%s", ns, pod)]
 	for _, srcIP := range srcIPs {
 		// only look for an entry in the audit log file if srcIP and dstIP are of the same family
 		if IPFamily(srcIP) != IPFamily(destIP) {
@@ -3125,8 +3125,8 @@ func testACNPNestedClusterGroupCreateAndUpdate(t *testing.T, data *TestData) {
 }
 
 func testACNPNestedIPBlockClusterGroupCreateAndUpdate(t *testing.T) {
-	podXAIP, _ := podIPs[getPodName("x", "a")]
-	podXBIP, _ := podIPs[getPodName("x", "b")]
+	podXAIP := podIPs[getPodName("x", "a")]
+	podXBIP := podIPs[getPodName("x", "b")]
 	cg1Name, cg2Name, cg3Name := "cg-x-a-ipb", "cg-x-b-ipb", "cg-select-x-c"
 	cgParentName := "cg-parent"
 	var ipBlockXA, ipBlockXB []crdv1beta1.IPBlock
@@ -4221,11 +4221,12 @@ func testACNPMulticastEgress(t *testing.T, data *TestData, acnpName, caseName, g
 	defer data.CRDClient.CrdV1beta1().ClusterNetworkPolicies().Delete(context.TODO(), acnp.Name, metav1.DeleteOptions{})
 
 	captured, err := checkPacketCaptureResult(t, data, tcpdumpName, cmd)
-	if action == crdv1beta1.RuleActionAllow {
+	switch action {
+	case crdv1beta1.RuleActionAllow:
 		if !captured || err != nil {
 			t.Fatalf("failed to apply acnp policy: %+v, err: %v", *acnp, err)
 		}
-	} else if action == crdv1beta1.RuleActionDrop {
+	case crdv1beta1.RuleActionDrop:
 		if captured || err != nil {
 			t.Fatalf("failed to apply acnp policy: %+v, err: %v", *acnp, err)
 		}
@@ -4320,7 +4321,7 @@ func executeTestsWithData(t *testing.T, testList []*TestCase, data *TestData) {
 			if reachability != nil {
 				start := time.Now()
 				k8sUtils.Validate(allPods, reachability, step.Ports, step.Protocol)
-				step.Duration = time.Now().Sub(start)
+				step.Duration = time.Since(start)
 
 				_, wrong, _ := step.Reachability.Summary()
 				if wrong != 0 {

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -366,10 +366,11 @@ func testReconcileGatewayRoutesOnStartup(t *testing.T, data *TestData, isIPv6 bo
 	}
 
 	expectedRtNumMin, expectedRtNumMax := clusterInfo.numNodes-1, clusterInfo.numNodes-1
-	if encapMode == config.TrafficEncapModeNoEncap {
+	switch encapMode {
+	case config.TrafficEncapModeNoEncap:
 		expectedRtNumMin, expectedRtNumMax = 0, 0
 
-	} else if encapMode == config.TrafficEncapModeHybrid {
+	case config.TrafficEncapModeHybrid:
 		expectedRtNumMin = 1
 	}
 

--- a/test/e2e/flowaggregator_test.go
+++ b/test/e2e/flowaggregator_test.go
@@ -2004,7 +2004,7 @@ func testL7FlowExporterController(t *testing.T, data *TestData, isIPv6 bool) {
 		assert.Contains(record, testFlow1.srcPodName, "Record with srcIP does not have Pod name: %s", testFlow1.srcPodName)
 		assert.Contains(record, fmt.Sprintf("sourcePodNamespace: %s", data.testNamespace), "Record does not have correct sourcePodNamespace: %s", data.testNamespace)
 		assert.Contains(record, fmt.Sprintf("sourceNodeName: %s", nodeName), "Record does not have correct sourceNodeName: %s", nodeName)
-		assert.Contains(record, fmt.Sprintf("\"flowexportertest\":\"l7\""), "Record does not have correct label for source Pod")
+		assert.Contains(record, "\"flowexportertest\":\"l7\"", "Record does not have correct label for source Pod")
 
 		checkL7FlowExporterData(t, record, "http")
 	}
@@ -2015,7 +2015,7 @@ func testL7FlowExporterController(t *testing.T, data *TestData, isIPv6 bool) {
 		assert.Equal(record.SourcePodName, testFlow1.srcPodName, "Record with srcIP does not have Pod name: %s", testFlow1.srcPodName)
 		assert.Equal(record.SourcePodNamespace, data.testNamespace, "Record does not have correct sourcePodNamespace: %s", data.testNamespace)
 		assert.Equal(record.SourceNodeName, nodeName, "Record does not have correct sourceNodeName: %s", nodeName)
-		assert.Contains(record.SourcePodLabels, fmt.Sprintf("\"flowexportertest\":\"l7\""), "Record does not have correct label for source Pod")
+		assert.Contains(record.SourcePodLabels, "\"flowexportertest\":\"l7\"", "Record does not have correct label for source Pod")
 
 		checkL7FlowExporterDataClickHouse(t, record, "http")
 	}

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -72,7 +72,7 @@ import (
 var AntreaConfigMap *corev1.ConfigMap
 
 var (
-	connectionLostError = fmt.Errorf("http2: client connection lost")
+	errConnectionLost = fmt.Errorf("http2: client connection lost")
 )
 
 const (
@@ -3179,7 +3179,7 @@ func (data *TestData) waitForStatefulSetPods(timeout time.Duration, stsName stri
 }
 
 func isConnectionLostError(err error) bool {
-	return strings.Contains(err.Error(), connectionLostError.Error())
+	return strings.Contains(err.Error(), errConnectionLost.Error())
 }
 
 // retryOnConnectionLostError allows the caller to retry fn in case the error is ConnectionLost.

--- a/test/e2e/ipsec_test.go
+++ b/test/e2e/ipsec_test.go
@@ -115,11 +115,12 @@ func (data *TestData) readSecurityAssociationsStatus(nodeName string) (up int, c
 		return 0, 0, false, fmt.Errorf("failed to determine authentication method from 'ipsec statusall' output: %s", stdout)
 	}
 
-	if match[1] == "pre-shared" {
+	switch match[1] {
+	case "pre-shared":
 		isCertAuth = false
-	} else if match[1] == "public" {
+	case "public":
 		isCertAuth = true
-	} else {
+	default:
 		return 0, 0, false, fmt.Errorf("unknown key authentication mode %q", match[1])
 	}
 

--- a/test/e2e/nodenetworkpolicy_test.go
+++ b/test/e2e/nodenetworkpolicy_test.go
@@ -264,7 +264,7 @@ func testNodeACNPPortRange(t *testing.T) {
 	reachability.Expect(getPod("x", "a"), getPod("y", "a"), Dropped)
 	testSteps := []*TestStep{
 		{
-			Name:          fmt.Sprintf("ACNP Drop Ports 8080:8082"),
+			Name:          "ACNP Drop Ports 8080:8082",
 			Reachability:  reachability,
 			TestResources: []metav1.Object{builder.Get()},
 			Ports:         []int32{8080, 8081, 8082},
@@ -735,8 +735,8 @@ func testNodeACNPClusterGroupUpdate(t *testing.T) {
 }
 
 func testNodeACNPClusterGroupRefRuleIPBlocks(t *testing.T) {
-	podYAIP, _ := podIPs[getNS("y")+"/a"]
-	podZAIP, _ := podIPs[getNS("z")+"/a"]
+	podYAIP := podIPs[getNS("y")+"/a"]
+	podZAIP := podIPs[getNS("z")+"/a"]
 	// There are three situations of a Pod's IP(s):
 	// 1. Only one IPv4 address.
 	// 2. Only one IPv6 address.
@@ -837,8 +837,8 @@ func testNodeACNPNestedClusterGroupCreateAndUpdate(t *testing.T, data *TestData)
 }
 
 func testNodeACNPNestedIPBlockClusterGroupCreateAndUpdate(t *testing.T) {
-	podYAIP, _ := podIPs[getPodName("y", "a")]
-	podZAIP, _ := podIPs[getPodName("z", "a")]
+	podYAIP := podIPs[getPodName("y", "a")]
+	podZAIP := podIPs[getPodName("z", "a")]
 	genCIDR := func(ip string) string {
 		switch IPFamily(ip) {
 		case "v4":

--- a/test/e2e/nodeportlocal_test.go
+++ b/test/e2e/nodeportlocal_test.go
@@ -247,12 +247,12 @@ func checkForNPLRuleInNetNat(t *testing.T, data *TestData, r *require.Assertions
 			return false, nil
 		}
 		for _, rule := range rules {
-			cmd := fmt.Sprintf("Get-NetNatStaticMapping -NatName antrea-nat") +
+			cmd := "Get-NetNatStaticMapping -NatName antrea-nat" +
 				fmt.Sprintf("|? ExternalIPAddress -EQ %s", defaultnodeIP) +
 				fmt.Sprintf("|? ExternalPort -EQ %d", rule.nodePort) +
 				fmt.Sprintf("|? Protocol -EQ %s", rule.protocol) +
 				"| Format-Table -HideTableHeaders"
-			cmdpwsh := fmt.Sprintf(`powershell.exe -NoLogo -NoProfile -NonInteractive -Command `) +
+			cmdpwsh := `powershell.exe -NoLogo -NoProfile -NonInteractive -Command ` +
 				fmt.Sprintf(`'$ErrorActionPreference="Stop";try {%s} catch {Write-Host $_;os.Exit(1)}'`, cmd)
 			_, stdout, _, err := data.RunCommandOnNode(nodeName, cmdpwsh)
 			if err != nil {

--- a/test/e2e/packetcapture_test.go
+++ b/test/e2e/packetcapture_test.go
@@ -712,18 +712,19 @@ func runPacketCaptureTest(t *testing.T, data *TestData, tc pcTestCase) {
 			connections = tc.numConnections
 		}
 		// Send an ICMP echo packet from the source Pod to the destination.
-		if protocol == icmpProto {
+		switch protocol {
+		case icmpProto:
 			if err := data.RunPingCommandFromTestPod(PodInfo{srcPod, getOSString(), "", data.testNamespace},
 				data.testNamespace, dstPodIPs, toolboxContainerName, 10, 0, false); err != nil {
 				t.Logf("Ping(%s) '%s' -> '%v' failed: ERROR (%v)", protocol.StrVal, srcPod, *dstPodIPs, err)
 			}
-		} else if protocol == tcpProto {
+		case tcpProto:
 			for i := 1; i <= connections; i++ {
 				if err := data.runNetcatCommandFromTestPodWithProtocol(srcPod, data.testNamespace, toolboxContainerName, server, serverPodPort, "tcp"); err != nil {
 					t.Logf("Netcat(TCP) '%s' -> '%v' failed: ERROR (%v)", srcPod, server, err)
 				}
 			}
-		} else if protocol == udpProto {
+		case udpProto:
 			for i := 1; i <= connections; i++ {
 				if err := data.runNetcatCommandFromTestPodWithProtocol(srcPod, data.testNamespace, toolboxContainerName, server, serverPodPort, "udp"); err != nil {
 					t.Logf("Netcat(UDP) '%s' -> '%v' failed: ERROR (%v)", srcPod, server, err)

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -1164,7 +1164,7 @@ func TestProxyLoadBalancerModeDSR(t *testing.T) {
 				assert.NoError(t, err, "Failed to delete route to client IP on Node %s, stdout: %s, stderr: %s", backendNode2, stdout, stderr)
 			}()
 
-			serviceName := fmt.Sprintf("svc-dsr")
+			serviceName := "svc-dsr"
 			annotations := map[string]string{
 				types.ServiceLoadBalancerModeAnnotationKey: "dsr",
 			}

--- a/test/e2e/reachability.go
+++ b/test/e2e/reachability.go
@@ -181,7 +181,7 @@ func (ct *ConnectivityTable) PrettyPrint(indent string) string {
 	for _, from := range ct.Items {
 		line := []string{from}
 		for _, to := range ct.Items {
-			val := fmt.Sprintf("%s", ct.Values[from][to])
+			val := string(ct.Values[from][to])
 			line = append(line, val)
 		}
 		lines = append(lines, indent+strings.Join(line, "\t"))

--- a/test/e2e/traceflow_test.go
+++ b/test/e2e/traceflow_test.go
@@ -2365,7 +2365,7 @@ func testTraceflowValidation(t *testing.T, data *TestData) {
 			if tc.allowed {
 				assert.Nil(t, err)
 			} else {
-				tc.deniedReason = strings.Replace(tc.deniedReason, "{{name}}", tf.Name, -1)
+				tc.deniedReason = strings.ReplaceAll(tc.deniedReason, "{{name}}", tf.Name)
 				expected := "admission webhook \"traceflowvalidator.antrea.io\" denied the request: " + tc.deniedReason
 				assert.EqualError(t, err, expected)
 			}

--- a/test/e2e/trafficcontrol_test.go
+++ b/test/e2e/trafficcontrol_test.go
@@ -137,28 +137,28 @@ func (data *TestData) createTrafficControl(t *testing.T,
 			ReturnPort: &v1alpha2.TrafficControlPort{},
 		},
 	}
-	switch targetPort.(type) {
+	switch targetPort := targetPort.(type) {
 	case *v1alpha2.OVSInternalPort:
-		tc.Spec.TargetPort.OVSInternal = targetPort.(*v1alpha2.OVSInternalPort)
+		tc.Spec.TargetPort.OVSInternal = targetPort
 	case *v1alpha2.NetworkDevice:
-		tc.Spec.TargetPort.Device = targetPort.(*v1alpha2.NetworkDevice)
+		tc.Spec.TargetPort.Device = targetPort
 	case *v1alpha2.UDPTunnel:
 		if isTargetPortVXLAN {
-			tc.Spec.TargetPort.VXLAN = targetPort.(*v1alpha2.UDPTunnel)
+			tc.Spec.TargetPort.VXLAN = targetPort
 		} else {
-			tc.Spec.TargetPort.GENEVE = targetPort.(*v1alpha2.UDPTunnel)
+			tc.Spec.TargetPort.GENEVE = targetPort
 		}
 	case *v1alpha2.GRETunnel:
-		tc.Spec.TargetPort.GRE = targetPort.(*v1alpha2.GRETunnel)
+		tc.Spec.TargetPort.GRE = targetPort
 	case *v1alpha2.ERSPANTunnel:
-		tc.Spec.TargetPort.ERSPAN = targetPort.(*v1alpha2.ERSPANTunnel)
+		tc.Spec.TargetPort.ERSPAN = targetPort
 	}
 
-	switch returnPort.(type) {
+	switch returnPort := returnPort.(type) {
 	case *v1alpha2.OVSInternalPort:
-		tc.Spec.ReturnPort.OVSInternal = returnPort.(*v1alpha2.OVSInternalPort)
+		tc.Spec.ReturnPort.OVSInternal = returnPort
 	case *v1alpha2.NetworkDevice:
-		tc.Spec.ReturnPort.Device = returnPort.(*v1alpha2.NetworkDevice)
+		tc.Spec.ReturnPort.Device = returnPort
 	default:
 		tc.Spec.ReturnPort = nil
 	}

--- a/test/e2e/utils/cnp_spec_builder.go
+++ b/test/e2e/utils/cnp_spec_builder.go
@@ -234,7 +234,7 @@ func (b *ClusterNetworkPolicySpecBuilder) AddIngressForSrcPort(protoc AntreaPoli
 			MatchExpressions: nsSelectorMatchExp,
 		}
 	}
-	if selfNS == true {
+	if selfNS {
 		ns = &crdv1beta1.PeerNamespaces{
 			Match: matchSelf,
 		}

--- a/test/integration/agent/openflow_test.go
+++ b/test/integration/agent/openflow_test.go
@@ -796,10 +796,11 @@ func uninstallServiceFlowsFunc(t *testing.T, svc *types.ServiceConfig, endpointL
 func expectedProxyServiceGroupAndFlows(svc *types.ServiceConfig, endpointList []k8sproxy.Endpoint, antreaPolicyEnabled bool) (tableFlows []expectTableFlows, groupBuckets []string) {
 	nw_proto := 6
 	learnProtoField := "NXM_OF_TCP_DST[]"
-	if svc.Protocol == ofconfig.ProtocolUDP {
+	switch svc.Protocol {
+	case ofconfig.ProtocolUDP:
 		nw_proto = 17
 		learnProtoField = "NXM_OF_UDP_DST[]"
-	} else if svc.Protocol == ofconfig.ProtocolSCTP {
+	case ofconfig.ProtocolSCTP:
 		nw_proto = 132
 		learnProtoField = "OXM_OF_SCTP_DST[]"
 	}

--- a/test/integration/agent/route_test.go
+++ b/test/integration/agent/route_test.go
@@ -294,9 +294,7 @@ func TestIpTablesSync(t *testing.T) {
 		close(inited)
 	})
 	assert.NoError(t, err)
-	select {
-	case <-inited: // Node network initialized
-	}
+	<-inited // Node network initialized
 
 	snatIP := net.ParseIP("1.1.1.1")
 	mark := uint32(1)
@@ -345,9 +343,7 @@ func TestAddAndDeleteSNATRule(t *testing.T) {
 		close(inited)
 	})
 	assert.NoError(t, err)
-	select {
-	case <-inited: // Node network initialized
-	}
+	<-inited // Node network initialized
 
 	snatIP := net.ParseIP("1.1.1.1")
 	mark := uint32(1)

--- a/test/integration/ovs/ofctrl_test.go
+++ b/test/integration/ovs/ofctrl_test.go
@@ -328,7 +328,7 @@ func TestOFctrlGroup(t *testing.T) {
 				for _, loading := range bucket.reg2reg {
 					rngStr := ""
 					data := loading[1]
-					if !(loading[2] == 0 && loading[3] == 31) {
+					if loading[2] != 0 || loading[3] != 31 {
 						length := loading[3] - loading[2] + 1
 						mask := ^uint32(0) >> (32 - length) << loading[2]
 						rngStr = fmt.Sprintf("/0x%x", mask)
@@ -429,8 +429,8 @@ func TestBundleErrorWhenOVSRestart(t *testing.T) {
 	defer bridge.Disconnect()
 
 	// Ensure OVS is connected before sending bundle messages.
-	select {
-	case <-time.Tick(1 * time.Second):
+	for {
+		<-time.Tick(1 * time.Second)
 		if bridge.IsConnected() {
 			break
 		}
@@ -438,11 +438,9 @@ func TestBundleErrorWhenOVSRestart(t *testing.T) {
 
 	// Restart OVS in another goroutine.
 	go func() {
-		select {
-		case <-time.After(100 * time.Millisecond):
-			DeleteOVSBridge(br)
-			PrepareOVSBridge(br)
-		}
+		<-time.After(100 * time.Millisecond)
+		DeleteOVSBridge(br)
+		PrepareOVSBridge(br)
 	}()
 
 	expectedErrorMsgs := map[string]bool{

--- a/test/integration/ovs/ovs_client_test.go
+++ b/test/integration/ovs/ovs_client_test.go
@@ -49,7 +49,7 @@ func (data *testData) setup(t *testing.T) {
 	var err error
 	// ensure that we timeout after a reasonable time duration if we cannot connect to the Unix
 	// socket.
-	connectErrorCh := make(chan error, 0)
+	connectErrorCh := make(chan error)
 	connect := func() {
 		data.ovsdb, err = ovsconfig.NewOVSDBConnectionUDS(UDSAddress)
 		connectErrorCh <- err
@@ -432,7 +432,7 @@ func TestTunnelOptionTunnelPort(t *testing.T) {
 			}
 			if testCase.updatedTunnelPort != 0 {
 				updatedOptions["dst_port"] = strconv.Itoa(int(testCase.updatedTunnelPort))
-			} else if _, ok := updatedOptions["dst_port"]; ok {
+			} else {
 				delete(updatedOptions, "dst_port")
 			}
 			err = data.br.SetInterfaceOptions(name, updatedOptions)


### PR DESCRIPTION
* Bumps golangcilint to v2
* Resolves new lint errors
* Given the large change, I've broken up each lint error fix into it's own commit so reviewing one commit at a time might be helpful as opposed to viewing the full diff