### PR TITLE
SNAT virtual Service IP to gateway IP for Pod traffic in noEncap/hybrid/WireGuard

### DIFF
--- a/pkg/agent/route/route_linux.go
+++ b/pkg/agent/route/route_linux.go
@@ -1469,6 +1469,20 @@ func (c *Client) restoreIptablesData(podCIDR *net.IPNet,
 	// If AntreaProxy full support is enabled, it SNATs the packets whose source IP is VirtualServiceIPv4/VirtualServiceIPv6
 	// so the packets can be routed back to this Node.
 	if c.proxyAll && !c.hostNetworkNFTables {
+		// In noEncap/hybrid mode, or when WireGuard encryption is used, packets sourced from the OVS virtual Service IP
+		// destined for peer Pod CIDRs are SNATed to the Antrea gateway IP instead of the Node IP. This ensures the remote
+		// Node treats the traffic as Pod-to-Pod. The gateway IP belongs to the local Pod CIDR, so it is recognized
+		// as a peer Pod CIDR address on the remote Node, which allows nftables flowtables to accelerate the Pod-to-Pod traffic.
+		gatewayIP := c.gatewayIP(isIPv6)
+		if gatewayIP != "" {
+			writeLine(iptablesData, []string{
+				"-A", antreaPostRoutingChain,
+				"-m", "comment", "--comment", `"Antrea: SNAT OVS virtual source IP to gateway IP for Pod traffic"`,
+				"-s", serviceVirtualIP.String(),
+				"-m", "set", "--match-set", podIPSet, "dst",
+				"-j", iptables.SNATTarget, "--to", gatewayIP,
+			}...)
+		}
 		writeLine(iptablesData, []string{
 			"-A", antreaPostRoutingChain,
 			"-m", "comment", "--comment", `"Antrea: masquerade OVS virtual source IP"`,
@@ -2986,6 +3000,7 @@ func (c *Client) nftablesProxyAll(tx *knftables.Transaction, ipProtocol knftable
 	var svcSNATVIP string
 	var nodePortSet string
 	var externalIPSet string
+	var gatewayIP string
 
 	switch ipProtocol {
 	case knftables.IPv4Family:
@@ -2996,6 +3011,7 @@ func (c *Client) nftablesProxyAll(tx *knftables.Transaction, ipProtocol knftable
 		svcSNATVIP = config.VirtualServiceIPv4.String()
 		nodePortSet = antreaNFTablesSetNodePort
 		externalIPSet = antreaNFTablesSetExternalIP
+		gatewayIP = c.gatewayIP(false)
 	case knftables.IPv6Family:
 		ipAddr = "ipv6_addr"
 		ip = "ip6"
@@ -3004,6 +3020,7 @@ func (c *Client) nftablesProxyAll(tx *knftables.Transaction, ipProtocol knftable
 		svcSNATVIP = config.VirtualServiceIPv6.String()
 		nodePortSet = antreaNFTablesSetNodePort6
 		externalIPSet = antreaNFTablesSetExternalIP6
+		gatewayIP = c.gatewayIP(true)
 	}
 
 	tx.Add(&knftables.Set{
@@ -3077,6 +3094,22 @@ func (c *Client) nftablesProxyAll(tx *knftables.Transaction, ipProtocol knftable
 		),
 		Comment: ptr.To("DNAT local to NodePort packets"),
 	})
+	// In noEncap/hybrid mode, or when WireGuard encryption is used, packets sourced from the OVS virtual Service IP
+	// destined for peer Pod CIDRs are SNATed to the Antrea gateway IP instead of the Node IP. This ensures the remote
+	// Node treats the traffic as Pod-to-Pod. The gateway IP belongs to the local Pod CIDR, so it is recognized
+	// as a peer Pod CIDR address on the remote Node, which allows nftables flowtables to accelerate the Pod-to-Pod traffic.
+	if gatewayIP != "" {
+		tx.Add(&knftables.Rule{
+			Chain: antreaNFTablesNatChainPostroutingProxyAll,
+			Rule: knftables.Concat(
+				ip, "saddr", svcSNATVIP,
+				ip, "daddr", "@", antreaNFTablesSetPeerPodCIDR,
+				"counter",
+				"snat", "to", gatewayIP,
+			),
+			Comment: ptr.To("SNAT OVS virtual source IP to gateway IP for Pod traffic"),
+		})
+	}
 	tx.Add(&knftables.Rule{
 		Chain: antreaNFTablesNatChainPostroutingProxyAll,
 		Rule: knftables.Concat(
@@ -3512,4 +3545,21 @@ func (c *Client) deleteExternalIPConfigsIPsets(externalIP net.IP) error {
 func (c *Client) shouldEnableEgressPolicyRouting() bool {
 	return c.egressEnabled && (c.networkConfig.TrafficEncapMode == config.TrafficEncapModeHybrid ||
 		c.networkConfig.TrafficEncryptionMode == config.TrafficEncryptionModeWireGuard)
+}
+
+// gatewayIP returns the Antrea gateway IPv4 or IPv6 address.
+func (c *Client) gatewayIP(ipv6 bool) string {
+	if c.nodeConfig == nil || c.nodeConfig.GatewayConfig == nil {
+		return ""
+	}
+	var ipAddr net.IP
+	if ipv6 {
+		ipAddr = c.nodeConfig.GatewayConfig.IPv6
+	} else {
+		ipAddr = c.nodeConfig.GatewayConfig.IPv4
+	}
+	if ipAddr == nil {
+		return ""
+	}
+	return ipAddr.String()
 }

--- a/pkg/agent/route/route_linux_test.go
+++ b/pkg/agent/route/route_linux_test.go
@@ -422,6 +422,8 @@ func TestSyncIPTables(t *testing.T) {
 				PodIPv6CIDR: ip.MustParseCIDR("2001:ab03:cd04:55ef::/64"),
 				GatewayConfig: &config.GatewayConfig{
 					Name: "antrea-gw0",
+					IPv4: net.ParseIP("172.16.10.1"),
+					IPv6: net.ParseIP("2001:ab03:cd04:55ef::1"),
 				},
 			},
 			nodeSNATRandomFully: true,
@@ -534,6 +536,7 @@ COMMIT
 -A ANTREA-POSTROUTING -m comment --comment "Antrea: SNAT Pod to external packets" ! -o antrea-gw0 -m mark --mark 0x00000001/0x000000ff -j SNAT --to 1.1.1.1
 -A ANTREA-POSTROUTING -m comment --comment "Antrea: masquerade Pod to external packets" -s 172.16.10.0/24 -m set ! --match-set ANTREA-POD-IP dst ! -o antrea-gw0 -j MASQUERADE --random-fully
 -A ANTREA-POSTROUTING -m comment --comment "Antrea: masquerade LOCAL traffic" -o antrea-gw0 -m addrtype ! --src-type LOCAL --limit-iface-out -m addrtype --src-type LOCAL -j MASQUERADE --random-fully
+-A ANTREA-POSTROUTING -m comment --comment "Antrea: SNAT OVS virtual source IP to gateway IP for Pod traffic" -s 169.254.0.253 -m set --match-set ANTREA-POD-IP dst -j SNAT --to 172.16.10.1
 -A ANTREA-POSTROUTING -m comment --comment "Antrea: masquerade OVS virtual source IP" -s 169.254.0.253 -j MASQUERADE
 COMMIT
 `, false, false)
@@ -592,6 +595,7 @@ COMMIT
 -A ANTREA-POSTROUTING -m comment --comment "Antrea: SNAT Pod to external packets" ! -o antrea-gw0 -m mark --mark 0x00000002/0x000000ff -j SNAT --to fe80::e643:4bff:fe02
 -A ANTREA-POSTROUTING -m comment --comment "Antrea: masquerade Pod to external packets" -s 2001:ab03:cd04:55ef::/64 -m set ! --match-set ANTREA-POD-IP6 dst ! -o antrea-gw0 -j MASQUERADE --random-fully
 -A ANTREA-POSTROUTING -m comment --comment "Antrea: masquerade LOCAL traffic" -o antrea-gw0 -m addrtype ! --src-type LOCAL --limit-iface-out -m addrtype --src-type LOCAL -j MASQUERADE --random-fully
+-A ANTREA-POSTROUTING -m comment --comment "Antrea: SNAT OVS virtual source IP to gateway IP for Pod traffic" -s fc01::aabb:ccdd:eeff -m set --match-set ANTREA-POD-IP6 dst -j SNAT --to 2001:ab03:cd04:55ef::1
 -A ANTREA-POSTROUTING -m comment --comment "Antrea: masquerade OVS virtual source IP" -s fc01::aabb:ccdd:eeff -j MASQUERADE
 COMMIT
 `, false, true)

--- a/test/e2e/proxy_test.go
+++ b/test/e2e/proxy_test.go
@@ -753,7 +753,7 @@ func testProxyHairpin(t *testing.T, isIPv6 bool) {
 	createAgnhostPod(t, data, agnhost, node, false)
 	t.Run("Non-HostNetwork Endpoints", func(t *testing.T) {
 		testProxyIntraNodeHairpinCases(data, t, expectedGatewayIP, agnhost, clusterIPUrl, workerNodePortClusterUrl, workerNodePortLocalUrl, lbClusterUrl, lbLocalUrl)
-		testProxyInterNodeHairpinCases(data, t, false, expectedNodeIP, nodeName(2), clusterIPUrl, worker2NodePortClusterUrl, lbClusterUrl)
+		testProxyInterNodeHairpinCases(data, t, false, expectedNodeIP, expectedGatewayIP, nodeName(2), clusterIPUrl, worker2NodePortClusterUrl, lbClusterUrl)
 	})
 	require.NoError(t, data.DeletePod(data.testNamespace, agnhost))
 
@@ -762,7 +762,7 @@ func testProxyHairpin(t *testing.T, isIPv6 bool) {
 	t.Run("HostNetwork Endpoints", func(t *testing.T) {
 		skipIfProxyAllDisabled(t, data)
 		testProxyIntraNodeHairpinCases(data, t, expectedVirtualIP, agnhostHost, clusterIPUrl, workerNodePortClusterUrl, workerNodePortLocalUrl, lbClusterUrl, lbLocalUrl)
-		testProxyInterNodeHairpinCases(data, t, true, expectedNodeIP, nodeName(2), clusterIPUrl, worker2NodePortClusterUrl, lbClusterUrl)
+		testProxyInterNodeHairpinCases(data, t, true, expectedNodeIP, expectedGatewayIP, nodeName(2), clusterIPUrl, worker2NodePortClusterUrl, lbClusterUrl)
 	})
 }
 
@@ -829,7 +829,7 @@ func testProxyIntraNodeHairpinCases(data *TestData, t *testing.T, expectedClient
 // - Node A Antrea gateway: virtual IP         -> Endpoint IP
 // - Node A output:         Node A IP          -> Endpoint IP (another SNAT for virtual IP, otherwise reply packets can't be routed back).
 // - Node B:                Node A IP          -> Endpoint IP
-func testProxyInterNodeHairpinCases(data *TestData, t *testing.T, hostNetwork bool, expectedClientIP, node, clusterIPUrl, nodePortClusterUrl, lbClusterUrl string) {
+func testProxyInterNodeHairpinCases(data *TestData, t *testing.T, hostNetwork bool, expectedClientIP, localGatewayIP, node, clusterIPUrl, nodePortClusterUrl, lbClusterUrl string) {
 	skipIfAntreaIPAMTest(t)
 	currentEncapMode, err := data.GetEncapMode()
 	if err != nil {
@@ -853,21 +853,37 @@ func testProxyInterNodeHairpinCases(data *TestData, t *testing.T, hostNetwork bo
 	})
 	t.Run("InterNode/NodePort/ExternalTrafficPolicy:Cluster", func(t *testing.T) {
 		skipIfProxyAllDisabled(t, data)
+		var expectedIP string
 		if !hostNetwork && currentEncapMode == config.TrafficEncapModeNoEncap {
 			skipIfHasWindowsNodes(t)
+			// For non-hostNetwork Endpoints in noEncap mode, clientIP should be the local gateway IP
+			// to ensure the remote Node treats the traffic as Pod-to-Pod and can accelerate it via flowtable.
+			expectedIP = localGatewayIP
+		} else if !hostNetwork && currentEncapMode == config.TrafficEncapModeHybrid {
+			skipIfHasWindowsNodes(t)
+			expectedIP = localGatewayIP
+		} else {
+			expectedIP = expectedClientIP
 		}
 		clientIP, err := probeClientIPFromNode(node, nodePortClusterUrl, data)
 		require.NoError(t, err, "NodePort whose externalTrafficPolicy is Cluster hairpin should be able to be connected")
-		require.Equal(t, expectedClientIP, clientIP)
+		require.Equal(t, expectedIP, clientIP)
 	})
 	t.Run("InterNode/LoadBalancer/ExternalTrafficPolicy:Cluster", func(t *testing.T) {
 		skipIfProxyAllDisabled(t, data)
+		var expectedIP string
 		if !hostNetwork && currentEncapMode == config.TrafficEncapModeNoEncap {
 			skipIfHasWindowsNodes(t)
+			expectedIP = localGatewayIP
+		} else if !hostNetwork && currentEncapMode == config.TrafficEncapModeHybrid {
+			skipIfHasWindowsNodes(t)
+			expectedIP = localGatewayIP
+		} else {
+			expectedIP = expectedClientIP
 		}
 		clientIP, err := probeClientIPFromNode(node, lbClusterUrl, data)
 		require.NoError(t, err, "LoadBalancer whose externalTrafficPolicy is Cluster hairpin should be able to be connected")
-		require.Equal(t, expectedClientIP, clientIP)
+		require.Equal(t, expectedIP, clientIP)
 	})
 }
 

--- a/test/integration/agent/route_test.go
+++ b/test/integration/agent/route_test.go
@@ -421,14 +421,20 @@ func TestInitialize(t *testing.T) {
 	}
 }
 `
-				expectedNFTablesChains["nat-postrouting-proxy-all"] = `table ip antrea {
+				natPostRoutingProxyAll := `table ip antrea {
 	chain nat-postrouting-proxy-all {
 		comment "NAT postrouting for proxyAll"
 		type nat hook postrouting priority srcnat; policy accept;
-		ip saddr 169.254.0.253 counter packets 0 bytes 0 masquerade comment "Masquerade OVS virtual source IP"
+`
+				if tc.networkConfig.EnableHostNetworkAcceleration {
+					natPostRoutingProxyAll += fmt.Sprintf(`		ip saddr 169.254.0.253 ip daddr @peer-pod-cidr counter packets 0 bytes 0 snat to %s comment "SNAT OVS virtual source IP to gateway IP for Pod traffic"
+`, nodeConfig.GatewayConfig.IPv4.String())
+				}
+				natPostRoutingProxyAll += `		ip saddr 169.254.0.253 counter packets 0 bytes 0 masquerade comment "Masquerade OVS virtual source IP"
 	}
 }
 `
+				expectedNFTablesChains["nat-postrouting-proxy-all"] = natPostRoutingProxyAll
 			}
 
 			for set, expected := range expectedNFTablesSets {


### PR DESCRIPTION
With proxyAll, Service traffic that is DNATed to a remote Pod is
hairpinned on the Antrea gateway: it leaves OVS again through antrea-gw0
so the host can route it to the peer Node. OVS SNATs the source to the
virtual Service IP (169.254.0.253 / fc01::aabb:ccdd:eeff) so that reply
packets come back to this Node and re-enter OVS for conntrack.

Host POSTROUTING then masqueraded that virtual source to the Node IP:
```
  before:  169.254.0.253 -> remote Pod IP    (in OVS)
           Node IP       -> remote Pod IP    (leaving the host)
```
The peer Node therefore saw the flow as Node-originated rather than
Pod-to-Pod, which has two consequences: nftables flowtable rules keyed on
peer Pod CIDRs do not match, so the flow is not offloaded, and WireGuard
does not encrypt it.

Add a more specific POSTROUTING rule, placed before the existing
virtual-IP masquerade, that SNATs to the Antrea gateway IP when the
destination is a Pod CIDR:
```
  after:   169.254.0.253 -> remote Pod IP    (in OVS)
           gateway IP    -> remote Pod IP    (leaving the host)
```
The gateway IP belongs to the local Pod CIDR, so the peer Node classifies
the flow as Pod-to-Pod, restoring flowtable offload and WireGuard
encryption. Both host backends are updated: the iptables path in
restoreIptablesData and the nftables path in nftablesProxyAll.

Traffic that is not sourced from the virtual Service IP, and traffic whose
destination is not a Pod CIDR, is unaffected and still falls through to
the existing virtual-IP masquerade.

Signed-off-by: Hongliang Liu <hongliang.liu@broadcom.com>
