### PR TITLE
Skip Windows unit tests for unsupported features

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -291,9 +291,10 @@ add-copyright:
 .windows-test-unit: .coverage
 	@echo
 	@echo "==> Running unit tests <=="
-	CGO_ENABLED=1 $(GO) test $(TEST_ARGS) -race -coverpkg=antrea.io/antrea/cmd/...,antrea.io/antrea/pkg/... \
+	@pkgs=$$($(GO) list antrea.io/antrea/cmd/... antrea.io/antrea/pkg/... | grep -v antrea.io/antrea/pkg/controller); \
+	CGO_ENABLED=1 $(GO) test $(TEST_ARGS) -race -coverpkg=$$(echo "$$pkgs" | tr '\n' ',' | sed 's/,$$//') \
 	  -coverprofile=.coverage/coverage-unit.txt -covermode=atomic \
-	  antrea.io/antrea/cmd/... antrea.io/antrea/pkg/...
+	  $$pkgs
 
 .PHONY: tidy
 tidy:

--- a/pkg/agent/controller/egress/egress_controller_test.go
+++ b/pkg/agent/controller/egress/egress_controller_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 // Copyright 2021 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/agent/controller/egress/id_allocator_test.go
+++ b/pkg/agent/controller/egress/id_allocator_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 // Copyright 2021 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/agent/controller/egress/ip_scheduler_test.go
+++ b/pkg/agent/controller/egress/ip_scheduler_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 // Copyright 2023 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/agent/controller/l7flowexporter/l7_flow_export_controller_test.go
+++ b/pkg/agent/controller/l7flowexporter/l7_flow_export_controller_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 // Copyright 2023 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/agent/controller/networkpolicy/l7engine/reconciler_test.go
+++ b/pkg/agent/controller/networkpolicy/l7engine/reconciler_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 // Copyright 2022 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/agent/monitortool/latency_store.go
+++ b/pkg/agent/monitortool/latency_store.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 // Copyright 2024 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/agent/monitortool/latency_store_test.go
+++ b/pkg/agent/monitortool/latency_store_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 // Copyright 2024 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/agent/monitortool/monitor.go
+++ b/pkg/agent/monitortool/monitor.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 // Copyright 2024 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/agent/monitortool/monitor_test.go
+++ b/pkg/agent/monitortool/monitor_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 // Copyright 2024 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/agent/monitortool/monitor_windows.go
+++ b/pkg/agent/monitortool/monitor_windows.go
@@ -1,0 +1,41 @@
+//go:build windows
+
+// Copyright 2025 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package monitortool
+
+import (
+	coreinformers "k8s.io/client-go/informers/core/v1"
+
+	"antrea.io/antrea/pkg/agent/client"
+	"antrea.io/antrea/pkg/agent/config"
+	crdinformers "antrea.io/antrea/pkg/client/informers/externalversions/crd/v1alpha1"
+)
+
+type NodeLatencyMonitor struct{}
+
+func NewNodeLatencyMonitor(
+	antreaClientProvider client.AntreaClientProvider,
+	nodeInformer coreinformers.NodeInformer,
+	nlmInformer crdinformers.NodeLatencyMonitorInformer,
+	nodeConfig *config.NodeConfig,
+	trafficEncapMode config.TrafficEncapModeType,
+) *NodeLatencyMonitor {
+	return &NodeLatencyMonitor{}
+}
+
+func (m *NodeLatencyMonitor) Run(stopCh <-chan struct{}) {}
+
+// Not supported on Windows.

--- a/pkg/agent/multicast/mcast_controller_test.go
+++ b/pkg/agent/multicast/mcast_controller_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 // Copyright 2021 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/agent/multicast/mcast_discovery_test.go
+++ b/pkg/agent/multicast/mcast_discovery_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 // Copyright 2022 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/agent/multicluster/mc_route_controller_test.go
+++ b/pkg/agent/multicluster/mc_route_controller_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 // Copyright 2022 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/agent/multicluster/pod_route_controller_test.go
+++ b/pkg/agent/multicluster/pod_route_controller_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 // Copyright 2023 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/agent/multicluster/stretched_networkpolicy_controller_test.go
+++ b/pkg/agent/multicluster/stretched_networkpolicy_controller_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 // Copyright 2022 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Skipping unit tests for all features explicitly listed as unsupported on Windows
(e.g., NodeLatencyMonitor, Egress).

This change was initiated following the observation of flaky failures in monitor tool
Windows unit tests. Disabling all related tests improves CI stability and releases resources.
