### PR TITLE
Fix invalid template ID in FlowAggregator (IPFIX exporter)

### DIFF
--- a/pkg/flowaggregator/exporter/ipfix_test.go
+++ b/pkg/flowaggregator/exporter/ipfix_test.go
@@ -126,7 +126,10 @@ func TestIPFIXExporter_UpdateOptions(t *testing.T) {
 	}
 
 	setCount := 0
-	mockIPFIXBufferedExp.EXPECT().AddRecord(mockRecord).Do(func(record ipfixentities.Record) {
+	mockRecord.EXPECT().GetOrderedElementList().Return(nil).Times(2)
+	mockIPFIXBufferedExp.EXPECT().AddRecord(gomock.Cond(func(record ipfixentities.Record) bool {
+		return record.GetTemplateID() == testTemplateIDv4
+	})).Do(func(record ipfixentities.Record) {
 		setCount += 1
 	}).Return(nil).Times(2)
 	// connection will be closed when updating the external flow collector address
@@ -183,8 +186,10 @@ func TestIPFIXExporter_AddRecord(t *testing.T) {
 		observationDomainID:        testObservationDomainID,
 	}
 
-	mockIPFIXBufferedExp.EXPECT().AddRecord(mockRecord).Return(nil)
-
+	mockRecord.EXPECT().GetOrderedElementList().Return(nil)
+	mockIPFIXBufferedExp.EXPECT().AddRecord(gomock.Cond(func(record ipfixentities.Record) bool {
+		return record.GetTemplateID() == testTemplateIDv4
+	})).Return(nil)
 	assert.NoError(t, ipfixExporter.AddRecord(mockRecord, false))
 }
 
@@ -230,7 +235,10 @@ func TestIPFIXExporter_sendRecord_Error(t *testing.T) {
 		observationDomainID:        testObservationDomainID,
 	}
 
-	mockIPFIXBufferedExp.EXPECT().AddRecord(mockRecord).Return(fmt.Errorf("send error"))
+	mockRecord.EXPECT().GetOrderedElementList().Return(nil)
+	mockIPFIXBufferedExp.EXPECT().AddRecord(gomock.Cond(func(record ipfixentities.Record) bool {
+		return record.GetTemplateID() == testTemplateIDv4
+	})).Return(fmt.Errorf("send error"))
 	mockIPFIXExpProc.EXPECT().CloseConnToCollector()
 
 	assert.Error(t, ipfixExporter.AddRecord(mockRecord, false))

--- a/pkg/flowaggregator/preprocessor_test.go
+++ b/pkg/flowaggregator/preprocessor_test.go
@@ -57,24 +57,28 @@ func TestPreprocessorProcessMsg(t *testing.T) {
 			name                  string
 			templateElementsCount int
 			msg                   *ipfixentities.Message
+			expectedTemplateID    uint16
 			expectedIEsWithValue  []ipfixentities.InfoElementWithValue
 		}{
 			{
 				name:                  "same elements",
 				templateElementsCount: 2,
 				msg:                   getTestMsg(iesWithValue[:2]),
+				expectedTemplateID:    testTemplateID,
 				expectedIEsWithValue:  iesWithValue,
 			},
 			{
 				name:                  "extra elements",
 				templateElementsCount: 1,
 				msg:                   getTestMsg(iesWithValue[:2]),
+				expectedTemplateID:    0,
 				expectedIEsWithValue:  iesWithValue[:1],
 			},
 			{
 				name:                  "missing elements",
 				templateElementsCount: 3,
 				msg:                   getTestMsg(iesWithValue[:2]),
+				expectedTemplateID:    0,
 				expectedIEsWithValue:  append(iesWithValue, ipfixentities.NewUnsigned64InfoElement(packetTotalCountIE, 0)),
 			},
 		}
@@ -96,6 +100,8 @@ func TestPreprocessorProcessMsg(t *testing.T) {
 					r = records[0]
 				default:
 				}
+				// Make sure template ID has been "reset" when the element list is mutated.
+				assert.Equal(t, tc.expectedTemplateID, r.GetTemplateID())
 				if tc.expectedIEsWithValue == nil {
 					assert.Nil(t, r, "No record expected")
 				} else {


### PR DESCRIPTION
When switching to a buffered exporter in #6998, the exporter code was "optimized" a bit too agressively, and we ended up in a situation where data records with a template ID of 0 could be exported.

The template ID should be set explicitly for all IPFIX records to account for the following:

1) the template ID may not always match between the FlowExporter (Agent)
   and the FlowAggregator, even though it is the case today.
2) when there is version skew between the FlowExporter and the
   FlowAggregator, and IEs are either added or removed, the FA
   preprocessor resets the template ID of data records to 0 to avoid
   confusion (mutated data record no longer matches original template
   ID), which means that the correct template ID must be set at export
   time.