### PR TITLE
Automated cherry pick of #7831: Extract composite actions for Kind test setup (#7831)
#8047: Add IPv6 e2e tests to GitHub Actions (#8047)
#8064: Add K8s conformance e2e test into Kind workflow (#8064)

### DIFF
--- a/.github/actions/setup-kind-test/action.yml
+++ b/.github/actions/setup-kind-test/action.yml
@@ -1,0 +1,62 @@
+name: Set up Kind test environment
+description: >
+  Common setup steps for Kind-based test jobs: free disk space, Go
+  toolchain, Docker classic image store, download and load Antrea image
+  artifacts, and install Kind.
+  The repository must already be checked out before using this action.
+
+inputs:
+  free-disk-space:
+    description: Free disk space before running the test.
+    default: 'true'
+  setup-go:
+    description: Install the Go toolchain.
+    default: 'true'
+  load-flow-aggregator:
+    description: Download and load the Flow Aggregator coverage image.
+    default: 'false'
+  tag-coverage-images:
+    description: >
+      Tag Antrea coverage images to non-coverage image names, so that
+      standard (non-coverage) manifests can be used.
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - name: Free disk space
+      if: ${{ inputs.free-disk-space == 'true' }}
+      shell: bash
+      # https://github.com/actions/virtual-environments/issues/709
+      run: |
+        sudo apt-get clean
+        df -h
+    - uses: actions/setup-go@v6
+      if: ${{ inputs.setup-go == 'true' }}
+      with:
+        go-version-file: '.go-version'
+    # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
+    - uses: ./.github/actions/setup-docker-classic
+    - name: Download Antrea image from previous job
+      uses: actions/download-artifact@v7
+      with:
+        name: antrea-ubuntu-cov
+    - name: Load Antrea image
+      shell: bash
+      run: docker load -i antrea-ubuntu.tar
+    - name: Tag coverage images
+      if: ${{ inputs.tag-coverage-images == 'true' }}
+      shell: bash
+      run: |
+        docker tag antrea/antrea-agent-ubuntu-coverage:latest antrea/antrea-agent-ubuntu:latest
+        docker tag antrea/antrea-controller-ubuntu-coverage:latest antrea/antrea-controller-ubuntu:latest
+    - name: Download Flow Aggregator image from previous job
+      if: ${{ inputs.load-flow-aggregator == 'true' }}
+      uses: actions/download-artifact@v7
+      with:
+        name: flow-aggregator-cov
+    - name: Load Flow Aggregator image
+      if: ${{ inputs.load-flow-aggregator == 'true' }}
+      shell: bash
+      run: docker load -i flow-aggregator.tar
+    - uses: ./.github/actions/setup-kind

--- a/.github/actions/setup-kind/action.yml
+++ b/.github/actions/setup-kind/action.yml
@@ -1,0 +1,18 @@
+name: Install Kind
+description: >
+  Install the Kind binary. The version is read from ci/kind/version.
+
+runs:
+  using: composite
+  steps:
+    - name: Get Kind version
+      id: get_kind_version
+      shell: bash
+      run: |
+        KIND_VERSION=$(head -n1 ./ci/kind/version)
+        echo "kind_version=${KIND_VERSION}" >> $GITHUB_OUTPUT
+    - name: Install Kind
+      uses: helm/kind-action@v1
+      with:
+        version: ${{ steps.get_kind_version.outputs.kind_version }}
+        install_only: true

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -85,16 +85,7 @@ jobs:
         if: ${{ steps.check-release.outputs.released == 'false' }}
         run: |
           ./hack/build-antrea-linux-all.sh --pull --distro ${{ inputs.antrea-image-distro }} --platform ${{ inputs.antrea-image-platform }}
