### PR TITLE
Fix rollback when configureContainerLinkVeth fails

### DIFF
--- a/pkg/agent/cniserver/interface_configuration_linux_test.go
+++ b/pkg/agent/cniserver/interface_configuration_linux_test.go
@@ -160,9 +160,11 @@ func TestConfigureContainerLink(t *testing.T) {
 		podSriovVFDeviceID        string
 		renameIntefaceErr         error
 		setupVethErr              error
+		delLinkErr                error
 		ipamConfigureIfaceErr     error
 		ethtoolEthTXHWCsumOffErr  error
 		expectErr                 error
+		delLinkCalled             bool
 	}{
 		{
 			name:                      "container-vethpair-success",
@@ -177,11 +179,13 @@ func TestConfigureContainerLink(t *testing.T) {
 			ovsHardwareOffloadEnabled: false,
 			ipamConfigureIfaceErr:     fmt.Errorf("unable to configure container IPAM"),
 			expectErr:                 fmt.Errorf("failed to configure IP address for container %s: unable to configure container IPAM", podContainerID),
+			delLinkCalled:             true,
 		}, {
 			name:                      "container-hwoffload-failure",
 			ovsHardwareOffloadEnabled: true,
 			ethtoolEthTXHWCsumOffErr:  fmt.Errorf("unable to disable offloading"),
 			expectErr:                 fmt.Errorf("error when disabling TX checksum offload on container veth: unable to disable offloading"),
+			delLinkCalled:             true,
 		}, {
 			name:                      "br-sriov-offloading-disable",
 			ovsHardwareOffloadEnabled: false,
@@ -212,7 +216,9 @@ func TestConfigureContainerLink(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			var delLinkCalled bool
 			defer mockSetupVethWithName(tc.setupVethErr, 1, 2)()
+			defer mockDelLinkByName(tc.delLinkErr, &delLinkCalled)()
 			defer mockRenameInterface(tc.renameIntefaceErr)()
 			defer mockIPAMConfigureIface(tc.ipamConfigureIfaceErr)()
 			defer mockEthtoolTXHWCsumOff(tc.ethtoolEthTXHWCsumOffErr)()
@@ -255,6 +261,7 @@ func TestConfigureContainerLink(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
+			assert.Equal(t, tc.delLinkCalled, delLinkCalled)
 		})
 	}
 }
@@ -806,6 +813,17 @@ func mockSetupVethWithName(setupVethErr error, containerIndex, hostIndex int) fu
 	}
 	return func() {
 		ipSetupVethWithName = originalIPSetupVethWithName
+	}
+}
+
+func mockDelLinkByName(err error, called *bool) func() {
+	origin := ipDelLinkByName
+	ipDelLinkByName = func(name string) error {
+		*called = true
+		return err
+	}
+	return func() {
+		ipDelLinkByName = origin
 	}
 }
 


### PR DESCRIPTION
If configureContainerLinkVeth fails, either while disabling TX checksum offloading or configuring IPAM, the veth interfaces are left behind in a broken state. Subsequent retries by the controller will fail to create the veth again because they already exist.

This patch performs proper cleanup, allowing retries to succeed.

