### PR TITLE
Fix codegen issues on ARM64 hosts with QEMU runtime

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -60,7 +60,7 @@ fi
 function docker_run() {
   # Silence CLI suggestions.
   export DOCKER_CLI_HINTS=false
-  [ -n "$NO_PULL" ] || docker pull "${DOCKER_PLATFORM_ARGS[@]}" "${IMAGE_NAME}"
+  [ -n "$NO_PULL" ] || docker pull "${IMAGE_NAME}"
   set -x
   ANTREA_SRC_PATH="/mnt/antrea"
   # The .git directory in ANTREA_SRC_PATH must be marked as "safe".

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -22,7 +22,19 @@ function echoerr {
 }
 
 ANTREA_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
-IMAGE_NAME="antrea/codegen:kubernetes-1.35.0-build.0"
+# Allow overriding the codegen image via environment variable (useful for ARM64 hosts).
+# To build a native ARM64 image and avoid Docker emulation issues:
+#   docker build --platform linux/arm64 -t antrea/codegen:arm64-local \
+#     -f ${ANTREA_ROOT}/build/images/codegen/Dockerfile --build-arg GO_VERSION="$(head -n1 ${ANTREA_ROOT}/build/images/deps/go-version)" .
+#   export ANTREA_CODEGEN_IMAGE=antrea/codegen:arm64-local
+#   export CODEGEN_DOCKER_PLATFORM=linux/arm64
+IMAGE_NAME="${ANTREA_CODEGEN_IMAGE:-antrea/codegen:kubernetes-1.35.0-build.0}"
+# Build a platform args array so --platform is safely quoted and applied consistently
+# to both docker pull and docker run.
+DOCKER_PLATFORM_ARGS=()
+if [ -n "${CODEGEN_DOCKER_PLATFORM}" ]; then
+  DOCKER_PLATFORM_ARGS=(--platform "${CODEGEN_DOCKER_PLATFORM}")
+fi
 
 # We will use git clone to make a working copy of the repository into a
 # temporary directory. This requires that all changes have been committed
@@ -48,7 +60,7 @@ fi
 function docker_run() {
   # Silence CLI suggestions.
   export DOCKER_CLI_HINTS=false
-  [ -n "$NO_PULL" ] || docker pull ${IMAGE_NAME}
+  [ -n "$NO_PULL" ] || docker pull "${DOCKER_PLATFORM_ARGS[@]}" "${IMAGE_NAME}"
   set -x
   ANTREA_SRC_PATH="/mnt/antrea"
   # The .git directory in ANTREA_SRC_PATH must be marked as "safe".
@@ -56,6 +68,7 @@ function docker_run() {
   # previously introduced in v2.30.3 were extended to cover cloning local
   # repositories, which is what we do in update-codegen-dockerized.sh.
   docker run --rm \
+		"${DOCKER_PLATFORM_ARGS[@]}" \
 		-e GOPROXY=${GOPROXY} \
 		-e HTTP_PROXY=${HTTP_PROXY} \
 		-e HTTPS_PROXY=${HTTPS_PROXY} \

--- a/multicluster/hack/update-codegen.sh
+++ b/multicluster/hack/update-codegen.sh
@@ -58,7 +58,7 @@ fi
 function docker_run() {
   # Silence CLI suggestions.
   export DOCKER_CLI_HINTS=false
-  [ -n "$NO_PULL" ] || docker pull "${DOCKER_PLATFORM_ARGS[@]}" "${IMAGE_NAME}"
+  [ -n "$NO_PULL" ] || docker pull "${IMAGE_NAME}"
   set -x
   ANTREA_SRC_PATH="/mnt/antrea"
   # Mount the same volumes as for the "main" codegen script (hack/update-codegen.sh)

--- a/multicluster/hack/update-codegen.sh
+++ b/multicluster/hack/update-codegen.sh
@@ -22,7 +22,17 @@ function echoerr {
 }
 
 ANTREA_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../" && pwd )"
-IMAGE_NAME="antrea/codegen:kubernetes-1.35.0-build.0"
+# Allow overriding the codegen image via environment variable (useful for ARM64 hosts).
+# To build a native ARM64 image and avoid Docker emulation issues:
+#   docker build --platform linux/arm64 -t antrea/codegen:arm64-local \
+#     -f ${ANTREA_ROOT}/build/images/codegen/Dockerfile --build-arg GO_VERSION="$(head -n1 ${ANTREA_ROOT}/build/images/deps/go-version)" .
+#   export ANTREA_CODEGEN_IMAGE=antrea/codegen:arm64-local
+#   export CODEGEN_DOCKER_PLATFORM=linux/arm64
+IMAGE_NAME="${ANTREA_CODEGEN_IMAGE:-antrea/codegen:kubernetes-1.35.0-build.0}"
+DOCKER_PLATFORM_ARGS=()
+if [ -n "${CODEGEN_DOCKER_PLATFORM}" ]; then
+  DOCKER_PLATFORM_ARGS=(--platform "${CODEGEN_DOCKER_PLATFORM}")
+fi
 
 # We will use git clone to make a working copy of the repository into a
 # temporary directory. This requires that all changes have been committed
@@ -48,7 +58,7 @@ fi
 function docker_run() {
   # Silence CLI suggestions.
   export DOCKER_CLI_HINTS=false
-  [ -n "$NO_PULL" ] || docker pull ${IMAGE_NAME}
+  [ -n "$NO_PULL" ] || docker pull "${DOCKER_PLATFORM_ARGS[@]}" "${IMAGE_NAME}"
   set -x
   ANTREA_SRC_PATH="/mnt/antrea"
   # Mount the same volumes as for the "main" codegen script (hack/update-codegen.sh)
@@ -58,6 +68,7 @@ function docker_run() {
   # previously introduced in v2.30.3 were extended to cover cloning local
   # repositories, which is what we do in update-codegen-dockerized.sh.
   docker run --rm \
+		"${DOCKER_PLATFORM_ARGS[@]}" \
 		-e GOPROXY=${GOPROXY} \
 		-e HTTP_PROXY=${HTTP_PROXY} \
 		-e HTTPS_PROXY=${HTTPS_PROXY} \


### PR DESCRIPTION
Adds ability for users to override the codegen image and specify a Docker platform in codegen scripts. This is particularly useful on ARM64 hosts to avoid QEMU emulation issues:
```
+ generate_multicluster_client_code
+ /go/bin/client-gen --clientset-name versioned --input-base antrea.io/antrea/v2/multicluster/apis --input multicluster/v1alpha1 --input multicluster/v1alpha2 --output-dir multicluster/pkg/client/clientset --output-pkg antrea.io/antrea/v2/multicluster/pkg/client/clientset --go-header-file hack/boilerplate/license_header.go.txt
F0501 17:33:16.927150      51 main.go:68] Error: failed making a parser: error loading packages: err: exit status 2: stderr: go: downloading k8s.io/api v0.35.3
go: downloading k8s.io/apimachinery v0.35.3
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x6c5bf2]
```
