### PR TITLE
Automated cherry pick of #7265: Fix ACNP applied to NodePort failing to reject traffic in

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -467,6 +467,73 @@ jobs:
         path: log.tar.gz
         retention-days: 30
 
+  test-e2e-hybrid-non-default:
+    name: E2e tests on a Kind cluster on Linux (hybrid) with non default values (proxyAll=true)
+    needs: [ build-antrea-coverage-image ]
+    runs-on: [ ubuntu-latest ]
+    steps:
+      - name: Free disk space
+        # https://github.com/actions/virtual-environments/issues/709
+        run: |
+          sudo apt-get clean
+          df -h
+      - uses: actions/checkout@v4
+        with:
+          show-progress: false
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+      - name: Download Antrea image from previous job
+        uses: actions/download-artifact@v4
+        with:
+          name: antrea-ubuntu-cov
+      - name: Load Antrea image
+        run: |
+          docker load -i antrea-ubuntu.tar
+      - name: Install Kind
+        run: |
+          KIND_VERSION=$(head -n1 ./ci/kind/version)
+          curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
+          chmod +x ./kind
+          sudo mv kind /usr/local/bin
+      - name: Run e2e tests
+        run: |
+          mkdir log
+          mkdir test-e2e-hybrid-non-default-coverage
+          ANTREA_LOG_DIR=$PWD/log ANTREA_COV_DIR=$PWD/test-e2e-hybrid-non-default-coverage ./ci/kind/test-e2e-kind.sh \
+            --encap-mode hybrid \
+            --coverage \
+            --proxy-all \
+            --skip mode-irrelevant
+      - name: Tar coverage files
+        run: tar -czf test-e2e-hybrid-non-default-coverage.tar.gz test-e2e-hybrid-non-default-coverage
+      - name: Upload coverage for test-e2e-hybrid-non-default-coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-e2e-hybrid-non-default-coverage
+          path: test-e2e-hybrid-non-default-coverage.tar.gz
+          retention-days: 30
+      - name: Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: '**/*.cov.out'
+          disable_search: true
+          flags: kind-e2e-tests
+          name: codecov-test-e2e-non-default-noencap
+          directory: test-e2e-hybrid-non-default-coverage
+          fail_ci_if_error: ${{ github.event_name == 'push' }}
+      - name: Tar log files
+        if: ${{ failure() }}
+        run: tar -czf log.tar.gz log
+      - name: Upload test log
+        uses: actions/upload-artifact@v4
+        if: ${{ failure() }}
+        with:
+          name: e2e-kind-hybrid-non-default.tar.gz
+          path: log.tar.gz
+          retention-days: 30
+
   test-e2e-flow-visibility:
     name: E2e tests on a Kind cluster on Linux for Flow Visibility
     needs: [build-antrea-coverage-image, build-flow-aggregator-coverage-image]
@@ -908,6 +975,7 @@ jobs:
     - test-e2e-encap-all-features-enabled
     - test-e2e-noencap
     - test-e2e-hybrid
+    - test-e2e-hybrid-non-default
     - test-upgrade-from-N-1
     - test-upgrade-from-N-2
     - test-compatible-N-1

--- a/docs/antrea-network-policy.md
+++ b/docs/antrea-network-policy.md
@@ -1650,7 +1650,9 @@ only a NodePort Service can be referred by `service` field.
 
 There are a few **restrictions** on configuring a policy/rule that applies to NodePort Services:
 
-1. This feature can only work when Antrea proxyAll is enabled and kube-proxy is disabled.
+1. This feature can only work when Antrea proxyAll is enabled.
+   - For Antrea versions prior to v2.1.0, kube-proxy must also be disabled.
+   - For Antrea v2.1.0 and later, disabling kube-proxy is no longer required.
 2. `service` field cannot be used with any other fields in `appliedTo`.
 3. a policy or a rule can't be applied to both a NodePort Service and other entities at the same time.
 4. If a `appliedTo` with `service` is used at policy level, then this policy can only contain ingress rules.

