### PR TITLE
Fix concurrent map access in GetFQDNCache

### DIFF
--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
@@ -540,6 +540,8 @@ func NewNetworkPolicyController(antreaClientGetter client.AntreaClientProvider,
 
 func (c *Controller) GetFQDNCache(fqdnFilter *querier.FQDNCacheFilter) []types.DnsCacheEntry {
 	cacheEntryList := []types.DnsCacheEntry{}
+	c.fqdnController.fqdnSelectorMutex.Lock()
+	defer c.fqdnController.fqdnSelectorMutex.Unlock()
 	for fqdn, dnsMeta := range c.fqdnController.dnsEntryCache {
 		for _, ipWithExpiration := range dnsMeta.responseIPs {
 			if fqdnFilter == nil || fqdnFilter.DomainRegex.MatchString(fqdn) {


### PR DESCRIPTION
**Fixes : #7793** 

## Summary

This PR fixes a concurrency issue in the NetworkPolicy controller where `GetFQDNCache()` iterated over `dnsEntryCache` without holding `fqdnSelectorMutex`.

All other accessors of `dnsEntryCache` (including `onDNSResponse`, `cleanupFQDNSelectorItem`, `addFQDNSelector`, and `getIPsForFQDNSelectors`) correctly acquire the mutex. However, `GetFQDNCache()` did not, creating a concurrent read/write path.

Under concurrent DNS response processing and API queries (e.g., `antctl get fqdn-cache`), this could trigger:

```
fatal error: concurrent map read and map write
```

resulting in a crash of the `antrea-agent` process.

---

## Impact

If this occurs:

- The `antrea-agent` crashes due to Go runtime concurrent map access.
- NetworkPolicy enforcement on the node is disrupted until the agent restarts.
- The failure can be triggered during normal operation when FQDN policies are active and the FQDN cache is queried.

This affects clusters using FQDN-based NetworkPolicies.

---

## Steps to Reproduce (realistic)

1. Deploy an `AntreaClusterNetworkPolicy` with an FQDN rule.
2. Generate DNS traffic from selected Pods so that DNS responses are continuously processed.
3. While DNS activity is ongoing, run:
   ```
   antctl get fqdn-cache
   ```
4. Under sufficient concurrency, the agent may terminate with:
   ```
   fatal error: concurrent map read and map write
   ```

---

## Fix

Acquire `fqdnSelectorMutex` in `GetFQDNCache()` before iterating `dnsEntryCache`, aligning it with the locking discipline used by all other accessors.

```go
c.fqdnController.fqdnSelectorMutex.Lock()
defer c.fqdnController.fqdnSelectorMutex.Unlock()

for fqdn, dnsMeta := range c.fqdnController.dnsEntryCache {
    ...
}
```

This ensures mutual exclusion with concurrent DNS response processing.

---

## Code Changes

- File modified:
  `pkg/agent/controller/networkpolicy/networkpolicy_controller.go`
- Added `fqdnSelectorMutex` acquisition in `GetFQDNCache()`.

No behavioral changes beyond proper synchronization. The lock is already held during DNS response processing; this only adds brief synchronization when the cache is queried via the API.
