### PR TITLE
Add destinationServiceIP IPFIX IE, deprecate destinationClusterIP

### DIFF
--- a/docs/network-flow-visibility.md
+++ b/docs/network-flow-visibility.md
@@ -196,8 +196,10 @@ Flow Exporter are listed below:
 | destinationPodName               | 103      | string      |             |
 | sourceNodeName                   | 104      | string      |             |
 | destinationNodeName              | 105      | string      |             |
-| destinationClusterIPv4           | 106      | ipv4Address |             |
-| destinationClusterIPv6           | 107      | ipv6Address |             |
+| destinationClusterIPv4           | 106      | ipv4Address | Deprecated in favor of destinationServiceIPv4. |
+| destinationClusterIPv6           | 107      | ipv6Address | Deprecated in favor of destinationServiceIPv6. |
+| destinationServiceIPv4           | 168      | ipv4Address | The service IP (ClusterIP, NodePort, or LoadBalancer) for the destination. |
+| destinationServiceIPv6           | 169      | ipv6Address | The service IP (ClusterIP, NodePort, or LoadBalancer) for the destination. |
 | destinationServicePort           | 108      | unsigned16  |             |
 | destinationServicePortName       | 109      | string      |             |
 | ingressNetworkPolicyName         | 110      | string      | Name of the ingress network policy applied to the destination Pod for this flow. |

--- a/pkg/agent/flowexporter/exporter/grpc.go
+++ b/pkg/agent/flowexporter/exporter/grpc.go
@@ -165,6 +165,7 @@ func (e *grpcExporter) createMessage(conn *connection.Connection) *flowpb.Flow {
 	}
 	if conn.DestinationServicePortName != "" {
 		flow.K8S.DestinationClusterIp = conn.OriginalDestinationAddress.AsSlice()
+		flow.K8S.DestinationServiceIp = conn.OriginalDestinationAddress.AsSlice()
 		flow.K8S.DestinationServicePort = uint32(conn.OriginalDestinationPort)
 		flow.K8S.DestinationServicePortName = conn.DestinationServicePortName
 	}

--- a/pkg/agent/flowexporter/exporter/ipfix.go
+++ b/pkg/agent/flowexporter/exporter/ipfix.go
@@ -75,8 +75,8 @@ var (
 		"egressIP",
 		"egressNodeName",
 	}
