### PR TITLE
Fix: Prevent "cache not started" error in StaleResCleanupController

### DIFF
--- a/multicluster/controllers/multicluster/leader/stale_controller_test.go
+++ b/multicluster/controllers/multicluster/leader/stale_controller_test.go
@@ -123,7 +123,7 @@ func TestReconcile(t *testing.T) {
 			}()
 			fakeClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithLists(tt.existingResExports).
 				WithObjects(tt.existingMemberAnnounce).WithStatusSubresource(tt.existingMemberAnnounce).Build()
-			c := NewStaleResCleanupController(fakeClient, common.TestScheme)
+			c := NewStaleResCleanupController(fakeClient, common.TestScheme, func() bool { return true })
 			ctx := context.Background()
 			_, err := c.Reconcile(ctx, ctrl.Request{
 				NamespacedName: types.NamespacedName{
@@ -230,7 +230,7 @@ func TestStaleController_CleanUpMemberClusterAnnounces(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithLists(tt.memberClusterAnnounceList).WithLists(tt.clusterSet).Build()
-			c := NewStaleResCleanupController(fakeClient, common.TestScheme)
+			c := NewStaleResCleanupController(fakeClient, common.TestScheme, func() bool { return true })
 			c.cleanUpExpiredMemberClusterAnnounces(ctx)
 
 			memberClusterAnnounceList := &mcv1alpha1.MemberClusterAnnounceList{}


### PR DESCRIPTION
Fixes: #6152 

This PR resolves the issue by ensuring the `StaleResCleanupController`'s periodic cleanup (specifically the `cleanUpExpiredMemberClusterAnnounces` function) only begins after the controller's required informer caches are fully synced.

This is achieved by:
1.  Delaying `StaleResCleanupController.Run()` execution: The `staleController.Run()` method is now added to the `manager.RunnableFunc` queue, ensuring it's invoked by the controller-runtime manager only after the manager has fully started and initialized its caches.
2.  Explicit Cache Synchronization Wait: Inside `StaleResCleanupController.Run()`, an explicit `cache.WaitForCacheSync()` call is added, utilizing the `mgr.GetCache().WaitForCacheSync()` function. This blocks the execution of the cleanup logic until the `MemberClusterAnnounce` informer's cache is confirmed to be populated.

The correct logs are posted in my comment on the issue [here](https://github.com/antrea-io/antrea/issues/6152#issuecomment-2927483890).

Let me know if any additional adjustments are needed.
@antoninbas @luolanzone 