Logs without the fix (2.3.0):
```
I0606 08:43:10.229897       1 allocator.go:155] "IP Pool update succeeded" pool="vlan100-ipv4" allocation={"ipAddresses":[{"ipAddress":"172.100.0.10","phase":"Allocated","owner":{"pod":{"name":"sample-pod-secondary-network-vlan","namespace":"default","containerID":"a18542cd74fa5a80cb3b0bf1b633976e13b68ef589a5c4ef47695851484a4d24","ifName":"eth1"}}}],"usage":{"total":11,"used":1}}
I0606 08:43:10.234288       1 allocator.go:251] "IP Pool update succeeded" pool="vlan100-ipv4" allocation={"usage":{"total":11,"used":0}}
E0606 08:43:10.234441       1 controller.go:448] "Secondary interface configuration failed" err="failed to configure IP address for container a18542cd74fa5a80cb3b0bf1b633976e13b68ef589a5c4ef47695851484a4d24: failed to add route '{10.0.0.0 ff000000} via 192.168.1.1 dev eth1': network is unreachable" Pod="default/sample-pod-secondary-network-vlan" interface="eth1" networkType="vlan"
I0606 08:43:12.240527       1 allocator.go:155] "IP Pool update succeeded" pool="vlan100-ipv4" allocation={"ipAddresses":[{"ipAddress":"172.100.0.10","phase":"Allocated","owner":{"pod":{"name":"sample-pod-secondary-network-vlan","namespace":"default","containerID":"a18542cd74fa5a80cb3b0bf1b633976e13b68ef589a5c4ef47695851484a4d24","ifName":"eth1"}}}],"usage":{"total":11,"used":1}}
E0606 08:43:12.240845       1 controller.go:448] "Secondary interface configuration failed" err="failed to create veth devices for container a18542cd74fa5a80cb3b0bf1b633976e13b68ef589a5c4ef47695851484a4d24: container veth name provided (eth1) already exists" Pod="default/sample-pod-secondary-network-vlan" interface="eth1" networkType="vlan"
I0606 08:43:16.244088       1 allocator.go:343] "Container already has an IP allocated" container="a18542cd74fa5a80cb3b0bf1b633976e13b68ef589a5c4ef47695851484a4d24" interface="eth1" IPPool="vlan100-ipv4"
I0606 08:43:16.248289       1 allocator.go:251] "IP Pool update succeeded" pool="vlan100-ipv4" allocation={"usage":{"total":11,"used":0}}
E0606 08:43:16.248324       1 controller.go:448] "Secondary interface configuration failed" err="failed to create veth devices for container a18542cd74fa5a80cb3b0bf1b633976e13b68ef589a5c4ef47695851484a4d24: container veth name provided (eth1) already exists" Pod="default/sample-pod-secondary-network-vlan" interface="eth1" networkType="vlan"
I0606 08:43:24.254550       1 allocator.go:155] "IP Pool update succeeded" pool="vlan100-ipv4" allocation={"ipAddresses":[{"ipAddress":"172.100.0.10","phase":"Allocated","owner":{"pod":{"name":"sample-pod-secondary-network-vlan","namespace":"default","containerID":"a18542cd74fa5a80cb3b0bf1b633976e13b68ef589a5c4ef47695851484a4d24","ifName":"eth1"}}}],"usage":{"total":11,"used":1}}
I0606 08:43:24.258653       1 allocator.go:251] "IP Pool update succeeded" pool="vlan100-ipv4" allocation={"usage":{"total":11,"used":0}}
E0606 08:43:24.258697       1 controller.go:448] "Secondary interface configuration failed" err="failed to create veth devices for container a18542cd74fa5a80cb3b0bf1b633976e13b68ef589a5c4ef47695851484a4d24: container veth name provided (eth1) already exists" Pod="default/sample-pod-secondary-network-vlan" interface="eth1" networkType="vlan"
```

