### PR TITLE
Multi-cluster controller leader cache changes

### DIFF
--- a/multicluster/cmd/multicluster-controller/leader.go
+++ b/multicluster/cmd/multicluster-controller/leader.go
@@ -123,7 +123,6 @@ func runLeader(o *Options) error {
 	if err = staleController.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("error creating StaleResCleanupController: %v", err)
 	}
-	go staleController.Run(stopCh)
 
 	klog.InfoS("Leader MC Controller Starting Manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {

--- a/multicluster/controllers/multicluster/leader/stale_controller.go
+++ b/multicluster/controllers/multicluster/leader/stale_controller.go
@@ -93,13 +93,12 @@ func (c *StaleResCleanupController) cleanUpExpiredMemberClusterAnnounces(ctx con
 	}
 }
 
-func (c *StaleResCleanupController) Run(stopCh <-chan struct{}) {
+func (c *StaleResCleanupController) Start(ctx context.Context) error {
 	klog.InfoS("Starting StaleResCleanupController")
 	defer klog.InfoS("Shutting down StaleResCleanupController")
 
-	ctx := wait.ContextForChannel(stopCh)
-	go wait.UntilWithContext(ctx, c.cleanUpExpiredMemberClusterAnnounces, memberClusterAnnounceStaleTime/2)
-	<-stopCh
+	wait.UntilWithContext(ctx, c.cleanUpExpiredMemberClusterAnnounces, memberClusterAnnounceStaleTime/2)
+	return nil
 }
 
 func (c *StaleResCleanupController) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -146,6 +145,11 @@ func (c *StaleResCleanupController) SetupWithManager(mgr ctrl.Manager) error {
 		return []string{resExport.Spec.ClusterID}
 	}); err != nil {
 		klog.ErrorS(err, "Failed to create the index")
+		return err
+	}
+
+	if err := mgr.Add(c); err != nil {
+		klog.ErrorS(err, "Failed to register StaleResCleanupController with the Manager")
 		return err
 	}
 

--- a/multicluster/controllers/multicluster/leader/stale_controller_test.go
+++ b/multicluster/controllers/multicluster/leader/stale_controller_test.go
@@ -144,6 +144,14 @@ func TestReconcile(t *testing.T) {
 	}
 }
 
+func TestStaleController_Start(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().WithScheme(common.TestScheme).Build()
+	c := NewStaleResCleanupController(fakeClient, common.TestScheme)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	assert.NoError(t, c.Start(ctx))
+}
+
 func TestStaleController_CleanUpMemberClusterAnnounces(t *testing.T) {
 	tests := []struct {
 		name                              string


### PR DESCRIPTION
```
╰─$ kubectl -n antrea-multicluster logs -f deploy/antrea-mc-controller
I0622 19:57:47.629373       1 server.go:183] "Registering webhook" logger="controller-runtime.webhook" path="/mutate-multicluster-crd-antrea-io-v1alpha1-resourceexport"
I0622 19:57:47.633820       1 leader.go:127] "Leader MC Controller Starting Manager"
I0622 19:57:47.633922       1 server.go:83] "starting server" name="health probe" addr="[::]:8080"
I0622 19:57:47.633992       1 server.go:191] "Starting webhook server" logger="controller-runtime.webhook"
I0622 19:57:47.634478       1 certwatcher.go:214] "Updated current TLS certificate" logger="controller-runtime.certwatcher" cert="/var/run/antrea/multicluster-controller-self-signed/tls.crt" key="/var/run/antrea/multicluster-controller-self-signed/tls.key"
I0622 19:57:47.634711       1 server.go:242] "Serving webhook server" logger="controller-runtime.webhook" host="" port=9443
I0622 19:57:47.634791       1 certwatcher.go:136] "Starting certificate poll+watcher" logger="controller-runtime.certwatcher" cert="/var/run/antrea/multicluster-controller-self-signed/tls.crt" key="/var/run/antrea/multicluster-controller-self-signed/tls.key" interval="10s"
I0622 19:57:47.735233       1 stale_controller.go:97] "Starting StaleResCleanupController"
```

changes are fairly simple  https://github.com/antrea-io/antrea/issues/6152