### PR TITLE
Add clarifying comment for reconcile interface removal

### DIFF
--- a/pkg/agent/cniserver/pod_configuration.go
+++ b/pkg/agent/cniserver/pod_configuration.go
@@ -470,6 +470,8 @@ func (pc *podConfigurator) reconcile(pods []corev1.Pod, containerAccess *contain
 		// the same name would have a different host interface associated to it.
 		if !desiredPods.Has(namespacedName) || pc.isInterfaceInvalid(containerConfig) {
 			klog.V(4).InfoS("Deleting interface", "Pod", klog.KRef(namespace, name), "iface", containerConfig.InterfaceName)
+			// This code is executed synchronously as part of cniServer.Initialize and prior to the call to cniServer.Run.
+			// As a result, concurrent calls to CNI ADD / DEL are not possible.
 			if err := pc.removeInterfaces(containerConfig.ContainerID); err != nil {
 				klog.ErrorS(err, "Failed to delete interface", "Pod", klog.KRef(namespace, name), "iface", containerConfig.InterfaceName)
 			}


### PR DESCRIPTION
Reverted the locking logic as discussed.

I added a comment in the code explaining that the lock isn't needed here because reconcile runs synchronously during initialization (before the CNI server runs).