### PR TITLE
Run all LoadBalancer / NodePort tests when proxyAll is enabled

### DIFF
--- a/build/charts/antrea/README.md
+++ b/build/charts/antrea/README.md
@@ -56,7 +56,7 @@ Kubernetes: `>= 1.19.0-0`
 | agent.updateStrategy | object | `{"type":"RollingUpdate"}` | Update strategy for the antrea-agent DaemonSet. |
 | agentImage | object | `{"pullPolicy":"IfNotPresent","repository":"antrea/antrea-agent-ubuntu","tag":""}` | Container image to use for the antrea-agent component. |
 | antreaProxy.defaultLoadBalancerMode | string | `"nat"` | Determines how external traffic is processed when it's load balanced across Nodes by default. It must be one of "nat" or "dsr". |
-| antreaProxy.disableServiceHealthCheckServer | bool | `false` | Disables the health check server run by Antrea Proxy, which provides health information about Services of type LoadBalancer with externalTrafficPolicy set to Local, when proxyAll is enabled. This avoids race conditions between kube-proxy and Antrea proxy, with both trying to bind to the same addresses, when proxyAll is enabled while kube-proxy has not been removed. |
+| antreaProxy.disableServiceHealthCheckServer | bool | `false` | Disables the health check server run by Antrea Proxy, which provides health information about Services of type LoadBalancer with externalTrafficPolicy set to Local, when proxyAll is enabled. This avoids race conditions between kube-proxy and Antrea Proxy, with both trying to bind to the same address, when proxyAll is enabled while kube-proxy has not been removed. |
 | antreaProxy.enable | bool | `true` | To disable AntreaProxy, set this to false. |
 | antreaProxy.nodePortAddresses | list | `[]` | String array of values which specifies the host IPv4/IPv6 addresses for NodePort. By default, all host addresses are used. |
 | antreaProxy.proxyAll | bool | `false` | Proxy all Service traffic, for all Service types, regardless of where it comes from. |

--- a/build/charts/antrea/conf/antrea-agent.conf
+++ b/build/charts/antrea/conf/antrea-agent.conf
@@ -422,8 +422,8 @@ antreaProxy:
   defaultLoadBalancerMode: {{ .defaultLoadBalancerMode | quote }}
   # Disables the health check server run by Antrea Proxy, which provides health information about
   # Services of type LoadBalancer with externalTrafficPolicy set to Local, when proxyAll is
-  # enabled. This avoids race conditions between kube-proxy and Antrea proxy, with both trying to
-  # bind to the same addresses, when proxyAll is enabled while kube-proxy has not been removed.
+  # enabled. This avoids race conditions between kube-proxy and Antrea Proxy, with both trying to
+  # bind to the same address, when proxyAll is enabled while kube-proxy has not been removed.
   disableServiceHealthCheckServer: {{ .disableServiceHealthCheckServer }}
 {{- end }}
 

--- a/build/charts/antrea/values.yaml
+++ b/build/charts/antrea/values.yaml
@@ -162,7 +162,7 @@ antreaProxy:
   # -- Disables the health check server run by Antrea Proxy, which provides health
   # information about Services of type LoadBalancer with externalTrafficPolicy set to
   # Local, when proxyAll is enabled. This avoids race conditions between kube-proxy
-  # and Antrea proxy, with both trying to bind to the same addresses, when proxyAll
+  # and Antrea Proxy, with both trying to bind to the same address, when proxyAll
   # is enabled while kube-proxy has not been removed.
   disableServiceHealthCheckServer: false
 

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -4541,8 +4541,8 @@ data:
       defaultLoadBalancerMode: "nat"
       # Disables the health check server run by Antrea Proxy, which provides health information about
       # Services of type LoadBalancer with externalTrafficPolicy set to Local, when proxyAll is
-      # enabled. This avoids race conditions between kube-proxy and Antrea proxy, with both trying to
-      # bind to the same addresses, when proxyAll is enabled while kube-proxy has not been removed.
+      # enabled. This avoids race conditions between kube-proxy and Antrea Proxy, with both trying to
+      # bind to the same address, when proxyAll is enabled while kube-proxy has not been removed.
       disableServiceHealthCheckServer: false
 
     # IPsec tunnel related configurations.
@@ -5643,7 +5643,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 57f02660c27175cf8cec0d665db7e91883d3d241ade3ed77d710ee98f5e3fe40
+        checksum/config: 23e14d3441d1d935b8499d78c5273dd1126c41c5b62b2b9403b739faa199d653
       labels:
         app: antrea
         component: antrea-agent
@@ -5891,7 +5891,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 57f02660c27175cf8cec0d665db7e91883d3d241ade3ed77d710ee98f5e3fe40
+        checksum/config: 23e14d3441d1d935b8499d78c5273dd1126c41c5b62b2b9403b739faa199d653
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -4537,8 +4537,8 @@ data:
       defaultLoadBalancerMode: "nat"
       # Disables the health check server run by Antrea Proxy, which provides health information about
       # Services of type LoadBalancer with externalTrafficPolicy set to Local, when proxyAll is
-      # enabled. This avoids race conditions between kube-proxy and Antrea proxy, with both trying to
-      # bind to the same addresses, when proxyAll is enabled while kube-proxy has not been removed.
+      # enabled. This avoids race conditions between kube-proxy and Antrea Proxy, with both trying to
+      # bind to the same address, when proxyAll is enabled while kube-proxy has not been removed.
       disableServiceHealthCheckServer: false
 
     # IPsec tunnel related configurations.
@@ -5639,7 +5639,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 57f02660c27175cf8cec0d665db7e91883d3d241ade3ed77d710ee98f5e3fe40
+        checksum/config: 23e14d3441d1d935b8499d78c5273dd1126c41c5b62b2b9403b739faa199d653
       labels:
         app: antrea
         component: antrea-agent
