### PR TITLE
Fix broken URL in release.md

### DIFF
--- a/docs/maintainers/release.md
+++ b/docs/maintainers/release.md
@@ -70,10 +70,7 @@ release. We use `<TAG>` as a placeholder for the release tag (e.g. `v1.4.0`).
 
 6. After a while (time for the relevant Github workflows to complete), check that:
    - the Docker image has been pushed to
-     [dockerhub](https://hub.docker.com/u/antrea) with the correct tag. This is
-     handled by a Github worfklow defined in a separate Github repository and it
-     can take some time for this workflow to complete. See this
-     [document](antrea-docker-image.md) for more information.
+     [dockerhub](https://hub.docker.com/u/antrea) with the correct tag.
    - the assets have been uploaded to the release (`antctl` binaries and yaml
      manifests). This is handled by the `Upload assets to release` workflow. In
      particular, the following link should work:

--- a/hack/.notableofcontents
+++ b/hack/.notableofcontents
@@ -21,7 +21,6 @@ docs/feature-gates.md
 docs/getting-started.md
 docs/gke-installation.md
 docs/kubernetes-installers.md
-docs/maintainers/antrea-docker-image.md
 docs/maintainers/build-kubemark.md
 docs/maintainers/getting-started-gif.md
 docs/maintainers/release.md


### PR DESCRIPTION
The doc antrea-docker-image.md was removed but the URL was not updated.
So remove the corresponding URL to fix `Verify docs` check.