### PR TITLE
Fix capitalized error strings to follow Go conventions

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1220,7 +1220,7 @@ func (i *Initializer) getInterfaceMTU(transportInterface *net.Interface) (int, e
 	mtu := transportInterface.MTU
 	// Make sure MTU is set on the interface.
 	if mtu <= 0 {
-		return 0, fmt.Errorf("Failed to fetch Node MTU : %v", mtu)
+		return 0, fmt.Errorf("failed to fetch Node MTU: %d", mtu)
 	}
 
 	isIPv6 := i.nodeConfig.NodeIPv6Addr != nil

--- a/pkg/agent/cniserver/ipam/ipam_service.go
+++ b/pkg/agent/cniserver/ipam/ipam_service.go
@@ -101,7 +101,7 @@ func ExecIPAMAdd(cniArgs *cnipb.CniCmdArgs, k8sArgs *types.K8sArgs, ipamType str
 		return result, nil
 	}
 
-	return nil, fmt.Errorf("No suitable IPAM driver found")
+	return nil, fmt.Errorf("no suitable IPAM driver found")
 }
 
 func ExecIPAMDelete(cniArgs *cnipb.CniCmdArgs, k8sArgs *types.K8sArgs, ipamType string, resultKey string) error {
@@ -119,7 +119,7 @@ func ExecIPAMDelete(cniArgs *cnipb.CniCmdArgs, k8sArgs *types.K8sArgs, ipamType 
 		ipamResults.Delete(resultKey)
 		return nil
 	}
-	return fmt.Errorf("No suitable IPAM driver found")
+	return fmt.Errorf("no suitable IPAM driver found")
 }
 
 func ExecIPAMCheck(cniArgs *cnipb.CniCmdArgs, k8sArgs *types.K8sArgs, ipamType string) error {
@@ -135,7 +135,7 @@ func ExecIPAMCheck(cniArgs *cnipb.CniCmdArgs, k8sArgs *types.K8sArgs, ipamType s
 		return err
 
 	}
-	return fmt.Errorf("No suitable IPAM driver found")
+	return fmt.Errorf("no suitable IPAM driver found")
 }
 
 func GetIPFromCache(resultKey string) (*IPAMResult, bool) {

--- a/pkg/agent/cniserver/ipam/ipam_service_test.go
+++ b/pkg/agent/cniserver/ipam/ipam_service_test.go
@@ -165,7 +165,7 @@ func TestExecIPAMAdd(t *testing.T) {
 			k8sArgs:     &argtypes.K8sArgs{},
 			ipamType:    "",
 			resultKey:   "",
-			exceptedRes: fmt.Errorf("No suitable IPAM driver found"),
+			exceptedRes: fmt.Errorf("no suitable IPAM driver found"),
 		},
 		{
 			name: "Exec successfully",
@@ -214,7 +214,7 @@ func TestExecIPAMDelete(t *testing.T) {
 			k8sArgs:     &argtypes.K8sArgs{},
 			ipamType:    "",
 			resultKey:   "",
-			exceptedRes: fmt.Errorf("No suitable IPAM driver found"),
+			exceptedRes: fmt.Errorf("no suitable IPAM driver found"),
 		},
 		{
 			name: "Exec successfully",
@@ -261,7 +261,7 @@ func TestExecIPAMCheck(t *testing.T) {
 			cniArgs:     &cnipb.CniCmdArgs{},
 			k8sArgs:     &argtypes.K8sArgs{},
 			ipamType:    "",
-			exceptedRes: fmt.Errorf("No suitable IPAM driver found"),
+			exceptedRes: fmt.Errorf("no suitable IPAM driver found"),
 		},
 		{
 			name: "Exec successfully",

--- a/pkg/antctl/raw/multicluster/get/join_config.go
+++ b/pkg/antctl/raw/multicluster/get/join_config.go
@@ -94,14 +94,14 @@ func runEJoinConfig(cmd *cobra.Command, args []string) error {
 	clusterSets := clusterSetList.Items
 
 	if len(clusterSets) == 0 {
-		return fmt.Errorf("No ClusterSet found in Namespace %s", joinConfigOpts.namespace)
+		return fmt.Errorf("no ClusterSet found in Namespace %s", joinConfigOpts.namespace)
 	} else if len(clusterSets) > 1 {
-		return fmt.Errorf("More than one ClusterSets in Namespace %s", joinConfigOpts.namespace)
+		return fmt.Errorf("more than one ClusterSet found in Namespace %s", joinConfigOpts.namespace)
 	}
 
 	cs := clusterSets[0]
 	if len(cs.Spec.Leaders) == 0 {
-		return fmt.Errorf("Invalid ClusterSet %s: no leader cluster", cs.Name)
+		return fmt.Errorf("invalid ClusterSet %s: no leader cluster", cs.Name)
 	}
 
 	var tokenSecret *corev1.Secret

--- a/pkg/antctl/raw/multicluster/get/join_config_test.go
+++ b/pkg/antctl/raw/multicluster/get/join_config_test.go
@@ -120,17 +120,17 @@ func TestJoinConfig(t *testing.T) {
 		},
 		{
 			name:           "no ClusterSet",
-			expectedOutput: "No ClusterSet found in Namespace",
+			expectedOutput: "no ClusterSet found in Namespace",
 		},
 		{
 			name:           "invalid ClusterSet",
 			clusterSets:    []*mcv1alpha2.ClusterSet{invalidClusterSet},
-			expectedOutput: "Invalid ClusterSet",
+			expectedOutput: "invalid ClusterSet",
 		},
 		{
 			name:           ">1 ClusterSets",
 			clusterSets:    []*mcv1alpha2.ClusterSet{clusterSet1, invalidClusterSet},
-			expectedOutput: "More than one ClusterSets in Namespace",
+			expectedOutput: "more than one ClusterSet found in Namespace",
 		},
 		{
 			name:           "get with token",

--- a/pkg/ipam/ipallocator/allocator.go
+++ b/pkg/ipam/ipallocator/allocator.go
@@ -209,7 +209,7 @@ func (a *SingleIPAllocator) AllocateRange(size int) ([]net.IP, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("Continuous range of size %d is not available", size)
+	return nil, fmt.Errorf("continuous range of size %d is not available", size)
 }
 
 func (a *SingleIPAllocator) getOffset(ip net.IP) int {
@@ -291,7 +291,7 @@ func (ma MultiIPAllocator) AllocateNext() (net.IP, error) {
 // If not available in any allocator, error is returned.
 func (ma MultiIPAllocator) AllocateRange(size int) ([]net.IP, error) {
 	if size > ma.Free() {
-		return nil, fmt.Errorf("Not enough IPs to reserve range of size %d", size)
+		return nil, fmt.Errorf("not enough IPs to reserve range of size %d", size)
 	}
 
 	for _, a := range ma {

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -2480,17 +2480,17 @@ func parseArpingStdout(out string) (sent uint32, received uint32, loss float32, 
 	re := regexp.MustCompile(`(\d+)\s+packets\s+transmitted,\s+(\d+)\s+packets\s+received,\s+(\d+)%\s+unanswered`)
 	matches := re.FindStringSubmatch(out)
 	if len(matches) == 0 {
-		return 0, 0, 0.0, fmt.Errorf("Unexpected arping output")
+		return 0, 0, 0.0, fmt.Errorf("unexpected arping output")
 	}
 	v, err := strconv.ParseUint(matches[1], 10, 32)
 	if err != nil {
-		return 0, 0, 0.0, fmt.Errorf("Error when retrieving 'packets transmitted' from arpping output: %v", err)
+		return 0, 0, 0.0, fmt.Errorf("error when retrieving 'packets transmitted' from arping output: %v", err)
 	}
 	sent = uint32(v)
 
 	v, err = strconv.ParseUint(matches[2], 10, 32)
 	if err != nil {
-		return 0, 0, 0.0, fmt.Errorf("Error when retrieving 'packets received' from arpping output: %v", err)
+		return 0, 0, 0.0, fmt.Errorf("error when retrieving 'packets received' from arping output: %v", err)
 	}
 	received = uint32(v)
 	loss = 100. * float32(sent-received) / float32(sent)


### PR DESCRIPTION
Error strings should not be capitalized or end with punctuation per Go Code Review Comments. Lowercase the first letter of error messages across the codebase, except where they start with proper nouns or acronyms.