### PR TITLE
[WIP]Promote SecondaryNetwork feature to Beta

### DIFF
--- a/build/charts/antrea/conf/antrea-agent.conf
+++ b/build/charts/antrea/conf/antrea-agent.conf
@@ -51,7 +51,7 @@ featureGates:
 # Enable AntreaIPAM, which can allocate IP addresses from IPPools. AntreaIPAM is required by the
 # bridging mode and allocates IPs to Pods in bridging mode. It is also required to use Antrea for
 # IPAM when configuring secondary network interfaces with Multus.
-{{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "AntreaIPAM" "default" false) }}
+{{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "AntreaIPAM" "default" true) }}
 
 # Enable multicast traffic.
 {{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "Multicast" "default" true) }}
@@ -63,7 +63,7 @@ featureGates:
 # Pod annotations). At the moment, Antrea can create secondary network
 # interfaces either using SR-IOV VFs on bare-metal Nodes or veth interfaces
 # bridged to the underlay network, with or without VLAN tagging.
-{{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "SecondaryNetwork" "default" false) }}
+{{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "SecondaryNetwork" "default" true) }}
 
 # Enable managing external IPs of Services of LoadBalancer type.
 {{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "ServiceExternalIP" "default" true) }}

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -4047,7 +4047,7 @@ data:
     # Pod annotations). At the moment, Antrea can create secondary network
     # interfaces either using SR-IOV VFs on bare-metal Nodes or veth interfaces
     # bridged to the underlay network, with or without VLAN tagging.
-    #  SecondaryNetwork: false
+    #  SecondaryNetwork: true
 
     # Enable managing external IPs of Services of LoadBalancer type.
     #  ServiceExternalIP: true

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -4047,7 +4047,7 @@ data:
     # Pod annotations). At the moment, Antrea can create secondary network
     # interfaces either using SR-IOV VFs on bare-metal Nodes or veth interfaces
     # bridged to the underlay network, with or without VLAN tagging.
-    #  SecondaryNetwork: false
+    #  SecondaryNetwork: true
 
     # Enable managing external IPs of Services of LoadBalancer type.
     #  ServiceExternalIP: true

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -4060,7 +4060,7 @@ data:
     # Pod annotations). At the moment, Antrea can create secondary network
     # interfaces either using SR-IOV VFs on bare-metal Nodes or veth interfaces
     # bridged to the underlay network, with or without VLAN tagging.
-    #  SecondaryNetwork: false
+    #  SecondaryNetwork: true
 
     # Enable managing external IPs of Services of LoadBalancer type.
     #  ServiceExternalIP: true

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -4035,7 +4035,7 @@ data:
     # Enable AntreaIPAM, which can allocate IP addresses from IPPools. AntreaIPAM is required by the
     # bridging mode and allocates IPs to Pods in bridging mode. It is also required to use Antrea for
     # IPAM when configuring secondary network interfaces with Multus.
-    #  AntreaIPAM: false
+    #  AntreaIPAM: true
 
     # Enable multicast traffic.
     #  Multicast: true
@@ -4047,7 +4047,7 @@ data:
     # Pod annotations). At the moment, Antrea can create secondary network
     # interfaces either using SR-IOV VFs on bare-metal Nodes or veth interfaces
     # bridged to the underlay network, with or without VLAN tagging.
-    #  SecondaryNetwork: false
+    #  SecondaryNetwork: true
 
     # Enable managing external IPs of Services of LoadBalancer type.
     #  ServiceExternalIP: true

