### PR TITLE
Extract composite actions for Kind test setup

### DIFF
--- a/.github/actions/setup-kind-test/action.yml
+++ b/.github/actions/setup-kind-test/action.yml
@@ -1,0 +1,62 @@
+name: Set up Kind test environment
+description: >
+  Common setup steps for Kind-based test jobs: free disk space, Go
+  toolchain, Docker classic image store, download and load Antrea image
+  artifacts, and install Kind.
+  The repository must already be checked out before using this action.
+
+inputs:
+  free-disk-space:
+    description: Free disk space before running the test.
+    default: 'true'
+  setup-go:
+    description: Install the Go toolchain.
+    default: 'true'
+  load-flow-aggregator:
+    description: Download and load the Flow Aggregator coverage image.
+    default: 'false'
+  tag-coverage-images:
+    description: >
+      Tag Antrea coverage images to non-coverage image names, so that
+      standard (non-coverage) manifests can be used.
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - name: Free disk space
+      if: ${{ inputs.free-disk-space == 'true' }}
+      shell: bash
+      # https://github.com/actions/virtual-environments/issues/709
+      run: |
+        sudo apt-get clean
+        df -h
+    - uses: actions/setup-go@v6
+      if: ${{ inputs.setup-go == 'true' }}
+      with:
+        go-version-file: '.go-version'
+    # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
+    - uses: ./.github/actions/setup-docker-classic
+    - name: Download Antrea image from previous job
+      uses: actions/download-artifact@v7
+      with:
+        name: antrea-ubuntu-cov
+    - name: Load Antrea image
+      shell: bash
+      run: docker load -i antrea-ubuntu.tar
+    - name: Tag coverage images
+      if: ${{ inputs.tag-coverage-images == 'true' }}
+      shell: bash
+      run: |
+        docker tag antrea/antrea-agent-ubuntu-coverage:latest antrea/antrea-agent-ubuntu:latest
+        docker tag antrea/antrea-controller-ubuntu-coverage:latest antrea/antrea-controller-ubuntu:latest
+    - name: Download Flow Aggregator image from previous job
+      if: ${{ inputs.load-flow-aggregator == 'true' }}
+      uses: actions/download-artifact@v7
+      with:
+        name: flow-aggregator-cov
+    - name: Load Flow Aggregator image
+      if: ${{ inputs.load-flow-aggregator == 'true' }}
+      shell: bash
+      run: docker load -i flow-aggregator.tar
+    - uses: ./.github/actions/setup-kind

--- a/.github/actions/setup-kind/action.yml
+++ b/.github/actions/setup-kind/action.yml
@@ -1,0 +1,18 @@
+name: Install Kind
+description: >
+  Install the Kind binary. The version is read from ci/kind/version.
+
+runs:
+  using: composite
+  steps:
+    - name: Get Kind version
+      id: get_kind_version
+      shell: bash
+      run: |
+        KIND_VERSION=$(head -n1 ./ci/kind/version)
+        echo "kind_version=${KIND_VERSION}" >> $GITHUB_OUTPUT
+    - name: Install Kind
+      uses: helm/kind-action@v1
+      with:
+        version: ${{ steps.get_kind_version.outputs.kind_version }}
+        install_only: true

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -85,16 +85,7 @@ jobs:
         if: ${{ steps.check-release.outputs.released == 'false' }}
         run: |
           ./hack/build-antrea-linux-all.sh --pull --distro ${{ inputs.antrea-image-distro }} --platform ${{ inputs.antrea-image-platform }}
-      - name: Get Kind version
-        id: get_kind_version
-        run: |
-          KIND_VERSION=$(head -n1 ./ci/kind/version || echo v0.31.0)
-          echo "kind_version=${KIND_VERSION}" >> $GITHUB_OUTPUT
-      - name: Install Kind
-        uses: helm/kind-action@v1
-        with:
-          version: ${{ steps.get_kind_version.outputs.kind_version }}
-          install_only: true
+      - uses: ./.github/actions/setup-kind
       - name: Build local image for conformance test
         if: ${{ inputs.k8s-version != '' }}
         run: |

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -80,32 +80,10 @@ jobs:
     needs: [build-antrea-coverage-image]
     runs-on: [ubuntu-latest]
     steps:
