### PR TITLE
Add Disclaimer to Azure Docs and Code

### DIFF
--- a/build/yamls/antrea-aks-node-init.yml
+++ b/build/yamls/antrea-aks-node-init.yml
@@ -1,3 +1,7 @@
+# ====== Azure Support Disclaimer ======
+# Due to limited resources, Azure support is no longer tested starting with Antrea 2.5.
+# Azure-related code and features are provided as-is and are not verified.
+# Any issues related to Azure will be addressed on a best-effort basis.
 kind: DaemonSet
 apiVersion: apps/v1
 metadata:

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -1,3 +1,7 @@
+# ====== Azure Support Disclaimer ======
+# Due to limited resources, Azure support is no longer tested starting with Antrea 2.5.
+# Azure-related code and features are provided as-is and are not verified.
+# Any issues related to Azure will be addressed on a best-effort basis.
 ---
 # Source: antrea/crds/antreaagentinfo.yaml
 apiVersion: apiextensions.k8s.io/v1

--- a/build/yamls/chart-values/antrea-aks.yml
+++ b/build/yamls/chart-values/antrea-aks.yml
@@ -1,3 +1,7 @@
+# ====== Azure Support Disclaimer ======
+# Due to limited resources, Azure support is no longer tested starting with Antrea 2.5.
+# Azure-related code and features are provided as-is and are not verified.
+# Any issues related to Azure will be addressed on a best-effort basis.
 trafficEncapMode: "networkPolicyOnly"
 agent:
   dnsPolicy: "ClusterFirst"

