### PR TITLE
Refactor declaration of IPFIX IEs for FlowExporter

### DIFF
--- a/pkg/apis/ipfix/ies.go
+++ b/pkg/apis/ipfix/ies.go
@@ -1,0 +1,109 @@
+// Copyright 2025 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipfix
+
+import (
+	"iter"
+
+	"github.com/vmware/go-ipfix/pkg/registry"
+)
+
+type IPFamilyType string
+
+const (
+	IPFamilyBoth IPFamilyType = ""
+	IPFamilyIPv4 IPFamilyType = "IPv4"
+	IPFamilyIPv6 IPFamilyType = "IPv6"
+)
+
+type InfoElement struct {
+	Name           string
+	EnterpriseName string
+	EnterpriseID   uint32
+	IPFamily       IPFamilyType
+}
+
+// AllInfoElements is the ordered list of all Information Elements exported by the FlowExporter.
+// Only add new elements to the end of this list!
+// Prefer
+var AllInfoElements = []InfoElement{
+	// IANA
+	{Name: "flowStartSeconds", EnterpriseName: "IANA", EnterpriseID: registry.IANAEnterpriseID},
+	{Name: "flowEndSeconds", EnterpriseName: "IANA", EnterpriseID: registry.IANAEnterpriseID},
+	{Name: "flowEndReason", EnterpriseName: "IANA", EnterpriseID: registry.IANAEnterpriseID},
+	{Name: "sourceTransportPort", EnterpriseName: "IANA", EnterpriseID: registry.IANAEnterpriseID},
+	{Name: "destinationTransportPort", EnterpriseName: "IANA", EnterpriseID: registry.IANAEnterpriseID},
+	{Name: "protocolIdentifier", EnterpriseName: "IANA", EnterpriseID: registry.IANAEnterpriseID},
+	{Name: "packetTotalCount", EnterpriseName: "IANA", EnterpriseID: registry.IANAEnterpriseID},
+	{Name: "octetTotalCount", EnterpriseName: "IANA", EnterpriseID: registry.IANAEnterpriseID},
+	{Name: "packetDeltaCount", EnterpriseName: "IANA", EnterpriseID: registry.IANAEnterpriseID},
+	{Name: "octetDeltaCount", EnterpriseName: "IANA", EnterpriseID: registry.IANAEnterpriseID},
+	{Name: "sourceIPv4Address", EnterpriseName: "IANA", EnterpriseID: registry.IANAEnterpriseID, IPFamily: IPFamilyIPv4},
+	{Name: "destinationIPv4Address", EnterpriseName: "IANA", EnterpriseID: registry.IANAEnterpriseID, IPFamily: IPFamilyIPv4},
+	{Name: "sourceIPv6Address", EnterpriseName: "IANA", EnterpriseID: registry.IANAEnterpriseID, IPFamily: IPFamilyIPv6},
+	{Name: "destinationIPv6Address", EnterpriseName: "IANA", EnterpriseID: registry.IANAEnterpriseID, IPFamily: IPFamilyIPv6},
+
+	// ReverseIANA
+	{Name: "reversePacketTotalCount", EnterpriseName: "ReverseIANA", EnterpriseID: registry.IANAReversedEnterpriseID},
+	{Name: "reverseOctetTotalCount", EnterpriseName: "ReverseIANA", EnterpriseID: registry.IANAReversedEnterpriseID},
+	{Name: "reversePacketDeltaCount", EnterpriseName: "ReverseIANA", EnterpriseID: registry.IANAReversedEnterpriseID},
+	{Name: "reverseOctetDeltaCount", EnterpriseName: "ReverseIANA", EnterpriseID: registry.IANAReversedEnterpriseID},
+
+	// Antrea
+	{Name: "sourcePodName", EnterpriseName: "Antrea", EnterpriseID: registry.AntreaEnterpriseID},
+	{Name: "sourcePodNamespace", EnterpriseName: "Antrea", EnterpriseID: registry.AntreaEnterpriseID},
+	{Name: "sourceNodeName", EnterpriseName: "Antrea", EnterpriseID: registry.AntreaEnterpriseID},
+	{Name: "destinationPodName", EnterpriseName: "Antrea", EnterpriseID: registry.AntreaEnterpriseID},
+	{Name: "destinationPodNamespace", EnterpriseName: "Antrea", EnterpriseID: registry.AntreaEnterpriseID},
+	{Name: "destinationNodeName", EnterpriseName: "Antrea", EnterpriseID: registry.AntreaEnterpriseID},
+	{Name: "destinationServicePort", EnterpriseName: "Antrea", EnterpriseID: registry.AntreaEnterpriseID},
+	{Name: "destinationServicePortName", EnterpriseName: "Antrea", EnterpriseID: registry.AntreaEnterpriseID},
+	{Name: "ingressNetworkPolicyName", EnterpriseName: "Antrea", EnterpriseID: registry.AntreaEnterpriseID},
+	{Name: "ingressNetworkPolicyNamespace", EnterpriseName: "Antrea", EnterpriseID: registry.AntreaEnterpriseID},
+	{Name: "ingressNetworkPolicyType", EnterpriseName: "Antrea", EnterpriseID: registry.AntreaEnterpriseID},
+	{Name: "ingressNetworkPolicyRuleName", EnterpriseName: "Antrea", EnterpriseID: registry.AntreaEnterpriseID},
+	{Name: "ingressNetworkPolicyRuleAction", EnterpriseName: "Antrea", EnterpriseID: registry.AntreaEnterpriseID},
+	{Name: "egressNetworkPolicyName", EnterpriseName: "Antrea", EnterpriseID: registry.AntreaEnterpriseID},
+	{Name: "egressNetworkPolicyNamespace", EnterpriseName: "Antrea", EnterpriseID: registry.AntreaEnterpriseID},
+	{Name: "egressNetworkPolicyType", EnterpriseName: "Antrea", EnterpriseID: registry.AntreaEnterpriseID},
+	{Name: "egressNetworkPolicyRuleName", EnterpriseName: "Antrea", EnterpriseID: registry.AntreaEnterpriseID},
+	{Name: "egressNetworkPolicyRuleAction", EnterpriseName: "Antrea", EnterpriseID: registry.AntreaEnterpriseID},
+	{Name: "tcpState", EnterpriseName: "Antrea", EnterpriseID: registry.AntreaEnterpriseID},
+	{Name: "flowType", EnterpriseName: "Antrea", EnterpriseID: registry.AntreaEnterpriseID},
+	{Name: "egressName", EnterpriseName: "Antrea", EnterpriseID: registry.AntreaEnterpriseID},
+	{Name: "egressIP", EnterpriseName: "Antrea", EnterpriseID: registry.AntreaEnterpriseID},
+	{Name: "appProtocolName", EnterpriseName: "Antrea", EnterpriseID: registry.AntreaEnterpriseID},
+	{Name: "httpVals", EnterpriseName: "Antrea", EnterpriseID: registry.AntreaEnterpriseID},
+	{Name: "egressNodeName", EnterpriseName: "Antrea", EnterpriseID: registry.AntreaEnterpriseID},
+	{Name: "destinationClusterIPv4", EnterpriseName: "Antrea", EnterpriseID: registry.AntreaEnterpriseID, IPFamily: IPFamilyIPv4},
+	{Name: "destinationClusterIPv6", EnterpriseName: "Antrea", EnterpriseID: registry.AntreaEnterpriseID, IPFamily: IPFamilyIPv6},
+}
+
+// AllInfoElementsIter returns an iter.Seq2 to iterate over the information elements for IPv4 or
+// IPv6 flows.
+func AllInfoElementsIter(isIPv6 bool) iter.Seq2[int, InfoElement] {
+	return func(yield func(int, InfoElement) bool) {
+		idx := 0
+		for _, ie := range AllInfoElements {
+			if (ie.IPFamily == IPFamilyIPv4 && isIPv6) || (ie.IPFamily == IPFamilyIPv6 && !isIPv6) {
+				continue
+			}
+			if !yield(idx, ie) {
+				return
+			}
+			idx++
+		}
+	}
+}