-    - name: Free disk space
-      # https://github.com/actions/virtual-environments/issues/709
-      run: |
-        sudo apt-get clean
-        df -h
     - uses: actions/checkout@v6
       with:
         show-progress: false
-    - uses: actions/setup-go@v6
-      with:
-        go-version-file: '.go-version'
-    # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
-    - uses: ./.github/actions/setup-docker-classic
-    - name: Download Antrea image from previous job
-      uses: actions/download-artifact@v7
-      with:
-        name: antrea-ubuntu-cov
-    - name: Load Antrea image
-      run: |
-        docker load -i antrea-ubuntu.tar
-    - name: Install Kind
-      run: |
-        KIND_VERSION=$(head -n1 ./ci/kind/version)
-        curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
-        chmod +x ./kind
-        sudo mv kind /usr/local/bin
+    - uses: ./.github/actions/setup-kind-test
     - name: Run e2e tests
       run: |
         mkdir log
@@ -145,32 +123,10 @@ jobs:
     needs: [build-antrea-coverage-image]
     runs-on: [ubuntu-latest]
     steps:
-    - name: Free disk space
-      # https://github.com/actions/virtual-environments/issues/709
-      run: |
-        sudo apt-get clean
-        df -h
     - uses: actions/checkout@v6
       with:
         show-progress: false
-    - uses: actions/setup-go@v6
-      with:
-        go-version-file: '.go-version'
-    # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
-    - uses: ./.github/actions/setup-docker-classic
-    - name: Download Antrea image from previous job
-      uses: actions/download-artifact@v7
-      with:
-        name: antrea-ubuntu-cov
-    - name: Load Antrea image
-      run: |
-        docker load -i antrea-ubuntu.tar
-    - name: Install Kind
-      run: |
-        KIND_VERSION=$(head -n1 ./ci/kind/version)
-        curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
-        chmod +x ./kind
-        sudo mv kind /usr/local/bin
+    - uses: ./.github/actions/setup-kind-test
     - name: Run e2e tests
       run: |
         mkdir log
@@ -217,32 +173,10 @@ jobs:
     needs: [build-antrea-coverage-image]
     runs-on: [ubuntu-latest]
     steps:
-      - name: Free disk space
-        # https://github.com/actions/virtual-environments/issues/709
-        run: |
-          sudo apt-get clean
-          df -h
       - uses: actions/checkout@v6
         with:
           show-progress: false
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: '.go-version'
-      # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
-      - uses: ./.github/actions/setup-docker-classic
-      - name: Download Antrea image from previous job
-        uses: actions/download-artifact@v7
-        with:
-          name: antrea-ubuntu-cov
-      - name: Load Antrea image
-        run: |
-          docker load -i antrea-ubuntu.tar
-      - name: Install Kind
-        run: |
-          KIND_VERSION=$(head -n1 ./ci/kind/version)
-          curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
-          chmod +x ./kind
-          sudo mv kind /usr/local/bin
+      - uses: ./.github/actions/setup-kind-test
       - name: Run e2e tests
         run: |
           mkdir log
@@ -294,24 +228,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           show-progress: false
-      - uses: actions/setup-go@v6
+      - uses: ./.github/actions/setup-kind-test
         with:
-          go-version-file: '.go-version'
-      # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
-      - uses: ./.github/actions/setup-docker-classic
-      - name: Download Antrea image from previous job
-        uses: actions/download-artifact@v7
-        with:
-          name: antrea-ubuntu-cov
-      - name: Load Antrea image
-        run: |
-          docker load -i antrea-ubuntu.tar
-      - name: Install Kind
-        run: |
-          KIND_VERSION=$(head -n1 ./ci/kind/version)
-          curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
-          chmod +x ./kind
-          sudo mv kind /usr/local/bin
+          free-disk-space: 'false'
       - name: Run ipam e2e tests
         # We enable multicast as some FlexibleIPAM e2e tests require it
         run: |
@@ -357,32 +276,10 @@ jobs:
     needs: [build-antrea-coverage-image]
     runs-on: [ubuntu-latest]
     steps:
