### PR TITLE
Automated cherry pick of #7883: fix(flowexporter): clamp negative IPFIX delta counts to 0

### DIFF
--- a/pkg/agent/flowexporter/exporter/ipfix.go
+++ b/pkg/agent/flowexporter/exporter/ipfix.go
@@ -292,33 +292,37 @@ func (e *ipfixExporter) addConnToSet(conn *connection.Connection) error {
 		case "octetTotalCount":
 			ie.SetUnsigned64Value(conn.OriginalBytes)
 		case "packetDeltaCount":
-			deltaPkts := int64(conn.OriginalPackets) - int64(conn.PrevPackets)
-			if deltaPkts < 0 {
-				klog.InfoS("Packet delta count for connection should not be negative", "packet delta count", deltaPkts)
+			if conn.OriginalPackets < conn.PrevPackets {
+				klog.InfoS("Packet delta count for connection should not be negative", "prevPackets", conn.PrevPackets, "currPackets", conn.OriginalPackets)
+				ie.SetUnsigned64Value(0)
+			} else {
+				ie.SetUnsigned64Value(conn.OriginalPackets - conn.PrevPackets)
 			}
-			ie.SetUnsigned64Value(uint64(deltaPkts))
 		case "octetDeltaCount":
-			deltaBytes := int64(conn.OriginalBytes) - int64(conn.PrevBytes)
-			if deltaBytes < 0 {
-				klog.InfoS("Byte delta count for connection should not be negative", "byte delta count", deltaBytes)
+			if conn.OriginalBytes < conn.PrevBytes {
+				klog.InfoS("Byte delta count for connection should not be negative", "prevBytes", conn.PrevBytes, "currBytes", conn.OriginalBytes)
+				ie.SetUnsigned64Value(0)
+			} else {
+				ie.SetUnsigned64Value(conn.OriginalBytes - conn.PrevBytes)
 			}
-			ie.SetUnsigned64Value(uint64(deltaBytes))
 		case "reversePacketTotalCount":
 			ie.SetUnsigned64Value(conn.ReversePackets)
 		case "reverseOctetTotalCount":
 			ie.SetUnsigned64Value(conn.ReverseBytes)
 		case "reversePacketDeltaCount":
-			deltaPkts := int64(conn.ReversePackets) - int64(conn.PrevReversePackets)
-			if deltaPkts < 0 {
-				klog.InfoS("Reverse packet delta count for connection should not be negative", "packet delta count", deltaPkts)
+			if conn.ReversePackets < conn.PrevReversePackets {
+				klog.InfoS("Reverse packet delta count for connection should not be negative", "prevReversePackets", conn.PrevReversePackets, "currReversePackets", conn.ReversePackets)
+				ie.SetUnsigned64Value(0)
+			} else {
+				ie.SetUnsigned64Value(conn.ReversePackets - conn.PrevReversePackets)
 			}
-			ie.SetUnsigned64Value(uint64(deltaPkts))
 		case "reverseOctetDeltaCount":
-			deltaBytes := int64(conn.ReverseBytes) - int64(conn.PrevReverseBytes)
-			if deltaBytes < 0 {
-				klog.InfoS("Reverse byte delta count for connection should not be negative", "byte delta count", deltaBytes)
+			if conn.ReverseBytes < conn.PrevReverseBytes {
+				klog.InfoS("Reverse byte delta count for connection should not be negative", "prevReverseBytes", conn.PrevReverseBytes, "currReverseBytes", conn.ReverseBytes)
+				ie.SetUnsigned64Value(0)
+			} else {
+				ie.SetUnsigned64Value(conn.ReverseBytes - conn.PrevReverseBytes)
 			}
-			ie.SetUnsigned64Value(uint64(deltaBytes))
 		case "sourcePodNamespace":
 			ie.SetStringValue(conn.SourcePodNamespace)
 		case "sourcePodName":

--- a/pkg/agent/flowexporter/exporter/ipfix_test.go
+++ b/pkg/agent/flowexporter/exporter/ipfix_test.go
@@ -15,11 +15,13 @@
 package exporter
 
 import (
+	"math"
 	"net"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	ipfixentities "github.com/vmware/go-ipfix/pkg/entities"
 	ipfixentitiestesting "github.com/vmware/go-ipfix/pkg/entities/testing"
 	ipfixregistry "github.com/vmware/go-ipfix/pkg/registry"
@@ -254,6 +256,61 @@ func createElement(name string, enterpriseID uint32) ipfixentities.InfoElementWi
 	element, _ := ipfixregistry.GetInfoElement(name, enterpriseID)
 	ieWithValue, _ := ipfixentities.DecodeAndCreateInfoElementWithValue(element, nil)
 	return ieWithValue
+}
+
+// getDeltaValues extracts the current exported values of the four delta fields from the
+// exporter's element list. Because addConnToSet mutates elementsListv4 in place and passes
+// the same slice to AddRecordV2, inspecting elementsListv4 after the call is equivalent to
+// inspecting what was actually sent.
+func getDeltaValues(eL []ipfixentities.InfoElementWithValue) map[string]uint64 {
+	// math.MaxUint64 is used as a sentinel so that any field not found in the element list
+	// is distinguishable from a valid exported value of 0.
+	result := map[string]uint64{
+		"packetDeltaCount":        math.MaxUint64,
+		"octetDeltaCount":         math.MaxUint64,
+		"reversePacketDeltaCount": math.MaxUint64,
+		"reverseOctetDeltaCount":  math.MaxUint64,
+	}
+	for _, ie := range eL {
+		if _, ok := result[ie.GetInfoElement().Name]; ok {
+			result[ie.GetInfoElement().Name] = ie.GetUnsigned64Value()
+		}
+	}
+	return result
+}
+
+// TestIPFIXExporter_negativeDeltaCounts verifies that when current packet/byte counters are
+// lower than the previously recorded values (counter rollback), the exported delta fields are
+// set to 0 rather than wrapping around to a large uint64 value.
+func TestIPFIXExporter_negativeDeltaCounts(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockIPFIXSet := ipfixentitiestesting.NewMockSet(ctrl)
+
+	elemListv4 := getElemList(IANAInfoElementsIPv4, AntreaInfoElementsIPv4)
+	flowExp := &ipfixExporter{
+		elementsListv4: elemListv4,
+		templateIDv4:   testTemplateIDv4,
+		ipfixSet:       mockIPFIXSet,
+	}
+
+	conn := flowexportertesting.GetConnection(false, true, 302, 6, "ESTABLISHED")
+	// Set Prev* fields to be larger than the current counters to simulate a counter rollback.
+	conn.PrevPackets = conn.OriginalPackets + 10
+	conn.PrevBytes = conn.OriginalBytes + 100
+	conn.PrevReversePackets = conn.ReversePackets + 5
+	conn.PrevReverseBytes = conn.ReverseBytes + 50
+
+	mockIPFIXSet.EXPECT().ResetSet()
+	mockIPFIXSet.EXPECT().PrepareSet(ipfixentities.Data, testTemplateIDv4).Return(nil)
+	mockIPFIXSet.EXPECT().AddRecordV2(gomock.Any(), testTemplateIDv4).Return(nil)
+
+	err := flowExp.addConnToSet(conn)
+	require.NoError(t, err)
+
+	for name, val := range getDeltaValues(flowExp.elementsListv4) {
+		assert.Equal(t, uint64(0), val,
+			"delta field %q: expected 0 on counter rollback, got %d", name, val)
+	}
 }
 
 func getElemList(ianaIE []string, antreaIE []string) []ipfixentities.InfoElementWithValue {


### PR DESCRIPTION
Cherry pick of #7883 on release-2.5.

#7883: fix(flowexporter): clamp negative IPFIX delta counts to 0

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.