### PR TITLE
Fix OVSBridge.Create hardware offload error handling and parsing

### DIFF
--- a/pkg/ovs/ovsconfig/ovs_client.go
+++ b/pkg/ovs/ovsconfig/ovs_client.go
@@ -1066,20 +1066,19 @@ func (br *OVSBridge) getHardwareOffload() (bool, Error) {
 	return parseHardwareOffloadConfig(otherConfig)
 }
 
-// parseHardwareOffloadConfig reads the hardware-offload key from the OVS
+// parseHardwareOffloadConfig reads the hw-offload key from the OVS
 // other_config map and returns its boolean value. It returns false with no
 // error when the key is absent.
 func parseHardwareOffloadConfig(otherConfig map[string]string) (bool, Error) {
-	for configKey, configValue := range otherConfig {
-		if configKey == hardwareOffload {
-			boolConfigVal, err := strconv.ParseBool(configValue)
-			if err != nil {
-				return false, newInvalidArgumentsError(fmt.Sprint("invalid hardwareOffload value: ", configValue))
-			}
-			return boolConfigVal, nil
-		}
+	configValue, ok := otherConfig[hardwareOffload]
+	if !ok {
+		return false, nil
 	}
-	return false, nil
+	boolConfigVal, err := strconv.ParseBool(configValue)
+	if err != nil {
+		return false, newInvalidArgumentsError(fmt.Sprintf("invalid %s value: %q", hardwareOffload, configValue))
+	}
+	return boolConfigVal, nil
 }
 
 func (br *OVSBridge) GetOVSDatapathType() OVSDatapathType {

--- a/pkg/ovs/ovsconfig/ovs_client.go
+++ b/pkg/ovs/ovsconfig/ovs_client.go
@@ -145,7 +145,7 @@ func (br *OVSBridge) Create() Error {
 	}
 	br.isHardwareOffloadEnabled, err = br.getHardwareOffload()
 	if err != nil {
-		klog.ErrorS(err, "Failed to get hardware offload")
+		return err
 	}
 	return nil
 }
@@ -1063,11 +1063,18 @@ func (br *OVSBridge) getHardwareOffload() (bool, Error) {
 	if err != nil {
 		return false, err
 	}
+	return parseHardwareOffloadConfig(otherConfig)
+}
+
+// parseHardwareOffloadConfig reads the hardware-offload key from the OVS
+// other_config map and returns its boolean value. It returns false with no
+// error when the key is absent.
+func parseHardwareOffloadConfig(otherConfig map[string]string) (bool, Error) {
 	for configKey, configValue := range otherConfig {
 		if configKey == hardwareOffload {
 			boolConfigVal, err := strconv.ParseBool(configValue)
 			if err != nil {
-				return boolConfigVal, newInvalidArgumentsError(fmt.Sprint("invalid hardwareOffload value: ", boolConfigVal))
+				return false, newInvalidArgumentsError(fmt.Sprint("invalid hardwareOffload value: ", configValue))
 			}
 			return boolConfigVal, nil
 		}

--- a/pkg/ovs/ovsconfig/ovs_client_test.go
+++ b/pkg/ovs/ovsconfig/ovs_client_test.go
@@ -16,9 +16,11 @@ package ovsconfig
 
 import (
 	"net"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestOVSClient(t *testing.T) {
@@ -117,4 +119,70 @@ func TestBuildPortDataCommon(t *testing.T) {
 		})
 	}
 
+}
+
+func TestParseHardwareOffloadConfig(t *testing.T) {
+	tests := []struct {
+		name            string
+		otherConfig     map[string]string
+		expectedEnabled bool
+		expectErr       bool
+		errContains     string
+	}{
+		{
+			name:            "empty config returns false",
+			otherConfig:     map[string]string{},
+			expectedEnabled: false,
+		},
+		{
+			name:            "hw-offload set to true",
+			otherConfig:     map[string]string{"hw-offload": "true"},
+			expectedEnabled: true,
+		},
+		{
+			name:            "hw-offload set to false",
+			otherConfig:     map[string]string{"hw-offload": "false"},
+			expectedEnabled: false,
+		},
+		{
+			name:            "hw-offload set to 1 (alternate truthy form)",
+			otherConfig:     map[string]string{"hw-offload": "1"},
+			expectedEnabled: true,
+		},
+		{
+			name:            "hw-offload set to 0 (alternate falsy form)",
+			otherConfig:     map[string]string{"hw-offload": "0"},
+			expectedEnabled: false,
+		},
+		{
+			name:        "hw-offload set to invalid value returns error with original string",
+			otherConfig: map[string]string{"hw-offload": "notabool"},
+			expectErr:   true,
+			errContains: "notabool",
+		},
+		{
+			name:            "unrelated keys present, no hw-offload key returns false",
+			otherConfig:     map[string]string{"flow-restore-wait": "true", "disable-in-band": "true"},
+			expectedEnabled: false,
+		},
+		{
+			name:            "multiple keys including hw-offload true",
+			otherConfig:     map[string]string{"flow-restore-wait": "true", "hw-offload": "true"},
+			expectedEnabled: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			enabled, err := parseHardwareOffloadConfig(tc.otherConfig)
+			if tc.expectErr {
+				require.Error(t, err)
+				assert.True(t, strings.Contains(err.Error(), tc.errContains),
+					"expected error message to contain %q, got: %s", tc.errContains, err.Error())
+				assert.False(t, enabled)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.expectedEnabled, enabled)
+			}
+		})
+	}
 }

