### PR TITLE
Add ClusterNetworkPolicy docs

### DIFF
--- a/docs/admin-network-policy.md
+++ b/docs/admin-network-policy.md
@@ -1,11 +1,19 @@
-# AdminNetworkPolicy API Support in Antrea
+# AdminNetworkPolicy API Support in Antrea (deprecated)
+
+**DEPRECATED**: This page documents the legacy v1alpha1 `AdminNetworkPolicy` and `BaselineAdminNetworkPolicy` APIs only.
+Antrea support for these APIs is deprecated.
+
+For the supported upstream cluster admin policy API, see
+[ClusterNetworkPolicy API Support in Antrea](cluster-network-policy.md) (v1alpha2 `ClusterNetworkPolicy`, enabled by the
+`ClusterNetworkPolicy` feature gate).
 
 ## Table of Contents
 
 <!-- toc -->
 - [Introduction](#introduction)
 - [Prerequisites](#prerequisites)
-- [Usage](#usage)
+- [Migration to ClusterNetworkPolicy](#migration-to-clusternetworkpolicy)
+- [Legacy usage](#legacy-usage)
   - [Sample specs for AdminNetworkPolicy and BaselineAdminNetworkPolicy](#sample-specs-for-adminnetworkpolicy-and-baselineadminnetworkpolicy)
   - [Relationship with Antrea-native Policies](#relationship-with-antrea-native-policies)
 <!-- /toc -->
@@ -19,14 +27,18 @@ The Network Policy API working group (subproject of Kubernetes SIG-Network) has 
 [AdminNetworkPolicy APIs](https://network-policy-api.sigs.k8s.io/api-overview/) which aims to solve the cluster admin
 policy usecases.
 
-Starting with v1.13, Antrea supports the `AdminNetworkPolicy` and `BaselineAdminNetworkPolicy` API types, except for
-advanced Namespace selection mechanisms (namely `sameLabels` and `notSameLabels` rules) which are still in the
+Starting with v1.13, Antrea supported the v1alpha1 `AdminNetworkPolicy` and `BaselineAdminNetworkPolicy` API types,
+except for advanced Namespace selection mechanisms (namely `sameLabels` and `notSameLabels` rules) which were still in the
 experimental phase and not required as part of conformance.
+
+**The v1alpha1 APIs have been deprecated upstream and replaced with the v1alpha2 `ClusterNetworkPolicy` API.** Users
+should migrate to the new API; see [ClusterNetworkPolicy API Support in Antrea](cluster-network-policy.md).
 
 ## Prerequisites
 
-AdminNetworkPolicy was introduced in v1.13 as an alpha feature and is disabled by default. A feature gate,
-`AdminNetworkPolicy`, must be enabled in antrea-controller.conf in the `antrea-config` ConfigMap when Antrea is deployed:
+**Legacy configuration only.** AdminNetworkPolicy was introduced in v1.13 as an alpha feature and is disabled by default.
+Feature gate `AdminNetworkPolicy` must be enabled in antrea-controller.conf in the `antrea-config` ConfigMap when Antrea
+is deployed:
 
 ```yaml
 apiVersion: v1
@@ -46,7 +58,52 @@ enabled by default since Antrea v1.0.
 In addition, the AdminNetworkPolicy CRD types need to be installed in the K8s cluster.
 Refer to [this document](https://network-policy-api.sigs.k8s.io/getting-started/) for more information.
 
-## Usage
+## Migration to ClusterNetworkPolicy
+
+**Action Required**: Users should migrate from the deprecated v1alpha1 `AdminNetworkPolicy` and `BaselineAdminNetworkPolicy`
+resources to the v1alpha2 `ClusterNetworkPolicy` resource. For prerequisites, sample policies, and precedence with
+Antrea-native policies, read [ClusterNetworkPolicy API Support in Antrea](cluster-network-policy.md).
+
+To migrate:
+
+1. **Enable the new feature gate**: Update your `antrea-controller.conf` to enable the `ClusterNetworkPolicy` feature gate:
+
+   ```yaml
+   apiVersion: v1
+   kind: ConfigMap
+   metadata:
+     name: antrea-config
+     namespace: kube-system
+   data:
+     antrea-controller.conf: |
+       featureGates:
+         ClusterNetworkPolicy: true
+   ```
+
+2. **Install v1alpha2 CRDs**: Ensure the v1alpha2 `ClusterNetworkPolicy` CRDs are installed in your cluster.
+   Refer to the [network-policy-api documentation](https://network-policy-api.sigs.k8s.io/) for installation instructions.
+
+3. **Convert your policies**: The v1alpha2 `ClusterNetworkPolicy` API unifies the functionality of `AdminNetworkPolicy`
+   and `BaselineAdminNetworkPolicy`. Key differences include:
+   - Single resource type for both admin and baseline policies
+   - Simplified tier-based priority system (Admin tier or Baseline tier)
+   - Updated field names and structure
+
+   Refer to the [network-policy-api v1alpha2 specification](https://network-policy-api.sigs.k8s.io/reference/spec/)
+   for detailed information on the new API structure.
+
+4. **Test and validate**: Test your converted policies in a non-production environment before rolling out to production.
+
+5. **Remove old policies**: Once you've verified the new `ClusterNetworkPolicy` resources work correctly, you can:
+   - Delete the old v1alpha1 `AdminNetworkPolicy` and `BaselineAdminNetworkPolicy` resources
+   - Disable the deprecated `AdminNetworkPolicy` feature gate
+
+**Timeline**: The `AdminNetworkPolicy` feature gate will be removed in two releases after Antrea v2.7.
+
+## Legacy usage
+
+The following applies only if you still run the deprecated v1alpha1 APIs with the `AdminNetworkPolicy` feature gate
+enabled.
 
 ### Sample specs for AdminNetworkPolicy and BaselineAdminNetworkPolicy
 
@@ -105,7 +162,7 @@ compared to other policy objects. The following diagram describes the relative p
 API types and Antrea-native policy types:
 
 ```text
-Antrea-native Policies (tier != baseline) > 
+Antrea-native Policies (tier != baseline) >
 AdminNetworkPolicies                      >
 K8s NetworkPolicies                       >
 Antrea-native Policies (tier == baseline) >

--- a/docs/admin-network-policy.md
+++ b/docs/admin-network-policy.md
@@ -64,9 +64,17 @@ Refer to [this document](https://network-policy-api.sigs.k8s.io/getting-started/
 resources to the v1alpha2 `ClusterNetworkPolicy` resource. For prerequisites, sample policies, and precedence with
 Antrea-native policies, read [ClusterNetworkPolicy API Support in Antrea](cluster-network-policy.md).
 
+**No automatic migration**: Antrea does **not** automatically convert or migrate v1alpha1 `AdminNetworkPolicy` and
+`BaselineAdminNetworkPolicy` objects to v1alpha2 `ClusterNetworkPolicy`. You must manually create the equivalent
+`ClusterNetworkPolicy` resources and delete the old ones. The two feature gates (`AdminNetworkPolicy` and
+`ClusterNetworkPolicy`) are independent; you can run both APIs simultaneously during a migration window to avoid a
+policy enforcement gap.
+
 To migrate:
 
-1. **Enable the new feature gate**: Update your `antrea-controller.conf` to enable the `ClusterNetworkPolicy` feature gate:
+1. **Enable the new feature gate**: Update your `antrea-controller.conf` to enable the `ClusterNetworkPolicy` feature
+   gate. You may keep the `AdminNetworkPolicy` gate enabled during migration so that existing policies continue to be
+   enforced while you create the equivalent `ClusterNetworkPolicy` resources.
 
    ```yaml
    apiVersion: v1
@@ -77,26 +85,30 @@ To migrate:
    data:
      antrea-controller.conf: |
        featureGates:
-         ClusterNetworkPolicy: true
+         ClusterNetworkPolicy: true   # enable the new API
+         AdminNetworkPolicy: true     # keep during migration; can be remove once migration is complete
    ```
 
 2. **Install v1alpha2 CRDs**: Ensure the v1alpha2 `ClusterNetworkPolicy` CRDs are installed in your cluster.
-   Refer to the [network-policy-api documentation](https://network-policy-api.sigs.k8s.io/) for installation instructions.
+   Refer to the [network-policy-api documentation](https://network-policy-api.sigs.k8s.io/getting-started/) for installation instructions.
 
-3. **Convert your policies**: The v1alpha2 `ClusterNetworkPolicy` API unifies the functionality of `AdminNetworkPolicy`
+3. **Rewrite your policies**: The v1alpha2 `ClusterNetworkPolicy` API unifies the functionality of `AdminNetworkPolicy`
    and `BaselineAdminNetworkPolicy`. Key differences include:
-   - Single resource type for both admin and baseline policies
-   - Simplified tier-based priority system (Admin tier or Baseline tier)
-   - Updated field names and structure
+   - Single resource type for both admin and baseline policies: use `spec.tier: Admin` for admin posture and
+     `spec.tier: Baseline` for baseline posture (replaces the singleton `BaselineAdminNetworkPolicy` named `default`).
+   - Updated field names and structure; see the
+     [Key differences section in the ClusterNetworkPolicy doc](cluster-network-policy.md#key-differences-from-v1alpha1-adminnetworkpolicy-apis).
 
    Refer to the [network-policy-api v1alpha2 specification](https://network-policy-api.sigs.k8s.io/reference/spec/)
-   for detailed information on the new API structure.
+   for the full API structure.
 
-4. **Test and validate**: Test your converted policies in a non-production environment before rolling out to production.
+4. **Test and validate**: Create the equivalent `ClusterNetworkPolicy` resources and verify they behave as expected
+   in a non-production environment before removing the old policies in production.
 
-5. **Remove old policies**: Once you've verified the new `ClusterNetworkPolicy` resources work correctly, you can:
-   - Delete the old v1alpha1 `AdminNetworkPolicy` and `BaselineAdminNetworkPolicy` resources
-   - Disable the deprecated `AdminNetworkPolicy` feature gate
+5. **Remove old policies and disable the deprecated gate**: Once you have verified the new `ClusterNetworkPolicy`
+   resources work correctly:
+   - Delete the old v1alpha1 `AdminNetworkPolicy` and `BaselineAdminNetworkPolicy` resources.
+   - [Optional] Remove or set `AdminNetworkPolicy: false` in your `antrea-controller.conf` and restart Antrea controler.
 
 **Timeline**: The `AdminNetworkPolicy` feature gate will be removed in two releases after Antrea v2.7.
 

--- a/docs/admin-network-policy.md
+++ b/docs/admin-network-policy.md
@@ -27,8 +27,8 @@ The Network Policy API working group (subproject of Kubernetes SIG-Network) has 
 [AdminNetworkPolicy APIs](https://network-policy-api.sigs.k8s.io/api-overview/) which aims to solve the cluster admin
 policy usecases.
 
-Starting with v1.13, Antrea supported the v1alpha1 `AdminNetworkPolicy` and `BaselineAdminNetworkPolicy` API types,
-except for advanced Namespace selection mechanisms (namely `sameLabels` and `notSameLabels` rules) which were still in the
+Starting with v1.13, Antrea supports the `AdminNetworkPolicy` and `BaselineAdminNetworkPolicy` API types, except for
+advanced Namespace selection mechanisms (namely `sameLabels` and `notSameLabels` rules) which are still in the
 experimental phase and not required as part of conformance.
 
 **The v1alpha1 APIs have been deprecated upstream and replaced with the v1alpha2 `ClusterNetworkPolicy` API.** Users
@@ -86,13 +86,18 @@ To migrate:
      antrea-controller.conf: |
        featureGates:
          ClusterNetworkPolicy: true   # enable the new API
-         AdminNetworkPolicy: true     # keep during migration; can be remove once migration is complete
+         AdminNetworkPolicy: true     # keep during migration; can be removed once migration is complete
    ```
 
 2. **Install v1alpha2 CRDs**: Ensure the v1alpha2 `ClusterNetworkPolicy` CRDs are installed in your cluster.
    Refer to the [network-policy-api documentation](https://network-policy-api.sigs.k8s.io/getting-started/) for installation instructions.
 
-3. **Rewrite your policies**: The v1alpha2 `ClusterNetworkPolicy` API unifies the functionality of `AdminNetworkPolicy`
+3. **Ensure no custom Tiers are present at priority 220**: ClusterNetworkPolicies with `tier: Admin` are created in
+   Antrea Tier priority 220, which must not be occupied by a custom Tier. See the
+   [Tier Priority Reservation and Conflict Handling section](cluster-network-policy.md#tier-priority-reservation-and-conflict-handling)
+   for more details.
+
+4. **Rewrite your policies**: The v1alpha2 `ClusterNetworkPolicy` API unifies the functionality of `AdminNetworkPolicy`
    and `BaselineAdminNetworkPolicy`. Key differences include:
    - Single resource type for both admin and baseline policies: use `spec.tier: Admin` for admin posture and
      `spec.tier: Baseline` for baseline posture (replaces the singleton `BaselineAdminNetworkPolicy` named `default`).
@@ -102,13 +107,13 @@ To migrate:
    Refer to the [network-policy-api v1alpha2 specification](https://network-policy-api.sigs.k8s.io/reference/spec/)
    for the full API structure.
 
-4. **Test and validate**: Create the equivalent `ClusterNetworkPolicy` resources and verify they behave as expected
+5. **Test and validate**: Create the equivalent `ClusterNetworkPolicy` resources and verify they behave as expected
    in a non-production environment before removing the old policies in production.
 
-5. **Remove old policies and disable the deprecated gate**: Once you have verified the new `ClusterNetworkPolicy`
+6. **Remove old policies and disable the deprecated gate**: Once you have verified the new `ClusterNetworkPolicy`
    resources work correctly:
    - Delete the old v1alpha1 `AdminNetworkPolicy` and `BaselineAdminNetworkPolicy` resources.
-   - [Optional] Remove or set `AdminNetworkPolicy: false` in your `antrea-controller.conf` and restart Antrea controler.
+   - [Optional] Remove or set `AdminNetworkPolicy: false` in your `antrea-controller.conf` and restart Antrea controller.
 
 **Timeline**: The `AdminNetworkPolicy` feature gate will be removed in two releases after Antrea v2.7.
 

--- a/docs/cluster-network-policy.md
+++ b/docs/cluster-network-policy.md
@@ -1,0 +1,148 @@
+# ClusterNetworkPolicy API Support in Antrea
+
+This document describes Antrea support for the upstream Kubernetes
+[`ClusterNetworkPolicy`](https://network-policy-api.sigs.k8s.io/) API (`policy.networking.k8s.io/v1alpha2`). It is
+different from the Antrea-native `ClusterNetworkPolicy` CRD (`crd.antrea.io/v1beta1`), which is documented in
+[Antrea Network Policy CRDs](antrea-network-policy.md#antrea-clusternetworkpolicy) as **Antrea ClusterNetworkPolicy
+(ACNP)**.
+
+## Table of Contents
+
+<!-- toc -->
+- [Introduction](#introduction)
+- [Prerequisites](#prerequisites)
+  - [Install upstream CRDs](#install-upstream-crds)
+- [Key differences from v1alpha1 AdminNetworkPolicy APIs](#key-differences-from-v1alpha1-adminnetworkpolicy-apis)
+- [Usage](#usage)
+  - [Sample ClusterNetworkPolicy specs](#sample-clusternetworkpolicy-specs)
+  - [Relationship with Antrea-native Policies](#relationship-with-antrea-native-policies)
+<!-- /toc -->
+
+## Introduction
+
+The [network-policy-api](https://github.com/kubernetes-sigs/network-policy-api) project defines cluster-wide policies for
+cluster administrators. The v1alpha2 `ClusterNetworkPolicy` resource replaces the deprecated v1alpha1
+`AdminNetworkPolicy` and `BaselineAdminNetworkPolicy` types with a single API, an explicit **Admin** or **Baseline**
+tier, and rule actions **Accept**, **Deny**, and **Pass**.
+
+When the `ClusterNetworkPolicy` feature gate is enabled, the Antrea Controller translates each upstream
+`ClusterNetworkPolicy` into Antrea's internal NetworkPolicy representation for enforcement in the dataplane.
+
+## Prerequisites
+
+`ClusterNetworkPolicy` was introduced as an Antrea Controller alpha feature in v2.7 and is disabled by default. Enable
+the `ClusterNetworkPolicy` feature gate in `antrea-controller.conf` in the `antrea-config` ConfigMap:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: antrea-config
+  namespace: kube-system
+data:
+  antrea-controller.conf: |
+    featureGates:
+      ClusterNetworkPolicy: true
+```
+
+Note: The `ClusterNetworkPolicy` feature requires the `AntreaPolicy` feature gate to be set to `true`, which is enabled by
+default since Antrea v1.0.
+
+### Install upstream CRDs
+
+Install the Custom Resource Definitions from the [network-policy-api documentation](https://network-policy-api.sigs.k8s.io/).
+
+For the v0.2.0 released version of ClusterNetworkPolicy, install via
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/network-policy-api/v0.2.0/config/crd/experimental/policy.networking.k8s.io_clusternetworkpolicies.yaml
+```
+
+## Key differences from v1alpha1 AdminNetworkPolicy APIs
+
+If you are familiar with the deprecated v1alpha1 APIs described in
+[AdminNetworkPolicy API Support in Antrea (deprecated)](admin-network-policy.md), the v1alpha2 model differs in several
+ways:
+
+- **Single resource**: One `ClusterNetworkPolicy` object replaces separate `AdminNetworkPolicy` and
+  `BaselineAdminNetworkPolicy` resources. Baseline posture is expressed with `spec.tier: Baseline` instead of a distinct
+  kind and singleton name.
+- **Tier field**: `spec.tier` is either `Admin` or `Baseline`, aligning with the upstream tier model.
+- **Actions**: `Accept`, `Deny`, and `Pass` replace the v1alpha1 action sets; Antrea maps **Accept** to allow, **Deny**
+  to drop, and **Pass** to pass-through for further evaluation in the Antrea pipeline.
+- **Rule structure**: Ingress and egress rules use the v1alpha2 peer and `protocols` shapes (including TCP/UDP/SCTP
+  destination ports, port ranges, and named ports). Egress peers can include pods, namespaces, nodes, CIDR
+  **networks**, and **domain names** as defined upstream.
+
+## Usage
+
+### Sample ClusterNetworkPolicy specs
+
+Refer to the [examples](https://network-policy-api.sigs.k8s.io/reference/examples/) published with network-policy-api.
+Below are minimal illustrations analogous to the legacy v1alpha1 samples in
+[AdminNetworkPolicy API Support in Antrea (deprecated)](admin-network-policy.md#sample-specs-for-adminnetworkpolicy-and-baselineadminnetworkpolicy).
+
+Admin-tier deny ingress to Pods in selected Namespaces from all Namespaces:
+
+```yaml
+apiVersion: policy.networking.k8s.io/v1alpha2
+kind: ClusterNetworkPolicy
+metadata:
+  name: cluster-wide-deny-example
+spec:
+  tier: Admin
+  priority: 10
+  subject:
+    namespaces:
+      matchLabels:
+        kubernetes.io/metadata.name: sensitive-ns
+  ingress:
+    - action: Deny
+      name: select-all-deny-all
+      from:
+        - namespaces: {}
+```
+
+Baseline-tier default deny (compare to the legacy `BaselineAdminNetworkPolicy` named `default`):
+
+```yaml
+apiVersion: policy.networking.k8s.io/v1alpha2
+kind: ClusterNetworkPolicy
+metadata:
+  name: default-baseline-deny
+spec:
+  tier: Baseline
+  priority: 10
+  subject:
+    namespaces: {}
+  ingress:
+    - action: Deny
+      name: default-deny-all
+      from:
+        - namespaces: {}
+```
+
+### Relationship with Antrea-native Policies
+
+Upstream `ClusterNetworkPolicy` objects and Antrea-native policies can co-exist in the same cluster. Upstream policies
+provide portable, CNI-agnostic guardrails; Antrea-native `AntreaClusterNetworkPolicy` and `AntreaNetworkPolicy` offer a
+richer feature set (for example FQDN rules beyond upstream domain peer types, node selectors, and L7 rules). See
+[Antrea Network Policy CRDs](antrea-network-policy.md) and [L7 policy](antrea-l7-network-policy.md) for details.
+
+Both upstream `ClusterNetworkPolicy` and Antrea-native policies use a `priority` field within a tier to order rules.
+The following diagram summarizes how Antrea orders **upstream** `ClusterNetworkPolicy` tiers relative to Antrea-native
+tiers and Kubernetes `NetworkPolicy` (consistent with the legacy Admin/Baseline model):
+
+```text
+Antrea-native Policies (tier != baseline) >
+ClusterNetworkPolicy (Admin tier)         >
+K8s NetworkPolicies                       >
+Antrea-native Policies (tier == baseline) >
+ClusterNetworkPolicy (Baseline tier)
+```
+
+In other words, Antrea-native policies that are not in the `baseline` tier are evaluated before any upstream
+`ClusterNetworkPolicy` in the **Admin** tier. Admin-tier upstream policies are evaluated before Kubernetes
+`NetworkPolicy`. Baseline-tier Antrea-native policies are evaluated before upstream **Baseline** tier
+`ClusterNetworkPolicy` objects. For more detail on Antrea-native ordering, see
+[Antrea-native policy ordering based on priorities](antrea-network-policy.md#antrea-native-policy-ordering-based-on-priorities).

--- a/docs/cluster-network-policy.md
+++ b/docs/cluster-network-policy.md
@@ -13,9 +13,12 @@ different from the Antrea-native `ClusterNetworkPolicy` CRD (`crd.antrea.io/v1be
 - [Prerequisites](#prerequisites)
   - [Install upstream CRDs](#install-upstream-crds)
 - [Key differences from v1alpha1 AdminNetworkPolicy APIs](#key-differences-from-v1alpha1-adminnetworkpolicy-apis)
+- [Relationship with Antrea-native Policies](#relationship-with-antrea-native-policies)
+- [Tier Priority Reservation and Conflict Handling](#tier-priority-reservation-and-conflict-handling)
+  - [Reserved Tier Priority](#reserved-tier-priority)
+  - [Enabling the Feature Gate When a Custom Tier Exists at Priority 220](#enabling-the-feature-gate-when-a-custom-tier-exists-at-priority-220)
 - [Usage](#usage)
   - [Sample ClusterNetworkPolicy specs](#sample-clusternetworkpolicy-specs)
-  - [Relationship with Antrea-native Policies](#relationship-with-antrea-native-policies)
 <!-- /toc -->
 
 ## Introduction
@@ -50,7 +53,7 @@ default since Antrea v1.0.
 
 ### Install upstream CRDs
 
-Install the Custom Resource Definitions from the [network-policy-api documentation](https://network-policy-api.sigs.k8s.io/).
+Install the Custom Resource Definitions from the [network-policy-api documentation](https://network-policy-api.sigs.k8s.io/getting-started/).
 
 For the v0.2.0 released version of ClusterNetworkPolicy, install via
 
@@ -73,6 +76,87 @@ ways:
 - **Rule structure**: Ingress and egress rules use the v1alpha2 peer and `protocols` shapes (including TCP/UDP/SCTP
   destination ports, port ranges, and named ports). Egress peers can include pods, namespaces, nodes, CIDR
   **networks**, and **domain names** as defined upstream.
+
+## Relationship with Antrea-native Policies
+
+Upstream `ClusterNetworkPolicy` objects and Antrea-native policies can co-exist in the same cluster. Upstream policies
+provide portable, CNI-agnostic guardrails; Antrea-native `AntreaClusterNetworkPolicy` and `AntreaNetworkPolicy` offer a
+richer feature set (for example FQDN rules beyond upstream domain peer types, node selectors, and L7 rules). See
+[Antrea Network Policy CRDs](antrea-network-policy.md) and [L7 policy](antrea-l7-network-policy.md) for details.
+
+Both upstream `ClusterNetworkPolicy` and Antrea-native policies use a `priority` field within a tier to order rules.
+The following diagram summarizes how Antrea orders **upstream** `ClusterNetworkPolicy` tiers relative to Antrea-native
+Tiers and Kubernetes `NetworkPolicy`, in the order of precedence:
+
+```text
+Antrea-native Policies, Tier priority higher than 220 (smaller numeric value)  >
+ClusterNetworkPolicy, Admin tier (inherent tier priority == 220)               >
+Antrea-native Policies, Tier priority lower than 220 (bigger numeric value)    >
+K8s NetworkPolicies                                                            >
+Antrea-native Policies, Tier == baseline                                       >
+ClusterNetworkPolicy, Baseline tier
+```
+
+This tiering model enables cluster admins to create upstream ClusterNetworkPolicies that cannot be overridden by any
+Application Tier (priority 250) Antrea-native policies (which presumably can be created by namespace admins), while at
+the same time ensuring higher priority Antrea Tiers like the Platform Tier (priority 200) remains authoritative compared
+to the upstream ClusterNetworkPolicy resource.
+
+For more detail on Antrea-native policy ordering, see [Antrea-native policy ordering based on priorities](antrea-network-policy.md#antrea-native-policy-ordering-based-on-priorities).
+
+## Tier Priority Reservation and Conflict Handling
+
+### Reserved Tier Priority
+
+When the `ClusterNetworkPolicy` feature gate is enabled, Antrea reserves Antrea Tier priority **220** for upstream
+ClusterNetworkPolicy's Admin tier. This priority places upstream CNPs between the Antrea-native Platform Tier
+(priority 200) and the Application Tier (priority 250), as shown in the precedence diagram in
+[Relationship with Antrea-native Policies](#relationship-with-antrea-native-policies) above.
+
+Two enforcement mechanisms protect priority 220:
+
+- **Tier creation**: the Antrea admission webhook rejects any new attempt to create a user-defined Antrea Tier at
+  priority 220 while the feature gate is enabled.
+- **ClusterNetworkPolicy creation**: if a conflicting Tier at priority 220 already exists in the cluster (see below),
+  the Antrea admission webhook rejects all new ClusterNetworkPolicy `CREATE` requests with an error such as:
+
+  ```text
+  ClusterNetworkPolicy creation is blocked: a user-created Tier at priority 220 (cnpAdminTierPriority) already
+  exists; the Tier and its associated policies must be deleted/migrated first before a ClusterNetworkPolicy can
+  be created
+  ```
+
+### Enabling the Feature Gate When a Custom Tier Exists at Priority 220
+
+If you already have a custom Antrea Tier at priority 220 when you enable the `ClusterNetworkPolicy` feature gate,
+Antrea detects the conflict on startup and immediately blocks all new ClusterNetworkPolicy `CREATE` requests (via the
+webhook above). Existing Antrea-native policies (ACNPs/ANNPs) in that Tier are **unaffected** — they continue to be
+enforced.
+
+To resolve the conflict and unblock ClusterNetworkPolicy creation, you must migrate your custom Tier away from priority
+220. Two constraints govern the migration:
+
+- **Tier priority cannot be updated in-place**: the Antrea admission webhook rejects any change to a Tier's
+  `spec.priority`.
+- **A Tier with associated policies cannot be deleted**: the Antrea admission webhook blocks deletion of a Tier
+  that still has ACNPs or ANNPs referencing it.
+
+The migration procedure is therefore:
+
+1. **Decide the new priority** for your custom Tier. Choose a value *lower* than 220 (e.g. 215) if you want your
+   Tier to take precedence *over* upstream CNPs, or a value *higher* than 220 (e.g. 225) if you want upstream CNPs
+   to take precedence.
+2. **Delete all Antrea-native policies** (ACNPs and ANNPs) that reference that Tier currently at priority 220.
+3. **Delete the Tier** (allowed once no policies reference it).
+4. **Recreate the Tier** at the new priority.
+5. **Recreate the policies** referencing the new Tier.
+
+Once the conflicting Tier at priority 220 is removed, Antrea re-allows ClusterNetworkPolicy creation immediately.
+
+If the `ClusterNetworkPolicy` feature gate is **not enabled**, priority 220 is not reserved and no restriction is
+placed on creating or maintaining a custom Antrea Tier at that priority. However, if you plan to enable the feature
+gate in the future and already have a Tier at priority 220, you should proactively migrate it (following the steps
+above) to avoid the conflict when the gate is eventually enabled.
 
 ## Usage
 
@@ -121,28 +205,3 @@ spec:
       from:
         - namespaces: {}
 ```
-
-### Relationship with Antrea-native Policies
-
-Upstream `ClusterNetworkPolicy` objects and Antrea-native policies can co-exist in the same cluster. Upstream policies
-provide portable, CNI-agnostic guardrails; Antrea-native `AntreaClusterNetworkPolicy` and `AntreaNetworkPolicy` offer a
-richer feature set (for example FQDN rules beyond upstream domain peer types, node selectors, and L7 rules). See
-[Antrea Network Policy CRDs](antrea-network-policy.md) and [L7 policy](antrea-l7-network-policy.md) for details.
-
-Both upstream `ClusterNetworkPolicy` and Antrea-native policies use a `priority` field within a tier to order rules.
-The following diagram summarizes how Antrea orders **upstream** `ClusterNetworkPolicy` tiers relative to Antrea-native
-tiers and Kubernetes `NetworkPolicy` (consistent with the legacy Admin/Baseline model):
-
-```text
-Antrea-native Policies (tier != baseline) >
-ClusterNetworkPolicy (Admin tier)         >
-K8s NetworkPolicies                       >
-Antrea-native Policies (tier == baseline) >
-ClusterNetworkPolicy (Baseline tier)
-```
-
-In other words, Antrea-native policies that are not in the `baseline` tier are evaluated before any upstream
-`ClusterNetworkPolicy` in the **Admin** tier. Admin-tier upstream policies are evaluated before Kubernetes
-`NetworkPolicy`. Baseline-tier Antrea-native policies are evaluated before upstream **Baseline** tier
-`ClusterNetworkPolicy` objects. For more detail on Antrea-native ordering, see
-[Antrea-native policy ordering based on priorities](antrea-network-policy.md#antrea-native-policy-ordering-based-on-priorities).

--- a/docs/cluster-network-policy.md
+++ b/docs/cluster-network-policy.md
@@ -81,8 +81,9 @@ ways:
 
 Upstream `ClusterNetworkPolicy` objects and Antrea-native policies can co-exist in the same cluster. Upstream policies
 provide portable, CNI-agnostic guardrails; Antrea-native `AntreaClusterNetworkPolicy` and `AntreaNetworkPolicy` offer a
-richer feature set (for example FQDN rules beyond upstream domain peer types, node selectors, and L7 rules). See
-[Antrea Network Policy CRDs](antrea-network-policy.md) and [L7 policy](antrea-l7-network-policy.md) for details.
+richer feature set (for example FQDN rules beyond upstream domain peer types, node selectors, user-defined tiers and
+L7 rules). See [Antrea Network Policy CRDs](antrea-network-policy.md) and [L7 policy](antrea-l7-network-policy.md) for
+details.
 
 Both upstream `ClusterNetworkPolicy` and Antrea-native policies use a `priority` field within a tier to order rules.
 The following diagram summarizes how Antrea orders **upstream** `ClusterNetworkPolicy` tiers relative to Antrea-native
@@ -128,7 +129,8 @@ Two enforcement mechanisms protect priority 220:
 
 ### Enabling the Feature Gate When a Custom Tier Exists at Priority 220
 
-If you already have a custom Antrea Tier at priority 220 when you enable the `ClusterNetworkPolicy` feature gate,
+If you already have a custom Antrea Tier at priority 220 when you enable the `ClusterNetworkPolicy` feature gate
+(you can check via `kubectl get tier`, which will display all the current Tiers and their respective priorities),
 Antrea detects the conflict on startup and immediately blocks all new ClusterNetworkPolicy `CREATE` requests (via the
 webhook above). Existing Antrea-native policies (ACNPs/ANNPs) in that Tier are **unaffected** — they continue to be
 enforced.

--- a/docs/feature-gates.md
+++ b/docs/feature-gates.md
@@ -56,7 +56,8 @@ edit the Agent configuration in the
 | `ExternalNode`                  | Agent              | `false` | Alpha      | v1.8          | N/A          | N/A        | Yes                |                                                        |
 | `SupportBundleCollection`       | Agent + Controller | `false` | Alpha      | v1.10         | N/A          | N/A        | Yes                |                                                        |
 | `L7NetworkPolicy`               | Agent + Controller | `false` | Alpha      | v1.10         | N/A          | N/A        | Yes                |                                                        |
-| `AdminNetworkPolicy`            | Controller         | `false` | Alpha      | v1.13         | N/A          | N/A        | Yes                |                                                        |
+| `AdminNetworkPolicy`            | Controller         | `false` | Alpha      | v1.13         | N/A          | N/A        | Yes                | **Deprecated**: Use `ClusterNetworkPolicy` instead     |
+| `ClusterNetworkPolicy`          | Controller         | `false` | Alpha      | v2.7          | N/A          | N/A        | Yes                | Successor to `AdminNetworkPolicy`                      |
 | `EgressTrafficShaping`          | Agent              | `false` | Alpha      | v1.14         | N/A          | N/A        | Yes                | OVS meters should be supported                         |
 | `EgressSeparateSubnet`          | Agent              | `true`  | Beta       | v1.15         | v2.3         | N/A        | No                 |                                                        |
 | `NodeNetworkPolicy`             | Agent              | `false` | Alpha      | v1.15         | N/A          | N/A        | Yes                |                                                        |
@@ -430,8 +431,28 @@ this [document](antrea-l7-network-policy.md#prerequisites) for more information 
 
 ### AdminNetworkPolicy
 
-The `AdminNetworkPolicy` API (which currently includes the AdminNetworkPolicy and BaselineAdminNetworkPolicy objects)
-complements the Antrea-native policies and help cluster administrators to set security postures in a portable manner.
+**DEPRECATED**: The `AdminNetworkPolicy` feature gate is deprecated and will be removed in two releases after v2.7.
+Users should migrate to the `ClusterNetworkPolicy` feature gate.
+
+The `AdminNetworkPolicy` feature gate enables support for the deprecated v1alpha1 AdminNetworkPolicy and
+BaselineAdminNetworkPolicy APIs from the Kubernetes network-policy-api project. These APIs have been deprecated
+upstream in favor of the unified v1alpha2 ClusterNetworkPolicy API.
+
+**Migration Path**: Users should migrate their existing AdminNetworkPolicy and BaselineAdminNetworkPolicy resources
+to the new ClusterNetworkPolicy type. See [ClusterNetworkPolicy API Support in Antrea](cluster-network-policy.md) and the
+[ClusterNetworkPolicy](#clusternetworkpolicy) section below.
+
+### ClusterNetworkPolicy
+
+The `ClusterNetworkPolicy` feature gate enables support for the v1alpha2 ClusterNetworkPolicy API from the Kubernetes
+network-policy-api project. This API provides a unified, portable way for cluster administrators to set security
+postures across the cluster, replacing the deprecated v1alpha1 AdminNetworkPolicy and BaselineAdminNetworkPolicy APIs.
+
+The v1alpha2 ClusterNetworkPolicy combines the functionality of both AdminNetworkPolicy and BaselineAdminNetworkPolicy
+into a single resource type with improved semantics.
+
+See [ClusterNetworkPolicy API Support in Antrea](cluster-network-policy.md) for prerequisites, examples, and how these
+policies interact with Antrea-native tiers.
 
 ### NodeNetworkPolicy
 

--- a/docs/feature-gates.md
+++ b/docs/feature-gates.md
@@ -11,6 +11,8 @@ In particular:
 * a feature in the Beta stage will be enabled by default but can be disabled by editing the appropriate `.conf` entry in
   the Antrea manifest.
 * a feature in the GA stage will be enabled by default and cannot be disabled.
+* a feature in the Deprecated stage will be disabled by default and will be removed in two major releases after its
+  initial deprecation notice.
 
 Some features are specific to the Agent, others are specific to the Controller, and some apply to both and should be
 enabled / disabled consistently in both
@@ -56,7 +58,7 @@ edit the Agent configuration in the
 | `ExternalNode`                  | Agent              | `false` | Alpha      | v1.8          | N/A          | N/A        | Yes                |                                                        |
 | `SupportBundleCollection`       | Agent + Controller | `false` | Alpha      | v1.10         | N/A          | N/A        | Yes                |                                                        |
 | `L7NetworkPolicy`               | Agent + Controller | `false` | Alpha      | v1.10         | N/A          | N/A        | Yes                |                                                        |
-| `AdminNetworkPolicy`            | Controller         | `false` | Alpha      | v1.13         | N/A          | N/A        | Yes                | **Deprecated**: Use `ClusterNetworkPolicy` instead     |
+| `AdminNetworkPolicy`            | Controller         | `false` | Deprecated | v1.13         | N/A          | N/A        | Yes                | **Deprecated**: Use `ClusterNetworkPolicy` instead     |
 | `ClusterNetworkPolicy`          | Controller         | `false` | Alpha      | v2.7          | N/A          | N/A        | Yes                | Successor to `AdminNetworkPolicy`                      |
 | `EgressTrafficShaping`          | Agent              | `false` | Alpha      | v1.14         | N/A          | N/A        | Yes                | OVS meters should be supported                         |
 | `EgressSeparateSubnet`          | Agent              | `true`  | Beta       | v1.15         | v2.3         | N/A        | No                 |                                                        |


### PR DESCRIPTION
Doc updates for #8018 

Add a new cluster-network-policy.md documenting the upstream v1alpha2 ClusterNetworkPolicy API support introduced in Antrea v2.7.

Update admin-network-policy.md to mark the v1alpha1 AdminNetworkPolicy and BaselineAdminNetworkPolicy APIs as deprecated and add a migration guide pointing users to the new ClusterNetworkPolicy feature.

Update feature-gates.md to add the new ClusterNetworkPolicy entry, mark AdminNetworkPolicy as deprecated, and add a new ClusterNetworkPolicy section in the feature descriptions.