### PR TITLE
Fix incorrect bitmap index in AllocateRange causing double allocation

### DIFF
--- a/pkg/ipam/ipallocator/allocator.go
+++ b/pkg/ipam/ipallocator/allocator.go
@@ -200,7 +200,7 @@ func (a *SingleIPAllocator) AllocateRange(size int) ([]net.IP, error) {
 			for i := 0; i < size; i++ {
 				offset := start + i
 				ip := utilnet.AddIPOffset(a.base, offset)
-				a.allocated.SetBit(a.allocated, i, 1)
+				a.allocated.SetBit(a.allocated, offset, 1)
 				a.count++
 				ips = append(ips, ip)
 			}

--- a/pkg/ipam/ipallocator/allocator_test.go
+++ b/pkg/ipam/ipallocator/allocator_test.go
@@ -304,6 +304,12 @@ func TestAllocateRange(t *testing.T) {
 			assert.Equal(t, tt.wantFirst, ips[0])
 			assert.Equal(t, tt.wantLast, ips[len(ips)-1])
 			assert.Equal(t, prevUsed+len(ips), tt.ipAllocator.Used())
+
+			// Verify every returned IP is marked allocated and cannot be re-allocated.
+			for _, ip := range ips {
+				err := tt.ipAllocator.AllocateIP(ip)
+				assert.Errorf(t, err, "expected error re-allocating %v, but got nil", ip)
+			}
 		})
 	}
 }


### PR DESCRIPTION
### What

Fix incorrect bit indexing in the IP allocator bitmap where the loop index i was used instead of the computed offset when marking an IP as allocated.

### Why

The allocator computes an offset that represents the correct position of an IP within the allocation bitmap. However, the code mistakenly used the loop index i when setting the bit:

SetBit(..., i, 1)

This results in a mismatch between:

the IP being allocated
and the bit being marked in the bitmap
### Impact

This bug can lead to multiple inconsistencies in IPAM:

Duplicate IP allocation
The actual allocated IP is not marked correctly, allowing it to be reassigned.
Phantom allocations
Bits corresponding to unrelated positions (based on i) are marked as used.
Bitmap corruption
The allocator state becomes inconsistent with real allocations.
Incorrect pool utilization tracking
The system may think IPs are exhausted or unavailable when they are not.
### Affected Area
pkg/ipam/ipallocator/allocator.go
Specifically impacts bitmap updates during IP allocation flows
### Fix

Replace incorrect index usage:

SetBit(..., i, 1)

with:

SetBit(..., offset, 1)

This ensures the bitmap correctly reflects the allocated IP.

### Tests
Added regression test to verify:
Allocated IPs are correctly marked in the bitmap
No duplicate allocation occurs
Bitmap state matches actual allocations
### Notes

This is a minimal and targeted fix that aligns with existing allocator design without introducing behavioral changes beyond correcting the inconsistency.