### PR TITLE
Enforce ResourceImport ClusterIDs in member importer reconciliation

### DIFF
--- a/multicluster/controllers/multicluster/member/resourceimport_controller.go
+++ b/multicluster/controllers/multicluster/member/resourceimport_controller.go
@@ -119,9 +119,9 @@ func (r *ResourceImportReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			return ctrl.Result{}, err
 		}
 		if !exist {
-			klog.V(2).InfoS("Skip reconciling ResourceImport since it is not targeted to local cluster",
+			klog.InfoS("ResourceImport is no longer targeted to local cluster and no cached installed state was found, performing best-effort cleanup",
 				"resourceimport", req.NamespacedName, "clusterID", r.localClusterID)
-			return ctrl.Result{}, nil
+			return r.cleanupInstalledResourceImport(ctx, req, &resImp)
 		}
 		cachedResImp := resImpObj.(multiclusterv1alpha1.ResourceImport)
 		klog.InfoS("ResourceImport is no longer targeted to local cluster, cleaning up installed resources",

--- a/multicluster/controllers/multicluster/member/resourceimport_controller.go
+++ b/multicluster/controllers/multicluster/member/resourceimport_controller.go
@@ -94,7 +94,6 @@ func newResourceImportReconciler(localClusterClient client.Client,
 // ResourceImport object.
 func (r *ResourceImportReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	klog.V(2).InfoS("Reconciling ResourceImport", "resourceimport", req.NamespacedName)
-	// TODO: Must check whether this ResourceImport must be reconciled by this member cluster. Check `spec.clusters` field.
 	var resImp multiclusterv1alpha1.ResourceImport
 	err := r.remoteCommonArea.Get(ctx, req.NamespacedName, &resImp)
 	var isDeleted bool
@@ -113,6 +112,21 @@ func (r *ResourceImportReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 				return ctrl.Result{}, nil
 			}
 		}
+	}
+	if !isDeleted && !r.isResourceImportTargeted(&resImp) {
+		resImpObj, exist, err := r.installedResImports.GetByKey(req.NamespacedName.String())
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if !exist {
+			klog.V(2).InfoS("Skip reconciling ResourceImport since it is not targeted to local cluster",
+				"resourceimport", req.NamespacedName, "clusterID", r.localClusterID)
+			return ctrl.Result{}, nil
+		}
+		cachedResImp := resImpObj.(multiclusterv1alpha1.ResourceImport)
+		klog.InfoS("ResourceImport is no longer targeted to local cluster, cleaning up installed resources",
+			"resourceimport", req.NamespacedName, "clusterID", r.localClusterID)
+		return r.cleanupInstalledResourceImport(ctx, req, &cachedResImp)
 	}
 	switch resImp.Spec.Kind {
 	case constants.ServiceImportKind:
@@ -137,6 +151,35 @@ func (r *ResourceImportReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return r.handleResImpUpdateForClusterInfo(ctx, req, &resImp)
 	}
 	return ctrl.Result{}, nil
+}
+
+func (r *ResourceImportReconciler) isResourceImportTargeted(resImp *multiclusterv1alpha1.ResourceImport) bool {
+	if len(resImp.Spec.ClusterIDs) == 0 {
+		return true
+	}
+	for _, clusterID := range resImp.Spec.ClusterIDs {
+		if clusterID == r.localClusterID {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *ResourceImportReconciler) cleanupInstalledResourceImport(ctx context.Context, req ctrl.Request,
+	resImp *multiclusterv1alpha1.ResourceImport) (ctrl.Result, error) {
+	switch resImp.Spec.Kind {
+	case constants.ServiceImportKind:
+		return r.handleResImpDeleteForService(ctx, resImp)
+	case constants.EndpointsKind:
+		return r.handleResImpDeleteForEndpoints(ctx, resImp)
+	case constants.AntreaClusterNetworkPolicyKind:
+		return r.handleResImpDeleteForClusterNetworkPolicy(ctx, resImp)
+	case constants.ClusterInfoKind:
+		return r.handleResImpDeleteForClusterInfo(ctx, req, resImp)
+	default:
+		r.installedResImports.Delete(*resImp)
+		return ctrl.Result{}, nil
+	}
 }
 
 func (r *ResourceImportReconciler) handleResImpUpdateForService(ctx context.Context, resImp *multiclusterv1alpha1.ResourceImport) (ctrl.Result, error) {

--- a/multicluster/controllers/multicluster/member/resourceimport_controller_test.go
+++ b/multicluster/controllers/multicluster/member/resourceimport_controller_test.go
@@ -496,6 +496,77 @@ func TestResourceImportReconciler_handleUpdateEvent(t *testing.T) {
 	}
 }
 
+func TestResourceImportReconciler_skipImportForNonTargetCluster(t *testing.T) {
+	nonTargetSvcResImport := svcResImport.DeepCopy()
+	nonTargetSvcResImport.Spec.ClusterIDs = []string{"cluster-b"}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(common.TestScheme).Build()
+	fakeRemoteClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithObjects(nonTargetSvcResImport).Build()
+	remoteCluster := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", localClusterID, "default", nil)
+
+	r := newResourceImportReconciler(fakeClient, localClusterID, "default", remoteCluster)
+	_, err := r.Reconcile(ctx, svcImportReq)
+	require.NoError(t, err)
+
+	svc := &corev1.Service{}
+	err = fakeClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "antrea-mc-nginx"}, svc)
+	require.True(t, apierrors.IsNotFound(err), "Service should not be imported for non-target cluster")
+
+	svcImp := &k8smcsapi.ServiceImport{}
+	err = fakeClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "nginx"}, svcImp)
+	require.True(t, apierrors.IsNotFound(err), "ServiceImport should not be imported for non-target cluster")
+
+	_, exists, err := r.installedResImports.GetByKey(svcImportReq.NamespacedName.String())
+	require.NoError(t, err)
+	require.False(t, exists, "ResourceImport should not be added to installed cache")
+}
+
+func TestResourceImportReconciler_cleanupUsesCachedInstalledObject(t *testing.T) {
+	installedSvcResImport := svcResImport.DeepCopy()
+	installedSvcResImport.Spec.ClusterIDs = []string{localClusterID}
+
+	nonTargetUpdatedResImport := svcResImport.DeepCopy()
+	nonTargetUpdatedResImport.Spec.ClusterIDs = []string{"cluster-b"}
+	nonTargetUpdatedResImport.Spec.Kind = "Endpoints"
+	nonTargetUpdatedResImport.Spec.Endpoints = &mcv1alpha1.EndpointsImport{Subsets: epSubset}
+	nonTargetUpdatedResImport.Spec.ServiceImport = nil
+
+	existingImportedSvc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "antrea-mc-nginx",
+		},
+	}
+	existingImportedSvcImp := &k8smcsapi.ServiceImport{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "nginx",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithObjects(existingImportedSvc, existingImportedSvcImp).Build()
+	fakeRemoteClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithObjects(nonTargetUpdatedResImport).Build()
+	remoteCluster := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", localClusterID, "default", nil)
+
+	r := newResourceImportReconciler(fakeClient, localClusterID, "default", remoteCluster)
+	r.installedResImports.Add(*installedSvcResImport)
+
+	_, err := r.Reconcile(ctx, svcImportReq)
+	require.NoError(t, err)
+
+	svc := &corev1.Service{}
+	err = fakeClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "antrea-mc-nginx"}, svc)
+	require.True(t, apierrors.IsNotFound(err), "Service should be cleaned up when ResourceImport no longer targets local cluster")
+
+	svcImp := &k8smcsapi.ServiceImport{}
+	err = fakeClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "nginx"}, svcImp)
+	require.True(t, apierrors.IsNotFound(err), "ServiceImport should be cleaned up when ResourceImport no longer targets local cluster")
+
+	_, exists, err := r.installedResImports.GetByKey(svcImportReq.NamespacedName.String())
+	require.NoError(t, err)
+	require.False(t, exists, "ResourceImport should be removed from installed cache after cleanup")
+}
+
 // fakeManager is a fake K8s controller manager which simulates a burst of ResourceImport events
 // from the leader's apiServer and triggers the LabelIdentityResourceImportReconciler's main
 // Reconcile loop. Once the fakeManager is run, all ResourceImports in the queue will be added

