### PR TITLE
Add custom rule for go.uber.org/mock to Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -52,6 +52,16 @@
 
     {
       matchManagers: ["gomod"],
+      matchPackageNames: ["go.uber.org/mock"],
+      assignees: ["antoninbas", "luolanzone"],
+      prBodyNotes: [
+        ":warning: The mockgen version in the [codegen image](https://github.com/antrea-io/antrea/blob/main/build/images/codegen/Dockerfile) should also be updated so that both versions stay synchronized. Either add a commit to this PR or open a replacement PR."
+      ],
+      matchBaseBranches: ["main"],
+    },
+
+    {
+      matchManagers: ["gomod"],
       matchPackagePrefixes: ["golang.org/x/"],
       groupName: "golang.org/x",
       groupSlug: "golang.org/x",


### PR DESCRIPTION
- A note will be included in the PR description to remind maintainers that the mockgen version should also be updated in the codegen image.
- PRs updating go.uber.org/mock will be assigned to antoninbas and luolanzone.