### PR TITLE
Add autoscaling and multi-replica for proxy mode flow-aggregator

### DIFF
--- a/build/charts/flow-aggregator/README.md
+++ b/build/charts/flow-aggregator/README.md
@@ -24,6 +24,10 @@ Kubernetes: `>= 1.19.0-0`
 | apiServer.apiPort | int | `10348` | The port for the Flow Aggregator APIServer to serve on. |
 | apiServer.tlsCipherSuites | string | `""` | Comma-separated list of cipher suites that will be used by the Flow Aggregator APIservers. If empty, the default Go Cipher Suites will be used. |
 | apiServer.tlsMinVersion | string | `""` | TLS min version from: VersionTLS10, VersionTLS11, VersionTLS12, VersionTLS13. |
+| autoscaling.cpu.averageUtilization | int | `70` | AverageUtilization is the target average CPU utilization. |
+| autoscaling.enable | bool | `false` | Enable installs the HPA for flow-aggregator. This must be disable when running in "Aggregate" mode. |
+| autoscaling.maxReplicas | int | `10` | MaxReplicas is the maximum number of replicas for autoscaling. This value must be greater than or equal to autoscaling.minReplicas |
+| autoscaling.minReplicas | int | `1` | MinReplicas is the minimum number of replicas for autoscaling. This value must be less than or equal to autoscaling.maxReplicas |
 | clickHouse.commitInterval | string | `"8s"` | CommitInterval is the periodical interval between batch commit of flow records to DB. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". |
 | clickHouse.compress | bool | `true` | Compress enables lz4 compression when committing flow records. |
 | clickHouse.connectionSecret | object | `{"password":"clickhouse_operator_password","username":"clickhouse_operator"}` | Credentials to connect to ClickHouse. They will be stored in a Secret. |
@@ -65,6 +69,7 @@ Kubernetes: `>= 1.19.0-0`
 | mode | string | `"Aggregate"` | Mode in which to run the flow aggregator. Must be one of "Aggregate" or "Proxy". In Aggregate mode, flow records received from source and destination are aggregated and sent as one flow record. In Proxy mode, flow records are enhanced with some additional information, then sent directly without buffering or aggregation. |
 | priorityClassName | string | `"system-cluster-critical"` | Prority class to use for the flow-aggregator Pod. |
 | recordContents.podLabels | bool | `false` | Determine whether source and destination Pod labels will be included in the flow records. |
+| replicas | int | `1` | Replicas is the number of flow-aggregator replicas. This must be 1 for "Aggregate" mode. |
 | s3Uploader.awsCredentials | object | `{"aws_access_key_id":"changeme","aws_secret_access_key":"changeme","aws_session_token":""}` | Credentials to authenticate to AWS. They will be stored in a Secret and injected into the Pod as environment variables. |
 | s3Uploader.bucketName | string | `""` | BucketName is the name of the S3 bucket to which flow records will be uploaded. It is required. |
 | s3Uploader.bucketPrefix | string | `""` | BucketPrefix is the prefix ("folder") under which flow records will be uploaded. |

