### PR TITLE
Increase the minimum supported Kubernetes version to 1.23

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Network Policies in a very efficient manner.
 
 ## Prerequisites
 
-Antrea has been tested with Kubernetes clusters running version 1.19 or later.
+Antrea has been tested with Kubernetes clusters running version 1.23 or later.
 
 * `NodeIPAMController` must be enabled in the Kubernetes cluster.\
   When deploying a cluster with kubeadm the `--pod-network-cidr <cidr>`

--- a/build/charts/antrea/Chart.yaml
+++ b/build/charts/antrea/Chart.yaml
@@ -5,7 +5,7 @@ displayName: Antrea
 home: https://antrea.io/
 version: 0.0.0
 appVersion: latest
-kubeVersion: ">= 1.19.0-0"
+kubeVersion: ">= 1.23.0-0"
 icon: https://raw.githubusercontent.com/antrea-io/antrea/main/docs/assets/logo/antrea_logo.svg
 description: Kubernetes networking based on Open vSwitch
 keywords:

--- a/build/charts/antrea/README.md
+++ b/build/charts/antrea/README.md
@@ -12,7 +12,7 @@ Kubernetes networking based on Open vSwitch
 
 ## Requirements
 
-Kubernetes: `>= 1.19.0-0`
+Kubernetes: `>= 1.23.0-0`
 
 ## Values
 

--- a/build/charts/flow-aggregator/Chart.yaml
+++ b/build/charts/flow-aggregator/Chart.yaml
@@ -5,7 +5,7 @@ displayName: Antrea Flow Aggregator
 home: https://antrea.io/
 version: 0.0.0
 appVersion: latest
-kubeVersion: ">= 1.19.0-0"
+kubeVersion: ">= 1.23.0-0"
 icon: https://raw.githubusercontent.com/antrea-io/antrea/main/docs/assets/logo/antrea_logo.svg
 description: Antrea Flow Aggregator
 keywords:

--- a/build/charts/flow-aggregator/README.md
+++ b/build/charts/flow-aggregator/README.md
@@ -12,7 +12,7 @@ Antrea Flow Aggregator
 
 ## Requirements
 
-Kubernetes: `>= 1.19.0-0`
+Kubernetes: `>= 1.23.0-0`
 
 ## Values
 

