### PR TITLE
Add tree visualization support to antctl traceflow

### DIFF
--- a/pkg/antctl/raw/traceflow/command_test.go
+++ b/pkg/antctl/raw/traceflow/command_test.go
@@ -269,6 +269,17 @@ destination: default/service
 source: default/pod-1
 `,
 		},
+		{
+			name:       "dummy-traceflow-tree-output",
+			src:        srcPod,
+			dst:        dstPod,
+			outputType: "tree",
+			expected: `Phase: Succeeded
+Source: default/pod-1
+Destination: default/pod-2
+Packet Flow:
+`,
+		},
 	}
 
 	for _, tt := range tcs {


### PR DESCRIPTION
## Description

This PR adds a tree-style visualization option to the `antctl traceflow` command to improve readability in headless environments where the Antrea Web UI is not accessible.

Fixes #7749

## Changes

- Added `tree` as a new output format option (alongside `yaml` and `json`)
- Implemented `treeOutput()` function to render traceflow results as a hierarchical ASCII tree
- Used Unicode box-drawing characters (├──, └──, │) for visual structure
- Added visual symbols for different actions:
  - ✓ for Delivered
  - → for Forwarded
  - ✗ for Dropped/Rejected
  - ⇉ for ForwardedOutOfNetwork
  - ⊙ for MarkedForSNAT
  - ⇨ for ForwardedToEgressNode
- Displays component information, policies, tunnels, and IP translations in a structured format
- Added test case for tree output format

## Usage Example

```bash
antctl traceflow -S pod1 -D pod2 -o tree
```

This will display the traceflow results in a hierarchical tree format, making it easier to visualize packet flow through the network, especially in complex scenarios involving multiple nodes, policies, and network components.

## Testing

- Added unit test case for tree output format
- Verified the tree output renders correctly with test data