--- a/build/charts/flow-aggregator/templates/_validate.tpl
+++ b/build/charts/flow-aggregator/templates/_validate.tpl
@@ -1,0 +1,18 @@
+{{- define "validateReplicas" -}}
+  {{- if eq .Values.mode "Aggregate"}}
+    {{- if gt (int .Values.replicas) 1 }}
+      {{- fail "Flow-aggregator can only have at most 1 replica in 'Aggreagte' mode." }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{- define "validateAutoscaling" -}}
+  {{- with .Values.autoscaling }}
+    {{- if and (ne $.Values.mode "Proxy") .enable }}
+      {{- fail "Autoscaling can only be used in 'Proxy' mode." }}
+    {{- end }}
+    {{- if gt .minReplicas .maxReplicas }}
+      {{- fail "autoscaling.minReplicas must be less than or equal to autoscaling.maxReplicas." }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/build/charts/flow-aggregator/templates/deployment.yaml
+++ b/build/charts/flow-aggregator/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- include "validateReplicas" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -6,7 +7,7 @@ metadata:
   name: flow-aggregator
   namespace: {{ .Release.Namespace }}
 spec:
-  replicas: 1
+  replicas: {{ default 1 .Values.replicas }}
   selector:
     matchLabels:
       app: flow-aggregator
@@ -49,16 +50,15 @@ spec:
           - --v=4
         {{- else }}
         args:
-        - --config
-        - /etc/flow-aggregator/flow-aggregator.conf
-        - --logtostderr=false
-        - --log_dir=/var/log/antrea/flow-aggregator
-        - --alsologtostderr
-        - --log_file_max_size=100
-        - --log_file_max_num=4
-        {{- if .Values.logVerbosity }}
-        - "--v={{ .Values.logVerbosity }}"
-        {{- end }}
+          - --config=/etc/flow-aggregator/flow-aggregator.conf
+          - --logtostderr=false
+          - --log_dir=/var/log/antrea/flow-aggregator
+          - --alsologtostderr
+          - --log_file_max_size=100
+          - --log_file_max_num=4
+          {{- if .Values.logVerbosity }}
+          - "--v={{ .Values.logVerbosity }}"
+          {{- end }}
         {{- end }}
         env:
           - name: POD_NAME

--- a/build/charts/flow-aggregator/templates/horizontalpodautoscaler.yaml
+++ b/build/charts/flow-aggregator/templates/horizontalpodautoscaler.yaml
@@ -1,0 +1,29 @@
+{{- include "validateAutoscaling" . }}
+{{- with .Values.autoscaling }}
+{{- if eq .enable true}}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: flow-aggregator
+  namespace: {{ $.Release.Namespace }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: flow-aggregator
+  minReplicas: {{ .minReplicas }}
+  maxReplicas: {{ .maxReplicas }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .cpu.averageUtilization }}
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300
+    scaleUp:
+      stabilizationWindowSeconds: 60
+{{- end }}
+{{- end }}

--- a/build/charts/flow-aggregator/values.yaml
+++ b/build/charts/flow-aggregator/values.yaml
@@ -186,3 +186,21 @@ testing:
 logVerbosity: 0
 # -- Namespace in which Antrea was installed.
 antreaNamespace: "kube-system"
+
+# Autoscaling contains HorizontalPodAutoscaler related configuration options. The HPA should be
+# enabled only if flow-aggregator is running in "Proxy" mode.
+autoscaling:
+  # -- Enable installs the HPA for flow-aggregator. This must be disable when running in "Aggregate" mode.
+  enable: false
+  # -- MinReplicas is the minimum number of replicas for autoscaling. This value must be less than or equal
+  # to autoscaling.maxReplicas
+  minReplicas: 1
+  # -- MaxReplicas is the maximum number of replicas for autoscaling. This value must be greater than or equal
+  # to autoscaling.minReplicas
+  maxReplicas: 10
+  cpu:
+    # -- AverageUtilization is the target average CPU utilization.
+    averageUtilization: 70
+
+# -- Replicas is the number of flow-aggregator replicas. This must be 1 for "Aggregate" mode.
+replicas: 1

--- a/build/yamls/flow-aggregator.yml
+++ b/build/yamls/flow-aggregator.yml
@@ -485,8 +485,7 @@ spec:
     spec:
       containers:
       - args:
-        - --config
-        - /etc/flow-aggregator/flow-aggregator.conf
+        - --config=/etc/flow-aggregator/flow-aggregator.conf
         - --logtostderr=false
         - --log_dir=/var/log/antrea/flow-aggregator
         - --alsologtostderr


### PR DESCRIPTION
Issue #7132

This adds a way for user to configure the flow-aggregator to use multiple replicas when using proxy mode. It introduces a few new configurations. I'm open to removing some and leaving it as a sane default if we want to reduce the number of settings.

I had considered adding an e2e test for it but in the end it would really be just testing that HPA works which I think we can assume it does. Additionally I don't see any tests for generated configs (yamls).

I did manually test this out and saw it did scale up and down properly by modifying the flow aggregator perf test.