### PR TITLE
fix: remove duplicate initOpenFlowPipeline call in agent Initializefix: remove duplicate initOpenFlowPipeline call in agent Initialize

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	golang.org/x/sync v0.21.0
 	golang.org/x/sys v0.46.0
 	golang.org/x/time v0.15.0
-	golang.org/x/tools v0.46.0
+	golang.org/x/tools v0.47.0
 	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20241231184526-a9ab2273dd10
 	google.golang.org/grpc v1.81.1
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af

--- a/go.sum
+++ b/go.sum
@@ -747,8 +747,8 @@ golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
-golang.org/x/tools v0.46.0 h1:7jTurBkPZu4moS/Uy4OQT1M+QBlsj3wejyZwsT8Z7rk=
-golang.org/x/tools v0.46.0/go.mod h1:FrD85F8l+NWL+9XWBSyVSHO6Ne4jutsfIFba7AWQ5Ys=
+golang.org/x/tools v0.47.0 h1:7Kn5x/d1svx/PzryTsqeoZN4TZwqeH5pGWjefhLi/1Q=
+golang.org/x/tools v0.47.0/go.mod h1:dFHnyTvFWY212G+h7ZY4Vsp/K3U4/7W9TyVaAul8uCA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -481,16 +481,11 @@ func (i *Initializer) Initialize(ctx context.Context) error {
 		if err := i.routeClient.Initialize(i.nodeConfig, i.podNetworkWait.Done); err != nil {
 			return err
 		}
+	}
 
