### PR TITLE
Automated cherry pick of #7794: Fix concurrent map access in GetFQDNCache (#7794)

### DIFF
--- a/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/agent/controller/networkpolicy/networkpolicy_controller.go
@@ -540,6 +540,8 @@ func NewNetworkPolicyController(antreaClientGetter client.AntreaClientProvider,
 
 func (c *Controller) GetFQDNCache(fqdnFilter *querier.FQDNCacheFilter) []types.DnsCacheEntry {
 	cacheEntryList := []types.DnsCacheEntry{}
+	c.fqdnController.fqdnSelectorMutex.Lock()
+	defer c.fqdnController.fqdnSelectorMutex.Unlock()
 	for fqdn, dnsMeta := range c.fqdnController.dnsEntryCache {
 		for _, ipWithExpiration := range dnsMeta.responseIPs {
 			if fqdnFilter == nil || fqdnFilter.DomainRegex.MatchString(fqdn) {


### PR DESCRIPTION
Cherry pick of #7794 on release-2.5.

#7794: Fix concurrent map access in GetFQDNCache (#7794)

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.