### PR TITLE
feat(packetcapture): add tcpdump output parser for BPF test validation

### DIFF
--- a/pkg/agent/packetcapture/capture/tcpdump_parser.go
+++ b/pkg/agent/packetcapture/capture/tcpdump_parser.go
@@ -1,0 +1,150 @@
+// Copyright 2024 Antrea Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package capture
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"golang.org/x/net/bpf"
+)
+
+// instructionParser defines how to match and parse a single tcpdump instruction line.
+type instructionParser struct {
+	pattern *regexp.Regexp
+	parse   func(matches []string) (bpf.Instruction, error)
+}
+
+var instructionParsers = []instructionParser{
+	// LoadAbsolute: ld/ldh/ldb [offset]
+	{
+		pattern: regexp.MustCompile(`^\((\d+)\)\s+(ld[bhw]?)\s+\[(\d+)\]$`),
+		parse: func(m []string) (bpf.Instruction, error) {
+			off, _ := strconv.ParseUint(m[3], 10, 32)
+			return bpf.LoadAbsolute{Off: uint32(off), Size: loadSize(m[2])}, nil
+		},
+	},
+	// LoadMemShift: ldxb 4*([offset]&0xf)
+	{
+		pattern: regexp.MustCompile(`^\((\d+)\)\s+ldxb\s+4\*\(\[(\d+)\]\&0xf\)$`),
+		parse: func(m []string) (bpf.Instruction, error) {
+			off, _ := strconv.ParseUint(m[2], 10, 32)
+			return bpf.LoadMemShift{Off: uint32(off)}, nil
+		},
+	},
+	// LoadIndirect: ld/ldh/ldb [x + offset]
+	{
+		pattern: regexp.MustCompile(`^\((\d+)\)\s+(ld[bhw]?)\s+\[x\s*\+\s*(\d+)\]$`),
+		parse: func(m []string) (bpf.Instruction, error) {
+			off, _ := strconv.ParseUint(m[3], 10, 32)
+			return bpf.LoadIndirect{Off: uint32(off), Size: loadSize(m[2])}, nil
+		},
+	},
+	// JumpIf Equal: jeq #val jt N jf M
+	{
+		pattern: regexp.MustCompile(`^\((\d+)\)\s+jeq\s+#(0x[0-9a-fA-F]+|\d+)\s+jt\s+(\d+)\s+jf\s+(\d+)$`),
+		parse: func(m []string) (bpf.Instruction, error) {
+			idx, _ := strconv.ParseUint(m[1], 10, 32)
+			jt, _ := strconv.ParseUint(m[3], 10, 32)
+			jf, _ := strconv.ParseUint(m[4], 10, 32)
+			return bpf.JumpIf{
+				Cond:      bpf.JumpEqual,
+				Val:       parseUint32(m[2]),
+				SkipTrue:  uint8(jt - idx - 1),
+				SkipFalse: uint8(jf - idx - 1),
+			}, nil
+		},
+	},
+	// JumpIf BitsSet: jset #val jt N jf M
+	{
+		pattern: regexp.MustCompile(`^\((\d+)\)\s+jset\s+#(0x[0-9a-fA-F]+|\d+)\s+jt\s+(\d+)\s+jf\s+(\d+)$`),
+		parse: func(m []string) (bpf.Instruction, error) {
+			idx, _ := strconv.ParseUint(m[1], 10, 32)
+			jt, _ := strconv.ParseUint(m[3], 10, 32)
+			jf, _ := strconv.ParseUint(m[4], 10, 32)
+			return bpf.JumpIf{
+				Cond:      bpf.JumpBitsSet,
+				Val:       parseUint32(m[2]),
+				SkipTrue:  uint8(jt - idx - 1),
+				SkipFalse: uint8(jf - idx - 1),
+			}, nil
+		},
+	},
+	// RetConstant: ret #val
+	{
+		pattern: regexp.MustCompile(`^\((\d+)\)\s+ret\s+#(\d+)$`),
+		parse: func(m []string) (bpf.Instruction, error) {
+			val, _ := strconv.ParseUint(m[2], 10, 32)
+			return bpf.RetConstant{Val: uint32(val)}, nil
+		},
+	},
+	// ALUOpConstant And: and #val
+	{
+		pattern: regexp.MustCompile(`^\((\d+)\)\s+and\s+#(0x[0-9a-fA-F]+|\d+)$`),
+		parse: func(m []string) (bpf.Instruction, error) {
+			return bpf.ALUOpConstant{Op: bpf.ALUOpAnd, Val: parseUint32(m[2])}, nil
+		},
+	},
+}
+
+// ParseTcpdumpOutput parses tcpdump -d output into BPF instructions.
+func ParseTcpdumpOutput(output string) ([]bpf.Instruction, error) {
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	instructions := make([]bpf.Instruction, 0, len(lines))
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		inst, err := parseLine(line)
+		if err != nil {
+			return nil, err
+		}
+		instructions = append(instructions, inst)
+	}
+	return instructions, nil
+}
+
+func parseLine(line string) (bpf.Instruction, error) {
+	for _, p := range instructionParsers {
+		if matches := p.pattern.FindStringSubmatch(line); matches != nil {
+			return p.parse(matches)
+		}
+	}
+	return nil, fmt.Errorf("unrecognized BPF instruction: %s", line)
+}
+
+func loadSize(op string) int {
+	switch op {
+	case "ldb":
+		return lengthByte
+	case "ldh":
+		return lengthHalf
+	default:
+		return lengthWord
+	}
+}
+
+func parseUint32(s string) uint32 {
+	if strings.HasPrefix(s, "0x") || strings.HasPrefix(s, "0X") {
+		val, _ := strconv.ParseUint(s[2:], 16, 32)
+		return uint32(val)
+	}
+	val, _ := strconv.ParseUint(s, 10, 32)
+	return uint32(val)
+}

