### PR TITLE
Automated cherry pick of #8055: Migrate UUID library from google/uuid to gofrs/uuid/v5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,10 +28,10 @@ require (
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/gammazero/deque v1.2.1
 	github.com/go-logr/logr v1.4.3
+	github.com/gofrs/uuid/v5 v5.4.0
 	github.com/google/btree v1.1.3
 	github.com/google/gnostic-models v0.7.1
 	github.com/google/go-cmp v0.7.0
-	github.com/google/uuid v1.6.0
 	github.com/gopacket/gopacket v1.6.0
 	github.com/hashicorp/memberlist v0.5.4
 	github.com/k8snetworkplumbingwg/network-attachment-definition-client v1.7.7
@@ -148,6 +148,7 @@ require (
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/cel-go v0.26.0 // indirect
 	github.com/google/pprof v0.0.0-20260402051712-545e8a4df936 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -327,6 +327,8 @@ github.com/go-test/deep v1.1.0/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncV
 github.com/gobuffalo/flect v0.2.0/go.mod h1:W3K3X9ksuZfir8f/LrfVtWmCDQFfayuylOJ7sz/Fj80=
 github.com/goccy/go-yaml v1.18.0 h1:8W7wMFS12Pcas7KU+VVkaiCng+kG8QiFeFwzFb+rwuw=
 github.com/goccy/go-yaml v1.18.0/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
+github.com/gofrs/uuid/v5 v5.4.0 h1:EfbpCTjqMuGyq5ZJwxqzn3Cbr2d0rUZU7v5ycAk/e/0=
+github.com/gofrs/uuid/v5 v5.4.0/go.mod h1:CDOjlDMVAtN56jqyRUZh58JT31Tiw7/oQyEXZV+9bD8=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -24,7 +24,7 @@ import (
 	"testing/synctest"
 	"time"
 
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid/v5"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -80,8 +80,8 @@ func TestInitInterfaceStore(t *testing.T) {
 	err := initializer.initInterfaceStore()
 	assert.Error(t, err, "failed to handle OVS return error")
 
-	uuid1 := uuid.New().String()
-	uuid2 := uuid.New().String()
+	uuid1 := uuid.Must(uuid.NewV4()).String()
+	uuid2 := uuid.Must(uuid.NewV4()).String()
 	p1MAC := "11:22:33:44:55:66"
 	p1IP := "1.1.1.1"
 	p2MAC := "11:22:33:44:55:77"
@@ -99,7 +99,7 @@ func TestInitInterfaceStore(t *testing.T) {
 			interfacestore.NewContainerInterface("p2", uuid2, "pod2", "ns2", "eth0", "netns2", p2NetMAC, []net.IP{p2NetIP}, 0),
 		)),
 	}
