### PR TITLE
Support customizing CNI configuration directory via helm chart

### DIFF
--- a/build/charts/antrea/README.md
+++ b/build/charts/antrea/README.md
@@ -75,6 +75,7 @@ Kubernetes: `>= 1.23.0-0`
 | clientCAFile | string | `""` | File path of the certificate bundle for all the signers that is recognized for incoming client certificates. |
 | cni.configFileMode | string | `"644"` | The file permission for 10-antrea.conflist when it is installed in the CNI configuration directory on the host. |
 | cni.hostBinPath | string | `"/opt/cni/bin"` | Installation path of CNI binaries on the host. |
+| cni.hostConfPath | string | `"/etc/cni/net.d"` | Path of CNI configuration on the host. |
 | cni.plugins | object | `{"bandwidth":true,"portmap":true}` | Chained plugins to use alongside antrea-cni. |
 | cni.skipBinaries | list | `[]` | CNI binaries shipped with Antrea for which installation should be skipped. |
 | controller.affinity | object | `{}` | Affinity for the antrea-controller Pod. |

--- a/build/charts/antrea/templates/agent/daemonset.yaml
+++ b/build/charts/antrea/templates/agent/daemonset.yaml
@@ -387,7 +387,7 @@ spec:
             name: antrea-config
         - name: host-cni-conf
           hostPath:
-            path: /etc/cni/net.d
+            path: {{ .Values.cni.hostConfPath }}
         - name: host-cni-bin
           hostPath:
             path: {{ .Values.cni.hostBinPath }}

--- a/build/charts/antrea/values.yaml
+++ b/build/charts/antrea/values.yaml
@@ -460,6 +460,8 @@ cni:
     bandwidth: true
   # -- Installation path of CNI binaries on the host.
   hostBinPath: "/opt/cni/bin"
+  # -- Path of CNI configuration on the host.
+  hostConfPath: "/etc/cni/net.d"
   # -- CNI binaries shipped with Antrea for which installation should be
   # skipped.
   skipBinaries: []

--- a/pkg/antctl/raw/check/cluster/command.go
+++ b/pkg/antctl/raw/check/cluster/command.go
@@ -41,6 +41,7 @@ func Command() *cobra.Command {
 		},
 	}
 	command.Flags().StringVar(&o.testImage, "test-image", o.testImage, "Container image override for the cluster checker")
+	command.Flags().StringVar(&o.cniConfDir, "cni-conf-dir", o.cniConfDir, "Host CNI configuration path override")
 	return command
 }
 
@@ -53,11 +54,14 @@ const (
 type options struct {
 	// Container image for the cluster checker.
 	testImage string
+	// CNI conf path on hosts (defaults to /etc/cni/net.d)
+	cniConfDir string
 }
 
 func newOptions() *options {
 	return &options{
-		testImage: check.DefaultTestImage,
+		testImage:  check.DefaultTestImage,
+		cniConfDir: check.DefaultCNIDir,
 	}
 }
 
@@ -92,6 +96,8 @@ type testContext struct {
 	testPod     *corev1.Pod
 	// Container image for the cluster checker.
 	testImage string
+	// CNI configuration directory on the host, mounted inside the container at /etc/cni/net.d.
+	cniConfDir string
 }
 
 func Run(o *options) error {
@@ -100,7 +106,7 @@ func Run(o *options) error {
 		return fmt.Errorf("unable to create Kubernetes client: %s", err)
 	}
 	ctx := context.Background()
-	testContext := NewTestContext(client, config, clusterName, o.testImage)
+	testContext := NewTestContext(client, config, clusterName, o.testImage, o.cniConfDir)
 	defer check.Teardown(ctx, testContext.Logger, testContext.client, testContext.namespace)
 	if err := testContext.setup(ctx); err != nil {
 		return err
@@ -168,7 +174,7 @@ func (t *testContext) setup(ctx context.Context) error {
 				Name: "cni-conf",
 				VolumeSource: corev1.VolumeSource{
 					HostPath: &corev1.HostPathVolumeSource{
-						Path: "/etc/cni/net.d",
+						Path: t.cniConfDir,
 					},
 				},
 			},
@@ -211,7 +217,7 @@ func (t *testContext) setup(ctx context.Context) error {
 	return nil
 }
 
-func NewTestContext(client kubernetes.Interface, config *rest.Config, clusterName, testImage string) *testContext {
+func NewTestContext(client kubernetes.Interface, config *rest.Config, clusterName, testImage, cniConfDir string) *testContext {
 	return &testContext{
 		Logger:      check.NewLogger(fmt.Sprintf("[%s] ", clusterName)),
 		client:      client,
@@ -219,6 +225,7 @@ func NewTestContext(client kubernetes.Interface, config *rest.Config, clusterNam
 		clusterName: clusterName,
 		namespace:   check.GenerateRandomNamespace(testNamespacePrefix),
 		testImage:   testImage,
+		cniConfDir:  cniConfDir,
 	}
 }
 

--- a/pkg/antctl/raw/check/constants.go
+++ b/pkg/antctl/raw/check/constants.go
@@ -16,4 +16,5 @@ package check
 
 const (
 	DefaultTestImage = "antrea/toolbox:1.7-0"
+	DefaultCNIDir    = "/etc/cni/net.d"
 )


### PR DESCRIPTION
Hi! This PR allows to customize CNI host configuration path (which is commonly pointed at `/etc/cni/net.d`) during helm chart installation with semantics similar to `cni.hostBinPath `. This change is backward-compatible