### PR TITLE
Migrate ipallocator from net to net/netip

### DIFF
--- a/pkg/agent/cniserver/ipam/antrea_ipam.go
+++ b/pkg/agent/cniserver/ipam/antrea_ipam.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/netip"
 	"sync"
 	"time"
 
@@ -148,26 +149,26 @@ func (d *AntreaIPAM) Add(args *invoke.Args, k8sArgs *types.K8sArgs, networkConfi
 	}
 
 	owner := *getAllocationOwner(args, k8sArgs, reservedOwner, false)
-	var ip net.IP
+	var allocatedIP netip.Addr
 	var subnetInfo *crdv1b1.SubnetInfo
 	if reservedOwner != nil {
-		ip, subnetInfo, err = allocator.AllocateReservedOrNext(crdv1b1.IPAddressPhaseAllocated, owner)
+		allocatedIP, subnetInfo, err = allocator.AllocateReservedOrNext(crdv1b1.IPAddressPhaseAllocated, owner)
 	} else if len(ips) == 0 {
-		ip, subnetInfo, err = allocator.AllocateNext(crdv1b1.IPAddressPhaseAllocated, owner)
+		allocatedIP, subnetInfo, err = allocator.AllocateNext(crdv1b1.IPAddressPhaseAllocated, owner)
 	} else {
-		ip = ips[0]
-		subnetInfo, err = allocator.AllocateIP(ip, crdv1b1.IPAddressPhaseAllocated, owner)
+		allocatedIP = ips[0]
+		subnetInfo, err = allocator.AllocateIP(allocatedIP, crdv1b1.IPAddressPhaseAllocated, owner)
 	}
 	if err != nil {
 		return true, nil, err
 	}
 
-	klog.V(4).InfoS("IP allocation successful", "IP", ip.String(), "Pod", string(k8sArgs.K8S_POD_NAME))
+	klog.V(4).InfoS("IP allocation successful", "IP", allocatedIP.String(), "Pod", string(k8sArgs.K8S_POD_NAME))
 
 	result := IPAMResult{Result: current.Result{CNIVersion: current.ImplementedSpecVersion}, VLANID: uint16(subnetInfo.VLAN)}
 	gwIP := net.ParseIP(subnetInfo.Gateway)
 
-	ipConfig, defaultRoute := generateIPConfig(ip, int(subnetInfo.PrefixLength), gwIP)
+	ipConfig, defaultRoute := generateIPConfig(allocatedIP.AsSlice(), int(subnetInfo.PrefixLength), gwIP)
 
 	result.Routes = append(result.Routes, defaultRoute)
 	result.IPs = append(result.IPs, ipConfig)
@@ -203,7 +204,7 @@ func (d *AntreaIPAM) Check(args *invoke.Args, k8sArgs *types.K8sArgs, networkCon
 		return true, err
 	}
 
