### PR TITLE
fix(ovsconfig): return getHardwareOffload error from OVSBridge.Create (#7978)

### DIFF
--- a/pkg/ovs/ovsconfig/ovs_client.go
+++ b/pkg/ovs/ovsconfig/ovs_client.go
@@ -145,7 +145,12 @@ func (br *OVSBridge) Create() Error {
 	}
 	br.isHardwareOffloadEnabled, err = br.getHardwareOffload()
 	if err != nil {
+		// Surface the failure instead of swallowing it. Logging then
+		// returning nil left isHardwareOffloadEnabled in an unknown
+		// state and downstream components proceeded as if the bridge
+		// was fully initialised — see #7978.
 		klog.ErrorS(err, "Failed to get hardware offload")
+		return err
 	}
 	return nil
 }

--- a/pkg/ovs/ovsconfig/ovs_client.go
+++ b/pkg/ovs/ovsconfig/ovs_client.go
@@ -148,7 +148,7 @@ func (br *OVSBridge) Create() Error {
 		// Surface the failure instead of swallowing it. Logging then
 		// returning nil left isHardwareOffloadEnabled in an unknown
 		// state and downstream components proceeded as if the bridge
-		// was fully initialised — see #7978.
+		// was fully initialised, see #7978.
 		klog.ErrorS(err, "Failed to get hardware offload")
 		return err
 	}


### PR DESCRIPTION
Fixes #7978. `OVSBridge.Create()` (`pkg/ovs/ovsconfig/ovs_client.go:146-150`) called `br.getHardwareOffload()` and only logged the failure before returning `nil`. `isHardwareOffloadEnabled` was left in an indeterminate state (its zero value, `false`) and downstream components proceeded as if initialisation succeeded, masking real OVSDB read failures or invalid `other_config:hw-offload` values.

## Change

After logging, return the error so the caller can fail fast / retry / abort startup instead of silently mis-running.

## Test plan

- [x] `go build ./pkg/ovs/ovsconfig/...`, clean
- [x] `go vet ./pkg/ovs/ovsconfig/...`, clean
- [x] No new state introduced; the existing klog message is preserved so log-based diagnostics still work the same way