### PR TITLE
Automated cherry pick of #8065: Add MC e2e tests to GitHub Actions (#8065)

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -606,6 +606,76 @@ jobs:
           path: log.tar.gz
           retention-days: 30
 
+  test-multicluster-e2e:
+    name: Multi-cluster e2e tests on Kind clusters
+    needs: [check-changes]
+    if: ${{ needs.check-changes.outputs.has_changes == 'yes' }}
+    runs-on: [ubuntu-latest-8-cores]
+    timeout-minutes: 150
+    env:
+      GIT_COMMIT: ${{ github.sha }}
+      WORKSPACE: ${{ github.workspace }}
+    steps:
+    - name: Free disk space (extended)
+      # Multi-cluster e2e builds Antrea and the multi-cluster controller, then runs three Kind clusters.
+      run: |
+        sudo apt-get clean
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /opt/ghc
+        sudo rm -rf "/usr/local/share/boost"
+        sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+        sudo rm -rf "/usr/local/lib/android"
+        df -h
+    - uses: actions/checkout@v6
+      with:
+        show-progress: false
+    - uses: actions/setup-go@v6
+      with:
+        go-version-file: '.go-version'
+    - uses: ./.github/actions/setup-docker-classic
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
+      with:
+        driver: docker
+    - uses: ./.github/actions/setup-kind
+    - name: Run multi-cluster e2e tests
+      run: |
+        mkdir -p "$HOME/.kube"
+        ./ci/jenkins/test-mc.sh \
+          --testcase e2e \
+          --registry "$(head -n1 ci/docker-registry)" \
+          --mc-gateway \
+          --coverage \
+          --kind \
+          --use-system-go \
+          --workdir "$GITHUB_WORKSPACE" \
+          --kubeconfigs-path "$HOME/.kube"
+    - name: Tar coverage files
+      run: tar -czf mc-e2e-coverage.tar.gz mc-e2e-coverage
+    - name: Upload coverage for test-multicluster-e2e
+      uses: actions/upload-artifact@v7
+      with:
+        name: test-multicluster-e2e-coverage
+        path: mc-e2e-coverage.tar.gz
+        retention-days: 30
+    - name: Codecov
+      uses: codecov/codecov-action@v6
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: '**/*.cov.out'
+        disable_search: true
+        flags: kind-e2e-tests
+        name: codecov-test-multicluster-e2e
+        directory: mc-e2e-coverage
+        fail_ci_if_error: ${{ github.event_name == 'push' }}
+    - name: Upload test log
+      uses: actions/upload-artifact@v7
+      if: ${{ failure() }}
+      with:
+        name: multicluster-e2e-kind.tar.gz
+        path: antrea-test-logs.tar.gz
+        retention-days: 30
+
   test-network-policy-conformance-encap:
     name: NetworkPolicy conformance tests on a Kind cluster on Linux
     needs: [build-antrea-coverage-image]
@@ -867,6 +937,7 @@ jobs:
     - test-network-policy-conformance-encap
     - test-secondary-network
     - test-e2e-conformance
+    - test-multicluster-e2e
     - run-installation-checks
     runs-on: [ubuntu-latest]
     steps:

--- a/ci/jenkins/test-mc.sh
+++ b/ci/jenkins/test-mc.sh
@@ -25,10 +25,7 @@ WORKDIR=$DEFAULT_WORKDIR
 TESTCASE=""
 TEST_FAILURE=false
 DOCKER_REGISTRY=$(head -n1 "${WORKSPACE}/ci/docker-registry")
-MULTICLUSTER_KUBECONFIG_PATH=$WORKDIR/.kube
-LEADER_CLUSTER_CONFIG="--kubeconfig=$MULTICLUSTER_KUBECONFIG_PATH/leader"
-EAST_CLUSTER_CONFIG="--kubeconfig=$MULTICLUSTER_KUBECONFIG_PATH/east"
-WEST_CLUSTER_CONFIG="--kubeconfig=$MULTICLUSTER_KUBECONFIG_PATH/west"
+MULTICLUSTER_KUBECONFIG_PATH=""
 CLUSTER_NAMES=("leader" "east" "west")
 ENABLE_MC_GATEWAY=false
 IS_CONTAINERD=false
@@ -36,6 +33,7 @@ CODECOV_TOKEN=""
 COVERAGE=false
 KIND=false
 DEBUG=false
+USE_SYSTEM_GO=false
 GOLANG_RELEASE_DIR=${WORKDIR}/golang-releases
 
 multicluster_kubeconfigs=($EAST_CLUSTER_CONFIG $LEADER_CLUSTER_CONFIG $WEST_CLUSTER_CONFIG)
@@ -48,7 +46,7 @@ CLEAN_STALE_IMAGES_CONTAINERD="crictl rmi --prune"
 PRINT_CONTAINERD_STATUS="crictl ps --state Exited"
 
 _usage="Usage: $0 [--kubeconfigs-path <KubeconfigSavePath>] [--workdir <HomePath>]
