### PR TITLE
Automated cherry pick of #7266: Handle Traceflow external destination IP correctly in NoEncap

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -676,6 +676,7 @@ func run(o *Options) error {
 			ofClient,
 			networkPolicyController,
 			egressController,
+			nodeRouteController,
 			ifaceStore,
 			networkConfig,
 			nodeConfig,

--- a/pkg/agent/controller/traceflow/traceflow_controller.go
+++ b/pkg/agent/controller/traceflow/traceflow_controller.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/netip"
 	"sync"
 	"time"
 
@@ -97,6 +98,7 @@ type Controller struct {
 	ofClient               openflow.Client
 	networkPolicyQuerier   querier.AgentNetworkPolicyInfoQuerier
 	egressQuerier          querier.EgressQuerier
+	podSubnetChecker       PodSubnetChecker
 	interfaceStore         interfacestore.InterfaceStore
 	networkConfig          *config.NetworkConfig
 	nodeConfig             *config.NodeConfig
@@ -119,6 +121,7 @@ func NewTraceflowController(
 	client openflow.Client,
 	npQuerier querier.AgentNetworkPolicyInfoQuerier,
 	egressQuerier querier.EgressQuerier,
+	podSubnetChecker PodSubnetChecker,
 	interfaceStore interfacestore.InterfaceStore,
 	networkConfig *config.NetworkConfig,
 	nodeConfig *config.NodeConfig,
@@ -133,6 +136,7 @@ func NewTraceflowController(
 		ofClient:              client,
 		networkPolicyQuerier:  npQuerier,
 		egressQuerier:         egressQuerier,
+		podSubnetChecker:      podSubnetChecker,
 		interfaceStore:        interfaceStore,
 		networkConfig:         networkConfig,
 		nodeConfig:            nodeConfig,
@@ -606,4 +610,11 @@ func (c *Controller) cleanupTraceflow(tfName string) {
 			break
 		}
 	}
+}
+
+type PodSubnetChecker interface {
+	// LookupIPInPodSubnets returns two boolean values. The first one indicates whether the IP can be
+	// found in a PodCIDR for one of the cluster Nodes. The second one indicates whether the IP is used
+	// as a gateway IP. The second boolean value can only be true if the first one is true.
+	LookupIPInPodSubnets(ip netip.Addr) (isFound bool, isGWIP bool)
 }

--- a/pkg/agent/controller/traceflow/traceflow_controller_test.go
+++ b/pkg/agent/controller/traceflow/traceflow_controller_test.go
@@ -17,6 +17,7 @@ package traceflow
 import (
 	"bytes"
 	"net"
+	"net/netip"
 	"os"
 	"testing"
 
@@ -53,6 +54,8 @@ var (
 	dstIPv4        = "192.168.99.99"
 	pod1MAC, _     = net.ParseMAC("aa:bb:cc:dd:ee:0f")
 	pod2MAC, _     = net.ParseMAC("aa:bb:cc:dd:ee:00")
+	podCIDR1IPv4   = netip.MustParsePrefix("192.168.10.0/24")
+	podCIDR2IPv4   = netip.MustParsePrefix("192.168.11.0/24")
 	ofPortPod1     = uint32(1)
 	ofPortPod2     = uint32(2)
 	protocolICMPv6 = int32(58)
@@ -100,6 +103,12 @@ var (
 	}
 )
 
+type fakePodSubnetChecker struct{}
+
+func (f *fakePodSubnetChecker) LookupIPInPodSubnets(ip netip.Addr) (bool, bool) {
+	return podCIDR1IPv4.Contains(ip) || podCIDR2IPv4.Contains(ip), false
+}
+
 type fakeTraceflowController struct {
 	*Controller
 	kubeClient           kubernetes.Interface
@@ -141,6 +150,7 @@ func newFakeTraceflowController(t *testing.T, initObjects []runtime.Object, netw
 		ofClient:              mockOFClient,
 		networkPolicyQuerier:  npQuerier,
 		egressQuerier:         egressQuerier,
+		podSubnetChecker:      &fakePodSubnetChecker{},
 		interfaceStore:        ifaceStore,
 		networkConfig:         networkConfig,
 		nodeConfig:            nodeConfig,

--- a/pkg/apis/crd/v1beta1/types.go
+++ b/pkg/apis/crd/v1beta1/types.go
@@ -1054,6 +1054,10 @@ const (
 	// ActionForwardedOutOfOverlay indicates that the packet has been forwarded out of the network
 	// managed by Antrea. This indicates that the Traceflow request can be considered complete.
 	ActionForwardedOutOfOverlay TraceflowAction = "ForwardedOutOfOverlay"
+	// ActionForwardedOutOfNetwork indicates that the packet has been forwarded out of the network
+	// managed by Antrea, but it's not a full end-to-end observation.
+	// TODO: unify "ForwardedOutOfOverlay" and "ForwardedOutOfNetwork" in a future API version
+	ActionForwardedOutOfNetwork TraceflowAction = "ForwardedOutOfNetwork"
 	ActionMarkedForSNAT         TraceflowAction = "MarkedForSNAT"
 	ActionForwardedToEgressNode TraceflowAction = "ForwardedToEgressNode"
 )

--- a/pkg/controller/traceflow/controller.go
+++ b/pkg/controller/traceflow/controller.go
@@ -278,7 +278,8 @@ func (c *Controller) checkTraceflowStatus(tf *crdv1beta1.Traceflow) error {
 				if ob.Action == crdv1beta1.ActionDelivered ||
 					ob.Action == crdv1beta1.ActionDropped ||
 					ob.Action == crdv1beta1.ActionRejected ||
-					ob.Action == crdv1beta1.ActionForwardedOutOfOverlay {
+					ob.Action == crdv1beta1.ActionForwardedOutOfOverlay ||
+					ob.Action == crdv1beta1.ActionForwardedOutOfNetwork {
 					receiver = true
 				}
 				if ob.TranslatedDstIP != "" {

--- a/test/e2e/traceflow_test.go
+++ b/test/e2e/traceflow_test.go
@@ -77,7 +77,6 @@ func TestTraceflow(t *testing.T) {
 		testTraceflowInterNode(t, data)
 	})
 	t.Run("testTraceflowExternalIP", func(t *testing.T) {
-		skipIfEncapModeIsNot(t, data, config.TrafficEncapModeEncap)
 		testTraceflowExternalIP(t, data)
 	})
 	t.Run("testTraceflowEgress", func(t *testing.T) {
@@ -2064,6 +2063,12 @@ func testTraceflowExternalIP(t *testing.T, data *TestData) {
 	} else {
 		srcPodIP = podIPs[0].IPv6.String()
 	}
+	expectOutputAction := v1beta1.ActionForwardedOutOfOverlay
+	currentEncapMode, err := data.GetEncapMode()
+	require.NoError(t, err, "Failed to get encap mode")
+	if currentEncapMode == config.TrafficEncapModeNoEncap {
+		expectOutputAction = v1beta1.ActionForwardedOutOfNetwork
+	}
 	testcase := testcase{
 		name:      "nodeIPDestination",
 		ipVersion: 4,
@@ -2099,7 +2104,7 @@ func testTraceflowExternalIP(t *testing.T, data *TestData) {
 					{
 						Component:     v1beta1.ComponentForwarding,
 						ComponentInfo: "Output",
-						Action:        v1beta1.ActionForwardedOutOfOverlay,
+						Action:        expectOutputAction,
 					},
 				},
 			},


### PR DESCRIPTION
Cherry pick of #7266 on release-2.4.

#7266: Handle Traceflow external destination IP correctly in NoEncap

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.