### PR TITLE
Clean up saved image files when E2E job exits

### DIFF
--- a/ci/jenkins/test.sh
+++ b/ci/jenkins/test.sh
@@ -204,6 +204,7 @@ function clean_antrea {
     docker images --format "{{.Repository}}:{{.Tag}}" | grep ${BUILD_TAG} | xargs -r docker rmi || true
     docker images | grep '<none>' | awk '{print $3}' | xargs -r docker rmi || true
     check_and_cleanup_docker_build_cache
+    rm -f antrea-ubuntu.tar antrea-windows.tar.gz flow-aggregator.tar
 }
 
 function clean_for_windows_install_cni {

--- a/ci/jenkins/utils.sh
+++ b/ci/jenkins/utils.sh
@@ -32,6 +32,12 @@ function check_and_cleanup_docker_build_cache() {
 }
 
 function check_and_upgrade_golang() {
+    echo "====== Clean up Golang cache ======"
+    free_space=$(df -h -B 1G / | awk 'NR==2 {print $4}')
+    free_space_threshold=40
+    if [[ $free_space -lt $free_space_threshold ]]; then
+      go clean -cache -modcache -testcache || true
+    fi
     if [ -z "${GOLANG_RELEASE_DIR}" ]; then
         GOLANG_RELEASE_DIR="/var/lib/jenkins/golang-releases"
     fi

--- a/ci/kind/kind-setup.sh
+++ b/ci/kind/kind-setup.sh
@@ -601,9 +601,11 @@ EOF
 
 function delete {
   local cluster_name="$1"
+  set +e
   delete_vlan_subnets $cluster_name
   kind delete cluster --name $cluster_name
   delete_networks $cluster_name
+  set -e
 }
 
 function destroy {


### PR DESCRIPTION
1. Multiple E2E jobs can be scheduled on the same Jenkins node.
If stale image files from previous jobs are not deleted, they
accumulate over time, consuming significant disk space. This
can eventually lead to 'no disk space left' errors when new
jobs start.

This change ensures that saved image files are cleaned up
when an E2E job exits, preventing disk space exhaustion.

2. Clean up Golang caches when the free disk storage is less than
40G