### PR TITLE
Automated cherry pick of #7996: Strengthen IPPool status retry on concurrent updates (#7996)

### DIFF
--- a/pkg/ipam/poolallocator/allocator.go
+++ b/pkg/ipam/poolallocator/allocator.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"time"
 
 	"antrea.io/antrea/pkg/apis/crd/v1beta1"
 	crdclientset "antrea.io/antrea/pkg/client/clientset/versioned"
@@ -27,10 +28,24 @@ import (
 	iputil "antrea.io/antrea/pkg/util/ip"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 	utilnet "k8s.io/utils/net"
 )
+
+// ipPoolStatusRetry backs off longer than retry.DefaultRetry (5 fixed ~10ms
+// sleeps) but avoids an overly long tail. client-go's retry.DefaultBackoff uses
+// fewer steps with a larger factor for a sub-second total; here we use a mild
+// exponential (1.5) with more attempts than DefaultRetry so many Nodes updating
+// the same IPPool status (shared pools, multi-NIC) can clear conflicts without
+// multi-second CNI stalls.
+var ipPoolStatusRetry = wait.Backoff{
+	Steps:    8,
+	Duration: 10 * time.Millisecond,
+	Factor:   1.5,
+	Jitter:   0.1,
+}
 
 // IPPoolAllocator is responsible for allocating IPs from IP set defined in IPPool CRD.
 // The will update CRD usage accordingly.
