### PR TITLE
Strengthen IPPool status retry on concurrent updates

### DIFF
--- a/pkg/ipam/poolallocator/allocator.go
+++ b/pkg/ipam/poolallocator/allocator.go
@@ -38,11 +38,14 @@ import (
 // ErrPoolExhausted is returned when an IPPool has no available IPs left.
 var ErrPoolExhausted = errors.New("pool exhausted")
 
-// ipPoolStatusRetry backs off longer than retry.DefaultRetry. Many Nodes may
-// update the same IPPool status concurrently (shared pools, multi-NIC), causing
-// frequent resourceVersion conflicts on UpdateStatus.
+// ipPoolStatusRetry backs off longer than retry.DefaultRetry (5 fixed ~10ms
+// sleeps) but avoids an overly long tail. client-go's retry.DefaultBackoff uses
+// fewer steps with a larger factor for a sub-second total; here we use a mild
+// exponential (1.5) with more attempts than DefaultRetry so many Nodes updating
+// the same IPPool status (shared pools, multi-NIC) can clear conflicts without
+// multi-second CNI stalls.
 var ipPoolStatusRetry = wait.Backoff{
-	Steps:    15,
+	Steps:    8,
 	Duration: 10 * time.Millisecond,
 	Factor:   1.5,
 	Jitter:   0.1,

--- a/pkg/ipam/poolallocator/allocator.go
+++ b/pkg/ipam/poolallocator/allocator.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"time"
 
 	"antrea.io/antrea/v2/pkg/apis/crd/v1beta1"
 	crdclientset "antrea.io/antrea/v2/pkg/client/clientset/versioned"
@@ -28,6 +29,7 @@ import (
 	iputil "antrea.io/antrea/v2/pkg/util/ip"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
@@ -35,6 +37,16 @@ import (
 
 // ErrPoolExhausted is returned when an IPPool has no available IPs left.
 var ErrPoolExhausted = errors.New("pool exhausted")
+
+// ipPoolStatusRetry backs off longer than retry.DefaultRetry. Many Nodes may
+// update the same IPPool status concurrently (shared pools, multi-NIC), causing
+// frequent resourceVersion conflicts on UpdateStatus.
+var ipPoolStatusRetry = wait.Backoff{
+	Steps:    15,
+	Duration: 10 * time.Millisecond,
+	Factor:   1.5,
+	Jitter:   0.1,
+}
 
 // IPPoolAllocator is responsible for allocating IPs from IP set defined in IPPool CRD.
 // The will update CRD usage accordingly.
@@ -289,7 +301,7 @@ func (a *IPPoolAllocator) getExistingAllocation(podOwner *v1beta1.PodOwner) (net
 func (a *IPPoolAllocator) AllocateIP(ip net.IP, state v1beta1.IPAddressPhase, owner v1beta1.IPAddressOwner) (*v1beta1.SubnetInfo, error) {
 	var subnetInfo *v1beta1.SubnetInfo
 	// Retry on CRD update conflict which is caused by multiple agents updating a pool at same time.
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	err := retry.RetryOnConflict(ipPoolStatusRetry, func() error {
 		ipPool, allocators, err := a.getPoolAndInitIPAllocators()
 		if err != nil {
 			return err
@@ -345,7 +357,7 @@ func (a *IPPoolAllocator) AllocateNext(state v1beta1.IPAddressPhase, owner v1bet
 	}
 
 	// Retry on CRD update conflict which is caused by multiple agents updating a pool at same time.
-	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	err = retry.RetryOnConflict(ipPoolStatusRetry, func() error {
 		ipPool, allocators, err := a.getPoolAndInitIPAllocators()
 		if err != nil {
 			return err
@@ -402,7 +414,7 @@ func (a *IPPoolAllocator) AllocateReservedOrNext(state v1beta1.IPAddressPhase, o
 	}
 
 	// Retry on CRD update conflict which is caused by multiple agents updating a pool at same time.
-	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	err = retry.RetryOnConflict(ipPoolStatusRetry, func() error {
 		ipPool, allocators, err := a.getPoolAndInitIPAllocators()
 		if err != nil {
 			return err
@@ -437,7 +449,7 @@ func (a *IPPoolAllocator) AllocateReservedOrNext(state v1beta1.IPAddressPhase, o
 // be allocated on the fly, and there is no guarantee for continuous IPs.
 func (a *IPPoolAllocator) AllocateStatefulSet(namespace, name string, size int, ip net.IP) error {
 	// Retry on CRD update conflict which is caused by multiple agents updating a pool at same time.
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	err := retry.RetryOnConflict(ipPoolStatusRetry, func() error {
 		ipPool, allocators, err := a.getPoolAndInitIPAllocators()
 		if err != nil {
 			return err
@@ -476,7 +488,7 @@ func (a *IPPoolAllocator) AllocateStatefulSet(namespace, name string, size int, 
 func (a *IPPoolAllocator) Release(ip net.IP) error {
 
 	// Retry on CRD update conflict which is caused by multiple agents updating a pool at same time.
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	err := retry.RetryOnConflict(ipPoolStatusRetry, func() error {
 		ipPool, allocators, err := a.getPoolAndInitIPAllocators()
 		if err != nil {
 			return err
@@ -504,7 +516,7 @@ func (a *IPPoolAllocator) Release(ip net.IP) error {
 func (a *IPPoolAllocator) ReleaseStatefulSet(namespace, name string) error {
 
 	// Retry on CRD update conflict which is caused by multiple agents updating a pool at same time.
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	err := retry.RetryOnConflict(ipPoolStatusRetry, func() error {
 		ipPool, err := a.getPool()
 
 		if err != nil {
@@ -548,7 +560,7 @@ func (a *IPPoolAllocator) ReleaseStatefulSet(namespace, name string) error {
 // change.
 func (a *IPPoolAllocator) ReleaseContainer(containerID, ifName string) error {
 	// Retry on CRD update conflict which is caused by multiple agents updating a pool at same time.
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	err := retry.RetryOnConflict(ipPoolStatusRetry, func() error {
 		ipPool, err := a.getPool()
 		if err != nil {
 			return err

--- a/pkg/ipam/poolallocator/allocator_test.go
+++ b/pkg/ipam/poolallocator/allocator_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"sync"
 	"testing"
 	"time"
 
@@ -155,6 +156,77 @@ func TestAllocateNext(t *testing.T) {
 	assert.Equal(t, 21, allocator.Total())
 
 	validateAllocationSequence(t, allocator, subnetInfo, []string{"10.2.2.100", "10.2.2.101"})
+}
+
+// TestConcurrentAllocateNextSharedIPPool simulates many Nodes (or many Pods on
+// different Nodes) calling AllocateNext on the same IPPool at once. The fake
+// client returns 409-style conflicts when ResourceVersion is stale, matching
+// concurrent UpdateStatus on a shared pool (e.g. several DaemonSets using the
+// same Antrea IPPool for secondary networks). All goroutines must succeed with
+// distinct IPs if ipPoolStatusRetry allows enough conflict retries.
+func TestConcurrentAllocateNextSharedIPPool(t *testing.T) {
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	// Six DaemonSets on a six-Node cluster all requesting the same pool is 36
+	// concurrent status writers; keep headroom in the range.
+	const concurrency = 36
+
+	poolName := uuid.New().String()
+	ipRange := crdv1b1.IPRange{
+		Start: "10.2.2.10",
+		End:   "10.2.2.99", // 90 addresses
+	}
+	subnetInfo := crdv1b1.SubnetInfo{
+		Gateway:      "10.2.2.1",
+		PrefixLength: 24,
+		VLAN:         101,
+	}
+	pool := crdv1b1.IPPool{
+		ObjectMeta: metav1.ObjectMeta{Name: poolName},
+		Spec:       crdv1b1.IPPoolSpec{IPRanges: []crdv1b1.IPRange{ipRange}, SubnetInfo: subnetInfo},
+	}
+
+	allocator := newTestIPPoolAllocator(&pool, stopCh)
+	require.NotNil(t, allocator)
+	require.GreaterOrEqual(t, allocator.Total(), concurrency)
+
+	var wg sync.WaitGroup
+	errs := make([]error, concurrency)
+	ipStrs := make([]string, concurrency)
+
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			owner := crdv1b1.IPAddressOwner{
+				Pod: &crdv1b1.PodOwner{
+					Name:        fmt.Sprintf("concurrent-pod-%d", idx),
+					Namespace:   testNamespace,
+					ContainerID: uuid.New().String(),
+					IFName:      "net1",
+				},
+			}
+			ip, _, err := allocator.AllocateNext(crdv1b1.IPAddressPhaseAllocated, owner)
+			if err != nil {
+				errs[idx] = err
+				return
+			}
+			ipStrs[idx] = ip.String()
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoError(t, err, "AllocateNext for worker %d should succeed under contention", i)
+	}
+	seen := make(map[string]struct{}, concurrency)
+	for _, s := range ipStrs {
+		_, dup := seen[s]
+		require.False(t, dup, "duplicate IP %s allocated", s)
+		seen[s] = struct{}{}
+	}
+	require.Len(t, seen, concurrency, "expected a distinct IP per concurrent allocator")
 }
 
 func TestAllocateNextMultiRange(t *testing.T) {

--- a/pkg/ipam/poolallocator/allocator_test.go
+++ b/pkg/ipam/poolallocator/allocator_test.go
@@ -212,6 +212,10 @@ func TestConcurrentAllocateNextSharedIPPool(t *testing.T) {
 				errs[idx] = err
 				return
 			}
+			if ip == nil {
+				errs[idx] = fmt.Errorf("worker %d: AllocateNext returned nil IP without error", idx)
+				return
+			}
 			ipStrs[idx] = ip.String()
 		}(i)
 	}
@@ -219,6 +223,7 @@ func TestConcurrentAllocateNextSharedIPPool(t *testing.T) {
 
 	for i, err := range errs {
 		require.NoError(t, err, "AllocateNext for worker %d should succeed under contention", i)
+		require.NotEmpty(t, ipStrs[i], "worker %d: no error but empty IP string returned", i)
 	}
 	seen := make(map[string]struct{}, concurrency)
 	for _, s := range ipStrs {


### PR DESCRIPTION
IPPool allocation updates status via UpdateStatus; many Nodes sharing the same pool (e.g. multi-NIC DaemonSets) cause frequent resourceVersion conflicts. Replace retry.DefaultRetry with a longer backoff (more steps + exponential factor) in IPPoolAllocator so conflicts are less likely to exhaust retries before succeeding.

Test details:
```
We create 6 DaemonSets using the same ippools (overlay-ippool1, overlay-ippool2, overlay-ippool3, vlan-ippool1, vlan-ippool2), but some pod fails to get IP from some ippool. 

For example, Pod multinic-ds2-n6js2 failed to get IP from vlan-ippool1, while the ippool still has free IP:

- apiVersion: crd.antrea.io/v1beta1
  kind: IPPool
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"crd.antrea.io/v1beta1","kind":"IPPool","metadata":{"annotations":{},"name":"vlan-ippool1"},"spec":{"ipRanges":[{"end":"40.70.252.11","start":"40.70.252.0"}],"subnetInfo":{"gateway":"40.70.0.1","prefixLength":16}}}
    creationTimestamp: "2026-04-11T11:48:06Z"
    generation: 1
    name: vlan-ippool1
    resourceVersion: "8649"
    uid: 8fc3bd19-7e8b-46da-9243-f0d8f910a150
  spec:
    ipRanges:
    - end: 40.70.252.11
      start: 40.70.252.0
    subnetInfo:
      gateway: 40.70.0.1
      prefixLength: 16
  status:
    ipAddresses:
    - ipAddress: 40.70.252.0
      owner:
        pod:
          containerID: d76fdb0e77752ffd477d46290afb02858cc6d12de897b956ae001c144b1cf773
          ifName: eth4
          name: multinic-ds1-jrc4w
          namespace: test-ns-1
      phase: Allocated
    - ipAddress: 40.70.252.1
      owner:
        pod:
          containerID: 7afcdd1f4962092db7bf5bf76160fc4475930284acdd82c539ae0951f904053c
          ifName: eth4
          name: multinic-ds2-v2bkh
          namespace: test-ns-1
      phase: Allocated
    - ipAddress: 40.70.252.2
      owner:
        pod:
          containerID: 8ce7283893a5e77b7bacfec272859517e4cc0ed5a2cbabd18a6e165c7c1b07d9
          ifName: eth4
          name: multinic-ds1-zhsd9
          namespace: test-ns-1
      phase: Allocated
    - ipAddress: 40.70.252.3
      owner:
        pod:
          containerID: a2f427c79a4956621f5dc25ccfd6540d6ffd60b862705e172b19ab12e83fd86b
          ifName: eth4
          name: multinic-ds6-ksxxs
          namespace: test-ns-3
      phase: Allocated
    - ipAddress: 40.70.252.4
      owner:
        pod:
          containerID: f058dd18190b64d9b64fc80169118d3e13501c7710d137f800821b0cc7ce61c2
          ifName: eth4
          name: multinic-ds4-8v7st
          namespace: test-ns-2
      phase: Allocated
    - ipAddress: 40.70.252.5
      owner:
        pod:
          containerID: ca243ef57f0017532c90d9a275bf681a1cdfe106b03e746f769844399a9b3516
          ifName: eth4
          name: multinic-ds3-8w77r
          namespace: test-ns-2
      phase: Allocated
    - ipAddress: 40.70.252.6
      owner:
        pod:
          containerID: c13bbc6a97ef3647bd97248f71083ae44ea72db21afd7ed89872e7f89d7c9550
          ifName: eth4
          name: multinic-ds6-w89pf
          namespace: test-ns-3
      phase: Allocated
    - ipAddress: 40.70.252.7
      owner:
        pod:
          containerID: c641567c6f6cfc0cf3b365669cf3f65937f7aa66bb46d9e562363d176fd4155e
          ifName: eth4
          name: multinic-ds5-cgl25
          namespace: test-ns-3
      phase: Allocated
    - ipAddress: 40.70.252.8
      owner:
        pod:
          containerID: 757705d06a3f70a410dd160d0cf978de0d463984b8cef74250d34beea290c683
          ifName: eth4
          name: multinic-ds3-hhspg
          namespace: test-ns-2
      phase: Allocated
    - ipAddress: 40.70.252.9
      owner:
        pod:
          containerID: c0b7fbf3ce8683d6c4aacd310b7609baabfbd6b416e47bf0fc387a767bdd4dd2
          ifName: eth4
          name: multinic-ds5-hght6
          namespace: test-ns-3
      phase: Allocated
    - ipAddress: 40.70.252.10
      owner:
        pod:
          containerID: 13fd73663c30e0641771acceb34a59418843e9766fb044782ae274eee405d609
          ifName: eth4
          name: multinic-ds4-9r6k4
          namespace: test-ns-2
      phase: Allocated
    usage:
      total: 12
      used: 11

[logs]

2026-04-11T11:49:02.956390562Z stderr F E0411 11:49:02.956211       1 controller.go:585] "Secondary interface configuration failed" err="secondary network IPAM failed: Operation cannot be fulfilled on ippools.crd.antrea.io \"vlan-ippool1\": the object has been modified; please apply your changes to the latest version and try again" Pod="test-ns-1/multinic-ds2-n6js2" interface="eth4" networkType="vlan"
```