### PR TITLE
Fix flaky timing-sensitive unit tests with synctest

### DIFF
--- a/pkg/apiserver/storage/ram/store_test.go
+++ b/pkg/apiserver/storage/ram/store_test.go
@@ -19,9 +19,11 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -30,7 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/client-go/tools/cache"
-	clocktesting "k8s.io/utils/clock/testing"
+	"k8s.io/utils/clock"
 
 	antreastorage "antrea.io/antrea/v2/pkg/apiserver/storage"
 )
@@ -469,77 +471,70 @@ func TestRamStoreWatchWithSelector(t *testing.T) {
 	}
 }
 
-func TestRamStoreWatchTimeout(t *testing.T) {
-	clock := clocktesting.NewFakeClock(time.Now())
-	store := newStoreWithClock(cache.MetaNamespaceKeyFunc, cache.Indexers{}, testGenEvent, testSelectFunc, func() runtime.Object { return new(v1.Pod) }, clock)
-	// watcherChanSize*2+1 events can fill a watcher's buffer: input channel buffer + result channel buffer + 1 in-flight.
-	maxBuffered := watcherChanSize*2 + 1
-
-	// w1 has consumer for its result chan.
-	w1, err := store.Watch(context.Background(), "", labels.SelectorFromSet(labels.Set{"app": "nginx"}), fields.Everything())
-	if err != nil {
-		t.Errorf("Failed to watch object: %v", err)
-	}
-
-	w1Done := make(chan struct{})
-	go func() {
-		defer close(w1Done)
-		ch := w1.ResultChan()
-		// Skip the bookmark event.
-		<-ch
-		for i := 0; i < maxBuffered+1; i++ {
-			actualEvent := <-ch
-			expectedEvent := watch.Event{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("pod%d", i), Labels: map[string]string{"app": "nginx"}}}}
-			if !reflect.DeepEqual(actualEvent, expectedEvent) {
-				t.Errorf("Unexpected event %d, got %#v, expected %#v ", i, actualEvent, expectedEvent)
-			}
-		}
-		select {
-		case obj, ok := <-ch:
-			t.Errorf("Unexpected excess event: %#v %t", obj, ok)
-		default:
-		}
-	}()
-
-	// w2 has no consumer for its result chan.
-	w2, err := store.Watch(context.Background(), "", labels.SelectorFromSet(labels.Set{"app": "nginx"}), fields.Everything())
-	if err != nil {
-		t.Errorf("Failed to watch object: %v", err)
-	}
-	// Skip the bookmark event.
-	<-w2.ResultChan()
-	assert.Equal(t, 2, store.GetWatchersNum(), "Unexpected watchers number")
-
-	// Generate all events at once: w1 can take all events (eventually) as it has a consumer. w2
-	// will not be able to take the last event as it has no consumer.
-	for i := 0; i < maxBuffered+1; i++ {
-		store.Create(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("pod%d", i), Labels: map[string]string{"app": "nginx"}}})
-	}
-
-	// Give 1s for the consumer for w1 to receive all events. During that time, we do not
-	// advance the fake clock.
+// isClosed reports whether the channel ch is already closed (non-blocking check).
+func isClosed(ch <-chan struct{}) bool {
 	select {
-	case <-w1Done:
-	case <-time.After(1 * time.Second):
-		t.Fatal("w1 consumer has not received all events")
-	}
-
-	// Make sure that w2 is not stopped yet.
-	select {
-	case <-w2.(*storeWatcher).done:
-		t.Fatal("w2 was stopped, expected not stopped")
+	case <-ch:
+		return true
 	default:
+		return false
 	}
+}
 
