### PR TITLE
fix: add missing synchronization in ReassignFlowPriorities

### DIFF
--- a/pkg/agent/openflow/network_policy.go
+++ b/pkg/agent/openflow/network_policy.go
@@ -1867,6 +1867,9 @@ func (f *featureNetworkPolicy) calculateFlowUpdates(updates map[uint16]uint16, t
 // ReassignFlowPriorities takes a list of priority updates, and update the actionFlows to replace
 // the old priority with the desired one, for each priority update.
 func (c *client) ReassignFlowPriorities(updates map[uint16]uint16, table uint8) error {
+	c.featureNetworkPolicy.conjMatchFlowLock.Lock()
+	defer c.featureNetworkPolicy.conjMatchFlowLock.Unlock()
+
 	addFlows, delFlows, conjFlowUpdates := c.featureNetworkPolicy.calculateFlowUpdates(updates, table)
 	add, update, del := c.featureNetworkPolicy.processFlowUpdates(addFlows, delFlows)
 	// Commit the flows updates calculated.
@@ -1874,6 +1877,7 @@ func (c *client) ReassignFlowPriorities(updates map[uint16]uint16, table uint8) 
 	if err != nil {
 		return err
 	}
+
 	for conjID, actionUpdates := range conjFlowUpdates {
 		originalConj, _, _ := c.featureNetworkPolicy.policyCache.GetByKey(fmt.Sprint(conjID))
 		conj := originalConj.(*policyRuleConjunction)


### PR DESCRIPTION
**Checklist**

- [x] I have read the [contribution guidelines](https://github.com/antrea-io/antrea/blob/main/CONTRIBUTING.md).
- [x] I have enabled the maintainer edits option .
- [x] I have self-reviewed the code changes.
- [x] I have run the [verification scripts](https://github.com/antrea-io/antrea/blob/main/docs/contributing/testing.md) matching my changes (e.g., `make unit-test`, `make test-integration-agent`).

**What this PR does**:

Fixes a race condition in ReassignFlowPriorities where `globalConjMatchFlowCache` was accessed without holding `conjMatchFlowLock`.

This patch acquires the lock at the function entry to ensure atomicity across:
1. Flow calculation (calculateFlowUpdates), which reads the cache.
2. OVS bundle implementation (`AddFlowsInBundle`).
3. Cache update (updateConjunctionMatchFlows]), which writes to the cache.

**Which issue(s) this PR fixes**:

Fixes #7726

The lock is held throughout the function execution to prevent "check-then-act" races where the cache state might change between calculation and update.
