### PR TITLE
Update lumberjack dependency to use antrea-io fork

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -252,3 +252,5 @@ require (
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
 )
+
+replace gopkg.in/natefinch/lumberjack.v2 => github.com/antrea-io/lumberjack v0.0.0-20260603202205-2fb47fcd712a

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwTo
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
 github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
+github.com/antrea-io/lumberjack v0.0.0-20260603202205-2fb47fcd712a h1:HDvMgm6xXycjAmXFUTogUAXp4M4GGSVtCXqqYRAs6+0=
+github.com/antrea-io/lumberjack v0.0.0-20260603202205-2fb47fcd712a/go.mod h1:+fykv+mf2DXpfbwYLEMzNFMd2x388oI8wcAd7ZsiO+4=
 github.com/armon/go-metrics v0.4.1 h1:hR91U9KYmb6bLBYLQjyM+3j+rcd/UhE+G78SFnF8gJA=
 github.com/armon/go-metrics v0.4.1/go.mod h1:E6amYzXo6aW1tqzoZGT755KkbgrJsSdpwZ+3JqfkOG4=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
@@ -797,8 +799,6 @@ gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
-gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
-gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
## Summary

Update the `lumberjack` dependency to use the `antrea-io/lumberjack` fork instead of switching to `timberjack`.

### Why the antrea-io fork?

The upstream `gopkg.in/natefinch/lumberjack.v2` repository is largely unmaintained. We have forked it to `antrea-io/lumberjack` (specifically the `v2.0` branch) to add necessary improvements while maintaining 100% API compatibility.

Improvements in the fork include:
- **Time-based rotation** in addition to size-based (via `RotationInterval`, `RotateAt`, `RotateAtMinutes`)
- **zstd compression** support alongside gzip
- **Configurable file mode** (`FileMode` field)

### Compatibility

Because we are using a `replace` directive in `go.mod`, all existing `lumberjack.Logger` struct fields and imports in the Antrea codebase remain completely unchanged.

## Changes

- `go.mod` / `go.sum`: Add `replace gopkg.in/natefinch/lumberjack.v2 => github.com/antrea-io/lumberjack v0.0.0-20260603202205-2fb47fcd712a` (pointing to the latest commit on the `v2.0` branch).

## Testing

- `go build ./pkg/agent/controller/networkpolicy/...` ✅
- `go build ./pkg/flowaggregator/...` ✅

Made with [Cursor](https://cursor.com)