### PR TITLE
Exclude SubnetInfo gateway from ExternalIPPool allocator

### DIFF
--- a/pkg/controller/externalippool/controller.go
+++ b/pkg/controller/externalippool/controller.go
@@ -233,6 +233,15 @@ func (c *ExternalIPPoolController) createOrUpdateIPAllocator(ipPool *antreacrds.
 				if utilnet.IsIPv4CIDR(ipNet) {
 					reservedIPs = append(reservedIPs, iputil.GetLocalBroadcastIP(ipNet))
 				}
+				// If the ExternalIPPool includes a SubnetInfo, and the subnet
+				// gateway is part of the CIDR, make sure that it won't be allocated.
+				// This makes it consistent with the IPPoolAllocator (pkg/ipam/poolallocator/).
+				if ipPool.Spec.SubnetInfo != nil {
+					gatewayIP := net.ParseIP(ipPool.Spec.SubnetInfo.Gateway)
+					if ipNet.Contains(gatewayIP) {
+						reservedIPs = append(reservedIPs, gatewayIP)
+					}
+				}
 				return ipallocator.NewCIDRAllocator(ipNet, reservedIPs)
 			} else {
 				if existingIPRanges.Has(fmt.Sprintf("%s-%s", ipRange.Start, ipRange.End)) {

--- a/pkg/controller/externalippool/controller_test.go
+++ b/pkg/controller/externalippool/controller_test.go
@@ -280,6 +280,30 @@ func TestCreateOrUpdateIPAllocator(t *testing.T) {
 	assert.Equal(t, 29, allocator.Total())
 }
 
+func TestCreateOrUpdateIPAllocatorSubnetInfoGateway(t *testing.T) {
+	controller := newController(nil)
+
+	ipPool := newExternalIPPool("ipPoolA", "192.168.1.144/28", "", "")
+	ipPool.Spec.SubnetInfo = &antreacrds.SubnetInfo{
+		Gateway:      "192.168.1.145",
+		PrefixLength: 28,
+		VLAN:         201,
+	}
+	changed := controller.createOrUpdateIPAllocator(ipPool)
+	assert.True(t, changed)
+	allocator, exists := controller.getIPAllocator(ipPool.Name)
+	require.True(t, exists)
+	gwIP := net.ParseIP("192.168.1.145")
+	assert.True(t, allocator.Has(gwIP))
+	assert.Equal(t, 1, len(allocator))
+	// 16 (block size) - network IP - broadcast IP - gateway IP
+	assert.Equal(t, 13, allocator.Total())
+	assert.Error(t, allocator.AllocateIP(gwIP))
+	firstIP, err := allocator.AllocateNext()
+	require.NoError(t, err)
+	assert.Equal(t, "192.168.1.146", firstIP.String())
+}
+
 func TestIPPoolEvents(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)

--- a/pkg/ipam/ipallocator/allocator.go
+++ b/pkg/ipam/ipallocator/allocator.go
@@ -71,13 +71,30 @@ func NewCIDRAllocator(cidr *net.IPNet, reservedIPs []net.IP) (*SingleIPAllocator
 		max = 65536
 	}
 
+	end := big.NewInt(max)
+	end.Add(base, end)
+	// Make sure that all reserved IPs are in the supported range. This is important because
+	// len(reservedIPs) is used to determine the number of available IPs, and we don't want to
+	// undercount. We also filter duplicates out for the same reason.
+	reservedIPSet := make(utilnet.IPSet)
+	for _, ip := range reservedIPs {
+		x := utilnet.BigForIP(ip)
+		if x.Cmp(base) >= 0 && x.Cmp(end) <= 0 {
+			reservedIPSet.Insert(ip)
+		}
+	}
+	newReservedIPs := make([]net.IP, 0, len(reservedIPSet))
+	for _, ip := range reservedIPSet {
+		newReservedIPs = append(newReservedIPs, ip)
+	}
+
 	allocator := &SingleIPAllocator{
 		ipRangeStr:  cidr.String(),
 		base:        base,
 		max:         int(max),
 		allocated:   big.NewInt(0),
 		count:       0,
-		reservedIPs: reservedIPs,
+		reservedIPs: newReservedIPs,
 	}
 	return allocator, nil
 }


### PR DESCRIPTION
When an ExternalIPPool uses a CIDR that includes the gateway IP from SubnetInfo, the controller would allocate that IP (e.g. for Egress), causing networking issues. Reserve the gateway IP in the IP allocator so it is never handed out, consistent with the IPPoolAllocator used for AntreaIPAM.

Fixes #7868