--- a/ci/test-conformance-aks.sh
+++ b/ci/test-conformance-aks.sh
@@ -14,6 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# ====== Azure Support Disclaimer ======
+# Due to limited resources, Azure support is no longer tested starting with Antrea 2.5.
+# Azure-related code and features are provided as-is and are not verified.
+# Any issues related to Azure will be addressed on a best-effort basis.
+
 set -exu
 
 function echoerr {
@@ -32,7 +37,12 @@ TEST_SCRIPT_RC=0
 MODE="report"
 KUBE_CONFORMANCE_IMAGE_VERSION=auto
 
-_usage="Usage: $0 [--cluster-name <AKSClusterNameToUse>] [--kubeconfig <KubeconfigSavePath>] [--k8s-version <ClusterVersion>]\
+_usage="====== Azure Support Disclaimer ======
+Due to limited resources, Azure support is no longer tested starting with Antrea 2.5.
+Azure-related code and features are provided as-is and are not verified.
+Any issues related to Azure will be addressed on a best-effort basis.
+
+Usage: $0 [--cluster-name <AKSClusterNameToUse>] [--kubeconfig <KubeconfigSavePath>] [--k8s-version <ClusterVersion>]\
                   [--azure-app-id <AppID>] [--azure-tenant-id <TenantID>] [--azure-password <Password>] \
                   [--aks-region <Region>] [--log-mode <SonobuoyResultLogLevel>] [--setup-only] [--cleanup-only]
 

--- a/docs/aks-installation.md
+++ b/docs/aks-installation.md
@@ -1,5 +1,10 @@
 # Deploying Antrea on AKS and AKS Engine
 
+> [!NOTE]
+> Due to limited resources, Azure support is no longer tested starting with Antrea 2.5.
+> Azure-related code and features are provided as-is and are not verified.
+> Any issues related to Azure will be addressed on a best-effort basis.
+
 This document describes steps to deploy Antrea to an AKS cluster or an AKS
 Engine cluster.
 

--- a/docs/contributors/eks-terraform.md
+++ b/docs/contributors/eks-terraform.md
@@ -1,6 +1,6 @@
 # Deploying EKS with Antrea
 
-Antrea may run in networkPolicyOnly mode in AKS and EKS clusters. This document
+Antrea may run in networkPolicyOnly mode in EKS clusters. This document
 describes the steps to create an EKS cluster with Antrea using terraform.
 
 ## Common Prerequisites

--- a/docs/contributors/github-labels.md
+++ b/docs/contributors/github-labels.md
@@ -58,7 +58,7 @@ The labels in this list originated within Kubernetes at
 | area/OS/linux                      | Issues or PRs related to the Linux operating system | Any |
 | area/OS/windows                    | Issues or PRs related to the Windows operating system | Any |
 | area/provider/aws                  | Issues or PRs related to aws provider | Any |
-| area/provider/azure                | Issues or PRs related to azure provider | Any |
+| area/provider/azure                | Issues or PRs related to azure provider[^Disclaimer] | Any |
 | area/provider/gcp                  | Issues or PRs related to gcp provider | Any |
 | area/provider/vmware               | Issues or PRs related to vmware provider | Any |
 | area/proxy                         | Issues or PRs related to proxy functions in Antrea | Any |
@@ -113,6 +113,10 @@ The labels in this list originated within Kubernetes at
 | triage/unresolved                  | Indicates an issue that can not or will not be resolved. | Humans |
 | action/backport                    | Indicates a PR that requires backports. | Humans |
 | action/release-note                | Indicates a PR that should be included in release notes.  | Humans |
+
+[^Disclaimer]: Due to limited resources, Azure support is no longer tested starting with Antrea 2.5.
+  Azure-related code and features are provided as-is and are not verified.
+  Any issues related to Azure will be addressed on a best-effort basis.
 
 ## Labels that apply only to issues
 

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -302,10 +302,7 @@ another cloud CNI and cloud network to implement Pod IPAM and cross-Node traffic
 forwarding. Refer to the [NetworkPolicyOnly mode design document](policy-only.md)
 for more information.
 
-[Antrea for AKS
-Engine](https://github.com/Azure/aks-engine/blob/master/docs/topics/features.md#feat-antrea)
-and [Antrea EKS support](../eks-installation.md) work in `NetworkPolicyOnly`
-mode.
+[Antrea EKS support](../eks-installation.md) works in `NetworkPolicyOnly` mode.
 
 ## Features
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -170,14 +170,18 @@ please refer to this [guide](minikube.md).
 To deploy Antrea in a [Rancher](https://github.com/rancher/rancher) managed cluster,
 please refer to this [guide](kubernetes-installers.md#rancher).
 
-### Deploying Antrea in AKS, EKS, and GKE
+### Deploying Antrea in EKS, GKE, and AKS
 
 Antrea can work with cloud managed Kubernetes services, and can be deployed to
-AKS, EKS, and GKE clusters.
+EKS, GEK, and AKS [^Disclaimer] clusters.
 
 * To deploy Antrea to an AKS or an AKS Engine cluster, please refer to [the AKS installation guide](aks-installation.md).
 * To deploy Antrea to an EKS cluster, please refer to [the EKS installation guide](eks-installation.md).
 * To deploy Antrea to a GKE cluster, please refer to [the GKE installation guide](gke-installation.md).
+
+[^Disclaimer]: Due to limited resources, Azure support is no longer tested starting with Antrea 2.5.
+  Azure-related code and features are provided as-is and are not verified.
+  Any issues related to Azure will be addressed on a best-effort basis.
 
 ### Deploying Antrea with Custom Certificates
 

--- a/docs/kubernetes-installers.md
+++ b/docs/kubernetes-installers.md
@@ -19,8 +19,6 @@ work with that Antrea version.
 | - | Kops v1.20, K8s v1.20.5 | AWS EC2 | Ubuntu 20.04.2 LTS (5.4.0-1041-aws) amd64, containerd://1.4.4 | t3.medium | [results tarball](http://downloads.antrea.io/artifacts/sonobuoy-conformance/kops_202104212218_sonobuoy_bf0f8e77-c9df-472a-85e2-65e456cf4d83.tar.gz) |  |
 | - | EKS, K8s v1.17.12 | AWS | AmazonLinux2, docker | t3.medium |  | Antrea CI |
 | - | GKE, K8s v1.19.8-gke.1600 | GCP | Ubuntu 18.04, docker | e2-standard-4 |  | Antrea CI |
-| - | AKS, K8s v1.18.14 | Azure | Ubuntu 18.04, moby | Standard_DS2_v2 |  | Antrea CI |
-| - | AKS, K8s v1.19.9 | Azure | Ubuntu 18.04, containerd | Standard_DS2_v2 |  | Antrea CI |
 | - | Kind v0.9.0, K8s v1.19.1 | N/A | Ubuntu 20.10, containerd://1.4.0 | N/A |  | [Requirements for using Antrea on Kind](kind.md) |
 | - | Minikube v1.25.0 | N/A | Ubuntu 20.04.2 LTS (5.10.76-linuxkit) arm64, docker://20.10.12 | 8GB RAM | | |
 | v1.11.0 | Kubeadm v1.20.2 | N/A | openEuler 22.03 LTS, docker://18.09.0 | 10GB RAM | | |

--- a/docs/maintainers/release.md
+++ b/docs/maintainers/release.md
@@ -36,7 +36,7 @@ release. We use `<TAG>` as a placeholder for the release tag (e.g. `v1.4.0`).
    - Jenkins tests need to be [triggered manually](../../CONTRIBUTING.md#getting-your-pr-verified-by-ci).
    - Cloud tests need to be triggered manually through the
      [Jenkins web UI](https://jenkins.antrea.io/). Admin access is
-     required. For each job (AKS, EKS, GKE), click on `Build with Parameters`,
+     required. For each job (EKS, GKE), click on `Build with Parameters`,
      and enter the name of your fork as `ANTREA_REPO` and the name of your
      branch as `ANTREA_GIT_REVISION`. Test starting times need to be staggered:
      if multiple jobs run at the same time, the Jenkins worker may run

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -141,7 +141,7 @@ we guarantee that 0.10 supports at least 1.19, 1.18 and 1.17 (in practice it
 also supports K8s 1.16).
 
 In addition, we strive to support the K8s versions used by default in
-cloud-managed K8s services ([EKS], [AKS] and [GKE] regular channel).
+cloud-managed K8s services ([EKS] and [GKE] regular channel).
 
 ## Deprecation policies
 
@@ -453,7 +453,6 @@ ignored by Antrea, and the behavior may not be what you expect.
 [Semantic Versioning]: https://semver.org/
 [CHANGELOG]: ../CHANGELOG.md
 [EKS]: https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
-[AKS]: https://docs.microsoft.com/en-us/azure/aks/supported-kubernetes-versions
 [GKE]: https://cloud.google.com/kubernetes-engine/docs/release-notes
 [`deprecated` field]: https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#version-deprecation
 [conversion webhook]: https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definition-versioning/#webhook-conversion

--- a/hack/generate-standard-manifests.sh
+++ b/hack/generate-standard-manifests.sh
@@ -128,6 +128,15 @@ for values in $VALUES_FILES; do
           "$ANTREA_CHART" \
           > "$OUTPUT_DIR/$values" \
           2> >(grep -v 'This is insecure' >&2)
+  if [ "$values" = "antrea-aks.yml" ]; then
+    cat - "$OUTPUT_DIR/$values" <<EOF >"$OUTPUT_DIR/${values}-disclaimer"
+# ====== Azure Support Disclaimer ======
+# Due to limited resources, Azure support is no longer tested starting with Antrea 2.5.
+# Azure-related code and features are provided as-is and are not verified.
+# Any issues related to Azure will be addressed on a best-effort basis.
+EOF
+  mv "$OUTPUT_DIR/${values}-disclaimer" "$OUTPUT_DIR/$values"
+  fi
 done
 
 # We also generate a manifest which only includes CRD resources (all of them).

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1259,7 +1259,7 @@ func (i *Initializer) patchNodeAnnotations(nodeName, key string, value interface
 
 // getNodeInterfaceFromIP returns the IPv4/IPv6 configuration, and the associated interface according the give nodeIPs.
 // When searching the Node interface, antrea-gw0 is ignored because it is configured with the same address as Node IP
-// with NetworkPolicyOnly mode on public cloud setup, e.g., AKS.
+// with NetworkPolicyOnly mode on public cloud setup, e.g., EKS.
 func (i *Initializer) getNodeInterfaceFromIP(nodeIPs *utilip.DualStackIPs) (v4IPNet *net.IPNet, v6IPNet *net.IPNet, iface *net.Interface, err error) {
 	return getIPNetDeviceFromIP(nodeIPs, sets.New[string](i.hostGateway))
 }

--- a/test/integration/agent/cniserver_test.go
+++ b/test/integration/agent/cniserver_test.go
@@ -145,7 +145,7 @@ const (
 
 	chainCNIConfStr = `{
 "cniVersion":"%s",
-"name":"azure",
+"name":"antrea",
 "type":"antrea",
 "prevResult":%s,
 "ipam":{"type":"unknown"}


### PR DESCRIPTION
We stopped testing Antrea on Azure. This patch adds disclaimers to Azure related code and docs.