### PR TITLE
Automated cherry pick of #7351: Correct ICMPv6 echo request type in ACNPICMPSupport (#7351)

### DIFF
--- a/test/e2e/antreapolicy_test.go
+++ b/test/e2e/antreapolicy_test.go
@@ -49,13 +49,6 @@ import (
 
 // common for all tests.
 var (
-	p80              int32 = 80
-	p81              int32 = 81
-	p6443            int32 = 6443
-	p8080            int32 = 8080
-	p8081            int32 = 8081
-	p8082            int32 = 8082
-	p8085            int32 = 8085
 	allPods          []Pod
 	podsByNamespace  map[string][]Pod
 	k8sUtils         *KubernetesUtils
@@ -4436,19 +4429,9 @@ func testACNPICMPSupport(t *testing.T, data *TestData) {
 	server1Name, server1IP, cleanupFunc := createAndWaitForPod(t, data, data.createNginxPodOnNode, "server1", nodeName(1), data.testNamespace, false)
 	defer cleanupFunc()
 
-	ICMPType := int32(8)
-	ICMPCode := int32(0)
 	builder := &ClusterNetworkPolicySpecBuilder{}
 	builder = builder.SetName("test-acnp-icmp").
 		SetPriority(1.0).SetAppliedToGroup([]ACNPAppliedToSpec{{PodSelector: map[string]string{"antrea-e2e": clientName}}})
-	builder.AddEgress(ACNPRuleBuilder{
-		BaseRuleBuilder: BaseRuleBuilder{
-			Protoc:      ProtocolICMP,
-			ICMPType:    &ICMPType,
-			ICMPCode:    &ICMPCode,
-			PodSelector: map[string]string{"antrea-e2e": server0Name},
-			Action:      crdv1beta1.RuleActionReject,
-		}})
 	builder.AddEgress(ACNPRuleBuilder{
 		BaseRuleBuilder: BaseRuleBuilder{
 			Protoc:      ProtocolICMP,
@@ -4458,6 +4441,16 @@ func testACNPICMPSupport(t *testing.T, data *TestData) {
 
 	testcases := []podToAddrTestStep{}
 	if clusterInfo.podV4NetworkCIDR != "" {
+		builder.AddEgress(ACNPRuleBuilder{
+			BaseRuleBuilder: BaseRuleBuilder{
+				Name:        "egress-ipv4",
+				Protoc:      ProtocolICMP,
+				ICMPType:    &icmpRequestType,
+				ICMPCode:    &icmpRequestCode,
+				PodSelector: map[string]string{"antrea-e2e": server0Name},
+				Action:      crdv1beta1.RuleActionReject,
+			}})
+
 		testcases = append(testcases, []podToAddrTestStep{
 			{
 				Pod(fmt.Sprintf("%s/%s", data.testNamespace, clientName)),
@@ -4474,6 +4467,16 @@ func testACNPICMPSupport(t *testing.T, data *TestData) {
 		}...)
 	}
 	if clusterInfo.podV6NetworkCIDR != "" {
+		builder.AddEgress(ACNPRuleBuilder{
+			BaseRuleBuilder: BaseRuleBuilder{
+				Name:        "egress-ipv6",
+				Protoc:      ProtocolICMP,
+				ICMPType:    &icmp6RequestType,
+				ICMPCode:    &icmpRequestCode,
+				PodSelector: map[string]string{"antrea-e2e": server0Name},
+				Action:      crdv1beta1.RuleActionReject,
+			}})
+
 		testcases = append(testcases, []podToAddrTestStep{
 			{
 				Pod(fmt.Sprintf("%s/%s", data.testNamespace, clientName)),

--- a/test/e2e/multicast_test.go
+++ b/test/e2e/multicast_test.go
@@ -45,8 +45,6 @@ func skipIfMulticastDisabled(tb testing.TB, data *TestData) {
 	}
 }
 
-var igmpQueryType = int32(0x11)
-
 func TestMulticast(t *testing.T) {
 	skipIfHasWindowsNodes(t)
 	skipIfNotIPv4Cluster(t)

--- a/test/e2e/net_constants.go
+++ b/test/e2e/net_constants.go
@@ -1,0 +1,39 @@
+// Copyright 2025 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+var (
+	protocolICMP   = int32(1)
+	protocolTCP    = int32(6)
+	protocolUDP    = int32(17)
+	protocolICMPv6 = int32(58)
+	tcpFlags       = int32(2) // SYN flag set
+)
+
+var (
+	icmpRequestType  = int32(8)
+	icmp6RequestType = int32(128)
+	icmpRequestCode  = int32(0)
+
+	igmpQueryType = int32(0x11)
+)
+
+var (
+	p80   = int32(80)
+	p81   = int32(81)
+	p6443 = int32(6443)
+	p8080 = int32(8080)
+	p8082 = int32(8082)
+)

--- a/test/e2e/nodenetworkpolicy_test.go
+++ b/test/e2e/nodenetworkpolicy_test.go
@@ -37,12 +37,6 @@ import (
 const labelNodeHostname = "kubernetes.io/hostname"
 
 func initializeAntreaNodeNetworkPolicy(t *testing.T, data *TestData, toHostNetworkPod bool) {
-	p80 = 80
-	p81 = 81
-	p8080 = 8080
-	p8081 = 8081
-	p8082 = 8082
-	p8085 = 8085
 	podsPerNamespace = []string{"a"}
 	suffix := randName("")
 	namespaces = make(map[string]TestNamespaceMeta)

--- a/test/e2e/traceflow_test.go
+++ b/test/e2e/traceflow_test.go
@@ -96,14 +96,6 @@ func skipIfTraceflowDisabled(t *testing.T) {
 	skipIfFeatureDisabled(t, features.Traceflow, true, true)
 }
 
-var (
-	protocolICMP   = int32(1)
-	protocolTCP    = int32(6)
-	protocolUDP    = int32(17)
-	protocolICMPv6 = int32(58)
-	tcpFlags       = int32(2) // SYN flag set
-)
-
 // testTraceflowIntraNodeANNP verifies if traceflow can trace intra node traffic with some Antrea NetworkPolicy sets.
 func testTraceflowIntraNodeANNP(t *testing.T, data *TestData) {
 	var err error

--- a/test/e2e/vmagent_test.go
+++ b/test/e2e/vmagent_test.go
@@ -46,11 +46,6 @@ const (
 	linuxOS              = "Linux"
 )
 
-var (
-	ICMPType = int32(8)
-	ICMPCode = int32(0)
-)
-
 type vmInfo struct {
 	nodeName string
 	osType   string
@@ -630,8 +625,8 @@ func createANPForExternalNode(t *testing.T, data *TestData, name, namespace stri
 		ruleFunc(ANNPRuleBuilder{
 			BaseRuleBuilder: BaseRuleBuilder{
 				Protoc:   ProtocolICMP,
-				ICMPType: &ICMPType,
-				ICMPCode: &ICMPCode,
+				ICMPType: &icmpRequestType,
+				ICMPCode: &icmpRequestCode,
 				Action:   ruleAction,
 				IPBlock:  ipBlock,
 			}})


### PR DESCRIPTION
Cherry pick of #7351 on release-2.4.

#7351: Correct ICMPv6 echo request type in ACNPICMPSupport (#7351)

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.