### PR TITLE
agent: fix socket leak in NPL AddRule when iptables rule installation fails

### DIFF
--- a/pkg/agent/nodeportlocal/portcache/port_table_others.go
+++ b/pkg/agent/nodeportlocal/portcache/port_table_others.go
@@ -95,8 +95,6 @@ func (pt *PortTable) AddRule(podKey string, podPort int, protocol string, podIP 
 			if closeErr := protocolData.socket.Close(); closeErr != nil {
 				klog.ErrorS(closeErr, "Failed to close local port after iptables rule addition failure",
 					"port", nodePort, "protocol", protocol)
-			} else {
-				protocolData.socket = nil
 			}
 			return 0, err
 		}

--- a/pkg/agent/nodeportlocal/portcache/port_table_others.go
+++ b/pkg/agent/nodeportlocal/portcache/port_table_others.go
@@ -96,6 +96,7 @@ func (pt *PortTable) AddRule(podKey string, podPort int, protocol string, podIP 
 				klog.ErrorS(closeErr, "Failed to close local port after iptables rule addition failure",
 					"port", nodePort, "protocol", protocol)
 			}
+			protocolData.socket = nil
 			return 0, err
 		}
 		pt.addPortTableCache(npData)

--- a/pkg/agent/nodeportlocal/portcache/port_table_others.go
+++ b/pkg/agent/nodeportlocal/portcache/port_table_others.go
@@ -92,6 +92,10 @@ func (pt *PortTable) AddRule(podKey string, podPort int, protocol string, podIP 
 		}
 		nodePort = npData.NodePort
 		if err := pt.PodPortRules.AddRule(nodePort, podIP, podPort, protocol); err != nil {
+			if closeErr := protocolData.socket.Close(); closeErr != nil {
+				klog.ErrorS(closeErr, "Failed to close local port after iptables rule addition failure",
+					"port", nodePort, "protocol", protocol)
+			}
 			return 0, err
 		}
 		pt.addPortTableCache(npData)

--- a/pkg/agent/nodeportlocal/portcache/port_table_others.go
+++ b/pkg/agent/nodeportlocal/portcache/port_table_others.go
@@ -95,8 +95,9 @@ func (pt *PortTable) AddRule(podKey string, podPort int, protocol string, podIP 
 			if closeErr := protocolData.socket.Close(); closeErr != nil {
 				klog.ErrorS(closeErr, "Failed to close local port after iptables rule addition failure",
 					"port", nodePort, "protocol", protocol)
+			} else {
+				protocolData.socket = nil
 			}
-			protocolData.socket = nil
 			return 0, err
 		}
 		pt.addPortTableCache(npData)

--- a/pkg/agent/nodeportlocal/portcache/port_table_others_test.go
+++ b/pkg/agent/nodeportlocal/portcache/port_table_others_test.go
@@ -193,6 +193,24 @@ func TestAddRule(t *testing.T) {
 			assert.Empty(t, portTable.PortTableCache.List())
 		})
 
