### PR TITLE
Update Windows config to align with supported features

### DIFF
--- a/build/charts/antrea-windows/conf/antrea-agent.conf
+++ b/build/charts/antrea-windows/conf/antrea-agent.conf
@@ -23,12 +23,7 @@ featureGates:
 # Default MTU to use for the host gateway interface and the network interface of each Pod.
 # If omitted, antrea-agent will discover the MTU of the Node's primary interface and
 # also adjust MTU to accommodate for tunnel encapsulation overhead.
-#defaultMTU: 1450
-
-# ClusterIP CIDR range for Services. It's required when AntreaProxy is not enabled, and should be
-# set to the same value as the one specified by --service-cluster-ip-range for kube-apiserver. When
-# AntreaProxy is enabled, this parameter is not needed and will be ignored if provided.
-#serviceCIDR: 10.96.0.0/12
+#defaultMTU: 0
 
 # The port for the antrea-agent APIServer to serve on.
 #apiPort: 10350
@@ -64,6 +59,18 @@ featureGates:
 # 3. The Node IP
 #transportInterfaceCIDRs: [<IPv4 CIDR>,<IPv6 CIDR>]
 
+# Fully randomize source port mapping in SNAT rules used for egress traffic from Pods to the
+# external network. This feature should be disabled on Windows as it is not supported.
+snatFullyRandomPorts: false
+
+# Determines how tunnel traffic is encrypted. Currently encryption only works with encap mode on Linux Nodes.
+trafficEncryptionMode: "none"
+
+# This option requires the `AntreaIPAM` feature gate to be enabled. At this moment, it supports only
+# IPv4 and Linux Nodes, and can be enabled only when `ovsDatapathType` is `system`,
+# `trafficEncapMode` is `noEncap`, and `noSNAT` is true.
+enableBridgingMode: false
+
 # Provide the address of Kubernetes apiserver, to override any value provided in kubeconfig or InClusterConfig.
 # Defaults to "". It must be a host string, a host:port pair, or a URL to the base of the apiserver.
 #kubeAPIServerOverride: ""
@@ -83,6 +90,22 @@ antreaProxy:
   # then AntreaProxy will only handle Services without the "service.kubernetes.io/service-proxy-name" label,
   # but ignore Services with the label no matter what is the value.
   serviceProxyName: ""
+  # When ProxyLoadBalancerIPs is set to false, AntreaProxy no longer load-balances traffic destined to the
+  # External IPs of LoadBalancer Services. This is useful when the external LoadBalancer provides additional
+  # capabilities (e.g. TLS termination) and it is desirable for Pod-to-ExternalIP traffic to be sent to the
+  # external LoadBalancer instead of being load-balanced to an Endpoint directly by AntreaProxy.
+  # For Antrea Windows:
+  #   1. If the external LoadBalancer has SNAT enabled and uses an LoadBalancer IP for SNAT, this field MUST be
+  #      set to false. Otherwise, Antrea will install a route for the LoadBalancer IP. This route is intended to
+  #      forward LoadBalancer traffic sourced from the local Node or an external client to AntreaProxy for
+  #      load-balancing. However, it will also match reply traffic that has been SNATed with the LoadBalancer IP by
+  #      the external LoadBalancer, causing the reply traffic to be forwarded to an incorrect destination instead of
+  #      back to the external LoadBalancer.
+  #   2. In other scenarios, when enabling this feature, it can still accelerate traffic when a Pod or local Node
+  #      accesses the LoadBalancer IP directly.
+  # Note that setting ProxyLoadBalancerIPs to false usually only makes sense when proxyAll is set to true and
+  # kube-proxy is removed from the cluster, otherwise kube-proxy will still load-balance this traffic.
+  proxyLoadBalancerIPs: false
 
 nodePortLocal:
 # Enable NodePortLocal, a feature used to make Pods reachable using port forwarding on the host. To

--- a/build/yamls/antrea-windows-with-ovs.yml
+++ b/build/yamls/antrea-windows-with-ovs.yml
@@ -154,12 +154,7 @@ data:
     # Default MTU to use for the host gateway interface and the network interface of each Pod.
     # If omitted, antrea-agent will discover the MTU of the Node's primary interface and
     # also adjust MTU to accommodate for tunnel encapsulation overhead.
