### PR TITLE
Use Pod CIDR network address for SNAT under hostNetworkAcceleration

### DIFF
--- a/pkg/agent/openflow/client_test.go
+++ b/pkg/agent/openflow/client_test.go
@@ -81,19 +81,20 @@ func skipTest(tb testing.TB, skipLinux, skipWindows bool) {
 }
 
 type clientOptions struct {
-	enableOVSMeters            bool
-	enableProxy                bool
-	enableAntreaPolicy         bool
-	enableEgress               bool
-	enableEgressTrafficShaping bool
-	proxyAll                   bool
-	enableDSR                  bool
-	connectUplinkToBridge      bool
-	enableMulticast            bool
-	enableTrafficControl       bool
-	enableMulticluster         bool
-	enableL7NetworkPolicy      bool
-	trafficEncryptionMode      config.TrafficEncryptionModeType
+	enableOVSMeters               bool
+	enableProxy                   bool
+	enableAntreaPolicy            bool
+	enableEgress                  bool
+	enableEgressTrafficShaping    bool
+	proxyAll                      bool
+	enableDSR                     bool
+	connectUplinkToBridge         bool
+	enableHostNetworkAcceleration bool
+	enableMulticast               bool
+	enableTrafficControl          bool
+	enableMulticluster            bool
+	enableL7NetworkPolicy         bool
+	trafficEncryptionMode         config.TrafficEncryptionModeType
 }
 
 type clientOptionsFn func(*clientOptions)
