### PR TITLE
Migrate go-yaml dependency from v2 to v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,6 @@ require (
 	github.com/vishvananda/netlink v1.3.1
 	github.com/vmware/go-ipfix v0.16.0
 	go.uber.org/mock v0.6.0
-	go.yaml.in/yaml/v2 v2.4.4
 	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/crypto v0.50.0
 	golang.org/x/mod v0.35.0
@@ -233,6 +232,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.5.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
+	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	golang.org/x/exp v0.0.0-20241108190413-2d47ceb2692f // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
 	golang.org/x/term v0.42.0 // indirect

--- a/pkg/antctl/output/output.go
+++ b/pkg/antctl/output/output.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 
 	"antrea.io/antrea/v2/pkg/antctl/transform/common"
 	"antrea.io/antrea/v2/pkg/apiserver/apis"
@@ -143,7 +143,9 @@ func YamlOutput(obj interface{}, writer io.Writer) error {
 	if err := yaml.Unmarshal(buf.Bytes(), &jsonObj); err != nil {
 		return fmt.Errorf("error when outputing in yaml format: %w", err)
 	}
-	if err := yaml.NewEncoder(writer).Encode(jsonObj); err != nil {
+	enc := yaml.NewEncoder(writer)
+	enc.SetIndent(2)
+	if err := enc.Encode(jsonObj); err != nil {
 		return fmt.Errorf("error when outputing in yaml format: %w", err)
 	}
 	return nil

--- a/pkg/antctl/raw/set/flowaggregator/command.go
+++ b/pkg/antctl/raw/set/flowaggregator/command.go
@@ -15,6 +15,7 @@
 package flowaggregator
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -23,7 +24,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -136,10 +137,13 @@ func updateRunE(cmd *cobra.Command, args []string) error {
 		}
 	}
 	// marshal back the changed parameters to configmap
-	b, err := yaml.Marshal(&flowAggregatorConf)
-	if err != nil {
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(&flowAggregatorConf); err != nil {
 		return err
 	}
+	b := buf.Bytes()
 
 	if configMap.Data == nil {
 		configMap.Data = make(map[string]string)

--- a/pkg/antctl/raw/supportbundle/command.go
+++ b/pkg/antctl/raw/supportbundle/command.go
@@ -30,7 +30,7 @@ import (
 	"github.com/cheggaaa/pb/v3"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/time/rate"
 

--- a/pkg/antctl/raw/traceflow/command.go
+++ b/pkg/antctl/raw/traceflow/command.go
@@ -27,7 +27,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"

--- a/pkg/apiserver/handlers/featuregates/handler.go
+++ b/pkg/apiserver/handlers/featuregates/handler.go
@@ -21,7 +21,7 @@ import (
 	"sort"
 	"strings"
 
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"

--- a/pkg/flowaggregator/flowaggregator.go
+++ b/pkg/flowaggregator/flowaggregator.go
@@ -153,7 +153,7 @@ func NewFlowAggregator(
 		return nil, fmt.Errorf("error when starting file watch on configuration dir: %v", err)
 	}
 
-	data, err := os.ReadFile(configFile) // #nosec G703: path is provided by a cluster admin via a ConfigMap mount; no privilege boundary crossed.
+	data, err := os.ReadFile(configFile) // #nosec G703: path is provided by a cluster admin via command-line args to the flow-aggregator; no privilege boundary crossed.
 	if err != nil {
 		return nil, fmt.Errorf("cannot read FlowAggregator configuration file: %v", err)
 	}

--- a/pkg/flowaggregator/flowaggregator.go
+++ b/pkg/flowaggregator/flowaggregator.go
@@ -153,7 +153,7 @@ func NewFlowAggregator(
 		return nil, fmt.Errorf("error when starting file watch on configuration dir: %v", err)
 	}
 
-	data, err := os.ReadFile(configFile)
+	data, err := os.ReadFile(configFile) // #nosec G703: path is provided by a cluster admin via a ConfigMap mount; no privilege boundary crossed.
 	if err != nil {
 		return nil, fmt.Errorf("cannot read FlowAggregator configuration file: %v", err)
 	}

--- a/pkg/flowaggregator/flowaggregator_test.go
+++ b/pkg/flowaggregator/flowaggregator_test.go
@@ -1107,11 +1107,6 @@ func TestNewFlowAggregator(t *testing.T) {
 	require.NoError(t, err)
 	// fsnotify does not seem to work when using the default tempdir on MacOS, which is why we
 	// use the current working directory.
-	f, err := os.CreateTemp(wd, "test_*.config")
-	require.NoError(t, err, "Failed to create test config file")
-	fileName := f.Name()
-	defer os.Remove(fileName)
-
 	newFlowAggregatorConfig := func(clusterID string) *flowaggregatorconfig.FlowAggregatorConfig {
 		return &flowaggregatorconfig.FlowAggregatorConfig{
 			FlowCollector: flowaggregatorconfig.FlowCollectorConfig{
@@ -1148,6 +1143,13 @@ func TestNewFlowAggregator(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
+			// Create a separate temp file for each test case to avoid
+			// duplicate key conflicts in YAML (v3+ rejects duplicate keys).
+			f, err := os.CreateTemp(wd, "test_*.config")
+			require.NoError(t, err, "Failed to create test config file")
+			fileName := f.Name()
+			defer os.Remove(fileName)
+
 			client := fake.NewSimpleClientset()
 			ctrl := gomock.NewController(t)
 			mockPodStore := objectstoretest.NewMockPodStore(ctrl)

--- a/pkg/flowaggregator/flowaggregator_test.go
+++ b/pkg/flowaggregator/flowaggregator_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 	"google.golang.org/protobuf/testing/protocmp"
 	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	v1 "k8s.io/api/core/v1"

--- a/pkg/flowaggregator/flowaggregator_test.go
+++ b/pkg/flowaggregator/flowaggregator_test.go
@@ -1105,8 +1105,6 @@ func TestFlowAggregator_fillK8sMetadata(t *testing.T) {
 func TestNewFlowAggregator(t *testing.T) {
 	wd, err := os.Getwd()
 	require.NoError(t, err)
-	// fsnotify does not seem to work when using the default tempdir on MacOS, which is why we
-	// use the current working directory.
 	newFlowAggregatorConfig := func(clusterID string) *flowaggregatorconfig.FlowAggregatorConfig {
 		return &flowaggregatorconfig.FlowAggregatorConfig{
 			FlowCollector: flowaggregatorconfig.FlowCollectorConfig{
@@ -1145,6 +1143,8 @@ func TestNewFlowAggregator(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Create a separate temp file for each test case to avoid
 			// duplicate key conflicts in YAML (v3+ rejects duplicate keys).
+			// fsnotify does not seem to work when using the default tempdir on MacOS, which is why we
+			// use the current working directory.
 			f, err := os.CreateTemp(wd, "test_*.config")
 			require.NoError(t, err, "Failed to create test config file")
 			fileName := f.Name()

--- a/pkg/support/dump.go
+++ b/pkg/support/dump.go
@@ -27,7 +27,7 @@ import (
 	"time"
 
 	"github.com/spf13/afero"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 	"k8s.io/utils/exec"
 
 	agentquerier "antrea.io/antrea/v2/pkg/agent/querier"

--- a/pkg/support/dump_test.go
+++ b/pkg/support/dump_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 	"k8s.io/utils/exec"
 	exectesting "k8s.io/utils/exec/testing"
 )

--- a/pkg/util/yaml/decode.go
+++ b/pkg/util/yaml/decode.go
@@ -15,22 +15,26 @@
 package yaml
 
 import (
-	"go.yaml.in/yaml/v2"
+	"bytes"
+
+	"go.yaml.in/yaml/v3"
 	"k8s.io/klog/v2"
 )
 
-// UnmarshalLenient tries strict decoding first, then fall back to lenient decoding, which tolerates unknown fields and
-// duplicate fields. It's typically used to avoid error when the provided data contains new fields that are not yet
-// known to this version of code, which may happen when doing upgrade.
+// UnmarshalLenient tries strict decoding first, then fall back to lenient decoding, which tolerates unknown fields
+// (note that duplicate fields will still cause an error). It's typically used to avoid error when the provided data
+// contains new fields that are not yet known to this version of code, which may happen when doing upgrade.
 func UnmarshalLenient(data []byte, v interface{}) error {
-	strictErr := yaml.UnmarshalStrict(data, v)
+	strictErr := func() error {
+		dec := yaml.NewDecoder(bytes.NewReader(data))
+		dec.KnownFields(true)
+		return dec.Decode(v)
+	}()
 	if strictErr != nil {
 		err := yaml.Unmarshal(data, v)
 		if err != nil {
-			// The data is malformed, return the original strict error.
 			return strictErr
 		}
-		// TypeError.Error() breaks the error into multiple lines, reformat it to keep the log on one line.
 		if e, ok := strictErr.(*yaml.TypeError); ok {
 			klog.InfoS("Used lenient decoding as strict decoding failed", "err", e.Errors)
 		} else {

--- a/pkg/util/yaml/decode.go
+++ b/pkg/util/yaml/decode.go
@@ -37,7 +37,7 @@ func UnmarshalLenient(data []byte, v interface{}) error {
 			return strictErr
 		}
 		if e, ok := strictErr.(*yaml.TypeError); ok {
-			// TypeError.Errors is a []string slice; log each entry directly.
+			// TypeError.Error() breaks the error into multiple lines, reformat it to keep the log on one line.
 			klog.InfoS("Used lenient decoding as strict decoding failed", "err", e.Errors)
 		} else {
 			klog.InfoS("Used lenient decoding as strict decoding failed", "err", e)

--- a/pkg/util/yaml/decode.go
+++ b/pkg/util/yaml/decode.go
@@ -33,9 +33,11 @@ func UnmarshalLenient(data []byte, v interface{}) error {
 	if strictErr != nil {
 		err := yaml.Unmarshal(data, v)
 		if err != nil {
+			// The data is malformed, return the original strict error.
 			return strictErr
 		}
 		if e, ok := strictErr.(*yaml.TypeError); ok {
+			// TypeError.Errors is a []string slice; log each entry directly.
 			klog.InfoS("Used lenient decoding as strict decoding failed", "err", e.Errors)
 		} else {
 			klog.InfoS("Used lenient decoding as strict decoding failed", "err", e)

--- a/pkg/util/yaml/decode_test.go
+++ b/pkg/util/yaml/decode_test.go
@@ -67,16 +67,15 @@ foo: abc
 			wantErr: true,
 		},
 		{
+			// go-yaml v3 unconditionally rejects duplicate keys per the YAML 1.2
+			// spec. This explicitly breaks from v2's silent last-wins behavior.
 			name: "duplicate field",
 			data: []byte(`
 foo: abc
 bar: 123
 foo: abcd
 `),
-			expectedV: &Config{
-				Foo: "abcd",
-				Bar: 123,
-			},
+			wantErr: true,
 		},
 		{
 			name: "unknown field",

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -37,7 +37,7 @@ import (
 	"github.com/containernetworking/plugins/pkg/ip"
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
-	"go.yaml.in/yaml/v2"
+	"go.yaml.in/yaml/v3"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"


### PR DESCRIPTION
Migration of all YAML configuration and output processing to go.yaml.in/yaml/v3