### PR TITLE
Fix audit log MaxSize default using wrong constant

### DIFF
--- a/cmd/antrea-agent/options.go
+++ b/cmd/antrea-agent/options.go
@@ -783,7 +783,7 @@ func (o *Options) setMulticlusterDefaultOptions() {
 func (o *Options) setAuditLoggingDefaultOptions() {
 	auditLogging := &o.config.AuditLogging
 	if auditLogging.MaxSize == 0 {
-		auditLogging.MaxSize = defaultAuditLogsMaxAge
+		auditLogging.MaxSize = defaultAuditLogsMaxSize
 	}
 	if auditLogging.MaxBackups == nil {
 		maxBackups := int32(defaultAuditLogsMaxBackups)


### PR DESCRIPTION
## **Summary**

This PR fixes an incorrect default assignment in `setAuditLoggingDefaultOptions()` in `cmd/antrea-agent/options.go`.

Currently, when `AuditLogging.MaxSize` is not explicitly configured, the code assigns it using `defaultAuditLogsMaxAge` instead of `defaultAuditLogsMaxSize`. As a result, the default audit log rotation size becomes **28 MB** rather than the intended **100 MB**.

This appears to be a simple constant mix-up introduced when the audit logging defaults were added.

---

## **Impact**

When `auditLogging.maxSize` is not set in the agent configuration, audit log files rotate at **28 MB** instead of the intended **100 MB**.

This can lead to more frequent log rotation and a larger number of rotated audit log files than expected.

---

### **Fix**

Use the correct constant when setting the default value.
```if auditLogging.MaxSize == 0 {
    auditLogging.MaxSize = defaultAuditLogsMaxSize
}
```