### PR TITLE
Automated cherry pick of #7210: Fix rollback when configureContainerLinkVeth fails (#7210)
#7213: Fix the interface name used for interface deletion (#7213)

### DIFF
--- a/pkg/agent/cniserver/interface_configuration_linux.go
+++ b/pkg/agent/cniserver/interface_configuration_linux.go
@@ -269,7 +269,7 @@ func (ic *ifConfigurator) configureContainerLinkVeth(
 		defer func() {
 			if !success {
 				klog.V(2).InfoS("Deleting veth devices for container during rollback", "containerID", containerID)
-				if err := ipDelLinkByName(hostVeth.Name); err != nil && err != ip.ErrLinkNotFound {
+				if err := ipDelLinkByName(containerVeth.Name); err != nil && err != ip.ErrLinkNotFound {
 					klog.ErrorS(err, "Failed to delete veth devices for container during rollback", "containerID", containerID)
 				}
 			}

--- a/pkg/agent/cniserver/interface_configuration_linux.go
+++ b/pkg/agent/cniserver/interface_configuration_linux.go
@@ -48,6 +48,7 @@ const (
 // Declared variables for test
 var (
 	ipSetupVethWithName            = ip.SetupVethWithName
+	ipDelLinkByName                = ip.DelLinkByName
 	ipamConfigureIface             = ipam.ConfigureIface
 	ethtoolTXHWCsumOff             = ethtool.EthtoolTXHWCsumOff
 	renameInterface                = util.RenameInterface
@@ -264,6 +265,15 @@ func (ic *ifConfigurator) configureContainerLinkVeth(
 		if err != nil {
 			return fmt.Errorf("failed to create veth devices for container %s: %v", containerID, err)
 		}
+		success := false
+		defer func() {
+			if !success {
+				klog.V(2).InfoS("Deleting veth devices for container during rollback", "containerID", containerID)
+				if err := ipDelLinkByName(hostVeth.Name); err != nil && err != ip.ErrLinkNotFound {
+					klog.ErrorS(err, "Failed to delete veth devices for container during rollback", "containerID", containerID)
+				}
+			}
+		}()
 		containerIface.Mac = podMAC.String()
 		hostIface.Mac = hostVeth.HardwareAddr.String()
 		// Disable TX checksum offloading when it's configured explicitly.
@@ -278,6 +288,7 @@ func (ic *ifConfigurator) configureContainerLinkVeth(
 		if err := ipamConfigureIface(containerIface.Name, result); err != nil {
 			return fmt.Errorf("failed to configure IP address for container %s: %v", containerID, err)
 		}
+		success = true
 		return nil
 	}); err != nil {
 		return err


### PR DESCRIPTION
Cherry pick of #7210 #7213 on release-2.2.

#7210: Fix rollback when configureContainerLinkVeth fails (#7210)
#7213: Fix the interface name used for interface deletion (#7213)

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.