### PR TITLE
Automated cherry pick of #7945: Fix wrong bitmap index in AllocateRange (#7945)

### DIFF
--- a/pkg/ipam/ipallocator/allocator.go
+++ b/pkg/ipam/ipallocator/allocator.go
@@ -200,7 +200,7 @@ func (a *SingleIPAllocator) AllocateRange(size int) ([]net.IP, error) {
 			for i := 0; i < size; i++ {
 				offset := start + i
 				ip := utilnet.AddIPOffset(a.base, offset)
-				a.allocated.SetBit(a.allocated, i, 1)
+				a.allocated.SetBit(a.allocated, offset, 1)
 				a.count++
 				ips = append(ips, ip)
 			}

--- a/pkg/ipam/ipallocator/allocator_test.go
+++ b/pkg/ipam/ipallocator/allocator_test.go
@@ -304,6 +304,12 @@ func TestAllocateRange(t *testing.T) {
 			assert.Equal(t, tt.wantFirst, ips[0])
 			assert.Equal(t, tt.wantLast, ips[len(ips)-1])
 			assert.Equal(t, prevUsed+len(ips), tt.ipAllocator.Used())
+
+			// Verify every returned IP is marked allocated and cannot be re-allocated.
+			for _, ip := range ips {
+				err := tt.ipAllocator.AllocateIP(ip)
+				assert.Errorf(t, err, "expected error re-allocating %v, but got nil", ip)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Cherry pick of #7945 on release-2.6.

#7945: Fix wrong bitmap index in AllocateRange (#7945)

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.