-	// After advancing the fake clock, w2 should be stopped. Because terminating watchers is
-	// asynchronous, we leave 500ms of reaction time.
-	clock.Step(watcherAddTimeout)
+func TestRamStoreWatchTimeout(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		store := newStoreWithClock(cache.MetaNamespaceKeyFunc, cache.Indexers{}, testGenEvent, testSelectFunc, func() runtime.Object { return new(v1.Pod) }, clock.RealClock{})
+		defer store.Stop()
 
-	select {
-	case <-w2.(*storeWatcher).done:
-	case <-time.After(500 * time.Millisecond):
-		t.Error("w2 was not stopped, expected stopped")
-	}
+		// watcherChanSize*2+1 events can fill a watcher's buffer: input channel buffer + result channel buffer + 1 in-flight.
+		maxBuffered := watcherChanSize*2 + 1
 
-	assert.Equal(t, 1, store.GetWatchersNum(), "Unexpected watchers number")
+		// w1 has consumer for its result chan.
+		w1, err := store.Watch(context.Background(), "", labels.SelectorFromSet(labels.Set{"app": "nginx"}), fields.Everything())
+		require.NoError(t, err)
+		defer w1.Stop()
+
+		w1Done := make(chan struct{})
+		go func() {
+			defer close(w1Done)
+			ch := w1.ResultChan()
+			// Skip the bookmark event.
+			<-ch
+			for i := 0; i < maxBuffered+1; i++ {
+				actualEvent := <-ch
+				expectedEvent := watch.Event{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("pod%d", i), Labels: map[string]string{"app": "nginx"}}}}
+				assert.Equal(t, expectedEvent, actualEvent, "unexpected event %d", i)
+			}
+			assert.Empty(t, ch, "unexpected excess event in result channel")
+		}()
+
+		// w2 has no consumer for its result chan.
+		w2, err := store.Watch(context.Background(), "", labels.SelectorFromSet(labels.Set{"app": "nginx"}), fields.Everything())
+		require.NoError(t, err)
+		// Skip the bookmark event.
+		<-w2.ResultChan()
+		assert.Equal(t, 2, store.GetWatchersNum(), "unexpected watchers number")
+
+		// Generate all events at once: w1 can take all events (eventually) as it has a consumer. w2
+		// will not be able to take the last event as it has no consumer.
+		for i := 0; i < maxBuffered+1; i++ {
+			store.Create(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("pod%d", i), Labels: map[string]string{"app": "nginx"}}})
+		}
+
+		// Wait for all goroutines in the bubble to settle: the w1 consumer goroutine and the
+		// store's dispatchEvents goroutine will drain all events and block. At that point the
+		// fake clock has not advanced, so w2 has not been timed out yet.
+		synctest.Wait()
+		require.True(t, isClosed(w1Done), "w1 consumer has not received all events")
+		require.False(t, isClosed(w2.(*storeWatcher).done), "w2 was stopped, expected not stopped")
+
+		// Advance the synctest fake clock past watcherAddTimeout. The store's internal timer
+		// fires, causing the async watcher-termination path to stop w2. synctest.Wait() lets
+		// those goroutines finish before we check.
+		time.Sleep(watcherAddTimeout)
+		synctest.Wait()
+
+		assert.True(t, isClosed(w2.(*storeWatcher).done), "w2 was not stopped, expected stopped")
+		assert.Equal(t, 1, store.GetWatchersNum(), "unexpected watchers number")
+	})
 }

--- a/pkg/apiserver/storage/ram/store_test.go
+++ b/pkg/apiserver/storage/ram/store_test.go
@@ -511,6 +511,7 @@ func TestRamStoreWatchTimeout(t *testing.T) {
 		// w2 has no consumer for its result chan.
 		w2, err := store.Watch(context.Background(), "", labels.SelectorFromSet(labels.Set{"app": "nginx"}), fields.Everything())
 		require.NoError(t, err)
+		defer w2.Stop()
 		// Skip the bookmark event.
 		<-w2.ResultChan()
 		assert.Equal(t, 2, store.GetWatchersNum(), "unexpected watchers number")

--- a/pkg/apiserver/storage/ram/store_test.go
+++ b/pkg/apiserver/storage/ram/store_test.go
@@ -471,11 +471,14 @@ func TestRamStoreWatchWithSelector(t *testing.T) {
 	}
 }
 
-// isClosed reports whether the channel ch is already closed (non-blocking check).
+// isClosed reports whether a close-only channel is already closed via a
+// non-blocking check. The channel must never have a value sent on it;
+// isClosed must only be used on channels that are exclusively closed (never
+// written to), so that a successful receive unambiguously means closed.
 func isClosed(ch <-chan struct{}) bool {
 	select {
-	case <-ch:
-		return true
+	case _, ok := <-ch:
+		return !ok
 	default:
 		return false
 	}
@@ -505,7 +508,11 @@ func TestRamStoreWatchTimeout(t *testing.T) {
 				expectedEvent := watch.Event{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("pod%d", i), Labels: map[string]string{"app": "nginx"}}}}
 				assert.Equal(t, expectedEvent, actualEvent, "unexpected event %d", i)
 			}
-			assert.Empty(t, ch, "unexpected excess event in result channel")
+			select {
+			case obj, ok := <-ch:
+				assert.Fail(t, "unexpected excess event", "%#v %t", obj, ok)
+			default:
+			}
 		}()
 
 		// w2 has no consumer for its result chan.

