### PR TITLE
Add direction flag to antctl packetcapture command

### DIFF
--- a/docs/antctl.md
+++ b/docs/antctl.md
@@ -597,6 +597,12 @@ include: IP protocol (`icmp`, `tcp`, `udp`), source and destination ports
 The `icmp_type` value can be provided in either numeric or string type (`icmp-echo`, `icmp-echoreply`, `icmp-unreach`, `icmp-timxceed`),
 and the `icmp_code` value can be provided in only numeric type.
 
+The `--direction` (or `-d`) argument can be used to specify the capture direction. Valid values are:
+
+* `SourceToDestination` (default): Capture packets flowing from source to destination
+* `DestinationToSource`: Capture packets flowing from destination to source
+* `Both`: Capture packets flowing in both directions
+
 By default, the command will wait for the PacketCapture to succeed or fail, or to
 timeout. The default timeout is 60 seconds, but can be changed with the
 `--timeout` (or `-t`) argument. Add the `--no-wait` flag to start a PacketCapture
@@ -620,6 +626,8 @@ $ antctl packetcapture -S pod1 -D pod2 -f udp,udp_dst=1234
 $ antctl packetcapture -S pod1 -D pod2 -f icmp,icmp_type=icmp-unreach,icmp_code=1
 # Start capturing ICMP echo packets from pod1 to pod2
 $ antctl packetcapture -S pod1 -D pod2 -f icmp,icmp_type=8
+# Start capturing packets in both directions between pod1 and pod2
+$ antctl packetcapture -S pod1 -D pod2 -d Both
 # Save the packets file to a specified directory
 $ antctl packetcapture -S 192.168.123.123 -D pod2 -f tcp,tcp_dst=80 -o /tmp
 ```
@@ -634,7 +642,7 @@ To run a reverse proxy for the Antrea Controller API, use:
 
 ```bash
 antctl proxy --controller
-````
+```
 
 To run a reverse proxy for the Antrea Agent API for the antrea-agent Pod running
 on Node <TARGET_NODE>, use:

--- a/pkg/antctl/raw/packetcapture/command.go
+++ b/pkg/antctl/raw/packetcapture/command.go
@@ -59,6 +59,7 @@ type packetCaptureOptions struct {
 	number    int32
 	flow      string
 	outputDir string
+	direction string
 }
 
 var options = &packetCaptureOptions{}
@@ -77,6 +78,8 @@ var packetCaptureExample = `  Start capturing packets from pod1 to pod2, both Po
   $ antctl packetcapture -S pod1 -D pod2 -f icmp,icmp_type=icmp-unreach,icmp_code=1
   Start capturing ICMP echo packets from pod1 to pod2
   $ antctl packetcapture -S pod1 -D pod2 -f icmp,icmp_type=8
