### PR TITLE
Refine antrea pod restart policy

### DIFF
--- a/build/charts/antrea/templates/agent/daemonset.yaml
+++ b/build/charts/antrea/templates/agent/daemonset.yaml
@@ -36,6 +36,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      restartPolicy: OnFailure   # Pod-level restart policy
       hostNetwork: true
       {{- if .Values.agent.dnsPolicy }}
       dnsPolicy: {{ .Values.agent.dnsPolicy }}
@@ -73,6 +74,7 @@ spec:
         - name: install-cni
           image: {{ include "antreaAgentImage" . | quote }}
           imagePullPolicy: {{ include "antreaAgentImagePullPolicy" . }}
+          restartPolicy: Never
           resources: {{- .Values.agent.installCNI.resources | toYaml | nindent 12 }}
           {{- if eq .Values.trafficEncapMode "networkPolicyOnly" }}
           command: ["install_cni_chaining"]
@@ -132,6 +134,13 @@ spec:
       {{- end }}
         - name: antrea-agent
           image: {{ include "antreaAgentImage" . | quote }}
+          # Fine-grained restart based on exit codes
+          restartPolicy: OnFailure
+          restartPolicyRules:
+            - exitCodes: [137, 143]  # OOMKilled or SIGTERM
+              restartPolicy: Always
+            - exitCodes: [1]          # Misconfiguration or startup errors
+              restartPolicy: Never
           imagePullPolicy: {{ include "antreaAgentImagePullPolicy" . }}
           {{- if ((.Values.testing).coverage) }}
           args:
@@ -274,6 +283,12 @@ spec:
         - name: antrea-ovs
           image: {{ include "antreaAgentImage" . | quote }}
           imagePullPolicy: {{ include "antreaAgentImagePullPolicy" . }}
+          restartPolicy: Always
+          restartPolicyRules:
+            - exitCodes: [137, 143]  # OOMKilled or SIGTERM
+              restartPolicy: Always
+            - exitCodes: [1, 2]      # Setup/configuration errors
+              restartPolicy: Never
           resources: {{- .Values.agent.antreaOVS.resources | toYaml | nindent 12 }}
           command: ["start_ovs"]
           args:
@@ -327,6 +342,12 @@ spec:
         - name: antrea-ipsec
           image: {{ include "antreaAgentImage" . | quote }}
           imagePullPolicy: {{ include "antreaAgentImagePullPolicy" . }}
+          restartPolicy: Always
+          restartPolicyRules:
+            - exitCodes: [137, 143]
+              restartPolicy: Always
+            - exitCodes: [1, 2]
+              restartPolicy: Never
           resources: {{- .Values.agent.antreaIPsec.resources | toYaml | nindent 12 }}
           command: ["start_ovs_ipsec"]
           livenessProbe:

--- a/build/charts/antrea/templates/controller/deployment.yaml
+++ b/build/charts/antrea/templates/controller/deployment.yaml
@@ -36,6 +36,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       hostNetwork: true
+      restartPolicy: Always   # Pod-level restart policy for Deployment
       priorityClassName: {{ .Values.controller.priorityClassName }}
       {{- with .Values.controller.tolerations }}
       tolerations:
@@ -64,6 +65,12 @@ spec:
           imagePullPolicy: {{ include "antreaControllerImagePullPolicy" . }}
           resources: {{- .Values.controller.antreaController.resources | toYaml | nindent 12 }}
           {{- if ((.Values.testing).coverage) }}
+          restartPolicy: Always
+          restartPolicyRules:
+            - exitCodes: [137, 143]  # OOMKilled or SIGTERM
+              restartPolicy: Always
+            - exitCodes: [1]         # Misconfiguration or startup errors
+              restartPolicy: Never
           args:
             - "antrea-controller"
             - "--config=/etc/antrea/antrea-controller.conf"

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -5508,6 +5508,7 @@ spec:
         app: antrea
         component: antrea-agent
     spec:
+      restartPolicy: OnFailure   # Pod-level restart policy
       hostNetwork: true
       dnsPolicy: ClusterFirst
       priorityClassName: system-node-critical
@@ -5526,6 +5527,7 @@ spec:
         - name: install-cni
           image: "antrea/antrea-agent-ubuntu:latest"
           imagePullPolicy: IfNotPresent
+          restartPolicy: Never
           resources:
             requests:
               cpu: 100m
@@ -5562,6 +5564,13 @@ spec:
             mountPath: /var/run/antrea
         - name: antrea-agent
           image: "antrea/antrea-agent-ubuntu:latest"
+          # Fine-grained restart based on exit codes
+          restartPolicy: OnFailure
+          restartPolicyRules:
+            - exitCodes: [137, 143]  # OOMKilled or SIGTERM
+              restartPolicy: Always
+            - exitCodes: [1]          # Misconfiguration or startup errors
+              restartPolicy: Never
           imagePullPolicy: IfNotPresent
           command: ["antrea-agent"]
           # Log to both "/var/log/antrea/" and stderr (so "kubectl logs" can work).-
