### PR TITLE
Allow multiple uplinks via master field for Antrea SecondaryNetwork

### DIFF
--- a/docs/secondary-network.md
+++ b/docs/secondary-network.md
@@ -10,6 +10,7 @@
     - [OVS bridge configuration](#ovs-bridge-configuration)
     - [Secondary VLAN network configuration](#secondary-vlan-network-configuration)
     - [Pod secondary interface configuration](#pod-secondary-interface-configuration)
+    - [Pod secondary interface configuration with different physical interfaces](#pod-secondary-interface-configuration-with-different-physical-interfaces)
   - [SR-IOV](#sr-iov)
     - [Creating network functions](#creating-network-functions)
     - [Installing SR-IOV Network Device Plugin](#installing-sr-iov-network-device-plugin)
@@ -48,7 +49,7 @@ in the `antrea-agent` configuration. If you need IPAM for the secondary
 interfaces, you should also enable the `AntreaIPAM` feature gate in both
 `antrea-agent` and `antrea-controller` configuration. At the moment, Antrea IPAM
 is the only available IPAM option for secondary networks managed by Antrea. The
-`antrea-config` ConfigMap with the two feature gates enables is like the
+`antrea-config` ConfigMap with the two feature gates enabled is like the
 following:
 
 ```yaml
@@ -99,7 +100,8 @@ the following parameters:
 * `physicalInterfaces` - a list of physical network interface names to be added
   to the bridge. These interfaces will serve as uplinks for the bridge. At
   least one interface must be specified, and up to eight interfaces are
-  supported.
+  supported. This parameter is optional since Antrea v2.6. Users can define multiple
+  uplinks for secondary networks via NetworkAttachmentDefinition.
 * `enableMulticastSnooping` - (supported after v2.4) enable multicast snooping
   on the bridge, allowing the bridge to learn about multicast group memberships
   and forward multicast traffic only to ports that have interested receivers.
@@ -148,6 +150,7 @@ spec:
       "type": "antrea",
       "networkType": "vlan",
       "mtu": 1500,
+      "master": "eth1",
       "vlan": 100,
       "ipam": {
         "type": "antrea",
@@ -168,6 +171,11 @@ A few extra notes about the NetworkAttachmentDefinition `config` fields:
 * `type` - must be set to `antrea`.
 * `networkType` - should be set to `vlan` if VLAN-based network is desired.
 * `mtu` - defaults to 1500 if not set.
+* `master` - supported since Antrea v2.6. Specifies the physical interface name on
+K8s Nodes, which will be used as the uplink for Pod secondary interfaces. When
+this field is defined, `vlan` must be set to a valid VLAN ID (1 - 4094). Each VLAN
+should be mapped to exactly one physical interface. If multiple physical interfaces
+are configured for the same VLAN, traffic symmetry is not guaranteed.
 * `vlan` - can be set to 0 or a valid VLAN ID (1 - 4094). Defaults to 0. The
 VLAN ID can also be specified as part of the spec of an IPPool referenced in the
 `ipam` section, but `vlan` in NetworkAttachmentDefinition `config` will override
@@ -237,6 +245,137 @@ spec:
  - name: toolbox
    image: antrea/toolbox:latest
 ```
+
+Note: you can remove the annotation `k8s.v1.cni.cncf.io/networks` to delete
+the secondary interfaces. Network updates are not supported. Please check
+the [Limitations](#limitations) section for more details.
+
+#### Pod secondary interface configuration with different physical interfaces
+
+Since Antrea v2.6, the `master` field in NetworkAttachmentDefinition has been added.
+Users can leverage this new field to define different uplinks for Pod secondary interfaces,
+to support more flexible network topologies. The following are example steps for
+configuring Pod secondary interfaces with different uplinks
+
+1. Assume there are two Node Pools in a Kubernetes cluster. Below is the basic
+   information about the Kubernetes Node interfaces:
+
+   | NodePools           | Nodes Name                    | Host Interfaces  |
+   |---------------      |-------------------------------|------------------|
+   | node-pool-1         | k8s-node-ubuntu-pool-1-abc    |   eth0, eth1     |
+   | node-pool-1         | k8s-node-ubuntu-pool-1-def    |   eth0, eth1     |
+   | node-pool-2         | k8s-node-ubuntu-pool-2-abc    | eth0, eth1, eth2 |
+   | node-pool-2         | k8s-node-ubuntu-pool-2-def    | eth0, eth1, eth2 |
+
+2. Add `node-pool` labels to Nodes to ensure they have the correct labels:
+
+   ```bash
+   kubectl get nodes -o name | grep '^node/k8s-node-ubuntu-pool-1-' | xargs -I {} kubectl label {}  node-pool=highspeed --overwrite
+   kubectl get nodes -o name | grep '^node/k8s-node-ubuntu-pool-2-' | xargs -I {} kubectl  label {}  node-pool=storage --overwrite
+   ```
+
+3. Prepare two `NetworkAttachmentDefinitions` with different uplinks by defining the `master` field.
+
+   ```yaml
+   apiVersion: "k8s.cni.cncf.io/v1"
+   kind: NetworkAttachmentDefinition
+   metadata:
+     name: vlan100
+   spec:
+     config: '{
+         "cniVersion": "0.3.0",
+         "type": "antrea",
+         "networkType": "vlan",
+         "mtu": 1500,
+         "master": "eth1",
+         "vlan": 100,
+         "ipam": {
+           "type": "antrea",
+           "ippools": ["vlan100"]
+         }
+       }'
+   ---
+   apiVersion: "k8s.cni.cncf.io/v1"
+   kind: NetworkAttachmentDefinition
+   metadata:
+     name: vlan200
+   spec:
+     config: '{
+         "cniVersion": "0.3.0",
+         "type": "antrea",
+         "networkType": "vlan",
+         "mtu": 1500,
+         "master": "eth2",
+         "vlan": 200,
+         "ipam": {
+           "type": "antrea",
+           "ippools": ["vlan200"]
+         }
+       }'
+   ```
+
+4. Deploy Pods with `nodeAffinity` to ensure they are scheduled to desired Nodes:
+
+   ```yaml
+   apiVersion: apps/v1
+   kind: Deployment
+   metadata:
+     name: vlan100-pods
+   spec:
+     replicas: 2
+     selector:
+       matchLabels:
+         app: vlan100
+     template:
+       metadata:
+         labels:
+           app: vlan100
+         annotations:
+           k8s.v1.cni.cncf.io/networks: '[{"name": "vlan100"}]'
+       spec:
+         affinity:
+           nodeAffinity:
+             requiredDuringSchedulingIgnoredDuringExecution:
+               nodeSelectorTerms:
+               - matchExpressions:
+                 - key: node-pool
+                   operator: In
+                   values:
+                   - "highspeed"
+                   - "storage"
+         containers:
+         - name: toolbox
+           image: antrea/toolbox:latest
+   ---
+   apiVersion: apps/v1
+   kind: Deployment
+   metadata:
+     name: two-vlans-pods
+   spec:
+     replicas: 2
+     selector:
+       matchLabels:
+         app: two-vlans
+     template:
+       metadata:
+         labels:
+           app: two-vlans
+         annotations:
+           k8s.v1.cni.cncf.io/networks: '[{"name": "vlan100"}, {"name": "vlan200"}]'
+       spec:
+         affinity:
+           nodeAffinity:
+             requiredDuringSchedulingIgnoredDuringExecution:
+               nodeSelectorTerms:
+               - matchExpressions:
+                 - key: node-pool
+                   operator: In
+                   values:
+                   - "storage"
+         containers:
+         - name: toolbox
+           image: antrea/toolbox:latest
+   ```
 
 ### SR-IOV
 
@@ -339,18 +478,24 @@ spec:
        intel.com/sriov_net_A: '1'
 ```
 
+Note: Similar to VLAN configurations, you can remove the annotation
+`k8s.v1.cni.cncf.io/networks` to delete the secondary interfaces.
+Network updates are not supported. Please check the [Limitations](#limitations)
+section for more details.
+
 ## Limitations
 
-* At the moment, we do NOT support annotation update / removal: when the
-  annotation is added to the Pod for the first time (e.g., when creating the
-  Pod), we will configure the secondary network interfaces accordingly, and no
-  change is possible after that, until the Pod is deleted.
+* At the moment, we do NOT support annotation updates: when the
+  `k8s.v1.cni.cncf.io/networks` annotation is added to the Pod for the first
+  time (e.g., when creating the Pod), we will configure the secondary network
+  interfaces accordingly. No network changes are possible after that, until the
+  Pod is deleted.
 * We don't support K8s Nodes with multi-path routes.
 
   > A multi-path route is a route with multiple possible next hops. When listing the
   > rules (e.g., with `ip route list`), a multi-path route may appear as multiple individual
   > routes (one for each next hop), all with the same cost.
 
-  When the K8s Node interfaces are managed by a network manager, please make sure the default
+  When the K8s Node interfaces are managed by a network manager, please ensure that the default
   routes for secondary interfaces are disabled, or configure the routes with different metrics.
-  Otherwise, you may encounter K8s Nodes connection issue. Please check issue [#7058](https://github.com/antrea-io/antrea/issues/7058) for details.
+  Otherwise, you may encounter K8s Node connection issues. Please check issue [#7058](https://github.com/antrea-io/antrea/issues/7058) for details.

--- a/pkg/agent/controller/noderoute/node_route_controller.go
+++ b/pkg/agent/controller/noderoute/node_route_controller.go
@@ -429,7 +429,7 @@ func (c *Controller) worker() {
 
 // processNextWorkItem processes an item in the "node" work queue, by calling syncNodeRoute after
 // casting the item to a string (Node name). If syncNodeRoute returns an error, this function
-// handles it by requeueing the item so that it can be processed again later. If syncNodeRoute is
+// handles it by requeuing the item so that it can be processed again later. If syncNodeRoute is
 // successful, the Node is removed from the queue until we get notified of a new change. This
 // function returns false if and only if the work queue was shutdown (no more items will be
 // processed).

--- a/pkg/agent/packetcapture/packetcapture_controller.go
+++ b/pkg/agent/packetcapture/packetcapture_controller.go
@@ -251,7 +251,7 @@ func (c *Controller) processPacketCaptureItem() bool {
 		c.queue.Forget(key)
 	} else {
 		c.queue.AddRateLimited(key)
-		klog.ErrorS(err, "Error syncing PacketCapture, requeueing", "key", key)
+		klog.ErrorS(err, "Error syncing PacketCapture, requeuing", "key", key)
 	}
 	return true
 }

--- a/pkg/agent/secondarynetwork/init.go
+++ b/pkg/agent/secondarynetwork/init.go
@@ -78,7 +78,8 @@ func NewController(
 	return &Controller{
 		ovsBridgeClient: ovsBridgeClient,
 		secNetConfig:    secNetConfig,
-		podController:   podWatchController}, nil
+		podController:   podWatchController,
+	}, nil
 }
 
 // Run starts the Pod controller for secondary networks.

--- a/pkg/agent/secondarynetwork/podwatch/types.go
+++ b/pkg/agent/secondarynetwork/podwatch/types.go
@@ -32,4 +32,8 @@ type SecondaryNetworkConfig struct {
 	// non-zero VLAN is specified, it will override the VLAN in the Antrea
 	// IPAM IPPool subnet.
 	VLAN int32 `json:"vlan,omitempty"`
+	// The physical interface name on the host to which the OVS bridge will be
+	// bound. Applicable only to the VLAN network type.
+	// When the Master is specified, the VLAN field must be non-zero.
+	Master string `json:"master,omitempty"`
 }

--- a/pkg/agent/secondarynetwork/util/helper.go
+++ b/pkg/agent/secondarynetwork/util/helper.go
@@ -1,0 +1,61 @@
+// Copyright 2026 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"fmt"
+	"net"
+
+	"k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/klog/v2"
+
+	"antrea.io/antrea/pkg/agent/interfacestore"
+	"antrea.io/antrea/pkg/ovs/ovsconfig"
+)
+
+var (
+	// Funcs which will be overridden with mock funcs in tests.
+	interfaceByNameFn = net.InterfaceByName
+)
+
+func ConnectPhyInterfacesToOVSBridge(ovsBridgeClient ovsconfig.OVSBridgeClient, phyInterfaces []string) error {
+	var errs []error
+	for i, phyInterface := range phyInterfaces {
+		err := connectPhyInterfaceToOVSBridge(ovsBridgeClient, phyInterface, ovsconfig.FirstControllerOFPort+int32(i), false)
+		errs = append(errs, err)
+	}
+	return errors.NewAggregate(errs)
+}
+
+func connectPhyInterfaceToOVSBridge(ovsBridgeClient ovsconfig.OVSBridgeClient, phyInterface string, ofPortRequest int32, trunkMode bool) error {
+	if _, err := interfaceByNameFn(phyInterface); err != nil {
+		return fmt.Errorf("failed to get interface %s: %v", phyInterface, err)
+	}
+
+	externalIDs := map[string]interface{}{
+		interfacestore.AntreaInterfaceTypeKey: interfacestore.AntreaUplink,
+	}
+
+	if _, err := ovsBridgeClient.GetOFPort(phyInterface, false); err == nil {
+		klog.V(2).InfoS("Physical interface already connected to secondary OVS bridge, skip the configuration", "device", phyInterface)
+		return nil
+	}
+
+	if _, err := ovsBridgeClient.CreateUplinkPort(phyInterface, ofPortRequest, externalIDs); err != nil {
+		return fmt.Errorf("failed to create OVS uplink port %s: %v", phyInterface, err)
+	}
+	klog.InfoS("Physical interface added to secondary OVS bridge", "device", phyInterface)
+	return nil
+}

--- a/pkg/agent/secondarynetwork/util/helper_test.go
+++ b/pkg/agent/secondarynetwork/util/helper_test.go
@@ -1,0 +1,115 @@
+// Copyright 2026 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	mock "go.uber.org/mock/gomock"
+
+	"antrea.io/antrea/pkg/ovs/ovsconfig"
+	ovsconfigtest "antrea.io/antrea/pkg/ovs/ovsconfig/testing"
+)
+
+const (
+	nonExistingInterface = "non-existing"
+	firstUplinkOFPort    = 32768
+)
+
+func TestConnectPhyInterfacesToOVSBridge(t *testing.T) {
+	tests := []struct {
+		name               string
+		physicalInterfaces []string
+		expectedErr        string
+		expectedCalls      func(m *ovsconfigtest.MockOVSBridgeClient)
+	}{
+		{
+			name:               "one interface",
+			physicalInterfaces: []string{"eth0~"},
+			expectedCalls: func(m *ovsconfigtest.MockOVSBridgeClient) {
+				m.EXPECT().GetOFPort("eth0~", false).Return(int32(firstUplinkOFPort), ovsconfig.InvalidArgumentsError("port not found"))
+				m.EXPECT().CreateUplinkPort("eth0~", int32(firstUplinkOFPort), map[string]interface{}{"antrea-type": "uplink"}).Return("", nil)
+			},
+		},
+		{
+			name:               "two interfaces",
+			physicalInterfaces: []string{"eth1", "eth2"},
+			expectedCalls: func(m *ovsconfigtest.MockOVSBridgeClient) {
+				m.EXPECT().GetOFPort("eth1", false).Return(int32(firstUplinkOFPort), ovsconfig.InvalidArgumentsError("port not found"))
+				m.EXPECT().CreateUplinkPort("eth1", int32(firstUplinkOFPort), map[string]interface{}{"antrea-type": "uplink"}).Return("", nil)
+				m.EXPECT().GetOFPort("eth2", false).Return(int32(firstUplinkOFPort+1), ovsconfig.InvalidArgumentsError("port not found"))
+				m.EXPECT().CreateUplinkPort("eth2", int32(firstUplinkOFPort+1), map[string]interface{}{"antrea-type": "uplink"}).Return("", nil)
+			},
+		},
+		{
+			name:               "interface already attached",
+			physicalInterfaces: []string{"eth1"},
+			expectedCalls: func(m *ovsconfigtest.MockOVSBridgeClient) {
+				m.EXPECT().GetOFPort("eth1", false).Return(int32(firstUplinkOFPort), nil)
+			},
+		},
+		{
+			name:               "non-existing interface",
+			physicalInterfaces: []string{nonExistingInterface, "eth2"},
+			expectedErr:        "failed to get interface",
+			expectedCalls: func(m *ovsconfigtest.MockOVSBridgeClient) {
+				m.EXPECT().GetOFPort("eth2", false).Return(int32(firstUplinkOFPort+1), ovsconfig.InvalidArgumentsError("port not found"))
+				m.EXPECT().CreateUplinkPort("eth2", int32(firstUplinkOFPort+1), map[string]interface{}{"antrea-type": "uplink"}).Return("", nil)
+			},
+		},
+		{
+			name:               "create port error",
+			physicalInterfaces: []string{"eth1"},
+			expectedErr:        "create error",
+			expectedCalls: func(m *ovsconfigtest.MockOVSBridgeClient) {
+				m.EXPECT().GetOFPort("eth1", false).Return(int32(firstUplinkOFPort), ovsconfig.InvalidArgumentsError("port not found"))
+				m.EXPECT().CreateUplinkPort("eth1", int32(firstUplinkOFPort), map[string]interface{}{"antrea-type": "uplink"}).Return("", ovsconfig.InvalidArgumentsError("create error"))
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+
+			controller := mock.NewController(t)
+			mockOVSBridgeClient := ovsconfigtest.NewMockOVSBridgeClient(controller)
+
+			mockInterfaceByName(t)
+			if tc.expectedCalls != nil {
+				tc.expectedCalls(mockOVSBridgeClient)
+			}
+
+			err := ConnectPhyInterfacesToOVSBridge(mockOVSBridgeClient, tc.physicalInterfaces)
+			if tc.expectedErr != "" {
+				assert.ErrorContains(t, err, tc.expectedErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func mockInterfaceByName(t *testing.T) {
+	prevFunc := interfaceByNameFn
+	interfaceByNameFn = func(name string) (*net.Interface, error) {
+		if name == nonExistingInterface {
+			return nil, errors.New("interface not found")
+		}
+		return nil, nil
+	}
+	t.Cleanup(func() { interfaceByNameFn = prevFunc })
+}

--- a/pkg/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller.go
@@ -1006,7 +1006,7 @@ func (n *NetworkPolicyController) internalNetworkPolicyWorker() {
 // Processes an item in the "internalNetworkPolicy" work queue, by calling
 // syncInternalNetworkPolicy after casting the item to a string
 // (NetworkPolicy key). If syncInternalNetworkPolicy returns an error, this
-// function handles it by requeueing the item so that it can be processed again
+// function handles it by requeuing the item so that it can be processed again
 // later. If syncInternalNetworkPolicy is successful, the NetworkPolicy is
 // removed from the queue until we get notify of a new change. This function
 // return false if and only if the work queue was shutdown (no more items will
@@ -1037,7 +1037,7 @@ func (n *NetworkPolicyController) processNextInternalNetworkPolicyWorkItem() boo
 
 // Processes an item in the "addressGroup" work queue, by calling
 // syncAddressGroup after casting the item to a string (addressGroup key).
-// If syncAddressGroup returns an error, this function handles it by requeueing
+// If syncAddressGroup returns an error, this function handles it by requeuing
 // the item so that it can be processed again later. If syncAddressGroup is
 // successful, the AddressGroup is removed from the queue until we get notify
 // of a new change. This function return false if and only if the work queue
@@ -1066,7 +1066,7 @@ func (n *NetworkPolicyController) processNextAddressGroupWorkItem() bool {
 // Processes an item in the "appliedToGroup" work queue, by calling
 // syncAppliedToGroup after casting the item to a string (appliedToGroup key).
 // If syncAppliedToGroup returns an error, this function handles it by
-// requeueing the item so that it can be processed again later. If
+// requeuing the item so that it can be processed again later. If
 // syncAppliedToGroup is successful, the AppliedToGroup is removed from the
 // queue until we get notify of a new change. This function return false if
 // and only if the work queue was shutdown (no more items will be processed).

--- a/pkg/ovs/ovsconfig/interfaces.go
+++ b/pkg/ovs/ovsconfig/interfaces.go
@@ -71,6 +71,7 @@ type OVSBridgeClient interface {
 	GetPortData(portUUID, ifName string) (*OVSPortData, Error)
 	GetPortList() ([]OVSPortData, Error)
 	SetInterfaceMTU(name string, MTU int) error
+	AddTrunksToPort(portName string, vlanID int32) Error
 	GetOVSVersion() (string, Error)
 	AddOVSOtherConfig(configs map[string]interface{}) Error
 	GetOVSOtherConfig() (map[string]string, Error)

--- a/pkg/ovs/ovsconfig/ovs_schema.go
+++ b/pkg/ovs/ovsconfig/ovs_schema.go
@@ -32,6 +32,11 @@ type AccessPort struct {
 	Tag uint32 `json:"tag"`
 }
 
+type TrunkPort struct {
+	Port
+	Trunks []uint32 `json:"trunks"`
+}
+
 type Interface struct {
 	Name          string        `json:"name"`
 	Type          string        `json:"type,omitempty"`

--- a/pkg/ovs/ovsconfig/testing/mock_ovsconfig.go
+++ b/pkg/ovs/ovsconfig/testing/mock_ovsconfig.go
@@ -1,4 +1,4 @@
-// Copyright 2024 Antrea Authors
+// Copyright 2025 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -83,6 +83,20 @@ func (m *MockOVSBridgeClient) AddOVSOtherConfig(configs map[string]any) ovsconfi
 func (mr *MockOVSBridgeClientMockRecorder) AddOVSOtherConfig(configs any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddOVSOtherConfig", reflect.TypeOf((*MockOVSBridgeClient)(nil).AddOVSOtherConfig), configs)
+}
+
+// AddTrunksToPort mocks base method.
+func (m *MockOVSBridgeClient) AddTrunksToPort(portName string, vlanID int32) ovsconfig.Error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddTrunksToPort", portName, vlanID)
+	ret0, _ := ret[0].(ovsconfig.Error)
+	return ret0
+}
+
+// AddTrunksToPort indicates an expected call of AddTrunksToPort.
+func (mr *MockOVSBridgeClientMockRecorder) AddTrunksToPort(portName, vlanID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddTrunksToPort", reflect.TypeOf((*MockOVSBridgeClient)(nil).AddTrunksToPort), portName, vlanID)
 }
 
 // Create mocks base method.


### PR DESCRIPTION
This commit introduces support for per-network physical interface
configuration through a new `master` field in SecondaryNetworkConfig,
enabling more flexible network topologies for secondary networks.

Key changes:
- Add `master` field to SecondaryNetworkConfig to specify the physical
  interface (uplink) for each NetworkAttachmentDefinition
- Implement automatic OVS port creation and VLAN trunk configuration
  when `master` field is specified
- Add CreateUplinkPort() and AddTrunksToPort() methods to OVS client
  for managing uplink ports and VLAN trunks
- Refactor physical interface connection logic into reusable utility
  functions (ConnectPhyInterfacesToOVSBridge)
- Make `physicalInterfaces` parameter optional in OVS bridge configuration
  since Antrea v2.6 (can now be defined per-NAD via master field)
- Add validation to require VLAN ID when `master` field is specified
- Update documentation with examples for per-node-pool uplink
  configurations using Pod nodeAffinity and `master` field

This enables users to:
- Define different uplinks for different NetworkAttachmentDefinitions
- Support per-node-pool network configurations by combining the master
  field with Pod label selectors and nodeAffinity
- Achieve more complex network topologies without requiring all networks
  to share the same physical interfaces