### PR TITLE
Remove redundant loop-variable shadowing in test files

### DIFF
--- a/pkg/agent/flowexporter/destination_test.go
+++ b/pkg/agent/flowexporter/destination_test.go
@@ -278,7 +278,6 @@ func TestDestination_fillEgressInfo(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			egressQuerier := queriertest.NewMockEgressQuerier(ctrl)
@@ -603,7 +602,6 @@ func TestFlowExporter_resolveCollectorAddress(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			addr, err := resolveCollectorAddress(ctx, k8sClient, tc.inputAddr)
 			if tc.expectedErr != "" {

--- a/pkg/agent/nodeportlocal/rules/iptable_rule_test.go
+++ b/pkg/agent/nodeportlocal/rules/iptable_rule_test.go
@@ -70,7 +70,6 @@ func TestAddAndDeleteRule(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.podIP, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockIPTables := iptablestest.NewMockInterface(ctrl)
@@ -172,7 +171,6 @@ COMMIT
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockIPTables := iptablestest.NewMockInterface(ctrl)

--- a/pkg/cni/client_test.go
+++ b/pkg/cni/client_test.go
@@ -134,7 +134,6 @@ func TestRpcErrorsCheck(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.cniCode.String(), func(t *testing.T) {
-			tc := tc
 			enableTestClient(t, tc.behavior, normal, normal)
 			defer disableTestClient()
 

--- a/pkg/controller/networkpolicy/endpoint_querier_test.go
+++ b/pkg/controller/networkpolicy/endpoint_querier_test.go
@@ -320,7 +320,6 @@ func TestQueryNetworkPolicyRules(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			endpointQuerier := makeControllerAndEndpointQuerier(tc.objs...)
@@ -574,7 +573,6 @@ func TestQueryNetworkPolicyEvaluation(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			mockQuerier := queriermock.NewMockEndpointQuerier(mockCtrl)

--- a/test/e2e/antctl_test.go
+++ b/test/e2e/antctl_test.go
@@ -208,7 +208,6 @@ func testAntctlVerboseMode(t *testing.T, data *TestData) {
 		{name: "CommandNonVerbose", hasStderr: false, commands: []string{"antctl", "version"}},
 		{name: "CommandVerbose", hasStderr: true, commands: []string{"antctl", "-v", "version"}},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			t.Logf("Running command `%s` on pod %s", tc.commands, podName)

--- a/test/e2e/packetcapture_test.go
+++ b/test/e2e/packetcapture_test.go
@@ -719,7 +719,6 @@ func testPacketCaptureBasic(t *testing.T, data *TestData, sftpServerIP string, p
 
 	t.Run("testPacketCaptureBasic", func(t *testing.T) {
 		for _, tc := range testcases {
-			tc := tc
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 				runPacketCaptureTest(t, data, tc)
@@ -901,7 +900,6 @@ func testPacketCaptureL4Filters(t *testing.T, data *TestData, sftpServerIP strin
 	}
 	t.Run("testPacketCaptureL4Filters", func(t *testing.T) {
 		for _, tc := range testcases {
-			tc := tc
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 				runPacketCaptureTest(t, data, tc)

--- a/test/e2e/tls_test.go
+++ b/test/e2e/tls_test.go
@@ -71,7 +71,6 @@ func TestAntreaApiserverTLSConfig(t *testing.T) {
 		{"AgentApiserver", apis.AntreaAgentAPIPort, "Agent"},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			data.checkTLS(t, clientPodName, toolboxContainerName, tc.apiserver, tc.apiserverStr, nodeIPv4, nodeIPv6)
 		})

--- a/test/e2e/traceflow_test.go
+++ b/test/e2e/traceflow_test.go
@@ -304,7 +304,6 @@ func testTraceflowIntraNodeANNP(t *testing.T, data *TestData) {
 	}
 	t.Run("traceflowANNPGroupTest", func(t *testing.T) {
 		for _, tc := range testcases {
-			tc := tc
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 				runTestTraceflow(t, data, tc)
@@ -1123,7 +1122,6 @@ func testTraceflowIntraNode(t *testing.T, data *TestData) {
 
 	t.Run("traceflowGroupTest", func(t *testing.T) {
 		for _, tc := range testcases {
-			tc := tc
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 				runTestTraceflow(t, data, tc)
@@ -2041,7 +2039,6 @@ func testTraceflowInterNode(t *testing.T, data *TestData) {
 
 	t.Run("traceflowGroupTest", func(t *testing.T) {
 		for _, tc := range testcases {
-			tc := tc
 			t.Run(tc.name, func(t *testing.T) {
 				// Run test cases in sequential on Windows environment to verify the first packet issue is worked around.
 				// TODO: Run test cases in parallel after Windows OVS fixes the issue (openvswitch/ovs-issues#253) that
@@ -2362,7 +2359,6 @@ func testTraceflowValidation(t *testing.T, data *TestData) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			tf := &v1beta1.Traceflow{
 				Spec: tc.spec,


### PR DESCRIPTION
Go 1.22 changed loop-variable semantics so each iteration gets its own copy, making the `tc := tc` / `tt := tt` self-assignment pattern inside `for range` loops unnecessary. Remove all 15 occurrences across 8 test files.