### PR TITLE
Fix e2e test DeleteACNP to ignore NotFound errors

### DIFF
--- a/test/e2e/k8s_util.go
+++ b/test/e2e/k8s_util.go
@@ -925,7 +925,11 @@ func (data *TestData) GetACNP(name string) (*crdv1beta1.ClusterNetworkPolicy, er
 // DeleteACNP is a convenience function for deleting ACNP by name.
 func (data *TestData) DeleteACNP(name string) error {
 	log.Infof("Deleting AntreaClusterNetworkPolicies %s", name)
-	return data.CRDClient.CrdV1beta1().ClusterNetworkPolicies().Delete(context.TODO(), name, metav1.DeleteOptions{})
+	err := data.CRDClient.CrdV1beta1().ClusterNetworkPolicies().Delete(context.TODO(), name, metav1.DeleteOptions{})
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	return err
 }
 
 // CleanACNPs is a convenience function for deleting all Antrea ClusterNetworkPolicies in the cluster.


### PR DESCRIPTION
When a test fails abruptly, the e2e framework still attempts to clean up
all tracked resources. If an ACNP was never created or was already deleted
in an earlier step, `DeleteACNP` returns a `NotFound` error.
Because `DeleteACNP` is wrapped in `failOnError`, this single `NotFound`
error crashes the entire cleanup loop. This leaves dangling resources in
the cluster, which causes subsequent, unrelated tests to fail.
This patch updates `DeleteACNP` to gracefully ignore `NotFound` errors,
making the teardown process idempotent and preventing cascading test failures.