@@ -5656,6 +5665,12 @@ spec:
         - name: antrea-ovs
           image: "antrea/antrea-agent-ubuntu:latest"
           imagePullPolicy: IfNotPresent
+          restartPolicy: Always
+          restartPolicyRules:
+            - exitCodes: [137, 143]  # OOMKilled or SIGTERM
+              restartPolicy: Always
+            - exitCodes: [1, 2]      # Setup/configuration errors
+              restartPolicy: Never
           resources:
             requests:
               cpu: 200m
@@ -5759,6 +5774,7 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       hostNetwork: true
+      restartPolicy: Always   # Pod-level restart policy for Deployment
       priorityClassName: system-cluster-critical
       tolerations:
         - key: CriticalAddonsOnly

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -5504,6 +5504,7 @@ spec:
         app: antrea
         component: antrea-agent
     spec:
+      restartPolicy: OnFailure   # Pod-level restart policy
       hostNetwork: true
       priorityClassName: system-node-critical
       nodeSelector:
@@ -5521,6 +5522,7 @@ spec:
         - name: install-cni
           image: "antrea/antrea-agent-ubuntu:latest"
           imagePullPolicy: IfNotPresent
+          restartPolicy: Never
           resources:
             requests:
               cpu: 100m
@@ -5557,6 +5559,13 @@ spec:
             mountPath: /var/run/antrea
         - name: antrea-agent
           image: "antrea/antrea-agent-ubuntu:latest"
+          # Fine-grained restart based on exit codes
+          restartPolicy: OnFailure
+          restartPolicyRules:
+            - exitCodes: [137, 143]  # OOMKilled or SIGTERM
+              restartPolicy: Always
+            - exitCodes: [1]          # Misconfiguration or startup errors
+              restartPolicy: Never
           imagePullPolicy: IfNotPresent
           command: ["antrea-agent"]
           # Log to both "/var/log/antrea/" and stderr (so "kubectl logs" can work).-
@@ -5653,6 +5662,12 @@ spec:
         - name: antrea-ovs
           image: "antrea/antrea-agent-ubuntu:latest"
           imagePullPolicy: IfNotPresent
+          restartPolicy: Always
+          restartPolicyRules:
+            - exitCodes: [137, 143]  # OOMKilled or SIGTERM
+              restartPolicy: Always
+            - exitCodes: [1, 2]      # Setup/configuration errors
+              restartPolicy: Never
           resources:
             requests:
               cpu: 200m
@@ -5756,6 +5771,7 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       hostNetwork: true
+      restartPolicy: Always   # Pod-level restart policy for Deployment
       priorityClassName: system-cluster-critical
       tolerations:
         - key: CriticalAddonsOnly

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -5504,6 +5504,7 @@ spec:
         app: antrea
         component: antrea-agent
     spec:
+      restartPolicy: OnFailure   # Pod-level restart policy
       hostNetwork: true
       priorityClassName: system-node-critical
       nodeSelector:
@@ -5520,6 +5521,7 @@ spec:
         - name: install-cni
           image: "antrea/antrea-agent-ubuntu:latest"
           imagePullPolicy: IfNotPresent
+          restartPolicy: Never
           resources:
             requests:
               cpu: 100m
@@ -5556,6 +5558,13 @@ spec:
       containers:
         - name: antrea-agent
           image: "antrea/antrea-agent-ubuntu:latest"
+          # Fine-grained restart based on exit codes
+          restartPolicy: OnFailure
+          restartPolicyRules:
+            - exitCodes: [137, 143]  # OOMKilled or SIGTERM
+              restartPolicy: Always
+            - exitCodes: [1]          # Misconfiguration or startup errors
+              restartPolicy: Never
           imagePullPolicy: IfNotPresent
           command: ["antrea-agent"]
           # Log to both "/var/log/antrea/" and stderr (so "kubectl logs" can work).-
@@ -5650,6 +5659,12 @@ spec:
         - name: antrea-ovs
           image: "antrea/antrea-agent-ubuntu:latest"
           imagePullPolicy: IfNotPresent
+          restartPolicy: Always
+          restartPolicyRules:
+            - exitCodes: [137, 143]  # OOMKilled or SIGTERM
+              restartPolicy: Always
+            - exitCodes: [1, 2]      # Setup/configuration errors
+              restartPolicy: Never
           resources:
             requests:
               cpu: 200m
@@ -5753,6 +5768,7 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       hostNetwork: true
+      restartPolicy: Always   # Pod-level restart policy for Deployment
       priorityClassName: system-cluster-critical
       tolerations:
         - key: CriticalAddonsOnly

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -5518,6 +5518,7 @@ spec:
         app: antrea
         component: antrea-agent
     spec:
