### PR TITLE
Fix flaky FlowAggregator E2E tests

### DIFF
--- a/test/e2e/flowaggregator_test.go
+++ b/test/e2e/flowaggregator_test.go
@@ -209,6 +209,11 @@ func setupFlowAggregatorTest(t *testing.T, options flowVisibilityTestOptions) (*
 	if err := setupFlowAggregator(t, data, options); err != nil {
 		t.Fatalf("Error when setting up FlowAggregator: %v", err)
 	}
+
+	if err := getAndCheckFlowAggregatorMetrics(t, data, options.databaseURL != ""); err != nil {
+		t.Fatalf("Error when checking metrics of Flow Aggregator: %v", err)
+	}
+
 	// Execute teardownFlowAggregator later than teardownTest to ensure that the logs of Flow
 	// Aggregator has been exported.
 	teardownFuncs = append(teardownFuncs, func() { teardownFlowAggregator(t, data) })
@@ -295,9 +300,6 @@ func TestFlowAggregator(t *testing.T) {
 	data, v4Enabled, v6Enabled := setupFlowAggregatorTest(t, flowVisibilityTestOptions{
 		databaseURL: defaultCHDatabaseURL,
 	})
-	if err := getAndCheckFlowAggregatorMetrics(t, data, true); err != nil {
-		t.Fatalf("Error when checking metrics of Flow Aggregator: %v", err)
-	}
 
 	k8sUtils, err = NewKubernetesUtils(data)
 	if err != nil {
@@ -341,7 +343,6 @@ func TestFlowAggregatorProxyMode(t *testing.T) {
 				includeK8sNames: includeK8sNames,
 			},
 		})
-		require.NoError(t, getAndCheckFlowAggregatorMetrics(t, data, false), "Error when checking metrics of Flow Aggregator")
 
 		// UIDs are only supported when using gRPC between FE and FA.
 		if k8sUIDsInsteadOfNames {


### PR DESCRIPTION
Fix flaky FlowAggregator E2E tests by confirming FlowAggregator metrics (#7740)

The FlowAggregator SecureConnection tests were flaky. Flows took a
long time to arrive in the FlowAggregator. When they did, it was only
1 flow instead of the expected 3. The Delta count and Total count were
always equal due to the FlowExporter buffering the flow data before
sending it.

This was caused by the fact that FlowAggregator was redeployed for
each subtest. The Agent was slow to reconnect to the freshly deployed
FlowAggregator. Thus, the FlowExporter didn't match the expected timings
of the tests.

The test setup was updated to check FlowAggregator metrics after each
redeployment. This ensures the FlowExporter has reconnected to the new
FlowAggregator before testing.

Closes #7740 