### PR TITLE
Only install Service external IPs NOTRACK rules on kube-proxy presence

### DIFF
--- a/pkg/agent/route/route_linux.go
+++ b/pkg/agent/route/route_linux.go
@@ -25,6 +25,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/containernetworking/plugins/pkg/ip"
@@ -36,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/exec"
 	utilnet "k8s.io/utils/net"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/knftables"
@@ -177,6 +179,8 @@ func newIPTablesCache() *iptablesCache {
 	return cache
 }
 
+var defaultExecutor = exec.New()
+
 // Client takes care of routing container packets in host network, coordinating ip route, ip rule, iptables and ipset.
 type Client struct {
 	nodeConfig             *config.NodeConfig
@@ -254,6 +258,12 @@ type Client struct {
 	wireguardPort int32
 	// proxyHealthCheckPort is the port on which AntreaProxy health check server listens when proxyAll is enabled.
 	proxyHealthCheckPort int32
+	// executor is used to execute commands.
+	executor exec.Interface
+	// kubeProxyExist should be set to true when kube-proxy is present (or detection failed). It is updated by kubeProxyDetect.
+	// and read by syncIPTables and syncNFTables to decide whether to install the rules to bypass kube-proxy process
+	// for Service external IPs.
+	kubeProxyExist atomic.Bool
 }
 
 // NewClient returns a route client.
@@ -288,6 +298,7 @@ func NewClient(networkConfig *config.NetworkConfig,
 		serviceExternalIPReferences: make(map[string]sets.Set[string]),
 		wireguardPort:               wireguardPort,
 		proxyHealthCheckPort:        proxyHealthCheckPort,
+		executor:                    defaultExecutor,
 	}, nil
 }
 
@@ -318,6 +329,8 @@ func (c *Client) Initialize(nodeConfig *config.NodeConfig, done func()) error {
 				antreaExternalIPIP6Set: {},
 			}
 		}
+		// Assume kube-proxy is present until detection runs.
+		c.kubeProxyExist.Store(true)
 	}
 
 	c.iptablesInitialized = make(chan struct{})
