### PR TITLE
[FlowExporter] Avoid invalid NetworkPolicy data in records

### DIFF
--- a/pkg/agent/controller/networkpolicy/allocator.go
+++ b/pkg/agent/controller/networkpolicy/allocator.go
@@ -31,11 +31,9 @@ import (
 )
 
 const (
-	deleteQueueName = "async_delete_networkpolicyrule"
-)
+	MinAllocatorAsyncDeleteInterval = 5 * time.Second
 
-var (
-	minAsyncDeleteInterval = time.Second * 5
+	deleteQueueName = "async_delete_networkpolicyrule"
 )
 
 // idAllocator provides interfaces to allocate and release uint32 IDs. It's thread-safe.
@@ -80,13 +78,7 @@ func newIDAllocatorWithClock(asyncRuleDeleteInterval time.Duration, clock clock.
 			Name:  deleteQueueName,
 			Clock: clock,
 		}),
-	}
-
-	// Set the deleteInterval.
-	if minAsyncDeleteInterval > asyncRuleDeleteInterval {
-		allocator.deleteInterval = minAsyncDeleteInterval
-	} else {
-		allocator.deleteInterval = asyncRuleDeleteInterval
+		deleteInterval: max(asyncRuleDeleteInterval, MinAllocatorAsyncDeleteInterval),
 	}
 
 	var maxID uint32

