### PR TITLE
Refactor IPFIXExporter Run loop

### DIFF
--- a/pkg/flowaggregator/exporter/ipfix.go
+++ b/pkg/flowaggregator/exporter/ipfix.go
@@ -17,7 +17,6 @@ package exporter
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"hash/fnv"
 	"net"
@@ -31,7 +30,6 @@ import (
 	ipfixregistry "github.com/vmware/go-ipfix/pkg/registry"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/clock"
 
 	flowpb "antrea.io/antrea/v2/pkg/apis/flow/v1alpha1"
 	flowaggregatorconfig "antrea.io/antrea/v2/pkg/config/flowaggregator"
@@ -57,8 +55,6 @@ const (
 	flushInterval = 1 * time.Second
 )
 
-var ErrIPFIXExporterBackoff = errors.New("backoff needed")
-
 type IPFIXExporter struct {
 	config                     flowaggregatorconfig.FlowCollectorConfig
 	externalFlowCollectorAddr  string
@@ -80,11 +76,6 @@ type IPFIXExporter struct {
 	clusterID                  string
 	maxIPFIXMsgSize            int
 	tls                        ipfixExporterTLSConfig
-	// initBackoff is used to enforce some minimum delay between initialization attempts.
-	initBackoff wait.Backoff
-	// initNextAttempt is the time after which the next initialization can be attempted.
-	initNextAttempt time.Time
-	clock           clock.Clock
 }
 
 type ipfixExporterTLSConfig struct {
@@ -140,16 +131,6 @@ func NewIPFIXExporter(
 	opt *options.Options,
 	registry ipfix.IPFIXRegistry,
 ) *IPFIXExporter {
-	return newIPFIXExporterWithClock(clusterUUID, clusterID, opt, registry, clock.RealClock{})
-}
-
-func newIPFIXExporterWithClock(
-	clusterUUID uuid.UUID,
-	clusterID string,
-	opt *options.Options,
-	registry ipfix.IPFIXRegistry,
-	clock clock.Clock,
-) *IPFIXExporter {
 	var sendJSONRecord bool
 	if opt.Config.FlowCollector.RecordFormat == "JSON" {
 		sendJSONRecord = true
@@ -165,7 +146,7 @@ func newIPFIXExporterWithClock(
 	}
 	klog.InfoS("Flow aggregator Observation Domain ID", "domainID", observationDomainID)
 
-	exporter := &IPFIXExporter{
+	return &IPFIXExporter{
 		config:                     opt.Config.FlowCollector,
 		externalFlowCollectorAddr:  opt.ExternalFlowCollectorAddr,
 		externalFlowCollectorProto: opt.ExternalFlowCollectorProto,
@@ -180,12 +161,7 @@ func newIPFIXExporterWithClock(
 		clusterID:                  clusterID,
 		maxIPFIXMsgSize:            int(opt.Config.FlowCollector.MaxIPFIXMsgSize),
 		tls:                        newIPFIXExporterTLSConfig(opt.Config.FlowCollector.TLS),
-		initBackoff:                newInitBackoff(),
-		initNextAttempt:            clock.Now(),
-		clock:                      clock,
 	}
-
-	return exporter
 }
 
 func (e *IPFIXExporter) reset() {
@@ -205,40 +181,80 @@ func (e *IPFIXExporter) Run(ctx context.Context, buf ringbuffer.BroadcastBuffer[
 		}
 	}()
 
-	// consumeDeadline must be <= flushInterval so that ConsumeMultiple returns
-	// often enough for the flush ticker to be checked promptly.
+	// consumeDeadline must be <= flushInterval so that Consume returns often
+	// enough for the flush ticker to be checked promptly.
 	consumer := buf.NewConsumer(ringbuffer.WithMaxConsumeDeadline(consumeDeadline))
 	flushTicker := time.NewTicker(flushInterval)
 	defer flushTicker.Stop()
 
-	records := make([]*flowpb.Flow, consumeMultipleBatchSize)
+	waitCh := make(chan struct{})
+	close(waitCh)
+	var waitTimer *time.Timer
+	waitFor := func(d time.Duration) {
+		// Using AfterFunc makes more sense than After: we want to use a custom
+		// channel and close it when we need the <- waitCh case to act as a
+		// "default" case in the select statement below.
+		waitCh = make(chan struct{})
+		ch := waitCh
+		waitTimer = time.AfterFunc(d, func() {
+			close(ch)
+		})
+	}
+
+	// initBackoff is used to enforce some minimum delay between initialization attempts.
+	initBackoff := newInitBackoff()
+	// initNextAttempt is the time after which the next initialization can be attempted.
+	initNextAttempt := time.Now()
+
 	for {
 		select {
 		case <-ctx.Done():
+			if waitTimer != nil {
+				waitTimer.Stop()
+			}
 			return
 		case <-flushTicker.C:
+			// Note that e.flush() will be a no-op and return nil if the exporting
+			// process is not initialized.
 			if err := e.flush(); err != nil {
 				klog.ErrorS(err, "Error when flushing IPFIX exporter")
 			}
-		default:
+		case <-waitCh: // if waitCh is closed, this case acts as a "default" case
+			break
 		}
 
-		n, _, shutdown := consumer.ConsumeMultiple(records)
-		for _, record := range records[:n] {
+		if e.exportingProcess == nil {
+			now := time.Now()
+			// Safety net: in the normal flow waitFor() is always called with the
+			// exact remaining duration before scheduling the next attempt, so
+			// this branch should not be reached. It protects against any future
+			// code path that reaches the init block without having waited.
+			if initNextAttempt.After(now) {
+				waitFor(initNextAttempt.Sub(now))
+				continue
+			}
+			initNextAttempt = now.Add(initBackoff.Step())
+			if err := e.initExportingProcess(); err != nil {
+				klog.ErrorS(err, "Error when initializing IPFIX exporting process", "nextAttempt", initNextAttempt)
+				waitFor(initNextAttempt.Sub(now))
+				continue
+			}
+			klog.InfoS("Successfully initialized IPFIX exporting process")
+			initBackoff = newInitBackoff()
+			initNextAttempt = now
+		}
+
+		record, n, _, shutdown := consumer.Consume()
+		if n > 0 {
 			isIPv6 := record.Ip.Version == flowpb.IPVersion_IP_VERSION_6
 			if err := e.sendRecord(record, isIPv6); err != nil {
+				// In case of error, we drop the current record and reset the
+				// exporting process. The next iteration of the loop will be
+				// responsible for re-initializing the exporting process.
+				klog.ErrorS(err, "Error when sending IPFIX record")
 				if e.exportingProcess != nil {
 					e.reset()
 				}
-				if errors.Is(err, ErrIPFIXExporterBackoff) {
-					// The exporting process is not ready yet (backoff period). Drop
-					// the current record and all remaining records in the batch. This
-					// matches the previous per-record behaviour in both Aggregate mode
-					// (the flow export loop retries after activeFlowRecordTimeout) and
-					// Proxy mode (the next proxied record triggers a new attempt).
-					break
-				}
-				klog.ErrorS(err, "Error when sending IPFIX record")
 			}
 		}
 		if shutdown {
@@ -488,13 +504,10 @@ func (e *IPFIXExporter) makeIPFIXRecord(flow *flowpb.Flow, isIPv6 bool) ipfixent
 }
 
 func (e *IPFIXExporter) sendRecord(flow *flowpb.Flow, isRecordIPv6 bool) error {
+	// Run() always initializes the exporting process before calling sendRecord,
+	// so this guard should never be triggered in practice.
 	if e.exportingProcess == nil {
-		if err := e.initExportingProcessWithBackoff(); err != nil {
-			// in case of error:
-			// in Aggregate mode: the FlowAggregator flowExportLoop will retry after activeFlowRecordTimeout
-			// in Proxy mode: the FlowAggregator flowExportLoop will retry the next time a record is proxied
-			return fmt.Errorf("error when initializing IPFIX exporting process: %w", err)
-		}
+		return fmt.Errorf("exporting process is not initialized")
 	}
 	record := e.makeIPFIXRecord(flow, isRecordIPv6)
 	if err := e.bufferedExporter.AddRecord(record); err != nil {
@@ -550,21 +563,6 @@ func (e *IPFIXExporter) prepareExportingProcessTLSClientConfig() (*exporter.Expo
 
 func (e *IPFIXExporter) initExportingProcess() error {
 	return initIPFIXExportingProcess(e)
-}
-
-func (e *IPFIXExporter) initExportingProcessWithBackoff() error {
-	now := e.clock.Now()
-	if e.initNextAttempt.After(now) {
-		return ErrIPFIXExporterBackoff
-	}
-	e.initNextAttempt = now.Add(e.initBackoff.Step())
-	if err := e.initExportingProcess(); err != nil {
-		return err
-	}
-	// Reset backoff after a successful initialization.
-	e.initBackoff = newInitBackoff()
-	e.initNextAttempt = now
-	return nil
 }
 
 func (e *IPFIXExporter) initExportingProcessImpl() error {

--- a/pkg/flowaggregator/exporter/ipfix_test.go
+++ b/pkg/flowaggregator/exporter/ipfix_test.go
@@ -34,8 +34,6 @@ import (
 	ipfixentities "github.com/vmware/go-ipfix/pkg/entities"
 	ipfixregistry "github.com/vmware/go-ipfix/pkg/registry"
 	"go.uber.org/mock/gomock"
-	"k8s.io/utils/clock"
-	clocktesting "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
 
 	flowpb "antrea.io/antrea/v2/pkg/apis/flow/v1alpha1"
@@ -92,7 +90,6 @@ func TestIPFIXExporter_Run(t *testing.T) {
 			registry:                   mockIPFIXRegistry,
 			aggregatorMode:             flowaggregatorconfig.AggregatorModeAggregate,
 			observationDomainID:        testObservationDomainID,
-			clock:                      clock.RealClock{},
 		}
 		createElementList(flowaggregatorconfig.AggregatorModeAggregate, true, false, false, mockIPFIXRegistry)
 		ipfixExporter.elementsV4, _ = ipfixExporter.prepareElements(false)
@@ -150,7 +147,6 @@ func TestIPFIXExporter_createAndSendTemplate(t *testing.T) {
 			registry:                   mockIPFIXRegistry,
 			aggregatorMode:             flowaggregatorconfig.AggregatorModeAggregate,
 			observationDomainID:        testObservationDomainID,
-			clock:                      clock.RealClock{},
 		}
 		elemList := createElementList(flowaggregatorconfig.AggregatorModeAggregate, true, false, isIPv6, mockIPFIXRegistry)
 		mockIPFIXBufferedExp.EXPECT().AddRecord(gomock.Cond(func(record ipfixentities.Record) bool {
@@ -172,29 +168,17 @@ func TestIPFIXExporter_flush(t *testing.T) {
 	mockIPFIXRegistry := ipfixtesting.NewMockIPFIXRegistry(ctrl)
 	record := flowaggregatortesting.PrepareTestFlowRecord(true)
 
-	// we override the initIPFIXExportingProcess var function: it will
-	// simply set the exportingProcess and bufferedExporter member fields of
-	// the ipfixExporter to our mocks.
-	initIPFIXExportingProcessSaved := initIPFIXExportingProcess
-	initIPFIXExportingProcess = func(exporter *IPFIXExporter) error {
-		exporter.exportingProcess = mockIPFIXExpProc
-		exporter.bufferedExporter = mockIPFIXBufferedExp
-		return nil
-	}
-	defer func() {
-		initIPFIXExportingProcess = initIPFIXExportingProcessSaved
-	}()
-
 	ipfixExporter := &IPFIXExporter{
 		externalFlowCollectorAddr:  "",
 		externalFlowCollectorProto: "",
+		exportingProcess:           mockIPFIXExpProc,
+		bufferedExporter:           mockIPFIXBufferedExp,
 		includeK8sNames:            true,
 		templateIDv4:               testTemplateIDv4,
 		templateIDv6:               testTemplateIDv6,
 		registry:                   mockIPFIXRegistry,
 		aggregatorMode:             flowaggregatorconfig.AggregatorModeAggregate,
 		observationDomainID:        testObservationDomainID,
-		clock:                      clock.RealClock{},
 	}
 	createElementList(flowaggregatorconfig.AggregatorModeAggregate, true, false, false, mockIPFIXRegistry)
 	ipfixExporter.elementsV4, _ = ipfixExporter.prepareElements(false)
@@ -223,22 +207,16 @@ func TestIPFIXExporter_sendRecord(t *testing.T) {
 		t.Run(fmt.Sprintf("%s-%t", tc.aggregatorMode, tc.isIPv6), func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 
+			mockIPFIXExpProc := ipfixtesting.NewMockIPFIXExportingProcess(ctrl)
 			mockIPFIXBufferedExp := ipfixtesting.NewMockIPFIXBufferedExporter(ctrl)
 			mockIPFIXRegistry := ipfixtesting.NewMockIPFIXRegistry(ctrl)
 			record := flowaggregatortesting.PrepareTestFlowRecord(true)
 
-			initIPFIXExportingProcessSaved := initIPFIXExportingProcess
-			initIPFIXExportingProcess = func(exporter *IPFIXExporter) error {
-				exporter.bufferedExporter = mockIPFIXBufferedExp
-				return nil
-			}
-			defer func() {
-				initIPFIXExportingProcess = initIPFIXExportingProcessSaved
-			}()
-
 			ipfixExporter := &IPFIXExporter{
 				externalFlowCollectorAddr:  "",
 				externalFlowCollectorProto: "",
+				exportingProcess:           mockIPFIXExpProc,
+				bufferedExporter:           mockIPFIXBufferedExp,
 				includeK8sNames:            true,
 				templateIDv4:               testTemplateIDv4,
 				templateIDv6:               testTemplateIDv6,
@@ -246,7 +224,6 @@ func TestIPFIXExporter_sendRecord(t *testing.T) {
 				aggregatorMode:             tc.aggregatorMode,
 				observationDomainID:        testObservationDomainID,
 				clusterID:                  "foobar",
-				clock:                      clock.RealClock{},
 			}
 			createElementList(tc.aggregatorMode, true, false, false, mockIPFIXRegistry)
 			ipfixExporter.elementsV4, _ = ipfixExporter.prepareElements(false)
@@ -269,25 +246,14 @@ func TestIPFIXExporter_sendRecord(t *testing.T) {
 	}
 }
 
-func TestIPFIXExporter_initIPFIXExportingProcess_Error(t *testing.T) {
+func TestIPFIXExporter_sendRecord_NoExportingProcess(t *testing.T) {
 	record := flowaggregatortesting.PrepareTestFlowRecord(true)
-
-	// we override the initIPFIXExportingProcess var function: it will
-	// simply return an error.
-	initIPFIXExportingProcessSaved := initIPFIXExportingProcess
-	initIPFIXExportingProcess = func(exporter *IPFIXExporter) error {
-		return fmt.Errorf("error when initializing IPFIX exporting process")
-	}
-	defer func() {
-		initIPFIXExportingProcess = initIPFIXExportingProcessSaved
-	}()
 
 	ipfixExporter := &IPFIXExporter{
 		externalFlowCollectorAddr:  "",
 		externalFlowCollectorProto: "",
 		includeK8sNames:            true,
 		aggregatorMode:             flowaggregatorconfig.AggregatorModeAggregate,
-		clock:                      clock.RealClock{},
 	}
 
 	assert.Error(t, ipfixExporter.sendRecord(record, false))
@@ -312,7 +278,6 @@ func TestIPFIXExporter_sendRecord_Error(t *testing.T) {
 		registry:                   mockIPFIXRegistry,
 		aggregatorMode:             flowaggregatorconfig.AggregatorModeAggregate,
 		observationDomainID:        testObservationDomainID,
-		clock:                      clock.RealClock{},
 	}
 	createElementList(flowaggregatorconfig.AggregatorModeAggregate, true, false, false, mockIPFIXRegistry)
 	ipfixExporter.elementsV4, _ = ipfixExporter.prepareElements(false)
@@ -624,64 +589,82 @@ func TestNewIPFIXExporterObservationDomainID(t *testing.T) {
 	}
 }
 
-func TestInitExportingProcessWithBackoff(t *testing.T) {
-	errCh := make(chan error, 1)
-	initIPFIXExportingProcessSaved := initIPFIXExportingProcess
-	initIPFIXExportingProcess = func(exporter *IPFIXExporter) error {
-		select {
-		case err := <-errCh:
-			return err
-		default:
-			return fmt.Errorf("no available error in channel")
+// TestInitBackoffInRun verifies the backoff logic in the Run loop: after a
+// failed initialization attempt, the loop waits for the backoff duration
+// before retrying; the backoff doubles on successive failures and resets after
+// a successful initialization.
+func TestInitBackoffInRun(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		// initErrCh controls what initIPFIXExportingProcess returns.
+		// Send nil for success, a non-nil error for failure.
+		// The default (empty channel) returns a "no error queued" sentinel so
+		// that we can detect unexpected extra calls.
+		initErrCh := make(chan error, 1)
+
+		ctrl := gomock.NewController(t)
+		mockIPFIXExpProc := ipfixtesting.NewMockIPFIXExportingProcess(ctrl)
+		mockIPFIXBufferedExp := ipfixtesting.NewMockIPFIXBufferedExporter(ctrl)
+		mockIPFIXExpProc.EXPECT().CloseConnToCollector().AnyTimes()
+		mockIPFIXBufferedExp.EXPECT().Flush().Return(nil).AnyTimes()
+
+		initIPFIXExportingProcessSaved := initIPFIXExportingProcess
+		initIPFIXExportingProcess = func(exporter *IPFIXExporter) error {
+			select {
+			case err := <-initErrCh:
+				if err == nil {
+					exporter.exportingProcess = mockIPFIXExpProc
+					exporter.bufferedExporter = mockIPFIXBufferedExp
+				}
+				return err
+			default:
+				// t.Errorf is safe to call from any goroutine, unlike require.Fail.
+				t.Errorf("unexpected extra call to initExportingProcess")
+				return fmt.Errorf("unexpected extra call to initExportingProcess")
+			}
 		}
-	}
-	defer func() {
-		initIPFIXExportingProcess = initIPFIXExportingProcessSaved
-	}()
-	clusterUUID := uuid.New()
-	opt := &options.Options{
-		AggregatorMode: flowaggregatorconfig.AggregatorModeProxy,
-		Config:         &flowaggregatorconfig.FlowAggregatorConfig{},
-	}
-	flowaggregatorconfig.SetConfigDefaults(opt.Config)
-	clock := clocktesting.NewFakeClock(time.Now())
-	exp := newIPFIXExporterWithClock(clusterUUID, clusterUUID.String(), opt, nil, clock)
-	require.NotNil(t, exp)
+		defer func() { initIPFIXExportingProcess = initIPFIXExportingProcessSaved }()
 
-	setError := func(err error) {
-		select {
-		case errCh <- err:
-			break
-		default:
-			require.Fail(t, "channel write should not block")
+		clusterUUID := uuid.New()
+		opt := &options.Options{
+			AggregatorMode: flowaggregatorconfig.AggregatorModeProxy,
+			Config:         &flowaggregatorconfig.FlowAggregatorConfig{},
 		}
-	}
+		flowaggregatorconfig.SetConfigDefaults(opt.Config)
 
-	setError(nil)
-	require.NoError(t, exp.initExportingProcessWithBackoff())
+		exp := NewIPFIXExporter(clusterUUID, clusterUUID.String(), opt, nil)
+		require.NotNil(t, exp)
 
-	connectionErr := fmt.Errorf("connection error")
-	setError(connectionErr)
-	require.ErrorIs(t, exp.initExportingProcessWithBackoff(), connectionErr)
+		buf := ringbuffer.NewBroadcastBuffer[*flowpb.Flow](8)
+		defer buf.Shutdown()
 
-	// Connection error starts the backoff, first step is 1s (no jitter).
-	require.ErrorIs(t, exp.initExportingProcessWithBackoff(), ErrIPFIXExporterBackoff)
-	require.Equal(t, clock.Now().Add(1*time.Second), exp.initNextAttempt)
-	require.ErrorIs(t, exp.initExportingProcessWithBackoff(), ErrIPFIXExporterBackoff)
+		connectionErr := fmt.Errorf("connection error")
 
-	// A second error will cause a 2s backoff.
-	setError(connectionErr)
-	clock.SetTime(exp.initNextAttempt)
-	require.ErrorIs(t, exp.initExportingProcessWithBackoff(), connectionErr)
-	require.Equal(t, clock.Now().Add(2*time.Second), exp.initNextAttempt)
-	require.ErrorIs(t, exp.initExportingProcessWithBackoff(), ErrIPFIXExporterBackoff)
+		// First attempt: fails with connectionErr → backoff step 1 = 1s.
+		// Note that we need to ensure that we write to initErrCh before calling Run.
+		initErrCh <- connectionErr
 
-	setError(nil)
-	clock.SetTime(exp.initNextAttempt)
-	require.NoError(t, exp.initExportingProcessWithBackoff())
+		go exp.Run(t.Context(), buf)
 
-	// After a successful initialization, backoff should be reset.
-	setError(connectionErr)
-	require.ErrorIs(t, exp.initExportingProcessWithBackoff(), connectionErr)
-	require.Equal(t, clock.Now().Add(1*time.Second), exp.initNextAttempt)
+		synctest.Wait()
+		require.Nil(t, exp.exportingProcess, "exporting process should not be set after failed init")
+
+		// The loop is now waiting on waitCh for 1s. A second init call must
+		// not happen yet; verify by advancing less than the full backoff.
+		time.Sleep(500 * time.Millisecond)
+		synctest.Wait()
+		require.Nil(t, exp.exportingProcess, "exporting process should not be set before backoff expires")
+
+		// Advance past the 1s backoff. Second attempt also fails → backoff
+		// step 2 = 2s.
+		initErrCh <- connectionErr
+		time.Sleep(500 * time.Millisecond) // total: 1s from first attempt
+		synctest.Wait()
+		require.Nil(t, exp.exportingProcess, "exporting process should not be set after second failed init")
+
+		// Now waiting for 2s. Advance past it. Third attempt succeeds.
+		initErrCh <- nil
+		time.Sleep(2 * time.Second)
+		synctest.Wait()
+		require.NotNil(t, exp.exportingProcess, "exporting process should be initialized after successful init")
+	})
 }

--- a/pkg/flowaggregator/ringbuffer/buffer_test.go
+++ b/pkg/flowaggregator/ringbuffer/buffer_test.go
@@ -730,12 +730,48 @@ func runBenchConsumer(
 	}
 }
 
-func benchmarkSingleProduce(b *testing.B, newHandler func() batchHandler) {
+func runBenchConsumerSingle(
+	c Consumer[*foo],
+	id int,
+	progress *consumerProgress,
+	stats *consumeStats,
+	handler batchHandler,
+) {
+	out := make([]*foo, 0, benchBatchSize)
+
+	for {
+		out = out[:0]
+		var shutdown bool
+		for range benchBatchSize {
+			val, n, lost, s := c.Consume()
+			if lost > 0 {
+				panic(fmt.Sprintf("consumer %d: lost %d items", id, lost))
+			}
+			if n > 0 {
+				out = append(out, val)
+			}
+			if s {
+				shutdown = true
+				break
+			}
+		}
+		stats.record(len(out))
+		if len(out) > 0 {
+			handler(out)
+			progress.add(id, len(out))
+		}
+		if shutdown {
+			return
+		}
+	}
+}
+
+func benchmarkSingleProduceConsumeMultiple(b *testing.B, newHandler func() batchHandler) {
 	items := generateItems(benchTotalItems)
 	var stats consumeStats
 	b.ResetTimer()
 
-	for iter := 0; iter < b.N; iter++ {
+	for b.Loop() {
 		buf := NewBroadcastBuffer[*foo](benchBufSize)
 		progress := newConsumerProgress(benchNumConsumers)
 
@@ -770,12 +806,12 @@ func benchmarkSingleProduce(b *testing.B, newHandler func() batchHandler) {
 	b.Logf("avg ConsumeMultiple batch size: %.1f", stats.avgBatchSize())
 }
 
-func benchmarkBatchProduce(b *testing.B, newHandler func() batchHandler) {
+func benchmarkBatchProduceConsumeMultiple(b *testing.B, newHandler func() batchHandler) {
 	items := generateItems(benchTotalItems)
 	var stats consumeStats
 	b.ResetTimer()
 
-	for iter := 0; iter < b.N; iter++ {
+	for b.Loop() {
 		buf := NewBroadcastBuffer[*foo](benchBufSize)
 		progress := newConsumerProgress(benchNumConsumers)
 
@@ -815,22 +851,127 @@ func benchmarkBatchProduce(b *testing.B, newHandler func() batchHandler) {
 	b.Logf("avg ConsumeMultiple batch size: %.1f", stats.avgBatchSize())
 }
 
+func benchmarkSingleProduceConsumeSingle(b *testing.B, newHandler func() batchHandler) {
+	items := generateItems(benchTotalItems)
+	var stats consumeStats
+	b.ResetTimer()
+
+	for b.Loop() {
+		buf := NewBroadcastBuffer[*foo](benchBufSize)
+		progress := newConsumerProgress(benchNumConsumers)
+
+		var wg sync.WaitGroup
+		for ci := 0; ci < benchNumConsumers; ci++ {
+			wg.Add(1)
+			c := buf.NewConsumer(WithMaxConsumeDeadline(benchConsumerDeadline))
+			id := ci
+			handler := newHandler()
+			go func() {
+				defer wg.Done()
+				runBenchConsumerSingle(c, id, progress, &stats, handler)
+			}()
+		}
+
+		produced := 0
+		for produced < benchTotalItems {
+			minConsumed := progress.minConsumed()
+			pending := int64(produced) - minConsumed
+			if pending >= benchBackpressure {
+				runtime.Gosched()
+				continue
+			}
+			buf.Produce(items[produced])
+			produced++
+		}
+		buf.Shutdown()
+
+		wg.Wait()
+	}
+
+	b.Logf("avg Consume batch size: %.1f", stats.avgBatchSize())
+}
+
+func benchmarkBatchProduceConsumeSingle(b *testing.B, newHandler func() batchHandler) {
+	items := generateItems(benchTotalItems)
+	var stats consumeStats
+	b.ResetTimer()
+
+	for b.Loop() {
+		buf := NewBroadcastBuffer[*foo](benchBufSize)
+		progress := newConsumerProgress(benchNumConsumers)
+
+		var wg sync.WaitGroup
+		for ci := 0; ci < benchNumConsumers; ci++ {
+			wg.Add(1)
+			c := buf.NewConsumer(WithMaxConsumeDeadline(benchConsumerDeadline))
+			id := ci
+			handler := newHandler()
+			go func() {
+				defer wg.Done()
+				runBenchConsumerSingle(c, id, progress, &stats, handler)
+			}()
+		}
+
+		produced := 0
+		for produced < benchTotalItems {
+			minConsumed := progress.minConsumed()
+			pending := int64(produced) - minConsumed
+			if pending >= benchBackpressure {
+				runtime.Gosched()
+				continue
+			}
+			end := produced + benchBatchSize
+			if end > benchTotalItems {
+				end = benchTotalItems
+			}
+			batch := items[produced:end]
+			buf.ProduceMultiple(batch)
+			produced += len(batch)
+		}
+		buf.Shutdown()
+
+		wg.Wait()
+	}
+
+	b.Logf("avg Consume batch size: %.1f", stats.avgBatchSize())
+}
+
 // ---------------------------------------------------------------------------
 // Benchmark entry points
 // ---------------------------------------------------------------------------
 
-func BenchmarkSingleProduceJSON(b *testing.B) {
-	benchmarkSingleProduce(b, jsonBatchHandler)
+// ConsumeMultiple-based consumers.
+
+func BenchmarkSingleProduceConsumeMultipleJSON(b *testing.B) {
+	benchmarkSingleProduceConsumeMultiple(b, jsonBatchHandler)
 }
 
-func BenchmarkBatchProduceJSON(b *testing.B) {
-	benchmarkBatchProduce(b, jsonBatchHandler)
+func BenchmarkBatchProduceConsumeMultipleJSON(b *testing.B) {
+	benchmarkBatchProduceConsumeMultiple(b, jsonBatchHandler)
 }
 
-func BenchmarkSingleProduceNoop(b *testing.B) {
-	benchmarkSingleProduce(b, noopBatchHandler)
+func BenchmarkSingleProduceConsumeMultipleNoop(b *testing.B) {
+	benchmarkSingleProduceConsumeMultiple(b, noopBatchHandler)
 }
 
-func BenchmarkBatchProduceNoop(b *testing.B) {
-	benchmarkBatchProduce(b, noopBatchHandler)
+func BenchmarkBatchProduceConsumeMultipleNoop(b *testing.B) {
+	benchmarkBatchProduceConsumeMultiple(b, noopBatchHandler)
+}
+
+// Consume-based consumers (benchBatchSize calls per handler invocation).
+
+func BenchmarkSingleProduceConsumeJSON(b *testing.B) {
+	benchmarkSingleProduceConsumeSingle(b, jsonBatchHandler)
+}
+
+func BenchmarkBatchProduceConsumeJSON(b *testing.B) {
+	benchmarkBatchProduceConsumeSingle(b, jsonBatchHandler)
+}
+
+func BenchmarkSingleProduceConsumeNoop(b *testing.B) {
+	benchmarkSingleProduceConsumeSingle(b, noopBatchHandler)
+}
+
+func BenchmarkBatchProduceConsumeNoop(b *testing.B) {
+	benchmarkBatchProduceConsumeSingle(b, noopBatchHandler)
 }


### PR DESCRIPTION
Move the backoff and initialization logic out of sendRecord and into the Run loop. The exporting process is now initialized (and re-initialized after failures) directly in Run, before any call to Consume. This avoids consuming records from the ring buffer while the exporter is not ready, and simplifies the overall control flow.

- Remove ErrIPFIXExporterBackoff, initExportingProcessWithBackoff, and the initBackoff / initNextAttempt struct fields; the backoff state is now local to Run.
- Add a waitFor helper using time.AfterFunc to pause the loop between initialization attempts without holding up ctx cancellation. The timer is stopped when ctx is cancelled to avoid leaking it.
- Switch from ConsumeMultiple to Consume (one record per iteration).
- sendRecord now returns a plain error when exportingProcess is nil instead of triggering initialization.

The test for the backoff logic is rewritten as TestInitBackoffInRun, exercising the same sequence (doubling delays, reset after success) through the Run loop using synctest and time.Sleep, with no need for a fake clock.

Also add some new ring buffer benchmarks, specifically for the Consume method, so we can compare the performance of Consume with ConsumeMultiple.