### PR TITLE
Add IP family validation for IPPool and ExternalIPPool

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -560,7 +560,7 @@ func run(o *Options) error {
 
 	if o.enableEgress || features.DefaultFeatureGate.Enabled(features.ServiceExternalIP) {
 		externalIPPoolController = externalippool.NewExternalIPPoolController(
-			crdClient, externalIPPoolInformer,
+			crdClient, externalIPPoolInformer, v4Enabled, v6Enabled,
 		)
 		var nodeTransportIP net.IP
 		if nodeConfig.NodeTransportIPv4Addr != nil {

--- a/cmd/antrea-controller/controller.go
+++ b/cmd/antrea-controller/controller.go
@@ -235,16 +235,23 @@ func run(o *Options) error {
 	ipv4Enabled, ipv6Enabled := true, true
 	if features.DefaultFeatureGate.Enabled(features.NodeIPAM) && o.config.NodeIPAM.EnableNodeIPAM && len(o.config.NodeIPAM.ClusterCIDRs) > 0 {
 		ipv4Enabled, ipv6Enabled = false, false
+		hasValidClusterCIDR := false
 		for _, cidrStr := range o.config.NodeIPAM.ClusterCIDRs {
 			clusterCIDR, _, err := net.ParseCIDR(cidrStr)
 			if err != nil {
+				klog.Warningf("Failed to parse NodeIPAM ClusterCIDR %q: %v", cidrStr, err)
 				continue
 			}
+			hasValidClusterCIDR = true
 			if clusterCIDR.To4() != nil {
 				ipv4Enabled = true
 			} else {
 				ipv6Enabled = true
 			}
+		}
+		if !hasValidClusterCIDR {
+			klog.Warning("No valid NodeIPAM ClusterCIDRs found; assuming both IPv4 and IPv6 are enabled")
+			ipv4Enabled, ipv6Enabled = true, true
 		}
 	}
 

--- a/cmd/antrea-controller/controller.go
+++ b/cmd/antrea-controller/controller.go
@@ -229,9 +229,28 @@ func run(o *Options) error {
 	var egressController *egress.EgressController
 	var externalIPPoolController *externalippool.ExternalIPPoolController
 	var externalIPController *serviceexternalip.ServiceExternalIPController
+
+	// Determine the cluster's IP family configuration from NodeIPAM ClusterCIDRs.
+	// If NodeIPAM is not configured, both IPv4 and IPv6 are considered enabled.
+	ipv4Enabled, ipv6Enabled := true, true
+	if features.DefaultFeatureGate.Enabled(features.NodeIPAM) && o.config.NodeIPAM.EnableNodeIPAM && len(o.config.NodeIPAM.ClusterCIDRs) > 0 {
+		ipv4Enabled, ipv6Enabled = false, false
+		for _, cidrStr := range o.config.NodeIPAM.ClusterCIDRs {
+			clusterCIDR, _, err := net.ParseCIDR(cidrStr)
+			if err != nil {
+				continue
+			}
+			if clusterCIDR.To4() != nil {
+				ipv4Enabled = true
+			} else {
+				ipv6Enabled = true
+			}
+		}
+	}
+
 	if features.DefaultFeatureGate.Enabled(features.Egress) || features.DefaultFeatureGate.Enabled(features.ServiceExternalIP) {
 		externalIPPoolController = externalippool.NewExternalIPPoolController(
-			crdClient, externalIPPoolInformer,
+			crdClient, externalIPPoolInformer, ipv4Enabled, ipv6Enabled,
 		)
 	}
 
@@ -282,7 +301,8 @@ func run(o *Options) error {
 			ipPoolInformer,
 			namespaceInformer,
 			podInformer,
-			statefulSetInformer)
+			statefulSetInformer,
+			ipv4Enabled, ipv6Enabled)
 	}
 
 	apiServerConfig, err := createAPIServerConfig(o.config.ClientConnection.Kubeconfig,

--- a/pkg/controller/egress/controller_test.go
+++ b/pkg/controller/egress/controller_test.go
@@ -182,7 +182,7 @@ func newController(objects, crdObjects []runtime.Object) *egressController {
 	crdClient.PrependReactor("patch", "egresses", egressPatchReactor)
 	informerFactory := informers.NewSharedInformerFactory(client, resyncPeriod)
 	crdInformerFactory := crdinformers.NewSharedInformerFactory(crdClient, resyncPeriod)
-	externalIPAllocator := externalippool.NewExternalIPPoolController(crdClient, crdInformerFactory.Crd().V1beta1().ExternalIPPools())
+	externalIPAllocator := externalippool.NewExternalIPPoolController(crdClient, crdInformerFactory.Crd().V1beta1().ExternalIPPools(), true, true)
 	egressGroupStore := store.NewEgressGroupStore()
 	egressInformer := crdInformerFactory.Crd().V1beta1().Egresses()
 	groupEntityIndex := grouping.NewGroupEntityIndex()

--- a/pkg/controller/externalippool/controller.go
+++ b/pkg/controller/externalippool/controller.go
@@ -119,10 +119,15 @@ type ExternalIPPoolController struct {
 
 	// queue maintains the ExternalIPPool objects that need to be synced.
 	queue workqueue.TypedRateLimitingInterface[string]
+
+	// ipv4Enabled indicates whether IPv4 is enabled in the cluster.
+	ipv4Enabled bool
+	// ipv6Enabled indicates whether IPv6 is enabled in the cluster.
+	ipv6Enabled bool
 }
 
 // NewExternalIPPoolController returns a new *ExternalIPPoolController.
-func NewExternalIPPoolController(crdClient clientset.Interface, externalIPPoolInformer antreainformers.ExternalIPPoolInformer) *ExternalIPPoolController {
+func NewExternalIPPoolController(crdClient clientset.Interface, externalIPPoolInformer antreainformers.ExternalIPPoolInformer, ipv4Enabled, ipv6Enabled bool) *ExternalIPPoolController {
 	c := &ExternalIPPoolController{
 		crdClient:                  crdClient,
 		externalIPPoolLister:       externalIPPoolInformer.Lister(),
@@ -135,6 +140,8 @@ func NewExternalIPPoolController(crdClient clientset.Interface, externalIPPoolIn
 		),
 		ipAllocatorInitialized: &atomic.Value{},
 		ipAllocatorMap:         make(map[string]ipallocator.MultiIPAllocator),
+		ipv4Enabled:            ipv4Enabled,
+		ipv6Enabled:            ipv6Enabled,
 	}
 	externalIPPoolInformer.Informer().AddEventHandlerWithResyncPeriod(
 		cache.ResourceEventHandlerFuncs{

--- a/pkg/controller/externalippool/controller_test.go
+++ b/pkg/controller/externalippool/controller_test.go
@@ -60,7 +60,7 @@ type controller struct {
 func newController(crdObjects []runtime.Object) *controller {
 	crdClient := fakeversioned.NewSimpleClientset(crdObjects...)
 	crdInformerFactory := crdinformers.NewSharedInformerFactory(crdClient, resyncPeriod)
-	externalIPPoolController := NewExternalIPPoolController(crdClient, crdInformerFactory.Crd().V1beta1().ExternalIPPools())
+	externalIPPoolController := NewExternalIPPoolController(crdClient, crdInformerFactory.Crd().V1beta1().ExternalIPPools(), true, true)
 	return &controller{
 		externalIPPoolController,
 		crdClient,

--- a/pkg/controller/externalippool/validate.go
+++ b/pkg/controller/externalippool/validate.go
@@ -57,12 +57,22 @@ func (c *ExternalIPPoolController) ValidateExternalIPPool(review *admv1.Admissio
 	switch review.Request.Operation {
 	case admv1.Create:
 		klog.V(2).Info("Validating CREATE request for ExternalIPPool")
+		if err := validation.ValidateIPRangeIPFamily(newObj.Spec.IPRanges, c.ipv4Enabled, c.ipv6Enabled); err != nil {
+			msg = err.Error()
+			allowed = false
+			break
+		}
 		if err := validateIPRangesAndSubnetInfoForExternalIPPool(&newObj, externalIPPools); err != nil {
 			msg = err.Error()
 			allowed = false
 		}
 	case admv1.Update:
 		klog.V(2).Info("Validating UPDATE request for ExternalIPPool")
+		if err := validation.ValidateIPRangeIPFamily(newObj.Spec.IPRanges, c.ipv4Enabled, c.ipv6Enabled); err != nil {
+			msg = err.Error()
+			allowed = false
+			break
+		}
 		if err := validateIPRangesAndSubnetInfoForExternalIPPool(&newObj, externalIPPools); err != nil {
 			msg = err.Error()
 			allowed = false

--- a/pkg/controller/ipam/antrea_ipam_controller.go
+++ b/pkg/controller/ipam/antrea_ipam_controller.go
@@ -89,6 +89,11 @@ type AntreaIPAMController struct {
 
 	// statusQueue maintains the IPPool objects that need to be synced.
 	statusQueue workqueue.TypedRateLimitingInterface[string]
+
+	// ipv4Enabled indicates whether IPv4 is enabled in the cluster.
+	ipv4Enabled bool
+	// ipv6Enabled indicates whether IPv6 is enabled in the cluster.
+	ipv6Enabled bool
 }
 
 func statefulSetIndexFunc(obj interface{}) ([]string, error) {
@@ -109,7 +114,8 @@ func NewAntreaIPAMController(crdClient versioned.Interface,
 	ipPoolInformer crdinformers.IPPoolInformer,
 	namespaceInformer coreinformers.NamespaceInformer,
 	podInformer coreinformers.PodInformer,
-	statefulSetInformer appsinformers.StatefulSetInformer) *AntreaIPAMController {
+	statefulSetInformer appsinformers.StatefulSetInformer,
+	ipv4Enabled, ipv6Enabled bool) *AntreaIPAMController {
 
 	ipPoolInformer.Informer().AddIndexers(cache.Indexers{statefulSetIndex: statefulSetIndexFunc})
 
@@ -136,6 +142,8 @@ func NewAntreaIPAMController(crdClient versioned.Interface,
 				Name: "IPPoolStatus",
 			},
 		),
+		ipv4Enabled: ipv4Enabled,
+		ipv6Enabled: ipv6Enabled,
 	}
 
 	// Add handlers for Stateful Set events.

--- a/pkg/controller/ipam/antrea_ipam_controller_test.go
+++ b/pkg/controller/ipam/antrea_ipam_controller_test.go
@@ -62,7 +62,7 @@ func newFakeAntreaIPAMController(pool *crdv1b1.IPPool, namespace *corev1.Namespa
 	poolInformer := crdInformerFactory.Crd().V1beta1().IPPools()
 	poolLister := poolInformer.Lister()
 
-	controller := NewAntreaIPAMController(crdClient, poolInformer, namespaceInformer, podInformer, statefulSetInformer)
+	controller := NewAntreaIPAMController(crdClient, poolInformer, namespaceInformer, podInformer, statefulSetInformer, true, true)
 	return &fakeAntreaIPAMController{
 		AntreaIPAMController: controller,
 		fakeK8sClient:        k8sClient,

--- a/pkg/controller/ipam/validate.go
+++ b/pkg/controller/ipam/validate.go
@@ -50,12 +50,22 @@ func (c *AntreaIPAMController) ValidateIPPool(review *admv1.AdmissionReview) *ad
 	switch review.Request.Operation {
 	case admv1.Create:
 		klog.V(2).Info("Validating CREATE request for IPPool")
+		if err := validation.ValidateIPRangeIPFamily(newObj.Spec.IPRanges, c.ipv4Enabled, c.ipv6Enabled); err != nil {
+			msg = err.Error()
+			allowed = false
+			break
+		}
 		if _, err := validation.ValidateIPRangesAndSubnetInfo(&newObj.Spec.SubnetInfo, newObj.Spec.IPRanges); err != nil {
 			msg = err.Error()
 			allowed = false
 		}
 	case admv1.Update:
 		klog.V(2).Info("Validating UPDATE request for IPPool")
+		if err := validation.ValidateIPRangeIPFamily(newObj.Spec.IPRanges, c.ipv4Enabled, c.ipv6Enabled); err != nil {
+			msg = err.Error()
+			allowed = false
+			break
+		}
 		if _, err := validation.ValidateIPRangesAndSubnetInfo(&newObj.Spec.SubnetInfo, newObj.Spec.IPRanges); err != nil {
 			msg = err.Error()
 			allowed = false

--- a/pkg/controller/serviceexternalip/controller_test.go
+++ b/pkg/controller/serviceexternalip/controller_test.go
@@ -86,7 +86,7 @@ func newController(objects, crdObjects []runtime.Object) *loadBalancerController
 	crdClient := fakeversioned.NewSimpleClientset(crdObjects...)
 	informerFactory := informers.NewSharedInformerFactory(client, resyncPeriod)
 	crdInformerFactory := crdinformers.NewSharedInformerFactory(crdClient, resyncPeriod)
-	externalIPPoolController := externalippool.NewExternalIPPoolController(crdClient, crdInformerFactory.Crd().V1beta1().ExternalIPPools())
+	externalIPPoolController := externalippool.NewExternalIPPoolController(crdClient, crdInformerFactory.Crd().V1beta1().ExternalIPPools(), true, true)
 	controller := NewServiceExternalIPController(client, informerFactory.Core().V1().Services(), externalIPPoolController)
 	return &loadBalancerController{
 		ServiceExternalIPController: controller,

--- a/pkg/controller/validation/ippool.go
+++ b/pkg/controller/validation/ippool.go
@@ -28,11 +28,7 @@ import (
 func GetIPRangeSet(ipRanges []crdv1beta1.IPRange) sets.Set[string] {
 	set := sets.New[string]()
 	for _, ipRange := range ipRanges {
-		ipRangeStr := ipRange.CIDR
-		if ipRangeStr == "" {
-			ipRangeStr = fmt.Sprintf("%s-%s", ipRange.Start, ipRange.End)
-		}
-		set.Insert(ipRangeStr)
+		set.Insert(ipRangeToString(ipRange))
 	}
 	return set
 }

--- a/pkg/controller/validation/ippool.go
+++ b/pkg/controller/validation/ippool.go
@@ -205,16 +205,16 @@ func ValidateIPRangeIPFamily(ipRanges []crdv1beta1.IPRange, ipv4Enabled, ipv6Ena
 // isIPRangeIPv4 returns true if the IP range uses IPv4 addresses.
 func isIPRangeIPv4(ipRange crdv1beta1.IPRange) (bool, error) {
 	if ipRange.CIDR != "" {
-		cidr, err := netip.ParsePrefix(ipRange.CIDR)
+		cidr, err := parseIPRangeCIDR(ipRange.CIDR)
 		if err != nil {
-			return false, fmt.Errorf("invalid cidr %s", ipRange.CIDR)
+			return false, err
 		}
 		return cidr.Addr().Is4(), nil
 	}
-	start, err := netip.ParseAddr(ipRange.Start)
-	if err != nil {
-		return false, fmt.Errorf("invalid start ip address %s", ipRange.Start)
+	if err := validateIPRange(ipRange); err != nil {
+		return false, err
 	}
+	start, _ := netip.ParseAddr(ipRange.Start)
 	return start.Is4(), nil
 }
 

--- a/pkg/controller/validation/ippool.go
+++ b/pkg/controller/validation/ippool.go
@@ -184,6 +184,9 @@ func RangesOverlap(start1, end1, start2, end2 netip.Addr) bool {
 
 // ValidateIPRangeIPFamily validates that all IP ranges use an IP family enabled in the cluster.
 func ValidateIPRangeIPFamily(ipRanges []crdv1beta1.IPRange, ipv4Enabled, ipv6Enabled bool) error {
+	if !ipv4Enabled && !ipv6Enabled {
+		return fmt.Errorf("no IP families are enabled in the cluster")
+	}
 	for _, ipRange := range ipRanges {
 		isIPv4, err := isIPRangeIPv4(ipRange)
 		if err != nil {

--- a/pkg/controller/validation/ippool_test.go
+++ b/pkg/controller/validation/ippool_test.go
@@ -757,6 +757,16 @@ func TestValidateIPRangeIPFamily(t *testing.T) {
 			expectErr:   true,
 			errContains: "IPv6 range fd00:10:96::/112 is not allowed in an IPv4-only cluster",
 		},
+		{
+			name: "neither IPv4 nor IPv6 enabled",
+			ipRanges: []crdv1beta1.IPRange{
+				{CIDR: "10.0.0.0/24"},
+			},
+			ipv4Enabled: false,
+			ipv6Enabled: false,
+			expectErr:   true,
+			errContains: "no IP families are enabled in the cluster",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## What this PR does
Fixes #7773 
This PR adds IP family validation for `IPPool` and `ExternalIPPool` resources. It prevents users from creating pools with IP families that are not enabled in the cluster.

For example, creating an IPv4 pool in an IPv6-only cluster will now be rejected with a clear error message.

## How it works
- Added a new `ValidateIPRangeIPFamily` function that checks if each IP range matches an enabled family. 
- The cluster's IP family config is passed to `ExternalIPPoolController` and `AntreaIPAMController` during initialization.
- On the controller side, IP family is determined from NodeIPAM.ClusterCIDRs. If NodeIPAM is not configured, both families are allowed.
- On the agent side, the existing `IPv4Enabled/IPv6Enabled` from `networkConfig` is used.
- Validation runs on both CREATE and UPDATE operations.

## Testing
- 12 unit tests for the core validation function (CIDR, start-end, dual-stack, IPv4-only, IPv6-only, mixed).
- 12 webhook-level integration tests (6 for IPPool, 6 for ExternalIPPool) testing the full admission path.
- All existing tests pass with no regressions.

