### PR TITLE
Remove commented-out L7FlowExporter FeatureGate from manifests

### DIFF
--- a/build/charts/antrea/conf/antrea-agent.conf
+++ b/build/charts/antrea/conf/antrea-agent.conf
@@ -76,9 +76,6 @@ featureGates:
 # Allow users to apply ClusterNetworkPolicy to Kubernetes Nodes.
 {{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "NodeNetworkPolicy" "default" false) }}
 
-# Enable L7FlowExporter on Pods and Namespaces to export the application layer flows such as HTTP flows.
-{{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "L7FlowExporter" "default" false) }}
-
 # Enable NodeLatencyMonitor to monitor the latency between Nodes.
 {{- include "featureGate" (dict "featureGates" .Values.featureGates "name" "NodeLatencyMonitor" "default" false) }}
 

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -4289,9 +4289,6 @@ data:
     # Allow users to apply ClusterNetworkPolicy to Kubernetes Nodes.
     #  NodeNetworkPolicy: false
 
-    # Enable L7FlowExporter on Pods and Namespaces to export the application layer flows such as HTTP flows.
-    #  L7FlowExporter: false
-
     # Enable NodeLatencyMonitor to monitor the latency between Nodes.
     #  NodeLatencyMonitor: false
 
@@ -5703,7 +5700,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 23e14d3441d1d935b8499d78c5273dd1126c41c5b62b2b9403b739faa199d653
+        checksum/config: 3102c632b42c98e161207364e65fa751a0b0831e87d878a3242c013c1b7d3c2b
       labels:
         app: antrea
         component: antrea-agent
@@ -5951,7 +5948,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 23e14d3441d1d935b8499d78c5273dd1126c41c5b62b2b9403b739faa199d653
+        checksum/config: 3102c632b42c98e161207364e65fa751a0b0831e87d878a3242c013c1b7d3c2b
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -4285,9 +4285,6 @@ data:
     # Allow users to apply ClusterNetworkPolicy to Kubernetes Nodes.
     #  NodeNetworkPolicy: false
 
-    # Enable L7FlowExporter on Pods and Namespaces to export the application layer flows such as HTTP flows.
-    #  L7FlowExporter: false
-
     # Enable NodeLatencyMonitor to monitor the latency between Nodes.
     #  NodeLatencyMonitor: false
 
@@ -5699,7 +5696,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 23e14d3441d1d935b8499d78c5273dd1126c41c5b62b2b9403b739faa199d653
+        checksum/config: 3102c632b42c98e161207364e65fa751a0b0831e87d878a3242c013c1b7d3c2b
       labels:
         app: antrea
         component: antrea-agent
@@ -5948,7 +5945,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 23e14d3441d1d935b8499d78c5273dd1126c41c5b62b2b9403b739faa199d653
+        checksum/config: 3102c632b42c98e161207364e65fa751a0b0831e87d878a3242c013c1b7d3c2b
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -4285,9 +4285,6 @@ data:
     # Allow users to apply ClusterNetworkPolicy to Kubernetes Nodes.
     #  NodeNetworkPolicy: false
 
-    # Enable L7FlowExporter on Pods and Namespaces to export the application layer flows such as HTTP flows.
-    #  L7FlowExporter: false
-
     # Enable NodeLatencyMonitor to monitor the latency between Nodes.
     #  NodeLatencyMonitor: false
 
@@ -5690,7 +5687,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 0590de6bed2f6fa138f38ca2e8eb6d6a5bbd50eddedd4ad46df3c320045a8edb
+        checksum/config: cbbcacc8999c945122b022df66a13638197a09dbd45eaa1120c1549c2a43ef3a
       labels:
         app: antrea
         component: antrea-agent
@@ -5936,7 +5933,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 0590de6bed2f6fa138f38ca2e8eb6d6a5bbd50eddedd4ad46df3c320045a8edb
+        checksum/config: cbbcacc8999c945122b022df66a13638197a09dbd45eaa1120c1549c2a43ef3a
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -4298,9 +4298,6 @@ data:
     # Allow users to apply ClusterNetworkPolicy to Kubernetes Nodes.
     #  NodeNetworkPolicy: false
 
-    # Enable L7FlowExporter on Pods and Namespaces to export the application layer flows such as HTTP flows.
-    #  L7FlowExporter: false
-
     # Enable NodeLatencyMonitor to monitor the latency between Nodes.
     #  NodeLatencyMonitor: false
 
@@ -5703,7 +5700,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: c8ef76cb4f2a74472668e957d4d7c9abf550bd1b9a4b9ba6a4358025eed3330f
+        checksum/config: 5ff1f5f4019866e71c486257fd6ad4fb867855ba3c7bd603bfce7c4d77f16116
         checksum/ipsec-secret: d0eb9c52d0cd4311b6d252a951126bf9bea27ec05590bed8a394f0f792dcb2a4
       labels:
         app: antrea
@@ -5995,7 +5992,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: c8ef76cb4f2a74472668e957d4d7c9abf550bd1b9a4b9ba6a4358025eed3330f
+        checksum/config: 5ff1f5f4019866e71c486257fd6ad4fb867855ba3c7bd603bfce7c4d77f16116
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -4285,9 +4285,6 @@ data:
     # Allow users to apply ClusterNetworkPolicy to Kubernetes Nodes.
     #  NodeNetworkPolicy: false
 
-    # Enable L7FlowExporter on Pods and Namespaces to export the application layer flows such as HTTP flows.
-    #  L7FlowExporter: false
-
     # Enable NodeLatencyMonitor to monitor the latency between Nodes.
     #  NodeLatencyMonitor: false
 
@@ -5690,7 +5687,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: ca42ed56b141c2179f6e01f274400b4149cf98942571f7c3a3989597ad7520d4
+        checksum/config: 5e83f654fbb48b39b21ceeeb20d4d60ca1cf3de258acc258a2cc961eda9ac2a2
       labels:
         app: antrea
         component: antrea-agent
@@ -5936,7 +5933,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: ca42ed56b141c2179f6e01f274400b4149cf98942571f7c3a3989597ad7520d4
+        checksum/config: 5e83f654fbb48b39b21ceeeb20d4d60ca1cf3de258acc258a2cc961eda9ac2a2
       labels:
         app: antrea
         component: antrea-controller

--- a/docs/network-flow-visibility.md
+++ b/docs/network-flow-visibility.md
@@ -715,6 +715,8 @@ instead, which is actively maintained.
 
 ## Layer 7 Network Flow Exporter
 
+**This feature is deprecated in Antrea v2.5.0, and will be removed in v2.6.0.**
+
 In addition to layer 4 network visibility, Antrea adds layer 7 network flow
 export.
 


### PR DESCRIPTION
Now that the feature is deprecated, it makes sense to hide it from the default manifests.
We also add a deprecation notice for L7FlowExporter to network-flow-visibility.md.