### PR TITLE
Ignore user-managed VLAN sub-interfaces in IP assigner

### DIFF
--- a/docs/egress.md
+++ b/docs/egress.md
@@ -233,7 +233,12 @@ Egress IP, otherwise route it to the destination directly.
 Once set, Antrea will tag Egress traffic leaving the Egress Node with the
 specified VLAN ID. Correspondingly, it's expected that reply traffic towards
 these Egress IPs is also tagged with the specified VLAN ID when arriving at the
-Egress Node.
+Egress Node. When a VLAN is specified, Antrea will automatically create and
+manage VLAN sub-interfaces on the Node's transport interface, named with an
+`antrea-ext.` prefix (e.g. `antrea-ext.10` for VLAN 10). Users should **not**
+pre-create VLAN sub-interfaces for Egress purposes, as Antrea only manages
+sub-interfaces with the `antrea-ext.` prefix and will ignore any other VLAN
+sub-interfaces on the transport interface.
 
 An example of ExternalIPPool using a non-default subnet is as below:
 

--- a/pkg/agent/ipassigner/ip_assigner_linux.go
+++ b/pkg/agent/ipassigner/ip_assigner_linux.go
@@ -268,7 +268,10 @@ func NewIPAssigner(nodeTransportInterface string, dummyDeviceName string, linkMo
 	return a, nil
 }
 
-// getVLANInterfaces returns all VLAN sub-interfaces of the given parent interface.
+// getVLANInterfaces returns VLAN sub-interfaces of the given parent interface
+// that were created by antrea-agent (i.e., whose names start with vlanInterfacePrefix).
+// User-managed VLAN sub-interfaces are ignored to avoid accidentally loading
+// their IPs and deleting them as stale during reconciliation.
 func getVLANInterfaces(parentIndex int) ([]*netlink.Vlan, error) {
 	links, err := netlink.LinkList()
 	if err != nil {
@@ -276,9 +279,15 @@ func getVLANInterfaces(parentIndex int) ([]*netlink.Vlan, error) {
 	}
 	var vlans []*netlink.Vlan
 	for _, link := range links {
-		if vlan, ok := link.(*netlink.Vlan); ok && vlan.ParentIndex == parentIndex {
-			vlans = append(vlans, vlan)
+		vlan, ok := link.(*netlink.Vlan)
+		if !ok || vlan.ParentIndex != parentIndex {
+			continue
 		}
+		if !strings.HasPrefix(vlan.Attrs().Name, vlanInterfacePrefix) {
+			klog.InfoS("Ignoring user-managed VLAN sub-interface", "interface", vlan.Attrs().Name)
+			continue
+		}
+		vlans = append(vlans, vlan)
 	}
 	return vlans, nil
 }

--- a/test/integration/agent/ip_assigner_linux_test.go
+++ b/test/integration/agent/ip_assigner_linux_test.go
@@ -16,6 +16,7 @@ package agent
 
 import (
 	"fmt"
+	"net"
 	"os/exec"
 	"testing"
 
@@ -177,6 +178,60 @@ func TestIPAssigner(t *testing.T) {
 	assert.Equal(t, sets.New[string](), actualIPs, "Actual IPs don't match")
 	_, err = netlink.LinkByName("antrea-ext.20")
 	require.Error(t, err, "VLAN 20 device should be deleted but was not")
+}
+
+func TestIPAssignerIgnoresUserInterfaces(t *testing.T) {
+	nodeLinkName := nodeIntf.Name
+	require.NotEmpty(t, nodeLinkName, "Get Node link failed")
+
+	nodeLink, err := netlink.LinkByName(nodeLinkName)
+	require.NoError(t, err)
+
+	userVLANName := "myvlan.100"
+	userVLAN := &netlink.Vlan{
+		LinkAttrs: netlink.LinkAttrs{
+			Name:        userVLANName,
+			ParentIndex: nodeLink.Attrs().Index,
+		},
+		VlanId: 100,
+	}
+	require.NoError(t, netlink.LinkAdd(userVLAN))
+	require.NoError(t, netlink.LinkSetUp(userVLAN))
+	defer func() {
+		link, err := netlink.LinkByName(userVLANName)
+		require.NoError(t, err)
+		require.NoError(t, netlink.LinkDel(link))
+	}()
+
+	userIP := "192.168.100.10"
+	addr := &netlink.Addr{
+		IPNet: &net.IPNet{
+			IP:   net.ParseIP(userIP),
+			Mask: net.CIDRMask(24, 32),
+		},
+	}
+	require.NoError(t, netlink.AddrAdd(userVLAN, addr))
+
+	ipAssigner, err := ipassigner.NewIPAssigner(nodeLinkName, dummyDeviceName, nil, true)
+	require.NoError(t, err, "Initializing IP assigner failed")
+	defer func() {
+		dummyDevice, err := netlink.LinkByName(dummyDeviceName)
+		if err == nil {
+			netlink.LinkDel(dummyDevice)
+		}
+	}()
+
+	assert.Equal(t, map[string]*crdv1b1.SubnetInfo{}, ipAssigner.AssignedIPs(),
+		"User VLAN IPs should not be loaded")
+
+	require.NoError(t, ipAssigner.InitIPs(map[string]*crdv1b1.SubnetInfo{}))
+
+	link, err := netlink.LinkByName(userVLANName)
+	require.NoError(t, err, "User VLAN interface should still exist after InitIPs")
+	actualIPs, err := listIPAddresses(link)
+	require.NoError(t, err)
+	assert.Equal(t, sets.New(fmt.Sprintf("%s/24", userIP)), actualIPs,
+		"User VLAN IPs should be untouched after reconciliation")
 }
 
 func listIPAddresses(device netlink.Link) (sets.Set[string], error) {


### PR DESCRIPTION
## Summary

- The IP assigner now only considers VLAN sub-interfaces whose names start with `antrea-ext.` (created by antrea-agent) when discovering existing interfaces at startup. User-managed VLAN sub-interfaces are left untouched, preventing accidental deletion of IPs and routes that could break Node connectivity.
- This change is unconditional (no new configuration option), as Antrea does not expect users to pre-create VLAN interfaces when `EgressSeparateSubnet` is used.
- Updated documentation (`docs/egress.md`) to clarify that Antrea manages VLAN sub-interfaces and users should not pre-create them.

Note: if a user-managed VLAN sub-interface already exists with the same VLAN ID needed by an Egress ExternalIPPool, creating the Antrea-managed sub-interface will fail.

Supersedes #7855, with a simplified approach: instead of adding a new `ignoreUserInterfaces` configuration option (defaulting to false), we always ignore user-managed VLAN interfaces. This was decided after discussing with other maintainers, as Antrea should not assume that all IPs on all VLAN sub-interfaces of the transport interface are Antrea-assigned Egress IPs.

Fixes #7834

## Test plan

- [x] Integration test `TestIPAssignerIgnoresUserInterfaces` added: creates a user-managed VLAN sub-interface with an IP, verifies that `NewIPAssigner` does not load it, and that `InitIPs` does not delete it.
- [x] Existing integration test `TestIPAssigner` continues to pass (Antrea-managed sub-interfaces still work correctly).
- [x] `golangci-lint` passes on changed files (pre-existing issue in unrelated untracked file).
- [x] Unit tests for `pkg/agent/ipassigner` pass.