### PR TITLE
Periodically sync permanent neighbors to ensure route correctness

### DIFF
--- a/pkg/agent/route/route_linux_test.go
+++ b/pkg/agent/route/route_linux_test.go
@@ -115,6 +115,37 @@ func TestSyncRoutes(t *testing.T) {
 	assert.NoError(t, c.syncRoute())
 }
 
+func TestSyncNeighbors(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockNetlink := netlinktest.NewMockInterface(ctrl)
+
+	c := &Client{
+		netlink:          mockNetlink,
+		proxyAll:         true,
+		nodeNeighbors:    sync.Map{},
+		serviceNeighbors: sync.Map{},
+		nodeConfig: &config.NodeConfig{
+			GatewayConfig: &config.GatewayConfig{LinkIndex: 10, IPv4: net.ParseIP("192.168.0.1"), IPv6: net.ParseIP("aabb:ccdd::1")},
+			PodIPv4CIDR:   ip.MustParseCIDR("192.168.0.0/24"),
+			PodIPv6CIDR:   ip.MustParseCIDR("aabb:ccdd::/64"),
+		},
+	}
+	nodeNeighbor1 := &netlink.Neigh{LinkIndex: 10, Family: netlink.FAMILY_V6, State: netlink.NUD_PERMANENT, IP: net.ParseIP("aabb:ccee::/64"), HardwareAddr: globalVMAC}
+	nodeNeighbor2 := &netlink.Neigh{LinkIndex: 10, Family: netlink.FAMILY_V6, State: netlink.NUD_PERMANENT, IP: net.ParseIP("aabb:ccee::/64"), HardwareAddr: globalVMAC}
+	serviceNeighbor1 := &netlink.Neigh{LinkIndex: 10, Family: netlink.FAMILY_V4, State: netlink.NUD_PERMANENT, IP: config.VirtualServiceIPv4, HardwareAddr: globalVMAC}
+	serviceNeighbor2 := &netlink.Neigh{LinkIndex: 10, Family: netlink.FAMILY_V6, State: netlink.NUD_PERMANENT, IP: config.VirtualServiceIPv6, HardwareAddr: globalVMAC}
+	mockNetlink.EXPECT().NeighList(10, netlink.FAMILY_ALL).Return([]*netlink.Neigh{nodeNeighbor1, serviceNeighbor1}, nil)
+	mockNetlink.EXPECT().NeighSet(nodeNeighbor2)
+	mockNetlink.EXPECT().NeighSet(serviceNeighbor2)
+
+	c.nodeNeighbors.Store("aabb:ccee::/64", nodeNeighbor1)
+	c.nodeNeighbors.Store("aabb:ccdd::/64", nodeNeighbor2)
+	c.serviceNeighbors.Store(config.VirtualServiceIPv4.String(), serviceNeighbor1)
+	c.serviceNeighbors.Store(config.VirtualServiceIPv6.String(), serviceNeighbor2)
+
+	assert.NoError(t, c.syncNeighbor())
+}
+
 func TestRestoreEgressRoutesAndRules(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockNetlink := netlinktest.NewMockInterface(ctrl)


### PR DESCRIPTION
In the current implementation, permanent neighbors are installed only once at startup. However, these neighbors are critical for the functionality of routes managed by antrea-agent. If they are accidentally deleted, the affected routes will break and remain non-functional until antrea-agent is restarted.

This commit adds periodic syncing of permanent neighbors to ensure they are reinstalled automatically if missing, improving the robustness and reliability of route management.