-      - name: Get Kind version
-        id: get_kind_version
-        run: |
-          KIND_VERSION=$(head -n1 ./ci/kind/version || echo v0.28.0)
-          echo "kind_version=${KIND_VERSION}" >> $GITHUB_OUTPUT
-      - name: Install Kind
-        uses: helm/kind-action@v1
-        with:
-          version: ${{ steps.get_kind_version.outputs.kind_version }}
-          install_only: true
+      - uses: ./.github/actions/setup-kind
       - name: Build local image for conformance test
         if: ${{ inputs.k8s-version != '' }}
         run: |

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -601,6 +601,40 @@ jobs:
         path: log.tar.gz
         retention-days: 30
 
+  test-e2e-conformance:
+    name: K8s e2e conformance tests
+    needs: build-antrea-coverage-image
+    runs-on: [ubuntu-latest]
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        show-progress: false
+    - uses: ./.github/actions/setup-kind-test
+      with:
+        setup-go: 'false'
+        tag-coverage-images: 'true'
+    - name: Create K8s cluster
+      run: |
+        ./ci/kind/kind-setup.sh create kind
+    - name: Install Antrea
+      run: |
+        helm_args=()
+        helm_repo="./build/charts/antrea"
+        helm_args+=(--set controllerImage.repository="antrea/antrea-controller-ubuntu")
+        helm_args+=(--set agentImage.repository="antrea/antrea-agent-ubuntu")
+        helm install --namespace kube-system antrea ${helm_repo} "${helm_args[@]}"
+        kubectl rollout status -n kube-system ds/antrea-agent --timeout=5m
+    - name: Run e2e conformance tests
+      run: |
+        ./ci/run-k8s-e2e-tests.sh --e2e-conformance
+    - name: Upload test log
+      uses: actions/upload-artifact@v7
+      if: ${{ failure() }}
+      with:
+        name: sonobuoy-conformance.tar.gz
+        path: "*_sonobuoy_*.tar.gz"
+        retention-days: 7
+
   test-upgrade-from-N-1:
     name: Upgrade from Antrea version N-1
     needs: build-antrea-coverage-image
@@ -765,6 +799,7 @@ jobs:
     - test-e2e-hybrid-non-default
     - test-e2e-ipv6-only
     - test-e2e-ipv6-ds
+    - test-e2e-ipam-feature-enabled
     - test-upgrade-from-N-1
     - test-upgrade-from-N-2
     - test-compatible-N-1
@@ -772,6 +807,8 @@ jobs:
     - validate-prometheus-metrics-doc
     - test-e2e-flow-visibility
     - test-network-policy-conformance-encap
+    - test-secondary-network
+    - test-e2e-conformance
     - run-installation-checks
     runs-on: [ubuntu-latest]
     steps:

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -354,6 +354,92 @@ jobs:
         path: log.tar.gz
         retention-days: 30
 
