### PR TITLE
Fix fillServiceUID to support services without port name

### DIFF
--- a/pkg/flowaggregator/flowaggregator.go
+++ b/pkg/flowaggregator/flowaggregator.go
@@ -676,11 +676,7 @@ func (fa *flowAggregator) fillServiceUID(record *flowpb.Flow, startTime time.Tim
 	if record.K8S.DestinationServicePortName == "" {
 		return
 	}
-	namespacedName, _, found := strings.Cut(record.K8S.DestinationServicePortName, ":")
-	if !found {
-		klog.ErrorS(nil, "Expected format for ServicePortName", "servicePortName", record.K8S.DestinationServicePortName)
-		return
-	}
+	namespacedName, _, _ := strings.Cut(record.K8S.DestinationServicePortName, ":")
 	service, exist := fa.serviceStore.GetServiceByNamespacedNameAndTime(namespacedName, startTime)
 	if !exist {
 		klog.ErrorS(nil, "Cannot find Service information", "name", namespacedName, "flowStartTime", startTime)


### PR DESCRIPTION
After PR #7371, third-party code no longer includes a ":" in ServicePortName
when the port name is not defined. This caused FlowAggregator to skip filling
the Service UID, resulting in exported flows missing Service UID information.

This change allows ServicePortName values without a port name to be parsed
correctly while preserving existing behavior.

The changed codes are from this file:
https://github.com/antrea-io/antrea/pull/7371/files#diff-a1dbf180227b6ab6978f90bf069c68a5edb01d485e7d11c06197589ce41a927bR83