### PR TITLE
Automated cherry pick of #7952: Fix NP stats panic from stale OpenFlow flows (#7952)

### DIFF
--- a/cmd/antrea-agent/agent.go
+++ b/cmd/antrea-agent/agent.go
@@ -281,6 +281,10 @@ func run(o *Options) error {
 	// NodeRouteController. Additional requirements may be added in the future.
 	flowRestoreCompleteWait := utilwait.NewGroup()
 
+	// staleFlowsDeletedWait starts with one pending unit (Increment); the stale-flow cleanup
+	// goroutine calls Done when deletion completes.
+	staleFlowsDeletedWait := utilwait.NewGroup().Increment()
+
 	// set up signal capture: the first SIGTERM / SIGINT signal is handled gracefully and will
 	// cause the stopCh channel to be closed; if another signal is received before the program
 	// exits, we will force exit.
@@ -327,6 +331,7 @@ func run(o *Options) error {
 		serviceConfig,
 		podNetworkWait,
 		flowRestoreCompleteWait,
+		staleFlowsDeletedWait,
 		stopCh,
 		o.nodeType,
 		o.config.ExternalNode.ExternalNodeNamespace,
@@ -974,7 +979,10 @@ func run(o *Options) error {
 	// statsCollector collects stats and reports to the antrea-controller periodically. For now it's only used for
 	// NetworkPolicy stats and Multicast stats.
 	if features.DefaultFeatureGate.Enabled(features.NetworkPolicyStats) {
-		statsCollector := stats.NewCollector(antreaClientProvider, ofClient, networkPolicyController, mcastController)
+		// staleFlowsDeletedWait: the collector waits inside Run until the initializer's stale-flow
+		// cleanup calls Done, so we do not report stats for flows from the prior round (see
+		// Initializer.initOpenFlowPipeline and flowRestoreCompleteWait / podNetworkWait).
+		statsCollector := stats.NewCollector(antreaClientProvider, ofClient, networkPolicyController, mcastController, staleFlowsDeletedWait)
 		go statsCollector.Run(stopCh)
 	}
 

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -77,6 +77,8 @@ const (
 	// supported. For simplicity's sake, we also use this upper bound for Windows, even if it
 	// does not apply.
 	ovsTunnelMaxMTU = 65000
+	// staleFlowDeleteRetryInterval is the wait between DeleteStaleFlows attempts on error.
+	staleFlowDeleteRetryInterval = 2 * time.Second
 )
 
 var (
@@ -140,9 +142,15 @@ type Initializer struct {
 	// been installed. We use it to determine whether flows from previous
 	// rounds can be deleted.
 	flowRestoreCompleteWait *utilwait.Group
-	stopCh                  <-chan struct{}
-	nodeType                config.NodeType
-	externalNodeNamespace   string
+	// staleFlowsDeletedWait is created by the caller with NewGroup().Increment();
+	// the stale-flow cleanup goroutine in initOpenFlowPipeline calls Done when
+	// deletion has finished (or the goroutine exits after a failed delete).
+	// Components that must not observe stale flows from a previous agent round
+	// should wait on this group before starting.
+	staleFlowsDeletedWait *utilwait.Group
+	stopCh                <-chan struct{}
+	nodeType              config.NodeType
+	externalNodeNamespace string
 }
 
 func NewInitializer(
@@ -162,6 +170,7 @@ func NewInitializer(
 	serviceConfig *config.ServiceConfig,
 	podNetworkWait *utilwait.Group,
 	flowRestoreCompleteWait *utilwait.Group,
+	staleFlowsDeletedWait *utilwait.Group,
 	stopCh <-chan struct{},
 	nodeType config.NodeType,
 	externalNodeNamespace string,
@@ -188,6 +197,7 @@ func NewInitializer(
 		l7NetworkPolicyConfig:    &config.L7NetworkPolicyConfig{},
 		podNetworkWait:           podNetworkWait,
 		flowRestoreCompleteWait:  flowRestoreCompleteWait,
+		staleFlowsDeletedWait:    staleFlowsDeletedWait,
 		stopCh:                   stopCh,
 		nodeType:                 nodeType,
 		externalNodeNamespace:    externalNodeNamespace,
@@ -506,6 +516,26 @@ func persistRoundNum(num uint64, bridgeClient ovsconfig.OVSBridgeClient, interva
 	klog.Errorf("Unable to persist round number %d to OVSDB after %d tries", num, maxRetries+1)
 }
 
+// deleteStaleFlowsWithRetry calls DeleteStaleFlows until it succeeds or stopCh is closed
+// during the wait before another attempt. It returns false when the new round number must not
+// be persisted (agent shutting down before stale flows could be deleted).
+func (i *Initializer) deleteStaleFlowsWithRetry() bool {
+	var lastErr error
+	for attempt := 1; ; attempt++ {
+		lastErr = i.ofClient.DeleteStaleFlows()
+		if lastErr == nil {
+			return true
+		}
+		klog.ErrorS(lastErr, "Error when deleting stale flows from previous round", "attempt", attempt)
+		select {
+		case <-i.stopCh:
+			klog.InfoS("Stopped retrying stale flow deletion; agent shutting down")
+			return false
+		case <-time.After(staleFlowDeleteRetryInterval):
+		}
+	}
+}
+
 // initOpenFlowPipeline sets up necessary Openflow entries, including pipeline, classifiers, conn_track, and gateway flows
 // Every time the agent is (re)started, we go through the following sequence:
 //  1. agent determines the new round number (this is done by incrementing the round number
@@ -550,11 +580,15 @@ func (i *Initializer) initOpenFlowPipeline() error {
 		// block until some key flows (NetworkPolicy flows, Pod flows, Node route flows)
 		// have been installed. But not all entities responsible for installing flows
 		// currently use this wait group, so we block for a minimum of 10 seconds.
+		//
+		// staleFlowsDeletedWait is satisfied when this goroutine exits so that
+		// components which must not see stale flows (e.g. the NP stats
+		// collector) can delay their start until cleanup is guaranteed.
+		defer i.staleFlowsDeletedWait.Done()
 		time.Sleep(10 * time.Second)
 		i.flowRestoreCompleteWait.Wait()
 		klog.Info("Deleting stale flows from previous round if any")
-		if err := i.ofClient.DeleteStaleFlows(); err != nil {
-			klog.Errorf("Error when deleting stale flows from previous round: %v", err)
+		if !i.deleteStaleFlowsWithRetry() {
 			return
 		}
 		persistRoundNum(roundInfo.RoundNum, i.ovsBridgeClient, 1*time.Second, maxRetryForRoundNumSave)

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -16,10 +16,12 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/google/uuid"
@@ -39,6 +41,7 @@ import (
 	"antrea.io/antrea/pkg/agent/cniserver"
 	"antrea.io/antrea/pkg/agent/config"
 	"antrea.io/antrea/pkg/agent/interfacestore"
+	openflowtest "antrea.io/antrea/pkg/agent/openflow/testing"
 	"antrea.io/antrea/pkg/agent/types"
 	crdv1alpha1 "antrea.io/antrea/pkg/apis/crd/v1alpha1"
 	fakeversioned "antrea.io/antrea/pkg/client/clientset/versioned/fake"
@@ -1045,4 +1048,91 @@ func TestValidateSupportedDPFeatures(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDeleteStaleFlowsWithRetry(t *testing.T) {
+	testErr := errors.New("delete stale flows error")
+
+	t.Run("succeeds on first attempt", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			ctrl := mock.NewController(t)
+			mockOFClient := openflowtest.NewMockClient(ctrl)
+			mockOFClient.EXPECT().DeleteStaleFlows().Return(nil)
+
+			initializer := &Initializer{
+				ofClient: mockOFClient,
+				stopCh:   make(chan struct{}),
+			}
+
+			result := initializer.deleteStaleFlowsWithRetry()
+			assert.True(t, result)
+		})
+	})
+
+	t.Run("succeeds after transient failures", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			ctrl := mock.NewController(t)
+			mockOFClient := openflowtest.NewMockClient(ctrl)
+			mock.InOrder(
+				mockOFClient.EXPECT().DeleteStaleFlows().Return(testErr),
+				mockOFClient.EXPECT().DeleteStaleFlows().Return(testErr),
+				mockOFClient.EXPECT().DeleteStaleFlows().Return(nil),
+			)
+
+			initializer := &Initializer{
+				ofClient: mockOFClient,
+				stopCh:   make(chan struct{}),
+			}
+
+			var result bool
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				result = initializer.deleteStaleFlowsWithRetry()
+			}()
+
+			// Let the retry loop block on time.After, then advance the fake clock
+			// through each retry interval.
+			synctest.Wait()
+			time.Sleep(staleFlowDeleteRetryInterval)
+			synctest.Wait()
+			select {
+			case <-done:
+				t.Fatal("deleteStaleFlowsWithRetry should not return until after the third DeleteStaleFlows succeeds")
+			default:
+			}
+			time.Sleep(staleFlowDeleteRetryInterval)
+			synctest.Wait()
+
+			<-done
+			assert.True(t, result)
+		})
+	})
+
+	t.Run("stops retrying when stopCh is closed", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			ctrl := mock.NewController(t)
+			mockOFClient := openflowtest.NewMockClient(ctrl)
+			mockOFClient.EXPECT().DeleteStaleFlows().Return(testErr).AnyTimes()
+
+			stopCh := make(chan struct{})
+			initializer := &Initializer{
+				ofClient: mockOFClient,
+				stopCh:   stopCh,
+			}
+
+			var result bool
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				result = initializer.deleteStaleFlowsWithRetry()
+			}()
+
+			synctest.Wait()
+			close(stopCh)
+
+			<-done
+			assert.False(t, result)
+		})
+	})
 }

