### PR TITLE
Assign unique MAC address for Egress VLAN interfaces

### DIFF
--- a/build/charts/antrea/README.md
+++ b/build/charts/antrea/README.md
@@ -95,6 +95,7 @@ Kubernetes: `>= 1.23.0-0`
 | egress.exceptCIDRs | list | `[]` | A list of CIDR ranges to which outbound Pod traffic will not be SNAT'd by Egresses, e.g. ["192.168.0.0/16", "172.16.0.0/12"]. |
 | egress.maxEgressIPsPerNode | int | `255` | The maximum number of Egress IPs that can be assigned to a Node. It is useful when the Node network restricts the number of secondary IPs a Node can have, e.g. EKS. It must not be greater than 255. |
 | egress.snatFullyRandomPorts | bool | `nil` | Fully randomize source port mapping in Egress SNAT rules. This has no impact on the default SNAT rules enforced by each Node for local Pod traffic. By default, we use the same value as for the top-level snatFullyRandomPorts configuration, but this field can be used as an override. |
+| egress.uniqueMACForSubInterfaces | bool | `true` | Enable Egress VLAN sub-interfaces to use unique MAC addresses instead of inheriting the parent interface’s MAC. Useful in cloud environments that require unique MAC addresses per interface. |
 | enableBridgingMode | bool | `false` | Enable bridging mode of Pod network on Nodes, in which the Node's transport interface is connected to the OVS bridge. |
 | featureGates | object | `{}` | To explicitly enable or disable a FeatureGate and bypass the Antrea defaults, add an entry to the dictionary with the FeatureGate's name as the key and a boolean as the value. |
 | flowExporter.activeFlowExportTimeout | string | `"5s"` | timeout after which a flow record is sent to the collector for active flows. |

--- a/build/charts/antrea/conf/antrea-agent.conf
+++ b/build/charts/antrea/conf/antrea-agent.conf
@@ -222,6 +222,10 @@ egress:
   {{- else }}
   snatFullyRandomPorts: {{ .snatFullyRandomPorts }}
   {{- end }}
+  # Enable Egress VLAN sub-interfaces to use unique MAC addresses instead of
+  # inheriting the parent interface’s MAC. Useful in cloud environments that require
+  # unique MAC addresses per interface.
+  uniqueMACForSubInterfaces: {{ .uniqueMACForSubInterfaces }}
 {{- end }}
 
 # ClusterIP CIDR range for Services. It's required when AntreaProxy is not enabled, and should be

--- a/build/charts/antrea/values.yaml
+++ b/build/charts/antrea/values.yaml
@@ -129,6 +129,10 @@ egress:
   # snatFullyRandomPorts configuration, but this field can be used as an
   # override.
   snatFullyRandomPorts:
+  # -- Enable Egress VLAN sub-interfaces to use unique MAC addresses instead of
+  # inheriting the parent interface’s MAC. Useful in cloud environments that require
+  # unique MAC addresses per interface.
+  uniqueMACForSubInterfaces: true
 
 nodePortLocal:
   # -- Enable the NodePortLocal feature.

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -4425,6 +4425,10 @@ data:
       # rules enforced by each Node for local Pod traffic. By default, we use the same value as for the
       # top-level snatFullyRandomPorts configuration, but this field can be used as an override.
       snatFullyRandomPorts:
+      # Enable Egress VLAN sub-interfaces to use unique MAC addresses instead of
+      # inheriting the parent interface’s MAC. Useful in cloud environments that require
+      # unique MAC addresses per interface.
+      uniqueMACForSubInterfaces: true
 
     # ClusterIP CIDR range for Services. It's required when AntreaProxy is not enabled, and should be
     # set to the same value as the one specified by --service-cluster-ip-range for kube-apiserver. When
@@ -5721,7 +5725,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 7164c2236357aab9edb1267ae3a6d8abdf7a4be1f60c444101f4012376d98172
+        checksum/config: 19cea71ebb0d852621308d71c5ee31a965d1fd7c0bc6a4c04bd09aa7ac2c1687
       labels:
         app: antrea
         component: antrea-agent
