### PR TITLE
[PacketCapture] Support arbitrary source or destination

### DIFF
--- a/build/charts/antrea/crds/packetcapture.yaml
+++ b/build/charts/antrea/crds/packetcapture.yaml
@@ -65,24 +65,16 @@ spec:
             spec:
               type: object
               required:
-                - source
                 - captureConfig
-                - destination
-              anyOf:
-                - properties:
-                    source:
-                      required: [pod]
-                - properties:
-                    destination:
-                      required: [pod]
+              x-kubernetes-validations:
+                - rule: "has(self.source.pod) || has(self.destination.pod)"
+                  message: "At least one of source.pod or destination.pod must be specified."
               properties:
                 source:
                   type: object
-                  oneOf:
-                    - required:
-                      - pod
-                    - required:
-                      - ip
+                  x-kubernetes-validations:
+                    - rule: "!(has(self.pod) && has(self.ip))"
+                      message: "At most one of 'pod' or 'ip' may be set"
                   properties:
                     pod:
                       type: object
@@ -99,11 +91,9 @@ spec:
                       format: ipv4
                 destination:
                   type: object
-                  oneOf:
-                    - required:
-                      - pod
-                    - required:
-                      - ip
+                  x-kubernetes-validations:
+                    - rule: "!(has(self.pod) && has(self.ip))"
+                      message: "At most one of 'pod' or 'ip' may be set"
                   properties:
                     pod:
                       type: object

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -2986,24 +2986,16 @@ spec:
             spec:
               type: object
               required:
-                - source
                 - captureConfig
-                - destination
-              anyOf:
-                - properties:
-                    source:
-                      required: [pod]
-                - properties:
-                    destination:
-                      required: [pod]
+              x-kubernetes-validations:
+                - rule: "has(self.source.pod) || has(self.destination.pod)"
+                  message: "At least one of source.pod or destination.pod must be specified."
               properties:
                 source:
                   type: object
-                  oneOf:
-                    - required:
-                      - pod
-                    - required:
-                      - ip
+                  x-kubernetes-validations:
+                    - rule: "!(has(self.pod) && has(self.ip))"
+                      message: "At most one of 'pod' or 'ip' may be set"
                   properties:
                     pod:
                       type: object
@@ -3020,11 +3012,9 @@ spec:
                       format: ipv4
                 destination:
                   type: object
-                  oneOf:
-                    - required:
-                      - pod
-                    - required:
-                      - ip
+                  x-kubernetes-validations:
+                    - rule: "!(has(self.pod) && has(self.ip))"
+                      message: "At most one of 'pod' or 'ip' may be set"
                   properties:
                     pod:
                       type: object

--- a/build/yamls/antrea-crds.yml
+++ b/build/yamls/antrea-crds.yml
@@ -2959,24 +2959,16 @@ spec:
             spec:
               type: object
               required:
-                - source
                 - captureConfig
-                - destination
-              anyOf:
-                - properties:
-                    source:
-                      required: [pod]
-                - properties:
-                    destination:
-                      required: [pod]
+              x-kubernetes-validations:
+                - rule: "has(self.source.pod) || has(self.destination.pod)"
+                  message: "At least one of source.pod or destination.pod must be specified."
               properties:
                 source:
                   type: object
-                  oneOf:
-                    - required:
-                      - pod
-                    - required:
-                      - ip
+                  x-kubernetes-validations:
+                    - rule: "!(has(self.pod) && has(self.ip))"
+                      message: "At most one of 'pod' or 'ip' may be set"
                   properties:
                     pod:
                       type: object
@@ -2993,11 +2985,9 @@ spec:
                       format: ipv4
                 destination:
                   type: object
-                  oneOf:
-                    - required:
-                      - pod
-                    - required:
-                      - ip
+                  x-kubernetes-validations:
+                    - rule: "!(has(self.pod) && has(self.ip))"
+                      message: "At most one of 'pod' or 'ip' may be set"
                   properties:
                     pod:
                       type: object

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -2986,24 +2986,16 @@ spec:
             spec:
               type: object
               required:
-                - source
                 - captureConfig
-                - destination
-              anyOf:
-                - properties:
-                    source:
-                      required: [pod]
-                - properties:
-                    destination:
-                      required: [pod]
+              x-kubernetes-validations:
+                - rule: "has(self.source.pod) || has(self.destination.pod)"
+                  message: "At least one of source.pod or destination.pod must be specified."
               properties:
                 source:
                   type: object
