### PR TITLE
Automated cherry pick of #7238: Periodically sync permanent neighbors to ensure route

### DIFF
--- a/pkg/agent/route/route_linux.go
+++ b/pkg/agent/route/route_linux.go
@@ -291,7 +291,11 @@ func (c *Client) syncIPInfra() {
 	if err := c.syncRoute(); err != nil {
 		klog.ErrorS(err, "Failed to sync route")
 	}
-	klog.V(3).Info("Successfully synced iptables, ipset and route")
+	if err := c.syncNeighbor(); err != nil {
+		klog.ErrorS(err, "Failed to sync neighbor")
+	}
+
+	klog.V(3).Info("Successfully synced iptables, ipset, route and neighbor")
 }
 
 type routeKey struct {
@@ -389,6 +393,56 @@ func (c *Client) syncRoute() error {
 	for _, route := range gwAutoconfRoutes {
 		restoreRoute(route)
 	}
+	return nil
+}
+
+type neighborKey struct {
+	ip  string
+	mac string
+}
+
+// syncNeighbor ensures that necessary neighbors exist on the Antrea gateway interface, as some routes managed by Antrea
+// depend on these neighbors.
+func (c *Client) syncNeighbor() error {
+	msg := netlink.Ndmsg{
+		Family: netlink.FAMILY_ALL,
+		Index:  uint32(c.nodeConfig.GatewayConfig.LinkIndex),
+		State:  netlink.NUD_PERMANENT,
+	}
+	neighborList, err := c.netlink.NeighListExecute(msg)
+	if err != nil {
+		return err
+	}
+	neighborKeys := sets.New[neighborKey]()
+	for i := range neighborList {
+		n := neighborList[i]
+		neighborKeys.Insert(neighborKey{
+			ip:  n.IP.String(),
+			mac: n.HardwareAddr.String(),
+		})
+	}
+	restoreNeighbor := func(neighbor *netlink.Neigh) bool {
+		if neighborKeys.Has(neighborKey{
+			ip:  neighbor.IP.String(),
+			mac: neighbor.HardwareAddr.String(),
+		}) {
+			return true
+		}
+		if err := c.netlink.NeighSet(neighbor); err != nil {
+			klog.ErrorS(err, "failed to sync neighbor", "Neighbor", neighbor)
+			return false
+		}
+		return true
+	}
+	c.nodeNeighbors.Range(func(_, v interface{}) bool {
+		return restoreNeighbor(v.(*netlink.Neigh))
+	})
+	if c.proxyAll {
+		c.serviceNeighbors.Range(func(_, v interface{}) bool {
+			return restoreNeighbor(v.(*netlink.Neigh))
+		})
+	}
+
 	return nil
 }
 

--- a/pkg/agent/util/netlink/netlink_linux.go
+++ b/pkg/agent/util/netlink/netlink_linux.go
@@ -46,6 +46,8 @@ type Interface interface {
 
 	NeighList(linkIndex, family int) ([]netlink.Neigh, error)
 
+	NeighListExecute(msg netlink.Ndmsg) ([]netlink.Neigh, error)
+
 	NeighSet(neigh *netlink.Neigh) error
 
 	NeighDel(neigh *netlink.Neigh) error

--- a/pkg/agent/util/netlink/testing/mock_netlink_linux.go
+++ b/pkg/agent/util/netlink/testing/mock_netlink_linux.go
@@ -314,6 +314,21 @@ func (mr *MockInterfaceMockRecorder) NeighList(linkIndex, family any) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NeighList", reflect.TypeOf((*MockInterface)(nil).NeighList), linkIndex, family)
 }
 
+// NeighListExecute mocks base method.
+func (m *MockInterface) NeighListExecute(msg netlink.Ndmsg) ([]netlink.Neigh, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NeighListExecute", msg)
+	ret0, _ := ret[0].([]netlink.Neigh)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// NeighListExecute indicates an expected call of NeighListExecute.
+func (mr *MockInterfaceMockRecorder) NeighListExecute(msg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NeighListExecute", reflect.TypeOf((*MockInterface)(nil).NeighListExecute), msg)
+}
+
 // NeighSet mocks base method.
 func (m *MockInterface) NeighSet(neigh *netlink.Neigh) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Cherry pick of #7238 on release-2.3.

#7238: Periodically sync permanent neighbors to ensure route

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.