### PR TITLE
multicluster: start StaleResCleanupController after cache is synced

### DIFF
--- a/multicluster/cmd/multicluster-controller/leader.go
+++ b/multicluster/cmd/multicluster-controller/leader.go
@@ -123,7 +123,12 @@ func runLeader(o *Options) error {
 	if err = staleController.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("error creating StaleResCleanupController: %v", err)
 	}
-	go staleController.Run(stopCh)
+	// Add the StaleResCleanupController as a Runnable to the Manager so it is started
+	// only after the cache has been synced, avoiding a spurious "the cache is not started"
+	// error on startup (see antrea-io/antrea#6152).
+	if err = mgr.Add(staleController); err != nil {
+		return fmt.Errorf("error adding StaleResCleanupController to Manager: %v", err)
+	}
 
 	klog.InfoS("Leader MC Controller Starting Manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {

--- a/multicluster/cmd/multicluster-controller/member.go
+++ b/multicluster/cmd/multicluster-controller/member.go
@@ -141,8 +141,12 @@ func runMember(o *Options) error {
 		env.GetPodNamespace(),
 		commonAreaGetter,
 	)
-
-	go staleController.Run(stopCh)
+	// Add the StaleResCleanupController as a Runnable to the Manager so it is started
+	// only after the cache has been synced, avoiding a spurious "the cache is not started"
+	// error on startup (see antrea-io/antrea#6152).
+	if err := mgr.Add(staleController); err != nil {
+		return fmt.Errorf("error adding StaleResCleanupController to Manager: %v", err)
+	}
 
 	// Member runs ResourceImportReconciler from RemoteCommonArea only
 

--- a/multicluster/controllers/multicluster/leader/stale_controller.go
+++ b/multicluster/controllers/multicluster/leader/stale_controller.go
@@ -93,13 +93,18 @@ func (c *StaleResCleanupController) cleanUpExpiredMemberClusterAnnounces(ctx con
 	}
 }
 
-func (c *StaleResCleanupController) Run(stopCh <-chan struct{}) {
+// Start starts the StaleResCleanupController and blocks until ctx is canceled. It implements
+// the controller-runtime Runnable interface, so the controller can be added to the Manager via
+// mgr.Add. The Manager only starts Runnables after the cache has been synced, which guarantees
+// that the first call to cleanUpExpiredMemberClusterAnnounces won't fail with
+// "the cache is not started, can not read objects" (see antrea-io/antrea#6152).
+func (c *StaleResCleanupController) Start(ctx context.Context) error {
 	klog.InfoS("Starting StaleResCleanupController")
 	defer klog.InfoS("Shutting down StaleResCleanupController")
 
-	ctx := wait.ContextForChannel(stopCh)
 	go wait.UntilWithContext(ctx, c.cleanUpExpiredMemberClusterAnnounces, memberClusterAnnounceStaleTime/2)
-	<-stopCh
+	<-ctx.Done()
+	return nil
 }
 
 func (c *StaleResCleanupController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/multicluster/controllers/multicluster/leader/stale_controller_test.go
+++ b/multicluster/controllers/multicluster/leader/stale_controller_test.go
@@ -28,6 +28,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	mcv1alpha1 "antrea.io/antrea/v2/multicluster/apis/multicluster/v1alpha1"
 	mcv1alpha2 "antrea.io/antrea/v2/multicluster/apis/multicluster/v1alpha2"
@@ -240,5 +241,37 @@ func TestStaleController_CleanUpMemberClusterAnnounces(t *testing.T) {
 
 			assert.Equal(t, tt.exceptMemberClusterAnnounceNumber, len(memberClusterAnnounceList.Items))
 		})
+	}
+}
+
+// TestStart verifies that Start implements the controller-runtime Runnable contract: it blocks
+// until the context is canceled and then returns nil. This guarantees the controller can be
+// added to a Manager via mgr.Add, which only starts Runnables after the cache is synced
+// (see antrea-io/antrea#6152).
+func TestStart(t *testing.T) {
+	// Compile-time check that StaleResCleanupController satisfies manager.Runnable.
+	var _ manager.Runnable = &StaleResCleanupController{}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(common.TestScheme).Build()
+	c := NewStaleResCleanupController(fakeClient, common.TestScheme)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- c.Start(ctx)
+	}()
+
+	select {
+	case err := <-done:
+		t.Fatalf("Start should block until ctx is canceled, but it returned early with err = %v", err)
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		require.NoError(t, err, "Start should return nil after ctx is canceled")
+	case <-time.After(2 * time.Second):
+		t.Fatalf("Start did not return after ctx was canceled")
 	}
 }

