### PR TITLE
Automated cherry pick of #7790: Use latest available Go patch release in Github workflows

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,10 +16,10 @@ jobs:
           fetch-depth: 0
           show-progress: false
 
-      - name: Set up Go using version from go.mod
+      - name: Set up Go using version from .go-version
         uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version-file: '.go-version'
 
       - name: Install benchci
         run: curl -sfL https://raw.githubusercontent.com/antrea-io/benchci/main/install.sh | sudo sh -s -- -b /usr/local/bin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -177,7 +177,7 @@ jobs:
         driver: ${{ needs.check-env.outputs.docker_driver }}
     - uses: actions/setup-go@v5
       with:
-        go-version-file: 'go.mod'
+        go-version-file: '.go-version'
     - name: Build Antrea UBI9 Docker image without pushing to registry
       if: ${{ needs.check-env.outputs.push_needed == 'false' }}
       run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,10 +43,10 @@ jobs:
       with:
         show-progress: false
 
-    - name: Set up Go using version from go.mod
+    - name: Set up Go using version from .go-version
       uses: actions/setup-go@v5
       with:
-        go-version-file: 'go.mod'
+        go-version-file: '.go-version'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
@@ -87,10 +87,10 @@ jobs:
       with:
         show-progress: false
 
-    - name: Set up Go using version from go.mod
+    - name: Set up Go using version from .go-version
       uses: actions/setup-go@v5
       with:
-        go-version-file: 'go.mod'
+        go-version-file: '.go-version'
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -40,10 +40,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         show-progress: false
-    - name: Set up Go using version from go.mod
+    - name: Set up Go using version from .go-version
       uses: actions/setup-go@v5
       with:
-        go-version-file: 'go.mod'
+        go-version-file: '.go-version'
     - name: Run unit tests
       run: make test-unit
     - name: Codecov
@@ -66,10 +66,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           show-progress: false
-      - name: Set up Go using version from go.mod
+      - name: Set up Go using version from .go-version
         uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version-file: '.go-version'
       - name: Run unit tests
         run: make test-unit
       - name: Codecov
@@ -92,10 +92,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           show-progress: false
-      - name: Set up Go using version from go.mod
+      - name: Set up Go using version from .go-version
         uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version-file: '.go-version'
       - name: Run integration tests
         run: |
           ./build/images/ovs/build.sh
@@ -127,10 +127,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         show-progress: false
-    - name: Set up Go using version from go.mod
+    - name: Set up Go using version from .go-version
       uses: actions/setup-go@v5
       with:
-        go-version-file: 'go.mod'
+        go-version-file: '.go-version'
     - name: Run golangci-lint
       run: make golangci
 
@@ -144,10 +144,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           show-progress: false
-      - name: Set up Go using version from go.mod
+      - name: Set up Go using version from .go-version
         uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version-file: '.go-version'
       - name: Run golangci-lint
         run: make golangci
 
@@ -161,10 +161,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         show-progress: false
-    - name: Set up Go using version from go.mod
+    - name: Set up Go using version from .go-version
       uses: actions/setup-go@v5
       with:
-        go-version-file: 'go.mod'
+        go-version-file: '.go-version'
     - name: Build Antrea binaries for amd64
       run: GOARCH=amd64 make bin
     - name: Build Antrea binaries for arm64
@@ -198,10 +198,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         show-progress: false
-    - name: Set up Go using version from go.mod
+    - name: Set up Go using version from .go-version
       uses: actions/setup-go@v5
       with:
-        go-version-file: 'go.mod'
+        go-version-file: '.go-version'
     - name: Build Antrea windows binaries
       run: make windows-bin
 
@@ -215,10 +215,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         show-progress: false
-    - name: Set up Go using version from go.mod
+    - name: Set up Go using version from .go-version
       uses: actions/setup-go@v5
       with:
-        go-version-file: 'go.mod'
+        go-version-file: '.go-version'
     # tidy check need to be run before code generation which will regenerate codes.
     - name: Check tidy
       run: make test-tidy
@@ -237,10 +237,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         show-progress: false
-    - name: Set up Go using version from go.mod
+    - name: Set up Go using version from .go-version
       uses: actions/setup-go@v5
       with:
-        go-version-file: 'go.mod'
+        go-version-file: '.go-version'
     - name: Run verify scripts
       run: make verify
     - name: Checking for broken Markdown links
@@ -275,9 +275,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           show-progress: false
-      - name: Set up Go using version from go.mod
+      - name: Set up Go using version from .go-version
         uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version-file: '.go-version'
       - name: Run Go benchmark test
         run: go test -run '^$' -bench . -benchtime 1x -timeout 10m -cpu 4 -v -benchmem ./pkg/...

--- a/.github/workflows/golicense.yml
+++ b/.github/workflows/golicense.yml
@@ -37,10 +37,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         show-progress: false
-    - name: Set up Go using version from go.mod
+    - name: Set up Go using version from .go-version
       uses: actions/setup-go@v5
       with:
-        go-version-file: 'go.mod'
+        go-version-file: '.go-version'
     - name: Cache licensing information for dependencies
       uses: actions/cache@v4
       id: cache

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -87,7 +87,7 @@ jobs:
         show-progress: false
     - uses: actions/setup-go@v5
       with:
