### PR TITLE
Exclude host-network and terminated Pods from NetworkPolicyEvaluation

### DIFF
--- a/pkg/controller/grouping/group_entity_index.go
+++ b/pkg/controller/grouping/group_entity_index.go
@@ -68,6 +68,9 @@ type Interface interface {
 	// GetEntities returns the selected Pods or ExternalEntities for the given group.
 	GetEntities(groupType GroupType, name string) ([]*v1.Pod, []*v1alpha2.ExternalEntity)
 	// GetGroupsForPod returns the groups that select the given Pod.
+	// If the Pod does not exist, it returns (nil, false). Host network Pods, terminated Pods,
+	// and Pods without IP addresses are excluded from group association lookups. If such a Pod
+	// exists, this method returns an empty map and true.
 	GetGroupsForPod(namespace, name string) (map[GroupType][]string, bool)
 	// GetGroupsForExternalEntity returns the groups that select the given ExternalEntity.
 	GetGroupsForExternalEntity(namespace, name string) (map[GroupType][]string, bool)
@@ -255,7 +258,29 @@ func (i *GroupEntityIndex) GetEntities(groupType GroupType, name string) ([]*v1.
 }
 
 func (i *GroupEntityIndex) GetGroupsForPod(namespace, name string) (map[GroupType][]string, bool) {
-	return i.getGroups(podEntityType, namespace, name)
+	// Before looking up groups, check if this Pod should be excluded from network policy
+	// enforcement. This mirrors the filtering in getMemberSetForGroupType and ensures callers
+	// never see group associations for Pods that can never be selected for policy processing:
+	// - Host-network Pods (https://github.com/antrea-io/antrea/issues/3078)
+	// - Terminated Pods (their IPs can be recycled and reused)
+	// - Pods without IP addresses
+	eKey := getEntityItemKeyByName(podEntityType, namespace, name)
+
+	i.lock.RLock()
+	defer i.lock.RUnlock()
+
+	eItem, exists := i.entityItems[eKey]
+	if !exists {
+		return nil, false
+	}
+	if pod, ok := eItem.entity.(*v1.Pod); ok {
+		if pod.Spec.HostNetwork || k8s.IsPodTerminated(pod) || len(pod.Status.PodIPs) == 0 {
+			// The Pod exists but is excluded from network policy enforcement.
+			// Return an empty map (no group associations) with exists=true.
+			return map[GroupType][]string{}, true
+		}
+	}
+	return i.getGroupsLocked(eItem)
 }
 
 func (i *GroupEntityIndex) GetGroupsForExternalEntity(namespace, name string) (map[GroupType][]string, bool) {
@@ -273,7 +298,12 @@ func (i *GroupEntityIndex) getGroups(entityType entityType, namespace, name stri
 	if !exists {
 		return nil, false
 	}
+	return i.getGroupsLocked(eItem)
+}
 
+// getGroupsLocked returns the groups associated with the given entityItem.
+// It must be called with the GroupEntityIndex read lock held.
+func (i *GroupEntityIndex) getGroupsLocked(eItem *entityItem) (map[GroupType][]string, bool) {
 	groups := map[GroupType][]string{}
 	lItem := i.labelItems[eItem.labelItemKey]
 	// Get the keys of the selectorItems the labelItem matches.

--- a/pkg/controller/grouping/group_entity_index.go
+++ b/pkg/controller/grouping/group_entity_index.go
@@ -68,11 +68,11 @@ type Interface interface {
 	// GetEntities returns the selected Pods or ExternalEntities for the given group.
 	GetEntities(groupType GroupType, name string) ([]*v1.Pod, []*v1alpha2.ExternalEntity)
 	// GetGroupsForPod returns the groups that select the given Pod.
-	// If the Pod does not exist, it returns (nil, false). If a non-nil podExcludeFilter is
+	// If the Pod does not exist, it returns (nil, false). If a non-nil excludePod filter is
 	// provided and it returns true for the Pod, the Pod is treated as having no group
-	// associations: an empty map and true are returned so callers can distinguish "pod not
-	// found" from "pod found but excluded".
-	GetGroupsForPod(namespace, name string, podExcludeFilter func(*v1.Pod) bool) (map[GroupType][]string, bool)
+	// associations: (nil, true) is returned so callers can distinguish "pod not found" from
+	// "pod found but excluded".
+	GetGroupsForPod(namespace, name string, excludePod func(*v1.Pod) bool) (map[GroupType][]string, bool)
 	// GetGroupsForExternalEntity returns the groups that select the given ExternalEntity.
 	GetGroupsForExternalEntity(namespace, name string) (map[GroupType][]string, bool)
 	// AddPod adds or updates a Pod to the index. If any existing groups are affected, eventHandlers will be called with
@@ -258,7 +258,7 @@ func (i *GroupEntityIndex) GetEntities(groupType GroupType, name string) ([]*v1.
 	return pods, externalEntities
 }
 
-func (i *GroupEntityIndex) GetGroupsForPod(namespace, name string, podExcludeFilter func(*v1.Pod) bool) (map[GroupType][]string, bool) {
+func (i *GroupEntityIndex) GetGroupsForPod(namespace, name string, excludePod func(*v1.Pod) bool) (map[GroupType][]string, bool) {
 	eKey := getEntityItemKeyByName(podEntityType, namespace, name)
 
 	i.lock.RLock()
@@ -268,12 +268,12 @@ func (i *GroupEntityIndex) GetGroupsForPod(namespace, name string, podExcludeFil
 	if !exists {
 		return nil, false
 	}
-	if podExcludeFilter != nil {
-		if pod, ok := eItem.entity.(*v1.Pod); ok && podExcludeFilter(pod) {
+	if excludePod != nil {
+		if pod, ok := eItem.entity.(*v1.Pod); ok && excludePod(pod) {
 			// The Pod exists but the caller's filter excludes it.
-			// Return an empty map with exists=true so callers can distinguish
-			// "pod not found" from "pod found but excluded".
-			return map[GroupType][]string{}, true
+			// Return (nil, true) so callers can distinguish "pod not found"
+			// from "pod found but excluded".
+			return nil, true
 		}
 	}
 	return i.getGroupsLocked(eItem)

--- a/pkg/controller/grouping/group_entity_index.go
+++ b/pkg/controller/grouping/group_entity_index.go
@@ -68,10 +68,11 @@ type Interface interface {
 	// GetEntities returns the selected Pods or ExternalEntities for the given group.
 	GetEntities(groupType GroupType, name string) ([]*v1.Pod, []*v1alpha2.ExternalEntity)
 	// GetGroupsForPod returns the groups that select the given Pod.
-	// If the Pod does not exist, it returns (nil, false). Host network Pods, terminated Pods,
-	// and Pods without IP addresses are excluded from group association lookups. If such a Pod
-	// exists, this method returns an empty map and true.
-	GetGroupsForPod(namespace, name string) (map[GroupType][]string, bool)
+	// If the Pod does not exist, it returns (nil, false). If a non-nil podExcludeFilter is
+	// provided and it returns true for the Pod, the Pod is treated as having no group
+	// associations: an empty map and true are returned so callers can distinguish "pod not
+	// found" from "pod found but excluded".
+	GetGroupsForPod(namespace, name string, podExcludeFilter func(*v1.Pod) bool) (map[GroupType][]string, bool)
 	// GetGroupsForExternalEntity returns the groups that select the given ExternalEntity.
 	GetGroupsForExternalEntity(namespace, name string) (map[GroupType][]string, bool)
 	// AddPod adds or updates a Pod to the index. If any existing groups are affected, eventHandlers will be called with
@@ -257,13 +258,7 @@ func (i *GroupEntityIndex) GetEntities(groupType GroupType, name string) ([]*v1.
 	return pods, externalEntities
 }
 
-func (i *GroupEntityIndex) GetGroupsForPod(namespace, name string) (map[GroupType][]string, bool) {
-	// Before looking up groups, check if this Pod should be excluded from network policy
-	// enforcement. This mirrors the filtering in getMemberSetForGroupType and ensures callers
-	// never see group associations for Pods that can never be selected for policy processing:
-	// - Host-network Pods (https://github.com/antrea-io/antrea/issues/3078)
-	// - Terminated Pods (their IPs can be recycled and reused)
-	// - Pods without IP addresses
+func (i *GroupEntityIndex) GetGroupsForPod(namespace, name string, podExcludeFilter func(*v1.Pod) bool) (map[GroupType][]string, bool) {
 	eKey := getEntityItemKeyByName(podEntityType, namespace, name)
 
 	i.lock.RLock()
@@ -273,10 +268,11 @@ func (i *GroupEntityIndex) GetGroupsForPod(namespace, name string) (map[GroupTyp
 	if !exists {
 		return nil, false
 	}
-	if pod, ok := eItem.entity.(*v1.Pod); ok {
-		if pod.Spec.HostNetwork || k8s.IsPodTerminated(pod) || len(pod.Status.PodIPs) == 0 {
-			// The Pod exists but is excluded from network policy enforcement.
-			// Return an empty map (no group associations) with exists=true.
+	if podExcludeFilter != nil {
+		if pod, ok := eItem.entity.(*v1.Pod); ok && podExcludeFilter(pod) {
+			// The Pod exists but the caller's filter excludes it.
+			// Return an empty map with exists=true so callers can distinguish
+			// "pod not found" from "pod found but excluded".
 			return map[GroupType][]string{}, true
 		}
 	}

--- a/pkg/controller/grouping/group_entity_index_test.go
+++ b/pkg/controller/grouping/group_entity_index_test.go
@@ -97,6 +97,9 @@ func newPod(namespace, name string, labels map[string]string) *v1.Pod {
 			Name:      name,
 			Labels:    labels,
 		},
+		Status: v1.PodStatus{
+			PodIPs: []v1.PodIP{{IP: "1.2.3.4"}},
+		},
 	}
 }
 
@@ -188,7 +191,20 @@ func TestGroupEntityIndexGetEntities(t *testing.T) {
 
 func TestGroupEntityIndexGetGroups(t *testing.T) {
 	index := NewGroupEntityIndex()
-	pods := []*v1.Pod{podFoo1, podFoo2, podBar1, podFoo1InOtherNamespace}
+	// excluded Pods: added to the index but should never return groups
+	hostNetworkPod := copyAndMutatePod(podFoo1, func(pod *v1.Pod) {
+		pod.Name = "host-network-pod"
+		pod.Spec.HostNetwork = true
+	})
+	terminatedPod := copyAndMutatePod(podFoo1, func(pod *v1.Pod) {
+		pod.Name = "terminated-pod"
+		pod.Status.Phase = v1.PodSucceeded
+	})
+	noIPPod := copyAndMutatePod(podFoo1, func(pod *v1.Pod) {
+		pod.Name = "no-ip-pod"
+		pod.Status.PodIPs = nil
+	})
+	pods := []*v1.Pod{podFoo1, podFoo2, podBar1, podFoo1InOtherNamespace, hostNetworkPod, terminatedPod, noIPPod}
 	externalEntities := []*v1alpha2.ExternalEntity{eeFoo1, eeFoo2, eeBar1, eeFoo1InOtherNamespace}
 	namespaces := []*v1.Namespace{nsDefault, nsOther}
 	groups := []*group{groupPodFooType1, groupPodFooType2, groupPodFooAllNamespaceType1, groupEEFooType1, groupEEFooType2, groupEEFooAllNamespaceType1}
@@ -255,6 +271,33 @@ func TestGroupEntityIndexGetGroups(t *testing.T) {
 			}),
 			expectedFound:  false,
 			expectedGroups: nil,
+		},
+		{
+			name: "Host network Pod excluded",
+			inputEntity: copyAndMutatePod(podFoo1, func(pod *v1.Pod) {
+				pod.Name = "host-network-pod"
+				pod.Spec.HostNetwork = true
+			}),
+			expectedFound:  true,
+			expectedGroups: map[GroupType][]string{},
+		},
+		{
+			name: "Terminated Pod excluded",
+			inputEntity: copyAndMutatePod(podFoo1, func(pod *v1.Pod) {
+				pod.Name = "terminated-pod"
+				pod.Status.Phase = v1.PodSucceeded
+			}),
+			expectedFound:  true,
+			expectedGroups: map[GroupType][]string{},
+		},
+		{
+			name: "Pod without IP excluded",
+			inputEntity: copyAndMutatePod(podFoo1, func(pod *v1.Pod) {
+				pod.Name = "no-ip-pod"
+				pod.Status.PodIPs = nil
+			}),
+			expectedFound:  true,
+			expectedGroups: map[GroupType][]string{},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/controller/grouping/group_entity_index_test.go
+++ b/pkg/controller/grouping/group_entity_index_test.go
@@ -191,20 +191,7 @@ func TestGroupEntityIndexGetEntities(t *testing.T) {
 
 func TestGroupEntityIndexGetGroups(t *testing.T) {
 	index := NewGroupEntityIndex()
-	// excluded Pods: added to the index but should never return groups
-	hostNetworkPod := copyAndMutatePod(podFoo1, func(pod *v1.Pod) {
-		pod.Name = "host-network-pod"
-		pod.Spec.HostNetwork = true
-	})
-	terminatedPod := copyAndMutatePod(podFoo1, func(pod *v1.Pod) {
-		pod.Name = "terminated-pod"
-		pod.Status.Phase = v1.PodSucceeded
-	})
-	noIPPod := copyAndMutatePod(podFoo1, func(pod *v1.Pod) {
-		pod.Name = "no-ip-pod"
-		pod.Status.PodIPs = nil
-	})
-	pods := []*v1.Pod{podFoo1, podFoo2, podBar1, podFoo1InOtherNamespace, hostNetworkPod, terminatedPod, noIPPod}
+	pods := []*v1.Pod{podFoo1, podFoo2, podBar1, podFoo1InOtherNamespace}
 	externalEntities := []*v1alpha2.ExternalEntity{eeFoo1, eeFoo2, eeBar1, eeFoo1InOtherNamespace}
 	namespaces := []*v1.Namespace{nsDefault, nsOther}
 	groups := []*group{groupPodFooType1, groupPodFooType2, groupPodFooAllNamespaceType1, groupEEFooType1, groupEEFooType2, groupEEFooAllNamespaceType1}
@@ -272,40 +259,54 @@ func TestGroupEntityIndexGetGroups(t *testing.T) {
 			expectedFound:  false,
 			expectedGroups: nil,
 		},
+	}
+	// podExclude filter tests: verify the filter parameter is honored.
+	podExcludeTests := []struct {
+		name             string
+		inputPod         *v1.Pod
+		podExcludeFilter func(*v1.Pod) bool
+		expectedFound    bool
+		expectedGroups   map[GroupType][]string
+	}{
 		{
-			name: "Host network Pod excluded",
-			inputEntity: copyAndMutatePod(podFoo1, func(pod *v1.Pod) {
-				pod.Name = "host-network-pod"
-				pod.Spec.HostNetwork = true
-			}),
-			expectedFound:  true,
-			expectedGroups: map[GroupType][]string{},
+			name:             "nil filter returns normal groups",
+			inputPod:         podFoo1,
+			podExcludeFilter: nil,
+			expectedFound:    true,
+			expectedGroups:   map[GroupType][]string{groupType1: {groupPodFooType1.groupName, groupPodFooAllNamespaceType1.groupName}, groupType2: {groupPodFooType2.groupName}},
 		},
 		{
-			name: "Terminated Pod excluded",
-			inputEntity: copyAndMutatePod(podFoo1, func(pod *v1.Pod) {
-				pod.Name = "terminated-pod"
-				pod.Status.Phase = v1.PodSucceeded
-			}),
-			expectedFound:  true,
-			expectedGroups: map[GroupType][]string{},
+			name:             "matching filter returns empty groups but pod found",
+			inputPod:         podFoo1,
+			podExcludeFilter: func(*v1.Pod) bool { return true },
+			expectedFound:    true,
+			expectedGroups:   map[GroupType][]string{},
 		},
 		{
-			name: "Pod without IP excluded",
-			inputEntity: copyAndMutatePod(podFoo1, func(pod *v1.Pod) {
-				pod.Name = "no-ip-pod"
-				pod.Status.PodIPs = nil
-			}),
-			expectedFound:  true,
-			expectedGroups: map[GroupType][]string{},
+			name:             "non-matching filter returns normal groups",
+			inputPod:         podFoo1,
+			podExcludeFilter: func(*v1.Pod) bool { return false },
+			expectedFound:    true,
+			expectedGroups:   map[GroupType][]string{groupType1: {groupPodFooType1.groupName, groupPodFooAllNamespaceType1.groupName}, groupType2: {groupPodFooType2.groupName}},
 		},
 	}
+	for _, tt := range podExcludeTests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualGroups, actualFound := index.GetGroupsForPod(tt.inputPod.GetNamespace(), tt.inputPod.GetName(), tt.podExcludeFilter)
+			assert.Equal(t, tt.expectedFound, actualFound)
+			assert.Equal(t, len(tt.expectedGroups), len(actualGroups))
+			for groupType, expected := range tt.expectedGroups {
+				assert.ElementsMatch(t, expected, actualGroups[groupType])
+			}
+		})
+	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var actualGroups map[GroupType][]string
 			var actualFound bool
 			if _, ok := tt.inputEntity.(*v1.Pod); ok {
-				actualGroups, actualFound = index.GetGroupsForPod(tt.inputEntity.GetNamespace(), tt.inputEntity.GetName())
+				actualGroups, actualFound = index.GetGroupsForPod(tt.inputEntity.GetNamespace(), tt.inputEntity.GetName(), nil)
 			} else {
 				actualGroups, actualFound = index.GetGroupsForExternalEntity(tt.inputEntity.GetNamespace(), tt.inputEntity.GetName())
 			}
@@ -333,7 +334,7 @@ func TestGroupEntityIndexUpdateGroup(t *testing.T) {
 		index.AddNamespace(ns)
 	}
 	index.AddGroup(groupType1, "group1", types.NewGroupSelector("default", &metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo"}}, nil, nil, nil))
-	actualGroups, _ := index.GetGroupsForPod(podFoo1.Namespace, podFoo1.Name)
+	actualGroups, _ := index.GetGroupsForPod(podFoo1.Namespace, podFoo1.Name, nil)
 	assert.Equal(t, map[GroupType][]string{groupType1: {"group1"}}, actualGroups)
 	actualGroups, _ = index.GetGroupsForExternalEntity(eeFoo1.Namespace, eeFoo1.Name)
 	assert.Equal(t, map[GroupType][]string{}, actualGroups)
@@ -342,7 +343,7 @@ func TestGroupEntityIndexUpdateGroup(t *testing.T) {
 	assert.ElementsMatch(t, []*v1alpha2.ExternalEntity{}, actualExternalEntities)
 
 	index.AddGroup(groupType1, "group1", types.NewGroupSelector("default", nil, nil, &metav1.LabelSelector{MatchLabels: map[string]string{"app": "foo"}}, nil))
-	actualGroups, _ = index.GetGroupsForPod(podFoo1.Namespace, podFoo1.Name)
+	actualGroups, _ = index.GetGroupsForPod(podFoo1.Namespace, podFoo1.Name, nil)
 	assert.Equal(t, map[GroupType][]string{}, actualGroups)
 	actualGroups, _ = index.GetGroupsForExternalEntity(eeFoo1.Namespace, eeFoo1.Name)
 	assert.Equal(t, map[GroupType][]string{groupType1: {"group1"}}, actualGroups)
@@ -370,13 +371,13 @@ func TestGroupEntityIndexDeleteGroup(t *testing.T) {
 		index.AddGroup(group.groupType, group.groupName, group.groupSelector)
 	}
 
-	actualGroups, _ := index.GetGroupsForPod(podFoo1.Namespace, podFoo1.Name)
+	actualGroups, _ := index.GetGroupsForPod(podFoo1.Namespace, podFoo1.Name, nil)
 	assert.Equal(t, map[GroupType][]string{groupType1: {groupPodFooType1.groupName}, groupType2: {groupPodFooType2.groupName}}, actualGroups)
 	index.DeleteGroup(groupPodFooType1.groupType, groupPodFooType1.groupName)
-	actualGroups, _ = index.GetGroupsForPod(podFoo1.Namespace, podFoo1.Name)
+	actualGroups, _ = index.GetGroupsForPod(podFoo1.Namespace, podFoo1.Name, nil)
 	assert.Equal(t, map[GroupType][]string{groupType2: {groupPodFooType2.groupName}}, actualGroups)
 	index.DeleteGroup(groupPodFooType2.groupType, groupPodFooType2.groupName)
-	actualGroups, _ = index.GetGroupsForPod(podFoo1.Namespace, podFoo1.Name)
+	actualGroups, _ = index.GetGroupsForPod(podFoo1.Namespace, podFoo1.Name, nil)
 	assert.Equal(t, map[GroupType][]string{}, actualGroups)
 
 	actualGroups, _ = index.GetGroupsForExternalEntity(eeFoo1.Namespace, eeFoo1.Name)

--- a/pkg/controller/grouping/group_entity_index_test.go
+++ b/pkg/controller/grouping/group_entity_index_test.go
@@ -260,39 +260,39 @@ func TestGroupEntityIndexGetGroups(t *testing.T) {
 			expectedGroups: nil,
 		},
 	}
-	// podExclude filter tests: verify the filter parameter is honored.
+	// excludePod filter tests: verify the filter parameter is honored.
 	podExcludeTests := []struct {
-		name             string
-		inputPod         *v1.Pod
-		podExcludeFilter func(*v1.Pod) bool
-		expectedFound    bool
-		expectedGroups   map[GroupType][]string
+		name           string
+		inputPod       *v1.Pod
+		excludePod     func(*v1.Pod) bool
+		expectedFound  bool
+		expectedGroups map[GroupType][]string
 	}{
 		{
-			name:             "nil filter returns normal groups",
-			inputPod:         podFoo1,
-			podExcludeFilter: nil,
-			expectedFound:    true,
-			expectedGroups:   map[GroupType][]string{groupType1: {groupPodFooType1.groupName, groupPodFooAllNamespaceType1.groupName}, groupType2: {groupPodFooType2.groupName}},
+			name:           "nil filter returns normal groups",
+			inputPod:       podFoo1,
+			excludePod:     nil,
+			expectedFound:  true,
+			expectedGroups: map[GroupType][]string{groupType1: {groupPodFooType1.groupName, groupPodFooAllNamespaceType1.groupName}, groupType2: {groupPodFooType2.groupName}},
 		},
 		{
-			name:             "matching filter returns empty groups but pod found",
-			inputPod:         podFoo1,
-			podExcludeFilter: func(*v1.Pod) bool { return true },
-			expectedFound:    true,
-			expectedGroups:   map[GroupType][]string{},
+			name:           "matching filter returns nil groups but pod found",
+			inputPod:       podFoo1,
+			excludePod:     func(*v1.Pod) bool { return true },
+			expectedFound:  true,
+			expectedGroups: nil,
 		},
 		{
-			name:             "non-matching filter returns normal groups",
-			inputPod:         podFoo1,
-			podExcludeFilter: func(*v1.Pod) bool { return false },
-			expectedFound:    true,
-			expectedGroups:   map[GroupType][]string{groupType1: {groupPodFooType1.groupName, groupPodFooAllNamespaceType1.groupName}, groupType2: {groupPodFooType2.groupName}},
+			name:           "non-matching filter returns normal groups",
+			inputPod:       podFoo1,
+			excludePod:     func(*v1.Pod) bool { return false },
+			expectedFound:  true,
+			expectedGroups: map[GroupType][]string{groupType1: {groupPodFooType1.groupName, groupPodFooAllNamespaceType1.groupName}, groupType2: {groupPodFooType2.groupName}},
 		},
 	}
 	for _, tt := range podExcludeTests {
 		t.Run(tt.name, func(t *testing.T) {
-			actualGroups, actualFound := index.GetGroupsForPod(tt.inputPod.GetNamespace(), tt.inputPod.GetName(), tt.podExcludeFilter)
+			actualGroups, actualFound := index.GetGroupsForPod(tt.inputPod.GetNamespace(), tt.inputPod.GetName(), tt.excludePod)
 			assert.Equal(t, tt.expectedFound, actualFound)
 			assert.Equal(t, len(tt.expectedGroups), len(actualGroups))
 			for groupType, expected := range tt.expectedGroups {

--- a/pkg/controller/networkpolicy/clustergroup.go
+++ b/pkg/controller/networkpolicy/clustergroup.go
@@ -400,7 +400,7 @@ func (c *NetworkPolicyController) GetAssociatedGroups(name, namespace string) []
 		}
 	} else {
 		// Try Pod first, then ExternalEntity.
-		groups, _ = c.groupingInterface.GetGroupsForPod(namespace, name, NetworkPolicyExcludedPodFilter)
+		groups, _ = c.groupingInterface.GetGroupsForPod(namespace, name, AddressGroupExcludedPodFilter)
 		if len(groups) == 0 {
 			groups, _ = c.groupingInterface.GetGroupsForExternalEntity(namespace, name)
 			if len(groups) == 0 {

--- a/pkg/controller/networkpolicy/clustergroup.go
+++ b/pkg/controller/networkpolicy/clustergroup.go
@@ -400,7 +400,7 @@ func (c *NetworkPolicyController) GetAssociatedGroups(name, namespace string) []
 		}
 	} else {
 		// Try Pod first, then ExternalEntity.
-		groups, _ = c.groupingInterface.GetGroupsForPod(namespace, name)
+		groups, _ = c.groupingInterface.GetGroupsForPod(namespace, name, NetworkPolicyExcludedPodFilter)
 		if len(groups) == 0 {
 			groups, _ = c.groupingInterface.GetGroupsForExternalEntity(namespace, name)
 			if len(groups) == 0 {

--- a/pkg/controller/networkpolicy/crd_utils.go
+++ b/pkg/controller/networkpolicy/crd_utils.go
@@ -43,18 +43,17 @@ var (
 	}
 )
 
-// NetworkPolicyExcludedPodFilter is the canonical filter used by the NetworkPolicy controller
-// when deciding which Pods are subject to network policy enforcement. It returns true (exclude)
-// for any Pod that are:
-//   - Host-network Pods, which share the Node's network namespace, and the address can only be
-//     selected by nodeSelectors.
+// AddressGroupExcludedPodFilter returns true for Pods that are excluded from network policy
+// enforcement as address-group or internal-group members, and from group-association queries.
+// It excludes:
+//   - Host-network Pods, which share the Node's network namespace; their address can only be
+//     selected via nodeSelector, not podSelector.
 //   - Terminated Pods, whose IPs may be recycled and reassigned to new Pods.
 //   - Pods that have not yet received an IP address.
 //
-// The same filter is applied consistently across:
-//   - Group-membership computation (getMemberSetForGroupType)
-//   - Group-association queries (GetGroupsForPod via QueryNetworkPolicyRules and GetAssociatedGroups)
-var NetworkPolicyExcludedPodFilter = func(pod *v1.Pod) bool {
+// Note: AppliedToGroup membership uses a different filter (see syncAppliedToGroup) that also
+// excludes unscheduled Pods (NodeName == "") but does not check PodIPs.
+var AddressGroupExcludedPodFilter = func(pod *v1.Pod) bool {
 	return pod.Spec.HostNetwork || k8s.IsPodTerminated(pod) || len(pod.Status.PodIPs) == 0
 }
 

--- a/pkg/controller/networkpolicy/crd_utils.go
+++ b/pkg/controller/networkpolicy/crd_utils.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"time"
 
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/conversion"
 	"k8s.io/apimachinery/pkg/types"
@@ -41,6 +42,21 @@ var (
 		NamespaceSelector: &metav1.LabelSelector{},
 	}
 )
+
+// NetworkPolicyExcludedPodFilter is the canonical filter used by the NetworkPolicy controller
+// when deciding which Pods are subject to network policy enforcement. It returns true (exclude)
+// for any Pod that are:
+//   - Host-network Pods, which share the Node's network namespace, and the address can only be
+//     selected by nodeSelectors.
+//   - Terminated Pods, whose IPs may be recycled and reassigned to new Pods.
+//   - Pods that have not yet received an IP address.
+//
+// The same filter is applied consistently across:
+//   - Group-membership computation (getMemberSetForGroupType)
+//   - Group-association queries (GetGroupsForPod via QueryNetworkPolicyRules and GetAssociatedGroups)
+var NetworkPolicyExcludedPodFilter = func(pod *v1.Pod) bool {
+	return pod.Spec.HostNetwork || k8s.IsPodTerminated(pod) || len(pod.Status.PodIPs) == 0
+}
 
 // semanticIgnoreLastTransitionTime does semantic deep equality checks for
 // NetworkPolicyCondition but excludes LastTransitionTime. They are used when

--- a/pkg/controller/networkpolicy/crd_utils.go
+++ b/pkg/controller/networkpolicy/crd_utils.go
@@ -53,7 +53,7 @@ var (
 //
 // Note: AppliedToGroup membership uses a different filter (see syncAppliedToGroup) that also
 // excludes unscheduled Pods (NodeName == "") but does not check PodIPs.
-var AddressGroupExcludedPodFilter = func(pod *v1.Pod) bool {
+func AddressGroupExcludedPodFilter(pod *v1.Pod) bool {
 	return pod.Spec.HostNetwork || k8s.IsPodTerminated(pod) || len(pod.Status.PodIPs) == 0
 }
 

--- a/pkg/controller/networkpolicy/endpoint_querier.go
+++ b/pkg/controller/networkpolicy/endpoint_querier.go
@@ -103,7 +103,7 @@ func (eq *EndpointQuerierImpl) QueryNetworkPolicyRules(namespace, podName string
 	if namespace == "" {
 		namespace = "default"
 	}
-	groups, exists := eq.networkPolicyController.groupingInterface.GetGroupsForPod(namespace, podName, NetworkPolicyExcludedPodFilter)
+	groups, exists := eq.networkPolicyController.groupingInterface.GetGroupsForPod(namespace, podName, AddressGroupExcludedPodFilter)
 	if !exists {
 		return nil, nil
 	}

--- a/pkg/controller/networkpolicy/endpoint_querier.go
+++ b/pkg/controller/networkpolicy/endpoint_querier.go
@@ -103,7 +103,7 @@ func (eq *EndpointQuerierImpl) QueryNetworkPolicyRules(namespace, podName string
 	if namespace == "" {
 		namespace = "default"
 	}
-	groups, exists := eq.networkPolicyController.groupingInterface.GetGroupsForPod(namespace, podName)
+	groups, exists := eq.networkPolicyController.groupingInterface.GetGroupsForPod(namespace, podName, NetworkPolicyExcludedPodFilter)
 	if !exists {
 		return nil, nil
 	}

--- a/pkg/controller/networkpolicy/endpoint_querier_test.go
+++ b/pkg/controller/networkpolicy/endpoint_querier_test.go
@@ -59,6 +59,9 @@ var pods = []*corev1.Pod{
 				},
 			},
 			PodIP: "1.2.3.4",
+			PodIPs: []corev1.PodIP{
+				{IP: "1.2.3.4"},
+			},
 		},
 	},
 	{
@@ -81,6 +84,9 @@ var pods = []*corev1.Pod{
 				},
 			},
 			PodIP: "1.2.3.4",
+			PodIPs: []corev1.PodIP{
+				{IP: "1.2.3.4"},
+			},
 		},
 	},
 }
@@ -321,7 +327,6 @@ func TestQueryNetworkPolicyRules(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
 			endpointQuerier := makeControllerAndEndpointQuerier(tc.objs...)
 			response, err := endpointQuerier.QueryNetworkPolicyRules(tc.podNamespace, tc.podName)
 			require.NoErrorf(t, err, "Expected QueryNetworkPolicies to succeed")
@@ -593,6 +598,131 @@ func TestQueryNetworkPolicyEvaluation(t *testing.T) {
 				assert.ErrorContains(t, err, tc.expectedErr)
 			}
 
+		})
+	}
+}
+
+func TestQueryNetworkPolicyRulesPodsExclusion(t *testing.T) {
+	// Test that host network pods are excluded from policy evaluation
+	hostNetworkPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kube-apiserver",
+			Namespace: "kube-system",
+			Labels:    map[string]string{"component": "kube-apiserver", "tier": "control-plane"},
+		},
+		Spec: corev1.PodSpec{
+			HostNetwork: true,
+			Containers:  []corev1.Container{{Name: "kube-apiserver"}},
+			NodeName:    "master",
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			PodIP: "192.168.1.100",
+			PodIPs: []corev1.PodIP{
+				{IP: "192.168.1.100"},
+			},
+		},
+	}
+	// Test that terminated pods are excluded from policy evaluation
+	terminatedPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "terminated-pod",
+			Namespace: "default",
+			Labels:    map[string]string{"app": "test"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "test-container"}},
+			NodeName:   "worker",
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodSucceeded,
+			PodIP: "10.244.0.1",
+			PodIPs: []corev1.PodIP{
+				{IP: "10.244.0.1"},
+			},
+		},
+	}
+	// Test that pods without IPs are excluded from policy evaluation
+	podWithoutIP := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pending-pod",
+			Namespace: "default",
+			Labels:    map[string]string{"app": "test"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "test-container"}},
+			NodeName:   "worker",
+		},
+		Status: corev1.PodStatus{
+			Phase:  corev1.PodPending,
+			PodIPs: []corev1.PodIP{},
+		},
+	}
+
+	kubeSystemNS := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "kube-system",
+			Labels: map[string]string{"kubernetes.io/metadata.name": "kube-system"},
+		},
+	}
+	defaultNS := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "default",
+			Labels: map[string]string{"kubernetes.io/metadata.name": "default"},
+		},
+	}
+
+	testCases := []struct {
+		name             string
+		objs             []runtime.Object
+		podNamespace     string
+		podName          string
+		expectedResponse *antreatypes.EndpointNetworkPolicyRules
+	}{
+		{
+			name:         "Host network pod returns empty rules",
+			objs:         []runtime.Object{kubeSystemNS, hostNetworkPod},
+			podNamespace: "kube-system",
+			podName:      "kube-apiserver",
+			expectedResponse: &antreatypes.EndpointNetworkPolicyRules{
+				Namespace: "kube-system",
+				Name:      "kube-apiserver",
+			},
+		},
+		{
+			name:         "Terminated pod returns empty rules",
+			objs:         []runtime.Object{defaultNS, terminatedPod},
+			podNamespace: "default",
+			podName:      "terminated-pod",
+			expectedResponse: &antreatypes.EndpointNetworkPolicyRules{
+				Namespace: "default",
+				Name:      "terminated-pod",
+			},
+		},
+		{
+			name:         "Pod without IP returns empty rules",
+			objs:         []runtime.Object{defaultNS, podWithoutIP},
+			podNamespace: "default",
+			podName:      "pending-pod",
+			expectedResponse: &antreatypes.EndpointNetworkPolicyRules{
+				Namespace: "default",
+				Name:      "pending-pod",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			endpointQuerier := makeControllerAndEndpointQuerier(tc.objs...)
+			response, err := endpointQuerier.QueryNetworkPolicyRules(tc.podNamespace, tc.podName)
+			require.NoError(t, err)
+			require.NotNil(t, response, "excluded pod should return non-nil response, not a 404")
+			assert.Equal(t, tc.expectedResponse.Namespace, response.Namespace)
+			assert.Equal(t, tc.expectedResponse.Name, response.Name)
+			assert.Empty(t, response.AppliedPolicies)
+			assert.Empty(t, response.EndpointAsIngressSrcRules)
+			assert.Empty(t, response.EndpointAsEgressDstRules)
 		})
 	}
 }

--- a/pkg/controller/networkpolicy/endpoint_querier_test.go
+++ b/pkg/controller/networkpolicy/endpoint_querier_test.go
@@ -327,6 +327,7 @@ func TestQueryNetworkPolicyRules(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			endpointQuerier := makeControllerAndEndpointQuerier(tc.objs...)
 			response, err := endpointQuerier.QueryNetworkPolicyRules(tc.podNamespace, tc.podName)
 			require.NoErrorf(t, err, "Expected QueryNetworkPolicies to succeed")
@@ -612,15 +613,9 @@ func TestQueryNetworkPolicyRulesPodsExclusion(t *testing.T) {
 		},
 		Spec: corev1.PodSpec{
 			HostNetwork: true,
-			Containers:  []corev1.Container{{Name: "kube-apiserver"}},
-			NodeName:    "master",
 		},
 		Status: corev1.PodStatus{
-			Phase: corev1.PodRunning,
-			PodIP: "192.168.1.100",
-			PodIPs: []corev1.PodIP{
-				{IP: "192.168.1.100"},
-			},
+			PodIPs: []corev1.PodIP{{IP: "192.168.1.100"}},
 		},
 	}
 	// Test that terminated pods are excluded from policy evaluation
@@ -630,16 +625,9 @@ func TestQueryNetworkPolicyRulesPodsExclusion(t *testing.T) {
 			Namespace: "default",
 			Labels:    map[string]string{"app": "test"},
 		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{{Name: "test-container"}},
-			NodeName:   "worker",
-		},
 		Status: corev1.PodStatus{
-			Phase: corev1.PodSucceeded,
-			PodIP: "10.244.0.1",
-			PodIPs: []corev1.PodIP{
-				{IP: "10.244.0.1"},
-			},
+			Phase:  corev1.PodSucceeded,
+			PodIPs: []corev1.PodIP{{IP: "10.244.0.1"}},
 		},
 	}
 	// Test that pods without IPs are excluded from policy evaluation
@@ -648,14 +636,6 @@ func TestQueryNetworkPolicyRulesPodsExclusion(t *testing.T) {
 			Name:      "pending-pod",
 			Namespace: "default",
 			Labels:    map[string]string{"app": "test"},
-		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{{Name: "test-container"}},
-			NodeName:   "worker",
-		},
-		Status: corev1.PodStatus{
-			Phase:  corev1.PodPending,
-			PodIPs: []corev1.PodIP{},
 		},
 	}
 
@@ -717,7 +697,7 @@ func TestQueryNetworkPolicyRulesPodsExclusion(t *testing.T) {
 			endpointQuerier := makeControllerAndEndpointQuerier(tc.objs...)
 			response, err := endpointQuerier.QueryNetworkPolicyRules(tc.podNamespace, tc.podName)
 			require.NoError(t, err)
-			require.NotNil(t, response, "excluded pod should return non-nil response, not a 404")
+			require.NotNil(t, response)
 			assert.Equal(t, tc.expectedResponse.Namespace, response.Namespace)
 			assert.Equal(t, tc.expectedResponse.Name, response.Name)
 			assert.Empty(t, response.AppliedPolicies)

--- a/pkg/controller/networkpolicy/endpoint_querier_test.go
+++ b/pkg/controller/networkpolicy/endpoint_querier_test.go
@@ -604,12 +604,14 @@ func TestQueryNetworkPolicyEvaluation(t *testing.T) {
 }
 
 func TestQueryNetworkPolicyRulesPodsExclusion(t *testing.T) {
-	// Test that host network pods are excluded from policy evaluation
+	// Each pod has a matching NetworkPolicy in its namespace so that removing the exclusion
+	// filter would produce non-empty results. The tests validate that the filter excludes
+	// those results for host-network, terminated, and no-IP Pods respectively.
 	hostNetworkPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kube-apiserver",
 			Namespace: "kube-system",
-			Labels:    map[string]string{"component": "kube-apiserver", "tier": "control-plane"},
+			Labels:    map[string]string{"component": "kube-apiserver"},
 		},
 		Spec: corev1.PodSpec{
 			HostNetwork: true,
@@ -618,7 +620,6 @@ func TestQueryNetworkPolicyRulesPodsExclusion(t *testing.T) {
 			PodIPs: []corev1.PodIP{{IP: "192.168.1.100"}},
 		},
 	}
-	// Test that terminated pods are excluded from policy evaluation
 	terminatedPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "terminated-pod",
@@ -630,7 +631,6 @@ func TestQueryNetworkPolicyRulesPodsExclusion(t *testing.T) {
 			PodIPs: []corev1.PodIP{{IP: "10.244.0.1"}},
 		},
 	}
-	// Test that pods without IPs are excluded from policy evaluation
 	podWithoutIP := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "pending-pod",
@@ -652,54 +652,69 @@ func TestQueryNetworkPolicyRulesPodsExclusion(t *testing.T) {
 		},
 	}
 
+	// policySelectingKubeSystemPod selects the host-network Pod's labels.
+	policySelectingKubeSystemPod := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "select-kube-apiserver",
+			Namespace: "kube-system",
+			UID:       types.UID("uid-hn"),
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"component": "kube-apiserver"},
+			},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+		},
+	}
+	// policySelectingDefaultPod selects the terminated/no-IP Pod's labels.
+	policySelectingDefaultPod := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "select-test-pod",
+			Namespace: "default",
+			UID:       types.UID("uid-def"),
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "test"},
+			},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+		},
+	}
+
 	testCases := []struct {
-		name             string
-		objs             []runtime.Object
-		podNamespace     string
-		podName          string
-		expectedResponse *antreatypes.EndpointNetworkPolicyRules
+		name         string
+		objs         []runtime.Object
+		podNamespace string
+		podName      string
 	}{
 		{
 			name:         "Host network pod returns empty rules",
-			objs:         []runtime.Object{kubeSystemNS, hostNetworkPod},
+			objs:         []runtime.Object{kubeSystemNS, hostNetworkPod, policySelectingKubeSystemPod},
 			podNamespace: "kube-system",
 			podName:      "kube-apiserver",
-			expectedResponse: &antreatypes.EndpointNetworkPolicyRules{
-				Namespace: "kube-system",
-				Name:      "kube-apiserver",
-			},
 		},
 		{
 			name:         "Terminated pod returns empty rules",
-			objs:         []runtime.Object{defaultNS, terminatedPod},
+			objs:         []runtime.Object{defaultNS, terminatedPod, policySelectingDefaultPod},
 			podNamespace: "default",
 			podName:      "terminated-pod",
-			expectedResponse: &antreatypes.EndpointNetworkPolicyRules{
-				Namespace: "default",
-				Name:      "terminated-pod",
-			},
 		},
 		{
 			name:         "Pod without IP returns empty rules",
-			objs:         []runtime.Object{defaultNS, podWithoutIP},
+			objs:         []runtime.Object{defaultNS, podWithoutIP, policySelectingDefaultPod},
 			podNamespace: "default",
 			podName:      "pending-pod",
-			expectedResponse: &antreatypes.EndpointNetworkPolicyRules{
-				Namespace: "default",
-				Name:      "pending-pod",
-			},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
 			endpointQuerier := makeControllerAndEndpointQuerier(tc.objs...)
 			response, err := endpointQuerier.QueryNetworkPolicyRules(tc.podNamespace, tc.podName)
 			require.NoError(t, err)
 			require.NotNil(t, response)
-			assert.Equal(t, tc.expectedResponse.Namespace, response.Namespace)
-			assert.Equal(t, tc.expectedResponse.Name, response.Name)
+			assert.Equal(t, tc.podNamespace, response.Namespace)
+			assert.Equal(t, tc.podName, response.Name)
 			assert.Empty(t, response.AppliedPolicies)
 			assert.Empty(t, response.EndpointAsIngressSrcRules)
 			assert.Empty(t, response.EndpointAsEgressDstRules)

--- a/pkg/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller.go
@@ -1201,7 +1201,7 @@ func (n *NetworkPolicyController) getMemberSetForGroupType(groupType grouping.Gr
 	groupMemberSet := controlplane.GroupMemberSet{}
 	pods, externalEntities := n.groupingInterface.GetEntities(groupType, name)
 	for _, pod := range pods {
-		if NetworkPolicyExcludedPodFilter(pod) {
+		if AddressGroupExcludedPodFilter(pod) {
 			continue
 		}
 		groupMemberSet.Insert(podToGroupMember(pod, true))

--- a/pkg/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller.go
@@ -1201,9 +1201,7 @@ func (n *NetworkPolicyController) getMemberSetForGroupType(groupType grouping.Gr
 	groupMemberSet := controlplane.GroupMemberSet{}
 	pods, externalEntities := n.groupingInterface.GetEntities(groupType, name)
 	for _, pod := range pods {
-		// HostNetwork Pods should be excluded from group members: https://github.com/antrea-io/antrea/issues/3078.
-		// Terminated Pods should be excluded as their IPs can be recycled and used by other Pods.
-		if pod.Spec.HostNetwork || k8s.IsPodTerminated(pod) || len(pod.Status.PodIPs) == 0 {
+		if NetworkPolicyExcludedPodFilter(pod) {
 			continue
 		}
 		groupMemberSet.Insert(podToGroupMember(pod, true))


### PR DESCRIPTION
Fixes #8041 

For a host network Pod (like kube-apiserver), the API will now return no applicable policies instead of incorrectly showing ACNPs that don't actually affect the traffic, if the ACNP is not configured with nodeSelector but with podSelector that matches the host-network Pods' labels instead.