### PR TITLE
Exclude Egress VLAN sub-interface (antrea-ext.VLAN) from NodePort

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -101,7 +101,10 @@ const informerDefaultResync = 12 * time.Hour
 const resyncPeriodDisabled = 0 * time.Minute
 
 // The devices that should be excluded from NodePort.
-var excludeNodePortDevices = []string{"antrea-egress0", "antrea-ingress0", "kube-ipvs0"}
+var (
+	excludeNodePortDevices        = []string{"antrea-egress0", "antrea-ingress0", "kube-ipvs0"}
+	excludeNodePortDevicePrefixes = []string{"antrea-ext."}
+)
 
 var ipv4Localhost = net.ParseIP("127.0.0.1")
 
@@ -285,7 +288,8 @@ func run(o *Options) error {
 	// Get all available NodePort addresses.
 	var nodePortAddressesIPv4, nodePortAddressesIPv6 []net.IP
 	if o.config.AntreaProxy.ProxyAll {
-		nodePortAddressesIPv4, nodePortAddressesIPv6, err = getAvailableNodePortAddresses(o.config.AntreaProxy.NodePortAddresses, append(excludeNodePortDevices, o.config.HostGateway))
+		excludeNodePortDevices := append(excludeNodePortDevices, o.config.HostGateway)
+		nodePortAddressesIPv4, nodePortAddressesIPv6, err = getAvailableNodePortAddresses(o.config.AntreaProxy.NodePortAddresses, excludeNodePortDevices, excludeNodePortDevicePrefixes)
 		if err != nil {
 			return fmt.Errorf("getting available NodePort IP addresses failed: %v", err)
 		}

--- a/cmd/antrea-agent/util.go
+++ b/cmd/antrea-agent/util.go
@@ -35,9 +35,20 @@ var (
 	getPodCIDRsFromKubeadm   = k8sutil.GetPodCIDRsFromKubeadm
 )
 
-func getAvailableNodePortAddresses(nodePortAddressesFromConfig []string, excludeDevices []string) ([]net.IP, []net.IP, error) {
+func getAvailableNodePortAddresses(nodePortAddressesFromConfig []string, excludeDevices []string, excludeDevicePrefixes []string) ([]net.IP, []net.IP, error) {
+	excludeDeviceMatchers := make([]func(string) bool, 0)
+	for _, device := range excludeDevices {
+		excludeDeviceMatchers = append(excludeDeviceMatchers, func(name string) bool {
+			return name == device
+		})
+	}
+	for _, devicePrefix := range excludeDevicePrefixes {
+		excludeDeviceMatchers = append(excludeDeviceMatchers, func(name string) bool {
+			return strings.HasPrefix(name, devicePrefix)
+		})
+	}
 	// Get all IP addresses of Node
-	nodeAddressesIPv4, nodeAddressesIPv6, err := getAllNodeAddresses(excludeDevices)
+	nodeAddressesIPv4, nodeAddressesIPv6, err := getAllNodeAddresses(excludeDeviceMatchers)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/cmd/antrea-agent/util_test.go
+++ b/cmd/antrea-agent/util_test.go
@@ -46,7 +46,7 @@ func TestGetAvailableNodePortAddresses(t *testing.T) {
 			expectedIPv6:                nil,
 		},
 	}
-	getAllNodeAddresses = func(excludeDevices []string) ([]net.IP, []net.IP, error) {
+	getAllNodeAddresses = func(excludeDeviceMatchers []func(string) bool) ([]net.IP, []net.IP, error) {
 		ipv4 := []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("192.168.225.234"), net.ParseIP("10.104.73.43")}
 		ipv6 := []net.IP{net.ParseIP("::1"), net.ParseIP("2409:4071:4d11:f5d2:71:e53f:7d28:668e"), net.ParseIP("2409:4071:4d11:f5d2:75ab:a5b6:ff05:b31e")}
 		return ipv4, ipv6, nil
@@ -57,7 +57,7 @@ func TestGetAvailableNodePortAddresses(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			gotIPv4, gotIPv6, err := getAvailableNodePortAddresses(tc.nodePortAddressesFromConfig, []string{"antrea-egress0", "antrea-ingress0", "kube-ipvs0", "antrea-gw0"})
+			gotIPv4, gotIPv6, err := getAvailableNodePortAddresses(tc.nodePortAddressesFromConfig, []string{"antrea-egress0", "antrea-ingress0", "kube-ipvs0", "antrea-gw0"}, []string{"antrea-ext."})
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedIPv4, gotIPv4)
 			assert.Equal(t, tc.expectedIPv6, gotIPv6)

--- a/pkg/agent/util/net_test.go
+++ b/pkg/agent/util/net_test.go
@@ -450,7 +450,13 @@ func TestGetAllNodeAddresses(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			defer mockNetInterfaceGet(testNetInterfaces, tc.testNetInterfaceErr)()
 			defer mockNetInterfaceAddrsMultiple(testNetInterfaces, true, nil)()
-			gotNodeAddrsIPv4, gotNodeAddrsIPv6, gotErr := GetAllNodeAddresses(tc.excludeDevices)
+			excludeDeviceMatchers := make([]func(string) bool, 0)
+			for _, device := range tc.excludeDevices {
+				excludeDeviceMatchers = append(excludeDeviceMatchers, func(name string) bool {
+					return name == device
+				})
+			}
+			gotNodeAddrsIPv4, gotNodeAddrsIPv6, gotErr := GetAllNodeAddresses(excludeDeviceMatchers)
 			assert.Equal(t, tc.wantNodeAddrsIPv4, gotNodeAddrsIPv4)
 			assert.Equal(t, tc.wantNodeAddrsIPv6, gotNodeAddrsIPv6)
 			assert.Equal(t, tc.testNetInterfaceErr, gotErr)


### PR DESCRIPTION
For consistency with "regular" Egress (without separate VLAN), these devices should be excluded from the default NodePort addresses. Failing to do so may lead to some unexpected behaviors.

Fixes #7518