### PR TITLE
Build new codegen image (kubernetes-1.31.1-build.3)

### DIFF
--- a/build/images/codegen/README.md
+++ b/build/images/codegen/README.md
@@ -22,6 +22,7 @@ Here is the table of codegen images that have been uploaded:
 
 | Tag                       | Change                                                                        |
 | :------------------------ | ----------------------------------------------------------------------------- |
+| kubernetes-1.31.1-build.3 | Build image with a more recent patch release of Go v1.24                      |
 | kubernetes-1.31.1-build.2 | Upgraded Go to v1.24                                                          |
 | kubernetes-1.31.1-build.1 | Upgraded controller-gen to v0.16.3                                            |
 | kubernetes-1.31.1-build.0 | Upgraded go.uber.org/mock/mockgen to v0.5.0                                   |

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -22,7 +22,7 @@ function echoerr {
 }
 
 ANTREA_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
-IMAGE_NAME="antrea/codegen:kubernetes-1.31.1-build.2"
+IMAGE_NAME="antrea/codegen:kubernetes-1.31.1-build.3"
 
 # We will use git clone to make a working copy of the repository into a
 # temporary directory. This requires that all changes have been committed

--- a/multicluster/hack/update-codegen.sh
+++ b/multicluster/hack/update-codegen.sh
@@ -22,7 +22,7 @@ function echoerr {
 }
 
 ANTREA_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../" && pwd )"
-IMAGE_NAME="antrea/codegen:kubernetes-1.31.1-build.2"
+IMAGE_NAME="antrea/codegen:kubernetes-1.31.1-build.3"
 
 # We will use git clone to make a working copy of the repository into a
 # temporary directory. This requires that all changes have been committed


### PR DESCRIPTION
This codegen image comes with a more recent patch release for Go 1.24 (1.24.11). We need this in order to udate one of our dependencies (`github.com/containernetworking/plugins`) for which the `go` directive has been changed to 1.24.2, hence requiring a more recent Go (toolchain) version.