### PR TITLE
Add nftables to antrea images

### DIFF
--- a/build/images/base/Dockerfile
+++ b/build/images/base/Dockerfile
@@ -49,7 +49,7 @@ USER root
 # chmod in the RUN command below instead.
 ADD https://raw.githubusercontent.com/kubernetes-sigs/iptables-wrappers/9e6ce59c864623ea71a6f7d59c35fcb13a919b87/iptables-wrapper-installer.sh /iptables-wrapper-installer.sh
 
-RUN apt-get update && apt-get install -y --no-install-recommends ipset jq inotify-tools gpg-agent software-properties-common && \
+RUN apt-get update && apt-get install -y --no-install-recommends ipset jq inotify-tools gpg-agent software-properties-common nftables && \
     add-apt-repository ppa:oisf/suricata-${SURICATA_VERSION} && apt-get update && apt-get install -y suricata && \
     apt-get remove -y gpg-agent software-properties-common && apt-get autoremove -y && rm -rf /var/cache/apt/* /var/lib/apt/lists/* && \
     chmod +x /iptables-wrapper-installer.sh && \

--- a/build/images/base/Dockerfile.ubi
+++ b/build/images/base/Dockerfile.ubi
@@ -44,7 +44,7 @@ LABEL description="An UBI9 based Docker base image for Antrea."
 USER root
 
 # Skip installing weak dependencies (geolite2-city and geolite2-country) for Suricata as they are not required for Antrea's use case.
-RUN yum install ipset jq yum-plugin-copr -y && \
+RUN yum install ipset jq yum-plugin-copr nftables -y && \
     yum copr enable @oisf/suricata-${SURICATA_VERSION} -y && yum install suricata --setopt=install_weak_deps=False -y && \
     yum remove yum-plugin-copr -y && yum clean all
 


### PR DESCRIPTION
Nftables needs to run in antrea-agent Pod to enforce nft elements in PR #7324.

Install nftables increases the antrea-ubuntu image size by 1.7MB and antrea-ubi image size by 1.1MB.

