### PR TITLE
Remove unnecessary logs about NPL cleanup

### DIFF
--- a/pkg/agent/nodeportlocal/portcache/port_table_others.go
+++ b/pkg/agent/nodeportlocal/portcache/port_table_others.go
@@ -137,16 +137,6 @@ func (pt *PortTable) DeleteRule(podKey string, podPort int, protocol string) err
 	return pt.deleteRule(data)
 }
 
-func (pt *PortTable) DeleteRulesForPod(podKey string) error {
-	pt.tableLock.Lock()
-	defer pt.tableLock.Unlock()
-	podEntries := pt.getDataForPod(podKey)
-	for _, podEntry := range podEntries {
-		return pt.deleteRule(podEntry)
-	}
-	return nil
-}
-
 // syncRules ensures that contents of the port table matches the iptables rules present on the Node.
 func (pt *PortTable) syncRules() error {
 	pt.tableLock.Lock()

--- a/pkg/agent/nodeportlocal/portcache/port_table_windows.go
+++ b/pkg/agent/nodeportlocal/portcache/port_table_windows.go
@@ -141,17 +141,3 @@ func (pt *PortTable) DeleteRule(podKey string, podPort int, protocol string) err
 	pt.deletePortTableCache(data)
 	return nil
 }
-
-func (pt *PortTable) DeleteRulesForPod(podKey string) error {
-	pt.tableLock.Lock()
-	defer pt.tableLock.Unlock()
-	podEntries := pt.getDataForPod(podKey)
-	for _, podEntry := range podEntries {
-		protocolSocketData := podEntry.Protocol
-		if err := pt.PodPortRules.DeleteRule(podEntry.NodePort, podEntry.PodIP, podEntry.PodPort, protocolSocketData.Protocol); err != nil {
-			return err
-		}
-		pt.deletePortTableCache(podEntry)
-	}
-	return nil
-}

--- a/pkg/agent/nodeportlocal/portcache/port_table_windows_test.go
+++ b/pkg/agent/nodeportlocal/portcache/port_table_windows_test.go
@@ -88,42 +88,6 @@ func TestDeleteRule(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestDeleteRulesForPod(t *testing.T) {
-	mockCtrl := gomock.NewController(t)
-	mockPortRules := rulestesting.NewMockPodPortRules(mockCtrl)
-	mockPortOpener := portcachetesting.NewMockLocalPortOpener(mockCtrl)
-	portTable := newPortTable(mockPortRules, mockPortOpener)
-
-	npData := []*NodePortData{
-		{
-			PodKey:   podKey,
-			NodePort: startPort,
-			PodIP:    podIP,
-			PodPort:  1001,
-			Protocol: ProtocolSocketData{
-				Protocol: "tcp",
-			},
-		},
-		{
-			PodKey:   podKey,
-			NodePort: startPort + 1,
-			PodIP:    podIP,
-			PodPort:  1002,
-			Protocol: ProtocolSocketData{
-				Protocol: "udp",
-			},
-		},
-	}
-
-	for _, data := range npData {
-		portTable.addPortTableCache(data)
-		mockPortRules.EXPECT().DeleteRule(data.NodePort, podIP, data.PodPort, data.Protocol.Protocol)
-	}
-
-	err := portTable.DeleteRulesForPod(podKey)
-	require.NoError(t, err)
-}
-
 func TestAddRule(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	mockPortRules := rulestesting.NewMockPodPortRules(mockCtrl)


### PR DESCRIPTION
A NPL cleanup log was being generated every time a Pod without NPL enabled was created, updated, or deleted. This could flood the logs and potentially confuse users.

This patch removes the code that handles the delete-all-rules case specifically and logs the event unconditionally even if nothing is done. It also reduces code redundancy.