### PR TITLE
Automated cherry pick of #7329: fix: protocolFilter struct tag typo

### DIFF
--- a/pkg/config/agent/config.go
+++ b/pkg/config/agent/config.go
@@ -311,7 +311,7 @@ type FlowExporterConfig struct {
 	// logged on the antrea agent. By default the full set of supported
 	// protocols are exported which are:
 	// "tcp", "udp", "sctp"
-	ProtocolFilter []string `yaml:"protocols,omitempty"`
+	ProtocolFilter []string `yaml:"protocolFilter,omitempty"`
 }
 
 type MulticastConfig struct {


### PR DESCRIPTION
Cherry pick of https://github.com/antrea-io/antrea/pull/7329 on release-2.4.

https://github.com/antrea-io/antrea/pull/7329: fix: protocolFilter struct tag typo

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.