### PR TITLE
Automated cherry pick of #7210: Fix rollback when configureContainerLinkVeth fails (#7210)
#7213: Fix the interface name used for interface deletion (#7213)

### DIFF
--- a/pkg/agent/cniserver/interface_configuration_linux.go
+++ b/pkg/agent/cniserver/interface_configuration_linux.go
@@ -262,7 +262,7 @@ func (ic *ifConfigurator) configureContainerLinkVeth(
 		defer func() {
 			if !success {
 				klog.V(2).InfoS("Deleting veth devices for container during rollback", "containerID", containerID)
-				if err := ipDelLinkByName(hostVeth.Name); err != nil && err != ip.ErrLinkNotFound {
+				if err := ipDelLinkByName(containerVeth.Name); err != nil && err != ip.ErrLinkNotFound {
 					klog.ErrorS(err, "Failed to delete veth devices for container during rollback", "containerID", containerID)
 				}
 			}

--- a/pkg/agent/cniserver/interface_configuration_linux_test.go
+++ b/pkg/agent/cniserver/interface_configuration_linux_test.go
@@ -160,9 +160,11 @@ func TestConfigureContainerLink(t *testing.T) {
 		podSriovVFDeviceID        string
 		renameIntefaceErr         error
 		setupVethErr              error
+		delLinkErr                error
 		ipamConfigureIfaceErr     error
 		ethtoolEthTXHWCsumOffErr  error
 		expectErr                 error
+		delLinkCalled             bool
 	}{
 		{
 			name:                      "container-vethpair-success",
@@ -177,11 +179,13 @@ func TestConfigureContainerLink(t *testing.T) {
 			ovsHardwareOffloadEnabled: false,
 			ipamConfigureIfaceErr:     fmt.Errorf("unable to configure container IPAM"),
 			expectErr:                 fmt.Errorf("failed to configure IP address for container %s: unable to configure container IPAM", podContainerID),
+			delLinkCalled:             true,
 		}, {
 			name:                      "container-hwoffload-failure",
 			ovsHardwareOffloadEnabled: true,
 			ethtoolEthTXHWCsumOffErr:  fmt.Errorf("unable to disable offloading"),
 			expectErr:                 fmt.Errorf("error when disabling TX checksum offload on container veth: unable to disable offloading"),
+			delLinkCalled:             true,
 		}, {
 			name:                      "br-sriov-offloading-disable",
 			ovsHardwareOffloadEnabled: false,
@@ -212,7 +216,9 @@ func TestConfigureContainerLink(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			var delLinkCalled bool
 			defer mockSetupVethWithName(tc.setupVethErr, 1, 2)()
+			defer mockDelLinkByName(tc.delLinkErr, &delLinkCalled)()
 			defer mockRenameInterface(tc.renameIntefaceErr)()
 			defer mockIPAMConfigureIface(tc.ipamConfigureIfaceErr)()
 			defer mockEthtoolTXHWCsumOff(tc.ethtoolEthTXHWCsumOffErr)()
@@ -255,6 +261,7 @@ func TestConfigureContainerLink(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
+			assert.Equal(t, tc.delLinkCalled, delLinkCalled)
 		})
 	}
 }
@@ -806,6 +813,17 @@ func mockSetupVethWithName(setupVethErr error, containerIndex, hostIndex int) fu
 	}
 	return func() {
 		ipSetupVethWithName = originalIPSetupVethWithName
+	}
+}
+
+func mockDelLinkByName(err error, called *bool) func() {
+	origin := ipDelLinkByName
+	ipDelLinkByName = func(name string) error {
+		*called = true
+		return err
+	}
+	return func() {
+		ipDelLinkByName = origin
 	}
 }
 

--- a/pkg/agent/cniserver/interface_configuration_linux_test.go
+++ b/pkg/agent/cniserver/interface_configuration_linux_test.go
@@ -164,7 +164,7 @@ func TestConfigureContainerLink(t *testing.T) {
 		ipamConfigureIfaceErr     error
 		ethtoolEthTXHWCsumOffErr  error
 		expectErr                 error
-		delLinkCalled             bool
+		deletedLink               string
 	}{
 		{
 			name:                      "container-vethpair-success",
@@ -179,13 +179,13 @@ func TestConfigureContainerLink(t *testing.T) {
 			ovsHardwareOffloadEnabled: false,
 			ipamConfigureIfaceErr:     fmt.Errorf("unable to configure container IPAM"),
 			expectErr:                 fmt.Errorf("failed to configure IP address for container %s: unable to configure container IPAM", podContainerID),
-			delLinkCalled:             true,
+			deletedLink:               containerIfaceName,
 		}, {
 			name:                      "container-hwoffload-failure",
 			ovsHardwareOffloadEnabled: true,
 			ethtoolEthTXHWCsumOffErr:  fmt.Errorf("unable to disable offloading"),
 			expectErr:                 fmt.Errorf("error when disabling TX checksum offload on container veth: unable to disable offloading"),
-			delLinkCalled:             true,
+			deletedLink:               containerIfaceName,
 		}, {
 			name:                      "br-sriov-offloading-disable",
 			ovsHardwareOffloadEnabled: false,
@@ -216,9 +216,9 @@ func TestConfigureContainerLink(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			var delLinkCalled bool
+			var deletedLink string
 			defer mockSetupVethWithName(tc.setupVethErr, 1, 2)()
-			defer mockDelLinkByName(tc.delLinkErr, &delLinkCalled)()
+			defer mockDelLinkByName(tc.delLinkErr, &deletedLink)()
 			defer mockRenameInterface(tc.renameIntefaceErr)()
 			defer mockIPAMConfigureIface(tc.ipamConfigureIfaceErr)()
 			defer mockEthtoolTXHWCsumOff(tc.ethtoolEthTXHWCsumOffErr)()
@@ -261,7 +261,7 @@ func TestConfigureContainerLink(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
-			assert.Equal(t, tc.delLinkCalled, delLinkCalled)
+			assert.Equal(t, tc.deletedLink, deletedLink)
 		})
 	}
 }
@@ -809,17 +809,17 @@ func mockSetupVethWithName(setupVethErr error, containerIndex, hostIndex int) fu
 		}
 		containerInterface := net.Interface{Index: containerIndex, MTU: mtu, HardwareAddr: containerVethMac, Name: contVethName, Flags: net.FlagUp}
 		hostInterface := net.Interface{Index: hostIndex, MTU: mtu, HardwareAddr: hostVethMac, Name: hostVethName, Flags: net.FlagUp}
-		return containerInterface, hostInterface, nil
+		return hostInterface, containerInterface, nil
 	}
 	return func() {
 		ipSetupVethWithName = originalIPSetupVethWithName
 	}
 }
 
-func mockDelLinkByName(err error, called *bool) func() {
+func mockDelLinkByName(err error, deletedLink *string) func() {
 	origin := ipDelLinkByName
 	ipDelLinkByName = func(name string) error {
-		*called = true
+		*deletedLink = name
 		return err
 	}
 	return func() {


### PR DESCRIPTION
Cherry pick of #7210 #7213 on release-2.3.

#7210: Fix rollback when configureContainerLinkVeth fails (#7210)
#7213: Fix the interface name used for interface deletion (#7213)

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.