### PR TITLE
Fix ServiceAddressToDNS to return error for non-namespaced addresses

### DIFF
--- a/pkg/agent/flowexporter/exporter.go
+++ b/pkg/agent/flowexporter/exporter.go
@@ -460,7 +460,7 @@ func ServiceAddressToDNS(address string) (string, error) {
 
 	ns, name := k8sutil.SplitNamespacedName(host)
 	if ns == "" {
-		return "", nil
+		return "", fmt.Errorf("address %q host %q is not a namespaced Kubernetes Service (expected namespace/name format)", address, host)
 	}
 
 	return fmt.Sprintf("%s.%s.svc", name, ns), nil
@@ -512,9 +512,16 @@ func createStaticDestinationResFromOptions(o *options.FlowExporterOptions) (*api
 	feProtocol := api.FlowExporterProtocol{}
 	var feTLSConfig *api.FlowExporterTLSConfig
 
+	// Resolve the service address to a DNS name if possible (namespace/name format).
+	// Fall back to the raw host for non-namespaced addresses (e.g. plain IP or FQDN).
 	dnsName, err := ServiceAddressToDNS(o.FlowCollectorAddr)
 	if err != nil {
-		return nil, fmt.Errorf("unable to determine transform service address to DNS name: %w", err)
+		// Not a namespaced K8s Service address — extract raw host for use as ServerName.
+		host, _, splitErr := net.SplitHostPort(o.FlowCollectorAddr)
+		if splitErr != nil {
+			return nil, fmt.Errorf("unable to parse flow collector address: %w", splitErr)
+		}
+		dnsName = host
 	}
 
 	if o.FlowCollectorProto == "grpc" {

--- a/pkg/agent/flowexporter/exporter_test.go
+++ b/pkg/agent/flowexporter/exporter_test.go
@@ -190,7 +190,7 @@ func Test_createDestinationResFromOptions(t *testing.T) {
 					ActiveFlowExportTimeoutSeconds: 5,
 					IdleFlowExportTimeoutSeconds:   2,
 					TLSConfig: &api.FlowExporterTLSConfig{
-						ServerName:    "",
+						ServerName:    "foo.example.com",
 						MinTLSVersion: "",
 						CAConfigMap: api.NamespacedName{
 							Name:      "flow-aggregator-ca",
@@ -210,6 +210,47 @@ func Test_createDestinationResFromOptions(t *testing.T) {
 			dest, err := createStaticDestinationResFromOptions(tt.o)
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, dest)
+		})
+	}
+}
+
+func TestServiceAddressToDNS(t *testing.T) {
+	tests := []struct {
+		name        string
+		address     string
+		wantDNS     string
+		wantErrStr  string
+	}{
+		{
+			name:    "namespaced service address",
+			address: "ns1/svc1:5678",
+			wantDNS: "svc1.ns1.svc",
+		},
+		{
+			name:       "plain IP address - not a K8s service",
+			address:    "1.2.3.4:5678",
+			wantErrStr: "is not a namespaced Kubernetes Service",
+		},
+		{
+			name:       "plain DNS name - not a K8s service",
+			address:    "foo.example.com:5678",
+			wantErrStr: "is not a namespaced Kubernetes Service",
+		},
+		{
+			name:       "invalid address - missing port",
+			address:    "foo.example.com",
+			wantErrStr: "missing port",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dns, err := ServiceAddressToDNS(tt.address)
+			if tt.wantErrStr != "" {
+				require.ErrorContains(t, err, tt.wantErrStr)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantDNS, dns)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Issue 3: ServiceAddressToDNS Silently Returns Empty ServerName for Non-Namespaced Addresses, Causing Hard-to-Debug TLS Failures
Branch: fix/flow-exporter-service-address-dns-empty Commit: 120884b4 — exporter.go + exporter_test.go (2 files, 51 insertions, 3 deletions)

🐛 GitHub Issue Description
Title: ServiceAddressToDNS returns empty string without error for non-namespaced addresses, silently breaking TLS in FlowExporter

Labels: kind/bug, component/flow-exporter, priority/high

Body:

Summary
The ServiceAddressToDNS function in pkg/agent/flowexporter/exporter.go is designed to convert a K8s Service address (in namespace/name:port format) to a DNS name. However, when the address host is not a namespaced K8s service name (e.g. a raw IP 1.2.3.4:4739 or an external DNS name collector.example.com:4739), the function silently returns an empty string with no error:

go

func ServiceAddressToDNS(address string) (string, error) {
    ...
    ns, name := k8sutil.SplitNamespacedName(host)
    if ns == "" {
        return "", nil   // ← Silent empty return!
    }
    ...
}
Impact
The caller createStaticDestinationResFromOptions uses this DNS name as the TLS ServerName field:

go

feTLSConfig = &api.FlowExporterTLSConfig{
    ServerName: dnsName,  // ← Empty string!
    ...
}
An empty ServerName in TLS configuration means the TLS handshake will fail with an obscure certificate validation error, since the server certificate won't match the empty server name. This makes it very difficult to diagnose — the error appears at connection time, not at startup.

Steps to Reproduce
Configure Antrea FlowExporter with a non-K8s-service collector address (e.g. a raw IP or external hostname) using grpc or tls protocol.
The TLS connection will fail with a certificate mismatch error.
No startup-time error or warning is logged about the empty ServerName.
Expected Behavior
ServiceAddressToDNS should return a descriptive error when the address is not a namespaced K8s Service, allowing callers to make an informed decision.
createStaticDestinationResFromOptions should fall back to the raw hostname as the TLS ServerName for non-K8s addresses.
🔀 GitHub PR Description
Title: Fix ServiceAddressToDNS to return error for non-namespaced addresses; use host as TLS ServerName fallback

Closes: #XXXX

What changed
ServiceAddressToDNS now returns a descriptive error when the address host is not in namespace/name format, instead of silently returning an empty string.

createStaticDestinationResFromOptions now handles the error from ServiceAddressToDNS gracefully: when the address is not a K8s Service (e.g. raw IP or FQDN), it falls back to using the raw host as the TLS ServerName, which is semantically correct.

New unit tests for ServiceAddressToDNS covering:

Namespaced service address (happy path)
Plain IP address (should error)
Plain DNS name (should error)
Invalid address with missing port (should error)
Before / After
diff

// ServiceAddressToDNS
  if ns == "" {
-     return "", nil
+     return "", fmt.Errorf("address %q host %q is not a namespaced Kubernetes Service (expected namespace/name format)", address, host)
  }
diff

// createStaticDestinationResFromOptions
  dnsName, err := ServiceAddressToDNS(o.FlowCollectorAddr)
  if err != nil {
-     return nil, fmt.Errorf("unable to determine transform service address to DNS name: %w", err)
+     // Not a namespaced K8s Service address — extract raw host for use as ServerName.
+     host, _, splitErr := net.SplitHostPort(o.FlowCollectorAddr)
+     if splitErr != nil {
+         return nil, fmt.Errorf("unable to parse flow collector address: %w", splitErr)
+     }
+     dnsName = host
  }