### PR TITLE
Automated cherry pick of #7760: Only delete Pod CIDR element from nftables set if it is

### DIFF
--- a/pkg/agent/route/route_linux.go
+++ b/pkg/agent/route/route_linux.go
@@ -3140,57 +3140,78 @@ func (c *Client) syncNFTables(ctx context.Context) error {
 }
 
 func (c *Client) addPeerPodCIDRToNFTablesSet(podCIDR *net.IPNet) error {
+	podCIDRStr := podCIDR.String()
 	var nft knftables.Interface
+	var podCIDRNFTablesSet *sync.Map
 	isIPv6 := utilnet.IsIPv6(podCIDR.IP)
 	if isIPv6 {
 		nft = c.nftables.IPv6
+		podCIDRNFTablesSet = &c.podCIDRNFTablesSetIPv6
 	} else {
 		nft = c.nftables.IPv4
+		podCIDRNFTablesSet = &c.podCIDRNFTablesSetIPv4
 	}
 
 	tx := nft.NewTransaction()
 	element := &knftables.Element{
 		Set: antreaNFTablesSetPeerPodCIDR,
-		Key: []string{podCIDR.String()},
+		Key: []string{podCIDRStr},
 	}
 	tx.Add(element)
 	if err := nft.Run(context.TODO(), tx); err != nil {
 		return err
 	}
-
-	if isIPv6 {
-		c.podCIDRNFTablesSetIPv6.Store(podCIDR.String(), element)
-	} else {
-		c.podCIDRNFTablesSetIPv4.Store(podCIDR.String(), element)
-	}
+	podCIDRNFTablesSet.Store(podCIDRStr, element)
 
 	return nil
 }
 
 func (c *Client) deletePeerPodCIDRFromNFTablesSet(podCIDR *net.IPNet) error {
+	podCIDRStr := podCIDR.String()
 	var nft knftables.Interface
+	var podCIDRNFTablesSet *sync.Map
 	isIPv6 := utilnet.IsIPv6(podCIDR.IP)
 	if isIPv6 {
 		nft = c.nftables.IPv6
+		podCIDRNFTablesSet = &c.podCIDRNFTablesSetIPv6
 	} else {
 		nft = c.nftables.IPv4
+		podCIDRNFTablesSet = &c.podCIDRNFTablesSetIPv4
+	}
+
+	if _, exists := podCIDRNFTablesSet.Load(podCIDRStr); !exists {
+		return nil
 	}
 
 	tx := nft.NewTransaction()
 	element := &knftables.Element{
 		Set: antreaNFTablesSetPeerPodCIDR,
-		Key: []string{podCIDR.String()},
+		Key: []string{podCIDRStr},
 	}
 	tx.Delete(element)
-	if err := nft.Run(context.TODO(), tx); err != nil {
-		return err
-	}
 
-	if isIPv6 {
-		c.podCIDRNFTablesSetIPv6.Delete(podCIDR.String())
-	} else {
-		c.podCIDRNFTablesSetIPv4.Delete(podCIDR.String())
+	isElementNotFound := func(err error) bool {
+		if err == nil {
+			return false
+		}
+		s := err.Error()
+		// NOTE: nftables error messages are not stable across versions / distros.
+		// This is a best-effort check until lib sigs.k8s.io/knftables provides a structured NotFound error for set
+		// elements.
+		return strings.Contains(s, "element does not exist") ||
+			strings.Contains(s, "no such element") ||
+			strings.Contains(s, "No such file or directory")
 	}
+	if err := nft.Run(context.TODO(), tx); err != nil {
+		if isElementNotFound(err) {
+			klog.InfoS("Failed to delete nftables element for Pod CIDR from set since it doesn't exist",
+				"Set", antreaNFTablesSetPeerPodCIDR,
+				"PodCIDR", podCIDRStr)
+		} else {
+			return err
+		}
+	}
+	podCIDRNFTablesSet.Delete(podCIDRStr)
 
 	return nil
 }


### PR DESCRIPTION
Cherry pick of #7760 on release-2.5.

#7760: Only delete Pod CIDR element from nftables set if it is

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.