### PR TITLE
ci: fix make test-unit on Windows CI runner

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -75,6 +75,7 @@ jobs:
         with:
           go-version-file: '.go-version'
       - name: Run unit tests
+        shell: bash
         run: make test-unit
       - name: Codecov
         uses: codecov/codecov-action@v6

--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,7 @@ flow-aggregator-instr-binary:
 ifeq ($(UNAME_S),Linux)
 test-unit: .linux-test-unit
 test-integration: .linux-test-integration
-else ifneq (,$(findstring MSYS_NT-,$(UNAME_S)))
+else ifneq (,$(or $(findstring MSYS_NT-,$(UNAME_S)),$(findstring MINGW,$(UNAME_S))))
 test-unit: .windows-test-unit
 test-integration:
 	$(error Cannot use target 'test-integration' on Windows, but you can run integration tests with 'docker-test-integration')


### PR DESCRIPTION
On Windows runners, GitHub Actions defaults to PowerShell for run
steps. When Make parses the Makefile, it evaluates GO_FILES via
$(shell find ...), which invokes Windows' FIND.EXE instead of GNU
find. The incompatible argument format produces "FIND: Parameter
format not correct" errors in the CI log.

Adding shell: bash to the "Run unit tests" step causes the step to
run under Git for Windows' bash, placing GNU find on the PATH and
resolving the find errors. The .windows-test-unit Makefile target
also uses bash-specific constructs (grep, tr, sed), so this is
consistent with its requirements.

However, Git Bash reports uname -s as MINGW64_NT-* rather than the
MSYS_NT-* prefix the Makefile's OS detection expected, causing
make to fall through to an error case. Extend the Windows condition
to also match strings containing MINGW, covering both MSYS2 and
Git for Windows environments.