### PR TITLE
Remove trailing whitespace from default manifests

### DIFF
--- a/build/charts/antrea/conf/antrea-agent.conf
+++ b/build/charts/antrea/conf/antrea-agent.conf
@@ -296,7 +296,11 @@ flowExporter:
   # logged on the antrea agent. By default the full set of supported
   # protocols are exported which are:
   # "tcp", "udp", "sctp"
+  {{- if eq .protocolFilter nil }}
+  protocolFilter:
+  {{- else }}
   protocolFilter: {{ .protocolFilter }}
+  {{- end }}
 {{- end }}
 
 nodePortLocal:

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -4308,7 +4308,7 @@ data:
       # logged on the antrea agent. By default the full set of supported
       # protocols are exported which are:
       # "tcp", "udp", "sctp"
-      protocolFilter: 
+      protocolFilter:
 
     nodePortLocal:
     # Enable NodePortLocal, a feature used to make Pods reachable using port forwarding on the host. To
@@ -5502,7 +5502,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 7dcad556b009a75a16ec216923b3fe36202ee1addc65c5ec04059205be651699
+        checksum/config: c1bd24e62946e1280264a6b2c25f3e1a0050476fc245b7f1b6bb6079c90a643e
       labels:
         app: antrea
         component: antrea-agent
@@ -5750,7 +5750,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 7dcad556b009a75a16ec216923b3fe36202ee1addc65c5ec04059205be651699
+        checksum/config: c1bd24e62946e1280264a6b2c25f3e1a0050476fc245b7f1b6bb6079c90a643e
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -4308,7 +4308,7 @@ data:
       # logged on the antrea agent. By default the full set of supported
       # protocols are exported which are:
       # "tcp", "udp", "sctp"
-      protocolFilter: 
+      protocolFilter:
 
     nodePortLocal:
     # Enable NodePortLocal, a feature used to make Pods reachable using port forwarding on the host. To
@@ -5502,7 +5502,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 7dcad556b009a75a16ec216923b3fe36202ee1addc65c5ec04059205be651699
+        checksum/config: c1bd24e62946e1280264a6b2c25f3e1a0050476fc245b7f1b6bb6079c90a643e
       labels:
         app: antrea
         component: antrea-agent
@@ -5751,7 +5751,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 7dcad556b009a75a16ec216923b3fe36202ee1addc65c5ec04059205be651699
+        checksum/config: c1bd24e62946e1280264a6b2c25f3e1a0050476fc245b7f1b6bb6079c90a643e
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -4308,7 +4308,7 @@ data:
       # logged on the antrea agent. By default the full set of supported
       # protocols are exported which are:
       # "tcp", "udp", "sctp"
-      protocolFilter: 
+      protocolFilter:
 
     nodePortLocal:
     # Enable NodePortLocal, a feature used to make Pods reachable using port forwarding on the host. To
@@ -5502,7 +5502,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: e75cfe9bdf49d46d5a320fcbc9bf270384f8c729471c853ce2028fa2928eaa88
+        checksum/config: 9517c513519edba80e567621e47957d49dde18393756d62ff46edaca13fc7ace
       labels:
         app: antrea
         component: antrea-agent
@@ -5748,7 +5748,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: e75cfe9bdf49d46d5a320fcbc9bf270384f8c729471c853ce2028fa2928eaa88
+        checksum/config: 9517c513519edba80e567621e47957d49dde18393756d62ff46edaca13fc7ace
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -4321,7 +4321,7 @@ data:
       # logged on the antrea agent. By default the full set of supported
       # protocols are exported which are:
       # "tcp", "udp", "sctp"
-      protocolFilter: 
+      protocolFilter:
 
     nodePortLocal:
     # Enable NodePortLocal, a feature used to make Pods reachable using port forwarding on the host. To
@@ -5515,7 +5515,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: be503a3fa823f8f59d30534532c6029bc1f579c16b94ccdf1af6b8c8347f02e9
+        checksum/config: b1759a7185fce7308723e0f322796b8d22e55847448b94fc47085e08c36504ae
         checksum/ipsec-secret: d0eb9c52d0cd4311b6d252a951126bf9bea27ec05590bed8a394f0f792dcb2a4
       labels:
         app: antrea
@@ -5807,7 +5807,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: be503a3fa823f8f59d30534532c6029bc1f579c16b94ccdf1af6b8c8347f02e9
+        checksum/config: b1759a7185fce7308723e0f322796b8d22e55847448b94fc47085e08c36504ae
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -4308,7 +4308,7 @@ data:
       # logged on the antrea agent. By default the full set of supported
       # protocols are exported which are:
       # "tcp", "udp", "sctp"
-      protocolFilter: 
+      protocolFilter:
 
     nodePortLocal:
     # Enable NodePortLocal, a feature used to make Pods reachable using port forwarding on the host. To
@@ -5502,7 +5502,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 9aa91ee18252eb53f869c787913a108193152dfe0b429500356c4626d67a6712
+        checksum/config: 7246ad2aecb3e83060de547adaec7ac8a140920bf60f014d92e7aa3bb83ebf51
       labels:
         app: antrea
         component: antrea-agent
@@ -5748,7 +5748,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 9aa91ee18252eb53f869c787913a108193152dfe0b429500356c4626d67a6712
+        checksum/config: 7246ad2aecb3e83060de547adaec7ac8a140920bf60f014d92e7aa3bb83ebf51
       labels:
         app: antrea
         component: antrea-controller


### PR DESCRIPTION
When the `flowExporter.protocolFilter` Helm value is nil, we need to make sure that we don't add a trailing whitespace in the rendered antrea-agent.conf YAML. Otherwise this leads to formatting issues (no pretty-printing) when displaying or editing the antrea-config ConfigMap.

This is a known "issue":
https://github.com/kubernetes/kubernetes/issues/75446.

We already have at least one other configuration value, `egress.snatFullyRandomPorts`, for which we can have a nil value and that is handled in the same way.