### PR TITLE
[FlowAggregator] Export aggregated record when ReadyToSend

### DIFF
--- a/build/charts/flow-aggregator/README.md
+++ b/build/charts/flow-aggregator/README.md
@@ -18,7 +18,7 @@ Kubernetes: `>= 1.23.0-0`
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| activeFlowRecordTimeout | string | `"60s"` | Provide the active flow record timeout as a duration string. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". |
+| activeFlowRecordTimeout | string | `"60s"` | Provide the active flow record timeout as a duration string. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". Values under 1s are not supported; they will be rounded up to 1s. |
 | aggregatorTransportProtocol | string | `"tls"` | Provide the transport protocol for the flow aggregator collecting process, which must be one of "tls", "tcp", "udp" or "none". Note that this only applies to the IPFIX collector. The gRPC collector will always run (and always use mTLS), regardless of this configuration. When using "none", the IPFIX collector will be disabled. |
 | antreaNamespace | string | `"kube-system"` | Namespace in which Antrea was installed. |
 | apiServer.apiPort | int | `10348` | The port for the Flow Aggregator APIServer to serve on. |
@@ -67,7 +67,7 @@ Kubernetes: `>= 1.23.0-0`
 | hostAliases | list | `[]` | HostAliases to be injected into the Pod's hosts file. For example: `[{"ip": "8.8.8.8", "hostnames": ["clickhouse.example.com"]}]` |
 | hostNetwork | bool | `false` | Run the flow-aggregator Pod in the host network. With hostNetwork enabled, it is usually necessary to set dnsPolicy to ClusterFirstWithHostNet. |
 | image | object | `{"pullPolicy":"IfNotPresent","repository":"antrea/flow-aggregator","tag":""}` | Container image used by Flow Aggregator. |
-| inactiveFlowRecordTimeout | string | `"90s"` | Provide the inactive flow record timeout as a duration string. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". |
+| inactiveFlowRecordTimeout | string | `"90s"` | Provide the inactive flow record timeout as a duration string. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". Values under 1s are not supported; they will be rounded up to 1s. |
 | logVerbosity | int | `0` | Log verbosity switch for Flow Aggregator. |
 | mode | string | `"Aggregate"` | Mode in which to run the flow aggregator. Must be one of "Aggregate" or "Proxy". In Aggregate mode, flow records received from source and destination are aggregated and sent as one flow record. In Proxy mode, flow records are enhanced with some additional information, then sent directly without buffering or aggregation. |
 | nameOverride | string | `""` | Override the name of the chart. |

--- a/build/charts/flow-aggregator/conf/flow-aggregator.conf
+++ b/build/charts/flow-aggregator/conf/flow-aggregator.conf
@@ -10,6 +10,7 @@ mode: {{ .Values.mode }}
 # will be exported to the collector once the elapsed time since the last export
 # event in the flow aggregator is equal to the value of this timeout.
 # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+# Values under 1s are not supported; they will be rounded up to 1s.
 activeFlowRecordTimeout: {{ .Values.activeFlowRecordTimeout }}
 
 # Provide the inactive flow record timeout as a duration string. This determines
@@ -17,6 +18,7 @@ activeFlowRecordTimeout: {{ .Values.activeFlowRecordTimeout }}
 # collector. A flow record is considered to be inactive if no matching record
 # has been received by the flow aggregator in the specified interval.
 # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+# Values under 1s are not supported; they will be rounded up to 1s.
 inactiveFlowRecordTimeout: {{ .Values.inactiveFlowRecordTimeout }}
 
 # Provide the transport protocol for the flow aggregator collecting process, which must be one of

--- a/build/charts/flow-aggregator/values.yaml
+++ b/build/charts/flow-aggregator/values.yaml
@@ -29,9 +29,11 @@ flowAggregator:
 mode: "Aggregate"
 # -- Provide the active flow record timeout as a duration string.
 # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+# Values under 1s are not supported; they will be rounded up to 1s.
 activeFlowRecordTimeout: 60s
 # -- Provide the inactive flow record timeout as a duration string.
 # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+# Values under 1s are not supported; they will be rounded up to 1s.
 inactiveFlowRecordTimeout: 90s
 # -- Provide the transport protocol for the flow aggregator collecting process, which must be one of
 # "tls", "tcp", "udp" or "none". Note that this only applies to the IPFIX collector. The gRPC

--- a/build/yamls/flow-aggregator.yml
+++ b/build/yamls/flow-aggregator.yml
@@ -64,6 +64,7 @@ data:
     # will be exported to the collector once the elapsed time since the last export
     # event in the flow aggregator is equal to the value of this timeout.
     # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+    # Values under 1s are not supported; they will be rounded up to 1s.
     activeFlowRecordTimeout: 60s
 
     # Provide the inactive flow record timeout as a duration string. This determines
@@ -71,6 +72,7 @@ data:
     # collector. A flow record is considered to be inactive if no matching record
     # has been received by the flow aggregator in the specified interval.
     # Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+    # Values under 1s are not supported; they will be rounded up to 1s.
     inactiveFlowRecordTimeout: 90s
 
     # Provide the transport protocol for the flow aggregator collecting process, which must be one of
