### PR TITLE
Use latest available Go patch release in Github workflows

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -23,10 +23,10 @@ jobs:
           fetch-depth: 0
           show-progress: false
 
-      - name: Set up Go using version from go.mod
+      - name: Set up Go using version from .go-version
         uses: actions/setup-go@v6
         with:
-          go-version-file: 'go.mod'
+          go-version-file: '.go-version'
 
       - name: Install benchci
         run: curl -sfL https://raw.githubusercontent.com/antrea-io/benchci/main/install.sh | sudo sh -s -- -b /usr/local/bin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -210,7 +210,7 @@ jobs:
         driver: ${{ needs.check-env.outputs.docker_driver }}
     - uses: actions/setup-go@v6
       with:
-        go-version-file: 'go.mod'
+        go-version-file: '.go-version'
     - name: Build Antrea UBI9 Docker image without pushing to registry
       if: ${{ needs.check-env.outputs.push_needed == 'false' }}
       run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,10 +47,10 @@ jobs:
       with:
         show-progress: false
 
-    - name: Set up Go using version from go.mod
+    - name: Set up Go using version from .go-version
       uses: actions/setup-go@v6
       with:
-        go-version-file: 'go.mod'
+        go-version-file: '.go-version'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
@@ -91,10 +91,10 @@ jobs:
       with:
         show-progress: false
 
-    - name: Set up Go using version from go.mod
+    - name: Set up Go using version from .go-version
       uses: actions/setup-go@v6
       with:
-        go-version-file: 'go.mod'
+        go-version-file: '.go-version'
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -44,10 +44,10 @@ jobs:
       uses: actions/checkout@v6
       with:
         show-progress: false
-    - name: Set up Go using version from go.mod
+    - name: Set up Go using version from .go-version
       uses: actions/setup-go@v6
       with:
-        go-version-file: 'go.mod'
+        go-version-file: '.go-version'
     - name: Run unit tests
       run: make test-unit
     - name: Codecov
@@ -70,10 +70,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           show-progress: false
-      - name: Set up Go using version from go.mod
+      - name: Set up Go using version from .go-version
         uses: actions/setup-go@v6
         with:
-          go-version-file: 'go.mod'
+          go-version-file: '.go-version'
       - name: Run unit tests
         run: make test-unit
       - name: Codecov
@@ -96,10 +96,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           show-progress: false
-      - name: Set up Go using version from go.mod
+      - name: Set up Go using version from .go-version
         uses: actions/setup-go@v6
         with:
-          go-version-file: 'go.mod'
+          go-version-file: '.go-version'
       - name: Run integration tests
         run: |
           ./build/images/ovs/build.sh
@@ -131,10 +131,10 @@ jobs:
       uses: actions/checkout@v6
       with:
         show-progress: false
-    - name: Set up Go using version from go.mod
+    - name: Set up Go using version from .go-version
       uses: actions/setup-go@v6
       with:
-        go-version-file: 'go.mod'
+        go-version-file: '.go-version'
     - name: Run golangci-lint
       run: make golangci
 
@@ -148,10 +148,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           show-progress: false
-      - name: Set up Go using version from go.mod
+      - name: Set up Go using version from .go-version
         uses: actions/setup-go@v6
         with:
-          go-version-file: 'go.mod'
+          go-version-file: '.go-version'
       - name: Run golangci-lint
         run: make golangci
 
@@ -165,10 +165,10 @@ jobs:
       uses: actions/checkout@v6
       with:
         show-progress: false
-    - name: Set up Go using version from go.mod
+    - name: Set up Go using version from .go-version
       uses: actions/setup-go@v6
       with:
-        go-version-file: 'go.mod'
+        go-version-file: '.go-version'
     - name: Build Antrea binaries for amd64
       run: GOARCH=amd64 make bin
     - name: Build Antrea binaries for arm64
@@ -202,10 +202,10 @@ jobs:
       uses: actions/checkout@v6
       with:
         show-progress: false
-    - name: Set up Go using version from go.mod
+    - name: Set up Go using version from .go-version
       uses: actions/setup-go@v6
       with:
-        go-version-file: 'go.mod'
+        go-version-file: '.go-version'
     - name: Build Antrea windows binaries
       run: make windows-bin
 