+  test-e2e-ipv6-only:
+    name: E2e tests on a Kind cluster on Linux (IPv6 only)
+    needs: [build-antrea-coverage-image]
+    runs-on: [ubuntu-latest]
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        show-progress: false
+    - uses: ./.github/actions/setup-kind-test
+    - name: Run e2e tests
+      run: |
+        mkdir log
+        mkdir test-e2e-ipv6-only-coverage
+        ANTREA_LOG_DIR=$PWD/log ANTREA_COV_DIR=$PWD/test-e2e-ipv6-only-coverage ./ci/kind/test-e2e-kind.sh --encap-mode encap --ip-family v6 --coverage
+    - name: Tar coverage files
+      run: tar -czf test-e2e-ipv6-only-coverage.tar.gz test-e2e-ipv6-only-coverage
+    - name: Upload coverage for test-e2e-ipv6-only-coverage
+      uses: actions/upload-artifact@v7
+      with:
+        name: test-e2e-ipv6-only-coverage
+        path: test-e2e-ipv6-only-coverage.tar.gz
+        retention-days: 30
+    - name: Codecov
+      uses: codecov/codecov-action@v6
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: '**/*.cov.out'
+        disable_search: true
+        flags: kind-e2e-tests
+        name: codecov-test-e2e-ipv6-only
+        directory: test-e2e-ipv6-only-coverage
+        fail_ci_if_error: ${{ github.event_name == 'push' }}
+    - name: Tar log files
+      if: ${{ failure() }}
+      run: tar -czf log.tar.gz log
+    - name: Upload test log
+      uses: actions/upload-artifact@v7
+      if: ${{ failure() }}
+      with:
+        name: e2e-kind-ipv6-only.tar.gz
+        path: log.tar.gz
+        retention-days: 30
+
+  test-e2e-ipv6-ds:
+    name: E2e tests on a Kind cluster on Linux (Dual-stack)
+    needs: [build-antrea-coverage-image]
+    runs-on: [ubuntu-latest]
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        show-progress: false
+    - uses: ./.github/actions/setup-kind-test
+    - name: Run e2e tests
+      run: |
+        mkdir log
+        mkdir test-e2e-ipv6-ds-coverage
+        ANTREA_LOG_DIR=$PWD/log ANTREA_COV_DIR=$PWD/test-e2e-ipv6-ds-coverage ./ci/kind/test-e2e-kind.sh --encap-mode encap --ip-family dual --coverage
+    - name: Tar coverage files
+      run: tar -czf test-e2e-ipv6-ds-coverage.tar.gz test-e2e-ipv6-ds-coverage
+    - name: Upload coverage for test-e2e-ipv6-ds-coverage
+      uses: actions/upload-artifact@v7
+      with:
+        name: test-e2e-ipv6-ds-coverage
+        path: test-e2e-ipv6-ds-coverage.tar.gz
+        retention-days: 30
+    - name: Codecov
+      uses: codecov/codecov-action@v6
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: '**/*.cov.out'
+        disable_search: true
+        flags: kind-e2e-tests
+        name: codecov-test-e2e-ipv6-ds
+        directory: test-e2e-ipv6-ds-coverage
+        fail_ci_if_error: ${{ github.event_name == 'push' }}
+    - name: Tar log files
+      if: ${{ failure() }}
+      run: tar -czf log.tar.gz log
+    - name: Upload test log
+      uses: actions/upload-artifact@v7
+      if: ${{ failure() }}
+      with:
+        name: e2e-kind-ipv6-ds.tar.gz
+        path: log.tar.gz
+        retention-days: 30
+
   test-e2e-hybrid-non-default:
     name: E2e tests on a Kind cluster on Linux (hybrid) with non default values (proxyAll=true, kube-proxy-mode=nftables)
     needs: [ build-antrea-coverage-image ]
@@ -677,6 +763,8 @@ jobs:
     - test-e2e-noencap
     - test-e2e-hybrid
     - test-e2e-hybrid-non-default
+    - test-e2e-ipv6-only
+    - test-e2e-ipv6-ds
     - test-upgrade-from-N-1
     - test-upgrade-from-N-2
     - test-compatible-N-1

--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -77,32 +77,10 @@ jobs:
     needs: [build-antrea-coverage-image]
     runs-on: [ubuntu-latest]
     steps:
-    - name: Free disk space
-      # https://github.com/actions/virtual-environments/issues/709
-      run: |
-        sudo apt-get clean
-        df -h
     - uses: actions/checkout@v6
       with:
         show-progress: false
-    - uses: actions/setup-go@v6
-      with:
-        go-version-file: '.go-version'
-    # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
-    - uses: ./.github/actions/setup-docker-classic
-    - name: Download Antrea image from previous job
-      uses: actions/download-artifact@v6
-      with:
-        name: antrea-ubuntu-cov
-    - name: Load Antrea image
-      run: |
-        docker load -i antrea-ubuntu.tar
-    - name: Install Kind
-      run: |
-        KIND_VERSION=$(head -n1 ./ci/kind/version)
-        curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
-        chmod +x ./kind
-        sudo mv kind /usr/local/bin
+    - uses: ./.github/actions/setup-kind-test
     - name: Run e2e tests
       run: |
         mkdir log