--- a/multicluster/controllers/multicluster/member/resourceimport_controller_test.go
+++ b/multicluster/controllers/multicluster/member/resourceimport_controller_test.go
@@ -567,6 +567,41 @@ func TestResourceImportReconciler_cleanupUsesCachedInstalledObject(t *testing.T)
 	require.False(t, exists, "ResourceImport should be removed from installed cache after cleanup")
 }
 
+func TestResourceImportReconciler_cleanupWithoutCachedInstalledObject(t *testing.T) {
+	nonTargetSvcResImport := svcResImport.DeepCopy()
+	nonTargetSvcResImport.Spec.ClusterIDs = []string{"cluster-b"}
+
+	existingImportedSvc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "antrea-mc-nginx",
+		},
+	}
+	existingImportedSvcImp := &k8smcsapi.ServiceImport{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "nginx",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithObjects(existingImportedSvc, existingImportedSvcImp).Build()
+	fakeRemoteClient := fake.NewClientBuilder().WithScheme(common.TestScheme).WithObjects(nonTargetSvcResImport).Build()
+	remoteCluster := commonarea.NewFakeRemoteCommonArea(fakeRemoteClient, "leader-cluster", localClusterID, "default", nil)
+
+	r := newResourceImportReconciler(fakeClient, localClusterID, "default", remoteCluster)
+
+	_, err := r.Reconcile(ctx, svcImportReq)
+	require.NoError(t, err)
+
+	svc := &corev1.Service{}
+	err = fakeClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "antrea-mc-nginx"}, svc)
+	require.True(t, apierrors.IsNotFound(err), "Service should be cleaned up for non-target cluster even when installed cache is empty")
+
+	svcImp := &k8smcsapi.ServiceImport{}
+	err = fakeClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "nginx"}, svcImp)
+	require.True(t, apierrors.IsNotFound(err), "ServiceImport should be cleaned up for non-target cluster even when installed cache is empty")
+}
+
 // fakeManager is a fake K8s controller manager which simulates a burst of ResourceImport events
 // from the leader's apiServer and triggers the LabelIdentityResourceImportReconciler's main
 // Reconcile loop. Once the fakeManager is run, all ResourceImports in the queue will be added


