### PR TITLE
backport: fix: protocolFilter struct tag typo (#7329)

### DIFF
--- a/pkg/config/agent/config.go
+++ b/pkg/config/agent/config.go
@@ -311,7 +311,7 @@ type FlowExporterConfig struct {
 	// logged on the antrea agent. By default the full set of supported
 	// protocols are exported which are:
 	// "tcp", "udp", "sctp"
-	ProtocolFilter []string `yaml:"protocols,omitempty"`
+	ProtocolFilter []string `yaml:"protocolFilter,omitempty"`
 }
 
 type MulticastConfig struct {


### PR DESCRIPTION
* Backporting the fix from main to release-2.4
* When protocolFilter was introduced, the previously proposed name still remained in the FlowExporter's struct tag
* As a result, any user configuration of protocolFilter did not propagate to the agent correctly