### PR TITLE
Fix nil pointer dereference in initInterfaceStore

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -336,7 +336,7 @@ func (i *Initializer) initInterfaceStore() error {
 		var intf *interfacestore.InterfaceConfig
 		interfaceType, ok := port.ExternalIDs[interfacestore.AntreaInterfaceTypeKey]
 		if !ok {
-			klog.ErrorS(nil, "Interface type is not set, you may be trying to upgrade from an Antrea version which is too old", "interfaceName", intf.InterfaceName)
+			klog.ErrorS(nil, "Interface type is not set, you may be trying to upgrade from an Antrea version which is too old", "interfaceName", port.Name)
 			continue
 		}
 		switch interfaceType {


### PR DESCRIPTION
Title: initInterfaceStore panics with nil pointer dereference when OVS port is missing AntreaInterfaceTypeKey

Labels: kind/bug, component/agent, priority/critical

Body:

Summary
When the Antrea agent starts and calls initInterfaceStore, it iterates over all OVS ports. For each port that is missing the AntreaInterfaceTypeKey external ID (which can happen when upgrading from a very old version of Antrea), the code logs an error — but the error log accesses a nil pointer.

Root Cause
In 
pkg/agent/agent.go
 around line 339:

go

var intf *interfacestore.InterfaceConfig           // intf is nil
interfaceType, ok := port.ExternalIDs[interfacestore.AntreaInterfaceTypeKey]
if !ok {
    // BUG: intf is nil at this point — intf.InterfaceName will PANIC
    klog.ErrorS(nil, "Interface type is not set...", "interfaceName", intf.InterfaceName)
    continue
}
intf is declared as a nil pointer and is only assigned later inside the switch interfaceType block. When the key is missing, we never enter the switch and intf remains nil. Accessing intf.InterfaceName causes a nil pointer dereference panic.

Impact
Any Antrea cluster that has OVS ports without the AntreaInterfaceTypeKey external ID (upgrade scenarios from older versions) will have the agent crash instead of logging a recoverable error and continuing.

Steps to Reproduce
Deploy Antrea to a cluster that previously had an older version.
Restart the Antrea agent.
If any OVS port lacks AntreaInterfaceTypeKey in its external IDs, the agent panics.
Expected Behavior
The agent should log an error and continue to the next port, as the comment suggests.

🔀 GitHub PR Description
Title: Fix nil pointer dereference in initInterfaceStore when OVS port has no interface type key

Closes: #XXXX

What changed
Replace intf.InterfaceName (nil pointer dereference) with port.Name (always available from the OVS port data) in the error log when AntreaInterfaceTypeKey is missing.

Before / After
diff

- klog.ErrorS(nil, "Interface type is not set...", "interfaceName", intf.InterfaceName)
+ klog.ErrorS(nil, "Interface type is not set...", "interfaceName", port.Name)
Testing
The existing unit tests in agent_test.go continue to pass.
This is a one-line defensive fix in the error path; no behavior change occurs in the happy path.