### PR TITLE
[Renovate] Disable digest pinning for Github Actions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,7 +3,6 @@
   extends: [
     "config:base",
     ":gitSignOff", // Add commit Sign-Off for renovate commits
-    "helpers:pinGitHubActionDigests", // Pins GitHub Actions to exact commit SHAs for security
   ],
 
   // Allow only certain package managers and implicitly disable all others


### PR DESCRIPTION
* to avoid frequent updates
* to match the earlier behavior we had with Dependabot
* to match the Renovate configuration of other Antrea repos