### PR TITLE
Add init container to apply Antrea-specific sysctl configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,11 @@ antrea-controller:
 	@mkdir -p $(BINDIR)
 	GOOS=linux $(GO) build -o $(BINDIR) $(GOFLAGS) -ldflags '$(LDFLAGS)' antrea.io/antrea/cmd/antrea-controller
 
+.PHONY: antrea-sysctl-init
+antrea-sysctl-init:
+	@mkdir -p $(BINDIR)
+	GOOS=linux $(GO) build -o $(BINDIR) $(GOFLAGS) -ldflags '$(LDFLAGS)' antrea.io/antrea/cmd/antrea-sysctl-init
+
 .PHONY: .coverage
 .coverage:
 	mkdir -p $(CURDIR)/.coverage

--- a/build/charts/antrea/README.md
+++ b/build/charts/antrea/README.md
@@ -26,17 +26,21 @@ Kubernetes: `>= 1.23.0-0`
 | agent.antreaAgent.logFileMaxSize | int | `100` | Max size in MBs of any single log file. |
 | agent.antreaAgent.resources | object | `{"requests":{"cpu":"200m"}}` | Resource requests and limits for the antrea-agent container. |
 | agent.antreaAgent.securityContext.capabilities | list | `[]` | Capabilities for the antrea-agent container. |
-| agent.antreaAgent.securityContext.privileged | bool | `true` | Run the antrea-agent container as privileged. Currently we require this to be true (for sysctl configurations), but we may support running as non-privileged in the future. |
+| agent.antreaAgent.securityContext.privileged | bool | `true` | Whether to run the antrea-agent container as privileged. Currently we require this to be true (for sysctl configurations), but we may support running as non-privileged in the future. |
 | agent.antreaIPsec.resources | object | `{"requests":{"cpu":"50m"}}` | Resource requests and limits for the antrea-ipsec container (when IPsec is enabled). |
 | agent.antreaIPsec.securityContext.capabilities | list | `["NET_ADMIN"]` | Capabilities for the antrea-ipsec container. |
-| agent.antreaIPsec.securityContext.privileged | bool | `false` | Run the antrea-ipsec container as privileged. |
+| agent.antreaIPsec.securityContext.privileged | bool | `false` | Whether to run the antrea-ipsec container as privileged. |
 | agent.antreaOVS.extraArgs | list | `[]` | Extra command-line arguments for antrea-ovs. |
 | agent.antreaOVS.extraEnv | object | `{}` | Extra environment variables to be injected into antrea-ovs. |
 | agent.antreaOVS.logFileMaxNum | int | `4` | Max number of log files. |
 | agent.antreaOVS.logFileMaxSize | int | `100` | Max size in MBs of any single log file. |
 | agent.antreaOVS.resources | object | `{"requests":{"cpu":"200m"}}` | Resource requests and limits for the antrea-ovs container. |
 | agent.antreaOVS.securityContext.capabilities | list | `["SYS_NICE","NET_ADMIN","SYS_ADMIN","IPC_LOCK"]` | Capabilities for the antrea-ovs container. |
-| agent.antreaOVS.securityContext.privileged | bool | `false` | Run the antrea-ovs container as privileged. |
+| agent.antreaOVS.securityContext.privileged | bool | `false` | Whether to run the antrea-ovs container as privileged. |
+| agent.antreaSysctlInit.enable | bool | `false` | Enable the sysctl override. When enabled, the init container will do the process. |
+| agent.antreaSysctlInit.hostSysctlDir | string | `"/etc/sysctl.d"` | Path to the sysctl configuration directory on the host. |
+| agent.antreaSysctlInit.resources | object | `{"requests":{"cpu":"50m"}}` | Resource requests and limits for the antrea-sysctl-init init container. |
+| agent.antreaSysctlInit.securityContext.privileged | bool | `true` | Whether to run the antrea-sysctl-init container as privileged. |
 | agent.apiPort | int | `10350` | Port for the antrea-agent APIServer to serve on. |
 | agent.clusterPort | int | `10351` | clusterPort is the server port used by the antrea-agent to run a gossip-based cluster membership protocol. Currently it's used only when the Egress feature is enabled. Defaults to 10351 |
 | agent.dnsPolicy | string | `""` | DNS Policy for the antrea-agent Pods. If empty, the Kubernetes default will be used. |
