### PR TITLE
Sync groups members for pods that turns into terminated status

### DIFF
--- a/pkg/controller/grouping/controller.go
+++ b/pkg/controller/grouping/controller.go
@@ -215,14 +215,7 @@ func (c *GroupEntityController) addPod(obj interface{}) {
 func (c *GroupEntityController) updatePod(_, curObj interface{}) {
 	curPod := curObj.(*v1.Pod)
 	klog.V(2).InfoS("Processing Pod UPDATE event", "pod", klog.KObj(curPod), "labels", curPod.Labels, "phase", curPod.Status.Phase)
-	if curPod.Status.Phase == v1.PodSucceeded || curPod.Status.Phase == v1.PodFailed {
-		// Once a Pod is in "Succeeded" or "Failed" phase, Kubernetes will not restart the same Pod.
-		// In groupEntityIndex, this should be considered as a terminal event, and the Pod should be
-		// excluded from any Network Policy computations in appliedTo or address groups.
-		c.groupEntityIndex.DeletePod(curPod)
-	} else {
-		c.groupEntityIndex.AddPod(curPod)
-	}
+	c.groupEntityIndex.AddPod(curPod)
 }
 
 func (c *GroupEntityController) deletePod(old interface{}) {

--- a/pkg/controller/grouping/controller_test.go
+++ b/pkg/controller/grouping/controller_test.go
@@ -15,22 +15,21 @@
 package grouping
 
 import (
-	"context"
 	"reflect"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 
 	"antrea.io/antrea/pkg/apis/crd/v1alpha2"
 	fakeversioned "antrea.io/antrea/pkg/client/clientset/versioned/fake"
 	crdinformers "antrea.io/antrea/pkg/client/informers/externalversions"
+	"antrea.io/antrea/pkg/features"
 )
 
 const informerDefaultResync = 30 * time.Second
@@ -69,6 +68,7 @@ func TestGroupEntityControllerRun(t *testing.T) {
 				eventChanSize = originalEventChanSize
 			}()
 
+			featuregatetesting.SetFeatureGateDuringTest(t, features.DefaultFeatureGate, features.AntreaPolicy, tt.antreaPolicyEnabled)
 			var objs []runtime.Object
 			for _, pod := range tt.initialPods {
 				objs = append(objs, pod)
@@ -105,61 +105,6 @@ func TestGroupEntityControllerRun(t *testing.T) {
 			}, time.Second, 10*time.Millisecond, "GroupEntityIndex hasn't been synced in 1 second after starting GroupEntityController")
 		})
 	}
