### PR TITLE
Automated cherry pick of #8064: Add K8s conformance e2e test into Kind workflow (#8064)

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -572,6 +572,40 @@ jobs:
         path: log.tar.gz
         retention-days: 30
 
+  test-e2e-conformance:
+    name: K8s e2e conformance tests
+    needs: build-antrea-coverage-image
+    runs-on: [ubuntu-latest]
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        show-progress: false
+    - uses: ./.github/actions/setup-kind-test
+      with:
+        setup-go: 'false'
+        tag-coverage-images: 'true'
+    - name: Create K8s cluster
+      run: |
+        ./ci/kind/kind-setup.sh create kind
+    - name: Install Antrea
+      run: |
+        helm_args=()
+        helm_repo="./build/charts/antrea"
+        helm_args+=(--set controllerImage.repository="antrea/antrea-controller-ubuntu")
+        helm_args+=(--set agentImage.repository="antrea/antrea-agent-ubuntu")
+        helm install --namespace kube-system antrea ${helm_repo} "${helm_args[@]}"
+        kubectl rollout status -n kube-system ds/antrea-agent --timeout=5m
+    - name: Run e2e conformance tests
+      run: |
+        ./ci/run-k8s-e2e-tests.sh --e2e-conformance
+    - name: Upload test log
+      uses: actions/upload-artifact@v7
+      if: ${{ failure() }}
+      with:
+        name: sonobuoy-conformance.tar.gz
+        path: "*_sonobuoy_*.tar.gz"
+        retention-days: 7
+
   test-upgrade-from-N-1:
     name: Upgrade from Antrea version N-1
     needs: build-antrea-coverage-image
@@ -735,6 +769,7 @@ jobs:
     - test-e2e-hybrid
     - test-e2e-hybrid-non-default
     - test-e2e-wireguard
+    - test-e2e-ipam-feature-enabled
     - test-upgrade-from-N-1
     - test-upgrade-from-N-2
     - test-compatible-N-1
@@ -742,6 +777,8 @@ jobs:
     - validate-prometheus-metrics-doc
     - test-e2e-flow-visibility
     - test-network-policy-conformance-encap
+    - test-secondary-network
+    - test-e2e-conformance
     - run-installation-checks
     runs-on: [ubuntu-latest]
     steps:


### PR DESCRIPTION
Cherry pick of #8064 on release-2.6.

#8064: Add K8s conformance e2e test into Kind workflow (#8064)

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.