### PR TITLE
Fix container networking setup failure

### DIFF
--- a/.github/actions/setup-docker-classic/action.yml
+++ b/.github/actions/setup-docker-classic/action.yml
@@ -14,5 +14,6 @@ runs:
           {
             "features": {
               "containerd-snapshotter": false
-            }
+            },
+            "userland-proxy": false
           }


### PR DESCRIPTION
Set "userland-proxy": false to tell Docker to use iptables DNAT instead, completely bypassing docker-proxy for port forwarding to fix conformance test failure.

The original error was like "docker: Error response from daemon: failed to set up container networking: driver failed programming external connectivity on endpoint kind-control-plane (33774dea72a437b357533f32808db6b5e37c21f4fa4eda2cd1fa3cb6663d420d): failed to start userland proxy for port mapping 127.0.0.1:45353:172.18.0.2:6443/tcp: fork/exec /opt/hostedtoolcache/docker-archive-stable/29.3.1/x64/docker-proxy: no such file or directory"
e.g. https://github.com/antrea-io/antrea/actions/runs/23737022940/job/69144208293

The fix has been verified with job https://github.com/antrea-io/antrea/actions/runs/23737588657/job/69146116540