### PR TITLE
Enable `tagliatelle` Linter in `golangci-lint`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,7 @@ linters:
     - revive
     - staticcheck
     - unused
+    - tagliatelle
   settings:
     gosec:
       excludes:
@@ -37,6 +38,26 @@ linters:
         - name: superfluous-else
         - name: var-declaration
         - name: duplicated-imports
+    tagliatelle:
+      case:
+        rules:
+          json: goCamel
+          yaml: goCamel
+        overrides:
+          - pkg: pkg/apis/
+            ignore: true
+          - pkg: pkg/agent/apis/
+            ignore: true
+          - pkg: multicluster/apis/
+            ignore: true
+          - pkg: pkg/flowaggregator/apis/
+            ignore: true
+          - pkg: pkg/config/
+            ignore: true
+          - pkg: pkg/ovs/ovsconfig/
+            ignore: true
+          - pkg: test/
+            ignore: true
   exclusions:
     presets:
       - legacy


### PR DESCRIPTION
## Summary

This PR enables the `tagliatelle` linter in `golangci-lint` using `goCamel` casing rules to enforce consistent struct tag naming for future and internal code.

## Rationale

Antrea contains multiple public and serialized interfaces (CRDs, APIs, configuration schemas, and external system schemas) whose existing tag names are part of the compatibility contract. Renaming these tags would be disruptive and out of scope for enabling a new linter.

This PR therefore introduces `tagliatelle` in a non-breaking manner by scoping it to internal and excluding existing public APIs.

## Implementation Details

**Note:** This approach differs from PR #7442 by using path-based exclusions rather than field-level exclusions for simpler maintainability.

- `tagliatelle` is enabled with `goCamel` rules for both JSON and YAML tags.
- Existing public APIs, CRDs, configuration schemas, OVS schemas, and test code are excluded using path-based rules to preserve backward compatibility.
- No existing code is modified; the change is limited to linter configuration.

Before enabling `tagliatelle`, the repository already contained pre-existing `gosec` warnings. After enabling and scoping `tagliatelle`, no new lint issues are introduced, and the baseline remains unchanged.

### Excluded Paths

The following directories are excluded from `tagliatelle` checks to avoid breaking changes:

- **`multicluster/apis/`** - Public multicluster API definitions (CRDs)
- **`pkg/agent/apis/`** - Agent API types
- **`pkg/apis/`** - Core API types and CRD definitions  
- **`pkg/config/`** - Configuration file schemas (backward compatibility required)
- **`pkg/flowaggregator/apis/`** - Flow aggregator API types
- **`pkg/ovs/ovsconfig/`** - OVS schema bindings (external schema definitions)
- **`test/`** - Test code

These exclusions ensure that existing public APIs, CRDs, configuration schemas, and external interfaces remain unchanged, while the linter enforces consistency only in internal code paths.

## Testing

### Baseline (before enabling `tagliatelle`)

```zsh
❯ golangci-lint run ./... --output.tab.path stdout
6 issues:
* gosec: 6
```

### After enabling `tagliatelle` (before exclusions)

```zsh
49 issues:
* gosec: 6
* tagliatelle: 43
```

### After Applying Exclusions

```zsh
❯ golangci-lint run ./... --output.tab.path stdout
6 issues:
* gosec: 6
```

## Notes

- No runtime behavior is affected.
- No public interfaces are modified.
- Existing `gosec` warnings are unchanged and pre-existing.

## Checklist

- [x] Fixes #7334
- [x] No runtime behavior is changed
- [x] Existing `gosec` warnings are unchanged
- [x] Commits are signed-off

@antoninbas @hangyan kindly review.