### PR TITLE
Persist container netns with OVS port external IDs

### DIFF
--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -90,10 +90,10 @@ func TestInitInterfaceStore(t *testing.T) {
 
 	ovsPort1 := ovsconfig.OVSPortData{UUID: uuid1, Name: "p1", IFName: "p1", OFPort: 11,
 		ExternalIDs: convertExternalIDMap(cniserver.BuildOVSPortExternalIDs(
-			interfacestore.NewContainerInterface("p1", uuid1, "pod1", "ns1", "eth0", p1NetMAC, []net.IP{p1NetIP}, 0)))}
+			interfacestore.NewContainerInterface("p1", uuid1, "pod1", "ns1", "eth0", "netns1", p1NetMAC, []net.IP{p1NetIP}, 0)))}
 	ovsPort2 := ovsconfig.OVSPortData{UUID: uuid2, Name: "p2", IFName: "p2", OFPort: 12,
 		ExternalIDs: convertExternalIDMap(cniserver.BuildOVSPortExternalIDs(
-			interfacestore.NewContainerInterface("p2", uuid2, "pod2", "ns2", "eth0", p2NetMAC, []net.IP{p2NetIP}, 0),
+			interfacestore.NewContainerInterface("p2", uuid2, "pod2", "ns2", "eth0", "netns2", p2NetMAC, []net.IP{p2NetIP}, 0),
 		)),
 	}
 	initOVSPorts := []ovsconfig.OVSPortData{ovsPort1, ovsPort2}
