### PR TITLE
Fix incorrect configmap name for FA deployment

### DIFF
--- a/build/charts/flow-aggregator/templates/deployment.yaml
+++ b/build/charts/flow-aggregator/templates/deployment.yaml
@@ -80,7 +80,7 @@ spec:
                 name: clickhouse-secret
                 key: password
           - name: FA_CONFIG_MAP_NAME
-            value: flow-aggregator-configmap
+            value: {{ include "flow-aggregator.fullname" . }}-configmap
           - name: AWS_ACCESS_KEY_ID
             valueFrom:
               secretKeyRef:

--- a/hack/generate-manifest-flow-aggregator.sh
+++ b/hack/generate-manifest-flow-aggregator.sh
@@ -20,8 +20,8 @@ function echoerr {
     >&2 echo "$@"
 }
 
-_usage="Usage: $0 [--mode (dev|release)] [-n|--namespace <namespace>] [-fc|--flow-collector <addr>] [-ch|--clickhouse] [--verbose-log] [--help|-h]
-Generate a YAML manifest for the Flow Aggregator, using Helm and Kustomize, and print it to stdout.
+_usage="Usage: $0 [--mode (dev|release)] [--release-name <name>] [-n|--namespace <namespace>] [-fc|--flow-collector <addr>] [-ch|--clickhouse] [--verbose-log] [--help|-h]
+Generate a YAML manifest for the Flow Aggregator using Helm, and print it to stdout.
         --mode (dev|release)            Choose the configuration variant that you need (default is 'dev').
         --release-name <name>           Specify the release name for the generated resources. (default is 'flow-aggregator')
         --namespace, -n <namespace>     Specify the namespace for the generated resources. (default is 'flow-aggregator')


### PR DESCRIPTION
Follow-up on #7670 to fix a missed template for `ConfigMap` name in FA's Deployment.