### PR TITLE
Fix Egress with WireGuard encryption enabled

### DIFF
--- a/docs/traffic-encryption.md
+++ b/docs/traffic-encryption.md
@@ -76,9 +76,9 @@ one if your cluster supports IPv6.
 
 Antrea can leverage [WireGuard](https://www.wireguard.com) to encrypt Pod traffic
 between Nodes. WireGuard encryption works like another tunnel type, and when it
-is enabled the `tunnelType` parameter in the `antrea-agent` configuration file
-will be ignored. It is not applicable with `hybrid`, `noEncap` or `networkPolicyOnly`
-traffic modes.
+is enabled the `tunnelType` parameter in the antrea-agent configuration file will
+only affect other traffic types such as [Egress](egress.md). It is not applicable
+with `hybrid`, `noEncap` or `networkPolicyOnly` traffic modes.
 
 ### Prerequisites
 
@@ -128,3 +128,9 @@ After saving the yaml file change, deploy Antrea with:
 ```bash
 kubectl apply -f antrea.yml
 ```
+
+## Limitations
+
+- Traffic encryption does not apply to [Egress](egress.md) traffic between the
+source Node (where the Pod runs) and the Egress Node. Packets on this hop are
+forwarded unencrypted, regardless of `trafficEncryptionMode`.

--- a/pkg/agent/config/node_config.go
+++ b/pkg/agent/config/node_config.go
@@ -283,14 +283,12 @@ func (nc *NetworkConfig) NeedsTunnelToPeer(peerIP net.IP, localIP *net.IPNet) bo
 }
 
 func (nc *NetworkConfig) NeedsTunnelInterface() bool {
-	// For encap or hybrid mode, we need to create the tunnel interface, except if we are using
-	// WireGuard, in which case inter-Node traffic always goes through the antrea-wg0 interface,
-	// and tunneling is managed by Linux, not OVS.
+	// For encap or hybrid mode, we need to create the tunnel interface.
 	// If multi-cluster gateway is enabled, we always need the tunnel interface. For example,
 	// cross-cluster traffic from a regular Node to the gateway Node for the source cluster
 	// always goes through antrea-tun0, regardless of the actual "traffic mode" for the source
 	// cluster.
-	return (nc.TrafficEncapMode.SupportsEncap() && nc.TrafficEncryptionMode != TrafficEncryptionModeWireGuard) || nc.EnableMulticlusterGW
+	return nc.TrafficEncapMode.SupportsEncap() || nc.EnableMulticlusterGW
 }
 
 // NeedsDirectRoutingToPeer returns true if Pod traffic to peer Node needs a direct route installed to the routing table.

