### PR TITLE
fix(deps): update module github.com/spf13/pflag to v1.0.10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/afero v1.14.0
 	github.com/spf13/cobra v1.9.1
-	github.com/spf13/pflag v1.0.6
+	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.10.0
 	github.com/ti-mo/conntrack v0.5.2
 	github.com/vishvananda/netlink v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -729,8 +729,9 @@ github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzu
 github.com/spf13/pflag v1.0.1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
-github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
 github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
+github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/spf13/viper v1.16.0 h1:rGGH0XDZhdUOryiDWjmIvUSWpbNqisK8Wk0Vyefw8hc=

--- a/pkg/antctl/raw/multicluster/get/join_config_test.go
+++ b/pkg/antctl/raw/multicluster/get/join_config_test.go
@@ -16,7 +16,6 @@ package get
 
 import (
 	"bytes"
-	"fmt"
 	"log"
 	"os"
 	"testing"
@@ -171,16 +170,16 @@ func TestJoinConfig(t *testing.T) {
 
 func TestOptValidate(t *testing.T) {
 	tests := []struct {
-		name string
-		opts *joinConfigOptions
-		err  error
+		name   string
+		opts   *joinConfigOptions
+		errStr string
 	}{
 		{
 			name: "no Namespace",
 			opts: &joinConfigOptions{
 				k8sClient: fake.NewClientBuilder().WithScheme(mcscheme.Scheme).Build(),
 			},
-			err: fmt.Errorf("Namespace must be specified"),
+			errStr: "Namespace must be specified",
 		},
 		{
 			name: "Namespace specified",
@@ -188,7 +187,7 @@ func TestOptValidate(t *testing.T) {
 				namespace: "ns1",
 				k8sClient: fake.NewClientBuilder().WithScheme(mcscheme.Scheme).Build(),
 			},
-			err: nil,
+			errStr: "",
 		},
 		{
 			name: "token specified",
@@ -197,14 +196,14 @@ func TestOptValidate(t *testing.T) {
 				memberToken: "token1",
 				k8sClient:   fake.NewClientBuilder().WithScheme(mcscheme.Scheme).Build(),
 			},
-			err: nil,
+			errStr: "",
 		},
 		{
 			name: "K8s client error",
 			opts: &joinConfigOptions{
 				namespace: "ns1",
 			},
-			err: fmt.Errorf("flag accessed but not defined: kubeconfig"),
+			errStr: "flag accessed but not defined: kubeconfig",
 		},
 	}
 
@@ -212,7 +211,11 @@ func TestOptValidate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.opts.validateAndComplete(cmd)
-			assert.Equal(t, tt.err, err)
+			if tt.errStr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tt.errStr)
+			}
 		})
 	}
 }


### PR DESCRIPTION
A new error "NotExistError" was introduced since v1.0.7, refined the test codes to check error message to fix the UT failure:
```
             	Error Trace:	/home/runner/work/antrea/antrea/pkg/antctl/raw/multicluster/get/join_config_test.go:215
            	Error:      	Not equal: 
            	            	expected: *errors.errorString(&errors.errorString{s:"flag accessed but not defined: kubeconfig"})
            	            	actual  : *pflag.NotExistError(&pflag.NotExistError{name:"kubeconfig", specifiedShorthands:"", messageType:1})
            	Test:       	TestOptValidate/K8s_client_error
```

https://github.com/antrea-io/antrea/actions/runs/17506341499/job/49730539389?pr=7411
This is to replace the PR https://github.com/antrea-io/antrea/pull/7411