### PR TITLE
Automated cherry pick of #8124: Annotate end-of-initial-events bookmark for watch-list

### DIFF
--- a/pkg/apiserver/registry/controlplane/egressgroup/rest.go
+++ b/pkg/apiserver/registry/controlplane/egressgroup/rest.go
@@ -99,6 +99,7 @@ func (r *REST) NamespaceScoped() bool {
 
 func (r *REST) Watch(ctx context.Context, options *internalversion.ListOptions) (watch.Interface, error) {
 	key, label, field := networkpolicy.GetSelectors(options)
+	ctx = storage.WithInitialEventsEndBookmarkAnnotationFromListOptions(ctx, options)
 	return r.egressGroupStore.Watch(ctx, key, label, field)
 }
 

--- a/pkg/apiserver/registry/controlplane/egressgroup/rest_test.go
+++ b/pkg/apiserver/registry/controlplane/egressgroup/rest_test.go
@@ -154,7 +154,7 @@ func TestRESTWatch(t *testing.T) {
 			name:          "nodeName selecting nothing",
 			fieldSelector: fields.OneTermEqualSelector("nodeName", "foo"),
 			expectedEvents: []watch.Event{
-				{Type: watch.Bookmark, Object: &controlplane.EgressGroup{}},
+				{Type: watch.Bookmark, Object: &controlplane.EgressGroup{ObjectMeta: v1.ObjectMeta{ResourceVersion: "1"}}},
 			},
 		},
 		{
@@ -162,7 +162,7 @@ func TestRESTWatch(t *testing.T) {
 			fieldSelector: fields.OneTermEqualSelector("nodeName", "node1"),
 			expectedEvents: []watch.Event{
 				{Type: watch.Added, Object: &controlplane.EgressGroup{ObjectMeta: v1.ObjectMeta{Name: "egress1"}}},
-				{Type: watch.Bookmark, Object: &controlplane.EgressGroup{}},
+				{Type: watch.Bookmark, Object: &controlplane.EgressGroup{ObjectMeta: v1.ObjectMeta{ResourceVersion: "1"}}},
 			},
 		},
 		{
@@ -170,7 +170,7 @@ func TestRESTWatch(t *testing.T) {
 			fieldSelector: nil,
 			expectedEvents: []watch.Event{
 				{Type: watch.Added, Object: &controlplane.EgressGroup{ObjectMeta: v1.ObjectMeta{Name: "egress1"}}},
-				{Type: watch.Bookmark, Object: &controlplane.EgressGroup{}},
+				{Type: watch.Bookmark, Object: &controlplane.EgressGroup{ObjectMeta: v1.ObjectMeta{ResourceVersion: "1"}}},
 			},
 		},
 	}

--- a/pkg/apiserver/registry/controlplane/supportbundlecollection/rest.go
+++ b/pkg/apiserver/registry/controlplane/supportbundlecollection/rest.go
@@ -99,6 +99,7 @@ func (r *REST) NamespaceScoped() bool {
 
 func (r *REST) Watch(ctx context.Context, options *internalversion.ListOptions) (watch.Interface, error) {
 	key, label, field := networkpolicy.GetSelectors(options)
+	ctx = storage.WithInitialEventsEndBookmarkAnnotationFromListOptions(ctx, options)
 	return r.supportBundleCollectionStore.Watch(ctx, key, label, field)
 }
 

--- a/pkg/apiserver/registry/networkpolicy/addressgroup/rest.go
+++ b/pkg/apiserver/registry/networkpolicy/addressgroup/rest.go
@@ -99,6 +99,7 @@ func (r *REST) NamespaceScoped() bool {
 
 func (r *REST) Watch(ctx context.Context, options *internalversion.ListOptions) (watch.Interface, error) {
 	key, label, field := networkpolicy.GetSelectors(options)
+	ctx = storage.WithInitialEventsEndBookmarkAnnotationFromListOptions(ctx, options)
 	return r.addressGroupStore.Watch(ctx, key, label, field)
 }
 

--- a/pkg/apiserver/registry/networkpolicy/addressgroup/rest_test.go
+++ b/pkg/apiserver/registry/networkpolicy/addressgroup/rest_test.go
@@ -154,7 +154,7 @@ func TestRESTWatch(t *testing.T) {
 			name:          "nodeName selecting nothing",
 			fieldSelector: fields.OneTermEqualSelector("nodeName", "foo"),
 			expectedEvents: []watch.Event{
-				{Type: watch.Bookmark, Object: &controlplane.AddressGroup{}},
+				{Type: watch.Bookmark, Object: &controlplane.AddressGroup{ObjectMeta: v1.ObjectMeta{ResourceVersion: "1"}}},
 			},
 		},
 		{
@@ -162,7 +162,7 @@ func TestRESTWatch(t *testing.T) {
 			fieldSelector: fields.OneTermEqualSelector("nodeName", "node1"),
 			expectedEvents: []watch.Event{
 				{Type: watch.Added, Object: &controlplane.AddressGroup{ObjectMeta: v1.ObjectMeta{Name: "addressGroup1"}}},
-				{Type: watch.Bookmark, Object: &controlplane.AddressGroup{}},
+				{Type: watch.Bookmark, Object: &controlplane.AddressGroup{ObjectMeta: v1.ObjectMeta{ResourceVersion: "1"}}},
 			},
 		},
 		{
@@ -170,7 +170,7 @@ func TestRESTWatch(t *testing.T) {
 			fieldSelector: nil,
 			expectedEvents: []watch.Event{
 				{Type: watch.Added, Object: &controlplane.AddressGroup{ObjectMeta: v1.ObjectMeta{Name: "addressGroup1"}}},
-				{Type: watch.Bookmark, Object: &controlplane.AddressGroup{}},
+				{Type: watch.Bookmark, Object: &controlplane.AddressGroup{ObjectMeta: v1.ObjectMeta{ResourceVersion: "1"}}},
 			},
 		},
 	}

--- a/pkg/apiserver/registry/networkpolicy/appliedtogroup/rest.go
+++ b/pkg/apiserver/registry/networkpolicy/appliedtogroup/rest.go
@@ -99,6 +99,7 @@ func (r *REST) NamespaceScoped() bool {
 
 func (r *REST) Watch(ctx context.Context, options *internalversion.ListOptions) (watch.Interface, error) {
 	key, label, field := networkpolicy.GetSelectors(options)
+	ctx = storage.WithInitialEventsEndBookmarkAnnotationFromListOptions(ctx, options)
 	return r.appliedToGroupStore.Watch(ctx, key, label, field)
 }
 

--- a/pkg/apiserver/registry/networkpolicy/appliedtogroup/rest_test.go
+++ b/pkg/apiserver/registry/networkpolicy/appliedtogroup/rest_test.go
@@ -154,7 +154,7 @@ func TestRESTWatch(t *testing.T) {
 			name:          "nodeName selecting nothing",
 			fieldSelector: fields.OneTermEqualSelector("nodeName", "foo"),
 			expectedEvents: []watch.Event{
-				{Type: watch.Bookmark, Object: &controlplane.AppliedToGroup{}},
+				{Type: watch.Bookmark, Object: &controlplane.AppliedToGroup{ObjectMeta: v1.ObjectMeta{ResourceVersion: "1"}}},
 			},
 		},
 		{
@@ -162,7 +162,7 @@ func TestRESTWatch(t *testing.T) {
 			fieldSelector: fields.OneTermEqualSelector("nodeName", "node1"),
 			expectedEvents: []watch.Event{
 				{Type: watch.Added, Object: &controlplane.AppliedToGroup{ObjectMeta: v1.ObjectMeta{Name: "appliedToGroup1"}}},
-				{Type: watch.Bookmark, Object: &controlplane.AppliedToGroup{}},
+				{Type: watch.Bookmark, Object: &controlplane.AppliedToGroup{ObjectMeta: v1.ObjectMeta{ResourceVersion: "1"}}},
 			},
 		},
 		{
@@ -170,7 +170,7 @@ func TestRESTWatch(t *testing.T) {
 			fieldSelector: nil,
 			expectedEvents: []watch.Event{
 				{Type: watch.Added, Object: &controlplane.AppliedToGroup{ObjectMeta: v1.ObjectMeta{Name: "appliedToGroup1"}}},
-				{Type: watch.Bookmark, Object: &controlplane.AppliedToGroup{}},
+				{Type: watch.Bookmark, Object: &controlplane.AppliedToGroup{ObjectMeta: v1.ObjectMeta{ResourceVersion: "1"}}},
 			},
 		},
 	}

--- a/pkg/apiserver/registry/networkpolicy/networkpolicy/rest.go
+++ b/pkg/apiserver/registry/networkpolicy/networkpolicy/rest.go
@@ -99,6 +99,7 @@ func (r *REST) NamespaceScoped() bool {
 
 func (r *REST) Watch(ctx context.Context, options *internalversion.ListOptions) (watch.Interface, error) {
 	key, label, field := networkpolicy.GetSelectors(options)
+	ctx = storage.WithInitialEventsEndBookmarkAnnotationFromListOptions(ctx, options)
 	return r.networkPolicyStore.Watch(ctx, key, label, field)
 }
 

--- a/pkg/apiserver/registry/networkpolicy/networkpolicy/rest_test.go
+++ b/pkg/apiserver/registry/networkpolicy/networkpolicy/rest_test.go
@@ -154,7 +154,7 @@ func TestRESTWatch(t *testing.T) {
 			name:          "nodeName selecting nothing",
 			fieldSelector: fields.OneTermEqualSelector("nodeName", "foo"),
 			expectedEvents: []watch.Event{
-				{Type: watch.Bookmark, Object: &controlplane.NetworkPolicy{}},
+				{Type: watch.Bookmark, Object: &controlplane.NetworkPolicy{ObjectMeta: v1.ObjectMeta{ResourceVersion: "1"}}},
 			},
 		},
 		{
@@ -162,7 +162,7 @@ func TestRESTWatch(t *testing.T) {
 			fieldSelector: fields.OneTermEqualSelector("nodeName", "node1"),
 			expectedEvents: []watch.Event{
 				{Type: watch.Added, Object: &controlplane.NetworkPolicy{ObjectMeta: v1.ObjectMeta{Name: "networkPolicy1"}}},
-				{Type: watch.Bookmark, Object: &controlplane.NetworkPolicy{}},
+				{Type: watch.Bookmark, Object: &controlplane.NetworkPolicy{ObjectMeta: v1.ObjectMeta{ResourceVersion: "1"}}},
 			},
 		},
 		{
@@ -170,7 +170,7 @@ func TestRESTWatch(t *testing.T) {
 			fieldSelector: nil,
 			expectedEvents: []watch.Event{
 				{Type: watch.Added, Object: &controlplane.NetworkPolicy{ObjectMeta: v1.ObjectMeta{Name: "networkPolicy1"}}},
-				{Type: watch.Bookmark, Object: &controlplane.NetworkPolicy{}},
+				{Type: watch.Bookmark, Object: &controlplane.NetworkPolicy{ObjectMeta: v1.ObjectMeta{ResourceVersion: "1"}}},
 			},
 		},
 	}

--- a/pkg/apiserver/storage/interfaces.go
+++ b/pkg/apiserver/storage/interfaces.go
@@ -17,6 +17,7 @@ package storage
 import (
 	"context"
 
+	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/watch"
@@ -53,6 +54,34 @@ type GenEventFunc func(key string, prevObj, obj interface{}, resourceVersion uin
 
 // SelectFunc checks whether an object match the provided selectors.
 type SelectFunc func(selectors *Selectors, key string, obj interface{}) bool
+
+type initialEventsEndBookmarkAnnotationKey struct{}
+
+// WithInitialEventsEndBookmarkAnnotation returns a Context that requests annotation of Antrea's
+// end-of-initial-events bookmark for Kubernetes watch-list clients.
+func WithInitialEventsEndBookmarkAnnotation(ctx context.Context) context.Context {
+	return context.WithValue(ctx, initialEventsEndBookmarkAnnotationKey{}, true)
+}
+
+// WithInitialEventsEndBookmarkAnnotationFromListOptions returns a Context that requests annotation
+// of Antrea's end-of-initial-events bookmark when the ListOptions describe a watch-list request.
+func WithInitialEventsEndBookmarkAnnotationFromListOptions(ctx context.Context, options *metainternalversion.ListOptions) context.Context {
+	if shouldAnnotateInitialEventsEndBookmark(options) {
+		return WithInitialEventsEndBookmarkAnnotation(ctx)
+	}
+	return ctx
+}
+
+// ShouldAnnotateInitialEventsEndBookmarkFromContext reports whether the Context requests the
+// Kubernetes watch-list end-of-initial-events annotation on Antrea's init bookmark.
+func ShouldAnnotateInitialEventsEndBookmarkFromContext(ctx context.Context) bool {
+	annotate, _ := ctx.Value(initialEventsEndBookmarkAnnotationKey{}).(bool)
+	return annotate
+}
+
+func shouldAnnotateInitialEventsEndBookmark(options *metainternalversion.ListOptions) bool {
+	return options != nil && options.SendInitialEvents != nil && *options.SendInitialEvents && options.AllowWatchBookmarks
+}
 
 // Interface offers a common storage interface for runtime.Object.
 // It's provided for Network Policy controller to store the translated Network Policy resources, then Antrea apiserver can

--- a/pkg/apiserver/storage/ram/store_test.go
+++ b/pkg/apiserver/storage/ram/store_test.go
@@ -294,7 +294,7 @@ func TestRamStoreWatchAll(t *testing.T) {
 				store.Update(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx2"}}})
 			},
 			expected: []watch.Event{
-				{Type: watch.Bookmark, Object: &v1.Pod{}},
+				bookmarkPod("0"),
 				{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx1"}}}},
 				{Type: watch.Modified, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx2"}}}},
 			},
@@ -305,7 +305,7 @@ func TestRamStoreWatchAll(t *testing.T) {
 				store.Delete("pod1")
 			},
 			expected: []watch.Event{
-				{Type: watch.Bookmark, Object: &v1.Pod{}},
+				bookmarkPod("0"),
 				{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx1"}}}},
 				{Type: watch.Deleted, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx1"}}}},
 			},
@@ -355,7 +355,7 @@ func TestRamStoreWatchWithInitOperations(t *testing.T) {
 			},
 			expected: []watch.Event{
 				{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx3"}}}},
-				{Type: watch.Bookmark, Object: &v1.Pod{}},
+				bookmarkPod("3"),
 				{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod2", Labels: map[string]string{"app": "nginx2"}}}},
 				{Type: watch.Modified, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod2", Labels: map[string]string{"app": "nginx3"}}}},
 			},
@@ -371,7 +371,7 @@ func TestRamStoreWatchWithInitOperations(t *testing.T) {
 			},
 			expected: []watch.Event{
 				{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx1"}}}},
-				{Type: watch.Bookmark, Object: &v1.Pod{}},
+				bookmarkPod("3"),
 				{Type: watch.Deleted, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx1"}}}},
 			},
 		},
@@ -416,7 +416,7 @@ func TestRamStoreWatchWithSelector(t *testing.T) {
 			},
 			labelSelector: labels.SelectorFromSet(labels.Set{"app": "nginx1"}),
 			expected: []watch.Event{
-				{Type: watch.Bookmark, Object: &v1.Pod{}},
+				bookmarkPod("0"),
 				{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx1"}}}},
 				{Type: watch.Deleted, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx1"}}}},
 			},
@@ -428,7 +428,7 @@ func TestRamStoreWatchWithSelector(t *testing.T) {
 			},
 			labelSelector: labels.SelectorFromSet(labels.Set{"app": "nginx2"}),
 			expected: []watch.Event{
-				{Type: watch.Bookmark, Object: &v1.Pod{}},
+				bookmarkPod("0"),
 				{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx2"}}}},
 			},
 		},
@@ -441,7 +441,7 @@ func TestRamStoreWatchWithSelector(t *testing.T) {
 			},
 			labelSelector: labels.SelectorFromSet(labels.Set{"app": "nginx1"}),
 			expected: []watch.Event{
-				{Type: watch.Bookmark, Object: &v1.Pod{}},
+				bookmarkPod("0"),
 				{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx1"}}}},
 				{Type: watch.Deleted, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx1"}}}},
 			},

--- a/pkg/apiserver/storage/ram/watch.go
+++ b/pkg/apiserver/storage/ram/watch.go
@@ -16,8 +16,12 @@ package ram
 
 import (
 	"context"
+	"fmt"
+	"strconv"
 	"sync"
 
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/klog/v2"
@@ -27,12 +31,40 @@ import (
 )
 
 type bookmarkEvent struct {
-	resourceVersion uint64
-	object          runtime.Object
+	resourceVersion                  uint64
+	object                           runtime.Object
+	annotateInitialEventsEndBookmark bool
 }
 
 func (b *bookmarkEvent) ToWatchEvent(selectors *storage.Selectors, isInitEvent bool) *watch.Event {
-	return &watch.Event{Type: watch.Bookmark, Object: b.object}
+	// Copy the object before mutating it: an InternalEvent is expected to be immutable during
+	// its conversion to a *watch.Event (ToWatchEvent may be called once per interested watcher).
+	object := b.object.DeepCopyObject()
+	// meta.Accessor is the upstream pattern (see k8s.io/apiserver/pkg/storage.AnnotateInitialEventsEndBookmark)
+	// for setting metadata on a bookmark object regardless of its concrete type.
+	objMeta, err := meta.Accessor(object)
+	if err != nil {
+		// This is not expected for the controlplane resources served from this storage, as they all
+		// embed ObjectMeta. Surface it so a contract violation (a bookmark on which the
+		// resourceVersion and the initial-events-end annotation could not be set, which breaks
+		// watch-list clients) is visible at runtime instead of failing silently.
+		klog.ErrorS(err, "Failed to access bookmark object metadata, unable to set resourceVersion and initial-events-end annotation on bookmark", "objectType", fmt.Sprintf("%T", object))
+		return &watch.Event{Type: watch.Bookmark, Object: object}
+	}
+	objMeta.SetResourceVersion(strconv.FormatUint(b.resourceVersion, 10))
+	annotations := objMeta.GetAnnotations()
+	if isInitEvent && b.annotateInitialEventsEndBookmark {
+		// Mark the bookmark that signals the end of the initial set of events with the
+		// "k8s.io/initial-events-end" annotation. This follows the Kubernetes watch-list
+		// (streaming list) contract so that client-go watch-list informers can detect the
+		// end of the initial events and complete their synchronization.
+		if annotations == nil {
+			annotations = map[string]string{}
+		}
+		annotations[metav1.InitialEventsAnnotationKey] = "true"
+		objMeta.SetAnnotations(annotations)
+	}
+	return &watch.Event{Type: watch.Bookmark, Object: object}
 }
 
 func (b *bookmarkEvent) GetResourceVersion() uint64 {
@@ -103,6 +135,7 @@ func (w *storeWatcher) add(event storage.InternalEvent, timer clock.Timer) bool 
 // process first sends initEvents and then keeps sending events got from channel input
 // if they are newer than the specified resourceVersion.
 func (w *storeWatcher) process(ctx context.Context, initEvents []storage.InternalEvent, resourceVersion uint64) {
+	annotateInitialEventsEndBookmark := storage.ShouldAnnotateInitialEventsEndBookmarkFromContext(ctx)
 	for _, event := range initEvents {
 		w.sendWatchEvent(event, true)
 	}
@@ -113,7 +146,7 @@ func (w *storeWatcher) process(ctx context.Context, initEvents []storage.Interna
 	// communicate to clients what the initial set of objects is, so that
 	// stale objects whose delete events were missed by the client (because
 	// the watch was down) can be deleted.
-	w.sendWatchEvent(&bookmarkEvent{resourceVersion, w.newFunc()}, true)
+	w.sendWatchEvent(&bookmarkEvent{resourceVersion: resourceVersion, object: w.newFunc(), annotateInitialEventsEndBookmark: annotateInitialEventsEndBookmark}, true)
 	defer close(w.result)
 	for {
 		select {

--- a/pkg/apiserver/storage/ram/watch_test.go
+++ b/pkg/apiserver/storage/ram/watch_test.go
@@ -19,13 +19,17 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/utils/clock"
 
 	"antrea.io/antrea/pkg/apiserver/storage"
+	"antrea.io/antrea/pkg/apiserver/storage/testutil"
 )
 
 // simpleInternalEvent simply construct watch.Event based on the provided Type and Object
@@ -58,6 +62,13 @@ func (e *emptyInternalEvent) GetResourceVersion() uint64 {
 	return 0
 }
 
+func bookmarkPod(resourceVersion string) watch.Event {
+	return watch.Event{
+		Type:   watch.Bookmark,
+		Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{ResourceVersion: resourceVersion}},
+	}
+}
+
 func TestEvents(t *testing.T) {
 	testCases := []struct {
 		initEvents  []storage.InternalEvent
@@ -85,7 +96,7 @@ func TestEvents(t *testing.T) {
 				},
 			},
 			expected: []watch.Event{
-				{Type: watch.Bookmark, Object: &v1.Pod{}},
+				bookmarkPod("0"),
 				{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1"}}},
 				{Type: watch.Modified, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod2"}}},
 				{Type: watch.Deleted, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod3"}}},
@@ -114,7 +125,7 @@ func TestEvents(t *testing.T) {
 			},
 			expected: []watch.Event{
 				{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1"}}},
-				{Type: watch.Bookmark, Object: &v1.Pod{}},
+				bookmarkPod("0"),
 				{Type: watch.Modified, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod2"}}},
 				{Type: watch.Deleted, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod3"}}},
 			},
@@ -139,7 +150,7 @@ func TestEvents(t *testing.T) {
 			},
 			expected: []watch.Event{
 				{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1"}}},
-				{Type: watch.Bookmark, Object: &v1.Pod{}},
+				bookmarkPod("0"),
 				{Type: watch.Deleted, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod3"}}},
 			},
 		},
@@ -166,6 +177,55 @@ func TestEvents(t *testing.T) {
 		}
 		w.Stop()
 	}
+}
+
+func TestEventsWithInitialEventsEndBookmarkAnnotation(t *testing.T) {
+	w := newStoreWatcher(10, &storage.Selectors{}, func() {}, func() runtime.Object { return new(v1.Pod) })
+	go w.process(storage.WithInitialEventsEndBookmarkAnnotation(context.Background()), nil, 7)
+
+	actualEvent := <-w.ResultChan()
+	assert.Equal(t, testutil.ExpectedInitBookmark(t, &v1.Pod{}, "7"), actualEvent)
+	w.Stop()
+}
+
+func TestBookmarkEventToWatchEvent(t *testing.T) {
+	b := &bookmarkEvent{resourceVersion: 5, object: &v1.Pod{}}
+
+	// A plain init bookmark carries the resourceVersion but must not be labeled as a Kubernetes
+	// watch-list completion bookmark.
+	initEvent := b.ToWatchEvent(&storage.Selectors{}, true)
+	assert.Equal(t, watch.Bookmark, initEvent.Type)
+	initMeta, err := meta.Accessor(initEvent.Object)
+	require.NoError(t, err)
+	assert.Equal(t, "5", initMeta.GetResourceVersion())
+	assert.NotContains(t, initMeta.GetAnnotations(), metav1.InitialEventsAnnotationKey)
+
+	// When requested for a watch-list, the bookmark marking the end of the initial events carries
+	// the initial-events-end annotation.
+	annotatedInit := &bookmarkEvent{resourceVersion: 6, object: &v1.Pod{}, annotateInitialEventsEndBookmark: true}
+	annotatedInitEvent := annotatedInit.ToWatchEvent(&storage.Selectors{}, true)
+	assert.Equal(t, watch.Bookmark, annotatedInitEvent.Type)
+	annotatedInitMeta, err := meta.Accessor(annotatedInitEvent.Object)
+	require.NoError(t, err)
+	assert.Equal(t, "6", annotatedInitMeta.GetResourceVersion())
+	assert.Equal(t, map[string]string{metav1.InitialEventsAnnotationKey: "true"}, annotatedInitMeta.GetAnnotations())
+
+	// A non-init bookmark carries the resourceVersion but must not be labeled as the end of the
+	// initial events, otherwise clients would prematurely consider their cache synced.
+	nonInitEvent := b.ToWatchEvent(&storage.Selectors{}, false)
+	assert.Equal(t, watch.Bookmark, nonInitEvent.Type)
+	nonInitMeta, err := meta.Accessor(nonInitEvent.Object)
+	require.NoError(t, err)
+	assert.Equal(t, "5", nonInitMeta.GetResourceVersion())
+	assert.NotContains(t, nonInitMeta.GetAnnotations(), metav1.InitialEventsAnnotationKey)
+
+	// The InternalEvent must remain immutable during its conversion: the stored object should not
+	// have been mutated by either conversion above.
+	storedMeta, err := meta.Accessor(b.object)
+	require.NoError(t, err)
+	assert.Empty(t, storedMeta.GetResourceVersion())
+	assert.Empty(t, storedMeta.GetAnnotations())
+
 }
 
 func TestAddTimeout(t *testing.T) {

--- a/pkg/apiserver/storage/testutil/bookmark.go
+++ b/pkg/apiserver/storage/testutil/bookmark.go
@@ -1,0 +1,51 @@
+// Copyright 2026 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package testutil provides shared helpers for tests that assert on the events emitted by the
+// in-memory watch storage.
+package testutil
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+// ExpectedInitBookmark returns the bookmark event that the storage emits to mark the end of the
+// initial set of events for a watch: the bookmark object carries the given resourceVersion and the
+// "k8s.io/initial-events-end" annotation required by the Kubernetes watch-list contract.
+//
+// The provided object is deep-copied before being mutated, so callers can pass a shared empty
+// object without risking accidental shared state, and only the initial-events-end annotation is
+// added (any existing annotations are preserved). It accepts testing.TB so it can be used from
+// tests and benchmarks alike.
+func ExpectedInitBookmark(tb testing.TB, obj runtime.Object, resourceVersion string) watch.Event {
+	tb.Helper()
+	obj = obj.DeepCopyObject()
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		tb.Fatalf("Failed to access bookmark object metadata: %v", err)
+	}
+	accessor.SetResourceVersion(resourceVersion)
+	annotations := accessor.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[metav1.InitialEventsAnnotationKey] = "true"
+	accessor.SetAnnotations(annotations)
+	return watch.Event{Type: watch.Bookmark, Object: obj}
+}

--- a/pkg/controller/egress/store/egressgroup_test.go
+++ b/pkg/controller/egress/store/egressgroup_test.go
@@ -78,7 +78,7 @@ func TestWatchEgressGroupEvent(t *testing.T) {
 				store.Create(eg1)
 			},
 			expectedEvents: []watch.Event{
-				{Type: watch.Bookmark, Object: &controlplane.EgressGroup{}},
+				{Type: watch.Bookmark, Object: &controlplane.EgressGroup{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "0"}}},
 				{Type: watch.Added, Object: &controlplane.EgressGroup{
 					TypeMeta: metav1.TypeMeta{},
 					ObjectMeta: metav1.ObjectMeta{
@@ -97,7 +97,7 @@ func TestWatchEgressGroupEvent(t *testing.T) {
 				store.Update(eg2)
 			},
 			expectedEvents: []watch.Event{
-				{Type: watch.Bookmark, Object: &controlplane.EgressGroup{}},
+				{Type: watch.Bookmark, Object: &controlplane.EgressGroup{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "0"}}},
 				{Type: watch.Added, Object: &controlplane.EgressGroup{
 					TypeMeta: metav1.TypeMeta{},
 					ObjectMeta: metav1.ObjectMeta{
@@ -126,7 +126,7 @@ func TestWatchEgressGroupEvent(t *testing.T) {
 				store.Update(eg3)
 			},
 			expectedEvents: []watch.Event{
-				{Type: watch.Bookmark, Object: &controlplane.EgressGroup{}},
+				{Type: watch.Bookmark, Object: &controlplane.EgressGroup{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "0"}}},
 				{Type: watch.Added, Object: &controlplane.EgressGroup{
 					TypeMeta: metav1.TypeMeta{},
 					ObjectMeta: metav1.ObjectMeta{
@@ -154,7 +154,7 @@ func TestWatchEgressGroupEvent(t *testing.T) {
 				store.Update(eg3)
 			},
 			expectedEvents: []watch.Event{
-				{Type: watch.Bookmark, Object: &controlplane.EgressGroup{}},
+				{Type: watch.Bookmark, Object: &controlplane.EgressGroup{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "0"}}},
 				{Type: watch.Added, Object: &controlplane.EgressGroup{
 					TypeMeta: metav1.TypeMeta{},
 					ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/networkpolicy/store/networkpolicy_test.go
+++ b/pkg/controller/networkpolicy/store/networkpolicy_test.go
@@ -90,7 +90,7 @@ func TestWatchNetworkPolicyEvent(t *testing.T) {
 				store.Update(policyV2)
 			},
 			expected: []watch.Event{
-				{Type: watch.Bookmark, Object: &controlplane.NetworkPolicy{}},
+				{Type: watch.Bookmark, Object: &controlplane.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "0"}}},
 				{Type: watch.Added, Object: &controlplane.NetworkPolicy{
 					ObjectMeta:      metav1.ObjectMeta{Name: "bar"},
 					SourceRef:       &npRef,
@@ -119,7 +119,7 @@ func TestWatchNetworkPolicyEvent(t *testing.T) {
 				store.Update(policyV1)
 			},
 			expected: []watch.Event{
-				{Type: watch.Bookmark, Object: &controlplane.NetworkPolicy{}},
+				{Type: watch.Bookmark, Object: &controlplane.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "0"}}},
 				{Type: watch.Added, Object: &controlplane.NetworkPolicy{
 					ObjectMeta:      metav1.ObjectMeta{Name: "bar"},
 					SourceRef:       &npRef,


### PR DESCRIPTION
Cherry pick of #8124 on release-2.6.

#8124: Annotate end-of-initial-events bookmark for watch-list

For details on the cherry pick process, see the [cherry pick requests](https://github.com/antrea-io/antrea/blob/main/docs/contributors/cherry-picks.md) page.