-                  [--testcase <e2e>] [--mc-gateway] [--codecov-token] [--coverage] [--kind] [--debug]
+                  [--testcase <e2e>] [--mc-gateway] [--codecov-token] [--coverage] [--kind] [--use-system-go] [--debug]
 
 Run Antrea multi-cluster e2e tests on a remote (Jenkins) Linux Cluster Set.
 
@@ -60,6 +58,7 @@ Run Antrea multi-cluster e2e tests on a remote (Jenkins) Linux Cluster Set.
         --codecov-token               Token used to upload coverage report(s) to Codecov.
         --coverage                    Run e2e with coverage.
         --kind                        Run e2e on Kind clusters.
+        --use-system-go               Use the Go toolchain already available in PATH.
         --debug                       Do not clean up Kind clusters when --kind is set."
 
 function print_usage {
@@ -104,6 +103,10 @@ case $key in
     KIND=true
     shift
     ;;
+    --use-system-go)
+    USE_SYSTEM_GO=true
+    shift
+    ;;
     --debug)
     DEBUG=true
     shift
@@ -118,6 +121,16 @@ case $key in
     ;;
 esac
 done
+
+# Recompute path-derived variables now that WORKDIR and MULTICLUSTER_KUBECONFIG_PATH
+# have their final values (--workdir and --kubeconfigs-path may have changed them).
+GOLANG_RELEASE_DIR=${WORKDIR}/golang-releases
+MULTICLUSTER_KUBECONFIG_PATH=${MULTICLUSTER_KUBECONFIG_PATH:-$WORKDIR/.kube}
+LEADER_CLUSTER_CONFIG="--kubeconfig=$MULTICLUSTER_KUBECONFIG_PATH/leader"
+EAST_CLUSTER_CONFIG="--kubeconfig=$MULTICLUSTER_KUBECONFIG_PATH/east"
+WEST_CLUSTER_CONFIG="--kubeconfig=$MULTICLUSTER_KUBECONFIG_PATH/west"
+multicluster_kubeconfigs=($EAST_CLUSTER_CONFIG $LEADER_CLUSTER_CONFIG $WEST_CLUSTER_CONFIG)
+membercluster_kubeconfigs=($EAST_CLUSTER_CONFIG $WEST_CLUSTER_CONFIG)
 
 function clean_tmp() {
     echo "===== Clean up stale files & folders older than 7 days under /tmp ====="
@@ -466,7 +479,9 @@ function collect_coverage {
 
 trap clean_multicluster EXIT
 source $WORKSPACE/ci/jenkins/utils.sh
-check_and_upgrade_golang
+if [[ ${USE_SYSTEM_GO} != "true" ]]; then
+    check_and_upgrade_golang
+fi
 clean_tmp
 clean_images
 
@@ -499,9 +514,11 @@ set -e
 if [[ ${TESTCASE} =~ "e2e" ]]; then
     export GO111MODULE=on
     export GOPATH=${WORKDIR}/go
-    export GOROOT=${GOLANG_RELEASE_DIR}/go
     export GOCACHE=${WORKDIR}/.cache/go-build
-    export PATH=$GOROOT/bin:$PATH
+    if [[ ${USE_SYSTEM_GO} != "true" ]]; then
+        export GOROOT=${GOLANG_RELEASE_DIR}/go
+        export PATH=$GOROOT/bin:$PATH
+    fi
 
     deliver_antrea_multicluster
     modify_config
@@ -513,9 +530,13 @@ if [[ ${TESTCASE} =~ "e2e" ]]; then
       mkdir -p mc-e2e-coverage
       collect_coverage ${CURRENT_DIR}/mc-e2e-coverage
       # Backup coverage files for later analysis
-      set +e;find ${DEFAULT_WORKDIR}/mc-e2e-coverage -maxdepth 1 -mtime +1 -type f | xargs -n 1 rm;set -e; # Clean up backup files older than one day.
-      cp -r mc-e2e-coverage ${DEFAULT_WORKDIR}
-      run_codecov "e2e-tests" "*antrea-mc*" "${CURRENT_DIR}/mc-e2e-coverage"
+      if [[ -d ${DEFAULT_WORKDIR} && -w ${DEFAULT_WORKDIR} ]]; then
+        set +e;find ${DEFAULT_WORKDIR}/mc-e2e-coverage -maxdepth 1 -mtime +1 -type f | xargs -n 1 rm;set -e; # Clean up backup files older than one day.
+        cp -r mc-e2e-coverage ${DEFAULT_WORKDIR}
+      fi
+      if [[ -n ${CODECOV_TOKEN} ]]; then
+        run_codecov "e2e-tests" "*antrea-mc*" "${CURRENT_DIR}/mc-e2e-coverage"
+      fi
     fi
 fi
 


### PR DESCRIPTION
Cherry pick of #8065 on release-2.6.

#8065: Add MC e2e tests to GitHub Actions (#8065)

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.