@@ -219,10 +219,10 @@ jobs:
       uses: actions/checkout@v6
       with:
         show-progress: false
-    - name: Set up Go using version from go.mod
+    - name: Set up Go using version from .go-version
       uses: actions/setup-go@v6
       with:
-        go-version-file: 'go.mod'
+        go-version-file: '.go-version'
     # tidy check need to be run before code generation which will regenerate codes.
     - name: Check tidy
       run: make test-tidy
@@ -241,10 +241,10 @@ jobs:
       uses: actions/checkout@v6
       with:
         show-progress: false
-    - name: Set up Go using version from go.mod
+    - name: Set up Go using version from .go-version
       uses: actions/setup-go@v6
       with:
-        go-version-file: 'go.mod'
+        go-version-file: '.go-version'
     - name: Run verify scripts
       run: make verify
     - name: Checking for broken Markdown links
@@ -279,9 +279,9 @@ jobs:
         uses: actions/checkout@v6
         with:
           show-progress: false
-      - name: Set up Go using version from go.mod
+      - name: Set up Go using version from .go-version
         uses: actions/setup-go@v6
         with:
-          go-version-file: 'go.mod'
+          go-version-file: '.go-version'
       - name: Run Go benchmark test
         run: go test -run '^$' -bench . -benchtime 1x -timeout 10m -cpu 4 -v -benchmem ./pkg/...

--- a/.github/workflows/golicense.yml
+++ b/.github/workflows/golicense.yml
@@ -41,10 +41,10 @@ jobs:
     - uses: actions/checkout@v6
       with:
         show-progress: false
-    - name: Set up Go using version from go.mod
+    - name: Set up Go using version from .go-version
       uses: actions/setup-go@v6
       with:
-        go-version-file: 'go.mod'
+        go-version-file: '.go-version'
     - name: Cache licensing information for dependencies
       uses: actions/cache@v5
       id: cache

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -90,7 +90,7 @@ jobs:
         show-progress: false
     - uses: actions/setup-go@v6
       with:
-        go-version-file: 'go.mod'
+        go-version-file: '.go-version'
     - name: Download Antrea image from previous job
       uses: actions/download-artifact@v7
       with:
@@ -153,7 +153,7 @@ jobs:
         show-progress: false
     - uses: actions/setup-go@v6
       with:
-        go-version-file: 'go.mod'
+        go-version-file: '.go-version'
     - name: Download Antrea image from previous job
       uses: actions/download-artifact@v7
       with:
@@ -223,7 +223,7 @@ jobs:
           show-progress: false
       - uses: actions/setup-go@v6
         with:
-          go-version-file: 'go.mod'
+          go-version-file: '.go-version'
       - name: Download Antrea image from previous job
         uses: actions/download-artifact@v7
         with:
@@ -290,7 +290,7 @@ jobs:
           show-progress: false
       - uses: actions/setup-go@v6
         with:
-          go-version-file: 'go.mod'
+          go-version-file: '.go-version'
       - name: Download Antrea image from previous job
         uses: actions/download-artifact@v7
         with:
@@ -359,7 +359,7 @@ jobs:
         show-progress: false
     - uses: actions/setup-go@v6
       with:
-        go-version-file: 'go.mod'
+        go-version-file: '.go-version'
     - name: Download Antrea image from previous job
       uses: actions/download-artifact@v7
       with:
@@ -422,7 +422,7 @@ jobs:
         show-progress: false
     - uses: actions/setup-go@v6
       with:
-        go-version-file: 'go.mod'
+        go-version-file: '.go-version'
     - name: Download Antrea image from previous job
       uses: actions/download-artifact@v7
       with:
@@ -485,7 +485,7 @@ jobs:
           show-progress: false
       - uses: actions/setup-go@v6
         with:
-          go-version-file: 'go.mod'
+          go-version-file: '.go-version'
       - name: Download Antrea image from previous job
         uses: actions/download-artifact@v7
         with:
@@ -563,7 +563,7 @@ jobs:
           show-progress: false
       - uses: actions/setup-go@v6
         with:
-          go-version-file: 'go.mod'
+          go-version-file: '.go-version'
       - name: Download Antrea image from previous job
         uses: actions/download-artifact@v7
         with:
@@ -633,7 +633,7 @@ jobs:
         show-progress: false
     - uses: actions/setup-go@v6
       with:
-        go-version-file: 'go.mod'
+        go-version-file: '.go-version'
     - name: Download Antrea image from previous job
       uses: actions/download-artifact@v7
       with:
@@ -679,7 +679,7 @@ jobs:
         show-progress: false
     - uses: actions/setup-go@v6
       with:
-        go-version-file: 'go.mod'
+        go-version-file: '.go-version'
     - name: Download Antrea image from previous job
       uses: actions/download-artifact@v7
       with:
@@ -725,7 +725,7 @@ jobs:
           show-progress: false
       - uses: actions/setup-go@v6
         with:
-          go-version-file: 'go.mod'
+          go-version-file: '.go-version'
       - name: Download Antrea image from previous job
         uses: actions/download-artifact@v7
         with:
@@ -771,7 +771,7 @@ jobs:
           show-progress: false
       - uses: actions/setup-go@v6
         with:
-          go-version-file: 'go.mod'
+          go-version-file: '.go-version'
       - name: Download Antrea image from previous job
         uses: actions/download-artifact@v7
         with:
@@ -817,7 +817,7 @@ jobs:
           show-progress: false
       - uses: actions/setup-go@v6
         with:
-          go-version-file: 'go.mod'
+          go-version-file: '.go-version'
       - name: Download Antrea image from previous job
         uses: actions/download-artifact@v7
         with:
@@ -863,7 +863,7 @@ jobs:
           show-progress: false
       - uses: actions/setup-go@v6
         with:
-          go-version-file: 'go.mod'
+          go-version-file: '.go-version'
       - name: Download Antrea image from previous job
         uses: actions/download-artifact@v7
         with:
@@ -908,7 +908,7 @@ jobs:
           show-progress: false
       - uses: actions/setup-go@v6
         with:
-          go-version-file: 'go.mod'
+          go-version-file: '.go-version'
       - name: Download Antrea image from previous job
         uses: actions/download-artifact@v7
         with:

--- a/.github/workflows/kind_ubi.yml
+++ b/.github/workflows/kind_ubi.yml
@@ -46,7 +46,7 @@ jobs:
         driver: docker
     - uses: actions/setup-go@v6
       with:
-        go-version-file: 'go.mod'
+        go-version-file: '.go-version'
     - name: Build Antrea UBI9 Docker image
       run: |
         ./hack/build-antrea-linux-all.sh --pull --distro ubi

--- a/.github/workflows/process_release.yml
+++ b/.github/workflows/process_release.yml
@@ -9,11 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
-    - name: Set up Go using version from go.mod
+    - name: Set up Go using version from .go-version
       uses: actions/setup-go@v6
       with:
-        go-version-file: 'go.mod'
-        # make sure the latest patch version is used
+        go-version-file: '.go-version'
+        # make sure the latest patch version is used for building release assets, and not a version
+        # cached by the runner
         check-latest: true
     - name: Build assets
       env:

--- a/.github/workflows/verify_docs.yml
+++ b/.github/workflows/verify_docs.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
     - name: Check-out code
       uses: actions/checkout@v6
-    - name: Set up Go using version from go.mod
+    - name: Set up Go using version from .go-version
       uses: actions/setup-go@v6
       with:
-        go-version-file: 'go.mod'
+        go-version-file: '.go-version'
     - name: Run verify scripts
       run: make verify
     - name: Checking for broken Markdown links for main branch

--- a/.go-version
+++ b/.go-version
@@ -1,0 +1,1 @@
+build/images/deps/go-version


### PR DESCRIPTION
Replace go-version-file: 'go.mod' with go-version-file: '.go-version' in
all GitHub Actions workflows. The .go-version file specifies only the
minor version (e.g., 1.25), so setup-go will always install the latest
available patch release in CI, unless a matching cached version is
already available.

This allows us to (eventually) benefit from bug fixes included in more
recent patch releases, in particular when running tests.

Note that the 'go.mod' needs to include a valid Go version (so it has to
be 1.25.0 for example, it cannot be 1.25), hence the need for a new file.

The '.go-version' file is currently just a symlink to the existing
'build/images/deps/go-version' file, since they use the same format.