### PR TITLE
Add support for Antrea Egress in noEncap mode

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -246,6 +246,7 @@ func run(o *Options) error {
 		},
 		EnableMulticlusterGW:          enableMulticlusterGW,
 		MulticlusterEncryptionMode:    multiclusterEncryptionMode,
+		EnableEgress:                  o.enableEgress,
 		EnableHostNetworkAcceleration: *o.config.HostNetworkAcceleration.Enable,
 		HostNetworkMode:               hostNetworkMode,
 	}

--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -234,6 +234,7 @@ func run(o *Options) error {
 		},
 		EnableMulticlusterGW:          enableMulticlusterGW,
 		MulticlusterEncryptionMode:    multiclusterEncryptionMode,
+		EnableEgress:                  o.enableEgress,
 		EnableHostNetworkAcceleration: *o.config.HostNetworkAcceleration.Enable,
 		HostNetworkMode:               hostNetworkMode,
 	}

--- a/cmd/antrea-agent/options.go
+++ b/cmd/antrea-agent/options.go
@@ -559,12 +559,23 @@ func (o *Options) setK8sNodeDefaultOptions() {
 	}
 }
 
-func (o *Options) validateEgressConfig(encapMode config.TrafficEncapModeType) error {
+func (o *Options) validateEgressConfig(encapMode config.TrafficEncapModeType, encryptionMode config.TrafficEncryptionModeType) error {
 	if !features.DefaultFeatureGate.Enabled(features.Egress) {
 		return nil
 	}
-	if !encapMode.SupportsEncap() {
-		klog.InfoS("The Egress feature gate is enabled, but it won't work because it requires either encap or hybrid mode")
+
+	// Egress forwards traffic to the Egress Node via the flow-based tunnel port, which is not
+	// used when IPsec is enabled (IPsec uses per-peer tunnel ports).
+	if encryptionMode != config.TrafficEncryptionModeNone &&
+		encryptionMode != config.TrafficEncryptionModeWireGuard {
+		klog.InfoS("The Egress feature gate is enabled, but it doesn't work with the current encryption mode", "encryptionMode", encryptionMode)
+		return nil
+	}
+
+	if encapMode != config.TrafficEncapModeEncap &&
+		encapMode != config.TrafficEncapModeHybrid &&
+		encapMode != config.TrafficEncapModeNoEncap {
+		klog.InfoS("The Egress feature gate is enabled, but it won't work because it is only applicable to the encap, hybrid, and noEncap modes")
 		return nil
 	}
 	for _, cidr := range o.config.Egress.ExceptCIDRs {
@@ -664,7 +675,7 @@ func (o *Options) validateK8sNodeOptions() error {
 	if err := o.validateMulticastConfig(encapMode, encryptionMode); err != nil {
 		return fmt.Errorf("failed to validate multicast config: %v", err)
 	}
-	if err := o.validateEgressConfig(encapMode); err != nil {
+	if err := o.validateEgressConfig(encapMode, encryptionMode); err != nil {
 		return fmt.Errorf("failed to validate egress config: %v", err)
 	}
 	if err := o.validateMulticlusterConfig(encapMode, encryptionMode); err != nil {

--- a/cmd/antrea-agent/options.go
+++ b/cmd/antrea-agent/options.go
@@ -553,12 +553,23 @@ func (o *Options) setK8sNodeDefaultOptions() {
 	}
 }
 
-func (o *Options) validateEgressConfig(encapMode config.TrafficEncapModeType) error {
+func (o *Options) validateEgressConfig(encapMode config.TrafficEncapModeType, encryptionMode config.TrafficEncryptionModeType) error {
 	if !features.DefaultFeatureGate.Enabled(features.Egress) {
 		return nil
 	}
-	if !encapMode.SupportsEncap() {
-		klog.InfoS("The Egress feature gate is enabled, but it won't work because it requires either encap or hybrid mode")
+
+	// Egress forwards traffic to the Egress Node via the flow-based tunnel port, which is not
+	// used when IPsec is enabled (IPsec uses per-peer tunnel ports).
+	if encryptionMode != config.TrafficEncryptionModeNone &&
+		encryptionMode != config.TrafficEncryptionModeWireGuard {
+		klog.InfoS("The Egress feature gate is enabled, but it doesn't work with the current encryption mode", "encryptionMode", encryptionMode)
+		return nil
+	}
+
+	if encapMode != config.TrafficEncapModeEncap &&
+		encapMode != config.TrafficEncapModeHybrid &&
+		encapMode != config.TrafficEncapModeNoEncap {
+		klog.InfoS("The Egress feature gate is enabled, but it won't work because it is only applicable to the encap, hybrid, and noEncap modes")
 		return nil
 	}
 	for _, cidr := range o.config.Egress.ExceptCIDRs {
@@ -658,7 +669,7 @@ func (o *Options) validateK8sNodeOptions() error {
 	if err := o.validateMulticastConfig(encapMode, encryptionMode); err != nil {
 		return fmt.Errorf("failed to validate multicast config: %v", err)
 	}
-	if err := o.validateEgressConfig(encapMode); err != nil {
+	if err := o.validateEgressConfig(encapMode, encryptionMode); err != nil {
 		return fmt.Errorf("failed to validate egress config: %v", err)
 	}
 	if err := o.validateMulticlusterConfig(encapMode, encryptionMode); err != nil {

--- a/cmd/antrea-agent/options_test.go
+++ b/cmd/antrea-agent/options_test.go
@@ -179,23 +179,64 @@ func TestOptionsValidateAntreaProxyConfig(t *testing.T) {
 
 func TestOptionsValidateEgressConfig(t *testing.T) {
 	tests := []struct {
-		name                 string
-		featureGateValue     bool
-		trafficEncapMode     config.TrafficEncapModeType
-		egressConfig         agentconfig.EgressConfig
-		expectedErr          string
-		expectedEnableEgress bool
+		name                  string
+		featureGateValue      bool
+		trafficEncapMode      config.TrafficEncapModeType
+		trafficEncryptionMode config.TrafficEncryptionModeType
+		egressConfig          agentconfig.EgressConfig
+		expectedErr           string
+		expectedEnableEgress  bool
 	}{
 		{
-			name:                 "enabled",
+			name:                 "feature gate disabled",
+			featureGateValue:     false,
+			trafficEncapMode:     config.TrafficEncapModeEncap,
+			expectedEnableEgress: false,
+		},
+		{
+			name:                 "encap mode",
 			featureGateValue:     true,
 			trafficEncapMode:     config.TrafficEncapModeEncap,
 			expectedEnableEgress: true,
 		},
 		{
-			name:                 "unsupported encap mode",
+			name:                  "encap mode with WireGuard",
+			featureGateValue:      true,
+			trafficEncapMode:      config.TrafficEncapModeEncap,
+			trafficEncryptionMode: config.TrafficEncryptionModeWireGuard,
+			expectedEnableEgress:  true,
+		},
+		{
+			// Egress cannot forward traffic via the encap tunnel when IPSec is enabled.
+			name:                  "encap mode with IPSec",
+			featureGateValue:      true,
+			trafficEncapMode:      config.TrafficEncapModeEncap,
+			trafficEncryptionMode: config.TrafficEncryptionModeIPSec,
+			expectedEnableEgress:  false,
+		},
+		{
+			name:                  "hybrid mode with IPSec",
+			featureGateValue:      true,
+			trafficEncapMode:      config.TrafficEncapModeHybrid,
+			trafficEncryptionMode: config.TrafficEncryptionModeIPSec,
+			expectedEnableEgress:  false,
+		},
+		{
+			name:                 "hybrid mode",
+			featureGateValue:     true,
+			trafficEncapMode:     config.TrafficEncapModeHybrid,
+			expectedEnableEgress: true,
+		},
+		{
+			name:                 "noEncap mode",
 			featureGateValue:     true,
 			trafficEncapMode:     config.TrafficEncapModeNoEncap,
+			expectedEnableEgress: true,
+		},
+		{
+			name:                 "unsupported encap mode (networkPolicyOnly)",
+			featureGateValue:     true,
+			trafficEncapMode:     config.TrafficEncapModeNetworkPolicyOnly,
 			expectedEnableEgress: false,
 		},
 		{
@@ -226,7 +267,7 @@ func TestOptionsValidateEgressConfig(t *testing.T) {
 			o := &Options{config: &agentconfig.AgentConfig{
 				Egress: tt.egressConfig,
 			}}
-			err := o.validateEgressConfig(tt.trafficEncapMode)
+			err := o.validateEgressConfig(tt.trafficEncapMode, tt.trafficEncryptionMode)
 			if tt.expectedErr == "" {
 				require.NoError(t, err)
 			} else {

--- a/docs/egress.md
+++ b/docs/egress.md
@@ -528,9 +528,9 @@ API.
 
 ## Limitations
 
-This feature is currently only supported for Nodes running Linux and "encap" / "hybrid"
-mode. The support for Windows and other traffic modes will be added in the
-future.
+This feature is currently supported for Nodes running Linux and "encap" / "hybrid"
+/ "noEncap" / WireGuard encryption mode. The support for Windows and other traffic
+modes will be added in the future.
 
 The previous implementation of Antrea Egress before Antrea v1.7.0 does not work
 with the `strictARP` configuration of `kube-proxy` IPVS mode. The `strictARP`

--- a/docs/egress.md
+++ b/docs/egress.md
@@ -660,9 +660,9 @@ API.
 
 ## Limitations
 
-This feature is currently only supported for Nodes running Linux and "encap" / "hybrid"
-mode. The support for Windows and other traffic modes will be added in the
-future.
+This feature is currently supported for Nodes running Linux and "encap" / "noEncap"
+/ "hybrid" / WireGuard encryption mode. The support for Windows and other traffic
+modes will be added in the future.
 
 The previous implementation of Antrea Egress before Antrea v1.7.0 does not work
 with the `strictARP` configuration of `kube-proxy` IPVS mode. The `strictARP`

--- a/docs/feature-gates.md
+++ b/docs/feature-gates.md
@@ -292,7 +292,7 @@ this [document](egress.md) for more information.
 
 #### Requirements for this Feature
 
-This feature is currently only supported for Nodes running Linux and "encap" / "hybrid"
+This feature is currently supported for Nodes running Linux and "encap" / "noEncap" / "hybrid" / WireGuard encryption
 mode. The support for Windows and other traffic modes will be added in the future.
 
 ### NodeIPAM

--- a/docs/feature-gates.md
+++ b/docs/feature-gates.md
@@ -291,7 +291,7 @@ this [document](egress.md) for more information.
 
 #### Requirements for this Feature
 
-This feature is currently only supported for Nodes running Linux and "encap" / "hybrid"
+This feature is currently supported for Nodes running Linux and "encap" / "hybrid" / "noEncap" / WireGuard encryption
 mode. The support for Windows and other traffic modes will be added in the future.
 
 ### NodeIPAM

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -830,7 +830,8 @@ func (i *Initializer) setupDefaultTunnelInterface() error {
 	// default tunnel port. So for now, we just reject configurations that
 	// request a GRE tunnel when the Node network supports IPv6.
 	// See https://github.com/antrea-io/antrea/issues/3150
-	if i.networkConfig.TrafficEncapMode.SupportsEncap() &&
+	if (i.networkConfig.TrafficEncapMode.SupportsEncap() ||
+		i.networkConfig.TrafficEncapMode == config.TrafficEncapModeNoEncap && i.networkConfig.EnableEgress) &&
 		i.networkConfig.TunnelType == ovsconfig.GRETunnel &&
 		i.nodeConfig.NodeIPv6Addr != nil {
 		return fmt.Errorf("GRE tunnel type is not supported for IPv6 overlay")
@@ -1255,7 +1256,8 @@ func (i *Initializer) getInterfaceMTU(transportInterface *net.Interface) (int, e
 
 	isIPv6 := i.nodeConfig.NodeIPv6Addr != nil
 	mtu -= i.networkConfig.CalculateMTUDeduction(isIPv6)
-	if i.networkConfig.TrafficEncapMode.SupportsEncap() {
+	if i.networkConfig.TrafficEncapMode.SupportsEncap() ||
+		i.networkConfig.TrafficEncapMode == config.TrafficEncapModeNoEncap && i.networkConfig.EnableEgress {
 		// See comment for ovsTunnelMaxMTU constant above.
 		mtu = min(mtu, ovsTunnelMaxMTU)
 	}

--- a/pkg/agent/config/node_config.go
+++ b/pkg/agent/config/node_config.go
@@ -234,6 +234,10 @@ type NetworkConfig struct {
 	EnableMulticlusterGW       bool
 	MulticlusterEncryptionMode TrafficEncryptionModeType
 
+	// EnableEgress indicates the Egress feature is enabled. It is used to determine whether
+	// a tunnel interface should be created in noEncap mode for Egress traffic forwarding.
+	EnableEgress bool
+
 	EnableHostNetworkAcceleration bool
 	HostNetworkMode               HostNetworkMode
 }
@@ -288,7 +292,12 @@ func (nc *NetworkConfig) NeedsTunnelInterface() bool {
 	// cross-cluster traffic from a regular Node to the gateway Node for the source cluster
 	// always goes through antrea-tun0, regardless of the actual "traffic mode" for the source
 	// cluster.
-	return nc.TrafficEncapMode.SupportsEncap() || nc.EnableMulticlusterGW
+	// In noEncap mode with Egress enabled, the tunnel interface is required so that OVS can
+	// forward Egress traffic from a non-Egress Node to the Egress Node via the tunnel. Regular
+	// Pod-to-Pod traffic continues to use direct routing and is unaffected.
+	return nc.TrafficEncapMode.SupportsEncap() ||
+		nc.EnableMulticlusterGW ||
+		nc.TrafficEncapMode == TrafficEncapModeNoEncap && nc.EnableEgress
 }
 
 // NeedsDirectRoutingToPeer returns true if Pod traffic to peer Node needs a direct route installed to the routing table.
@@ -329,7 +338,7 @@ func (nc *NetworkConfig) CalculateMTUDeduction(isIPv6 bool) int {
 		}
 		return nc.MTUDeduction
 	}
-	if nc.TrafficEncapMode.SupportsEncap() {
+	if nc.TrafficEncapMode.SupportsEncap() || nc.TrafficEncapMode == TrafficEncapModeNoEncap && nc.EnableEgress {
 		nc.MTUDeduction = nc.getEncapMTUDeduction(isIPv6)
 	}
 	switch nc.TrafficEncryptionMode {

--- a/pkg/agent/config/node_config.go
+++ b/pkg/agent/config/node_config.go
@@ -234,6 +234,10 @@ type NetworkConfig struct {
 	EnableMulticlusterGW       bool
 	MulticlusterEncryptionMode TrafficEncryptionModeType
 
+	// EnableEgress indicates the Egress feature is enabled. It is used to determine whether
+	// a tunnel interface should be created in noEncap mode for Egress traffic forwarding.
+	EnableEgress bool
+
 	EnableHostNetworkAcceleration bool
 	HostNetworkMode               HostNetworkMode
 }
@@ -288,7 +292,24 @@ func (nc *NetworkConfig) NeedsTunnelInterface() bool {
 	// cross-cluster traffic from a regular Node to the gateway Node for the source cluster
 	// always goes through antrea-tun0, regardless of the actual "traffic mode" for the source
 	// cluster.
-	return nc.TrafficEncapMode.SupportsEncap() || nc.EnableMulticlusterGW
+	// In noEncap mode with Egress enabled, the tunnel interface is required so that OVS can
+	// forward Egress traffic from a non-Egress Node to the Egress Node via the tunnel. Regular
+	// Pod-to-Pod traffic continues to use direct routing and is unaffected.
+	return nc.TrafficEncapMode.SupportsEncap() ||
+		nc.EnableMulticlusterGW ||
+		nc.TrafficEncapMode == TrafficEncapModeNoEncap && nc.EnableEgress
+}
+
+// NeedsEgressSymmetricPath returns true when Egress traffic takes a tunnel path which is distinct from the
+// path taken by the common Pod-to-Pod traffic, which is the case in noEncap and hybrid modes, and when
+// WireGuard encryption is enabled. Pod-to-Pod traffic then goes via routing while Egress traffic from remote
+// Pods reaches the Egress Node through a tunnel, so the reply packets of those Egress connections have to be
+// steered back to that tunnel to keep the path of a connection symmetric. The OVS pipeline installs a return
+// flow and the route client installs policy routing for that, both under this condition.
+func (nc *NetworkConfig) NeedsEgressSymmetricPath(egressEnabled bool) bool {
+	return egressEnabled && (nc.TrafficEncapMode == TrafficEncapModeNoEncap ||
+		nc.TrafficEncapMode == TrafficEncapModeHybrid ||
+		nc.TrafficEncryptionMode == TrafficEncryptionModeWireGuard)
 }
 
 // NeedsDirectRoutingToPeer returns true if Pod traffic to peer Node needs a direct route installed to the routing table.
@@ -329,7 +350,9 @@ func (nc *NetworkConfig) CalculateMTUDeduction(isIPv6 bool) int {
 		}
 		return nc.MTUDeduction
 	}
-	if nc.TrafficEncapMode.SupportsEncap() {
+	// EnableMulticlusterGW is handled above, so the remaining cases where a tunnel is needed are
+	// exactly the ones where traffic going through it must have a reduced MTU.
+	if nc.NeedsTunnelInterface() {
 		nc.MTUDeduction = nc.getEncapMTUDeduction(isIPv6)
 	}
 	switch nc.TrafficEncryptionMode {

--- a/pkg/agent/config/node_config_test.go
+++ b/pkg/agent/config/node_config_test.go
@@ -352,6 +352,22 @@ func TestCalculateMTUDeduction(t *testing.T) {
 			nc:                   &NetworkConfig{TunnelType: ovsconfig.GRETunnel, TrafficEncryptionMode: TrafficEncryptionModeIPSec},
 			expectedMTUDeduction: 80,
 		},
+		{
+			name:                 "noEncap with Egress enabled and Geneve",
+			nc:                   &NetworkConfig{TrafficEncapMode: TrafficEncapModeNoEncap, TunnelType: ovsconfig.GeneveTunnel, EnableEgress: true},
+			expectedMTUDeduction: 50,
+		},
+		{
+			name:                 "noEncap with Egress enabled and Geneve and IPv6",
+			nc:                   &NetworkConfig{TrafficEncapMode: TrafficEncapModeNoEncap, TunnelType: ovsconfig.GeneveTunnel, EnableEgress: true},
+			isIPv6:               true,
+			expectedMTUDeduction: 70,
+		},
+		{
+			name:                 "noEncap without Egress enabled",
+			nc:                   &NetworkConfig{TrafficEncapMode: TrafficEncapModeNoEncap, TunnelType: ovsconfig.GeneveTunnel, EnableEgress: false},
+			expectedMTUDeduction: 0,
+		},
 	}
 
 	for _, tt := range tests {
@@ -391,6 +407,16 @@ func TestNeedsTunnelInterface(t *testing.T) {
 		{
 			name:     "networkPolicyOnly without Multicluster enabled",
 			nc:       &NetworkConfig{TrafficEncapMode: TrafficEncapModeNetworkPolicyOnly, EnableMulticlusterGW: false},
+			expected: false,
+		},
+		{
+			name:     "noEncap mode with Egress enabled",
+			nc:       &NetworkConfig{TrafficEncapMode: TrafficEncapModeNoEncap, EnableEgress: true},
+			expected: true,
+		},
+		{
+			name:     "noEncap mode without Egress enabled",
+			nc:       &NetworkConfig{TrafficEncapMode: TrafficEncapModeNoEncap, EnableEgress: false},
 			expected: false,
 		},
 	}

--- a/pkg/agent/controller/traceflow/packetin.go
+++ b/pkg/agent/controller/traceflow/packetin.go
@@ -300,7 +300,13 @@ func (c *Controller) parsePacketIn(pktIn *ofctrl.PacketIn) (*crdv1beta1.Traceflo
 		}
 		gwPort := c.nodeConfig.GatewayConfig.OFPort
 		tunPort := c.nodeConfig.TunnelOFPort
-		if c.networkConfig.TrafficEncapMode.SupportsEncap() && outputPort == tunPort {
+		// In noEncap mode, the tunnel port only exists when Egress is enabled; tunPort is 0
+		// otherwise and must not be compared against outputPort, which can also be 0 when the
+		// output register is unset.
+		if (c.networkConfig.TrafficEncapMode == config.TrafficEncapModeEncap ||
+			c.networkConfig.TrafficEncapMode == config.TrafficEncapModeHybrid ||
+			c.networkConfig.TrafficEncapMode == config.TrafficEncapModeNoEncap) &&
+			tunPort != 0 && outputPort == tunPort {
 			var isRemoteEgress uint32
 			if match := getMatchRegField(matchers, openflow.RemoteSNATRegMark.GetField()); match != nil {
 				isRemoteEgress, err = getRegValue(match, openflow.RemoteSNATRegMark.GetField().GetRange().ToNXRange())
@@ -320,7 +326,10 @@ func (c *Controller) parsePacketIn(pktIn *ofctrl.PacketIn) (*crdv1beta1.Traceflo
 			ob.Action = crdv1beta1.ActionForwarded
 		} else if ipDst == gatewayIP.String() && outputPort == gwPort {
 			ob.Action = crdv1beta1.ActionDelivered
-		} else if c.networkConfig.TrafficEncapMode.SupportsEncap() && outputPort == gwPort { // encap or hybrid
+		} else if (c.networkConfig.TrafficEncapMode == config.TrafficEncapModeEncap ||
+			c.networkConfig.TrafficEncapMode == config.TrafficEncapModeHybrid ||
+			c.networkConfig.TrafficEncapMode == config.TrafficEncapModeNoEncap) &&
+			outputPort == gwPort { // encap, noEncap, or hybrid
 			var pktMark uint32
 			if match := getMatchPktMarkField(matchers); match != nil {
 				pktMark, err = getMarkValue(match)
@@ -358,7 +367,11 @@ func (c *Controller) parsePacketIn(pktIn *ofctrl.PacketIn) (*crdv1beta1.Traceflo
 						ob.Action = crdv1beta1.ActionForwarded
 						ob.TunnelDstIP = peerNodeIP.String()
 					}
-				} else if c.networkConfig.TrafficEncapMode == config.TrafficEncapModeHybrid {
+				} else if c.networkConfig.TrafficEncapMode == config.TrafficEncapModeHybrid ||
+					c.networkConfig.TrafficEncapMode == config.TrafficEncapModeNoEncap {
+					// In hybrid and noEncap modes, packets destined for remote Pod IPs can be forwarded via Antrea
+					// gateway port. Check if the destination is a Pod IP to distinguish it from traffic leaving
+					// the cluster.
 					isPodIP, _ := c.nodeRouteQuerier.LookupIPInPodSubnets(netAddrDst)
 					if isPodIP {
 						ob.Action = crdv1beta1.ActionForwarded
@@ -372,18 +385,6 @@ func (c *Controller) parsePacketIn(pktIn *ofctrl.PacketIn) (*crdv1beta1.Traceflo
 					isPodIP = true
 					break
 				}
-			}
-			if isPodIP {
-				ob.Action = crdv1beta1.ActionForwarded
-			} else {
-				ob.Action = crdv1beta1.ActionForwardedOutOfNetwork
-			}
-		} else if c.networkConfig.TrafficEncapMode == config.TrafficEncapModeNoEncap && outputPort == gwPort { // noEncap
-			// TODO: update this and above case if noEncap mode supports Egress feature
-			isPodIP := false
-			if c.nodeRouteQuerier != nil {
-				netAddrDst, _ := netip.AddrFromSlice(netIPDst)
-				isPodIP, _ = c.nodeRouteQuerier.LookupIPInPodSubnets(netAddrDst)
 			}
 			if isPodIP {
 				ob.Action = crdv1beta1.ActionForwarded

--- a/pkg/agent/controller/traceflow/packetin.go
+++ b/pkg/agent/controller/traceflow/packetin.go
@@ -300,7 +300,13 @@ func (c *Controller) parsePacketIn(pktIn *ofctrl.PacketIn) (*crdv1beta1.Traceflo
 		}
 		gwPort := c.nodeConfig.GatewayConfig.OFPort
 		tunPort := c.nodeConfig.TunnelOFPort
-		if c.networkConfig.TrafficEncapMode.SupportsEncap() && outputPort == tunPort {
+		// The tunnel port does not always exist: in noEncap mode it is only created when Egress is
+		// enabled. tunPort is 0 when there is none, and it must not be compared against outputPort,
+		// which is also 0 when the output register is unset. A packet output to a port which is the
+		// tunnel port left the Node through the tunnel whatever the traffic encapsulation mode is, so
+		// the mode is not checked here.
+		switch {
+		case tunPort != 0 && outputPort == tunPort:
 			var isRemoteEgress uint32
 			if match := getMatchRegField(matchers, openflow.RemoteSNATRegMark.GetField()); match != nil {
 				isRemoteEgress, err = getRegValue(match, openflow.RemoteSNATRegMark.GetField().GetRange().ToNXRange())
@@ -318,81 +324,82 @@ func (c *Controller) parsePacketIn(pktIn *ofctrl.PacketIn) (*crdv1beta1.Traceflo
 			}
 			ob.TunnelDstIP = tunnelDstIP
 			ob.Action = crdv1beta1.ActionForwarded
-		} else if ipDst == gatewayIP.String() && outputPort == gwPort {
-			ob.Action = crdv1beta1.ActionDelivered
-		} else if c.networkConfig.TrafficEncapMode.SupportsEncap() && outputPort == gwPort { // encap or hybrid
-			var pktMark uint32
-			if match := getMatchPktMarkField(matchers); match != nil {
-				pktMark, err = getMarkValue(match)
-				if err != nil {
-					return nil, nil, nil, err
-				}
-			}
-			if pktMark != 0 { // Egress packet on Egress Node
-				egressName, egressIP, egressNode := "", "", ""
-				if tunnelDstIP == "" { // Egress Node is Source Node of this Egress packet
-					egressConfig, err := c.egressQuerier.GetEgress(ns, srcPod)
-					if err != nil {
-						return nil, nil, nil, err
-					}
-					egressName = egressConfig.Name
-					egressIP = egressConfig.EgressIP
-					egressNode = egressConfig.EgressNode
-				} else {
-					egressIP, err = c.egressQuerier.GetEgressIPByMark(pktMark)
+		case outputPort == gwPort:
+			switch {
+			case ipDst == gatewayIP.String():
+				ob.Action = crdv1beta1.ActionDelivered
+			case !c.networkConfig.TrafficEncapMode.IsNetworkPolicyOnly(): // encap, noEncap, or hybrid
+				// noEncap used to have a case of its own, which reported the packet as forwarded or as
+				// forwarded out of the network but knew nothing about Egress. Now that Egress is supported
+				// in noEncap mode, it shares this case, which reports both, and that case is gone.
+				var pktMark uint32
+				if match := getMatchPktMarkField(matchers); match != nil {
+					pktMark, err = getMarkValue(match)
 					if err != nil {
 						return nil, nil, nil, err
 					}
 				}
-				obEgress := getEgressObservation(true, egressIP, egressName, egressNode)
-				obs = append(obs, *obEgress)
-			}
+				if pktMark != 0 { // Egress packet on Egress Node
+					egressName, egressIP, egressNode := "", "", ""
+					if tunnelDstIP == "" { // Egress Node is Source Node of this Egress packet
+						egressConfig, err := c.egressQuerier.GetEgress(ns, srcPod)
+						if err != nil {
+							return nil, nil, nil, err
+						}
+						egressName = egressConfig.Name
+						egressIP = egressConfig.EgressIP
+						egressNode = egressConfig.EgressNode
+					} else {
+						egressIP, err = c.egressQuerier.GetEgressIPByMark(pktMark)
+						if err != nil {
+							return nil, nil, nil, err
+						}
+					}
+					obEgress := getEgressObservation(true, egressIP, egressName, egressNode)
+					obs = append(obs, *obEgress)
+				}
 
-			ob.Action = crdv1beta1.ActionForwardedOutOfNetwork
-			netAddrDst, isValidIP := netip.AddrFromSlice(netIPDst)
-			if pktMark == 0 && isValidIP && c.nodeRouteQuerier != nil {
-				if c.networkConfig.TrafficEncryptionMode == config.TrafficEncryptionModeWireGuard {
-					// WireGuard sends cross-Node Pod traffic through the gateway port. Resolve the destination Pod IP
-					// through NodeRoute to distinguish it from traffic leaving the cluster and report the peer Node IP.
-					if peerNodeIP, ok := c.nodeRouteQuerier.GetNodeIPForPodIP(netAddrDst); ok {
-						ob.Action = crdv1beta1.ActionForwarded
-						ob.TunnelDstIP = peerNodeIP.String()
-					}
-				} else if c.networkConfig.TrafficEncapMode == config.TrafficEncapModeHybrid {
-					isPodIP, _ := c.nodeRouteQuerier.LookupIPInPodSubnets(netAddrDst)
-					if isPodIP {
-						ob.Action = crdv1beta1.ActionForwarded
+				ob.Action = crdv1beta1.ActionForwardedOutOfNetwork
+				netAddrDst, isValidIP := netip.AddrFromSlice(netIPDst)
+				if pktMark == 0 && isValidIP && c.nodeRouteQuerier != nil {
+					if c.networkConfig.TrafficEncryptionMode == config.TrafficEncryptionModeWireGuard {
+						// WireGuard sends cross-Node Pod traffic through the gateway port. Resolve the destination Pod IP
+						// through NodeRoute to distinguish it from traffic leaving the cluster and report the peer Node IP.
+						if peerNodeIP, ok := c.nodeRouteQuerier.GetNodeIPForPodIP(netAddrDst); ok {
+							ob.Action = crdv1beta1.ActionForwarded
+							ob.TunnelDstIP = peerNodeIP.String()
+						}
+					} else if c.networkConfig.TrafficEncapMode == config.TrafficEncapModeNoEncap ||
+						c.networkConfig.TrafficEncapMode == config.TrafficEncapModeHybrid {
+						// In noEncap and hybrid modes, packets destined for remote Pod IPs can be forwarded via Antrea
+						// gateway port. Check if the destination is a Pod IP to distinguish it from traffic leaving
+						// the cluster.
+						isPodIP, _ := c.nodeRouteQuerier.LookupIPInPodSubnets(netAddrDst)
+						if isPodIP {
+							ob.Action = crdv1beta1.ActionForwarded
+						}
 					}
 				}
-			}
-		} else if c.networkConfig.TrafficEncapMode == config.TrafficEncapModeNetworkPolicyOnly && outputPort == gwPort { // networkPolicyOnly
-			isPodIP := false
-			for _, podCIDR := range c.podCIDRs {
-				if podCIDR.Contains(netIPDst) {
-					isPodIP = true
-					break
+			default: // networkPolicyOnly
+				isPodIP := false
+				for _, podCIDR := range c.podCIDRs {
+					if podCIDR.Contains(netIPDst) {
+						isPodIP = true
+						break
+					}
+				}
+				if isPodIP {
+					ob.Action = crdv1beta1.ActionForwarded
+				} else {
+					ob.Action = crdv1beta1.ActionForwardedOutOfNetwork
 				}
 			}
-			if isPodIP {
-				ob.Action = crdv1beta1.ActionForwarded
-			} else {
-				ob.Action = crdv1beta1.ActionForwardedOutOfNetwork
-			}
-		} else if c.networkConfig.TrafficEncapMode == config.TrafficEncapModeNoEncap && outputPort == gwPort { // noEncap
-			// TODO: update this and above case if noEncap mode supports Egress feature
-			isPodIP := false
-			if c.nodeRouteQuerier != nil {
-				netAddrDst, _ := netip.AddrFromSlice(netIPDst)
-				isPodIP, _ = c.nodeRouteQuerier.LookupIPInPodSubnets(netAddrDst)
-			}
-			if isPodIP {
-				ob.Action = crdv1beta1.ActionForwarded
-			} else {
-				ob.Action = crdv1beta1.ActionForwardedOutOfNetwork
-			}
-		} else {
-			// Output port is Pod port, packet is delivered.
+		case outputPort != 0:
+			// The output port is a Pod port, the packet is delivered.
 			ob.Action = crdv1beta1.ActionDelivered
+		default:
+			// The output register was not set, so where the packet went is unknown. Reporting it
+			// as delivered to a Pod would be wrong, so no action is reported.
 		}
 		ob.ComponentInfo = openflow.OutputTable.GetName()
 		ob.Component = crdv1beta1.ComponentForwarding

--- a/pkg/agent/controller/traceflow/packetin_test.go
+++ b/pkg/agent/controller/traceflow/packetin_test.go
@@ -221,6 +221,7 @@ func getTestPacketBytes(dstIP string) []byte {
 }
 
 func TestParsePacketIn(t *testing.T) {
+	prepareMockTables()
 	xreg0 := make([]byte, 8)
 	binary.BigEndian.PutUint32(xreg0[0:4], openflow.RemoteSNATRegMark.GetValue()<<openflow.RemoteSNATRegMark.GetField().GetRange().Offset()) // RemoteSNATRegMark in 32bit reg0
 	binary.BigEndian.PutUint32(xreg0[4:8], 2)                                                                                                // outputPort in 32bit reg1
@@ -274,9 +275,39 @@ func TestParsePacketIn(t *testing.T) {
 
 	pktBytesPodToIP := getTestPacketBytes(dstIPv4)
 	pktBytesPodToPod := getTestPacketBytes(pod2IPv4)
+	// The peer Node transport IP returned by fakeNodeRouteQuerier for Pod IPs in podCIDR2.
 	peerNodeIP := "192.168.77.77"
 
-	tests := []struct {
+	makePodToIPv4TF := func() *crdv1beta1.Traceflow {
+		return &crdv1beta1.Traceflow{
+			ObjectMeta: metav1.ObjectMeta{Name: "traceflow-pod-to-ipv4"},
+			Spec: crdv1beta1.TraceflowSpec{
+				Source:      crdv1beta1.Source{Namespace: pod1.Namespace, Pod: pod1.Name},
+				Destination: crdv1beta1.Destination{IP: dstIPv4},
+			},
+			Status: crdv1beta1.TraceflowStatus{Phase: crdv1beta1.Running, DataplaneTag: 1},
+		}
+	}
+	makeNodeConfig := func(tunPort, gwPort uint32) *config.NodeConfig {
+		return &config.NodeConfig{
+			TunnelOFPort:  tunPort,
+			GatewayConfig: &config.GatewayConfig{OFPort: gwPort},
+		}
+	}
+	egressConfig := types.EgressConfig{Name: egressName, EgressIP: egressIP, EgressNode: egressNode}
+
+	type trafficMode struct {
+		name          string
+		networkConfig *config.NetworkConfig
+	}
+	trafficModes := []trafficMode{
+		{"encap", &config.NetworkConfig{TrafficEncapMode: config.TrafficEncapModeEncap}},
+		{"noEncap", &config.NetworkConfig{TrafficEncapMode: config.TrafficEncapModeNoEncap}},
+		{"hybrid", &config.NetworkConfig{TrafficEncapMode: config.TrafficEncapModeHybrid}},
+		{"WireGuard", &config.NetworkConfig{TrafficEncapMode: config.TrafficEncapModeEncap, TrafficEncryptionMode: config.TrafficEncryptionModeWireGuard}},
+	}
+
+	type testCase struct {
 		name               string
 		networkConfig      *config.NetworkConfig
 		nodeConfig         *config.NodeConfig
@@ -285,291 +316,8 @@ func TestParsePacketIn(t *testing.T) {
 		expectedCalls      func(*queriertest.MockAgentNetworkPolicyInfoQuerier, *queriertest.MockEgressQuerier)
 		expectedTf         *crdv1beta1.Traceflow
 		expectedNodeResult *crdv1beta1.NodeResult
-	}{
-		{
-			name: "packet at source Node for local Egress",
-			networkConfig: &config.NetworkConfig{
-				TrafficEncapMode: 0,
-			},
-			nodeConfig: &config.NodeConfig{
-				TunnelOFPort: 1,
-				GatewayConfig: &config.GatewayConfig{
-					OFPort: 2,
-				},
-			},
-			tfState: &traceflowState{
-				name:     "traceflow-pod-to-ipv4",
-				tag:      1,
-				isSender: true,
-			},
-			pktIn: &ofctrl.PacketIn{
-				PacketIn: &openflow15.PacketIn{
-					TableId: openflow.OutputTable.GetID(),
-					Match: openflow15.Match{
-						Fields: []openflow15.MatchField{*matchOutPort, *matchPktMark, *matchCTSrc},
-					},
-					Data: util.NewBuffer(pktBytesPodToIP),
-				},
-			},
-			expectedCalls: func(npQuerierq *queriertest.MockAgentNetworkPolicyInfoQuerier, egressQuerier *queriertest.MockEgressQuerier) {
-				egressQuerier.EXPECT().GetEgress(pod1.Namespace, pod1.Name).Return(types.EgressConfig{
-					Name:       egressName,
-					EgressIP:   egressIP,
-					EgressNode: egressNode,
-				}, nil)
-			},
-			expectedTf: &crdv1beta1.Traceflow{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "traceflow-pod-to-ipv4",
-				},
-				Spec: crdv1beta1.TraceflowSpec{
-					Source: crdv1beta1.Source{
-						Namespace: pod1.Namespace,
-						Pod:       pod1.Name,
-					},
-					Destination: crdv1beta1.Destination{
-						IP: dstIPv4,
-					},
-				},
-				Status: crdv1beta1.TraceflowStatus{
-					Phase:        crdv1beta1.Running,
-					DataplaneTag: 1,
-				},
-			},
-			expectedNodeResult: &crdv1beta1.NodeResult{
-				Observations: []crdv1beta1.Observation{
-					{
-						Component: crdv1beta1.ComponentSpoofGuard,
-						Action:    crdv1beta1.ActionForwarded,
-						SrcPodIP:  pod1IPv4,
-					},
-					{
-						Component:  crdv1beta1.ComponentEgress,
-						Action:     crdv1beta1.ActionMarkedForSNAT,
-						Egress:     egressName,
-						EgressIP:   egressIP,
-						EgressNode: egressNode,
-					},
-					{
-						Component:     crdv1beta1.ComponentForwarding,
-						ComponentInfo: openflow.OutputTable.GetName(),
-						Action:        crdv1beta1.ActionForwardedOutOfNetwork,
-					},
-				},
-			},
-		},
-		{
-			name: "packet at source Node for remote Egress",
-			networkConfig: &config.NetworkConfig{
-				TrafficEncapMode: 0,
-			},
-			nodeConfig: &config.NodeConfig{
-				TunnelOFPort: 2,
-				GatewayConfig: &config.GatewayConfig{
-					OFPort: 1,
-				},
-			},
-			tfState: &traceflowState{
-				name:     "traceflow-pod-to-ipv4",
-				tag:      1,
-				isSender: true,
-			},
-			pktIn: &ofctrl.PacketIn{
-				PacketIn: &openflow15.PacketIn{
-					TableId: openflow.OutputTable.GetID(),
-					Match: openflow15.Match{
-						// We are omitting matchCTSrc intentionally here to test
-						// the case where there is no valid ct_nw_src match in the packet metadata.
-						Fields: []openflow15.MatchField{*matchTunDst, *matchOutPort},
-					},
-					Data: util.NewBuffer(pktBytesPodToIP),
-				},
-			},
-			expectedCalls: func(npQuerierq *queriertest.MockAgentNetworkPolicyInfoQuerier, egressQuerier *queriertest.MockEgressQuerier) {
-				egressQuerier.EXPECT().GetEgress(pod1.Namespace, pod1.Name).Return(types.EgressConfig{
-					Name:       egressName,
-					EgressIP:   egressIP,
-					EgressNode: egressNode,
-				}, nil)
-			},
-			expectedTf: &crdv1beta1.Traceflow{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "traceflow-pod-to-ipv4",
-				},
-				Spec: crdv1beta1.TraceflowSpec{
-					Source: crdv1beta1.Source{
-						Namespace: pod1.Namespace,
-						Pod:       pod1.Name,
-					},
-					Destination: crdv1beta1.Destination{
-						IP: dstIPv4,
-					},
-				},
-				Status: crdv1beta1.TraceflowStatus{
-					Phase:        crdv1beta1.Running,
-					DataplaneTag: 1,
-				},
-			},
-			expectedNodeResult: &crdv1beta1.NodeResult{
-				Observations: []crdv1beta1.Observation{
-					{
-						Component: crdv1beta1.ComponentSpoofGuard,
-						Action:    crdv1beta1.ActionForwarded,
-						SrcPodIP:  pod1IPv4,
-					},
-					{
-						Component:  crdv1beta1.ComponentEgress,
-						Action:     crdv1beta1.ActionForwardedToEgressNode,
-						Egress:     egressName,
-						EgressIP:   egressIP,
-						EgressNode: egressNode,
-					},
-					{
-						Component:     crdv1beta1.ComponentForwarding,
-						ComponentInfo: openflow.OutputTable.GetName(),
-						Action:        crdv1beta1.ActionForwarded,
-						TunnelDstIP:   egressIP,
-					},
-				},
-			},
-		},
-		{
-			name: "marked packet to remote Pod in hybrid mode",
-			networkConfig: &config.NetworkConfig{
-				TrafficEncapMode: config.TrafficEncapModeHybrid,
-			},
-			nodeConfig: &config.NodeConfig{
-				TunnelOFPort: 1,
-				GatewayConfig: &config.GatewayConfig{
-					OFPort: 2,
-				},
-			},
-			tfState: &traceflowState{
-				name:     "traceflow-pod-to-pod",
-				tag:      1,
-				isSender: true,
-			},
-			pktIn: &ofctrl.PacketIn{
-				PacketIn: &openflow15.PacketIn{
-					TableId: openflow.OutputTable.GetID(),
-					Match: openflow15.Match{
-						Fields: []openflow15.MatchField{*matchOutPort, *matchPktMark, *matchCTSrc},
-					},
-					Data: util.NewBuffer(pktBytesPodToPod),
-				},
-			},
-			expectedCalls: func(npQuerierq *queriertest.MockAgentNetworkPolicyInfoQuerier, egressQuerier *queriertest.MockEgressQuerier) {
-				egressQuerier.EXPECT().GetEgress(pod1.Namespace, pod1.Name).Return(types.EgressConfig{
-					Name:       egressName,
-					EgressIP:   egressIP,
-					EgressNode: egressNode,
-				}, nil)
-			},
-			expectedTf: &crdv1beta1.Traceflow{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "traceflow-pod-to-pod",
-				},
-				Spec: crdv1beta1.TraceflowSpec{
-					Source: crdv1beta1.Source{
-						Namespace: pod1.Namespace,
-						Pod:       pod1.Name,
-					},
-					Destination: crdv1beta1.Destination{
-						Namespace: pod2.Namespace,
-						Pod:       pod2.Name,
-					},
-				},
-				Status: crdv1beta1.TraceflowStatus{
-					Phase:        crdv1beta1.Running,
-					DataplaneTag: 1,
-				},
-			},
-			expectedNodeResult: &crdv1beta1.NodeResult{
-				Observations: []crdv1beta1.Observation{
-					{
-						Component: crdv1beta1.ComponentSpoofGuard,
-						Action:    crdv1beta1.ActionForwarded,
-						SrcPodIP:  pod1IPv4,
-					},
-					{
-						Component:  crdv1beta1.ComponentEgress,
-						Action:     crdv1beta1.ActionMarkedForSNAT,
-						Egress:     egressName,
-						EgressIP:   egressIP,
-						EgressNode: egressNode,
-					},
-					{
-						Component:     crdv1beta1.ComponentForwarding,
-						ComponentInfo: openflow.OutputTable.GetName(),
-						Action:        crdv1beta1.ActionForwardedOutOfNetwork,
-					},
-				},
-			},
-		},
-		{
-			name: "packet at remote Node for remote Egress",
-			networkConfig: &config.NetworkConfig{
-				TrafficEncapMode: 0,
-			},
-			nodeConfig: &config.NodeConfig{
-				TunnelOFPort: 1,
-				GatewayConfig: &config.GatewayConfig{
-					OFPort: 2,
-				},
-			},
-			tfState: &traceflowState{
-				name: "traceflow-pod-to-ipv4",
-				tag:  1,
-			},
-			pktIn: &ofctrl.PacketIn{
-				PacketIn: &openflow15.PacketIn{
-					TableId: openflow.OutputTable.GetID(),
-					Match: openflow15.Match{
-						Fields: []openflow15.MatchField{*matchOutPort, *matchTunDst, *matchPktMark},
-					},
-					Data: util.NewBuffer(pktBytesPodToIP),
-				},
-			},
-			expectedCalls: func(npQuerierq *queriertest.MockAgentNetworkPolicyInfoQuerier, egressQuerier *queriertest.MockEgressQuerier) {
-				egressQuerier.EXPECT().GetEgressIPByMark(uint32(1)).Return(egressIP, nil)
-			},
-			expectedTf: &crdv1beta1.Traceflow{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "traceflow-pod-to-ipv4",
-				},
-				Spec: crdv1beta1.TraceflowSpec{
-					Source: crdv1beta1.Source{
-						Namespace: pod1.Namespace,
-						Pod:       pod1.Name,
-					},
-					Destination: crdv1beta1.Destination{
-						IP: dstIPv4,
-					},
-				},
-				Status: crdv1beta1.TraceflowStatus{
-					Phase:        crdv1beta1.Running,
-					DataplaneTag: 1,
-				},
-			},
-			expectedNodeResult: &crdv1beta1.NodeResult{
-				Observations: []crdv1beta1.Observation{
-					{
-						Component: crdv1beta1.ComponentForwarding,
-						Action:    crdv1beta1.ActionReceived,
-					},
-					{
-						Component: crdv1beta1.ComponentEgress,
-						Action:    crdv1beta1.ActionMarkedForSNAT,
-						EgressIP:  egressIP,
-					},
-					{
-						Component:     crdv1beta1.ComponentForwarding,
-						ComponentInfo: openflow.OutputTable.GetName(),
-						Action:        crdv1beta1.ActionForwardedOutOfNetwork,
-					},
-				},
-			},
-		},
+	}
+	tests := []testCase{
 		{
 			name:       "packet at source Node forwarded by acnp egress rule",
 			nodeConfig: &config.NodeConfig{},
@@ -764,250 +512,162 @@ func TestParsePacketIn(t *testing.T) {
 				},
 			},
 		},
-		{
-			name: "packet at source Node to remote Pod with WireGuard",
-			networkConfig: &config.NetworkConfig{
-				TrafficEncapMode:      config.TrafficEncapModeEncap,
-				TrafficEncryptionMode: config.TrafficEncryptionModeWireGuard,
+	}
+	for _, mode := range trafficModes {
+		tests = append(tests, testCase{
+			name:          "packet at source Node for local Egress " + mode.name,
+			networkConfig: mode.networkConfig,
+			nodeConfig:    makeNodeConfig(1, 2),
+			tfState:       &traceflowState{name: "traceflow-pod-to-ipv4", tag: 1, isSender: true},
+			pktIn: &ofctrl.PacketIn{PacketIn: &openflow15.PacketIn{
+				TableId: openflow.OutputTable.GetID(),
+				Match:   openflow15.Match{Fields: []openflow15.MatchField{*matchOutPort, *matchPktMark, *matchCTSrc}},
+				Data:    util.NewBuffer(pktBytesPodToIP),
+			}},
+			expectedCalls: func(_ *queriertest.MockAgentNetworkPolicyInfoQuerier, eq *queriertest.MockEgressQuerier) {
+				eq.EXPECT().GetEgress(pod1.Namespace, pod1.Name).Return(egressConfig, nil)
 			},
-			nodeConfig: &config.NodeConfig{
-				TunnelOFPort: 1,
-				GatewayConfig: &config.GatewayConfig{
-					OFPort: 2,
-				},
+			expectedTf: makePodToIPv4TF(),
+			expectedNodeResult: &crdv1beta1.NodeResult{Observations: []crdv1beta1.Observation{
+				{Component: crdv1beta1.ComponentSpoofGuard, Action: crdv1beta1.ActionForwarded, SrcPodIP: pod1IPv4},
+				{Component: crdv1beta1.ComponentEgress, Action: crdv1beta1.ActionMarkedForSNAT, Egress: egressName, EgressIP: egressIP, EgressNode: egressNode},
+				{Component: crdv1beta1.ComponentForwarding, ComponentInfo: openflow.OutputTable.GetName(), Action: crdv1beta1.ActionForwardedOutOfNetwork},
+			}},
+		})
+	}
+	for _, mode := range trafficModes {
+		tests = append(tests, testCase{
+			name:          "packet at source Node for remote Egress " + mode.name,
+			networkConfig: mode.networkConfig,
+			nodeConfig:    makeNodeConfig(2, 1),
+			tfState:       &traceflowState{name: "traceflow-pod-to-ipv4", tag: 1, isSender: true},
+			pktIn: &ofctrl.PacketIn{PacketIn: &openflow15.PacketIn{
+				TableId: openflow.OutputTable.GetID(),
+				Match:   openflow15.Match{Fields: []openflow15.MatchField{*matchTunDst, *matchOutPort}},
+				Data:    util.NewBuffer(pktBytesPodToIP),
+			}},
+			expectedCalls: func(_ *queriertest.MockAgentNetworkPolicyInfoQuerier, eq *queriertest.MockEgressQuerier) {
+				eq.EXPECT().GetEgress(pod1.Namespace, pod1.Name).Return(egressConfig, nil)
 			},
-			tfState: &traceflowState{
-				name:     "traceflow-pod-to-pod",
-				tag:      1,
-				isSender: true,
+			expectedTf: makePodToIPv4TF(),
+			expectedNodeResult: &crdv1beta1.NodeResult{Observations: []crdv1beta1.Observation{
+				{Component: crdv1beta1.ComponentSpoofGuard, Action: crdv1beta1.ActionForwarded, SrcPodIP: pod1IPv4},
+				{Component: crdv1beta1.ComponentEgress, Action: crdv1beta1.ActionForwardedToEgressNode, Egress: egressName, EgressIP: egressIP, EgressNode: egressNode},
+				{Component: crdv1beta1.ComponentForwarding, ComponentInfo: openflow.OutputTable.GetName(), Action: crdv1beta1.ActionForwarded, TunnelDstIP: egressIP},
+			}},
+		})
+	}
+	// The output register is not always set. The packet then went to a port which is neither the tunnel
+	// port nor the gateway port, and reporting it as delivered to a Pod would be wrong.
+	tests = append(tests, testCase{
+		name:          "packet at source Node with the output register unset",
+		networkConfig: &config.NetworkConfig{TrafficEncapMode: config.TrafficEncapModeNoEncap},
+		nodeConfig:    makeNodeConfig(1, 2),
+		tfState:       &traceflowState{name: "traceflow-pod-to-ipv4", tag: 1, isSender: true},
+		pktIn: &ofctrl.PacketIn{PacketIn: &openflow15.PacketIn{
+			TableId: openflow.OutputTable.GetID(),
+			Match:   openflow15.Match{Fields: []openflow15.MatchField{*matchCTSrc}},
+			Data:    util.NewBuffer(pktBytesPodToIP),
+		}},
+		expectedCalls: func(_ *queriertest.MockAgentNetworkPolicyInfoQuerier, _ *queriertest.MockEgressQuerier) {},
+		expectedTf:    makePodToIPv4TF(),
+		expectedNodeResult: &crdv1beta1.NodeResult{Observations: []crdv1beta1.Observation{
+			{Component: crdv1beta1.ComponentSpoofGuard, Action: crdv1beta1.ActionForwarded, SrcPodIP: pod1IPv4},
+			{Component: crdv1beta1.ComponentForwarding, ComponentInfo: openflow.OutputTable.GetName()},
+		}},
+	})
+	for _, mode := range trafficModes {
+		tests = append(tests, testCase{
+			name:          "packet at remote Node for remote Egress " + mode.name,
+			networkConfig: mode.networkConfig,
+			nodeConfig:    makeNodeConfig(1, 2),
+			tfState:       &traceflowState{name: "traceflow-pod-to-ipv4", tag: 1},
+			pktIn: &ofctrl.PacketIn{PacketIn: &openflow15.PacketIn{
+				TableId: openflow.OutputTable.GetID(),
+				Match:   openflow15.Match{Fields: []openflow15.MatchField{*matchOutPort, *matchTunDst, *matchPktMark}},
+				Data:    util.NewBuffer(pktBytesPodToIP),
+			}},
+			expectedCalls: func(_ *queriertest.MockAgentNetworkPolicyInfoQuerier, eq *queriertest.MockEgressQuerier) {
+				eq.EXPECT().GetEgressIPByMark(uint32(1)).Return(egressIP, nil)
 			},
-			pktIn: &ofctrl.PacketIn{
-				PacketIn: &openflow15.PacketIn{
-					TableId: openflow.OutputTable.GetID(),
-					Match: openflow15.Match{
-						Fields: []openflow15.MatchField{*matchOutPort, *matchCTSrc},
-					},
-					Data: util.NewBuffer(pktBytesPodToPod),
-				},
+			expectedTf: makePodToIPv4TF(),
+			expectedNodeResult: &crdv1beta1.NodeResult{Observations: []crdv1beta1.Observation{
+				{Component: crdv1beta1.ComponentForwarding, Action: crdv1beta1.ActionReceived},
+				{Component: crdv1beta1.ComponentEgress, Action: crdv1beta1.ActionMarkedForSNAT, EgressIP: egressIP},
+				{Component: crdv1beta1.ComponentForwarding, ComponentInfo: openflow.OutputTable.GetName(), Action: crdv1beta1.ActionForwardedOutOfNetwork},
+			}},
+		})
+	}
+	for _, mode := range trafficModes {
+		tests = append(tests, testCase{
+			name:          "packet at source Node to external " + mode.name,
+			networkConfig: mode.networkConfig,
+			nodeConfig:    makeNodeConfig(1, 2),
+			tfState:       &traceflowState{name: "traceflow-pod-to-ipv4", tag: 1, isSender: true},
+			pktIn: &ofctrl.PacketIn{PacketIn: &openflow15.PacketIn{
+				TableId: openflow.OutputTable.GetID(),
+				Match:   openflow15.Match{Fields: []openflow15.MatchField{*matchOutPort, *matchCTSrc}},
+				Data:    util.NewBuffer(pktBytesPodToIP),
+			}},
+			expectedCalls: func(_ *queriertest.MockAgentNetworkPolicyInfoQuerier, _ *queriertest.MockEgressQuerier) {},
+			expectedTf:    makePodToIPv4TF(),
+			expectedNodeResult: &crdv1beta1.NodeResult{Observations: []crdv1beta1.Observation{
+				{Component: crdv1beta1.ComponentSpoofGuard, Action: crdv1beta1.ActionForwarded, SrcPodIP: pod1IPv4},
+				{Component: crdv1beta1.ComponentForwarding, ComponentInfo: openflow.OutputTable.GetName(), Action: crdv1beta1.ActionForwardedOutOfNetwork},
+			}},
+		})
+	}
+	for _, mode := range trafficModes {
+		podRouteAction := crdv1beta1.ActionForwarded
+		tunnelDstIP := ""
+		if mode.networkConfig.TrafficEncryptionMode == config.TrafficEncryptionModeWireGuard {
+			// WireGuard reports the peer Node transport IP resolved via NodeRoute.
+			tunnelDstIP = peerNodeIP
+		} else if mode.networkConfig.TrafficEncapMode == config.TrafficEncapModeEncap {
+			podRouteAction = crdv1beta1.ActionForwardedOutOfNetwork
+		}
+		tests = append(tests, testCase{
+			name:          "packet at source Node to remote Pod " + mode.name,
+			networkConfig: mode.networkConfig,
+			nodeConfig:    makeNodeConfig(1, 2),
+			tfState:       &traceflowState{name: "traceflow-pod-to-ipv4", tag: 1, isSender: true},
+			pktIn: &ofctrl.PacketIn{PacketIn: &openflow15.PacketIn{
+				TableId: openflow.OutputTable.GetID(),
+				Match:   openflow15.Match{Fields: []openflow15.MatchField{*matchOutPort, *matchCTSrc}},
+				Data:    util.NewBuffer(pktBytesPodToPod),
+			}},
+			expectedCalls: func(_ *queriertest.MockAgentNetworkPolicyInfoQuerier, _ *queriertest.MockEgressQuerier) {},
+			expectedTf:    makePodToIPv4TF(),
+			expectedNodeResult: &crdv1beta1.NodeResult{Observations: []crdv1beta1.Observation{
+				{Component: crdv1beta1.ComponentSpoofGuard, Action: crdv1beta1.ActionForwarded, SrcPodIP: pod1IPv4},
+				{Component: crdv1beta1.ComponentForwarding, ComponentInfo: openflow.OutputTable.GetName(), Action: podRouteAction, TunnelDstIP: tunnelDstIP},
+			}},
+		})
+	}
+	for _, mode := range trafficModes {
+		// Marked (Egress) packets must keep the ForwardedOutOfNetwork action even when the
+		// destination is a remote Pod IP, since the Pod destination classification only
+		// applies to unmarked packets.
+		tests = append(tests, testCase{
+			name:          "marked packet to remote Pod " + mode.name,
+			networkConfig: mode.networkConfig,
+			nodeConfig:    makeNodeConfig(1, 2),
+			tfState:       &traceflowState{name: "traceflow-pod-to-ipv4", tag: 1, isSender: true},
+			pktIn: &ofctrl.PacketIn{PacketIn: &openflow15.PacketIn{
+				TableId: openflow.OutputTable.GetID(),
+				Match:   openflow15.Match{Fields: []openflow15.MatchField{*matchOutPort, *matchPktMark, *matchCTSrc}},
+				Data:    util.NewBuffer(pktBytesPodToPod),
+			}},
+			expectedCalls: func(_ *queriertest.MockAgentNetworkPolicyInfoQuerier, eq *queriertest.MockEgressQuerier) {
+				eq.EXPECT().GetEgress(pod1.Namespace, pod1.Name).Return(egressConfig, nil)
 			},
-			expectedCalls: func(npQuerierq *queriertest.MockAgentNetworkPolicyInfoQuerier, egressQuerier *queriertest.MockEgressQuerier) {
-			},
-			expectedTf: &crdv1beta1.Traceflow{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "traceflow-pod-to-pod",
-				},
-				Spec: crdv1beta1.TraceflowSpec{
-					Source: crdv1beta1.Source{
-						Namespace: pod1.Namespace,
-						Pod:       pod1.Name,
-					},
-					Destination: crdv1beta1.Destination{
-						Namespace: pod2.Namespace,
-						Pod:       pod2.Name,
-					},
-				},
-				Status: crdv1beta1.TraceflowStatus{
-					Phase:        crdv1beta1.Running,
-					DataplaneTag: 1,
-				},
-			},
-			expectedNodeResult: &crdv1beta1.NodeResult{
-				Observations: []crdv1beta1.Observation{
-					{
-						Component: crdv1beta1.ComponentSpoofGuard,
-						Action:    crdv1beta1.ActionForwarded,
-						SrcPodIP:  pod1IPv4,
-					},
-					{
-						Component:     crdv1beta1.ComponentForwarding,
-						ComponentInfo: openflow.OutputTable.GetName(),
-						Action:        crdv1beta1.ActionForwarded,
-						TunnelDstIP:   peerNodeIP,
-					},
-				},
-			},
-		},
-		{
-			name: "packet at source Node to external with WireGuard",
-			networkConfig: &config.NetworkConfig{
-				TrafficEncapMode:      config.TrafficEncapModeEncap,
-				TrafficEncryptionMode: config.TrafficEncryptionModeWireGuard,
-			},
-			nodeConfig: &config.NodeConfig{
-				TunnelOFPort: 1,
-				GatewayConfig: &config.GatewayConfig{
-					OFPort: 2,
-				},
-			},
-			tfState: &traceflowState{
-				name:     "traceflow-pod-to-ipv4",
-				tag:      1,
-				isSender: true,
-			},
-			pktIn: &ofctrl.PacketIn{
-				PacketIn: &openflow15.PacketIn{
-					TableId: openflow.OutputTable.GetID(),
-					Match: openflow15.Match{
-						Fields: []openflow15.MatchField{*matchOutPort, *matchCTSrc},
-					},
-					Data: util.NewBuffer(pktBytesPodToIP),
-				},
-			},
-			expectedCalls: func(npQuerierq *queriertest.MockAgentNetworkPolicyInfoQuerier, egressQuerier *queriertest.MockEgressQuerier) {
-			},
-			expectedTf: &crdv1beta1.Traceflow{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "traceflow-pod-to-ipv4",
-				},
-				Spec: crdv1beta1.TraceflowSpec{
-					Source: crdv1beta1.Source{
-						Namespace: pod1.Namespace,
-						Pod:       pod1.Name,
-					},
-					Destination: crdv1beta1.Destination{
-						IP: dstIPv4,
-					},
-				},
-				Status: crdv1beta1.TraceflowStatus{
-					Phase:        crdv1beta1.Running,
-					DataplaneTag: 1,
-				},
-			},
-			expectedNodeResult: &crdv1beta1.NodeResult{
-				Observations: []crdv1beta1.Observation{
-					{
-						Component: crdv1beta1.ComponentSpoofGuard,
-						Action:    crdv1beta1.ActionForwarded,
-						SrcPodIP:  pod1IPv4,
-					},
-					{
-						Component:     crdv1beta1.ComponentForwarding,
-						ComponentInfo: openflow.OutputTable.GetName(),
-						Action:        crdv1beta1.ActionForwardedOutOfNetwork,
-					},
-				},
-			},
-		},
-		{
-			name: "packet at source Node to external NoEncap",
-			networkConfig: &config.NetworkConfig{
-				TrafficEncapMode: 1,
-			},
-			nodeConfig: &config.NodeConfig{
-				TunnelOFPort: 1,
-				GatewayConfig: &config.GatewayConfig{
-					OFPort: 2,
-				},
-			},
-			tfState: &traceflowState{
-				name:     "traceflow-pod-to-ipv4",
-				tag:      1,
-				isSender: true,
-			},
-			pktIn: &ofctrl.PacketIn{
-				PacketIn: &openflow15.PacketIn{
-					TableId: openflow.OutputTable.GetID(),
-					Match: openflow15.Match{
-						Fields: []openflow15.MatchField{*matchOutPort, *matchCTSrc},
-					},
-					Data: util.NewBuffer(pktBytesPodToIP),
-				},
-			},
-			expectedCalls: func(npQuerierq *queriertest.MockAgentNetworkPolicyInfoQuerier, egressQuerier *queriertest.MockEgressQuerier) {
-			},
-			expectedTf: &crdv1beta1.Traceflow{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "traceflow-pod-to-ipv4",
-				},
-				Spec: crdv1beta1.TraceflowSpec{
-					Source: crdv1beta1.Source{
-						Namespace: pod1.Namespace,
-						Pod:       pod1.Name,
-					},
-					Destination: crdv1beta1.Destination{
-						IP: dstIPv4,
-					},
-				},
-				Status: crdv1beta1.TraceflowStatus{
-					Phase:        crdv1beta1.Running,
-					DataplaneTag: 1,
-				},
-			},
-			expectedNodeResult: &crdv1beta1.NodeResult{
-				Observations: []crdv1beta1.Observation{
-					{
-						Component: crdv1beta1.ComponentSpoofGuard,
-						Action:    crdv1beta1.ActionForwarded,
-						SrcPodIP:  pod1IPv4,
-					},
-					{
-						Component:     crdv1beta1.ComponentForwarding,
-						ComponentInfo: openflow.OutputTable.GetName(),
-						Action:        crdv1beta1.ActionForwardedOutOfNetwork,
-					},
-				},
-			},
-		},
-		{
-			name: "packet at source Node to remote Pod NoEncap",
-			networkConfig: &config.NetworkConfig{
-				TrafficEncapMode: 1,
-			},
-			nodeConfig: &config.NodeConfig{
-				TunnelOFPort: 1,
-				GatewayConfig: &config.GatewayConfig{
-					OFPort: 2,
-				},
-			},
-			tfState: &traceflowState{
-				name:     "traceflow-pod-to-ipv4",
-				tag:      1,
-				isSender: true,
-			},
-			pktIn: &ofctrl.PacketIn{
-				PacketIn: &openflow15.PacketIn{
-					TableId: openflow.OutputTable.GetID(),
-					Match: openflow15.Match{
-						Fields: []openflow15.MatchField{*matchOutPort, *matchCTSrc},
-					},
-					Data: util.NewBuffer(pktBytesPodToPod),
-				},
-			},
-			expectedCalls: func(npQuerierq *queriertest.MockAgentNetworkPolicyInfoQuerier, egressQuerier *queriertest.MockEgressQuerier) {
-			},
-			expectedTf: &crdv1beta1.Traceflow{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "traceflow-pod-to-ipv4",
-				},
-				Spec: crdv1beta1.TraceflowSpec{
-					Source: crdv1beta1.Source{
-						Namespace: pod1.Namespace,
-						Pod:       pod1.Name,
-					},
-					Destination: crdv1beta1.Destination{
-						IP: dstIPv4,
-					},
-				},
-				Status: crdv1beta1.TraceflowStatus{
-					Phase:        crdv1beta1.Running,
-					DataplaneTag: 1,
-				},
-			},
-			expectedNodeResult: &crdv1beta1.NodeResult{
-				Observations: []crdv1beta1.Observation{
-					{
-						Component: crdv1beta1.ComponentSpoofGuard,
-						Action:    crdv1beta1.ActionForwarded,
-						SrcPodIP:  pod1IPv4,
-					},
-					{
-						Component:     crdv1beta1.ComponentForwarding,
-						ComponentInfo: openflow.OutputTable.GetName(),
-						Action:        crdv1beta1.ActionForwarded,
-					},
-				},
-			},
-		},
+			expectedTf: makePodToIPv4TF(),
+			expectedNodeResult: &crdv1beta1.NodeResult{Observations: []crdv1beta1.Observation{
+				{Component: crdv1beta1.ComponentSpoofGuard, Action: crdv1beta1.ActionForwarded, SrcPodIP: pod1IPv4},
+				{Component: crdv1beta1.ComponentEgress, Action: crdv1beta1.ActionMarkedForSNAT, Egress: egressName, EgressIP: egressIP, EgressNode: egressNode},
+				{Component: crdv1beta1.ComponentForwarding, ComponentInfo: openflow.OutputTable.GetName(), Action: crdv1beta1.ActionForwardedOutOfNetwork},
+			}},
+		})
 	}
 
 	for _, tt := range tests {
@@ -1030,7 +690,7 @@ func TestParsePacketIn(t *testing.T) {
 
 func TestParsePacketInLiveDuplicates(t *testing.T) {
 	networkConfig := &config.NetworkConfig{
-		TrafficEncapMode: 0,
+		TrafficEncapMode: config.TrafficEncapModeEncap,
 	}
 	nodeConfig := &config.NodeConfig{
 		TunnelOFPort: 1,

--- a/pkg/agent/controller/traceflow/packetin_test.go
+++ b/pkg/agent/controller/traceflow/packetin_test.go
@@ -221,6 +221,7 @@ func getTestPacketBytes(dstIP string) []byte {
 }
 
 func TestParsePacketIn(t *testing.T) {
+	prepareMockTables()
 	xreg0 := make([]byte, 8)
 	binary.BigEndian.PutUint32(xreg0[0:4], openflow.RemoteSNATRegMark.GetValue()<<openflow.RemoteSNATRegMark.GetField().GetRange().Offset()) // RemoteSNATRegMark in 32bit reg0
 	binary.BigEndian.PutUint32(xreg0[4:8], 2)                                                                                                // outputPort in 32bit reg1
@@ -274,9 +275,39 @@ func TestParsePacketIn(t *testing.T) {
 
 	pktBytesPodToIP := getTestPacketBytes(dstIPv4)
 	pktBytesPodToPod := getTestPacketBytes(pod2IPv4)
+	// The peer Node transport IP returned by fakeNodeRouteQuerier for Pod IPs in podCIDR2.
 	peerNodeIP := "192.168.77.77"
 
-	tests := []struct {
+	makePodToIPv4TF := func() *crdv1beta1.Traceflow {
+		return &crdv1beta1.Traceflow{
+			ObjectMeta: metav1.ObjectMeta{Name: "traceflow-pod-to-ipv4"},
+			Spec: crdv1beta1.TraceflowSpec{
+				Source:      crdv1beta1.Source{Namespace: pod1.Namespace, Pod: pod1.Name},
+				Destination: crdv1beta1.Destination{IP: dstIPv4},
+			},
+			Status: crdv1beta1.TraceflowStatus{Phase: crdv1beta1.Running, DataplaneTag: 1},
+		}
+	}
+	makeNodeConfig := func(tunPort, gwPort uint32) *config.NodeConfig {
+		return &config.NodeConfig{
+			TunnelOFPort:  tunPort,
+			GatewayConfig: &config.GatewayConfig{OFPort: gwPort},
+		}
+	}
+	egressConfig := types.EgressConfig{Name: egressName, EgressIP: egressIP, EgressNode: egressNode}
+
+	type trafficMode struct {
+		name          string
+		networkConfig *config.NetworkConfig
+	}
+	trafficModes := []trafficMode{
+		{"encap", &config.NetworkConfig{TrafficEncapMode: config.TrafficEncapModeEncap}},
+		{"noEncap", &config.NetworkConfig{TrafficEncapMode: config.TrafficEncapModeNoEncap}},
+		{"hybrid", &config.NetworkConfig{TrafficEncapMode: config.TrafficEncapModeHybrid}},
+		{"WireGuard", &config.NetworkConfig{TrafficEncapMode: config.TrafficEncapModeEncap, TrafficEncryptionMode: config.TrafficEncryptionModeWireGuard}},
+	}
+
+	type testCase struct {
 		name               string
 		networkConfig      *config.NetworkConfig
 		nodeConfig         *config.NodeConfig
@@ -285,291 +316,8 @@ func TestParsePacketIn(t *testing.T) {
 		expectedCalls      func(*queriertest.MockAgentNetworkPolicyInfoQuerier, *queriertest.MockEgressQuerier)
 		expectedTf         *crdv1beta1.Traceflow
 		expectedNodeResult *crdv1beta1.NodeResult
-	}{
-		{
-			name: "packet at source Node for local Egress",
-			networkConfig: &config.NetworkConfig{
-				TrafficEncapMode: 0,
-			},
-			nodeConfig: &config.NodeConfig{
-				TunnelOFPort: 1,
-				GatewayConfig: &config.GatewayConfig{
-					OFPort: 2,
-				},
-			},
-			tfState: &traceflowState{
-				name:     "traceflow-pod-to-ipv4",
-				tag:      1,
-				isSender: true,
-			},
-			pktIn: &ofctrl.PacketIn{
-				PacketIn: &openflow15.PacketIn{
-					TableId: openflow.OutputTable.GetID(),
-					Match: openflow15.Match{
-						Fields: []openflow15.MatchField{*matchOutPort, *matchPktMark, *matchCTSrc},
-					},
-					Data: util.NewBuffer(pktBytesPodToIP),
-				},
-			},
-			expectedCalls: func(npQuerierq *queriertest.MockAgentNetworkPolicyInfoQuerier, egressQuerier *queriertest.MockEgressQuerier) {
-				egressQuerier.EXPECT().GetEgress(pod1.Namespace, pod1.Name).Return(types.EgressConfig{
-					Name:       egressName,
-					EgressIP:   egressIP,
-					EgressNode: egressNode,
-				}, nil)
-			},
-			expectedTf: &crdv1beta1.Traceflow{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "traceflow-pod-to-ipv4",
-				},
-				Spec: crdv1beta1.TraceflowSpec{
-					Source: crdv1beta1.Source{
-						Namespace: pod1.Namespace,
-						Pod:       pod1.Name,
-					},
-					Destination: crdv1beta1.Destination{
-						IP: dstIPv4,
-					},
-				},
-				Status: crdv1beta1.TraceflowStatus{
-					Phase:        crdv1beta1.Running,
-					DataplaneTag: 1,
-				},
-			},
-			expectedNodeResult: &crdv1beta1.NodeResult{
-				Observations: []crdv1beta1.Observation{
-					{
-						Component: crdv1beta1.ComponentSpoofGuard,
-						Action:    crdv1beta1.ActionForwarded,
-						SrcPodIP:  pod1IPv4,
-					},
-					{
-						Component:  crdv1beta1.ComponentEgress,
-						Action:     crdv1beta1.ActionMarkedForSNAT,
-						Egress:     egressName,
-						EgressIP:   egressIP,
-						EgressNode: egressNode,
-					},
-					{
-						Component:     crdv1beta1.ComponentForwarding,
-						ComponentInfo: openflow.OutputTable.GetName(),
-						Action:        crdv1beta1.ActionForwardedOutOfNetwork,
-					},
-				},
-			},
-		},
-		{
-			name: "packet at source Node for remote Egress",
-			networkConfig: &config.NetworkConfig{
-				TrafficEncapMode: 0,
-			},
-			nodeConfig: &config.NodeConfig{
-				TunnelOFPort: 2,
-				GatewayConfig: &config.GatewayConfig{
-					OFPort: 1,
-				},
-			},
-			tfState: &traceflowState{
-				name:     "traceflow-pod-to-ipv4",
-				tag:      1,
-				isSender: true,
-			},
-			pktIn: &ofctrl.PacketIn{
-				PacketIn: &openflow15.PacketIn{
-					TableId: openflow.OutputTable.GetID(),
-					Match: openflow15.Match{
-						// We are omitting matchCTSrc intentionally here to test
-						// the case where there is no valid ct_nw_src match in the packet metadata.
-						Fields: []openflow15.MatchField{*matchTunDst, *matchOutPort},
-					},
-					Data: util.NewBuffer(pktBytesPodToIP),
-				},
-			},
-			expectedCalls: func(npQuerierq *queriertest.MockAgentNetworkPolicyInfoQuerier, egressQuerier *queriertest.MockEgressQuerier) {
-				egressQuerier.EXPECT().GetEgress(pod1.Namespace, pod1.Name).Return(types.EgressConfig{
-					Name:       egressName,
-					EgressIP:   egressIP,
-					EgressNode: egressNode,
-				}, nil)
-			},
-			expectedTf: &crdv1beta1.Traceflow{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "traceflow-pod-to-ipv4",
-				},
-				Spec: crdv1beta1.TraceflowSpec{
-					Source: crdv1beta1.Source{
-						Namespace: pod1.Namespace,
-						Pod:       pod1.Name,
-					},
-					Destination: crdv1beta1.Destination{
-						IP: dstIPv4,
-					},
-				},
-				Status: crdv1beta1.TraceflowStatus{
-					Phase:        crdv1beta1.Running,
-					DataplaneTag: 1,
-				},
-			},
-			expectedNodeResult: &crdv1beta1.NodeResult{
-				Observations: []crdv1beta1.Observation{
-					{
-						Component: crdv1beta1.ComponentSpoofGuard,
-						Action:    crdv1beta1.ActionForwarded,
-						SrcPodIP:  pod1IPv4,
-					},
-					{
-						Component:  crdv1beta1.ComponentEgress,
-						Action:     crdv1beta1.ActionForwardedToEgressNode,
-						Egress:     egressName,
-						EgressIP:   egressIP,
-						EgressNode: egressNode,
-					},
-					{
-						Component:     crdv1beta1.ComponentForwarding,
-						ComponentInfo: openflow.OutputTable.GetName(),
-						Action:        crdv1beta1.ActionForwarded,
-						TunnelDstIP:   egressIP,
-					},
-				},
-			},
-		},
-		{
-			name: "marked packet to remote Pod in hybrid mode",
-			networkConfig: &config.NetworkConfig{
-				TrafficEncapMode: config.TrafficEncapModeHybrid,
-			},
-			nodeConfig: &config.NodeConfig{
-				TunnelOFPort: 1,
-				GatewayConfig: &config.GatewayConfig{
-					OFPort: 2,
-				},
-			},
-			tfState: &traceflowState{
-				name:     "traceflow-pod-to-pod",
-				tag:      1,
-				isSender: true,
-			},
-			pktIn: &ofctrl.PacketIn{
-				PacketIn: &openflow15.PacketIn{
-					TableId: openflow.OutputTable.GetID(),
-					Match: openflow15.Match{
-						Fields: []openflow15.MatchField{*matchOutPort, *matchPktMark, *matchCTSrc},
-					},
-					Data: util.NewBuffer(pktBytesPodToPod),
-				},
-			},
-			expectedCalls: func(npQuerierq *queriertest.MockAgentNetworkPolicyInfoQuerier, egressQuerier *queriertest.MockEgressQuerier) {
-				egressQuerier.EXPECT().GetEgress(pod1.Namespace, pod1.Name).Return(types.EgressConfig{
-					Name:       egressName,
-					EgressIP:   egressIP,
-					EgressNode: egressNode,
-				}, nil)
-			},
-			expectedTf: &crdv1beta1.Traceflow{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "traceflow-pod-to-pod",
-				},
-				Spec: crdv1beta1.TraceflowSpec{
-					Source: crdv1beta1.Source{
-						Namespace: pod1.Namespace,
-						Pod:       pod1.Name,
-					},
-					Destination: crdv1beta1.Destination{
-						Namespace: pod2.Namespace,
-						Pod:       pod2.Name,
-					},
-				},
-				Status: crdv1beta1.TraceflowStatus{
-					Phase:        crdv1beta1.Running,
-					DataplaneTag: 1,
-				},
-			},
-			expectedNodeResult: &crdv1beta1.NodeResult{
-				Observations: []crdv1beta1.Observation{
-					{
-						Component: crdv1beta1.ComponentSpoofGuard,
-						Action:    crdv1beta1.ActionForwarded,
-						SrcPodIP:  pod1IPv4,
-					},
-					{
-						Component:  crdv1beta1.ComponentEgress,
-						Action:     crdv1beta1.ActionMarkedForSNAT,
-						Egress:     egressName,
-						EgressIP:   egressIP,
-						EgressNode: egressNode,
-					},
-					{
-						Component:     crdv1beta1.ComponentForwarding,
-						ComponentInfo: openflow.OutputTable.GetName(),
-						Action:        crdv1beta1.ActionForwardedOutOfNetwork,
-					},
-				},
-			},
-		},
-		{
-			name: "packet at remote Node for remote Egress",
-			networkConfig: &config.NetworkConfig{
-				TrafficEncapMode: 0,
-			},
-			nodeConfig: &config.NodeConfig{
-				TunnelOFPort: 1,
-				GatewayConfig: &config.GatewayConfig{
-					OFPort: 2,
-				},
-			},
-			tfState: &traceflowState{
-				name: "traceflow-pod-to-ipv4",
-				tag:  1,
-			},
-			pktIn: &ofctrl.PacketIn{
-				PacketIn: &openflow15.PacketIn{
-					TableId: openflow.OutputTable.GetID(),
-					Match: openflow15.Match{
-						Fields: []openflow15.MatchField{*matchOutPort, *matchTunDst, *matchPktMark},
-					},
-					Data: util.NewBuffer(pktBytesPodToIP),
-				},
-			},
-			expectedCalls: func(npQuerierq *queriertest.MockAgentNetworkPolicyInfoQuerier, egressQuerier *queriertest.MockEgressQuerier) {
-				egressQuerier.EXPECT().GetEgressIPByMark(uint32(1)).Return(egressIP, nil)
-			},
-			expectedTf: &crdv1beta1.Traceflow{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "traceflow-pod-to-ipv4",
-				},
-				Spec: crdv1beta1.TraceflowSpec{
-					Source: crdv1beta1.Source{
-						Namespace: pod1.Namespace,
-						Pod:       pod1.Name,
-					},
-					Destination: crdv1beta1.Destination{
-						IP: dstIPv4,
-					},
-				},
-				Status: crdv1beta1.TraceflowStatus{
-					Phase:        crdv1beta1.Running,
-					DataplaneTag: 1,
-				},
-			},
-			expectedNodeResult: &crdv1beta1.NodeResult{
-				Observations: []crdv1beta1.Observation{
-					{
-						Component: crdv1beta1.ComponentForwarding,
-						Action:    crdv1beta1.ActionReceived,
-					},
-					{
-						Component: crdv1beta1.ComponentEgress,
-						Action:    crdv1beta1.ActionMarkedForSNAT,
-						EgressIP:  egressIP,
-					},
-					{
-						Component:     crdv1beta1.ComponentForwarding,
-						ComponentInfo: openflow.OutputTable.GetName(),
-						Action:        crdv1beta1.ActionForwardedOutOfNetwork,
-					},
-				},
-			},
-		},
+	}
+	tests := []testCase{
 		{
 			name:       "packet at source Node forwarded by acnp egress rule",
 			nodeConfig: &config.NodeConfig{},
@@ -764,250 +512,143 @@ func TestParsePacketIn(t *testing.T) {
 				},
 			},
 		},
-		{
-			name: "packet at source Node to remote Pod with WireGuard",
-			networkConfig: &config.NetworkConfig{
-				TrafficEncapMode:      config.TrafficEncapModeEncap,
-				TrafficEncryptionMode: config.TrafficEncryptionModeWireGuard,
+	}
+	for _, mode := range trafficModes {
+		tests = append(tests, testCase{
+			name:          "packet at source Node for local Egress " + mode.name,
+			networkConfig: mode.networkConfig,
+			nodeConfig:    makeNodeConfig(1, 2),
+			tfState:       &traceflowState{name: "traceflow-pod-to-ipv4", tag: 1, isSender: true},
+			pktIn: &ofctrl.PacketIn{PacketIn: &openflow15.PacketIn{
+				TableId: openflow.OutputTable.GetID(),
+				Match:   openflow15.Match{Fields: []openflow15.MatchField{*matchOutPort, *matchPktMark, *matchCTSrc}},
+				Data:    util.NewBuffer(pktBytesPodToIP),
+			}},
+			expectedCalls: func(_ *queriertest.MockAgentNetworkPolicyInfoQuerier, eq *queriertest.MockEgressQuerier) {
+				eq.EXPECT().GetEgress(pod1.Namespace, pod1.Name).Return(egressConfig, nil)
 			},
-			nodeConfig: &config.NodeConfig{
-				TunnelOFPort: 1,
-				GatewayConfig: &config.GatewayConfig{
-					OFPort: 2,
-				},
+			expectedTf: makePodToIPv4TF(),
+			expectedNodeResult: &crdv1beta1.NodeResult{Observations: []crdv1beta1.Observation{
+				{Component: crdv1beta1.ComponentSpoofGuard, Action: crdv1beta1.ActionForwarded, SrcPodIP: pod1IPv4},
+				{Component: crdv1beta1.ComponentEgress, Action: crdv1beta1.ActionMarkedForSNAT, Egress: egressName, EgressIP: egressIP, EgressNode: egressNode},
+				{Component: crdv1beta1.ComponentForwarding, ComponentInfo: openflow.OutputTable.GetName(), Action: crdv1beta1.ActionForwardedOutOfNetwork},
+			}},
+		})
+	}
+	for _, mode := range trafficModes {
+		tests = append(tests, testCase{
+			name:          "packet at source Node for remote Egress " + mode.name,
+			networkConfig: mode.networkConfig,
+			nodeConfig:    makeNodeConfig(2, 1),
+			tfState:       &traceflowState{name: "traceflow-pod-to-ipv4", tag: 1, isSender: true},
+			pktIn: &ofctrl.PacketIn{PacketIn: &openflow15.PacketIn{
+				TableId: openflow.OutputTable.GetID(),
+				Match:   openflow15.Match{Fields: []openflow15.MatchField{*matchTunDst, *matchOutPort}},
+				Data:    util.NewBuffer(pktBytesPodToIP),
+			}},
+			expectedCalls: func(_ *queriertest.MockAgentNetworkPolicyInfoQuerier, eq *queriertest.MockEgressQuerier) {
+				eq.EXPECT().GetEgress(pod1.Namespace, pod1.Name).Return(egressConfig, nil)
 			},
-			tfState: &traceflowState{
-				name:     "traceflow-pod-to-pod",
-				tag:      1,
-				isSender: true,
+			expectedTf: makePodToIPv4TF(),
+			expectedNodeResult: &crdv1beta1.NodeResult{Observations: []crdv1beta1.Observation{
+				{Component: crdv1beta1.ComponentSpoofGuard, Action: crdv1beta1.ActionForwarded, SrcPodIP: pod1IPv4},
+				{Component: crdv1beta1.ComponentEgress, Action: crdv1beta1.ActionForwardedToEgressNode, Egress: egressName, EgressIP: egressIP, EgressNode: egressNode},
+				{Component: crdv1beta1.ComponentForwarding, ComponentInfo: openflow.OutputTable.GetName(), Action: crdv1beta1.ActionForwarded, TunnelDstIP: egressIP},
+			}},
+		})
+	}
+	for _, mode := range trafficModes {
+		tests = append(tests, testCase{
+			name:          "packet at remote Node for remote Egress " + mode.name,
+			networkConfig: mode.networkConfig,
+			nodeConfig:    makeNodeConfig(1, 2),
+			tfState:       &traceflowState{name: "traceflow-pod-to-ipv4", tag: 1},
+			pktIn: &ofctrl.PacketIn{PacketIn: &openflow15.PacketIn{
+				TableId: openflow.OutputTable.GetID(),
+				Match:   openflow15.Match{Fields: []openflow15.MatchField{*matchOutPort, *matchTunDst, *matchPktMark}},
+				Data:    util.NewBuffer(pktBytesPodToIP),
+			}},
+			expectedCalls: func(_ *queriertest.MockAgentNetworkPolicyInfoQuerier, eq *queriertest.MockEgressQuerier) {
+				eq.EXPECT().GetEgressIPByMark(uint32(1)).Return(egressIP, nil)
 			},
-			pktIn: &ofctrl.PacketIn{
-				PacketIn: &openflow15.PacketIn{
-					TableId: openflow.OutputTable.GetID(),
-					Match: openflow15.Match{
-						Fields: []openflow15.MatchField{*matchOutPort, *matchCTSrc},
-					},
-					Data: util.NewBuffer(pktBytesPodToPod),
-				},
+			expectedTf: makePodToIPv4TF(),
+			expectedNodeResult: &crdv1beta1.NodeResult{Observations: []crdv1beta1.Observation{
+				{Component: crdv1beta1.ComponentForwarding, Action: crdv1beta1.ActionReceived},
+				{Component: crdv1beta1.ComponentEgress, Action: crdv1beta1.ActionMarkedForSNAT, EgressIP: egressIP},
+				{Component: crdv1beta1.ComponentForwarding, ComponentInfo: openflow.OutputTable.GetName(), Action: crdv1beta1.ActionForwardedOutOfNetwork},
+			}},
+		})
+	}
+	for _, mode := range trafficModes {
+		tests = append(tests, testCase{
+			name:          "packet at source Node to external " + mode.name,
+			networkConfig: mode.networkConfig,
+			nodeConfig:    makeNodeConfig(1, 2),
+			tfState:       &traceflowState{name: "traceflow-pod-to-ipv4", tag: 1, isSender: true},
+			pktIn: &ofctrl.PacketIn{PacketIn: &openflow15.PacketIn{
+				TableId: openflow.OutputTable.GetID(),
+				Match:   openflow15.Match{Fields: []openflow15.MatchField{*matchOutPort, *matchCTSrc}},
+				Data:    util.NewBuffer(pktBytesPodToIP),
+			}},
+			expectedCalls: func(_ *queriertest.MockAgentNetworkPolicyInfoQuerier, _ *queriertest.MockEgressQuerier) {},
+			expectedTf:    makePodToIPv4TF(),
+			expectedNodeResult: &crdv1beta1.NodeResult{Observations: []crdv1beta1.Observation{
+				{Component: crdv1beta1.ComponentSpoofGuard, Action: crdv1beta1.ActionForwarded, SrcPodIP: pod1IPv4},
+				{Component: crdv1beta1.ComponentForwarding, ComponentInfo: openflow.OutputTable.GetName(), Action: crdv1beta1.ActionForwardedOutOfNetwork},
+			}},
+		})
+	}
+	for _, mode := range trafficModes {
+		podRouteAction := crdv1beta1.ActionForwarded
+		tunnelDstIP := ""
+		if mode.networkConfig.TrafficEncryptionMode == config.TrafficEncryptionModeWireGuard {
+			// WireGuard reports the peer Node transport IP resolved via NodeRoute.
+			tunnelDstIP = peerNodeIP
+		} else if mode.networkConfig.TrafficEncapMode == config.TrafficEncapModeEncap {
+			podRouteAction = crdv1beta1.ActionForwardedOutOfNetwork
+		}
+		tests = append(tests, testCase{
+			name:          "packet at source Node to remote Pod " + mode.name,
+			networkConfig: mode.networkConfig,
+			nodeConfig:    makeNodeConfig(1, 2),
+			tfState:       &traceflowState{name: "traceflow-pod-to-ipv4", tag: 1, isSender: true},
+			pktIn: &ofctrl.PacketIn{PacketIn: &openflow15.PacketIn{
+				TableId: openflow.OutputTable.GetID(),
+				Match:   openflow15.Match{Fields: []openflow15.MatchField{*matchOutPort, *matchCTSrc}},
+				Data:    util.NewBuffer(pktBytesPodToPod),
+			}},
+			expectedCalls: func(_ *queriertest.MockAgentNetworkPolicyInfoQuerier, _ *queriertest.MockEgressQuerier) {},
+			expectedTf:    makePodToIPv4TF(),
+			expectedNodeResult: &crdv1beta1.NodeResult{Observations: []crdv1beta1.Observation{
+				{Component: crdv1beta1.ComponentSpoofGuard, Action: crdv1beta1.ActionForwarded, SrcPodIP: pod1IPv4},
+				{Component: crdv1beta1.ComponentForwarding, ComponentInfo: openflow.OutputTable.GetName(), Action: podRouteAction, TunnelDstIP: tunnelDstIP},
+			}},
+		})
+	}
+	for _, mode := range trafficModes {
+		// Marked (Egress) packets must keep the ForwardedOutOfNetwork action even when the
+		// destination is a remote Pod IP, since the Pod destination classification only
+		// applies to unmarked packets.
+		tests = append(tests, testCase{
+			name:          "marked packet to remote Pod " + mode.name,
+			networkConfig: mode.networkConfig,
+			nodeConfig:    makeNodeConfig(1, 2),
+			tfState:       &traceflowState{name: "traceflow-pod-to-ipv4", tag: 1, isSender: true},
+			pktIn: &ofctrl.PacketIn{PacketIn: &openflow15.PacketIn{
+				TableId: openflow.OutputTable.GetID(),
+				Match:   openflow15.Match{Fields: []openflow15.MatchField{*matchOutPort, *matchPktMark, *matchCTSrc}},
+				Data:    util.NewBuffer(pktBytesPodToPod),
+			}},
+			expectedCalls: func(_ *queriertest.MockAgentNetworkPolicyInfoQuerier, eq *queriertest.MockEgressQuerier) {
+				eq.EXPECT().GetEgress(pod1.Namespace, pod1.Name).Return(egressConfig, nil)
 			},
-			expectedCalls: func(npQuerierq *queriertest.MockAgentNetworkPolicyInfoQuerier, egressQuerier *queriertest.MockEgressQuerier) {
-			},
-			expectedTf: &crdv1beta1.Traceflow{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "traceflow-pod-to-pod",
-				},
-				Spec: crdv1beta1.TraceflowSpec{
-					Source: crdv1beta1.Source{
-						Namespace: pod1.Namespace,
-						Pod:       pod1.Name,
-					},
-					Destination: crdv1beta1.Destination{
-						Namespace: pod2.Namespace,
-						Pod:       pod2.Name,
-					},
-				},
-				Status: crdv1beta1.TraceflowStatus{
-					Phase:        crdv1beta1.Running,
-					DataplaneTag: 1,
-				},
-			},
-			expectedNodeResult: &crdv1beta1.NodeResult{
-				Observations: []crdv1beta1.Observation{
-					{
-						Component: crdv1beta1.ComponentSpoofGuard,
-						Action:    crdv1beta1.ActionForwarded,
-						SrcPodIP:  pod1IPv4,
-					},
-					{
-						Component:     crdv1beta1.ComponentForwarding,
-						ComponentInfo: openflow.OutputTable.GetName(),
-						Action:        crdv1beta1.ActionForwarded,
-						TunnelDstIP:   peerNodeIP,
-					},
-				},
-			},
-		},
-		{
-			name: "packet at source Node to external with WireGuard",
-			networkConfig: &config.NetworkConfig{
-				TrafficEncapMode:      config.TrafficEncapModeEncap,
-				TrafficEncryptionMode: config.TrafficEncryptionModeWireGuard,
-			},
-			nodeConfig: &config.NodeConfig{
-				TunnelOFPort: 1,
-				GatewayConfig: &config.GatewayConfig{
-					OFPort: 2,
-				},
-			},
-			tfState: &traceflowState{
-				name:     "traceflow-pod-to-ipv4",
-				tag:      1,
-				isSender: true,
-			},
-			pktIn: &ofctrl.PacketIn{
-				PacketIn: &openflow15.PacketIn{
-					TableId: openflow.OutputTable.GetID(),
-					Match: openflow15.Match{
-						Fields: []openflow15.MatchField{*matchOutPort, *matchCTSrc},
-					},
-					Data: util.NewBuffer(pktBytesPodToIP),
-				},
-			},
-			expectedCalls: func(npQuerierq *queriertest.MockAgentNetworkPolicyInfoQuerier, egressQuerier *queriertest.MockEgressQuerier) {
-			},
-			expectedTf: &crdv1beta1.Traceflow{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "traceflow-pod-to-ipv4",
-				},
-				Spec: crdv1beta1.TraceflowSpec{
-					Source: crdv1beta1.Source{
-						Namespace: pod1.Namespace,
-						Pod:       pod1.Name,
-					},
-					Destination: crdv1beta1.Destination{
-						IP: dstIPv4,
-					},
-				},
-				Status: crdv1beta1.TraceflowStatus{
-					Phase:        crdv1beta1.Running,
-					DataplaneTag: 1,
-				},
-			},
-			expectedNodeResult: &crdv1beta1.NodeResult{
-				Observations: []crdv1beta1.Observation{
-					{
-						Component: crdv1beta1.ComponentSpoofGuard,
-						Action:    crdv1beta1.ActionForwarded,
-						SrcPodIP:  pod1IPv4,
-					},
-					{
-						Component:     crdv1beta1.ComponentForwarding,
-						ComponentInfo: openflow.OutputTable.GetName(),
-						Action:        crdv1beta1.ActionForwardedOutOfNetwork,
-					},
-				},
-			},
-		},
-		{
-			name: "packet at source Node to external NoEncap",
-			networkConfig: &config.NetworkConfig{
-				TrafficEncapMode: 1,
-			},
-			nodeConfig: &config.NodeConfig{
-				TunnelOFPort: 1,
-				GatewayConfig: &config.GatewayConfig{
-					OFPort: 2,
-				},
-			},
-			tfState: &traceflowState{
-				name:     "traceflow-pod-to-ipv4",
-				tag:      1,
-				isSender: true,
-			},
-			pktIn: &ofctrl.PacketIn{
-				PacketIn: &openflow15.PacketIn{
-					TableId: openflow.OutputTable.GetID(),
-					Match: openflow15.Match{
-						Fields: []openflow15.MatchField{*matchOutPort, *matchCTSrc},
-					},
-					Data: util.NewBuffer(pktBytesPodToIP),
-				},
-			},
-			expectedCalls: func(npQuerierq *queriertest.MockAgentNetworkPolicyInfoQuerier, egressQuerier *queriertest.MockEgressQuerier) {
-			},
-			expectedTf: &crdv1beta1.Traceflow{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "traceflow-pod-to-ipv4",
-				},
-				Spec: crdv1beta1.TraceflowSpec{
-					Source: crdv1beta1.Source{
-						Namespace: pod1.Namespace,
-						Pod:       pod1.Name,
-					},
-					Destination: crdv1beta1.Destination{
-						IP: dstIPv4,
-					},
-				},
-				Status: crdv1beta1.TraceflowStatus{
-					Phase:        crdv1beta1.Running,
-					DataplaneTag: 1,
-				},
-			},
-			expectedNodeResult: &crdv1beta1.NodeResult{
-				Observations: []crdv1beta1.Observation{
-					{
-						Component: crdv1beta1.ComponentSpoofGuard,
-						Action:    crdv1beta1.ActionForwarded,
-						SrcPodIP:  pod1IPv4,
-					},
-					{
-						Component:     crdv1beta1.ComponentForwarding,
-						ComponentInfo: openflow.OutputTable.GetName(),
-						Action:        crdv1beta1.ActionForwardedOutOfNetwork,
-					},
-				},
-			},
-		},
-		{
-			name: "packet at source Node to remote Pod NoEncap",
-			networkConfig: &config.NetworkConfig{
-				TrafficEncapMode: 1,
-			},
-			nodeConfig: &config.NodeConfig{
-				TunnelOFPort: 1,
-				GatewayConfig: &config.GatewayConfig{
-					OFPort: 2,
-				},
-			},
-			tfState: &traceflowState{
-				name:     "traceflow-pod-to-ipv4",
-				tag:      1,
-				isSender: true,
-			},
-			pktIn: &ofctrl.PacketIn{
-				PacketIn: &openflow15.PacketIn{
-					TableId: openflow.OutputTable.GetID(),
-					Match: openflow15.Match{
-						Fields: []openflow15.MatchField{*matchOutPort, *matchCTSrc},
-					},
-					Data: util.NewBuffer(pktBytesPodToPod),
-				},
-			},
-			expectedCalls: func(npQuerierq *queriertest.MockAgentNetworkPolicyInfoQuerier, egressQuerier *queriertest.MockEgressQuerier) {
-			},
-			expectedTf: &crdv1beta1.Traceflow{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "traceflow-pod-to-ipv4",
-				},
-				Spec: crdv1beta1.TraceflowSpec{
-					Source: crdv1beta1.Source{
-						Namespace: pod1.Namespace,
-						Pod:       pod1.Name,
-					},
-					Destination: crdv1beta1.Destination{
-						IP: dstIPv4,
-					},
-				},
-				Status: crdv1beta1.TraceflowStatus{
-					Phase:        crdv1beta1.Running,
-					DataplaneTag: 1,
-				},
-			},
-			expectedNodeResult: &crdv1beta1.NodeResult{
-				Observations: []crdv1beta1.Observation{
-					{
-						Component: crdv1beta1.ComponentSpoofGuard,
-						Action:    crdv1beta1.ActionForwarded,
-						SrcPodIP:  pod1IPv4,
-					},
-					{
-						Component:     crdv1beta1.ComponentForwarding,
-						ComponentInfo: openflow.OutputTable.GetName(),
-						Action:        crdv1beta1.ActionForwarded,
-					},
-				},
-			},
-		},
+			expectedTf: makePodToIPv4TF(),
+			expectedNodeResult: &crdv1beta1.NodeResult{Observations: []crdv1beta1.Observation{
+				{Component: crdv1beta1.ComponentSpoofGuard, Action: crdv1beta1.ActionForwarded, SrcPodIP: pod1IPv4},
+				{Component: crdv1beta1.ComponentEgress, Action: crdv1beta1.ActionMarkedForSNAT, Egress: egressName, EgressIP: egressIP, EgressNode: egressNode},
+				{Component: crdv1beta1.ComponentForwarding, ComponentInfo: openflow.OutputTable.GetName(), Action: crdv1beta1.ActionForwardedOutOfNetwork},
+			}},
+		})
 	}
 
 	for _, tt := range tests {
@@ -1030,7 +671,7 @@ func TestParsePacketIn(t *testing.T) {
 
 func TestParsePacketInLiveDuplicates(t *testing.T) {
 	networkConfig := &config.NetworkConfig{
-		TrafficEncapMode: 0,
+		TrafficEncapMode: config.TrafficEncapModeEncap,
 	}
 	nodeConfig := &config.NodeConfig{
 		TunnelOFPort: 1,

--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -610,9 +610,10 @@ func (c *client) InstallNodeFlows(hostname string,
 			flows = append(flows, c.featurePodConnectivity.l3FwdFlowToRemoteViaRouting(localGatewayMAC, remoteGatewayMAC, peerNodeIP, peerPodCIDR)...)
 			// Flow to forward the reply packets of Egress connections, whose request packets came from remote Pods
 			// via tunnel, back to those Pods via tunnel, ensuring symmetric paths of the connections. This flow is
-			// needed when Egress uses a tunnel path distinct from the common Pod-to-Pod path (hybrid or WireGuard)
-			// and the peer is reachable via routing.
-			if c.enableEgress && (c.networkConfig.TrafficEncapMode == config.TrafficEncapModeHybrid || c.networkConfig.TrafficEncryptionMode == config.TrafficEncryptionModeWireGuard) {
+			// needed when Egress uses a tunnel path distinct from the common Pod-to-Pod path (noEncap, hybrid,
+			// and WireGuard encryption modes) and the peer is reachable via routing. The route client installs
+			// the matching policy routing under the same condition.
+			if c.networkConfig.NeedsEgressSymmetricPath(c.enableEgress) {
 				flows = append(flows, c.featurePodConnectivity.l3FwdFlowEgressReturnViaTun(localGatewayMAC, *peerPodCIDR, peerNodeIP))
 			}
 		}

--- a/pkg/agent/openflow/client.go
+++ b/pkg/agent/openflow/client.go
@@ -610,9 +610,11 @@ func (c *client) InstallNodeFlows(hostname string,
 			flows = append(flows, c.featurePodConnectivity.l3FwdFlowToRemoteViaRouting(localGatewayMAC, remoteGatewayMAC, peerNodeIP, peerPodCIDR)...)
 			// Flow to forward the reply packets of Egress connections, whose request packets came from remote Pods
 			// via tunnel, back to those Pods via tunnel, ensuring symmetric paths of the connections. This flow is
-			// needed when Egress uses a tunnel path distinct from the common Pod-to-Pod path (hybrid or WireGuard)
-			// and the peer is reachable via routing.
-			if c.enableEgress && (c.networkConfig.TrafficEncapMode == config.TrafficEncapModeHybrid || c.networkConfig.TrafficEncryptionMode == config.TrafficEncryptionModeWireGuard) {
+			// needed when Egress uses a tunnel path distinct from the common Pod-to-Pod path (hybrid, noEncap, and
+			// WireGuard encryption modes) and the peer is reachable via routing.
+			if c.enableEgress && (c.networkConfig.TrafficEncapMode == config.TrafficEncapModeHybrid ||
+				c.networkConfig.TrafficEncapMode == config.TrafficEncapModeNoEncap ||
+				c.networkConfig.TrafficEncryptionMode == config.TrafficEncryptionModeWireGuard) {
 				flows = append(flows, c.featurePodConnectivity.l3FwdFlowEgressReturnViaTun(localGatewayMAC, *peerPodCIDR, peerNodeIP))
 			}
 		}

--- a/pkg/agent/route/route_linux.go
+++ b/pkg/agent/route/route_linux.go
@@ -393,7 +393,8 @@ func (c *Client) Initialize(nodeConfig *config.NodeConfig, done func()) error {
 		}
 	}
 
-	// In hybrid mode, or encap mode with WireGuard enabled, Egress traffic originating from remote Pod CIDRs is forwarded like this:
+	// In hybrid, noEncap, and WireGuard encryption modes, Egress traffic originating from remote Pod CIDRs is
+	// forwarded like this:
 	//     remote Pods -> tunnel (remote Node OVS) -> tunnel (local Node OVS) -> antrea-gw0 (local Node) -> external network.
 	//
 	// To ensure reply packets follow a symmetric path, Antrea uses policy routing on the local Node. However, the
@@ -413,13 +414,13 @@ func (c *Client) Initialize(nodeConfig *config.NodeConfig, done func()) error {
 			return fmt.Errorf("failed to initialize Service IP routes: %v", err)
 		}
 	}
-	// Set up the policy routing ip rule to support Egress in hybrid mode or encap mode with WireGuard enabled.
+	// Set up the policy routing ip rule to support Egress in hybrid, noEncap, and WireGuard encryption modes.
 	if c.shouldEnableEgressPolicyRouting() {
 		if err := c.initEgressIPRules(); err != nil {
-			return fmt.Errorf("failed to initialize ip rules for Egress in hybrid mode: %w", err)
+			return fmt.Errorf("failed to initialize ip rules for Egress policy routing: %w", err)
 		}
 		if err := c.initEgressIPRoutes(); err != nil {
-			return fmt.Errorf("failed to initialize IP routes for Egress in hybrid mode: %w", err)
+			return fmt.Errorf("failed to initialize IP routes for Egress policy routing: %w", err)
 		}
 	}
 	// Build static iptables rules for NodeNetworkPolicy.
@@ -1320,7 +1321,7 @@ func (c *Client) restoreIptablesData(podCIDR *net.IPNet,
 			"-j", iptables.MarkTarget, "--or-mark", fmt.Sprintf("%#08x", types.HostLocalSourceMark),
 		}...)
 	}
-	if c.egressEnabled && c.networkConfig.TrafficEncapMode == config.TrafficEncapModeHybrid {
+	if c.shouldEnableEgressPolicyRouting() {
 		writeLine(iptablesData, []string{
 			"-A", antreaOutputChain,
 			"-m", "comment", "--comment", `"Antrea: restore fwmark from connmark for reply Egress packets to remote Pods"`,
@@ -2384,9 +2385,9 @@ func (c *Client) addVirtualServiceIPRoute(isIPv6 bool) error {
 }
 
 // addEgressReplyDefaultPolicyIPRoute is used to add a default route to policy-routing table ReplyEgressRouteTable when traffic
-// mode is hybrid. The route is to route the reply Egress packets originated from remote Nodes to Antrea gateway,
-// avoiding the packets to be matched by the routes in main route table. This ensures that the reply Egress packets
-// can be forwarded back to the remote Nodes through OVS flow-based tunnel.
+// mode is hybrid, noEncap, or WireGuard encryption. The route is to route the reply Egress packets originated
+// from remote Nodes to Antrea gateway, avoiding the packets to be matched by the routes in main route table. This ensures
+// that the reply Egress packets can be forwarded back to the remote Nodes through OVS flow-based tunnel.
 func (c *Client) addEgressReplyDefaultPolicyIPRoute(isIPv6 bool) error {
 	linkIndex := c.nodeConfig.GatewayConfig.LinkIndex
 	nextHopIP := config.VirtualReplyEgressRouteNextHopIPv4
@@ -3505,11 +3506,12 @@ func (c *Client) deleteExternalIPConfigsIPsets(externalIP net.IP) error {
 }
 
 // shouldEnableEgressPolicyRouting returns true when Egress is enabled and policy based routing
-// is needed for Egress traffic, such as when traffic encapsulation mode is hybrid or traffic
-// encryption mode is WireGuard. In those cases, Egress uses a tunnel path distinct from the common
-// Pod-to-Pod traffic path (e.g. Pod-to-Pod may go via routing in hybrid), so symmetric-path handling
-// for Egress reply packets is needed.
+// is needed for Egress traffic, such as when traffic encapsulation mode is hybrid, noEncap, or
+// WireGuard encryption. In those cases, Egress uses a tunnel path distinct from the common
+// Pod-to-Pod traffic path (e.g. Pod-to-Pod may go via routing in hybrid or noEncap),
+// so symmetric-path handling for Egress reply packets is needed.
 func (c *Client) shouldEnableEgressPolicyRouting() bool {
 	return c.egressEnabled && (c.networkConfig.TrafficEncapMode == config.TrafficEncapModeHybrid ||
+		c.networkConfig.TrafficEncapMode == config.TrafficEncapModeNoEncap ||
 		c.networkConfig.TrafficEncryptionMode == config.TrafficEncryptionModeWireGuard)
 }

--- a/pkg/agent/route/route_linux.go
+++ b/pkg/agent/route/route_linux.go
@@ -494,7 +494,8 @@ func (c *Client) Initialize(nodeConfig *config.NodeConfig, done func()) error {
 		}
 	}
 
-	// In hybrid mode, or encap mode with WireGuard enabled, Egress traffic originating from remote Pod CIDRs is forwarded like this:
+	// In hybrid, noEncap, and WireGuard encryption modes, Egress traffic originating from remote Pod CIDRs is
+	// forwarded like this:
 	//     remote Pods -> tunnel (remote Node OVS) -> tunnel (local Node OVS) -> antrea-gw0 (local Node) -> external network.
 	//
 	// To ensure reply packets follow a symmetric path, Antrea uses policy routing on the local Node. However, the
@@ -514,13 +515,13 @@ func (c *Client) Initialize(nodeConfig *config.NodeConfig, done func()) error {
 			return fmt.Errorf("failed to initialize Service IP routes: %v", err)
 		}
 	}
-	// Set up the policy routing ip rule to support Egress in hybrid mode or encap mode with WireGuard enabled.
+	// Set up the policy routing ip rule to support Egress in hybrid, noEncap, and WireGuard encryption modes.
 	if c.shouldEnableEgressPolicyRouting() {
 		if err := c.initEgressIPRules(); err != nil {
-			return fmt.Errorf("failed to initialize ip rules for Egress in hybrid mode: %w", err)
+			return fmt.Errorf("failed to initialize ip rules for Egress policy routing: %w", err)
 		}
 		if err := c.initEgressIPRoutes(); err != nil {
-			return fmt.Errorf("failed to initialize IP routes for Egress in hybrid mode: %w", err)
+			return fmt.Errorf("failed to initialize IP routes for Egress policy routing: %w", err)
 		}
 	}
 
@@ -2730,9 +2731,9 @@ func (c *Client) addVirtualServiceIPRoute(isIPv6 bool) error {
 }
 
 // addEgressReplyDefaultPolicyIPRoute is used to add a default route to policy-routing table ReplyEgressRouteTable when traffic
-// mode is hybrid. The route is to route the reply Egress packets originated from remote Nodes to Antrea gateway,
-// avoiding the packets to be matched by the routes in main route table. This ensures that the reply Egress packets
-// can be forwarded back to the remote Nodes through OVS flow-based tunnel.
+// mode is hybrid, noEncap, or WireGuard encryption. The route is to route the reply Egress packets originated
+// from remote Nodes to Antrea gateway, avoiding the packets to be matched by the routes in main route table. This ensures
+// that the reply Egress packets can be forwarded back to the remote Nodes through OVS flow-based tunnel.
 func (c *Client) addEgressReplyDefaultPolicyIPRoute(isIPv6 bool) error {
 	linkIndex := c.nodeConfig.GatewayConfig.LinkIndex
 	nextHopIP := config.VirtualReplyEgressRouteNextHopIPv4
@@ -3850,14 +3851,12 @@ func (c *Client) deleteExternalIPConfigsIPsets(externalIP net.IP) error {
 	return nil
 }
 
-// shouldEnableEgressPolicyRouting returns true when Egress is enabled and policy based routing
-// is needed for Egress traffic, such as when traffic encapsulation mode is hybrid or traffic
-// encryption mode is WireGuard. In those cases, Egress uses a tunnel path distinct from the common
-// Pod-to-Pod traffic path (e.g. Pod-to-Pod may go via routing in hybrid), so symmetric-path handling
-// for Egress reply packets is needed.
+// shouldEnableEgressPolicyRouting returns true when policy based routing is needed for Egress traffic, which
+// is the case whenever Egress takes a tunnel path distinct from the common Pod-to-Pod traffic path. The OVS
+// pipeline installs its matching return flow under the same condition, so both read it from NetworkConfig
+// instead of each spelling the modes out.
 func (c *Client) shouldEnableEgressPolicyRouting() bool {
-	return c.egressEnabled && (c.networkConfig.TrafficEncapMode == config.TrafficEncapModeHybrid ||
-		c.networkConfig.TrafficEncryptionMode == config.TrafficEncryptionModeWireGuard)
+	return c.networkConfig.NeedsEgressSymmetricPath(c.egressEnabled)
 }
 
 // Enqueue implements the client.Listener interface. It is called by the Antrea Service EndpointResolver

--- a/pkg/agent/route/route_linux_test.go
+++ b/pkg/agent/route/route_linux_test.go
@@ -496,6 +496,7 @@ COMMIT
 -A ANTREA-PREROUTING -m comment --comment "Antrea: persist connmark for the first request Egress packet from remote Pods" -i antrea-gw0 ! -s 172.16.10.0/24 -m conntrack --ctstate NEW -m mark ! --mark 0x00000000/0x000000ff -j CONNMARK --set-mark 0x40000000/0x40000000
 -A ANTREA-POSTROUTING -m comment --comment "Antrea: clear fwmark from reply Egress packets to remote Pods" -m conntrack --ctstate ESTABLISHED -m conntrack --ctdir REPLY -j MARK --set-xmark 0x0/0x40000000
 -A ANTREA-OUTPUT -m comment --comment "Antrea: mark LOCAL output packets" -m addrtype --src-type LOCAL -o antrea-gw0 -j MARK --or-mark 0x80000000
+-A ANTREA-OUTPUT -m comment --comment "Antrea: restore fwmark from connmark for reply Egress packets to remote Pods" -m conntrack --ctstate ESTABLISHED -m conntrack --ctdir REPLY -m connmark --mark 0x40000000/0x40000000 -j CONNMARK --restore-mark --nfmask 0x40000000 --ctmask 0x40000000
 COMMIT
 *filter
 :ANTREA-FORWARD - [0:0]
@@ -554,6 +555,7 @@ COMMIT
 -A ANTREA-PREROUTING -m comment --comment "Antrea: persist connmark for the first request Egress packet from remote Pods" -i antrea-gw0 ! -s 2001:ab03:cd04:55ef::/64 -m conntrack --ctstate NEW -m mark ! --mark 0x00000000/0x000000ff -j CONNMARK --set-mark 0x40000000/0x40000000
 -A ANTREA-POSTROUTING -m comment --comment "Antrea: clear fwmark from reply Egress packets to remote Pods" -m conntrack --ctstate ESTABLISHED -m conntrack --ctdir REPLY -j MARK --set-xmark 0x0/0x40000000
 -A ANTREA-OUTPUT -m comment --comment "Antrea: mark LOCAL output packets" -m addrtype --src-type LOCAL -o antrea-gw0 -j MARK --or-mark 0x80000000
+-A ANTREA-OUTPUT -m comment --comment "Antrea: restore fwmark from connmark for reply Egress packets to remote Pods" -m conntrack --ctstate ESTABLISHED -m conntrack --ctdir REPLY -m connmark --mark 0x40000000/0x40000000 -j CONNMARK --restore-mark --nfmask 0x40000000 --ctmask 0x40000000
 COMMIT
 *filter
 :ANTREA-FORWARD - [0:0]
@@ -673,6 +675,7 @@ COMMIT
 -A ANTREA-PREROUTING -m comment --comment "Antrea: persist connmark for the first request Egress packet from remote Pods" -i antrea-gw0 ! -s 172.16.10.0/24 -m conntrack --ctstate NEW -m mark ! --mark 0x00000000/0x000000ff -j CONNMARK --set-mark 0x40000000/0x40000000
 -A ANTREA-POSTROUTING -m comment --comment "Antrea: clear fwmark from reply Egress packets to remote Pods" -m conntrack --ctstate ESTABLISHED -m conntrack --ctdir REPLY -j MARK --set-xmark 0x0/0x40000000
 -A ANTREA-OUTPUT -m comment --comment "Antrea: mark LOCAL output packets" -m addrtype --src-type LOCAL -o antrea-gw0 -j MARK --or-mark 0x80000000
+-A ANTREA-OUTPUT -m comment --comment "Antrea: restore fwmark from connmark for reply Egress packets to remote Pods" -m conntrack --ctstate ESTABLISHED -m conntrack --ctdir REPLY -m connmark --mark 0x40000000/0x40000000 -j CONNMARK --restore-mark --nfmask 0x40000000 --ctmask 0x40000000
 COMMIT
 *filter
 :ANTREA-FORWARD - [0:0]
@@ -704,6 +707,7 @@ COMMIT
 -A ANTREA-PREROUTING -m comment --comment "Antrea: persist connmark for the first request Egress packet from remote Pods" -i antrea-gw0 ! -s 2001:ab03:cd04:55ef::/64 -m conntrack --ctstate NEW -m mark ! --mark 0x00000000/0x000000ff -j CONNMARK --set-mark 0x40000000/0x40000000
 -A ANTREA-POSTROUTING -m comment --comment "Antrea: clear fwmark from reply Egress packets to remote Pods" -m conntrack --ctstate ESTABLISHED -m conntrack --ctdir REPLY -j MARK --set-xmark 0x0/0x40000000
 -A ANTREA-OUTPUT -m comment --comment "Antrea: mark LOCAL output packets" -m addrtype --src-type LOCAL -o antrea-gw0 -j MARK --or-mark 0x80000000
+-A ANTREA-OUTPUT -m comment --comment "Antrea: restore fwmark from connmark for reply Egress packets to remote Pods" -m conntrack --ctstate ESTABLISHED -m conntrack --ctdir REPLY -m connmark --mark 0x40000000/0x40000000 -j CONNMARK --restore-mark --nfmask 0x40000000 --ctmask 0x40000000
 COMMIT
 *filter
 :ANTREA-FORWARD - [0:0]
@@ -1166,6 +1170,8 @@ COMMIT
 				mockIPTables.AppendRule(iptables.ProtocolIPv4, iptables.MangleTable, iptables.PreRoutingChain, []string{"-j", antreaPreRoutingChain, "-m", "comment", "--comment", "Antrea: jump to Antrea prerouting rules"})
 				mockIPTables.EnsureChain(iptables.ProtocolIPv4, iptables.MangleTable, antreaOutputChain)
 				mockIPTables.AppendRule(iptables.ProtocolIPv4, iptables.MangleTable, iptables.OutputChain, []string{"-j", antreaOutputChain, "-m", "comment", "--comment", "Antrea: jump to Antrea output rules"})
+				mockIPTables.EnsureChain(iptables.ProtocolIPv4, iptables.MangleTable, antreaPostRoutingChain)
+				mockIPTables.AppendRule(iptables.ProtocolIPv4, iptables.MangleTable, iptables.PostRoutingChain, []string{"-j", antreaPostRoutingChain, "-m", "comment", "--comment", "Antrea: jump to Antrea postrouting rules"})
 				mockIPTables.Restore(`*raw
 :ANTREA-PREROUTING - [0:0]
 :ANTREA-OUTPUT - [0:0]
@@ -1173,8 +1179,13 @@ COMMIT
 *mangle
 :ANTREA-PREROUTING - [0:0]
 :ANTREA-OUTPUT - [0:0]
+:ANTREA-POSTROUTING - [0:0]
+-A ANTREA-PREROUTING -m comment --comment "Antrea: restore fwmark from connmark for reply Egress packets to remote Pods" -m conntrack --ctstate ESTABLISHED -m conntrack --ctdir REPLY -m connmark --mark 0x40000000/0x40000000 -j CONNMARK --restore-mark --nfmask 0x40000000 --ctmask 0x40000000
+-A ANTREA-PREROUTING -m comment --comment "Antrea: persist connmark for the first request Egress packet from remote Pods" -i antrea-gw0 ! -s 172.16.10.0/24 -m conntrack --ctstate NEW -m mark ! --mark 0x00000000/0x000000ff -j CONNMARK --set-mark 0x40000000/0x40000000
+-A ANTREA-POSTROUTING -m comment --comment "Antrea: clear fwmark from reply Egress packets to remote Pods" -m conntrack --ctstate ESTABLISHED -m conntrack --ctdir REPLY -j MARK --set-xmark 0x0/0x40000000
 -A ANTREA-OUTPUT -m comment --comment "Antrea: mark LOCAL output packets" -m addrtype --src-type LOCAL -o antrea-gw0 -j MARK --or-mark 0x80000000
 -A ANTREA-OUTPUT -m comment --comment "Antrea: mark LOCAL output packets" -m addrtype --src-type LOCAL -o  -j MARK --or-mark 0x80000000
+-A ANTREA-OUTPUT -m comment --comment "Antrea: restore fwmark from connmark for reply Egress packets to remote Pods" -m conntrack --ctstate ESTABLISHED -m conntrack --ctdir REPLY -m connmark --mark 0x40000000/0x40000000 -j CONNMARK --restore-mark --nfmask 0x40000000 --ctmask 0x40000000
 COMMIT
 *filter
 :ANTREA-FORWARD - [0:0]

--- a/pkg/agent/route/route_linux_test.go
+++ b/pkg/agent/route/route_linux_test.go
@@ -1302,6 +1302,8 @@ COMMIT
 				mockIPTables.AppendRule(iptables.ProtocolIPv4, iptables.FilterTable, iptables.InputChain, []string{"-j", antreaInputChain, "-m", "comment", "--comment", "Antrea: jump to Antrea input rules"})
 				mockIPTables.EnsureChain(iptables.ProtocolIPv4, iptables.FilterTable, antreaOutputChain)
 				mockIPTables.AppendRule(iptables.ProtocolIPv4, iptables.FilterTable, iptables.OutputChain, []string{"-j", antreaOutputChain, "-m", "comment", "--comment", "Antrea: jump to Antrea output rules"})
+				mockIPTables.EnsureChain(iptables.ProtocolIPv4, iptables.MangleTable, antreaPostRoutingChain)
+				mockIPTables.AppendRule(iptables.ProtocolIPv4, iptables.MangleTable, iptables.PostRoutingChain, []string{"-j", antreaPostRoutingChain, "-m", "comment", "--comment", "Antrea: jump to Antrea postrouting rules"})
 				mockIPTables.Restore(`*raw
 :ANTREA-PREROUTING - [0:0]
 :ANTREA-OUTPUT - [0:0]
@@ -1309,8 +1311,13 @@ COMMIT
 *mangle
 :ANTREA-PREROUTING - [0:0]
 :ANTREA-OUTPUT - [0:0]
+:ANTREA-POSTROUTING - [0:0]
+-A ANTREA-PREROUTING -m comment --comment "Antrea: restore fwmark from connmark for reply Egress packets to remote Pods" -m conntrack --ctstate ESTABLISHED -m conntrack --ctdir REPLY -m connmark --mark 0x40000000/0x40000000 -j CONNMARK --restore-mark --nfmask 0x40000000 --ctmask 0x40000000
+-A ANTREA-PREROUTING -m comment --comment "Antrea: persist connmark for the first request Egress packet from remote Pods" -i antrea-gw0 ! -s 172.16.10.0/24 -m conntrack --ctstate NEW -m mark ! --mark 0x00000000/0x000000ff -j CONNMARK --set-mark 0x40000000/0x40000000
+-A ANTREA-POSTROUTING -m comment --comment "Antrea: clear fwmark from reply Egress packets to remote Pods" -m conntrack --ctstate ESTABLISHED -m conntrack --ctdir REPLY -j MARK --set-xmark 0x0/0x40000000
 -A ANTREA-OUTPUT -m comment --comment "Antrea: mark LOCAL output packets" -m addrtype --src-type LOCAL -o antrea-gw0 -j MARK --or-mark 0x80000000
 -A ANTREA-OUTPUT -m comment --comment "Antrea: mark LOCAL output packets" -m addrtype --src-type LOCAL -o  -j MARK --or-mark 0x80000000
+-A ANTREA-OUTPUT -m comment --comment "Antrea: restore fwmark from connmark for reply Egress packets to remote Pods" -m conntrack --ctstate ESTABLISHED -m conntrack --ctdir REPLY -m connmark --mark 0x40000000/0x40000000 -j CONNMARK --restore-mark --nfmask 0x40000000 --ctmask 0x40000000
 COMMIT
 *filter
 :ANTREA-FORWARD - [0:0]

--- a/pkg/agent/types/net.go
+++ b/pkg/agent/types/net.go
@@ -20,7 +20,7 @@ const (
 	HostLocalSourceBit = 31
 
 	// EgressNoEncapReturnToRemoteBit is the bit of the iptables fwmark space to mark the reply Egress packets whose request
-	// packets are from remote Pods.
+	// packets are from remote Pods. It is used in hybrid, noEncap, and WireGuard encryption modes.
 	EgressNoEncapReturnToRemoteBit = 30
 )
 
@@ -43,6 +43,6 @@ const (
 	MinRequestEgressRouteTable = 101
 	MaxRequestEgressRouteTable = 120
 
-	// ReplyEgressRouteTable is the route table ID which is used to add policy routing rules in hybrid mode.
+	// ReplyEgressRouteTable is the route table ID which is used to add policy routing rules in hybrid, noEncap, and WireGuard encryption modes.
 	ReplyEgressRouteTable = 141
 )

--- a/test/integration/agent/route_test.go
+++ b/test/integration/agent/route_test.go
@@ -274,7 +274,8 @@ func TestInitialize(t *testing.T) {
 -A ANTREA-OUTPUT -o antrea-gw0 -m comment --comment "Antrea: mark LOCAL output packets" -m addrtype --src-type LOCAL -j MARK --set-xmark 0x80000000/0x80000000
 `,
 			}
-			if tc.networkConfig.TrafficEncapMode == config.TrafficEncapModeHybrid {
+			if tc.networkConfig.TrafficEncapMode == config.TrafficEncapModeHybrid ||
+				tc.networkConfig.TrafficEncapMode == config.TrafficEncapModeNoEncap {
 				expectedIPTables["mangle"] = `:ANTREA-OUTPUT - [0:0]
 :ANTREA-POSTROUTING - [0:0]
 :ANTREA-PREROUTING - [0:0]

--- a/test/integration/agent/route_test.go
+++ b/test/integration/agent/route_test.go
@@ -291,7 +291,8 @@ func TestInitialize(t *testing.T) {
 -A ANTREA-OUTPUT -o antrea-gw0 -m comment --comment "Antrea: mark LOCAL output packets" -m addrtype --src-type LOCAL -j MARK --set-xmark 0x80000000/0x80000000
 `,
 			}
-			if tc.networkConfig.TrafficEncapMode == config.TrafficEncapModeHybrid {
+			if tc.networkConfig.TrafficEncapMode == config.TrafficEncapModeHybrid ||
+				tc.networkConfig.TrafficEncapMode == config.TrafficEncapModeNoEncap {
 				expectedIPTables["mangle"] = `:ANTREA-OUTPUT - [0:0]
 :ANTREA-POSTROUTING - [0:0]
 :ANTREA-PREROUTING - [0:0]


### PR DESCRIPTION
In noEncap mode with the Egress feature gate enabled, a Geneve tunnel interface (antrea-tun0) is created so that OVS can forward Egress traffic from a non-Egress Node to the Egress Node via the tunnel, while regular Pod-to-Pod traffic continues to use direct routing unaffected.

Key changes:
- Unblock validateEgressConfig for TrafficEncapModeNoEncap
- Add EgressEnabled to NetworkConfig; update NeedsTunnelInterface() to create antrea-tun0 when noEncap+Egress, and CalculateMTUDeduction() to apply encap overhead so Pod MTU is reduced accordingly
- Install l3FwdFlowEgressReturnViaTun for noEncap peers to route reply packets back to the originating Node via tunnel (symmetric path)
- Enable shouldEnableEgressPolicyRouting() for noEncap mode so that iptables mangle rules, ip rules, and the ReplyEgressRouteTable default route are provisioned, and rp_filter is set to loose mode
- Update docs (egress.md, noencap-hybrid-modes.md, feature-gates.md)