@@ -334,6 +347,12 @@ func (c *Client) Initialize(nodeConfig *config.NodeConfig, done func()) error {
 	c.iptablesHasRandomFully = c.iptables.HasRandomFully()
 	if (c.nodeSNATRandomFully || c.egressSNATRandomFully) && !c.iptablesHasRandomFully {
 		return fmt.Errorf("iptables does not support --random-fully for SNAT / MASQUERADE rules")
+	}
+
+	// Perform an initial kube-proxy detection after iptables client is ready so the first iptables/nftables sync can
+	// use an accurate kubeProxyExist value.
+	if c.proxyAll {
+		c.kubeProxyDetect()
 	}
 
 	c.iptablesCache = newIPTablesCache()
@@ -453,6 +472,9 @@ func (c *Client) syncNetworkConfig(ctx context.Context) {
 	if err := c.syncIPSet(); err != nil {
 		klog.ErrorS(err, "Failed to sync ipset")
 		return
+	}
+	if c.proxyAll {
+		c.kubeProxyDetect()
 	}
 	if err := c.syncIPTables(false); err != nil {
 		klog.ErrorS(err, "Failed to sync iptables")
@@ -941,6 +963,74 @@ func (j *jumpRule) getKey() jumpRuleKey {
 	}
 }
 
+// kubeProxyDetect updates c.kubeProxyExist by detecting whether kube-proxy rules exist.
+// It checks the existence of kube-proxy nftables tables first, then iptables table nat chains PREROUTING and OUTPUT
+// jump rules targeting KUBE-SERVICES. If any check fails, we assume that kube-proxy is present and set kubeProxyExist
+// to true. Only when all checks succeed and no rules are found we set kubeProxyExist to false.
+func (c *Client) kubeProxyDetect() {
+	var errors []error
+
+	kubeProxyTables := []string{
+		"ip kube-proxy",
+		"ip6 kube-proxy",
+	}
+
+	output, err := c.executor.Command("nft", "list", "tables").CombinedOutput()
+	if err != nil {
+		errors = append(errors, fmt.Errorf("failed to run 'nft list tables': %w, output: %s", err, strings.TrimSpace(string(output))))
+	} else {
+		for _, table := range kubeProxyTables {
+			if strings.Contains(string(output), table) {
+				c.kubeProxyExist.Store(true)
+				klog.V(5).InfoS("Detected kube-proxy via nftables table existence", "table", table)
+				return
+			}
+		}
+	}
+
+	kubeProxyJumpRuleKeyword := fmt.Sprintf("-j %s", kubeProxyServiceChain)
+	ipProtocol := c.getIPProtocol()
+	checkChain := func(table, chain string) (found bool, err error) {
+		allRules, err := c.iptables.ListRules(ipProtocol, table, chain)
+		if err != nil {
+			return false, fmt.Errorf("failed to list iptables table %s chain %s rules: %w", table, chain, err)
+		}
+		for _, rules := range allRules {
+			for _, rule := range rules {
+				if strings.Contains(rule, kubeProxyJumpRuleKeyword) {
+					return true, nil
+				}
+			}
+		}
+		return false, nil
+	}
+
+	if found, err := checkChain(iptables.NATTable, iptables.PreRoutingChain); err != nil {
+		errors = append(errors, err)
+	} else if found {
+		c.kubeProxyExist.Store(true)
+		klog.V(5).InfoS("Detected kube-proxy via iptables rule", "table", iptables.NATTable, "chain", iptables.PreRoutingChain)
+		return
+	}
+
+	if found, err := checkChain(iptables.NATTable, iptables.OutputChain); err != nil {
+		errors = append(errors, err)
+	} else if found {
+		c.kubeProxyExist.Store(true)
+		klog.V(5).InfoS("Detected kube-proxy via iptables rule", "table", iptables.NATTable, "chain", iptables.OutputChain)
+		return
+	}
+
+	// If any check failed, assume kube-proxy is present.
+	if len(errors) > 0 {
+		c.kubeProxyExist.Store(true)
+		klog.V(5).InfoS("Got errors when detecting kube-proxy, assume kube-proxy is present", "errors", errors)
+	} else {
+		c.kubeProxyExist.Store(false)
+		klog.V(5).InfoS("Detected no rules related to kube-proxy, assume kube-proxy is not present")
+	}
+}
+
 func (c *Client) removeUnexpectedAntreaJumpRule(protocol iptables.Protocol, jumpRule jumpRule) error {
 	// List all the existing rules of the table and the chain where the Antrea jump rule will be added.
 	allExistingRules, err := c.iptables.ListRules(protocol, jumpRule.table, jumpRule.srcChain)
@@ -1224,7 +1314,7 @@ func (c *Client) restoreIptablesData(podCIDR *net.IPNet,
 		}
 	}
 
-	if c.proxyAll && !c.hostNetworkNFTables {
+	if c.proxyAll && !c.hostNetworkNFTables && c.kubeProxyExist.Load() {
 		// This rule is to bypass conntrack for packets sourced from external and destined to externalIPs, which also
 		// results in bypassing the chains managed by Antrea Proxy and kube-proxy in nat table.
 		writeLine(iptablesData, []string{
@@ -3031,33 +3121,36 @@ func (c *Client) nftablesProxyAll(tx *knftables.Transaction, ipProtocol knftable
 		})
 	}
 
-	tx.Add(&knftables.Rule{
-		Chain: antreaNFTablesRawChainPreroutingProxyAll,
-		Rule: knftables.Concat(
-			ip, "daddr", "@", externalIPSet,
-			"counter",
-			"notrack",
-		),
-		Comment: ptr.To("Do not track request packets destined to external IPs"),
-	})
-	tx.Add(&knftables.Rule{
-		Chain: antreaNFTablesRawChainPreroutingProxyAll,
-		Rule: knftables.Concat(
-			ip, "saddr", "@", externalIPSet,
-			"counter",
-			"notrack",
-		),
-		Comment: ptr.To("Do not track reply packets sourced from external IPs"),
-	})
-	tx.Add(&knftables.Rule{
-		Chain: antreaNFTablesRawChainOutputProxyAll,
-		Rule: knftables.Concat(
-			ip, "daddr", "@", externalIPSet,
-			"counter",
-			"notrack",
-		),
-		Comment: ptr.To("Do not track request packets destined to external IPs"),
-	})
+	// When kube-proxy is present, add NOTRACK rules matching Service external IPs to bypass kube-proxy process.
+	if c.kubeProxyExist.Load() {
+		tx.Add(&knftables.Rule{
+			Chain: antreaNFTablesRawChainPreroutingProxyAll,
+			Rule: knftables.Concat(
+				ip, "daddr", "@", externalIPSet,
+				"counter",
+				"notrack",
+			),
+			Comment: ptr.To("Do not track request packets destined to external IPs"),
+		})
+		tx.Add(&knftables.Rule{
+			Chain: antreaNFTablesRawChainPreroutingProxyAll,
+			Rule: knftables.Concat(
+				ip, "saddr", "@", externalIPSet,
+				"counter",
+				"notrack",
+			),
+			Comment: ptr.To("Do not track reply packets sourced from external IPs"),
+		})
+		tx.Add(&knftables.Rule{
+			Chain: antreaNFTablesRawChainOutputProxyAll,
+			Rule: knftables.Concat(
+				ip, "daddr", "@", externalIPSet,
+				"counter",
+				"notrack",
+			),
+			Comment: ptr.To("Do not track request packets destined to external IPs"),
+		})
+	}
 
 	tx.Add(&knftables.Rule{
 		Chain: antreaNFTablesNatChainPreroutingProxyAll,

--- a/pkg/agent/route/route_linux_test.go
+++ b/pkg/agent/route/route_linux_test.go
@@ -28,6 +28,8 @@ import (
 	"go.uber.org/mock/gomock"
 	"golang.org/x/sys/unix"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/exec"
+	exectesting "k8s.io/utils/exec/testing"
 	utilnet "k8s.io/utils/net"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/knftables"
@@ -405,7 +407,7 @@ func TestSyncIPTables(t *testing.T) {
 		expectedCalls             func(iptables *iptablestest.MockInterfaceMockRecorder)
 	}{
 		{
-			name:                      "encap,wireguard,egress=true,multicastEnabled=true,proxyAll=true,nodeNetworkPolicy=true,nodeLatencyMonitor=true,nodeSNATRandomFully=true,proxyHealthCheck",
+			name:                      "encap,wireguard,egress=true,multicastEnabled=true,proxyAll=true,nodeNetworkPolicy=true,nodeLatencyMonitor=true,nodeSNATRandomFully=true,proxyHealthCheck,kube-proxy present",
 			proxyAll:                  true,
 			multicastEnabled:          true,
 			nodeNetworkPolicyEnabled:  true,
@@ -454,7 +456,7 @@ func TestSyncIPTables(t *testing.T) {
 							"-A " + iptables.PreRoutingChain + " -j " + antreaPreRoutingChain,
 							"-A " + iptables.PreRoutingChain + " -j " + kubeProxyServiceChain,
 						},
-					}, nil)
+					}, nil).Times(2)
 				mockIPTables.DeleteRule(iptables.ProtocolIPv4, iptables.NATTable, iptables.PreRoutingChain, []string{"-j", antreaPreRoutingChain, "-m", "comment", "--comment", "Antrea: jump to Antrea prerouting rules"})
 				mockIPTables.ListRules(iptables.ProtocolDual, iptables.NATTable, iptables.OutputChain).Return(
 					map[iptables.Protocol][]string{
@@ -732,7 +734,7 @@ COMMIT
 			},
 		},
 		{
-			name:                      "hybrid,egress=true,multicastEnabled=true,proxyAll=true,nodeNetworkPolicy=true,nodeLatencyMonitor=true,nodeSNATRandomFully=true",
+			name:                      "hybrid,egress=true,multicastEnabled=true,proxyAll=true,nodeNetworkPolicy=true,nodeLatencyMonitor=true,nodeSNATRandomFully=true,kube-proxy not present",
 			proxyAll:                  true,
 			multicastEnabled:          true,
 			nodeNetworkPolicyEnabled:  true,
@@ -774,27 +776,21 @@ COMMIT
 				mockIPTables.ListRules(iptables.ProtocolDual, iptables.NATTable, iptables.PreRoutingChain).Return(
 					map[iptables.Protocol][]string{
 						iptables.ProtocolIPv4: {
-							"-A " + iptables.PreRoutingChain + " -j " + kubeProxyServiceChain,
 							"-A " + iptables.PreRoutingChain + " -j " + antreaPreRoutingChain,
 						},
 						iptables.ProtocolIPv6: {
 							"-A " + iptables.PreRoutingChain + " -j " + antreaPreRoutingChain,
-							"-A " + iptables.PreRoutingChain + " -j " + kubeProxyServiceChain,
 						},
-					}, nil)
-				mockIPTables.DeleteRule(iptables.ProtocolIPv4, iptables.NATTable, iptables.PreRoutingChain, []string{"-j", antreaPreRoutingChain, "-m", "comment", "--comment", "Antrea: jump to Antrea prerouting rules"})
+					}, nil).Times(2)
 				mockIPTables.ListRules(iptables.ProtocolDual, iptables.NATTable, iptables.OutputChain).Return(
 					map[iptables.Protocol][]string{
 						iptables.ProtocolIPv4: {
 							"-A " + iptables.OutputChain + " -j " + antreaOutputChain,
-							"-A " + iptables.OutputChain + " -j " + kubeProxyServiceChain,
 						},
 						iptables.ProtocolIPv6: {
-							"-A " + iptables.OutputChain + " -j " + kubeProxyServiceChain,
 							"-A " + iptables.OutputChain + " -j " + antreaOutputChain,
 						},
-					}, nil)
-				mockIPTables.DeleteRule(iptables.ProtocolIPv6, iptables.NATTable, iptables.OutputChain, []string{"-j", antreaOutputChain, "-m", "comment", "--comment", "Antrea: jump to Antrea output rules"})
+					}, nil).Times(2)
 				mockIPTables.EnsureChain(iptables.ProtocolDual, iptables.NATTable, antreaPreRoutingChain)
 				mockIPTables.InsertRule(iptables.ProtocolDual, iptables.NATTable, iptables.PreRoutingChain, []string{"-j", antreaPreRoutingChain, "-m", "comment", "--comment", "Antrea: jump to Antrea prerouting rules"})
 				mockIPTables.EnsureChain(iptables.ProtocolDual, iptables.NATTable, antreaOutputChain)
@@ -809,9 +805,6 @@ COMMIT
 -A ANTREA-PREROUTING -m comment --comment "Antrea: do not track incoming encapsulation packets" -m udp -p udp --dport 6082 -m addrtype --dst-type LOCAL -j NOTRACK
 -A ANTREA-OUTPUT -m comment --comment "Antrea: do not track outgoing encapsulation packets" -m udp -p udp --dport 6082 -m addrtype --src-type LOCAL -j NOTRACK
 -A ANTREA-PREROUTING -m comment --comment "Antrea: drop Pod multicast traffic forwarded via underlay network" -m set --match-set CLUSTER-NODE-IP src -d 224.0.0.0/4 -j DROP
--A ANTREA-PREROUTING -m comment --comment "Antrea: do not track request packets destined to external IPs" -m set --match-set ANTREA-EXTERNAL-IP dst -j NOTRACK
--A ANTREA-PREROUTING -m comment --comment "Antrea: do not track reply packets sourced from external IPs" -m set --match-set ANTREA-EXTERNAL-IP src -j NOTRACK
--A ANTREA-OUTPUT -m comment --comment "Antrea: do not track request packets destined to external IPs" -m set --match-set ANTREA-EXTERNAL-IP dst -j NOTRACK
 COMMIT
 *mangle
 :ANTREA-PREROUTING - [0:0]
@@ -865,9 +858,6 @@ COMMIT
 :ANTREA-OUTPUT - [0:0]
 -A ANTREA-PREROUTING -m comment --comment "Antrea: do not track incoming encapsulation packets" -m udp -p udp --dport 6082 -m addrtype --dst-type LOCAL -j NOTRACK
 -A ANTREA-OUTPUT -m comment --comment "Antrea: do not track outgoing encapsulation packets" -m udp -p udp --dport 6082 -m addrtype --src-type LOCAL -j NOTRACK
--A ANTREA-PREROUTING -m comment --comment "Antrea: do not track request packets destined to external IPs" -m set --match-set ANTREA-EXTERNAL-IP6 dst -j NOTRACK
--A ANTREA-PREROUTING -m comment --comment "Antrea: do not track reply packets sourced from external IPs" -m set --match-set ANTREA-EXTERNAL-IP6 src -j NOTRACK
--A ANTREA-OUTPUT -m comment --comment "Antrea: do not track request packets destined to external IPs" -m set --match-set ANTREA-EXTERNAL-IP6 dst -j NOTRACK
 COMMIT
 *mangle
 :ANTREA-PREROUTING - [0:0]
@@ -1205,6 +1195,17 @@ COMMIT
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockIPTables := iptablestest.NewMockInterface(ctrl)
+			fakeExecutor := &exectesting.FakeExec{}
+			fakeExecutor.CommandScript = []exectesting.FakeCommandAction{
+				func(cmd string, args ...string) exec.Cmd {
+					return exectesting.InitFakeCmd(&exectesting.FakeCmd{
+						CombinedOutputScript: []exectesting.FakeAction{
+							func() ([]byte, []byte, error) { return []byte("table ip nat"), nil, nil },
+						},
+					}, cmd, args...)
+				},
+			}
+
 			c := &Client{iptables: mockIPTables,
 				networkConfig:            tt.networkConfig,
 				nodeConfig:               tt.nodeConfig,
@@ -1220,6 +1221,7 @@ COMMIT
 				wireguardPort:            tt.wireguardPort,
 				proxyHealthCheckPort:     tt.proxyHealthCheckPort,
 				iptablesCache:            newIPTablesCache(),
+				executor:                 fakeExecutor,
 			}
 			for mark, snatIP := range tt.markToSNATIP {
 				c.markToSNATIP.Store(mark, net.ParseIP(snatIP))
@@ -1241,7 +1243,157 @@ COMMIT
 				c.initProxyHealthCheck()
 			}
 			tt.expectedCalls(mockIPTables.EXPECT())
+			if c.proxyAll {
+				c.kubeProxyDetect()
+			}
 			assert.NoError(t, c.syncIPTables(true))
+		})
+	}
+}
+
+func TestKubeProxyDetect(t *testing.T) {
+	tests := []struct {
+		name          string
+		ipv4Enabled   bool
+		ipv6Enabled   bool
+		commandScript []exectesting.FakeCommandAction
+		expectedCalls func(*iptablestest.MockInterfaceMockRecorder)
+		expected      bool
+	}{
+		{
+			name:        "nftables ip kube-proxy table exists",
+			ipv4Enabled: true,
+			ipv6Enabled: false,
+			commandScript: []exectesting.FakeCommandAction{
+				func(cmd string, args ...string) exec.Cmd {
+					return exectesting.InitFakeCmd(&exectesting.FakeCmd{
+						CombinedOutputScript: []exectesting.FakeAction{
+							func() ([]byte, []byte, error) { return []byte("table ip kube-proxy"), nil, nil },
+						},
+					}, cmd, args...)
+				},
+			},
+			expectedCalls: func(*iptablestest.MockInterfaceMockRecorder) {},
+			expected:      true,
+		},
+		{
+			name:        "nftables ip6 kube-proxy table exists",
+			ipv4Enabled: false,
+			ipv6Enabled: true,
+			commandScript: []exectesting.FakeCommandAction{
+				func(cmd string, args ...string) exec.Cmd {
+					return exectesting.InitFakeCmd(&exectesting.FakeCmd{
+						CombinedOutputScript: []exectesting.FakeAction{
+							func() ([]byte, []byte, error) { return []byte("table ip6 kube-proxy"), nil, nil },
+						},
+					}, cmd, args...)
+				},
+			},
+			expectedCalls: func(*iptablestest.MockInterfaceMockRecorder) {},
+			expected:      true,
+		},
+
+		{
+			name:        "no nftables kube-proxy table exists, iptables PREROUTING has rule targeting KUBE-SERVICES",
+			ipv4Enabled: true,
+			ipv6Enabled: false,
+			commandScript: []exectesting.FakeCommandAction{
+				func(cmd string, args ...string) exec.Cmd {
+					return exectesting.InitFakeCmd(&exectesting.FakeCmd{
+						CombinedOutputScript: []exectesting.FakeAction{
+							func() ([]byte, []byte, error) { return []byte("table ip nat"), nil, nil },
+						},
+					}, cmd, args...)
+				},
+			},
+			expectedCalls: func(m *iptablestest.MockInterfaceMockRecorder) {
+				m.ListRules(iptables.ProtocolIPv4, iptables.NATTable, iptables.PreRoutingChain).
+					Return(map[iptables.Protocol][]string{iptables.ProtocolIPv4: {"-A PREROUTING -j KUBE-SERVICES"}}, nil)
+			},
+			expected: true,
+		},
+		{
+			name:        "no nftables kube-proxy table exists, ip6tables OUTPUT has rule targeting KUBE-SERVICES chain",
+			ipv4Enabled: false,
+			ipv6Enabled: true,
+			commandScript: []exectesting.FakeCommandAction{
+				func(cmd string, args ...string) exec.Cmd {
+					return exectesting.InitFakeCmd(&exectesting.FakeCmd{
+						CombinedOutputScript: []exectesting.FakeAction{
+							func() ([]byte, []byte, error) { return []byte("table ip nat"), nil, nil },
+						},
+					}, cmd, args...)
+				},
+			},
+			expectedCalls: func(m *iptablestest.MockInterfaceMockRecorder) {
+				m.ListRules(iptables.ProtocolIPv6, iptables.NATTable, iptables.PreRoutingChain).
+					Return(map[iptables.Protocol][]string{iptables.ProtocolIPv6: {"-A PREROUTING -j ANTREA-PREROUTING"}}, nil)
+				m.ListRules(iptables.ProtocolIPv6, iptables.NATTable, iptables.OutputChain).
+					Return(map[iptables.Protocol][]string{iptables.ProtocolIPv6: {"-A OUTPUT -j KUBE-SERVICES"}}, nil)
+			},
+			expected: true,
+		},
+		{
+			name:        "no kube-proxy rules found",
+			ipv4Enabled: true,
+			ipv6Enabled: false,
+			commandScript: []exectesting.FakeCommandAction{
+				func(cmd string, args ...string) exec.Cmd {
+					return exectesting.InitFakeCmd(&exectesting.FakeCmd{
+						CombinedOutputScript: []exectesting.FakeAction{
+							func() ([]byte, []byte, error) { return []byte("table ip nat"), nil, nil },
+						},
+					}, cmd, args...)
+				},
+			},
+			expectedCalls: func(m *iptablestest.MockInterfaceMockRecorder) {
+				m.ListRules(iptables.ProtocolIPv4, iptables.NATTable, iptables.PreRoutingChain).
+					Return(map[iptables.Protocol][]string{iptables.ProtocolIPv4: {"-A PREROUTING -j ANTREA-PREROUTING"}}, nil)
+				m.ListRules(iptables.ProtocolIPv4, iptables.NATTable, iptables.OutputChain).
+					Return(map[iptables.Protocol][]string{iptables.ProtocolIPv4: {"-A OUTPUT -j ANTREA-OUTPUT"}}, nil)
+			},
+			expected: false,
+		},
+		{
+			name:        "error detecting kube-proxy",
+			ipv4Enabled: true,
+			ipv6Enabled: false,
+			commandScript: []exectesting.FakeCommandAction{
+				func(cmd string, args ...string) exec.Cmd {
+					return exectesting.InitFakeCmd(&exectesting.FakeCmd{
+						CombinedOutputScript: []exectesting.FakeAction{
+							func() ([]byte, []byte, error) { return nil, nil, fmt.Errorf("failed to list tables") },
+						},
+					}, cmd, args...)
+				},
+			},
+			expectedCalls: func(m *iptablestest.MockInterfaceMockRecorder) {
+				m.ListRules(iptables.ProtocolIPv4, iptables.NATTable, iptables.PreRoutingChain).
+					Return(nil, fmt.Errorf("failed to list rules"))
+				m.ListRules(iptables.ProtocolIPv4, iptables.NATTable, iptables.OutputChain).
+					Return(nil, fmt.Errorf("failed to list rules"))
+			},
+			expected: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockIPTables := iptablestest.NewMockInterface(ctrl)
+			tt.expectedCalls(mockIPTables.EXPECT())
+			c := &Client{
+				networkConfig: &config.NetworkConfig{
+					IPv4Enabled: tt.ipv4Enabled,
+					IPv6Enabled: tt.ipv6Enabled,
+				},
+				iptables: mockIPTables,
+				executor: &exectesting.FakeExec{
+					CommandScript: tt.commandScript,
+				},
+			}
+			c.kubeProxyExist.Store(true)
+			c.kubeProxyDetect()
+			assert.Equal(t, tt.expected, c.kubeProxyExist.Load())
 		})
 	}
 }

