### PR TITLE
update github runners to oci gh arc runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,10 +51,10 @@ jobs:
           runner: ubuntu-latest
           suffix: amd64
         - platform: linux/arm64
-          runner: github-arm64-2c-8gb
+          runner: oracle-vm-2cpu-8gb-arm64
           suffix: arm64
         - platform: linux/arm/v7
-          runner: github-arm64-2c-8gb
+          runner: oracle-vm-2cpu-8gb-arm64
           suffix: arm
     runs-on: ${{ matrix.runner }}
     env:

--- a/.github/workflows/build_tag.yml
+++ b/.github/workflows/build_tag.yml
@@ -38,10 +38,10 @@ jobs:
           runner: ubuntu-latest
           suffix: amd64
         - platform: linux/arm64
-          runner: github-arm64-2c-8gb
+          runner: oracle-vm-2cpu-8gb-arm64
           suffix: arm64
         - platform: linux/arm/v7
-          runner: github-arm64-2c-8gb
+          runner: oracle-vm-2cpu-8gb-arm64
           suffix: arm
     runs-on: ${{ matrix.runner }}
     env:

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -280,7 +280,7 @@ jobs:
   test-e2e-ipam-feature-enabled:
     name: E2e tests on a Kind cluster on Linux with FlexibleIPAM feature enabled
     needs: [build-antrea-coverage-image]
-    runs-on: [ubuntu-latest-4-cores]
+    runs-on: [oracle-vm-4cpu-16gb-x86-64]
     steps:
       - uses: actions/checkout@v5
         with:


### PR DESCRIPTION
CNCF has hosted ephemeral GitHub runners on Oracle that we want projects to use instead of the GitHub-hosted ones, which now incur a cost to use.

Please direct any questions to me, @jeefy, @krook, and @RobertKielty. You can also join `#cncf-ci-infra` channel on CNCF Slack.