--- a/pkg/ovs/ovsconfig/ovs_client_test.go
+++ b/pkg/ovs/ovsconfig/ovs_client_test.go
@@ -155,10 +155,10 @@ func TestParseHardwareOffloadConfig(t *testing.T) {
 			expectedEnabled: false,
 		},
 		{
-			name:        "hw-offload set to invalid value returns error with original string",
+			name:        "hw-offload set to invalid value returns error with key name and original string",
 			otherConfig: map[string]string{"hw-offload": "notabool"},
 			expectErr:   true,
-			errContains: "notabool",
+			errContains: "hw-offload",
 		},
 		{
 			name:            "unrelated keys present, no hw-offload key returns false",


### PR DESCRIPTION
fixes #7978

- Fix OVSBridge.Create() to return an error when reading hardware offload config fails, instead of logging and returning success.
- Refactor hardware offload parsing into a small helper (parseHardwareOffloadConfig) for clearer behavior and easier testing.
- Improve invalid-value error reporting to include the original hw-offload string from OVS config.

**Testing**

- Added unit tests for hardware offload parsing in pkg/ovs/ovsconfig/ovs_client_test.go:

key missing
valid true/false values
alternate boolean forms (1 / 0)
invalid value path with error message check
unrelated keys present


`=== RUN   TestOVSClient
--- PASS: TestOVSClient (0.00s)
=== RUN   TestBuildPortDataCommon
=== RUN   TestBuildPortDataCommon/gw-port
=== RUN   TestBuildPortDataCommon/tun-port
=== RUN   TestBuildPortDataCommon/general-port
=== RUN   TestBuildPortDataCommon/access-port
=== RUN   TestBuildPortDataCommon/no-mac-port
--- PASS: TestBuildPortDataCommon (0.00s)
    --- PASS: TestBuildPortDataCommon/gw-port (0.00s)
    --- PASS: TestBuildPortDataCommon/tun-port (0.00s)
    --- PASS: TestBuildPortDataCommon/general-port (0.00s)
    --- PASS: TestBuildPortDataCommon/access-port (0.00s)
    --- PASS: TestBuildPortDataCommon/no-mac-port (0.00s)
=== RUN   TestParseHardwareOffloadConfig
=== RUN   TestParseHardwareOffloadConfig/empty_config_returns_false
=== RUN   TestParseHardwareOffloadConfig/hw-offload_set_to_true
=== RUN   TestParseHardwareOffloadConfig/hw-offload_set_to_false
=== RUN   TestParseHardwareOffloadConfig/hw-offload_set_to_1_(alternate_truthy_form)
=== RUN   TestParseHardwareOffloadConfig/hw-offload_set_to_0_(alternate_falsy_form)
=== RUN   TestParseHardwareOffloadConfig/hw-offload_set_to_invalid_value_returns_error_with_original_string
=== RUN   TestParseHardwareOffloadConfig/unrelated_keys_present,_no_hw-offload_key_returns_false
=== RUN   TestParseHardwareOffloadConfig/multiple_keys_including_hw-offload_true
--- PASS: TestParseHardwareOffloadConfig (0.00s)
    --- PASS: TestParseHardwareOffloadConfig/empty_config_returns_false (0.00s)
    --- PASS: TestParseHardwareOffloadConfig/hw-offload_set_to_true (0.00s)
    --- PASS: TestParseHardwareOffloadConfig/hw-offload_set_to_false (0.00s)
    --- PASS: TestParseHardwareOffloadConfig/hw-offload_set_to_1_(alternate_truthy_form) (0.00s)
    --- PASS: TestParseHardwareOffloadConfig/hw-offload_set_to_0_(alternate_falsy_form) (0.00s)
    --- PASS: TestParseHardwareOffloadConfig/hw-offload_set_to_invalid_value_returns_error_with_original_string (0.00s)
    --- PASS: TestParseHardwareOffloadConfig/unrelated_keys_present,_no_hw-offload_key_returns_false (0.00s)
    --- PASS: TestParseHardwareOffloadConfig/multiple_keys_including_hw-offload_true (0.00s)
PASS
ok  	antrea.io/antrea/v2/pkg/ovs/ovsconfig	0.262s
?   	antrea.io/antrea/v2/pkg/ovs/ovsconfig/testing	[no test files]
`