### PR TITLE
fix: implement Clear method for ExpirePriorityQueue and update DeleteAllConnections logic

### DIFF
--- a/pkg/agent/flowexporter/connections/conntrack_connections.go
+++ b/pkg/agent/flowexporter/connections/conntrack_connections.go
@@ -224,6 +224,8 @@ func (cs *ConntrackConnectionStore) DeleteAllConnections() int {
 	defer cs.ReleaseConnStoreLock()
 	num := len(cs.connections)
 	clear(cs.connections)
+	metrics.TotalAntreaConnectionsInConnTrackTable.Set(0)
+	cs.expirePriorityQueue.Clear()
 	return num
 }
 

--- a/pkg/agent/flowexporter/connections/conntrack_connections_test.go
+++ b/pkg/agent/flowexporter/connections/conntrack_connections_test.go
@@ -342,6 +342,57 @@ func TestConnectionStore_DeleteConnectionByKey(t *testing.T) {
 	}
 }
 
+func TestConntrackConnectionStore_DeleteAllConnections(t *testing.T) {
+	metrics.TotalAntreaConnectionsInConnTrackTable.Set(0)
+
+	cs := NewConntrackConnectionStore(nil, nil, nil, testFlowExporterOptions)
+
+	conns := []*connection.Connection{
+		{
+			FlowKey: connection.Tuple{
+				SourceAddress:      netip.MustParseAddr("10.0.0.1"),
+				DestinationAddress: netip.MustParseAddr("10.0.0.10"),
+				Protocol:           6,
+				SourcePort:         10001,
+				DestinationPort:    80,
+			},
+		},
+		{
+			FlowKey: connection.Tuple{
+				SourceAddress:      netip.MustParseAddr("10.0.0.2"),
+				DestinationAddress: netip.MustParseAddr("10.0.0.11"),
+				Protocol:           6,
+				SourcePort:         10002,
+				DestinationPort:    80,
+			},
+		},
+		{
+			FlowKey: connection.Tuple{
+				SourceAddress:      netip.MustParseAddr("10.0.0.3"),
+				DestinationAddress: netip.MustParseAddr("10.0.0.12"),
+				Protocol:           17,
+				SourcePort:         10003,
+				DestinationPort:    53,
+			},
+		},
+	}
+
+	for _, conn := range conns {
+		addConnToStore(cs, conn)
+	}
+
+	checkAntreaConnectionMetrics(t, len(conns))
+	assert.Equal(t, len(conns), cs.GetPriorityQueue().Len())
+	assert.Equal(t, len(conns), len(cs.GetPriorityQueue().KeyToItem))
+
+	deletedCount := cs.DeleteAllConnections()
+	assert.Equal(t, len(conns), deletedCount)
+	assert.Equal(t, 0, cs.NumConnections())
+	checkAntreaConnectionMetrics(t, 0)
+	assert.Equal(t, 0, cs.GetPriorityQueue().Len())
+	assert.Equal(t, 0, len(cs.GetPriorityQueue().KeyToItem))
+}
+
 func TestConntrackConnectionStore_AddOrUpdateConns(t *testing.T) {
 	refTime := time.Now()
 	tuple1 := connection.Tuple{SourceAddress: netip.MustParseAddr("1.1.1.1"), DestinationAddress: netip.MustParseAddr("2.2.2.2"), Protocol: 6, SourcePort: 50000, DestinationPort: 100}

--- a/pkg/agent/flowexporter/priorityqueue/priorityqueue.go
+++ b/pkg/agent/flowexporter/priorityqueue/priorityqueue.go
@@ -108,6 +108,12 @@ func (pq *ExpirePriorityQueue) Remove(connKey connection.ConnectionKey) *ItemToE
 	return removedItem.(*ItemToExpire)
 }
 
+// Clear removes all items from the queue and key index map.
+func (pq *ExpirePriorityQueue) Clear() {
+	pq.items = pq.items[:0]
+	clear(pq.KeyToItem)
+}
+
 // GetExpiryFromExpirePriorityQueue returns the shortest expire time duration
 // from expire priority queue.
 func (pq *ExpirePriorityQueue) GetExpiryFromExpirePriorityQueue() time.Duration {

--- a/pkg/agent/flowexporter/priorityqueue/priorityqueue.go
+++ b/pkg/agent/flowexporter/priorityqueue/priorityqueue.go
@@ -110,6 +110,7 @@ func (pq *ExpirePriorityQueue) Remove(connKey connection.ConnectionKey) *ItemToE
 
 // Clear removes all items from the queue and key index map.
 func (pq *ExpirePriorityQueue) Clear() {
+	clear(pq.items)
 	pq.items = pq.items[:0]
 	clear(pq.KeyToItem)
 }

--- a/pkg/agent/flowexporter/priorityqueue/priorityqueue_test.go
+++ b/pkg/agent/flowexporter/priorityqueue/priorityqueue_test.go
@@ -201,3 +201,24 @@ func TestExpirePriorityQueue_GetTopExpiredItem(t *testing.T) {
 		assert.Equal(t, tc.expectedResult, result)
 	}
 }
+
+func TestExpirePriorityQueue_Clear(t *testing.T) {
+	pq := NewExpirePriorityQueue(1*time.Second, 2*time.Second)
+	for i := 0; i < 3; i++ {
+		conn := &connection.Connection{}
+		pq.WriteItemToQueue(testConnectionKey(i), conn)
+	}
+
+	assert.Equal(t, 3, pq.Len())
+	assert.Equal(t, 3, len(pq.KeyToItem))
+
+	pq.Clear()
+
+	assert.Equal(t, 0, pq.Len())
+	assert.Equal(t, 0, len(pq.KeyToItem))
+
+	// Ensure Clear is safe to call repeatedly.
+	pq.Clear()
+	assert.Equal(t, 0, pq.Len())
+	assert.Equal(t, 0, len(pq.KeyToItem))
+}


### PR DESCRIPTION
fixes #7934  

### Summary
Fixes inconsistent state in conntrack flow exporter bulk deletion path.

`DeleteAllConnections()` previously cleared only the connection map.  
It did not reset:
1. `TotalAntreaConnectionsInConnTrackTable` metric
2. `ExpirePriorityQueue` internal state (`items` and `KeyToItem`)

This could leave stale metric values and stale queue entries after bulk delete.

### Changes
1. Added `Clear()` to `ExpirePriorityQueue` to clear both heap items and key index map.
2. Updated `ConntrackConnectionStore.DeleteAllConnections()` to:
   - clear connection map
   - reset `TotalAntreaConnectionsInConnTrackTable` to `0`
   - clear expire priority queue via `Clear()`

### Tests
Added targeted unit tests:
1. `TestConntrackConnectionStore_DeleteAllConnections`
   - verifies pre-populated metric and queue state
   - verifies metric reset and queue cleanup after `DeleteAllConnections()`
2. `TestExpirePriorityQueue_Clear`
   - verifies `Clear()` empties heap and map
   - verifies repeated `Clear()` is safe

![WhatsApp Image 2026-03-31 at 7 53 44 PM](https://github.com/user-attachments/assets/008eaa35-7126-47b7-9c91-2443935f5255)
![WhatsApp Image 2026-03-31 at 7 53 59 PM](https://github.com/user-attachments/assets/a0b7d6af-16b1-420f-9425-f99d7dc27904)
