### PR TITLE
Fix docker IP retrieval in kind CI script

### DIFF
--- a/ci/kind/kind-setup.sh
+++ b/ci/kind/kind-setup.sh
@@ -46,9 +46,8 @@ options=()
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 set -eo pipefail
-function echoerr {
-    >&2 echo "$@"
-}
+
+source "$THIS_DIR/utils.sh"
 
 _usage="
 Usage: $0 create CLUSTER_NAME [--pod-cidr POD_CIDR] [--service-cidr SERVICE_CIDR] [--antrea-cni] [--num-workers NUM_WORKERS] [--images IMAGES] [--subnets SUBNETS] [--ip-family ipv4|ipv6|dual] [--k8s-version VERSION]
@@ -194,21 +193,23 @@ function configure_networks {
     num_networks=$((num_networks+1))
   fi
 
-  control_plane_ip4=$(docker inspect $cluster_name-control-plane --format '{{range $i, $conf:=.NetworkSettings.Networks}}{{$conf.IPAddress}}{{end}}')
-  control_plane_ip6=$(docker inspect $cluster_name-control-plane --format '{{range $i, $conf:=.NetworkSettings.Networks}}{{$conf.GlobalIPv6Address}}{{end}}')
+  control_plane_ip4=$(docker_get_ipv4 "$cluster_name-control-plane" "$cluster_name")
+  control_plane_ip6=$(docker_get_ipv6 "$cluster_name-control-plane" "$cluster_name")
 
   i=0
+  declare -A node_network
   for node in $nodes; do
     network=${networks[i]}
+    node_network["$node"]="$network"
     ifname="eth1"
     # the com.docker.network.endpoint.ifname label is only supported starting with Docker Engine v28
     # prior to that, the interface should be named "eth1" by default
     # note that providing an unsupported label does not generate an error
     docker network connect --driver-opt=com.docker.network.endpoint.ifname=$ifname $network $node
     echo "connected worker $node to network $network"
-    node_ip4=$(docker inspect $node --format '{{range $i, $conf:=.NetworkSettings.Networks}}{{$conf.IPAddress}}{{end}}')
-    node_ip6=$(docker inspect $node --format '{{range $i, $conf:=.NetworkSettings.Networks}}{{$conf.GlobalIPv6Address}}{{end}}')
-    node_ip6_prefix=$(docker inspect $node --format '{{range $i, $conf:=.NetworkSettings.Networks}}{{$conf.GlobalIPv6PrefixLen}}{{end}}')
+    node_ip4=$(docker_get_ipv4 "$node" "$network")
+    node_ip6=$(docker_get_ipv6 "$node" "$network")
+    node_ip6_prefix=$(docker_get_ipv6_prefix_len "$node" "$network")
 
     # reset network
     docker exec -t $node ip link set $ifname down
@@ -257,9 +258,10 @@ function configure_networks {
   done
 
   for node in $nodes; do
-    node_ip4=$(docker inspect $node --format '{{range $i, $conf:=.NetworkSettings.Networks}}{{$conf.IPAddress}}{{end}}')
+    network=${node_network["$node"]}
+    node_ip4=$(docker_get_ipv4 "$node" "$network")
     [[ "$IP_FAMILY" == "ipv6" ]] && node_ip4=""
-    node_ip6=$(docker inspect $node --format '{{range $i, $conf:=.NetworkSettings.Networks}}{{$conf.GlobalIPv6Address}}{{end}}')
+    node_ip6=$(docker_get_ipv6 "$node" "$network")
 
     echo "Waiting for node $node to be assigned InternalIP..."
     max_attempts=30
@@ -465,7 +467,7 @@ function load_images {
       echoerr "docker image $img not found"
       continue
     fi
-    kind load docker-image $img --name $cluster_name > /dev/null 2>&1
+    kind load docker-image "$img" --name "$cluster_name"
     if [[ $? -ne 0 ]]; then
       echoerr "docker image $img failed to load"
       continue

--- a/ci/kind/test-e2e-kind.sh
+++ b/ci/kind/test-e2e-kind.sh
@@ -18,9 +18,9 @@
 
 set -eo pipefail
 
-function echoerr {
-    >&2 echo "$@"
-}
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+source "$THIS_DIR/utils.sh"
 
 _usage="Usage: $0 [--encap-mode <mode>] [--ip-family <v4|v6|dual>] [--coverage] [--help|-h]
         --encap-mode                  Traffic encapsulation mode. (default is 'encap').
@@ -56,8 +56,6 @@ function print_usage {
     echoerr -n "$_usage"
 }
 
-
-THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 TESTBED_CMD="$THIS_DIR/kind-setup.sh"
 YML_CMD="$THIS_DIR/../../hack/generate-manifest.sh"
 FLOWAGGREGATOR_YML_CMD="$THIS_DIR/../../hack/generate-manifest-flow-aggregator.sh"
@@ -459,12 +457,12 @@ function run_test {
   fi
 
   external_agnhost_cid=$(docker ps -f name="^antrea-external-agnhost" --format '{{.ID}}')
-  external_agnhost_ips=$(docker inspect $external_agnhost_cid -f '{{.NetworkSettings.Networks.kind.IPAddress}},{{.NetworkSettings.Networks.kind.GlobalIPv6Address}}')
+  external_agnhost_ips=$(docker_get_ips "$external_agnhost_cid" kind)
   EXTRA_ARGS="$vlan_args --external-agnhost-ips $external_agnhost_ips"
 
   if $bgp_policy; then
     external_frr_cid=$(docker ps -f name="^antrea-external-frr" --format '{{.ID}}')
-    external_frr_ips=$(docker inspect $external_frr_cid -f '{{.NetworkSettings.Networks.kind.IPAddress}},{{.NetworkSettings.Networks.kind.GlobalIPv6Address}}')
+    external_frr_ips=$(docker_get_ips "$external_frr_cid" kind)
     EXTRA_ARGS="$EXTRA_ARGS --external-frr-cid $external_frr_cid --external-frr-ips $external_frr_ips"
   fi
 

--- a/ci/kind/utils.sh
+++ b/ci/kind/utils.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 Antrea Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function echoerr {
+    >&2 echo "$@"
+}
+
+function docker_get_ip {
+    local cid="${1}"
+    local network="${2}"
+    local property="${3:-IPAddress}"
+    local ip=$(docker inspect "$cid" -f "{{(index .NetworkSettings.Networks \"$network\").$property}}")
+    if [[ "$ip" == "invalid IP" ]]; then
+        ip=""
+    fi
+    echo "$ip"
+}
+
+function docker_get_ipv4 {
+    docker_get_ip "$@" "IPAddress"
+}
+
+function docker_get_ipv6 {
+    docker_get_ip "$@" "GlobalIPv6Address"
+}
+
+function docker_get_ips {
+    local ipv4=$(docker_get_ip "$@" "IPAddress")
+    local ipv6=$(docker_get_ip "$@" "GlobalIPv6Address")
+    echo "$ipv4,$ipv6"
+}
+
+function docker_get_ipv6_prefix_len {
+    local cid="${1}"
+    local network="${2}"
+    local prefix_len=$(docker inspect "$cid" -f "{{(index .NetworkSettings.Networks \"$network\").GlobalIPv6PrefixLen}}")
+    echo "$prefix_len"
+}


### PR DESCRIPTION
Moby recently switched from net.IP to netip.Addr to represent IP addresses for containers:
https://github.com/moby/moby/commit/a90adb6dc11aadec57832781316dac7865fc8da6 This change is included in version 1.52 of the API.

When the zero value is used for netip.Addr, its string form is "invalid IP" and *not* the empty string:
https://pkg.go.dev/net/netip#Addr.String
This means that when using docker inspect with Go template formatting, a missing IP address now shows as "invalid IP".
This change was causing the e2e test framework to fail for all single-stack tests, for which either the IPv4 address or the IPv6 address is missing.

To address this issue, we define some common bash functions to retrieve the IP addresses of a running docker container. If "invalid IP" is returned by inspect, we replace it with an empty string.

Note that there are other ways to resolve the issue. We could switch to JSON format (instead of Go templates), but then values are returned with extra quotes. The implementation of the bash functions can change in the future if a better approach comes along.

We also stop ignoring the output of 'kind load docker-image', as we have seen the command fail in CI recently.

Fixes #7780