### PR TITLE
Annotate end-of-initial-events bookmark for watch-list clients

### DIFF
--- a/pkg/apiserver/registry/controlplane/egressgroup/rest.go
+++ b/pkg/apiserver/registry/controlplane/egressgroup/rest.go
@@ -99,6 +99,7 @@ func (r *REST) NamespaceScoped() bool {
 
 func (r *REST) Watch(ctx context.Context, options *internalversion.ListOptions) (watch.Interface, error) {
 	key, label, field := networkpolicy.GetSelectors(options)
+	ctx = storage.WithInitialEventsEndBookmarkAnnotationFromListOptions(ctx, options)
 	return r.egressGroupStore.Watch(ctx, key, label, field)
 }
 

--- a/pkg/apiserver/registry/controlplane/egressgroup/rest_test.go
+++ b/pkg/apiserver/registry/controlplane/egressgroup/rest_test.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 
 	"antrea.io/antrea/v2/pkg/apis/controlplane"
-	"antrea.io/antrea/v2/pkg/apiserver/storage/testutil"
 	"antrea.io/antrea/v2/pkg/controller/egress/store"
 	"antrea.io/antrea/v2/pkg/controller/types"
 )
@@ -155,7 +154,7 @@ func TestRESTWatch(t *testing.T) {
 			name:          "nodeName selecting nothing",
 			fieldSelector: fields.OneTermEqualSelector("nodeName", "foo"),
 			expectedEvents: []watch.Event{
-				testutil.ExpectedInitBookmark(t, &controlplane.EgressGroup{}, "1"),
+				{Type: watch.Bookmark, Object: &controlplane.EgressGroup{ObjectMeta: v1.ObjectMeta{ResourceVersion: "1"}}},
 			},
 		},
 		{
@@ -163,7 +162,7 @@ func TestRESTWatch(t *testing.T) {
 			fieldSelector: fields.OneTermEqualSelector("nodeName", "node1"),
 			expectedEvents: []watch.Event{
 				{Type: watch.Added, Object: &controlplane.EgressGroup{ObjectMeta: v1.ObjectMeta{Name: "egress1"}}},
-				testutil.ExpectedInitBookmark(t, &controlplane.EgressGroup{}, "1"),
+				{Type: watch.Bookmark, Object: &controlplane.EgressGroup{ObjectMeta: v1.ObjectMeta{ResourceVersion: "1"}}},
 			},
 		},
 		{
@@ -171,7 +170,7 @@ func TestRESTWatch(t *testing.T) {
 			fieldSelector: nil,
 			expectedEvents: []watch.Event{
 				{Type: watch.Added, Object: &controlplane.EgressGroup{ObjectMeta: v1.ObjectMeta{Name: "egress1"}}},
-				testutil.ExpectedInitBookmark(t, &controlplane.EgressGroup{}, "1"),
+				{Type: watch.Bookmark, Object: &controlplane.EgressGroup{ObjectMeta: v1.ObjectMeta{ResourceVersion: "1"}}},
 			},
 		},
 	}

--- a/pkg/apiserver/registry/controlplane/egressgroup/rest_test.go
+++ b/pkg/apiserver/registry/controlplane/egressgroup/rest_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 
 	"antrea.io/antrea/v2/pkg/apis/controlplane"
+	"antrea.io/antrea/v2/pkg/apiserver/storage/testutil"
 	"antrea.io/antrea/v2/pkg/controller/egress/store"
 	"antrea.io/antrea/v2/pkg/controller/types"
 )