--- a/ci/jenkins/test.sh
+++ b/ci/jenkins/test.sh
@@ -942,9 +942,6 @@ function redeploy_k8s_if_ip_mode_changes() {
         POD_SUBNET_STRING="${POD_SUBNET_IPV4},${POD_SUBNET_IPV6}"
         SERVICE_SUBNET_STRING="${SERVICE_SUBNET_IPV4},${SERVICE_SUBNET_IPV6}"
         ADVERTISE_ADDRESS_STRING=${CONTROL_PLANE_IPV4}
-        if [[ ${K8S_VERSION} =~ 1.19. ]] || [[ ${K8S_VERSION} =~ 1.20. ]]; then
-          FEATURE_GATES_STRING=`echo -e "featureGates:\n  IPv6DualStack: true"`
-        fi
         APISERVER_IP_STRING=${ADVERTISE_ADDRESS_STRING}
     fi
     cat <<EOF | tee ${WORKDIR}/kubeadm.conf

--- a/docs/antrea-proxy.md
+++ b/docs/antrea-proxy.md
@@ -102,9 +102,7 @@ To remove kube-proxy from an existing cluster, you can use the following steps:
 # Delete the kube-proxy DaemonSet
 kubectl -n kube-system delete ds/kube-proxy
 # Delete the kube-proxy ConfigMap to prevent kube-proxy from being re-deployed
-# by kubeadm during "upgrade apply". This workaround will not take effect for
-# kubeadm versions older than v1.19 as the following patch is required:
-# https://github.com/kubernetes/kubernetes/pull/89593
+# by kubeadm during "upgrade apply".
 kubectl -n kube-system delete cm/kube-proxy
 # Delete existing kube-proxy rules; there are several options for doing that
 # Option 1 (if using kube-proxy in iptables mode), run the following on each Node:

--- a/multicluster/controllers/multicluster/member/labelidentity_controller.go
+++ b/multicluster/controllers/multicluster/member/labelidentity_controller.go
@@ -356,12 +356,6 @@ func (r *LabelIdentityReconciler) getLabelIdentityResourceExport(name, normalize
 }
 
 func GetNormalizedLabel(nsLabels, podLabels map[string]string, ns string) string {
-	if _, ok := nsLabels[v1.LabelMetadataName]; !ok {
-		// NamespaceDefaultLabelName is supported from K8s v1.21. For K8s versions before v1.21,
-		// we append the Namespace name label to the Namespace label set, so that the exported
-		// label is guaranteed to have Namespace name information.
-		nsLabels[v1.LabelMetadataName] = ns
-	}
 	return "ns:" + labels.Set(nsLabels).String() + "&pod:" + labels.Set(podLabels).String()
 }
 

--- a/multicluster/controllers/multicluster/member/labelidentity_controller_test.go
+++ b/multicluster/controllers/multicluster/member/labelidentity_controller_test.go
@@ -267,17 +267,10 @@ func TestGetNormalizedLabel(t *testing.T) {
 			"ns:kubernetes.io/metadata.name=test-ns&pod:purpose=test",
 		},
 		{
-			"no Namespace default name label",
-			"test-ns",
-			map[string]string{"purpose": "test"},
-			map[string]string{"region": "west"},
-			"ns:kubernetes.io/metadata.name=test-ns,region=west&pod:purpose=test",
-		},
-		{
 			"no Pod label",
 			"test-ns",
 			map[string]string{},
-			map[string]string{"region": "west"},
+			map[string]string{v1.LabelMetadataName: "test-ns", "region": "west"},
 			"ns:kubernetes.io/metadata.name=test-ns,region=west&pod:",
 		},
 	}

--- a/multicluster/controllers/multicluster/member/stale_controller.go
+++ b/multicluster/controllers/multicluster/member/stale_controller.go
@@ -318,11 +318,6 @@ func (c *StaleResCleanupController) cleanUpLabelIdentityResourceExports(ctx cont
 	}
 	nsLabelMap := map[string]string{}
 	for _, ns := range nsList.Items {
-		if _, ok := ns.Labels[corev1.LabelMetadataName]; !ok {
-			// NamespaceDefaultLabelName is supported from K8s v1.21. For K8s versions before v1.21,
-			// we append the Namespace name label to the Namespace label set.
-			ns.Labels[corev1.LabelMetadataName] = ns.Name
-		}
 		nsLabelMap[ns.Name] = "ns:" + labels.FormatLabels(ns.Labels)
 	}
 	for _, p := range podList.Items {

--- a/multicluster/controllers/multicluster/member/stale_controller_test.go
+++ b/multicluster/controllers/multicluster/member/stale_controller_test.go
@@ -303,7 +303,8 @@ func TestStaleController_CleanUpResourceExports(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-ns",
 					Labels: map[string]string{
-						"purpose": "test",
+						"kubernetes.io/metadata.name": "test-ns",
+						"purpose":                     "test",
 					},
 				},
 			},
@@ -448,7 +449,7 @@ func TestStaleController_CleanUpResourceExports(t *testing.T) {
 			resExpLen := len(resExpList.Items)
 			if err == nil {
 				if resExpLen != 4 {
-					t.Errorf("Should only FOUR valid ResourceExports left but got %v", resExpLen)
+					t.Errorf("Should only have FOUR valid ResourceExports left but got %v", resExpLen)
 				}
 			} else {
 				t.Errorf("Should list ResourceExport successfully but got err = %v", err)

--- a/pkg/agent/multicluster/stretched_networkpolicy_controller_test.go
+++ b/pkg/agent/multicluster/stretched_networkpolicy_controller_test.go
@@ -121,7 +121,8 @@ func TestEnqueueAllPods(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "ns",
 			Labels: map[string]string{
-				"env": "test",
+				"kubernetes.io/metadata.name": "ns",
+				"env":                         "test",
 			},
 		},
 	}
@@ -188,7 +189,8 @@ func TestStretchedNetworkPolicyControllerPodEvent(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "ns",
 			Labels: map[string]string{
-				"env": "test",
+				"kubernetes.io/metadata.name": "ns",
+				"env":                         "test",
 			},
 		},
 	}
