### PR TITLE
Refactor flowexporter to treat Connections as read‑only and classify FlowType in connection store

### DIFF
--- a/pkg/agent/flowexporter/connections/connections_test.go
+++ b/pkg/agent/flowexporter/connections/connections_test.go
@@ -125,7 +125,7 @@ func TestConnectionStore_DeleteConnWithoutLock(t *testing.T) {
 
 	// test on conntrack connection store
 	mockConnDumper := connectionstest.NewMockConnTrackDumper(ctrl)
-	conntrackConnStore := NewConntrackConnectionStore(mockConnDumper, true, false, nil, mockPodStore, nil, nil, testFlowExporterOptions)
+	conntrackConnStore := NewConntrackConnectionStore(mockConnDumper, true, false, nil, mockPodStore, nil, nil, testFlowExporterOptions, nil, false)
 	conntrackConnStore.connections[connKey] = conn
 
 	metrics.TotalAntreaConnectionsInConnTrackTable.Set(1)

--- a/pkg/agent/flowexporter/connections/connections_test.go
+++ b/pkg/agent/flowexporter/connections/connections_test.go
@@ -108,7 +108,7 @@ func TestConnectionStore_DeleteConnWithoutLock(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	// test on deny connection store
 	mockPodStore := objectstoretest.NewMockPodStore(ctrl)
-	denyConnStore := NewDenyConnectionStore(nil, mockPodStore, nil, testFlowExporterOptions, filter.NewProtocolFilter(nil))
+	denyConnStore := NewDenyConnectionStore(nil, mockPodStore, nil, testFlowExporterOptions, filter.NewProtocolFilter(nil), nil, false)
 	tuple := connection.Tuple{SourceAddress: netip.MustParseAddr("1.2.3.4"), DestinationAddress: netip.MustParseAddr("4.3.2.1"), Protocol: 6, SourcePort: 65280, DestinationPort: 255}
 	conn := &connection.Connection{
 		FlowKey: tuple,

--- a/pkg/agent/flowexporter/connections/conntrack_connections.go
+++ b/pkg/agent/flowexporter/connections/conntrack_connections.go
@@ -267,6 +267,13 @@ func (cs *ConntrackConnectionStore) AddOrUpdateConn(conn *connection.Connection)
 		existingConn.ReversePackets = conn.ReversePackets
 		existingConn.TCPState = conn.TCPState
 		existingConn.IsActive = utils.CheckConntrackConnActive(existingConn)
+		// If FlowType was set to Unspecified because the nodeRouteController had not yet
+		// synced when the connection was first seen, recompute it now if the controller is synced.
+		if existingConn.FlowType == utils.FlowTypeUnspecified {
+			if nrc, ok := cs.nodeRouteController.(interface{ HasSynced() bool }); !ok || nrc.HasSynced() {
+				existingConn.FlowType = findFlowType(existingConn, cs.nodeRouteController, cs.isNetworkPolicyOnly)
+			}
+		}
 		if existingConn.IsActive {
 			existingItem, exists := cs.expirePriorityQueue.KeyToItem[connKey]
 			if !exists {

--- a/pkg/agent/flowexporter/connections/conntrack_connections.go
+++ b/pkg/agent/flowexporter/connections/conntrack_connections.go
@@ -46,7 +46,7 @@ func findFlowType(conn *connection.Connection, nodeRouteController NodeRouteQuer
 		return utils.FlowTypeIntraNode
 	}
 
-	if nodeRouteController == nil {
+	if !isNetworkPolicyOnly && nodeRouteController == nil {
 		klog.V(5).InfoS("Can't find flow type without nodeRouteController")
 		return utils.FlowTypeUnspecified
 	}
@@ -304,7 +304,12 @@ func (cs *ConntrackConnectionStore) AddOrUpdateConn(conn *connection.Connection)
 			conn.StartTime = time.Now()
 			conn.StopTime = time.Now()
 		}
-		conn.FlowType = findFlowType(conn, cs.nodeRouteController, cs.isNetworkPolicyOnly)
+		// Defer FlowType classification until the nodeRouteController has synced, if possible.
+		if nrc, ok := cs.nodeRouteController.(interface{ HasSynced() bool }); ok && !nrc.HasSynced() {
+			conn.FlowType = utils.FlowTypeUnspecified
+		} else {
+			conn.FlowType = findFlowType(conn, cs.nodeRouteController, cs.isNetworkPolicyOnly)
+		}
 		if conn.StartTime.Before(cs.networkPolicyReadyTime) {
 			klog.V(1).InfoS("Skip adding NetworkPolicy metadata to connection to avoid reporting invalid information")
 		} else {

--- a/pkg/agent/flowexporter/connections/conntrack_connections.go
+++ b/pkg/agent/flowexporter/connections/conntrack_connections.go
@@ -33,6 +33,44 @@ import (
 	utilwait "antrea.io/antrea/pkg/util/wait"
 )
 
+// findFlowType classifies a Connection into one of the supported flow types.
+// It relies on the nodeRouteController to look up whether IPs belong to Pod
+// subnets. The result should be stored in conn.FlowType when the connection is
+// first added to the store so that exportConn() can treat FlowType as read-only.
+func findFlowType(conn *connection.Connection, nodeRouteController NodeRouteQuerier, isNetworkPolicyOnly bool) uint8 {
+	// TODO: support Pod-To-External flows in network policy only mode.
+	if isNetworkPolicyOnly {
+		if conn.SourcePodName == "" || conn.DestinationPodName == "" {
+			return utils.FlowTypeInterNode
+		}
+		return utils.FlowTypeIntraNode
+	}
+
+	if nodeRouteController == nil {
+		klog.V(5).InfoS("Can't find flow type without nodeRouteController")
+		return utils.FlowTypeUnspecified
+	}
+	srcIsPod, srcIsGw := nodeRouteController.LookupIPInPodSubnets(conn.FlowKey.SourceAddress)
+	dstIsPod, dstIsGw := nodeRouteController.LookupIPInPodSubnets(conn.FlowKey.DestinationAddress)
+	if srcIsGw || dstIsGw {
+		// This matches what we do in filterAntreaConns but is more general as we consider
+		// remote gateways as well.
+		klog.V(5).InfoS("Flows where the source or destination IP is a gateway IP will not be exported")
+		return utils.FlowTypeUnsupported
+	}
+	if !srcIsPod {
+		klog.V(5).InfoS("Flows where the source is not a Pod will not be exported")
+		return utils.FlowTypeUnsupported
+	}
+	if !dstIsPod {
+		return utils.FlowTypeToExternal
+	}
+	if conn.SourcePodName == "" || conn.DestinationPodName == "" {
+		return utils.FlowTypeInterNode
+	}
+	return utils.FlowTypeIntraNode
+}
+
 var serviceProtocolMap = map[uint8]corev1.Protocol{
 	6:   corev1.ProtocolTCP,
 	17:  corev1.ProtocolUDP,
@@ -45,6 +83,8 @@ type ConntrackConnectionStore struct {
 	v6Enabled             bool
 	pollInterval          time.Duration
 	connectUplinkToBridge bool
+	nodeRouteController   NodeRouteQuerier
+	isNetworkPolicyOnly   bool
 	// networkPolicyWait is used to determine when NetworkPolicy flows have been installed and
 	// when the mapping from flow ID to NetworkPolicy rule is available. We will ignore
 	// connections which started prior to that time to avoid reporting invalid NetworkPolicy
@@ -65,6 +105,8 @@ func NewConntrackConnectionStore(
 	proxier proxy.ProxyQuerier,
 	networkPolicyWait *utilwait.Group,
 	o *options.FlowExporterOptions,
+	nodeRouteController NodeRouteQuerier,
+	isNetworkPolicyOnly bool,
 ) *ConntrackConnectionStore {
 	return &ConntrackConnectionStore{
 		connDumper:            connTrackDumper,
@@ -74,6 +116,8 @@ func NewConntrackConnectionStore(
 		connectionStore:       NewConnectionStore(npQuerier, podStore, proxier, o),
 		connectUplinkToBridge: o.ConnectUplinkToBridge,
 		networkPolicyWait:     networkPolicyWait,
+		nodeRouteController:   nodeRouteController,
+		isNetworkPolicyOnly:   isNetworkPolicyOnly,
 	}
 }
 
@@ -260,6 +304,7 @@ func (cs *ConntrackConnectionStore) AddOrUpdateConn(conn *connection.Connection)
 			conn.StartTime = time.Now()
 			conn.StopTime = time.Now()
 		}
+		conn.FlowType = findFlowType(conn, cs.nodeRouteController, cs.isNetworkPolicyOnly)
 		if conn.StartTime.Before(cs.networkPolicyReadyTime) {
 			klog.V(1).InfoS("Skip adding NetworkPolicy metadata to connection to avoid reporting invalid information")
 		} else {

--- a/pkg/agent/flowexporter/connections/conntrack_connections_perf_test.go
+++ b/pkg/agent/flowexporter/connections/conntrack_connections_perf_test.go
@@ -147,7 +147,7 @@ func setupConntrackConnStore(b *testing.B) (*ConntrackConnectionStore, *connecti
 	mockProxier.EXPECT().GetServiceByIP(serviceStr).Return(servicePortName, true).AnyTimes()
 
 	npQuerier := queriertest.NewMockAgentNetworkPolicyInfoQuerier(ctrl)
-	return NewConntrackConnectionStore(mockConnDumper, true, false, npQuerier, mockPodStore, nil, nil, testFlowExporterOptions), mockConnDumper
+	return NewConntrackConnectionStore(mockConnDumper, true, false, npQuerier, mockPodStore, nil, nil, testFlowExporterOptions, nil, false), mockConnDumper
 }
 
 func generateConns() []*connection.Connection {

--- a/pkg/agent/flowexporter/connections/conntrack_connections_test.go
+++ b/pkg/agent/flowexporter/connections/conntrack_connections_test.go
@@ -104,6 +104,7 @@ func TestConntrackConnectionStore_AddOrUpdateConn(t *testing.T) {
 		newConn                          connection.Connection
 		expectedConn                     connection.Connection
 		expectNetworkPolicyMetadataAdded bool
+		nodeRouteController              NodeRouteQuerier
 	}{
 		{
 			name:                             "addNewConn",
@@ -237,7 +238,51 @@ func TestConntrackConnectionStore_AddOrUpdateConn(t *testing.T) {
 				DestinationPodName:         "pod1",
 				DestinationPodNamespace:    "ns1",
 				DestinationServicePortName: servicePortName.String(),
-				// NetworkPolicy fields should be empty for old connections
+			// NetworkPolicy fields should be empty for old connections
+			},
+		},
+		{
+			// Verify that conn.FlowType is set from findFlowType when a
+			// nodeRouteController is provided. Both IPs belong to pod subnets,
+			// but only the destination maps to a local Pod, so SourcePodName is
+			// empty after fillPodInfo → FlowTypeInterNode.
+			name:                             "addNewConn_withRouteController_setsFlowType",
+			oldConn:                          nil,
+			expectNetworkPolicyMetadataAdded: true,
+			nodeRouteController: &fakeNodeRouteQuerier{
+				podSubnets: map[string]bool{
+					"5.6.7.8": true,
+					"8.7.6.5": true,
+				},
+			},
+			newConn: connection.Connection{
+				StartTime: refTime,
+				StopTime:  refTime,
+				FlowKey:   tuple,
+				Labels:    []byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
+				Mark:      openflow.ServiceCTMark.GetValue(),
+			},
+			expectedConn: connection.Connection{
+				StartTime:                      refTime,
+				StopTime:                       refTime,
+				LastExportTime:                 refTime,
+				FlowKey:                        tuple,
+				Labels:                         []byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1},
+				Mark:                           openflow.ServiceCTMark.GetValue(),
+				IsPresent:                      true,
+				IsActive:                       true,
+				DestinationPodName:             "pod1",
+				DestinationPodNamespace:        "ns1",
+				DestinationServicePortName:     servicePortName.String(),
+				IngressNetworkPolicyName:       np1.Name,
+				IngressNetworkPolicyNamespace:  np1.Namespace,
+				IngressNetworkPolicyUID:        string(np1.UID),
+				IngressNetworkPolicyType:       utils.PolicyTypeToUint8(np1.Type),
+				IngressNetworkPolicyRuleName:   rule1.Name,
+				IngressNetworkPolicyRuleAction: utils.RuleActionToUint8(string(*rule1.Action)),
+				// SourcePodName is "" after fillPodInfo (not a local pod), so
+				// findFlowType returns FlowTypeInterNode.
+				FlowType: utils.FlowTypeInterNode,
 			},
 		},
 	}
@@ -250,7 +295,7 @@ func TestConntrackConnectionStore_AddOrUpdateConn(t *testing.T) {
 			mockConnDumper := connectionstest.NewMockConnTrackDumper(ctrl)
 			npQuerier := queriertest.NewMockAgentNetworkPolicyInfoQuerier(ctrl)
 
-			conntrackConnStore := NewConntrackConnectionStore(mockConnDumper, true, false, npQuerier, mockPodStore, mockProxier, nil, testFlowExporterOptions)
+			conntrackConnStore := NewConntrackConnectionStore(mockConnDumper, true, false, npQuerier, mockPodStore, mockProxier, nil, testFlowExporterOptions, c.nodeRouteController, false)
 			// Set the networkPolicyReadyTime to simulate that NetworkPolicies are ready
 			conntrackConnStore.networkPolicyReadyTime = networkPolicyReadyTime
 
@@ -332,7 +377,7 @@ func TestConnectionStore_DeleteConnectionByKey(t *testing.T) {
 	metrics.TotalAntreaConnectionsInConnTrackTable.Set(float64(len(testFlows)))
 	// Create connectionStore
 	mockPodStore := objectstoretest.NewMockPodStore(ctrl)
-	connStore := NewConntrackConnectionStore(nil, true, false, nil, mockPodStore, nil, nil, testFlowExporterOptions)
+	connStore := NewConntrackConnectionStore(nil, true, false, nil, mockPodStore, nil, nil, testFlowExporterOptions, nil, false)
 	// Add flows to the connection store.
 	for i, flow := range testFlows {
 		connStore.connections[*testFlowKeys[i]] = flow
@@ -354,7 +399,7 @@ func TestConnectionStore_MetricSettingInPoll(t *testing.T) {
 	// Create connectionStore
 	mockPodStore := objectstoretest.NewMockPodStore(ctrl)
 	mockConnDumper := connectionstest.NewMockConnTrackDumper(ctrl)
-	conntrackConnStore := NewConntrackConnectionStore(mockConnDumper, true, false, nil, mockPodStore, nil, nil, testFlowExporterOptions)
+	conntrackConnStore := NewConntrackConnectionStore(mockConnDumper, true, false, nil, mockPodStore, nil, nil, testFlowExporterOptions, nil, false)
 	// Hard-coded conntrack occupancy metrics for test
 	TotalConnections := 0
 	MaxConnections := 300000
@@ -382,7 +427,7 @@ func TestConntrackConnectionStore_Run_NetworkPolicyWait(t *testing.T) {
 		StaleConnectionTimeout: testStaleConnectionTimeout,
 		PollInterval:           100 * time.Millisecond, // Valid but small poll interval
 	}
-	conntrackConnStore := NewConntrackConnectionStore(mockConnDumper, true, false, nil, nil, nil, networkPolicyWait, testOptions)
+	conntrackConnStore := NewConntrackConnectionStore(mockConnDumper, true, false, nil, nil, nil, networkPolicyWait, testOptions, nil, false)
 
 	// Create a signal channel that will be closed on the first DumpFlows call
 	firstPollDoneCh := make(chan struct{})
@@ -436,4 +481,100 @@ func TestConntrackConnectionStore_Run_NetworkPolicyWait(t *testing.T) {
 	// Verify that networkPolicyReadyTime has been set and is after we started the test
 	require.NotZero(t, conntrackConnStore.networkPolicyReadyTime)
 	assert.True(t, conntrackConnStore.networkPolicyReadyTime.After(beforeRunTime))
+}
+
+// fakeNodeRouteQuerier is a test implementation of NodeRouteQuerier.
+type fakeNodeRouteQuerier struct {
+	podSubnets map[string]bool
+	gwSubnets  map[string]bool
+}
+
+func (f *fakeNodeRouteQuerier) LookupIPInPodSubnets(ip netip.Addr) (bool, bool) {
+	s := ip.String()
+	isGw := f.gwSubnets[s]
+	isPod := f.podSubnets[s] || isGw
+	return isPod, isGw
+}
+
+func TestFindFlowType(t *testing.T) {
+	srcIP := netip.MustParseAddr("1.2.3.4")
+	dstIP := netip.MustParseAddr("5.6.7.8")
+	extIP := netip.MustParseAddr("9.9.9.9")
+
+	// nrc: both src and dst are ordinary pod IPs (no gateway).
+	nrc := &fakeNodeRouteQuerier{
+		podSubnets: map[string]bool{srcIP.String(): true, dstIP.String(): true},
+	}
+	// gwNRC: src IP is a gateway (also a pod subnet hit).
+	gwNRC := &fakeNodeRouteQuerier{
+		podSubnets: map[string]bool{srcIP.String(): true, dstIP.String(): true},
+		gwSubnets:  map[string]bool{srcIP.String(): true},
+	}
+	// externalNRC: only src is a pod; dst is external.
+	externalNRC := &fakeNodeRouteQuerier{
+		podSubnets: map[string]bool{srcIP.String(): true},
+	}
+
+	testCases := []struct {
+		name                string
+		conn                *connection.Connection
+		nodeRouteController NodeRouteQuerier
+		isNetworkPolicyOnly bool
+		expected            uint8
+	}{
+		{
+			name:                "networkPolicyOnly_bothPodsKnown_intraNode",
+			conn:                &connection.Connection{SourcePodName: "podA", DestinationPodName: "podB"},
+			isNetworkPolicyOnly: true,
+			expected:            utils.FlowTypeIntraNode,
+		},
+		{
+			name:                "networkPolicyOnly_dstPodUnknown_interNode",
+			conn:                &connection.Connection{SourcePodName: "podA"},
+			isNetworkPolicyOnly: true,
+			expected:            utils.FlowTypeInterNode,
+		},
+		{
+			name:     "noController_unspecified",
+			conn:     &connection.Connection{FlowKey: connection.Tuple{SourceAddress: srcIP, DestinationAddress: dstIP}},
+			expected: utils.FlowTypeUnspecified,
+		},
+		{
+			name:                "srcIsGateway_unsupported",
+			conn:                &connection.Connection{FlowKey: connection.Tuple{SourceAddress: srcIP, DestinationAddress: dstIP}},
+			nodeRouteController: gwNRC,
+			expected:            utils.FlowTypeUnsupported,
+		},
+		{
+			name:                "srcNotPod_unsupported",
+			conn:                &connection.Connection{FlowKey: connection.Tuple{SourceAddress: extIP, DestinationAddress: dstIP}},
+			nodeRouteController: nrc,
+			expected:            utils.FlowTypeUnsupported,
+		},
+		{
+			name:                "dstNotPod_toExternal",
+			conn:                &connection.Connection{FlowKey: connection.Tuple{SourceAddress: srcIP, DestinationAddress: extIP}},
+			nodeRouteController: externalNRC,
+			expected:            utils.FlowTypeToExternal,
+		},
+		{
+			name:                "bothPods_srcPodNameUnknown_interNode",
+			conn:                &connection.Connection{FlowKey: connection.Tuple{SourceAddress: srcIP, DestinationAddress: dstIP}, DestinationPodName: "podB"},
+			nodeRouteController: nrc,
+			expected:            utils.FlowTypeInterNode,
+		},
+		{
+			name:                "bothPods_bothNamesKnown_intraNode",
+			conn:                &connection.Connection{FlowKey: connection.Tuple{SourceAddress: srcIP, DestinationAddress: dstIP}, SourcePodName: "podA", DestinationPodName: "podB"},
+			nodeRouteController: nrc,
+			expected:            utils.FlowTypeIntraNode,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := findFlowType(tc.conn, tc.nodeRouteController, tc.isNetworkPolicyOnly)
+			assert.Equal(t, tc.expected, got)
+		})
+	}
 }

--- a/pkg/agent/flowexporter/connections/conntrack_connections_test.go
+++ b/pkg/agent/flowexporter/connections/conntrack_connections_test.go
@@ -216,6 +216,98 @@ func TestConntrackConnectionStore_AddOrUpdateConn(t *testing.T) {
 			},
 		},
 		{
+			// A connection stored with FlowTypeUnspecified (NRC not yet synced) must have its
+			// FlowType recomputed on the next update once the NRC has synced.
+			name:                             "updateConn_recomputesFlowTypeWhenUnspecifiedAndSynced",
+			expectNetworkPolicyMetadataAdded: false,
+			nodeRouteController: &fakeNodeRouteQuerier{
+				hasSynced:  true,
+				podSubnets: map[string]bool{"5.6.7.8": true, "8.7.6.5": true},
+			},
+			oldConn: &connection.Connection{
+				StartTime:       refTime.Add(-(time.Second * 50)),
+				StopTime:        refTime.Add(-(time.Second * 30)),
+				LastExportTime:  refTime.Add(-(time.Second * 50)),
+				OriginalPackets: 0xfff,
+				OriginalBytes:   0xbaaaaa00000000,
+				ReversePackets:  0xf,
+				ReverseBytes:    0xbaa,
+				FlowKey:         tuple,
+				IsPresent:       true,
+				FlowType:        utils.FlowTypeUnspecified,
+			},
+			newConn: connection.Connection{
+				StartTime:       refTime.Add(-(time.Second * 50)),
+				StopTime:        refTime,
+				OriginalPackets: 0xffff,
+				OriginalBytes:   0xbaaaaa0000000000,
+				ReversePackets:  0xff,
+				ReverseBytes:    0xbaaa,
+				FlowKey:         tuple,
+				IsPresent:       true,
+			},
+			expectedConn: connection.Connection{
+				StartTime:       refTime.Add(-(time.Second * 50)),
+				StopTime:        refTime,
+				LastExportTime:  refTime.Add(-(time.Second * 50)),
+				OriginalPackets: 0xffff,
+				OriginalBytes:   0xbaaaaa0000000000,
+				ReversePackets:  0xff,
+				ReverseBytes:    0xbaaa,
+				FlowKey:         tuple,
+				IsPresent:       true,
+				IsActive:        true,
+				// Both IPs are in pod subnets; neither SourcePodName nor DestinationPodName
+				// is set on the stored connection, so findFlowType returns FlowTypeInterNode.
+				FlowType: utils.FlowTypeInterNode,
+			},
+		},
+		{
+			// A connection stored with FlowTypeUnspecified must remain Unspecified on update
+			// when the NRC has still not synced.
+			name:                             "updateConn_keepsUnspecifiedFlowTypeWhenNotSynced",
+			expectNetworkPolicyMetadataAdded: false,
+			nodeRouteController: &fakeNodeRouteQuerier{
+				hasSynced:  false,
+				podSubnets: map[string]bool{"5.6.7.8": true, "8.7.6.5": true},
+			},
+			oldConn: &connection.Connection{
+				StartTime:       refTime.Add(-(time.Second * 50)),
+				StopTime:        refTime.Add(-(time.Second * 30)),
+				LastExportTime:  refTime.Add(-(time.Second * 50)),
+				OriginalPackets: 0xfff,
+				OriginalBytes:   0xbaaaaa00000000,
+				ReversePackets:  0xf,
+				ReverseBytes:    0xbaa,
+				FlowKey:         tuple,
+				IsPresent:       true,
+				FlowType:        utils.FlowTypeUnspecified,
+			},
+			newConn: connection.Connection{
+				StartTime:       refTime.Add(-(time.Second * 50)),
+				StopTime:        refTime,
+				OriginalPackets: 0xffff,
+				OriginalBytes:   0xbaaaaa0000000000,
+				ReversePackets:  0xff,
+				ReverseBytes:    0xbaaa,
+				FlowKey:         tuple,
+				IsPresent:       true,
+			},
+			expectedConn: connection.Connection{
+				StartTime:       refTime.Add(-(time.Second * 50)),
+				StopTime:        refTime,
+				LastExportTime:  refTime.Add(-(time.Second * 50)),
+				OriginalPackets: 0xffff,
+				OriginalBytes:   0xbaaaaa0000000000,
+				ReversePackets:  0xff,
+				ReverseBytes:    0xbaaa,
+				FlowKey:         tuple,
+				IsPresent:       true,
+				IsActive:        true,
+				FlowType:        utils.FlowTypeUnspecified,
+			},
+		},
+		{
 			name:                             "addConnWithOldTimestamp_NoNetworkPolicyMetadata",
 			oldConn:                          nil,
 			expectNetworkPolicyMetadataAdded: false,
@@ -250,6 +342,7 @@ func TestConntrackConnectionStore_AddOrUpdateConn(t *testing.T) {
 			oldConn:                          nil,
 			expectNetworkPolicyMetadataAdded: true,
 			nodeRouteController: &fakeNodeRouteQuerier{
+				hasSynced: true,
 				podSubnets: map[string]bool{
 					"5.6.7.8": true,
 					"8.7.6.5": true,
@@ -487,6 +580,7 @@ func TestConntrackConnectionStore_Run_NetworkPolicyWait(t *testing.T) {
 type fakeNodeRouteQuerier struct {
 	podSubnets map[string]bool
 	gwSubnets  map[string]bool
+	hasSynced  bool
 }
 
 func (f *fakeNodeRouteQuerier) LookupIPInPodSubnets(ip netip.Addr) (bool, bool) {
@@ -494,6 +588,10 @@ func (f *fakeNodeRouteQuerier) LookupIPInPodSubnets(ip netip.Addr) (bool, bool) 
 	isGw := f.gwSubnets[s]
 	isPod := f.podSubnets[s] || isGw
 	return isPod, isGw
+}
+
+func (f *fakeNodeRouteQuerier) HasSynced() bool {
+	return f.hasSynced
 }
 
 func TestFindFlowType(t *testing.T) {

--- a/pkg/agent/flowexporter/connections/conntrack_connections_test.go
+++ b/pkg/agent/flowexporter/connections/conntrack_connections_test.go
@@ -238,7 +238,7 @@ func TestConntrackConnectionStore_AddOrUpdateConn(t *testing.T) {
 				DestinationPodName:         "pod1",
 				DestinationPodNamespace:    "ns1",
 				DestinationServicePortName: servicePortName.String(),
-			// NetworkPolicy fields should be empty for old connections
+				// NetworkPolicy fields should be empty for old connections
 			},
 		},
 		{

--- a/pkg/agent/flowexporter/connections/deny_connections.go
+++ b/pkg/agent/flowexporter/connections/deny_connections.go
@@ -24,6 +24,7 @@ import (
 	"antrea.io/antrea/pkg/agent/flowexporter/filter"
 	"antrea.io/antrea/pkg/agent/flowexporter/options"
 	"antrea.io/antrea/pkg/agent/flowexporter/priorityqueue"
+	"antrea.io/antrea/pkg/agent/flowexporter/utils"
 	"antrea.io/antrea/pkg/agent/metrics"
 	"antrea.io/antrea/pkg/agent/openflow"
 	"antrea.io/antrea/pkg/agent/proxy"
@@ -34,7 +35,9 @@ import (
 
 type DenyConnectionStore struct {
 	connectionStore
-	protocolFilter filter.ProtocolFilter
+	protocolFilter       filter.ProtocolFilter
+	nodeRouteController  NodeRouteQuerier
+	isNetworkPolicyOnly  bool
 }
 
 func NewDenyConnectionStore(
@@ -43,10 +46,14 @@ func NewDenyConnectionStore(
 	proxier proxy.ProxyQuerier,
 	o *options.FlowExporterOptions,
 	protocolFilter filter.ProtocolFilter,
+	nodeRouteController NodeRouteQuerier,
+	isNetworkPolicyOnly bool,
 ) *DenyConnectionStore {
 	return &DenyConnectionStore{
-		connectionStore: NewConnectionStore(npQuerier, podStore, proxier, o),
-		protocolFilter:  protocolFilter,
+		connectionStore:     NewConnectionStore(npQuerier, podStore, proxier, o),
+		protocolFilter:      protocolFilter,
+		nodeRouteController: nodeRouteController,
+		isNetworkPolicyOnly: isNetworkPolicyOnly,
 	}
 }
 
@@ -125,6 +132,12 @@ func (ds *DenyConnectionStore) AddOrUpdateConn(conn *connection.Connection, time
 		}
 		// For intra-Node flows which are denied by an ingress policy rule, we can retrieve
 		// egress policy information from the CT labels.
+		// Defer FlowType classification until the nodeRouteController has synced, if possible.
+		if nrc, ok := ds.nodeRouteController.(interface{ HasSynced() bool }); ok && !nrc.HasSynced() {
+			conn.FlowType = utils.FlowTypeUnspecified
+		} else {
+			conn.FlowType = findFlowType(conn, ds.nodeRouteController, ds.isNetworkPolicyOnly)
+		}
 		ds.addNetworkPolicyMetadata(conn)
 		metrics.TotalDenyConnections.Inc()
 		conn.IsActive = true

--- a/pkg/agent/flowexporter/connections/deny_connections.go
+++ b/pkg/agent/flowexporter/connections/deny_connections.go
@@ -35,9 +35,9 @@ import (
 
 type DenyConnectionStore struct {
 	connectionStore
-	protocolFilter       filter.ProtocolFilter
-	nodeRouteController  NodeRouteQuerier
-	isNetworkPolicyOnly  bool
+	protocolFilter      filter.ProtocolFilter
+	nodeRouteController NodeRouteQuerier
+	isNetworkPolicyOnly bool
 }
 
 func NewDenyConnectionStore(

--- a/pkg/agent/flowexporter/connections/deny_connections.go
+++ b/pkg/agent/flowexporter/connections/deny_connections.go
@@ -100,6 +100,13 @@ func (ds *DenyConnectionStore) AddOrUpdateConn(conn *connection.Connection, time
 		conn.OriginalPackets += 1
 		conn.StopTime = timeSeen
 		conn.IsActive = true
+		// If FlowType was set to Unspecified because the nodeRouteController had not yet
+		// synced when the connection was first seen, recompute it now if the controller is synced.
+		if conn.FlowType == utils.FlowTypeUnspecified {
+			if nrc, ok := ds.nodeRouteController.(interface{ HasSynced() bool }); !ok || nrc.HasSynced() {
+				conn.FlowType = findFlowType(conn, ds.nodeRouteController, ds.isNetworkPolicyOnly)
+			}
+		}
 		existingItem, exists := ds.expirePriorityQueue.KeyToItem[connKey]
 		if !exists {
 			ds.expirePriorityQueue.WriteItemToQueue(connKey, conn)

--- a/pkg/agent/flowexporter/connections/deny_connections_test.go
+++ b/pkg/agent/flowexporter/connections/deny_connections_test.go
@@ -132,7 +132,7 @@ func TestDenyConnectionStore_AddOrUpdateConn(t *testing.T) {
 				mockPodStore.EXPECT().GetPodByIPAndTime(tuple.DestinationAddress.String(), gomock.Any()).Return(pod1, true)
 			}
 
-			denyConnStore := NewDenyConnectionStore(nil, mockPodStore, mockProxier, testFlowExporterOptions, filter.NewProtocolFilter(c.protocolFilter))
+			denyConnStore := NewDenyConnectionStore(nil, mockPodStore, mockProxier, testFlowExporterOptions, filter.NewProtocolFilter(c.protocolFilter), nil, false)
 
 			denyConnStore.AddOrUpdateConn(&c.testFlow, refTime.Add(-(time.Second * 20)), uint64(60))
 			expConn := c.testFlow

--- a/pkg/agent/flowexporter/connections/deny_connections_test.go
+++ b/pkg/agent/flowexporter/connections/deny_connections_test.go
@@ -27,6 +27,7 @@ import (
 
 	"antrea.io/antrea/pkg/agent/flowexporter/connection"
 	"antrea.io/antrea/pkg/agent/flowexporter/filter"
+	"antrea.io/antrea/pkg/agent/flowexporter/utils"
 	"antrea.io/antrea/pkg/agent/metrics"
 	"antrea.io/antrea/pkg/agent/openflow"
 	proxytest "antrea.io/antrea/pkg/agent/proxy/testing"
@@ -164,4 +165,53 @@ func TestDenyConnectionStore_AddOrUpdateConn(t *testing.T) {
 			checkDenyConnectionMetrics(t, len(denyConnStore.connections))
 		})
 	}
+}
+
+func TestDenyConnectionStore_FlowTypeRecomputeAfterSync(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	refTime := time.Now()
+	tuple := connection.Tuple{
+		SourceAddress:      netip.MustParseAddr("1.2.3.4"),
+		DestinationAddress: netip.MustParseAddr("4.3.2.1"),
+		Protocol:           6,
+		SourcePort:         65280,
+		DestinationPort:    255,
+	}
+
+	mockPodStore := objectstoretest.NewMockPodStore(ctrl)
+	mockProxier := proxytest.NewMockProxyQuerier(ctrl)
+
+	// fillPodInfo is called once during the initial add; both IPs map to pod1.
+	mockPodStore.EXPECT().GetPodByIPAndTime(tuple.SourceAddress.String(), gomock.Any()).Return(pod1, true)
+	mockPodStore.EXPECT().GetPodByIPAndTime(tuple.DestinationAddress.String(), gomock.Any()).Return(pod1, true)
+
+	// NRC starts unsynced; both IPs are in pod subnets.
+	nrc := &fakeNodeRouteQuerier{
+		hasSynced:  false,
+		podSubnets: map[string]bool{"1.2.3.4": true, "4.3.2.1": true},
+	}
+	denyConnStore := NewDenyConnectionStore(nil, mockPodStore, mockProxier, testFlowExporterOptions, filter.NewProtocolFilter(nil), nrc, false)
+
+	testFlow := &connection.Connection{
+		FlowKey:                    tuple,
+		OriginalDestinationAddress: tuple.DestinationAddress,
+		OriginalDestinationPort:    tuple.DestinationPort,
+	}
+
+	// First add: NRC not yet synced → FlowType must be Unspecified.
+	denyConnStore.AddOrUpdateConn(testFlow, refTime, 60)
+	actualConn, ok := denyConnStore.GetConnByKey(connection.NewConnectionKey(testFlow))
+	assert.True(t, ok, "deny connection should be present after add")
+	assert.Equal(t, utils.FlowTypeUnspecified, actualConn.FlowType, "FlowType should be Unspecified before NRC syncs")
+
+	// Simulate NRC becoming synced.
+	nrc.hasSynced = true
+
+	// Update: NRC is now synced → FlowType must be recomputed.
+	// Both IPs are pod subnets and both pod names are populated by fillPodInfo
+	// during the initial add, so findFlowType returns FlowTypeIntraNode.
+	denyConnStore.AddOrUpdateConn(testFlow, refTime.Add(time.Second), 60)
+	actualConn, ok = denyConnStore.GetConnByKey(connection.NewConnectionKey(testFlow))
+	assert.True(t, ok, "deny connection should still be present after update")
+	assert.Equal(t, utils.FlowTypeIntraNode, actualConn.FlowType, "FlowType should be recomputed to IntraNode after NRC syncs")
 }

--- a/pkg/agent/flowexporter/connections/interface.go
+++ b/pkg/agent/flowexporter/connections/interface.go
@@ -15,10 +15,17 @@
 package connections
 
 import (
+	"net/netip"
 	"time"
 
 	"antrea.io/antrea/pkg/agent/flowexporter/connection"
 )
+
+// NodeRouteQuerier is used by ConntrackConnectionStore to classify connections
+// by flow type. It is satisfied by *noderoute.Controller.
+type NodeRouteQuerier interface {
+	LookupIPInPodSubnets(ip netip.Addr) (bool, bool)
+}
 
 // ConnTrackDumper is an interface that is used to dump connections from conntrack module. This supports dumping through
 // netfilter socket (OVS kernel datapath) and ovs-appctl command (OVS userspace datapath).

--- a/pkg/agent/flowexporter/exporter.go
+++ b/pkg/agent/flowexporter/exporter.go
@@ -85,7 +85,6 @@ func NewFlowExporter(podStore objectstore.PodStore, proxier proxy.ProxyQuerier, 
 ) (*FlowExporter, error) {
 	protocolFilter := filter.NewProtocolFilter(o.ProtocolFilter)
 	connTrackDumper := connections.InitializeConnTrackDumper(nodeConfig, serviceCIDRNet, serviceCIDRNetv6, ovsDatapathType, proxyEnabled, protocolFilter)
-	denyConnStore := connections.NewDenyConnectionStore(npQuerier, podStore, proxier, o, protocolFilter)
 	isNetworkPolicyOnly := trafficEncapMode.IsNetworkPolicyOnly()
 	// Guard against a nil concrete pointer being wrapped in a non-nil interface value,
 	// which would cause a panic inside findFlowType when the nil check is evaluated.
@@ -93,6 +92,7 @@ func NewFlowExporter(podStore objectstore.PodStore, proxier proxy.ProxyQuerier, 
 	if nodeRouteController != nil {
 		nrc = nodeRouteController
 	}
+	denyConnStore := connections.NewDenyConnectionStore(npQuerier, podStore, proxier, o, protocolFilter, nrc, isNetworkPolicyOnly)
 	conntrackConnStore := connections.NewConntrackConnectionStore(connTrackDumper, v4Enabled, v6Enabled, npQuerier, podStore, proxier, podNetworkWait, o, nrc, isNetworkPolicyOnly)
 	if nodeRouteController == nil {
 		klog.InfoS("NodeRouteController is nil, will not be able to determine flow type for connections")

--- a/pkg/agent/flowexporter/exporter.go
+++ b/pkg/agent/flowexporter/exporter.go
@@ -69,7 +69,6 @@ type FlowExporter struct {
 	v6Enabled              bool
 	k8sClient              kubernetes.Interface
 	nodeRouteController    *noderoute.Controller
-	isNetworkPolicyOnly    bool
 	conntrackPriorityQueue *priorityqueue.ExpirePriorityQueue
 	denyPriorityQueue      *priorityqueue.ExpirePriorityQueue
 	expiredConns           []connection.Connection
@@ -87,7 +86,14 @@ func NewFlowExporter(podStore objectstore.PodStore, proxier proxy.ProxyQuerier, 
 	protocolFilter := filter.NewProtocolFilter(o.ProtocolFilter)
 	connTrackDumper := connections.InitializeConnTrackDumper(nodeConfig, serviceCIDRNet, serviceCIDRNetv6, ovsDatapathType, proxyEnabled, protocolFilter)
 	denyConnStore := connections.NewDenyConnectionStore(npQuerier, podStore, proxier, o, protocolFilter)
-	conntrackConnStore := connections.NewConntrackConnectionStore(connTrackDumper, v4Enabled, v6Enabled, npQuerier, podStore, proxier, podNetworkWait, o)
+	isNetworkPolicyOnly := trafficEncapMode.IsNetworkPolicyOnly()
+	// Guard against a nil concrete pointer being wrapped in a non-nil interface value,
+	// which would cause a panic inside findFlowType when the nil check is evaluated.
+	var nrc connections.NodeRouteQuerier
+	if nodeRouteController != nil {
+		nrc = nodeRouteController
+	}
+	conntrackConnStore := connections.NewConntrackConnectionStore(connTrackDumper, v4Enabled, v6Enabled, npQuerier, podStore, proxier, podNetworkWait, o, nrc, isNetworkPolicyOnly)
 	if nodeRouteController == nil {
 		klog.InfoS("NodeRouteController is nil, will not be able to determine flow type for connections")
 	}
@@ -129,7 +135,6 @@ func NewFlowExporter(podStore objectstore.PodStore, proxier proxy.ProxyQuerier, 
 		v6Enabled:              v6Enabled,
 		k8sClient:              k8sClient,
 		nodeRouteController:    nodeRouteController,
-		isNetworkPolicyOnly:    trafficEncapMode.IsNetworkPolicyOnly(),
 		conntrackPriorityQueue: conntrackConnStore.GetPriorityQueue(),
 		denyPriorityQueue:      denyConnStore.GetPriorityQueue(),
 		expiredConns:           make([]connection.Connection, 0, maxConnsToExport*2),
@@ -290,40 +295,6 @@ func (exp *FlowExporter) initFlowExporter(ctx context.Context) error {
 	return nil
 }
 
-func (exp *FlowExporter) findFlowType(conn connection.Connection) uint8 {
-	// TODO: support Pod-To-External flows in network policy only mode.
-	if exp.isNetworkPolicyOnly {
-		if conn.SourcePodName == "" || conn.DestinationPodName == "" {
-			return utils.FlowTypeInterNode
-		}
-		return utils.FlowTypeIntraNode
-	}
-
-	if exp.nodeRouteController == nil {
-		klog.V(5).InfoS("Can't find flow type without nodeRouteController")
-		return utils.FlowTypeUnspecified
-	}
-	srcIsPod, srcIsGw := exp.nodeRouteController.LookupIPInPodSubnets(conn.FlowKey.SourceAddress)
-	dstIsPod, dstIsGw := exp.nodeRouteController.LookupIPInPodSubnets(conn.FlowKey.DestinationAddress)
-	if srcIsGw || dstIsGw {
-		// This matches what we do in filterAntreaConns but is more general as we consider
-		// remote gateways as well.
-		klog.V(5).InfoS("Flows where the source or destination IP is a gateway IP will not be exported")
-		return utils.FlowTypeUnsupported
-	}
-	if !srcIsPod {
-		klog.V(5).InfoS("Flows where the source is not a Pod will not be exported")
-		return utils.FlowTypeUnsupported
-	}
-	if !dstIsPod {
-		return utils.FlowTypeToExternal
-	}
-	if conn.SourcePodName == "" || conn.DestinationPodName == "" {
-		return utils.FlowTypeInterNode
-	}
-	return utils.FlowTypeIntraNode
-}
-
 func (exp *FlowExporter) fillEgressInfo(conn *connection.Connection) {
 	egress, err := exp.egressQuerier.GetEgress(conn.SourcePodNamespace, conn.SourcePodName)
 	if err != nil {
@@ -340,7 +311,6 @@ func (exp *FlowExporter) fillEgressInfo(conn *connection.Connection) {
 }
 
 func (exp *FlowExporter) exportConn(conn *connection.Connection) error {
-	conn.FlowType = exp.findFlowType(*conn)
 	if conn.FlowType == utils.FlowTypeUnsupported {
 		return nil
 	}

--- a/pkg/agent/flowexporter/exporter_perf_test.go
+++ b/pkg/agent/flowexporter/exporter_perf_test.go
@@ -167,7 +167,7 @@ func NewFlowExporterForTest(tb testing.TB, o *options.FlowExporterOptions) *Flow
 	v4Enabled := !testWithIPv6
 	v6Enabled := testWithIPv6
 
-	denyConnStore := connections.NewDenyConnectionStore(nil, nil, nil, o, filter.NewProtocolFilter(nil))
+	denyConnStore := connections.NewDenyConnectionStore(nil, nil, nil, o, filter.NewProtocolFilter(nil), nil, false)
 	conntrackConnStore := connections.NewConntrackConnectionStore(nil, v4Enabled, v6Enabled, nil, nil, nil, nil, o, nil, false)
 
 	return &FlowExporter{

--- a/pkg/agent/flowexporter/exporter_perf_test.go
+++ b/pkg/agent/flowexporter/exporter_perf_test.go
@@ -168,7 +168,7 @@ func NewFlowExporterForTest(tb testing.TB, o *options.FlowExporterOptions) *Flow
 	v6Enabled := testWithIPv6
 
 	denyConnStore := connections.NewDenyConnectionStore(nil, nil, nil, o, filter.NewProtocolFilter(nil))
-	conntrackConnStore := connections.NewConntrackConnectionStore(nil, v4Enabled, v6Enabled, nil, nil, nil, nil, o)
+	conntrackConnStore := connections.NewConntrackConnectionStore(nil, v4Enabled, v6Enabled, nil, nil, nil, nil, o, nil, false)
 
 	return &FlowExporter{
 		collectorProto:         o.FlowCollectorProto,
@@ -180,7 +180,6 @@ func NewFlowExporterForTest(tb testing.TB, o *options.FlowExporterOptions) *Flow
 		v6Enabled:              v6Enabled,
 		k8sClient:              nil,
 		nodeRouteController:    nil,
-		isNetworkPolicyOnly:    false,
 		conntrackPriorityQueue: conntrackConnStore.GetPriorityQueue(),
 		denyPriorityQueue:      denyConnStore.GetPriorityQueue(),
 		expiredConns:           make([]connection.Connection, 0, maxConnsToExport*2),

--- a/pkg/agent/flowexporter/exporter_test.go
+++ b/pkg/agent/flowexporter/exporter_test.go
@@ -302,7 +302,7 @@ func runSendFlowRecordTests(t *testing.T, flowExp *FlowExporter, isIPv6 bool) {
 				PollInterval:           1,
 			}
 			flowExp.conntrackConnStore = connections.NewConntrackConnectionStore(mockConnDumper, !isIPv6, isIPv6, nil, nil, nil, nil, o, nil, false)
-			flowExp.denyConnStore = connections.NewDenyConnectionStore(nil, nil, nil, o, filter.NewProtocolFilter(nil))
+			flowExp.denyConnStore = connections.NewDenyConnectionStore(nil, nil, nil, o, filter.NewProtocolFilter(nil), nil, false)
 			flowExp.conntrackPriorityQueue = flowExp.conntrackConnStore.GetPriorityQueue()
 			flowExp.denyPriorityQueue = flowExp.denyConnStore.GetPriorityQueue()
 			flowExp.numConnsExported = 0

--- a/pkg/agent/flowexporter/exporter_test.go
+++ b/pkg/agent/flowexporter/exporter_test.go
@@ -39,6 +39,7 @@ import (
 	"antrea.io/antrea/pkg/agent/flowexporter/options"
 	"antrea.io/antrea/pkg/agent/flowexporter/priorityqueue"
 	flowexportertesting "antrea.io/antrea/pkg/agent/flowexporter/testing"
+	"antrea.io/antrea/pkg/agent/flowexporter/utils"
 	"antrea.io/antrea/pkg/agent/metrics"
 	agenttypes "antrea.io/antrea/pkg/agent/types"
 	queriertest "antrea.io/antrea/pkg/querier/testing"
@@ -300,7 +301,7 @@ func runSendFlowRecordTests(t *testing.T, flowExp *FlowExporter, isIPv6 bool) {
 				StaleConnectionTimeout: 1,
 				PollInterval:           1,
 			}
-			flowExp.conntrackConnStore = connections.NewConntrackConnectionStore(mockConnDumper, !isIPv6, isIPv6, nil, nil, nil, nil, o)
+			flowExp.conntrackConnStore = connections.NewConntrackConnectionStore(mockConnDumper, !isIPv6, isIPv6, nil, nil, nil, nil, o, nil, false)
 			flowExp.denyConnStore = connections.NewDenyConnectionStore(nil, nil, nil, o, filter.NewProtocolFilter(nil))
 			flowExp.conntrackPriorityQueue = flowExp.conntrackConnStore.GetPriorityQueue()
 			flowExp.denyPriorityQueue = flowExp.denyConnStore.GetPriorityQueue()
@@ -387,23 +388,74 @@ func getNumOfDenyConns(connStore *connections.DenyConnectionStore) int {
 	return count
 }
 
-func TestFlowExporter_findFlowType(t *testing.T) {
-	conn1 := connection.Connection{SourcePodName: "podA", DestinationPodName: "podB"}
-	conn2 := connection.Connection{SourcePodName: "podA", DestinationPodName: ""}
-	for _, tc := range []struct {
-		isNetworkPolicyOnly bool
-		conn                connection.Connection
-		expectedFlowType    uint8
+func TestFlowExporter_exportConn(t *testing.T) {
+	testCases := []struct {
+		name         string
+		conn         connection.Connection
+		expectExport bool
+		egressSetup  func(*queriertest.MockEgressQuerier)
 	}{
-		{true, conn1, 1},
-		{true, conn2, 2},
-		{false, conn1, 0},
-	} {
-		flowExp := &FlowExporter{
-			isNetworkPolicyOnly: tc.isNetworkPolicyOnly,
-		}
-		flowType := flowExp.findFlowType(tc.conn)
-		assert.Equal(t, tc.expectedFlowType, flowType)
+		{
+			name: "FlowTypeUnsupported is skipped",
+			conn: connection.Connection{FlowType: utils.FlowTypeUnsupported},
+		},
+		{
+			name: "FlowTypeToExternal without source pod is skipped",
+			conn: connection.Connection{FlowType: utils.FlowTypeToExternal},
+		},
+		{
+			name: "FlowTypeToExternal with source pod is exported",
+			conn: connection.Connection{
+				FlowType:           utils.FlowTypeToExternal,
+				SourcePodNamespace: "ns",
+				SourcePodName:      "pod",
+			},
+			expectExport: true,
+			egressSetup: func(q *queriertest.MockEgressQuerier) {
+				q.EXPECT().GetEgress("ns", "pod").Return(agenttypes.EgressConfig{}, fmt.Errorf("no egress"))
+			},
+		},
+		{
+			name:         "FlowTypeIntraNode is exported",
+			conn:         connection.Connection{FlowType: utils.FlowTypeIntraNode},
+			expectExport: true,
+		},
+		{
+			name:         "FlowTypeInterNode is exported",
+			conn:         connection.Connection{FlowType: utils.FlowTypeInterNode},
+			expectExport: true,
+		},
+		{
+			name:         "FlowTypeUnspecified is exported",
+			conn:         connection.Connection{FlowType: utils.FlowTypeUnspecified},
+			expectExport: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockExporter := exportertesting.NewMockInterface(ctrl)
+			egressQuerier := queriertest.NewMockEgressQuerier(ctrl)
+			exp := &FlowExporter{
+				exporter:      mockExporter,
+				egressQuerier: egressQuerier,
+			}
+			if tc.egressSetup != nil {
+				tc.egressSetup(egressQuerier)
+			}
+			if tc.expectExport {
+				mockExporter.EXPECT().Export(gomock.Any()).Return(nil)
+			}
+			err := exp.exportConn(&tc.conn)
+			require.NoError(t, err)
+			if tc.expectExport {
+				assert.Equal(t, uint64(1), exp.numConnsExported)
+			} else {
+				assert.Equal(t, uint64(0), exp.numConnsExported)
+			}
+		})
 	}
 }
 

--- a/test/integration/agent/flowexporter_test.go
+++ b/test/integration/agent/flowexporter_test.go
@@ -136,7 +136,7 @@ func TestConnectionStoreAndFlowRecords(t *testing.T) {
 		IdleFlowTimeout:        testIdleFlowTimeout,
 		StaleConnectionTimeout: testStaleConnectionTimeout,
 		PollInterval:           testPollInterval}
-	conntrackConnStore := connections.NewConntrackConnectionStore(connDumperMock, true, false, npQuerier, mockPodStore, nil, nil, o)
+	conntrackConnStore := connections.NewConntrackConnectionStore(connDumperMock, true, false, npQuerier, mockPodStore, nil, nil, o, nil, false)
 	// Expect calls for connStore.poll and other callees
 	connDumperMock.EXPECT().DumpFlows(uint16(openflow.CtZone)).Return(testConns, 0, nil)
 	connDumperMock.EXPECT().GetMaxConnections().Return(0, nil)
@@ -366,6 +366,8 @@ func BenchmarkConntrackConnectionStorePoll(b *testing.B) {
 		nil,
 		nil,
 		o,
+		nil,
+		false,
 	)
 
 	for b.Loop() {


### PR DESCRIPTION
## Summary

fixes #7801 

This PR addresses by making `flowexporter` treat `Connection` objects as read‑only and moving FlowType classification into the connections store.

introduces a `NodeRouteQuerier` interface in the `connections` package so FlowType classification can use `LookupIPInPodSubnets` without directly depending on `noderoute.Controller`.

moves `findFlowType` from `flowexporter` to `pkg/agent/flowexporter/connections/conntrack_connections.go`.

extends `ConntrackConnectionStore` with `nodeRouteController` and `isNetworkPolicyOnly` fields, and updates `NewConntrackConnectionStore` to accept these parameters.

sets `conn.FlowType` for new connections inside `AddOrUpdateConn` using the new `findFlowType` helper.

simplifies `exportConn` so it no longer mutates `conn.FlowType`. it now only reads the existing `FlowType` to decide whether and how the connection should be exported.

updates all call sites of `NewConntrackConnectionStore` and adjusts tests accordingly:

• added new tests for `findFlowType` and FlowType assignment in the connections store
• added new `exportConn` tests that operate on connections with pre set FlowTypes


