### PR TITLE
Refactor TestIPsecCertificateApproverAndSigner for speed

### DIFF
--- a/pkg/controller/certificatesigningrequest/ipsec_csr_signing_controller.go
+++ b/pkg/controller/certificatesigningrequest/ipsec_csr_signing_controller.go
@@ -108,9 +108,15 @@ func (c *certificateAuthority) signCSR(template *x509.Certificate, requestKey cr
 	return certs[0], nil
 }
 
-// NewIPsecCSRSigningController returns a new *IPsecCSRSigningController.
-func NewIPsecCSRSigningController(client clientset.Interface, csrInformer cache.SharedIndexInformer, csrLister csrlister.CertificateSigningRequestLister, selfSignedCA bool) *IPsecCSRSigningController {
-
+// newIPsecCSRSigningController supports setting minRetryDelay and maxRetryDelay to non-default
+// values for testing.
+func newIPsecCSRSigningController(
+	client clientset.Interface,
+	csrInformer cache.SharedIndexInformer,
+	csrLister csrlister.CertificateSigningRequestLister,
+	selfSignedCA bool,
+	minRetryDelay, maxRetryDelay time.Duration,
+) *IPsecCSRSigningController {
 	caConfigMapInformer := corev1informers.NewFilteredConfigMapInformer(client, env.GetAntreaNamespace(), resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, func(listOptions *metav1.ListOptions) {
 		listOptions.FieldSelector = fields.OneTermEqualSelector("metadata.name", ipsecRootCAName).String()
 	})
@@ -166,6 +172,16 @@ func NewIPsecCSRSigningController(client clientset.Interface, csrInformer cache.
 	)
 
 	return c
+}
+
+// NewIPsecCSRSigningController returns a new *IPsecCSRSigningController.
+func NewIPsecCSRSigningController(
+	client clientset.Interface,
+	csrInformer cache.SharedIndexInformer,
+	csrLister csrlister.CertificateSigningRequestLister,
+	selfSignedCA bool,
+) *IPsecCSRSigningController {
+	return newIPsecCSRSigningController(client, csrInformer, csrLister, selfSignedCA, minRetryDelay, maxRetryDelay)
 }
 
 // Run begins watching and syncing of the IPsecCSRSigningController.

--- a/pkg/controller/certificatesigningrequest/ipsec_csr_signing_controller_test.go
+++ b/pkg/controller/certificatesigningrequest/ipsec_csr_signing_controller_test.go
@@ -34,6 +34,7 @@ import (
 )
 
 func TestIPsecCertificateApproverAndSigner(t *testing.T) {
+	t.Setenv("POD_NAMESPACE", "kube-system")
 	validX509CertificateRequest := x509.CertificateRequest{
 		Subject: pkix.Name{
 			Organization: []string{"antrea.io"},
@@ -42,99 +43,83 @@ func TestIPsecCertificateApproverAndSigner(t *testing.T) {
 		DNSNames: []string{"worker-node-1"},
 	}
 	_, crBytes := x509CRtoPEM(t, &validX509CertificateRequest)
-	tests := []struct {
-		name                             string
-		objects                          []runtime.Object
-		csr                              *certificatesv1.CertificateSigningRequest
-		expectedError                    error
-		expectedApproved, expectedDenied bool
-	}{
-		{
-			name: "verify and sign valid IPsec CSR",
-			objects: []runtime.Object{
-				&corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "worker-node-1",
-					},
-				},
-				&corev1.Pod{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "kube-system",
-						Name:      "antrea-agent-8r5f9",
-						UID:       "1206ba75-7d75-474c-8110-99255502178c",
-					},
-					Spec: corev1.PodSpec{
-						NodeName: "worker-node-1",
-					},
-				},
+	objects := []runtime.Object{
+		&corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "worker-node-1",
 			},
-			csr: &certificatesv1.CertificateSigningRequest{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "worker-node-1-ipsec",
-				},
-				Spec: certificatesv1.CertificateSigningRequestSpec{
-					Request:    crBytes,
-					SignerName: "antrea.io/antrea-agent-ipsec-tunnel",
-					Extra: map[string]certificatesv1.ExtraValue{
-						"authentication.kubernetes.io/pod-name": {"antrea-agent-8r5f9"},
-						"authentication.kubernetes.io/pod-uid":  {"1206ba75-7d75-474c-8110-99255502178c"},
-					},
-					Usages: []certificatesv1.KeyUsage{
-						certificatesv1.UsageIPsecTunnel,
-					},
-					Username: "system:serviceaccount:kube-system:antrea-agent",
-				},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "kube-system",
+				Name:      "antrea-agent-8r5f9",
+				UID:       "1206ba75-7d75-474c-8110-99255502178c",
 			},
-			expectedApproved: true,
-			expectedDenied:   false,
+			Spec: corev1.PodSpec{
+				NodeName: "worker-node-1",
+			},
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			clientset := fake.NewSimpleClientset(tt.objects...)
-			informerFactory := informers.NewSharedInformerFactory(clientset, 0)
-			stopCh := make(chan struct{})
-			defer close(stopCh)
-			csrInformer := informerFactory.Certificates().V1().CertificateSigningRequests()
-
-			approvingController := NewCSRApprovingController(clientset, csrInformer.Informer(), csrInformer.Lister())
-			signingController := NewIPsecCSRSigningController(clientset, csrInformer.Informer(), csrInformer.Lister(), true)
-
-			informerFactory.Start(stopCh)
-			informerFactory.WaitForCacheSync(stopCh)
-
-			go approvingController.Run(stopCh)
-			go signingController.Run(stopCh)
-
-			csr, err := clientset.CertificatesV1().CertificateSigningRequests().Create(context.TODO(), tt.csr, metav1.CreateOptions{})
-			require.NoError(t, err)
-			err = wait.PollUntilContextTimeout(context.Background(), 200*time.Millisecond, 10*time.Second, true,
-				func(ctx context.Context) (done bool, err error) {
-					csr, err = clientset.CertificatesV1().CertificateSigningRequests().Get(context.TODO(), tt.csr.Name, metav1.GetOptions{})
-					require.NoError(t, err)
-					if !isCertificateRequestApproved(csr) {
-						return false, nil
-					}
-					if len(csr.Status.Certificate) == 0 {
-						return false, nil
-					}
-					return true, nil
-				})
-			require.NoError(t, err)
-			issued := csr.Status.Certificate
-			parsed, err := certutil.ParseCertsPEM(issued)
-			assert.NoError(t, err)
-			require.Len(t, parsed, 1)
-			roots := x509.NewCertPool()
-			roots.AddCert(signingController.certificateAuthority.Load().(*certificateAuthority).Certificate)
-			verifyOptions := x509.VerifyOptions{
-				Roots: roots,
-				KeyUsages: []x509.ExtKeyUsage{
-					x509.ExtKeyUsageIPSECTunnel,
-				},
-			}
-			_, err = parsed[0].Verify(verifyOptions)
-			assert.NoError(t, err)
-		})
+	csr := &certificatesv1.CertificateSigningRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "worker-node-1-ipsec",
+		},
+		Spec: certificatesv1.CertificateSigningRequestSpec{
+			Request:    crBytes,
+			SignerName: "antrea.io/antrea-agent-ipsec-tunnel",
+			Extra: map[string]certificatesv1.ExtraValue{
+				"authentication.kubernetes.io/pod-name": {"antrea-agent-8r5f9"},
+				"authentication.kubernetes.io/pod-uid":  {"1206ba75-7d75-474c-8110-99255502178c"},
+			},
+			Usages: []certificatesv1.KeyUsage{
+				certificatesv1.UsageIPsecTunnel,
+			},
+			Username: "system:serviceaccount:kube-system:antrea-agent",
+		},
 	}