--- a/pkg/agent/controller/serviceexternalip/controller.go
+++ b/pkg/agent/controller/serviceexternalip/controller.go
@@ -117,7 +117,9 @@ func NewServiceExternalIPController(
 		linkMonitor:               linkMonitor,
 	}
 	ipAssigner, err := ipassigner.NewIPAssigner(nodeTransportInterface, "", linkMonitor, false)
-	if err != nil {
+	// On Windows, ipassigner.NewIPAssigner always returns a non-nil error (see ip_assigner_windows.go);
+	// on Linux, err is nil when initialization succeeds. golangci runs staticcheck with GOOS=windows too.
+	if err != nil { //nolint:staticcheck // SA4023: err is always non-nil on Windows only.
 		return nil, fmt.Errorf("initializing service external IP assigner failed: %v", err)
 	}
 	c.ipAssigner = ipAssigner

--- a/pkg/agent/openflow/network_policy.go
+++ b/pkg/agent/openflow/network_policy.go
@@ -15,6 +15,7 @@
 package openflow
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -34,6 +35,13 @@ import (
 	binding "antrea.io/antrea/pkg/ovs/openflow"
 	thirdpartynp "antrea.io/antrea/third_party/networkpolicy"
 )
+
+// errSkipNetworkPolicyMetricFlow means the OpenFlow dump line is not a valid
+// NetworkPolicy metric flow (for example a stale routing flow after a pipeline table ID shift).
+var errSkipNetworkPolicyMetricFlow = errors.New("not a valid network policy metric flow")
+
+// errSkipMulticastMetricFlow means the OpenFlow dump line is not a valid multicast metric flow.
+var errSkipMulticastMetricFlow = errors.New("not a valid multicast metric flow")
 
 var (
 	MatchDstIP          = types.NewMatchKey(binding.ProtocolIP, types.IPAddr, "nw_dst")
@@ -1837,7 +1845,7 @@ func (f *featureNetworkPolicy) calculateFlowUpdates(updates map[uint16]uint16, t
 			conj := conjObj.(*policyRuleConjunction)
 			// Only re-assign flow priorities for flows in the table specified.
 			if conj.ruleTableID != table {
-				klog.V(4).Infof("Conjunction %v with the same actionFlow priority is from a different table %v", conj.id, conj.ruleTableID)
+				klog.V(4).InfoS("Conjunction with the same actionFlow priority is from a different table", "conjunctionID", conj.id, "tableID", conj.ruleTableID)
 				continue
 			}
 			for _, actionFlow := range conj.actionFlows {
@@ -1902,17 +1910,28 @@ func parseMulticastEgressPodFlow(flowMap map[string]string) (string, types.RuleM
 	return nwSrc, m
 }
 
-func parseMulticastMetricFlow(flowMap map[string]string) (uint32, types.RuleMetric) {
+func parseMulticastMetricFlow(flowMap map[string]string) (uint32, types.RuleMetric, error) {
 	// example MulticastEgressMetric allow flow format:
 	// table=MulticastEgressMetric, n_packets=11, n_bytes=1562, priority=200,reg0=0x400/0x400,reg3=0x4 actions=goto_table:MulticastEgressPodMetric
 	// example MulticastEgressMetric drop flow format:
 	// table=MulticastEgressMetric, n_packets=230, n_bytes=32660, priority=200,reg0=0x400/0x400,reg3=0x3 actions=drop
 	// example MulticastIngressMetric allow flow format:
 	// table=MulticastIngressMetric, n_packets=18, n_bytes=780, priority=200,reg0=0x400/0x400,reg3=0x3 actions=resubmit(,MulticastOutput)
+	//
+	// Valid flows always match APConjIDField (reg3). Stale non-multicast flows can share the same
+	// table id and priority=200 after a pipeline shift; they lack a usable conjunction id and must
+	// not be attributed as multicast policy metrics (cookie filtering also skips wrong categories).
 	m := parseFlowMetric(flowMap)
-	conjID := flowMap["reg3"]
-	id, _ := strconv.ParseUint(conjID, 0, 32)
-	return uint32(id), m
+	conjID, ok := flowMap["reg3"]
+	conjID = strings.TrimSpace(conjID)
+	if !ok || conjID == "" {
+		return 0, types.RuleMetric{}, errSkipMulticastMetricFlow
+	}
+	id, err := strconv.ParseUint(conjID, 0, 32)
+	if err != nil || id == 0 {
+		return 0, types.RuleMetric{}, errSkipMulticastMetricFlow
+	}
+	return uint32(id), m, nil
 }
 
 func parseFlowMetric(flowMap map[string]string) types.RuleMetric {
@@ -1924,26 +1943,49 @@ func parseFlowMetric(flowMap map[string]string) types.RuleMetric {
 	return m
 }
 
-func parseDropFlow(flowMap map[string]string) (uint32, types.RuleMetric) {
+func parseDropFlow(flowMap map[string]string) (uint32, types.RuleMetric, error) {
+	// Deny metric flows match reg0 (deny mark) and encode the conjunction id in reg3; see denyRuleMetricFlow.
 	m := parseFlowMetric(flowMap)
 	m.Sessions = m.Packets
-	reg3 := flowMap["reg3"]
-	id, _ := strconv.ParseUint(reg3, 0, 32)
-	return uint32(id), m
+	reg3, ok := flowMap["reg3"]
+	reg3 = strings.TrimSpace(reg3)
+	if !ok || reg3 == "" {
+		return 0, types.RuleMetric{}, errSkipNetworkPolicyMetricFlow
+	}
+	id, err := strconv.ParseUint(reg3, 0, 32)
+	if err != nil || id == 0 {
+		return 0, types.RuleMetric{}, errSkipNetworkPolicyMetricFlow
+	}
+	return uint32(id), m, nil
 }
 
-func parseAllowFlow(flowMap map[string]string) (uint32, types.RuleMetric) {
+func parseAllowFlow(flowMap map[string]string) (uint32, types.RuleMetric, error) {
+	// A valid allow metric flow must have ct_label, which encodes the rule ID.
+	// Flows without ct_label are not metric flows — they may be stale flows from a
+	// prior agent version that occupied the same table ID after a pipeline table shift
+	// (e.g., L3 routing flows from an old pipeline that now share the EgressMetricTable
+	// ID after a new table was inserted earlier in the pipeline). Skip them to avoid
+	// misinterpreting non-metric flows as NetworkPolicy statistics.
+	if _, ok := flowMap["ct_label"]; !ok {
+		return 0, types.RuleMetric{}, errSkipNetworkPolicyMetricFlow
+	}
 	m := parseFlowMetric(flowMap)
 	if strings.Contains(flowMap["ct_state"], "+") { // ct_state=+new
 		m.Sessions = m.Packets
 	}
-	ct_label := flowMap["ct_label"]
-	idRaw := ct_label[strings.Index(ct_label, "0x")+2 : strings.Index(ct_label, "/")]
+	ctLabel := flowMap["ct_label"]
+	hexIdx := strings.Index(ctLabel, "0x")
+	slashIdx := strings.Index(ctLabel, "/")
+	if hexIdx == -1 || slashIdx == -1 || slashIdx <= hexIdx+2 {
+		// ct_label is absent or malformed; this is not a valid allow metric flow.
+		return 0, types.RuleMetric{}, errSkipNetworkPolicyMetricFlow
+	}
+	idRaw := ctLabel[hexIdx+2 : slashIdx]
 	if len(idRaw) > 8 { // only 32 bits are valid.
 		idRaw = idRaw[:len(idRaw)-8]
 	}
 	id, _ := strconv.ParseUint(idRaw, 16, 32)
-	return uint32(id), m
+	return uint32(id), m, nil
 }
 
 func parseFlowToMap(flow string) map[string]string {
@@ -1968,7 +2010,7 @@ func parseFlowToMap(flow string) map[string]string {
 	return flowMap
 }
 
-func parseMetricFlow(flowMap map[string]string) (uint32, types.RuleMetric) {
+func parseMetricFlow(flowMap map[string]string) (uint32, types.RuleMetric, error) {
 	dropIdentifier := "reg0"
 	// example allow flow format:
 	// table=101, n_packets=0, n_bytes=0, priority=200,ct_state=-new,ct_label=0x1/0xffffffff,ip actions=goto_table:105
@@ -1980,11 +2022,28 @@ func parseMetricFlow(flowMap map[string]string) (uint32, types.RuleMetric) {
 	return parseAllowFlow(flowMap)
 }
 
+// metricFlowsDumpFilter builds ovs-ofctl dump-flows FLOW match text for Antrea metric flows: exact
+// cookie for the agent round and category. This excludes stale flows from prior rounds and flows
+// from other feature categories (e.g. PodConnectivity, Traceflow) that may share the same table ID
+// after a pipeline table shift. Note: "priority=N" is not a valid ovs-ofctl dump-flows keyword and
+// must not be included; priority-based filtering is handled by parseMetricFlow and its callers.
+func (c *client) metricFlowsDumpFilter(wantCategory cookie.Category) string {
+	round := c.roundInfo.RoundNum % (1 << cookie.BitwidthRound)
+	raw := cookie.NewAllocator(round).Request(wantCategory).Raw()
+	return fmt.Sprintf("cookie=0x%x/0x%x", raw, ^uint64(0))
+}
+
 func (c *client) MulticastIngressPodMetrics() map[uint32]*types.RuleMetric {
 	result := map[uint32]*types.RuleMetric{}
-	ingressFlows, _ := c.ovsctlClient.DumpTableFlows(MulticastIngressPodMetricTable.ofTable.GetID())
+	ingressFlows, err := c.ovsctlClient.DumpTableFlows(
+		MulticastIngressPodMetricTable.ofTable.GetID(), c.metricFlowsDumpFilter(cookie.Multicast))
+	if err != nil {
+		klog.ErrorS(err, "Failed to dump multicast ingress pod metrics", "table", MulticastIngressPodMetricTable.ofTable.GetName(), "wantCategory", cookie.Multicast)
+		return result
+	}
 	for _, flow := range ingressFlows {
 		if !strings.Contains(flow, metricFlowIdentifier) {
+			klog.V(4).InfoS("Skipping non-metric flow", "flow", flow)
 			continue
 		}
 		flowMap := parseFlowToMap(flow)
@@ -2008,9 +2067,15 @@ func (c *client) MulticastIngressPodMetricsByOFPort(ofPort int32) *types.RuleMet
 
 func (c *client) MulticastEgressPodMetrics() map[string]*types.RuleMetric {
 	result := map[string]*types.RuleMetric{}
-	ingressFlows, _ := c.ovsctlClient.DumpTableFlows(MulticastEgressPodMetricTable.ofTable.GetID())
+	ingressFlows, err := c.ovsctlClient.DumpTableFlows(
+		MulticastEgressPodMetricTable.ofTable.GetID(), c.metricFlowsDumpFilter(cookie.Multicast))
+	if err != nil {
+		klog.ErrorS(err, "Failed to dump multicast egress pod metrics", "table", MulticastEgressPodMetricTable.ofTable.GetName(), "wantCategory", cookie.Multicast)
+		return result
+	}
 	for _, flow := range ingressFlows {
 		if !strings.Contains(flow, metricFlowIdentifier) {
+			klog.V(4).InfoS("Skipping non-metric flow", "flow", flow)
 			continue
 		}
 		flowMap := parseFlowToMap(flow)
@@ -2034,14 +2099,24 @@ func (c *client) MulticastEgressPodMetricsByIP(ip net.IP) *types.RuleMetric {
 
 func (c *client) NetworkPolicyMetrics() map[uint32]*types.RuleMetric {
 	result := map[uint32]*types.RuleMetric{}
-	collectMetricsFromFlows := func(table *Table, getMetricAndID func(flowMap map[string]string) (uint32, types.RuleMetric)) {
-		dumpedFlows, _ := c.ovsctlClient.DumpTableFlows(table.ofTable.GetID())
+	collectMetricsFromFlows := func(table *Table, wantCategory cookie.Category, getMetricAndID func(flowMap map[string]string) (uint32, types.RuleMetric, error)) {
+		dumpedFlows, err := c.ovsctlClient.DumpTableFlows(
+			table.ofTable.GetID(), c.metricFlowsDumpFilter(wantCategory))
+		if err != nil {
+			klog.ErrorS(err, "Failed to dump network policy metrics", "table", table.ofTable.GetName(), "wantCategory", wantCategory)
+			return
+		}
 		for _, flow := range dumpedFlows {
 			if !strings.Contains(flow, metricFlowIdentifier) {
+				klog.V(4).InfoS("Skipping non-metric flow", "flow", flow)
 				continue
 			}
 			flowMap := parseFlowToMap(flow)
-			ruleID, metric := getMetricAndID(flowMap)
+			ruleID, metric, err := getMetricAndID(flowMap)
+			if err != nil {
+				klog.V(4).InfoS("Failed to parse metric flow", "flow", flow, "table", table.ofTable.GetName(), "error", err)
+				continue
+			}
 			if accMetric, ok := result[ruleID]; ok {
 				accMetric.Merge(&metric)
 			} else {
@@ -2050,9 +2125,11 @@ func (c *client) NetworkPolicyMetrics() map[uint32]*types.RuleMetric {
 		}
 	}
 	if c.enableMulticast {
-		// We need to collect NP statistics matching IGMP query messages and egress multicast traffic.
-		collectMetricsFromFlows(MulticastIngressMetricTable, parseMulticastMetricFlow)
-		collectMetricsFromFlows(MulticastEgressMetricTable, parseMulticastMetricFlow)
+		// Multicast ANP metric flows are installed by featureNetworkPolicy and use the same cookie
+		// category as unicast ANP metrics (NetworkPolicy), not cookie.Multicast (used by the multicast
+		// feature for IGMP / pod tables). Use NetworkPolicy in the dump filter or those flows are never matched.
+		collectMetricsFromFlows(MulticastIngressMetricTable, cookie.NetworkPolicy, parseMulticastMetricFlow)
+		collectMetricsFromFlows(MulticastEgressMetricTable, cookie.NetworkPolicy, parseMulticastMetricFlow)
 	}
 	// We have two flows for each allow rule. One matches 'ct_state=+new'
 	// and counts the number of first packets, which is also the number
@@ -2060,8 +2137,8 @@ func (c *client) NetworkPolicyMetrics() map[uint32]*types.RuleMetric {
 	// matches 'ct_state=-new' and is used to count all subsequent
 	// packets in the session. We need to merge metrics from these 2
 	// flows to get the correct number of total packets.
-	collectMetricsFromFlows(EgressMetricTable, parseMetricFlow)
-	collectMetricsFromFlows(IngressMetricTable, parseMetricFlow)
+	collectMetricsFromFlows(EgressMetricTable, cookie.NetworkPolicy, parseMetricFlow)
+	collectMetricsFromFlows(IngressMetricTable, cookie.NetworkPolicy, parseMetricFlow)
 	return result
 }
 

--- a/pkg/agent/openflow/network_policy_test.go
+++ b/pkg/agent/openflow/network_policy_test.go
@@ -76,6 +76,9 @@ var (
 	icmpType8    = int32(8)
 	icmpCode0    = int32(0)
 
+	// testNPMCMetricCookieRound0 is the OVS cookie field prefix for NetworkPolicy metric flows at agent round 0.
+	testNPMCMetricCookieRound0 = fmt.Sprintf("cookie=0x%x,", cookie.NewAllocator(0).Request(cookie.NetworkPolicy).Raw())
+
 	mockFeaturePodConnectivity = featurePodConnectivity{}
 	mockFeatureNetworkPolicy   = featureNetworkPolicy{enableAntreaPolicy: true}
 	activeFeatures             = []feature{&mockFeaturePodConnectivity, &mockFeatureNetworkPolicy}
@@ -1058,11 +1061,67 @@ func prepareClient(ctrl *gomock.Controller, dualStack bool) *client {
 	return c
 }
 
+func TestParseMulticastMetricFlow(t *testing.T) {
+	for name, tc := range map[string]struct {
+		flow        string
+		wantID      uint32
+		wantPackets uint64
+		wantBytes   uint64
+		wantErr     error
+	}{
+		"egress allow": {
+			flow:        "table=MulticastEgressMetric, n_packets=11, n_bytes=1562, priority=200,reg0=0x400/0x400,reg3=0x4 actions=goto_table:MulticastEgressPodMetric",
+			wantID:      4,
+			wantPackets: 11,
+			wantBytes:   1562,
+		},
+		"egress drop": {
+			flow:        "table=MulticastEgressMetric, n_packets=230, n_bytes=32660, priority=200,reg0=0x400/0x400,reg3=0x3 actions=drop",
+			wantID:      3,
+			wantPackets: 230,
+			wantBytes:   32660,
+		},
+		"ingress allow": {
+			flow:        "table=MulticastIngressMetric, n_packets=18, n_bytes=780, priority=200,reg0=0x400/0x400,reg3=0x3 actions=resubmit(,MulticastOutput)",
+			wantID:      3,
+			wantPackets: 18,
+			wantBytes:   780,
+		},
+		"stale routing-like flow without reg3": {
+			flow:    "table=MulticastEgressMetric, n_packets=289, n_bytes=2385154, priority=200,ip,nw_dst=10.0.0.0/24 actions=resubmit(,SNATMark)",
+			wantErr: errSkipMulticastMetricFlow,
+		},
+		"malformed reg3": {
+			flow:    "table=MulticastEgressMetric, n_packets=1, n_bytes=74, priority=200,reg0=0x400/0x400,reg3=notahex actions=drop",
+			wantErr: errSkipMulticastMetricFlow,
+		},
+		"reg3 zero": {
+			flow:    "table=MulticastEgressMetric, n_packets=1, n_bytes=74, priority=200,reg0=0x400/0x400,reg3=0x0 actions=drop",
+			wantErr: errSkipMulticastMetricFlow,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			id, m, err := parseMulticastMetricFlow(parseFlowToMap(tc.flow))
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+				require.Equal(t, uint32(0), id)
+				require.Equal(t, types.RuleMetric{}, m)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.wantID, id)
+				require.Equal(t, tc.wantPackets, m.Packets)
+				require.Equal(t, tc.wantBytes, m.Bytes)
+			}
+		})
+	}
+}
+
 func TestParseMetricFlow(t *testing.T) {
 	for name, tc := range map[string]struct {
-		flow   string
-		rule   uint32
-		metric types.RuleMetric
+		flow        string
+		rule        uint32
+		metric      types.RuleMetric
+		wantSkipErr bool
 	}{
 		"Drop flow": {
 			flow: "table=101, n_packets=9, n_bytes=666, priority=200,reg0=0x100000/0x100000,reg3=0x5 actions=drop",
@@ -1072,6 +1131,18 @@ func TestParseMetricFlow(t *testing.T) {
 				Packets:  9,
 				Sessions: 9,
 			},
+		},
+		"Drop flow without reg3": {
+			flow:        "table=101, n_packets=1, n_bytes=64, priority=200,reg0=0x100000/0x100000,ip actions=drop",
+			wantSkipErr: true,
+		},
+		"Drop flow malformed reg3": {
+			flow:        "table=101, n_packets=1, n_bytes=64, priority=200,reg0=0x100000/0x100000,reg3=notahex actions=drop",
+			wantSkipErr: true,
+		},
+		"Drop flow reg3 zero": {
+			flow:        "table=101, n_packets=1, n_bytes=64, priority=200,reg0=0x100000/0x100000,reg3=0x0 actions=drop",
+			wantSkipErr: true,
 		},
 		"New allow flow": {
 			flow: "table=101, n_packets=123, n_bytes=456, priority=200,ct_state=+new,ct_label=0x112345678/0xffffffff00000000,ip actions=goto_table:105",
@@ -1091,42 +1162,68 @@ func TestParseMetricFlow(t *testing.T) {
 				Sessions: 0,
 			},
 		},
+		"Stale L3 routing flow without ct_label": {
+			// A stale flow from a prior agent version that occupied the same table ID
+			// after a pipeline table shift. It has neither reg0 nor ct_label and must
+			// be skipped without panicking.
+			flow:        "table=101, n_packets=289, n_bytes=2385154, priority=200,ip,nw_dst=193.5.2.0/24 actions=resubmit(,SNATMark)",
+			wantSkipErr: true,
+		},
+		"Allow flow malformed ct_label missing slash": {
+			flow:        "table=101, n_packets=1, n_bytes=10, priority=200,ct_state=+new,ct_label=0x5abcde,ip actions=goto_table:105",
+			wantSkipErr: true,
+		},
+		"Allow flow malformed ct_label empty hex segment": {
+			flow:        "table=101, n_packets=1, n_bytes=10, priority=200,ct_state=+new,ct_label=0x/0xffffffff,ip actions=goto_table:105",
+			wantSkipErr: true,
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			rule, metric := parseMetricFlow(parseFlowToMap(tc.flow))
-			require.Equal(t, tc.rule, rule)
-			require.Equal(t, tc.metric.Bytes, metric.Bytes)
-			require.Equal(t, tc.metric.Sessions, metric.Sessions)
-			require.Equal(t, tc.metric.Packets, metric.Packets)
+			rule, metric, err := parseMetricFlow(parseFlowToMap(tc.flow))
+			if tc.wantSkipErr {
+				require.ErrorIs(t, err, errSkipNetworkPolicyMetricFlow)
+				require.Equal(t, uint32(0), rule)
+				require.Equal(t, types.RuleMetric{}, metric)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.rule, rule)
+				require.Equal(t, tc.metric.Bytes, metric.Bytes)
+				require.Equal(t, tc.metric.Sessions, metric.Sessions)
+				require.Equal(t, tc.metric.Packets, metric.Packets)
+			}
 		})
 	}
 }
 
 func TestNetworkPolicyMetrics(t *testing.T) {
+	dumpErr := errors.New("injected ovs dump failure")
 	tests := []struct {
-		name         string
-		egressFlows  []string
-		ingressFlows []string
-		want         map[uint32]*types.RuleMetric
+		name           string
+		roundNum       uint64
+		egressFlows    []string
+		ingressFlows   []string
+		want           map[uint32]*types.RuleMetric
+		egressDumpErr  bool
+		ingressDumpErr bool
 	}{
 		{
 			name: "Normal flows",
 			egressFlows: []string{
-				"table=61, n_packets=1, n_bytes=74, priority=200,ct_state=+new,ct_label=0x200000000/0xffffffff00000000,ip actions=goto_table:70",
-				"table=61, n_packets=11, n_bytes=1661, priority=200,ct_state=-new,ct_label=0x200000000/0xffffffff00000000,ip actions=goto_table:70",
-				"table=61, n_packets=0, n_bytes=0, priority=200,ct_state=+new,ct_label=0x600000000/0xffffffff00000000,ip actions=goto_table:70",
-				"table=61, n_packets=0, n_bytes=0, priority=200,ct_state=-new,ct_label=0x600000000/0xffffffff00000000,ip actions=goto_table:70",
-				"table=61, n_packets=4, n_bytes=336, priority=200,reg0=0x100000/0x100000,reg3=0x4 actions=drop",
-				"table=61, n_packets=0, n_bytes=0, priority=200,reg0=0x100000/0x100000,reg3=0x8 actions=drop",
+				testNPMCMetricCookieRound0 + "table=61, n_packets=1, n_bytes=74, priority=200,ct_state=+new,ct_label=0x200000000/0xffffffff00000000,ip actions=goto_table:70",
+				testNPMCMetricCookieRound0 + "table=61, n_packets=11, n_bytes=1661, priority=200,ct_state=-new,ct_label=0x200000000/0xffffffff00000000,ip actions=goto_table:70",
+				testNPMCMetricCookieRound0 + "table=61, n_packets=0, n_bytes=0, priority=200,ct_state=+new,ct_label=0x600000000/0xffffffff00000000,ip actions=goto_table:70",
+				testNPMCMetricCookieRound0 + "table=61, n_packets=0, n_bytes=0, priority=200,ct_state=-new,ct_label=0x600000000/0xffffffff00000000,ip actions=goto_table:70",
+				testNPMCMetricCookieRound0 + "table=61, n_packets=4, n_bytes=336, priority=200,reg0=0x100000/0x100000,reg3=0x4 actions=drop",
+				testNPMCMetricCookieRound0 + "table=61, n_packets=0, n_bytes=0, priority=200,reg0=0x100000/0x100000,reg3=0x8 actions=drop",
 				"table=61, n_packets=1502362, n_bytes=601635949, priority=0 actions=goto_table:70",
 			},
 			ingressFlows: []string{
-				"table=101, n_packets=1, n_bytes=74, priority=200,ct_state=+new,ct_label=0x1/0xffffffff,ip actions=resubmit(,105)",
-				"table=101, n_packets=11, n_bytes=1661, priority=200,ct_state=-new,ct_label=0x1/0xffffffff,ip actions=resubmit(,105)",
-				"table=101, n_packets=2, n_bytes=148, priority=200,ct_state=+new,ct_label=0x5/0xffffffff,ip actions=resubmit(,105)",
-				"table=101, n_packets=12, n_bytes=943, priority=200,ct_state=-new,ct_label=0x5/0xffffffff,ip actions=resubmit(,105)",
-				"table=101, n_packets=0, n_bytes=0, priority=200,reg0=0x100000/0x100000,reg3=0x3 actions=drop",
-				"table=101, n_packets=4, n_bytes=338, priority=200,reg0=0x100000/0x100000,reg3=0xb actions=drop",
+				testNPMCMetricCookieRound0 + "table=101, n_packets=1, n_bytes=74, priority=200,ct_state=+new,ct_label=0x1/0xffffffff,ip actions=resubmit(,105)",
+				testNPMCMetricCookieRound0 + "table=101, n_packets=11, n_bytes=1661, priority=200,ct_state=-new,ct_label=0x1/0xffffffff,ip actions=resubmit(,105)",
+				testNPMCMetricCookieRound0 + "table=101, n_packets=2, n_bytes=148, priority=200,ct_state=+new,ct_label=0x5/0xffffffff,ip actions=resubmit(,105)",
+				testNPMCMetricCookieRound0 + "table=101, n_packets=12, n_bytes=943, priority=200,ct_state=-new,ct_label=0x5/0xffffffff,ip actions=resubmit(,105)",
+				testNPMCMetricCookieRound0 + "table=101, n_packets=0, n_bytes=0, priority=200,reg0=0x100000/0x100000,reg3=0x3 actions=drop",
+				testNPMCMetricCookieRound0 + "table=101, n_packets=4, n_bytes=338, priority=200,reg0=0x100000/0x100000,reg3=0xb actions=drop",
 				"table=101, n_packets=1407190, n_bytes=509746586, priority=0 actions=resubmit(,105)",
 			},
 			want: map[uint32]*types.RuleMetric{
@@ -1141,27 +1238,60 @@ func TestNetworkPolicyMetrics(t *testing.T) {
 			},
 		},
 		{
+			name: "Stale flows mixed with normal metric flows",
+			egressFlows: []string{
+				// Valid metric flows.
+				testNPMCMetricCookieRound0 + "table=61, n_packets=1, n_bytes=74, priority=200,ct_state=+new,ct_label=0x200000000/0xffffffff00000000,ip actions=goto_table:70",
+				testNPMCMetricCookieRound0 + "table=61, n_packets=11, n_bytes=1661, priority=200,ct_state=-new,ct_label=0x200000000/0xffffffff00000000,ip actions=goto_table:70",
+				// Stale L3 routing flows from a prior pipeline version (no ct_label, no reg0).
+				// No matching cookie: skipped before parse (no panic, no bogus stats).
+				"table=61, n_packets=289, n_bytes=2385154, priority=200,ip,nw_dst=193.5.2.0/24 actions=resubmit(,SNATMark)",
+				"table=61, n_packets=31, n_bytes=2465, priority=200,ip,nw_dst=193.5.1.0/24 actions=mod_dl_dst:1e:48:f1:41:e2:15,resubmit(,EgressMark)",
+			},
+			ingressFlows: []string{},
+			want: map[uint32]*types.RuleMetric{
+				2: {Bytes: 1735, Sessions: 1, Packets: 12},
+			},
+		},
+		{
+			name:     "Skips flows by cookie when round or category does not match",
+			roundNum: 2,
+			// round=2, category=NetworkPolicy (see pkg/agent/openflow/cookie/allocator.go).
+			egressFlows: []string{
+				"cookie=0x2020000000000, table=61, n_packets=1, n_bytes=74, priority=200,ct_state=+new,ct_label=0x200000000/0xffffffff00000000,ip actions=goto_table:70",
+				"cookie=0x2020000000000, table=61, n_packets=11, n_bytes=1661, priority=200,ct_state=-new,ct_label=0x200000000/0xffffffff00000000,ip actions=goto_table:70",
+				// Prior round, Pod connectivity cookie — not an NP metric flow for this round.
+				"cookie=0x1010000000000, table=61, n_packets=999, n_bytes=9999, priority=200,ip,nw_dst=10.0.0.0/24 actions=resubmit(,SNATMark)",
+				// Current round but Pod connectivity category.
+				"cookie=0x2010000000000, table=61, n_packets=888, n_bytes=8888, priority=200,ip,nw_dst=10.1.0.0/24 actions=resubmit(,SNATMark)",
+			},
+			ingressFlows: []string{},
+			want: map[uint32]*types.RuleMetric{
+				2: {Bytes: 1735, Sessions: 1, Packets: 12},
+			},
+		},
+		{
 			name: "Flows with traceflow flows",
 			egressFlows: []string{
 				"table=61, n_packets=0, n_bytes=0, hard_timeout=300, priority=202,ip,reg0=0x100000/0x100000,reg3=0x4,nw_tos=28 actions=controller(max_len=65535,id=15768)",
 				"table=61, n_packets=0, n_bytes=0, hard_timeout=300, priority=202,ip,reg0=0x100000/0x100000,reg3=0x8,nw_tos=28 actions=controller(max_len=65535,id=15768)",
-				"table=61, n_packets=1, n_bytes=74, priority=200,ct_state=+new,ct_label=0x200000000/0xffffffff00000000,ip actions=goto_table:70",
-				"table=61, n_packets=11, n_bytes=1661, priority=200,ct_state=-new,ct_label=0x200000000/0xffffffff00000000,ip actions=goto_table:70",
-				"table=61, n_packets=0, n_bytes=0, priority=200,ct_state=+new,ct_label=0x600000000/0xffffffff00000000,ip actions=goto_table:70",
-				"table=61, n_packets=0, n_bytes=0, priority=200,ct_state=-new,ct_label=0x600000000/0xffffffff00000000,ip actions=goto_table:70",
-				"table=61, n_packets=4, n_bytes=336, priority=200,reg0=0x100000/0x100000,reg3=0x4 actions=drop",
-				"table=61, n_packets=0, n_bytes=0, priority=200,reg0=0x100000/0x100000,reg3=0x8 actions=drop",
+				testNPMCMetricCookieRound0 + "table=61, n_packets=1, n_bytes=74, priority=200,ct_state=+new,ct_label=0x200000000/0xffffffff00000000,ip actions=goto_table:70",
+				testNPMCMetricCookieRound0 + "table=61, n_packets=11, n_bytes=1661, priority=200,ct_state=-new,ct_label=0x200000000/0xffffffff00000000,ip actions=goto_table:70",
+				testNPMCMetricCookieRound0 + "table=61, n_packets=0, n_bytes=0, priority=200,ct_state=+new,ct_label=0x600000000/0xffffffff00000000,ip actions=goto_table:70",
+				testNPMCMetricCookieRound0 + "table=61, n_packets=0, n_bytes=0, priority=200,ct_state=-new,ct_label=0x600000000/0xffffffff00000000,ip actions=goto_table:70",
+				testNPMCMetricCookieRound0 + "table=61, n_packets=4, n_bytes=336, priority=200,reg0=0x100000/0x100000,reg3=0x4 actions=drop",
+				testNPMCMetricCookieRound0 + "table=61, n_packets=0, n_bytes=0, priority=200,reg0=0x100000/0x100000,reg3=0x8 actions=drop",
 				"table=61, n_packets=1502362, n_bytes=601635949, priority=0 actions=goto_table:70",
 			},
 			ingressFlows: []string{
 				"table=101, n_packets=0, n_bytes=0, hard_timeout=300, priority=202,ip,reg0=0x100000/0x100000,reg3=0x3,nw_tos=28 actions=controller(max_len=65535,id=15768)",
 				"table=101, n_packets=0, n_bytes=0, hard_timeout=300, priority=202,ip,reg0=0x100000/0x100000,reg3=0xb,nw_tos=28 actions=controller(max_len=65535,id=15768)",
-				"table=101, n_packets=1, n_bytes=74, priority=200,ct_state=+new,ct_label=0x1/0xffffffff,ip actions=resubmit(,105)",
-				"table=101, n_packets=11, n_bytes=1661, priority=200,ct_state=-new,ct_label=0x1/0xffffffff,ip actions=resubmit(,105)",
-				"table=101, n_packets=2, n_bytes=148, priority=200,ct_state=+new,ct_label=0x5/0xffffffff,ip actions=resubmit(,105)",
-				"table=101, n_packets=12, n_bytes=943, priority=200,ct_state=-new,ct_label=0x5/0xffffffff,ip actions=resubmit(,105)",
-				"table=101, n_packets=0, n_bytes=0, priority=200,reg0=0x100000/0x100000,reg3=0x3 actions=drop",
-				"table=101, n_packets=4, n_bytes=338, priority=200,reg0=0x100000/0x100000,reg3=0xb actions=drop",
+				testNPMCMetricCookieRound0 + "table=101, n_packets=1, n_bytes=74, priority=200,ct_state=+new,ct_label=0x1/0xffffffff,ip actions=resubmit(,105)",
+				testNPMCMetricCookieRound0 + "table=101, n_packets=11, n_bytes=1661, priority=200,ct_state=-new,ct_label=0x1/0xffffffff,ip actions=resubmit(,105)",
+				testNPMCMetricCookieRound0 + "table=101, n_packets=2, n_bytes=148, priority=200,ct_state=+new,ct_label=0x5/0xffffffff,ip actions=resubmit(,105)",
+				testNPMCMetricCookieRound0 + "table=101, n_packets=12, n_bytes=943, priority=200,ct_state=-new,ct_label=0x5/0xffffffff,ip actions=resubmit(,105)",
+				testNPMCMetricCookieRound0 + "table=101, n_packets=0, n_bytes=0, priority=200,reg0=0x100000/0x100000,reg3=0x3 actions=drop",
+				testNPMCMetricCookieRound0 + "table=101, n_packets=4, n_bytes=338, priority=200,reg0=0x100000/0x100000,reg3=0xb actions=drop",
 				"table=101, n_packets=1407190, n_bytes=509746586, priority=0 actions=resubmit(,105)",
 			},
 			want: map[uint32]*types.RuleMetric{
@@ -1173,6 +1303,54 @@ func TestNetworkPolicyMetrics(t *testing.T) {
 				5:  {Bytes: 1091, Sessions: 2, Packets: 14},
 				3:  {Bytes: 0, Sessions: 0, Packets: 0},
 				11: {Bytes: 338, Sessions: 4, Packets: 4},
+			},
+		},
+		{
+			name:           "DumpTableFlows error on both NP metric tables",
+			roundNum:       0,
+			egressDumpErr:  true,
+			ingressDumpErr: true,
+			want:           map[uint32]*types.RuleMetric{},
+		},
+		{
+			name:          "DumpTableFlows error on egress only",
+			roundNum:      0,
+			egressDumpErr: true,
+			ingressFlows: []string{
+				testNPMCMetricCookieRound0 + "table=101, n_packets=1, n_bytes=74, priority=200,ct_state=+new,ct_label=0x1/0xffffffff,ip actions=resubmit(,105)",
+				testNPMCMetricCookieRound0 + "table=101, n_packets=11, n_bytes=1661, priority=200,ct_state=-new,ct_label=0x1/0xffffffff,ip actions=resubmit(,105)",
+				testNPMCMetricCookieRound0 + "table=101, n_packets=2, n_bytes=148, priority=200,ct_state=+new,ct_label=0x5/0xffffffff,ip actions=resubmit(,105)",
+				testNPMCMetricCookieRound0 + "table=101, n_packets=12, n_bytes=943, priority=200,ct_state=-new,ct_label=0x5/0xffffffff,ip actions=resubmit(,105)",
+				testNPMCMetricCookieRound0 + "table=101, n_packets=0, n_bytes=0, priority=200,ct_state=+new,ct_label=0x600000000/0xffffffff00000000,ip actions=resubmit(,105)",
+				testNPMCMetricCookieRound0 + "table=101, n_packets=0, n_bytes=0, priority=200,ct_state=-new,ct_label=0x600000000/0xffffffff00000000,ip actions=resubmit(,105)",
+				testNPMCMetricCookieRound0 + "table=101, n_packets=0, n_bytes=0, priority=200,reg0=0x100000/0x100000,reg3=0x3 actions=drop",
+				testNPMCMetricCookieRound0 + "table=101, n_packets=4, n_bytes=338, priority=200,reg0=0x100000/0x100000,reg3=0xb actions=drop",
+			},
+			want: map[uint32]*types.RuleMetric{
+				1:  {Bytes: 1735, Sessions: 1, Packets: 12},
+				5:  {Bytes: 1091, Sessions: 2, Packets: 14},
+				6:  {Bytes: 0, Sessions: 0, Packets: 0},
+				3:  {Bytes: 0, Sessions: 0, Packets: 0},
+				11: {Bytes: 338, Sessions: 4, Packets: 4},
+			},
+		},
+		{
+			name:           "DumpTableFlows error on ingress only",
+			roundNum:       0,
+			ingressDumpErr: true,
+			egressFlows: []string{
+				testNPMCMetricCookieRound0 + "table=61, n_packets=1, n_bytes=74, priority=200,ct_state=+new,ct_label=0x200000000/0xffffffff00000000,ip actions=goto_table:70",
+				testNPMCMetricCookieRound0 + "table=61, n_packets=11, n_bytes=1661, priority=200,ct_state=-new,ct_label=0x200000000/0xffffffff00000000,ip actions=goto_table:70",
+				testNPMCMetricCookieRound0 + "table=61, n_packets=0, n_bytes=0, priority=200,ct_state=+new,ct_label=0x600000000/0xffffffff00000000,ip actions=goto_table:70",
+				testNPMCMetricCookieRound0 + "table=61, n_packets=0, n_bytes=0, priority=200,ct_state=-new,ct_label=0x600000000/0xffffffff00000000,ip actions=goto_table:70",
+				testNPMCMetricCookieRound0 + "table=61, n_packets=4, n_bytes=336, priority=200,reg0=0x100000/0x100000,reg3=0x4 actions=drop",
+				testNPMCMetricCookieRound0 + "table=61, n_packets=0, n_bytes=0, priority=200,reg0=0x100000/0x100000,reg3=0x8 actions=drop",
+			},
+			want: map[uint32]*types.RuleMetric{
+				2: {Bytes: 1735, Sessions: 1, Packets: 12},
+				6: {Bytes: 0, Sessions: 0, Packets: 0},
+				4: {Bytes: 336, Sessions: 4, Packets: 4},
+				8: {Bytes: 0, Sessions: 0, Packets: 0},
 			},
 		},
 	}
@@ -1184,9 +1362,21 @@ func TestNetworkPolicyMetrics(t *testing.T) {
 			c = prepareClient(ctrl, false)
 			mockOVSClient := ovsctltest.NewMockOVSCtlClient(ctrl)
 			c.ovsctlClient = mockOVSClient
+			c.roundInfo = types.RoundInfo{RoundNum: tt.roundNum}
+			round := tt.roundNum % (1 << cookie.BitwidthRound)
+			npCookie := cookie.NewAllocator(round).Request(cookie.NetworkPolicy).Raw()
+			flowFilter := fmt.Sprintf("cookie=0x%x/0x%x", npCookie, ^uint64(0))
+			egressFlows, egressErr := tt.egressFlows, error(nil)
+			if tt.egressDumpErr {
+				egressFlows, egressErr = nil, dumpErr
+			}
+			ingressFlows, ingressErr := tt.ingressFlows, error(nil)
+			if tt.ingressDumpErr {
+				ingressFlows, ingressErr = nil, dumpErr
+			}
 			gomock.InOrder(
-				mockOVSClient.EXPECT().DumpTableFlows(EgressMetricTable.ofTable.GetID()).Return(tt.egressFlows, nil),
-				mockOVSClient.EXPECT().DumpTableFlows(IngressMetricTable.ofTable.GetID()).Return(tt.ingressFlows, nil),
+				mockOVSClient.EXPECT().DumpTableFlows(EgressMetricTable.ofTable.GetID(), flowFilter).Return(egressFlows, egressErr),
+				mockOVSClient.EXPECT().DumpTableFlows(IngressMetricTable.ofTable.GetID(), flowFilter).Return(ingressFlows, ingressErr),
 			)
 			got := c.NetworkPolicyMetrics()
 			assert.Equal(t, tt.want, got)

--- a/pkg/agent/secondarynetwork/podwatch/sriov.go
+++ b/pkg/agent/secondarynetwork/podwatch/sriov.go
@@ -65,9 +65,6 @@ func getPodContainerDeviceIDs(podName string, podNamespace string) (map[string][
 	defer conn.Close()
 
 	client := podresourcesv1alpha1.NewPodResourcesListerClient(conn)
-	if client == nil {
-		return nil, fmt.Errorf("error getting the lister client for Pod resources")
-	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), listTimeout)
 	defer cancel()

--- a/pkg/agent/stats/collector.go
+++ b/pkg/agent/stats/collector.go
@@ -32,6 +32,7 @@ import (
 	"antrea.io/antrea/pkg/querier"
 	"antrea.io/antrea/pkg/util/env"
 	"antrea.io/antrea/pkg/util/k8s"
+	utilwait "antrea.io/antrea/pkg/util/wait"
 )
 
 const (
@@ -66,23 +67,35 @@ type Collector struct {
 	// It is used to calculate the delta of the statistics that will be reported.
 	lastStatsCollection *statsCollection
 	multicastEnabled    bool
+	// staleFlowsDeletedWait, when non-nil, must unblock before the first collect so metric dumps
+	// do not include flows from a prior agent round. The initializer's stale-flow goroutine calls
+	// Done on this group when deletion finishes or exits.
+	staleFlowsDeletedWait *utilwait.Group
 }
 
-func NewCollector(antreaClientProvider client.AntreaClientProvider, ofClient openflow.Client, npQuerier querier.AgentNetworkPolicyInfoQuerier, mcQuerier *multicast.Controller) *Collector {
+func NewCollector(antreaClientProvider client.AntreaClientProvider, ofClient openflow.Client, npQuerier querier.AgentNetworkPolicyInfoQuerier, mcQuerier *multicast.Controller, staleFlowsDeletedWait *utilwait.Group) *Collector {
 	nodeName, _ := env.GetNodeName()
 	manager := &Collector{
-		nodeName:             nodeName,
-		antreaClientProvider: antreaClientProvider,
-		ofClient:             ofClient,
-		networkPolicyQuerier: npQuerier,
-		multicastQuerier:     mcQuerier,
-		multicastEnabled:     mcQuerier != nil,
+		nodeName:              nodeName,
+		antreaClientProvider:  antreaClientProvider,
+		ofClient:              ofClient,
+		networkPolicyQuerier:  npQuerier,
+		multicastQuerier:      mcQuerier,
+		multicastEnabled:      mcQuerier != nil,
+		staleFlowsDeletedWait: staleFlowsDeletedWait,
 	}
 	return manager
 }
 
 // Run runs a loop that collects statistics and reports them until the provided channel is closed.
 func (m *Collector) Run(stopCh <-chan struct{}) {
+	if m.staleFlowsDeletedWait != nil {
+		klog.InfoS("Waiting for stale flows from previous agent round to be deleted")
+		if err := m.staleFlowsDeletedWait.WaitUntil(stopCh); err != nil {
+			klog.ErrorS(err, "Error while waiting for stale flow deletion; stats collector will not start")
+			return
+		}
+	}
 	klog.Info("Start collecting metrics")
 	ticker := time.NewTicker(collectPeriod)
 	defer ticker.Stop()

--- a/pkg/ovs/ovsctl/interface.go
+++ b/pkg/ovs/ovsctl/interface.go
@@ -36,8 +36,11 @@ type OVSCtlClient interface {
 	DumpFlowsWithoutTableNames(args ...string) ([]string, error)
 	// DumpMatchedFlows returns the flow which exactly matches the matchStr.
 	DumpMatchedFlow(matchStr string) (string, error)
-	// DumpTableFlows returns all flows in the table.
-	DumpTableFlows(table uint8) ([]string, error)
+	// DumpTableFlows returns flows in the table. Optional filters are extra ovs-ofctl dump-flows
+	// FLOW fields (see ovs-fields(7)); each non-empty element is appended after "table=<id>," (for
+	// example "cookie=0x1/0xffffffffffffffff" as one or more comma-separated fields). Note:
+	// "priority=N" is not a valid keyword in ovs-ofctl dump-flows match syntax and must not be used.
+	DumpTableFlows(table uint8, filters ...string) ([]string, error)
 	// DumpGroup returns the OpenFlow group if it exists on the bridge.
 	DumpGroup(groupID uint32) (string, error)
 	// DumpGroups returns OpenFlow groups of the bridge.

--- a/pkg/ovs/ovsctl/ovsctl.go
+++ b/pkg/ovs/ovsctl/ovsctl.go
@@ -292,7 +292,7 @@ func (c *ovsCtlClient) parseFlowEntries(flowDump []byte) ([]string, error) {
 	scanner.Split(bufio.ScanLines)
 	flowList := []string{}
 	for scanner.Scan() {
-		flow := trimFlowStr(scanner.Text())
+		flow := strings.TrimSpace(scanner.Text())
 		// Skip the non-flow line, which is printed when using parameter "--no-names" in tests.
 		if strings.Contains(flow, "NXST_FLOW reply") || strings.Contains(flow, "OFPST_FLOW reply") {
 			continue
@@ -310,7 +310,7 @@ func (c *ovsCtlClient) DumpMatchedFlow(matchStr string) (string, error) {
 	scanner := bufio.NewScanner(strings.NewReader(string(flowDump)))
 	scanner.Split(bufio.ScanLines)
 	for scanner.Scan() {
-		flowStr := trimFlowStr(scanner.Text())
+		flowStr := strings.TrimSpace(scanner.Text())
 		// ovs-ofctl dump-flows can return multiple flows that match matchStr, here we
 		// check and return only the one that exactly matches matchStr (no extra match
 		// conditions).
@@ -323,8 +323,16 @@ func (c *ovsCtlClient) DumpMatchedFlow(matchStr string) (string, error) {
 	return "", nil
 }
 
-func (c *ovsCtlClient) DumpTableFlows(table uint8) ([]string, error) {
-	return c.DumpFlows(fmt.Sprintf("table=%d", table))
+func (c *ovsCtlClient) DumpTableFlows(table uint8, filters ...string) ([]string, error) {
+	match := fmt.Sprintf("table=%d", table)
+	for _, f := range filters {
+		f = strings.TrimSpace(f)
+		if f == "" {
+			continue
+		}
+		match += "," + strings.TrimPrefix(f, ",")
+	}
+	return c.DumpFlows(match)
 }
 
 func (c *ovsCtlClient) DumpGroup(groupID uint32) (string, error) {
@@ -410,11 +418,6 @@ func (c *ovsCtlClient) SetPortNoFlood(ofport int) error {
 
 func (c *ovsCtlClient) RunOfctlCmd(cmd string, args ...string) ([]byte, error) {
 	return c.ovsOfctlRunner.RunOfctlCmd(cmd, args...)
-}
-
-// trimFlowStr removes undesirable fields from the flow string.
-func trimFlowStr(flowStr string) string {
-	return flowStr[strings.Index(flowStr, " table")+1:]
 }
 
 func flowExactMatch(matchStr, flowStr string) bool {

--- a/pkg/ovs/ovsctl/ovsctl_test.go
+++ b/pkg/ovs/ovsctl/ovsctl_test.go
@@ -299,14 +299,7 @@ func TestOfCtl(t *testing.T) {
 		mockOVSOfctlRunner.EXPECT().RunOfctlCmd("dump-flows", "--names").Return(DumpFlows())
 		got, err := client.DumpFlows()
 		require.NoError(err)
-		expectedFlows := []string{
-			"table=0, priority=200, n_packets=143, n_bytes=6006, idle_age=15512, hard_age=65534,arp actions=resubmit(,1)",
-			"table=1, priority=200, n_packets=12, n_bytes=504, idle_age=17282, hard_age=65534,arp,in_port=32769,arp_spa=192.168.1.1,arp_sha=16:92:82:a4:69:50 actions=resubmit(,2)",
-			"table=2, priority=0, n_packets=0, n_bytes=0, idle_age=65534, hard_age=65534, actions=drop",
-			"table=3, priority=200, n_packets=29233419, n_bytes=2703471860, idle_age=8, hard_age=65534,in_port=32769 actions=load:0x2->NXM_NX_REG0[0..3],resubmit(,4)",
-			"table=3, priority=200, n_packets=0, n_bytes=0, idle_age=65534, hard_age=65534,in_port=32768 actions=load:0x1->reg0",
-		}
-		assert.Equal(expectedFlows, got)
+		assert.Equal(testDumpFlows, got)
 	})
 	t.Run("Dump Flows Without Table Names", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
@@ -321,12 +314,7 @@ func TestOfCtl(t *testing.T) {
 		mockOVSOfctlRunner.EXPECT().RunOfctlCmd("dump-flows", "--no-names").Return(DumpFlowsWithoutTableNames())
 		got, err := client.DumpFlowsWithoutTableNames()
 		require.NoError(err)
-		expectedFlows := []string{
-			"table=0, priority=200, n_packets=143, n_bytes=6006, idle_age=15512, hard_age=65534,arp actions=resubmit(,1)",
-			"table=1, priority=200, n_packets=12, n_bytes=504, idle_age=17282, hard_age=65534,arp,in_port=32769,arp_spa=192.168.1.1,arp_sha=16:92:82:a4:69:50 actions=resubmit(,2)",
-			"table=3, priority=200, n_packets=29233419, n_bytes=2703471860, idle_age=8, hard_age=65534,in_port=32769 actions=load:0x2->NXM_NX_REG0[0..3],resubmit(,4)",
-		}
-		assert.Equal(expectedFlows, got)
+		assert.Equal(testDumpFlowsWithoutTableNames, got)
 	})
 	t.Run("Dump Matched Flow", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
@@ -342,8 +330,7 @@ func TestOfCtl(t *testing.T) {
 		mockOVSOfctlRunner.EXPECT().RunOfctlCmd("dump-flows", matchFlow, "--names").Return(DumpMatchedFlow())
 		out, err := client.DumpMatchedFlow(matchFlow)
 		require.NoError(err)
-		expectedFlow := "table=2, priority=0, n_packets=0, n_bytes=0, idle_age=65534, hard_age=65534, actions=drop"
-		assert.Equal(expectedFlow, out)
+		assert.Equal(testDumpFlows[2], out)
 
 	})
 	t.Run("Dump Table Flows", func(t *testing.T) {
@@ -365,14 +352,37 @@ func TestOfCtl(t *testing.T) {
 			}
 			return x, nil
 		}
-		mockOVSOfctlRunner.EXPECT().RunOfctlCmd("dump-flows", []string{"table=3", "--names"}).Return(DumpTableFlows())
+		mockOVSOfctlRunner.EXPECT().RunOfctlCmd("dump-flows", "table=3", "--names").Return(DumpTableFlows())
 		out, err := client.DumpTableFlows(uint8(3))
 		require.NoError(err)
-		expectedFlows := []string{
-			"table=3, priority=200, n_packets=29233419, n_bytes=2703471860, idle_age=8, hard_age=65534,in_port=32769 actions=load:0x2->NXM_NX_REG0[0..3],resubmit(,4)",
-			"table=3, priority=200, n_packets=0, n_bytes=0, idle_age=65534, hard_age=65534,in_port=32768 actions=load:0x1->reg0",
+		assert.Equal([]string{testDumpFlows[3], testDumpFlows[4]}, out)
+	})
+	t.Run("Dump Table Flows With Filters", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockOVSOfctlRunner := NewMockOVSOfctlRunner(ctrl)
+		client := &ovsCtlClient{
+			bridge:         "br-int",
+			ovsOfctlRunner: mockOVSOfctlRunner,
 		}
-		assert.Equal(expectedFlows, out)
+		DumpTableFlowsFiltered := func() ([]byte, error) {
+			var x = []byte{}
+			table := "table=3"
+			cookie := "cookie=0xa010000000000"
+			for i := 0; i < len(testDumpFlows); i++ {
+				if !strings.Contains(testDumpFlows[i], table) || !strings.Contains(testDumpFlows[i], cookie) {
+					continue
+				}
+				x = append(x, []byte(testDumpFlows[i])...)
+				x = append(x, "\n"...)
+			}
+			return x, nil
+		}
+		match := fmt.Sprintf("table=3,cookie=0xa010000000000/0x%x", ^uint64(0))
+		mockOVSOfctlRunner.EXPECT().RunOfctlCmd("dump-flows", match, "--names").Return(DumpTableFlowsFiltered())
+		filter := fmt.Sprintf("cookie=0xa010000000000/0x%x", ^uint64(0))
+		out, err := client.DumpTableFlows(3, filter)
+		require.NoError(err)
+		assert.Equal([]string{testDumpFlows[3], testDumpFlows[4]}, out)
 	})
 	t.Run("Dump Groups", func(t *testing.T) {
 		ctrl := gomock.NewController(t)

--- a/pkg/ovs/ovsctl/testing/mock_ovsctl.go
+++ b/pkg/ovs/ovsctl/testing/mock_ovsctl.go
@@ -168,18 +168,23 @@ func (mr *MockOVSCtlClientMockRecorder) DumpPortsDesc() *gomock.Call {
 }
 
 // DumpTableFlows mocks base method.
-func (m *MockOVSCtlClient) DumpTableFlows(table uint8) ([]string, error) {
+func (m *MockOVSCtlClient) DumpTableFlows(table uint8, filters ...string) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DumpTableFlows", table)
+	varargs := []any{table}
+	for _, a := range filters {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DumpTableFlows", varargs...)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // DumpTableFlows indicates an expected call of DumpTableFlows.
-func (mr *MockOVSCtlClientMockRecorder) DumpTableFlows(table any) *gomock.Call {
+func (mr *MockOVSCtlClientMockRecorder) DumpTableFlows(table any, filters ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DumpTableFlows", reflect.TypeOf((*MockOVSCtlClient)(nil).DumpTableFlows), table)
+	varargs := append([]any{table}, filters...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DumpTableFlows", reflect.TypeOf((*MockOVSCtlClient)(nil).DumpTableFlows), varargs...)
 }
 
 // GetDPFeatures mocks base method.

--- a/test/integration/ovs/openflow_test_utils.go
+++ b/test/integration/ovs/openflow_test_utils.go
@@ -150,6 +150,17 @@ func OfctlFlowMatch(flowList []string, tableName string, flow *ExpectFlow) bool 
 	return false
 }
 
+// trimOVSFlowLine matches historical pkg/ovs/ovsctl.trimFlowStr: find " table" and
+// return the substring from the "t" of "table=..." onward so each dump line is shaped
+// like the output ovsctl used to return. pkg/ovs/ovsctl no longer applies this trim, so
+// the integration test helpers do it before formatFlowDump.
+func trimOVSFlowLine(line string) string {
+	if idx := strings.Index(line, " table"); idx >= 0 {
+		return line[idx+1:]
+	}
+	return line
+}
+
 func formatFlowDump(rawFlows []string) []string {
 	flowList := []string{}
 	for _, flow := range rawFlows {
@@ -168,6 +179,9 @@ func OfctlDumpFlows(ovsCtlClient ovsctl.OVSCtlClient, args ...string) ([]string,
 	if err != nil {
 		return nil, err
 	}
+	for i := range rawFlows {
+		rawFlows[i] = trimOVSFlowLine(rawFlows[i])
+	}
 	return formatFlowDump(rawFlows), nil
 }
 
@@ -176,6 +190,9 @@ func OfctlDumpTableFlows(ovsCtlClient ovsctl.OVSCtlClient, table string) ([]stri
 	if err != nil {
 		return nil, err
 	}
+	for i := range rawFlows {
+		rawFlows[i] = trimOVSFlowLine(rawFlows[i])
+	}
 	return formatFlowDump(rawFlows), nil
 }
 
@@ -183,6 +200,9 @@ func OfctlDumpTableFlowsWithoutName(ovsCtlClient ovsctl.OVSCtlClient, table uint
 	rawFlows, err := ovsCtlClient.DumpFlowsWithoutTableNames(fmt.Sprintf("table=%d", table))
 	if err != nil {
 		return nil, err
+	}
+	for i := range rawFlows {
+		rawFlows[i] = trimOVSFlowLine(rawFlows[i])
 	}
 	return formatFlowDump(rawFlows), nil
 }


### PR DESCRIPTION
Cherry pick of #7952 on release-2.6.

#7952: Fix NP stats panic from stale OpenFlow flows (#7952)

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.