### PR TITLE
Remove AWS_SERVICE_USER_NAME usage and improve AWS EC2/ENI cleanup in SRIOV test scripts

### DIFF
--- a/ci/jenkins/jobs/projects-cloud.yaml
+++ b/ci/jenkins/jobs/projects-cloud.yaml
@@ -693,7 +693,7 @@
           - shell: |-
               #!/bin/bash
               sudo ./ci/test-conformance-eks.sh --aws-access-key ${{AWS_ACCESS_KEY}} --aws-secret-key ${{AWS_SECRET_KEY}} \
-                --aws-service-user-role-arn ${{AWS_SERVICE_USER_ROLE_ARN}} --aws-service-user ${{AWS_SERVICE_USER_NAME}} --cluster-name ${{JOB_NAME}}-${{BUILD_NUMBER}} \
+                --aws-service-user-role-arn ${{AWS_SERVICE_USER_ROLE_ARN}} --cluster-name ${{JOB_NAME}}-${{BUILD_NUMBER}} \
                 --log-mode detail --setup-only
           triggers:
           - timed: H H */2 * *
@@ -724,9 +724,6 @@
             - text:
                 credential-id: AWS_SERVICE_USER_ROLE_ARN # Jenkins secret that stores aws role arn
                 variable: AWS_SERVICE_USER_ROLE_ARN
-            - text:
-                credential-id: AWS_SERVICE_USER_NAME # Jenkins secret that stores aws source profile
-                variable: AWS_SERVICE_USER_NAME
       - 'cloud-{name}-{test_name}-cleanup':
           test_name: eks
           description: This is for deleting EKS test clusters.
@@ -1635,8 +1632,7 @@
               export WORKER_NODE_ENI=${{WORKER_NODE_ENI}}
               export SUBNET_CIDR_RES_ID=${{SUBNET_CIDR_RESERVATION_ID}}
               source ./ci/test-sriov-secondary-network-aws.sh --cleanup-only \
-                --aws-access-key ${{AWS_ACCESS_KEY}} --aws-secret-key ${{AWS_SECRET_KEY}} --aws-service-user-role-arn ${{AWS_SERVICE_USER_ROLE_ARN}} --aws-service-user ${{AWS_SERVICE_USER_NAME}} \
-                --CONTROLPLANE_INSTANCE_ID ${{CONTROLPLANE_INSTANCE_ID}}
+                --aws-access-key ${{AWS_ACCESS_KEY}} --aws-secret-key ${{AWS_SECRET_KEY}} --aws-service-user-role-arn ${{AWS_SERVICE_USER_ROLE_ARN}}
           concurrent: false
           disabled: false
           node: antrea-cloud
@@ -1659,9 +1655,6 @@
             - text:
                 credential-id: AWS_SERVICE_USER_ROLE_ARN
                 variable: AWS_SERVICE_USER_ROLE_ARN
-            - text:
-               credential-id: AWS_SERVICE_USER_NAME
-               variable: AWS_SERVICE_USER_NAME
       - '{name}-{test_name}-for-pull-request':
           disabled: false
           test_name: sriov-secondary-network-e2e
@@ -1693,7 +1686,7 @@
               [ "$DOCKER_REGISTRY" != "docker.io" ] || ./ci/jenkins/docker_login.sh --docker-user ${{DOCKER_USERNAME}} --docker-password ${{DOCKER_PASSWORD}}
               sudo ./ci/test-sriov-secondary-network-aws.sh --aws-access-key ${{AWS_ACCESS_KEY}} --aws-secret-key ${{AWS_SECRET_KEY}} \
                 --aws-security-group-id ${{AWS_SECURITY_GROUP}} --aws-subnet-id ${{AWS_SUBNET_ID}} \