-    - name: Free disk space
-      # https://github.com/actions/virtual-environments/issues/709
-      run: |
-        sudo apt-get clean
-        df -h
     - uses: actions/checkout@v6
       with:
         show-progress: false
-    - uses: actions/setup-go@v6
-      with:
-        go-version-file: '.go-version'
-    # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
-    - uses: ./.github/actions/setup-docker-classic
-    - name: Download Antrea image from previous job
-      uses: actions/download-artifact@v7
-      with:
-        name: antrea-ubuntu-cov
-    - name: Load Antrea image
-      run: |
-        docker load -i antrea-ubuntu.tar
-    - name: Install Kind
-      run: |
-        KIND_VERSION=$(head -n1 ./ci/kind/version)
-        curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
-        chmod +x ./kind
-        sudo mv kind /usr/local/bin
+    - uses: ./.github/actions/setup-kind-test
     - name: Run e2e tests
       run: |
         mkdir log
@@ -422,32 +319,10 @@ jobs:
     needs: [build-antrea-coverage-image]
     runs-on: [ubuntu-latest]
     steps:
-    - name: Free disk space
-      # https://github.com/actions/virtual-environments/issues/709
-      run: |
-        sudo apt-get clean
-        df -h
     - uses: actions/checkout@v6
       with:
         show-progress: false
-    - uses: actions/setup-go@v6
-      with:
-        go-version-file: '.go-version'
-    # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
-    - uses: ./.github/actions/setup-docker-classic
-    - name: Download Antrea image from previous job
-      uses: actions/download-artifact@v7
-      with:
-        name: antrea-ubuntu-cov
-    - name: Load Antrea image
-      run: |
-        docker load -i antrea-ubuntu.tar
-    - name: Install Kind
-      run: |
-        KIND_VERSION=$(head -n1 ./ci/kind/version)
-        curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
-        chmod +x ./kind
-        sudo mv kind /usr/local/bin
+    - uses: ./.github/actions/setup-kind-test
     - name: Run e2e tests
       run: |
         mkdir log
@@ -487,32 +362,10 @@ jobs:
     needs: [ build-antrea-coverage-image ]
     runs-on: [ ubuntu-latest ]
     steps:
-      - name: Free disk space
-        # https://github.com/actions/virtual-environments/issues/709
-        run: |
-          sudo apt-get clean
-          df -h
       - uses: actions/checkout@v6
         with:
           show-progress: false
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: '.go-version'
-      # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
-      - uses: ./.github/actions/setup-docker-classic
-      - name: Download Antrea image from previous job
-        uses: actions/download-artifact@v7
-        with:
-          name: antrea-ubuntu-cov
-      - name: Load Antrea image
-        run: |
-          docker load -i antrea-ubuntu.tar
-      - name: Install Kind
-        run: |
-          KIND_VERSION=$(head -n1 ./ci/kind/version)
-          curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
-          chmod +x ./kind
-          sudo mv kind /usr/local/bin
+      - uses: ./.github/actions/setup-kind-test
       - name: Run e2e tests
         run: |
           mkdir log
@@ -562,7 +415,7 @@ jobs:
       matrix:
         protocol: [grpc, ipfix]
     steps:
-      - name: Free disk space
+      - name: Free disk space (extended)
         # https://github.com/actions/virtual-environments/issues/709
         run: |
           sudo apt-get clean
@@ -575,31 +428,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           show-progress: false
-      - uses: actions/setup-go@v6
+      - uses: ./.github/actions/setup-kind-test
         with:
-          go-version-file: '.go-version'
-      # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
-      - uses: ./.github/actions/setup-docker-classic
-      - name: Download Antrea image from previous job
-        uses: actions/download-artifact@v7
-        with:
-          name: antrea-ubuntu-cov
-      - name: Load Antrea image
-        run: |
-          docker load -i antrea-ubuntu.tar
-      - name: Download Flow Aggregator image from previous job
-        uses: actions/download-artifact@v7
-        with:
-          name: flow-aggregator-cov
-      - name: Load Flow Aggregator image
-        run: |
-          docker load -i flow-aggregator.tar
-      - name: Install Kind
-        run: |
-          KIND_VERSION=$(head -n1 ./ci/kind/version)
-          curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
-          chmod +x ./kind
-          sudo mv kind /usr/local/bin
+          free-disk-space: 'false'
+          load-flow-aggregator: 'true'
       - name: Run e2e tests
         run: |
           mkdir log
