### PR TITLE
Log PacketIn drops when dispatching to per-category queues

### DIFF
--- a/pkg/agent/openflow/packetin.go
+++ b/pkg/agent/openflow/packetin.go
@@ -100,7 +100,7 @@ type featureStartPacketIn struct {
 
 func newFeatureStartPacketIn(category uint8, stopCh <-chan struct{}, queueSize, queueRate int) *featureStartPacketIn {
 	featurePacketIn := featureStartPacketIn{category: category, stopCh: stopCh}
-	featurePacketIn.packetInQueue = openflow.NewPacketInQueue(queueSize, rate.Limit(queueRate))
+	featurePacketIn.packetInQueue = openflow.NewPacketInQueue(category, queueSize, rate.Limit(queueRate))
 
 	return &featurePacketIn
 }

--- a/pkg/ovs/openflow/ofctrl_bridge_test.go
+++ b/pkg/ovs/openflow/ofctrl_bridge_test.go
@@ -139,7 +139,7 @@ func TestOFBridgePacketRcvd(t *testing.T) {
 	packetInQueueTracker := map[uint8]*PacketInQueue{}
 	// Test different userdata.
 	for i := 0; i < 5; i++ {
-		packetInQueue := NewPacketInQueue(1, rate.Limit(10))
+		packetInQueue := NewPacketInQueue(0, 1, rate.Limit(10))
 		b.SubscribePacketIn(uint8(i), packetInQueue)
 		packetInQueueTracker[uint8(i)] = packetInQueue
 		b.PacketRcvd(nil, &ofctrl.PacketIn{
@@ -202,10 +202,10 @@ func TestOFMeterStats(t *testing.T) {
 
 func TestPacketInQueue(t *testing.T) {
 	burst := 200
-	q := NewPacketInQueue(burst, rate.Limit(100))
+	q := NewPacketInQueue(0, burst, rate.Limit(100))
 	for i := 0; i < burst; i++ {
 		assert.True(t, q.AddOrDrop(nil), "Packet should not be dropped before reaching the burst")
 	}
 	assert.False(t, q.AddOrDrop(nil), "Packet should be dropped after reaching the burst")
-	assert.Equal(t, float64(burst), q.rateLimiter.Tokens())
+	assert.Equal(t, float64(burst), q.pktRateLimiter.Tokens())
 }

--- a/test/integration/ovs/ofctrl_test.go
+++ b/test/integration/ovs/ofctrl_test.go
@@ -609,7 +609,7 @@ func TestPacketOutIn(t *testing.T) {
 	defer bridge.Disconnect()
 
 	category := uint8(1)
-	pktInQueue := binding.NewPacketInQueue(200, rate.Limit(100))
+	pktInQueue := binding.NewPacketInQueue(0, 200, rate.Limit(100))
 	err = bridge.SubscribePacketIn(category, pktInQueue)
 	require.NoError(t, err)
 


### PR DESCRIPTION
PacketIn events may be dropped when their rate exceeds 500 per second. Such drops can lead to traffic issues, for instance, if the dropped packet is a DNS reply for FQDN policy enforcement. Previously, there was no visibility into whether such drops occurred.

This patch adds rate-limited logging (once per minute) for these dropped events to help identify potential bottleneck. Frequent occurrences may indicate the need to increase the rate limit.

```
E0516 10:29:58.479969       1 ofctrl_bridge.go:681] "Failed to dispatch PacketIn event due to full channel" category=2 pktDrops=1
E0516 10:31:01.431538       1 ofctrl_bridge.go:681] "Failed to dispatch PacketIn event due to full channel" category=2 pktDrops=255
E0516 10:34:43.554807       1 ofctrl_bridge.go:681] "Failed to dispatch PacketIn event due to full channel" category=2 pktDrops=305
```

Note that when OVS supports meter, the packets would likely be dropped by meter, the log could be used to check whether the bottleneck is in userspace in that case.