### PR TITLE
Add resource requests for Windows container in Antrea deployment

### DIFF
--- a/build/charts/antrea-windows/templates/daemonset.yaml
+++ b/build/charts/antrea-windows/templates/daemonset.yaml
@@ -62,6 +62,10 @@ spec:
               - disable
         {{- end}}
         name: antrea-agent
+        resources:
+            requests:
+              cpu: 200m
+              memory: 100Mi
         volumeMounts:
         - mountPath: /etc/antrea
           name: antrea-windows-config
@@ -78,6 +82,10 @@ spec:
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: IfNotPresent
         name: antrea-ovs
+        resources:
+            requests:
+              cpu: 200m
+              memory: 100Mi
         volumeMounts:
         - mountPath: /var/lib/antrea-windows
           name: antrea-agent-windows
@@ -95,6 +103,9 @@ spec:
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         imagePullPolicy: IfNotPresent
         name: install-cni
+        resources:
+            requests:
+              cpu: 100m
         volumeMounts:
         - mountPath: /etc/antrea
           name: antrea-windows-config

--- a/build/yamls/antrea-windows-with-ovs.yml
+++ b/build/yamls/antrea-windows-with-ovs.yml
@@ -355,6 +355,10 @@ spec:
               - -VMSwitchExtension
               - disable
         name: antrea-agent
+        resources:
+            requests:
+              cpu: 200m
+              memory: 100Mi
         volumeMounts:
         - mountPath: /etc/antrea
           name: antrea-windows-config
@@ -370,6 +374,10 @@ spec:
         image: antrea/antrea-windows:latest
         imagePullPolicy: IfNotPresent
         name: antrea-ovs
+        resources:
+            requests:
+              cpu: 200m
+              memory: 100Mi
         volumeMounts:
         - mountPath: /var/lib/antrea-windows
           name: antrea-agent-windows
@@ -386,6 +394,9 @@ spec:
         image: antrea/antrea-windows:latest
         imagePullPolicy: IfNotPresent
         name: install-cni
+        resources:
+            requests:
+              cpu: 100m
         volumeMounts:
         - mountPath: /etc/antrea
           name: antrea-windows-config

--- a/build/yamls/antrea-windows.yml
+++ b/build/yamls/antrea-windows.yml
@@ -262,6 +262,10 @@ spec:
         image: antrea/antrea-windows:latest
         imagePullPolicy: IfNotPresent
         name: antrea-agent
+        resources:
+            requests:
+              cpu: 200m
+              memory: 100Mi
         volumeMounts:
         - mountPath: /etc/antrea
           name: antrea-windows-config
@@ -279,6 +283,9 @@ spec:
         image: antrea/antrea-windows:latest
         imagePullPolicy: IfNotPresent
         name: install-cni
+        resources:
+            requests:
+              cpu: 100m
         volumeMounts:
         - mountPath: /etc/antrea
           name: antrea-windows-config


### PR DESCRIPTION
Based on performance testing on a 4C8G Windows node running 100 pods, the antrea-agent container showed an average CPU usage of 30m and memory usage of 50MB, while the OVS container consumed 17m CPU and 23MB memory.
To account for potential burst scenarios and ensure runtime stability, both containers have been configured with resource requests of 100m CPU and 100MB memory.