### PR TITLE
Automated cherry pick of #7346: Fix kind network cleanup failure on newly provisioned Jenkins

### DIFF
--- a/ci/kind/kind-setup.sh
+++ b/ci/kind/kind-setup.sh
@@ -328,7 +328,12 @@ function configure_vlan_subnets {
 function delete_vlan_subnets {
   echo "Deleting VLAN subnets"
 
-  bridge_id=$(docker network inspect kind -f {{.ID}})
+  bridge_id=$(docker network inspect -f '{{.ID}}' kind 2>/dev/null || true)
+  if [[ -z "$bridge_id" ]]; then
+    echo "kind network not found, skipping VLAN subnet deletion."
+    return
+  fi
+
   bridge_interface="br-${bridge_id:0:12}"
   vlan_interface_prefix="br-${bridge_id:0:7}."
 


### PR DESCRIPTION
Cherry pick of #7346 on release-2.4.

#7346: Fix kind network cleanup failure on newly provisioned Jenkins

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.