### PR TITLE
Enhance AWS CI job stability and relocate sriov-secondary-network-e2e test to antrea-cloud node

### DIFF
--- a/ci/jenkins/jobs/projects-cloud.yaml
+++ b/ci/jenkins/jobs/projects-cloud.yaml
@@ -1665,7 +1665,7 @@
       - '{name}-{test_name}-for-pull-request':
           disabled: false
           test_name: sriov-secondary-network-e2e
-          node: antrea-cloud-test
+          node: antrea-cloud
           description: 'Test SR-IOV secondary network in AWS for antrea.'
           branches:
           - ${{sha1}}


### PR DESCRIPTION
Improve AWS credential management and job timeout handling in AWS CI scripts

- Set AWS STS session duration via `AWS_DURATION_SECONDS` (default 2 hours) in EKS and SR-IOV secondary network test scripts.
- Update `aws sts assume-role` usage: dynamic session name, configurable duration, immediate error handling, and cleanup of sensitive variables.
- Add robust timeout wrapper to terminate test jobs before AWS credentials expire, ensuring proper exit codes and error messages.
- Change Jenkins job node label for `sriov-secondary-network-e2e` from `antrea-cloud-test` to `antrea-cloud`.