### PR TITLE
[Flaky unit test] Fix typo in TestPreventDefunctRuleReuse

### DIFF
--- a/pkg/agent/nodeportlocal/npl_agent_test.go
+++ b/pkg/agent/nodeportlocal/npl_agent_test.go
@@ -947,7 +947,7 @@ func TestPreventDefunctRuleReuse(t *testing.T) {
 		if !assert.NoError(t, err) {
 			return
 		}
-		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.EventuallyWithT(t, func(t *assert.CollectT) {
 			obj, exists, err := testData.svcInformer.GetIndexer().GetByKey(testSvc.Namespace + "/" + testSvc.Name)
 			if !assert.NoError(t, err) || !assert.True(t, exists) {
 				return


### PR DESCRIPTION
The test had an invalid usage of assert.EventuallyWithT: the assertions included in the condition function applied to the outer *testing.T instead of to the condition function parameter.

After #7448, the test started failing due to the change in the implementation of assert.EventuallyWithT.