### PR TITLE
Add labels to distinguish clean vs conflicted cherry-picks

### DIFF
--- a/docs/contributors/github-labels.md
+++ b/docs/contributors/github-labels.md
@@ -84,6 +84,8 @@ The labels in this list originated within Kubernetes at
 | kind/api-change                    | Categorizes issue or PR as related to adding, removing, or otherwise changing an API. | Any |
 | kind/bug                           | Categorizes issue or PR as related to a bug.              | Any                |
 | kind/cherry-pick                   | Categorizes issue or PR as related to the cherry-pick of a bug fix from the main branch to a release branch | Any |
+| kind/cherry-pick-clean             | Categorizes a cherry-pick PR where patches applied cleanly without conflicts | Any |
+| kind/cherry-pick-conflicts         | Categorizes a cherry-pick PR where patches required manual conflict resolution | Any |
 | kind/cleanup                       | Categorizes issue or PR as related to cleaning up code, process, or technical debt | Any |
 | kind/deprecation                   | Categorizes issue or PR as related to feature marked for deprecation | Any |
 | kind/design                        | Categorizes issue or PR as related to design | Any |


### PR DESCRIPTION
Update the cherry-pick script to automatically apply one of two new labels to backport PRs: kind/cherry-pick-clean when patches apply cleanly, or kind/cherry-pick-conflicts when manual conflict resolution was required. This helps reviewers quickly identify PRs that may need extra scrutiny due to manual conflict resolution.

The script now tracks whether conflicts occurred during the git am process and applies the appropriate label alongside the existing kind/cherry-pick label when creating the pull request.

Also update the GitHub labels documentation to include descriptions of the two new labels.