@@ -492,7 +494,7 @@ spec:
       annotations:
         # Automatically restart Pod if the ConfigMap changes
         # See https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: 7f2d0d8a536a220895730b91887df92fb154d1294d945c6ff4b7e54d296bd58c
+        checksum/config: b754d61f2a19c5b221897f568384a711a96fbd96e50fff9770821c8ace477ef8
       labels:
         app: flow-aggregator
     spec:

--- a/pkg/config/flowaggregator/config.go
+++ b/pkg/config/flowaggregator/config.go
@@ -43,14 +43,14 @@ type FlowAggregatorConfig struct {
 	// will be exported to the collector once the elapsed time since the last export
 	// event in the flow aggregator is equal to the value of this timeout.
 	// Defaults to "60s". Valid time units are "ns", "us" (or "µs"), "ms", "s",
-	// "m", "h".
+	// "m", "h". Values under 1s are not supported; they will be rounded up to 1s.
 	ActiveFlowRecordTimeout string `yaml:"activeFlowRecordTimeout,omitempty"`
 	// Provide the inactive flow record timeout as a duration string. This determines
 	// how often the flow aggregator exports the inactive flow records to the flow
 	// collector. A flow record is considered to be inactive if no matching record
 	// has been received by the flow aggregator in the specified interval.
 	// Defaults to "90s". Valid time units are "ns", "us" (or "µs"), "ms", "s",
-	// "m", "h".
+	// "m", "h". Values under 1s are not supported; they will be rounded up to 1s.
 	InactiveFlowRecordTimeout string `yaml:"inactiveFlowRecordTimeout,omitempty"`
 	// Transport protocol over which the aggregator collects IPFIX records from all Agents.
 	// Defaults to "tls"

--- a/pkg/flowaggregator/flowaggregator.go
+++ b/pkg/flowaggregator/flowaggregator.go
@@ -516,8 +516,12 @@ func (fa *flowAggregator) flowExportLoopProxy(stopCh <-chan struct{}) {
 }
 
 func (fa *flowAggregator) flowExportLoopAggregate(stopCh <-chan struct{}) {
-	expireTimer := time.NewTimer(fa.activeFlowRecordTimeout)
-	defer expireTimer.Stop()
+	// Every 1s, we check for expired records and we export all of them. 1s is small enough to have good accuracy,
+	// and long enough that we don't call the function too often. In the future, we can support handling batches of
+	// expired records, which we can add to the ring buffer in a single API call.
+	// Note that ActiveFlowRecordTimeout / InactiveFlowRecordTimeout values under 1s are not reasonable and not supported.
+	expiredFlowRecordsTicker := time.NewTicker(1 * time.Second)
+	defer expiredFlowRecordsTicker.Stop()
 	logTicker := time.NewTicker(fa.logTickerDuration)
 	defer logTicker.Stop()
 
@@ -526,13 +530,10 @@ func (fa *flowAggregator) flowExportLoopAggregate(stopCh <-chan struct{}) {
 		select {
 		case <-stopCh:
 			return
-		case <-expireTimer.C:
+		case <-expiredFlowRecordsTicker.C:
 			if err := fa.aggregationProcess.ForAllExpiredFlowRecordsDo(fa.sendAggregatedRecord); err != nil {
 				klog.ErrorS(err, "Error when sending expired flow records")
-				expireTimer.Reset(fa.activeFlowRecordTimeout)
-				continue
 			}
-			expireTimer.Reset(fa.aggregationProcess.GetExpiryFromExpirePriorityQueue())
 		case <-logTicker.C:
 			klog.V(4).InfoS("Total number of records received", "count", fa.getNumRecordsReceived())
 			klog.V(4).InfoS("Total number of records exported by each active exporter", "count", fa.numRecordsExported.Load())

--- a/pkg/flowaggregator/flowaggregator_test.go
+++ b/pkg/flowaggregator/flowaggregator_test.go
@@ -669,6 +669,7 @@ func TestFlowAggregator_Run(t *testing.T) {
 	mockIPFIXExporter, mockClickHouseExporter, mockS3Exporter, mockLogExporter := mockExporters(t, ctrl, &clusterUUID, &clusterID)
 	mockCollector := collectortesting.NewMockInterface(ctrl)
 	mockAggregationProcess := intermediatetesting.NewMockAggregationProcess(ctrl)
+	mockAggregationProcess.EXPECT().ForAllExpiredFlowRecordsDo(gomock.Any()).AnyTimes()
 
 	// create dummy watcher: we will not add any files or directory to it.
 	configWatcher, err := fsnotify.NewWatcher()
@@ -699,21 +700,19 @@ func TestFlowAggregator_Run(t *testing.T) {
 	require.NoError(t, err)
 
 	fa := &flowAggregator{
-		clusterUUID:    clusterUUID,
-		clusterID:      clusterID,
-		aggregatorMode: flowaggregatorconfig.AggregatorModeAggregate,
-		// must be large enough to avoid a call to ForAllExpiredFlowRecordsDo
-		activeFlowRecordTimeout: 1 * time.Hour,
-		logTickerDuration:       1 * time.Hour,
-		grpcCollector:           mockCollector,
-		aggregationProcess:      mockAggregationProcess,
-		configWatcher:           configWatcher,
-		updateCh:                updateCh,
-		podStore:                mockPodStore,
-		nodeStore:               mockNodeStore,
-		serviceStore:            mockServiceStore,
-		recordBuffer:            buf,
-		configData:              initialConfigData,
+		clusterUUID:        clusterUUID,
+		clusterID:          clusterID,
+		aggregatorMode:     flowaggregatorconfig.AggregatorModeAggregate,
+		logTickerDuration:  1 * time.Hour,
+		grpcCollector:      mockCollector,
+		aggregationProcess: mockAggregationProcess,
+		configWatcher:      configWatcher,
+		updateCh:           updateCh,
+		podStore:           mockPodStore,
+		nodeStore:          mockNodeStore,
+		serviceStore:       mockServiceStore,
+		recordBuffer:       buf,
+		configData:         initialConfigData,
 	}
 
 	mockAggregationProcess.EXPECT().Start()

--- a/pkg/flowaggregator/intermediate/aggregate.go
+++ b/pkg/flowaggregator/intermediate/aggregate.go
@@ -28,10 +28,7 @@ import (
 	flowpb "antrea.io/antrea/v2/pkg/apis/flow/v1alpha1"
 )
 
-var (
-	MaxRetries    = 2
-	MinExpiryTime = 100 * time.Millisecond
-)
+var MaxRetries = 2
 
 type aggregationProcess struct {
 	// flowKeyRecordMap maps each connection (5-tuple) with its records
@@ -153,27 +150,6 @@ func (a *aggregationProcess) deleteFlowKeyFromMapWithoutLock(flowKey FlowKey) er
 	}
 	delete(a.flowKeyRecordMap, flowKey)
 	return nil
-}
-
-// GetExpiryFromExpirePriorityQueue returns the earliest timestamp (active expiry
-// or inactive expiry) from expire priority queue.
-func (a *aggregationProcess) GetExpiryFromExpirePriorityQueue() time.Duration {
-	a.mutex.Lock()
-	defer a.mutex.Unlock()
-
-	currTime := a.clock.Now()
-	if a.expirePriorityQueue.Len() > 0 {
-		// Get the minExpireTime of the top item in expirePriorityQueue.
-		expiryDuration := MinExpiryTime + a.expirePriorityQueue.minExpireTime(0).Sub(currTime)
-		if expiryDuration < 0 {
-			return MinExpiryTime
-		}
-		return expiryDuration
-	}
-	if a.activeExpiryTimeout < a.inactiveExpiryTimeout {
-		return a.activeExpiryTimeout
-	}
-	return a.inactiveExpiryTimeout
 }
 
 // GetRecords returns map format flow records given a flow key.
@@ -301,15 +277,20 @@ func (a *aggregationProcess) ForAllExpiredFlowRecordsDo(callback FlowKeyRecordMa
 		if err != nil {
 			return fmt.Errorf("callback execution failed for popped flow record with key: %v, record: %v, error: %v", pqItem.flowKey, pqItem.flowRecord, err)
 		}
+
+		// We need to use !expireTime.After(currTime) and not expireTime.Before(currTime) to account for the
+		// equality case (expireTime == currTime) and match the if statement at the beginning of the for loop
+		// (which determines whether the item is expired or not).
+
 		// Delete the flow record if it is expired because of inactive expiry timeout.
-		if pqItem.inactiveExpireTime.Before(currTime) {
+		if !pqItem.inactiveExpireTime.After(currTime) {
 			if err = a.deleteFlowKeyFromMapWithoutLock(*pqItem.flowKey); err != nil {
 				return fmt.Errorf("error while deleting flow record after inactive expiry: %v", err)
 			}
 			continue
 		}
 		// Reset the expireTime for the popped item and push it to the priority queue.
-		if pqItem.activeExpireTime.Before(currTime) {
+		if !pqItem.activeExpireTime.After(currTime) {
 			// Reset the active expire timeout and push the record into priority
 			// queue.
 			pqItem.activeExpireTime = currTime.Add(a.activeExpiryTimeout)
@@ -355,10 +336,11 @@ func (a *aggregationProcess) addOrUpdateRecordInMap(flowKey *FlowKey, record *fl
 	currTime := a.clock.Now()
 	aggregationRecord, exist := a.flowKeyRecordMap[*flowKey]
 	if exist {
+		readyToSend := aggregationRecord.ReadyToSend
 		if correlationRequired {
 			// Do correlation of records if record belongs to inter-node flow and
 			// records from source and destination node are not received.
-			if !aggregationRecord.ReadyToSend && !areRecordsFromSameNode(record, aggregationRecord.Record) {
+			if !readyToSend && !areRecordsFromSameNode(record, aggregationRecord.Record) {
 				a.correlateRecords(record, aggregationRecord.Record)
 				aggregationRecord.ReadyToSend = true
 				aggregationRecord.areCorrelatedFieldsFilled = true
@@ -375,10 +357,14 @@ func (a *aggregationProcess) addOrUpdateRecordInMap(flowKey *FlowKey, record *fl
 			// flow record with existing record by updating the stats and flow timestamps.
 			a.aggregateRecords(record, aggregationRecord.Record, true, true)
 		}
-		// Reset the inactive expiry time in the queue item with updated aggregate
-		// record.
-		a.expirePriorityQueue.Update(aggregationRecord.PriorityQueueItem,
-			flowKey, aggregationRecord, aggregationRecord.PriorityQueueItem.activeExpireTime, currTime.Add(a.inactiveExpiryTimeout))
+		// Reset the inactive expiry time in the queue item with updated aggregate record.
+		// If this is the first time we have a "complete" record (ReadyToSend becomes true),
+		// export it right away by setting activeExpireTime to now.
+		activeExpireTime := aggregationRecord.PriorityQueueItem.activeExpireTime
+		if !readyToSend && aggregationRecord.ReadyToSend {
+			activeExpireTime = currTime
+		}
+		a.expirePriorityQueue.Update(aggregationRecord.PriorityQueueItem, flowKey, aggregationRecord, activeExpireTime, currTime.Add(a.inactiveExpiryTimeout))
 	} else {
 		record.Aggregation = &flowpb.Aggregation{}
 		// Add all the new stat fields and initialize them.
@@ -420,7 +406,12 @@ func (a *aggregationProcess) addOrUpdateRecordInMap(flowKey *FlowKey, record *fl
 		aggregationRecord.PriorityQueueItem = pqItem
 
 		pqItem.flowRecord = aggregationRecord
-		pqItem.activeExpireTime = currTime.Add(a.activeExpiryTimeout)
+		// If no correlation is required and the record is ReadyToSend, export it right away.
+		if aggregationRecord.ReadyToSend {
+			pqItem.activeExpireTime = currTime
+		} else {
+			pqItem.activeExpireTime = currTime.Add(a.activeExpiryTimeout)
+		}
 		pqItem.inactiveExpireTime = currTime.Add(a.inactiveExpiryTimeout)
 		heap.Push(&a.expirePriorityQueue, pqItem)
 	}

--- a/pkg/flowaggregator/intermediate/aggregate_test.go
+++ b/pkg/flowaggregator/intermediate/aggregate_test.go
@@ -31,7 +31,6 @@ import (
 
 func init() {
 	MaxRetries = 1
-	MinExpiryTime = 0
 }
 
 const (
@@ -431,51 +430,6 @@ func TestDeleteFlowKeyFromMapWithLock(t *testing.T) {
 	assert.Empty(t, aggregationProcess.flowKeyRecordMap)
 }
 
-func TestGetExpiryFromExpirePriorityQueue(t *testing.T) {
-	recordChan := make(chan *flowpb.Flow)
-	input := AggregationInput{
-		RecordChan:            recordChan,
-		WorkerNum:             2,
-		ActiveExpiryTimeout:   testActiveExpiry,
-		InactiveExpiryTimeout: testInactiveExpiry,
-	}
-	ap, _ := InitAggregationProcess(input)
-	// Add records with IPv4 fields.
-	recordIPv4Src := createFlowRecordForSrc(false, flowpb.FlowType_FLOW_TYPE_INTER_NODE, false, flowpb.NetworkPolicyRuleAction_NETWORK_POLICY_RULE_ACTION_NO_ACTION)
-	recordIPv4Dst := createFlowRecordForDst(false, flowpb.FlowType_FLOW_TYPE_INTER_NODE, false, flowpb.NetworkPolicyRuleAction_NETWORK_POLICY_RULE_ACTION_NO_ACTION)
-	// Add records with IPv6 fields.
-	recordIPv6Src := createFlowRecordForSrc(true, flowpb.FlowType_FLOW_TYPE_INTER_NODE, false, flowpb.NetworkPolicyRuleAction_NETWORK_POLICY_RULE_ACTION_NO_ACTION)
-	recordIPv6Dst := createFlowRecordForDst(true, flowpb.FlowType_FLOW_TYPE_INTER_NODE, false, flowpb.NetworkPolicyRuleAction_NETWORK_POLICY_RULE_ACTION_NO_ACTION)
-	testCases := []struct {
-		name    string
-		records []*flowpb.Flow
-	}{
-		{
-			"empty queue",
-			nil,
-		},
-		{
-			"One aggregation record",
-			[]*flowpb.Flow{recordIPv4Src, recordIPv4Dst},
-		},
-		{
-			"Two aggregation records",
-			[]*flowpb.Flow{recordIPv4Src, recordIPv4Dst, recordIPv6Src, recordIPv6Dst},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			for _, record := range tc.records {
-				flowKey, isIPv4 := getFlowKeyFromRecord(record)
-				ap.addOrUpdateRecordInMap(flowKey, record, isIPv4)
-			}
-			expiryTime := ap.GetExpiryFromExpirePriorityQueue()
-			assert.LessOrEqualf(t, expiryTime.Nanoseconds(), testActiveExpiry.Nanoseconds(), "incorrect expiry time")
-		})
-	}
-}
-
 func assertElementMap(t *testing.T, record map[string]interface{}, ipv6 bool) {
 	if ipv6 {
 		assert.Equal(t, net.ParseIP("2001:0:3238:dfe1:63::fefb"), record["sourceIPv6Address"])
@@ -683,13 +637,19 @@ func TestForAllExpiredFlowRecordsDo(t *testing.T) {
 }
 
 func runCorrelationAndCheckResult(t *testing.T, ap *aggregationProcess, clock *clocktesting.FakeClock, record1, record2 *flowpb.Flow, isIPv6 bool, flowType flowpb.FlowType, needsCorrelation bool) {
+	const recordDelay = 10 * time.Millisecond
 	flowKey1, isIPv4 := getFlowKeyFromRecord(record1)
 	ap.addOrUpdateRecordInMap(flowKey1, record1, isIPv4)
 	item := ap.expirePriorityQueue.Peek()
-	oldActiveExpiryTime := item.activeExpireTime
-	oldInactiveExpiryTime := item.inactiveExpireTime
-	if flowType != flowpb.FlowType_FLOW_TYPE_INTRA_NODE && needsCorrelation {
-		clock.Step(10 * time.Millisecond)
+	if !needsCorrelation {
+		// no correlation needed, immediate export requested
+		assert.Equal(t, clock.Now(), item.activeExpireTime)
+	} else {
+		assert.Equal(t, clock.Now().Add(ap.activeExpiryTimeout), item.activeExpireTime)
+	}
+	assert.Equal(t, clock.Now().Add(ap.inactiveExpiryTimeout), item.inactiveExpireTime)
+	if needsCorrelation {
+		clock.Step(recordDelay)
 		flowKey2, isIPv4 := getFlowKeyFromRecord(record2)
 		assert.Equalf(t, *flowKey1, *flowKey2, "flow keys should be equal.")
 		ap.addOrUpdateRecordInMap(flowKey2, record2, isIPv4)
@@ -699,9 +659,9 @@ func runCorrelationAndCheckResult(t *testing.T, ap *aggregationProcess, clock *c
 	aggRecord := ap.flowKeyRecordMap[*flowKey1]
 	item = ap.expirePriorityQueue.Peek()
 	assert.Equal(t, *aggRecord, *item.flowRecord)
-	assert.Equal(t, oldActiveExpiryTime, item.activeExpireTime)
-	if flowType != flowpb.FlowType_FLOW_TYPE_INTRA_NODE && needsCorrelation {
-		assert.Equal(t, oldInactiveExpiryTime.Add(10*time.Millisecond), item.inactiveExpireTime)
+	assert.Equal(t, clock.Now().Add(ap.inactiveExpiryTimeout), item.inactiveExpireTime)
+	if needsCorrelation {
+		assert.Equal(t, clock.Now(), item.activeExpireTime)
 		assert.True(t, ap.AreCorrelatedFieldsFilled(*aggRecord))
 	}
 	if flowType == flowpb.FlowType_FLOW_TYPE_INTRA_NODE || needsCorrelation {
@@ -726,22 +686,27 @@ func runCorrelationAndCheckResult(t *testing.T, ap *aggregationProcess, clock *c
 }
 
 func runAggregationAndCheckResult(t *testing.T, ap *aggregationProcess, clock *clocktesting.FakeClock, srcRecord, dstRecord, srcRecordLatest, dstRecordLatest *flowpb.Flow, isIntraNode bool) {
+	const recordDelay = 10 * time.Millisecond
 	flowKey, isIPv4 := getFlowKeyFromRecord(srcRecord)
+	var lastUpdatedTime time.Time
 	addOrUpdateRecordInMap := func(record *flowpb.Flow) {
 		ap.addOrUpdateRecordInMap(flowKey, record, isIPv4)
-		clock.Step(10 * time.Millisecond)
+		lastUpdatedTime = clock.Now()
 	}
 
 	addOrUpdateRecordInMap(srcRecord)
 	item := ap.expirePriorityQueue.Peek()
-	oldActiveExpiryTime := item.activeExpireTime
-	oldInactiveExpiryTime := item.inactiveExpireTime
+	assert.Equal(t, clock.Now().Add(ap.inactiveExpiryTimeout), item.inactiveExpireTime)
 
 	if !isIntraNode {
+		clock.Step(recordDelay)
 		addOrUpdateRecordInMap(dstRecord)
 	}
+	readyToSendTime := clock.Now()
+	clock.Step(recordDelay)
 	addOrUpdateRecordInMap(srcRecordLatest)
 	if !isIntraNode {
+		clock.Step(recordDelay)
 		addOrUpdateRecordInMap(dstRecordLatest)
 	}
 	assert.Equal(t, int64(1), ap.GetNumFlows())
@@ -749,10 +714,8 @@ func runAggregationAndCheckResult(t *testing.T, ap *aggregationProcess, clock *c
 	aggRecord := ap.flowKeyRecordMap[*flowKey]
 	item = ap.expirePriorityQueue.Peek()
 	assert.Equal(t, *aggRecord, *item.flowRecord)
-	assert.Equal(t, oldActiveExpiryTime, item.activeExpireTime)
-	if !isIntraNode {
-		assert.NotEqual(t, oldInactiveExpiryTime, item.inactiveExpireTime)
-	}
+	assert.Equal(t, readyToSendTime, item.activeExpireTime)
+	assert.Equal(t, lastUpdatedTime.Add(ap.inactiveExpiryTimeout), item.inactiveExpireTime)
 	assert.Equal(t, "pod1", aggRecord.Record.K8S.SourcePodName)
 	assert.Equal(t, "pod2", aggRecord.Record.K8S.DestinationPodName)
 	assert.Equal(t, netip.MustParseAddr("192.168.0.1").AsSlice(), aggRecord.Record.K8S.DestinationClusterIp)

--- a/pkg/flowaggregator/intermediate/interface.go
+++ b/pkg/flowaggregator/intermediate/interface.go
@@ -15,8 +15,6 @@
 package intermediate
 
 import (
-	"time"
-
 	flowpb "antrea.io/antrea/v2/pkg/apis/flow/v1alpha1"
 )
 
@@ -24,7 +22,6 @@ type AggregationProcess interface {
 	Start()
 	Stop()
 	ForAllExpiredFlowRecordsDo(callback FlowKeyRecordMapCallBack) error
-	GetExpiryFromExpirePriorityQueue() time.Duration
 	GetRecords(flowKey *FlowKey) []map[string]interface{}
 	ResetStatAndThroughputElementsInRecord(record *flowpb.Flow) error
 	SetCorrelatedFieldsFilled(record *AggregationFlowRecord, isFilled bool)

--- a/pkg/flowaggregator/intermediate/testing/mock_intermediate.go
+++ b/pkg/flowaggregator/intermediate/testing/mock_intermediate.go
@@ -26,7 +26,6 @@ package testing
 
 import (
 	reflect "reflect"
-	time "time"
 
 	v1alpha1 "antrea.io/antrea/v2/pkg/apis/flow/v1alpha1"
 	intermediate "antrea.io/antrea/v2/pkg/flowaggregator/intermediate"
@@ -97,20 +96,6 @@ func (m *MockAggregationProcess) ForAllExpiredFlowRecordsDo(callback intermediat
 func (mr *MockAggregationProcessMockRecorder) ForAllExpiredFlowRecordsDo(callback any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForAllExpiredFlowRecordsDo", reflect.TypeOf((*MockAggregationProcess)(nil).ForAllExpiredFlowRecordsDo), callback)
-}
-
-// GetExpiryFromExpirePriorityQueue mocks base method.
-func (m *MockAggregationProcess) GetExpiryFromExpirePriorityQueue() time.Duration {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetExpiryFromExpirePriorityQueue")
-	ret0, _ := ret[0].(time.Duration)
-	return ret0
-}
-
-// GetExpiryFromExpirePriorityQueue indicates an expected call of GetExpiryFromExpirePriorityQueue.
-func (mr *MockAggregationProcessMockRecorder) GetExpiryFromExpirePriorityQueue() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetExpiryFromExpirePriorityQueue", reflect.TypeOf((*MockAggregationProcess)(nil).GetExpiryFromExpirePriorityQueue))
 }
 
 // GetNumFlows mocks base method.

--- a/pkg/flowaggregator/options/options.go
+++ b/pkg/flowaggregator/options/options.go
@@ -80,9 +80,17 @@ func LoadConfig(configBytes []byte) (*Options, error) {
 	if err != nil {
 		return nil, err
 	}
+	if opt.ActiveFlowRecordTimeout < time.Second {
+		klog.InfoS("ActiveFlowRecordTimeout is too small, rounding up to 1s", "configured", opt.ActiveFlowRecordTimeout)
+		opt.ActiveFlowRecordTimeout = time.Second
+	}
 	opt.InactiveFlowRecordTimeout, err = time.ParseDuration(opt.Config.InactiveFlowRecordTimeout)
 	if err != nil {
 		return nil, err
+	}
+	if opt.InactiveFlowRecordTimeout < time.Second {
+		klog.InfoS("InactiveFlowRecordTimeout is too small, rounding up to 1s", "configured", opt.InactiveFlowRecordTimeout)
+		opt.InactiveFlowRecordTimeout = time.Second
 	}
 	opt.AggregatorTransportProtocol, err = flowexport.ParseTransportProtocol(opt.Config.AggregatorTransportProtocol)
 	if err != nil {

--- a/test/e2e/flowaggregator_test.go
+++ b/test/e2e/flowaggregator_test.go
@@ -151,12 +151,12 @@ const (
 )
 
 var (
-	// Single iperf run results in two connections with separate ports (control connection and actual data connection).
-	// As 2s is the export active timeout of flow exporter and iperf traffic runs for 12s, we expect totally 12 records
-	// exporting to the flow aggregator at time 2s, 4s, 6s, 8s, 10s, and 12s after iperf traffic begins.
-	// Since flow aggregator will aggregate records based on 5-tuple connection key and active timeout is 3.5 seconds,
-	// we expect 3 records at time 5.5s, 9s, and 12.5s after iperf traffic begins.
-	expectedNumDataRecords                      = 3
+	// For a given connection, we expect the first record around 2s (export active timeout of FlowExporter) when
+	// the record becomes "ready to send". We should then have additional records at 5.5s, 9s and 12.5s, based on
+	// the 3.5s active timeout for the FlowAggregator and the iperf duration (12s). Some variability is expected
+	// because of batching and buffering in the FlowAggregator, but it is safe to assume that we need to receive at
+	// least 4 records.
+	expectedNumDataRecords                      = 4
 	podAIPs, podBIPs, podCIPs, podDIPs, podEIPs *PodIPs
 	serviceNames                                = []string{"perftest-a", "perftest-b", "perftest-c", "perftest-d", "perftest-e"}
 	podNames                                    = serviceNames
@@ -164,9 +164,11 @@ var (
 	// It will be initialized the first time setupFlowAggregatorTest is called.
 	antreaClusterUUID = ""
 
-	// In the ToExternalFlows test, flow record will arrive 5.5s (exporterActiveFlowExportTimeout+aggregatorActiveFlowRecordTimeout) after executing wget command
-	// We set the timeout to 9s (5.5s plus one more aggregatorActiveFlowRecordTimeout) to make the ToExternalFlows test more stable
-	getCollectorOutputDefaultTimeout = exporterActiveFlowExportTimeout + 2*aggregatorActiveFlowRecordTimeout
+	// Makes sure we have enough time to receive all expected records.
+	// After the connection closes, need to account for: the poll interval, the export active timeout of
+	// FlowExporter, the export active timeout of the FlowAggregator. The extra 2s are to account for processing
+	// time and variability in the FlowAggregator.
+	getCollectorOutputDefaultTimeout = exporterFlowPollInterval + exporterActiveFlowExportTimeout + aggregatorActiveFlowRecordTimeout + 2*time.Second
 )
 
 type testFlow struct {
@@ -1049,25 +1051,32 @@ func checkRecordsForFlowsCollector(t *testing.T, data *TestData, srcIP, dstIP, s
 		}
 
 		// Skip the bandwidth check for the iperf control flow records which have 0 throughput.
-		if !strings.Contains(record, "throughput: 0") {
-			flowStartTime := int64(getUint64FieldFromRecord(t, record, "flowStartSeconds"))
-			exportTime := int64(getUint64FieldFromRecord(t, record, "flowEndSeconds"))
-			flowEndReason := int64(getUint64FieldFromRecord(t, record, "flowEndReason"))
-			var recBandwidth float64
-			// flowEndReason == 3 means the end of flow detected
-			if flowEndReason == 3 {
-				// Check average bandwidth on the last record.
-				octetTotalCount := getUint64FieldFromRecord(t, record, "octetTotalCount")
-				recBandwidth = float64(octetTotalCount) * 8 / float64(iperfTimeSec) / 1000000
-			} else {
-				// Check bandwidth with the field "throughput" except for the last record,
-				// as their throughput may be significantly lower than the average Iperf throughput.
-				throughput := getUint64FieldFromRecord(t, record, "throughput")
-				recBandwidth = float64(throughput) / 1000000
-			}
-			t.Logf("Throughput check on record with flowEndSeconds-flowStartSeconds: %v, Iperf throughput: %.2f Mbits/s, IPFIX record throughput: %.2f Mbits/s", exportTime-flowStartTime, bandwidthInMbps, recBandwidth)
-			assert.InDeltaf(recBandwidth, bandwidthInMbps, bandwidthInMbps*0.15, "Difference between Iperf bandwidth and IPFIX record bandwidth should be lower than 15%%, record: %s", record)
+		if strings.Contains(record, "throughput: 0") {
+			continue
 		}
+		flowStartTime := int64(getUint64FieldFromRecord(t, record, "flowStartSeconds"))
+		exportTime := int64(getUint64FieldFromRecord(t, record, "flowEndSeconds"))
+		// Because the timestamps in the flow records have a granularity of a second, throughput calculation by
+		// the FlowAggregator will be inaccurate at the beginning of the flow. So we exclude records coming in
+		// before 5s (the first record comes at 2s),
+		if exportTime-flowStartTime <= 5 {
+			continue
+		}
+		flowEndReason := int64(getUint64FieldFromRecord(t, record, "flowEndReason"))
+		var recBandwidth float64
+		// flowEndReason == 3 means the end of flow detected
+		if flowEndReason == 3 {
+			// Check average bandwidth on the last record.
+			octetTotalCount := getUint64FieldFromRecord(t, record, "octetTotalCount")
+			recBandwidth = float64(octetTotalCount) * 8 / float64(iperfTimeSec) / 1000000
+		} else {
+			// Check bandwidth with the field "throughput" except for the last record,
+			// as their throughput may be significantly lower than the average Iperf throughput.
+			throughput := getUint64FieldFromRecord(t, record, "throughput")
+			recBandwidth = float64(throughput) / 1000000
+		}
+		t.Logf("Throughput check on record with flowEndSeconds-flowStartSeconds: %v, Iperf throughput: %.2f Mbits/s, IPFIX record throughput: %.2f Mbits/s", exportTime-flowStartTime, bandwidthInMbps, recBandwidth)
+		assert.InDeltaf(recBandwidth, bandwidthInMbps, bandwidthInMbps*0.15, "Difference between Iperf bandwidth and IPFIX record bandwidth should be lower than 15%%, record: %s", record)
 	}
 }
 
@@ -1118,24 +1127,30 @@ func checkRecordsForFlowsClickHouse(t *testing.T, data *TestData, srcIP, dstIP, 
 		}
 
 		// Skip the bandwidth check for the iperf control flow records which have 0 throughput.
-		if record.Throughput > 0 {
-			flowStartTime := record.FlowStartSeconds.Unix()
-			exportTime := record.FlowEndSeconds.Unix()
-			var recBandwidth float64
-			// flowEndReason == 3 means the end of flow detected
-			if record.FlowEndReason == 3 {
-				octetTotalCount := record.OctetTotalCount
-				recBandwidth = float64(octetTotalCount) * 8 / float64(exportTime-flowStartTime) / 1000000
-			} else {
-				// Check bandwidth with the field "throughput" except for the last record,
-				// as their throughput may be significantly lower than the average Iperf throughput.
-				throughput := record.Throughput
-				recBandwidth = float64(throughput) / 1000000
-			}
-			t.Logf("Throughput check on record with flowEndSeconds-flowStartSeconds: %v, Iperf throughput: %.2f Mbits/s, ClickHouse record throughput: %.2f Mbits/s", exportTime-flowStartTime, bandwidthInMbps, recBandwidth)
-			assert.InDeltaf(recBandwidth, bandwidthInMbps, bandwidthInMbps*0.15, "Difference between Iperf bandwidth and ClickHouse record bandwidth should be lower than 15%%, record: %v", record)
+		if record.Throughput == 0 {
+			continue
 		}
-
+		flowStartTime := record.FlowStartSeconds.Unix()
+		exportTime := record.FlowEndSeconds.Unix()
+		// Because the timestamps in the flow records have a granularity of a second, throughput calculation by
+		// the FlowAggregator will be inaccurate at the beginning of the flow. So we exclude records coming in
+		// before 5s (the first record comes at 2s),
+		if exportTime-flowStartTime <= 5 {
+			continue
+		}
+		var recBandwidth float64
+		// flowEndReason == 3 means the end of flow detected
+		if record.FlowEndReason == 3 {
+			octetTotalCount := record.OctetTotalCount
+			recBandwidth = float64(octetTotalCount) * 8 / float64(exportTime-flowStartTime) / 1000000
+		} else {
+			// Check bandwidth with the field "throughput" except for the last record,
+			// as their throughput may be significantly lower than the average Iperf throughput.
+			throughput := record.Throughput
+			recBandwidth = float64(throughput) / 1000000
+		}
+		t.Logf("Throughput check on record with flowEndSeconds-flowStartSeconds: %v, Iperf throughput: %.2f Mbits/s, ClickHouse record throughput: %.2f Mbits/s", exportTime-flowStartTime, bandwidthInMbps, recBandwidth)
+		assert.InDeltaf(recBandwidth, bandwidthInMbps, bandwidthInMbps*0.15, "Difference between Iperf bandwidth and ClickHouse record bandwidth should be lower than 15%%, record: %v", record)
 	}
 	// Checking only data records as data records cannot be decoded without template record.
 	assert.GreaterOrEqualf(t, len(clickHouseRecords), expectedNumDataRecords, "ClickHouse should receive expected number of flow records. Considered records: %s", clickHouseRecords)


### PR DESCRIPTION
With this change, we export ("expire") an aggregated flow record as soon as it is ReadyToSend. For inter-Node flows, this means as soon as it has been correlated.
This is a quality of life improvement (initial records can now be received by collectors much sooner) at the cost of some extra records being generated by the FlowAggregator.
As part of this change, we simplify how expired records are consumed from the priority queue. We use a ticker to write all expired records to the ring buffer every second, instead of checking the next "expiry time". One reason is that with this change, the next "expiry time" can actually change when items are updated in the priority queue. However, I think this simplification is a net benefit.