### PR TITLE
fix: protocolFilter struct tag typo

### DIFF
--- a/pkg/config/agent/config.go
+++ b/pkg/config/agent/config.go
@@ -311,7 +311,7 @@ type FlowExporterConfig struct {
 	// logged on the antrea agent. By default the full set of supported
 	// protocols are exported which are:
 	// "tcp", "udp", "sctp"
-	ProtocolFilter []string `yaml:"protocols,omitempty"`
+	ProtocolFilter []string `yaml:"protocolFilter,omitempty"`
 }
 
 type MulticastConfig struct {


### PR DESCRIPTION
* When protocolFilter was introduced, the original name still remained in the FlowExporter's struct tag
* As a result, any user configuration of protocolFilter did not propagate to the agent
* The included unit test validates a match between the generated build yaml which provides the keys for user input and the struct tag. It confirms user's inputted value for protocolFitler is properly consumed by the agent