### PR TITLE
Fix ExternalTrafficPolicy=Local for ServiceExternalIP with IPv6 services

### DIFF
--- a/pkg/agent/controller/serviceexternalip/controller.go
+++ b/pkg/agent/controller/serviceexternalip/controller.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
+	utilnet "k8s.io/utils/net"
 
 	"antrea.io/antrea/pkg/agent/apis"
 	"antrea.io/antrea/pkg/agent/ipassigner"
@@ -432,7 +433,8 @@ func (c *ServiceExternalIPController) unassignIP(ip string, service apimachinery
 	return nil
 }
 
-// nodesHasHealthyServiceEndpoint returns the set of Nodes which has at least one healthy endpoint.
+// nodesHasHealthyServiceEndpoint returns the set of Nodes which has at least one healthy endpoint
+// for the address family matching the service's external IP.
 func (c *ServiceExternalIPController) nodesHasHealthyServiceEndpoint(service *corev1.Service) (sets.Set[string], error) {
 	nodes := sets.New[string]()
 	// List all EndpointSlices for this service using the label selector
@@ -443,7 +445,17 @@ func (c *ServiceExternalIPController) nodesHasHealthyServiceEndpoint(service *co
 	if err != nil {
 		return nodes, err
 	}
+	// Determine the address type matching the service's external IP, so that on dual-stack clusters
+	// we only consider EndpointSlices of the correct address family.
+	externalIP := c.getServiceExternalIP(service)
+	wantAddressType := discoveryv1.AddressTypeIPv4
+	if utilnet.IsIPv6String(externalIP) {
+		wantAddressType = discoveryv1.AddressTypeIPv6
+	}
 	for _, endpointSlice := range endpointSlices {
+		if endpointSlice.AddressType != wantAddressType {
+			continue
+		}
 		for _, ep := range endpointSlice.Endpoints {
 			if ep.NodeName == nil {
 				continue

--- a/pkg/agent/controller/serviceexternalip/controller_test.go
+++ b/pkg/agent/controller/serviceexternalip/controller_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/util/workqueue"
+	utilnet "k8s.io/utils/net"
 	"k8s.io/utils/ptr"
 
 	"antrea.io/antrea/pkg/agent/apis"
@@ -39,16 +40,18 @@ import (
 )
 
 const (
-	fakeNode1              = "node1"
-	fakeNode2              = "node2"
-	fakeExternalIPPoolName = "pool1"
-	fakeServiceExternalIP1 = "1.2.3.4"
-	fakeServiceExternalIP2 = "1.2.3.5"
+	fakeNode1               = "node1"
+	fakeNode2               = "node2"
+	fakeExternalIPPoolName  = "pool1"
+	fakeServiceExternalIP1  = "1.2.3.4"
+	fakeServiceExternalIP2  = "1.2.3.5"
+	fakeServiceExternalIPv6 = "2021:1::aa01"
 )
 
 var (
-	servicePolicyCluster = makeService("svc1", "ns1", corev1.ServiceTypeLoadBalancer, corev1.ServiceExternalTrafficPolicyCluster, fakeExternalIPPoolName, fakeServiceExternalIP1)
-	servicePolicyLocal   = makeService("svc2", "ns1", corev1.ServiceTypeLoadBalancer, corev1.ServiceExternalTrafficPolicyLocal, fakeExternalIPPoolName, fakeServiceExternalIP1)
+	servicePolicyCluster   = makeService("svc1", "ns1", corev1.ServiceTypeLoadBalancer, corev1.ServiceExternalTrafficPolicyCluster, fakeExternalIPPoolName, fakeServiceExternalIP1)
+	servicePolicyLocal     = makeService("svc2", "ns1", corev1.ServiceTypeLoadBalancer, corev1.ServiceExternalTrafficPolicyLocal, fakeExternalIPPoolName, fakeServiceExternalIP1)
+	servicePolicyLocalIPv6 = makeService("svc3", "ns1", corev1.ServiceTypeLoadBalancer, corev1.ServiceExternalTrafficPolicyLocal, fakeExternalIPPoolName, fakeServiceExternalIPv6)
 )
 
 type fakeMemberlistCluster struct {
@@ -182,7 +185,30 @@ func makeService(name, namespace string, serviceType corev1.ServiceType,
 }
 
 func makeEndpointSlice(name, namespace string, addresses, notReadyAddresses map[string]string) *discoveryv1.EndpointSlice {
+	return makeEndpointSliceWithSuffix(name, namespace, "slice", addresses, notReadyAddresses)
+}
+
+func makeEndpointSliceWithSuffix(name, namespace, suffix string, addresses, notReadyAddresses map[string]string) *discoveryv1.EndpointSlice {
 	var readyEndpoints, notReadyEndpoints []discoveryv1.Endpoint
+	// Derive AddressType from the first address found in either map, defaulting to IPv4.
+	addressType := discoveryv1.AddressTypeIPv4
+	for ip := range addresses {
+		if utilnet.IsIPv6String(ip) {
+			addressType = discoveryv1.AddressTypeIPv6
+			break
+		}
+	}
+
+	// Only check notReadyAddresses if we haven't already detected an IPv6 address.
+	if addressType == discoveryv1.AddressTypeIPv4 {
+		for ip := range notReadyAddresses {
+			if utilnet.IsIPv6String(ip) {
+				addressType = discoveryv1.AddressTypeIPv6
+				break
+			}
+		}
+	}
+
 	for ip, nodeName := range addresses {
 		readyEndpoints = append(readyEndpoints, discoveryv1.Endpoint{
 			Addresses: []string{ip},
@@ -204,18 +230,17 @@ func makeEndpointSlice(name, namespace string, addresses, notReadyAddresses map[
 		})
 	}
 	allEndpoints := append(readyEndpoints, notReadyEndpoints...)
-	endpointSlice := &discoveryv1.EndpointSlice{
+	return &discoveryv1.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-%s", name, "slice"),
+			Name:      fmt.Sprintf("%s-%s", name, suffix),
 			Namespace: namespace,
 			Labels: map[string]string{
 				discoveryv1.LabelServiceName: name,
 			},
 		},
-		AddressType: discoveryv1.AddressTypeIPv4,
+		AddressType: addressType,
 		Endpoints:   allEndpoints,
 	}
-	return endpointSlice
 }
 
 func TestCreateService(t *testing.T) {
@@ -685,6 +710,40 @@ func TestServiceExternalIPController_nodesHasHealthyServiceEndpoint(t *testing.T
 			},
 			serviceToTest:        servicePolicyLocal.DeepCopy(),
 			expectedHealthyNodes: sets.New(fakeNode1, fakeNode2),
+		},
+		{
+			name: "IPv6 service only considers IPv6 EndpointSlices",
+			endpointSlices: []*discoveryv1.EndpointSlice{
+				makeEndpointSliceWithSuffix(servicePolicyLocalIPv6.Name, servicePolicyLocalIPv6.Namespace, "slice-ipv6",
+					map[string]string{
+						"2021:1::1": fakeNode1,
+					},
+					nil),
+				makeEndpointSliceWithSuffix(servicePolicyLocalIPv6.Name, servicePolicyLocalIPv6.Namespace, "slice-ipv4",
+					map[string]string{
+						"2.3.4.5": fakeNode2,
+					},
+					nil),
+			},
+			serviceToTest:        servicePolicyLocalIPv6.DeepCopy(),
+			expectedHealthyNodes: sets.New(fakeNode1),
+		},
+		{
+			name: "IPv6 EndpointSlice is ignored for IPv4 service",
+			endpointSlices: []*discoveryv1.EndpointSlice{
+				makeEndpointSliceWithSuffix(servicePolicyLocal.Name, servicePolicyLocal.Namespace, "slice-ipv6",
+					map[string]string{
+						"2021:1::1": fakeNode1,
+					},
+					nil),
+				makeEndpointSliceWithSuffix(servicePolicyLocal.Name, servicePolicyLocal.Namespace, "slice-ipv4",
+					map[string]string{
+						"2.3.4.5": fakeNode2,
+					},
+					nil),
+			},
+			serviceToTest:        servicePolicyLocal.DeepCopy(),
+			expectedHealthyNodes: sets.New(fakeNode2),
 		},
 	}
 	for _, tt := range tests {

--- a/test/e2e/service_externalip_test.go
+++ b/test/e2e/service_externalip_test.go
@@ -300,7 +300,11 @@ func testServiceExternalTrafficPolicyLocal(t *testing.T, data *TestData) {
 			require.NoError(t, err)
 			defer data.clientset.CoreV1().Services(service.Namespace).Delete(context.TODO(), service.Name, metav1.DeleteOptions{})
 
-			eps = createEndpointSlice(service.Name, service.Namespace, tt.originalEndpoints)
+			epsAddrType := discoveryv1.AddressTypeIPv4
+			if utilnet.IsIPv6String(tt.expectedExternalIP) {
+				epsAddrType = discoveryv1.AddressTypeIPv6
+			}
+			eps = createEndpointSlice(service.Name, service.Namespace, epsAddrType, tt.originalEndpoints)
 			eps, err = data.clientset.DiscoveryV1().EndpointSlices(eps.Namespace).Create(context.TODO(), eps, metav1.CreateOptions{})
 			require.NoError(t, err)
 			defer data.clientset.DiscoveryV1().EndpointSlices(eps.Namespace).Delete(context.TODO(), eps.Name, metav1.DeleteOptions{})
@@ -322,19 +326,9 @@ func testServiceExternalTrafficPolicyLocal(t *testing.T, data *TestData) {
 }
 
 // createEndpointSlice creates an EndpointSlice for the given service with the specified endpoints.
-func createEndpointSlice(serviceName, namespace string, endpoints []discoveryv1.Endpoint) *discoveryv1.EndpointSlice {
-	var addressType discoveryv1.AddressType
-	// Determine address type from first endpoint
-	if len(endpoints) > 0 && len(endpoints[0].Addresses) > 0 {
-		if utilnet.IsIPv6String(endpoints[0].Addresses[0]) {
-			addressType = discoveryv1.AddressTypeIPv6
-		} else {
-			addressType = discoveryv1.AddressTypeIPv4
-		}
-	} else {
-		// Default to IPv4 if no endpoints
-		addressType = discoveryv1.AddressTypeIPv4
-	}
+// The addressType parameter determines the address family of the EndpointSlice, which is immutable
+// after creation. It must be set correctly even when the initial endpoints slice is empty.
+func createEndpointSlice(serviceName, namespace string, addressType discoveryv1.AddressType, endpoints []discoveryv1.Endpoint) *discoveryv1.EndpointSlice {
 	return &discoveryv1.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-%s", serviceName, "slice"),
@@ -917,7 +911,7 @@ func (data *TestData) waitForServiceConfigured(service *v1.Service, expectedExte
 		return true, nil
 	})
 	if err != nil {
-		return service, assignedNode, fmt.Errorf("wait for Service %q configured failed: %v. Expected external IP %s on Node %s, actual status %#v, assigned Node: %s"+
+		return service, assignedNode, fmt.Errorf("wait for Service %q configured failed: %v. Expected external IP %s on Node %s, actual status %#v, assigned Node: %s",
 			service.Name, err, expectedExternalIP, expectedNodeName, service.Status, assignedNode)
 	}
 	return service, assignedNode, nil


### PR DESCRIPTION
Fix ExternalTrafficPolicy=Local for ServiceExternalIP with IPv6 services
    was rejected by the API server, so the controller never saw a
    healthy endpoint on the expected node and waitForServiceConfigured
    timed out.

2. nodesHasHealthyServiceEndpoint in the agent controller listed all
    EndpointSlices for a service regardless of address family. On a
    dual-stack cluster, Kubernetes creates separate IPv4 and IPv6
    EndpointSlices per service, so without filtering by address type
    the controller could use IPv4 endpoints to select a node for an
    IPv6 external IP (or vice versa), resulting in incorrect node
    assignment.

Fix (1) by making createEndpointSlice accept an explicit addressType
parameter and deriving it from the service's expected external IP at
the call site.

Fix (2) by determining the required AddressType from the service's
external IP before iterating EndpointSlices and skipping those that
don't match.

Also fix a format-string bug in waitForServiceConfigured where a '+'
concatenation was used instead of ',', causing service.Name to be
appended to the format string instead of being passed as an argument.

Unit tests are updated to derive AddressType from endpoint addresses
in makeEndpointSlice, and two new test cases are added to
TestServiceExternalIPController_nodesHasHealthyServiceEndpoint to
cover the dual-stack address family filtering.

Signed-off-by: Lan Luo <lan.luo@broadcom.com>
Made-with: Cursor