### PR TITLE
Update AntreaNodeConfig CRD validation rules

### DIFF
--- a/build/charts/antrea/crds/antreanodeconfig.yaml
+++ b/build/charts/antrea/crds/antreanodeconfig.yaml
@@ -70,10 +70,13 @@ spec:
                           bridgeName:
                             description: Name of the OVS bridge.
                             type: string
+                            maxLength: 15
+                            pattern: '^[a-zA-Z0-9._-]+$'
                           physicalInterfaces:
                             description: >-
                               Physical interfaces to be connected to this bridge.
                             type: array
+                            maxItems: 8
                             items:
                               type: object
                               required:
@@ -83,6 +86,8 @@ spec:
                                   description: Name of the physical interface.
                                   type: string
                                   minLength: 1
+                                  maxLength: 15
+                                  pattern: '^[a-zA-Z0-9._-]+$'
                                 allowedVLANs:
                                   description: >-
                                     VLAN IDs or VLAN ID ranges (e.g. "100",

--- a/build/yamls/antrea-aks.yml
+++ b/build/yamls/antrea-aks.yml
@@ -397,10 +397,13 @@ spec:
                           bridgeName:
                             description: Name of the OVS bridge.
                             type: string
+                            maxLength: 15
+                            pattern: '^[a-zA-Z0-9._-]+$'
                           physicalInterfaces:
                             description: >-
                               Physical interfaces to be connected to this bridge.
                             type: array
+                            maxItems: 8
                             items:
                               type: object
                               required:
@@ -410,6 +413,8 @@ spec:
                                   description: Name of the physical interface.
                                   type: string
                                   minLength: 1
+                                  maxLength: 15
+                                  pattern: '^[a-zA-Z0-9._-]+$'
                                 allowedVLANs:
                                   description: >-
                                     VLAN IDs or VLAN ID ranges (e.g. "100",

--- a/build/yamls/antrea-crds.yml
+++ b/build/yamls/antrea-crds.yml
@@ -388,10 +388,13 @@ spec:
                           bridgeName:
                             description: Name of the OVS bridge.
                             type: string
+                            maxLength: 15
+                            pattern: '^[a-zA-Z0-9._-]+$'
                           physicalInterfaces:
                             description: >-
                               Physical interfaces to be connected to this bridge.
                             type: array
+                            maxItems: 8
                             items:
                               type: object
                               required:
@@ -401,6 +404,8 @@ spec:
                                   description: Name of the physical interface.
                                   type: string
                                   minLength: 1
+                                  maxLength: 15
+                                  pattern: '^[a-zA-Z0-9._-]+$'
                                 allowedVLANs:
                                   description: >-
                                     VLAN IDs or VLAN ID ranges (e.g. "100",

--- a/build/yamls/antrea-eks.yml
+++ b/build/yamls/antrea-eks.yml
@@ -393,10 +393,13 @@ spec:
                           bridgeName:
                             description: Name of the OVS bridge.
                             type: string
+                            maxLength: 15
+                            pattern: '^[a-zA-Z0-9._-]+$'
                           physicalInterfaces:
                             description: >-
                               Physical interfaces to be connected to this bridge.
                             type: array
+                            maxItems: 8
                             items:
                               type: object
                               required:
@@ -406,6 +409,8 @@ spec:
                                   description: Name of the physical interface.
                                   type: string
                                   minLength: 1
+                                  maxLength: 15
+                                  pattern: '^[a-zA-Z0-9._-]+$'
                                 allowedVLANs:
                                   description: >-
                                     VLAN IDs or VLAN ID ranges (e.g. "100",

--- a/build/yamls/antrea-gke.yml
+++ b/build/yamls/antrea-gke.yml
@@ -393,10 +393,13 @@ spec:
                           bridgeName:
                             description: Name of the OVS bridge.
                             type: string
+                            maxLength: 15
+                            pattern: '^[a-zA-Z0-9._-]+$'
                           physicalInterfaces:
                             description: >-
                               Physical interfaces to be connected to this bridge.
                             type: array
+                            maxItems: 8
                             items:
                               type: object
                               required:
@@ -406,6 +409,8 @@ spec:
                                   description: Name of the physical interface.
                                   type: string
                                   minLength: 1
+                                  maxLength: 15
+                                  pattern: '^[a-zA-Z0-9._-]+$'
                                 allowedVLANs:
                                   description: >-
                                     VLAN IDs or VLAN ID ranges (e.g. "100",

--- a/build/yamls/antrea-ipsec.yml
+++ b/build/yamls/antrea-ipsec.yml
@@ -393,10 +393,13 @@ spec:
                           bridgeName:
                             description: Name of the OVS bridge.
                             type: string
+                            maxLength: 15
+                            pattern: '^[a-zA-Z0-9._-]+$'
                           physicalInterfaces:
                             description: >-
                               Physical interfaces to be connected to this bridge.
                             type: array
+                            maxItems: 8
                             items:
                               type: object
                               required:
@@ -406,6 +409,8 @@ spec:
                                   description: Name of the physical interface.
                                   type: string
                                   minLength: 1
+                                  maxLength: 15
+                                  pattern: '^[a-zA-Z0-9._-]+$'
                                 allowedVLANs:
                                   description: >-
                                     VLAN IDs or VLAN ID ranges (e.g. "100",

--- a/build/yamls/antrea.yml
+++ b/build/yamls/antrea.yml
@@ -393,10 +393,13 @@ spec:
                           bridgeName:
                             description: Name of the OVS bridge.
                             type: string
+                            maxLength: 15
+                            pattern: '^[a-zA-Z0-9._-]+$'
                           physicalInterfaces:
                             description: >-
                               Physical interfaces to be connected to this bridge.
                             type: array
+                            maxItems: 8
                             items:
                               type: object
                               required:
@@ -406,6 +409,8 @@ spec:
                                   description: Name of the physical interface.
                                   type: string
                                   minLength: 1
+                                  maxLength: 15
+                                  pattern: '^[a-zA-Z0-9._-]+$'
                                 allowedVLANs:
                                   description: >-
                                     VLAN IDs or VLAN ID ranges (e.g. "100",


### PR DESCRIPTION
* Enforce a maximum length of 15 characters for bridgeName and physicalInterface names, and restrict allowed characters to align with Linux interface naming rules.
* Limit the number of physicalInterfaces to 8 to match the existing static configuration limitation and reduce CEL evaluation cost.