@@ -639,34 +471,12 @@ jobs:
     needs: [build-antrea-coverage-image]
     runs-on: [ubuntu-latest]
     steps:
-    - name: Free disk space
-      # https://github.com/actions/virtual-environments/issues/709
-      run: |
-        sudo apt-get clean
-        df -h
     - uses: actions/checkout@v6
       with:
         show-progress: false
-    - uses: actions/setup-go@v6
+    - uses: ./.github/actions/setup-kind-test
       with:
-        go-version-file: '.go-version'
-    # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
-    - uses: ./.github/actions/setup-docker-classic
-    - name: Download Antrea image from previous job
-      uses: actions/download-artifact@v7
-      with:
-        name: antrea-ubuntu-cov
-    - name: Load Antrea image
-      run: |
-        docker load -i antrea-ubuntu.tar
-        docker tag antrea/antrea-agent-ubuntu-coverage:latest antrea/antrea-agent-ubuntu:latest
-        docker tag antrea/antrea-controller-ubuntu-coverage:latest antrea/antrea-controller-ubuntu:latest
-    - name: Install Kind
-      run: |
-        KIND_VERSION=$(head -n1 ./ci/kind/version)
-        curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
-        chmod +x ./kind
-        sudo mv kind /usr/local/bin
+        tag-coverage-images: 'true'
     - name: Run NetworkPolicy conformance tests
       run: |
         mkdir log
@@ -687,34 +497,12 @@ jobs:
     needs: [build-antrea-coverage-image]
     runs-on: [ubuntu-latest]
     steps:
-    - name: Free disk space
-      # https://github.com/actions/virtual-environments/issues/709
-      run: |
-        sudo apt-get clean
-        df -h
     - uses: actions/checkout@v6
       with:
         show-progress: false
-    - uses: actions/setup-go@v6
+    - uses: ./.github/actions/setup-kind-test
       with:
-        go-version-file: '.go-version'
-    # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
-    - uses: ./.github/actions/setup-docker-classic
-    - name: Download Antrea image from previous job
-      uses: actions/download-artifact@v7
-      with:
-        name: antrea-ubuntu-cov
-    - name: Load Antrea image
-      run: |
-        docker load -i antrea-ubuntu.tar
-        docker tag antrea/antrea-agent-ubuntu-coverage:latest antrea/antrea-agent-ubuntu:latest
-        docker tag antrea/antrea-controller-ubuntu-coverage:latest antrea/antrea-controller-ubuntu:latest
-    - name: Install Kind
-      run: |
-        KIND_VERSION=$(head -n1 ./ci/kind/version)
-        curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
-        chmod +x ./kind
-        sudo mv kind /usr/local/bin
+        tag-coverage-images: 'true'
     - name: Run secondary network tests
       run: |
         mkdir log
@@ -735,34 +523,12 @@ jobs:
     needs: build-antrea-coverage-image
     runs-on: [ubuntu-latest]
     steps:
-      - name: Free disk space
-        # https://github.com/actions/virtual-environments/issues/709
-        run: |
-          sudo apt-get clean
-          df -h
       - uses: actions/checkout@v6
         with:
           show-progress: false
-      - uses: actions/setup-go@v6
+      - uses: ./.github/actions/setup-kind-test
         with:
-          go-version-file: '.go-version'
-      # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
-      - uses: ./.github/actions/setup-docker-classic
-      - name: Download Antrea image from previous job
-        uses: actions/download-artifact@v7
-        with:
-          name: antrea-ubuntu-cov
-      - name: Load Antrea image
-        run: |
-          docker load -i antrea-ubuntu.tar
-          docker tag antrea/antrea-agent-ubuntu-coverage:latest antrea/antrea-agent-ubuntu:latest
-          docker tag antrea/antrea-controller-ubuntu-coverage:latest antrea/antrea-controller-ubuntu:latest
-      - name: Install Kind
-        run: |
-          KIND_VERSION=$(head -n1 ./ci/kind/version)
-          curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
-          chmod +x ./kind
-          sudo mv kind /usr/local/bin
+          tag-coverage-images: 'true'
       - name: Run test
         run: |
           mkdir log
