### PR TITLE
Improve logging in NodePortLocal controller

### DIFF
--- a/pkg/agent/nodeportlocal/k8s/npl_controller.go
+++ b/pkg/agent/nodeportlocal/k8s/npl_controller.go
@@ -379,6 +379,7 @@ func (c *NPLController) processNextWorkItem() bool {
 }
 
 func (c *NPLController) deleteAllPortRulesIfAny(podKey string) error {
+	klog.InfoS("Deleting all NodePortLocal rules for Pod", "pod", podKey)
 	return c.portTable.DeleteRulesForPod(podKey)
 }
 


### PR DESCRIPTION
* Use structured logging consistently in handleAddUpdatePod.
* Increase verbosity level of "IP address not set for Pod" log.
* Add new logs when a rule is added / deleted. While the iptables-based implementation of NPL will also log a message, it doesn't include the Pod name, which makes troubleshooting issues harder.