### PR TITLE
Fix integer overflow in IPFIX exporter delta calculation

### DIFF
--- a/pkg/agent/flowexporter/exporter/ipfix.go
+++ b/pkg/agent/flowexporter/exporter/ipfix.go
@@ -290,33 +290,48 @@ func (e *ipfixExporter) addConnToSet(conn *connection.Connection) error {
 		case "octetTotalCount":
 			ie.SetUnsigned64Value(conn.OriginalBytes)
 		case "packetDeltaCount":
-			deltaPkts := int64(conn.OriginalPackets) - int64(conn.PrevPackets)
-			if deltaPkts < 0 {
-				klog.InfoS("Packet delta count for connection should not be negative", "packet delta count", deltaPkts)
+			var deltaPkts uint64
+			if conn.OriginalPackets >= conn.PrevPackets {
+				deltaPkts = conn.OriginalPackets - conn.PrevPackets
+			} else {
+				// While the unsigned subtraction will behave correctly (wrap around) in case of a simple
+				// overflow (which happens when converting a large uint64 to int64), we still want to
+				// detect if the packet count has actually decreased (e.g. counter reset).
+				deltaPkts = conn.OriginalPackets - conn.PrevPackets
+				klog.InfoS("Packet delta count for connection should not be negative", "packet delta count", int64(deltaPkts))
 			}
-			ie.SetUnsigned64Value(uint64(deltaPkts))
+			ie.SetUnsigned64Value(deltaPkts)
 		case "octetDeltaCount":
-			deltaBytes := int64(conn.OriginalBytes) - int64(conn.PrevBytes)
-			if deltaBytes < 0 {
-				klog.InfoS("Byte delta count for connection should not be negative", "byte delta count", deltaBytes)
+			var deltaBytes uint64
+			if conn.OriginalBytes >= conn.PrevBytes {
+				deltaBytes = conn.OriginalBytes - conn.PrevBytes
+			} else {
+				deltaBytes = conn.OriginalBytes - conn.PrevBytes
+				klog.InfoS("Byte delta count for connection should not be negative", "byte delta count", int64(deltaBytes))
 			}
-			ie.SetUnsigned64Value(uint64(deltaBytes))
+			ie.SetUnsigned64Value(deltaBytes)
 		case "reversePacketTotalCount":
 			ie.SetUnsigned64Value(conn.ReversePackets)
 		case "reverseOctetTotalCount":
 			ie.SetUnsigned64Value(conn.ReverseBytes)
 		case "reversePacketDeltaCount":
-			deltaPkts := int64(conn.ReversePackets) - int64(conn.PrevReversePackets)
-			if deltaPkts < 0 {
-				klog.InfoS("Reverse packet delta count for connection should not be negative", "packet delta count", deltaPkts)
+			var deltaPkts uint64
+			if conn.ReversePackets >= conn.PrevReversePackets {
+				deltaPkts = conn.ReversePackets - conn.PrevReversePackets
+			} else {
+				deltaPkts = conn.ReversePackets - conn.PrevReversePackets
+				klog.InfoS("Reverse packet delta count for connection should not be negative", "packet delta count", int64(deltaPkts))
 			}
-			ie.SetUnsigned64Value(uint64(deltaPkts))
+			ie.SetUnsigned64Value(deltaPkts)
 		case "reverseOctetDeltaCount":
-			deltaBytes := int64(conn.ReverseBytes) - int64(conn.PrevReverseBytes)
-			if deltaBytes < 0 {
-				klog.InfoS("Reverse byte delta count for connection should not be negative", "byte delta count", deltaBytes)
+			var deltaBytes uint64
+			if conn.ReverseBytes >= conn.PrevReverseBytes {
+				deltaBytes = conn.ReverseBytes - conn.PrevReverseBytes
+			} else {
+				deltaBytes = conn.ReverseBytes - conn.PrevReverseBytes
+				klog.InfoS("Reverse byte delta count for connection should not be negative", "byte delta count", int64(deltaBytes))
 			}
-			ie.SetUnsigned64Value(uint64(deltaBytes))
+			ie.SetUnsigned64Value(deltaBytes)
 		case "sourcePodNamespace":
 			ie.SetStringValue(conn.SourcePodNamespace)
 		case "sourcePodName":

--- a/pkg/agent/flowexporter/exporter/ipfix_overflow_test.go
+++ b/pkg/agent/flowexporter/exporter/ipfix_overflow_test.go
@@ -1,0 +1,115 @@
+package exporter
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	ipfixentities "github.com/vmware/go-ipfix/pkg/entities"
+	ipfixentitiestesting "github.com/vmware/go-ipfix/pkg/entities/testing"
+	"go.uber.org/mock/gomock"
+
+	"antrea.io/antrea/pkg/agent/flowexporter/connection"
+	ipfixtest "antrea.io/antrea/pkg/ipfix/testing"
+)
+
+func TestIPFIXExporter_DeltaCalculation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockIPFIXExpProc := ipfixtest.NewMockIPFIXExportingProcess(ctrl)
+	mockDataSet := ipfixentitiestesting.NewMockSet(ctrl)
+	mockIPFIXRegistry := ipfixtest.NewMockIPFIXRegistry(ctrl)
+
+	flowExp := &ipfixExporter{
+		process:        mockIPFIXExpProc,
+		elementsListv4: getElemList(IANAInfoElementsIPv4, AntreaInfoElementsIPv4),
+		templateIDv4:   testTemplateIDv4,
+		registry:       mockIPFIXRegistry,
+		v4Enabled:      true,
+		ipfixSet:       mockDataSet,
+	}
+
+	// Helper to find value in ElementListMatcher
+	getValue := func(name string, elements []ipfixentities.InfoElementWithValue) uint64 {
+		for _, ie := range elements {
+			if ie.GetInfoElement().Name == name {
+				return ie.GetUnsigned64Value()
+			}
+		}
+		return 0
+	}
+
+	tests := []struct {
+		name            string
+		originalPackets uint64
+		prevPackets     uint64
+		expectedDelta   uint64
+		originalBytes   uint64
+		prevBytes       uint64
+		expectedBytes   uint64
+	}{
+		{
+			name:            "Normal increase",
+			originalPackets: 100,
+			prevPackets:     90,
+			expectedDelta:   10,
+			originalBytes:   1000,
+			prevBytes:       900,
+			expectedBytes:   100,
+		},
+		{
+			name:            "Large value (potential overflow in int64)",
+			originalPackets: uint64(1<<63) + 100, // > MaxInt64
+			prevPackets:     uint64(1 << 63),
+			expectedDelta:   100,
+			originalBytes:   uint64(1<<63) + 1000,
+			prevBytes:       uint64(1 << 63),
+			expectedBytes:   1000,
+		},
+		{
+			name:            "Very large delta (overflow int64)",
+			originalPackets: uint64(1<<63) + 100,
+			prevPackets:     0,
+			expectedDelta:   uint64(1<<63) + 100,
+			originalBytes:   uint64(1<<63) + 1000,
+			prevBytes:       0,
+			expectedBytes:   uint64(1<<63) + 1000,
+		},
+		// Case: counter reset (Original < Prev)
+		// Logic: Original - Prev (wrap around)
+		{
+			name:            "Counter reset (negative delta)",
+			originalPackets: 10,
+			prevPackets:     20,
+			expectedDelta:   ^uint64(0) - 9, // -10 wrapped
+			originalBytes:   100,
+			prevBytes:       200,
+			expectedBytes:   ^uint64(0) - 99, // -100 wrapped
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			conn := &connection.Connection{
+				OriginalPackets: tc.originalPackets,
+				PrevPackets:     tc.prevPackets,
+				OriginalBytes:   tc.originalBytes,
+				PrevBytes:       tc.prevBytes,
+				FlowKey:         connection.Tuple{SourceAddress: netip.MustParseAddr("1.1.1.1"), DestinationAddress: netip.MustParseAddr("2.2.2.2")},
+			}
+
+			mockDataSet.EXPECT().ResetSet()
+			mockDataSet.EXPECT().PrepareSet(ipfixentities.Data, testTemplateIDv4).Return(nil)
+			mockDataSet.EXPECT().AddRecordV2(gomock.Any(), testTemplateIDv4).DoAndReturn(
+				func(elements []ipfixentities.InfoElementWithValue, templateID uint16) error {
+					deltaPkts := getValue("packetDeltaCount", elements)
+					deltaBytes := getValue("octetDeltaCount", elements)
+					assert.Equal(t, tc.expectedDelta, deltaPkts, "packetDeltaCount mismatch")
+					assert.Equal(t, tc.expectedBytes, deltaBytes, "octetDeltaCount mismatch")
+					return nil
+				})
+
+			err := flowExp.addConnToSet(conn)
+			assert.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
The IPFIX exporter computes delta counts for packets and bytes by subtracting the previous counter value from the current one. The original code cast both `uint64` operands to `int64` before subtraction, which silently overflows when counter values exceed `math.MaxInt64` (~9.2 × 10¹⁸).

This change removes the `int64` casts and performs the subtraction directly in `uint64` arithmetic, which is correct for monotonically increasing counters and also handles wrap-around naturally. A conditional log is emitted when the current value is less than the previous value (counter reset), preserving observability without altering the exported value.

**What changed:**
- `pkg/agent/flowexporter/exporter/ipfix.go`: replaced `int64` casts with direct `uint64` subtraction for `packetDeltaCount`, `octetDeltaCount`, `reversePacketDeltaCount`, and `reverseOctetDeltaCount`.
- `pkg/agent/flowexporter/exporter/ipfix_overflow_test.go` [NEW]: table-driven test covering normal deltas, values exceeding `MaxInt64`, and counter-reset scenarios.
  
  Fixes #7783
