### PR TITLE
Improve stale IP recycling in AntreaIPAM controller

### DIFF
--- a/test/performance/benchmark.yml
+++ b/test/performance/benchmark.yml
@@ -75,3 +75,6 @@ benchmarks:
     package: "./pkg/apis/controlplane"
   - name: "BenchmarkSymmetricDifferenceString"
     package: "./pkg/util/sets"
+  - name: "BenchmarkCleanUpStaleIPAddresses"
+    package: "./pkg/controller/ipam"
+    threshold: 0.3


### PR DESCRIPTION
When a Node is deleted, the CNI DEL command may not be invoked for Pods
running on that Node. As a result, antrea-agent cannot release their IPs,
leaving stale entries in the IPPool. To mitigate this, increase the IP
recycle interval from 10 minutes to 1 minute.

Additionally, add a benchmark test for the IP recycle function and refine
its implementation based on benchmark results to reduce memory allocations
and improve cleanup performance.