### PR TITLE
traceflow: clear DataplaneTag when agent sets Failed status

### DIFF
--- a/pkg/agent/controller/traceflow/traceflow_controller.go
+++ b/pkg/agent/controller/traceflow/traceflow_controller.go
@@ -590,10 +590,15 @@ func (c *Controller) preparePacket(tf *crdv1beta1.Traceflow, intf *interfacestor
 func (c *Controller) errorTraceflowCRD(tf *crdv1beta1.Traceflow, reason string) (*crdv1beta1.Traceflow, error) {
 	tf.Status.Phase = crdv1beta1.Failed
 
-	type Traceflow struct {
-		Status crdv1beta1.TraceflowStatus `json:"status,omitempty"`
+	// Use a raw map so that dataplaneTag: 0 is explicitly included in the patch.
+	// A typed struct with omitempty would silently drop the zero value.
+	patchData := map[string]interface{}{
+		"status": map[string]interface{}{
+			"phase":        crdv1beta1.Failed,
+			"reason":       reason,
+			"dataplaneTag": 0,
+		},
 	}
-	patchData := Traceflow{Status: crdv1beta1.TraceflowStatus{Phase: tf.Status.Phase, Reason: reason, DataplaneTag: 0}}
 	payloads, _ := json.Marshal(patchData)
 	return c.crdClient.CrdV1beta1().Traceflows().Patch(context.TODO(), tf.Name, types.MergePatchType, payloads, metav1.PatchOptions{}, "status")
 }

--- a/pkg/agent/controller/traceflow/traceflow_controller.go
+++ b/pkg/agent/controller/traceflow/traceflow_controller.go
@@ -593,7 +593,7 @@ func (c *Controller) errorTraceflowCRD(tf *crdv1beta1.Traceflow, reason string) 
 	type Traceflow struct {
 		Status crdv1beta1.TraceflowStatus `json:"status,omitempty"`
 	}
-	patchData := Traceflow{Status: crdv1beta1.TraceflowStatus{Phase: tf.Status.Phase, Reason: reason}}
+	patchData := Traceflow{Status: crdv1beta1.TraceflowStatus{Phase: tf.Status.Phase, Reason: reason, DataplaneTag: 0}}
 	payloads, _ := json.Marshal(patchData)
 	return c.crdClient.CrdV1beta1().Traceflows().Patch(context.TODO(), tf.Name, types.MergePatchType, payloads, metav1.PatchOptions{}, "status")
 }

--- a/pkg/agent/controller/traceflow/traceflow_controller_test.go
+++ b/pkg/agent/controller/traceflow/traceflow_controller_test.go
@@ -16,6 +16,7 @@ package traceflow
 
 import (
 	"bytes"
+	"context"
 	"net"
 	"net/netip"
 	"os"
@@ -619,20 +620,23 @@ func TestErrTraceflowCRD(t *testing.T) {
 		},
 		Status: crdv1beta1.TraceflowStatus{
 			Phase:        crdv1beta1.Running,
-			DataplaneTag: 1,
+			DataplaneTag: 7,
 		},
 	}
-	expectedTf := tf
-	reason := "failed"
-	expectedTf.Status.Phase = crdv1beta1.Failed
-	expectedTf.Status.Reason = reason
-	expectedTf.Status.DataplaneTag = 0
+	reason := "node error"
 
 	tfc := newFakeTraceflowController(t, []runtime.Object{tf}, nil, nil)
 
-	gotTf, err := tfc.errorTraceflowCRD(tf, reason)
+	_, err := tfc.errorTraceflowCRD(tf, reason)
 	require.NoError(t, err)
-	assert.Equal(t, expectedTf, gotTf)
+
+	// Fetch the patched object directly from the fake client to avoid
+	// comparing against a stale in-memory pointer.
+	gotTf, err := tfc.crdClient.CrdV1beta1().Traceflows().Get(context.TODO(), tf.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, crdv1beta1.Failed, gotTf.Status.Phase)
+	assert.Equal(t, reason, gotTf.Status.Reason)
+	assert.Equal(t, int8(0), gotTf.Status.DataplaneTag)
 }
 
 func TestStartTraceflow(t *testing.T) {

--- a/pkg/agent/controller/traceflow/traceflow_controller_test.go
+++ b/pkg/agent/controller/traceflow/traceflow_controller_test.go
@@ -626,6 +626,7 @@ func TestErrTraceflowCRD(t *testing.T) {
 	reason := "failed"
 	expectedTf.Status.Phase = crdv1beta1.Failed
 	expectedTf.Status.Reason = reason
+	expectedTf.Status.DataplaneTag = 0
 
 	tfc := newFakeTraceflowController(t, []runtime.Object{tf}, nil, nil)
 

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -3099,7 +3099,7 @@ func (data *TestData) gracefulExitFlowAggregators(covDir string) error {
 // collectCovFiles collects coverage files from the Pod and saves them to the coverage directory
 func (data *TestData) collectCovFiles(podName string, containerName string, nsName string, covDir string) error {
 	// copy antctl coverage files from Pod to the coverage directory
-	cmds := []string{"bash", "-c", "find /tmp/coverage  -mindepth 1"}
+	cmds := []string{"bash", "-c", "[ -d /tmp/coverage ] && find /tmp/coverage -mindepth 1 || true"}
 	stdout, stderr, err := data.RunCommandFromPod(nsName, podName, containerName, cmds)
 	if err != nil {
 		return fmt.Errorf("error when running this find command '%s' on Pod '%s', stderr: <%v>, err: <%v>", cmds, podName, stderr, err)
@@ -3109,6 +3109,10 @@ func (data *TestData) collectCovFiles(podName string, containerName string, nsNa
 		return fmt.Errorf("error creating coverage directory for Pod %s: %v", podName, err)
 	}
 	stdout = strings.TrimSpace(stdout)
+	if stdout == "" {
+		// No coverage files found, nothing to collect.
+		return nil
+	}
 	files := strings.Split(stdout, "\n")
 	for _, file := range files {
 		if len(file) == 0 {


### PR DESCRIPTION
Fixes #8004

Ensure consistent handling of DataplaneTag when a Traceflow transitions to Failed.

The controller clears DataplaneTag for terminal states, but the agent did not when setting Failed.

This change aligns agent behavior with the controller by clearing DataplaneTag in errorTraceflowCRD

The previous implementation used a typed struct for the patch, which caused DataplaneTag=0 to be omitted due to omitempty, preventing the field from being cleared.