### PR TITLE
[Flaky unit test] Fix TestCluster_RunClusterEvents

### DIFF
--- a/pkg/agent/memberlist/cluster.go
+++ b/pkg/agent/memberlist/cluster.go
@@ -540,7 +540,7 @@ func (c *Cluster) AliveNodes() sets.Set[string] {
 	return nodes
 }
 
-// ShouldSelectIP returns true if the local Node selected as the owner Node of the IP in the specific
+// ShouldSelectIP returns true if the local Node is selected as the owner Node of the IP in the specific
 // ExternalIPPool. The local Node in the cluster holds the same consistent hash ring for each ExternalIPPool,
 // consistentHash.Get gets the closest item (Node name) in the hash to the provided key (IP), if the name of
 // the local Node is equal to the name of the selected Node, returns true.


### PR DESCRIPTION
This is a follow-up to #7448.
The change in behavor of assert.Eventually has caused to the unit test to become flaky. This change improves how the result of egress selection is validated, and resolves the flakiness issue.
It is expected that the test function can be greatly improved when we upgrade to Go 1.25 and we can start using the new testing/synctest package. Upgrading to Go 1.25 is not immediately possible because of some dependency issues.