### PR TITLE
Automated cherry pick of #7343: Add missing Run calls for nodeStore /

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -700,9 +700,10 @@ func run(o *Options) error {
 		return err
 	}
 
+	var podStore objectstore.PodStore
 	var flowExporter *flowexporter.FlowExporter
 	if enableFlowExporter {
-		podStore := objectstore.NewPodStore(localPodInformer.Get())
+		podStore = objectstore.NewPodStore(localPodInformer.Get())
 		flowExporterOptions := &flowexporteroptions.FlowExporterOptions{
 			FlowCollectorAddr:      o.flowCollectorAddr,
 			FlowCollectorProto:     o.flowCollectorProto,
@@ -1031,6 +1032,7 @@ func run(o *Options) error {
 
 	// Start the goroutine to periodically export IPFIX flow records.
 	if enableFlowExporter {
+		go podStore.Run(stopCh)
 		go flowExporter.Run(stopCh)
 	}
 

--- a/cmd/flow-aggregator/flow-aggregator.go
+++ b/cmd/flow-aggregator/flow-aggregator.go
@@ -79,10 +79,14 @@ func run(configFile string) error {
 		serviceStore,
 		configFile,
 	)
-
 	if err != nil {
 		return err
 	}
+
+	go podStore.Run(stopCh)
+	go nodeStore.Run(stopCh)
+	go serviceStore.Run(stopCh)
+
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {

--- a/pkg/agent/flowexporter/exporter.go
+++ b/pkg/agent/flowexporter/exporter.go
@@ -159,7 +159,6 @@ func (exp *FlowExporter) GetDenyConnStore() *connections.DenyConnectionStore {
 }
 
 func (exp *FlowExporter) Run(stopCh <-chan struct{}) {
-	go exp.podStore.Run(stopCh)
 	// Start L7 connection flow socket
 	if features.DefaultFeatureGate.Enabled(features.L7FlowExporter) {
 		go exp.l7Listener.Run(stopCh)

--- a/pkg/flowaggregator/flowaggregator.go
+++ b/pkg/flowaggregator/flowaggregator.go
@@ -237,18 +237,20 @@ func (fa *flowAggregator) InitAggregationProcess() error {
 func (fa *flowAggregator) Run(stopCh <-chan struct{}) {
 	var wg sync.WaitGroup
 
-	// We first wait for the PodStore to sync to avoid lookup failures when processing records.
-	const podStoreSyncTimeout = 30 * time.Second
-	klog.InfoS("Waiting for PodStore to sync", "timeout", podStoreSyncTimeout)
-	if err := wait.PollUntilContextTimeout(wait.ContextForChannel(stopCh), 100*time.Millisecond, podStoreSyncTimeout, true, func(ctx context.Context) (done bool, err error) {
-		return fa.podStore.HasSynced(), nil
-	}); err != nil {
-		// PodStore not synced within a reasonable time. We continue with the rest of the
-		// function but there may be error logs when processing records.
-		klog.ErrorS(err, "PodStore not synced", "timeout", podStoreSyncTimeout)
-	} else {
-		klog.InfoS("PodStore synced")
-	}
+	// We first wait for the object stores to sync to avoid lookup failures when processing records.
+	const objectStoreSyncTimeout = 30 * time.Second
+	func() {
+		ctx, cancel := context.WithTimeout(wait.ContextForChannel(stopCh), objectStoreSyncTimeout)
+		defer cancel()
+		klog.InfoS("Waiting for object stores to sync", "timeout", objectStoreSyncTimeout)
+		if err := objectstore.WaitForStoreSyncs(ctx, fa.podStore.HasSynced, fa.nodeStore.HasSynced, fa.serviceStore.HasSynced); err != nil {
+			// Stores not synced within a reasonable time. We continue with the rest of the
+			// function but there may be error logs when processing records.
+			klog.ErrorS(err, "Object stores not synced", "timeout", objectStoreSyncTimeout)
+			return
+		}
+		klog.InfoS("Object stores synced")
+	}()
 
 	wg.Add(1)
 	go func() {
@@ -286,14 +288,6 @@ func (fa *flowAggregator) Run(stopCh <-chan struct{}) {
 	if fa.logExporter != nil {
 		fa.logExporter.Start()
 	}
-
-	wg.Add(1)
-	go func() {
-		// Waiting for this function to return on stop makes it easier to set expectations
-		// when testing.
-		defer wg.Done()
-		fa.podStore.Run(stopCh)
-	}()
 
 	wg.Add(1)
 	go func() {

--- a/pkg/flowaggregator/flowaggregator_test.go
+++ b/pkg/flowaggregator/flowaggregator_test.go
@@ -638,6 +638,10 @@ func TestFlowAggregator_Run(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockPodStore := objectstoretest.NewMockPodStore(ctrl)
 	mockPodStore.EXPECT().HasSynced().Return(true)
+	mockNodeStore := objectstoretest.NewMockNodeStore(ctrl)
+	mockNodeStore.EXPECT().HasSynced().Return(true)
+	mockServiceStore := objectstoretest.NewMockServiceStore(ctrl)
+	mockServiceStore.EXPECT().HasSynced().Return(true)
 	mockIPFIXExporter, mockClickHouseExporter, mockS3Exporter, mockLogExporter := mockExporters(t, ctrl, nil, nil)
 	mockCollector := collectortesting.NewMockInterface(ctrl)
 	mockAggregationProcess := intermediatetesting.NewMockAggregationProcess(ctrl)
@@ -669,12 +673,13 @@ func TestFlowAggregator_Run(t *testing.T) {
 		configWatcher:           configWatcher,
 		updateCh:                updateCh,
 		podStore:                mockPodStore,
+		nodeStore:               mockNodeStore,
+		serviceStore:            mockServiceStore,
 	}
 
 	mockCollector.EXPECT().Run(gomock.Any())
 	mockAggregationProcess.EXPECT().Start()
 	mockAggregationProcess.EXPECT().Stop()
-	mockPodStore.EXPECT().Run(gomock.Any())
 
 	// Mock expectations determined by sequence of updateOptions operations below.
 	mockIPFIXExporter.EXPECT().Start().Times(2)

--- a/pkg/util/objectstore/store.go
+++ b/pkg/util/objectstore/store.go
@@ -15,6 +15,7 @@
 package objectstore
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -334,4 +335,18 @@ func (s *ObjectStore[T]) processDeleteQueueItem(objectDeletionKey *objectKey) bo
 // HasSynced returns true when the event handler has been called for the initial list of Objects.
 func (s *ObjectStore[T]) HasSynced() bool {
 	return s.hasSynced()
+}
+
+// WaitForStoreSyncs waits for stores to sync. It returns an error if the context is cancelled. You
+// need to provide the HasSynced method for each store you want to wait on.
+func WaitForStoreSyncs(ctx context.Context, storeSyncs ...func() bool) error {
+	const storeSyncPollInterval = 100 * time.Millisecond
+	return wait.PollUntilContextCancel(ctx, storeSyncPollInterval, true, func(ctx context.Context) (done bool, err error) {
+		for _, synced := range storeSyncs {
+			if !synced() {
+				return false, nil
+			}
+		}
+		return true, nil
+	})
 }


### PR DESCRIPTION
Cherry pick of #7343 on release-2.4.

#7343: Add missing Run calls for nodeStore /

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.