### PR TITLE
[FlowAggregator] Add missing Run calls for nodeStore / serviceStore

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -700,9 +700,10 @@ func run(o *Options) error {
 		return err
 	}
 
+	var podStore objectstore.PodStore
 	var flowExporter *flowexporter.FlowExporter
 	if enableFlowExporter {
-		podStore := objectstore.NewPodStore(localPodInformer.Get())
+		podStore = objectstore.NewPodStore(localPodInformer.Get())
 		flowExporterOptions := &flowexporteroptions.FlowExporterOptions{
 			FlowCollectorAddr:      o.flowCollectorAddr,
 			FlowCollectorProto:     o.flowCollectorProto,
@@ -1031,6 +1032,7 @@ func run(o *Options) error {
 
 	// Start the goroutine to periodically export IPFIX flow records.
 	if enableFlowExporter {
+		go podStore.Run(stopCh)
 		go flowExporter.Run(stopCh)
 	}
 

--- a/cmd/flow-aggregator/flow-aggregator.go
+++ b/cmd/flow-aggregator/flow-aggregator.go
@@ -79,10 +79,14 @@ func run(configFile string) error {
 		serviceStore,
 		configFile,
 	)
-
 	if err != nil {
 		return err
 	}
+
+	go podStore.Run(stopCh)
+	go nodeStore.Run(stopCh)
+	go serviceStore.Run(stopCh)
+
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {

--- a/pkg/agent/flowexporter/exporter.go
+++ b/pkg/agent/flowexporter/exporter.go
@@ -159,7 +159,6 @@ func (exp *FlowExporter) GetDenyConnStore() *connections.DenyConnectionStore {
 }
 
 func (exp *FlowExporter) Run(stopCh <-chan struct{}) {
-	go exp.podStore.Run(stopCh)
 	// Start L7 connection flow socket
 	if features.DefaultFeatureGate.Enabled(features.L7FlowExporter) {
 		go exp.l7Listener.Run(stopCh)

--- a/pkg/flowaggregator/flowaggregator_test.go
+++ b/pkg/flowaggregator/flowaggregator_test.go
@@ -638,6 +638,10 @@ func TestFlowAggregator_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockPodStore := objectstoretest.NewMockPodStore(ctrl)
 	mockPodStore.EXPECT().HasSynced().Return(true)
+	mockNodeStore := objectstoretest.NewMockNodeStore(ctrl)
+	mockNodeStore.EXPECT().HasSynced().Return(true)
+	mockServiceStore := objectstoretest.NewMockServiceStore(ctrl)
+	mockServiceStore.EXPECT().HasSynced().Return(true)
 	mockIPFIXExporter, mockClickHouseExporter, mockS3Exporter, mockLogExporter := mockExporters(t, ctrl, nil, nil)
 	mockCollector := collectortesting.NewMockInterface(ctrl)
 	mockAggregationProcess := intermediatetesting.NewMockAggregationProcess(ctrl)
@@ -669,12 +673,13 @@ func TestFlowAggregator_Run(t *testing.T) {
 		configWatcher:           configWatcher,
 		updateCh:                updateCh,
 		podStore:                mockPodStore,
+		nodeStore:               mockNodeStore,
+		serviceStore:            mockServiceStore,
 	}
 
 	mockCollector.EXPECT().Run(gomock.Any())
 	mockAggregationProcess.EXPECT().Start()
 	mockAggregationProcess.EXPECT().Stop()
-	mockPodStore.EXPECT().Run(gomock.Any())
 
 	// Mock expectations determined by sequence of updateOptions operations below.
 	mockIPFIXExporter.EXPECT().Start().Times(2)


### PR DESCRIPTION
Without a call to Run, there is no worker to consume items from the deletion workqueue, and the size of the store will keep increasing until the process runs out-of-memory. We add the missing Run calls, which are now in cmd/flow-aggregator.

Additionally, we wait for the nodeStore and serviceStore to be synced before we start processing flows in the FlowAggregator. This is consistent with what we already do for the podStore, and helps avoid failed store lookups.