-	AntreaInfoElementsIPv4 = append(antreaInfoElementsCommon, []string{"destinationClusterIPv4"}...)
-	AntreaInfoElementsIPv6 = append(antreaInfoElementsCommon, []string{"destinationClusterIPv6"}...)
+	AntreaInfoElementsIPv4 = append(antreaInfoElementsCommon, []string{"destinationClusterIPv4", "destinationServiceIPv4"}...)
+	AntreaInfoElementsIPv6 = append(antreaInfoElementsCommon, []string{"destinationClusterIPv6", "destinationServiceIPv6"}...)
 )
 
 type ipfixExporter struct {
@@ -343,7 +343,7 @@ func (e *ipfixExporter) addConnToSet(conn *connection.Connection) error {
 			} else {
 				ie.SetStringValue("")
 			}
-		case "destinationClusterIPv4":
+		case "destinationClusterIPv4", "destinationServiceIPv4":
 			if conn.DestinationServicePortName != "" {
 				ie.SetIPAddressValue(conn.OriginalDestinationAddress.AsSlice())
 			} else {
@@ -352,7 +352,7 @@ func (e *ipfixExporter) addConnToSet(conn *connection.Connection) error {
 				// this dummy IP address.
 				ie.SetIPAddressValue(net.IP{0, 0, 0, 0})
 			}
-		case "destinationClusterIPv6":
+		case "destinationClusterIPv6", "destinationServiceIPv6":
 			if conn.DestinationServicePortName != "" {
 				ie.SetIPAddressValue(conn.OriginalDestinationAddress.AsSlice())
 			} else {

--- a/pkg/agent/flowexporter/exporter/ipfix_test.go
+++ b/pkg/agent/flowexporter/exporter/ipfix_test.go
@@ -337,9 +337,9 @@ func getElemList(ianaIE []string, antreaIE []string) []ipfixentities.InfoElement
 			ie.SetUnsigned8Value(uint8(0))
 		case "sourceIPv4Address", "destinationIPv4Address", "sourceIPv6Address", "destinationIPv6Address":
 			ie.SetIPAddressValue(net.ParseIP(""))
-		case "destinationClusterIPv4":
+		case "destinationClusterIPv4", "destinationServiceIPv4":
 			ie.SetIPAddressValue(net.IP{0, 0, 0, 0})
-		case "destinationClusterIPv6":
+		case "destinationClusterIPv6", "destinationServiceIPv6":
 			ie.SetIPAddressValue(net.ParseIP("::"))
 		case "sourceTransportPort", "destinationTransportPort", "destinationServicePort":
 			ie.SetUnsigned16Value(uint16(0))

--- a/pkg/apis/flow/v1alpha1/flow.pb.go
+++ b/pkg/apis/flow/v1alpha1/flow.pb.go
@@ -762,6 +762,7 @@ type Kubernetes struct {
 	DestinationPodLabels           *Labels                 `protobuf:"bytes,11,opt,name=destination_pod_labels,json=destinationPodLabels,proto3" json:"destination_pod_labels,omitempty"`
 	DestinationNodeName            string                  `protobuf:"bytes,12,opt,name=destination_node_name,json=destinationNodeName,proto3" json:"destination_node_name,omitempty"`
 	DestinationNodeUid             string                  `protobuf:"bytes,13,opt,name=destination_node_uid,json=destinationNodeUid,proto3" json:"destination_node_uid,omitempty"`
+	// Deprecated: use DestinationServiceIp instead.
 	DestinationClusterIp           []byte                  `protobuf:"bytes,14,opt,name=destination_cluster_ip,json=destinationClusterIp,proto3" json:"destination_cluster_ip,omitempty"`
 	DestinationServicePort         uint32                  `protobuf:"varint,15,opt,name=destination_service_port,json=destinationServicePort,proto3" json:"destination_service_port,omitempty"`
 	DestinationServicePortName     string                  `protobuf:"bytes,16,opt,name=destination_service_port_name,json=destinationServicePortName,proto3" json:"destination_service_port_name,omitempty"`
@@ -783,6 +784,7 @@ type Kubernetes struct {
 	EgressNodeName                 string                  `protobuf:"bytes,32,opt,name=egress_node_name,json=egressNodeName,proto3" json:"egress_node_name,omitempty"`
 	EgressNodeUid                  string                  `protobuf:"bytes,33,opt,name=egress_node_uid,json=egressNodeUid,proto3" json:"egress_node_uid,omitempty"`
 	EgressUid                      string                  `protobuf:"bytes,34,opt,name=egress_uid,json=egressUid,proto3" json:"egress_uid,omitempty"`
+	DestinationServiceIp           []byte                  `protobuf:"bytes,35,opt,name=destination_service_ip,json=destinationServiceIp,proto3" json:"destination_service_ip,omitempty"`
 }
 
 func (x *Kubernetes) Reset() {
@@ -1053,6 +1055,13 @@ func (x *Kubernetes) GetEgressUid() string {
 		return x.EgressUid
 	}
 	return ""
+}
+
+func (x *Kubernetes) GetDestinationServiceIp() []byte {
+	if x != nil {
+		return x.DestinationServiceIp
+	}
+	return nil
 }
 
 type App struct {

--- a/pkg/apis/flow/v1alpha1/flow.proto
+++ b/pkg/apis/flow/v1alpha1/flow.proto
@@ -117,7 +117,7 @@ message Kubernetes {
   string destination_node_name = 12;
   string destination_node_uid = 13;
 
-  bytes destination_cluster_ip = 14;
+  bytes destination_cluster_ip = 14 [deprecated = true];
   uint32 destination_service_port = 15;
   string destination_service_port_name = 16;
   string destination_service_uid = 17;
@@ -141,6 +141,8 @@ message Kubernetes {
   string egress_node_name = 32;
   string egress_node_uid = 33;
   string egress_uid = 34;
+
+  bytes destination_service_ip = 35;
 }
 
 message App {

--- a/pkg/flowaggregator/clickhouseclient/clickhouseclient.go
+++ b/pkg/flowaggregator/clickhouseclient/clickhouseclient.go
@@ -63,6 +63,7 @@ const (
                    destinationPodNamespace,
                    destinationNodeName,
                    destinationClusterIP,
+                   destinationServiceIP,
                    destinationServicePort,
                    destinationServicePortName,
                    ingressNetworkPolicyName,
@@ -89,9 +90,9 @@ const (
                    egressName,
                    egressIP,
                    egressNodeName)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
                            ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                           ?, ?, ?, ?, ?)`
+                           ?, ?, ?, ?, ?, ?)`
 )
 
 // PrepareClickHouseConnection is used for unit testing
@@ -306,6 +307,7 @@ func (ch *ClickHouseExportProcess) batchCommitAll(ctx context.Context) (int, err
 			record.DestinationPodNamespace,
 			record.DestinationNodeName,
 			record.DestinationClusterIP,
+			record.DestinationServiceIP,
 			record.DestinationServicePort,
 			record.DestinationServicePortName,
 			record.IngressNetworkPolicyName,

--- a/pkg/flowaggregator/collector/preprocessor.go
+++ b/pkg/flowaggregator/collector/preprocessor.go
@@ -155,6 +155,16 @@ func (p *preprocessor) processMsg(msg *entities.Message) {
 				if !ip.Equal(net.IPv6zero) {
 					flow.K8S.DestinationClusterIp = ie.GetIPAddressValue()
 				}
+			case "destinationServiceIPv4":
+				ip := ie.GetIPAddressValue()
+				if !ip.Equal(net.IPv4zero) {
+					flow.K8S.DestinationServiceIp = ie.GetIPAddressValue()
+				}
+			case "destinationServiceIPv6":
+				ip := ie.GetIPAddressValue()
+				if !ip.Equal(net.IPv6zero) {
+					flow.K8S.DestinationServiceIp = ie.GetIPAddressValue()
+				}
 			case "destinationServicePort":
 				flow.K8S.DestinationServicePort = uint32(ie.GetUnsigned16Value())
 			case "destinationServicePortName":

--- a/pkg/flowaggregator/collector/preprocessor_test.go
+++ b/pkg/flowaggregator/collector/preprocessor_test.go
@@ -202,6 +202,10 @@ func createTestElements(isIPv4 bool) []ipfixentities.InfoElementWithValue {
 		destinationClusterIPv4Elem.SetIPAddressValue(netip.MustParseAddr("10.10.1.10").AsSlice())
 		elements = append(elements, destinationClusterIPv4Elem)
 
+		destinationServiceIPv4Elem := createTestElement("destinationServiceIPv4", ipfixregistry.AntreaEnterpriseID)
+		destinationServiceIPv4Elem.SetIPAddressValue(netip.MustParseAddr("10.10.1.10").AsSlice())
+		elements = append(elements, destinationServiceIPv4Elem)
+
 		egressIPElem := createTestElement("egressIP", ipfixregistry.AntreaEnterpriseID)
 		egressIPElem.SetStringValue("172.18.0.1")
 		elements = append(elements, egressIPElem)
@@ -217,6 +221,10 @@ func createTestElements(isIPv4 bool) []ipfixentities.InfoElementWithValue {
 		destinationClusterIPv6Elem := createTestElement("destinationClusterIPv6", ipfixregistry.AntreaEnterpriseID)
 		destinationClusterIPv6Elem.SetIPAddressValue(netip.MustParseAddr("2001:0:3238:dfe1:64::a").AsSlice())
 		elements = append(elements, destinationClusterIPv6Elem)
+
+		destinationServiceIPv6Elem := createTestElement("destinationServiceIPv6", ipfixregistry.AntreaEnterpriseID)
+		destinationServiceIPv6Elem.SetIPAddressValue(netip.MustParseAddr("2001:0:3238:dfe1:64::a").AsSlice())
+		elements = append(elements, destinationServiceIPv6Elem)
 
 		egressIPElem := createTestElement("egressIP", ipfixregistry.AntreaEnterpriseID)
 		egressIPElem.SetStringValue("2001:0:3238:dfe1::ac12:1")
@@ -271,6 +279,7 @@ func createExpectedFlowRecord(isIPv4 bool) *flowpb.Flow {
 			DestinationPodNamespace:        "antrea-test-b",
 			DestinationNodeName:            "k8s-node-control-plane-b",
 			DestinationClusterIp:           destinationClusterIP.AsSlice(),
+			DestinationServiceIp:           destinationClusterIP.AsSlice(),
 			DestinationServicePort:         5202,
 			DestinationServicePortName:     "perftest",
 			IngressNetworkPolicyName:       "test-flow-aggregator-networkpolicy-ingress-allow",

--- a/pkg/flowaggregator/exporter/ipfix.go
+++ b/pkg/flowaggregator/exporter/ipfix.go
@@ -390,6 +390,7 @@ func (e *IPFIXExporter) makeIPFIXRecord(flow *flowpb.Flow, isIPv6 bool) ipfixent
 		setUUID(flow.K8S.EgressNodeUid)
 	}
 	setIPAddress(flow.K8S.DestinationClusterIp)
+	setIPAddress(flow.K8S.DestinationServiceIp)
 	if e.aggregatorMode == flowaggregatorconfig.AggregatorModeAggregate {
 		// Add Antrea source stats fields
 		next().SetUnsigned64Value(flow.Aggregation.StatsFromSource.PacketTotalCount)

--- a/pkg/flowaggregator/flowlogger/logger.go
+++ b/pkg/flowaggregator/flowlogger/logger.go
@@ -102,6 +102,7 @@ func (fl *FlowLogger) WriteRecord(r *flowrecord.FlowRecord, prettyPrint bool) er
 		r.DestinationPodNamespace,
 		r.DestinationNodeName,
 		r.DestinationClusterIP,
+		r.DestinationServiceIP,
 		fmt.Sprintf("%d", r.DestinationServicePort),
 		r.DestinationServicePortName,
 		r.IngressNetworkPolicyName,

--- a/pkg/flowaggregator/flowrecord/record.go
+++ b/pkg/flowaggregator/flowrecord/record.go
@@ -49,6 +49,7 @@ type FlowRecord struct {
 	DestinationPodNamespace              string
 	DestinationNodeName                  string
 	DestinationClusterIP                 string
+	DestinationServiceIP                 string
 	DestinationServicePort               uint16
 	DestinationServicePortName           string
 	IngressNetworkPolicyName             string
@@ -144,6 +145,7 @@ func GetFlowRecord(record *flowpb.Flow) (*FlowRecord, error) {
 		DestinationPodNamespace:           record.K8S.DestinationPodNamespace,
 		DestinationNodeName:               record.K8S.DestinationNodeName,
 		DestinationClusterIP:              ipAddressAsString(record.K8S.DestinationClusterIp),
+		DestinationServiceIP:              ipAddressAsString(record.K8S.DestinationServiceIp),
 		DestinationServicePort:            uint16(record.K8S.DestinationServicePort),
 		DestinationServicePortName:        record.K8S.DestinationServicePortName,
 		IngressNetworkPolicyName:          record.K8S.IngressNetworkPolicyName,

--- a/pkg/flowaggregator/flowrecord/record_test.go
+++ b/pkg/flowaggregator/flowrecord/record_test.go
@@ -80,11 +80,13 @@ func TestGetFlowRecord(t *testing.T) {
 			assert.Equal(t, "10.10.0.79", flowRecord.SourceIP)
 			assert.Equal(t, "10.10.0.80", flowRecord.DestinationIP)
 			assert.Equal(t, "10.10.1.10", flowRecord.DestinationClusterIP)
+			assert.Equal(t, "10.10.1.10", flowRecord.DestinationServiceIP)
 			assert.Equal(t, "172.18.0.1", flowRecord.EgressIP)
 		} else {
 			assert.Equal(t, "2001:0:3238:dfe1:63::fefb", flowRecord.SourceIP)
 			assert.Equal(t, "2001:0:3238:dfe1:63::fefc", flowRecord.DestinationIP)
 			assert.Equal(t, "2001:0:3238:dfe1:64::a", flowRecord.DestinationClusterIP)
+			assert.Equal(t, "2001:0:3238:dfe1:64::a", flowRecord.DestinationServiceIP)
 			assert.Equal(t, "2001:0:3238:dfe1::ac12:1", flowRecord.EgressIP)
 		}
 	}

--- a/pkg/flowaggregator/flowrecord/testing/util.go
+++ b/pkg/flowaggregator/flowrecord/testing/util.go
@@ -48,6 +48,7 @@ func PrepareTestFlowRecord() *flowrecord.FlowRecord {
 		DestinationPodNamespace:              "antrea-test-b",
 		DestinationNodeName:                  "k8s-node-control-plane-b",
 		DestinationClusterIP:                 "10.10.1.10",
+		DestinationServiceIP:                 "10.10.1.10",
 		DestinationServicePort:               5202,
 		DestinationServicePortName:           "perftest",
 		IngressNetworkPolicyName:             "test-flow-aggregator-networkpolicy-ingress-allow",

--- a/pkg/flowaggregator/infoelements/elements.go
+++ b/pkg/flowaggregator/infoelements/elements.go
@@ -177,8 +177,10 @@ func AntreaInfoElements(includeK8sNames, includeK8sUIDs, isIPv6 bool) []string {
 	}
 	if isIPv6 {
 		ies = append(ies, "destinationClusterIPv6")
+		ies = append(ies, "destinationServiceIPv6")
 	} else {
 		ies = append(ies, "destinationClusterIPv4")
+		ies = append(ies, "destinationServiceIPv4")
 	}
 	return ies
 }

--- a/pkg/flowaggregator/infoelements/elements_test.go
+++ b/pkg/flowaggregator/infoelements/elements_test.go
@@ -150,11 +150,11 @@ func TestAntreaInfoElements(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Run("ipv4", func(t *testing.T) {
-				expectedIEs := append(tc.expectedIEs, "destinationClusterIPv4")
+				expectedIEs := append(tc.expectedIEs, "destinationClusterIPv4", "destinationServiceIPv4")
 				assert.Equal(t, expectedIEs, AntreaInfoElements(tc.includeK8sNames, tc.includeK8sUIDs, false))
 			})
 			t.Run("ipv6", func(t *testing.T) {
-				expectedIEs := append(tc.expectedIEs, "destinationClusterIPv6")
+				expectedIEs := append(tc.expectedIEs, "destinationClusterIPv6", "destinationServiceIPv6")
 				assert.Equal(t, expectedIEs, AntreaInfoElements(tc.includeK8sNames, tc.includeK8sUIDs, true))
 			})
 		})

--- a/pkg/flowaggregator/intermediate/aggregate.go
+++ b/pkg/flowaggregator/intermediate/aggregate.go
@@ -229,10 +229,12 @@ func (a *aggregationProcess) GetRecords(flowKey *FlowKey) []map[string]interface
 			m["sourceIPv4Address"] = net.IP(f.Ip.Source)
 			m["destinationIPv4Address"] = net.IP(f.Ip.Destination)
 			m["destinationClusterIPv4"] = net.IP(f.K8S.DestinationClusterIp)
+			m["destinationServiceIPv4"] = net.IP(f.K8S.DestinationServiceIp)
 		} else {
 			m["sourceIPv6Address"] = net.IP(f.Ip.Source)
 			m["destinationIPv6Address"] = net.IP(f.Ip.Destination)
 			m["destinationClusterIPv6"] = net.IP(f.K8S.DestinationClusterIp)
+			m["destinationServiceIPv6"] = net.IP(f.K8S.DestinationServiceIp)
 		}
 		return m
 	}
@@ -462,6 +464,9 @@ func (a *aggregationProcess) correlateRecords(incomingRecord, existingRecord *fl
 	}
 	if destinationClusterIP := incomingRecord.K8S.DestinationClusterIp; destinationClusterIP != nil {
 		existingRecord.K8S.DestinationClusterIp = destinationClusterIP
+	}
+	if destinationServiceIP := incomingRecord.K8S.DestinationServiceIp; destinationServiceIP != nil {
+		existingRecord.K8S.DestinationServiceIp = destinationServiceIP
 	}
 	if destinationServicePort := incomingRecord.K8S.DestinationServicePort; destinationServicePort != 0 {
 		existingRecord.K8S.DestinationServicePort = destinationServicePort

--- a/pkg/flowaggregator/intermediate/aggregate_test.go
+++ b/pkg/flowaggregator/intermediate/aggregate_test.go
@@ -99,8 +99,10 @@ func createFlowRecordForSrc(isIPv6 bool, flowType flowpb.FlowType, isUpdatedReco
 	record.K8S.DestinationServicePort = 4739
 	if isIPv6 {
 		record.K8S.DestinationClusterIp = netip.MustParseAddr("2001:0:3238:BBBB:63::AAAA").AsSlice()
+		record.K8S.DestinationServiceIp = netip.MustParseAddr("2001:0:3238:BBBB:63::AAAA").AsSlice()
 	} else {
 		record.K8S.DestinationClusterIp = netip.MustParseAddr("192.168.0.1").AsSlice()
+		record.K8S.DestinationServiceIp = netip.MustParseAddr("192.168.0.1").AsSlice()
 	}
 	record.K8S.EgressNetworkPolicyRuleAction = egressNetworkPolicyRuleAction
 	if !isUpdatedRecord {
@@ -131,8 +133,10 @@ func createFlowRecordForDst(isIPv6 bool, flowType flowpb.FlowType, isUpdatedReco
 		record.K8S.DestinationServicePort = 4739
 		if isIPv6 {
 			record.K8S.DestinationClusterIp = netip.MustParseAddr("2001:0:3238:BBBB:63::AAAA").AsSlice()
+			record.K8S.DestinationServiceIp = netip.MustParseAddr("2001:0:3238:BBBB:63::AAAA").AsSlice()
 		} else {
 			record.K8S.DestinationClusterIp = netip.MustParseAddr("192.168.0.1").AsSlice()
+			record.K8S.DestinationServiceIp = netip.MustParseAddr("192.168.0.1").AsSlice()
 		}
 	}
 	record.K8S.IngressNetworkPolicyRuleAction = ingressNetworkPolicyRuleAction
@@ -481,10 +485,12 @@ func assertElementMap(t *testing.T, record map[string]interface{}, ipv6 bool) {
 		assert.Equal(t, net.ParseIP("2001:0:3238:dfe1:63::fefb"), record["sourceIPv6Address"])
 		assert.Equal(t, net.ParseIP("2001:0:3238:dfe1:63::fefc"), record["destinationIPv6Address"])
 		assert.Equal(t, net.ParseIP("2001:0:3238:bbbb:63::aaaa"), record["destinationClusterIPv6"])
+		assert.Equal(t, net.ParseIP("2001:0:3238:bbbb:63::aaaa"), record["destinationServiceIPv6"])
 	} else {
 		assert.Equal(t, net.ParseIP("10.0.0.1").To4(), record["sourceIPv4Address"])
 		assert.Equal(t, net.ParseIP("10.0.0.2").To4(), record["destinationIPv4Address"])
 		assert.Equal(t, net.ParseIP("192.168.0.1").To4(), record["destinationClusterIPv4"])
+		assert.Equal(t, net.ParseIP("192.168.0.1").To4(), record["destinationServiceIPv4"])
 	}
 	assert.Equal(t, uint16(1234), record["sourceTransportPort"])
 	assert.Equal(t, uint16(5678), record["destinationTransportPort"])

--- a/pkg/flowaggregator/s3uploader/s3uploader.go
+++ b/pkg/flowaggregator/s3uploader/s3uploader.go
@@ -431,6 +431,8 @@ func writeRecord(w io.Writer, r *flowrecord.FlowRecord, clusterUUID string) {
 	io.WriteString(w, ",")
 	io.WriteString(w, r.DestinationClusterIP)
 	io.WriteString(w, ",")
+	io.WriteString(w, r.DestinationServiceIP)
+	io.WriteString(w, ",")
 	io.WriteString(w, fmt.Sprintf("%d", r.DestinationServicePort))
 	io.WriteString(w, ",")
 	io.WriteString(w, r.DestinationServicePortName)

--- a/pkg/flowaggregator/testing/util.go
+++ b/pkg/flowaggregator/testing/util.go
@@ -81,6 +81,7 @@ func PrepareTestFlowRecord(isIPv4 bool) *flowpb.Flow {
 			},
 			DestinationNodeName:            "k8s-node-control-plane-b",
 			DestinationClusterIp:           destinationClusterIP.AsSlice(),
+			DestinationServiceIp:           destinationClusterIP.AsSlice(),
 			DestinationServicePort:         5202,
 			DestinationServicePortName:     "perftest",
 			IngressNetworkPolicyName:       "test-flow-aggregator-networkpolicy-ingress-allow",


### PR DESCRIPTION
Addresses #7610

The `destinationClusterIP` IE name is misleading — it implies only ClusterIP, but in practice it records NodePort and LoadBalancer IPs too when the flow originates externally. This adds `destinationServiceIPv4`/`v6` (IEs 168/169, already registered in go-ipfix) as the replacement.

Both old and new IEs/proto fields are populated during the transition. The old proto field (`destination_cluster_ip`, field 14) is marked `[deprecated = true]`. The actual IE deprecation in go-ipfix registry (marking 106/107 as deprecated) will be done in a separate PR there.

What changed:
- Proto: marked field 14 deprecated, added `destination_service_ip` as field 35
- Agent flow exporter: populates both old and new IEs in IPFIX records and gRPC export
- Flow aggregator: handles both old and new IEs in collector, aggregator, IPFIX exporter, ClickHouse client, S3 uploader, and logger
- Tests updated across the board
- Docs: marked old IEs as deprecated in the IE registry table, added new ones

I followed the checklist from @antoninbas in the issue. The go-ipfix registry change (marking 106/107 status as deprecated) can be done as a follow-up.