### PR TITLE
Fix Multi-cluster coverage build with no space left issue

### DIFF
--- a/ci/jenkins/test-mc.sh
+++ b/ci/jenkins/test-mc.sh
@@ -405,8 +405,8 @@ function run_multicluster_e2e {
 
     # Use the same agnhost image which is defined as 'agnhostImage' in antrea/test/e2e/framework.go to
     # avoid pulling the image again when running Multi-cluster e2e tests.
-    docker pull "registry.k8s.io/e2e-test-images/agnhost:2.29"
-    docker save "registry.k8s.io/e2e-test-images/agnhost:2.29" -o "${WORKDIR}"/agnhost.tar
+    docker pull "registry.k8s.io/e2e-test-images/agnhost:2.40"
+    docker save "registry.k8s.io/e2e-test-images/agnhost:2.40" -o "${WORKDIR}"/agnhost.tar
 
     if [[ ${KIND} == "true" ]]; then
         for name in ${CLUSTER_NAMES[*]}; do
@@ -414,7 +414,7 @@ function run_multicluster_e2e {
                 continue
             fi
             kind load docker-image "${DOCKER_REGISTRY}"/antrea/nginx:1.21.6-alpine --name ${name}
-            kind load docker-image "registry.k8s.io/e2e-test-images/agnhost:2.29" --name ${name}
+            kind load docker-image "registry.k8s.io/e2e-test-images/agnhost:2.40" --name ${name}
         done
     else
         for kubeconfig in "${membercluster_kubeconfigs[@]}"; do

--- a/multicluster/build/images/Dockerfile.build.coverage
+++ b/multicluster/build/images/Dockerfile.build.coverage
@@ -19,11 +19,16 @@ WORKDIR /antrea
 
 COPY go.mod /antrea/go.mod
 
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+    --mount=type=bind,source=go.sum,target=go.sum \
+    --mount=type=bind,source=go.mod,target=go.mod \
+    go mod download
 
 COPY . /antrea
 
-RUN cd multicluster && make antrea-mc-instr-binary
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+    --mount=type=cache,target=/root/.cache/go-build/ \
+    cd multicluster && make antrea-mc-instr-binary
 
 FROM ubuntu:24.04
 


### PR DESCRIPTION
No space left issue on /tmp was observed when running Multi-cluster e2e:
`mkdir /tmp/go-build2473123557/b1104/: no space left on device`

Fix it by mounting cache instead of writing files to /tmp