### PR TITLE
fix(egress): validate max-egress-ips annotation range [0, 255]

### DIFF
--- a/pkg/agent/controller/egress/ip_scheduler.go
+++ b/pkg/agent/controller/egress/ip_scheduler.go
@@ -15,6 +15,7 @@
 package egress
 
 import (
+	"fmt"
 	"sort"
 	"strconv"
 	"sync"
@@ -117,6 +118,8 @@ func NewEgressIPScheduler(cluster memberlist.Interface, egressInformer crdinform
 	return s
 }
 
+const maxEgressIPsAnnotationValue = 255
+
 func getMaxEgressIPsFromAnnotation(node *corev1.Node) (int, bool, error) {
 	maxEgressIPsStr, exists := node.Annotations[types.NodeMaxEgressIPsAnnotationKey]
 	if !exists {
@@ -125,6 +128,9 @@ func getMaxEgressIPsFromAnnotation(node *corev1.Node) (int, bool, error) {
 	maxEgressIPs, err := strconv.Atoi(maxEgressIPsStr)
 	if err != nil {
 		return 0, false, err
+	}
+	if maxEgressIPs < 0 || maxEgressIPs > maxEgressIPsAnnotationValue {
+		return 0, false, fmt.Errorf("max-egress-ips annotation value %d is out of range [0, %d]", maxEgressIPs, maxEgressIPsAnnotationValue)
 	}
 	return maxEgressIPs, true, nil
 }

--- a/pkg/agent/controller/egress/ip_scheduler_test.go
+++ b/pkg/agent/controller/egress/ip_scheduler_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -350,7 +351,20 @@ func TestRun(t *testing.T) {
 	// Set node1's max-egress-ips annotation to invalid value, nothing should happen.
 	updatedNode1 := node1.DeepCopy()
 	updatedNode1.Annotations[agenttypes.NodeMaxEgressIPsAnnotationKey] = "invalid-value"
-	clientset.CoreV1().Nodes().Update(ctx, updatedNode1, metav1.UpdateOptions{})
+	_, err := clientset.CoreV1().Nodes().Update(ctx, updatedNode1, metav1.UpdateOptions{})
+	require.NoError(t, err)
+	assertReceivedItems(t, egressUpdates, sets.New[string]())
+	// Set node1's max-egress-ips annotation to a negative value, nothing should happen.
+	updatedNode1 = node1.DeepCopy()
+	updatedNode1.Annotations[agenttypes.NodeMaxEgressIPsAnnotationKey] = "-1"
+	_, err = clientset.CoreV1().Nodes().Update(ctx, updatedNode1, metav1.UpdateOptions{})
+	require.NoError(t, err)
+	assertReceivedItems(t, egressUpdates, sets.New[string]())
+	// Set node1's max-egress-ips annotation to a value greater than 255, nothing should happen.
+	updatedNode1 = node1.DeepCopy()
+	updatedNode1.Annotations[agenttypes.NodeMaxEgressIPsAnnotationKey] = "300"
+	_, err = clientset.CoreV1().Nodes().Update(ctx, updatedNode1, metav1.UpdateOptions{})
+	require.NoError(t, err)
 	assertReceivedItems(t, egressUpdates, sets.New[string]())
 	// Set node1's max-egress-ips annotation to 1, egressD should be moved to node2.
 	updatedNode1 = node1.DeepCopy()


### PR DESCRIPTION
getMaxEgressIPsFromAnnotation only checked that the annotation was a valid integer but not that it was in range. Negative values silently exclude a node from scheduling (surfaces as 'no node available'), and values > 255 bypass the documented platform limit enforced on the config option.

Adds a range check [0, 255] with an error return, consistent with the egress.maxEgressIPsPerNode validation in options.go, plus test coverage for negative and out-of-range values.

Fixes #8115