### PR TITLE
Fix doc typos and ignore .cursor in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ bin
 
 .idea/
 .vscode/
+.cursor/
 vendor
 
 ci/jenkins/jobs/defaults.yml

--- a/docs/antctl.md
+++ b/docs/antctl.md
@@ -210,7 +210,7 @@ included over time):
 
 **Be aware that the generated support bundle includes a lot of information,
   including logs, so please review the contents of the directory before sharing
-  it on Github and ensure that you do not share anything sensitive.**
+  it on GitHub and ensure that you do not share anything sensitive.**
 
 The `antctl supportbundle` command can also be run inside a Controller or Agent
 Pod, in which case only local information will be collected.
@@ -560,7 +560,7 @@ More examples of `antctl traceflow`:
 ```bash
 # Start a Traceflow from pod1 to pod2, both Pods are in Namespace default
 $ antctl traceflow -S pod1 -D pod2
-# Start a Traceflow from pod1 in Namepace ns1 to a destination IP
+# Start a Traceflow from pod1 in Namespace ns1 to a destination IP
 $ antctl traceflow -S ns1/pod1 -D 123.123.123.123
 # Start a Traceflow from pod1 to Service svc1 in Namespace ns1
 $ antctl traceflow -S pod1 -D ns1/svc1 -f tcp,tcp_dst=80

--- a/docs/antrea-l7-network-policy.md
+++ b/docs/antrea-l7-network-policy.md
@@ -35,7 +35,7 @@ This guide demonstrates how to configure layer 7 NetworkPolicy.
 Layer 7 NetworkPolicy was introduced in v1.10 as an alpha feature and is disabled by default. A feature gate,
 `L7NetworkPolicy`, must be enabled in antrea-controller.conf and antrea-agent.conf in the `antrea-config` ConfigMap.
 Additionally, to ensure proper functionality, TX checksum offloading must be disabled for container network interfaces
-and the host gateway interface (default: antrea-gw0) due to the constraint of the application detection engine. Ths can
+and the host gateway interface (default: antrea-gw0) due to the constraint of the application detection engine. This can
 be configured using the `disableTXChecksumOffload` option in antrea-agent.conf. Disabling TX checksum offloading ensures
 that TCP connections traverse these interfaces correctly, preventing connection failures and packet loss.
 

--- a/docs/contributors/cherry-picks.md
+++ b/docs/contributors/cherry-picks.md
@@ -47,7 +47,7 @@ policy](../versioning.md#minor-releases-and-patch-releases).
   why we ask contributors to backport their own bug fixes, as their
   participation is critical in case of such a conflict.
 
-The script will create a PR on Github for you, which will automatically be
+The script will create a PR on GitHub for you, which will automatically be
 labelled with `kind/cherry-pick`. This PR will go through the normal testing
 process, although it should be very quick given that the original PR was already
 approved and merged into the main branch. The PR should also go through normal

--- a/docs/contributors/github-labels.md
+++ b/docs/contributors/github-labels.md
@@ -31,7 +31,7 @@ The labels in this list originated within Kubernetes at
 | area/flow-visibility               | Issues or PRs related to flow visibility support in Antrea | Any |
 | area/flow-visibility/aggregation   | Issues or PRs related to flow aggregation | Any |
 | area/flow-visibility/export        | Issues or PRs related to the Flow Exporter functions in the Agent | Any |
-| area/github-membership             | Categorizes an issue as a membership request to join the antrea-io Github organization | Any |
+| area/github-membership             | Categorizes an issue as a membership request to join the antrea-io GitHub organization | Any |
 | area/grouping                      | Issues or PRs related to ClusterGroup, Group API | Any |
 | area/ipam                          | Issues or PRs related to IP address management (IPAM) | Any |
 | area/interface                     | Issues or PRs related to network interfaces | Any |

--- a/docs/cookbooks/fluentd/README.md
+++ b/docs/cookbooks/fluentd/README.md
@@ -121,7 +121,7 @@ code to `./resources/kubernetes.conf`, then update ConfigMap in
   count_interval 3  # The time window for counting errors (in secs)
   input_key code    # The field to apply the regular expression
   regexp ^5\d\d$    # The regular expression to be applied
-  threshold 1       # The minimum number of erros to trigger an alert
+  threshold 1       # The minimum number of errors to trigger an alert
   add_tag_prefix error_ANPxx  # Generate tags like "error_ANPxx.antrea-networkpolicy"
 </match>
 

--- a/docs/design/traffic-acceleration.md
+++ b/docs/design/traffic-acceleration.md
@@ -17,7 +17,7 @@
 
 Antrea introduces nftables flowtable to accelerate traffic that is forwarded through the Node's host network when the
 traffic mode is noEncap or hybrid. By offloading eligible connections into the nftables flowtable at the ingress hook,
-packets can be fast-tracked through the Node's host networking stack. Once offloaded, theses packets bypass most kernel
+packets can be fast-tracked through the Node's host networking stack. Once offloaded, these packets bypass most kernel
 networking processing, reducing overhead and significantly improving forwarding performance.
 
 ## Prerequisites

--- a/docs/maintainers/release.md
+++ b/docs/maintainers/release.md
@@ -24,7 +24,7 @@ release. We use `<TAG>` as a placeholder for the release tag (e.g. `v1.4.0`).
      will look for this commit and cherry-pick it to update the main branch
      (starting with Antrea v1.0). The
      [prepare-changelog.sh](../../hack/release/prepare-changelog.sh) script may
-     be used to easily generate links to PRs and the Github profiles of PR
+     be used to easily generate links to PRs and the GitHub profiles of PR
      authors. Use `prepare-changelog.sh -h` to get the usage.
    - a commit to update [VERSION](../../VERSION) as needed, using the following
      commit message: `"Set VERSION to <TAG>"`. Before committing, ensure that
@@ -32,7 +32,7 @@ release. We use `<TAG>` as a placeholder for the release tag (e.g. `v1.4.0`).
 
 3. Run all the tests for the PR, investigating test failures and re-triggering
    the tests as needed.
-   - Github worfklows are run automatically whenever the head branch is updated.
+   - GitHub workflows are run automatically whenever the head branch is updated.
    - Jenkins tests need to be [triggered manually](../../CONTRIBUTING.md#getting-your-pr-verified-by-ci).
    - Cloud tests need to be triggered manually through the
      [Jenkins web UI](https://jenkins.antrea.io/). Admin access is
@@ -54,7 +54,7 @@ release. We use `<TAG>` as a placeholder for the release tag (e.g. `v1.4.0`).
      repository settings temporarily, and remember to disable it again right
      after you merge.
 
-5. Make the release on Github **with the release branch as the target** and copy
+5. Make the release on GitHub **with the release branch as the target** and copy
    the relevant section of the CHANGELOG as the release description (make sure
    all the markdown links work). The
    [draft-release.sh](../../hack/release/draft-release.sh) script can
@@ -62,13 +62,13 @@ release. We use `<TAG>` as a placeholder for the release tag (e.g. `v1.4.0`).
    usage. You typically should **not** be checking the `Set as a pre-release`
    box. This would only be necessary for a release candidate (e.g., `<TAG>` is
    `1.4.0-rc.1`), which we do not have at the moment. There is no need to upload
-   any assets as this will be done automatically by a Github workflow, after you
+   any assets as this will be done automatically by a GitHub workflow, after you
    create the release.
    - the `Set as the latest release` box is checked by default. **If you are
      creating a patch release for an older minor version of Antrea, you should
      uncheck the box.**
 
-6. After a while (time for the relevant Github workflows to complete), check that:
+6. After a while (time for the relevant GitHub workflows to complete), check that:
    - the Docker image has been pushed to
      [dockerhub](https://hub.docker.com/u/antrea) with the correct tag.
    - the assets have been uploaded to the release (`antctl` binaries and yaml
@@ -76,7 +76,7 @@ release. We use `<TAG>` as a placeholder for the release tag (e.g. `v1.4.0`).
      particular, the following link should work:
      `https://github.com/antrea-io/antrea/releases/download/<TAG>/antrea.yml`.
 