@@ -142,32 +120,10 @@ jobs:
     needs: [build-antrea-coverage-image]
     runs-on: [ubuntu-latest]
     steps:
-    - name: Free disk space
-      # https://github.com/actions/virtual-environments/issues/709
-      run: |
-        sudo apt-get clean
-        df -h
     - uses: actions/checkout@v6
       with:
         show-progress: false
-    - uses: actions/setup-go@v6
-      with:
-        go-version-file: '.go-version'
-    # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
-    - uses: ./.github/actions/setup-docker-classic
-    - name: Download Antrea image from previous job
-      uses: actions/download-artifact@v6
-      with:
-        name: antrea-ubuntu-cov
-    - name: Load Antrea image
-      run: |
-        docker load -i antrea-ubuntu.tar
-    - name: Install Kind
-      run: |
-        KIND_VERSION=$(head -n1 ./ci/kind/version)
-        curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
-        chmod +x ./kind
-        sudo mv kind /usr/local/bin
+    - uses: ./.github/actions/setup-kind-test
     - name: Run e2e tests
       run: |
         mkdir log
@@ -214,32 +170,10 @@ jobs:
     needs: [build-antrea-coverage-image]
     runs-on: [ubuntu-latest]
     steps:
-      - name: Free disk space
-        # https://github.com/actions/virtual-environments/issues/709
-        run: |
-          sudo apt-get clean
-          df -h
       - uses: actions/checkout@v6
         with:
           show-progress: false
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: '.go-version'
-      # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
-      - uses: ./.github/actions/setup-docker-classic
-      - name: Download Antrea image from previous job
-        uses: actions/download-artifact@v6
-        with:
-          name: antrea-ubuntu-cov
-      - name: Load Antrea image
-        run: |
-          docker load -i antrea-ubuntu.tar
-      - name: Install Kind
-        run: |
-          KIND_VERSION=$(head -n1 ./ci/kind/version)
-          curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
-          chmod +x ./kind
-          sudo mv kind /usr/local/bin
+      - uses: ./.github/actions/setup-kind-test
       - name: Run e2e tests
         run: |
           mkdir log
@@ -291,24 +225,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           show-progress: false
-      - uses: actions/setup-go@v6
+      - uses: ./.github/actions/setup-kind-test
         with:
-          go-version-file: '.go-version'
-      # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
-      - uses: ./.github/actions/setup-docker-classic
-      - name: Download Antrea image from previous job
-        uses: actions/download-artifact@v6
-        with:
-          name: antrea-ubuntu-cov
-      - name: Load Antrea image
-        run: |
-          docker load -i antrea-ubuntu.tar
-      - name: Install Kind
-        run: |
-          KIND_VERSION=$(head -n1 ./ci/kind/version)
-          curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
-          chmod +x ./kind
-          sudo mv kind /usr/local/bin
+          free-disk-space: 'false'
       - name: Run ipam e2e tests
         # We enable multicast as some FlexibleIPAM e2e tests require it
         run: |
@@ -354,32 +273,10 @@ jobs:
     needs: [build-antrea-coverage-image]
     runs-on: [ubuntu-latest]
     steps:
-    - name: Free disk space
-      # https://github.com/actions/virtual-environments/issues/709
-      run: |
-        sudo apt-get clean
-        df -h
     - uses: actions/checkout@v6
       with:
         show-progress: false
-    - uses: actions/setup-go@v6
-      with:
-        go-version-file: '.go-version'
-    # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
-    - uses: ./.github/actions/setup-docker-classic
-    - name: Download Antrea image from previous job
-      uses: actions/download-artifact@v6
-      with:
-        name: antrea-ubuntu-cov
-    - name: Load Antrea image
-      run: |
-        docker load -i antrea-ubuntu.tar
-    - name: Install Kind
-      run: |
-        KIND_VERSION=$(head -n1 ./ci/kind/version)
-        curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
-        chmod +x ./kind
-        sudo mv kind /usr/local/bin
+    - uses: ./.github/actions/setup-kind-test
     - name: Run e2e tests
       run: |
         mkdir log
