### PR TITLE
Automated cherry pick of #8047: Add IPv6 e2e tests to GitHub Actions (#8047)

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -479,6 +479,146 @@ jobs:
         path: log.tar.gz
         retention-days: 30
 
+  test-e2e-wireguard:
+    name: E2e tests on a Kind cluster on Linux with WireGuard encryption
+    needs: [build-antrea-coverage-image]
+    runs-on: [ubuntu-latest]
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        show-progress: false
+    - uses: ./.github/actions/setup-kind-test
+    - name: Run e2e tests
+      run: |
+        mkdir log
+        mkdir test-e2e-wireguard-coverage
+        ANTREA_LOG_DIR=$PWD/log ANTREA_COV_DIR=$PWD/test-e2e-wireguard-coverage ./ci/kind/test-e2e-kind.sh \
+        --encap-mode encap --coverage \
+        --traffic-encryption-mode wireguard \
+        --skip mode-irrelevant \
+        --setup-only
+    - name: Run antctl check installation
+      run: |
+        make antctl
+        ./bin/antctl check installation --run wireguard
+    - name: Cleanup Kind cluster
+      if: ${{ always() }}
+      run: ./ci/kind/test-e2e-kind.sh --cleanup-only
+    - name: Tar coverage files
+      run: tar -czf test-e2e-wireguard-coverage.tar.gz test-e2e-wireguard-coverage
+    - name: Upload coverage for test-e2e-wireguard-coverage
+      uses: actions/upload-artifact@v7
+      with:
+        name: test-e2e-wireguard-coverage
+        path: test-e2e-wireguard-coverage.tar.gz
+        retention-days: 30
+    - name: Codecov
+      uses: codecov/codecov-action@v6
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: '**/*.cov.out'
+        disable_search: true
+        flags: kind-e2e-tests
+        name: codecov-test-e2e-wireguard
+        directory: test-e2e-wireguard-coverage
+        fail_ci_if_error: ${{ github.event_name == 'push' }}
+    - name: Tar log files
+      if: ${{ failure() }}
+      run: tar -czf log.tar.gz log
+    - name: Upload test log
+      uses: actions/upload-artifact@v7
+      if: ${{ failure() }}
+      with:
+        name: e2e-kind-wireguard.tar.gz
+        path: log.tar.gz
+        retention-days: 30
+
+  test-e2e-ipv6-only:
+    name: E2e tests on a Kind cluster on Linux (IPv6 only)
+    needs: [build-antrea-coverage-image]
+    runs-on: [ubuntu-latest]
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        show-progress: false
+    - uses: ./.github/actions/setup-kind-test
+    - name: Run e2e tests
+      run: |
+        mkdir log
+        mkdir test-e2e-ipv6-only-coverage
+        ANTREA_LOG_DIR=$PWD/log ANTREA_COV_DIR=$PWD/test-e2e-ipv6-only-coverage ./ci/kind/test-e2e-kind.sh --encap-mode encap --ip-family v6 --coverage
+    - name: Tar coverage files
+      run: tar -czf test-e2e-ipv6-only-coverage.tar.gz test-e2e-ipv6-only-coverage
+    - name: Upload coverage for test-e2e-ipv6-only-coverage
+      uses: actions/upload-artifact@v7
+      with:
+        name: test-e2e-ipv6-only-coverage
+        path: test-e2e-ipv6-only-coverage.tar.gz
+        retention-days: 30
+    - name: Codecov
+      uses: codecov/codecov-action@v6
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: '**/*.cov.out'
+        disable_search: true
+        flags: kind-e2e-tests
+        name: codecov-test-e2e-ipv6-only
+        directory: test-e2e-ipv6-only-coverage
+        fail_ci_if_error: ${{ github.event_name == 'push' }}
+    - name: Tar log files
+      if: ${{ failure() }}
+      run: tar -czf log.tar.gz log
+    - name: Upload test log
+      uses: actions/upload-artifact@v7
+      if: ${{ failure() }}
+      with:
+        name: e2e-kind-ipv6-only.tar.gz
+        path: log.tar.gz
+        retention-days: 30
+
+  test-e2e-ipv6-ds:
+    name: E2e tests on a Kind cluster on Linux (Dual-stack)
+    needs: [build-antrea-coverage-image]
+    runs-on: [ubuntu-latest]
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        show-progress: false
+    - uses: ./.github/actions/setup-kind-test
+    - name: Run e2e tests
+      run: |
+        mkdir log
+        mkdir test-e2e-ipv6-ds-coverage
+        ANTREA_LOG_DIR=$PWD/log ANTREA_COV_DIR=$PWD/test-e2e-ipv6-ds-coverage ./ci/kind/test-e2e-kind.sh --encap-mode encap --ip-family dual --coverage
+    - name: Tar coverage files
+      run: tar -czf test-e2e-ipv6-ds-coverage.tar.gz test-e2e-ipv6-ds-coverage
+    - name: Upload coverage for test-e2e-ipv6-ds-coverage
+      uses: actions/upload-artifact@v7
+      with:
+        name: test-e2e-ipv6-ds-coverage
+        path: test-e2e-ipv6-ds-coverage.tar.gz
+        retention-days: 30
+    - name: Codecov
+      uses: codecov/codecov-action@v6
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: '**/*.cov.out'
+        disable_search: true
+        flags: kind-e2e-tests
+        name: codecov-test-e2e-ipv6-ds
+        directory: test-e2e-ipv6-ds-coverage
+        fail_ci_if_error: ${{ github.event_name == 'push' }}
+    - name: Tar log files
+      if: ${{ failure() }}
+      run: tar -czf log.tar.gz log
+    - name: Upload test log
+      uses: actions/upload-artifact@v7
+      if: ${{ failure() }}
+      with:
+        name: e2e-kind-ipv6-ds.tar.gz
+        path: log.tar.gz
+        retention-days: 30
+
   test-e2e-hybrid-non-default:
     name: E2e tests on a Kind cluster on Linux (hybrid) with non default values (proxyAll=true, kube-proxy-mode=nftables)
     needs: [ build-antrea-coverage-image ]
@@ -1016,6 +1156,9 @@ jobs:
     - test-e2e-noencap
     - test-e2e-hybrid
     - test-e2e-hybrid-non-default
+    - test-e2e-wireguard
+    - test-e2e-ipv6-only
+    - test-e2e-ipv6-ds
     - test-upgrade-from-N-1
     - test-upgrade-from-N-2
     - test-compatible-N-1


### PR DESCRIPTION
Cherry pick of #8047 on release-2.5.

#8047: Add IPv6 e2e tests to GitHub Actions (#8047)

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.