@@ -289,7 +304,7 @@ func (a *IPPoolAllocator) getExistingAllocation(podOwner *v1beta1.PodOwner) (net
 func (a *IPPoolAllocator) AllocateIP(ip net.IP, state v1beta1.IPAddressPhase, owner v1beta1.IPAddressOwner) (*v1beta1.SubnetInfo, error) {
 	var subnetInfo *v1beta1.SubnetInfo
 	// Retry on CRD update conflict which is caused by multiple agents updating a pool at same time.
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	err := retry.RetryOnConflict(ipPoolStatusRetry, func() error {
 		ipPool, allocators, err := a.getPoolAndInitIPAllocators()
 		if err != nil {
 			return err
@@ -345,7 +360,7 @@ func (a *IPPoolAllocator) AllocateNext(state v1beta1.IPAddressPhase, owner v1bet
 	}
 
 	// Retry on CRD update conflict which is caused by multiple agents updating a pool at same time.
-	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	err = retry.RetryOnConflict(ipPoolStatusRetry, func() error {
 		ipPool, allocators, err := a.getPoolAndInitIPAllocators()
 		if err != nil {
 			return err
@@ -403,7 +418,7 @@ func (a *IPPoolAllocator) AllocateReservedOrNext(state v1beta1.IPAddressPhase, o
 	}
 
 	// Retry on CRD update conflict which is caused by multiple agents updating a pool at same time.
-	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	err = retry.RetryOnConflict(ipPoolStatusRetry, func() error {
 		ipPool, allocators, err := a.getPoolAndInitIPAllocators()
 		if err != nil {
 			return err
@@ -438,7 +453,7 @@ func (a *IPPoolAllocator) AllocateReservedOrNext(state v1beta1.IPAddressPhase, o
 // be allocated on the fly, and there is no guarantee for continuous IPs.
 func (a *IPPoolAllocator) AllocateStatefulSet(namespace, name string, size int, ip net.IP) error {
 	// Retry on CRD update conflict which is caused by multiple agents updating a pool at same time.
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	err := retry.RetryOnConflict(ipPoolStatusRetry, func() error {
 		ipPool, allocators, err := a.getPoolAndInitIPAllocators()
 		if err != nil {
 			return err
@@ -477,7 +492,7 @@ func (a *IPPoolAllocator) AllocateStatefulSet(namespace, name string, size int, 
 func (a *IPPoolAllocator) Release(ip net.IP) error {
 
 	// Retry on CRD update conflict which is caused by multiple agents updating a pool at same time.
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	err := retry.RetryOnConflict(ipPoolStatusRetry, func() error {
 		ipPool, allocators, err := a.getPoolAndInitIPAllocators()
 		if err != nil {
 			return err
@@ -505,7 +520,7 @@ func (a *IPPoolAllocator) Release(ip net.IP) error {
 func (a *IPPoolAllocator) ReleaseStatefulSet(namespace, name string) error {
 
 	// Retry on CRD update conflict which is caused by multiple agents updating a pool at same time.
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	err := retry.RetryOnConflict(ipPoolStatusRetry, func() error {
 		ipPool, err := a.getPool()
 
 		if err != nil {
@@ -550,7 +565,7 @@ func (a *IPPoolAllocator) ReleaseStatefulSet(namespace, name string) error {
 // change.
 func (a *IPPoolAllocator) ReleaseContainer(containerID, ifName string) error {
 	// Retry on CRD update conflict which is caused by multiple agents updating a pool at same time.
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	err := retry.RetryOnConflict(ipPoolStatusRetry, func() error {
 		ipPool, err := a.getPool()
 		if err != nil {
 			return err

--- a/pkg/ipam/poolallocator/allocator_test.go
+++ b/pkg/ipam/poolallocator/allocator_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"sync"
 	"testing"
 	"time"
 
@@ -155,6 +156,82 @@ func TestAllocateNext(t *testing.T) {
 	assert.Equal(t, 21, allocator.Total())
 
 	validateAllocationSequence(t, allocator, subnetInfo, []string{"10.2.2.100", "10.2.2.101"})
+}
+
+// TestConcurrentAllocateNextSharedIPPool simulates many Nodes (or many Pods on
+// different Nodes) calling AllocateNext on the same IPPool at once. The fake
+// client returns 409-style conflicts when ResourceVersion is stale, matching
+// concurrent UpdateStatus on a shared pool (e.g. several DaemonSets using the
+// same Antrea IPPool for secondary networks). All goroutines must succeed with
+// distinct IPs if ipPoolStatusRetry allows enough conflict retries.
+func TestConcurrentAllocateNextSharedIPPool(t *testing.T) {
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	// Six DaemonSets on a six-Node cluster all requesting the same pool is 36
+	// concurrent status writers; keep headroom in the range.
+	const concurrency = 36
+
+	poolName := uuid.New().String()
+	ipRange := crdv1b1.IPRange{
+		Start: "10.2.2.10",
+		End:   "10.2.2.99", // 90 addresses
+	}
+	subnetInfo := crdv1b1.SubnetInfo{
+		Gateway:      "10.2.2.1",
+		PrefixLength: 24,
+		VLAN:         101,
+	}
+	pool := crdv1b1.IPPool{
+		ObjectMeta: metav1.ObjectMeta{Name: poolName},
+		Spec:       crdv1b1.IPPoolSpec{IPRanges: []crdv1b1.IPRange{ipRange}, SubnetInfo: subnetInfo},
+	}
+
+	allocator := newTestIPPoolAllocator(&pool, stopCh)
+	require.NotNil(t, allocator)
+	require.GreaterOrEqual(t, allocator.Total(), concurrency)
+
+	var wg sync.WaitGroup
+	errs := make([]error, concurrency)
+	ipStrs := make([]string, concurrency)
+
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			owner := crdv1b1.IPAddressOwner{
+				Pod: &crdv1b1.PodOwner{
+					Name:        fmt.Sprintf("concurrent-pod-%d", idx),
+					Namespace:   testNamespace,
+					ContainerID: uuid.New().String(),
+					IFName:      "net1",
+				},
+			}
+			ip, _, err := allocator.AllocateNext(crdv1b1.IPAddressPhaseAllocated, owner)
+			if err != nil {
+				errs[idx] = err
+				return
+			}
+			if ip == nil {
+				errs[idx] = fmt.Errorf("worker %d: AllocateNext returned nil IP without error", idx)
+				return
+			}
+			ipStrs[idx] = ip.String()
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoError(t, err, "AllocateNext for worker %d should succeed under contention", i)
+		require.NotEmpty(t, ipStrs[i], "worker %d: no error but empty IP string returned", i)
+	}
+	seen := make(map[string]struct{}, concurrency)
+	for _, s := range ipStrs {
+		_, dup := seen[s]
+		require.False(t, dup, "duplicate IP %s allocated", s)
+		seen[s] = struct{}{}
+	}
+	require.Len(t, seen, concurrency, "expected a distinct IP per concurrent allocator")
 }
 
 func TestAllocateNextMultiRange(t *testing.T) {


### PR DESCRIPTION
Cherry pick of #7996 on release-2.5.

#7996: Strengthen IPPool status retry on concurrent updates (#7996)

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.