@@ -5969,7 +5973,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 7164c2236357aab9edb1267ae3a6d8abdf7a4be1f60c444101f4012376d98172
+        checksum/config: 19cea71ebb0d852621308d71c5ee31a965d1fd7c0bc6a4c04bd09aa7ac2c1687
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -4421,6 +4421,10 @@ data:
       # rules enforced by each Node for local Pod traffic. By default, we use the same value as for the
       # top-level snatFullyRandomPorts configuration, but this field can be used as an override.
       snatFullyRandomPorts:
+      # Enable Egress VLAN sub-interfaces to use unique MAC addresses instead of
+      # inheriting the parent interface’s MAC. Useful in cloud environments that require
+      # unique MAC addresses per interface.
+      uniqueMACForSubInterfaces: true
 
     # ClusterIP CIDR range for Services. It's required when AntreaProxy is not enabled, and should be
     # set to the same value as the one specified by --service-cluster-ip-range for kube-apiserver. When
@@ -5717,7 +5721,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 7164c2236357aab9edb1267ae3a6d8abdf7a4be1f60c444101f4012376d98172
+        checksum/config: 19cea71ebb0d852621308d71c5ee31a965d1fd7c0bc6a4c04bd09aa7ac2c1687
       labels:
         app: antrea
         component: antrea-agent
@@ -5966,7 +5970,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 7164c2236357aab9edb1267ae3a6d8abdf7a4be1f60c444101f4012376d98172
+        checksum/config: 19cea71ebb0d852621308d71c5ee31a965d1fd7c0bc6a4c04bd09aa7ac2c1687
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -4421,6 +4421,10 @@ data:
       # rules enforced by each Node for local Pod traffic. By default, we use the same value as for the
       # top-level snatFullyRandomPorts configuration, but this field can be used as an override.
       snatFullyRandomPorts:
+      # Enable Egress VLAN sub-interfaces to use unique MAC addresses instead of
+      # inheriting the parent interface’s MAC. Useful in cloud environments that require
+      # unique MAC addresses per interface.
+      uniqueMACForSubInterfaces: true
 
     # ClusterIP CIDR range for Services. It's required when AntreaProxy is not enabled, and should be
     # set to the same value as the one specified by --service-cluster-ip-range for kube-apiserver. When
@@ -5708,7 +5712,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: bf5a6fee5b84edc0803d6bf0965a411f3d88f64776ebfe30a8924baa9dc8c5da
+        checksum/config: 850a3f0b6a90ccc8380a7c5681a989b0d0204183d289c8d75fd76eab8cd1161a
       labels:
         app: antrea
         component: antrea-agent
@@ -5954,7 +5958,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: bf5a6fee5b84edc0803d6bf0965a411f3d88f64776ebfe30a8924baa9dc8c5da
+        checksum/config: 850a3f0b6a90ccc8380a7c5681a989b0d0204183d289c8d75fd76eab8cd1161a
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -4434,6 +4434,10 @@ data:
       # rules enforced by each Node for local Pod traffic. By default, we use the same value as for the
       # top-level snatFullyRandomPorts configuration, but this field can be used as an override.
       snatFullyRandomPorts:
+      # Enable Egress VLAN sub-interfaces to use unique MAC addresses instead of
+      # inheriting the parent interface’s MAC. Useful in cloud environments that require
+      # unique MAC addresses per interface.
+      uniqueMACForSubInterfaces: true
 
     # ClusterIP CIDR range for Services. It's required when AntreaProxy is not enabled, and should be
     # set to the same value as the one specified by --service-cluster-ip-range for kube-apiserver. When
@@ -5721,7 +5725,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: df497006c72465290efa91e3abc8ce6169b087a6a7ddc2bacda4aecab200a774
+        checksum/config: bd3bfe0a3cf17f563005ab065f7a981e07285271165795d9f1ab81bb9c0dc1e3
         checksum/ipsec-secret: d0eb9c52d0cd4311b6d252a951126bf9bea27ec05590bed8a394f0f792dcb2a4
       labels:
         app: antrea
@@ -6013,7 +6017,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: df497006c72465290efa91e3abc8ce6169b087a6a7ddc2bacda4aecab200a774
+        checksum/config: bd3bfe0a3cf17f563005ab065f7a981e07285271165795d9f1ab81bb9c0dc1e3
       labels:
         app: antrea
         component: antrea-controller

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -4421,6 +4421,10 @@ data:
       # rules enforced by each Node for local Pod traffic. By default, we use the same value as for the
       # top-level snatFullyRandomPorts configuration, but this field can be used as an override.
       snatFullyRandomPorts:
