### PR TITLE
Automated cherry pick of #7636: Fix antrea-agent crashing when AntreaProxy is not enabled

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -457,6 +457,7 @@ func run(o *Options) error {
 		return fmt.Errorf("failed to create node manager: %w", err)
 	}
 	var proxyServer *proxy.ProxyServer
+	var proxyQuerier proxy.ProxyQuerier
 	if o.enableAntreaProxy {
 		proxyServer, err = proxy.NewProxyServer(nodeConfig.Name,
 			nodeManager,
@@ -476,6 +477,7 @@ func run(o *Options) error {
 			return fmt.Errorf("error when creating proxyServer: %w", err)
 		}
 		proxyServer.Initialize(ctx, serviceInformer, endpointSliceInformer)
+		proxyQuerier = proxyServer.GetProxyQuerier()
 	}
 
 	// We pick a time interval for rule deletion in the async rule cache (part of the
@@ -739,7 +741,7 @@ func run(o *Options) error {
 		}
 		flowExporter, err = flowexporter.NewFlowExporter(
 			podStore,
-			proxyServer.GetProxyQuerier(),
+			proxyQuerier,
 			k8sClient,
 			nodeRouteController,
 			networkConfig.TrafficEncapMode,
@@ -986,7 +988,7 @@ func run(o *Options) error {
 		k8sClient,
 		ofClient,
 		ovsBridgeClient,
-		proxyServer.GetProxyQuerier(),
+		proxyQuerier,
 		networkPolicyController,
 		o.config.APIPort,
 		o.config.NodePortLocal.PortRange,


### PR DESCRIPTION
Cherry pick of #7636 on release-2.5.

#7636: Fix antrea-agent crashing when AntreaProxy is not enabled

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.