### PR TITLE
Fix type assertion panic in GetFlowTableID

### DIFF
--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -267,7 +267,7 @@ func GetFlowTableID(tableName string) uint8 {
 	if len(objs) == 0 {
 		return binding.TableIDAll
 	}
-	return objs[0].(binding.Table).GetID()
+	return objs[0].(*Table).ofTable.GetID()
 }
 
 func GetTableList() []binding.Table {


### PR DESCRIPTION
The GetFlowTableID function was incorrectly attempting to cast tableCache objects directly to binding.Table, but the cache stores *Table wrapper objects. The wrapper's ofTable field contains the actual binding.Table implementation. This caused a panic in the `/ovsflows` HTTP handler.

Fix the type assertion to match the pattern used in getTableByID:
```
objs[0].(*Table).ofTable.GetID()
```

Also add unit tests for GetFlowTableID, GetFlowTableName, and GetTableList to prevent regressions.