@@ -145,6 +146,10 @@ func setEnableEgressTrafficShaping(v bool) clientOptionsFn {
 
 func enableConnectUplinkToBridge(o *clientOptions) {
 	o.connectUplinkToBridge = true
+}
+
+func enableHostNetworkAcceleration(o *clientOptions) {
+	o.enableHostNetworkAcceleration = true
 }
 
 func enableMulticast(o *clientOptions) {
@@ -463,10 +468,11 @@ func newFakeClientWithBridge(
 		OFPort: config.DefaultHostGatewayOFPort,
 	}
 	networkConfig := &config.NetworkConfig{
-		IPv4Enabled:           enableIPv4,
-		IPv6Enabled:           enableIPv6,
-		TrafficEncapMode:      trafficEncapMode,
-		TrafficEncryptionMode: o.trafficEncryptionMode,
+		IPv4Enabled:                   enableIPv4,
+		IPv6Enabled:                   enableIPv6,
+		TrafficEncapMode:              trafficEncapMode,
+		TrafficEncryptionMode:         o.trafficEncryptionMode,
+		EnableHostNetworkAcceleration: o.enableHostNetworkAcceleration,
 	}
 	tunnelOFPort := uint32(0)
 	if networkConfig.NeedsTunnelInterface() {
@@ -2751,7 +2757,7 @@ func Test_client_ReplayFlows(t *testing.T) {
 	expectedFlows = append(expectedFlows, multicastInitFlows(true)...)
 	expectedFlows = append(expectedFlows, networkPolicyInitFlows(true, false)...)
 	expectedFlows = append(expectedFlows, podConnectivityInitFlows(config.TrafficEncapModeEncap, config.TrafficEncryptionModeNone, false, true, true, true)...)
-	expectedFlows = append(expectedFlows, serviceInitFlows(true, true, false, false)...)
+	expectedFlows = append(expectedFlows, serviceInitFlows(true, true, false, false, false, config.TrafficEncapModeEncap)...)
 
 	addFlowInCache := func(cache *flowCategoryCache, cacheKey string, flows []binding.Flow) {
 		fCache := flowMessageCache{}

--- a/pkg/agent/openflow/pipeline.go
+++ b/pkg/agent/openflow/pipeline.go
@@ -727,18 +727,25 @@ func (f *featureService) snatConntrackFlows() []binding.Flow {
 	var flows []binding.Flow
 	for _, ipProtocol := range f.ipProtocols {
 		gatewayIP := f.gatewayIPs[ipProtocol]
-		// virtualIP is used as SNAT IP when a request's source IP is gateway IP and we need to forward it back to
-		// gateway interface to avoid asymmetry path.
-		virtualIP := f.virtualIPs[ipProtocol]
+		// snatIP is used as SNAT IP when a request's source IP is gateway IP and we need to forward it back to
+		// gateway interface to avoid asymmetry path. In noEncap or hybrid mode with hostNetworkAcceleration enabled,
+		// the Pod CIDR network address is used so that SNAT packets can be delivered to the Node via its uplink
+		// interface. In other cases, the virtual IP is used.
+		snatIP := f.virtualIPs[ipProtocol]
+		if f.hostNetworkAccelerationEnabled {
+			if podCIDR := f.podCIDRs[ipProtocol]; podCIDR != nil {
+				snatIP = podCIDR.IP.Mask(podCIDR.Mask)
+			}
+		}
 		flows = append(flows,
 			// SNAT should be performed for the following connections:
 			// - Hairpin Service connection initiated through a local Pod, and SNAT should be performed with the Antrea
 			//   gateway IP.
 			// - Hairpin Service connection initiated through the Antrea gateway, and SNAT should be performed with a
-			//   virtual IP.
+			//   virtual IP (or Pod CIDR network address when hostNetworkAcceleration is enabled in noEncap/hybrid mode).
 			// - Nodeport / LoadBalancer connection initiated through the Antrea gateway and externalTrafficPolicy is
 			//   Cluster, if the selected Endpoint is not on local Node, then SNAT should be performed with the Antrea
-			//   gateway IP.
+			//   gateway IP when traffic mode is encap.
 			// Note that, for Service connections that require SNAT, ServiceCTMark is loaded in SNAT CT zone when performing
 			// SNAT since ServiceCTMark loaded in DNAT CT zone cannot be read in SNAT CT zone. For Service connections,
 			// ServiceCTMark (loaded in DNAT / SNAT CT zone) is used to bypass ConntrackCommitTable which is used to commit
@@ -756,7 +763,7 @@ func (f *featureService) snatConntrackFlows() []binding.Flow {
 				MatchRegMark(FromGatewayRegMark).
 				MatchCTMark(HairpinCTMark).
 				Action().CT(true, SNATTable.GetNext(), f.snatCtZones[ipProtocol], nil).
-				SNAT(&binding.IPRange{StartIP: virtualIP, EndIP: virtualIP}, nil).
+				SNAT(&binding.IPRange{StartIP: snatIP, EndIP: snatIP}, nil).
 				LoadToCtMark(ServiceCTMark, ConnSNATCTMark, HairpinCTMark).
 				CTDone().
 				Done(),
@@ -764,7 +771,7 @@ func (f *featureService) snatConntrackFlows() []binding.Flow {
 			UnSNATTable.ofTable.BuildFlow(priorityNormal).
 				Cookie(cookieID).
 				MatchProtocol(ipProtocol).
-				MatchDstIP(virtualIP).
+				MatchDstIP(snatIP).
 				Action().CT(false, UnSNATTable.GetNext(), f.snatCtZones[ipProtocol], nil).
 				NAT().
 				CTDone().

--- a/pkg/agent/openflow/service.go
+++ b/pkg/agent/openflow/service.go
@@ -42,6 +42,7 @@ type featureService struct {
 	snatCtZones            map[binding.Protocol]int
 	gatewayMAC             net.HardwareAddr
 	nodePortAddresses      map[binding.Protocol][]net.IP
+	podCIDRs               map[binding.Protocol]*net.IPNet
 	serviceCIDRs           map[binding.Protocol]net.IPNet
 	networkConfig          *config.NetworkConfig
 	gatewayPort            uint32
@@ -51,7 +52,10 @@ type featureService struct {
 	proxyAll              bool
 	enableDSR             bool
 	connectUplinkToBridge bool
-	ctZoneSrcField        *binding.RegField
+
+	hostNetworkAccelerationEnabled bool
+
+	ctZoneSrcField *binding.RegField
 
 	category cookie.Category
 }
@@ -79,6 +83,7 @@ func newFeatureService(
 	dnatCtZones := make(map[binding.Protocol]int)
 	snatCtZones := make(map[binding.Protocol]int)
 	nodePortAddresses := make(map[binding.Protocol][]net.IP)
+	podCIDRs := make(map[binding.Protocol]*net.IPNet)
 	serviceCIDRs := make(map[binding.Protocol]net.IPNet)
 	for _, ipProtocol := range ipProtocols {
 		switch ipProtocol {
@@ -89,6 +94,7 @@ func newFeatureService(
 			dnatCtZones[ipProtocol] = CtZone
 			snatCtZones[ipProtocol] = SNATCtZone
 			nodePortAddresses[ipProtocol] = serviceConfig.NodePortAddressesIPv4
+			podCIDRs[ipProtocol] = nodeConfig.PodIPv4CIDR
 			if serviceConfig.ServiceCIDR != nil {
 				serviceCIDRs[ipProtocol] = *serviceConfig.ServiceCIDR
 			}
@@ -99,36 +105,42 @@ func newFeatureService(
 			dnatCtZones[ipProtocol] = CtZoneV6
 			snatCtZones[ipProtocol] = SNATCtZoneV6
 			nodePortAddresses[ipProtocol] = serviceConfig.NodePortAddressesIPv6
+			podCIDRs[ipProtocol] = nodeConfig.PodIPv6CIDR
 			if serviceConfig.ServiceCIDRv6 != nil {
 				serviceCIDRs[ipProtocol] = *serviceConfig.ServiceCIDRv6
 			}
 		}
 	}
-
+	hostNetworkAccelerationEnabled := networkConfig.EnableHostNetworkAcceleration &&
+		proxyAll &&
+		(networkConfig.TrafficEncapMode == config.TrafficEncapModeNoEncap ||
+			networkConfig.TrafficEncapMode == config.TrafficEncapModeHybrid)
 	return &featureService{
-		cookieAllocator:        cookieAllocator,
-		nodeIPChecker:          nodeIPChecker,
-		ipProtocols:            ipProtocols,
-		bridge:                 bridge,
-		cachedFlows:            newFlowCategoryCache(),
-		groupCache:             sync.Map{},
-		gatewayIPs:             gatewayIPs,
-		virtualIPs:             virtualIPs,
-		virtualNodePortDNATIPs: virtualNodePortDNATIPs,
-		dnatCtZones:            dnatCtZones,
-		snatCtZones:            snatCtZones,
-		nodePortAddresses:      nodePortAddresses,
-		serviceCIDRs:           serviceCIDRs,
-		gatewayMAC:             nodeConfig.GatewayConfig.MAC,
-		gatewayPort:            nodeConfig.GatewayConfig.OFPort,
-		networkConfig:          networkConfig,
-		enableAntreaPolicy:     enableAntreaPolicy,
-		enableProxy:            enableProxy,
-		proxyAll:               proxyAll,
-		enableDSR:              enableDSR,
-		connectUplinkToBridge:  connectUplinkToBridge,
-		ctZoneSrcField:         getZoneSrcField(connectUplinkToBridge),
-		category:               cookie.Service,
+		cookieAllocator:                cookieAllocator,
+		nodeIPChecker:                  nodeIPChecker,
+		ipProtocols:                    ipProtocols,
+		bridge:                         bridge,
+		cachedFlows:                    newFlowCategoryCache(),
+		groupCache:                     sync.Map{},
+		gatewayIPs:                     gatewayIPs,
+		virtualIPs:                     virtualIPs,
+		virtualNodePortDNATIPs:         virtualNodePortDNATIPs,
+		dnatCtZones:                    dnatCtZones,
+		snatCtZones:                    snatCtZones,
+		nodePortAddresses:              nodePortAddresses,
+		podCIDRs:                       podCIDRs,
+		serviceCIDRs:                   serviceCIDRs,
+		gatewayMAC:                     nodeConfig.GatewayConfig.MAC,
+		gatewayPort:                    nodeConfig.GatewayConfig.OFPort,
+		networkConfig:                  networkConfig,
+		enableAntreaPolicy:             enableAntreaPolicy,
+		enableProxy:                    enableProxy,
+		proxyAll:                       proxyAll,
+		enableDSR:                      enableDSR,
+		connectUplinkToBridge:          connectUplinkToBridge,
+		hostNetworkAccelerationEnabled: hostNetworkAccelerationEnabled,
+		ctZoneSrcField:                 getZoneSrcField(connectUplinkToBridge),
+		category:                       cookie.Service,
 	}
 }
 

--- a/pkg/agent/openflow/service_test.go
+++ b/pkg/agent/openflow/service_test.go
@@ -15,37 +15,56 @@
 package openflow
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"antrea.io/antrea/pkg/agent/config"
+	"antrea.io/antrea/pkg/util/runtime"
 )
 
-func serviceInitFlows(proxyEnabled, isIPv4, proxyAllEnabled, dsrEnabled bool) []string {
+func serviceInitFlows(proxyEnabled, isIPv4, proxyAllEnabled, dsrEnabled, hostNetworkAccelerationEnabled bool, trafficEncapMode config.TrafficEncapModeType) []string {
 	if !proxyEnabled {
 		return []string{
 			"cookie=0x1030000000000, table=DNAT, priority=200,ip,nw_dst=10.96.0.0/16 actions=set_field:0x8001->reg1,set_field:0x200000/0x600000->reg0,goto_table:ConntrackCommit",
 			"cookie=0x1030000000000, table=DNAT, priority=200,ipv6,ipv6_dst=fec0:10:96::/64 actions=set_field:0x8001->reg1,set_field:0x200000/0x600000->reg0,goto_table:ConntrackCommit",
 		}
 	}
-	var flows []string
+	// snatIP is the SNAT address used for hairpin connections initiated through the Antrea
+	// gateway. When hostNetworkAcceleration is enabled in noEncap/hybrid mode, it is the Pod
+	// CIDR network address so that SNAT packets can be delivered via the uplink interface.
+	// fakePodIPv4CIDR is "10.10.0.1/24" so its network address is "10.10.0.0".
+	// fakePodIPv6CIDR is "fec0:10:10::1/80" so its network address is "fec0:10:10::".
+	snatIPv4 := "169.254.0.253"
+	snatIPv6 := "fc01::aabb:ccdd:eeff"
+	if hostNetworkAccelerationEnabled {
+		snatIPv4 = "10.10.0.0"
+		snatIPv6 = "fec0:10:10::"
+	}
+	flows := []string{
+		"cookie=0x1030000000000, table=SessionAffinity, priority=0 actions=set_field:0x10000/0x70000->reg4",
+		"cookie=0x1030000000000, table=EndpointDNAT, priority=200,reg0=0x4000/0x4000 actions=controller(id=32776,reason=no_match,userdata=04,max_len=65535)",
+		"cookie=0x1030000000000, table=EndpointDNAT, priority=190,reg4=0x20000/0x70000 actions=set_field:0x10000/0x70000->reg4,resubmit:ServiceLB",
+		"cookie=0x1030000000000, table=L3Forwarding, priority=190,ct_mark=0x10/0x10,reg0=0x202/0x20f actions=set_field:0a:00:00:00:00:01->eth_dst,set_field:0x20/0xf0->reg0,goto_table:L3DecTTL",
+		"cookie=0x1030000000000, table=Output, priority=210,ct_mark=0x40/0x40,reg0=0x200000/0x600000 actions=IN_PORT",
+	}
 	if isIPv4 {
-		flows = []string{
-			"cookie=0x1030000000000, table=UnSNAT, priority=200,ip,nw_dst=169.254.0.253 actions=ct(table=ConntrackZone,zone=65521,nat)",
+		flows = append(flows,
+			fmt.Sprintf("cookie=0x1030000000000, table=UnSNAT, priority=200,ip,nw_dst=%s actions=ct(table=ConntrackZone,zone=65521,nat)", snatIPv4),
 			"cookie=0x1030000000000, table=UnSNAT, priority=200,ip,nw_dst=10.10.0.1 actions=ct(table=ConntrackZone,zone=65521,nat)",
 			"cookie=0x1030000000000, table=ConntrackState, priority=190,ct_state=-new+trk,ct_mark=0x10/0x10,ip actions=set_field:0x200/0x200->reg0,goto_table:AntreaPolicyEgressRule",
-			"cookie=0x1030000000000, table=SessionAffinity, priority=0 actions=set_field:0x10000/0x70000->reg4",
-			"cookie=0x1030000000000, table=EndpointDNAT, priority=200,reg0=0x4000/0x4000 actions=controller(id=32776,reason=no_match,userdata=04,max_len=65535)",
-			"cookie=0x1030000000000, table=EndpointDNAT, priority=190,reg4=0x20000/0x70000 actions=set_field:0x10000/0x70000->reg4,resubmit:ServiceLB",
-			"cookie=0x1030000000000, table=L3Forwarding, priority=190,ct_mark=0x10/0x10,reg0=0x202/0x20f actions=set_field:0a:00:00:00:00:01->eth_dst,set_field:0x20/0xf0->reg0,goto_table:L3DecTTL",
 			"cookie=0x1030000000000, table=SNATMark, priority=200,ct_state=+new+trk,ip,reg0=0x22/0xff actions=ct(commit,table=SNAT,zone=65520,exec(set_field:0x20/0x20->ct_mark,set_field:0x40/0x40->ct_mark,move:NXM_NX_REG0[0..3]->NXM_NX_CT_MARK[0..3]))",
-			"cookie=0x1030000000000, table=SNATMark, priority=200,ct_state=+new+trk,ip,reg0=0x12/0xff,reg4=0x200000/0x2200000 actions=ct(commit,table=SNAT,zone=65520,exec(set_field:0x20/0x20->ct_mark,move:NXM_NX_REG0[0..3]->NXM_NX_CT_MARK[0..3]))",
-			"cookie=0x1030000000000, table=SNAT, priority=200,ct_state=+new+trk,ct_mark=0x40/0x40,ip,reg0=0x2/0xf actions=ct(commit,table=L2ForwardingCalc,zone=65521,nat(src=169.254.0.253),exec(set_field:0x10/0x10->ct_mark,set_field:0x20/0x20->ct_mark,set_field:0x40/0x40->ct_mark))",
+			fmt.Sprintf("cookie=0x1030000000000, table=SNAT, priority=200,ct_state=+new+trk,ct_mark=0x40/0x40,ip,reg0=0x2/0xf actions=ct(commit,table=L2ForwardingCalc,zone=65521,nat(src=%s),exec(set_field:0x10/0x10->ct_mark,set_field:0x20/0x20->ct_mark,set_field:0x40/0x40->ct_mark))", snatIPv4),
 			"cookie=0x1030000000000, table=SNAT, priority=200,ct_state=+new+trk,ct_mark=0x40/0x40,ip,reg0=0x3/0xf actions=ct(commit,table=L2ForwardingCalc,zone=65521,nat(src=10.10.0.1),exec(set_field:0x10/0x10->ct_mark,set_field:0x20/0x20->ct_mark,set_field:0x40/0x40->ct_mark))",
 			"cookie=0x1030000000000, table=SNAT, priority=190,ct_state=+new+trk,ct_mark=0x20/0x20,ip,reg0=0x2/0xf actions=ct(commit,table=L2ForwardingCalc,zone=65521,nat(src=10.10.0.1),exec(set_field:0x10/0x10->ct_mark,set_field:0x20/0x20->ct_mark))",
 			"cookie=0x1030000000000, table=SNAT, priority=200,ct_state=-new-rpl+trk,ct_mark=0x20/0x20,ip actions=ct(table=L2ForwardingCalc,zone=65521,nat)",
-			"cookie=0x1030000000000, table=Output, priority=210,ct_mark=0x40/0x40,reg0=0x200000/0x600000 actions=IN_PORT",
+		)
+		if trafficEncapMode.SupportsEncap() {
+			flows = append(flows, "cookie=0x1030000000000, table=SNATMark, priority=200,ct_state=+new+trk,ip,reg0=0x12/0xff,reg4=0x200000/0x2200000 actions=ct(commit,table=SNAT,zone=65520,exec(set_field:0x20/0x20->ct_mark,move:NXM_NX_REG0[0..3]->NXM_NX_CT_MARK[0..3]))")
+		}
+		if trafficEncapMode.SupportsNoEncap() && runtime.IsWindowsPlatform() {
+			flows = append(flows, "cookie=0x1030000000000, table=SNATMark, priority=200,ct_state=+new+trk,ip,reg0=0x42/0xff,reg4=0x200000/0x2200000 actions=ct(commit,table=SNAT,zone=65520,exec(set_field:0x20/0x20->ct_mark,move:NXM_NX_REG0[0..3]->NXM_NX_CT_MARK[0..3]))")
 		}
 		if proxyAllEnabled {
 			flows = append(flows,
@@ -64,21 +83,21 @@ func serviceInitFlows(proxyEnabled, isIPv4, proxyAllEnabled, dsrEnabled bool) []
 			)
 		}
 	} else {
-		flows = []string{
-			"cookie=0x1030000000000, table=UnSNAT, priority=200,ipv6,ipv6_dst=fc01::aabb:ccdd:eeff actions=ct(table=ConntrackZone,zone=65511,nat)",
+		flows = append(flows,
+			fmt.Sprintf("cookie=0x1030000000000, table=UnSNAT, priority=200,ipv6,ipv6_dst=%s actions=ct(table=ConntrackZone,zone=65511,nat)", snatIPv6),
 			"cookie=0x1030000000000, table=UnSNAT, priority=200,ipv6,ipv6_dst=fec0:10:10::1 actions=ct(table=ConntrackZone,zone=65511,nat)",
 			"cookie=0x1030000000000, table=ConntrackState, priority=190,ct_state=-new+trk,ct_mark=0x10/0x10,ipv6 actions=set_field:0x200/0x200->reg0,goto_table:AntreaPolicyEgressRule",
-			"cookie=0x1030000000000, table=SessionAffinity, priority=0 actions=set_field:0x10000/0x70000->reg4",
-			"cookie=0x1030000000000, table=EndpointDNAT, priority=200,reg0=0x4000/0x4000 actions=controller(id=32776,reason=no_match,userdata=04,max_len=65535)",
-			"cookie=0x1030000000000, table=EndpointDNAT, priority=190,reg4=0x20000/0x70000 actions=set_field:0x10000/0x70000->reg4,resubmit:ServiceLB",
-			"cookie=0x1030000000000, table=L3Forwarding, priority=190,ct_mark=0x10/0x10,reg0=0x202/0x20f actions=set_field:0a:00:00:00:00:01->eth_dst,set_field:0x20/0xf0->reg0,goto_table:L3DecTTL",
 			"cookie=0x1030000000000, table=SNATMark, priority=200,ct_state=+new+trk,ipv6,reg0=0x22/0xff actions=ct(commit,table=SNAT,zone=65510,exec(set_field:0x20/0x20->ct_mark,set_field:0x40/0x40->ct_mark,move:NXM_NX_REG0[0..3]->NXM_NX_CT_MARK[0..3]))",
-			"cookie=0x1030000000000, table=SNATMark, priority=200,ct_state=+new+trk,ipv6,reg0=0x12/0xff,reg4=0x200000/0x2200000 actions=ct(commit,table=SNAT,zone=65510,exec(set_field:0x20/0x20->ct_mark,move:NXM_NX_REG0[0..3]->NXM_NX_CT_MARK[0..3]))",
-			"cookie=0x1030000000000, table=SNAT, priority=200,ct_state=+new+trk,ct_mark=0x40/0x40,ipv6,reg0=0x2/0xf actions=ct(commit,table=L2ForwardingCalc,zone=65511,nat(src=fc01::aabb:ccdd:eeff),exec(set_field:0x10/0x10->ct_mark,set_field:0x20/0x20->ct_mark,set_field:0x40/0x40->ct_mark))",
+			fmt.Sprintf("cookie=0x1030000000000, table=SNAT, priority=200,ct_state=+new+trk,ct_mark=0x40/0x40,ipv6,reg0=0x2/0xf actions=ct(commit,table=L2ForwardingCalc,zone=65511,nat(src=%s),exec(set_field:0x10/0x10->ct_mark,set_field:0x20/0x20->ct_mark,set_field:0x40/0x40->ct_mark))", snatIPv6),
 			"cookie=0x1030000000000, table=SNAT, priority=200,ct_state=+new+trk,ct_mark=0x40/0x40,ipv6,reg0=0x3/0xf actions=ct(commit,table=L2ForwardingCalc,zone=65511,nat(src=fec0:10:10::1),exec(set_field:0x10/0x10->ct_mark,set_field:0x20/0x20->ct_mark,set_field:0x40/0x40->ct_mark))",
 			"cookie=0x1030000000000, table=SNAT, priority=200,ct_state=-new-rpl+trk,ct_mark=0x20/0x20,ipv6 actions=ct(table=L2ForwardingCalc,zone=65511,nat)",
 			"cookie=0x1030000000000, table=SNAT, priority=190,ct_state=+new+trk,ct_mark=0x20/0x20,ipv6,reg0=0x2/0xf actions=ct(commit,table=L2ForwardingCalc,zone=65511,nat(src=fec0:10:10::1),exec(set_field:0x10/0x10->ct_mark,set_field:0x20/0x20->ct_mark))",
-			"cookie=0x1030000000000, table=Output, priority=210,ct_mark=0x40/0x40,reg0=0x200000/0x600000 actions=IN_PORT",
+		)
+		if trafficEncapMode.SupportsEncap() {
+			flows = append(flows, "cookie=0x1030000000000, table=SNATMark, priority=200,ct_state=+new+trk,ipv6,reg0=0x12/0xff,reg4=0x200000/0x2200000 actions=ct(commit,table=SNAT,zone=65510,exec(set_field:0x20/0x20->ct_mark,move:NXM_NX_REG0[0..3]->NXM_NX_CT_MARK[0..3]))")
+		}
+		if trafficEncapMode.SupportsNoEncap() && runtime.IsWindowsPlatform() {
+			flows = append(flows, "cookie=0x1030000000000, table=SNATMark, priority=200,ct_state=+new+trk,ipv6,reg0=0x42/0xff,reg4=0x200000/0x2200000 actions=ct(commit,table=SNAT,zone=65510,exec(set_field:0x20/0x20->ct_mark,move:NXM_NX_REG0[0..3]->NXM_NX_CT_MARK[0..3]))")
 		}
 		if proxyAllEnabled {
 			flows = append(flows,
@@ -108,59 +127,95 @@ func serviceInitFlows(proxyEnabled, isIPv4, proxyAllEnabled, dsrEnabled bool) []
 
 func Test_featureService_initFlows(t *testing.T) {
 	testCases := []struct {
-		name          string
-		enableIPv4    bool
-		enableIPv6    bool
-		clientOptions []clientOptionsFn
-		expectedFlows []string
+		name             string
+		enableIPv4       bool
+		enableIPv6       bool
+		trafficEncapMode config.TrafficEncapModeType
+		clientOptions    []clientOptionsFn
+		expectedFlows    []string
 	}{
 		{
-			name:          "IPv4,Proxy",
-			enableIPv4:    true,
-			clientOptions: []clientOptionsFn{enableProxy},
-			expectedFlows: serviceInitFlows(true, true, false, false),
+			name:             "IPv4,Encap,Proxy",
+			enableIPv4:       true,
+			trafficEncapMode: config.TrafficEncapModeEncap,
+			clientOptions:    []clientOptionsFn{enableProxy},
+			expectedFlows:    serviceInitFlows(true, true, false, false, false, config.TrafficEncapModeEncap),
 		},
 		{
-			name:          "IPv6,Proxy",
-			enableIPv6:    true,
-			clientOptions: []clientOptionsFn{enableProxy},
-			expectedFlows: serviceInitFlows(true, false, false, false),
+			name:             "IPv6,Encap,Proxy",
+			enableIPv6:       true,
+			trafficEncapMode: config.TrafficEncapModeEncap,
+			clientOptions:    []clientOptionsFn{enableProxy},
+			expectedFlows:    serviceInitFlows(true, false, false, false, false, config.TrafficEncapModeEncap),
 		},
 		{
-			name:          "IPv4,ProxyAll",
-			enableIPv4:    true,
-			clientOptions: []clientOptionsFn{enableProxyAll},
-			expectedFlows: serviceInitFlows(true, true, true, false),
+			name:             "IPv4,Encap,ProxyAll",
+			enableIPv4:       true,
+			trafficEncapMode: config.TrafficEncapModeEncap,
+			clientOptions:    []clientOptionsFn{enableProxyAll},
+			expectedFlows:    serviceInitFlows(true, true, true, false, false, config.TrafficEncapModeEncap),
 		},
 		{
-			name:          "IPv6,ProxyAll",
-			enableIPv6:    true,
-			clientOptions: []clientOptionsFn{enableProxyAll},
-			expectedFlows: serviceInitFlows(true, false, true, false),
+			name:             "IPv6,Encap,ProxyAll",
+			enableIPv6:       true,
+			trafficEncapMode: config.TrafficEncapModeEncap,
+			clientOptions:    []clientOptionsFn{enableProxyAll},
+			expectedFlows:    serviceInitFlows(true, false, true, false, false, config.TrafficEncapModeEncap),
 		},
 		{
-			name:          "IPv4,DSR",
-			enableIPv4:    true,
-			clientOptions: []clientOptionsFn{enableDSR},
-			expectedFlows: serviceInitFlows(true, true, true, true),
+			name:             "IPv4,Encap,DSR",
+			enableIPv4:       true,
+			trafficEncapMode: config.TrafficEncapModeEncap,
+			clientOptions:    []clientOptionsFn{enableDSR},
+			expectedFlows:    serviceInitFlows(true, true, true, true, false, config.TrafficEncapModeEncap),
 		},
 		{
-			name:          "IPv6,DSR",
-			enableIPv6:    true,
-			clientOptions: []clientOptionsFn{enableDSR},
-			expectedFlows: serviceInitFlows(true, false, true, true),
+			name:             "IPv6,Encap,DSR",
+			enableIPv6:       true,
+			trafficEncapMode: config.TrafficEncapModeEncap,
+			clientOptions:    []clientOptionsFn{enableDSR},
+			expectedFlows:    serviceInitFlows(true, false, true, true, false, config.TrafficEncapModeEncap),
 		},
 		{
-			name:          "No Proxy",
-			enableIPv4:    true,
-			enableIPv6:    true,
-			clientOptions: []clientOptionsFn{disableProxy},
-			expectedFlows: serviceInitFlows(false, true, false, false),
+			name:             "Encap,No Proxy",
+			enableIPv4:       true,
+			enableIPv6:       true,
+			trafficEncapMode: config.TrafficEncapModeEncap,
+			clientOptions:    []clientOptionsFn{disableProxy},
+			expectedFlows:    serviceInitFlows(false, true, false, false, false, config.TrafficEncapModeEncap),
+		},
+		{
+			name:             "IPv4,NoEncap,ProxyAll,HostNetworkAcceleration",
+			enableIPv4:       true,
+			trafficEncapMode: config.TrafficEncapModeNoEncap,
+			clientOptions:    []clientOptionsFn{enableProxyAll, enableHostNetworkAcceleration},
+			expectedFlows:    serviceInitFlows(true, true, true, false, true, config.TrafficEncapModeNoEncap),
+		},
+		{
+			name:             "IPv6,NoEncap,ProxyAll,HostNetworkAcceleration",
+			enableIPv6:       true,
+			trafficEncapMode: config.TrafficEncapModeNoEncap,
+			clientOptions:    []clientOptionsFn{enableProxyAll, enableHostNetworkAcceleration},
+			expectedFlows:    serviceInitFlows(true, false, true, false, true, config.TrafficEncapModeNoEncap),
+		},
+		{
+			name:             "IPv4,Hybrid,ProxyAll,HostNetworkAcceleration",
+			enableIPv4:       true,
+			trafficEncapMode: config.TrafficEncapModeHybrid,
+			clientOptions:    []clientOptionsFn{enableProxyAll, enableHostNetworkAcceleration},
+			expectedFlows:    serviceInitFlows(true, true, true, false, true, config.TrafficEncapModeHybrid),
+		},
+		{
+			name:             "IPv6,Hybrid,ProxyAll,HostNetworkAcceleration",
+			enableIPv6:       true,
+			trafficEncapMode: config.TrafficEncapModeHybrid,
+			clientOptions:    []clientOptionsFn{enableProxyAll, enableHostNetworkAcceleration},
+			expectedFlows:    serviceInitFlows(true, false, true, false, true, config.TrafficEncapModeHybrid),
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			fc := newFakeClient(nil, tc.enableIPv4, tc.enableIPv6, config.K8sNode, config.TrafficEncapModeEncap, tc.clientOptions...)
+			fc := newFakeClient(nil, tc.enableIPv4, tc.enableIPv6, config.K8sNode, tc.trafficEncapMode, tc.clientOptions...)
 			defer resetPipelines()
 
 			flows := getFlowStrings(fc.featureService.initFlows())

--- a/pkg/agent/route/route_linux.go
+++ b/pkg/agent/route/route_linux.go
@@ -1545,6 +1545,11 @@ func (c *Client) initServiceIPRoutes() error {
 		if err := c.addVirtualServiceIPRoute(false); err != nil {
 			return err
 		}
+		if c.hostNetworkAccelerationEnabled {
+			if err := c.addPodCIDRNetworkNeighbor(false); err != nil {
+				return err
+			}
+		}
 		if err := c.addVirtualNodePortDNATIPRoute(false); err != nil {
 			return err
 		}
@@ -1552,6 +1557,11 @@ func (c *Client) initServiceIPRoutes() error {
 	if c.networkConfig.IPv6Enabled {
 		if err := c.addVirtualServiceIPRoute(true); err != nil {
 			return err
+		}
+		if c.hostNetworkAccelerationEnabled {
+			if err := c.addPodCIDRNetworkNeighbor(true); err != nil {
+				return err
+			}
 		}
 		if err := c.addVirtualNodePortDNATIPRoute(true); err != nil {
 			return err
@@ -1564,6 +1574,32 @@ func (c *Client) initServiceIPRoutes() error {
 			}
 		}
 	})
+	return nil
+}
+
+// addPodCIDRNetworkNeighbor installs a neighbor entry for the Pod CIDR network address to ensure packets destined to
+// that address are forwarded to the OVS pipeline via the Antrea gateway without querying the destination MAC address
+// through ARP/NDP query. The on-link route for the Pod CIDR is already added by the NodeController, so no additional
+// route is needed here.
+func (c *Client) addPodCIDRNetworkNeighbor(isIPv6 bool) error {
+	var podCIDR *net.IPNet
+	if isIPv6 {
+		podCIDR = c.nodeConfig.PodIPv6CIDR
+	} else {
+		podCIDR = c.nodeConfig.PodIPv4CIDR
+	}
+	if podCIDR == nil {
+		return fmt.Errorf("Pod CIDR is not configured")
+	}
+	networkIP := podCIDR.IP.Mask(podCIDR.Mask)
+	if networkIP == nil {
+		return fmt.Errorf("failed to compute network IP from Pod CIDR %s", podCIDR.String())
+	}
+	neigh := generateNeigh(networkIP, c.nodeConfig.GatewayConfig.LinkIndex)
+	if err := c.netlink.NeighSet(neigh); err != nil {
+		return fmt.Errorf("failed to add neighbor for Pod CIDR network IP %s: %w", networkIP, err)
+	}
+	c.serviceNeighbors.Store(networkIP.String(), neigh)
 	return nil
 }
 

--- a/pkg/agent/route/route_linux_test.go
+++ b/pkg/agent/route/route_linux_test.go
@@ -1254,6 +1254,7 @@ func TestInitIPRoutes(t *testing.T) {
 
 	tests := []struct {
 		name          string
+		proxyAll      bool
 		networkConfig *config.NetworkConfig
 		nodeConfig    *config.NodeConfig
 		expectedCalls func(mockNetlink *netlinktest.MockInterfaceMockRecorder)
@@ -1301,10 +1302,11 @@ func TestInitIPRoutes(t *testing.T) {
 
 func TestInitServiceIPRoutes(t *testing.T) {
 	tests := []struct {
-		name          string
-		networkConfig *config.NetworkConfig
-		nodeConfig    *config.NodeConfig
-		expectedCalls func(mockNetlink *netlinktest.MockInterfaceMockRecorder)
+		name                           string
+		hostNetworkAccelerationEnabled bool
+		networkConfig                  *config.NetworkConfig
+		nodeConfig                     *config.NodeConfig
+		expectedCalls                  func(mockNetlink *netlinktest.MockInterfaceMockRecorder)
 	}{
 		{
 			name: "encap",
@@ -1367,6 +1369,147 @@ func TestInitServiceIPRoutes(t *testing.T) {
 				})
 			},
 		},
+		{
+			name: "noEncap without hostNetworkAcceleration",
+			networkConfig: &config.NetworkConfig{
+				TrafficEncapMode: config.TrafficEncapModeNoEncap,
+				IPv4Enabled:      true,
+				IPv6Enabled:      true,
+			},
+			nodeConfig: &config.NodeConfig{
+				PodIPv4CIDR:   ip.MustParseCIDR("10.244.0.0/24"),
+				PodIPv6CIDR:   ip.MustParseCIDR("2001:db8:244::/64"),
+				GatewayConfig: &config.GatewayConfig{Name: "antrea-gw0", LinkIndex: 10},
+			},
+			expectedCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
+				mockNetlink.NeighSet(&netlink.Neigh{
+					LinkIndex:    10,
+					Family:       netlink.FAMILY_V4,
+					State:        netlink.NUD_PERMANENT,
+					IP:           config.VirtualServiceIPv4,
+					HardwareAddr: globalVMAC,
+				})
+				mockNetlink.RouteReplace(&netlink.Route{
+					Dst: &net.IPNet{
+						IP:   config.VirtualServiceIPv4,
+						Mask: net.CIDRMask(32, 32),
+					},
+					Scope:     netlink.SCOPE_LINK,
+					LinkIndex: 10,
+				})
+				mockNetlink.RouteReplace(&netlink.Route{
+					Dst: &net.IPNet{
+						IP:   config.VirtualNodePortDNATIPv4,
+						Mask: net.CIDRMask(32, 32),
+					},
+					Gw:        config.VirtualServiceIPv4,
+					Scope:     netlink.SCOPE_UNIVERSE,
+					LinkIndex: 10,
+				})
+				mockNetlink.NeighSet(&netlink.Neigh{
+					LinkIndex:    10,
+					Family:       netlink.FAMILY_V6,
+					State:        netlink.NUD_PERMANENT,
+					IP:           config.VirtualServiceIPv6,
+					HardwareAddr: globalVMAC,
+				})
+				mockNetlink.RouteReplace(&netlink.Route{
+					Dst: &net.IPNet{
+						IP:   config.VirtualServiceIPv6,
+						Mask: net.CIDRMask(128, 128),
+					},
+					Scope:     netlink.SCOPE_LINK,
+					LinkIndex: 10,
+				})
+				mockNetlink.RouteReplace(&netlink.Route{
+					Dst: &net.IPNet{
+						IP:   config.VirtualNodePortDNATIPv6,
+						Mask: net.CIDRMask(128, 128),
+					},
+					Gw:        config.VirtualServiceIPv6,
+					Scope:     netlink.SCOPE_UNIVERSE,
+					LinkIndex: 10,
+				})
+			},
+		},
+		{
+			name:                           "noEncap with hostNetworkAcceleration",
+			hostNetworkAccelerationEnabled: true,
+			networkConfig: &config.NetworkConfig{
+				TrafficEncapMode: config.TrafficEncapModeNoEncap,
+				IPv4Enabled:      true,
+				IPv6Enabled:      true,
+			},
+			nodeConfig: &config.NodeConfig{
+				PodIPv4CIDR:   ip.MustParseCIDR("10.244.0.0/24"),
+				PodIPv6CIDR:   ip.MustParseCIDR("2001:db8:244::/64"),
+				GatewayConfig: &config.GatewayConfig{Name: "antrea-gw0", LinkIndex: 10},
+			},
+			expectedCalls: func(mockNetlink *netlinktest.MockInterfaceMockRecorder) {
+				mockNetlink.NeighSet(&netlink.Neigh{
+					LinkIndex:    10,
+					Family:       netlink.FAMILY_V4,
+					State:        netlink.NUD_PERMANENT,
+					IP:           config.VirtualServiceIPv4,
+					HardwareAddr: globalVMAC,
+				})
+				mockNetlink.RouteReplace(&netlink.Route{
+					Dst: &net.IPNet{
+						IP:   config.VirtualServiceIPv4,
+						Mask: net.CIDRMask(32, 32),
+					},
+					Scope:     netlink.SCOPE_LINK,
+					LinkIndex: 10,
+				})
+				mockNetlink.NeighSet(&netlink.Neigh{
+					LinkIndex:    10,
+					Family:       netlink.FAMILY_V4,
+					State:        netlink.NUD_PERMANENT,
+					IP:           net.ParseIP("10.244.0.0").To4(),
+					HardwareAddr: globalVMAC,
+				})
+				mockNetlink.RouteReplace(&netlink.Route{
+					Dst: &net.IPNet{
+						IP:   config.VirtualNodePortDNATIPv4,
+						Mask: net.CIDRMask(32, 32),
+					},
+					Gw:        config.VirtualServiceIPv4,
+					Scope:     netlink.SCOPE_UNIVERSE,
+					LinkIndex: 10,
+				})
+				mockNetlink.NeighSet(&netlink.Neigh{
+					LinkIndex:    10,
+					Family:       netlink.FAMILY_V6,
+					State:        netlink.NUD_PERMANENT,
+					IP:           config.VirtualServiceIPv6,
+					HardwareAddr: globalVMAC,
+				})
+				mockNetlink.RouteReplace(&netlink.Route{
+					Dst: &net.IPNet{
+						IP:   config.VirtualServiceIPv6,
+						Mask: net.CIDRMask(128, 128),
+					},
+					Scope:     netlink.SCOPE_LINK,
+					LinkIndex: 10,
+				})
+				mockNetlink.NeighSet(&netlink.Neigh{
+					LinkIndex:    10,
+					Family:       netlink.FAMILY_V6,
+					State:        netlink.NUD_PERMANENT,
+					IP:           net.ParseIP("2001:db8:244::").To16(),
+					HardwareAddr: globalVMAC,
+				})
+				mockNetlink.RouteReplace(&netlink.Route{
+					Dst: &net.IPNet{
+						IP:   config.VirtualNodePortDNATIPv6,
+						Mask: net.CIDRMask(128, 128),
+					},
+					Gw:        config.VirtualServiceIPv6,
+					Scope:     netlink.SCOPE_UNIVERSE,
+					LinkIndex: 10,
+				})
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1374,9 +1517,10 @@ func TestInitServiceIPRoutes(t *testing.T) {
 			mockNetlink := netlinktest.NewMockInterface(ctrl)
 			mockServiceCIDRProvider := servicecidrtest.NewMockInterface(ctrl)
 			c := &Client{netlink: mockNetlink,
-				networkConfig:       tt.networkConfig,
-				nodeConfig:          tt.nodeConfig,
-				serviceCIDRProvider: mockServiceCIDRProvider,
+				networkConfig:                  tt.networkConfig,
+				nodeConfig:                     tt.nodeConfig,
+				serviceCIDRProvider:            mockServiceCIDRProvider,
+				hostNetworkAccelerationEnabled: tt.hostNetworkAccelerationEnabled,
 			}
 			tt.expectedCalls(mockNetlink.EXPECT())
 			mockServiceCIDRProvider.EXPECT().AddEventHandler(gomock.Any())

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -742,11 +742,33 @@ func testProxyHairpin(t *testing.T, isIPv6 bool) {
 
 	// These are expected client IP.
 	expectedGatewayIP, _ := nodeGatewayIPs(1)
-	expectedVirtualIP := config.VirtualServiceIPv4.String()
+	expectedSNATIP := config.VirtualServiceIPv4.String()
 	expectedNodeIP := worker2NodeIP
 	if isIPv6 {
 		_, expectedGatewayIP = nodeGatewayIPs(1)
-		expectedVirtualIP = config.VirtualServiceIPv6.String()
+		expectedSNATIP = config.VirtualServiceIPv6.String()
+	}
+
+	// In noEncap or hybrid mode with hostNetworkAcceleration enabled, the SNAT IP for
+	// host-network intra-node hairpin connections is the Pod CIDR network address of the
+	// worker node instead of the virtual Service IP.
+	encapMode, err := data.GetEncapMode()
+	require.NoError(t, err)
+	if encapMode == config.TrafficEncapModeNoEncap || encapMode == config.TrafficEncapModeHybrid {
+		agentConf, err := data.GetAntreaAgentConf()
+		require.NoError(t, err)
+		if agentConf.HostNetworkAcceleration.Enable != nil && *agentConf.HostNetworkAcceleration.Enable {
+			workerNode := clusterInfo.nodes[1]
+			var podCIDR *net.IPNet
+			var err error
+			if isIPv6 {
+				_, podCIDR, err = net.ParseCIDR(workerNode.podV6NetworkCIDR)
+			} else {
+				_, podCIDR, err = net.ParseCIDR(workerNode.podV4NetworkCIDR)
+			}
+			require.NoError(t, err)
+			expectedSNATIP = podCIDR.IP.Mask(podCIDR.Mask).String()
+		}
 	}
 
 	agnhost := fmt.Sprintf("agnhost-%v", isIPv6)
@@ -761,7 +783,7 @@ func testProxyHairpin(t *testing.T, isIPv6 bool) {
 	createAgnhostPod(t, data, agnhostHost, node, true)
 	t.Run("HostNetwork Endpoints", func(t *testing.T) {
 		skipIfProxyAllDisabled(t, data)
-		testProxyIntraNodeHairpinCases(data, t, expectedVirtualIP, agnhostHost, clusterIPUrl, workerNodePortClusterUrl, workerNodePortLocalUrl, lbClusterUrl, lbLocalUrl)
+		testProxyIntraNodeHairpinCases(data, t, expectedSNATIP, agnhostHost, clusterIPUrl, workerNodePortClusterUrl, workerNodePortLocalUrl, lbClusterUrl, lbLocalUrl)
 		testProxyInterNodeHairpinCases(data, t, true, expectedNodeIP, nodeName(2), clusterIPUrl, worker2NodePortClusterUrl, lbClusterUrl)
 	})
 }
@@ -775,12 +797,13 @@ func testProxyHairpin(t *testing.T, isIPv6 bool) {
 //
 // If a Pod is on host network, when it accesses a ClusterIP/NodePort/LoadBalancer Service whose Endpoint is on itself
 // (this is equivalent to that a Node accesses a Cluster/NodePort/LoadBalancer whose Endpoint is host network and the
-// Endpoint is on this Node), that means a hairpin connection. A virtual IP is used to SNAT the connection to ensure
-// that the packet can be routed via Antrea gateway. The IP changes of the connection are:
+// Endpoint is on this Node), that means a hairpin connection. A virtual IP (or the Pod CIDR network address when
+// hostNetworkAcceleration is enabled in noEncap/hybrid mode) is used to SNAT the connection to ensure that the packet
+// can be routed via Antrea gateway. The IP changes of the connection are:
 // - Antrea gateway: Antrea gateway IP  -> Service IP
 // - OVS DNAT:       Antrea gateway IP  -> Node IP
-// - OVS SNAT:       virtual IP         -> Node IP
-// - Antrea gateway: virtual IP         -> Node IP
+// - OVS SNAT:       virtual IP (or Pod CIDR network address) -> Node IP
+// - Antrea gateway: virtual IP (or Pod CIDR network address) -> Node IP
 func testProxyIntraNodeHairpinCases(data *TestData, t *testing.T, expectedClientIP, pod, clusterIPUrl, nodePortClusterUrl, nodePortLocalUrl, lbClusterUrl, lbLocalUrl string) {
 	t.Run("IntraNode/ClusterIP", func(t *testing.T) {
 		clientIP, err := probeClientIPFromPod(data, pod, agnhostContainerName, clusterIPUrl)
@@ -823,12 +846,14 @@ func testProxyIntraNodeHairpinCases(data *TestData, t *testing.T, expectedClient
 // - Traffic mode: noEncap,  Endpoint network: not host network, OS: Linux (packets are routed via uplink interface)
 // - Traffic mode: noEncap,  Endpoint network: host network,     OS: Linux/Windows
 // The IP changes of the hairpin connections are:
-// - Node A Antrea gateway: Antrea gateway IP  -> Service IP
-// - OVS DNAT:              Antrea gateway IP  -> Endpoint IP
-// - OVS SNAT:              virtual IP         -> Endpoint IP
-// - Node A Antrea gateway: virtual IP         -> Endpoint IP
-// - Node A output:         Node A IP          -> Endpoint IP (another SNAT for virtual IP, otherwise reply packets can't be routed back).
-// - Node B:                Node A IP          -> Endpoint IP
+// - Node A Antrea gateway: Antrea gateway IP                       -> Service IP
+// - OVS DNAT:              Antrea gateway IP                       -> Endpoint IP
+// - OVS SNAT:              virtual IP (or Pod CIDR network address) -> Endpoint IP
+// - Node A Antrea gateway: virtual IP (or Pod CIDR network address) -> Endpoint IP
+// - Node A output:         Node A IP -> Endpoint IP (Node IP SNAT so reply can be routed back).
+// - Node B:                Node A IP -> Endpoint IP
+// Note: when hostNetworkAcceleration is enabled in noEncap or hybrid mode, the Pod CIDR network
+// address of Node A is used as the OVS SNAT IP instead of the virtual IP.
 func testProxyInterNodeHairpinCases(data *TestData, t *testing.T, hostNetwork bool, expectedClientIP, node, clusterIPUrl, nodePortClusterUrl, lbClusterUrl string) {
 	skipIfAntreaIPAMTest(t)
 	currentEncapMode, err := data.GetEncapMode()


### PR DESCRIPTION
In noEncap or hybrid mode with hostNetworkAcceleration enabled, use the Pod CIDR network address (the .0 address of the node's pod CIDR) as the SNAT IP for hairpin connections initiated through the Antrea gateway, instead of the virtual Service IP. This allows SNAT packets to be delivered to the Node via its uplink interface.

A static neighbor entry for the Pod CIDR network address is added only when this mode is active (proxyAll + noEncap/hybrid + HNA), so that packets destined to that address are forwarded to the OVS pipeline via the Antrea gateway without an ARP/NDP query. The on-link route for the Pod CIDR is already added by NodeController, so no additional route is needed here.

In all other cases (encap mode, or noEncap/hybrid without hostNetworkAcceleration), the virtual Service IP is still used.

The .0 address works well in this context: in noEncap/hybrid mode the underlay only performs L3 forwarding and does not rely on Pod CIDR semantics, so it treats .0 like any other routable address. That said, .0 is historically "special" and some underlays or future policy- enforcement layers might validate or restrict it unexpectedly. Gating the behaviour behind hostNetworkAcceleration makes the whole thing optional, which provides a safe fallback for environments where .0 causes issues in practice.

Test results:

- **Platform:** Kind (Kubernetes in Docker), 3 nodes (`kind-control-plane`, `kind-worker`, `kind-worker2`)
- **Encapsulation:** noEncap
- **Proxy:** kube-proxy is present
- **Runs:** 11 per test, trimmed mean (drop min & max, average remaining 9)

| Traffic | Test | Baseline | Patch | Delta | Change |
|---------|------|----------:|--------:|------:|-------:|
| NodePort | TCP_STREAM | 3,842.67 | 5,232.19 | +1,389.52 | **+36.2%** |
| NodePort | TCP_RR | 11,738.90 | 13,265.37 | +1,526.47 | **+13.0%** |
| NodePort | TCP_CRR | 3,124.11 | 3,087.63 | -36.48 | -1.2% |
| ExternalIP | TCP_STREAM | 3,617.60 | 4,409.01 | +791.41 | **+21.9%** |
| ExternalIP | TCP_RR | 11,589.38 | 13,569.30 | +1,979.92 | **+17.1%** |
| ExternalIP | TCP_CRR | 3,181.57 | 3,116.92 | -64.65 | -2.0% |

- **TCP_STREAM (throughput):** +36.2% on NodePort, +21.9% on ExternalIP. This patch minimum (4,187) still exceeds the Baseline average (3,843), confirming a consistent improvement across all runs.
- **TCP_RR (request-response):** +13.0% on NodePort, +17.1% on ExternalIP. Latency on established connections is noticeably reduced.
- **TCP_CRR (connect-request-response):** -1.2% / -2.0%, statistically insignificant — overlapping per-run distributions with inconsistent direction. Expected since TCP_CRR is dominated by connection setup/teardown overhead outside the scope of this patch.

