### PR TITLE
Support BGP Timers and BFD configuration in BGPPolicy

### DIFF
--- a/pkg/agent/bgp/gobgp/gobgp.go
+++ b/pkg/agent/bgp/gobgp/gobgp.go
@@ -307,6 +307,18 @@ func convertPeerConfigToGoBGPPeer(peerConfig bgp.PeerConfig) (*gobgpapi.Peer, er
 			RestartTime: uint32(*peerConfig.GracefulRestartTimeSeconds),
 		}
 	}
+	if peerConfig.KeepaliveTimeSeconds != nil || peerConfig.HoldTimeSeconds != nil {
+		peer.Timers = &gobgpapi.Timers{
+			Config: &gobgpapi.TimersConfig{},
+		}
+		if peerConfig.KeepaliveTimeSeconds != nil {
+			peer.Timers.Config.KeepaliveInterval = uint64(*peerConfig.KeepaliveTimeSeconds)
+		}
+		if peerConfig.HoldTimeSeconds != nil {
+			peer.Timers.Config.HoldTime = uint64(*peerConfig.HoldTimeSeconds)
+		}
+	}
+	// Note: BFD is currently not supported by the GoBGP API version used in Antrea (v3.37.0).
 	return peer, nil
 }
 

--- a/pkg/apis/crd/v1alpha1/types.go
+++ b/pkg/apis/crd/v1alpha1/types.go
@@ -344,6 +344,35 @@ type BGPPeer struct {
 	// GracefulRestartTimeSeconds specifies how long the BGP peer would wait for the BGP session to re-establish after
 	// a restart before deleting stale routes. The range of the value is from 1 to 3600, and the default value is 120.
 	GracefulRestartTimeSeconds *int32 `json:"gracefulRestartTimeSeconds,omitempty"`
+
+	// KeepaliveTimeSeconds specifies the interval in seconds between BGP keepalive messages sent to the peer.
+	// The range of the value is from 1 to 65535, and the default value is 60.
+	KeepaliveTimeSeconds *int32 `json:"keepaliveTimeSeconds,omitempty"`
+
+	// HoldTimeSeconds specifies the interval in seconds after which the BGP session is considered down if no BGP
+	// keepalive or update messages are received from the peer. The range of the value is from 3 to 65535, and the
+	// default value is 180.
+	HoldTimeSeconds *int32 `json:"holdTimeSeconds,omitempty"`
+
+	// BFD configures BFD (Bidirectional Forwarding Detection) for the BGP peer.
+	BFD *BFDConfig `json:"bfd,omitempty"`
+}
+
+type BFDConfig struct {
+	// Enabled specifies whether BFD is enabled for the BGP peer.
+	Enabled bool `json:"enabled"`
+
+	// MinTransmitInterval specifies the minimum interval in milliseconds between BFD control packets sent to the peer.
+	// The range of the value is from 10 to 60000, and the default value is 300.
+	MinTransmitInterval *int32 `json:"minTransmitInterval,omitempty"`
+
+	// MinReceiveInterval specifies the minimum interval in milliseconds between BFD control packets received from the
+	// peer. The range of the value is from 10 to 60000, and the default value is 300.
+	MinReceiveInterval *int32 `json:"minReceiveInterval,omitempty"`
+
+	// Multiplier specifies the number of BFD control packets that can be missed before the BFD session is considered
+	// down. The range of the value is from 2 to 255, and the default value is 3.
+	Multiplier *int32 `json:"multiplier,omitempty"`
 }
 
 type PodReference struct {


### PR DESCRIPTION
Fixes #7673
This PR adds support for configuring BGP timers (Keepalive and HoldTime) and BFD (Bidirectional Forwarding Detection) in the BGPPolicy CRD.

Key changes:
- Added KeepaliveTimeSeconds, HoldTimeSeconds, and BFD configuration fields to the BGPPeer struct in v1alpha1.
- Updated the GoBGP wrapper to map these timer settings to the underlying GoBGP gRPC API.
- BFD configuration is added to the CRD but mapping is currently pending underlying GoBGP API support for per-peer BFD settings.
