### PR TITLE
Enhance antctl to list specific featuregates prerequisites

### DIFF
--- a/docs/antctl.md
+++ b/docs/antctl.md
@@ -124,11 +124,25 @@ The feature gates of Antrea Controller and Agent can be shown using the `antctl 
 The command can run locally inside the `antrea-controller` or `antrea-agent` container or out-of-cluster,
 when it is running out-of-cluster or in Controller Pod, it will print both Controller and Agent's feature gates list.
 
-The following command prints the current feature gates:
+The following command prints all current feature gates:
 
 ```bash
 antctl get featuregates
 ```
+
+To get information about a specific feature gate including its prerequisites, you can specify the feature gate name:
+
+```bash
+antctl get featuregates <FeatureName>
+```
+
+For example, to get information about the AntreaIPAM feature gate:
+
+```bash
+antctl get featuregates AntreaIPAM
+```
+
+This will display detailed information about the feature gate, including its status, version, and any prerequisites required for the feature to work as designed.
 
 ### Performing checks to facilitate installation process
 
@@ -175,6 +189,28 @@ Run the following command to discover more options:
 ```bash
 antctl check installation --help
 ```
+
+### Feature Gates and Prerequisites
+
+Antrea supports various feature gates that can be enabled or disabled. Some feature gates have prerequisites that must be met for the feature to work correctly. You can view all available feature gates and their status using:
+
+```bash
+antctl get featuregates
+```
+
+To view detailed information about a specific feature gate, including its prerequisites:
+
+```bash
+antctl get featuregates <FEATURE_GATE_NAME>
+```
+
+For example:
+
+```bash
+antctl get featuregates AntreaIPAM
+```
+
+This will display the status, version, and any prerequisites required for the feature gate to function properly.
 
 ### Collecting support information
 

--- a/pkg/agent/apis/types.go
+++ b/pkg/agent/apis/types.go
@@ -96,10 +96,11 @@ func (r FQDNCacheResponse) SortRows() bool {
 }
 
 type FeatureGateResponse struct {
-	Component string `json:"component,omitempty"`
-	Name      string `json:"name,omitempty"`
-	Status    string `json:"status,omitempty"`
-	Version   string `json:"version,omitempty"`
+	Component     string   `json:"component,omitempty"`
+	Name          string   `json:"name,omitempty"`
+	Status        string   `json:"status,omitempty"`
+	Version       string   `json:"version,omitempty"`
+	Prerequisites []string `json:"prerequisites,omitempty"`
 }
 
 // MemberlistResponse describes the response struct of memberlist command.

--- a/pkg/apiserver/apis/types.go
+++ b/pkg/apiserver/apis/types.go
@@ -36,8 +36,9 @@ type Endpoint struct {
 }
 
 type FeatureGateResponse struct {
-	Component string `json:"component,omitempty"`
-	Name      string `json:"name,omitempty"`
-	Status    string `json:"status,omitempty"`
-	Version   string `json:"version,omitempty"`
+	Component     string   `json:"component,omitempty"`
+	Name          string   `json:"name,omitempty"`
+	Status        string   `json:"status,omitempty"`
+	Version       string   `json:"version,omitempty"`
+	Prerequisites []string `json:"prerequisites,omitempty"`
 }

--- a/pkg/apiserver/handlers/featuregates/handler.go
+++ b/pkg/apiserver/handlers/featuregates/handler.go
@@ -130,11 +130,17 @@ func getFeatureGatesResponse(cfg *Config, component string) []apis.FeatureGateRe
 				status = features.DefaultFeatureGate.Enabled(df)
 			}
 			featureStatus := features.GetStatus(status)
+
+			// Get prerequisites for this feature gate
+			prerequisites := features.GetFeaturePrerequisites(df)
+			klog.V(2).InfoS("Controller: Feature gate prerequisites", "featureGate", string(df), "prerequisites", prerequisites)
+
 			gatesResp = append(gatesResp, apis.FeatureGateResponse{
-				Component: component,
-				Name:      string(df),
-				Status:    featureStatus,
-				Version:   features.GetVersion(string(features.DefaultAntreaFeatureGates[df].PreRelease)),
+				Component:     component,
+				Name:          string(df),
+				Status:        featureStatus,
+				Version:       features.GetVersion(string(features.DefaultAntreaFeatureGates[df].PreRelease)),
+				Prerequisites: prerequisites,
 			})
 		}
 	}

--- a/pkg/features/prerequisites.go
+++ b/pkg/features/prerequisites.go
@@ -1,0 +1,51 @@
+// Copyright 2025 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package features
+
+import (
+	"k8s.io/component-base/featuregate"
+	"k8s.io/klog/v2"
+)
+
+// FeaturePrerequisites maps feature gates to their prerequisite flags
+var FeaturePrerequisites = map[featuregate.Feature][]string{
+	// AntreaIPAM prerequisites
+	AntreaIPAM: {
+		"enableBridgingMode=true",
+		"trafficEncapMode=true",
+		"noSNAT=true",
+	},
+	// AntreaProxy prerequisites
+	AntreaProxy: {
+		"proxyAll=true",
+	},
+	// SecondaryNetwork prerequisites
+	SecondaryNetwork: {
+		"multipleNetworkInterfaces=true",
+	},
+	// Add more feature gates and their prerequisites as needed
+}
+
+// GetFeaturePrerequisites returns the prerequisites for a given feature gate
+func GetFeaturePrerequisites(featureName featuregate.Feature) []string {
+	if prerequisites, exists := FeaturePrerequisites[featureName]; exists {
+		// Log when prerequisites are found
+		klog.V(2).InfoS("Found prerequisites for feature gate", "featureName", string(featureName), "prerequisites", prerequisites)
+		return prerequisites
+	}
+	// Log when no prerequisites are found
+	klog.V(2).InfoS("No prerequisites found for feature gate", "featureName", string(featureName))
+	return nil
+}


### PR DESCRIPTION

## What this pr solve
-  https://github.com/antrea-io/antrea/issues/7051
## Description 
Extend `antctl get featuregates` command to support FeaturegateName `antctl get featuregates <FeatureName>`


Implementation Overview

Centralized Prerequisite Definition:

- Created `FeaturePrerequisites `map in `pkg/features/prerequisites.go` to define prerequisites for feature gates
- Implemented `GetFeaturePrerequisites` helper function to retrieve prerequisites for a given feature gate

API Handler :

- Modified controller API handler `pkg/apiserver/handlers/featuregates/handler.go` to include prerequisites
- Enhanced agent API handler `pkg/agent/apiserver/handlers/featuregates/handler.go` similarly
- Added Prerequisites field to `FeatureGateResponse ` structs in both controller and agent API types

CLI Improvement:

- Enhanced `antctl get featuregates` command to display prerequisites when querying specific feature gates

Docs:

- Updated `docs/antctl.md` to document the new feature gate prerequisites functionality and added an example 

### Tested in my local machine 

![image](https://github.com/user-attachments/assets/9a1fb1b3-25d9-4dde-8236-e0c957b8d433)



