### PR TITLE
Automated cherry pick of #7741: Fix flaky FlowAggregator E2E tests by checking metrics

### DIFF
--- a/test/e2e/flowaggregator_test.go
+++ b/test/e2e/flowaggregator_test.go
@@ -213,6 +213,11 @@ func setupFlowAggregatorTest(t *testing.T, options flowVisibilityTestOptions) (*
 	if err := setupFlowAggregator(t, data, options); err != nil {
 		t.Fatalf("Error when setting up FlowAggregator: %v", err)
 	}
+
+	if err := getAndCheckFlowAggregatorMetrics(t, data, options.databaseURL != ""); err != nil {
+		t.Fatalf("Error when checking metrics of Flow Aggregator: %v", err)
+	}
+
 	// Execute teardownFlowAggregator later than teardownTest to ensure that the logs of Flow
 	// Aggregator has been exported.
 	teardownFuncs = append(teardownFuncs, func() { teardownFlowAggregator(t, data) })
@@ -299,9 +304,6 @@ func TestFlowAggregator(t *testing.T) {
 	data, v4Enabled, v6Enabled := setupFlowAggregatorTest(t, flowVisibilityTestOptions{
 		databaseURL: defaultCHDatabaseURL,
 	})
-	if err := getAndCheckFlowAggregatorMetrics(t, data, true); err != nil {
-		t.Fatalf("Error when checking metrics of Flow Aggregator: %v", err)
-	}
 
 	k8sUtils, err = NewKubernetesUtils(data)
 	if err != nil {
@@ -350,7 +352,6 @@ func TestFlowAggregatorProxyMode(t *testing.T) {
 				includeK8sNames: includeK8sNames,
 			},
 		})
-		require.NoError(t, getAndCheckFlowAggregatorMetrics(t, data, false), "Error when checking metrics of Flow Aggregator")
 
 		// UIDs are only supported when using gRPC between FE and FA.
 		if k8sUIDsInsteadOfNames {


### PR DESCRIPTION
Cherry pick of #7741 on release-2.4.

#7741: Fix flaky FlowAggregator E2E tests by checking metrics

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.