### PR TITLE
Fix benchmark names and allow manual benchmark runs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Git branch to run benchmarks on'
+        required: false
+        default: main
 
 jobs:
   go-benchmark-checks:
@@ -13,6 +19,7 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v6
         with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.branch || 'main' }}
           fetch-depth: 0
           show-progress: false
 

--- a/test/performance/benchmark.yml
+++ b/test/performance/benchmark.yml
@@ -75,6 +75,12 @@ benchmarks:
     package: "./pkg/apis/controlplane"
   - name: "BenchmarkSymmetricDifferenceString"
     package: "./pkg/util/sets"
-  - name: "BenchmarkCleanUpStaleIPAddresses"
+  - name: "BenchmarkCleanUpStaleIPAddresses/Small"
+    package: "./pkg/controller/ipam"
+    threshold: 0.2
+  - name: "BenchmarkCleanUpStaleIPAddresses/Medium"
+    package: "./pkg/controller/ipam"
+    threshold: 0.3
+  - name: "BenchmarkCleanUpStaleIPAddresses/Large"
     package: "./pkg/controller/ipam"
     threshold: 0.3


### PR DESCRIPTION
1. Fix benchmark test names for CleanUpStaleIPAddresses
2. Allow running benchmark tests manually, so that the change can be
    verified before PR merge.

The benchmark tests were broken after PR #7538 is merged.
```
I1117 09:13:45.094766    2199 main.go:108] "Parse result" parseSet=map[BenchmarkCleanUpStaleIPAddresses/Large-2:[BenchmarkCleanUpStaleIPAddresses/Large-2 81 124494007.00 ns/op 126337650 B/op 2511153 allocs/op] BenchmarkCleanUpStaleIPAddresses/Medium-2:[BenchmarkCleanUpStaleIPAddresses/Medium-2 1298 9647115.00 ns/op 10304754 B/op 202329 allocs/op] BenchmarkCleanUpStaleIPAddresses/Small-2:[BenchmarkCleanUpStaleIPAddresses/Small-2 41005 314668.00 ns/op 291707 B/op 5254 allocs/op]]
F1117 09:13:45.248579    2199 main.go:60] failed to run a benchmark: expected exactly one benchmark result
goroutine 1 [running]:
```