-                --aws-ec2-ssh-key-name ${{AWS_EC2_SSH_KEY_NAME}} --aws-service-user-role-arn ${{AWS_SERVICE_USER_ROLE_ARN}} --aws-service-user ${{AWS_SERVICE_USER_NAME}}
+                --aws-ec2-ssh-key-name ${{AWS_EC2_SSH_KEY_NAME}} --aws-service-user-role-arn ${{AWS_SERVICE_USER_ROLE_ARN}}
           publishers:
           - email:
               notify-every-unstable-build: true
@@ -1724,9 +1717,6 @@
             - text:
                 credential-id: AWS_SERVICE_USER_ROLE_ARN
                 variable: AWS_SERVICE_USER_ROLE_ARN
-            - text:
-               credential-id: AWS_SERVICE_USER_NAME
-               variable: AWS_SERVICE_USER_NAME
             - ssh-user-private-key:
                 credential-id: AWS_EC2_SSH_KEY
                 key-file-variable: AWS_EC2_SSH_KEY

--- a/ci/test-conformance-eks.sh
+++ b/ci/test-conformance-eks.sh
@@ -38,7 +38,7 @@ AWS_SERVICE_USER_ROLE_ARN=""
 AWS_DURATION_SECONDS=7200
 
 _usage="Usage: $0 [--cluster-name <EKSClusterNameToUse>] [--kubeconfig <KubeconfigSavePath>] [--k8s-version <ClusterVersion>]\
-                  [--aws-access-key <AccessKey>] [--aws-secret-key <SecretKey>] [--aws-region <Region>] [--aws-service-user <ServiceUserName>]\
+                  [--aws-access-key <AccessKey>] [--aws-secret-key <SecretKey>] [--aws-region <Region>]\
                   [--aws-service-user-role-arn <ServiceUserRoleARN>] [--ssh-key <SSHKey] [--ssh-private-key <SSHPrivateKey] [--log-mode <SonobuoyResultLogLevel>]\
                   [--setup-only] [--cleanup-only]
 
@@ -50,7 +50,6 @@ Setup a EKS cluster to run K8s e2e community tests (Conformance & Network Policy
         --aws-access-key              AWS Acess Key for logging in to awscli.
         --aws-secret-key              AWS Secret Key for logging in to awscli.
         --aws-service-user-role-arn   AWS Service User Role ARN for logging in to awscli.
-        --aws-service-user            AWS Service User Name for logging in to awscli.
         --aws-region                  The AWS region where the cluster will be initiated. Defaults to us-east-2.
         --ssh-key                     The path of key to be used for ssh access to worker nodes.
         --log-mode                    Use the flag to set either 'report', 'detail', or 'dump' level data for sonobuoy results.

--- a/ci/test-conformance-eks.sh
+++ b/ci/test-conformance-eks.sh
@@ -87,10 +87,6 @@ case $key in
     AWS_SERVICE_USER_ROLE_ARN="$2"
     shift 2
     ;;
-    --aws-service-user)
-    AWS_SERVICE_USER_NAME="$2"
-    shift 2
-    ;;
     --aws-region)
     REGION="$2"
     shift 2


### PR DESCRIPTION
- Removed all usage and references to AWS_SERVICE_USER_NAME from ci/jenkins/jobs/projects-cloud.yaml and related test scripts.
  - Eliminated AWS_SERVICE_USER_NAME as a Jenkins credential and variable.
  - Removed --aws-service-user parameter and all associated handling from test-conformance-eks.sh and test-sriov-secondary-network-aws.sh.
  - Updated usage messages and documentation accordingly.
- Improved the cleanup logic in ci/test-sriov-secondary-network-aws.sh:
  - Refactored the clean_up function to dynamically find and remove all network interfaces attached to an instance, rather than relying on a single ENI argument.
  - Now waits for instance termination and for each ENI to be available before deletion, and handles possible missing ENIs gracefully.
  - Updated clean_up_all to call clean_up with just the instance IDs (no ENI).
- Minor logic fixes for setup/cleanup flags in test-sriov-secondary-network-aws.sh.  
These changes simplify credential handling and make AWS resource cleanup more robust and reliable during CI testing.