@@ -304,7 +306,8 @@ func TestStretchedNetworkPolicyControllerNSEvent(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "ns",
 			Labels: map[string]string{
-				"env": "test",
+				"kubernetes.io/metadata.name": "ns",
+				"env":                         "test",
 			},
 		},
 	}
@@ -456,7 +459,8 @@ func TestStretchedNetworkPolicyControllerLabelIdentityEvent(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "ns",
 			Labels: map[string]string{
-				"env": "test",
+				"kubernetes.io/metadata.name": "ns",
+				"env":                         "test",
 			},
 		},
 	}

--- a/pkg/antctl/raw/check/cluster/test_checkk8sversion.go
+++ b/pkg/antctl/raw/check/cluster/test_checkk8sversion.go
@@ -38,11 +38,11 @@ func (t *checkK8sVersion) Run(ctx context.Context, testContext *testContext) err
 	if err != nil {
 		return fmt.Errorf("error parsing server version: %w", err)
 	}
-	minVersion, _ := semver.Parse("1.19")
+	minVersion := semver.MustParse("1.23")
 	if currentVersion.GTE(minVersion) {
 		testContext.Log("Kubernetes server version is compatible with Antrea. Kubernetes version: %s", serverVersion.GitVersion)
 	} else {
-		return fmt.Errorf("Kubernetes min version required: 1.19")
+		return fmt.Errorf("Kubernetes min version required: %s", minVersion.String())
 	}
 	return nil
 }

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -36,7 +36,6 @@ import (
 	"github.com/containernetworking/plugins/pkg/ip"
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/mod/semver"
 	"gopkg.in/yaml.v2"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -484,19 +483,12 @@ func isIPv6Enabled() bool {
 }
 
 func labelNodeRoleControlPlane() string {
-	// TODO: return labelNodeRoleControlPlane unconditionally when the min K8s version
-	// requirement to run Antrea becomes K8s v1.20
-	const labelNodeRoleControlPlane = "node-role.kubernetes.io/control-plane"
-	const labelNodeRoleOldControlPlane = "node-role.kubernetes.io/master"
-	// If clusterInfo.k8sServerVersion < "v1.20.0"
-	if semver.Compare(clusterInfo.k8sServerVersion, "v1.20.0") < 0 {
-		return labelNodeRoleOldControlPlane
-	}
-	return labelNodeRoleControlPlane
+	return "node-role.kubernetes.io/control-plane"
 }
 
 func controlPlaneNoScheduleTolerations() []corev1.Toleration {
-	// the Node taint still uses "master" in K8s v1.20
+	// "node-role.kubernetes.io/control-plane" was added in K8s 1.20
+	// "node-role.kubernetes.io/master" was removed in K8s 1.24
 	return []corev1.Toleration{
 		{
 			Key:      "node-role.kubernetes.io/master",


### PR DESCRIPTION
K8s 1.23 is the release where the IPv6DualStack feature gate became GA and locked to true. By increasing the minimum supported version to 1.23, we can assume that some dual-stack fields (e.g., spec.ipFamilies` for Services) are always present and populated correctly.

K8s 1.23 is also the release were the EndpointSlice feature gate became GA and locked to true.

Additionally, because NamespaceDefaultLabelName was removed in K8s 1.23, we can furthermore remove some code / documentation that is no longer needed. However, we do not drop support for `antrea.io/metadata.name` (yet?) - we just stop mentioning it in the Antrea NetworkPolicy documentation.

Note that K8s 1.23 was released at the end of 2021.