-                  oneOf:
-                    - required:
-                      - pod
-                    - required:
-                      - ip
+                  x-kubernetes-validations:
+                    - rule: "!(has(self.pod) && has(self.ip))"
+                      message: "At most one of 'pod' or 'ip' may be set"
                   properties:
                     pod:
                       type: object
@@ -3020,11 +3012,9 @@ spec:
                       format: ipv4
                 destination:
                   type: object
-                  oneOf:
-                    - required:
-                      - pod
-                    - required:
-                      - ip
+                  x-kubernetes-validations:
+                    - rule: "!(has(self.pod) && has(self.ip))"
+                      message: "At most one of 'pod' or 'ip' may be set"
                   properties:
                     pod:
                       type: object

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -2986,24 +2986,16 @@ spec:
             spec:
               type: object
               required:
-                - source
                 - captureConfig
-                - destination
-              anyOf:
-                - properties:
-                    source:
-                      required: [pod]
-                - properties:
-                    destination:
-                      required: [pod]
+              x-kubernetes-validations:
+                - rule: "has(self.source.pod) || has(self.destination.pod)"
+                  message: "At least one of source.pod or destination.pod must be specified."
               properties:
                 source:
                   type: object
-                  oneOf:
-                    - required:
-                      - pod
-                    - required:
-                      - ip
+                  x-kubernetes-validations:
+                    - rule: "!(has(self.pod) && has(self.ip))"
+                      message: "At most one of 'pod' or 'ip' may be set"
                   properties:
                     pod:
                       type: object
@@ -3020,11 +3012,9 @@ spec:
                       format: ipv4
                 destination:
                   type: object
-                  oneOf:
-                    - required:
-                      - pod
-                    - required:
-                      - ip
+                  x-kubernetes-validations:
+                    - rule: "!(has(self.pod) && has(self.ip))"
+                      message: "At most one of 'pod' or 'ip' may be set"
                   properties:
                     pod:
                       type: object

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -2986,24 +2986,16 @@ spec:
             spec:
               type: object
               required:
-                - source
                 - captureConfig
-                - destination
-              anyOf:
-                - properties:
-                    source:
-                      required: [pod]
-                - properties:
-                    destination:
-                      required: [pod]
+              x-kubernetes-validations:
+                - rule: "has(self.source.pod) || has(self.destination.pod)"
+                  message: "At least one of source.pod or destination.pod must be specified."
               properties:
                 source:
                   type: object
-                  oneOf:
-                    - required:
-                      - pod
-                    - required:
-                      - ip
+                  x-kubernetes-validations:
+                    - rule: "!(has(self.pod) && has(self.ip))"
+                      message: "At most one of 'pod' or 'ip' may be set"
                   properties:
                     pod:
                       type: object
@@ -3020,11 +3012,9 @@ spec:
                       format: ipv4
                 destination:
                   type: object
-                  oneOf:
-                    - required:
-                      - pod
-                    - required:
-                      - ip
+                  x-kubernetes-validations:
+                    - rule: "!(has(self.pod) && has(self.ip))"
+                      message: "At most one of 'pod' or 'ip' may be set"
                   properties:
                     pod:
                       type: object

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -2986,24 +2986,16 @@ spec:
             spec:
               type: object
               required:
-                - source
                 - captureConfig
-                - destination
-              anyOf:
-                - properties:
-                    source:
-                      required: [pod]
-                - properties:
-                    destination:
-                      required: [pod]
+              x-kubernetes-validations:
+                - rule: "has(self.source.pod) || has(self.destination.pod)"
+                  message: "At least one of source.pod or destination.pod must be specified."
               properties:
                 source:
                   type: object
-                  oneOf:
-                    - required:
-                      - pod
-                    - required:
-                      - ip
+                  x-kubernetes-validations:
+                    - rule: "!(has(self.pod) && has(self.ip))"
+                      message: "At most one of 'pod' or 'ip' may be set"
                   properties:
                     pod:
                       type: object
@@ -3020,11 +3012,9 @@ spec:
                       format: ipv4
                 destination:
                   type: object
-                  oneOf:
-                    - required:
-                      - pod
-                    - required:
-                      - ip
+                  x-kubernetes-validations:
+                    - rule: "!(has(self.pod) && has(self.ip))"
+                      message: "At most one of 'pod' or 'ip' may be set"
                   properties:
                     pod:
                       type: object

--- a/docs/antctl.md
+++ b/docs/antctl.md
@@ -581,7 +581,7 @@ local path to the pcapng file as it exits. Users can also create a PacketCapture
 with `kubectl`, but `antctl` makes it easier. For more information about PacketCapture,
 refer to [PacketCapture guide](packetcapture-guide.md).
 
