### PR TITLE
Remove leftover Antrea nftables at antrea-agent startup

### DIFF
--- a/pkg/agent/route/route_linux.go
+++ b/pkg/agent/route/route_linux.go
@@ -355,22 +355,29 @@ func (c *Client) Initialize(nodeConfig *config.NodeConfig, done func()) error {
 		klog.Info("Initialized iptables")
 	}()
 
-	if c.hostNetworkAccelerationEnabled || c.hostNetworkNFTables && c.proxyAll {
-		nftables, err := nftables.New(c.networkConfig.IPv4Enabled, c.networkConfig.IPv6Enabled)
-		if err != nil {
-			if c.proxyAll && c.hostNetworkNFTables {
-				// ProxyAll depends on nftables; fail if unavailable.
-				return fmt.Errorf("failed to create nftables instance: %w", err)
-			}
-			// Host-network acceleration is optional; skip gracefully.
-			if c.hostNetworkAccelerationEnabled {
-				klog.ErrorS(err, "Failed to create nftables instance, skipping host network acceleration")
-			}
+	// Create a nftables client and sync nftables configuration. This is done even when no nftables
+	// feature is currently active, to clean up any stale objects left from a previous run.
+	var nftOptions []nftables.OptionsFn
+	if c.hostNetworkAccelerationEnabled {
+		// When host-network acceleration is enabled, do the flowtable dry-run check.
+		nftOptions = append(nftOptions, nftables.WithFlowtableCheck)
+	}
+	nftClient, err := nftables.New(c.networkConfig.IPv4Enabled, c.networkConfig.IPv6Enabled, nftOptions...)
+	if err != nil {
+		if c.proxyAll && c.hostNetworkNFTables {
+			// ProxyAll depends on nftables; fail if unavailable.
+			return fmt.Errorf("failed to create nftables instance: %w", err)
+		}
+		// Host-network acceleration is optional; skip gracefully.
+		if c.hostNetworkAccelerationEnabled {
+			klog.ErrorS(err, "Failed to create nftables instance, skipping host network acceleration")
 		} else {
-			c.nftables = nftables
-			if err := c.syncNFTables(context.TODO()); err != nil {
-				return fmt.Errorf("failed to initialize nftables: %w", err)
-			}
+			klog.ErrorS(err, "Skipping nftables leftover cleanup because nftables is not available")
+		}
+	} else {
+		c.nftables = nftClient
+		if err := c.syncNFTables(context.TODO(), true); err != nil {
+			return fmt.Errorf("failed to initialize nftables: %w", err)
 		}
 	}
 
@@ -459,7 +466,7 @@ func (c *Client) syncNetworkConfig(ctx context.Context) {
 		return
 	}
 	if c.nftables != nil {
-		if err := c.syncNFTables(ctx); err != nil {
+		if err := c.syncNFTables(ctx, false); err != nil {
 			klog.ErrorS(err, "Failed to sync nftables")
 		}
 	}
@@ -2036,7 +2043,7 @@ func (c *Client) AddRoutes(podCIDR *net.IPNet, nodeName string, nodeIP, nodeGwIP
 		podCIDRRoute.Gw = nodeIP
 		routes = append(routes, podCIDRRoute)
 		// Update the nftables set that contains all peer PodCIDRs.
-		if c.nftables != nil {
+		if c.hostNetworkAccelerationEnabled && c.nftables != nil {
 			if err := c.addPeerPodCIDRToNFTablesSet(podCIDR); err != nil {
 				return err
 			}
@@ -2130,7 +2137,7 @@ func (c *Client) DeleteRoutes(podCIDR *net.IPNet) error {
 			c.nodeNeighbors.Delete(podCIDRStr)
 		}
 	}
-	if c.nftables != nil {
+	if c.hostNetworkAccelerationEnabled && c.nftables != nil {
 		if err := c.deletePeerPodCIDRFromNFTablesSet(podCIDR); err != nil {
 			return err
 		}
@@ -3201,8 +3208,79 @@ func (c *Client) nftablesTrafficAcceleration(tx *knftables.Transaction, ipProtoc
 	}
 }
 
-func (c *Client) syncNFTables(ctx context.Context) error {
+func (c *Client) nftablesTrafficAccelerationCleanup(tx *knftables.Transaction, ipProtocol knftables.Family) {
+	tx.Destroy(&knftables.Chain{Name: antreaNFTablesChainForwardOffload})
+	tx.Destroy(&knftables.Flowtable{Name: antreaNFTablesFlowtable})
+	var ipAddr string
+	switch ipProtocol {
+	case knftables.IPv4Family:
+		ipAddr = "ipv4_addr"
+	case knftables.IPv6Family:
+		ipAddr = "ipv6_addr"
+	}
+	tx.Destroy(&knftables.Set{
+		Name:  antreaNFTablesSetPeerPodCIDR,
+		Type:  ipAddr,
+		Flags: []knftables.SetFlag{knftables.IntervalFlag},
+	})
+}
+
+func (c *Client) nftablesProxyAllCleanup(tx *knftables.Transaction, ipProtocol knftables.Family) {
+	for _, chain := range []string{
+		antreaNFTablesRawChainPreroutingProxyAll,
+		antreaNFTablesRawChainOutputProxyAll,
+		antreaNFTablesNatChainPreroutingProxyAll,
+		antreaNFTablesNatChainOutputProxyAll,
+		antreaNFTablesNatChainPostroutingProxyAll,
+	} {
+		tx.Destroy(&knftables.Chain{Name: chain})
+	}
+	var ipAddr string
+	var nodePortSet string
+	var externalIPSet string
+	switch ipProtocol {
+	case knftables.IPv4Family:
+		ipAddr = "ipv4_addr"
+		nodePortSet = antreaNFTablesSetNodePort
+		externalIPSet = antreaNFTablesSetExternalIP
+	case knftables.IPv6Family:
+		ipAddr = "ipv6_addr"
+		nodePortSet = antreaNFTablesSetNodePort6
+		externalIPSet = antreaNFTablesSetExternalIP6
+	}
+	tx.Destroy(&knftables.Set{
+		Name: nodePortSet,
+		Type: ipAddr + " . inet_proto . inet_service",
+	})
+	tx.Destroy(&knftables.Set{
+		Name: externalIPSet,
+		Type: ipAddr,
+	})
+}
+
+func (c *Client) syncNFTables(ctx context.Context, cleanupStaleObjects bool) error {
 	for ipProtocol, nft := range c.nftables.All() {
+		if cleanupStaleObjects {
+			cleanAcceleration := !c.hostNetworkAccelerationEnabled
+			cleanProxyAll := !c.proxyAll || !c.hostNetworkNFTables
+			if cleanAcceleration || cleanProxyAll {
+				tx := nft.NewTransaction()
+				if cleanAcceleration {
+					c.nftablesTrafficAccelerationCleanup(tx, ipProtocol)
+				}
+				if cleanProxyAll {
+					c.nftablesProxyAllCleanup(tx, ipProtocol)
+				}
+				if err := nft.Run(ctx, tx); err != nil {
+					klog.InfoS("nftables leftover cleanup did not fully apply", "family", ipProtocol, "err", err)
+				}
+			}
+		}
+
+		if !c.hostNetworkAccelerationEnabled && (!c.proxyAll || !c.hostNetworkNFTables) {
+			continue
+		}
+
 		tx := nft.NewTransaction()
 		// Add the table whose name is defined when initializing nftables instance.
 		tx.Add(&knftables.Table{

--- a/pkg/agent/route/route_linux_test.go
+++ b/pkg/agent/route/route_linux_test.go
@@ -1670,7 +1670,7 @@ func TestAddRoutes(t *testing.T) {
 						tt.networkConfig.TrafficEncapMode == config.TrafficEncapModeHybrid),
 			}
 			if c.hostNetworkAccelerationEnabled {
-				require.NoError(t, c.syncNFTables(context.TODO()))
+				require.NoError(t, c.syncNFTables(context.TODO(), false))
 			}
 
 			tt.expectedIPSetCalls(mockIPSet.EXPECT())
@@ -1780,7 +1780,7 @@ func TestDeleteRoutes(t *testing.T) {
 			for podCIDR, nodeNeighbor := range tt.existingNodeNeighbors {
 				c.nodeNeighbors.Store(podCIDR, nodeNeighbor)
 			}
-			require.NoError(t, c.syncNFTables(context.TODO()))
+			require.NoError(t, c.syncNFTables(context.TODO(), false))
 
 			for _, podCIDR := range tt.existingPodCIDRs {
 				isIPv6 := utilnet.IsIPv6(podCIDR.IP)
@@ -1905,7 +1905,7 @@ func TestAddPeerPodCIDRToNFTablesSet(t *testing.T) {
 					NodeTransportInterfaceName: "eth0",
 				},
 			}
-			require.NoError(t, c.syncNFTables(context.TODO()))
+			require.NoError(t, c.syncNFTables(context.TODO(), false))
 
 			// Prepare enforced nftables set and elements.
 			isIPv6 := utilnet.IsIPv6(tt.podCIDRToAdd.IP)
@@ -2029,7 +2029,7 @@ func TestDeletePeerPodCIDRFromNFTablesSet(t *testing.T) {
 					NodeTransportInterfaceName: "eth0",
 				},
 			}
-			require.NoError(t, c.syncNFTables(context.TODO()))
+			require.NoError(t, c.syncNFTables(context.TODO(), false))
 
 			// Prepare enforced nftables set and elements.
 			isIPv6 := utilnet.IsIPv6(tt.podCIDRToDelete.IP)
@@ -2472,7 +2472,7 @@ func TestAddNodePortConfigsNFTablesMode(t *testing.T) {
 				hostNetworkNFTables: true,
 				proxyAll:            true,
 			}
-			require.NoError(t, c.syncNFTables(context.TODO()))
+			require.NoError(t, c.syncNFTables(context.TODO(), false))
 			require.NoError(t, c.AddNodePortConfigs(tt.nodePortAddresses, tt.port, tt.protocol))
 			for _, nft := range c.nftables.All() {
 				nftablesSet := getNodePortNFTablesSet(tt.enableIPv6)
@@ -2556,7 +2556,7 @@ func TestDeleteNodePortConfigsNFTablesMode(t *testing.T) {
 			}
 			c.serviceNFTablesSets[getNodePortNFTablesSet(tt.enableIPv6)].Store(strconv.Itoa(int(tt.port)), tt.existingElements)
 
-			require.NoError(t, c.syncNFTables(context.TODO()))
+			require.NoError(t, c.syncNFTables(context.TODO(), false))
 			require.NoError(t, c.DeleteNodePortConfigs(tt.nodePortAddresses, tt.port, tt.protocol))
 			for _, nft := range c.nftables.All() {
 				nftablesSet := getNodePortNFTablesSet(tt.enableIPv6)
@@ -2973,7 +2973,7 @@ func TestAddExternalIPConfigsNFTablesMode(t *testing.T) {
 				hostNetworkNFTables: true,
 				proxyAll:            true,
 			}
-			require.NoError(t, c.syncNFTables(context.TODO()))
+			require.NoError(t, c.syncNFTables(context.TODO(), false))
 			tt.expectedCalls(mockNetlink.EXPECT())
 
 			for svcInfo, externalIPs := range tt.svcToExternalIPs {
@@ -3081,7 +3081,7 @@ func TestDeleteExternalIPRouteNFTablesMode(t *testing.T) {
 					}})
 				}
 			}
-			require.NoError(t, c.syncNFTables(context.TODO()))
+			require.NoError(t, c.syncNFTables(context.TODO(), false))
 			tt.expectedCalls(mockNetlink.EXPECT())
 
 			for svcInfo, externalIPs := range tt.svcToExternalIPs {
@@ -3682,4 +3682,231 @@ func newMockNFTables(enableIPv4, enableIPv6 bool) (*nftables.Client, error) {
 	}
 
 	return mockNFTables, nil
+}
+
+type nftablesRunErrFake struct {
+	*knftables.Fake
+}
+
+func (f *nftablesRunErrFake) Run(_ context.Context, _ *knftables.Transaction) error {
+	return fmt.Errorf("mock nft Run failure")
+}
+
+func testNFTAddAccelerationRules(t *testing.T, ctx context.Context, f *knftables.Fake) {
+	t.Helper()
+	tx := f.NewTransaction()
+	tx.Add(&knftables.Table{Comment: ptr.To("Rules for Antrea")})
+	tx.Add(&knftables.Flowtable{
+		Name:     antreaNFTablesFlowtable,
+		Priority: ptr.To(knftables.FilterIngressPriority),
+		Devices:  []string{"antrea-gw0"},
+	})
+	tx.Add(&knftables.Chain{
+		Name:     antreaNFTablesChainForwardOffload,
+		Type:     ptr.To(knftables.FilterType),
+		Hook:     ptr.To(knftables.ForwardHook),
+		Priority: ptr.To(knftables.FilterPriority),
+	})
+	tx.Add(&knftables.Set{
+		Name:  antreaNFTablesSetPeerPodCIDR,
+		Type:  "ipv4_addr",
+		Flags: []knftables.SetFlag{knftables.IntervalFlag},
+	})
+	require.NoError(t, f.Run(ctx, tx))
+}
+
+func testNFTAddProxyAllRules(t *testing.T, ctx context.Context, f *knftables.Fake) {
+	t.Helper()
+	dnatPrio := knftables.DNATPriority + "-1"
+	tx := f.NewTransaction()
+	tx.Add(&knftables.Table{Comment: ptr.To("Rules for Antrea")})
+	tx.Add(&knftables.Chain{
+		Name:     antreaNFTablesRawChainPreroutingProxyAll,
+		Type:     ptr.To(knftables.FilterType),
+		Hook:     ptr.To(knftables.PreroutingHook),
+		Priority: ptr.To(knftables.RawPriority),
+	})
+	tx.Add(&knftables.Chain{
+		Name:     antreaNFTablesRawChainOutputProxyAll,
+		Type:     ptr.To(knftables.FilterType),
+		Hook:     ptr.To(knftables.OutputHook),
+		Priority: ptr.To(knftables.RawPriority),
+	})
+	tx.Add(&knftables.Chain{
+		Name:     antreaNFTablesNatChainPreroutingProxyAll,
+		Type:     ptr.To(knftables.NATType),
+		Hook:     ptr.To(knftables.PreroutingHook),
+		Priority: &dnatPrio,
+	})
+	tx.Add(&knftables.Chain{
+		Name:     antreaNFTablesNatChainOutputProxyAll,
+		Type:     ptr.To(knftables.NATType),
+		Hook:     ptr.To(knftables.OutputHook),
+		Priority: &dnatPrio,
+	})
+	tx.Add(&knftables.Chain{
+		Name:     antreaNFTablesNatChainPostroutingProxyAll,
+		Type:     ptr.To(knftables.NATType),
+		Hook:     ptr.To(knftables.PostroutingHook),
+		Priority: ptr.To(knftables.SNATPriority),
+	})
+	tx.Add(&knftables.Set{Name: antreaNFTablesSetNodePort, Type: "ipv4_addr . inet_proto . inet_service"})
+	tx.Add(&knftables.Set{Name: antreaNFTablesSetExternalIP, Type: "ipv4_addr"})
+	require.NoError(t, f.Run(ctx, tx))
+}
+
+func TestSyncNFTablesCleanup(t *testing.T) {
+	ctx := context.TODO()
+	proxyAllChainNames := []string{
+		antreaNFTablesRawChainPreroutingProxyAll,
+		antreaNFTablesRawChainOutputProxyAll,
+		antreaNFTablesNatChainPreroutingProxyAll,
+		antreaNFTablesNatChainOutputProxyAll,
+		antreaNFTablesNatChainPostroutingProxyAll,
+	}
+	testCases := []struct {
+		name                           string
+		hostNetworkAccelerationEnabled bool
+		proxyAll                       bool
+		hostNetworkNFTables            bool
+		accelerationRulesInstalled     bool
+		proxyAllRulesInstalled         bool
+		nftRunFails                    bool
+		checkNFTAfterSync              func(t *testing.T, f *knftables.Fake)
+	}{
+		{
+			name:                           "no need to cleanup",
+			hostNetworkAccelerationEnabled: true,
+			proxyAll:                       true,
+			hostNetworkNFTables:            true,
+			accelerationRulesInstalled:     true,
+			proxyAllRulesInstalled:         true,
+			checkNFTAfterSync: func(t *testing.T, f *knftables.Fake) {
+				chains, err := f.List(ctx, "chains")
+				require.NoError(t, err)
+				assert.Contains(t, chains, antreaNFTablesChainForwardOffload)
+
+				for _, n := range proxyAllChainNames {
+					assert.Contains(t, chains, n)
+				}
+				ft, err := f.List(ctx, "flowtables")
+				require.NoError(t, err)
+				assert.Contains(t, ft, antreaNFTablesFlowtable)
+
+				sets, err := f.List(ctx, "sets")
+				require.NoError(t, err)
+				assert.Contains(t, sets, antreaNFTablesSetPeerPodCIDR)
+				assert.Contains(t, sets, antreaNFTablesSetNodePort)
+				assert.Contains(t, sets, antreaNFTablesSetExternalIP)
+			},
+		},
+		{
+			name:                           "cleanup acceleration successfully",
+			hostNetworkAccelerationEnabled: false,
+			proxyAll:                       true,
+			hostNetworkNFTables:            true,
+			accelerationRulesInstalled:     true,
+			proxyAllRulesInstalled:         true,
+			checkNFTAfterSync: func(t *testing.T, f *knftables.Fake) {
+				chains, err := f.List(ctx, "chains")
+				require.NoError(t, err)
+				assert.NotContains(t, chains, antreaNFTablesChainForwardOffload)
+				for _, n := range proxyAllChainNames {
+					assert.Contains(t, chains, n, "proxyAll nft should be untouched when only acceleration cleanup runs")
+				}
+
+				ft, err := f.List(ctx, "flowtables")
+				require.NoError(t, err)
+				assert.NotContains(t, ft, antreaNFTablesFlowtable)
+
+				sets, err := f.List(ctx, "sets")
+				require.NoError(t, err)
+				assert.NotContains(t, sets, antreaNFTablesSetPeerPodCIDR)
+				assert.Contains(t, sets, antreaNFTablesSetNodePort)
+				assert.Contains(t, sets, antreaNFTablesSetExternalIP)
+			},
+		},
+		{
+			name:                           "cleanup proxyAll successfully",
+			hostNetworkAccelerationEnabled: true,
+			proxyAll:                       true,
+			hostNetworkNFTables:            false,
+			accelerationRulesInstalled:     true,
+			proxyAllRulesInstalled:         true,
+			checkNFTAfterSync: func(t *testing.T, f *knftables.Fake) {
+				chains, err := f.List(ctx, "chains")
+				require.NoError(t, err)
+				for _, n := range proxyAllChainNames {
+					assert.NotContains(t, chains, n)
+				}
+				assert.Contains(t, chains, antreaNFTablesChainForwardOffload, "acceleration nft should remain when only proxyAll cleanup runs")
+
+				ft, err := f.List(ctx, "flowtables")
+				require.NoError(t, err)
+				assert.Contains(t, ft, antreaNFTablesFlowtable)
+
+				sets, err := f.List(ctx, "sets")
+				require.NoError(t, err)
+				assert.NotContains(t, sets, antreaNFTablesSetNodePort)
+				assert.NotContains(t, sets, antreaNFTablesSetExternalIP)
+				assert.Contains(t, sets, antreaNFTablesSetPeerPodCIDR)
+			},
+		},
+		{
+			name:                           "cleanup failed",
+			hostNetworkAccelerationEnabled: false,
+			proxyAll:                       false,
+			hostNetworkNFTables:            false,
+			accelerationRulesInstalled:     true,
+			proxyAllRulesInstalled:         false,
+			nftRunFails:                    true,
+			checkNFTAfterSync: func(t *testing.T, f *knftables.Fake) {
+				chains, err := f.List(ctx, "chains")
+				require.NoError(t, err)
+				assert.Contains(t, chains, antreaNFTablesChainForwardOffload)
+				ft, err := f.List(ctx, "flowtables")
+				require.NoError(t, err)
+				assert.Contains(t, ft, antreaNFTablesFlowtable)
+				sets, err := f.List(ctx, "sets")
+				require.NoError(t, err)
+				assert.Contains(t, sets, antreaNFTablesSetPeerPodCIDR)
+			},
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeNFT := knftables.NewFake(knftables.IPv4Family, "antrea")
+			if tt.accelerationRulesInstalled {
+				testNFTAddAccelerationRules(t, ctx, fakeNFT)
+			}
+			if tt.proxyAllRulesInstalled {
+				testNFTAddProxyAllRules(t, ctx, fakeNFT)
+			}
+
+			ipv4Iface := knftables.Interface(fakeNFT)
+			if tt.nftRunFails {
+				ipv4Iface = &nftablesRunErrFake{Fake: fakeNFT}
+			}
+
+			client := &Client{
+				networkConfig:                  &config.NetworkConfig{IPv4Enabled: true, IPv6Enabled: false},
+				hostNetworkAccelerationEnabled: tt.hostNetworkAccelerationEnabled,
+				proxyAll:                       tt.proxyAll,
+				hostNetworkNFTables:            tt.hostNetworkNFTables,
+				nftables:                       &nftables.Client{IPv4: ipv4Iface},
+				nodeConfig: &config.NodeConfig{
+					GatewayConfig:              &config.GatewayConfig{Name: "antrea-gw0"},
+					NodeTransportInterfaceName: "eth0",
+					PodIPv4CIDR:                ip.MustParseCIDR("10.0.0.0/24"),
+				},
+				serviceNFTablesSets: map[string]*sync.Map{
+					antreaNFTablesSetNodePort:   {},
+					antreaNFTablesSetExternalIP: {},
+				},
+			}
+			err := client.syncNFTables(ctx, true)
+			require.NoError(t, err)
+			tt.checkNFTAfterSync(t, fakeNFT)
+		})
+	}
 }

--- a/pkg/agent/util/nftables/nftables.go
+++ b/pkg/agent/util/nftables/nftables.go
@@ -30,6 +30,17 @@ type Client struct {
 	IPv6 knftables.Interface
 }
 
+type options struct {
+	withFlowtableCheck bool
+}
+
+type OptionsFn func(*options)
+
+// WithFlowtableCheck enables the dry-run that verifies kernel flow offload (flowtable) support.
+func WithFlowtableCheck(o *options) {
+	o.withFlowtableCheck = true
+}
+
 func (c *Client) All() iter.Seq2[knftables.Family, knftables.Interface] {
 	return func(yield func(knftables.Family, knftables.Interface) bool) {
 		if c.IPv4 != nil {
@@ -45,17 +56,22 @@ func (c *Client) All() iter.Seq2[knftables.Family, knftables.Interface] {
 	}
 }
 
-func New(enableIPv4, enableIPv6 bool) (*Client, error) {
+func New(enableIPv4, enableIPv6 bool, optionFns ...OptionsFn) (*Client, error) {
+	o := &options{}
+	for _, fn := range optionFns {
+		fn(o)
+	}
+
 	client := &Client{}
 	if enableIPv4 {
-		nft, err := newNFTables(knftables.IPv4Family)
+		nft, err := newNFTables(knftables.IPv4Family, o.withFlowtableCheck)
 		if err != nil {
 			return nil, fmt.Errorf("error creating nftables instance: %v", err)
 		}
 		client.IPv4 = nft
 	}
 	if enableIPv6 {
-		nft, err := newNFTables(knftables.IPv6Family)
+		nft, err := newNFTables(knftables.IPv6Family, o.withFlowtableCheck)
 		if err != nil {
 			return nil, fmt.Errorf("error creating nftables instance: %v", err)
 		}
@@ -64,7 +80,7 @@ func New(enableIPv4, enableIPv6 bool) (*Client, error) {
 	return client, nil
 }
 
-func newNFTables(ipFamily knftables.Family) (knftables.Interface, error) {
+func newNFTables(ipFamily knftables.Family, withFlowtableCheck bool) (knftables.Interface, error) {
 	// knftables.New validates:
 	//  - nft binary is available
 	//  - sufficient permissions
@@ -76,25 +92,27 @@ func newNFTables(ipFamily knftables.Family) (knftables.Interface, error) {
 	}
 
 	// Verify nft_flow_offload support with a dry-run.
-	tx := nft.NewTransaction()
-	tx.Add(&knftables.Table{})
-	tx.Add(&knftables.Flowtable{
-		Name:     "test_flowtable",
-		Priority: ptr.To(knftables.FilterIngressPriority),
-		Devices:  []string{"lo"},
-	})
-	tx.Add(&knftables.Chain{
-		Name:     "test_chain",
-		Type:     ptr.To(knftables.FilterType),
-		Hook:     ptr.To(knftables.ForwardHook),
-		Priority: ptr.To(knftables.FilterPriority),
-	})
-	tx.Add(&knftables.Rule{
-		Chain: "test_chain",
-		Rule:  knftables.Concat("flow", "add", "@", "test_flowtable"),
-	})
-	if err := nft.Check(context.TODO(), tx); err != nil {
-		return nil, fmt.Errorf("nftables flowtable is not supported: %w", err)
+	if withFlowtableCheck {
+		tx := nft.NewTransaction()
+		tx.Add(&knftables.Table{})
+		tx.Add(&knftables.Flowtable{
+			Name:     "test_flowtable",
+			Priority: ptr.To(knftables.FilterIngressPriority),
+			Devices:  []string{"lo"},
+		})
+		tx.Add(&knftables.Chain{
+			Name:     "test_chain",
+			Type:     ptr.To(knftables.FilterType),
+			Hook:     ptr.To(knftables.ForwardHook),
+			Priority: ptr.To(knftables.FilterPriority),
+		})
+		tx.Add(&knftables.Rule{
+			Chain: "test_chain",
+			Rule:  knftables.Concat("flow", "add", "@", "test_flowtable"),
+		})
+		if err := nft.Check(context.TODO(), tx); err != nil {
+			return nil, fmt.Errorf("nftables flowtable is not supported: %w", err)
+		}
 	}
 
 	return nft, nil


### PR DESCRIPTION
Orphaned nftables objects can remain after reboot or toggling
host network acceleration, or after switching proxyAll host traffic
from nftables to iptables.

Destroy those chains, sets, and the acceleration flowtable during
antrea-agent route client initialization when they are no longer used.