--- a/ci/kind/test-secondary-network-kind.sh
+++ b/ci/kind/test-secondary-network-kind.sh
@@ -107,7 +107,7 @@ function run_test {
   # Create a secondary OVS bridge with the Node's physical interface on the extra
   # network.
   helm install antrea $ANTREA_CHART --namespace kube-system \
-     --set featureGates.SecondaryNetwork=true,featureGates.AntreaIPAM=true \
+#     --set featureGates.SecondaryNetwork=true,featureGates.AntreaIPAM=true \
      --set-json secondaryNetwork.ovsBridges='[{"bridgeName": "br-secondary", "physicalInterfaces": ["eth1"]}]'
 
   # Wait for antrea-controller start to make sure the IPPool validation webhook is ready.

--- a/ci/test-sriov-secondary-network-aws.sh
+++ b/ci/test-sriov-secondary-network-aws.sh
@@ -375,7 +375,7 @@ EOF
 
 function deploy_antrea() {
     echo "Deploy antrea on cluster..."
-    helm install antrea "$ANTREA_CHART" --namespace kube-system --set featureGates.SecondaryNetwork=true,featureGates.AntreaIPAM=true
+#    helm install antrea "$ANTREA_CHART" --namespace kube-system --set featureGates.SecondaryNetwork=true,featureGates.AntreaIPAM=true
     kubectl rollout status --timeout=2m deployment.apps/antrea-controller -n kube-system
     kubectl rollout status --timeout=2m daemonset/antrea-agent -n kube-system
     kubectl get node -owide

--- a/docs/feature-gates.md
+++ b/docs/feature-gates.md
@@ -31,7 +31,7 @@ edit the Agent configuration in the
 ## List of Available Features
 
 | Feature Name                  | Component          | Default | Stage | Alpha Release | Beta Release | GA Release | Extra Requirements | Notes                                         |
-| ----------------------------- | ------------------ | ------- | ----- | ------------- | ------------ | ---------- | ------------------ | --------------------------------------------- |
+| ----------------------------- | ------------------ |---------|-------| ------------- |--------------| ---------- | ------------------ | --------------------------------------------- |
 | `AntreaProxy`                 | Agent              | `true`  | GA    | v0.8          | v0.11        | v1.14      | Yes                | Must be enabled for Windows.                  |
 | `EndpointSlice`               | Agent              | `true`  | GA    | v0.13.0       | v1.11        | v1.14      | Yes                |                                               |
 | `TopologyAwareHints`          | Agent              | `true`  | Beta  | v1.8          | v1.12        | N/A        | Yes                |                                               |
@@ -45,9 +45,9 @@ edit the Agent configuration in the
 | `NodePortLocal`               | Agent              | `true`  | GA    | v0.13         | v1.4         | v1.14      | Yes                | Important user-facing change in v1.2.0        |
 | `Egress`                      | Agent + Controller | `true`  | Beta  | v1.0          | v1.6         | N/A        | Yes                |                                               |
 | `NodeIPAM`                    | Controller         | `true`  | Beta  | v1.4          | v1.12        | N/A        | Yes                |                                               |
-| `AntreaIPAM`                  | Agent + Controller | `false` | Alpha | v1.4          | N/A          | N/A        | Yes                |                                               |
+| `AntreaIPAM`                  | Agent + Controller | `true`  | Beta  | v1.4          | v2.4         | N/A        | Yes                |                                               |
 | `Multicast`                   | Agent + Controller | `true`  | Beta  | v1.5          | v1.12        | N/A        | Yes                |                                               |
-| `SecondaryNetwork`            | Agent              | `false` | Alpha | v1.5          | N/A          | N/A        | Yes                |                                               |
+| `SecondaryNetwork`            | Agent              | `true`  | Beta  | v1.5          | v2.4         | N/A        | Yes                |                                               |
 | `ServiceExternalIP`           | Agent + Controller | `false` | Beta  | v1.5          | v2.3         | N/A        | Yes                |                                               |
 | `TrafficControl`              | Agent              | `false` | Alpha | v1.7          | N/A          | N/A        | No                 |                                               |
 | `Multicluster`                | Agent + Controller | `false` | Alpha | v1.7          | N/A          | N/A        | Yes                | Controller side feature gate added in v1.10.0 |

--- a/docs/secondary-network.md
+++ b/docs/secondary-network.md
@@ -35,37 +35,16 @@ feature across different releases.
 |---------------|-----------------------------|---------|---------------------------|
 | v1.5 - v1.14  | `Alpha`                     |         |                           |
 | v1.15 - v2.2  | `Alpha`                     | `Alpha` |                           |
-| v2.3 - latest | `Alpha`                     | `Alpha` | `Alpha`                   |
+| v2.3          | `Alpha`                     | `Alpha` | `Alpha`                   |
+| v2.4 - latest | `Beta`                      | `Beta`  | `Beta`                    |
 
 This document describes steps to enable and use Antrea's native support for
 secondary networks.
 
 ## Prerequisites
 
-Native secondary network support is still an alpha feature and is disabled by
-default. To use the feature, the `SecondaryNetwork` feature gate must be enabled
-in the `antrea-agent` configuration. If you need IPAM for the secondary
-interfaces, you should also enable the `AntreaIPAM` feature gate in both
-`antrea-agent` and `antrea-controller` configuration. At the moment, Antrea IPAM
-is the only available IPAM option for secondary networks managed by Antrea. The
-`antrea-config` ConfigMap with the two feature gates enables is like the
-following:
-
-```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: antrea-config
-  namespace: kube-system
-data:
-  antrea-controller.conf: |
-    featureGates:
-      AntreaIPAM: true
-  antrea-agent.conf: |
-    featureGates:
-      AntreaIPAM: true
-      SecondaryNetwork: true
-```
+Native secondary network support has been promoted to Beta and is now enabled by default. 
+AntreaIPAM, the integrated IP address management solution for secondary networks, is also in Beta stage and enabled by default. 
 
 Antrea leverages the `NetworkAttachmentDefinition` CRD from [Kubernetes Network
 Plumbing Working Group](https://github.com/k8snetworkplumbingwg/multi-net-spec)

--- a/hack/generate-manifest.sh
+++ b/hack/generate-manifest.sh
@@ -349,7 +349,7 @@ if [[ $SECONDARY_BRIDGE != "" ]]; then
 secondaryNetwork:
   ovsBridges: $ovs_bridges
 EOF
-    HELM_VALUES+=("featureGates.SecondaryNetwork=true" "featureGates.AntreaIPAM=true")
+#    HELM_VALUES+=("featureGates.SecondaryNetwork=true" "featureGates.AntreaIPAM=true")
     HELM_VALUES_FILES+=("$TMP_DIR/secondary-network.yml")
 fi
 

--- a/pkg/antctl/raw/featuregates/command_test.go
+++ b/pkg/antctl/raw/featuregates/command_test.go
@@ -76,8 +76,8 @@ func TestGetFeatureGates(t *testing.T) {
 		{
 			"component": "agent",
 			"name": "AntreaIPAM",
-			"status": "Disabled",
-			"version": "ALPHA"
+			"status": "Enabled",
+			"version": "BETA"
 		},
 		{
 			"component": "agent",
@@ -166,8 +166,8 @@ func TestGetFeatureGates(t *testing.T) {
 		{
 			"component": "agent",
 			"name": "SecondaryNetwork",
-			"status": "Disabled",
-			"version": "ALPHA"
+			"status": "Enabled",
+			"version": "BETA"
 		},
 		{
 			"component": "agent",
@@ -283,8 +283,8 @@ func TestGetFeatureGates(t *testing.T) {
 		{
 			"component": "agent",
 			"name": "AntreaIPAM",
-			"status": "Disabled",
-			"version": "ALPHA"
+			"status": "Enabled",
+			"version": "BETA"
 		},
 		{
 			"component": "agent",
@@ -373,8 +373,8 @@ func TestGetFeatureGates(t *testing.T) {
 		{
 			"component": "agent",
 			"name": "SecondaryNetwork",
-			"status": "Disabled",
-			"version": "ALPHA"
+			"status": "Enabled",
+			"version": "BETA"
 		},
 		{
 			"component": "agent",
@@ -412,8 +412,8 @@ func TestGetFeatureGates(t *testing.T) {
 		{
 			"component": "agent",
 			"name": "AntreaIPAM",
-			"status": "Disabled",
-			"version": "ALPHA"
+			"status": "Enabled",
+			"version": "BETA"
 		},
 		{
 			"component": "agent",
@@ -502,8 +502,8 @@ func TestGetFeatureGates(t *testing.T) {
 		{
 			"component": "agent",
 			"name": "SecondaryNetwork",
-			"status": "Disabled",
-			"version": "ALPHA"
+			"status": "Enabled",
+			"version": "BETA"
 		},
 		{
 			"component": "agent",
@@ -695,7 +695,7 @@ func TestGetFeatureGates(t *testing.T) {
 			runE: controllerRemoteRunE,
 			expectedOutput: `Antrea Agent Feature Gates
 FEATUREGATE                     STATUS       VERSION
-AntreaIPAM                      Disabled     ALPHA
+AntreaIPAM                      Enabled      BETA
 AntreaPolicy                    Enabled      BETA
 AntreaProxy                     Enabled      BETA
 CleanupStaleUDPSvcConntrack     Disabled     ALPHA
@@ -710,7 +710,7 @@ Multicast                       Enabled      BETA
 Multicluster                    Disabled     ALPHA
 NetworkPolicyStats              Enabled      BETA
 NodePortLocal                   Enabled      BETA
-SecondaryNetwork                Disabled     ALPHA
+SecondaryNetwork                Enabled      BETA
 ServiceExternalIP               Disabled     ALPHA
 SupportBundleCollection         Disabled     ALPHA
 TopologyAwareHints              Enabled      BETA
@@ -740,7 +740,7 @@ Traceflow                   Enabled      BETA
 			runE: agentRunE,
 			expectedOutput: `Antrea Agent Feature Gates
 FEATUREGATE                     STATUS       VERSION
-AntreaIPAM                      Disabled     ALPHA
+AntreaIPAM                      Enabled      BETA
 AntreaPolicy                    Enabled      BETA
 AntreaProxy                     Enabled      BETA
 CleanupStaleUDPSvcConntrack     Disabled     ALPHA
@@ -755,7 +755,7 @@ Multicast                       Enabled      BETA
 Multicluster                    Disabled     ALPHA
 NetworkPolicyStats              Enabled      BETA
 NodePortLocal                   Enabled      BETA
-SecondaryNetwork                Disabled     ALPHA
+SecondaryNetwork                Enabled      BETA
 ServiceExternalIP               Disabled     ALPHA
 SupportBundleCollection         Disabled     ALPHA
 TopologyAwareHints              Enabled      BETA
@@ -769,7 +769,7 @@ TrafficControl                  Disabled     ALPHA
 			runE: controllerLocalRunE,
 			expectedOutput: `Antrea Agent Feature Gates
 FEATUREGATE                     STATUS       VERSION
-AntreaIPAM                      Disabled     ALPHA
+AntreaIPAM                      Enabled      BETA
 AntreaPolicy                    Enabled      BETA
 AntreaProxy                     Enabled      BETA
 CleanupStaleUDPSvcConntrack     Disabled     ALPHA
@@ -784,7 +784,7 @@ Multicast                       Enabled      BETA
 Multicluster                    Disabled     ALPHA
 NetworkPolicyStats              Enabled      BETA
 NodePortLocal                   Enabled      BETA
-SecondaryNetwork                Disabled     ALPHA
+SecondaryNetwork                Enabled      BETA
 ServiceExternalIP               Disabled     ALPHA
 SupportBundleCollection         Disabled     ALPHA
 TopologyAwareHints              Enabled      BETA
@@ -814,7 +814,7 @@ Traceflow                   Enabled      BETA
 			runE: controllerLocalRunE,
 			expectedOutput: `Antrea Agent Feature Gates
 FEATUREGATE                     STATUS       VERSION
-AntreaIPAM                      Disabled     ALPHA
+AntreaIPAM                      Enabled      BETA
 AntreaPolicy                    Enabled      BETA
 AntreaProxy                     Enabled      BETA
 CleanupStaleUDPSvcConntrack     Disabled     ALPHA
@@ -829,7 +829,7 @@ Multicast                       Enabled      BETA
 Multicluster                    Disabled     ALPHA
 NetworkPolicyStats              Enabled      BETA
 NodePortLocal                   Enabled      BETA
-SecondaryNetwork                Disabled     ALPHA
+SecondaryNetwork                Enabled      BETA
 ServiceExternalIP               Disabled     ALPHA
 SupportBundleCollection         Disabled     ALPHA
 TopologyAwareHints              Enabled      BETA
@@ -853,7 +853,7 @@ TrafficControl              Disabled     ALPHA
 Antrea Controller Feature Gates
 FEATUREGATE                 STATUS       VERSION
 AdminNetworkPolicy          Disabled     ALPHA
-AntreaIPAM                  Disabled     ALPHA
+AntreaIPAM                  Enabled      BETA
 AntreaPolicy                Enabled      BETA
 Egress                      Enabled      BETA
 IPsecCertAuth               Disabled     ALPHA

--- a/pkg/apiserver/handlers/featuregates/handler_test.go
+++ b/pkg/apiserver/handlers/featuregates/handler_test.go
@@ -76,7 +76,7 @@ func Test_getGatesResponse(t *testing.T) {
 				{Component: "agent", Name: "NodeNetworkPolicy", Status: "Disabled", Version: "ALPHA"},
 				{Component: "agent", Name: "NodePortLocal", Status: "Enabled", Version: "GA"},
 				{Component: "agent", Name: "PacketCapture", Status: "Disabled", Version: "ALPHA"},
-				{Component: "agent", Name: "SecondaryNetwork", Status: "Disabled", Version: "ALPHA"},
+				{Component: "agent", Name: "SecondaryNetwork", Status: "Enabled", Version: "BETA"},
 				{Component: "agent", Name: "ServiceExternalIP", Status: serviceExternalIPStatus, Version: "BETA"},
 				{Component: "agent", Name: "ServiceTrafficDistribution", Status: "Enabled", Version: "BETA"},
 				{Component: "agent", Name: "SupportBundleCollection", Status: "Disabled", Version: "ALPHA"},

--- a/pkg/features/antrea_features.go
+++ b/pkg/features/antrea_features.go
@@ -116,6 +116,7 @@ const (
 	Multicluster featuregate.Feature = "Multicluster"
 
 	// alpha: v1.5
+	// beta: v2.4
 	// Enable Secondary interface feature for Antrea.
 	SecondaryNetwork featuregate.Feature = "SecondaryNetwork"
 
@@ -203,14 +204,14 @@ var (
 		CleanupStaleUDPSvcConntrack: {Default: true, PreRelease: featuregate.Beta},
 		Traceflow:                   {Default: true, PreRelease: featuregate.Beta},
 		PacketCapture:               {Default: false, PreRelease: featuregate.Alpha},
-		AntreaIPAM:                  {Default: false, PreRelease: featuregate.Alpha},
+		AntreaIPAM:                  {Default: true, PreRelease: featuregate.Beta},
 		FlowExporter:                {Default: false, PreRelease: featuregate.Alpha},
 		NetworkPolicyStats:          {Default: true, PreRelease: featuregate.Beta},
 		NodePortLocal:               {Default: true, PreRelease: featuregate.GA},
 		NodeIPAM:                    {Default: true, PreRelease: featuregate.Beta},
 		Multicast:                   {Default: true, PreRelease: featuregate.Beta},
 		Multicluster:                {Default: false, PreRelease: featuregate.Alpha},
-		SecondaryNetwork:            {Default: false, PreRelease: featuregate.Alpha},
+		SecondaryNetwork:            {Default: true, PreRelease: featuregate.Beta},
 		ServiceExternalIP:           {Default: true, PreRelease: featuregate.Beta},
 		TrafficControl:              {Default: false, PreRelease: featuregate.Alpha},
 		IPsecCertAuth:               {Default: false, PreRelease: featuregate.Alpha},


### PR DESCRIPTION
Secondary network support has been promoted to Beta and is now enabled by default.
AntreaIPAM, the integrated IP address management solution for secondary networks, is also in Beta stage and enabled by default.