### PR TITLE
Include extra ip and sysctl info in Agent supportbundle

### DIFF
--- a/pkg/support/dump_others.go
+++ b/pkg/support/dump_others.go
@@ -19,6 +19,7 @@ package support
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -170,7 +171,10 @@ func (d *agentDumper) dumpSysctlNetIF(basedir string) error {
 		for _, param := range params {
 			data, err := os.ReadFile(filepath.Join(sysctlNetIPv4ConfPath, iface, param))
 			if err != nil {
-				continue
+				if errors.Is(err, os.ErrNotExist) {
+					continue
+				}
+				return fmt.Errorf("error when reading sysctl parameter %s for interface %s: %w", param, iface, err)
 			}
 			fmt.Fprintf(&buf, "net.ipv4.conf.%s.%s = %s\n", iface, param, strings.TrimSpace(string(data)))
 		}

--- a/pkg/support/dump_others.go
+++ b/pkg/support/dump_others.go
@@ -20,6 +20,7 @@ package support
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"path"
 	"path/filepath"
 	"strings"
@@ -73,6 +74,9 @@ func (d *agentDumper) DumpHostNetworkInfo(basedir string) error {
 	if err := d.dumpIPToolInfo(basedir); err != nil {
 		return err
 	}
+	if err := d.dumpSysctlNetIF(basedir); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -120,19 +124,58 @@ func (d *agentDumper) dumpNFTables(basedir string) error {
 }
 
 func (d *agentDumper) dumpIPToolInfo(basedir string) error {
-	dump := func(name string) error {
-		output, err := d.executor.Command("ip", name).CombinedOutput()
-		if err != nil {
-			return fmt.Errorf("error when dumping %s: %w", name, err)
-		}
-		return writeFile(d.fs, filepath.Join(basedir, name), name, output)
+	type ipCmd struct {
+		fileName string
+		args     []string
 	}
-	for _, item := range []string{"route", "link", "address"} {
+	dump := func(cmd ipCmd) error {
+		output, err := d.executor.Command("ip", cmd.args...).CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("error when dumping ip %s: %w", strings.Join(cmd.args, " "), err)
+		}
+		return writeFile(d.fs, filepath.Join(basedir, cmd.fileName), cmd.fileName, output)
+	}
+	for _, item := range []ipCmd{
+		{fileName: "route", args: []string{"route"}},
+		{fileName: "route-all", args: []string{"route", "show", "table", "all"}},
+		{fileName: "rule", args: []string{"rule"}},
+		{fileName: "link", args: []string{"link"}},
+		{fileName: "address", args: []string{"address"}},
+	} {
 		if err := dump(item); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// sysctlNetIPv4ConfPath is the path to the per-interface IPv4 sysctl
+// parameters. It is a variable to allow overriding in tests.
+var sysctlNetIPv4ConfPath = "/proc/sys/net/ipv4/conf"
+
+// dumpSysctlNetIF reads the rp_filter, arp_ignore, and arp_announce sysctl
+// parameters for all network interfaces and writes them to a file.
+func (d *agentDumper) dumpSysctlNetIF(basedir string) error {
+	entries, err := os.ReadDir(sysctlNetIPv4ConfPath)
+	if err != nil {
+		return fmt.Errorf("error when reading sysctl net IPv4 conf: %w", err)
+	}
+	params := []string{"rp_filter", "arp_ignore", "arp_announce"}
+	var buf bytes.Buffer
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		iface := entry.Name()
+		for _, param := range params {
+			data, err := os.ReadFile(filepath.Join(sysctlNetIPv4ConfPath, iface, param))
+			if err != nil {
+				continue
+			}
+			fmt.Fprintf(&buf, "net.ipv4.conf.%s.%s = %s\n", iface, param, strings.TrimSpace(string(data)))
+		}
+	}
+	return writeFile(d.fs, filepath.Join(basedir, "sysctl-net"), "sysctl-net", buf.Bytes())
 }
 
 func (d *agentDumper) DumpMemberlist(basedir string) error {

--- a/pkg/support/dump_others_test.go
+++ b/pkg/support/dump_others_test.go
@@ -162,6 +162,133 @@ func TestDumpNFTables(t *testing.T) {
 	}
 }
 
+func TestDumpIPToolInfo(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	fs.MkdirAll(baseDir, os.ModePerm)
+
+	exe := new(testExec)
+	dumper := &agentDumper{
+		fs:       fs,
+		executor: exe,
+	}
+
+	err := dumper.dumpIPToolInfo(baseDir)
+	require.NoError(t, err)
+
+	expectedFiles := map[string]string{
+		"route":     "ip route",
+		"route-all": "ip route show table all",
+		"rule":      "ip rule",
+		"link":      "ip link",
+		"address":   "ip address",
+	}
+	for fileName, expectedContent := range expectedFiles {
+		content, err := afero.ReadFile(fs, filepath.Join(baseDir, fileName))
+		require.NoError(t, err, "expected file %q to exist", fileName)
+		assert.Equal(t, expectedContent, string(content), "unexpected content for file %q", fileName)
+	}
+}
+
+func TestDumpSysctlNetIF(t *testing.T) {
+	tests := []struct {
+		name            string
+		interfaces      map[string]map[string]string
+		expectedContent []string
+		notExpected     []string
+		sysctlPathEmpty bool
+		expectedErr     string
+	}{
+		{
+			name: "reads rp_filter, arp_ignore and arp_announce for all interfaces",
+			interfaces: map[string]map[string]string{
+				"eth0": {
+					"rp_filter":    "1",
+					"arp_ignore":   "0",
+					"arp_announce": "0",
+				},
+				"antrea-ext.10": {
+					"rp_filter":    "2",
+					"arp_ignore":   "1",
+					"arp_announce": "2",
+				},
+			},
+			expectedContent: []string{
+				"net.ipv4.conf.eth0.rp_filter = 1",
+				"net.ipv4.conf.eth0.arp_ignore = 0",
+				"net.ipv4.conf.eth0.arp_announce = 0",
+				"net.ipv4.conf.antrea-ext.10.rp_filter = 2",
+				"net.ipv4.conf.antrea-ext.10.arp_ignore = 1",
+				"net.ipv4.conf.antrea-ext.10.arp_announce = 2",
+			},
+		},
+		{
+			name: "missing param files are silently skipped",
+			interfaces: map[string]map[string]string{
+				"all": {
+					"rp_filter": "0",
+					// arp_ignore and arp_announce intentionally absent
+				},
+			},
+			expectedContent: []string{
+				"net.ipv4.conf.all.rp_filter = 0",
+			},
+			notExpected: []string{
+				"net.ipv4.conf.all.arp_ignore",
+				"net.ipv4.conf.all.arp_announce",
+			},
+		},
+		{
+			name:            "returns error when sysctl path does not exist",
+			sysctlPathEmpty: true,
+			expectedErr:     "error when reading sysctl net IPv4 conf",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			origPath := sysctlNetIPv4ConfPath
+			t.Cleanup(func() { sysctlNetIPv4ConfPath = origPath })
+
+			if tc.sysctlPathEmpty {
+				sysctlNetIPv4ConfPath = filepath.Join(t.TempDir(), "nonexistent")
+			} else {
+				tmpDir := t.TempDir()
+				sysctlNetIPv4ConfPath = tmpDir
+				for iface, params := range tc.interfaces {
+					ifaceDir := filepath.Join(tmpDir, iface)
+					require.NoError(t, os.MkdirAll(ifaceDir, 0755))
+					for param, value := range params {
+						require.NoError(t, os.WriteFile(filepath.Join(ifaceDir, param), []byte(value+"\n"), 0644))
+					}
+				}
+			}
+
+			fs := afero.NewMemMapFs()
+			fs.MkdirAll(baseDir, os.ModePerm)
+			dumper := &agentDumper{fs: fs}
+
+			err := dumper.dumpSysctlNetIF(baseDir)
+
+			if tc.expectedErr != "" {
+				require.ErrorContains(t, err, tc.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+
+			content, err := afero.ReadFile(fs, filepath.Join(baseDir, "sysctl-net"))
+			require.NoError(t, err)
+			output := string(content)
+
+			for _, expected := range tc.expectedContent {
+				assert.Contains(t, output, expected)
+			}
+			for _, notExpected := range tc.notExpected {
+				assert.NotContains(t, output, notExpected)
+			}
+		})
+	}
+}
+
 func TestDumpIPSet(t *testing.T) {
 	const ipsetOutput = `create ANTREA-POD-IP hash:net family inet hashsize 1024 maxelem 65536 bucketsize 12 initval 0xaff5135c
 add ANTREA-POD-IP 10.244.0.0/24

--- a/pkg/support/dump_others_test.go
+++ b/pkg/support/dump_others_test.go
@@ -191,12 +191,13 @@ func TestDumpIPToolInfo(t *testing.T) {
 
 func TestDumpSysctlNetIF(t *testing.T) {
 	tests := []struct {
-		name            string
-		interfaces      map[string]map[string]string
-		expectedContent []string
-		notExpected     []string
-		sysctlPathEmpty bool
-		expectedErr     string
+		name             string
+		interfaces       map[string]map[string]string
+		unreadableParams map[string][]string // params to create as dirs to trigger a non-ErrNotExist error
+		expectedContent  []string
+		notExpected      []string
+		sysctlPathEmpty  bool
+		expectedErr      string
 	}{
 		{
 			name: "reads rp_filter, arp_ignore and arp_announce for all interfaces",
@@ -238,6 +239,18 @@ func TestDumpSysctlNetIF(t *testing.T) {
 			},
 		},
 		{
+			name: "non-ErrNotExist read error is returned with interface and param context",
+			interfaces: map[string]map[string]string{
+				"eth0": {"rp_filter": "1"},
+			},
+			// Creating arp_ignore as a directory makes os.ReadFile return EISDIR,
+			// which is not ErrNotExist and must not be silently skipped.
+			unreadableParams: map[string][]string{
+				"eth0": {"arp_ignore"},
+			},
+			expectedErr: "error when reading sysctl parameter arp_ignore for interface eth0",
+		},
+		{
 			name:            "returns error when sysctl path does not exist",
 			sysctlPathEmpty: true,
 			expectedErr:     "error when reading sysctl net IPv4 conf",
@@ -259,6 +272,11 @@ func TestDumpSysctlNetIF(t *testing.T) {
 					require.NoError(t, os.MkdirAll(ifaceDir, 0755))
 					for param, value := range params {
 						require.NoError(t, os.WriteFile(filepath.Join(ifaceDir, param), []byte(value+"\n"), 0644))
+					}
+				}
+				for iface, params := range tc.unreadableParams {
+					for _, param := range params {
+						require.NoError(t, os.MkdirAll(filepath.Join(tmpDir, iface, param), 0755))
 					}
 				}
 			}


### PR DESCRIPTION
fixes #7516 


## Summary

This PR extends the Agent supportbundle to include additional `ip` and sysctl information that is useful when troubleshooting Egress and EgressSeparateSubnet.

## Changes

- Update `dumpIPToolInfo` to collect:
  - `ip route`
  - `ip route show table all` (saved as `route-all`)
  - `ip rule`
  - `ip link`
  - `ip address`
- Add `dumpSysctlNetIF` to dump selected IPv4 sysctl parameters for all interfaces under `/proc/sys/net/ipv4/conf`:
  - `rp_filter`
  - `arp_ignore`
  - `arp_announce`
- Wire `dumpSysctlNetIF` into `DumpHostNetworkInfo` so the new `sysctl-net` file is included in the Agent supportbundle.

## Testing

- Added unit tests for `dumpIPToolInfo` to verify all commands and output files.
- Added unit tests for `dumpSysctlNetIF` to cover:
  - normal case with multiple interfaces,
  - missing parameter files (silently skipped),
  - missing sysctl path (returns a clear error).
