### PR TITLE
Use a more robust way to extract the source Node IP from encapsulated IGMP messages

### DIFF
--- a/pkg/agent/multicast/mcast_discovery_test.go
+++ b/pkg/agent/multicast/mcast_discovery_test.go
@@ -143,9 +143,14 @@ func TestParseIGMPPacket(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			igmpMsg, err := parseIGMPPacket(tc.packet)
-			assert.Equal(t, tc.igmpMsg, igmpMsg)
-			assert.Equal(t, tc.err, err)
+			ipPacket, err := parseIPv4Packet(&tc.packet)
+			if err != nil {
+				assert.Equal(t, tc.err, err)
+			} else {
+				igmpMsg, err := parseIGMPPacket(ipPacket)
+				assert.Equal(t, tc.igmpMsg, igmpMsg)
+				assert.Equal(t, tc.err, err)
+			}
 		})
 	}
 }
@@ -237,16 +242,13 @@ func generatePacketWithMatches(m util.Message, ofport uint32, srcNodeIP net.IP, 
 	for i := range matches {
 		pkt.Match.AddField(matches[i])
 	}
-	if srcNodeIP != nil {
-		matchTunSrc := openflow15.NewTunnelIpv4SrcField(srcNodeIP, nil)
-		pkt.Match.AddField(*matchTunSrc)
-	}
 	ipPacket := &protocol.IPv4{
 		Version:  0x4,
 		IHL:      5,
 		Protocol: IGMPProtocolNumber,
 		Length:   20 + m.Len(),
 		Data:     m,
+		NWSrc:    srcNodeIP,
 	}
 	ethernetPkt := protocol.NewEthernet()
 	ethernetPkt.HWDst = pktInDstMAC

--- a/test/e2e/multicast_test.go
+++ b/test/e2e/multicast_test.go
@@ -591,7 +591,7 @@ func testMulticastForwardToMultipleInterfaces(t *testing.T, data *TestData, send
 
 func runTestMulticastBetweenPods(t *testing.T, data *TestData, mc multicastTestcase, nodeMulticastInterfaces map[int][]string, testNamespace string, transportInterface string, checkReceiverRoute bool, checkSenderRoute bool) {
 	currentEncapMode, _ := data.GetEncapMode()
-	if requiresExternalHostSupport(mc) && currentEncapMode == config.TrafficEncapModeEncap {
+	if requiresExternalHostSupport(mc) && currentEncapMode.SupportsEncap() {
 		t.Skipf("Multicast does not support using hostNetwork Pod to simulate the external host with encap mode, skip the case")
 	}
 	mcjoinWaitTimeout := defaultTimeout / time.Second


### PR DESCRIPTION
In hybrid or encap mode, IGMP reports between Nodes could be sent via tunnels using packet-out,
with the Node transport IP as the source for encapsulated packets. For remote Nodes:

- The underlay packet (carrying the encapsulated IGMP report) uses the Node transport IP as
  its source.
- The remote Node extracts this source IP of the underlay packet to determine `tun_dst`
  and install OVS flow-based tunnel flows.
- The installed OVS flow-based tunnel flows ensures that the multicast traffic is correctly
  forwarded over tunnel.

In hybrid or encap mode, however, the underlay packets may be SNATed before reaching the remote
Node. This means:

- The underlay packet source IP could be altered and no longer reflect the Node transport IP.
- Relying on the underlay source IP would cause incorrect OVS flow-based tunnel flows to be
  installed.

The Node transport IP is used as the source IP of the IGMP report packets. When sending the
packet via tunnel, the source IP of the underlay packet that encapsulating the IGMP packets
is the Node transport IP. On the remote Node receiving the packets, the source IP of the
underlay packet are used as the tun_dst to install flow-based tunnel flows, which ensure
that the multicast traffic can be forwarded to remote Node via tunnel properly.

To handle hybrid or encap mode properly, we are using a more robust way to extract the source
Node IP from encapsulated IGMP messages:

- Extract the source IP from the overlay IGMP packet, not the underlay one.
- The overlay packet’s source stays as the Node transport IP, even if underlay SNAT occurs.