### PR TITLE
Validate max-egress-ips Node annotation range

### DIFF
--- a/cmd/antrea-agent/options.go
+++ b/cmd/antrea-agent/options.go
@@ -57,7 +57,6 @@ const (
 	defaultIGMPQueryInterval       = 125 * time.Second
 	defaultStaleConnectionTimeout  = 5 * time.Minute
 	defaultNodeType                = config.K8sNode
-	defaultMaxEgressIPsPerNode     = 255
 	defaultAuditLogsMaxSize        = 500
 	defaultAuditLogsMaxBackups     = 3
 	defaultAuditLogsMaxAge         = 28
@@ -534,7 +533,7 @@ func (o *Options) setK8sNodeDefaultOptions() {
 
 	if features.DefaultFeatureGate.Enabled(features.Egress) {
 		if o.config.Egress.MaxEgressIPsPerNode == 0 {
-			o.config.Egress.MaxEgressIPsPerNode = defaultMaxEgressIPsPerNode
+			o.config.Egress.MaxEgressIPsPerNode = agentconfig.MaxEgressIPsPerNodeUpperBound
 		}
 	}
 
@@ -567,8 +566,8 @@ func (o *Options) validateEgressConfig(encapMode config.TrafficEncapModeType) er
 			return fmt.Errorf("Egress Except CIDR %s is invalid", cidr)
 		}
 	}
-	if o.config.Egress.MaxEgressIPsPerNode > defaultMaxEgressIPsPerNode {
-		return fmt.Errorf("maxEgressIPsPerNode cannot be greater than %d", defaultMaxEgressIPsPerNode)
+	if o.config.Egress.MaxEgressIPsPerNode > agentconfig.MaxEgressIPsPerNodeUpperBound {
+		return fmt.Errorf("maxEgressIPsPerNode cannot be greater than %d", agentconfig.MaxEgressIPsPerNodeUpperBound)
 	}
 	o.enableEgress = true
 	return nil

--- a/docs/egress.md
+++ b/docs/egress.md
@@ -428,8 +428,10 @@ case.
   you want to set different capacities for Nodes, the
   `node.antrea.io/max-egress-ips` annotation of Node objects can be used to
   specify different values for different Nodes, taking priority over the value
-  configured in the config file. The option and the annotation were added in
-  Antrea v1.11.0.
+  configured in the config file. Like the configuration option, the annotation
+  value must be an integer between 0 and 255; an invalid value is ignored and
+  the Node falls back to the value from the config file. The option and the
+  annotation were added in Antrea v1.11.0.
 
 ## Reverse Path Filtering (rp_filter) Requirements
 

--- a/pkg/agent/controller/egress/ip_scheduler.go
+++ b/pkg/agent/controller/egress/ip_scheduler.go
@@ -15,6 +15,7 @@
 package egress
 
 import (
+	"fmt"
 	"sort"
 	"strconv"
 	"sync"
@@ -33,6 +34,7 @@ import (
 	crdv1b1 "antrea.io/antrea/v2/pkg/apis/crd/v1beta1"
 	crdinformers "antrea.io/antrea/v2/pkg/client/informers/externalversions/crd/v1beta1"
 	crdlisters "antrea.io/antrea/v2/pkg/client/listers/crd/v1beta1"
+	agentconfig "antrea.io/antrea/v2/pkg/config/agent"
 )
 
 const (
@@ -125,6 +127,9 @@ func getMaxEgressIPsFromAnnotation(node *corev1.Node) (int, bool, error) {
 	maxEgressIPs, err := strconv.Atoi(maxEgressIPsStr)
 	if err != nil {
 		return 0, false, err
+	}
+	if maxEgressIPs < 0 || maxEgressIPs > agentconfig.MaxEgressIPsPerNodeUpperBound {
+		return 0, false, fmt.Errorf("value must be between 0 and %d, got %d", agentconfig.MaxEgressIPsPerNodeUpperBound, maxEgressIPs)
 	}
 	return maxEgressIPs, true, nil
 }

--- a/pkg/agent/controller/egress/ip_scheduler_test.go
+++ b/pkg/agent/controller/egress/ip_scheduler_test.go
@@ -352,6 +352,19 @@ func TestRun(t *testing.T) {
 	updatedNode1.Annotations[agenttypes.NodeMaxEgressIPsAnnotationKey] = "invalid-value"
 	clientset.CoreV1().Nodes().Update(ctx, updatedNode1, metav1.UpdateOptions{})
 	assertReceivedItems(t, egressUpdates, sets.New[string]())
+	assertScheduleResult(t, s, "egressD", "1.1.1.1", "node1", true)
+	// Set node1's max-egress-ips annotation to a negative value, which is invalid, so nothing should happen.
+	updatedNode1 = node1.DeepCopy()
+	updatedNode1.Annotations[agenttypes.NodeMaxEgressIPsAnnotationKey] = "-1"
+	clientset.CoreV1().Nodes().Update(ctx, updatedNode1, metav1.UpdateOptions{})
+	assertReceivedItems(t, egressUpdates, sets.New[string]())
+	assertScheduleResult(t, s, "egressD", "1.1.1.1", "node1", true)
+	// Set node1's max-egress-ips annotation to a value greater than the upper bound (255), which is invalid, so nothing should happen.
+	updatedNode1 = node1.DeepCopy()
+	updatedNode1.Annotations[agenttypes.NodeMaxEgressIPsAnnotationKey] = "300"
+	clientset.CoreV1().Nodes().Update(ctx, updatedNode1, metav1.UpdateOptions{})
+	assertReceivedItems(t, egressUpdates, sets.New[string]())
+	assertScheduleResult(t, s, "egressD", "1.1.1.1", "node1", true)
 	// Set node1's max-egress-ips annotation to 1, egressD should be moved to node2.
 	updatedNode1 = node1.DeepCopy()
 	updatedNode1.Annotations[agenttypes.NodeMaxEgressIPsAnnotationKey] = "1"

--- a/pkg/config/agent/config.go
+++ b/pkg/config/agent/config.go
@@ -350,6 +350,11 @@ type MulticastConfig struct {
 	IGMPQueryVersions []int `yaml:"igmpQueryVersions"`
 }
 
+// MaxEgressIPsPerNodeUpperBound is the maximum value allowed for EgressConfig.MaxEgressIPsPerNode and
+// for the node.antrea.io/max-egress-ips Node annotation. It is also used as the default value for
+// MaxEgressIPsPerNode when the option is not set.
+const MaxEgressIPsPerNodeUpperBound = 255
+
 type EgressConfig struct {
 	ExceptCIDRs []string `yaml:"exceptCIDRs,omitempty"`
 	// The maximum number of Egress IPs that can be assigned to a Node. It's useful when the Node network restricts


### PR DESCRIPTION
The node.antrea.io/max-egress-ips annotation was only checked for being a valid integer; negative or greater-than-255 values were silently accepted. This is inconsistent with the egress.maxEgressIPsPerNode config option, which is validated to be at most 255. Reject out-of-range annotation values so they are ignored and logged, the same way a non-integer value already is, and document the accepted range.

Also updates docs/egress.md to document the annotation's accepted range (0–255).

Small fix; happy to adjust the approach (e.g. clamping instead of rejecting, or sharing the upper-bound constant) if maintainers prefer.

Fixes #8115