--- a/multicluster/controllers/multicluster/member/resourceimport_controller_test.go
+++ b/multicluster/controllers/multicluster/member/resourceimport_controller_test.go
@@ -587,7 +587,7 @@ func TestStaleControllerNoRaceWithResourceImportReconciler(t *testing.T) {
 	go mgr.Run(stopCh)
 	// The staleController should not erroneously delete any LabelIdentities while the reconciliation
 	// of newly added ResourceImports are in-flight.
-	go c.Run(stopCh)
+	go c.Start(wait.ContextForChannel(stopCh))
 	time.Sleep(1 * time.Second)
 	actLabelIdentities := &mcv1alpha1.LabelIdentityList{}
 	err := fakeClient.List(ctx, actLabelIdentities)

--- a/multicluster/controllers/multicluster/member/stale_controller.go
+++ b/multicluster/controllers/multicluster/member/stale_controller.go
@@ -24,7 +24,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -361,12 +360,14 @@ func (c *StaleResCleanupController) cleanUpClusterInfoResourceExports(ctx contex
 	return nil
 }
 
-// Run starts the StaleResCleanupController and blocks until stopCh is closed.
-func (c *StaleResCleanupController) Run(stopCh <-chan struct{}) {
+// Start starts the StaleResCleanupController and blocks until ctx is canceled. It implements
+// the controller-runtime Runnable interface, so the controller can be added to the Manager via
+// mgr.Add. The Manager only starts Runnables after the cache has been synced, which guarantees
+// that the first call to CleanUp won't fail with "the cache is not started, can not read objects"
+// (see antrea-io/antrea#6152).
+func (c *StaleResCleanupController) Start(ctx context.Context) error {
 	klog.InfoS("Starting StaleResCleanupController")
 	defer klog.InfoS("Shutting down StaleResCleanupController")
-
-	ctx := wait.ContextForChannel(stopCh)
 
 	go func() {
 		retry.OnError(common.CleanUpRetry, func(err error) bool { return true },
@@ -375,15 +376,23 @@ func (c *StaleResCleanupController) Run(stopCh <-chan struct{}) {
 			})
 	}()
 
-	for range c.commonAreaCreationCh {
-		retry.OnError(common.CleanUpRetry, func(err error) bool { return true },
-			func() error {
-				if err := c.cleanUpStaleResources(ctx); err != nil {
-					klog.ErrorS(err, "Failed to clean up stale resources after a ClusterSet is created, will retry later")
-					return err
-				}
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case _, ok := <-c.commonAreaCreationCh:
+			if !ok {
 				return nil
-			})
+			}
+			retry.OnError(common.CleanUpRetry, func(err error) bool { return true },
+				func() error {
+					if err := c.cleanUpStaleResources(ctx); err != nil {
+						klog.ErrorS(err, "Failed to clean up stale resources after a ClusterSet is created, will retry later")
+						return err
+					}
+					return nil
+				})
+		}
 	}
 }
 

--- a/multicluster/test/integration/suite_test.go
+++ b/multicluster/test/integration/suite_test.go
@@ -175,7 +175,7 @@ var _ = BeforeSuite(func() {
 		clusterSetReconciler,
 	)
 
-	go staleController.Run(stopCh)
+	go staleController.Start(ctx)
 	// Fake the commonAreaCreation event since the ClusterSet creation is only triggered one time
 	// when the ClusterSet is created, but the stale controller test is not running yet.
 	go wait.UntilWithContext(ctx, func(ctx context.Context) {


### PR DESCRIPTION
The StaleResCleanupController.Run method was launched as a goroutine before the manager started, which caused the controller's first cache List call to fail with "the cache is not started, can not read objects" (antrea-io/antrea#6152).

Convert both leader and member StaleResCleanupController from the Run(stopCh) pattern to the controller-runtime Runnable interface Start(ctx) error, and register them with mgr.Add() instead of launching them as raw goroutines. The Manager only starts Runnables after the cache has been synced, which eliminates the spurious error.

- Rename Run(stopCh) to Start(ctx context.Context) error for both leader and member StaleResCleanupController
- Wire via mgr.Add() in leader.go and member.go instead of go .Run()
- Add TestStart to verify the Runnable contract (blocks until ctx done)
- Update integration and resourceimport_controller_test call sites