### PR TITLE
Unify Antrea iptables chain names and clean up orphan rules/chains

### DIFF
--- a/pkg/agent/route/route_linux.go
+++ b/pkg/agent/route/route_linux.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -83,7 +84,6 @@ const (
 	antreaPostRoutingChain = "ANTREA-POSTROUTING"
 	antreaInputChain       = "ANTREA-INPUT"
 	antreaOutputChain      = "ANTREA-OUTPUT"
-	antreaMangleChain      = "ANTREA-MANGLE"
 
 	kubeProxyServiceChain = "KUBE-SERVICES"
 
@@ -106,6 +106,10 @@ var (
 	// interface's global address's mask.
 	_, llrCIDR, _ = net.ParseCIDR("fe80::/64")
 )
+
+// jumpToAntreaChainPattern matches iptables jump rules that have a comment enclosed in double quotes and target
+// Antrea-managed chains.
+var jumpToAntreaChainPattern = regexp.MustCompile(`--comment\s+"(Antrea:[^"]+)"\s+-j\s+(ANTREA-[A-Z0-9-]+)`)
 
 // Client takes care of routing container packets in host network, coordinating ip route, ip rule, iptables and ipset.
 type Client struct {
@@ -245,7 +249,7 @@ func (c *Client) Initialize(nodeConfig *config.NodeConfig, done func()) error {
 		defer close(c.iptablesInitialized)
 		var backoffTime = 2 * time.Second
 		for {
-			if err := c.syncIPTables(); err != nil {
+			if err := c.syncIPTables(true); err != nil {
 				klog.Errorf("Failed to initialize iptables: %v - will retry in %v", err, backoffTime)
 				time.Sleep(backoffTime)
 				continue
@@ -309,7 +313,7 @@ func (c *Client) syncIPInfra() {
 		klog.ErrorS(err, "Failed to sync ipset")
 		return
 	}
-	if err := c.syncIPTables(); err != nil {
+	if err := c.syncIPTables(false); err != nil {
 		klog.ErrorS(err, "Failed to sync iptables")
 		return
 	}
@@ -585,7 +589,7 @@ func (c *Client) writeEKSMangleRules(iptablesData *bytes.Buffer) {
 	// whether we need to install this rule.
 	klog.V(2).InfoS("Add iptables mangle rules for EKS")
 	writeLine(iptablesData, []string{
-		"-A", antreaMangleChain,
+		"-A", antreaPreRoutingChain,
 		"-m", "comment", "--comment", `"Antrea: AWS, primary ENI"`,
 		"-i", c.nodeConfig.GatewayConfig.Name, "-j", "CONNMARK",
 		"--restore-mark", "--nfmask", "0x80", "--ctmask", "0x80",
@@ -647,6 +651,22 @@ type jumpRule struct {
 	insert   bool
 }
 
+type jumpRuleKey struct {
+	table    string
+	srcChain string
+	dstChain string
+	comment  string
+}
+
+func (j *jumpRule) getKey() jumpRuleKey {
+	return jumpRuleKey{
+		table:    j.table,
+		srcChain: j.srcChain,
+		dstChain: j.dstChain,
+		comment:  j.comment,
+	}
+}
+
 func (c *Client) removeUnexpectedAntreaJumpRule(protocol iptables.Protocol, jumpRule jumpRule) error {
 	// List all the existing rules of the table and the chain where the Antrea jump rule will be added.
 	allExistingRules, err := c.iptables.ListRules(protocol, jumpRule.table, jumpRule.srcChain)
@@ -684,14 +704,14 @@ func (c *Client) removeUnexpectedAntreaJumpRule(protocol iptables.Protocol, jump
 
 // syncIPTables ensure that the iptables infrastructure we use is set up.
 // It's idempotent and can safely be called on every startup.
-func (c *Client) syncIPTables() error {
+func (c *Client) syncIPTables(cleanupStaleJumpRules bool) error {
 	ipProtocol := c.getIPProtocol()
 	jumpRules := []jumpRule{
 		{iptables.RawTable, iptables.PreRoutingChain, antreaPreRoutingChain, "Antrea: jump to Antrea prerouting rules", false},
 		{iptables.RawTable, iptables.OutputChain, antreaOutputChain, "Antrea: jump to Antrea output rules", false},
 		{iptables.FilterTable, iptables.ForwardChain, antreaForwardChain, "Antrea: jump to Antrea forwarding rules", false},
 		{iptables.NATTable, iptables.PostRoutingChain, antreaPostRoutingChain, "Antrea: jump to Antrea postrouting rules", false},
-		{iptables.MangleTable, iptables.PreRoutingChain, antreaMangleChain, "Antrea: jump to Antrea mangle rules", false}, // TODO: unify the chain naming style
+		{iptables.MangleTable, iptables.PreRoutingChain, antreaPreRoutingChain, "Antrea: jump to Antrea prerouting rules", false},
 		{iptables.MangleTable, iptables.OutputChain, antreaOutputChain, "Antrea: jump to Antrea output rules", false},
 	}
 	if c.proxyAll || c.isCloudEKS {
@@ -704,6 +724,8 @@ func (c *Client) syncIPTables() error {
 		jumpRules = append(jumpRules, jumpRule{iptables.FilterTable, iptables.InputChain, antreaInputChain, "Antrea: jump to Antrea input rules", false})
 		jumpRules = append(jumpRules, jumpRule{iptables.FilterTable, iptables.OutputChain, antreaOutputChain, "Antrea: jump to Antrea output rules", false})
 	}
+
+	jumpRuleKeys := sets.New[jumpRuleKey]()
 	for _, rule := range jumpRules {
 		if err := c.iptables.EnsureChain(ipProtocol, rule.table, rule.dstChain); err != nil {
 			return err
@@ -719,6 +741,25 @@ func (c *Client) syncIPTables() error {
 		} else {
 			if err := c.iptables.AppendRule(ipProtocol, rule.table, rule.srcChain, ruleSpec); err != nil {
 				return err
+			}
+		}
+		if cleanupStaleJumpRules {
+			jumpRuleKeys.Insert(rule.getKey())
+		}
+	}
+
+	if cleanupStaleJumpRules {
+		existingJumpRuleKeys := c.getJumpRuleKeys(ipProtocol)
+		for key := range existingJumpRuleKeys {
+			if !jumpRuleKeys.Has(key) {
+				err := c.iptables.DeleteRule(ipProtocol, key.table, key.srcChain, []string{"-j", key.dstChain, "-m", "comment", "--comment", key.comment})
+				if err != nil {
+					klog.ErrorS(err, "Failed to delete orphan jump rule", "table", key.table, "srcChain", key.srcChain, "dstChain", key.dstChain)
+				}
+				err = c.iptables.DeleteChain(ipProtocol, key.table, key.dstChain)
+				if err != nil {
+					klog.ErrorS(err, "Failed to delete orphan chain", "table", key.table, "dstChain", key.dstChain)
+				}
 			}
 		}
 	}
@@ -797,6 +838,41 @@ func (c *Client) syncIPTables() error {
 	}
 
 	return nil
+}
+
+func (c *Client) getJumpRuleKeys(ipProtocol iptables.Protocol) sets.Set[jumpRuleKey] {
+	allChains := map[string][]string{
+		iptables.RawTable:    {iptables.PreRoutingChain, iptables.OutputChain},
+		iptables.MangleTable: {iptables.PreRoutingChain, iptables.InputChain, iptables.ForwardChain, iptables.OutputChain, iptables.PostRoutingChain},
+		iptables.NATTable:    {iptables.PreRoutingChain, iptables.InputChain, iptables.OutputChain, iptables.PostRoutingChain},
+		iptables.FilterTable: {iptables.InputChain, iptables.ForwardChain, iptables.OutputChain},
+	}
+	jumpRuleKeys := sets.New[jumpRuleKey]()
+
+	for table, chains := range allChains {
+		for _, chain := range chains {
+			allRules, err := c.iptables.ListRules(ipProtocol, table, chain)
+			if err != nil {
+				klog.ErrorS(err, "Failed to list rules", "table", table, "chain", chain)
+				continue
+			}
+			for _, rules := range allRules {
+				for _, rule := range rules {
+					matches := jumpToAntreaChainPattern.FindStringSubmatch(rule)
+					if len(matches) > 2 {
+						key := jumpRuleKey{
+							table:    table,
+							srcChain: chain,
+							dstChain: matches[2],
+							comment:  matches[1],
+						}
+						jumpRuleKeys.Insert(key)
+					}
+				}
+			}
+		}
+	}
+	return jumpRuleKeys
 }
 
 func (c *Client) restoreIptablesData(podCIDR *net.IPNet,
@@ -893,7 +969,7 @@ func (c *Client) restoreIptablesData(podCIDR *net.IPNet,
 
 	// Write head lines anyway so the undesired rules can be deleted when noEncap -> encap.
 	writeLine(iptablesData, "*mangle")
-	writeLine(iptablesData, iptables.MakeChainLine(antreaMangleChain))
+	writeLine(iptablesData, iptables.MakeChainLine(antreaPreRoutingChain))
 	writeLine(iptablesData, iptables.MakeChainLine(antreaOutputChain))
 
 	// When Antrea is used to enforce NetworkPolicies in EKS, additional iptables

--- a/pkg/agent/route/route_linux_test.go
+++ b/pkg/agent/route/route_linux_test.go
@@ -369,8 +369,8 @@ func TestSyncIPTables(t *testing.T) {
 				mockIPTables.AppendRule(iptables.ProtocolDual, iptables.FilterTable, iptables.ForwardChain, []string{"-j", antreaForwardChain, "-m", "comment", "--comment", "Antrea: jump to Antrea forwarding rules"})
 				mockIPTables.EnsureChain(iptables.ProtocolDual, iptables.NATTable, antreaPostRoutingChain)
 				mockIPTables.AppendRule(iptables.ProtocolDual, iptables.NATTable, iptables.PostRoutingChain, []string{"-j", antreaPostRoutingChain, "-m", "comment", "--comment", "Antrea: jump to Antrea postrouting rules"})
-				mockIPTables.EnsureChain(iptables.ProtocolDual, iptables.MangleTable, antreaMangleChain)
-				mockIPTables.AppendRule(iptables.ProtocolDual, iptables.MangleTable, iptables.PreRoutingChain, []string{"-j", antreaMangleChain, "-m", "comment", "--comment", "Antrea: jump to Antrea mangle rules"})
+				mockIPTables.EnsureChain(iptables.ProtocolDual, iptables.MangleTable, antreaPreRoutingChain)
+				mockIPTables.AppendRule(iptables.ProtocolDual, iptables.MangleTable, iptables.PreRoutingChain, []string{"-j", antreaPreRoutingChain, "-m", "comment", "--comment", "Antrea: jump to Antrea prerouting rules"})
 				mockIPTables.EnsureChain(iptables.ProtocolDual, iptables.MangleTable, antreaOutputChain)
 				mockIPTables.AppendRule(iptables.ProtocolDual, iptables.MangleTable, iptables.OutputChain, []string{"-j", antreaOutputChain, "-m", "comment", "--comment", "Antrea: jump to Antrea output rules"})
 				mockIPTables.ListRules(iptables.ProtocolDual, iptables.NATTable, iptables.PreRoutingChain).Return(
@@ -416,7 +416,7 @@ func TestSyncIPTables(t *testing.T) {
 -A ANTREA-OUTPUT -m comment --comment "Antrea: do not track request packets destined to external IPs" -m set --match-set ANTREA-EXTERNAL-IP dst -j NOTRACK
 COMMIT
 *mangle
-:ANTREA-MANGLE - [0:0]
+:ANTREA-PREROUTING - [0:0]
 :ANTREA-OUTPUT - [0:0]
 -A ANTREA-OUTPUT -m comment --comment "Antrea: mark LOCAL output packets" -m addrtype --src-type LOCAL -o antrea-gw0 -j MARK --or-mark 0x80000000
 COMMIT
@@ -468,7 +468,7 @@ COMMIT
 -A ANTREA-OUTPUT -m comment --comment "Antrea: do not track request packets destined to external IPs" -m set --match-set ANTREA-EXTERNAL-IP6 dst -j NOTRACK
 COMMIT
 *mangle
-:ANTREA-MANGLE - [0:0]
+:ANTREA-PREROUTING - [0:0]
 :ANTREA-OUTPUT - [0:0]
 -A ANTREA-OUTPUT -m comment --comment "Antrea: mark LOCAL output packets" -m addrtype --src-type LOCAL -o antrea-gw0 -j MARK --or-mark 0x80000000
 COMMIT
@@ -510,6 +510,29 @@ COMMIT
 -A ANTREA-POSTROUTING -m comment --comment "Antrea: masquerade OVS virtual source IP" -s fc01::aabb:ccdd:eeff -j MASQUERADE
 COMMIT
 `, false, true)
+				mockIPTables.ListRules(iptables.ProtocolDual, iptables.RawTable, iptables.PreRoutingChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolDual, iptables.RawTable, iptables.OutputChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolDual, iptables.MangleTable, iptables.PreRoutingChain).Return(map[iptables.Protocol][]string{
+					iptables.ProtocolIPv4: {
+						`-A PREROUTING -m comment --comment "Antrea: jump to Antrea mangle rules" -j ANTREA-MANGLE`,
+					},
+					iptables.ProtocolIPv6: {
+						`-A PREROUTING -m comment --comment "Antrea: jump to Antrea mangle rules" -j ANTREA-MANGLE`,
+					},
+				}, nil)
+				mockIPTables.ListRules(iptables.ProtocolDual, iptables.MangleTable, iptables.InputChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolDual, iptables.MangleTable, iptables.ForwardChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolDual, iptables.MangleTable, iptables.OutputChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolDual, iptables.MangleTable, iptables.PostRoutingChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolDual, iptables.NATTable, iptables.PreRoutingChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolDual, iptables.NATTable, iptables.InputChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolDual, iptables.NATTable, iptables.OutputChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolDual, iptables.NATTable, iptables.PostRoutingChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolDual, iptables.FilterTable, iptables.InputChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolDual, iptables.FilterTable, iptables.ForwardChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolDual, iptables.FilterTable, iptables.OutputChain).Return(nil, nil)
+				mockIPTables.DeleteRule(iptables.ProtocolDual, iptables.MangleTable, iptables.PreRoutingChain, []string{"-j", "ANTREA-MANGLE", "-m", "comment", "--comment", "Antrea: jump to Antrea mangle rules"})
+				mockIPTables.DeleteChain(iptables.ProtocolDual, iptables.MangleTable, "ANTREA-MANGLE")
 			},
 		},
 		{
@@ -546,8 +569,8 @@ COMMIT
 				mockIPTables.AppendRule(iptables.ProtocolDual, iptables.FilterTable, iptables.ForwardChain, []string{"-j", antreaForwardChain, "-m", "comment", "--comment", "Antrea: jump to Antrea forwarding rules"})
 				mockIPTables.EnsureChain(iptables.ProtocolDual, iptables.NATTable, antreaPostRoutingChain)
 				mockIPTables.AppendRule(iptables.ProtocolDual, iptables.NATTable, iptables.PostRoutingChain, []string{"-j", antreaPostRoutingChain, "-m", "comment", "--comment", "Antrea: jump to Antrea postrouting rules"})
-				mockIPTables.EnsureChain(iptables.ProtocolDual, iptables.MangleTable, antreaMangleChain)
-				mockIPTables.AppendRule(iptables.ProtocolDual, iptables.MangleTable, iptables.PreRoutingChain, []string{"-j", antreaMangleChain, "-m", "comment", "--comment", "Antrea: jump to Antrea mangle rules"})
+				mockIPTables.EnsureChain(iptables.ProtocolDual, iptables.MangleTable, antreaPreRoutingChain)
+				mockIPTables.AppendRule(iptables.ProtocolDual, iptables.MangleTable, iptables.PreRoutingChain, []string{"-j", antreaPreRoutingChain, "-m", "comment", "--comment", "Antrea: jump to Antrea prerouting rules"})
 				mockIPTables.EnsureChain(iptables.ProtocolDual, iptables.MangleTable, antreaOutputChain)
 				mockIPTables.AppendRule(iptables.ProtocolDual, iptables.MangleTable, iptables.OutputChain, []string{"-j", antreaOutputChain, "-m", "comment", "--comment", "Antrea: jump to Antrea output rules"})
 				mockIPTables.EnsureChain(iptables.ProtocolDual, iptables.FilterTable, antreaInputChain)
@@ -561,7 +584,7 @@ COMMIT
 -A ANTREA-OUTPUT -m comment --comment "Antrea: do not track outgoing encapsulation packets" -m udp -p udp --dport 6081 -m addrtype --src-type LOCAL -j NOTRACK
 COMMIT
 *mangle
-:ANTREA-MANGLE - [0:0]
+:ANTREA-PREROUTING - [0:0]
 :ANTREA-OUTPUT - [0:0]
 -A ANTREA-OUTPUT -m comment --comment "Antrea: mark LOCAL output packets" -m addrtype --src-type LOCAL -o antrea-gw0 -j MARK --or-mark 0x80000000
 COMMIT
@@ -588,7 +611,7 @@ COMMIT
 -A ANTREA-OUTPUT -m comment --comment "Antrea: do not track outgoing encapsulation packets" -m udp -p udp --dport 6081 -m addrtype --src-type LOCAL -j NOTRACK
 COMMIT
 *mangle
-:ANTREA-MANGLE - [0:0]
+:ANTREA-PREROUTING - [0:0]
 :ANTREA-OUTPUT - [0:0]
 -A ANTREA-OUTPUT -m comment --comment "Antrea: mark LOCAL output packets" -m addrtype --src-type LOCAL -o antrea-gw0 -j MARK --or-mark 0x80000000
 COMMIT
@@ -608,6 +631,20 @@ COMMIT
 -A ANTREA-POSTROUTING -m comment --comment "Antrea: masquerade LOCAL traffic" -o antrea-gw0 -m addrtype ! --src-type LOCAL --limit-iface-out -m addrtype --src-type LOCAL -j MASQUERADE --random-fully
 COMMIT
 `, false, true)
+				mockIPTables.ListRules(iptables.ProtocolDual, iptables.RawTable, iptables.PreRoutingChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolDual, iptables.RawTable, iptables.OutputChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolDual, iptables.MangleTable, iptables.PreRoutingChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolDual, iptables.MangleTable, iptables.InputChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolDual, iptables.MangleTable, iptables.ForwardChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolDual, iptables.MangleTable, iptables.OutputChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolDual, iptables.MangleTable, iptables.PostRoutingChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolDual, iptables.NATTable, iptables.PreRoutingChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolDual, iptables.NATTable, iptables.InputChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolDual, iptables.NATTable, iptables.OutputChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolDual, iptables.NATTable, iptables.PostRoutingChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolDual, iptables.FilterTable, iptables.InputChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolDual, iptables.FilterTable, iptables.ForwardChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolDual, iptables.FilterTable, iptables.OutputChain).Return(nil, nil)
 			},
 		},
 		{
@@ -635,8 +672,8 @@ COMMIT
 				mockIPTables.AppendRule(iptables.ProtocolDual, iptables.FilterTable, iptables.ForwardChain, []string{"-j", antreaForwardChain, "-m", "comment", "--comment", "Antrea: jump to Antrea forwarding rules"})
 				mockIPTables.EnsureChain(iptables.ProtocolDual, iptables.NATTable, antreaPostRoutingChain)
 				mockIPTables.AppendRule(iptables.ProtocolDual, iptables.NATTable, iptables.PostRoutingChain, []string{"-j", antreaPostRoutingChain, "-m", "comment", "--comment", "Antrea: jump to Antrea postrouting rules"})
-				mockIPTables.EnsureChain(iptables.ProtocolDual, iptables.MangleTable, antreaMangleChain)
-				mockIPTables.AppendRule(iptables.ProtocolDual, iptables.MangleTable, iptables.PreRoutingChain, []string{"-j", antreaMangleChain, "-m", "comment", "--comment", "Antrea: jump to Antrea mangle rules"})
+				mockIPTables.EnsureChain(iptables.ProtocolDual, iptables.MangleTable, antreaPreRoutingChain)
+				mockIPTables.AppendRule(iptables.ProtocolDual, iptables.MangleTable, iptables.PreRoutingChain, []string{"-j", antreaPreRoutingChain, "-m", "comment", "--comment", "Antrea: jump to Antrea prerouting rules"})
 				mockIPTables.EnsureChain(iptables.ProtocolDual, iptables.MangleTable, antreaOutputChain)
 				mockIPTables.AppendRule(iptables.ProtocolDual, iptables.MangleTable, iptables.OutputChain, []string{"-j", antreaOutputChain, "-m", "comment", "--comment", "Antrea: jump to Antrea output rules"})
 				mockIPTables.EnsureChain(iptables.ProtocolDual, iptables.NATTable, antreaPreRoutingChain)
@@ -648,9 +685,9 @@ COMMIT
 -A ANTREA-OUTPUT -m comment --comment "Antrea: do not track outgoing encapsulation packets" -m udp -p udp --dport 6081 -m addrtype --src-type LOCAL -j NOTRACK
 COMMIT
 *mangle
-:ANTREA-MANGLE - [0:0]
+:ANTREA-PREROUTING - [0:0]
 :ANTREA-OUTPUT - [0:0]
--A ANTREA-MANGLE -m comment --comment "Antrea: AWS, primary ENI" -i antrea-gw0 -j CONNMARK --restore-mark --nfmask 0x80 --ctmask 0x80
+-A ANTREA-PREROUTING -m comment --comment "Antrea: AWS, primary ENI" -i antrea-gw0 -j CONNMARK --restore-mark --nfmask 0x80 --ctmask 0x80
 -A ANTREA-OUTPUT -m comment --comment "Antrea: mark LOCAL output packets" -m addrtype --src-type LOCAL -o antrea-gw0 -j MARK --or-mark 0x80000000
 COMMIT
 *filter
@@ -674,7 +711,7 @@ COMMIT
 -A ANTREA-OUTPUT -m comment --comment "Antrea: do not track outgoing encapsulation packets" -m udp -p udp --dport 6081 -m addrtype --src-type LOCAL -j NOTRACK
 COMMIT
 *mangle
-:ANTREA-MANGLE - [0:0]
+:ANTREA-PREROUTING - [0:0]
 :ANTREA-OUTPUT - [0:0]
 -A ANTREA-OUTPUT -m comment --comment "Antrea: mark LOCAL output packets" -m addrtype --src-type LOCAL -o antrea-gw0 -j MARK --or-mark 0x80000000
 COMMIT
@@ -690,6 +727,38 @@ COMMIT
 -A ANTREA-POSTROUTING -m comment --comment "Antrea: masquerade LOCAL traffic" -o antrea-gw0 -m addrtype ! --src-type LOCAL --limit-iface-out -m addrtype --src-type LOCAL -j MASQUERADE --random-fully
 COMMIT
 `, false, true)
+				mockIPTables.ListRules(iptables.ProtocolDual, iptables.RawTable, iptables.PreRoutingChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolDual, iptables.RawTable, iptables.OutputChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolDual, iptables.MangleTable, iptables.PreRoutingChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolDual, iptables.MangleTable, iptables.InputChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolDual, iptables.MangleTable, iptables.ForwardChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolDual, iptables.MangleTable, iptables.OutputChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolDual, iptables.MangleTable, iptables.PostRoutingChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolDual, iptables.NATTable, iptables.PreRoutingChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolDual, iptables.NATTable, iptables.InputChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolDual, iptables.NATTable, iptables.OutputChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolDual, iptables.NATTable, iptables.PostRoutingChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolDual, iptables.FilterTable, iptables.InputChain).Return(map[iptables.Protocol][]string{
+					iptables.ProtocolIPv4: {
+						fmt.Sprintf(`-A INPUT -m comment --comment "Antrea: jump to Antrea input rules" -j %s`, antreaInputChain),
+					},
+					iptables.ProtocolIPv6: {
+						fmt.Sprintf(`-A INPUT -m comment --comment "Antrea: jump to Antrea input rules" -j %s`, antreaInputChain),
+					},
+				}, nil)
+				mockIPTables.ListRules(iptables.ProtocolDual, iptables.FilterTable, iptables.ForwardChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolDual, iptables.FilterTable, iptables.OutputChain).Return(map[iptables.Protocol][]string{
+					iptables.ProtocolIPv4: {
+						fmt.Sprintf(`-A OUTPUT -m comment --comment "Antrea: jump to Antrea output rules" -j %s`, antreaOutputChain),
+					},
+					iptables.ProtocolIPv6: {
+						fmt.Sprintf(`-A OUTPUT -m comment --comment "Antrea: jump to Antrea output rules" -j %s`, antreaOutputChain),
+					},
+				}, nil)
+				mockIPTables.DeleteRule(iptables.ProtocolDual, iptables.FilterTable, iptables.InputChain, []string{"-j", antreaInputChain, "-m", "comment", "--comment", "Antrea: jump to Antrea input rules"})
+				mockIPTables.DeleteChain(iptables.ProtocolDual, iptables.FilterTable, antreaInputChain)
+				mockIPTables.DeleteRule(iptables.ProtocolDual, iptables.FilterTable, iptables.OutputChain, []string{"-j", antreaOutputChain, "-m", "comment", "--comment", "Antrea: jump to Antrea output rules"})
+				mockIPTables.DeleteChain(iptables.ProtocolDual, iptables.FilterTable, antreaOutputChain)
 			},
 		},
 		{
@@ -714,8 +783,8 @@ COMMIT
 				mockIPTables.AppendRule(iptables.ProtocolIPv4, iptables.FilterTable, iptables.ForwardChain, []string{"-j", antreaForwardChain, "-m", "comment", "--comment", "Antrea: jump to Antrea forwarding rules"})
 				mockIPTables.EnsureChain(iptables.ProtocolIPv4, iptables.NATTable, antreaPostRoutingChain)
 				mockIPTables.AppendRule(iptables.ProtocolIPv4, iptables.NATTable, iptables.PostRoutingChain, []string{"-j", antreaPostRoutingChain, "-m", "comment", "--comment", "Antrea: jump to Antrea postrouting rules"})
-				mockIPTables.EnsureChain(iptables.ProtocolIPv4, iptables.MangleTable, antreaMangleChain)
-				mockIPTables.AppendRule(iptables.ProtocolIPv4, iptables.MangleTable, iptables.PreRoutingChain, []string{"-j", antreaMangleChain, "-m", "comment", "--comment", "Antrea: jump to Antrea mangle rules"})
+				mockIPTables.EnsureChain(iptables.ProtocolIPv4, iptables.MangleTable, antreaPreRoutingChain)
+				mockIPTables.AppendRule(iptables.ProtocolIPv4, iptables.MangleTable, iptables.PreRoutingChain, []string{"-j", antreaPreRoutingChain, "-m", "comment", "--comment", "Antrea: jump to Antrea prerouting rules"})
 				mockIPTables.EnsureChain(iptables.ProtocolIPv4, iptables.MangleTable, antreaOutputChain)
 				mockIPTables.AppendRule(iptables.ProtocolIPv4, iptables.MangleTable, iptables.OutputChain, []string{"-j", antreaOutputChain, "-m", "comment", "--comment", "Antrea: jump to Antrea output rules"})
 				mockIPTables.Restore(`*raw
@@ -723,7 +792,7 @@ COMMIT
 :ANTREA-OUTPUT - [0:0]
 COMMIT
 *mangle
-:ANTREA-MANGLE - [0:0]
+:ANTREA-PREROUTING - [0:0]
 :ANTREA-OUTPUT - [0:0]
 -A ANTREA-OUTPUT -m comment --comment "Antrea: mark LOCAL output packets" -m addrtype --src-type LOCAL -o antrea-gw0 -j MARK --or-mark 0x80000000
 -A ANTREA-OUTPUT -m comment --comment "Antrea: mark LOCAL output packets" -m addrtype --src-type LOCAL -o  -j MARK --or-mark 0x80000000
@@ -742,6 +811,20 @@ COMMIT
 -A ANTREA-POSTROUTING -m comment --comment "Antrea: masquerade traffic to local AntreaIPAM hostPort Pod" ! -s 172.16.10.0/24 -m set --match-set LOCAL-FLEXIBLE-IPAM-POD-IP dst -j MASQUERADE
 COMMIT
 `, false, false)
+				mockIPTables.ListRules(iptables.ProtocolIPv4, iptables.RawTable, iptables.PreRoutingChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolIPv4, iptables.RawTable, iptables.OutputChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolIPv4, iptables.MangleTable, iptables.PreRoutingChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolIPv4, iptables.MangleTable, iptables.InputChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolIPv4, iptables.MangleTable, iptables.ForwardChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolIPv4, iptables.MangleTable, iptables.OutputChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolIPv4, iptables.MangleTable, iptables.PostRoutingChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolIPv4, iptables.NATTable, iptables.PreRoutingChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolIPv4, iptables.NATTable, iptables.InputChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolIPv4, iptables.NATTable, iptables.OutputChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolIPv4, iptables.NATTable, iptables.PostRoutingChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolIPv4, iptables.FilterTable, iptables.InputChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolIPv4, iptables.FilterTable, iptables.ForwardChain).Return(nil, nil)
+				mockIPTables.ListRules(iptables.ProtocolIPv4, iptables.FilterTable, iptables.OutputChain).Return(nil, nil)
 			},
 		},
 	}
@@ -779,7 +862,7 @@ COMMIT
 				c.initNodeLatencyRules()
 			}
 			tt.expectedCalls(mockIPTables.EXPECT())
-			assert.NoError(t, c.syncIPTables())
+			assert.NoError(t, c.syncIPTables(true))
 		})
 	}
 }

--- a/test/integration/agent/route_test.go
+++ b/test/integration/agent/route_test.go
@@ -235,9 +235,9 @@ func TestInitialize(t *testing.T) {
 -A ANTREA-FORWARD -i antrea-gw0 -m comment --comment "Antrea: accept packets from local Pods" -j ACCEPT
 -A ANTREA-FORWARD -o antrea-gw0 -m comment --comment "Antrea: accept packets to local Pods" -j ACCEPT
 `,
-				"mangle": `:ANTREA-MANGLE - [0:0]
-:ANTREA-OUTPUT - [0:0]
--A PREROUTING -m comment --comment "Antrea: jump to Antrea mangle rules" -j ANTREA-MANGLE
+				"mangle": `:ANTREA-OUTPUT - [0:0]
+:ANTREA-PREROUTING - [0:0]
+-A PREROUTING -m comment --comment "Antrea: jump to Antrea prerouting rules" -j ANTREA-PREROUTING
 -A OUTPUT -m comment --comment "Antrea: jump to Antrea output rules" -j ANTREA-OUTPUT
 -A ANTREA-OUTPUT -o antrea-gw0 -m comment --comment "Antrea: mark LOCAL output packets" -m addrtype --src-type LOCAL -j MARK --set-xmark 0x80000000/0x80000000
 `,


### PR DESCRIPTION
This commit replaces the custom Antrea chain `ANTREA-MANGLE` (previously used
in the iptables mangle PREROUTING chain) with a unified name: `ANTREA-PREROUTING`.

This commit also introduces a mechanism to clean up orphan jump rules and chains
that were previously added by Antrea but are no longer in use.