@@ -154,7 +155,7 @@ func TestRESTWatch(t *testing.T) {
 			name:          "nodeName selecting nothing",
 			fieldSelector: fields.OneTermEqualSelector("nodeName", "foo"),
 			expectedEvents: []watch.Event{
-				{Type: watch.Bookmark, Object: &controlplane.EgressGroup{}},
+				testutil.ExpectedInitBookmark(t, &controlplane.EgressGroup{}, "1"),
 			},
 		},
 		{
@@ -162,7 +163,7 @@ func TestRESTWatch(t *testing.T) {
 			fieldSelector: fields.OneTermEqualSelector("nodeName", "node1"),
 			expectedEvents: []watch.Event{
 				{Type: watch.Added, Object: &controlplane.EgressGroup{ObjectMeta: v1.ObjectMeta{Name: "egress1"}}},
-				{Type: watch.Bookmark, Object: &controlplane.EgressGroup{}},
+				testutil.ExpectedInitBookmark(t, &controlplane.EgressGroup{}, "1"),
 			},
 		},
 		{
@@ -170,7 +171,7 @@ func TestRESTWatch(t *testing.T) {
 			fieldSelector: nil,
 			expectedEvents: []watch.Event{
 				{Type: watch.Added, Object: &controlplane.EgressGroup{ObjectMeta: v1.ObjectMeta{Name: "egress1"}}},
-				{Type: watch.Bookmark, Object: &controlplane.EgressGroup{}},
+				testutil.ExpectedInitBookmark(t, &controlplane.EgressGroup{}, "1"),
 			},
 		},
 	}

--- a/pkg/apiserver/registry/controlplane/supportbundlecollection/rest.go
+++ b/pkg/apiserver/registry/controlplane/supportbundlecollection/rest.go
@@ -99,6 +99,7 @@ func (r *REST) NamespaceScoped() bool {
 
 func (r *REST) Watch(ctx context.Context, options *internalversion.ListOptions) (watch.Interface, error) {
 	key, label, field := networkpolicy.GetSelectors(options)
+	ctx = storage.WithInitialEventsEndBookmarkAnnotationFromListOptions(ctx, options)
 	return r.supportBundleCollectionStore.Watch(ctx, key, label, field)
 }
 

--- a/pkg/apiserver/registry/networkpolicy/addressgroup/rest.go
+++ b/pkg/apiserver/registry/networkpolicy/addressgroup/rest.go
@@ -99,6 +99,7 @@ func (r *REST) NamespaceScoped() bool {
 
 func (r *REST) Watch(ctx context.Context, options *internalversion.ListOptions) (watch.Interface, error) {
 	key, label, field := networkpolicy.GetSelectors(options)
+	ctx = storage.WithInitialEventsEndBookmarkAnnotationFromListOptions(ctx, options)
 	return r.addressGroupStore.Watch(ctx, key, label, field)
 }
 

--- a/pkg/apiserver/registry/networkpolicy/addressgroup/rest_test.go
+++ b/pkg/apiserver/registry/networkpolicy/addressgroup/rest_test.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 
 	"antrea.io/antrea/v2/pkg/apis/controlplane"
-	"antrea.io/antrea/v2/pkg/apiserver/storage/testutil"
 	"antrea.io/antrea/v2/pkg/controller/networkpolicy/store"
 	"antrea.io/antrea/v2/pkg/controller/types"
 )
@@ -155,7 +154,7 @@ func TestRESTWatch(t *testing.T) {
 			name:          "nodeName selecting nothing",
 			fieldSelector: fields.OneTermEqualSelector("nodeName", "foo"),
 			expectedEvents: []watch.Event{
-				testutil.ExpectedInitBookmark(t, &controlplane.AddressGroup{}, "1"),
+				{Type: watch.Bookmark, Object: &controlplane.AddressGroup{ObjectMeta: v1.ObjectMeta{ResourceVersion: "1"}}},
 			},
 		},
 		{
@@ -163,7 +162,7 @@ func TestRESTWatch(t *testing.T) {
 			fieldSelector: fields.OneTermEqualSelector("nodeName", "node1"),
 			expectedEvents: []watch.Event{
 				{Type: watch.Added, Object: &controlplane.AddressGroup{ObjectMeta: v1.ObjectMeta{Name: "addressGroup1"}}},
-				testutil.ExpectedInitBookmark(t, &controlplane.AddressGroup{}, "1"),
+				{Type: watch.Bookmark, Object: &controlplane.AddressGroup{ObjectMeta: v1.ObjectMeta{ResourceVersion: "1"}}},
 			},
 		},
 		{
@@ -171,7 +170,7 @@ func TestRESTWatch(t *testing.T) {
 			fieldSelector: nil,
 			expectedEvents: []watch.Event{
 				{Type: watch.Added, Object: &controlplane.AddressGroup{ObjectMeta: v1.ObjectMeta{Name: "addressGroup1"}}},
-				testutil.ExpectedInitBookmark(t, &controlplane.AddressGroup{}, "1"),
+				{Type: watch.Bookmark, Object: &controlplane.AddressGroup{ObjectMeta: v1.ObjectMeta{ResourceVersion: "1"}}},
 			},
 		},
 	}

--- a/pkg/apiserver/registry/networkpolicy/addressgroup/rest_test.go
+++ b/pkg/apiserver/registry/networkpolicy/addressgroup/rest_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 
 	"antrea.io/antrea/v2/pkg/apis/controlplane"
+	"antrea.io/antrea/v2/pkg/apiserver/storage/testutil"
 	"antrea.io/antrea/v2/pkg/controller/networkpolicy/store"
 	"antrea.io/antrea/v2/pkg/controller/types"
 )
@@ -154,7 +155,7 @@ func TestRESTWatch(t *testing.T) {
 			name:          "nodeName selecting nothing",
 			fieldSelector: fields.OneTermEqualSelector("nodeName", "foo"),
 			expectedEvents: []watch.Event{
-				{Type: watch.Bookmark, Object: &controlplane.AddressGroup{}},
+				testutil.ExpectedInitBookmark(t, &controlplane.AddressGroup{}, "1"),
 			},
 		},
 		{
@@ -162,7 +163,7 @@ func TestRESTWatch(t *testing.T) {
 			fieldSelector: fields.OneTermEqualSelector("nodeName", "node1"),
 			expectedEvents: []watch.Event{
 				{Type: watch.Added, Object: &controlplane.AddressGroup{ObjectMeta: v1.ObjectMeta{Name: "addressGroup1"}}},
-				{Type: watch.Bookmark, Object: &controlplane.AddressGroup{}},
+				testutil.ExpectedInitBookmark(t, &controlplane.AddressGroup{}, "1"),
 			},
 		},
 		{
@@ -170,7 +171,7 @@ func TestRESTWatch(t *testing.T) {
 			fieldSelector: nil,
 			expectedEvents: []watch.Event{
 				{Type: watch.Added, Object: &controlplane.AddressGroup{ObjectMeta: v1.ObjectMeta{Name: "addressGroup1"}}},
-				{Type: watch.Bookmark, Object: &controlplane.AddressGroup{}},
+				testutil.ExpectedInitBookmark(t, &controlplane.AddressGroup{}, "1"),
 			},
 		},
 	}

--- a/pkg/apiserver/registry/networkpolicy/appliedtogroup/rest.go
+++ b/pkg/apiserver/registry/networkpolicy/appliedtogroup/rest.go
@@ -99,6 +99,7 @@ func (r *REST) NamespaceScoped() bool {
 
 func (r *REST) Watch(ctx context.Context, options *internalversion.ListOptions) (watch.Interface, error) {
 	key, label, field := networkpolicy.GetSelectors(options)
+	ctx = storage.WithInitialEventsEndBookmarkAnnotationFromListOptions(ctx, options)
 	return r.appliedToGroupStore.Watch(ctx, key, label, field)
 }
 

--- a/pkg/apiserver/registry/networkpolicy/appliedtogroup/rest_test.go
+++ b/pkg/apiserver/registry/networkpolicy/appliedtogroup/rest_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 
 	"antrea.io/antrea/v2/pkg/apis/controlplane"
+	"antrea.io/antrea/v2/pkg/apiserver/storage/testutil"
 	"antrea.io/antrea/v2/pkg/controller/networkpolicy/store"
 	"antrea.io/antrea/v2/pkg/controller/types"
 )
@@ -154,7 +155,7 @@ func TestRESTWatch(t *testing.T) {
 			name:          "nodeName selecting nothing",
 			fieldSelector: fields.OneTermEqualSelector("nodeName", "foo"),
 			expectedEvents: []watch.Event{
-				{Type: watch.Bookmark, Object: &controlplane.AppliedToGroup{}},
+				testutil.ExpectedInitBookmark(t, &controlplane.AppliedToGroup{}, "1"),
 			},
 		},
 		{
@@ -162,7 +163,7 @@ func TestRESTWatch(t *testing.T) {
 			fieldSelector: fields.OneTermEqualSelector("nodeName", "node1"),
 			expectedEvents: []watch.Event{
 				{Type: watch.Added, Object: &controlplane.AppliedToGroup{ObjectMeta: v1.ObjectMeta{Name: "appliedToGroup1"}}},
-				{Type: watch.Bookmark, Object: &controlplane.AppliedToGroup{}},
+				testutil.ExpectedInitBookmark(t, &controlplane.AppliedToGroup{}, "1"),
 			},
 		},
 		{
@@ -170,7 +171,7 @@ func TestRESTWatch(t *testing.T) {
 			fieldSelector: nil,
 			expectedEvents: []watch.Event{
 				{Type: watch.Added, Object: &controlplane.AppliedToGroup{ObjectMeta: v1.ObjectMeta{Name: "appliedToGroup1"}}},
-				{Type: watch.Bookmark, Object: &controlplane.AppliedToGroup{}},
+				testutil.ExpectedInitBookmark(t, &controlplane.AppliedToGroup{}, "1"),
 			},
 		},
 	}

--- a/pkg/apiserver/registry/networkpolicy/appliedtogroup/rest_test.go
+++ b/pkg/apiserver/registry/networkpolicy/appliedtogroup/rest_test.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 
 	"antrea.io/antrea/v2/pkg/apis/controlplane"
-	"antrea.io/antrea/v2/pkg/apiserver/storage/testutil"
 	"antrea.io/antrea/v2/pkg/controller/networkpolicy/store"
 	"antrea.io/antrea/v2/pkg/controller/types"
 )
@@ -155,7 +154,7 @@ func TestRESTWatch(t *testing.T) {
 			name:          "nodeName selecting nothing",
 			fieldSelector: fields.OneTermEqualSelector("nodeName", "foo"),
 			expectedEvents: []watch.Event{
-				testutil.ExpectedInitBookmark(t, &controlplane.AppliedToGroup{}, "1"),
+				{Type: watch.Bookmark, Object: &controlplane.AppliedToGroup{ObjectMeta: v1.ObjectMeta{ResourceVersion: "1"}}},
 			},
 		},
 		{
@@ -163,7 +162,7 @@ func TestRESTWatch(t *testing.T) {
 			fieldSelector: fields.OneTermEqualSelector("nodeName", "node1"),
 			expectedEvents: []watch.Event{
 				{Type: watch.Added, Object: &controlplane.AppliedToGroup{ObjectMeta: v1.ObjectMeta{Name: "appliedToGroup1"}}},
-				testutil.ExpectedInitBookmark(t, &controlplane.AppliedToGroup{}, "1"),
+				{Type: watch.Bookmark, Object: &controlplane.AppliedToGroup{ObjectMeta: v1.ObjectMeta{ResourceVersion: "1"}}},
 			},
 		},
 		{
@@ -171,7 +170,7 @@ func TestRESTWatch(t *testing.T) {
 			fieldSelector: nil,
 			expectedEvents: []watch.Event{
 				{Type: watch.Added, Object: &controlplane.AppliedToGroup{ObjectMeta: v1.ObjectMeta{Name: "appliedToGroup1"}}},
-				testutil.ExpectedInitBookmark(t, &controlplane.AppliedToGroup{}, "1"),
+				{Type: watch.Bookmark, Object: &controlplane.AppliedToGroup{ObjectMeta: v1.ObjectMeta{ResourceVersion: "1"}}},
 			},
 		},
 	}

--- a/pkg/apiserver/registry/networkpolicy/networkpolicy/rest.go
+++ b/pkg/apiserver/registry/networkpolicy/networkpolicy/rest.go
@@ -99,6 +99,7 @@ func (r *REST) NamespaceScoped() bool {
 
 func (r *REST) Watch(ctx context.Context, options *internalversion.ListOptions) (watch.Interface, error) {
 	key, label, field := networkpolicy.GetSelectors(options)
+	ctx = storage.WithInitialEventsEndBookmarkAnnotationFromListOptions(ctx, options)
 	return r.networkPolicyStore.Watch(ctx, key, label, field)
 }
 

--- a/pkg/apiserver/registry/networkpolicy/networkpolicy/rest_test.go
+++ b/pkg/apiserver/registry/networkpolicy/networkpolicy/rest_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 
 	"antrea.io/antrea/v2/pkg/apis/controlplane"
+	"antrea.io/antrea/v2/pkg/apiserver/storage/testutil"
 	"antrea.io/antrea/v2/pkg/controller/networkpolicy/store"
 	"antrea.io/antrea/v2/pkg/controller/types"
 )
@@ -154,7 +155,7 @@ func TestRESTWatch(t *testing.T) {
 			name:          "nodeName selecting nothing",
 			fieldSelector: fields.OneTermEqualSelector("nodeName", "foo"),
 			expectedEvents: []watch.Event{
-				{Type: watch.Bookmark, Object: &controlplane.NetworkPolicy{}},
+				testutil.ExpectedInitBookmark(t, &controlplane.NetworkPolicy{}, "1"),
 			},
 		},
 		{
@@ -162,7 +163,7 @@ func TestRESTWatch(t *testing.T) {
 			fieldSelector: fields.OneTermEqualSelector("nodeName", "node1"),
 			expectedEvents: []watch.Event{
 				{Type: watch.Added, Object: &controlplane.NetworkPolicy{ObjectMeta: v1.ObjectMeta{Name: "networkPolicy1"}}},
-				{Type: watch.Bookmark, Object: &controlplane.NetworkPolicy{}},
+				testutil.ExpectedInitBookmark(t, &controlplane.NetworkPolicy{}, "1"),
 			},
 		},
 		{
@@ -170,7 +171,7 @@ func TestRESTWatch(t *testing.T) {
 			fieldSelector: nil,
 			expectedEvents: []watch.Event{
 				{Type: watch.Added, Object: &controlplane.NetworkPolicy{ObjectMeta: v1.ObjectMeta{Name: "networkPolicy1"}}},
-				{Type: watch.Bookmark, Object: &controlplane.NetworkPolicy{}},
+				testutil.ExpectedInitBookmark(t, &controlplane.NetworkPolicy{}, "1"),
 			},
 		},
 	}

--- a/pkg/apiserver/registry/networkpolicy/networkpolicy/rest_test.go
+++ b/pkg/apiserver/registry/networkpolicy/networkpolicy/rest_test.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 
 	"antrea.io/antrea/v2/pkg/apis/controlplane"
-	"antrea.io/antrea/v2/pkg/apiserver/storage/testutil"
 	"antrea.io/antrea/v2/pkg/controller/networkpolicy/store"
 	"antrea.io/antrea/v2/pkg/controller/types"
 )
@@ -155,7 +154,7 @@ func TestRESTWatch(t *testing.T) {
 			name:          "nodeName selecting nothing",
 			fieldSelector: fields.OneTermEqualSelector("nodeName", "foo"),
 			expectedEvents: []watch.Event{
-				testutil.ExpectedInitBookmark(t, &controlplane.NetworkPolicy{}, "1"),
+				{Type: watch.Bookmark, Object: &controlplane.NetworkPolicy{ObjectMeta: v1.ObjectMeta{ResourceVersion: "1"}}},
 			},
 		},
 		{
@@ -163,7 +162,7 @@ func TestRESTWatch(t *testing.T) {
 			fieldSelector: fields.OneTermEqualSelector("nodeName", "node1"),
 			expectedEvents: []watch.Event{
 				{Type: watch.Added, Object: &controlplane.NetworkPolicy{ObjectMeta: v1.ObjectMeta{Name: "networkPolicy1"}}},
-				testutil.ExpectedInitBookmark(t, &controlplane.NetworkPolicy{}, "1"),
+				{Type: watch.Bookmark, Object: &controlplane.NetworkPolicy{ObjectMeta: v1.ObjectMeta{ResourceVersion: "1"}}},
 			},
 		},
 		{
@@ -171,7 +170,7 @@ func TestRESTWatch(t *testing.T) {
 			fieldSelector: nil,
 			expectedEvents: []watch.Event{
 				{Type: watch.Added, Object: &controlplane.NetworkPolicy{ObjectMeta: v1.ObjectMeta{Name: "networkPolicy1"}}},
-				testutil.ExpectedInitBookmark(t, &controlplane.NetworkPolicy{}, "1"),
+				{Type: watch.Bookmark, Object: &controlplane.NetworkPolicy{ObjectMeta: v1.ObjectMeta{ResourceVersion: "1"}}},
 			},
 		},
 	}

--- a/pkg/apiserver/storage/interfaces.go
+++ b/pkg/apiserver/storage/interfaces.go
@@ -17,6 +17,7 @@ package storage
 import (
 	"context"
 
+	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/watch"
@@ -53,6 +54,34 @@ type GenEventFunc func(key string, prevObj, obj interface{}, resourceVersion uin
 
 // SelectFunc checks whether an object match the provided selectors.
 type SelectFunc func(selectors *Selectors, key string, obj interface{}) bool
+
+type initialEventsEndBookmarkAnnotationKey struct{}
+
+// WithInitialEventsEndBookmarkAnnotation returns a Context that requests annotation of Antrea's
+// end-of-initial-events bookmark for Kubernetes watch-list clients.
+func WithInitialEventsEndBookmarkAnnotation(ctx context.Context) context.Context {
+	return context.WithValue(ctx, initialEventsEndBookmarkAnnotationKey{}, true)
+}
+
+// WithInitialEventsEndBookmarkAnnotationFromListOptions returns a Context that requests annotation
+// of Antrea's end-of-initial-events bookmark when the ListOptions describe a watch-list request.
+func WithInitialEventsEndBookmarkAnnotationFromListOptions(ctx context.Context, options *metainternalversion.ListOptions) context.Context {
+	if shouldAnnotateInitialEventsEndBookmark(options) {
+		return WithInitialEventsEndBookmarkAnnotation(ctx)
+	}
+	return ctx
+}
+
+// ShouldAnnotateInitialEventsEndBookmarkFromContext reports whether the Context requests the
+// Kubernetes watch-list end-of-initial-events annotation on Antrea's init bookmark.
+func ShouldAnnotateInitialEventsEndBookmarkFromContext(ctx context.Context) bool {
+	annotate, _ := ctx.Value(initialEventsEndBookmarkAnnotationKey{}).(bool)
+	return annotate
+}
+
+func shouldAnnotateInitialEventsEndBookmark(options *metainternalversion.ListOptions) bool {
+	return options != nil && options.SendInitialEvents != nil && *options.SendInitialEvents && options.AllowWatchBookmarks
+}
 
 // Interface offers a common storage interface for runtime.Object.
 // It's provided for Network Policy controller to store the translated Network Policy resources, then Antrea apiserver can

--- a/pkg/apiserver/storage/ram/store_test.go
+++ b/pkg/apiserver/storage/ram/store_test.go
@@ -35,7 +35,6 @@ import (
 	"k8s.io/utils/clock"
 
 	antreastorage "antrea.io/antrea/v2/pkg/apiserver/storage"
-	"antrea.io/antrea/v2/pkg/apiserver/storage/testutil"
 )
 
 // testEvent implements InternalEvent.
@@ -297,7 +296,7 @@ func TestRamStoreWatchAll(t *testing.T) {
 				store.Update(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx2"}}})
 			},
 			expected: []watch.Event{
-				testutil.ExpectedInitBookmark(t, &v1.Pod{}, "0"),
+				bookmarkPod("0"),
 				{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx1"}}}},
 				{Type: watch.Modified, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx2"}}}},
 			},
@@ -308,7 +307,7 @@ func TestRamStoreWatchAll(t *testing.T) {
 				store.Delete("pod1")
 			},
 			expected: []watch.Event{
-				testutil.ExpectedInitBookmark(t, &v1.Pod{}, "0"),
+				bookmarkPod("0"),
 				{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx1"}}}},
 				{Type: watch.Deleted, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx1"}}}},
 			},
@@ -358,7 +357,7 @@ func TestRamStoreWatchWithInitOperations(t *testing.T) {
 			},
 			expected: []watch.Event{
 				{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx3"}}}},
-				testutil.ExpectedInitBookmark(t, &v1.Pod{}, "3"),
+				bookmarkPod("3"),
 				{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod2", Labels: map[string]string{"app": "nginx2"}}}},
 				{Type: watch.Modified, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod2", Labels: map[string]string{"app": "nginx3"}}}},
 			},
@@ -374,7 +373,7 @@ func TestRamStoreWatchWithInitOperations(t *testing.T) {
 			},
 			expected: []watch.Event{
 				{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx1"}}}},
-				testutil.ExpectedInitBookmark(t, &v1.Pod{}, "3"),
+				bookmarkPod("3"),
 				{Type: watch.Deleted, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx1"}}}},
 			},
 		},
@@ -419,7 +418,7 @@ func TestRamStoreWatchWithSelector(t *testing.T) {
 			},
 			labelSelector: labels.SelectorFromSet(labels.Set{"app": "nginx1"}),
 			expected: []watch.Event{
-				testutil.ExpectedInitBookmark(t, &v1.Pod{}, "0"),
+				bookmarkPod("0"),
 				{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx1"}}}},
 				{Type: watch.Deleted, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx1"}}}},
 			},
@@ -431,7 +430,7 @@ func TestRamStoreWatchWithSelector(t *testing.T) {
 			},
 			labelSelector: labels.SelectorFromSet(labels.Set{"app": "nginx2"}),
 			expected: []watch.Event{
-				testutil.ExpectedInitBookmark(t, &v1.Pod{}, "0"),
+				bookmarkPod("0"),
 				{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx2"}}}},
 			},
 		},
@@ -444,7 +443,7 @@ func TestRamStoreWatchWithSelector(t *testing.T) {
 			},
 			labelSelector: labels.SelectorFromSet(labels.Set{"app": "nginx1"}),
 			expected: []watch.Event{
-				testutil.ExpectedInitBookmark(t, &v1.Pod{}, "0"),
+				bookmarkPod("0"),
 				{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx1"}}}},
 				{Type: watch.Deleted, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx1"}}}},
 			},

--- a/pkg/apiserver/storage/ram/store_test.go
+++ b/pkg/apiserver/storage/ram/store_test.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/utils/clock"
 
 	antreastorage "antrea.io/antrea/v2/pkg/apiserver/storage"
+	"antrea.io/antrea/v2/pkg/apiserver/storage/testutil"
 )
 
 // testEvent implements InternalEvent.
@@ -296,7 +297,7 @@ func TestRamStoreWatchAll(t *testing.T) {
 				store.Update(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx2"}}})
 			},
 			expected: []watch.Event{
-				{Type: watch.Bookmark, Object: &v1.Pod{}},
+				testutil.ExpectedInitBookmark(t, &v1.Pod{}, "0"),
 				{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx1"}}}},
 				{Type: watch.Modified, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx2"}}}},
 			},
@@ -307,7 +308,7 @@ func TestRamStoreWatchAll(t *testing.T) {
 				store.Delete("pod1")
 			},
 			expected: []watch.Event{
-				{Type: watch.Bookmark, Object: &v1.Pod{}},
+				testutil.ExpectedInitBookmark(t, &v1.Pod{}, "0"),
 				{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx1"}}}},
 				{Type: watch.Deleted, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx1"}}}},
 			},
@@ -357,7 +358,7 @@ func TestRamStoreWatchWithInitOperations(t *testing.T) {
 			},
 			expected: []watch.Event{
 				{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx3"}}}},
-				{Type: watch.Bookmark, Object: &v1.Pod{}},
+				testutil.ExpectedInitBookmark(t, &v1.Pod{}, "3"),
 				{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod2", Labels: map[string]string{"app": "nginx2"}}}},
 				{Type: watch.Modified, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod2", Labels: map[string]string{"app": "nginx3"}}}},
 			},
@@ -373,7 +374,7 @@ func TestRamStoreWatchWithInitOperations(t *testing.T) {
 			},
 			expected: []watch.Event{
 				{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx1"}}}},
-				{Type: watch.Bookmark, Object: &v1.Pod{}},
+				testutil.ExpectedInitBookmark(t, &v1.Pod{}, "3"),
 				{Type: watch.Deleted, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx1"}}}},
 			},
 		},
@@ -418,7 +419,7 @@ func TestRamStoreWatchWithSelector(t *testing.T) {
 			},
 			labelSelector: labels.SelectorFromSet(labels.Set{"app": "nginx1"}),
 			expected: []watch.Event{
-				{Type: watch.Bookmark, Object: &v1.Pod{}},
+				testutil.ExpectedInitBookmark(t, &v1.Pod{}, "0"),
 				{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx1"}}}},
 				{Type: watch.Deleted, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx1"}}}},
 			},
@@ -430,7 +431,7 @@ func TestRamStoreWatchWithSelector(t *testing.T) {
 			},
 			labelSelector: labels.SelectorFromSet(labels.Set{"app": "nginx2"}),
 			expected: []watch.Event{
-				{Type: watch.Bookmark, Object: &v1.Pod{}},
+				testutil.ExpectedInitBookmark(t, &v1.Pod{}, "0"),
 				{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx2"}}}},
 			},
 		},
@@ -443,7 +444,7 @@ func TestRamStoreWatchWithSelector(t *testing.T) {
 			},
 			labelSelector: labels.SelectorFromSet(labels.Set{"app": "nginx1"}),
 			expected: []watch.Event{
-				{Type: watch.Bookmark, Object: &v1.Pod{}},
+				testutil.ExpectedInitBookmark(t, &v1.Pod{}, "0"),
 				{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx1"}}}},
 				{Type: watch.Deleted, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx1"}}}},
 			},

--- a/pkg/apiserver/storage/ram/watch.go
+++ b/pkg/apiserver/storage/ram/watch.go
@@ -16,8 +16,12 @@ package ram
 
 import (
 	"context"
+	"fmt"
+	"strconv"
 	"sync"
 
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/klog/v2"
@@ -32,7 +36,34 @@ type bookmarkEvent struct {
 }
 
 func (b *bookmarkEvent) ToWatchEvent(selectors *storage.Selectors, isInitEvent bool) *watch.Event {
-	return &watch.Event{Type: watch.Bookmark, Object: b.object}
+	// Copy the object before mutating it: an InternalEvent is expected to be immutable during
+	// its conversion to a *watch.Event (ToWatchEvent may be called once per interested watcher).
+	object := b.object.DeepCopyObject()
+	// meta.Accessor is the upstream pattern (see k8s.io/apiserver/pkg/storage.AnnotateInitialEventsEndBookmark)
+	// for setting metadata on a bookmark object regardless of its concrete type.
+	objMeta, err := meta.Accessor(object)
+	if err != nil {
+		// This is not expected for the controlplane resources served from this storage, as they all
+		// embed ObjectMeta. Surface it so a contract violation (a bookmark on which the
+		// resourceVersion and the initial-events-end annotation could not be set, which breaks
+		// watch-list clients) is visible at runtime instead of failing silently.
+		klog.ErrorS(err, "Failed to access bookmark object metadata, unable to set resourceVersion and initial-events-end annotation on bookmark", "objectType", fmt.Sprintf("%T", object))
+		return &watch.Event{Type: watch.Bookmark, Object: object}
+	}
+	objMeta.SetResourceVersion(strconv.FormatUint(b.resourceVersion, 10))
+	annotations := objMeta.GetAnnotations()
+	if isInitEvent {
+		// Mark the bookmark that signals the end of the initial set of events with the
+		// "k8s.io/initial-events-end" annotation. This follows the Kubernetes watch-list
+		// (streaming list) contract so that client-go watch-list informers can detect the
+		// end of the initial events and complete their synchronization.
+		if annotations == nil {
+			annotations = map[string]string{}
+		}
+		annotations[metav1.InitialEventsAnnotationKey] = "true"
+		objMeta.SetAnnotations(annotations)
+	}
+	return &watch.Event{Type: watch.Bookmark, Object: object}
 }
 
 func (b *bookmarkEvent) GetResourceVersion() uint64 {

--- a/pkg/apiserver/storage/ram/watch.go
+++ b/pkg/apiserver/storage/ram/watch.go
@@ -31,8 +31,9 @@ import (
 )
 
 type bookmarkEvent struct {
-	resourceVersion uint64
-	object          runtime.Object
+	resourceVersion                  uint64
+	object                           runtime.Object
+	annotateInitialEventsEndBookmark bool
 }
 
 func (b *bookmarkEvent) ToWatchEvent(selectors *storage.Selectors, isInitEvent bool) *watch.Event {
@@ -52,7 +53,7 @@ func (b *bookmarkEvent) ToWatchEvent(selectors *storage.Selectors, isInitEvent b
 	}
 	objMeta.SetResourceVersion(strconv.FormatUint(b.resourceVersion, 10))
 	annotations := objMeta.GetAnnotations()
-	if isInitEvent {
+	if isInitEvent && b.annotateInitialEventsEndBookmark {
 		// Mark the bookmark that signals the end of the initial set of events with the
 		// "k8s.io/initial-events-end" annotation. This follows the Kubernetes watch-list
 		// (streaming list) contract so that client-go watch-list informers can detect the
@@ -134,6 +135,7 @@ func (w *storeWatcher) add(event storage.InternalEvent, timer clock.Timer) bool 
 // process first sends initEvents and then keeps sending events got from channel input
 // if they are newer than the specified resourceVersion.
 func (w *storeWatcher) process(ctx context.Context, initEvents []storage.InternalEvent, resourceVersion uint64) {
+	annotateInitialEventsEndBookmark := storage.ShouldAnnotateInitialEventsEndBookmarkFromContext(ctx)
 	for _, event := range initEvents {
 		w.sendWatchEvent(event, true)
 	}
@@ -144,7 +146,7 @@ func (w *storeWatcher) process(ctx context.Context, initEvents []storage.Interna
 	// communicate to clients what the initial set of objects is, so that
 	// stale objects whose delete events were missed by the client (because
 	// the watch was down) can be deleted.
-	w.sendWatchEvent(&bookmarkEvent{resourceVersion, w.newFunc()}, true)
+	w.sendWatchEvent(&bookmarkEvent{resourceVersion: resourceVersion, object: w.newFunc(), annotateInitialEventsEndBookmark: annotateInitialEventsEndBookmark}, true)
 	defer close(w.result)
 	for {
 		select {

--- a/pkg/apiserver/storage/ram/watch_test.go
+++ b/pkg/apiserver/storage/ram/watch_test.go
@@ -19,13 +19,17 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/utils/clock"
 
 	"antrea.io/antrea/v2/pkg/apiserver/storage"
+	"antrea.io/antrea/v2/pkg/apiserver/storage/testutil"
 )
 
 // simpleInternalEvent simply construct watch.Event based on the provided Type and Object
@@ -85,7 +89,7 @@ func TestEvents(t *testing.T) {
 				},
 			},
 			expected: []watch.Event{
-				{Type: watch.Bookmark, Object: &v1.Pod{}},
+				testutil.ExpectedInitBookmark(t, &v1.Pod{}, "0"),
 				{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1"}}},
 				{Type: watch.Modified, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod2"}}},
 				{Type: watch.Deleted, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod3"}}},
@@ -114,7 +118,7 @@ func TestEvents(t *testing.T) {
 			},
 			expected: []watch.Event{
 				{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1"}}},
-				{Type: watch.Bookmark, Object: &v1.Pod{}},
+				testutil.ExpectedInitBookmark(t, &v1.Pod{}, "0"),
 				{Type: watch.Modified, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod2"}}},
 				{Type: watch.Deleted, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod3"}}},
 			},
@@ -139,7 +143,7 @@ func TestEvents(t *testing.T) {
 			},
 			expected: []watch.Event{
 				{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1"}}},
-				{Type: watch.Bookmark, Object: &v1.Pod{}},
+				testutil.ExpectedInitBookmark(t, &v1.Pod{}, "0"),
 				{Type: watch.Deleted, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod3"}}},
 			},
 		},
@@ -166,6 +170,45 @@ func TestEvents(t *testing.T) {
 		}
 		w.Stop()
 	}
+}
+
+func TestBookmarkEventToWatchEvent(t *testing.T) {
+	b := &bookmarkEvent{resourceVersion: 5, object: &v1.Pod{}}
+
+	// The bookmark marking the end of the initial events carries the resourceVersion and the
+	// initial-events-end annotation.
+	initEvent := b.ToWatchEvent(&storage.Selectors{}, true)
+	assert.Equal(t, watch.Bookmark, initEvent.Type)
+	initMeta, err := meta.Accessor(initEvent.Object)
+	require.NoError(t, err)
+	assert.Equal(t, "5", initMeta.GetResourceVersion())
+	assert.Equal(t, map[string]string{metav1.InitialEventsAnnotationKey: "true"}, initMeta.GetAnnotations())
+
+	// A non-init bookmark carries the resourceVersion but must not be labeled as the end of the
+	// initial events, otherwise clients would prematurely consider their cache synced.
+	nonInitEvent := b.ToWatchEvent(&storage.Selectors{}, false)
+	assert.Equal(t, watch.Bookmark, nonInitEvent.Type)
+	nonInitMeta, err := meta.Accessor(nonInitEvent.Object)
+	require.NoError(t, err)
+	assert.Equal(t, "5", nonInitMeta.GetResourceVersion())
+	assert.NotContains(t, nonInitMeta.GetAnnotations(), metav1.InitialEventsAnnotationKey)
+
+	// The InternalEvent must remain immutable during its conversion: the stored object should not
+	// have been mutated by either conversion above.
+	storedMeta, err := meta.Accessor(b.object)
+	require.NoError(t, err)
+	assert.Empty(t, storedMeta.GetResourceVersion())
+	assert.Empty(t, storedMeta.GetAnnotations())
+
+	// Even if the bookmark object already carries the initial-events-end annotation, a non-init
+	// bookmark must have it stripped so clients don't mistake it for the end of the initial events.
+	annotated := &bookmarkEvent{resourceVersion: 7, object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Annotations: map[string]string{metav1.InitialEventsAnnotationKey: "true"},
+	}}}
+	annotatedEvent := annotated.ToWatchEvent(&storage.Selectors{}, false)
+	annotatedMeta, err := meta.Accessor(annotatedEvent.Object)
+	require.NoError(t, err)
+	assert.NotContains(t, annotatedMeta.GetAnnotations(), metav1.InitialEventsAnnotationKey)
 }
 
 func TestAddTimeout(t *testing.T) {

--- a/pkg/apiserver/storage/ram/watch_test.go
+++ b/pkg/apiserver/storage/ram/watch_test.go
@@ -62,6 +62,13 @@ func (e *emptyInternalEvent) GetResourceVersion() uint64 {
 	return 0
 }
 
+func bookmarkPod(resourceVersion string) watch.Event {
+	return watch.Event{
+		Type:   watch.Bookmark,
+		Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{ResourceVersion: resourceVersion}},
+	}
+}
+
 func TestEvents(t *testing.T) {
 	testCases := []struct {
 		initEvents  []storage.InternalEvent
@@ -89,7 +96,7 @@ func TestEvents(t *testing.T) {
 				},
 			},
 			expected: []watch.Event{
-				testutil.ExpectedInitBookmark(t, &v1.Pod{}, "0"),
+				bookmarkPod("0"),
 				{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1"}}},
 				{Type: watch.Modified, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod2"}}},
 				{Type: watch.Deleted, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod3"}}},
@@ -118,7 +125,7 @@ func TestEvents(t *testing.T) {
 			},
 			expected: []watch.Event{
 				{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1"}}},
-				testutil.ExpectedInitBookmark(t, &v1.Pod{}, "0"),
+				bookmarkPod("0"),
 				{Type: watch.Modified, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod2"}}},
 				{Type: watch.Deleted, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod3"}}},
 			},
@@ -143,7 +150,7 @@ func TestEvents(t *testing.T) {
 			},
 			expected: []watch.Event{
 				{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1"}}},
-				testutil.ExpectedInitBookmark(t, &v1.Pod{}, "0"),
+				bookmarkPod("0"),
 				{Type: watch.Deleted, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod3"}}},
 			},
 		},
@@ -172,17 +179,36 @@ func TestEvents(t *testing.T) {
 	}
 }
 
+func TestEventsWithInitialEventsEndBookmarkAnnotation(t *testing.T) {
+	w := newStoreWatcher(10, &storage.Selectors{}, func() {}, func() runtime.Object { return new(v1.Pod) })
+	go w.process(storage.WithInitialEventsEndBookmarkAnnotation(context.Background()), nil, 7)
+
+	actualEvent := <-w.ResultChan()
+	assert.Equal(t, testutil.ExpectedInitBookmark(t, &v1.Pod{}, "7"), actualEvent)
+	w.Stop()
+}
+
 func TestBookmarkEventToWatchEvent(t *testing.T) {
 	b := &bookmarkEvent{resourceVersion: 5, object: &v1.Pod{}}
 
-	// The bookmark marking the end of the initial events carries the resourceVersion and the
-	// initial-events-end annotation.
+	// A plain init bookmark carries the resourceVersion but must not be labeled as a Kubernetes
+	// watch-list completion bookmark.
 	initEvent := b.ToWatchEvent(&storage.Selectors{}, true)
 	assert.Equal(t, watch.Bookmark, initEvent.Type)
 	initMeta, err := meta.Accessor(initEvent.Object)
 	require.NoError(t, err)
 	assert.Equal(t, "5", initMeta.GetResourceVersion())
-	assert.Equal(t, map[string]string{metav1.InitialEventsAnnotationKey: "true"}, initMeta.GetAnnotations())
+	assert.NotContains(t, initMeta.GetAnnotations(), metav1.InitialEventsAnnotationKey)
+
+	// When requested for a watch-list, the bookmark marking the end of the initial events carries
+	// the initial-events-end annotation.
+	annotatedInit := &bookmarkEvent{resourceVersion: 6, object: &v1.Pod{}, annotateInitialEventsEndBookmark: true}
+	annotatedInitEvent := annotatedInit.ToWatchEvent(&storage.Selectors{}, true)
+	assert.Equal(t, watch.Bookmark, annotatedInitEvent.Type)
+	annotatedInitMeta, err := meta.Accessor(annotatedInitEvent.Object)
+	require.NoError(t, err)
+	assert.Equal(t, "6", annotatedInitMeta.GetResourceVersion())
+	assert.Equal(t, map[string]string{metav1.InitialEventsAnnotationKey: "true"}, annotatedInitMeta.GetAnnotations())
 
 	// A non-init bookmark carries the resourceVersion but must not be labeled as the end of the
 	// initial events, otherwise clients would prematurely consider their cache synced.
@@ -200,15 +226,6 @@ func TestBookmarkEventToWatchEvent(t *testing.T) {
 	assert.Empty(t, storedMeta.GetResourceVersion())
 	assert.Empty(t, storedMeta.GetAnnotations())
 
-	// Even if the bookmark object already carries the initial-events-end annotation, a non-init
-	// bookmark must have it stripped so clients don't mistake it for the end of the initial events.
-	annotated := &bookmarkEvent{resourceVersion: 7, object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{
-		Annotations: map[string]string{metav1.InitialEventsAnnotationKey: "true"},
-	}}}
-	annotatedEvent := annotated.ToWatchEvent(&storage.Selectors{}, false)
-	annotatedMeta, err := meta.Accessor(annotatedEvent.Object)
-	require.NoError(t, err)
-	assert.NotContains(t, annotatedMeta.GetAnnotations(), metav1.InitialEventsAnnotationKey)
 }
 
 func TestAddTimeout(t *testing.T) {

--- a/pkg/apiserver/storage/testutil/bookmark.go
+++ b/pkg/apiserver/storage/testutil/bookmark.go
@@ -1,0 +1,51 @@
+// Copyright 2026 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package testutil provides shared helpers for tests that assert on the events emitted by the
+// in-memory watch storage.
+package testutil
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+// ExpectedInitBookmark returns the bookmark event that the storage emits to mark the end of the
+// initial set of events for a watch: the bookmark object carries the given resourceVersion and the
+// "k8s.io/initial-events-end" annotation required by the Kubernetes watch-list contract.
+//
+// The provided object is deep-copied before being mutated, so callers can pass a shared empty
+// object without risking accidental shared state, and only the initial-events-end annotation is
+// added (any existing annotations are preserved). It accepts testing.TB so it can be used from
+// tests and benchmarks alike.
+func ExpectedInitBookmark(tb testing.TB, obj runtime.Object, resourceVersion string) watch.Event {
+	tb.Helper()
+	obj = obj.DeepCopyObject()
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		tb.Fatalf("Failed to access bookmark object metadata: %v", err)
+	}
+	accessor.SetResourceVersion(resourceVersion)
+	annotations := accessor.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[metav1.InitialEventsAnnotationKey] = "true"
+	accessor.SetAnnotations(annotations)
+	return watch.Event{Type: watch.Bookmark, Object: obj}
+}

--- a/pkg/controller/egress/store/egressgroup_test.go
+++ b/pkg/controller/egress/store/egressgroup_test.go
@@ -29,6 +29,7 @@ import (
 
 	"antrea.io/antrea/v2/pkg/apis/controlplane"
 	"antrea.io/antrea/v2/pkg/apiserver/storage"
+	"antrea.io/antrea/v2/pkg/apiserver/storage/testutil"
 	"antrea.io/antrea/v2/pkg/controller/types"
 )
 
@@ -78,7 +79,7 @@ func TestWatchEgressGroupEvent(t *testing.T) {
 				store.Create(eg1)
 			},
 			expectedEvents: []watch.Event{
-				{Type: watch.Bookmark, Object: &controlplane.EgressGroup{}},
+				testutil.ExpectedInitBookmark(t, &controlplane.EgressGroup{}, "0"),
 				{Type: watch.Added, Object: &controlplane.EgressGroup{
 					TypeMeta: metav1.TypeMeta{},
 					ObjectMeta: metav1.ObjectMeta{
@@ -97,7 +98,7 @@ func TestWatchEgressGroupEvent(t *testing.T) {
 				store.Update(eg2)
 			},
 			expectedEvents: []watch.Event{
-				{Type: watch.Bookmark, Object: &controlplane.EgressGroup{}},
+				testutil.ExpectedInitBookmark(t, &controlplane.EgressGroup{}, "0"),
 				{Type: watch.Added, Object: &controlplane.EgressGroup{
 					TypeMeta: metav1.TypeMeta{},
 					ObjectMeta: metav1.ObjectMeta{
@@ -126,7 +127,7 @@ func TestWatchEgressGroupEvent(t *testing.T) {
 				store.Update(eg3)
 			},
 			expectedEvents: []watch.Event{
-				{Type: watch.Bookmark, Object: &controlplane.EgressGroup{}},
+				testutil.ExpectedInitBookmark(t, &controlplane.EgressGroup{}, "0"),
 				{Type: watch.Added, Object: &controlplane.EgressGroup{
 					TypeMeta: metav1.TypeMeta{},
 					ObjectMeta: metav1.ObjectMeta{
@@ -154,7 +155,7 @@ func TestWatchEgressGroupEvent(t *testing.T) {
 				store.Update(eg3)
 			},
 			expectedEvents: []watch.Event{
-				{Type: watch.Bookmark, Object: &controlplane.EgressGroup{}},
+				testutil.ExpectedInitBookmark(t, &controlplane.EgressGroup{}, "0"),
 				{Type: watch.Added, Object: &controlplane.EgressGroup{
 					TypeMeta: metav1.TypeMeta{},
 					ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/egress/store/egressgroup_test.go
+++ b/pkg/controller/egress/store/egressgroup_test.go
@@ -29,7 +29,6 @@ import (
 
 	"antrea.io/antrea/v2/pkg/apis/controlplane"
 	"antrea.io/antrea/v2/pkg/apiserver/storage"
-	"antrea.io/antrea/v2/pkg/apiserver/storage/testutil"
 	"antrea.io/antrea/v2/pkg/controller/types"
 )
 
@@ -79,7 +78,7 @@ func TestWatchEgressGroupEvent(t *testing.T) {
 				store.Create(eg1)
 			},
 			expectedEvents: []watch.Event{
-				testutil.ExpectedInitBookmark(t, &controlplane.EgressGroup{}, "0"),
+				{Type: watch.Bookmark, Object: &controlplane.EgressGroup{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "0"}}},
 				{Type: watch.Added, Object: &controlplane.EgressGroup{
 					TypeMeta: metav1.TypeMeta{},
 					ObjectMeta: metav1.ObjectMeta{
@@ -98,7 +97,7 @@ func TestWatchEgressGroupEvent(t *testing.T) {
 				store.Update(eg2)
 			},
 			expectedEvents: []watch.Event{
-				testutil.ExpectedInitBookmark(t, &controlplane.EgressGroup{}, "0"),
+				{Type: watch.Bookmark, Object: &controlplane.EgressGroup{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "0"}}},
 				{Type: watch.Added, Object: &controlplane.EgressGroup{
 					TypeMeta: metav1.TypeMeta{},
 					ObjectMeta: metav1.ObjectMeta{
@@ -127,7 +126,7 @@ func TestWatchEgressGroupEvent(t *testing.T) {
 				store.Update(eg3)
 			},
 			expectedEvents: []watch.Event{
-				testutil.ExpectedInitBookmark(t, &controlplane.EgressGroup{}, "0"),
+				{Type: watch.Bookmark, Object: &controlplane.EgressGroup{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "0"}}},
 				{Type: watch.Added, Object: &controlplane.EgressGroup{
 					TypeMeta: metav1.TypeMeta{},
 					ObjectMeta: metav1.ObjectMeta{
@@ -155,7 +154,7 @@ func TestWatchEgressGroupEvent(t *testing.T) {
 				store.Update(eg3)
 			},
 			expectedEvents: []watch.Event{
-				testutil.ExpectedInitBookmark(t, &controlplane.EgressGroup{}, "0"),
+				{Type: watch.Bookmark, Object: &controlplane.EgressGroup{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "0"}}},
 				{Type: watch.Added, Object: &controlplane.EgressGroup{
 					TypeMeta: metav1.TypeMeta{},
 					ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/networkpolicy/store/networkpolicy_test.go
+++ b/pkg/controller/networkpolicy/store/networkpolicy_test.go
@@ -27,7 +27,6 @@ import (
 
 	"antrea.io/antrea/v2/pkg/apis/controlplane"
 	"antrea.io/antrea/v2/pkg/apiserver/storage"
-	"antrea.io/antrea/v2/pkg/apiserver/storage/testutil"
 	"antrea.io/antrea/v2/pkg/controller/types"
 )
 
@@ -91,7 +90,7 @@ func TestWatchNetworkPolicyEvent(t *testing.T) {
 				store.Update(policyV2)
 			},
 			expected: []watch.Event{
-				testutil.ExpectedInitBookmark(t, &controlplane.NetworkPolicy{}, "0"),
+				{Type: watch.Bookmark, Object: &controlplane.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "0"}}},
 				{Type: watch.Added, Object: &controlplane.NetworkPolicy{
 					ObjectMeta:      metav1.ObjectMeta{Name: "bar"},
 					SourceRef:       &npRef,
@@ -120,7 +119,7 @@ func TestWatchNetworkPolicyEvent(t *testing.T) {
 				store.Update(policyV1)
 			},
 			expected: []watch.Event{
-				testutil.ExpectedInitBookmark(t, &controlplane.NetworkPolicy{}, "0"),
+				{Type: watch.Bookmark, Object: &controlplane.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "0"}}},
 				{Type: watch.Added, Object: &controlplane.NetworkPolicy{
 					ObjectMeta:      metav1.ObjectMeta{Name: "bar"},
 					SourceRef:       &npRef,

--- a/pkg/controller/networkpolicy/store/networkpolicy_test.go
+++ b/pkg/controller/networkpolicy/store/networkpolicy_test.go
@@ -27,6 +27,7 @@ import (
 
 	"antrea.io/antrea/v2/pkg/apis/controlplane"
 	"antrea.io/antrea/v2/pkg/apiserver/storage"
+	"antrea.io/antrea/v2/pkg/apiserver/storage/testutil"
 	"antrea.io/antrea/v2/pkg/controller/types"
 )
 
@@ -90,7 +91,7 @@ func TestWatchNetworkPolicyEvent(t *testing.T) {
 				store.Update(policyV2)
 			},
 			expected: []watch.Event{
-				{Type: watch.Bookmark, Object: &controlplane.NetworkPolicy{}},
+				testutil.ExpectedInitBookmark(t, &controlplane.NetworkPolicy{}, "0"),
 				{Type: watch.Added, Object: &controlplane.NetworkPolicy{
 					ObjectMeta:      metav1.ObjectMeta{Name: "bar"},
 					SourceRef:       &npRef,
@@ -119,7 +120,7 @@ func TestWatchNetworkPolicyEvent(t *testing.T) {
 				store.Update(policyV1)
 			},
 			expected: []watch.Event{
-				{Type: watch.Bookmark, Object: &controlplane.NetworkPolicy{}},
+				testutil.ExpectedInitBookmark(t, &controlplane.NetworkPolicy{}, "0"),
 				{Type: watch.Added, Object: &controlplane.NetworkPolicy{
 					ObjectMeta:      metav1.ObjectMeta{Name: "bar"},
 					SourceRef:       &npRef,


### PR DESCRIPTION
The controlplane aggregated API emits a BOOKMARK event to signal the end of the initial set of objects on a watch. However, the bookmark object did not carry a resourceVersion nor the "k8s.io/initial-events-end" annotation that Kubernetes watch-list (streaming list) semantics require. As a result, client-go watch-list informers never observed the end of the initial events and hung waiting for synchronization. This was reported with Rancher v2.14.2, whose cache sync stalled against an Antrea cluster.

Set the bookmark object's resourceVersion and, for the bookmark that marks the end of the initial events, add the "k8s.io/initial-events-end" annotation, following the upstream pattern in
k8s.io/apiserver/pkg/storage.AnnotateInitialEventsEndBookmark. The bookmark object is deep-copied before being mutated so that the InternalEvent remains immutable during its conversion to a watch.Event, and meta.Accessor is used to set the metadata regardless of the concrete object type.

Ref: https://github.com/antrea-io/antrea/issues/8123