--- a/test/integration/agent/route_test.go
+++ b/test/integration/agent/route_test.go
@@ -392,8 +392,6 @@ func TestInitialize(t *testing.T) {
 	chain raw-prerouting-proxy-all {
 		comment "Raw prerouting for proxyAll"
 		type filter hook prerouting priority raw; policy accept;
-		ip daddr @externalip counter packets 0 bytes 0 notrack comment "Do not track request packets destined to external IPs"
-		ip saddr @externalip counter packets 0 bytes 0 notrack comment "Do not track reply packets sourced from external IPs"
 	}
 }
 `
@@ -401,7 +399,6 @@ func TestInitialize(t *testing.T) {
 	chain raw-output-proxy-all {
 		comment "Raw output for proxyAll"
 		type filter hook output priority raw; policy accept;
-		ip daddr @externalip counter packets 0 bytes 0 notrack comment "Do not track request packets destined to external IPs"
 	}
 }
 `


### PR DESCRIPTION
To bypass kube-proxy processing for Service external IPs when proxyAll is enabled, AntreaProxy installs host network NOTRACK rules matching Service external IPs. The matched connections bypass PREROUTING processing since NOTRACK bypasses conntrack, and traffic originating externally and destined for Service external IPs can be forwarded to Antrea OVS pipelines.

However, a side effect of NOTRACK rules is that the traffic will never have a chance to be accelerated by nftables flowtable, because nftables flowtable relies on conntrack.

This patch adds a best-effort detection of kube-proxy. The steps are:

1. Search for the keywords `ip kube-proxy` or `ip6 kube-proxy` in the output of the command `nft list tables`. If kube-proxy is running in nftables, such tables should be created. If one is found, assume kube-proxy is present and return.
2. Search for the keyword `-j KUBE-SERVICES` in the output of the iptables nat table PREROUTING chain. If it is found, assume kube-proxy is present and return.
3. Search for the keyword `-j KUBE-SERVICES` in the output of the iptables nat table OUTPUT chain. If it is found, assume kube-proxy is present and return.
4. If none of the keywords above are found and there are no errors, assume kube-proxy is NOT present and return.
5. If there are errors in the steps above, assume kube-proxy is present.

This detection is run during periodic syncing of network configurations managed by Antrea, and the presence of kube-proxy determines whether to install the NOTRACK rules for Service external IPs. If kube-proxy is not present, traffic for external-to-Service connections (external IPs like LoadBalancer ingress IPs or ClusterIP external IPs) may have a chance to be accelerated by nftables flowtable in the future.