### PR TITLE
Fix flaky TestGoBGPLifecycle integration test

### DIFF
--- a/pkg/agent/bgp/interface.go
+++ b/pkg/agent/bgp/interface.go
@@ -59,10 +59,13 @@ type Confederation struct {
 
 // GlobalConfig contains the global configuration to start a BGP server. More attributes might be added later.
 type GlobalConfig struct {
-	ASN           uint32
-	RouterID      string
-	ListenPort    int32
-	Confederation *Confederation
+	ASN        uint32
+	RouterID   string
+	ListenPort int32
+	// ListenAddresses is the list of addresses that the BGP server binds to. If omitted, the
+	// server will bind to all addresses (INADDR_ANY).
+	ListenAddresses []string
+	Confederation   *Confederation
 }
 
 type SessionState string
@@ -87,9 +90,23 @@ const (
 	RouteReceived
 )
 
+type ConnectionModeType int
+
+const (
+	ConnectionModeActive ConnectionModeType = iota // default
+	ConnectionModePassive
+)
+
 // PeerConfig contains the configuration for a BGP peer. More attributes might be added later.
 type PeerConfig struct {
 	*v1alpha1.BGPPeer
+	// These 2 fields are not currently exposed in the BGPPeer API but are used in integration tests.
+	// LocalAddress is the address used by the BGP server to connect to the peer. If omitted, it
+	// will be determined automatically based on the routing decision.
+	LocalAddress string
+	// ConnectionMode determines the connection mode (active / passive): this provides direct
+	// control over the direction of the BGP session. The default mode is active.
+	ConnectionMode ConnectionModeType
 	// Password is used to authenticate the BGP session with a BGP peer. This field holds the authentication password
 	// required to establish a secure BGP connection. If the peer requires password-based authentication, this value
 	// must be set to the appropriate password. Leaving this field empty will disable password authentication.


### PR DESCRIPTION
The major change is that we are forcing the connection mode for each side of the BGP session: one side active and one side passive. This eliminates connection "collisions" and back-offs: by making Server2 always the active connector and Server1 always the passive listener, we prevent both sides from trying to connect simultaneously. In particular, when we update the peer as a test step (which requires re-establishing the session), the connection modes remain the same and reconnection succeeds immediately. This is better than increasing polling timeouts to very large values.

We also improve the test by using a different localhost address (127.0.0.1 and 127.0.0.2) for each server, and matching the router ID to the listen address. This requires explicitly setting the "local address" used to connect to the peer, for each server.

Finally, we also improve our logging wrapper for gobgp: we include the router ID in each log message and we make sure that the source location logged is the correct one (gobgp code, not log wrapper function) by going one call frame up the stack.