### PR TITLE
Add LICENSE file to published Docker images

### DIFF
--- a/build/images/Dockerfile.agent.ubuntu
+++ b/build/images/Dockerfile.agent.ubuntu
@@ -25,3 +25,5 @@ COPY bin/antrea-agent /usr/local/bin/
 COPY bin/antrea-cni /usr/local/bin/
 COPY bin/antctl /usr/local/bin/
 COPY bin/antrea-sysctl-init /usr/local/bin/
+
+COPY LICENSE /LICENSE

--- a/build/images/Dockerfile.build.agent.ubi
+++ b/build/images/Dockerfile.build.agent.ubi
@@ -45,3 +45,5 @@ COPY --from=antrea-build /antrea/bin/antrea-agent /usr/local/bin/
 COPY --from=antrea-build /antrea/bin/antrea-cni /usr/local/bin/
 COPY --from=antrea-build /antrea/bin/antctl /usr/local/bin/
 COPY --from=antrea-build /antrea/bin/antrea-sysctl-init /usr/local/bin/
+
+COPY LICENSE /LICENSE

--- a/build/images/Dockerfile.build.agent.ubuntu
+++ b/build/images/Dockerfile.build.agent.ubuntu
@@ -45,3 +45,5 @@ COPY --from=antrea-build /antrea/bin/antrea-agent /usr/local/bin/
 COPY --from=antrea-build /antrea/bin/antrea-cni /usr/local/bin/
 COPY --from=antrea-build /antrea/bin/antctl /usr/local/bin/
 COPY --from=antrea-build /antrea/bin/antrea-sysctl-init /usr/local/bin/
+
+COPY LICENSE /LICENSE

--- a/build/images/Dockerfile.build.controller.ubi
+++ b/build/images/Dockerfile.build.controller.ubi
@@ -41,3 +41,5 @@ USER root
 
 COPY --from=antrea-build /antrea/bin/antctl /usr/local/bin/
 COPY --from=antrea-build /antrea/bin/antrea-controller /usr/local/bin/
+
+COPY LICENSE /LICENSE

--- a/build/images/Dockerfile.build.controller.ubuntu
+++ b/build/images/Dockerfile.build.controller.ubuntu
@@ -41,3 +41,5 @@ USER root
 
 COPY --from=antrea-build /antrea/bin/antctl /usr/local/bin/
 COPY --from=antrea-build /antrea/bin/antrea-controller /usr/local/bin/
+
+COPY LICENSE /LICENSE

--- a/build/images/Dockerfile.build.migrator
+++ b/build/images/Dockerfile.build.migrator
@@ -34,4 +34,6 @@ RUN apt update \
 
 COPY --from=registry.k8s.io/pause:latest /pause /pause
 
+COPY LICENSE /LICENSE
+
 CMD ["/pause"]

--- a/build/images/Dockerfile.build.windows
+++ b/build/images/Dockerfile.build.windows
@@ -50,4 +50,6 @@ FROM mcr.microsoft.com/oss/kubernetes/windows-host-process-containers-base-image
 COPY --from=antrea-build-windows /go/k /k
 COPY --from=antrea-ovs /openvswitch /openvswitch
 
+COPY LICENSE /LICENSE
+
 ENV PATH="C:\Windows\system32;C:\Windows;C:\WINDOWS\System32\WindowsPowerShell\v1.0\;C:\Windows\System32\wbem;"

--- a/build/images/Dockerfile.controller.ubuntu
+++ b/build/images/Dockerfile.controller.ubuntu
@@ -21,3 +21,5 @@ USER root
 
 COPY bin/antrea-controller /usr/local/bin/
 COPY bin/antctl /usr/local/bin/
+
+COPY LICENSE /LICENSE

--- a/build/images/Dockerfile.simulator.build.ubuntu
+++ b/build/images/Dockerfile.simulator.build.ubuntu
@@ -34,4 +34,4 @@ LABEL description="The Docker image to deploy the Antrea simulator."
 USER root
 
 COPY --from=antrea-build /antrea/bin/* /usr/local/bin/
-
+COPY LICENSE /LICENSE

--- a/build/images/flow-aggregator/Dockerfile
+++ b/build/images/flow-aggregator/Dockerfile
@@ -47,4 +47,6 @@ RUN apt-get update \
 COPY --from=flow-aggregator-build /antrea/bin/flow-aggregator /
 COPY --from=flow-aggregator-build /antrea/bin/antctl /usr/local/bin/
 
+COPY LICENSE /LICENSE
+
 ENTRYPOINT ["/flow-aggregator"]

--- a/multicluster/build/images/Dockerfile
+++ b/multicluster/build/images/Dockerfile
@@ -20,3 +20,4 @@ LABEL description="The Docker image to deploy the Antrea Multi-cluster Controlle
 USER root
 
 COPY multicluster/bin/antrea-mc-controller /
+COPY LICENSE /LICENSE

--- a/multicluster/build/images/Dockerfile.build
+++ b/multicluster/build/images/Dockerfile.build
@@ -36,3 +36,4 @@ LABEL description="The Docker image to deploy the Antrea Multi-cluster Controlle
 USER root
 
 COPY --from=antrea-build /antrea/multicluster/bin/antrea-mc-controller /
+COPY LICENSE /LICENSE


### PR DESCRIPTION
Currently, the published Antrea Docker images (agent, controller) do not contain the LICENSE file. This commit adds COPY LICENSE instruction to all Dockerfiles for distributed images.

Fixes #7656