+  Start capturing packets in both directions between pod1 and pod2
+  $ antctl packetcapture -S pod1 -D pod2 -d Both
   Save the packets file to a specified directory
   $ antctl packetcapture -S 192.168.123.123 -D pod2 -f tcp,tcp_dst=80 -o /tmp
 `
@@ -97,6 +100,7 @@ func init() {
 	Command.Flags().StringVarP(&options.flow, "flow", "f", "", "specify the flow (packet headers) of the PacketCapture, including tcp_src, tcp_dst, tcp_flags, udp_src, udp_dst, icmp_type, icmp_code")
 	Command.Flags().BoolVarP(&options.nowait, "nowait", "", false, "if set, command returns without retrieving results")
 	Command.Flags().StringVarP(&options.outputDir, "output-dir", "o", ".", "save the packets file to the target directory")
+	Command.Flags().StringVarP(&options.direction, "direction", "d", "SourceToDestination", "direction of the traffic to capture: SourceToDestination, DestinationToSource, or Both")
 }
 
 var protocols = map[string]int32{
@@ -417,6 +421,20 @@ func parseFlow(options *packetCaptureOptions) (*v1alpha1.Packet, error) {
 	return &pkt, nil
 }
 
+func parseDirection(direction string) (v1alpha1.CaptureDirection, error) {
+	// This case should not occur in practice as the direction flag is defaulted to SourceToDestination
+	if direction == "" {
+		return "", nil
+	}
+
+	switch v1alpha1.CaptureDirection(direction) {
+	case v1alpha1.CaptureDirectionSourceToDestination, v1alpha1.CaptureDirectionDestinationToSource, v1alpha1.CaptureDirectionBoth:
+		return v1alpha1.CaptureDirection(direction), nil
+	default:
+		return "", fmt.Errorf("invalid direction: %q, must be one of SourceToDestination, DestinationToSource, or Both", direction)
+	}
+}
+
 func newPacketCapture(options *packetCaptureOptions) (*v1alpha1.PacketCapture, error) {
 	if options.source == "" && options.dest == "" {
 		return nil, errors.New("must specify at least one of --source or --destination")
@@ -446,6 +464,11 @@ func newPacketCapture(options *packetCaptureOptions) (*v1alpha1.PacketCapture, e
 		return nil, fmt.Errorf("failed to parse flow: %w", err)
 	}
 
+	direction, err := parseDirection(options.direction)
+	if err != nil {
+		return nil, err
+	}
+
 	name := getPCName(options)
 	timeout := int32(options.timeout.Seconds())
 	pc := &v1alpha1.PacketCapture{
@@ -455,6 +478,7 @@ func newPacketCapture(options *packetCaptureOptions) (*v1alpha1.PacketCapture, e
 		Spec: v1alpha1.PacketCaptureSpec{
 			Source:      src,
 			Destination: dst,
+			Direction:   direction,
 			Timeout:     &timeout,
 			Packet:      pkt,
 			CaptureConfig: v1alpha1.CaptureConfig{
@@ -464,5 +488,6 @@ func newPacketCapture(options *packetCaptureOptions) (*v1alpha1.PacketCapture, e
 			},
 		},
 	}
+
 	return pc, nil
 }

--- a/pkg/antctl/raw/packetcapture/command_test.go
+++ b/pkg/antctl/raw/packetcapture/command_test.go
@@ -343,6 +343,51 @@ func TestNewPacketCapture(t *testing.T) {
 			},
 			expectErr: "failed to parse flow: icmp_type must be specified when icmp_code is provided",
 		},
+		{
+			name: "pod-2-pod-with-direction-both",
+			option: packetCaptureOptions{
+				source:    srcPod,
+				dest:      dstPod,
+				number:    testNum,
+				direction: "Both",
+			},
+			expectPC: &v1alpha1.PacketCapture{
+				Spec: v1alpha1.PacketCaptureSpec{
+					Source: v1alpha1.Source{
+						Pod: &v1alpha1.PodReference{
+							Namespace: "default",
+							Name:      "pod-1",
+						},
+					},
+					Destination: v1alpha1.Destination{
+						Pod: &v1alpha1.PodReference{
+							Namespace: "default",
+							Name:      "pod-2",
+						},
+					},
+					Direction: v1alpha1.CaptureDirectionBoth,
+					Timeout:   ptr.To(int32(0)),
+					CaptureConfig: v1alpha1.CaptureConfig{
+						FirstN: &v1alpha1.PacketCaptureFirstNConfig{
+							Number: testNum,
+						},
+					},
+					Packet: &v1alpha1.Packet{
+						IPFamily: v1.IPv4Protocol,
+					},
+				},
+			},
+		},
+		{
+			name: "pod-2-pod-with-invalid-direction",
+			option: packetCaptureOptions{
+				source:    srcPod,
+				dest:      dstPod,
+				number:    testNum,
+				direction: "InvalidDirection",
+			},
+			expectErr: "invalid direction: \"InvalidDirection\", must be one of SourceToDestination, DestinationToSource, or Both",
+		},
 	}
 
 	for _, tt := range tcs {


### PR DESCRIPTION
The antctl packetcapture command did not support specifying the traffic capture direction, despite the PacketCapture CRD supporting it.

This commit adds a new optional '-d' flag to antctl packetcapture, allowing users to set the direction of packet capture. Supported values are: SourceToDestination, DestinationToSource, and Both.

#7193 