### PR TITLE
Automated cherry pick of #7908: Add explicit permissions to workflows needing write access

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,10 @@ jobs:
   build:
     needs: check-env
     if: ${{ needs.check-env.outputs.has_changes == 'yes' || github.event_name == 'push' }}
+    permissions:
+      contents: read
+      packages: write
+      actions: write
     strategy:
       matrix:
         include:
@@ -146,6 +150,9 @@ jobs:
   push-manifest:
     needs: [check-env, build]
     if: ${{ needs.check-env.outputs.push_needed == 'true' }}
+    permissions:
+      contents: read
+      packages: write
     strategy:
       matrix:
         include:
@@ -286,6 +293,9 @@ jobs:
   build-flow-aggregator:
     needs: check-env
     if: ${{ needs.check-env.outputs.has_changes == 'yes' || github.event_name == 'push' }}
+    permissions:
+      contents: read
+      packages: write
     runs-on: ubuntu-latest
     env:
       DOCKER_TAG: latest

--- a/.github/workflows/build_tag.yml
+++ b/.github/workflows/build_tag.yml
@@ -31,6 +31,10 @@ jobs:
 
   build:
     needs: get-version
+    permissions:
+      contents: read
+      packages: write
+      actions: write
     strategy:
       matrix:
         include:
@@ -95,6 +99,9 @@ jobs:
 
   push-manifest:
     needs: [get-version, build]
+    permissions:
+      contents: read
+      packages: write
     strategy:
       matrix:
         include:
@@ -195,6 +202,9 @@ jobs:
 
   build-flow-aggregator:
     needs: get-version
+    permissions:
+      contents: read
+      packages: write
     runs-on: ubuntu-latest
     env:
       DOCKER_TAG: ${{ needs.get-version.outputs.version }}

--- a/.github/workflows/lifecycle_management.yml
+++ b/.github/workflows/lifecycle_management.yml
@@ -8,6 +8,9 @@ jobs:
   stale:
     if: github.repository == 'antrea-io/antrea'
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/stale@v10
         with:

--- a/.github/workflows/process_release.yml
+++ b/.github/workflows/process_release.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   upload-release-assets:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@v6
     - name: Set up Go using version from .go-version


### PR DESCRIPTION
Cherry pick of #7908 on release-2.6.

#7908: Add explicit permissions to workflows needing write access

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.