### PR TITLE
Fix potential command injection in trivy_scan workflow

### DIFF
--- a/.github/workflows/trivy_scan.yml
+++ b/.github/workflows/trivy_scan.yml
@@ -26,8 +26,9 @@ jobs:
       id: find-antrea-greatest-version
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        ANTREA_VERSION: ${{ inputs.antrea-version }}
       run: |
-        VERSION=${{ inputs.antrea-version }}
+        VERSION=$ANTREA_VERSION
         if [ -z "$VERSION" ]; then
             VERSION=$(gh api /repos/antrea-io/antrea/releases/latest --jq '.tag_name')
         fi


### PR DESCRIPTION
### Description

This PR mitigates a potential command injection vulnerability in the `trivy_scan.yml` workflow when triggered via `workflow_dispatch`. 

While the practical attack surface is limited (as only users with write access can trigger this), directly interpolating untrusted input via `${{ inputs.antrea-version }}` inside a `run:` block is generally unsafe. 

This fix follows [GitHub's recommended security hardening practices](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections) by moving the input into an intermediate environment variable (`env:`) before evaluating it in the shell script. This acts as a defense-in-depth and code hygiene improvement.

Closes #7988 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

This is a trivial syntax change to the GitHub Actions YAML, moving an input to an environment variable. No logic changes were introduced.