-    #defaultMTU: 1450
-
-    # ClusterIP CIDR range for Services. It's required when AntreaProxy is not enabled, and should be
-    # set to the same value as the one specified by --service-cluster-ip-range for kube-apiserver. When
-    # AntreaProxy is enabled, this parameter is not needed and will be ignored if provided.
-    #serviceCIDR: 10.96.0.0/12
+    #defaultMTU: 0
 
     # The port for the antrea-agent APIServer to serve on.
     #apiPort: 10350
@@ -195,6 +190,18 @@ data:
     # 3. The Node IP
     #transportInterfaceCIDRs: [<IPv4 CIDR>,<IPv6 CIDR>]
 
+    # Fully randomize source port mapping in SNAT rules used for egress traffic from Pods to the
+    # external network. This feature should be disabled on Windows as it is not supported.
+    snatFullyRandomPorts: false
+
+    # Determines how tunnel traffic is encrypted. Currently encryption only works with encap mode on Linux Nodes.
+    trafficEncryptionMode: "none"
+
+    # This option requires the `AntreaIPAM` feature gate to be enabled. At this moment, it supports only
+    # IPv4 and Linux Nodes, and can be enabled only when `ovsDatapathType` is `system`,
+    # `trafficEncapMode` is `noEncap`, and `noSNAT` is true.
+    enableBridgingMode: false
+
     # Provide the address of Kubernetes apiserver, to override any value provided in kubeconfig or InClusterConfig.
     # Defaults to "". It must be a host string, a host:port pair, or a URL to the base of the apiserver.
     #kubeAPIServerOverride: ""
@@ -214,6 +221,22 @@ data:
       # then AntreaProxy will only handle Services without the "service.kubernetes.io/service-proxy-name" label,
       # but ignore Services with the label no matter what is the value.
       serviceProxyName: ""
+      # When ProxyLoadBalancerIPs is set to false, AntreaProxy no longer load-balances traffic destined to the
+      # External IPs of LoadBalancer Services. This is useful when the external LoadBalancer provides additional
+      # capabilities (e.g. TLS termination) and it is desirable for Pod-to-ExternalIP traffic to be sent to the
+      # external LoadBalancer instead of being load-balanced to an Endpoint directly by AntreaProxy.
+      # For Antrea Windows:
+      #   1. If the external LoadBalancer has SNAT enabled and uses an LoadBalancer IP for SNAT, this field MUST be
+      #      set to false. Otherwise, Antrea will install a route for the LoadBalancer IP. This route is intended to
+      #      forward LoadBalancer traffic sourced from the local Node or an external client to AntreaProxy for
+      #      load-balancing. However, it will also match reply traffic that has been SNATed with the LoadBalancer IP by
+      #      the external LoadBalancer, causing the reply traffic to be forwarded to an incorrect destination instead of
+      #      back to the external LoadBalancer.
+      #   2. In other scenarios, when enabling this feature, it can still accelerate traffic when a Pod or local Node
+      #      accesses the LoadBalancer IP directly.
+      # Note that setting ProxyLoadBalancerIPs to false usually only makes sense when proxyAll is set to true and
+      # kube-proxy is removed from the cluster, otherwise kube-proxy will still load-balance this traffic.
+      proxyLoadBalancerIPs: false
 
     nodePortLocal:
     # Enable NodePortLocal, a feature used to make Pods reachable using port forwarding on the host. To
@@ -264,7 +287,7 @@ spec:
     metadata:
       annotations:
         checksum/agent-windows: 4a8b62e6d8076e1792f4a0a880a806016eb6991994c7cc63ac71bcf5bb2f9432
-        checksum/windows-config: 25fbe0add2041817f8d57d17e6f83bfe1d0f60aeac7ea189827ab2d42db1802b
+        checksum/windows-config: f3b8258c8243cb214efef19f07c24aae3926f8bb479edc792a9786f9999c59ba
         microsoft.com/hostprocess-inherit-user: "true"
       labels:
         app: antrea

--- a/build/yamls/antrea-windows.yml
+++ b/build/yamls/antrea-windows.yml
@@ -78,12 +78,7 @@ data:
     # Default MTU to use for the host gateway interface and the network interface of each Pod.
     # If omitted, antrea-agent will discover the MTU of the Node's primary interface and
     # also adjust MTU to accommodate for tunnel encapsulation overhead.