+
+	clientset := fake.NewSimpleClientset(objects...)
+	informerFactory := informers.NewSharedInformerFactory(clientset, 0)
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	csrInformer := informerFactory.Certificates().V1().CertificateSigningRequests()
+
+	approvingController := NewCSRApprovingController(clientset, csrInformer.Informer(), csrInformer.Lister())
+	signingController := newIPsecCSRSigningController(clientset, csrInformer.Informer(), csrInformer.Lister(), true, 1*time.Second, maxRetryDelay)
+
+	informerFactory.Start(stopCh)
+	informerFactory.WaitForCacheSync(stopCh)
+
+	go approvingController.Run(stopCh)
+	go signingController.Run(stopCh)
+
+	csr, err := clientset.CertificatesV1().CertificateSigningRequests().Create(t.Context(), csr, metav1.CreateOptions{})
+	require.NoError(t, err)
+	err = wait.PollUntilContextTimeout(t.Context(), 200*time.Millisecond, 5*time.Second, true,
+		func(ctx context.Context) (done bool, err error) {
+			csr, err = clientset.CertificatesV1().CertificateSigningRequests().Get(t.Context(), csr.Name, metav1.GetOptions{})
+			require.NoError(t, err)
+			if !isCertificateRequestApproved(csr) {
+				return false, nil
+			}
+			if len(csr.Status.Certificate) == 0 {
+				return false, nil
+			}
+			return true, nil
+		})
+	require.NoError(t, err)
+	issued := csr.Status.Certificate
+	parsed, err := certutil.ParseCertsPEM(issued)
+	assert.NoError(t, err)
+	require.Len(t, parsed, 1)
+	roots := x509.NewCertPool()
+	roots.AddCert(signingController.certificateAuthority.Load().(*certificateAuthority).Certificate)
+	verifyOptions := x509.VerifyOptions{
+		Roots: roots,
+		KeyUsages: []x509.ExtKeyUsage{
+			x509.ExtKeyUsageIPSECTunnel,
+		},
+	}
+	_, err = parsed[0].Verify(verifyOptions)
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
Simplified the test by removing unnecessary table-driven test structure since only one test case exists. Reduced test execution time by lowering timeout from 10s to 5s and making retry delays configurable through a new internal constructor function.

Set POD_NAMESPACE env variable in test to avoid log spam.