### PR TITLE
Fix Prometheus test panic due to unset validation scheme

### DIFF
--- a/test/e2e/prometheus_test.go
+++ b/test/e2e/prometheus_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 
 	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -188,7 +189,6 @@ func testPrometheusMetricsOnPods(t *testing.T, data *TestData, component string,
 	var hostIP = ""
 	var hostPort int32
 	var address = ""
-	var parser expfmt.TextParser
 
 	// Find Pods' API endpoints, check for metrics existence on each of them
 	for _, pod := range pods.Items {
@@ -202,6 +202,7 @@ func testPrometheusMetricsOnPods(t *testing.T, data *TestData, component string,
 				t.Logf("Found %s", address)
 				respBody := getMetricsFromAPIServer(t, fmt.Sprintf("https://%s/metrics", address), token)
 
+				parser := expfmt.NewTextParser(model.LegacyValidation)
 				parsed, err := parser.TextToMetricFamilies(strings.NewReader(respBody))
 				if err != nil {
 					t.Fatalf("Parsing Prometheus metrics failed with: %v", err)


### PR DESCRIPTION
The TestPrometheus e2e test was failing with panic:
```
Invalid name validation scheme requested: unset
```

Root cause: PR #7668 transitively upgraded github.com/prometheus/common to v0.66.1, which requires TextParser to be initialized with a validation scheme. The zero value is no longer valid.

Solution: Use `expfmt.NewTextParser(model.LegacyValidation)` instead of the zero value `expfmt.TextParser{}`. LegacyValidation is a setting that requires that all metric and label names conform to the original Prometheus naming requirements

This properly initializes the parser with a validation scheme, preventing the panic when parsing Prometheus metrics.