-    #defaultMTU: 1450
-
-    # ClusterIP CIDR range for Services. It's required when AntreaProxy is not enabled, and should be
-    # set to the same value as the one specified by --service-cluster-ip-range for kube-apiserver. When
-    # AntreaProxy is enabled, this parameter is not needed and will be ignored if provided.
-    #serviceCIDR: 10.96.0.0/12
+    #defaultMTU: 0
 
     # The port for the antrea-agent APIServer to serve on.
     #apiPort: 10350
@@ -119,6 +114,18 @@ data:
     # 3. The Node IP
     #transportInterfaceCIDRs: [<IPv4 CIDR>,<IPv6 CIDR>]
 
+    # Fully randomize source port mapping in SNAT rules used for egress traffic from Pods to the
+    # external network. This feature should be disabled on Windows as it is not supported.
+    snatFullyRandomPorts: false
+
+    # Determines how tunnel traffic is encrypted. Currently encryption only works with encap mode on Linux Nodes.
+    trafficEncryptionMode: "none"
+
+    # This option requires the `AntreaIPAM` feature gate to be enabled. At this moment, it supports only
+    # IPv4 and Linux Nodes, and can be enabled only when `ovsDatapathType` is `system`,
+    # `trafficEncapMode` is `noEncap`, and `noSNAT` is true.
+    enableBridgingMode: false
+
     # Provide the address of Kubernetes apiserver, to override any value provided in kubeconfig or InClusterConfig.
     # Defaults to "". It must be a host string, a host:port pair, or a URL to the base of the apiserver.
     #kubeAPIServerOverride: ""
@@ -138,6 +145,22 @@ data:
       # then AntreaProxy will only handle Services without the "service.kubernetes.io/service-proxy-name" label,
       # but ignore Services with the label no matter what is the value.
       serviceProxyName: ""
+      # When ProxyLoadBalancerIPs is set to false, AntreaProxy no longer load-balances traffic destined to the
+      # External IPs of LoadBalancer Services. This is useful when the external LoadBalancer provides additional
+      # capabilities (e.g. TLS termination) and it is desirable for Pod-to-ExternalIP traffic to be sent to the
+      # external LoadBalancer instead of being load-balanced to an Endpoint directly by AntreaProxy.
+      # For Antrea Windows:
+      #   1. If the external LoadBalancer has SNAT enabled and uses an LoadBalancer IP for SNAT, this field MUST be
+      #      set to false. Otherwise, Antrea will install a route for the LoadBalancer IP. This route is intended to
+      #      forward LoadBalancer traffic sourced from the local Node or an external client to AntreaProxy for
+      #      load-balancing. However, it will also match reply traffic that has been SNATed with the LoadBalancer IP by
+      #      the external LoadBalancer, causing the reply traffic to be forwarded to an incorrect destination instead of
+      #      back to the external LoadBalancer.
+      #   2. In other scenarios, when enabling this feature, it can still accelerate traffic when a Pod or local Node
+      #      accesses the LoadBalancer IP directly.
+      # Note that setting ProxyLoadBalancerIPs to false usually only makes sense when proxyAll is set to true and
+      # kube-proxy is removed from the cluster, otherwise kube-proxy will still load-balance this traffic.
+      proxyLoadBalancerIPs: false
 
     nodePortLocal:
     # Enable NodePortLocal, a feature used to make Pods reachable using port forwarding on the host. To
@@ -188,7 +211,7 @@ spec:
     metadata:
       annotations:
         checksum/agent-windows: 63f16e1fadb6b1354efda21c73702b4290400181136d4d47d4b1cd6a5f82d037
-        checksum/windows-config: 25fbe0add2041817f8d57d17e6f83bfe1d0f60aeac7ea189827ab2d42db1802b
+        checksum/windows-config: f3b8258c8243cb214efef19f07c24aae3926f8bb479edc792a9786f9999c59ba
         microsoft.com/hostprocess-inherit-user: "true"
       labels:
         app: antrea


### PR DESCRIPTION
* Expose `proxyLoadBalancerIPs` in AntreaProxy config.
* Remove `serviceCIDR` since AntreaProxy is now mandatory on Windows, making this parameter redundant.