### PR TITLE
Add conntrack_poll_cycle_duration_seconds metric

### DIFF
--- a/docs/prometheus-integration.md
+++ b/docs/prometheus-integration.md
@@ -148,6 +148,9 @@ the Agent.
 - **antrea_agent_conntrack_max_connection_count:** Size of the conntrack
 table. This metric gets updated at an interval specified by flowPollInterval,
 a configuration parameter for the Agent.
+- **antrea_agent_conntrack_poll_cycle_duration_seconds:** Duration of
+conntrack poll cycles, which includes reading all connections from conntrack
+and processing them.
 - **antrea_agent_conntrack_total_connection_count:** Number of connections
 in the conntrack table. This metric gets updated at an interval specified
 by flowPollInterval, a configuration parameter for the Agent.

--- a/pkg/agent/metrics/prometheus.go
+++ b/pkg/agent/metrics/prometheus.go
@@ -183,6 +183,18 @@ var (
 			StabilityLevel: metrics.ALPHA,
 		},
 	)
+
+	ConntrackPollCycleDuration = metrics.NewHistogram(
+		&metrics.HistogramOpts{
+			Namespace:      metricNamespaceAntrea,
+			Subsystem:      metricSubsystemAgent,
+			Name:           "conntrack_poll_cycle_duration_seconds",
+			Help:           "Duration of conntrack poll cycles, which includes reading all connections from conntrack and processing them.",
+			StabilityLevel: metrics.ALPHA,
+			// Buckets for conntrack polling in seconds (10ms to 10s range)
+			Buckets: []float64{0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+		},
+	)
 )
 
 func InitializePrometheusMetrics() {
@@ -261,5 +273,8 @@ func InitializeConnectionMetrics() {
 	}
 	if err := legacyregistry.Register(MaxConnectionsInConnTrackTable); err != nil {
 		klog.ErrorS(err, "Failed to register metrics with Prometheus", "metrics", "antrea_agent_conntrack_max_connection_count")
+	}
+	if err := legacyregistry.Register(ConntrackPollCycleDuration); err != nil {
+		klog.ErrorS(err, "Failed to register metrics with Prometheus", "metrics", "antrea_agent_conntrack_poll_cycle_duration_seconds")
 	}
 }


### PR DESCRIPTION
To keep track of how long it takes to poll conntrack and update the connection store. This could help troubleshoot issues. We also log the duration, using the existing verbosity (`V(2)`).

Note that unlike some other existing metrics, we use seconds as the unit, not milliseconds. Using seconds seems to be best practice for this type of Prometheus metrics.