### PR TITLE
Initialize SRIOV interfaces via NetworkStatus when agent restarts

### DIFF
--- a/pkg/agent/cniserver/ipam/antrea_ipam_controller.go
+++ b/pkg/agent/cniserver/ipam/antrea_ipam_controller.go
@@ -221,7 +221,7 @@ func (c *AntreaIPAMController) getPoolAllocatorByPod(namespace, podName string) 
 	return mineTrue, allocator, ips, reservedOwner, err
 }
 
-// Look up IPPools by matching PodOwnder.
+// Look up IPPools by matching PodOwner.
 func (c *AntreaIPAMController) getPoolAllocatorsByOwner(podOwner *crdv1b1.PodOwner) ([]*poolallocator.IPPoolAllocator, error) {
 	var allocators []*poolallocator.IPPoolAllocator
 	ipPools, _ := c.ipPoolInformer.Informer().GetIndexer().ByIndex(podIndex,

--- a/pkg/agent/cniserver/secondary.go
+++ b/pkg/agent/cniserver/secondary.go
@@ -56,7 +56,7 @@ func (pc *podConfigurator) ConfigureSriovSecondaryInterface(
 	containerConfig := buildContainerConfig(hostInterfaceName, containerID, podName, podNamespace,
 		containerNetNS, containerIface, result.IPs, 0)
 	pc.ifaceStore.AddInterface(containerConfig)
-
+	containerIface.PciID = podSriovVFDeviceID
 	if result.IPs != nil {
 		if err = pc.ifConfigurator.advertiseContainerAddr(containerNetNS, containerIface.Name, result); err != nil {
 			klog.ErrorS(err, "Failed to advertise IP address for SR-IOV interface",
@@ -72,7 +72,6 @@ func (pc *podConfigurator) DeleteSriovSecondaryInterface(interfaceConfig *interf
 	klog.InfoS("Deleted SR-IOV interface", "Pod", klog.KRef(interfaceConfig.PodNamespace, interfaceConfig.PodName),
 		"interface", interfaceConfig.IFDev)
 	return nil
-
 }
 
 // ConfigureVLANSecondaryInterface configures a VLAN secondary interface on the secondary network


### PR DESCRIPTION
When the agent restarts, current interfaceStore for SecondaryNetwork will not recover the assigned SRIOV interfaces for containers because of no OVS bridge to check, so we leverage the NetworkStatus info in the Pod annotation to recover the interface info.

This change would help to ensure the interface name restoration for SR-IOV devices after agent restarts, and also fix the issue that IP is not released when a Pod with secondary SR-IOV nic is deleted after agent restarts.