### PR TITLE
Improve initK8sNodeLocalConfig in Agent initialization

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -272,10 +272,7 @@ func run(o *Options) error {
 	// exits, we will force exit.
 	stopCh := signals.RegisterSignalHandlers()
 	// Generate a context for functions which require one (instead of stopCh).
-	// We cancel the context when the function returns, which in the normal case will be when
-	// stopCh is closed.
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := wait.ContextForChannel(stopCh)
 
 	if o.nodeType == config.K8sNode {
 		// Must start after registering all event handlers.
@@ -323,9 +320,8 @@ func run(o *Options) error {
 		l7NetworkPolicyEnabled,
 		l7FlowExporterEnabled,
 		o.config.DisableTXChecksumOffload)
-	err = agentInitializer.Initialize()
-	if err != nil {
-		return fmt.Errorf("error initializing agent: %v", err)
+	if err := agentInitializer.Initialize(ctx); err != nil {
+		return fmt.Errorf("error initializing agent: %w", err)
 	}
 	nodeConfig := agentInitializer.GetNodeConfig()
 


### PR DESCRIPTION
We separate polling for the Node resource to beccome available from polling for the PodCIDR to be set, so that we can get more accurate and helpful log messages.

We also increase the ivrall timeout from 30s to 60s. It is possible that the Agent may be killed by kubelet first because of a failing liveness probe, but that is also handled correctly.

For #7472