### PR TITLE
fix premature loop exit in RunPeriodicDeletion method

### DIFF
--- a/pkg/agent/flowexporter/connections/deny_connections.go
+++ b/pkg/agent/flowexporter/connections/deny_connections.go
@@ -57,7 +57,7 @@ func (ds *DenyConnectionStore) RunPeriodicDeletion(stopCh <-chan struct{}) {
 	for {
 		select {
 		case <-stopCh:
-			break
+			return
 		case <-pollTicker.C:
 			deleteIfStaleConn := func(key connection.ConnectionKey, conn *connection.Connection) error {
 				if conn.ReadyToDelete || time.Since(conn.LastExportTime) >= ds.staleConnectionTimeout {


### PR DESCRIPTION
fixes #7841 

small change to the `RunPeriodicDeletion` method in `deny_connections.go` to improve the control flow. The change replaces a `break` statement with a `return` statement, ensuring the function exits cleanly when the `stopCh` channel is signaled.