### PR DESCRIPTION
fixes #8009 

This PR fixes a gap where member-side ResourceImport reconciliation did not enforce Spec.ClusterIDs.

What changed:

Added target-cluster filtering so a ResourceImport is reconciled only when the local cluster is included in Spec.ClusterIDs (or when the field is empty).
Added cleanup logic for include -> exclude transitions using the cached installed ResourceImport object, so previously imported resources are removed correctly.
Added unit tests to verify:
-> non-target clusters skip import
-> include -> exclude triggers cleanup via cached installed state

Why:
-> Aligns behavior with API contract for ResourceImport target scoping.
-> Prevents unintended import of Services, ServiceImports, Endpoints, and policies in non-target member clusters.

<details>
<summary>view test logs</summary>

```txt
=== RUN   TestResourceImportReconciler_handleCopySpanACNPCreateEvent    
=== RUN   TestResourceImportReconciler_handleCopySpanACNPCreateEvent/import_ACNP_of_pre-defined_tiers
I0423 18:07:19.481415   32516 acnp_resourceimport_controller.go:54] "Updating ACNP corresponding to ResourceImport" acnp="/antrea-mc-acnp-for-isolation" resourceimport="default/default-acnp-for-isolation"
=== RUN   TestResourceImportReconciler_handleCopySpanACNPCreateEvent/import_ACNP_of_non-existing_tier
I0423 18:07:19.483199   32516 acnp_resourceimport_controller.go:54] "Updating ACNP corresponding to ResourceImport" acnp="/antrea-mc-acnp-no-matching-tier" resourceimport="default/default-acnp-no-matching-tier"
=== RUN   TestResourceImportReconciler_handleCopySpanACNPCreateEvent/import_ACNP_of_empty_spec
--- PASS: TestResourceImportReconciler_handleCopySpanACNPCreateEvent (0.01s)
    --- PASS: TestResourceImportReconciler_handleCopySpanACNPCreateEvent/import_ACNP_of_pre-defined_tiers (0.00s)
    --- PASS: TestResourceImportReconciler_handleCopySpanACNPCreateEvent/import_ACNP_of_non-existing_tier (0.00s)
    --- PASS: TestResourceImportReconciler_handleCopySpanACNPCreateEvent/import_ACNP_of_empty_spec (0.00s)
=== RUN   TestResourceImportReconciler_handleCopySpanACNPDeleteEvent
I0423 18:07:19.484337   32516 acnp_resourceimport_controller.go:115] "Deleting ACNP corresponding to ResourceImport" acnp="antrea-mc-acnp-for-isolation" resourceimport="default/default-acnp-for-isolation"
--- PASS: TestResourceImportReconciler_handleCopySpanACNPDeleteEvent (0.00s)
=== RUN   TestResourceImportReconciler_handleCopySpanACNPUpdateEvent
=== RUN   TestResourceImportReconciler_handleCopySpanACNPUpdateEvent/update_acnp_spec
I0423 18:07:19.484963   32516 acnp_resourceimport_controller.go:54] "Updating ACNP corresponding to ResourceImport" acnp="/antrea-mc-acnp-for-isolation" resourceimport="default/default-acnp-for-isolation"
=== RUN   TestResourceImportReconciler_handleCopySpanACNPUpdateEvent/imported_acnp_missing_tier_update_to_valid_tier
I0423 18:07:19.484963   32516 acnp_resourceimport_controller.go:54] "Updating ACNP corresponding to ResourceImport" acnp="/antrea-mc-acnp-no-matching-tier" resourceimport="default/default-acnp-no-matching-tier"
=== RUN   TestResourceImportReconciler_handleCopySpanACNPUpdateEvent/valid_imported_acnp_update_to_missing_tier
I0423 18:07:19.484963   32516 acnp_resourceimport_controller.go:54] "Updating ACNP corresponding to ResourceImport" acnp="/antrea-mc-acnp-for-isolation" resourceimport="default/default-valid-updated-to-no-valid"
=== RUN   TestResourceImportReconciler_handleCopySpanACNPUpdateEvent/name_conflict_with_existing_acnp
E0423 18:07:19.485532   32516 resourceimport_controller.go:111] "No cached data for ResourceImport" resourceimport="default/default-name-conflict"
--- PASS: TestResourceImportReconciler_handleCopySpanACNPUpdateEvent (0.00s)
    --- PASS: TestResourceImportReconciler_handleCopySpanACNPUpdateEvent/update_acnp_spec (0.00s)
    --- PASS: TestResourceImportReconciler_handleCopySpanACNPUpdateEvent/imported_acnp_missing_tier_update_to_valid_tier (0.00s)
    --- PASS: TestResourceImportReconciler_handleCopySpanACNPUpdateEvent/valid_imported_acnp_update_to_missing_tier (0.00s)
    --- PASS: TestResourceImportReconciler_handleCopySpanACNPUpdateEvent/name_conflict_with_existing_acnp (0.00s)
=== RUN   TestResourceImportReconciler_handleClusterInfo
=== RUN   TestResourceImportReconciler_handleClusterInfo/create_ClusterInfoImport_successfully
=== RUN   TestResourceImportReconciler_handleClusterInfo/skip_import_empty_ResourceImport
=== RUN   TestResourceImportReconciler_handleClusterInfo/skip_import_ResourceImport_from_local
=== RUN   TestResourceImportReconciler_handleClusterInfo/update_ClusterInfoImport_successfully
=== RUN   TestResourceImportReconciler_handleClusterInfo/delete_ClusterInfoImport_successfully
E0423 18:07:19.486128   32516 resourceimport_controller.go:111] "No cached data for ResourceImport" resourceimport="default/cluster-c-default-clusterinfo"
--- PASS: TestResourceImportReconciler_handleClusterInfo (0.00s)
    --- PASS: TestResourceImportReconciler_handleClusterInfo/create_ClusterInfoImport_successfully (0.00s)
    --- PASS: TestResourceImportReconciler_handleClusterInfo/skip_import_empty_ResourceImport (0.00s)
    --- PASS: TestResourceImportReconciler_handleClusterInfo/skip_import_ResourceImport_from_local (0.00s)
    --- PASS: TestResourceImportReconciler_handleClusterInfo/update_ClusterInfoImport_successfully (0.00s)
    --- PASS: TestResourceImportReconciler_handleClusterInfo/delete_ClusterInfoImport_successfully (0.00s)
=== RUN   TestResourceImportReconciler_handleCreateEvent
=== RUN   TestResourceImportReconciler_handleCreateEvent/import_Service
I0423 18:07:19.486712   32516 resourceimport_controller.go:188] "Updating Service and ServiceImport corresponding to ResourceImport" service="default/antrea-mc-nginx" serviceimport="default/nginx" resourceimport="default/default-nginx-service"
=== RUN   TestResourceImportReconciler_handleCreateEvent/import_Endpoints
I0423 18:07:19.487862   32516 resourceimport_controller.go:303] "Updating Endpoints corresponding to ResourceImport" endpoints="default/antrea-mc-nginx" resourceimport="default/default-nginx-endpoints"
--- PASS: TestResourceImportReconciler_handleCreateEvent (0.00s)
    --- PASS: TestResourceImportReconciler_handleCreateEvent/import_Service (0.00s)
    --- PASS: TestResourceImportReconciler_handleCreateEvent/import_Endpoints (0.00s)
=== RUN   TestResourceImportReconciler_handleDeleteEvent
=== RUN   TestResourceImportReconciler_handleDeleteEvent/delete_Service
I0423 18:07:19.488432   32516 resourceimport_controller.go:270] "Deleting Service and ServiceImport corresponding to ResourceImport" service="default/antrea-mc-nginx" serviceImport="default/nginx" resourceimport="default/default-nginx-service"
=== RUN   TestResourceImportReconciler_handleDeleteEvent/delete_Endpoints
I0423 18:07:19.488432   32516 resourceimport_controller.go:358] "Deleting Endpoints corresponding to ResourceImport" endpoints="default/antrea-mc-nginx" resourceimport="default/default-nginx-endpoints"
--- PASS: TestResourceImportReconciler_handleDeleteEvent (0.00s)
    --- PASS: TestResourceImportReconciler_handleDeleteEvent/delete_Service (0.00s)
    --- PASS: TestResourceImportReconciler_handleDeleteEvent/delete_Endpoints (0.00s)
=== RUN   TestResourceImportReconciler_handleUpdateEvent
=== RUN   TestResourceImportReconciler_handleUpdateEvent/update_Service
I0423 18:07:19.489064   32516 resourceimport_controller.go:188] "Updating Service and ServiceImport corresponding to ResourceImport" service="default/antrea-mc-nginx" serviceimport="default/nginx" resourceimport="default/default-nginx-service"
=== RUN   TestResourceImportReconciler_handleUpdateEvent/update_Endpoints
I0423 18:07:19.489064   32516 resourceimport_controller.go:303] "Updating Endpoints corresponding to ResourceImport" endpoints="default/antrea-mc-nginx" resourceimport="default/default-nginx-endpoints"
=== RUN   TestResourceImportReconciler_handleUpdateEvent/skip_update_a_Service_without_mcs_annotation
I0423 18:07:19.489682   32516 resourceimport_controller.go:188] "Updating Service and ServiceImport corresponding to ResourceImport" service="kube-system/antrea-mc-nginx" serviceimport="kube-system/nginx" resourceimport="default/kube-system-nginx-service"
E0423 18:07:19.489682   32516 resourceimport_controller.go:202] "Unable to import Service" err="the Service conflicts with existing one" service="kube-system/antrea-mc-nginx"
=== RUN   TestResourceImportReconciler_handleUpdateEvent/skip_update_an_Endpoint_without_mcs_annotation
I0423 18:07:19.489682   32516 resourceimport_controller.go:303] "Updating Endpoints corresponding to ResourceImport" endpoints="kube-system/antrea-mc-nginx" resourceimport="default/kube-system-nginx-endpoints"
E0423 18:07:19.489682   32516 resourceimport_controller.go:315] "Unable to import Endpoints" err="the Endpoints conflicts with existing one" endpoints="kube-system/antrea-mc-nginx"
--- PASS: TestResourceImportReconciler_handleUpdateEvent (0.00s)
    --- PASS: TestResourceImportReconciler_handleUpdateEvent/update_Service (0.00s)
    --- PASS: TestResourceImportReconciler_handleUpdateEvent/update_Endpoints (0.00s)
    --- PASS: TestResourceImportReconciler_handleUpdateEvent/skip_update_a_Service_without_mcs_annotation (0.00s)
    --- PASS: TestResourceImportReconciler_handleUpdateEvent/skip_update_an_Endpoint_without_mcs_annotation (0.00s)
=== RUN   TestResourceImportReconciler_skipImportForNonTargetCluster
I0423 18:07:19.489682   32516 resourceimport_controller.go:122] "ResourceImport is no longer targeted to local cluster and no cached installed state was found, performing best-effort cleanup" resourceimport="default/default-nginx-service" clusterID="cluster-a"
I0423 18:07:19.489682   32516 resourceimport_controller.go:270] "Deleting Service and ServiceImport corresponding to ResourceImport" service="default/antrea-mc-nginx" serviceImport="default/nginx" resourceimport="default/default-nginx-service"
--- PASS: TestResourceImportReconciler_skipImportForNonTargetCluster (0.00s)
=== RUN   TestResourceImportReconciler_cleanupUsesCachedInstalledObject
I0423 18:07:19.490267   32516 resourceimport_controller.go:127] "ResourceImport is no longer targeted to local cluster, cleaning up installed resources" resourceimport="default/default-nginx-service" clusterID="cluster-a"
I0423 18:07:19.490267   32516 resourceimport_controller.go:270] "Deleting Service and ServiceImport corresponding to ResourceImport" service="default/antrea-mc-nginx" serviceImport="default/nginx" resourceimport="default/default-nginx-service"
--- PASS: TestResourceImportReconciler_cleanupUsesCachedInstalledObject (0.00s)
=== RUN   TestResourceImportReconciler_cleanupWithoutCachedInstalledObject
I0423 18:07:19.490267   32516 resourceimport_controller.go:122] "ResourceImport is no longer targeted to local cluster and no cached installed state was found, performing best-effort cleanup" resourceimport="default/default-nginx-service" clusterID="cluster-a"
I0423 18:07:19.490267   32516 resourceimport_controller.go:270] "Deleting Service and ServiceImport corresponding to ResourceImport" service="default/antrea-mc-nginx" serviceImport="default/nginx" resourceimport="default/default-nginx-service"
--- PASS: TestResourceImportReconciler_cleanupWithoutCachedInstalledObject (0.00s)
PASS
ok      antrea.io/antrea/v2/multicluster/controllers/multicluster/member        0.379s