### PR TITLE
Replace usage of math/rand with math/rand/v2

### DIFF
--- a/multicluster/test/e2e/service_test.go
+++ b/multicluster/test/e2e/service_test.go
@@ -17,7 +17,7 @@ package e2e
 import (
 	"encoding/json"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"strconv"
 	"strings"
 	"testing"
@@ -509,7 +509,7 @@ func (data *MCTestData) getNodeNamesFromCluster(clusterName string) (string, str
 		return "", "", fmt.Errorf("error when getting Node list: %v, stderr: %s", err, stderr)
 	}
 	nodes := strings.Split(strings.TrimRight(output, " "), " ")
-	gwIdx := rand.Intn(len(nodes)) // #nosec G404: for test only
+	gwIdx := rand.IntN(len(nodes)) // #nosec G404: for test only
 	var regularNode string
 	for i, node := range nodes {
 		if i != gwIdx {

--- a/pkg/agent/monitortool/monitor.go
+++ b/pkg/agent/monitortool/monitor.go
@@ -16,7 +16,7 @@ package monitortool
 
 import (
 	"context"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -40,7 +40,7 @@ import (
 )
 
 // #nosec G404: random number generator not used for security purposes.
-var icmpEchoID = rand.Int31n(1 << 16)
+var icmpEchoID = rand.Int32N(1 << 16)
 
 const (
 	ipv4ProtocolICMPRaw = "ip4:icmp"

--- a/pkg/agent/multicast/mcast_controller_test.go
+++ b/pkg/agent/multicast/mcast_controller_test.go
@@ -17,7 +17,7 @@ package multicast
 import (
 	"context"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"os"
 	"sync"

--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -16,7 +16,7 @@ package openflow
 
 import (
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 
 	"antrea.io/libOpenflow/openflow15"

--- a/pkg/agent/openflow/cookie/allocator_test.go
+++ b/pkg/agent/openflow/cookie/allocator_test.go
@@ -15,7 +15,7 @@
 package cookie
 
 import (
-	"math/rand"
+	"math/rand/v2"
 	"sync"
 	"testing"
 

--- a/pkg/flowaggregator/s3uploader/s3uploader.go
+++ b/pkg/flowaggregator/s3uploader/s3uploader.go
@@ -81,7 +81,6 @@ type S3UploadProcess struct {
 	awsS3Uploader *s3manager.Uploader
 	// s3UploaderAPI wraps the call made by awsS3Uploader
 	s3UploaderAPI S3UploaderAPI
-	nameRand      *rand.Rand
 	clusterUUID   string
 }
 
@@ -135,8 +134,6 @@ func NewS3UploadProcess(input S3Input, clusterUUID string) (*S3UploadProcess, er
 	awsS3Uploader := s3manager.NewUploader(awsS3Client)
 
 	buf := &bytes.Buffer{}
-	// #nosec G404: random number generator not used for security purposes
-	nameRand := rand.New(rand.NewPCG(rand.Uint64(), rand.Uint64()))
 
 	s3ExportProcess := &S3UploadProcess{
 		bucketName:       config.BucketName,
@@ -152,7 +149,6 @@ func NewS3UploadProcess(input S3Input, clusterUUID string) (*S3UploadProcess, er
 		awsS3Client:      awsS3Client,
 		awsS3Uploader:    awsS3Uploader,
 		s3UploaderAPI:    &S3Uploader{},
-		nameRand:         nameRand,
 		clusterUUID:      clusterUUID,
 	}
 	return s3ExportProcess, nil
@@ -337,7 +333,7 @@ func (p *S3UploadProcess) writeRecordToBuffer(record *flowrecord.FlowRecord) {
 }
 
 func (p *S3UploadProcess) uploadFile(ctx context.Context, reader *bytes.Reader) error {
-	fileName := fmt.Sprintf("records-%s.csv", randSeq(p.nameRand, 12))
+	fileName := fmt.Sprintf("records-%s.csv", randSeq(12))
 	if p.compress {
 		fileName += ".gz"
 	}
@@ -370,12 +366,11 @@ func (p *S3UploadProcess) appendBufferToQueue() {
 	}
 }
 
-func randSeq(randSrc *rand.Rand, n int) string {
+func randSeq(n int) string {
 	var alphabet = []rune("abcdefghijklmnopqrstuvwxyz0123456789")
 	b := make([]rune, n)
 	for i := range b {
-		randIdx := randSrc.IntN(len(alphabet))
-		b[i] = alphabet[randIdx]
+		b[i] = alphabet[rand.IntN(len(alphabet))]
 	}
 	return string(b)
 }

--- a/pkg/flowaggregator/s3uploader/s3uploader.go
+++ b/pkg/flowaggregator/s3uploader/s3uploader.go
@@ -370,6 +370,7 @@ func randSeq(n int) string {
 	var alphabet = []rune("abcdefghijklmnopqrstuvwxyz0123456789")
 	b := make([]rune, n)
 	for i := range b {
+		// #nosec G404: random number generator not used for security purposes.
 		b[i] = alphabet[rand.IntN(len(alphabet))]
 	}
 	return string(b)

--- a/pkg/flowaggregator/s3uploader/s3uploader.go
+++ b/pkg/flowaggregator/s3uploader/s3uploader.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"math/rand"
+	"math/rand/v2"
 	"sync"
 	"time"
 
@@ -136,7 +136,7 @@ func NewS3UploadProcess(input S3Input, clusterUUID string) (*S3UploadProcess, er
 
 	buf := &bytes.Buffer{}
 	// #nosec G404: random number generator not used for security purposes
-	nameRand := rand.New(rand.NewSource(time.Now().UnixNano()))
+	nameRand := rand.New(rand.NewPCG(rand.Uint64(), rand.Uint64()))
 
 	s3ExportProcess := &S3UploadProcess{
 		bucketName:       config.BucketName,
@@ -374,7 +374,7 @@ func randSeq(randSrc *rand.Rand, n int) string {
 	var alphabet = []rune("abcdefghijklmnopqrstuvwxyz0123456789")
 	b := make([]rune, n)
 	for i := range b {
-		randIdx := randSrc.Intn(len(alphabet))
+		randIdx := randSrc.IntN(len(alphabet))
 		b[i] = alphabet[randIdx]
 	}
 	return string(b)

--- a/pkg/flowaggregator/s3uploader/s3uploader_test.go
+++ b/pkg/flowaggregator/s3uploader/s3uploader_test.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"strings"
 	"testing"
 	"time"
@@ -104,7 +104,7 @@ func TestBatchUploadAll(t *testing.T) {
 	ctx := context.Background()
 	mockS3Uploader.EXPECT().Upload(ctx, gomock.Any(), nil).Return(nil, nil)
 	// #nosec G404: random number generator not used for security purposes
-	nameRand := rand.New(rand.NewSource(seed))
+	nameRand := rand.New(rand.NewPCG(seed, 0))
 	s3UploadProc := S3UploadProcess{
 		compress:         false,
 		maxRecordPerFile: 10,
@@ -137,7 +137,7 @@ func TestBatchUploadAllPartialSuccess(t *testing.T) {
 		mockS3Uploader.EXPECT().Upload(ctx, gomock.Any(), nil).Return(nil, fmt.Errorf("random error")),
 	)
 	// #nosec G404: random number generator not used for security purposes
-	nameRand := rand.New(rand.NewSource(seed))
+	nameRand := rand.New(rand.NewPCG(seed, 0))
 	s3UploadProc := S3UploadProcess{
 		compress:         false,
 		maxRecordPerFile: 1,
@@ -166,7 +166,7 @@ func TestBatchUploadAllError(t *testing.T) {
 	ctx := context.Background()
 	s3uploader := &S3Uploader{}
 	// #nosec G404: random number generator not used for security purposes
-	nameRand := rand.New(rand.NewSource(seed))
+	nameRand := rand.New(rand.NewPCG(seed, 0))
 	s3UploadProc := S3UploadProcess{
 		bucketName:       "test-bucket-name",
 		compress:         false,
@@ -209,7 +209,7 @@ func TestFlowRecordPeriodicCommit(t *testing.T) {
 		},
 	)
 	// #nosec G404: random number generator not used for security purposes
-	nameRand := rand.New(rand.NewSource(seed))
+	nameRand := rand.New(rand.NewPCG(seed, 0))
 	s3UploadProc := S3UploadProcess{
 		compress:         false,
 		maxRecordPerFile: 10,
@@ -249,7 +249,7 @@ func TestFlushCacheOnStop(t *testing.T) {
 	mockS3Uploader := s3uploadertesting.NewMockS3UploaderAPI(ctrl)
 	mockS3Uploader.EXPECT().Upload(gomock.Any(), gomock.Any(), nil).Return(nil, nil)
 	// #nosec G404: random number generator not used for security purposes
-	nameRand := rand.New(rand.NewSource(seed))
+	nameRand := rand.New(rand.NewPCG(seed, 0))
 	s3UploadProc := S3UploadProcess{
 		compress:         false,
 		maxRecordPerFile: 10,

--- a/pkg/flowaggregator/s3uploader/s3uploader_test.go
+++ b/pkg/flowaggregator/s3uploader/s3uploader_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"math/rand/v2"
 	"strings"
 	"testing"
 	"time"
@@ -41,8 +40,6 @@ var (
 	recordStrIPv4   = "1637706961,1637706973,1637706974,1637706975,3,10.10.0.79,10.10.0.80,44752,5201,6,823188,30472817041,241333,8982624938,471111,24500996,136211,7083284,perftest-a,antrea-test,k8s-node-control-plane,perftest-b,antrea-test-b,k8s-node-control-plane-b,10.10.1.10,5202,perftest,test-flow-aggregator-networkpolicy-ingress-allow,antrea-test-ns,test-flow-aggregator-networkpolicy-rule,2,1,test-flow-aggregator-networkpolicy-egress-allow,antrea-test-ns-e,test-flow-aggregator-networkpolicy-rule-e,5,4,TIME_WAIT,11,'{\"antrea-e2e\":\"perftest-a\",\"app\":\"iperf\"}','{\"antrea-e2e\":\"perftest-b\",\"app\":\"iperf\"}',15902813472,12381344,15902813473,15902813474,12381345,12381346," + fakeClusterUUID + "," + fmt.Sprintf("%d", time.Now().Unix()) + ",test-egress,172.18.0.1,http,mockHttpString,test-egress-node"
 	recordStrIPv6   = "1637706961,1637706973,1637706974,1637706975,3,2001:0:3238:dfe1:63::fefb,2001:0:3238:dfe1:63::fefc,44752,5201,6,823188,30472817041,241333,8982624938,471111,24500996,136211,7083284,perftest-a,antrea-test,k8s-node-control-plane,perftest-b,antrea-test-b,k8s-node-control-plane-b,2001:0:3238:dfe1:64::a,5202,perftest,test-flow-aggregator-networkpolicy-ingress-allow,antrea-test-ns,test-flow-aggregator-networkpolicy-rule,2,1,test-flow-aggregator-networkpolicy-egress-allow,antrea-test-ns-e,test-flow-aggregator-networkpolicy-rule-e,5,4,TIME_WAIT,11,'{\"antrea-e2e\":\"perftest-a\",\"app\":\"iperf\"}','{\"antrea-e2e\":\"perftest-b\",\"app\":\"iperf\"}',15902813472,12381344,15902813473,15902813474,12381345,12381346," + fakeClusterUUID + "," + fmt.Sprintf("%d", time.Now().Unix()) + ",test-egress,172.18.0.1,http,mockHttpString,test-egress-node"
 )
-
-const seed = 1
 
 func init() {
 	registry.LoadRegistry()
@@ -103,8 +100,6 @@ func TestBatchUploadAll(t *testing.T) {
 	mockS3Uploader := s3uploadertesting.NewMockS3UploaderAPI(ctrl)
 	ctx := context.Background()
 	mockS3Uploader.EXPECT().Upload(ctx, gomock.Any(), nil).Return(nil, nil)
-	// #nosec G404: random number generator not used for security purposes
-	nameRand := rand.New(rand.NewPCG(seed, 0))
 	s3UploadProc := S3UploadProcess{
 		compress:         false,
 		maxRecordPerFile: 10,
@@ -112,7 +107,6 @@ func TestBatchUploadAll(t *testing.T) {
 		bufferQueue:      make([]*bytes.Buffer, 0),
 		buffersToUpload:  make([]*bytes.Buffer, 0, maxNumBuffersPendingUpload),
 		s3UploaderAPI:    mockS3Uploader,
-		nameRand:         nameRand,
 		clusterUUID:      fakeClusterUUID,
 	}
 	mockRecord := ipfixentitiestesting.NewMockRecord(ctrl)
@@ -136,8 +130,6 @@ func TestBatchUploadAllPartialSuccess(t *testing.T) {
 		mockS3Uploader.EXPECT().Upload(ctx, gomock.Any(), nil).Return(nil, nil),
 		mockS3Uploader.EXPECT().Upload(ctx, gomock.Any(), nil).Return(nil, fmt.Errorf("random error")),
 	)
-	// #nosec G404: random number generator not used for security purposes
-	nameRand := rand.New(rand.NewPCG(seed, 0))
 	s3UploadProc := S3UploadProcess{
 		compress:         false,
 		maxRecordPerFile: 1,
@@ -145,7 +137,6 @@ func TestBatchUploadAllPartialSuccess(t *testing.T) {
 		bufferQueue:      make([]*bytes.Buffer, 0),
 		buffersToUpload:  make([]*bytes.Buffer, 0, maxNumBuffersPendingUpload),
 		s3UploaderAPI:    mockS3Uploader,
-		nameRand:         nameRand,
 		clusterUUID:      fakeClusterUUID,
 	}
 	mockRecord := ipfixentitiestesting.NewMockRecord(ctrl)
@@ -165,8 +156,6 @@ func TestBatchUploadAllError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	ctx := context.Background()
 	s3uploader := &S3Uploader{}
-	// #nosec G404: random number generator not used for security purposes
-	nameRand := rand.New(rand.NewPCG(seed, 0))
 	s3UploadProc := S3UploadProcess{
 		bucketName:       "test-bucket-name",
 		compress:         false,
@@ -175,7 +164,6 @@ func TestBatchUploadAllError(t *testing.T) {
 		bufferQueue:      make([]*bytes.Buffer, 0),
 		buffersToUpload:  make([]*bytes.Buffer, 0, maxNumBuffersPendingUpload),
 		s3UploaderAPI:    s3uploader,
-		nameRand:         nameRand,
 	}
 	cfg, _ := config.LoadDefaultConfig(ctx, config.WithRegion("us-west-2"))
 	s3UploadProc.awsS3Client = s3.NewFromConfig(cfg)
@@ -202,14 +190,11 @@ func TestFlowRecordPeriodicCommit(t *testing.T) {
 	mockS3Uploader := s3uploadertesting.NewMockS3UploaderAPI(ctrl)
 	waitCh := make(chan struct{})
 	mockS3Uploader.EXPECT().Upload(context.Background(), gomock.Any(), nil).DoAndReturn(
-		// arguments have to exactly match func (mr *MockS3UploaderAPIMockRecorder) Upload(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call
 		func(arg0, arg1, arg2 interface{}, arg3 ...interface{}) (*s3manager.UploadOutput, error) {
 			close(waitCh)
 			return nil, nil
 		},
 	)
-	// #nosec G404: random number generator not used for security purposes
-	nameRand := rand.New(rand.NewPCG(seed, 0))
 	s3UploadProc := S3UploadProcess{
 		compress:         false,
 		maxRecordPerFile: 10,
@@ -218,7 +203,6 @@ func TestFlowRecordPeriodicCommit(t *testing.T) {
 		bufferQueue:      make([]*bytes.Buffer, 0),
 		buffersToUpload:  make([]*bytes.Buffer, 0, maxNumBuffersPendingUpload),
 		s3UploaderAPI:    mockS3Uploader,
-		nameRand:         nameRand,
 		clusterUUID:      fakeClusterUUID,
 	}
 	mockRecord := ipfixentitiestesting.NewMockRecord(ctrl)
@@ -248,8 +232,6 @@ func TestFlushCacheOnStop(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockS3Uploader := s3uploadertesting.NewMockS3UploaderAPI(ctrl)
 	mockS3Uploader.EXPECT().Upload(gomock.Any(), gomock.Any(), nil).Return(nil, nil)
-	// #nosec G404: random number generator not used for security purposes
-	nameRand := rand.New(rand.NewPCG(seed, 0))
 	s3UploadProc := S3UploadProcess{
 		compress:         false,
 		maxRecordPerFile: 10,
@@ -258,7 +240,6 @@ func TestFlushCacheOnStop(t *testing.T) {
 		bufferQueue:      make([]*bytes.Buffer, 0),
 		buffersToUpload:  make([]*bytes.Buffer, 0, maxNumBuffersPendingUpload),
 		s3UploaderAPI:    mockS3Uploader,
-		nameRand:         nameRand,
 		clusterUUID:      fakeClusterUUID,
 	}
 	mockRecord := ipfixentitiestesting.NewMockRecord(ctrl)

--- a/pkg/ovs/openflow/ofctrl_packetout.go
+++ b/pkg/ovs/openflow/ofctrl_packetout.go
@@ -16,9 +16,8 @@ package openflow
 
 import (
 	"encoding/binary"
-	"math/rand"
+	"math/rand/v2"
 	"net"
-	"time"
 
 	"antrea.io/libOpenflow/openflow15"
 	"antrea.io/libOpenflow/protocol"
@@ -28,7 +27,7 @@ import (
 )
 
 // #nosec G404: random number generator not used for security purposes
-var pktRand = rand.New(rand.NewSource(time.Now().UnixNano()))
+var pktRand = rand.New(rand.NewPCG(rand.Uint64(), rand.Uint64()))
 
 type ofPacketOutBuilder struct {
 	pktOut  *ofctrl.PacketOut

--- a/pkg/ovs/openflow/ofctrl_packetout_test.go
+++ b/pkg/ovs/openflow/ofctrl_packetout_test.go
@@ -1031,8 +1031,8 @@ func Test_ofPacketOutBuilder_Done(t *testing.T) {
 				IPHeader: &protocol.IPv4{
 					Version:  0x4,
 					Length:   28,
-					Checksum: 46753,
-					Id:       1090,
+					Checksum: 6586,
+					Id:       41257,
 				},
 				ICMPHeader: &protocol.ICMP{
 					Type:     3,
@@ -1057,10 +1057,10 @@ func Test_ofPacketOutBuilder_Done(t *testing.T) {
 			want: &ofctrl.PacketOut{
 				IPHeader: &protocol.IPv4{
 					Version:  uint8(4),
-					Id:       uint16(1090),
+					Id:       uint16(41257),
 					Protocol: protocol.Type_IGMP,
 					Length:   uint16(28),
-					Checksum: uint16(46751),
+					Checksum: uint16(6584),
 					Data: &protocol.IGMPv1or2{
 						Checksum:     uint16(64505),
 						GroupAddress: net.ParseIP("1.2.3.4"),
@@ -1085,10 +1085,10 @@ func Test_ofPacketOutBuilder_Done(t *testing.T) {
 			want: &ofctrl.PacketOut{
 				IPHeader: &protocol.IPv4{
 					Version:  uint8(4),
-					Id:       uint16(1090),
+					Id:       uint16(41257),
 					Protocol: protocol.Type_IGMP,
 					Length:   uint16(36),
-					Checksum: uint16(46743),
+					Checksum: uint16(6576),
 					Data: &protocol.IGMPv3Query{
 						Checksum:        uint16(61933),
 						GroupAddress:    net.ParseIP("1.2.3.4"),
@@ -1120,10 +1120,10 @@ func Test_ofPacketOutBuilder_Done(t *testing.T) {
 			want: &ofctrl.PacketOut{
 				IPHeader: &protocol.IPv4{
 					Version:  uint8(4),
-					Id:       uint16(1090),
+					Id:       uint16(41257),
 					Protocol: protocol.Type_IGMP,
 					Length:   uint16(40),
-					Checksum: uint16(46739),
+					Checksum: uint16(6572),
 					Data: &protocol.IGMPv3MembershipReport{
 						Checksum:       uint16(6935),
 						NumberOfGroups: 1,
@@ -1154,16 +1154,16 @@ func Test_ofPacketOutBuilder_Done(t *testing.T) {
 				IPHeader: &protocol.IPv4{
 					Version:  0x4,
 					Length:   40,
-					Checksum: 8009,
-					Id:       39822,
+					Checksum: 8512,
+					Id:       39319,
 				},
 				TCPHeader: &protocol.TCP{
 					PortSrc:  10000,
 					PortDst:  10001,
 					HdrLen:   5,
-					Checksum: 40408,
-					SeqNum:   2596996162,
-					AckNum:   4039455774,
+					Checksum: 2333,
+					SeqNum:   2569511209,
+					AckNum:   382732172,
 				},
 			},
 		},
@@ -1182,8 +1182,8 @@ func Test_ofPacketOutBuilder_Done(t *testing.T) {
 				IPHeader: &protocol.IPv4{
 					Version:  0x4,
 					Length:   28,
-					Checksum: 46753,
-					Id:       1090,
+					Checksum: 6586,
+					Id:       41257,
 				},
 				UDPHeader: &protocol.UDP{
 					PortSrc:  10000,
@@ -1240,9 +1240,9 @@ func Test_ofPacketOutBuilder_Done(t *testing.T) {
 					PortSrc:  10000,
 					PortDst:  10001,
 					HdrLen:   5,
-					Checksum: 40408,
-					SeqNum:   2596996162,
-					AckNum:   4039455774,
+					Checksum: 2333,
+					SeqNum:   2569511209,
+					AckNum:   382732172,
 				},
 			},
 		},

--- a/pkg/ovs/openflow/ofctrl_packetout_test.go
+++ b/pkg/ovs/openflow/ofctrl_packetout_test.go
@@ -15,7 +15,7 @@
 package openflow
 
 import (
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"reflect"
 	"testing"
@@ -1275,7 +1275,7 @@ func Test_ofPacketOutBuilder_Done(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Specify a hardcoded seed for testing to make output predictable.
 			// #nosec G404: random number generator not used for security purposes
-			pktRand = rand.New(rand.NewSource(1))
+			pktRand = rand.New(rand.NewPCG(1, 0))
 			b := &ofPacketOutBuilder{
 				pktOut:  tt.fields.pktOut,
 				icmpID:  tt.fields.icmpID,

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"os"
 	"path"
@@ -2264,7 +2264,7 @@ func randSeq(n int) string {
 	b := make([]rune, n)
 	for i := range b {
 		// #nosec G404: random number generator not used for security purposes
-		randIdx := rand.Intn(len(lettersAndDigits))
+		randIdx := rand.IntN(len(lettersAndDigits))
 		b[i] = lettersAndDigits[randIdx]
 	}
 	return string(b)

--- a/test/e2e/performance_test.go
+++ b/test/e2e/performance_test.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net/url"
 	"strings"
 	"testing"
@@ -95,7 +95,7 @@ func BenchmarkCustomizeRealizeNetworkPolicy(b *testing.B) {
 
 func randCidr(rnd *rand.Rand) string {
 	getByte := func() int {
-		return rnd.Intn(255) + 1
+		return rnd.IntN(255) + 1
 	}
 	return fmt.Sprintf("%d.%d.%d.%d/32", getByte(), getByte(), getByte(), getByte())
 }
@@ -150,7 +150,7 @@ func setupTestPodsConnection(data *TestData) error {
 func generateWorkloadNetworkPolicy(policyRules int) *networkv1.NetworkPolicy {
 	ingressRules := make([]networkv1.NetworkPolicyPeer, policyRules)
 	// #nosec G404: random number generator not used for security purposes
-	rnd := rand.New(rand.NewSource(seed))
+	rnd := rand.New(rand.NewPCG(seed, 0))
 	existingCIDRs := make(map[string]struct{}) // ensure no duplicated cidrs
 	for i := 0; i < policyRules; i++ {
 		cidr := randCidr(rnd)

--- a/test/integration/agent/net_test.go
+++ b/test/integration/agent/net_test.go
@@ -16,7 +16,7 @@ package agent
 
 import (
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"testing"
 


### PR DESCRIPTION
Fixes: #6648 

This PR replaces all usages of `math/rand` with the new `math/rand/v2` package.
I have updated the code following the previous review suggestions from @antoninbas on related PRs.
Let me know if any additional adjustments are needed.