### PR TITLE
Automated cherry pick of #8128: Fix a typo in v2.6.2 release log (#8128)

### DIFF
--- a/CHANGELOG/CHANGELOG-2.6.md
+++ b/CHANGELOG/CHANGELOG-2.6.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Migrate UUID library from google/uuid to gofrs/uuid/v5. ([#8053](https://github.com/antrea-io/antrea/pull/8055), [@hangyan])
+- Migrate UUID library from google/uuid to gofrs/uuid/v5. ([#8055](https://github.com/antrea-io/antrea/pull/8055), [@hangyan])
 - Update lumberjack dependency to use the Antrea fork. ([#8053](https://github.com/antrea-io/antrea/pull/8053), [@hangyan])
 - Upgrade Kubernetes dependencies to 1.36.1 and regenerate code. ([#8057](https://github.com/antrea-io/antrea/pull/8057), [@antoninbas])
 - Update AWS SDK Go v2 dependencies and migrate the S3 uploader to the transfer manager API. ([#7983](https://github.com/antrea-io/antrea/pull/7983), [#8036](https://github.com/antrea-io/antrea/pull/8036), [@antoninbas] [@luolanzone])


### PR DESCRIPTION
Cherry pick of #8128 on release-2.6.

#8128: Fix a typo in v2.6.2 release log (#8128)

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.