### PR TITLE
Log invalid Namespace enable-logging annotation values

### DIFF
--- a/pkg/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller.go
@@ -720,7 +720,18 @@ func (n *NetworkPolicyController) processNetworkPolicy(np *networkingv1.NetworkP
 	enableLogging := false
 	namespace, err := n.namespaceLister.Get(np.Namespace)
 	if err == nil {
-		enableLogging, _ = strconv.ParseBool(namespace.Annotations[EnableNPLoggingAnnotationKey])
+		// Only parse the annotation when it is present: an absent annotation is the common case and
+		// must not be reported as an error, while a present but invalid value should be surfaced
+		// instead of being silently ignored.
+		if value, exists := namespace.Annotations[EnableNPLoggingAnnotationKey]; exists {
+			parsed, parseErr := strconv.ParseBool(value)
+			if parseErr != nil {
+				klog.ErrorS(parseErr, "The Namespace's enable-logging annotation was invalid, NetworkPolicy logging will not be enabled",
+					"Namespace", np.Namespace, "annotation", EnableNPLoggingAnnotationKey, "value", value)
+			} else {
+				enableLogging = parsed
+			}
+		}
 	}
 	var ingressRuleExists, egressRuleExists bool
 	// Compute NetworkPolicyRule for Ingress Rule.

--- a/pkg/controller/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller_test.go
@@ -2322,6 +2322,47 @@ func TestProcessNetworkPolicy(t *testing.T) {
 			expectedAppliedToGroups: 1,
 			expectedAddressGroups:   0,
 		},
+		{
+			name: "default-allow-ingress-invalid-logging-annotation",
+			existingObjects: []runtime.Object{
+				&corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "nsA",
+						// An invalid (non-boolean) value must not enable logging.
+						Annotations: map[string]string{"networkpolicy.antrea.io/enable-logging": "yes"},
+					},
+				},
+			},
+			inputPolicy: &networkingv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "nsA", Name: "npA", UID: "uidA"},
+				Spec: networkingv1.NetworkPolicySpec{
+					PodSelector: metav1.LabelSelector{},
+					PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+					Ingress:     []networkingv1.NetworkPolicyIngressRule{{}},
+				},
+			},
+			expectedPolicy: &antreatypes.NetworkPolicy{
+				UID:  "uidA",
+				Name: "uidA",
+				SourceRef: &controlplane.NetworkPolicyReference{
+					Type:      controlplane.K8sNetworkPolicy,
+					Namespace: "nsA",
+					Name:      "npA",
+					UID:       "uidA",
+				},
+				Rules: []controlplane.NetworkPolicyRule{{
+					Direction: controlplane.DirectionIn,
+					From:      matchAllPeer,
+					Services:  nil,
+					Priority:  defaultRulePriority,
+					Action:    &defaultAction,
+					// EnableLogging stays false because the annotation value is invalid.
+				}},
+				AppliedToGroups: []string{getNormalizedUID(antreatypes.NewGroupSelector("nsA", &metav1.LabelSelector{}, nil, nil, nil).NormalizedName)},
+			},
+			expectedAppliedToGroups: 1,
+			expectedAddressGroups:   0,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes #8134

The `networkpolicy.antrea.io/enable-logging` Namespace annotation was parsed
with `strconv.ParseBool` and the error was silently dropped
(`enableLogging, _ = ...`). An invalid value such as `yes`, `on`, or `true `
(trailing space) therefore left NetworkPolicy audit logging disabled with no
indication to the operator.

This change parses the annotation only when it is present (an absent
annotation is the common case and also makes `ParseBool` error, so it must not
be reported), and logs the invalid value instead of swallowing the error,
while still defaulting to logging disabled. The resulting `EnableLogging` value
is unchanged; the improvement is surfacing the previously-swallowed error so a
misconfigured annotation is observable.

A `TestProcessNetworkPolicy` case is added asserting that an invalid
annotation value does not enable logging.