@@ -419,32 +316,10 @@ jobs:
     needs: [build-antrea-coverage-image]
     runs-on: [ubuntu-latest]
     steps:
-    - name: Free disk space
-      # https://github.com/actions/virtual-environments/issues/709
-      run: |
-        sudo apt-get clean
-        df -h
     - uses: actions/checkout@v6
       with:
         show-progress: false
-    - uses: actions/setup-go@v6
-      with:
-        go-version-file: '.go-version'
-    # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
-    - uses: ./.github/actions/setup-docker-classic
-    - name: Download Antrea image from previous job
-      uses: actions/download-artifact@v6
-      with:
-        name: antrea-ubuntu-cov
-    - name: Load Antrea image
-      run: |
-        docker load -i antrea-ubuntu.tar
-    - name: Install Kind
-      run: |
-        KIND_VERSION=$(head -n1 ./ci/kind/version)
-        curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
-        chmod +x ./kind
-        sudo mv kind /usr/local/bin
+    - uses: ./.github/actions/setup-kind-test
     - name: Run e2e tests
       run: |
         mkdir log
@@ -484,32 +359,10 @@ jobs:
     needs: [ build-antrea-coverage-image ]
     runs-on: [ ubuntu-latest ]
     steps:
-      - name: Free disk space
-        # https://github.com/actions/virtual-environments/issues/709
-        run: |
-          sudo apt-get clean
-          df -h
       - uses: actions/checkout@v6
         with:
           show-progress: false
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: '.go-version'
-      # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
-      - uses: ./.github/actions/setup-docker-classic
-      - name: Download Antrea image from previous job
-        uses: actions/download-artifact@v6
-        with:
-          name: antrea-ubuntu-cov
-      - name: Load Antrea image
-        run: |
-          docker load -i antrea-ubuntu.tar
-      - name: Install Kind
-        run: |
-          KIND_VERSION=$(head -n1 ./ci/kind/version)
-          curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
-          chmod +x ./kind
-          sudo mv kind /usr/local/bin
+      - uses: ./.github/actions/setup-kind-test
       - name: Run e2e tests
         run: |
           mkdir log
@@ -559,7 +412,7 @@ jobs:
       matrix:
         protocol: [grpc, ipfix]
     steps:
-      - name: Free disk space
+      - name: Free disk space (extended)
         # https://github.com/actions/virtual-environments/issues/709
         run: |
           sudo apt-get clean
@@ -572,31 +425,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           show-progress: false
-      - uses: actions/setup-go@v6
+      - uses: ./.github/actions/setup-kind-test
         with:
-          go-version-file: '.go-version'
-      # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
-      - uses: ./.github/actions/setup-docker-classic
-      - name: Download Antrea image from previous job
-        uses: actions/download-artifact@v6
-        with:
-          name: antrea-ubuntu-cov
-      - name: Load Antrea image
-        run: |
-          docker load -i antrea-ubuntu.tar
-      - name: Download Flow Aggregator image from previous job
-        uses: actions/download-artifact@v6
-        with:
-          name: flow-aggregator-cov
-      - name: Load Flow Aggregator image
-        run: |
-          docker load -i flow-aggregator.tar
-      - name: Install Kind
-        run: |
-          KIND_VERSION=$(head -n1 ./ci/kind/version)
-          curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
-          chmod +x ./kind
-          sudo mv kind /usr/local/bin
+          free-disk-space: 'false'
+          load-flow-aggregator: 'true'
       - name: Run e2e tests
         run: |
           mkdir log
@@ -636,34 +468,12 @@ jobs:
     needs: [build-antrea-coverage-image]
     runs-on: [ubuntu-latest]
     steps:
-    - name: Free disk space
-      # https://github.com/actions/virtual-environments/issues/709
-      run: |
-        sudo apt-get clean
-        df -h
     - uses: actions/checkout@v6
       with:
         show-progress: false
