### PR TITLE
Remove cgroup driver configuration from e2e test infra

### DIFF
--- a/test/e2e/infra/vagrant/playbook/roles/control-plane/templates/kubeadm.conf.j2
+++ b/test/e2e/infra/vagrant/playbook/roles/control-plane/templates/kubeadm.conf.j2
@@ -30,5 +30,5 @@ ipvs:
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
-# this is the default starting with v1.22, but we prefer to set it explicitly
-cgroupDriver: systemd
+# cgroupDriver is deprecated in v1.34+, kubelet auto-detect the CRI's driver
+# cgroupDriver: systemd


### PR DESCRIPTION
No  need to explicitly set cgroupDriver in kubelet configuration.
The kubelet will pick the correct driver automatically, avoiding misconfiguration.