### PR TITLE
Automated cherry pick of #8090: Fix WireGuard Traceflow tunnel destination (#8090)

### DIFF
--- a/pkg/agent/controller/noderoute/node_route_controller.go
+++ b/pkg/agent/controller/noderoute/node_route_controller.go
@@ -846,6 +846,26 @@ func (c *Controller) LookupIPInPodSubnets(ip netip.Addr) (bool, bool) {
 	return ok, ip == util.GetGatewayIPForPodPrefix(prefix)
 }
 
+// GetNodeIPForPodIP returns the transport IP of the remote Node whose PodCIDR contains the IP.
+func (c *Controller) GetNodeIPForPodIP(ip netip.Addr) (net.IP, bool) {
+	prefix, ok := c.findPodSubnetForIP(ip)
+	if !ok {
+		return nil, false
+	}
+	nodeRouteInfos, err := c.installedNodes.ByIndex(nodeRouteInfoPodCIDRIndexName, prefix.String())
+	if err != nil || len(nodeRouteInfos) != 1 {
+		return nil, false
+	}
+	nodeIPs := nodeRouteInfos[0].(*nodeRouteInfo).nodeIPs
+	if ip.Is4() && nodeIPs.IPv4 != nil {
+		return nodeIPs.IPv4, true
+	}
+	if ip.Is6() && nodeIPs.IPv6 != nil {
+		return nodeIPs.IPv6, true
+	}
+	return nil, false
+}
+
 // getNodeMAC gets Node's br-int MAC from its annotation. It is only for Windows Noencap mode.
 func getNodeMAC(node *corev1.Node) (net.HardwareAddr, error) {
 	macStr := node.Annotations[types.NodeMACAddressAnnotationKey]

--- a/pkg/agent/controller/noderoute/node_route_controller_test.go
+++ b/pkg/agent/controller/noderoute/node_route_controller_test.go
@@ -266,6 +266,61 @@ func TestLookupIPInPodSubnets(t *testing.T) {
 	}
 }
 