--- a/pkg/agent/config/node_config_test.go
+++ b/pkg/agent/config/node_config_test.go
@@ -374,6 +374,16 @@ func TestNeedsTunnelInterface(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "Default encap mode with wireguard enabled",
+			nc:       &NetworkConfig{TunnelType: ovsconfig.GeneveTunnel, TrafficEncryptionMode: TrafficEncryptionModeWireGuard},
+			expected: true,
+		},
+		{
+			name:     "Hybrid mode",
+			nc:       &NetworkConfig{TrafficEncapMode: TrafficEncapModeHybrid, TunnelType: ovsconfig.GeneveTunnel},
+			expected: true,
+		},
+		{
 			name:     "networkPolicyOnly with Multicluster enabled",
 			nc:       &NetworkConfig{TrafficEncapMode: TrafficEncapModeNetworkPolicyOnly, EnableMulticlusterGW: true},
 			expected: true,

--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -608,8 +608,9 @@ func (c *client) InstallNodeFlows(hostname string,
 			flows = append(flows, c.featurePodConnectivity.l3FwdFlowToRemoteViaRouting(localGatewayMAC, remoteGatewayMAC, peerNodeIP, peerPodCIDR)...)
 			// Flow to forward the reply packets of Egress connections, whose request packets came from remote Pods
 			// via tunnel, back to those Pods via tunnel, ensuring symmetric paths of the connections. This flow is
-			// only needed when traffic mode is hybrid and remote Nodes are reachable through routing.
-			if c.enableEgress && c.networkConfig.TrafficEncapMode == config.TrafficEncapModeHybrid {
+			// needed when Egress uses a tunnel path distinct from the common Pod-to-Pod path (hybrid or WireGuard)
+			// and the peer is reachable via routing.
+			if c.enableEgress && (c.networkConfig.TrafficEncapMode == config.TrafficEncapModeHybrid || c.networkConfig.TrafficEncryptionMode == config.TrafficEncryptionModeWireGuard) {
 				flows = append(flows, c.featurePodConnectivity.l3FwdFlowEgressReturnViaTun(localGatewayMAC, *peerPodCIDR, peerNodeIP))
 			}
 		}

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -1365,9 +1365,10 @@ func (f *featurePodConnectivity) l3FwdFlowsToRemoteViaTun(localGatewayMAC net.Ha
 	return flows
 }
 
-// l3FwdFlowEgressReturnViaTun generates the flow to match the packets sourced from the Antrea gateway and destined for
-// remote Pods and forward them via tunnel. This flow is installed only in hybrid mode for matching reply packets of
-// Egress connections originated from tunnel and these packets should be sent to remote Pods via tunnel.
+// l3FwdFlowEgressReturnViaTun generates the flow to match reply packets of Egress connections (whose request packets
+// came from remote Pods via tunnel) and forward them back to those Pods via tunnel, ensuring symmetric paths. It is
+// used when Egress uses a tunnel path distinct from the common Pod-to-Pod path (hybrid or WireGuard) and the peer is
+// reachable via routing.
 func (f *featurePodConnectivity) l3FwdFlowEgressReturnViaTun(localGatewayMAC net.HardwareAddr, peerSubnet net.IPNet, tunnelPeer net.IP) binding.Flow {
 	ipProtocol := getIPProtocol(peerSubnet.IP)
 	flow := L3ForwardingTable.ofTable.BuildFlow(priorityNormal + 1).

--- a/pkg/agent/openflow/pod_connectivity_test.go
+++ b/pkg/agent/openflow/pod_connectivity_test.go
@@ -75,11 +75,7 @@ func podConnectivityInitFlows(
 			"cookie=0x1010000000000, table=L3DecTTL, priority=200,ip actions=dec_ttl,goto_table:SNATMark",
 			"cookie=0x1010000000000, table=ConntrackCommit, priority=200,ct_state=+new+trk,ct_mark=0x0/0x20,ip actions=ct(commit,table=Output,zone=65520,exec(move:NXM_NX_REG0[0..3]->NXM_NX_CT_MARK[0..3]))",
 			"cookie=0x1010000000000, table=Output, priority=200,reg0=0x200000/0x600000 actions=output:NXM_NX_REG1[]",
-		}
-		if trafficEncryptionMode != config.TrafficEncryptionModeWireGuard {
-			flows = append(flows,
-				"cookie=0x1010000000000, table=Classifier, priority=200,in_port=32768 actions=set_field:0x1/0xf->reg0,set_field:0x200/0x200->reg0,goto_table:UnSNAT",
-			)
+			"cookie=0x1010000000000, table=Classifier, priority=200,in_port=32768 actions=set_field:0x1/0xf->reg0,set_field:0x200/0x200->reg0,goto_table:UnSNAT",
 		}
 		if !multicastEnabled {
 			flows = append(flows, "cookie=0x1010000000000, table=SpoofGuard, priority=200,ip,in_port=32769 actions=goto_table:UnSNAT")
@@ -105,15 +101,13 @@ func podConnectivityInitFlows(
 				"cookie=0x1010000000000, table=TrafficControl, priority=210,reg0=0x200006/0x60000f actions=goto_table:Output",
 				"cookie=0x1010000000000, table=Output, priority=211,reg0=0x200000/0x600000,reg4=0x400000/0xc00000 actions=output:NXM_NX_REG1[],output:NXM_NX_REG9[]",
 				"cookie=0x1010000000000, table=Output, priority=211,reg0=0x200000/0x600000,reg4=0x800000/0xc00000 actions=output:NXM_NX_REG9[]",
+				"cookie=0x1010000000000, table=L2ForwardingCalc, priority=200,dl_dst=aa:bb:cc:dd:ee:ff actions=set_field:0x8000->reg1,set_field:0x200000/0x600000->reg0,goto_table:TrafficControl",
 			)
-			if trafficEncryptionMode != config.TrafficEncryptionModeWireGuard {
-				flows = append(flows, "cookie=0x1010000000000, table=L2ForwardingCalc, priority=200,dl_dst=aa:bb:cc:dd:ee:ff actions=set_field:0x8000->reg1,set_field:0x200000/0x600000->reg0,goto_table:TrafficControl")
-			}
 		} else {
-			flows = append(flows, "cookie=0x1010000000000, table=L2ForwardingCalc, priority=200,dl_dst=0a:00:00:00:00:01 actions=set_field:0x8001->reg1,set_field:0x200000/0x600000->reg0,goto_table:IngressSecurityClassifier")
-			if trafficEncryptionMode != config.TrafficEncryptionModeWireGuard {
-				flows = append(flows, "cookie=0x1010000000000, table=L2ForwardingCalc, priority=200,dl_dst=aa:bb:cc:dd:ee:ff actions=set_field:0x8000->reg1,set_field:0x200000/0x600000->reg0,goto_table:IngressSecurityClassifier")
-			}
+			flows = append(flows,
+				"cookie=0x1010000000000, table=L2ForwardingCalc, priority=200,dl_dst=0a:00:00:00:00:01 actions=set_field:0x8001->reg1,set_field:0x200000/0x600000->reg0,goto_table:IngressSecurityClassifier",
+				"cookie=0x1010000000000, table=L2ForwardingCalc, priority=200,dl_dst=aa:bb:cc:dd:ee:ff actions=set_field:0x8000->reg1,set_field:0x200000/0x600000->reg0,goto_table:IngressSecurityClassifier",
+			)
 		}
 	case config.TrafficEncapModeNoEncap:
 		if !isIPv4 {

--- a/pkg/agent/route/route_linux_test.go
+++ b/pkg/agent/route/route_linux_test.go
@@ -476,6 +476,8 @@ func TestSyncIPTables(t *testing.T) {
 				mockIPTables.AppendRule(iptables.ProtocolDual, iptables.FilterTable, iptables.InputChain, []string{"-j", antreaInputChain, "-m", "comment", "--comment", "Antrea: jump to Antrea input rules"})
 				mockIPTables.EnsureChain(iptables.ProtocolDual, iptables.FilterTable, antreaOutputChain)
 				mockIPTables.AppendRule(iptables.ProtocolDual, iptables.FilterTable, iptables.OutputChain, []string{"-j", antreaOutputChain, "-m", "comment", "--comment", "Antrea: jump to Antrea output rules"})
+				mockIPTables.EnsureChain(iptables.ProtocolDual, iptables.MangleTable, antreaPostRoutingChain)
+				mockIPTables.AppendRule(iptables.ProtocolDual, iptables.MangleTable, iptables.PostRoutingChain, []string{"-j", antreaPostRoutingChain, "-m", "comment", "--comment", "Antrea: jump to Antrea postrouting rules"})
 				mockIPTables.Restore(`*raw
 :ANTREA-PREROUTING - [0:0]
 :ANTREA-OUTPUT - [0:0]
@@ -489,6 +491,10 @@ COMMIT
 *mangle
 :ANTREA-PREROUTING - [0:0]
 :ANTREA-OUTPUT - [0:0]
+:ANTREA-POSTROUTING - [0:0]
+-A ANTREA-PREROUTING -m comment --comment "Antrea: restore fwmark from connmark for reply Egress packets to remote Pods" -m conntrack --ctstate ESTABLISHED -m conntrack --ctdir REPLY -m connmark --mark 0x40000000/0x40000000 -j CONNMARK --restore-mark --nfmask 0x40000000 --ctmask 0x40000000
+-A ANTREA-PREROUTING -m comment --comment "Antrea: persist connmark for the first request Egress packet from remote Pods" -i antrea-gw0 ! -s 172.16.10.0/24 -m conntrack --ctstate NEW -m mark ! --mark 0x00000000/0x000000ff -j CONNMARK --set-mark 0x40000000/0x40000000
+-A ANTREA-POSTROUTING -m comment --comment "Antrea: clear fwmark from reply Egress packets to remote Pods" -m conntrack --ctstate ESTABLISHED -m conntrack --ctdir REPLY -j MARK --set-xmark 0x0/0x40000000
 -A ANTREA-OUTPUT -m comment --comment "Antrea: mark LOCAL output packets" -m addrtype --src-type LOCAL -o antrea-gw0 -j MARK --or-mark 0x80000000
 COMMIT
 *filter
@@ -543,6 +549,10 @@ COMMIT
 *mangle
 :ANTREA-PREROUTING - [0:0]
 :ANTREA-OUTPUT - [0:0]
+:ANTREA-POSTROUTING - [0:0]
+-A ANTREA-PREROUTING -m comment --comment "Antrea: restore fwmark from connmark for reply Egress packets to remote Pods" -m conntrack --ctstate ESTABLISHED -m conntrack --ctdir REPLY -m connmark --mark 0x40000000/0x40000000 -j CONNMARK --restore-mark --nfmask 0x40000000 --ctmask 0x40000000
+-A ANTREA-PREROUTING -m comment --comment "Antrea: persist connmark for the first request Egress packet from remote Pods" -i antrea-gw0 ! -s 2001:ab03:cd04:55ef::/64 -m conntrack --ctstate NEW -m mark ! --mark 0x00000000/0x000000ff -j CONNMARK --set-mark 0x40000000/0x40000000
+-A ANTREA-POSTROUTING -m comment --comment "Antrea: clear fwmark from reply Egress packets to remote Pods" -m conntrack --ctstate ESTABLISHED -m conntrack --ctdir REPLY -j MARK --set-xmark 0x0/0x40000000
 -A ANTREA-OUTPUT -m comment --comment "Antrea: mark LOCAL output packets" -m addrtype --src-type LOCAL -o antrea-gw0 -j MARK --or-mark 0x80000000
 COMMIT
 *filter
@@ -647,6 +657,8 @@ COMMIT
 				mockIPTables.AppendRule(iptables.ProtocolDual, iptables.FilterTable, iptables.InputChain, []string{"-j", antreaInputChain, "-m", "comment", "--comment", "Antrea: jump to Antrea input rules"})
 				mockIPTables.EnsureChain(iptables.ProtocolDual, iptables.FilterTable, antreaOutputChain)
 				mockIPTables.AppendRule(iptables.ProtocolDual, iptables.FilterTable, iptables.OutputChain, []string{"-j", antreaOutputChain, "-m", "comment", "--comment", "Antrea: jump to Antrea output rules"})
+				mockIPTables.EnsureChain(iptables.ProtocolDual, iptables.MangleTable, antreaPostRoutingChain)
+				mockIPTables.AppendRule(iptables.ProtocolDual, iptables.MangleTable, iptables.PostRoutingChain, []string{"-j", antreaPostRoutingChain, "-m", "comment", "--comment", "Antrea: jump to Antrea postrouting rules"})
 				mockIPTables.Restore(`*raw
 :ANTREA-PREROUTING - [0:0]
 :ANTREA-OUTPUT - [0:0]
@@ -656,6 +668,10 @@ COMMIT
 *mangle
 :ANTREA-PREROUTING - [0:0]
 :ANTREA-OUTPUT - [0:0]
+:ANTREA-POSTROUTING - [0:0]
+-A ANTREA-PREROUTING -m comment --comment "Antrea: restore fwmark from connmark for reply Egress packets to remote Pods" -m conntrack --ctstate ESTABLISHED -m conntrack --ctdir REPLY -m connmark --mark 0x40000000/0x40000000 -j CONNMARK --restore-mark --nfmask 0x40000000 --ctmask 0x40000000
+-A ANTREA-PREROUTING -m comment --comment "Antrea: persist connmark for the first request Egress packet from remote Pods" -i antrea-gw0 ! -s 172.16.10.0/24 -m conntrack --ctstate NEW -m mark ! --mark 0x00000000/0x000000ff -j CONNMARK --set-mark 0x40000000/0x40000000
+-A ANTREA-POSTROUTING -m comment --comment "Antrea: clear fwmark from reply Egress packets to remote Pods" -m conntrack --ctstate ESTABLISHED -m conntrack --ctdir REPLY -j MARK --set-xmark 0x0/0x40000000
 -A ANTREA-OUTPUT -m comment --comment "Antrea: mark LOCAL output packets" -m addrtype --src-type LOCAL -o antrea-gw0 -j MARK --or-mark 0x80000000
 COMMIT
 *filter
@@ -683,6 +699,10 @@ COMMIT
 *mangle
 :ANTREA-PREROUTING - [0:0]
 :ANTREA-OUTPUT - [0:0]
+:ANTREA-POSTROUTING - [0:0]
+-A ANTREA-PREROUTING -m comment --comment "Antrea: restore fwmark from connmark for reply Egress packets to remote Pods" -m conntrack --ctstate ESTABLISHED -m conntrack --ctdir REPLY -m connmark --mark 0x40000000/0x40000000 -j CONNMARK --restore-mark --nfmask 0x40000000 --ctmask 0x40000000
+-A ANTREA-PREROUTING -m comment --comment "Antrea: persist connmark for the first request Egress packet from remote Pods" -i antrea-gw0 ! -s 2001:ab03:cd04:55ef::/64 -m conntrack --ctstate NEW -m mark ! --mark 0x00000000/0x000000ff -j CONNMARK --set-mark 0x40000000/0x40000000
+-A ANTREA-POSTROUTING -m comment --comment "Antrea: clear fwmark from reply Egress packets to remote Pods" -m conntrack --ctstate ESTABLISHED -m conntrack --ctdir REPLY -j MARK --set-xmark 0x0/0x40000000
 -A ANTREA-OUTPUT -m comment --comment "Antrea: mark LOCAL output packets" -m addrtype --src-type LOCAL -o antrea-gw0 -j MARK --or-mark 0x80000000
 COMMIT
 *filter


### PR DESCRIPTION
When WireGuard encryption is enabled, Egress traffic from remote Pods needs tunnel-based forwarding and policy routing rules similar to hybrid mode. This commit removes the WireGuard exception from tunnel interface creation and adds the necessary OpenFlow flows and routing rules to support Egress functionality with WireGuard.

Fixes: #6190