### PR TITLE
Clean up stale secondary IPs in IPPool when Node restarts with invalid OVSDB

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -621,7 +621,7 @@ func run(o *Options) error {
 			o.config.ClientConnection, o.config.KubeAPIServerOverride,
 			k8sClient, localPodInformer.Get(),
 			podUpdateChannel, ifaceStore, nodeConfig,
-			&o.config.SecondaryNetwork, ovsdbConnection)
+			&o.config.SecondaryNetwork, ovsdbConnection, ipPoolInformer.Lister())
 		if err != nil {
 			return fmt.Errorf("failed to create secondary network controller: %w", err)
 		}

--- a/pkg/agent/secondarynetwork/init.go
+++ b/pkg/agent/secondarynetwork/init.go
@@ -27,6 +27,7 @@ import (
 	"antrea.io/antrea/pkg/agent/config"
 	"antrea.io/antrea/pkg/agent/interfacestore"
 	"antrea.io/antrea/pkg/agent/secondarynetwork/podwatch"
+	crdlisters "antrea.io/antrea/pkg/client/listers/crd/v1beta1"
 	agentconfig "antrea.io/antrea/pkg/config/agent"
 	"antrea.io/antrea/pkg/ovs/ovsconfig"
 	"antrea.io/antrea/pkg/util/channel"
@@ -52,6 +53,7 @@ func NewController(
 	primaryInterfaceStore interfacestore.InterfaceStore,
 	nodeConfig *config.NodeConfig,
 	secNetConfig *agentconfig.SecondaryNetworkConfig, ovsdb *ovsdb.OVSDB,
+	ipPoolLister crdlisters.IPPoolLister,
 ) (*Controller, error) {
 	ovsBridgeClient, err := createOVSBridge(secNetConfig.OVSBridges, ovsdb)
 	if err != nil {
@@ -69,7 +71,7 @@ func NewController(
 	// k8s.v1.cni.cncf.io/networks Annotation defined.
 	podWatchController, err := podwatch.NewPodController(
 		k8sClient, netAttachDefClient, podInformer,
-		podUpdateSubscriber, primaryInterfaceStore, nodeConfig, ovsBridgeClient)
+		podUpdateSubscriber, primaryInterfaceStore, nodeConfig, ovsBridgeClient, ipPoolLister)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ipam/poolallocator/allocator.go
+++ b/pkg/ipam/poolallocator/allocator.go
@@ -324,7 +324,7 @@ func (a *IPPoolAllocator) AllocateIP(ip net.IP, state v1beta1.IPAddressPhase, ow
 	return subnetInfo, err
 }
 
-// AllocateNext allocates the next available IP. It returns error if pool is exausted,
+// AllocateNext allocates the next available IP. It returns error if pool is exhausted,
 // or in case CRD failed to update its state.
 // In case of success, IPPool CRD status is updated with allocated IP/state/resource/container.
 // AllocateIP returns subnet details for the requested IP, as defined in IP pool spec.
@@ -363,7 +363,7 @@ func (a *IPPoolAllocator) AllocateNext(state v1beta1.IPAddressPhase, owner v1bet
 
 		if index == len(allocators) {
 			// Failed to find matching range
-			return fmt.Errorf("failed to allocate IP: Pool %s is exausted", a.ipPoolName)
+			return fmt.Errorf("failed to allocate IP: Pool %s is exhausted", a.ipPoolName)
 		}
 
 		subnetInfo = &ipPool.Spec.SubnetInfo

--- a/pkg/ipam/poolallocator/allocator_test.go
+++ b/pkg/ipam/poolallocator/allocator_test.go
@@ -186,7 +186,7 @@ func TestAllocateNextMultiRange(t *testing.T) {
 	validateAllocationSequence(t, allocator, subnetInfo, []string{"10.2.2.100", "10.2.2.101", "10.2.2.2", "10.2.2.3"})
 }
 
-func TestAllocateNextMultiRangeExausted(t *testing.T) {
+func TestAllocateNextMultiRangeExhausted(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 


### PR DESCRIPTION
When a Kubernetes Node reboots and the OVSDB file is not properly restored,
the primary and secondary OVS ports are lost. Pods may temporarily
appear as "unknown" and later get recreated with new container IDs.

The cleanup of secondary interfaces during agent restart relies on the
InterfaceStores being initialized with existing OVS ports. If the OVSDB file
is missing, the primary InterfaceStore is empty, which prevents the secondary
InterfaceStore from initializing correctly. Consequently, secondary IPs assigned
to old Pods (with previous container IDs) are not deleted, leaving stale entries
in the IPPool.
    
This change adds logic to periodically verify all IPPool allocations and release
any secondary IPs associated with non-existing container IDs. This also covers
the case where a Pod is recreated with the same name on another Node and has any
secondary IPs.