### PR TITLE
Enforce strict Pod IP and IPPool family validation

### DIFF
--- a/docs/antrea-ipam.md
+++ b/docs/antrea-ipam.md
@@ -10,6 +10,7 @@
       * [Create IPPool CR](#create-ippool-cr)
       * [IPPool Annotations on Namespace](#ippool-annotations-on-namespace)
       * [IPPool Annotations on Pod (available since Antrea 1.5)](#ippool-annotations-on-pod-available-since-antrea-15)
+        * [Specifying fixed Pod IPs](#specifying-fixed-pod-ips)
       * [Persistent IP for StatefulSet Pod (available since Antrea 1.5)](#persistent-ip-for-statefulset-pod-available-since-antrea-15)
     * [Data path behaviors](#data-path-behaviors)
     * [Requirements for this Feature](#requirements-for-this-feature)
@@ -193,11 +194,23 @@ Since Antrea v1.5.0, Pod IPPool annotation is supported and has a higher
 priority than the Namespace IPPool annotation. This annotation can be added to
 `PodTemplate` of a controller resource such as StatefulSet and Deployment.
 
-The `ipam.antrea.io/pod-ips` annotation sets a fixed IP for a Pod. Antrea reads it from
-each Pod object; set it on the Pod or on a workload Pod template so controllers copy
-it to Pods they create. A fixed value in a template is only valid when one Pod is
-created from that template (for example, `replicas: 1`); see the StatefulSet examples
-below.
+##### Specifying fixed Pod IPs
+
+The `ipam.antrea.io/pod-ips` annotation specifies fixed IPs for a Pod. The
+annotation is valid only when a single Pod is created from that template (for
+example, `replicas: 1`); see the StatefulSet examples below.
+
+The following restrictions apply when you use `ipam.antrea.io/pod-ips`:
+
+- At most one IPv4 address and one IPv6 address can be allocated to a Pod. If
+  the `ipam.antrea.io/pod-ips` annotation contains multiple addresses of the
+  same IP family, only the first one of each family will be used; the rest are
+  silently ignored.
+- When multiple IPPools of the same IP family are listed in the
+  `ipam.antrea.io/ippools` annotation (or inherited from the Namespace), a
+  specified IP must belong to the first IPPool of the matching IP family.
+  Allocation will fail if the IP is not within that Pool's range; subsequent
+  Pools of the same family will **not** be tried as a fallback.
 
 Examples of annotations on a Pod or PodTemplate:
 
@@ -256,18 +269,6 @@ metadata:
   annotations:
     ipam.antrea.io/pod-ips: '<ip-in-namespace-pool>'
 ```
-
-**Restrictions on specified Pod IPs:**
-
-- At most one IPv4 address and one IPv6 address can be allocated to a Pod. If
-  the `ipam.antrea.io/pod-ips` annotation contains multiple addresses of the
-  same IP family, only the first one of each family will be used; the rest are
-  silently ignored.
-- When multiple IPPools of the same IP family are listed in the
-  `ipam.antrea.io/ippools` annotation (or inherited from the Namespace), a
-  specified IP must belong to the first IPPool of the matching IP family.
-  Allocation will fail if the IP is not within that Pool's range; subsequent
-  Pools of the same family will **not** be tried as a fallback.
 
 #### Persistent IP for StatefulSet Pod (available since Antrea 1.5)
 

--- a/docs/antrea-ipam.md
+++ b/docs/antrea-ipam.md
@@ -193,7 +193,11 @@ Since Antrea v1.5.0, Pod IPPool annotation is supported and has a higher
 priority than the Namespace IPPool annotation. This annotation can be added to
 `PodTemplate` of a controller resource such as StatefulSet and Deployment.
 
-Pod IP annotation is supported for a single Pod to specify a fixed IP for the Pod.
+The `ipam.antrea.io/pod-ips` annotation sets a fixed IP for a Pod. Antrea reads it from
+each Pod object; set it on the Pod or on a workload Pod template so controllers copy
+it to Pods they create. A fixed value in a template is only valid when one Pod is
+created from that template (for example, `replicas: 1`); see the StatefulSet examples
+below.
 
 Examples of annotations on a Pod or PodTemplate:
 

--- a/docs/antrea-ipam.md
+++ b/docs/antrea-ipam.md
@@ -260,15 +260,16 @@ example, `replicas: 1`); see the StatefulSet examples above.
 
 The following restrictions apply when you use `ipam.antrea.io/pod-ips`:
 
-- At most one IPv4 address and one IPv6 address can be allocated to a Pod. If
-  the `ipam.antrea.io/pod-ips` annotation contains multiple addresses of the
-  same IP family, only the first one of each family will be used, and the rest are
-  silently ignored.
-- When multiple IPPools of the same IP family are listed in the
-  `ipam.antrea.io/ippools` annotation (or inherited from the Namespace), a
-  specified IP must belong to the first IPPool of the matching IP family.
-  Allocation will fail if the IP is not within that Pool's range, and subsequent
-  Pools of the same family will **not** be tried as a fallback.
+- At most one IPv4 address and one IPv6 address can be specified. If the
+  `ipam.antrea.io/pod-ips` annotation contains more than one address of the
+  same IP family, the request is **rejected** (it is not valid to list
+  duplicates and have the rest ignored).
+- For each address family in which a static IP is requested, the effective
+  `ipam.antrea.io/ippools` list (on the Pod or inherited from the Namespace) must
+  name **at most one** IPPool of that family. If a static IPv4 is requested, you
+  cannot list two IPv4 IPPools; the same applies to IPv6 when a static IPv6 is
+  requested. (You can still list one IPv4 pool and one IPv6 pool for dual-stack
+  static addresses.)
 
 #### Persistent IP for StatefulSet Pod (available since Antrea 1.5)
 

--- a/docs/antrea-ipam.md
+++ b/docs/antrea-ipam.md
@@ -194,24 +194,6 @@ Since Antrea v1.5.0, Pod IPPool annotation is supported and has a higher
 priority than the Namespace IPPool annotation. This annotation can be added to
 `PodTemplate` of a controller resource such as StatefulSet and Deployment.
 
-##### Specifying fixed Pod IPs
-
-The `ipam.antrea.io/pod-ips` annotation specifies fixed IPs for a Pod. The
-annotation is valid only when a single Pod is created from that template (for
-example, `replicas: 1`); see the StatefulSet examples below.
-
-The following restrictions apply when you use `ipam.antrea.io/pod-ips`:
-
-- At most one IPv4 address and one IPv6 address can be allocated to a Pod. If
-  the `ipam.antrea.io/pod-ips` annotation contains multiple addresses of the
-  same IP family, only the first one of each family will be used; the rest are
-  silently ignored.
-- When multiple IPPools of the same IP family are listed in the
-  `ipam.antrea.io/ippools` annotation (or inherited from the Namespace), a
-  specified IP must belong to the first IPPool of the matching IP family.
-  Allocation will fail if the IP is not within that Pool's range; subsequent
-  Pools of the same family will **not** be tried as a fallback.
-
 Examples of annotations on a Pod or PodTemplate:
 
 ```yaml
@@ -269,6 +251,24 @@ metadata:
   annotations:
     ipam.antrea.io/pod-ips: '<ip-in-namespace-pool>'
 ```
+
+##### Specifying fixed Pod IPs
+
+The `ipam.antrea.io/pod-ips` annotation specifies fixed IPs for a Pod. The
+annotation is valid only when a single Pod is created from that template (for
+example, `replicas: 1`); see the StatefulSet examples above.
+
+The following restrictions apply when you use `ipam.antrea.io/pod-ips`:
+
+- At most one IPv4 address and one IPv6 address can be allocated to a Pod. If
+  the `ipam.antrea.io/pod-ips` annotation contains multiple addresses of the
+  same IP family, only the first one of each family will be used, and the rest are
+  silently ignored.
+- When multiple IPPools of the same IP family are listed in the
+  `ipam.antrea.io/ippools` annotation (or inherited from the Namespace), a
+  specified IP must belong to the first IPPool of the matching IP family.
+  Allocation will fail if the IP is not within that Pool's range, and subsequent
+  Pools of the same family will **not** be tried as a fallback.
 
 #### Persistent IP for StatefulSet Pod (available since Antrea 1.5)
 

--- a/docs/antrea-ipam.md
+++ b/docs/antrea-ipam.md
@@ -259,10 +259,9 @@ When applied to a `PodTemplate` (e.g., in a StatefulSet), the annotation
 is valid only if a single Pod is created from that template (for example,
 `replicas: 1`); see the StatefulSet examples above.
 
-**Note:** Starting from Antrea v2.7, requesting multiple IPs of the same address family (e.g.,
-two IPv4 addresses) for a single Pod is strictly validated and will cause the IP allocation to
-fail. In previous versions, Antrea would silently ignore the extra IPs of the same family. Ensure
-that your configurations do not request more than one IP per address family.
+**Note:** Starting from Antrea v2.7, providing multiple IPs of the same address family (e.g.,
+two IPv4 addresses) for a single Pod is strictly validated and the request will be rejected.
+In previous versions, Antrea would silently ignore the extra IPs of the same family.
 
 The following restrictions apply when using `ipam.antrea.io/pod-ips`:
 

--- a/docs/antrea-ipam.md
+++ b/docs/antrea-ipam.md
@@ -259,11 +259,7 @@ When applied to a `PodTemplate` (e.g., in a StatefulSet), the annotation
 is valid only if a single Pod is created from that template (for example,
 `replicas: 1`); see the StatefulSet examples above.
 
-**Note:** Starting from Antrea v2.7, providing multiple IPs of the same address family (e.g.,
-two IPv4 addresses) for a single Pod is strictly validated and the request will be rejected.
-In previous versions, Antrea would silently ignore the extra IPs of the same family.
-
-The following restrictions apply when using `ipam.antrea.io/pod-ips`:
+Starting with Antrea v2.7, the following restrictions apply when using `ipam.antrea.io/pod-ips`:
 
 - At most one IPv4 address and one IPv6 address can be specified. If the
   `ipam.antrea.io/pod-ips` annotation contains more than one address of the
@@ -274,6 +270,9 @@ The following restrictions apply when using `ipam.antrea.io/pod-ips`:
   cannot list two IPv4 IPPools; the same applies to IPv6 when a static IPv6 is
   requested. (You can still list one IPv4 pool and one IPv6 pool for dual-stack
   static addresses.)
+
+**Note:** these two restrictions were introduced in Antrea v2.7. Previous versions
+of Antrea silently ignore the extra IP addresses and pools of the same family.
 
 #### Persistent IP for StatefulSet Pod (available since Antrea 1.5)
 

--- a/docs/antrea-ipam.md
+++ b/docs/antrea-ipam.md
@@ -254,19 +254,19 @@ metadata:
 
 ##### Specifying fixed Pod IPs
 
-The `ipam.antrea.io/pod-ips` annotation specifies fixed IPs for a Pod. The
-annotation is valid only when a single Pod is created from that template (for
-example, `replicas: 1`); see the StatefulSet examples above.
+The `ipam.antrea.io/pod-ips` annotation specifies fixed IPs for a Pod.
+When applied to a `PodTemplate` (e.g., in a StatefulSet), the annotation
+is valid only if a single Pod is created from that template (for example,
+`replicas: 1`); see the StatefulSet examples above.
 
-The following restrictions apply when you use `ipam.antrea.io/pod-ips`:
+The following restrictions apply when using `ipam.antrea.io/pod-ips`:
 
 - At most one IPv4 address and one IPv6 address can be specified. If the
   `ipam.antrea.io/pod-ips` annotation contains more than one address of the
-  same IP family, the request is **rejected** (it is not valid to list
-  duplicates and have the rest ignored).
+  same IP family, the request will be **rejected**.
 - For each address family in which a static IP is requested, the effective
   `ipam.antrea.io/ippools` list (on the Pod or inherited from the Namespace) must
-  name **at most one** IPPool of that family. If a static IPv4 is requested, you
+  contain **at most one** IPPool of that family. If a static IPv4 is requested, you
   cannot list two IPv4 IPPools; the same applies to IPv6 when a static IPv6 is
   requested. (You can still list one IPv4 pool and one IPv6 pool for dual-stack
   static addresses.)

--- a/docs/antrea-ipam.md
+++ b/docs/antrea-ipam.md
@@ -259,6 +259,11 @@ When applied to a `PodTemplate` (e.g., in a StatefulSet), the annotation
 is valid only if a single Pod is created from that template (for example,
 `replicas: 1`); see the StatefulSet examples above.
 
+**Note:** Starting from Antrea v2.7, requesting multiple IPs of the same address family (e.g.,
+two IPv4 addresses) for a single Pod is strictly validated and will cause the IP allocation to
+fail. In previous versions, Antrea would silently ignore the extra IPs of the same family. Ensure
+that your configurations do not request more than one IP per address family.
+
 The following restrictions apply when using `ipam.antrea.io/pod-ips`:
 
 - At most one IPv4 address and one IPv6 address can be specified. If the

--- a/pkg/agent/cniserver/ipam/antrea_ipam.go
+++ b/pkg/agent/cniserver/ipam/antrea_ipam.go
@@ -166,13 +166,13 @@ func splitIPsByFamily(ips []net.IP) (v4, v6 net.IP) {
 // free IPs), the next Pool of the same family is attempted. Other errors
 // (e.g. API failures) cause an immediate return.
 //
-// When a Pod specifies desired IPs via the AntreaIPAMPodIP annotation, exactly
-// one IPv4 and/or one IPv6 address may be provided. Multiple addresses of the
-// same family are rejected during annotation parsing. When an IP is specified,
-// only a single Pool of that IP family is allowed; multiple Pools of the same
-// family will also be rejected. The specified IP is allocated from that Pool,
-// and if the allocation fails for any reason (IP not in range, already
-// allocated, etc.), the error is returned immediately.
+// When a Pod specifies desired IPs via the AntreaIPAMPodIP annotation, at most
+// one IPv4 address and at most one IPv6 address may be provided. Multiple
+// addresses of the same family are rejected during annotation parsing. When an
+// IP is specified, only a single Pool of that IP family is allowed; multiple
+// Pools of the same family will also be rejected. The specified IP is
+// allocated from that Pool, and if the allocation fails for any reason (IP not
+// in range, already allocated, etc.), the error is returned immediately.
 // See https://antrea.io/docs/main/docs/antrea-ipam.md for more details.
 func (d *AntreaIPAM) Add(args *invoke.Args, k8sArgs *types.K8sArgs, networkConfig []byte) (bool, *IPAMResult, error) {
 	mine, allocators, ips, reservedOwner, err := d.owns(k8sArgs)

--- a/pkg/agent/cniserver/ipam/antrea_ipam.go
+++ b/pkg/agent/cniserver/ipam/antrea_ipam.go
@@ -138,7 +138,6 @@ func (d *AntreaIPAM) setController(controller *AntreaIPAMController) {
 }
 
 // splitIPsByFamily returns the first IPv4 and IPv6 address found in ips.
-// Additional addresses of the same family are silently ignored.
 func splitIPsByFamily(ips []net.IP) (v4, v6 net.IP) {
 	for _, ip := range ips {
 		if ip.To4() != nil {
@@ -167,12 +166,13 @@ func splitIPsByFamily(ips []net.IP) (v4, v6 net.IP) {
 // free IPs), the next Pool of the same family is attempted. Other errors
 // (e.g. API failures) cause an immediate return.
 //
-// When a Pod specifies desired IPs via the AntreaIPAMPodIP annotation, at most
-// one IPv4 and one IPv6 address are used; additional addresses of the same
-// family are silently ignored. The specified IP is always allocated from the
-// first Pool of the corresponding IP family. If the allocation fails for any
-// reason (IP not in range, already allocated, etc.), the error is returned
-// immediately without trying subsequent Pools.
+// When a Pod specifies desired IPs via the AntreaIPAMPodIP annotation, exactly
+// one IPv4 and/or one IPv6 address may be provided. Multiple addresses of the
+// same family are rejected during annotation parsing. When an IP is specified,
+// only a single Pool of that IP family is allowed; multiple Pools of the same
+// family will also be rejected. The specified IP is allocated from that Pool,
+// and if the allocation fails for any reason (IP not in range, already
+// allocated, etc.), the error is returned immediately.
 // See https://antrea.io/docs/main/docs/antrea-ipam.md for more details.
 func (d *AntreaIPAM) Add(args *invoke.Args, k8sArgs *types.K8sArgs, networkConfig []byte) (bool, *IPAMResult, error) {
 	mine, allocators, ips, reservedOwner, err := d.owns(k8sArgs)

--- a/pkg/agent/cniserver/ipam/antrea_ipam.go
+++ b/pkg/agent/cniserver/ipam/antrea_ipam.go
@@ -167,7 +167,7 @@ func splitIPsByFamily(ips []net.IP) (v4, v6 net.IP) {
 // (e.g. API failures) cause an immediate return.
 //
 // When a Pod specifies desired IPs via the AntreaIPAMPodIP annotation, at most
-// one IPv4 address and at most one IPv6 address may be provided. Multiple
+// one IPv4 address and one IPv6 address may be provided. Multiple
 // addresses of the same family are rejected during annotation parsing. When an
 // IP is specified, only a single Pool of that IP family is allowed; multiple
 // Pools of the same family will also be rejected. The specified IP is

--- a/pkg/agent/cniserver/ipam/antrea_ipam_controller.go
+++ b/pkg/agent/cniserver/ipam/antrea_ipam_controller.go
@@ -25,6 +25,7 @@ import (
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
+	utilnet "k8s.io/utils/net"
 
 	crdv1b1 "antrea.io/antrea/v2/pkg/apis/crd/v1beta1"
 	clientsetversioned "antrea.io/antrea/v2/pkg/client/clientset/versioned"
@@ -148,14 +149,13 @@ func (c *AntreaIPAMController) getIPPoolsByPod(namespace, name string) ([]string
 	}
 
 	// Collect specified IPs from the AntreaIPAMPodIP annotation.
-	// Multiple IPs (comma-separated) may be provided, but the caller
-	// (AntreaIPAM.Add) will only consume at most one IPv4 and one IPv6
-	// address. Each IP must belong to the first Pool of the corresponding
-	// IP family listed in the AntreaIPAM annotation.
+	// At most one IPv4 and one IPv6 address may be specified; duplicates
+	// within the same family are rejected.
 	ipStrings := pod.Annotations[annotation.AntreaIPAMPodIPAnnotationKey]
 	ipStrings = strings.ReplaceAll(ipStrings, " ", "")
 	var ipErr error
 	if ipStrings != "" {
+		var hasV4, hasV6 bool
 		splittedIPStrings := strings.Split(ipStrings, annotation.AntreaIPAMAnnotationDelimiter)
 		for _, ipString := range splittedIPStrings {
 			if ipString == "" {
@@ -166,6 +166,21 @@ func (c *AntreaIPAMController) getIPPoolsByPod(namespace, name string) ([]string
 				ipErr = fmt.Errorf("invalid IP annotation %s", ipStrings)
 				ips = nil
 				break
+			}
+			if ip.To4() != nil {
+				if hasV4 {
+					ipErr = fmt.Errorf("multiple IPv4 addresses in annotation %s", ipStrings)
+					ips = nil
+					break
+				}
+				hasV4 = true
+			} else {
+				if hasV6 {
+					ipErr = fmt.Errorf("multiple IPv6 addresses in annotation %s", ipStrings)
+					ips = nil
+					break
+				}
+				hasV6 = true
 			}
 			ips = append(ips, ip)
 		}
@@ -199,6 +214,8 @@ ownerReferenceLoop:
 // getPoolAllocatorsByPod looks up IPPools from the Pod annotation and returns
 // allocators for all valid pools. This supports IPv4, IPv6, and dual-stack
 // configurations where multiple pools (one per IP family) may be specified.
+// When specific IPs are requested, it validates that only one pool of each
+// requested IP family is configured.
 func (c *AntreaIPAMController) getPoolAllocatorsByPod(namespace, podName string) (mineType, []*poolallocator.IPPoolAllocator, []net.IP, *crdv1b1.IPAddressOwner, error) {
 	poolNames, ips, reservedOwner, err := c.getIPPoolsByPod(namespace, podName)
 	if err != nil {
@@ -221,6 +238,31 @@ func (c *AntreaIPAMController) getPoolAllocatorsByPod(namespace, podName string)
 	}
 	if len(allocators) == 0 {
 		return mineTrue, nil, nil, nil, fmt.Errorf("no valid IPPool found")
+	}
+
+	if len(ips) > 0 {
+		var hasRequestedV4, hasRequestedV6 bool
+		for _, ip := range ips {
+			if ip.To4() != nil {
+				hasRequestedV4 = true
+			} else {
+				hasRequestedV6 = true
+			}
+		}
+		var v4Pools, v6Pools int
+		for _, a := range allocators {
+			if a.IPVersion == utilnet.IPv4 {
+				v4Pools++
+			} else {
+				v6Pools++
+			}
+		}
+		if hasRequestedV4 && v4Pools > 1 {
+			return mineTrue, nil, nil, nil, fmt.Errorf("multiple IPv4 IPPools configured with a requested IPv4 address; only one IPv4 IPPool is allowed when specifying an IP")
+		}
+		if hasRequestedV6 && v6Pools > 1 {
+			return mineTrue, nil, nil, nil, fmt.Errorf("multiple IPv6 IPPools configured with a requested IPv6 address; only one IPv6 IPPool is allowed when specifying an IP")
+		}
 	}
 
 	return mineTrue, allocators, ips, reservedOwner, nil

--- a/pkg/agent/cniserver/ipam/antrea_ipam_controller.go
+++ b/pkg/agent/cniserver/ipam/antrea_ipam_controller.go
@@ -163,20 +163,20 @@ func (c *AntreaIPAMController) getIPPoolsByPod(namespace, name string) ([]string
 			}
 			ip := net.ParseIP(ipString)
 			if ip == nil {
-				ipErr = fmt.Errorf("invalid IP annotation %s", ipStrings)
+				ipErr = fmt.Errorf("invalid IP %q in %s annotation %q", ipString, annotation.AntreaIPAMPodIPAnnotationKey, ipStrings)
 				ips = nil
 				break
 			}
 			if ip.To4() != nil {
 				if hasV4 {
-					ipErr = fmt.Errorf("multiple IPv4 addresses in annotation %s", ipStrings)
+					ipErr = fmt.Errorf("multiple IPv4 addresses in %s annotation %q", annotation.AntreaIPAMPodIPAnnotationKey, ipStrings)
 					ips = nil
 					break
 				}
 				hasV4 = true
 			} else {
 				if hasV6 {
-					ipErr = fmt.Errorf("multiple IPv6 addresses in annotation %s", ipStrings)
+					ipErr = fmt.Errorf("multiple IPv6 addresses in %s annotation %q", annotation.AntreaIPAMPodIPAnnotationKey, ipStrings)
 					ips = nil
 					break
 				}
@@ -237,31 +237,37 @@ func (c *AntreaIPAMController) getPoolAllocatorsByPod(namespace, podName string)
 		allocators = append(allocators, allocator)
 	}
 	if len(allocators) == 0 {
-		return mineTrue, nil, nil, nil, fmt.Errorf("no valid IPPool found")
+		return mineTrue, nil, nil, nil, fmt.Errorf("no valid IPPool found for configured pools: [%s]", strings.Join(poolNames, ", "))
 	}
 
 	if len(ips) > 0 {
 		var hasRequestedV4, hasRequestedV6 bool
+		var requestedV4IPs, requestedV6IPs []string
 		for _, ip := range ips {
 			if ip.To4() != nil {
 				hasRequestedV4 = true
+				requestedV4IPs = append(requestedV4IPs, ip.String())
 			} else {
 				hasRequestedV6 = true
+				requestedV6IPs = append(requestedV6IPs, ip.String())
 			}
 		}
 		var v4Pools, v6Pools int
+		var v4PoolNames, v6PoolNames []string
 		for _, a := range allocators {
 			if a.IPVersion == utilnet.IPv4 {
 				v4Pools++
+				v4PoolNames = append(v4PoolNames, a.Name())
 			} else {
 				v6Pools++
+				v6PoolNames = append(v6PoolNames, a.Name())
 			}
 		}
 		if hasRequestedV4 && v4Pools > 1 {
-			return mineTrue, nil, nil, nil, fmt.Errorf("multiple IPv4 IPPools configured with a requested IPv4 address; only one IPv4 IPPool is allowed when specifying an IP")
+			return mineTrue, nil, nil, nil, fmt.Errorf("multiple IPv4 IPPools configured with requested IPv4 address(es) [%s]; configured IPv4 IPPools (%d): [%s]; only one IPv4 IPPool is allowed when specifying an IP", strings.Join(requestedV4IPs, ", "), v4Pools, strings.Join(v4PoolNames, ", "))
 		}
 		if hasRequestedV6 && v6Pools > 1 {
-			return mineTrue, nil, nil, nil, fmt.Errorf("multiple IPv6 IPPools configured with a requested IPv6 address; only one IPv6 IPPool is allowed when specifying an IP")
+			return mineTrue, nil, nil, nil, fmt.Errorf("multiple IPv6 IPPools configured with requested IPv6 address(es) [%s]; configured IPv6 IPPools (%d): [%s]; only one IPv6 IPPool is allowed when specifying an IP", strings.Join(requestedV6IPs, ", "), v6Pools, strings.Join(v6PoolNames, ", "))
 		}
 	}
 

--- a/pkg/agent/cniserver/ipam/antrea_ipam_controller.go
+++ b/pkg/agent/cniserver/ipam/antrea_ipam_controller.go
@@ -241,15 +241,12 @@ func (c *AntreaIPAMController) getPoolAllocatorsByPod(namespace, podName string)
 	}
 
 	if len(ips) > 0 {
-		var hasRequestedV4, hasRequestedV6 bool
-		var requestedV4IPs, requestedV6IPs []string
+		var requestedV4, requestedV6 string
 		for _, ip := range ips {
 			if ip.To4() != nil {
-				hasRequestedV4 = true
-				requestedV4IPs = append(requestedV4IPs, ip.String())
+				requestedV4 = ip.String()
 			} else {
-				hasRequestedV6 = true
-				requestedV6IPs = append(requestedV6IPs, ip.String())
+				requestedV6 = ip.String()
 			}
 		}
 		var v4Pools, v6Pools int
@@ -263,11 +260,11 @@ func (c *AntreaIPAMController) getPoolAllocatorsByPod(namespace, podName string)
 				v6PoolNames = append(v6PoolNames, a.Name())
 			}
 		}
-		if hasRequestedV4 && v4Pools > 1 {
-			return mineTrue, nil, nil, nil, fmt.Errorf("multiple IPv4 IPPools configured with requested IPv4 address(es) [%s]; configured IPv4 IPPools (%d): [%s]; only one IPv4 IPPool is allowed when specifying an IP", strings.Join(requestedV4IPs, ", "), v4Pools, strings.Join(v4PoolNames, ", "))
+		if requestedV4 != "" && v4Pools > 1 {
+			return mineTrue, nil, nil, nil, fmt.Errorf("multiple IPv4 IPPools configured with requested IPv4 address(es) [%s]; configured IPv4 IPPools (%d): [%s]; specifying an IP restricts the selection to exactly one IPPool of that corresponding IP family", requestedV4, v4Pools, strings.Join(v4PoolNames, ", "))
 		}
-		if hasRequestedV6 && v6Pools > 1 {
-			return mineTrue, nil, nil, nil, fmt.Errorf("multiple IPv6 IPPools configured with requested IPv6 address(es) [%s]; configured IPv6 IPPools (%d): [%s]; only one IPv6 IPPool is allowed when specifying an IP", strings.Join(requestedV6IPs, ", "), v6Pools, strings.Join(v6PoolNames, ", "))
+		if requestedV6 != "" && v6Pools > 1 {
+			return mineTrue, nil, nil, nil, fmt.Errorf("multiple IPv6 IPPools configured with requested IPv6 address(es) [%s]; configured IPv6 IPPools (%d): [%s]; specifying an IP restricts the selection to exactly one IPPool of that corresponding IP family", requestedV6, v6Pools, strings.Join(v6PoolNames, ", "))
 		}
 	}
 

--- a/pkg/agent/cniserver/ipam/antrea_ipam_controller.go
+++ b/pkg/agent/cniserver/ipam/antrea_ipam_controller.go
@@ -214,8 +214,8 @@ ownerReferenceLoop:
 // getPoolAllocatorsByPod looks up IPPools from the Pod annotation and returns
 // allocators for all valid pools. This supports IPv4, IPv6, and dual-stack
 // configurations where multiple pools (one per IP family) may be specified.
-// When specific IPs are requested, it validates that only one pool of each
-// requested IP family is configured.
+// When specific IPs are requested, it validates and ensures that at most one
+// pool is configured for each requested IP family.
 func (c *AntreaIPAMController) getPoolAllocatorsByPod(namespace, podName string) (mineType, []*poolallocator.IPPoolAllocator, []net.IP, *crdv1b1.IPAddressOwner, error) {
 	poolNames, ips, reservedOwner, err := c.getIPPoolsByPod(namespace, podName)
 	if err != nil {

--- a/pkg/agent/cniserver/ipam/antrea_ipam_test.go
+++ b/pkg/agent/cniserver/ipam/antrea_ipam_test.go
@@ -1325,7 +1325,7 @@ func TestGetPoolAllocatorsByPod_RequestedIPPoolFamilyValidation(t *testing.T) {
 			podName:       "pool-val-req-v4-two-v4",
 			ipamAnnot:     "multiv4-pool-a,multiv4-pool-b",
 			podIPAnnot:    "10.10.0.10",
-			wantErrSubstr: "multiple IPv4 IPPools configured with a requested IPv4 address",
+			wantErrSubstr: "multiple IPv4 IPPools configured with requested IPv4 address(es)",
 		},
 		{
 			name:             "requested IPv4 with one IPv4 pool and two IPv6 pools",
@@ -1339,14 +1339,14 @@ func TestGetPoolAllocatorsByPod_RequestedIPPoolFamilyValidation(t *testing.T) {
 			podName:       "pool-val-dual-two-v4",
 			ipamAnnot:     "multiv4-pool-a,multiv4-pool-b",
 			podIPAnnot:    "10.10.0.10,20::5",
-			wantErrSubstr: "multiple IPv4 IPPools configured with a requested IPv4 address",
+			wantErrSubstr: "multiple IPv4 IPPools configured with requested IPv4 address(es)",
 		},
 		{
 			name:          "dual-stack requested with two IPv6 pools",
 			podName:       "pool-val-dual-two-v6",
 			ipamAnnot:     "multiv4-pool-a,ippool-family-val-ipv6-a,ippool-family-val-ipv6-b",
 			podIPAnnot:    "10.10.0.10,fd00:aa::10",
-			wantErrSubstr: "multiple IPv6 IPPools configured with a requested IPv6 address",
+			wantErrSubstr: "multiple IPv6 IPPools configured with requested IPv6 address(es)",
 		},
 	}
 

--- a/pkg/agent/cniserver/ipam/antrea_ipam_test.go
+++ b/pkg/agent/cniserver/ipam/antrea_ipam_test.go
@@ -1196,12 +1196,12 @@ func TestGetIPPoolsByPod_PodIPAnnotationPerFamilyLimit(t *testing.T) {
 		{
 			podName:       "pear-podip-two-v4",
 			podIPAnnot:    "10.2.3.199,10.2.3.198",
-			wantErrSubstr: "multiple IPv4 addresses in annotation",
+			wantErrSubstr: fmt.Sprintf("multiple IPv4 addresses in %s annotation", annotations.AntreaIPAMPodIPAnnotationKey),
 		},
 		{
 			podName:       "pear-podip-two-v6",
 			podIPAnnot:    "fd00::1,fd00::2",
-			wantErrSubstr: "multiple IPv6 addresses in annotation",
+			wantErrSubstr: fmt.Sprintf("multiple IPv6 addresses in %s annotation", annotations.AntreaIPAMPodIPAnnotationKey),
 		},
 		{
 			podName:    "pear-podip-dual-stack",

--- a/pkg/agent/cniserver/ipam/antrea_ipam_test.go
+++ b/pkg/agent/cniserver/ipam/antrea_ipam_test.go
@@ -17,6 +17,7 @@ package ipam
 import (
 	"context"
 	"fmt"
+	"net"
 	"regexp"
 	"sync"
 	"testing"
@@ -1178,4 +1179,237 @@ func TestGetIPPoolsByPod_SkipEmptyIPTokens(t *testing.T) {
 	require.Len(t, ips, 1)
 	require.NotNil(t, ips[0])
 	require.Equal(t, "10.2.3.199", ips[0].String())
+}
+
+func TestGetIPPoolsByPod_PodIPAnnotationPerFamilyLimit(t *testing.T) {
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	k8sClient, crdClient := initTestClients()
+
+	cases := []struct {
+		podName       string
+		podIPAnnot    string
+		wantErrSubstr string
+		wantIPs       []string
+	}{
+		{
+			podName:       "pear-podip-two-v4",
+			podIPAnnot:    "10.2.3.199,10.2.3.198",
+			wantErrSubstr: "multiple IPv4 addresses in annotation",
+		},
+		{
+			podName:       "pear-podip-two-v6",
+			podIPAnnot:    "fd00::1,fd00::2",
+			wantErrSubstr: "multiple IPv6 addresses in annotation",
+		},
+		{
+			podName:    "pear-podip-dual-stack",
+			podIPAnnot: "10.2.3.199,fd00::1",
+			wantIPs:    []string{"10.2.3.199", "fd00::1"},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		_, err := k8sClient.CoreV1().Pods(testPear).Create(context.Background(), &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      tc.podName,
+				Namespace: testPear,
+				Annotations: map[string]string{
+					annotations.AntreaIPAMAnnotationKey:      testPear,
+					annotations.AntreaIPAMPodIPAnnotationKey: tc.podIPAnnot,
+				},
+			},
+			Spec: corev1.PodSpec{NodeName: "fakeNode"},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+	}
+
+	informerFactory := informers.NewSharedInformerFactory(k8sClient, 0)
+	crdInformerFactory := crdinformers.NewSharedInformerFactory(crdClient, 0)
+	listOptions := func(options *metav1.ListOptions) {
+		options.FieldSelector = fields.OneTermEqualSelector("spec.nodeName", "fakeNode").String()
+	}
+	localPodInformer := coreinformers.NewFilteredPodInformer(
+		k8sClient,
+		metav1.NamespaceAll,
+		0,
+		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		listOptions,
+	)
+
+	c, err := InitializeAntreaIPAMController(
+		crdClient,
+		informerFactory.Core().V1().Namespaces(),
+		crdInformerFactory.Crd().V1beta1().IPPools(),
+		localPodInformer,
+		true,
+	)
+	require.NoError(t, err)
+
+	informerFactory.Start(stopCh)
+	go localPodInformer.Run(stopCh)
+	crdInformerFactory.Start(stopCh)
+
+	informerFactory.WaitForCacheSync(stopCh)
+	crdInformerFactory.WaitForCacheSync(stopCh)
+	require.True(t, cache.WaitForCacheSync(stopCh, localPodInformer.HasSynced), "failed to sync localPodInformer cache")
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.podName, func(t *testing.T) {
+			pools, ips, reservedOwner, ipErr := c.getIPPoolsByPod(testPear, tc.podName)
+			require.Nil(t, reservedOwner)
+			require.Equal(t, []string{testPear}, pools)
+			if tc.wantErrSubstr != "" {
+				require.Error(t, ipErr)
+				require.Contains(t, ipErr.Error(), tc.wantErrSubstr)
+				require.Nil(t, ips)
+				return
+			}
+			require.NoError(t, ipErr)
+			require.Len(t, ips, len(tc.wantIPs))
+			for i, want := range tc.wantIPs {
+				require.True(t, ips[i].Equal(net.ParseIP(want)), "got %s want %s", ips[i].String(), want)
+			}
+		})
+	}
+}
+
+func TestGetPoolAllocatorsByPod_RequestedIPPoolFamilyValidation(t *testing.T) {
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	k8sClient, crdClient := initTestClients()
+	createIPPools(crdClient)
+
+	// Extra IPv6 pools for cases that combine one IPv4 pool with multiple IPv6 pools.
+	crdClient.InitPool(&crdv1b1.IPPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "ippool-family-val-ipv6-a"},
+		Spec: crdv1b1.IPPoolSpec{
+			IPRanges: []crdv1b1.IPRange{{
+				Start: "fd00:aa::10",
+				End:   "fd00:aa::20",
+			}},
+			SubnetInfo: crdv1b1.SubnetInfo{
+				Gateway:      "fd00:aa::1",
+				PrefixLength: 64,
+			},
+		},
+	})
+	crdClient.InitPool(&crdv1b1.IPPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "ippool-family-val-ipv6-b"},
+		Spec: crdv1b1.IPPoolSpec{
+			IPRanges: []crdv1b1.IPRange{{
+				Start: "fd00:bb::10",
+				End:   "fd00:bb::20",
+			}},
+			SubnetInfo: crdv1b1.SubnetInfo{
+				Gateway:      "fd00:bb::1",
+				PrefixLength: 64,
+			},
+		},
+	})
+
+	cases := []struct {
+		name             string
+		podName          string
+		ipamAnnot        string
+		podIPAnnot       string
+		wantErrSubstr    string
+		wantAllocatorLen int
+	}{
+		{
+			name:          "requested IPv4 with two IPv4 pools",
+			podName:       "pool-val-req-v4-two-v4",
+			ipamAnnot:     "multiv4-pool-a,multiv4-pool-b",
+			podIPAnnot:    "10.10.0.10",
+			wantErrSubstr: "multiple IPv4 IPPools configured with a requested IPv4 address",
+		},
+		{
+			name:             "requested IPv4 with one IPv4 pool and two IPv6 pools",
+			podName:          "pool-val-req-v4-multi-v6",
+			ipamAnnot:        "multiv4-pool-a,ippool-family-val-ipv6-a,ippool-family-val-ipv6-b",
+			podIPAnnot:       "10.10.0.10",
+			wantAllocatorLen: 3,
+		},
+		{
+			name:          "dual-stack requested with two IPv4 pools",
+			podName:       "pool-val-dual-two-v4",
+			ipamAnnot:     "multiv4-pool-a,multiv4-pool-b",
+			podIPAnnot:    "10.10.0.10,20::5",
+			wantErrSubstr: "multiple IPv4 IPPools configured with a requested IPv4 address",
+		},
+		{
+			name:          "dual-stack requested with two IPv6 pools",
+			podName:       "pool-val-dual-two-v6",
+			ipamAnnot:     "multiv4-pool-a,ippool-family-val-ipv6-a,ippool-family-val-ipv6-b",
+			podIPAnnot:    "10.10.0.10,fd00:aa::10",
+			wantErrSubstr: "multiple IPv6 IPPools configured with a requested IPv6 address",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		_, err := k8sClient.CoreV1().Pods(testMultiV4).Create(context.Background(), &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      tc.podName,
+				Namespace: testMultiV4,
+				Annotations: map[string]string{
+					annotations.AntreaIPAMAnnotationKey:      tc.ipamAnnot,
+					annotations.AntreaIPAMPodIPAnnotationKey: tc.podIPAnnot,
+				},
+			},
+			Spec: corev1.PodSpec{NodeName: "fakeNode"},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+	}
+
+	informerFactory := informers.NewSharedInformerFactory(k8sClient, 0)
+	crdInformerFactory := crdinformers.NewSharedInformerFactory(crdClient, 0)
+	listOptions := func(options *metav1.ListOptions) {
+		options.FieldSelector = fields.OneTermEqualSelector("spec.nodeName", "fakeNode").String()
+	}
+	localPodInformer := coreinformers.NewFilteredPodInformer(
+		k8sClient,
+		metav1.NamespaceAll,
+		0,
+		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		listOptions,
+	)
+
+	c, err := InitializeAntreaIPAMController(
+		crdClient,
+		informerFactory.Core().V1().Namespaces(),
+		crdInformerFactory.Crd().V1beta1().IPPools(),
+		localPodInformer,
+		true,
+	)
+	require.NoError(t, err)
+
+	informerFactory.Start(stopCh)
+	go localPodInformer.Run(stopCh)
+	crdInformerFactory.Start(stopCh)
+
+	informerFactory.WaitForCacheSync(stopCh)
+	crdInformerFactory.WaitForCacheSync(stopCh)
+	require.True(t, cache.WaitForCacheSync(stopCh, localPodInformer.HasSynced), "failed to sync localPodInformer cache")
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			mt, allocators, _, _, err := c.getPoolAllocatorsByPod(testMultiV4, tc.podName)
+			if tc.wantErrSubstr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.wantErrSubstr)
+				require.Nil(t, allocators)
+				require.Equal(t, mineTrue, mt)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, mineTrue, mt)
+			require.Len(t, allocators, tc.wantAllocatorLen)
+		})
+	}
 }

--- a/pkg/agent/cniserver/ipam/antrea_ipam_test.go
+++ b/pkg/agent/cniserver/ipam/antrea_ipam_test.go
@@ -1185,8 +1185,6 @@ func TestGetIPPoolsByPod_PodIPAnnotationPerFamilyLimit(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	k8sClient, crdClient := initTestClients()
-
 	cases := []struct {
 		podName       string
 		podIPAnnot    string
@@ -1208,7 +1206,18 @@ func TestGetIPPoolsByPod_PodIPAnnotationPerFamilyLimit(t *testing.T) {
 			podIPAnnot: "10.2.3.199,fd00::1",
 			wantIPs:    []string{"10.2.3.199", "fd00::1"},
 		},
+		{
+			podName:       "pear-podip-v4-v6-v4",
+			podIPAnnot:    "10.2.3.199,fd00::1,10.2.3.198",
+			wantErrSubstr: fmt.Sprintf("multiple IPv4 addresses in %s annotation", annotations.AntreaIPAMPodIPAnnotationKey),
+		},
+		{
+			podName:       "pear-podip-wrong-delimiter",
+			podIPAnnot:    "10.2.3.199;fd00::1",
+			wantErrSubstr: fmt.Sprintf("invalid IP %q in %s annotation", "10.2.3.199;fd00::1", annotations.AntreaIPAMPodIPAnnotationKey),
+		},
 	}
+	k8sClient, crdClient := initTestClients()
 
 	for _, tc := range cases {
 		tc := tc
@@ -1328,7 +1337,9 @@ func TestGetPoolAllocatorsByPod_RequestedIPPoolFamilyValidation(t *testing.T) {
 			wantErrSubstr: "multiple IPv4 IPPools configured with requested IPv4 address(es)",
 		},
 		{
-			name:             "requested IPv4 with one IPv4 pool and two IPv6 pools",
+			// Only an IPv4 address is requested; no IPv6 address is requested, so
+			// having multiple IPv6 pools does not trigger the single-pool constraint.
+			name:             "requested IPv4 only, one IPv4 pool and two IPv6 pools",
 			podName:          "pool-val-req-v4-multi-v6",
 			ipamAnnot:        "multiv4-pool-a,ippool-family-val-ipv6-a,ippool-family-val-ipv6-b",
 			podIPAnnot:       "10.10.0.10",

--- a/pkg/agent/cniserver/ipam/antrea_ipam_test.go
+++ b/pkg/agent/cniserver/ipam/antrea_ipam_test.go
@@ -1294,7 +1294,7 @@ func TestGetPoolAllocatorsByPod_RequestedIPPoolFamilyValidation(t *testing.T) {
 	createIPPools(crdClient)
 
 	// Extra IPv6 pools for cases that combine one IPv4 pool with multiple IPv6 pools.
-	crdClient.InitPool(&crdv1b1.IPPool{
+	crdClient.CrdV1beta1().IPPools().Create(context.Background(), &crdv1b1.IPPool{
 		ObjectMeta: metav1.ObjectMeta{Name: "ippool-family-val-ipv6-a"},
 		Spec: crdv1b1.IPPoolSpec{
 			IPRanges: []crdv1b1.IPRange{{
@@ -1306,8 +1306,8 @@ func TestGetPoolAllocatorsByPod_RequestedIPPoolFamilyValidation(t *testing.T) {
 				PrefixLength: 64,
 			},
 		},
-	})
-	crdClient.InitPool(&crdv1b1.IPPool{
+	}, metav1.CreateOptions{})
+	crdClient.CrdV1beta1().IPPools().Create(context.Background(), &crdv1b1.IPPool{
 		ObjectMeta: metav1.ObjectMeta{Name: "ippool-family-val-ipv6-b"},
 		Spec: crdv1b1.IPPoolSpec{
 			IPRanges: []crdv1b1.IPRange{{
@@ -1319,7 +1319,7 @@ func TestGetPoolAllocatorsByPod_RequestedIPPoolFamilyValidation(t *testing.T) {
 				PrefixLength: 64,
 			},
 		},
-	})
+	}, metav1.CreateOptions{})
 
 	cases := []struct {
 		name             string

--- a/pkg/controller/ipam/antrea_ipam_controller.go
+++ b/pkg/controller/ipam/antrea_ipam_controller.go
@@ -290,20 +290,34 @@ func (c *AntreaIPAMController) cleanIPPoolForStatefulSet(namespacedName string) 
 }
 
 // Find IP Pools annotated to StatefulSet via direct annotation or Namespace annotation
-func (c *AntreaIPAMController) getIPPoolsForStatefulSet(ss *appsv1.StatefulSet) ([]string, []net.IP) {
+func (c *AntreaIPAMController) getIPPoolsForStatefulSet(ss *appsv1.StatefulSet) ([]string, []net.IP, error) {
 
-	// Inspect IP annotation for the Pods
+	// Inspect IP annotation for the Pods. Parsing matches pkg/agent/cniserver/ipam getIPPoolsByPod:
+	// empty tokens are skipped; invalid or duplicate addresses of the same IP family are rejected.
 	ipStrings := ss.Spec.Template.Annotations[annotation.AntreaIPAMPodIPAnnotationKey]
 	ipStrings = strings.ReplaceAll(ipStrings, " ", "")
 	var ips []net.IP
 	if ipStrings != "" {
+		var hasV4, hasV6 bool
 		splittedIPStrings := strings.Split(ipStrings, annotation.AntreaIPAMAnnotationDelimiter)
 		for _, ipString := range splittedIPStrings {
+			if ipString == "" {
+				continue
+			}
 			ip := net.ParseIP(ipString)
 			if ip == nil {
-				klog.ErrorS(nil, "Ignored invalid Pod IP annotation in the StatefulSet template", "annotation", ipStrings, "statefulSet", klog.KObj(ss))
-				ips = nil
-				break
+				return nil, nil, fmt.Errorf("invalid IP %q in %s annotation %q", ipString, annotation.AntreaIPAMPodIPAnnotationKey, ipStrings)
+			}
+			if ip.To4() != nil {
+				if hasV4 {
+					return nil, nil, fmt.Errorf("multiple IPv4 addresses in %s annotation %q", annotation.AntreaIPAMPodIPAnnotationKey, ipStrings)
+				}
+				hasV4 = true
+			} else {
+				if hasV6 {
+					return nil, nil, fmt.Errorf("multiple IPv6 addresses in %s annotation %q", annotation.AntreaIPAMPodIPAnnotationKey, ipStrings)
+				}
+				hasV6 = true
 			}
 			ips = append(ips, ip)
 		}
@@ -315,7 +329,7 @@ func (c *AntreaIPAMController) getIPPoolsForStatefulSet(ss *appsv1.StatefulSet) 
 	annotations, exists := ss.Spec.Template.Annotations[annotation.AntreaIPAMAnnotationKey]
 	if exists {
 		// Stateful Set Pod is annotated with dedicated IP pool
-		return strings.Split(annotations, annotation.AntreaIPAMAnnotationDelimiter), ips
+		return strings.Split(annotations, annotation.AntreaIPAMAnnotationDelimiter), ips, nil
 	}
 
 	// Inspect Namespace
@@ -323,15 +337,15 @@ func (c *AntreaIPAMController) getIPPoolsForStatefulSet(ss *appsv1.StatefulSet) 
 	if err != nil {
 		// Should never happen
 		klog.Errorf("Namespace %s not found for StatefulSet %s", ss.Namespace, ss.Name)
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	annotations, exists = namespace.Annotations[annotation.AntreaIPAMAnnotationKey]
 	if exists {
-		return strings.Split(annotations, annotation.AntreaIPAMAnnotationDelimiter), ips
+		return strings.Split(annotations, annotation.AntreaIPAMAnnotationDelimiter), ips, nil
 	}
 
-	return nil, nil
+	return nil, nil, nil
 
 }
 
@@ -341,7 +355,10 @@ func (c *AntreaIPAMController) getIPPoolsForStatefulSet(ss *appsv1.StatefulSet) 
 func (c *AntreaIPAMController) preallocateIPPoolForStatefulSet(ss *appsv1.StatefulSet) error {
 	klog.InfoS("Processing create notification", "Namespace", ss.Namespace, "StatefulSet", ss.Name)
 
-	ipPools, ips := c.getIPPoolsForStatefulSet(ss)
+	ipPools, ips, err := c.getIPPoolsForStatefulSet(ss)
+	if err != nil {
+		return err
+	}
 	var ip net.IP
 	if len(ips) > 0 {
 		ip = ips[0]

--- a/pkg/controller/ipam/antrea_ipam_controller.go
+++ b/pkg/controller/ipam/antrea_ipam_controller.go
@@ -346,7 +346,6 @@ func (c *AntreaIPAMController) getIPPoolsForStatefulSet(ss *appsv1.StatefulSet) 
 	}
 
 	return nil, nil, nil
-
 }
 
 // Look for an IP Pool associated with this StatefulSet, either a dedicated one or

--- a/pkg/controller/ipam/antrea_ipam_controller_test.go
+++ b/pkg/controller/ipam/antrea_ipam_controller_test.go
@@ -301,10 +301,11 @@ func TestReleaseStaleAddresses(t *testing.T) {
 
 func TestAntreaIPAMController_getIPPoolsForStatefulSet(t *testing.T) {
 	tests := []struct {
-		name        string
-		prepareFunc func(*appsv1.StatefulSet)
-		hasIPPool   bool
-		expectedIPs []net.IP
+		name          string
+		prepareFunc   func(*appsv1.StatefulSet)
+		hasIPPool     bool
+		expectedIPs   []net.IP
+		wantErrSubstr string
 	}{
 		{
 			name: "no annotation",
@@ -333,8 +334,14 @@ func TestAntreaIPAMController_getIPPoolsForStatefulSet(t *testing.T) {
 			prepareFunc: func(sts *appsv1.StatefulSet) {
 				sts.Spec.Template.Annotations[annotation.AntreaIPAMPodIPAnnotationKey] = "10.2.2.109, a.b.c.d"
 			},
-			hasIPPool:   true,
-			expectedIPs: nil,
+			wantErrSubstr: `invalid IP "a.b.c.d"`,
+		},
+		{
+			name: "duplicate ipv4",
+			prepareFunc: func(sts *appsv1.StatefulSet) {
+				sts.Spec.Template.Annotations[annotation.AntreaIPAMPodIPAnnotationKey] = "10.2.2.109,10.2.2.110"
+			},
+			wantErrSubstr: fmt.Sprintf("multiple IPv4 addresses in %s annotation", annotation.AntreaIPAMPodIPAnnotationKey),
 		},
 	}
 	for _, tt := range tests {
@@ -349,7 +356,15 @@ func TestAntreaIPAMController_getIPPoolsForStatefulSet(t *testing.T) {
 			controller.informerFactory.WaitForCacheSync(stopCh)
 			controller.crdInformerFactory.WaitForCacheSync(stopCh)
 
-			got, got1 := controller.getIPPoolsForStatefulSet(statefulSet)
+			got, got1, err := controller.getIPPoolsForStatefulSet(statefulSet)
+			if tt.wantErrSubstr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.wantErrSubstr)
+				require.Nil(t, got)
+				require.Nil(t, got1)
+				return
+			}
+			require.NoError(t, err)
 			var want []string
 			if tt.hasIPPool {
 				want = []string{pool.Name}

--- a/pkg/controller/ipam/antrea_ipam_controller_test.go
+++ b/pkg/controller/ipam/antrea_ipam_controller_test.go
@@ -356,12 +356,12 @@ func TestAntreaIPAMController_getIPPoolsForStatefulSet(t *testing.T) {
 			controller.informerFactory.WaitForCacheSync(stopCh)
 			controller.crdInformerFactory.WaitForCacheSync(stopCh)
 
-			got, got1, err := controller.getIPPoolsForStatefulSet(statefulSet)
+			gotIPPools, gotIPs, err := controller.getIPPoolsForStatefulSet(statefulSet)
 			if tt.wantErrSubstr != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tt.wantErrSubstr)
-				require.Nil(t, got)
-				require.Nil(t, got1)
+				require.Nil(t, gotIPPools)
+				require.Nil(t, gotIPs)
 				return
 			}
 			require.NoError(t, err)
@@ -369,8 +369,8 @@ func TestAntreaIPAMController_getIPPoolsForStatefulSet(t *testing.T) {
 			if tt.hasIPPool {
 				want = []string{pool.Name}
 			}
-			assert.Equalf(t, want, got, "Unexpected IPPool result")
-			assert.Equalf(t, tt.expectedIPs, got1, "Unexpected IP result")
+			assert.Equalf(t, want, gotIPPools, "Unexpected IPPool result")
+			assert.Equalf(t, tt.expectedIPs, gotIPs, "Unexpected IP result")
 		})
 	}
 }

--- a/pkg/controller/ipam/antrea_ipam_controller_test.go
+++ b/pkg/controller/ipam/antrea_ipam_controller_test.go
@@ -343,6 +343,13 @@ func TestAntreaIPAMController_getIPPoolsForStatefulSet(t *testing.T) {
 			},
 			wantErrSubstr: fmt.Sprintf("multiple IPv4 addresses in %s annotation", annotation.AntreaIPAMPodIPAnnotationKey),
 		},
+		{
+			name: "duplicate ipv6",
+			prepareFunc: func(sts *appsv1.StatefulSet) {
+				sts.Spec.Template.Annotations[annotation.AntreaIPAMPodIPAnnotationKey] = "fd00::1,fd00::2"
+			},
+			wantErrSubstr: fmt.Sprintf("multiple IPv6 addresses in %s annotation", annotation.AntreaIPAMPodIPAnnotationKey),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Reject duplicate IPv4 or IPv6 entries in the AntreaIPAMPodIP annotation instead of silently using the first of each family. When a Pod requests static IPs, require at most one IPPool per requested address family.

When a Pod's antrea-ips annotation contains multiple addresses of the same IP family (e.g. two IPv4 addresses), the annotation is invalid and the CNI ADD call fails with an IPAM_FAILURE error. The Pod will be stuck in ContainerCreating and kubelet will report a FailedCreatePodSandBox event with the exact error message (e.g. multiple IPv4 addresses in antrea-ips annotation "10.2.3.1,10.2.3.2"). Only one IPv4 and/or one IPv6 address may be specified per Pod.