### PR TITLE
Fix wrong error variable in updateSupportBundleCollectionStatus

### DIFF
--- a/pkg/agent/supportbundlecollection/support_bundle_controller.go
+++ b/pkg/agent/supportbundlecollection/support_bundle_controller.go
@@ -338,7 +338,7 @@ func (c *SupportBundleController) updateSupportBundleCollectionStatus(key string
 			},
 		},
 	}); updateErr != nil {
-		return fmt.Errorf("failed to update collection status for bundle: %s, err: %w", key, err)
+		return fmt.Errorf("failed to update collection status for bundle: %s, err: %w", key, updateErr)
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes #7920
The fmt.Errorf call on line 341 wraps 'err' (from GetAntreaClient, which is nil at this point) instead of 'updateErr' (the actual error from UpdateStatus). This causes the real API error to be lost.