-	uuid3 := uuid.New().String()
+	uuid3 := uuid.Must(uuid.NewV4()).String()
 	ovsPortUplinkInternal := ovsconfig.OVSPortData{UUID: uuid3, Name: "eth-antrea-test-1", IFName: "eth-antrea-test-1", OFPort: 100,
 		ExternalIDs: map[string]string{
 			interfacestore.AntreaInterfaceTypeKey: interfacestore.AntreaHost,

--- a/pkg/agent/cniserver/ipam/antrea_ipam_test.go
+++ b/pkg/agent/cniserver/ipam/antrea_ipam_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/containernetworking/cni/pkg/invoke"
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	current "github.com/containernetworking/cni/pkg/types/100"
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -347,7 +347,7 @@ func TestAntreaIPAMDriver(t *testing.T) {
 		re := regexp.MustCompile("(-sts-)*[0-9]*$")
 		namespace := re.ReplaceAllString(test, "")
 		args := argtypes.K8sArgs{}
-		cnitypes.LoadArgs(cniservertest.GenerateCNIArgs(test, namespace, uuid.New().String()), &args)
+		cnitypes.LoadArgs(cniservertest.GenerateCNIArgs(test, namespace, uuid.Must(uuid.NewV4()).String()), &args)
 		k8sArgsMap[test] = &args
 		cniArgsMap[test] = &invoke.Args{
 			ContainerID: fmt.Sprintf("%s-container", test),
@@ -512,7 +512,7 @@ func TestAntreaIPAMDriver(t *testing.T) {
 
 	// Make sure Del call with irrelevant container ID is ignored
 	cniArgsBadContainer := &invoke.Args{
-		ContainerID: uuid.New().String(),
+		ContainerID: uuid.Must(uuid.NewV4()).String(),
 	}
 
 	owns, err = testDriver.Del(cniArgsBadContainer, k8sArgsMap["orange1"], networkConfig)

--- a/pkg/agent/cniserver/server_linux_test.go
+++ b/pkg/agent/cniserver/server_linux_test.go
@@ -24,7 +24,7 @@ import (
 
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	current "github.com/containernetworking/cni/pkg/types/100"
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -60,7 +60,7 @@ func TestValidatePrevResult(t *testing.T) {
 
 	prevResult, _ := cniServer.parsePrevResultFromRequest(networkCfg)
 	containerIface := &current.Interface{Name: ifname, Sandbox: netns}
-	containerID := uuid.New().String()
+	containerID := uuid.Must(uuid.NewV4()).String()
 	hostIfaceName := util.GenerateContainerInterfaceName(testPodNameA, testPodNamespace, containerID)
 	hostIface := &current.Interface{Name: hostIfaceName}
 	prevResult.Interfaces = []*current.Interface{hostIface, containerIface}
@@ -134,10 +134,10 @@ func TestRemoveInterface(t *testing.T) {
 	var fakePortUUID string
 
 	newContainerConfig := func(name string) *interfacestore.InterfaceConfig {
-		containerID = uuid.New().String()
+		containerID = uuid.Must(uuid.NewV4()).String()
 		podName = name
 		hostIfaceName = util.GenerateContainerInterfaceName(podName, testPodNamespace, containerID)
-		fakePortUUID = uuid.New().String()
+		fakePortUUID = uuid.Must(uuid.NewV4()).String()
 
 		containerConfig := interfacestore.NewContainerInterface(
 			hostIfaceName,

--- a/pkg/agent/cniserver/server_test.go
+++ b/pkg/agent/cniserver/server_test.go
@@ -25,7 +25,7 @@ import (
 
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	current "github.com/containernetworking/cni/pkg/types/100"
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -654,7 +654,7 @@ func TestUpdateResultIfaceConfig(t *testing.T) {
 func TestValidateOVSInterface(t *testing.T) {
 	ifaceStore := interfacestore.NewInterfaceStore()
 	podConfigurator := &podConfigurator{ifaceStore: ifaceStore}
-	containerID := uuid.New().String()
+	containerID := uuid.Must(uuid.NewV4()).String()
 	containerMACStr := "11:22:33:44:55:66"
 	containerIP := []string{"10.1.2.100/24,10.1.2.1,4"}
 	result := ipamtest.GenerateIPAMResult(containerIP, routes, dns)
@@ -662,7 +662,7 @@ func TestValidateOVSInterface(t *testing.T) {
 	hostIfaceName := util.GenerateContainerInterfaceName(testPodNameA, testPodNamespace, containerID)
 	hostIface := &current.Interface{Name: hostIfaceName}
 	result.Interfaces = []*current.Interface{hostIface, containerIface}
-	portUUID := uuid.New().String()
+	portUUID := uuid.Must(uuid.NewV4()).String()
 	containerConfig := buildContainerConfig(hostIfaceName, containerID, testPodNameA, testPodNamespace,
 		"netns1", containerIface, result.IPs, 0)
 	containerConfig.OVSPortConfig = &interfacestore.OVSPortConfig{PortUUID: portUUID}
@@ -673,7 +673,7 @@ func TestValidateOVSInterface(t *testing.T) {
 }
 
 func TestBuildOVSPortExternalIDs(t *testing.T) {
-	containerID := uuid.New().String()
+	containerID := uuid.Must(uuid.NewV4()).String()
 	containerMAC, _ := net.ParseMAC("aa:bb:cc:dd:ee:ff")
 	containerIP1 := net.ParseIP("10.1.2.100")
 	containerIP2 := net.ParseIP("2001:fd1a::2")
@@ -810,8 +810,7 @@ func newRequest(args string, netCfg *types.NetworkConfig, path string, t *testin
 }
 
 func generateUUID() string {
-	newID, _ := uuid.NewUUID()
-	return newID.String()
+	return uuid.Must(uuid.NewV4()).String()
 }
 
 func init() {

--- a/pkg/agent/controller/networkpolicy/filestore_test.go
+++ b/pkg/agent/controller/networkpolicy/filestore_test.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid/v5"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -109,7 +109,7 @@ func TestFileStore(t *testing.T) {
 }
 
 func BenchmarkFileStoreAddNetworkPolicy(b *testing.B) {
-	policy := newNetworkPolicy("policy1", types.UID(uuid.New().String()), []string{uuid.New().String()}, nil, []string{uuid.New().String()}, nil)
+	policy := newNetworkPolicy("policy1", types.UID(uuid.Must(uuid.NewV4()).String()), []string{uuid.Must(uuid.NewV4()).String()}, nil, []string{uuid.Must(uuid.NewV4()).String()}, nil)
 	s := newFakeFileStore(b, networkPoliciesDir)
 	b.ResetTimer()
 	b.ReportAllocs()
@@ -123,7 +123,7 @@ func BenchmarkFileStoreAddAppliedToGroup(b *testing.B) {
 	for i := 0; i < 100; i++ {
 		members = append(members, *newAppliedToGroupMemberPod(fmt.Sprintf("pod-%d", i), "namespace"))
 	}
-	atg := newAppliedToGroup(uuid.New().String(), members)
+	atg := newAppliedToGroup(uuid.Must(uuid.NewV4()).String(), members)
 	s := newFakeFileStore(b, appliedToGroupsDir)
 	b.ResetTimer()
 	b.ReportAllocs()
@@ -137,7 +137,7 @@ func BenchmarkFileStoreAddAddressGroup(b *testing.B) {
 	for i := 0; i < 1000; i++ {
 		members = append(members, *newAddressGroupPodMember(fmt.Sprintf("pod-%d", i), "namespace", "192.168.0.1"))
 	}
-	ag := newAddressGroup(uuid.New().String(), members)
+	ag := newAddressGroup(uuid.Must(uuid.NewV4()).String(), members)
 	s := newFakeFileStore(b, addressGroupsDir)
 	b.ResetTimer()
 	b.ReportAllocs()
@@ -151,9 +151,9 @@ func BenchmarkFileStoreReplaceAll(b *testing.B) {
 	atgs := make([]runtime.Object, 0, 1000)
 	ags := make([]runtime.Object, 0, 1000)
 	for i := 0; i < 1000; i++ {
-		policyName := uuid.New().String()
-		addressGroupName := uuid.New().String()
-		appliedToGroupName := uuid.New().String()
+		policyName := uuid.Must(uuid.NewV4()).String()
+		addressGroupName := uuid.Must(uuid.NewV4()).String()
+		appliedToGroupName := uuid.Must(uuid.NewV4()).String()
 		nps = append(nps, newNetworkPolicy(policyName, types.UID(policyName), []string{addressGroupName}, nil, []string{appliedToGroupName}, nil))
 
 		var atgMembers []v1beta2.GroupMember

--- a/pkg/agent/controller/networkpolicy/packetin_test.go
+++ b/pkg/agent/controller/networkpolicy/packetin_test.go
@@ -22,7 +22,7 @@ import (
 
 	"antrea.io/libOpenflow/openflow15"
 	"antrea.io/ofnet/ofctrl"
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	k8stypes "k8s.io/apimachinery/pkg/types"
@@ -144,7 +144,7 @@ func TestPublishDenyConnection(t *testing.T) {
 		SourceAddress:      sourceAddr,
 		DestinationAddress: destinationAddr,
 	}
-	policyUID := uuid.New().String()
+	policyUID := uuid.Must(uuid.NewV4()).String()
 
 	dropCNPDispositionData := []byte{0x11, 0x00, 0x0c, 0x11}
 	dispositionMatch := generateRegMatch(openflow.APDispositionField.GetRegID(), dropCNPDispositionData)

--- a/pkg/agent/externalnode/external_node_controller_linux_test.go
+++ b/pkg/agent/externalnode/external_node_controller_linux_test.go
@@ -19,7 +19,7 @@ import (
 	"net"
 	"testing"
 
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/vishvananda/netlink"
 	"go.uber.org/mock/gomock"
@@ -390,8 +390,8 @@ func TestCreateOVSPortsAndFlowsSuccess(t *testing.T) {
 		HardwareAddr: net.HardwareAddr{0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88},
 		MTU:          1500,
 	}
-	uplinkUUID := uuid.NewString()
-	hostIfUUID := uuid.NewString()
+	uplinkUUID := uuid.Must(uuid.NewV4()).String()
+	hostIfUUID := uuid.Must(uuid.NewV4()).String()
 	hostOFPort := int32(3)
 	uplinkOFPort := int32(4)
 	ipAddrs := []string{"10.20.30.40"}

--- a/pkg/agent/externalnode/external_node_controller_test.go
+++ b/pkg/agent/externalnode/external_node_controller_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -49,10 +49,10 @@ var (
 	uplinkName      = "uplinkName"
 	entityName      = "entityName"
 	entityNamespace = "entityNamespace"
-	ifaceUUID1      = uuid.NewString()
-	ifaceUUID2      = uuid.NewString()
-	portUUID1       = uuid.NewString()
-	portUUID2       = uuid.NewString()
+	ifaceUUID1      = uuid.Must(uuid.NewV4()).String()
+	ifaceUUID2      = uuid.Must(uuid.NewV4()).String()
+	portUUID1       = uuid.Must(uuid.NewV4()).String()
+	portUUID2       = uuid.Must(uuid.NewV4()).String()
 	_, cidr1, _     = net.ParseCIDR("10.20.30.40")
 	intf1           = interfacestore.InterfaceConfig{
 		InterfaceName: ifaceName1,
@@ -105,8 +105,8 @@ func TestCreateOVSPortsAndFlowsFailure(t *testing.T) {
 		HardwareAddr: net.HardwareAddr{0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88},
 		MTU:          1500,
 	}
-	uplinkUUID := uuid.NewString()
-	hostIfUUID := uuid.NewString()
+	uplinkUUID := uuid.Must(uuid.NewV4()).String()
+	hostIfUUID := uuid.Must(uuid.NewV4()).String()
 	hostOFPort := int32(3)
 	uplinkOFPort := int32(4)
 	hostIfName := "hostIfName"
@@ -216,8 +216,8 @@ func TestParseProtocol(t *testing.T) {
 }
 
 func TestParseHostInterfaceConfig(t *testing.T) {
-	randomUUID := uuid.NewString()
-	portUUID := uuid.NewString()
+	randomUUID := uuid.Must(uuid.NewV4()).String()
+	portUUID := uuid.Must(uuid.NewV4()).String()
 
 	for _, tt := range []struct {
 		name                  string
@@ -501,7 +501,7 @@ func TestGetHostInterfaceName(t *testing.T) {
 }
 
 func TestGetOVSAttachInfo(t *testing.T) {
-	uplinkUUID := uuid.NewString()
+	uplinkUUID := uuid.Must(uuid.NewV4()).String()
 
 	ips := []string{"10.20.30.40"}
 	info := GetOVSAttachInfo(uplinkName, uplinkUUID, entityName, entityNamespace, ips)

--- a/pkg/agent/flowexporter/testing/conn.go
+++ b/pkg/agent/flowexporter/testing/conn.go
@@ -18,7 +18,7 @@ import (
 	"net/netip"
 	"time"
 
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid/v5"
 
 	"antrea.io/antrea/pkg/agent/flowexporter/connection"
 	"antrea.io/antrea/pkg/agent/flowexporter/utils"
@@ -45,7 +45,7 @@ func GetConnection(isIPv6 bool, isPresent bool, statusFlag uint32, protoID uint8
 		IsPresent:                      isPresent,
 		SourcePodNamespace:             "ns",
 		SourcePodName:                  "pod",
-		SourcePodUID:                   uuid.New().String(),
+		SourcePodUID:                   uuid.Must(uuid.NewV4()).String(),
 		DestinationPodNamespace:        "",
 		DestinationPodName:             "",
 		IngressNetworkPolicyName:       "",
@@ -55,7 +55,7 @@ func GetConnection(isIPv6 bool, isPresent bool, statusFlag uint32, protoID uint8
 		IngressNetworkPolicyRuleAction: utils.NetworkPolicyRuleActionNoAction,
 		EgressNetworkPolicyName:        "np",
 		EgressNetworkPolicyNamespace:   "ns",
-		EgressNetworkPolicyUID:         uuid.New().String(),
+		EgressNetworkPolicyUID:         uuid.Must(uuid.NewV4()).String(),
 		EgressNetworkPolicyType:        utils.PolicyTypeK8sNetworkPolicy,
 		EgressNetworkPolicyRuleName:    "",
 		EgressNetworkPolicyRuleAction:  utils.NetworkPolicyRuleActionAllow,
@@ -63,7 +63,7 @@ func GetConnection(isIPv6 bool, isPresent bool, statusFlag uint32, protoID uint8
 		TCPState:                       tcpState,
 		FlowType:                       utils.FlowTypeInterNode,
 		EgressName:                     "my-egress",
-		EgressUID:                      uuid.New().String(),
+		EgressUID:                      uuid.Must(uuid.NewV4()).String(),
 		EgressNodeName:                 "egress-node",
 	}
 	return conn

--- a/pkg/agent/secondarynetwork/podwatch/controller_test.go
+++ b/pkg/agent/secondarynetwork/podwatch/controller_test.go
@@ -32,7 +32,7 @@ import (
 	"time"
 
 	current "github.com/containernetworking/cni/pkg/types/100"
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid/v5"
 	netdefv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	netdefclientfake "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/fake"
 	netdefutils "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/utils"
@@ -251,7 +251,7 @@ func TestPodControllerRun(t *testing.T) {
 	}
 
 	pool := &crdv1beta1.IPPool{
-		ObjectMeta: metav1.ObjectMeta{Name: uuid.New().String()},
+		ObjectMeta: metav1.ObjectMeta{Name: uuid.Must(uuid.NewV4()).String()},
 		Spec: crdv1beta1.IPPoolSpec{
 			IPRanges: []crdv1beta1.IPRange{
 				{
@@ -1279,10 +1279,10 @@ func convertExternalIDMap(in map[string]interface{}) map[string]string {
 }
 
 func createTestInterfaces() ([]ovsconfig.OVSPortData, []*interfacestore.InterfaceConfig) {
-	uuid1 := uuid.New().String()
-	uuid2 := uuid.New().String()
-	uuid3 := uuid.New().String()
-	uuid4 := uuid.New().String()
+	uuid1 := uuid.Must(uuid.NewV4()).String()
+	uuid2 := uuid.Must(uuid.NewV4()).String()
+	uuid3 := uuid.Must(uuid.NewV4()).String()
+	uuid4 := uuid.Must(uuid.NewV4()).String()
 
 	p1MAC, p1IP := "11:22:33:44:55:66", "192.168.1.10"
 	p2MAC, p2IP := "11:22:33:44:55:77", "192.168.1.11"

--- a/pkg/clusteridentity/clusteridentity.go
+++ b/pkg/clusteridentity/clusteridentity.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid/v5"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -75,7 +75,7 @@ func (a *ClusterIdentityAllocator) updateConfigMapIfNeeded() error {
 
 	clusterUUIDStr, ok := configMap.Data[uuidConfigMapKey]
 	if ok && clusterUUIDStr != "" {
-		clusterUUID, err := uuid.Parse(clusterUUIDStr)
+		clusterUUID, err := uuid.FromString(clusterUUIDStr)
 		if err != nil {
 			return fmt.Errorf("cluster already has UUID '%s' but it is not valid: %v", clusterUUIDStr, err)
 		}
@@ -83,7 +83,7 @@ func (a *ClusterIdentityAllocator) updateConfigMapIfNeeded() error {
 		return nil
 	}
 
-	generatedClusterUUID := uuid.New().String()
+	generatedClusterUUID := uuid.Must(uuid.NewV4()).String()
 	configMap.Data = map[string]string{
 		uuidConfigMapKey: generatedClusterUUID,
 	}
@@ -181,7 +181,7 @@ func (p *clusterIdentityProvider) Get() (ClusterIdentity, time.Time, error) {
 		if !ok || clusterUUIDStr == "" {
 			return fmt.Errorf("cluster UUID has not been set yet")
 		}
-		clusterUUID, err := uuid.Parse(clusterUUIDStr)
+		clusterUUID, err := uuid.FromString(clusterUUIDStr)
 		if err != nil {
 			return fmt.Errorf("cluster UUID cannot be parsed")
 		}

--- a/pkg/clusteridentity/clusteridentity_test.go
+++ b/pkg/clusteridentity/clusteridentity_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -33,7 +33,7 @@ const (
 )
 
 var (
-	clusterUUID = uuid.New()
+	clusterUUID = uuid.Must(uuid.NewV4())
 
 	// First release of Antrea (v0.1.0) at KubeCon NA 2019 (San Diego) :)
 	sanDiegoLocation, _        = time.LoadLocation("America/Los_Angeles")

--- a/pkg/controller/ipam/antrea_ipam_controller_test.go
+++ b/pkg/controller/ipam/antrea_ipam_controller_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
@@ -76,7 +76,7 @@ func newFakeAntreaIPAMController(pool *crdv1b1.IPPool, namespace *corev1.Namespa
 func initTestObjects(annotateNamespace bool, annotateStatefulSet bool, replicas int32) (*corev1.Namespace, *crdv1b1.IPPool, *appsv1.StatefulSet) {
 	namespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: uuid.New().String(),
+			Name: uuid.Must(uuid.NewV4()).String(),
 		},
 	}
 	ipRange := crdv1b1.IPRange{
@@ -90,7 +90,7 @@ func initTestObjects(annotateNamespace bool, annotateStatefulSet bool, replicas 
 	}
 
 	pool := &crdv1b1.IPPool{
-		ObjectMeta: metav1.ObjectMeta{Name: uuid.New().String()},
+		ObjectMeta: metav1.ObjectMeta{Name: uuid.Must(uuid.NewV4()).String()},
 		Spec: crdv1b1.IPPoolSpec{
 			IPRanges:   []crdv1b1.IPRange{ipRange},
 			SubnetInfo: subnetInfo,
@@ -103,7 +103,7 @@ func initTestObjects(annotateNamespace bool, annotateStatefulSet bool, replicas 
 
 	statefulSet := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      uuid.New().String(),
+			Name:      uuid.Must(uuid.NewV4()).String(),
 			Namespace: namespace.Name,
 		},
 		Spec: appsv1.StatefulSetSpec{
@@ -215,12 +215,12 @@ func TestReleaseStaleAddresses(t *testing.T) {
 	}
 
 	staleSetOwner := crdv1b1.StatefulSetOwner{
-		Name:      uuid.New().String(),
+		Name:      uuid.Must(uuid.NewV4()).String(),
 		Namespace: namespace.Name,
 	}
 
 	stalePodOwner := crdv1b1.PodOwner{
-		Name:      uuid.New().String(),
+		Name:      uuid.Must(uuid.NewV4()).String(),
 		Namespace: namespace.Name,
 	}
 
@@ -260,7 +260,7 @@ func TestReleaseStaleAddresses(t *testing.T) {
 
 	terminatedPod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      uuid.New().String(),
+			Name:      uuid.Must(uuid.NewV4()).String(),
 			Namespace: namespace.Name,
 		},
 		Status: corev1.PodStatus{

--- a/pkg/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller.go
@@ -26,7 +26,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid/v5"
 	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -99,12 +99,11 @@ const (
 )
 
 var (
-	// uuidNamespace is a uuid.UUID type generated from a string to be
-	// used to generate uuid.UUID for internal Antrea objects like
-	// AppliedToGroup, AddressGroup etc.
-	// e4f24a48-ca1f-4d5b-819c-ea7632b22115 was generated using
-	// uuid.NewRandom() function.
-	uuidNamespace = uuid.Must(uuid.Parse("e4f24a48-ca1f-4d5b-819c-ea7632b22115"))
+	// uuidNamespace is a uuid.UUID used as the namespace for generating
+	// deterministic UUIDs for internal Antrea objects like AppliedToGroup,
+	// AddressGroup etc. e4f24a48-ca1f-4d5b-819c-ea7632b22115 was generated
+	// once using a random UUID generator.
+	uuidNamespace = uuid.Must(uuid.FromString("e4f24a48-ca1f-4d5b-819c-ea7632b22115"))
 
 	// matchAllPeer is a NetworkPolicyPeer matching all source/destination IP addresses. Both IPv4 Any (0.0.0.0/0) and
 	// IPv6 Any (::/0) are added into the IPBlocks, and Antrea Agent should decide if both two are used according the
@@ -619,7 +618,7 @@ func (n *NetworkPolicyController) GetConnectedAgentNum() int {
 // For example, it can be used to generate keys using normalized selectors
 // unique within the Namespace by adding the constant UID.
 func getNormalizedUID(name string) string {
-	return uuid.NewSHA1(uuidNamespace, []byte(name)).String()
+	return uuid.NewV5(uuidNamespace, name).String()
 }
 
 // createAppliedToGroup creates an AppliedToGroup object corresponding to the provided selectors.

--- a/pkg/controller/networkpolicy/networkpolicy_controller_perf_test.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller_perf_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid/v5"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -401,7 +401,7 @@ func newPod(namespace, name string, labels map[string]string) *corev1.Pod {
 	}
 	podIP := getRandomIP()
 	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name, UID: types.UID(uuid.New().String()), Labels: labels},
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name, UID: types.UID(uuid.Must(uuid.NewV4()).String()), Labels: labels},
 		Spec: corev1.PodSpec{
 			NodeName:    getRandomNodeName(),
 			HostNetwork: false,
@@ -416,7 +416,7 @@ func newExternalEntity(namespace, name string, labels map[string]string) *v1alph
 		name = "ee-" + rand.String(8)
 	}
 	externalEntity := &v1alpha2.ExternalEntity{
-		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name, UID: types.UID(uuid.New().String()), Labels: labels},
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name, UID: types.UID(uuid.Must(uuid.NewV4()).String()), Labels: labels},
 		Spec: v1alpha2.ExternalEntitySpec{
 			Endpoints: []v1alpha2.Endpoint{
 				{
@@ -439,7 +439,7 @@ func newNetworkPolicy(namespace, name string, podSelector, ingressPodSelector, i
 		name = "np-" + rand.String(8)
 	}
 	policy := &networkingv1.NetworkPolicy{
-		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name, UID: types.UID(uuid.New().String())},
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name, UID: types.UID(uuid.Must(uuid.NewV4()).String())},
 		Spec: networkingv1.NetworkPolicySpec{
 			PodSelector: metav1.LabelSelector{MatchLabels: podSelector},
 			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
@@ -473,7 +473,7 @@ func newANNPAppliedToExternalEntity(namespace, name string, externalEntitySelect
 		name = "annp-" + rand.String(8)
 	}
 	annp := &v1beta1.NetworkPolicy{
-		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name, UID: types.UID(uuid.New().String())},
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name, UID: types.UID(uuid.Must(uuid.NewV4()).String())},
 		Spec: v1beta1.NetworkPolicySpec{
 			AppliedTo: []v1beta1.AppliedTo{
 				{

--- a/pkg/flowaggregator/clickhouseclient/clickhouseclient_test.go
+++ b/pkg/flowaggregator/clickhouseclient/clickhouseclient_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -33,7 +33,7 @@ import (
 	flowaggregatortesting "antrea.io/antrea/pkg/flowaggregator/testing"
 )
 
-var fakeClusterUUID = uuid.New().String()
+var fakeClusterUUID = uuid.Must(uuid.NewV4()).String()
 
 func TestCacheRecord(t *testing.T) {
 	chExportProc := &ClickHouseExportProcess{

--- a/pkg/flowaggregator/cluster_uuid.go
+++ b/pkg/flowaggregator/cluster_uuid.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid/v5"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 

--- a/pkg/flowaggregator/exporter/clickhouse.go
+++ b/pkg/flowaggregator/exporter/clickhouse.go
@@ -22,7 +22,7 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid/v5"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 

--- a/pkg/flowaggregator/exporter/clickhouse_test.go
+++ b/pkg/flowaggregator/exporter/clickhouse_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -52,7 +52,7 @@ func TestClickHouse_UpdateOptions(t *testing.T) {
 		ClickHouseCommitInterval: 8 * time.Second,
 	}
 	chConfig := buildClickHouseConfig(opt)
-	chExportProcess, err := clickhouseclient.NewClickHouseClient(chConfig, uuid.New().String())
+	chExportProcess, err := clickhouseclient.NewClickHouseClient(chConfig, uuid.Must(uuid.NewV4()).String())
 	require.NoError(t, err)
 	clickHouseExporter := ClickHouseExporter{chConfig: &chConfig, chExportProcess: chExportProcess}
 	clickHouseExporter.Start()

--- a/pkg/flowaggregator/exporter/ipfix.go
+++ b/pkg/flowaggregator/exporter/ipfix.go
@@ -24,7 +24,7 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid/v5"
 	"github.com/spf13/afero"
 	ipfixentities "github.com/vmware/go-ipfix/pkg/entities"
 	"github.com/vmware/go-ipfix/pkg/exporter"
@@ -285,7 +285,7 @@ func (e *IPFIXExporter) makeIPFIXRecord(flow *flowpb.Flow, isIPv6 bool) ipfixent
 			next().SetOctetArrayValue(uuid.Nil[:])
 			return
 		}
-		v, err := uuid.Parse(uid)
+		v, err := uuid.FromString(uid)
 		if err != nil {
 			klog.ErrorS(err, "Error when parsing UID string", "uid", uid)
 			next().SetOctetArrayValue(uuid.Nil[:])

--- a/pkg/flowaggregator/exporter/ipfix_test.go
+++ b/pkg/flowaggregator/exporter/ipfix_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid/v5"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -486,7 +486,7 @@ func runTestTLSServer(t *testing.T, tlsConfig *tls.Config, recvCh chan<- []byte)
 }
 
 func TestInitExportingProcess(t *testing.T) {
-	clusterUUID := uuid.New()
+	clusterUUID := uuid.Must(uuid.NewV4())
 
 	t.Run("tcp success", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
@@ -637,7 +637,7 @@ func TestInitExportingProcess(t *testing.T) {
 }
 
 func TestNewIPFIXExporterObservationDomainID(t *testing.T) {
-	clusterUUID := uuid.New()
+	clusterUUID := uuid.Must(uuid.NewV4())
 	testCases := []struct {
 		name                        string
 		userObservationDomainID     *uint32
@@ -676,7 +676,7 @@ func TestInitExportingProcessWithBackoff(t *testing.T) {
 	defer func() {
 		initIPFIXExportingProcess = initIPFIXExportingProcessSaved
 	}()
-	clusterUUID := uuid.New()
+	clusterUUID := uuid.Must(uuid.NewV4())
 	opt := &options.Options{
 		AggregatorMode: flowaggregatorconfig.AggregatorModeProxy,
 		Config:         &flowaggregatorconfig.FlowAggregatorConfig{},

--- a/pkg/flowaggregator/exporter/s3.go
+++ b/pkg/flowaggregator/exporter/s3.go
@@ -15,7 +15,7 @@
 package exporter
 
 import (
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid/v5"
 	"k8s.io/klog/v2"
 
 	flowpb "antrea.io/antrea/pkg/apis/flow/v1alpha1"

--- a/pkg/flowaggregator/exporter/s3_test.go
+++ b/pkg/flowaggregator/exporter/s3_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -51,7 +51,7 @@ func TestS3_UpdateOptions(t *testing.T) {
 		S3UploadInterval: 8 * time.Second,
 	}
 	s3Input := buildS3Input(opt)
-	s3UploadProcess, err := s3uploader.NewS3UploadProcess(s3Input, uuid.New().String())
+	s3UploadProcess, err := s3uploader.NewS3UploadProcess(s3Input, uuid.Must(uuid.NewV4()).String())
 	require.NoError(t, err)
 	s3Exporter := S3Exporter{s3Input: &s3Input, s3UploadProcess: s3UploadProcess}
 	s3Exporter.Start()

--- a/pkg/flowaggregator/flowaggregator.go
+++ b/pkg/flowaggregator/flowaggregator.go
@@ -28,7 +28,7 @@ import (
 	"time"
 
 	"github.com/fsnotify/fsnotify"
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid/v5"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"

--- a/pkg/flowaggregator/flowaggregator_test.go
+++ b/pkg/flowaggregator/flowaggregator_test.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -1129,7 +1129,7 @@ func TestNewFlowAggregator(t *testing.T) {
 			mockPodStore := objectstoretest.NewMockPodStore(ctrl)
 			mockNodeStore := objectstoretest.NewMockNodeStore(ctrl)
 			mockServiceStore := objectstoretest.NewMockServiceStore(ctrl)
-			clusterUUID := uuid.New()
+			clusterUUID := uuid.Must(uuid.NewV4())
 			clusterID := tc.config.ClusterID
 			if clusterID == "" {
 				clusterID = clusterUUID.String()

--- a/pkg/flowaggregator/flowaggregator_test.go
+++ b/pkg/flowaggregator/flowaggregator_test.go
@@ -24,8 +24,8 @@ import (
 	"time"
 
 	"github.com/fsnotify/fsnotify"
-	"github.com/google/go-cmp/cmp"
 	"github.com/gofrs/uuid/v5"
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"

--- a/pkg/flowaggregator/s3uploader/s3uploader_test.go
+++ b/pkg/flowaggregator/s3uploader/s3uploader_test.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -34,7 +34,7 @@ import (
 
 var (
 	timestampStr    = fmt.Sprint(time.Now().Unix())
-	fakeClusterUUID = uuid.New().String()
+	fakeClusterUUID = uuid.Must(uuid.NewV4()).String()
 	recordStrIPv4   = "1637706961,1637706973,1637706974,1637706975,3,10.10.0.79,10.10.0.80,44752,5201,6,823188,30472817041,241333,8982624938,471111,24500996,136211,7083284,perftest-a,antrea-test,k8s-node-control-plane,perftest-b,antrea-test-b,k8s-node-control-plane-b,10.10.1.10,5202,perftest,test-flow-aggregator-networkpolicy-ingress-allow,antrea-test-ns,test-flow-aggregator-networkpolicy-rule,2,1,test-flow-aggregator-networkpolicy-egress-allow,antrea-test-ns-e,test-flow-aggregator-networkpolicy-rule-e,1,3,TIME_WAIT,2,'{\"antrea-e2e\":\"perftest-a\",\"app\":\"iperf\"}','{\"antrea-e2e\":\"perftest-b\",\"app\":\"iperf\"}',15902813472,12381344,15902813473,15902813474,12381345,12381346," + fakeClusterUUID + "," + timestampStr + ",test-egress,172.18.0.1,test-egress-node"
 	recordStrIPv6   = "1637706961,1637706973,1637706974,1637706975,3,2001:0:3238:dfe1:63::fefb,2001:0:3238:dfe1:63::fefc,44752,5201,6,823188,30472817041,241333,8982624938,471111,24500996,136211,7083284,perftest-a,antrea-test,k8s-node-control-plane,perftest-b,antrea-test-b,k8s-node-control-plane-b,2001:0:3238:dfe1:64::a,5202,perftest,test-flow-aggregator-networkpolicy-ingress-allow,antrea-test-ns,test-flow-aggregator-networkpolicy-rule,2,1,test-flow-aggregator-networkpolicy-egress-allow,antrea-test-ns-e,test-flow-aggregator-networkpolicy-rule-e,1,3,TIME_WAIT,2,'{\"antrea-e2e\":\"perftest-a\",\"app\":\"iperf\"}','{\"antrea-e2e\":\"perftest-b\",\"app\":\"iperf\"}',15902813472,12381344,15902813473,15902813474,12381345,12381346," + fakeClusterUUID + "," + timestampStr + ",test-egress,2001:0:3238:dfe1::ac12:1,test-egress-node"
 )

--- a/pkg/ipam/poolallocator/allocator_test.go
+++ b/pkg/ipam/poolallocator/allocator_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -43,7 +43,7 @@ var fakePodOwner = crdv1b1.IPAddressOwner{
 	Pod: &crdv1b1.PodOwner{
 		Name:        "fakePod",
 		Namespace:   testNamespace,
-		ContainerID: uuid.New().String(),
+		ContainerID: uuid.Must(uuid.NewV4()).String(),
 	},
 }
 
@@ -80,7 +80,7 @@ func validateAllocationSequence(t *testing.T, allocator *IPPoolAllocator, subnet
 			Pod: &crdv1b1.PodOwner{
 				Name:        fmt.Sprintf("fakePod%d", i),
 				Namespace:   testNamespace,
-				ContainerID: uuid.New().String(),
+				ContainerID: uuid.Must(uuid.NewV4()).String(),
 			},
 		}
 		ip, returnInfo, err := allocator.AllocateNext(crdv1b1.IPAddressPhaseAllocated, owner)
@@ -95,7 +95,7 @@ func TestAllocateIP(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	poolName := uuid.New().String()
+	poolName := uuid.Must(uuid.NewV4()).String()
 	ipRange := crdv1b1.IPRange{
 		Start: "10.2.2.100",
 		End:   "10.2.2.120",
@@ -172,7 +172,7 @@ func TestConcurrentAllocateNextSharedIPPool(t *testing.T) {
 	// concurrent status writers; keep headroom in the range.
 	const concurrency = 36
 
-	poolName := uuid.New().String()
+	poolName := uuid.Must(uuid.NewV4()).String()
 	ipRange := crdv1b1.IPRange{
 		Start: "10.2.2.10",
 		End:   "10.2.2.99", // 90 addresses
@@ -203,7 +203,7 @@ func TestConcurrentAllocateNextSharedIPPool(t *testing.T) {
 				Pod: &crdv1b1.PodOwner{
 					Name:        fmt.Sprintf("concurrent-pod-%d", idx),
 					Namespace:   testNamespace,
-					ContainerID: uuid.New().String(),
+					ContainerID: uuid.Must(uuid.NewV4()).String(),
 					IFName:      "net1",
 				},
 			}
@@ -238,7 +238,7 @@ func TestAllocateNextMultiRange(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	poolName := uuid.New().String()
+	poolName := uuid.Must(uuid.NewV4()).String()
 	ipRange1 := crdv1b1.IPRange{
 		Start: "10.2.2.100",
 		End:   "10.2.2.101",
@@ -267,7 +267,7 @@ func TestAllocateNextMultiRangeExhausted(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	poolName := uuid.New().String()
+	poolName := uuid.Must(uuid.NewV4()).String()
 	ipRange1 := crdv1b1.IPRange{
 		Start: "10.2.2.100",
 		End:   "10.2.2.101",
@@ -303,7 +303,7 @@ func TestAllocateReleaseSequence(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	poolName := uuid.New().String()
+	poolName := uuid.Must(uuid.NewV4()).String()
 	ipRange1 := crdv1b1.IPRange{
 		Start: "2001::1000",
 		End:   "2001::1000",
@@ -368,7 +368,7 @@ func TestReleaseResource(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	poolName := uuid.New().String()
+	poolName := uuid.Must(uuid.NewV4()).String()
 	ipRange1 := crdv1b1.IPRange{
 		Start: "2001::1000",
 		End:   "2001::1000",
@@ -414,7 +414,7 @@ func TestHas(t *testing.T) {
 			IFName:      "eth1",
 		},
 	}
-	poolName := uuid.New().String()
+	poolName := uuid.Must(uuid.NewV4()).String()
 	ipRange1 := crdv1b1.IPRange{
 		Start: "2001::1000",
 		End:   "2001::1000",
@@ -459,7 +459,7 @@ func TestAllocateReleaseStatefulSet(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	poolName := uuid.New().String()
+	poolName := uuid.Must(uuid.NewV4()).String()
 	setName := "fakeSet"
 	ipRange := crdv1b1.IPRange{
 		Start: "10.2.2.100",

--- a/pkg/ipam/poolallocator/testing/fake_client.go
+++ b/pkg/ipam/poolallocator/testing/fake_client.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"sync"
 
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid/v5"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -60,7 +60,7 @@ func NewIPPoolClient() *IPPoolClientset {
 	// detection, then let the tracker handle the actual storage and watch event.
 	crdClient.PrependReactor("create", "ippools", func(action k8stesting.Action) (bool, runtime.Object, error) {
 		pool := action.(k8stesting.CreateAction).GetObject().(*crdv1b1.IPPool)
-		pool.ResourceVersion = uuid.New().String()
+		pool.ResourceVersion = uuid.Must(uuid.NewV4()).String()
 		crdClient.poolVersion.Store(pool.Name, pool.ResourceVersion)
 		return false, pool, nil
 	})
@@ -76,7 +76,7 @@ func NewIPPoolClient() *IPPoolClientset {
 		if obj.(string) != updatedPool.ResourceVersion {
 			return true, nil, &errors.StatusError{ErrStatus: metav1.Status{Reason: metav1.StatusReasonConflict, Message: "pool status update conflict"}}
 		}
-		updatedPool.ResourceVersion = uuid.New().String()
+		updatedPool.ResourceVersion = uuid.Must(uuid.NewV4()).String()
 		crdClient.poolVersion.Store(updatedPool.Name, updatedPool.ResourceVersion)
 		return false, updatedPool, nil
 	})

--- a/pkg/util/objectstore/podstore_test.go
+++ b/pkg/util/objectstore/podstore_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -324,7 +324,7 @@ func addPods(number int, k8sClient kubernetes.Interface) ([]*corev1.Pod, error) 
 
 func generatePod() *corev1.Pod {
 	ip := getRandomIP()
-	uid := uuid.New().String()
+	uid := uuid.Must(uuid.NewV4()).String()
 	startTime := rand.Intn(360000000)
 	creationTime := refTime.Add(time.Duration(startTime))
 	deletionTime := creationTime.Add(time.Hour)

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"

--- a/test/e2e/flowaggregator_test.go
+++ b/test/e2e/flowaggregator_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	ipfixregistry "github.com/vmware/go-ipfix/pkg/registry"
@@ -380,7 +380,7 @@ func getPodUID(t *testing.T, data *TestData, namespace, name string) string {
 }
 
 func k8sUIDAsHexString(uid string) string {
-	v := uuid.MustParse(uid)
+	v := uuid.Must(uuid.FromString(uid))
 	return hex.EncodeToString(v[:])
 }
 

--- a/test/e2e/framework.go
+++ b/test/e2e/framework.go
@@ -35,7 +35,7 @@ import (
 	"time"
 
 	"github.com/containernetworking/plugins/pkg/ip"
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid/v5"
 	log "github.com/sirupsen/logrus"
 	"go.yaml.in/yaml/v3"
 	appsv1 "k8s.io/api/apps/v1"

--- a/test/integration/agent/cniserver_test.go
+++ b/test/integration/agent/cniserver_test.go
@@ -36,7 +36,7 @@ import (
 	"github.com/containernetworking/plugins/pkg/testutils"
 	"github.com/containernetworking/plugins/plugins/ipam/host-local/backend/allocator"
 	"github.com/containernetworking/plugins/plugins/ipam/host-local/backend/disk"
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid/v5"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -614,7 +614,7 @@ func cmdAddDelCheckTest(testNS ns.NetNS, tc testCase, dataDir string) {
 
 	// Mock ovs output while get ovs port external configuration
 	ovsPortname := util.GenerateContainerInterfaceName(testPod, testPodNamespace, ContainerID)
-	ovsPortUUID := uuid.New().String()
+	ovsPortUUID := uuid.Must(uuid.NewV4()).String()
 	ovsServiceMock.EXPECT().CreatePort(ovsPortname, ovsPortname, mock.Any()).Return(ovsPortUUID, nil).AnyTimes()
 	ovsServiceMock.EXPECT().GetOFPort(ovsPortname, false).Return(int32(10), nil).AnyTimes()
 	ofServiceMock.EXPECT().InstallPodFlows(ovsPortname, mock.Any(), mock.Any(), mock.Any(), uint16(0), nil).Return(nil)
@@ -824,7 +824,7 @@ func TestCNIServerChaining(t *testing.T) {
 
 		// test cmdAdd
 		ovsPortname := hostVeth.Name
-		ovsPortUUID := uuid.New().String()
+		ovsPortUUID := uuid.Must(uuid.NewV4()).String()
 		podIP, _, err := net.ParseCIDR(tc.Subnet)
 		testRequire.Nil(err)
 		containerIntf, err := util.GetNSDevInterface(netNS.Path(), IFName)


### PR DESCRIPTION
Cherry pick of #8055 on release-2.6.

#8055: Migrate UUID library from google/uuid to gofrs/uuid/v5

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.