@@ -783,34 +549,12 @@ jobs:
     needs: build-antrea-coverage-image
     runs-on: [ubuntu-latest]
     steps:
-      - name: Free disk space
-        # https://github.com/actions/virtual-environments/issues/709
-        run: |
-          sudo apt-get clean
-          df -h
       - uses: actions/checkout@v6
         with:
           show-progress: false
-      - uses: actions/setup-go@v6
+      - uses: ./.github/actions/setup-kind-test
         with:
-          go-version-file: '.go-version'
-      # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
-      - uses: ./.github/actions/setup-docker-classic
-      - name: Download Antrea image from previous job
-        uses: actions/download-artifact@v7
-        with:
-          name: antrea-ubuntu-cov
-      - name: Load Antrea image
-        run: |
-          docker load -i antrea-ubuntu.tar
-          docker tag antrea/antrea-agent-ubuntu-coverage:latest antrea/antrea-agent-ubuntu:latest
-          docker tag antrea/antrea-controller-ubuntu-coverage:latest antrea/antrea-controller-ubuntu:latest
-      - name: Install Kind
-        run: |
-          KIND_VERSION=$(head -n1 ./ci/kind/version)
-          curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
-          chmod +x ./kind
-          sudo mv kind /usr/local/bin
+          tag-coverage-images: 'true'
       - name: Run test
         run: |
           mkdir log
@@ -831,34 +575,12 @@ jobs:
     needs: build-antrea-coverage-image
     runs-on: [ubuntu-latest]
     steps:
-      - name: Free disk space
-        # https://github.com/actions/virtual-environments/issues/709
-        run: |
-          sudo apt-get clean
-          df -h
       - uses: actions/checkout@v6
         with:
           show-progress: false
-      - uses: actions/setup-go@v6
+      - uses: ./.github/actions/setup-kind-test
         with:
-          go-version-file: '.go-version'
-      # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
-      - uses: ./.github/actions/setup-docker-classic
-      - name: Download Antrea image from previous job
-        uses: actions/download-artifact@v7
-        with:
-          name: antrea-ubuntu-cov
-      - name: Load Antrea image
-        run: |
-          docker load -i antrea-ubuntu.tar
-          docker tag antrea/antrea-agent-ubuntu-coverage:latest antrea/antrea-agent-ubuntu:latest
-          docker tag antrea/antrea-controller-ubuntu-coverage:latest antrea/antrea-controller-ubuntu:latest
-      - name: Install Kind
-        run: |
-          KIND_VERSION=$(head -n1 ./ci/kind/version)
-          curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
-          chmod +x ./kind
-          sudo mv kind /usr/local/bin
+          tag-coverage-images: 'true'
       - name: Run test
         run: |
           mkdir log
@@ -879,34 +601,12 @@ jobs:
     needs: build-antrea-coverage-image
     runs-on: [ubuntu-latest]
     steps:
-      - name: Free disk space
-        # https://github.com/actions/virtual-environments/issues/709
-        run: |
-          sudo apt-get clean
-          df -h
       - uses: actions/checkout@v6
         with:
           show-progress: false
-      - uses: actions/setup-go@v6
+      - uses: ./.github/actions/setup-kind-test
         with:
-          go-version-file: '.go-version'
-      # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
-      - uses: ./.github/actions/setup-docker-classic
-      - name: Download Antrea image from previous job
-        uses: actions/download-artifact@v7
-        with:
-          name: antrea-ubuntu-cov
-      - name: Load Antrea image
-        run: |
-          docker load -i antrea-ubuntu.tar
-          docker tag antrea/antrea-agent-ubuntu-coverage:latest antrea/antrea-agent-ubuntu:latest
-          docker tag antrea/antrea-controller-ubuntu-coverage:latest antrea/antrea-controller-ubuntu:latest
-      - name: Install Kind
-        run: |
-          KIND_VERSION=$(head -n1 ./ci/kind/version)
-          curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
-          chmod +x ./kind
-          sudo mv kind /usr/local/bin
+          tag-coverage-images: 'true'
       - name: Run test
         run: |
           mkdir log
