### PR TITLE
agent: handle tombstone objects in Tracker.OnNodeDelete

### DIFF
--- a/pkg/agent/nodeip/tracker.go
+++ b/pkg/agent/nodeip/tracker.go
@@ -72,7 +72,16 @@ func (t *Tracker) OnNodeUpdate(oldObj, obj interface{}) {
 func (t *Tracker) OnNodeDelete(obj interface{}) {
 	node, ok := obj.(*corev1.Node)
 	if !ok {
-		return
+		// When the informer's watch connection is interrupted and re-established,
+		// delete events are delivered as cache.DeletedFinalStateUnknown tombstones.
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			return
+		}
+		node, ok = tombstone.Obj.(*corev1.Node)
+		if !ok {
+			return
+		}
 	}
 	t.mutex.Lock()
 	defer t.mutex.Unlock()

--- a/pkg/agent/nodeip/tracker_test.go
+++ b/pkg/agent/nodeip/tracker_test.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
 )
 
 func TestNewTracker(t *testing.T) {
@@ -78,4 +79,27 @@ func TestNewTracker(t *testing.T) {
 		assert.False(t, tracker.IsNodeIP(updatedNodeInternalIP))
 		assert.False(t, tracker.IsNodeIP(nodeExternalIP))
 	})
+}
+
+func TestOnNodeDelete_Tombstone(t *testing.T) {
+	k8sClient := fake.NewSimpleClientset()
+	informerFactory := informers.NewSharedInformerFactory(k8sClient, 0)
+	nodeInformer := informerFactory.Core().V1().Nodes()
+	tracker := NewTracker(nodeInformer)
+
+	nodeIP := "3.3.3.3"
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node2"},
+		Status: corev1.NodeStatus{Addresses: []corev1.NodeAddress{
+			{Type: corev1.NodeInternalIP, Address: nodeIP},
+		}},
+	}
+
+	// Seed the tracker directly.
+	tracker.OnNodeAdd(node)
+	assert.True(t, tracker.IsNodeIP(nodeIP))
+
+	// Deliver the delete as a tombstone, as the informer does after a watch reconnect.
+	tracker.OnNodeDelete(cache.DeletedFinalStateUnknown{Key: "node2", Obj: node})
+	assert.False(t, tracker.IsNodeIP(nodeIP))
 }


### PR DESCRIPTION
### What

Handle cache.DeletedFinalStateUnknown tombstone objects in Tracker.OnNodeDelete.

### Why

Kubernetes informers may deliver delete events as tombstone objects (cache.DeletedFinalStateUnknown) when a watch is interrupted and later re-established.

The current implementation only handles direct *corev1.Node objects and silently ignores tombstones, which can leave stale Node IP entries in the tracker.

### Impact
Stale Node IPs may remain in nodeIPs
IsNodeIP may return incorrect results
Can lead to incorrect traffic classification and NetworkPolicy behavior
### Fix

Add handling for tombstone objects and extract the underlying *corev1.Node before processing the delete event.

### Tests

Added regression test to verify that Node IPs are correctly removed when delete events are received as tombstones.

### Scope

Limited to pkg/agent/nodeip/tracker.go and corresponding tests.

Fixes #7948