-	if ip == nil {
+	if !ip.IsValid() {
 		return true, fmt.Errorf("no IP Address association found for container %s", string(k8sArgs.K8S_POD_NAME))
 	}
 	return true, nil
@@ -245,10 +246,10 @@ func (d *AntreaIPAM) SecondaryNetworkAllocate(podOwner *crdv1b1.PodOwner, networ
 				return nil, err
 			}
 
-			var ip net.IP
+			var allocatedAddr netip.Addr
 			var subnetInfo *crdv1b1.SubnetInfo
 			owner := crdv1b1.IPAddressOwner{Pod: podOwner}
-			ip, subnetInfo, err = allocator.AllocateNext(crdv1b1.IPAddressPhaseAllocated, owner)
+			allocatedAddr, subnetInfo, err = allocator.AllocateNext(crdv1b1.IPAddressPhaseAllocated, owner)
 			if err != nil {
 				return nil, err
 			}
@@ -257,7 +258,7 @@ func (d *AntreaIPAM) SecondaryNetworkAllocate(podOwner *crdv1b1.PodOwner, networ
 			}
 
 			gwIP := net.ParseIP(subnetInfo.Gateway)
-			ipConfig, _ := generateIPConfig(ip, int(subnetInfo.PrefixLength), gwIP)
+			ipConfig, _ := generateIPConfig(allocatedAddr.AsSlice(), int(subnetInfo.PrefixLength), gwIP)
 			// CNI spec 0.2.0 and below support only one v4 and one v6 address. But we
 			// assume the CNI version >= 0.3.0, and so do not check the number of
 			// addresses.
@@ -340,7 +341,7 @@ func (d *AntreaIPAM) del(podOwner *crdv1b1.PodOwner) (foundAllocation bool, err 
 // mineTrue + timeout error
 // mineTrue + IPPoolNotFound error
 // mineTrue + nil error
-func (d *AntreaIPAM) owns(k8sArgs *types.K8sArgs) (mineType, *poolallocator.IPPoolAllocator, []net.IP, *crdv1b1.IPAddressOwner, error) {
+func (d *AntreaIPAM) owns(k8sArgs *types.K8sArgs) (mineType, *poolallocator.IPPoolAllocator, []netip.Addr, *crdv1b1.IPAddressOwner, error) {
 	// Wait controller ready to avoid inappropriate behaviors on the CNI request.
 	if err := d.waitForControllerReady(); err != nil {
 		// Return mineTrue to make this request fail and kubelet will retry.

--- a/pkg/agent/cniserver/ipam/antrea_ipam_controller.go
+++ b/pkg/agent/cniserver/ipam/antrea_ipam_controller.go
@@ -16,7 +16,7 @@ package ipam
 
 import (
 	"fmt"
-	"net"
+	"net/netip"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -127,8 +127,8 @@ func (c *AntreaIPAMController) Run(stopCh <-chan struct{}) {
 }
 
 // Look up IPPools from the Pod annotation.
-func (c *AntreaIPAMController) getIPPoolsByPod(namespace, name string) ([]string, []net.IP, *crdv1b1.IPAddressOwner, error) {
-	var ips []net.IP
+func (c *AntreaIPAMController) getIPPoolsByPod(namespace, name string) ([]string, []netip.Addr, *crdv1b1.IPAddressOwner, error) {
+	var ips []netip.Addr
 	var reservedOwner *crdv1b1.IPAddressOwner
 	pod, err := c.podLister.Pods(namespace).Get(name)
 	if err != nil {
@@ -158,8 +158,8 @@ func (c *AntreaIPAMController) getIPPoolsByPod(namespace, name string) ([]string
 			if ipString == "" {
 				continue
 			}
-			ip := net.ParseIP(ipString)
-			if ip == nil {
+			ip, err := netip.ParseAddr(ipString)
+			if err != nil {
 				ipErr = fmt.Errorf("invalid IP annotation %s", ipStrings)
 				ips = nil
 				break
@@ -194,7 +194,7 @@ ownerReferenceLoop:
 }
 
 // Look up IPPools from the Pod annotation.
-func (c *AntreaIPAMController) getPoolAllocatorByPod(namespace, podName string) (mineType, *poolallocator.IPPoolAllocator, []net.IP, *crdv1b1.IPAddressOwner, error) {
+func (c *AntreaIPAMController) getPoolAllocatorByPod(namespace, podName string) (mineType, *poolallocator.IPPoolAllocator, []netip.Addr, *crdv1b1.IPAddressOwner, error) {
 	poolNames, ips, reservedOwner, err := c.getIPPoolsByPod(namespace, podName)
 	if err != nil {
 		return mineUnknown, nil, nil, nil, err

--- a/pkg/controller/egress/controller.go
+++ b/pkg/controller/egress/controller.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net"
+	"net/netip"
 	"reflect"
 	"sync"
 	"time"
@@ -64,7 +64,7 @@ const (
 
 // ipAllocation contains the IP and the IP Pool which allocates it.
 type ipAllocation struct {
-	ip     net.IP
+	ip     netip.Addr
 	ipPool string
 }
 
@@ -178,7 +178,7 @@ func (c *EgressController) restoreIPAllocations(egresses []*egressv1beta1.Egress
 		if egress.Spec.ExternalIPPool == "" || egress.Spec.EgressIP == "" {
 			continue
 		}
-		ip := net.ParseIP(egress.Spec.EgressIP)
+		ip, _ := netip.ParseAddr(egress.Spec.EgressIP)
 		allocation := externalippool.IPAllocation{
 			ObjectReference: v1.ObjectReference{
 				Name: egress.Name,
@@ -220,12 +220,12 @@ func (c *EgressController) processNextEgressGroupWorkItem() bool {
 	return true
 }
 
-func (c *EgressController) getIPAllocation(egressName string) (net.IP, string, bool) {
+func (c *EgressController) getIPAllocation(egressName string) (netip.Addr, string, bool) {
 	c.ipAllocationMutex.RLock()
 	defer c.ipAllocationMutex.RUnlock()
 	allocation, exists := c.ipAllocationMap[egressName]
 	if !exists {
-		return nil, "", false
+		return netip.Addr{}, "", false
 	}
 	return allocation.ip, allocation.ipPool, true
 }
@@ -236,7 +236,7 @@ func (c *EgressController) deleteIPAllocation(egressName string) {
 	delete(c.ipAllocationMap, egressName)
 }
 
-func (c *EgressController) setIPAllocation(egressName string, ip net.IP, poolName string) {
+func (c *EgressController) setIPAllocation(egressName string, ip netip.Addr, poolName string) {
 	c.ipAllocationMutex.Lock()
 	defer c.ipAllocationMutex.Unlock()
 	c.ipAllocationMap[egressName] = &ipAllocation{
@@ -246,7 +246,7 @@ func (c *EgressController) setIPAllocation(egressName string, ip net.IP, poolNam
 }
 
 // syncEgressIP is responsible for releasing stale EgressIP and allocating new EgressIP for an Egress if applicable.
-func (c *EgressController) syncEgressIP(egress *egressv1beta1.Egress) (net.IP, *egressv1beta1.Egress, error) {
+func (c *EgressController) syncEgressIP(egress *egressv1beta1.Egress) (netip.Addr, *egressv1beta1.Egress, error) {
 	prevIP, prevIPPool, exists := c.getIPAllocation(egress.Name)
 	if exists {
 		// The EgressIP and the ExternalIPPool haven't changed.
@@ -259,7 +259,7 @@ func (c *EgressController) syncEgressIP(egress *egressv1beta1.Egress) (net.IP, *
 			// Reclaim the IP from the Egress API.
 			klog.InfoS("Allocated EgressIP is no longer part of ExternalIPPool, releasing it", "egress", klog.KObj(egress), "ip", egress.Spec.EgressIP, "pool", egress.Spec.ExternalIPPool)
 			if updatedEgress, err := c.updateEgressIP(egress, ""); err != nil {
-				return nil, egress, err
+				return netip.Addr{}, egress, err
 			} else {
 				egress = updatedEgress
 			}
@@ -270,42 +270,43 @@ func (c *EgressController) syncEgressIP(egress *egressv1beta1.Egress) (net.IP, *
 
 	// Skip allocating EgressIP if ExternalIPPool is not specified and return whatever user specifies.
 	if egress.Spec.ExternalIPPool == "" {
-		return net.ParseIP(egress.Spec.EgressIP), egress, nil
+		ip, _ := netip.ParseAddr(egress.Spec.EgressIP)
+		return ip, egress, nil
 	}
 
 	if !c.externalIPAllocator.IPPoolExists(egress.Spec.ExternalIPPool) {
 		// The IP pool has been deleted, reclaim the IP from the Egress API.
 		if egress.Spec.EgressIP != "" {
 			if updatedEgress, err := c.updateEgressIP(egress, ""); err != nil {
-				return nil, egress, err
+				return netip.Addr{}, egress, err
 			} else {
 				egress = updatedEgress
 			}
 		}
-		return nil, egress, fmt.Errorf("ExternalIPPool %s does not exist", egress.Spec.ExternalIPPool)
+		return netip.Addr{}, egress, fmt.Errorf("ExternalIPPool %s does not exist", egress.Spec.ExternalIPPool)
 	}
 
-	var ip net.IP
+	var ip netip.Addr
 	// User specifies the Egress IP, try to allocate it. If it fails, the datapath may still work, we just don't track
 	// the IP allocation so deleting this Egress won't release the IP to the Pool.
 	// TODO: Use validation webhook to ensure the requested IP matches the pool.
 	if egress.Spec.EgressIP != "" {
-		ip = net.ParseIP(egress.Spec.EgressIP)
+		ip, _ = netip.ParseAddr(egress.Spec.EgressIP)
 		if err := c.externalIPAllocator.UpdateIPAllocation(egress.Spec.ExternalIPPool, ip); err != nil {
-			return nil, egress, fmt.Errorf("error when allocating IP %v for Egress %s from ExternalIPPool %s: %v", ip, egress.Name, egress.Spec.ExternalIPPool, err)
+			return netip.Addr{}, egress, fmt.Errorf("error when allocating IP %v for Egress %s from ExternalIPPool %s: %v", ip, egress.Name, egress.Spec.ExternalIPPool, err)
 		}
 	} else {
 		var err error
 		// User doesn't specify the Egress IP, allocate one.
 		if ip, err = c.externalIPAllocator.AllocateIPFromPool(egress.Spec.ExternalIPPool); err != nil {
-			return nil, egress, err
+			return netip.Addr{}, egress, err
 		}
 		if updatedEgress, err := c.updateEgressIP(egress, ip.String()); err != nil {
 			if rerr := c.externalIPAllocator.ReleaseIP(egress.Spec.ExternalIPPool, ip); rerr != nil &&
 				rerr != externalippool.ErrExternalIPPoolNotFound {
 				klog.ErrorS(rerr, "Failed to release IP", "ip", ip, "pool", egress.Spec.ExternalIPPool)
 			}
-			return nil, egress, err
+			return netip.Addr{}, egress, err
 		} else {
 			egress = updatedEgress
 		}
@@ -335,7 +336,7 @@ func (c *EgressController) updateEgressIP(egress *egressv1beta1.Egress, ip strin
 }
 
 // releaseEgressIP removes the Egress's ipAllocation in the cache and releases the IP to the pool.
-func (c *EgressController) releaseEgressIP(egressName string, egressIP net.IP, poolName string) {
+func (c *EgressController) releaseEgressIP(egressName string, egressIP netip.Addr, poolName string) {
 	if err := c.externalIPAllocator.ReleaseIP(poolName, egressIP); err != nil {
 		if err == externalippool.ErrExternalIPPoolNotFound {
 			// Ignore the error since the external IP Pool could be deleted.

--- a/pkg/controller/egress/controller_test.go
+++ b/pkg/controller/egress/controller_test.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net"
+	"net/netip"
 	"testing"
 	"time"
 
@@ -579,7 +579,7 @@ func TestRecreateExternalIPPoolWithNewRange(t *testing.T) {
 	require.True(t, controller.externalIPAllocator.IPPoolExists(eipFoo1.Name))
 	getEgressIP, egress, err := controller.syncEgressIP(egress)
 	require.NoError(t, err)
-	assert.Equal(t, net.ParseIP("1.1.1.1"), getEgressIP)
+	assert.Equal(t, netip.MustParseAddr("1.1.1.1"), getEgressIP)
 
 	// Delete and recreate the ExternalIPPool immediately with a different IP range. We do not
 	// call syncEgressIP in-between, so the Egress controller doesn't have a chance to process
@@ -597,7 +597,7 @@ func TestRecreateExternalIPPoolWithNewRange(t *testing.T) {
 
 	getEgressIP, _, err = controller.syncEgressIP(egress)
 	require.NoError(t, err)
-	assert.Equal(t, net.ParseIP("1.1.2.1"), getEgressIP)
+	assert.Equal(t, netip.MustParseAddr("1.1.2.1"), getEgressIP)
 }
 
 func TestSyncEgressIP(t *testing.T) {
@@ -606,7 +606,7 @@ func TestSyncEgressIP(t *testing.T) {
 		existingEgresses           []*v1beta1.Egress
 		existingExternalIPPool     *v1beta1.ExternalIPPool
 		inputEgress                *v1beta1.Egress
-		expectedEgressIP           string
+		expectedEgressIP           netip.Addr
 		expectedExternalIPPoolUsed int
 		expectErr                  bool
 	}{
@@ -628,8 +628,8 @@ func TestSyncEgressIP(t *testing.T) {
 					},
 				},
 			},
-			// The first IPRange 1.1.1.0/30 should be occupied by the existing Egresses. The input Egress's IP should
-			// be allocated from the second IPRange 1.1.2.10-1.1.2.20.
+			// The first IPRange 1.1.1.0/30 should be occupied by the existing Egresses. The input
+			// Egress's IP should be allocated from the second IPRange 1.1.2.10-1.1.2.20.
 			existingExternalIPPool: newExternalIPPool("ipPoolA", "1.1.1.0/30", "1.1.2.10", "1.1.2.20"),
 			inputEgress: &v1beta1.Egress{
 				ObjectMeta: metav1.ObjectMeta{Name: "egressC", UID: "uidC"},
@@ -638,7 +638,7 @@ func TestSyncEgressIP(t *testing.T) {
 					ExternalIPPool: "ipPoolA",
 				},
 			},
-			expectedEgressIP:           "1.1.2.10",
+			expectedEgressIP:           netip.MustParseAddr("1.1.2.10"),
 			expectedExternalIPPoolUsed: 3,
 			expectErr:                  false,
 		},
@@ -652,7 +652,6 @@ func TestSyncEgressIP(t *testing.T) {
 					ExternalIPPool: "ipPoolB",
 				},
 			},
-			expectedEgressIP:           "",
 			expectedExternalIPPoolUsed: 0,
 			expectErr:                  true,
 		},
@@ -665,7 +664,7 @@ func TestSyncEgressIP(t *testing.T) {
 					ExternalIPPool: "ipPoolA",
 				},
 			},
-			expectedEgressIP:           "2021:2::aaa1",
+			expectedEgressIP:           netip.MustParseAddr("2021:2::aaa1"),
 			expectedExternalIPPoolUsed: 1,
 			expectErr:                  false,
 		},
@@ -679,7 +678,7 @@ func TestSyncEgressIP(t *testing.T) {
 					ExternalIPPool: "ipPoolA",
 				},
 			},
-			expectedEgressIP:           "1.1.1.2",
+			expectedEgressIP:           netip.MustParseAddr("1.1.1.2"),
 			expectedExternalIPPoolUsed: 1,
 			expectErr:                  false,
 		},
@@ -693,7 +692,6 @@ func TestSyncEgressIP(t *testing.T) {
 					ExternalIPPool: "ipPoolA",
 				},
 			},
-			expectedEgressIP:           "",
 			expectedExternalIPPoolUsed: 0,
 			expectErr:                  true,
 		},
@@ -716,7 +714,7 @@ func TestSyncEgressIP(t *testing.T) {
 					ExternalIPPool: "ipPoolA",
 				},
 			},
-			expectedEgressIP:           "1.1.1.3",
+			expectedEgressIP:           netip.MustParseAddr("1.1.1.3"),
 			expectedExternalIPPoolUsed: 1,
 			expectErr:                  false,
 		},
@@ -739,7 +737,7 @@ func TestSyncEgressIP(t *testing.T) {
 					ExternalIPPool: "ipPoolA",
 				},
 			},
-			expectedEgressIP:           "1.1.1.2",
+			expectedEgressIP:           netip.MustParseAddr("1.1.1.2"),
 			expectedExternalIPPoolUsed: 1,
 			expectErr:                  false,
 		},
@@ -762,7 +760,6 @@ func TestSyncEgressIP(t *testing.T) {
 					ExternalIPPool: "ipPoolA",
 				},
 			},
-			expectedEgressIP:           "",
 			expectedExternalIPPoolUsed: 1,
 			expectErr:                  true,
 		},
@@ -784,7 +781,7 @@ func TestSyncEgressIP(t *testing.T) {
 					EgressIP: "10.10.10.10",
 				},
 			},
-			expectedEgressIP:           "10.10.10.10",
+			expectedEgressIP:           netip.MustParseAddr("10.10.10.10"),
 			expectedExternalIPPoolUsed: 0,
 			expectErr:                  false,
 		},
@@ -809,7 +806,7 @@ func TestSyncEgressIP(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
-			assert.Equal(t, net.ParseIP(tt.expectedEgressIP), getEgressIP)
+			assert.Equal(t, tt.expectedEgressIP, getEgressIP)
 			checkExternalIPPoolUsed(t, controller, tt.existingExternalIPPool.Name, tt.expectedExternalIPPoolUsed)
 		})
 	}

--- a/pkg/controller/egress/validate.go
+++ b/pkg/controller/egress/validate.go
@@ -17,7 +17,7 @@ package egress
 import (
 	"encoding/json"
 	"fmt"
-	"net"
+	"net/netip"
 
 	admv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -73,8 +73,8 @@ func (c *EgressController) ValidateEgress(review *admv1.AdmissionReview) *admv1.
 		if newEgress.Spec.EgressIP == "" || newEgress.Spec.ExternalIPPool == "" {
 			return true, ""
 		}
-		ip := net.ParseIP(newEgress.Spec.EgressIP)
-		if ip == nil {
+		ip, err := netip.ParseAddr(newEgress.Spec.EgressIP)
+		if err != nil {
 			return false, fmt.Sprintf("IP %s is not valid", newEgress.Spec.EgressIP)
 		}
 		if !c.externalIPAllocator.IPPoolExists(newEgress.Spec.ExternalIPPool) {

--- a/pkg/controller/externalippool/controller.go
+++ b/pkg/controller/externalippool/controller.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net"
+	"net/netip"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -33,7 +33,6 @@ import (
 	"k8s.io/client-go/util/retry"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
-	utilnet "k8s.io/utils/net"
 
 	antreacrds "antrea.io/antrea/v2/pkg/apis/crd/v1beta1"
 	clientset "antrea.io/antrea/v2/pkg/client/clientset/versioned"
@@ -66,7 +65,7 @@ type IPAllocation struct {
 	// IPPoolName is the name of the IP pool.
 	IPPoolName string
 	// IP is the allocated IP.
-	IP net.IP
+	IP netip.Addr
 }
 
 // ExternalIPPoolEventHandler defines a consumer to subscribe for external ExternalIPPool events.
@@ -80,19 +79,19 @@ type ExternalIPAllocator interface {
 	// succeeded IP Allocations.
 	RestoreIPAllocations(allocations []IPAllocation) []IPAllocation
 	// AllocateIPFromPool allocates an IP from the given IP pool.
-	AllocateIPFromPool(externalIPPool string) (net.IP, error)
+	AllocateIPFromPool(externalIPPool string) (netip.Addr, error)
 	// IPPoolExists checks whether the IP pool exists.
 	IPPoolExists(externalIPPool string) bool
 	// IPPoolHasIP checks whether the IP pool contains the given IP.
-	IPPoolHasIP(externalIPPool string, ip net.IP) bool
+	IPPoolHasIP(externalIPPool string, ip netip.Addr) bool
 	// UpdateIPAllocation marks the IP in the specified ExternalIPPool as occupied.
-	UpdateIPAllocation(externalIPPool string, ip net.IP) error
+	UpdateIPAllocation(externalIPPool string, ip netip.Addr) error
 	// ReleaseIP releases the IP to the IP pool.
 	// It returns ErrExternalIPPoolNotFound if the externalIPPool does not exist.
 	// Any other error indicates that the IP was not allocated, or is not currently allocated.
 	// In case of an error, there is no reason to try again with the same arguments, as
 	// transient errors are not possible.
-	ReleaseIP(externalIPPool string, ip net.IP) error
+	ReleaseIP(externalIPPool string, ip netip.Addr) error
 	// HasSynced indicates ExternalIPAllocator has finished syncing all ExternalIPPool resources.
 	HasSynced() bool
 }
@@ -217,28 +216,37 @@ func (c *ExternalIPPoolController) createOrUpdateIPAllocator(ipPool *antreacrds.
 		ipRange := &ipPool.Spec.IPRanges[idx]
 		ipAllocator, err := func() (*ipallocator.SingleIPAllocator, error) {
 			if ipRange.CIDR != "" {
-				_, ipNet, err := net.ParseCIDR(ipRange.CIDR)
+				prefix, err := netip.ParsePrefix(ipRange.CIDR)
 				if err != nil {
 					return nil, err
 				}
-				// Must use normalized IPNet string to check if the IP range exists. Otherwise non-strict CIDR like
-				// 192.168.0.1/24 will be considered new even if it doesn't change.
-				// Validating or normalizing the input CIDR should be a better solution but the externalIPPools that
-				// have been created will still have this issue, so we just normalize the CIDR when using it.
-				if existingIPRanges.Has(ipNet.String()) {
+				// Normalize the prefix: a non-strict CIDR like 192.168.0.1/24 would otherwise
+				// be treated as a new range even when unchanged. Validating at admission would be
+				// cleaner, but existing pools may already carry non-canonical CIDRs, so we
+				// normalize at the point of use.
+				prefix = prefix.Masked()
+				if existingIPRanges.Has(prefix.String()) {
 					return nil, nil
 				}
 				// Don't use the IPv4 network's broadcast address.
-				var reservedIPs []net.IP
-				if utilnet.IsIPv4CIDR(ipNet) {
-					reservedIPs = append(reservedIPs, iputil.GetLocalBroadcastIP(ipNet))
+				var reservedIPs []netip.Addr
+				if prefix.Addr().Is4() {
+					reservedIPs = append(reservedIPs, iputil.GetLocalBroadcastAddr(prefix))
 				}
-				return ipallocator.NewCIDRAllocator(ipNet, reservedIPs)
+				return ipallocator.NewCIDRAllocator(prefix, reservedIPs)
 			} else {
 				if existingIPRanges.Has(fmt.Sprintf("%s-%s", ipRange.Start, ipRange.End)) {
 					return nil, nil
 				}
-				return ipallocator.NewIPRangeAllocator(net.ParseIP(ipRange.Start), net.ParseIP(ipRange.End))
+				startIP, err := netip.ParseAddr(ipRange.Start)
+				if err != nil {
+					return nil, err
+				}
+				endIP, err := netip.ParseAddr(ipRange.End)
+				if err != nil {
+					return nil, err
+				}
+				return ipallocator.NewIPRangeAllocator(startIP, endIP)
 			}
 		}()
 		if err != nil {
@@ -273,11 +281,11 @@ func (c *ExternalIPPoolController) getIPAllocator(poolName string) (ipallocator.
 }
 
 // AllocateIPFromPool allocates an IP from the the given IP pool.
-func (c *ExternalIPPoolController) AllocateIPFromPool(ipPoolName string) (net.IP, error) {
+func (c *ExternalIPPoolController) AllocateIPFromPool(ipPoolName string) (netip.Addr, error) {
 	c.handlersWaitGroup.Wait()
 	ipAllocator, exists := c.getIPAllocator(ipPoolName)
 	if !exists {
-		return nil, ErrExternalIPPoolNotFound
+		return netip.Addr{}, ErrExternalIPPoolNotFound
 	}
 	ip, err := ipAllocator.AllocateNext()
 	if err != nil {
@@ -288,7 +296,7 @@ func (c *ExternalIPPoolController) AllocateIPFromPool(ipPoolName string) (net.IP
 }
 
 // UpdateIPAllocation sets the IP in the specified ExternalIPPool.
-func (c *ExternalIPPoolController) UpdateIPAllocation(poolName string, ip net.IP) error {
+func (c *ExternalIPPoolController) UpdateIPAllocation(poolName string, ip netip.Addr) error {
 	ipAllocator, exists := c.getIPAllocator(poolName)
 	if !exists {
 		return ErrExternalIPPoolNotFound
@@ -341,7 +349,7 @@ func (c *ExternalIPPoolController) updateExternalIPPoolStatus(poolName string) e
 }
 
 // ReleaseIP releases the IP to the pool.
-func (c *ExternalIPPoolController) ReleaseIP(poolName string, ip net.IP) error {
+func (c *ExternalIPPoolController) ReleaseIP(poolName string, ip netip.Addr) error {
 	allocator, exists := c.getIPAllocator(poolName)
 	if !exists {
 		return ErrExternalIPPoolNotFound
@@ -353,7 +361,7 @@ func (c *ExternalIPPoolController) ReleaseIP(poolName string, ip net.IP) error {
 	return nil
 }
 
-func (c *ExternalIPPoolController) IPPoolHasIP(poolName string, ip net.IP) bool {
+func (c *ExternalIPPoolController) IPPoolHasIP(poolName string, ip netip.Addr) bool {
 	allocator, exists := c.getIPAllocator(poolName)
 	if !exists {
 		return false

--- a/pkg/controller/externalippool/controller_test.go
+++ b/pkg/controller/externalippool/controller_test.go
@@ -16,7 +16,7 @@ package externalippool
 
 import (
 	"context"
-	"net"
+	"net/netip"
 	"sort"
 	"testing"
 	"time"
@@ -77,7 +77,7 @@ func TestAllocateIPFromPool(t *testing.T) {
 			pool string
 		}
 		allocateFrom         string
-		expectedIP           string
+		expectedIP           netip.Addr
 		expectError          bool
 		expectedIPPoolStatus []antreacrds.IPPoolUsage
 	}{
@@ -88,7 +88,7 @@ func TestAllocateIPFromPool(t *testing.T) {
 			},
 			allocatedIP:  nil,
 			allocateFrom: "eip1",
-			expectedIP:   "10.10.10.2",
+			expectedIP:   netip.MustParseAddr("10.10.10.2"),
 			expectError:  false,
 			expectedIPPoolStatus: []antreacrds.IPPoolUsage{
 				{Total: 2, Used: 1},
@@ -107,7 +107,6 @@ func TestAllocateIPFromPool(t *testing.T) {
 				{"10.10.10.3", "eip1"},
 			},
 			allocateFrom: "eip1",
-			expectedIP:   "",
 			expectError:  true,
 			expectedIPPoolStatus: []antreacrds.IPPoolUsage{
 				{Total: 2, Used: 2},
@@ -120,7 +119,6 @@ func TestAllocateIPFromPool(t *testing.T) {
 			},
 			allocatedIP:  nil,
 			allocateFrom: "eip2",
-			expectedIP:   "",
 			expectError:  true,
 			expectedIPPoolStatus: []antreacrds.IPPoolUsage{
 				{Total: 2, Used: 0},
@@ -141,11 +139,11 @@ func TestAllocateIPFromPool(t *testing.T) {
 			go controller.Run(stopCh)
 			require.True(t, cache.WaitForCacheSync(stopCh, controller.HasSynced))
 			for _, alloc := range tt.allocatedIP {
-				require.NoError(t, controller.UpdateIPAllocation(alloc.pool, net.ParseIP(alloc.ip)))
+				require.NoError(t, controller.UpdateIPAllocation(alloc.pool, netip.MustParseAddr(alloc.ip)))
 			}
 			ipGot, err := controller.AllocateIPFromPool(tt.allocateFrom)
 			assert.Equal(t, tt.expectError, err != nil)
-			assert.Equal(t, net.ParseIP(tt.expectedIP), ipGot)
+			assert.Equal(t, tt.expectedIP, ipGot)
 			for idx, pool := range tt.ipPools {
 				checkExternalIPPoolStatus(t, controller, pool.Name, tt.expectedIPPoolStatus[idx])
 			}
@@ -219,9 +217,9 @@ func TestReleaseIP(t *testing.T) {
 			go controller.Run(stopCh)
 			require.True(t, cache.WaitForCacheSync(stopCh, controller.HasSynced))
 			for _, alloc := range tt.allocatedIP {
-				require.NoError(t, controller.UpdateIPAllocation(alloc.pool, net.ParseIP(alloc.ip)))
+				require.NoError(t, controller.UpdateIPAllocation(alloc.pool, netip.MustParseAddr(alloc.ip)))
 			}
-			err := controller.ReleaseIP(tt.ipPoolToRelease, net.ParseIP(tt.ipToRelease))
+			err := controller.ReleaseIP(tt.ipPoolToRelease, netip.MustParseAddr(tt.ipToRelease))
 			assert.Equal(t, tt.expectError, err != nil)
 			for idx, pool := range tt.ipPools {
 				checkExternalIPPoolStatus(t, controller, pool.Name, tt.expectedIPPoolStatus[idx])
@@ -335,7 +333,7 @@ func TestConsumersRestoreIPAllocation(t *testing.T) {
 		allocatedIPs := []IPAllocation{
 			{
 				IPPoolName: "eip1",
-				IP:         net.ParseIP("10.10.10.2"),
+				IP:         netip.MustParseAddr("10.10.10.2"),
 			},
 		}
 		restored := controller.RestoreIPAllocations(allocatedIPs)
@@ -348,7 +346,7 @@ func TestConsumersRestoreIPAllocation(t *testing.T) {
 		allocatedIPs := []IPAllocation{
 			{
 				IPPoolName: "eip1",
-				IP:         net.ParseIP("10.10.10.3"),
+				IP:         netip.MustParseAddr("10.10.10.3"),
 			},
 		}
 		restored := controller.RestoreIPAllocations(allocatedIPs)
@@ -414,7 +412,7 @@ func TestIPPoolHasIP(t *testing.T) {
 		name           string
 		ipPools        []*antreacrds.ExternalIPPool
 		ipPoolToCheck  string
-		ipToCheck      net.IP
+		ipToCheck      netip.Addr
 		expectedExists bool
 	}{
 		{
@@ -423,7 +421,7 @@ func TestIPPoolHasIP(t *testing.T) {
 				newExternalIPPool("eip1", "", "10.10.10.2", "10.10.10.3"),
 			},
 			ipPoolToCheck:  "eip1",
-			ipToCheck:      net.ParseIP("10.10.10.2"),
+			ipToCheck:      netip.MustParseAddr("10.10.10.2"),
 			expectedExists: true,
 		},
 		{
@@ -432,7 +430,7 @@ func TestIPPoolHasIP(t *testing.T) {
 				newExternalIPPool("eip1", "", "10.10.10.2", "10.10.10.3"),
 			},
 			ipPoolToCheck:  "eip1",
-			ipToCheck:      net.ParseIP("10.10.10.1"),
+			ipToCheck:      netip.MustParseAddr("10.10.10.1"),
 			expectedExists: false,
 		},
 	}
@@ -490,14 +488,14 @@ func TestExternalIPPoolController_RestoreIPAllocations(t *testing.T) {
 						Name: "egress-1",
 					},
 					"eip1",
-					net.ParseIP("10.10.10.2"),
+					netip.MustParseAddr("10.10.10.2"),
 				},
 				{
 					v1.ObjectReference{
 						Name: "egress-2",
 					},
 					"eip2",
-					net.ParseIP("10.10.11.2"),
+					netip.MustParseAddr("10.10.11.2"),
 				},
 			},
 			expectedSucceeded: []IPAllocation{
@@ -506,14 +504,14 @@ func TestExternalIPPoolController_RestoreIPAllocations(t *testing.T) {
 						Name: "egress-1",
 					},
 					"eip1",
-					net.ParseIP("10.10.10.2"),
+					netip.MustParseAddr("10.10.10.2"),
 				},
 				{
 					v1.ObjectReference{
 						Name: "egress-2",
 					},
 					"eip2",
-					net.ParseIP("10.10.11.2"),
+					netip.MustParseAddr("10.10.11.2"),
 				},
 			},
 			expectedIPPoolStatus: []antreacrds.IPPoolUsage{
@@ -533,7 +531,7 @@ func TestExternalIPPoolController_RestoreIPAllocations(t *testing.T) {
 						Name: "other-service-1",
 					},
 					"eip1",
-					net.ParseIP("10.10.10.2"),
+					netip.MustParseAddr("10.10.10.2"),
 				},
 			},
 			allocationsToRestore: []IPAllocation{
@@ -542,14 +540,14 @@ func TestExternalIPPoolController_RestoreIPAllocations(t *testing.T) {
 						Name: "egress-1",
 					},
 					"eip1",
-					net.ParseIP("10.10.10.2"),
+					netip.MustParseAddr("10.10.10.2"),
 				},
 				{
 					v1.ObjectReference{
 						Name: "egress-2",
 					},
 					"eip2",
-					net.ParseIP("10.10.11.2"),
+					netip.MustParseAddr("10.10.11.2"),
 				},
 			},
 			expectedSucceeded: []IPAllocation{
@@ -558,7 +556,7 @@ func TestExternalIPPoolController_RestoreIPAllocations(t *testing.T) {
 						Name: "egress-2",
 					},
 					"eip2",
-					net.ParseIP("10.10.11.2"),
+					netip.MustParseAddr("10.10.11.2"),
 				},
 			},
 			expectedIPPoolStatus: []antreacrds.IPPoolUsage{
@@ -579,14 +577,14 @@ func TestExternalIPPoolController_RestoreIPAllocations(t *testing.T) {
 						Name: "egress-1",
 					},
 					"eip2",
-					net.ParseIP("10.10.11.2"),
+					netip.MustParseAddr("10.10.11.2"),
 				},
 				{
 					v1.ObjectReference{
 						Name: "egress-2",
 					},
 					"eip3",
-					net.ParseIP("10.10.12.2"),
+					netip.MustParseAddr("10.10.12.2"),
 				},
 			},
 			expectedSucceeded: []IPAllocation{
@@ -595,7 +593,7 @@ func TestExternalIPPoolController_RestoreIPAllocations(t *testing.T) {
 						Name: "egress-1",
 					},
 					"eip2",
-					net.ParseIP("10.10.11.2"),
+					netip.MustParseAddr("10.10.11.2"),
 				},
 			},
 			expectedIPPoolStatus: []antreacrds.IPPoolUsage{

--- a/pkg/controller/ipam/antrea_ipam_controller.go
+++ b/pkg/controller/ipam/antrea_ipam_controller.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net"
+	"net/netip"
 	"strings"
 	"time"
 
@@ -290,17 +290,17 @@ func (c *AntreaIPAMController) cleanIPPoolForStatefulSet(namespacedName string) 
 }
 
 // Find IP Pools annotated to StatefulSet via direct annotation or Namespace annotation
-func (c *AntreaIPAMController) getIPPoolsForStatefulSet(ss *appsv1.StatefulSet) ([]string, []net.IP) {
+func (c *AntreaIPAMController) getIPPoolsForStatefulSet(ss *appsv1.StatefulSet) ([]string, []netip.Addr) {
 
 	// Inspect IP annotation for the Pods
 	ipStrings := ss.Spec.Template.Annotations[annotation.AntreaIPAMPodIPAnnotationKey]
 	ipStrings = strings.ReplaceAll(ipStrings, " ", "")
-	var ips []net.IP
+	var ips []netip.Addr
 	if ipStrings != "" {
 		splittedIPStrings := strings.Split(ipStrings, annotation.AntreaIPAMAnnotationDelimiter)
 		for _, ipString := range splittedIPStrings {
-			ip := net.ParseIP(ipString)
-			if ip == nil {
+			ip, err := netip.ParseAddr(ipString)
+			if err != nil {
 				klog.ErrorS(nil, "Ignored invalid Pod IP annotation in the StatefulSet template", "annotation", ipStrings, "statefulSet", klog.KObj(ss))
 				ips = nil
 				break
@@ -342,7 +342,7 @@ func (c *AntreaIPAMController) preallocateIPPoolForStatefulSet(ss *appsv1.Statef
 	klog.InfoS("Processing create notification", "Namespace", ss.Namespace, "StatefulSet", ss.Name)
 
 	ipPools, ips := c.getIPPoolsForStatefulSet(ss)
-	var ip net.IP
+	var ip netip.Addr
 	if len(ips) > 0 {
 		ip = ips[0]
 	}

--- a/pkg/controller/ipam/antrea_ipam_controller_test.go
+++ b/pkg/controller/ipam/antrea_ipam_controller_test.go
@@ -17,7 +17,7 @@ package ipam
 import (
 	"context"
 	"fmt"
-	"net"
+	"net/netip"
 	"testing"
 	"time"
 
@@ -304,7 +304,7 @@ func TestAntreaIPAMController_getIPPoolsForStatefulSet(t *testing.T) {
 		name        string
 		prepareFunc func(*appsv1.StatefulSet)
 		hasIPPool   bool
-		expectedIPs []net.IP
+		expectedIPs []netip.Addr
 	}{
 		{
 			name: "no annotation",
@@ -326,7 +326,7 @@ func TestAntreaIPAMController_getIPPoolsForStatefulSet(t *testing.T) {
 				sts.Spec.Template.Annotations[annotation.AntreaIPAMPodIPAnnotationKey] = "10.2.2.109"
 			},
 			hasIPPool:   true,
-			expectedIPs: []net.IP{net.ParseIP("10.2.2.109")},
+			expectedIPs: []netip.Addr{netip.MustParseAddr("10.2.2.109")},
 		},
 		{
 			name: "invalid ip",

--- a/pkg/controller/serviceexternalip/controller.go
+++ b/pkg/controller/serviceexternalip/controller.go
@@ -17,7 +17,7 @@ package serviceexternalip
 import (
 	"context"
 	"fmt"
-	"net"
+	"net/netip"
 	"reflect"
 	"strconv"
 	"sync"
@@ -61,7 +61,7 @@ const (
 // ipAllocation contains the IP and the IP Pool which allocates it.
 type ipAllocation struct {
 	service  apimachinerytypes.NamespacedName
-	ip       net.IP
+	ip       netip.Addr
 	ipPool   string
 	sharable bool
 }
@@ -228,8 +228,8 @@ func (c *ServiceExternalIPController) restoreIPAllocations(services []*corev1.Se
 		if svc.Spec.Type != corev1.ServiceTypeLoadBalancer || ipPool == "" || ip == "" {
 			continue
 		}
-		parsedIP := net.ParseIP(ip)
-		if parsedIP == nil {
+		parsedIP, err := netip.ParseAddr(ip)
+		if err != nil {
 			continue
 		}
 
@@ -272,13 +272,14 @@ func (c *ServiceExternalIPController) restoreIPAllocations(services []*corev1.Se
 				Namespace: svc.Namespace,
 				Name:      svc.Name,
 			}
-			c.addIPAllocationLocked(name, ipPool, net.ParseIP(ip), isServiceExternalIPSharable(svc))
+			restoredIP, _ := netip.ParseAddr(ip)
+			c.addIPAllocationLocked(name, ipPool, restoredIP, isServiceExternalIPSharable(svc))
 		}
 		klog.InfoS("Restored external IP", "service", klog.KObj(svc), "ip", ip, "pool", ipPool)
 	}
 }
 
-func (c *ServiceExternalIPController) updateIPAllocation(name apimachinerytypes.NamespacedName, ipPool string, ip net.IP, sharable bool) {
+func (c *ServiceExternalIPController) updateIPAllocation(name apimachinerytypes.NamespacedName, ipPool string, ip netip.Addr, sharable bool) {
 	c.ipAllocationMutex.Lock()
 	defer c.ipAllocationMutex.Unlock()
 	newAllocation := &ipAllocation{
@@ -295,7 +296,7 @@ func (c *ServiceExternalIPController) updateIPAllocation(name apimachinerytypes.
 	}
 }
 
-func (c *ServiceExternalIPController) addIPAllocationLocked(name apimachinerytypes.NamespacedName, ipPool string, ip net.IP, sharable bool) {
+func (c *ServiceExternalIPController) addIPAllocationLocked(name apimachinerytypes.NamespacedName, ipPool string, ip netip.Addr, sharable bool) {
 	c.ipAllocations.Add(&ipAllocation{
 		service:  name,
 		ip:       ip,
@@ -364,7 +365,7 @@ func (c *ServiceExternalIPController) releaseExternalIP(service apimachinerytype
 	return false, nil
 }
 
-func (c *ServiceExternalIPController) allocateExternalIP(service apimachinerytypes.NamespacedName, pool string, requestedIP string, allowSharedIP bool) (net.IP, error) {
+func (c *ServiceExternalIPController) allocateExternalIP(service apimachinerytypes.NamespacedName, pool string, requestedIP string, allowSharedIP bool) (netip.Addr, error) {
 	c.ipAllocationMutex.Lock()
 	defer c.ipAllocationMutex.Unlock()
 
@@ -372,7 +373,7 @@ func (c *ServiceExternalIPController) allocateExternalIP(service apimachinerytyp
 	if requestedIP == "" {
 		ip, err := c.externalIPAllocator.AllocateIPFromPool(pool)
 		if err != nil {
-			return nil, fmt.Errorf("error when allocating IP from ExternalIPPool %s for Service %s: %v", pool, service, err)
+			return netip.Addr{}, fmt.Errorf("error when allocating IP from ExternalIPPool %s for Service %s: %v", pool, service, err)
 		}
 		klog.InfoS("Allocated external IP for Service", "service", service, "externalIPPool", pool, "ip", ip)
 		c.addIPAllocationLocked(service, pool, ip, allowSharedIP)
@@ -380,10 +381,10 @@ func (c *ServiceExternalIPController) allocateExternalIP(service apimachinerytyp
 	}
 
 	// Check whether the requested IP is in the IP pool or not.
-	ip := net.ParseIP(requestedIP)
+	ip, _ := netip.ParseAddr(requestedIP)
 	if !c.externalIPAllocator.IPPoolHasIP(pool, ip) {
 		klog.ErrorS(nil, "ExternalIPPool did not contain the requested IP", "externalIPPool", pool, "ip", requestedIP)
-		return nil, nil
+		return netip.Addr{}, nil
 	}
 
 	// Check whether the requested IP is already used.
@@ -392,14 +393,14 @@ func (c *ServiceExternalIPController) allocateExternalIP(service apimachinerytyp
 		// Fail if the Service itself doesn't allow shared IP.
 		if !allowSharedIP {
 			klog.ErrorS(nil, "The Service didn't allow shared IP but the requested IP had been allocated to other Service", "service", service, "externalIPPool", pool, "ip", requestedIP)
-			return nil, nil
+			return netip.Addr{}, nil
 		}
 		// Fail if any Service already using the IP doesn't allow shared IP.
 		for _, obj := range objs {
 			allocation := obj.(*ipAllocation)
 			if !allocation.sharable {
 				klog.ErrorS(nil, "The requested IP had been allocated to other Service not allowing shared IP", "service", service, "externalIPPool", pool, "ip", requestedIP)
-				return nil, nil
+				return netip.Addr{}, nil
 			}
 		}
 		klog.InfoS("Shared external IP for Service", "service", service, "externalIPPool", pool, "ip", ip)
@@ -409,7 +410,7 @@ func (c *ServiceExternalIPController) allocateExternalIP(service apimachinerytyp
 
 	// The requested IP is not used yet, allocate it.
 	if err := c.externalIPAllocator.UpdateIPAllocation(pool, ip); err != nil {
-		return nil, fmt.Errorf("error when allocating IP %s from ExternalIPPool %s for Service %s: %v", requestedIP, pool, service, err)
+		return netip.Addr{}, fmt.Errorf("error when allocating IP %s from ExternalIPPool %s for Service %s: %v", requestedIP, pool, service, err)
 	}
 	klog.InfoS("Requested external IP for Service", "service", service, "externalIPPool", pool, "ip", ip)
 	c.addIPAllocationLocked(service, pool, ip, allowSharedIP)
@@ -472,7 +473,7 @@ func (c *ServiceExternalIPController) syncService(key apimachinerytypes.Namespac
 		}
 		// Ensure the LoadBalancerStatus in Kubernetes API is unset if the IP was allocated by it.
 		if released {
-			return c.updateServiceLoadBalancerIP(service, nil)
+			return c.updateServiceLoadBalancerIP(service, netip.Addr{})
 		}
 		return nil
 	}
@@ -503,7 +504,7 @@ func (c *ServiceExternalIPController) syncService(key apimachinerytypes.Namespac
 		if _, err := c.releaseExternalIP(key); err != nil {
 			return err
 		}
-		return c.updateServiceLoadBalancerIP(service, nil)
+		return c.updateServiceLoadBalancerIP(service, netip.Addr{})
 	}
 
 	// The external IP or ExternalIPPool changes. Delete the previous allocation.
@@ -515,7 +516,7 @@ func (c *ServiceExternalIPController) syncService(key apimachinerytypes.Namespac
 	if currentIPPool == "" {
 		klog.V(2).InfoS("Ignored Service as the required annotation no longer exists", "service", key)
 		if released {
-			return c.updateServiceLoadBalancerIP(service, nil)
+			return c.updateServiceLoadBalancerIP(service, netip.Addr{})
 		}
 		return nil
 	}
@@ -531,9 +532,9 @@ func (c *ServiceExternalIPController) syncService(key apimachinerytypes.Namespac
 }
 
 // updateService updates the Service status in Kubernetes API.
-func (c *ServiceExternalIPController) updateServiceLoadBalancerIP(svc *corev1.Service, ip net.IP) error {
+func (c *ServiceExternalIPController) updateServiceLoadBalancerIP(svc *corev1.Service, ip netip.Addr) error {
 	expectedLoadBalancerStatus := corev1.LoadBalancerStatus{}
-	if ip != nil {
+	if ip.IsValid() {
 		expectedLoadBalancerStatus.Ingress = append(expectedLoadBalancerStatus.Ingress, corev1.LoadBalancerIngress{IP: ip.String()})
 	}
 	toUpdate := svc.DeepCopy()

--- a/pkg/controller/serviceexternalip/controller_test.go
+++ b/pkg/controller/serviceexternalip/controller_test.go
@@ -16,7 +16,7 @@ package serviceexternalip
 
 import (
 	"context"
-	"net"
+	"net/netip"
 	"testing"
 	"time"
 
@@ -215,7 +215,7 @@ func TestAddService(t *testing.T) {
 			assert.NotEmpty(t, ipPool)
 			assert.True(t, controller.externalIPAllocator.IPPoolExists(ipPool))
 			if externalIP != "" {
-				assert.True(t, controller.externalIPAllocator.IPPoolHasIP(ipPool, net.ParseIP(externalIP)))
+				assert.True(t, controller.externalIPAllocator.IPPoolHasIP(ipPool, netip.MustParseAddr(externalIP)))
 			}
 		})
 	}

--- a/pkg/ipam/ipallocator/allocator.go
+++ b/pkg/ipam/ipallocator/allocator.go
@@ -15,28 +15,30 @@
 package ipallocator
 
 import (
+	"encoding/binary"
 	"fmt"
+	"math"
 	"math/big"
-	"net"
+	"net/netip"
 	"sync"
-
-	utilnet "k8s.io/utils/net"
 )
 
+const maxAllocatedSize = 65536
+
 type IPAllocator interface {
-	AllocateIP(ip net.IP) error
+	AllocateIP(ip netip.Addr) error
 
-	AllocateNext() (net.IP, error)
+	AllocateNext() (netip.Addr, error)
 
-	// Allocate range of continuous IPs in one go. If continuus chunk is not
-	// available, error will be returned.
-	AllocateRange(size int) ([]net.IP, error)
+	// AllocateRange allocates a range of continuous IPs in one go. If a
+	// contiguous chunk is not available, an error will be returned.
+	AllocateRange(size int) ([]netip.Addr, error)
 
-	Release(ip net.IP) error
+	Release(ip netip.Addr) error
 
 	Used() int
 
-	Has(ip net.IP) bool
+	Has(ip netip.Addr) bool
 }
 
 // SingleIPAllocator is responsible for allocating IPs from a contiguous IP range.
@@ -45,36 +47,39 @@ type SingleIPAllocator struct {
 	ipRangeStr string
 
 	mutex sync.RWMutex
-	// base is a cached version of the start IP in the CIDR range as a *big.Int.
-	base *big.Int
+	// base is the first allocatable IP in the range.
+	base netip.Addr
 	// max is the maximum size of the usable addresses in the range.
 	max int
 	// allocated is a bit array of the allocated items in the range.
 	allocated *big.Int
 	// count is the number of currently allocated elements in the range.
 	count int
-	// IPs inside the cidr not available for allocation
-	reservedIPs []net.IP
+	// IPs inside the cidr not available for allocation.
+	reservedIPs []netip.Addr
 }
 
-// NewCIDRAllocator creates an IPAllocator based on the provided CIDR.
-func NewCIDRAllocator(cidr *net.IPNet, reservedIPs []net.IP) (*SingleIPAllocator, error) {
-	base := utilnet.BigForIP(cidr.IP)
+// NewCIDRAllocator creates an IPAllocator based on the provided CIDR prefix.
+func NewCIDRAllocator(cidr netip.Prefix, reservedIPs []netip.Addr) (*SingleIPAllocator, error) {
+	cidr = cidr.Masked()
 	// Start from "x.x.x.1".
-	base.Add(base, big.NewInt(1))
-	max := utilnet.RangeSize(cidr) - 1
-	if max < 0 {
-		return nil, fmt.Errorf("no available IP in %s", cidr.String())
+	base := cidr.Addr().Next()
+	bits := cidr.Addr().BitLen() - cidr.Bits()
+	var max int
+	if bits >= 16 {
+		// In case a big range occupies too much memory, allow at most maxAllocatedSize IPs for each IP range.
+		max = maxAllocatedSize
+	} else {
+		max = (1 << bits) - 1
 	}
-	// In case a big range occupies too much memory, allow at most 65536 IP for each IP range.
-	if max > 65536 {
-		max = 65536
+	if max <= 0 {
+		return nil, fmt.Errorf("no available IP in %s", cidr.String())
 	}
 
 	allocator := &SingleIPAllocator{
 		ipRangeStr:  cidr.String(),
 		base:        base,
-		max:         int(max),
+		max:         max,
 		allocated:   big.NewInt(0),
 		count:       0,
 		reservedIPs: reservedIPs,
@@ -84,23 +89,22 @@ func NewCIDRAllocator(cidr *net.IPNet, reservedIPs []net.IP) (*SingleIPAllocator
 
 // NewIPRangeAllocator creates an IPAllocator based on the provided start IP and end IP.
 // The start IP and end IP are inclusive.
-func NewIPRangeAllocator(startIP, endIP net.IP) (*SingleIPAllocator, error) {
+func NewIPRangeAllocator(startIP, endIP netip.Addr) (*SingleIPAllocator, error) {
 	ipRangeStr := fmt.Sprintf("%s-%s", startIP.String(), endIP.String())
-	base := utilnet.BigForIP(startIP)
-	offset := big.NewInt(0).Sub(utilnet.BigForIP(endIP), base).Int64()
+	offset := getIPOffset(startIP, endIP)
 	if offset < 0 {
 		return nil, fmt.Errorf("invalid IP range %s", ipRangeStr)
 	}
 	max := offset + 1
-	// In case a big range occupies too much memory, allow at most 65536 IP for each ipset.
-	if max > 65536 {
-		max = 65536
+	// In case a big range occupies too much memory, allow at most maxAllocatedSize IPs for each IP range.
+	if max > maxAllocatedSize {
+		max = maxAllocatedSize
 	}
 
 	allocator := &SingleIPAllocator{
 		ipRangeStr: ipRangeStr,
-		base:       base,
-		max:        int(max),
+		base:       startIP,
+		max:        max,
 		allocated:  big.NewInt(0),
 		count:      0,
 	}
@@ -111,30 +115,29 @@ func (a *SingleIPAllocator) Name() string {
 	return a.ipRangeStr
 }
 
-func (a *SingleIPAllocator) checkReserved(ip net.IP) error {
+func (a *SingleIPAllocator) isReserved(ip netip.Addr) bool {
 	for _, reservedIP := range a.reservedIPs {
-		if reservedIP.Equal(ip) {
-			return fmt.Errorf("IP %v is reserved and not available for allocation", ip)
+		if reservedIP == ip {
+			return true
 		}
 	}
-	return nil
+	return false
 }
 
 // AllocateIP allocates the specified IP. It returns error if the IP is not in the range or already allocated.
-func (a *SingleIPAllocator) AllocateIP(ip net.IP) error {
-	offset := a.getOffset(ip)
+func (a *SingleIPAllocator) AllocateIP(ip netip.Addr) error {
+	offset := getIPOffset(a.base, ip)
 	if offset < 0 || offset >= a.max {
 		return fmt.Errorf("IP %v is not in the ipset", ip)
 	}
 
-	err := a.checkReserved(ip)
-	if err != nil {
-		return err
+	if a.isReserved(ip) {
+		return fmt.Errorf("IP %v is reserved and not available for allocation", ip)
 	}
 
 	a.mutex.Lock()
 	defer a.mutex.Unlock()
-	if a.allocated.Bit(offset) == 1 {
+	if a.allocated.Bit(offset) != 0 {
 		return fmt.Errorf("IP %v is already allocated", ip)
 	}
 	a.allocated.SetBit(a.allocated, offset, 1)
@@ -142,82 +145,80 @@ func (a *SingleIPAllocator) AllocateIP(ip net.IP) error {
 	return nil
 }
 
-func (a *SingleIPAllocator) allocateOffset(i int) (net.IP, bool) {
-	if a.allocated.Bit(i) == 0 {
-		ip := utilnet.AddIPOffset(a.base, i)
-		if a.checkReserved(ip) != nil {
-			return nil, false
-		}
-		a.allocated.SetBit(a.allocated, i, 1)
-		a.count++
-		return ip, true
-	}
-
-	return nil, false
-}
-
 // AllocateNext allocates an IP from the IP range. It returns error if no IP is available.
-func (a *SingleIPAllocator) AllocateNext() (net.IP, error) {
+func (a *SingleIPAllocator) AllocateNext() (netip.Addr, error) {
 	a.mutex.Lock()
 	defer a.mutex.Unlock()
 	if a.count >= a.max-len(a.reservedIPs) {
-		return nil, fmt.Errorf("no available IP")
+		return netip.Addr{}, fmt.Errorf("no available IP")
 	}
-	for i := 0; i <= a.max; i++ {
-		if ip, ok := a.allocateOffset(i); ok {
-			return ip, nil
+	ip := a.base
+	for i := 0; i < a.max; i++ {
+		if a.allocated.Bit(i) != 0 || a.isReserved(ip) {
+			ip = ip.Next()
+			continue
 		}
+		a.allocated.SetBit(a.allocated, i, 1)
+		a.count++
+		return ip, nil
 	}
 
-	// we should never reach here
-	return nil, fmt.Errorf("no available IP")
+	// We should never reach here.
+	return netip.Addr{}, fmt.Errorf("no available IP")
 }
 
 // AllocateRange allocates continuous range of specified size. If not available, error is returned.
-func (a *SingleIPAllocator) AllocateRange(size int) ([]net.IP, error) {
+func (a *SingleIPAllocator) AllocateRange(size int) ([]netip.Addr, error) {
 	a.mutex.Lock()
 	defer a.mutex.Unlock()
 	if a.count+size > a.max-len(a.reservedIPs) {
 		return nil, fmt.Errorf("not enough available IPs")
 	}
 
-	rangeAvailable := func(offset int) bool {
+	// rangeAvailable returns whether the range starting at the specified offset is
+	// available. The IP address corresponding to the offset also needs to be provided as a
+	// parameter. The function returns the last visited IP and offset, so that subsequent calls
+	// to rangeAvailable (if necessary) can be done more efficiently.
+	rangeAvailable := func(ip netip.Addr, offset int) (bool, netip.Addr, int) {
 		for i := offset; i < offset+size; i++ {
-			ip := utilnet.AddIPOffset(a.base, i)
-			if a.checkReserved(ip) != nil || (a.allocated.Bit(i) == 1) {
-				return false
+			if a.allocated.Bit(i) != 0 || a.isReserved(ip) {
+				return false, ip, i
 			}
+			ip = ip.Next()
 		}
-
-		return true
+		return true, ip, offset + size
 	}
 
-	for start := 0; start <= a.max-size; start++ {
-		// check if this continuous range is available
-		if rangeAvailable(start) {
-			// perform the actual allocation
-			ips := make([]net.IP, 0, size)
+	ip := a.base
+	start := 0
+	for start <= a.max-size {
+		// Check if a continuous range of the requested size is available.
+		available, maxIP, maxOffset := rangeAvailable(ip, start)
+		if available {
+			// Perform the actual allocation.
+			ips := make([]netip.Addr, 0, size)
 			for i := 0; i < size; i++ {
 				offset := start + i
-				ip := utilnet.AddIPOffset(a.base, offset)
 				a.allocated.SetBit(a.allocated, offset, 1)
 				a.count++
 				ips = append(ips, ip)
+				ip = ip.Next()
 			}
-
 			return ips, nil
 		}
+		ip = maxIP.Next()
+		start = maxOffset + 1
 	}
 
 	return nil, fmt.Errorf("continuous range of size %d is not available", size)
 }
 
-func (a *SingleIPAllocator) getOffset(ip net.IP) int {
-	return int(big.NewInt(0).Sub(utilnet.BigForIP(ip), a.base).Int64())
+func (a *SingleIPAllocator) getOffset(ip netip.Addr) int {
+	return getIPOffset(a.base, ip)
 }
 
 // Release releases the provided IP. It returns error if the IP is not in the range or not allocated.
-func (a *SingleIPAllocator) Release(ip net.IP) error {
+func (a *SingleIPAllocator) Release(ip netip.Addr) error {
 	offset := a.getOffset(ip)
 	if offset < 0 || offset >= a.max {
 		return fmt.Errorf("IP %v is not in the ipset", ip)
@@ -253,7 +254,7 @@ func (a *SingleIPAllocator) Total() int {
 }
 
 // Has returns whether the provided IP is in the range or not.
-func (a *SingleIPAllocator) Has(ip net.IP) bool {
+func (a *SingleIPAllocator) Has(ip netip.Addr) bool {
 	offset := a.getOffset(ip)
 	return offset >= 0 && offset < a.max
 }
@@ -269,7 +270,7 @@ func (ma MultiIPAllocator) Names() []string {
 	return names
 }
 
-func (ma MultiIPAllocator) AllocateIP(ip net.IP) error {
+func (ma MultiIPAllocator) AllocateIP(ip netip.Addr) error {
 	for _, a := range ma {
 		if err := a.AllocateIP(ip); err == nil {
 			return nil
@@ -278,18 +279,18 @@ func (ma MultiIPAllocator) AllocateIP(ip net.IP) error {
 	return fmt.Errorf("cannot allocate IP %v in any range", ip)
 }
 
-func (ma MultiIPAllocator) AllocateNext() (net.IP, error) {
+func (ma MultiIPAllocator) AllocateNext() (netip.Addr, error) {
 	for _, a := range ma {
 		if ip, err := a.AllocateNext(); err == nil {
 			return ip, nil
 		}
 	}
-	return nil, fmt.Errorf("cannot allocate IP in any range")
+	return netip.Addr{}, fmt.Errorf("cannot allocate IP in any range")
 }
 
 // AllocateRange allocates continuous range of specified size.
 // If not available in any allocator, error is returned.
-func (ma MultiIPAllocator) AllocateRange(size int) ([]net.IP, error) {
+func (ma MultiIPAllocator) AllocateRange(size int) ([]netip.Addr, error) {
 	if size > ma.Free() {
 		return nil, fmt.Errorf("not enough IPs to reserve range of size %d", size)
 	}
@@ -300,10 +301,10 @@ func (ma MultiIPAllocator) AllocateRange(size int) ([]net.IP, error) {
 		}
 	}
 
-	return nil, fmt.Errorf("cannot allocate continuus IPs in any range")
+	return nil, fmt.Errorf("cannot allocate contiguous IPs in any range")
 }
 
-func (ma MultiIPAllocator) Release(ip net.IP) error {
+func (ma MultiIPAllocator) Release(ip netip.Addr) error {
 	for _, a := range ma {
 		if err := a.Release(ip); err == nil {
 			return nil
@@ -332,11 +333,36 @@ func (ma MultiIPAllocator) Total() int {
 	return total
 }
 
-func (ma MultiIPAllocator) Has(ip net.IP) bool {
+func (ma MultiIPAllocator) Has(ip netip.Addr) bool {
 	for _, a := range ma {
 		if a.Has(ip) {
 			return true
 		}
 	}
 	return false
+}
+
+// getIPOffset returns the offset of ip from base as a non-negative int, or -1 if ip is before base
+// or of a different address family. It returns math.MaxInt if the offset overflows int.
+func getIPOffset(base, ip netip.Addr) int {
+	if base.Is4() != ip.Is4() {
+		return -1
+	}
+	b := base.As16()
+	i := ip.As16()
+	hiB := binary.BigEndian.Uint64(b[:8])
+	loB := binary.BigEndian.Uint64(b[8:])
+	hiI := binary.BigEndian.Uint64(i[:8])
+	loI := binary.BigEndian.Uint64(i[8:])
+	if hiI < hiB || (hiI == hiB && loI < loB) {
+		return -1
+	}
+	if hiI > hiB {
+		return math.MaxInt
+	}
+	diff := loI - loB
+	if diff > math.MaxInt {
+		return math.MaxInt
+	}
+	return int(diff)
 }

--- a/pkg/ipam/ipallocator/allocator_benchmark_test.go
+++ b/pkg/ipam/ipallocator/allocator_benchmark_test.go
@@ -1,0 +1,161 @@
+// Copyright 2026 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ipallocator
+
+import (
+	"net/netip"
+	"testing"
+)
+
+func BenchmarkNewCIDRAllocator(b *testing.B) {
+	cidr := netip.MustParsePrefix("10.10.0.0/16")
+	reservedIPs := []netip.Addr{netip.MustParseAddr("10.10.255.255")}
+	for b.Loop() {
+		NewCIDRAllocator(cidr, reservedIPs)
+	}
+}
+
+func BenchmarkNewIPRangeAllocator(b *testing.B) {
+	startIP := netip.MustParseAddr("10.10.0.1")
+	endIP := netip.MustParseAddr("10.10.0.254")
+	for b.Loop() {
+		NewIPRangeAllocator(startIP, endIP)
+	}
+}
+
+func BenchmarkAllocateIPAndRelease(b *testing.B) {
+	cidr := netip.MustParsePrefix("10.10.0.0/24")
+	a, _ := NewCIDRAllocator(cidr, nil)
+	ip := netip.MustParseAddr("10.10.0.100")
+	for b.Loop() {
+		a.AllocateIP(ip)
+		a.Release(ip)
+	}
+}
+
+func BenchmarkAllocateNextAndRelease(b *testing.B) {
+	cidr := netip.MustParsePrefix("10.10.0.0/24")
+	a, _ := NewCIDRAllocator(cidr, nil)
+	for b.Loop() {
+		ip, _ := a.AllocateNext()
+		a.Release(ip)
+	}
+}
+
+func BenchmarkAllocateNextLargeSequence(b *testing.B) {
+	for b.Loop() {
+		cidr := netip.MustParsePrefix("10.10.0.0/24")
+		a, _ := NewCIDRAllocator(cidr, nil)
+		for i := 0; i < 100; i++ {
+			a.AllocateNext()
+		}
+	}
+}
+
+// BenchmarkAllocateNextHalfFull measures AllocateNext when the allocator is half-full,
+// forcing the scan to skip the first half of the range before finding a free slot.
+func BenchmarkAllocateNextHalfFull(b *testing.B) {
+	cidr := netip.MustParsePrefix("10.10.0.0/24")
+	a, _ := NewCIDRAllocator(cidr, nil)
+	for i := 0; i < 127; i++ {
+		_, _ = a.AllocateNext()
+	}
+	for b.Loop() {
+		ip, _ := a.AllocateNext()
+		// need to release, otherwise we may run out of IPs
+		a.Release(ip)
+	}
+}
+
+func BenchmarkRelease(b *testing.B) {
+	cidr := netip.MustParsePrefix("10.10.0.0/24")
+	a, _ := NewCIDRAllocator(cidr, nil)
+	ip := netip.MustParseAddr("10.10.0.100")
+	_ = a.AllocateIP(ip)
+	for b.Loop() {
+		_ = a.Release(ip)
+		_ = a.AllocateIP(ip)
+	}
+}
+
+func BenchmarkHas(b *testing.B) {
+	cidr := netip.MustParsePrefix("10.10.0.0/24")
+	a, _ := NewCIDRAllocator(cidr, nil)
+	ip := netip.MustParseAddr("10.10.0.100")
+	for b.Loop() {
+		a.Has(ip)
+	}
+}
+
+func BenchmarkAllocateRangeAndRelease(b *testing.B) {
+	cidr := netip.MustParsePrefix("10.10.0.0/16")
+	a, _ := NewCIDRAllocator(cidr, nil)
+	for b.Loop() {
+		ips, _ := a.AllocateRange(10)
+		for _, ip := range ips {
+			a.Release(ip)
+		}
+	}
+}
+
+func BenchmarkAllocateLargeRange(b *testing.B) {
+	cidr := netip.MustParsePrefix("10.10.0.0/16")
+	for b.Loop() {
+		a, _ := NewCIDRAllocator(cidr, nil)
+		a.AllocateRange(200)
+	}
+}
+
+// BenchmarkAllocateRangeSkipSmallGaps measures AllocateRange when several free runs
+// shorter than the requested size precede the first run that is large enough.
+func BenchmarkAllocateRangeSkipSmallGaps(b *testing.B) {
+	const (
+		gapSize      = 10
+		requestSize  = 20
+		numSmallGaps = 2
+	)
+
+	cidr := netip.MustParsePrefix("10.10.0.0/16")
+	ip1 := netip.MustParseAddr("10.10.0.10")
+	ip2 := netip.MustParseAddr("10.10.0.20")
+	ip3 := netip.MustParseAddr("10.10.0.30")
+
+	for b.Loop() {
+		a, _ := NewCIDRAllocator(cidr, nil)
+		a.AllocateIP(ip1)
+		a.AllocateIP(ip2)
+		a.AllocateIP(ip3)
+		a.AllocateRange(requestSize)
+	}
+}
+
+// BenchmarkAllocateNextWithReserved measures AllocateNext when the first several offsets
+// are reserved, requiring isReserved checks before a free slot is found.
+func BenchmarkAllocateNextWithReserved(b *testing.B) {
+	cidr := netip.MustParsePrefix("10.10.0.0/24")
+	reservedIPs := []netip.Addr{
+		netip.MustParseAddr("10.10.0.1"),
+		netip.MustParseAddr("10.10.0.2"),
+		netip.MustParseAddr("10.10.0.3"),
+		netip.MustParseAddr("10.10.0.4"),
+		netip.MustParseAddr("10.10.0.5"),
+	}
+	a, _ := NewCIDRAllocator(cidr, reservedIPs)
+	for b.Loop() {
+		ip, _ := a.AllocateNext()
+		a.Release(ip)
+
+	}
+}

--- a/pkg/ipam/ipallocator/allocator_test.go
+++ b/pkg/ipam/ipallocator/allocator_test.go
@@ -15,7 +15,7 @@
 package ipallocator
 
 import (
-	"net"
+	"net/netip"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -23,17 +23,17 @@ import (
 )
 
 func newCIDRAllocator(cidr string, reservedIPs []string) *SingleIPAllocator {
-	_, ipNet, _ := net.ParseCIDR(cidr)
-	var parsedIPs []net.IP
+	prefix := netip.MustParsePrefix(cidr)
+	var parsed []netip.Addr
 	for _, ip := range reservedIPs {
-		parsedIPs = append(parsedIPs, net.ParseIP(ip))
+		parsed = append(parsed, netip.MustParseAddr(ip))
 	}
-	allocator, _ := NewCIDRAllocator(ipNet, parsedIPs)
+	allocator, _ := NewCIDRAllocator(prefix, parsed)
 	return allocator
 }
 
 func newIPRangeAllocator(start, end string) *SingleIPAllocator {
-	allocator, _ := NewIPRangeAllocator(net.ParseIP(start), net.ParseIP(end))
+	allocator, _ := NewIPRangeAllocator(netip.MustParseAddr(start), netip.MustParseAddr(end))
 	return allocator
 }
 
@@ -43,36 +43,39 @@ func TestAllocateNext(t *testing.T) {
 		ipAllocator IPAllocator
 		ipRanges    []string
 		wantNum     int
-		wantFirst   net.IP
-		wantLast    net.IP
+		wantFirst   netip.Addr
+		wantLast    netip.Addr
 	}{
 		{
 			name:        "IPv4-CIDR-prefix-24",
 			ipAllocator: newCIDRAllocator("10.10.10.0/24", []string{"10.10.10.255"}),
 			wantNum:     254,
-			wantFirst:   net.ParseIP("10.10.10.1"),
-			wantLast:    net.ParseIP("10.10.10.254"),
+			wantFirst:   netip.MustParseAddr("10.10.10.1"),
+			wantLast:    netip.MustParseAddr("10.10.10.254"),
 		},
 		{
 			name:        "IPv4-CIDR-prefix-30",
 			ipAllocator: newCIDRAllocator("10.10.10.128/30", nil),
 			wantNum:     3,
-			wantFirst:   net.ParseIP("10.10.10.129"),
-			wantLast:    net.ParseIP("10.10.10.131"),
+			wantFirst:   netip.MustParseAddr("10.10.10.129"),
+			wantLast:    netip.MustParseAddr("10.10.10.131"),
 		},
 		{
 			name:        "IPv4-range",
 			ipAllocator: newIPRangeAllocator("1.1.1.10", "1.1.1.20"),
 			wantNum:     11,
-			wantFirst:   net.ParseIP("1.1.1.10"),
-			wantLast:    net.ParseIP("1.1.1.20"),
+			wantFirst:   netip.MustParseAddr("1.1.1.10"),
+			wantLast:    netip.MustParseAddr("1.1.1.20"),
 		},
 		{
-			name:        "IPv4-multiple",
-			ipAllocator: MultiIPAllocator{newIPRangeAllocator("1.1.1.10", "1.1.1.20"), newCIDRAllocator("10.10.10.128/30", []string{"10.10.10.131"})},
-			wantNum:     13,
-			wantFirst:   net.ParseIP("1.1.1.10"),
-			wantLast:    net.ParseIP("10.10.10.130"),
+			name: "IPv4-multiple",
+			ipAllocator: MultiIPAllocator{
+				newIPRangeAllocator("1.1.1.10", "1.1.1.20"),
+				newCIDRAllocator("10.10.10.128/30", []string{"10.10.10.131"}),
+			},
+			wantNum:   13,
+			wantFirst: netip.MustParseAddr("1.1.1.10"),
+			wantLast:  netip.MustParseAddr("10.10.10.130"),
 		},
 	}
 	for _, tt := range tests {
@@ -98,40 +101,46 @@ func TestAllocateIP(t *testing.T) {
 	tests := []struct {
 		name         string
 		ipAllocator  IPAllocator
-		allocatedIP1 net.IP
-		allocatedIP2 net.IP
+		allocatedIP1 netip.Addr
+		allocatedIP2 netip.Addr
 		wantErr1     bool
 		wantErr2     bool
 	}{
 		{
 			name:         "IPv4-duplicate",
 			ipAllocator:  newCIDRAllocator("10.10.10.0/24", nil),
-			allocatedIP1: net.ParseIP("10.10.10.1"),
-			allocatedIP2: net.ParseIP("10.10.10.1"),
+			allocatedIP1: netip.MustParseAddr("10.10.10.1"),
+			allocatedIP2: netip.MustParseAddr("10.10.10.1"),
 			wantErr1:     false,
 			wantErr2:     true,
 		},
 		{
-			name:         "IPv4-no-duplicate",
-			ipAllocator:  MultiIPAllocator{newIPRangeAllocator("1.1.1.10", "1.1.1.20"), newCIDRAllocator("10.10.10.128/30", nil)},
-			allocatedIP1: net.ParseIP("1.1.1.10"),
-			allocatedIP2: net.ParseIP("10.10.10.130"),
+			name: "IPv4-no-duplicate",
+			ipAllocator: MultiIPAllocator{
+				newIPRangeAllocator("1.1.1.10", "1.1.1.20"),
+				newCIDRAllocator("10.10.10.128/30", nil),
+			},
+			allocatedIP1: netip.MustParseAddr("1.1.1.10"),
+			allocatedIP2: netip.MustParseAddr("10.10.10.130"),
 			wantErr1:     false,
 			wantErr2:     false,
 		},
 		{
-			name:         "IPv4-out-of-scope",
-			ipAllocator:  MultiIPAllocator{newIPRangeAllocator("1.1.1.10", "1.1.1.20"), newCIDRAllocator("10.10.10.128/30", []string{"10.10.10.128"})},
-			allocatedIP1: net.ParseIP("1.1.1.21"),
-			allocatedIP2: net.ParseIP("10.10.10.127"),
+			name: "IPv4-out-of-scope",
+			ipAllocator: MultiIPAllocator{
+				newIPRangeAllocator("1.1.1.10", "1.1.1.20"),
+				newCIDRAllocator("10.10.10.128/30", []string{"10.10.10.128"}),
+			},
+			allocatedIP1: netip.MustParseAddr("1.1.1.21"),
+			allocatedIP2: netip.MustParseAddr("10.10.10.127"),
 			wantErr1:     true,
 			wantErr2:     true,
 		},
 		{
 			name:         "IPv4-reserved",
 			ipAllocator:  MultiIPAllocator{newCIDRAllocator("10.10.10.128/30", []string{"10.10.10.1", "10.10.10.5"})},
-			allocatedIP1: net.ParseIP("10.10.10.1"),
-			allocatedIP2: net.ParseIP("10.10.10.5"),
+			allocatedIP1: netip.MustParseAddr("10.10.10.1"),
+			allocatedIP2: netip.MustParseAddr("10.10.10.5"),
 			wantErr1:     true,
 			wantErr2:     true,
 		},
@@ -192,19 +201,22 @@ func TestHas(t *testing.T) {
 	tests := []struct {
 		name        string
 		ipAllocator IPAllocator
-		ip          net.IP
+		ip          netip.Addr
 		expectedHas bool
 	}{
 		{
 			name:        "IPv4-single",
 			ipAllocator: newCIDRAllocator("10.10.10.0/24", nil),
-			ip:          net.ParseIP("10.10.10.0"),
+			ip:          netip.MustParseAddr("10.10.10.0"),
 			expectedHas: false,
 		},
 		{
-			name:        "IPv4-multiple",
-			ipAllocator: MultiIPAllocator{newIPRangeAllocator("1.1.1.10", "1.1.1.20"), newCIDRAllocator("10.10.10.128/30", nil)},
-			ip:          net.ParseIP("10.10.10.130"),
+			name: "IPv4-multiple",
+			ipAllocator: MultiIPAllocator{
+				newIPRangeAllocator("1.1.1.10", "1.1.1.20"),
+				newCIDRAllocator("10.10.10.128/30", nil),
+			},
+			ip:          netip.MustParseAddr("10.10.10.130"),
 			expectedHas: true,
 		},
 	}
@@ -220,75 +232,96 @@ func TestAllocateRange(t *testing.T) {
 		name        string
 		ipAllocator IPAllocator
 		size        int
-		prevIPs     []net.IP
+		prevIPs     []netip.Addr
 		wantError   bool
-		wantFirst   net.IP
-		wantLast    net.IP
+		wantFirst   netip.Addr
+		wantLast    netip.Addr
 	}{
 		{
 			name:        "IPv4-CIDR-Empty-OK",
 			ipAllocator: newCIDRAllocator("10.10.10.0/24", []string{"10.10.10.255"}),
 			wantError:   false,
 			size:        15,
-			wantFirst:   net.ParseIP("10.10.10.1"),
-			wantLast:    net.ParseIP("10.10.10.15"),
+			wantFirst:   netip.MustParseAddr("10.10.10.1"),
+			wantLast:    netip.MustParseAddr("10.10.10.15"),
 		},
 		{
 			name:        "IPv4-CIDR-Middle-OK",
 			ipAllocator: newCIDRAllocator("10.10.10.0/24", nil),
 			wantError:   false,
-			prevIPs:     []net.IP{net.ParseIP("10.10.10.13"), net.ParseIP("10.10.10.30")},
+			prevIPs:     []netip.Addr{netip.MustParseAddr("10.10.10.13"), netip.MustParseAddr("10.10.10.30")},
 			size:        15,
-			wantFirst:   net.ParseIP("10.10.10.14"),
-			wantLast:    net.ParseIP("10.10.10.28"),
+			wantFirst:   netip.MustParseAddr("10.10.10.14"),
+			wantLast:    netip.MustParseAddr("10.10.10.28"),
 		},
 		{
 			name:        "IPv4-Range-Error",
 			ipAllocator: newIPRangeAllocator("1.1.1.10", "1.1.1.20"),
 			wantError:   true,
-			prevIPs:     []net.IP{net.ParseIP("1.1.1.12"), net.ParseIP("1.1.1.16")},
+			prevIPs:     []netip.Addr{netip.MustParseAddr("1.1.1.12"), netip.MustParseAddr("1.1.1.16")},
 			size:        5,
 		},
 		{
-			name:        "IPv4-Multiple-OK",
-			ipAllocator: MultiIPAllocator{newIPRangeAllocator("1.1.1.10", "1.1.1.20"), newCIDRAllocator("10.10.10.128/30", nil)},
-			wantError:   false,
-			prevIPs:     []net.IP{net.ParseIP("1.1.1.12")},
-			size:        5,
-			wantFirst:   net.ParseIP("1.1.1.13"),
-			wantLast:    net.ParseIP("1.1.1.17"),
+			name: "IPv4-Multiple-OK",
+			ipAllocator: MultiIPAllocator{
+				newIPRangeAllocator("1.1.1.10", "1.1.1.20"),
+				newCIDRAllocator("10.10.10.128/30", nil),
+			},
+			wantError: false,
+			prevIPs:   []netip.Addr{netip.MustParseAddr("1.1.1.12")},
+			size:      5,
+			wantFirst: netip.MustParseAddr("1.1.1.13"),
+			wantLast:  netip.MustParseAddr("1.1.1.17"),
 		},
 		{
-			name:        "IPv4-Multiple-Second-OK",
-			ipAllocator: MultiIPAllocator{newIPRangeAllocator("1.1.1.10", "1.1.1.20"), newIPRangeAllocator("2.2.2.10", "2.2.2.30")},
-			wantError:   false,
-			prevIPs:     []net.IP{net.ParseIP("1.1.1.15"), net.ParseIP("2.2.2.15"), net.ParseIP("2.2.2.16")},
-			size:        10,
-			wantFirst:   net.ParseIP("2.2.2.17"),
-			wantLast:    net.ParseIP("2.2.2.26"),
+			name: "IPv4-Multiple-Second-OK",
+			ipAllocator: MultiIPAllocator{
+				newIPRangeAllocator("1.1.1.10", "1.1.1.20"),
+				newIPRangeAllocator("2.2.2.10", "2.2.2.30"),
+			},
+			wantError: false,
+			prevIPs: []netip.Addr{
+				netip.MustParseAddr("1.1.1.15"),
+				netip.MustParseAddr("2.2.2.15"),
+				netip.MustParseAddr("2.2.2.16"),
+			},
+			size:      10,
+			wantFirst: netip.MustParseAddr("2.2.2.17"),
+			wantLast:  netip.MustParseAddr("2.2.2.26"),
 		},
 		{
-			name:        "IPv6-Multiple-Full-Range-OK",
-			ipAllocator: MultiIPAllocator{newIPRangeAllocator("1000::2", "1000::5"), newIPRangeAllocator("1000::10", "1000::12"), newIPRangeAllocator("1000::20", "1000::29")},
-			wantError:   false,
-			size:        10,
-			wantFirst:   net.ParseIP("1000::20"),
-			wantLast:    net.ParseIP("1000::29"),
+			name: "IPv6-Multiple-Full-Range-OK",
+			ipAllocator: MultiIPAllocator{
+				newIPRangeAllocator("1000::2", "1000::5"),
+				newIPRangeAllocator("1000::10", "1000::12"),
+				newIPRangeAllocator("1000::20", "1000::29"),
+			},
+			wantError: false,
+			size:      10,
+			wantFirst: netip.MustParseAddr("1000::20"),
+			wantLast:  netip.MustParseAddr("1000::29"),
 		},
 		{
-			name:        "IPv6-Multiple-Error",
-			ipAllocator: MultiIPAllocator{newIPRangeAllocator("1000::2", "1000::5"), newIPRangeAllocator("1000::10", "1000::12"), newIPRangeAllocator("1000::20", "1000::30")},
-			wantError:   true,
-			prevIPs:     []net.IP{net.ParseIP("1000::23"), net.ParseIP("1000::2d"), net.ParseIP("1000::30")},
-			size:        10,
-			wantFirst:   net.ParseIP("1000::20"),
-			wantLast:    net.ParseIP("1000::2a"),
+			name: "IPv6-Multiple-Error",
+			ipAllocator: MultiIPAllocator{
+				newIPRangeAllocator("1000::2", "1000::5"),
+				newIPRangeAllocator("1000::10", "1000::12"),
+				newIPRangeAllocator("1000::20", "1000::30"),
+			},
+			wantError: true,
+			prevIPs: []netip.Addr{
+				netip.MustParseAddr("1000::23"),
+				netip.MustParseAddr("1000::2d"),
+				netip.MustParseAddr("1000::30"),
+			},
+			size:      10,
+			wantFirst: netip.MustParseAddr("1000::20"),
+			wantLast:  netip.MustParseAddr("1000::2a"),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// preallocate IPs for the test
 			for _, ip := range tt.prevIPs {
 				err := tt.ipAllocator.AllocateIP(ip)
 				require.NoError(t, err)

--- a/pkg/ipam/poolallocator/allocator.go
+++ b/pkg/ipam/poolallocator/allocator.go
@@ -17,7 +17,7 @@ package poolallocator
 import (
 	"context"
 	"fmt"
-	"net"
+	"net/netip"
 	"reflect"
 
 	"antrea.io/antrea/v2/pkg/apis/crd/v1beta1"
@@ -83,27 +83,40 @@ func (a *IPPoolAllocator) initIPAllocators(ipPool *v1beta1.IPPool) (ipallocator.
 	// Initialize a list of IP allocators based on pool spec
 	for _, ipRange := range ipPool.Spec.IPRanges {
 		if len(ipRange.CIDR) > 0 {
-			// Reserve gateway address and broadcast address
-			reservedIPs := []net.IP{net.ParseIP(ipPool.Spec.SubnetInfo.Gateway)}
-			_, ipNet, err := net.ParseCIDR(ipRange.CIDR)
+			// Reserve gateway address and broadcast address.
+			gwAddr, err := netip.ParseAddr(ipPool.Spec.SubnetInfo.Gateway)
+			if err != nil {
+				return nil, fmt.Errorf("invalid gateway address %s: %v", ipPool.Spec.SubnetInfo.Gateway, err)
+			}
+			reservedIPs := []netip.Addr{gwAddr}
+			prefix, err := netip.ParsePrefix(ipRange.CIDR)
 			if err != nil {
 				return nil, err
 			}
+			prefix = prefix.Masked()
 
-			size, bits := ipNet.Mask.Size()
-			if size == int(ipPool.Spec.SubnetInfo.PrefixLength) && bits == 32 {
-				// Allocation CIDR covers entire subnet, thus we need
-				// to reserve broadcast IP as well for IPv4
-				reservedIPs = append(reservedIPs, iputil.GetLocalBroadcastIP(ipNet))
+			prefixLen := prefix.Bits()
+			addrBits := prefix.Addr().BitLen()
+			if prefixLen == int(ipPool.Spec.SubnetInfo.PrefixLength) && addrBits == 32 {
+				// Allocation CIDR covers entire subnet, so reserve the IPv4 broadcast address.
+				reservedIPs = append(reservedIPs, iputil.GetLocalBroadcastAddr(prefix))
 			}
 
-			allocator, err := ipallocator.NewCIDRAllocator(ipNet, reservedIPs)
+			allocator, err := ipallocator.NewCIDRAllocator(prefix, reservedIPs)
 			if err != nil {
 				return nil, err
 			}
 			allocators = append(allocators, allocator)
 		} else {
-			allocator, err := ipallocator.NewIPRangeAllocator(net.ParseIP(ipRange.Start), net.ParseIP(ipRange.End))
+			startIP, err := netip.ParseAddr(ipRange.Start)
+			if err != nil {
+				return allocators, err
+			}
+			endIP, err := netip.ParseAddr(ipRange.End)
+			if err != nil {
+				return allocators, err
+			}
+			allocator, err := ipallocator.NewIPRangeAllocator(startIP, endIP)
 			if err != nil {
 				return allocators, err
 			}
@@ -113,7 +126,11 @@ func (a *IPPoolAllocator) initIPAllocators(ipPool *v1beta1.IPPool) (ipallocator.
 
 	// Mark allocated IPs from pool status as unavailable
 	for _, ip := range ipPool.Status.IPAddresses {
-		err := allocators.AllocateIP(net.ParseIP(ip.IPAddress))
+		addr, err := netip.ParseAddr(ip.IPAddress)
+		if err != nil {
+			return allocators, fmt.Errorf("invalid IP address %s in pool %s: %v", ip.IPAddress, ipPool.Name, err)
+		}
+		err = allocators.AllocateIP(addr)
 		if err != nil {
 			// TODO - fix state if possible
 			return allocators, fmt.Errorf("inconsistent state for IP Pool %s with IP %s", ipPool.Name, ip.IPAddress)
@@ -137,7 +154,7 @@ func (a *IPPoolAllocator) getPoolAndInitIPAllocators() (*v1beta1.IPPool, ipalloc
 	return ipPool, allocators, nil
 }
 
-func (a *IPPoolAllocator) appendPoolUsage(ipPool *v1beta1.IPPool, ip net.IP, state v1beta1.IPAddressPhase, owner v1beta1.IPAddressOwner) error {
+func (a *IPPoolAllocator) appendPoolUsage(ipPool *v1beta1.IPPool, ip netip.Addr, state v1beta1.IPAddressPhase, owner v1beta1.IPAddressOwner) error {
 	newPool := ipPool.DeepCopy()
 	usageEntry := v1beta1.IPAddressState{
 		IPAddress: ip.String(),
@@ -157,7 +174,7 @@ func (a *IPPoolAllocator) appendPoolUsage(ipPool *v1beta1.IPPool, ip net.IP, sta
 }
 
 // updateIPAddressState updates the status of the specified IP in the provided IPPool. It requires the IP is already in the IPAddresses list of the IPPool's status.
-func (a *IPPoolAllocator) updateIPAddressState(ipPool *v1beta1.IPPool, ip net.IP, state v1beta1.IPAddressPhase, owner v1beta1.IPAddressOwner) error {
+func (a *IPPoolAllocator) updateIPAddressState(ipPool *v1beta1.IPPool, ip netip.Addr, state v1beta1.IPAddressPhase, owner v1beta1.IPAddressOwner) error {
 	newPool := ipPool.DeepCopy()
 	ipString := ip.String()
 	found := false
@@ -183,7 +200,7 @@ func (a *IPPoolAllocator) updateIPAddressState(ipPool *v1beta1.IPPool, ip net.IP
 
 }
 
-func (a *IPPoolAllocator) appendPoolUsageForStatefulSet(ipPool *v1beta1.IPPool, ips []net.IP, namespace, name string) error {
+func (a *IPPoolAllocator) appendPoolUsageForStatefulSet(ipPool *v1beta1.IPPool, ips []netip.Addr, namespace, name string) error {
 	newPool := ipPool.DeepCopy()
 
 	for i, ip := range ips {
@@ -212,7 +229,7 @@ func (a *IPPoolAllocator) appendPoolUsageForStatefulSet(ipPool *v1beta1.IPPool, 
 }
 
 // removeIPAddressState updates ipPool status to delete released IP allocation, and keeps preallocation information
-func (a *IPPoolAllocator) removeIPAddressState(ipPool *v1beta1.IPPool, ip net.IP) error {
+func (a *IPPoolAllocator) removeIPAddressState(ipPool *v1beta1.IPPool, ip netip.Addr) error {
 
 	ipString := ip.String()
 	newPool := ipPool.DeepCopy()
@@ -251,18 +268,18 @@ func (a *IPPoolAllocator) removeIPAddressState(ipPool *v1beta1.IPPool, ip net.IP
 
 // getExistingAllocation looks up the existing IP allocation for a Pod network interface, and
 // returns the IP address and SubnetInfo if found.
-func (a *IPPoolAllocator) getExistingAllocation(podOwner *v1beta1.PodOwner) (net.IP, *v1beta1.SubnetInfo, error) {
+func (a *IPPoolAllocator) getExistingAllocation(podOwner *v1beta1.PodOwner) (netip.Addr, *v1beta1.SubnetInfo, error) {
 	ip, err := a.GetContainerIP(podOwner.ContainerID, podOwner.IFName)
 	if err != nil {
-		return nil, nil, err
+		return netip.Addr{}, nil, err
 	}
-	if ip == nil {
-		return nil, nil, nil
+	if !ip.IsValid() {
+		return netip.Addr{}, nil, nil
 	}
 
 	ipPool, allocators, err := a.getPoolAndInitIPAllocators()
 	if err != nil {
-		return nil, nil, err
+		return netip.Addr{}, nil, err
 	}
 
 	index := -1
@@ -273,7 +290,7 @@ func (a *IPPoolAllocator) getExistingAllocation(podOwner *v1beta1.PodOwner) (net
 		}
 	}
 	if index == -1 {
-		return nil, nil, fmt.Errorf("IP %v does not belong to IPPool %s", ip, a.ipPoolName)
+		return netip.Addr{}, nil, fmt.Errorf("IP %v does not belong to IPPool %s", ip, a.ipPoolName)
 	}
 	return ip, &ipPool.Spec.SubnetInfo, nil
 }
@@ -282,7 +299,7 @@ func (a *IPPoolAllocator) getExistingAllocation(podOwner *v1beta1.PodOwner) (net
 // allocated, or in case CRD failed to update its state.
 // In case of success, IP pool CRD status is updated with allocated IP/state/resource/container.
 // AllocateIP returns subnet details for the requested IP, as defined in IP pool spec.
-func (a *IPPoolAllocator) AllocateIP(ip net.IP, state v1beta1.IPAddressPhase, owner v1beta1.IPAddressOwner) (*v1beta1.SubnetInfo, error) {
+func (a *IPPoolAllocator) AllocateIP(ip netip.Addr, state v1beta1.IPAddressPhase, owner v1beta1.IPAddressOwner) (*v1beta1.SubnetInfo, error) {
 	var subnetInfo *v1beta1.SubnetInfo
 	// Retry on CRD update conflict which is caused by multiple agents updating a pool at same time.
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
@@ -323,16 +340,16 @@ func (a *IPPoolAllocator) AllocateIP(ip net.IP, state v1beta1.IPAddressPhase, ow
 // AllocateNext allocates the next available IP. It returns error if pool is exhausted,
 // or in case CRD failed to update its state.
 // In case of success, IPPool CRD status is updated with allocated IP/state/resource/container.
-// AllocateIP returns subnet details for the requested IP, as defined in IP pool spec.
-func (a *IPPoolAllocator) AllocateNext(state v1beta1.IPAddressPhase, owner v1beta1.IPAddressOwner) (net.IP, *v1beta1.SubnetInfo, error) {
+// AllocateNext returns subnet details for the requested IP, as defined in IP pool spec.
+func (a *IPPoolAllocator) AllocateNext(state v1beta1.IPAddressPhase, owner v1beta1.IPAddressOwner) (netip.Addr, *v1beta1.SubnetInfo, error) {
 	podOwner := owner.Pod
 	// Same resource can not ask for allocation twice without release.
 	// This needs to be verified even at the expense of another API call.
 	ip, subnetInfo, err := a.getExistingAllocation(podOwner)
 	if err != nil {
-		return nil, nil, err
+		return netip.Addr{}, nil, err
 	}
-	if ip != nil {
+	if ip.IsValid() {
 		// This can happen when the container requests IPs from multiple pools, and after an
 		// allocation failure, not all allocated IPs were successfully released, and then
 		// CNI ADD is retried.
@@ -376,24 +393,24 @@ func (a *IPPoolAllocator) AllocateNext(state v1beta1.IPAddressPhase, owner v1bet
 // It returns error if pool is exhausted, or in case it fails to update IPPool's state. In case of
 // success, IP pool status is updated with allocated IP/state/resource/container.
 // AllocateReservedOrNext returns subnet details for the requested IP, as defined in IP pool spec.
-func (a *IPPoolAllocator) AllocateReservedOrNext(state v1beta1.IPAddressPhase, owner v1beta1.IPAddressOwner) (net.IP, *v1beta1.SubnetInfo, error) {
+func (a *IPPoolAllocator) AllocateReservedOrNext(state v1beta1.IPAddressPhase, owner v1beta1.IPAddressOwner) (netip.Addr, *v1beta1.SubnetInfo, error) {
 	ip, err := a.getReservedIP(owner)
 	if err != nil {
-		return nil, nil, err
+		return netip.Addr{}, nil, err
 	}
-	if ip == nil {
+	if !ip.IsValid() {
 		// IP is not reserved, allocate next available IP.
 		return a.AllocateNext(state, owner)
 	}
 
-	var prevIP net.IP
+	var prevIP netip.Addr
 	var subnetInfo *v1beta1.SubnetInfo
 	podOwner := owner.Pod
 	prevIP, subnetInfo, err = a.getExistingAllocation(podOwner)
 	if err != nil {
-		return nil, nil, err
+		return netip.Addr{}, nil, err
 	}
-	if prevIP != nil {
+	if prevIP.IsValid() {
 		klog.InfoS("Container already has an IP allocated", "container", podOwner.ContainerID, "interface", podOwner.IFName, "IPPool", a.ipPoolName)
 		return prevIP, subnetInfo, err
 	}
@@ -432,7 +449,7 @@ func (a *IPPoolAllocator) AllocateReservedOrNext(state v1beta1.IPAddressPhase, o
 // This functionality is useful when StatefulSet does not have a dedicated IP Pool assigned.
 // It returns error if such range is not available. In this case IPs for the StatefulSet will
 // be allocated on the fly, and there is no guarantee for continuous IPs.
-func (a *IPPoolAllocator) AllocateStatefulSet(namespace, name string, size int, ip net.IP) error {
+func (a *IPPoolAllocator) AllocateStatefulSet(namespace, name string, size int, ip netip.Addr) error {
 	// Retry on CRD update conflict which is caused by multiple agents updating a pool at same time.
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		ipPool, allocators, err := a.getPoolAndInitIPAllocators()
@@ -447,10 +464,10 @@ func (a *IPPoolAllocator) AllocateStatefulSet(namespace, name string, size int, 
 			}
 		}
 
-		var ips []net.IP
-		if size == 1 && ip != nil {
+		var ips []netip.Addr
+		if size == 1 && ip.IsValid() {
 			err = allocators.AllocateIP(ip)
-			ips = []net.IP{ip}
+			ips = []netip.Addr{ip}
 		} else {
 			ips, err = allocators.AllocateRange(size)
 		}
@@ -470,7 +487,7 @@ func (a *IPPoolAllocator) AllocateStatefulSet(namespace, name string, size int, 
 // Release releases the provided IP. It returns error if the IP is not in the range or not allocated,
 // or in case CRD failed to update its state.
 // In case of success, IP pool CRD status is updated with released IP/state/resource.
-func (a *IPPoolAllocator) Release(ip net.IP) error {
+func (a *IPPoolAllocator) Release(ip netip.Addr) error {
 
 	// Retry on CRD update conflict which is caused by multiple agents updating a pool at same time.
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
@@ -555,8 +572,8 @@ func (a *IPPoolAllocator) ReleaseContainer(containerID, ifName string) error {
 		for _, ip := range ipPool.Status.IPAddresses {
 			savedOwner := ip.Owner.Pod
 			if savedOwner != nil && savedOwner.ContainerID == containerID && savedOwner.IFName == ifName {
-				return a.removeIPAddressState(ipPool, net.ParseIP(ip.IPAddress))
-
+				addr, _ := netip.ParseAddr(ip.IPAddress)
+				return a.removeIPAddressState(ipPool, addr)
 			}
 		}
 
@@ -588,35 +605,37 @@ func (a *IPPoolAllocator) hasPod(namespace, podName string) (bool, error) {
 }
 
 // GetContainerIP returns the IP allocated for the container interface if found.
-func (a *IPPoolAllocator) GetContainerIP(containerID, ifName string) (net.IP, error) {
+func (a *IPPoolAllocator) GetContainerIP(containerID, ifName string) (netip.Addr, error) {
 	ipPool, err := a.getPool()
 	if err != nil {
-		return nil, err
+		return netip.Addr{}, err
 	}
 
 	for _, ip := range ipPool.Status.IPAddresses {
 		if ip.Owner.Pod != nil && ip.Owner.Pod.ContainerID == containerID && ip.Owner.Pod.IFName == ifName {
-			return net.ParseIP(ip.IPAddress), nil
+			addr, _ := netip.ParseAddr(ip.IPAddress)
+			return addr, nil
 		}
 	}
-	return nil, nil
+	return netip.Addr{}, nil
 }
 
 // getReservedIP checks whether an IP was reserved with specified owner. It returns error if the resource crd fails to be retrieved.
-func (a *IPPoolAllocator) getReservedIP(reservedOwner v1beta1.IPAddressOwner) (net.IP, error) {
+func (a *IPPoolAllocator) getReservedIP(reservedOwner v1beta1.IPAddressOwner) (netip.Addr, error) {
 	ipPool, err := a.getPool()
 	if err != nil {
-		return nil, err
+		return netip.Addr{}, err
 	}
 
 	if reservedOwner.StatefulSet != nil {
 		for _, ip := range ipPool.Status.IPAddresses {
 			if reflect.DeepEqual(ip.Owner.StatefulSet, reservedOwner.StatefulSet) {
-				return net.ParseIP(ip.IPAddress), nil
+				addr, _ := netip.ParseAddr(ip.IPAddress)
+				return addr, nil
 			}
 		}
 	}
-	return nil, nil
+	return netip.Addr{}, nil
 }
 
 func (a IPPoolAllocator) Total() int {

--- a/pkg/ipam/poolallocator/allocator_test.go
+++ b/pkg/ipam/poolallocator/allocator_test.go
@@ -17,7 +17,7 @@ package poolallocator
 import (
 	"context"
 	"fmt"
-	"net"
+	"net/netip"
 	"testing"
 	"time"
 
@@ -84,7 +84,7 @@ func validateAllocationSequence(t *testing.T, allocator *IPPoolAllocator, subnet
 		}
 		ip, returnInfo, err := allocator.AllocateNext(crdv1b1.IPAddressPhaseAllocated, owner)
 		require.NoError(t, err)
-		assert.Equal(t, net.ParseIP(expectedIP), ip)
+		assert.Equal(t, netip.MustParseAddr(expectedIP), ip)
 		assert.Equal(t, subnetInfo, *returnInfo)
 		i += 1
 	}
@@ -115,19 +115,19 @@ func TestAllocateIP(t *testing.T) {
 	assert.Equal(t, 21, allocator.Total())
 
 	// Allocate specific IP from the range
-	returnInfo, err := allocator.AllocateIP(net.ParseIP("10.2.2.101"), crdv1b1.IPAddressPhaseAllocated, fakePodOwner)
+	returnInfo, err := allocator.AllocateIP(netip.MustParseAddr("10.2.2.101"), crdv1b1.IPAddressPhaseAllocated, fakePodOwner)
 	assert.Equal(t, subnetInfo, *returnInfo)
 	require.NoError(t, err)
 
 	// Validate IP outside the range is not allocated
-	_, err = allocator.AllocateIP(net.ParseIP("10.2.2.121"), crdv1b1.IPAddressPhaseAllocated, fakePodOwner)
+	_, err = allocator.AllocateIP(netip.MustParseAddr("10.2.2.121"), crdv1b1.IPAddressPhaseAllocated, fakePodOwner)
 	require.Error(t, err)
 
 	// Make sure IP allocated above is not allocated again
 	validateAllocationSequence(t, allocator, subnetInfo, []string{"10.2.2.100", "10.2.2.102"})
 
 	// Validate error is returned if IP is already allocated
-	_, err = allocator.AllocateIP(net.ParseIP("10.2.2.102"), crdv1b1.IPAddressPhaseAllocated, fakePodOwner)
+	_, err = allocator.AllocateIP(netip.MustParseAddr("10.2.2.102"), crdv1b1.IPAddressPhaseAllocated, fakePodOwner)
 	require.Error(t, err)
 }
 
@@ -252,7 +252,7 @@ func TestAllocateReleaseSequence(t *testing.T) {
 
 	// Release first IP from first range and middle IP from second range
 	for _, ipToRelease := range []string{"2001::1000", "2001::2"} {
-		err := allocator.Release(net.ParseIP(ipToRelease))
+		err := allocator.Release(netip.MustParseAddr(ipToRelease))
 		require.NoError(t, err)
 	}
 
@@ -272,7 +272,8 @@ func (a *IPPoolAllocator) releasePod(namespace, podName string) error {
 		// Mark allocated IPs from pool status as unavailable
 		for _, ip := range ipPool.Status.IPAddresses {
 			if ip.Owner.Pod != nil && ip.Owner.Pod.Namespace == namespace && ip.Owner.Pod.Name == podName {
-				return a.removeIPAddressState(ipPool, net.ParseIP(ip.IPAddress))
+				addr, _ := netip.ParseAddr(ip.IPAddress)
+				return a.removeIPAddressState(ipPool, addr)
 
 			}
 		}
@@ -366,16 +367,16 @@ func TestHas(t *testing.T) {
 	has, err := allocator.hasPod(testNamespace, "realPod")
 	require.NoError(t, err)
 	assert.False(t, has)
-	var ip net.IP
+	var ip netip.Addr
 	ip, err = allocator.GetContainerIP("fakeContainer", "eth1")
 	require.NoError(t, err)
-	assert.NotNil(t, ip)
+	assert.True(t, ip.IsValid())
 	ip, err = allocator.GetContainerIP("fakeContainer", "")
 	require.NoError(t, err)
-	assert.Nil(t, ip)
+	assert.False(t, ip.IsValid())
 	ip, err = allocator.GetContainerIP("realContainer", "eth1")
 	require.NoError(t, err)
-	assert.Nil(t, ip)
+	assert.False(t, ip.IsValid())
 }
 
 func TestAllocateReleaseStatefulSet(t *testing.T) {
@@ -399,7 +400,7 @@ func TestAllocateReleaseStatefulSet(t *testing.T) {
 	}
 
 	allocator := newTestIPPoolAllocator(&pool, stopCh)
-	err := allocator.AllocateStatefulSet(testNamespace, setName, 7, nil)
+	err := allocator.AllocateStatefulSet(testNamespace, setName, 7, netip.Addr{})
 	require.NoError(t, err)
 
 	// Make sure reserved IPs are respected for next allocate
@@ -413,7 +414,7 @@ func TestAllocateReleaseStatefulSet(t *testing.T) {
 	validateAllocationSequence(t, allocator, subnetInfo, []string{"10.2.2.100"})
 
 	allocator = newTestIPPoolAllocator(&pool, stopCh)
-	err = allocator.AllocateStatefulSet(testNamespace, setName, 1, net.ParseIP("10.2.2.101"))
+	err = allocator.AllocateStatefulSet(testNamespace, setName, 1, netip.MustParseAddr("10.2.2.101"))
 	require.NoError(t, err)
 
 	// Make sure specified IP is reserved
@@ -427,6 +428,6 @@ func TestAllocateReleaseStatefulSet(t *testing.T) {
 	validateAllocationSequence(t, allocator, subnetInfo, []string{"10.2.2.101"})
 
 	// Invalid IP will result in an error
-	err = allocator.AllocateStatefulSet(testNamespace, setName, 1, net.ParseIP("10.2.3.103"))
+	err = allocator.AllocateStatefulSet(testNamespace, setName, 1, netip.MustParseAddr("10.2.3.103"))
 	require.Error(t, err)
 }

--- a/pkg/util/ip/ip.go
+++ b/pkg/util/ip/ip.go
@@ -279,6 +279,12 @@ func AppendPortIfMissing(addr, port string) string {
 	return net.JoinHostPort(addr, port)
 }
 
+// GetLocalBroadcastAddr returns the last address in a prefix (the IPv4 broadcast address).
+func GetLocalBroadcastAddr(prefix netip.Prefix) netip.Addr {
+	_, end := GetStartAndEndOfPrefix(prefix)
+	return end
+}
+
 // GetStartAndEndOfPrefix retrieves the start and end addresses of a netip.Prefix.
 // For example:  10.10.40.0/24 -> 10.10.40.0, 10.10.40.255
 func GetStartAndEndOfPrefix(prefix netip.Prefix) (netip.Addr, netip.Addr) {


### PR DESCRIPTION
Replace net.IP / *net.IPNet with netip.Addr / netip.Prefix throughout the ipallocator package and all its consumers.

netip.Addr is a value type with no heap allocation, which eliminates the per-call allocations that net.IP (a []byte) imposed on every AllocateIP, AllocateNext, AllocateRange, Release, and Has call. The old implementation also called fmt.Errorf inside checkReserved on every iteration, adding further allocations on the reserved-IP path.

AllocateNext and AllocateRange now scan with ip.Next() instead of recomputing addIPOffset(base, i) from scratch each iteration. AllocateRange additionally skips past blocking positions (rather than retrying from start+1), avoiding redundant re-examination of IPs that are known to be unavailable.

Also fix a pre-existing off-by-one bug in AllocateNext where the loop bound was i <= max instead of i < max.

Key changes:
- Update IPAllocator interface signatures to use netip.Addr
- Rewrite SingleIPAllocator internals: netip.Addr base, custom getIPOffset helper, ip.Next()-based scan in hot paths
- Replace checkReserved (returned error) with isReserved (bool)
- Add GetLocalBroadcastAddr utility for netip.Prefix
- Migrate all consumers: externalippool, poolallocator, egress, serviceexternalip, cniserver/ipam, and controller/ipam
- Add comprehensive benchmarks for SingleIPAllocator