### PR TITLE
Fix race in ReassignFlowPriorities by adding missing locks

### DIFF
--- a/pkg/agent/openflow/network_policy.go
+++ b/pkg/agent/openflow/network_policy.go
@@ -1867,9 +1867,14 @@ func (f *featureNetworkPolicy) calculateFlowUpdates(updates map[uint16]uint16, t
 // ReassignFlowPriorities takes a list of priority updates, and update the actionFlows to replace
 // the old priority with the desired one, for each priority update.
 func (c *client) ReassignFlowPriorities(updates map[uint16]uint16, table uint8) error {
+	c.replayMutex.RLock()
+	defer c.replayMutex.RUnlock()
+
+	c.featureNetworkPolicy.conjMatchFlowLock.Lock()
+	defer c.featureNetworkPolicy.conjMatchFlowLock.Unlock()
+
 	addFlows, delFlows, conjFlowUpdates := c.featureNetworkPolicy.calculateFlowUpdates(updates, table)
 	add, update, del := c.featureNetworkPolicy.processFlowUpdates(addFlows, delFlows)
-	// Commit the flows updates calculated.
 	err := c.bridge.AddFlowsInBundle(add, update, del)
 	if err != nil {
 		return err


### PR DESCRIPTION
**Add missing conjMatchFlowLock and replayMutex acquisitions to prevent concurrent access to globalConjMatchFlowCache during priority reassignment.**

**Fixes : #7716**

### **Summary :**
Fix a race condition in ReassignFlowPriorities where globalConjMatchFlowCache was modified without holding conjMatchFlowLock.
This brings the function in line with all other policy flow update paths that already follow the required locking pattern.

### **Problem :**
ReassignFlowPriorities updates conjunction match flows via updateConjunctionMatchFlows, which performs deletes and writes on globalConjMatchFlowCache.
Unlike other callers, this function did not acquire conjMatchFlowLock, allowing concurrent access with policy operations such as InstallPolicyRuleFlows and AddPolicyRuleAddress.

Under concurrent policy updates, this could lead to unsafe map access and inconsistent control-plane state.

### **Impact :**
- Prevents concurrent read/write on globalConjMatchFlowCache
- Avoids potential Go runtime panics and silent cache corruption
- Ensures datapath and control-plane state remain consistent during priority reassignment
- Reduces risk of incorrect NetworkPolicy enforcement in high-churn clusters

### **Fix :**
Add the missing lock acquisitions at the start of ReassignFlowPriorities, following the same pattern used everywhere else that accesses globalConjMatchFlowCache.

`c.replayMutex.RLock()
defer c.replayMutex.RUnlock()

c.featureNetworkPolicy.conjMatchFlowLock.Lock()
defer c.featureNetworkPolicy.conjMatchFlowLock.Unlock()`

No logic changes were made beyond synchronization.

<img width="779" height="201" alt="image" src="https://github.com/user-attachments/assets/d3c5105a-2b16-4ef5-9a07-20c51df7c875" />

<img width="804" height="213" alt="image" src="https://github.com/user-attachments/assets/ff6e758b-f1db-4c22-aa8a-26710c03af34" />
