### PR TITLE
Add network-policy-delay flag to antctl check installation

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -933,7 +933,7 @@ jobs:
         # due to a slow runner / oversubscribed infra.
         # To avoid flakes, we choose a long realization timeout.
         run: |
-          ./bin/antctl-linux check installation -network-policy-delay 5s
+          ./bin/antctl-linux check installation --network-policy-delay 5s
 
   validate-prometheus-metrics-doc:
     name: Validate metrics in Prometheus document match running deployment's

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -929,8 +929,11 @@ jobs:
         run: |
           kubectl apply -f build/yamls/antrea.yml
       - name: Run Post checks
+        # In some cases, it seems that NetworkPolicy realization takes a long time in CI, probably
+        # due to a slow runner / oversubscribed infra.
+        # To avoid flakes, we choose a long realization timeout.
         run: |
-          ./bin/antctl-linux check installation
+          ./bin/antctl-linux check installation -network-policy-delay 5s
 
   validate-prometheus-metrics-doc:
     name: Validate metrics in Prometheus document match running deployment's

--- a/pkg/antctl/raw/check/cluster/command.go
+++ b/pkg/antctl/raw/check/cluster/command.go
@@ -35,6 +35,7 @@ func Command() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "cluster",
 		Short: "Runs pre installation checks",
+		Args:  cobra.NoArgs, // Disables positional arguments
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return Run(o)
 		},

--- a/pkg/antctl/raw/check/installation/command.go
+++ b/pkg/antctl/raw/check/installation/command.go
@@ -38,6 +38,7 @@ func Command() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "installation",
 		Short: "Runs post installation checks",
+		Args:  cobra.NoArgs, // Disables positional arguments
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return Run(o)
 		},
@@ -222,6 +223,7 @@ func NewTestContext(
 
 func (t *testContext) setup(ctx context.Context) error {
 	t.Log("Test starting....")
+	t.Log("Checking for existence of %q DaemonSet in %q Namespace", agentDaemonSetName, t.antreaNamespace)
 	_, err := t.client.AppsV1().DaemonSets(t.antreaNamespace).Get(ctx, agentDaemonSetName, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("unable to determine status of Antrea DaemonSet: %w", err)

--- a/pkg/antctl/raw/check/installation/command_test.go
+++ b/pkg/antctl/raw/check/installation/command_test.go
@@ -105,7 +105,7 @@ func TestRun(t *testing.T) {
 			overrideTestsRegistry(t, tc.registry)
 			runFilterRegex, err := compileRunFilter(tc.runFilter)
 			require.NoError(t, err)
-			testContext := NewTestContext(nil, nil, "test-cluster", "kube-system", runFilterRegex, check.DefaultTestImage)
+			testContext := NewTestContext(nil, nil, "test-cluster", "kube-system", runFilterRegex, check.DefaultTestImage, minNetworkPolicyDelay)
 			stats := testContext.runTests(ctx)
 			assert.Equal(t, tc.expectedStats, stats)
 		})

--- a/pkg/antctl/raw/check/installation/test_denyall.go
+++ b/pkg/antctl/raw/check/installation/test_denyall.go
@@ -28,9 +28,6 @@ type DenyAllConnectivityTest struct {
 	networkPolicy *networkingv1.NetworkPolicy
 }
 
-// Provide enough time for policies to be enforced by the CNI plugin.
-const networkPolicyDelay = 2 * time.Second
-
 func init() {
 	RegisterTest("egress-deny-all-connectivity", &DenyAllConnectivityTest{networkPolicy: &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
@@ -88,7 +85,10 @@ func (t *DenyAllConnectivityTest) Run(ctx context.Context, testContext *testCont
 		testContext.Log("NetworkPolicy deletion was successful")
 		return nil
 	}()
-	time.Sleep(networkPolicyDelay)
+	// Instead of an arbitrary sleep, we could poll and invoke tcpProbe at reasonable intervals?
+	// Unlike Antrea NetworkPolicies, K8s NetworkPolicies don't have a Status that can be used
+	// to determined whether the policy has been realized.
+	time.Sleep(testContext.networkPolicyDelay)
 	testContext.Log("NetworkPolicy applied successfully")
 	for _, clientPod := range testContext.clientPods {
 		for _, service := range services {

--- a/pkg/antctl/raw/check/util.go
+++ b/pkg/antctl/raw/check/util.go
@@ -192,7 +192,9 @@ func Teardown(ctx context.Context, logger Logger, client kubernetes.Interface, n
 	logger.Log("Deleting installation tests setup...")
 	err := client.CoreV1().Namespaces().Delete(ctx, namespace, metav1.DeleteOptions{})
 	if err != nil {
-		logger.Fail("Namespace %s deletion failed: %v", namespace, err)
+		if !errors.IsNotFound(err) {
+			logger.Fail("Namespace %s deletion failed: %v", namespace, err)
+		}
 		return
 	}
 	logger.Log("Waiting for Namespace %s to be deleted", namespace)


### PR DESCRIPTION
Instead of using a hard-coded 2s value.
While I am not able to reproduce the issue locally (even without a sleep), the egress-deny-all-connectivity and ingress-deny-all-connectivity tests sometimes fail in CI, presumably because the policy has not been realized by all Agents yet. So to help prevent the issue, we use a 5s delay in CI, using the new flag.