### PR TITLE
Fix index out of range issue for GetVFLinkNames

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,6 @@ require (
 	github.com/gopacket/gopacket v1.3.2-0.20241202175635-b43272ae1eb8
 	github.com/hashicorp/memberlist v0.5.3
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.5
-	github.com/k8snetworkplumbingwg/sriov-cni v2.1.0+incompatible
 	github.com/kevinburke/ssh_config v1.2.0
 	github.com/lithammer/dedent v1.1.0
 	github.com/mdlayher/arp v0.0.0-20220221190821-c37aaafac7f9

--- a/go.sum
+++ b/go.sum
@@ -477,8 +477,6 @@ github.com/k-sone/critbitgo v1.4.0 h1:l71cTyBGeh6X5ATh6Fibgw3+rtNT80BA0uNNWgkPrb
 github.com/k-sone/critbitgo v1.4.0/go.mod h1:7E6pyoyADnFxlUBEKcnfS49b7SUAQGMK+OAp/UQvo0s=
 github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.5 h1:CELpSMPSyicFBaVsxROmfrWlu9yr3Dduk+y7vGrIsx8=
 github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.5/go.mod h1:CM7HAH5PNuIsqjMN0fGc1ydM74Uj+0VZFhob620nklw=
-github.com/k8snetworkplumbingwg/sriov-cni v2.1.0+incompatible h1:5comk9qUB9j99Oc+rvnm92RWWe9urdJ1TP3cXM3fmmc=
-github.com/k8snetworkplumbingwg/sriov-cni v2.1.0+incompatible/go.mod h1:sVTfViXOlaxc7X9fnixa5L1FQqEAybehD20yXyagYLE=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
 github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=

--- a/pkg/agent/cniserver/sriov_linux.go
+++ b/pkg/agent/cniserver/sriov_linux.go
@@ -18,8 +18,16 @@
 package cniserver
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
+
 	"github.com/Mellanox/sriovnet"
-	sriovcniutils "github.com/k8snetworkplumbingwg/sriov-cni/pkg/utils"
+)
+
+var (
+	// SysBusPCI is the /sysfs PCI device directory
+	SysBusPCI = "/sys/bus/pci/devices"
 )
 
 // getVFLinkName returns a VF's network interface name given its PCI address.
@@ -46,9 +54,42 @@ func (n *sriovNet) GetVfRepresentor(uplink string, vfIndex int) (string, error) 
 }
 
 func (n *sriovNet) GetVFLinkNames(pciAddr string) (string, error) {
-	return sriovcniutils.GetVFLinkNames(pciAddr)
+	return GetVFLinkName(pciAddr)
 }
 
 func newSriovNet() *sriovNet {
 	return &sriovNet{}
+}
+
+// Note: The following fuction is coming from https://github.com/k8snetworkplumbingwg/sriov-cni/blob/master/pkg/utils/utils.go
+// The permanent link is https://github.com/k8snetworkplumbingwg/sriov-cni/blob/3d9014b16bd22ed3381f41cd6ad097b8b741cab2/pkg/utils/utils.go#L186-L211
+// We can't directly import the package in go.mod due to the sriov-cni repo has no v2 module yet. it reports:
+// "require github.com/k8snetworkplumbingwg/sriov-cni: version “v2.9.0” invalid: should be v0 or v1, not v2.""
+
+// GetVFLinkName returns VF's network interface name given it's PCI addr
+func GetVFLinkName(pciAddr string) (string, error) {
+	var names []string
+	vfDir := filepath.Join(SysBusPCI, pciAddr, "net")
+	if _, err := os.Lstat(vfDir); err != nil {
+		return "", err
+	}
+
+	fInfos, err := os.ReadDir(vfDir)
+	if err != nil {
+		return "", fmt.Errorf("failed to read net dir of the device %s: %v", pciAddr, err)
+	}
+
+	if len(fInfos) == 0 {
+		return "", fmt.Errorf("VF device %s sysfs path (%s) has no entries", pciAddr, vfDir)
+	}
+
+	names = make([]string, len(fInfos))
+	for idx, f := range fInfos {
+		names[idx] = f.Name()
+	}
+
+	if len(names) < 1 {
+		return "", fmt.Errorf("VF device %s has no entries", pciAddr)
+	}
+	return names[0], nil
 }

--- a/pkg/agent/cniserver/sriov_linux_test.go
+++ b/pkg/agent/cniserver/sriov_linux_test.go
@@ -1,0 +1,84 @@
+//go:build linux
+// +build linux
+
+// Copyright 2025 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cniserver
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Helper to create a fake net directory with interface names
+func createFakeVFNetDir(t *testing.T, base string, pciAddr string, interfaces []string) string {
+	vfNetDir := filepath.Join(base, pciAddr, "net")
+	if err := os.MkdirAll(vfNetDir, 0755); err != nil {
+		t.Fatalf("failed to create fake VF dir: %v", err)
+	}
+
+	for _, iface := range interfaces {
+		ifacePath := filepath.Join(vfNetDir, iface)
+		if err := os.Mkdir(ifacePath, 0755); err != nil {
+			t.Fatalf("failed to create fake interface dir: %v", err)
+		}
+	}
+	return vfNetDir
+}
+
+func fakeSysBusPCI(tmpDir string) func() {
+	oldSysBusPCI := SysBusPCI
+	SysBusPCI = tmpDir
+	return func() { SysBusPCI = oldSysBusPCI }
+}
+
+func TestGetVFLinkName_Success(t *testing.T) {
+	tmpDir := t.TempDir()
+	defer fakeSysBusPCI(tmpDir)()
+
+	pciAddr := "0000:03:00.1"
+	ifaces := []string{"eth0", "eth1"}
+	createFakeVFNetDir(t, tmpDir, pciAddr, ifaces)
+
+	name, err := GetVFLinkName(pciAddr)
+	assert.NoError(t, err)
+	assert.Equal(t, "eth0", name)
+}
+
+func TestGetVFLinkName_NoDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	defer fakeSysBusPCI(tmpDir)()
+
+	_, err := GetVFLinkName("0000:99:99.9")
+	assert.ErrorContains(t, err, "no such file or directory")
+}
+
+func TestGetVFLinkName_EmptyDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	defer fakeSysBusPCI(tmpDir)()
+
+	pciAddr := "0000:04:00.0"
+	vfNetDir := filepath.Join(tmpDir, pciAddr, "net")
+	if err := os.MkdirAll(vfNetDir, 0755); err != nil {
+		t.Fatalf("failed to create empty vf dir: %v", err)
+	}
+
+	_, err := GetVFLinkName(pciAddr)
+	assert.EqualError(t, err, fmt.Sprintf("VF device %s sysfs path (%s) has no entries", pciAddr, vfNetDir))
+}


### PR DESCRIPTION
The old version [GetVFLinkNames](https://github.com/k8snetworkplumbingwg/sriov-cni/blob/v2.1.0/pkg/utils/utils.go#L145-L163) from sriov-cni utils may raise an errror: `runtime error: index out of range [0] with length 0`, so copy the latest version to Antrea without importing the package.