+      # Enable Egress VLAN sub-interfaces to use unique MAC addresses instead of
+      # inheriting the parent interface’s MAC. Useful in cloud environments that require
+      # unique MAC addresses per interface.
+      uniqueMACForSubInterfaces: true
 
     # ClusterIP CIDR range for Services. It's required when AntreaProxy is not enabled, and should be
     # set to the same value as the one specified by --service-cluster-ip-range for kube-apiserver. When
@@ -5708,7 +5712,7 @@ spec:
         kubectl.kubernetes.io/default-container: antrea-agent
         # Automatically restart Pods with a RollingUpdate if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: d30e0a917e8224438e4772d6a2b79a9e993b01c077bc1f75eeb7df9a5d8eeb8f
+        checksum/config: ce43af869242f2d5f0787dd0b9643a42f005e0426c4bfd7e3f38abda8b7718bc
       labels:
         app: antrea
         component: antrea-agent
@@ -5954,7 +5958,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: d30e0a917e8224438e4772d6a2b79a9e993b01c077bc1f75eeb7df9a5d8eeb8f
+        checksum/config: ce43af869242f2d5f0787dd0b9643a42f005e0426c4bfd7e3f38abda8b7718bc
       labels:
         app: antrea
         component: antrea-controller

--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -591,6 +591,7 @@ func run(o *Options) error {
 			features.DefaultFeatureGate.Enabled(features.EgressTrafficShaping),
 			features.DefaultFeatureGate.Enabled(features.EgressSeparateSubnet),
 			linkMonitor,
+			*o.config.Egress.UniqueMACForSubInterfaces,
 		)
 		if err != nil {
 			return fmt.Errorf("error creating new Egress controller: %v", err)

--- a/cmd/antrea-agent/options.go
+++ b/cmd/antrea-agent/options.go
@@ -535,6 +535,9 @@ func (o *Options) setK8sNodeDefaultOptions() {
 	if o.config.Egress.SNATFullyRandomPorts == nil {
 		o.config.Egress.SNATFullyRandomPorts = ptr.To(o.config.SNATFullyRandomPorts)
 	}
+	if o.config.Egress.UniqueMACForSubInterfaces == nil {
+		o.config.Egress.UniqueMACForSubInterfaces = ptr.To(true)
+	}
 	if o.config.HostNetworkAcceleration.Enable == nil {
 		o.config.HostNetworkAcceleration.Enable = ptr.To(true)
 	}

--- a/pkg/agent/controller/egress/egress_controller.go
+++ b/pkg/agent/controller/egress/egress_controller.go
@@ -229,6 +229,7 @@ func NewEgressController(
 	trafficShapingEnabled bool,
 	supportSeparateSubnet bool,
 	linkMonitor linkmonitor.Interface,
+	uniqueMACForSubInterfaces bool,
 ) (*EgressController, error) {
 	if trafficShapingEnabled && !openflow.OVSMetersAreSupported() {
 		klog.Info("EgressTrafficShaping feature gate is enabled, but it is ignored because OVS meters are not supported.")
@@ -290,7 +291,7 @@ func NewEgressController(
 			resyncPeriod,
 		)
 	}
-	ipAssigner, err := newIPAssigner(nodeTransportInterface, egressDummyDevice, linkMonitor)
+	ipAssigner, err := newIPAssigner(nodeTransportInterface, egressDummyDevice, linkMonitor, uniqueMACForSubInterfaces)
 	if err != nil {
 		return nil, fmt.Errorf("initializing egressIP assigner failed: %v", err)
 	}

--- a/pkg/agent/controller/egress/egress_controller_test.go
+++ b/pkg/agent/controller/egress/egress_controller_test.go
@@ -136,7 +136,7 @@ func (c *fakeSingleNodeCluster) AddClusterEventHandler(handler memberlist.Cluste
 
 func mockNewIPAssigner(ipAssigner ipassigner.IPAssigner) func() {
 	originalNewIPAssigner := newIPAssigner
-	newIPAssigner = func(_, _ string, _ linkmonitor.Interface) (ipassigner.IPAssigner, error) {
+	newIPAssigner = func(_, _ string, _ linkmonitor.Interface, _ bool) (ipassigner.IPAssigner, error) {
 		return ipAssigner, nil
 	}
 	return func() {
@@ -203,6 +203,7 @@ func newFakeController(t *testing.T, initObjects []runtime.Object) *fakeControll
 		true,
 		true,
 		nil,
+		true,
 	)
 	egressController.localIPDetector = localIPDetector
 	return &fakeController{

--- a/pkg/agent/controller/serviceexternalip/controller.go
+++ b/pkg/agent/controller/serviceexternalip/controller.go
@@ -111,7 +111,7 @@ func NewServiceExternalIPController(
 		assignedIPs:           make(map[string]sets.Set[string]),
 		linkMonitor:           linkMonitor,
 	}
-	ipAssigner, err := ipassigner.NewIPAssigner(nodeTransportInterface, "", linkMonitor)
+	ipAssigner, err := ipassigner.NewIPAssigner(nodeTransportInterface, "", linkMonitor, false)
 	if err != nil {
 		return nil, fmt.Errorf("initializing service external IP assigner failed: %v", err)
 	}

--- a/pkg/agent/ipassigner/ip_assigner_windows.go
+++ b/pkg/agent/ipassigner/ip_assigner_windows.go
@@ -20,6 +20,6 @@ import (
 	"antrea.io/antrea/pkg/agent/ipassigner/linkmonitor"
 )
 
-func NewIPAssigner(nodeTransportInterface string, dummyDeviceName string, linkMonitor linkmonitor.Interface) (IPAssigner, error) {
+func NewIPAssigner(nodeTransportInterface string, dummyDeviceName string, linkMonitor linkmonitor.Interface, uniqueMACForSubInterfaces bool) (IPAssigner, error) {
 	return nil, errors.New("IPAssigner is not implemented on Windows")
 }

--- a/pkg/config/agent/config.go
+++ b/pkg/config/agent/config.go
@@ -361,6 +361,10 @@ type EgressConfig struct {
 	// same value as for the top-level snatFullyRandomPorts configuration, but this field can be
 	// used as an override.
 	SNATFullyRandomPorts *bool `yaml:"snatFullyRandomPorts,omitempty"`
+	// Enable Egress VLAN sub-interfaces to use unique MAC addresses instead of
+	// inheriting the parent interface’s MAC. Useful in cloud environments that require
+	// unique MAC addresses per interface.
+	UniqueMACForSubInterfaces *bool `yaml:"uniqueMACForSubInterfaces,omitempty"`
 }
 
 type IPsecConfig struct {

--- a/test/integration/agent/ip_assigner_linux_test.go
+++ b/test/integration/agent/ip_assigner_linux_test.go
@@ -52,7 +52,7 @@ func TestIPAssigner(t *testing.T) {
 	nodeLinkName := nodeIntf.Name
 	require.NotNil(t, nodeLinkName, "Get Node link failed")
 
-	ipAssigner, err := ipassigner.NewIPAssigner(nodeLinkName, dummyDeviceName, nil)
+	ipAssigner, err := ipassigner.NewIPAssigner(nodeLinkName, dummyDeviceName, nil, true)
 	require.NoError(t, err, "Initializing IP assigner failed")
 
 	dummyDevice, err := netlink.LinkByName(dummyDeviceName)
@@ -140,7 +140,7 @@ func TestIPAssigner(t *testing.T) {
 	require.NoError(t, err, "Failed to list IP addresses")
 	assert.Equal(t, sets.New(fmt.Sprintf("%s/%d", ip1VLAN30, subnet30.PrefixLength)), actualIPs, "Actual IPs don't match")
 
-	newIPAssigner, err := ipassigner.NewIPAssigner(nodeLinkName, dummyDeviceName, nil)
+	newIPAssigner, err := ipassigner.NewIPAssigner(nodeLinkName, dummyDeviceName, nil, true)
 	require.NoError(t, err, "Initializing new IP assigner failed")
 	assert.Equal(t, map[string]*crdv1b1.SubnetInfo{}, newIPAssigner.AssignedIPs(), "Assigned IPs don't match")
 


### PR DESCRIPTION
Add `uniqueMACForSubInterfaces` option for Egress to control MAC
assignment of VLAN sub-interfaces. This option allows Egress VLAN
sub-interfaces to use unique MAC addresses instead of inheriting
the parent interface’s MAC.

The default value is true, meaning each VLAN sub-interface will
be assigned its own MAC address. To inherit the parent interface’s MAC,
users must explicitly set this option to false in antrea-config.