@@ -46,7 +50,7 @@ Kubernetes: `>= 1.23.0-0`
 | agent.installCNI.extraEnv | object | `{}` | Extra environment variables to be injected into install-cni. |
 | agent.installCNI.resources | object | `{"requests":{"cpu":"100m"}}` | Resource requests and limits for the install-cni initContainer. |
 | agent.installCNI.securityContext.capabilities | list | `["SYS_MODULE"]` | Capabilities for the install-cni initContainer. |
-| agent.installCNI.securityContext.privileged | bool | `false` | Run the install-cni container as privileged. |
+| agent.installCNI.securityContext.privileged | bool | `false` | Whether to run the install-cni container as privileged. |
 | agent.kubeletRootDir | string | `"/var/lib/kubelet"` | The root directory where kubelet stores its files. This is required to access the pod resources API, which is used to retrieve SR-IOV device allocation details for Pods. By default, the subdirectory containing the pod resources socket is mounted into antrea-agent Pods. Setting it to an empty value disables the mounting. |
 | agent.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node selector for the antrea-agent Pods. |
 | agent.podAnnotations | object | `{}` | Annotations to be added to antrea-agent Pods. |

--- a/build/charts/antrea/templates/agent/daemonset.yaml
+++ b/build/charts/antrea/templates/agent/daemonset.yaml
@@ -67,6 +67,24 @@ spec:
       {{- end }}
       serviceAccountName: antrea-agent
       initContainers:
+      {{- if .Values.agent.antreaSysctlInit.enable }}
+        - name: antrea-sysctl-init
+          image: {{ include "antreaAgentImage" . | quote }}
+          imagePullPolicy: {{ include "antreaAgentImagePullPolicy" . }}
+          resources: {{- .Values.agent.antreaSysctlInit.resources | toYaml | nindent 12 }}
+          command: ["antrea-sysctl-init"]
+          args:
+            - "--host-gateway-name={{ .Values.hostGateway }}"
+          {{- with .Values.agent.antreaSysctlInit.securityContext }}
+          securityContext:
+            {{- if .privileged }}
+            privileged: true
+            {{- end }}
+          {{- end }}
+          volumeMounts:
+            - name: host-sysctl-dir
+              mountPath: /host/etc/sysctl.d
+      {{- end }}
       {{- if eq .Values.trafficEncapMode "networkPolicyOnly" }}
       containers:
       {{- end }}
@@ -409,6 +427,12 @@ spec:
         - name: host-pod-resources
           hostPath:
             path: {{ .Values.agent.kubeletRootDir }}/pod-resources
+            type: Directory
+        {{- end }}
+        {{- if .Values.agent.antreaSysctlInit.enable }}
+        - name: host-sysctl-dir
+          hostPath:
+            path: {{ .Values.agent.antreaSysctlInit.hostSysctlDir }}
             type: Directory
         {{- end }}
         {{- with .Values.agent.extraVolumes }}

--- a/build/charts/antrea/values.yaml
+++ b/build/charts/antrea/values.yaml
@@ -294,6 +294,18 @@ agent:
   # resources socket is mounted into antrea-agent Pods. Setting it to an empty
   # value disables the mounting.
   kubeletRootDir: "/var/lib/kubelet"
+  antreaSysctlInit:
+    # -- Enable the sysctl override. When enabled, the init container will do the process.
+    enable: false
+    # -- Path to the sysctl configuration directory on the host.
+    hostSysctlDir: "/etc/sysctl.d"
+    # -- Resource requests and limits for the antrea-sysctl-init init container.
+    resources:
+      requests:
+        cpu: "50m"
+    securityContext:
+      # -- Whether to run the antrea-sysctl-init container as privileged.
+      privileged: true
   installCNI:
     # -- Extra environment variables to be injected into install-cni.
     extraEnv: {}
@@ -302,7 +314,7 @@ agent:
       requests:
         cpu: "100m"
     securityContext:
-      # -- Run the install-cni container as privileged.
+      # -- Whether to run the install-cni container as privileged.
       privileged: false
       # -- Capabilities for the install-cni initContainer.
       capabilities:
@@ -324,7 +336,7 @@ agent:
       requests:
         cpu: "200m"
     securityContext:
-      # -- Run the antrea-agent container as privileged. Currently we require
+      # -- Whether to run the antrea-agent container as privileged. Currently we require
       # this to be true (for sysctl configurations), but we may support running
       # as non-privileged in the future.
       privileged: true
@@ -344,7 +356,7 @@ agent:
       requests:
         cpu: "200m"
     securityContext:
-      # -- Run the antrea-ovs container as privileged.
+      # -- Whether to run the antrea-ovs container as privileged.
       privileged: false
       # -- Capabilities for the antrea-ovs container.
       capabilities:
@@ -360,7 +372,7 @@ agent:
       requests:
         cpu: "50m"
     securityContext:
-      # -- Run the antrea-ipsec container as privileged.
+      # -- Whether to run the antrea-ipsec container as privileged.
       privileged: false
       # -- Capabilities for the antrea-ipsec container.
       capabilities:

--- a/build/images/Dockerfile.agent.ubuntu
+++ b/build/images/Dockerfile.agent.ubuntu
@@ -24,3 +24,4 @@ COPY build/images/scripts/* /usr/local/bin/
 COPY bin/antrea-agent /usr/local/bin/
 COPY bin/antrea-cni /usr/local/bin/
 COPY bin/antctl /usr/local/bin/
+COPY bin/antrea-sysctl-init /usr/local/bin/

--- a/build/images/Dockerfile.build.agent.coverage
+++ b/build/images/Dockerfile.build.agent.coverage
@@ -26,7 +26,7 @@ COPY . /antrea
 
 RUN make antctl-instr-binary
 
-RUN make antrea-cni antrea-agent-instr-binary
+RUN make antrea-cni antrea-agent-instr-binary antrea-sysctl-init
 
 FROM antrea/base-ubuntu-${TARGETARCH}:${BUILD_TAG}
 
@@ -38,6 +38,7 @@ USER root
 COPY build/images/scripts/* /usr/local/bin/
 COPY --from=antrea-build /antrea/bin/antrea-agent-coverage /usr/local/bin/antrea-agent
 COPY --from=antrea-build /antrea/bin/antrea-cni /usr/local/bin/
+COPY --from=antrea-build /antrea/bin/antrea-sysctl-init /usr/local/bin/
 COPY --from=antrea-build /antrea/bin/antctl-coverage /usr/local/bin/antctl
 COPY --from=antrea-build /antrea/test/e2e/utils/run_cov_binary.sh /
 

--- a/build/images/Dockerfile.build.agent.ubi
+++ b/build/images/Dockerfile.build.agent.ubi
@@ -31,7 +31,7 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
 
 RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=cache,target=/root/.cache/go-build/ \
-    make antrea-agent antrea-cni
+    make antrea-agent antrea-cni antrea-sysctl-init
 
 FROM antrea/base-ubi-${TARGETARCH}:${BUILD_TAG}
 
@@ -44,3 +44,4 @@ COPY build/images/scripts/* /usr/local/bin/
 COPY --from=antrea-build /antrea/bin/antrea-agent /usr/local/bin/
 COPY --from=antrea-build /antrea/bin/antrea-cni /usr/local/bin/
 COPY --from=antrea-build /antrea/bin/antctl /usr/local/bin/
+COPY --from=antrea-build /antrea/bin/antrea-sysctl-init /usr/local/bin/

--- a/build/images/Dockerfile.build.agent.ubuntu
+++ b/build/images/Dockerfile.build.agent.ubuntu
@@ -31,7 +31,7 @@ RUN --mount=type=cache,target=/go/pkg/mod/ \
 
 RUN --mount=type=cache,target=/go/pkg/mod/ \
     --mount=type=cache,target=/root/.cache/go-build/ \
-    make antrea-agent antrea-cni
+    make antrea-agent antrea-cni antrea-sysctl-init
 
 FROM antrea/base-ubuntu-${TARGETARCH}:${BUILD_TAG}
 
@@ -44,3 +44,4 @@ COPY build/images/scripts/* /usr/local/bin/
 COPY --from=antrea-build /antrea/bin/antrea-agent /usr/local/bin/
 COPY --from=antrea-build /antrea/bin/antrea-cni /usr/local/bin/
 COPY --from=antrea-build /antrea/bin/antctl /usr/local/bin/
+COPY --from=antrea-build /antrea/bin/antrea-sysctl-init /usr/local/bin/

--- a/cmd/antrea-sysctl-init/main.go
+++ b/cmd/antrea-sysctl-init/main.go
@@ -1,0 +1,61 @@
+//go:build linux
+// +build linux
+
+// Copyright 2025 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"os"
+
+	"antrea.io/antrea/pkg/log"
+	"antrea.io/antrea/pkg/version"
+
+	"github.com/spf13/cobra"
+	"k8s.io/klog/v2"
+)
+
+func main() {
+	command := newAntreaSysctlInitCommand()
+	if err := command.Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+func newAntreaSysctlInitCommand() *cobra.Command {
+	opts := newOptions()
+
+	cmd := &cobra.Command{
+		Use:  "antrea-sysctl-init",
+		Long: "Initialize Antrea-required sysctl config.",
+		Run: func(cmd *cobra.Command, args []string) {
+			log.InitLogs(cmd.Flags())
+			defer log.FlushLogs()
+
+			if err := opts.validate(); err != nil {
+				klog.Fatalf("Failed to validate: %v", err)
+			}
+			if err := run(opts); err != nil {
+				klog.Fatalf("Error running sysctl init: %v", err)
+			}
+		},
+		Version: version.GetFullVersionWithRuntimeInfo(),
+	}
+
+	flags := cmd.Flags()
+	opts.addFlags(flags)
+	log.AddFlags(flags)
+	return cmd
+}

--- a/cmd/antrea-sysctl-init/options.go
+++ b/cmd/antrea-sysctl-init/options.go
@@ -1,0 +1,45 @@
+//go:build linux
+// +build linux
+
+// Copyright 2025 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/pflag"
+)
+
+type options struct {
+	// Name of the interface that antrea-agent creates for host <-> Pod communication.
+	// The rp_filter of the interface should be set to loose mode (2) for feature Egress in hybrid mode.
+	hostGatewayName string
+}
+
+func newOptions() *options {
+	return &options{}
+}
+
+func (o *options) addFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&o.hostGatewayName, "host-gateway-name", "antrea-gw0", "Name of the Antrea host gateway interface")
+}
+
+func (o *options) validate() error {
+	if o.hostGatewayName == "" {
+		return fmt.Errorf("host-gateway-name must be specified")
+	}
+	return nil
+}

--- a/cmd/antrea-sysctl-init/sysctl_init.go
+++ b/cmd/antrea-sysctl-init/sysctl_init.go
@@ -1,0 +1,79 @@
+//go:build linux
+// +build linux
+
+// Copyright 2025 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/afero"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/exec"
+)
+
+var (
+	defaultFs   = afero.NewOsFs()
+	defaultExec = exec.New()
+
+	// Name of the Antrea-specific sysctl configuration file created or overwritten by the init container. This file contains
+	// sysctl settings that apply only to the interfaces managed by Antrea.
+	// On some Linux distributions, sysctl configuration files may be automatically re-applied to all existing interfaces
+	// when an interface is added or updated. In such environments, a relatively high filename prefix is used to ensure the
+	// Antrea-specific sysctl configuration file is applied after most default distribution- or administrator-provided sysctl
+	// configuration files.
+	defaultSysctlFile = "/host/etc/sysctl.d/99-zzzz-antrea.conf"
+)
+
+func run(opts *options) error {
+	sysctlConfig := buildAntreaSysctlConfig(opts.hostGatewayName)
+
+	if err := afero.WriteFile(defaultFs, defaultSysctlFile, []byte(sysctlConfig), 0644); err != nil {
+		return fmt.Errorf("failed to write Antrea sysctl configuration %q: %w", defaultSysctlFile, err)
+	}
+
+	// Apply the sysctl settings immediately. This may return an error if per-interface sysctl keys
+	// (e.g. net.ipv4.conf.antrea-gw0.rp_filter) refer to interfaces that do not yet exist at the time of execution.
+	cmd := defaultExec.Command("/usr/sbin/sysctl", "-p", defaultSysctlFile)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		klog.InfoS(
+			"sysctl returned a non-fatal error while applying Antrea sysctl configuration",
+			"filePath", defaultSysctlFile,
+			"output", string(output),
+			"error", err,
+		)
+	}
+
+	klog.InfoS("Successfully wrote and applied Antrea sysctl configuration", "filePath", defaultSysctlFile)
+
+	return nil
+}
+
+// buildAntreaSysctlConfig generates the Antrea-specific sysctl configuration file which is required by feature Antrea
+// Egress separate-subnet or hybrid mode. For these cases, Antrea Egress replies on policy routing, which requires
+// the reverse path filtering (rp_filter) to be set to loose mode (2) on network interfaces managed by Antrea.
+func buildAntreaSysctlConfig(hostGateway string) string {
+	lines := []string{
+		"# Antrea-specific sysctl overrides. These settings are required for features that rely on policy routing",
+		"# (e.g. Antrea Egress).",
+		"",
+		"net.ipv4.conf.antrea-ext*.rp_filter = 2",
+		fmt.Sprintf("net.ipv4.conf.%s.rp_filter = 2", hostGateway),
+	}
+
+	return strings.Join(lines, "\n") + "\n"
+}

--- a/cmd/antrea-sysctl-init/sysctl_init_test.go
+++ b/cmd/antrea-sysctl-init/sysctl_init_test.go
@@ -1,0 +1,98 @@
+//go:build linux
+// +build linux
+
+// Copyright 2025 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/exec"
+	exectesting "k8s.io/utils/exec/testing"
+)
+
+func newFakeExec() *exectesting.FakeExec {
+	fcmd := exectesting.FakeCmd{
+		CombinedOutputScript: []exectesting.FakeAction{
+			func() ([]byte, []byte, error) {
+				return nil, nil, nil
+			},
+		},
+	}
+	return &exectesting.FakeExec{
+		CommandScript: []exectesting.FakeCommandAction{
+			func(cmd string, args ...string) exec.Cmd {
+				return exectesting.InitFakeCmd(&fcmd, cmd, args...)
+			},
+		},
+	}
+}
+
+func TestRun(t *testing.T) {
+	opts := &options{
+		hostGatewayName: "antrea-gw0",
+	}
+
+	tests := []struct {
+		name string
+		fs   afero.Fs
+		err  string
+	}{
+		{
+			name: "success",
+			fs:   afero.NewMemMapFs(),
+		},
+		{
+			name: "write file failure",
+			fs:   afero.NewReadOnlyFs(afero.NewMemMapFs()),
+			err:  "failed to write Antrea sysctl configuration",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			origFs := defaultFs
+			origExec := defaultExec
+			origSysctlFile := defaultSysctlFile
+			defaultFs = tt.fs
+			defaultExec = newFakeExec()
+			defaultSysctlFile = "/antrea-test.conf"
+			t.Cleanup(func() {
+				defaultFs = origFs
+				defaultExec = origExec
+				defaultSysctlFile = origSysctlFile
+			})
+
+			err := run(opts)
+			if tt.err != "" {
+				assert.ErrorContains(t, err, tt.err)
+			} else {
+				require.NoError(t, err)
+
+				exists, err := afero.Exists(defaultFs, defaultSysctlFile)
+				require.NoError(t, err)
+				require.True(t, exists)
+
+				content, err := afero.ReadFile(defaultFs, defaultSysctlFile)
+				require.NoError(t, err)
+				require.Equal(t, buildAntreaSysctlConfig(opts.hostGatewayName), string(content))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Introduce a new antrea-sysctl-init command to run as an init container
before Antrea components start. The command creates a dedicated sysctl.d
configuration file containing Antrea-specific sysctl settings required
by features that rely on policy routing (e.g. Egress).

The sysctl configuration applies only to the interfaces managed by
Antrea. A relatively high filename prefix is used so that the Antrea-
specific sysctl configuration is applied after most default distribution-
or administrator-provided sysctl configuration files, while still allowing
explicit higher-priority overrides when desired.

This logic is intentionally implemented as an init container rather than
as part of antrea-agent, to avoid modifying node-wide sysctl state during
normal agent operation.