### PR TITLE
Automated cherry pick of #7759: Support IPv6 traffic over IPv4 IPsec tunnel (#7759)

### DIFF
--- a/pkg/agent/controller/noderoute/node_route_controller.go
+++ b/pkg/agent/controller/noderoute/node_route_controller.go
@@ -621,7 +621,8 @@ func (c *Controller) addNodeRoute(nodeName string, node *corev1.Node) error {
 	if c.networkConfig.TrafficEncryptionMode == config.TrafficEncryptionModeIPSec {
 		// Create a separate tunnel port for the Node, as OVS IPsec monitor needs to
 		// read PSK and remote IP from the Node's tunnel interface to create IPsec
-		// security policies.
+		// security policies. We use the Node's IPv4 address when present, and the
+		// Node's IPv6 address otherwise.
 		peerNodeIP := peerNodeIPs.IPv4
 		if peerNodeIP == nil {
 			peerNodeIP = peerNodeIPs.IPv6


### PR DESCRIPTION
Cherry pick of #7759 on release-2.4.

#7759: Support IPv6 traffic over IPv4 IPsec tunnel (#7759)

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.