### PR TITLE
Automated cherry pick of #7681: Fix fillServiceUID to support services without port name

### DIFF
--- a/pkg/flowaggregator/flowaggregator.go
+++ b/pkg/flowaggregator/flowaggregator.go
@@ -676,11 +676,7 @@ func (fa *flowAggregator) fillServiceUID(record *flowpb.Flow, startTime time.Tim
 	if record.K8S.DestinationServicePortName == "" {
 		return
 	}
-	namespacedName, _, found := strings.Cut(record.K8S.DestinationServicePortName, ":")
-	if !found {
-		klog.ErrorS(nil, "Expected format for ServicePortName", "servicePortName", record.K8S.DestinationServicePortName)
-		return
-	}
+	namespacedName, _, _ := strings.Cut(record.K8S.DestinationServicePortName, ":")
 	service, exist := fa.serviceStore.GetServiceByNamespacedNameAndTime(namespacedName, startTime)
 	if !exist {
 		klog.ErrorS(nil, "Cannot find Service information", "name", namespacedName, "flowStartTime", startTime)

--- a/pkg/flowaggregator/flowaggregator_test.go
+++ b/pkg/flowaggregator/flowaggregator_test.go
@@ -52,6 +52,7 @@ import (
 	"antrea.io/antrea/pkg/flowaggregator/querier"
 	"antrea.io/antrea/pkg/ipfix"
 	ipfixtesting "antrea.io/antrea/pkg/ipfix/testing"
+	"antrea.io/antrea/pkg/util/k8s"
 	objectstoretest "antrea.io/antrea/pkg/util/objectstore/testing"
 )
 
@@ -1146,6 +1147,78 @@ func TestNewFlowAggregator(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, clusterUUID, fa.clusterUUID)
 			assert.Equal(t, clusterID, fa.clusterID)
+		})
+	}
+}
+
+func TestFillServiceUID(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name               string
+		servicePortName    string
+		service            *v1.Service
+		exists             bool
+		expectedServiceUID string
+	}{
+		{
+			name:               "empty DestinationServicePortName",
+			servicePortName:    "",
+			expectedServiceUID: "",
+		},
+		{
+			name:            "service exists with port name",
+			servicePortName: "default/nginx:http",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nginx",
+					Namespace: "default",
+					UID:       "svc-uid",
+				},
+			},
+			exists:             true,
+			expectedServiceUID: "svc-uid",
+		},
+		{
+			name:            "service exists without port name",
+			servicePortName: "default/nginx",
+			service: &v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					UID:       "svc-uid",
+					Namespace: "default",
+					Name:      "nginx",
+				},
+			},
+			exists:             true,
+			expectedServiceUID: "svc-uid",
+		},
+		{
+			name:               "service not found",
+			servicePortName:    "default/nginx:http",
+			exists:             false,
+			expectedServiceUID: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockServiceStore := objectstoretest.NewMockServiceStore(ctrl)
+			newFlowAggregator := &flowAggregator{
+				serviceStore: mockServiceStore,
+			}
+
+			record := &flowpb.Flow{
+				K8S: &flowpb.Kubernetes{
+					DestinationServicePortName: tt.servicePortName,
+				},
+			}
+			if tt.exists {
+				mockServiceStore.EXPECT().GetServiceByNamespacedNameAndTime(k8s.NamespacedName(tt.service.Namespace, tt.service.Name), gomock.Any()).Return(tt.service, true)
+			} else if tt.servicePortName != "" {
+				mockServiceStore.EXPECT().GetServiceByNamespacedNameAndTime(gomock.Any(), gomock.Any()).Return(nil, false)
+			}
+			newFlowAggregator.fillServiceUID(record, now)
+			assert.Equal(t, tt.expectedServiceUID, record.K8S.DestinationServiceUid)
 		})
 	}
 }


### PR DESCRIPTION
Cherry pick of #7681 on release-2.5.

#7681: Fix fillServiceUID to support services without port name

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.