### PR TITLE
Decouple sending of ICMP probes & latency reporting

### DIFF
--- a/pkg/agent/monitortool/monitor.go
+++ b/pkg/agent/monitortool/monitor.go
@@ -439,7 +439,7 @@ func (m *NodeLatencyMonitor) monitorLoop(stopCh <-chan struct{}) {
 			pingTicker.Stop() // Stop the pingTicker
 		}
 		pingTicker = m.clock.NewTicker(interval)
-		pingTickerCh = pingTicker.C() 
+		pingTickerCh = pingTicker.C()
 	}
 
 	// Update report ticker with minimum interval and jitter

--- a/pkg/agent/monitortool/monitor.go
+++ b/pkg/agent/monitortool/monitor.go
@@ -453,10 +453,7 @@ func (m *NodeLatencyMonitor) monitorLoop(stopCh <-chan struct{}) {
 		}
 		reportTicker = m.clock.NewTicker(reportInterval)
 		reportTickerCh = reportTicker.C()
-		klog.V(4).InfoS("Updated report interval",
-			"requested", interval,
-			"minimum", minReportInterval,
-			"actualWithJitter", reportInterval)
+		klog.V(4).InfoS("Updated report interval", "requested", interval, "minimum", minReportInterval, "actualWithJitter", reportInterval)
 	}
 
 	wg := sync.WaitGroup{}

--- a/pkg/agent/monitortool/monitor.go
+++ b/pkg/agent/monitortool/monitor.go
@@ -433,13 +433,13 @@ func (m *NodeLatencyMonitor) monitorLoop(stopCh <-chan struct{}) {
 		}
 	}()
 
-	// Update ping ticker based on latencyConfig
+	// Update ping ticker based on the latencyConfig
 	updatePingTicker := func(interval time.Duration) {
 		if pingTicker != nil {
-			pingTicker.Stop()
+			pingTicker.Stop() // Stop the pingTicker
 		}
 		pingTicker = m.clock.NewTicker(interval)
-		pingTickerCh = pingTicker.C() // Stop the pingTicker
+		pingTickerCh = pingTicker.C() 
 	}
 
 	// Update report ticker with minimum interval and jitter
@@ -449,7 +449,7 @@ func (m *NodeLatencyMonitor) monitorLoop(stopCh <-chan struct{}) {
 		reportInterval += reportJitter
 
 		if reportTicker != nil {
-			reportTicker.Stop()
+			reportTicker.Stop() // Stop the reportTicker
 		}
 		reportTicker = m.clock.NewTicker(reportInterval)
 		reportTickerCh = reportTicker.C()
@@ -470,7 +470,6 @@ func (m *NodeLatencyMonitor) monitorLoop(stopCh <-chan struct{}) {
 			// to avoid consistency issues and because it would not be sufficient to avoid stale entries completely.
 			// This means that we have to periodically invoke DeleteStaleNodeIPs to avoid stale entries in the map.
 			m.latencyStore.DeleteStaleNodeIPs()
-
 		case <-reportTickerCh:
 			m.report()
 		case <-stopCh:


### PR DESCRIPTION
Fixes: #6570 

This PR decouples ICMP probe sending from latency reporting in the NodeLatencyMonitor to improve accuracy of measurements and reduce system load. Previously, latency reporting happened immediately after sending probes, which could lead to misleading timestamps in the NodeLatencyStats CRD.

### Changes
- Separated ping and report operations into distinct tickers
- Added minimum report interval (10s) to prevent excessive reporting 
- Added jitter to report interval to avoid report clustering
- Updated tests to handle decoupled operations

I have updated the code following the previous review suggestions from @antoninbas  on related PRs.
Let me know if any additional adjustments are needed.

Attached the test result.

![Screenshot from 2025-05-22 13-54-14](https://github.com/user-attachments/assets/c079994d-e8d9-4801-ae44-3869aaa31707)
