### PR TITLE
feat: add ipset to supportbundles

### DIFF
--- a/pkg/agent/util/ipset/ipset.go
+++ b/pkg/agent/util/ipset/ipset.go
@@ -45,6 +45,8 @@ type Interface interface {
 	DelEntry(name string, entry string) error
 
 	ListEntries(name string) ([]string, error)
+
+	Save() ([]byte, error)
 }
 
 type Client struct {
@@ -120,4 +122,13 @@ func (c *Client) ListEntries(name string) ([]string, error) {
 		}
 	}
 	return entries, nil
+}
+
+func (c *Client) Save() ([]byte, error) {
+	cmd := c.exec.Command("ipset", "save")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("error saving ipset: %w, output: %s", err, string(output))
+	}
+	return output, nil
 }

--- a/pkg/agent/util/ipset/testing/mock_ipset.go
+++ b/pkg/agent/util/ipset/testing/mock_ipset.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Antrea Authors
+// Copyright 2026 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -124,4 +124,19 @@ func (m *MockInterface) ListEntries(name string) ([]string, error) {
 func (mr *MockInterfaceMockRecorder) ListEntries(name any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEntries", reflect.TypeOf((*MockInterface)(nil).ListEntries), name)
+}
+
+// Save mocks base method.
+func (m *MockInterface) Save() ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Save")
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Save indicates an expected call of Save.
+func (mr *MockInterfaceMockRecorder) Save() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Save", reflect.TypeOf((*MockInterface)(nil).Save))
 }

--- a/pkg/support/dump.go
+++ b/pkg/support/dump.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/utils/exec"
 
 	agentquerier "antrea.io/antrea/pkg/agent/querier"
+	"antrea.io/antrea/pkg/agent/util/ipset"
 	clusterinformationv1beta1 "antrea.io/antrea/pkg/apis/crd/v1beta1"
 	"antrea.io/antrea/pkg/ovs/ovsctl"
 	"antrea.io/antrea/pkg/querier"
@@ -298,6 +299,7 @@ type agentDumper struct {
 	fs           afero.Fs
 	executor     exec.Interface
 	ovsCtlClient ovsctl.OVSCtlClient
+	ipsetClient  ipset.Interface
 	aq           agentquerier.AgentQuerier
 	npq          querier.AgentNetworkPolicyInfoQuerier
 	since        string
@@ -365,6 +367,7 @@ func NewAgentDumper(fs afero.Fs, executor exec.Interface, ovsCtlClient ovsctl.OV
 		fs:           fs,
 		executor:     executor,
 		ovsCtlClient: ovsCtlClient,
+		ipsetClient:  ipset.NewClient(),
 		aq:           aq,
 		npq:          npq,
 		since:        since,

--- a/pkg/support/dump_others.go
+++ b/pkg/support/dump_others.go
@@ -64,6 +64,9 @@ func (d *agentDumper) DumpHostNetworkInfo(basedir string) error {
 	if err := d.dumpIPTables(basedir); err != nil {
 		return err
 	}
+	if err := d.dumpIPSet(basedir); err != nil {
+		return err
+	}
 	if err := d.dumpNFTables(basedir); err != nil {
 		return err
 	}
@@ -83,6 +86,14 @@ func (d *agentDumper) dumpIPTables(basedir string) error {
 		return err
 	}
 	return writeFile(d.fs, filepath.Join(basedir, "iptables"), "iptables", data)
+}
+
+func (d *agentDumper) dumpIPSet(basedir string) error {
+	data, err := d.ipsetClient.Save()
+	if err != nil {
+		return err
+	}
+	return writeFile(d.fs, filepath.Join(basedir, "ipset"), "ipset", data)
 }
 
 func (d *agentDumper) dumpNFTables(basedir string) error {


### PR DESCRIPTION
Summary :
Added ipsets information to supportbundle

Component: 
- `pkg/support/dump_others.go`
- `pkg/agent/util/ipset/ipset.go`

Closes #7517 