### PR TITLE
Automated cherry pick of #7282: More robust way to extract source Node IP from encapsulated

### DIFF
--- a/pkg/agent/multicast/mcast_discovery_test.go
+++ b/pkg/agent/multicast/mcast_discovery_test.go
@@ -143,9 +143,14 @@ func TestParseIGMPPacket(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			igmpMsg, err := parseIGMPPacket(tc.packet)
-			assert.Equal(t, tc.igmpMsg, igmpMsg)
-			assert.Equal(t, tc.err, err)
+			ipPacket, err := parseIPv4Packet(&tc.packet)
+			if err != nil {
+				assert.Equal(t, tc.err, err)
+			} else {
+				igmpMsg, err := parseIGMPPacket(ipPacket)
+				assert.Equal(t, tc.igmpMsg, igmpMsg)
+				assert.Equal(t, tc.err, err)
+			}
 		})
 	}
 }
@@ -237,16 +242,13 @@ func generatePacketWithMatches(m util.Message, ofport uint32, srcNodeIP net.IP, 
 	for i := range matches {
 		pkt.Match.AddField(matches[i])
 	}
-	if srcNodeIP != nil {
-		matchTunSrc := openflow15.NewTunnelIpv4SrcField(srcNodeIP, nil)
-		pkt.Match.AddField(*matchTunSrc)
-	}
 	ipPacket := &protocol.IPv4{
 		Version:  0x4,
 		IHL:      5,
 		Protocol: IGMPProtocolNumber,
 		Length:   20 + m.Len(),
 		Data:     m,
+		NWSrc:    srcNodeIP,
 	}
 	ethernetPkt := protocol.NewEthernet()
 	ethernetPkt.HWDst = pktInDstMAC

--- a/test/e2e/multicast_test.go
+++ b/test/e2e/multicast_test.go
@@ -591,7 +591,7 @@ func testMulticastForwardToMultipleInterfaces(t *testing.T, data *TestData, send
 
 func runTestMulticastBetweenPods(t *testing.T, data *TestData, mc multicastTestcase, nodeMulticastInterfaces map[int][]string, testNamespace string, transportInterface string, checkReceiverRoute bool, checkSenderRoute bool) {
 	currentEncapMode, _ := data.GetEncapMode()
-	if requiresExternalHostSupport(mc) && currentEncapMode == config.TrafficEncapModeEncap {
+	if requiresExternalHostSupport(mc) && currentEncapMode.SupportsEncap() {
 		t.Skipf("Multicast does not support using hostNetwork Pod to simulate the external host with encap mode, skip the case")
 	}
 	mcjoinWaitTimeout := defaultTimeout / time.Second


### PR DESCRIPTION
Cherry pick of #7282 on release-2.4.

#7282: More robust way to extract source Node IP from encapsulated

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.