--- a/pkg/flowaggregator/exporter/ipfix.go
+++ b/pkg/flowaggregator/exporter/ipfix.go
@@ -269,30 +269,12 @@ func (e *IPFIXExporter) createAndSendTemplate(isRecordIPv6 bool) error {
 
 func (e *IPFIXExporter) sendTemplateSet(isIPv6 bool) error {
 	elements := make([]ipfixentities.InfoElementWithValue, 0)
-	ianaInfoElements := infoelements.IANAInfoElementsIPv4
-	antreaInfoElements := infoelements.AntreaInfoElementsIPv4
 	templateID := e.templateIDv4
 	if isIPv6 {
-		ianaInfoElements = infoelements.IANAInfoElementsIPv6
-		antreaInfoElements = infoelements.AntreaInfoElementsIPv6
 		templateID = e.templateIDv6
 	}
-	for _, ieName := range ianaInfoElements {
-		ie, err := e.createInfoElementForTemplateSet(ieName, ipfixregistry.IANAEnterpriseID)
-		if err != nil {
-			return err
-		}
-		elements = append(elements, ie)
-	}
-	for _, ieName := range infoelements.IANAReverseInfoElements {
-		ie, err := e.createInfoElementForTemplateSet(ieName, ipfixregistry.IANAReversedEnterpriseID)
-		if err != nil {
-			return err
-		}
-		elements = append(elements, ie)
-	}
-	for _, ieName := range antreaInfoElements {
-		ie, err := e.createInfoElementForTemplateSet(ieName, ipfixregistry.AntreaEnterpriseID)
+	for _, infoElement := range infoelements.FlowExporterElements(isIPv6) {
+		ie, err := e.createInfoElementForTemplateSet(infoElement.Name, infoElement.EnterpriseID)
 		if err != nil {
 			return err
 		}

--- a/pkg/flowaggregator/exporter/ipfix_test.go
+++ b/pkg/flowaggregator/exporter/ipfix_test.go
@@ -237,26 +237,11 @@ func TestIPFIXExporter_sendRecord_Error(t *testing.T) {
 }
 
 func createElementList(isIPv6 bool, mockIPFIXRegistry *ipfixtesting.MockIPFIXRegistry) []ipfixentities.InfoElementWithValue {
-	ianaInfoElements := infoelements.IANAInfoElementsIPv4
-	antreaInfoElements := infoelements.AntreaInfoElementsIPv4
-	if isIPv6 {
-		ianaInfoElements = infoelements.IANAInfoElementsIPv6
-		antreaInfoElements = infoelements.AntreaInfoElementsIPv6
-	}
-	// Following consists of all elements that are in ianaInfoElements and antreaInfoElements (globals)
 	// Only the element name is needed, other arguments have dummy values
 	elemList := make([]ipfixentities.InfoElementWithValue, 0)
-	for _, ie := range ianaInfoElements {
-		elemList = append(elemList, createElement(ie, ipfixregistry.IANAEnterpriseID))
-		mockIPFIXRegistry.EXPECT().GetInfoElement(ie, ipfixregistry.IANAEnterpriseID).Return(elemList[len(elemList)-1].GetInfoElement(), nil)
-	}
-	for _, ie := range infoelements.IANAReverseInfoElements {
-		elemList = append(elemList, createElement(ie, ipfixregistry.IANAReversedEnterpriseID))
-		mockIPFIXRegistry.EXPECT().GetInfoElement(ie, ipfixregistry.IANAReversedEnterpriseID).Return(elemList[len(elemList)-1].GetInfoElement(), nil)
-	}
-	for _, ie := range antreaInfoElements {
-		elemList = append(elemList, createElement(ie, ipfixregistry.AntreaEnterpriseID))
-		mockIPFIXRegistry.EXPECT().GetInfoElement(ie, ipfixregistry.AntreaEnterpriseID).Return(elemList[len(elemList)-1].GetInfoElement(), nil)
+	for _, ie := range infoelements.FlowExporterElements(isIPv6) {
+		elemList = append(elemList, createElement(ie.Name, ie.EnterpriseID))
+		mockIPFIXRegistry.EXPECT().GetInfoElement(ie.Name, ie.EnterpriseID).Return(elemList[len(elemList)-1].GetInfoElement(), nil)
 	}
 	for i := range infoelements.StatsElementList {
 		elemList = append(elemList, createElement(infoelements.AntreaSourceStatsElementList[i], ipfixregistry.AntreaEnterpriseID))

--- a/pkg/flowaggregator/flowaggregator.go
+++ b/pkg/flowaggregator/flowaggregator.go
@@ -302,31 +302,10 @@ func (fa *flowAggregator) InitPreprocessor() error {
 		return ie, err
 	}
 
-	getInfoElements := func(isIPv4 bool) ([]*ipfixentities.InfoElement, error) {
-		ianaInfoElements := infoelements.IANAInfoElementsIPv4
-		ianaReverseInfoElements := infoelements.IANAReverseInfoElements
-		antreaInfoElements := infoelements.AntreaInfoElementsIPv4
-		if !isIPv4 {
-			ianaInfoElements = infoelements.IANAInfoElementsIPv6
-			antreaInfoElements = infoelements.AntreaInfoElementsIPv6
-		}
+	getInfoElements := func(isIPv6 bool) ([]*ipfixentities.InfoElement, error) {
 		infoElements := make([]*ipfixentities.InfoElement, 0)
-		for _, ieName := range ianaInfoElements {
-			ie, err := getInfoElementFromRegistry(ieName, ipfixregistry.IANAEnterpriseID)
-			if err != nil {
-				return nil, err
-			}
-			infoElements = append(infoElements, ie)
-		}
-		for _, ieName := range ianaReverseInfoElements {
-			ie, err := getInfoElementFromRegistry(ieName, ipfixregistry.IANAReversedEnterpriseID)
-			if err != nil {
-				return nil, err
-			}
-			infoElements = append(infoElements, ie)
-		}
-		for _, ieName := range antreaInfoElements {
-			ie, err := getInfoElementFromRegistry(ieName, ipfixregistry.AntreaEnterpriseID)
+		for _, infoElement := range infoelements.FlowExporterElements(isIPv6) {
+			ie, err := getInfoElementFromRegistry(infoElement.Name, infoElement.EnterpriseID)
 			if err != nil {
 				return nil, err
 			}
@@ -335,11 +314,11 @@ func (fa *flowAggregator) InitPreprocessor() error {
 		return infoElements, nil
 	}
 
-	infoElementsIPv4, err := getInfoElements(true)
+	infoElementsIPv4, err := getInfoElements(false)
 	if err != nil {
 		return err
 	}
-	infoElementsIPv6, err := getInfoElements(false)
+	infoElementsIPv6, err := getInfoElements(true)
 	if err != nil {
 		return err
 	}

--- a/pkg/flowaggregator/infoelements/elements.go
+++ b/pkg/flowaggregator/infoelements/elements.go
@@ -14,58 +14,17 @@
 
 package infoelements
 
+import (
+	"iter"
+
+	"antrea.io/antrea/pkg/apis/ipfix"
+)
+
+func FlowExporterElements(isIPv6 bool) iter.Seq2[int, ipfix.InfoElement] {
+	return ipfix.AllInfoElementsIter(isIPv6)
+}
+
 var (
-	IANAInfoElementsCommon = []string{
-		"flowStartSeconds",
-		"flowEndSeconds",
-		"flowEndReason",
-		"sourceTransportPort",
-		"destinationTransportPort",
-		"protocolIdentifier",
-		"packetTotalCount",
-		"octetTotalCount",
-		"packetDeltaCount",
-		"octetDeltaCount",
-	}
-	IANAInfoElementsIPv4    = append(IANAInfoElementsCommon, []string{"sourceIPv4Address", "destinationIPv4Address"}...)
-	IANAInfoElementsIPv6    = append(IANAInfoElementsCommon, []string{"sourceIPv6Address", "destinationIPv6Address"}...)
-	IANAReverseInfoElements = []string{
-		"reversePacketTotalCount",
-		"reverseOctetTotalCount",
-		"reversePacketDeltaCount",
-		"reverseOctetDeltaCount",
-	}
-
-	AntreaInfoElementsCommon = []string{
-		"sourcePodName",
-		"sourcePodNamespace",
-		"sourceNodeName",
-		"destinationPodName",
-		"destinationPodNamespace",
-		"destinationNodeName",
-		"destinationServicePort",
-		"destinationServicePortName",
-		"ingressNetworkPolicyName",
-		"ingressNetworkPolicyNamespace",
-		"ingressNetworkPolicyType",
-		"ingressNetworkPolicyRuleName",
-		"ingressNetworkPolicyRuleAction",
-		"egressNetworkPolicyName",
-		"egressNetworkPolicyNamespace",
-		"egressNetworkPolicyType",
-		"egressNetworkPolicyRuleName",
-		"egressNetworkPolicyRuleAction",
-		"tcpState",
-		"flowType",
-		"egressName",
-		"egressIP",
-		"appProtocolName",
-		"httpVals",
-		"egressNodeName",
-	}
-	AntreaInfoElementsIPv4 = append(AntreaInfoElementsCommon, []string{"destinationClusterIPv4"}...)
-	AntreaInfoElementsIPv6 = append(AntreaInfoElementsCommon, []string{"destinationClusterIPv6"}...)
-
 	NonStatsElementList = []string{
 		"flowEndSeconds",
 		"flowEndReason",


### PR DESCRIPTION
In #6912, we added support for version skew betwen the FlowExporter (Agent) and the FlowAggregator. The implementation was based on the observation that when a new Antrea version introduces additional Information Elements (IEs), they are always added "after" all existing IEs. I have recently realized that this is not accurate, due to the destinationClusterIPv4 / destinationClusterIPv6 always being conditionally added after all other IEs, including new ones.

To ensure that future new IEs are always added at the end of the list, we refactor how these IEs are declared. As an added benefit, we now share the declaration between the FlowExporter and the FlowAggregator, and the code is overall less verbose.

Note that we should still improve how version skew is handled in the future, e.g., we should tolerate the removal of deprecated IEs, but this is hard to do efficiently.

There is also still room for improvement in the FlowAggregator, as we could consistently use the new style of declaring IEs for the FA-specific ones.