### PR TITLE
Migrate `ServiceExternalIP` controller to use `EndpointSlices`

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -129,7 +129,6 @@ func run(o *Options) error {
 	ipPoolInformer := crdInformerFactory.Crd().V1beta1().IPPools()
 	nodeInformer := informerFactory.Core().V1().Nodes()
 	serviceInformer := informerFactory.Core().V1().Services()
-	endpointsInformer := informerFactory.Core().V1().Endpoints()
 	endpointSliceInformer := informerFactory.Discovery().V1().EndpointSlices()
 	namespaceInformer := informerFactory.Core().V1().Namespaces()
 	nodeLatencyMonitorInformer := crdInformerFactory.Crd().V1alpha1().NodeLatencyMonitors()
@@ -598,7 +597,7 @@ func run(o *Options) error {
 			nodeConfig.NodeTransportInterfaceName,
 			memberlistCluster,
 			serviceInformer,
-			endpointsInformer,
+			endpointSliceInformer,
 			linkMonitor,
 		)
 		if err != nil {


### PR DESCRIPTION
## Summary

This PR migrates the ServiceExternalIP controller from using the legacy `CoreV1.Endpoints` API to the `DiscoveryV1.EndpointSlices` API. This ensures compatibility with future Kubernetes versions (v1.33+) and leverages the scalability benefits of `EndpointSlices`.

## Rationale

As noted in issue #7332, usage of `v1 Endpoints` will trigger deprecation warnings in `K8s 1.33+`. Additionally, `EndpointSlices` provide better performance at scale by sharding endpoints into multiple resources, preventing large object updates during minor network changes.

## Implementation Details

This refactor updates the controller logic to handle the architectural differences between `Endpoints` (1:1 with Services) and `EndpointSlices` (1:N with Services).

+ `cmd/antrea-agent/agent.go`: Replaced the `EndpointsInformer` initialization with `EndpointSliceInformer`.
+ `pkg/agent/controller/serviceexternalip/controller.go`:
    + Updated controller struct to hold `EndpointSliceLister` and `EndpointSliceInformer`.
    + **Service Lookup**: Refactored `enqueueService` to locate the owning Service via the `kubernetes.io/service-name` label, as Slices do not share the Service's name.
    + **Aggregation Logic**: Updated `nodesHasHealthyServiceEndpoint` to list all Slices matching the Service's label selector and iterate through them to find ready endpoints.
    + **Ready Check**: Added nil-safe checks for `Endpoint.Conditions.Ready` (which is a pointer in the Slice API).
+ `pkg/agent/controller/serviceexternalip/controller_test.go`: Rewrote test data generators (`makeEndpointSlices`) to produce `discoveryv1.EndpointSlice` objects and updated all test cases to assert against the new types.

## Testing

**Unit Tests**: Verified that all tests passed, ensuring no regressions in the agent or controller logic.

```zsh
sudo make test
# All tests passed
```

## Notes

+ This PR focuses strictly on the `ServiceExternalIP` controller.
+ Changes to multicluster components are out of scope for this PR, as indicated in the issue comments regarding separate handling for multi-cluster features. (https://github.com/antrea-io/antrea/issues/7332#issuecomment-3153553261)
+ No changes were made to `third_party proxy` code to avoid diverging from upstream dependencies.

## Checklist

+ [x] Fixes #7332 
+ [x] Commits are signed-off
+ [x] Unit tests updated and passing
+ [x] Logic validated for 1-to-N Service-to-Slice relationship

@luolanzone @antoninbas kindly review.