### PR TITLE
Use reserved OVS controller ports for Antrea SecondaryNetwork

### DIFF
--- a/pkg/agent/secondarynetwork/init_linux.go
+++ b/pkg/agent/secondarynetwork/init_linux.go
@@ -84,7 +84,7 @@ func connectPhyInterfacesToOVSBridge(ovsBridgeClient ovsconfig.OVSBridgeClient, 
 			continue
 		}
 
-		if _, err := ovsBridgeClient.CreateUplinkPort(phyInterface, int32(i), externalIDs); err != nil {
+		if _, err := ovsBridgeClient.CreateUplinkPort(phyInterface, ovsconfig.FirstControllerOFPort+int32(i), externalIDs); err != nil {
 			return fmt.Errorf("failed to create OVS uplink port %s: %v", phyInterface, err)
 		}
 		klog.InfoS("Physical interface added to secondary OVS bridge", "device", phyInterface)

--- a/pkg/agent/secondarynetwork/init_linux_test.go
+++ b/pkg/agent/secondarynetwork/init_linux_test.go
@@ -32,7 +32,10 @@ import (
 	ovsconfigtest "antrea.io/antrea/pkg/ovs/ovsconfig/testing"
 )
 
-const nonExistingInterface = "non-existing"
+const (
+	nonExistingInterface = "non-existing"
+	firstUplinkOFPort    = 32768
+)
 
 func TestCreateOVSBridge(t *testing.T) {
 	tests := []struct {
@@ -108,25 +111,25 @@ func TestConnectPhyInterfacesToOVSBridge(t *testing.T) {
 			name:               "one interface",
 			physicalInterfaces: []string{"eth0~"},
 			expectedCalls: func(m *ovsconfigtest.MockOVSBridgeClient) {
-				m.EXPECT().GetOFPort("eth0~", false).Return(int32(0), ovsconfig.InvalidArgumentsError("port not found"))
-				m.EXPECT().CreateUplinkPort("eth0~", int32(0), map[string]interface{}{"antrea-type": "uplink"}).Return("", nil)
+				m.EXPECT().GetOFPort("eth0~", false).Return(int32(firstUplinkOFPort), ovsconfig.InvalidArgumentsError("port not found"))
+				m.EXPECT().CreateUplinkPort("eth0~", int32(firstUplinkOFPort), map[string]interface{}{"antrea-type": "uplink"}).Return("", nil)
 			},
 		},
 		{
 			name:               "two interfaces",
 			physicalInterfaces: []string{"eth1", "eth2"},
 			expectedCalls: func(m *ovsconfigtest.MockOVSBridgeClient) {
-				m.EXPECT().GetOFPort("eth1", false).Return(int32(0), ovsconfig.InvalidArgumentsError("port not found"))
-				m.EXPECT().CreateUplinkPort("eth1", int32(0), map[string]interface{}{"antrea-type": "uplink"}).Return("", nil)
-				m.EXPECT().GetOFPort("eth2", false).Return(int32(1), ovsconfig.InvalidArgumentsError("port not found"))
-				m.EXPECT().CreateUplinkPort("eth2", int32(1), map[string]interface{}{"antrea-type": "uplink"}).Return("", nil)
+				m.EXPECT().GetOFPort("eth1", false).Return(int32(firstUplinkOFPort), ovsconfig.InvalidArgumentsError("port not found"))
+				m.EXPECT().CreateUplinkPort("eth1", int32(firstUplinkOFPort), map[string]interface{}{"antrea-type": "uplink"}).Return("", nil)
+				m.EXPECT().GetOFPort("eth2", false).Return(int32(firstUplinkOFPort+1), ovsconfig.InvalidArgumentsError("port not found"))
+				m.EXPECT().CreateUplinkPort("eth2", int32(firstUplinkOFPort+1), map[string]interface{}{"antrea-type": "uplink"}).Return("", nil)
 			},
 		},
 		{
 			name:               "interface already attached",
 			physicalInterfaces: []string{"eth1"},
 			expectedCalls: func(m *ovsconfigtest.MockOVSBridgeClient) {
-				m.EXPECT().GetOFPort("eth1", false).Return(int32(0), nil)
+				m.EXPECT().GetOFPort("eth1", false).Return(int32(firstUplinkOFPort), nil)
 			},
 		},
 		{
@@ -139,8 +142,8 @@ func TestConnectPhyInterfacesToOVSBridge(t *testing.T) {
 			physicalInterfaces: []string{"eth1"},
 			expectedErr:        "create error",
 			expectedCalls: func(m *ovsconfigtest.MockOVSBridgeClient) {
-				m.EXPECT().GetOFPort("eth1", false).Return(int32(0), ovsconfig.InvalidArgumentsError("port not found"))
-				m.EXPECT().CreateUplinkPort("eth1", int32(0), map[string]interface{}{"antrea-type": "uplink"}).Return("", ovsconfig.InvalidArgumentsError("create error"))
+				m.EXPECT().GetOFPort("eth1", false).Return(int32(firstUplinkOFPort), ovsconfig.InvalidArgumentsError("port not found"))
+				m.EXPECT().CreateUplinkPort("eth1", int32(firstUplinkOFPort), map[string]interface{}{"antrea-type": "uplink"}).Return("", ovsconfig.InvalidArgumentsError("create error"))
 			},
 		},
 	}


### PR DESCRIPTION
Configure Antrea secondary network bridges to use reserved OVS controller
ports. This ensures consistency with primary bridge behavior.

This is a follow up change for the issue #6192