### PR TITLE
FlowAggregator improvements

### DIFF
--- a/docs/antctl.md
+++ b/docs/antctl.md
@@ -766,14 +766,15 @@ the following:
 
 * number of records received by the collector process in the Flow Aggregator
 * number of records exported by the Flow Aggregator
-* number of active flows that are being tracked
+* number of records dropped by the Flow Aggregator (Proxy mode)
+* number of active flows that are being tracked (Aggregate mode)
 * number of exporters connected to the Flow Aggregator
 
 Example outputs of record metrics:
 
 ```bash
-RECORDS-EXPORTED RECORDS-RECEIVED FLOWS EXPORTERS-CONNECTED
-46               118              7     2      
+RECORDS-EXPORTED RECORDS-RECEIVED RECORDS-DROPPED FLOWS EXPORTERS-CONNECTED
+46               118              0               7     2
 ```
 
 ### Multi-cluster commands

--- a/pkg/flowaggregator/apis/types.go
+++ b/pkg/flowaggregator/apis/types.go
@@ -57,6 +57,7 @@ func (r FlowRecordsResponse) SortRows() bool {
 type RecordMetricsResponse struct {
 	NumRecordsExported     int64 `json:"numRecordsExported,omitempty"`
 	NumRecordsReceived     int64 `json:"numRecordsReceived,omitempty"`
+	NumRecordsDropped      int64 `json:"numRecordsDropped,omitempty"`
 	NumFlows               int64 `json:"numFlows,omitempty"`
 	NumConnToCollector     int64 `json:"numConnToCollector,omitempty"`
 	WithClickHouseExporter bool  `json:"withClickHouseExporter,omitempty"`
@@ -66,13 +67,14 @@ type RecordMetricsResponse struct {
 }
 
 func (r RecordMetricsResponse) GetTableHeader() []string {
-	return []string{"RECORDS-EXPORTED", "RECORDS-RECEIVED", "FLOWS", "EXPORTERS-CONNECTED", "CLICKHOUSE-EXPORTER", "S3-EXPORTER", "LOG-EXPORTER", "IPFIX-EXPORTER"}
+	return []string{"RECORDS-EXPORTED", "RECORDS-RECEIVED", "RECORDS-DROPPED", "FLOWS", "EXPORTERS-CONNECTED", "CLICKHOUSE-EXPORTER", "S3-EXPORTER", "LOG-EXPORTER", "IPFIX-EXPORTER"}
 }
 
 func (r RecordMetricsResponse) GetTableRow(maxColumnLength int) []string {
 	return []string{
 		strconv.Itoa(int(r.NumRecordsExported)),
 		strconv.Itoa(int(r.NumRecordsReceived)),
+		strconv.Itoa(int(r.NumRecordsDropped)),
 		strconv.Itoa(int(r.NumFlows)),
 		strconv.Itoa(int(r.NumConnToCollector)),
 		strconv.FormatBool(r.WithClickHouseExporter),

--- a/pkg/flowaggregator/apiserver/handlers/recordmetrics/handler.go
+++ b/pkg/flowaggregator/apiserver/handlers/recordmetrics/handler.go
@@ -31,6 +31,7 @@ func HandleFunc(faq querier.FlowAggregatorQuerier) http.HandlerFunc {
 		metricsResponse := apis.RecordMetricsResponse{
 			NumRecordsExported:     metrics.NumRecordsExported,
 			NumRecordsReceived:     metrics.NumRecordsReceived,
+			NumRecordsDropped:      metrics.NumRecordsDropped,
 			NumFlows:               metrics.NumFlows,
 			NumConnToCollector:     metrics.NumConnToCollector,
 			WithClickHouseExporter: metrics.WithClickHouseExporter,

--- a/pkg/flowaggregator/apiserver/handlers/recordmetrics/handler_test.go
+++ b/pkg/flowaggregator/apiserver/handlers/recordmetrics/handler_test.go
@@ -34,6 +34,7 @@ func TestRecordMetricsQuery(t *testing.T) {
 	faq.EXPECT().GetRecordMetrics().Return(querier.Metrics{
 		NumRecordsExported:     20,
 		NumRecordsReceived:     15,
+		NumRecordsDropped:      5,
 		NumFlows:               30,
 		NumConnToCollector:     1,
 		WithClickHouseExporter: true,
@@ -55,6 +56,7 @@ func TestRecordMetricsQuery(t *testing.T) {
 	assert.Equal(t, apis.RecordMetricsResponse{
 		NumRecordsExported:     20,
 		NumRecordsReceived:     15,
+		NumRecordsDropped:      5,
 		NumFlows:               30,
 		NumConnToCollector:     1,
 		WithClickHouseExporter: true,
@@ -63,6 +65,6 @@ func TestRecordMetricsQuery(t *testing.T) {
 		WithIPFIXExporter:      true,
 	}, received)
 
-	assert.Equal(t, received.GetTableRow(0), []string{"20", "15", "30", "1", "true", "true", "true", "true"})
+	assert.Equal(t, received.GetTableRow(0), []string{"20", "15", "5", "30", "1", "true", "true", "true", "true"})
 
 }

--- a/pkg/flowaggregator/flowaggregator_test.go
+++ b/pkg/flowaggregator/flowaggregator_test.go
@@ -690,6 +690,7 @@ func TestFlowAggregator_updateFlowAggregator(t *testing.T) {
 func TestFlowAggregator_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockPodStore := podstoretest.NewMockInterface(ctrl)
+	mockPodStore.EXPECT().HasSynced().Return(true)
 	mockIPFIXExporter, mockClickHouseExporter, mockS3Exporter, mockLogExporter := mockExporters(t, ctrl, nil)
 	mockCollectingProcess := ipfixtesting.NewMockIPFIXCollectingProcess(ctrl)
 	mockAggregationProcess := ipfixtesting.NewMockIPFIXAggregationProcess(ctrl)

--- a/pkg/flowaggregator/querier/querier.go
+++ b/pkg/flowaggregator/querier/querier.go
@@ -21,6 +21,7 @@ import (
 type Metrics struct {
 	NumRecordsExported     int64
 	NumRecordsReceived     int64
+	NumRecordsDropped      int64
 	NumFlows               int64
 	NumConnToCollector     int64
 	WithClickHouseExporter bool

--- a/pkg/util/podstore/testing/mock_podstore.go
+++ b/pkg/util/podstore/testing/mock_podstore.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Antrea Authors
+// Copyright 2025 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -69,6 +69,20 @@ func (m *MockInterface) GetPodByIPAndTime(ip string, startTime time.Time) (*v1.P
 func (mr *MockInterfaceMockRecorder) GetPodByIPAndTime(ip, startTime any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPodByIPAndTime", reflect.TypeOf((*MockInterface)(nil).GetPodByIPAndTime), ip, startTime)
+}
+
+// HasSynced mocks base method.
+func (m *MockInterface) HasSynced() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasSynced")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// HasSynced indicates an expected call of HasSynced.
+func (mr *MockInterfaceMockRecorder) HasSynced() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasSynced", reflect.TypeOf((*MockInterface)(nil).HasSynced))
 }
 
 // Run mocks base method.


### PR DESCRIPTION
* Use exponential backoff when reconnecting to IPFIX collector. This is especially important in Proxy mode, where previously we would try to reconnect for every new proxied record, and log an error in case of failure. We now enforce a backoff and skip logging an error when reconnection is not attempted because of the backoff delay (instead we increment a counter).
* Reset the IPFIX exporting process when a flush operation fails. This also helps to avoid repeated error logs.
* Wait for initial sync of the PodStore before collecting records, to avoid error logs about missing Pod information.