+func TestGetNodeIPForPodIP(t *testing.T) {
+	c := newController(t, &config.NetworkConfig{})
+	defer c.queue.ShutDown()
+
+	nodeIPv6 := net.ParseIP("2001:db8::10")
+	require.NoError(t, c.installedNodes.Add(&nodeRouteInfo{
+		nodeName: "node1",
+		podCIDRs: []*net.IPNet{podCIDR1, podCIDR1v6},
+		nodeIPs: &utilip.DualStackIPs{
+			IPv4: nodeIP1,
+			IPv6: nodeIPv6,
+		},
+	}))
+	for _, podCIDR := range []*net.IPNet{podCIDR1, podCIDR1v6} {
+		prefix, _ := cidrToPrefix(podCIDR)
+		c.podSubnets.Insert(prefix)
+	}
+
+	testCases := []struct {
+		name       string
+		podIP      string
+		expectedIP net.IP
+		found      bool
+	}{
+		{
+			name:       "remote IPv4 Pod",
+			podIP:      "1.1.1.101",
+			expectedIP: nodeIP1,
+			found:      true,
+		},
+		{
+			name:       "remote IPv6 Pod",
+			podIP:      "2001:4860:0001::101",
+			expectedIP: nodeIPv6,
+			found:      true,
+		},
+		{
+			name:  "local Pod",
+			podIP: "1.1.0.101",
+		},
+		{
+			name:  "unknown IP",
+			podIP: "1.1.10.101",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			nodeIP, found := c.Controller.GetNodeIPForPodIP(netip.MustParseAddr(tc.podIP))
+			assert.Equal(t, tc.found, found)
+			assert.Equal(t, tc.expectedIP, nodeIP)
+		})
+	}
+}
+
 func BenchmarkLookupIPInPodSubnets(b *testing.B) {
 	c := newController(b, &config.NetworkConfig{})
 	defer c.queue.ShutDown()

--- a/pkg/agent/controller/traceflow/packetin.go
+++ b/pkg/agent/controller/traceflow/packetin.go
@@ -349,14 +349,20 @@ func (c *Controller) parsePacketIn(pktIn *ofctrl.PacketIn) (*crdv1beta1.Traceflo
 			}
 
 			ob.Action = crdv1beta1.ActionForwardedOutOfNetwork
-			// In hybrid mode or WireGuard mode, packets to Pod IPs in the same subnet are forwarded
-			// directly without encapsulation. Check if the destination is a Pod IP to determine
-			// the correct action (Forwarded vs ForwardedOutOfNetwork).
-			if (c.networkConfig.TrafficEncapMode == config.TrafficEncapModeHybrid || c.networkConfig.TrafficEncryptionMode == config.TrafficEncryptionModeWireGuard) && c.podSubnetChecker != nil {
-				netAddrDst, _ := netip.AddrFromSlice(netIPDst)
-				isPodIP, _ := c.podSubnetChecker.LookupIPInPodSubnets(netAddrDst)
-				if isPodIP {
-					ob.Action = crdv1beta1.ActionForwarded
+			netAddrDst, isValidIP := netip.AddrFromSlice(netIPDst)
+			if pktMark == 0 && isValidIP && c.nodeRouteQuerier != nil {
+				if c.networkConfig.TrafficEncryptionMode == config.TrafficEncryptionModeWireGuard {
+					// WireGuard sends cross-Node Pod traffic through the gateway port. Resolve the destination Pod IP
+					// through NodeRoute to distinguish it from traffic leaving the cluster and report the peer Node IP.
+					if peerNodeIP, ok := c.nodeRouteQuerier.GetNodeIPForPodIP(netAddrDst); ok {
+						ob.Action = crdv1beta1.ActionForwarded
+						ob.TunnelDstIP = peerNodeIP.String()
+					}
+				} else if c.networkConfig.TrafficEncapMode == config.TrafficEncapModeHybrid {
+					isPodIP, _ := c.nodeRouteQuerier.LookupIPInPodSubnets(netAddrDst)
+					if isPodIP {
+						ob.Action = crdv1beta1.ActionForwarded
+					}
 				}
 			}
 		} else if c.networkConfig.TrafficEncapMode == config.TrafficEncapModeNetworkPolicyOnly && outputPort == gwPort { // networkPolicyOnly
@@ -375,9 +381,9 @@ func (c *Controller) parsePacketIn(pktIn *ofctrl.PacketIn) (*crdv1beta1.Traceflo
 		} else if c.networkConfig.TrafficEncapMode == config.TrafficEncapModeNoEncap && outputPort == gwPort { // noEncap
 			// TODO: update this and above case if noEncap mode supports Egress feature
 			isPodIP := false
-			if c.podSubnetChecker != nil {
+			if c.nodeRouteQuerier != nil {
 				netAddrDst, _ := netip.AddrFromSlice(netIPDst)
-				isPodIP, _ = c.podSubnetChecker.LookupIPInPodSubnets(netAddrDst)
+				isPodIP, _ = c.nodeRouteQuerier.LookupIPInPodSubnets(netAddrDst)
 			}
 			if isPodIP {
 				ob.Action = crdv1beta1.ActionForwarded

--- a/pkg/agent/controller/traceflow/packetin_test.go
+++ b/pkg/agent/controller/traceflow/packetin_test.go
@@ -274,6 +274,7 @@ func TestParsePacketIn(t *testing.T) {
 
 	pktBytesPodToIP := getTestPacketBytes(dstIPv4)
 	pktBytesPodToPod := getTestPacketBytes(pod2IPv4)
+	peerNodeIP := "192.168.77.77"
 
 	tests := []struct {
 		name               string
@@ -428,6 +429,79 @@ func TestParsePacketIn(t *testing.T) {
 						ComponentInfo: openflow.OutputTable.GetName(),
 						Action:        crdv1beta1.ActionForwarded,
 						TunnelDstIP:   egressIP,
+					},
+				},
+			},
+		},
+		{
+			name: "marked packet to remote Pod in hybrid mode",
+			networkConfig: &config.NetworkConfig{
+				TrafficEncapMode: config.TrafficEncapModeHybrid,
+			},
+			nodeConfig: &config.NodeConfig{
+				TunnelOFPort: 1,
+				GatewayConfig: &config.GatewayConfig{
+					OFPort: 2,
+				},
+			},
+			tfState: &traceflowState{
+				name:     "traceflow-pod-to-pod",
+				tag:      1,
+				isSender: true,
+			},
+			pktIn: &ofctrl.PacketIn{
+				PacketIn: &openflow15.PacketIn{
+					TableId: openflow.OutputTable.GetID(),
+					Match: openflow15.Match{
+						Fields: []openflow15.MatchField{*matchOutPort, *matchPktMark, *matchCTSrc},
+					},
+					Data: util.NewBuffer(pktBytesPodToPod),
+				},
+			},
+			expectedCalls: func(npQuerierq *queriertest.MockAgentNetworkPolicyInfoQuerier, egressQuerier *queriertest.MockEgressQuerier) {
+				egressQuerier.EXPECT().GetEgress(pod1.Namespace, pod1.Name).Return(types.EgressConfig{
+					Name:       egressName,
+					EgressIP:   egressIP,
+					EgressNode: egressNode,
+				}, nil)
+			},
+			expectedTf: &crdv1beta1.Traceflow{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "traceflow-pod-to-pod",
+				},
+				Spec: crdv1beta1.TraceflowSpec{
+					Source: crdv1beta1.Source{
+						Namespace: pod1.Namespace,
+						Pod:       pod1.Name,
+					},
+					Destination: crdv1beta1.Destination{
+						Namespace: pod2.Namespace,
+						Pod:       pod2.Name,
+					},
+				},
+				Status: crdv1beta1.TraceflowStatus{
+					Phase:        crdv1beta1.Running,
+					DataplaneTag: 1,
+				},
+			},
+			expectedNodeResult: &crdv1beta1.NodeResult{
+				Observations: []crdv1beta1.Observation{
+					{
+						Component: crdv1beta1.ComponentSpoofGuard,
+						Action:    crdv1beta1.ActionForwarded,
+						SrcPodIP:  pod1IPv4,
+					},
+					{
+						Component:  crdv1beta1.ComponentEgress,
+						Action:     crdv1beta1.ActionMarkedForSNAT,
+						Egress:     egressName,
+						EgressIP:   egressIP,
+						EgressNode: egressNode,
+					},
+					{
+						Component:     crdv1beta1.ComponentForwarding,
+						ComponentInfo: openflow.OutputTable.GetName(),
+						Action:        crdv1beta1.ActionForwardedOutOfNetwork,
 					},
 				},
 			},
@@ -686,6 +760,130 @@ func TestParsePacketIn(t *testing.T) {
 						Action:            crdv1beta1.ActionDropped,
 						NetworkPolicy:     string(v1beta2.AntreaClusterNetworkPolicy) + ":acnp-3",
 						NetworkPolicyRule: "egress-drop-rule",
+					},
+				},
+			},
+		},
+		{
+			name: "packet at source Node to remote Pod with WireGuard",
+			networkConfig: &config.NetworkConfig{
+				TrafficEncapMode:      config.TrafficEncapModeEncap,
+				TrafficEncryptionMode: config.TrafficEncryptionModeWireGuard,
+			},
+			nodeConfig: &config.NodeConfig{
+				TunnelOFPort: 1,
+				GatewayConfig: &config.GatewayConfig{
+					OFPort: 2,
+				},
+			},
+			tfState: &traceflowState{
+				name:     "traceflow-pod-to-pod",
+				tag:      1,
+				isSender: true,
+			},
+			pktIn: &ofctrl.PacketIn{
+				PacketIn: &openflow15.PacketIn{
+					TableId: openflow.OutputTable.GetID(),
+					Match: openflow15.Match{
+						Fields: []openflow15.MatchField{*matchOutPort, *matchCTSrc},
+					},
+					Data: util.NewBuffer(pktBytesPodToPod),
+				},
+			},
+			expectedCalls: func(npQuerierq *queriertest.MockAgentNetworkPolicyInfoQuerier, egressQuerier *queriertest.MockEgressQuerier) {
+			},
+			expectedTf: &crdv1beta1.Traceflow{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "traceflow-pod-to-pod",
+				},
+				Spec: crdv1beta1.TraceflowSpec{
+					Source: crdv1beta1.Source{
+						Namespace: pod1.Namespace,
+						Pod:       pod1.Name,
+					},
+					Destination: crdv1beta1.Destination{
+						Namespace: pod2.Namespace,
+						Pod:       pod2.Name,
+					},
+				},
+				Status: crdv1beta1.TraceflowStatus{
+					Phase:        crdv1beta1.Running,
+					DataplaneTag: 1,
+				},
+			},
+			expectedNodeResult: &crdv1beta1.NodeResult{
+				Observations: []crdv1beta1.Observation{
+					{
+						Component: crdv1beta1.ComponentSpoofGuard,
+						Action:    crdv1beta1.ActionForwarded,
+						SrcPodIP:  pod1IPv4,
+					},
+					{
+						Component:     crdv1beta1.ComponentForwarding,
+						ComponentInfo: openflow.OutputTable.GetName(),
+						Action:        crdv1beta1.ActionForwarded,
+						TunnelDstIP:   peerNodeIP,
+					},
+				},
+			},
+		},
+		{
+			name: "packet at source Node to external with WireGuard",
+			networkConfig: &config.NetworkConfig{
+				TrafficEncapMode:      config.TrafficEncapModeEncap,
+				TrafficEncryptionMode: config.TrafficEncryptionModeWireGuard,
+			},
+			nodeConfig: &config.NodeConfig{
+				TunnelOFPort: 1,
+				GatewayConfig: &config.GatewayConfig{
+					OFPort: 2,
+				},
+			},
+			tfState: &traceflowState{
+				name:     "traceflow-pod-to-ipv4",
+				tag:      1,
+				isSender: true,
+			},
+			pktIn: &ofctrl.PacketIn{
+				PacketIn: &openflow15.PacketIn{
+					TableId: openflow.OutputTable.GetID(),
+					Match: openflow15.Match{
+						Fields: []openflow15.MatchField{*matchOutPort, *matchCTSrc},
+					},
+					Data: util.NewBuffer(pktBytesPodToIP),
+				},
+			},
+			expectedCalls: func(npQuerierq *queriertest.MockAgentNetworkPolicyInfoQuerier, egressQuerier *queriertest.MockEgressQuerier) {
+			},
+			expectedTf: &crdv1beta1.Traceflow{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "traceflow-pod-to-ipv4",
+				},
+				Spec: crdv1beta1.TraceflowSpec{
+					Source: crdv1beta1.Source{
+						Namespace: pod1.Namespace,
+						Pod:       pod1.Name,
+					},
+					Destination: crdv1beta1.Destination{
+						IP: dstIPv4,
+					},
+				},
+				Status: crdv1beta1.TraceflowStatus{
+					Phase:        crdv1beta1.Running,
+					DataplaneTag: 1,
+				},
+			},
+			expectedNodeResult: &crdv1beta1.NodeResult{
+				Observations: []crdv1beta1.Observation{
+					{
+						Component: crdv1beta1.ComponentSpoofGuard,
+						Action:    crdv1beta1.ActionForwarded,
+						SrcPodIP:  pod1IPv4,
+					},
+					{
+						Component:     crdv1beta1.ComponentForwarding,
+						ComponentInfo: openflow.OutputTable.GetName(),
+						Action:        crdv1beta1.ActionForwardedOutOfNetwork,
 					},
 				},
 			},

--- a/pkg/agent/controller/traceflow/traceflow_controller.go
+++ b/pkg/agent/controller/traceflow/traceflow_controller.go
@@ -98,7 +98,7 @@ type Controller struct {
 	ofClient               openflow.Client
 	networkPolicyQuerier   querier.AgentNetworkPolicyInfoQuerier
 	egressQuerier          querier.EgressQuerier
-	podSubnetChecker       PodSubnetChecker
+	nodeRouteQuerier       NodeRouteQuerier
 	interfaceStore         interfacestore.InterfaceStore
 	networkConfig          *config.NetworkConfig
 	nodeConfig             *config.NodeConfig
@@ -122,7 +122,7 @@ func NewTraceflowController(
 	client openflow.Client,
 	npQuerier querier.AgentNetworkPolicyInfoQuerier,
 	egressQuerier querier.EgressQuerier,
-	podSubnetChecker PodSubnetChecker,
+	nodeRouteQuerier NodeRouteQuerier,
 	interfaceStore interfacestore.InterfaceStore,
 	networkConfig *config.NetworkConfig,
 	nodeConfig *config.NodeConfig,
@@ -138,7 +138,7 @@ func NewTraceflowController(
 		ofClient:              client,
 		networkPolicyQuerier:  npQuerier,
 		egressQuerier:         egressQuerier,
-		podSubnetChecker:      podSubnetChecker,
+		nodeRouteQuerier:      nodeRouteQuerier,
 		interfaceStore:        interfaceStore,
 		networkConfig:         networkConfig,
 		nodeConfig:            nodeConfig,
@@ -615,9 +615,12 @@ func (c *Controller) cleanupTraceflow(tfName string) {
 	}
 }
 
-type PodSubnetChecker interface {
+// NodeRouteQuerier provides PodCIDR and peer Node information to Traceflow.
+type NodeRouteQuerier interface {
 	// LookupIPInPodSubnets returns two boolean values. The first one indicates whether the IP can be
 	// found in a PodCIDR for one of the cluster Nodes. The second one indicates whether the IP is used
 	// as a gateway IP. The second boolean value can only be true if the first one is true.
 	LookupIPInPodSubnets(ip netip.Addr) (isFound bool, isGWIP bool)
+	// GetNodeIPForPodIP returns the transport IP of the remote Node whose PodCIDR contains the IP.
+	GetNodeIPForPodIP(ip netip.Addr) (net.IP, bool)
 }

--- a/pkg/agent/controller/traceflow/traceflow_controller_test.go
+++ b/pkg/agent/controller/traceflow/traceflow_controller_test.go
@@ -103,10 +103,17 @@ var (
 	}
 )
 
-type fakePodSubnetChecker struct{}
+type fakeNodeRouteQuerier struct{}
 
-func (f *fakePodSubnetChecker) LookupIPInPodSubnets(ip netip.Addr) (bool, bool) {
+func (f *fakeNodeRouteQuerier) LookupIPInPodSubnets(ip netip.Addr) (bool, bool) {
 	return podCIDR1IPv4.Contains(ip) || podCIDR2IPv4.Contains(ip), false
+}
+
+func (f *fakeNodeRouteQuerier) GetNodeIPForPodIP(ip netip.Addr) (net.IP, bool) {
+	if podCIDR2IPv4.Contains(ip) {
+		return net.ParseIP("192.168.77.77"), true
+	}
+	return nil, false
 }
 
 type fakeTraceflowController struct {
@@ -150,7 +157,7 @@ func newFakeTraceflowController(t *testing.T, initObjects []runtime.Object, netw
 		ofClient:              mockOFClient,
 		networkPolicyQuerier:  npQuerier,
 		egressQuerier:         egressQuerier,
-		podSubnetChecker:      &fakePodSubnetChecker{},
+		nodeRouteQuerier:      &fakeNodeRouteQuerier{},
 		interfaceStore:        ifaceStore,
 		networkConfig:         networkConfig,
 		nodeConfig:            nodeConfig,


### PR DESCRIPTION
Cherry pick of #8090 on release-2.6.

#8090: Fix WireGuard Traceflow tunnel destination (#8090)

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.