@@ -112,7 +112,8 @@ func TestInitInterfaceStore(t *testing.T) {
 	container1, found1 := store.GetContainerInterface(uuid1)
 	if !found1 {
 		t.Errorf("Failed to load OVS port into local store")
-	} else if container1.OFPort != 11 || len(container1.IPs) == 0 || container1.IPs[0].String() != p1IP || container1.MAC.String() != p1MAC || container1.InterfaceName != "p1" {
+	} else if container1.OFPort != 11 || len(container1.IPs) == 0 || container1.IPs[0].String() != p1IP || container1.MAC.String() != p1MAC ||
+		container1.InterfaceName != "p1" || container1.NetNS != "netns1" {
 		t.Errorf("Failed to load OVS port configuration into local store")
 	}
 	_, found2 := store.GetContainerInterface(uuid2)

--- a/pkg/agent/cniserver/pod_configuration_linux.go
+++ b/pkg/agent/cniserver/pod_configuration_linux.go
@@ -38,7 +38,8 @@ func (pc *podConfigurator) connectInterfaceToOVS(
 	containerAccess *containerAccessArbitrator) (*interfacestore.InterfaceConfig, error) {
 	// Use the outer veth interface name as the OVS port name.
 	ovsPortName := hostIface.Name
-	containerConfig := buildContainerConfig(ovsPortName, containerID, podName, podNamespace, containerIface, ips, vlanID)
+	containerConfig := buildContainerConfig(ovsPortName, containerID, podName, podNamespace,
+		netNS, containerIface, ips, vlanID)
 	return containerConfig, pc.connectInterfaceToOVSCommon(ovsPortName, netNS, containerConfig)
 }
 

--- a/pkg/agent/cniserver/pod_configuration_windows.go
+++ b/pkg/agent/cniserver/pod_configuration_windows.go
@@ -73,7 +73,8 @@ func (pc *podConfigurator) connectInterfaceToOVS(
 	containerAccess *containerAccessArbitrator) (*interfacestore.InterfaceConfig, error) {
 	// Use the outer veth interface name as the OVS port name.
 	ovsPortName := hostIface.Name
-	containerConfig := buildContainerConfig(ovsPortName, containerID, podName, podNamespace, containerIface, ips, vlanID)
+	containerConfig := buildContainerConfig(ovsPortName, containerID, podName, podNamespace,
+		netNS, containerIface, ips, vlanID)
 	// The container interface is created after the CNI returns the network setup result.
 	// Because of this, we need to wait asynchronously for the interface to be created: we create the OVS port
 	// and set the OVS Interface type "" first, and change the OVS Interface type to "internal" to connect to the

--- a/pkg/agent/cniserver/secondary.go
+++ b/pkg/agent/cniserver/secondary.go
@@ -53,7 +53,8 @@ func (pc *podConfigurator) ConfigureSriovSecondaryInterface(
 
 	// Use podSriovVFDeviceID as the interface name in the interface store.
 	hostInterfaceName := podSriovVFDeviceID
-	containerConfig := buildContainerConfig(hostInterfaceName, containerID, podName, podNamespace, containerIface, result.IPs, 0)
+	containerConfig := buildContainerConfig(hostInterfaceName, containerID, podName, podNamespace,
+		containerNetNS, containerIface, result.IPs, 0)
 	pc.ifaceStore.AddInterface(containerConfig)
 
 	if result.IPs != nil {

--- a/pkg/agent/cniserver/server_linux_test.go
+++ b/pkg/agent/cniserver/server_linux_test.go
@@ -142,6 +142,7 @@ func TestRemoveInterface(t *testing.T) {
 			podName,
 			testPodNamespace,
 			"eth0",
+			"netns1",
 			containerMAC,
 			[]net.IP{containerIP},
 			0)
@@ -475,7 +476,7 @@ func TestCmdDel(t *testing.T) {
 			requestMsg, hostInterfaceName := createCNIRequestAndInterfaceName(t, testPodNameA, tc.cniType, ipamResult, tc.ipamType, true)
 			containerID := requestMsg.CniArgs.ContainerId
 			containerIfaceConfig := interfacestore.NewContainerInterface(hostInterfaceName, containerID,
-				testPodNameA, testPodNamespace, "eth0",
+				testPodNameA, testPodNamespace, "eth0", "netns1",
 				containerVethMac, []net.IP{net.ParseIP("10.1.2.100")}, 0)
 			containerIfaceConfig.OVSPortConfig = &interfacestore.OVSPortConfig{PortUUID: ovsPortID, OFPort: ovsPort}
 			ifaceStore.AddInterface(containerIfaceConfig)
@@ -540,7 +541,7 @@ func TestCmdCheck(t *testing.T) {
 		podArgs := cniservertest.GenerateCNIArgs(name, testPodNamespace, testPodInfraContainerID)
 		requestMsg, containerID := newRequest(podArgs, networkCfg, "", t)
 		containerIfaceConfig := interfacestore.NewContainerInterface(hostInterfaceName, containerID,
-			name, testPodNamespace, "eth0",
+			name, testPodNamespace, "eth0", "netns1",
 			containerVethMac, []net.IP{net.ParseIP("10.1.2.100")}, 0)
 		containerIfaceConfig.OVSPortConfig = &interfacestore.OVSPortConfig{PortUUID: ovsPortID, OFPort: ovsPort}
 		ifaceStore.AddInterface(containerIfaceConfig)

--- a/pkg/agent/cniserver/server_windows_test.go
+++ b/pkg/agent/cniserver/server_windows_test.go
@@ -536,7 +536,8 @@ func TestCmdDel(t *testing.T) {
 				server.podConfigurator.ifConfigurator.(*ifConfigurator).addEndpoint(hnsEndpoint)
 			}
 			if tc.ifaceExists {
-				containerIface := interfacestore.NewContainerInterface(ovsPortName, containerID, testPodNameA, testPodNamespace, "", containerMAC, []net.IP{net.ParseIP("10.1.2.100")}, 0)
+				containerIface := interfacestore.NewContainerInterface(ovsPortName, containerID, testPodNameA, testPodNamespace,
+					"", "netns1", containerMAC, []net.IP{net.ParseIP("10.1.2.100")}, 0)
 				containerIface.OVSPortConfig = &interfacestore.OVSPortConfig{
 					OFPort:   100,
 					PortUUID: ovsPortID,
@@ -594,7 +595,8 @@ func TestCmdCheck(t *testing.T) {
 		return &result
 	}
 	wrapperContainerInterface := func(ifaceName, containerID, podName, ovsPortID string, mac net.HardwareAddr, containerIP net.IP) *interfacestore.InterfaceConfig {
-		containerIface := interfacestore.NewContainerInterface(ifaceName, containerID, podName, testPodNamespace, "", mac, []net.IP{containerIP}, 0)
+		containerIface := interfacestore.NewContainerInterface(ifaceName, containerID, podName, testPodNamespace,
+			"", "netns1", mac, []net.IP{containerIP}, 0)
 		containerIface.OVSPortConfig = &interfacestore.OVSPortConfig{
 			PortUUID: ovsPortID,
 			OFPort:   10,

--- a/pkg/agent/interfacestore/interface_cache_test.go
+++ b/pkg/agent/interfacestore/interface_cache_test.go
@@ -48,7 +48,8 @@ func TestNewInterfaceStore(t *testing.T) {
 
 func testContainerInterface(t *testing.T) {
 	store := NewInterfaceStore()
-	containerInterface := NewContainerInterface("ns0p0c0", "c0", "p0", "ns0", "eth0", podMAC, []net.IP{podIP, podIPv6}, 2)
+	containerInterface := NewContainerInterface("ns0p0c0", "c0", "p0", "ns0", "eth0", "netns0",
+		podMAC, []net.IP{podIP, podIPv6}, 2)
 	containerInterface.OVSPortConfig = &OVSPortConfig{
 		OFPort:   12,
 		PortUUID: "1234567890",
@@ -99,8 +100,10 @@ func testContainerInterface(t *testing.T) {
 func testSecondaryInterface(t *testing.T) {
 	store := NewInterfaceStore()
 	// Seondary interface without an IP.
-	containerInterface1 := NewContainerInterface("c0-eth1", "c0", "p0", "ns0", "eth1", podMAC, nil, 2)
-	containerInterface2 := NewContainerInterface("c0-eth2", "c0", "p0", "ns0", "eth2", podMAC, []net.IP{podIP}, 0)
+	containerInterface1 := NewContainerInterface("c0-eth1", "c0", "p0", "ns0", "eth1", "netns0",
+		podMAC, nil, 2)
+	containerInterface2 := NewContainerInterface("c0-eth2", "c0", "p0", "ns0", "eth2", "netns0",
+		podMAC, []net.IP{podIP}, 0)
 	store.Initialize([]*InterfaceConfig{containerInterface1, containerInterface2})
 	assert.Equal(t, 2, store.Len())
 

--- a/pkg/agent/interfacestore/types.go
+++ b/pkg/agent/interfacestore/types.go
@@ -68,6 +68,7 @@ type ContainerInterfaceConfig struct {
 	PodNamespace string
 	// Interface name inside container.
 	IFDev string
+	NetNS string
 }
 
 // +k8s:deepcopy-gen=true
@@ -142,6 +143,7 @@ func NewContainerInterface(
 	podName string,
 	podNamespace string,
 	ifDev string,
+	netNS string,
 	mac net.HardwareAddr,
 	ips []net.IP,
 	vlanID uint16) *InterfaceConfig {
@@ -149,7 +151,8 @@ func NewContainerInterface(
 		ContainerID:  containerID,
 		PodName:      podName,
 		PodNamespace: podNamespace,
-		IFDev:        ifDev}
+		IFDev:        ifDev,
+		NetNS:        netNS}
 	return &InterfaceConfig{
 		InterfaceName:            interfaceName,
 		Type:                     ContainerInterface,

--- a/pkg/agent/secondarynetwork/podwatch/controller.go
+++ b/pkg/agent/secondarynetwork/podwatch/controller.go
@@ -610,6 +610,7 @@ func (pc *PodController) reconcileSecondaryInterfaces(primaryInterfaceStore inte
 		podKey := podKeyGet(config.PodName, config.PodNamespace)
 		pc.cniCache.Store(podKey, &podCNIInfo{
 			containerID: config.ContainerID,
+			netNS:       config.NetNS,
 		})
 	}
 


### PR DESCRIPTION
The following agent functions require netns of a container network interface:
* Create or update a Pod secondary interface.
* Delete a Pod secondary interface and clean up its state.
* Restore the original name of a SR-IOV VF interface after it is removed from the container netns.
If the container netns info is not persisted, these functions may break after agent restarts. This commit stores netns in the interface store, and writes it to an OVS port external ID with a Pod's primary or a secondary VLAN interface and restores it into the interface store after agent restarts.