-To start a PacketCapture, users must provide the following arguments:
+To start a PacketCapture, users must provide `--number` and at least one of `--source` or `--destination`.
 
 * `--source` (or `-S`)
 * `--destination` (or `-D`)

--- a/docs/packetcapture-guide.md
+++ b/docs/packetcapture-guide.md
@@ -68,6 +68,7 @@ spec:
   captureConfig:
     firstN:
       number: 5
+  # Specify at least one of `source` or `destination`.
   source:
     pod:
       namespace: default

--- a/pkg/antctl/raw/packetcapture/command.go
+++ b/pkg/antctl/raw/packetcapture/command.go
@@ -136,7 +136,14 @@ func getPCName(options *packetCaptureOptions) string {
 	replace := func(s string) string {
 		return strings.ReplaceAll(s, "/", "-")
 	}
-	prefix := fmt.Sprintf("%s-%s", replace(options.source), replace(options.dest))
+	var parts []string
+	if options.source != "" {
+		parts = append(parts, replace(options.source))
+	}
+	if options.dest != "" {
+		parts = append(parts, replace(options.dest))
+	}
+	prefix := strings.Join(parts, "-")
 	if options.nowait {
 		return prefix
 	}
@@ -411,6 +418,10 @@ func parseFlow(options *packetCaptureOptions) (*v1alpha1.Packet, error) {
 }
 
 func newPacketCapture(options *packetCaptureOptions) (*v1alpha1.PacketCapture, error) {
+	if options.source == "" && options.dest == "" {
+		return nil, errors.New("must specify at least one of --source or --destination")
+	}
+
 	var src v1alpha1.Source
 	if options.source != "" {
 		src.Pod, src.IP = parseEndpoint(options.source)

--- a/pkg/antctl/raw/packetcapture/command_test.go
+++ b/pkg/antctl/raw/packetcapture/command_test.go
@@ -90,6 +90,24 @@ func TestPacketCaptureRun(t *testing.T) {
 			},
 		},
 		{
+			name: "src-pod-only",
+			option: packetCaptureOptions{
+				source: srcPod,
+				dest:   "",
+				flow:   "tcp,tcp_src=50060,tcp_dst=80",
+				number: testNum,
+			},
+		},
+		{
+			name: "dst-pod-only",
+			option: packetCaptureOptions{
+				source: "",
+				dest:   dstPod,
+				flow:   "tcp,tcp_src=50060,tcp_dst=80",
+				number: testNum,
+			},
+		},
+		{
 			name: "pod-2-ip",
 			option: packetCaptureOptions{
 				source: srcPod,
@@ -272,6 +290,14 @@ func TestNewPacketCapture(t *testing.T) {
 					},
 				},
 			},
+		},
+		{
+			name: "no-src-and-dst",
+			option: packetCaptureOptions{
+				source: "",
+				dest:   "",
+			},
+			expectErr: "must specify at least one of --source or --destination",
 		},
 		{
 			name: "no-pod",

--- a/pkg/apis/crd/v1alpha1/types.go
+++ b/pkg/apis/crd/v1alpha1/types.go
@@ -492,7 +492,7 @@ type PacketCaptureSpec struct {
 	// Timeout is the timeout for this capture session. If not specified, defaults to 60s.
 	Timeout       *int32        `json:"timeout,omitempty"`
 	CaptureConfig CaptureConfig `json:"captureConfig"`
-	// Source is the traffic source we want to perform capture on. Both `Source` and `Destination` is required
+	// Source is the traffic source we want to perform capture on. At least one of Source or Destination must be specified
 	// for a capture session, and at least one `Pod` should be present either in the source or the destination.
 	Source      Source      `json:"source"`
 	Destination Destination `json:"destination"`


### PR DESCRIPTION
Fixes: #6976 

This PR enhances the `PacketCapture` feature by making the `.spec.source` and `.spec.destination` fields optional. It addresses the limitation where users were required to specify both endpoints, preventing them from being able to capture all ingress or egress traffic for a given Pod.

With this change, users can now specify just a `source` or just a `destination`, as long as at least one of them is present in the manifest.

- [x] Update API and schema
- [x] Update BPF Program
- [x] Update Command Code 
- [x] Add unit test
- [x] Add e2e test
- [x] Update Documentation

@antoninbas @hangyan 
Let me know if the updated code looks good to you or if you'd like me to tweak anything further! 