### PR TITLE
ipam: handle tombstone objects in StatefulSet delete handler

### DIFF
--- a/pkg/controller/ipam/antrea_ipam_controller.go
+++ b/pkg/controller/ipam/antrea_ipam_controller.go
@@ -163,7 +163,21 @@ func (c *AntreaIPAMController) enqueueStatefulSetCreateEvent(obj interface{}) {
 
 // Enqueue the StatefulSet delete notification to be processed by the worker
 func (c *AntreaIPAMController) enqueueStatefulSetDeleteEvent(obj interface{}) {
-	ss := obj.(*appsv1.StatefulSet)
+	ss, ok := obj.(*appsv1.StatefulSet)
+	if !ok {
+		// When the informer's watch connection is interrupted and re-established,
+		// delete events are delivered as cache.DeletedFinalStateUnknown tombstones.
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			klog.ErrorS(nil, "Error decoding object when deleting StatefulSet, invalid type", "object", obj)
+			return
+		}
+		ss, ok = tombstone.Obj.(*appsv1.StatefulSet)
+		if !ok {
+			klog.ErrorS(nil, "Error decoding object tombstone when deleting StatefulSet, invalid type", "object", tombstone.Obj)
+			return
+		}
+	}
 	klog.V(2).InfoS("Delete notification", "Namespace", ss.Namespace, "StatefulSet", ss.Name)
 
 	key := k8s.NamespacedName(ss.Namespace, ss.Name)

--- a/pkg/controller/ipam/antrea_ipam_controller_test.go
+++ b/pkg/controller/ipam/antrea_ipam_controller_test.go
@@ -39,6 +39,7 @@ import (
 	crdinformers "antrea.io/antrea/pkg/client/informers/externalversions"
 	listers "antrea.io/antrea/pkg/client/listers/crd/v1beta1"
 	annotation "antrea.io/antrea/pkg/ipam"
+	"antrea.io/antrea/pkg/util/k8s"
 )
 
 type fakeAntreaIPAMController struct {
@@ -438,4 +439,21 @@ func BenchmarkCleanUpStaleIPAddresses(b *testing.B) {
 			}
 		})
 	}
+}
+
+func TestEnqueueStatefulSetDeleteEvent_Tombstone(t *testing.T) {
+	namespace, pool, statefulSet := initTestObjects(false, true, 3)
+	controller := newFakeAntreaIPAMController(pool, namespace, statefulSet)
+
+	expectedKey := k8s.NamespacedName(statefulSet.Namespace, statefulSet.Name)
+
+	// Deliver the delete as a tombstone, as the informer does after a watch reconnect.
+	controller.enqueueStatefulSetDeleteEvent(cache.DeletedFinalStateUnknown{
+		Key: expectedKey,
+		Obj: statefulSet,
+	})
+
+	require.Equal(t, 1, controller.statefulSetQueue.Len())
+	key, _ := controller.statefulSetQueue.Get()
+	assert.Equal(t, expectedKey, key)
 }


### PR DESCRIPTION
Fixes #7957

## What

Handle `cache.DeletedFinalStateUnknown` tombstone objects in `enqueueStatefulSetDeleteEvent` of AntreaIPAMController.

## Why

The handler previously performed an unchecked type assertion:

```go
obj.(*appsv1.StatefulSet)
```

When the informer's watch connection is interrupted and later re-established (e.g. API server restart, network partition, or controller restart), Kubernetes may deliver delete events as tombstone objects instead of `*appsv1.StatefulSet`.

This caused a panic in the controller, disrupting IPAM operations and potentially leaving StatefulSet IPs allocated in the pool.

## How

Added safe type handling to support both direct `*appsv1.StatefulSet` objects and `cache.DeletedFinalStateUnknown` tombstones, following existing patterns used by other delete handlers in the codebase.

## Testing

Added `TestEnqueueStatefulSetDeleteEvent_Tombstone` to verify that:

* Tombstone objects are handled correctly
* The expected key is enqueued
* No panic occurs

All existing tests pass.
