### PR TITLE
Fix Traceflow with WireGuard enabled

### DIFF
--- a/pkg/agent/controller/traceflow/packetin.go
+++ b/pkg/agent/controller/traceflow/packetin.go
@@ -349,7 +349,10 @@ func (c *Controller) parsePacketIn(pktIn *ofctrl.PacketIn) (*crdv1beta1.Traceflo
 			}
 
 			ob.Action = crdv1beta1.ActionForwardedOutOfNetwork
-			if c.networkConfig.TrafficEncapMode == config.TrafficEncapModeHybrid && c.podSubnetChecker != nil {
+			// In hybrid mode or WireGuard mode, packets to Pod IPs in the same subnet are forwarded
+			// directly without encapsulation. Check if the destination is a Pod IP to determine
+			// the correct action (Forwarded vs ForwardedOutOfNetwork).
+			if (c.networkConfig.TrafficEncapMode == config.TrafficEncapModeHybrid || c.networkConfig.TrafficEncryptionMode == config.TrafficEncryptionModeWireGuard) && c.podSubnetChecker != nil {
 				netAddrDst, _ := netip.AddrFromSlice(netIPDst)
 				isPodIP, _ := c.podSubnetChecker.LookupIPInPodSubnets(netAddrDst)
 				if isPodIP {

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -954,9 +954,8 @@ func (f *featurePodConnectivity) flowsToTrace(dataplaneTag uint8,
 		}
 		flows = append(flows, flowBuilder.Done())
 	}
-
-	// Do not send to controller if captures only dropped packet.
-	ifDroppedOnly := func(fb binding.FlowBuilder) binding.FlowBuilder {
+	// Add controller actions unless we are capturing only dropped packets.
+	ifNotDroppedOnly := func(fb binding.FlowBuilder) binding.FlowBuilder {
 		if !droppedOnly {
 			if ovsMetersAreSupported {
 				fb = fb.Action().Meter(PacketInMeterIDTF)
@@ -973,9 +972,12 @@ func (f *featurePodConnectivity) flowsToTrace(dataplaneTag uint8,
 		}
 		return fb
 	}
-	// Output the packets if traffic mode is noEncap or hybrid.
-	ifSupportsNoEncap := func(fb binding.FlowBuilder) binding.FlowBuilder {
-		if f.networkConfig.TrafficEncapMode.SupportsNoEncap() {
+	// Output the packets if traffic mode uses direct routing (noEncap, hybrid, or WireGuard).
+	// In direct routing modes, packets are routed directly without overlay encapsulation.
+	// WireGuard mode utilizes direct routing for all encrypted Pod traffic, similar to the
+	// behavior seen in noEncap and hybrid modes for direct-reachability traffic.
+	ifDirectRouting := func(fb binding.FlowBuilder) binding.FlowBuilder {
+		if f.networkConfig.TrafficEncapMode.SupportsNoEncap() || f.networkConfig.TrafficEncryptionMode == config.TrafficEncryptionModeWireGuard {
 			fb = fb.Action().OutputToRegField(TargetOFPortField)
 		}
 		return fb
@@ -994,14 +996,14 @@ func (f *featurePodConnectivity) flowsToTrace(dataplaneTag uint8,
 				MatchIPDSCP(dataplaneTag).
 				SetHardTimeout(timeout).
 				Action().OutputToRegField(TargetOFPortField)
-			fb = ifDroppedOnly(fb)
+			fb = ifNotDroppedOnly(fb)
 			flows = append(flows, fb.Done())
 		}
 		// For injected packets, SendToController and Output depending on traffic mode if output port is local gateway.
 		// - In encap mode, a Traceflow packet going out of the gateway port (i.e. exiting the overlay) essentially means
 		//   that the Traceflow request is complete. only SendToController if output port is local gateway.
-		// - In noEncap or hybrid mode, inter-Node Pod-to-Pod traffic is expected to go out of the gateway port on the
-		//   way to its destination.
+		// - In direct routing modes (noEncap, hybrid, or WireGuard), inter-Node Pod-to-Pod traffic is expected to go out of
+		//   the gateway port on the way to its destination.
 		fb := OutputTable.ofTable.BuildFlow(priorityNormal+2).
 			Cookie(cookieID).
 			MatchRegFieldWithValue(TargetOFPortField, f.gatewayPort).
@@ -1009,8 +1011,8 @@ func (f *featurePodConnectivity) flowsToTrace(dataplaneTag uint8,
 			MatchRegMark(OutputToOFPortRegMark).
 			MatchIPDSCP(dataplaneTag).
 			SetHardTimeout(timeout)
-		fb = ifSupportsNoEncap(fb)
-		fb = ifDroppedOnly(fb)
+		fb = ifDirectRouting(fb)
+		fb = ifNotDroppedOnly(fb)
 		fb = ifLiveTraffic(fb)
 		flows = append(flows, fb.Done())
 
@@ -1025,7 +1027,7 @@ func (f *featurePodConnectivity) flowsToTrace(dataplaneTag uint8,
 				MatchRegMark(OutputToOFPortRegMark).
 				MatchIPDSCP(dataplaneTag).
 				SetHardTimeout(timeout)
-			fb = ifDroppedOnly(fb)
+			fb = ifNotDroppedOnly(fb)
 			fb = ifLiveTraffic(fb)
 			flows = append(flows, fb.Done())
 		}
@@ -1036,7 +1038,7 @@ func (f *featurePodConnectivity) flowsToTrace(dataplaneTag uint8,
 			MatchRegMark(OutputToOFPortRegMark).
 			MatchIPDSCP(dataplaneTag).
 			SetHardTimeout(timeout)
-		fb = ifDroppedOnly(fb)
+		fb = ifNotDroppedOnly(fb)
 		fb = ifLiveTraffic(fb)
 		flows = append(flows, fb.Done())
 	}
@@ -1055,8 +1057,8 @@ func (f *featureService) flowsToTrace(dataplaneTag uint8,
 	timeout uint16) []binding.Flow {
 	cookieID := f.cookieAllocator.Request(cookie.Traceflow).Raw()
 	var flows []binding.Flow
-	// Do not send to controller if captures only dropped packet.
-	ifDroppedOnly := func(fb binding.FlowBuilder) binding.FlowBuilder {
+	// Add controller actions unless we are capturing only dropped packets.
+	ifNotDroppedOnly := func(fb binding.FlowBuilder) binding.FlowBuilder {
 		if !droppedOnly {
 			if ovsMetersAreSupported {
 				fb = fb.Action().Meter(PacketInMeterIDTF)
@@ -1086,7 +1088,7 @@ func (f *featureService) flowsToTrace(dataplaneTag uint8,
 				MatchCTMark(HairpinCTMark).
 				MatchIPDSCP(dataplaneTag).
 				SetHardTimeout(timeout)
-			fb = ifDroppedOnly(fb)
+			fb = ifNotDroppedOnly(fb)
 			fb = ifLiveTraffic(fb)
 			flows = append(flows, fb.Done())
 		}


### PR DESCRIPTION
WireGuard uses direct routing for same-subnet traffic similar to hybrid mode, but Traceflow was not checking for WireGuard mode when determining packet actions and forwarding behavior.

This commit adds WireGuard mode checks in the Traceflow packet parsing and flow generation logic to correctly handle packets when WireGuard encryption is enabled.