### PR TITLE
Automated cherry pick of #8047: Add IPv6 e2e tests to GitHub Actions (#8047)
#8064: Add K8s conformance e2e test into Kind workflow (#8064)

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -411,6 +411,92 @@ jobs:
         path: log.tar.gz
         retention-days: 30
 
+  test-e2e-ipv6-only:
+    name: E2e tests on a Kind cluster on Linux (IPv6 only)
+    needs: [build-antrea-coverage-image]
+    runs-on: [ubuntu-latest]
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        show-progress: false
+    - uses: ./.github/actions/setup-kind-test
+    - name: Run e2e tests
+      run: |
+        mkdir log
+        mkdir test-e2e-ipv6-only-coverage
+        ANTREA_LOG_DIR=$PWD/log ANTREA_COV_DIR=$PWD/test-e2e-ipv6-only-coverage ./ci/kind/test-e2e-kind.sh --encap-mode encap --ip-family v6 --coverage
+    - name: Tar coverage files
+      run: tar -czf test-e2e-ipv6-only-coverage.tar.gz test-e2e-ipv6-only-coverage
+    - name: Upload coverage for test-e2e-ipv6-only-coverage
+      uses: actions/upload-artifact@v7
+      with:
+        name: test-e2e-ipv6-only-coverage
+        path: test-e2e-ipv6-only-coverage.tar.gz
+        retention-days: 30
+    - name: Codecov
+      uses: codecov/codecov-action@v6
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: '**/*.cov.out'
+        disable_search: true
+        flags: kind-e2e-tests
+        name: codecov-test-e2e-ipv6-only
+        directory: test-e2e-ipv6-only-coverage
+        fail_ci_if_error: ${{ github.event_name == 'push' }}
+    - name: Tar log files
+      if: ${{ failure() }}
+      run: tar -czf log.tar.gz log
+    - name: Upload test log
+      uses: actions/upload-artifact@v7
+      if: ${{ failure() }}
+      with:
+        name: e2e-kind-ipv6-only.tar.gz
+        path: log.tar.gz
+        retention-days: 30
+
+  test-e2e-ipv6-ds:
+    name: E2e tests on a Kind cluster on Linux (Dual-stack)
+    needs: [build-antrea-coverage-image]
+    runs-on: [ubuntu-latest]
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        show-progress: false
+    - uses: ./.github/actions/setup-kind-test
+    - name: Run e2e tests
+      run: |
+        mkdir log
+        mkdir test-e2e-ipv6-ds-coverage
+        ANTREA_LOG_DIR=$PWD/log ANTREA_COV_DIR=$PWD/test-e2e-ipv6-ds-coverage ./ci/kind/test-e2e-kind.sh --encap-mode encap --ip-family dual --coverage
+    - name: Tar coverage files
+      run: tar -czf test-e2e-ipv6-ds-coverage.tar.gz test-e2e-ipv6-ds-coverage
+    - name: Upload coverage for test-e2e-ipv6-ds-coverage
+      uses: actions/upload-artifact@v7
+      with:
+        name: test-e2e-ipv6-ds-coverage
+        path: test-e2e-ipv6-ds-coverage.tar.gz
+        retention-days: 30
+    - name: Codecov
+      uses: codecov/codecov-action@v6
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: '**/*.cov.out'
+        disable_search: true
+        flags: kind-e2e-tests
+        name: codecov-test-e2e-ipv6-ds
+        directory: test-e2e-ipv6-ds-coverage
+        fail_ci_if_error: ${{ github.event_name == 'push' }}
+    - name: Tar log files
+      if: ${{ failure() }}
+      run: tar -czf log.tar.gz log
+    - name: Upload test log
+      uses: actions/upload-artifact@v7
+      if: ${{ failure() }}
+      with:
+        name: e2e-kind-ipv6-ds.tar.gz
+        path: log.tar.gz
+        retention-days: 30
+
   test-e2e-hybrid-non-default:
     name: E2e tests on a Kind cluster on Linux (hybrid) with non default values (proxyAll=true, kube-proxy-mode=nftables)
     needs: [ build-antrea-coverage-image ]
@@ -735,6 +821,8 @@ jobs:
     - test-e2e-hybrid
     - test-e2e-hybrid-non-default
     - test-e2e-wireguard
+    - test-e2e-ipv6-only
+    - test-e2e-ipv6-ds
     - test-upgrade-from-N-1
     - test-upgrade-from-N-2
     - test-compatible-N-1

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -658,6 +658,40 @@ jobs:
         path: log.tar.gz
         retention-days: 30
 
+  test-e2e-conformance:
+    name: K8s e2e conformance tests
+    needs: build-antrea-coverage-image
+    runs-on: [ubuntu-latest]
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        show-progress: false
+    - uses: ./.github/actions/setup-kind-test
+      with:
+        setup-go: 'false'
+        tag-coverage-images: 'true'
+    - name: Create K8s cluster
+      run: |
+        ./ci/kind/kind-setup.sh create kind
+    - name: Install Antrea
+      run: |
+        helm_args=()
+        helm_repo="./build/charts/antrea"
+        helm_args+=(--set controllerImage.repository="antrea/antrea-controller-ubuntu")
+        helm_args+=(--set agentImage.repository="antrea/antrea-agent-ubuntu")
+        helm install --namespace kube-system antrea ${helm_repo} "${helm_args[@]}"
+        kubectl rollout status -n kube-system ds/antrea-agent --timeout=5m
+    - name: Run e2e conformance tests
+      run: |
+        ./ci/run-k8s-e2e-tests.sh --e2e-conformance
+    - name: Upload test log
+      uses: actions/upload-artifact@v7
+      if: ${{ failure() }}
+      with:
+        name: sonobuoy-conformance.tar.gz
+        path: "*_sonobuoy_*.tar.gz"
+        retention-days: 7
+
   test-upgrade-from-N-1:
     name: Upgrade from Antrea version N-1
     needs: build-antrea-coverage-image
@@ -823,6 +857,7 @@ jobs:
     - test-e2e-wireguard
     - test-e2e-ipv6-only
     - test-e2e-ipv6-ds
+    - test-e2e-ipam-feature-enabled
     - test-upgrade-from-N-1
     - test-upgrade-from-N-2
     - test-compatible-N-1
@@ -830,6 +865,8 @@ jobs:
     - validate-prometheus-metrics-doc
     - test-e2e-flow-visibility
     - test-network-policy-conformance-encap
+    - test-secondary-network
+    - test-e2e-conformance
     - run-installation-checks
     runs-on: [ubuntu-latest]
     steps:


### PR DESCRIPTION
Cherry pick of #8047 #8064 on release-2.6.

#8047: Add IPv6 e2e tests to GitHub Actions (#8047)
#8064: Add K8s conformance e2e test into Kind workflow (#8064)

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.