-7. After the appropriate Github workflow completes, a bot will automatically
+7. After the appropriate GitHub workflow completes, a bot will automatically
    submit a PR to update the CHANGELOG in the main branch. You should verify the
    contents of the PR and merge it (no need to run the tests, use admin
    privileges).

--- a/docs/multicluster/quick-start.md
+++ b/docs/multicluster/quick-start.md
@@ -74,7 +74,7 @@ installation of `antctl`, please refer to the [installation guide](../antctl.md#
 Run the following commands to deploy Multi-cluster Controller for the leader
 into Namespace `antrea-multicluster` (Namespace `antrea-multicluster` will be
 created by the commands), and Multi-cluster Controller for the member into
-Namepsace `kube-system`.
+Namespace `kube-system`.
 
 ```bash
 kubectl create ns antrea-multicluster
@@ -213,7 +213,7 @@ antctl mc join --clusterid test-cluster-member2 -n kube-system --config-file joi
 Run the following commands to deploy Multi-cluster Controller for the leader
 into Namespace `antrea-multicluster` (Namespace `antrea-multicluster` will be
 created by the commands), and Multi-cluster Controller for the member into
-Namepsace `kube-system`.
+Namespace `kube-system`.
 
 ```bash
 kubectl apply -f https://github.com/antrea-io/antrea/releases/download/$TAG/antrea-multicluster-leader-global.yml

--- a/docs/multicluster/upgrade.md
+++ b/docs/multicluster/upgrade.md
@@ -2,7 +2,7 @@
 
 The Antrea Multi-cluster feature is introduced from v1.5.0. There is no data-plane
 related changes from release v1.5.0, so Antrea deployment and Antrea Multi-cluster
-deployment are indenpendent. However, we suggest to keep Antrea and Antrea Multi-cluster
+deployment are independent. However, we suggest to keep Antrea and Antrea Multi-cluster
 in the same version considering there will be data-plane change involved in the future.
 Please refer to [Antrea upgrade and supported version skew](../versioning.md#antrea-upgrade-and-supported-version-skew)
 to learn the requirement of Antrea upgrade. This doc focuses on Multi-cluster deployment only.

--- a/docs/multicluster/user-guide.md
+++ b/docs/multicluster/user-guide.md
@@ -377,7 +377,7 @@ there are several possibilities:
 * By default, the K8s Node's `InternalIP` is used as `gatewayIP` too.
 * You can choose to use the K8s Node's `ExternalIP` as `gatewayIP`, by changing
 the configuration option `gatewayIPPrecedence` to value: `external`, when
-deploying the member Multi-cluster Controller. The configration option is
+deploying the member Multi-cluster Controller. The configuration option is
 defined in ConfigMap `antrea-mc-controller-config` in `antrea-multicluster-member.yml`.
 * When the Gateway Node has a separate IP for external communication or is
 associated with a public IP (e.g. an Elastic IP on AWS), but the IP is not added
@@ -510,7 +510,7 @@ requests may be routed to other clusters, and the endpoints from the local
 cluster do not take precedence. A Service cannot have conflicted definitions in
 different export clusters, otherwise only the first export will be replicated to
 other clusters; other exports as well as new updates to the Service will be
-ingored, until user fixes the conflicts. For example, after a member cluster
+ignored, until user fixes the conflicts. For example, after a member cluster
 exported a Service: `default/nginx` with TCP Port `80`, other clusters can only
 export the same Service with the same Ports definition including Port names. At
 the moment, Antrea Multi-cluster supports only IPv4 multi-cluster Services.

--- a/docs/securing-control-plane.md
+++ b/docs/securing-control-plane.md
@@ -51,7 +51,7 @@ you must set the `selfSignedCert` field of `antrea-controller.conf` to `false`,
 so that the antrea-controller will read the certificate key pair from the
 `antrea-controller-tls` Secret. The example manifests and descriptions below
 assume Antrea is deployed in the `kube-system` Namespace. If you deploy Antrea
-in a different Namepace, please update the Namespace name in the manifests
+in a different Namespace, please update the Namespace name in the manifests
 accordingly.
 
 ```yaml


### PR DESCRIPTION
Fix spelling mistakes, also add .cursor/ to .gitignore so that Cursor IDE project files are not tracked.