### PR TITLE
Add ipsets information to Agent support bundle

### DIFF
--- a/pkg/support/dump_others.go
+++ b/pkg/support/dump_others.go
@@ -67,6 +67,9 @@ func (d *agentDumper) DumpHostNetworkInfo(basedir string) error {
 	if err := d.dumpNFTables(basedir); err != nil {
 		return err
 	}
+	if err := d.dumpIPSets(basedir); err != nil {
+		return err
+	}
 	if err := d.dumpIPToolInfo(basedir); err != nil {
 		return err
 	}
@@ -83,6 +86,20 @@ func (d *agentDumper) dumpIPTables(basedir string) error {
 		return err
 	}
 	return writeFile(d.fs, filepath.Join(basedir, "iptables"), "iptables", data)
+}
+func (d *agentDumper) dumpIPSets(basedir string) error {
+	if d.executor == nil {
+		return nil
+	}
+	output, err := d.executor.Command("ipset", "save").CombinedOutput()
+	if err != nil {
+		klog.ErrorS(err, "Failed to dump ipsets")
+		return nil
+	}
+	if len(output) == 0 {
+		return nil
+	}
+	return writeFile(d.fs, filepath.Join(basedir, "ipsets"), "ipsets", output)
 }
 
 func (d *agentDumper) dumpNFTables(basedir string) error {


### PR DESCRIPTION
## Summary
Include ipsets information in the Agent support bundle by dumping the output of `ipset save`.

## Changes
- Add ipsets dump to Agent host network information
- Handle nil executor and empty ipset output safely
- Add unit tests covering success, error, empty output, and nil executor cases

## Testing
- go test ./pkg/support/...

Fixes #7517
>Screenshots below are included only for quick  local  review  visibility only.
<img width="1250" height="766" alt="Screenshot 2026-01-24 at 2 03 36 AM" src="https://github.com/user-attachments/assets/ee108c18-3f7c-4449-b006-00540be66a49" />
<img width="1038" height="884" alt="Screenshot 2026-01-24 at 2 18 35 AM" src="https://github.com/user-attachments/assets/1d3efafe-c65a-47a0-b72f-41320e5511e1" />