@@ -5888,7 +5888,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 57f02660c27175cf8cec0d665db7e91883d3d241ade3ed77d710ee98f5e3fe40
+        checksum/config: 23e14d3441d1d935b8499d78c5273dd1126c41c5b62b2b9403b739faa199d653
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -4537,8 +4537,8 @@ data:
       defaultLoadBalancerMode: "nat"
       # Disables the health check server run by Antrea Proxy, which provides health information about
       # Services of type LoadBalancer with externalTrafficPolicy set to Local, when proxyAll is
-      # enabled. This avoids race conditions between kube-proxy and Antrea proxy, with both trying to
-      # bind to the same addresses, when proxyAll is enabled while kube-proxy has not been removed.
+      # enabled. This avoids race conditions between kube-proxy and Antrea Proxy, with both trying to
+      # bind to the same address, when proxyAll is enabled while kube-proxy has not been removed.
       disableServiceHealthCheckServer: false
 
     # IPsec tunnel related configurations.
@@ -5630,7 +5630,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: da05c6a135078734144b39bec8201adac80e58264879d2787f22c4c850d0400a
+        checksum/config: 0590de6bed2f6fa138f38ca2e8eb6d6a5bbd50eddedd4ad46df3c320045a8edb
       labels:
         app: antrea
         component: antrea-agent
@@ -5876,7 +5876,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: da05c6a135078734144b39bec8201adac80e58264879d2787f22c4c850d0400a
+        checksum/config: 0590de6bed2f6fa138f38ca2e8eb6d6a5bbd50eddedd4ad46df3c320045a8edb
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -4550,8 +4550,8 @@ data:
       defaultLoadBalancerMode: "nat"
       # Disables the health check server run by Antrea Proxy, which provides health information about
       # Services of type LoadBalancer with externalTrafficPolicy set to Local, when proxyAll is
-      # enabled. This avoids race conditions between kube-proxy and Antrea proxy, with both trying to
-      # bind to the same addresses, when proxyAll is enabled while kube-proxy has not been removed.
+      # enabled. This avoids race conditions between kube-proxy and Antrea Proxy, with both trying to
+      # bind to the same address, when proxyAll is enabled while kube-proxy has not been removed.
       disableServiceHealthCheckServer: false
 
     # IPsec tunnel related configurations.
@@ -5643,7 +5643,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: a7959b53cad321c489dc702dfd46ca38cc648c22c35224cded1d3f5791d12313
+        checksum/config: c8ef76cb4f2a74472668e957d4d7c9abf550bd1b9a4b9ba6a4358025eed3330f
         checksum/ipsec-secret: d0eb9c52d0cd4311b6d252a951126bf9bea27ec05590bed8a394f0f792dcb2a4
       labels:
         app: antrea
@@ -5935,7 +5935,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: a7959b53cad321c489dc702dfd46ca38cc648c22c35224cded1d3f5791d12313
+        checksum/config: c8ef76cb4f2a74472668e957d4d7c9abf550bd1b9a4b9ba6a4358025eed3330f
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -4537,8 +4537,8 @@ data:
       defaultLoadBalancerMode: "nat"
       # Disables the health check server run by Antrea Proxy, which provides health information about
       # Services of type LoadBalancer with externalTrafficPolicy set to Local, when proxyAll is
-      # enabled. This avoids race conditions between kube-proxy and Antrea proxy, with both trying to
-      # bind to the same addresses, when proxyAll is enabled while kube-proxy has not been removed.
+      # enabled. This avoids race conditions between kube-proxy and Antrea Proxy, with both trying to
+      # bind to the same address, when proxyAll is enabled while kube-proxy has not been removed.
       disableServiceHealthCheckServer: false
 
     # IPsec tunnel related configurations.
@@ -5630,7 +5630,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: bb8fac5c1560989b411d798cbe1d008b486533e21a967351ad77a1fd7749b85b
+        checksum/config: ca42ed56b141c2179f6e01f274400b4149cf98942571f7c3a3989597ad7520d4
       labels:
         app: antrea
         component: antrea-agent
@@ -5876,7 +5876,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: bb8fac5c1560989b411d798cbe1d008b486533e21a967351ad77a1fd7749b85b
+        checksum/config: ca42ed56b141c2179f6e01f274400b4149cf98942571f7c3a3989597ad7520d4
       labels:
         app: antrea
         component: antrea-controller

--- a/ci/kind/test-e2e-kind.sh
+++ b/ci/kind/test-e2e-kind.sh
@@ -253,6 +253,13 @@ if [ -n "$feature_gates" ]; then
 fi
 if $proxy_all; then
     manifest_args="$manifest_args --proxy-all"
+    # Disables the health check server run by Antrea Proxy, which provides health information about
+    # Services of type LoadBalancer with externalTrafficPolicy set to Local, when proxyAll is
+    # enabled. This avoids race conditions between kube-proxy and Antrea Proxy, with both trying to
+    # bind to the same address, when proxyAll is enabled while kube-proxy has not been removed.
+    if ! $no_kube_proxy; then
+      manifest_args="$manifest_args --extra-helm-values antreaProxy.disableServiceHealthCheckServer=true"
+    fi
 fi
 if [ -n "$load_balancer_mode" ]; then
     manifest_args="$manifest_args --extra-helm-values antreaProxy.defaultLoadBalancerMode=$load_balancer_mode"


### PR DESCRIPTION
This patch enables to run all LoadBalancer / NodePort e2e tests when proxyAll
is enabled even kube-proxy presents. Current AntreaProxy proxyAll implementation
can handle LoadBalancer / NodePort traffic from external without removing
kube-proxy. As result, this patch removes the limitation in related e2e tests.