-    - uses: actions/setup-go@v6
+    - uses: ./.github/actions/setup-kind-test
       with:
-        go-version-file: '.go-version'
-    # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
-    - uses: ./.github/actions/setup-docker-classic
-    - name: Download Antrea image from previous job
-      uses: actions/download-artifact@v6
-      with:
-        name: antrea-ubuntu-cov
-    - name: Load Antrea image
-      run: |
-        docker load -i antrea-ubuntu.tar
-        docker tag antrea/antrea-agent-ubuntu-coverage:latest antrea/antrea-agent-ubuntu:latest
-        docker tag antrea/antrea-controller-ubuntu-coverage:latest antrea/antrea-controller-ubuntu:latest
-    - name: Install Kind
-      run: |
-        KIND_VERSION=$(head -n1 ./ci/kind/version)
-        curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
-        chmod +x ./kind
-        sudo mv kind /usr/local/bin
+        tag-coverage-images: 'true'
     - name: Run NetworkPolicy conformance tests
       run: |
         mkdir log
@@ -684,34 +494,12 @@ jobs:
     needs: [build-antrea-coverage-image]
     runs-on: [ubuntu-latest]
     steps:
-    - name: Free disk space
-      # https://github.com/actions/virtual-environments/issues/709
-      run: |
-        sudo apt-get clean
-        df -h
     - uses: actions/checkout@v6
       with:
         show-progress: false
-    - uses: actions/setup-go@v6
+    - uses: ./.github/actions/setup-kind-test
       with:
-        go-version-file: '.go-version'
-    # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
-    - uses: ./.github/actions/setup-docker-classic
-    - name: Download Antrea image from previous job
-      uses: actions/download-artifact@v6
-      with:
-        name: antrea-ubuntu-cov
-    - name: Load Antrea image
-      run: |
-        docker load -i antrea-ubuntu.tar
-        docker tag antrea/antrea-agent-ubuntu-coverage:latest antrea/antrea-agent-ubuntu:latest
-        docker tag antrea/antrea-controller-ubuntu-coverage:latest antrea/antrea-controller-ubuntu:latest
-    - name: Install Kind
-      run: |
-        KIND_VERSION=$(head -n1 ./ci/kind/version)
-        curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
-        chmod +x ./kind
-        sudo mv kind /usr/local/bin
+        tag-coverage-images: 'true'
     - name: Run secondary network tests
       run: |
         mkdir log
@@ -732,34 +520,12 @@ jobs:
     needs: build-antrea-coverage-image
     runs-on: [ubuntu-latest]
     steps:
-      - name: Free disk space
-        # https://github.com/actions/virtual-environments/issues/709
-        run: |
-          sudo apt-get clean
-          df -h
       - uses: actions/checkout@v6
         with:
           show-progress: false
-      - uses: actions/setup-go@v6
+      - uses: ./.github/actions/setup-kind-test
         with:
-          go-version-file: '.go-version'
-      # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
-      - uses: ./.github/actions/setup-docker-classic
-      - name: Download Antrea image from previous job
-        uses: actions/download-artifact@v6
-        with:
-          name: antrea-ubuntu-cov
-      - name: Load Antrea image
-        run: |
-          docker load -i antrea-ubuntu.tar
-          docker tag antrea/antrea-agent-ubuntu-coverage:latest antrea/antrea-agent-ubuntu:latest
-          docker tag antrea/antrea-controller-ubuntu-coverage:latest antrea/antrea-controller-ubuntu:latest
-      - name: Install Kind
-        run: |
-          KIND_VERSION=$(head -n1 ./ci/kind/version)
-          curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
-          chmod +x ./kind
-          sudo mv kind /usr/local/bin
+          tag-coverage-images: 'true'
       - name: Run test
         run: |
           mkdir log
@@ -780,34 +546,12 @@ jobs:
     needs: build-antrea-coverage-image
     runs-on: [ubuntu-latest]
     steps:
