### PR TITLE
Fix out-of-date generated code

### DIFF
--- a/pkg/apiserver/openapi/zz_generated.openapi.go
+++ b/pkg/apiserver/openapi/zz_generated.openapi.go
@@ -4166,7 +4166,7 @@ func schema_pkg_apis_crd_v1beta1_GroupSpec(ref common.ReferenceCallback) common.
 					"nodeSelector": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Select Nodes matched by this selector as workloads in AppliedTo/To/From fields. Cannot be set with any other selector or ServiceReference",
-							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelector"),
+							Ref:         ref(metav1.LabelSelector{}.OpenAPIModelName()),
 						},
 					},
 					"ipBlocks": {


### PR DESCRIPTION
One generated file was out-of-date, probably because of 2 concurrent PRs: #7344 and #7668. I ran `make codegen` and committed the results.