+		t.Run("iptables error with socket close error", func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			mockIPTables := rulestesting.NewMockPodPortRules(mockCtrl)
+			mockPortOpener := portcachetesting.NewMockLocalPortOpener(mockCtrl)
+			portTable := newPortTable(mockIPTables, mockPortOpener, isIPv6)
+
+			closer := &mockCloser{closeErr: fmt.Errorf("socket close error")}
+			mockPortOpener.EXPECT().OpenLocalPort(startPort, protocol, isIPv6).Return(closer, nil)
+			mockIPTables.EXPECT().AddRule(startPort, podIP, podPort, protocol).
+				Return(fmt.Errorf("iptables error"))
+
+			_, err := portTable.AddRule(podKey, podPort, protocol, podIP)
+			// Ensure it still returns the original iptables error.
+			require.ErrorContains(t, err, "iptables error")
+			assert.True(t, closer.closed)
+			assert.Empty(t, portTable.PortTableCache.List())
+		})
+
 		t.Run("duplicate entry", func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
 			mockIPTables := rulestesting.NewMockPodPortRules(mockCtrl)

--- a/pkg/agent/nodeportlocal/portcache/port_table_others_test.go
+++ b/pkg/agent/nodeportlocal/portcache/port_table_others_test.go
@@ -84,10 +84,12 @@ func TestRestoreRules(t *testing.T) {
 }
 
 type mockCloser struct {
+	closed   bool
 	closeErr error
 }
 
 func (m *mockCloser) Close() error {
+	m.closed = true
 	return m.closeErr
 }
 
@@ -138,6 +140,78 @@ func TestDeleteRule(t *testing.T) {
 		assert.NoError(t, portTable.DeleteRule(podKey, podPort, protocol))
 	}
 
+	t.Run("IPv4", func(t *testing.T) { runTest(t, false) })
+	t.Run("IPv6", func(t *testing.T) { runTest(t, true) })
+}
+
+func TestAddRule(t *testing.T) {
+	runTest := func(t *testing.T, isIPv6 bool) {
+		const (
+			podPort  = 1001
+			protocol = "tcp"
+		)
+
+		t.Run("success", func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			mockIPTables := rulestesting.NewMockPodPortRules(mockCtrl)
+			mockPortOpener := portcachetesting.NewMockLocalPortOpener(mockCtrl)
+			portTable := newPortTable(mockIPTables, mockPortOpener, isIPv6)
+
+			closer := &mockCloser{}
+			mockPortOpener.EXPECT().OpenLocalPort(startPort, protocol, isIPv6).Return(closer, nil)
+			mockIPTables.EXPECT().AddRule(startPort, podIP, podPort, protocol).Return(nil)
+
+			gotPort, err := portTable.AddRule(podKey, podPort, protocol, podIP)
+			require.NoError(t, err)
+			assert.Equal(t, startPort, gotPort)
+			// Socket must NOT be closed on success - it is kept open to hold the port.
+			assert.False(t, closer.closed)
+			// Entry must be in the cache.
+			assert.Len(t, portTable.PortTableCache.List(), 1)
+		})
+
+		t.Run("iptables error closes socket", func(t *testing.T) {
+			// Regression test for socket/port leak:
+			// When PodPortRules.AddRule fails after getFreePort has opened a local
+			// socket, the socket must be closed to release the OS file descriptor
+			// and unblock the port for future use.
+			mockCtrl := gomock.NewController(t)
+			mockIPTables := rulestesting.NewMockPodPortRules(mockCtrl)
+			mockPortOpener := portcachetesting.NewMockLocalPortOpener(mockCtrl)
+			portTable := newPortTable(mockIPTables, mockPortOpener, isIPv6)
+
+			closer := &mockCloser{}
+			mockPortOpener.EXPECT().OpenLocalPort(startPort, protocol, isIPv6).Return(closer, nil)
+			mockIPTables.EXPECT().AddRule(startPort, podIP, podPort, protocol).
+				Return(fmt.Errorf("iptables error"))
+
+			_, err := portTable.AddRule(podKey, podPort, protocol, podIP)
+			require.ErrorContains(t, err, "iptables error")
+			// The socket MUST be closed to avoid leaking the FD and blocking the port.
+			assert.True(t, closer.closed, "socket must be closed after iptables failure to prevent FD/port leak")
+			// The cache must be empty; no unusable entry should be left behind.
+			assert.Empty(t, portTable.PortTableCache.List())
+		})
+
+		t.Run("duplicate entry", func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			mockIPTables := rulestesting.NewMockPodPortRules(mockCtrl)
+			mockPortOpener := portcachetesting.NewMockLocalPortOpener(mockCtrl)
+			portTable := newPortTable(mockIPTables, mockPortOpener, isIPv6)
+
+			closer := &mockCloser{}
+			mockPortOpener.EXPECT().OpenLocalPort(startPort, protocol, isIPv6).Return(closer, nil)
+			mockIPTables.EXPECT().AddRule(startPort, podIP, podPort, protocol).Return(nil)
+
+			_, err := portTable.AddRule(podKey, podPort, protocol, podIP)
+			require.NoError(t, err)
+
+			// Second call for the same podKey/podPort/protocol must fail without
+			// opening a new socket or touching iptables.
+			_, err = portTable.AddRule(podKey, podPort, protocol, podIP)
+			require.ErrorContains(t, err, "existing Linux Nodeport entry")
+		})
+	}
 	t.Run("IPv4", func(t *testing.T) { runTest(t, false) })
 	t.Run("IPv6", func(t *testing.T) { runTest(t, true) })
 }


### PR DESCRIPTION
**Problem**

When a NodePortLocal rule is added on Linux, `AddRule` in
`pkg/agent/nodeportlocal/portcache/port_table_others.go` performs two operations:

1. Opens a local OS socket (`net.Listen` for TCP, `net.ListenUDP` for UDP) via
   `getFreePort → openSocketsForPort → OpenLocalPort` to reserve the node port at
   the OS level.
2. Installs an iptables DNAT rule via `PodPortRules.AddRule`.

If step 2 fails (e.g., a transient iptables error), the code returned the error
**without closing the socket** opened in step 1. This causes:

- A leaked OS file descriptor per failed call.
- The node port stays in `LISTEN`/`BOUND` state at the OS level but is completely
  unknown to NPL's port table.
- The port **cannot be reused** by NPL until the agent restarts.
- No log message indicated the port was being held open.

The Windows implementation is **not affected** — on Windows, rule installation and
socket allocation are combined into a single atomic `addRuleForPort` call.

**Solution**

Close `protocolData.socket` when `PodPortRules.AddRule` returns an error, before
propagating the error to the caller. Any error from `Close()` is logged with
`klog.ErrorS` but does not replace the original iptables error.

This matches the existing pattern in `deleteRule`, which always closes the socket.

**Testing**

Added `TestAddRule` to `pkg/agent/nodeportlocal/portcache/port_table_others_test.go`
covering three scenarios (run for both IPv4 and IPv6):

- `success` — happy path: socket kept open, entry stored in cache
- `iptables error closes socket` — regression test: verifies socket is closed and
  cache is empty after iptables failure
- `duplicate entry` — second call for the same mapping returns an error immediately

All 15 tests (3 existing + 6 new sub-cases × 2 IP families) pass.

**Files Changed**

| File | Change |
|---|---|
| `pkg/agent/nodeportlocal/portcache/port_table_others.go` | +4 lines on error path |
| `pkg/agent/nodeportlocal/portcache/port_table_others_test.go` | +74 lines (TestAddRule + mockCloser enhancement) |