--- a/pkg/ipam/poolallocator/allocator_test.go
+++ b/pkg/ipam/poolallocator/allocator_test.go
@@ -167,9 +167,11 @@ func TestAllocateNext(t *testing.T) {
 // distinct IPs if ipPoolStatusRetry allows enough conflict retries.
 //
 // synctest.Test is used so that the time.Sleep calls inside retry.RetryOnConflict
-// (driven by ipPoolStatusRetry backoff) use the fake clock. synctest.Wait()
-// advances fake time to drain all sleeping goroutines at once, making the test
-// deterministic and fast regardless of CI runner speed.
+// (driven by ipPoolStatusRetry backoff) use the fake clock instead of the real
+// wall clock. When all worker goroutines are blocked on a backoff sleep, the
+// synctest scheduler automatically advances fake time, so wg.Wait() returns as
+// soon as all retries complete — no real delays, deterministic regardless of CI
+// runner speed.
 func TestConcurrentAllocateNextSharedIPPool(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		stopCh := make(chan struct{})

--- a/pkg/ipam/poolallocator/allocator_test.go
+++ b/pkg/ipam/poolallocator/allocator_test.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/google/uuid"
@@ -164,74 +165,85 @@ func TestAllocateNext(t *testing.T) {
 // concurrent UpdateStatus on a shared pool (e.g. several DaemonSets using the
 // same Antrea IPPool for secondary networks). All goroutines must succeed with
 // distinct IPs if ipPoolStatusRetry allows enough conflict retries.
+//
+// synctest.Test is used so that the time.Sleep calls inside retry.RetryOnConflict
+// (driven by ipPoolStatusRetry backoff) use the fake clock. synctest.Wait()
+// advances fake time to drain all sleeping goroutines at once, making the test
+// deterministic and fast regardless of CI runner speed.
 func TestConcurrentAllocateNextSharedIPPool(t *testing.T) {
-	stopCh := make(chan struct{})
-	defer close(stopCh)
+	synctest.Test(t, func(t *testing.T) {
+		stopCh := make(chan struct{})
+		defer close(stopCh)
 
-	// Six DaemonSets on a six-Node cluster all requesting the same pool is 36
-	// concurrent status writers; keep headroom in the range.
-	const concurrency = 36
+		// Six DaemonSets on a six-Node cluster all requesting the same pool is 36
+		// concurrent status writers; keep headroom in the range.
+		const concurrency = 36
 
-	poolName := uuid.New().String()
-	ipRange := crdv1b1.IPRange{
-		Start: "10.2.2.10",
-		End:   "10.2.2.99", // 90 addresses
-	}
-	subnetInfo := crdv1b1.SubnetInfo{
-		Gateway:      "10.2.2.1",
-		PrefixLength: 24,
-		VLAN:         101,
-	}
-	pool := crdv1b1.IPPool{
-		ObjectMeta: metav1.ObjectMeta{Name: poolName},
-		Spec:       crdv1b1.IPPoolSpec{IPRanges: []crdv1b1.IPRange{ipRange}, SubnetInfo: subnetInfo},
-	}
+		poolName := uuid.New().String()
+		ipRange := crdv1b1.IPRange{
+			Start: "10.2.2.10",
+			End:   "10.2.2.99", // 90 addresses
+		}
+		subnetInfo := crdv1b1.SubnetInfo{
+			Gateway:      "10.2.2.1",
+			PrefixLength: 24,
+			VLAN:         101,
+		}
+		pool := crdv1b1.IPPool{
+			ObjectMeta: metav1.ObjectMeta{Name: poolName},
+			Spec:       crdv1b1.IPPoolSpec{IPRanges: []crdv1b1.IPRange{ipRange}, SubnetInfo: subnetInfo},
+		}
 
-	allocator := newTestIPPoolAllocator(&pool, stopCh)
-	require.NotNil(t, allocator)
-	require.GreaterOrEqual(t, allocator.Total(), concurrency)
+		allocator := newTestIPPoolAllocator(&pool, stopCh)
+		require.NotNil(t, allocator)
+		require.GreaterOrEqual(t, allocator.Total(), concurrency)
 
-	var wg sync.WaitGroup
-	errs := make([]error, concurrency)
-	ipStrs := make([]string, concurrency)
+		var wg sync.WaitGroup
+		errs := make([]error, concurrency)
+		ipStrs := make([]string, concurrency)
 
-	for i := 0; i < concurrency; i++ {
-		wg.Add(1)
-		go func(idx int) {
-			defer wg.Done()
-			owner := crdv1b1.IPAddressOwner{
-				Pod: &crdv1b1.PodOwner{
-					Name:        fmt.Sprintf("concurrent-pod-%d", idx),
-					Namespace:   testNamespace,
-					ContainerID: uuid.New().String(),
-					IFName:      "net1",
-				},
-			}
-			ip, _, err := allocator.AllocateNext(crdv1b1.IPAddressPhaseAllocated, owner)
-			if err != nil {
-				errs[idx] = err
-				return
-			}
-			if ip == nil {
-				errs[idx] = fmt.Errorf("worker %d: AllocateNext returned nil IP without error", idx)
-				return
-			}
-			ipStrs[idx] = ip.String()
-		}(i)
-	}
-	wg.Wait()
+		for i := 0; i < concurrency; i++ {
+			wg.Add(1)
+			go func(idx int) {
+				defer wg.Done()
+				owner := crdv1b1.IPAddressOwner{
+					Pod: &crdv1b1.PodOwner{
+						Name:        fmt.Sprintf("concurrent-pod-%d", idx),
+						Namespace:   testNamespace,
+						ContainerID: uuid.New().String(),
+						IFName:      "net1",
+					},
+				}
+				ip, _, err := allocator.AllocateNext(crdv1b1.IPAddressPhaseAllocated, owner)
+				if err != nil {
+					errs[idx] = err
+					return
+				}
+				if ip == nil {
+					errs[idx] = fmt.Errorf("worker %d: AllocateNext returned nil IP without error", idx)
+					return
+				}
+				ipStrs[idx] = ip.String()
+			}(i)
+		}
 
-	for i, err := range errs {
-		require.NoError(t, err, "AllocateNext for worker %d should succeed under contention", i)
-		require.NotEmpty(t, ipStrs[i], "worker %d: no error but empty IP string returned", i)
-	}
-	seen := make(map[string]struct{}, concurrency)
-	for _, s := range ipStrs {
-		_, dup := seen[s]
-		require.False(t, dup, "duplicate IP %s allocated", s)
-		seen[s] = struct{}{}
-	}
-	require.Len(t, seen, concurrency, "expected a distinct IP per concurrent allocator")
+		// wg.Wait() will block until all workers finish. When all workers are blocked on
+		// time.Sleep (inside retry.RetryOnConflict backoff), the synctest runtime advances
+		// the fake clock automatically, so conflicts are resolved without real delays.
+		wg.Wait()
+
+		for i, err := range errs {
+			require.NoError(t, err, "AllocateNext for worker %d should succeed under contention", i)
+			require.NotEmpty(t, ipStrs[i], "worker %d: no error but empty IP string returned", i)
+		}
+		seen := make(map[string]struct{}, concurrency)
+		for _, s := range ipStrs {
+			_, dup := seen[s]
+			require.False(t, dup, "duplicate IP %s allocated", s)
+			seen[s] = struct{}{}
+		}
+		require.Len(t, seen, concurrency, "expected a distinct IP per concurrent allocator")
+	})
 }
 
 func TestAllocateNextMultiRange(t *testing.T) {


### PR DESCRIPTION
TestRamStoreWatchTimeout used a clocktesting.FakeClock that required manual clock.Step() calls, and guarded on event delivery with time.After(1s) / time.After(500ms) — real wall-clock waits that cause flakes on slow CI runners (especially Windows).

TestConcurrentAllocateNextSharedIPPool relied on the real wall clock for retry.RetryOnConflict backoff sleeps. Under high contention on a loaded runner the 8-step ipPoolStatusRetry backoff could be exhausted before all 36 goroutines succeeded, producing spurious "pool exhausted" or "update conflict" failures.

Both tests are now wrapped in synctest.Test. Using clock.RealClock{} (whose NewTimer wraps time.NewTimer) means all timer and sleep calls inside the synctest bubble use the fake clock automatically — no separate FakeClock injection is needed. synctest.Wait() replaces the real-time guards: it advances fake time only when all bubble goroutines are durably blocked, making the tests deterministic and instant.

Additional cleanup in TestRamStoreWatchTimeout: replace manual reflect.DeepEqual / select / t.Errorf patterns with testify assert/require calls, and introduce a small isClosed() helper to express the non-blocking channel checks as plain boolean assertions.