### PR TITLE
Remove go 1.16 version check from scripts

### DIFF
--- a/hack/add-license.sh
+++ b/hack/add-license.sh
@@ -19,15 +19,6 @@ set -eo pipefail
 # if Go environment variable is set, use it as it is, otherwise default to "go"
 : "${GO:=go}"
 
-GO_VERSION="$(${GO} version | awk '{print $3}')"
-function version_lt() { test "$(printf '%s\n' "$@" | sort -rV | head -n 1)" != "$1"; }
-
-if version_lt "${GO_VERSION}" "go1.16"; then
-    # See https://golang.org/doc/go-get-install-deprecation
-    echo "Running this script requires Go >= 1.16, please upgrade"
-    exit 1
-fi
-
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 cd "${ROOT}"
 

--- a/hack/update-toc.sh
+++ b/hack/update-toc.sh
@@ -23,15 +23,6 @@ set -o pipefail
 
 TOOL_VERSION=$(head hack/mdtoc-version)
 
-GO_VERSION="$(${GO} version | awk '{print $3}')"
-function version_lt() { test "$(printf '%s\n' "$@" | sort -rV | head -n 1)" != "$1"; }
-
-if version_lt "${GO_VERSION}" "go1.16"; then
-    # See https://golang.org/doc/go-get-install-deprecation
-    echo "Running this script requires Go >= 1.16, please upgrade"
-    exit 1
-fi
-
 # cd to the root path
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 cd "${ROOT}"

--- a/hack/verify-spelling.sh
+++ b/hack/verify-spelling.sh
@@ -25,15 +25,6 @@ set -o pipefail
 : "${GO:=go}"
 TOOL_VERSION="v0.3.4"
 
-GO_VERSION="$(${GO} version | awk '{print $3}')"
-function version_lt() { test "$(printf '%s\n' "$@" | sort -rV | head -n 1)" != "$1"; }
-
-if version_lt "${GO_VERSION}" "go1.16"; then
-    # See https://golang.org/doc/go-get-install-deprecation
-    echo "Running this script requires Go >= 1.16, please upgrade"
-    exit 1
-fi
-
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 cd "${ROOT}"
 

--- a/hack/verify-toc.sh
+++ b/hack/verify-toc.sh
@@ -23,15 +23,6 @@ set -o pipefail
 
 TOOL_VERSION=$(head hack/mdtoc-version)
 
-GO_VERSION="$(${GO} version | awk '{print $3}')"
-function version_lt() { test "$(printf '%s\n' "$@" | sort -rV | head -n 1)" != "$1"; }
-
-if version_lt "${GO_VERSION}" "go1.16"; then
-    # See https://golang.org/doc/go-get-install-deprecation
-    echo "Running this script requires Go >= 1.16, please upgrade"
-    exit 1
-fi
-
 # cd to the root path
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 cd "${ROOT}"


### PR DESCRIPTION
Go 1.16 was released in 2021, now we use Go 1.25.0