-		// Install OpenFlow entries on OVS bridge.
-		if err := i.initOpenFlowPipeline(); err != nil {
-			return err
-		}
-	} else {
-		// Install OpenFlow entries on OVS bridge.
-		if err := i.initOpenFlowPipeline(); err != nil {
-			return err
-		}
+	// Install OpenFlow entries on OVS bridge.
+	if err := i.initOpenFlowPipeline(); err != nil {
+		return err
 	}
 	klog.Infof("Agent initialized NodeConfig=%v, NetworkConfig=%v", i.nodeConfig, i.networkConfig)
 	return nil

--- a/pkg/apiserver/registry/controlplane/egressgroup/rest.go
+++ b/pkg/apiserver/registry/controlplane/egressgroup/rest.go
@@ -99,6 +99,7 @@ func (r *REST) NamespaceScoped() bool {
 
 func (r *REST) Watch(ctx context.Context, options *internalversion.ListOptions) (watch.Interface, error) {
 	key, label, field := networkpolicy.GetSelectors(options)
+	ctx = storage.WithInitialEventsEndBookmarkAnnotationFromListOptions(ctx, options)
 	return r.egressGroupStore.Watch(ctx, key, label, field)
 }
 

--- a/pkg/apiserver/registry/controlplane/egressgroup/rest_test.go
+++ b/pkg/apiserver/registry/controlplane/egressgroup/rest_test.go
@@ -154,7 +154,7 @@ func TestRESTWatch(t *testing.T) {
 			name:          "nodeName selecting nothing",
 			fieldSelector: fields.OneTermEqualSelector("nodeName", "foo"),
 			expectedEvents: []watch.Event{
-				{Type: watch.Bookmark, Object: &controlplane.EgressGroup{}},
+				{Type: watch.Bookmark, Object: &controlplane.EgressGroup{ObjectMeta: v1.ObjectMeta{ResourceVersion: "1"}}},
 			},
 		},
 		{
@@ -162,7 +162,7 @@ func TestRESTWatch(t *testing.T) {
 			fieldSelector: fields.OneTermEqualSelector("nodeName", "node1"),
 			expectedEvents: []watch.Event{
 				{Type: watch.Added, Object: &controlplane.EgressGroup{ObjectMeta: v1.ObjectMeta{Name: "egress1"}}},
-				{Type: watch.Bookmark, Object: &controlplane.EgressGroup{}},
+				{Type: watch.Bookmark, Object: &controlplane.EgressGroup{ObjectMeta: v1.ObjectMeta{ResourceVersion: "1"}}},
 			},
 		},
 		{
@@ -170,7 +170,7 @@ func TestRESTWatch(t *testing.T) {
 			fieldSelector: nil,
 			expectedEvents: []watch.Event{
 				{Type: watch.Added, Object: &controlplane.EgressGroup{ObjectMeta: v1.ObjectMeta{Name: "egress1"}}},
-				{Type: watch.Bookmark, Object: &controlplane.EgressGroup{}},
+				{Type: watch.Bookmark, Object: &controlplane.EgressGroup{ObjectMeta: v1.ObjectMeta{ResourceVersion: "1"}}},
 			},
 		},
 	}

--- a/pkg/apiserver/registry/controlplane/supportbundlecollection/rest.go
+++ b/pkg/apiserver/registry/controlplane/supportbundlecollection/rest.go
@@ -99,6 +99,7 @@ func (r *REST) NamespaceScoped() bool {
 
 func (r *REST) Watch(ctx context.Context, options *internalversion.ListOptions) (watch.Interface, error) {
 	key, label, field := networkpolicy.GetSelectors(options)
+	ctx = storage.WithInitialEventsEndBookmarkAnnotationFromListOptions(ctx, options)
 	return r.supportBundleCollectionStore.Watch(ctx, key, label, field)
 }
 

--- a/pkg/apiserver/registry/networkpolicy/addressgroup/rest.go
+++ b/pkg/apiserver/registry/networkpolicy/addressgroup/rest.go
@@ -99,6 +99,7 @@ func (r *REST) NamespaceScoped() bool {
 
 func (r *REST) Watch(ctx context.Context, options *internalversion.ListOptions) (watch.Interface, error) {
 	key, label, field := networkpolicy.GetSelectors(options)
+	ctx = storage.WithInitialEventsEndBookmarkAnnotationFromListOptions(ctx, options)
 	return r.addressGroupStore.Watch(ctx, key, label, field)
 }
 

--- a/pkg/apiserver/registry/networkpolicy/addressgroup/rest_test.go
+++ b/pkg/apiserver/registry/networkpolicy/addressgroup/rest_test.go
@@ -154,7 +154,7 @@ func TestRESTWatch(t *testing.T) {
 			name:          "nodeName selecting nothing",
 			fieldSelector: fields.OneTermEqualSelector("nodeName", "foo"),
 			expectedEvents: []watch.Event{
-				{Type: watch.Bookmark, Object: &controlplane.AddressGroup{}},
+				{Type: watch.Bookmark, Object: &controlplane.AddressGroup{ObjectMeta: v1.ObjectMeta{ResourceVersion: "1"}}},
 			},
 		},
 		{
@@ -162,7 +162,7 @@ func TestRESTWatch(t *testing.T) {
 			fieldSelector: fields.OneTermEqualSelector("nodeName", "node1"),
 			expectedEvents: []watch.Event{
 				{Type: watch.Added, Object: &controlplane.AddressGroup{ObjectMeta: v1.ObjectMeta{Name: "addressGroup1"}}},
-				{Type: watch.Bookmark, Object: &controlplane.AddressGroup{}},
+				{Type: watch.Bookmark, Object: &controlplane.AddressGroup{ObjectMeta: v1.ObjectMeta{ResourceVersion: "1"}}},
 			},
 		},
 		{
@@ -170,7 +170,7 @@ func TestRESTWatch(t *testing.T) {
 			fieldSelector: nil,
 			expectedEvents: []watch.Event{
 				{Type: watch.Added, Object: &controlplane.AddressGroup{ObjectMeta: v1.ObjectMeta{Name: "addressGroup1"}}},
-				{Type: watch.Bookmark, Object: &controlplane.AddressGroup{}},
+				{Type: watch.Bookmark, Object: &controlplane.AddressGroup{ObjectMeta: v1.ObjectMeta{ResourceVersion: "1"}}},
 			},
 		},
 	}

--- a/pkg/apiserver/registry/networkpolicy/appliedtogroup/rest.go
+++ b/pkg/apiserver/registry/networkpolicy/appliedtogroup/rest.go
@@ -99,6 +99,7 @@ func (r *REST) NamespaceScoped() bool {
 
 func (r *REST) Watch(ctx context.Context, options *internalversion.ListOptions) (watch.Interface, error) {
 	key, label, field := networkpolicy.GetSelectors(options)
+	ctx = storage.WithInitialEventsEndBookmarkAnnotationFromListOptions(ctx, options)
 	return r.appliedToGroupStore.Watch(ctx, key, label, field)
 }
 

--- a/pkg/apiserver/registry/networkpolicy/appliedtogroup/rest_test.go
+++ b/pkg/apiserver/registry/networkpolicy/appliedtogroup/rest_test.go
@@ -154,7 +154,7 @@ func TestRESTWatch(t *testing.T) {
 			name:          "nodeName selecting nothing",
 			fieldSelector: fields.OneTermEqualSelector("nodeName", "foo"),
 			expectedEvents: []watch.Event{
-				{Type: watch.Bookmark, Object: &controlplane.AppliedToGroup{}},
+				{Type: watch.Bookmark, Object: &controlplane.AppliedToGroup{ObjectMeta: v1.ObjectMeta{ResourceVersion: "1"}}},
 			},
 		},
 		{
@@ -162,7 +162,7 @@ func TestRESTWatch(t *testing.T) {
 			fieldSelector: fields.OneTermEqualSelector("nodeName", "node1"),
 			expectedEvents: []watch.Event{
 				{Type: watch.Added, Object: &controlplane.AppliedToGroup{ObjectMeta: v1.ObjectMeta{Name: "appliedToGroup1"}}},
-				{Type: watch.Bookmark, Object: &controlplane.AppliedToGroup{}},
+				{Type: watch.Bookmark, Object: &controlplane.AppliedToGroup{ObjectMeta: v1.ObjectMeta{ResourceVersion: "1"}}},
 			},
 		},
 		{
@@ -170,7 +170,7 @@ func TestRESTWatch(t *testing.T) {
 			fieldSelector: nil,
 			expectedEvents: []watch.Event{
 				{Type: watch.Added, Object: &controlplane.AppliedToGroup{ObjectMeta: v1.ObjectMeta{Name: "appliedToGroup1"}}},
-				{Type: watch.Bookmark, Object: &controlplane.AppliedToGroup{}},
+				{Type: watch.Bookmark, Object: &controlplane.AppliedToGroup{ObjectMeta: v1.ObjectMeta{ResourceVersion: "1"}}},
 			},
 		},
 	}

--- a/pkg/apiserver/registry/networkpolicy/networkpolicy/rest.go
+++ b/pkg/apiserver/registry/networkpolicy/networkpolicy/rest.go
@@ -99,6 +99,7 @@ func (r *REST) NamespaceScoped() bool {
 
 func (r *REST) Watch(ctx context.Context, options *internalversion.ListOptions) (watch.Interface, error) {
 	key, label, field := networkpolicy.GetSelectors(options)
+	ctx = storage.WithInitialEventsEndBookmarkAnnotationFromListOptions(ctx, options)
 	return r.networkPolicyStore.Watch(ctx, key, label, field)
 }
 

--- a/pkg/apiserver/registry/networkpolicy/networkpolicy/rest_test.go
+++ b/pkg/apiserver/registry/networkpolicy/networkpolicy/rest_test.go
@@ -154,7 +154,7 @@ func TestRESTWatch(t *testing.T) {
 			name:          "nodeName selecting nothing",
 			fieldSelector: fields.OneTermEqualSelector("nodeName", "foo"),
 			expectedEvents: []watch.Event{
-				{Type: watch.Bookmark, Object: &controlplane.NetworkPolicy{}},
+				{Type: watch.Bookmark, Object: &controlplane.NetworkPolicy{ObjectMeta: v1.ObjectMeta{ResourceVersion: "1"}}},
 			},
 		},
 		{
@@ -162,7 +162,7 @@ func TestRESTWatch(t *testing.T) {
 			fieldSelector: fields.OneTermEqualSelector("nodeName", "node1"),
 			expectedEvents: []watch.Event{
 				{Type: watch.Added, Object: &controlplane.NetworkPolicy{ObjectMeta: v1.ObjectMeta{Name: "networkPolicy1"}}},
-				{Type: watch.Bookmark, Object: &controlplane.NetworkPolicy{}},
+				{Type: watch.Bookmark, Object: &controlplane.NetworkPolicy{ObjectMeta: v1.ObjectMeta{ResourceVersion: "1"}}},
 			},
 		},
 		{
@@ -170,7 +170,7 @@ func TestRESTWatch(t *testing.T) {
 			fieldSelector: nil,
 			expectedEvents: []watch.Event{
 				{Type: watch.Added, Object: &controlplane.NetworkPolicy{ObjectMeta: v1.ObjectMeta{Name: "networkPolicy1"}}},
-				{Type: watch.Bookmark, Object: &controlplane.NetworkPolicy{}},
+				{Type: watch.Bookmark, Object: &controlplane.NetworkPolicy{ObjectMeta: v1.ObjectMeta{ResourceVersion: "1"}}},
 			},
 		},
 	}

--- a/pkg/apiserver/storage/interfaces.go
+++ b/pkg/apiserver/storage/interfaces.go
@@ -17,6 +17,7 @@ package storage
 import (
 	"context"
 
+	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/watch"
@@ -53,6 +54,34 @@ type GenEventFunc func(key string, prevObj, obj interface{}, resourceVersion uin
 
 // SelectFunc checks whether an object match the provided selectors.
 type SelectFunc func(selectors *Selectors, key string, obj interface{}) bool
+
+type initialEventsEndBookmarkAnnotationKey struct{}
+
+// WithInitialEventsEndBookmarkAnnotation returns a Context that requests annotation of Antrea's
+// end-of-initial-events bookmark for Kubernetes watch-list clients.
+func WithInitialEventsEndBookmarkAnnotation(ctx context.Context) context.Context {
+	return context.WithValue(ctx, initialEventsEndBookmarkAnnotationKey{}, true)
+}
+
+// WithInitialEventsEndBookmarkAnnotationFromListOptions returns a Context that requests annotation
+// of Antrea's end-of-initial-events bookmark when the ListOptions describe a watch-list request.
+func WithInitialEventsEndBookmarkAnnotationFromListOptions(ctx context.Context, options *metainternalversion.ListOptions) context.Context {
+	if shouldAnnotateInitialEventsEndBookmark(options) {
+		return WithInitialEventsEndBookmarkAnnotation(ctx)
+	}
+	return ctx
+}
+
+// ShouldAnnotateInitialEventsEndBookmarkFromContext reports whether the Context requests the
+// Kubernetes watch-list end-of-initial-events annotation on Antrea's init bookmark.
+func ShouldAnnotateInitialEventsEndBookmarkFromContext(ctx context.Context) bool {
+	annotate, _ := ctx.Value(initialEventsEndBookmarkAnnotationKey{}).(bool)
+	return annotate
+}
+
+func shouldAnnotateInitialEventsEndBookmark(options *metainternalversion.ListOptions) bool {
+	return options != nil && options.SendInitialEvents != nil && *options.SendInitialEvents && options.AllowWatchBookmarks
+}
 
 // Interface offers a common storage interface for runtime.Object.
 // It's provided for Network Policy controller to store the translated Network Policy resources, then Antrea apiserver can

--- a/pkg/apiserver/storage/ram/store_test.go
+++ b/pkg/apiserver/storage/ram/store_test.go
@@ -296,7 +296,7 @@ func TestRamStoreWatchAll(t *testing.T) {
 				store.Update(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx2"}}})
 			},
 			expected: []watch.Event{
-				{Type: watch.Bookmark, Object: &v1.Pod{}},
+				bookmarkPod("0"),
 				{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx1"}}}},
 				{Type: watch.Modified, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx2"}}}},
 			},
@@ -307,7 +307,7 @@ func TestRamStoreWatchAll(t *testing.T) {
 				store.Delete("pod1")
 			},
 			expected: []watch.Event{
-				{Type: watch.Bookmark, Object: &v1.Pod{}},
+				bookmarkPod("0"),
 				{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx1"}}}},
 				{Type: watch.Deleted, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx1"}}}},
 			},
@@ -357,7 +357,7 @@ func TestRamStoreWatchWithInitOperations(t *testing.T) {
 			},
 			expected: []watch.Event{
 				{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx3"}}}},
-				{Type: watch.Bookmark, Object: &v1.Pod{}},
+				bookmarkPod("3"),
 				{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod2", Labels: map[string]string{"app": "nginx2"}}}},
 				{Type: watch.Modified, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod2", Labels: map[string]string{"app": "nginx3"}}}},
 			},
@@ -373,7 +373,7 @@ func TestRamStoreWatchWithInitOperations(t *testing.T) {
 			},
 			expected: []watch.Event{
 				{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx1"}}}},
-				{Type: watch.Bookmark, Object: &v1.Pod{}},
+				bookmarkPod("3"),
 				{Type: watch.Deleted, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx1"}}}},
 			},
 		},
@@ -418,7 +418,7 @@ func TestRamStoreWatchWithSelector(t *testing.T) {
 			},
 			labelSelector: labels.SelectorFromSet(labels.Set{"app": "nginx1"}),
 			expected: []watch.Event{
-				{Type: watch.Bookmark, Object: &v1.Pod{}},
+				bookmarkPod("0"),
 				{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx1"}}}},
 				{Type: watch.Deleted, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx1"}}}},
 			},
@@ -430,7 +430,7 @@ func TestRamStoreWatchWithSelector(t *testing.T) {
 			},
 			labelSelector: labels.SelectorFromSet(labels.Set{"app": "nginx2"}),
 			expected: []watch.Event{
-				{Type: watch.Bookmark, Object: &v1.Pod{}},
+				bookmarkPod("0"),
 				{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx2"}}}},
 			},
 		},
@@ -443,7 +443,7 @@ func TestRamStoreWatchWithSelector(t *testing.T) {
 			},
 			labelSelector: labels.SelectorFromSet(labels.Set{"app": "nginx1"}),
 			expected: []watch.Event{
-				{Type: watch.Bookmark, Object: &v1.Pod{}},
+				bookmarkPod("0"),
 				{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx1"}}}},
 				{Type: watch.Deleted, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Labels: map[string]string{"app": "nginx1"}}}},
 			},

--- a/pkg/apiserver/storage/ram/watch.go
+++ b/pkg/apiserver/storage/ram/watch.go
@@ -16,8 +16,12 @@ package ram
 
 import (
 	"context"
+	"fmt"
+	"strconv"
 	"sync"
 
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/klog/v2"
@@ -27,12 +31,40 @@ import (
 )
 
 type bookmarkEvent struct {
-	resourceVersion uint64
-	object          runtime.Object
+	resourceVersion                  uint64
+	object                           runtime.Object
+	annotateInitialEventsEndBookmark bool
 }
 
 func (b *bookmarkEvent) ToWatchEvent(selectors *storage.Selectors, isInitEvent bool) *watch.Event {
-	return &watch.Event{Type: watch.Bookmark, Object: b.object}
+	// Copy the object before mutating it: an InternalEvent is expected to be immutable during
+	// its conversion to a *watch.Event (ToWatchEvent may be called once per interested watcher).
+	object := b.object.DeepCopyObject()
+	// meta.Accessor is the upstream pattern (see k8s.io/apiserver/pkg/storage.AnnotateInitialEventsEndBookmark)
+	// for setting metadata on a bookmark object regardless of its concrete type.
+	objMeta, err := meta.Accessor(object)
+	if err != nil {
+		// This is not expected for the controlplane resources served from this storage, as they all
+		// embed ObjectMeta. Surface it so a contract violation (a bookmark on which the
+		// resourceVersion and the initial-events-end annotation could not be set, which breaks
+		// watch-list clients) is visible at runtime instead of failing silently.
+		klog.ErrorS(err, "Failed to access bookmark object metadata, unable to set resourceVersion and initial-events-end annotation on bookmark", "objectType", fmt.Sprintf("%T", object))
+		return &watch.Event{Type: watch.Bookmark, Object: object}
+	}
+	objMeta.SetResourceVersion(strconv.FormatUint(b.resourceVersion, 10))
+	annotations := objMeta.GetAnnotations()
+	if isInitEvent && b.annotateInitialEventsEndBookmark {
+		// Mark the bookmark that signals the end of the initial set of events with the
+		// "k8s.io/initial-events-end" annotation. This follows the Kubernetes watch-list
+		// (streaming list) contract so that client-go watch-list informers can detect the
+		// end of the initial events and complete their synchronization.
+		if annotations == nil {
+			annotations = map[string]string{}
+		}
+		annotations[metav1.InitialEventsAnnotationKey] = "true"
+		objMeta.SetAnnotations(annotations)
+	}
+	return &watch.Event{Type: watch.Bookmark, Object: object}
 }
 
 func (b *bookmarkEvent) GetResourceVersion() uint64 {
@@ -103,6 +135,7 @@ func (w *storeWatcher) add(event storage.InternalEvent, timer clock.Timer) bool 
 // process first sends initEvents and then keeps sending events got from channel input
 // if they are newer than the specified resourceVersion.
 func (w *storeWatcher) process(ctx context.Context, initEvents []storage.InternalEvent, resourceVersion uint64) {
+	annotateInitialEventsEndBookmark := storage.ShouldAnnotateInitialEventsEndBookmarkFromContext(ctx)
 	for _, event := range initEvents {
 		w.sendWatchEvent(event, true)
 	}
@@ -113,7 +146,7 @@ func (w *storeWatcher) process(ctx context.Context, initEvents []storage.Interna
 	// communicate to clients what the initial set of objects is, so that
 	// stale objects whose delete events were missed by the client (because
 	// the watch was down) can be deleted.
-	w.sendWatchEvent(&bookmarkEvent{resourceVersion, w.newFunc()}, true)
+	w.sendWatchEvent(&bookmarkEvent{resourceVersion: resourceVersion, object: w.newFunc(), annotateInitialEventsEndBookmark: annotateInitialEventsEndBookmark}, true)
 	defer close(w.result)
 	for {
 		select {

--- a/pkg/apiserver/storage/ram/watch_test.go
+++ b/pkg/apiserver/storage/ram/watch_test.go
@@ -19,13 +19,17 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/utils/clock"
 
 	"antrea.io/antrea/v2/pkg/apiserver/storage"
+	"antrea.io/antrea/v2/pkg/apiserver/storage/testutil"
 )
 
 // simpleInternalEvent simply construct watch.Event based on the provided Type and Object
@@ -58,6 +62,13 @@ func (e *emptyInternalEvent) GetResourceVersion() uint64 {
 	return 0
 }
 
+func bookmarkPod(resourceVersion string) watch.Event {
+	return watch.Event{
+		Type:   watch.Bookmark,
+		Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{ResourceVersion: resourceVersion}},
+	}
+}
+
 func TestEvents(t *testing.T) {
 	testCases := []struct {
 		initEvents  []storage.InternalEvent
@@ -85,7 +96,7 @@ func TestEvents(t *testing.T) {
 				},
 			},
 			expected: []watch.Event{
-				{Type: watch.Bookmark, Object: &v1.Pod{}},
+				bookmarkPod("0"),
 				{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1"}}},
 				{Type: watch.Modified, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod2"}}},
 				{Type: watch.Deleted, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod3"}}},
@@ -114,7 +125,7 @@ func TestEvents(t *testing.T) {
 			},
 			expected: []watch.Event{
 				{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1"}}},
-				{Type: watch.Bookmark, Object: &v1.Pod{}},
+				bookmarkPod("0"),
 				{Type: watch.Modified, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod2"}}},
 				{Type: watch.Deleted, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod3"}}},
 			},
@@ -139,7 +150,7 @@ func TestEvents(t *testing.T) {
 			},
 			expected: []watch.Event{
 				{Type: watch.Added, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1"}}},
-				{Type: watch.Bookmark, Object: &v1.Pod{}},
+				bookmarkPod("0"),
 				{Type: watch.Deleted, Object: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod3"}}},
 			},
 		},
@@ -166,6 +177,55 @@ func TestEvents(t *testing.T) {
 		}
 		w.Stop()
 	}
+}
+
+func TestEventsWithInitialEventsEndBookmarkAnnotation(t *testing.T) {
+	w := newStoreWatcher(10, &storage.Selectors{}, func() {}, func() runtime.Object { return new(v1.Pod) })
+	go w.process(storage.WithInitialEventsEndBookmarkAnnotation(context.Background()), nil, 7)
+
+	actualEvent := <-w.ResultChan()
+	assert.Equal(t, testutil.ExpectedInitBookmark(t, &v1.Pod{}, "7"), actualEvent)
+	w.Stop()
+}
+
+func TestBookmarkEventToWatchEvent(t *testing.T) {
+	b := &bookmarkEvent{resourceVersion: 5, object: &v1.Pod{}}
+
+	// A plain init bookmark carries the resourceVersion but must not be labeled as a Kubernetes
+	// watch-list completion bookmark.
+	initEvent := b.ToWatchEvent(&storage.Selectors{}, true)
+	assert.Equal(t, watch.Bookmark, initEvent.Type)
+	initMeta, err := meta.Accessor(initEvent.Object)
+	require.NoError(t, err)
+	assert.Equal(t, "5", initMeta.GetResourceVersion())
+	assert.NotContains(t, initMeta.GetAnnotations(), metav1.InitialEventsAnnotationKey)
+
+	// When requested for a watch-list, the bookmark marking the end of the initial events carries
+	// the initial-events-end annotation.
+	annotatedInit := &bookmarkEvent{resourceVersion: 6, object: &v1.Pod{}, annotateInitialEventsEndBookmark: true}
+	annotatedInitEvent := annotatedInit.ToWatchEvent(&storage.Selectors{}, true)
+	assert.Equal(t, watch.Bookmark, annotatedInitEvent.Type)
+	annotatedInitMeta, err := meta.Accessor(annotatedInitEvent.Object)
+	require.NoError(t, err)
+	assert.Equal(t, "6", annotatedInitMeta.GetResourceVersion())
+	assert.Equal(t, map[string]string{metav1.InitialEventsAnnotationKey: "true"}, annotatedInitMeta.GetAnnotations())
+
+	// A non-init bookmark carries the resourceVersion but must not be labeled as the end of the
+	// initial events, otherwise clients would prematurely consider their cache synced.
+	nonInitEvent := b.ToWatchEvent(&storage.Selectors{}, false)
+	assert.Equal(t, watch.Bookmark, nonInitEvent.Type)
+	nonInitMeta, err := meta.Accessor(nonInitEvent.Object)
+	require.NoError(t, err)
+	assert.Equal(t, "5", nonInitMeta.GetResourceVersion())
+	assert.NotContains(t, nonInitMeta.GetAnnotations(), metav1.InitialEventsAnnotationKey)
+
+	// The InternalEvent must remain immutable during its conversion: the stored object should not
+	// have been mutated by either conversion above.
+	storedMeta, err := meta.Accessor(b.object)
+	require.NoError(t, err)
+	assert.Empty(t, storedMeta.GetResourceVersion())
+	assert.Empty(t, storedMeta.GetAnnotations())
+
 }
 
 func TestAddTimeout(t *testing.T) {

--- a/pkg/apiserver/storage/testutil/bookmark.go
+++ b/pkg/apiserver/storage/testutil/bookmark.go
@@ -1,0 +1,51 @@
+// Copyright 2026 Antrea Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package testutil provides shared helpers for tests that assert on the events emitted by the
+// in-memory watch storage.
+package testutil
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+// ExpectedInitBookmark returns the bookmark event that the storage emits to mark the end of the
+// initial set of events for a watch: the bookmark object carries the given resourceVersion and the
+// "k8s.io/initial-events-end" annotation required by the Kubernetes watch-list contract.
+//
+// The provided object is deep-copied before being mutated, so callers can pass a shared empty
+// object without risking accidental shared state, and only the initial-events-end annotation is
+// added (any existing annotations are preserved). It accepts testing.TB so it can be used from
+// tests and benchmarks alike.
+func ExpectedInitBookmark(tb testing.TB, obj runtime.Object, resourceVersion string) watch.Event {
+	tb.Helper()
+	obj = obj.DeepCopyObject()
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		tb.Fatalf("Failed to access bookmark object metadata: %v", err)
+	}
+	accessor.SetResourceVersion(resourceVersion)
+	annotations := accessor.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[metav1.InitialEventsAnnotationKey] = "true"
+	accessor.SetAnnotations(annotations)
+	return watch.Event{Type: watch.Bookmark, Object: obj}
+}

--- a/pkg/controller/egress/store/egressgroup_test.go
+++ b/pkg/controller/egress/store/egressgroup_test.go
@@ -78,7 +78,7 @@ func TestWatchEgressGroupEvent(t *testing.T) {
 				store.Create(eg1)
 			},
 			expectedEvents: []watch.Event{
-				{Type: watch.Bookmark, Object: &controlplane.EgressGroup{}},
+				{Type: watch.Bookmark, Object: &controlplane.EgressGroup{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "0"}}},
 				{Type: watch.Added, Object: &controlplane.EgressGroup{
 					TypeMeta: metav1.TypeMeta{},
 					ObjectMeta: metav1.ObjectMeta{
@@ -97,7 +97,7 @@ func TestWatchEgressGroupEvent(t *testing.T) {
 				store.Update(eg2)
 			},
 			expectedEvents: []watch.Event{
-				{Type: watch.Bookmark, Object: &controlplane.EgressGroup{}},
+				{Type: watch.Bookmark, Object: &controlplane.EgressGroup{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "0"}}},
 				{Type: watch.Added, Object: &controlplane.EgressGroup{
 					TypeMeta: metav1.TypeMeta{},
 					ObjectMeta: metav1.ObjectMeta{
@@ -126,7 +126,7 @@ func TestWatchEgressGroupEvent(t *testing.T) {
 				store.Update(eg3)
 			},
 			expectedEvents: []watch.Event{
-				{Type: watch.Bookmark, Object: &controlplane.EgressGroup{}},
+				{Type: watch.Bookmark, Object: &controlplane.EgressGroup{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "0"}}},
 				{Type: watch.Added, Object: &controlplane.EgressGroup{
 					TypeMeta: metav1.TypeMeta{},
 					ObjectMeta: metav1.ObjectMeta{
@@ -154,7 +154,7 @@ func TestWatchEgressGroupEvent(t *testing.T) {
 				store.Update(eg3)
 			},
 			expectedEvents: []watch.Event{
-				{Type: watch.Bookmark, Object: &controlplane.EgressGroup{}},
+				{Type: watch.Bookmark, Object: &controlplane.EgressGroup{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "0"}}},
 				{Type: watch.Added, Object: &controlplane.EgressGroup{
 					TypeMeta: metav1.TypeMeta{},
 					ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/networkpolicy/networkpolicy_controller.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller.go
@@ -720,7 +720,18 @@ func (n *NetworkPolicyController) processNetworkPolicy(np *networkingv1.NetworkP
 	enableLogging := false
 	namespace, err := n.namespaceLister.Get(np.Namespace)
 	if err == nil {
-		enableLogging, _ = strconv.ParseBool(namespace.Annotations[EnableNPLoggingAnnotationKey])
+		// Only parse the annotation when it is present: an absent annotation is the common case and
+		// must not be reported as an error, while a present but invalid value should be surfaced
+		// instead of being silently ignored.
+		if value, exists := namespace.Annotations[EnableNPLoggingAnnotationKey]; exists {
+			parsed, parseErr := strconv.ParseBool(value)
+			if parseErr != nil {
+				klog.ErrorS(parseErr, "The Namespace's enable-logging annotation was invalid, NetworkPolicy logging will not be enabled",
+					"Namespace", np.Namespace, "annotation", EnableNPLoggingAnnotationKey, "value", value)
+			} else {
+				enableLogging = parsed
+			}
+		}
 	}
 	var ingressRuleExists, egressRuleExists bool
 	// Compute NetworkPolicyRule for Ingress Rule.

--- a/pkg/controller/networkpolicy/networkpolicy_controller_test.go
+++ b/pkg/controller/networkpolicy/networkpolicy_controller_test.go
@@ -2322,6 +2322,47 @@ func TestProcessNetworkPolicy(t *testing.T) {
 			expectedAppliedToGroups: 1,
 			expectedAddressGroups:   0,
 		},
+		{
+			name: "default-allow-ingress-invalid-logging-annotation",
+			existingObjects: []runtime.Object{
+				&corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "nsA",
+						// An invalid (non-boolean) value must not enable logging.
+						Annotations: map[string]string{"networkpolicy.antrea.io/enable-logging": "yes"},
+					},
+				},
+			},
+			inputPolicy: &networkingv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "nsA", Name: "npA", UID: "uidA"},
+				Spec: networkingv1.NetworkPolicySpec{
+					PodSelector: metav1.LabelSelector{},
+					PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+					Ingress:     []networkingv1.NetworkPolicyIngressRule{{}},
+				},
+			},
+			expectedPolicy: &antreatypes.NetworkPolicy{
+				UID:  "uidA",
+				Name: "uidA",
+				SourceRef: &controlplane.NetworkPolicyReference{
+					Type:      controlplane.K8sNetworkPolicy,
+					Namespace: "nsA",
+					Name:      "npA",
+					UID:       "uidA",
+				},
+				Rules: []controlplane.NetworkPolicyRule{{
+					Direction: controlplane.DirectionIn,
+					From:      matchAllPeer,
+					Services:  nil,
+					Priority:  defaultRulePriority,
+					Action:    &defaultAction,
+					// EnableLogging stays false because the annotation value is invalid.
+				}},
+				AppliedToGroups: []string{getNormalizedUID(antreatypes.NewGroupSelector("nsA", &metav1.LabelSelector{}, nil, nil, nil).NormalizedName)},
+			},
+			expectedAppliedToGroups: 1,
+			expectedAddressGroups:   0,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/controller/networkpolicy/store/networkpolicy_test.go
+++ b/pkg/controller/networkpolicy/store/networkpolicy_test.go
@@ -90,7 +90,7 @@ func TestWatchNetworkPolicyEvent(t *testing.T) {
 				store.Update(policyV2)
 			},
 			expected: []watch.Event{
-				{Type: watch.Bookmark, Object: &controlplane.NetworkPolicy{}},
+				{Type: watch.Bookmark, Object: &controlplane.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "0"}}},
 				{Type: watch.Added, Object: &controlplane.NetworkPolicy{
 					ObjectMeta:      metav1.ObjectMeta{Name: "bar"},
 					SourceRef:       &npRef,
@@ -119,7 +119,7 @@ func TestWatchNetworkPolicyEvent(t *testing.T) {
 				store.Update(policyV1)
 			},
 			expected: []watch.Event{
-				{Type: watch.Bookmark, Object: &controlplane.NetworkPolicy{}},
+				{Type: watch.Bookmark, Object: &controlplane.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "0"}}},
 				{Type: watch.Added, Object: &controlplane.NetworkPolicy{
 					ObjectMeta:      metav1.ObjectMeta{Name: "bar"},
 					SourceRef:       &npRef,


### PR DESCRIPTION
## What does this PR do?
Removes redundant initOpenFlowPipeline() call in agent Initialize method.

## Why is this needed?
Both branches in the if/else statement (lines 486-490) called the same 
function. The function should be called once after the if/else block to 
apply to both branches (K8sNode and non-K8sNode).

## How was it tested?
Built locally: `go build ./cmd/antrea-agent/`

Fixes #8145