### PR TITLE
Update dev VERSION automatically using Github workflow

### DIFF
--- a/.github/workflows/post_release_actions.yml
+++ b/.github/workflows/post_release_actions.yml
@@ -115,14 +115,14 @@ jobs:
             exit 1
           fi
 
-          # Extract major.minor from released version
+          # Extract major.minor from released version (patch not needed)
           released_without_v=${RELEASED_VERSION#v}
-          IFS="." read -r released_major released_minor released_patch <<< "$released_without_v"
+          IFS="." read -r released_major released_minor _ <<< "$released_without_v"
 
           # Extract major.minor from current VERSION
           current_without_prefix=${current_version#v}
           current_without_suffix=${current_without_prefix%-dev}
-          IFS="." read -r current_major current_minor current_patch <<< "$current_without_suffix"
+          IFS="." read -r current_major current_minor _ <<< "$current_without_suffix"
 
           # Compare versions: VERSION should be > released version
           if [ "$current_major" -gt "$released_major" ] ||
@@ -139,7 +139,9 @@ jobs:
           echo "Updating VERSION to: $new_version"
           echo "$new_version" > VERSION
 
-          git add VERSION
+          cd build/charts; make helm-docs; cd -
+
+          git add .
           git commit --signoff -m "Bump VERSION to $new_version"
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7


### PR DESCRIPTION
For now, this is done with a separate job (and a sepaarte PR) in the post_release_actions.yml workflow. We could unify the VERSION update PR and the CHANGELOG update PR in the future.

If we need to bump the *major* version number instead of the *minor* version number, the PR can be discarded (or overridden afterwards).