### PR TITLE
Fix panic in `antctl check cluster`

### DIFF
--- a/pkg/antctl/raw/check/cluster/test_checkk8sversion.go
+++ b/pkg/antctl/raw/check/cluster/test_checkk8sversion.go
@@ -38,7 +38,7 @@ func (t *checkK8sVersion) Run(ctx context.Context, testContext *testContext) err
 	if err != nil {
 		return fmt.Errorf("error parsing server version: %w", err)
 	}
-	minVersion := semver.MustParse("1.23")
+	minVersion := semver.MustParse("1.23.0")
 	if currentVersion.GTE(minVersion) {
 		testContext.Log("Kubernetes server version is compatible with Antrea. Kubernetes version: %s", serverVersion.GitVersion)
 	} else {


### PR DESCRIPTION
The panic was introduced by #7564.
Prior to that, `semver.Parse` was used instead of `semver.MustParse`, and the returned error was ignored. While there was no panic prior to the change, the code was still incorrect as the K8s server version was always compared to 0.0.0, instead of the actual min required version.