-        go-version-file: 'go.mod'
+        go-version-file: '.go-version'
     - name: Download Antrea image from previous job
       uses: actions/download-artifact@v4
       with:
@@ -150,7 +150,7 @@ jobs:
         show-progress: false
     - uses: actions/setup-go@v5
       with:
-        go-version-file: 'go.mod'
+        go-version-file: '.go-version'
     - name: Download Antrea image from previous job
       uses: actions/download-artifact@v4
       with:
@@ -220,7 +220,7 @@ jobs:
           show-progress: false
       - uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version-file: '.go-version'
       - name: Download Antrea image from previous job
         uses: actions/download-artifact@v4
         with:
@@ -287,7 +287,7 @@ jobs:
           show-progress: false
       - uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version-file: '.go-version'
       - name: Download Antrea image from previous job
         uses: actions/download-artifact@v4
         with:
@@ -356,7 +356,7 @@ jobs:
         show-progress: false
     - uses: actions/setup-go@v5
       with:
-        go-version-file: 'go.mod'
+        go-version-file: '.go-version'
     - name: Download Antrea image from previous job
       uses: actions/download-artifact@v4
       with:
@@ -419,7 +419,7 @@ jobs:
         show-progress: false
     - uses: actions/setup-go@v5
       with:
-        go-version-file: 'go.mod'
+        go-version-file: '.go-version'
     - name: Download Antrea image from previous job
       uses: actions/download-artifact@v4
       with:
@@ -482,7 +482,7 @@ jobs:
           show-progress: false
       - uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version-file: '.go-version'
       - name: Download Antrea image from previous job
         uses: actions/download-artifact@v4
         with:
@@ -557,7 +557,7 @@ jobs:
           show-progress: false
       - uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version-file: '.go-version'
       - name: Download Antrea image from previous job
         uses: actions/download-artifact@v4
         with:
@@ -627,7 +627,7 @@ jobs:
         show-progress: false
     - uses: actions/setup-go@v5
       with:
-        go-version-file: 'go.mod'
+        go-version-file: '.go-version'
     - name: Download Antrea image from previous job
       uses: actions/download-artifact@v4
       with:
@@ -673,7 +673,7 @@ jobs:
         show-progress: false
     - uses: actions/setup-go@v5
       with:
-        go-version-file: 'go.mod'
+        go-version-file: '.go-version'
     - name: Download Antrea image from previous job
       uses: actions/download-artifact@v4
       with:
@@ -719,7 +719,7 @@ jobs:
           show-progress: false
       - uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version-file: '.go-version'
       - name: Download Antrea image from previous job
         uses: actions/download-artifact@v4
         with:
@@ -765,7 +765,7 @@ jobs:
           show-progress: false
       - uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version-file: '.go-version'
       - name: Download Antrea image from previous job
         uses: actions/download-artifact@v4
         with:
@@ -811,7 +811,7 @@ jobs:
           show-progress: false
       - uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version-file: '.go-version'
       - name: Download Antrea image from previous job
         uses: actions/download-artifact@v4
         with:
@@ -857,7 +857,7 @@ jobs:
           show-progress: false
       - uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version-file: '.go-version'
       - name: Download Antrea image from previous job
         uses: actions/download-artifact@v4
         with:
@@ -902,7 +902,7 @@ jobs:
           show-progress: false
       - uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version-file: '.go-version'
       - name: Download Antrea image from previous job
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/kind_ubi.yml
+++ b/.github/workflows/kind_ubi.yml
@@ -46,7 +46,7 @@ jobs:
         driver: docker
     - uses: actions/setup-go@v5
       with:
-        go-version-file: 'go.mod'
+        go-version-file: '.go-version'
     - name: Build Antrea UBI9 Docker image
       run: |
         ./hack/build-antrea-linux-all.sh --pull --distro ubi

--- a/.github/workflows/process_release.yml
+++ b/.github/workflows/process_release.yml
@@ -9,11 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Go using version from go.mod
+    - name: Set up Go using version from .go-version
       uses: actions/setup-go@v5
       with:
-        go-version-file: 'go.mod'
-        # make sure the latest patch version is used
+        go-version-file: '.go-version'
+        # make sure the latest patch version is used for building release assets, and not a version
+        # cached by the runner
         check-latest: true
     - name: Build assets
       env:

--- a/.github/workflows/verify_docs.yml
+++ b/.github/workflows/verify_docs.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
     - name: Check-out code
       uses: actions/checkout@v4
-    - name: Set up Go using version from go.mod
+    - name: Set up Go using version from .go-version
       uses: actions/setup-go@v5
       with:
-        go-version-file: 'go.mod'
+        go-version-file: '.go-version'
     - name: Run verify scripts
       run: make verify
     - name: Checking for broken Markdown links for main branch

--- a/.go-version
+++ b/.go-version
@@ -1,0 +1,1 @@
+build/images/deps/go-version


### PR DESCRIPTION
Cherry pick of #7790 on release-2.4.

#7790: Use latest available Go patch release in Github workflows

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.