-      - name: Free disk space
-        # https://github.com/actions/virtual-environments/issues/709
-        run: |
-          sudo apt-get clean
-          df -h
       - uses: actions/checkout@v6
         with:
           show-progress: false
-      - uses: actions/setup-go@v6
+      - uses: ./.github/actions/setup-kind-test
         with:
-          go-version-file: '.go-version'
-      # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
-      - uses: ./.github/actions/setup-docker-classic
-      - name: Download Antrea image from previous job
-        uses: actions/download-artifact@v6
-        with:
-          name: antrea-ubuntu-cov
-      - name: Load Antrea image
-        run: |
-          docker load -i antrea-ubuntu.tar
-          docker tag antrea/antrea-agent-ubuntu-coverage:latest antrea/antrea-agent-ubuntu:latest
-          docker tag antrea/antrea-controller-ubuntu-coverage:latest antrea/antrea-controller-ubuntu:latest
-      - name: Install Kind
-        run: |
-          KIND_VERSION=$(head -n1 ./ci/kind/version)
-          curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
-          chmod +x ./kind
-          sudo mv kind /usr/local/bin
+          tag-coverage-images: 'true'
       - name: Run test
         run: |
           mkdir log
@@ -828,34 +572,12 @@ jobs:
     needs: build-antrea-coverage-image
     runs-on: [ubuntu-latest]
     steps:
-      - name: Free disk space
-        # https://github.com/actions/virtual-environments/issues/709
-        run: |
-          sudo apt-get clean
-          df -h
       - uses: actions/checkout@v6
         with:
           show-progress: false
-      - uses: actions/setup-go@v6
+      - uses: ./.github/actions/setup-kind-test
         with:
-          go-version-file: '.go-version'
-      # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
-      - uses: ./.github/actions/setup-docker-classic
-      - name: Download Antrea image from previous job
-        uses: actions/download-artifact@v6
-        with:
-          name: antrea-ubuntu-cov
-      - name: Load Antrea image
-        run: |
-          docker load -i antrea-ubuntu.tar
-          docker tag antrea/antrea-agent-ubuntu-coverage:latest antrea/antrea-agent-ubuntu:latest
-          docker tag antrea/antrea-controller-ubuntu-coverage:latest antrea/antrea-controller-ubuntu:latest
-      - name: Install Kind
-        run: |
-          KIND_VERSION=$(head -n1 ./ci/kind/version)
-          curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
-          chmod +x ./kind
-          sudo mv kind /usr/local/bin
+          tag-coverage-images: 'true'
       - name: Run test
         run: |
           mkdir log
@@ -876,34 +598,12 @@ jobs:
     needs: build-antrea-coverage-image
     runs-on: [ubuntu-latest]
     steps:
-      - name: Free disk space
-        # https://github.com/actions/virtual-environments/issues/709
-        run: |
-          sudo apt-get clean
-          df -h
       - uses: actions/checkout@v6
         with:
           show-progress: false
-      - uses: actions/setup-go@v6
+      - uses: ./.github/actions/setup-kind-test
         with:
-          go-version-file: '.go-version'
-      # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
-      - uses: ./.github/actions/setup-docker-classic
-      - name: Download Antrea image from previous job
-        uses: actions/download-artifact@v6
-        with:
-          name: antrea-ubuntu-cov
-      - name: Load Antrea image
-        run: |
-          docker load -i antrea-ubuntu.tar
-          docker tag antrea/antrea-agent-ubuntu-coverage:latest antrea/antrea-agent-ubuntu:latest
-          docker tag antrea/antrea-controller-ubuntu-coverage:latest antrea/antrea-controller-ubuntu:latest
-      - name: Install Kind
-        run: |
-          KIND_VERSION=$(head -n1 ./ci/kind/version)
-          curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
-          chmod +x ./kind
-          sudo mv kind /usr/local/bin
+          tag-coverage-images: 'true'
       - name: Run test
         run: |
           mkdir log