--- a/pkg/agent/controller/networkpolicy/fqdn_test.go
+++ b/pkg/agent/controller/networkpolicy/fqdn_test.go
@@ -47,7 +47,7 @@ func newMockFQDNController(t *testing.T, controller *gomock.Controller, dnsServe
 	}
 	f, err := newFQDNController(
 		mockOFClient,
-		newIDAllocator(testAsyncDeleteInterval),
+		newIDAllocator(MinAllocatorAsyncDeleteInterval),
 		dnsServerAddr,
 		dirtyRuleHandler,
 		true,

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
@@ -594,7 +594,7 @@ func (c *Controller) GetNetworkPolicyByRuleFlowID(ruleFlowID uint32) *v1beta2.Ne
 func (c *Controller) GetRuleByFlowID(ruleFlowID uint32) *types.PolicyRule {
 	rule, exists, err := c.podReconciler.GetRuleByFlowID(ruleFlowID)
 	if err != nil {
-		klog.Errorf("Error when getting network policy by rule flow ID: %v", err)
+		klog.ErrorS(err, "Error when getting network policy by rule flow ID")
 		return nil
 	}
 	if !exists {

--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller_test.go
@@ -97,7 +97,7 @@ func newTestController() (*Controller, *fake.Clientset, *mockReconciler) {
 		true,
 		false,
 		nil,
-		testAsyncDeleteInterval,
+		MinAllocatorAsyncDeleteInterval,
 		"8.8.8.8:53",
 		config.K8sNode,
 		true,

--- a/pkg/agent/controller/networkpolicy/pod_reconciler_test.go
+++ b/pkg/agent/controller/networkpolicy/pod_reconciler_test.go
@@ -112,7 +112,7 @@ func newTestReconciler(t *testing.T, controller *gomock.Controller, ifaceStore i
 	ch := make(chan string, 100)
 	groupIDAllocator := openflow.NewGroupAllocator()
 	groupCounters := []proxytypes.GroupCounter{proxytypes.NewGroupCounter(groupIDAllocator, ch)}
-	r := newPodReconciler(ofClient, ifaceStore, newIDAllocator(testAsyncDeleteInterval), f, groupCounters, v4Enabled, v6Enabled, true, false)
+	r := newPodReconciler(ofClient, ifaceStore, newIDAllocator(MinAllocatorAsyncDeleteInterval), f, groupCounters, v4Enabled, v6Enabled, true, false)
 	return r
 }
 

--- a/pkg/agent/flowexporter/connections/connections_test.go
+++ b/pkg/agent/flowexporter/connections/connections_test.go
@@ -125,7 +125,7 @@ func TestConnectionStore_DeleteConnWithoutLock(t *testing.T) {
 
 	// test on conntrack connection store
 	mockConnDumper := connectionstest.NewMockConnTrackDumper(ctrl)
-	conntrackConnStore := NewConntrackConnectionStore(mockConnDumper, true, false, nil, mockPodStore, nil, nil, testFlowExporterOptions)
+	conntrackConnStore := NewConntrackConnectionStore(mockConnDumper, true, false, nil, mockPodStore, nil, nil, nil, testFlowExporterOptions)
 	conntrackConnStore.connections[connKey] = conn
 
 	metrics.TotalAntreaConnectionsInConnTrackTable.Set(1)

--- a/pkg/agent/flowexporter/connections/conntrack_connections.go
+++ b/pkg/agent/flowexporter/connections/conntrack_connections.go
@@ -87,17 +87,18 @@ func NewConntrackConnectionStore(
 
 // Run enables the periodical polling of conntrack connections at a given flowPollInterval.
 func (cs *ConntrackConnectionStore) Run(stopCh <-chan struct{}) {
-	klog.Info("Starting conntrack polling")
-
 	if cs.networkPolicyWait != nil {
+		klog.Info("Waiting for NetworkPolicies to become ready")
 		if err := cs.networkPolicyWait.WaitUntil(stopCh); err != nil {
 			klog.ErrorS(err, "Error while waiting for NetworkPolicies to become ready")
 			return
 		}
 	} else {
-		klog.InfoS("Skip waiting for NetworkPolicies to become ready")
+		klog.Info("Skip waiting for NetworkPolicies to become ready")
 	}
 	cs.networkPolicyReadyTime = time.Now()
+
+	klog.Info("Starting conntrack polling")
 
 	pollTicker := time.NewTicker(cs.pollInterval)
 	defer pollTicker.Stop()

--- a/pkg/agent/flowexporter/connections/conntrack_connections.go
+++ b/pkg/agent/flowexporter/connections/conntrack_connections.go
@@ -31,6 +31,7 @@ import (
 	"antrea.io/antrea/pkg/agent/proxy"
 	"antrea.io/antrea/pkg/querier"
 	"antrea.io/antrea/pkg/util/objectstore"
+	utilwait "antrea.io/antrea/pkg/util/wait"
 )
 
 var serviceProtocolMap = map[uint8]corev1.Protocol{
@@ -46,6 +47,14 @@ type ConntrackConnectionStore struct {
 	pollInterval          time.Duration
 	connectUplinkToBridge bool
 	l7EventMapGetter      L7EventMapGetter
+	// networkPolicyWait is used to determine when NetworkPolicy flows have been installed and
+	// when the mapping from flow ID to NetworkPolicy rule is available. We will ignore
+	// connections which started prior to that time to avoid reporting invalid NetworkPolicy
+	// metadata in flow records. This is because the mapping is not "stable" and is expected to
+	// change when the Agent restarts.
+	networkPolicyWait *utilwait.Group
+	// networkPolicyReadyTime is set to the current time when we are done waiting on networkPolicyWait.
+	networkPolicyReadyTime time.Time
 	connectionStore
 }
 
@@ -61,6 +70,7 @@ func NewConntrackConnectionStore(
 	podStore objectstore.PodStore,
 	proxier proxy.Proxier,
 	l7EventMapGetterFunc L7EventMapGetter,
+	networkPolicyWait *utilwait.Group,
 	o *options.FlowExporterOptions,
 ) *ConntrackConnectionStore {
 	return &ConntrackConnectionStore{
@@ -71,12 +81,23 @@ func NewConntrackConnectionStore(
 		connectionStore:       NewConnectionStore(npQuerier, podStore, proxier, o),
 		connectUplinkToBridge: o.ConnectUplinkToBridge,
 		l7EventMapGetter:      l7EventMapGetterFunc,
+		networkPolicyWait:     networkPolicyWait,
 	}
 }
 
 // Run enables the periodical polling of conntrack connections at a given flowPollInterval.
 func (cs *ConntrackConnectionStore) Run(stopCh <-chan struct{}) {
 	klog.Info("Starting conntrack polling")
+
+	if cs.networkPolicyWait != nil {
+		if err := cs.networkPolicyWait.WaitUntil(stopCh); err != nil {
+			klog.ErrorS(err, "Error while waiting for NetworkPolicies to become ready")
+			return
+		}
+	} else {
+		klog.InfoS("Skip waiting for NetworkPolicies to become ready")
+	}
+	cs.networkPolicyReadyTime = time.Now()
 
 	pollTicker := time.NewTicker(cs.pollInterval)
 	defer pollTicker.Stop()
@@ -251,10 +272,15 @@ func (cs *ConntrackConnectionStore) AddOrUpdateConn(conn *connection.Connection)
 				cs.fillServiceInfo(conn, serviceStr)
 			}
 		}
-		cs.addNetworkPolicyMetadata(conn)
+		// This should only happen if we failed to set net.netfilter.nf_conntrack_timestamp
 		if conn.StartTime.IsZero() {
 			conn.StartTime = time.Now()
 			conn.StopTime = time.Now()
+		}
+		if conn.StartTime.Before(cs.networkPolicyReadyTime) {
+			klog.V(1).InfoS("Skip adding NetworkPolicy metadata to connection to avoid reporting invalid information")
+		} else {
+			cs.addNetworkPolicyMetadata(conn)
 		}
 		conn.LastExportTime = conn.StartTime
 		metrics.TotalAntreaConnectionsInConnTrackTable.Inc()

--- a/pkg/agent/flowexporter/connections/conntrack_connections_perf_test.go
+++ b/pkg/agent/flowexporter/connections/conntrack_connections_perf_test.go
@@ -148,7 +148,7 @@ func setupConntrackConnStore(b *testing.B) (*ConntrackConnectionStore, *connecti
 
 	npQuerier := queriertest.NewMockAgentNetworkPolicyInfoQuerier(ctrl)
 	l7Listener := NewL7Listener(nil, mockPodStore)
-	return NewConntrackConnectionStore(mockConnDumper, true, false, npQuerier, mockPodStore, nil, l7Listener, testFlowExporterOptions), mockConnDumper
+	return NewConntrackConnectionStore(mockConnDumper, true, false, npQuerier, mockPodStore, nil, l7Listener, nil, testFlowExporterOptions), mockConnDumper
 }
 
 func generateConns() []*connection.Connection {

--- a/pkg/agent/flowexporter/exporter_perf_test.go
+++ b/pkg/agent/flowexporter/exporter_perf_test.go
@@ -169,7 +169,7 @@ func NewFlowExporterForTest(tb testing.TB, o *options.FlowExporterOptions) *Flow
 
 	l7Listener := connections.NewL7Listener(nil, nil)
 	denyConnStore := connections.NewDenyConnectionStore(nil, nil, nil, o, filter.NewProtocolFilter(nil))
-	conntrackConnStore := connections.NewConntrackConnectionStore(nil, v4Enabled, v6Enabled, nil, nil, nil, l7Listener, o)
+	conntrackConnStore := connections.NewConntrackConnectionStore(nil, v4Enabled, v6Enabled, nil, nil, nil, l7Listener, nil, o)
 
 	return &FlowExporter{
 		collectorProto:         o.FlowCollectorProto,

--- a/pkg/agent/flowexporter/exporter_test.go
+++ b/pkg/agent/flowexporter/exporter_test.go
@@ -300,7 +300,7 @@ func runSendFlowRecordTests(t *testing.T, flowExp *FlowExporter, isIPv6 bool) {
 				StaleConnectionTimeout: 1,
 				PollInterval:           1,
 			}
-			flowExp.conntrackConnStore = connections.NewConntrackConnectionStore(mockConnDumper, !isIPv6, isIPv6, nil, nil, nil, nil, o)
+			flowExp.conntrackConnStore = connections.NewConntrackConnectionStore(mockConnDumper, !isIPv6, isIPv6, nil, nil, nil, nil, nil, o)
 			flowExp.denyConnStore = connections.NewDenyConnectionStore(nil, nil, nil, o, filter.NewProtocolFilter(nil))
 			flowExp.conntrackPriorityQueue = flowExp.conntrackConnStore.GetPriorityQueue()
 			flowExp.denyPriorityQueue = flowExp.denyConnStore.GetPriorityQueue()

--- a/test/integration/agent/flowexporter_test.go
+++ b/test/integration/agent/flowexporter_test.go
@@ -133,7 +133,7 @@ func TestConnectionStoreAndFlowRecords(t *testing.T) {
 		IdleFlowTimeout:        testIdleFlowTimeout,
 		StaleConnectionTimeout: testStaleConnectionTimeout,
 		PollInterval:           testPollInterval}
-	conntrackConnStore := connections.NewConntrackConnectionStore(connDumperMock, true, false, npQuerier, mockPodStore, nil, &fakel7EventMapGetter{}, o)
+	conntrackConnStore := connections.NewConntrackConnectionStore(connDumperMock, true, false, npQuerier, mockPodStore, nil, &fakel7EventMapGetter{}, nil, o)
 	// Expect calls for connStore.poll and other callees
 	connDumperMock.EXPECT().DumpFlows(uint16(openflow.CtZone)).Return(testConns, 0, nil)
 	connDumperMock.EXPECT().GetMaxConnections().Return(0, nil)


### PR DESCRIPTION
To avoid missing or invalid NetworkPolicy data in flow records, we increase the time interval during which the mapping from flow ID to NetworkPolicy rule is available in the idAllocator after rule deletion. During that time, the flow ID cannot be reused.

We also avoid resolving NetworkPolicy metadata for connections which started prior to the Agent starting and the initial NetworkPolicy flows being installed. After an Agent restart, the flow ID assignment is expected to change, and we do not want to include invalid NetworkPolicy data for these connections (better to omit it altogether). We only make this change for the "conntrack" connection store. The "deny" connection store is not as sensitive to this because it reacts to PacketIn messages and not conntrack entries (which can exist for a while and persist during an Agent restart).

For #7438