### PR TITLE
Build flow-aggregator image for multiple architectures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,6 +194,47 @@ jobs:
           ${{ matrix.registry }}/${{ matrix.namespace }}/antrea-agent-ubuntu-arm:"${DOCKER_TAG}" \
           ${{ matrix.registry }}/${{ matrix.namespace }}/antrea-agent-ubuntu-amd64:"${DOCKER_TAG}"
 
+  push-manifest-flow-aggregator:
+    needs: [check-env, build-flow-aggregator]
+    if: ${{ needs.check-env.outputs.push_needed == 'true' }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        include:
+        - registry: docker.io
+          namespace: antrea
+        - registry: ghcr.io
+          namespace: antrea-io
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_TAG: latest
+    steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
+      with:
+        driver: ${{ needs.check-env.outputs.docker_driver }}
+    - name: Login to Docker Hub
+      if: ${{ needs.check-env.outputs.push_needed == 'true' && matrix.registry == 'docker.io' }}
+      uses: docker/login-action@v4
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+    - name: Login to Github Container Registry
+      if: ${{ needs.check-env.outputs.push_needed == 'true' && matrix.registry == 'ghcr.io' }}
+      uses: docker/login-action@v4
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Create and push manifest for flow-aggregator image
+      run: |
+        docker buildx imagetools create --tag ${{ matrix.registry }}/${{ matrix.namespace }}/flow-aggregator:"${DOCKER_TAG}" \
+          ${{ matrix.registry }}/${{ matrix.namespace }}/flow-aggregator-arm64:"${DOCKER_TAG}" \
+          ${{ matrix.registry }}/${{ matrix.namespace }}/flow-aggregator-arm:"${DOCKER_TAG}" \
+          ${{ matrix.registry }}/${{ matrix.namespace }}/flow-aggregator-amd64:"${DOCKER_TAG}"
+
   build-ubi:
     needs: check-env
     if: ${{ needs.check-env.outputs.has_changes == 'yes' || github.event_name == 'push' }}
@@ -296,7 +337,19 @@ jobs:
     permissions:
       contents: read
       packages: write
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+        - platform: linux/amd64
+          runner: ubuntu-latest
+          suffix: amd64
+        - platform: linux/arm64
+          runner: oracle-vm-2cpu-8gb-arm64
+          suffix: arm64
+        - platform: linux/arm/v7
+          runner: oracle-vm-2cpu-8gb-arm64
+          suffix: arm
+    runs-on: ${{ matrix.runner }}
     env:
       DOCKER_TAG: latest
     steps:
@@ -308,7 +361,7 @@ jobs:
       with:
         driver: ${{ needs.check-env.outputs.docker_driver }}
     - name: Build flow-aggregator Docker image
-      run: make flow-aggregator-image
+      run: make flow-aggregator-image DOCKER_TARGETPLATFORM=${{ matrix.platform }}
     - name: Check flow-aggregator Docker image
       run: docker run antrea/flow-aggregator --version
     - name: Login to Docker Hub
@@ -335,8 +388,8 @@ jobs:
           t=($target)
           registry="${t[0]}"
           namespace="${t[1]}"
-          docker tag antrea/flow-aggregator:"${DOCKER_TAG}" ${registry}/${namespace}/flow-aggregator:"${DOCKER_TAG}"
-          docker push ${registry}/${namespace}/flow-aggregator:"${DOCKER_TAG}"
+          docker tag antrea/flow-aggregator:"${DOCKER_TAG}" ${registry}/${namespace}/flow-aggregator-${{ matrix.suffix }}:"${DOCKER_TAG}"
+          docker push ${registry}/${namespace}/flow-aggregator-${{ matrix.suffix }}:"${DOCKER_TAG}"
         done
 
   build-antrea-migrator:

--- a/.github/workflows/build_tag.yml
+++ b/.github/workflows/build_tag.yml
@@ -141,6 +141,44 @@ jobs:
           ${{ matrix.registry }}/${{ matrix.namespace }}/antrea-agent-ubuntu-arm:"${DOCKER_TAG}" \
           ${{ matrix.registry }}/${{ matrix.namespace }}/antrea-agent-ubuntu-amd64:"${DOCKER_TAG}"
 
+  push-manifest-flow-aggregator:
+    needs: [get-version, build-flow-aggregator]
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        include:
+        - registry: docker.io
+          namespace: antrea
+        - registry: ghcr.io
+          namespace: antrea-io
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_TAG: ${{ needs.get-version.outputs.version }}
+    steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
+    - name: Login to Docker Hub
+      if: ${{ matrix.registry == 'docker.io' }}
+      uses: docker/login-action@v4
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+    - name: Login to Github Container Registry
+      if: ${{ matrix.registry == 'ghcr.io' }}
+      uses: docker/login-action@v4
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Create and push manifest for flow-aggregator image
+      run: |
+        docker buildx imagetools create --tag ${{ matrix.registry }}/${{ matrix.namespace }}/flow-aggregator:"${DOCKER_TAG}" \
+          ${{ matrix.registry }}/${{ matrix.namespace }}/flow-aggregator-arm64:"${DOCKER_TAG}" \
+          ${{ matrix.registry }}/${{ matrix.namespace }}/flow-aggregator-arm:"${DOCKER_TAG}" \
+          ${{ matrix.registry }}/${{ matrix.namespace }}/flow-aggregator-amd64:"${DOCKER_TAG}"
+
   build-ubi:
     runs-on: [ubuntu-latest]
     needs: get-version
@@ -205,7 +243,19 @@ jobs:
     permissions:
       contents: read
       packages: write
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+        - platform: linux/amd64
+          runner: ubuntu-latest
+          suffix: amd64
+        - platform: linux/arm64
+          runner: oracle-vm-2cpu-8gb-arm64
+          suffix: arm64
+        - platform: linux/arm/v7
+          runner: oracle-vm-2cpu-8gb-arm64
+          suffix: arm
+    runs-on: ${{ matrix.runner }}
     env:
       DOCKER_TAG: ${{ needs.get-version.outputs.version }}
     steps:
@@ -220,7 +270,7 @@ jobs:
     - name: Build flow-aggregator Docker image
       env:
         VERSION: ${{ needs.get-version.outputs.version }}
-      run: make flow-aggregator-image
+      run: make flow-aggregator-image DOCKER_TARGETPLATFORM=${{ matrix.platform }}
     - name: Login to Docker Hub
       uses: docker/login-action@v4
       with:
@@ -242,6 +292,6 @@ jobs:
           t=($target)
           registry="${t[0]}"
           namespace="${t[1]}"
-          docker tag antrea/flow-aggregator:"${DOCKER_TAG}" ${registry}/${namespace}/flow-aggregator:"${DOCKER_TAG}"
-          docker push ${registry}/${namespace}/flow-aggregator:"${DOCKER_TAG}"
+          docker tag antrea/flow-aggregator:"${DOCKER_TAG}" ${registry}/${namespace}/flow-aggregator-${{ matrix.suffix }}:"${DOCKER_TAG}"
+          docker push ${registry}/${namespace}/flow-aggregator-${{ matrix.suffix }}:"${DOCKER_TAG}"
         done

--- a/build/charts/flow-aggregator/templates/deployment.yaml
+++ b/build/charts/flow-aggregator/templates/deployment.yaml
@@ -125,7 +125,6 @@ spec:
         {{- end }}
       nodeSelector:
         kubernetes.io/os: linux
-        kubernetes.io/arch: amd64
       priorityClassName: {{ .Values.priorityClassName }}
       serviceAccountName: {{ include "flow-aggregator.fullname" . }}
       volumes:

--- a/build/yamls/flow-aggregator.yml
+++ b/build/yamls/flow-aggregator.yml
@@ -569,7 +569,6 @@ spec:
             memory: 256Mi
       nodeSelector:
         kubernetes.io/os: linux
-        kubernetes.io/arch: amd64
       priorityClassName: system-cluster-critical
       serviceAccountName: flow-aggregator
       volumes:


### PR DESCRIPTION
Build and publish the flow-aggregator image for linux/amd64, linux/arm64, and linux/arm/v7, matching what is already done for antrea-agent-ubuntu and antrea-controller-ubuntu.

The build jobs now run on architecture-native runners in a matrix. Per-platform images are pushed with a suffix (e.g. flow-aggregator-amd64), and a new push-manifest job assembles them into a multi-arch manifest under the canonical flow-aggregator tag.

As a result, the kubernetes.io/arch: amd64 node selector is no longer needed and is removed from the Helm chart template and the generated manifest.