### PR TITLE
Automated cherry pick of #7512: Handle missing Pod IP and Pod IP changes

### DIFF
--- a/docs/feature-gates.md
+++ b/docs/feature-gates.md
@@ -261,8 +261,7 @@ this [document](node-port-local.md) for more information.
 
 #### Requirements for this Feature
 
-This feature is currently only supported for Nodes running Linux with IPv4 addresses. Only TCP & UDP Service ports are
-supported (not SCTP).
+This feature currently only supports IPv4. Only TCP & UDP Service ports are supported (not SCTP).
 
 ### Egress
 

--- a/pkg/agent/nodeportlocal/k8s/npl_controller_test.go
+++ b/pkg/agent/nodeportlocal/k8s/npl_controller_test.go
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package nodeportlocal
+package k8s
 
 import (
 	"context"
@@ -39,7 +39,6 @@ import (
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
 
-	"antrea.io/antrea/pkg/agent/nodeportlocal/k8s"
 	"antrea.io/antrea/pkg/agent/nodeportlocal/portcache"
 	portcachetesting "antrea.io/antrea/pkg/agent/nodeportlocal/portcache/testing"
 	"antrea.io/antrea/pkg/agent/nodeportlocal/rules"
@@ -176,19 +175,20 @@ func getTestSvcWithPortName(portName string) *corev1.Service {
 
 type testData struct {
 	*testing.T
-	stopCh      chan struct{}
-	ctrl        *gomock.Controller
-	k8sClient   *k8sfake.Clientset
-	portTable   *portcache.PortTable
-	svcInformer cache.SharedIndexInformer
-	wg          sync.WaitGroup
+	stopCh        chan struct{}
+	ctrl          *gomock.Controller
+	k8sClient     *k8sfake.Clientset
+	portTable     *portcache.PortTable
+	svcInformer   cache.SharedIndexInformer
+	nplController *NPLController
+	wg            sync.WaitGroup
 }
 
-func (t *testData) runWrapper(c *k8s.NPLController) {
+func (t *testData) runWrapper() {
 	t.wg.Add(1)
 	go func() {
 		defer t.wg.Done()
-		c.Run(t.stopCh)
+		t.nplController.Run(t.stopCh)
 	}()
 }
 
@@ -223,9 +223,25 @@ func setUp(t *testing.T, tc *testConfig, objects ...runtime.Object) *testData {
 	if tc.customPodPortRulesExpectations != nil {
 		tc.customPodPortRulesExpectations(mockIPTables)
 	} else {
-		mockIPTables.EXPECT().AddRule(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+		mockIPTables.EXPECT().AddRule(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(
+			func(nodePort int, podIP string, podPort int, protocol string) error {
+				if nodePort == 0 || podIP == "" || podPort == 0 || protocol == "" {
+					return fmt.Errorf("invalid argument to AddRule")
+				}
+				return nil
+			},
+		)
 		mockIPTables.EXPECT().DeleteRule(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
-		mockIPTables.EXPECT().AddAllRules(gomock.Any()).AnyTimes()
+		mockIPTables.EXPECT().AddAllRules(gomock.Any()).AnyTimes().DoAndReturn(
+			func(nplList []rules.PodNodePort) error {
+				for _, nplData := range nplList {
+					if nplData.NodePort == 0 || nplData.PodIP == "" || nplData.PodPort == 0 || nplData.Protocol == "" {
+						return fmt.Errorf("invalid entry in nplList argument to AddAllRules: %+v", nplData)
+					}
+				}
+				return nil
+			},
+		)
 	}
 
 	mockPortOpener := portcachetesting.NewMockLocalPortOpener(mockCtrl)
@@ -254,18 +270,19 @@ func setUp(t *testing.T, tc *testConfig, objects ...runtime.Object) *testData {
 	)
 	svcInformer := informerFactory.Core().V1().Services().Informer()
 
-	c := k8s.NewNPLController(k8sClient, localPodInformer, svcInformer, portTable, defaultNodeName)
+	c := NewNPLController(k8sClient, localPodInformer, svcInformer, portTable, defaultNodeName)
 
 	data := &testData{
-		T:           t,
-		stopCh:      make(chan struct{}),
-		ctrl:        mockCtrl,
-		k8sClient:   k8sClient,
-		portTable:   portTable,
-		svcInformer: svcInformer,
+		T:             t,
+		stopCh:        make(chan struct{}),
+		ctrl:          mockCtrl,
+		k8sClient:     k8sClient,
+		portTable:     portTable,
+		svcInformer:   svcInformer,
+		nplController: c,
 	}
 
-	data.runWrapper(c)
+	data.runWrapper()
 	informerFactory.Start(data.stopCh)
 	go localPodInformer.Run(data.stopCh)
 
@@ -828,18 +845,131 @@ func TestMultipleServicesSameBackendPod(t *testing.T) {
 	assert.True(t, testData.portTable.RuleExists(defaultPodKey, 9090, protocolTCP))
 }
 
-// TestInitInvalidPod simulates an agent reboot case. A Pod with an invalid NPL annotation is
-// added, this invalid annotation should get cleaned up. And a proper NPL annotation should get
-// added.
-func TestInitInvalidPod(t *testing.T) {
+// TestInitInvalidAnnotation simulates the case where the agent reboots and for some reason an NPL
+// annotation is invalid. The annotation should eventually be replaced by a valid one.
+func TestInitInvalidAnnotation(t *testing.T) {
 	testSvc := getTestSvc()
 	testPod := getTestPod()
-	// assign an invalid annotation
-	annotations := map[string]string{
-		types.NPLAnnotationKey: "[{\"podPort\":53,\"nodeIP\":\"10.10.10.10\", \"nodePort\": 30000}]",
+	testPod.Annotations = map[string]string{
+		types.NPLAnnotationKey: "",
 	}
-	testPod.SetAnnotations(annotations)
-	testData := setUp(t, newTestConfig(), testSvc, testPod)
+	testConfig := newTestConfig().withCustomPodPortRulesExpectations(func(mockIPTables *rulestesting.MockPodPortRules) {
+		// No initial rule should be synced.
+		mockIPTables.EXPECT().AddAllRules(gomock.Len(0)).Return(nil)
+		mockIPTables.EXPECT().AddRule(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+	})
+	testData := setUp(t, testConfig, testSvc, testPod)
+	defer testData.tearDown()
+
+	value, err := testData.pollForPodAnnotation(testPod.Name, true)
+	require.NoError(t, err, "Poll for annotation check failed")
+	expectedAnnotations := newExpectedNPLAnnotations().Add(nil, defaultPort, protocolTCP)
+	expectedAnnotations.Check(t, value)
+	assert.True(t, testData.portTable.RuleExists(defaultPodKey, defaultPort, protocolTCP))
+}
+
+// TestInitNodePortOutOfRange simulates the case where the agent reboots and the NPL port range has
+// changed. The existing NPL annotation should be replaced by one with a valid NodePort (i.e., with
+// a value in the new range) and the correct rule should be installed.
+func TestInitNodePortOutOfRange(t *testing.T) {
+	testSvc := getTestSvc()
+	testPod := getTestPod()
+	nplAnnotation := []types.NPLAnnotation{
+		{
+			PodPort:  defaultPort,
+			NodeIP:   defaultHostIP,
+			NodePort: 30000,
+			Protocol: protocolTCP,
+		},
+	}
+	nplAnnotationBytes, err := json.Marshal(nplAnnotation)
+	require.NoError(t, err)
+	testPod.Annotations = map[string]string{
+		types.NPLAnnotationKey: string(nplAnnotationBytes),
+	}
+	testConfig := newTestConfig().withCustomPodPortRulesExpectations(func(mockIPTables *rulestesting.MockPodPortRules) {
+		// No initial rule should be synced.
+		mockIPTables.EXPECT().AddAllRules(gomock.Len(0)).Return(nil)
+		mockIPTables.EXPECT().AddRule(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+	})
+	testData := setUp(t, testConfig, testSvc, testPod)
+	defer testData.tearDown()
+
+	value, err := testData.pollForPodAnnotation(testPod.Name, true)
+	require.NoError(t, err, "Poll for annotation check failed")
+	expectedAnnotations := newExpectedNPLAnnotations().Add(nil, defaultPort, protocolTCP)
+	expectedAnnotations.Check(t, value)
+	assert.True(t, testData.portTable.RuleExists(defaultPodKey, defaultPort, protocolTCP))
+}
+
+// TestInitMissingPodIP simulates the case where the agent reboots and one Pod has an existing NPL
+// annotation but is mising its Pod IP. We expect the annotation to be removed until the Pod IP
+// becomes available, at which point a new NPL annotation should be added.
+func TestInitMissingPodIP(t *testing.T) {
+	testSvc := getTestSvc()
+	testPod := getTestPod()
+	testPod.Status.PodIP = ""
+	nplAnnotation := []types.NPLAnnotation{
+		{
+			PodPort:  defaultPort,
+			NodeIP:   defaultHostIP,
+			NodePort: defaultStartPort,
+			Protocol: protocolTCP,
+		},
+	}
+	nplAnnotationBytes, err := json.Marshal(nplAnnotation)
+	require.NoError(t, err)
+	testPod.Annotations = map[string]string{
+		types.NPLAnnotationKey: string(nplAnnotationBytes),
+	}
+	testConfig := newTestConfig().withCustomPodPortRulesExpectations(func(mockIPTables *rulestesting.MockPodPortRules) {
+		// No initial rule should be synced.
+		mockIPTables.EXPECT().AddAllRules(gomock.Len(0)).Return(nil)
+		mockIPTables.EXPECT().AddRule(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+	})
+	testData := setUp(t, testConfig, testSvc, testPod)
+	defer testData.tearDown()
+
+	_, err = testData.pollForPodAnnotation(testPod.Name, false)
+	require.NoError(t, err, "Poll for annotation check failed: annotation should have been removed")
+	assert.False(t, testData.portTable.RuleExists(defaultPodKey, defaultPort, protocolTCP))
+
+	testPod.Status.PodIP = defaultPodIP
+	testData.updatePodOrFail(testPod)
+
+	value, err := testData.pollForPodAnnotation(testPod.Name, true)
+	require.NoError(t, err, "Poll for annotation check failed")
+	expectedAnnotations := newExpectedNPLAnnotations().Add(nil, defaultPort, protocolTCP)
+	expectedAnnotations.Check(t, value)
+	assert.True(t, testData.portTable.RuleExists(defaultPodKey, defaultPort, protocolTCP))
+}
+
+// TestInitIncompleteRuleInAnnotation simulates the case where the agent reboots and one Pod has an
+// existing NPL annotation with an incomplete rule (e.g., missing podPort). The annotation should
+// eventually be replaced by a valid one.
+func TestInitIncompleteRuleInAnnotation(t *testing.T) {
+	testSvc := getTestSvc()
+	testPod := getTestPod()
+	nplAnnotation := []types.NPLAnnotation{
+		{
+			// Omit intentionally.
+			// PodPort:  defaultPort,
+			NodeIP:   defaultHostIP,
+			NodePort: defaultStartPort,
+			Protocol: protocolTCP,
+		},
+	}
+	nplAnnotationBytes, err := json.Marshal(nplAnnotation)
+	require.NoError(t, err)
+	testPod.Annotations = map[string]string{
+		types.NPLAnnotationKey: string(nplAnnotationBytes),
+	}
+	testConfig := newTestConfig().withCustomPodPortRulesExpectations(func(mockIPTables *rulestesting.MockPodPortRules) {
+		// No initial rule should be synced.
+		mockIPTables.EXPECT().AddAllRules(gomock.Len(0)).Return(nil)
+		mockIPTables.EXPECT().AddRule(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+	})
+	testData := setUp(t, testConfig, testSvc, testPod)
 	defer testData.tearDown()
 
 	value, err := testData.pollForPodAnnotation(testPod.Name, true)
@@ -984,4 +1114,55 @@ func TestPreventDefunctRuleReuse(t *testing.T) {
 	testData.updateServiceOrFail(testSvc)
 
 	assert.Eventually(t, testData.ctrl.Satisfied, 2*time.Second, 50*time.Millisecond)
+}
+
+// TestPodIPReset tests the case where a Pod "loses" its IP address. This can theoretically happen
+// when there is an issue with the Pod Sandbox. For example, after a Node restart, a Pod's status
+// may change to Unknown and its IP may be reset. After a while, the Sandbox is recreated, and the
+// Pod goes back to Running with a new IP.
+func TestPodIPReset(t *testing.T) {
+	testSvc := getTestSvc()
+	testPod := getTestPod()
+	testData := setUp(t, newTestConfig(), testSvc, testPod)
+	defer testData.tearDown()
+
+	_, err := testData.pollForPodAnnotation(testPod.Name, true)
+	require.NoError(t, err, "Poll for annotation check failed")
+	nplData := testData.portTable.GetEntry(defaultPodKey, defaultPort, protocolTCP)
+	require.NotNil(t, nplData)
+	require.Equal(t, defaultPodIP, nplData.PodIP)
+
+	testPod.Status.PodIP = ""
+	testData.updatePodOrFail(testPod)
+
+	_, err = testData.pollForPodAnnotation(testPod.Name, false)
+	require.NoError(t, err, "Poll for annotation check failed")
+	assert.False(t, testData.portTable.RuleExists(defaultPodKey, defaultPort, protocolTCP))
+}
+
+// TestPodIPChange tests the case where a Pod's IP address changes. This can happen when a Sandbox
+// is recreated (see TestPodIPReset above). This can also happen when a Pod is deleted and recreated
+// with the same name and a different IP: because the NPLController uses a workqueue, the DELETE and
+// CREATE events can theoretically be merged and processed as a single UPDATE event.
+func TestPodIPChange(t *testing.T) {
+	testSvc := getTestSvc()
+	testPod := getTestPod()
+	testData := setUp(t, newTestConfig(), testSvc, testPod)
+	defer testData.tearDown()
+
+	_, err := testData.pollForPodAnnotation(testPod.Name, true)
+	require.NoError(t, err, "Poll for annotation check failed")
+	nplData := testData.portTable.GetEntry(defaultPodKey, defaultPort, protocolTCP)
+	require.NotNil(t, nplData)
+	require.Equal(t, defaultPodIP, nplData.PodIP)
+
+	newPodIP := "192.168.32.11"
+	testPod.Status.PodIP = newPodIP
+	testData.updatePodOrFail(testPod)
+
+	assert.EventuallyWithT(t, func(t *assert.CollectT) {
+		nplData := testData.portTable.GetEntry(defaultPodKey, defaultPort, protocolTCP)
+		require.NotNil(t, nplData)
+		assert.Equal(t, newPodIP, nplData.PodIP)
+	}, 1*time.Second, 10*time.Millisecond)
 }

--- a/pkg/agent/nodeportlocal/portcache/port_table.go
+++ b/pkg/agent/nodeportlocal/portcache/port_table.go
@@ -245,6 +245,8 @@ func (lpo *localPortOpener) OpenLocalPort(port int, protocol string) (io.Closer,
 			return nil, err
 		}
 		socket = conn
+	default:
+		return nil, fmt.Errorf("unknown or missing protocol: %q", protocol)
 	}
 	klog.V(2).InfoS("Opened local port", "port", port)
 	return socket, nil


### PR DESCRIPTION
Cherry pick of #7512 on release-2.4.

#7512: Handle missing Pod IP and Pod IP changes

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.