### PR TITLE
Fix ServiceCIDR issue in Multi-cluster member controller

### DIFF
--- a/multicluster/build/yamls/antrea-multicluster-member.yml
+++ b/multicluster/build/yamls/antrea-multicluster-member.yml
@@ -1144,6 +1144,13 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - servicecidrs
+  verbs:
+  - get
+  - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/multicluster/cmd/multicluster-controller/controller.go
+++ b/multicluster/cmd/multicluster-controller/controller.go
@@ -22,6 +22,7 @@ import (
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
+	networkingv1 "k8s.io/api/networking/v1"
 	apiextensionclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -80,6 +81,7 @@ func init() {
 	utilruntime.Must(mcv1alpha2.AddToScheme(scheme))
 	utilruntime.Must(antreacrdv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(antreacrdv1beta1.AddToScheme(scheme))
+	utilruntime.Must(networkingv1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 }
 

--- a/multicluster/cmd/multicluster-controller/leader_test.go
+++ b/multicluster/cmd/multicluster-controller/leader_test.go
@@ -42,6 +42,7 @@ func initMockManager(mockManager *mocks.MockManager) {
 
 	mockManager.EXPECT().GetWebhookServer().Return(&webhook.DefaultServer{}).AnyTimes()
 	mockManager.EXPECT().GetWebhookServer().Return(&webhook.DefaultServer{}).AnyTimes()
+	mockManager.EXPECT().GetAPIReader().Return(fakeClient).AnyTimes()
 	mockManager.EXPECT().GetClient().Return(fakeClient).AnyTimes()
 	mockManager.EXPECT().GetScheme().Return(common.TestScheme).AnyTimes()
 	mockManager.EXPECT().GetControllerOptions().Return(config.Controller{

--- a/multicluster/cmd/multicluster-controller/member_test.go
+++ b/multicluster/cmd/multicluster-controller/member_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
+	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -93,7 +94,7 @@ func TestRunMember(t *testing.T) {
 			setupManagerAndCertControllerFunc = func(isLeader bool, o *Options) (ctrl.Manager, error) {
 				return mockMemberManager, nil
 			}
-			member.ServiceCIDRDiscoverFn = func(ctx context.Context, k8sClient client.Client, namespace string) (string, error) {
+			member.ServiceCIDRDiscoverFn = func(ctx context.Context, mgrConfig *rest.Config, apiReader client.Reader, k8sClient client.Client, namespace string) (string, error) {
 				return "10.101.0.0/16", nil
 			}
 			ctrl.SetupSignalHandler = mockSetupSignalHandler

--- a/multicluster/config/overlays/member/role.yaml
+++ b/multicluster/config/overlays/member/role.yaml
@@ -232,3 +232,10 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - servicecidrs
+  verbs:
+  - get
+  - list

--- a/multicluster/controllers/multicluster/common/test_data.go
+++ b/multicluster/controllers/multicluster/common/test_data.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -109,4 +110,5 @@ func init() {
 	utilruntime.Must(k8smcsapi.AddToScheme(TestScheme))
 	utilruntime.Must(k8sscheme.AddToScheme(TestScheme))
 	utilruntime.Must(crdv1beta1.AddToScheme(TestScheme))
+	utilruntime.Must(networkingv1.AddToScheme(TestScheme))
 }

--- a/multicluster/controllers/multicluster/member/node_controller.go
+++ b/multicluster/controllers/multicluster/member/node_controller.go
@@ -44,7 +44,7 @@ import (
 )
 
 var (
-	ServiceCIDRDiscoverFn = common.DiscoverServiceCIDRByInvalidServiceCreation
+	ServiceCIDRDiscoverFn = common.DiscoverClusterServiceCIDR
 
 	statusReadyPredicateFunc = func(e event.UpdateEvent) bool {
 		if e.ObjectOld == nil || e.ObjectNew == nil {
@@ -365,7 +365,7 @@ func (r *NodeReconciler) getGatawayNodeIP(node *corev1.Node) (string, string, er
 func (r *NodeReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if r.serviceCIDR == "" {
 		var err error
-		r.serviceCIDR, err = ServiceCIDRDiscoverFn(context.TODO(), r.Client, r.namespace)
+		r.serviceCIDR, err = ServiceCIDRDiscoverFn(context.Background(), mgr.GetConfig(), mgr.GetAPIReader(), r.Client, r.namespace)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The original way to get the ServiceCIDR is from an error message, but
the error message doesn't contain the Service IP range anymore since
1.33. Change it to a new network API to get Service CIDR conditionally
when the K8s version is newer than 1.33.0. 1.33.0 is the version which
the ServiceCIDR CR was enabled by default.

```
F0710 03:59:25.869671      14 member.go:45] Error running controller: error creating Node controller: could not determine
the ClusterIP range via Service creation - the expected error was not returned. The actual error was "Service \"invalid-svc\"
is invalid: spec.clusterIPs: Invalid value: []string{\"0.0.0.0\"}: failed to allocate IP 0.0.0.0: the provided network does not
match the current range"
```