### PR TITLE
Automated cherry pick of #7547: Include nftables information in Agent supportbundle (#7547)

### DIFF
--- a/pkg/support/dump_others_test.go
+++ b/pkg/support/dump_others_test.go
@@ -18,6 +18,7 @@
 package support
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -27,6 +28,8 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/utils/exec"
+	testingexec "k8s.io/utils/exec/testing"
 )
 
 func TestDumpLog(t *testing.T) {
@@ -48,4 +51,111 @@ func TestDumpLog(t *testing.T) {
 	ok, err = afero.Exists(fs, filepath.Join(baseDir, "logs", "ovs", "ovs.log"))
 	require.NoError(t, err)
 	assert.True(t, ok)
+}
+
+func TestDumpNFTables(t *testing.T) {
+	const nftOutput = `table ip antrea { 
+	chain antrea-chain { 
+		type filter hook input priority 0; 
+	} 
+}`
+
+	errorAction := func() ([]byte, []byte, error) {
+		return nil, nil, fmt.Errorf("error")
+	}
+	successAction := func() ([]byte, []byte, error) {
+		return []byte(nftOutput), nil, nil
+	}
+	emptySuccessAction := func() ([]byte, []byte, error) {
+		return []byte(""), nil, nil
+	}
+
+	originalV4Check := nftablesIPv4Supported
+	originalV6Check := nftablesIPv6Supported
+	nftablesIPv4Supported = func() bool { return true }
+	nftablesIPv6Supported = func() bool { return true }
+	t.Cleanup(func() {
+		nftablesIPv4Supported = originalV4Check
+		nftablesIPv6Supported = originalV6Check
+	})
+
+	tests := []struct {
+		name            string
+		commandActions  []testingexec.FakeCommandAction
+		expectedContent string
+		expectFile      bool
+		expectedErr     string
+	}{
+		{
+			name: "dump succeeds and writes nftables file",
+			commandActions: []testingexec.FakeCommandAction{
+				func(cmd string, args ...string) exec.Cmd {
+					return &testingexec.FakeCmd{
+						CombinedOutputScript: []testingexec.FakeAction{successAction},
+					}
+				},
+			},
+			expectedContent: nftOutput + "\n",
+			expectFile:      true,
+		},
+		{
+			name: "command failure returns error and no file is written",
+			commandActions: []testingexec.FakeCommandAction{
+				func(cmd string, args ...string) exec.Cmd {
+					return &testingexec.FakeCmd{
+						CombinedOutputScript: []testingexec.FakeAction{errorAction},
+					}
+				},
+			},
+			expectFile:  false,
+			expectedErr: "failed to dump nftables: error",
+		},
+		{
+			name: "empty nft output does not create file",
+			commandActions: []testingexec.FakeCommandAction{
+				func(cmd string, args ...string) exec.Cmd {
+					return &testingexec.FakeCmd{
+						CombinedOutputScript: []testingexec.FakeAction{emptySuccessAction},
+					}
+				},
+			},
+			expectFile: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fs := afero.NewMemMapFs()
+			fs.MkdirAll(baseDir, os.ModePerm)
+
+			fakeExecutor := &testingexec.FakeExec{}
+			fakeExecutor.CommandScript = tc.commandActions
+
+			dumper := &agentDumper{
+				fs:        fs,
+				executor:  fakeExecutor,
+				v4Enabled: true,
+				v6Enabled: true,
+			}
+
+			err := dumper.dumpNFTables(baseDir)
+
+			if tc.expectedErr != "" {
+				assert.ErrorContains(t, err, tc.expectedErr)
+			} else {
+				require.NoError(t, err)
+			}
+
+			filePath := filepath.Join(baseDir, "nftables")
+			ok, err := afero.Exists(fs, filePath)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectFile, ok, "Expected nftables file existence to be %t", tc.expectFile)
+
+			if tc.expectFile {
+				content, err := afero.ReadFile(fs, filePath)
+				require.NoError(t, err)
+				assert.Equal(t, tc.expectedContent, string(content), "File content does not match")
+			}
+		})
+	}
 }


### PR DESCRIPTION
Cherry pick of #7547 on release-2.5.

#7547: Include nftables information in Agent supportbundle (#7547)

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.