### PR TITLE
Fix integer overflow in OpenFlow meter stats

### DIFF
--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -1694,7 +1694,7 @@ func (c *client) getMeterStats() {
 		PacketInMeterIDTF:  metrics.LabelPacketInMeterTraceflow,
 		PacketInMeterIDDNS: metrics.LabelPacketInMeterDNSInterception,
 	}
-	handleMeterStatsReply := func(meterID int, packetCount int64) {
+	handleMeterStatsReply := func(meterID int, packetCount uint64) {
 		label, exists := labels[meterID]
 		if !exists {
 			klog.V(4).InfoS("Received unexpected meterID", "meterID", meterID)

--- a/pkg/agent/openflow/meter_test.go
+++ b/pkg/agent/openflow/meter_test.go
@@ -1,0 +1,50 @@
+package openflow
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	ovsoftest "antrea.io/antrea/pkg/ovs/openflow/testing"
+)
+
+func TestClient_getMeterStats(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockBridge := ovsoftest.NewMockBridge(ctrl)
+
+	c := &client{
+		bridge: mockBridge,
+		ovsMeterPacketDrops: map[int]*atomic.Uint64{
+			PacketInMeterIDNP: {},
+		},
+		ovsMetersAreSupported: true,
+	}
+
+	// TestCase 1: Initial drop count
+	mockBridge.EXPECT().GetMeterStats(gomock.Any()).DoAndReturn(func(handleMeterStatsReply func(int, uint64)) error {
+		handleMeterStatsReply(PacketInMeterIDNP, 100)
+		return nil
+	})
+
+	c.getMeterStats()
+	assert.Equal(t, uint64(100), c.ovsMeterPacketDrops[PacketInMeterIDNP].Load())
+
+	// TestCase 2: Increase drop count (no overflow)
+	mockBridge.EXPECT().GetMeterStats(gomock.Any()).DoAndReturn(func(handleMeterStatsReply func(int, uint64)) error {
+		handleMeterStatsReply(PacketInMeterIDNP, 200)
+		return nil
+	})
+	c.getMeterStats()
+	assert.Equal(t, uint64(200), c.ovsMeterPacketDrops[PacketInMeterIDNP].Load())
+
+	// TestCase 3: Large drop count (overflow scenario if int64 was used)
+	largeCount := uint64(1<<63 + 100) // Value larger than max int64
+	mockBridge.EXPECT().GetMeterStats(gomock.Any()).DoAndReturn(func(handleMeterStatsReply func(int, uint64)) error {
+		handleMeterStatsReply(PacketInMeterIDNP, largeCount)
+		return nil
+	})
+	c.getMeterStats()
+	assert.Equal(t, largeCount, c.ovsMeterPacketDrops[PacketInMeterIDNP].Load())
+}

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -440,7 +440,7 @@ type client struct {
 	// ovsMetersAreSupported indicates whether the OVS datapath supports OpenFlow meters.
 	ovsMetersAreSupported bool
 	// ovsMeterPacketDrops tracks the number of packets dropped by each OVS meter, keyed by meter ID.
-	ovsMeterPacketDrops map[int]*atomic.Int64
+	ovsMeterPacketDrops map[int]*atomic.Uint64
 	// packetInRate defines the OVS controller packet rate limits for different
 	// features. All features will apply this rate-limit individually on packet-in
 	// messages sent to antrea-agent. The number stands for the rate as packets per
@@ -2885,7 +2885,7 @@ func NewClient(bridgeName string,
 	c.ofEntryOperations = operations.NewOFEntryOperations(bridge)
 	if c.ovsMetersAreSupported {
 		// Pre-initialize the map with all possible keys to avoid concurrent updates and potential race conditions later.
-		c.ovsMeterPacketDrops = map[int]*atomic.Int64{
+		c.ovsMeterPacketDrops = map[int]*atomic.Uint64{
 			PacketInMeterIDNP:  {},
 			PacketInMeterIDTF:  {},
 			PacketInMeterIDDNS: {},

--- a/pkg/ovs/openflow/interfaces.go
+++ b/pkg/ovs/openflow/interfaces.go
@@ -115,7 +115,7 @@ type Bridge interface {
 	NewMeter(id MeterIDType, flags ofctrl.MeterFlag) Meter
 	// DeleteMeterAll deletes all meter entries from the switch.
 	DeleteMeterAll() error
-	GetMeterStats(handleMeterStatsReply func(meterID int, packetCount int64)) error
+	GetMeterStats(handleMeterStatsReply func(meterID int, packetCount uint64)) error
 	DumpTableStatus() []TableStatus
 	// DumpFlows queries the Openflow entries from OFSwitch. The filter of the query is Openflow cookieID; the result is
 	// a map from flow cookieID to FlowStates.

--- a/pkg/ovs/openflow/ofctrl_bridge.go
+++ b/pkg/ovs/openflow/ofctrl_bridge.go
@@ -248,7 +248,7 @@ func (b *OFBridge) DeleteGroupAll() error {
 	return b.ofSwitch.Send(groupMod)
 }
 
-func (b *OFBridge) GetMeterStats(handleMeterStatsReply func(meterID int, packetCount int64)) error {
+func (b *OFBridge) GetMeterStats(handleMeterStatsReply func(meterID int, packetCount uint64)) error {
 	const OFPM_ALL = 0xffffffff // Represents all meters
 	mpMeterStatsReq := openflow15.NewMpRequest(openflow15.MultipartType_MeterStats)
 	meterMPReq := openflow15.NewMeterMultipartRequest(OFPM_ALL)
@@ -263,7 +263,7 @@ func (b *OFBridge) GetMeterStats(handleMeterStatsReply func(meterID int, packetC
 				for _, entry := range reply.Body {
 					stats := entry.(*openflow15.MeterStats)
 					if len(stats.BandStats) > 0 {
-						handleMeterStatsReply(int(stats.MeterId), int64(stats.BandStats[0].PacketBandCount))
+						handleMeterStatsReply(int(stats.MeterId), stats.BandStats[0].PacketBandCount)
 					}
 				}
 			}

--- a/pkg/ovs/openflow/ofctrl_bridge_test.go
+++ b/pkg/ovs/openflow/ofctrl_bridge_test.go
@@ -178,9 +178,9 @@ func TestOFMeterStats(t *testing.T) {
 	meterStats2 := newMeterStats(2, 0)
 	mpMeterStatsReply.Body = append(mpMeterStatsReply.Body, meterStats1)
 	mpMeterStatsReply.Body = append(mpMeterStatsReply.Body, meterStats2)
-	packetCounts := make(map[int]int64)
+	packetCounts := make(map[int]uint64)
 	packetCountsMutex := sync.RWMutex{}
-	handleMeterStatsReply := func(meterID int, packetCount int64) {
+	handleMeterStatsReply := func(meterID int, packetCount uint64) {
 		packetCountsMutex.Lock()
 		defer packetCountsMutex.Unlock()
 		packetCounts[meterID] = packetCount
@@ -196,7 +196,7 @@ func TestOFMeterStats(t *testing.T) {
 	assert.Eventually(t, func() bool {
 		packetCountsMutex.RLock()
 		defer packetCountsMutex.RUnlock()
-		return packetCounts[1] == int64(100) && packetCounts[2] == int64(0)
+		return packetCounts[1] == uint64(100) && packetCounts[2] == uint64(0)
 	}, 2*time.Second, 50*time.Millisecond)
 }
 

--- a/pkg/ovs/openflow/testing/mock_openflow.go
+++ b/pkg/ovs/openflow/testing/mock_openflow.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Antrea Authors
+// Copyright 2026 Antrea Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -202,7 +202,7 @@ func (mr *MockBridgeMockRecorder) DumpTableStatus() *gomock.Call {
 }
 
 // GetMeterStats mocks base method.
-func (m *MockBridge) GetMeterStats(handleMeterStatsReply func(int, int64)) error {
+func (m *MockBridge) GetMeterStats(handleMeterStatsReply func(int, uint64)) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMeterStats", handleMeterStatsReply)
 	ret0, _ := ret[0].(error)


### PR DESCRIPTION
`GetMeterStats` retrieves per-meter packet drop counts from OVS via OpenFlow multipart replies. The OVS `PacketBandCount` field is`uint64`, but the callback signature truncated it to `int64`, causing silent overflow when cumulative drop counts exceed `math.MaxInt64`.

This change updates the entire call chain to use `uint64`:

**What changed:**
- `pkg/ovs/openflow/interfaces.go`: updated `GetMeterStats` callback signature from `func(int, int64)` to `func(int, uint64)`.
- `pkg/ovs/openflow/ofctrl_bridge.go`: removed explicit `int64` cast; `stats.BandStats[0].PacketBandCount` is passed directly as `uint64`.
- `pkg/agent/openflow/client.go`: updated `handleMeterStatsReply` to accept `uint64`.
- `pkg/agent/openflow/pipeline.go`: changed `ovsMeterPacketDrops` from `map[int]*atomic.Int64` to `map[int]*atomic.Uint64`.
- `pkg/ovs/openflow/ofctrl_bridge_test.go`: aligned test assertions with `uint64` types.
- `pkg/ovs/openflow/testing/mock_openflow.go`: regenerated mock to match updated interface.
- `pkg/agent/openflow/meter_test.go` [NEW]: test covering initial counts, incremental updates, and values exceeding `MaxInt64`.
  
  Fixes #7784
