### PR TITLE
[WIP]Fix ServiceCIDR issue in MC member cluster

### DIFF
--- a/multicluster/cmd/multicluster-controller/leader.go
+++ b/multicluster/cmd/multicluster-controller/leader.go
@@ -54,7 +54,7 @@ func runLeader(o *Options) error {
 	podNamespace := env.GetPodNamespace()
 	stopCh := signals.RegisterSignalHandlers()
 
-	mgr, err := setupManagerAndCertControllerFunc(true, o)
+	mgr, _, err := setupManagerAndCertControllerFunc(true, o)
 	if err != nil {
 		return err
 	}

--- a/multicluster/cmd/multicluster-controller/leader_test.go
+++ b/multicluster/cmd/multicluster-controller/leader_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 	"k8s.io/apimachinery/pkg/api/meta"
+	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
@@ -79,8 +80,8 @@ func TestRunLeader(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
 			mockLeaderManager := mocks.NewMockManager(mockCtrl)
 			initMockManager(mockLeaderManager)
-			setupManagerAndCertControllerFunc = func(isLeader bool, o *Options) (ctrl.Manager, error) {
-				return mockLeaderManager, nil
+			setupManagerAndCertControllerFunc = func(isLeader bool, o *Options) (ctrl.Manager, clientset.Interface, error) {
+				return mockLeaderManager, nil, nil
 			}
 			ctrl.SetupSignalHandler = mockSetupSignalHandler
 

--- a/multicluster/cmd/multicluster-controller/member_test.go
+++ b/multicluster/cmd/multicluster-controller/member_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
+	clientset "k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -90,8 +91,8 @@ func TestRunMember(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
 			mockMemberManager := mocks.NewMockManager(mockCtrl)
 			initMockManager(mockMemberManager)
-			setupManagerAndCertControllerFunc = func(isLeader bool, o *Options) (ctrl.Manager, error) {
-				return mockMemberManager, nil
+			setupManagerAndCertControllerFunc = func(isLeader bool, o *Options) (ctrl.Manager, clientset.Interface, error) {
+				return mockMemberManager, nil, nil
 			}
 			member.ServiceCIDRDiscoverFn = func(ctx context.Context, k8sClient client.Client, namespace string) (string, error) {
 				return "10.101.0.0/16", nil

--- a/multicluster/controllers/multicluster/member/node_controller_test.go
+++ b/multicluster/controllers/multicluster/member/node_controller_test.go
@@ -236,7 +236,7 @@ func TestNodeReconciler(t *testing.T) {
 			mcReconciler := NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false, false, make(chan struct{}))
 			mcReconciler.SetRemoteCommonArea(commonArea)
 			commonAreaGetter := mcReconciler
-			r := NewNodeReconciler(fakeClient, common.TestScheme, "default", "10.100.0.0/16", tt.precedence, commonAreaGetter)
+			r := NewNodeReconciler(fakeClient, common.TestScheme, "default", "10.100.0.0/16", tt.precedence, nil, commonAreaGetter)
 			r.activeGateway = tt.activeGateway
 			if _, err := r.Reconcile(common.TestCtx, tt.req); err != nil {
 				t.Errorf("Node Reconciler should handle Node events successfully but got error = %v", err)
@@ -318,7 +318,7 @@ func TestInitialize(t *testing.T) {
 			mcReconciler := NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false, false, make(chan struct{}))
 			mcReconciler.SetRemoteCommonArea(commonArea)
 			commonAreaGetter := mcReconciler
-			r := NewNodeReconciler(fakeClient, common.TestScheme, "default", "10.100.0.0/16", mcv1alpha1.PrecedencePublic, commonAreaGetter)
+			r := NewNodeReconciler(fakeClient, common.TestScheme, "default", "10.100.0.0/16", mcv1alpha1.PrecedencePublic, nil, commonAreaGetter)
 			if err := r.initialize(); err != nil {
 				t.Errorf("Expected initialize() successfully but got err: %v", err)
 			} else {
@@ -377,14 +377,14 @@ func TestClusterSetMapFunc(t *testing.T) {
 	ctx := context.Background()
 
 	fakeClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithObjects(clusterSet, node1).Build()
-	r := NewNodeReconciler(fakeClient, common.TestScheme, "default", "10.200.1.1/16", "", nil)
+	r := NewNodeReconciler(fakeClient, common.TestScheme, "default", "10.200.1.1/16", "", nil, nil)
 	requests := r.clusterSetMapFunc(ctx, clusterSet)
 	assert.Equal(t, expectedReqs, requests)
 
 	requests = r.clusterSetMapFunc(ctx, deletedClusterSet)
 	assert.Equal(t, []reconcile.Request{}, requests)
 
-	r = NewNodeReconciler(fakeClient, common.TestScheme, "mismatch_ns", "10.200.1.1/16", "", nil)
+	r = NewNodeReconciler(fakeClient, common.TestScheme, "mismatch_ns", "10.200.1.1/16", "", nil, nil)
 	requests = r.clusterSetMapFunc(ctx, clusterSet)
 	assert.Equal(t, []reconcile.Request{}, requests)
 }


### PR DESCRIPTION
The original way to get the ServiceCIDR is from an error message, but the error message doesn't contain the Service IP range anymore since 1.33. We move it to ServiceCIDR discovery interface to get the CIDR for now.