### PR TITLE
test/e2e: improves VLAN Network test flake's reliability and logging

### DIFF
--- a/test/e2e/antctl_test.go
+++ b/test/e2e/antctl_test.go
@@ -110,7 +110,7 @@ func runAntctl(podName string, cmds []string, data *TestData) (string, string, e
 
 // testAntctlAgentLocalAccess ensures antctl is accessible in an agent Pod.
 func testAntctlAgentLocalAccess(t *testing.T, data *TestData) {
-	podName, err := data.getAntreaPodOnNode(controlPlaneNodeName())
+	podName, err := data.GetAntreaPodOnNode(controlPlaneNodeName())
 	if err != nil {
 		t.Fatalf("Error when getting antrea-agent pod name: %v", err)
 	}
@@ -187,7 +187,7 @@ func testAntctlControllerRemoteAccess(t *testing.T, data *TestData, antctlServic
 // testAntctlVerboseMode ensures no unexpected outputs during the execution of
 // the antctl client.
 func testAntctlVerboseMode(t *testing.T, data *TestData) {
-	podName, err := data.getAntreaPodOnNode(controlPlaneNodeName())
+	podName, err := data.GetAntreaPodOnNode(controlPlaneNodeName())
 	require.Nil(t, err, "Error when retrieving antrea controller pod name")
 	for _, tc := range []struct {
 		name      string

--- a/test/e2e/antreapolicy_test.go
+++ b/test/e2e/antreapolicy_test.go
@@ -4840,7 +4840,7 @@ func testACNPMulticastEgress(t *testing.T, data *TestData, acnpName, caseName, g
 // the matchers parameter is a list of regular expressions which will be matched against the
 // contents of the audit logs. The call will "succeed" if all matches are successful.
 func checkAuditLoggingResult(t *testing.T, data *TestData, nodeName, logLocator string, matchers []*regexp.Regexp) {
-	antreaPodName, err := data.getAntreaPodOnNode(nodeName)
+	antreaPodName, err := data.GetAntreaPodOnNode(nodeName)
 	if err != nil {
 		t.Errorf("Error occurred when trying to get the Antrea Agent Pod running on Node %s: %v", nodeName, err)
 	}

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -109,7 +109,7 @@ func checkPodIP(t *testing.T, podNetworkCIDR string, podIP *net.IP) {
 func (data *TestData) testDeletePod(t *testing.T, podName string, nodeName string, namespace string, isWindowsNode bool) {
 	var antreaPodName string
 	var err error
-	if antreaPodName, err = data.getAntreaPodOnNode(nodeName); err != nil {
+	if antreaPodName, err = data.GetAntreaPodOnNode(nodeName); err != nil {
 		t.Fatalf("Error when retrieving the name of the Antrea Pod running on Node '%s': %v", nodeName, err)
 	}
 	t.Logf("The Antrea Pod for Node '%s' is '%s'", nodeName, antreaPodName)
@@ -683,7 +683,7 @@ func getRoundNumber(data *TestData, podName string) (uint64, error) {
 }
 
 func getAntreaPodName(t *testing.T, data *TestData, nodeName string) string {
-	antreaPodName, err := data.getAntreaPodOnNode(nodeName)
+	antreaPodName, err := data.GetAntreaPodOnNode(nodeName)
 	if err != nil {
 		t.Fatalf("Error when retrieving the name of the Antrea Pod running on Node '%s': %v", nodeName, err)
 	}
@@ -872,7 +872,7 @@ func testGratuitousARP(t *testing.T, data *TestData, namespace string) {
 	}
 	defer deletePodWrapper(t, data, namespace, podName)
 
-	antreaPodName, err := data.getAntreaPodOnNode(nodeName)
+	antreaPodName, err := data.GetAntreaPodOnNode(nodeName)
 	if err != nil {
 		t.Fatalf("Error when retrieving the name of the Antrea Pod running on Node '%s': %v", nodeName, err)
 	}

--- a/test/e2e/batch_test.go
+++ b/test/e2e/batch_test.go
@@ -39,7 +39,7 @@ func TestBatchCreatePods(t *testing.T) {
 	batchNum := 20
 
 	node1 := workerNodeName(1)
-	podName, err := data.getAntreaPodOnNode(node1)
+	podName, err := data.GetAntreaPodOnNode(node1)
 	assert.NoError(t, err)
 
 	getFDs := func() sets.Set[string] {

--- a/test/e2e/connectivity_test.go
+++ b/test/e2e/connectivity_test.go
@@ -158,7 +158,7 @@ func (data *TestData) dumpOVSFlows(t *testing.T, workerNode string) []string {
 		ovsOfctlCmd = `c:/openvswitch/usr/bin/ovs-ofctl.exe`
 	}
 	cmd := []string{ovsOfctlCmd, "dump-flows", defaultBridgeName, "--names"}
-	antreaPodName, err := data.getAntreaPodOnNode(workerNode)
+	antreaPodName, err := data.GetAntreaPodOnNode(workerNode)
 	if err != nil {
 		t.Fatalf("Error when retrieving the name of the Antrea Pod running on Node '%s': %v", workerNode, err)
 	}
@@ -520,7 +520,7 @@ func testOVSFlowReplay(t *testing.T, data *TestData, namespace string) {
 
 	var antreaPodName string
 	var err error
-	if antreaPodName, err = data.getAntreaPodOnNode(workerNode); err != nil {
+	if antreaPodName, err = data.GetAntreaPodOnNode(workerNode); err != nil {
 		t.Fatalf("Error when retrieving the name of the Antrea Pod running on Node '%s': %v", workerNode, err)
 	}
 	t.Logf("The Antrea Pod for Node '%s' is '%s'", workerNode, antreaPodName)

--- a/test/e2e/egress_test.go
+++ b/test/e2e/egress_test.go
@@ -899,7 +899,7 @@ func (data *TestData) checkEgressState(egressName, expectedIP, expectedNode, oth
 }
 
 func hasIP(data *TestData, nodeName string, ip string) (bool, error) {
-	antreaPodName, err := data.getAntreaPodOnNode(nodeName)
+	antreaPodName, err := data.GetAntreaPodOnNode(nodeName)
 	if err != nil {
 		return false, err
 	}
@@ -921,7 +921,7 @@ func setupIPNeighborChecker(data *TestData, t *testing.T, observerNode, node1, n
 	require.NoError(t, err)
 	nodeToMACAddress := map[string]string{node1: macAddress1, node2: macAddress2}
 
-	antreaPodName, err := data.getAntreaPodOnNode(observerNode)
+	antreaPodName, err := data.GetAntreaPodOnNode(observerNode)
 	require.NoError(t, err)
 
 	// The Egress IP may not be in the same subnet as the primary IP of the transport interface.

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -2052,8 +2052,8 @@ func (data *TestData) deleteAntreaAgentOnNode(nodeName string, gracePeriodSecond
 	return delay, nil
 }
 
-// getAntreaPodOnNode retrieves the name of the Antrea Pod (antrea-agent-*) running on a specific Node.
-func (data *TestData) getAntreaPodOnNode(nodeName string) (podName string, err error) {
+// GetAntreaPodOnNode retrieves the name of the Antrea Pod (antrea-agent-*) running on a specific Node.
+func (data *TestData) GetAntreaPodOnNode(nodeName string) (podName string, err error) {
 	listOptions := metav1.ListOptions{
 		LabelSelector: "app=antrea,component=antrea-agent",
 		FieldSelector: fmt.Sprintf("spec.nodeName=%s", nodeName),
@@ -2069,7 +2069,7 @@ func (data *TestData) getAntreaPodOnNode(nodeName string) (podName string, err e
 }
 
 func (data *TestData) RunCommandFromAntreaPodOnNode(nodeName string, cmd []string) (string, string, error) {
-	antreaPodName, err := data.getAntreaPodOnNode(nodeName)
+	antreaPodName, err := data.GetAntreaPodOnNode(nodeName)
 	if err != nil {
 		return "", "", err
 	}
@@ -2758,7 +2758,7 @@ func (data *TestData) GetTransportInterfaceName() (string, error) {
 
 func (data *TestData) GetTransportInterfaceForNode(nodeIdx int) (string, *net.IPNet, *net.IPNet, error) {
 	nodeName := nodeName(nodeIdx)
-	antreaPod, err := data.getAntreaPodOnNode(nodeName)
+	antreaPod, err := data.GetAntreaPodOnNode(nodeName)
 	if err != nil {
 		return "", nil, nil, fmt.Errorf("failed to get Antrea Pod on Node %s: %v", nodeName, err)
 	}
@@ -2832,7 +2832,7 @@ func (data *TestData) GetPodInterfaceMTU(namespace string, podName string, conta
 }
 
 func (data *TestData) GetNodeMACAddress(node, device string) (string, error) {
-	antreaPod, err := data.getAntreaPodOnNode(node)
+	antreaPod, err := data.GetAntreaPodOnNode(node)
 	if err != nil {
 		return "", fmt.Errorf("failed to get Antrea Pod on Node %s: %v", node, err)
 	}

--- a/test/e2e/ipsec_test.go
+++ b/test/e2e/ipsec_test.go
@@ -84,7 +84,7 @@ func TestIPSec(t *testing.T) {
 }
 
 func (data *TestData) readSecurityAssociationsStatus(nodeName string) (up int, connecting int, isCertAuth bool, err error) {
-	antreaPodName, err := data.getAntreaPodOnNode(nodeName)
+	antreaPodName, err := data.GetAntreaPodOnNode(nodeName)
 	if err != nil {
 		return 0, 0, false, err
 	}
@@ -165,7 +165,7 @@ func testIPSecDeleteStaleTunnelPorts(t *testing.T, data *TestData) {
 	nodeName0 := nodeName(0)
 	nodeName1 := nodeName(1)
 	antreaPodName := func() string {
-		antreaPodName, err := data.getAntreaPodOnNode(nodeName0)
+		antreaPodName, err := data.GetAntreaPodOnNode(nodeName0)
 		if err != nil {
 			t.Fatalf("Error when retrieving the name of the Antrea Pod running on Node '%s': %v", nodeName0, err)
 		}

--- a/test/e2e/l7networkpolicy_test.go
+++ b/test/e2e/l7networkpolicy_test.go
@@ -426,7 +426,7 @@ func testL7NetworkPolicyLogging(t *testing.T, data *TestData) {
 	require.NoError(t, err, "Expected IP for Pod '%s'", serverPodName)
 	serverIPs := podIPs.AsSlice()
 
-	antreaPodName, err := data.getAntreaPodOnNode(l7LoggingNode)
+	antreaPodName, err := data.GetAntreaPodOnNode(l7LoggingNode)
 	require.NoError(t, err, "Error occurred when trying to get the antrea-agent Pod running on Node %s", l7LoggingNode)
 
 	// Find filename of L7 log file.

--- a/test/e2e/multicast_test.go
+++ b/test/e2e/multicast_test.go
@@ -467,9 +467,9 @@ func testMulticastStatsWithSendersReceivers(t *testing.T, data *TestData, testNa
 		for _, senderConfig := range mc.senderConfigs {
 			stats := mc.antctlResults[senderConfig.name]
 			t.Logf("Checking antctl get podmulticaststats result for %s", senderConfig.name)
-			antreaPod, err := data.getAntreaPodOnNode(senderConfig.nodeName)
+			antreaPod, err := data.GetAntreaPodOnNode(senderConfig.nodeName)
 			if err != nil {
-				t.Fatalf("Error getting getAntreaPodOnNode for %s", senderConfig.name)
+				t.Fatalf("Error getting GetAntreaPodOnNode for %s", senderConfig.name)
 			}
 			matches, err := checkAntctlResult(t, data, antreaPod, senderConfig.name, testNamespace, stats.Inbound, stats.Outbound)
 			if err != nil || !matches {
@@ -481,9 +481,9 @@ func testMulticastStatsWithSendersReceivers(t *testing.T, data *TestData, testNa
 			groupAddresses.Insert(receiverConfig.IPs...)
 			stats := mc.antctlResults[receiverConfig.name]
 			t.Logf("Checking antctl get podmulticaststats result for %s", receiverConfig.name)
-			antreaPod, err := data.getAntreaPodOnNode(receiverConfig.nodeName)
+			antreaPod, err := data.GetAntreaPodOnNode(receiverConfig.nodeName)
 			if err != nil {
-				t.Fatalf("Error getting getAntreaPodOnNode for %s", receiverConfig.name)
+				t.Fatalf("Error getting GetAntreaPodOnNode for %s", receiverConfig.name)
 			}
 			matches, err := checkAntctlResult(t, data, antreaPod, receiverConfig.name, testNamespace, stats.Inbound, stats.Outbound)
 			if err != nil || !matches {

--- a/test/e2e/networkpolicy_test.go
+++ b/test/e2e/networkpolicy_test.go
@@ -456,7 +456,7 @@ func testDefaultDenyEgressPolicy(t *testing.T, data *TestData) {
 
 func testNetworkPolicyResyncAfterRestart(t *testing.T, data *TestData) {
 	workerNode := workerNodeName(1)
-	antreaPod, err := data.getAntreaPodOnNode(workerNode)
+	antreaPod, err := data.GetAntreaPodOnNode(workerNode)
 	if err != nil {
 		t.Fatalf("Error when getting antrea-agent pod name: %v", err)
 	}
@@ -645,7 +645,7 @@ func testNetworkPolicyAfterAgentRestart(t *testing.T, data *TestData) {
 		checkFunc(t, deniedPod, deniedPodIPs, true)
 	}
 
-	antreaPod, err := data.getAntreaPodOnNode(workerNode)
+	antreaPod, err := data.GetAntreaPodOnNode(workerNode)
 	require.NoError(t, err)
 	// Make sure the new antrea-agent disconnects from antrea-controller but connects to OVS.
 	waitForAgentCondition(t, data, antreaPod, v1beta1.ControllerConnectionUp, corev1.ConditionFalse)

--- a/test/e2e/nodenetworkpolicy_test.go
+++ b/test/e2e/nodenetworkpolicy_test.go
@@ -1108,7 +1108,7 @@ func testNodeACNPAuditLogging(t *testing.T, data *TestData) {
 	require.NoError(t, err)
 	require.NoError(t, data.waitForACNPRealized(t, acnp.Name, policyRealizedTimeout))
 
-	antreaPodName, err := data.getAntreaPodOnNode(nodes["x"])
+	antreaPodName, err := data.GetAntreaPodOnNode(nodes["x"])
 	require.NoError(t, err)
 
 	expectedLogPrefix := fmt.Sprintf("Antrea:O:Drop:%s:", randomLogLabel)

--- a/test/e2e/nodeportlocal_test.go
+++ b/test/e2e/nodeportlocal_test.go
@@ -427,7 +427,7 @@ func NPLTestMultiplePods(t *testing.T, data *TestData) {
 	err = testData.podWaitForRunning(defaultTimeout, clientName, data.testNamespace)
 	r.NoError(err, "Error when waiting for Pod %s to be running", clientName)
 
-	antreaPod, err := testData.getAntreaPodOnNode(serverNode)
+	antreaPod, err := testData.GetAntreaPodOnNode(serverNode)
 	r.NoError(err, "Error when getting Antrea Agent Pod on Node '%s'", serverNode)
 
 	for _, testPodName := range testPods {
@@ -501,7 +501,7 @@ func NPLTestPodAddMultiPort(t *testing.T, data *TestData) {
 	err = testData.podWaitForRunning(defaultTimeout, clientName, data.testNamespace)
 	r.NoError(err, "Error when waiting for Pod %s to be running", clientName)
 
-	antreaPod, err := testData.getAntreaPodOnNode(serverNode)
+	antreaPod, err := testData.GetAntreaPodOnNode(serverNode)
 	r.NoError(err, "Error when getting Antrea Agent Pod on Node '%s'", serverNode)
 
 	checkNPLRules(t, testData, r, nplAnnotations, antreaPod, testPodIPs, serverNode, true)
@@ -548,7 +548,7 @@ func NPLTestPodAddMultiProtocol(t *testing.T, data *TestData) {
 	err = testData.podWaitForRunning(defaultTimeout, clientName, data.testNamespace)
 	r.NoError(err, "Error when waiting for Pod %s to be running", clientName)
 
-	antreaPod, err := testData.getAntreaPodOnNode(serverNode)
+	antreaPod, err := testData.GetAntreaPodOnNode(serverNode)
 	r.NoError(err, "Error when getting Antrea Agent Pod on Node '%s'", serverNode)
 
 	checkNPLRules(t, testData, r, nplAnnotations, antreaPod, testPodIPs, serverNode, true)
@@ -606,7 +606,7 @@ func NPLTestLocalAccess(t *testing.T, data *TestData) {
 	err = testData.podWaitForRunning(defaultTimeout, clientName, data.testNamespace)
 	r.NoError(err, "Error when waiting for Pod %s to be running", clientName)
 
-	antreaPod, err := testData.getAntreaPodOnNode(serverNode)
+	antreaPod, err := testData.GetAntreaPodOnNode(serverNode)
 	r.NoError(err, "Error when getting Antrea Agent Pod on Node '%s'", serverNode)
 
 	nplAnnotations, testPodIPs := getNPLAnnotations(t, testData, r, testPodName, nil)
@@ -647,7 +647,7 @@ func testNPLMultiplePodsAgentRestart(t *testing.T, data *TestData) {
 	err = data.podWaitForRunning(defaultTimeout, clientName, data.testNamespace)
 	r.NoError(err, "Error when waiting for Pod %s to be running", clientName)
 
-	antreaPod, err := data.getAntreaPodOnNode(serverNode)
+	antreaPod, err := data.GetAntreaPodOnNode(serverNode)
 	r.NoError(err, "Error when getting Antrea Agent Pod on Node '%s'", serverNode)
 
 	// Delete one iptables rule to ensure it gets re-installed correctly on restart.
@@ -687,7 +687,7 @@ func testNPLMultiplePodsAgentRestart(t *testing.T, data *TestData) {
 	err = data.RestartAntreaAgentPods(defaultTimeout)
 	r.NoError(err, "Error when restarting Antrea Agent Pods")
 
-	antreaPod, err = data.getAntreaPodOnNode(serverNode)
+	antreaPod, err = data.GetAntreaPodOnNode(serverNode)
 	r.NoError(err, "Error when getting Antrea Agent Pod on Node '%s'", serverNode)
 
 	for _, testPodName := range testPods {
@@ -746,7 +746,7 @@ func testNPLChangePortRangeAgentRestart(t *testing.T, data *TestData) {
 	}
 	configureNPLForAgent(t, data, updatedStartPort, updatedEndPort)
 
-	antreaPod, err := data.getAntreaPodOnNode(serverNode)
+	antreaPod, err := data.GetAntreaPodOnNode(serverNode)
 	r.NoError(err, "Error when getting Antrea Agent Pod on Node '%s'", serverNode)
 
 	if clusterInfo.nodesOS[serverNode] == "windows" {

--- a/test/e2e/packetcapture_test.go
+++ b/test/e2e/packetcapture_test.go
@@ -227,7 +227,7 @@ func testPacketCaptureBasic(t *testing.T, data *TestData, sftpServerIP string, p
 
 	// This is the name of the Antrea Pod which performs the capture. The capture is performed
 	// on the Node where the source Pod (clientPodName) is running, which is node1.
-	antreaPodName, err := data.getAntreaPodOnNode(node1)
+	antreaPodName, err := data.GetAntreaPodOnNode(node1)
 	require.NoError(t, err)
 
 	getPcapURL := func(name string) string {
@@ -1091,7 +1091,7 @@ func runPacketCaptureTest(t *testing.T, data *TestData, tc pcTestCase) {
 	require.NotEmpty(t, captureNodeName, "Could not determine any node for packet capture")
 
 	// verify packets.
-	antreaPodName, err := data.getAntreaPodOnNode(captureNodeName)
+	antreaPodName, err := data.GetAntreaPodOnNode(captureNodeName)
 	require.NoError(t, err)
 	tmpDir := t.TempDir()
 	dstFileName := filepath.Join(tmpDir, tc.pc.Name+".pcapng")

--- a/test/e2e/performance_test.go
+++ b/test/e2e/performance_test.go
@@ -290,7 +290,7 @@ func WaitNetworkPolicyRealize(nodeName string, table *openflow.Table, policyRule
 // default flow entry which is used for default matching.
 // Since the check is done over SSH, the time measurement is not completely accurate.
 func checkRealize(nodeName string, table *openflow.Table, policyRules int, data *TestData) (bool, error) {
-	antreaPodName, err := data.getAntreaPodOnNode(nodeName)
+	antreaPodName, err := data.GetAntreaPodOnNode(nodeName)
 	if err != nil {
 		return false, err
 	}

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -634,7 +634,7 @@ func testProxyServiceSessionAffinity(ipFamily *corev1.IPFamily, ingressIPs []str
 	// Hold on to make sure that the Service is realized.
 	time.Sleep(serviceDelay)
 
-	agentName, err := data.getAntreaPodOnNode(nodeName)
+	agentName, err := data.GetAntreaPodOnNode(nodeName)
 	require.NoError(t, err)
 	tableSessionAffinityName := "SessionAffinity"
 	tableSessionAffinityOutput, _, err := data.RunCommandFromPod(metav1.NamespaceSystem, agentName, "antrea-agent", []string{"ovs-ofctl", "dump-flows", defaultBridgeName, fmt.Sprintf("table=%s", tableSessionAffinityName)})
@@ -915,7 +915,7 @@ func testProxyEndpointLifeCycle(ipFamily *corev1.IPFamily, data *TestData, t *te
 	// Hold on to make sure that the Service is realized.
 	time.Sleep(serviceDelay)
 
-	agentName, err := data.getAntreaPodOnNode(nodeName)
+	agentName, err := data.GetAntreaPodOnNode(nodeName)
 	require.NoError(t, err)
 	var nginxIP string
 	if *ipFamily == corev1.IPv6Protocol {
@@ -1016,7 +1016,7 @@ func testProxyServiceLifeCycle(ipFamily *corev1.IPFamily, ingressIPs []string, d
 	_, err = data.createNginxLoadBalancerService(false, ingressIPs, ipFamily)
 	defer data.deleteServiceAndWait(defaultTimeout, nginxLBService, data.testNamespace)
 	require.NoError(t, err)
-	agentName, err := data.getAntreaPodOnNode(nodeName)
+	agentName, err := data.GetAntreaPodOnNode(nodeName)
 	require.NoError(t, err)
 
 	// Hold on to make sure that the Service is realized.

--- a/test/e2e/service_externalip_test.go
+++ b/test/e2e/service_externalip_test.go
@@ -868,7 +868,7 @@ func (data *TestData) getServiceAssignedNode(node string, service *v1.Service) (
 	if node == "" {
 		node = nodeName(0)
 	}
-	agentPodName, err := data.getAntreaPodOnNode(node)
+	agentPodName, err := data.GetAntreaPodOnNode(node)
 	if err != nil {
 		return "", err
 	}

--- a/test/e2e/supportbundle_test.go
+++ b/test/e2e/supportbundle_test.go
@@ -73,7 +73,7 @@ func testSupportBundle(name string, t *testing.T) {
 		podName = pod.Name
 		podPort = apis.AntreaControllerAPIPort
 	} else {
-		podName, err = data.getAntreaPodOnNode(controlPlaneNodeName())
+		podName, err = data.GetAntreaPodOnNode(controlPlaneNodeName())
 		require.NoError(t, err)
 		podPort = apis.AntreaAgentAPIPort
 	}

--- a/test/e2e/traceflow_test.go
+++ b/test/e2e/traceflow_test.go
@@ -371,7 +371,7 @@ func testTraceflowIntraNode(t *testing.T, data *TestData) {
 		}
 	}()
 
-	antreaPod, err := data.getAntreaPodOnNode(node1)
+	antreaPod, err := data.GetAntreaPodOnNode(node1)
 	if err = data.waitForNetworkpolicyRealized(antreaPod, node1, isWindows, allowAllEgressName, v1beta2.K8sNetworkPolicy); err != nil {
 		t.Fatal(err)
 	}
@@ -1227,7 +1227,7 @@ func testTraceflowInterNode(t *testing.T, data *TestData) {
 		}
 	}()
 
-	antreaPod, err := data.getAntreaPodOnNode(node2)
+	antreaPod, err := data.GetAntreaPodOnNode(node2)
 	if err = data.waitForNetworkpolicyRealized(antreaPod, node2, isWindows, allowAllEgressName, v1beta2.K8sNetworkPolicy); err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/wireguard_test.go
+++ b/test/e2e/wireguard_test.go
@@ -73,7 +73,7 @@ func testPodConnectivity(t *testing.T, data *TestData) {
 	data.runPingMesh(t, podInfos[:numPods], toolboxContainerName, true)
 
 	// Make sure that route to Pod on peer Node and route to peer gateway is targeting the WireGuard device.
-	srcPod, err := data.getAntreaPodOnNode(nodeName(0))
+	srcPod, err := data.GetAntreaPodOnNode(nodeName(0))
 	require.NoError(t, err)
 	var srcIP, peerGatewayIP, peerPodIP string
 	ipv4, ipv6 := nodeGatewayIPs(0)


### PR DESCRIPTION
test/e2e: improves VLAN Network test flake's reliability and logging

When flakes occurred it was unclear which stage of the pod setup took
too long. In addition, we could only see that one pod failed to finish.

Future debugging improved with more detailed error messages:
* Check for Pods getting "Scheduled"
* Check for podInterface creation for each Pod
* Summary of number Pods finished instead of erroring out on the first
  incomplete Pod

Reliability improved with a shared timeout budget:
* The default timeout per pod is now treated as a total budget shared
  across all checks and Pods. This allows "fast" steps or Pods to
  yield their unused time to "slower" ones

Example output from when podScheduling timeout is reached:
* https://github.com/antrea-io/antrea/actions/runs/21674797248/job/62493063563?pr=7751
  * created by intentionally shrinking timeout to 1 ms to force an error
  * shows the number of pods that have been scheduled
  
```
Error verifying secondary interfaces (configuration and connectivity): Reached timeout (1ms) for when waiting for Pod to be scheduled. 1 out of 3 pods scheduled
```

Example output from when podInterface timeout is reached:
* https://github.com/antrea-io/antrea/actions/runs/21679923463/job/62511671886?pr=7751#step:8:80
 
```
Error verifying secondary interfaces (configuration and connectivity): Reached timeout (1ms) for when waiting for podInterface to be created. 0 out of 3 podInterfaces created.
```