### PR TITLE
Fix conformance failures for netpol v2

### DIFF
--- a/ci/kind/test-netpol-v2-conformance-kind.sh
+++ b/ci/kind/test-netpol-v2-conformance-kind.sh
@@ -141,8 +141,8 @@ function run_test {
   export KUBE_CONTAINER_RUNTIME_ENDPOINT=unix:///run/containerd/containerd.sock
   export KUBE_CONTAINER_RUNTIME_NAME=containerd
 
-  # TODO: use https://github.com/kubernetes-sigs/network-policy-api when conformance test config timeout and go dependency is fixed
-  git clone https://github.com/Dyanngg/network-policy-api.git
+  # Clone the network-policy-api repo at the specified tag version
+  git clone --branch "$api_version" --depth 1 https://github.com/kubernetes-sigs/network-policy-api.git
   pushd network-policy-api/conformance
   go mod download
   go test -v --debug=true -timeout=15m


### PR DESCRIPTION
Due to broken dependencies in upstream, the netpol v2 conformance tests were always executed against code from a fork. Recently the main branch of the fork was synced with the upstream main, causing conformance tests to break, as the upstream main branch is now only testing conformance for a new, un-released ClusterNetworkPolicy API type.

Fixing the failure by running the conformance test against the API from the correct release tag. When support for ClusterNetworkPolicy in Antrea isimplemented, the script will be updated to only test conformance for the new resource instead.