Logs with the fix:
```
I0606 10:36:24.088820       1 allocator.go:155] "IP Pool update succeeded" pool="vlan100-ipv4" allocation={"ipAddresses":[{"ipAddress":"172.100.0.10","phase":"Allocated","owner":{"pod":{"name":"sample-pod-secondary-network-vlan","namespace":"default","containerID":"3e55df4acec7f6de678a20618b17c6e7c11ffec57b47fc7cfcc3ec9964fddfb7","ifName":"eth1"}}}],"usage":{"total":11,"used":1}}
I0606 10:36:24.104097       1 allocator.go:251] "IP Pool update succeeded" pool="vlan100-ipv4" allocation={"usage":{"total":11,"used":0}}
E0606 10:36:24.104145       1 controller.go:463] "Secondary interface configuration failed" err="failed to configure IP address for container 3e55df4acec7f6de678a20618b17c6e7c11ffec57b47fc7cfcc3ec9964fddfb7: failed to add route '{10.0.0.0 ff000000} via 192.168.1.1 dev eth1': network is unreachable" Pod="default/sample-pod-secondary-network-vlan" interface="eth1" networkType="vlan"
E0606 10:36:24.104536       1 controller.go:331] "Error syncing Pod for SecondaryNetwork, requeuing" err="failed to configure IP address for container 3e55df4acec7f6de678a20618b17c6e7c11ffec57b47fc7cfcc3ec9964fddfb7: failed to add route '{10.0.0.0 ff000000} via 192.168.1.1 dev eth1': network is unreachable" key="default/sample-pod-secondary-network-vlan"
I0606 10:36:26.112055       1 allocator.go:155] "IP Pool update succeeded" pool="vlan100-ipv4" allocation={"ipAddresses":[{"ipAddress":"172.100.0.10","phase":"Allocated","owner":{"pod":{"name":"sample-pod-secondary-network-vlan","namespace":"default","containerID":"3e55df4acec7f6de678a20618b17c6e7c11ffec57b47fc7cfcc3ec9964fddfb7","ifName":"eth1"}}}],"usage":{"total":11,"used":1}}
I0606 10:36:26.124499       1 allocator.go:251] "IP Pool update succeeded" pool="vlan100-ipv4" allocation={"usage":{"total":11,"used":0}}
E0606 10:36:26.124549       1 controller.go:463] "Secondary interface configuration failed" err="failed to configure IP address for container 3e55df4acec7f6de678a20618b17c6e7c11ffec57b47fc7cfcc3ec9964fddfb7: failed to add route '{10.0.0.0 ff000000} via 192.168.1.1 dev eth1': network is unreachable" Pod="default/sample-pod-secondary-network-vlan" interface="eth1" networkType="vlan"
E0606 10:36:26.124560       1 controller.go:331] "Error syncing Pod for SecondaryNetwork, requeuing" err="failed to configure IP address for container 3e55df4acec7f6de678a20618b17c6e7c11ffec57b47fc7cfcc3ec9964fddfb7: failed to add route '{10.0.0.0 ff000000} via 192.168.1.1 dev eth1': network is unreachable" key="default/sample-pod-secondary-network-vlan"
I0606 10:36:30.131833       1 allocator.go:155] "IP Pool update succeeded" pool="vlan100-ipv4" allocation={"ipAddresses":[{"ipAddress":"172.100.0.10","phase":"Allocated","owner":{"pod":{"name":"sample-pod-secondary-network-vlan","namespace":"default","containerID":"3e55df4acec7f6de678a20618b17c6e7c11ffec57b47fc7cfcc3ec9964fddfb7","ifName":"eth1"}}}],"usage":{"total":11,"used":1}}
I0606 10:36:30.146626       1 allocator.go:251] "IP Pool update succeeded" pool="vlan100-ipv4" allocation={"usage":{"total":11,"used":0}}
E0606 10:36:30.146658       1 controller.go:463] "Secondary interface configuration failed" err="failed to configure IP address for container 3e55df4acec7f6de678a20618b17c6e7c11ffec57b47fc7cfcc3ec9964fddfb7: failed to add route '{10.0.0.0 ff000000} via 192.168.1.1 dev eth1': network is unreachable" Pod="default/sample-pod-secondary-network-vlan" interface="eth1" networkType="vlan"
E0606 10:36:30.146678       1 controller.go:331] "Error syncing Pod for SecondaryNetwork, requeuing" err="failed to configure IP address for container 3e55df4acec7f6de678a20618b17c6e7c11ffec57b47fc7cfcc3ec9964fddfb7: failed to add route '{10.0.0.0 ff000000} via 192.168.1.1 dev eth1': network is unreachable" key="default/sample-pod-secondary-network-vlan"
```

It also applies to the SR-IOV case, but it's better to wait for #7144 which fixes the cleanup logic of SR-IOV case to be merged first.
