### PR TITLE
Fix testReconcileGatewayRoutesOnStartup with WireGuard

### DIFF
--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -2635,6 +2635,19 @@ func (data *TestData) GetEncapMode() (config.TrafficEncapModeType, error) {
 	return encapMode, nil
 }
 
+func (data *TestData) GetEncryptionnMode() (config.TrafficEncryptionModeType, error) {
+	agentConf, err := data.GetAntreaAgentConf()
+	if err != nil {
+		return config.TrafficEncapModeInvalid, fmt.Errorf("failed to get Antrea Agent config: %w", err)
+	}
+	if agentConf.TrafficEncryptionMode == "" {
+		// default encryption mode
+		return config.TrafficEncryptionModeNone, nil
+	}
+	_, encryptionMode := config.GetTrafficEncryptionModeFromStr(agentConf.TrafficEncryptionMode)
+	return encryptionMode, nil
+}
+
 func (data *TestData) isProxyAll() (bool, error) {
 	agentConf, err := data.GetAntreaAgentConf()
 	if err != nil {


### PR DESCRIPTION
The test was failing when WireGuard encryption is enabled because it expects gateway routes for encap mode, but WireGuard doesn't require gateway routes since it handles routing through its own interface.

This commit adds encryption mode detection to the test framework and updates the test to expect 0 gateway routes when WireGuard is enabled with encap mode.