@@ -924,31 +624,10 @@ jobs:
     needs: [ build-antrea-coverage-image ]
     runs-on: [ ubuntu-latest ]
     steps:
-      - name: Free disk space
-        run: |
-          sudo apt-get clean
-          df -h
       - uses: actions/checkout@v6
         with:
           show-progress: false
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: '.go-version'
-      # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
-      - uses: ./.github/actions/setup-docker-classic
-      - name: Download Antrea image from previous job
-        uses: actions/download-artifact@v6
-        with:
-          name: antrea-ubuntu-cov
-      - name: Load Antrea image
-        run: |
-          docker load -i antrea-ubuntu.tar
-      - name: Install Kind
-        run: |
-          KIND_VERSION=$(head -n1 ./ci/kind/version)
-          curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
-          chmod +x ./kind
-          sudo mv kind /usr/local/bin
+      - uses: ./.github/actions/setup-kind-test
       - name: Create Kind Cluster
         run: |
           ./ci/kind/kind-setup.sh create kind --ip-family dual
@@ -972,31 +651,13 @@ jobs:
     needs: build-antrea-coverage-image
     runs-on: [ubuntu-latest]
     steps:
-      - name: Free disk space
-        # https://github.com/actions/virtual-environments/issues/709
-        run: |
-          sudo apt-get clean
-          df -h
       - uses: actions/checkout@v6
         with:
           show-progress: false
-      # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
-      - uses: ./.github/actions/setup-docker-classic
-      - name: Download Antrea image from previous job
-        uses: actions/download-artifact@v6
+      - uses: ./.github/actions/setup-kind-test
         with:
-          name: antrea-ubuntu-cov
-      - name: Load Antrea image
-        run: |
-          docker load -i antrea-ubuntu.tar
-          docker tag antrea/antrea-agent-ubuntu-coverage:latest antrea/antrea-agent-ubuntu:latest
-          docker tag antrea/antrea-controller-ubuntu-coverage:latest antrea/antrea-controller-ubuntu:latest
-      - name: Install Kind
-        run: |
-          KIND_VERSION=$(head -n1 ./ci/kind/version)
-          curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
-          chmod +x ./kind
-          sudo mv kind /usr/local/bin
+          setup-go: 'false'
+          tag-coverage-images: 'true'
       - name: Validate document
         run: |
           ./ci/kind/validate-metrics-doc.sh

--- a/.github/workflows/kind_ubi.yml
+++ b/.github/workflows/kind_ubi.yml
@@ -55,12 +55,7 @@ jobs:
     - name: Clean up docker build cache
       run: |
         docker builder prune -f
-    - name: Install Kind
-      run: |
-        KIND_VERSION=$(head -n1 ./ci/kind/version)
-        curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
-        chmod +x ./kind
-        sudo mv kind /usr/local/bin
+    - uses: ./.github/actions/setup-kind
     - name: Run basic e2e tests
       run: |
         mkdir log

--- a/.github/workflows/netpol_cyclonus.yml
+++ b/.github/workflows/netpol_cyclonus.yml
@@ -20,12 +20,7 @@ jobs:
       # Docker 29+ defaults to the containerd image store, which breaks kind load docker-image.
       - uses: ./.github/actions/setup-docker-classic
       - run: make
-      - name: Install Kind
-        run: |
-          KIND_VERSION=$(head -n1 ./ci/kind/version)
-          curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-$(uname)-amd64
-          chmod +x ./kind
-          sudo mv kind /usr/local/bin
+      - uses: ./.github/actions/setup-kind
       - name: Run cyclonus tests
         working-directory: hack/netpol-generator
         run: ./test-kind.sh


### PR DESCRIPTION
Cherry pick of #7831 #8047 #8064 on release-2.5.

#7831: Extract composite actions for Kind test setup (#7831)
#8047: Add IPv6 e2e tests to GitHub Actions (#8047)
#8064: Add K8s conformance e2e test into Kind workflow (#8064)

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.