### PR TITLE
Fix panic in NodeIPsIndexFunc for Nodes without IPs

### DIFF
--- a/pkg/controller/grouping/controller.go
+++ b/pkg/controller/grouping/controller.go
@@ -69,9 +69,14 @@ func NodeIPsIndexFunc(obj interface{}) ([]string, error) {
 		return nil, nil
 	}
 
+	// We should not return an error if no IP is found as it can be a transient condition, and
+	// it would cause a panic.
+	// In practice, the only reason for k8s.GetNodeAllAddrs to return an error is if no matching
+	// IP address is found for the Node.
 	ips, err := k8s.GetNodeAllAddrs(node)
 	if err != nil {
-		return nil, err
+		klog.V(3).InfoS("Failed to get addresses for Node", "node", klog.KObj(node), "err", err)
+		return nil, nil
 	}
 	return ips.UnsortedList(), nil
 }

--- a/pkg/controller/grouping/controller_test.go
+++ b/pkg/controller/grouping/controller_test.go
@@ -198,7 +198,7 @@ func TestNodeIPsIndexFunc(t *testing.T) {
 				Spec: v1.NodeSpec{PodCIDR: "10.0.0.0/8"},
 			}},
 			want:    nil,
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name:    "empty PODCIDR",
@@ -213,7 +213,21 @@ func TestNodeIPsIndexFunc(t *testing.T) {
 				Spec:   v1.NodeSpec{PodCIDR: "10.0.0.0/8"},
 			}},
 			want:    nil,
-			wantErr: true,
+			wantErr: false,
+		},
+		{
+			name: "invalid IP address",
+			args: args{obj: &v1.Node{
+				Status: v1.NodeStatus{Addresses: []v1.NodeAddress{
+					{
+						Type:    v1.NodeInternalIP,
+						Address: "not-a-valid-ip",
+					},
+				}},
+				Spec: v1.NodeSpec{PodCIDR: "10.0.0.0/8"},
+			}},
+			want:    nil,
+			wantErr: false,
 		},
 		{
 			name: "Node with IPs",


### PR DESCRIPTION
NodeIPsIndexFunc is used as a cache.IndexFunc, and returning an error from it causes the client-go indexer to panic. This happens when a Node temporarily has no InternalIP or ExternalIP in .status.addresses.

Instead of propagating the error from GetNodeAllAddrs, ignore it and check whether the resulting IP set is empty. If it is, log an informational message and return nil gracefully.

Fixes #7914