+      restartPolicy: OnFailure   # Pod-level restart policy
       hostNetwork: true
       priorityClassName: system-node-critical
       nodeSelector:
@@ -5534,6 +5535,7 @@ spec:
         - name: install-cni
           image: "antrea/antrea-agent-ubuntu:latest"
           imagePullPolicy: IfNotPresent
+          restartPolicy: Never
           resources:
             requests:
               cpu: 100m
@@ -5570,6 +5572,13 @@ spec:
       containers:
         - name: antrea-agent
           image: "antrea/antrea-agent-ubuntu:latest"
+          # Fine-grained restart based on exit codes
+          restartPolicy: OnFailure
+          restartPolicyRules:
+            - exitCodes: [137, 143]  # OOMKilled or SIGTERM
+              restartPolicy: Always
+            - exitCodes: [1]          # Misconfiguration or startup errors
+              restartPolicy: Never
           imagePullPolicy: IfNotPresent
           command: ["antrea-agent"]
           # Log to both "/var/log/antrea/" and stderr (so "kubectl logs" can work).-
@@ -5673,6 +5682,12 @@ spec:
         - name: antrea-ovs
           image: "antrea/antrea-agent-ubuntu:latest"
           imagePullPolicy: IfNotPresent
+          restartPolicy: Always
+          restartPolicyRules:
+            - exitCodes: [137, 143]  # OOMKilled or SIGTERM
+              restartPolicy: Always
+            - exitCodes: [1, 2]      # Setup/configuration errors
+              restartPolicy: Never
           resources:
             requests:
               cpu: 200m
@@ -5709,6 +5724,12 @@ spec:
         - name: antrea-ipsec
           image: "antrea/antrea-agent-ubuntu:latest"
           imagePullPolicy: IfNotPresent
+          restartPolicy: Always
+          restartPolicyRules:
+            - exitCodes: [137, 143]
+              restartPolicy: Always
+            - exitCodes: [1, 2]
+              restartPolicy: Never
           resources:
             requests:
               cpu: 50m
@@ -5812,6 +5833,7 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       hostNetwork: true
+      restartPolicy: Always   # Pod-level restart policy for Deployment
       priorityClassName: system-cluster-critical
       tolerations:
         - key: CriticalAddonsOnly

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -5504,6 +5504,7 @@ spec:
         app: antrea
         component: antrea-agent
     spec:
+      restartPolicy: OnFailure   # Pod-level restart policy
       hostNetwork: true
       priorityClassName: system-node-critical
       nodeSelector:
@@ -5520,6 +5521,7 @@ spec:
         - name: install-cni
           image: "antrea/antrea-agent-ubuntu:latest"
           imagePullPolicy: IfNotPresent
+          restartPolicy: Never
           resources:
             requests:
               cpu: 100m
@@ -5556,6 +5558,13 @@ spec:
       containers:
         - name: antrea-agent
           image: "antrea/antrea-agent-ubuntu:latest"
+          # Fine-grained restart based on exit codes
+          restartPolicy: OnFailure
+          restartPolicyRules:
+            - exitCodes: [137, 143]  # OOMKilled or SIGTERM
+              restartPolicy: Always
+            - exitCodes: [1]          # Misconfiguration or startup errors
+              restartPolicy: Never
           imagePullPolicy: IfNotPresent
           command: ["antrea-agent"]
           # Log to both "/var/log/antrea/" and stderr (so "kubectl logs" can work).-
@@ -5650,6 +5659,12 @@ spec:
         - name: antrea-ovs
           image: "antrea/antrea-agent-ubuntu:latest"
           imagePullPolicy: IfNotPresent
+          restartPolicy: Always
+          restartPolicyRules:
+            - exitCodes: [137, 143]  # OOMKilled or SIGTERM
+              restartPolicy: Always
+            - exitCodes: [1, 2]      # Setup/configuration errors
+              restartPolicy: Never
           resources:
             requests:
               cpu: 200m
@@ -5753,6 +5768,7 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       hostNetwork: true
+      restartPolicy: Always   # Pod-level restart policy for Deployment
       priorityClassName: system-cluster-critical
       tolerations:
         - key: CriticalAddonsOnly


### PR DESCRIPTION
Antrea Agent Pod: Init containers like install-cni should not retry repeatedly to avoid churn. The Agent container restarts on failures, immediately recovering from transient issues (exit codes 137, 143) but not on configuration errors (exit code 1). The OVS container always restarts for transient failures but avoids restart on setup errors (exit codes 1, 2).

Antrea Controller Pod: The Controller container restarts automatically on transient issues (exit codes 137, 143) but will not restart on fatal errors or misconfigurations (exit codes 1, 2) to prevent crash loops.

More details refer #7484 