### PR TITLE
Reserve last 4 IPs of each Node's PodCIDR for Antrea

### DIFF
--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -171,6 +171,13 @@ first IP of the local Node's subnet to be the gateway IP and assigns it to the
 to allocate IPs from the subnet to all Pods. A local Pod is assigned an IP
 when the CNI ADD command is received for that Pod.
 
+> [!IMPORTANT]
+> Antrea reserves the **last 4 IP addresses** of each Node's PodCIDR for
+> internal use (e.g. `.252`–`.255` for a `/24` subnet). These addresses are
+> never allocated to Pods. When sizing Node subnets, account for this
+> reservation: a `/24` subnet provides **250 allocatable Pod IPs** per Node
+> (256 − 1 network − 1 gateway − 4 reserved).
+
 `NodeIPAMController` can run in `kube-controller-manager` context, or within
 the context of Antrea Controller.
 

--- a/pkg/agent/cniserver/server.go
+++ b/pkg/agent/cniserver/server.go
@@ -46,6 +46,7 @@ import (
 	"antrea.io/antrea/pkg/cni"
 	"antrea.io/antrea/pkg/ovs/ovsconfig"
 	"antrea.io/antrea/pkg/util/channel"
+	utilip "antrea.io/antrea/pkg/util/ip"
 	"antrea.io/antrea/pkg/util/wait"
 )
 
@@ -270,16 +271,30 @@ func (s *CNIServer) validateRequestMessage(request *cnipb.CniCmdRequest) (*CNICo
 	return cniConfig, nil
 }
 
+// podCIDRReservedCount is the number of IPs at the end of each node's PodCIDR that Antrea reserves for internal use
+// and will never allocate to a Pod. It equals 4, equivalent to the last /30 block of an IPv4 subnet. Of the 4 reserved
+// IPs, 3 are practically usable for internal purposes.
+const podCIDRReservedCount = 4
+
 // updateLocalIPAMSubnet updates CNIConfig.CniCmdArgs with this Node's Pod CIDRs, which will be
-// passed to the IPAM driver.
+// passed to the IPAM driver. rangeEnd is set so that the last podCIDRReservedCount IPs are
+// never allocated to a Pod.
 func (s *CNIServer) updateLocalIPAMSubnet(cniConfig *CNIConfig) {
 	if (s.nodeConfig.GatewayConfig.IPv4 != nil) && (s.nodeConfig.PodIPv4CIDR != nil) {
 		cniConfig.NetworkConfig.IPAM.Ranges = append(cniConfig.NetworkConfig.IPAM.Ranges,
-			types.RangeSet{types.Range{Subnet: s.nodeConfig.PodIPv4CIDR.String(), Gateway: s.nodeConfig.GatewayConfig.IPv4.String()}})
+			types.RangeSet{types.Range{
+				Subnet:   s.nodeConfig.PodIPv4CIDR.String(),
+				Gateway:  s.nodeConfig.GatewayConfig.IPv4.String(),
+				RangeEnd: utilip.NthIPFromCIDREnd(s.nodeConfig.PodIPv4CIDR, podCIDRReservedCount+1),
+			}})
 	}
 	if (s.nodeConfig.GatewayConfig.IPv6 != nil) && (s.nodeConfig.PodIPv6CIDR != nil) {
 		cniConfig.NetworkConfig.IPAM.Ranges = append(cniConfig.NetworkConfig.IPAM.Ranges,
-			types.RangeSet{types.Range{Subnet: s.nodeConfig.PodIPv6CIDR.String(), Gateway: s.nodeConfig.GatewayConfig.IPv6.String()}})
+			types.RangeSet{types.Range{
+				Subnet:   s.nodeConfig.PodIPv6CIDR.String(),
+				Gateway:  s.nodeConfig.GatewayConfig.IPv6.String(),
+				RangeEnd: utilip.NthIPFromCIDREnd(s.nodeConfig.PodIPv6CIDR, podCIDRReservedCount+1),
+			}})
 	}
 	cniConfig.NetworkConfiguration, _ = json.Marshal(cniConfig.NetworkConfig)
 }