-}
-
-func TestGroupEntityControllerHandlePodUpdate(t *testing.T) {
-	var objs []runtime.Object
-	initialPods := []*v1.Pod{podFoo1, podFoo2, podBar1}
-	initialNamespaces := []*v1.Namespace{nsDefault, nsOther}
-	initialGroups := []*group{groupPodFooType1, groupPodFooType2, groupPodBarType1, groupPodFooAllNamespaceType1}
-	for _, pod := range initialPods {
-		objs = append(objs, pod)
-	}
-	for _, namespace := range initialNamespaces {
-		objs = append(objs, namespace)
-	}
-	index := NewGroupEntityIndex()
-	for _, group := range initialGroups {
-		index.AddGroup(group.groupType, group.groupName, group.groupSelector)
-	}
-
-	client := fake.NewSimpleClientset(objs...)
-	crdClient := fakeversioned.NewSimpleClientset()
-	informerFactory := informers.NewSharedInformerFactory(client, informerDefaultResync)
-	crdInformerFactory := crdinformers.NewSharedInformerFactory(crdClient, informerDefaultResync)
-	stopCh := make(chan struct{})
-	defer close(stopCh)
-
-	c := NewGroupEntityController(index, informerFactory.Core().V1().Pods(), informerFactory.Core().V1().Namespaces(), crdInformerFactory.Crd().V1alpha2().ExternalEntities())
-	informerFactory.Start(stopCh)
-	crdInformerFactory.Start(stopCh)
-	go c.groupEntityIndex.Run(stopCh)
-	go c.Run(stopCh)
-	// Wait for the GroupEntityIndex to be synced
-	require.Eventually(t, func() bool {
-		return index.HasSynced()
-	}, time.Second, 10*time.Millisecond, "GroupEntityIndex hasn't been synced in 1 second after starting GroupEntityController")
-
-	podFoo1Succeeded := podFoo1.DeepCopy()
-	podFoo1Succeeded.Status.Phase = v1.PodSucceeded
-	client.CoreV1().Pods("default").Update(context.TODO(), podFoo1Succeeded, metav1.UpdateOptions{})
-	podFoo2Failed := podFoo2.DeepCopy()
-	podFoo2Failed.Status.Phase = v1.PodFailed
-	client.CoreV1().Pods("default").Update(context.TODO(), podFoo2Failed, metav1.UpdateOptions{})
-	podBar1Running := podBar1.DeepCopy()
-	podBar1Running.Status.Phase = v1.PodRunning
-	client.CoreV1().Pods("default").Update(context.TODO(), podBar1Running, metav1.UpdateOptions{})
-
-	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		// The following two Foo Pods should be removed from all groups as they are terminated
-		_, groupForFoo1Found := index.GetGroupsForPod(podFoo1.Namespace, podFoo1.Name)
-		assert.False(t, groupForFoo1Found, "Succeeded Pod should be removed from the GroupEntityIndex")
-		_, groupForFoo2Found := index.GetGroupsForPod(podFoo2.Namespace, podFoo2.Name)
-		assert.False(t, groupForFoo2Found, "Failed Pod should be removed from the GroupEntityIndex")
-		// The following Bar Pod should still remain in the group that selects it
-		_, groupForBar1Found := index.GetGroupsForPod(podBar1.Namespace, podBar1.Name)
-		assert.True(t, groupForBar1Found, "Running Pod should remain in the GroupEntityIndex")
-	}, time.Second, 10*time.Millisecond, "GroupEntityIndex did not process Pod update event correctly")
 }
 
 func TestPodIPsIndexFunc(t *testing.T) {

--- a/pkg/controller/grouping/group_entity_index_test.go
+++ b/pkg/controller/grouping/group_entity_index_test.go
@@ -473,6 +473,39 @@ func TestGroupEntityIndexEventHandlers(t *testing.T) {
 			expectedGroupsCalled: map[GroupType][]string{},
 		},
 		{
+			name:           "update an existing pod's phase to running",
+			existingPods:   []*v1.Pod{podFoo1, podBar1, podFoo1InOtherNamespace},
+			existingGroups: []*group{groupPodFooType1, groupPodFooAllNamespaceType1, groupEEFooType1, groupPodAllNamespaceType1},
+			inputEvent: func(i *GroupEntityIndex) {
+				i.AddPod(copyAndMutatePod(podFoo1, func(pod *v1.Pod) {
+					pod.Status.Phase = v1.PodRunning
+				}))
+			},
+			expectedGroupsCalled: map[GroupType][]string{},
+		},
+		{
+			name:           "update an existing pod's phase to succeeded",
+			existingPods:   []*v1.Pod{podFoo1, podBar1, podFoo1InOtherNamespace},
+			existingGroups: []*group{groupPodFooType1, groupPodFooAllNamespaceType1, groupEEFooType1, groupPodAllNamespaceType1},
+			inputEvent: func(i *GroupEntityIndex) {
+				i.AddPod(copyAndMutatePod(podFoo1, func(pod *v1.Pod) {
+					pod.Status.Phase = v1.PodSucceeded
+				}))
+			},
+			expectedGroupsCalled: map[GroupType][]string{groupType1: {groupPodFooType1.groupName, groupPodFooAllNamespaceType1.groupName, groupPodAllNamespaceType1.groupName}},
+		},
+		{
+			name:           "update an existing pod's phase to failed",
+			existingPods:   []*v1.Pod{podFoo1, podBar1, podFoo1InOtherNamespace},
+			existingGroups: []*group{groupPodFooType1, groupPodFooAllNamespaceType1, groupPodBarType1, groupPodAllNamespaceType1},
+			inputEvent: func(i *GroupEntityIndex) {
+				i.AddPod(copyAndMutatePod(podBar1, func(pod *v1.Pod) {
+					pod.Status.Phase = v1.PodFailed
+				}))
+			},
+			expectedGroupsCalled: map[GroupType][]string{groupType1: {groupPodBarType1.groupName, groupPodAllNamespaceType1.groupName}},
+		},
+		{
 			name:                     "delete an existing pod",
 			existingPods:             []*v1.Pod{podFoo1, podBar1, podFoo1InOtherNamespace},
 			existingExternalEntities: []*v1alpha2.ExternalEntity{eeFoo1, eeBar1, eeFoo1InOtherNamespace},


### PR DESCRIPTION
Once a Pod is updated to terminated state (succeeded or failed), the selectorItems
in GroupEntityIndex need to be notified so that they are excluded from any Network
Policy computations in appliedTo or address groups.