### PR TITLE
Disable containerd image store for Kind CI jobs

### DIFF
--- a/.github/actions/setup-docker-classic/action.yml
+++ b/.github/actions/setup-docker-classic/action.yml
@@ -1,0 +1,18 @@
+name: Set up Docker (classic image store)
+description: >
+  Configure the Docker daemon to use the classic (non-containerd) image store.
+  Docker 29+ defaults to the containerd image store, which breaks kind load
+  docker-image. See https://github.com/kubernetes-sigs/kind/issues/3795.
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Docker
+      uses: docker/setup-docker-action@v4
+      with:
+        daemon-config: |
+          {
+            "features": {
+              "containerd-snapshotter": false
+            }
+          }

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -64,6 +64,8 @@ jobs:
           ref: ${{ inputs.antrea-version }}
           fetch-depth: 0
           show-progress: false
+      # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
+      - uses: ./.github/actions/setup-docker-classic
       - name: Check if it is a released version
         id: check-release
         run: |

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -91,6 +91,8 @@ jobs:
     - uses: actions/setup-go@v6
       with:
         go-version-file: '.go-version'
+    # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
+    - uses: ./.github/actions/setup-docker-classic
     - name: Download Antrea image from previous job
       uses: actions/download-artifact@v7
       with:
@@ -154,6 +156,8 @@ jobs:
     - uses: actions/setup-go@v6
       with:
         go-version-file: '.go-version'
+    # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
+    - uses: ./.github/actions/setup-docker-classic
     - name: Download Antrea image from previous job
       uses: actions/download-artifact@v7
       with:
@@ -224,6 +228,8 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: '.go-version'
+      # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
+      - uses: ./.github/actions/setup-docker-classic
       - name: Download Antrea image from previous job
         uses: actions/download-artifact@v7
         with:
@@ -291,6 +297,8 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: '.go-version'
+      # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
+      - uses: ./.github/actions/setup-docker-classic
       - name: Download Antrea image from previous job
         uses: actions/download-artifact@v7
         with:
@@ -360,6 +368,8 @@ jobs:
     - uses: actions/setup-go@v6
       with:
         go-version-file: '.go-version'
+    # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
+    - uses: ./.github/actions/setup-docker-classic
     - name: Download Antrea image from previous job
       uses: actions/download-artifact@v7
       with:
@@ -423,6 +433,8 @@ jobs:
     - uses: actions/setup-go@v6
       with:
         go-version-file: '.go-version'
+    # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
+    - uses: ./.github/actions/setup-docker-classic
     - name: Download Antrea image from previous job
       uses: actions/download-artifact@v7
       with:
@@ -486,6 +498,8 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: '.go-version'
+      # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
+      - uses: ./.github/actions/setup-docker-classic
       - name: Download Antrea image from previous job
         uses: actions/download-artifact@v7
         with:
@@ -564,6 +578,8 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: '.go-version'
+      # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
+      - uses: ./.github/actions/setup-docker-classic
       - name: Download Antrea image from previous job
         uses: actions/download-artifact@v7
         with:
@@ -634,6 +650,8 @@ jobs:
     - uses: actions/setup-go@v6
       with:
         go-version-file: '.go-version'
+    # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
+    - uses: ./.github/actions/setup-docker-classic
     - name: Download Antrea image from previous job
       uses: actions/download-artifact@v7
       with:
@@ -680,6 +698,8 @@ jobs:
     - uses: actions/setup-go@v6
       with:
         go-version-file: '.go-version'
+    # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
+    - uses: ./.github/actions/setup-docker-classic
     - name: Download Antrea image from previous job
       uses: actions/download-artifact@v7
       with:
@@ -726,6 +746,8 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: '.go-version'
+      # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
+      - uses: ./.github/actions/setup-docker-classic
       - name: Download Antrea image from previous job
         uses: actions/download-artifact@v7
         with:
@@ -772,6 +794,8 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: '.go-version'
+      # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
+      - uses: ./.github/actions/setup-docker-classic
       - name: Download Antrea image from previous job
         uses: actions/download-artifact@v7
         with:
@@ -818,6 +842,8 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: '.go-version'
+      # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
+      - uses: ./.github/actions/setup-docker-classic
       - name: Download Antrea image from previous job
         uses: actions/download-artifact@v7
         with:
@@ -864,6 +890,8 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: '.go-version'
+      # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
+      - uses: ./.github/actions/setup-docker-classic
       - name: Download Antrea image from previous job
         uses: actions/download-artifact@v7
         with:
@@ -909,6 +937,8 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: '.go-version'
+      # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
+      - uses: ./.github/actions/setup-docker-classic
       - name: Download Antrea image from previous job
         uses: actions/download-artifact@v7
         with:
@@ -953,6 +983,8 @@ jobs:
       - uses: actions/checkout@v6
         with:
           show-progress: false
+      # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
+      - uses: ./.github/actions/setup-docker-classic
       - name: Download Antrea image from previous job
         uses: actions/download-artifact@v7
         with:

--- a/.github/workflows/kind_ubi.yml
+++ b/.github/workflows/kind_ubi.yml
@@ -40,6 +40,8 @@ jobs:
     - uses: actions/checkout@v6
       with:
         show-progress: false
+    # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
+    - uses: ./.github/actions/setup-docker-classic
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
       with:

--- a/.github/workflows/netpol_cyclonus.yml
+++ b/.github/workflows/netpol_cyclonus.yml
@@ -17,6 +17,8 @@ jobs:
           sudo apt-get clean
           df -h
       - uses: actions/checkout@v6
+      # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
+      - uses: ./.github/actions/setup-docker-classic
       - run: make
       - name: Install Kind
         run: |


### PR DESCRIPTION
Docker 29 defaults to the containerd image store, which breaks `kind load docker-image`. Add a `docker/setup-docker-action@v4` step to every job that uses Kind to explicitly disable the containerd snapshotter.

See https://github.com/kubernetes-sigs/kind/issues/3795