--- a/pkg/agent/packetcapture/capture/tcpdump_parser_test.go
+++ b/pkg/agent/packetcapture/capture/tcpdump_parser_test.go
@@ -1,0 +1,183 @@
+// Copyright 2024 Antrea Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package capture
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/bpf"
+)
+
+func TestParseTcpdumpOutput(t *testing.T) {
+	tt := []struct {
+		name     string
+		input    string
+		expected []bpf.Instruction
+		wantErr  bool
+	}{
+		{
+			name: "simple-ipv4-tcp",
+			input: `(000) ldh      [12]
+(001) jeq      #0x800           jt 2    jf 8
+(002) ldb      [23]
+(003) jeq      #0x6             jt 4    jf 8
+(004) ld       [26]
+(005) jeq      #0x7f000001      jt 6    jf 8
+(006) ld       [30]
+(007) jeq      #0x7f000002      jt 9    jf 8
+(008) ret      #0
+(009) ret      #262144`,
+			expected: []bpf.Instruction{
+				bpf.LoadAbsolute{Off: 12, Size: lengthHalf},
+				bpf.JumpIf{Cond: bpf.JumpEqual, Val: 0x800, SkipTrue: 0, SkipFalse: 6},
+				bpf.LoadAbsolute{Off: 23, Size: lengthByte},
+				bpf.JumpIf{Cond: bpf.JumpEqual, Val: 0x6, SkipTrue: 0, SkipFalse: 4},
+				bpf.LoadAbsolute{Off: 26, Size: lengthWord},
+				bpf.JumpIf{Cond: bpf.JumpEqual, Val: 0x7f000001, SkipTrue: 0, SkipFalse: 2},
+				bpf.LoadAbsolute{Off: 30, Size: lengthWord},
+				bpf.JumpIf{Cond: bpf.JumpEqual, Val: 0x7f000002, SkipTrue: 1, SkipFalse: 0},
+				bpf.RetConstant{Val: 0},
+				bpf.RetConstant{Val: 262144},
+			},
+		},
+		{
+			name: "with-port-filter",
+			input: `(000) ldh      [12]
+(001) jeq      #0x800           jt 2    jf 10
+(002) ldb      [23]
+(003) jeq      #0x6             jt 4    jf 10
+(004) ldh      [20]
+(005) jset     #0x1fff          jt 10   jf 6
+(006) ldxb     4*([14]&0xf)
+(007) ldh      [x + 14]
+(008) jeq      #0x50            jt 11   jf 9
+(009) ldh      [x + 16]
+(010) jeq      #0x50            jt 11   jf 12
+(011) ret      #262144
+(012) ret      #0`,
+			expected: []bpf.Instruction{
+				bpf.LoadAbsolute{Off: 12, Size: lengthHalf},
+				bpf.JumpIf{Cond: bpf.JumpEqual, Val: 0x800, SkipTrue: 0, SkipFalse: 8},
+				bpf.LoadAbsolute{Off: 23, Size: lengthByte},
+				bpf.JumpIf{Cond: bpf.JumpEqual, Val: 0x6, SkipTrue: 0, SkipFalse: 6},
+				bpf.LoadAbsolute{Off: 20, Size: lengthHalf},
+				bpf.JumpIf{Cond: bpf.JumpBitsSet, Val: 0x1fff, SkipTrue: 4, SkipFalse: 0},
+				bpf.LoadMemShift{Off: 14},
+				bpf.LoadIndirect{Off: 14, Size: lengthHalf},
+				bpf.JumpIf{Cond: bpf.JumpEqual, Val: 0x50, SkipTrue: 2, SkipFalse: 0},
+				bpf.LoadIndirect{Off: 16, Size: lengthHalf},
+				bpf.JumpIf{Cond: bpf.JumpEqual, Val: 0x50, SkipTrue: 0, SkipFalse: 1},
+				bpf.RetConstant{Val: 262144},
+				bpf.RetConstant{Val: 0},
+			},
+		},
+		{
+			name:     "empty-input",
+			input:    "",
+			expected: []bpf.Instruction{},
+		},
+	}
+
+	for _, item := range tt {
+		t.Run(item.name, func(t *testing.T) {
+			result, err := ParseTcpdumpOutput(item.input)
+			if item.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, item.expected, result)
+		})
+	}
+}
+
+func TestParseLine(t *testing.T) {
+	tt := []struct {
+		name     string
+		line     string
+		expected bpf.Instruction
+		wantErr  bool
+	}{
+		{
+			name:     "ldh-absolute",
+			line:     "(000) ldh      [12]",
+			expected: bpf.LoadAbsolute{Off: 12, Size: lengthHalf},
+		},
+		{
+			name:     "ldb-absolute",
+			line:     "(002) ldb      [23]",
+			expected: bpf.LoadAbsolute{Off: 23, Size: lengthByte},
+		},
+		{
+			name:     "ld-absolute",
+			line:     "(004) ld       [26]",
+			expected: bpf.LoadAbsolute{Off: 26, Size: lengthWord},
+		},
+		{
+			name:     "ldxb-memshift",
+			line:     "(006) ldxb     4*([14]&0xf)",
+			expected: bpf.LoadMemShift{Off: 14},
+		},
+		{
+			name:     "ldh-indirect",
+			line:     "(007) ldh      [x + 14]",
+			expected: bpf.LoadIndirect{Off: 14, Size: lengthHalf},
+		},
+		{
+			name:     "jeq-hex",
+			line:     "(001) jeq      #0x800           jt 2    jf 16",
+			expected: bpf.JumpIf{Cond: bpf.JumpEqual, Val: 0x800, SkipTrue: 0, SkipFalse: 14},
+		},
+		{
+			name:     "jset",
+			line:     "(009) jset     #0x1fff          jt 16   jf 10",
+			expected: bpf.JumpIf{Cond: bpf.JumpBitsSet, Val: 0x1fff, SkipTrue: 6, SkipFalse: 0},
+		},
+		{
+			name:     "ret-match",
+			line:     "(015) ret      #262144",
+			expected: bpf.RetConstant{Val: 262144},
+		},
+		{
+			name:     "ret-drop",
+			line:     "(016) ret      #0",
+			expected: bpf.RetConstant{Val: 0},
+		},
+		{
+			name:     "alu-and",
+			line:     "(012) and      #0x2",
+			expected: bpf.ALUOpConstant{Op: bpf.ALUOpAnd, Val: 0x2},
+		},
+		{
+			name:    "invalid",
+			line:    "garbage input",
+			wantErr: true,
+		},
+	}
+
+	for _, item := range tt {
+		t.Run(item.name, func(t *testing.T) {
+			result, err := parseLine(item.line)
+			if item.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, item.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does

Adds a parser to convert `tcpdump -d` output into `golang.org/x/net/bpf` instructions. This enables future work to validate Antrea's BPF generation against tcpdump's reference implementation.

## Design

- Table-driven parser with regex patterns for each instruction type
- Reuses existing `lengthByte/lengthHalf/lengthWord` constants
- Handles: LoadAbsolute, LoadIndirect, LoadMemShift, JumpIf, RetConstant, ALUOpConstant

## Testing

- Added `TestParseTcpdumpOutput` for full output parsing
- Added `TestParseLine` for individual instruction parsing

Related-to: #7701