@@ -927,31 +627,10 @@ jobs:
     needs: [ build-antrea-coverage-image ]
     runs-on: [ ubuntu-latest ]
     steps:
-      - name: Free disk space
-        run: |
-          sudo apt-get clean
-          df -h
       - uses: actions/checkout@v6
         with:
           show-progress: false
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: '.go-version'
-      # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
-      - uses: ./.github/actions/setup-docker-classic
-      - name: Download Antrea image from previous job
-        uses: actions/download-artifact@v7
-        with:
-          name: antrea-ubuntu-cov
-      - name: Load Antrea image
-        run: |
-          docker load -i antrea-ubuntu.tar
-      - name: Install Kind
-        run: |
-          KIND_VERSION=$(head -n1 ./ci/kind/version)
-          curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
-          chmod +x ./kind
-          sudo mv kind /usr/local/bin
+      - uses: ./.github/actions/setup-kind-test
       - name: Create Kind Cluster
         run: |
           ./ci/kind/kind-setup.sh create kind --ip-family dual
@@ -975,31 +654,13 @@ jobs:
     needs: build-antrea-coverage-image
     runs-on: [ubuntu-latest]
     steps:
-      - name: Free disk space
-        # https://github.com/actions/virtual-environments/issues/709
-        run: |
-          sudo apt-get clean
-          df -h
       - uses: actions/checkout@v6
         with:
           show-progress: false
-      # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
-      - uses: ./.github/actions/setup-docker-classic
-      - name: Download Antrea image from previous job
-        uses: actions/download-artifact@v7
+      - uses: ./.github/actions/setup-kind-test
         with:
-          name: antrea-ubuntu-cov
-      - name: Load Antrea image
-        run: |
-          docker load -i antrea-ubuntu.tar
-          docker tag antrea/antrea-agent-ubuntu-coverage:latest antrea/antrea-agent-ubuntu:latest
-          docker tag antrea/antrea-controller-ubuntu-coverage:latest antrea/antrea-controller-ubuntu:latest
-      - name: Install Kind
-        run: |
-          KIND_VERSION=$(head -n1 ./ci/kind/version)
-          curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
-          chmod +x ./kind
-          sudo mv kind /usr/local/bin
+          setup-go: 'false'
+          tag-coverage-images: 'true'
       - name: Validate document
         run: |
           ./ci/kind/validate-metrics-doc.sh

--- a/.github/workflows/kind_ubi.yml
+++ b/.github/workflows/kind_ubi.yml
@@ -55,12 +55,7 @@ jobs:
     - name: Clean up docker build cache
       run: |
         docker builder prune -f
-    - name: Install Kind
-      run: |
-        KIND_VERSION=$(head -n1 ./ci/kind/version)
-        curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
-        chmod +x ./kind
-        sudo mv kind /usr/local/bin
+    - uses: ./.github/actions/setup-kind
     - name: Run basic e2e tests
       run: |
         mkdir log

--- a/.github/workflows/netpol_cyclonus.yml
+++ b/.github/workflows/netpol_cyclonus.yml
@@ -20,12 +20,7 @@ jobs:
       # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
       - uses: ./.github/actions/setup-docker-classic
       - run: make
-      - name: Install Kind
-        run: |
-          KIND_VERSION=$(head -n1 ./ci/kind/version)
-          curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
-          chmod +x ./kind
-          sudo mv kind /usr/local/bin
+      - uses: ./.github/actions/setup-kind
       - name: Run cyclonus tests
         working-directory: hack/netpol-generator
         run: ./test-kind.sh


### PR DESCRIPTION
The Kind workflow had ~400 lines of duplicated setup steps (checkout, Go, Docker classic, artifact download, Kind install) repeated across 15 jobs. Introduce two composite actions to eliminate this duplication:

- setup-kind: installs the Kind binary using helm/kind-action, reading the version from ci/kind/version
- setup-kind-test: bundles the full preamble (free disk space, checkout, Go, Docker classic, artifact download/load, Kind install) with inputs for the per-job variations

All Kind-based workflows (kind.yml, kind_ubi.yml,
netpol_cyclonus.yml, conformance.yml) are updated to use these actions.