### PR TITLE
fix: update StateResCleanupController for accessing the controller-runtime for leaders and member controllers

### DIFF
--- a/multicluster/cmd/multicluster-controller/leader.go
+++ b/multicluster/cmd/multicluster-controller/leader.go
@@ -119,6 +119,7 @@ func runLeader(o *Options) error {
 	staleController := leader.NewStaleResCleanupController(
 		mgr.GetClient(),
 		mgr.GetScheme(),
+		mgr.GetCache(),
 	)
 	if err = staleController.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("error creating StaleResCleanupController: %v", err)

--- a/multicluster/cmd/multicluster-controller/member.go
+++ b/multicluster/cmd/multicluster-controller/member.go
@@ -140,6 +140,7 @@ func runMember(o *Options) error {
 		commonAreaCreationCh,
 		env.GetPodNamespace(),
 		commonAreaGetter,
+		mgr.GetCache(),
 	)
 
 	go staleController.Run(stopCh)

--- a/multicluster/controllers/multicluster/leader/stale_controller_test.go
+++ b/multicluster/controllers/multicluster/leader/stale_controller_test.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache/informertest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -123,7 +124,7 @@ func TestReconcile(t *testing.T) {
 			}()
 			fakeClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithLists(tt.existingResExports).
 				WithObjects(tt.existingMemberAnnounce).WithStatusSubresource(tt.existingMemberAnnounce).Build()
-			c := NewStaleResCleanupController(fakeClient, common.TestScheme)
+			c := NewStaleResCleanupController(fakeClient, common.TestScheme, &informertest.FakeInformers{})
 			ctx := context.Background()
 			_, err := c.Reconcile(ctx, ctrl.Request{
 				NamespacedName: types.NamespacedName{
@@ -230,7 +231,7 @@ func TestStaleController_CleanUpMemberClusterAnnounces(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithLists(tt.memberClusterAnnounceList).WithLists(tt.clusterSet).Build()
-			c := NewStaleResCleanupController(fakeClient, common.TestScheme)
+			c := NewStaleResCleanupController(fakeClient, common.TestScheme, &informertest.FakeInformers{})
 			c.cleanUpExpiredMemberClusterAnnounces(ctx)
 
 			memberClusterAnnounceList := &mcv1alpha1.MemberClusterAnnounceList{}

--- a/multicluster/controllers/multicluster/member/resourceimport_controller_test.go
+++ b/multicluster/controllers/multicluster/member/resourceimport_controller_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache/informertest"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	k8smcsapi "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 
@@ -546,7 +547,7 @@ func TestStaleControllerNoRaceWithResourceImportReconciler(t *testing.T) {
 
 	mcReconciler := NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", true, false, make(chan struct{}))
 	mcReconciler.SetRemoteCommonArea(ca)
-	c := NewStaleResCleanupController(fakeClient, common.TestScheme, make(chan struct{}), "default", mcReconciler)
+	c := NewStaleResCleanupController(fakeClient, common.TestScheme, make(chan struct{}), "default", mcReconciler, &informertest.FakeInformers{})
 	go func() {
 		c.commonAreaCreationCh <- struct{}{}
 	}()

--- a/multicluster/controllers/multicluster/member/stale_controller_test.go
+++ b/multicluster/controllers/multicluster/member/stale_controller_test.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/cache/informertest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	k8smcv1alpha1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
@@ -106,7 +107,7 @@ func TestStaleController_CleanUpService(t *testing.T) {
 			commonArea := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", common.LocalClusterID, "default", nil)
 			mcReconciler := NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false, false, make(chan struct{}))
 			mcReconciler.SetRemoteCommonArea(commonArea)
-			c := NewStaleResCleanupController(fakeClient, common.TestScheme, make(chan struct{}), "default", mcReconciler)
+			c := NewStaleResCleanupController(fakeClient, common.TestScheme, make(chan struct{}), "default", mcReconciler, &informertest.FakeInformers{})
 			if err := c.cleanUpStaleResources(ctx); err != nil {
 				t.Errorf("StaleController.cleanup() should clean up all stale Service and ServiceImport but got err = %v", err)
 			}
@@ -201,7 +202,7 @@ func TestStaleController_CleanUpACNP(t *testing.T) {
 
 			mcReconciler := NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false, false, make(chan struct{}))
 			mcReconciler.SetRemoteCommonArea(commonArea)
-			c := NewStaleResCleanupController(fakeClient, common.TestScheme, make(chan struct{}), "default", mcReconciler)
+			c := NewStaleResCleanupController(fakeClient, common.TestScheme, make(chan struct{}), "default", mcReconciler, &informertest.FakeInformers{})
 			if err := c.cleanUpStaleResources(ctx); err != nil {
 				t.Errorf("StaleController.cleanup() should clean up all stale ACNPs but got err = %v", err)
 			}
@@ -440,7 +441,7 @@ func TestStaleController_CleanUpResourceExports(t *testing.T) {
 
 			mcReconciler := NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false, false, make(chan struct{}))
 			mcReconciler.SetRemoteCommonArea(commonArea)
-			c := NewStaleResCleanupController(fakeClient, common.TestScheme, make(chan struct{}), "default", mcReconciler)
+			c := NewStaleResCleanupController(fakeClient, common.TestScheme, make(chan struct{}), "default", mcReconciler, &informertest.FakeInformers{})
 			if err := c.cleanUpStaleResources(ctx); err != nil {
 				t.Errorf("StaleController.cleanup() should clean up all stale ResourceExports but got err = %v", err)
 			}
@@ -517,7 +518,7 @@ func TestStaleController_CleanUpClusterInfoImports(t *testing.T) {
 
 			mcReconciler := NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false, false, make(chan struct{}))
 			mcReconciler.SetRemoteCommonArea(commonarea)
-			c := NewStaleResCleanupController(fakeClient, common.TestScheme, make(chan struct{}), "default", mcReconciler)
+			c := NewStaleResCleanupController(fakeClient, common.TestScheme, make(chan struct{}), "default", mcReconciler, &informertest.FakeInformers{})
 			if err := c.cleanUpStaleResources(ctx); err != nil {
 				t.Errorf("StaleController.cleanup() should clean up all stale ClusterInfoImport but got err = %v", err)
 			}
@@ -600,7 +601,7 @@ func TestStaleController_CleanUpLabelIdentites(t *testing.T) {
 
 			mcReconciler := NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false, false, make(chan struct{}))
 			mcReconciler.SetRemoteCommonArea(ca)
-			c := NewStaleResCleanupController(fakeClient, common.TestScheme, make(chan struct{}), "default", mcReconciler)
+			c := NewStaleResCleanupController(fakeClient, common.TestScheme, make(chan struct{}), "default", mcReconciler, &informertest.FakeInformers{})
 			if err := c.cleanUpStaleResources(ctx); err != nil {
 				t.Errorf("StaleController.cleanup() should clean up all stale LabelIdentities but got err = %v", err)
 			}
@@ -626,7 +627,7 @@ func TestStaleController_CleanupAllWithEmptyClusterSet(t *testing.T) {
 
 	mcReconciler := NewMemberClusterSetReconciler(fakeClient, common.TestScheme, "default", false, false, make(chan struct{}))
 	mcReconciler.SetRemoteCommonArea(commonarea)
-	c := NewStaleResCleanupController(fakeClient, common.TestScheme, make(chan struct{}), "default", mcReconciler)
+	c := NewStaleResCleanupController(fakeClient, common.TestScheme, make(chan struct{}), "default", mcReconciler, &informertest.FakeInformers{})
 	if err := c.CleanUp(ctx); err != nil {
 		t.Errorf("StaleController.cleanup() should clean up all stale resources but got err = %v", err)
 	}

--- a/multicluster/test/integration/suite_test.go
+++ b/multicluster/test/integration/suite_test.go
@@ -173,6 +173,7 @@ var _ = BeforeSuite(func() {
 		commonAreaCreationCh,
 		"default",
 		clusterSetReconciler,
+		k8sManager.GetCache(),
 	)
 
 	go staleController.Run(stopCh)


### PR DESCRIPTION
## Description
- Updated `StaleResCleanupController` for both leader and member controllers.
- Updated initialization code by passing `mgr.GetCache()` to the stale controller
- All updated test cases with this functionality pass succesfully

## Issue
fixes #6152 


## Proof Manifests:

update tests for resourceimportreconciler
```yaml
% go test -v ./multicluster/controllers/multicluster/member -run "TestResourceImportReconciler"                
=== RUN   TestResourceImportReconciler_handleCopySpanACNPCreateEvent
=== RUN   TestResourceImportReconciler_handleCopySpanACNPCreateEvent/import_ACNP_of_pre-defined_tiers
I0121 20:25:47.444220   22407 acnp_resourceimport_controller.go:54] "Updating ACNP corresponding to ResourceImport" acnp="/antrea-mc-acnp-for-isolation" resourceimport="default/default-acnp-for-isolation"
=== RUN   TestResourceImportReconciler_handleCopySpanACNPCreateEvent/import_ACNP_of_non-existing_tier
I0121 20:25:47.445324   22407 acnp_resourceimport_controller.go:54] "Updating ACNP corresponding to ResourceImport" acnp="/antrea-mc-acnp-no-matching-tier" resourceimport="default/default-acnp-no-matching-tier"
=== RUN   TestResourceImportReconciler_handleCopySpanACNPCreateEvent/import_ACNP_of_empty_spec
--- PASS: TestResourceImportReconciler_handleCopySpanACNPCreateEvent (0.00s)
    --- PASS: TestResourceImportReconciler_handleCopySpanACNPCreateEvent/import_ACNP_of_pre-defined_tiers (0.00s)
    --- PASS: TestResourceImportReconciler_handleCopySpanACNPCreateEvent/import_ACNP_of_non-existing_tier (0.00s)
    --- PASS: TestResourceImportReconciler_handleCopySpanACNPCreateEvent/import_ACNP_of_empty_spec (0.00s)
=== RUN   TestResourceImportReconciler_handleCopySpanACNPDeleteEvent
I0121 20:25:47.445720   22407 acnp_resourceimport_controller.go:115] "Deleting ACNP corresponding to ResourceImport" acnp="antrea-mc-acnp-for-isolation" resourceimport="default/default-acnp-for-isolation"
--- PASS: TestResourceImportReconciler_handleCopySpanACNPDeleteEvent (0.00s)
=== RUN   TestResourceImportReconciler_handleCopySpanACNPUpdateEvent
=== RUN   TestResourceImportReconciler_handleCopySpanACNPUpdateEvent/update_acnp_spec
I0121 20:25:47.445856   22407 acnp_resourceimport_controller.go:54] "Updating ACNP corresponding to ResourceImport" acnp="/antrea-mc-acnp-for-isolation" resourceimport="default/default-acnp-for-isolation"
=== RUN   TestResourceImportReconciler_handleCopySpanACNPUpdateEvent/imported_acnp_missing_tier_update_to_valid_tier
I0121 20:25:47.445954   22407 acnp_resourceimport_controller.go:54] "Updating ACNP corresponding to ResourceImport" acnp="/antrea-mc-acnp-no-matching-tier" resourceimport="default/default-acnp-no-matching-tier"
=== RUN   TestResourceImportReconciler_handleCopySpanACNPUpdateEvent/valid_imported_acnp_update_to_missing_tier
I0121 20:25:47.446016   22407 acnp_resourceimport_controller.go:54] "Updating ACNP corresponding to ResourceImport" acnp="/antrea-mc-acnp-for-isolation" resourceimport="default/default-valid-updated-to-no-valid"
=== RUN   TestResourceImportReconciler_handleCopySpanACNPUpdateEvent/name_conflict_with_existing_acnp
E0121 20:25:47.446072   22407 resourceimport_controller.go:112] "No cached data for ResourceImport" resourceimport="default/default-name-conflict"
--- PASS: TestResourceImportReconciler_handleCopySpanACNPUpdateEvent (0.00s)
    --- PASS: TestResourceImportReconciler_handleCopySpanACNPUpdateEvent/update_acnp_spec (0.00s)
    --- PASS: TestResourceImportReconciler_handleCopySpanACNPUpdateEvent/imported_acnp_missing_tier_update_to_valid_tier (0.00s)
    --- PASS: TestResourceImportReconciler_handleCopySpanACNPUpdateEvent/valid_imported_acnp_update_to_missing_tier (0.00s)
    --- PASS: TestResourceImportReconciler_handleCopySpanACNPUpdateEvent/name_conflict_with_existing_acnp (0.00s)
=== RUN   TestResourceImportReconciler_handleClusterInfo
=== RUN   TestResourceImportReconciler_handleClusterInfo/create_ClusterInfoImport_successfully
=== RUN   TestResourceImportReconciler_handleClusterInfo/skip_import_empty_ResourceImport
=== RUN   TestResourceImportReconciler_handleClusterInfo/skip_import_ResourceImport_from_local
=== RUN   TestResourceImportReconciler_handleClusterInfo/update_ClusterInfoImport_successfully
=== RUN   TestResourceImportReconciler_handleClusterInfo/delete_ClusterInfoImport_successfully
E0121 20:25:47.446408   22407 resourceimport_controller.go:112] "No cached data for ResourceImport" resourceimport="default/cluster-c-default-clusterinfo"
--- PASS: TestResourceImportReconciler_handleClusterInfo (0.00s)
    --- PASS: TestResourceImportReconciler_handleClusterInfo/create_ClusterInfoImport_successfully (0.00s)
    --- PASS: TestResourceImportReconciler_handleClusterInfo/skip_import_empty_ResourceImport (0.00s)
    --- PASS: TestResourceImportReconciler_handleClusterInfo/skip_import_ResourceImport_from_local (0.00s)
    --- PASS: TestResourceImportReconciler_handleClusterInfo/update_ClusterInfoImport_successfully (0.00s)
    --- PASS: TestResourceImportReconciler_handleClusterInfo/delete_ClusterInfoImport_successfully (0.00s)
=== RUN   TestResourceImportReconciler_handleCreateEvent
=== RUN   TestResourceImportReconciler_handleCreateEvent/import_Service
I0121 20:25:47.446582   22407 resourceimport_controller.go:145] "Updating Service and ServiceImport corresponding to ResourceImport" service="default/antrea-mc-nginx" serviceimport="default/nginx" resourceimport="default/default-nginx-service"
=== RUN   TestResourceImportReconciler_handleCreateEvent/import_Endpoints
I0121 20:25:47.446944   22407 resourceimport_controller.go:260] "Updating Endpoints corresponding to ResourceImport" endpoints="default/antrea-mc-nginx" resourceimport="default/default-nginx-endpoints"
--- PASS: TestResourceImportReconciler_handleCreateEvent (0.00s)
    --- PASS: TestResourceImportReconciler_handleCreateEvent/import_Service (0.00s)
    --- PASS: TestResourceImportReconciler_handleCreateEvent/import_Endpoints (0.00s)
=== RUN   TestResourceImportReconciler_handleDeleteEvent
=== RUN   TestResourceImportReconciler_handleDeleteEvent/delete_Service
I0121 20:25:47.447046   22407 resourceimport_controller.go:227] "Deleting Service and ServiceImport corresponding to ResourceImport" service="default/antrea-mc-nginx" serviceImport="default/nginx" resourceimport="default/default-nginx-service"
=== RUN   TestResourceImportReconciler_handleDeleteEvent/delete_Endpoints
I0121 20:25:47.447098   22407 resourceimport_controller.go:315] "Deleting Endpoints corresponding to ResourceImport" endpoints="default/antrea-mc-nginx" resourceimport="default/default-nginx-endpoints"
--- PASS: TestResourceImportReconciler_handleDeleteEvent (0.00s)
    --- PASS: TestResourceImportReconciler_handleDeleteEvent/delete_Service (0.00s)
    --- PASS: TestResourceImportReconciler_handleDeleteEvent/delete_Endpoints (0.00s)
=== RUN   TestResourceImportReconciler_handleUpdateEvent
=== RUN   TestResourceImportReconciler_handleUpdateEvent/update_Service
I0121 20:25:47.447243   22407 resourceimport_controller.go:145] "Updating Service and ServiceImport corresponding to ResourceImport" service="default/antrea-mc-nginx" serviceimport="default/nginx" resourceimport="default/default-nginx-service"
=== RUN   TestResourceImportReconciler_handleUpdateEvent/update_Endpoints
I0121 20:25:47.447373   22407 resourceimport_controller.go:260] "Updating Endpoints corresponding to ResourceImport" endpoints="default/antrea-mc-nginx" resourceimport="default/default-nginx-endpoints"
=== RUN   TestResourceImportReconciler_handleUpdateEvent/skip_update_a_Service_without_mcs_annotation
I0121 20:25:47.447440   22407 resourceimport_controller.go:145] "Updating Service and ServiceImport corresponding to ResourceImport" service="kube-system/antrea-mc-nginx" serviceimport="kube-system/nginx" resourceimport="default/kube-system-nginx-service"
E0121 20:25:47.447459   22407 resourceimport_controller.go:159] "Unable to import Service" err="the Service conflicts with existing one" service="kube-system/antrea-mc-nginx"
=== RUN   TestResourceImportReconciler_handleUpdateEvent/skip_update_an_Endpoint_without_mcs_annotation
I0121 20:25:47.447501   22407 resourceimport_controller.go:260] "Updating Endpoints corresponding to ResourceImport" endpoints="kube-system/antrea-mc-nginx" resourceimport="default/kube-system-nginx-endpoints"
E0121 20:25:47.447513   22407 resourceimport_controller.go:272] "Unable to import Endpoints" err="the Endpoints conflicts with existing one" endpoints="kube-system/antrea-mc-nginx"
--- PASS: TestResourceImportReconciler_handleUpdateEvent (0.00s)
    --- PASS: TestResourceImportReconciler_handleUpdateEvent/update_Service (0.00s)
    --- PASS: TestResourceImportReconciler_handleUpdateEvent/update_Endpoints (0.00s)
    --- PASS: TestResourceImportReconciler_handleUpdateEvent/skip_update_a_Service_without_mcs_annotation (0.00s)
    --- PASS: TestResourceImportReconciler_handleUpdateEvent/skip_update_an_Endpoint_without_mcs_annotation (0.00s)
PASS
ok      antrea.io/antrea/multicluster/controllers/multicluster/member 
```

updated test cases for stalecontroller

```yaml
 % go test -v ./multicluster/controllers/multicluster/member -run "TestStaleController"   
=== RUN   TestStaleControllerNoRaceWithResourceImportReconciler
I0121 20:25:31.835989   22184 stale_controller.go:370] "Starting StaleResCleanupController"
I0121 20:25:31.836424   22184 stale_controller.go:379] "Cache synced, starting cleanup"
I0121 20:25:31.836451   22184 stale_controller.go:408] "Clean up all stale imported and exported resources created by Antrea Multi-cluster Controller"
I0121 20:25:31.838076   22184 stale_controller.go:360] "Cleaning up stale ClusterInfo kind of ResourceExport" resourceexport="antrea-mcs/cluster-a-clusterinfo"
--- PASS: TestStaleControllerNoRaceWithResourceImportReconciler (1.00s)
=== RUN   TestStaleController_CleanUpService
=== RUN   TestStaleController_CleanUpService/clean_up_MC_Serivce_and_ServiceImport_successfully
I0121 20:25:32.837292   22184 stale_controller.go:408] "Clean up all stale imported and exported resources created by Antrea Multi-cluster Controller"
I0121 20:25:32.837440   22184 stale_controller.go:194] "Cleaning up stale imported Service" service="default/nginx"
I0121 20:25:32.837451   22184 stale_controller.go:201] "Cleaning up stale ServiceImport" serviceimport="default/nginx"
I0121 20:25:32.837465   22184 stale_controller.go:360] "Cleaning up stale ClusterInfo kind of ResourceExport" resourceexport="default/cluster-a-clusterinfo"
--- PASS: TestStaleController_CleanUpService (0.00s)
    --- PASS: TestStaleController_CleanUpService/clean_up_MC_Serivce_and_ServiceImport_successfully (0.00s)
=== RUN   TestStaleController_CleanUpACNP
=== RUN   TestStaleController_CleanUpACNP/cleanup_stale_ACNP
I0121 20:25:32.837630   22184 stale_controller.go:408] "Clean up all stale imported and exported resources created by Antrea Multi-cluster Controller"
I0121 20:25:32.837712   22184 stale_controller.go:225] "Cleaning up stale imported ACNP" acnp="antrea-mc-some-deleted-resimp"
I0121 20:25:32.837725   22184 stale_controller.go:360] "Cleaning up stale ClusterInfo kind of ResourceExport" resourceexport="default/cluster-a-clusterinfo"
--- PASS: TestStaleController_CleanUpACNP (0.00s)
    --- PASS: TestStaleController_CleanUpACNP/cleanup_stale_ACNP (0.00s)
=== RUN   TestStaleController_CleanUpResourceExports
=== RUN   TestStaleController_CleanUpResourceExports/clean_up_ResourceExport_successfully
I0121 20:25:32.837898   22184 stale_controller.go:408] "Clean up all stale imported and exported resources created by Antrea Multi-cluster Controller"
I0121 20:25:32.837927   22184 stale_controller.go:360] "Cleaning up stale ClusterInfo kind of ResourceExport" resourceexport="default/cluster-a-clusterinfo"
I0121 20:25:32.838087   22184 stale_controller.go:300] "Cleaning up stale ResourceExport" ResourceExport="default/cluster-a-default-nginx-endpoint"
I0121 20:25:32.838095   22184 stale_controller.go:300] "Cleaning up stale ResourceExport" ResourceExport="default/cluster-a-default-nginx-service"
I0121 20:25:32.840287   22184 stale_controller.go:337] "Cleaning up stale ResourceExport" ResourceExport="default/cluster-a-2e18c1c372942d65"
I0121 20:25:32.840306   22184 stale_controller.go:337] "Cleaning up stale ResourceExport" ResourceExport="default/cluster-a-1553d8831bab2ce1"
--- PASS: TestStaleController_CleanUpResourceExports (0.00s)
    --- PASS: TestStaleController_CleanUpResourceExports/clean_up_ResourceExport_successfully (0.00s)
=== RUN   TestStaleController_CleanUpClusterInfoImports
=== RUN   TestStaleController_CleanUpClusterInfoImports/clean_up_ClusterInfoImport_successfully
I0121 20:25:32.840446   22184 stale_controller.go:408] "Clean up all stale imported and exported resources created by Antrea Multi-cluster Controller"
I0121 20:25:32.840517   22184 stale_controller.go:246] "Cleaning up stale ClusterInfoImport" clusterinfoimport="default/cluster-b-default-clusterinfo"
I0121 20:25:32.840533   22184 stale_controller.go:360] "Cleaning up stale ClusterInfo kind of ResourceExport" resourceexport="antrea-mcs/cluster-a-clusterinfo"
--- PASS: TestStaleController_CleanUpClusterInfoImports (0.00s)
    --- PASS: TestStaleController_CleanUpClusterInfoImports/clean_up_ClusterInfoImport_successfully (0.00s)
=== RUN   TestStaleController_CleanUpLabelIdentites
=== RUN   TestStaleController_CleanUpLabelIdentites/clean_up_LabelIdentities_successfully
I0121 20:25:32.840606   22184 stale_controller.go:408] "Clean up all stale imported and exported resources created by Antrea Multi-cluster Controller"
I0121 20:25:32.840748   22184 stale_controller.go:360] "Cleaning up stale ClusterInfo kind of ResourceExport" resourceexport="antrea-mcs/cluster-a-clusterinfo"
--- PASS: TestStaleController_CleanUpLabelIdentites (0.00s)
    --- PASS: TestStaleController_CleanUpLabelIdentites/clean_up_LabelIdentities_successfully (0.00s)
=== RUN   TestStaleController_CleanupAllWithEmptyClusterSet
I0121 20:25:32.841958   22184 stale_controller.go:91] "There is no existing ClusterSet, try to clean up all auto-generated resources by Antrea Multi-cluster"
--- PASS: TestStaleController_CleanupAllWithEmptyClusterSet (0.00s)
PASS
ok      antrea.io/antrea/multicluster/controllers/multicluster/member 
```

updated test case for reconcile/stalecontroller

```yaml
 % go test -v ./multicluster/controllers/multicluster/leader -run "TestReconcile|TestStaleController"
=== RUN   TestReconcile
=== RUN   TestReconcile/MemberClusterAnnounce_deleted
=== RUN   TestReconcile/MemberClusterAnnounce_exists
--- PASS: TestReconcile (0.00s)
    --- PASS: TestReconcile/MemberClusterAnnounce_deleted (0.00s)
    --- PASS: TestReconcile/MemberClusterAnnounce_exists (0.00s)
=== RUN   TestStaleController_CleanUpMemberClusterAnnounces
=== RUN   TestStaleController_CleanUpMemberClusterAnnounces/no_MemberClusterAnnounce_to_clean_up_when_there_is_no_resource
=== RUN   TestStaleController_CleanUpMemberClusterAnnounces/no_MemberClusterAnnounce_to_clean_up_when_the_resource_has_a_valid_update_time
=== RUN   TestStaleController_CleanUpMemberClusterAnnounces/clean_up_outdated_MemberClusterAnnounce
I0121 20:25:18.265068   21988 stale_controller.go:86] "Cleaning up stale MemberClusterAnnounce. It has not been updated within the agreed period" MemberClusterAnnounce="default/member-cluster-from-cluster-outdated" agreedPeriod="24h0m0s"
--- PASS: TestStaleController_CleanUpMemberClusterAnnounces (0.00s)
    --- PASS: TestStaleController_CleanUpMemberClusterAnnounces/no_MemberClusterAnnounce_to_clean_up_when_there_is_no_resource (0.00s)
    --- PASS: TestStaleController_CleanUpMemberClusterAnnounces/no_MemberClusterAnnounce_to_clean_up_when_the_resource_has_a_valid_update_time (0.00s)
    --- PASS: TestStaleController_CleanUpMemberClusterAnnounces/clean_up_outdated_MemberClusterAnnounce (0.00s)
PASS
ok      antrea.io/antrea/multicluster/controllers/multicluster/leader   (cached)
```