--- a/pkg/agent/cniserver/types/types.go
+++ b/pkg/agent/cniserver/types/types.go
@@ -37,8 +37,9 @@ type RuntimeConfig struct {
 }
 
 type Range struct {
-	Subnet  string `json:"subnet"`
-	Gateway string `json:"gateway,omitempty"`
+	Subnet   string `json:"subnet"`
+	Gateway  string `json:"gateway,omitempty"`
+	RangeEnd string `json:"rangeEnd,omitempty"`
 }
 
 type RangeSet []Range

--- a/pkg/util/ip/ip.go
+++ b/pkg/util/ip/ip.go
@@ -279,8 +279,18 @@ func AppendPortIfMissing(addr, port string) string {
 	return net.JoinHostPort(addr, port)
 }
 
-// GetStartAndEndOfPrefix retrieves the start and end addresses of a netip.Prefix.
-// For example:  10.10.40.0/24 -> 10.10.40.0, 10.10.40.255
+// NthIPFromCIDREnd returns the IP at position n counting backwards from the last (broadcast) address of cidr.
+// It works for both IPv4 and IPv6.
+func NthIPFromCIDREnd(cidr *net.IPNet, n int) string {
+	addr, _ := netip.AddrFromSlice(cidr.IP)
+	ones, _ := cidr.Mask.Size()
+	_, end := GetStartAndEndOfPrefix(netip.PrefixFrom(addr.Unmap(), ones))
+	for i := 1; i < n; i++ {
+		end = end.Prev()
+	}
+	return end.String()
+}
+
 func GetStartAndEndOfPrefix(prefix netip.Prefix) (netip.Addr, netip.Addr) {
 	var start, end netip.Addr
 	var mask net.IPMask

--- a/pkg/util/ip/ip_test.go
+++ b/pkg/util/ip/ip_test.go
@@ -412,3 +412,37 @@ func TestGetStartAndEndOfPrefix(t *testing.T) {
 		})
 	}
 }
+func TestNthIPFromCIDREnd(t *testing.T) {
+	tests := []struct {
+		name     string
+		cidr     *net.IPNet
+		n        int
+		expected string
+	}{
+		// IPv4 tests
+		{name: "IPv4 /24 n=1", cidr: newCIDR("10.244.0.0/24"), n: 1, expected: "10.244.0.255"},
+		{name: "IPv4 /24 n=5", cidr: newCIDR("10.244.0.0/24"), n: 5, expected: "10.244.0.251"},
+		{name: "IPv4 /16 n=5", cidr: newCIDR("10.0.0.0/16"), n: 5, expected: "10.0.255.251"},
+		{name: "IPv4 /26 n=5", cidr: newCIDR("10.0.0.0/26"), n: 5, expected: "10.0.0.59"},
+		// IPv6 tests
+		{name: "IPv6 /64 n=1", cidr: newCIDR("fd74:ca9b:172:18::/64"), n: 1, expected: "fd74:ca9b:172:18:ffff:ffff:ffff:ffff"},
+		{name: "IPv6 /64 n=5", cidr: newCIDR("fd74:ca9b:172:18::/64"), n: 5, expected: "fd74:ca9b:172:18:ffff:ffff:ffff:fffb"},
+		{name: "IPv6 /120 n=5", cidr: newCIDR("fd00::/120"), n: 5, expected: "fd00::fb"},
+		// IPv4-mapped IPv6 form
+		{
+			name: "IPv4-mapped IPv6 n=5",
+			cidr: &net.IPNet{
+				IP:   net.IP{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 10, 244, 0, 0},
+				Mask: net.CIDRMask(24, 32),
+			},
+			n:        5,
+			expected: "10.244.0.251",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, NthIPFromCIDREnd(tc.cidr, tc.n))
+		})
+	}
+}


### PR DESCRIPTION
Set host-local IPAM's rangeEnd to (broadcast - 4) so the last 4 addresses of every Node's PodCIDR are never allocated to Pods. These addresses are reserved for future internal Antrea use (e.g. hairpin SNAT).

The implementation uses the existing host-local `rangeEnd` field, which is natively respected by the allocator. No changes to the host-local vendor code are required.