### PR TITLE
Fix flaky TestCluster_RejoinNodes unit test

### DIFF
--- a/pkg/agent/memberlist/cluster_test.go
+++ b/pkg/agent/memberlist/cluster_test.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/hashicorp/memberlist"
@@ -676,25 +677,34 @@ func TestCluster_RejoinNodes(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "winnode1", Labels: labelsWindowsOS},
 		Status:     v1.NodeStatus{Addresses: []v1.NodeAddress{{Type: v1.NodeInternalIP, Address: "10.0.0.11"}}},
 	}
-	stopCh := make(chan struct{})
-	defer close(stopCh)
-	controller := gomock.NewController(t)
-	mockMemberlist := NewMockMemberlist(controller)
-	mockMemberlist.EXPECT().Join([]string{"10.0.0.2"})
-	mockMemberlist.EXPECT().Join([]string{"10.0.0.3"})
-	fakeCluster, _ := newFakeCluster(localNodeConfig, stopCh, mockMemberlist, node1, node2, node3, winNode1)
+	synctest.Test(t, func(t *testing.T) {
+		stopCh := make(chan struct{})
+		defer close(stopCh)
+		controller := gomock.NewController(t)
+		mockMemberlist := NewMockMemberlist(controller)
+		mockMemberlist.EXPECT().Join([]string{"10.0.0.2"}).Return(1, nil)
+		mockMemberlist.EXPECT().Join([]string{"10.0.0.3"}).Return(1, nil)
+		fakeCluster, _ := newFakeCluster(localNodeConfig, stopCh, mockMemberlist, node1, node2, node3, winNode1)
+		defer fakeCluster.cluster.queue.ShutDown()
+		// We need to wait for the "add" event handler (handleCreateNode) to have been
+		// called for the initial list of Nodes. Otherwise, we can potentially end up with a
+		// flaky test, as it is possible for the test to exit with some unsatisfied
+		// expectations.
+		// This is also the reason why we use a synctest bubble to begin with.
+		synctest.Wait()
 
-	mockMemberlist.EXPECT().Members().Return([]*memberlist.Node{
-		{Name: "node1"},
-		{Name: "node2"},
-	})
-	mockMemberlist.EXPECT().Join([]string{"10.0.0.3"})
-	fakeCluster.cluster.RejoinNodes()
+		mockMemberlist.EXPECT().Members().Return([]*memberlist.Node{
+			{Name: "node1"},
+			{Name: "node2"},
+		})
+		mockMemberlist.EXPECT().Join([]string{"10.0.0.3"}).Return(1, nil)
+		fakeCluster.cluster.RejoinNodes()
 
-	mockMemberlist.EXPECT().Members().Return([]*memberlist.Node{
-		{Name: "node1"},
-		{Name: "node3"},
+		mockMemberlist.EXPECT().Members().Return([]*memberlist.Node{
+			{Name: "node1"},
+			{Name: "node3"},
+		})
+		mockMemberlist.EXPECT().Join([]string{"10.0.0.2"}).Return(1, nil)
+		fakeCluster.cluster.RejoinNodes()
 	})
-	mockMemberlist.EXPECT().Join([]string{"10.0.0.2"})
-	fakeCluster.cluster.RejoinNodes()
 }


### PR DESCRIPTION
The test was failing randomly in CI because of some unsatisified expectations. The original test did not account for the fact that WaitForCacheSync returns true as soom as the informer cache has been populated, and does not wait for registered event handlers to be called for the initial list of resources (Nodes in this case).

To fix the test, we run it in a synctest bubble. While there are other ways to address the issue, 1) this is a simple approach, 2) it doesn't require any change to non-test code, 3) it makes the test slightly faster by removing a 100ms polling period in the first WaitForCacheSync call.