### PR TITLE
Add benchmark for ConntrackConnectionStore's Poll method

### DIFF
--- a/pkg/agent/flowexporter/connections/connections.go
+++ b/pkg/agent/flowexporter/connections/connections.go
@@ -71,6 +71,12 @@ func (cs *connectionStore) GetConnByKey(connKey connection.ConnectionKey) (*conn
 	return conn, found
 }
 
+func (cs *connectionStore) NumConnections() int {
+	cs.mutex.Lock()
+	defer cs.mutex.Unlock()
+	return len(cs.connections)
+}
+
 // ForAllConnectionsDo execute the callback for each connection in connection map.
 func (cs *connectionStore) ForAllConnectionsDo(callback connection.ConnectionMapCallBack) error {
 	cs.mutex.Lock()

--- a/pkg/agent/flowexporter/connections/conntrack_connections.go
+++ b/pkg/agent/flowexporter/connections/conntrack_connections.go
@@ -330,6 +330,14 @@ func (cs *ConntrackConnectionStore) deleteConnWithoutLock(connKey connection.Con
 	return nil
 }
 
+func (cs *ConntrackConnectionStore) DeleteAllConnections() int {
+	cs.AcquireConnStoreLock()
+	defer cs.ReleaseConnStoreLock()
+	num := len(cs.connections)
+	clear(cs.connections)
+	return num
+}
+
 func (cs *ConntrackConnectionStore) GetPriorityQueue() *priorityqueue.ExpirePriorityQueue {
 	return cs.connectionStore.expirePriorityQueue
 }

--- a/test/integration/agent/flowexporter_test.go
+++ b/test/integration/agent/flowexporter_test.go
@@ -192,7 +192,7 @@ func TestSetupConnTrackParameters(t *testing.T) {
 // ConntrackConnectionStore, which periodically dumps all connections from conntrack and updates its
 // internal store. This benchmark only evaluates connection "add", and not connection "update",
 // which is achieved by clearing the connection store after each benchmark loop iteration. Note that
-// connection "add" is more expensive that connection "update". However, it seems that dumping the
+// connection "add" is more expensive than connection "update". However, it seems that dumping the
 // connections from conntrack is what is using the most CPU time.
 func BenchmarkConntrackConnectionStorePoll(b *testing.B) {
 	// 32K is not such a high number (we could go to 128K or even more), but it seems reasonable


### PR DESCRIPTION
We can use this to evaluate improvements to the FlowExporter in the future.

Current results:
```
go test -bench=BenchmarkConntrackConnectionStorePoll -cpuprofile=cpu.out -benchtime=100x -benchmem -run=XXX ./test/integration/agent/
goos: linux
goarch: amd64
pkg: antrea.io/antrea/test/integration/agent
cpu: Intel(R) Xeon(R) Platinum 8275CL CPU @ 3.00GHz
BenchmarkConntrackConnectionStorePoll-16    	     100	 279751187 ns/op	146577693 B/op	 2373538 allocs/op
--- BENCH: BenchmarkConntrackConnectionStorePoll-16
    flowexporter_test.go:229: Creating 32768 conntrack entries across multiple destination addresses...
    flowexporter_test.go:262: Cleaning up 32768 conntrack entries...
PASS
ok  	antrea.io/antrea/test/integration/agent	29.711s
```

CPU time is almost the same when forcing `GOMAXPROCS=1`.

This is with 32K connections in the Antrea CT zone (and <100 connections in the default zone). We can extrapolate that with 100K connections, the FlowExporter will use almost 500MB of memory, and a single poll cycle will take almost 1s.

Here is the CPU profile for reference: [profile.pdf](https://github.com/user-attachments/files/22569048/profile010.pdf)