--- a/pkg/agent/controller/networkpolicy/reject_test.go
+++ b/pkg/agent/controller/networkpolicy/reject_test.go
@@ -38,6 +38,7 @@ func TestGetRejectType(t *testing.T) {
 		antreaProxyEnabled bool
 		srcIsLocal         bool
 		dstIsLocal         bool
+		srcFromTun         bool
 		expectRejectType   rejectType
 	}{
 		{
@@ -105,12 +106,21 @@ func TestGetRejectType(t *testing.T) {
 			expectRejectType:   rejectNoAPServiceRemoteToLocal,
 		},
 		{
-			name:               "rejectServiceRemoteToExternal",
+			name:               "rejectServiceRemoteFromTunToExternal",
 			isServiceTraffic:   true,
 			antreaProxyEnabled: true,
 			srcIsLocal:         false,
 			dstIsLocal:         false,
-			expectRejectType:   rejectServiceRemoteToExternal,
+			srcFromTun:         true,
+			expectRejectType:   rejectServiceRemoteFromTunToExternal,
+		},
+		{
+			name:               "rejectServiceRemoteFromGwToExternal",
+			isServiceTraffic:   true,
+			antreaProxyEnabled: true,
+			srcIsLocal:         false,
+			dstIsLocal:         false,
+			expectRejectType:   rejectServiceRemoteFromGwToExternal,
 		},
 		{
 			name:               "unsupported pod2pod remote2remote",
@@ -131,7 +141,7 @@ func TestGetRejectType(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rejectType := getRejectType(tt.isServiceTraffic, tt.antreaProxyEnabled, tt.srcIsLocal, tt.dstIsLocal)
+			rejectType := getRejectType(tt.isServiceTraffic, tt.antreaProxyEnabled, tt.srcIsLocal, tt.dstIsLocal, tt.srcFromTun)
 			assert.Equal(t, tt.expectRejectType, rejectType)
 		})
 	}
@@ -358,15 +368,15 @@ func TestGetRejectOFPorts(t *testing.T) {
 			expectOutPort: gwPort,
 		},
 		{
-			name:          "rejectServiceRemoteToExternal",
-			rejectType:    rejectServiceRemoteToExternal,
+			name:          "RejectServiceRemoteFromTunToExternal",
+			rejectType:    rejectServiceRemoteFromTunToExternal,
 			tunPort:       tunPort,
 			expectInPort:  tunPort,
 			expectOutPort: unsetPort,
 		},
 		{
-			name:          "RejectServiceRemoteToExternalWithoutTun",
-			rejectType:    rejectServiceRemoteToExternal,
+			name:          "RejectServiceRemoteFromGatewayToExternal",
+			rejectType:    rejectServiceRemoteFromGwToExternal,
 			tunPort:       unsetPort,
 			expectInPort:  gwPort,
 			expectOutPort: unsetPort,

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -1194,10 +1194,12 @@ func (f *featurePodConnectivity) l2ForwardCalcFlow(dstMAC net.HardwareAddr, ofPo
 }
 
 // l2ForwardOutputHairpinServiceFlow generates the flow to output the packet of hairpin Service connection with IN_PORT
-// action.
+// action. It matches OutputToOFPortRegMark to ensure only packets explicitly marked for output are processed, excluding
+// packets intended for packet-in to the controller.
 func (f *featureService) l2ForwardOutputHairpinServiceFlow() binding.Flow {
 	return OutputTable.ofTable.BuildFlow(priorityHigh).
 		Cookie(f.cookieAllocator.Request(f.category).Raw()).
+		MatchRegMark(OutputToOFPortRegMark).
 		MatchCTMark(HairpinCTMark).
 		Action().OutputInPort().
 		Done()

--- a/pkg/agent/openflow/service_test.go
+++ b/pkg/agent/openflow/service_test.go
@@ -45,7 +45,7 @@ func serviceInitFlows(proxyEnabled, isIPv4, proxyAllEnabled, dsrEnabled bool) []
 			"cookie=0x1030000000000, table=SNAT, priority=200,ct_state=+new+trk,ct_mark=0x40/0x40,ip,reg0=0x3/0xf actions=ct(commit,table=L2ForwardingCalc,zone=65521,nat(src=10.10.0.1),exec(set_field:0x10/0x10->ct_mark,set_field:0x40/0x40->ct_mark))",
 			"cookie=0x1030000000000, table=SNAT, priority=190,ct_state=+new+trk,ct_mark=0x20/0x20,ip,reg0=0x2/0xf actions=ct(commit,table=L2ForwardingCalc,zone=65521,nat(src=10.10.0.1),exec(set_field:0x10/0x10->ct_mark))",
 			"cookie=0x1030000000000, table=SNAT, priority=200,ct_state=-new-rpl+trk,ct_mark=0x20/0x20,ip actions=ct(table=L2ForwardingCalc,zone=65521,nat)",
-			"cookie=0x1030000000000, table=Output, priority=210,ct_mark=0x40/0x40 actions=IN_PORT",
+			"cookie=0x1030000000000, table=Output, priority=210,ct_mark=0x40/0x40,reg0=0x200000/0x600000 actions=IN_PORT",
 		}
 		if proxyAllEnabled {
 			flows = append(flows,
@@ -78,7 +78,7 @@ func serviceInitFlows(proxyEnabled, isIPv4, proxyAllEnabled, dsrEnabled bool) []
 			"cookie=0x1030000000000, table=SNAT, priority=200,ct_state=+new+trk,ct_mark=0x40/0x40,ipv6,reg0=0x3/0xf actions=ct(commit,table=L2ForwardingCalc,zone=65511,nat(src=fec0:10:10::1),exec(set_field:0x10/0x10->ct_mark,set_field:0x40/0x40->ct_mark))",
 			"cookie=0x1030000000000, table=SNAT, priority=200,ct_state=-new-rpl+trk,ct_mark=0x20/0x20,ipv6 actions=ct(table=L2ForwardingCalc,zone=65511,nat)",
 			"cookie=0x1030000000000, table=SNAT, priority=190,ct_state=+new+trk,ct_mark=0x20/0x20,ipv6,reg0=0x2/0xf actions=ct(commit,table=L2ForwardingCalc,zone=65511,nat(src=fec0:10:10::1),exec(set_field:0x10/0x10->ct_mark))",
-			"cookie=0x1030000000000, table=Output, priority=210,ct_mark=0x40/0x40 actions=IN_PORT",
+			"cookie=0x1030000000000, table=Output, priority=210,ct_mark=0x40/0x40,reg0=0x200000/0x600000 actions=IN_PORT",
 		}
 		if proxyAllEnabled {
 			flows = append(flows,

--- a/test/e2e/antreapolicy_test.go
+++ b/test/e2e/antreapolicy_test.go
@@ -3993,6 +3993,7 @@ func testACNPICMPSupport(t *testing.T, data *TestData) {
 
 func testACNPNodePortServiceSupport(t *testing.T, data *TestData, serverNamespace string) {
 	skipIfProxyAllDisabled(t, data)
+	skipIfNumNodesLessThan(t, 3)
 
 	// Create a NodePort Service.
 	ipProtocol := v1.IPv4Protocol
@@ -4015,7 +4016,7 @@ func testACNPNodePortServiceSupport(t *testing.T, data *TestData, serverNamespac
 
 	// Create another netns to fake an external network on the host network Pod.
 	cmd, testNetns := getCommandInFakeExternalNetwork("sleep 3600", 24, "1.1.1.1", "1.1.1.254")
-	clientNames := []string{"client0", "client1"}
+	clientNames := []string{"client0", "client1", "client2"}
 	for idx, clientName := range clientNames {
 		if err := NewPodBuilder(clientName, data.testNamespace, agnhostImage).OnNode(nodeName(idx)).WithCommand([]string{"sh", "-c", cmd}).InHostNetwork().Privileged().Create(data); err != nil {
 			t.Fatalf("Failed to create client Pod: %v", err)


### PR DESCRIPTION
Cherry pick of #7265 on release-2.3.

#7265: Fix ACNP applied to NodePort failing to reject traffic in

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.