### PR TITLE
change LastSendTime/LastRecvTime type from metav1.Time to metav1.Micr…

### DIFF
--- a/pkg/agent/monitortool/latency_store.go
+++ b/pkg/agent/monitortool/latency_store.go
@@ -274,8 +274,8 @@ func (l *LatencyStore) ConvertList(currentNodeName string) []statsv1alpha1.PeerN
 			}
 			entry := statsv1alpha1.TargetIPLatencyStats{
 				TargetIP:                   nodeIPStr,
-				LastSendTime:               metav1.NewTime(latencyEntry.LastSendTime),
-				LastRecvTime:               metav1.NewTime(latencyEntry.LastRecvTime),
+				LastSendTime:               metav1.NewMicroTime(latencyEntry.LastSendTime),
+				LastRecvTime:               metav1.NewMicroTime(latencyEntry.LastRecvTime),
 				LastMeasuredRTTNanoseconds: latencyEntry.LastMeasuredRTT.Nanoseconds(),
 			}
 			targetIPLatencyStats = append(targetIPLatencyStats, entry)

--- a/pkg/apis/stats/v1alpha1/types.go
+++ b/pkg/apis/stats/v1alpha1/types.go
@@ -175,9 +175,9 @@ type TargetIPLatencyStats struct {
 	// The target IP address.
 	TargetIP string `json:"targetIP,omitempty" protobuf:"bytes,1,opt,name=targetIP"`
 	// The timestamp of the last sent packet.
-	LastSendTime metav1.Time `json:"lastSendTime,omitempty" protobuf:"bytes,2,opt,name=lastSendTime"`
+	LastSendTime metav1.MicroTime `json:"lastSendTime,omitempty" protobuf:"bytes,2,opt,name=lastSendTime"`
 	// The timestamp of the last received packet.
-	LastRecvTime metav1.Time `json:"lastRecvTime,omitempty" protobuf:"bytes,3,opt,name=lastRecvTime"`
+	LastRecvTime metav1.MicroTime `json:"lastRecvTime,omitempty" protobuf:"bytes,3,opt,name=lastRecvTime"`
 	// The last measured RTT for this target IP, in nanoseconds.
 	LastMeasuredRTTNanoseconds int64 `json:"lastMeasuredRTTNanoseconds,omitempty" protobuf:"varint,4,opt,name=lastMeasuredRTTNanoseconds"`
 }


### PR DESCRIPTION
change has been tested.
------before------
kubectl get nodelatencystats/ceph-04 -oyaml
apiVersion: stats.antrea.io/v1alpha1
kind: NodeLatencyStats
metadata:
  creationTimestamp: "2025-06-16T07:36:07Z"
  managedFields:
  - apiVersion: stats.antrea.io/v1alpha1
    fieldsType: FieldsV1
    fieldsV1:
      f:peerNodeLatencyStats: {}
    manager: antrea-agent
    operation: Update
    time: "2025-06-16T07:36:07Z"
  name: ceph-04
peerNodeLatencyStats:
- nodeName: ceph-03
  targetIPLatencyStats:
  - lastMeasuredRTTNanoseconds: 209787
    lastRecvTime: "2025-06-16T07:35:07Z"
    lastSendTime: "2025-06-16T07:36:07Z"
    targetIP: 10.124.1.1
- nodeName: ceph-05
  targetIPLatencyStats:
  - lastMeasuredRTTNanoseconds: 242272
    lastRecvTime: "2025-06-16T07:35:07Z"
    lastSendTime: "2025-06-16T07:36:07Z"
    targetIP: 10.124.2.1
------after--------
kubectl get nodelatencystats/ceph-04 -oyaml
apiVersion: stats.antrea.io/v1alpha1
kind: NodeLatencyStats
metadata:
  creationTimestamp: "2025-06-16T10:04:02Z"
  managedFields:
  - apiVersion: stats.antrea.io/v1alpha1
    fieldsType: FieldsV1
    fieldsV1:
      f:peerNodeLatencyStats: {}
    manager: antrea-agent
    operation: Update
    time: "2025-06-16T10:04:02Z"
  name: ceph-04
peerNodeLatencyStats:
- nodeName: ceph-03
  targetIPLatencyStats:
  - lastMeasuredRTTNanoseconds: 286393
    lastRecvTime: "2025-06-16T10:03:02.757939Z"
    lastSendTime: "2025-06-16T10:04:02.757015Z"
    targetIP: 10.124.1.1
- nodeName: ceph-05
  targetIPLatencyStats:
  - lastMeasuredRTTNanoseconds: 241721
    lastRecvTime: "2025-06-16T10:03:02.758023Z"
    lastSendTime: "2025-06-16T10:04:02.757116Z"
    targetIP: 10.124.2.1