### PR TITLE
Validate NodePortLocal port range bounds

### DIFF
--- a/cmd/antrea-agent/options_test.go
+++ b/cmd/antrea-agent/options_test.go
@@ -237,6 +237,49 @@ func TestOptionsValidateEgressConfig(t *testing.T) {
 	}
 }
 
+func TestOptionsValidateNodePortLocalConfig(t *testing.T) {
+	tests := []struct {
+		name         string
+		portRange    string
+		expectedErr  string
+		expectedFrom int
+		expectedTo   int
+	}{
+		{
+			name:         "valid range",
+			portRange:    "61000-62000",
+			expectedFrom: 61000,
+			expectedTo:   62000,
+		},
+		{
+			name:        "out of range port",
+			portRange:   "70000-71000",
+			expectedErr: "NodePortLocal portRange is not valid: start port is invalid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := &Options{config: &agentconfig.AgentConfig{
+				NodePortLocal: agentconfig.NodePortLocalConfig{
+					Enable:    true,
+					PortRange: tt.portRange,
+				},
+			}}
+
+			err := o.validateNodePortLocalConfig()
+			if tt.expectedErr != "" {
+				require.ErrorContains(t, err, tt.expectedErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedFrom, o.nplStartPort)
+			assert.Equal(t, tt.expectedTo, o.nplEndPort)
+		})
+	}
+}
+
 func TestOptionsValidateMulticastConfig(t *testing.T) {
 	tests := []struct {
 		name              string

--- a/cmd/antrea-agent/util.go
+++ b/cmd/antrea-agent/util.go
@@ -25,6 +25,7 @@ import (
 
 	"antrea.io/antrea/v2/pkg/agent/util"
 	k8sutil "antrea.io/antrea/v2/pkg/util/k8s"
+	"antrea.io/antrea/v2/pkg/util/validation"
 )
 
 var (
@@ -94,6 +95,12 @@ func parsePortRange(portRangeStr string) (start, end int, err error) {
 		return 0, 0, err
 	}
 
+	if err := validation.ValidatePort(start); err != nil {
+		return 0, 0, fmt.Errorf("start port is invalid: %w", err)
+	}
+	if err := validation.ValidatePort(end); err != nil {
+		return 0, 0, fmt.Errorf("end port is invalid: %w", err)
+	}
 	if end <= start {
 		return 0, 0, fmt.Errorf("start port must be smaller than end port: %s", portRangeStr)
 	}

--- a/cmd/antrea-agent/util_test.go
+++ b/cmd/antrea-agent/util_test.go
@@ -109,12 +109,22 @@ func TestParsePortRange(t *testing.T) {
 			portRangeStr: "6100-6100",
 			expectedErr:  "start port must be smaller than end port: 6100-6100",
 		},
+		{
+			name:         "port range start is out of bounds",
+			portRangeStr: "0-6100",
+			expectedErr:  "start port is invalid",
+		},
+		{
+			name:         "port range end is out of bounds",
+			portRangeStr: "6100-70000",
+			expectedErr:  "end port is invalid",
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			start, end, err := parsePortRange(tc.portRangeStr)
 			if tc.expectedErr != "" {
-				assert.EqualError(t, err, tc.expectedErr)
+				assert.ErrorContains(t, err, tc.expectedErr)
 			} else {
 				assert.NoError(t, err)
 			}


### PR DESCRIPTION
NodePortLocal currently accepts out of range `portRange` values like `70000-71000`.
That slips past agent config validation and only blows up later when NPL tries to bind ports, which is pretty meh.

This makes it fail fast during validation, and adds tests for the helper and option path.

Repro:
1. Set `nodePortLocal.enable: true`
2. Set `nodePortLocal.portRange: 70000-71000`
3. Start `antrea-agent`

Before this patch, validation passes and NPL fails later on socket bind.
After this patch, `antrea-agent` returns `NodePortLocal portRange is not valid...` right away.

Tested with `go test ./cmd/antrea-agent ./pkg/agent/nodeportlocal/...`
